### PR TITLE
Add 24.04 to list of expected ubuntu versions

### DIFF
--- a/apiserver/facades/client/modelupgrader/upgrader_test.go
+++ b/apiserver/facades/client/modelupgrader/upgrader_test.go
@@ -65,6 +65,7 @@ var ubuntuVersions = []string{
 	"22.10",
 	"23.04",
 	"23.10",
+	"24.04",
 }
 
 var controllerCfg = controller.Config{


### PR DESCRIPTION
Add 24.04 to the tests in the model upgrader tests.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc

## QA steps
go test ./apiserver/facades/client/modelupgrader/...

This does not work on my machine because it currently does not find 24.04 on it, but it should pass in the CI.
