### PR TITLE
Panic nil pointer when deploying to existing container

### DIFF
--- a/apiserver/facades/client/application/backend.go
+++ b/apiserver/facades/client/application/backend.go
@@ -148,6 +148,7 @@ type CharmMeta interface {
 type Machine interface {
 	Base() state.Base
 	HardwareCharacteristics() (*instance.HardwareCharacteristics, error)
+	Id() string
 	PublicAddress() (network.SpaceAddress, error)
 	IsLockedForSeriesUpgrade() (bool, error)
 	IsParentLockedForSeriesUpgrade() (bool, error)

--- a/apiserver/facades/client/application/deployrepository.go
+++ b/apiserver/facades/client/application/deployrepository.go
@@ -581,19 +581,21 @@ func (v *deployFromRepositoryValidator) createOrigin(arg params.DeployFromReposi
 
 // deducePlatform returns a platform for initial resolveCharm call.
 // At minimum, it must contain an architecture.
-// Platform is determined by the args: architecture constraint and
-// provided base.
-// - Check placement to determine known machine platform. If diffs from
-// other provided data return error.
+// Platform is determined by the args: architecture constraint and provided
+// base. Or from the model default architecture and base.
 // - If no base provided, use model default base.
 // - If no model default base, will be determined later.
 // - If no architecture provided, use model default. Fallback
 // to DefaultArchitecture.
+//
+// Then check for the platform of any machine scoped placement directives.
+// Use that for the platform if no base provided by the user.
+// Return an error if the placement platform and user provided base do not
+// match.
 func (v *deployFromRepositoryValidator) deducePlatform(arg params.DeployFromRepositoryArg) (corecharm.Platform, bool, error) {
 	argArch := arg.Cons.Arch
 	argBase := arg.Base
 	var usedModelDefaultBase bool
-	var usedModelDefaultArch bool
 
 	// Try argBase with provided argArch and argBase first.
 	platform := corecharm.Platform{}
@@ -610,7 +612,6 @@ func (v *deployFromRepositoryValidator) deducePlatform(arg params.DeployFromRepo
 			platform.Architecture = *mConst.Arch
 		} else {
 			platform.Architecture = arch.DefaultArchitecture
-			usedModelDefaultArch = true
 		}
 	}
 	if argBase != nil {
@@ -619,9 +620,7 @@ func (v *deployFromRepositoryValidator) deducePlatform(arg params.DeployFromRepo
 			return corecharm.Platform{}, usedModelDefaultBase, err
 		}
 		platform.OS = base.OS
-		// platform channels don't model the concept of a risk
-		// so ensure that only the track is included
-		platform.Channel = base.Channel.Track
+		platform.Channel = base.Channel.String()
 	}
 
 	// Initial validation of platform from known data.
@@ -630,78 +629,120 @@ func (v *deployFromRepositoryValidator) deducePlatform(arg params.DeployFromRepo
 		return corecharm.Platform{}, usedModelDefaultBase, err
 	}
 
-	// Match against platforms from placement
 	placementPlatform, placementsMatch, err := v.platformFromPlacement(arg.Placement)
-	if err != nil && !errors.Is(err, errors.NotFound) {
+	if err != nil {
 		return corecharm.Platform{}, usedModelDefaultBase, err
 	}
-	if err == nil && !placementsMatch {
-		return corecharm.Platform{}, usedModelDefaultBase, errors.BadRequestf("bases of existing placement machines do not match")
+	// No machine scoped placement to match, return after checking
+	// if using default model base.
+	if placementPlatform == nil {
+		return v.modelDefaultBase(platform)
+	}
+	// There can be only 1 platform.
+	if !placementsMatch {
+		return corecharm.Platform{}, usedModelDefaultBase, errors.BadRequestf("bases of existing placement machines do not match each other")
 	}
 
-	// No platform args, and one platform from placement, use that.
-	if placementsMatch && usedModelDefaultArch && argBase == nil {
-		return placementPlatform, usedModelDefaultBase, nil
+	// No base args provided. Use the placement platform to deploy.
+	if argBase == nil {
+		deployRepoLogger.Tracef("using placement platform %q to deploy", placementPlatform.String())
+		return *placementPlatform, usedModelDefaultBase, nil
 	}
-	if platform.Channel == "" {
-		mCfg, err := v.model.Config()
-		if err != nil {
-			return corecharm.Platform{}, usedModelDefaultBase, err
-		}
-		if db, ok := mCfg.DefaultBase(); ok {
-			defaultBase, err := corebase.ParseBaseFromString(db)
-			if err != nil {
-				return corecharm.Platform{}, usedModelDefaultBase, err
-			}
-			platform.OS = defaultBase.OS
-			// platform channels don't model the concept of a risk
-			// so ensure that only the track is included
-			platform.Channel = defaultBase.Channel.Track
-			usedModelDefaultBase = true
-		}
+
+	// Check that the placement platform and the derived platform match
+	// when a base is supplied. There is no guarantee that all placement
+	// directives are machine scoped.
+	if placementPlatform.String() == platform.String() {
+		return *placementPlatform, usedModelDefaultBase, nil
 	}
-	return platform, usedModelDefaultBase, nil
+	var msg string
+	if usedModelDefaultBase {
+		msg = fmt.Sprintf("base from placements, %q, does not match model default base %q", placementPlatform.String(), platform.String())
+	} else {
+		msg = fmt.Sprintf("base from placements, %q, does not match requested base %q", placementPlatform.String(), platform.String())
+	}
+	return corecharm.Platform{}, usedModelDefaultBase, fmt.Errorf(msg)
+
 }
 
-func (v *deployFromRepositoryValidator) platformFromPlacement(placements []*instance.Placement) (corecharm.Platform, bool, error) {
-	if len(placements) == 0 {
-		return corecharm.Platform{}, false, errors.NotFoundf("placements")
+func (v *deployFromRepositoryValidator) modelDefaultBase(p corecharm.Platform) (corecharm.Platform, bool, error) {
+	// No provided platform channel, check model defaults.
+	if p.Channel != "" {
+		return p, false, nil
 	}
+	mCfg, err := v.model.Config()
+	if err != nil {
+		return p, false, nil
+	}
+	db, ok := mCfg.DefaultBase()
+	if !ok {
+		return p, false, nil
+	}
+	defaultBase, err := corebase.ParseBaseFromString(db)
+	if err != nil {
+		return corecharm.Platform{}, false, err
+	}
+	p.OS = defaultBase.OS
+	p.Channel = defaultBase.Channel.String()
+	return p, true, nil
+}
+
+// platformFromPlacement attempts to choose a platform to deploy with based on the
+// machine scoped placement values provided by the user. The platform for all provided
+// machines much match.
+func (v *deployFromRepositoryValidator) platformFromPlacement(placements []*instance.Placement) (*corecharm.Platform, bool, error) {
+	if len(placements) == 0 {
+		return nil, false, nil
+	}
+
 	machines := make([]Machine, 0)
+	var machineScopeCnt int
 	// Find which machines in placement actually exist.
 	for _, placement := range placements {
-		m, err := v.state.Machine(placement.Directive)
-		if errors.Is(err, errors.NotFound) {
+		if placement.Scope != instance.MachineScope {
 			continue
 		}
+		machineScopeCnt += 1
+		m, err := v.state.Machine(placement.Directive)
 		if err != nil {
-			return corecharm.Platform{}, false, err
+			return nil, false, errors.Annotate(err, "verifying machine for placement")
 		}
 		machines = append(machines, m)
 	}
-	if len(machines) == 0 {
-		return corecharm.Platform{}, false, errors.NotFoundf("machines in placements")
+
+	if machineScopeCnt == 0 {
+		// Not all placements refer to actual machines, no need to continue.
+		deployRepoLogger.Tracef("no machine scoped directives found in placements")
+		return nil, false, nil
 	}
 
 	// Gather platforms for existing machines
 	var platform corecharm.Platform
+	// Use a set to determine if all the machines have the same platform.
 	platStrings := set.NewStrings()
 	for _, machine := range machines {
 		b := machine.Base()
-		a, err := machine.HardwareCharacteristics()
+		hc, err := machine.HardwareCharacteristics()
 		if err != nil {
-			return corecharm.Platform{}, false, err
+			if errors.Is(err, errors.NotFound) {
+				return nil, false, fmt.Errorf("machine %q not started, please retry when started", machine.Id())
+			}
+			return nil, false, err
 		}
-		platString := fmt.Sprintf("%s/%s/%s", *a.Arch, b.OS, b.Channel)
+		mArch := hc.Arch
+		if mArch == nil {
+			return nil, false, fmt.Errorf("machine %q has no saved architecture", machine.Id())
+		}
+		platString := fmt.Sprintf("%s/%s/%s", *mArch, b.OS, b.Channel)
 		p, err := corecharm.ParsePlatformNormalize(platString)
 		if err != nil {
-			return corecharm.Platform{}, false, err
+			return nil, false, err
 		}
 		platform = p
 		platStrings.Add(p.String())
 	}
 
-	return platform, platStrings.Size() == 1, nil
+	return &platform, platStrings.Size() == 1, nil
 }
 
 func (v *deployFromRepositoryValidator) resolveCharm(curl *charm.URL, requestedOrigin corecharm.Origin, force, usedModelDefaultBase bool, cons constraints.Value) (corecharm.ResolvedDataForDeploy, error) {

--- a/apiserver/facades/client/application/deployrepository.go
+++ b/apiserver/facades/client/application/deployrepository.go
@@ -741,6 +741,9 @@ func (v *deployFromRepositoryValidator) platformFromPlacement(placements []*inst
 		platform = p
 		platStrings.Add(p.String())
 	}
+	if platStrings.Size() == 1 {
+		deployRepoLogger.Errorf("Mismatched platforms for machine scoped placements %s", platStrings.SortedValues())
+	}
 
 	return &platform, platStrings.Size() == 1, nil
 }

--- a/apiserver/facades/client/application/deployrepository_mocks_test.go
+++ b/apiserver/facades/client/application/deployrepository_mocks_test.go
@@ -640,6 +640,20 @@ func (mr *MockMachineMockRecorder) HardwareCharacteristics() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HardwareCharacteristics", reflect.TypeOf((*MockMachine)(nil).HardwareCharacteristics))
 }
 
+// Id mocks base method.
+func (m *MockMachine) Id() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Id")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Id indicates an expected call of Id.
+func (mr *MockMachineMockRecorder) Id() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Id", reflect.TypeOf((*MockMachine)(nil).Id))
+}
+
 // IsLockedForSeriesUpgrade mocks base method.
 func (m *MockMachine) IsLockedForSeriesUpgrade() (bool, error) {
 	m.ctrl.T.Helper()

--- a/apiserver/facades/client/application/deployrepository_test.go
+++ b/apiserver/facades/client/application/deployrepository_test.go
@@ -647,28 +647,6 @@ func (s *validatorSuite) TestDeducePlatformSimple(c *gc.C) {
 	c.Assert(plat, gc.DeepEquals, corecharm.Platform{Architecture: "amd64"})
 }
 
-//func (s *validatorSuite) TestDeducePlatformRiskInChannel(c *gc.C) {
-//	defer s.setupMocks(c).Finish()
-//	//model constraint default
-//	s.state.EXPECT().ModelConstraints().Return(constraints.Value{Arch: strptr("amd64")}, nil)
-//
-//	arg := params.DeployFromRepositoryArg{
-//		CharmName: "testme",
-//		Base: &params.Base{
-//			Name:    "ubuntu",
-//			Channel: "22.10/stable",
-//		},
-//	}
-//	plat, usedModelDefaultBase, err := s.getValidator().deducePlatform(arg)
-//	c.Assert(err, gc.IsNil)
-//	c.Assert(usedModelDefaultBase, jc.IsFalse)
-//	c.Assert(plat, gc.DeepEquals, corecharm.Platform{
-//		Architecture: "amd64",
-//		OS:           "ubuntu",
-//		Channel:      "22.10",
-//	})
-//}
-
 func (s *validatorSuite) TestDeducePlatformArgArchBase(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 

--- a/apiserver/facades/client/application/deployrepository_test.go
+++ b/apiserver/facades/client/application/deployrepository_test.go
@@ -647,27 +647,27 @@ func (s *validatorSuite) TestDeducePlatformSimple(c *gc.C) {
 	c.Assert(plat, gc.DeepEquals, corecharm.Platform{Architecture: "amd64"})
 }
 
-func (s *validatorSuite) TestDeducePlatformRiskInChannel(c *gc.C) {
-	defer s.setupMocks(c).Finish()
-	//model constraint default
-	s.state.EXPECT().ModelConstraints().Return(constraints.Value{Arch: strptr("amd64")}, nil)
-
-	arg := params.DeployFromRepositoryArg{
-		CharmName: "testme",
-		Base: &params.Base{
-			Name:    "ubuntu",
-			Channel: "22.10/stable",
-		},
-	}
-	plat, usedModelDefaultBase, err := s.getValidator().deducePlatform(arg)
-	c.Assert(err, gc.IsNil)
-	c.Assert(usedModelDefaultBase, jc.IsFalse)
-	c.Assert(plat, gc.DeepEquals, corecharm.Platform{
-		Architecture: "amd64",
-		OS:           "ubuntu",
-		Channel:      "22.10",
-	})
-}
+//func (s *validatorSuite) TestDeducePlatformRiskInChannel(c *gc.C) {
+//	defer s.setupMocks(c).Finish()
+//	//model constraint default
+//	s.state.EXPECT().ModelConstraints().Return(constraints.Value{Arch: strptr("amd64")}, nil)
+//
+//	arg := params.DeployFromRepositoryArg{
+//		CharmName: "testme",
+//		Base: &params.Base{
+//			Name:    "ubuntu",
+//			Channel: "22.10/stable",
+//		},
+//	}
+//	plat, usedModelDefaultBase, err := s.getValidator().deducePlatform(arg)
+//	c.Assert(err, gc.IsNil)
+//	c.Assert(usedModelDefaultBase, jc.IsFalse)
+//	c.Assert(plat, gc.DeepEquals, corecharm.Platform{
+//		Architecture: "amd64",
+//		OS:           "ubuntu",
+//		Channel:      "22.10",
+//	})
+//}
 
 func (s *validatorSuite) TestDeducePlatformArgArchBase(c *gc.C) {
 	defer s.setupMocks(c).Finish()
@@ -686,7 +686,7 @@ func (s *validatorSuite) TestDeducePlatformArgArchBase(c *gc.C) {
 	c.Assert(plat, gc.DeepEquals, corecharm.Platform{
 		Architecture: "arm64",
 		OS:           "ubuntu",
-		Channel:      "22.10",
+		Channel:      "22.10/stable",
 	})
 }
 
@@ -711,7 +711,7 @@ func (s *validatorSuite) TestDeducePlatformModelDefaultBase(c *gc.C) {
 	c.Assert(plat, gc.DeepEquals, corecharm.Platform{
 		Architecture: "amd64",
 		OS:           "ubuntu",
-		Channel:      "22.04",
+		Channel:      "22.04/stable",
 	})
 }
 
@@ -721,16 +721,17 @@ func (s *validatorSuite) TestDeducePlatformPlacementSimpleFound(c *gc.C) {
 	s.state.EXPECT().Machine("0").Return(s.machine, nil)
 	s.machine.EXPECT().Base().Return(state.Base{
 		OS:      "ubuntu",
-		Channel: "18.04",
+		Channel: "22.04",
 	})
 	hwc := &instance.HardwareCharacteristics{Arch: strptr("arm64")}
 	s.machine.EXPECT().HardwareCharacteristics().Return(hwc, nil)
 
 	arg := params.DeployFromRepositoryArg{
 		CharmName: "testme",
-		Placement: []*instance.Placement{{
-			Directive: "0",
-		}},
+		Placement: []*instance.Placement{
+			{Scope: instance.MachineScope, Directive: "0"},
+			{Scope: "lxd"},
+		},
 	}
 	plat, usedModelDefaultBase, err := s.getValidator().deducePlatform(arg)
 	c.Assert(err, gc.IsNil)
@@ -738,27 +739,47 @@ func (s *validatorSuite) TestDeducePlatformPlacementSimpleFound(c *gc.C) {
 	c.Assert(plat, gc.DeepEquals, corecharm.Platform{
 		Architecture: "arm64",
 		OS:           "ubuntu",
-		Channel:      "18.04",
+		Channel:      "22.04",
 	})
+}
+
+func (s *validatorSuite) TestDeducePlatformPlacementNoPanic(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+	s.state.EXPECT().ModelConstraints().Return(constraints.Value{}, nil)
+	s.machine.EXPECT().Id().Return("5/lxd/6")
+	s.state.EXPECT().Machine("5/lxd/6").Return(s.machine, nil)
+	s.machine.EXPECT().Base().Return(state.Base{
+		OS:      "ubuntu",
+		Channel: "22.04",
+	})
+	hwc := &instance.HardwareCharacteristics{}
+	s.machine.EXPECT().HardwareCharacteristics().Return(hwc, nil)
+
+	arg := params.DeployFromRepositoryArg{
+		CharmName: "testme",
+		Placement: []*instance.Placement{
+			{Scope: instance.MachineScope, Directive: "5/lxd/6"},
+			{Scope: "lxd"},
+		},
+	}
+	_, _, err := s.getValidator().deducePlatform(arg)
+	c.Assert(err, gc.NotNil)
 }
 
 func (s *validatorSuite) TestDeducePlatformPlacementSimpleNotFound(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	//model constraint default
 	s.state.EXPECT().ModelConstraints().Return(constraints.Value{Arch: strptr("amd64")}, nil)
-	s.model.EXPECT().Config().Return(config.New(config.UseDefaults, coretesting.FakeConfig()))
-	s.state.EXPECT().Machine("0/lxd/0").Return(nil, errors.NotFoundf("machine 0/lxd/0 not found"))
+	s.state.EXPECT().Machine("0/lxd/0").Return(nil, errors.NotFoundf("machine 0/lxd/0"))
 
 	arg := params.DeployFromRepositoryArg{
 		CharmName: "testme",
 		Placement: []*instance.Placement{{
-			Directive: "0/lxd/0",
+			Scope: instance.MachineScope, Directive: "0/lxd/0",
 		}},
 	}
-	plat, usedModelDefaultBase, err := s.getValidator().deducePlatform(arg)
-	c.Assert(err, gc.IsNil)
-	c.Assert(usedModelDefaultBase, jc.IsFalse)
-	c.Assert(plat, gc.DeepEquals, corecharm.Platform{Architecture: "amd64"})
+	_, _, err := s.getValidator().deducePlatform(arg)
+	c.Assert(err, jc.ErrorIs, errors.NotFound)
 }
 
 func (s *validatorSuite) TestResolvedCharmValidationSubordinate(c *gc.C) {
@@ -785,7 +806,7 @@ func (s *validatorSuite) TestDeducePlatformPlacementMutipleMatch(c *gc.C) {
 	s.state.EXPECT().Machine(gomock.Any()).Return(s.machine, nil).Times(3)
 	s.machine.EXPECT().Base().Return(state.Base{
 		OS:      "ubuntu",
-		Channel: "18.04",
+		Channel: "22.04",
 	}).Times(3)
 	hwc := &instance.HardwareCharacteristics{Arch: strptr("arm64")}
 	s.machine.EXPECT().HardwareCharacteristics().Return(hwc, nil).Times(3)
@@ -793,9 +814,9 @@ func (s *validatorSuite) TestDeducePlatformPlacementMutipleMatch(c *gc.C) {
 	arg := params.DeployFromRepositoryArg{
 		CharmName: "testme",
 		Placement: []*instance.Placement{
-			{Directive: "0"},
-			{Directive: "1"},
-			{Directive: "3"},
+			{Scope: instance.MachineScope, Directive: "0"},
+			{Scope: instance.MachineScope, Directive: "1"},
+			{Scope: instance.MachineScope, Directive: "3"},
 		},
 	}
 	plat, usedModelDefaultBase, err := s.getValidator().deducePlatform(arg)
@@ -804,7 +825,7 @@ func (s *validatorSuite) TestDeducePlatformPlacementMutipleMatch(c *gc.C) {
 	c.Assert(plat, gc.DeepEquals, corecharm.Platform{
 		Architecture: "arm64",
 		OS:           "ubuntu",
-		Channel:      "18.04",
+		Channel:      "22.04",
 	})
 }
 
@@ -815,7 +836,7 @@ func (s *validatorSuite) TestDeducePlatformPlacementMutipleMatchFail(c *gc.C) {
 	s.machine.EXPECT().Base().Return(
 		state.Base{
 			OS:      "ubuntu",
-			Channel: "18.04",
+			Channel: "22.04",
 		}).AnyTimes()
 	gomock.InOrder(
 		s.machine.EXPECT().HardwareCharacteristics().Return(
@@ -829,8 +850,8 @@ func (s *validatorSuite) TestDeducePlatformPlacementMutipleMatchFail(c *gc.C) {
 	arg := params.DeployFromRepositoryArg{
 		CharmName: "testme",
 		Placement: []*instance.Placement{
-			{Directive: "0"},
-			{Directive: "1"},
+			{Scope: instance.MachineScope, Directive: "0"},
+			{Scope: instance.MachineScope, Directive: "1"},
 		},
 	}
 	_, _, err := s.getValidator().deducePlatform(arg)

--- a/apiserver/facades/client/application/mocks/application_mock.go
+++ b/apiserver/facades/client/application/mocks/application_mock.go
@@ -2364,6 +2364,20 @@ func (mr *MockMachineMockRecorder) HardwareCharacteristics() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HardwareCharacteristics", reflect.TypeOf((*MockMachine)(nil).HardwareCharacteristics))
 }
 
+// Id mocks base method.
+func (m *MockMachine) Id() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Id")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Id indicates an expected call of Id.
+func (mr *MockMachineMockRecorder) Id() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Id", reflect.TypeOf((*MockMachine)(nil).Id))
+}
+
 // IsLockedForSeriesUpgrade mocks base method.
 func (m *MockMachine) IsLockedForSeriesUpgrade() (bool, error) {
 	m.ctrl.T.Helper()

--- a/container/kvm/kvm.go
+++ b/container/kvm/kvm.go
@@ -162,7 +162,7 @@ func (manager *containerManager) CreateContainer(
 	networkConfig *container.NetworkConfig,
 	storageConfig *container.StorageConfig,
 	callback environs.StatusCallbackFunc,
-) (_ instances.Instance, hc *instance.HardwareCharacteristics, err error) {
+) (_ instances.Instance, _ *instance.HardwareCharacteristics, err error) {
 
 	name, err := manager.namespace.Hostname(instanceConfig.MachineId)
 	if err != nil {
@@ -182,8 +182,6 @@ func (manager *containerManager) CreateContainer(
 	// object, and doesn't actually construct the underlying kvm container on
 	// disk.
 	kvmContainer := KVMObjectFactory.New(name)
-
-	hc = &instance.HardwareCharacteristics{AvailabilityZone: &manager.availabilityZone}
 
 	// Create the cloud-init.
 	cloudConfig, err := cloudinit.New(instanceConfig.Base.OS)
@@ -237,10 +235,9 @@ func (manager *containerManager) CreateContainer(
 	}
 	startParams.ImageDownloadURL = imURL
 
-	var hardware instance.HardwareCharacteristics
-	hardware, err = instance.ParseHardware(
-		fmt.Sprintf("arch=%s mem=%vM root-disk=%vG cores=%v",
-			startParams.Arch, startParams.Memory, startParams.RootDisk, startParams.CpuCores))
+	hardware, err := instance.ParseHardware(
+		fmt.Sprintf("arch=%s mem=%vM root-disk=%vG cores=%v availability-zone=%s",
+			startParams.Arch, startParams.Memory, startParams.RootDisk, startParams.CpuCores, manager.availabilityZone))
 	if err != nil {
 		return nil, nil, errors.Annotate(err, "failed to parse hardware")
 	}

--- a/container/lxd/manager.go
+++ b/container/lxd/manager.go
@@ -141,7 +141,9 @@ func (m *containerManager) CreateContainer(
 	_ = callback(status.Running, "Container started", nil)
 
 	virtType := string(spec.VirtType)
+	arch := c.Arch()
 	hardware := &instance.HardwareCharacteristics{
+		Arch:             &arch,
 		AvailabilityZone: &m.availabilityZone,
 		VirtType:         &virtType,
 	}

--- a/container/lxd/manager_test.go
+++ b/container/lxd/manager_test.go
@@ -141,6 +141,7 @@ func (s *managerSuite) TestContainerCreateDestroy(c *gc.C) {
 
 	exp.GetInstanceState(hostName).Return(
 		&lxdapi.InstanceState{
+
 			StatusCode: lxdapi.Running,
 			Network: map[string]lxdapi.InstanceStateNetwork{
 				"fan0": {
@@ -152,8 +153,12 @@ func (s *managerSuite) TestContainerCreateDestroy(c *gc.C) {
 				},
 			},
 		}, lxdtesting.ETag, nil).Times(2)
-
-	exp.GetInstance(hostName).Return(&lxdapi.Instance{Name: hostName, Type: "container"}, lxdtesting.ETag, nil)
+	inst := &lxdapi.Instance{
+		Name:        hostName,
+		Type:        "container",
+		InstancePut: lxdapi.InstancePut{Architecture: "amd64"},
+	}
+	exp.GetInstance(hostName).Return(inst, lxdtesting.ETag, nil)
 
 	// Arrangements for the container destruction.
 	stopReq := lxdapi.InstanceStatePut{
@@ -174,6 +179,8 @@ func (s *managerSuite) TestContainerCreateDestroy(c *gc.C) {
 
 	instanceId := instance.Id()
 	c.Check(string(instanceId), gc.Equals, hostName)
+	c.Check(hc.Arch, gc.NotNil)
+	c.Check(*hc.Arch, gc.Equals, "amd64")
 
 	instanceStatus := instance.Status(context.NewEmptyCloudCallContext())
 	c.Check(instanceStatus.Status, gc.Equals, status.Running)
@@ -211,7 +218,12 @@ func (s *managerSuite) TestContainerCreateUpdateIPv4Network(c *gc.C) {
 	s.expectStartOp(ctrl)
 
 	exp.UpdateInstanceState(hostName, lxdapi.InstanceStatePut{Action: "start", Timeout: -1}, "").Return(s.startOp, nil)
-	exp.GetInstance(hostName).Return(&lxdapi.Instance{Name: hostName, Type: "container"}, lxdtesting.ETag, nil)
+	inst := &lxdapi.Instance{
+		Name:        hostName,
+		Type:        "container",
+		InstancePut: lxdapi.InstancePut{Architecture: "amd64"},
+	}
+	exp.GetInstance(hostName).Return(inst, lxdtesting.ETag, nil)
 
 	// Supplying config for a single device with default bridge and without a
 	// CIDR will cause the default bridge to be updated with IPv4 config.

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -449,7 +449,7 @@ func (i *importer) modelUsers() error {
 func (i *importer) machines() error {
 	i.logger.Debugf("importing machines")
 	for _, m := range i.model.Machines() {
-		if err := i.machine(m); err != nil {
+		if err := i.machine(m, ""); err != nil {
 			i.logger.Errorf("error importing machine: %s", err)
 			return errors.Annotate(err, m.Id())
 		}
@@ -459,7 +459,7 @@ func (i *importer) machines() error {
 	return nil
 }
 
-func (i *importer) machine(m description.Machine) error {
+func (i *importer) machine(m description.Machine, arch string) error {
 	// Import this machine, then import its containers.
 	i.logger.Debugf("importing machine %s", m.Id())
 
@@ -516,7 +516,7 @@ func (i *importer) machine(m description.Machine) error {
 	)
 
 	// 3. create op for adding in instance data
-	prereqOps = append(prereqOps, i.machineInstanceOp(mdoc, instance))
+	prereqOps = append(prereqOps, i.machineInstanceOp(mdoc, instance, arch))
 
 	if parentId := container.ParentId(mdoc.Id); parentId != "" {
 		prereqOps = append(prereqOps,
@@ -557,7 +557,9 @@ func (i *importer) machine(m description.Machine) error {
 	// Now that this machine exists in the database, process each of the
 	// containers in this machine.
 	for _, container := range m.Containers() {
-		if err := i.machine(container); err != nil {
+		// Pass the parent machine's architecture when creating an op to fix
+		// a container's data.
+		if err := i.machine(container, m.Instance().Architecture()); err != nil {
 			return errors.Annotate(err, container.Id())
 		}
 	}
@@ -653,7 +655,11 @@ func (i *importer) applicationPortsOp(a description.Application) txn.Op {
 	}
 }
 
-func (i *importer) machineInstanceOp(mdoc *machineDoc, inst description.CloudInstance) txn.Op {
+// machineInstanceOp creates for txn operation for inserting a doc into
+// instance data collection. The parentArch is included to fix data from
+// older versions of juju where the architecture of a container was left
+// empty.
+func (i *importer) machineInstanceOp(mdoc *machineDoc, inst description.CloudInstance, parentArch string) txn.Op {
 	doc := &instanceData{
 		DocID:       mdoc.DocID,
 		MachineId:   mdoc.Id,
@@ -664,6 +670,8 @@ func (i *importer) machineInstanceOp(mdoc *machineDoc, inst description.CloudIns
 
 	if arch := inst.Architecture(); arch != "" {
 		doc.Arch = &arch
+	} else if parentArch != "" {
+		doc.Arch = &parentArch
 	}
 	if mem := inst.Memory(); mem != 0 {
 		doc.Mem = &mem

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -324,41 +324,47 @@ func (s *MigrationImportSuite) TestMeterStatusNotAvailable(c *gc.C) {
 }
 
 func (s *MigrationImportSuite) AssertMachineEqual(c *gc.C, newMachine, oldMachine *state.Machine) {
-	c.Assert(newMachine.Id(), gc.Equals, oldMachine.Id())
-	c.Assert(newMachine.Principals(), jc.DeepEquals, oldMachine.Principals())
-	c.Assert(newMachine.Base().String(), gc.Equals, oldMachine.Base().String())
-	c.Assert(newMachine.ContainerType(), gc.Equals, oldMachine.ContainerType())
+	c.Check(newMachine.Id(), gc.Equals, oldMachine.Id())
+	c.Check(newMachine.Principals(), jc.DeepEquals, oldMachine.Principals())
+	c.Check(newMachine.Base().String(), gc.Equals, oldMachine.Base().String())
+	c.Check(newMachine.ContainerType(), gc.Equals, oldMachine.ContainerType())
 	newHardware, err := newMachine.HardwareCharacteristics()
 	c.Assert(err, jc.ErrorIsNil)
 	oldHardware, err := oldMachine.HardwareCharacteristics()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(newHardware, jc.DeepEquals, oldHardware)
-	c.Assert(newMachine.Jobs(), jc.DeepEquals, oldMachine.Jobs())
-	c.Assert(newMachine.Life(), gc.Equals, oldMachine.Life())
+	if oldMachine.ContainerType() != instance.NONE && oldHardware.Arch == nil {
+		// test that containers have an architecture added during import
+		// if not already there.
+		oldHardware.Arch = strPtr("amd64")
+	}
+	c.Check(newHardware, jc.DeepEquals, oldHardware, gc.Commentf("machine %q", newMachine.Id()))
+
+	c.Check(newMachine.Jobs(), jc.DeepEquals, oldMachine.Jobs())
+	c.Check(newMachine.Life(), gc.Equals, oldMachine.Life())
 	newTools, err := newMachine.AgentTools()
 	c.Assert(err, jc.ErrorIsNil)
 	oldTools, err := oldMachine.AgentTools()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(newTools, jc.DeepEquals, oldTools)
+	c.Check(newTools, jc.DeepEquals, oldTools)
 
 	oldStatus, err := oldMachine.Status()
 	c.Assert(err, jc.ErrorIsNil)
 	newStatus, err := newMachine.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(newStatus, jc.DeepEquals, oldStatus)
+	c.Check(newStatus, jc.DeepEquals, oldStatus)
 
 	oldInstID, oldInstDisplayName, err := oldMachine.InstanceNames()
 	c.Assert(err, jc.ErrorIsNil)
 	newInstID, newInstDisplayName, err := newMachine.InstanceNames()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(newInstID, gc.Equals, oldInstID)
-	c.Assert(newInstDisplayName, gc.Equals, oldInstDisplayName)
+	c.Check(newInstID, gc.Equals, oldInstID)
+	c.Check(newInstDisplayName, gc.Equals, oldInstDisplayName)
 
 	oldStatus, err = oldMachine.InstanceStatus()
 	c.Assert(err, jc.ErrorIsNil)
 	newStatus, err = newMachine.InstanceStatus()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(newStatus, jc.DeepEquals, oldStatus)
+	c.Check(newStatus, jc.DeepEquals, oldStatus)
 }
 
 func (s *MigrationImportSuite) TestMachines(c *gc.C) {
@@ -373,6 +379,8 @@ func (s *MigrationImportSuite) TestMachines(c *gc.C) {
 	machine1 := s.Factory.MakeMachine(c, &factory.MachineParams{
 		Constraints: cons,
 		Characteristics: &instance.HardwareCharacteristics{
+			Arch:           cons.Arch,
+			Mem:            cons.Mem,
 			RootDiskSource: &source,
 		},
 		DisplayName: displayName,
@@ -388,16 +396,22 @@ func (s *MigrationImportSuite) TestMachines(c *gc.C) {
 	c.Assert(hardware, gc.NotNil)
 
 	_ = s.Factory.MakeMachineNested(c, machine1.Id(), nil)
+	_ = s.Factory.MakeMachineNested(c, machine1.Id(), &factory.MachineParams{
+		Constraints: constraints.MustParse("arch=arm64"),
+		Characteristics: &instance.HardwareCharacteristics{
+			Arch: cons.Arch,
+		},
+	})
 
 	allMachines, err := s.State.AllMachines()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(allMachines, gc.HasLen, 2)
+	c.Assert(allMachines, gc.HasLen, 3)
 
 	newModel, newSt := s.importModel(c, s.State)
 
 	importedMachines, err := newSt.AllMachines()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(importedMachines, gc.HasLen, 2)
+	c.Assert(importedMachines, gc.HasLen, 3)
 
 	// AllMachines returns the machines in the same order, yay us.
 	for i, newMachine := range importedMachines {
@@ -406,30 +420,34 @@ func (s *MigrationImportSuite) TestMachines(c *gc.C) {
 
 	// And a few extra checks.
 	parent := importedMachines[0]
-	container := importedMachines[1]
 	containers, err := parent.Containers()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(containers, jc.DeepEquals, []string{container.Id()})
-	parentId, isContainer := container.ParentId()
-	c.Assert(parentId, gc.Equals, parent.Id())
-	c.Assert(isContainer, jc.IsTrue)
+	c.Assert(containers, jc.SameContents, []string{importedMachines[1].Id(), importedMachines[2].Id()})
+	for _, cont := range []*state.Machine{importedMachines[1], importedMachines[2]} {
+		parentId, isContainer := cont.ParentId()
+		c.Assert(parentId, gc.Equals, parent.Id())
+		c.Assert(isContainer, jc.IsTrue)
+	}
 
 	s.assertAnnotations(c, newModel, parent)
 	s.checkStatusHistory(c, machine1, parent, 5)
 
 	newCons, err := parent.Constraints()
-	c.Assert(err, jc.ErrorIsNil)
-	// Can't test the constraints directly, so go through the string repr.
-	c.Assert(newCons.String(), gc.Equals, cons.String())
+	if c.Check(err, jc.ErrorIsNil) {
+		// Can't test the constraints directly, so go through the string repr.
+		c.Check(newCons.String(), gc.Equals, cons.String())
+	}
 
 	// Test the modification status is set to the initial state.
 	modStatus, err := parent.ModificationStatus()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(modStatus.Status, gc.Equals, status.Idle)
+	if c.Check(err, jc.ErrorIsNil) {
+		c.Check(modStatus.Status, gc.Equals, status.Idle)
+	}
 
 	characteristics, err := parent.HardwareCharacteristics()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(*characteristics.RootDiskSource, gc.Equals, "bunyan")
+	if c.Check(err, jc.ErrorIsNil) {
+		c.Check(*characteristics.RootDiskSource, gc.Equals, "bunyan")
+	}
 }
 
 func (s *MigrationImportSuite) TestMachineDevices(c *gc.C) {

--- a/state/upgrades.go
+++ b/state/upgrades.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/names/v5"
 
 	"github.com/juju/juju/core/charm"
+	"github.com/juju/juju/core/container"
 )
 
 // Until we add 3.0 upgrade steps, keep static analysis happy.
@@ -174,6 +175,62 @@ func FillInEmptyCharmhubTracks(pool *StatePool) error {
 				Update: bson.M{"$set": bson.M{"charm-origin.channel.track": "latest"}},
 			})
 		}
+		if len(ops) > 0 {
+			return errors.Trace(st.runRawTransaction(ops))
+		}
+		return nil
+	}))
+}
+
+// AssignArchToContainers assigns an architecture to container
+// instance data based on their host.
+func AssignArchToContainers(pool *StatePool) error {
+	return errors.Trace(runForAllModelStates(pool, func(st *State) error {
+		instData, closer := st.db().GetCollection(instanceDataC)
+		defer closer()
+
+		var containers []instanceData
+		if err := instData.Find(bson.M{"machineid": bson.M{"$regex": "[0-9]+/[a-z]+/[0-9]+"}}).All(&containers); err != nil {
+			return errors.Annotatef(err, "failed to read container instance data")
+		}
+		// Nothing to do if no containers in the model.
+		if len(containers) == 0 {
+			return nil
+		}
+
+		var machines []instanceData
+		if err := instData.Find(bson.D{{"machineid", bson.D{{"$regex", "^[0-9]+$"}}}}).All(&machines); err != nil {
+			return errors.Annotatef(err, "failed to read machine instance data")
+		}
+
+		machineArch := make(map[string]string, len(machines))
+
+		for _, machine := range machines {
+			if machine.Arch == nil {
+				logger.Errorf("no architecture for machine %q", machine.MachineId)
+			}
+			machineArch[machine.MachineId] = *machine.Arch
+		}
+
+		var ops []txn.Op
+		for _, cont := range containers {
+			if cont.Arch != nil {
+				continue
+			}
+			mID := container.ParentId(cont.MachineId)
+			a, ok := machineArch[mID]
+			if !ok {
+				logger.Errorf("no instance data for machine %q, but has container %q", mID, cont.MachineId)
+				continue
+			}
+			ops = append(ops, txn.Op{
+				C:      instanceDataC,
+				Id:     cont.DocID,
+				Assert: txn.DocExists,
+				Update: bson.M{"$set": bson.M{"arch": &a}},
+			})
+		}
+
 		if len(ops) > 0 {
 			return errors.Trace(st.runRawTransaction(ops))
 		}

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -255,3 +255,75 @@ func (s *upgradesSuite) TestFillInEmptyCharmhubTracks(c *gc.C) {
 	expectedData := upgradedData(applications, expected)
 	s.assertUpgradedData(c, FillInEmptyCharmhubTracks, expectedData)
 }
+
+func (s *upgradesSuite) TestAssignArchToContainers(c *gc.C) {
+	st := s.state
+	instanceDataColl, closer := st.db().GetRawCollection(instanceDataC)
+	defer closer()
+
+	err := instanceDataColl.Insert(bson.M{
+		"_id":        ensureModelUUID(st.ModelUUID(), "0"),
+		"model-uuid": st.ModelUUID(),
+		"machineid":  "0",
+		"arch":       "arm64",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	err = instanceDataColl.Insert(bson.M{
+		"_id":        ensureModelUUID(st.ModelUUID(), "0/lxd/7"),
+		"model-uuid": st.ModelUUID(),
+		"machineid":  "0/lxd/7",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	err = instanceDataColl.Insert(bson.M{
+		"_id":        ensureModelUUID(st.ModelUUID(), "2"),
+		"model-uuid": st.ModelUUID(),
+		"machineid":  "2",
+		"arch":       "amd64",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	err = instanceDataColl.Insert(bson.M{
+		"_id":        ensureModelUUID(st.ModelUUID(), "3"),
+		"model-uuid": st.ModelUUID(),
+		"machineid":  "3",
+		"arch":       "amd64",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	err = instanceDataColl.Insert(bson.M{
+		"_id":        ensureModelUUID(st.ModelUUID(), "3/kvm/2"),
+		"model-uuid": st.ModelUUID(),
+		"machineid":  "3/kvm/2",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	var expected bsonMById
+	expected = append(expected, bson.M{
+		"_id":        ensureModelUUID(st.ModelUUID(), "0"),
+		"model-uuid": st.ModelUUID(),
+		"machineid":  "0",
+		"arch":       "arm64",
+	}, bson.M{
+		"_id":        ensureModelUUID(st.ModelUUID(), "0/lxd/7"),
+		"model-uuid": st.ModelUUID(),
+		"machineid":  "0/lxd/7",
+		"arch":       "arm64",
+	}, bson.M{
+		"_id":        ensureModelUUID(st.ModelUUID(), "2"),
+		"model-uuid": st.ModelUUID(),
+		"machineid":  "2",
+		"arch":       "amd64",
+	}, bson.M{
+		"_id":        ensureModelUUID(st.ModelUUID(), "3"),
+		"model-uuid": st.ModelUUID(),
+		"machineid":  "3",
+		"arch":       "amd64",
+	}, bson.M{
+		"_id":        ensureModelUUID(st.ModelUUID(), "3/kvm/2"),
+		"model-uuid": st.ModelUUID(),
+		"machineid":  "3/kvm/2",
+		"arch":       "amd64",
+	})
+
+	sort.Sort(expected)
+	expectedData := upgradedData(instanceDataColl, expected)
+	s.assertUpgradedData(c, AssignArchToContainers, expectedData)
+}

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -13,6 +13,7 @@ import (
 type StateBackend interface {
 	ConvertApplicationOfferTokenKeys() error
 	FillInEmptyCharmhubTracks() error
+	AssignArchToContainers() error
 }
 
 // Model is an interface providing access to the details of a model within the
@@ -37,4 +38,8 @@ func (s stateBackend) ConvertApplicationOfferTokenKeys() error {
 
 func (s stateBackend) FillInEmptyCharmhubTracks() error {
 	return state.FillInEmptyCharmhubTracks(s.pool)
+}
+
+func (s stateBackend) AssignArchToContainers() error {
+	return state.AssignArchToContainers(s.pool)
 }

--- a/upgrades/operations.go
+++ b/upgrades/operations.go
@@ -32,8 +32,6 @@ var stateUpgradeOperations = func() []Operation {
 var upgradeOperations = func() []Operation {
 	steps := []Operation{
 		upgradeToVersion{version.MustParse("3.3.1"), stepsFor331()},
-		upgradeToVersion{version.MustParse("3.3.4"), stepsFor334()},
-		upgradeToVersion{version.MustParse("3.3.5"), stepsFor335()},
 	}
 	return steps
 }

--- a/upgrades/operations.go
+++ b/upgrades/operations.go
@@ -21,6 +21,7 @@ var stateUpgradeOperations = func() []Operation {
 	steps := []Operation{
 		upgradeToVersion{version.MustParse("3.3.1"), stateStepsFor331()},
 		upgradeToVersion{version.MustParse("3.3.4"), stateStepsFor334()},
+		upgradeToVersion{version.MustParse("3.3.5"), stateStepsFor335()},
 	}
 	return steps
 }
@@ -32,6 +33,7 @@ var upgradeOperations = func() []Operation {
 	steps := []Operation{
 		upgradeToVersion{version.MustParse("3.3.1"), stepsFor331()},
 		upgradeToVersion{version.MustParse("3.3.4"), stepsFor334()},
+		upgradeToVersion{version.MustParse("3.3.5"), stepsFor335()},
 	}
 	return steps
 }

--- a/upgrades/steps_331.go
+++ b/upgrades/steps_331.go
@@ -3,6 +3,10 @@
 
 package upgrades
 
+// stepsFor331 is a stub for how to write non-state upgrade tests. These are
+// rarely necessary. They have been used in the past for upgrade steps where
+// changes to workload machines are necessary. E.g. renaming the directory
+// where agent binaries are placed in /var/lib/juju.
 func stepsFor331() []Step {
 	return []Step{}
 }

--- a/upgrades/steps_334.go
+++ b/upgrades/steps_334.go
@@ -3,10 +3,6 @@
 
 package upgrades
 
-func stepsFor334() []Step {
-	return []Step{}
-}
-
 func stateStepsFor334() []Step {
 	return []Step{
 		&upgradeStep{

--- a/upgrades/steps_335.go
+++ b/upgrades/steps_335.go
@@ -3,10 +3,6 @@
 
 package upgrades
 
-func stepsFor335() []Step {
-	return []Step{}
-}
-
 func stateStepsFor335() []Step {
 	return []Step{
 		&upgradeStep{

--- a/upgrades/steps_335.go
+++ b/upgrades/steps_335.go
@@ -1,0 +1,20 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades
+
+func stepsFor335() []Step {
+	return []Step{}
+}
+
+func stateStepsFor335() []Step {
+	return []Step{
+		&upgradeStep{
+			description: "assign architectures to container's instance data",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().AssignArchToContainers()
+			},
+		},
+	}
+}

--- a/upgrades/steps_335_test.go
+++ b/upgrades/steps_335_test.go
@@ -1,0 +1,26 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version/v2"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/upgrades"
+)
+
+var v335 = version.MustParse("3.3.5")
+
+type steps335Suite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&steps335Suite{})
+
+func (s *steps335Suite) TestAssignArchToContainers(c *gc.C) {
+	step := findStateStep(c, v335, "assign architectures to container's instance data")
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
+}

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -599,6 +599,7 @@ func (s *upgradeSuite) TestStateUpgradeOperationsVersions(c *gc.C) {
 	c.Assert(versions, gc.DeepEquals, []string{
 		"3.3.1",
 		"3.3.4",
+		"3.3.5",
 	})
 }
 
@@ -606,6 +607,7 @@ func (s *upgradeSuite) TestUpgradeOperationsVersions(c *gc.C) {
 	versions := extractUpgradeVersions(c, (*upgrades.UpgradeOperations)())
 	c.Assert(versions, gc.DeepEquals, []string{
 		"3.3.1",
+		"3.3.4",
 		"3.3.4",
 	})
 }

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -607,8 +607,6 @@ func (s *upgradeSuite) TestUpgradeOperationsVersions(c *gc.C) {
 	versions := extractUpgradeVersions(c, (*upgrades.UpgradeOperations)())
 	c.Assert(versions, gc.DeepEquals, []string{
 		"3.3.1",
-		"3.3.4",
-		"3.3.4",
 	})
 }
 


### PR DESCRIPTION
The nil pointer panic was due to not checking the Arch pointer wasn't nil before using. Turns out that we aren't writing the architecture of LXD containers to their instance data. 

To deploy a charm, we need a platform composed of architecture, os and channel, e.g. amd64/ubuntu/22.04. When deploying to existing machines it's essential that we can find out the architecture to find the correct charm blob. 

Added code to write the architecture of the LXD container to their instance data when created to solve the above problem.

To fix this scenario for existing users, both upgrade and migration steps are necessary. The KVM container manager already assumes that the architecture is the same as the host. LXD only supports the same architecture. Therefore upgrade and migration is straightforward.

While in the placement code for deploy, fixed a few holes:
- Require the instance data to be able before deploying when a machine scoped placement directive.
- Ensure we find all machines when attempting to find the base for deploy.
- Match the placement machine deployed base with any requested base from the user.

We had a placement directive ploy test, I enhanced it to include a container. For LXD providers, the host machine is created as a virtual-machine to enable nested containers.


## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Updated the test for deploying a charm with placement to catch this case, it's the second test.
```
(cd tests ; ./main.sh  -v deploy test_deploy_charms )
```

Manual qa
```
# bootstrap controller for upgrade and migration tests.
$ snap install juju_334 --channel 3.3/stable
$ juju_334 bootstrap localhost three-three-stable

$ juju_334 add-model upgrade-me
$ juju_334 add-machine --constraints virt-type=virtual-machine
$ juju_334 add-machine lxd:0

$ juju_334 add-model migrate-me
$ juju_334 add-machine --constraints virt-type=virtual-machine
$ juju_334 add-machine lxd:0

# you can verify the panic at this point if you wish on either model

-------------------------------------------------------------------------------------------------

# Using the juju under test, bootstrap
$ juju bootstrap localhost destination

# Create a model to test.
# Machine 0 should be running 22.04, machine 1 should be running 20.04
$ juju add-model test-no-panic
$ juju add-machine --constraints virt-type=virtual-machine
created machine 0
$ juju add-machine lxd:0
created container 0/lxd/0
$ juju add-machine --constraints virt-type=virtual-machine --base ubuntu@20.04
created machine 1
$ juju add-machine lxd:1 --base ubuntu@20.04
created container 1/lxd/0

# Test nil pointer panic doesn't happen.
$ juju deploy ubuntu-lite --to 0/lxd/0
Deployed "ubuntu-lite" from charm-hub charm "ubuntu-lite", revision 1 in channel latest/stable on ubuntu@22.04/stable

# Test the correct base is chosen
$ juju deploy ubuntu-lite --to 1/lxd/0 ubuntu-lite-focal

# Depending on how fast you run the commands, deploy will fail if the machine or container
# machine scoped in the placement directive does not exist. We're unable to find the base
# for deployment until the machine base and instance data is filled in.
$ juju deploy ubuntu-lite --to 1/lxd/0 ubuntu-lite-focal
ERROR machine "1/lxd/0" not started, please retry when started
ERROR failed to deploy charm "ubuntu-lite"

# Retry works, with the correct base found for the container.
# $ juju deploy ubuntu-lite --to 1/lxd/0 ubuntu-lite-focal
Deployed "ubuntu-lite-focal" from charm-hub charm "ubuntu-lite", revision 1 in channel latest/stable on ubuntu@20.04/stable

# Attempting to deploy to 2 existing machines with different bases should fail.
$ juju deploy ubuntu-lite --to 1/lxd/1,0/lxd/0 -n 2 ubuntu-lite-jammy
ERROR bases of existing placement machines do not match each other
ERROR failed to deploy charm "ubuntu-lite"

# Specifying a base different from the machine scoped placement directive should fail.
$ juju deploy ubuntu-lite --to 1/lxd/1 ubuntu-lite-jammy --base ubuntu@22.04
ERROR base from placements, "amd64/ubuntu/20.04/stable", does not match requested base "amd64/ubuntu/22.04/stable"
ERROR failed to deploy charm "ubuntu-lite"

-------------------------------------------------------------------------------------------------

# Verify migration resolves the nil pointer panic.
$ juju switch three-three
$ juju migrate migrate-me destination
Migration started with ID "ea982527-9234-4fa8-85a1-9dd8844b90be:0"
$ juju switch destination:admin/migrate-me
$ juju deploy ubuntu-lite --to 0/lxd/0
Deployed "ubuntu-lite" from charm-hub charm "ubuntu-lite", revision 1 in channel latest/stable on ubuntu@22.04/stable

-------------------------------------------------------------------------------------------------

# Verify upgrade resolves the nil pointer panic.
$ juju switch three-three:admin/test-no-panic
$ juju upgrade-controller --build-agent
$ juju upgrade-model
$ juju deploy ubuntu-lite --to 0/lxd/0
Deployed "ubuntu-lite" from charm-hub charm "ubuntu-lite", revision 1 in channel latest/stable on ubuntu@22.04/stable

## Links

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2064174

**Jira card:** JUJU-5984

