### PR TITLE
[JUJU-5922] Drop support for parsing platforms which include series

### DIFF
--- a/core/charm/origin_test.go
+++ b/core/charm/origin_test.go
@@ -50,11 +50,11 @@ func (s platformSuite) TestParsePlatform(c *gc.C) {
 	}, {
 		Name:        "too many components",
 		Value:       "////",
-		ExpectedErr: `platform is malformed and has too many components "////"`,
+		ExpectedErr: `platform is malformed; it has an invalid number of components "////"`,
 	}, {
 		Name:        "architecture and channel, no os name",
 		Value:       "amd64/18.04",
-		ExpectedErr: `channel without os name in platform "amd64/18.04" not valid`,
+		ExpectedErr: `platform is malformed; it has an invalid number of components "amd64/18.04"`,
 	}, {
 		Name:  "architecture",
 		Value: "amd64",
@@ -93,23 +93,15 @@ func (s platformSuite) TestParsePlatform(c *gc.C) {
 			OS:           "",
 			Channel:      "",
 		},
-	}, {
-		Name:  "architecture and unknown series",
-		Value: "amd64/unknown",
-		Expected: charm.Platform{
-			Architecture: "amd64",
-			OS:           "",
-			Channel:      "",
-		},
 	}}
 	for k, test := range tests {
 		c.Logf("test %q at %d", test.Name, k)
 		ch, err := charm.ParsePlatformNormalize(test.Value)
 		if test.ExpectedErr != "" {
-			c.Assert(err, gc.ErrorMatches, test.ExpectedErr)
+			c.Check(err, gc.ErrorMatches, test.ExpectedErr)
 		} else {
-			c.Assert(ch, gc.DeepEquals, test.Expected)
-			c.Assert(err, gc.IsNil)
+			c.Check(ch, gc.DeepEquals, test.Expected)
+			c.Check(err, gc.IsNil)
 		}
 	}
 }
@@ -124,9 +116,9 @@ func (s platformSuite) TestString(c *gc.C) {
 		Value:    "amd64",
 		Expected: "amd64",
 	}, {
-		Name:     "architecture, os and series",
-		Value:    "amd64/os/series",
-		Expected: "amd64/os/series",
+		Name:     "architecture, os and version",
+		Value:    "amd64/os/version",
+		Expected: "amd64/os/version",
 	}, {
 		Name:     "architecture, os, version and risk",
 		Value:    "amd64/os/version/risk",

--- a/internal/charm/repository/charmhub_test.go
+++ b/internal/charm/repository/charmhub_test.go
@@ -971,7 +971,8 @@ var _ = gc.Suite(&refreshConfigSuite{})
 
 func (refreshConfigSuite) TestRefreshByChannel(c *gc.C) {
 	name := "wordpress"
-	platform := corecharm.MustParsePlatform("amd64/ubuntu/focal")
+	// 'mistakenly' include a risk in the platform
+	platform := corecharm.MustParsePlatform("amd64/ubuntu/20.04/stable")
 	channel := corecharm.MustParseChannel("latest/stable").Normalize()
 	origin := corecharm.Origin{
 		Platform: platform,
@@ -1005,8 +1006,7 @@ func (refreshConfigSuite) TestRefreshByChannel(c *gc.C) {
 
 func (refreshConfigSuite) TestRefreshByChannelVersion(c *gc.C) {
 	name := "wordpress"
-	// 'mistakenly' include a risk in the platform
-	platform := corecharm.MustParsePlatform("amd64/ubuntu/20.10/stable")
+	platform := corecharm.MustParsePlatform("amd64/ubuntu/20.10")
 	channel := corecharm.MustParseChannel("latest/stable").Normalize()
 	origin := corecharm.Origin{
 		Platform: platform,
@@ -1041,7 +1041,7 @@ func (refreshConfigSuite) TestRefreshByChannelVersion(c *gc.C) {
 func (refreshConfigSuite) TestRefreshByRevision(c *gc.C) {
 	revision := 1
 	name := "wordpress"
-	platform := corecharm.MustParsePlatform("amd64/ubuntu/focal")
+	platform := corecharm.MustParsePlatform("amd64/ubuntu/20.04")
 	origin := corecharm.Origin{
 		Platform: platform,
 		Revision: &revision,
@@ -1069,7 +1069,7 @@ func (refreshConfigSuite) TestRefreshByRevision(c *gc.C) {
 func (refreshConfigSuite) TestRefreshByID(c *gc.C) {
 	id := "aaabbbccc"
 	revision := 1
-	platform := corecharm.MustParsePlatform("amd64/ubuntu/focal")
+	platform := corecharm.MustParsePlatform("amd64/ubuntu/20.04")
 	channel := corecharm.MustParseChannel("stable")
 	origin := corecharm.Origin{
 		Type:        transport.CharmType.String(),
@@ -1162,31 +1162,6 @@ func (*selectNextBaseSuite) TestSelectNextBaseWithInvalidOS(c *gc.C) {
 func (*selectNextBaseSuite) TestSelectNextBaseWithValidBases(c *gc.C) {
 	repo := new(CharmHubRepository)
 	platform, err := repo.selectNextBases([]transport.Base{{
-		Architecture: "amd64",
-		Name:         "ubuntu",
-		Channel:      "20.04",
-	}}, corecharm.Origin{
-		Platform: corecharm.Platform{
-			Architecture: "amd64",
-			OS:           "ubuntu",
-			Channel:      "20.04",
-		},
-	})
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(platform, gc.DeepEquals, []corecharm.Platform{{
-		Architecture: "amd64",
-		OS:           "ubuntu",
-		Channel:      "20.04",
-	}})
-}
-
-func (*selectNextBaseSuite) TestSelectNextBaseWithValidBasesWithSeries(c *gc.C) {
-	repo := new(CharmHubRepository)
-	platform, err := repo.selectNextBases([]transport.Base{{
-		Architecture: "amd64",
-		Name:         "ubuntu",
-		Channel:      "focal",
-	}, {
 		Architecture: "amd64",
 		Name:         "ubuntu",
 		Channel:      "20.04",


### PR DESCRIPTION
We are working to drop for support from the Juju codebase. One place it appears during ParsePlatform.

However, we do not make use of this functionality anywhere, so removing it is fairly simple.

At the same time, we can drop support for supplying "unknown" channel.

NOTE: This change has to target 4.0, since 3.x still needs to support series in platforms for migrations from 2.9
However, since 3.0 exported models are exported without series in platforms, so we do not need to worry in 4.0

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

### Bootstrap and deploy some things

```
$ juju bootstrap lxd lxd-4.0
$ juju add-model m
$ juju deploy ubuntu
$ juju deploy postgresql --channel latest --base ubuntu@20.04
(wait)
$ juju status
Model  Controller  Cloud/Region         Version      Timestamp
m      lxd-4.0     localhost/localhost  4.0-beta3.1  12:19:58+01:00

App         Version  Status  Scale  Charm       Channel        Rev  Exposed  Message
postgresql  12.18    active      1  postgresql  latest/stable  345  no       Live master (12.18)
ubuntu      22.04    active      1  ubuntu      latest/stable   24  no       

Unit           Workload  Agent  Machine  Public address  Ports     Message
postgresql/0*  active    idle   1        10.219.211.13   5432/tcp  Live master (12.18)
ubuntu/0*      active    idle   0        10.219.211.50             

Machine  State    Address        Inst id        Base          AZ  Message
0        started  10.219.211.50  juju-bcba9d-0  ubuntu@22.04      Running
1        started  10.219.211.13  juju-bcba9d-1  ubuntu@20.04      Running
```

### Export bundle

```
$ juju export-bundle
default-base: ubuntu@22.04/stable
applications:
  postgresql:
    charm: postgresql
    channel: latest/stable
    revision: 345
    base: ubuntu@20.04/stable
    resources:
      wal-e: 0
    num_units: 1
    to:
    - "1"
    constraints: arch=amd64
    storage:
      pgdata: rootfs,5M
  ubuntu:
    charm: ubuntu
    channel: latest/stable
    revision: 24
    num_units: 1
    to:
    - "0"
    constraints: arch=amd64
    storage:
      block: loop,100M
      files: rootfs,100M
machines:
  "0":
    constraints: arch=amd64
  "1":
    constraints: arch=amd64
    base: ubuntu@20.04/stable
```

### Model migration

`juju-3.5` denotes juju build from the 3.5 branch

```
$ juju-3.5 bootstrap lxd lxd-3.5
$ juju-3.6 add-model m2
$ juju-3.6 deploy ubuntu
(wait)
$ juju-3.5 status
Model  Controller  Cloud/Region         Version      Timestamp
m2     lxd-3.5     localhost/localhost  3.5.0  12:27:21+01:00

App     Version  Status  Scale  Charm   Channel        Rev  Exposed  Message
ubuntu  22.04    active      1  ubuntu  latest/stable   24  no       

Unit       Workload  Agent  Machine  Public address  Ports  Message
ubuntu/0*  active    idle   0        10.219.211.156         

Machine  State    Address         Inst id        Base          AZ  Message
0        started  10.219.211.156  juju-b80815-0  ubuntu@22.04      Running

$ juju-3.5 migrate m2 lxd-4.0
Migration started with ID "6bef867e-6d25-4e2c-8d60-0eeffdb80815:0"
(wait)
$ juju-3.5 status
ERROR Model "admin/m2" has been migrated to controller "lxd-4.0".
To access it run 'juju switch lxd-4.0:admin/m2'.

$ juju switch lxd-4.0:m2
$ juju upgrade-model
$ juju status
Model  Controller  Cloud/Region         Version      Timestamp
m2     lxd-4.0     localhost/localhost  4.0-beta3.1  12:34:40+01:00

App     Version  Status  Scale  Charm   Channel        Rev  Exposed  Message
ubuntu  22.04    active      1  ubuntu  latest/stable   24  no       

Unit       Workload  Agent  Machine  Public address  Ports  Message
ubuntu/0*  active    idle   0        10.219.211.156         

Machine  State    Address         Inst id        Base          AZ  Message
0        started  10.219.211.156  juju-b80815-0  ubuntu@22.04      Running
```

## Links

Jira card: https://warthogs.atlassian.net/browse/JUJU-5922