### PR TITLE
Correctly insert space ID for reloaded spaces and subnets

### DIFF
--- a/domain/network/service/space.go
+++ b/domain/network/service/space.go
@@ -327,7 +327,7 @@ func (s *ProviderSpaces) saveSpaces(ctx context.Context, providerSpaces []networ
 			spaceName := network.ConvertSpaceName(string(spaceInfo.Name), spaceNames)
 
 			s.logger.Debugf("Adding space %s from provider %s", spaceName, string(spaceInfo.ProviderId))
-			spaceID, err := s.spaceService.AddSpace(
+			spaceUUID, err := s.spaceService.AddSpace(
 				ctx,
 				network.SpaceInfo{
 					Name:       network.SpaceName(spaceName),
@@ -343,10 +343,11 @@ func (s *ProviderSpaces) saveSpaces(ctx context.Context, providerSpaces []networ
 			// To ensure that we can remove spaces, we back-fill the new spaces
 			// onto the modelSpaceMap.
 			s.modelSpaceMap[spaceInfo.ProviderId] = network.SpaceInfo{
-				ID:         spaceID.String(),
+				ID:         spaceUUID.String(),
 				Name:       network.SpaceName(spaceName),
 				ProviderId: spaceInfo.ProviderId,
 			}
+			spaceID = spaceUUID.String()
 		}
 
 		err = s.spaceService.saveProviderSubnets(ctx, spaceInfo.Subnets, spaceID, fanConfig)


### PR DESCRIPTION
This patch fixes a bug discovered when reloading spaces on MAAS, where all the discovered subnets were assigned to the alpha space instead of the actual corresponding space.

The bug was simply an incorrectly assigned var during spaces insertion.



## Checklist



- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

The QA steps must be done in MAAS: after bootstrap and adding a model, `juju spaces` should return the spaces and their subnets correctly assigned.

## Links


**Jira card:** JUJU-

