### PR TITLE
Replace mongo model config watcher with domain service for the pruner worker

### DIFF
--- a/cmd/jujud-controller/agent/model/manifolds.go
+++ b/cmd/jujud-controller/agent/model/manifolds.go
@@ -297,20 +297,22 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			Logger:        config.LoggingContext.GetLogger("juju.worker.cleaner"),
 		})),
 		statusHistoryPrunerName: ifNotMigrating(pruner.Manifold(pruner.ManifoldConfig{
-			APICallerName: apiCallerName,
-			Clock:         config.Clock,
-			NewWorker:     statushistorypruner.New,
-			NewClient:     statushistorypruner.NewClient,
-			PruneInterval: config.StatusHistoryPrunerInterval,
-			Logger:        config.LoggingContext.GetLogger("juju.worker.pruner.statushistory"),
+			APICallerName:      apiCallerName,
+			ServiceFactoryName: serviceFactoryName,
+			Clock:              config.Clock,
+			NewWorker:          statushistorypruner.New,
+			NewClient:          statushistorypruner.NewClient,
+			PruneInterval:      config.StatusHistoryPrunerInterval,
+			Logger:             config.LoggingContext.GetLogger("juju.worker.pruner.statushistory"),
 		})),
 		actionPrunerName: ifNotMigrating(pruner.Manifold(pruner.ManifoldConfig{
-			APICallerName: apiCallerName,
-			Clock:         config.Clock,
-			NewWorker:     actionpruner.New,
-			NewClient:     actionpruner.NewClient,
-			PruneInterval: config.ActionPrunerInterval,
-			Logger:        config.LoggingContext.GetLogger("juju.worker.pruner.action"),
+			APICallerName:      apiCallerName,
+			ServiceFactoryName: serviceFactoryName,
+			Clock:              config.Clock,
+			NewWorker:          actionpruner.New,
+			NewClient:          actionpruner.NewClient,
+			PruneInterval:      config.ActionPrunerInterval,
+			Logger:             config.LoggingContext.GetLogger("juju.worker.pruner.action"),
 		})),
 		// The provider upgrader runs on all controller agents, and
 		// unlocks the gate when the provider is up-to-date. The
@@ -660,6 +662,8 @@ const (
 	clockName            = "clock"
 	apiConfigWatcherName = "api-config-watcher"
 	apiCallerName        = "api-caller"
+
+	serviceFactoryName = "service-factory"
 
 	isResponsibleFlagName = "is-responsible-flag"
 	notDeadFlagName       = "not-dead-flag"

--- a/cmd/jujud-controller/agent/model/manifolds_test.go
+++ b/cmd/jujud-controller/agent/model/manifolds_test.go
@@ -217,6 +217,7 @@ var expectedCAASModelManifoldsWithDependencies = map[string][]string{
 		"not-dead-flag",
 		"provider-upgrade-gate",
 		"provider-upgraded-flag",
+		"service-factory",
 	},
 
 	"secrets-pruner": {
@@ -432,6 +433,7 @@ var expectedCAASModelManifoldsWithDependencies = map[string][]string{
 		"not-dead-flag",
 		"provider-upgrade-gate",
 		"provider-upgraded-flag",
+		"service-factory",
 	},
 
 	"undertaker": {
@@ -455,6 +457,7 @@ var expectedIAASModelManifoldsWithDependencies = map[string][]string{
 		"provider-upgrade-gate",
 		"provider-upgraded-flag",
 		"not-dead-flag",
+		"service-factory",
 	},
 
 	"secrets-pruner": {
@@ -685,6 +688,7 @@ var expectedIAASModelManifoldsWithDependencies = map[string][]string{
 		"provider-upgrade-gate",
 		"provider-upgraded-flag",
 		"not-dead-flag",
+		"service-factory",
 	},
 
 	"storage-provisioner": {

--- a/internal/worker/pruner/config.go
+++ b/internal/worker/pruner/config.go
@@ -17,10 +17,11 @@ type Logger interface {
 
 // Config holds all necessary attributes to start a pruner worker.
 type Config struct {
-	Facade        Facade
-	PruneInterval time.Duration
-	Clock         clock.Clock
-	Logger        Logger
+	Facade             Facade
+	ModelConfigService ModelConfigService
+	PruneInterval      time.Duration
+	Clock              clock.Clock
+	Logger             Logger
 }
 
 // Validate will err unless basic requirements for a valid
@@ -28,6 +29,9 @@ type Config struct {
 func (c *Config) Validate() error {
 	if c.Facade == nil {
 		return errors.New("missing Facade")
+	}
+	if c.ModelConfigService == nil {
+		return errors.New("missing ModelConfigService")
 	}
 	if c.Clock == nil {
 		return errors.New("missing Clock")

--- a/internal/worker/pruner/manifold_test.go
+++ b/internal/worker/pruner/manifold_test.go
@@ -36,11 +36,12 @@ func (s *ManifoldConfigSuite) SetUpTest(c *gc.C) {
 
 func (s *ManifoldConfigSuite) validConfig() pruner.ManifoldConfig {
 	return pruner.ManifoldConfig{
-		APICallerName: "api-caller",
-		Clock:         clock.WallClock,
-		NewWorker:     func(pruner.Config) (worker.Worker, error) { return nil, nil },
-		NewClient:     func(caller base.APICaller) pruner.Facade { return nil },
-		Logger:        loggo.GetLogger("test"),
+		APICallerName:      "api-caller",
+		ServiceFactoryName: "service-factory",
+		Clock:              clock.WallClock,
+		NewWorker:          func(pruner.Config) (worker.Worker, error) { return nil, nil },
+		NewClient:          func(caller base.APICaller) pruner.Facade { return nil },
+		Logger:             loggo.GetLogger("test"),
 	}
 }
 
@@ -51,6 +52,11 @@ func (s *ManifoldConfigSuite) TestValid(c *gc.C) {
 func (s *ManifoldConfigSuite) TestMissingAPICallerName(c *gc.C) {
 	s.config.APICallerName = ""
 	s.checkNotValid(c, "empty APICallerName not valid")
+}
+
+func (s *ManifoldConfigSuite) TestMissingServiceFactoryName(c *gc.C) {
+	s.config.ServiceFactoryName = ""
+	s.checkNotValid(c, "empty ServiceFactoryName not valid")
 }
 
 func (s *ManifoldConfigSuite) TestMissingClock(c *gc.C) {

--- a/internal/worker/pruner/mocks/mocks_facade.go
+++ b/internal/worker/pruner/mocks/mocks_facade.go
@@ -10,12 +10,9 @@
 package mocks
 
 import (
-	context "context"
 	reflect "reflect"
 	time "time"
 
-	watcher "github.com/juju/juju/core/watcher"
-	config "github.com/juju/juju/environs/config"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -42,21 +39,6 @@ func (m *MockFacade) EXPECT() *MockFacadeMockRecorder {
 	return m.recorder
 }
 
-// ModelConfig mocks base method.
-func (m *MockFacade) ModelConfig(arg0 context.Context) (*config.Config, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ModelConfig", arg0)
-	ret0, _ := ret[0].(*config.Config)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ModelConfig indicates an expected call of ModelConfig.
-func (mr *MockFacadeMockRecorder) ModelConfig(arg0 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModelConfig", reflect.TypeOf((*MockFacade)(nil).ModelConfig), arg0)
-}
-
 // Prune mocks base method.
 func (m *MockFacade) Prune(arg0 time.Duration, arg1 int) error {
 	m.ctrl.T.Helper()
@@ -69,19 +51,4 @@ func (m *MockFacade) Prune(arg0 time.Duration, arg1 int) error {
 func (mr *MockFacadeMockRecorder) Prune(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Prune", reflect.TypeOf((*MockFacade)(nil).Prune), arg0, arg1)
-}
-
-// WatchForModelConfigChanges mocks base method.
-func (m *MockFacade) WatchForModelConfigChanges() (watcher.Watcher[struct{}], error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchForModelConfigChanges")
-	ret0, _ := ret[0].(watcher.Watcher[struct{}])
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// WatchForModelConfigChanges indicates an expected call of WatchForModelConfigChanges.
-func (mr *MockFacadeMockRecorder) WatchForModelConfigChanges() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchForModelConfigChanges", reflect.TypeOf((*MockFacade)(nil).WatchForModelConfigChanges))
 }


### PR DESCRIPTION
The pruner worker is used by the actions pruner and status history pruner. Replace the mongo model config calls with the new service based implementation.

## QA steps

bootstrap and check engine report

**Jira card:** JUJU-5342

