### PR TITLE
Ensure we clear multiwatcher payload on send

### DIFF
--- a/core/watcher/watchertest/strings.go
+++ b/core/watcher/watchertest/strings.go
@@ -68,6 +68,19 @@ type StringsWatcherC struct {
 	Watcher watcher.StringsWatcher
 }
 
+// AssertOneChange fails if no change is sent before a long time has passed; or
+// if, subsequent to that, any further change is sent before a short time has
+// passed.
+func (c StringsWatcherC) AssertOneChange() {
+	select {
+	case _, ok := <-c.Watcher.Changes():
+		c.Assert(ok, jc.IsTrue)
+	case <-time.After(testing.LongWait):
+		c.Fatalf("watcher did not send change")
+	}
+	c.AssertNoChange()
+}
+
 // AssertChanges fails if it cannot read a value from Changes despite waiting a
 // long time. It logs, but does not check, the received changes; but will fail
 // if the Changes chan is closed.
@@ -80,6 +93,17 @@ func (c StringsWatcherC) AssertChanges() {
 		c.Fatalf("watcher did not send change")
 	}
 	c.AssertNoChange()
+}
+
+// AssertAtLeastOneChange fails if no change is sent before a long time has
+// passed.
+func (c StringsWatcherC) AssertAtLeastOneChange() {
+	select {
+	case _, ok := <-c.Watcher.Changes():
+		c.Assert(ok, jc.IsTrue)
+	case <-time.After(testing.LongWait):
+		c.Fatalf("watcher did not send change")
+	}
 }
 
 // AssertNoChange fails if it manages to read a value from Changes before a


### PR DESCRIPTION
When we send the payload we need to ensure that we clear the payload to the initial value, otherwise we'll build up the payload forever. This was done when we added the strings multiwatcher to the multiwatcher type.

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

The two tests that are impacted directly by this.

```
TEST_PACKAGES="./domain/network" TEST_FILTER="watcherSuite.TestWatchWithSubnetAssociation -count=100" make run-go-tests
TEST_PACKAGES="./domain/secret" TEST_FILTER="watcherSuite.TestWatchObsoleteForAppsAndUnitsOwned -count=10" make run-go-tests
```

## Links

**Jira card:** JUJU-

