### PR TITLE
Fix returned errors on network domain state layer

### DIFF
--- a/domain/network/service/space.go
+++ b/domain/network/service/space.go
@@ -267,7 +267,10 @@ func (s *ProviderService) upsertProviderSubnets(ctx context.Context, subnetsToUp
 		}
 
 	}
-	return errors.Trace(s.st.UpsertSubnets(ctx, subnetsToUpsert))
+	if err := s.st.UpsertSubnets(ctx, subnetsToUpsert); err != nil && !errors.Is(err, errors.AlreadyExists) {
+		return errors.Trace(err)
+	}
+	return nil
 }
 
 // generateFanSubnetID generates a correct ID for a subnet of type fan overlay.

--- a/domain/network/service/subnet.go
+++ b/domain/network/service/subnet.go
@@ -22,7 +22,7 @@ func (s *Service) AddSubnet(ctx context.Context, args network.SubnetInfo) (netwo
 		args.ID = network.Id(uuid.String())
 	}
 
-	if err := s.st.AddSubnet(ctx, args); err != nil {
+	if err := s.st.AddSubnet(ctx, args); err != nil && !errors.Is(err, errors.AlreadyExists) {
 		return "", errors.Trace(err)
 	}
 

--- a/domain/network/state/subnet_test.go
+++ b/domain/network/state/subnet_test.go
@@ -272,7 +272,7 @@ func (s *stateSuite) TestFailAddTwoSubnetsSameProviderID(c *gc.C) {
 			FanInfo:           nil,
 		},
 	)
-	c.Assert(err, gc.ErrorMatches, fmt.Sprintf("inserting provider id %q for subnet %q: UNIQUE constraint failed: provider_subnet.provider_id", "provider-id", subnetUUID1.String()))
+	c.Assert(err, gc.ErrorMatches, fmt.Sprintf("provider id %q for subnet %q already exists", "provider-id", subnetUUID1.String()))
 }
 
 func (s *stateSuite) TestRetrieveFanSubnet(c *gc.C) {


### PR DESCRIPTION
This patch fixes two cases on which the wrong error was returned from the state layer on the network domain, meaning that the service layer wasn't handling those correctly.

The first one is when trying to add a subnet with the same provider-id (this happens when reloading spaces twice on a row for example). The second one is when trying to remove spaces that don't contain a provider id, this should not prevent the delete.


## Checklist


- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Bootstrap, reload spaces twice. Then add a space and remove it. There should be no errors.

```
juju bootstrap localhost c
juju add-model m
juju reload-spaces
juju reload-spaces
juju add-space foo 10.68.58.0/24
juju spaces
Name   Space ID                              Subnets
alpha  0                                     10.170.236.0/24
                                             10.215.127.0/24
                                             172.17.0.0/16
                                             172.18.0.0/16
                                             192.168.49.0/24
foo    018f1a6f-069e-700b-9904-53921fa813ea  10.68.58.0/24
juju remove-space foo
juju spaces
Name   Space ID  Subnets
alpha  0         10.170.236.0/24
                 10.215.127.0/24
                 10.68.58.0/24
                 172.17.0.0/16
                 172.18.0.0/16
                 192.168.49.0/24
```

## Links

**Jira card:** JUJU-

