### PR TITLE
Add JUJU_AGENT_VERSION to terraform smoke tests

### DIFF
--- a/.github/workflows/terraform-smoke.yml
+++ b/.github/workflows/terraform-smoke.yml
@@ -76,6 +76,7 @@ jobs:
     - name: Set environment to configure provider for test
       run: |
         CONTROLLER=$(juju whoami --format yaml | yq .controller)
+        echo "JUJU_AGENT_VERSION=$(juju show-controller | yq .$CONTROLLER.details.agent-version |tr -d '"')" >> $GITHUB_ENV
         echo "JUJU_CONTROLLER_ADDRESSES=$(juju show-controller | yq .$CONTROLLER.details.api-endpoints | yq -r '. | join(",")')" >> $GITHUB_ENV
         echo "JUJU_USERNAME=$(juju show-controller | yq .$CONTROLLER.account.user)"  >> $GITHUB_ENV
         echo "JUJU_PASSWORD=$(cat ~/.local/share/juju/accounts.yaml | yq .controllers.$CONTROLLER.password)"  >> $GITHUB_ENV


### PR DESCRIPTION
<!-- Why this change is needed and what it does. -->
Terraform tests require a new variable to indicate the version of juju that they are operating with. This is added to the actions yaml.
## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc

## QA steps

CI passes

