### PR TITLE
Replace BootstrapSeries with BootstrapBase

### DIFF
--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -461,8 +461,8 @@ func (k *kubernetesClient) Bootstrap(
 	args environs.BootstrapParams,
 ) (*environs.BootstrapResult, error) {
 
-	if args.BootstrapSeries != "" {
-		return nil, errors.NotSupportedf("set series for bootstrapping to kubernetes")
+	if !args.BootstrapBase.Empty() {
+		return nil, errors.NotSupportedf("set base for bootstrapping to kubernetes")
 	}
 
 	storageClass, err := k.validateOperatorStorage()

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -53,6 +53,7 @@ import (
 	"github.com/juju/juju/caas/specs"
 	"github.com/juju/juju/core/annotations"
 	"github.com/juju/juju/core/assumes"
+	"github.com/juju/juju/core/base"
 	"github.com/juju/juju/core/config"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/devices"
@@ -1477,9 +1478,9 @@ func (s *K8sBrokerSuite) TestBootstrapNoOperatorStorage(c *gc.C) {
 	ctx := envtesting.BootstrapContext(stdcontext.TODO(), c)
 	callCtx := &context.CloudCallContext{}
 	bootstrapParams := environs.BootstrapParams{
-		ControllerConfig:         testing.FakeControllerConfig(),
-		BootstrapConstraints:     constraints.MustParse("mem=3.5G"),
-		SupportedBootstrapSeries: testing.FakeSupportedJujuSeries,
+		ControllerConfig:        testing.FakeControllerConfig(),
+		BootstrapConstraints:    constraints.MustParse("mem=3.5G"),
+		SupportedBootstrapBases: testing.FakeSupportedJujuBases,
 	}
 
 	_, err := s.broker.Bootstrap(ctx, callCtx, bootstrapParams)
@@ -1498,9 +1499,9 @@ func (s *K8sBrokerSuite) TestBootstrap(c *gc.C) {
 	ctx := envtesting.BootstrapContext(stdcontext.TODO(), c)
 	callCtx := &context.CloudCallContext{}
 	bootstrapParams := environs.BootstrapParams{
-		ControllerConfig:         testing.FakeControllerConfig(),
-		BootstrapConstraints:     constraints.MustParse("mem=3.5G"),
-		SupportedBootstrapSeries: testing.FakeSupportedJujuSeries,
+		ControllerConfig:        testing.FakeControllerConfig(),
+		BootstrapConstraints:    constraints.MustParse("mem=3.5G"),
+		SupportedBootstrapBases: testing.FakeSupportedJujuBases,
 	}
 
 	sc := &storagev1.StorageClass{
@@ -1520,7 +1521,7 @@ func (s *K8sBrokerSuite) TestBootstrap(c *gc.C) {
 	c.Assert(result.Arch, gc.Equals, "amd64")
 	c.Assert(result.CaasBootstrapFinalizer, gc.NotNil)
 
-	bootstrapParams.BootstrapSeries = "bionic"
+	bootstrapParams.BootstrapBase = base.MustParseBaseFromString("ubuntu@18.04")
 	_, err = s.broker.Bootstrap(ctx, callCtx, bootstrapParams)
 	c.Assert(err, jc.Satisfies, errors.IsNotSupported)
 }

--- a/environs/bootstrap.go
+++ b/environs/bootstrap.go
@@ -9,8 +9,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/juju/collections/set"
-
 	"github.com/juju/juju/cloudconfig/instancecfg"
 	"github.com/juju/juju/cloudconfig/podcfg"
 	"github.com/juju/juju/controller"
@@ -49,20 +47,20 @@ type BootstrapParams struct {
 	// in the controller model.
 	StoragePools map[string]storage.Attrs
 
-	// BootstrapSeries, if specified, is the series to use for the
+	// BootstrapBase, if specified, is the base to use for the
 	// initial bootstrap machine.
-	BootstrapSeries string
+	BootstrapBase corebase.Base
 
-	// SupportedBootstrapSeries is a supported set of series to use for
-	// validating against the bootstrap series.
-	SupportedBootstrapSeries set.Strings
+	// SupportedBootstrapBases is a supported set of bases to use for
+	// validating against the bootstrap base.
+	SupportedBootstrapBases []corebase.Base
 
 	// Placement, if non-empty, holds an environment-specific placement
 	// directive used to choose the initial instance.
 	Placement string
 
 	// AvailableTools is a collection of tools which the Bootstrap method
-	// may use to decide which architecture/series to instantiate.
+	// may use to decide which architecture/base to instantiate.
 	AvailableTools tools.List
 
 	// ImageMetadata contains simplestreams image metadata for providers
@@ -73,7 +71,7 @@ type BootstrapParams struct {
 	// ExtraAgentValuesForTesting are testing only values written to the agent config file.
 	ExtraAgentValuesForTesting map[string]string
 
-	// Force is used to allow a bootstrap to be run on unsupported series.
+	// Force is used to allow a bootstrap to be run on unsupported base.
 	Force bool
 }
 

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -694,33 +694,14 @@ func Bootstrap(
 		return errors.Annotate(err, "validating bootstrap parameters")
 	}
 
-	// TODO(stickupkid): Once environs doesn't have a dependency on series, we
-	// can remove this conversion.
-	var bootstrapSeries string
-	if !args.BootstrapBase.Empty() {
-		var err error
-		bootstrapSeries, err = corebase.GetSeriesFromBase(args.BootstrapBase)
-		if err != nil {
-			return errors.NotValidf("base %q", args.BootstrapBase)
-		}
-	}
-	supportedBootstrapSeries := set.NewStrings()
-	for _, base := range args.SupportedBootstrapBases {
-		s, err := corebase.GetSeriesFromBase(base)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		supportedBootstrapSeries.Add(s)
-	}
-
 	bootstrapParams := environs.BootstrapParams{
 		CloudName:                  args.Cloud.Name,
 		CloudRegion:                args.CloudRegion,
 		ControllerConfig:           args.ControllerConfig,
 		ModelConstraints:           args.ModelConstraints,
 		StoragePools:               args.StoragePools,
-		BootstrapSeries:            bootstrapSeries,
-		SupportedBootstrapSeries:   supportedBootstrapSeries,
+		BootstrapBase:              args.BootstrapBase,
+		SupportedBootstrapBases:    args.SupportedBootstrapBases,
 		Placement:                  args.Placement,
 		Force:                      args.Force,
 		ExtraAgentValuesForTesting: args.ExtraAgentValuesForTesting,

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -1448,11 +1448,11 @@ func (s *environSuite) TestBootstrap(c *gc.C) {
 	s.requests = nil
 	result, err := env.Bootstrap(
 		ctx, s.callCtx, environs.BootstrapParams{
-			ControllerConfig:         testing.FakeControllerConfig(),
-			AvailableTools:           makeToolsList("ubuntu"),
-			BootstrapSeries:          "jammy",
-			BootstrapConstraints:     constraints.MustParse("mem=3.5G"),
-			SupportedBootstrapSeries: testing.FakeSupportedJujuSeries,
+			ControllerConfig:        testing.FakeControllerConfig(),
+			AvailableTools:          makeToolsList("ubuntu"),
+			BootstrapBase:           corebase.MustParseBaseFromString("ubuntu@22.04"),
+			BootstrapConstraints:    constraints.MustParse("mem=3.5G"),
+			SupportedBootstrapBases: testing.FakeSupportedJujuBases,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1482,11 +1482,11 @@ func (s *environSuite) TestBootstrapPrivateIP(c *gc.C) {
 	s.requests = nil
 	result, err := env.Bootstrap(
 		ctx, s.callCtx, environs.BootstrapParams{
-			ControllerConfig:         testing.FakeControllerConfig(),
-			AvailableTools:           makeToolsList("ubuntu"),
-			BootstrapSeries:          "jammy",
-			BootstrapConstraints:     constraints.MustParse("mem=3.5G allocate-public-ip=false"),
-			SupportedBootstrapSeries: testing.FakeSupportedJujuSeries,
+			ControllerConfig:        testing.FakeControllerConfig(),
+			AvailableTools:          makeToolsList("ubuntu"),
+			BootstrapBase:           corebase.MustParseBaseFromString("ubuntu@22.04"),
+			BootstrapConstraints:    constraints.MustParse("mem=3.5G allocate-public-ip=false"),
+			SupportedBootstrapBases: testing.FakeSupportedJujuBases,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1516,11 +1516,11 @@ func (s *environSuite) TestBootstrapCustomNetwork(c *gc.C) {
 	s.requests = nil
 	result, err := env.Bootstrap(
 		ctx, s.callCtx, environs.BootstrapParams{
-			ControllerConfig:         testing.FakeControllerConfig(),
-			AvailableTools:           makeToolsList("ubuntu"),
-			BootstrapSeries:          "jammy",
-			BootstrapConstraints:     constraints.MustParse("mem=3.5G"),
-			SupportedBootstrapSeries: testing.FakeSupportedJujuSeries,
+			ControllerConfig:        testing.FakeControllerConfig(),
+			AvailableTools:          makeToolsList("ubuntu"),
+			BootstrapBase:           corebase.MustParseBaseFromString("ubuntu@22.04"),
+			BootstrapConstraints:    constraints.MustParse("mem=3.5G"),
+			SupportedBootstrapBases: testing.FakeSupportedJujuBases,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1554,11 +1554,11 @@ func (s *environSuite) TestBootstrapWithInvalidCredential(c *gc.C) {
 	c.Assert(s.invalidatedCredential, jc.IsFalse)
 	_, err := env.Bootstrap(
 		ctx, s.callCtx, environs.BootstrapParams{
-			ControllerConfig:         testing.FakeControllerConfig(),
-			AvailableTools:           makeToolsList("ubuntu"),
-			BootstrapSeries:          "jammy",
-			BootstrapConstraints:     constraints.MustParse("mem=3.5G"),
-			SupportedBootstrapSeries: testing.FakeSupportedJujuSeries,
+			ControllerConfig:        testing.FakeControllerConfig(),
+			AvailableTools:          makeToolsList("ubuntu"),
+			BootstrapBase:           corebase.MustParseBaseFromString("ubuntu@22.04"),
+			BootstrapConstraints:    constraints.MustParse("mem=3.5G"),
+			SupportedBootstrapBases: testing.FakeSupportedJujuBases,
 		},
 	)
 	c.Assert(err, gc.NotNil)
@@ -1685,11 +1685,11 @@ func (s *environSuite) TestBootstrapWithAutocert(c *gc.C) {
 	config["autocert-dns-name"] = "example.com"
 	result, err := env.Bootstrap(
 		ctx, s.callCtx, environs.BootstrapParams{
-			ControllerConfig:         config,
-			AvailableTools:           makeToolsList("ubuntu"),
-			BootstrapSeries:          "jammy",
-			BootstrapConstraints:     constraints.MustParse("mem=3.5G"),
-			SupportedBootstrapSeries: testing.FakeSupportedJujuSeries,
+			ControllerConfig:        config,
+			AvailableTools:          makeToolsList("ubuntu"),
+			BootstrapBase:           corebase.MustParseBaseFromString("ubuntu@22.04"),
+			BootstrapConstraints:    constraints.MustParse("mem=3.5G"),
+			SupportedBootstrapBases: testing.FakeSupportedJujuBases,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/provider/common/bootstrap.go
+++ b/provider/common/bootstrap.go
@@ -89,27 +89,9 @@ func BootstrapInstance(
 	// no way to make sure that only one succeeds.
 
 	// First thing, ensure we have tools otherwise there's no point.
-	supportedBootstrapBase := make([]corebase.Base, len(args.SupportedBootstrapSeries))
-	for i, b := range args.SupportedBootstrapSeries.SortedValues() {
-		sb, err := corebase.GetBaseFromSeries(b)
-		if err != nil {
-			return nil, nil, nil, errors.Trace(err)
-		}
-		supportedBootstrapBase[i] = sb
-	}
-
-	var bootstrapBase corebase.Base
-	if args.BootstrapSeries != "" {
-		b, err := corebase.GetBaseFromSeries(args.BootstrapSeries)
-		if err != nil {
-			return nil, nil, nil, errors.Trace(err)
-		}
-		bootstrapBase = b
-	}
-
 	requestedBootstrapBase, err := corebase.ValidateBase(
-		supportedBootstrapBase,
-		bootstrapBase,
+		args.SupportedBootstrapBases,
+		args.BootstrapBase,
 		config.PreferredBase(env.Config()),
 	)
 	if !args.Force && err != nil {

--- a/provider/gce/environ_test.go
+++ b/provider/gce/environ_test.go
@@ -78,8 +78,8 @@ func (s *environSuite) TestBootstrap(c *gc.C) {
 
 	ctx := envtesting.BootstrapTODOContext(c)
 	params := environs.BootstrapParams{
-		ControllerConfig:         testing.FakeControllerConfig(),
-		SupportedBootstrapSeries: testing.FakeSupportedJujuSeries,
+		ControllerConfig:        testing.FakeControllerConfig(),
+		SupportedBootstrapBases: testing.FakeSupportedJujuBases,
 	}
 	result, err := s.Env.Bootstrap(ctx, s.CallCtx, params)
 	c.Assert(err, jc.ErrorIsNil)
@@ -94,8 +94,8 @@ func (s *environSuite) TestBootstrapInvalidCredentialError(c *gc.C) {
 	s.FakeConn.Err = gce.InvalidCredentialError
 	c.Assert(s.InvalidatedCredentials, jc.IsFalse)
 	params := environs.BootstrapParams{
-		ControllerConfig:         testing.FakeControllerConfig(),
-		SupportedBootstrapSeries: testing.FakeSupportedJujuSeries,
+		ControllerConfig:        testing.FakeControllerConfig(),
+		SupportedBootstrapBases: testing.FakeSupportedJujuBases,
 	}
 	_, err := s.Env.Bootstrap(envtesting.BootstrapTODOContext(c), s.CallCtx, params)
 	c.Check(err, gc.NotNil)
@@ -122,8 +122,8 @@ func (s *environSuite) checkAPIPorts(c *gc.C, config controller.Config, expected
 
 	ctx := envtesting.BootstrapTODOContext(c)
 	params := environs.BootstrapParams{
-		ControllerConfig:         config,
-		SupportedBootstrapSeries: testing.FakeSupportedJujuSeries,
+		ControllerConfig:        config,
+		SupportedBootstrapBases: testing.FakeSupportedJujuBases,
 	}
 	_, err := s.Env.Bootstrap(ctx, s.CallCtx, params)
 	c.Assert(err, jc.ErrorIsNil)
@@ -151,8 +151,8 @@ func (s *environSuite) checkAPIPorts(c *gc.C, config controller.Config, expected
 func (s *environSuite) TestBootstrapCommon(c *gc.C) {
 	ctx := envtesting.BootstrapTODOContext(c)
 	params := environs.BootstrapParams{
-		ControllerConfig:         testing.FakeControllerConfig(),
-		SupportedBootstrapSeries: testing.FakeSupportedJujuSeries,
+		ControllerConfig:        testing.FakeControllerConfig(),
+		SupportedBootstrapBases: testing.FakeSupportedJujuBases,
 	}
 	_, err := s.Env.Bootstrap(ctx, s.CallCtx, params)
 	c.Assert(err, jc.ErrorIsNil)

--- a/provider/lxd/environ_test.go
+++ b/provider/lxd/environ_test.go
@@ -94,8 +94,8 @@ func (s *environSuite) TestBootstrapOkay(c *gc.C) {
 
 	ctx := cmdtesting.Context(c)
 	params := environs.BootstrapParams{
-		ControllerConfig:         coretesting.FakeControllerConfig(),
-		SupportedBootstrapSeries: coretesting.FakeSupportedJujuSeries,
+		ControllerConfig:        coretesting.FakeControllerConfig(),
+		SupportedBootstrapBases: coretesting.FakeSupportedJujuBases,
 	}
 	result, err := s.Env.Bootstrap(modelcmd.BootstrapContext(context.Background(), ctx), s.callCtx, params)
 	c.Assert(err, jc.ErrorIsNil)
@@ -112,8 +112,8 @@ func (s *environSuite) TestBootstrapOkay(c *gc.C) {
 func (s *environSuite) TestBootstrapAPI(c *gc.C) {
 	ctx := envtesting.BootstrapContext(context.TODO(), c)
 	params := environs.BootstrapParams{
-		ControllerConfig:         coretesting.FakeControllerConfig(),
-		SupportedBootstrapSeries: coretesting.FakeSupportedJujuSeries,
+		ControllerConfig:        coretesting.FakeControllerConfig(),
+		SupportedBootstrapBases: coretesting.FakeSupportedJujuBases,
 	}
 	_, err := s.Env.Bootstrap(ctx, s.callCtx, params)
 	c.Assert(err, jc.ErrorIsNil)

--- a/provider/oci/environ_integration_test.go
+++ b/provider/oci/environ_integration_test.go
@@ -15,6 +15,7 @@ import (
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/core/base"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/environs"
@@ -912,10 +913,10 @@ func (s *environSuite) TestBootstrap(c *gc.C) {
 	ctx := envtesting.BootstrapTODOContext(c)
 	_, err := s.env.Bootstrap(ctx, nil,
 		environs.BootstrapParams{
-			ControllerConfig:         testing.FakeControllerConfig(),
-			AvailableTools:           makeToolsList("ubuntu"),
-			BootstrapSeries:          "jammy",
-			SupportedBootstrapSeries: testing.FakeSupportedJujuSeries,
+			ControllerConfig:        testing.FakeControllerConfig(),
+			AvailableTools:          makeToolsList("ubuntu"),
+			BootstrapBase:           base.MustParseBaseFromString("ubuntu@22.04"),
+			SupportedBootstrapBases: testing.FakeSupportedJujuBases,
 		})
 	c.Assert(err, gc.IsNil)
 }
@@ -932,11 +933,11 @@ func (s *environSuite) TestBootstrapFlexibleShape(c *gc.C) {
 	ctx := envtesting.BootstrapTODOContext(c)
 	_, err := s.env.Bootstrap(ctx, nil,
 		environs.BootstrapParams{
-			ControllerConfig:         testing.FakeControllerConfig(),
-			AvailableTools:           makeToolsList("ubuntu"),
-			BootstrapSeries:          "jammy",
-			SupportedBootstrapSeries: testing.FakeSupportedJujuSeries,
-			BootstrapConstraints:     constraints.MustParse("cpu-cores=32"),
+			ControllerConfig:        testing.FakeControllerConfig(),
+			AvailableTools:          makeToolsList("ubuntu"),
+			BootstrapBase:           base.MustParseBaseFromString("ubuntu@22.04"),
+			SupportedBootstrapBases: testing.FakeSupportedJujuBases,
+			BootstrapConstraints:    constraints.MustParse("cpu-cores=32"),
 		})
 	c.Assert(err, gc.IsNil)
 }
@@ -960,11 +961,11 @@ func (s *environSuite) TestBootstrapNoAllocatePublicIP(c *gc.C) {
 	ctx := envtesting.BootstrapTODOContext(c)
 	_, err := s.env.Bootstrap(ctx, nil,
 		environs.BootstrapParams{
-			ControllerConfig:         testing.FakeControllerConfig(),
-			AvailableTools:           makeToolsList("ubuntu"),
-			BootstrapSeries:          "jammy",
-			SupportedBootstrapSeries: testing.FakeSupportedJujuSeries,
-			BootstrapConstraints:     constraints.MustParse("allocate-public-ip=false"),
+			ControllerConfig:        testing.FakeControllerConfig(),
+			AvailableTools:          makeToolsList("ubuntu"),
+			BootstrapBase:           base.MustParseBaseFromString("ubuntu@22.04"),
+			SupportedBootstrapBases: testing.FakeSupportedJujuBases,
+			BootstrapConstraints:    constraints.MustParse("allocate-public-ip=false"),
 		})
 	c.Assert(err, gc.IsNil)
 }
@@ -990,10 +991,10 @@ func (s *environSuite) TestBootstrapNoMatchingTools(c *gc.C) {
 	ctx := envtesting.BootstrapTODOContext(c)
 	_, err := s.env.Bootstrap(ctx, nil,
 		environs.BootstrapParams{
-			ControllerConfig:         testing.FakeControllerConfig(),
-			AvailableTools:           makeToolsList("centos"),
-			BootstrapSeries:          "jammy",
-			SupportedBootstrapSeries: testing.FakeSupportedJujuSeries,
+			ControllerConfig:        testing.FakeControllerConfig(),
+			AvailableTools:          makeToolsList("centos"),
+			BootstrapBase:           base.MustParseBaseFromString("ubuntu@22.04"),
+			SupportedBootstrapBases: testing.FakeSupportedJujuBases,
 		})
 	c.Assert(err, gc.ErrorMatches, "no matching agent binaries available")
 

--- a/provider/vsphere/environ_test.go
+++ b/provider/vsphere/environ_test.go
@@ -156,8 +156,8 @@ func (s *environSuite) TestAdoptResourcesPermissionError(c *gc.C) {
 func (s *environSuite) TestBootstrapPermissionError(c *gc.C) {
 	AssertInvalidatesCredential(c, s.client, func(ctx environscontext.ProviderCallContext) error {
 		_, err := s.env.Bootstrap(nil, ctx, environs.BootstrapParams{
-			ControllerConfig:         testing.FakeControllerConfig(),
-			SupportedBootstrapSeries: testing.FakeSupportedJujuSeries,
+			ControllerConfig:        testing.FakeControllerConfig(),
+			SupportedBootstrapBases: testing.FakeSupportedJujuBases,
 		})
 		return err
 	})

--- a/testing/environ.go
+++ b/testing/environ.go
@@ -4,7 +4,6 @@
 package testing
 
 import (
-	"github.com/juju/collections/set"
 	"github.com/juju/names/v5"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -33,10 +32,6 @@ func init() {
 }
 
 var (
-	// FakeSupportedJujuSeries is used to provide a series of canned results
-	// of series to test bootstrap code against.
-	FakeSupportedJujuSeries = set.NewStrings("focal", "jammy", jujuversion.DefaultSupportedLTS())
-
 	// FakeSupportedJujuBases is used to provide a list of canned results
 	// of a base to test bootstrap code against.
 	FakeSupportedJujuBases = []corebase.Base{


### PR DESCRIPTION
For some reason when bootstraping we convert bases to series and then back to bases

Just keep the bases throughout

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

All unit tests pass

```
juju bootstrap lxd lxd
juju bootstrap lxd jammy --bootstrap-base ubuntu@22.04
juju bootstrap lxd focal --bootstrap-base ubuntu@20.04
```