### PR TITLE
Add default-space config validation for model config update

### DIFF
--- a/domain/modelconfig/service/service.go
+++ b/domain/modelconfig/service/service.go
@@ -30,6 +30,7 @@ type ModelDefaultsProvider interface {
 // model configuration values.
 type State interface {
 	ProviderState
+	SpaceValidatorState
 
 	// AgentVersion returns the current models agent version. If no agent
 	// version has been set for the current model then a error satisfying
@@ -48,7 +49,11 @@ type State interface {
 	// UpdateModelConfig is responsible for both inserting, updating and
 	// removing model config values for the current model.
 	UpdateModelConfig(context.Context, map[string]string, []string) error
+}
 
+// SpaceValidatorState represents the state entity for validating space-related
+// model config.
+type SpaceValidatorState interface {
 	// SpaceExists checks if the space identified by the given space name exists.
 	SpaceExists(ctx context.Context, spaceName string) (bool, error)
 }
@@ -305,15 +310,13 @@ func (*dummySecretsBackendProvider) HasSecretsBackend(_ string) (bool, error) {
 
 // spaceValidator implements validators.SpaceProvider.
 type spaceValidator struct {
-	st State
+	st SpaceValidatorState
 }
 
 // HasSpace implements validators.SpaceProvider. It checks whether the
 // given space exists.
-func (v *spaceValidator) HasSpace(spaceName string) (bool, error) {
-	// TODO(nvinuesa): We should inject the context into this function,
-	// which will come from the environs ValidateFunc.
-	return v.st.SpaceExists(context.TODO(), spaceName)
+func (v *spaceValidator) HasSpace(ctx context.Context, spaceName string) (bool, error) {
+	return v.st.SpaceExists(ctx, spaceName)
 }
 
 // updateModelConfigValidator returns a config validator to use on model config

--- a/domain/modelconfig/service/service.go
+++ b/domain/modelconfig/service/service.go
@@ -49,8 +49,8 @@ type State interface {
 	// removing model config values for the current model.
 	UpdateModelConfig(context.Context, map[string]string, []string) error
 
-	// CheckSpace checks if the space identified by the given space name exists.
-	CheckSpace(ctx context.Context, spaceName string) (bool, error)
+	// SpaceExists checks if the space identified by the given space name exists.
+	SpaceExists(ctx context.Context, spaceName string) (bool, error)
 }
 
 // WatcherFactory describes methods for creating watchers.
@@ -313,7 +313,7 @@ type spaceValidator struct {
 func (v *spaceValidator) HasSpace(spaceName string) (bool, error) {
 	// TODO(nvinuesa): We should inject the context into this function,
 	// which will come from the environs ValidateFunc.
-	return v.st.CheckSpace(context.TODO(), spaceName)
+	return v.st.SpaceExists(context.TODO(), spaceName)
 }
 
 // updateModelConfigValidator returns a config validator to use on model config

--- a/domain/modelconfig/service/testing/state.go
+++ b/domain/modelconfig/service/testing/state.go
@@ -126,3 +126,8 @@ func (s *MemoryState) UpdateModelConfig(
 	changes = append(changes, remove...)
 	return s.FeedChange(ctx, "model_config", changestream.Update, changes)
 }
+
+// CheckSpace checks if the space identified by the given space name exists.
+func (st *MemoryState) CheckSpace(ctx context.Context, spaceName string) (bool, error) {
+	return false, nil
+}

--- a/domain/modelconfig/service/testing/state.go
+++ b/domain/modelconfig/service/testing/state.go
@@ -127,7 +127,7 @@ func (s *MemoryState) UpdateModelConfig(
 	return s.FeedChange(ctx, "model_config", changestream.Update, changes)
 }
 
-// CheckSpace checks if the space identified by the given space name exists.
-func (st *MemoryState) CheckSpace(ctx context.Context, spaceName string) (bool, error) {
+// SpaceExists checks if the space identified by the given space name exists.
+func (st *MemoryState) SpaceExists(ctx context.Context, spaceName string) (bool, error) {
 	return false, nil
 }

--- a/domain/modelconfig/state/state.go
+++ b/domain/modelconfig/state/state.go
@@ -245,8 +245,8 @@ WHERE key = excluded.key
 	})
 }
 
-// CheckSpace checks if the space identified by the given space name exists.
-func (st *State) CheckSpace(ctx context.Context, spaceName string) (bool, error) {
+// SpaceExists checks if the space identified by the given space name exists.
+func (st *State) SpaceExists(ctx context.Context, spaceName string) (bool, error) {
 	db, err := st.DB()
 	if err != nil {
 		return false, errors.Trace(err)
@@ -260,7 +260,7 @@ func (st *State) CheckSpace(ctx context.Context, spaceName string) (bool, error)
 		if err := row.Scan(&res); errors.Is(err, sql.ErrNoRows) {
 			return nil
 		} else if err != nil {
-			return domain.CoerceError(err)
+			return domain.CoerceError(errors.Annotatef(err, "checking space %q exists", spaceName))
 		}
 		exists = true
 		return nil

--- a/domain/modelconfig/state/state_test.go
+++ b/domain/modelconfig/state/state_test.go
@@ -168,3 +168,19 @@ func (s *stateSuite) TestAgentVersion(c *gc.C) {
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(version, gc.Equals, "1.2.3")
 }
+
+func (s *stateSuite) TestCheckSpace(c *gc.C) {
+	st := state.NewState(s.TxnRunnerFactory())
+	db := s.DB()
+
+	_, err := db.Exec("INSERT INTO space (uuid, name) VALUES ('1', 'foo')")
+	c.Assert(err, jc.ErrorIsNil)
+
+	exists, err := st.CheckSpace(context.Background(), "bar")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(exists, jc.IsFalse)
+
+	exists, err = st.CheckSpace(context.Background(), "foo")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(exists, jc.IsTrue)
+}

--- a/domain/modelconfig/state/state_test.go
+++ b/domain/modelconfig/state/state_test.go
@@ -176,11 +176,11 @@ func (s *stateSuite) TestCheckSpace(c *gc.C) {
 	_, err := db.Exec("INSERT INTO space (uuid, name) VALUES ('1', 'foo')")
 	c.Assert(err, jc.ErrorIsNil)
 
-	exists, err := st.CheckSpace(context.Background(), "bar")
+	exists, err := st.SpaceExists(context.Background(), "bar")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(exists, jc.IsFalse)
 
-	exists, err = st.CheckSpace(context.Background(), "foo")
+	exists, err = st.SpaceExists(context.Background(), "foo")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(exists, jc.IsTrue)
 }

--- a/domain/modelconfig/validators/validators.go
+++ b/domain/modelconfig/validators/validators.go
@@ -82,7 +82,7 @@ type SpaceProvider interface {
 	// HasSpace checks if the supplied space exists within the controller. If
 	// during the course of checking for space existence false and an error will
 	// be returned.
-	HasSpace(string) (bool, error)
+	HasSpace(context.Context, string) (bool, error)
 }
 
 // SpaceChecker will validate a model config's space to see if it exists within
@@ -96,7 +96,7 @@ func SpaceChecker(provider SpaceProvider) config.ValidatorFunc {
 			return cfg, nil
 		}
 
-		has, err := provider.HasSpace(spaceName)
+		has, err := provider.HasSpace(ctx, spaceName)
 		if err != nil {
 			return cfg, fmt.Errorf("checking for space %q existence to validate model config: %w", spaceName, err)
 		}

--- a/domain/modelconfig/validators/validators_test.go
+++ b/domain/modelconfig/validators/validators_test.go
@@ -16,7 +16,7 @@ import (
 
 type dummySecretBackendProviderFunc func(string) (bool, error)
 
-type dummySpaceProviderFunc func(string) (bool, error)
+type dummySpaceProviderFunc func(context.Context, string) (bool, error)
 
 type validatorsSuite struct{}
 
@@ -26,8 +26,8 @@ func (d dummySecretBackendProviderFunc) HasSecretsBackend(s string) (bool, error
 	return d(s)
 }
 
-func (d dummySpaceProviderFunc) HasSpace(s string) (bool, error) {
-	return d(s)
+func (d dummySpaceProviderFunc) HasSpace(ctx context.Context, s string) (bool, error) {
+	return d(ctx, s)
 }
 
 func (*validatorsSuite) TestCharmhubURLChange(c *gc.C) {
@@ -141,7 +141,7 @@ func (*validatorsSuite) TestAgentVersionNoChange(c *gc.C) {
 }
 
 func (*validatorsSuite) TestSpaceCheckerFound(c *gc.C) {
-	provider := dummySpaceProviderFunc(func(s string) (bool, error) {
+	provider := dummySpaceProviderFunc(func(ctx context.Context, s string) (bool, error) {
 		c.Assert(s, gc.Equals, "foobar")
 		return true, nil
 	})
@@ -167,7 +167,7 @@ func (*validatorsSuite) TestSpaceCheckerFound(c *gc.C) {
 }
 
 func (*validatorsSuite) TestSpaceCheckerNotFound(c *gc.C) {
-	provider := dummySpaceProviderFunc(func(s string) (bool, error) {
+	provider := dummySpaceProviderFunc(func(ctx context.Context, s string) (bool, error) {
 		c.Assert(s, gc.Equals, "foobar")
 		return false, nil
 	})
@@ -196,7 +196,7 @@ func (*validatorsSuite) TestSpaceCheckerNotFound(c *gc.C) {
 
 func (*validatorsSuite) TestSpaceCheckerError(c *gc.C) {
 	providerErr := errors.New("some error")
-	provider := dummySpaceProviderFunc(func(s string) (bool, error) {
+	provider := dummySpaceProviderFunc(func(ctx context.Context, s string) (bool, error) {
 		c.Assert(s, gc.Equals, "foobar")
 		return false, providerErr
 	})


### PR DESCRIPTION
This patch adds the space checker validation, which was previously not implemented.

The way it works is simply by querying the space table on with the provided space name and returning true if the space exists.

## Checklist


- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

_Note: this method is only used when updating the model config, and the updating is not wired yet. So no QA is possible, only unit tests:_

```
TEST_PACKAGES="./domain/modelconfig/... -count=1 -race -check.vv" make run-go-tests
```
## Links

**Jira card:** JUJU-5884

