### PR TITLE
Construct secret backend service without passing in controller uuid or provider registry

### DIFF
--- a/apiserver/facades/agent/secretsdrain/register.go
+++ b/apiserver/facades/agent/secretsdrain/register.go
@@ -39,7 +39,7 @@ func newSecretsDrainAPI(ctx facade.ModelContext) (*commonsecrets.SecretsDrainAPI
 	modelUUID := coremodel.UUID(model.UUID())
 	authTag := ctx.Auth().GetAuthTag()
 
-	secretBackendService := ctx.ServiceFactory().SecretBackend(model.ControllerUUID(), provider.Provider)
+	secretBackendService := ctx.ServiceFactory().SecretBackend()
 	secretBackendAdminConfigGetter := func(stdCtx context.Context) (*provider.ModelBackendConfigInfo, error) {
 		return secretBackendService.GetSecretBackendConfigForAdmin(stdCtx, modelUUID)
 	}

--- a/apiserver/facades/agent/secretsmanager/register.go
+++ b/apiserver/facades/agent/secretsmanager/register.go
@@ -47,7 +47,7 @@ func NewSecretManagerAPI(stdCtx context.Context, ctx facade.ModelContext) (*Secr
 		return nil, errors.Trace(err)
 	}
 
-	backendService := serviceFactory.SecretBackend(model.ControllerUUID(), provider.Provider)
+	backendService := serviceFactory.SecretBackend()
 	secretBackendAdminConfigGetter := func(stdCtx context.Context) (*provider.ModelBackendConfigInfo, error) {
 		return backendService.GetSecretBackendConfigForAdmin(stdCtx, coremodel.UUID(model.UUID()))
 	}

--- a/apiserver/facades/agent/uniter/register.go
+++ b/apiserver/facades/agent/uniter/register.go
@@ -32,7 +32,7 @@ func newUniterAPI(_ context.Context, ctx facade.ModelContext) (*UniterAPI, error
 		return nil, errors.Trace(err)
 	}
 	serviceFactory := ctx.ServiceFactory()
-	secretBackendService := serviceFactory.SecretBackend(m.ControllerUUID(), provider.Provider)
+	secretBackendService := serviceFactory.SecretBackend()
 	secretBackendAdminConfigGetter := func(stdCtx context.Context) (*provider.ModelBackendConfigInfo, error) {
 		return secretBackendService.GetSecretBackendConfigForAdmin(stdCtx, model.UUID(m.UUID()))
 	}

--- a/apiserver/facades/client/modelconfig/register.go
+++ b/apiserver/facades/client/modelconfig/register.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/environs"
-	"github.com/juju/juju/internal/secrets/provider"
 )
 
 // Register is called to expose a package of facades onto a given registry.
@@ -31,7 +30,7 @@ func newFacadeV3(ctx facade.ModelContext) (*ModelConfigAPIV3, error) {
 	}
 
 	serviceFactory := ctx.ServiceFactory()
-	backendService := serviceFactory.SecretBackend(model.ControllerUUID(), provider.Provider)
+	backendService := serviceFactory.SecretBackend()
 
 	configService := serviceFactory.Config()
 	configSchemaSourceGetter := environs.ProviderConfigSchemaSource(ctx.ServiceFactory().Cloud())

--- a/apiserver/facades/client/modelmanager/register.go
+++ b/apiserver/facades/client/modelmanager/register.go
@@ -15,7 +15,6 @@ import (
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/environs"
-	"github.com/juju/juju/internal/secrets/provider"
 	"github.com/juju/juju/internal/uuid"
 	"github.com/juju/juju/state/stateenvirons"
 )
@@ -83,7 +82,7 @@ func newFacadeV10(ctx facade.MultiModelContext) (*ModelManagerAPI, error) {
 	apiUser, _ := auth.GetAuthTag().(names.UserTag)
 	backend := common.NewUserAwareModelManagerBackend(configSchemaSource, model, pool, apiUser)
 
-	secretBackendService := serviceFactory.SecretBackend(model.ControllerUUID(), provider.Provider)
+	secretBackendService := serviceFactory.SecretBackend()
 	return NewModelManagerAPI(
 		backend.(StateBackend),
 		ctx.ModelExporter(backend),

--- a/apiserver/facades/client/secretbackends/register.go
+++ b/apiserver/facades/client/secretbackends/register.go
@@ -9,7 +9,6 @@ import (
 
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facade"
-	"github.com/juju/juju/internal/secrets/provider"
 )
 
 // Register is called to expose a package of facades onto a given registry.
@@ -24,12 +23,8 @@ func newSecretBackendsAPI(context facade.ModelContext) (*SecretBackendsAPI, erro
 	if !context.Auth().AuthClient() {
 		return nil, apiservererrors.ErrPerm
 	}
-	model, err := context.State().Model()
-	if err != nil {
-		return nil, err
-	}
 	serviceFactory := context.ServiceFactory()
-	secretBackendService := serviceFactory.SecretBackend(model.ControllerUUID(), provider.Provider)
+	secretBackendService := serviceFactory.SecretBackend()
 	return &SecretBackendsAPI{
 		authorizer:     context.Auth(),
 		controllerUUID: context.State().ControllerUUID(),

--- a/apiserver/facades/client/secrets/register.go
+++ b/apiserver/facades/client/secrets/register.go
@@ -44,7 +44,7 @@ func newSecretsAPI(context facade.ModelContext) (*SecretsAPI, error) {
 		return nil, errors.Trace(err)
 	}
 	serviceFactory := context.ServiceFactory()
-	backendService := serviceFactory.SecretBackend(model.ControllerUUID(), provider.Provider)
+	backendService := serviceFactory.SecretBackend()
 	adminBackendConfigGetter := func(ctx stdcontext.Context) (*provider.ModelBackendConfigInfo, error) {
 		return backendService.GetSecretBackendConfigForAdmin(
 			ctx, coremodel.UUID(model.UUID()),

--- a/apiserver/facades/controller/crossmodelsecrets/register.go
+++ b/apiserver/facades/controller/crossmodelsecrets/register.go
@@ -35,7 +35,7 @@ func newStateCrossModelSecretsAPI(stdCtx context.Context, ctx facade.MultiModelC
 	}
 	serviceFactory := ctx.ServiceFactory()
 
-	backendService := serviceFactory.SecretBackend(model.ControllerUUID(), provider.Provider)
+	backendService := serviceFactory.SecretBackend()
 	secretBackendAdminConfigGetter := func(stdCtx context.Context) (*provider.ModelBackendConfigInfo, error) {
 		return backendService.GetSecretBackendConfigForAdmin(stdCtx, coremodel.UUID(model.UUID()))
 	}

--- a/apiserver/facades/controller/migrationtarget/servicefactory_mock_test.go
+++ b/apiserver/facades/controller/migrationtarget/servicefactory_mock_test.go
@@ -380,17 +380,17 @@ func (mr *MockServiceFactoryMockRecorder) Secret(arg0 any) *gomock.Call {
 }
 
 // SecretBackend mocks base method.
-func (m *MockServiceFactory) SecretBackend(arg0 string, arg1 service17.SecretProviderRegistry) *service17.WatchableService {
+func (m *MockServiceFactory) SecretBackend() *service17.WatchableService {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SecretBackend", arg0, arg1)
+	ret := m.ctrl.Call(m, "SecretBackend")
 	ret0, _ := ret[0].(*service17.WatchableService)
 	return ret0
 }
 
 // SecretBackend indicates an expected call of SecretBackend.
-func (mr *MockServiceFactoryMockRecorder) SecretBackend(arg0, arg1 any) *gomock.Call {
+func (mr *MockServiceFactoryMockRecorder) SecretBackend() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SecretBackend", reflect.TypeOf((*MockServiceFactory)(nil).SecretBackend), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SecretBackend", reflect.TypeOf((*MockServiceFactory)(nil).SecretBackend))
 }
 
 // Storage mocks base method.

--- a/apiserver/facades/controller/secretbackendmanager/register.go
+++ b/apiserver/facades/controller/secretbackendmanager/register.go
@@ -8,11 +8,9 @@ import (
 	"reflect"
 
 	"github.com/juju/clock"
-	"github.com/juju/errors"
 
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facade"
-	"github.com/juju/juju/internal/secrets/provider"
 )
 
 // Register is called to expose a package of facades onto a given registry.
@@ -27,12 +25,8 @@ func NewSecretBackendsManagerAPI(ctx facade.ModelContext) (*SecretBackendsManage
 	if !ctx.Auth().AuthController() {
 		return nil, apiservererrors.ErrPerm
 	}
-	model, err := ctx.State().Model()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
 	serviceFactory := ctx.ServiceFactory()
-	backendService := serviceFactory.SecretBackend(model.ControllerUUID(), provider.Provider)
+	backendService := serviceFactory.SecretBackend()
 	return &SecretBackendsManagerAPI{
 		watcherRegistry: ctx.WatcherRegistry(),
 		backendService:  backendService,

--- a/apiserver/facades/controller/undertaker/register.go
+++ b/apiserver/facades/controller/undertaker/register.go
@@ -12,7 +12,6 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/common/cloudspec"
 	"github.com/juju/juju/apiserver/facade"
-	"github.com/juju/juju/internal/secrets/provider"
 )
 
 // Register is called to expose a package of facades onto a given registry.
@@ -32,7 +31,7 @@ func newUndertakerFacade(ctx facade.ModelContext) (*UndertakerAPI, error) {
 	serviceFactory := ctx.ServiceFactory()
 	cloudService := serviceFactory.Cloud()
 	credentialService := serviceFactory.Credential()
-	backendService := serviceFactory.SecretBackend(model.ControllerUUID(), provider.Provider)
+	backendService := serviceFactory.SecretBackend()
 	cloudSpecAPI := cloudspec.NewCloudSpec(
 		ctx.Resources(),
 		cloudspec.MakeCloudSpecGetterForModel(st, cloudService, credentialService),

--- a/apiserver/facades/controller/usersecrets/register.go
+++ b/apiserver/facades/controller/usersecrets/register.go
@@ -33,7 +33,7 @@ func NewUserSecretsManager(ctx facade.ModelContext) (*UserSecretsManager, error)
 	}
 
 	serviceFactory := ctx.ServiceFactory()
-	backendService := serviceFactory.SecretBackend(model.ControllerUUID(), provider.Provider)
+	backendService := serviceFactory.SecretBackend()
 	backendConfigGetter := func(ctx stdcontext.Context) (*provider.ModelBackendConfigInfo, error) {
 		return backendService.GetSecretBackendConfigForAdmin(ctx, coremodel.UUID(model.UUID()))
 	}

--- a/apiserver/facades/controller/usersecretsdrain/register.go
+++ b/apiserver/facades/controller/usersecretsdrain/register.go
@@ -38,7 +38,7 @@ func newUserSecretsDrainAPI(context facade.ModelContext) (*SecretsDrainAPI, erro
 	}
 	modelUUID := coremodel.UUID(model.UUID())
 	serviceFactory := context.ServiceFactory()
-	backendService := serviceFactory.SecretBackend(model.ControllerUUID(), provider.Provider)
+	backendService := serviceFactory.SecretBackend()
 
 	secretBackendAdminConfigGetter := func(stdCtx stdcontext.Context) (*provider.ModelBackendConfigInfo, error) {
 		return backendService.GetSecretBackendConfigForAdmin(stdCtx, modelUUID)

--- a/domain/schema/secret.go
+++ b/domain/schema/secret.go
@@ -77,6 +77,7 @@ CREATE TABLE model_secret_backend (
 
 CREATE VIEW v_model_secret_backend AS
 SELECT
+    (SELECT value FROM controller_config WHERE key='controller-uuid') AS controller_uuid,
     m.uuid,
     m.name,
     mt.type AS model_type,

--- a/domain/secretbackend/service/service.go
+++ b/domain/secretbackend/service/service.go
@@ -37,25 +37,22 @@ import (
 type SecretProviderRegistry func(backendType string) (provider.SecretBackendProvider, error)
 
 type Service struct {
-	st             State
-	logger         Logger
-	clock          clock.Clock
-	controllerUUID string
-	registry       SecretProviderRegistry
+	st       State
+	logger   Logger
+	clock    clock.Clock
+	registry SecretProviderRegistry
 }
 
 func newService(
 	st State, logger Logger,
-	controllerUUID string,
 	clk clock.Clock,
 	registry SecretProviderRegistry,
 ) *Service {
 	return &Service{
-		st:             st,
-		logger:         logger,
-		controllerUUID: controllerUUID,
-		clock:          clk,
-		registry:       registry,
+		st:       st,
+		logger:   logger,
+		clock:    clk,
+		registry: registry,
 	}
 }
 
@@ -97,7 +94,7 @@ func (s *Service) GetSecretBackendConfigForAdmin(ctx context.Context, modelUUID 
 			}
 		}
 		info.Configs[b.ID] = provider.ModelBackendConfig{
-			ControllerUUID: s.controllerUUID,
+			ControllerUUID: m.ControllerUUID,
 			ModelUUID:      m.ID.String(),
 			ModelName:      m.Name,
 			BackendConfig: provider.BackendConfig{
@@ -752,28 +749,24 @@ type WatchableService struct {
 func NewWatchableService(
 	st State, logger Logger,
 	wf WatcherFactory,
-	controllerUUID string,
-	registry SecretProviderRegistry,
 ) *WatchableService {
 	return newWatchableService(
-		st, logger, wf, controllerUUID, clock.WallClock, registry,
+		st, logger, wf, clock.WallClock, provider.Provider,
 	)
 }
 
 func newWatchableService(
 	st State, logger Logger,
 	wf WatcherFactory,
-	controllerUUID string,
 	clk clock.Clock,
 	registry SecretProviderRegistry,
 ) *WatchableService {
 	return &WatchableService{
 		Service: Service{
-			st:             st,
-			logger:         logger,
-			controllerUUID: controllerUUID,
-			clock:          clk,
-			registry:       registry,
+			st:       st,
+			logger:   logger,
+			clock:    clk,
+			registry: registry,
 		},
 		watcherFactory: wf,
 	}

--- a/domain/secretbackend/service/service_test.go
+++ b/domain/secretbackend/service/service_test.go
@@ -190,6 +190,7 @@ func (s *serviceSuite) expectGetSecretBackendConfigForAdminDefault(
 	s.mockState.EXPECT().ListSecretBackendsForModel(gomock.Any(), modelUUID, true).Return(append(builtIn, backends...), nil)
 	s.mockState.EXPECT().GetModelSecretBackendDetails(gomock.Any(), modelUUID).
 		Return(secretbackend.ModelSecretBackend{
+			ControllerUUID:  jujutesting.ControllerTag.Id(),
 			ID:              modelUUID,
 			Name:            "fred",
 			Type:            coremodel.ModelType(modelType),
@@ -223,7 +224,7 @@ func (s *serviceSuite) assertGetSecretBackendConfigForAdminDefault(
 func (s *serviceSuite) TestGetSecretBackendConfigForAdminInternalIAAS(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	svc := newService(
-		s.mockState, s.logger, jujutesting.ControllerTag.Id(), s.clock,
+		s.mockState, s.logger, s.clock,
 		func(backendType string) (provider.SecretBackendProvider, error) {
 			c.Assert(backendType, gc.Equals, "vault")
 			return s.mockRegistry, nil
@@ -243,7 +244,7 @@ func (s *serviceSuite) TestGetSecretBackendConfigForAdminInternalIAAS(c *gc.C) {
 func (s *serviceSuite) TestGetSecretBackendConfigForAdminInternalCAAS(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	svc := newService(
-		s.mockState, s.logger, jujutesting.ControllerTag.Id(), s.clock,
+		s.mockState, s.logger, s.clock,
 		func(backendType string) (provider.SecretBackendProvider, error) {
 			c.Assert(backendType, gc.Equals, "vault")
 			return s.mockRegistry, nil
@@ -263,7 +264,7 @@ func (s *serviceSuite) TestGetSecretBackendConfigForAdminInternalCAAS(c *gc.C) {
 func (s *serviceSuite) TestGetSecretBackendConfigForAdminExternalIAAS(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	svc := newService(
-		s.mockState, s.logger, jujutesting.ControllerTag.Id(), s.clock,
+		s.mockState, s.logger, s.clock,
 		func(backendType string) (provider.SecretBackendProvider, error) {
 			c.Assert(backendType, gc.Equals, "vault")
 			return s.mockRegistry, nil
@@ -283,7 +284,7 @@ func (s *serviceSuite) TestGetSecretBackendConfigForAdminExternalIAAS(c *gc.C) {
 func (s *serviceSuite) TestGetSecretBackendConfigForAdminExternalCAAS(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	svc := newService(
-		s.mockState, s.logger, jujutesting.ControllerTag.Id(), s.clock,
+		s.mockState, s.logger, s.clock,
 		func(backendType string) (provider.SecretBackendProvider, error) {
 			c.Assert(backendType, gc.Equals, "vault")
 			return s.mockRegistry, nil
@@ -396,7 +397,7 @@ func (s *serviceSuite) assertBackendSummaryInfo(
 func (s *serviceSuite) TestBackendSummaryInfoWithFilterAllCAAS(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	svc := newService(
-		s.mockState, s.logger, jujutesting.ControllerTag.Id(), s.clock,
+		s.mockState, s.logger, s.clock,
 		func(backendType string) (provider.SecretBackendProvider, error) {
 			if backendType != vault.BackendType {
 				return s.mockRegistry, nil
@@ -454,7 +455,7 @@ func (s *serviceSuite) TestBackendSummaryInfoWithFilterAllCAAS(c *gc.C) {
 func (s *serviceSuite) TestBackendSummaryInfoWithFilterAllIAAS(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	svc := newService(
-		s.mockState, s.logger, jujutesting.ControllerTag.Id(), s.clock,
+		s.mockState, s.logger, s.clock,
 		func(backendType string) (provider.SecretBackendProvider, error) {
 			if backendType != vault.BackendType {
 				return s.mockRegistry, nil
@@ -506,7 +507,7 @@ func (s *serviceSuite) TestBackendSummaryInfoWithFilterAllIAAS(c *gc.C) {
 func (s *serviceSuite) TestBackendSummaryInfoWithFilterNames(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	svc := newService(
-		s.mockState, s.logger, jujutesting.ControllerTag.Id(), s.clock,
+		s.mockState, s.logger, s.clock,
 		func(backendType string) (provider.SecretBackendProvider, error) {
 			if backendType != vault.BackendType {
 				return s.mockRegistry, nil
@@ -539,7 +540,7 @@ func (s *serviceSuite) TestBackendSummaryInfoWithFilterNames(c *gc.C) {
 func (s *serviceSuite) TestBackendSummaryInfoWithFilterNamesNotFound(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	svc := newService(
-		s.mockState, s.logger, jujutesting.ControllerTag.Id(), s.clock,
+		s.mockState, s.logger, s.clock,
 		func(backendType string) (provider.SecretBackendProvider, error) {
 			if backendType != vault.BackendType {
 				return s.mockRegistry, nil
@@ -559,7 +560,7 @@ func (s *serviceSuite) TestBackendSummaryInfoWithFilterNamesNotFound(c *gc.C) {
 func (s *serviceSuite) TestPingSecretBackend(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	svc := newService(
-		s.mockState, s.logger, jujutesting.ControllerTag.Id(), s.clock,
+		s.mockState, s.logger, s.clock,
 		func(backendType string) (provider.SecretBackendProvider, error) {
 			c.Assert(backendType, gc.Equals, "vault")
 			return s.mockRegistry, nil
@@ -591,7 +592,7 @@ func (s *serviceSuite) TestPingSecretBackend(c *gc.C) {
 func (s *serviceSuite) TestCreateSecretBackendFailed(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	svc := newService(
-		s.mockState, s.logger, jujutesting.ControllerTag.Id(), s.clock,
+		s.mockState, s.logger, s.clock,
 		func(backendType string) (provider.SecretBackendProvider, error) {
 			c.Assert(backendType, gc.Equals, "something")
 			return providerWithConfig{
@@ -637,7 +638,7 @@ func (s *serviceSuite) TestCreateSecretBackendFailed(c *gc.C) {
 func (s *serviceSuite) TestCreateSecretBackend(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	svc := newService(
-		s.mockState, s.logger, jujutesting.ControllerTag.Id(), s.clock,
+		s.mockState, s.logger, s.clock,
 		func(backendType string) (provider.SecretBackendProvider, error) {
 			c.Assert(backendType, gc.Equals, "vault")
 			return providerWithConfig{
@@ -684,7 +685,7 @@ func (s *serviceSuite) TestCreateSecretBackend(c *gc.C) {
 func (s *serviceSuite) TestUpdateSecretBackendFailed(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	svc := newService(
-		s.mockState, s.logger, jujutesting.ControllerTag.Id(), s.clock,
+		s.mockState, s.logger, s.clock,
 		func(backendType string) (provider.SecretBackendProvider, error) {
 			return providerWithConfig{
 				SecretBackendProvider: s.mockRegistry,
@@ -730,7 +731,7 @@ func (s *serviceSuite) TestUpdateSecretBackendFailed(c *gc.C) {
 func (s *serviceSuite) assertUpdateSecretBackend(c *gc.C, byName, skipPing bool) {
 	defer s.setupMocks(c).Finish()
 	svc := newService(
-		s.mockState, s.logger, jujutesting.ControllerTag.Id(), s.clock,
+		s.mockState, s.logger, s.clock,
 		func(backendType string) (provider.SecretBackendProvider, error) {
 			c.Assert(backendType, gc.Equals, "vault")
 			return providerWithConfig{
@@ -820,7 +821,7 @@ func (s *serviceSuite) TestUpdateSecretBackendWithForceByName(c *gc.C) {
 func (s *serviceSuite) TestDeleteSecretBackend(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	svc := newService(
-		s.mockState, s.logger, jujutesting.ControllerTag.Id(), s.clock,
+		s.mockState, s.logger, s.clock,
 		func(backendType string) (provider.SecretBackendProvider, error) {
 			return providerWithConfig{
 				SecretBackendProvider: s.mockRegistry,
@@ -838,7 +839,7 @@ func (s *serviceSuite) TestDeleteSecretBackend(c *gc.C) {
 func (s *serviceSuite) TestGetSecretBackendByName(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	svc := newService(
-		s.mockState, s.logger, jujutesting.ControllerTag.Id(), s.clock,
+		s.mockState, s.logger, s.clock,
 		func(backendType string) (provider.SecretBackendProvider, error) {
 			return providerWithConfig{
 				SecretBackendProvider: s.mockRegistry,
@@ -860,7 +861,7 @@ func (s *serviceSuite) TestGetSecretBackendByName(c *gc.C) {
 func (s *serviceSuite) TestRotateBackendToken(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	svc := newService(
-		s.mockState, s.logger, jujutesting.ControllerTag.Id(), s.clock,
+		s.mockState, s.logger, s.clock,
 		func(backendType string) (provider.SecretBackendProvider, error) {
 			return providerWithConfig{
 				SecretBackendProvider: s.mockRegistry,
@@ -898,7 +899,7 @@ func (s *serviceSuite) TestRotateBackendToken(c *gc.C) {
 func (s *serviceSuite) TestRotateBackendTokenRetry(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	svc := newService(
-		s.mockState, s.logger, jujutesting.ControllerTag.Id(), s.clock,
+		s.mockState, s.logger, s.clock,
 		func(backendType string) (provider.SecretBackendProvider, error) {
 			return providerWithConfig{
 				SecretBackendProvider: s.mockRegistry,
@@ -943,7 +944,7 @@ func (s *serviceSuite) TestWatchSecretBackendRotationChanges(c *gc.C) {
 	nextRotateTime2 := time.Now().Add(24 * time.Hour)
 
 	svc := newWatchableService(
-		s.mockState, s.logger, s.mockWatcherFactory, jujutesting.ControllerTag.Id(), s.clock,
+		s.mockState, s.logger, s.mockWatcherFactory, s.clock,
 		func(backendType string) (provider.SecretBackendProvider, error) {
 			return providerWithConfig{
 				SecretBackendProvider: s.mockRegistry,
@@ -1005,7 +1006,7 @@ func (s *serviceSuite) TestWatchSecretBackendRotationChanges(c *gc.C) {
 func (s *serviceSuite) assertGetSecretsToDrain(c *gc.C, backendID string, expectedRevisions ...RevisionInfo) {
 	defer s.setupMocks(c).Finish()
 	svc := newService(
-		s.mockState, s.logger, jujutesting.ControllerTag.Id(), s.clock,
+		s.mockState, s.logger, s.clock,
 		func(backendType string) (provider.SecretBackendProvider, error) {
 			if backendType != vault.BackendType {
 				return s.mockRegistry, nil
@@ -1121,7 +1122,7 @@ func (s *serviceSuite) assertBackendConfigInfoLeaderUnit(c *gc.C, wanted []strin
 	defer ctrl.Finish()
 
 	svc := newService(
-		s.mockState, s.logger, jujutesting.ControllerTag.Id(), s.clock,
+		s.mockState, s.logger, s.clock,
 		func(backendType string) (provider.SecretBackendProvider, error) {
 			if backendType != vault.BackendType {
 				return s.mockRegistry, nil
@@ -1235,7 +1236,7 @@ func (s *serviceSuite) TestBackendConfigInfoNonLeaderUnit(c *gc.C) {
 	defer ctrl.Finish()
 
 	svc := newService(
-		s.mockState, s.logger, jujutesting.ControllerTag.Id(), s.clock,
+		s.mockState, s.logger, s.clock,
 		func(backendType string) (provider.SecretBackendProvider, error) {
 			if backendType != vault.BackendType {
 				return s.mockRegistry, nil
@@ -1355,7 +1356,7 @@ func (s *serviceSuite) TestDrainBackendConfigInfo(c *gc.C) {
 	defer ctrl.Finish()
 
 	svc := newService(
-		s.mockState, s.logger, jujutesting.ControllerTag.Id(), s.clock,
+		s.mockState, s.logger, s.clock,
 		func(backendType string) (provider.SecretBackendProvider, error) {
 			if backendType != vault.BackendType {
 				return s.mockRegistry, nil
@@ -1474,7 +1475,7 @@ func (s *serviceSuite) TestBackendConfigInfoFailedInvalidAccessor(c *gc.C) {
 	defer ctrl.Finish()
 
 	svc := newService(
-		s.mockState, s.logger, jujutesting.ControllerTag.Id(), s.clock,
+		s.mockState, s.logger, s.clock,
 		func(backendType string) (provider.SecretBackendProvider, error) {
 			if backendType != vault.BackendType {
 				return s.mockRegistry, nil

--- a/domain/secretbackend/state/state.go
+++ b/domain/secretbackend/state/state.go
@@ -81,6 +81,7 @@ WHERE  uuid = $M.uuid`, sqlair.M{}, ModelSecretBackend{})
 		return secretbackend.ModelSecretBackend{}, fmt.Errorf("invalid model type for model %q", m.Name)
 	}
 	return secretbackend.ModelSecretBackend{
+		ControllerUUID:  m.ControllerUUID,
 		ID:              m.ID,
 		Name:            m.Name,
 		Type:            m.Type,

--- a/domain/secretbackend/state/types.go
+++ b/domain/secretbackend/state/types.go
@@ -21,6 +21,8 @@ import (
 
 // ModelSecretBackend represents a set of data about a model and its current secret backend config.
 type ModelSecretBackend struct {
+	// ControllerUUID is the UUID of the controller.
+	ControllerUUID string `db:"controller_uuid"`
 	// ID is the unique identifier for the model.
 	ID coremodel.UUID `db:"uuid"`
 	// Name is the name of the model.

--- a/domain/secretbackend/types.go
+++ b/domain/secretbackend/types.go
@@ -9,6 +9,8 @@ import (
 
 // ModelSecretBackend represents a set of data about a model and its secret backend config.
 type ModelSecretBackend struct {
+	// ControllerUUID is the uuid of the controller.
+	ControllerUUID string
 	// ID is the unique identifier for the model.
 	ID coremodel.UUID
 	// Name is the name of the model.

--- a/domain/secretbackend/watcher_test.go
+++ b/domain/secretbackend/watcher_test.go
@@ -39,7 +39,6 @@ func (s *watcherSuite) TestWatchSecretBackendRotationChanges(c *gc.C) {
 	svc := service.NewWatchableService(
 		state, logger,
 		domain.NewWatcherFactory(factory, logger),
-		testing.ControllerTag.Id(), nil,
 	)
 
 	watcher, err := svc.WatchSecretBackendRotationChanges()

--- a/domain/servicefactory/controller.go
+++ b/domain/servicefactory/controller.go
@@ -177,10 +177,7 @@ func (s *ControllerFactory) Access() *accessservice.Service {
 	)
 }
 
-func (s *ControllerFactory) SecretBackend(
-	controllerUUID string,
-	registry secretbackendservice.SecretProviderRegistry,
-) *secretbackendservice.WatchableService {
+func (s *ControllerFactory) SecretBackend() *secretbackendservice.WatchableService {
 	logger := s.logger.Child("secretbackend")
 	state := secretbackendstate.NewState(
 		changestream.NewTxnRunnerFactory(s.controllerDB),
@@ -193,6 +190,5 @@ func (s *ControllerFactory) SecretBackend(
 			s.controllerDB,
 			s.logger.Child("watcherfactory"),
 		),
-		controllerUUID, registry,
 	)
 }

--- a/domain/servicefactory/testing/service.go
+++ b/domain/servicefactory/testing/service.go
@@ -160,10 +160,7 @@ func (s *TestingServiceFactory) BlockDevice() *blockdeviceservice.WatchableServi
 }
 
 // SecretBackend returns the secret backend service.
-func (s *TestingServiceFactory) SecretBackend(
-	controllerUUID string,
-	registry secretbackendservice.SecretProviderRegistry,
-) *secretbackendservice.WatchableService {
+func (s *TestingServiceFactory) SecretBackend() *secretbackendservice.WatchableService {
 	return nil
 }
 

--- a/internal/migration/servicefactory_mock_test.go
+++ b/internal/migration/servicefactory_mock_test.go
@@ -380,17 +380,17 @@ func (mr *MockServiceFactoryMockRecorder) Secret(arg0 any) *gomock.Call {
 }
 
 // SecretBackend mocks base method.
-func (m *MockServiceFactory) SecretBackend(arg0 string, arg1 service17.SecretProviderRegistry) *service17.WatchableService {
+func (m *MockServiceFactory) SecretBackend() *service17.WatchableService {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SecretBackend", arg0, arg1)
+	ret := m.ctrl.Call(m, "SecretBackend")
 	ret0, _ := ret[0].(*service17.WatchableService)
 	return ret0
 }
 
 // SecretBackend indicates an expected call of SecretBackend.
-func (mr *MockServiceFactoryMockRecorder) SecretBackend(arg0, arg1 any) *gomock.Call {
+func (mr *MockServiceFactoryMockRecorder) SecretBackend() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SecretBackend", reflect.TypeOf((*MockServiceFactory)(nil).SecretBackend), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SecretBackend", reflect.TypeOf((*MockServiceFactory)(nil).SecretBackend))
 }
 
 // Storage mocks base method.

--- a/internal/servicefactory/interface.go
+++ b/internal/servicefactory/interface.go
@@ -60,9 +60,7 @@ type ControllerServiceFactory interface {
 	// controller.
 	Access() *accessservice.Service
 	// SecretBackend returns the secret backend service.
-	SecretBackend(
-		controllerUUID string, registry secretbackendservice.SecretProviderRegistry,
-	) *secretbackendservice.WatchableService
+	SecretBackend() *secretbackendservice.WatchableService
 }
 
 // ModelServiceFactory provides access to the services required by the

--- a/internal/worker/peergrouper/service_mock_test.go
+++ b/internal/worker/peergrouper/service_mock_test.go
@@ -206,17 +206,17 @@ func (mr *MockControllerServiceFactoryMockRecorder) ModelDefaults() *gomock.Call
 }
 
 // SecretBackend mocks base method.
-func (m *MockControllerServiceFactory) SecretBackend(arg0 string, arg1 service10.SecretProviderRegistry) *service10.WatchableService {
+func (m *MockControllerServiceFactory) SecretBackend() *service10.WatchableService {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SecretBackend", arg0, arg1)
+	ret := m.ctrl.Call(m, "SecretBackend")
 	ret0, _ := ret[0].(*service10.WatchableService)
 	return ret0
 }
 
 // SecretBackend indicates an expected call of SecretBackend.
-func (mr *MockControllerServiceFactoryMockRecorder) SecretBackend(arg0, arg1 any) *gomock.Call {
+func (mr *MockControllerServiceFactoryMockRecorder) SecretBackend() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SecretBackend", reflect.TypeOf((*MockControllerServiceFactory)(nil).SecretBackend), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SecretBackend", reflect.TypeOf((*MockControllerServiceFactory)(nil).SecretBackend))
 }
 
 // Upgrade mocks base method.

--- a/internal/worker/servicefactory/servicefactory_mock_test.go
+++ b/internal/worker/servicefactory/servicefactory_mock_test.go
@@ -217,17 +217,17 @@ func (mr *MockControllerServiceFactoryMockRecorder) ModelDefaults() *gomock.Call
 }
 
 // SecretBackend mocks base method.
-func (m *MockControllerServiceFactory) SecretBackend(arg0 string, arg1 service17.SecretProviderRegistry) *service17.WatchableService {
+func (m *MockControllerServiceFactory) SecretBackend() *service17.WatchableService {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SecretBackend", arg0, arg1)
+	ret := m.ctrl.Call(m, "SecretBackend")
 	ret0, _ := ret[0].(*service17.WatchableService)
 	return ret0
 }
 
 // SecretBackend indicates an expected call of SecretBackend.
-func (mr *MockControllerServiceFactoryMockRecorder) SecretBackend(arg0, arg1 any) *gomock.Call {
+func (mr *MockControllerServiceFactoryMockRecorder) SecretBackend() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SecretBackend", reflect.TypeOf((*MockControllerServiceFactory)(nil).SecretBackend), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SecretBackend", reflect.TypeOf((*MockControllerServiceFactory)(nil).SecretBackend))
 }
 
 // Upgrade mocks base method.
@@ -725,17 +725,17 @@ func (mr *MockServiceFactoryMockRecorder) Secret(arg0 any) *gomock.Call {
 }
 
 // SecretBackend mocks base method.
-func (m *MockServiceFactory) SecretBackend(arg0 string, arg1 service17.SecretProviderRegistry) *service17.WatchableService {
+func (m *MockServiceFactory) SecretBackend() *service17.WatchableService {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SecretBackend", arg0, arg1)
+	ret := m.ctrl.Call(m, "SecretBackend")
 	ret0, _ := ret[0].(*service17.WatchableService)
 	return ret0
 }
 
 // SecretBackend indicates an expected call of SecretBackend.
-func (mr *MockServiceFactoryMockRecorder) SecretBackend(arg0, arg1 any) *gomock.Call {
+func (mr *MockServiceFactoryMockRecorder) SecretBackend() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SecretBackend", reflect.TypeOf((*MockServiceFactory)(nil).SecretBackend), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SecretBackend", reflect.TypeOf((*MockServiceFactory)(nil).SecretBackend))
 }
 
 // Storage mocks base method.

--- a/internal/worker/upgradedatabase/servicefactory_mock_test.go
+++ b/internal/worker/upgradedatabase/servicefactory_mock_test.go
@@ -206,17 +206,17 @@ func (mr *MockControllerServiceFactoryMockRecorder) ModelDefaults() *gomock.Call
 }
 
 // SecretBackend mocks base method.
-func (m *MockControllerServiceFactory) SecretBackend(arg0 string, arg1 service10.SecretProviderRegistry) *service10.WatchableService {
+func (m *MockControllerServiceFactory) SecretBackend() *service10.WatchableService {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SecretBackend", arg0, arg1)
+	ret := m.ctrl.Call(m, "SecretBackend")
 	ret0, _ := ret[0].(*service10.WatchableService)
 	return ret0
 }
 
 // SecretBackend indicates an expected call of SecretBackend.
-func (mr *MockControllerServiceFactoryMockRecorder) SecretBackend(arg0, arg1 any) *gomock.Call {
+func (mr *MockControllerServiceFactoryMockRecorder) SecretBackend() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SecretBackend", reflect.TypeOf((*MockControllerServiceFactory)(nil).SecretBackend), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SecretBackend", reflect.TypeOf((*MockControllerServiceFactory)(nil).SecretBackend))
 }
 
 // Upgrade mocks base method.


### PR DESCRIPTION
The secret backend service needs the controller uuid. This was being passed in via the constructor, however it can be obtained from the controller config. So the state query which reads the backend info now includes getting the controller uuid.

Also, the backend provider registry was being passed in as well. We don't need to do that anymore.

## QA steps

Run the secrets_k8s bash ci tests.

## Links

**Jira card:**[ JUJU-5997](https://warthogs.atlassian.net/browse/JUJU-5997)

