### PR TITLE
Replace BOOTSTRAP_SERIES with BOOTSTRAP_BASE in tests

### DIFF
--- a/tests/ENV.md
+++ b/tests/ENV.md
@@ -10,7 +10,7 @@ definitive source is the code.
 | `BOOTSTRAP_PROVIDER`         | The provider to use when bootstrapping (see the `provider` package).               |
 | `BOOTSTRAP_REUSE`            | Reuse an existing controller when asked to bootstrap (true/false).                 |
 | `BOOTSTRAP_REUSE_LOCAL`      | The name of a local controller to reuse for testing. Set using the `-l` flag.      |
-| `BOOTSTRAP_SERIES`           | Series to use for the controller. Set using the `-S` flag.                         |
+| `BOOTSTRAP_BASE`             | Base to use for the controller. Set using the `-B` flag.                           |
 | `CONTROLLER_CHARM_CHANNEL`   | The channel to pull the controller charm from (CaaS only).                         |
 | `CONTROLLER_CHARM_PATH_CAAS` | The Charmhub charm name to pull the controller charm from (CaaS only).             |
 | `CONTROLLER_CHARM_PATH_IAAS` | Path to a locally built controller charm to use (IaaS only).                       |

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -7,13 +7,13 @@ export BOOTSTRAP_REUSE_LOCAL="${BOOTSTRAP_REUSE_LOCAL:-}"
 export BOOTSTRAP_REUSE="${BOOTSTRAP_REUSE:-false}"
 export BOOTSTRAP_PROVIDER="${BOOTSTRAP_PROVIDER:-lxd}"
 export BOOTSTRAP_CLOUD="${BOOTSTRAP_CLOUD:-lxd}"
-export BOOTSTRAP_SERIES="${BOOTSTRAP_SERIES:-}"
+export BOOTSTRAP_BASE="${BOOTSTRAP_BASE:-}"
 export BOOTSTRAP_ARCH="${BOOTSTRAP_ARCH:-}"
 export BUILD_ARCH="${BUILD_ARCH:-}"
 export MODEL_ARCH="${MODEL_ARCH:-}"
 export BUILD_AGENT="${BUILD_AGENT:-false}"
 export RUN_SUBTEST="${RUN_SUBTEST:-}"
-export CURRENT_LTS="jammy"
+export CURRENT_LTS="ubuntu@22.04"
 
 current_pwd=$(pwd)
 export CURRENT_DIR="${current_pwd}"
@@ -125,7 +125,7 @@ show_help() {
 	echo "                                     openstack assumes providing image data directly is not required"
 	echo "    $(green './main.sh -c')        Cloud name to use when bootstrapping, must be one of provider types listed above"
 	echo "    $(green './main.sh -R')        Region to use with cloud"
-	echo "    $(green './main.sh -S')        Bootstrap series to use <default is host>, priority over -l"
+	echo "    $(green './main.sh -B')        Bootstrap base to use <default is host>, priority over -l"
 	echo ""
 	echo "Tests:"
 	echo "¯¯¯¯¯¯"
@@ -160,7 +160,7 @@ show_help() {
 	exit 1
 }
 
-while getopts "hH?vAs:a:x:rl:p:c:R:S:" opt; do
+while getopts "hH?vAs:a:x:rl:p:c:R:B:" opt; do
 	case "${opt}" in
 	h | \?)
 		show_help
@@ -216,8 +216,8 @@ while getopts "hH?vAs:a:x:rl:p:c:R:S:" opt; do
 	R)
 		export BOOTSTRAP_REGION="${OPTARG}"
 		;;
-	S)
-		export BOOTSTRAP_SERIES="${OPTARG}"
+	B)
+		export BOOTSTRAP_BASE="${OPTARG}"
 		;;
 	*)
 		echo "Unexpected argument ${opt}" >&2

--- a/tests/suites/bootstrap/streams.sh
+++ b/tests/suites/bootstrap/streams.sh
@@ -33,7 +33,7 @@ run_simplestream_metadata() {
 		--config agent-metadata-url="http://${server_address}:8666/" \
 		--config test-mode=true \
 		--add-model=default \
-		--bootstrap-series="${BOOTSTRAP_SERIES}" \
+		--bootstrap-base="${BOOTSTRAP_BASE}" \
 		--agent-version="${JUJUD_VERSION}" 2>&1 | OUTPUT "${file}"
 	echo "${name}" >>"${TEST_DIR}/jujus"
 

--- a/tests/suites/manual/deploy_manual_aws.sh
+++ b/tests/suites/manual/deploy_manual_aws.sh
@@ -54,7 +54,7 @@ run_deploy_manual_aws() {
 
 	add_clean_func "run_cleanup_deploy_manual_aws"
 
-	# Eventually we should use BOOTSTRAP_SERIES
+	# Eventually we should use BOOTSTRAP_BASE.
 	series="jammy"
 
 	# This creates a new VPC for this deployment. If one already exists it will

--- a/tests/suites/manual/spaces.sh
+++ b/tests/suites/manual/spaces.sh
@@ -35,7 +35,7 @@ run_spaces_manual_aws() {
 
 	add_clean_func "run_cleanup_deploy_manual_aws"
 
-	# Eventually we should use BOOTSTRAP_SERIES.
+	# Eventually we should use BOOTSTRAP_BASE.
 	series="jammy"
 
 	echo "==> Configuring aws"

--- a/tests/suites/ovs_maas/task.sh
+++ b/tests/suites/ovs_maas/task.sh
@@ -12,7 +12,7 @@ test_ovs_maas() {
 	file="${TEST_DIR}/test-ovs-maas.log"
 
 	# shellcheck disable=SC2140
-	export BOOTSTRAP_ADDITIONAL_ARGS="${BOOTSTRAP_ADDITIONAL_ARGS:-} --bootstrap-series=jammy --bootstrap-constraints="tags=ovs""
+	export BOOTSTRAP_ADDITIONAL_ARGS="${BOOTSTRAP_ADDITIONAL_ARGS:-} --bootstrap-base=ubuntu@22.04 --bootstrap-constraints="tags=ovs""
 	bootstrap "test-ovs-maas" "${file}"
 
 	test_ovs_netplan_config

--- a/tests/suites/upgrade/streams.sh
+++ b/tests/suites/upgrade/streams.sh
@@ -77,7 +77,7 @@ exec_simplestream_metadata() {
 	${bootstrap_juju_client} bootstrap "lxd" "${name}" \
 		--show-log \
 		--agent-version="${stable_version}" \
-		--bootstrap-series="${BOOTSTRAP_SERIES}" \
+		--bootstrap-base="${BOOTSTRAP_BASE}" \
 		--config agent-metadata-url="http://${server_address}:8666/" 2>&1 | OUTPUT "${file}"
 	echo "${name}" >>"${TEST_DIR}/jujus"
 


### PR DESCRIPTION
We recently removed --bootstrap-series option from bootstrapping. However, we still make use of this flag in many tests.

Switch this flag out for --bootstrap-base and replace the corresponding envvar BOOTSTRAP_SERIES with BOOTSTRAP_BASE.

Also, swap out the ./main.sh flag -S for -B. In all the places it counts we insert options directly using envvars so this won't be a compatibility problem for our integration tests.

We also need to fix controller reuse, which still checks against show-machine series, an attribute which doesn't exist in 4.0.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

### Verify `bootstrap` test pass

NOTE: There is currently a bug with `juju bootstrap --add-model`. This is out of scope for this change. See the following LP bug:
https://bugs.launchpad.net/juju/+bug/2064107

So please apply the following diff before QA
```
diff --git a/tests/suites/bootstrap/streams.sh b/tests/suites/bootstrap/streams.sh
index 204c52ef24..ba00ec65a3 100644
--- a/tests/suites/bootstrap/streams.sh
+++ b/tests/suites/bootstrap/streams.sh
@@ -32,10 +32,10 @@ run_simplestream_metadata() {
                --show-log \
                --config agent-metadata-url="http://${server_address}:8666/" \
                --config test-mode=true \
-               --add-model=default \
                --bootstrap-base="${BOOTSTRAP_BASE}" \
                --agent-version="${JUJUD_VERSION}" 2>&1 | OUTPUT "${file}"
        echo "${name}" >>"${TEST_DIR}/jujus"
+       juju add-model default
 
        juju deploy jameinel-ubuntu-lite
        wait_for "ubuntu-lite" "$(idle_condition "ubuntu-lite")"
```

Run:
```
./main.sh -v bootstrap
```

### Verify `-B`

Run:
```
./main.sh -v -B ubuntu@22.04 unit
```

And during the test verify:
```
$ juju status -m controller
Model       Controller     Cloud/Region         Version      Timestamp
controller  ctrl-irof5ahf  localhost/localhost  4.0-beta3.1  11:56:21+01:00

App         Version  Status  Scale  Charm            Channel     Rev  Exposed  Message
controller           active      1  juju-controller  4.0/stable   91  no       

Unit           Workload  Agent      Machine  Public address  Ports  Message
controller/0*  active    executing  0        10.219.211.77          

Machine  State    Address        Inst id        Base          AZ  Message
0        started  10.219.211.77  juju-9ed0e8-0  ubuntu@20.04      Running
```

### Verify controller re-use

Bootstrap a controller with `juju bootstrap lxd contr --bootstrap-base ubuntu@22.04`.

Run:
```
$ BOOTSTRAP_REUSE="true" BOOTSTRAP_REUSE_LOCAL="contr" ./main.sh -v -B ubuntu@20.04 unit
...
====> Unable to reuse bootstrapped juju
...
```

And also run:
```
$ BOOTSTRAP_REUSE="true" BOOTSTRAP_REUSE_LOCAL="contr" ./main.sh -v -B ubuntu@22.04 unit 

==> Checking for dependencies
==> Using Juju located at /home/jack/.go/bin/juju
==> TEST BEGIN: test_unit (tmp.apf)
==> Checking for dependencies
====> Reusing bootstrapped juju (4.0-beta3:localhost)
```

(NOTE: there are some other unrelated issues with controller reuse, so these commands may not succeed)