### PR TITLE
Logtailer test fix

### DIFF
--- a/internal/logtailer/tailer.go
+++ b/internal/logtailer/tailer.go
@@ -213,7 +213,6 @@ func (t *logTailer) tailFile(seekTo *tail.SeekInfo) (err error) {
 		Location: seekTo,
 		ReOpen:   follow,
 		Follow:   follow,
-		Poll:     true,
 		Logger:   loggerAdaptor{},
 	})
 	if err != nil {

--- a/internal/logtailer/tailer.go
+++ b/internal/logtailer/tailer.go
@@ -213,6 +213,7 @@ func (t *logTailer) tailFile(seekTo *tail.SeekInfo) (err error) {
 		Location: seekTo,
 		ReOpen:   follow,
 		Follow:   follow,
+		Poll:     true,
 		Logger:   loggerAdaptor{},
 	})
 	if err != nil {

--- a/internal/logtailer/tailer_test.go
+++ b/internal/logtailer/tailer_test.go
@@ -152,6 +152,9 @@ func (s *TailerSuite) TestProcessForwardTail(c *gc.C) {
 	tailer, err := logtailer.NewLogTailer(coretesting.ModelTag.Id(), testFileName, logtailer.LogTailerParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
+	// Allow logtailer to start up.
+	time.Sleep(100 * time.Millisecond)
+
 	s.writeAdditionalLogs(c, testFileName, logLines[2:])
 
 	records := s.fetchLogs(tailer, 4)
@@ -173,6 +176,9 @@ func (s *TailerSuite) TestProcessReverseTail(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	records := s.fetchLogs(tailer, 2)
+
+	// Allow logtailer to start up.
+	time.Sleep(100 * time.Millisecond)
 
 	s.writeAdditionalLogs(c, testFileName, logLines[3:])
 


### PR DESCRIPTION
The ci race tests sometimes fail running the log tailer tests. It's very intermittent and hard to repro locally - maybe 1 in 30 attempts.
In the 2 tests where the log tailer is started and then additonal logs are written, introduce a small sleep to allow the log tailer go routine to run before writing the additional logs.

## QA steps

go test --race

## Links

**Jira card:** [JUJU-6004](https://warthogs.atlassian.net/browse/JUJU-6004)



[JUJU-6004]: https://warthogs.atlassian.net/browse/JUJU-6004?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ