### PR TITLE
Fix client tests gh action for mac

### DIFF
--- a/.github/workflows/client-tests.yml
+++ b/.github/workflows/client-tests.yml
@@ -43,6 +43,15 @@ jobs:
       run: |
         make install-mongo-dependencies
 
+    - name: "Install Mongo Dependencies: macOS-latest"
+      if: (matrix.os == 'macOS-latest')
+      run: |
+        brew tap mongodb/brew
+        brew update
+        brew install mongodb-community@4.4
+        brew link mongodb-community@4.4
+        brew services start mongodb/brew/mongodb-community@4.4
+
     - name: "Remove Mongo Dependencies: windows-latest"
       if: (matrix.os == 'windows-latest')
       uses: crazy-max/ghaction-chocolatey@90deb87d9fbf0bb2f022b91e3bf11b4441cddda5 # v1


### PR DESCRIPTION
In github's MacOs runner images, mongodb is no longer present in versions of toolsets 13 and beyond

See:
- https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md
- vs. https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md

So install mongodb as a pre-requisite step on mac, so we can keep with latest

## QA steps

gh actions pass