### PR TITLE
Drop support for importing default-series model config

### DIFF
--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -216,44 +216,8 @@ func (ctrl *Controller) Import(
 	return dbModel, newSt, nil
 }
 
-var defaultSeriesKey = "default-series"
-
 // modelConfig creates a config for the model being imported.
 func modelConfig(attrs map[string]interface{}) (*config.Config, error) {
-	// If the tools version is before 2.9.35, the default-series
-	// value is cleared. This matches an upgrade step for 2.9.35
-	// as well. Ensuring that the default-series value is set by
-	// the user rather than a hold over from an old juju set value.
-	// Related to using the default-series value in the same way
-	// as a series flag at deploy.
-	v, ok := attrs[config.AgentVersionKey].(string)
-	if !ok {
-		return nil, errors.New("model config missing agent-version")
-	}
-	toolsVersion, err := version.Parse(v)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	// Using MustParse as the value parsed will never change.
-	newer := version.MustParse("2.9.35")
-	if comp := toolsVersion.Compare(newer); comp < 0 {
-		attrs[config.DefaultBaseKey] = ""
-		delete(attrs, defaultSeriesKey)
-	}
-
-	if v, ok := attrs[defaultSeriesKey]; ok {
-		if v == "" {
-			attrs[config.DefaultBaseKey] = ""
-		} else {
-			s, err := corebase.GetBaseFromSeries(v.(string))
-			if err != nil {
-				return nil, errors.Trace(err)
-			}
-			attrs[config.DefaultBaseKey] = s.String()
-		}
-		delete(attrs, defaultSeriesKey)
-	}
-
 	// Ensure the expected default secret-backend value is set.
 	if v, ok := attrs[config.SecretBackendKey].(string); v == "" || !ok {
 		attrs[config.SecretBackendKey] = config.DefaultSecretBackend

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -2068,46 +2068,6 @@ func (s *MigrationImportSuite) TestImportingModelWithBlankType(c *gc.C) {
 	c.Assert(imported.Type(), gc.Equals, state.ModelTypeIAAS)
 }
 
-func (s *MigrationImportSuite) TestImportingModelWithDefaultSeriesBefore2935(c *gc.C) {
-	defaultBase, ok := s.testImportingModelWithDefaultSeries(c, version.MustParse("2.7.8"))
-	c.Assert(ok, jc.IsFalse, gc.Commentf("value: %q", defaultBase))
-}
-
-func (s *MigrationImportSuite) TestImportingModelWithDefaultSeriesAfter2935(c *gc.C) {
-	defaultBase, ok := s.testImportingModelWithDefaultSeries(c, version.MustParse("2.9.35"))
-	c.Assert(ok, jc.IsTrue)
-	c.Assert(defaultBase, gc.Equals, "ubuntu@22.04/stable")
-}
-
-func (s *MigrationImportSuite) testImportingModelWithDefaultSeries(c *gc.C, toolsVer version.Number) (string, bool) {
-	testModel, err := s.State.Export(map[string]string{}, state.NewObjectStore(c, s.State.ModelUUID()))
-	c.Assert(err, jc.ErrorIsNil)
-
-	ctrlCfg := coretesting.FakeControllerConfig()
-
-	newConfig := testModel.Config()
-	newConfig["uuid"] = "aabbccdd-1234-8765-abcd-0123456789ab"
-	newConfig["name"] = "something-new"
-	newConfig["default-series"] = "jammy"
-	newConfig["agent-version"] = toolsVer.String()
-	importModel := description.NewModel(description.ModelArgs{
-		Type:           string(state.ModelTypeIAAS),
-		Owner:          testModel.Owner(),
-		Config:         newConfig,
-		EnvironVersion: testModel.EnvironVersion(),
-		Blocks:         testModel.Blocks(),
-		Cloud:          testModel.Cloud(),
-		CloudRegion:    testModel.CloudRegion(),
-	})
-	imported, newSt, err := s.Controller.Import(importModel, ctrlCfg, state.NoopConfigSchemaSource)
-	c.Assert(err, jc.ErrorIsNil)
-	defer func() { _ = newSt.Close() }()
-
-	importedCfg, err := imported.Config()
-	c.Assert(err, jc.ErrorIsNil)
-	return importedCfg.DefaultBase()
-}
-
 func (s *MigrationImportSuite) TestImportingRelationApplicationSettings(c *gc.C) {
 	state.AddTestingApplication(c, s.State, s.objectStore, "wordpress", state.AddTestingCharm(c, s.State, "wordpress"))
 	state.AddTestingApplication(c, s.State, s.objectStore, "mysql", state.AddTestingCharm(c, s.State, "mysql"))


### PR DESCRIPTION
The earliest version we support importing from only exports default-base. So we can drop support for importing default-series

This removes a series to base conversion

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Unfortunately migrations from 3.5 to 4.0 are currently broken. However, 3.5 and 3.6 are almost identical on this front

```
$ juju bootstrap lxd lxd-4.0
```

From here on, `juju-3.6` designates v3.6 of Juju
```
$ juju-3.6 bootstrap lxd lxd-3.6
$ juju-3.6 add-model m
$ juju-3.6 model-config default-series="focal"
$ juju-3.6 deploy ubuntu
(wait)
$ juju-3.6 status
Model       Controller  Cloud/Region         Version      SLA          Timestamp
controller  lxd         localhost/localhost  3.6-beta1.1  unsupported  11:11:56+01:00

App         Version  Status  Scale  Charm            Channel     Rev  Exposed  Message
controller           active      1  juju-controller  3.6/stable   83  no       

Unit           Workload  Agent  Machine  Public address  Ports  Message
controller/0*  active    idle   0        10.219.211.97          

Machine  State    Address        Inst id        Base          AZ  Message
0        started  10.219.211.97  juju-61729c-0  ubuntu@20.04      Running

$ juju-3.6 migrate m lxd-4.0
Migration started with ID "ea5d2734-1559-4f68-8d7e-10aabb951998:0"

$ juju-3.6 status
ERROR Model "admin/m" has been migrated to controller "lxd".
To access it run 'juju switch lxd-4.0:admin/m'.

$ juju switch lxd-4.0:m
$ juju model-config default-base
ubuntu@20.04/stable
```