### PR TITLE
Add watcher for subnets

### DIFF
--- a/apiserver/common/firewall/state.go
+++ b/apiserver/common/firewall/state.go
@@ -17,8 +17,6 @@ type State interface {
 	state.ModelMachinesWatcher
 	state.ModelAccessor
 
-	WatchSubnets(func(id interface{}) bool) state.StringsWatcher
-
 	KeyRelation(string) (Relation, error)
 
 	Unit(string) (Unit, error)

--- a/apiserver/facades/controller/firewaller/firewaller_test.go
+++ b/apiserver/facades/controller/firewaller/firewaller_test.go
@@ -33,8 +33,9 @@ type firewallerSuite struct {
 	firewallerBaseSuite
 	*commontesting.ModelWatcherTest
 
-	firewaller *firewaller.FirewallerAPI
-	subnet     *state.Subnet
+	firewaller     *firewaller.FirewallerAPI
+	subnet         *state.Subnet
+	networkService *MockNetworkService
 
 	ctrl *gomock.Controller
 }
@@ -63,10 +64,12 @@ func (s *firewallerSuite) SetUpTest(c *gc.C) {
 	s.ctrl = gomock.NewController(c)
 	controllerConfigService := mocks.NewMockControllerConfigService(s.ctrl)
 	controllerConfigAPI := NewMockControllerConfigAPI(s.ctrl)
+	s.networkService = NewMockNetworkService(s.ctrl)
+
 	// Create a firewaller API for the machine.
 	firewallerAPI, err := firewaller.NewStateFirewallerAPI(
 		firewaller.StateShim(st, s.ControllerModel(c)),
-		nil,
+		s.networkService,
 		s.resources,
 		s.authorizer,
 		cloudSpecAPI,

--- a/apiserver/facades/controller/firewaller/interface.go
+++ b/apiserver/facades/controller/firewaller/interface.go
@@ -6,12 +6,14 @@ package firewaller
 import (
 	"context"
 
+	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 	"gopkg.in/macaroon.v2"
 
 	"github.com/juju/juju/apiserver/common/firewall"
 	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
 )
@@ -34,6 +36,10 @@ type State interface {
 type NetworkService interface {
 	// GetAllSpaces returns all spaces for the model.
 	GetAllSpaces(ctx context.Context) (network.SpaceInfos, error)
+	// Watch returns a watcher that observes changes to subnets and their
+	// association (fan underlays), filtered based on the provided list of subnets
+	// to watch.
+	WatchSubnets(ctx context.Context, subnetUUIDsToWatch set.Strings) (watcher.StringsWatcher, error)
 }
 
 // ControllerConfigAPI provides the subset of common.ControllerConfigAPI

--- a/apiserver/facades/controller/firewaller/package_mock_test.go
+++ b/apiserver/facades/controller/firewaller/package_mock_test.go
@@ -14,9 +14,11 @@ import (
 	reflect "reflect"
 	time "time"
 
+	set "github.com/juju/collections/set"
 	firewall "github.com/juju/juju/apiserver/common/firewall"
 	controller "github.com/juju/juju/controller"
 	network "github.com/juju/juju/core/network"
+	watcher "github.com/juju/juju/core/watcher"
 	config "github.com/juju/juju/environs/config"
 	params "github.com/juju/juju/rpc/params"
 	state "github.com/juju/juju/state"
@@ -252,20 +254,6 @@ func (mr *MockStateMockRecorder) WatchOpenedPorts() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchOpenedPorts", reflect.TypeOf((*MockState)(nil).WatchOpenedPorts))
 }
 
-// WatchSubnets mocks base method.
-func (m *MockState) WatchSubnets(arg0 func(any) bool) state.StringsWatcher {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchSubnets", arg0)
-	ret0, _ := ret[0].(state.StringsWatcher)
-	return ret0
-}
-
-// WatchSubnets indicates an expected call of WatchSubnets.
-func (mr *MockStateMockRecorder) WatchSubnets(arg0 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchSubnets", reflect.TypeOf((*MockState)(nil).WatchSubnets), arg0)
-}
-
 // MockControllerConfigAPI is a mock of ControllerConfigAPI interface.
 type MockControllerConfigAPI struct {
 	ctrl     *gomock.Controller
@@ -393,4 +381,19 @@ func (m *MockNetworkService) GetAllSpaces(arg0 context.Context) (network.SpaceIn
 func (mr *MockNetworkServiceMockRecorder) GetAllSpaces(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllSpaces", reflect.TypeOf((*MockNetworkService)(nil).GetAllSpaces), arg0)
+}
+
+// WatchSubnets mocks base method.
+func (m *MockNetworkService) WatchSubnets(arg0 context.Context, arg1 set.Strings) (watcher.Watcher[[]string], error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WatchSubnets", arg0, arg1)
+	ret0, _ := ret[0].(watcher.Watcher[[]string])
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WatchSubnets indicates an expected call of WatchSubnets.
+func (mr *MockNetworkServiceMockRecorder) WatchSubnets(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchSubnets", reflect.TypeOf((*MockNetworkService)(nil).WatchSubnets), arg0, arg1)
 }

--- a/apiserver/facades/controller/migrationtarget/servicefactory_mock_test.go
+++ b/apiserver/facades/controller/migrationtarget/servicefactory_mock_test.go
@@ -338,10 +338,10 @@ func (mr *MockServiceFactoryMockRecorder) ModelInfo() *gomock.Call {
 }
 
 // Network mocks base method.
-func (m *MockServiceFactory) Network() *service14.ProviderService {
+func (m *MockServiceFactory) Network() *service14.WatchableService {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Network")
-	ret0, _ := ret[0].(*service14.ProviderService)
+	ret0, _ := ret[0].(*service14.WatchableService)
 	return ret0
 }
 

--- a/core/watcher/eventsource/multiwatcher.go
+++ b/core/watcher/eventsource/multiwatcher.go
@@ -31,6 +31,16 @@ func NewMultiNotifyWatcher(ctx context.Context, watchers ...Watcher[struct{}]) (
 	return NewMultiWatcher[struct{}](ctx, applier, watchers...)
 }
 
+// NewMultiStringsWatcher creates a strings watcher (Watcher[[]string]) that
+// combines each of the (strings) watchers passed in. Each watcher's initial
+// event is consumed, and a single initial event is sent.
+func NewMultiStringsWatcher(ctx context.Context, watchers ...Watcher[[]string]) (*MultiWatcher[[]string], error) {
+	applier := func(staging, in []string) []string {
+		return append(staging, in...)
+	}
+	return NewMultiWatcher[[]string](ctx, applier, watchers...)
+}
+
 // NewMultiWatcher creates a NotifyWatcher that combines
 // each of the NotifyWatchers passed in. Each watcher's initial
 // event is consumed, and a single initial event is sent.
@@ -68,9 +78,7 @@ func NewMultiWatcher[T any](ctx context.Context, applier Applier[T], watchers ..
 	return w, nil
 }
 
-// loop copies events from the input channel to the output channel,
-// coalescing events by waiting a short time between receiving and
-// sending.
+// loop copies events from the input channel to the output channel.
 func (w *MultiWatcher[T]) loop() error {
 	defer close(w.changes)
 
@@ -88,7 +96,7 @@ func (w *MultiWatcher[T]) loop() error {
 	}
 }
 
-// copyEvents copies channel events from "in" to "out", coalescing.
+// copyEvents copies channel events from "in" to "out".
 func (w *MultiWatcher[T]) copyEvents(in <-chan T) {
 	var (
 		outC    chan<- T

--- a/domain/network/package_test.go
+++ b/domain/network/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package network
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/domain/network/service/package_mock_test.go
+++ b/domain/network/service/package_mock_test.go
@@ -13,6 +13,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	database "github.com/juju/juju/core/database"
 	instance "github.com/juju/juju/core/instance"
 	network "github.com/juju/juju/core/network"
 	environs "github.com/juju/juju/environs"
@@ -70,6 +71,36 @@ func (m *MockState) AddSubnet(arg0 context.Context, arg1 network.SubnetInfo) err
 func (mr *MockStateMockRecorder) AddSubnet(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddSubnet", reflect.TypeOf((*MockState)(nil).AddSubnet), arg0, arg1)
+}
+
+// AllAssociatedSubnetsQuery mocks base method.
+func (m *MockState) AllAssociatedSubnetsQuery(arg0 context.Context, arg1 database.TxnRunner) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AllAssociatedSubnetsQuery", arg0, arg1)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AllAssociatedSubnetsQuery indicates an expected call of AllAssociatedSubnetsQuery.
+func (mr *MockStateMockRecorder) AllAssociatedSubnetsQuery(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllAssociatedSubnetsQuery", reflect.TypeOf((*MockState)(nil).AllAssociatedSubnetsQuery), arg0, arg1)
+}
+
+// AllSubnetsQuery mocks base method.
+func (m *MockState) AllSubnetsQuery(arg0 context.Context, arg1 database.TxnRunner) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AllSubnetsQuery", arg0, arg1)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AllSubnetsQuery indicates an expected call of AllSubnetsQuery.
+func (mr *MockStateMockRecorder) AllSubnetsQuery(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllSubnetsQuery", reflect.TypeOf((*MockState)(nil).AllSubnetsQuery), arg0, arg1)
 }
 
 // DeleteSpace mocks base method.

--- a/domain/network/service/watcher.go
+++ b/domain/network/service/watcher.go
@@ -1,0 +1,82 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package service
+
+import (
+	"context"
+
+	"github.com/juju/collections/set"
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/core/changestream"
+	"github.com/juju/juju/core/providertracker"
+	"github.com/juju/juju/core/watcher"
+	"github.com/juju/juju/core/watcher/eventsource"
+)
+
+// WatchableService provides the API for working with external controllers
+// and the ability to create watchers.
+type WatchableService struct {
+	ProviderService
+	watcherFactory WatcherFactory
+}
+
+// NewWatchableService returns a new watchable service reference wrapping the
+// input state and provider.
+func NewWatchableService(st State, provider providertracker.ProviderGetter[Provider], watcherFactory WatcherFactory, logger Logger) *WatchableService {
+	return &WatchableService{
+		ProviderService: ProviderService{
+			Service: Service{
+				st:     st,
+				logger: logger,
+			},
+			provider: provider,
+		},
+		watcherFactory: watcherFactory,
+	}
+}
+
+// Watch returns a watcher that observes changes to subnets and their
+// association (fan underlays), filtered based on the provided list of subnets
+// to watch.
+func (s *WatchableService) WatchSubnets(ctx context.Context, subnetUUIDsToWatch set.Strings) (watcher.StringsWatcher, error) {
+	if s.watcherFactory != nil {
+		filter := subnetUUIDsFilter(subnetUUIDsToWatch)
+
+		subnetWatcher, err := s.watcherFactory.NewNamespaceMapperWatcher(
+			"subnet",
+			changestream.All,
+			s.st.AllSubnetsQuery,
+			eventsource.FilterEvents(filter),
+		)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		subnetAssociationWatcher, err := s.watcherFactory.NewNamespaceMapperWatcher(
+			"subnet_association",
+			changestream.All,
+			s.st.AllAssociatedSubnetsQuery,
+			eventsource.FilterEvents(filter),
+		)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+
+		return eventsource.NewMultiStringsWatcher(ctx, subnetWatcher, subnetAssociationWatcher)
+	}
+	return nil, errors.NotYetAvailablef("subnet watcher")
+}
+
+// subnetUUIDsFilter filters the returned subnet UUIDs from the changelog
+// according to the user-provided list of subnet UUIDs.
+// To keep the compatibility with legacy watchers, if the input set of subnets
+// is empty then no filtering is applied.
+func subnetUUIDsFilter(subnetUUIDsToWatch set.Strings) func(changestream.ChangeEvent) bool {
+	if subnetUUIDsToWatch.IsEmpty() {
+		return func(_ changestream.ChangeEvent) bool { return true }
+	}
+	return func(event changestream.ChangeEvent) bool {
+		return subnetUUIDsToWatch.Contains(event.Changed())
+	}
+}

--- a/domain/network/service/watcher.go
+++ b/domain/network/service/watcher.go
@@ -41,31 +41,28 @@ func NewWatchableService(st State, provider providertracker.ProviderGetter[Provi
 // association (fan underlays), filtered based on the provided list of subnets
 // to watch.
 func (s *WatchableService) WatchSubnets(ctx context.Context, subnetUUIDsToWatch set.Strings) (watcher.StringsWatcher, error) {
-	if s.watcherFactory != nil {
-		filter := subnetUUIDsFilter(subnetUUIDsToWatch)
+	filter := subnetUUIDsFilter(subnetUUIDsToWatch)
 
-		subnetWatcher, err := s.watcherFactory.NewNamespaceMapperWatcher(
-			"subnet",
-			changestream.All,
-			s.st.AllSubnetsQuery,
-			eventsource.FilterEvents(filter),
-		)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		subnetAssociationWatcher, err := s.watcherFactory.NewNamespaceMapperWatcher(
-			"subnet_association",
-			changestream.All,
-			s.st.AllAssociatedSubnetsQuery,
-			eventsource.FilterEvents(filter),
-		)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-
-		return eventsource.NewMultiStringsWatcher(ctx, subnetWatcher, subnetAssociationWatcher)
+	subnetWatcher, err := s.watcherFactory.NewNamespaceMapperWatcher(
+		"subnet",
+		changestream.All,
+		s.st.AllSubnetsQuery,
+		eventsource.FilterEvents(filter),
+	)
+	if err != nil {
+		return nil, errors.Trace(err)
 	}
-	return nil, errors.NotYetAvailablef("subnet watcher")
+	subnetAssociationWatcher, err := s.watcherFactory.NewNamespaceMapperWatcher(
+		"subnet_association",
+		changestream.All,
+		s.st.AllAssociatedSubnetsQuery,
+		eventsource.FilterEvents(filter),
+	)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	return eventsource.NewMultiStringsWatcher(ctx, subnetWatcher, subnetAssociationWatcher)
 }
 
 // subnetUUIDsFilter filters the returned subnet UUIDs from the changelog

--- a/domain/network/watcher_test.go
+++ b/domain/network/watcher_test.go
@@ -1,0 +1,126 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package network_test
+
+import (
+	"context"
+
+	"github.com/juju/collections/set"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/changestream"
+	"github.com/juju/juju/core/database"
+	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/core/watcher/watchertest"
+	"github.com/juju/juju/domain"
+	service "github.com/juju/juju/domain/network/service"
+	state "github.com/juju/juju/domain/network/state"
+	changestreamtesting "github.com/juju/juju/internal/changestream/testing"
+	"github.com/juju/juju/testing"
+)
+
+type watcherSuite struct {
+	changestreamtesting.ModelSuite
+}
+
+var _ = gc.Suite(&watcherSuite{})
+
+func (s *watcherSuite) TestWatchWithAdd(c *gc.C) {
+	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "subnet")
+
+	svc := service.NewWatchableService(
+		state.NewState(func() (database.TxnRunner, error) { return factory() }, testing.NewCheckLogger(c)),
+		nil,
+		domain.NewWatcherFactory(factory,
+			testing.NewCheckLogger(c),
+		),
+		testing.NewCheckLogger(c),
+	)
+	watcher, err := svc.WatchSubnets(context.Background(), set.NewStrings())
+	c.Assert(err, jc.ErrorIsNil)
+	watcherC := watchertest.NewStringsWatcherC(c, watcher)
+
+	// Add a new subnet.
+	subnet := network.SubnetInfo{
+		CIDR:              "10.0.0.0/24",
+		ProviderId:        "subnet-provider-id",
+		ProviderNetworkId: "subnet-provider-network-id",
+	}
+	createdSubnetID, err := svc.AddSubnet(context.Background(), subnet)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Get the change.
+	watcherC.AssertChange(createdSubnetID.String())
+}
+
+func (s *watcherSuite) TestWatchWithSubnetAssociation(c *gc.C) {
+	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "subnet")
+
+	svc := service.NewWatchableService(
+		state.NewState(func() (database.TxnRunner, error) { return factory() }, testing.NewCheckLogger(c)),
+		nil,
+		domain.NewWatcherFactory(factory,
+			testing.NewCheckLogger(c),
+		),
+		testing.NewCheckLogger(c),
+	)
+	watcher, err := svc.WatchSubnets(context.Background(), set.NewStrings())
+	c.Assert(err, jc.ErrorIsNil)
+	watcherC := watchertest.NewStringsWatcherC(c, watcher)
+
+	// Add a new subnet.
+	createdSubnetID0, err := svc.AddSubnet(context.Background(), network.SubnetInfo{
+		CIDR:              "192.168.0.0/20",
+		ProviderId:        "subnet-provider-id-0",
+		ProviderNetworkId: "subnet-provider-network-id-0",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	createdSubnetID1, err := svc.AddSubnet(context.Background(), network.SubnetInfo{
+		CIDR:              "10.0.0.0/12",
+		ProviderId:        "subnet-provider-id-1",
+		ProviderNetworkId: "subnet-provider-network-id-1",
+		FanInfo: &network.FanCIDRs{
+			FanLocalUnderlay: "192.168.0.0/20",
+			FanOverlay:       "10.0.0.0/8",
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	// Get the changes, we know we must get 3 changes, 2 for the newly
+	// created subnets and the other one for the association between the
+	// two subnets (which should contain the UUID of the first created
+	// subnet which is the underlay).
+	watcherC.AssertChange(createdSubnetID0.String(), createdSubnetID0.String(), createdSubnetID1.String())
+}
+
+func (s *watcherSuite) TestWatchWithDelete(c *gc.C) {
+	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "subnet")
+
+	svc := service.NewWatchableService(
+		state.NewState(func() (database.TxnRunner, error) { return factory() }, testing.NewCheckLogger(c)),
+		nil,
+		domain.NewWatcherFactory(factory,
+			testing.NewCheckLogger(c),
+		),
+		testing.NewCheckLogger(c),
+	)
+	watcher, err := svc.WatchSubnets(context.Background(), set.NewStrings())
+	c.Assert(err, jc.ErrorIsNil)
+	watcherC := watchertest.NewStringsWatcherC(c, watcher)
+
+	// Add a new subnet.
+	subnet := network.SubnetInfo{
+		CIDR:              "10.0.0.0/24",
+		ProviderId:        "subnet-provider-id",
+		ProviderNetworkId: "subnet-provider-network-id",
+	}
+	createdSubnetID, err := svc.AddSubnet(context.Background(), subnet)
+	c.Assert(err, jc.ErrorIsNil)
+	// Delete the subnet.
+	err = svc.RemoveSubnet(context.Background(), createdSubnetID.String())
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Get the change.
+	watcherC.AssertChange(createdSubnetID.String())
+}

--- a/domain/schema/model.go
+++ b/domain/schema/model.go
@@ -23,6 +23,8 @@ const (
 	tableSecretRotation
 	tableSecretRevisionObsolete
 	tableSecretRevisionExpire
+	tableSubnet
+	tableSubnetAssociation
 )
 
 // ModelDDL is used to create model databases.
@@ -60,6 +62,10 @@ func ModelDDL() *schema.Schema {
 		changeLogTriggersForTable("secret_revision", "uuid", tableSecretRevisionObsolete),
 		changeLogTriggersForTable("secret_revision_expire", "revision_uuid", tableSecretRevisionExpire),
 		changeLogTriggersForTableOnColumn("secret_metadata", "secret_id", "auto_prune", tableSecretAutoPrune),
+		changeLogTriggersForTable(
+			"subnet", "uuid", tableSubnet),
+		changeLogTriggersForTable(
+			"subnet_association", "associated_subnet_uuid", tableSubnetAssociation),
 
 		triggersForImmutableTable("model", "", "model table is immutable"),
 
@@ -129,8 +135,9 @@ INSERT INTO change_log_namespace VALUES
     (10, 'secret_rotation', 'Secret rotation changes based on UUID'),
     (11, 'secret_revision', 'Secret revision obsolete changes based on UUID'),
     (12, 'secret_revision_expire', 'Secret revision next expire time changes based on UUID'),
-    (13, 'secret_unit_consumer', 'Secret unit consumer current revision changes based on UUID'),
-    (14, 'secret_remote_unit_consumer', 'Secret remote unit consumer current revision changes based on UUID');
+    (13, 'subnet', 'Subnet changes based on UUID'),
+    (14, 'subnet_association', 'Subnet association (fan underlay) changes based on UUID'),
+    (15, 'secret_unit_consumer', 'Secret unit consumer current revision changes based on UUID');
 `)
 }
 

--- a/domain/schema/schema_test.go
+++ b/domain/schema/schema_test.go
@@ -444,6 +444,14 @@ func (s *schemaSuite) TestModelTriggers(c *gc.C) {
 		"trg_log_storage_volume_delete",
 
 		"trg_secret_permission_immutable_update",
+
+		"trg_log_subnet_association_delete",
+		"trg_log_subnet_association_insert",
+		"trg_log_subnet_association_update",
+
+		"trg_log_subnet_delete",
+		"trg_log_subnet_insert",
+		"trg_log_subnet_update",
 	)
 
 	// These are additional triggers that are not change log triggers, but

--- a/domain/servicefactory/model.go
+++ b/domain/servicefactory/model.go
@@ -120,10 +120,11 @@ func (s *ModelFactory) Unit() *unitservice.Service {
 }
 
 // Network returns the model's network service.
-func (s *ModelFactory) Network() *networkservice.ProviderService {
-	return networkservice.NewProviderService(
+func (s *ModelFactory) Network() *networkservice.WatchableService {
+	return networkservice.NewWatchableService(
 		networkstate.NewState(changestream.NewTxnRunnerFactory(s.modelDB), s.logger.Child("network.state")),
 		providertracker.ProviderRunner[networkservice.Provider](s.providerFactory, s.modelUUID.String()),
+		domain.NewWatcherFactory(s.modelDB, s.logger.Child("network.watcherfactory")),
 		s.logger.Child("network.service"),
 	)
 }

--- a/domain/servicefactory/testing/service.go
+++ b/domain/servicefactory/testing/service.go
@@ -122,7 +122,7 @@ func (s *TestingServiceFactory) Machine() *machineservice.Service {
 }
 
 // Network returns the network service.
-func (s *TestingServiceFactory) Network() *networkservice.ProviderService {
+func (s *TestingServiceFactory) Network() *networkservice.WatchableService {
 	return nil
 }
 

--- a/internal/migration/servicefactory_mock_test.go
+++ b/internal/migration/servicefactory_mock_test.go
@@ -338,10 +338,10 @@ func (mr *MockServiceFactoryMockRecorder) ModelInfo() *gomock.Call {
 }
 
 // Network mocks base method.
-func (m *MockServiceFactory) Network() *service14.ProviderService {
+func (m *MockServiceFactory) Network() *service14.WatchableService {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Network")
-	ret0, _ := ret[0].(*service14.ProviderService)
+	ret0, _ := ret[0].(*service14.WatchableService)
 	return ret0
 }
 

--- a/internal/servicefactory/interface.go
+++ b/internal/servicefactory/interface.go
@@ -81,7 +81,7 @@ type ModelServiceFactory interface {
 	// Unit returns the machine service.
 	Unit() *unitservice.Service
 	// Network returns the space service.
-	Network() *networkservice.ProviderService
+	Network() *networkservice.WatchableService
 	// Annotation returns the annotation service.
 	Annotation() *annotationService.Service
 	// Storage returns the storage service.

--- a/internal/worker/firewaller/firewaller.go
+++ b/internal/worker/firewaller/firewaller.go
@@ -407,6 +407,7 @@ func (fw *Firewaller) subnetsChanged(ctx context.Context) error {
 		return nil // nothing to do
 	}
 
+	fw.logger.Debugf("updating %d units after changes in subnets", len(unitds))
 	if err := fw.flushUnits(ctx, unitds); err != nil {
 		return errors.Annotate(err, "cannot update unit ingress rules")
 	}

--- a/internal/worker/servicefactory/servicefactory_mock_test.go
+++ b/internal/worker/servicefactory/servicefactory_mock_test.go
@@ -352,10 +352,10 @@ func (mr *MockModelServiceFactoryMockRecorder) ModelInfo() *gomock.Call {
 }
 
 // Network mocks base method.
-func (m *MockModelServiceFactory) Network() *service14.ProviderService {
+func (m *MockModelServiceFactory) Network() *service14.WatchableService {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Network")
-	ret0, _ := ret[0].(*service14.ProviderService)
+	ret0, _ := ret[0].(*service14.WatchableService)
 	return ret0
 }
 
@@ -683,10 +683,10 @@ func (mr *MockServiceFactoryMockRecorder) ModelInfo() *gomock.Call {
 }
 
 // Network mocks base method.
-func (m *MockServiceFactory) Network() *service14.ProviderService {
+func (m *MockServiceFactory) Network() *service14.WatchableService {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Network")
-	ret0, _ := ret[0].(*service14.ProviderService)
+	ret0, _ := ret[0].(*service14.WatchableService)
 	return ret0
 }
 


### PR DESCRIPTION
This patch adds a new subnets watcher on the network domain. This watcher is formed by composing one watcher out of two: one for the subnet table and the second one for the subnet_association table. The second one is needed to watch underlay fan subnets.

This watcher is wired on the apiserver for its usage on the firewaller worker.


## Checklist


- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

_Note: ideally, this patch must be QA'd on a substrate supporting port opening (e.g. AWS), but we currently have an issue on model creation which is under investigation._

Bootstrap on lxd, add a model and deploy apache2:
```
juju bootstrap localhost c
juju add-model m --config logging-config="juju.worker.firewaller=DEBUG"
juju deploy apache2
```
Once the app is running, expose apache2:
```
juju expose apache2 --to-spaces alpha
```
Then create a new space (make sure you use a correct subnet in your environment) and watch for firewaller debug logs:
```
juju add-space foo 10.68.58.0/24
juju  debug-log --replay --level DEBUG --tail | grep "firewaller"     
...
controller-0: 11:52:20 DEBUG juju.worker.firewaller updating 1 units after changes in subnets
```

## Links


**Jira card:** JUJU-5927

