### PR TITLE
Match by MAC in Netplan for LXD VMs

### DIFF
--- a/cloudconfig/cloudinit/cloudinit.go
+++ b/cloudconfig/cloudinit/cloudinit.go
@@ -82,15 +82,15 @@ type cloudConfig struct {
 	// update_hostname
 	attrs map[string]interface{}
 
-	// omitNetplanHWAddrMatch if true, causes Netplan to be rendered without
+	// useNetplanHWAddrMatch if false, causes Netplan to be rendered without
 	// a stanza that matches by MAC address in order to apply configuration to
 	// a device.
-	// This will be recruited for LXD, where we have observed 22.04 containers
-	// being assigned a different MAC to the one configured.
+	// This will be disabled for LXD containers, where we have observed 22.04
+	// containers being assigned a different MAC to the one configured.
 	// For these cases we fall back to the default match by ID (name).
 	// MAC address matching is still required by KVM where devices are assigned
 	// different names by the kernel to those we configured.
-	omitNetplanHWAddrMatch bool
+	useNetplanHWAddrMatch bool
 }
 
 // getPackagingConfigurer is defined on the AdvancedPackagingConfig interface.

--- a/cloudconfig/cloudinit/interface.go
+++ b/cloudconfig/cloudinit/interface.go
@@ -408,8 +408,13 @@ type NetworkingConfig interface {
 	AddNetworkConfig(interfaces corenetwork.InterfaceInfos) error
 }
 
-func WithDisableNetplanMACMatch(cfg *cloudConfig) {
-	cfg.omitNetplanHWAddrMatch = true
+// WithNetplanMACMatch returns a cloud config option for telling Netplan
+// whether to match by MAC address (true) or the interface name (false) when
+// configuring NICs.
+func WithNetplanMACMatch(enabled bool) func(*cloudConfig) {
+	return func(cfg *cloudConfig) {
+		cfg.useNetplanHWAddrMatch = enabled
+	}
 }
 
 // New returns a new Config with no options set.

--- a/cloudconfig/cloudinit/interface_test.go
+++ b/cloudconfig/cloudinit/interface_test.go
@@ -17,7 +17,7 @@ type InterfaceSuite struct{}
 var _ = gc.Suite(InterfaceSuite{})
 
 func (HelperSuite) TestNewCloudConfigWithoutMACMatch(c *gc.C) {
-	cfg, err := New("ubuntu", WithDisableNetplanMACMatch)
+	cfg, err := New("ubuntu", WithNetplanMACMatch(true))
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(cfg.(*ubuntuCloudConfig).omitNetplanHWAddrMatch, jc.IsTrue)
+	c.Check(cfg.(*ubuntuCloudConfig).useNetplanHWAddrMatch, jc.IsTrue)
 }

--- a/cloudconfig/cloudinit/network_ubuntu.go
+++ b/cloudconfig/cloudinit/network_ubuntu.go
@@ -204,6 +204,7 @@ func GenerateNetplan(interfaces corenetwork.InterfaceInfos, matchHWAddr bool) (s
 	if err != nil {
 		return "", errors.Trace(err)
 	}
+
 	return string(out), nil
 }
 
@@ -320,7 +321,7 @@ func (cfg *ubuntuCloudConfig) AddNetworkConfig(interfaces corenetwork.InterfaceI
 		if err != nil {
 			return errors.Trace(err)
 		}
-		netPlan, err := GenerateNetplan(interfaces, !cfg.omitNetplanHWAddrMatch)
+		netPlan, err := GenerateNetplan(interfaces, cfg.useNetplanHWAddrMatch)
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/cloudconfig/cloudinit/network_ubuntu_test.go
+++ b/cloudconfig/cloudinit/network_ubuntu_test.go
@@ -409,7 +409,7 @@ network:
 
 func (s *NetworkUbuntuSuite) TestAddNetworkConfigSampleConfig(c *gc.C) {
 	netConfig := container.BridgeNetworkConfig(0, s.fakeInterfaces)
-	cloudConf, err := cloudinit.New("ubuntu")
+	cloudConf, err := cloudinit.New("ubuntu", cloudinit.WithNetplanMACMatch(true))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cloudConf, gc.NotNil)
 	err = cloudConf.AddNetworkConfig(netConfig.Interfaces)

--- a/container/kvm/kvm.go
+++ b/container/kvm/kvm.go
@@ -184,7 +184,8 @@ func (manager *containerManager) CreateContainer(
 	kvmContainer := KVMObjectFactory.New(name)
 
 	// Create the cloud-init.
-	cloudConfig, err := cloudinit.New(instanceConfig.Base.OS)
+	// Netplan configures NICs by matching MAC addresses.
+	cloudConfig, err := cloudinit.New(instanceConfig.Base.OS, cloudinit.WithNetplanMACMatch(true))
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}

--- a/container/lxd/manager.go
+++ b/container/lxd/manager.go
@@ -273,7 +273,9 @@ func (m *containerManager) getContainerSpec(
 		networkConfig.Interfaces = interfaces
 	}
 
-	cloudConfig, err := cloudinit.New(instanceConfig.Base.OS, cloudinit.WithDisableNetplanMACMatch)
+	// We tell Netplan to match by interface name for containers; by MAC for VMs.
+	cloudConfig, err := cloudinit.New(
+		instanceConfig.Base.OS, cloudinit.WithNetplanMACMatch(virtType == api.InstanceTypeVM))
 	if err != nil {
 		return ContainerSpec{}, errors.Trace(err)
 	}


### PR DESCRIPTION
Some time ago, we observed that 22.04 LXD containers were sometimes getting NICs with different MAC addresses to what the on-machine broker was configuring.

At this time we changed the behaviour of the cloud-init Netplan generation to match NICs by name instead of MAC when provisioning LXD containers.

The linked bug describes network configuration failures for VMs on LXD due to being unable to match by name. This is because interfaces get the kernel generated names (such as "ens5s0") instead of the configured "eth0".

Here we recruit matching by name specifically for LXD _containers_. LXD VMs and VMs provisioned by the KVM broker use MAC matching, which fixes the issue.

## QA steps

I tested on MAAS, but the manual provider should work.
- `juju add-model work`.
- `juju add-machine`.
- `juju deploy ubuntu --to lxd:0 --constraints virt-type=virtual-machine`.
- Ensure quiescence.

## Documentation changes

None.

## Links

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2064515

**Jira card:** [JUJU-5981](https://warthogs.atlassian.net/browse/JUJU-5981)



[JUJU-5981]: https://warthogs.atlassian.net/browse/JUJU-5981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ