### PR TITLE
Simplify model config service creation.

### DIFF
--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -344,8 +344,7 @@ func (m *ModelManagerAPI) createModelNew(
 	modelServiceFactory := m.serviceFactoryGetter.ServiceFactoryForModel(modelUUID)
 	modelInfoService := modelServiceFactory.ModelInfo()
 
-	modelDefaults := m.modelDefaultsService.ModelDefaultsProvider(modelUUID)
-	modelConfigService := modelServiceFactory.Config(modelDefaults)
+	modelConfigService := modelServiceFactory.Config()
 
 	if err := modelConfigService.SetModelConfig(ctx, args.Config); err != nil {
 		return errors.Annotatef(err, "failed to set model config for model %q", modelUUID)

--- a/apiserver/facades/client/modelmanager/services.go
+++ b/apiserver/facades/client/modelmanager/services.go
@@ -27,7 +27,7 @@ import (
 // ServiceFactory is a factory for creating model info services.
 type ServiceFactory interface {
 	ModelInfo() ModelInfoService
-	Config(modeldefaultsservice.ModelDefaultsProviderFunc) ModelConfigService
+	Config() ModelConfigService
 	Network() NetworkService
 }
 
@@ -172,8 +172,8 @@ func (s serviceFactory) ModelInfo() ModelInfoService {
 	return s.serviceFactory.ModelInfo()
 }
 
-func (s serviceFactory) Config(defaults modeldefaultsservice.ModelDefaultsProviderFunc) ModelConfigService {
-	return s.serviceFactory.Config(defaults)
+func (s serviceFactory) Config() ModelConfigService {
+	return s.serviceFactory.Config()
 }
 
 func (s serviceFactory) Network() NetworkService {

--- a/apiserver/facades/controller/migrationtarget/servicefactory_mock_test.go
+++ b/apiserver/facades/controller/migrationtarget/servicefactory_mock_test.go
@@ -198,17 +198,17 @@ func (mr *MockServiceFactoryMockRecorder) Cloud() *gomock.Call {
 }
 
 // Config mocks base method.
-func (m *MockServiceFactory) Config(arg0 service12.ModelDefaultsProvider) *service12.WatchableService {
+func (m *MockServiceFactory) Config() *service12.WatchableService {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Config", arg0)
+	ret := m.ctrl.Call(m, "Config")
 	ret0, _ := ret[0].(*service12.WatchableService)
 	return ret0
 }
 
 // Config indicates an expected call of Config.
-func (mr *MockServiceFactoryMockRecorder) Config(arg0 any) *gomock.Call {
+func (mr *MockServiceFactoryMockRecorder) Config() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Config", reflect.TypeOf((*MockServiceFactory)(nil).Config), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Config", reflect.TypeOf((*MockServiceFactory)(nil).Config))
 }
 
 // ControllerConfig mocks base method.

--- a/domain/servicefactory/model.go
+++ b/domain/servicefactory/model.go
@@ -20,6 +20,8 @@ import (
 	modelstate "github.com/juju/juju/domain/model/state"
 	modelconfigservice "github.com/juju/juju/domain/modelconfig/service"
 	modelconfigstate "github.com/juju/juju/domain/modelconfig/state"
+	modeldefaultsservice "github.com/juju/juju/domain/modeldefaults/service"
+	modeldefaultsstate "github.com/juju/juju/domain/modeldefaults/state"
 	networkservice "github.com/juju/juju/domain/network/service"
 	networkstate "github.com/juju/juju/domain/network/state"
 	objectstoreservice "github.com/juju/juju/domain/objectstore/service"
@@ -61,12 +63,13 @@ func NewModelFactory(
 	}
 }
 
-// Config returns the model's configuration service. A ModelDefaultsProvider
-// needs to be supplied for the model config service. The provider can be
-// obtained from the controller service factory model defaults service.
-func (s *ModelFactory) Config(
-	defaultsProvider modelconfigservice.ModelDefaultsProvider,
-) *modelconfigservice.WatchableService {
+// Config returns the model's configuration service.
+func (s *ModelFactory) Config() *modelconfigservice.WatchableService {
+	defaultsProvider := modeldefaultsservice.NewService(
+		modeldefaultsstate.NewState(
+			changestream.NewTxnRunnerFactory(s.controllerDB),
+		)).ModelDefaultsProvider(s.modelUUID)
+
 	return modelconfigservice.NewWatchableService(
 		defaultsProvider,
 		config.ModelValidator(),

--- a/domain/servicefactory/testing/service.go
+++ b/domain/servicefactory/testing/service.go
@@ -49,7 +49,7 @@ func (s *TestingServiceFactory) AutocertCache() *autocertcacheservice.Service {
 }
 
 // Config returns the model config service.
-func (s *TestingServiceFactory) Config(_ modelconfigservice.ModelDefaultsProvider) *modelconfigservice.WatchableService {
+func (s *TestingServiceFactory) Config() *modelconfigservice.WatchableService {
 	return nil
 }
 

--- a/internal/migration/servicefactory_mock_test.go
+++ b/internal/migration/servicefactory_mock_test.go
@@ -198,17 +198,17 @@ func (mr *MockServiceFactoryMockRecorder) Cloud() *gomock.Call {
 }
 
 // Config mocks base method.
-func (m *MockServiceFactory) Config(arg0 service12.ModelDefaultsProvider) *service12.WatchableService {
+func (m *MockServiceFactory) Config() *service12.WatchableService {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Config", arg0)
+	ret := m.ctrl.Call(m, "Config")
 	ret0, _ := ret[0].(*service12.WatchableService)
 	return ret0
 }
 
 // Config indicates an expected call of Config.
-func (mr *MockServiceFactoryMockRecorder) Config(arg0 any) *gomock.Call {
+func (mr *MockServiceFactoryMockRecorder) Config() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Config", reflect.TypeOf((*MockServiceFactory)(nil).Config), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Config", reflect.TypeOf((*MockServiceFactory)(nil).Config))
 }
 
 // ControllerConfig mocks base method.

--- a/internal/servicefactory/interface.go
+++ b/internal/servicefactory/interface.go
@@ -69,7 +69,7 @@ type ControllerServiceFactory interface {
 // apiserver for a given model.
 type ModelServiceFactory interface {
 	// Config returns the modelconfig service.
-	Config(modelconfigservice.ModelDefaultsProvider) *modelconfigservice.WatchableService
+	Config() *modelconfigservice.WatchableService
 	// ObjectStore returns the object store service.
 	ObjectStore() *objectstoreservice.WatchableService
 	// Machine returns the machine service.

--- a/internal/worker/servicefactory/servicefactory_mock_test.go
+++ b/internal/worker/servicefactory/servicefactory_mock_test.go
@@ -310,17 +310,17 @@ func (mr *MockModelServiceFactoryMockRecorder) BlockDevice() *gomock.Call {
 }
 
 // Config mocks base method.
-func (m *MockModelServiceFactory) Config(arg0 service12.ModelDefaultsProvider) *service12.WatchableService {
+func (m *MockModelServiceFactory) Config() *service12.WatchableService {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Config", arg0)
+	ret := m.ctrl.Call(m, "Config")
 	ret0, _ := ret[0].(*service12.WatchableService)
 	return ret0
 }
 
 // Config indicates an expected call of Config.
-func (mr *MockModelServiceFactoryMockRecorder) Config(arg0 any) *gomock.Call {
+func (mr *MockModelServiceFactoryMockRecorder) Config() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Config", reflect.TypeOf((*MockModelServiceFactory)(nil).Config), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Config", reflect.TypeOf((*MockModelServiceFactory)(nil).Config))
 }
 
 // Machine mocks base method.
@@ -543,17 +543,17 @@ func (mr *MockServiceFactoryMockRecorder) Cloud() *gomock.Call {
 }
 
 // Config mocks base method.
-func (m *MockServiceFactory) Config(arg0 service12.ModelDefaultsProvider) *service12.WatchableService {
+func (m *MockServiceFactory) Config() *service12.WatchableService {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Config", arg0)
+	ret := m.ctrl.Call(m, "Config")
 	ret0, _ := ret[0].(*service12.WatchableService)
 	return ret0
 }
 
 // Config indicates an expected call of Config.
-func (mr *MockServiceFactoryMockRecorder) Config(arg0 any) *gomock.Call {
+func (mr *MockServiceFactoryMockRecorder) Config() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Config", reflect.TypeOf((*MockServiceFactory)(nil).Config), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Config", reflect.TypeOf((*MockServiceFactory)(nil).Config))
 }
 
 // ControllerConfig mocks base method.


### PR DESCRIPTION
Because we now have access to the controller database and model uuid inside of the model service we can construct the model config service for the user without them having to build their own defaults service to supply to the factory.

This will make it much cleaner and easier for users of the model config service.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Unit tests and compiling code is enough to validate this change as it is just procedural.

## Documentation changes

N/A

## Links

**Jira card:** JUJU-5342

