### PR TITLE
Remove LegacyKubernetesSeries

### DIFF
--- a/core/base/base.go
+++ b/core/base/base.go
@@ -182,8 +182,3 @@ func GetSeriesFromBase(v Base) (string, error) {
 func LegacyKubernetesBase() Base {
 	return MakeDefaultBase(UbuntuOS, "20.04")
 }
-
-// LegacyKubernetesSeries is the ubuntu series for legacy k8s charms.
-func LegacyKubernetesSeries() string {
-	return "focal"
-}

--- a/core/bundle/changes/handlers.go
+++ b/core/bundle/changes/handlers.go
@@ -53,7 +53,8 @@ func (r *resolver) handleApplications() (map[string]string, error) {
 		application := applications[name]
 		// Legacy k8s charms - assume ubuntu focal.
 		if application.Series == kubernetes {
-			application.Series = corebase.LegacyKubernetesSeries()
+			application.Series = ""
+			application.Base = corebase.LegacyKubernetesBase().String()
 		}
 		existingApp := existing.GetApplication(name)
 		computedBase, err := computeApplicationBase(application, defaultBase)

--- a/juju/testing/conn.go
+++ b/juju/testing/conn.go
@@ -845,12 +845,15 @@ func (s *JujuConnSuite) AddTestingCharmForSeries(c *gc.C, name, series string) *
 
 func (s *JujuConnSuite) AddTestingApplication(c *gc.C, name string, ch *state.Charm) *state.Application {
 	curl := charm.MustParseURL(ch.URL())
+	var base corebase.Base
 	appSeries := curl.Series
 	if appSeries == "kubernetes" {
-		appSeries = corebase.LegacyKubernetesSeries()
+		base = corebase.LegacyKubernetesBase()
+	} else {
+		var err error
+		base, err = corebase.GetBaseFromSeries(appSeries)
+		c.Assert(err, jc.ErrorIsNil)
 	}
-	base, err := corebase.GetBaseFromSeries(appSeries)
-	c.Assert(err, jc.ErrorIsNil)
 	app, err := s.State.AddApplication(state.AddApplicationArgs{
 		Name: name, Charm: ch,
 		CharmOrigin: &state.CharmOrigin{

--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -494,11 +494,14 @@ func (factory *Factory) MakeApplicationReturningPassword(c *gc.C, params *Applic
 		curl := charm.MustParseURL(params.Charm.URL())
 		chSeries := curl.Series
 		// Legacy k8s charms - assume ubuntu focal.
+		var base corebase.Base
 		if chSeries == "kubernetes" {
-			chSeries = corebase.LegacyKubernetesSeries()
+			base = corebase.LegacyKubernetesBase()
+		} else {
+			var err error
+			base, err = corebase.GetBaseFromSeries(chSeries)
+			c.Assert(err, jc.ErrorIsNil)
 		}
-		base, err := corebase.GetBaseFromSeries(chSeries)
-		c.Assert(err, jc.ErrorIsNil)
 		var channel *state.Channel
 		var source string
 		// local charms cannot have a channel


### PR DESCRIPTION
Remove LegacyKubernetesSeries

Use LegacyKubernetesBase everywhere instead

The only place outside of tests this is used is in bundle deploy. In this case, make use of the 'new' application.Base attribute and drop the series 

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

All unit tests pass

#### Deploy a bundle with legacy 'kubernetes' series

Bootstrap
```
$ make microk8s-operator-upgarde
$ juju bootstrap microk8s mk8s
$ juju add-model m
```

Construct bundle
```
$ juju download cos-lite
Fetching bundle "cos-lite" revision 11 using "stable" channel and base "amd64/ubuntu/22.04"
Install the "cos-lite" bundle with:
    juju deploy ./cos-lite_r11.bundle

$ unzip cos-lite_r11.bundle
[edit ./bundle.yaml such that:]
$ cat bundle.yaml
---
bundle: kubernetes
name: cos-lite
description: >
  COS Lite is a light-weight, highly-integrated, observability stack running on Kubernetes
applications:
  traefik:
    charm: traefik-k8s
    series: kubernetes
    scale: 1
    trust: true
    channel: stable
  alertmanager:
    charm: alertmanager-k8s
    series: kubernetes
    scale: 1
    trust: true
    channel: stable
  prometheus:
    charm: prometheus-k8s
    series: kubernetes
    scale: 1
    trust: true
    channel: stable
  grafana:
    charm: grafana-k8s
    series: kubernetes
    scale: 1
    trust: true
    channel: stable
  catalogue:
    charm: catalogue-k8s
    series: kubernetes
    scale: 1
    trust: true
    channel: stable
...
```

Deploy
```
$ juju deploy ./bundle
Located charm "alertmanager-k8s" in charm-hub, channel latest/stable
Located charm "catalogue-k8s" in charm-hub, channel latest/stable
Located charm "grafana-k8s" in charm-hub, channel latest/stable
Located charm "loki-k8s" in charm-hub, channel latest/stable
Located charm "prometheus-k8s" in charm-hub, channel latest/stable
Located charm "traefik-k8s" in charm-hub, channel latest/stable
Executing changes:
- upload charm alertmanager-k8s from charm-hub for base ubuntu@20.04/stable from channel stable with architecture=amd64
- deploy application alertmanager from charm-hub with 1 unit on ubuntu@20.04/stable with stable using alertmanager-k8s
  added resource alertmanager-image
- upload charm catalogue-k8s from charm-hub for base ubuntu@20.04/stable from channel stable with architecture=amd64
- deploy application catalogue from charm-hub with 1 unit on ubuntu@20.04/stable with stable using catalogue-k8s
  added resource catalogue-image
- upload charm grafana-k8s from charm-hub for base ubuntu@20.04/stable from channel stable with architecture=amd64
- deploy application grafana from charm-hub with 1 unit on ubuntu@20.04/stable with stable using grafana-k8s
  added resource grafana-image
  added resource litestream-image
- upload charm loki-k8s from charm-hub from channel stable with architecture=amd64
- deploy application loki from charm-hub with 1 unit with stable using loki-k8s
  added resource loki-image
- upload charm prometheus-k8s from charm-hub for base ubuntu@20.04/stable from channel stable with architecture=amd64
- deploy application prometheus from charm-hub with 1 unit on ubuntu@20.04/stable with stable using prometheus-k8s
  added resource prometheus-image
- upload charm traefik-k8s from charm-hub for base ubuntu@20.04/stable from channel stable with architecture=amd64
- deploy application traefik from charm-hub with 1 unit on ubuntu@20.04/stable with stable using traefik-k8s
  added resource traefik-image
- add relation traefik:ingress-per-unit - prometheus:ingress
- add relation traefik:ingress-per-unit - loki:ingress
- add relation traefik:traefik-route - grafana:ingress
- add relation traefik:ingress - alertmanager:ingress
- add relation prometheus:alertmanager - alertmanager:alerting
- add relation grafana:grafana-source - prometheus:grafana-source
- add relation grafana:grafana-source - loki:grafana-source
- add relation grafana:grafana-source - alertmanager:grafana-source
- add relation loki:alertmanager - alertmanager:alerting
- add relation prometheus:metrics-endpoint - traefik:metrics-endpoint
- add relation prometheus:metrics-endpoint - alertmanager:self-metrics-endpoint
- add relation prometheus:metrics-endpoint - loki:metrics-endpoint
- add relation prometheus:metrics-endpoint - grafana:metrics-endpoint
- add relation grafana:grafana-dashboard - loki:grafana-dashboard
- add relation grafana:grafana-dashboard - prometheus:grafana-dashboard
- add relation grafana:grafana-dashboard - alertmanager:grafana-dashboard
- add relation catalogue:ingress - traefik:ingress
- add relation catalogue:catalogue - grafana:catalogue
- add relation catalogue:catalogue - prometheus:catalogue
- add relation catalogue:catalogue - alertmanager:catalogue
Deploy of bundle completed.
```
