### PR TITLE
Ignore secret not found in secret revision watcher

### DIFF
--- a/apiserver/watcher.go
+++ b/apiserver/watcher.go
@@ -1419,20 +1419,23 @@ func (w *srvSecretsRevisionWatcher) translateChanges(changes []string) ([]params
 		return nil, nil
 	}
 	secrets := state.NewSecrets(w.st)
-	result := make([]params.SecretRevisionChange, len(changes))
-	for i, uriStr := range changes {
+	result := make([]params.SecretRevisionChange, 0, len(changes))
+	for _, uriStr := range changes {
 		uri, err := coresecrets.ParseURI(uriStr)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
 		md, err := secrets.GetSecret(uri)
+		if errors.Is(err, errors.NotFound) {
+			continue
+		}
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		result[i] = params.SecretRevisionChange{
+		result = append(result, params.SecretRevisionChange{
 			URI:      uri.String(),
 			Revision: md.LatestRevision,
-		}
+		})
 	}
 	return result, nil
 }


### PR DESCRIPTION
The secret revision watcher takes the secret uris and looks up the secret to hydrate the result. If a secret is deleted, the not found error was escaping and killing workers which used the watcher.  If a secret was deleted in the relation broken hook, this broke the relation tear down workflow and the relation was left behind.

This PR tweaks the watcher to skip over secrets which are not found.

## QA steps

See the reproducer script in the bug.

```
juju add-model $MODEL1

juju deploy ./*.charm -m $MODEL1 app1 
juju deploy ./*.charm -m $MODEL2 app2

juju offer ${MODEL1}.app1:a-relation a-relation
juju switch ${MODEL2}
juju consume ${MODEL1}.a-relation

juju relate a-relation app2:b-relation

juju remove-relation a-relation app2:b-relation
```

## Links

https://bugs.launchpad.net/bugs/2065284

**Jira card:** [JUJU-6007](https://warthogs.atlassian.net/browse/JUJU-6007)



[JUJU-6007]: https://warthogs.atlassian.net/browse/JUJU-6007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ