### PR TITLE
Use WorkloadBases everywhere

### DIFF
--- a/cmd/juju/application/setapplicationbase.go
+++ b/cmd/juju/application/setapplicationbase.go
@@ -159,9 +159,5 @@ func (c *setApplicationBase) parseBase(ctx *cmd.Context, arg string) (corebase.B
 	}
 
 	ctx.Warningf("series argument is deprecated, use base instead")
-	_, err := corebase.GetOSFromSeries(arg)
-	if err != nil {
-		return corebase.Base{}, errors.Trace(err)
-	}
 	return corebase.GetBaseFromSeries(arg)
 }

--- a/cmd/juju/machine/upgrademachine_test.go
+++ b/cmd/juju/machine/upgrademachine_test.go
@@ -7,11 +7,9 @@ import (
 	"bytes"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/juju/cmd/v3"
 	"github.com/juju/cmd/v3/cmdtesting"
-	"github.com/juju/collections/set"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"go.uber.org/mock/gomock"
@@ -68,15 +66,6 @@ func (s *UpgradeMachineSuite) SetUpTest(c *gc.C) {
 	s.prepareExpectation = &upgradeMachinePrepareExpectation{gomock.Any(), gomock.Any(), gomock.Any()}
 	s.completeExpectation = &upgradeMachineCompleteExpectation{gomock.Any()}
 
-	// TODO: remove this patch once we removed all the old series from tests in current package.
-	s.PatchValue(&machine.SupportedJujuSeries,
-		func(time.Time, string, string) (set.Strings, error) {
-			return set.NewStrings(
-				"centos7", "centos9", "genericlinux", "kubernetes",
-				"jammy", "focal", "bionic", "xenial",
-			), nil
-		},
-	)
 }
 
 const (
@@ -179,12 +168,12 @@ func (s *UpgradeMachineSuite) TestUpgradeCommandShouldNotAcceptInvalidMachineArg
 func (s *UpgradeMachineSuite) TestPrepareCommandShouldOnlyAcceptSupportedSeries(c *gc.C) {
 	BadSeries := "Combative Caribou"
 	err := s.runUpgradeMachineCommand(c, machineArg, machine.PrepareCommand, BadSeries)
-	c.Assert(err, gc.ErrorMatches, ".* is an unsupported series")
+	c.Assert(err, gc.ErrorMatches, "series .* not valid")
 }
 
 func (s *UpgradeMachineSuite) TestPrepareCommandShouldSupportSeriesRegardlessOfCase(c *gc.C) {
-	capitalizedCaseXenial := "Xenial"
-	err := s.runUpgradeMachineCommand(c, machineArg, machine.PrepareCommand, capitalizedCaseXenial)
+	capitalizedCaseJammy := "Jammy"
+	err := s.runUpgradeMachineCommand(c, machineArg, machine.PrepareCommand, capitalizedCaseJammy)
 	c.Assert(err, jc.ErrorIsNil)
 }
 


### PR DESCRIPTION
It turns out in cmd upgrade machine we were still using WorkloadSeries instead of WorkloadBases. Swap this over to WorkloadBases

This is the last occurence of WorkloadSeries being called (outside of WorkloadBases itself)

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

### Setup

Download ubuntu with `juju download ubuntu` and unzip into the dir `./ubuntu`

Then edit the charm manifest.yaml to be:
```
bases:
  - architectures:
      - amd64
    channel: '20.04'
    name: ubuntu
  - architectures:
      - amd64
    channel: '22.04'
    name: ubuntu
  - architectures:
      - amd64
    channel: '25.04'
    name: ubuntu
```

(i.e. add ubuntu@25.04 support to the charm, a future OS that is not yet a workload base)

### Upgrade a machine

```
$ juju deploy ./ubuntu --base ubuntu@20.04
Located local charm "ubuntu", revision 0
Deploying "ubuntu" from local charm "ubuntu", revision 0 on ubuntu@20.04/stable

$ juju status 
Model  Controller  Cloud/Region         Version      SLA          Timestamp
m2     lxd         localhost/localhost  3.6-beta1.1  unsupported  12:25:39+01:00

App     Version  Status  Scale  Charm   Channel  Rev  Exposed  Message
ubuntu  20.04    active      1  ubuntu             0  no       

Unit       Workload  Agent  Machine  Public address  Ports  Message
ubuntu/0*  active    idle   0        10.219.211.72          

Machine  State    Address        Inst id        Base          AZ  Message
0        started  10.219.211.72  juju-88afe1-0  ubuntu@20.04      Running

$ juju upgrade-machine 0 prepare ubuntu@25.04
ERROR os "ubuntu" version "25.04" not found

$ juju upgrade-machine 0 prepare ubuntu@22.04
WARNING: This command will mark machine "0" as being upgraded to "ubuntu@22.04".
This operation cannot be reverted or canceled once started.
Units running on the machine will also be upgraded. These units include:
  - ubuntu/0

Leadership for the following applications will be pinned and not
subject to change until the "complete" command is run:
  - ubuntu

Continue [y/N]? y
machine-0 validation of upgrade base from "ubuntu@20.04/stable" to "ubuntu@22.04"
machine-0 started upgrade from "ubuntu@20.04" to "ubuntu@22.04"
ubuntu/0 pre-series-upgrade hook running
ubuntu/0 pre-series-upgrade completed
machine-0 binaries and service files written

Juju is now ready for the machine base to be updated.
Perform any manual steps required along with "do-release-upgrade".
When ready, run the following to complete the upgrade base process:

juju upgrade-machine 0 complete
```