### PR TITLE
Use model access

### DIFF
--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -250,7 +250,7 @@ func (b *AgentBootstrap) Initialize(ctx stdcontext.Context) (_ *state.Controller
 		Credential:   credential.KeyFromTag(cloudCredTag),
 		UUID:         controllerModelUUID,
 	}
-	_, controllerModelCreateFunc := modelbootstrap.CreateModel(controllerModelArgs)
+	controllerModelCreateFunc := modelbootstrap.CreateModel(controllerModelArgs)
 
 	controllerModelDefaults := modeldefaultsbootstrap.ModelDefaultsProvider(
 		nil,

--- a/apiserver/facades/client/modelmanager/mocks/service_mock.go
+++ b/apiserver/facades/client/modelmanager/mocks/service_mock.go
@@ -137,13 +137,12 @@ func (m *MockModelService) EXPECT() *MockModelServiceMockRecorder {
 }
 
 // CreateModel mocks base method.
-func (m *MockModelService) CreateModel(arg0 context.Context, arg1 model0.ModelCreationArgs) (model.UUID, func(context.Context) error, error) {
+func (m *MockModelService) CreateModel(arg0 context.Context, arg1 model0.ModelCreationArgs) (func(context.Context) error, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateModel", arg0, arg1)
-	ret0, _ := ret[0].(model.UUID)
-	ret1, _ := ret[1].(func(context.Context) error)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+	ret0, _ := ret[0].(func(context.Context) error)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // CreateModel indicates an expected call of CreateModel.

--- a/apiserver/facades/client/modelmanager/mocks/service_mock.go
+++ b/apiserver/facades/client/modelmanager/mocks/service_mock.go
@@ -17,6 +17,7 @@ import (
 	model "github.com/juju/juju/core/model"
 	permission "github.com/juju/juju/core/permission"
 	user "github.com/juju/juju/core/user"
+	access "github.com/juju/juju/domain/access"
 	model0 "github.com/juju/juju/domain/model"
 	service "github.com/juju/juju/domain/secretbackend/service"
 	gomock "go.uber.org/mock/gomock"
@@ -73,6 +74,20 @@ func (m *MockAccessService) ReadUserAccessLevelForTarget(arg0 context.Context, a
 func (mr *MockAccessServiceMockRecorder) ReadUserAccessLevelForTarget(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadUserAccessLevelForTarget", reflect.TypeOf((*MockAccessService)(nil).ReadUserAccessLevelForTarget), arg0, arg1, arg2)
+}
+
+// UpdatePermission mocks base method.
+func (m *MockAccessService) UpdatePermission(arg0 context.Context, arg1 access.UpdatePermissionArgs) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdatePermission", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdatePermission indicates an expected call of UpdatePermission.
+func (mr *MockAccessServiceMockRecorder) UpdatePermission(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePermission", reflect.TypeOf((*MockAccessService)(nil).UpdatePermission), arg0, arg1)
 }
 
 // MockSecretBackendService is a mock of SecretBackendService interface.

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -258,10 +258,11 @@ func (m *ModelManagerAPI) createModelNew(
 	// if there was an error. If a failure to rollback occurs, then the endpoint
 	// should at least be somewhat idempotent.
 
+	modelUUID := coremodel.UUID(uuid)
 	creationArgs := model.ModelCreationArgs{
 		CloudRegion: args.CloudRegion,
 		Name:        args.Name,
-		UUID:        coremodel.UUID(uuid),
+		UUID:        modelUUID,
 	}
 
 	// We need to get the controller's default cloud and credential. To help
@@ -329,7 +330,7 @@ func (m *ModelManagerAPI) createModelNew(
 	}
 
 	// Create the model in the controller database.
-	modelUUID, finaliser, err := m.modelService.CreateModel(ctx, creationArgs)
+	finaliser, err := m.modelService.CreateModel(ctx, creationArgs)
 	if err != nil {
 		return errors.Annotatef(err, "failed to create model %q", modelUUID)
 	}

--- a/apiserver/facades/client/modelmanager/services.go
+++ b/apiserver/facades/client/modelmanager/services.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/juju/core/objectstore"
 	corepermission "github.com/juju/juju/core/permission"
 	coreuser "github.com/juju/juju/core/user"
+	"github.com/juju/juju/domain/access"
 	"github.com/juju/juju/domain/model"
 	modeldefaultsservice "github.com/juju/juju/domain/modeldefaults/service"
 	secretbackendservice "github.com/juju/juju/domain/secretbackend/service"
@@ -114,8 +115,10 @@ type AccessService interface {
 	// GetUserByName returns a User for the given name.
 	GetUserByName(context.Context, string) (coreuser.User, error)
 	// ReadUserAccessLevelForTarget returns the Access level for the given
-	// subject (user) on the given target.
+	// subject (user) on the given target (model).
 	ReadUserAccessLevelForTarget(ctx context.Context, subject string, target corepermission.ID) (corepermission.Access, error)
+	// UpdatePermission updates the access level for a user of the model.
+	UpdatePermission(ctx context.Context, args access.UpdatePermissionArgs) error
 }
 
 // NetworkService is the interface that is used to interact with the

--- a/apiserver/facades/client/modelmanager/services.go
+++ b/apiserver/facades/client/modelmanager/services.go
@@ -50,7 +50,7 @@ type ModelConfigService interface {
 // ModelService defines a interface for interacting with the underlying state.
 type ModelService interface {
 	// CreateModel creates a model.
-	CreateModel(context.Context, model.ModelCreationArgs) (coremodel.UUID, func(context.Context) error, error)
+	CreateModel(context.Context, model.ModelCreationArgs) (func(context.Context) error, error)
 
 	// DefaultModelCloudNameAndCredential returns the default cloud name and
 	// credential that should be used for newly created models that haven't had

--- a/domain/cloud/state/state_test.go
+++ b/domain/cloud/state/state_test.go
@@ -602,12 +602,12 @@ func (s *stateSuite) TestCloudIsControllerCloud(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = modelSt.Create(
 		context.Background(),
-		modelUUID,
 		coremodel.IAAS,
 		model.ModelCreationArgs{
 			Cloud: testCloud.Name,
 			Name:  coremodel.ControllerModelName,
 			Owner: user.UUID(s.adminUUID.String()),
+			UUID:  modelUUID,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/domain/model/bootstrap/bootstrap_test.go
+++ b/domain/model/bootstrap/bootstrap_test.go
@@ -71,29 +71,10 @@ type bootstrapSuite struct {
 
 var _ = gc.Suite(&bootstrapSuite{})
 
-func (s *bootstrapSuite) TestUUIDIsCreated(c *gc.C) {
-	uuid, fn := CreateModel(model.ModelCreationArgs{
-		AgentVersion: jujuversion.Current,
-		Cloud:        s.cloudName,
-		Credential: credential.Key{
-			Cloud: s.cloudName,
-			Name:  s.credentialName,
-			Owner: coreuser.AdminUserName,
-		},
-		Name:  "test",
-		Owner: s.adminUserUUID,
-	})
-
-	err := fn(context.Background(), s.ControllerTxnRunner(), s.NoopTxnRunner())
-	c.Assert(err, jc.ErrorIsNil)
-
-	c.Check(uuid.String() == "", jc.IsFalse)
-}
-
 func (s *bootstrapSuite) TestUUIDIsRespected(c *gc.C) {
 	modelUUID := modeltesting.GenModelUUID(c)
 
-	uuid, fn := CreateModel(model.ModelCreationArgs{
+	fn := CreateModel(model.ModelCreationArgs{
 		AgentVersion: jujuversion.Current,
 		Cloud:        s.cloudName,
 		Credential: credential.Key{
@@ -108,8 +89,6 @@ func (s *bootstrapSuite) TestUUIDIsRespected(c *gc.C) {
 
 	err := fn(context.Background(), s.ControllerTxnRunner(), s.NoopTxnRunner())
 	c.Assert(err, jc.ErrorIsNil)
-
-	c.Check(uuid, gc.Equals, modelUUID)
 }
 
 type modelBootstrapSuite struct {
@@ -142,7 +121,7 @@ func (s *modelBootstrapSuite) TestCreateReadOnlyModel(c *gc.C) {
 	}
 
 	// Create a model and then create a read-only model from it.
-	_, fn := CreateModel(args)
+	fn := CreateModel(args)
 	err := fn(context.Background(), s.ControllerTxnRunner(), s.NoopTxnRunner())
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/domain/model/modelmigration/import_test.go
+++ b/domain/model/modelmigration/import_test.go
@@ -154,7 +154,7 @@ func (i *importSuite) TestModelCreate(c *gc.C) {
 	controllerUUID, err := uuid.UUIDFromString(testing.ControllerTag.Id())
 	c.Assert(err, jc.ErrorIsNil)
 
-	i.modelService.EXPECT().CreateModel(gomock.Any(), args).Return(modelUUID, finaliser, nil)
+	i.modelService.EXPECT().CreateModel(gomock.Any(), args).Return(finaliser, nil)
 	i.readOnlyModelService.EXPECT().CreateModel(gomock.Any(), modelUUID, controllerUUID).Return(nil)
 
 	model := description.NewModel(description.ModelArgs{
@@ -225,7 +225,7 @@ func (i *importSuite) TestModelCreateRollbacksOnFailure(c *gc.C) {
 	controllerUUID, err := uuid.UUIDFromString(testing.ControllerTag.Id())
 	c.Assert(err, jc.ErrorIsNil)
 
-	i.modelService.EXPECT().CreateModel(gomock.Any(), args).Return(modelUUID, finaliser, nil)
+	i.modelService.EXPECT().CreateModel(gomock.Any(), args).Return(finaliser, nil)
 	i.readOnlyModelService.EXPECT().CreateModel(gomock.Any(), modelUUID, controllerUUID).Return(errors.New("boom"))
 	i.modelService.EXPECT().DeleteModel(gomock.Any(), modelUUID).Return(nil)
 	i.readOnlyModelService.EXPECT().DeleteModel(gomock.Any(), modelUUID).Return(nil)
@@ -300,7 +300,7 @@ func (i *importSuite) TestModelCreateRollbacksOnFailureIgnoreNotFoundModel(c *gc
 	controllerUUID, err := uuid.UUIDFromString(testing.ControllerTag.Id())
 	c.Assert(err, jc.ErrorIsNil)
 
-	i.modelService.EXPECT().CreateModel(gomock.Any(), args).Return(modelUUID, finaliser, nil)
+	i.modelService.EXPECT().CreateModel(gomock.Any(), args).Return(finaliser, nil)
 	i.readOnlyModelService.EXPECT().CreateModel(gomock.Any(), modelUUID, controllerUUID).Return(errors.New("boom"))
 	i.modelService.EXPECT().DeleteModel(gomock.Any(), modelUUID).Return(modelerrors.NotFound)
 	i.readOnlyModelService.EXPECT().DeleteModel(gomock.Any(), modelUUID).Return(nil)
@@ -375,7 +375,7 @@ func (i *importSuite) TestModelCreateRollbacksOnFailureIgnoreNotFoundReadOnlyMod
 	controllerUUID, err := uuid.UUIDFromString(testing.ControllerTag.Id())
 	c.Assert(err, jc.ErrorIsNil)
 
-	i.modelService.EXPECT().CreateModel(gomock.Any(), args).Return(modelUUID, finaliser, nil)
+	i.modelService.EXPECT().CreateModel(gomock.Any(), args).Return(finaliser, nil)
 	i.readOnlyModelService.EXPECT().CreateModel(gomock.Any(), modelUUID, controllerUUID).Return(errors.New("boom"))
 	i.modelService.EXPECT().DeleteModel(gomock.Any(), modelUUID).Return(nil)
 	i.readOnlyModelService.EXPECT().DeleteModel(gomock.Any(), modelUUID).Return(modelerrors.NotFound)

--- a/domain/model/modelmigration/migrations_mock_test.go
+++ b/domain/model/modelmigration/migrations_mock_test.go
@@ -45,13 +45,12 @@ func (m *MockModelService) EXPECT() *MockModelServiceMockRecorder {
 }
 
 // CreateModel mocks base method.
-func (m *MockModelService) CreateModel(arg0 context.Context, arg1 model0.ModelCreationArgs) (model.UUID, func(context.Context) error, error) {
+func (m *MockModelService) CreateModel(arg0 context.Context, arg1 model0.ModelCreationArgs) (func(context.Context) error, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateModel", arg0, arg1)
-	ret0, _ := ret[0].(model.UUID)
-	ret1, _ := ret[1].(func(context.Context) error)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+	ret0, _ := ret[0].(func(context.Context) error)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // CreateModel indicates an expected call of CreateModel.

--- a/domain/model/service/state_test.go
+++ b/domain/model/service/state_test.go
@@ -46,12 +46,11 @@ func (d *dummyState) CloudType(
 
 func (d *dummyState) Create(
 	_ context.Context,
-	uuid coremodel.UUID,
 	modelType coremodel.ModelType,
 	args model.ModelCreationArgs,
 ) error {
-	if _, exists := d.models[uuid]; exists {
-		return fmt.Errorf("%w %q", modelerrors.AlreadyExists, uuid)
+	if _, exists := d.models[args.UUID]; exists {
+		return fmt.Errorf("%w %q", modelerrors.AlreadyExists, args.UUID)
 	}
 
 	for _, v := range d.models {
@@ -86,10 +85,10 @@ func (d *dummyState) Create(
 		}
 	}
 
-	d.nonFinalisedModels[uuid] = coremodel.Model{
+	d.nonFinalisedModels[args.UUID] = coremodel.Model{
 		AgentVersion: args.AgentVersion,
 		Name:         args.Name,
-		UUID:         uuid,
+		UUID:         args.UUID,
 		ModelType:    modelType,
 		Cloud:        args.Cloud,
 		CloudRegion:  args.CloudRegion,

--- a/domain/model/state/state_test.go
+++ b/domain/model/state/state_test.go
@@ -134,7 +134,6 @@ func (m *stateSuite) SetUpTest(c *gc.C) {
 	modelSt := NewState(m.TxnRunnerFactory())
 	err = modelSt.Create(
 		context.Background(),
-		m.uuid,
 		coremodel.IAAS,
 		model.ModelCreationArgs{
 			AgentVersion: version.Current,
@@ -147,6 +146,7 @@ func (m *stateSuite) SetUpTest(c *gc.C) {
 			},
 			Name:  "my-test-model",
 			Owner: m.userUUID,
+			UUID:  m.uuid,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -212,7 +212,6 @@ func (m *stateSuite) TestModelCloudNameAndCredentialController(c *gc.C) {
 	// We need to first inject a model that does not have a cloud credential set
 	err = st.Create(
 		context.Background(),
-		modelUUID,
 		coremodel.IAAS,
 		model.ModelCreationArgs{
 			AgentVersion: version.Current,
@@ -224,6 +223,7 @@ func (m *stateSuite) TestModelCloudNameAndCredentialController(c *gc.C) {
 			},
 			Name:  coremodel.ControllerModelName,
 			Owner: userUUID,
+			UUID:  modelUUID,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -337,13 +337,13 @@ func (m *stateSuite) TestCreateModelWithExisting(c *gc.C) {
 		return createModel(
 			ctx,
 			tx,
-			m.uuid,
 			coremodel.IAAS,
 			model.ModelCreationArgs{
 				Cloud:       "my-cloud",
 				CloudRegion: "my-region",
 				Name:        "fantasticmodel",
 				Owner:       m.userUUID,
+				UUID:        m.uuid,
 			},
 		)
 	})
@@ -358,13 +358,13 @@ func (m *stateSuite) TestCreateModelWithSameNameAndOwner(c *gc.C) {
 	testUUID := modeltesting.GenModelUUID(c)
 	err := modelSt.Create(
 		context.Background(),
-		testUUID,
 		coremodel.IAAS,
 		model.ModelCreationArgs{
 			Cloud:       "my-cloud",
 			CloudRegion: "my-region",
 			Name:        "my-test-model",
 			Owner:       m.userUUID,
+			UUID:        testUUID,
 		},
 	)
 	c.Assert(err, jc.ErrorIs, modelerrors.AlreadyExists)
@@ -375,13 +375,13 @@ func (m *stateSuite) TestCreateModelWithInvalidCloudRegion(c *gc.C) {
 	testUUID := modeltesting.GenModelUUID(c)
 	err := modelSt.Create(
 		context.Background(),
-		testUUID,
 		coremodel.IAAS,
 		model.ModelCreationArgs{
 			Cloud:       "my-cloud",
 			CloudRegion: "noexist",
 			Name:        "noregion",
 			Owner:       m.userUUID,
+			UUID:        testUUID,
 		},
 	)
 	c.Assert(err, jc.ErrorIs, errors.NotFound)
@@ -392,7 +392,6 @@ func (m *stateSuite) TestCreateWithEmptyRegion(c *gc.C) {
 	testUUID := modeltesting.GenModelUUID(c)
 	err := modelSt.Create(
 		context.Background(),
-		testUUID,
 		coremodel.IAAS,
 		model.ModelCreationArgs{
 			Cloud: "my-cloud",
@@ -403,6 +402,7 @@ func (m *stateSuite) TestCreateWithEmptyRegion(c *gc.C) {
 				Owner: "test-user",
 				Name:  "foobar",
 			},
+			UUID: testUUID,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -420,7 +420,6 @@ func (m *stateSuite) TestCreateWithEmptyRegionUsesControllerRegion(c *gc.C) {
 
 	err := modelSt.Create(
 		context.Background(),
-		modeltesting.GenModelUUID(c),
 		coremodel.IAAS,
 		model.ModelCreationArgs{
 			Cloud:       "my-cloud",
@@ -432,6 +431,7 @@ func (m *stateSuite) TestCreateWithEmptyRegionUsesControllerRegion(c *gc.C) {
 				Owner: "test-user",
 				Name:  "foobar",
 			},
+			UUID: modeltesting.GenModelUUID(c),
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -439,7 +439,6 @@ func (m *stateSuite) TestCreateWithEmptyRegionUsesControllerRegion(c *gc.C) {
 	testUUID := modeltesting.GenModelUUID(c)
 	err = modelSt.Create(
 		context.Background(),
-		testUUID,
 		coremodel.IAAS,
 		model.ModelCreationArgs{
 			Cloud: "my-cloud",
@@ -450,6 +449,7 @@ func (m *stateSuite) TestCreateWithEmptyRegionUsesControllerRegion(c *gc.C) {
 				Owner: "test-user",
 				Name:  "foobar",
 			},
+			UUID: testUUID,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -469,7 +469,6 @@ func (m *stateSuite) TestCreateWithEmptyRegionDoesNotUseControllerRegionForDiffe
 
 	err := modelSt.Create(
 		context.Background(),
-		controllerUUID,
 		coremodel.IAAS,
 		model.ModelCreationArgs{
 			Cloud:       "my-cloud",
@@ -481,6 +480,7 @@ func (m *stateSuite) TestCreateWithEmptyRegionDoesNotUseControllerRegionForDiffe
 				Owner: "test-user",
 				Name:  "foobar",
 			},
+			UUID: controllerUUID,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -495,7 +495,6 @@ func (m *stateSuite) TestCreateWithEmptyRegionDoesNotUseControllerRegionForDiffe
 	testUUID := modeltesting.GenModelUUID(c)
 	err = modelSt.Create(
 		context.Background(),
-		testUUID,
 		coremodel.IAAS,
 		model.ModelCreationArgs{
 			Cloud: "other-cloud",
@@ -506,6 +505,7 @@ func (m *stateSuite) TestCreateWithEmptyRegionDoesNotUseControllerRegionForDiffe
 				Owner: "test-user",
 				Name:  "foobar",
 			},
+			UUID: testUUID,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -530,13 +530,13 @@ func (m *stateSuite) TestCreateModelWithNonExistentOwner(c *gc.C) {
 	testUUID := modeltesting.GenModelUUID(c)
 	err := modelSt.Create(
 		context.Background(),
-		testUUID,
 		coremodel.IAAS,
 		model.ModelCreationArgs{
 			Cloud:       "my-cloud",
 			CloudRegion: "noexist",
 			Name:        "noregion",
 			Owner:       user.UUID("noexist"), // does not exist
+			UUID:        testUUID,
 		},
 	)
 	c.Assert(err, jc.ErrorIs, usererrors.UserNotFound)
@@ -554,13 +554,13 @@ func (m *stateSuite) TestCreateModelWithRemovedOwner(c *gc.C) {
 	testUUID := modeltesting.GenModelUUID(c)
 	err = modelSt.Create(
 		context.Background(),
-		testUUID,
 		coremodel.IAAS,
 		model.ModelCreationArgs{
 			Cloud:       "my-cloud",
 			CloudRegion: "noexist",
 			Name:        "noregion",
 			Owner:       m.userUUID,
+			UUID:        testUUID,
 		},
 	)
 	c.Assert(err, jc.ErrorIs, usererrors.UserNotFound)
@@ -571,13 +571,13 @@ func (m *stateSuite) TestCreateModelWithInvalidCloud(c *gc.C) {
 	testUUID := modeltesting.GenModelUUID(c)
 	err := modelSt.Create(
 		context.Background(),
-		testUUID,
 		coremodel.IAAS,
 		model.ModelCreationArgs{
 			Cloud:       "noexist",
 			CloudRegion: "my-region",
 			Name:        "noregion",
 			Owner:       m.userUUID,
+			UUID:        testUUID,
 		},
 	)
 	c.Assert(err, jc.ErrorIs, errors.NotFound)
@@ -673,7 +673,6 @@ func (m *stateSuite) TestSetModelCloudCredentialWithoutRegion(c *gc.C) {
 	modelSt := NewState(m.TxnRunnerFactory())
 	err = modelSt.Create(
 		context.Background(),
-		m.uuid,
 		coremodel.CAAS,
 		model.ModelCreationArgs{
 			Cloud: "minikube",
@@ -684,6 +683,7 @@ func (m *stateSuite) TestSetModelCloudCredentialWithoutRegion(c *gc.C) {
 			},
 			Name:  "controller",
 			Owner: m.userUUID,
+			UUID:  m.uuid,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -738,7 +738,6 @@ func (m *stateSuite) TestListModelIDs(c *gc.C) {
 	modelSt := NewState(m.TxnRunnerFactory())
 	err := modelSt.Create(
 		context.Background(),
-		uuid1,
 		coremodel.IAAS,
 		model.ModelCreationArgs{
 			AgentVersion: version.Current,
@@ -751,6 +750,7 @@ func (m *stateSuite) TestListModelIDs(c *gc.C) {
 			},
 			Name:  "listtest1",
 			Owner: m.userUUID,
+			UUID:  uuid1,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -760,7 +760,6 @@ func (m *stateSuite) TestListModelIDs(c *gc.C) {
 	uuid2 := modeltesting.GenModelUUID(c)
 	err = modelSt.Create(
 		context.Background(),
-		uuid2,
 		coremodel.IAAS,
 		model.ModelCreationArgs{
 			AgentVersion: version.Current,
@@ -773,6 +772,7 @@ func (m *stateSuite) TestListModelIDs(c *gc.C) {
 			},
 			Name:  "listtest2",
 			Owner: m.userUUID,
+			UUID:  uuid2,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -849,7 +849,6 @@ func (m *stateSuite) TestModelsOwnedByUser(c *gc.C) {
 	modelSt := NewState(m.TxnRunnerFactory())
 	err := modelSt.Create(
 		context.Background(),
-		uuid1,
 		coremodel.IAAS,
 		model.ModelCreationArgs{
 			AgentVersion: version.Current,
@@ -862,6 +861,7 @@ func (m *stateSuite) TestModelsOwnedByUser(c *gc.C) {
 			},
 			Name:  "owned1",
 			Owner: m.userUUID,
+			UUID:  uuid1,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -870,7 +870,6 @@ func (m *stateSuite) TestModelsOwnedByUser(c *gc.C) {
 	uuid2 := modeltesting.GenModelUUID(c)
 	err = modelSt.Create(
 		context.Background(),
-		uuid2,
 		coremodel.IAAS,
 		model.ModelCreationArgs{
 			AgentVersion: version.Current,
@@ -883,6 +882,7 @@ func (m *stateSuite) TestModelsOwnedByUser(c *gc.C) {
 			},
 			Name:  "owned2",
 			Owner: m.userUUID,
+			UUID:  uuid2,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/domain/model/state/testing/model.go
+++ b/domain/model/state/testing/model.go
@@ -128,7 +128,6 @@ func CreateTestModel(
 	modelSt := modelstate.NewState(txnRunner)
 	err = modelSt.Create(
 		context.Background(),
-		modelUUID,
 		coremodel.IAAS,
 		model.ModelCreationArgs{
 			AgentVersion: version.Current,
@@ -140,6 +139,7 @@ func CreateTestModel(
 			},
 			Name:  name,
 			Owner: userUUID,
+			UUID:  modelUUID,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/domain/model/types.go
+++ b/domain/model/types.go
@@ -41,9 +41,7 @@ type ModelCreationArgs struct {
 	// Owner is the uuid of the user that owns this model in the Juju controller.
 	Owner user.UUID
 
-	// UUID represents the unique id for the model when being created. This
-	// value is optional and if omitted will be generated for the caller. Use
-	// this value when you are trying to import a model during model migration.
+	// UUID represents the unique id for the model when being created.
 	UUID coremodel.UUID
 }
 
@@ -64,11 +62,8 @@ func (m ModelCreationArgs) Validate() error {
 			return fmt.Errorf("credential: %w", err)
 		}
 	}
-
-	if m.UUID != "" {
-		if err := m.UUID.Validate(); err != nil {
-			return fmt.Errorf("uuid: %w", err)
-		}
+	if err := m.UUID.Validate(); err != nil {
+		return fmt.Errorf("uuid: %w", err)
 	}
 	return nil
 }

--- a/domain/model/types_test.go
+++ b/domain/model/types_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/juju/core/credential"
 	coremodel "github.com/juju/juju/core/model"
+	modeltesting "github.com/juju/juju/core/model/testing"
 	usertesting "github.com/juju/juju/core/user/testing"
 )
 
@@ -22,6 +23,7 @@ var _ = gc.Suite(&typesSuite{})
 
 func (*typesSuite) TestModelCreationArgsValidation(c *gc.C) {
 	userUUID := usertesting.GenUserUUID(c)
+	modelUUID := modeltesting.GenModelUUID(c)
 
 	tests := []struct {
 		Args    ModelCreationArgs
@@ -33,6 +35,7 @@ func (*typesSuite) TestModelCreationArgsValidation(c *gc.C) {
 				CloudRegion: "my-region",
 				Name:        "",
 				Owner:       userUUID,
+				UUID:        modelUUID,
 			},
 			ErrTest: errors.NotValid,
 		},
@@ -42,6 +45,7 @@ func (*typesSuite) TestModelCreationArgsValidation(c *gc.C) {
 				CloudRegion: "my-region",
 				Name:        "my-awesome-model",
 				Owner:       "",
+				UUID:        modelUUID,
 			},
 			ErrTest: errors.NotValid,
 		},
@@ -51,6 +55,7 @@ func (*typesSuite) TestModelCreationArgsValidation(c *gc.C) {
 				CloudRegion: "my-region",
 				Name:        "my-awesome-model",
 				Owner:       userUUID,
+				UUID:        modelUUID,
 			},
 			ErrTest: errors.NotValid,
 		},
@@ -60,6 +65,7 @@ func (*typesSuite) TestModelCreationArgsValidation(c *gc.C) {
 				CloudRegion: "",
 				Name:        "my-awesome-model",
 				Owner:       userUUID,
+				UUID:        modelUUID,
 			},
 			ErrTest: nil,
 		},
@@ -72,6 +78,7 @@ func (*typesSuite) TestModelCreationArgsValidation(c *gc.C) {
 				},
 				Name:  "my-awesome-model",
 				Owner: userUUID,
+				UUID:  modelUUID,
 			},
 			ErrTest: errors.NotValid,
 		},
@@ -91,6 +98,7 @@ func (*typesSuite) TestModelCreationArgsValidation(c *gc.C) {
 				CloudRegion: "my-region",
 				Name:        "my-awesome-model",
 				Owner:       userUUID,
+				UUID:        modelUUID,
 			},
 			ErrTest: nil,
 		},
@@ -105,6 +113,7 @@ func (*typesSuite) TestModelCreationArgsValidation(c *gc.C) {
 				},
 				Name:  "my-awesome-model",
 				Owner: userUUID,
+				UUID:  modelUUID,
 			},
 			ErrTest: nil,
 		},

--- a/domain/modelconfig/bootstrap/bootstrap_test.go
+++ b/domain/modelconfig/bootstrap/bootstrap_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/core/credential"
 	coremodel "github.com/juju/juju/core/model"
+	modeltesting "github.com/juju/juju/core/model/testing"
 	"github.com/juju/juju/core/permission"
 	coreuser "github.com/juju/juju/core/user"
 	userbootstrap "github.com/juju/juju/domain/access/bootstrap"
@@ -75,7 +76,8 @@ func (s *bootstrapSuite) SetUpTest(c *gc.C) {
 
 	testing.CreateInternalSecretBackend(c, s.ControllerTxnRunner())
 
-	id, fn := modelbootstrap.CreateModel(model.ModelCreationArgs{
+	modelUUID := modeltesting.GenModelUUID(c)
+	modelFn := modelbootstrap.CreateModel(model.ModelCreationArgs{
 		AgentVersion: jujuversion.Current,
 		Cloud:        cloudName,
 		Credential: credential.Key{
@@ -85,10 +87,11 @@ func (s *bootstrapSuite) SetUpTest(c *gc.C) {
 		},
 		Name:  "test",
 		Owner: userID,
+		UUID:  modelUUID,
 	})
-	s.modelID = id
+	s.modelID = modelUUID
 
-	err = fn(context.Background(), s.ControllerTxnRunner(), s.ControllerSuite.NoopTxnRunner())
+	err = modelFn(context.Background(), s.ControllerTxnRunner(), s.ControllerSuite.NoopTxnRunner())
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/domain/secretbackend/state/state_test.go
+++ b/domain/secretbackend/state/state_test.go
@@ -163,7 +163,6 @@ func (s *stateSuite) createModelWithName(c *gc.C, modelType coremodel.ModelType,
 	modelSt := modelestate.NewState(s.TxnRunnerFactory())
 	err = modelSt.Create(
 		context.Background(),
-		modelUUID,
 		modelType,
 		model.ModelCreationArgs{
 			AgentVersion: version.Current,
@@ -176,6 +175,7 @@ func (s *stateSuite) createModelWithName(c *gc.C, modelType coremodel.ModelType,
 			},
 			Name:  name,
 			Owner: userUUID,
+			UUID:  modelUUID,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/domain/servicefactory/testing/suite.go
+++ b/domain/servicefactory/testing/suite.go
@@ -147,22 +147,21 @@ func (s *ServiceFactorySuite) SeedModelDatabases(c *gc.C) {
 		UUID:         s.ControllerModelUUID,
 	}
 
-	uuid, fn := modelbootstrap.CreateModel(controllerArgs)
+	fn := modelbootstrap.CreateModel(controllerArgs)
 	c.Assert(backendbootstrap.CreateDefaultBackends(coremodel.IAAS)(
-		ctx, s.ControllerTxnRunner(), s.ModelTxnRunner(c, uuid.String())), jc.ErrorIsNil)
+		ctx, s.ControllerTxnRunner(), s.ModelTxnRunner(c, s.ControllerModelUUID.String())), jc.ErrorIsNil)
 	err = fn(ctx, s.ControllerTxnRunner(), s.NoopTxnRunner())
 	c.Assert(err, jc.ErrorIsNil)
-	s.ControllerModelUUID = uuid
 
-	err = modelbootstrap.CreateReadOnlyModel(uuid, controllerUUID)(ctx, s.ControllerTxnRunner(), s.ModelTxnRunner(c, uuid.String()))
+	err = modelbootstrap.CreateReadOnlyModel(s.ControllerModelUUID, controllerUUID)(ctx, s.ControllerTxnRunner(), s.ModelTxnRunner(c, s.ControllerModelUUID.String()))
 	c.Assert(err, jc.ErrorIsNil)
 
 	fn = modelconfigbootstrap.SetModelConfig(
-		uuid,
+		s.ControllerModelUUID,
 		nil,
 		modeldefaultsbootstrap.ModelDefaultsProvider(nil, nil, nil),
 	)
-	err = fn(ctx, s.ControllerTxnRunner(), s.ModelTxnRunner(c, uuid.String()))
+	err = fn(ctx, s.ControllerTxnRunner(), s.ModelTxnRunner(c, s.ControllerModelUUID.String()))
 	c.Assert(err, jc.ErrorIsNil)
 
 	modelArgs := modeldomain.ModelCreationArgs{
@@ -174,20 +173,19 @@ func (s *ServiceFactorySuite) SeedModelDatabases(c *gc.C) {
 		UUID:         s.DefaultModelUUID,
 	}
 
-	uuid, fn = modelbootstrap.CreateModel(modelArgs)
+	fn = modelbootstrap.CreateModel(modelArgs)
 	err = fn(ctx, s.ControllerTxnRunner(), s.NoopTxnRunner())
 	c.Assert(err, jc.ErrorIsNil)
-	s.DefaultModelUUID = uuid
 
-	err = modelbootstrap.CreateReadOnlyModel(uuid, controllerUUID)(ctx, s.ControllerTxnRunner(), s.ModelTxnRunner(c, uuid.String()))
+	err = modelbootstrap.CreateReadOnlyModel(s.DefaultModelUUID, controllerUUID)(ctx, s.ControllerTxnRunner(), s.ModelTxnRunner(c, s.DefaultModelUUID.String()))
 	c.Assert(err, jc.ErrorIsNil)
 
 	fn = modelconfigbootstrap.SetModelConfig(
-		uuid,
+		s.DefaultModelUUID,
 		nil,
 		modeldefaultsbootstrap.ModelDefaultsProvider(nil, nil, nil),
 	)
-	err = fn(ctx, s.ControllerTxnRunner(), s.ModelTxnRunner(c, uuid.String()))
+	err = fn(ctx, s.ControllerTxnRunner(), s.ModelTxnRunner(c, s.DefaultModelUUID.String()))
 	c.Assert(err, jc.ErrorIsNil)
 }
 


### PR DESCRIPTION
Update the model manager facade to use the access service for permissions rather than state. Part of the move to domains and dqlite.

Functionality of granting and revoking permissions on a model has been moved into the Access domain. Users() was not replaced in the modelmanager facade as it's being done as part of #17257 

Updated the model domain to give and remove permissions as models are created and deleted.

Secondarily, I found the dual uuids provided for creating a model to be highly error prone to the person just starting in this area. Updated for one uuid to be provided. All real calls provided a UUID, only the tests did it various ways. ModelType is only needed when calling the state version of create model, not the service version.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Ideally we could run `juju grant <username> write <modelname>` to test. However the checks on the other side, after you've logged in as a new user with permissions on a model that have been granted to you, aren't using the domain yet to verify. 

I've verified that UpdatePermission in the access domain is called. 

## Links

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/

**Jira card:** JUJU-5409

