### PR TITLE
Implement core/watcher.Normalise that reduces any watcher to a NotifyWatcher

### DIFF
--- a/apiserver/common/modelwatcher.go
+++ b/apiserver/common/modelwatcher.go
@@ -51,11 +51,15 @@ func NewModelWatcher(modelConfigService ModelConfigService, watcherRegistry faca
 // so we use the regular error return.
 func (m *ModelWatcher) WatchForModelConfigChanges(ctx context.Context) (params.NotifyWatchResult, error) {
 	result := params.NotifyWatchResult{}
-	watcher, err := m.modelConfigService.Watch()
+	w, err := m.modelConfigService.Watch()
 	if err != nil {
 		return result, errors.Trace(err)
 	}
-	result.NotifyWatcherId, _, err = internal.EnsureRegisterWatcher[[]string](ctx, m.watcherRegistry, watcher)
+	notifyWatcher, err := watcher.Normalise[[]string](w)
+	if err != nil {
+		return result, errors.Trace(err)
+	}
+	result.NotifyWatcherId, _, err = internal.EnsureRegisterWatcher[struct{}](ctx, m.watcherRegistry, notifyWatcher)
 	return result, err
 }
 

--- a/core/watcher/normalise.go
+++ b/core/watcher/normalise.go
@@ -1,0 +1,74 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package watcher
+
+import (
+	"github.com/juju/worker/v4"
+	"github.com/juju/worker/v4/catacomb"
+)
+
+// Normalise takes any watcher and normalises it down to a NotifyWatcher.
+// This is useful in legacy code that expects a NotifyWatcher.
+func Normalise[T any](source Watcher[T]) (NotifyWatcher, error) {
+	if w, ok := source.(NotifyWatcher); ok {
+		// If we are already a NotifyWatcher, we can return the source watcher.
+		return w, nil
+	}
+
+	ch := make(chan struct{})
+	w := &normaliseWatcher{
+		ch: ch,
+	}
+	loop := func() error {
+		defer close(ch)
+		for {
+			select {
+			case <-w.catacomb.Dying():
+				return w.catacomb.ErrDying()
+
+			case _, ok := <-source.Changes():
+				if !ok {
+					select {
+					case <-w.catacomb.Dying():
+						return w.catacomb.ErrDying()
+					default:
+						return nil
+					}
+				}
+				select {
+				case <-w.catacomb.Dying():
+					return w.catacomb.ErrDying()
+				case ch <- struct{}{}:
+				}
+			}
+		}
+	}
+
+	err := catacomb.Invoke(catacomb.Plan{
+		Site: &w.catacomb,
+		Work: loop,
+		Init: []worker.Worker{source},
+	})
+	if err != nil {
+		return nil, err
+	}
+	return w, nil
+}
+
+type normaliseWatcher struct {
+	catacomb catacomb.Catacomb
+	ch       chan struct{}
+}
+
+func (w *normaliseWatcher) Kill() {
+	w.catacomb.Kill(nil)
+}
+
+func (w *normaliseWatcher) Wait() error {
+	return w.catacomb.Wait()
+}
+
+func (w *normaliseWatcher) Changes() <-chan struct{} {
+	return w.ch
+}

--- a/core/watcher/normalise_test.go
+++ b/core/watcher/normalise_test.go
@@ -1,0 +1,68 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package watcher_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/worker/v4/workertest"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/watcher"
+	"github.com/juju/juju/core/watcher/watchertest"
+)
+
+type normaliseWatcherSuite struct{}
+
+var _ = gc.Suite(&normaliseWatcherSuite{})
+
+func (s *normaliseWatcherSuite) TestStringsWatcher(c *gc.C) {
+	ch := make(chan []string, 1)
+	source := watchertest.NewMockStringsWatcher(ch)
+
+	nw, err := watcher.Normalise[[]string](source)
+	c.Assert(err, jc.ErrorIsNil)
+
+	nwC := watchertest.NewNotifyWatcherC(c, nw)
+
+	ch <- []string{}
+	nwC.AssertOneChange()
+
+	ch <- []string{"does", "not", "matter"}
+	nwC.AssertOneChange()
+
+	nwC.AssertNoChange()
+
+	nwC.AssertKilled()
+}
+
+func (s *normaliseWatcherSuite) TestSourceDies(c *gc.C) {
+	ch := make(chan []string, 1)
+	source := watchertest.NewMockStringsWatcher(ch)
+
+	nw, err := watcher.Normalise[[]string](source)
+	c.Assert(err, jc.ErrorIsNil)
+
+	nwC := watchertest.NewNotifyWatcherC(c, nw)
+
+	ch <- []string{}
+	nwC.AssertOneChange()
+
+	ch <- []string{"does", "not", "matter"}
+	nwC.AssertOneChange()
+
+	nwC.AssertNoChange()
+
+	workertest.CleanKill(c, source)
+	close(ch)
+	workertest.CheckKilled(c, nw)
+}
+
+func (s *normaliseWatcherSuite) TestNotifyWatcherElided(c *gc.C) {
+	ch := make(chan struct{}, 1)
+	source := watchertest.NewMockNotifyWatcher(ch)
+
+	nw, err := watcher.Normalise[struct{}](source)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(nw, gc.Equals, source)
+}


### PR DESCRIPTION
The model config service implements it's watcher as a strings watcher, but the facades were expecting a notify watcher. This introduces a Normalise function to the core/watcher package to easily convert any watcher into a notify watcher for legacy code that expects a notify watcher.

## QA steps

Unit tests

## Documentation changes

N/A

## Links

**Jira card:** JUJU-

