### PR TITLE
Use new bespoke structs for fetching secrets to drain info

### DIFF
--- a/api/common/secretsdrain/client_test.go
+++ b/api/common/secretsdrain/client_test.go
@@ -4,8 +4,6 @@
 package secretsdrain_test
 
 import (
-	"time"
-
 	jc "github.com/juju/testing/checkers"
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
@@ -39,16 +37,10 @@ func (s *secretsDrainSuite) TestGetSecretsToDrain(c *gc.C) {
 	apiCaller := mocks.NewMockFacadeCaller(ctrl)
 
 	uri := coresecrets.NewURI()
-	now := time.Now()
 	apiCaller.EXPECT().FacadeCall(gomock.Any(), "GetSecretsToDrain", nil, gomock.Any()).SetArg(
-		3, params.ListSecretResults{
-			Results: []params.ListSecretResult{{
-				URI:              uri.String(),
-				OwnerTag:         "application-mariadb",
-				Label:            "label",
-				LatestRevision:   667,
-				NextRotateTime:   &now,
-				LatestExpireTime: &now,
+		3, params.SecretRevisionsToDrainResults{
+			Results: []params.SecretRevisionsToDrainResult{{
+				URI: uri.String(),
 				Revisions: []params.SecretRevision{{
 					Revision: 666,
 					ValueRef: &params.SecretValueRef{
@@ -67,13 +59,8 @@ func (s *secretsDrainSuite) TestGetSecretsToDrain(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.HasLen, 1)
 	for _, info := range result {
-		c.Assert(info.Metadata.URI.String(), gc.Equals, uri.String())
-		c.Assert(info.Metadata.Owner, jc.DeepEquals, coresecrets.Owner{Kind: coresecrets.ApplicationOwner, ID: "mariadb"})
-		c.Assert(info.Metadata.Label, gc.Equals, "label")
-		c.Assert(info.Metadata.LatestRevision, gc.Equals, 667)
-		c.Assert(info.Metadata.LatestExpireTime, gc.Equals, &now)
-		c.Assert(info.Metadata.NextRotateTime, gc.Equals, &now)
-		c.Assert(info.Revisions, jc.DeepEquals, []coresecrets.SecretRevisionMetadata{
+		c.Assert(info.URI.String(), gc.Equals, uri.String())
+		c.Assert(info.Revisions, jc.DeepEquals, []coresecrets.SecretExternalRevision{
 			{
 				Revision: 666,
 				ValueRef: &coresecrets.ValueRef{

--- a/apiserver/common/secrets/drain.go
+++ b/apiserver/common/secrets/drain.go
@@ -68,7 +68,7 @@ func (s *SecretsDrainAPI) GetSecretsToDrain(ctx context.Context) (params.SecretR
 		err     error
 	)
 	if s.authTag.Kind() == names.ModelTagKind {
-		toDrain, err = s.secretService.ListCharmSecretsToDrain(ctx)
+		toDrain, err = s.secretService.ListUserSecretsToDrain(ctx)
 	} else {
 		toDrain, err = s.getCharmSecretsToDrain(ctx)
 	}

--- a/apiserver/common/secrets/drain.go
+++ b/apiserver/common/secrets/drain.go
@@ -62,44 +62,28 @@ func NewSecretsDrainAPI(
 }
 
 // GetSecretsToDrain returns metadata for the secrets that need to be drained.
-func (s *SecretsDrainAPI) GetSecretsToDrain(ctx context.Context) (params.ListSecretResults, error) {
+func (s *SecretsDrainAPI) GetSecretsToDrain(ctx context.Context) (params.SecretRevisionsToDrainResults, error) {
 	var (
-		metadata         []*coresecrets.SecretMetadata
-		revisionMetadata [][]*coresecrets.SecretRevisionMetadata
-		err              error
+		toDrain []*coresecrets.SecretMetadataForDrain
+		err     error
 	)
 	if s.authTag.Kind() == names.ModelTagKind {
-		metadata, revisionMetadata, err = s.secretService.ListUserSecrets(ctx)
+		toDrain, err = s.secretService.ListCharmSecretsToDrain(ctx)
 	} else {
-		metadata, revisionMetadata, err = s.getCharmSecrets(ctx)
+		toDrain, err = s.getCharmSecretsToDrain(ctx)
 	}
 	if err != nil {
-		return params.ListSecretResults{}, errors.Trace(err)
+		return params.SecretRevisionsToDrainResults{}, errors.Trace(err)
 	}
 
-	var result params.ListSecretResults
-	for i, md := range metadata {
-		ownerTag, err := OwnerTagFromOwner(md.Owner)
-		if err != nil {
-			// This should never happen.
-			return params.ListSecretResults{}, errors.Trace(err)
+	var result params.SecretRevisionsToDrainResults
+	for _, info := range toDrain {
+		secretResult := params.SecretRevisionsToDrainResult{
+			URI: info.URI.String(),
 		}
-		secretResult := params.ListSecretResult{
-			URI:              md.URI.String(),
-			Version:          md.Version,
-			OwnerTag:         ownerTag.String(),
-			RotatePolicy:     md.RotatePolicy.String(),
-			NextRotateTime:   md.NextRotateTime,
-			Description:      md.Description,
-			Label:            md.Label,
-			LatestRevision:   md.LatestRevision,
-			LatestExpireTime: md.LatestExpireTime,
-			CreateTime:       md.CreateTime,
-			UpdateTime:       md.UpdateTime,
-		}
-		toDrain, err := s.secretBackendService.GetRevisionsToDrain(ctx, s.modelUUID, revisionMetadata[i])
+		toDrain, err := s.secretBackendService.GetRevisionsToDrain(ctx, s.modelUUID, info.Revisions)
 		if err != nil {
-			return params.ListSecretResults{}, errors.Trace(err)
+			return params.SecretRevisionsToDrainResults{}, errors.Trace(err)
 		}
 		for _, r := range toDrain {
 			var valueRef *params.SecretValueRef
@@ -160,7 +144,7 @@ func isLeaderUnit(authTag names.Tag, leadershipChecker leadership.Checker) (bool
 	return err == nil, nil
 }
 
-func (s *SecretsDrainAPI) getCharmSecrets(ctx context.Context) ([]*coresecrets.SecretMetadata, [][]*coresecrets.SecretRevisionMetadata, error) {
+func (s *SecretsDrainAPI) getCharmSecretsToDrain(ctx context.Context) ([]*coresecrets.SecretMetadataForDrain, error) {
 	owners := []secretservice.CharmSecretOwner{{
 		Kind: secretservice.UnitOwner,
 		ID:   s.authTag.Id(),
@@ -168,7 +152,7 @@ func (s *SecretsDrainAPI) getCharmSecrets(ctx context.Context) ([]*coresecrets.S
 	// Unit leaders can also get metadata for secrets owned by the app.
 	isLeader, err := isLeaderUnit(s.authTag, s.leadershipChecker)
 	if err != nil {
-		return nil, nil, errors.Trace(err)
+		return nil, errors.Trace(err)
 	}
 	if isLeader {
 		appName, _ := names.UnitApplication(s.authTag.Id())
@@ -177,7 +161,7 @@ func (s *SecretsDrainAPI) getCharmSecrets(ctx context.Context) ([]*coresecrets.S
 			ID:   appName,
 		})
 	}
-	return s.secretService.ListCharmSecrets(ctx, owners...)
+	return s.secretService.ListCharmSecretsToDrain(ctx, owners...)
 }
 
 // ChangeSecretBackend updates the backend for the specified secret after migration done.

--- a/apiserver/common/secrets/mocks/commonsecrets_mock.go
+++ b/apiserver/common/secrets/mocks/commonsecrets_mock.go
@@ -111,41 +111,39 @@ func (mr *MockSecretServiceMockRecorder) ChangeSecretBackend(arg0, arg1, arg2, a
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChangeSecretBackend", reflect.TypeOf((*MockSecretService)(nil).ChangeSecretBackend), arg0, arg1, arg2, arg3)
 }
 
-// ListCharmSecrets mocks base method.
-func (m *MockSecretService) ListCharmSecrets(arg0 context.Context, arg1 ...service.CharmSecretOwner) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error) {
+// ListCharmSecretsToDrain mocks base method.
+func (m *MockSecretService) ListCharmSecretsToDrain(arg0 context.Context, arg1 ...service.CharmSecretOwner) ([]*secrets.SecretMetadataForDrain, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0}
 	for _, a := range arg1 {
 		varargs = append(varargs, a)
 	}
-	ret := m.ctrl.Call(m, "ListCharmSecrets", varargs...)
-	ret0, _ := ret[0].([]*secrets.SecretMetadata)
-	ret1, _ := ret[1].([][]*secrets.SecretRevisionMetadata)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+	ret := m.ctrl.Call(m, "ListCharmSecretsToDrain", varargs...)
+	ret0, _ := ret[0].([]*secrets.SecretMetadataForDrain)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
-// ListCharmSecrets indicates an expected call of ListCharmSecrets.
-func (mr *MockSecretServiceMockRecorder) ListCharmSecrets(arg0 any, arg1 ...any) *gomock.Call {
+// ListCharmSecretsToDrain indicates an expected call of ListCharmSecretsToDrain.
+func (mr *MockSecretServiceMockRecorder) ListCharmSecretsToDrain(arg0 any, arg1 ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]any{arg0}, arg1...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCharmSecrets", reflect.TypeOf((*MockSecretService)(nil).ListCharmSecrets), varargs...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCharmSecretsToDrain", reflect.TypeOf((*MockSecretService)(nil).ListCharmSecretsToDrain), varargs...)
 }
 
-// ListUserSecrets mocks base method.
-func (m *MockSecretService) ListUserSecrets(arg0 context.Context) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error) {
+// ListUserSecretsToDrain mocks base method.
+func (m *MockSecretService) ListUserSecretsToDrain(arg0 context.Context) ([]*secrets.SecretMetadataForDrain, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListUserSecrets", arg0)
-	ret0, _ := ret[0].([]*secrets.SecretMetadata)
-	ret1, _ := ret[1].([][]*secrets.SecretRevisionMetadata)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+	ret := m.ctrl.Call(m, "ListUserSecretsToDrain", arg0)
+	ret0, _ := ret[0].([]*secrets.SecretMetadataForDrain)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
-// ListUserSecrets indicates an expected call of ListUserSecrets.
-func (mr *MockSecretServiceMockRecorder) ListUserSecrets(arg0 any) *gomock.Call {
+// ListUserSecretsToDrain indicates an expected call of ListUserSecretsToDrain.
+func (mr *MockSecretServiceMockRecorder) ListUserSecretsToDrain(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListUserSecrets", reflect.TypeOf((*MockSecretService)(nil).ListUserSecrets), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListUserSecretsToDrain", reflect.TypeOf((*MockSecretService)(nil).ListUserSecretsToDrain), arg0)
 }
 
 // MockSecretBackendService is a mock of SecretBackendService interface.
@@ -172,7 +170,7 @@ func (m *MockSecretBackendService) EXPECT() *MockSecretBackendServiceMockRecorde
 }
 
 // GetRevisionsToDrain mocks base method.
-func (m *MockSecretBackendService) GetRevisionsToDrain(arg0 context.Context, arg1 model.UUID, arg2 []*secrets.SecretRevisionMetadata) ([]service0.RevisionInfo, error) {
+func (m *MockSecretBackendService) GetRevisionsToDrain(arg0 context.Context, arg1 model.UUID, arg2 []secrets.SecretExternalRevision) ([]service0.RevisionInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRevisionsToDrain", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]service0.RevisionInfo)

--- a/apiserver/common/secrets/service.go
+++ b/apiserver/common/secrets/service.go
@@ -14,12 +14,14 @@ import (
 
 // SecretService instances provide secret service apis.
 type SecretService interface {
-	ListCharmSecrets(context.Context, ...secretservice.CharmSecretOwner) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error)
-	ListUserSecrets(ctx context.Context) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error)
+	ListCharmSecretsToDrain(
+		ctx context.Context, owners ...secretservice.CharmSecretOwner,
+	) ([]*secrets.SecretMetadataForDrain, error)
+	ListUserSecretsToDrain(ctx context.Context) ([]*secrets.SecretMetadataForDrain, error)
 	ChangeSecretBackend(ctx context.Context, uri *secrets.URI, revision int, params secretservice.ChangeSecretBackendParams) error
 }
 
 // SecretBackendService instances provide secret backend service apis.
 type SecretBackendService interface {
-	GetRevisionsToDrain(ctx context.Context, modelUUID coremodel.UUID, revs []*secrets.SecretRevisionMetadata) ([]backendservice.RevisionInfo, error)
+	GetRevisionsToDrain(ctx context.Context, modelUUID coremodel.UUID, revs []secrets.SecretExternalRevision) ([]backendservice.RevisionInfo, error)
 }

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -34796,7 +34796,7 @@
                     "type": "object",
                     "properties": {
                         "Result": {
-                            "$ref": "#/definitions/ListSecretResults"
+                            "$ref": "#/definitions/SecretRevisionsToDrainResults"
                         }
                     },
                     "description": "GetSecretsToDrain returns metadata for the secrets that need to be drained."
@@ -34812,26 +34812,6 @@
                 }
             },
             "definitions": {
-                "AccessInfo": {
-                    "type": "object",
-                    "properties": {
-                        "role": {
-                            "type": "string"
-                        },
-                        "scope-tag": {
-                            "type": "string"
-                        },
-                        "target-tag": {
-                            "type": "string"
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "target-tag",
-                        "scope-tag",
-                        "role"
-                    ]
-                },
                 "ChangeSecretBackendArg": {
                     "type": "object",
                     "properties": {
@@ -34915,88 +34895,6 @@
                         "results"
                     ]
                 },
-                "ListSecretResult": {
-                    "type": "object",
-                    "properties": {
-                        "access": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/AccessInfo"
-                            }
-                        },
-                        "create-time": {
-                            "type": "string",
-                            "format": "date-time"
-                        },
-                        "description": {
-                            "type": "string"
-                        },
-                        "label": {
-                            "type": "string"
-                        },
-                        "latest-expire-time": {
-                            "type": "string",
-                            "format": "date-time"
-                        },
-                        "latest-revision": {
-                            "type": "integer"
-                        },
-                        "next-rotate-time": {
-                            "type": "string",
-                            "format": "date-time"
-                        },
-                        "owner-tag": {
-                            "type": "string"
-                        },
-                        "revisions": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/SecretRevision"
-                            }
-                        },
-                        "rotate-policy": {
-                            "type": "string"
-                        },
-                        "update-time": {
-                            "type": "string",
-                            "format": "date-time"
-                        },
-                        "uri": {
-                            "type": "string"
-                        },
-                        "value": {
-                            "$ref": "#/definitions/SecretValueResult"
-                        },
-                        "version": {
-                            "type": "integer"
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "uri",
-                        "version",
-                        "owner-tag",
-                        "latest-revision",
-                        "create-time",
-                        "update-time",
-                        "revisions"
-                    ]
-                },
-                "ListSecretResults": {
-                    "type": "object",
-                    "properties": {
-                        "results": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/ListSecretResult"
-                            }
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "results"
-                    ]
-                },
                 "NotifyWatchResult": {
                     "type": "object",
                     "properties": {
@@ -35059,6 +34957,40 @@
                         "revision"
                     ]
                 },
+                "SecretRevisionsToDrainResult": {
+                    "type": "object",
+                    "properties": {
+                        "revisions": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/SecretRevision"
+                            }
+                        },
+                        "uri": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "uri",
+                        "revisions"
+                    ]
+                },
+                "SecretRevisionsToDrainResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/SecretRevisionsToDrainResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
                 "SecretValueRef": {
                     "type": "object",
                     "properties": {
@@ -35074,23 +35006,6 @@
                         "backend-id",
                         "revision-id"
                     ]
-                },
-                "SecretValueResult": {
-                    "type": "object",
-                    "properties": {
-                        "data": {
-                            "type": "object",
-                            "patternProperties": {
-                                ".*": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "error": {
-                            "$ref": "#/definitions/Error"
-                        }
-                    },
-                    "additionalProperties": false
                 }
             }
         }
@@ -45469,7 +45384,7 @@
                     "type": "object",
                     "properties": {
                         "Result": {
-                            "$ref": "#/definitions/ListSecretResults"
+                            "$ref": "#/definitions/SecretRevisionsToDrainResults"
                         }
                     },
                     "description": "GetSecretsToDrain returns metadata for the secrets that need to be drained."
@@ -45485,26 +45400,6 @@
                 }
             },
             "definitions": {
-                "AccessInfo": {
-                    "type": "object",
-                    "properties": {
-                        "role": {
-                            "type": "string"
-                        },
-                        "scope-tag": {
-                            "type": "string"
-                        },
-                        "target-tag": {
-                            "type": "string"
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "target-tag",
-                        "scope-tag",
-                        "role"
-                    ]
-                },
                 "ChangeSecretBackendArg": {
                     "type": "object",
                     "properties": {
@@ -45622,88 +45517,6 @@
                     "additionalProperties": false,
                     "required": [
                         "args"
-                    ]
-                },
-                "ListSecretResult": {
-                    "type": "object",
-                    "properties": {
-                        "access": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/AccessInfo"
-                            }
-                        },
-                        "create-time": {
-                            "type": "string",
-                            "format": "date-time"
-                        },
-                        "description": {
-                            "type": "string"
-                        },
-                        "label": {
-                            "type": "string"
-                        },
-                        "latest-expire-time": {
-                            "type": "string",
-                            "format": "date-time"
-                        },
-                        "latest-revision": {
-                            "type": "integer"
-                        },
-                        "next-rotate-time": {
-                            "type": "string",
-                            "format": "date-time"
-                        },
-                        "owner-tag": {
-                            "type": "string"
-                        },
-                        "revisions": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/SecretRevision"
-                            }
-                        },
-                        "rotate-policy": {
-                            "type": "string"
-                        },
-                        "update-time": {
-                            "type": "string",
-                            "format": "date-time"
-                        },
-                        "uri": {
-                            "type": "string"
-                        },
-                        "value": {
-                            "$ref": "#/definitions/SecretValueResult"
-                        },
-                        "version": {
-                            "type": "integer"
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "uri",
-                        "version",
-                        "owner-tag",
-                        "latest-revision",
-                        "create-time",
-                        "update-time",
-                        "revisions"
-                    ]
-                },
-                "ListSecretResults": {
-                    "type": "object",
-                    "properties": {
-                        "results": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/ListSecretResult"
-                            }
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "results"
                     ]
                 },
                 "NotifyWatchResult": {
@@ -45914,6 +45727,40 @@
                         "pending-delete"
                     ]
                 },
+                "SecretRevisionsToDrainResult": {
+                    "type": "object",
+                    "properties": {
+                        "revisions": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/SecretRevision"
+                            }
+                        },
+                        "uri": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "uri",
+                        "revisions"
+                    ]
+                },
+                "SecretRevisionsToDrainResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/SecretRevisionsToDrainResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
                 "SecretValueRef": {
                     "type": "object",
                     "properties": {
@@ -45929,23 +45776,6 @@
                         "backend-id",
                         "revision-id"
                     ]
-                },
-                "SecretValueResult": {
-                    "type": "object",
-                    "properties": {
-                        "data": {
-                            "type": "object",
-                            "patternProperties": {
-                                ".*": {
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "error": {
-                            "$ref": "#/definitions/Error"
-                        }
-                    },
-                    "additionalProperties": false
                 }
             }
         }

--- a/core/secrets/secret.go
+++ b/core/secrets/secret.go
@@ -251,10 +251,16 @@ type SecretOwnerMetadata struct {
 	Revisions []int
 }
 
+// SecretExternalRevision holds metadata about an external secret revision.
+type SecretExternalRevision struct {
+	Revision int
+	ValueRef *ValueRef
+}
+
 // SecretMetadataForDrain holds a secret metadata and any backend references of revisions for drain.
 type SecretMetadataForDrain struct {
-	Metadata  SecretMetadata
-	Revisions []SecretRevisionMetadata
+	URI       *URI
+	Revisions []SecretExternalRevision
 }
 
 // SecretConsumerMetadata holds metadata about a secret

--- a/domain/secret/service/state_mock_test.go
+++ b/domain/secret/service/state_mock_test.go
@@ -316,6 +316,21 @@ func (mr *MockStateMockRecorder) ListCharmSecrets(arg0, arg1, arg2 any) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCharmSecrets", reflect.TypeOf((*MockState)(nil).ListCharmSecrets), arg0, arg1, arg2)
 }
 
+// ListCharmSecretsToDrain mocks base method.
+func (m *MockState) ListCharmSecretsToDrain(arg0 context.Context, arg1 secret.ApplicationOwners, arg2 secret.UnitOwners) ([]*secrets.SecretMetadataForDrain, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListCharmSecretsToDrain", arg0, arg1, arg2)
+	ret0, _ := ret[0].([]*secrets.SecretMetadataForDrain)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListCharmSecretsToDrain indicates an expected call of ListCharmSecretsToDrain.
+func (mr *MockStateMockRecorder) ListCharmSecretsToDrain(arg0, arg1, arg2 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCharmSecretsToDrain", reflect.TypeOf((*MockState)(nil).ListCharmSecretsToDrain), arg0, arg1, arg2)
+}
+
 // ListExternalSecretRevisions mocks base method.
 func (m *MockState) ListExternalSecretRevisions(arg0 context.Context, arg1 *secrets.URI, arg2 ...int) ([]secrets.ValueRef, error) {
 	m.ctrl.T.Helper()
@@ -367,20 +382,19 @@ func (mr *MockStateMockRecorder) ListSecrets(arg0, arg1, arg2, arg3 any) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSecrets", reflect.TypeOf((*MockState)(nil).ListSecrets), arg0, arg1, arg2, arg3)
 }
 
-// ListUserSecrets mocks base method.
-func (m *MockState) ListUserSecrets(arg0 context.Context) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error) {
+// ListUserSecretsToDrain mocks base method.
+func (m *MockState) ListUserSecretsToDrain(arg0 context.Context) ([]*secrets.SecretMetadataForDrain, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListUserSecrets", arg0)
-	ret0, _ := ret[0].([]*secrets.SecretMetadata)
-	ret1, _ := ret[1].([][]*secrets.SecretRevisionMetadata)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+	ret := m.ctrl.Call(m, "ListUserSecretsToDrain", arg0)
+	ret0, _ := ret[0].([]*secrets.SecretMetadataForDrain)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
-// ListUserSecrets indicates an expected call of ListUserSecrets.
-func (mr *MockStateMockRecorder) ListUserSecrets(arg0 any) *gomock.Call {
+// ListUserSecretsToDrain indicates an expected call of ListUserSecretsToDrain.
+func (mr *MockStateMockRecorder) ListUserSecretsToDrain(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListUserSecrets", reflect.TypeOf((*MockState)(nil).ListUserSecrets), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListUserSecretsToDrain", reflect.TypeOf((*MockState)(nil).ListUserSecretsToDrain), arg0)
 }
 
 // RevokeAccess mocks base method.

--- a/domain/secret/state/types.go
+++ b/domain/secret/state/types.go
@@ -279,7 +279,7 @@ func (rows secretIDs) toSecretMetadataForDrain(revRows secretExternalRevisions) 
 				URI: uri,
 			}
 			current = &md
-			result = append(result, &md)
+			result = append(result, current)
 		}
 		rev := coresecrets.SecretExternalRevision{
 			Revision: revRows[i].Revision,

--- a/domain/secret/state/types.go
+++ b/domain/secret/state/types.go
@@ -124,6 +124,12 @@ type secretValueRef struct {
 	RevisionID   string `db:"revision_id"`
 }
 
+type secretExternalRevision struct {
+	Revision    int    `db:"revision"`
+	BackendUUID string `db:"backend_uuid"`
+	RevisionID  string `db:"revision_id"`
+}
+
 type secretUnitConsumer struct {
 	UnitUUID        string `db:"unit_uuid"`
 	SecretID        string `db:"secret_id"`
@@ -243,6 +249,48 @@ func (rows secrets) toSecretRevisionRef(refs secretValueRefs) ([]*coresecrets.Se
 			URI:        uri,
 			RevisionID: refs[i].RevisionID,
 		}
+	}
+	return result, nil
+}
+
+type (
+	secretIDs               []secretID
+	secretExternalRevisions []secretExternalRevision
+)
+
+func (rows secretIDs) toSecretMetadataForDrain(revRows secretExternalRevisions) ([]*coresecrets.SecretMetadataForDrain, error) {
+	if len(rows) != len(revRows) {
+		// Should never happen.
+		return nil, errors.New("row length mismatch composing secret results")
+	}
+
+	var (
+		result  []*coresecrets.SecretMetadataForDrain
+		current *coresecrets.SecretMetadataForDrain
+	)
+	for i, row := range rows {
+		if current == nil || current.URI.ID != row.ID {
+			// Encountered a new record.
+			uri, err := coresecrets.ParseURI(row.ID)
+			if err != nil {
+				return nil, errors.NotValidf("secret URI %q", row.ID)
+			}
+			md := coresecrets.SecretMetadataForDrain{
+				URI: uri,
+			}
+			current = &md
+			result = append(result, &md)
+		}
+		rev := coresecrets.SecretExternalRevision{
+			Revision: revRows[i].Revision,
+		}
+		if revRows[i].BackendUUID != "" {
+			rev.ValueRef = &coresecrets.ValueRef{
+				BackendID:  revRows[i].BackendUUID,
+				RevisionID: revRows[i].RevisionID,
+			}
+		}
+		current.Revisions = append(current.Revisions, rev)
 	}
 	return result, nil
 }

--- a/domain/secretbackend/service/service.go
+++ b/domain/secretbackend/service/service.go
@@ -713,7 +713,7 @@ func (s *Service) SetModelSecretBackend(ctx context.Context, modelUUID coremodel
 
 // GetRevisionsToDrain looks at the supplied revisions and returns any which should be
 // drained to a different backend for the specified model.
-func (s *Service) GetRevisionsToDrain(ctx context.Context, modelUUID coremodel.UUID, revs []*coresecrets.SecretRevisionMetadata) ([]RevisionInfo, error) {
+func (s *Service) GetRevisionsToDrain(ctx context.Context, modelUUID coremodel.UUID, revs []coresecrets.SecretExternalRevision) ([]RevisionInfo, error) {
 	activeBackendDetails, err := s.st.GetModelSecretBackendDetails(ctx, modelUUID)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/domain/secretbackend/service/service_test.go
+++ b/domain/secretbackend/service/service_test.go
@@ -1026,7 +1026,7 @@ func (s *serviceSuite) assertGetSecretsToDrain(c *gc.C, backendID string, expect
 			ID: jujuBackendID,
 		}, nil)
 
-	revisions := []*coresecrets.SecretRevisionMetadata{
+	revisions := []coresecrets.SecretExternalRevision{
 		{
 			// External backend.
 			Revision: 666,

--- a/internal/worker/secretsdrainworker/worker_test.go
+++ b/internal/worker/secretsdrainworker/worker_test.go
@@ -101,8 +101,8 @@ func (s *workerSuite) TestDrainNoOPS(c *gc.C) {
 	gomock.InOrder(
 		s.facade.EXPECT().GetSecretsToDrain().Return([]coresecrets.SecretMetadataForDrain{
 			{
-				Metadata: coresecrets.SecretMetadata{URI: uri},
-				Revisions: []coresecrets.SecretRevisionMetadata{
+				URI: uri,
+				Revisions: []coresecrets.SecretExternalRevision{
 					{
 						Revision: 1,
 						ValueRef: &coresecrets.ValueRef{BackendID: "backend-1", RevisionID: "revision-1"},
@@ -132,8 +132,8 @@ func (s *workerSuite) TestDrainBetweenExternalBackends(c *gc.C) {
 	gomock.InOrder(
 		s.facade.EXPECT().GetSecretsToDrain().Return([]coresecrets.SecretMetadataForDrain{
 			{
-				Metadata: coresecrets.SecretMetadata{URI: uri},
-				Revisions: []coresecrets.SecretRevisionMetadata{
+				URI: uri,
+				Revisions: []coresecrets.SecretExternalRevision{
 					{
 						Revision: 1,
 						ValueRef: &coresecrets.ValueRef{BackendID: "backend-1", RevisionID: "revision-1"},
@@ -178,8 +178,8 @@ func (s *workerSuite) TestDrainFromInternalToExternal(c *gc.C) {
 	gomock.InOrder(
 		s.facade.EXPECT().GetSecretsToDrain().Return([]coresecrets.SecretMetadataForDrain{
 			{
-				Metadata:  coresecrets.SecretMetadata{URI: uri},
-				Revisions: []coresecrets.SecretRevisionMetadata{{Revision: 1}},
+				URI:       uri,
+				Revisions: []coresecrets.SecretExternalRevision{{Revision: 1}},
 			},
 		}, nil),
 		s.backendClient.EXPECT().GetBackend(nil, true).Return(activeBackend, "backend-2", nil),
@@ -217,8 +217,8 @@ func (s *workerSuite) TestDrainFromExternalToInternal(c *gc.C) {
 	gomock.InOrder(
 		s.facade.EXPECT().GetSecretsToDrain().Return([]coresecrets.SecretMetadataForDrain{
 			{
-				Metadata: coresecrets.SecretMetadata{URI: uri},
-				Revisions: []coresecrets.SecretRevisionMetadata{
+				URI: uri,
+				Revisions: []coresecrets.SecretExternalRevision{
 					{
 						Revision: 1,
 						ValueRef: &coresecrets.ValueRef{BackendID: "backend-1", RevisionID: "revision-1"},
@@ -262,8 +262,8 @@ func (s *workerSuite) TestDrainPartiallyFailed(c *gc.C) {
 	gomock.InOrder(
 		s.facade.EXPECT().GetSecretsToDrain().Return([]coresecrets.SecretMetadataForDrain{
 			{
-				Metadata: coresecrets.SecretMetadata{URI: uri},
-				Revisions: []coresecrets.SecretRevisionMetadata{
+				URI: uri,
+				Revisions: []coresecrets.SecretExternalRevision{
 					{
 						Revision: 1,
 						ValueRef: &coresecrets.ValueRef{BackendID: "backend-1", RevisionID: "revision-1"},

--- a/rpc/params/secrets.go
+++ b/rpc/params/secrets.go
@@ -286,6 +286,23 @@ type ListSecretResult struct {
 	Access           []AccessInfo       `json:"access,omitempty"`
 }
 
+// SecretRevisionsToDrainResults holds secret revisions to drain results.
+type SecretRevisionsToDrainResults struct {
+	Results []SecretRevisionsToDrainResult `json:"results"`
+}
+
+// SecretRevisionsToDrainResult holds secret revisions to drain for a given secret.
+type SecretRevisionsToDrainResult struct {
+	URI       string           `json:"uri"`
+	Revisions []SecretRevision `json:"revisions"`
+}
+
+// SecretExternalRevision holds secret revision metadata for an external revision.
+type SecretExternalRevision struct {
+	Revision int             `json:"revision"`
+	ValueRef *SecretValueRef `json:"value-ref,omitempty"`
+}
+
 // AccessInfo holds info about a secret access information.
 type AccessInfo struct {
 	TargetTag string             `json:"target-tag"`


### PR DESCRIPTION
The secret drain worker fetches info about secret revisions to drain. It was using apis implemented to list full secret and revision metadata, where in reality only a subset of attributes are needed. This PR adds new bespoke service and state methods to serve the metadata for revisions to drain.

New rpc params structs are introduced but these are over the wire compatible with the exists SecretsResults struct.

## QA steps

Just unit tests, drain not fully wired up yet.

## Links

**Jira card:** [JUJU-5968](https://warthogs.atlassian.net/browse/JUJU-5968)



[JUJU-5968]: https://warthogs.atlassian.net/browse/JUJU-5968?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ