### PR TITLE
Fix/lp 2064772

### DIFF
--- a/apiserver/facades/agent/secretsmanager/secrets_test.go
+++ b/apiserver/facades/agent/secretsmanager/secrets_test.go
@@ -938,7 +938,7 @@ func (s *SecretsManagerSuite) TestGetSecretContentForAppSecretUpdateLabelNotLead
 		Return(nil, errors.NotFoundf("secret consumer"))
 	s.secretsState.EXPECT().GetSecret(uri).Return(&coresecrets.SecretMetadata{LatestRevision: 668}, nil)
 	s.secretsConsumer.EXPECT().SaveSecretConsumer(
-		uri, names.NewUnitTag("mariadb/0"), &coresecrets.SecretConsumerMetadata{Label: "foo", LatestRevision: 668, CurrentRevision: 668}).Return(nil)
+		uri, names.NewUnitTag("mariadb/0"), &coresecrets.SecretConsumerMetadata{LatestRevision: 668, CurrentRevision: 668}).Return(nil)
 	s.secretsState.EXPECT().GetSecretValue(uri, 668).Return(
 		val, nil, nil,
 	)


### PR DESCRIPTION
This PR fixes a regression introduced in 3.3 recently.

So the problem described [here](https://bugs.launchpad.net/juju/+bug/2064772) is peer units created the consumer label `database-peers.mysql.app` for the application-owned secret, and then the leader unit tries to create the application label `database-peers.mysql.app`. Now Juju complains the label `database-peers.mysql.app` has already been used for a peer unit as the consumer label. Juju requires that the label has to be unique for both unit-owned and app-owned secrets.

This fix ensures that peer units should never have their own consumer labels for the application-owned secrets. Both leader and other peer units should just use the owner label to access the application-owned secrets. Obviously, the leader unit is responsible for setting the owner label.


## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

```
juju deploy mysql --config profile=testing -n 3
juju wait-for application mysql
juju run mysql/leader pre-upgrade-check
juju refresh mysql --channel 8.0/beta`
```

## Documentation changes

No

## Links

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2064772

**Jira card:** JUJU-5989

