### PR TITLE
Remove unused functions UbuntuSeriesVersion

### DIFF
--- a/core/base/supportedseries.go
+++ b/core/base/supportedseries.go
@@ -208,26 +208,6 @@ func SeriesVersion(series string) (string, error) {
 	return "", errors.Trace(unknownSeriesVersionError(series))
 }
 
-// UbuntuSeriesVersion returns the ubuntu version for the specified series.
-func UbuntuSeriesVersion(series string) (string, error) {
-	if series == "" {
-		return "", errors.Trace(unknownSeriesVersionError(""))
-	}
-	seriesVersionsMutex.Lock()
-	defer seriesVersionsMutex.Unlock()
-
-	seriesName := SeriesName(series)
-	if vers, ok := ubuntuSeries[seriesName]; ok {
-		return vers.Version, nil
-	}
-	updateSeriesVersionsOnce()
-	if vers, ok := ubuntuSeries[seriesName]; ok {
-		return vers.Version, nil
-	}
-
-	return "", errors.Trace(unknownSeriesVersionError(series))
-}
-
 // UbuntuVersions returns the ubuntu versions as a map.
 func UbuntuVersions(supported, esmSupported *bool) map[string]string {
 	return ubuntuVersions(supported, esmSupported, ubuntuSeries)

--- a/core/base/supportedseries_linux_test.go
+++ b/core/base/supportedseries_linux_test.go
@@ -28,36 +28,6 @@ func (s *SupportedSeriesLinuxSuite) SetUpTest(c *gc.C) {
 	})
 }
 
-func (s *SupportedSeriesLinuxSuite) TestUbuntuSeriesVersionEmpty(c *gc.C) {
-	_, err := UbuntuSeriesVersion("")
-	c.Assert(err, gc.ErrorMatches, `.*unknown version for series: "".*`)
-}
-
-func (s *SupportedSeriesLinuxSuite) TestUbuntuSeriesVersion(c *gc.C) {
-	isUbuntuTests := []struct {
-		series   string
-		expected string
-	}{
-		{"precise", "12.04"},
-		{"raring", "13.04"},
-		{"bionic", "18.04"},
-		{"eoan", "19.10"},
-		{"focal", "20.04"},
-		{"jammy", "22.04"},
-		{"noble", "24.04"},
-	}
-	for _, v := range isUbuntuTests {
-		ver, err := UbuntuSeriesVersion(v.series)
-		c.Assert(err, gc.IsNil)
-		c.Assert(ver, gc.Equals, v.expected)
-	}
-}
-
-func (s *SupportedSeriesLinuxSuite) TestUbuntuInvalidSeriesVersion(c *gc.C) {
-	_, err := UbuntuSeriesVersion("firewolf")
-	c.Assert(err, gc.ErrorMatches, `.*unknown version for series: "firewolf".*`)
-}
-
 func (s *SupportedSeriesLinuxSuite) TestWorkloadSeries(c *gc.C) {
 	tmpFile, close := makeTempFile(c, distroInfoContents)
 	defer close()


### PR DESCRIPTION
Remove unused functions UbuntuSeriesVersion

Turns out this series function is no longer used anywhere, so we can remove it!

## QA steps

Static analysis passes