### PR TITLE
Remove BaseSeriesVersion & UbuntuBaseVersion

### DIFF
--- a/apiserver/facades/client/machinemanager/upgradebase.go
+++ b/apiserver/facades/client/machinemanager/upgradebase.go
@@ -310,7 +310,7 @@ func makeUpgradeSeriesValidator(client CharmhubClient) upgradeSeriesValidator {
 }
 
 func baseFromParams(machineTag string, base state.Base, channel string) (corebase.Base, error) {
-	if base.OS != "ubuntu" {
+	if base.OS != corebase.UbuntuOS {
 		return corebase.Base{}, errors.Errorf("%s is running %s and is not valid for Ubuntu series upgrade",
 			machineTag, base.OS)
 	}
@@ -327,7 +327,7 @@ func (s upgradeSeriesValidator) ValidateBase(requestedBase, machineBase corebase
 		return errors.BadRequestf("base missing from args")
 	}
 
-	if requestedBase.OS != "ubuntu" {
+	if requestedBase.OS != corebase.UbuntuOS {
 		return errors.Errorf("base %q is not a valid upgrade target", requestedBase)
 	}
 

--- a/core/base/base.go
+++ b/core/base/base.go
@@ -21,6 +21,16 @@ type Base struct {
 	Channel Channel
 }
 
+const (
+	// UbuntuOS is the special value to be places in OS field of a base to
+	// indicate an operating system is an Ubuntu distro
+	UbuntuOS = "ubuntu"
+
+	// CentosOS is the special value to be places in OS field of a base to
+	// indicate an operating system is a CentOS distro
+	CentosOS = "centos"
+)
+
 // ParseBase constructs a Base from the os and channel string.
 func ParseBase(os string, channel string) (Base, error) {
 	if os == "" && channel == "" {
@@ -155,9 +165,9 @@ func GetSeriesFromChannel(name string, channel string) (string, error) {
 func GetSeriesFromBase(v Base) (string, error) {
 	var osSeries map[SeriesName]seriesVersion
 	switch strings.ToLower(v.OS) {
-	case "ubuntu":
+	case UbuntuOS:
 		osSeries = ubuntuSeries
-	case "centos":
+	case CentosOS:
 		osSeries = centosSeries
 	}
 	for s, vers := range osSeries {
@@ -170,7 +180,7 @@ func GetSeriesFromBase(v Base) (string, error) {
 
 // LegacyKubernetesBase is the ubuntu base image for legacy k8s charms.
 func LegacyKubernetesBase() Base {
-	return MakeDefaultBase("ubuntu", "20.04")
+	return MakeDefaultBase(UbuntuOS, "20.04")
 }
 
 // LegacyKubernetesSeries is the ubuntu series for legacy k8s charms.

--- a/core/base/supportedbases.go
+++ b/core/base/supportedbases.go
@@ -64,25 +64,3 @@ func seriesToBase(requestedBase Base, fn func(string) (set.Strings, error)) ([]B
 	})
 	return results, nil
 }
-
-// BaseSeriesVersion returns the series version for the given base.
-// TODO(stickupkid): The underlying series version should be a base, until that
-// logic has changes, just convert between base and series.
-func BaseSeriesVersion(base Base) (string, error) {
-	s, err := GetSeriesFromBase(base)
-	if err != nil {
-		return "", errors.Trace(err)
-	}
-	return SeriesVersion(s)
-}
-
-// UbuntuBaseVersion returns the series version for the given base.
-// TODO(stickupkid): The underlying series version should be a base, until that
-// logic has changes, just convert between base and series.
-func UbuntuBaseVersion(base Base) (string, error) {
-	s, err := GetSeriesFromBase(base)
-	if err != nil {
-		return "", errors.Trace(err)
-	}
-	return UbuntuSeriesVersion(s)
-}

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -386,7 +386,7 @@ func bootstrapIAAS(
 	if !args.Force && err != nil {
 		// If the base isn't valid (i.e. non-ubuntu) then don't prompt users to use
 		// the --force flag.
-		if requestedBootstrapBase.OS != "ubuntu" {
+		if requestedBootstrapBase.OS != corebase.UbuntuOS {
 			return errors.NotValidf("non-ubuntu bootstrap base %q", requestedBootstrapBase.String())
 		}
 		return errors.Annotatef(err, "use --force to override")

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -384,10 +384,10 @@ func bootstrapIAAS(
 		config.PreferredBase(cfg),
 	)
 	if !args.Force && err != nil {
-		// If the series isn't valid at all, then don't prompt users to use
+		// If the base isn't valid (i.e. non-ubuntu) then don't prompt users to use
 		// the --force flag.
-		if _, err := corebase.UbuntuBaseVersion(requestedBootstrapBase); err != nil {
-			return errors.NotValidf("base %q", requestedBootstrapBase.String())
+		if requestedBootstrapBase.OS != "ubuntu" {
+			return errors.NotValidf("non-ubuntu bootstrap base %q", requestedBootstrapBase.String())
 		}
 		return errors.Annotatef(err, "use --force to override")
 	}
@@ -943,17 +943,13 @@ func bootstrapImageMetadata(
 		if bootstrapBase == nil {
 			return nil, errors.NotValidf("no base specified with bootstrap image")
 		}
-		seriesVersion, err := corebase.BaseSeriesVersion(*bootstrapBase)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
 		// The returned metadata does not have information about the
 		// storage or virtualisation type. Any provider that wants to
 		// filter on those properties should allow for empty values.
 		meta := &imagemetadata.ImageMetadata{
 			Id:         bootstrapImageId,
 			Arch:       bootstrapArch,
-			Version:    seriesVersion,
+			Version:    bootstrapBase.Channel.Track,
 			RegionName: region.Region,
 			Endpoint:   region.Endpoint,
 			Stream:     environ.Config().ImageStream(),

--- a/packaging/dependency/kvm.go
+++ b/packaging/dependency/kvm.go
@@ -22,7 +22,7 @@ type kvmDependency struct {
 
 // PackageList implements packaging.Dependency.
 func (dep kvmDependency) PackageList(b base.Base) ([]packaging.Package, error) {
-	if b.OS != ubuntu {
+	if b.OS != base.UbuntuOS {
 		return nil, errors.NotSupportedf("installing kvm on base %q", b)
 	}
 

--- a/packaging/dependency/lxd.go
+++ b/packaging/dependency/lxd.go
@@ -12,8 +12,6 @@ import (
 	"github.com/juju/juju/packaging"
 )
 
-var ubuntu = "ubuntu"
-
 // LXD returns a dependency instance for installing lxd support using the
 // specified channel preferences (applies to cosmic or later).
 func LXD(snapChannel string) packaging.Dependency {
@@ -28,7 +26,7 @@ type lxdDependency struct {
 
 // PackageList implements packaging.Dependency.
 func (dep lxdDependency) PackageList(b base.Base) ([]packaging.Package, error) {
-	if b.OS != ubuntu {
+	if b.OS != base.UbuntuOS {
 		return nil, errors.NotSupportedf("LXD containers on base %q", b)
 	}
 

--- a/packaging/dependency/mongo.go
+++ b/packaging/dependency/mongo.go
@@ -26,7 +26,7 @@ func Mongo(snapChannel string) packaging.Dependency {
 
 // PackageList implements packaging.Dependency.
 func (dep mongoDependency) PackageList(b base.Base) ([]packaging.Package, error) {
-	if b.OS != ubuntu {
+	if b.OS != base.UbuntuOS {
 		return nil, errors.NotSupportedf("installing mongo on base %q", b)
 	}
 

--- a/provider/common/bootstrap.go
+++ b/provider/common/bootstrap.go
@@ -113,10 +113,10 @@ func BootstrapInstance(
 		config.PreferredBase(env.Config()),
 	)
 	if !args.Force && err != nil {
-		// If the base isn't valid at all, then don't prompt users to use
+		// If the base isn't valid (i.e. non-ubuntu) then don't prompt users to use
 		// the --force flag.
-		if _, err := corebase.UbuntuBaseVersion(requestedBootstrapBase); err != nil {
-			return nil, nil, nil, errors.NotValidf("base %q", requestedBootstrapBase.String())
+		if requestedBootstrapBase.OS != "ubuntu" {
+			return nil, nil, nil, errors.NotValidf("non-ubuntu bootstrap base %q", requestedBootstrapBase.String())
 		}
 		return nil, nil, nil, errors.Annotatef(err, "use --force to override")
 	}
@@ -133,14 +133,10 @@ func BootstrapInstance(
 		return nil, nil, nil, err
 	}
 
-	// Filter image metadata to the selected series.
+	// Filter image metadata to the selected base.
 	var imageMetadata []*imagemetadata.ImageMetadata
-	seriesVersion, err := corebase.BaseSeriesVersion(requestedBootstrapBase)
-	if err != nil {
-		return nil, nil, nil, errors.Trace(err)
-	}
 	for _, m := range args.ImageMetadata {
-		if m.Version != seriesVersion {
+		if m.Version != requestedBootstrapBase.Channel.Track {
 			continue
 		}
 		imageMetadata = append(imageMetadata, m)

--- a/provider/common/bootstrap.go
+++ b/provider/common/bootstrap.go
@@ -115,7 +115,7 @@ func BootstrapInstance(
 	if !args.Force && err != nil {
 		// If the base isn't valid (i.e. non-ubuntu) then don't prompt users to use
 		// the --force flag.
-		if requestedBootstrapBase.OS != "ubuntu" {
+		if requestedBootstrapBase.OS != corebase.UbuntuOS {
 			return nil, nil, nil, errors.NotValidf("non-ubuntu bootstrap base %q", requestedBootstrapBase.String())
 		}
 		return nil, nil, nil, errors.Annotatef(err, "use --force to override")

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -1055,7 +1055,7 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, callCtx context.Provi
 
 	bsResult := &environs.BootstrapResult{
 		Arch:                    arch,
-		Base:                    corebase.MakeDefaultBase("ubuntu", "22.04"),
+		Base:                    corebase.MakeDefaultBase(corebase.UbuntuOS, "22.04"),
 		CloudBootstrapFinalizer: finalize,
 	}
 	return bsResult, nil

--- a/provider/equinix/environ.go
+++ b/provider/equinix/environ.go
@@ -47,7 +47,6 @@ var logger = loggo.GetLogger("juju.provider.equinix")
 
 const (
 	sshPort = 22
-	ubuntu  = "ubuntu"
 )
 
 type environConfig struct {
@@ -331,7 +330,7 @@ func getCloudConfig(args environs.StartInstanceParams) (cloudinit.CloudConfig, e
 	// NOTE(achilleasa): this is a hack and is only meant to be used
 	// temporarily; we must ensure that equinix mirrors the official
 	// ubuntu cloud images.
-	if args.InstanceConfig.Base.OS == ubuntu {
+	if args.InstanceConfig.Base.OS == corebase.UbuntuOS {
 		cloudCfg.AddScripts(
 			"apt-get update",
 			"DEBIAN_FRONTEND=noninteractive apt-get --option=Dpkg::Options::=--force-confdef --option=Dpkg::Options::=--force-confold --option=Dpkg::Options::=--force-unsafe-io --assume-yes --quiet install dmidecode snapd",
@@ -343,7 +342,7 @@ func getCloudConfig(args environs.StartInstanceParams) (cloudinit.CloudConfig, e
 	// references the juju-assigned hostname before localhost. Otherwise,
 	// running 'hostname -f' would return localhost whereas 'hostname'
 	// returns the juju-assigned host (see LP1956538).
-	if args.InstanceConfig.Base.OS == ubuntu {
+	if args.InstanceConfig.Base.OS == corebase.UbuntuOS {
 		cloudCfg.AddScripts(
 			`sed -i -e "/127\.0\.0\.1/c\127\.0\.0\.1 $(hostname) localhost" /etc/hosts`,
 		)

--- a/provider/oci/images.go
+++ b/provider/oci/images.go
@@ -39,8 +39,6 @@ const (
 	centOS   = "CentOS"
 	ubuntuOS = "Canonical Ubuntu"
 
-	UbuntuBase = "ubuntu"
-
 	staleImageCacheTimeoutInMinutes = 30
 )
 
@@ -322,7 +320,7 @@ func parseUbuntuImage(img ociCore.Image) (corebase.Base, string, bool) {
 	//   the ubuntu image's metadata) so we need to find a workaround as
 	//   explained in the NOTE a few lines below.
 	channel, postfix, _ := strings.Cut(*img.OperatingSystemVersion, " ")
-	base = corebase.MakeDefaultBase(UbuntuBase, channel)
+	base = corebase.MakeDefaultBase(corebase.UbuntuOS, channel)
 	// if not found, means that the OperatingSystemVersion only contained
 	// the channel.
 	if strings.Contains(*img.DisplayName, "Minimal") ||

--- a/state/charm.go
+++ b/state/charm.go
@@ -81,12 +81,12 @@ func (b Base) String() string {
 
 // UbuntuBase is used in tests.
 func UbuntuBase(channel string) Base {
-	return Base{OS: "ubuntu", Channel: channel + "/stable"}
+	return Base{OS: corebase.UbuntuOS, Channel: channel + "/stable"}
 }
 
 // DefaultLTSBase is used in tests.
 func DefaultLTSBase() Base {
-	return Base{OS: "ubuntu", Channel: jujuversion.DefaultSupportedLTSBase().Channel.String()}
+	return Base{OS: corebase.UbuntuOS, Channel: jujuversion.DefaultSupportedLTSBase().Channel.String()}
 }
 
 // Platform identifies the platform the charm was installed on.

--- a/upgrades/upgradevalidation/validation.go
+++ b/upgrades/upgradevalidation/validation.go
@@ -196,7 +196,7 @@ func checkForDeprecatedUbuntuSeriesForModel(
 	supported := false
 	var deprecatedBases []state.Base
 	for _, vers := range corebase.UbuntuVersions(&supported, nil) {
-		deprecatedBases = append(deprecatedBases, state.Base{OS: "ubuntu", Channel: vers})
+		deprecatedBases = append(deprecatedBases, state.Base{OS: corebase.UbuntuOS, Channel: vers})
 	}
 
 	// sort for tests.

--- a/version/series.go
+++ b/version/series.go
@@ -14,5 +14,5 @@ func DefaultSupportedLTS() string {
 // DefaultSupportedLTSBase returns the latest LTS base that Juju supports
 // and is compatible with.
 func DefaultSupportedLTSBase() corebase.Base {
-	return corebase.MakeDefaultBase("ubuntu", "22.04")
+	return corebase.MakeDefaultBase(corebase.UbuntuOS, "22.04")
 }


### PR DESCRIPTION
It seems these functions essentially just query a base for it's channel track with extra steps

However, we also used UbuntuBaseVersion to determine if a base was a valid ubuntu base. Instead here we should just check the base OS

As a flyby, export an "ubuntu" constant in core/base to centralise all the places in the Juju codebase we treat "ubuntu"
as a magic string within the base OS field
 
## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made

## QA steps

Bootstrap some controllers

```
$ juju bootstrap aws aws
(success)

$ juju bootstrap lxd jammy --bootstrap-base ubuntu@22.04
(success)

$ juju bootstrap lxd focal --bootstrap-base ubuntu@20.04
(success)

$ juju bootstrap lxd err --bootstrap-base ubuntu@21.10
Creating Juju controller "err" on lxd/localhost
ERROR failed to bootstrap model: use --force to override: ubuntu@21.10/stable not supported

$ juju bootstrap lxd err --bootstrap-base ubuntu@21.10 --force
(this will likely fail for apt reasons, out of scope of this PR)

$ juju bootstrap lxd err --bootstrap-base centos@7
Creating Juju controller "err" on lxd/localhost
ERROR failed to bootstrap model: non-ubuntu bootstrap base "centos@7/stable" not valid
```