### PR TITLE
Use channel in RefreshBase in charm revision updater

### DIFF
--- a/apiserver/facades/controller/charmrevisionupdater/charmhub.go
+++ b/apiserver/facades/controller/charmrevisionupdater/charmhub.go
@@ -20,13 +20,13 @@ import (
 // charmhubID holds identifying information for several charms for a
 // charmhubLatestCharmInfo call.
 type charmhubID struct {
-	id       string
-	revision int
-	channel  string
-	os       string
-	series   string
-	arch     string
-	metrics  map[metrics.MetricKey]string
+	id        string
+	revision  int
+	channel   string
+	osType    string
+	osChannel string
+	arch      string
+	metrics   map[metrics.MetricKey]string
 	// Required for charmhub only.  instanceKey is a unique string associated
 	// with the application. To assist with keeping KPI data in charmhub, it
 	// must be the same for every charmhub Refresh action related to an
@@ -59,8 +59,8 @@ func charmhubLatestCharmInfo(client CharmhubRefreshClient, metrics map[metrics.M
 	for i, id := range ids {
 		base := charmhub.RefreshBase{
 			Architecture: id.arch,
-			Name:         id.os,
-			Channel:      id.series,
+			Name:         id.osType,
+			Channel:      id.osChannel,
 		}
 		cfg, err := charmhub.RefreshOne(id.instanceKey, id.id, id.revision, id.channel, base)
 		if err != nil {

--- a/apiserver/facades/controller/charmrevisionupdater/updater.go
+++ b/apiserver/facades/controller/charmrevisionupdater/updater.go
@@ -18,7 +18,6 @@ import (
 
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/charmhub"
-	corebase "github.com/juju/juju/core/base"
 	charmmetrics "github.com/juju/juju/core/charm/metrics"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/rpc/params"
@@ -162,16 +161,12 @@ func (api *CharmRevisionUpdaterAPI) retrieveLatestCharmInfo() ([]latestCharmInfo
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
-			series, err := corebase.GetSeriesFromChannel(origin.Platform.OS, origin.Platform.Channel)
-			if err != nil {
-				return nil, errors.Trace(err)
-			}
 			cid := charmhubID{
 				id:          origin.ID,
 				revision:    *origin.Revision,
 				channel:     channel.String(),
-				os:          strings.ToLower(origin.Platform.OS), // charmhub API requires lowercase OS key
-				series:      series,
+				osType:      strings.ToLower(origin.Platform.OS), // charmhub API requires lowercase OS key
+				osChannel:   origin.Platform.Channel,
 				arch:        origin.Platform.Architecture,
 				instanceKey: charmhub.CreateInstanceKey(application.ApplicationTag(), model.ModelTag()),
 			}


### PR DESCRIPTION
RefreshBases, at the moment, are agnostic to the format of their channel. They can be channels, channels with risks, or series

In the charm revision updater for some reason we go with a series, which is parsed from a charm origin in a previous step.

Use a channel instead which, as it turns out, was already available

See here, where the channel is finally read:
https://github.com/juju/juju/blob/3.6/charmhub/refresh.go#L425-L432

You see we first check if the channel is a series, and if it is not, in the sanatiseChannel step, we parse it as a channel and extract the track

## QA steps

Ensure

#### Bootstrap

```
$ juju bootstrap lxd lxd
```

#### Enable wrench

```
$ juju ssh -m controller 0
$ cd /var/lib/juju
$ sudo mkdir wrench
$ cd wrench
$ sudo vim charmrevision
[write "shortinterval", save and exit]
$ cat charmrevision
shortinterval
$ exit
```

#### Deploy a charm from not the latest revision
```
$ juju add-model m --config logging-config="<root>=INFO;juju.worker.charmrevision=DEBUG"
$ juju debug-log
...
controller-0: 15:42:16 DEBUG juju.worker.charmrevision 10s elapsed, performing work
controller-0: 15:42:36 DEBUG juju.worker.charmrevision 10s elapsed, performing work
controller-0: 15:42:49 DEBUG juju.worker.charmrevision 10s elapsed, performing work
controller-0: 15:42:59 DEBUG juju.worker.charmrevision 10s elapsed, performing work
controller-0: 15:43:12 DEBUG juju.worker.charmrevision 10s elapsed, performing work
controller-0: 15:43:22 DEBUG juju.worker.charmrevision 10s elapsed, performing work
controller-0: 15:43:32 DEBUG juju.worker.charmrevision 10s elapsed, performing work
...

$ juju deploy ubuntu --revision 22 --channel latest/stable # <-- 24 is the latest revision
```

#### Check mongo [using this plugin](https://discourse.charmhub.io/t/login-into-mongodb/309)

```
$ juju mongo
>>> db.charms.find().pretty()
...
{
	"_id" : "110944e2-5095-4f58-83f2-211055ef7dfa:ch:amd64/ubuntu-24",
	"model-uuid" : "110944e2-5095-4f58-83f2-211055ef7dfa",
	"url" : "ch:amd64/ubuntu-24",
	"charm-version" : "",
	"life" : 0,
	"pendingupload" : false,
	"placeholder" : true,
	"bundlesha256" : "",
	"storagepath" : "",
	"meta" : null,
	"config" : null,
	"manifest" : null,
	"actions" : null,
	"metrics" : null,
	"lxd-profile" : null,
	"txn-revno" : 2
}
```

#### Check juju status

```
$ juju status
Model  Controller  Cloud/Region         Version      SLA          Timestamp
m      lxd         localhost/localhost  3.6-beta1.1  unsupported  15:48:40+01:00

App     Version  Status  Scale  Charm   Channel        Rev  Exposed  Message
ubuntu  22.04    active      1  ubuntu  latest/stable   22  no                 # <-- "22" should be orange

Unit       Workload  Agent  Machine  Public address  Ports  Message
ubuntu/0*  active    idle   0        10.219.211.38          

Machine  State    Address        Inst id        Base          AZ  Message
0        started  10.219.211.38  juju-ef7dfa-0  ubuntu@22.04      Running
