### PR TITLE
Rename vsphere template dir

### DIFF
--- a/provider/vsphere/environ_broker.go
+++ b/provider/vsphere/environ_broker.go
@@ -16,7 +16,6 @@ import (
 	"github.com/juju/juju/cloudconfig/cloudinit"
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/cloudconfig/providerinit"
-	corebase "github.com/juju/juju/core/base"
 	"github.com/juju/juju/core/instance"
 	corenetwork "github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/os/ostype"
@@ -175,11 +174,7 @@ func (env *sessionEnviron) newRawInstance(
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
-	series, err := corebase.GetSeriesFromBase(args.InstanceConfig.Base)
-	if err != nil {
-		return nil, nil, errors.Trace(err)
-	}
-	vmTemplate, arch, err := tplManager.EnsureTemplate(env.ctx, series, arch)
+	vmTemplate, arch, err := tplManager.EnsureTemplate(env.ctx, args.InstanceConfig.Base, arch)
 	if err != nil {
 		return nil, nil, environs.ZoneIndependentError(err)
 	}
@@ -255,7 +250,6 @@ func (env *sessionEnviron) newRawInstance(
 	createVMArgs := vsphereclient.CreateVirtualMachineParams{
 		Name:                   vmName,
 		Folder:                 path.Join(env.getVMFolder(), controllerFolderName(args.ControllerUUID), env.modelFolderName()),
-		Series:                 series,
 		UserData:               string(userData),
 		Metadata:               args.InstanceConfig.Tags,
 		Constraints:            cons,

--- a/provider/vsphere/environ_broker_test.go
+++ b/provider/vsphere/environ_broker_test.go
@@ -154,7 +154,6 @@ func (s *legacyEnvironBrokerSuite) TestStartInstance(c *gc.C) {
 	c.Assert(createVMArgs, jc.DeepEquals, vsphereclient.CreateVirtualMachineParams{
 		Name:            "juju-f75cba-0",
 		Folder:          `Juju Controller (deadbeef-1bad-500d-9000-4b1d0d06f00d)/Model "testmodel" (2d02eeac-9dbb-11e4-89d3-123b93f75cba)`,
-		Series:          "jammy",
 		Metadata:        startInstArgs.InstanceConfig.Tags,
 		ComputeResource: s.client.computeResources[0].Resource,
 		ResourcePool: types.ManagedObjectReference{

--- a/provider/vsphere/internal/vsphereclient/createvm_test.go
+++ b/provider/vsphere/internal/vsphereclient/createvm_test.go
@@ -19,6 +19,7 @@ import (
 	"golang.org/x/net/context"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/core/base"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/provider/vsphere/internal/ovatest"
 	coretesting "github.com/juju/juju/testing"
@@ -818,10 +819,10 @@ func baseImportOVAParameters(c *gc.C, client *Client) ImportOVAParameters {
 		},
 		TemplateName: "juju-template-" + fakeSHA256,
 		Arch:         "amd64",
-		Series:       "xenial",
+		Base:         base.MustParseBaseFromString("ubuntu@16.04"),
 		DestinationFolder: &object.Folder{
 			Common: object.Common{
-				InventoryPath: "/dc0/vm/juju-vmdks/ctrl/xenial",
+				InventoryPath: "/dc0/vm/juju-vmdks/ctrl/ubuntu_16.04",
 			},
 		},
 		Datastore: object.NewDatastore(client.client.Client, fakeDS),
@@ -842,7 +843,6 @@ func baseCreateVirtualMachineParams(c *gc.C, client *Client) CreateVirtualMachin
 	return CreateVirtualMachineParams{
 		Name:     "vm-0",
 		Folder:   "foo",
-		Series:   "xenial",
 		UserData: "baz",
 		ComputeResource: &mo.ComputeResource{
 			ResourcePool: &types.ManagedObjectReference{

--- a/provider/vsphere/vm_template.go
+++ b/provider/vsphere/vm_template.go
@@ -5,6 +5,7 @@ package vsphere
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"path"
@@ -21,7 +22,7 @@ import (
 )
 
 // vmTemplateManager implements a template registry that
-// can return a proper VMware template given a series and
+// can return a proper VMware template given a base and
 // image metadata.
 type vmTemplateManager struct {
 	imageMetadata    []*imagemetadata.ImageMetadata
@@ -35,29 +36,29 @@ type vmTemplateManager struct {
 	controllerUUID string
 }
 
-// EnsureTemplate will return a virtual machine template for the requested series.
+// EnsureTemplate will return a virtual machine template for the requested base.
 // If image metadata is supplied, this function will first look for "image-ids" entries
 // describing a template already available in the vsphere deployment. If none is found
 // or if no "image-ids" entries exist, it will then try to find a previously imported
 // template via "image-download" simplestreams entries. As a last resort, it will try
 // to import a new template from simplestreams.
-func (v *vmTemplateManager) EnsureTemplate(ctx context.Context, series string, agentArch string) (*object.VirtualMachine, string, error) {
+func (v *vmTemplateManager) EnsureTemplate(ctx context.Context, b base.Base, agentArch string) (*object.VirtualMachine, string, error) {
 	// Attempt to find image in image-metadata
 	logger.Debugf("looking for local templates")
 	tpl, arch, err := v.findTemplate(ctx)
 	if err == nil {
-		logger.Debugf("found requested template for series %s", series)
+		logger.Debugf("found requested template for base %s", b)
 		return tpl, arch, nil
 	}
 	if !errors.IsNotFound(err) {
 		return nil, "", errors.Annotate(err, "searching for template")
 	}
 
-	logger.Debugf("looking for already imported templates for series %q", series)
+	logger.Debugf("looking for already imported templates for base %q", b)
 	// Attempt to find a previously imported instance template
-	importedTemplate, arch, err := v.getImportedTemplate(ctx, series, agentArch)
+	importedTemplate, arch, err := v.getImportedTemplate(ctx, b, agentArch)
 	if err == nil {
-		logger.Debugf("using already imported template for series %s", series)
+		logger.Debugf("using already imported template for base %s", b)
 		return importedTemplate, arch, nil
 	}
 	logger.Debugf("could not find cached image: %s", err)
@@ -68,12 +69,12 @@ func (v *vmTemplateManager) EnsureTemplate(ctx context.Context, series string, a
 	}
 	logger.Debugf("downloading and importing template from simplestreams")
 	// Last resort, download and import a template.
-	return v.downloadAndImportTemplate(ctx, series, agentArch)
+	return v.downloadAndImportTemplate(ctx, b, agentArch)
 }
 
 // findTemplate uses the imageMetadata provided to find a local template.
 // The imageMetadata parameter holds a list of already filtered templates,
-// that should match the series that was requested.
+// that should match the base that was requested.
 func (v *vmTemplateManager) findTemplate(ctx context.Context) (*object.VirtualMachine, string, error) {
 	if len(v.imageMetadata) == 0 {
 		return nil, "", errors.NotFoundf("image metadata")
@@ -105,9 +106,9 @@ func (v *vmTemplateManager) controllerTemplatesFolder() string {
 	return path.Join(v.vmFolder, templateFolder)
 }
 
-func (v *vmTemplateManager) seriesTemplateFolder(series string) string {
+func (v *vmTemplateManager) baseTemplateFolder(b base.Base) string {
 	templatesPath := v.controllerTemplatesFolder()
-	return path.Join(templatesPath, series)
+	return path.Join(templatesPath, fmt.Sprintf("%s_%s", b.OS, b.Channel.Track))
 }
 
 func (v *vmTemplateManager) getVMArch(ctx context.Context, vmObj *object.VirtualMachine) (string, error) {
@@ -128,21 +129,21 @@ func (v *vmTemplateManager) getVMArch(ctx context.Context, vmObj *object.Virtual
 	return "", errors.NotFoundf("arch tag")
 }
 
-func (v *vmTemplateManager) getImportedTemplate(ctx context.Context, series string, agentArch string) (*object.VirtualMachine, string, error) {
-	logger.Tracef("getImportedTemplate for series %q, arch %q", series, agentArch)
-	seriesTemplatesFolder := v.seriesTemplateFolder(series)
-	seriesTemplates, err := v.client.ListVMTemplates(ctx, path.Join(seriesTemplatesFolder, "*"))
+func (v *vmTemplateManager) getImportedTemplate(ctx context.Context, b base.Base, agentArch string) (*object.VirtualMachine, string, error) {
+	logger.Tracef("getImportedTemplate for base %q, arch %q", b, agentArch)
+	baseTemplateFolder := v.baseTemplateFolder(b)
+	baseTemplates, err := v.client.ListVMTemplates(ctx, path.Join(baseTemplateFolder, "*"))
 	if err != nil {
 		logger.Tracef("failed to fetch templates: %v", err)
 		return nil, "", errors.Trace(err)
 	}
-	logger.Tracef("Series templates: %v", seriesTemplates)
-	if len(seriesTemplates) == 0 {
-		return nil, "", errors.NotFoundf("%s templates", series)
+	logger.Tracef("Base templates: %v", baseTemplates)
+	if len(baseTemplates) == 0 {
+		return nil, "", errors.NotFoundf("%s templates", b)
 	}
 	var vmTpl *object.VirtualMachine
 	var arch string
-	for _, item := range seriesTemplates {
+	for _, item := range baseTemplates {
 		arch, err = v.getVMArch(ctx, item)
 		if err != nil {
 			if errors.IsNotFound(err) {
@@ -161,7 +162,7 @@ func (v *vmTemplateManager) getImportedTemplate(ctx context.Context, series stri
 	if vmTpl == nil {
 		// Templates created by juju before 2.9, do not have an arch tag.
 		logger.Warningf("using default template since old templates do not contain arch")
-		vmTpl = seriesTemplates[0]
+		vmTpl = baseTemplates[0]
 	}
 
 	return vmTpl, arch, nil
@@ -169,22 +170,18 @@ func (v *vmTemplateManager) getImportedTemplate(ctx context.Context, series stri
 
 func (v *vmTemplateManager) downloadAndImportTemplate(
 	ctx context.Context,
-	series string, arch string,
+	b base.Base, arch string,
 ) (*object.VirtualMachine, string, error) {
 
-	seriesTemplateFolder := v.seriesTemplateFolder(series)
-	if len(v.vmFolder) > 0 && strings.HasPrefix(seriesTemplateFolder, v.vmFolder) {
-		seriesTemplateFolder = seriesTemplateFolder[len(v.vmFolder)+1:]
+	baseTemplateFolder := v.baseTemplateFolder(b)
+	if len(v.vmFolder) > 0 && strings.HasPrefix(baseTemplateFolder, v.vmFolder) {
+		baseTemplateFolder = baseTemplateFolder[len(v.vmFolder)+1:]
 	}
 
 	vmFolder, err := v.client.EnsureVMFolder(
-		ctx, v.vmFolder, seriesTemplateFolder)
+		ctx, v.vmFolder, baseTemplateFolder)
 	if err != nil {
 		return nil, "", errors.Trace(err)
-	}
-	b, err := base.GetBaseFromSeries(series)
-	if err != nil {
-		return nil, "", environs.ZoneIndependentError(err)
 	}
 	img, err := findImageMetadata(v.env, arch, b)
 	if err != nil {
@@ -208,7 +205,7 @@ func (v *vmTemplateManager) downloadAndImportTemplate(
 		StatusUpdateParams: v.statusUpdateArgs,
 		Datastore:          v.datastore,
 		Arch:               img.Arch,
-		Series:             series,
+		Base:               b,
 	}
 	vmTpl, err := v.client.CreateTemplateVM(ctx, ovaArgs)
 	if err != nil {

--- a/provider/vsphere/vm_template_test.go
+++ b/provider/vsphere/vm_template_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/core/base"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/provider/vsphere"
@@ -81,12 +82,12 @@ func (v *vmTemplateSuite) SetUpTest(c *gc.C) {
 func (v *vmTemplateSuite) addMockLocalTemplateToClient() {
 	args := vsphereclient.ImportOVAParameters{
 		OVASHA256:    ovatest.FakeOVASHA256(),
-		Series:       "jammy",
+		Base:         base.MustParseBaseFromString("ubuntu@22.04"),
 		Arch:         "amd64",
 		TemplateName: "juju-template-" + ovatest.FakeOVASHA256(),
 		DestinationFolder: object.NewFolder(nil, types.ManagedObjectReference{
 			Type:  "Folder",
-			Value: "custom-templates/jammy",
+			Value: "custom-templates/ubuntu_22.04",
 		}),
 	}
 	v.client.virtualMachineTemplates = []mockTemplateVM{
@@ -111,14 +112,14 @@ func (v *vmTemplateSuite) addMockDownloadedTemplateToClientNoArch() {
 func (v *vmTemplateSuite) mockDownloadedTemplateToClient(arch string) {
 	args := vsphereclient.ImportOVAParameters{
 		OVASHA256:    ovatest.FakeOVASHA256(),
-		Series:       "jammy",
+		Base:         base.MustParseBaseFromString("ubuntu@22.04"),
 		Arch:         arch,
 		TemplateName: "juju-template-" + ovatest.FakeOVASHA256(),
 		DestinationFolder: object.NewFolder(nil, types.ManagedObjectReference{
 			Type: "Folder",
 			// The mocked client does a strings.HasPrefix() on this path when listing templates.
 			// We do a greedy search when looking for already imported templates.
-			Value: "Juju Controller (deadbeef-1bad-500d-9000-4b1d0d06f00d)/templates/jammy/*",
+			Value: "Juju Controller (deadbeef-1bad-500d-9000-4b1d0d06f00d)/templates/ubuntu_22.04/*",
 		}),
 	}
 	v.client.virtualMachineTemplates = []mockTemplateVM{
@@ -140,7 +141,7 @@ func (v *vmTemplateSuite) TestEnsureTemplateNoImageMetadataSuppliedButImageExist
 		coretesting.FakeControllerConfig().ControllerUUID(),
 	)
 
-	tpl, arch, err := tplMgr.EnsureTemplate(context.Background(), "jammy", "amd64")
+	tpl, arch, err := tplMgr.EnsureTemplate(context.Background(), base.MustParseBaseFromString("ubuntu@22.04"), "amd64")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(tpl, gc.NotNil)
 	c.Assert(arch, gc.Equals, "amd64")
@@ -155,7 +156,7 @@ func (v *vmTemplateSuite) TestEnsureTemplateNoImageMetadataSuppliedAndImageDoesN
 		coretesting.FakeControllerConfig().ControllerUUID(),
 	)
 
-	_, _, err := tplMgr.EnsureTemplate(context.Background(), "xenial", "amd64")
+	_, _, err := tplMgr.EnsureTemplate(context.Background(), base.MustParseBaseFromString("ubuntu@16.04"), "amd64")
 	c.Assert(errors.Is(err, environs.ErrAvailabilityZoneIndependent), jc.IsTrue)
 	c.Assert(err.Error(), gc.Matches, "no matching images found for given constraints.*")
 	v.client.CheckCallNames(c, "ListVMTemplates", "EnsureVMFolder")
@@ -164,7 +165,7 @@ func (v *vmTemplateSuite) TestEnsureTemplateNoImageMetadataSuppliedAndImageDoesN
 func (v *vmTemplateSuite) TestEnsureTemplateWithImageMetadataSupplied(c *gc.C) {
 	imgMeta := []*imagemetadata.ImageMetadata{
 		{
-			Id:         "custom-templates/jammy",
+			Id:         "custom-templates/ubuntu_22.04",
 			RegionName: "/datacenter1",
 			Endpoint:   "host1",
 			Arch:       "amd64",
@@ -177,7 +178,7 @@ func (v *vmTemplateSuite) TestEnsureTemplateWithImageMetadataSupplied(c *gc.C) {
 		v.datastore, v.statusUpdateParams, "",
 		coretesting.FakeControllerConfig().ControllerUUID(),
 	)
-	tpl, arch, err := tplMgr.EnsureTemplate(context.Background(), "jammy", "amd64")
+	tpl, arch, err := tplMgr.EnsureTemplate(context.Background(), base.MustParseBaseFromString("ubuntu@22.04"), "amd64")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(tpl, jc.DeepEquals, v.client.virtualMachineTemplates[0].vm)
 	c.Assert(arch, gc.Equals, "amd64")
@@ -188,7 +189,7 @@ func (v *vmTemplateSuite) TestEnsureTemplateImageNotFoundLocally(c *gc.C) {
 	imgMeta := []*imagemetadata.ImageMetadata{
 		{
 			// this image ID does not exist in our mocked templates.
-			Id:         "custom-templates/xenial",
+			Id:         "custom-templates/ubuntu_16.04",
 			RegionName: "/datacenter1",
 			Endpoint:   "host1",
 			Arch:       "amd64",
@@ -203,7 +204,7 @@ func (v *vmTemplateSuite) TestEnsureTemplateImageNotFoundLocally(c *gc.C) {
 		coretesting.FakeControllerConfig().ControllerUUID(),
 	)
 	// jammy exists in the image-download simplestreams
-	tpl, arch, err := tplMgr.EnsureTemplate(context.Background(), "jammy", "amd64")
+	tpl, arch, err := tplMgr.EnsureTemplate(context.Background(), base.MustParseBaseFromString("ubuntu@22.04"), "amd64")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(tpl, gc.NotNil)
 	c.Assert(arch, gc.Equals, "amd64")
@@ -220,7 +221,7 @@ func (v *vmTemplateSuite) TestEnsureTemplateImageCachedImage(c *gc.C) {
 		coretesting.FakeControllerConfig().ControllerUUID(),
 	)
 
-	tpl, arch, err := tplMgr.EnsureTemplate(context.Background(), "jammy", "amd64")
+	tpl, arch, err := tplMgr.EnsureTemplate(context.Background(), base.MustParseBaseFromString("ubuntu@22.04"), "amd64")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(tpl, gc.NotNil)
 	c.Assert(arch, gc.Equals, "amd64")
@@ -236,7 +237,7 @@ func (v *vmTemplateSuite) TestEnsureTemplateImageCachedImageNoArch(c *gc.C) {
 		coretesting.FakeControllerConfig().ControllerUUID(),
 	)
 
-	tpl, arch, err := tplMgr.EnsureTemplate(context.Background(), "jammy", "amd64")
+	tpl, arch, err := tplMgr.EnsureTemplate(context.Background(), base.MustParseBaseFromString("ubuntu@22.04"), "amd64")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(tpl, gc.NotNil)
 	c.Assert(arch, gc.Equals, "")


### PR DESCRIPTION
In 3.5 we would cache our images in directories named according to the series. This meant converting a series to a base

Dop this conversion and instead name these directorys based on the striaght base

Since 3.6 is a new minor version requiring model migration to access, we don't need to worry about incompatibilities when upgrading in place

Fortunately, once a template is created, we only pass through the template structure (i.e. the whole dir), so this change was fairly simple and painless

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```
$ juju bootstrap vsphere-boston vsphere
Creating Juju controller "vsphere" on vsphere-boston/Boston
Looking for packaged Juju agent version 3.6-beta1 for amd64
No packaged binary found, preparing local Juju agent binary
Launching controller instance(s) on vsphere-boston/Boston...
 - juju-51e713-0 (arch=amd64 mem=3.5G)                                                                  
Installing Juju agent on bootstrap instance
Waiting for address
Attempting to connect to 10.246.157.128:22
Attempting to connect to [fe80::250:56ff:fe36:ec7c]:22
Connected to 10.246.157.128
Running machine configuration script...
Bootstrap agent now started
Contacting Juju controller at 10.246.157.128 to verify accessibility...

Bootstrap complete, controller "vsphere" is now available
Controller machines are in the "controller" model

Now you can run
	juju add-model <model-name>
to create a new model to deploy workloads.

$ juju status -m controller
Model       Controller  Cloud/Region           Version      SLA          Timestamp
controller  vsphere     vsphere-boston/Boston  3.6-beta1.1  unsupported  12:11:58+01:00

App         Version  Status  Scale  Charm            Channel     Rev  Exposed  Message
controller           active      1  juju-controller  3.6/stable   83  no       

Unit           Workload  Agent  Machine  Public address  Ports  Message
controller/0*  active    idle   0        10.246.157.128         

Machine  State    Address         Inst id        Base          AZ  Message
0        started  10.246.157.128  juju-51e713-0  ubuntu@22.04      poweredOn

$ juju add-model m
$ juju add-machine --base ubuntu@22.04
$ juju add-machine --base ubuntu@20.04
$ juju status
Model  Controller  Cloud/Region           Version      SLA          Timestamp
m      vsphere     vsphere-boston/Boston  3.6-beta1.1  unsupported  12:13:19+01:00

Machine  State    Address         Inst id        Base          AZ  Message
0        started  10.246.157.106  juju-0ed1b9-0  ubuntu@22.04      poweredOn
1        started  10.246.157.129  juju-0ed1b9-1  ubuntu@20.04      poweredOn
```

Observe in vsphere console
![image](https://github.com/juju/juju/assets/22304952/7a9612a1-a333-467c-a8af-0361ed726715)

### Migrate from 3.5

`juju-3.5` indicates juju build from `3.5` branch of `juju/juju`

```
$ juju-3.5 bootstrap vsphere-boston vsphere-3.5
$ juju-3.5 add-model m2
$ juju-3.5 deploy ubuntu jammy
$ juju-3.5 deploy ubuntu focal --base uubntu@20.04
(wait)
$ juju status
Model  Controller   Cloud/Region           Version  SLA          Timestamp
m2     vsphere-3.5  vsphere-boston/Boston  3.5.0.1  unsupported  12:44:09+01:00

App    Version  Status  Scale  Charm   Channel        Rev  Exposed  Message
focal  20.04    active      1  ubuntu  latest/stable   24  no       
jammy  22.04    active      1  ubuntu  latest/stable   24  no       

Unit      Workload  Agent  Machine  Public address  Ports  Message
focal/0*  active    idle   1        10.246.157.133         
jammy/0*  active    idle   0        10.246.157.130         

Machine  State    Address         Inst id        Base          AZ  Message
0        started  10.246.157.130  juju-293607-0  ubuntu@22.04      poweredOn
1        started  10.246.157.133  juju-293607-1  ubuntu@20.04      poweredOn

$ juju migrate m2 vsphere
$ juju switch vsphere:m2
$ juju upgrade-model
$ juju status
Model  Controller  Cloud/Region           Version      SLA          Timestamp
m2     vsphere     vsphere-boston/Boston  3.6-beta1.1  unsupported  12:46:17+01:00

App    Version  Status  Scale  Charm   Channel        Rev  Exposed  Message
focal  20.04    active      1  ubuntu  latest/stable   24  no       
jammy  22.04    active      1  ubuntu  latest/stable   24  no       

Unit      Workload  Agent  Machine  Public address  Ports  Message
focal/0*  active    idle   1        10.246.157.133         
jammy/0*  active    idle   0        10.246.157.130         

Machine  State    Address         Inst id        Base          AZ  Message
0        started  10.246.157.130  juju-293607-0  ubuntu@22.04      poweredOn
1        started  10.246.157.133  juju-293607-1  ubuntu@20.04      poweredOn

$ juju add-unit jammy
$ juju add-unit focal
(wait)
$ juju status
Model  Controller  Cloud/Region           Version      SLA          Timestamp
m2     vsphere     vsphere-boston/Boston  3.6-beta1.1  unsupported  12:48:57+01:00

App    Version  Status  Scale  Charm   Channel        Rev  Exposed  Message
focal           active      2  ubuntu  latest/stable   24  no       
jammy           active      2  ubuntu  latest/stable   24  no       

Unit      Workload  Agent  Machine  Public address  Ports  Message
focal/0*  active    idle   1        10.246.157.133         
focal/1   active    idle   3        10.246.157.121         
jammy/0*  active    idle   0        10.246.157.130         
jammy/1   active    idle   2        10.246.157.115         

Machine  State    Address         Inst id        Base          AZ  Message
0        started  10.246.157.130  juju-293607-0  ubuntu@22.04      poweredOn
1        started  10.246.157.133  juju-293607-1  ubuntu@20.04      poweredOn
2        started  10.246.157.115  juju-293607-2  ubuntu@20.04      poweredOn
3        started  10.246.157.121  juju-293607-3  ubuntu@20.04      poweredOn
```
