### PR TITLE
Fixes `sqlair.Outcome` issue.

### DIFF
--- a/domain/access/state/user.go
+++ b/domain/access/state/user.go
@@ -748,16 +748,11 @@ WHERE      disabled = false`
 		return errors.Annotate(err, "preparing insert defineUserAuthentication query")
 	}
 
-	query := tx.Query(ctx, insertDefineUserAuthenticationStmt, sqlair.M{"name": name, "disabled": false})
-	err = query.Run()
+	var outcome sqlair.Outcome
+	err = tx.Query(ctx, insertDefineUserAuthenticationStmt, sqlair.M{"name": name, "disabled": false}).Get(&outcome)
 	if internaldatabase.IsErrConstraintForeignKey(err) {
 		return errors.Annotatef(accesserrors.UserNotFound, "%q", name)
 	} else if err != nil {
-		return errors.Annotatef(err, "setting authentication for user %q", name)
-	}
-
-	outcome := sqlair.Outcome{}
-	if err := query.Get(&outcome); err != nil {
 		return errors.Annotatef(err, "setting authentication for user %q", name)
 	}
 


### PR DESCRIPTION
This PR provider fix for usage of `sqlair.Outcome`.

For SQLair, you should do `.Get(&outcome)` and only use the query once, it has the same effect as `.Run`. Rather than doing both.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```
go test github.com/juju/juju/domain/access/state/... -gocheck.v
```

## Links

**Jira card:** [JUJU-5965](https://warthogs.atlassian.net/browse/JUJU-5965)



[JUJU-5965]: https://warthogs.atlassian.net/browse/JUJU-5965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ