### PR TITLE
Fix `SimpleConnector` to set `UserTag` when no client credentials provided

### DIFF
--- a/api/connector/package_test.go
+++ b/api/connector/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2020 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package connector
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/api/connector/simpleconnector.go
+++ b/api/connector/simpleconnector.go
@@ -51,9 +51,6 @@ func NewSimple(opts SimpleConfig, dialOptions ...api.DialOption) (*SimpleConnect
 		Addrs:    opts.ControllerAddresses,
 		CACert:   opts.CACert,
 		ModelTag: names.NewModelTag(opts.ModelUUID),
-
-		Password:  opts.Password,
-		Macaroons: opts.Macaroons,
 	}
 
 	isClientCredentialsProvided := opts.ClientID != "" && opts.ClientSecret != ""
@@ -64,6 +61,8 @@ func NewSimple(opts SimpleConfig, dialOptions ...api.DialOption) (*SimpleConnect
 	// In such cases, assigning a user tag to `info.Tag` will result in panic.
 	if !isClientCredentialsProvided {
 		info.Tag = names.NewUserTag(opts.Username)
+		info.Password = opts.Password
+		info.Macaroons = opts.Macaroons
 	}
 
 	if err := info.Validate(); err != nil {

--- a/api/connector/simpleconnector.go
+++ b/api/connector/simpleconnector.go
@@ -53,13 +53,11 @@ func NewSimple(opts SimpleConfig, dialOptions ...api.DialOption) (*SimpleConnect
 		ModelTag: names.NewModelTag(opts.ModelUUID),
 	}
 
-	isClientCredentialsProvided := opts.ClientID != "" && opts.ClientSecret != ""
-
 	// When the client intends to login via client credentials (like a service
 	// account) they leave `SimpleConfig.Username` empty and assign the client
 	// credentials to `SimpleConfig.ClientID` and `SimpleConfig.ClientSecret`.
 	// In such cases, assigning a user tag to `info.Tag` will result in panic.
-	if !isClientCredentialsProvided {
+	if opts.Username != "" {
 		info.Tag = names.NewUserTag(opts.Username)
 		info.Password = opts.Password
 		info.Macaroons = opts.Macaroons
@@ -70,7 +68,7 @@ func NewSimple(opts SimpleConfig, dialOptions ...api.DialOption) (*SimpleConnect
 	}
 
 	dialOpts := api.DefaultDialOpts()
-	if isClientCredentialsProvided {
+	if opts.Username == "" {
 		dialOpts.LoginProvider = api.NewClientCredentialsLoginProvider(
 			opts.ClientID,
 			opts.ClientSecret,

--- a/api/connector/simpleconnector.go
+++ b/api/connector/simpleconnector.go
@@ -55,17 +55,14 @@ func NewSimple(opts SimpleConfig, dialOptions ...api.DialOption) (*SimpleConnect
 	}
 
 	// When the client intends to login via client credentials (like a service
-	// account) they leave `SimpleConfig.Username` empty and assign the client
-	// credentials to `SimpleConfig.ClientID` and `SimpleConfig.ClientSecret`.
-	// To ensure that `info.Tag` is never empty, we should assign it with
-	// username or client ID, whichever is not empty.
+	// account) they leave `opts.Username` empty and assign the client
+	// credentials to `opts.ClientID` and `opts.ClientSecret`. In such cases,
+	// we shouldn't assign `info.Tag` with a user tag.
 	if opts.Username != "" {
 		info.Tag = names.NewUserTag(opts.Username)
 		info.Password = opts.Password
 		info.Macaroons = opts.Macaroons
-	} else if opts.ClientID != "" {
-		info.Tag = names.NewUserTag(opts.ClientID)
-	} else {
+	} else if opts.ClientID == "" {
 		return nil, errors.New("either Username or ClientID should be set")
 	}
 

--- a/api/connector/simpleconnector.go
+++ b/api/connector/simpleconnector.go
@@ -4,6 +4,7 @@
 package connector
 
 import (
+	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 	"gopkg.in/macaroon.v2"
 
@@ -47,6 +48,12 @@ var _ Connector = (*SimpleConnector)(nil)
 // connect according to the specified options.  If some options are invalid an
 // error is returned.
 func NewSimple(opts SimpleConfig, dialOptions ...api.DialOption) (*SimpleConnector, error) {
+	if opts.Username == "" && opts.ClientID == "" {
+		return nil, errors.New("one of Username or ClientID must be set")
+	} else if opts.Username != "" && opts.ClientID != "" {
+		return nil, errors.New("only one of Username or ClientID should be set")
+	}
+
 	info := api.Info{
 		Addrs:    opts.ControllerAddresses,
 		CACert:   opts.CACert,

--- a/api/connector/simpleconnector.go
+++ b/api/connector/simpleconnector.go
@@ -68,7 +68,7 @@ func NewSimple(opts SimpleConfig, dialOptions ...api.DialOption) (*SimpleConnect
 	}
 
 	dialOpts := api.DefaultDialOpts()
-	if opts.Username == "" {
+	if opts.ClientID != "" && opts.ClientSecret != "" {
 		dialOpts.LoginProvider = api.NewClientCredentialsLoginProvider(
 			opts.ClientID,
 			opts.ClientSecret,

--- a/api/connector/simpleconnector.go
+++ b/api/connector/simpleconnector.go
@@ -4,7 +4,6 @@
 package connector
 
 import (
-	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 	"gopkg.in/macaroon.v2"
 
@@ -62,8 +61,6 @@ func NewSimple(opts SimpleConfig, dialOptions ...api.DialOption) (*SimpleConnect
 		info.Tag = names.NewUserTag(opts.Username)
 		info.Password = opts.Password
 		info.Macaroons = opts.Macaroons
-	} else if opts.ClientID == "" {
-		return nil, errors.New("either Username or ClientID should be set")
 	}
 
 	if err := info.Validate(); err != nil {

--- a/api/connector/simpleconnector_test.go
+++ b/api/connector/simpleconnector_test.go
@@ -77,7 +77,7 @@ func (s *simpleConnectorSuite) TestNewSimpleRespectsClientCredentials(c *gc.C) {
 			},
 		},
 		{
-			name: "with neither username nre client id",
+			name: "with neither username nor client id",
 			opts: SimpleConfig{
 				ControllerAddresses: []string{"some.host:9999"},
 				ModelUUID:           "some-uuid",

--- a/api/connector/simpleconnector_test.go
+++ b/api/connector/simpleconnector_test.go
@@ -59,7 +59,7 @@ func (s *simpleConnectorSuite) TestNewSimpleRespectsClientCredentials(c *gc.C) {
 			},
 		},
 		{
-			name: "with username/password and client credentials; username/password takes over",
+			name: "with both username and client ID",
 			opts: SimpleConfig{
 				ControllerAddresses: []string{"some.host:9999"},
 				ModelUUID:           "some-uuid",
@@ -68,17 +68,15 @@ func (s *simpleConnectorSuite) TestNewSimpleRespectsClientCredentials(c *gc.C) {
 				ClientID:            "some-client-id",
 				ClientSecret:        "some-client-secret",
 			},
-			expectedAPIInfo: api.Info{
-				Addrs:    []string{"some.host:9999"},
-				ModelTag: names.NewModelTag("some-uuid"),
-				Tag:      names.NewUserTag("some-username"),
-				Password: "some-password",
+			expectedError: "only one of Username or ClientID should be set",
+		},
+		{
+			name: "with neither username nor client ID",
+			opts: SimpleConfig{
+				ControllerAddresses: []string{"some.host:9999"},
+				ModelUUID:           "some-uuid",
 			},
-			expectedDefaultDialOpts: func() api.DialOpts {
-				expected := api.DefaultDialOpts()
-				expected.LoginProvider = api.NewClientCredentialsLoginProvider("some-client-id", "some-client-secret")
-				return expected
-			},
+			expectedError: "one of Username or ClientID must be set",
 		},
 	}
 

--- a/api/connector/simpleconnector_test.go
+++ b/api/connector/simpleconnector_test.go
@@ -1,0 +1,101 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package connector
+
+import (
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/testing"
+	"github.com/juju/names/v5"
+	gc "gopkg.in/check.v1"
+)
+
+type simpleConnectorSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&simpleConnectorSuite{})
+
+func (s *simpleConnectorSuite) TestNewSimpleRespectsClientCredentials(c *gc.C) {
+	tests := []struct {
+		name                    string
+		opts                    SimpleConfig
+		expectedError           string
+		expectedAPIInfo         api.Info
+		expectedDefaultDialOpts func() api.DialOpts
+	}{
+		{
+			name: "with username/password",
+			opts: SimpleConfig{
+				ControllerAddresses: []string{"some.host:9999"},
+				ModelUUID:           "some-uuid",
+				Username:            "some-username",
+				Password:            "some-password",
+			},
+			expectedAPIInfo: api.Info{
+				Addrs:    []string{"some.host:9999"},
+				ModelTag: names.NewModelTag("some-uuid"),
+				Tag:      names.NewUserTag("some-username"),
+				Password: "some-password",
+			},
+		},
+		{
+			name: "with client credentials",
+			opts: SimpleConfig{
+				ControllerAddresses: []string{"some.host:9999"},
+				ModelUUID:           "some-uuid",
+				ClientID:            "some-client-id",
+				ClientSecret:        "some-client-secret",
+			},
+			expectedAPIInfo: api.Info{
+				Addrs:    []string{"some.host:9999"},
+				ModelTag: names.NewModelTag("some-uuid"),
+			},
+			expectedDefaultDialOpts: func() api.DialOpts {
+				expected := api.DefaultDialOpts()
+				expected.LoginProvider = api.NewClientCredentialsLoginProvider("some-client-id", "some-client-secret")
+				return expected
+			},
+		},
+		{
+			name: "with username/password and client credentials; client credentials should take over",
+			opts: SimpleConfig{
+				ControllerAddresses: []string{"some.host:9999"},
+				ModelUUID:           "some-uuid",
+				Username:            "some-username",
+				Password:            "some-password",
+				ClientID:            "some-client-id",
+				ClientSecret:        "some-client-secret",
+			},
+			expectedAPIInfo: api.Info{
+				Addrs:    []string{"some.host:9999"},
+				ModelTag: names.NewModelTag("some-uuid"),
+			},
+			expectedDefaultDialOpts: func() api.DialOpts {
+				expected := api.DefaultDialOpts()
+				expected.LoginProvider = api.NewClientCredentialsLoginProvider("some-client-id", "some-client-secret")
+				return expected
+			},
+		},
+	}
+
+	for _, test := range tests {
+		c.Logf("running test %s", test.name)
+
+		connector, err := NewSimple(test.opts)
+
+		if test.expectedError != "" {
+			c.Assert(err, gc.Equals, test.expectedError)
+			c.Assert(connector, gc.IsNil)
+		} else {
+			c.Assert(err, gc.IsNil)
+			c.Assert(connector.info, gc.DeepEquals, test.expectedAPIInfo)
+
+			expectedDefaultDialOpts := api.DefaultDialOpts()
+			if test.expectedDefaultDialOpts != nil {
+				expectedDefaultDialOpts = test.expectedDefaultDialOpts()
+			}
+			c.Assert(connector.defaultDialOpts, gc.DeepEquals, expectedDefaultDialOpts)
+		}
+	}
+}

--- a/api/connector/simpleconnector_test.go
+++ b/api/connector/simpleconnector_test.go
@@ -51,6 +51,7 @@ func (s *simpleConnectorSuite) TestNewSimpleRespectsClientCredentials(c *gc.C) {
 			expectedAPIInfo: api.Info{
 				Addrs:    []string{"some.host:9999"},
 				ModelTag: names.NewModelTag("some-uuid"),
+				Tag:      names.NewUserTag("some-client-id"),
 			},
 			expectedDefaultDialOpts: func() api.DialOpts {
 				expected := api.DefaultDialOpts()
@@ -75,6 +76,14 @@ func (s *simpleConnectorSuite) TestNewSimpleRespectsClientCredentials(c *gc.C) {
 				Password: "some-password",
 			},
 		},
+		{
+			name: "with neither username nre client id",
+			opts: SimpleConfig{
+				ControllerAddresses: []string{"some.host:9999"},
+				ModelUUID:           "some-uuid",
+			},
+			expectedError: "either Username or ClientID should be set",
+		},
 	}
 
 	for _, test := range tests {
@@ -83,7 +92,7 @@ func (s *simpleConnectorSuite) TestNewSimpleRespectsClientCredentials(c *gc.C) {
 		connector, err := NewSimple(test.opts)
 
 		if test.expectedError != "" {
-			c.Assert(err, gc.Equals, test.expectedError)
+			c.Assert(err, gc.ErrorMatches, test.expectedError)
 			c.Assert(connector, gc.IsNil)
 		} else {
 			c.Assert(err, gc.IsNil)

--- a/api/connector/simpleconnector_test.go
+++ b/api/connector/simpleconnector_test.go
@@ -51,7 +51,6 @@ func (s *simpleConnectorSuite) TestNewSimpleRespectsClientCredentials(c *gc.C) {
 			expectedAPIInfo: api.Info{
 				Addrs:    []string{"some.host:9999"},
 				ModelTag: names.NewModelTag("some-uuid"),
-				Tag:      names.NewUserTag("some-client-id"),
 			},
 			expectedDefaultDialOpts: func() api.DialOpts {
 				expected := api.DefaultDialOpts()

--- a/api/connector/simpleconnector_test.go
+++ b/api/connector/simpleconnector_test.go
@@ -4,10 +4,11 @@
 package connector
 
 import (
-	"github.com/juju/juju/api"
-	"github.com/juju/juju/testing"
 	"github.com/juju/names/v5"
 	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/api"
+	"github.com/juju/juju/testing"
 )
 
 type simpleConnectorSuite struct {

--- a/api/connector/simpleconnector_test.go
+++ b/api/connector/simpleconnector_test.go
@@ -59,7 +59,7 @@ func (s *simpleConnectorSuite) TestNewSimpleRespectsClientCredentials(c *gc.C) {
 			},
 		},
 		{
-			name: "with username/password and client credentials; client credentials should take over",
+			name: "with username/password and client credentials; username/password takes over",
 			opts: SimpleConfig{
 				ControllerAddresses: []string{"some.host:9999"},
 				ModelUUID:           "some-uuid",
@@ -71,11 +71,8 @@ func (s *simpleConnectorSuite) TestNewSimpleRespectsClientCredentials(c *gc.C) {
 			expectedAPIInfo: api.Info{
 				Addrs:    []string{"some.host:9999"},
 				ModelTag: names.NewModelTag("some-uuid"),
-			},
-			expectedDefaultDialOpts: func() api.DialOpts {
-				expected := api.DefaultDialOpts()
-				expected.LoginProvider = api.NewClientCredentialsLoginProvider("some-client-id", "some-client-secret")
-				return expected
+				Tag:      names.NewUserTag("some-username"),
+				Password: "some-password",
 			},
 		},
 	}

--- a/api/connector/simpleconnector_test.go
+++ b/api/connector/simpleconnector_test.go
@@ -74,14 +74,11 @@ func (s *simpleConnectorSuite) TestNewSimpleRespectsClientCredentials(c *gc.C) {
 				Tag:      names.NewUserTag("some-username"),
 				Password: "some-password",
 			},
-		},
-		{
-			name: "with neither username nor client id",
-			opts: SimpleConfig{
-				ControllerAddresses: []string{"some.host:9999"},
-				ModelUUID:           "some-uuid",
+			expectedDefaultDialOpts: func() api.DialOpts {
+				expected := api.DefaultDialOpts()
+				expected.LoginProvider = api.NewClientCredentialsLoginProvider("some-client-id", "some-client-secret")
+				return expected
 			},
-			expectedError: "either Username or ClientID should be set",
 		},
 	}
 


### PR DESCRIPTION
**(Note that this PR is relevant to JIMM controllers which support login with client credentials. So whenever we say *controller*, it's a *JIMM controller*.)**

When Juju Terraform Provider uses client credentials (as a service account) to communicate with the API using a `SimpleConnector`, it leaves `SimpleConfig.Username` empty and assigns the client credentials to `SimpleConfig.ClientID` and `SimpleConfig.ClientSecret`.

The problem is the `NewSimple` function does not take this into account and panics with the following message whenever the `Username` is empty:

```
invalid user tag ""
```

This PR adds a simple check to prevent the panic.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [ ] ~Go unit tests, with comments saying what you're testing~
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

QA-ing this change is a bit complicated because of two reasons:

1. The `NewSimple` function is meant to be used by users of the `juju/juju` module, and hence there's no internal usage in Juju (so we can verify the changes without spinning up other things). To invoke the method, we can use Juju Terraform Provider. Note that, for this purpose, we need to build the provider with the new Juju changes.
2. We'd need a controller that provides the newly introduced login method, `LoginWithClientCredentials`. If the controller The only controller that supports this method at the moment, is JIMM. Therefore, we need to spin up a JIMM controller. If we try with a non-JIMM controller, instead of a panic we get this error, which is a bit misleading but converts the unsupported state:
   ```
   this version of Juju does not support login from old clients (not supported) (not supported)
   ```

We can, of course, help out with QA-ing this to make sure it works as expected.

Anyway, the whole QA process should look like this:

0. Build the Juju Terraform Provider with the changes in Juju.
1. Spin up a JIMM controller.
2. Create a Terraform plan from this template:
   ```tf
   terraform {
       required_providers {
           juju = {
               source = "registry.terraform.io/juju/juju" # (uses local provider repository)
               version = "=0.12.0"
           }
       }
   }

   provider "juju" {
       controller_addresses = "jimm.localhost:443"

       client_id     = "some-client-id" # Value not important
       client_secret = "some-secret"    # Value not important

       ca_certificate = <<EOT
   -----BEGIN CERTIFICATE-----
   JIMM TLS termination CERT
   -----END CERTIFICATE-----
   EOT

   }

   resource "juju_model" "qa" {
       name = "qa"

       cloud {
           name = "localhost"
       }
   }

   resource "juju_application" "qa" {
       name = "qa"

       model = juju_model.qa.name

       charm {
           name = "juju-qa-test"
       }

       units = 1
   }
   ```
3. Run `terraform init` and `terraform apply`.
4. No Panic (i.e., `invalid user tag ""`) should happen.

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/

**Jira card:** JUJU-

