### PR TITLE
Add context on environs.Config

### DIFF
--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -489,7 +489,7 @@ func (b *AgentBootstrap) ensureInitialModel(
 
 	creator := modelmanager.ModelConfigCreator{Provider: b.provider}
 	initialModelConfig, err := creator.NewModelConfig(
-		cloudSpec, stateParams.ControllerModelConfig, attrs,
+		ctx, cloudSpec, stateParams.ControllerModelConfig, attrs,
 	)
 	if err != nil {
 		return errors.Annotate(err, "creating initial model config")

--- a/agent/agentbootstrap/bootstrap_test.go
+++ b/agent/agentbootstrap/bootstrap_test.go
@@ -517,12 +517,12 @@ type fakeProvider struct {
 	environ *fakeEnviron
 }
 
-func (p *fakeProvider) PrepareConfig(args environs.PrepareConfigParams) (*config.Config, error) {
+func (p *fakeProvider) PrepareConfig(_ context.Context, args environs.PrepareConfigParams) (*config.Config, error) {
 	p.MethodCall(p, "PrepareConfig", args)
 	return args.Config, p.NextErr()
 }
 
-func (p *fakeProvider) Validate(newCfg, oldCfg *config.Config) (*config.Config, error) {
+func (p *fakeProvider) Validate(_ context.Context, newCfg, oldCfg *config.Config) (*config.Config, error) {
 	p.MethodCall(p, "Validate", newCfg, oldCfg)
 	return newCfg, p.NextErr()
 }

--- a/apiserver/common/mocks/environs.go
+++ b/apiserver/common/mocks/environs.go
@@ -199,17 +199,17 @@ func (mr *MockBootstrapEnvironMockRecorder) PrepareForBootstrap(arg0, arg1 any) 
 }
 
 // SetConfig mocks base method.
-func (m *MockBootstrapEnviron) SetConfig(arg0 *config.Config) error {
+func (m *MockBootstrapEnviron) SetConfig(arg0 context.Context, arg1 *config.Config) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetConfig", arg0)
+	ret := m.ctrl.Call(m, "SetConfig", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetConfig indicates an expected call of SetConfig.
-func (mr *MockBootstrapEnvironMockRecorder) SetConfig(arg0 any) *gomock.Call {
+func (mr *MockBootstrapEnvironMockRecorder) SetConfig(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetConfig", reflect.TypeOf((*MockBootstrapEnviron)(nil).SetConfig), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetConfig", reflect.TypeOf((*MockBootstrapEnviron)(nil).SetConfig), arg0, arg1)
 }
 
 // StorageProvider mocks base method.

--- a/apiserver/facades/client/machinemanager/environ_mock_test.go
+++ b/apiserver/facades/client/machinemanager/environ_mock_test.go
@@ -10,6 +10,7 @@
 package machinemanager_test
 
 import (
+	context "context"
 	reflect "reflect"
 
 	constraints "github.com/juju/juju/core/constraints"
@@ -264,17 +265,17 @@ func (mr *MockEnvironMockRecorder) Provider() *gomock.Call {
 }
 
 // SetConfig mocks base method.
-func (m *MockEnviron) SetConfig(arg0 *config.Config) error {
+func (m *MockEnviron) SetConfig(arg0 context.Context, arg1 *config.Config) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetConfig", arg0)
+	ret := m.ctrl.Call(m, "SetConfig", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetConfig indicates an expected call of SetConfig.
-func (mr *MockEnvironMockRecorder) SetConfig(arg0 any) *gomock.Call {
+func (mr *MockEnvironMockRecorder) SetConfig(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetConfig", reflect.TypeOf((*MockEnviron)(nil).SetConfig), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetConfig", reflect.TypeOf((*MockEnviron)(nil).SetConfig), arg0, arg1)
 }
 
 // StartInstance mocks base method.

--- a/apiserver/facades/client/modelconfig/modelconfig.go
+++ b/apiserver/facades/client/modelconfig/modelconfig.go
@@ -187,7 +187,7 @@ func (c *ModelConfigAPI) ModelSet(ctx context.Context, args params.ModelSet) err
 // change is being requested, specifically that of trace and to see if the
 // requesting user has the required permission for the change.
 func LogTracingValidator(isAdmin bool) config.ValidatorFunc {
-	return func(cfg, old *config.Config) (*config.Config, error) {
+	return func(ctx context.Context, cfg, old *config.Config) (*config.Config, error) {
 		spec := cfg.LoggingConfig()
 		oldSpec := old.LoggingConfig()
 

--- a/apiserver/facades/client/modelconfig/modelconfig_test.go
+++ b/apiserver/facades/client/modelconfig/modelconfig_test.go
@@ -178,7 +178,7 @@ func (s *modelconfigSuite) TestAdminCanSetLogTrace(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	cfg, err := modelconfig.LogTracingValidator(true)(newConfig, oldConfig)
+	cfg, err := modelconfig.LogTracingValidator(true)(context.Background(), newConfig, oldConfig)
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(cfg.AllAttrs(), jc.DeepEquals, newConfig.AllAttrs())
 }
@@ -201,7 +201,7 @@ func (s *modelconfigSuite) TestUserCanSetLogNoTrace(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	cfg, err := modelconfig.LogTracingValidator(true)(newConfig, oldConfig)
+	cfg, err := modelconfig.LogTracingValidator(true)(context.Background(), newConfig, oldConfig)
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(cfg.AllAttrs(), jc.DeepEquals, newConfig.AllAttrs())
 }
@@ -236,7 +236,7 @@ func (s *modelconfigSuite) TestUserCannotSetLogTrace(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = modelconfig.LogTracingValidator(false)(newConfig, oldConfig)
+	_, err = modelconfig.LogTracingValidator(false)(context.Background(), newConfig, oldConfig)
 	var validationErr *config.ValidationError
 	c.Check(errors.As(err, &validationErr), jc.IsTrue)
 	c.Check(*validationErr, jc.DeepEquals, config.ValidationError{

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -226,7 +226,7 @@ func (m *ModelManagerAPI) newModelConfig(
 			return toolsList, nil
 		},
 	}
-	return creator.NewModelConfig(cloudSpec, baseConfig, joint)
+	return creator.NewModelConfig(ctx, cloudSpec, baseConfig, joint)
 }
 
 func (m *ModelManagerAPI) checkAddModelPermission(ctx context.Context, cloud string, userTag names.UserTag) (bool, error) {

--- a/apiserver/facades/client/modelmanager/modelmanager_test.go
+++ b/apiserver/facades/client/modelmanager/modelmanager_test.go
@@ -4,6 +4,7 @@
 package modelmanager_test
 
 import (
+	"context"
 	stdcontext "context"
 	"regexp"
 	"time"
@@ -2094,7 +2095,7 @@ type fakeProvider struct {
 	environs.CloudEnvironProvider
 }
 
-func (*fakeProvider) Validate(cfg, old *config.Config) (*config.Config, error) {
+func (*fakeProvider) Validate(_ context.Context, cfg, old *config.Config) (*config.Config, error) {
 	return cfg, nil
 }
 

--- a/apiserver/facades/client/modelupgrader/mocks/environs_mock.go
+++ b/apiserver/facades/client/modelupgrader/mocks/environs_mock.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	constraints "github.com/juju/juju/core/constraints"
@@ -144,17 +145,17 @@ func (mr *MockBootstrapEnvironMockRecorder) PrepareForBootstrap(arg0, arg1 any) 
 }
 
 // SetConfig mocks base method.
-func (m *MockBootstrapEnviron) SetConfig(arg0 *config.Config) error {
+func (m *MockBootstrapEnviron) SetConfig(arg0 context.Context, arg1 *config.Config) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetConfig", arg0)
+	ret := m.ctrl.Call(m, "SetConfig", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetConfig indicates an expected call of SetConfig.
-func (mr *MockBootstrapEnvironMockRecorder) SetConfig(arg0 any) *gomock.Call {
+func (mr *MockBootstrapEnvironMockRecorder) SetConfig(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetConfig", reflect.TypeOf((*MockBootstrapEnviron)(nil).SetConfig), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetConfig", reflect.TypeOf((*MockBootstrapEnviron)(nil).SetConfig), arg0, arg1)
 }
 
 // StorageProvider mocks base method.

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -149,7 +149,7 @@ func newK8sBroker(
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	newCfg, err := providerInstance.newConfig(cfg)
+	newCfg, err := providerInstance.newConfig(ctx, cfg)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -317,10 +317,10 @@ func (k *kubernetesClient) Config() *config.Config {
 }
 
 // SetConfig is specified in the Environ interface.
-func (k *kubernetesClient) SetConfig(cfg *config.Config) error {
+func (k *kubernetesClient) SetConfig(ctx context.Context, cfg *config.Config) error {
 	k.lock.Lock()
 	defer k.lock.Unlock()
-	newCfg, err := providerInstance.newConfig(cfg)
+	newCfg, err := providerInstance.newConfig(ctx, cfg)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -241,7 +241,7 @@ func (s *K8sBrokerSuite) TestSetConfig(c *gc.C) {
 	ctrl := s.setupController(c)
 	defer ctrl.Finish()
 
-	err := s.broker.SetConfig(s.cfg)
+	err := s.broker.SetConfig(context.Background(), s.cfg)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -305,7 +305,7 @@ func (s *K8sBrokerSuite) setupOperatorStorageConfig(c *gc.C) {
 	var err error
 	cfg, err = cfg.Apply(map[string]interface{}{"operator-storage": "some-storage"})
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.broker.SetConfig(cfg)
+	err = s.broker.SetConfig(context.Background(), cfg)
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/caas/kubernetes/provider/provider.go
+++ b/caas/kubernetes/provider/provider.go
@@ -4,6 +4,7 @@
 package provider
 
 import (
+	"context"
 	stdcontext "context"
 	"net/url"
 	osexec "os/exec"
@@ -214,7 +215,7 @@ func (p kubernetesEnvironProvider) Ping(ctx envcontext.ProviderCallContext, endp
 }
 
 // PrepareConfig is specified in the EnvironProvider interface.
-func (p kubernetesEnvironProvider) PrepareConfig(args environs.PrepareConfigParams) (*config.Config, error) {
+func (p kubernetesEnvironProvider) PrepareConfig(ctx context.Context, args environs.PrepareConfigParams) (*config.Config, error) {
 	if err := p.validateCloudSpec(args.Cloud); err != nil {
 		return nil, errors.Annotate(err, "validating cloud spec")
 	}

--- a/caas/kubernetes/provider/provider_test.go
+++ b/caas/kubernetes/provider/provider_test.go
@@ -116,7 +116,7 @@ func (s *providerSuite) testOpenError(c *gc.C, spec environscloudspec.CloudSpec,
 }
 
 func (s *providerSuite) TestPrepareConfig(c *gc.C) {
-	cfg, err := s.provider.PrepareConfig(environs.PrepareConfigParams{
+	cfg, err := s.provider.PrepareConfig(context.Background(), environs.PrepareConfigParams{
 		Config: fakeConfig(c),
 		Cloud:  fakeCloudSpec(),
 	})
@@ -126,7 +126,7 @@ func (s *providerSuite) TestPrepareConfig(c *gc.C) {
 
 func (s *providerSuite) TestValidate(c *gc.C) {
 	config := fakeConfig(c)
-	validCfg, err := s.provider.Validate(config, nil)
+	validCfg, err := s.provider.Validate(context.Background(), config, nil)
 	c.Check(err, jc.ErrorIsNil)
 
 	validAttrs := validCfg.AllAttrs()

--- a/caas/kubernetes/provider/providerconfig.go
+++ b/caas/kubernetes/provider/providerconfig.go
@@ -4,6 +4,7 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/juju/charm/v13"
@@ -63,16 +64,16 @@ type brokerConfig struct {
 	attrs map[string]interface{}
 }
 
-func (p kubernetesEnvironProvider) Validate(cfg, old *config.Config) (*config.Config, error) {
-	newCfg, err := validateConfig(cfg, old)
+func (p kubernetesEnvironProvider) Validate(ctx context.Context, cfg, old *config.Config) (*config.Config, error) {
+	newCfg, err := validateConfig(ctx, cfg, old)
 	if err != nil {
 		return nil, fmt.Errorf("invalid k8s provider config: %v", err)
 	}
 	return newCfg.Apply(newCfg.attrs)
 }
 
-func (p kubernetesEnvironProvider) newConfig(cfg *config.Config) (*brokerConfig, error) {
-	valid, err := p.Validate(cfg, nil)
+func (p kubernetesEnvironProvider) newConfig(ctx context.Context, cfg *config.Config) (*brokerConfig, error) {
+	valid, err := p.Validate(ctx, cfg, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -100,9 +101,9 @@ func (p kubernetesEnvironProvider) ConfigDefaults() schema.Defaults {
 	return providerConfigDefaults
 }
 
-func validateConfig(cfg, old *config.Config) (*brokerConfig, error) {
+func validateConfig(ctx context.Context, cfg, old *config.Config) (*brokerConfig, error) {
 	// Check for valid changes for the base config values.
-	if err := config.Validate(cfg, old); err != nil {
+	if err := config.Validate(ctx, cfg, old); err != nil {
 		return nil, err
 	}
 	validated, err := cfg.ValidateUnknownAttrs(providerConfigFields, providerConfigDefaults)

--- a/caas/mocks/broker_mock.go
+++ b/caas/mocks/broker_mock.go
@@ -412,17 +412,17 @@ func (mr *MockBrokerMockRecorder) SaveJujuSecret(arg0, arg1, arg2 any) *gomock.C
 }
 
 // SetConfig mocks base method.
-func (m *MockBroker) SetConfig(arg0 *config.Config) error {
+func (m *MockBroker) SetConfig(arg0 context.Context, arg1 *config.Config) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetConfig", arg0)
+	ret := m.ctrl.Call(m, "SetConfig", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetConfig indicates an expected call of SetConfig.
-func (mr *MockBrokerMockRecorder) SetConfig(arg0 any) *gomock.Call {
+func (mr *MockBrokerMockRecorder) SetConfig(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetConfig", reflect.TypeOf((*MockBroker)(nil).SetConfig), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetConfig", reflect.TypeOf((*MockBroker)(nil).SetConfig), arg0, arg1)
 }
 
 // StorageProvider mocks base method.

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -1337,7 +1337,7 @@ func (s *BootstrapSuite) TestAutoSyncLocalSource(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	provider, err := environs.Provider(bootstrapConfig.CloudType)
 	c.Assert(err, jc.ErrorIsNil)
-	cfg, err := provider.PrepareConfig(*params)
+	cfg, err := provider.PrepareConfig(context.Background(), *params)
 	c.Assert(err, jc.ErrorIsNil)
 
 	env, err := environs.New(context.Background(), environs.OpenParams{

--- a/cmd/juju/commands/mockenvirons_test.go
+++ b/cmd/juju/commands/mockenvirons_test.go
@@ -10,6 +10,7 @@
 package commands
 
 import (
+	context "context"
 	reflect "reflect"
 
 	constraints "github.com/juju/juju/core/constraints"
@@ -264,17 +265,17 @@ func (mr *MockEnvironMockRecorder) Provider() *gomock.Call {
 }
 
 // SetConfig mocks base method.
-func (m *MockEnviron) SetConfig(arg0 *config.Config) error {
+func (m *MockEnviron) SetConfig(arg0 context.Context, arg1 *config.Config) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetConfig", arg0)
+	ret := m.ctrl.Call(m, "SetConfig", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetConfig indicates an expected call of SetConfig.
-func (mr *MockEnvironMockRecorder) SetConfig(arg0 any) *gomock.Call {
+func (mr *MockEnvironMockRecorder) SetConfig(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetConfig", reflect.TypeOf((*MockEnviron)(nil).SetConfig), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetConfig", reflect.TypeOf((*MockEnviron)(nil).SetConfig), arg0, arg1)
 }
 
 // StartInstance mocks base method.

--- a/cmd/juju/common/cloudprovider_mock_test.go
+++ b/cmd/juju/common/cloudprovider_mock_test.go
@@ -10,6 +10,7 @@
 package common
 
 import (
+	context "context"
 	reflect "reflect"
 
 	jsonschema "github.com/juju/jsonschema"
@@ -116,18 +117,18 @@ func (mr *MockTestCloudProviderMockRecorder) Ping(arg0, arg1 any) *gomock.Call {
 }
 
 // PrepareConfig mocks base method.
-func (m *MockTestCloudProvider) PrepareConfig(arg0 environs.PrepareConfigParams) (*config.Config, error) {
+func (m *MockTestCloudProvider) PrepareConfig(arg0 context.Context, arg1 environs.PrepareConfigParams) (*config.Config, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PrepareConfig", arg0)
+	ret := m.ctrl.Call(m, "PrepareConfig", arg0, arg1)
 	ret0, _ := ret[0].(*config.Config)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // PrepareConfig indicates an expected call of PrepareConfig.
-func (mr *MockTestCloudProviderMockRecorder) PrepareConfig(arg0 any) *gomock.Call {
+func (mr *MockTestCloudProviderMockRecorder) PrepareConfig(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareConfig", reflect.TypeOf((*MockTestCloudProvider)(nil).PrepareConfig), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareConfig", reflect.TypeOf((*MockTestCloudProvider)(nil).PrepareConfig), arg0, arg1)
 }
 
 // RegisterCredentials mocks base method.
@@ -146,18 +147,18 @@ func (mr *MockTestCloudProviderMockRecorder) RegisterCredentials(arg0 any) *gomo
 }
 
 // Validate mocks base method.
-func (m *MockTestCloudProvider) Validate(arg0, arg1 *config.Config) (*config.Config, error) {
+func (m *MockTestCloudProvider) Validate(arg0 context.Context, arg1, arg2 *config.Config) (*config.Config, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Validate", arg0, arg1)
+	ret := m.ctrl.Call(m, "Validate", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*config.Config)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Validate indicates an expected call of Validate.
-func (mr *MockTestCloudProviderMockRecorder) Validate(arg0, arg1 any) *gomock.Call {
+func (mr *MockTestCloudProviderMockRecorder) Validate(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Validate", reflect.TypeOf((*MockTestCloudProvider)(nil).Validate), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Validate", reflect.TypeOf((*MockTestCloudProvider)(nil).Validate), arg0, arg1, arg2)
 }
 
 // Version mocks base method.

--- a/cmd/juju/controller/destroy.go
+++ b/cmd/juju/controller/destroy.go
@@ -621,7 +621,7 @@ func (c *destroyCommandBase) getControllerEnvironFromStore(
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	cfg, err := provider.PrepareConfig(*params)
+	cfg, err := provider.PrepareConfig(ctx, *params)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/cmd/jujud-controller/agent/bootstrap_test.go
+++ b/cmd/jujud-controller/agent/bootstrap_test.go
@@ -533,7 +533,7 @@ func (s *BootstrapSuite) makeTestModel(c *gc.C) {
 	provider, err := environs.Provider(cfg.Type())
 	c.Assert(err, jc.ErrorIsNil)
 	controllerCfg := testing.FakeControllerConfig()
-	cfg, err = provider.PrepareConfig(environs.PrepareConfigParams{
+	cfg, err = provider.PrepareConfig(context.Background(), environs.PrepareConfigParams{
 		Config: cfg,
 	})
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/jujud-controller/agent/util_test.go
+++ b/cmd/jujud-controller/agent/util_test.go
@@ -454,7 +454,7 @@ func (e *minModelWorkersEnviron) Config() *config.Config {
 	return cfg
 }
 
-func (e *minModelWorkersEnviron) SetConfig(*config.Config) error {
+func (e *minModelWorkersEnviron) SetConfig(context.Context, *config.Config) error {
 	return nil
 }
 

--- a/cmd/modelcmd/cloudprovider_mock_test.go
+++ b/cmd/modelcmd/cloudprovider_mock_test.go
@@ -10,6 +10,7 @@
 package modelcmd
 
 import (
+	context "context"
 	reflect "reflect"
 
 	jsonschema "github.com/juju/jsonschema"
@@ -116,18 +117,18 @@ func (mr *MockTestCloudProviderMockRecorder) Ping(arg0, arg1 any) *gomock.Call {
 }
 
 // PrepareConfig mocks base method.
-func (m *MockTestCloudProvider) PrepareConfig(arg0 environs.PrepareConfigParams) (*config.Config, error) {
+func (m *MockTestCloudProvider) PrepareConfig(arg0 context.Context, arg1 environs.PrepareConfigParams) (*config.Config, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PrepareConfig", arg0)
+	ret := m.ctrl.Call(m, "PrepareConfig", arg0, arg1)
 	ret0, _ := ret[0].(*config.Config)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // PrepareConfig indicates an expected call of PrepareConfig.
-func (mr *MockTestCloudProviderMockRecorder) PrepareConfig(arg0 any) *gomock.Call {
+func (mr *MockTestCloudProviderMockRecorder) PrepareConfig(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareConfig", reflect.TypeOf((*MockTestCloudProvider)(nil).PrepareConfig), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareConfig", reflect.TypeOf((*MockTestCloudProvider)(nil).PrepareConfig), arg0, arg1)
 }
 
 // RegisterCredentials mocks base method.
@@ -146,18 +147,18 @@ func (mr *MockTestCloudProviderMockRecorder) RegisterCredentials(arg0 any) *gomo
 }
 
 // Validate mocks base method.
-func (m *MockTestCloudProvider) Validate(arg0, arg1 *config.Config) (*config.Config, error) {
+func (m *MockTestCloudProvider) Validate(arg0 context.Context, arg1, arg2 *config.Config) (*config.Config, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Validate", arg0, arg1)
+	ret := m.ctrl.Call(m, "Validate", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*config.Config)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Validate indicates an expected call of Validate.
-func (mr *MockTestCloudProviderMockRecorder) Validate(arg0, arg1 any) *gomock.Call {
+func (mr *MockTestCloudProviderMockRecorder) Validate(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Validate", reflect.TypeOf((*MockTestCloudProvider)(nil).Validate), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Validate", reflect.TypeOf((*MockTestCloudProvider)(nil).Validate), arg0, arg1, arg2)
 }
 
 // Version mocks base method.

--- a/cmd/plugins/juju-metadata/imagemetadata.go
+++ b/cmd/plugins/juju-metadata/imagemetadata.go
@@ -44,7 +44,7 @@ func prepare(ctx *cmd.Context, controllerName string, store jujuclient.ClientSto
 	if _, ok := provider.(caas.ContainerEnvironProvider); ok {
 		return nil, errors.NotSupportedf("preparing environ for CAAS")
 	}
-	cfg, err := provider.PrepareConfig(*params)
+	cfg, err := provider.PrepareConfig(ctx, *params)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/controller/modelmanager/createmodel_test.go
+++ b/controller/modelmanager/createmodel_test.go
@@ -4,6 +4,8 @@
 package modelmanager_test
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -56,7 +58,7 @@ func (s *ModelConfigCreatorSuite) SetUpTest(c *gc.C) {
 
 func (s *ModelConfigCreatorSuite) newModelConfig(attrs map[string]interface{}) (*config.Config, error) {
 	cloudSpec := environscloudspec.CloudSpec{Type: "fake"}
-	return s.creator.NewModelConfig(cloudSpec, s.baseConfig, attrs)
+	return s.creator.NewModelConfig(context.Background(), cloudSpec, s.baseConfig, attrs)
 }
 
 func (s *ModelConfigCreatorSuite) TestCreateModelValidatesConfig(c *gc.C) {
@@ -185,12 +187,12 @@ type fakeProvider struct {
 	restrictedConfigAttributes []string
 }
 
-func (p *fakeProvider) Validate(cfg, old *config.Config) (*config.Config, error) {
+func (p *fakeProvider) Validate(_ context.Context, cfg, old *config.Config) (*config.Config, error) {
 	p.MethodCall(p, "Validate", cfg, old)
 	return cfg, p.NextErr()
 }
 
-func (p *fakeProvider) PrepareConfig(args environs.PrepareConfigParams) (*config.Config, error) {
+func (p *fakeProvider) PrepareConfig(_ context.Context, args environs.PrepareConfigParams) (*config.Config, error) {
 	p.MethodCall(p, "PrepareConfig", args)
 	return args.Config, p.NextErr()
 }

--- a/core/providertracker/provider_mock_test.go
+++ b/core/providertracker/provider_mock_test.go
@@ -212,17 +212,17 @@ func (mr *MockProviderMockRecorder) PrepareForBootstrap(arg0, arg1 any) *gomock.
 }
 
 // SetConfig mocks base method.
-func (m *MockProvider) SetConfig(arg0 *config.Config) error {
+func (m *MockProvider) SetConfig(arg0 context.Context, arg1 *config.Config) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetConfig", arg0)
+	ret := m.ctrl.Call(m, "SetConfig", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetConfig indicates an expected call of SetConfig.
-func (mr *MockProviderMockRecorder) SetConfig(arg0 any) *gomock.Call {
+func (mr *MockProviderMockRecorder) SetConfig(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetConfig", reflect.TypeOf((*MockProvider)(nil).SetConfig), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetConfig", reflect.TypeOf((*MockProvider)(nil).SetConfig), arg0, arg1)
 }
 
 // StorageProvider mocks base method.

--- a/domain/modelconfig/bootstrap/bootstrap.go
+++ b/domain/modelconfig/bootstrap/bootstrap.go
@@ -73,7 +73,7 @@ func SetModelConfig(
 			return fmt.Errorf("constructing new model config with model defaults: %w", err)
 		}
 
-		_, err = config.ModelValidator().Validate(cfg, nil)
+		_, err = config.ModelValidator().Validate(ctx, cfg, nil)
 		if err != nil {
 			return fmt.Errorf("validating model config to set for model: %w", err)
 		}

--- a/domain/modelconfig/service/service.go
+++ b/domain/modelconfig/service/service.go
@@ -217,7 +217,7 @@ func (s *Service) SetModelConfig(
 		return fmt.Errorf("constructing new model config with model defaults: %w", err)
 	}
 
-	_, err = s.modelValidator.Validate(setCfg, nil)
+	_, err = s.modelValidator.Validate(ctx, setCfg, nil)
 	if err != nil {
 		return fmt.Errorf("validating model config to set for model: %w", err)
 	}
@@ -272,7 +272,7 @@ func (s *Service) UpdateModelConfig(
 		return fmt.Errorf("making updated model configuration: %w", err)
 	}
 
-	_, err = s.updateModelConfigValidator().Validate(newCfg, currCfg)
+	_, err = s.updateModelConfigValidator().Validate(ctx, newCfg, currCfg)
 	if err != nil {
 		return fmt.Errorf("validating updated model configuration: %w", err)
 	}

--- a/domain/modelconfig/validators/validators.go
+++ b/domain/modelconfig/validators/validators.go
@@ -4,6 +4,7 @@
 package validators
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/juju/errors"
@@ -15,7 +16,7 @@ import (
 // CharmhubURLChange returns a config validator that will check to make sure
 // the charm hub url has not changed.
 func CharmhubURLChange() config.ValidatorFunc {
-	return func(cfg, old *config.Config) (*config.Config, error) {
+	return func(ctx context.Context, cfg, old *config.Config) (*config.Config, error) {
 		if v, has := cfg.CharmHubURL(); has {
 			oldURL, _ := old.CharmHubURL()
 			if v != oldURL {
@@ -38,7 +39,7 @@ func CharmhubURLChange() config.ValidatorFunc {
 // config this validator will keep removing it from the new config so that it
 // does not get persisted to state.
 func AgentVersionChange() config.ValidatorFunc {
-	return func(cfg, old *config.Config) (*config.Config, error) {
+	return func(ctx context.Context, cfg, old *config.Config) (*config.Config, error) {
 		if v, has := cfg.AgentVersion(); has {
 			oldVersion, has := old.AgentVersion()
 			if !has {
@@ -63,7 +64,7 @@ func AgentVersionChange() config.ValidatorFunc {
 // AuthorizedKeysChange checks to see if there has been any change to a model
 // config authorized keys.
 func AuthorizedKeysChange() config.ValidatorFunc {
-	return func(cfg, old *config.Config) (*config.Config, error) {
+	return func(ctx context.Context, cfg, old *config.Config) (*config.Config, error) {
 		if cfg.AuthorizedKeys() == old.AuthorizedKeys() {
 			// No change. Nothing more todo.
 			return cfg, nil
@@ -88,7 +89,7 @@ type SpaceProvider interface {
 // this Juju controller. Should the space not exist an error satisfying
 // config.ValidationError will be returned.
 func SpaceChecker(provider SpaceProvider) config.ValidatorFunc {
-	return func(cfg, old *config.Config) (*config.Config, error) {
+	return func(ctx context.Context, cfg, old *config.Config) (*config.Config, error) {
 		spaceName := cfg.DefaultSpace()
 		if spaceName == "" {
 			// No need to verify if the space isn't defined
@@ -123,7 +124,7 @@ const (
 // level logging and the canTrace is set to false we error with an error that
 // satisfies both ErrorLogTracingPermission and config.ValidationError.
 func LoggingTracePermissionChecker(canTrace bool) config.ValidatorFunc {
-	return func(cfg, old *config.Config) (*config.Config, error) {
+	return func(ctx context.Context, cfg, old *config.Config) (*config.Config, error) {
 		// If we can trace no point in checking to see if we having tracing.
 		if canTrace {
 			return cfg, nil
@@ -178,7 +179,7 @@ type SecretBackendProvider interface {
 // secret backend has not changed or is the default backend then no validation
 // is performed. Any validation errors will satisfy config.ValidationError.
 func SecretBackendChecker(provider SecretBackendProvider) config.ValidatorFunc {
-	return func(cfg, old *config.Config) (*config.Config, error) {
+	return func(ctx context.Context, cfg, old *config.Config) (*config.Config, error) {
 		backendName := cfg.SecretBackend()
 		if backendName == old.SecretBackend() {
 			return cfg, nil

--- a/domain/modelconfig/validators/validators_test.go
+++ b/domain/modelconfig/validators/validators_test.go
@@ -4,6 +4,8 @@
 package validators
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -46,7 +48,7 @@ func (*validatorsSuite) TestCharmhubURLChange(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	var validationError *config.ValidationError
-	_, err = CharmhubURLChange()(newCfg, oldCfg)
+	_, err = CharmhubURLChange()(context.Background(), newCfg, oldCfg)
 	c.Assert(errors.As(err, &validationError), jc.IsTrue)
 	c.Assert(validationError.InvalidAttrs, gc.DeepEquals, []string{"charmhub-url"})
 }
@@ -68,7 +70,7 @@ func (*validatorsSuite) TestCharmhubURLNoChange(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = CharmhubURLChange()(newCfg, oldCfg)
+	_, err = CharmhubURLChange()(context.Background(), newCfg, oldCfg)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -90,7 +92,7 @@ func (*validatorsSuite) TestAgentVersionChanged(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	var validationError *config.ValidationError
-	_, err = AgentVersionChange()(newCfg, oldCfg)
+	_, err = AgentVersionChange()(context.Background(), newCfg, oldCfg)
 	c.Assert(errors.As(err, &validationError), jc.IsTrue)
 	c.Assert(validationError.InvalidAttrs, gc.DeepEquals, []string{"agent-version"})
 }
@@ -114,7 +116,7 @@ func (*validatorsSuite) TestAgentVersionNoChange(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	cfg, err := AgentVersionChange()(newCfg, oldCfg)
+	cfg, err := AgentVersionChange()(context.Background(), newCfg, oldCfg)
 	c.Assert(err, jc.ErrorIsNil)
 	_, agentVersionSet := cfg.AgentVersion()
 	c.Check(agentVersionSet, jc.IsFalse)
@@ -134,7 +136,7 @@ func (*validatorsSuite) TestAgentVersionNoChange(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = AgentVersionChange()(newCfg, oldCfg)
+	_, err = AgentVersionChange()(context.Background(), newCfg, oldCfg)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -160,7 +162,7 @@ func (*validatorsSuite) TestSpaceCheckerFound(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = SpaceChecker(provider)(newCfg, oldCfg)
+	_, err = SpaceChecker(provider)(context.Background(), newCfg, oldCfg)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -186,7 +188,7 @@ func (*validatorsSuite) TestSpaceCheckerNotFound(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = SpaceChecker(provider)(newCfg, oldCfg)
+	_, err = SpaceChecker(provider)(context.Background(), newCfg, oldCfg)
 	var validationError *config.ValidationError
 	c.Assert(errors.As(err, &validationError), jc.IsTrue)
 	c.Assert(validationError.InvalidAttrs, gc.DeepEquals, []string{"default-space"})
@@ -215,7 +217,7 @@ func (*validatorsSuite) TestSpaceCheckerError(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = SpaceChecker(provider)(newCfg, oldCfg)
+	_, err = SpaceChecker(provider)(context.Background(), newCfg, oldCfg)
 	c.Assert(err, jc.ErrorIs, providerErr)
 }
 
@@ -235,7 +237,7 @@ func (*validatorsSuite) TestLoggincTracePermissionNoTrace(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = LoggingTracePermissionChecker(false)(newCfg, oldCfg)
+	_, err = LoggingTracePermissionChecker(false)(context.Background(), newCfg, oldCfg)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -255,7 +257,7 @@ func (*validatorsSuite) TestLoggincTracePermissionTrace(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = LoggingTracePermissionChecker(false)(newCfg, oldCfg)
+	_, err = LoggingTracePermissionChecker(false)(context.Background(), newCfg, oldCfg)
 	c.Assert(err, jc.ErrorIs, ErrorLogTracingPermission)
 
 	var validationError *config.ValidationError
@@ -279,7 +281,7 @@ func (*validatorsSuite) TestLoggincTracePermissionTraceAllow(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = LoggingTracePermissionChecker(true)(newCfg, oldCfg)
+	_, err = LoggingTracePermissionChecker(true)(context.Background(), newCfg, oldCfg)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -305,7 +307,7 @@ func (*validatorsSuite) TestSecretsBackendChecker(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = SecretBackendChecker(provider)(newCfg, oldCfg)
+	_, err = SecretBackendChecker(provider)(context.Background(), newCfg, oldCfg)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -331,7 +333,7 @@ func (*validatorsSuite) TestSecretsBackendCheckerNoExist(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = SecretBackendChecker(provider)(newCfg, oldCfg)
+	_, err = SecretBackendChecker(provider)(context.Background(), newCfg, oldCfg)
 	var validationError *config.ValidationError
 	c.Assert(errors.As(err, &validationError), jc.IsTrue)
 	c.Assert(validationError.InvalidAttrs, gc.DeepEquals, []string{"secret-backend"})
@@ -360,7 +362,7 @@ func (*validatorsSuite) TestSecretsBackendCheckerProviderError(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = SecretBackendChecker(provider)(newCfg, oldCfg)
+	_, err = SecretBackendChecker(provider)(context.Background(), newCfg, oldCfg)
 	c.Assert(err, jc.ErrorIs, providerErr)
 }
 
@@ -383,7 +385,7 @@ func (*validatorsSuite) TestAuthorizedKeysChanged(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = AuthorizedKeysChange()(newCfg, oldCfg)
+	_, err = AuthorizedKeysChange()(context.Background(), newCfg, oldCfg)
 	var validationError *config.ValidationError
 	c.Assert(errors.As(err, &validationError), jc.IsTrue)
 	c.Assert(validationError.InvalidAttrs, gc.DeepEquals, []string{"authorized-keys"})
@@ -408,6 +410,6 @@ func (*validatorsSuite) TestAuthorizedKeysChangedNoChange(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = AuthorizedKeysChange()(newCfg, oldCfg)
+	_, err = AuthorizedKeysChange()(context.Background(), newCfg, oldCfg)
 	c.Check(err, jc.ErrorIsNil)
 }

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -4,6 +4,7 @@
 package bootstrap
 
 import (
+	"context"
 	stdcontext "context"
 	"fmt"
 	"os"
@@ -292,7 +293,7 @@ func bootstrapCAAS(
 		jujuVersion = *args.AgentVersion
 	}
 	// set agent version before finalizing bootstrap config
-	if err := setBootstrapAgentVersion(environ, jujuVersion); err != nil {
+	if err := setBootstrapAgentVersion(ctx, environ, jujuVersion); err != nil {
 		return errors.Trace(err)
 	}
 	podConfig.JujuVersion = jujuVersion
@@ -563,7 +564,7 @@ func bootstrapIAAS(
 	}); err != nil {
 		return errors.Trace(err)
 	}
-	if err = environ.SetConfig(cfg); err != nil {
+	if err = environ.SetConfig(ctx, cfg); err != nil {
 		return errors.Trace(err)
 	}
 
@@ -618,7 +619,7 @@ func bootstrapIAAS(
 	// in that case the specific version will be the only version available.
 	newestToolVersion, _ := matchingTools.Newest()
 	// set agent version before finalizing bootstrap config
-	if err := setBootstrapAgentVersion(environ, newestToolVersion); err != nil {
+	if err := setBootstrapAgentVersion(ctx, environ, newestToolVersion); err != nil {
 		return errors.Trace(err)
 	}
 
@@ -1011,14 +1012,14 @@ func getBootstrapToolsVersion(possibleTools coretools.List) (coretools.List, err
 }
 
 // setBootstrapAgentVersion updates the agent-version configuration attribute.
-func setBootstrapAgentVersion(environ environs.Configer, toolsVersion version.Number) error {
+func setBootstrapAgentVersion(ctx context.Context, environ environs.Configer, toolsVersion version.Number) error {
 	cfg := environ.Config()
 	if agentVersion, _ := cfg.AgentVersion(); agentVersion != toolsVersion {
 		cfg, err := cfg.Apply(map[string]interface{}{
 			"agent-version": toolsVersion.String(),
 		})
 		if err == nil {
-			err = environ.SetConfig(cfg)
+			err = environ.SetConfig(ctx, cfg)
 		}
 		if err != nil {
 			return errors.Errorf("failed to update model configuration: %v", err)

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -856,7 +856,7 @@ func (s *bootstrapSuite) TestBootstrapToolsVersion(c *gc.C) {
 		c.Logf("test %d: %+v", i, t)
 		cfg, err := env.Config().Remove([]string{"agent-version"})
 		c.Assert(err, jc.ErrorIsNil)
-		err = env.SetConfig(cfg)
+		err = env.SetConfig(context.Background(), cfg)
 		c.Assert(err, jc.ErrorIsNil)
 		s.PatchValue(&jujuversion.Current, t.currentVersion)
 		tools, err := bootstrap.GetBootstrapToolsVersion(availableTools)
@@ -1473,7 +1473,7 @@ func (e *bootstrapEnviron) Config() *config.Config {
 	return e.cfg
 }
 
-func (e *bootstrapEnviron) SetConfig(cfg *config.Config) error {
+func (e *bootstrapEnviron) SetConfig(ctx context.Context, cfg *config.Config) error {
 	e.cfg = cfg
 	return nil
 }

--- a/environs/bootstrap/prepare.go
+++ b/environs/bootstrap/prepare.go
@@ -191,7 +191,7 @@ func prepare(
 		return cfg, details, errors.Trace(err)
 	}
 
-	cfg, err = p.PrepareConfig(environs.PrepareConfigParams{Cloud: args.Cloud, Config: cfg})
+	cfg, err = p.PrepareConfig(ctx, environs.PrepareConfigParams{Cloud: args.Cloud, Config: cfg})
 	if err != nil {
 		return cfg, details, errors.Trace(err)
 	}

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -4,6 +4,7 @@
 package config
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/url"
@@ -479,7 +480,7 @@ func New(withDefaults Defaulting, attrs map[string]any) (*Config, error) {
 	}
 
 	// no old config to compare against
-	if err := Validate(c, nil); err != nil {
+	if err := Validate(context.TODO(), c, nil); err != nil {
 		return nil, errors.Trace(err)
 	}
 	// Copy unknown attributes onto the type-specific map.
@@ -672,7 +673,7 @@ func CoerceForStorage(attrs map[string]any) map[string]any {
 // Validate ensures that config is a valid configuration.  If old is not nil,
 // it holds the previous environment configuration for consideration when
 // validating changes.
-func Validate(cfg, old *Config) error {
+func Validate(_ctx context.Context, cfg, old *Config) error {
 	// Check that all other fields that have been specified are non-empty,
 	// unless they're allowed to be empty for backward compatibility,
 	for attr, val := range cfg.defined {

--- a/environs/config/config_test.go
+++ b/environs/config/config_test.go
@@ -4,6 +4,7 @@
 package config_test
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	stdtesting "testing"
@@ -918,7 +919,7 @@ func (s *ConfigSuite) TestValidateChange(c *gc.C) {
 		c.Logf("test %d: %s", i, test.about)
 		newConfig := newTestConfig(c, test.new)
 		oldConfig := newTestConfig(c, test.old)
-		err := config.Validate(newConfig, oldConfig)
+		err := config.Validate(context.Background(), newConfig, oldConfig)
 		if test.err == "" {
 			c.Check(err, jc.ErrorIsNil)
 		} else {

--- a/environs/config/validator_test.go
+++ b/environs/config/validator_test.go
@@ -4,6 +4,8 @@
 package config_test
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -28,7 +30,7 @@ func (_ *validatorSuite) TestControllerNotContainingValidator(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	rval, err := config.NoControllerAttributesValidator().Validate(cfg, nil)
+	rval, err := config.NoControllerAttributesValidator().Validate(context.Background(), cfg, nil)
 	valErr, is := errors.AsType[*config.ValidationError](err)
 	c.Assert(is, jc.IsTrue)
 	c.Assert(valErr.InvalidAttrs, jc.DeepEquals, []string{controller.AllowModelAccessKey, controller.ControllerName})
@@ -46,7 +48,7 @@ func (_ *validatorSuite) TestModelValidator(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	rval, err := config.ModelValidator().Validate(cfg, nil)
+	rval, err := config.ModelValidator().Validate(context.Background(), cfg, nil)
 	valErr, is := errors.AsType[*config.ValidationError](err)
 	c.Assert(is, jc.IsTrue)
 	c.Assert(valErr.InvalidAttrs, jc.DeepEquals, []string{config.AgentVersionKey})
@@ -67,7 +69,7 @@ func (_ *validatorSuite) TestModelValidatorFailsForControllerAttrs(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	rval, err := config.ModelValidator().Validate(cfg, nil)
+	rval, err := config.ModelValidator().Validate(context.Background(), cfg, nil)
 	valErr, is := errors.AsType[*config.ValidationError](err)
 	c.Assert(is, jc.IsTrue)
 	c.Assert(valErr.InvalidAttrs, jc.DeepEquals, []string{controller.AllowModelAccessKey, controller.ControllerName})

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -4,6 +4,7 @@
 package environs
 
 import (
+	"context"
 	stdcontext "context"
 	"io"
 
@@ -56,7 +57,7 @@ type EnvironProvider interface {
 	// deterministic output. Any unique values should be based on the
 	// "uuid" attribute of the base configuration. This is called for the
 	// controller model during bootstrap, and also for new hosted models.
-	PrepareConfig(PrepareConfigParams) (*config.Config, error)
+	PrepareConfig(context.Context, PrepareConfigParams) (*config.Config, error)
 }
 
 // A CloudEnvironProvider represents a computing and storage provider
@@ -280,7 +281,7 @@ type ConfigSetter interface {
 	//
 	// Calls to SetConfig do not affect the configuration of
 	// values previously obtained from Storage.
-	SetConfig(cfg *config.Config) error
+	SetConfig(ctx context.Context, cfg *config.Config) error
 }
 
 // CloudSpecSetter implements access to an environment's cloud spec.

--- a/environs/jujutest/tests.go
+++ b/environs/jujutest/tests.go
@@ -4,6 +4,7 @@
 package jujutest
 
 import (
+	"context"
 	stdcontext "context"
 	"path/filepath"
 
@@ -154,7 +155,7 @@ func (t *Tests) TestStartStop(c *gc.C) {
 		"agent-version": jujuversion.Current.String(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	err = e.SetConfig(cfg)
+	err = e.SetConfig(context.Background(), cfg)
 	c.Assert(err, jc.ErrorIsNil)
 
 	insts, err := e.Instances(t.ProviderCallContext, nil)

--- a/environs/mocks/package_mock.go
+++ b/environs/mocks/package_mock.go
@@ -269,17 +269,17 @@ func (mr *MockEnvironMockRecorder) Provider() *gomock.Call {
 }
 
 // SetConfig mocks base method.
-func (m *MockEnviron) SetConfig(arg0 *config.Config) error {
+func (m *MockEnviron) SetConfig(arg0 context.Context, arg1 *config.Config) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetConfig", arg0)
+	ret := m.ctrl.Call(m, "SetConfig", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetConfig indicates an expected call of SetConfig.
-func (mr *MockEnvironMockRecorder) SetConfig(arg0 any) *gomock.Call {
+func (mr *MockEnvironMockRecorder) SetConfig(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetConfig", reflect.TypeOf((*MockEnviron)(nil).SetConfig), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetConfig", reflect.TypeOf((*MockEnviron)(nil).SetConfig), arg0, arg1)
 }
 
 // StartInstance mocks base method.
@@ -646,17 +646,17 @@ func (mr *MockNetworkingEnvironMockRecorder) ReleaseContainerAddresses(arg0, arg
 }
 
 // SetConfig mocks base method.
-func (m *MockNetworkingEnviron) SetConfig(arg0 *config.Config) error {
+func (m *MockNetworkingEnviron) SetConfig(arg0 context.Context, arg1 *config.Config) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetConfig", arg0)
+	ret := m.ctrl.Call(m, "SetConfig", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetConfig indicates an expected call of SetConfig.
-func (mr *MockNetworkingEnvironMockRecorder) SetConfig(arg0 any) *gomock.Call {
+func (mr *MockNetworkingEnvironMockRecorder) SetConfig(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetConfig", reflect.TypeOf((*MockNetworkingEnviron)(nil).SetConfig), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetConfig", reflect.TypeOf((*MockNetworkingEnviron)(nil).SetConfig), arg0, arg1)
 }
 
 // Spaces mocks base method.
@@ -924,33 +924,33 @@ func (mr *MockCloudEnvironProviderMockRecorder) Ping(arg0, arg1 any) *gomock.Cal
 }
 
 // PrepareConfig mocks base method.
-func (m *MockCloudEnvironProvider) PrepareConfig(arg0 environs.PrepareConfigParams) (*config.Config, error) {
+func (m *MockCloudEnvironProvider) PrepareConfig(arg0 context.Context, arg1 environs.PrepareConfigParams) (*config.Config, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PrepareConfig", arg0)
+	ret := m.ctrl.Call(m, "PrepareConfig", arg0, arg1)
 	ret0, _ := ret[0].(*config.Config)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // PrepareConfig indicates an expected call of PrepareConfig.
-func (mr *MockCloudEnvironProviderMockRecorder) PrepareConfig(arg0 any) *gomock.Call {
+func (mr *MockCloudEnvironProviderMockRecorder) PrepareConfig(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareConfig", reflect.TypeOf((*MockCloudEnvironProvider)(nil).PrepareConfig), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareConfig", reflect.TypeOf((*MockCloudEnvironProvider)(nil).PrepareConfig), arg0, arg1)
 }
 
 // Validate mocks base method.
-func (m *MockCloudEnvironProvider) Validate(arg0, arg1 *config.Config) (*config.Config, error) {
+func (m *MockCloudEnvironProvider) Validate(arg0 context.Context, arg1, arg2 *config.Config) (*config.Config, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Validate", arg0, arg1)
+	ret := m.ctrl.Call(m, "Validate", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*config.Config)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Validate indicates an expected call of Validate.
-func (mr *MockCloudEnvironProviderMockRecorder) Validate(arg0, arg1 any) *gomock.Call {
+func (mr *MockCloudEnvironProviderMockRecorder) Validate(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Validate", reflect.TypeOf((*MockCloudEnvironProvider)(nil).Validate), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Validate", reflect.TypeOf((*MockCloudEnvironProvider)(nil).Validate), arg0, arg1, arg2)
 }
 
 // Version mocks base method.

--- a/environs/testing/package_mock.go
+++ b/environs/testing/package_mock.go
@@ -125,33 +125,33 @@ func (mr *MockEnvironProviderMockRecorder) Ping(arg0, arg1 any) *gomock.Call {
 }
 
 // PrepareConfig mocks base method.
-func (m *MockEnvironProvider) PrepareConfig(arg0 environs.PrepareConfigParams) (*config.Config, error) {
+func (m *MockEnvironProvider) PrepareConfig(arg0 context.Context, arg1 environs.PrepareConfigParams) (*config.Config, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PrepareConfig", arg0)
+	ret := m.ctrl.Call(m, "PrepareConfig", arg0, arg1)
 	ret0, _ := ret[0].(*config.Config)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // PrepareConfig indicates an expected call of PrepareConfig.
-func (mr *MockEnvironProviderMockRecorder) PrepareConfig(arg0 any) *gomock.Call {
+func (mr *MockEnvironProviderMockRecorder) PrepareConfig(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareConfig", reflect.TypeOf((*MockEnvironProvider)(nil).PrepareConfig), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareConfig", reflect.TypeOf((*MockEnvironProvider)(nil).PrepareConfig), arg0, arg1)
 }
 
 // Validate mocks base method.
-func (m *MockEnvironProvider) Validate(arg0, arg1 *config.Config) (*config.Config, error) {
+func (m *MockEnvironProvider) Validate(arg0 context.Context, arg1, arg2 *config.Config) (*config.Config, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Validate", arg0, arg1)
+	ret := m.ctrl.Call(m, "Validate", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*config.Config)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Validate indicates an expected call of Validate.
-func (mr *MockEnvironProviderMockRecorder) Validate(arg0, arg1 any) *gomock.Call {
+func (mr *MockEnvironProviderMockRecorder) Validate(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Validate", reflect.TypeOf((*MockEnvironProvider)(nil).Validate), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Validate", reflect.TypeOf((*MockEnvironProvider)(nil).Validate), arg0, arg1, arg2)
 }
 
 // Version mocks base method.
@@ -279,33 +279,33 @@ func (mr *MockCloudEnvironProviderMockRecorder) Ping(arg0, arg1 any) *gomock.Cal
 }
 
 // PrepareConfig mocks base method.
-func (m *MockCloudEnvironProvider) PrepareConfig(arg0 environs.PrepareConfigParams) (*config.Config, error) {
+func (m *MockCloudEnvironProvider) PrepareConfig(arg0 context.Context, arg1 environs.PrepareConfigParams) (*config.Config, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PrepareConfig", arg0)
+	ret := m.ctrl.Call(m, "PrepareConfig", arg0, arg1)
 	ret0, _ := ret[0].(*config.Config)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // PrepareConfig indicates an expected call of PrepareConfig.
-func (mr *MockCloudEnvironProviderMockRecorder) PrepareConfig(arg0 any) *gomock.Call {
+func (mr *MockCloudEnvironProviderMockRecorder) PrepareConfig(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareConfig", reflect.TypeOf((*MockCloudEnvironProvider)(nil).PrepareConfig), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareConfig", reflect.TypeOf((*MockCloudEnvironProvider)(nil).PrepareConfig), arg0, arg1)
 }
 
 // Validate mocks base method.
-func (m *MockCloudEnvironProvider) Validate(arg0, arg1 *config.Config) (*config.Config, error) {
+func (m *MockCloudEnvironProvider) Validate(arg0 context.Context, arg1, arg2 *config.Config) (*config.Config, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Validate", arg0, arg1)
+	ret := m.ctrl.Call(m, "Validate", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*config.Config)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Validate indicates an expected call of Validate.
-func (mr *MockCloudEnvironProviderMockRecorder) Validate(arg0, arg1 any) *gomock.Call {
+func (mr *MockCloudEnvironProviderMockRecorder) Validate(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Validate", reflect.TypeOf((*MockCloudEnvironProvider)(nil).Validate), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Validate", reflect.TypeOf((*MockCloudEnvironProvider)(nil).Validate), arg0, arg1, arg2)
 }
 
 // Version mocks base method.
@@ -1021,17 +1021,17 @@ func (mr *MockEnvironMockRecorder) Provider() *gomock.Call {
 }
 
 // SetConfig mocks base method.
-func (m *MockEnviron) SetConfig(arg0 *config.Config) error {
+func (m *MockEnviron) SetConfig(arg0 context.Context, arg1 *config.Config) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetConfig", arg0)
+	ret := m.ctrl.Call(m, "SetConfig", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetConfig indicates an expected call of SetConfig.
-func (mr *MockEnvironMockRecorder) SetConfig(arg0 any) *gomock.Call {
+func (mr *MockEnvironMockRecorder) SetConfig(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetConfig", reflect.TypeOf((*MockEnviron)(nil).SetConfig), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetConfig", reflect.TypeOf((*MockEnviron)(nil).SetConfig), arg0, arg1)
 }
 
 // StartInstance mocks base method.
@@ -1776,17 +1776,17 @@ func (mr *MockNetworkingEnvironMockRecorder) ReleaseContainerAddresses(arg0, arg
 }
 
 // SetConfig mocks base method.
-func (m *MockNetworkingEnviron) SetConfig(arg0 *config.Config) error {
+func (m *MockNetworkingEnviron) SetConfig(arg0 context.Context, arg1 *config.Config) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetConfig", arg0)
+	ret := m.ctrl.Call(m, "SetConfig", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetConfig indicates an expected call of SetConfig.
-func (mr *MockNetworkingEnvironMockRecorder) SetConfig(arg0 any) *gomock.Call {
+func (mr *MockNetworkingEnvironMockRecorder) SetConfig(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetConfig", reflect.TypeOf((*MockNetworkingEnviron)(nil).SetConfig), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetConfig", reflect.TypeOf((*MockNetworkingEnviron)(nil).SetConfig), arg0, arg1)
 }
 
 // Spaces mocks base method.

--- a/internal/provider/azure/config.go
+++ b/internal/provider/azure/config.go
@@ -4,6 +4,7 @@
 package azure
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -109,16 +110,16 @@ func knownLoadBalancerSkuNames() (skus []string) {
 // Validate ensures that the provided configuration is valid for this
 // provider, and that changes between the old (if provided) and new
 // configurations are valid.
-func (*azureEnvironProvider) Validate(newCfg, oldCfg *config.Config) (*config.Config, error) {
-	_, err := validateConfig(newCfg, oldCfg)
+func (*azureEnvironProvider) Validate(ctx context.Context, newCfg, oldCfg *config.Config) (*config.Config, error) {
+	_, err := validateConfig(ctx, newCfg, oldCfg)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	return newCfg, nil
 }
 
-func validateConfig(newCfg, oldCfg *config.Config) (*azureModelConfig, error) {
-	err := config.Validate(newCfg, oldCfg)
+func validateConfig(ctx context.Context, newCfg, oldCfg *config.Config) (*azureModelConfig, error) {
+	err := config.Validate(ctx, newCfg, oldCfg)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/provider/azure/config_test.go
+++ b/internal/provider/azure/config_test.go
@@ -4,6 +4,8 @@
 package azure_test
 
 import (
+	"context"
+
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -72,46 +74,46 @@ Please choose a name of no more than 80 characters.`)
 
 func (s *configSuite) TestValidateLoadBalancerSkuNameCanChange(c *gc.C) {
 	cfgOld := makeTestModelConfig(c, testing.Attrs{"load-balancer-sku-name": "Standard"})
-	_, err := s.provider.Validate(cfgOld, cfgOld)
+	_, err := s.provider.Validate(context.Background(), cfgOld, cfgOld)
 	c.Assert(err, jc.ErrorIsNil)
 
 	cfgNew := makeTestModelConfig(c, testing.Attrs{"load-balancer-sku-name": "Basic"})
-	_, err = s.provider.Validate(cfgNew, cfgOld)
+	_, err = s.provider.Validate(context.Background(), cfgNew, cfgOld)
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = s.provider.Validate(cfgOld, cfgNew)
+	_, err = s.provider.Validate(context.Background(), cfgOld, cfgNew)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *configSuite) TestValidateResourceGroupNameCantChange(c *gc.C) {
 	cfgOld := makeTestModelConfig(c, testing.Attrs{"resource-group-name": "foo"})
-	_, err := s.provider.Validate(cfgOld, cfgOld)
+	_, err := s.provider.Validate(context.Background(), cfgOld, cfgOld)
 	c.Assert(err, jc.ErrorIsNil)
 
 	cfgNew := makeTestModelConfig(c, testing.Attrs{"resource-group-name": "bar"})
-	_, err = s.provider.Validate(cfgNew, cfgOld)
+	_, err = s.provider.Validate(context.Background(), cfgNew, cfgOld)
 	c.Assert(err, gc.ErrorMatches, `cannot change immutable "resource-group-name" config \(foo -> bar\)`)
 }
 
 func (s *configSuite) TestValidateVirtualNetworkNameCantChange(c *gc.C) {
 	cfgOld := makeTestModelConfig(c, testing.Attrs{"network": "foo"})
-	_, err := s.provider.Validate(cfgOld, cfgOld)
+	_, err := s.provider.Validate(context.Background(), cfgOld, cfgOld)
 	c.Assert(err, jc.ErrorIsNil)
 
 	cfgNew := makeTestModelConfig(c, testing.Attrs{"network": "bar"})
-	_, err = s.provider.Validate(cfgNew, cfgOld)
+	_, err = s.provider.Validate(context.Background(), cfgNew, cfgOld)
 	c.Assert(err, gc.ErrorMatches, `cannot change immutable "network" config \(foo -> bar\)`)
 }
 
 func (s *configSuite) assertConfigValid(c *gc.C, attrs testing.Attrs) {
 	cfg := makeTestModelConfig(c, attrs)
-	_, err := s.provider.Validate(cfg, nil)
+	_, err := s.provider.Validate(context.Background(), cfg, nil)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *configSuite) assertConfigInvalid(c *gc.C, attrs testing.Attrs, expect string) {
 	cfg := makeTestModelConfig(c, attrs)
-	_, err := s.provider.Validate(cfg, nil)
+	_, err := s.provider.Validate(context.Background(), cfg, nil)
 	c.Assert(err, gc.ErrorMatches, expect)
 }
 

--- a/internal/provider/azure/environ.go
+++ b/internal/provider/azure/environ.go
@@ -4,6 +4,7 @@
 package azure
 
 import (
+	"context"
 	stdcontext "context"
 	"fmt"
 	"net/url"
@@ -360,7 +361,7 @@ func (env *azureEnviron) Config() *config.Config {
 }
 
 // SetConfig is specified in the Environ interface.
-func (env *azureEnviron) SetConfig(cfg *config.Config) error {
+func (env *azureEnviron) SetConfig(ctx context.Context, cfg *config.Config) error {
 	env.mu.Lock()
 	defer env.mu.Unlock()
 
@@ -368,7 +369,7 @@ func (env *azureEnviron) SetConfig(cfg *config.Config) error {
 	if env.config != nil {
 		old = env.config.Config
 	}
-	ecfg, err := validateConfig(cfg, old)
+	ecfg, err := validateConfig(context.Background(), cfg, old)
 	if err != nil {
 		return err
 	}

--- a/internal/provider/azure/environ_test.go
+++ b/internal/provider/azure/environ_test.go
@@ -281,7 +281,7 @@ func prepareForBootstrap(
 ) environs.Environ {
 	// Opening the environment should not incur network communication,
 	// so we don't set s.sender until after opening.
-	cfg, err := provider.PrepareConfig(environs.PrepareConfigParams{
+	cfg, err := provider.PrepareConfig(context.Background(), environs.PrepareConfigParams{
 		Config: makeTestModelConfig(c, attrs...),
 		Cloud:  fakeCloudSpec(),
 	})
@@ -709,7 +709,7 @@ func (s *environSuite) TestStartInstanceNoAuthorizedKeys(c *gc.C) {
 	env := s.openEnviron(c)
 	cfg, err := env.Config().Remove([]string{"authorized-keys"})
 	c.Assert(err, jc.ErrorIsNil)
-	err = env.SetConfig(cfg)
+	err = env.SetConfig(context.Background(), cfg)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.sender = s.startInstanceSenders(startInstanceSenderParams{bootstrap: false})
@@ -740,7 +740,7 @@ func (s *environSuite) TestStartInstanceInvalidCredential(c *gc.C) {
 	env := s.openEnviron(c)
 	cfg, err := env.Config().Remove([]string{"authorized-keys"})
 	c.Assert(err, jc.ErrorIsNil)
-	err = env.SetConfig(cfg)
+	err = env.SetConfig(context.Background(), cfg)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.createSenderWithUnauthorisedStatusCode(c)

--- a/internal/provider/azure/environprovider.go
+++ b/internal/provider/azure/environprovider.go
@@ -4,6 +4,7 @@
 package azure
 
 import (
+	"context"
 	stdcontext "context"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -131,7 +132,7 @@ func (prov *azureEnvironProvider) Open(ctx stdcontext.Context, args environs.Ope
 	}
 
 	// Config is needed before cloud spec.
-	if err := environ.SetConfig(args.Config); err != nil {
+	if err := environ.SetConfig(ctx, args.Config); err != nil {
 		return nil, errors.Trace(err)
 	}
 
@@ -153,7 +154,7 @@ func (p azureEnvironProvider) Ping(ctx envcontext.ProviderCallContext, endpoint 
 }
 
 // PrepareConfig is part of the EnvironProvider interface.
-func (prov *azureEnvironProvider) PrepareConfig(args environs.PrepareConfigParams) (*config.Config, error) {
+func (prov *azureEnvironProvider) PrepareConfig(ctx context.Context, args environs.PrepareConfigParams) (*config.Config, error) {
 	if err := validateCloudSpec(args.Cloud); err != nil {
 		return nil, errors.Annotate(err, "validating cloud spec")
 	}

--- a/internal/provider/azure/environprovider_test.go
+++ b/internal/provider/azure/environprovider_test.go
@@ -4,6 +4,7 @@
 package azure_test
 
 import (
+	"context"
 	stdcontext "context"
 	"net/http"
 	"time"
@@ -68,7 +69,7 @@ func fakeServicePrincipalCredential() *cloud.Credential {
 
 func (s *environProviderSuite) TestPrepareConfig(c *gc.C) {
 	cfg := makeTestModelConfig(c)
-	cfg, err := s.provider.PrepareConfig(environs.PrepareConfigParams{
+	cfg, err := s.provider.PrepareConfig(context.Background(), environs.PrepareConfigParams{
 		Cloud:  s.spec,
 		Config: cfg,
 	})

--- a/internal/provider/common/mock_test.go
+++ b/internal/provider/common/mock_test.go
@@ -4,6 +4,7 @@
 package common_test
 
 import (
+	"context"
 	"fmt"
 	"io"
 
@@ -77,7 +78,7 @@ func (env *mockEnviron) Config() *config.Config {
 	return env.config()
 }
 
-func (env *mockEnviron) SetConfig(cfg *config.Config) error {
+func (env *mockEnviron) SetConfig(_ context.Context, cfg *config.Config) error {
 	if env.setConfig != nil {
 		return env.setConfig(cfg)
 	}

--- a/internal/provider/common/mocks/zoned_environ.go
+++ b/internal/provider/common/mocks/zoned_environ.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	constraints "github.com/juju/juju/core/constraints"
@@ -310,17 +311,17 @@ func (mr *MockZonedEnvironMockRecorder) Provider() *gomock.Call {
 }
 
 // SetConfig mocks base method.
-func (m *MockZonedEnviron) SetConfig(arg0 *config.Config) error {
+func (m *MockZonedEnviron) SetConfig(arg0 context.Context, arg1 *config.Config) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetConfig", arg0)
+	ret := m.ctrl.Call(m, "SetConfig", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetConfig indicates an expected call of SetConfig.
-func (mr *MockZonedEnvironMockRecorder) SetConfig(arg0 any) *gomock.Call {
+func (mr *MockZonedEnvironMockRecorder) SetConfig(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetConfig", reflect.TypeOf((*MockZonedEnviron)(nil).SetConfig), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetConfig", reflect.TypeOf((*MockZonedEnviron)(nil).SetConfig), arg0, arg1)
 }
 
 // StartInstance mocks base method.

--- a/internal/provider/ec2/config.go
+++ b/internal/provider/ec2/config.go
@@ -4,6 +4,7 @@
 package ec2
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/juju/schema"
@@ -54,8 +55,8 @@ func (c *environConfig) forceVPCID() bool {
 	return c.attrs["vpc-id-force"].(bool)
 }
 
-func (p environProvider) newConfig(cfg *config.Config) (*environConfig, error) {
-	valid, err := p.Validate(cfg, nil)
+func (p environProvider) newConfig(ctx context.Context, cfg *config.Config) (*environConfig, error) {
+	valid, err := p.Validate(ctx, cfg, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -83,9 +84,9 @@ func (p environProvider) ConfigDefaults() schema.Defaults {
 	return configDefaults
 }
 
-func validateConfig(cfg, old *config.Config) (*environConfig, error) {
+func validateConfig(ctx context.Context, cfg, old *config.Config) (*environConfig, error) {
 	// Check for valid changes for the base config values.
-	if err := config.Validate(cfg, old); err != nil {
+	if err := config.Validate(ctx, cfg, old); err != nil {
 		return nil, err
 	}
 	validated, err := cfg.ValidateUnknownAttrs(configFields, configDefaults)

--- a/internal/provider/ec2/config_test.go
+++ b/internal/provider/ec2/config_test.go
@@ -79,9 +79,9 @@ func (t configTest) check(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 
 		// Keep err for validation below.
-		valid, err = providerInstance.Validate(changed, old)
+		valid, err = providerInstance.Validate(context.Background(), changed, old)
 		if err == nil {
-			err = ec2env.SetConfig(valid)
+			err = ec2env.SetConfig(context.Background(), valid)
 		}
 	}
 	if t.err != "" {
@@ -305,7 +305,7 @@ func (s *ConfigSuite) TestPrepareConfigSetsDefaultBlockSource(c *gc.C) {
 			"secret-key": "y",
 		},
 	)
-	cfg, err = providerInstance.PrepareConfig(environs.PrepareConfigParams{
+	cfg, err = providerInstance.PrepareConfig(context.Background(), environs.PrepareConfigParams{
 		Config: cfg,
 		Cloud: environscloudspec.CloudSpec{
 			Type:       "ec2",
@@ -335,7 +335,7 @@ func (s *ConfigSuite) TestPrepareSetsDefaultBlockSource(c *gc.C) {
 			"secret-key": "y",
 		},
 	)
-	cfg, err := providerInstance.PrepareConfig(environs.PrepareConfigParams{
+	cfg, err := providerInstance.PrepareConfig(context.Background(), environs.PrepareConfigParams{
 		Config: baseConfig,
 		Cloud: environscloudspec.CloudSpec{
 			Type:       "ec2",

--- a/internal/provider/ec2/environ.go
+++ b/internal/provider/ec2/environ.go
@@ -4,6 +4,7 @@
 package ec2
 
 import (
+	"context"
 	stdcontext "context"
 	"encoding/base64"
 	stderrors "errors"
@@ -134,8 +135,8 @@ func (e *environ) Config() *config.Config {
 	return e.ecfg().Config
 }
 
-func (e *environ) SetConfig(cfg *config.Config) error {
-	ecfg, err := providerInstance.newConfig(cfg)
+func (e *environ) SetConfig(ctx context.Context, cfg *config.Config) error {
+	ecfg, err := providerInstance.newConfig(ctx, cfg)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/internal/provider/ec2/local_test.go
+++ b/internal/provider/ec2/local_test.go
@@ -2917,7 +2917,7 @@ func (t *localServerSuite) TestGlobalPorts(c *gc.C) {
 	// Change configuration.
 	oldConfig := t.Env.Config()
 	defer func() {
-		err := t.Env.SetConfig(oldConfig)
+		err := t.Env.SetConfig(context.Background(), oldConfig)
 		c.Assert(err, jc.ErrorIsNil)
 	}()
 
@@ -2934,7 +2934,7 @@ func (t *localServerSuite) TestGlobalPorts(c *gc.C) {
 	attrs["firewall-mode"] = config.FwGlobal
 	newConfig, err := t.Env.Config().Apply(attrs)
 	c.Assert(err, jc.ErrorIsNil)
-	err = t.Env.SetConfig(newConfig)
+	err = t.Env.SetConfig(context.Background(), newConfig)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Create instances and check open ports on both instances.

--- a/internal/provider/ec2/provider.go
+++ b/internal/provider/ec2/provider.go
@@ -4,6 +4,7 @@
 package ec2
 
 import (
+	"context"
 	stdcontext "context"
 	"fmt"
 
@@ -54,7 +55,7 @@ func (p environProvider) Open(ctx stdcontext.Context, args environs.OpenParams) 
 		return nil, err
 	}
 
-	if err := e.SetConfig(args.Config); err != nil {
+	if err := e.SetConfig(ctx, args.Config); err != nil {
 		return nil, errors.Trace(err)
 	}
 	return e, nil
@@ -72,7 +73,7 @@ func (p environProvider) Ping(ctx envcontext.ProviderCallContext, endpoint strin
 }
 
 // PrepareConfig is specified in the EnvironProvider interface.
-func (p environProvider) PrepareConfig(args environs.PrepareConfigParams) (*config.Config, error) {
+func (p environProvider) PrepareConfig(ctx context.Context, args environs.PrepareConfigParams) (*config.Config, error) {
 	if err := validateCloudSpec(args.Cloud); err != nil {
 		return nil, errors.Annotate(err, "validating cloud spec")
 	}
@@ -102,8 +103,8 @@ func validateCloudSpec(c environscloudspec.CloudSpec) error {
 }
 
 // Validate is specified in the EnvironProvider interface.
-func (environProvider) Validate(cfg, old *config.Config) (valid *config.Config, err error) {
-	newEcfg, err := validateConfig(cfg, old)
+func (environProvider) Validate(ctx context.Context, cfg, old *config.Config) (valid *config.Config, err error) {
+	newEcfg, err := validateConfig(ctx, cfg, old)
 	if err != nil {
 		return nil, fmt.Errorf("invalid EC2 provider config: %v", err)
 	}

--- a/internal/provider/equinix/environ.go
+++ b/internal/provider/equinix/environ.go
@@ -4,6 +4,7 @@
 package equinix
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"regexp"
@@ -225,10 +226,10 @@ func (*environ) Provider() environs.EnvironProvider {
 	return &environProvider{}
 }
 
-func (e *environ) SetConfig(cfg *config.Config) error {
+func (e *environ) SetConfig(ctx context.Context, cfg *config.Config) error {
 	e.ecfgMutex.Lock()
 	defer e.ecfgMutex.Unlock()
-	ecfg, err := providerInstance.newConfig(cfg)
+	ecfg, err := providerInstance.newConfig(ctx, cfg)
 	if err != nil {
 		return errors.Annotate(err, "invalid config change")
 	}

--- a/internal/provider/equinix/environ_test.go
+++ b/internal/provider/equinix/environ_test.go
@@ -74,7 +74,7 @@ func fakeServicePrincipalCredential() *cloud.Credential {
 
 func (s *environProviderSuite) TestPrepareConfig(c *gc.C) {
 	cfg := makeTestModelConfig(c)
-	cfg, err := s.provider.PrepareConfig(environs.PrepareConfigParams{
+	cfg, err := s.provider.PrepareConfig(context.Background(), environs.PrepareConfigParams{
 		Cloud:  s.spec,
 		Config: cfg,
 	})

--- a/internal/provider/equinix/provider_test.go
+++ b/internal/provider/equinix/provider_test.go
@@ -4,6 +4,7 @@
 package equinix_test
 
 import (
+	"context"
 	stdcontext "context"
 
 	"github.com/juju/testing"
@@ -50,7 +51,7 @@ func (s *providerSuite) TestOpen(c *gc.C) {
 }
 
 func (s *providerSuite) TestPrepareConfig(c *gc.C) {
-	cfg, err := s.provider.PrepareConfig(environs.PrepareConfigParams{
+	cfg, err := s.provider.PrepareConfig(context.Background(), environs.PrepareConfigParams{
 		Config: fakeConfig(c),
 		Cloud:  fakeCloudSpec(),
 	})
@@ -60,7 +61,7 @@ func (s *providerSuite) TestPrepareConfig(c *gc.C) {
 
 func (s *providerSuite) TestValidate(c *gc.C) {
 	config := fakeConfig(c)
-	validCfg, err := s.provider.Validate(config, nil)
+	validCfg, err := s.provider.Validate(context.Background(), config, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	validAttrs := validCfg.AllAttrs()

--- a/internal/provider/gce/config.go
+++ b/internal/provider/gce/config.go
@@ -4,6 +4,8 @@
 package gce
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/schema"
 	"gopkg.in/juju/environschema.v1"
@@ -45,9 +47,9 @@ type environConfig struct {
 // newConfig builds a new environConfig from the provided Config
 // filling in default values, if any. It returns an error if the
 // resulting configuration is not valid.
-func newConfig(cfg, old *config.Config) (*environConfig, error) {
+func newConfig(ctx context.Context, cfg, old *config.Config) (*environConfig, error) {
 	// Ensure that the provided config is valid.
-	if err := config.Validate(cfg, old); err != nil {
+	if err := config.Validate(ctx, cfg, old); err != nil {
 		return nil, errors.Trace(err)
 	}
 	attrs, err := cfg.ValidateUnknownAttrs(configFields, configDefaults)
@@ -59,7 +61,7 @@ func newConfig(cfg, old *config.Config) (*environConfig, error) {
 		// There's an old configuration. Validate it so that any
 		// default values are correctly coerced for when we check
 		// the old values later.
-		oldEcfg, err := newConfig(old, nil)
+		oldEcfg, err := newConfig(ctx, old, nil)
 		if err != nil {
 			return nil, errors.Annotatef(err, "invalid base config")
 		}

--- a/internal/provider/gce/config_test.go
+++ b/internal/provider/gce/config_test.go
@@ -4,6 +4,7 @@
 package gce_test
 
 import (
+	"context"
 	stdcontext "context"
 
 	jc "github.com/juju/testing/checkers"
@@ -121,7 +122,7 @@ func (s *ConfigSuite) TestValidateNewConfig(c *gc.C) {
 		c.Logf("test %d: %s", i, test.info)
 
 		testConfig := test.newConfig(c)
-		validatedConfig, err := gce.Provider.Validate(testConfig, nil)
+		validatedConfig, err := gce.Provider.Validate(context.Background(), testConfig, nil)
 
 		// Check the result
 		if test.err != "" {
@@ -140,7 +141,7 @@ func (s *ConfigSuite) TestValidateOldConfig(c *gc.C) {
 
 		// Validate the new config (relative to the old one) using the
 		// provider.
-		_, err := gce.Provider.Validate(s.config, test.newConfig(c))
+		_, err := gce.Provider.Validate(context.Background(), s.config, test.newConfig(c))
 		if test.err != "" {
 			// In this test, we case only about the validating
 			// the old configuration, not about the success cases.
@@ -164,7 +165,7 @@ func (s *ConfigSuite) TestValidateChange(c *gc.C) {
 		c.Logf("test %d: %s", i, test.info)
 
 		testConfig := test.newConfig(c)
-		validatedConfig, err := gce.Provider.Validate(testConfig, s.config)
+		validatedConfig, err := gce.Provider.Validate(context.Background(), testConfig, s.config)
 
 		// Check the result.
 		if test.err != "" {
@@ -186,7 +187,7 @@ func (s *ConfigSuite) TestSetConfig(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 
 		testConfig := test.newConfig(c)
-		err = environ.SetConfig(testConfig)
+		err = environ.SetConfig(context.Background(), testConfig)
 
 		// Check the result.
 		if test.err != "" {

--- a/internal/provider/gce/environ.go
+++ b/internal/provider/gce/environ.go
@@ -4,6 +4,7 @@
 package gce
 
 import (
+	"context"
 	stdcontext "context"
 	"strings"
 	"sync"
@@ -111,7 +112,7 @@ var (
 )
 
 func newEnviron(ctx stdcontext.Context, cloud environscloudspec.CloudSpec, cfg *config.Config) (*environ, error) {
-	ecfg, err := newConfig(cfg, nil)
+	ecfg, err := newConfig(ctx, cfg, nil)
 	if err != nil {
 		return nil, errors.Annotate(err, "invalid config")
 	}
@@ -199,11 +200,11 @@ func (env *environ) Region() (simplestreams.CloudSpec, error) {
 }
 
 // SetConfig updates the env's configuration.
-func (env *environ) SetConfig(cfg *config.Config) error {
+func (env *environ) SetConfig(ctx context.Context, cfg *config.Config) error {
 	env.lock.Lock()
 	defer env.lock.Unlock()
 
-	ecfg, err := newConfig(cfg, env.ecfg.config)
+	ecfg, err := newConfig(ctx, cfg, env.ecfg.config)
 	if err != nil {
 		return errors.Annotate(err, "invalid config change")
 	}

--- a/internal/provider/gce/environ_test.go
+++ b/internal/provider/gce/environ_test.go
@@ -4,6 +4,7 @@
 package gce_test
 
 import (
+	"context"
 	"fmt"
 
 	jc "github.com/juju/testing/checkers"
@@ -48,7 +49,7 @@ func (s *environSuite) TestRegion(c *gc.C) {
 }
 
 func (s *environSuite) TestSetConfig(c *gc.C) {
-	err := s.Env.SetConfig(s.Config)
+	err := s.Env.SetConfig(context.Background(), s.Config)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(gce.ExposeEnvConfig(s.Env), jc.DeepEquals, s.EnvConfig)
@@ -56,7 +57,7 @@ func (s *environSuite) TestSetConfig(c *gc.C) {
 }
 
 func (s *environSuite) TestSetConfigFake(c *gc.C) {
-	err := s.Env.SetConfig(s.Config)
+	err := s.Env.SetConfig(context.Background(), s.Config)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(s.FakeConn.Calls, gc.HasLen, 0)

--- a/internal/provider/gce/provider.go
+++ b/internal/provider/gce/provider.go
@@ -4,6 +4,7 @@
 package gce
 
 import (
+	"context"
 	stdcontext "context"
 
 	"github.com/juju/errors"
@@ -58,7 +59,7 @@ func (p environProvider) Ping(ctx envcontext.ProviderCallContext, endpoint strin
 }
 
 // PrepareConfig implements environs.EnvironProvider.
-func (p environProvider) PrepareConfig(args environs.PrepareConfigParams) (*config.Config, error) {
+func (p environProvider) PrepareConfig(ctx context.Context, args environs.PrepareConfigParams) (*config.Config, error) {
 	if err := validateCloudSpec(args.Cloud); err != nil {
 		return nil, errors.Annotate(err, "validating cloud spec")
 	}
@@ -114,8 +115,8 @@ func configWithDefaults(cfg *config.Config) (*config.Config, error) {
 }
 
 // Validate implements environs.EnvironProvider.Validate.
-func (environProvider) Validate(cfg, old *config.Config) (*config.Config, error) {
-	newCfg, err := newConfig(cfg, old)
+func (environProvider) Validate(ctx context.Context, cfg, old *config.Config) (*config.Config, error) {
+	newCfg, err := newConfig(ctx, cfg, old)
 	if err != nil {
 		return nil, errors.Annotate(err, "invalid config")
 	}

--- a/internal/provider/gce/provider_test.go
+++ b/internal/provider/gce/provider_test.go
@@ -4,6 +4,7 @@
 package gce_test
 
 import (
+	"context"
 	stdcontext "context"
 
 	jc "github.com/juju/testing/checkers"
@@ -74,7 +75,7 @@ func (s *providerSuite) testOpenError(c *gc.C, spec environscloudspec.CloudSpec,
 }
 
 func (s *providerSuite) TestPrepareConfig(c *gc.C) {
-	cfg, err := s.provider.PrepareConfig(environs.PrepareConfigParams{
+	cfg, err := s.provider.PrepareConfig(context.Background(), environs.PrepareConfigParams{
 		Config: s.Config,
 		Cloud:  gce.MakeTestCloudSpec(),
 	})
@@ -83,7 +84,7 @@ func (s *providerSuite) TestPrepareConfig(c *gc.C) {
 }
 
 func (s *providerSuite) TestValidate(c *gc.C) {
-	validCfg, err := s.provider.Validate(s.Config, nil)
+	validCfg, err := s.provider.Validate(context.Background(), s.Config, nil)
 	c.Check(err, jc.ErrorIsNil)
 
 	validAttrs := validCfg.AllAttrs()

--- a/internal/provider/gce/testing_test.go
+++ b/internal/provider/gce/testing_test.go
@@ -236,7 +236,7 @@ func (s *BaseSuiteUnpatched) initNet(c *gc.C) {
 
 func (s *BaseSuiteUnpatched) setConfig(c *gc.C, cfg *config.Config) {
 	s.Config = cfg
-	ecfg, err := newConfig(cfg, nil)
+	ecfg, err := newConfig(context.Background(), cfg, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	s.EnvConfig = ecfg
 	uuid := cfg.UUID()

--- a/internal/provider/lxd/config.go
+++ b/internal/provider/lxd/config.go
@@ -4,6 +4,8 @@
 package lxd
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/schema"
 	"gopkg.in/juju/environschema.v1"
@@ -47,9 +49,9 @@ func newConfig(cfg *config.Config) *environConfig {
 // newValidConfig builds a new environConfig from the provided Config
 // and returns it. This includes applying the provided defaults
 // values, if any. The resulting config values are validated.
-func newValidConfig(cfg *config.Config) (*environConfig, error) {
+func newValidConfig(ctx context.Context, cfg *config.Config) (*environConfig, error) {
 	// Ensure that the provided config is valid.
-	if err := config.Validate(cfg, nil); err != nil {
+	if err := config.Validate(ctx, cfg, nil); err != nil {
 		return nil, errors.Trace(err)
 	}
 

--- a/internal/provider/lxd/config_test.go
+++ b/internal/provider/lxd/config_test.go
@@ -4,6 +4,7 @@
 package lxd_test
 
 import (
+	"context"
 	stdcontext "context"
 
 	jc "github.com/juju/testing/checkers"
@@ -159,7 +160,7 @@ func (s *configSuite) TestValidateNewConfig(c *gc.C) {
 		c.Logf("test %d: %s", i, test.info)
 
 		testConfig := test.newConfig(c)
-		validatedConfig, err := s.provider.Validate(testConfig, nil)
+		validatedConfig, err := s.provider.Validate(context.Background(), testConfig, nil)
 
 		// Check the result
 		if test.err != "" {
@@ -177,14 +178,14 @@ func (s *configSuite) TestValidateOldConfig(c *gc.C) {
 
 		oldcfg := test.newConfig(c)
 		var err error
-		oldcfg, err = s.provider.Validate(oldcfg, nil)
+		oldcfg, err = s.provider.Validate(context.Background(), oldcfg, nil)
 		c.Assert(err, jc.ErrorIsNil)
 		newcfg := test.fixCfg(c, s.config)
 		expected := updateAttrs(lxd.ConfigAttrs, test.insert)
 
 		// Validate the new config (relative to the old one) using the
 		// provider.
-		validatedConfig, err := s.provider.Validate(newcfg, oldcfg)
+		validatedConfig, err := s.provider.Validate(context.Background(), newcfg, oldcfg)
 
 		// Check the result.
 		if test.err != "" {
@@ -215,7 +216,7 @@ func (s *configSuite) TestValidateChange(c *gc.C) {
 		c.Logf("test %d: %s", i, test.info)
 
 		testConfig := test.newConfig(c)
-		validatedConfig, err := s.provider.Validate(testConfig, s.config)
+		validatedConfig, err := s.provider.Validate(context.Background(), testConfig, s.config)
 
 		// Check the result.
 		if test.err != "" {
@@ -237,12 +238,12 @@ func (s *configSuite) TestSetConfig(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 
 		testConfig := test.newConfig(c)
-		err = environ.SetConfig(testConfig)
+		err = environ.SetConfig(context.Background(), testConfig)
 
 		// Check the result.
 		if test.err != "" {
 			test.checkFailure(c, err, "invalid config change")
-			expected, err := s.provider.Validate(s.config, nil)
+			expected, err := s.provider.Validate(context.Background(), s.config, nil)
 			c.Assert(err, jc.ErrorIsNil)
 			test.checkAttrs(c, environ.Config().AllAttrs(), expected)
 		} else {

--- a/internal/provider/lxd/environ.go
+++ b/internal/provider/lxd/environ.go
@@ -4,6 +4,7 @@
 package lxd
 
 import (
+	"context"
 	stdcontext "context"
 	"net"
 	"net/url"
@@ -68,7 +69,7 @@ func newEnviron(
 	spec environscloudspec.CloudSpec,
 	cfg *config.Config,
 ) (*environ, error) {
-	ecfg, err := newValidConfig(cfg)
+	ecfg, err := newValidConfig(ctx, cfg)
 	if err != nil {
 		return nil, errors.Annotate(err, "invalid config")
 	}
@@ -148,10 +149,10 @@ func (env *environ) Provider() environs.EnvironProvider {
 }
 
 // SetConfig updates the environ's configuration.
-func (env *environ) SetConfig(cfg *config.Config) error {
+func (env *environ) SetConfig(ctx context.Context, cfg *config.Config) error {
 	env.lock.Lock()
 	defer env.lock.Unlock()
-	ecfg, err := newValidConfig(cfg)
+	ecfg, err := newValidConfig(ctx, cfg)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/internal/provider/lxd/environ_test.go
+++ b/internal/provider/lxd/environ_test.go
@@ -60,7 +60,7 @@ func (s *environSuite) TestProvider(c *gc.C) {
 }
 
 func (s *environSuite) TestSetConfigOkay(c *gc.C) {
-	err := s.Env.SetConfig(s.Config)
+	err := s.Env.SetConfig(context.Background(), s.Config)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(lxd.ExposeEnvConfig(s.Env), jc.DeepEquals, s.EnvConfig)
@@ -69,7 +69,7 @@ func (s *environSuite) TestSetConfigOkay(c *gc.C) {
 }
 
 func (s *environSuite) TestSetConfigNoAPI(c *gc.C) {
-	err := s.Env.SetConfig(s.Config)
+	err := s.Env.SetConfig(context.Background(), s.Config)
 
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/internal/provider/lxd/provider.go
+++ b/internal/provider/lxd/provider.go
@@ -4,6 +4,7 @@
 package lxd
 
 import (
+	"context"
 	stdcontext "context"
 	"net/http"
 	"os"
@@ -188,7 +189,7 @@ func (p *environProvider) Ping(ctx envcontext.ProviderCallContext, endpoint stri
 }
 
 // PrepareConfig implements environs.EnvironProvider.
-func (p *environProvider) PrepareConfig(args environs.PrepareConfigParams) (*config.Config, error) {
+func (p *environProvider) PrepareConfig(ctx context.Context, args environs.PrepareConfigParams) (*config.Config, error) {
 	if err := p.validateCloudSpec(args.Cloud); err != nil {
 		return nil, errors.Annotate(err, "validating cloud spec")
 	}
@@ -205,8 +206,8 @@ func (p *environProvider) PrepareConfig(args environs.PrepareConfigParams) (*con
 }
 
 // Validate implements environs.EnvironProvider.
-func (*environProvider) Validate(cfg, old *config.Config) (valid *config.Config, err error) {
-	if _, err := newValidConfig(cfg); err != nil {
+func (*environProvider) Validate(ctx context.Context, cfg, old *config.Config) (valid *config.Config, err error) {
+	if _, err := newValidConfig(ctx, cfg); err != nil {
 		return nil, errors.Annotate(err, "invalid base config")
 	}
 	return cfg, nil

--- a/internal/provider/lxd/provider_test.go
+++ b/internal/provider/lxd/provider_test.go
@@ -466,7 +466,7 @@ func (s *providerSuite) TestValidate(c *gc.C) {
 
 	deps := s.createProvider(ctrl)
 
-	validCfg, err := deps.provider.Validate(s.Config, nil)
+	validCfg, err := deps.provider.Validate(context.Background(), s.Config, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	validAttrs := validCfg.AllAttrs()
 
@@ -484,7 +484,7 @@ func (s *providerSuite) TestValidateWithInvalidConfig(c *gc.C) {
 	})
 	c.Assert(err, gc.IsNil)
 
-	_, err = deps.provider.Validate(config, nil)
+	_, err = deps.provider.Validate(context.Background(), config, nil)
 	c.Assert(err, gc.NotNil)
 }
 
@@ -560,7 +560,7 @@ func (s *ProviderFunctionalSuite) TestOpen(c *gc.C) {
 }
 
 func (s *ProviderFunctionalSuite) TestPrepareConfig(c *gc.C) {
-	cfg, err := s.provider.PrepareConfig(environs.PrepareConfigParams{
+	cfg, err := s.provider.PrepareConfig(context.Background(), environs.PrepareConfigParams{
 		Cloud:  lxdCloudSpec(),
 		Config: s.Config,
 	})
@@ -571,7 +571,7 @@ func (s *ProviderFunctionalSuite) TestPrepareConfig(c *gc.C) {
 func (s *ProviderFunctionalSuite) TestPrepareConfigUnsupportedEndpointScheme(c *gc.C) {
 	cloudSpec := lxdCloudSpec()
 	cloudSpec.Endpoint = "unix://foo"
-	_, err := s.provider.PrepareConfig(environs.PrepareConfigParams{
+	_, err := s.provider.PrepareConfig(context.Background(), environs.PrepareConfigParams{
 		Cloud:  cloudSpec,
 		Config: s.Config,
 	})
@@ -580,7 +580,7 @@ func (s *ProviderFunctionalSuite) TestPrepareConfigUnsupportedEndpointScheme(c *
 
 func (s *ProviderFunctionalSuite) TestPrepareConfigUnsupportedAuthType(c *gc.C) {
 	cred := cloud.NewCredential("foo", nil)
-	_, err := s.provider.PrepareConfig(environs.PrepareConfigParams{
+	_, err := s.provider.PrepareConfig(context.Background(), environs.PrepareConfigParams{
 		Cloud: environscloudspec.CloudSpec{
 			Type:       "lxd",
 			Name:       "remotehost",
@@ -592,7 +592,7 @@ func (s *ProviderFunctionalSuite) TestPrepareConfigUnsupportedAuthType(c *gc.C) 
 
 func (s *ProviderFunctionalSuite) TestPrepareConfigInvalidCertificateAttrs(c *gc.C) {
 	cred := cloud.NewCredential(cloud.CertificateAuthType, map[string]string{})
-	_, err := s.provider.PrepareConfig(environs.PrepareConfigParams{
+	_, err := s.provider.PrepareConfig(context.Background(), environs.PrepareConfigParams{
 		Cloud: environscloudspec.CloudSpec{
 			Type:       "lxd",
 			Name:       "remotehost",
@@ -604,7 +604,7 @@ func (s *ProviderFunctionalSuite) TestPrepareConfigInvalidCertificateAttrs(c *gc
 
 func (s *ProviderFunctionalSuite) TestPrepareConfigEmptyAuthNonLocal(c *gc.C) {
 	cred := cloud.NewEmptyCredential()
-	_, err := s.provider.PrepareConfig(environs.PrepareConfigParams{
+	_, err := s.provider.PrepareConfig(context.Background(), environs.PrepareConfigParams{
 		Cloud: environscloudspec.CloudSpec{
 			Type:       "lxd",
 			Name:       "remotehost",

--- a/internal/provider/lxd/testing_test.go
+++ b/internal/provider/lxd/testing_test.go
@@ -4,6 +4,7 @@
 package lxd
 
 import (
+	"context"
 	stdcontext "context"
 	"net"
 	"os"
@@ -211,7 +212,7 @@ func (s *BaseSuiteUnpatched) initNet(c *gc.C) {
 
 func (s *BaseSuiteUnpatched) setConfig(c *gc.C, cfg *config.Config) {
 	s.Config = cfg
-	ecfg, err := newValidConfig(cfg)
+	ecfg, err := newValidConfig(context.Background(), cfg)
 	c.Assert(err, jc.ErrorIsNil)
 	s.EnvConfig = ecfg
 	uuid := cfg.UUID()
@@ -750,7 +751,7 @@ func (s *EnvironSuite) NewEnviron(c *gc.C, srv Server, cfgEdit map[string]interf
 		c.Assert(err, jc.ErrorIsNil)
 	}
 
-	eCfg, err := newValidConfig(cfg)
+	eCfg, err := newValidConfig(context.Background(), cfg)
 	c.Assert(err, jc.ErrorIsNil)
 
 	namespace, err := instance.NewNamespace(cfg.UUID())
@@ -774,7 +775,7 @@ func (s *EnvironSuite) NewEnvironWithServerFactory(c *gc.C, srv ServerFactory, c
 		c.Assert(err, jc.ErrorIsNil)
 	}
 
-	eCfg, err := newValidConfig(cfg)
+	eCfg, err := newValidConfig(context.Background(), cfg)
 	c.Assert(err, jc.ErrorIsNil)
 
 	namespace, err := instance.NewNamespace(cfg.UUID())

--- a/internal/provider/maas/config.go
+++ b/internal/provider/maas/config.go
@@ -4,6 +4,8 @@
 package maas
 
 import (
+	"context"
+
 	"github.com/juju/schema"
 	"gopkg.in/juju/environschema.v1"
 
@@ -27,8 +29,8 @@ type maasModelConfig struct {
 	attrs map[string]interface{}
 }
 
-func (p EnvironProvider) newConfig(cfg *config.Config) (*maasModelConfig, error) {
-	validCfg, err := p.Validate(cfg, nil)
+func (p EnvironProvider) newConfig(ctx context.Context, cfg *config.Config) (*maasModelConfig, error) {
+	validCfg, err := p.Validate(ctx, cfg, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -59,9 +61,9 @@ func (p EnvironProvider) ConfigDefaults() schema.Defaults {
 	return configDefaults
 }
 
-func (p EnvironProvider) Validate(cfg, oldCfg *config.Config) (*config.Config, error) {
+func (p EnvironProvider) Validate(ctx context.Context, cfg, oldCfg *config.Config) (*config.Config, error) {
 	// Validate base configuration change before validating MAAS specifics.
-	err := config.Validate(cfg, oldCfg)
+	err := config.Validate(ctx, cfg, oldCfg)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/provider/maas/config_test.go
+++ b/internal/provider/maas/config_test.go
@@ -4,6 +4,8 @@
 package maas
 
 import (
+	"context"
+
 	"github.com/juju/gomaasapi/v2"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -33,7 +35,7 @@ func newConfig(values map[string]interface{}) (*maasModelConfig, error) {
 	if err != nil {
 		return nil, err
 	}
-	return providerInstance.newConfig(cfg)
+	return providerInstance.newConfig(context.Background(), cfg)
 }
 
 func (s *configSuite) SetUpTest(c *gc.C) {
@@ -54,7 +56,7 @@ func (*configSuite) TestValidateUpcallsEnvironsConfigValidate(c *gc.C) {
 	newCfg, err := oldCfg.Apply(map[string]interface{}{"name": newName})
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = EnvironProvider{}.Validate(newCfg, oldCfg.Config)
+	_, err = EnvironProvider{}.Validate(context.Background(), newCfg, oldCfg.Config)
 
 	c.Assert(err, gc.NotNil)
 	c.Check(err, gc.ErrorMatches, ".*cannot change name.*")

--- a/internal/provider/maas/environ.go
+++ b/internal/provider/maas/environ.go
@@ -4,6 +4,7 @@
 package maas
 
 import (
+	"context"
 	stdcontext "context"
 	"fmt"
 	"net/http"
@@ -122,7 +123,7 @@ func NewEnviron(ctx stdcontext.Context, cloud environscloudspec.CloudSpec, cfg *
 		shortRetryStrategy: defaultShortRetryStrategy,
 		longRetryStrategy:  defaultLongRetryStrategy,
 	}
-	if err := env.SetConfig(cfg); err != nil {
+	if err := env.SetConfig(ctx, cfg); err != nil {
 		return nil, errors.Trace(err)
 	}
 	if err := env.SetCloudSpec(ctx, cloud); err != nil {
@@ -221,7 +222,7 @@ func (env *maasEnviron) Config() *config.Config {
 }
 
 // SetConfig is specified in the Environ interface.
-func (env *maasEnviron) SetConfig(cfg *config.Config) error {
+func (env *maasEnviron) SetConfig(ctx context.Context, cfg *config.Config) error {
 	env.ecfgMutex.Lock()
 	defer env.ecfgMutex.Unlock()
 
@@ -231,12 +232,12 @@ func (env *maasEnviron) SetConfig(cfg *config.Config) error {
 	if env.ecfgUnlocked != nil {
 		oldCfg = env.ecfgUnlocked.Config
 	}
-	cfg, err := env.Provider().Validate(cfg, oldCfg)
+	cfg, err := env.Provider().Validate(ctx, cfg, oldCfg)
 	if err != nil {
 		return errors.Trace(err)
 	}
 
-	ecfg, err := providerInstance.newConfig(cfg)
+	ecfg, err := providerInstance.newConfig(ctx, cfg)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/internal/provider/maas/environprovider.go
+++ b/internal/provider/maas/environprovider.go
@@ -4,6 +4,7 @@
 package maas
 
 import (
+	"context"
 	stdcontext "context"
 	"fmt"
 	"net/url"
@@ -107,7 +108,7 @@ func (p EnvironProvider) checkMaas(endpoint, ver string) error {
 }
 
 // PrepareConfig is specified in the EnvironProvider interface.
-func (p EnvironProvider) PrepareConfig(args environs.PrepareConfigParams) (*config.Config, error) {
+func (p EnvironProvider) PrepareConfig(ctx context.Context, args environs.PrepareConfigParams) (*config.Config, error) {
 	if err := validateCloudSpec(args.Cloud); err != nil {
 		return nil, errors.Annotate(err, "validating cloud spec")
 	}

--- a/internal/provider/maas/environprovider_test.go
+++ b/internal/provider/maas/environprovider_test.go
@@ -52,7 +52,7 @@ func (s *EnvironProviderSuite) TestPrepareConfig(c *gc.C) {
 	attrs := testing.FakeConfig().Merge(testing.Attrs{"type": "maas"})
 	config, err := config.New(config.NoDefaults, attrs)
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = providerInstance.PrepareConfig(environs.PrepareConfigParams{
+	_, err = providerInstance.PrepareConfig(context.Background(), environs.PrepareConfigParams{
 		Config: config,
 		Cloud:  s.cloudSpec(),
 	})
@@ -66,7 +66,7 @@ func (s *EnvironProviderSuite) TestPrepareConfigInvalidOAuth(c *gc.C) {
 	spec := s.cloudSpec()
 	cred := oauthCredential("wrongly-formatted-oauth-string")
 	spec.Credential = &cred
-	_, err = providerInstance.PrepareConfig(environs.PrepareConfigParams{
+	_, err = providerInstance.PrepareConfig(context.Background(), environs.PrepareConfigParams{
 		Config: config,
 		Cloud:  spec,
 	})
@@ -79,7 +79,7 @@ func (s *EnvironProviderSuite) TestPrepareConfigInvalidEndpoint(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	spec := s.cloudSpec()
 	spec.Endpoint = "This should have been a URL or host."
-	_, err = providerInstance.PrepareConfig(environs.PrepareConfigParams{
+	_, err = providerInstance.PrepareConfig(context.Background(), environs.PrepareConfigParams{
 		Config: config,
 		Cloud:  spec,
 	})
@@ -92,7 +92,7 @@ func (s *EnvironProviderSuite) TestPrepareConfigSetsDefaults(c *gc.C) {
 	attrs := testing.FakeConfig().Merge(testing.Attrs{"type": "maas"})
 	config, err := config.New(config.NoDefaults, attrs)
 	c.Assert(err, jc.ErrorIsNil)
-	cfg, err := providerInstance.PrepareConfig(environs.PrepareConfigParams{
+	cfg, err := providerInstance.PrepareConfig(context.Background(), environs.PrepareConfigParams{
 		Config: config,
 		Cloud:  s.cloudSpec(),
 	})

--- a/internal/provider/manual/environ.go
+++ b/internal/provider/manual/environ.go
@@ -5,6 +5,7 @@ package manual
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"path"
@@ -186,10 +187,10 @@ func (e *manualEnviron) AdoptResources(ctx envcontext.ProviderCallContext, contr
 	return nil
 }
 
-func (e *manualEnviron) SetConfig(cfg *config.Config) error {
+func (e *manualEnviron) SetConfig(ctx context.Context, cfg *config.Config) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	_, err := ManualProvider{}.validate(cfg, e.cfg.Config)
+	_, err := ManualProvider{}.validate(ctx, cfg, e.cfg.Config)
 	if err != nil {
 		return err
 	}

--- a/internal/provider/manual/provider_test.go
+++ b/internal/provider/manual/provider_test.go
@@ -63,7 +63,7 @@ func (s *providerSuite) testPrepareForBootstrap(c *gc.C, endpoint, region string
 		Endpoint: endpoint,
 		Region:   region,
 	}
-	testConfig, err = manual.ProviderInstance.PrepareConfig(environs.PrepareConfigParams{
+	testConfig, err = manual.ProviderInstance.PrepareConfig(context.Background(), environs.PrepareConfigParams{
 		Config: testConfig,
 		Cloud:  cloudSpec,
 	})
@@ -100,7 +100,7 @@ func (s *providerSuite) TestDisablesUpdatesByDefault(c *gc.C) {
 	c.Check(testConfig.EnableOSRefreshUpdate(), jc.IsTrue)
 	c.Check(testConfig.EnableOSUpgrade(), jc.IsTrue)
 
-	validCfg, err := p.Validate(testConfig, nil)
+	validCfg, err := p.Validate(context.Background(), testConfig, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Unless specified, update should default to true,
@@ -119,7 +119,7 @@ func (s *providerSuite) TestDefaultsCanBeOverriden(c *gc.C) {
 
 	testConfig, err := config.New(config.UseDefaults, attrs)
 	c.Assert(err, jc.ErrorIsNil)
-	validCfg, err := p.Validate(testConfig, nil)
+	validCfg, err := p.Validate(context.Background(), testConfig, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Our preferences should not have been overwritten.

--- a/internal/provider/oci/environ.go
+++ b/internal/provider/oci/environ.go
@@ -339,8 +339,8 @@ func (e *Environ) ConstraintsValidator(ctx envcontext.ProviderCallContext) (cons
 }
 
 // SetConfig implements environs.Environ.
-func (e *Environ) SetConfig(cfg *config.Config) error {
-	ecfg, err := e.p.newConfig(cfg)
+func (e *Environ) SetConfig(ctx context.Context, cfg *config.Config) error {
+	ecfg, err := e.p.newConfig(ctx, cfg)
 	if err != nil {
 		return err
 	}

--- a/internal/provider/openstack/config.go
+++ b/internal/provider/openstack/config.go
@@ -4,6 +4,7 @@
 package openstack
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -114,9 +115,9 @@ func (p EnvironProvider) ConfigDefaults() schema.Defaults {
 	return configDefaults
 }
 
-func (p EnvironProvider) Validate(cfg, old *config.Config) (valid *config.Config, err error) {
+func (p EnvironProvider) Validate(ctx context.Context, cfg, old *config.Config) (valid *config.Config, err error) {
 	// Check for valid changes for the base config values.
-	if err := config.Validate(cfg, old); err != nil {
+	if err := config.Validate(ctx, cfg, old); err != nil {
 		return nil, err
 	}
 

--- a/internal/provider/openstack/config_test.go
+++ b/internal/provider/openstack/config_test.go
@@ -4,6 +4,8 @@
 package openstack
 
 import (
+	"context"
+
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -50,7 +52,7 @@ func (t configTest) check(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	e := &Environ{}
-	err = e.SetConfig(cfg)
+	err = e.SetConfig(context.Background(), cfg)
 
 	if t.change != nil {
 		c.Assert(err, jc.ErrorIsNil)
@@ -63,9 +65,9 @@ func (t configTest) check(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 
 		// Keep err for validation below.
-		valid, err = providerInstance.Validate(changed, old)
+		valid, err = providerInstance.Validate(context.Background(), changed, old)
 		if err == nil {
-			err = osenv.SetConfig(valid)
+			err = osenv.SetConfig(context.Background(), valid)
 		}
 	}
 	if t.err != "" {
@@ -251,7 +253,7 @@ func (s *ConfigSuite) TestDeprecatedAttributesRemoved(c *gc.C) {
 	cfg, err := config.New(config.NoDefaults, attrs)
 	c.Assert(err, jc.ErrorIsNil)
 	// Keep err for validation below.
-	valid, err := providerInstance.Validate(cfg, nil)
+	valid, err := providerInstance.Validate(context.Background(), cfg, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	// Check deprecated attributes removed.
 	allAttrs := valid.AllAttrs()
@@ -270,7 +272,7 @@ func (s *ConfigSuite) TestPrepareConfigSetsDefaultBlockSource(c *gc.C) {
 	_, ok := cfg.StorageDefaultBlockSource()
 	c.Assert(ok, jc.IsFalse)
 
-	cfg, err = providerInstance.PrepareConfig(prepareConfigParams(cfg))
+	cfg, err = providerInstance.PrepareConfig(context.Background(), prepareConfigParams(cfg))
 	c.Assert(err, jc.ErrorIsNil)
 	source, ok := cfg.StorageDefaultBlockSource()
 	c.Assert(ok, jc.IsTrue)

--- a/internal/provider/openstack/local_test.go
+++ b/internal/provider/openstack/local_test.go
@@ -543,7 +543,7 @@ func (s *localServerSuite) TestStartInstanceNetwork(c *gc.C) {
 		"network": "net",
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.env.SetConfig(cfg)
+	err = s.env.SetConfig(context.Background(), cfg)
 	c.Assert(err, jc.ErrorIsNil)
 
 	inst, _ := testing.AssertStartInstance(c, s.env, s.callCtx, s.ControllerUUID, "100")
@@ -557,7 +557,7 @@ func (s *localServerSuite) TestStartInstanceMultiNetworkFound(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = s.env.SetConfig(cfg)
+	err = s.env.SetConfig(context.Background(), cfg)
 	c.Assert(err, jc.ErrorIsNil)
 
 	inst, _, _, err := testing.StartInstance(s.env, s.callCtx, s.ControllerUUID, "100")
@@ -571,7 +571,7 @@ func (s *localServerSuite) TestStartInstanceExternalNetwork(c *gc.C) {
 		"external-network": "ext-net",
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.env.SetConfig(cfg)
+	err = s.env.SetConfig(context.Background(), cfg)
 	c.Assert(err, jc.ErrorIsNil)
 
 	cons := constraints.MustParse("allocate-public-ip=true")
@@ -586,7 +586,7 @@ func (s *localServerSuite) TestStartInstanceNetworkUnknownLabel(c *gc.C) {
 		"network": "no-network-with-this-label",
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.env.SetConfig(cfg)
+	err = s.env.SetConfig(context.Background(), cfg)
 	c.Assert(err, jc.ErrorIsNil)
 
 	inst, _, _, err := testing.StartInstance(s.env, s.callCtx, s.ControllerUUID, "100")
@@ -600,7 +600,7 @@ func (s *localServerSuite) TestStartInstanceExternalNetworkUnknownLabel(c *gc.C)
 		"external-network": "no-network-with-this-label",
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.env.SetConfig(cfg)
+	err = s.env.SetConfig(context.Background(), cfg)
 	c.Assert(err, jc.ErrorIsNil)
 
 	cons := constraints.MustParse("allocate-public-ip=true")
@@ -616,7 +616,7 @@ func (s *localServerSuite) TestStartInstanceNetworkUnknownID(c *gc.C) {
 		"network": "f81d4fae-7dec-11d0-a765-00a0c91e6bf6",
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.env.SetConfig(cfg)
+	err = s.env.SetConfig(context.Background(), cfg)
 	c.Assert(err, jc.ErrorIsNil)
 
 	inst, _, _, err := testing.StartInstance(s.env, s.callCtx, s.ControllerUUID, "100")
@@ -639,7 +639,7 @@ func (s *localServerSuite) TestStartInstanceNoNetworksNetworkNotSetNoError(c *gc
 		"network": "",
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.env.SetConfig(cfg)
+	err = s.env.SetConfig(context.Background(), cfg)
 	c.Assert(err, jc.ErrorIsNil)
 
 	inst, _, _, err := testing.StartInstance(s.env, s.callCtx, s.ControllerUUID, "100")
@@ -669,7 +669,7 @@ func (s *localServerSuite) TestStartInstanceOneNetworkNetworkNotSetNoError(c *gc
 		"network": "",
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.env.SetConfig(cfg)
+	err = s.env.SetConfig(context.Background(), cfg)
 	c.Assert(err, jc.ErrorIsNil)
 
 	inst, _, _, err := testing.StartInstance(s.env, s.callCtx, s.ControllerUUID, "100")
@@ -686,7 +686,7 @@ func (s *localServerSuite) TestStartInstanceNetworksDifferentAZ(c *gc.C) {
 		"external-network": "ext-net", // az = test-available
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.env.SetConfig(cfg)
+	err = s.env.SetConfig(context.Background(), cfg)
 	c.Assert(err, jc.ErrorIsNil)
 
 	cons := constraints.MustParse("allocate-public-ip=true")
@@ -729,7 +729,7 @@ func (s *localServerSuite) TestStartInstanceNetworksEmptyAZ(c *gc.C) {
 		"network": "no-az-net", // az = nova
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.env.SetConfig(cfg)
+	err = s.env.SetConfig(context.Background(), cfg)
 	c.Assert(err, jc.ErrorIsNil)
 
 	cons := constraints.MustParse("allocate-public-ip=true")
@@ -744,7 +744,7 @@ func (s *localServerSuite) TestStartInstanceNetworkNoExternalNetInAZ(c *gc.C) {
 		"network": "net", // az = nova
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.env.SetConfig(cfg)
+	err = s.env.SetConfig(context.Background(), cfg)
 	c.Assert(err, jc.ErrorIsNil)
 
 	cons := constraints.MustParse("allocate-public-ip=true")
@@ -757,7 +757,7 @@ func (s *localServerSuite) TestStartInstancePortSecurityEnabled(c *gc.C) {
 		"network": "net",
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.env.SetConfig(cfg)
+	err = s.env.SetConfig(context.Background(), cfg)
 	c.Assert(err, jc.ErrorIsNil)
 
 	inst, _, _, err := testing.StartInstance(s.env, s.callCtx, s.ControllerUUID, "100")
@@ -773,7 +773,7 @@ func (s *localServerSuite) TestStartInstancePortSecurityDisabled(c *gc.C) {
 		"network": "net-disabled",
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.env.SetConfig(cfg)
+	err = s.env.SetConfig(context.Background(), cfg)
 	c.Assert(err, jc.ErrorIsNil)
 
 	inst, _, _, err := testing.StartInstance(s.env, s.callCtx, s.ControllerUUID, "100")
@@ -2207,7 +2207,7 @@ func (s *localServerSuite) TestGlobalPorts(c *gc.C) {
 	// Change configuration.
 	oldConfig := s.env.Config()
 	defer func() {
-		err := s.env.SetConfig(oldConfig)
+		err := s.env.SetConfig(context.Background(), oldConfig)
 		c.Assert(err, jc.ErrorIsNil)
 	}()
 
@@ -2215,7 +2215,7 @@ func (s *localServerSuite) TestGlobalPorts(c *gc.C) {
 	attrs["firewall-mode"] = config.FwGlobal
 	newConfig, err := s.env.Config().Apply(attrs)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.env.SetConfig(newConfig)
+	err = s.env.SetConfig(context.Background(), newConfig)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Create instances and check open ports on both instances.
@@ -2710,7 +2710,7 @@ func (s *localHTTPSServerSuite) TestFetchFromImageMetadataSources(c *gc.C) {
 		map[string]interface{}{"image-metadata-url": customURL},
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.env.SetConfig(envConfig)
+	err = s.env.SetConfig(context.Background(), envConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	sources, err := environs.ImageMetadataSources(s.env, ss)
 	c.Assert(err, jc.ErrorIsNil)
@@ -2770,7 +2770,7 @@ func (s *localHTTPSServerSuite) TestFetchFromImageMetadataSourcesWithCertificate
 		map[string]interface{}{"image-metadata-url": customURL},
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	err = env.SetConfig(envConfig)
+	err = env.SetConfig(context.Background(), envConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	sources, err := environs.ImageMetadataSources(env, ss)
 	c.Assert(err, jc.ErrorIsNil)
@@ -2820,7 +2820,7 @@ func (s *localHTTPSServerSuite) TestFetchFromToolsMetadataSources(c *gc.C) {
 		map[string]interface{}{"agent-metadata-url": customURL},
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.env.SetConfig(envConfig)
+	err = s.env.SetConfig(context.Background(), envConfig)
 	c.Assert(err, jc.ErrorIsNil)
 	sources, err := tools.GetMetadataSources(s.env, ss)
 	c.Assert(err, jc.ErrorIsNil)
@@ -3873,7 +3873,7 @@ func (s *noSwiftSuite) TestBootstrap(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = s.env.SetConfig(cfg)
+	err = s.env.SetConfig(context.Background(), cfg)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(bootstrapEnv(c, s.env), jc.ErrorIsNil)

--- a/internal/provider/openstack/provider.go
+++ b/internal/provider/openstack/provider.go
@@ -6,6 +6,7 @@
 package openstack
 
 import (
+	"context"
 	stdcontext "context"
 	"crypto/tls"
 	"crypto/x509"
@@ -177,7 +178,7 @@ func (p EnvironProvider) Open(ctx stdcontext.Context, args environs.OpenParams) 
 		flavorFilter: p.FlavorFilter,
 	}
 
-	if err := e.SetConfig(args.Config); err != nil {
+	if err := e.SetConfig(ctx, args.Config); err != nil {
 		return nil, errors.Trace(err)
 	}
 	if err := e.SetCloudSpec(ctx, args.Cloud); err != nil {
@@ -260,7 +261,7 @@ func newGooseClient(endpoint string) client.AuthenticatingClient {
 }
 
 // PrepareConfig is specified in the EnvironProvider interface.
-func (p EnvironProvider) PrepareConfig(args environs.PrepareConfigParams) (*config.Config, error) {
+func (p EnvironProvider) PrepareConfig(ctx context.Context, args environs.PrepareConfigParams) (*config.Config, error) {
 	if err := validateCloudSpec(args.Cloud); err != nil {
 		return nil, errors.Annotate(err, "validating cloud spec")
 	}
@@ -299,8 +300,8 @@ func (p EnvironProvider) metadataLookupParams(region string) (*simplestreams.Met
 	}, nil
 }
 
-func (p EnvironProvider) newConfig(cfg *config.Config) (*environConfig, error) {
-	valid, err := p.Validate(cfg, nil)
+func (p EnvironProvider) newConfig(ctx context.Context, cfg *config.Config) (*environConfig, error) {
+	valid, err := p.Validate(ctx, cfg, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -889,8 +890,8 @@ var authenticateClient = func(auth authenticator) error {
 	return nil
 }
 
-func (e *Environ) SetConfig(cfg *config.Config) error {
-	ecfg, err := providerInstance.newConfig(cfg)
+func (e *Environ) SetConfig(ctx context.Context, cfg *config.Config) error {
+	ecfg, err := providerInstance.newConfig(ctx, cfg)
 	if err != nil {
 		return err
 	}

--- a/internal/provider/vsphere/config.go
+++ b/internal/provider/vsphere/config.go
@@ -4,6 +4,8 @@
 package vsphere
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/schema"
 	"gopkg.in/juju/environschema.v1"
@@ -88,9 +90,9 @@ var configFields = func() schema.Fields {
 
 // newValidConfig builds a new environConfig from the provided Config
 // and returns it. The resulting config values are validated.
-func newValidConfig(cfg *config.Config) (*environConfig, error) {
+func newValidConfig(ctx context.Context, cfg *config.Config) (*environConfig, error) {
 	// Ensure that the provided config is valid.
-	if err := config.Validate(cfg, nil); err != nil {
+	if err := config.Validate(ctx, cfg, nil); err != nil {
 		return nil, errors.Trace(err)
 	}
 
@@ -221,14 +223,14 @@ func (c environConfig) validate() error {
 
 // update applies changes from the provided config to the env config.
 // Changes to any immutable attributes result in an error.
-func (c *environConfig) update(cfg *config.Config) error {
+func (c *environConfig) update(ctx context.Context, cfg *config.Config) error {
 	// Validate the updates. newValidConfig does not modify the "known"
 	// config attributes so it is safe to call Validate here first.
-	if err := config.Validate(cfg, c.Config); err != nil {
+	if err := config.Validate(ctx, cfg, c.Config); err != nil {
 		return errors.Trace(err)
 	}
 
-	updates, err := newValidConfig(cfg)
+	updates, err := newValidConfig(ctx, cfg)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/internal/provider/vsphere/config_test.go
+++ b/internal/provider/vsphere/config_test.go
@@ -4,6 +4,7 @@
 package vsphere_test
 
 import (
+	"context"
 	stdcontext "context"
 
 	jc "github.com/juju/testing/checkers"
@@ -166,7 +167,7 @@ func (s *ConfigSuite) TestValidateNewConfig(c *gc.C) {
 		c.Logf("test %d: %s", i, test.info)
 
 		fakeConfig := test.newConfig(c)
-		validatedConfig, err := s.provider.Validate(fakeConfig, nil)
+		validatedConfig, err := s.provider.Validate(context.Background(), fakeConfig, nil)
 
 		// Check the result
 		if test.err != "" {
@@ -188,7 +189,7 @@ func (s *ConfigSuite) TestValidateOldConfig(c *gc.C) {
 
 		// Validate the new config (relative to the old one) using the
 		// provider.
-		validatedConfig, err := s.provider.Validate(newcfg, oldcfg)
+		validatedConfig, err := s.provider.Validate(context.Background(), newcfg, oldcfg)
 
 		// Check the result.
 		if test.err != "" {
@@ -223,7 +224,7 @@ func (s *ConfigSuite) TestValidateChange(c *gc.C) {
 		c.Logf("test %d: %s", i, test.info)
 
 		fakeConfig := test.newConfig(c)
-		validatedConfig, err := s.provider.Validate(fakeConfig, s.config)
+		validatedConfig, err := s.provider.Validate(context.Background(), fakeConfig, s.config)
 
 		// Check the result.
 		if test.err != "" {
@@ -245,7 +246,7 @@ func (s *ConfigSuite) TestSetConfig(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 
 		fakeConfig := test.newConfig(c)
-		err = environ.SetConfig(fakeConfig)
+		err = environ.SetConfig(context.Background(), fakeConfig)
 
 		// Check the result.
 		if test.err != "" {

--- a/internal/provider/vsphere/environ.go
+++ b/internal/provider/vsphere/environ.go
@@ -35,11 +35,12 @@ type environ struct {
 }
 
 func newEnviron(
+	ctx context.Context,
 	provider *environProvider,
 	cloud environscloudspec.CloudSpec,
 	cfg *config.Config,
 ) (*environ, error) {
-	ecfg, err := newValidConfig(cfg)
+	ecfg, err := newValidConfig(ctx, cfg)
 	if err != nil {
 		return nil, errors.Annotate(err, "invalid config")
 	}
@@ -87,7 +88,7 @@ func (env *environ) Provider() environs.EnvironProvider {
 }
 
 // SetConfig is part of the environs.Environ interface.
-func (env *environ) SetConfig(cfg *config.Config) error {
+func (env *environ) SetConfig(ctx context.Context, cfg *config.Config) error {
 	env.lock.Lock()
 	defer env.lock.Unlock()
 
@@ -95,7 +96,7 @@ func (env *environ) SetConfig(cfg *config.Config) error {
 		return errors.New("cannot set config on uninitialized env")
 	}
 
-	if err := env.ecfg.update(cfg); err != nil {
+	if err := env.ecfg.update(ctx, cfg); err != nil {
 		return errors.Annotate(err, "invalid config change")
 	}
 	return nil

--- a/internal/provider/vsphere/environ_broker_test.go
+++ b/internal/provider/vsphere/environ_broker_test.go
@@ -347,7 +347,7 @@ func (s *legacyEnvironBrokerSuite) TestStartInstanceDefaultConstraintsApplied(c 
 		"datastore": "datastore0",
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.env.SetConfig(cfg)
+	err = s.env.SetConfig(context.Background(), cfg)
 	c.Assert(err, jc.ErrorIsNil)
 
 	startInstArgs := s.createStartInstanceArgs(c)
@@ -447,7 +447,7 @@ func (s *legacyEnvironBrokerSuite) TestStartInstanceDatastoreDefault(c *gc.C) {
 		"datastore": "datastore0",
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.env.SetConfig(cfg)
+	err = s.env.SetConfig(context.Background(), cfg)
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, err = s.env.StartInstance(s.callCtx, s.createStartInstanceArgs(c))
@@ -464,7 +464,7 @@ func (s *legacyEnvironBrokerSuite) TestStartInstanceRootDiskSource(c *gc.C) {
 		"datastore": "datastore0",
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.env.SetConfig(cfg)
+	err = s.env.SetConfig(context.Background(), cfg)
 	c.Assert(err, jc.ErrorIsNil)
 
 	args := s.createStartInstanceArgs(c)

--- a/internal/provider/vsphere/provider.go
+++ b/internal/provider/vsphere/provider.go
@@ -55,11 +55,11 @@ func (p *environProvider) Version() int {
 }
 
 // Open implements environs.EnvironProvider.
-func (p *environProvider) Open(_ stdcontext.Context, args environs.OpenParams) (environs.Environ, error) {
+func (p *environProvider) Open(ctx stdcontext.Context, args environs.OpenParams) (environs.Environ, error) {
 	if err := validateCloudSpec(args.Cloud); err != nil {
 		return nil, errors.Annotate(err, "validating cloud spec")
 	}
-	env, err := newEnviron(p, args.Cloud, args.Config)
+	env, err := newEnviron(ctx, p, args.Cloud, args.Config)
 	return env, errors.Trace(err)
 }
 
@@ -139,7 +139,7 @@ func (p *environProvider) Ping(callCtx callcontext.ProviderCallContext, endpoint
 }
 
 // PrepareConfig implements environs.EnvironProvider.
-func (p *environProvider) PrepareConfig(args environs.PrepareConfigParams) (*config.Config, error) {
+func (p *environProvider) PrepareConfig(ctx context.Context, args environs.PrepareConfigParams) (*config.Config, error) {
 	if err := validateCloudSpec(args.Cloud); err != nil {
 		return nil, errors.Annotate(err, "validating cloud spec")
 	}
@@ -147,21 +147,21 @@ func (p *environProvider) PrepareConfig(args environs.PrepareConfigParams) (*con
 }
 
 // Validate implements environs.EnvironProvider.
-func (*environProvider) Validate(cfg, old *config.Config) (valid *config.Config, err error) {
+func (*environProvider) Validate(ctx context.Context, cfg, old *config.Config) (valid *config.Config, err error) {
 	if old == nil {
-		ecfg, err := newValidConfig(cfg)
+		ecfg, err := newValidConfig(ctx, cfg)
 		if err != nil {
 			return nil, errors.Annotate(err, "invalid config")
 		}
 		return ecfg.Config, nil
 	}
 
-	ecfg, err := newValidConfig(old)
+	ecfg, err := newValidConfig(ctx, old)
 	if err != nil {
 		return nil, errors.Annotate(err, "invalid base config")
 	}
 
-	if err := ecfg.update(cfg); err != nil {
+	if err := ecfg.update(ctx, cfg); err != nil {
 		return nil, errors.Annotate(err, "invalid config change")
 	}
 

--- a/internal/provider/vsphere/provider_test.go
+++ b/internal/provider/vsphere/provider_test.go
@@ -71,7 +71,7 @@ func (s *providerSuite) testOpenError(c *gc.C, spec environscloudspec.CloudSpec,
 }
 
 func (s *providerSuite) TestPrepareConfig(c *gc.C) {
-	cfg, err := s.provider.PrepareConfig(environs.PrepareConfigParams{
+	cfg, err := s.provider.PrepareConfig(context.Background(), environs.PrepareConfigParams{
 		Config: fakeConfig(c),
 		Cloud:  fakeCloudSpec(),
 	})
@@ -81,7 +81,7 @@ func (s *providerSuite) TestPrepareConfig(c *gc.C) {
 
 func (s *providerSuite) TestValidate(c *gc.C) {
 	config := fakeConfig(c)
-	validCfg, err := s.provider.Validate(config, nil)
+	validCfg, err := s.provider.Validate(context.Background(), config, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	validAttrs := validCfg.AllAttrs()

--- a/internal/worker/caasbroker/broker.go
+++ b/internal/worker/caasbroker/broker.go
@@ -162,7 +162,7 @@ func (t *Tracker) loop() error {
 			if err != nil {
 				return errors.Annotate(err, "cannot read model config")
 			}
-			if err = t.broker.SetConfig(modelConfig); err != nil {
+			if err = t.broker.SetConfig(context.TODO(), modelConfig); err != nil {
 				return errors.Annotate(err, "cannot update model config")
 			}
 		case _, ok := <-cloudWatcherChanges:

--- a/internal/worker/caasbroker/fixture_test.go
+++ b/internal/worker/caasbroker/fixture_test.go
@@ -252,7 +252,7 @@ func (e *mockBroker) Config() *config.Config {
 	return e.cfg
 }
 
-func (e *mockBroker) SetConfig(cfg *config.Config) error {
+func (e *mockBroker) SetConfig(_ context.Context, cfg *config.Config) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	e.MethodCall(e, "SetConfig", cfg)

--- a/internal/worker/instancemutater/mocks/environs_mock.go
+++ b/internal/worker/instancemutater/mocks/environs_mock.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	constraints "github.com/juju/juju/core/constraints"
@@ -265,17 +266,17 @@ func (mr *MockEnvironMockRecorder) Provider() *gomock.Call {
 }
 
 // SetConfig mocks base method.
-func (m *MockEnviron) SetConfig(arg0 *config.Config) error {
+func (m *MockEnviron) SetConfig(arg0 context.Context, arg1 *config.Config) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetConfig", arg0)
+	ret := m.ctrl.Call(m, "SetConfig", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetConfig indicates an expected call of SetConfig.
-func (mr *MockEnvironMockRecorder) SetConfig(arg0 any) *gomock.Call {
+func (mr *MockEnvironMockRecorder) SetConfig(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetConfig", reflect.TypeOf((*MockEnviron)(nil).SetConfig), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetConfig", reflect.TypeOf((*MockEnviron)(nil).SetConfig), arg0, arg1)
 }
 
 // StartInstance mocks base method.

--- a/internal/worker/providertracker/caas_mock_test.go
+++ b/internal/worker/providertracker/caas_mock_test.go
@@ -412,17 +412,17 @@ func (mr *MockBrokerMockRecorder) SaveJujuSecret(arg0, arg1, arg2 any) *gomock.C
 }
 
 // SetConfig mocks base method.
-func (m *MockBroker) SetConfig(arg0 *config.Config) error {
+func (m *MockBroker) SetConfig(arg0 context.Context, arg1 *config.Config) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetConfig", arg0)
+	ret := m.ctrl.Call(m, "SetConfig", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetConfig indicates an expected call of SetConfig.
-func (mr *MockBrokerMockRecorder) SetConfig(arg0 any) *gomock.Call {
+func (mr *MockBrokerMockRecorder) SetConfig(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetConfig", reflect.TypeOf((*MockBroker)(nil).SetConfig), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetConfig", reflect.TypeOf((*MockBroker)(nil).SetConfig), arg0, arg1)
 }
 
 // StorageProvider mocks base method.

--- a/internal/worker/providertracker/environs_mock_test.go
+++ b/internal/worker/providertracker/environs_mock_test.go
@@ -266,17 +266,17 @@ func (mr *MockEnvironMockRecorder) Provider() *gomock.Call {
 }
 
 // SetConfig mocks base method.
-func (m *MockEnviron) SetConfig(arg0 *config.Config) error {
+func (m *MockEnviron) SetConfig(arg0 context.Context, arg1 *config.Config) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetConfig", arg0)
+	ret := m.ctrl.Call(m, "SetConfig", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetConfig indicates an expected call of SetConfig.
-func (mr *MockEnvironMockRecorder) SetConfig(arg0 any) *gomock.Call {
+func (mr *MockEnvironMockRecorder) SetConfig(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetConfig", reflect.TypeOf((*MockEnviron)(nil).SetConfig), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetConfig", reflect.TypeOf((*MockEnviron)(nil).SetConfig), arg0, arg1)
 }
 
 // StartInstance mocks base method.

--- a/internal/worker/providertracker/trackerworker.go
+++ b/internal/worker/providertracker/trackerworker.go
@@ -200,7 +200,7 @@ func (t *trackerWorker) loop() (err error) {
 			if err != nil {
 				return errors.Annotate(err, "reading model config")
 			}
-			if err = t.provider.SetConfig(modelConfig); err != nil {
+			if err = t.provider.SetConfig(ctx, modelConfig); err != nil {
 				return errors.Annotate(err, "updating provider config")
 			}
 

--- a/internal/worker/providertracker/trackerworker_test.go
+++ b/internal/worker/providertracker/trackerworker_test.go
@@ -233,7 +233,7 @@ func (s *trackerWorkerSuite) expectCloudSpec(c *gc.C, cfg *config.Config) {
 
 func (s *trackerWorkerSuite) expectEnvironSetConfig(c *gc.C, cfg *config.Config) {
 	s.configService.EXPECT().ModelConfig(gomock.Any()).Return(cfg, nil)
-	s.environ.EXPECT().SetConfig(cfg)
+	s.environ.EXPECT().SetConfig(gomock.Any(), cfg)
 }
 
 func (s *trackerWorkerSuite) expectEnvironSetSpecUpdate(c *gc.C) {

--- a/internal/worker/provisioner/provisioner.go
+++ b/internal/worker/provisioner/provisioner.go
@@ -254,7 +254,8 @@ func (p *environProvisioner) loop() error {
 			if err != nil {
 				return errors.Annotate(err, "cannot load model configuration")
 			}
-			if err := p.setConfig(modelConfig); err != nil {
+
+			if err := p.setConfig(context.TODO(), modelConfig); err != nil {
 				return errors.Annotate(err, "loaded invalid model configuration")
 			}
 			task.SetHarvestMode(modelConfig.ProvisionerHarvestMode())
@@ -273,8 +274,8 @@ func (p *environProvisioner) getRetryWatcher() (watcher.NotifyWatcher, error) {
 
 // setConfig updates the environment configuration and notifies
 // the config observer.
-func (p *environProvisioner) setConfig(modelConfig *config.Config) error {
-	if err := p.environ.SetConfig(modelConfig); err != nil {
+func (p *environProvisioner) setConfig(ctx context.Context, modelConfig *config.Config) error {
+	if err := p.environ.SetConfig(ctx, modelConfig); err != nil {
 		return errors.Trace(err)
 	}
 	p.configObserver.notify(modelConfig)

--- a/internal/worker/provisioner/provisioner_test.go
+++ b/internal/worker/provisioner/provisioner_test.go
@@ -121,7 +121,7 @@ func (s *CommonProvisionerSuite) assertProvisionerObservesConfigChanges(c *gc.C,
 	s.controllerAPI.EXPECT().ModelConfig(gomock.Any()).Return(modelCfg, nil)
 
 	if !container {
-		s.broker.EXPECT().SetConfig(modelCfg).Return(nil)
+		s.broker.EXPECT().SetConfig(gomock.Any(), modelCfg).Return(nil)
 	}
 
 	s.sendModelConfigChange(c)
@@ -167,7 +167,7 @@ func (s *CommonProvisionerSuite) assertProvisionerObservesConfigChangesWorkerCou
 	s.controllerAPI.EXPECT().ModelConfig(gomock.Any()).Return(modelCfg, nil)
 
 	if !container {
-		s.broker.EXPECT().SetConfig(modelCfg).Return(nil)
+		s.broker.EXPECT().SetConfig(gomock.Any(), modelCfg).Return(nil)
 	}
 
 	s.sendModelConfigChange(c)

--- a/internal/worker/servicefactory/providertracker_mock_test.go
+++ b/internal/worker/servicefactory/providertracker_mock_test.go
@@ -175,17 +175,17 @@ func (mr *MockProviderMockRecorder) PrepareForBootstrap(arg0, arg1 any) *gomock.
 }
 
 // SetConfig mocks base method.
-func (m *MockProvider) SetConfig(arg0 *config.Config) error {
+func (m *MockProvider) SetConfig(arg0 context.Context, arg1 *config.Config) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetConfig", arg0)
+	ret := m.ctrl.Call(m, "SetConfig", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetConfig indicates an expected call of SetConfig.
-func (mr *MockProviderMockRecorder) SetConfig(arg0 any) *gomock.Call {
+func (mr *MockProviderMockRecorder) SetConfig(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetConfig", reflect.TypeOf((*MockProvider)(nil).SetConfig), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetConfig", reflect.TypeOf((*MockProvider)(nil).SetConfig), arg0, arg1)
 }
 
 // StorageProvider mocks base method.

--- a/state/configvalidator_test.go
+++ b/state/configvalidator_test.go
@@ -45,7 +45,7 @@ func mockValidCfg() (valid *config.Config, err error) {
 	return valid, nil
 }
 
-func (p *mockConfigValidator) Validate(cfg, old *config.Config) (valid *config.Config, err error) {
+func (p *mockConfigValidator) Validate(ctx context.Context, cfg, old *config.Config) (valid *config.Config, err error) {
 	p.validateCfg = cfg
 	p.validateOld = old
 	p.validateValid, p.validateError = mockValidCfg()

--- a/state/policy.go
+++ b/state/policy.go
@@ -4,6 +4,7 @@
 package state
 
 import (
+	"context"
 	stdcontext "context"
 	"fmt"
 
@@ -136,7 +137,9 @@ func (st *State) validate(cfg, old *config.Config) (valid *config.Config, err er
 	if configValidator == nil {
 		return nil, errors.New("policy returned nil configValidator without an error")
 	}
-	return configValidator.Validate(cfg, old)
+	// NOTE(nvinuesa): This context.TODO is scaffolding until we finish
+	// removing the migrated model-config from the legacy state.
+	return configValidator.Validate(context.TODO(), cfg, old)
 }
 
 // Used for tests.


### PR DESCRIPTION
This patch adds context on environs config (Validate(), PrepareConfig() and SetConfig() methods).

This was identified when modifying the validators during the migration of model-config to dqlite, where we need to be able to cancel queries to the db.


## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Juju bootstrap, retrieve model-config and update it:

```
juju bootstrap localhost c
juju add-model m --config default-space=bar       
juju model-config default-space=foo
```

## Links

**Jira card:** JUJU-5980

