### PR TITLE
Remove unused region field in gce provider Connection

### DIFF
--- a/provider/gce/google/conn.go
+++ b/provider/gce/google/conn.go
@@ -131,7 +131,6 @@ type service interface {
 // Otherwise a panic will result.
 type Connection struct {
 	service   service
-	region    string
 	projectID string
 }
 
@@ -148,7 +147,6 @@ func Connect(ctx context.Context, connCfg ConnectionConfig, creds *Credentials) 
 
 	conn := &Connection{
 		service:   &rawConn{raw},
-		region:    connCfg.Region,
 		projectID: connCfg.ProjectID,
 	}
 	return conn, nil

--- a/provider/gce/google/testing_test.go
+++ b/provider/gce/google/testing_test.go
@@ -59,7 +59,6 @@ func (s *BaseSuite) SetUpTest(c *gc.C) {
 	fake := &fakeConn{}
 	s.Conn = &Connection{
 		service:   fake,
-		region:    "a",
 		projectID: "spam",
 	}
 	s.FakeConn = fake


### PR DESCRIPTION
This is something we stumbled upon recently with @manadart when figuring out [an LP bug about region on the gce provider](https://bugs.launchpad.net/juju/+bug/2058714). The region information in the environ is always picked up from the cloud spec, so the `region` field in the Connection seems redundant.

There's more to be done in this piece of code to unravel some of the unnecessary levels of abstractions. However, this small change is a clear win for now.

## QA steps

```
$ juju add-credential google --client
<pick a region R>
```

```
$ juju bootstrap google deleteme
Creating Juju controller "deleteme" on google/R <-------------- make sure this R is the one you picked
Looking for packaged Juju agent version 3.4.3 for amd64
......
```

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2058714

**Jira card:** JUJU-5940

