### PR TITLE
Service factory at model worker level

### DIFF
--- a/cmd/jujud-controller/agent/machine.go
+++ b/cmd/jujud-controller/agent/machine.go
@@ -1006,6 +1006,7 @@ func (a *MachineAgent) startModelWorkers(cfg modelworkermanager.NewModelConfig) 
 		NewEnvironFunc:               newEnvirons,
 		NewContainerBrokerFunc:       newCAASBroker,
 		NewMigrationMaster:           migrationmaster.NewWorker,
+		ServiceFactory:               cfg.ServiceFactory,
 		ProviderServiceFactoryGetter: cfg.ProviderServiceFactoryGetter,
 	}
 	if wrench.IsActive("charmrevision", "shortinterval") {

--- a/cmd/jujud-controller/agent/machine/manifolds.go
+++ b/cmd/jujud-controller/agent/machine/manifolds.go
@@ -715,6 +715,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			ModelMetrics:                    config.DependencyEngineMetrics,
 			Logger:                          loggo.GetLogger("juju.workers.modelworkermanager"),
 			GetProviderServiceFactoryGetter: modelworkermanager.GetProviderServiceFactoryGetter,
+			GetControllerConfig:             modelworkermanager.GetControllerConfig,
 		})),
 
 		peergrouperName: ifFullyUpgraded(peergrouper.Manifold(peergrouper.ManifoldConfig{

--- a/cmd/jujud-controller/agent/model/manifolds.go
+++ b/cmd/jujud-controller/agent/model/manifolds.go
@@ -24,6 +24,7 @@ import (
 	corelogger "github.com/juju/juju/core/logger"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/internal/pki"
+	"github.com/juju/juju/internal/servicefactory"
 	"github.com/juju/juju/internal/worker/actionpruner"
 	"github.com/juju/juju/internal/worker/agent"
 	"github.com/juju/juju/internal/worker/apicaller"
@@ -123,6 +124,9 @@ type ManifoldsConfig struct {
 
 	// ProviderServiceFactoryGetter is used to access the provider service.
 	ProviderServiceFactoryGetter modelworkermanager.ProviderServiceFactoryGetter
+
+	// ServiceFactory is used to access the service factory.
+	ServiceFactory servicefactory.ServiceFactory
 }
 
 // commonManifolds returns a set of interdependent dependency manifolds that will
@@ -158,6 +162,14 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		providerServiceFactoriesName: dependency.Manifold{
 			Start: func(_ context.Context, _ dependency.Getter) (worker.Worker, error) {
 				return engine.NewValueWorker(config.ProviderServiceFactoryGetter)
+			},
+			Output: engine.ValueWorkerOutput,
+		},
+
+		// ServiceFactory is used to access the service factory.
+		serviceFactoryName: dependency.Manifold{
+			Start: func(_ context.Context, _ dependency.Getter) (worker.Worker, error) {
+				return engine.NewValueWorker(config.ServiceFactory)
 			},
 			Output: engine.ValueWorkerOutput,
 		},
@@ -691,6 +703,7 @@ const (
 	loggingConfigUpdaterName     = "logging-config-updater"
 	instanceMutaterName          = "instance-mutater"
 	providerServiceFactoriesName = "provider-service-factories"
+	serviceFactoryName           = "service-factory"
 
 	caasFirewallerName             = "caas-firewaller"
 	caasModelOperatorName          = "caas-model-operator"

--- a/cmd/jujud-controller/agent/model/manifolds_test.go
+++ b/cmd/jujud-controller/agent/model/manifolds_test.go
@@ -63,6 +63,7 @@ func (s *ManifoldsSuite) TestIAASNames(c *gc.C) {
 		"provider-upgrader",
 		"remote-relations",
 		"secrets-pruner",
+		"service-factory",
 		"state-cleaner",
 		"status-history-pruner",
 		"storage-provisioner",
@@ -111,6 +112,7 @@ func (s *ManifoldsSuite) TestCAASNames(c *gc.C) {
 		"provider-upgrader",
 		"remote-relations",
 		"secrets-pruner",
+		"service-factory",
 		"state-cleaner",
 		"status-history-pruner",
 		"undertaker",
@@ -134,6 +136,7 @@ func (s *ManifoldsSuite) TestFlagDependencies(c *gc.C) {
 		"provider-upgrade-gate",
 		"provider-upgraded-flag",
 		"provider-upgrader",
+		"service-factory",
 		"valid-credential-flag",
 	)
 	manifolds := model.IAASManifolds(model.ManifoldsConfig{
@@ -412,6 +415,8 @@ var expectedCAASModelManifoldsWithDependencies = map[string][]string{
 		"provider-upgraded-flag",
 	},
 
+	"service-factory": {},
+
 	"state-cleaner": {
 		"agent",
 		"api-caller",
@@ -664,7 +669,10 @@ var expectedIAASModelManifoldsWithDependencies = map[string][]string{
 		"migration-inactive-flag",
 		"provider-upgrade-gate",
 		"provider-upgraded-flag",
-		"not-dead-flag"},
+		"not-dead-flag",
+	},
+
+	"service-factory": {},
 
 	"state-cleaner": {
 		"agent",


### PR DESCRIPTION
Push the service factory through the model worker manager. As we require the model config and ancillary services, we need the service factory available to us in the model workers. As the model workers are just hosted on the jujud-controller we can now just get at it directly. There is no longer an API barrier to cross.

We already do this for the provider service factory, so we can do the same here.

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

We just need to ensure we can create a model.

```
$ juju bootstrap lxd test
$ juju add-model default
```

## Links


**Jira card:** JUJU-

