### PR TITLE
Improve changestream pruner log output

### DIFF
--- a/internal/worker/changestreampruner/package_test.go
+++ b/internal/worker/changestreampruner/package_test.go
@@ -71,7 +71,11 @@ func (s *baseSuite) expectControllerDBGet() {
 }
 
 func (s *baseSuite) expectDBGet(namespace string, txnRunner coredatabase.TxnRunner) {
-	s.dbGetter.EXPECT().GetDB(namespace).Return(txnRunner, nil)
+	s.expectDBGetTimes(namespace, txnRunner, 1)
+}
+
+func (s *baseSuite) expectDBGetTimes(namespace string, txnRunner coredatabase.TxnRunner, amount int) {
+	s.dbGetter.EXPECT().GetDB(namespace).Return(txnRunner, nil).Times(amount)
 }
 
 func (s *baseSuite) expectAnyLogs(c *gc.C) {


### PR DESCRIPTION
The changestream pruner will log out if the changestream isn't keeping up with all the terms in the changestream. Unfortunately, if there aren't any writes going to the changestream it will still message out that it isn't keeping up. This isn't actually true. There just isn't enough changes being added to the changestream for the log message to be useful. Refactoring it to only log out if the window of changes has moved will then surface the real log messages.

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
$ juju bootstrap lxd test
$ juju debug-log -m controller
```

The warning log messages should no longer be emitted.


## Links

**Jira card:** JUJU-

