### PR TITLE
Drop support for series in RefreshBase

### DIFF
--- a/charmhub/refresh.go
+++ b/charmhub/refresh.go
@@ -420,16 +420,10 @@ func constructRefreshBase(base RefreshBase) (transport.Base, error) {
 		name = b.OS
 		channel = b.Channel.Track
 	default:
-		// If we have a series, we need to convert it to a stable version.
-		// If we have a version, then just pass that through.
-		potential, err := corebase.SeriesVersion(base.Channel)
-		if err == nil {
-			channel = potential
-		} else {
-			channel, err = sanitiseChannel(base.Channel)
-			if err != nil {
-				return transport.Base{}, logAndReturnError(errors.Trace(err))
-			}
+		var err error
+		channel, err = sanitiseChannel(base.Channel)
+		if err != nil {
+			return transport.Base{}, logAndReturnError(errors.Trace(err))
 		}
 	}
 

--- a/charmhub/refresh_test.go
+++ b/charmhub/refresh_test.go
@@ -978,7 +978,7 @@ func (s *RefreshConfigSuite) TestRefreshManyBuild(c *gc.C) {
 	name3 := "baz"
 	config3, err := InstallOneFromChannel(name3, "1/stable", RefreshBase{
 		Name:         "ubuntu",
-		Channel:      "disco",
+		Channel:      "19.04",
 		Architecture: arch.DefaultArchitecture,
 	})
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
Up until now we supported constructing the RefreshBase type with a series in the channel. However, no where in the code base do we make use of this.

I checked every read and write to the Channel attribute and nowhere do we fill in what could be a series.

Since we're moving away from the series construct, drop suport for this.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

### Deploy some charms with different bases

```
$ juju deploy ubuntu
$ juju deploy ubuntu focal --base ubuntu@20.04
(wait)
$ juju status
Model  Controller  Cloud/Region         Version      SLA          Timestamp
m      lxd         localhost/localhost  3.6-beta1.1  unsupported  12:37:55+01:00

App     Version  Status  Scale  Charm   Channel        Rev  Exposed  Message
focal   20.04    active      1  ubuntu  latest/stable   24  no       
ubuntu  22.04    active      1  ubuntu  latest/stable   24  no       

Unit       Workload  Agent  Machine  Public address  Ports  Message
focal/0*   active    idle   1        10.219.211.70          
ubuntu/0*  active    idle   0        10.219.211.170         

Machine  State    Address         Inst id        Base          AZ  Message
0        started  10.219.211.170  juju-4dcf8d-0  ubuntu@22.04      Running
1        started  10.219.211.70   juju-4dcf8d-1  ubuntu@20.04      Running
```

### Refresh a charm

