### PR TITLE
Configure log tailer to poll for file changes

### DIFF
--- a/internal/logtailer/tailer.go
+++ b/internal/logtailer/tailer.go
@@ -213,6 +213,7 @@ func (t *logTailer) tailFile(seekTo *tail.SeekInfo) (err error) {
 		Location: seekTo,
 		ReOpen:   follow,
 		Follow:   follow,
+		Poll:     true,
 		Logger:   loggerAdaptor{},
 	})
 	if err != nil {


### PR DESCRIPTION
The ci race tests sometimes fail running the log tailer tests. I can only reproduce locally once every 30 runs or so. What appears to be happening is the upstream file tailer is not being informed when new lines are added. This PR changes the tailer config to enable polling the file. Many attempts to get the test to fail sees continued success. Let's see if this change improves ci and we can then take a view....

## QA steps

go test --race

