### PR TITLE
Fix incorrect usage of FilesystemMountPoint

### DIFF
--- a/state/application.go
+++ b/state/application.go
@@ -2598,13 +2598,12 @@ func (a *Application) addUnitStorageOps(
 		machineAssignable = pu
 	}
 	platform := a.CharmOrigin().Platform
-	sSeries, _ := corebase.GetSeriesFromChannel(platform.OS, platform.Channel)
 	storageOps, storageTags, numStorageAttachments, err := createStorageOps(
 		sb,
 		unitTag,
 		charm.Meta(),
 		args.storageCons,
-		sSeries,
+		platform.OS,
 		machineAssignable,
 	)
 	if err != nil {
@@ -2621,7 +2620,7 @@ func (a *Application) addUnitStorageOps(
 		ops, err := sb.attachStorageOps(
 			si,
 			unitTag,
-			sSeries,
+			platform.OS,
 			charm,
 			machineAssignable,
 		)

--- a/state/storage.go
+++ b/state/storage.go
@@ -19,7 +19,6 @@ import (
 	jujutxn "github.com/juju/txn/v3"
 
 	k8sconstants "github.com/juju/juju/caas/kubernetes/provider/constants"
-	corebase "github.com/juju/juju/core/base"
 	"github.com/juju/juju/environs/config"
 	stateerrors "github.com/juju/juju/state/errors"
 	"github.com/juju/juju/storage"
@@ -1038,11 +1037,7 @@ func (sb *storageBackend) AttachStorage(storage names.StorageTag, unit names.Uni
 		if err != nil {
 			return nil, errors.Annotate(err, "getting charm")
 		}
-		uSeries, err := corebase.GetSeriesFromChannel(u.Base().OS, u.Base().Channel)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		ops, err := sb.attachStorageOps(si, u.UnitTag(), uSeries, ch, u)
+		ops, err := sb.attachStorageOps(si, u.UnitTag(), u.Base().OS, ch, u)
 		if errors.IsAlreadyExists(err) {
 			return nil, jujutxn.ErrNoOperations
 		}
@@ -2218,16 +2213,12 @@ func (sb *storageBackend) addUnitStorageOps(
 	}
 
 	// Create storage db operations
-	sSeries, err := corebase.GetSeriesFromChannel(u.Base().OS, u.Base().Channel)
-	if err != nil {
-		return nil, nil, errors.Trace(err)
-	}
 	storageOps, storageTags, _, err := createStorageOps(
 		sb,
 		u.Tag(),
 		charmMeta,
 		map[string]StorageConstraints{storageName: cons},
-		sSeries,
+		u.Base().OS,
 		u,
 	)
 	if err != nil {


### PR DESCRIPTION
FilesystemMountPoint wants an ostype as a parameter, but in a few places in state we pass in a series

Fix this to instead pass in an ostype and remove some calls to series parsig functions

See here:
https://github.com/juju/juju/blob/5bdd424d5a5e27aa507861cc8bb41ef5098aab34/state/filesystem.go#L1398-L1403

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

```
./main.sh -v storage
```