### PR TITLE
Remove some easy win calls to SeriesVersion

### DIFF
--- a/caas/kubernetes/provider/bootstrap.go
+++ b/caas/kubernetes/provider/bootstrap.go
@@ -42,7 +42,6 @@ import (
 	"github.com/juju/juju/cloudconfig/podcfg"
 	"github.com/juju/juju/controller"
 	k8sannotations "github.com/juju/juju/core/annotations"
-	corebase "github.com/juju/juju/core/base"
 	"github.com/juju/juju/core/paths"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/docker"
@@ -1632,24 +1631,15 @@ func (c *controllerStack) buildContainerSpecForCommands(setupCmd, machineCmd str
 		c.broker.randomPrefix,
 	)
 
-	chSeries := version.DefaultSupportedLTS()
-	os, err := corebase.GetOSFromSeries(chSeries)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	ver, err := corebase.SeriesVersion(chSeries)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
+	chBase := version.DefaultSupportedLTSBase()
 	repo, err := docker.NewImageRepoDetails(c.pcfg.Controller.CAASImageRepo())
 	if err != nil {
 		return nil, errors.Annotatef(err, "parsing %s", controller.CAASImageRepo)
 	}
 	charmBaseImage, err := podcfg.ImageForBase(repo.Repository, charm.Base{
-		Name: strings.ToLower(os.String()),
+		Name: chBase.OS,
 		Channel: charm.Channel{
-			Track: ver,
+			Track: chBase.Channel.Track,
 			Risk:  charm.Stable,
 		},
 	})

--- a/charmhub/refresh.go
+++ b/charmhub/refresh.go
@@ -410,18 +410,15 @@ func constructRefreshBase(base RefreshBase) (transport.Base, error) {
 	}
 
 	var channel string
-	var err error
 	switch base.Channel {
 	case "":
 		channel = notAvailable
 	case "kubernetes":
 		// Kubernetes is not a valid channel for a base.
 		// Instead use the latest LTS version of ubuntu.
-		name = "ubuntu"
-		channel, err = corebase.SeriesVersion(version.DefaultSupportedLTS())
-		if err != nil {
-			return transport.Base{}, errors.NotValidf("invalid latest version")
-		}
+		b := version.DefaultSupportedLTSBase()
+		name = b.OS
+		channel = b.Channel.Track
 	default:
 		// If we have a series, we need to convert it to a stable version.
 		// If we have a version, then just pass that through.

--- a/provider/azure/internal/imageutils/images.go
+++ b/provider/azure/internal/imageutils/images.go
@@ -49,12 +49,9 @@ func SeriesImage(
 	var publisher, offering, sku string
 	switch seriesOS {
 	case ostype.Ubuntu:
-		series, err := jujubase.GetSeriesFromBase(base)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
 		publisher = ubuntuPublisher
-		sku, offering, err = ubuntuSKU(ctx, series, stream, location, client)
+		var err error
+		sku, offering, err = ubuntuSKU(ctx, base, stream, location, client)
 		if err != nil {
 			return nil, errors.Annotatef(err, "selecting SKU for %s", base.DisplayString())
 		}
@@ -80,22 +77,19 @@ func SeriesImage(
 	}, nil
 }
 
-func offerForUbuntuSeries(series string) (string, string, error) {
-	seriesVersion, err := jujubase.SeriesVersion(series)
-	if err != nil {
-		return "", "", errors.Trace(err)
-	}
-	seriesVersion = strings.ReplaceAll(seriesVersion, ".", "_")
-	return fmt.Sprintf("0001-com-ubuntu-server-%s", series), seriesVersion, nil
+func offerForUbuntuSeries(series string) string {
+	return fmt.Sprintf("0001-com-ubuntu-server-%s", series)
 }
 
 // ubuntuSKU returns the best SKU for the Canonical:UbuntuServer offering,
 // matching the given series.
-func ubuntuSKU(ctx context.ProviderCallContext, series, stream, location string, client *armcompute.VirtualMachineImagesClient) (string, string, error) {
-	offer, seriesVersion, err := offerForUbuntuSeries(series)
+func ubuntuSKU(ctx context.ProviderCallContext, base jujubase.Base, stream, location string, client *armcompute.VirtualMachineImagesClient) (string, string, error) {
+	series, err := jujubase.GetSeriesFromBase(base)
 	if err != nil {
 		return "", "", errors.Trace(err)
 	}
+	offer := offerForUbuntuSeries(series)
+	version := strings.ReplaceAll(base.Channel.Track, ".", "_")
 	logger.Debugf("listing SKUs: Location=%s, Publisher=%s, Offer=%s", location, ubuntuPublisher, offer)
 	result, err := client.ListSKUs(ctx, location, ubuntuPublisher, offer, nil)
 	if err != nil {
@@ -106,8 +100,8 @@ func ubuntuSKU(ctx context.ProviderCallContext, series, stream, location string,
 	for _, img := range result.VirtualMachineImageResourceArray {
 		skuName := *img.Name
 		logger.Debugf("Found Azure SKU Name: %v", skuName)
-		if !strings.HasPrefix(skuName, seriesVersion) {
-			logger.Debugf("ignoring SKU %q (does not match series %q with version %q)", skuName, series, seriesVersion)
+		if !strings.HasPrefix(skuName, version) {
+			logger.Debugf("ignoring SKU %q (does not match base %q with version %q)", skuName, base, version)
 			continue
 		}
 		version, tag, err := parseUbuntuSKU(skuName)


### PR DESCRIPTION
Remove some easy win calls to SeriesVersion

This is part of the work to remove the concept of a series from Juju

The remaining calls will be removed when support for series is dropped from charmhub.RefreshBase and Platforms

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

### Bootstrap a k8s controller + refresh a charm

```
$ make microk8s-operator-update
$ juju bootstrap microk8s mk8s
$ juju add-model m
$ juju deploy mysql-k8s
(wait)
Model  Controller  Cloud/Region        Version    SLA          Timestamp
m2     mk8s        microk8s/localhost  3.6-beta1  unsupported  00:32:05+01:00

App        Version                  Status  Scale  Charm      Channel     Rev  Address        Exposed  Message
mysql-k8s  8.0.35-0ubuntu0.22.04.1  active      1  mysql-k8s  8.0/stable  127  10.152.183.18  no       Primary

Unit          Workload  Agent  Address       Ports  Message
mysql-k8s/0*  active    idle   10.1.130.205         Primary

$ juju refresh mysql-k8s --channel 8.0/beta
Added charm-hub charm "mysql-k8s", revision 132 in channel 8.0/beta, to the model

$ juju status
Model  Controller  Cloud/Region        Version    SLA          Timestamp
m2     mk8s        microk8s/localhost  3.6-beta1  unsupported  00:32:33+01:00

App        Version                  Status  Scale  Charm      Channel   Rev  Address        Exposed  Message
mysql-k8s  8.0.35-0ubuntu0.22.04.1  active      1  mysql-k8s  8.0/beta  132  10.152.183.18  no       Primary

Unit          Workload  Agent  Address       Ports  Message
mysql-k8s/0*  active    idle   10.1.130.205         Primary
```

### Bootstrap azure + add machine with bases

```
$ juju bootstrap azure azure
$ juju add-model m
$ juju add-machine --base ubuntu@22.04
$ juju add-machine --base ubuntu@20.04
$ juju status
Model  Controller  Cloud/Region     Version      SLA          Timestamp
m      azure       azure/centralus  3.6-beta1.1  unsupported  17:29:06+01:00

Machine  State    Address         Inst id        Base          AZ  Message
0        started  172.169.72.245  juju-6e32f4-0  ubuntu@22.04      
1        started  172.169.72.242  juju-6e32f4-1  ubuntu@20.04
```