### PR TITLE
Wireup external secrets

### DIFF
--- a/api/common/secretbackends/client.go
+++ b/api/common/secretbackends/client.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/juju/api/base"
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	coresecrets "github.com/juju/juju/core/secrets"
+	secretbackenderrors "github.com/juju/juju/domain/secretbackend/errors"
 	"github.com/juju/juju/internal/secrets"
 	"github.com/juju/juju/internal/secrets/provider"
 	"github.com/juju/juju/rpc/params"
@@ -37,7 +38,7 @@ func (c *Client) GetSecretBackendConfig(backendID *string) (*provider.ModelBacke
 		args.BackendIDs = []string{*backendID}
 	}
 	err := c.facade.FacadeCall(context.TODO(), "GetSecretBackendConfigs", args, &results)
-	if err != nil && !errors.Is(err, errors.NotFound) {
+	if err != nil && !errors.Is(err, secretbackenderrors.NotFound) {
 		return nil, errors.Trace(err)
 	}
 	if err != nil || len(results.Results) == 0 {
@@ -45,7 +46,7 @@ func (c *Client) GetSecretBackendConfig(backendID *string) (*provider.ModelBacke
 		if backendID != nil {
 			msg = fmt.Sprintf("external secret backend id %q", *backendID)
 		}
-		return nil, errors.NotFoundf(msg)
+		return nil, fmt.Errorf("%s%w", msg, errors.Hide(secretbackenderrors.NotFound))
 	}
 	if len(results.Results) != 1 {
 		return nil, errors.Errorf("expected 1 result, got %d", len(results.Results))
@@ -76,7 +77,7 @@ func (c *Client) GetBackendConfigForDrain(backendID *string) (*provider.ModelBac
 		arg.BackendIDs = []string{*backendID}
 	}
 	err := c.facade.FacadeCall(context.TODO(), "GetSecretBackendConfigs", arg, &result)
-	if err != nil && !errors.Is(err, errors.NotFound) {
+	if err != nil && !errors.Is(err, secretbackenderrors.NotFound) {
 		return nil, "", errors.Trace(err)
 	}
 	if len(result.Results) == 0 {

--- a/api/common/secretbackends/client.go
+++ b/api/common/secretbackends/client.go
@@ -38,7 +38,7 @@ func (c *Client) GetSecretBackendConfig(backendID *string) (*provider.ModelBacke
 		args.BackendIDs = []string{*backendID}
 	}
 	err := c.facade.FacadeCall(context.TODO(), "GetSecretBackendConfigs", args, &results)
-	if err != nil && !errors.Is(err, secretbackenderrors.NotFound) {
+	if err != nil && !errors.Is(params.TranslateWellKnownError(err), secretbackenderrors.NotFound) {
 		return nil, errors.Trace(err)
 	}
 	if err != nil || len(results.Results) == 0 {
@@ -77,7 +77,7 @@ func (c *Client) GetBackendConfigForDrain(backendID *string) (*provider.ModelBac
 		arg.BackendIDs = []string{*backendID}
 	}
 	err := c.facade.FacadeCall(context.TODO(), "GetSecretBackendConfigs", arg, &result)
-	if err != nil && !errors.Is(err, secretbackenderrors.NotFound) {
+	if err != nil && !errors.Is(params.TranslateWellKnownError(err), secretbackenderrors.NotFound) {
 		return nil, "", errors.Trace(err)
 	}
 	if len(result.Results) == 0 {

--- a/apiserver/common/secrets/mocks/commonsecrets_mock.go
+++ b/apiserver/common/secrets/mocks/commonsecrets_mock.go
@@ -248,25 +248,24 @@ func (mr *MockSecretServiceMockRecorder) ListCharmSecrets(arg0 any, arg1 ...any)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCharmSecrets", reflect.TypeOf((*MockSecretService)(nil).ListCharmSecrets), varargs...)
 }
 
-// ListGrantedSecrets mocks base method.
-func (m *MockSecretService) ListGrantedSecrets(arg0 context.Context, arg1 ...service.SecretAccessor) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error) {
+// ListGrantedSecretsForBackend mocks base method.
+func (m *MockSecretService) ListGrantedSecretsForBackend(arg0 context.Context, arg1 string, arg2 secrets.SecretRole, arg3 ...service.SecretAccessor) ([]*secrets.SecretRevisionRef, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0}
-	for _, a := range arg1 {
+	varargs := []any{arg0, arg1, arg2}
+	for _, a := range arg3 {
 		varargs = append(varargs, a)
 	}
-	ret := m.ctrl.Call(m, "ListGrantedSecrets", varargs...)
-	ret0, _ := ret[0].([]*secrets.SecretMetadata)
-	ret1, _ := ret[1].([][]*secrets.SecretRevisionMetadata)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+	ret := m.ctrl.Call(m, "ListGrantedSecretsForBackend", varargs...)
+	ret0, _ := ret[0].([]*secrets.SecretRevisionRef)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
-// ListGrantedSecrets indicates an expected call of ListGrantedSecrets.
-func (mr *MockSecretServiceMockRecorder) ListGrantedSecrets(arg0 any, arg1 ...any) *gomock.Call {
+// ListGrantedSecretsForBackend indicates an expected call of ListGrantedSecretsForBackend.
+func (mr *MockSecretServiceMockRecorder) ListGrantedSecretsForBackend(arg0, arg1, arg2 any, arg3 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0}, arg1...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListGrantedSecrets", reflect.TypeOf((*MockSecretService)(nil).ListGrantedSecrets), varargs...)
+	varargs := append([]any{arg0, arg1, arg2}, arg3...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListGrantedSecretsForBackend", reflect.TypeOf((*MockSecretService)(nil).ListGrantedSecretsForBackend), varargs...)
 }
 
 // ListUserSecrets mocks base method.

--- a/apiserver/common/secrets/mocks/provider_mock.go
+++ b/apiserver/common/secrets/mocks/provider_mock.go
@@ -15,7 +15,6 @@ import (
 
 	secrets "github.com/juju/juju/core/secrets"
 	provider "github.com/juju/juju/internal/secrets/provider"
-	names "github.com/juju/names/v5"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -57,7 +56,7 @@ func (mr *MockSecretBackendProviderMockRecorder) CleanupModel(arg0 any) *gomock.
 }
 
 // CleanupSecrets mocks base method.
-func (m *MockSecretBackendProvider) CleanupSecrets(arg0 context.Context, arg1 *provider.ModelBackendConfig, arg2 names.Tag, arg3 provider.SecretRevisions) error {
+func (m *MockSecretBackendProvider) CleanupSecrets(arg0 context.Context, arg1 *provider.ModelBackendConfig, arg2 *secrets.URI, arg3 provider.SecretRevisions) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CleanupSecrets", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
@@ -100,7 +99,7 @@ func (mr *MockSecretBackendProviderMockRecorder) NewBackend(arg0 any) *gomock.Ca
 }
 
 // RestrictedConfig mocks base method.
-func (m *MockSecretBackendProvider) RestrictedConfig(arg0 context.Context, arg1 *provider.ModelBackendConfig, arg2, arg3 bool, arg4 names.Tag, arg5, arg6 provider.SecretRevisions) (*provider.BackendConfig, error) {
+func (m *MockSecretBackendProvider) RestrictedConfig(arg0 context.Context, arg1 *provider.ModelBackendConfig, arg2, arg3 bool, arg4 secrets.Accessor, arg5, arg6 provider.SecretRevisions) (*provider.BackendConfig, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RestrictedConfig", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 	ret0, _ := ret[0].(*provider.BackendConfig)

--- a/apiserver/common/secrets/mocks/provider_mock.go
+++ b/apiserver/common/secrets/mocks/provider_mock.go
@@ -56,7 +56,7 @@ func (mr *MockSecretBackendProviderMockRecorder) CleanupModel(arg0 any) *gomock.
 }
 
 // CleanupSecrets mocks base method.
-func (m *MockSecretBackendProvider) CleanupSecrets(arg0 context.Context, arg1 *provider.ModelBackendConfig, arg2 *secrets.URI, arg3 provider.SecretRevisions) error {
+func (m *MockSecretBackendProvider) CleanupSecrets(arg0 context.Context, arg1 *provider.ModelBackendConfig, arg2 string, arg3 provider.SecretRevisions) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CleanupSecrets", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)

--- a/apiserver/common/secrets/service.go
+++ b/apiserver/common/secrets/service.go
@@ -15,8 +15,7 @@ import (
 
 // SecretService instances provide secret service apis.
 type SecretService interface {
-	ListGrantedSecrets(ctx context.Context, consumers ...secretservice.SecretAccessor) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error)
-
+	ListGrantedSecretsForBackend(ctx context.Context, backendID string, role secrets.SecretRole, consumers ...secretservice.SecretAccessor) ([]*secrets.SecretRevisionRef, error)
 	ListCharmSecrets(context.Context, ...secretservice.CharmSecretOwner) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error)
 	ListUserSecrets(ctx context.Context) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error)
 	ChangeSecretBackend(ctx context.Context, uri *secrets.URI, revision int, params secretservice.ChangeSecretBackendParams) error

--- a/apiserver/errors/errors.go
+++ b/apiserver/errors/errors.go
@@ -106,6 +106,7 @@ func ServerErrorAndStatus(err error) (*params.Error, int) {
 		params.CodeUserNotFound,
 		params.CodeModelNotFound,
 		params.CodeSecretNotFound,
+		params.CodeSecretRevisionNotFound,
 		params.CodeSecretConsumerNotFound,
 		params.CodeSecretBackendNotFound:
 		status = http.StatusNotFound
@@ -174,6 +175,8 @@ func ServerError(err error) *params.Error {
 		code = params.CodeUserNotFound
 	case errors.Is(err, secreterrors.SecretNotFound):
 		code = params.CodeSecretNotFound
+	case errors.Is(err, secreterrors.SecretRevisionNotFound):
+		code = params.CodeSecretRevisionNotFound
 	case errors.Is(err, secreterrors.SecretConsumerNotFound):
 		code = params.CodeSecretConsumerNotFound
 	case errors.Is(err, secretbackenderrors.NotFound):

--- a/apiserver/errors/errors_test.go
+++ b/apiserver/errors/errors_test.go
@@ -55,6 +55,11 @@ var errorTransformTests = []struct {
 	status:     http.StatusNotFound,
 	helperFunc: params.IsCodeSecretNotFound,
 }, {
+	err:        secreterrors.SecretRevisionNotFound,
+	code:       params.CodeSecretRevisionNotFound,
+	status:     http.StatusNotFound,
+	helperFunc: params.IsCodeSecretRevisionNotFound,
+}, {
 	err:        secreterrors.SecretConsumerNotFound,
 	code:       params.CodeSecretConsumerNotFound,
 	status:     http.StatusNotFound,

--- a/apiserver/facades/agent/secretsmanager/mocks/secretsprovider.go
+++ b/apiserver/facades/agent/secretsmanager/mocks/secretsprovider.go
@@ -56,7 +56,7 @@ func (mr *MockSecretBackendProviderMockRecorder) CleanupModel(arg0 any) *gomock.
 }
 
 // CleanupSecrets mocks base method.
-func (m *MockSecretBackendProvider) CleanupSecrets(arg0 context.Context, arg1 *provider.ModelBackendConfig, arg2 *secrets.URI, arg3 provider.SecretRevisions) error {
+func (m *MockSecretBackendProvider) CleanupSecrets(arg0 context.Context, arg1 *provider.ModelBackendConfig, arg2 string, arg3 provider.SecretRevisions) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CleanupSecrets", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)

--- a/apiserver/facades/agent/secretsmanager/mocks/secretsprovider.go
+++ b/apiserver/facades/agent/secretsmanager/mocks/secretsprovider.go
@@ -13,8 +13,8 @@ import (
 	context "context"
 	reflect "reflect"
 
+	secrets "github.com/juju/juju/core/secrets"
 	provider "github.com/juju/juju/internal/secrets/provider"
-	names "github.com/juju/names/v5"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -56,7 +56,7 @@ func (mr *MockSecretBackendProviderMockRecorder) CleanupModel(arg0 any) *gomock.
 }
 
 // CleanupSecrets mocks base method.
-func (m *MockSecretBackendProvider) CleanupSecrets(arg0 context.Context, arg1 *provider.ModelBackendConfig, arg2 names.Tag, arg3 provider.SecretRevisions) error {
+func (m *MockSecretBackendProvider) CleanupSecrets(arg0 context.Context, arg1 *provider.ModelBackendConfig, arg2 *secrets.URI, arg3 provider.SecretRevisions) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CleanupSecrets", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
@@ -99,7 +99,7 @@ func (mr *MockSecretBackendProviderMockRecorder) NewBackend(arg0 any) *gomock.Ca
 }
 
 // RestrictedConfig mocks base method.
-func (m *MockSecretBackendProvider) RestrictedConfig(arg0 context.Context, arg1 *provider.ModelBackendConfig, arg2, arg3 bool, arg4 names.Tag, arg5, arg6 provider.SecretRevisions) (*provider.BackendConfig, error) {
+func (m *MockSecretBackendProvider) RestrictedConfig(arg0 context.Context, arg1 *provider.ModelBackendConfig, arg2, arg3 bool, arg4 secrets.Accessor, arg5, arg6 provider.SecretRevisions) (*provider.BackendConfig, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RestrictedConfig", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 	ret0, _ := ret[0].(*provider.BackendConfig)

--- a/apiserver/facades/client/secrets/mocks/secretsbackend.go
+++ b/apiserver/facades/client/secrets/mocks/secretsbackend.go
@@ -15,7 +15,6 @@ import (
 
 	secrets "github.com/juju/juju/core/secrets"
 	provider "github.com/juju/juju/internal/secrets/provider"
-	names "github.com/juju/names/v5"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -138,7 +137,7 @@ func (mr *MockSecretBackendProviderMockRecorder) CleanupModel(arg0 any) *gomock.
 }
 
 // CleanupSecrets mocks base method.
-func (m *MockSecretBackendProvider) CleanupSecrets(arg0 context.Context, arg1 *provider.ModelBackendConfig, arg2 names.Tag, arg3 provider.SecretRevisions) error {
+func (m *MockSecretBackendProvider) CleanupSecrets(arg0 context.Context, arg1 *provider.ModelBackendConfig, arg2 *secrets.URI, arg3 provider.SecretRevisions) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CleanupSecrets", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
@@ -181,7 +180,7 @@ func (mr *MockSecretBackendProviderMockRecorder) NewBackend(arg0 any) *gomock.Ca
 }
 
 // RestrictedConfig mocks base method.
-func (m *MockSecretBackendProvider) RestrictedConfig(arg0 context.Context, arg1 *provider.ModelBackendConfig, arg2, arg3 bool, arg4 names.Tag, arg5, arg6 provider.SecretRevisions) (*provider.BackendConfig, error) {
+func (m *MockSecretBackendProvider) RestrictedConfig(arg0 context.Context, arg1 *provider.ModelBackendConfig, arg2, arg3 bool, arg4 secrets.Accessor, arg5, arg6 provider.SecretRevisions) (*provider.BackendConfig, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RestrictedConfig", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 	ret0, _ := ret[0].(*provider.BackendConfig)

--- a/apiserver/facades/client/secrets/mocks/secretsbackend.go
+++ b/apiserver/facades/client/secrets/mocks/secretsbackend.go
@@ -137,7 +137,7 @@ func (mr *MockSecretBackendProviderMockRecorder) CleanupModel(arg0 any) *gomock.
 }
 
 // CleanupSecrets mocks base method.
-func (m *MockSecretBackendProvider) CleanupSecrets(arg0 context.Context, arg1 *provider.ModelBackendConfig, arg2 *secrets.URI, arg3 provider.SecretRevisions) error {
+func (m *MockSecretBackendProvider) CleanupSecrets(arg0 context.Context, arg1 *provider.ModelBackendConfig, arg2 string, arg3 provider.SecretRevisions) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CleanupSecrets", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)

--- a/caas/broker.go
+++ b/caas/broker.go
@@ -229,9 +229,6 @@ type ApplicationBroker interface {
 type SecretsProvider interface {
 	// EnsureSecretAccessToken ensures the secret related RBAC resources for the provided entity.
 	EnsureSecretAccessToken(ctx context.Context, unitName string, owned, read, removed []string) (string, error)
-
-	// RemoveSecretAccessToken removes the secret related RBAC resources for the provided secret.
-	RemoveSecretAccessToken(ctx context.Context, uri *secrets.URI) error
 }
 
 // SecretsBackend provides an API for managing Juju secrets.

--- a/caas/broker.go
+++ b/caas/broker.go
@@ -228,10 +228,10 @@ type ApplicationBroker interface {
 // SecretsProvider provides an API for accessing the broker interface for managing secret k8s provider resources.
 type SecretsProvider interface {
 	// EnsureSecretAccessToken ensures the secret related RBAC resources for the provided entity.
-	EnsureSecretAccessToken(ctx context.Context, tag names.Tag, owned, read, removed []string) (string, error)
+	EnsureSecretAccessToken(ctx context.Context, unitName string, owned, read, removed []string) (string, error)
 
-	// RemoveSecretAccessToken removes the secret related RBAC resources for the provided entity.
-	RemoveSecretAccessToken(ctx context.Context, tag names.Tag) error
+	// RemoveSecretAccessToken removes the secret related RBAC resources for the provided secret.
+	RemoveSecretAccessToken(ctx context.Context, uri *secrets.URI) error
 }
 
 // SecretsBackend provides an API for managing Juju secrets.

--- a/caas/kubernetes/provider/bootstrap.go
+++ b/caas/kubernetes/provider/bootstrap.go
@@ -42,6 +42,7 @@ import (
 	k8sannotations "github.com/juju/juju/core/annotations"
 	"github.com/juju/juju/core/paths"
 	"github.com/juju/juju/core/watcher"
+	secreterrors "github.com/juju/juju/domain/secret/errors"
 	"github.com/juju/juju/environs"
 	environsbootstrap "github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/internal/cloudconfig"
@@ -378,7 +379,7 @@ func (c *controllerStack) getControllerSecret(ctx context.Context) (secret *core
 	if err == nil {
 		return secret, nil
 	}
-	if errors.Is(err, errors.NotFound) {
+	if errors.Is(err, secreterrors.SecretRevisionNotFound) {
 		_, err = c.broker.createSecret(ctx, &core.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        c.resourceNameSecret,

--- a/caas/kubernetes/provider/bootstrap.go
+++ b/caas/kubernetes/provider/bootstrap.go
@@ -42,7 +42,6 @@ import (
 	k8sannotations "github.com/juju/juju/core/annotations"
 	"github.com/juju/juju/core/paths"
 	"github.com/juju/juju/core/watcher"
-	secreterrors "github.com/juju/juju/domain/secret/errors"
 	"github.com/juju/juju/environs"
 	environsbootstrap "github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/internal/cloudconfig"
@@ -379,7 +378,7 @@ func (c *controllerStack) getControllerSecret(ctx context.Context) (secret *core
 	if err == nil {
 		return secret, nil
 	}
-	if errors.Is(err, secreterrors.SecretRevisionNotFound) {
+	if errors.Is(err, errors.NotFound) {
 		_, err = c.broker.createSecret(ctx, &core.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        c.resourceNameSecret,

--- a/caas/kubernetes/provider/rbac.go
+++ b/caas/kubernetes/provider/rbac.go
@@ -27,7 +27,6 @@ import (
 	"github.com/juju/juju/caas/kubernetes/provider/constants"
 	"github.com/juju/juju/caas/kubernetes/provider/resources"
 	"github.com/juju/juju/caas/kubernetes/provider/utils"
-	"github.com/juju/juju/core/secrets"
 	environsbootstrap "github.com/juju/juju/environs/bootstrap"
 )
 
@@ -430,6 +429,7 @@ func (k *kubernetesClient) listClusterRoleBindings(ctx context.Context, selector
 var expiresInSeconds = int64(60 * 10)
 
 // EnsureSecretAccessToken ensures the RBAC resources created and updated for the provided resource name.
+// Any revisions listed in removed have access revoked.
 func (k *kubernetesClient) EnsureSecretAccessToken(ctx context.Context, unitName string, owned, read, removed []string) (string, error) {
 	appName, _ := names.UnitApplication(unitName)
 	labels := utils.LabelsForApp(appName, k.IsLegacyLabels())
@@ -674,19 +674,4 @@ func rulesForSecretAccess(
 		})
 	}
 	return existing
-}
-
-// RemoveSecretAccessToken removes the RBAC resources for the provided secret.
-func (k *kubernetesClient) RemoveSecretAccessToken(ctx context.Context, uri *secrets.URI) error {
-	// TODO(secrets) - this was never called and is wrong anyway and needs to be implemented
-	//if err := k.deleteRoleBinding(ctx, name, ""); err != nil {
-	//	logger.Warningf("cannot delete service account %q", name)
-	//}
-	//if err := k.deleteRole(ctx, name, ""); err != nil {
-	//	logger.Warningf("cannot delete service account %q", name)
-	//}
-	//if err := k.deleteServiceAccount(ctx, name, ""); err != nil {
-	//	logger.Warningf("cannot delete service account %q", name)
-	//}
-	return nil
 }

--- a/caas/kubernetes/provider/rbac_test.go
+++ b/caas/kubernetes/provider/rbac_test.go
@@ -6,7 +6,6 @@ package provider_test
 import (
 	"context"
 
-	"github.com/juju/names/v5"
 	jc "github.com/juju/testing/checkers"
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
@@ -18,6 +17,7 @@ import (
 
 	"github.com/juju/juju/caas/kubernetes/provider"
 	k8sconstants "github.com/juju/juju/caas/kubernetes/provider/constants"
+	coresecrets "github.com/juju/juju/core/secrets"
 	environsbootstrap "github.com/juju/juju/environs/bootstrap"
 	"github.com/juju/juju/environs/config"
 	coretesting "github.com/juju/juju/testing"
@@ -33,10 +33,8 @@ func (s *rbacSuite) TestEnsureSecretAccessTokenCreate(c *gc.C) {
 	ctrl := s.setupController(c)
 	defer ctrl.Finish()
 
-	tag := names.NewUnitTag("gitlab/0")
-
 	objMeta := v1.ObjectMeta{
-		Name:      tag.String(),
+		Name:      "unit-gitlab-0",
 		Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "gitlab"},
 		Namespace: s.namespace,
 	}
@@ -97,7 +95,7 @@ func (s *rbacSuite) TestEnsureSecretAccessTokenCreate(c *gc.C) {
 		),
 	)
 
-	token, err := s.broker.EnsureSecretAccessToken(context.Background(), tag, nil, nil, nil)
+	token, err := s.broker.EnsureSecretAccessToken(context.Background(), "gitlab/0", nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(token, gc.Equals, "token")
 }
@@ -118,10 +116,13 @@ func (s *rbacSuite) TestEnsureSecretAccessTokenControllerModelCreate(c *gc.C) {
 	ctrl := s.setupController(c)
 	defer ctrl.Finish()
 
-	tag := names.NewUnitTag("gitlab/0")
+	accessor := coresecrets.Accessor{
+		Kind: coresecrets.UnitAccessor,
+		ID:   "gitlab/0",
+	}
 
 	objMeta := v1.ObjectMeta{
-		Name:      tag.String(),
+		Name:      accessor.String(),
 		Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "gitlab"},
 		Namespace: s.namespace,
 	}
@@ -130,7 +131,7 @@ func (s *rbacSuite) TestEnsureSecretAccessTokenControllerModelCreate(c *gc.C) {
 		ObjectMeta:                   objMeta,
 		AutomountServiceAccountToken: &automountServiceAccountToken,
 	}
-	objMeta.Name = s.namespace + "-" + tag.String()
+	objMeta.Name = s.namespace + "-" + accessor.String()
 	clusterrole := &rbacv1.ClusterRole{
 		ObjectMeta: objMeta,
 		Rules: []rbacv1.PolicyRule{
@@ -183,7 +184,7 @@ func (s *rbacSuite) TestEnsureSecretAccessTokenControllerModelCreate(c *gc.C) {
 		),
 	)
 
-	token, err := s.broker.EnsureSecretAccessToken(context.Background(), tag, nil, nil, nil)
+	token, err := s.broker.EnsureSecretAccessToken(context.Background(), "gitlab/0", nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(token, gc.Equals, "token")
 }
@@ -192,10 +193,8 @@ func (s *rbacSuite) TestEnsureSecretAccessTokeUpdate(c *gc.C) {
 	ctrl := s.setupController(c)
 	defer ctrl.Finish()
 
-	tag := names.NewUnitTag("gitlab/0")
-
 	objMeta := v1.ObjectMeta{
-		Name:      tag.String(),
+		Name:      "unit-gitlab-0",
 		Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "gitlab"},
 		Namespace: s.namespace,
 	}
@@ -260,7 +259,7 @@ func (s *rbacSuite) TestEnsureSecretAccessTokeUpdate(c *gc.C) {
 		),
 	)
 
-	token, err := s.broker.EnsureSecretAccessToken(context.Background(), tag, nil, nil, nil)
+	token, err := s.broker.EnsureSecretAccessToken(context.Background(), "gitlab/0", nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(token, gc.Equals, "token")
 }
@@ -270,10 +269,8 @@ func (s *rbacSuite) TestEnsureSecretAccessTokeControllerModelUpdate(c *gc.C) {
 	ctrl := s.setupController(c)
 	defer ctrl.Finish()
 
-	tag := names.NewUnitTag("gitlab/0")
-
 	objMeta := v1.ObjectMeta{
-		Name:      tag.String(),
+		Name:      "unit-gitlab-0",
 		Labels:    map[string]string{"app.kubernetes.io/managed-by": "juju", "app.kubernetes.io/name": "gitlab"},
 		Namespace: s.namespace,
 	}
@@ -282,7 +279,7 @@ func (s *rbacSuite) TestEnsureSecretAccessTokeControllerModelUpdate(c *gc.C) {
 		ObjectMeta:                   objMeta,
 		AutomountServiceAccountToken: &automountServiceAccountToken,
 	}
-	objMeta.Name = s.namespace + "-" + tag.String()
+	objMeta.Name = s.namespace + "-" + "unit-gitlab-0"
 	clusterrole := &rbacv1.ClusterRole{
 		ObjectMeta: objMeta,
 		Rules: []rbacv1.PolicyRule{
@@ -337,7 +334,7 @@ func (s *rbacSuite) TestEnsureSecretAccessTokeControllerModelUpdate(c *gc.C) {
 		),
 	)
 
-	token, err := s.broker.EnsureSecretAccessToken(context.Background(), tag, nil, nil, nil)
+	token, err := s.broker.EnsureSecretAccessToken(context.Background(), "gitlab/0", nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(token, gc.Equals, "token")
 }

--- a/caas/kubernetes/provider/secrets.go
+++ b/caas/kubernetes/provider/secrets.go
@@ -6,6 +6,7 @@ package provider
 import (
 	"context"
 	"encoding/base64"
+	"fmt"
 	"time"
 
 	"github.com/juju/errors"
@@ -19,6 +20,7 @@ import (
 	"github.com/juju/juju/caas/kubernetes/provider/utils"
 	k8sannotations "github.com/juju/juju/core/annotations"
 	"github.com/juju/juju/core/secrets"
+	secreterrors "github.com/juju/juju/domain/secret/errors"
 )
 
 func processSecretData(in map[string]string) (_ map[string][]byte, err error) {
@@ -98,7 +100,7 @@ func (k *kubernetesClient) getSecret(ctx context.Context, secretName string) (*c
 	secret, err := k.client().CoreV1().Secrets(k.namespace).Get(ctx, secretName, v1.GetOptions{})
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
-			return nil, errors.NotFoundf("secret %q", secretName)
+			return nil, fmt.Errorf("secret %q not found%w", secretName, errors.Hide(secreterrors.SecretRevisionNotFound))
 		}
 		return nil, errors.Trace(err)
 	}

--- a/caas/kubernetes/provider/secrets.go
+++ b/caas/kubernetes/provider/secrets.go
@@ -6,7 +6,6 @@ package provider
 import (
 	"context"
 	"encoding/base64"
-	"fmt"
 	"time"
 
 	"github.com/juju/errors"
@@ -20,7 +19,6 @@ import (
 	"github.com/juju/juju/caas/kubernetes/provider/utils"
 	k8sannotations "github.com/juju/juju/core/annotations"
 	"github.com/juju/juju/core/secrets"
-	secreterrors "github.com/juju/juju/domain/secret/errors"
 )
 
 func processSecretData(in map[string]string) (_ map[string][]byte, err error) {
@@ -100,7 +98,7 @@ func (k *kubernetesClient) getSecret(ctx context.Context, secretName string) (*c
 	secret, err := k.client().CoreV1().Secrets(k.namespace).Get(ctx, secretName, v1.GetOptions{})
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
-			return nil, fmt.Errorf("secret %q not found%w", secretName, errors.Hide(secreterrors.SecretRevisionNotFound))
+			return nil, errors.NotFoundf("secret %q", secretName)
 		}
 		return nil, errors.Trace(err)
 	}

--- a/caas/kubernetes/provider/secrets_test.go
+++ b/caas/kubernetes/provider/secrets_test.go
@@ -6,7 +6,6 @@ package provider_test
 import (
 	"context"
 
-	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	core "k8s.io/api/core/v1"
@@ -14,6 +13,7 @@ import (
 
 	"github.com/juju/juju/caas/kubernetes/provider"
 	"github.com/juju/juju/core/secrets"
+	secreterrors "github.com/juju/juju/domain/secret/errors"
 )
 
 var _ = gc.Suite(&secretsSuite{})
@@ -114,7 +114,7 @@ func (s *secretsSuite) TestDeleteJujuSecret(c *gc.C) {
 	err = s.broker.DeleteJujuSecret(context.Background(), "provider-id")
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.broker.DeleteJujuSecret(context.Background(), "provider-id")
-	c.Assert(err, jc.ErrorIs, errors.NotFound)
+	c.Assert(err, jc.ErrorIs, secreterrors.SecretRevisionNotFound)
 	result, err := s.mockSecrets.List(context.Background(), v1.ListOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Items, gc.HasLen, 1)

--- a/caas/kubernetes/provider/secrets_test.go
+++ b/caas/kubernetes/provider/secrets_test.go
@@ -6,6 +6,7 @@ package provider_test
 import (
 	"context"
 
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	core "k8s.io/api/core/v1"
@@ -13,7 +14,6 @@ import (
 
 	"github.com/juju/juju/caas/kubernetes/provider"
 	"github.com/juju/juju/core/secrets"
-	secreterrors "github.com/juju/juju/domain/secret/errors"
 )
 
 var _ = gc.Suite(&secretsSuite{})
@@ -114,7 +114,7 @@ func (s *secretsSuite) TestDeleteJujuSecret(c *gc.C) {
 	err = s.broker.DeleteJujuSecret(context.Background(), "provider-id")
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.broker.DeleteJujuSecret(context.Background(), "provider-id")
-	c.Assert(err, jc.ErrorIs, secreterrors.SecretRevisionNotFound)
+	c.Assert(err, jc.ErrorIs, errors.NotFound)
 	result, err := s.mockSecrets.List(context.Background(), v1.ListOptions{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.Items, gc.HasLen, 1)

--- a/caas/mocks/broker_mock.go
+++ b/caas/mocks/broker_mock.go
@@ -250,7 +250,7 @@ func (mr *MockBrokerMockRecorder) EnsureModelOperator(arg0, arg1, arg2, arg3 any
 }
 
 // EnsureSecretAccessToken mocks base method.
-func (m *MockBroker) EnsureSecretAccessToken(arg0 context.Context, arg1 names.Tag, arg2, arg3, arg4 []string) (string, error) {
+func (m *MockBroker) EnsureSecretAccessToken(arg0 context.Context, arg1 string, arg2, arg3, arg4 []string) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EnsureSecretAccessToken", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(string)
@@ -397,7 +397,7 @@ func (mr *MockBrokerMockRecorder) ProxyToApplication(arg0, arg1, arg2 any) *gomo
 }
 
 // RemoveSecretAccessToken mocks base method.
-func (m *MockBroker) RemoveSecretAccessToken(arg0 context.Context, arg1 names.Tag) error {
+func (m *MockBroker) RemoveSecretAccessToken(arg0 context.Context, arg1 *secrets.URI) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveSecretAccessToken", arg0, arg1)
 	ret0, _ := ret[0].(error)

--- a/caas/mocks/broker_mock.go
+++ b/caas/mocks/broker_mock.go
@@ -396,20 +396,6 @@ func (mr *MockBrokerMockRecorder) ProxyToApplication(arg0, arg1, arg2 any) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProxyToApplication", reflect.TypeOf((*MockBroker)(nil).ProxyToApplication), arg0, arg1, arg2)
 }
 
-// RemoveSecretAccessToken mocks base method.
-func (m *MockBroker) RemoveSecretAccessToken(arg0 context.Context, arg1 *secrets.URI) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RemoveSecretAccessToken", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// RemoveSecretAccessToken indicates an expected call of RemoveSecretAccessToken.
-func (mr *MockBrokerMockRecorder) RemoveSecretAccessToken(arg0, arg1 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveSecretAccessToken", reflect.TypeOf((*MockBroker)(nil).RemoveSecretAccessToken), arg0, arg1)
-}
-
 // SaveJujuSecret mocks base method.
 func (m *MockBroker) SaveJujuSecret(arg0 context.Context, arg1 string, arg2 secrets.SecretValue) (string, error) {
 	m.ctrl.T.Helper()

--- a/core/secrets/secret.go
+++ b/core/secrets/secret.go
@@ -160,6 +160,10 @@ type Owner struct {
 	ID   string
 }
 
+func (o Owner) String() string {
+	return fmt.Sprintf("%s-%s", o.Kind, strings.ReplaceAll(o.ID, "/", "-"))
+}
+
 // SecretMetadata holds metadata about a secret.
 type SecretMetadata struct {
 	// Read only after creation.
@@ -203,6 +207,32 @@ type AccessInfo struct {
 	Target string
 	Scope  string
 	Role   SecretRole
+}
+
+// AccessorKind represents the kind of a secret accessor entity.
+type AccessorKind string
+
+// These represent the kinds of secret accessor.
+const (
+	UnitAccessor  AccessorKind = "unit"
+	ModelAccessor AccessorKind = "model"
+)
+
+// Accessor is the accessor of a secret.
+type Accessor struct {
+	Kind AccessorKind
+	ID   string
+}
+
+func (a Accessor) String() string {
+	return fmt.Sprintf("%s-%s", a.Kind, strings.ReplaceAll(a.ID, "/", "-"))
+}
+
+// SecretRevisionRef is a reference to a secret revision
+// stored in a secret backend.
+type SecretRevisionRef struct {
+	URI        *URI
+	RevisionID string
 }
 
 // SecretRevisionMetadata holds metadata about a secret revision.

--- a/domain/secret/service/delete.go
+++ b/domain/secret/service/delete.go
@@ -26,100 +26,68 @@ func (s *SecretService) DeleteSecret(ctx context.Context, uri *secrets.URI, para
 		return errors.Trace(err)
 	}
 
-	return s.deleteSecret(
-		ctx,
-		uri, params.Revisions,
-		func(ctx context.Context, p provider.SecretBackendProvider, cfg provider.ModelBackendConfig, revs provider.SecretRevisions) error {
-			backend, err := p.NewBackend(&cfg)
-			if err != nil {
-				return errors.Trace(err)
-			}
-			for _, revId := range revs.RevisionIDs() {
-				if err = backend.DeleteContent(ctx, revId); err != nil {
-					return errors.Trace(err)
-				}
-			}
-			// TODO(secrets) - support backends properly
-			// Ideally we'd not use tags but secret API uses them.
-			//modelUUID, err := s.st.GetModelUUID(ctx)
-			//if err != nil {
-			//	return errors.Annotate(err, "getting model uuid")
-			//}
-			//ownerTag := names.NewModelTag(modelUUID)
-			//if err := p.CleanupSecrets(ctx, &cfg, ownerTag, revs); err != nil {
-			//	return errors.Trace(err)
-			//}
-			return nil
-		},
-	)
+	// We remove the secret from the backend first.
+	if err := s.removeFromExternal(ctx, uri, params.Revisions...); err != nil {
+		return errors.Trace(err)
+	}
+
+	return s.st.DeleteSecret(ctx, uri, params.Revisions)
 }
 
-func (s *SecretService) deleteSecret(
-	ctx context.Context,
-	uri *secrets.URI,
-	revisions []int,
-	removeFromBackend func(context.Context, provider.SecretBackendProvider, provider.ModelBackendConfig, provider.SecretRevisions) error,
-) error {
+func (s *SecretService) removeFromExternal(ctx context.Context, uri *secrets.URI, revisions ...int) error {
+	externalRevs := make(map[string]provider.SecretRevisions)
+	revs, err := s.st.ListExternalSecretRevisions(ctx, uri, revisions...)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	for _, valRef := range revs {
+		if _, ok := externalRevs[valRef.BackendID]; !ok {
+			externalRevs[valRef.BackendID] = provider.SecretRevisions{}
+		}
+		externalRevs[valRef.BackendID].Add(uri, valRef.RevisionID)
+
+	}
+
+	if len(externalRevs) == 0 {
+		return nil
+	}
+
 	cfgInfo, err := s.adminConfigGetter(ctx)
 	if err != nil {
 		return errors.Trace(err)
 	}
 
-	removeFromExternal := func(uri *secrets.URI, revisions ...int) error {
-		externalRevs := make(map[string]provider.SecretRevisions)
-		gatherExternalRevs := func(valRef *secrets.ValueRef) {
-			if valRef == nil {
-				// Internal secret, nothing to do here.
-				return
-			}
-			if _, ok := externalRevs[valRef.BackendID]; !ok {
-				externalRevs[valRef.BackendID] = provider.SecretRevisions{}
-			}
-			externalRevs[valRef.BackendID].Add(uri, valRef.RevisionID)
+	for backendID, r := range externalRevs {
+		backendCfg, ok := cfgInfo.Configs[backendID]
+		if !ok {
+			return errors.NotFoundf("secret backend %q", backendID)
 		}
-		if len(revisions) == 0 {
-			// Remove all revisions.
-			revs, err := s.listSecretRevisions(ctx, uri)
-			if err != nil {
-				return errors.Trace(err)
-			}
-			for _, rev := range revs {
-				gatherExternalRevs(rev.ValueRef)
-			}
-		} else {
-			for _, rev := range revisions {
-				revMeta, err := s.st.GetSecretRevision(ctx, uri, rev)
-				if err != nil {
-					return errors.Trace(err)
-				}
-				gatherExternalRevs(revMeta.ValueRef)
-			}
+		p, err := s.providerGetter(backendCfg.BackendType)
+		if err != nil {
+			return errors.Trace(err)
 		}
-
-		for backendID, r := range externalRevs {
-			backendCfg, ok := cfgInfo.Configs[backendID]
-			if !ok {
-				return errors.NotFoundf("secret backend %q", backendID)
-			}
-			provider, err := s.providerGetter(backendCfg.BackendType)
-			if err != nil {
-				return errors.Trace(err)
-			}
-			if err := removeFromBackend(ctx, provider, backendCfg, r); err != nil {
-				return errors.Trace(err)
-			}
+		if err := s.removeFromBackend(ctx, p, backendCfg, uri, r); err != nil {
+			return errors.Trace(err)
 		}
-		return nil
 	}
-
-	// We remove the secret from the backend first.
-	if err := removeFromExternal(uri, revisions...); err != nil {
-		return errors.Trace(err)
-	}
-
-	return s.st.DeleteSecret(ctx, uri, revisions)
+	return nil
 }
 
-func (s *SecretService) listSecretRevisions(ctx context.Context, uri *secrets.URI) ([]*secrets.SecretRevisionMetadata, error) {
-	return nil, nil
+func (s *SecretService) removeFromBackend(
+	ctx context.Context, p provider.SecretBackendProvider, cfg provider.ModelBackendConfig,
+	uri *secrets.URI, revs provider.SecretRevisions,
+) error {
+	backend, err := p.NewBackend(&cfg)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	for _, revId := range revs.RevisionIDs() {
+		if err = backend.DeleteContent(ctx, revId); err != nil {
+			return errors.Annotatef(err, "deleting secret content from backend for %q", revId)
+		}
+	}
+	if err := p.CleanupSecrets(ctx, &cfg, uri, revs); err != nil {
+		return errors.Annotate(err, "cleaning secret resources from backend")
+	}
+	return nil
 }

--- a/domain/secret/service/delete_test.go
+++ b/domain/secret/service/delete_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/juju/juju/internal/secrets/provider"
 )
 
-func (s *serviceSuite) TestDeleteSecret(c *gc.C) {
+func (s *serviceSuite) TestDeleteSecretInternal(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 
@@ -30,7 +30,7 @@ func (s *serviceSuite) TestDeleteSecret(c *gc.C) {
 		SubjectTypeID: domainsecret.SubjectUnit,
 		SubjectID:     "mariadb/0",
 	}).Return("manage", nil)
-	s.state.EXPECT().GetSecretRevision(gomock.Any(), uri, 666).Return(&coresecrets.SecretRevisionMetadata{}, nil)
+	s.state.EXPECT().ListExternalSecretRevisions(gomock.Any(), uri, 666).Return([]coresecrets.ValueRef{}, nil)
 	s.state.EXPECT().DeleteSecret(gomock.Any(), uri, []int{666}).Return(nil)
 
 	err := s.service().DeleteSecret(context.Background(), uri, DeleteSecretParams{

--- a/domain/secret/service/service.go
+++ b/domain/secret/service/service.go
@@ -31,7 +31,7 @@ type State interface {
 	UpdateSecret(ctx context.Context, uri *secrets.URI, secret domainsecret.UpsertSecretParams) error
 	DeleteSecret(ctx context.Context, uri *secrets.URI, revs []int) error
 	GetSecret(ctx context.Context, uri *secrets.URI) (*secrets.SecretMetadata, error)
-	GetSecretRevision(ctx context.Context, uri *secrets.URI, revision int) (*secrets.SecretRevisionMetadata, error)
+	ListExternalSecretRevisions(ctx context.Context, uri *secrets.URI, revisions ...int) ([]secrets.ValueRef, error)
 	GetSecretValue(ctx context.Context, uri *secrets.URI, revision int) (secrets.SecretData, *secrets.ValueRef, error)
 	ListSecrets(ctx context.Context, uri *secrets.URI,
 		revision *int, labels domainsecret.Labels,
@@ -52,6 +52,10 @@ type State interface {
 	GetSecretAccess(ctx context.Context, uri *secrets.URI, params domainsecret.AccessParams) (string, error)
 	GetSecretAccessScope(ctx context.Context, uri *secrets.URI, params domainsecret.AccessParams) (*domainsecret.AccessScope, error)
 	GetSecretGrants(ctx context.Context, uri *secrets.URI, role secrets.SecretRole) ([]domainsecret.GrantParams, error)
+	ListGrantedSecretsForBackend(
+		ctx context.Context, backendID string, accessors []domainsecret.AccessParams, role secrets.SecretRole,
+	) ([]*secrets.SecretRevisionRef, error)
+
 	InitialWatchStatementForObsoleteRevision(
 		ctx context.Context, appOwners domainsecret.ApplicationOwners, unitOwners domainsecret.UnitOwners,
 	) (tableName string, statement eventsource.NamespaceQuery)

--- a/domain/secret/service/state_mock_test.go
+++ b/domain/secret/service/state_mock_test.go
@@ -225,21 +225,6 @@ func (mr *MockStateMockRecorder) GetSecretRemoteConsumer(arg0, arg1, arg2 any) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecretRemoteConsumer", reflect.TypeOf((*MockState)(nil).GetSecretRemoteConsumer), arg0, arg1, arg2)
 }
 
-// GetSecretRevision mocks base method.
-func (m *MockState) GetSecretRevision(arg0 context.Context, arg1 *secrets.URI, arg2 int) (*secrets.SecretRevisionMetadata, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetSecretRevision", arg0, arg1, arg2)
-	ret0, _ := ret[0].(*secrets.SecretRevisionMetadata)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetSecretRevision indicates an expected call of GetSecretRevision.
-func (mr *MockStateMockRecorder) GetSecretRevision(arg0, arg1, arg2 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecretRevision", reflect.TypeOf((*MockState)(nil).GetSecretRevision), arg0, arg1, arg2)
-}
-
 // GetSecretValue mocks base method.
 func (m *MockState) GetSecretValue(arg0 context.Context, arg1 *secrets.URI, arg2 int) (secrets.SecretData, *secrets.ValueRef, error) {
 	m.ctrl.T.Helper()
@@ -329,6 +314,41 @@ func (m *MockState) ListCharmSecrets(arg0 context.Context, arg1 secret.Applicati
 func (mr *MockStateMockRecorder) ListCharmSecrets(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCharmSecrets", reflect.TypeOf((*MockState)(nil).ListCharmSecrets), arg0, arg1, arg2)
+}
+
+// ListExternalSecretRevisions mocks base method.
+func (m *MockState) ListExternalSecretRevisions(arg0 context.Context, arg1 *secrets.URI, arg2 ...int) ([]secrets.ValueRef, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ListExternalSecretRevisions", varargs...)
+	ret0, _ := ret[0].([]secrets.ValueRef)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListExternalSecretRevisions indicates an expected call of ListExternalSecretRevisions.
+func (mr *MockStateMockRecorder) ListExternalSecretRevisions(arg0, arg1 any, arg2 ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListExternalSecretRevisions", reflect.TypeOf((*MockState)(nil).ListExternalSecretRevisions), varargs...)
+}
+
+// ListGrantedSecretsForBackend mocks base method.
+func (m *MockState) ListGrantedSecretsForBackend(arg0 context.Context, arg1 string, arg2 []secret.AccessParams, arg3 secrets.SecretRole) ([]*secrets.SecretRevisionRef, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListGrantedSecretsForBackend", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].([]*secrets.SecretRevisionRef)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListGrantedSecretsForBackend indicates an expected call of ListGrantedSecretsForBackend.
+func (mr *MockStateMockRecorder) ListGrantedSecretsForBackend(arg0, arg1, arg2, arg3 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListGrantedSecretsForBackend", reflect.TypeOf((*MockState)(nil).ListGrantedSecretsForBackend), arg0, arg1, arg2, arg3)
 }
 
 // ListSecrets mocks base method.

--- a/domain/secretbackend/service/provider_mock_test.go
+++ b/domain/secretbackend/service/provider_mock_test.go
@@ -15,7 +15,6 @@ import (
 
 	secrets "github.com/juju/juju/core/secrets"
 	provider "github.com/juju/juju/internal/secrets/provider"
-	names "github.com/juju/names/v5"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -57,7 +56,7 @@ func (mr *MockSecretBackendProviderMockRecorder) CleanupModel(arg0 any) *gomock.
 }
 
 // CleanupSecrets mocks base method.
-func (m *MockSecretBackendProvider) CleanupSecrets(arg0 context.Context, arg1 *provider.ModelBackendConfig, arg2 names.Tag, arg3 provider.SecretRevisions) error {
+func (m *MockSecretBackendProvider) CleanupSecrets(arg0 context.Context, arg1 *provider.ModelBackendConfig, arg2 *secrets.URI, arg3 provider.SecretRevisions) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CleanupSecrets", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
@@ -100,7 +99,7 @@ func (mr *MockSecretBackendProviderMockRecorder) NewBackend(arg0 any) *gomock.Ca
 }
 
 // RestrictedConfig mocks base method.
-func (m *MockSecretBackendProvider) RestrictedConfig(arg0 context.Context, arg1 *provider.ModelBackendConfig, arg2, arg3 bool, arg4 names.Tag, arg5, arg6 provider.SecretRevisions) (*provider.BackendConfig, error) {
+func (m *MockSecretBackendProvider) RestrictedConfig(arg0 context.Context, arg1 *provider.ModelBackendConfig, arg2, arg3 bool, arg4 secrets.Accessor, arg5, arg6 provider.SecretRevisions) (*provider.BackendConfig, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RestrictedConfig", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 	ret0, _ := ret[0].(*provider.BackendConfig)

--- a/domain/secretbackend/service/provider_mock_test.go
+++ b/domain/secretbackend/service/provider_mock_test.go
@@ -56,7 +56,7 @@ func (mr *MockSecretBackendProviderMockRecorder) CleanupModel(arg0 any) *gomock.
 }
 
 // CleanupSecrets mocks base method.
-func (m *MockSecretBackendProvider) CleanupSecrets(arg0 context.Context, arg1 *provider.ModelBackendConfig, arg2 *secrets.URI, arg3 provider.SecretRevisions) error {
+func (m *MockSecretBackendProvider) CleanupSecrets(arg0 context.Context, arg1 *provider.ModelBackendConfig, arg2 string, arg3 provider.SecretRevisions) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CleanupSecrets", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)

--- a/internal/secrets/backend.go
+++ b/internal/secrets/backend.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/core/secrets"
+	secreterrors "github.com/juju/juju/domain/secret/errors"
 	"github.com/juju/juju/internal/secrets/provider"
 )
 
@@ -94,7 +95,7 @@ func (c *secretsClient) GetContent(uri *secrets.URI, label string, refresh, peek
 			return nil, errors.Trace(err)
 		}
 		val, err := backend.GetContent(context.TODO(), content.ValueRef.RevisionID)
-		if err == nil || !errors.Is(err, errors.NotFound) || lastBackendID == backendID {
+		if err == nil || !errors.Is(err, secreterrors.SecretRevisionNotFound) || lastBackendID == backendID {
 			return val, errors.Trace(err)
 		}
 		lastBackendID = backendID
@@ -164,7 +165,7 @@ func (c *secretsClient) DeleteContent(uri *secrets.URI, revision int) error {
 			return errors.Trace(err)
 		}
 		err = backend.DeleteContent(context.TODO(), content.ValueRef.RevisionID)
-		if err == nil || !errors.Is(err, errors.NotFound) || lastBackendID == backendID {
+		if err == nil || !errors.Is(err, secreterrors.SecretRevisionNotFound) || lastBackendID == backendID {
 			return errors.Trace(err)
 		}
 		lastBackendID = backendID
@@ -183,7 +184,7 @@ func (c *secretsClient) DeleteExternalContent(ref secrets.ValueRef) error {
 		return errors.Trace(err)
 	}
 	err = backend.DeleteContent(context.TODO(), ref.RevisionID)
-	if errors.Is(err, errors.NotFound) {
+	if errors.Is(err, secreterrors.SecretRevisionNotFound) {
 		return nil
 	}
 	return errors.Trace(err)

--- a/internal/secrets/backend_test.go
+++ b/internal/secrets/backend_test.go
@@ -5,13 +5,13 @@ package secrets_test
 
 import (
 	"github.com/juju/collections/set"
-	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
 	coresecrets "github.com/juju/juju/core/secrets"
+	secreterrors "github.com/juju/juju/domain/secret/errors"
 	"github.com/juju/juju/internal/secrets"
 	"github.com/juju/juju/internal/secrets/mocks"
 	"github.com/juju/juju/internal/secrets/provider"
@@ -137,7 +137,7 @@ func (s *backendSuite) TestGetContentSecretDrained(c *gc.C) {
 		}, true, nil),
 
 		// First not found - we try again with the active backend.
-		backend.EXPECT().GetContent(gomock.Any(), "rev-id").Return(nil, errors.NotFoundf("")),
+		backend.EXPECT().GetContent(gomock.Any(), "rev-id").Return(nil, secreterrors.SecretRevisionNotFound),
 		jujuapi.EXPECT().GetContentInfo(uri, "label", true, false).Return(&secrets.ContentParams{
 			ValueRef: &coresecrets.ValueRef{
 				BackendID:  "backend-id2",
@@ -151,7 +151,7 @@ func (s *backendSuite) TestGetContentSecretDrained(c *gc.C) {
 		}, true, nil),
 
 		// Second not found - refresh backend config.
-		backend.EXPECT().GetContent(gomock.Any(), "rev-id2").Return(nil, errors.NotFoundf("")),
+		backend.EXPECT().GetContent(gomock.Any(), "rev-id2").Return(nil, secreterrors.SecretRevisionNotFound),
 
 		// Third time lucky.
 		jujuapi.EXPECT().GetContentInfo(uri, "label", true, false).Return(&secrets.ContentParams{
@@ -237,7 +237,7 @@ func (s *backendSuite) TestDeleteContentDrained(c *gc.C) {
 			ModelName:      "model1",
 			BackendConfig:  provider.BackendConfig{BackendType: "somebackend1"},
 		}, true, nil),
-		backend.EXPECT().DeleteContent(gomock.Any(), "rev-id").Return(errors.NotFoundf("")),
+		backend.EXPECT().DeleteContent(gomock.Any(), "rev-id").Return(secreterrors.SecretRevisionNotFound),
 
 		// Second not found - refresh backend config.
 		jujuapi.EXPECT().GetRevisionContentInfo(uri, 666, true).Return(&secrets.ContentParams{
@@ -251,7 +251,7 @@ func (s *backendSuite) TestDeleteContentDrained(c *gc.C) {
 			ModelName:      "model2",
 			BackendConfig:  provider.BackendConfig{BackendType: "somebackend2"},
 		}, true, nil),
-		backend.EXPECT().DeleteContent(gomock.Any(), "rev-id2").Return(errors.NotFoundf("")),
+		backend.EXPECT().DeleteContent(gomock.Any(), "rev-id2").Return(secreterrors.SecretRevisionNotFound),
 
 		// Third time lucky.
 		jujuapi.EXPECT().GetRevisionContentInfo(uri, 666, true).Return(&secrets.ContentParams{

--- a/internal/secrets/provider/juju/backend.go
+++ b/internal/secrets/provider/juju/backend.go
@@ -5,10 +5,12 @@ package juju
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/juju/errors"
 
 	coresecrets "github.com/juju/juju/core/secrets"
+	secreterrors "github.com/juju/juju/domain/secret/errors"
 )
 
 // jujuBackend is a dummy backend which returns
@@ -17,12 +19,12 @@ type jujuBackend struct{}
 
 // GetContent implements SecretsBackend.
 func (k jujuBackend) GetContent(ctx context.Context, revisionId string) (coresecrets.SecretValue, error) {
-	return nil, errors.NotFoundf("secret revision %d", revisionId)
+	return nil, fmt.Errorf("secret revision %s not found%w", revisionId, errors.Hide(secreterrors.SecretRevisionNotFound))
 }
 
 // DeleteContent implements SecretsBackend.
 func (k jujuBackend) DeleteContent(ctx context.Context, revisionId string) error {
-	return errors.NotFoundf("secret revision %d", revisionId)
+	return fmt.Errorf("secret revision %s not found%w", revisionId, errors.Hide(secreterrors.SecretRevisionNotFound))
 }
 
 // SaveContent implements SecretsBackend.

--- a/internal/secrets/provider/juju/provider.go
+++ b/internal/secrets/provider/juju/provider.go
@@ -6,8 +6,7 @@ package juju
 import (
 	"context"
 
-	"github.com/juju/names/v5"
-
+	"github.com/juju/juju/core/secrets"
 	"github.com/juju/juju/internal/secrets/provider"
 )
 
@@ -41,20 +40,15 @@ func (p jujuProvider) CleanupModel(*provider.ModelBackendConfig) error {
 }
 
 // CleanupSecrets is not used.
-func (p jujuProvider) CleanupSecrets(ctx context.Context, cfg *provider.ModelBackendConfig, tag names.Tag, removed provider.SecretRevisions) error {
+func (p jujuProvider) CleanupSecrets(_ context.Context, _ *provider.ModelBackendConfig, _ *secrets.URI, _ provider.SecretRevisions) error {
 	return nil
-}
-
-// BuiltInConfig returns a minimal config for the Juju backend.
-func BuiltInConfig() provider.BackendConfig {
-	return provider.BackendConfig{BackendType: BackendType}
 }
 
 // RestrictedConfig returns the config needed to create a
 // secrets backend client restricted to manage the specified
 // owned secrets and read shared secrets for the given entity tag.
 func (p jujuProvider) RestrictedConfig(
-	ctx context.Context, adminCfg *provider.ModelBackendConfig, sameController, forDrain bool, tag names.Tag, owned provider.SecretRevisions, read provider.SecretRevisions,
+	_ context.Context, _ *provider.ModelBackendConfig, _, _ bool, _ secrets.Accessor, _ provider.SecretRevisions, _ provider.SecretRevisions,
 ) (*provider.BackendConfig, error) {
 	return &provider.BackendConfig{
 		BackendType: BackendType,
@@ -63,6 +57,6 @@ func (p jujuProvider) RestrictedConfig(
 
 // NewBackend returns a nil backend since the Juju backend saves
 // secret content to the Juju database.
-func (jujuProvider) NewBackend(*provider.ModelBackendConfig) (provider.SecretsBackend, error) {
+func (jujuProvider) NewBackend(_ *provider.ModelBackendConfig) (provider.SecretsBackend, error) {
 	return &jujuBackend{}, nil
 }

--- a/internal/secrets/provider/juju/provider.go
+++ b/internal/secrets/provider/juju/provider.go
@@ -40,7 +40,7 @@ func (p jujuProvider) CleanupModel(*provider.ModelBackendConfig) error {
 }
 
 // CleanupSecrets is not used.
-func (p jujuProvider) CleanupSecrets(_ context.Context, _ *provider.ModelBackendConfig, _ *secrets.URI, _ provider.SecretRevisions) error {
+func (p jujuProvider) CleanupSecrets(_ context.Context, _ *provider.ModelBackendConfig, _ string, _ provider.SecretRevisions) error {
 	return nil
 }
 

--- a/internal/secrets/provider/kubernetes/mocks/kubernetes_mocks.go
+++ b/internal/secrets/provider/kubernetes/mocks/kubernetes_mocks.go
@@ -85,20 +85,6 @@ func (mr *MockBrokerMockRecorder) GetJujuSecret(arg0, arg1 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetJujuSecret", reflect.TypeOf((*MockBroker)(nil).GetJujuSecret), arg0, arg1)
 }
 
-// RemoveSecretAccessToken mocks base method.
-func (m *MockBroker) RemoveSecretAccessToken(arg0 context.Context, arg1 *secrets.URI) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RemoveSecretAccessToken", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// RemoveSecretAccessToken indicates an expected call of RemoveSecretAccessToken.
-func (mr *MockBrokerMockRecorder) RemoveSecretAccessToken(arg0, arg1 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveSecretAccessToken", reflect.TypeOf((*MockBroker)(nil).RemoveSecretAccessToken), arg0, arg1)
-}
-
 // SaveJujuSecret mocks base method.
 func (m *MockBroker) SaveJujuSecret(arg0 context.Context, arg1 string, arg2 secrets.SecretValue) (string, error) {
 	m.ctrl.T.Helper()

--- a/internal/secrets/provider/kubernetes/mocks/kubernetes_mocks.go
+++ b/internal/secrets/provider/kubernetes/mocks/kubernetes_mocks.go
@@ -14,7 +14,6 @@ import (
 	reflect "reflect"
 
 	secrets "github.com/juju/juju/core/secrets"
-	names "github.com/juju/names/v5"
 	version "github.com/juju/version/v2"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -57,7 +56,7 @@ func (mr *MockBrokerMockRecorder) DeleteJujuSecret(arg0, arg1 any) *gomock.Call 
 }
 
 // EnsureSecretAccessToken mocks base method.
-func (m *MockBroker) EnsureSecretAccessToken(arg0 context.Context, arg1 names.Tag, arg2, arg3, arg4 []string) (string, error) {
+func (m *MockBroker) EnsureSecretAccessToken(arg0 context.Context, arg1 string, arg2, arg3, arg4 []string) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EnsureSecretAccessToken", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(string)
@@ -87,7 +86,7 @@ func (mr *MockBrokerMockRecorder) GetJujuSecret(arg0, arg1 any) *gomock.Call {
 }
 
 // RemoveSecretAccessToken mocks base method.
-func (m *MockBroker) RemoveSecretAccessToken(arg0 context.Context, arg1 names.Tag) error {
+func (m *MockBroker) RemoveSecretAccessToken(arg0 context.Context, arg1 *secrets.URI) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveSecretAccessToken", arg0, arg1)
 	ret0, _ := ret[0].(error)

--- a/internal/secrets/provider/kubernetes/provider.go
+++ b/internal/secrets/provider/kubernetes/provider.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"strings"
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo/v2"
@@ -79,7 +78,7 @@ func (p k8sProvider) getBroker(cfg *provider.ModelBackendConfig) (Broker, clouds
 }
 
 // CleanupSecrets removes rules of the role associated with the removed secrets.
-func (p k8sProvider) CleanupSecrets(ctx context.Context, cfg *provider.ModelBackendConfig, uri *coresecrets.URI, removed provider.SecretRevisions) error {
+func (p k8sProvider) CleanupSecrets(ctx context.Context, cfg *provider.ModelBackendConfig, unitName string, removed provider.SecretRevisions) error {
 	if len(removed) == 0 {
 		return nil
 	}
@@ -87,7 +86,7 @@ func (p k8sProvider) CleanupSecrets(ctx context.Context, cfg *provider.ModelBack
 	if err != nil {
 		return errors.Trace(err)
 	}
-	err = broker.RemoveSecretAccessToken(ctx, uri)
+	_, err = broker.EnsureSecretAccessToken(ctx, unitName, nil, nil, removed.RevisionIDs())
 	return errors.Trace(err)
 }
 
@@ -116,11 +115,6 @@ func BuiltInConfig(cloudSpec cloudspec.CloudSpec) (*provider.BackendConfig, erro
 // BuiltInName returns the backend name for the k8s in-model backend.
 func BuiltInName(modelName string) string {
 	return modelName + "-local"
-}
-
-// IsBuiltInName returns true of the backend name is the built-in one.
-func IsBuiltInName(backendName string) bool {
-	return strings.HasSuffix(backendName, "-local")
 }
 
 // RestrictedConfig returns the config needed to create a

--- a/internal/secrets/provider/kubernetes/provider_test.go
+++ b/internal/secrets/provider/kubernetes/provider_test.go
@@ -127,14 +127,13 @@ func (s *providerSuite) TestCleanupSecrets(c *gc.C) {
 		},
 	}
 
-	uri := secrets.NewURI()
 	gomock.InOrder(
-		broker.EXPECT().RemoveSecretAccessToken(
-			gomock.Any(), uri,
-		).Return(nil),
+		broker.EXPECT().EnsureSecretAccessToken(
+			gomock.Any(), "gitlab/0", nil, nil, []string{"rev-1", "rev-2"},
+		).Return("token", nil),
 	)
 
-	err = p.CleanupSecrets(context.Background(), adminCfg, uri, provider.SecretRevisions{"removed": set.NewStrings("rev-1", "rev-2")})
+	err = p.CleanupSecrets(context.Background(), adminCfg, "gitlab/0", provider.SecretRevisions{"removed": set.NewStrings("rev-1", "rev-2")})
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/internal/secrets/provider/provider.go
+++ b/internal/secrets/provider/provider.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/juju/collections/set"
-	"github.com/juju/names/v5"
 	"github.com/juju/schema"
 	"gopkg.in/juju/environschema.v1"
 
@@ -75,7 +74,7 @@ type SecretBackendProvider interface {
 
 	// CleanupSecrets removes any ACLs / resources associated
 	// with the removed secrets.
-	CleanupSecrets(ctx context.Context, cfg *ModelBackendConfig, tag names.Tag, removed SecretRevisions) error
+	CleanupSecrets(ctx context.Context, cfg *ModelBackendConfig, uri *secrets.URI, removed SecretRevisions) error
 
 	// CleanupModel removes any secrets / ACLs / resources
 	// associated with the model config.
@@ -84,7 +83,7 @@ type SecretBackendProvider interface {
 	// RestrictedConfig returns the config needed to create a
 	// secrets backend client restricted to manage the specified
 	// owned secrets and read shared secrets for the given entity tag.
-	RestrictedConfig(ctx context.Context, adminCfg *ModelBackendConfig, sameController, forDrain bool, tag names.Tag, owned SecretRevisions, read SecretRevisions) (*BackendConfig, error)
+	RestrictedConfig(ctx context.Context, adminCfg *ModelBackendConfig, sameController, forDrain bool, accessor secrets.Accessor, owned SecretRevisions, read SecretRevisions) (*BackendConfig, error)
 
 	// NewBackend creates a secrets backend client using the
 	// specified model config.

--- a/internal/secrets/provider/provider.go
+++ b/internal/secrets/provider/provider.go
@@ -74,7 +74,7 @@ type SecretBackendProvider interface {
 
 	// CleanupSecrets removes any ACLs / resources associated
 	// with the removed secrets.
-	CleanupSecrets(ctx context.Context, cfg *ModelBackendConfig, uri *secrets.URI, removed SecretRevisions) error
+	CleanupSecrets(ctx context.Context, cfg *ModelBackendConfig, unitName string, removed SecretRevisions) error
 
 	// CleanupModel removes any secrets / ACLs / resources
 	// associated with the model config.

--- a/internal/secrets/provider/vault/provider.go
+++ b/internal/secrets/provider/vault/provider.go
@@ -13,9 +13,9 @@ import (
 	"github.com/hashicorp/vault/api"
 	"github.com/juju/errors"
 	"github.com/juju/loggo/v2"
-	"github.com/juju/names/v5"
 	vault "github.com/mittwald/vaultgo"
 
+	"github.com/juju/juju/core/secrets"
 	"github.com/juju/juju/internal/secrets/provider"
 )
 
@@ -140,7 +140,7 @@ func (p vaultProvider) CleanupModel(cfg *provider.ModelBackendConfig) (err error
 }
 
 // CleanupSecrets removes policies associated with the removed secrets.
-func (p vaultProvider) CleanupSecrets(ctx context.Context, cfg *provider.ModelBackendConfig, tag names.Tag, removed provider.SecretRevisions) error {
+func (p vaultProvider) CleanupSecrets(ctx context.Context, cfg *provider.ModelBackendConfig, _ *secrets.URI, removed provider.SecretRevisions) error {
 	modelPath := modelPathPrefix(cfg.ModelName, cfg.ModelUUID)
 	client, err := p.newBackend(modelPath, &cfg.BackendConfig)
 	if err != nil {
@@ -180,11 +180,11 @@ func (p vaultProvider) CleanupSecrets(ctx context.Context, cfg *provider.ModelBa
 
 // RestrictedConfig returns the config needed to create a
 // secrets backend client restricted to manage the specified
-// owned secrets and read shared secrets for the given entity tag.
+// owned secrets and read shared secrets for the given accessor.
 func (p vaultProvider) RestrictedConfig(
-	ctx context.Context, adminCfg *provider.ModelBackendConfig, sameController, forDrain bool, tag names.Tag, owned provider.SecretRevisions, read provider.SecretRevisions,
+	ctx context.Context, adminCfg *provider.ModelBackendConfig, _, forDrain bool, accessor secrets.Accessor, owned provider.SecretRevisions, read provider.SecretRevisions,
 ) (*provider.BackendConfig, error) {
-	adminUser := tag == nil
+	adminUser := accessor.Kind == secrets.ModelAccessor
 	// Get an admin backend client so we can set up the policies.
 	mountPath := modelPathPrefix(adminCfg.ModelName, adminCfg.ModelUUID)
 	backend, err := p.newBackend(mountPath, &adminCfg.BackendConfig)

--- a/internal/secrets/provider/vault/provider.go
+++ b/internal/secrets/provider/vault/provider.go
@@ -140,7 +140,7 @@ func (p vaultProvider) CleanupModel(cfg *provider.ModelBackendConfig) (err error
 }
 
 // CleanupSecrets removes policies associated with the removed secrets.
-func (p vaultProvider) CleanupSecrets(ctx context.Context, cfg *provider.ModelBackendConfig, _ *secrets.URI, removed provider.SecretRevisions) error {
+func (p vaultProvider) CleanupSecrets(ctx context.Context, cfg *provider.ModelBackendConfig, _ string, removed provider.SecretRevisions) error {
 	modelPath := modelPathPrefix(cfg.ModelName, cfg.ModelUUID)
 	client, err := p.newBackend(modelPath, &cfg.BackendConfig)
 	if err != nil {

--- a/internal/secrets/provider/vault/provider_test.go
+++ b/internal/secrets/provider/vault/provider_test.go
@@ -12,13 +12,13 @@ import (
 	"github.com/hashicorp/vault/api"
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
-	"github.com/juju/names/v5"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	vault "github.com/mittwald/vaultgo"
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/core/secrets"
 	"github.com/juju/juju/internal/secrets/provider"
 	_ "github.com/juju/juju/internal/secrets/provider/all"
 	jujuvault "github.com/juju/juju/internal/secrets/provider/vault"
@@ -102,7 +102,12 @@ func (s *providerSuite) TestBackendConfigBadClient(c *gc.C) {
 			},
 		},
 	}
-	_, err = p.RestrictedConfig(context.Background(), adminCfg, true, false, nil, nil, nil)
+
+	accessor := secrets.Accessor{
+		Kind: secrets.UnitAccessor,
+		ID:   "gitlab/0",
+	}
+	_, err = p.RestrictedConfig(context.Background(), adminCfg, true, false, accessor, nil, nil)
 	c.Assert(err, gc.ErrorMatches, "boom")
 }
 
@@ -152,7 +157,12 @@ func (s *providerSuite) TestBackendConfigAdmin(c *gc.C) {
 			},
 		},
 	}
-	cfg, err := p.RestrictedConfig(context.Background(), adminCfg, true, false, nil, nil, nil)
+
+	accessor := secrets.Accessor{
+		Kind: secrets.ModelAccessor,
+		ID:   coretesting.ModelTag.Id(),
+	}
+	cfg, err := p.RestrictedConfig(context.Background(), adminCfg, true, false, accessor, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cfg.Config["token"], gc.Equals, "foo")
 }
@@ -227,7 +237,12 @@ func (s *providerSuite) TestBackendConfigNonAdmin(c *gc.C) {
 	readRevs := map[string]set.Strings{
 		"read-1": set.NewStrings("read-rev-1"),
 	}
-	cfg, err := p.RestrictedConfig(context.Background(), adminCfg, true, false, names.NewUnitTag("ubuntu/0"), ownedRevs, readRevs)
+
+	accessor := secrets.Accessor{
+		Kind: secrets.UnitAccessor,
+		ID:   "ubuntu/0",
+	}
+	cfg, err := p.RestrictedConfig(context.Background(), adminCfg, true, false, accessor, ownedRevs, readRevs)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cfg.Config["token"], gc.Equals, "foo")
 }
@@ -312,7 +327,12 @@ func (s *providerSuite) TestBackendConfigForDrain(c *gc.C) {
 	readRevs := map[string]set.Strings{
 		"read-1": set.NewStrings("read-rev-1"),
 	}
-	cfg, err := p.RestrictedConfig(context.Background(), adminCfg, true, true, names.NewUnitTag("ubuntu/0"), ownedRevs, readRevs)
+
+	accessor := secrets.Accessor{
+		Kind: secrets.UnitAccessor,
+		ID:   "gitlab/0",
+	}
+	cfg, err := p.RestrictedConfig(context.Background(), adminCfg, true, true, accessor, ownedRevs, readRevs)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cfg.Config["token"], gc.Equals, "foo")
 }

--- a/internal/worker/providertracker/caas_mock_test.go
+++ b/internal/worker/providertracker/caas_mock_test.go
@@ -250,7 +250,7 @@ func (mr *MockBrokerMockRecorder) EnsureModelOperator(arg0, arg1, arg2, arg3 any
 }
 
 // EnsureSecretAccessToken mocks base method.
-func (m *MockBroker) EnsureSecretAccessToken(arg0 context.Context, arg1 names.Tag, arg2, arg3, arg4 []string) (string, error) {
+func (m *MockBroker) EnsureSecretAccessToken(arg0 context.Context, arg1 string, arg2, arg3, arg4 []string) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EnsureSecretAccessToken", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(string)
@@ -397,7 +397,7 @@ func (mr *MockBrokerMockRecorder) ProxyToApplication(arg0, arg1, arg2 any) *gomo
 }
 
 // RemoveSecretAccessToken mocks base method.
-func (m *MockBroker) RemoveSecretAccessToken(arg0 context.Context, arg1 names.Tag) error {
+func (m *MockBroker) RemoveSecretAccessToken(arg0 context.Context, arg1 *secrets.URI) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveSecretAccessToken", arg0, arg1)
 	ret0, _ := ret[0].(error)

--- a/internal/worker/providertracker/caas_mock_test.go
+++ b/internal/worker/providertracker/caas_mock_test.go
@@ -396,20 +396,6 @@ func (mr *MockBrokerMockRecorder) ProxyToApplication(arg0, arg1, arg2 any) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProxyToApplication", reflect.TypeOf((*MockBroker)(nil).ProxyToApplication), arg0, arg1, arg2)
 }
 
-// RemoveSecretAccessToken mocks base method.
-func (m *MockBroker) RemoveSecretAccessToken(arg0 context.Context, arg1 *secrets.URI) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RemoveSecretAccessToken", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// RemoveSecretAccessToken indicates an expected call of RemoveSecretAccessToken.
-func (mr *MockBrokerMockRecorder) RemoveSecretAccessToken(arg0, arg1 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveSecretAccessToken", reflect.TypeOf((*MockBroker)(nil).RemoveSecretAccessToken), arg0, arg1)
-}
-
 // SaveJujuSecret mocks base method.
 func (m *MockBroker) SaveJujuSecret(arg0 context.Context, arg1 string, arg2 secrets.SecretValue) (string, error) {
 	m.ctrl.T.Helper()

--- a/internal/worker/uniter/runner/context/context.go
+++ b/internal/worker/uniter/runner/context/context.go
@@ -29,6 +29,7 @@ import (
 	coresecrets "github.com/juju/juju/core/secrets"
 	"github.com/juju/juju/core/status"
 	coretrace "github.com/juju/juju/core/trace"
+	secreterrors "github.com/juju/juju/domain/secret/errors"
 	"github.com/juju/juju/internal/storage"
 	"github.com/juju/juju/internal/worker/common/charmrunner"
 	"github.com/juju/juju/internal/worker/uniter/api"
@@ -1572,7 +1573,7 @@ func (c *HookContext) doFlush(process string) error {
 		c.logger.Debugf("deleting secret %q provider ids: %v", d.URI.ID, toDelete)
 		for _, rev := range toDelete {
 			if err := secretsBackend.DeleteContent(d.URI, rev); err != nil {
-				if errors.Is(err, errors.NotFound) {
+				if errors.Is(err, secreterrors.SecretRevisionNotFound) {
 					continue
 				}
 				return errors.Annotatef(err, "cannot delete secret %q revision %d from backend: %v", d.URI.ID, rev, err)

--- a/rpc/params/apierror.go
+++ b/rpc/params/apierror.go
@@ -153,6 +153,7 @@ const (
 	CodeUserNotFound               = "user not found"
 	CodeModelNotFound              = "model not found"
 	CodeSecretNotFound             = "secret not found"
+	CodeSecretRevisionNotFound     = "secret revision not found"
 	CodeSecretBackendNotFound      = "secret backend not found"
 	CodeSecretConsumerNotFound     = "secret consumer not found"
 	CodeUnauthorized               = "unauthorized access"
@@ -219,6 +220,8 @@ func TranslateWellKnownError(err error) error {
 		return errors.NewUserNotFound(err, "")
 	case CodeSecretNotFound:
 		return fmt.Errorf("%s%w", err.Error(), errors.Hide(secreterrors.SecretNotFound))
+	case CodeSecretRevisionNotFound:
+		return fmt.Errorf("%s%w", err.Error(), errors.Hide(secreterrors.SecretRevisionNotFound))
 	case CodeSecretConsumerNotFound:
 		return fmt.Errorf("%s%w", err.Error(), errors.Hide(secreterrors.SecretConsumerNotFound))
 	case CodeSecretBackendNotFound:
@@ -292,6 +295,10 @@ func IsCodeModelNotFound(err error) bool {
 
 func IsCodeSecretNotFound(err error) bool {
 	return ErrCode(err) == CodeSecretNotFound
+}
+
+func IsCodeSecretRevisionNotFound(err error) bool {
+	return ErrCode(err) == CodeSecretRevisionNotFound
 }
 
 func IsCodeSecretConsumerNotFound(err error) bool {

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -81,6 +81,9 @@ bootstrap() {
 	"azure")
 		cloud="azure"
 		;;
+	"microk8s")
+		cloud="microk8s"
+		;;
 	"localhost" | "lxd")
 		cloud="localhost"
 		;;
@@ -505,7 +508,7 @@ introspect_controller() {
 
 	name=${1}
 
-	if [[ ${BOOTSTRAP_PROVIDER} == "k8s" ]]; then
+	if [[ ${BOOTSTRAP_PROVIDER} == "k8s" || ${BOOTSTRAP_PROVIDER} == "microk8s" ]]; then
 		echo "====> TODO: Implement introspection for k8s"
 		return
 	fi

--- a/tests/suites/secrets_iaas/cmr.sh
+++ b/tests/suites/secrets_iaas/cmr.sh
@@ -48,7 +48,7 @@ run_secrets_cmr() {
 	juju switch "model-secrets-offer"
 	juju suspend-relation "$relation_id"
 	juju switch "model-secrets-consume"
-	check_contains "$(juju exec --unit dummy-sink/0 -- secret-get "$secret_uri" 2>&1)" 'permission denied'
+	check_contains "$(juju exec --unit dummy-sink/0 -- secret-get "$secret_uri" 2>&1)" 'is not allowed to read this secret'
 	echo "Checking: resume relation and access is restored"
 	juju switch "model-secrets-offer"
 	juju resume-relation "$relation_id"
@@ -59,7 +59,7 @@ run_secrets_cmr() {
 	juju switch "model-secrets-offer"
 	juju exec --unit dummy-source/0 -- secret-revoke "$secret_uri" --relation "$relation_id"
 	juju switch "model-secrets-consume"
-	check_contains "$(juju exec --unit dummy-sink/0 -- secret-get "$secret_uri" 2>&1)" 'permission denied'
+	check_contains "$(juju exec --unit dummy-sink/0 -- secret-get "$secret_uri" 2>&1)" 'is not allowed to read this secret'
 }
 
 test_secrets_cmr() {

--- a/tests/suites/secrets_iaas/juju.sh
+++ b/tests/suites/secrets_iaas/juju.sh
@@ -53,11 +53,11 @@ check_secrets() {
 
 	echo "Checking: secret-revoke by relation ID"
 	juju exec --unit easyrsa/0 -- secret-revoke "$secret_owned_by_easyrsa" --relation "$relation_id"
-	check_contains "$(juju exec --unit etcd/0 -- secret-get "$secret_owned_by_easyrsa" 2>&1)" 'permission denied'
+	check_contains "$(juju exec --unit etcd/0 -- secret-get "$secret_owned_by_easyrsa" 2>&1)" 'is not allowed to read this secret'
 
 	echo "Checking: secret-revoke by app name"
 	juju exec --unit easyrsa/0 -- secret-revoke "$secret_owned_by_easyrsa_0" --app etcd
-	check_contains "$(juju exec --unit etcd/0 -- secret-get "$secret_owned_by_easyrsa_0" 2>&1)" 'permission denied'
+	check_contains "$(juju exec --unit etcd/0 -- secret-get "$secret_owned_by_easyrsa_0" 2>&1)" 'is not allowed to read this secret'
 
 	echo "Checking: secret-remove"
 	juju exec --unit easyrsa/0 -- secret-remove "$secret_owned_by_easyrsa_0"
@@ -85,7 +85,7 @@ run_user_secrets() {
 	check_contains "$(juju --show-log show-secret "$secret_uri" --revisions | yq ".${secret_short_uri}.description")" 'info'
 
 	# grant secret to the app, and now the application can access the revision 2.
-	check_contains "$(juju exec --unit "$app_name"/0 -- secret-get "$secret_uri" 2>&1)" 'permission denied'
+	check_contains "$(juju exec --unit "$app_name"/0 -- secret-get "$secret_uri" 2>&1)" 'is not allowed to read this secret'
 	juju --show-log grant-secret mysecret "$app_name"
 	check_contains "$(juju exec --unit "$app_name/0" -- secret-get $secret_short_uri)" "owned-by: $model_name-2"
 
@@ -121,7 +121,7 @@ run_user_secrets() {
 	check_contains "$(juju --show-log show-secret $secret_uri --reveal --revision 3 | yq .${secret_short_uri}.content)" "owned-by: $model_name-3"
 
 	juju --show-log revoke-secret mysecret "$app_name"
-	check_contains "$(juju exec --unit "$app_name"/0 -- secret-get "$secret_uri" 2>&1)" 'permission denied'
+	check_contains "$(juju exec --unit "$app_name"/0 -- secret-get "$secret_uri" 2>&1)" 'is not allowed to read this secret'
 
 	juju --show-log remove-secret mysecret
 	check_contains "$(juju --show-log secrets --format yaml | yq length)" '0'


### PR DESCRIPTION
This PR wires up the remaining external secrets functionality.
There's a few changes, primarily:
- simplify external secret delete logic in service
- implement new GetGrantedSecretsForBackend method
- remove tags from service
- address issues with secret cleanup

When consuming external secrets, a restricted config is used. To get this config, we need to know what secrets have read access, what secrets can be managed by the caller. We used to list owned secrets and then get granted secrets. But things are now simplified by adopting a common approach of getting secrets by role assignment (view or manage). A new service method GetGrantedSecretsForBackend runs a bespoke query to get the required info. This allows client side filtering to all be shifted to SQL.

For deletion, logic was simplified and generic not found errors replaced with revision not found.

A few ci test script changes also - we don't want to run a microk8s enable command which needs sudo - this should be done as part of microk8s setup. Also, the tests can now target microk8s directly.

## QA steps

`./main.sh -v -p microk8s -s test_user_secrets,test_secret_drain,test_user_secret_drain secrets_k8s`

## Links

**Jira card:** [JUJU-5899](https://warthogs.atlassian.net/browse/JUJU-5899)



[JUJU-5899]: https://warthogs.atlassian.net/browse/JUJU-5899?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ