### PR TITLE
Use a base instead of a series in set-application-base test

### DIFF
--- a/tests/suites/unit/unit_series.sh
+++ b/tests/suites/unit/unit_series.sh
@@ -6,13 +6,13 @@ run_unit_set_series() {
 	file="${TEST_DIR}/test-unit-series.log"
 	ensure "unit-series" "${file}"
 
-	echo "Deploy ubuntu focal"
+	echo "Deploy ubuntu ubuntu@20.04"
 	juju deploy ubuntu --base ubuntu@20.04
 
 	wait_for "ubuntu" "$(idle_condition "ubuntu")"
 
-	echo "Change application base to jammy and add-unit"
-	juju set-application-base ubuntu jammy
+	echo "Change application base to ubuntu@22.04 and add-unit"
+	juju set-application-base ubuntu ubuntu@22.04
 	juju add-unit ubuntu
 
 	wait_for "ubuntu" "$(idle_condition "ubuntu" 0 1)"


### PR DESCRIPTION
We no longer support providing a series in set-application-base. Fix our integration test so that we use a base instead

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- ~[ ] Go unit tests, with comments saying what you're testing~
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```
./main.sh -v unit
```