### PR TITLE
Fix secret ci

### DIFF
--- a/apiserver/facades/controller/crossmodelsecrets/crossmodelsecrets.go
+++ b/apiserver/facades/controller/crossmodelsecrets/crossmodelsecrets.go
@@ -108,6 +108,9 @@ func (s *CrossModelSecretsAPI) getSecretAccessScope(ctx stdcontext.Context, arg 
 
 	secretService := s.secretServiceGetter(uri.SourceUUID)
 	scopeTag, err := s.accessScope(ctx, secretService, uri, consumerUnit)
+	if errors.Is(err, secreterrors.SecretAccessScopeNotFound) {
+		return "", apiservererrors.ErrPerm
+	}
 	if err != nil {
 		return "", errors.Trace(err)
 	}

--- a/domain/secret/service/service.go
+++ b/domain/secret/service/service.go
@@ -308,6 +308,7 @@ func (s *SecretService) UpdateUserSecret(ctx context.Context, uri *secrets.URI, 
 		// loadBackendInfo will error is there's no active backend.
 		backend := s.backends[s.activeBackendID]
 
+		// TODO: use a bespoke "GetLatestRevision(ctx, uri) method instead of GetSecret().
 		md, err := s.GetSecret(ctx, uri)
 		if err != nil {
 			// Check if the uri exists or not.

--- a/tests/suites/secrets_iaas/cmr.sh
+++ b/tests/suites/secrets_iaas/cmr.sh
@@ -48,7 +48,7 @@ run_secrets_cmr() {
 	juju switch "model-secrets-offer"
 	juju suspend-relation "$relation_id"
 	juju switch "model-secrets-consume"
-	check_contains "$(juju exec --unit dummy-sink/0 -- secret-get "$secret_uri" 2>&1)" 'is not allowed to read this secret'
+	check_contains "$(juju exec --unit dummy-sink/0 -- secret-get "$secret_uri" 2>&1)" 'permission denied'
 	echo "Checking: resume relation and access is restored"
 	juju switch "model-secrets-offer"
 	juju resume-relation "$relation_id"
@@ -59,7 +59,7 @@ run_secrets_cmr() {
 	juju switch "model-secrets-offer"
 	juju exec --unit dummy-source/0 -- secret-revoke "$secret_uri" --relation "$relation_id"
 	juju switch "model-secrets-consume"
-	check_contains "$(juju exec --unit dummy-sink/0 -- secret-get "$secret_uri" 2>&1)" 'is not allowed to read this secret'
+	check_contains "$(juju exec --unit dummy-sink/0 -- secret-get "$secret_uri" 2>&1)" 'permission denied'
 }
 
 test_secrets_cmr() {


### PR DESCRIPTION
This PR fixes two bugs, and a few secret-related bash test fixes:

- fix UpdateUserSecret secret service method to support for updating secret metadata (config autoprune for example);
- convert the secreterrors.SecretAccessScopeNotFound to apiservererrors.ErrPerm in GetSecretAccessScope facade method because the existing client side does not handle this error and also the permission denied error makes more sense for users.

After this PR landed, below test should be fixed:
- test-secrets_iaas-test-secrets-cmr-lxd
- test-secrets_iaas-test-secrets-juju-lxd
- test-secrets_iaas-test-secrets-vault-lxd
- test-secrets_k8s-test-user-secrets-microk8s