### PR TITLE
Implement SecretRotated service call

### DIFF
--- a/domain/secret/service/service.go
+++ b/domain/secret/service/service.go
@@ -361,6 +361,15 @@ func (s *SecretService) UpdateCharmSecret(ctx context.Context, uri *secrets.URI,
 	}
 	rotatePolicy := domainsecret.MarshallRotatePolicy(params.RotatePolicy)
 	p.RotatePolicy = &rotatePolicy
+	if params.RotatePolicy.WillRotate() {
+		md, err := s.GetSecret(ctx, uri)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if !md.RotatePolicy.WillRotate() {
+			p.NextRotateTime = params.RotatePolicy.NextRotateTime(s.clock.Now())
+		}
+	}
 	if len(params.Data) > 0 {
 		p.Data = make(map[string]string)
 		for k, v := range params.Data {

--- a/domain/secret/service/service.go
+++ b/domain/secret/service/service.go
@@ -366,10 +366,10 @@ func (s *SecretService) UpdateCharmSecret(ctx context.Context, uri *secrets.URI,
 	p.RotatePolicy = &rotatePolicy
 	if params.RotatePolicy.WillRotate() {
 		policy, err := s.st.GetRotatePolicy(ctx, uri)
-		if err != nil && !errors.Is(err, secreterrors.SecretNotFound) {
+		if err != nil {
 			return errors.Trace(err)
 		}
-		if errors.Is(err, secreterrors.SecretNotFound) || !policy.WillRotate() {
+		if !policy.WillRotate() {
 			p.NextRotateTime = params.RotatePolicy.NextRotateTime(s.clock.Now())
 		}
 	}

--- a/domain/secret/service/service_test.go
+++ b/domain/secret/service/service_test.go
@@ -409,7 +409,7 @@ func (s *serviceSuite) TestUpdateCharmSecret(c *gc.C) {
 	}).Return("manage", nil)
 	s.state.EXPECT().GetRotatePolicy(gomock.Any(), uri).Return(
 		coresecrets.RotateNever, // No rotate policy.
-		secreterrors.SecretNotFound)
+		nil)
 	s.state.EXPECT().UpdateSecret(gomock.Any(), uri, gomock.Any()).DoAndReturn(func(_ context.Context, _ *coresecrets.URI, got domainsecret.UpsertSecretParams) error {
 		c.Assert(got.NextRotateTime, gc.NotNil)
 		c.Assert(*got.NextRotateTime, jc.Almost, *p.NextRotateTime)

--- a/domain/secret/service/service_test.go
+++ b/domain/secret/service/service_test.go
@@ -1102,7 +1102,7 @@ func (s *serviceSuite) TestSecretsRotated(c *gc.C) {
 		LatestRevision: 667,
 	}, nil)
 
-	err := s.service().SecretRotated(ctx, uri, SecretRotatedParams{
+	err := s.service(c).SecretRotated(ctx, uri, SecretRotatedParams{
 		LeaderToken: successfulToken{},
 		Accessor: SecretAccessor{
 			Kind: UnitAccessor,
@@ -1131,7 +1131,7 @@ func (s *serviceSuite) TestSecretsRotatedRetry(c *gc.C) {
 		LatestRevision: 666,
 	}, nil)
 
-	err := s.service().SecretRotated(ctx, uri, SecretRotatedParams{
+	err := s.service(c).SecretRotated(ctx, uri, SecretRotatedParams{
 		LeaderToken: successfulToken{},
 		Accessor: SecretAccessor{
 			Kind: UnitAccessor,
@@ -1161,7 +1161,7 @@ func (s *serviceSuite) TestSecretsRotatedForce(c *gc.C) {
 		LatestRevision:   667,
 	}, nil)
 
-	err := s.service().SecretRotated(ctx, uri, SecretRotatedParams{
+	err := s.service(c).SecretRotated(ctx, uri, SecretRotatedParams{
 		LeaderToken: successfulToken{},
 		Accessor: SecretAccessor{
 			Kind: UnitAccessor,
@@ -1188,7 +1188,7 @@ func (s *serviceSuite) TestSecretsRotatedThenNever(c *gc.C) {
 		LatestRevision: 667,
 	}, nil)
 
-	err := s.service().SecretRotated(ctx, uri, SecretRotatedParams{
+	err := s.service(c).SecretRotated(ctx, uri, SecretRotatedParams{
 		LeaderToken: successfulToken{},
 		Accessor: SecretAccessor{
 			Kind: UnitAccessor,

--- a/domain/secret/service/state_mock_test.go
+++ b/domain/secret/service/state_mock_test.go
@@ -410,6 +410,36 @@ func (c *MockStateGetRevisionIDsForObsoleteCall) DoAndReturn(f func(context.Cont
 	return c
 }
 
+// GetRotatePolicy mocks base method.
+func (m *MockState) GetRotatePolicy(arg0 context.Context, arg1 *secrets.URI) (secrets.RotatePolicy, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRotatePolicy", arg0, arg1)
+	ret0, _ := ret[0].(secrets.RotatePolicy)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRotatePolicy indicates an expected call of GetRotatePolicy.
+func (mr *MockStateMockRecorder) GetRotatePolicy(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRotatePolicy", reflect.TypeOf((*MockState)(nil).GetRotatePolicy), arg0, arg1)
+}
+
+// GetRotationExpiryInfo mocks base method.
+func (m *MockState) GetRotationExpiryInfo(arg0 context.Context, arg1 *secrets.URI) (*secret.RotationExpiryInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRotationExpiryInfo", arg0, arg1)
+	ret0, _ := ret[0].(*secret.RotationExpiryInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRotationExpiryInfo indicates an expected call of GetRotationExpiryInfo.
+func (mr *MockStateMockRecorder) GetRotationExpiryInfo(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRotationExpiryInfo", reflect.TypeOf((*MockState)(nil).GetRotationExpiryInfo), arg0, arg1)
+}
+
 // GetSecret mocks base method.
 func (m *MockState) GetSecret(arg0 context.Context, arg1 *secrets.URI) (*secrets.SecretMetadata, error) {
 	m.ctrl.T.Helper()

--- a/domain/secret/service/state_mock_test.go
+++ b/domain/secret/service/state_mock_test.go
@@ -420,9 +420,33 @@ func (m *MockState) GetRotatePolicy(arg0 context.Context, arg1 *secrets.URI) (se
 }
 
 // GetRotatePolicy indicates an expected call of GetRotatePolicy.
-func (mr *MockStateMockRecorder) GetRotatePolicy(arg0, arg1 any) *gomock.Call {
+func (mr *MockStateMockRecorder) GetRotatePolicy(arg0, arg1 any) *MockStateGetRotatePolicyCall {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRotatePolicy", reflect.TypeOf((*MockState)(nil).GetRotatePolicy), arg0, arg1)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRotatePolicy", reflect.TypeOf((*MockState)(nil).GetRotatePolicy), arg0, arg1)
+	return &MockStateGetRotatePolicyCall{Call: call}
+}
+
+// MockStateGetRotatePolicyCall wrap *gomock.Call
+type MockStateGetRotatePolicyCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateGetRotatePolicyCall) Return(arg0 secrets.RotatePolicy, arg1 error) *MockStateGetRotatePolicyCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateGetRotatePolicyCall) Do(f func(context.Context, *secrets.URI) (secrets.RotatePolicy, error)) *MockStateGetRotatePolicyCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateGetRotatePolicyCall) DoAndReturn(f func(context.Context, *secrets.URI) (secrets.RotatePolicy, error)) *MockStateGetRotatePolicyCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
 }
 
 // GetRotationExpiryInfo mocks base method.
@@ -435,9 +459,33 @@ func (m *MockState) GetRotationExpiryInfo(arg0 context.Context, arg1 *secrets.UR
 }
 
 // GetRotationExpiryInfo indicates an expected call of GetRotationExpiryInfo.
-func (mr *MockStateMockRecorder) GetRotationExpiryInfo(arg0, arg1 any) *gomock.Call {
+func (mr *MockStateMockRecorder) GetRotationExpiryInfo(arg0, arg1 any) *MockStateGetRotationExpiryInfoCall {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRotationExpiryInfo", reflect.TypeOf((*MockState)(nil).GetRotationExpiryInfo), arg0, arg1)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRotationExpiryInfo", reflect.TypeOf((*MockState)(nil).GetRotationExpiryInfo), arg0, arg1)
+	return &MockStateGetRotationExpiryInfoCall{Call: call}
+}
+
+// MockStateGetRotationExpiryInfoCall wrap *gomock.Call
+type MockStateGetRotationExpiryInfoCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateGetRotationExpiryInfoCall) Return(arg0 *secret.RotationExpiryInfo, arg1 error) *MockStateGetRotationExpiryInfoCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateGetRotationExpiryInfoCall) Do(f func(context.Context, *secrets.URI) (*secret.RotationExpiryInfo, error)) *MockStateGetRotationExpiryInfoCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateGetRotationExpiryInfoCall) DoAndReturn(f func(context.Context, *secrets.URI) (*secret.RotationExpiryInfo, error)) *MockStateGetRotationExpiryInfoCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
 }
 
 // GetSecret mocks base method.
@@ -1352,9 +1400,33 @@ func (m *MockState) SecretRotated(arg0 context.Context, arg1 *secrets.URI, arg2 
 }
 
 // SecretRotated indicates an expected call of SecretRotated.
-func (mr *MockStateMockRecorder) SecretRotated(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockStateMockRecorder) SecretRotated(arg0, arg1, arg2 any) *MockStateSecretRotatedCall {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SecretRotated", reflect.TypeOf((*MockState)(nil).SecretRotated), arg0, arg1, arg2)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SecretRotated", reflect.TypeOf((*MockState)(nil).SecretRotated), arg0, arg1, arg2)
+	return &MockStateSecretRotatedCall{Call: call}
+}
+
+// MockStateSecretRotatedCall wrap *gomock.Call
+type MockStateSecretRotatedCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateSecretRotatedCall) Return(arg0 error) *MockStateSecretRotatedCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateSecretRotatedCall) Do(f func(context.Context, *secrets.URI, time.Time) error) *MockStateSecretRotatedCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateSecretRotatedCall) DoAndReturn(f func(context.Context, *secrets.URI, time.Time) error) *MockStateSecretRotatedCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
 }
 
 // UpdateRemoteSecretRevision mocks base method.

--- a/domain/secret/service/state_mock_test.go
+++ b/domain/secret/service/state_mock_test.go
@@ -12,6 +12,7 @@ package service
 import (
 	context "context"
 	reflect "reflect"
+	time "time"
 
 	secrets "github.com/juju/juju/core/secrets"
 	eventsource "github.com/juju/juju/core/watcher/eventsource"
@@ -1310,6 +1311,20 @@ func (c *MockStateSaveSecretRemoteConsumerCall) Do(f func(context.Context, *secr
 func (c *MockStateSaveSecretRemoteConsumerCall) DoAndReturn(f func(context.Context, *secrets.URI, string, *secrets.SecretConsumerMetadata) error) *MockStateSaveSecretRemoteConsumerCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
+}
+
+// SecretRotated mocks base method.
+func (m *MockState) SecretRotated(arg0 context.Context, arg1 *secrets.URI, arg2 time.Time) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SecretRotated", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SecretRotated indicates an expected call of SecretRotated.
+func (mr *MockStateMockRecorder) SecretRotated(arg0, arg1, arg2 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SecretRotated", reflect.TypeOf((*MockState)(nil).SecretRotated), arg0, arg1, arg2)
 }
 
 // UpdateRemoteSecretRevision mocks base method.

--- a/domain/secret/state/types.go
+++ b/domain/secret/state/types.go
@@ -197,9 +197,9 @@ var ownerKindParam = ownerKind{
 	Application: string(coresecrets.ApplicationOwner),
 }
 
-type secrets []secretInfo
+type secretInfos []secretInfo
 
-func (rows secrets) toSecretMetadata(secretOwners []secretOwner) ([]*coresecrets.SecretMetadata, error) {
+func (rows secretInfos) toSecretMetadata(secretOwners []secretOwner) ([]*coresecrets.SecretMetadata, error) {
 	if len(rows) != len(secretOwners) {
 		// Should never happen.
 		return nil, errors.New("row length mismatch composing secret results")
@@ -236,7 +236,7 @@ func (rows secrets) toSecretMetadata(secretOwners []secretOwner) ([]*coresecrets
 	return result, nil
 }
 
-func (rows secrets) toSecretRevisionRef(refs secretValueRefs) ([]*coresecrets.SecretRevisionRef, error) {
+func (rows secretInfos) toSecretRevisionRef(refs secretValueRefs) ([]*coresecrets.SecretRevisionRef, error) {
 	if len(rows) != len(refs) {
 		// Should never happen.
 		return nil, errors.New("row length mismatch composing secret results")

--- a/domain/secret/types.go
+++ b/domain/secret/types.go
@@ -73,3 +73,15 @@ type AccessScope struct {
 	ScopeTypeID GrantScopeType
 	ScopeID     string
 }
+
+// RotationExpiryInfo holds information about the rotation and expiry of a secret.
+type RotationExpiryInfo struct {
+	// RotatePolicy is the rotation policy of the secret.
+	RotatePolicy secrets.RotatePolicy
+	// NextRotateTime is when the secret should be rotated.
+	NextRotateTime *time.Time
+	// LatestExpireTime is the expire time of the most recent revision.
+	LatestExpireTime *time.Time
+	// LatestRevision is the most recent secret revision.
+	LatestRevision int
+}


### PR DESCRIPTION
This PR implements a secret rotated service and state methods to ensure the next rotation time for the provided secret stored in the Dqlite database.
Driveby: 
1. fixed the missing next rotation time update in SecretUpdate call.
2. add UNIQUE INDEX for secret_backend_type.type.
3. align fields for secrets DDL.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Because the WatchSecretsRotationChanges watcher has not been implemented yet, we can only test the rotation policy changes.

```
juju exec --unit dummy-source/0 "secret-add data=foo"
secret://2bfad23f-a54d-48ed-87ec-e2776e2ea0b4/cotiv4uc5e02l6npsdm0

juju exec --unit dummy-source/0 "secret-set cotiv4uc5e02l6npsdm0 --rotate hourly"
```

```
dqlite> select * from secret_rotation
cotiv4uc5e02l6npsdm0|2024-05-08 07:57:02.922271014 +0000 UTC
dqlite> select srp.policy from secret_metadata sm inner join secret_rotate_policy srp on sm.rotate_policy_id = srp.id
hourly
```

## Documentation changes

No

## Links

**Jira card:** JUJU-5897

