### PR TITLE
Secret consumed changes watcher

### DIFF
--- a/domain/schema/model.go
+++ b/domain/schema/model.go
@@ -60,16 +60,12 @@ func ModelDDL() *schema.Schema {
 		changeLogTriggersForTable("storage_volume", "uuid", tableVolume),
 		changeLogTriggersForTable("storage_volume_attachment", "uuid", tableVolumeAttachment),
 		changeLogTriggersForTable("storage_volume_attachment_plan", "uuid", tableVolumeAttachmentPlan),
-
 		changeLogTriggersForTableOnColumn("secret_metadata", "secret_id", "auto_prune", tableSecretMetadata),
 		changeLogTriggersForTable("secret_rotation", "secret_id", tableSecretRotation),
-		changeLogTriggersForTableOnColumn("secret_revision_obsolete", "revision_uuid", "obsolete", tableSecretRevisionObsolete),
+		changeLogTriggersForTable("secret_revision_obsolete", "revision_uuid", tableSecretRevisionObsolete),
 		changeLogTriggersForTable("secret_revision_expire", "revision_uuid", tableSecretRevisionExpire),
-		// We only want to watch the new revision INSERT.
-		// To achieve this and have less performance impact on the event stream watcher,
-		// we watch the changes on the immutable revision field.
-		changeLogTriggersForTableOnColumn("secret_revision", "uuid", "revision", tableSecretRevision),
-		changeLogTriggersForTableOnColumn("secret_reference", "secret_id", "latest_revision", tableSecretReference),
+		changeLogTriggersForTable("secret_revision", "uuid", tableSecretRevision),
+		changeLogTriggersForTable("secret_reference", "secret_id", tableSecretReference),
 		changeLogTriggersForTable("subnet", "uuid", tableSubnet),
 		changeLogTriggersForTable("subnet_association", "associated_subnet_uuid", tableSubnetAssociation),
 

--- a/domain/schema/model.go
+++ b/domain/schema/model.go
@@ -19,13 +19,17 @@ const (
 	tableVolume
 	tableVolumeAttachment
 	tableVolumeAttachmentPlan
-	tableSecretAutoPrune
+	tableSecretMetadata
 	tableSecretRotation
 	tableSecretRevisionObsolete
 	tableSecretRevisionExpire
+<<<<<<< HEAD
 	tableSubnet
 	tableSubnetAssociation
 	tableSecretUnitConsumer
+=======
+	tableSecretRevision
+>>>>>>> 5d04551d31 (Move the obsolete field in table secret_revision to a new table secret_revision_obsolete;)
 )
 
 // ModelDDL is used to create model databases.
@@ -59,15 +63,24 @@ func ModelDDL() *schema.Schema {
 		changeLogTriggersForTable("storage_volume", "uuid", tableVolume),
 		changeLogTriggersForTable("storage_volume_attachment", "uuid", tableVolumeAttachment),
 		changeLogTriggersForTable("storage_volume_attachment_plan", "uuid", tableVolumeAttachmentPlan),
+
+		changeLogTriggersForTableOnColumn("secret_metadata", "secret_id", "auto_prune", tableSecretMetadata),
 		changeLogTriggersForTable("secret_rotation", "secret_id", tableSecretRotation),
-		changeLogTriggersForTable("secret_revision", "uuid", tableSecretRevisionObsolete),
+		changeLogTriggersForTableOnColumn("secret_revision_obsolete", "revision_uuid", "obsolete", tableSecretRevisionObsolete),
 		changeLogTriggersForTable("secret_revision_expire", "revision_uuid", tableSecretRevisionExpire),
+<<<<<<< HEAD
 		changeLogTriggersForTableOnColumn("secret_unit_consumer", "secret_id", "current_revision", tableSecretUnitConsumer),
 		changeLogTriggersForTableOnColumn("secret_metadata", "secret_id", "auto_prune", tableSecretAutoPrune),
 		changeLogTriggersForTable(
 			"subnet", "uuid", tableSubnet),
 		changeLogTriggersForTable(
 			"subnet_association", "associated_subnet_uuid", tableSubnetAssociation),
+=======
+		// We only want to watch the new revision INSERT.
+		// To achieve this and have less performance impact on the event stream watcher,
+		// we watch the changes on the immutable revision field.
+		changeLogTriggersForTableOnColumn("secret_revision", "uuid", "revision", tableSecretRevision),
+>>>>>>> 5d04551d31 (Move the obsolete field in table secret_revision to a new table secret_revision_obsolete;)
 
 		triggersForImmutableTable("model", "", "model table is immutable"),
 
@@ -133,13 +146,14 @@ INSERT INTO change_log_namespace VALUES
     (6, 'storage_volume', 'Storage volume changes based on UUID'),
     (7, 'storage_volume_attachment', 'Volume attachment changes based on UUID'),
     (8, 'storage_volume_attachment_plan', 'Volume attachment plan changes based on UUID'),
-    (9, 'secret', 'Secret auto prune changes based on UUID'),
+    (9, 'secret_metadata', 'Secret auto prune changes based on UUID'),
     (10, 'secret_rotation', 'Secret rotation changes based on UUID'),
-    (11, 'secret_revision', 'Secret revision obsolete changes based on UUID'),
+    (11, 'secret_revision_obsolete', 'Secret revision obsolete changes based on UUID'),
     (12, 'secret_revision_expire', 'Secret revision next expire time changes based on UUID'),
-    (13, 'subnet', 'Subnet changes based on UUID'),
-    (14, 'subnet_association', 'Subnet association (fan underlay) changes based on UUID'),
-    (15, 'secret_unit_consumer', 'Secret unit consumer current revision changes based on UUID');
+    (13, 'secret_unit_consumer', 'Secret unit consumer current revision changes based on UUID');
+    (14, 'secret_revision', 'Secret revision changes based on UUID');
+    (15, 'subnet', 'Subnet changes based on UUID'),
+    (16, 'subnet_association', 'Subnet association (fan underlay) changes based on UUID'),
 `)
 }
 

--- a/domain/schema/model.go
+++ b/domain/schema/model.go
@@ -25,6 +25,7 @@ const (
 	tableSecretRevisionExpire
 	tableSubnet
 	tableSubnetAssociation
+	tableSecretUnitConsumer
 )
 
 // ModelDDL is used to create model databases.
@@ -61,6 +62,7 @@ func ModelDDL() *schema.Schema {
 		changeLogTriggersForTable("secret_rotation", "secret_id", tableSecretRotation),
 		changeLogTriggersForTable("secret_revision", "uuid", tableSecretRevisionObsolete),
 		changeLogTriggersForTable("secret_revision_expire", "revision_uuid", tableSecretRevisionExpire),
+		changeLogTriggersForTableOnColumn("secret_unit_consumer", "secret_id", "current_revision", tableSecretUnitConsumer),
 		changeLogTriggersForTableOnColumn("secret_metadata", "secret_id", "auto_prune", tableSecretAutoPrune),
 		changeLogTriggersForTable(
 			"subnet", "uuid", tableSubnet),

--- a/domain/schema/model.go
+++ b/domain/schema/model.go
@@ -24,6 +24,7 @@ const (
 	tableSecretRevisionObsolete
 	tableSecretRevisionExpire
 	tableSecretRevision
+	tableSecretReference
 	tableSubnet
 	tableSubnetAssociation
 )
@@ -68,6 +69,7 @@ func ModelDDL() *schema.Schema {
 		// To achieve this and have less performance impact on the event stream watcher,
 		// we watch the changes on the immutable revision field.
 		changeLogTriggersForTableOnColumn("secret_revision", "uuid", "revision", tableSecretRevision),
+		changeLogTriggersForTableOnColumn("secret_reference", "secret_id", "latest_revision", tableSecretReference),
 		changeLogTriggersForTable("subnet", "uuid", tableSubnet),
 		changeLogTriggersForTable("subnet_association", "associated_subnet_uuid", tableSubnetAssociation),
 
@@ -140,8 +142,9 @@ INSERT INTO change_log_namespace VALUES
     (11, 'secret_revision_obsolete', 'Secret revision obsolete changes based on UUID'),
     (12, 'secret_revision_expire', 'Secret revision next expire time changes based on UUID'),
     (13, 'secret_revision', 'Secret revision changes based on UUID'),
-    (14, 'subnet', 'Subnet changes based on UUID'),
-    (15, 'subnet_association', 'Subnet association (fan underlay) changes based on UUID');
+    (14, 'secret_reference', 'Secret reference changes based on UUID'),
+    (15, 'subnet', 'Subnet changes based on UUID'),
+    (16, 'subnet_association', 'Subnet association (fan underlay) changes based on UUID');
 `)
 }
 

--- a/domain/schema/model.go
+++ b/domain/schema/model.go
@@ -139,10 +139,9 @@ INSERT INTO change_log_namespace VALUES
     (10, 'secret_rotation', 'Secret rotation changes based on UUID'),
     (11, 'secret_revision_obsolete', 'Secret revision obsolete changes based on UUID'),
     (12, 'secret_revision_expire', 'Secret revision next expire time changes based on UUID'),
-    (13, 'secret_unit_consumer', 'Secret unit consumer current revision changes based on UUID');
-    (14, 'secret_revision', 'Secret revision changes based on UUID');
-    (15, 'subnet', 'Subnet changes based on UUID'),
-    (16, 'subnet_association', 'Subnet association (fan underlay) changes based on UUID'),
+    (13, 'secret_revision', 'Secret revision changes based on UUID'),
+    (14, 'subnet', 'Subnet changes based on UUID'),
+    (15, 'subnet_association', 'Subnet association (fan underlay) changes based on UUID');
 `)
 }
 

--- a/domain/schema/model.go
+++ b/domain/schema/model.go
@@ -19,7 +19,7 @@ const (
 	tableVolume
 	tableVolumeAttachment
 	tableVolumeAttachmentPlan
-	tableSecretMetadata
+	tableSecretMetadataAutoPrune
 	tableSecretRotation
 	tableSecretRevisionObsolete
 	tableSecretRevisionExpire
@@ -60,7 +60,7 @@ func ModelDDL() *schema.Schema {
 		changeLogTriggersForTable("storage_volume", "uuid", tableVolume),
 		changeLogTriggersForTable("storage_volume_attachment", "uuid", tableVolumeAttachment),
 		changeLogTriggersForTable("storage_volume_attachment_plan", "uuid", tableVolumeAttachmentPlan),
-		changeLogTriggersForTableOnColumn("secret_metadata", "secret_id", "auto_prune", tableSecretMetadata),
+		changeLogTriggersForTableOnColumn("secret_metadata", "secret_id", "auto_prune", tableSecretMetadataAutoPrune),
 		changeLogTriggersForTable("secret_rotation", "secret_id", tableSecretRotation),
 		changeLogTriggersForTable("secret_revision_obsolete", "revision_uuid", tableSecretRevisionObsolete),
 		changeLogTriggersForTable("secret_revision_expire", "revision_uuid", tableSecretRevisionExpire),

--- a/domain/schema/model.go
+++ b/domain/schema/model.go
@@ -23,13 +23,9 @@ const (
 	tableSecretRotation
 	tableSecretRevisionObsolete
 	tableSecretRevisionExpire
-<<<<<<< HEAD
+	tableSecretRevision
 	tableSubnet
 	tableSubnetAssociation
-	tableSecretUnitConsumer
-=======
-	tableSecretRevision
->>>>>>> 5d04551d31 (Move the obsolete field in table secret_revision to a new table secret_revision_obsolete;)
 )
 
 // ModelDDL is used to create model databases.
@@ -68,19 +64,12 @@ func ModelDDL() *schema.Schema {
 		changeLogTriggersForTable("secret_rotation", "secret_id", tableSecretRotation),
 		changeLogTriggersForTableOnColumn("secret_revision_obsolete", "revision_uuid", "obsolete", tableSecretRevisionObsolete),
 		changeLogTriggersForTable("secret_revision_expire", "revision_uuid", tableSecretRevisionExpire),
-<<<<<<< HEAD
-		changeLogTriggersForTableOnColumn("secret_unit_consumer", "secret_id", "current_revision", tableSecretUnitConsumer),
-		changeLogTriggersForTableOnColumn("secret_metadata", "secret_id", "auto_prune", tableSecretAutoPrune),
-		changeLogTriggersForTable(
-			"subnet", "uuid", tableSubnet),
-		changeLogTriggersForTable(
-			"subnet_association", "associated_subnet_uuid", tableSubnetAssociation),
-=======
 		// We only want to watch the new revision INSERT.
 		// To achieve this and have less performance impact on the event stream watcher,
 		// we watch the changes on the immutable revision field.
 		changeLogTriggersForTableOnColumn("secret_revision", "uuid", "revision", tableSecretRevision),
->>>>>>> 5d04551d31 (Move the obsolete field in table secret_revision to a new table secret_revision_obsolete;)
+		changeLogTriggersForTable("subnet", "uuid", tableSubnet),
+		changeLogTriggersForTable("subnet_association", "associated_subnet_uuid", tableSubnetAssociation),
 
 		triggersForImmutableTable("model", "", "model table is immutable"),
 

--- a/domain/schema/schema_test.go
+++ b/domain/schema/schema_test.go
@@ -527,9 +527,9 @@ func (s *schemaSuite) TestModelChangeLogTriggersForSecretTables(c *gc.C) {
 	s.applyDDL(c, ModelDDL())
 
 	// secret table triggers.
-	s.assertChangeLogCount(c, 1, tableSecretMetadata, 0)
-	s.assertChangeLogCount(c, 2, tableSecretMetadata, 0)
-	s.assertChangeLogCount(c, 4, tableSecretMetadata, 0)
+	s.assertChangeLogCount(c, 1, tableSecretMetadataAutoPrune, 0)
+	s.assertChangeLogCount(c, 2, tableSecretMetadataAutoPrune, 0)
+	s.assertChangeLogCount(c, 4, tableSecretMetadataAutoPrune, 0)
 
 	secretURI := coresecrets.NewURI()
 	s.assertExecSQL(c, `INSERT INTO secret (id) VALUES (?);`, "", secretURI.ID)
@@ -537,9 +537,9 @@ func (s *schemaSuite) TestModelChangeLogTriggersForSecretTables(c *gc.C) {
 	s.assertExecSQL(c, `UPDATE secret_metadata SET auto_prune = true WHERE secret_id = ?;`, "", secretURI.ID)
 	s.assertExecSQL(c, `DELETE FROM secret_metadata WHERE secret_id = ?;`, "", secretURI.ID)
 
-	s.assertChangeLogCount(c, 1, tableSecretMetadata, 1)
-	s.assertChangeLogCount(c, 2, tableSecretMetadata, 1)
-	s.assertChangeLogCount(c, 4, tableSecretMetadata, 1)
+	s.assertChangeLogCount(c, 1, tableSecretMetadataAutoPrune, 1)
+	s.assertChangeLogCount(c, 2, tableSecretMetadataAutoPrune, 1)
+	s.assertChangeLogCount(c, 4, tableSecretMetadataAutoPrune, 1)
 
 	// secret_rotation table triggers.
 	s.assertChangeLogCount(c, 1, tableSecretRotation, 0)

--- a/domain/schema/schema_test.go
+++ b/domain/schema/schema_test.go
@@ -409,21 +409,21 @@ func (s *schemaSuite) TestModelTriggers(c *gc.C) {
 		"trg_log_secret_rotation_update",
 		"trg_log_secret_rotation_delete",
 
-		"trg_log_secret_revision_obsolete_obsolete_insert",
-		"trg_log_secret_revision_obsolete_obsolete_update",
-		"trg_log_secret_revision_obsolete_obsolete_delete",
+		"trg_log_secret_revision_obsolete_insert",
+		"trg_log_secret_revision_obsolete_update",
+		"trg_log_secret_revision_obsolete_delete",
 
 		"trg_log_secret_revision_expire_insert",
 		"trg_log_secret_revision_expire_update",
 		"trg_log_secret_revision_expire_delete",
 
-		"trg_log_secret_revision_revision_insert",
-		"trg_log_secret_revision_revision_update",
-		"trg_log_secret_revision_revision_delete",
+		"trg_log_secret_revision_insert",
+		"trg_log_secret_revision_update",
+		"trg_log_secret_revision_delete",
 
-		"trg_log_secret_reference_latest_revision_insert",
-		"trg_log_secret_reference_latest_revision_update",
-		"trg_log_secret_reference_latest_revision_delete",
+		"trg_log_secret_reference_insert",
+		"trg_log_secret_reference_update",
+		"trg_log_secret_reference_delete",
 
 		"trg_log_block_device_insert",
 		"trg_log_block_device_update",

--- a/domain/schema/schema_test.go
+++ b/domain/schema/schema_test.go
@@ -405,6 +405,14 @@ func (s *schemaSuite) TestModelTriggers(c *gc.C) {
 		"trg_log_secret_metadata_auto_prune_update",
 		"trg_log_secret_metadata_auto_prune_delete",
 
+		"trg_log_secret_rotation_insert",
+		"trg_log_secret_rotation_update",
+		"trg_log_secret_rotation_delete",
+
+		"trg_log_secret_revision_obsolete_obsolete_insert",
+		"trg_log_secret_revision_obsolete_obsolete_update",
+		"trg_log_secret_revision_obsolete_obsolete_delete",
+
 		"trg_log_secret_revision_expire_insert",
 		"trg_log_secret_revision_expire_update",
 		"trg_log_secret_revision_expire_delete",
@@ -413,13 +421,9 @@ func (s *schemaSuite) TestModelTriggers(c *gc.C) {
 		"trg_log_secret_revision_revision_update",
 		"trg_log_secret_revision_revision_delete",
 
-		"trg_log_secret_revision_obsolete_obsolete_insert",
-		"trg_log_secret_revision_obsolete_obsolete_update",
-		"trg_log_secret_revision_obsolete_obsolete_delete",
-
-		"trg_log_secret_rotation_insert",
-		"trg_log_secret_rotation_update",
-		"trg_log_secret_rotation_delete",
+		"trg_log_secret_reference_latest_revision_insert",
+		"trg_log_secret_reference_latest_revision_update",
+		"trg_log_secret_reference_latest_revision_delete",
 
 		"trg_log_block_device_insert",
 		"trg_log_block_device_update",
@@ -593,6 +597,19 @@ func (s *schemaSuite) TestModelChangeLogTriggersForSecretTables(c *gc.C) {
 	s.assertChangeLogCount(c, 1, tableSecretRevision, 3)
 	s.assertChangeLogCount(c, 2, tableSecretRevision, 0)
 	s.assertChangeLogCount(c, 4, tableSecretRevision, 3)
+
+	// secret_reference table triggers.
+	s.assertChangeLogCount(c, 1, tableSecretReference, 0)
+	s.assertChangeLogCount(c, 2, tableSecretReference, 0)
+	s.assertChangeLogCount(c, 4, tableSecretReference, 0)
+
+	s.assertExecSQL(c, `INSERT INTO secret_reference (secret_id, latest_revision) VALUES (?, 1);`, "", secretURI.ID)
+	s.assertExecSQL(c, `UPDATE secret_reference SET latest_revision = 2 WHERE secret_id = ?;`, "", secretURI.ID)
+	s.assertExecSQL(c, `DELETE FROM secret_reference WHERE secret_id = ?;`, "", secretURI.ID)
+
+	s.assertChangeLogCount(c, 1, tableSecretReference, 1)
+	s.assertChangeLogCount(c, 2, tableSecretReference, 1)
+	s.assertChangeLogCount(c, 4, tableSecretReference, 1)
 
 	appUUID := utils.MustNewUUID().String()
 	s.assertExecSQL(c, `INSERT INTO application (uuid, name, life_id) VALUES (?, 'mysql', 0);`, "", appUUID)

--- a/domain/schema/secret.go
+++ b/domain/schema/secret.go
@@ -183,6 +183,7 @@ CREATE TABLE secret_revision (
     uuid TEXT PRIMARY KEY,
     secret_id TEXT NOT NULL,
     revision INT NOT NULL,
+    create_time DATETIME NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW', 'utc')),
     CONSTRAINT fk_secret_revision_secret_metadata_id
         FOREIGN KEY (secret_id)
         REFERENCES secret_metadata (secret_id)
@@ -196,8 +197,6 @@ CREATE TABLE secret_revision_obsolete (
     -- pending_delete is true if the revision is to be deleted.
     -- It will not be drained to a new active backend.
     pending_delete BOOLEAN NOT NULL DEFAULT (FALSE),
-    create_time DATETIME NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW', 'utc')),
-    update_time DATETIME NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW', 'utc')),
     CONSTRAINT fk_secret_revision_obsolete_revision_uuid
         FOREIGN KEY (revision_uuid)
         REFERENCES secret_revision (uuid)

--- a/domain/schema/secret.go
+++ b/domain/schema/secret.go
@@ -183,18 +183,25 @@ CREATE TABLE secret_revision (
     uuid TEXT PRIMARY KEY,
     secret_id TEXT NOT NULL,
     revision INT NOT NULL,
-    obsolete BOOLEAN NOT NULL DEFAULT (FALSE),
-    -- pending_delete is true if the revision is to be deleted.
-    -- It will not be drained to a new active backend.
-    pending_delete BOOLEAN NOT NULL DEFAULT (FALSE),
-    create_time DATETIME NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW', 'utc')),
-    update_time DATETIME NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW', 'utc')),
     CONSTRAINT fk_secret_revision_secret_metadata_id
         FOREIGN KEY (secret_id)
         REFERENCES secret_metadata (secret_id)
 );
 
 CREATE UNIQUE INDEX idx_secret_revision_secret_id_revision ON secret_revision (secret_id,revision);
+
+CREATE TABLE secret_revision_obsolete (
+    revision_uuid TEXT PRIMARY KEY,
+    obsolete BOOLEAN NOT NULL DEFAULT (FALSE),
+    -- pending_delete is true if the revision is to be deleted.
+    -- It will not be drained to a new active backend.
+    pending_delete BOOLEAN NOT NULL DEFAULT (FALSE),
+    create_time DATETIME NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW', 'utc')),
+    update_time DATETIME NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW', 'utc')),
+    CONSTRAINT fk_secret_revision_obsolete_revision_uuid
+        FOREIGN KEY (revision_uuid)
+        REFERENCES secret_revision (uuid)
+);
 
 CREATE TABLE secret_revision_expire (
     revision_uuid TEXT PRIMARY KEY,

--- a/domain/secret/service/consume.go
+++ b/domain/secret/service/consume.go
@@ -70,8 +70,10 @@ func (s *SecretService) GetURIByConsumerLabel(ctx context.Context, label string,
 // the label associated with the secret for the consumer.
 // TODO(secrets) - test
 func (s *SecretService) GetConsumedRevision(ctx context.Context, uri *secrets.URI, unitName string, refresh, peek bool, labelToUpdate *string) (int, error) {
+	s.logger.Warningf("GetConsumedRevision: uri: %v, unitName: %v, refresh: %#v, peek: %#v, labelToUpdate: %#v", uri, unitName, refresh, peek, labelToUpdate)
 	consumerInfo, latestRevision, err := s.GetSecretConsumerAndLatest(ctx, uri, unitName)
-	if err != nil && !errors.Is(err, secreterrors.SecretConsumerNotFound) {
+	s.logger.Warningf("GetConsumedRevision: consumerInfo: %v, latestRevision: %v, err: %v", consumerInfo, latestRevision, err)
+	if err != nil && !errors.Is(err, secreterrors.SecretConsumerNotFound) && !errors.Is(err, secreterrors.SecretNotFound) {
 		return 0, errors.Trace(err)
 	}
 	refresh = refresh ||

--- a/domain/secret/service/consume.go
+++ b/domain/secret/service/consume.go
@@ -69,9 +69,7 @@ func (s *SecretService) GetURIByConsumerLabel(ctx context.Context, label string,
 // the label associated with the secret for the consumer.
 // TODO(secrets) - test
 func (s *SecretService) GetConsumedRevision(ctx context.Context, uri *secrets.URI, unitName string, refresh, peek bool, labelToUpdate *string) (int, error) {
-	s.logger.Warningf("GetConsumedRevision: uri: %v, unitName: %v, refresh: %#v, peek: %#v, labelToUpdate: %#v", uri, unitName, refresh, peek, labelToUpdate)
 	consumerInfo, latestRevision, err := s.GetSecretConsumerAndLatest(ctx, uri, unitName)
-	s.logger.Warningf("GetConsumedRevision: consumerInfo: %v, latestRevision: %v, err: %v", consumerInfo, latestRevision, err)
 	if err != nil && !errors.Is(err, secreterrors.SecretConsumerNotFound) {
 		return 0, errors.Trace(err)
 	}

--- a/domain/secret/service/consume.go
+++ b/domain/secret/service/consume.go
@@ -21,7 +21,6 @@ import (
 // along with an error satisfying [secreterrors.SecretConsumerNotFound].
 func (s *SecretService) GetSecretConsumerAndLatest(ctx context.Context, uri *secrets.URI, unitName string) (*secrets.SecretConsumerMetadata, int, error) {
 	consumerMetadata, latestRevision, err := s.st.GetSecretConsumer(ctx, uri, unitName)
-
 	if err != nil {
 		return nil, latestRevision, errors.Trace(err)
 	}

--- a/domain/secret/service/consume.go
+++ b/domain/secret/service/consume.go
@@ -73,7 +73,7 @@ func (s *SecretService) GetConsumedRevision(ctx context.Context, uri *secrets.UR
 	s.logger.Warningf("GetConsumedRevision: uri: %v, unitName: %v, refresh: %#v, peek: %#v, labelToUpdate: %#v", uri, unitName, refresh, peek, labelToUpdate)
 	consumerInfo, latestRevision, err := s.GetSecretConsumerAndLatest(ctx, uri, unitName)
 	s.logger.Warningf("GetConsumedRevision: consumerInfo: %v, latestRevision: %v, err: %v", consumerInfo, latestRevision, err)
-	if err != nil && !errors.Is(err, secreterrors.SecretConsumerNotFound) && !errors.Is(err, secreterrors.SecretNotFound) {
+	if err != nil && !errors.Is(err, secreterrors.SecretConsumerNotFound) {
 		return 0, errors.Trace(err)
 	}
 	refresh = refresh ||

--- a/domain/secret/service/service.go
+++ b/domain/secret/service/service.go
@@ -61,14 +61,14 @@ type State interface {
 	) ([]*secrets.SecretMetadataForDrain, error)
 	ListUserSecretsToDrain(ctx context.Context) ([]*secrets.SecretMetadataForDrain, error)
 	InitialWatchStatementForObsoleteRevision(
-		ctx context.Context, appOwners domainsecret.ApplicationOwners, unitOwners domainsecret.UnitOwners,
+		appOwners domainsecret.ApplicationOwners, unitOwners domainsecret.UnitOwners,
 	) (tableName string, statement eventsource.NamespaceQuery)
 	GetRevisionIDsForObsolete(
-		ctx context.Context,
-		appOwners domainsecret.ApplicationOwners,
-		unitOwners domainsecret.UnitOwners,
-		revisionUUID ...string,
+		ctx context.Context, appOwners domainsecret.ApplicationOwners, unitOwners domainsecret.UnitOwners, revisionUUID ...string,
 	) ([]string, error)
+
+	InitialWatchStatementForConsumedSecrets(unitName string) (string, eventsource.NamespaceQuery)
+	GetConsumedSecretURIs(ctx context.Context, unitName string, consumerIDs ...string) ([]string, error)
 }
 
 // WatcherFactory describes methods for creating watchers.

--- a/domain/secret/service/service.go
+++ b/domain/secret/service/service.go
@@ -510,9 +510,6 @@ func (s *SecretService) GetSecretContentFromBackend(ctx context.Context, uri *se
 func (s *SecretService) ProcessCharmSecretConsumerLabel(
 	ctx context.Context, unitName string, uri *secrets.URI, label string, token leadership.Token,
 ) (_ *secrets.URI, _ *string, err error) {
-	defer func() {
-		s.logger.Warningf("ProcessSecretConsumerLabel unit %q, uri %q, label %q, err %v", unitName, uri, label, err)
-	}()
 	modelUUID, err := s.st.GetModelUUID(ctx)
 	if err != nil {
 		return nil, nil, errors.Annotate(err, "getting model uuid")
@@ -527,7 +524,6 @@ func (s *SecretService) ProcessCharmSecretConsumerLabel(
 	// For local secrets, check those which may be owned by the caller.
 	if uri == nil || uri.IsLocal(modelUUID) {
 		md, err := s.getAppOwnedOrUnitOwnedSecretMetadata(ctx, uri, unitName, label)
-		s.logger.Warningf("getAppOwnedOrUnitOwnedSecretMetadata unit %q, uri %q, label %q, md %v, err %v", unitName, uri, label, md, err)
 		if err != nil && !errors.Is(err, secreterrors.SecretNotFound) {
 			return nil, nil, errors.Trace(err)
 		}
@@ -607,7 +603,6 @@ func (s *SecretService) getAppOwnedOrUnitOwnedSecretMetadata(ctx context.Context
 	}
 
 	appName, err := names.UnitApplication(unitName)
-	s.logger.Warningf("getAppOwnedOrUnitOwnedSecretMetadata unit %q, appName %q", unitName, appName)
 	if err != nil {
 		// Should never happen.
 		return nil, errors.Trace(err)

--- a/domain/secret/service/service.go
+++ b/domain/secret/service/service.go
@@ -69,6 +69,9 @@ type State interface {
 
 	InitialWatchStatementForConsumedSecretsChange(unitName string) (string, eventsource.NamespaceQuery)
 	GetConsumedSecretURIsWithChanges(ctx context.Context, unitName string, consumerIDs ...string) ([]string, error)
+
+	InitialWatchStatementForRemoteConsumedSecretsChange(appName string) (string, eventsource.NamespaceQuery)
+	GetRemoteConsumedSecretURIsWithChanges(ctx context.Context, appName string, secretIDs ...string) ([]string, error)
 }
 
 // WatcherFactory describes methods for creating watchers.
@@ -501,7 +504,10 @@ func (s *SecretService) GetSecretContentFromBackend(ctx context.Context, uri *se
 // This method returns the resulting uri, and optionally the label to update for the consumer.
 func (s *SecretService) ProcessCharmSecretConsumerLabel(
 	ctx context.Context, unitName string, uri *secrets.URI, label string, token leadership.Token,
-) (*secrets.URI, *string, error) {
+) (_ *secrets.URI, _ *string, err error) {
+	defer func() {
+		s.logger.Warningf("ProcessSecretConsumerLabel unit %q, uri %q, label %q, err %v", unitName, uri, label, err)
+	}()
 	modelUUID, err := s.st.GetModelUUID(ctx)
 	if err != nil {
 		return nil, nil, errors.Annotate(err, "getting model uuid")
@@ -516,6 +522,7 @@ func (s *SecretService) ProcessCharmSecretConsumerLabel(
 	// For local secrets, check those which may be owned by the caller.
 	if uri == nil || uri.IsLocal(modelUUID) {
 		md, err := s.getAppOwnedOrUnitOwnedSecretMetadata(ctx, uri, unitName, label)
+		s.logger.Warningf("getAppOwnedOrUnitOwnedSecretMetadata unit %q, uri %q, label %q, md %v, err %v", unitName, uri, label, md, err)
 		if err != nil && !errors.Is(err, secreterrors.SecretNotFound) {
 			return nil, nil, errors.Trace(err)
 		}
@@ -595,6 +602,7 @@ func (s *SecretService) getAppOwnedOrUnitOwnedSecretMetadata(ctx context.Context
 	}
 
 	appName, err := names.UnitApplication(unitName)
+	s.logger.Warningf("getAppOwnedOrUnitOwnedSecretMetadata unit %q, appName %q", unitName, appName)
 	if err != nil {
 		// Should never happen.
 		return nil, errors.Trace(err)

--- a/domain/secret/service/service.go
+++ b/domain/secret/service/service.go
@@ -67,8 +67,8 @@ type State interface {
 		ctx context.Context, appOwners domainsecret.ApplicationOwners, unitOwners domainsecret.UnitOwners, revisionUUID ...string,
 	) ([]string, error)
 
-	InitialWatchStatementForConsumedSecrets(unitName string) (string, eventsource.NamespaceQuery)
-	GetConsumedSecretURIs(ctx context.Context, unitName string, consumerIDs ...string) ([]string, error)
+	InitialWatchStatementForConsumedSecretsChange(unitName string) (string, eventsource.NamespaceQuery)
+	GetConsumedSecretURIsWithChanges(ctx context.Context, unitName string, consumerIDs ...string) ([]string, error)
 }
 
 // WatcherFactory describes methods for creating watchers.

--- a/domain/secret/service/service.go
+++ b/domain/secret/service/service.go
@@ -67,11 +67,16 @@ type State interface {
 		ctx context.Context, appOwners domainsecret.ApplicationOwners, unitOwners domainsecret.UnitOwners, revisionUUID ...string,
 	) ([]string, error)
 
+	// For watching consumed local secret changes.
 	InitialWatchStatementForConsumedSecretsChange(unitName string) (string, eventsource.NamespaceQuery)
-	GetConsumedSecretURIsWithChanges(ctx context.Context, unitName string, consumerIDs ...string) ([]string, error)
+	GetConsumedSecretURIsWithChanges(ctx context.Context, unitName string, revisionIDs ...string) ([]string, error)
+	// For watching consumed remote secret changes.
+	InitialWatchStatementForConsumedRemoteSecretsChange(unitName string) (string, eventsource.NamespaceQuery)
+	GetConsumedRemoteSecretURIsWithChanges(ctx context.Context, unitName string, secretIDs ...string) (secretURIs []string, err error)
 
-	InitialWatchStatementForRemoteConsumedSecretsChange(appName string) (string, eventsource.NamespaceQuery)
-	GetRemoteConsumedSecretURIsWithChanges(ctx context.Context, appName string, secretIDs ...string) ([]string, error)
+	// For watching local secret changes that consumed by remote consumers.
+	InitialWatchStatementForRemoteConsumedSecretsChangesFromOfferingSide(appName string) (string, eventsource.NamespaceQuery)
+	GetRemoteConsumedSecretURIsWithChangesFromOfferingSide(ctx context.Context, appName string, secretIDs ...string) ([]string, error)
 }
 
 // WatcherFactory describes methods for creating watchers.

--- a/domain/secret/service/service_test.go
+++ b/domain/secret/service/service_test.go
@@ -1392,11 +1392,11 @@ func (s *serviceSuite) TestWatchConsumedSecretsChanges(c *gc.C) {
 	var namespaceQuery eventsource.NamespaceQuery = func(context.Context, database.TxnRunner) ([]string, error) {
 		return []string{uri1.ID, uri2.ID}, nil
 	}
-	s.state.EXPECT().InitialWatchStatementForConsumedSecrets("mysql/0").Return("table", namespaceQuery)
-	mockWatcherFactory.EXPECT().NewNamespaceWatcher("table", changestream.Update, gomock.Any()).Return(mockStringWatcher, nil)
+	s.state.EXPECT().InitialWatchStatementForConsumedSecretsChange("mysql/0").Return("table", namespaceQuery)
+	mockWatcherFactory.EXPECT().NewNamespaceWatcher("table", changestream.Create, gomock.Any()).Return(mockStringWatcher, nil)
 
 	gomock.InOrder(
-		s.state.EXPECT().GetConsumedSecretURIs(gomock.Any(),
+		s.state.EXPECT().GetConsumedSecretURIsWithChanges(gomock.Any(),
 			"mysql/0", uri1.ID, uri2.ID,
 		).Return([]string{uri1.String(), uri2.String()}, nil),
 	)

--- a/domain/secret/service/service_test.go
+++ b/domain/secret/service/service_test.go
@@ -1330,7 +1330,7 @@ func (s *serviceSuite) TestWatchObsolete(c *gc.C) {
 		domainsecret.ApplicationOwners([]string{"mysql"}),
 		domainsecret.UnitOwners([]string{"mysql/0", "mysql/1"}),
 	).Return("table", namespaceQuery)
-	mockWatcherFactory.EXPECT().NewNamespaceWatcher("table", changestream.Update, gomock.Any()).Return(mockStringWatcher, nil)
+	mockWatcherFactory.EXPECT().NewNamespaceWatcher("table", changestream.Create, gomock.Any()).Return(mockStringWatcher, nil)
 
 	gomock.InOrder(
 		s.state.EXPECT().GetRevisionIDsForObsolete(gomock.Any(),

--- a/domain/secret/service/service_test.go
+++ b/domain/secret/service/service_test.go
@@ -1390,19 +1390,67 @@ func (s *serviceSuite) TestWatchConsumedSecretsChanges(c *gc.C) {
 	mockStringWatcher.EXPECT().Kill().AnyTimes()
 
 	var namespaceQuery eventsource.NamespaceQuery = func(context.Context, database.TxnRunner) ([]string, error) {
-		return []string{uri1.ID, uri2.ID}, nil
+		return []string{"revision-uuid-1", "revision-uuid-2"}, nil
 	}
 	s.state.EXPECT().InitialWatchStatementForConsumedSecretsChange("mysql/0").Return("table", namespaceQuery)
 	mockWatcherFactory.EXPECT().NewNamespaceWatcher("table", changestream.Create, gomock.Any()).Return(mockStringWatcher, nil)
 
 	gomock.InOrder(
 		s.state.EXPECT().GetConsumedSecretURIsWithChanges(gomock.Any(),
-			"mysql/0", uri1.ID, uri2.ID,
+			"mysql/0", "revision-uuid-1", "revision-uuid-2",
 		).Return([]string{uri1.String(), uri2.String()}, nil),
 	)
 
 	svc := NewWatchableService(s.state, coretesting.NewCheckLogger(c), mockWatcherFactory, nil)
 	w, err := svc.WatchConsumedSecretsChanges(context.Background(), "mysql/0")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(w, gc.NotNil)
+	defer workertest.CleanKill(c, w)
+	wC := watchertest.NewStringsWatcherC(c, w)
+
+	select {
+	case ch <- []string{"revision-uuid-1", "revision-uuid-2"}:
+	case <-time.After(coretesting.ShortWait):
+		c.Fatalf("timed out waiting for the initial changes")
+	}
+
+	wC.AssertChange(
+		uri1.String(),
+		uri2.String(),
+	)
+	wC.AssertNoChange()
+}
+
+func (s *serviceSuite) TestWatchRemoteConsumedSecretsChanges(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	s.state = NewMockState(ctrl)
+	mockWatcherFactory := NewMockWatcherFactory(ctrl)
+
+	uri1 := coresecrets.NewURI()
+	uri2 := coresecrets.NewURI()
+
+	ch := make(chan []string)
+	mockStringWatcher := NewMockStringsWatcher(ctrl)
+	mockStringWatcher.EXPECT().Changes().Return(ch).AnyTimes()
+	mockStringWatcher.EXPECT().Wait().Return(nil).AnyTimes()
+	mockStringWatcher.EXPECT().Kill().AnyTimes()
+
+	var namespaceQuery eventsource.NamespaceQuery = func(context.Context, database.TxnRunner) ([]string, error) {
+		return []string{uri1.ID, uri2.ID}, nil
+	}
+	s.state.EXPECT().InitialWatchStatementForRemoteConsumedSecretsChange("mysql").Return("table", namespaceQuery)
+	mockWatcherFactory.EXPECT().NewNamespaceWatcher("table", changestream.All, gomock.Any()).Return(mockStringWatcher, nil)
+
+	gomock.InOrder(
+		s.state.EXPECT().GetRemoteConsumedSecretURIsWithChanges(gomock.Any(),
+			"mysql", uri1.ID, uri2.ID,
+		).Return([]string{uri1.String(), uri2.String()}, nil),
+	)
+
+	svc := NewWatchableService(s.state, coretesting.NewCheckLogger(c), mockWatcherFactory, nil)
+	w, err := svc.WatchRemoteConsumedSecretsChanges(context.Background(), "mysql")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(w, gc.NotNil)
 	defer workertest.CleanKill(c, w)

--- a/domain/secret/service/state_mock_test.go
+++ b/domain/secret/service/state_mock_test.go
@@ -98,6 +98,26 @@ func (mr *MockStateMockRecorder) DeleteSecret(arg0, arg1, arg2 any) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSecret", reflect.TypeOf((*MockState)(nil).DeleteSecret), arg0, arg1, arg2)
 }
 
+// GetConsumedRemoteSecretURIsWithChanges mocks base method.
+func (m *MockState) GetConsumedRemoteSecretURIsWithChanges(arg0 context.Context, arg1 string, arg2 ...string) ([]string, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "GetConsumedRemoteSecretURIsWithChanges", varargs...)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetConsumedRemoteSecretURIsWithChanges indicates an expected call of GetConsumedRemoteSecretURIsWithChanges.
+func (mr *MockStateMockRecorder) GetConsumedRemoteSecretURIsWithChanges(arg0, arg1 any, arg2 ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConsumedRemoteSecretURIsWithChanges", reflect.TypeOf((*MockState)(nil).GetConsumedRemoteSecretURIsWithChanges), varargs...)
+}
+
 // GetConsumedSecretURIsWithChanges mocks base method.
 func (m *MockState) GetConsumedSecretURIsWithChanges(arg0 context.Context, arg1 string, arg2 ...string) ([]string, error) {
 	m.ctrl.T.Helper()
@@ -133,24 +153,24 @@ func (mr *MockStateMockRecorder) GetModelUUID(arg0 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetModelUUID", reflect.TypeOf((*MockState)(nil).GetModelUUID), arg0)
 }
 
-// GetRemoteConsumedSecretURIsWithChanges mocks base method.
-func (m *MockState) GetRemoteConsumedSecretURIsWithChanges(arg0 context.Context, arg1 string, arg2 ...string) ([]string, error) {
+// GetRemoteConsumedSecretURIsWithChangesFromOfferingSide mocks base method.
+func (m *MockState) GetRemoteConsumedSecretURIsWithChangesFromOfferingSide(arg0 context.Context, arg1 string, arg2 ...string) ([]string, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
-	ret := m.ctrl.Call(m, "GetRemoteConsumedSecretURIsWithChanges", varargs...)
+	ret := m.ctrl.Call(m, "GetRemoteConsumedSecretURIsWithChangesFromOfferingSide", varargs...)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetRemoteConsumedSecretURIsWithChanges indicates an expected call of GetRemoteConsumedSecretURIsWithChanges.
-func (mr *MockStateMockRecorder) GetRemoteConsumedSecretURIsWithChanges(arg0, arg1 any, arg2 ...any) *gomock.Call {
+// GetRemoteConsumedSecretURIsWithChangesFromOfferingSide indicates an expected call of GetRemoteConsumedSecretURIsWithChangesFromOfferingSide.
+func (mr *MockStateMockRecorder) GetRemoteConsumedSecretURIsWithChangesFromOfferingSide(arg0, arg1 any, arg2 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]any{arg0, arg1}, arg2...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRemoteConsumedSecretURIsWithChanges", reflect.TypeOf((*MockState)(nil).GetRemoteConsumedSecretURIsWithChanges), varargs...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRemoteConsumedSecretURIsWithChangesFromOfferingSide", reflect.TypeOf((*MockState)(nil).GetRemoteConsumedSecretURIsWithChangesFromOfferingSide), varargs...)
 }
 
 // GetRevisionIDsForObsolete mocks base method.
@@ -325,6 +345,21 @@ func (mr *MockStateMockRecorder) GrantAccess(arg0, arg1, arg2 any) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GrantAccess", reflect.TypeOf((*MockState)(nil).GrantAccess), arg0, arg1, arg2)
 }
 
+// InitialWatchStatementForConsumedRemoteSecretsChange mocks base method.
+func (m *MockState) InitialWatchStatementForConsumedRemoteSecretsChange(arg0 string) (string, eventsource.NamespaceQuery) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InitialWatchStatementForConsumedRemoteSecretsChange", arg0)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(eventsource.NamespaceQuery)
+	return ret0, ret1
+}
+
+// InitialWatchStatementForConsumedRemoteSecretsChange indicates an expected call of InitialWatchStatementForConsumedRemoteSecretsChange.
+func (mr *MockStateMockRecorder) InitialWatchStatementForConsumedRemoteSecretsChange(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitialWatchStatementForConsumedRemoteSecretsChange", reflect.TypeOf((*MockState)(nil).InitialWatchStatementForConsumedRemoteSecretsChange), arg0)
+}
+
 // InitialWatchStatementForConsumedSecretsChange mocks base method.
 func (m *MockState) InitialWatchStatementForConsumedSecretsChange(arg0 string) (string, eventsource.NamespaceQuery) {
 	m.ctrl.T.Helper()
@@ -355,19 +390,19 @@ func (mr *MockStateMockRecorder) InitialWatchStatementForObsoleteRevision(arg0, 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitialWatchStatementForObsoleteRevision", reflect.TypeOf((*MockState)(nil).InitialWatchStatementForObsoleteRevision), arg0, arg1)
 }
 
-// InitialWatchStatementForRemoteConsumedSecretsChange mocks base method.
-func (m *MockState) InitialWatchStatementForRemoteConsumedSecretsChange(arg0 string) (string, eventsource.NamespaceQuery) {
+// InitialWatchStatementForRemoteConsumedSecretsChangesFromOfferingSide mocks base method.
+func (m *MockState) InitialWatchStatementForRemoteConsumedSecretsChangesFromOfferingSide(arg0 string) (string, eventsource.NamespaceQuery) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InitialWatchStatementForRemoteConsumedSecretsChange", arg0)
+	ret := m.ctrl.Call(m, "InitialWatchStatementForRemoteConsumedSecretsChangesFromOfferingSide", arg0)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(eventsource.NamespaceQuery)
 	return ret0, ret1
 }
 
-// InitialWatchStatementForRemoteConsumedSecretsChange indicates an expected call of InitialWatchStatementForRemoteConsumedSecretsChange.
-func (mr *MockStateMockRecorder) InitialWatchStatementForRemoteConsumedSecretsChange(arg0 any) *gomock.Call {
+// InitialWatchStatementForRemoteConsumedSecretsChangesFromOfferingSide indicates an expected call of InitialWatchStatementForRemoteConsumedSecretsChangesFromOfferingSide.
+func (mr *MockStateMockRecorder) InitialWatchStatementForRemoteConsumedSecretsChangesFromOfferingSide(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitialWatchStatementForRemoteConsumedSecretsChange", reflect.TypeOf((*MockState)(nil).InitialWatchStatementForRemoteConsumedSecretsChange), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitialWatchStatementForRemoteConsumedSecretsChangesFromOfferingSide", reflect.TypeOf((*MockState)(nil).InitialWatchStatementForRemoteConsumedSecretsChangesFromOfferingSide), arg0)
 }
 
 // ListCharmSecrets mocks base method.

--- a/domain/secret/service/state_mock_test.go
+++ b/domain/secret/service/state_mock_test.go
@@ -98,24 +98,24 @@ func (mr *MockStateMockRecorder) DeleteSecret(arg0, arg1, arg2 any) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSecret", reflect.TypeOf((*MockState)(nil).DeleteSecret), arg0, arg1, arg2)
 }
 
-// GetConsumedSecretURIs mocks base method.
-func (m *MockState) GetConsumedSecretURIs(arg0 context.Context, arg1 string, arg2 ...string) ([]string, error) {
+// GetConsumedSecretURIsWithChanges mocks base method.
+func (m *MockState) GetConsumedSecretURIsWithChanges(arg0 context.Context, arg1 string, arg2 ...string) ([]string, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
-	ret := m.ctrl.Call(m, "GetConsumedSecretURIs", varargs...)
+	ret := m.ctrl.Call(m, "GetConsumedSecretURIsWithChanges", varargs...)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetConsumedSecretURIs indicates an expected call of GetConsumedSecretURIs.
-func (mr *MockStateMockRecorder) GetConsumedSecretURIs(arg0, arg1 any, arg2 ...any) *gomock.Call {
+// GetConsumedSecretURIsWithChanges indicates an expected call of GetConsumedSecretURIsWithChanges.
+func (mr *MockStateMockRecorder) GetConsumedSecretURIsWithChanges(arg0, arg1 any, arg2 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]any{arg0, arg1}, arg2...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConsumedSecretURIs", reflect.TypeOf((*MockState)(nil).GetConsumedSecretURIs), varargs...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConsumedSecretURIsWithChanges", reflect.TypeOf((*MockState)(nil).GetConsumedSecretURIsWithChanges), varargs...)
 }
 
 // GetModelUUID mocks base method.
@@ -305,19 +305,19 @@ func (mr *MockStateMockRecorder) GrantAccess(arg0, arg1, arg2 any) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GrantAccess", reflect.TypeOf((*MockState)(nil).GrantAccess), arg0, arg1, arg2)
 }
 
-// InitialWatchStatementForConsumedSecrets mocks base method.
-func (m *MockState) InitialWatchStatementForConsumedSecrets(arg0 string) (string, eventsource.NamespaceQuery) {
+// InitialWatchStatementForConsumedSecretsChange mocks base method.
+func (m *MockState) InitialWatchStatementForConsumedSecretsChange(arg0 string) (string, eventsource.NamespaceQuery) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InitialWatchStatementForConsumedSecrets", arg0)
+	ret := m.ctrl.Call(m, "InitialWatchStatementForConsumedSecretsChange", arg0)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(eventsource.NamespaceQuery)
 	return ret0, ret1
 }
 
-// InitialWatchStatementForConsumedSecrets indicates an expected call of InitialWatchStatementForConsumedSecrets.
-func (mr *MockStateMockRecorder) InitialWatchStatementForConsumedSecrets(arg0 any) *gomock.Call {
+// InitialWatchStatementForConsumedSecretsChange indicates an expected call of InitialWatchStatementForConsumedSecretsChange.
+func (mr *MockStateMockRecorder) InitialWatchStatementForConsumedSecretsChange(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitialWatchStatementForConsumedSecrets", reflect.TypeOf((*MockState)(nil).InitialWatchStatementForConsumedSecrets), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitialWatchStatementForConsumedSecretsChange", reflect.TypeOf((*MockState)(nil).InitialWatchStatementForConsumedSecretsChange), arg0)
 }
 
 // InitialWatchStatementForObsoleteRevision mocks base method.

--- a/domain/secret/service/state_mock_test.go
+++ b/domain/secret/service/state_mock_test.go
@@ -98,6 +98,26 @@ func (mr *MockStateMockRecorder) DeleteSecret(arg0, arg1, arg2 any) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSecret", reflect.TypeOf((*MockState)(nil).DeleteSecret), arg0, arg1, arg2)
 }
 
+// GetConsumedSecretURIs mocks base method.
+func (m *MockState) GetConsumedSecretURIs(arg0 context.Context, arg1 string, arg2 ...string) ([]string, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "GetConsumedSecretURIs", varargs...)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetConsumedSecretURIs indicates an expected call of GetConsumedSecretURIs.
+func (mr *MockStateMockRecorder) GetConsumedSecretURIs(arg0, arg1 any, arg2 ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConsumedSecretURIs", reflect.TypeOf((*MockState)(nil).GetConsumedSecretURIs), varargs...)
+}
+
 // GetModelUUID mocks base method.
 func (m *MockState) GetModelUUID(arg0 context.Context) (string, error) {
 	m.ctrl.T.Helper()
@@ -285,19 +305,34 @@ func (mr *MockStateMockRecorder) GrantAccess(arg0, arg1, arg2 any) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GrantAccess", reflect.TypeOf((*MockState)(nil).GrantAccess), arg0, arg1, arg2)
 }
 
-// InitialWatchStatementForObsoleteRevision mocks base method.
-func (m *MockState) InitialWatchStatementForObsoleteRevision(arg0 context.Context, arg1 secret.ApplicationOwners, arg2 secret.UnitOwners) (string, eventsource.NamespaceQuery) {
+// InitialWatchStatementForConsumedSecrets mocks base method.
+func (m *MockState) InitialWatchStatementForConsumedSecrets(arg0 string) (string, eventsource.NamespaceQuery) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InitialWatchStatementForObsoleteRevision", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "InitialWatchStatementForConsumedSecrets", arg0)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(eventsource.NamespaceQuery)
+	return ret0, ret1
+}
+
+// InitialWatchStatementForConsumedSecrets indicates an expected call of InitialWatchStatementForConsumedSecrets.
+func (mr *MockStateMockRecorder) InitialWatchStatementForConsumedSecrets(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitialWatchStatementForConsumedSecrets", reflect.TypeOf((*MockState)(nil).InitialWatchStatementForConsumedSecrets), arg0)
+}
+
+// InitialWatchStatementForObsoleteRevision mocks base method.
+func (m *MockState) InitialWatchStatementForObsoleteRevision(arg0 secret.ApplicationOwners, arg1 secret.UnitOwners) (string, eventsource.NamespaceQuery) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InitialWatchStatementForObsoleteRevision", arg0, arg1)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(eventsource.NamespaceQuery)
 	return ret0, ret1
 }
 
 // InitialWatchStatementForObsoleteRevision indicates an expected call of InitialWatchStatementForObsoleteRevision.
-func (mr *MockStateMockRecorder) InitialWatchStatementForObsoleteRevision(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockStateMockRecorder) InitialWatchStatementForObsoleteRevision(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitialWatchStatementForObsoleteRevision", reflect.TypeOf((*MockState)(nil).InitialWatchStatementForObsoleteRevision), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitialWatchStatementForObsoleteRevision", reflect.TypeOf((*MockState)(nil).InitialWatchStatementForObsoleteRevision), arg0, arg1)
 }
 
 // ListCharmSecrets mocks base method.

--- a/domain/secret/service/state_mock_test.go
+++ b/domain/secret/service/state_mock_test.go
@@ -133,6 +133,26 @@ func (mr *MockStateMockRecorder) GetModelUUID(arg0 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetModelUUID", reflect.TypeOf((*MockState)(nil).GetModelUUID), arg0)
 }
 
+// GetRemoteConsumedSecretURIsWithChanges mocks base method.
+func (m *MockState) GetRemoteConsumedSecretURIsWithChanges(arg0 context.Context, arg1 string, arg2 ...string) ([]string, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "GetRemoteConsumedSecretURIsWithChanges", varargs...)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRemoteConsumedSecretURIsWithChanges indicates an expected call of GetRemoteConsumedSecretURIsWithChanges.
+func (mr *MockStateMockRecorder) GetRemoteConsumedSecretURIsWithChanges(arg0, arg1 any, arg2 ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRemoteConsumedSecretURIsWithChanges", reflect.TypeOf((*MockState)(nil).GetRemoteConsumedSecretURIsWithChanges), varargs...)
+}
+
 // GetRevisionIDsForObsolete mocks base method.
 func (m *MockState) GetRevisionIDsForObsolete(arg0 context.Context, arg1 secret.ApplicationOwners, arg2 secret.UnitOwners, arg3 ...string) ([]string, error) {
 	m.ctrl.T.Helper()
@@ -333,6 +353,21 @@ func (m *MockState) InitialWatchStatementForObsoleteRevision(arg0 secret.Applica
 func (mr *MockStateMockRecorder) InitialWatchStatementForObsoleteRevision(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitialWatchStatementForObsoleteRevision", reflect.TypeOf((*MockState)(nil).InitialWatchStatementForObsoleteRevision), arg0, arg1)
+}
+
+// InitialWatchStatementForRemoteConsumedSecretsChange mocks base method.
+func (m *MockState) InitialWatchStatementForRemoteConsumedSecretsChange(arg0 string) (string, eventsource.NamespaceQuery) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InitialWatchStatementForRemoteConsumedSecretsChange", arg0)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(eventsource.NamespaceQuery)
+	return ret0, ret1
+}
+
+// InitialWatchStatementForRemoteConsumedSecretsChange indicates an expected call of InitialWatchStatementForRemoteConsumedSecretsChange.
+func (mr *MockStateMockRecorder) InitialWatchStatementForRemoteConsumedSecretsChange(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitialWatchStatementForRemoteConsumedSecretsChange", reflect.TypeOf((*MockState)(nil).InitialWatchStatementForRemoteConsumedSecretsChange), arg0)
 }
 
 // ListCharmSecrets mocks base method.

--- a/domain/secret/service/watcher.go
+++ b/domain/secret/service/watcher.go
@@ -49,7 +49,7 @@ func (s *WatchableService) WatchConsumedSecretsChanges(ctx context.Context, unit
 	table, query := s.st.InitialWatchStatementForConsumedSecretsChange(unitName)
 	w, err := s.watcherFactory.NewNamespaceWatcher(
 		// We are only interested in CREATE changes because
-		// the secret_revision.version is immutable anyway.
+		// the secret_revision.revision is immutable anyway.
 		table, changestream.Create, query,
 	)
 	if err != nil {
@@ -93,7 +93,7 @@ func (s *WatchableService) WatchObsolete(ctx context.Context, owners ...CharmSec
 	appOwners, unitOwners := splitCharmSecretOwners(owners...)
 	table, query := s.st.InitialWatchStatementForObsoleteRevision(appOwners, unitOwners)
 	w, err := s.watcherFactory.NewNamespaceWatcher(
-		table, changestream.Update, query,
+		table, changestream.Create, query,
 	)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/domain/secret/service/watcher.go
+++ b/domain/secret/service/watcher.go
@@ -46,15 +46,15 @@ func NewWatchableService(
 // WatchConsumedSecretsChanges watches secrets consumed by the specified unit
 // and returns a watcher which notifies of secret URIs that have had a new revision added.
 func (s *WatchableService) WatchConsumedSecretsChanges(ctx context.Context, unitName string) (watcher.StringsWatcher, error) {
-	table, query := s.st.InitialWatchStatementForConsumedSecrets(unitName)
+	table, query := s.st.InitialWatchStatementForConsumedSecretsChange(unitName)
 	w, err := s.watcherFactory.NewNamespaceWatcher(
-		table, changestream.Update, query,
+		table, changestream.Create, query,
 	)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	processChanges := func(ctx context.Context, consumerIDs ...string) ([]string, error) {
-		return s.st.GetConsumedSecretURIs(ctx, unitName, consumerIDs...)
+	processChanges := func(ctx context.Context, revisionUUIDs ...string) ([]string, error) {
+		return s.st.GetConsumedSecretURIsWithChanges(ctx, unitName, revisionUUIDs...)
 	}
 	return newStringsWatcher(w, s.logger, processChanges)
 }

--- a/domain/secret/state/state.go
+++ b/domain/secret/state/state.go
@@ -2995,7 +2995,6 @@ INNER JOIN secret_revision sr ON sr.uuid = sro.revision_uuid`, selectStmt)
 	}
 	err = runner.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err := tx.Query(ctx, stmt, queryParams...).GetAll(result)
-		st.logger.Warningf("err: %#v, Result: %+v", err, result)
 		if errors.Is(err, sqlair.ErrNoRows) {
 			// It's ok, the revisions probably have already been pruned.
 			return nil

--- a/domain/secret/state/types.go
+++ b/domain/secret/state/types.go
@@ -98,17 +98,16 @@ type secretRotate struct {
 }
 
 type secretRevision struct {
-	ID       string `db:"uuid"`
-	SecretID string `db:"secret_id"`
-	Revision int    `db:"revision"`
+	ID         string    `db:"uuid"`
+	SecretID   string    `db:"secret_id"`
+	Revision   int       `db:"revision"`
+	CreateTime time.Time `db:"create_time"`
 }
 
 type secretRevisionObsolete struct {
-	ID            string    `db:"revision_uuid"`
-	Obsolete      bool      `db:"obsolete"`
-	PendingDelete bool      `db:"pending_delete"`
-	CreateTime    time.Time `db:"create_time"`
-	UpdateTime    time.Time `db:"update_time"`
+	ID            string `db:"revision_uuid"`
+	Obsolete      bool   `db:"obsolete"`
+	PendingDelete bool   `db:"pending_delete"`
 }
 
 type secretRevisionExpire struct {
@@ -300,13 +299,12 @@ func (rows secretIDs) toSecretMetadataForDrain(revRows secretExternalRevisions) 
 }
 
 type secretRevisions []secretRevision
-type secretRevisionsObsolete []secretRevisionObsolete
 type secretRevisionsExpire []secretRevisionExpire
 
 func (rows secretRevisions) toSecretRevisions(
-	valueRefs secretValueRefs, revObsolete secretRevisionsObsolete, revExpire secretRevisionsExpire,
+	valueRefs secretValueRefs, revExpire secretRevisionsExpire,
 ) ([]*coresecrets.SecretRevisionMetadata, error) {
-	if n := len(rows); n != len(valueRefs) || n != len(revObsolete) || n != len(revExpire) {
+	if n := len(rows); n != len(valueRefs) || n != len(revExpire) {
 		// Should never happen.
 		return nil, errors.New("row length mismatch composing secret revision results")
 	}
@@ -316,8 +314,7 @@ func (rows secretRevisions) toSecretRevisions(
 		result[i] = &coresecrets.SecretRevisionMetadata{
 			Revision:    row.Revision,
 			ValueRef:    nil,
-			CreateTime:  revObsolete[i].CreateTime,
-			UpdateTime:  revObsolete[i].UpdateTime,
+			CreateTime:  row.CreateTime,
 			BackendName: nil,
 		}
 		if tm := revExpire[i].ExpireTime; !tm.IsZero() {

--- a/domain/secret/watcher_test.go
+++ b/domain/secret/watcher_test.go
@@ -5,6 +5,7 @@ package secret_test
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 
 	jc "github.com/juju/testing/checkers"
@@ -21,7 +22,9 @@ import (
 	"github.com/juju/juju/domain/secret/service"
 	"github.com/juju/juju/domain/secret/state"
 	"github.com/juju/juju/internal/changestream/testing"
+	"github.com/juju/juju/internal/uuid"
 	coretesting "github.com/juju/juju/testing"
+	jujuversion "github.com/juju/juju/version"
 )
 
 type watcherSuite struct {
@@ -29,6 +32,19 @@ type watcherSuite struct {
 }
 
 var _ = gc.Suite(&watcherSuite{})
+
+func (s *watcherSuite) SetUpTest(c *gc.C) {
+	s.ModelSuite.SetUpTest(c)
+
+	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+			INSERT INTO model (uuid, controller_uuid, target_agent_version, name, type, cloud)
+			VALUES (?, ?, ?, "test", "iaas", "fluffy")
+		`, s.ModelUUID(), coretesting.ControllerTag.Id(), jujuversion.Current.String())
+		return err
+	})
+	c.Assert(err, jc.ErrorIsNil)
+}
 
 func (s *watcherSuite) setupUnits(c *gc.C, appName string) {
 	logger := coretesting.NewCheckLogger(c)
@@ -301,7 +317,7 @@ func (s *watcherSuite) TestWatchConsumedSecretsChanges(c *gc.C) {
 	)
 	wC.AssertNoChange()
 
-	// pretent that the agent restarted and the watcher is re-created.
+	// pretend that the agent restarted and the watcher is re-created.
 	watcher1, err := svc.WatchConsumedSecretsChanges(ctx, "mediawiki/0")
 	c.Assert(err, gc.IsNil)
 	c.Assert(watcher1, gc.NotNil)
@@ -316,6 +332,88 @@ func (s *watcherSuite) TestWatchConsumedSecretsChanges(c *gc.C) {
 	saveConsumer(uri1, 2, "mediawiki/0")
 	wC.AssertNoChange()
 	wC1.AssertNoChange()
+
+	// pretend that the agent restarted and the watcher is re-created again.
+	// Since we comsume the latest revision already, so there should be no change.
+	watcher2, err := svc.WatchConsumedSecretsChanges(ctx, "mediawiki/0")
+	c.Assert(err, gc.IsNil)
+	c.Assert(watcher2, gc.NotNil)
+	defer workertest.CleanKill(c, watcher1)
+	wC2 := watchertest.NewStringsWatcherC(c, watcher2)
+	wC2.AssertChange([]string(nil)...)
+	wC2.AssertNoChange()
+}
+
+func (s *watcherSuite) TestWatchConsumedRemoteSecretsChanges(c *gc.C) {
+	s.setupUnits(c, "mediawiki")
+
+	ctx := context.Background()
+	svc, st := s.setupServiceAndState(c)
+
+	saveConsumer := func(uri *coresecrets.URI, revision int, consumerID string) {
+		consumer := &coresecrets.SecretConsumerMetadata{
+			CurrentRevision: revision,
+		}
+		err := st.SaveSecretConsumer(ctx, uri, consumerID, consumer)
+		c.Assert(err, jc.ErrorIsNil)
+	}
+
+	sourceModelUUID := uuid.MustNewUUID()
+	uri1 := coresecrets.NewURI()
+	uri1.SourceUUID = sourceModelUUID.String()
+
+	uri2 := coresecrets.NewURI()
+	uri2.SourceUUID = sourceModelUUID.String()
+
+	// The consumed revision 1 is the initial revision - will be ignored.
+	saveConsumer(uri1, 1, "mediawiki/0")
+	// The consumed revision 1 is the initial revision - will be ignored.
+	saveConsumer(uri2, 1, "mediawiki/0")
+
+	watcher, err := svc.WatchConsumedSecretsChanges(ctx, "mediawiki/0")
+	c.Assert(err, gc.IsNil)
+	c.Assert(watcher, gc.NotNil)
+	defer workertest.CleanKill(c, watcher)
+
+	wC := watchertest.NewStringsWatcherC(c, watcher)
+
+	// Wait for the initial changes.
+	wC.AssertChange([]string(nil)...)
+	wC.AssertNoChange()
+
+	err = st.UpdateRemoteSecretRevision(ctx, uri1, 2)
+	c.Assert(err, jc.ErrorIsNil)
+
+	wC.AssertChange(
+		uri1.String(),
+	)
+	wC.AssertNoChange()
+
+	// pretend that the agent restarted and the watcher is re-created.
+	watcher1, err := svc.WatchConsumedSecretsChanges(ctx, "mediawiki/0")
+	c.Assert(err, gc.IsNil)
+	c.Assert(watcher1, gc.NotNil)
+	defer workertest.CleanKill(c, watcher1)
+	wC1 := watchertest.NewStringsWatcherC(c, watcher1)
+	wC1.AssertChange([]string(nil)...)
+	wC1.AssertChange(
+		uri1.String(),
+	)
+
+	// The consumed revision 2 is the updated current_revision.
+	saveConsumer(uri1, 2, "mediawiki/0")
+	wC.AssertNoChange()
+	wC1.AssertNoChange()
+
+	// pretend that the agent restarted and the watcher is re-created again.
+	// Since we comsume the latest revision already, so there should be no change.
+	watcher2, err := svc.WatchConsumedSecretsChanges(ctx, "mediawiki/0")
+	c.Assert(err, gc.IsNil)
+	c.Assert(watcher2, gc.NotNil)
+	defer workertest.CleanKill(c, watcher1)
+	wC2 := watchertest.NewStringsWatcherC(c, watcher2)
+	wC2.AssertChange([]string(nil)...)
+	wC2.AssertNoChange()
 }
 
 func (s *watcherSuite) TestWatchRemoteConsumedSecretsChanges(c *gc.C) {
@@ -338,10 +436,12 @@ func (s *watcherSuite) TestWatchRemoteConsumedSecretsChanges(c *gc.C) {
 	uri1 := coresecrets.NewURI()
 	err := st.CreateCharmApplicationSecret(ctx, 1, uri1, "mysql", sp)
 	c.Assert(err, jc.ErrorIsNil)
+	uri1.SourceUUID = s.ModelUUID()
 
 	uri2 := coresecrets.NewURI()
 	err = st.CreateCharmApplicationSecret(ctx, 1, uri2, "mysql", sp)
 	c.Assert(err, jc.ErrorIsNil)
+	uri2.SourceUUID = s.ModelUUID()
 
 	// The consumed revision 1 is the initial revision - will be ignored.
 	saveRemoteConsumer(uri1, 1, "mediawiki/0")
@@ -369,7 +469,7 @@ func (s *watcherSuite) TestWatchRemoteConsumedSecretsChanges(c *gc.C) {
 	)
 	wC.AssertNoChange()
 
-	// pretent that the agent restarted and the watcher is re-created.
+	// pretend that the agent restarted and the watcher is re-created.
 	watcher1, err := svc.WatchRemoteConsumedSecretsChanges(ctx, "mediawiki")
 	c.Assert(err, gc.IsNil)
 	c.Assert(watcher1, gc.NotNil)
@@ -384,4 +484,14 @@ func (s *watcherSuite) TestWatchRemoteConsumedSecretsChanges(c *gc.C) {
 	saveRemoteConsumer(uri1, 2, "mediawiki/0")
 	wC.AssertNoChange()
 	wC1.AssertNoChange()
+
+	// pretend that the agent restarted and the watcher is re-created again.
+	// Since we comsume the latest revision already, so there should be no change.
+	watcher2, err := svc.WatchRemoteConsumedSecretsChanges(ctx, "mediawiki")
+	c.Assert(err, gc.IsNil)
+	c.Assert(watcher2, gc.NotNil)
+	defer workertest.CleanKill(c, watcher1)
+	wC2 := watchertest.NewStringsWatcherC(c, watcher2)
+	wC2.AssertChange([]string(nil)...)
+	wC2.AssertNoChange()
 }

--- a/internal/worker/uniter/remotestate/watcher.go
+++ b/internal/worker/uniter/remotestate/watcher.go
@@ -441,10 +441,9 @@ func (w *RemoteStateWatcher) loop(unitTag names.UnitTag) (err error) {
 		return errors.Trace(err)
 	}
 	secretsChanges := secretsw.Changes()
-	// TODO(secrets) - uncomment when watcher is implemented
-	//if err := w.catacomb.Add(secretsw); err != nil {
-	//	return errors.Trace(err)
-	//}
+	if err := w.catacomb.Add(secretsw); err != nil {
+		return errors.Trace(err)
+	}
 	requiredEvents++
 
 	var (

--- a/tests/suites/secrets_iaas/cmr.sh
+++ b/tests/suites/secrets_iaas/cmr.sh
@@ -23,9 +23,9 @@ run_secrets_cmr() {
 	wait_for "1" '.offers["dummy-source"]["active-connected-count"]'
 
 	echo "Create and share a secret on the offer side"
-	secret_uri=$(juju exec --unit dummy-source/0 -- secret-add foo=bar)
+	secret_uri=$(juju exec -m model-secrets-offer --unit dummy-source/0 -- secret-add foo=bar)
 	relation_id=$(juju --show-log show-unit -m model-secrets-offer dummy-source/0 --format json | jq '."dummy-source/0"."relation-info"[0]."relation-id"')
-	juju exec --unit dummy-source/0 -- secret-grant "$secret_uri" -r "$relation_id"
+	juju exec -m model-secrets-offer --unit dummy-source/0 -- secret-grant "$secret_uri" -r "$relation_id"
 
 	echo "Checking: the secret can be read by the consumer"
 	juju switch "model-secrets-consume"


### PR DESCRIPTION
This PR adds a new watcher WatchConsumedSecretsChanges for watching consumed secret revision changes. When the consumer starts to consume a new secret revision, all the consumer units will run a `secret-changed` hook.
To achieve this, a new ChangeLog trigger on the `secret_unit_consumer` table is added.


## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```
juju add-model t1

juju --show-log deploy easyrsa
juju --show-log deploy etcd
juju --show-log integrate etcd easyrsa

juju exec --unit easyrsa/0 -- secret-add --owner unit owned-by=easyrsa/0
secret://2f45edf0-cefa-47b8-8bad-fac56c397010/coov83gqgc9h8cd2rg6g

juju exec --unit easyrsa/0 -- secret-grant coov83gqgc9h8cd2rg6g -r 1

juju exec --unit etcd/0 -- secret-get coov83gqgc9h8cd2rg6g
owned-by: easyrsa/0

juju exec --unit easyrsa/0 -- secret-set coov83gqgc9h8cd2rg6g foo=bar

juju show-secret coov83gqgc9h8cd2rg6g --revisions
coov83gqgc9h8cd2rg6g:
  revision: 2
  rotation: never
  owner: easyrsa/0
  created: 2024-05-01T07:49:34.019423227Z
  updated: 2024-05-01T07:57:16.752301869Z
  revisions:
  - revision: 1
    backend: internal
    created: 2024-05-01T07:49:34.019423227Z
    updated: 2024-05-01T07:49:34.019423227Z
  - revision: 2
    backend: internal
    created: 2024-05-01T07:57:16.752301869Z
    updated: 2024-05-01T07:57:16.752301869Z
  access:
  - target: application-etcd
    scope: relation-etcd.certificates#easyrsa.client
    role: view

juju show-status-log etcd/0
Time                        Type       Status       Message
...
01 May 2024 17:53:41+10:00  juju-unit  idle
01 May 2024 17:56:43+10:00  workload   active       Healthy with 1 known peer
01 May 2024 17:57:16+10:00  juju-unit  executing    running secret-changed hook for secret:coov83gqgc9h8cd2rg6g
01 May 2024 17:57:16+10:00  juju-unit  idle

juju offer easyrsa:client
Application "easyrsa" endpoints [client] available at "juj

juju add-model t2

juju --show-log deploy etcd

juju --show-log integrate etcd admin/t1.easyrsa

juju switch t1
juju exec --unit easyrsa/0 -- secret-grant coov83gqgc9h8cd2rg6g -r 2
juju exec --unit easyrsa/0 -- secret-set coov83gqgc9h8cd2rg6g foo=bar1

juju switch t2
juju show-status-log etcd/0
...
03 May 2024 20:14:09+10:00  juju-unit  executing    running secret-changed hook for secret://2f45edf0-cefa-47b8-8bad-fac56c397010/coov83gqgc9h8cd2rg6g
03 May 2024 20:14:09+10:00  juju-unit  idle

```

## Documentation changes

No

## Links

**Jira card:** JUJU-5813

