### PR TITLE
Remove debug logging for loggo labels.

### DIFF
--- a/cmd/jujud-controller/agent/machine.go
+++ b/cmd/jujud-controller/agent/machine.go
@@ -617,7 +617,7 @@ func (a *MachineAgent) makeEngineCreator(
 
 		// Create a single HTTP client so we can reuse HTTP connections, for
 		// example across the various Charmhub API requests required for deploy.
-		charmhubLogger := loggo.GetLoggerWithTags("juju.charmhub", corelogger.CHARMHUB).WithLabels(loggo.Labels{"foo": "bar"})
+		charmhubLogger := loggo.GetLoggerWithTags("juju.charmhub", corelogger.CHARMHUB)
 		charmhubHTTPClient := charmhub.DefaultHTTPClient(charmhub.LoggoLoggerFactory(charmhubLogger))
 
 		s3Logger := loggo.GetLoggerWithTags("juju.objectstore.s3", corelogger.OBJECTSTORE)

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -539,7 +539,7 @@ func (a *MachineAgent) makeEngineCreator(
 
 		// Create a single HTTP client so we can reuse HTTP connections, for
 		// example across the various Charmhub API requests required for deploy.
-		charmhubLogger := loggo.GetLoggerWithTags("juju.charmhub", corelogger.CHARMHUB).WithLabels(loggo.Labels{"foo": "bar"})
+		charmhubLogger := loggo.GetLoggerWithTags("juju.charmhub", corelogger.CHARMHUB)
 		charmhubHTTPClient := charmhub.DefaultHTTPClient(charmhub.LoggoLoggerFactory(charmhubLogger))
 
 		s3Logger := loggo.GetLoggerWithTags("juju.objectstore.s3", corelogger.OBJECTSTORE)


### PR DESCRIPTION
This was probably a mistake. Probably used when adding labels to loggo.

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```
$ juju bootstrap lxd test
$ juju debug-log -m controller
```
