### PR TITLE
Remove last controller config watcher

### DIFF
--- a/apiserver/facades/controller/caasapplicationprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/provisioner_test.go
@@ -24,6 +24,7 @@ import (
 	jujuresource "github.com/juju/juju/core/resources"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/watcher/eventsource"
+	"github.com/juju/juju/core/watcher/watchertest"
 	envconfig "github.com/juju/juju/environs/config"
 	"github.com/juju/juju/internal/docker"
 	"github.com/juju/juju/rpc/params"
@@ -163,9 +164,9 @@ func (s *CAASApplicationProvisionerSuite) TestWatchProvisioningInfo(c *gc.C) {
 	appChanged := make(chan struct{}, 1)
 	portsChanged := make(chan struct{}, 1)
 	modelConfigChanged := make(chan struct{}, 1)
-	controllerConfigChanged := make(chan struct{}, 1)
+	controllerConfigChanged := make(chan []string, 1)
 	s.st.apiHostPortsForAgentsWatcher = statetesting.NewMockNotifyWatcher(portsChanged)
-	s.st.model.state.controllerConfigWatcher = statetesting.NewMockNotifyWatcher(controllerConfigChanged)
+	s.controllerConfigService.controllerConfigWatcher = watchertest.NewMockStringsWatcher(controllerConfigChanged)
 	s.st.model.modelConfigChanges = statetesting.NewMockNotifyWatcher(modelConfigChanged)
 	s.st.app = &mockApplication{
 		life: state.Alive,
@@ -178,7 +179,7 @@ func (s *CAASApplicationProvisionerSuite) TestWatchProvisioningInfo(c *gc.C) {
 	appChanged <- struct{}{}
 	portsChanged <- struct{}{}
 	modelConfigChanged <- struct{}{}
-	controllerConfigChanged <- struct{}{}
+	controllerConfigChanged <- []string{}
 
 	results, err := s.api.WatchProvisioningInfo(context.Background(), params.Entities{
 		Entities: []params.Entity{

--- a/apiserver/facades/controller/caasapplicationprovisioner/state.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/state.go
@@ -41,7 +41,6 @@ type CAASApplicationControllerState interface {
 	ModelUUID() string
 	APIHostPortsForAgents(controller.Config) ([]network.SpaceHostPorts, error)
 	WatchAPIHostPortsForAgents() state.NotifyWatcher
-	WatchControllerConfig() state.NotifyWatcher
 }
 
 type Model interface {

--- a/internal/worker/peergrouper/mock_test.go
+++ b/internal/worker/peergrouper/mock_test.go
@@ -230,10 +230,6 @@ func (st *fakeState) WatchControllerStatusChanges() state.StringsWatcher {
 	return WatchStrings(&st.statuses)
 }
 
-func (st *fakeState) WatchControllerConfig() state.NotifyWatcher {
-	return WatchValue(&st.controllerConfig)
-}
-
 func (st *fakeState) ModelConfig() (*config.Config, error) {
 	attrs := coretesting.FakeConfig()
 	cfg, err := config.New(config.NoDefaults, attrs)

--- a/state/settings.go
+++ b/state/settings.go
@@ -488,12 +488,6 @@ func (st *State) NewSettings() *StateSettings {
 	return &StateSettings{st, settingsC}
 }
 
-// NewControllerSettings returns a new StateSettings reference for working with
-// controller settings in the current database.
-func (st *State) NewControllerSettings() *StateSettings {
-	return &StateSettings{st, controllersC}
-}
-
 // NewStateSettings creates a StateSettings from a modelBackend (e.g. State).
 // TODO (manadart 2020-01-21): Usage of this method should be phased out in
 // favour of NewSettings, above.

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -1965,11 +1965,6 @@ func (st *State) WatchControllerInfo() StringsWatcher {
 	return newCollectionWatcher(st, colWCfg{col: controllerNodesC})
 }
 
-// WatchControllerConfig returns a NotifyWatcher for controller settings.
-func (st *State) WatchControllerConfig() NotifyWatcher {
-	return newEntityWatcher(st, controllersC, ControllerSettingsGlobalKey)
-}
-
 // Watch returns a watcher for observing changes to a controller service.
 func (c *CloudService) Watch() NotifyWatcher {
 	return newEntityWatcher(c.st, cloudServicesC, c.doc.DocID)


### PR DESCRIPTION
I noticed this controller config watcher was still hanging around, this should have been removed. It's the last piece of the puzzle.

There should be no controller config watchers any more.

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
$ juju bootstrap microk8s test
$ juju add-model default
$ juju deploy prometheus-k8s
```

## Links

**Jira card:** JUJU-

