### PR TITLE
Drop DefaultSeries key from config in BootstrapConfig

### DIFF
--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -316,7 +316,6 @@ func (s *BootstrapSuite) run(c *gc.C, test bootstrapTest) testing.Restorer {
 		"name":            bootstrap.ControllerModelName,
 		"type":            "dummy",
 		"default-base":    "ubuntu@22.04/stable",
-		"default-series":  "jammy",
 		"authorized-keys": "public auth key\n",
 		// Dummy provider defaults
 		"broken":     "",

--- a/jujuclient/mem.go
+++ b/jujuclient/mem.go
@@ -11,8 +11,6 @@ import (
 	cookiejar "github.com/juju/persistent-cookiejar"
 
 	"github.com/juju/juju/cloud"
-	corebase "github.com/juju/juju/core/base"
-	"github.com/juju/juju/environs/config"
 )
 
 var _ ClientStore = (*MemStore)(nil)
@@ -472,24 +470,6 @@ func (c *MemStore) BootstrapConfigForController(controllerName string) (*Bootstr
 	defer c.mu.Unlock()
 
 	if cfg, ok := c.BootstrapConfig[controllerName]; ok {
-		// TODO(stickupkid): This can be removed once series has been removed.
-		// This is here to keep us honest with the tests, although not required.
-		if key, ok := cfg.Config[config.DefaultBaseKey]; ok {
-			if key == nil || key == "" {
-				cfg.Config[config.DefaultSeriesKey] = ""
-			} else {
-				base, err := corebase.ParseBaseFromString(key.(string))
-				if err != nil {
-					return nil, errors.Trace(err)
-				}
-
-				s, err := corebase.GetSeriesFromBase(base)
-				if err != nil {
-					return nil, errors.Trace(err)
-				}
-				cfg.Config[config.DefaultSeriesKey] = s
-			}
-		}
 		return &cfg, nil
 	}
 	return nil, errors.NotFoundf("bootstrap config for controller %s", controllerName)


### PR DESCRIPTION
Drop DefaultSeries config item from Bootstrap config

We no longer read it anywhere from here, so do not need to fill it in here

This removes a base -> series transformation


## QA steps

```
$ juju bootstrap lxd lxd
(success)
$ juju status -m lxd:controller
Model       Controller  Cloud/Region         Version      SLA          Timestamp
controller  lxd         localhost/localhost  3.6-beta1.1  unsupported  10:51:02+01:00

App         Version  Status  Scale  Charm            Channel     Rev  Exposed  Message
controller           active      1  juju-controller  3.6/stable   83  no       

Unit           Workload  Agent  Machine  Public address  Ports  Message
controller/0*  active    idle   0        10.219.211.84          

Machine  State    Address        Inst id        Base          AZ  Message
0        started  10.219.211.84  juju-b7c48e-0  ubuntu@22.04      Running

$ juju destroy-controller lxd --no-prompt
(success)
```
```
$ juju bootstrap lxd jammy --bootstrap-base ubuntu@22.04
(success)
$ juju status -m jammy:controller
Model       Controller  Cloud/Region         Version      SLA          Timestamp
controller  jammy       localhost/localhost  3.6-beta1.1  unsupported  10:51:50+01:00

App         Version  Status  Scale  Charm            Channel     Rev  Exposed  Message
controller           active      1  juju-controller  3.6/stable   83  no       

Unit           Workload  Agent  Machine  Public address  Ports  Message
controller/0*  active    idle   0        10.219.211.50          

Machine  State    Address        Inst id        Base          AZ  Message
0        started  10.219.211.50  juju-306c08-0  ubuntu@22.04      Running

$ juju destroy-controller focal --no-prompt
(success)
```
```
$ juju bootstrap lxd focal --bootstrap-base ubuntu@20.04
(success)
$ juju status -m focal:controller
Model       Controller  Cloud/Region         Version      SLA          Timestamp
controller  focal       localhost/localhost  3.6-beta1.1  unsupported  10:52:25+01:00

App         Version  Status  Scale  Charm            Channel     Rev  Exposed  Message
controller           active      1  juju-controller  3.6/stable   83  no       

Unit           Workload  Agent  Machine  Public address  Ports  Message
controller/0*  active    idle   0        10.219.211.2           

Machine  State    Address       Inst id        Base          AZ  Message
0        started  10.219.211.2  juju-740a06-0  ubuntu@20.04      Running

$ juju destroy-controller jammy --no-prompt
(success)
```