### PR TITLE
Fix logical race in tests

### DIFF
--- a/internal/worker/upgradesteps/controllerworker_test.go
+++ b/internal/worker/upgradesteps/controllerworker_test.go
@@ -243,12 +243,8 @@ func (s *controllerWorkerSuite) TestUpgradeFailureWithAPILostError(c *gc.C) {
 	srv.WatchForUpgradeState(gomock.Any(), s.upgradeUUID, upgrade.StepsCompleted).Return(completedWatcher, nil)
 	srv.WatchForUpgradeState(gomock.Any(), s.upgradeUUID, upgrade.Error).Return(failedWatcher, nil)
 
-	done := make(chan struct{})
-
 	w := s.newWorker(c)
 	w.base.PreUpgradeSteps = func(_ agent.Config, _ bool) error {
-		defer close(done)
-
 		return upgradesteps.NewAPILostDuringUpgrade(errors.New("boom"))
 	}
 	defer workertest.DirtyKill(c, w)
@@ -257,10 +253,18 @@ func (s *controllerWorkerSuite) TestUpgradeFailureWithAPILostError(c *gc.C) {
 	s.dispatchChange(c, chCompleted)
 	s.dispatchChange(c, chFailed)
 
+	// Manually wait for the worker to be done. This ensures that the worker
+	// correctly terminates and we don't encounter a logic race condition for
+	// the mocks in the tests.
+	done := make(chan struct{})
+	go func() {
+		w.Wait()
+		close(done)
+	}()
 	select {
 	case <-done:
 	case <-time.After(testing.LongWait):
-		c.Fatalf("timed out waiting abort")
+		c.Fatalf("timed out waiting for worker to be done")
 	}
 
 	err := workertest.CheckKill(c, w)


### PR DESCRIPTION
The original tests stated that the expected test case was done when the pre-upgrade steps was complete. This wasn't exactly true. Instead, the worker test would race to the kill the worker and we could call the catacomb dying case.
The fix is to wait for the worker to die based on the steps worker and return correctly. This will then return the correct error message.

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```
$ go test -v ./internal/worker/upgradesteps -check.v -count=100
```

## Links

**Jira card:** JUJU-

