### PR TITLE
Store controller UUID for controller config in another table

### DIFF
--- a/domain/controllerconfig/bootstrap/bootstrap_test.go
+++ b/domain/controllerconfig/bootstrap/bootstrap_test.go
@@ -26,7 +26,7 @@ func (s *bootstrapSuite) TestInsertInitialControllerConfig(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	var cert string
-	row := s.DB().QueryRow("SELECT value FROM CONTROLLER_CONFIG where key = ?", controller.CACertKey)
+	row := s.DB().QueryRow("SELECT value FROM controller_config where key = ?", controller.CACertKey)
 	c.Assert(row.Scan(&cert), jc.ErrorIsNil)
 
 	c.Check(cert, gc.Equals, testing.CACert)

--- a/domain/controllerconfig/service/service.go
+++ b/domain/controllerconfig/service/service.go
@@ -91,6 +91,11 @@ func (s *Service) UpdateControllerConfig(ctx context.Context, updateAttrs contro
 	if err != nil {
 		return errors.Trace(err)
 	}
+
+	// Drop controller UUID, as we don't need to set it and it will be validated
+	// in the validate config. It's not possible to update it.
+	delete(coerced, controller.ControllerUUIDKey)
+
 	err = s.st.UpdateControllerConfig(ctx, coerced, removeAttrs, func(current map[string]string) error {
 		// Validate the updateAttrs against the current config.
 		// This is done to ensure that the update config values are allowed

--- a/domain/controllerconfig/state/state.go
+++ b/domain/controllerconfig/state/state.go
@@ -7,10 +7,14 @@ import (
 	"context"
 	"database/sql"
 
+	"github.com/canonical/sqlair"
+	"github.com/juju/collections/transform"
 	"github.com/juju/errors"
 
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/database"
 	"github.com/juju/juju/domain"
+	internaldatabase "github.com/juju/juju/internal/database"
 )
 
 // State represents a type for interacting with the underlying state.
@@ -32,18 +36,26 @@ func (st *State) ControllerConfig(ctx context.Context) (map[string]string, error
 		return nil, errors.Trace(err)
 	}
 
-	query := "SELECT key, value FROM controller_config"
+	stmt, err := st.Prepare("SELECT &dbKeyValue.* FROM v_controller_config", dbKeyValue{})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 
-	var result map[string]string
-	err = db.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
-		rows, err := tx.QueryContext(ctx, query)
-		if err != nil {
+	result := make(map[string]string)
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		var keyValues []dbKeyValue
+		if err := tx.Query(ctx, stmt).GetAll(&keyValues); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return nil
+			}
 			return errors.Trace(err)
 		}
-		defer rows.Close()
 
-		result, err = controllerConfigFromRows(rows)
-		return errors.Trace(err)
+		for _, kv := range keyValues {
+			result[kv.Key] = kv.Value
+		}
+
+		return nil
 	})
 
 	return result, err
@@ -56,44 +68,96 @@ func (st *State) ControllerConfig(ctx context.Context) (map[string]string, error
 // after bootstrapping.
 // ValidateModification is a function that will be called with the current
 // config, and should return an error if the modification is not allowed.
-func (st *State) UpdateControllerConfig(ctx context.Context, updateAttrs map[string]string, removeAttrs []string, validateModification func(map[string]string) error) error {
+func (st *State) UpdateControllerConfig(
+	ctx context.Context,
+	updateAttrs map[string]string, removeAttrs []string,
+	validateModification func(map[string]string) error,
+) error {
 	db, err := st.DB()
 	if err != nil {
 		return errors.Trace(err)
 	}
 
-	selectQuery := "SELECT key, value FROM controller_config"
-	deleteQuery := "DELETE FROM controller_config WHERE key = ?"
-	updateQuery := `
-INSERT INTO controller_config (key, value)
-VALUES (?, ?)
-  ON CONFLICT(key) DO UPDATE SET value=?`
+	selectStmt, err := st.Prepare("SELECT &dbKeyValue.* FROM v_controller_config", dbKeyValue{})
+	if err != nil {
+		return errors.Trace(err)
+	}
 
-	err = db.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
-		// Check keys and values are valid between current and new config.
-		rows, err := tx.QueryContext(ctx, selectQuery)
+	deleteStmt, err := st.Prepare("DELETE FROM controller_config WHERE key IN ($S[:])", sqlair.S{})
+	if err != nil {
+		return errors.Trace(err)
+	}
+	removeKeys := sqlair.S(transform.Slice(removeAttrs, func(s string) any { return any(s) }))
+
+	var (
+		controllerStmt *sqlair.Statement
+		uuid           dbController
+	)
+	if v, ok := updateAttrs[controller.ControllerUUIDKey]; ok && v != "" {
+		controllerStmt, err = st.Prepare(`INSERT INTO controller (uuid) VALUES ($dbController.uuid)`, dbController{})
 		if err != nil {
 			return errors.Trace(err)
 		}
-		current, err := controllerConfigFromRows(rows)
-		if err != nil {
-			return errors.Trace(err)
+		uuid = dbController{UUID: v}
+	}
+
+	updateStmt, err := st.Prepare(`
+INSERT INTO controller_config (key, value)
+VALUES ($dbKeyValue.*)
+  ON CONFLICT(key) DO UPDATE SET value=excluded.value`, dbKeyValue{})
+	if err != nil {
+		return errors.Trace(err)
+	}
+	updateKeyValues := make([]dbKeyValue, 0)
+	for k, v := range updateAttrs {
+		if k == controller.ControllerUUIDKey {
+			continue
+		}
+		updateKeyValues = append(updateKeyValues, dbKeyValue{
+			Key:   k,
+			Value: v,
+		})
+	}
+
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		// Check keys and values are valid between current and new config.
+		var keyValues []dbKeyValue
+		if err := tx.Query(ctx, selectStmt).GetAll(&keyValues); err != nil {
+			if !errors.Is(err, sql.ErrNoRows) {
+				return errors.Trace(err)
+			}
+		}
+
+		current := make(map[string]string)
+		for _, kv := range keyValues {
+			current[kv.Key] = kv.Value
 		}
 		if err := validateModification(current); err != nil {
 			return errors.Trace(err)
 		}
 
-		// Remove the attributes
-		for _, r := range removeAttrs {
-			if _, err := tx.ExecContext(ctx, deleteQuery, r); err != nil {
-				return errors.Trace(err)
+		// Insert the controller UUID, we ignore if it already exists, as
+		// the errors will tell use why it might not of worked.
+		if controllerStmt != nil {
+			if err := tx.Query(ctx, controllerStmt, uuid).Run(); err != nil {
+				if !internaldatabase.IsErrConstraintPrimaryKey(err) && !internaldatabase.IsErrConstraintUnique(err) {
+					return errors.Trace(err)
+				}
+
+				if uuid.UUID != current[controller.ControllerUUIDKey] {
+					return errors.Errorf("controller UUID cannot be changed")
+				}
 			}
 		}
 
 		// Update the attributes.
-		for key := range updateAttrs {
-			value := updateAttrs[key]
-			if _, err := tx.ExecContext(ctx, updateQuery, key, value, value); err != nil {
+		if err := tx.Query(ctx, updateStmt, updateKeyValues).Run(); err != nil {
+			return errors.Trace(err)
+		}
+
+		// Remove the attributes
+		if len(removeKeys) > 0 {
+			if err := tx.Query(ctx, deleteStmt, removeKeys).Run(); err != nil {
 				return errors.Trace(err)
 			}
 		}
@@ -107,23 +171,5 @@ VALUES (?, ?)
 // AllKeysQuery returns a SQL statement that will return
 // all known controller configuration keys.
 func (*State) AllKeysQuery() string {
-	return "SELECT key FROM controller_config"
-}
-
-// controllerConfigFromRows returns controller config info from rows returned from the backing DB.
-func controllerConfigFromRows(rows *sql.Rows) (map[string]string, error) {
-	result := make(map[string]string)
-
-	for rows.Next() {
-		var key string
-		var value string
-
-		if err := rows.Scan(&key, &value); err != nil {
-			return nil, errors.Trace(err)
-		}
-
-		result[key] = value
-	}
-
-	return result, errors.Trace(rows.Err())
+	return "SELECT key FROM v_controller_config"
 }

--- a/domain/controllerconfig/state/state_test.go
+++ b/domain/controllerconfig/state/state_test.go
@@ -11,6 +11,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/controller"
+	"github.com/juju/juju/domain/controllerconfig/bootstrap"
 	schematesting "github.com/juju/juju/domain/schema/testing"
 	jujutesting "github.com/juju/juju/testing"
 )
@@ -20,6 +21,17 @@ type stateSuite struct {
 }
 
 var _ = gc.Suite(&stateSuite{})
+
+func (s *stateSuite) SetUpTest(c *gc.C) {
+	s.ControllerSuite.SetUpTest(c)
+
+	cfg := controller.Config{
+		controller.ControllerUUIDKey: jujutesting.ControllerTag.Id(),
+		controller.CACertKey:         jujutesting.CACert,
+	}
+	err := bootstrap.InsertInitialControllerConfig(cfg)(ctx.Background(), s.TxnRunner(), s.NoopTxnRunner())
+	c.Assert(err, jc.ErrorIsNil)
+}
 
 func (s *stateSuite) TestControllerConfigRead(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory())
@@ -47,7 +59,12 @@ func (s *stateSuite) TestControllerConfigReadWithoutData(c *gc.C) {
 
 	controllerConfig, err := st.ControllerConfig(ctx.Background())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(controllerConfig, gc.HasLen, 0)
+
+	// This is set at bootstrap time.
+	c.Check(controllerConfig, jc.DeepEquals, map[string]string{
+		controller.ControllerUUIDKey: jujutesting.ControllerTag.Id(),
+		controller.CACertKey:         jujutesting.CACert,
+	})
 }
 
 func (s *stateSuite) TestControllerConfigUpdateTwice(c *gc.C) {
@@ -116,10 +133,12 @@ func (s *stateSuite) TestControllerConfigUpdateTwiceWithDifferentControllerUUID(
 	err := st.UpdateControllerConfig(ctx.Background(), ctrlConfig, nil, alwaysValid)
 	c.Assert(err, jc.ErrorIsNil)
 
+	// This is just ignored, the service layer will not allow this.
+
 	ctrlConfig[controller.ControllerUUIDKey] = "new-controller-uuid"
 
 	err = st.UpdateControllerConfig(ctx.Background(), ctrlConfig, nil, alwaysValid)
-	c.Assert(err, gc.ErrorMatches, `controller UUID cannot be changed`)
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *stateSuite) TestUpdateControllerConfigNewData(c *gc.C) {

--- a/domain/controllerconfig/state/types.go
+++ b/domain/controllerconfig/state/types.go
@@ -3,11 +3,14 @@
 
 package state
 
-type dbKeyValue struct {
+type KeyValue struct {
 	Key   string `db:"key"`
 	Value string `db:"value"`
 }
 
-type dbController struct {
+type Controller struct {
 	UUID string `db:"uuid"`
+	Name string `db:"name"`
 }
+
+type StringSlice []string

--- a/domain/controllerconfig/state/types.go
+++ b/domain/controllerconfig/state/types.go
@@ -1,0 +1,13 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+type dbKeyValue struct {
+	Key   string `db:"key"`
+	Value string `db:"value"`
+}
+
+type dbController struct {
+	UUID string `db:"uuid"`
+}

--- a/domain/schema/controller.go
+++ b/domain/schema/controller.go
@@ -575,7 +575,21 @@ func controllerConfigSchema() schema.Patch {
 CREATE TABLE controller_config (
     key     TEXT PRIMARY KEY,
     value   TEXT
-);`)
+);
+
+CREATE TABLE controller (
+    uuid    TEXT PRIMARY KEY NOT NULL
+);
+
+-- A unique constraint over a constant index ensures only 1 entry matching the 
+-- condition can exist.
+CREATE UNIQUE INDEX idx_singleton_controller ON controller ((1));
+
+CREATE VIEW v_controller_config AS
+SELECT key, value FROM controller_config
+UNION
+SELECT 'controller-uuid' AS key, controller.uuid AS value FROM controller;
+`)
 }
 
 func controllerNodeTableSchema() schema.Patch {

--- a/domain/schema/schema_test.go
+++ b/domain/schema/schema_test.go
@@ -136,6 +136,7 @@ func (s *schemaSuite) TestControllerTables(c *gc.C) {
 		"life",
 
 		// Controller config
+		"controller",
 		"controller_config",
 
 		// Controller nodes
@@ -191,6 +192,9 @@ func (s *schemaSuite) TestControllerViews(c *gc.C) {
 	// Ensure that each view is present.
 	expected := set.NewStrings(
 		"v_user_auth",
+
+		// Controller and controller config
+		"v_controller_config",
 
 		// Cloud
 		"v_cloud",

--- a/domain/schema/secret.go
+++ b/domain/schema/secret.go
@@ -77,7 +77,7 @@ CREATE TABLE model_secret_backend (
 
 CREATE VIEW v_model_secret_backend AS
 SELECT
-    (SELECT value FROM controller_config WHERE key='controller-uuid') AS controller_uuid,
+    (SELECT uuid FROM controller) AS controller_uuid,
     m.uuid,
     m.name,
     mt.type AS model_type,

--- a/domain/secretbackend/state/state_test.go
+++ b/domain/secretbackend/state/state_test.go
@@ -57,10 +57,7 @@ func (s *stateSuite) SetUpTest(c *gc.C) {
 func (s *stateSuite) setupController(c *gc.C) string {
 	controllerUUID := uuid.MustNewUUID().String()
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
-		_, err := tx.ExecContext(ctx, `
-			INSERT INTO controller_config (key, value)
-			VALUES (?, ?)
-		`, "controller-uuid", controllerUUID)
+		_, err := tx.ExecContext(ctx, `INSERT INTO controller (uuid) VALUES (?)`, controllerUUID)
 		return err
 	})
 	c.Assert(err, jc.ErrorIsNil)

--- a/domain/secretbackend/state/types.go
+++ b/domain/secretbackend/state/types.go
@@ -14,7 +14,6 @@ import (
 	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/domain/secretbackend"
-	domainsecretbackend "github.com/juju/juju/domain/secretbackend"
 	backenderrors "github.com/juju/juju/domain/secretbackend/errors"
 	"github.com/juju/juju/internal/database"
 )
@@ -87,7 +86,7 @@ type SecretBackend struct {
 	// Name is the name of the secret backend.
 	Name string `db:"name"`
 	// BackendType is the id of the secret backend type.
-	BackendTypeID domainsecretbackend.BackendType `db:"backend_type_id"`
+	BackendTypeID secretbackend.BackendType `db:"backend_type_id"`
 	// TokenRotateInterval is the interval at which the token for the secret backend should be rotated.
 	TokenRotateInterval database.NullDuration `db:"token_rotate_interval"`
 }


### PR DESCRIPTION
There are parts of controller config that shouldn't be stored in the controller config table as key and values. For example the controller UUID should be part of a new controller table. The controller table can then hold values that are known and unlikely to change, whilst also adding the ability to add foreign key constraints to them (RI).

The service layer doesn't care how the data is laid out, only that it can get a map of keys and values. The state layer translates that to the right table locations.

We can use a view to simulate the old controller config table with all the values, yet the controller config table just holds scalar or simple string values.

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

### Setup

Run tempo for open telemetry

### Bootstrap

Bootstrap to lxd pointing to tempo.

```
$ juju bootstrap lxd test --config="open-telemetry-enabled=true" --config="open-telemetry-insecure=true" --config="open-telemetry-endpoint=<IP address>" --config="open-telemetry-sample-ratio=1"
```

### Other tests

Test that we can't update controller-uuid

```
$ juju controller-config controller-uuid=deadbeef
ERROR invalid or read-only controller config values cannot be updated: [controller-uuid]
```

Ensure that validation checks aren't broken

```
$ juju controller-config query-tracing-threshold=0.5
ERROR query-tracing-threshold: conversion to duration: time: missing unit in duration "0.5"
```

Ensure that the update works

```
$ juju controller-config query-tracing-threshold=0.5s
$ juju controller-config query-tracing-threshold
500ms
```

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/

**Jira card:** JUJU-

