### PR TITLE
Remove default-series from test

### DIFF
--- a/provider/common/bootstrap_test.go
+++ b/provider/common/bootstrap_test.go
@@ -84,7 +84,6 @@ func minimalConfig(c *gc.C) *config.Config {
 }
 
 func minimalConfigWithBase(c *gc.C, base corebase.Base) *config.Config {
-	series, _ := corebase.GetSeriesFromBase(base)
 	attrs := map[string]interface{}{
 		"name":               "whatever",
 		"type":               "anything, really",
@@ -93,7 +92,6 @@ func minimalConfigWithBase(c *gc.C, base corebase.Base) *config.Config {
 		"ca-cert":            coretesting.CACert,
 		"ca-private-key":     coretesting.CAKey,
 		"authorized-keys":    coretesting.FakeAuthKeys,
-		"default-series":     series,
 		"default-base":       base.String(),
 		"cloudinit-userdata": validCloudInitUserData,
 	}


### PR DESCRIPTION
Remove a redundant conversion between base and series in some tests

This brings us a (small) step closer towards removing series from the codebase entirely 

## QA steps

```
go test github.com/juju/juju/provider/openstack
```

Unit tests pass