### PR TITLE
Add model last login to domain

### DIFF
--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -30,6 +30,7 @@ import (
 	corecontroller "github.com/juju/juju/controller"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/migration"
+	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/domain/access/service"
@@ -957,8 +958,8 @@ func (s *loginSuite) TestLoginUpdatesLastLoginAndConnection(c *gc.C) {
 	apiState, err := api.Open(info, api.DialOpts{})
 	c.Assert(err, jc.ErrorIsNil)
 	defer func() { _ = apiState.Close() }()
-
 	// The user now has last login updated.
+
 	user, err := userService.GetUser(context.Background(), uuid)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(user.LastLogin, jc.Almost, now)
@@ -967,7 +968,7 @@ func (s *loginSuite) TestLoginUpdatesLastLoginAndConnection(c *gc.C) {
 	model := s.ControllerModel(c)
 	modelUser, err := model.State().UserAccess(names.NewUserTag("bobbrown"), model.ModelTag())
 	c.Assert(err, jc.ErrorIsNil)
-	when, err := model.LastModelConnection(modelUser.UserTag)
+	when, err := userService.LastModelLogin(context.Background(), modelUser.UserTag.Name(), coremodel.UUID(model.UUID()))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(when, jc.Almost, now)
 }

--- a/apiserver/facades/client/controller/controller_test.go
+++ b/apiserver/facades/client/controller/controller_test.go
@@ -157,50 +157,6 @@ func (s *controllerSuite) TestNewAPIRefusesNonClient(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 }
 
-func (s *controllerSuite) checkModelMatches(c *gc.C, model params.Model, expected *state.Model) {
-	c.Check(model.Name, gc.Equals, expected.Name())
-	c.Check(model.UUID, gc.Equals, expected.UUID())
-	c.Check(model.OwnerTag, gc.Equals, expected.Owner().String())
-}
-
-func (s *controllerSuite) TestAllModels(c *gc.C) {
-	admin := s.Factory.MakeUser(c, &factory.UserParams{Name: "foobar"})
-
-	s.Factory.MakeModel(c, &factory.ModelParams{
-		Name: "owned", Owner: admin.UserTag()}).Close()
-	remoteUserTag := names.NewUserTag("user@remote")
-	st := s.Factory.MakeModel(c, &factory.ModelParams{
-		Name: "user", Owner: remoteUserTag})
-	defer func() { _ = st.Close() }()
-	model, err := st.Model()
-	c.Assert(err, jc.ErrorIsNil)
-
-	model.AddUser(
-		state.UserAccessSpec{
-			User:        admin.UserTag(),
-			CreatedBy:   remoteUserTag,
-			DisplayName: "Foo Bar",
-			Access:      permission.WriteAccess})
-
-	s.Factory.MakeModel(c, &factory.ModelParams{
-		Name: "no-access", Owner: remoteUserTag}).Close()
-
-	response, err := s.controller.AllModels(stdcontext.Background())
-	c.Assert(err, jc.ErrorIsNil)
-	// The results are sorted.
-	expected := []string{"controller", "no-access", "owned", "user"}
-	var obtained []string
-	for _, userModel := range response.UserModels {
-		c.Assert(userModel.Type, gc.Equals, "iaas")
-		obtained = append(obtained, userModel.Name)
-		stateModel, ph, err := s.StatePool.GetModel(userModel.UUID)
-		c.Assert(err, jc.ErrorIsNil)
-		defer ph.Release()
-		s.checkModelMatches(c, userModel.Model, stateModel)
-	}
-	c.Assert(obtained, jc.DeepEquals, expected)
-}
-
 func (s *controllerSuite) TestHostedModelConfigs_OnlyHostedModelsReturned(c *gc.C) {
 	owner := s.Factory.MakeUser(c, nil)
 	s.Factory.MakeModel(c, &factory.ModelParams{
@@ -779,39 +735,6 @@ func (s *controllerSuite) TestGrantControllerInvalidUserTag(c *gc.C) {
 	}
 }
 
-type accessSuite struct {
-	statetesting.StateSuite
-
-	resources  *common.Resources
-	authorizer apiservertesting.FakeAuthorizer
-
-	accessService *mocks.MockControllerAccessService
-}
-
-var _ = gc.Suite(&accessSuite{})
-
-func (s *accessSuite) SetUpSuite(c *gc.C) {
-	s.StateSuite.SetUpSuite(c)
-}
-func (s *accessSuite) SetUpTest(c *gc.C) {
-	// Initial config needs to be set before the StateSuite SetUpTest.
-	s.InitialConfig = testing.CustomModelConfig(c, testing.Attrs{
-		"name": "controller",
-	})
-	controllerCfg := testing.FakeControllerConfig()
-
-	s.StateSuite.ControllerConfig = controllerCfg
-	s.StateSuite.SetUpTest(c)
-
-	s.resources = common.NewResources()
-	s.AddCleanup(func(_ *gc.C) { s.resources.StopAll() })
-
-	s.authorizer = apiservertesting.FakeAuthorizer{
-		Tag:      s.Owner,
-		AdminTag: s.Owner,
-	}
-}
-
 func (s *controllerSuite) TestModelStatus(c *gc.C) {
 	// Check that we don't err out immediately if a model errs.
 	results, err := s.controller.ModelStatus(context.Background(), params.Entities{Entities: []params.Entity{{
@@ -1118,6 +1041,51 @@ func (s *controllerSuite) TestWatchModelSummariesByNonAdmin(c *gc.C) {
 
 }
 
+type accessSuite struct {
+	statetesting.StateSuite
+
+	resources  *common.Resources
+	authorizer apiservertesting.FakeAuthorizer
+
+	accessService *mocks.MockControllerAccessService
+}
+
+var _ = gc.Suite(&accessSuite{})
+
+func (s *accessSuite) SetUpSuite(c *gc.C) {
+	s.StateSuite.SetUpSuite(c)
+}
+
+func (s *accessSuite) SetUpTest(c *gc.C) {
+	// Initial config needs to be set before the StateSuite SetUpTest.
+	s.InitialConfig = testing.CustomModelConfig(c, testing.Attrs{
+		"name": "controller",
+	})
+	controllerCfg := testing.FakeControllerConfig()
+
+	s.StateSuite.ControllerConfig = controllerCfg
+	s.StateSuite.SetUpTest(c)
+
+	s.resources = common.NewResources()
+	s.AddCleanup(func(_ *gc.C) { s.resources.StopAll() })
+
+	s.authorizer = apiservertesting.FakeAuthorizer{
+		Tag:      s.Owner,
+		AdminTag: s.Owner,
+	}
+
+}
+
+func (s *accessSuite) setupMocks(c *gc.C) *gomock.Controller {
+	ctrl := gomock.NewController(c)
+	s.accessService = mocks.NewMockControllerAccessService(ctrl)
+	return ctrl
+}
+
+func (s *accessSuite) TearDownTest(c *gc.C) {
+	s.StateSuite.TearDownTest(c)
+}
+
 func (s *accessSuite) controllerAPI(c *gc.C) *controller.ControllerAPI {
 	api, err := controller.NewControllerAPI(
 		context.Background(),
@@ -1142,12 +1110,9 @@ func (s *accessSuite) controllerAPI(c *gc.C) *controller.ControllerAPI {
 }
 
 func (s *accessSuite) TestModifyControllerAccess(c *gc.C) {
-	ctrl := gomock.NewController(c)
-	defer ctrl.Finish()
-
+	defer s.setupMocks(c).Finish()
 	userName := "test-user"
 
-	s.accessService = mocks.NewMockControllerAccessService(ctrl)
 	updateArgs := access.UpdatePermissionArgs{
 		AccessSpec: permission.ControllerForAccess(permission.SuperuserAccess),
 		AddUser:    true,
@@ -1169,15 +1134,12 @@ func (s *accessSuite) TestModifyControllerAccess(c *gc.C) {
 }
 
 func (s *accessSuite) TestGetControllerAccessPermissions(c *gc.C) {
-	// Set up the user making the call.
-	ctrl := gomock.NewController(c)
-	defer ctrl.Finish()
+	defer s.setupMocks(c).Finish()
 
 	userName := "test-user"
 	userTag := names.NewUserTag(userName)
 	differentUser := "different-test-user"
 
-	s.accessService = mocks.NewMockControllerAccessService(ctrl)
 	target := permission.ControllerForAccess(permission.SuperuserAccess)
 	s.accessService.EXPECT().ReadUserAccessLevelForTarget(gomock.Any(), userName, target.Target).Return(permission.SuperuserAccess, nil)
 
@@ -1198,6 +1160,53 @@ func (s *accessSuite) TestGetControllerAccessPermissions(c *gc.C) {
 	c.Assert(*results.Results[1].Error, gc.DeepEquals, params.Error{
 		Message: "permission denied", Code: "unauthorized access",
 	})
+}
+
+func (s *accessSuite) TestAllModels(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+	admin := s.Factory.MakeUser(c, &factory.UserParams{Name: "foobar"})
+
+	s.Factory.MakeModel(c, &factory.ModelParams{
+		Name: "owned", Owner: admin.UserTag()}).Close()
+	remoteUserTag := names.NewUserTag("user@remote")
+	st := s.Factory.MakeModel(c, &factory.ModelParams{
+		Name: "user", Owner: remoteUserTag})
+	defer func() { _ = st.Close() }()
+	model, err := st.Model()
+	c.Assert(err, jc.ErrorIsNil)
+
+	model.AddUser(
+		state.UserAccessSpec{
+			User:        admin.UserTag(),
+			CreatedBy:   remoteUserTag,
+			DisplayName: "Foo Bar",
+			Access:      permission.WriteAccess})
+
+	s.Factory.MakeModel(c, &factory.ModelParams{
+		Name: "no-access", Owner: remoteUserTag}).Close()
+
+	s.accessService.EXPECT().LastModelLogin(gomock.Any(), "test-admin", gomock.Any()).Times(4)
+
+	response, err := s.controllerAPI(c).AllModels(stdcontext.Background())
+	c.Assert(err, jc.ErrorIsNil)
+	// The results are sorted.
+	expected := []string{"controller", "no-access", "owned", "user"}
+	var obtained []string
+	for _, userModel := range response.UserModels {
+		c.Assert(userModel.Type, gc.Equals, "iaas")
+		obtained = append(obtained, userModel.Name)
+		stateModel, ph, err := s.StatePool.GetModel(userModel.UUID)
+		c.Assert(err, jc.ErrorIsNil)
+		defer ph.Release()
+		s.checkModelMatches(c, userModel.Model, stateModel)
+	}
+	c.Assert(obtained, jc.DeepEquals, expected)
+}
+
+func (s *accessSuite) checkModelMatches(c *gc.C, model params.Model, expected *state.Model) {
+	c.Check(model.Name, gc.Equals, expected.Name())
+	c.Check(model.UUID, gc.Equals, expected.UUID())
+	c.Check(model.OwnerTag, gc.Equals, expected.Owner().String())
 }
 
 type noopRegisterer struct {

--- a/apiserver/facades/client/controller/mocks/domain_mock.go
+++ b/apiserver/facades/client/controller/mocks/domain_mock.go
@@ -12,8 +12,10 @@ package mocks
 import (
 	context "context"
 	reflect "reflect"
+	time "time"
 
 	controller "github.com/juju/juju/controller"
+	model "github.com/juju/juju/core/model"
 	permission "github.com/juju/juju/core/permission"
 	access "github.com/juju/juju/domain/access"
 	gomock "go.uber.org/mock/gomock"
@@ -40,6 +42,45 @@ func NewMockControllerAccessService(ctrl *gomock.Controller) *MockControllerAcce
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockControllerAccessService) EXPECT() *MockControllerAccessServiceMockRecorder {
 	return m.recorder
+}
+
+// LastModelLogin mocks base method.
+func (m *MockControllerAccessService) LastModelLogin(arg0 context.Context, arg1 string, arg2 model.UUID) (time.Time, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LastModelLogin", arg0, arg1, arg2)
+	ret0, _ := ret[0].(time.Time)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// LastModelLogin indicates an expected call of LastModelLogin.
+func (mr *MockControllerAccessServiceMockRecorder) LastModelLogin(arg0, arg1, arg2 any) *MockControllerAccessServiceLastModelLoginCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LastModelLogin", reflect.TypeOf((*MockControllerAccessService)(nil).LastModelLogin), arg0, arg1, arg2)
+	return &MockControllerAccessServiceLastModelLoginCall{Call: call}
+}
+
+// MockControllerAccessServiceLastModelLoginCall wrap *gomock.Call
+type MockControllerAccessServiceLastModelLoginCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockControllerAccessServiceLastModelLoginCall) Return(arg0 time.Time, arg1 error) *MockControllerAccessServiceLastModelLoginCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockControllerAccessServiceLastModelLoginCall) Do(f func(context.Context, string, model.UUID) (time.Time, error)) *MockControllerAccessServiceLastModelLoginCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockControllerAccessServiceLastModelLoginCall) DoAndReturn(f func(context.Context, string, model.UUID) (time.Time, error)) *MockControllerAccessServiceLastModelLoginCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
 }
 
 // ReadUserAccessLevelForTarget mocks base method.

--- a/apiserver/facades/client/modelmanager/mocks/service_mock.go
+++ b/apiserver/facades/client/modelmanager/mocks/service_mock.go
@@ -12,6 +12,7 @@ package mocks
 import (
 	context "context"
 	reflect "reflect"
+	time "time"
 
 	credential "github.com/juju/juju/core/credential"
 	model "github.com/juju/juju/core/model"
@@ -81,6 +82,45 @@ func (c *MockAccessServiceGetUserByNameCall) Do(f func(context.Context, string) 
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockAccessServiceGetUserByNameCall) DoAndReturn(f func(context.Context, string) (user.User, error)) *MockAccessServiceGetUserByNameCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// LastModelLogin mocks base method.
+func (m *MockAccessService) LastModelLogin(arg0 context.Context, arg1 string, arg2 model.UUID) (time.Time, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LastModelLogin", arg0, arg1, arg2)
+	ret0, _ := ret[0].(time.Time)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// LastModelLogin indicates an expected call of LastModelLogin.
+func (mr *MockAccessServiceMockRecorder) LastModelLogin(arg0, arg1, arg2 any) *MockAccessServiceLastModelLoginCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LastModelLogin", reflect.TypeOf((*MockAccessService)(nil).LastModelLogin), arg0, arg1, arg2)
+	return &MockAccessServiceLastModelLoginCall{Call: call}
+}
+
+// MockAccessServiceLastModelLoginCall wrap *gomock.Call
+type MockAccessServiceLastModelLoginCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockAccessServiceLastModelLoginCall) Return(arg0 time.Time, arg1 error) *MockAccessServiceLastModelLoginCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockAccessServiceLastModelLoginCall) Do(f func(context.Context, string, model.UUID) (time.Time, error)) *MockAccessServiceLastModelLoginCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockAccessServiceLastModelLoginCall) DoAndReturn(f func(context.Context, string, model.UUID) (time.Time, error)) *MockAccessServiceLastModelLoginCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/client/modelmanager/services.go
+++ b/apiserver/facades/client/modelmanager/services.go
@@ -5,6 +5,7 @@ package modelmanager
 
 import (
 	"context"
+	"time"
 
 	"github.com/juju/description/v6"
 
@@ -125,6 +126,10 @@ type AccessService interface {
 	ReadUserAccessLevelForTarget(ctx context.Context, subject string, target corepermission.ID) (corepermission.Access, error)
 	// UpdatePermission updates the access level for a user of the model.
 	UpdatePermission(ctx context.Context, args access.UpdatePermissionArgs) error
+	// LastModelLogin will return the last login time of the specified
+	// user. An accesserrors.UserNeverAccessedModel error will be returned if
+	// there is no record of the user logging in to this model.
+	LastModelLogin(context.Context, string, coremodel.UUID) (time.Time, error)
 }
 
 // NetworkService is the interface that is used to interact with the

--- a/apiserver/stateauthenticator/context.go
+++ b/apiserver/stateauthenticator/context.go
@@ -23,6 +23,7 @@ import (
 	"github.com/juju/juju/apiserver/bakeryutil"
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	coremacaroon "github.com/juju/juju/core/macaroon"
+	coremodel "github.com/juju/juju/core/model"
 	coreuser "github.com/juju/juju/core/user"
 	"github.com/juju/juju/internal/auth"
 	"github.com/juju/juju/state"
@@ -46,9 +47,9 @@ type UserService interface {
 	GetUserByAuth(ctx context.Context, name string, password auth.Password) (coreuser.User, error)
 	// GetUserByName returns the user with the given name.
 	GetUserByName(ctx context.Context, name string) (coreuser.User, error)
-	// UpdateLastLogin updates the last login time for the user with the
+	// UpdateLastModelLogin updates the last login time for the user with the
 	// given name.
-	UpdateLastLogin(ctx context.Context, name string) error
+	UpdateLastModelLogin(ctx context.Context, name string, modelUUID coremodel.UUID) error
 }
 
 // AgentAuthenticatorFactory is a factory for creating authenticators, which

--- a/apiserver/stateauthenticator/services_mock_test.go
+++ b/apiserver/stateauthenticator/services_mock_test.go
@@ -15,6 +15,7 @@ import (
 
 	authentication "github.com/juju/juju/apiserver/authentication"
 	controller "github.com/juju/juju/controller"
+	model "github.com/juju/juju/core/model"
 	user "github.com/juju/juju/core/user"
 	auth "github.com/juju/juju/internal/auth"
 	state "github.com/juju/juju/state"
@@ -184,40 +185,40 @@ func (c *MockUserServiceGetUserByNameCall) DoAndReturn(f func(context.Context, s
 	return c
 }
 
-// UpdateLastLogin mocks base method.
-func (m *MockUserService) UpdateLastLogin(arg0 context.Context, arg1 string) error {
+// UpdateLastModelLogin mocks base method.
+func (m *MockUserService) UpdateLastModelLogin(arg0 context.Context, arg1 string, arg2 model.UUID) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateLastLogin", arg0, arg1)
+	ret := m.ctrl.Call(m, "UpdateLastModelLogin", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// UpdateLastLogin indicates an expected call of UpdateLastLogin.
-func (mr *MockUserServiceMockRecorder) UpdateLastLogin(arg0, arg1 any) *MockUserServiceUpdateLastLoginCall {
+// UpdateLastModelLogin indicates an expected call of UpdateLastModelLogin.
+func (mr *MockUserServiceMockRecorder) UpdateLastModelLogin(arg0, arg1, arg2 any) *MockUserServiceUpdateLastModelLoginCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateLastLogin", reflect.TypeOf((*MockUserService)(nil).UpdateLastLogin), arg0, arg1)
-	return &MockUserServiceUpdateLastLoginCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateLastModelLogin", reflect.TypeOf((*MockUserService)(nil).UpdateLastModelLogin), arg0, arg1, arg2)
+	return &MockUserServiceUpdateLastModelLoginCall{Call: call}
 }
 
-// MockUserServiceUpdateLastLoginCall wrap *gomock.Call
-type MockUserServiceUpdateLastLoginCall struct {
+// MockUserServiceUpdateLastModelLoginCall wrap *gomock.Call
+type MockUserServiceUpdateLastModelLoginCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockUserServiceUpdateLastLoginCall) Return(arg0 error) *MockUserServiceUpdateLastLoginCall {
+func (c *MockUserServiceUpdateLastModelLoginCall) Return(arg0 error) *MockUserServiceUpdateLastModelLoginCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockUserServiceUpdateLastLoginCall) Do(f func(context.Context, string) error) *MockUserServiceUpdateLastLoginCall {
+func (c *MockUserServiceUpdateLastModelLoginCall) Do(f func(context.Context, string, model.UUID) error) *MockUserServiceUpdateLastModelLoginCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockUserServiceUpdateLastLoginCall) DoAndReturn(f func(context.Context, string) error) *MockUserServiceUpdateLastLoginCall {
+func (c *MockUserServiceUpdateLastModelLoginCall) DoAndReturn(f func(context.Context, string, model.UUID) error) *MockUserServiceUpdateLastModelLoginCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/access/errors/errors.go
+++ b/domain/access/errors/errors.go
@@ -77,4 +77,8 @@ const (
 	// AccessNotFound describes an error that occurs no access is found for a
 	// user on a target.
 	AccessNotFound = errors.ConstError("access not found")
+
+	// UserNeverAccessedModel describes an error that occurs if a user has
+	// never accessed a model.
+	UserNeverAccessedModel = errors.ConstError("user never accessed model")
 )

--- a/domain/access/service/service.go
+++ b/domain/access/service/service.go
@@ -5,8 +5,10 @@ package service
 
 import (
 	"context"
+	"time"
 
 	"github.com/juju/juju/core/credential"
+	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/core/user"
 	"github.com/juju/juju/domain/access"
@@ -119,10 +121,21 @@ type UserState interface {
 	// satisfies accesserrors.UserNotFound.
 	DisableUserAuthentication(context.Context, string) error
 
-	// UpdateLastLogin will update the last login time for the user.
-	// If no user is found for the supplied user name an error is returned that
-	// satisfies accesserrors.UserNotFound.
-	UpdateLastLogin(context.Context, string) error
+	// UpdateLastModelLogin will update the last login time for the user.
+	// The following error types are possible from this function:
+	// - accesserrors.UserNameNotValid: When the username is not valid.
+	// - accesserrors.UserNotFound: When the user cannot be found.
+	// - modelerrors.NotFound: If no model by the given modelUUID exists.
+	UpdateLastModelLogin(context.Context, string, coremodel.UUID) error
+
+	// LastModelLogin will return the last login time of the specified user.
+	// The following error types are possible from this function:
+	// - accesserrors.UserNameNotValid: When the username is not valid.
+	// - accesserrors.UserNotFound: When the user cannot be found.
+	// - modelerrors.NotFound: If no model by the given modelUUID exists.
+	// - accesserrors.UserNeverAccessedModel: If there is no record of the user
+	// accessing the model.
+	LastModelLogin(context.Context, string, coremodel.UUID) (time.Time, error)
 }
 
 // PermissionState describes retrieval and persistence methods for user

--- a/domain/access/service/state_mock_test.go
+++ b/domain/access/service/state_mock_test.go
@@ -12,8 +12,10 @@ package service
 import (
 	context "context"
 	reflect "reflect"
+	time "time"
 
 	credential "github.com/juju/juju/core/credential"
+	model "github.com/juju/juju/core/model"
 	permission "github.com/juju/juju/core/permission"
 	user "github.com/juju/juju/core/user"
 	access "github.com/juju/juju/domain/access"
@@ -546,6 +548,45 @@ func (c *MockStateGetUserByNameCall) DoAndReturn(f func(context.Context, string)
 	return c
 }
 
+// LastModelLogin mocks base method.
+func (m *MockState) LastModelLogin(arg0 context.Context, arg1 string, arg2 model.UUID) (time.Time, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LastModelLogin", arg0, arg1, arg2)
+	ret0, _ := ret[0].(time.Time)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// LastModelLogin indicates an expected call of LastModelLogin.
+func (mr *MockStateMockRecorder) LastModelLogin(arg0, arg1, arg2 any) *MockStateLastModelLoginCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LastModelLogin", reflect.TypeOf((*MockState)(nil).LastModelLogin), arg0, arg1, arg2)
+	return &MockStateLastModelLoginCall{Call: call}
+}
+
+// MockStateLastModelLoginCall wrap *gomock.Call
+type MockStateLastModelLoginCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateLastModelLoginCall) Return(arg0 time.Time, arg1 error) *MockStateLastModelLoginCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateLastModelLoginCall) Do(f func(context.Context, string, model.UUID) (time.Time, error)) *MockStateLastModelLoginCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateLastModelLoginCall) DoAndReturn(f func(context.Context, string, model.UUID) (time.Time, error)) *MockStateLastModelLoginCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // ReadAllAccessForUserAndObjectType mocks base method.
 func (m *MockState) ReadAllAccessForUserAndObjectType(arg0 context.Context, arg1 string, arg2 permission.ObjectType) ([]permission.UserAccess, error) {
 	m.ctrl.T.Helper()
@@ -855,40 +896,40 @@ func (c *MockStateSetPasswordHashCall) DoAndReturn(f func(context.Context, strin
 	return c
 }
 
-// UpdateLastLogin mocks base method.
-func (m *MockState) UpdateLastLogin(arg0 context.Context, arg1 string) error {
+// UpdateLastModelLogin mocks base method.
+func (m *MockState) UpdateLastModelLogin(arg0 context.Context, arg1 string, arg2 model.UUID) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateLastLogin", arg0, arg1)
+	ret := m.ctrl.Call(m, "UpdateLastModelLogin", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// UpdateLastLogin indicates an expected call of UpdateLastLogin.
-func (mr *MockStateMockRecorder) UpdateLastLogin(arg0, arg1 any) *MockStateUpdateLastLoginCall {
+// UpdateLastModelLogin indicates an expected call of UpdateLastModelLogin.
+func (mr *MockStateMockRecorder) UpdateLastModelLogin(arg0, arg1, arg2 any) *MockStateUpdateLastModelLoginCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateLastLogin", reflect.TypeOf((*MockState)(nil).UpdateLastLogin), arg0, arg1)
-	return &MockStateUpdateLastLoginCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateLastModelLogin", reflect.TypeOf((*MockState)(nil).UpdateLastModelLogin), arg0, arg1, arg2)
+	return &MockStateUpdateLastModelLoginCall{Call: call}
 }
 
-// MockStateUpdateLastLoginCall wrap *gomock.Call
-type MockStateUpdateLastLoginCall struct {
+// MockStateUpdateLastModelLoginCall wrap *gomock.Call
+type MockStateUpdateLastModelLoginCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockStateUpdateLastLoginCall) Return(arg0 error) *MockStateUpdateLastLoginCall {
+func (c *MockStateUpdateLastModelLoginCall) Return(arg0 error) *MockStateUpdateLastModelLoginCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateUpdateLastLoginCall) Do(f func(context.Context, string) error) *MockStateUpdateLastLoginCall {
+func (c *MockStateUpdateLastModelLoginCall) Do(f func(context.Context, string, model.UUID) error) *MockStateUpdateLastModelLoginCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateUpdateLastLoginCall) DoAndReturn(f func(context.Context, string) error) *MockStateUpdateLastLoginCall {
+func (c *MockStateUpdateLastModelLoginCall) DoAndReturn(f func(context.Context, string, model.UUID) error) *MockStateUpdateLastModelLoginCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1339,6 +1380,45 @@ func (c *MockUserStateGetUserByNameCall) DoAndReturn(f func(context.Context, str
 	return c
 }
 
+// LastModelLogin mocks base method.
+func (m *MockUserState) LastModelLogin(arg0 context.Context, arg1 string, arg2 model.UUID) (time.Time, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LastModelLogin", arg0, arg1, arg2)
+	ret0, _ := ret[0].(time.Time)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// LastModelLogin indicates an expected call of LastModelLogin.
+func (mr *MockUserStateMockRecorder) LastModelLogin(arg0, arg1, arg2 any) *MockUserStateLastModelLoginCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LastModelLogin", reflect.TypeOf((*MockUserState)(nil).LastModelLogin), arg0, arg1, arg2)
+	return &MockUserStateLastModelLoginCall{Call: call}
+}
+
+// MockUserStateLastModelLoginCall wrap *gomock.Call
+type MockUserStateLastModelLoginCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockUserStateLastModelLoginCall) Return(arg0 time.Time, arg1 error) *MockUserStateLastModelLoginCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockUserStateLastModelLoginCall) Do(f func(context.Context, string, model.UUID) (time.Time, error)) *MockUserStateLastModelLoginCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockUserStateLastModelLoginCall) DoAndReturn(f func(context.Context, string, model.UUID) (time.Time, error)) *MockUserStateLastModelLoginCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // RemoveUser mocks base method.
 func (m *MockUserState) RemoveUser(arg0 context.Context, arg1 string) error {
 	m.ctrl.T.Helper()
@@ -1453,40 +1533,40 @@ func (c *MockUserStateSetPasswordHashCall) DoAndReturn(f func(context.Context, s
 	return c
 }
 
-// UpdateLastLogin mocks base method.
-func (m *MockUserState) UpdateLastLogin(arg0 context.Context, arg1 string) error {
+// UpdateLastModelLogin mocks base method.
+func (m *MockUserState) UpdateLastModelLogin(arg0 context.Context, arg1 string, arg2 model.UUID) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateLastLogin", arg0, arg1)
+	ret := m.ctrl.Call(m, "UpdateLastModelLogin", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// UpdateLastLogin indicates an expected call of UpdateLastLogin.
-func (mr *MockUserStateMockRecorder) UpdateLastLogin(arg0, arg1 any) *MockUserStateUpdateLastLoginCall {
+// UpdateLastModelLogin indicates an expected call of UpdateLastModelLogin.
+func (mr *MockUserStateMockRecorder) UpdateLastModelLogin(arg0, arg1, arg2 any) *MockUserStateUpdateLastModelLoginCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateLastLogin", reflect.TypeOf((*MockUserState)(nil).UpdateLastLogin), arg0, arg1)
-	return &MockUserStateUpdateLastLoginCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateLastModelLogin", reflect.TypeOf((*MockUserState)(nil).UpdateLastModelLogin), arg0, arg1, arg2)
+	return &MockUserStateUpdateLastModelLoginCall{Call: call}
 }
 
-// MockUserStateUpdateLastLoginCall wrap *gomock.Call
-type MockUserStateUpdateLastLoginCall struct {
+// MockUserStateUpdateLastModelLoginCall wrap *gomock.Call
+type MockUserStateUpdateLastModelLoginCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockUserStateUpdateLastLoginCall) Return(arg0 error) *MockUserStateUpdateLastLoginCall {
+func (c *MockUserStateUpdateLastModelLoginCall) Return(arg0 error) *MockUserStateUpdateLastModelLoginCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockUserStateUpdateLastLoginCall) Do(f func(context.Context, string) error) *MockUserStateUpdateLastLoginCall {
+func (c *MockUserStateUpdateLastModelLoginCall) Do(f func(context.Context, string, model.UUID) error) *MockUserStateUpdateLastModelLoginCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockUserStateUpdateLastLoginCall) DoAndReturn(f func(context.Context, string) error) *MockUserStateUpdateLastLoginCall {
+func (c *MockUserStateUpdateLastModelLoginCall) DoAndReturn(f func(context.Context, string, model.UUID) error) *MockUserStateUpdateLastModelLoginCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/access/state/permission.go
+++ b/domain/access/state/permission.go
@@ -856,7 +856,7 @@ AND    grant_to IN (
 `
 	updateQueryStmt, err := st.Prepare(updateQuery, permInOut{})
 	if err != nil {
-		return errors.Annotate(err, "preparing update updateLastLogin query")
+		return errors.Annotate(err, "preparing updatePermission query")
 	}
 
 	in := permInOut{

--- a/domain/access/state/types.go
+++ b/domain/access/state/types.go
@@ -143,6 +143,11 @@ type userName struct {
 	Name string `db:"name"`
 }
 
+// userUUID is used to retrieve the UUID from the user table.
+type userUUID struct {
+	UUID string `db:"uuid"`
+}
+
 // permInOut is a struct to replace sqlair.M with permission
 // SQL that contains a user name, grant_on and access both
 // input and output.
@@ -150,4 +155,28 @@ type permInOut struct {
 	Name    string `db:"name"`
 	GrantOn string `db:"grant_on"`
 	Access  string `db:"access"`
+}
+
+// dbModelAccess is a struct used to record a users logging in to a particular
+// model.
+type dbModelAccess struct {
+	UserUUID  string `db:"user_uuid"`
+	ModelUUID string `db:"model_uuid"`
+}
+
+// dbModelUUID is a struct used to record a model UUID from the database.
+type dbModelUUID struct {
+	UUID string `db:"uuid"`
+}
+
+// dbModelExists is used to record if a row in the database exists by selecting true
+// into it.
+type dbModelExists struct {
+	Exists bool `db:"exists"`
+}
+
+// loginTime is used to record the last time a user logged in when reading from
+// model_last_login.
+type loginTime struct {
+	Time time.Time `db:"time"`
 }

--- a/domain/model/state/testing/model.go
+++ b/domain/model/state/testing/model.go
@@ -82,6 +82,7 @@ func CreateTestModel(
 	credId, err := corecredential.NewID()
 	c.Assert(err, jc.ErrorIsNil)
 
+	userName := "test-user" + name
 	runner, err := txnRunner()
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -91,7 +92,7 @@ func CreateTestModel(
 		_, err := tx.ExecContext(ctx, `
 			INSERT INTO user (uuid, name, display_name, removed, created_by_uuid, created_at)
 			VALUES (?, ?, ?, ?, ?, ?)
-		`, userUUID.String(), name, "test-user", false, userUUID, time.Now())
+		`, userUUID.String(), name, userName, false, userUUID, time.Now())
 		if err != nil {
 			return err
 		}

--- a/domain/schema/controller/sql/0015-user.sql
+++ b/domain/schema/controller/sql/0015-user.sql
@@ -14,7 +14,6 @@ CREATE UNIQUE INDEX idx_singleton_active_user ON user (name) WHERE removed IS FA
 
 CREATE TABLE user_authentication (
     user_uuid      TEXT PRIMARY KEY,
-    last_login     TIMESTAMP,
     disabled       BOOLEAN NOT NULL,
     CONSTRAINT     fk_user_authentication_user
         FOREIGN KEY (user_uuid)
@@ -45,6 +44,5 @@ SELECT u.uuid,
        u.removed,
        u.created_by_uuid, 
        u.created_at,
-       a.last_login, 
        a.disabled
 FROM   user u LEFT JOIN user_authentication a on u.uuid = a.user_uuid;

--- a/domain/schema/controller/sql/0019-model-last-login.sql
+++ b/domain/schema/controller/sql/0019-model-last-login.sql
@@ -1,0 +1,18 @@
+CREATE TABLE model_last_login (
+    model_uuid TEXT NOT NULL,
+    user_uuid TEXT NOT NULL,
+    time TIMESTAMP NOT NULL,
+    PRIMARY KEY (model_uuid, user_uuid),
+    CONSTRAINT            fk_model_last_login_model
+        FOREIGN KEY           (model_uuid)
+            REFERENCES            model(uuid),
+    CONSTRAINT            fk_model_last_login_user
+        FOREIGN KEY           (user_uuid)
+            REFERENCES            user(uuid)
+);
+CREATE VIEW v_user_last_login AS
+-- We cannot select last_login as MAX directly here because it returns a sqlite
+-- string value, not a timestamp and this stops us scanning into time.Time.
+SELECT time AS last_login, user_uuid, MAX(time) AS _
+FROM model_last_login
+GROUP BY user_uuid;

--- a/domain/schema/schema_test.go
+++ b/domain/schema/schema_test.go
@@ -164,6 +164,7 @@ func (s *schemaSuite) TestControllerTables(c *gc.C) {
 		"user_authentication",
 		"user_password",
 		"user_activation_key",
+		"model_last_login",
 
 		// Flags
 		"flag",
@@ -192,6 +193,7 @@ func (s *schemaSuite) TestControllerViews(c *gc.C) {
 	// Ensure that each view is present.
 	expected := set.NewStrings(
 		"v_user_auth",
+		"v_user_last_login",
 
 		// Controller and controller config
 		"v_controller_config",

--- a/internal/worker/httpserverargs/authenticator.go
+++ b/internal/worker/httpserverargs/authenticator.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/apiserver/authentication/macaroon"
 	"github.com/juju/juju/apiserver/stateauthenticator"
 	"github.com/juju/juju/controller"
+	coremodel "github.com/juju/juju/core/model"
 	coreuser "github.com/juju/juju/core/user"
 	"github.com/juju/juju/internal/auth"
 	"github.com/juju/juju/state"
@@ -32,9 +33,9 @@ type UserService interface {
 	GetUserByAuth(ctx context.Context, name string, password auth.Password) (coreuser.User, error)
 	// GetUserByName returns the user with the given name.
 	GetUserByName(ctx context.Context, name string) (coreuser.User, error)
-	// UpdateLastLogin updates the last login time for the user with the
-	// given name.
-	UpdateLastLogin(ctx context.Context, name string) error
+	// UpdateLastModelLogin updates the last login time for the user with the
+	// given name on the given model.
+	UpdateLastModelLogin(ctx context.Context, name string, modelUUID coremodel.UUID) error
 }
 
 // NewStateAuthenticatorFunc is a function type satisfied by

--- a/internal/worker/httpserverargs/services_mock_test.go
+++ b/internal/worker/httpserverargs/services_mock_test.go
@@ -14,6 +14,7 @@ import (
 	reflect "reflect"
 
 	controller "github.com/juju/juju/controller"
+	model "github.com/juju/juju/core/model"
 	user "github.com/juju/juju/core/user"
 	auth "github.com/juju/juju/internal/auth"
 	gomock "go.uber.org/mock/gomock"
@@ -182,40 +183,40 @@ func (c *MockUserServiceGetUserByNameCall) DoAndReturn(f func(context.Context, s
 	return c
 }
 
-// UpdateLastLogin mocks base method.
-func (m *MockUserService) UpdateLastLogin(arg0 context.Context, arg1 string) error {
+// UpdateLastModelLogin mocks base method.
+func (m *MockUserService) UpdateLastModelLogin(arg0 context.Context, arg1 string, arg2 model.UUID) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateLastLogin", arg0, arg1)
+	ret := m.ctrl.Call(m, "UpdateLastModelLogin", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// UpdateLastLogin indicates an expected call of UpdateLastLogin.
-func (mr *MockUserServiceMockRecorder) UpdateLastLogin(arg0, arg1 any) *MockUserServiceUpdateLastLoginCall {
+// UpdateLastModelLogin indicates an expected call of UpdateLastModelLogin.
+func (mr *MockUserServiceMockRecorder) UpdateLastModelLogin(arg0, arg1, arg2 any) *MockUserServiceUpdateLastModelLoginCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateLastLogin", reflect.TypeOf((*MockUserService)(nil).UpdateLastLogin), arg0, arg1)
-	return &MockUserServiceUpdateLastLoginCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateLastModelLogin", reflect.TypeOf((*MockUserService)(nil).UpdateLastModelLogin), arg0, arg1, arg2)
+	return &MockUserServiceUpdateLastModelLoginCall{Call: call}
 }
 
-// MockUserServiceUpdateLastLoginCall wrap *gomock.Call
-type MockUserServiceUpdateLastLoginCall struct {
+// MockUserServiceUpdateLastModelLoginCall wrap *gomock.Call
+type MockUserServiceUpdateLastModelLoginCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockUserServiceUpdateLastLoginCall) Return(arg0 error) *MockUserServiceUpdateLastLoginCall {
+func (c *MockUserServiceUpdateLastModelLoginCall) Return(arg0 error) *MockUserServiceUpdateLastModelLoginCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockUserServiceUpdateLastLoginCall) Do(f func(context.Context, string) error) *MockUserServiceUpdateLastLoginCall {
+func (c *MockUserServiceUpdateLastModelLoginCall) Do(f func(context.Context, string, model.UUID) error) *MockUserServiceUpdateLastModelLoginCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockUserServiceUpdateLastLoginCall) DoAndReturn(f func(context.Context, string) error) *MockUserServiceUpdateLastLoginCall {
+func (c *MockUserServiceUpdateLastModelLoginCall) DoAndReturn(f func(context.Context, string, model.UUID) error) *MockUserServiceUpdateLastModelLoginCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/httpserverargs/worker.go
+++ b/internal/worker/httpserverargs/worker.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/juju/apiserver/apiserverhttp"
 	"github.com/juju/juju/apiserver/authentication/macaroon"
 	"github.com/juju/juju/controller"
+	coremodel "github.com/juju/juju/core/model"
 	coreuser "github.com/juju/juju/core/user"
 	"github.com/juju/juju/internal/auth"
 	"github.com/juju/juju/state"
@@ -152,10 +153,10 @@ func (b *managedServices) GetUserByName(ctx context.Context, name string) (coreu
 	return b.userService.GetUserByName(b.tomb.Context(ctx), name)
 }
 
-// UpdateLastLogin updates the last login time for the user with the
+// UpdateLastModelLogin updates the last login time for the user with the
 // given name.
-func (b *managedServices) UpdateLastLogin(ctx context.Context, name string) error {
-	return b.userService.UpdateLastLogin(b.tomb.Context(ctx), name)
+func (b *managedServices) UpdateLastModelLogin(ctx context.Context, name string, modelUUID coremodel.UUID) error {
+	return b.userService.UpdateLastModelLogin(b.tomb.Context(ctx), name, modelUUID)
 }
 
 // Kill is part of the worker.Worker interface.


### PR DESCRIPTION
<!-- Why this change is needed and what it does. -->
Juju stores the time each user last logged in to each model. It previously did this via a collection in mongo. This PR adds a table to the access service that tracks the users last logins.

The last login column is removed from the user table and the users last login is instead calculated by selecting the most recent login by that user to any model from the new table.

Currently we are double writing the last login to mongo and to DQLite but a subsequent PR will remove the need to do that by replacing all the remaining last login calls.

The tests for ListModels in the model-manager are currently commented out so this functionality is tests. I had a go at fixing the tests but realised that ListModels itself does not work as expected and fixing that is out of scope of this PR. I have coordinated with @tlm and he will land a patch for this soon.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps
The QA for this PR is a little difficult since the login and permissions stories are currently in flux. Specifically, when a is granted access to a model and logs in they do not see the model when they do `juju models` (this is likely because of the changes by @tlm that move ListModels to use state). There is also the issue that adding a model and accessing it does not trigger the expected login code and therefore, new models added do not have their last login updated.

The extent of the QA possible right now is:
```
$ juju bootstrap lxd test-controller
$ juju models
Controller: test-controller

Model       Cloud/Region  Type  Status     Machines  Units  Access  Last connection
controller  lxd/default   lxd   available         1      1  admin   just now
```

In the future, it should be possible to add a model and see that the last connection is just now. For the moment it says never connected.
```
$ juju add-model default
$ juju models
Controller: test-controller

Model       Cloud/Region  Type  Status     Machines  Units  Access  Last connection
controller  lxd/default   lxd   available         1      1  admin   just now
default*    lxd/default   lxd   available         0      -  admin   never connected
```
It should also be possible to see the last logins of other users, however listing the models of other users is currently not working. You should be able to do:
```
$ juju add-user test-user
$ juju change-user-password test-user
$ juju grant test-user admin default
$ juju models --user test-user
// Or instead of listing the models as the admin, you could do
$ juju logout 
$ juju login -u test-user -c test-controller
$ juju models
```

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Jira card:** JUJU-5835
