### PR TITLE
Deprecate series in bundles

### DIFF
--- a/cmd/juju/application/bundle/bundle_test.go
+++ b/cmd/juju/application/bundle/bundle_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/juju/charm/v11"
+	"github.com/juju/cmd/v3"
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"go.uber.org/mock/gomock"
@@ -215,8 +216,10 @@ func (s *composeAndVerifyRepSuite) TestComposeAndVerifyBundleNoOverlay(c *gc.C) 
 	c.Assert(err, jc.ErrorIsNil)
 	s.expectParts(&charm.BundleDataPart{Data: bundleData})
 	s.expectBasePath()
+	ctx, err := cmd.DefaultContext()
+	c.Assert(err, jc.ErrorIsNil)
 
-	obtained, _, err := ComposeAndVerifyBundle(s.bundleDataSource, nil)
+	obtained, _, err := ComposeAndVerifyBundle(ctx, s.bundleDataSource, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(obtained, gc.DeepEquals, bundleData)
 }
@@ -228,13 +231,15 @@ func (s *composeAndVerifyRepSuite) TestComposeAndVerifyBundleOverlay(c *gc.C) {
 	s.expectParts(&charm.BundleDataPart{Data: bundleData})
 	s.expectBasePath()
 	s.setupOverlayFile(c)
+	ctx, err := cmd.DefaultContext()
+	c.Assert(err, jc.ErrorIsNil)
 
 	expected := *bundleData
 	expected.Applications["wordpress"].Options = map[string]interface{}{
 		"blog-title": "magic bundle config",
 	}
 
-	obtained, _, err := ComposeAndVerifyBundle(s.bundleDataSource, []string{s.overlayFile})
+	obtained, _, err := ComposeAndVerifyBundle(ctx, s.bundleDataSource, []string{s.overlayFile})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(obtained, gc.DeepEquals, &expected)
 }
@@ -250,13 +255,15 @@ func (s *composeAndVerifyRepSuite) TestComposeAndVerifyBundleOverlayUnmarshallEr
 	})
 	s.expectBasePath()
 	s.setupOverlayFile(c)
+	ctx, err := cmd.DefaultContext()
+	c.Assert(err, jc.ErrorIsNil)
 
 	expected := *bundleData
 	expected.Applications["wordpress"].Options = map[string]interface{}{
 		"blog-title": "magic bundle config",
 	}
 
-	obtained, unmarshallErrors, err := ComposeAndVerifyBundle(s.bundleDataSource, []string{s.overlayFile})
+	obtained, unmarshallErrors, err := ComposeAndVerifyBundle(ctx, s.bundleDataSource, []string{s.overlayFile})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(obtained, gc.DeepEquals, &expected)
 	c.Assert(unmarshallErrors, gc.HasLen, 1)
@@ -269,8 +276,10 @@ func (s *composeAndVerifyRepSuite) TestComposeAndVerifyBundleMixingBaseAndSeries
 	c.Assert(err, jc.ErrorIsNil)
 	s.expectParts(&charm.BundleDataPart{Data: bundleData})
 	s.expectBasePath()
+	ctx, err := cmd.DefaultContext()
+	c.Assert(err, jc.ErrorIsNil)
 
-	obtained, _, err := ComposeAndVerifyBundle(s.bundleDataSource, nil)
+	obtained, _, err := ComposeAndVerifyBundle(ctx, s.bundleDataSource, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(obtained, gc.DeepEquals, bundleData)
 }
@@ -281,8 +290,10 @@ func (s *composeAndVerifyRepSuite) TestComposeAndVerifyBundleMixingBaseAndSeries
 	c.Assert(err, jc.ErrorIsNil)
 	s.expectParts(&charm.BundleDataPart{Data: bundleData})
 	s.expectBasePath()
+	ctx, err := cmd.DefaultContext()
+	c.Assert(err, jc.ErrorIsNil)
 
-	obtained, _, err := ComposeAndVerifyBundle(s.bundleDataSource, nil)
+	obtained, _, err := ComposeAndVerifyBundle(ctx, s.bundleDataSource, nil)
 	c.Assert(err, gc.ErrorMatches, `(?s)the provided bundle has the following errors:.*application "wordpress" series "jammy" and base "ubuntu@20.04" must match if both supplied.*invalid constraints.*`)
 	c.Assert(obtained, gc.IsNil)
 }

--- a/cmd/juju/application/deployer/bundle.go
+++ b/cmd/juju/application/deployer/bundle.go
@@ -93,7 +93,7 @@ func (d *deployBundle) deploy(
 
 	// Compose bundle to be deployed and check its validity before running
 	// any pre/post checks.
-	bundleData, unmarshalErrors, err := bundle.ComposeAndVerifyBundle(d.bundleDataSource, d.bundleOverlayFile)
+	bundleData, unmarshalErrors, err := bundle.ComposeAndVerifyBundle(ctx, d.bundleDataSource, d.bundleOverlayFile)
 	if err != nil {
 		return errors.Annotatef(err, "cannot deploy bundle")
 	}

--- a/cmd/juju/application/diffbundle.go
+++ b/cmd/juju/application/diffbundle.go
@@ -229,7 +229,7 @@ func (c *diffBundleCommand) Run(ctx *cmd.Context) error {
 		return errors.Trace(err)
 	}
 
-	bundle, _, err := appbundle.ComposeAndVerifyBundle(baseSrc, c.bundleOverlays)
+	bundle, _, err := appbundle.ComposeAndVerifyBundle(ctx, baseSrc, c.bundleOverlays)
 	if err != nil {
 		return errors.Trace(err)
 	}


### PR DESCRIPTION
Show a deprecation warning when deploying a bundle with series

We are deprecating series in favour of base in general. In Juju 4.0 we will error out if a bundle provides a base. This change in in preparation for this later breaking change

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Deploy some bundles

```
$ cat ./bundle.yaml
series: focal
applications:
  ubuntu:
    charm: ubuntu
    num_units: 1
    to:
    - "0"
machines:
  "0":

$ juju deploy ./bundle.yaml
WARNING series in being deprecated in favour of bases. For more information about the transition to bases see https://discourse.charmhub.io/t/transition-from-series-to-base-in-juju-4-0/14127
...
```

```
$ cat bundle.yaml 
applications:
  ubuntu:
    series: focal
    charm: ubuntu
    num_units: 1
    to:
    - "0"
machines:
  "0":
    base: ubuntu@20.04

$ juju deploy ./bundle.yaml
WARNING series in being deprecated in favour of bases. For more information about the transition to bases see https://discourse.charmhub.io/t/transition-from-series-to-base-in-juju-4-0/14127
...
```

```
$ cat bundle.yaml 
applications:
  ubuntu:
    base: ubuntu@20.04
    charm: ubuntu
    num_units: 1
    to:
    - "0"
machines:
  "0":
    series: focal

$ juju deploy ./bundle.yaml
WARNING series in being deprecated in favour of bases. For more information about the transition to bases see https://discourse.charmhub.io/t/transition-from-series-to-base-in-juju-4-0/14127
...
```

```
$ cat ./bundle.yaml
series: focal
default-base: ubuntu@20.04
applications:
  ubuntu:
    charm: ubuntu
    num_units: 1
    to:
    - "0"
machines:
  "0":

$ juju deploy ./bundle.yaml
WARNING series in being deprecated in favour of bases. For more information about the transition to bases see https://discourse.charmhub.io/t/transition-from-series-to-base-in-juju-4-0/14127
...
```

```
default-base: ubuntu@20.04
applications:
  ubuntu:
    charm: ubuntu
    num_units: 1
    to:
    - "0"
machines:
  "0":

$ juju deploy ./bundle.yaml
...
```

```
$ juju deploy charmed-kubernetes
Located bundle "charmed-kubernetes" in charm-hub, revision 1243
WARNING series in being deprecated in favour of bases. For more information about the transition to bases see https://discourse.charmhub.io/t/transition-from-series-to-base-in-juju-4-0/14127
...
```

## Links

**Jira card:** [JUJU-5596](https://warthogs.atlassian.net/browse/JUJU-5996)

[JUJU-5596]: https://warthogs.atlassian.net/browse/JUJU-5596?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ