### PR TITLE
Add dualwritehack worker that handles model concerns that need dual writing.

### DIFF
--- a/cmd/jujud-controller/agent/machine.go
+++ b/cmd/jujud-controller/agent/machine.go
@@ -1008,6 +1008,7 @@ func (a *MachineAgent) startModelWorkers(cfg modelworkermanager.NewModelConfig) 
 		NewMigrationMaster:           migrationmaster.NewWorker,
 		ServiceFactory:               cfg.ServiceFactory,
 		ProviderServiceFactoryGetter: cfg.ProviderServiceFactoryGetter,
+		StatePool:                    cfg.StatePool,
 	}
 	if wrench.IsActive("charmrevision", "shortinterval") {
 		interval := 10 * time.Second

--- a/cmd/jujud-controller/agent/model/manifolds_test.go
+++ b/cmd/jujud-controller/agent/model/manifolds_test.go
@@ -45,6 +45,7 @@ func (s *ManifoldsSuite) TestIAASNames(c *gc.C) {
 		"charm-revision-updater",
 		"clock",
 		"compute-provisioner",
+		"dual-write-hack-worker",
 		"firewaller",
 		"instance-mutater",
 		"instance-poller",
@@ -98,6 +99,7 @@ func (s *ManifoldsSuite) TestCAASNames(c *gc.C) {
 		"charm-downloader",
 		"charm-revision-updater",
 		"clock",
+		"dual-write-hack-worker",
 		"is-responsible-flag",
 		"logging-config-updater",
 		"migration-fortress",
@@ -449,6 +451,18 @@ var expectedCAASModelManifoldsWithDependencies = map[string][]string{
 	},
 
 	"valid-credential-flag": {"agent", "api-caller"},
+
+	"dual-write-hack-worker": {
+		"agent",
+		"api-caller",
+		"is-responsible-flag",
+		"migration-fortress",
+		"migration-inactive-flag",
+		"not-dead-flag",
+		"provider-upgrade-gate",
+		"provider-upgraded-flag",
+		"service-factory",
+	},
 }
 
 var expectedIAASModelManifoldsWithDependencies = map[string][]string{
@@ -731,4 +745,16 @@ var expectedIAASModelManifoldsWithDependencies = map[string][]string{
 		"not-dead-flag"},
 
 	"valid-credential-flag": {"agent", "api-caller"},
+
+	"dual-write-hack-worker": {
+		"agent",
+		"api-caller",
+		"is-responsible-flag",
+		"migration-fortress",
+		"migration-inactive-flag",
+		"not-dead-flag",
+		"provider-upgrade-gate",
+		"provider-upgraded-flag",
+		"service-factory",
+	},
 }

--- a/internal/worker/dualwritehack/config.go
+++ b/internal/worker/dualwritehack/config.go
@@ -1,0 +1,35 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package dualwritehack
+
+import (
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/internal/servicefactory"
+	"github.com/juju/juju/state"
+)
+
+// Logger defines the methods used by the dual write worker/
+type Logger interface {
+	Infof(string, ...interface{})
+}
+
+// Config holds all necessary attributes to start a dual write worker.
+type Config struct {
+	StatePool      *state.StatePool
+	ServiceFactory servicefactory.ServiceFactory
+	Logger         Logger
+}
+
+// Validate will err unless basic requirements for a valid
+// config are met.
+func (c *Config) Validate() error {
+	if c.ServiceFactory == nil {
+		return errors.New("missing ServiceFactory")
+	}
+	if c.Logger == nil {
+		return errors.New("missing Logger")
+	}
+	return nil
+}

--- a/internal/worker/dualwritehack/doc.go
+++ b/internal/worker/dualwritehack/doc.go
@@ -1,0 +1,8 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// This worker is where you put some ugly hacks to do eventually consistent
+// dual writing to mongo from dqlite. Don't write tests here, this is a best
+// effort to keep systems working while other systems are being rewritten as
+// services.
+package dualwritehack

--- a/internal/worker/dualwritehack/manifold.go
+++ b/internal/worker/dualwritehack/manifold.go
@@ -1,0 +1,67 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package dualwritehack
+
+import (
+	"context"
+
+	"github.com/juju/errors"
+	"github.com/juju/worker/v4"
+	"github.com/juju/worker/v4/dependency"
+
+	"github.com/juju/juju/internal/servicefactory"
+	"github.com/juju/juju/state"
+)
+
+// ManifoldConfig describes the resources and configuration on which the
+// dualwritehack worker depends.
+type ManifoldConfig struct {
+	ServiceFactoryName string
+	StatePool          *state.StatePool
+	Logger             Logger
+}
+
+// Validate is called by start to check for bad configuration.
+func (config ManifoldConfig) Validate() error {
+	if config.ServiceFactoryName == "" {
+		return errors.NotValidf("empty ServiceFactoryName")
+	}
+	if config.Logger == nil {
+		return errors.NotValidf("nil Logger")
+	}
+	return nil
+}
+
+// Manifold returns a Manifold that encapsulates the statushistorypruner worker.
+func Manifold(config ManifoldConfig) dependency.Manifold {
+	return dependency.Manifold{
+		Inputs: []string{
+			config.ServiceFactoryName,
+		},
+		Start: config.start,
+	}
+}
+
+// start is a StartFunc for a Worker manifold.
+func (config ManifoldConfig) start(context context.Context, getter dependency.Getter) (worker.Worker, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var serviceFactory servicefactory.ServiceFactory
+	if err := getter.Get(config.ServiceFactoryName, &serviceFactory); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	prunerConfig := Config{
+		StatePool:      config.StatePool,
+		ServiceFactory: serviceFactory,
+		Logger:         config.Logger,
+	}
+	w, err := NewWorker(prunerConfig)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return w, nil
+}

--- a/internal/worker/dualwritehack/no_test.go
+++ b/internal/worker/dualwritehack/no_test.go
@@ -1,0 +1,6 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package dualwritehack_test
+
+// No tests because this is an abomination to dual write stuff to mongo.

--- a/internal/worker/dualwritehack/worker.go
+++ b/internal/worker/dualwritehack/worker.go
@@ -1,0 +1,130 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package dualwritehack
+
+import (
+	"context"
+
+	"github.com/juju/errors"
+	"github.com/juju/worker/v4/catacomb"
+
+	"github.com/juju/juju/internal/worker"
+)
+
+// NewWorker returns a worker.Worker for DualWriteWorker.
+func NewWorker(config Config) (*DualWriteWorker, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+	w := &DualWriteWorker{
+		config: config,
+	}
+	err := catacomb.Invoke(catacomb.Plan{
+		Site: &w.catacomb,
+		Work: w.init,
+	})
+	return w, errors.Trace(err)
+}
+
+// DualWriteWorker prunes status history or action records at regular intervals.
+type DualWriteWorker struct {
+	catacomb catacomb.Catacomb
+	config   Config
+}
+
+// Kill is defined on worker.Worker.
+func (w *DualWriteWorker) Kill() {
+	w.catacomb.Kill(nil)
+}
+
+// Wait is defined on worker.Worker.
+func (w *DualWriteWorker) Wait() error {
+	return w.catacomb.Wait()
+}
+
+// Catacomb returns the prune worker's catacomb.
+func (w *DualWriteWorker) Catacomb() *catacomb.Catacomb {
+	return &w.catacomb
+}
+
+// Config return the prune worker's config.
+func (w *DualWriteWorker) Config() *Config {
+	return &w.config
+}
+
+func (w *DualWriteWorker) init() error {
+	if w.config.StatePool == nil {
+		w.config.Logger.Infof("no state pool, doing nothing")
+		<-w.catacomb.Dying()
+		return w.catacomb.ErrDying()
+	}
+
+	// Add your dual write workers here.
+	modelConfigDualWriteWorker := worker.NewSimpleWorker(w.ModelConfigDualWrite)
+	if err := w.catacomb.Add(modelConfigDualWriteWorker); err != nil {
+		return errors.Trace(err)
+	}
+	<-w.catacomb.Dying()
+	return w.catacomb.ErrDying()
+}
+
+// ModelConfigDualWrite is a worker that watches dqlite model config and smashes it into
+// mongo state model config.
+func (w *DualWriteWorker) ModelConfigDualWrite(stopCh <-chan struct{}) error {
+	ctx, cancel := w.scopedContext()
+	defer cancel()
+
+	modelConfigService := w.config.ServiceFactory.Config()
+	modelConfig, err := modelConfigService.ModelConfig(ctx)
+	if err != nil {
+		return errors.Annotate(err, "cannot load model configuration")
+	}
+
+	st, err := w.config.StatePool.Get(modelConfig.UUID())
+	if err != nil {
+		return errors.Trace(err)
+	}
+	defer st.Release()
+
+	m, err := st.Model()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	modelConfigWatcher, err := modelConfigService.Watch()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	defer modelConfigWatcher.Kill()
+
+	for {
+		select {
+		case <-stopCh:
+			return nil
+
+		case _, ok := <-modelConfigWatcher.Changes():
+			if !ok {
+				return errors.New("model configuration watcher closed")
+			}
+			modelConfig, err := modelConfigService.ModelConfig(ctx)
+			if err != nil {
+				return errors.Annotate(err, "cannot load model configuration from dqlite")
+			}
+			configToSmashIn := modelConfig.AllAttrs()
+			err = m.ForceUpdateModelConfigForDualWrite(configToSmashIn)
+			if err != nil {
+				return errors.Annotate(err, "cannot force write model config to state from dqlite")
+			}
+			w.config.Logger.Infof("updated model config in mongo")
+		}
+	}
+}
+
+// scopedContext returns a context that is in the scope of the worker lifetime.
+// It returns a cancellable context that is cancelled when the action has
+// completed.
+func (w *DualWriteWorker) scopedContext() (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(context.Background())
+	return w.catacomb.Context(ctx), cancel
+}

--- a/internal/worker/modelworkermanager/manifold.go
+++ b/internal/worker/modelworkermanager/manifold.go
@@ -185,6 +185,7 @@ func (config ManifoldConfig) start(context context.Context, getter dependency.Ge
 		ServiceFactoryGetter:         serviceFactoryGetter,
 		ProviderServiceFactoryGetter: providerServiceFactoryGetter,
 		GetControllerConfig:          config.GetControllerConfig,
+		StatePool:                    statePool,
 	})
 	if err != nil {
 		_ = stTracker.Done()

--- a/internal/worker/modelworkermanager/manifold_test.go
+++ b/internal/worker/modelworkermanager/manifold_test.go
@@ -163,7 +163,9 @@ func (s *ManifoldSuite) TestStart(c *gc.C) {
 	config.NewModelWorker = nil
 	config.GetControllerConfig = nil
 
-	c.Assert(config, jc.DeepEquals, modelworkermanager.Config{
+	mc := jc.NewMultiChecker()
+	mc.AddExpr("_.StatePool", jc.Ignore)
+	c.Assert(config, mc, modelworkermanager.Config{
 		Authority:    s.authority,
 		ModelWatcher: s.state,
 		ModelMetrics: dummyModelMetrics{},

--- a/internal/worker/modelworkermanager/modelworkermanager.go
+++ b/internal/worker/modelworkermanager/modelworkermanager.go
@@ -90,6 +90,9 @@ type NewModelConfig struct {
 	ControllerConfig             controller.Config
 	ProviderServiceFactoryGetter ProviderServiceFactoryGetter
 	ServiceFactory               servicefactory.ServiceFactory
+
+	// StatePool is for the dualwritehack worker, do not use for anything else.
+	StatePool *state.StatePool
 }
 
 // NewModelWorkerFunc should return a worker responsible for running
@@ -113,6 +116,9 @@ type Config struct {
 	ProviderServiceFactoryGetter ProviderServiceFactoryGetter
 	ServiceFactoryGetter         servicefactory.ServiceFactoryGetter
 	GetControllerConfig          GetControllerConfigFunc
+
+	// StatePool is for the dualwritehack worker, do not use for anything else.
+	StatePool *state.StatePool
 }
 
 // Validate returns an error if config cannot be expected to drive
@@ -256,6 +262,7 @@ func (m *modelWorkerManager) modelChanged(modelUUID string) error {
 		ModelUUID:    modelUUID,
 		ModelType:    model.Type(),
 		ModelMetrics: m.config.ModelMetrics.ForModel(names.NewModelTag(modelUUID)),
+		StatePool:    m.config.StatePool,
 	}
 	return errors.Trace(m.ensure(cfg))
 }
@@ -297,6 +304,9 @@ func (m *modelWorkerManager) starter(cfg NewModelConfig) func() (worker.Worker, 
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
+
+		// StatePool is for the dualwritehack worker, don't use it for anything else.
+		cfg.StatePool = m.config.StatePool
 
 		cfg.ModelLogger = newModelLogger(
 			"controller-"+m.config.MachineID,


### PR DESCRIPTION
This is a hack. A horrible hack. But it allows us to isolate dual writing concerns to a single model worker that has access to both the model servicefactory and state. That can be deleted when the time comes that we have no mongo.

This is an eventually consistent approach to dual writing.

First example is dual writing model config. It watches model config, and smashes the values into state. Simple.

## QA steps

- No unit tests because this should not live long, tests are integration tests.
- Bootstrap
- Change model config
- See that `juju.worker.dualwritehack updated model config in mongo` is in the logs.
- Probably something else to test.

## Documentation changes

Need to add this to the risk registry.

## Links

**Jira card:** JUJU-

