### PR TITLE
Drop series parsing from supported-bases code

### DIFF
--- a/apiserver/facades/client/machinemanager/machinemanager_test.go
+++ b/apiserver/facades/client/machinemanager/machinemanager_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/juju/juju/apiserver/facades/client/machinemanager"
 	"github.com/juju/juju/apiserver/facades/client/machinemanager/mocks"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
-	"github.com/juju/juju/core/base"
 	corebase "github.com/juju/juju/core/base"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/model"
@@ -1461,7 +1460,7 @@ type IsBaseLessThanMachineManagerSuite struct{}
 // but complex enough to warrant being exported from an export test package for
 // testing.
 func (s *IsBaseLessThanMachineManagerSuite) TestIsBaseLessThan(c *gc.C) {
-	workloadVersions, err := corebase.AllWorkloadVersions(base.Base{}, "")
+	workloadVersions, err := corebase.AllWorkloadVersions()
 	c.Assert(err, jc.ErrorIsNil)
 	vers := workloadVersions.Values()
 	s.assertSeriesLessThan(c, "ubuntu", vers)

--- a/apiserver/facades/client/machinemanager/machinemanager_test.go
+++ b/apiserver/facades/client/machinemanager/machinemanager_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/juju/juju/apiserver/facades/client/machinemanager"
 	"github.com/juju/juju/apiserver/facades/client/machinemanager/mocks"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/core/base"
 	corebase "github.com/juju/juju/core/base"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/model"
@@ -1460,7 +1461,7 @@ type IsBaseLessThanMachineManagerSuite struct{}
 // but complex enough to warrant being exported from an export test package for
 // testing.
 func (s *IsBaseLessThanMachineManagerSuite) TestIsBaseLessThan(c *gc.C) {
-	workloadVersions, err := corebase.AllWorkloadVersions("", "")
+	workloadVersions, err := corebase.AllWorkloadVersions(base.Base{}, "")
 	c.Assert(err, jc.ErrorIsNil)
 	vers := workloadVersions.Values()
 	s.assertSeriesLessThan(c, "ubuntu", vers)

--- a/core/base/supportedbases.go
+++ b/core/base/supportedbases.go
@@ -4,63 +4,75 @@
 package base
 
 import (
-	"sort"
 	"time"
 
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
+	"github.com/juju/os/v2/series"
 )
+
+// UbuntuDistroInfo is the path for the Ubuntu distro info file.
+var UbuntuDistroInfo = series.UbuntuDistroInfo
 
 // ControllerBases returns the supported workload bases available to it at the
 // execution time.
 func ControllerBases(now time.Time, requestedBase Base, imageStream string) ([]Base, error) {
-	return seriesToBase(requestedBase, func(requestedSeries string) (set.Strings, error) {
-		// The DistroInfo is currently in series, so we need to convert it to
-		// base to get the correct series.
-		return ControllerSeries(now, requestedSeries, imageStream)
-	})
+	supported, err := supportedInfoForType(UbuntuDistroInfo, now, requestedBase, imageStream)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return supported.controllerBases(), nil
 }
 
 // WorkloadBases returns the supported workload bases available to it at the
 // execution time.
 func WorkloadBases(now time.Time, requestedBase Base, imageStream string) ([]Base, error) {
-	return seriesToBase(requestedBase, func(requestedSeries string) (set.Strings, error) {
-		// The DistroInfo is currently in series, so we need to convert it to
-		// base to get the correct series.
-		return WorkloadSeries(now, requestedSeries, imageStream)
-	})
-}
-
-func seriesToBase(requestedBase Base, fn func(string) (set.Strings, error)) ([]Base, error) {
-	var requestedSeries string
-	if !requestedBase.Empty() {
-		var err error
-		requestedSeries, err = GetSeriesFromBase(requestedBase)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-	}
-
-	series, err := fn(requestedSeries)
+	supported, err := supportedInfoForType(UbuntuDistroInfo, now, requestedBase, imageStream)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	return supported.workloadBases(false), nil
+}
 
-	bases := map[Base]struct{}{}
-	for _, s := range series.Values() {
-		b, err := GetBaseFromSeries(s)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		bases[b] = struct{}{}
+// AllWorkloadVersions returns all the workload versions (supported or not).
+func AllWorkloadVersions(requestedBase Base, imageStream string) (set.Strings, error) {
+	supported, err := supportedInfoForType(UbuntuDistroInfo, time.Now(), requestedBase, imageStream)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return set.NewStrings(supported.workloadVersions(true)...), nil
+}
+
+// AllWorkloadOSTypes returns all the workload os types (supported or not).
+func AllWorkloadOSTypes(requestedBase Base, imageStream string) (set.Strings, error) {
+	supported, err := supportedInfoForType(UbuntuDistroInfo, time.Now(), requestedBase, imageStream)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	result := set.NewStrings()
+	for _, wBase := range supported.workloadBases(true) {
+		result.Add(wBase.OS)
+	}
+	return result, nil
+}
+
+func supportedInfoForType(path string, now time.Time, requestedBase Base, imageStream string) (*supportedInfo, error) {
+	// For non-LTS releases; they'll appear in juju/os as default available, but
+	// after reading the `/usr/share/distro-info/ubuntu.csv` on the Ubuntu distro
+	// the non-LTS should disappear if they're not in the release window for that
+	// series.
+	seriesVersionsMutex.Lock()
+	defer seriesVersionsMutex.Unlock()
+	updateSeriesVersionsOnce()
+	all := getAllSeriesVersions()
+	if !requestedBase.Empty() && imageStream == Daily {
+		setSupported(all, requestedBase)
+	}
+	source := series.NewDistroInfo(path)
+	supported := newSupportedInfo(source, all)
+	if err := supported.compile(now); err != nil {
+		return nil, errors.Trace(err)
 	}
 
-	results := make([]Base, 0, len(bases))
-	for b := range bases {
-		results = append(results, b)
-	}
-	sort.Slice(results, func(i, j int) bool {
-		return results[i].String() < results[j].String()
-	})
-	return results, nil
+	return supported, nil
 }

--- a/core/base/supportedbases.go
+++ b/core/base/supportedbases.go
@@ -35,8 +35,8 @@ func WorkloadBases(now time.Time, requestedBase Base, imageStream string) ([]Bas
 }
 
 // AllWorkloadVersions returns all the workload versions (supported or not).
-func AllWorkloadVersions(requestedBase Base, imageStream string) (set.Strings, error) {
-	supported, err := supportedInfoForType(UbuntuDistroInfo, time.Now(), requestedBase, imageStream)
+func AllWorkloadVersions() (set.Strings, error) {
+	supported, err := supportedInfoForType(UbuntuDistroInfo, time.Now(), Base{}, "")
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -44,8 +44,8 @@ func AllWorkloadVersions(requestedBase Base, imageStream string) (set.Strings, e
 }
 
 // AllWorkloadOSTypes returns all the workload os types (supported or not).
-func AllWorkloadOSTypes(requestedBase Base, imageStream string) (set.Strings, error) {
-	supported, err := supportedInfoForType(UbuntuDistroInfo, time.Now(), requestedBase, imageStream)
+func AllWorkloadOSTypes() (set.Strings, error) {
+	supported, err := supportedInfoForType(UbuntuDistroInfo, time.Now(), Base{}, "")
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/core/base/supportedbases_test.go
+++ b/core/base/supportedbases_test.go
@@ -50,11 +50,6 @@ func (s *BasesSuite) TestWorkloadBases(c *gc.C) {
 			MustParseBaseFromString("ubuntu@22.04/stable"),
 			MustParseBaseFromString("ubuntu@24.04/stable"),
 		},
-	}, {
-		name:          "invalid base",
-		requestedBase: MustParseBaseFromString("foo@bar"),
-		imageStream:   Daily,
-		err:           `os "foo" version "bar" not found`,
 	}}
 	for _, test := range tests {
 		c.Logf("test %q", test.name)

--- a/core/base/supportedseries.go
+++ b/core/base/supportedseries.go
@@ -25,75 +25,9 @@ const (
 	Daily = "daily"
 )
 
-// UbuntuDistroInfo is the path for the Ubuntu distro info file.
-var UbuntuDistroInfo = series.UbuntuDistroInfo
-
 // SupportedSeriesFunc describes a function that has commonality between
 // controller and workload types.
 type SupportedSeriesFunc = func(time.Time, string, string) (set.Strings, error)
-
-// ControllerSeries returns all the controller series available to it at the
-// execution time.
-func ControllerSeries(now time.Time, requestedSeries, imageStream string) (set.Strings, error) {
-	supported, err := seriesForTypes(UbuntuDistroInfo, now, requestedSeries, imageStream)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return set.NewStrings(supported.controllerSeries()...), nil
-}
-
-// WorkloadSeries returns the supported workload series available to it at the
-// execution time.
-func WorkloadSeries(now time.Time, requestedSeries, imageStream string) (set.Strings, error) {
-	supported, err := seriesForTypes(UbuntuDistroInfo, now, requestedSeries, imageStream)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return set.NewStrings(supported.workloadSeries(false)...), nil
-}
-
-// AllWorkloadVersions returns all the workload versions (supported or not).
-func AllWorkloadVersions(requestedSeries, imageStream string) (set.Strings, error) {
-	supported, err := seriesForTypes(UbuntuDistroInfo, time.Now(), requestedSeries, imageStream)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return set.NewStrings(supported.workloadVersions(true)...), nil
-}
-
-// AllWorkloadOSTypes returns all the workload os types (supported or not).
-func AllWorkloadOSTypes(requestedSeries, imageStream string) (set.Strings, error) {
-	supported, err := seriesForTypes(UbuntuDistroInfo, time.Now(), requestedSeries, imageStream)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	result := set.NewStrings()
-	for _, wSeries := range supported.workloadSeries(true) {
-		result.Add(DefaultOSTypeNameFromSeries(wSeries))
-	}
-	return result, nil
-}
-
-func seriesForTypes(path string, now time.Time, requestedSeries, imageStream string) (*supportedInfo, error) {
-	// For non-LTS releases; they'll appear in juju/os as default available, but
-	// after reading the `/usr/share/distro-info/ubuntu.csv` on the Ubuntu distro
-	// the non-LTS should disappear if they're not in the release window for that
-	// series.
-	seriesVersionsMutex.Lock()
-	defer seriesVersionsMutex.Unlock()
-	updateSeriesVersionsOnce()
-	all := getAllSeriesVersions()
-	if requestedSeries != "" && imageStream == Daily {
-		setSupported(all, requestedSeries)
-	}
-	source := series.NewDistroInfo(path)
-	supported := newSupportedInfo(source, all)
-	if err := supported.compile(now); err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	return supported, nil
-}
 
 func getAllSeriesVersions() map[SeriesName]seriesVersion {
 	copy := make(map[SeriesName]seriesVersion, len(allSeriesVersions))
@@ -135,6 +69,7 @@ func DefaultOSTypeNameFromSeries(series string) string {
 
 const (
 	genericLinuxSeries  = "genericlinux"
+	genericLinuxOS      = "genericlinux"
 	genericLinuxVersion = "genericlinux"
 )
 
@@ -156,6 +91,7 @@ func updateSeriesVersions() error {
 			}
 			ubuntuSeries[key] = seriesVersion{
 				WorkloadType:             ControllerWorkloadType,
+				OS:                       UbuntuOS,
 				Version:                  s.Version,
 				LTS:                      s.LTS,
 				Supported:                s.Supported,
@@ -183,6 +119,7 @@ func composeSeriesVersions() {
 	}
 	allSeriesVersions[genericLinuxSeries] = seriesVersion{
 		WorkloadType: OtherWorkloadType,
+		OS:           genericLinuxOS,
 		Version:      genericLinuxVersion,
 		Supported:    true,
 	}

--- a/core/base/supportedseries_linux_test.go
+++ b/core/base/supportedseries_linux_test.go
@@ -6,6 +6,7 @@ package base
 import (
 	"time"
 
+	"github.com/juju/collections/transform"
 	jujuos "github.com/juju/os/v2"
 	jujuseries "github.com/juju/os/v2/series"
 	"github.com/juju/testing"
@@ -28,15 +29,16 @@ func (s *SupportedSeriesLinuxSuite) SetUpTest(c *gc.C) {
 	})
 }
 
-func (s *SupportedSeriesLinuxSuite) TestWorkloadSeries(c *gc.C) {
+func (s *SupportedSeriesLinuxSuite) TestWorkloadBases(c *gc.C) {
 	tmpFile, close := makeTempFile(c, distroInfoContents)
 	defer close()
 
 	s.PatchValue(&UbuntuDistroInfo, tmpFile.Name())
 
-	series, err := WorkloadSeries(time.Time{}, "", "")
+	bases, err := WorkloadBases(time.Time{}, Base{}, "")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(series.SortedValues(), gc.DeepEquals, []string{
-		"centos7", "centos9", "focal", "genericlinux", "jammy", "kubernetes", "noble",
-	})
+	c.Assert(bases, gc.DeepEquals, transform.Slice([]string{
+		"centos@7", "centos@9", "genericlinux@genericlinux", "kubernetes@kubernetes",
+		"ubuntu@20.04", "ubuntu@22.04", "ubuntu@24.04",
+	}, MustParseBaseFromString))
 }

--- a/environs/imagedownloads/simplestreams.go
+++ b/environs/imagedownloads/simplestreams.go
@@ -112,7 +112,7 @@ func Fetch(
 	return md, resolveInfo, nil
 }
 
-func validateArgs(arch, release, stream, ftype string) error {
+func validateArgs(arch, release, ftype string) error {
 	bad := map[string]string{}
 
 	if !validArches[arch] {
@@ -120,7 +120,7 @@ func validateArgs(arch, release, stream, ftype string) error {
 	}
 
 	validVersion := false
-	workloadVersions, err := corebase.AllWorkloadVersions(corebase.Base{}, stream)
+	workloadVersions, err := corebase.AllWorkloadVersions()
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -159,7 +159,7 @@ func validateArgs(arch, release, stream, ftype string) error {
 //
 // src exists to pass in a data source for testing.
 func One(fetcher imagemetadata.SimplestreamsFetcher, arch, release, stream, ftype string, src func() simplestreams.DataSource) (*Metadata, error) {
-	if err := validateArgs(arch, release, stream, ftype); err != nil {
+	if err := validateArgs(arch, release, ftype); err != nil {
 		return nil, errors.Trace(err)
 	}
 	if src == nil {

--- a/environs/imagedownloads/simplestreams.go
+++ b/environs/imagedownloads/simplestreams.go
@@ -120,7 +120,7 @@ func validateArgs(arch, release, stream, ftype string) error {
 	}
 
 	validVersion := false
-	workloadVersions, err := corebase.AllWorkloadVersions(release, stream)
+	workloadVersions, err := corebase.AllWorkloadVersions(corebase.Base{}, stream)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/environs/imagemetadata/simplestreams.go
+++ b/environs/imagemetadata/simplestreams.go
@@ -139,7 +139,7 @@ type ImageConstraint struct {
 
 func NewImageConstraint(params simplestreams.LookupParams) (*ImageConstraint, error) {
 	if len(params.Releases) == 0 {
-		workloadVersions, err := corebase.AllWorkloadVersions("", params.Stream)
+		workloadVersions, err := corebase.AllWorkloadVersions(corebase.Base{}, params.Stream)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/environs/imagemetadata/simplestreams.go
+++ b/environs/imagemetadata/simplestreams.go
@@ -139,7 +139,7 @@ type ImageConstraint struct {
 
 func NewImageConstraint(params simplestreams.LookupParams) (*ImageConstraint, error) {
 	if len(params.Releases) == 0 {
-		workloadVersions, err := corebase.AllWorkloadVersions(corebase.Base{}, params.Stream)
+		workloadVersions, err := corebase.AllWorkloadVersions()
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/environs/tools/tools.go
+++ b/environs/tools/tools.go
@@ -52,7 +52,7 @@ func makeToolsConstraint(cloudSpec simplestreams.CloudSpec, stream string, major
 	if filter.OSType != "" {
 		osToSearch = []string{filter.OSType}
 	} else {
-		workloadOSTypes, err := corebase.AllWorkloadOSTypes("", stream)
+		workloadOSTypes, err := corebase.AllWorkloadOSTypes(corebase.Base{}, stream)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/environs/tools/tools.go
+++ b/environs/tools/tools.go
@@ -52,7 +52,7 @@ func makeToolsConstraint(cloudSpec simplestreams.CloudSpec, stream string, major
 	if filter.OSType != "" {
 		osToSearch = []string{filter.OSType}
 	} else {
-		workloadOSTypes, err := corebase.AllWorkloadOSTypes(corebase.Base{}, stream)
+		workloadOSTypes, err := corebase.AllWorkloadOSTypes()
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -3154,7 +3154,7 @@ func (s *localServerSuite) ensureAMDImages(c *gc.C) environs.Environ {
 		Number: jujuversion.Current,
 		Arch:   arch.AMD64,
 	}
-	workloadOSList, err := corebase.AllWorkloadOSTypes(corebase.Base{}, "")
+	workloadOSList, err := corebase.AllWorkloadOSTypes()
 	c.Assert(err, jc.ErrorIsNil)
 	for _, workloadOS := range workloadOSList.Values() {
 		amd64Version.Release = workloadOS

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -3154,7 +3154,7 @@ func (s *localServerSuite) ensureAMDImages(c *gc.C) environs.Environ {
 		Number: jujuversion.Current,
 		Arch:   arch.AMD64,
 	}
-	workloadOSList, err := corebase.AllWorkloadOSTypes("", "")
+	workloadOSList, err := corebase.AllWorkloadOSTypes(corebase.Base{}, "")
 	c.Assert(err, jc.ErrorIsNil)
 	for _, workloadOS := range workloadOSList.Values() {
 		amd64Version.Release = workloadOS


### PR DESCRIPTION
Drop series parsing from supported-bases code

Originally, ControllerBases and WorkloadBases were shims around
ControllerSeries and WorkloadBases

De-couple these functions from eachother

We still read distro-info, which will remain the case until after Madrid
where a final decision for direction can be made.

As such, we still read the codename, and do use this in a few places.
However, we treat the codenames as opaque strings, and never parse them
as OS systems. This is as close as we can get before Madrid

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

### Setup

Download ubuntu with `juju download ubuntu` and unzip into the dir `./ubuntu`

Then edit the charm manifest.yaml to be:
```
bases:
  - architectures:
      - amd64
    channel: '20.04'
    name: ubuntu
  - architectures:
      - amd64
    channel: '22.04'
    name: ubuntu
  - architectures:
      - amd64
    channel: '25.04'
    name: ubuntu
```

(i.e. add ubuntu@25.04 support to the charm, a future OS that is not yet a workload base)

### Bootstrap controllers to various bases

```
$ juju bootstrap lxd err --bootstrap-base ubuntu@18.04
Creating Juju controller "err" on lxd/localhost
ERROR failed to bootstrap model: use --force to override: ubuntu@18.04/stable not supported

$ juju bootstrap lxd err --bootstrap-base ubuntu@23.04
Creating Juju controller "err" on lxd/localhost
ERROR failed to bootstrap model: use --force to override: ubuntu@23.04/stable not supported

$ juju bootstrap lxd err --bootstrap-base ubuntu@26.04
Creating Juju controller "err" on lxd/localhost
ERROR failed to bootstrap model: base "ubuntu@26.04/stable" not valid
```

```
$ juju bootstrap lxd jammy --bootstrap-base ubuntu@22.04
Creating Juju controller "jammy" on lxd/localhost
Looking for packaged Juju agent version 3.6-beta1 for amd64
No packaged binary found, preparing local Juju agent binary
To configure your system to better support LXD containers, please see: https://documentation.ubuntu.com/lxd/en/latest/explanation/performance_tuning/
Launching controller instance(s) on localhost/localhost...
 - juju-c70ac7-0 (arch=amd64)          
Installing Juju agent on bootstrap instance
Waiting for address
Attempting to connect to 10.219.211.9:22
Connected to 10.219.211.9
Running machine configuration script...
Bootstrap agent now started
Contacting Juju controller at 10.219.211.9 to verify accessibility...

Bootstrap complete, controller "jammy" is now available
Controller machines are in the "controller" model

Now you can run
	juju add-model <model-name>
to create a new model to deploy workloads.

$ juju status -m controller
Model       Controller  Cloud/Region         Version      SLA          Timestamp
controller  jammy       localhost/localhost  3.6-beta1.1  unsupported  18:04:42+01:00

App         Version  Status  Scale  Charm            Channel     Rev  Exposed  Message
controller           active      1  juju-controller  3.6/stable   83  no       

Unit           Workload  Agent  Machine  Public address  Ports  Message
controller/0*  active    idle   0        10.219.211.9           

Machine  State    Address       Inst id        Base          AZ  Message
0        started  10.219.211.9  juju-c70ac7-0  ubuntu@22.04      Running
```

```
$ juju bootstrap lxd focal --bootstrap-base ubuntu@20.04
Creating Juju controller "focal" on lxd/localhost
Looking for packaged Juju agent version 3.6-beta1 for amd64
No packaged binary found, preparing local Juju agent binary
To configure your system to better support LXD containers, please see: https://documentation.ubuntu.com/lxd/en/latest/explanation/performance_tuning/
Launching controller instance(s) on localhost/localhost...
 - juju-e97da4-0 (arch=amd64)          
Installing Juju agent on bootstrap instance
Waiting for address
Attempting to connect to 10.219.211.217:22
Connected to 10.219.211.217
Running machine configuration script...
Bootstrap agent now started
Contacting Juju controller at 10.219.211.217 to verify accessibility...

Bootstrap complete, controller "focal" is now available
Controller machines are in the "controller" model

Now you can run
	juju add-model <model-name>
to create a new model to deploy workloads.

$ juju status -m controller
Model       Controller  Cloud/Region         Version      SLA          Timestamp
controller  focal       localhost/localhost  3.6-beta1.1  unsupported  18:05:34+01:00

App         Version  Status  Scale  Charm            Channel     Rev  Exposed  Message
controller           active      1  juju-controller  3.6/stable   83  no       

Unit           Workload  Agent  Machine  Public address  Ports  Message
controller/0*  active    idle   0        10.219.211.217         

Machine  State    Address         Inst id        Base          AZ  Message
0        started  10.219.211.217  juju-e97da4-0  ubuntu@20.04      Running
```

### Deploy machines to various bases

```
$ juju add-machine
$ juju add-machine --base ubuntu@22.04
$ juju add-machine --base ubuntu@20.04
$ juju add-machine --base ubuntu@21.04
$ juju status
Model  Controller  Cloud/Region         Version      SLA          Timestamp
m      jammy       localhost/localhost  3.6-beta1.1  unsupported  18:07:35+01:00

Machine  State    Address         Inst id        Base          AZ  Message
0        started  10.219.211.195  juju-8f4c57-0  ubuntu@22.04      Running
1        started  10.219.211.215  juju-8f4c57-1  ubuntu@22.04      Running
2        started  10.219.211.194  juju-8f4c57-2  ubuntu@20.04      Running
3        started  10.219.211.85   juju-8f4c57-3  ubuntu@21.04      Running
```

### Upgrade a machine

```
$ juju deploy ./ubuntu --base ubuntu@20.04
Located local charm "ubuntu", revision 0
Deploying "ubuntu" from local charm "ubuntu", revision 0 on ubuntu@20.04/stable

$ juju status 
Model  Controller  Cloud/Region         Version      SLA          Timestamp
m2     lxd         localhost/localhost  3.6-beta1.1  unsupported  12:25:39+01:00

App     Version  Status  Scale  Charm   Channel  Rev  Exposed  Message
ubuntu  20.04    active      1  ubuntu             0  no       

Unit       Workload  Agent  Machine  Public address  Ports  Message
ubuntu/0*  active    idle   0        10.219.211.72          

Machine  State    Address        Inst id        Base          AZ  Message
0        started  10.219.211.72  juju-88afe1-0  ubuntu@20.04      Running

$ juju upgrade-machine 0 prepare ubuntu@25.04
ERROR os "ubuntu" version "25.04" not found

$ juju upgrade-machine 0 prepare ubuntu@22.04
WARNING: This command will mark machine "0" as being upgraded to "ubuntu@22.04".
This operation cannot be reverted or canceled once started.
Units running on the machine will also be upgraded. These units include:
  - ubuntu/0

Leadership for the following applications will be pinned and not
subject to change until the "complete" command is run:
  - ubuntu

Continue [y/N]? y
machine-0 validation of upgrade base from "ubuntu@20.04/stable" to "ubuntu@22.04"
machine-0 started upgrade from "ubuntu@20.04" to "ubuntu@22.04"
ubuntu/0 pre-series-upgrade hook running
ubuntu/0 pre-series-upgrade completed
machine-0 binaries and service files written

Juju is now ready for the machine base to be updated.
Perform any manual steps required along with "do-release-upgrade".
When ready, run the following to complete the upgrade base process:

juju upgrade-machine 0 complete
```