### PR TITLE
Remove redundant methods from logger

### DIFF
--- a/api/controller/crossmodelrelations/crossmodelrelations.go
+++ b/api/controller/crossmodelrelations/crossmodelrelations.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/juju/juju/api/base"
 	apiwatcher "github.com/juju/juju/api/watcher"
-	corellogger "github.com/juju/juju/core/logger"
+	corelogger "github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/watcher"
 	internallogger "github.com/juju/juju/internal/logger"
 	"github.com/juju/juju/rpc/params"
@@ -79,7 +79,7 @@ func (c *Client) handleError(ctx context.Context, apiErr error) (macaroon.Slice,
 		}
 	}
 	ms, err := c.facade.RawAPICaller().BakeryClient().DischargeAll(ctx, m)
-	if err == nil && logger.IsLevelEnabled(corellogger.TRACE) {
+	if err == nil && logger.IsLevelEnabled(corelogger.TRACE) {
 		logger.Tracef("discharge macaroon ids:")
 		for _, m := range ms {
 			logger.Tracef("  - %v", m.Id())
@@ -95,7 +95,7 @@ func (c *Client) getCachedMacaroon(opName, token string) (macaroon.Slice, bool) 
 	ms, ok := c.cache.Get(token)
 	if ok {
 		logger.Debugf("%s using cached macaroons for %s", opName, token)
-		if logger.IsLevelEnabled(corellogger.TRACE) {
+		if logger.IsLevelEnabled(corelogger.TRACE) {
 			for _, m := range ms {
 				logger.Tracef("  - %v", m.Id())
 			}

--- a/api/controller/crossmodelrelations/crossmodelrelations.go
+++ b/api/controller/crossmodelrelations/crossmodelrelations.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/juju/juju/api/base"
 	apiwatcher "github.com/juju/juju/api/watcher"
+	corellogger "github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/watcher"
 	internallogger "github.com/juju/juju/internal/logger"
 	"github.com/juju/juju/rpc/params"
@@ -78,7 +79,7 @@ func (c *Client) handleError(ctx context.Context, apiErr error) (macaroon.Slice,
 		}
 	}
 	ms, err := c.facade.RawAPICaller().BakeryClient().DischargeAll(ctx, m)
-	if err == nil && logger.IsTraceEnabled() {
+	if err == nil && logger.IsLevelEnabled(corellogger.TRACE) {
 		logger.Tracef("discharge macaroon ids:")
 		for _, m := range ms {
 			logger.Tracef("  - %v", m.Id())
@@ -94,7 +95,7 @@ func (c *Client) getCachedMacaroon(opName, token string) (macaroon.Slice, bool) 
 	ms, ok := c.cache.Get(token)
 	if ok {
 		logger.Debugf("%s using cached macaroons for %s", opName, token)
-		if logger.IsTraceEnabled() {
+		if logger.IsLevelEnabled(corellogger.TRACE) {
 			for _, m := range ms {
 				logger.Tracef("  - %v", m.Id())
 			}

--- a/api/controller/crossmodelsecrets/crossmodelsecrets.go
+++ b/api/controller/crossmodelsecrets/crossmodelsecrets.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/controller/crossmodelrelations"
 	apiservererrors "github.com/juju/juju/apiserver/errors"
+	corelogger "github.com/juju/juju/core/logger"
 	coresecrets "github.com/juju/juju/core/secrets"
 	internallogger "github.com/juju/juju/internal/logger"
 	"github.com/juju/juju/internal/secrets"
@@ -69,7 +70,7 @@ func (c *Client) handleDischargeError(ctx context.Context, apiErr error) (macaro
 
 	m := info.BakeryMacaroon
 	ms, err := c.facade.RawAPICaller().BakeryClient().DischargeAll(ctx, m)
-	if err == nil && logger.IsTraceEnabled() {
+	if err == nil && logger.IsLevelEnabled(corelogger.TRACE) {
 		logger.Tracef("discharge macaroon ids:")
 		for _, m := range ms {
 			logger.Tracef("  - %v", m.Id())
@@ -85,7 +86,7 @@ func (c *Client) getCachedMacaroon(opName, token string) (macaroon.Slice, bool) 
 	ms, ok := c.cache.Get(token)
 	if ok {
 		logger.Debugf("%s using cached macaroons for %s", opName, token)
-		if logger.IsTraceEnabled() {
+		if logger.IsLevelEnabled(corelogger.TRACE) {
 			for _, m := range ms {
 				logger.Tracef("  - %v", m.Id())
 			}

--- a/api/watcher/watcher.go
+++ b/api/watcher/watcher.go
@@ -344,7 +344,7 @@ func (w *relationUnitsWatcher) loop(initialChanges params.RelationUnitsChange) e
 		select {
 		// Send the initial event or subsequent change.
 		case w.out <- changes:
-			if w.logger.IsTraceEnabled() {
+			if w.logger.IsLevelEnabled(corelogger.TRACE) {
 				w.logger.Tracef("sent relation units changes %# v", pretty.Formatter(changes))
 			}
 		case <-w.tomb.Dying():
@@ -416,7 +416,7 @@ func (w *remoteRelationWatcher) loop(initialChange params.RemoteRelationChangeEv
 		select {
 		// Send out the initial event or subsequent change.
 		case w.out <- change:
-			if w.logger.IsTraceEnabled() {
+			if w.logger.IsLevelEnabled(corelogger.TRACE) {
 				w.logger.Tracef("sent remote relation change %# v", pretty.Formatter(change))
 			}
 		case <-w.tomb.Dying():

--- a/apiserver/authentication/user.go
+++ b/apiserver/authentication/user.go
@@ -19,6 +19,7 @@ import (
 	"gopkg.in/macaroon.v2"
 
 	apiservererrors "github.com/juju/juju/apiserver/errors"
+	corelogger "github.com/juju/juju/core/logger"
 	coremacaroon "github.com/juju/juju/core/macaroon"
 	coreuser "github.com/juju/juju/core/user"
 	usererrors "github.com/juju/juju/domain/access/errors"
@@ -148,7 +149,7 @@ func (u *LocalUserAuthenticator) Authenticate(
 
 func (u *LocalUserAuthenticator) authenticateMacaroons(ctx context.Context, userTag names.UserTag, authParams AuthParams) (state.Entity, error) {
 	// Check for a valid request macaroon.
-	if logger.IsTraceEnabled() {
+	if logger.IsLevelEnabled(corelogger.TRACE) {
 		mac, _ := json.Marshal(authParams.Macaroons)
 		logger.Tracef("authentication macaroons for %s: %s", userTag, mac)
 	}

--- a/apiserver/bakeryutil/service.go
+++ b/apiserver/bakeryutil/service.go
@@ -13,6 +13,7 @@ import (
 	"gopkg.in/macaroon.v2"
 
 	"github.com/juju/juju/apiserver/authentication"
+	corelogger "github.com/juju/juju/core/logger"
 	internallogger "github.com/juju/juju/internal/logger"
 	"github.com/juju/juju/state/bakerystorage"
 )
@@ -63,7 +64,7 @@ var logger = internallogger.GetLogger("juju.apiserver.bakery")
 
 // Auth implements MacaroonChecker.Auth.
 func (s *ExpirableStorageBakery) Auth(ctx context.Context, mss ...macaroon.Slice) *bakery.AuthChecker {
-	if logger.IsTraceEnabled() {
+	if logger.IsLevelEnabled(corelogger.TRACE) {
 		for i, ms := range mss {
 			ops, conditions, err := s.Oven.VerifyMacaroon(ctx, ms)
 			if err != nil {

--- a/apiserver/charms.go
+++ b/apiserver/charms.go
@@ -101,7 +101,7 @@ func (h *charmsHandler) ServeUnsupported(w http.ResponseWriter, r *http.Request)
 }
 
 func (h *charmsHandler) ServePost(w http.ResponseWriter, r *http.Request) error {
-	if h.logger.IsTraceEnabled() {
+	if h.logger.IsLevelEnabled(corelogger.TRACE) {
 		h.logger.Tracef("ServePost(%s)", r.URL)
 	}
 
@@ -130,7 +130,7 @@ func (h *charmsHandler) ServePost(w http.ResponseWriter, r *http.Request) error 
 }
 
 func (h *charmsHandler) ServeGet(w http.ResponseWriter, r *http.Request) error {
-	if h.logger.IsTraceEnabled() {
+	if h.logger.IsLevelEnabled(corelogger.TRACE) {
 		h.logger.Tracef("ServeGet(%s)", r.URL)
 	}
 

--- a/apiserver/errors/errors.go
+++ b/apiserver/errors/errors.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/juju/juju/core/leadership"
 	"github.com/juju/juju/core/lease"
+	corelogger "github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/upgrade"
 	secreterrors "github.com/juju/juju/domain/secret/errors"
 	secretbackenderrors "github.com/juju/juju/domain/secretbackend/errors"
@@ -146,7 +147,7 @@ func ServerError(err error) *params.Error {
 	if err == nil {
 		return nil
 	}
-	if logger.IsTraceEnabled() {
+	if logger.IsLevelEnabled(corelogger.TRACE) {
 		logger.Tracef("server RPC error %v", errors.Details(err))
 	}
 

--- a/apiserver/facades/agent/secretsmanager/register.go
+++ b/apiserver/facades/agent/secretsmanager/register.go
@@ -98,6 +98,6 @@ func NewSecretManagerAPI(stdCtx context.Context, ctx facade.ModelContext) (*Secr
 		modelUUID:            ctx.State().ModelUUID(),
 		remoteClientGetter:   remoteClientGetter,
 		crossModelState:      ctx.State().RemoteEntities(),
-		logger:               ctx.Logger().ChildWithTags("secretsmanager", corelogger.SECRETS),
+		logger:               ctx.Logger().Child("secretsmanager", corelogger.SECRETS),
 	}, nil
 }

--- a/apiserver/facades/client/application/deployrepository.go
+++ b/apiserver/facades/client/application/deployrepository.go
@@ -25,6 +25,7 @@ import (
 	"github.com/juju/juju/core/config"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/logger"
 	corelogger "github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/objectstore"
 	applicationservice "github.com/juju/juju/domain/application/service"
@@ -423,7 +424,7 @@ func (v *deployFromRepositoryValidator) validate(ctx context.Context, arg params
 	dt.pendingResourceUploads = pendingResourceUploads
 	dt.resolvedResources = resources
 
-	if v.logger.IsTraceEnabled() {
+	if v.logger.IsLevelEnabled(logger.TRACE) {
 		v.logger.Tracef("validateDeployFromRepositoryArgs returning: %s", pretty.Sprint(dt))
 	}
 	return dt, errs

--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -21,6 +21,7 @@ import (
 	"github.com/juju/juju/core/container"
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/life"
+	corelogger "github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/lxdprofile"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/network"
@@ -322,7 +323,7 @@ func (c *Client) FullStatus(ctx context.Context, args params.StatusParams) (para
 		}
 	}
 
-	if logger.IsTraceEnabled() {
+	if logger.IsLevelEnabled(corelogger.TRACE) {
 		logger.Tracef("Applications: %v", context.allAppsUnitsCharmBindings.applications)
 		logger.Tracef("Remote applications: %v", context.consumerRemoteApplications)
 		logger.Tracef("Offers: %v", context.offers)

--- a/apiserver/facades/client/resources/facade.go
+++ b/apiserver/facades/client/resources/facade.go
@@ -78,7 +78,7 @@ func NewFacade(ctx facade.ModelContext) (*API, error) {
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
-			return repository.NewCharmHubRepository(logger.ChildWithTags("charmhub", corelogger.CHARMHUB), chClient), nil
+			return repository.NewCharmHubRepository(logger.Child("charmhub", corelogger.CHARMHUB), chClient), nil
 
 		case charm.Local.Matches(schema):
 			return &localClient{}, nil

--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
@@ -24,6 +24,7 @@ import (
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/apiserver/internal"
 	"github.com/juju/juju/core/life"
+	"github.com/juju/juju/core/logger"
 	corelogger "github.com/juju/juju/core/logger"
 	coremacaroon "github.com/juju/juju/core/macaroon"
 	"github.com/juju/juju/core/secrets"
@@ -396,7 +397,7 @@ func (api *CrossModelRelationsAPIv3) WatchRelationChanges(ctx context.Context, r
 	for i, arg := range remoteRelationArgs.Args {
 		w, changes, err := watchOne(arg)
 		if err != nil {
-			if api.logger.IsTraceEnabled() {
+			if api.logger.IsLevelEnabled(logger.TRACE) {
 				api.logger.Tracef("error watching relation for token %s: %s", arg.Token, errors.ErrorStack(err))
 			} else {
 				api.logger.Debugf("error watching relation for token %s: %v", err)

--- a/apiserver/facades/controller/crossmodelrelations/register.go
+++ b/apiserver/facades/controller/crossmodelrelations/register.go
@@ -46,6 +46,6 @@ func newStateCrossModelRelationsAPI(ctx facade.ModelContext) (*CrossModelRelatio
 		watchRelationLifeSuspendedStatus,
 		watchOfferStatus,
 		watchConsumedSecrets,
-		ctx.Logger().ChildWithTags("crossmodelrelations", corelogger.CMR),
+		ctx.Logger().Child("crossmodelrelations", corelogger.CMR),
 	)
 }

--- a/apiserver/facades/controller/crossmodelsecrets/register.go
+++ b/apiserver/facades/controller/crossmodelsecrets/register.go
@@ -53,6 +53,6 @@ func newStateCrossModelSecretsAPI(stdCtx context.Context, ctx facade.MultiModelC
 		backendService,
 		&crossModelShim{st.RemoteEntities()},
 		&stateBackendShim{st},
-		ctx.Logger().ChildWithTags("crossmodelsecrets", corelogger.SECRETS),
+		ctx.Logger().Child("crossmodelsecrets", corelogger.SECRETS),
 	)
 }

--- a/apiserver/facades/controller/remoterelations/register.go
+++ b/apiserver/facades/controller/remoterelations/register.go
@@ -38,6 +38,6 @@ func newAPI(ctx facade.ModelContext) (*API, error) {
 		serviceFactory.Secret(secretservice.NotImplementedBackendConfigGetter),
 		common.NewControllerConfigAPI(systemState, controllerConfigService, externalControllerService),
 		ctx.Resources(), ctx.Auth(),
-		ctx.Logger().ChildWithTags("remoterelations", corelogger.CMR),
+		ctx.Logger().Child("remoterelations", corelogger.CMR),
 	)
 }

--- a/apiserver/observer/request_notifier.go
+++ b/apiserver/observer/request_notifier.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/clock"
 	"github.com/juju/names/v5"
 
+	"github.com/juju/juju/core/logger"
 	corelogger "github.com/juju/juju/core/logger"
 	"github.com/juju/juju/internal/pubsub/apiserver"
 	"github.com/juju/juju/rpc"
@@ -164,13 +165,13 @@ func (n *rpcObserver) ServerRequest(hdr *rpc.Header, body interface{}) {
 	// We know that if *at least* debug logging is not enabled, there will be
 	// nothing to do here. Since this is a hot path, we can avoid the call to
 	// DumpRequest below that would otherwise still be paid for every request.
-	if !n.logger.IsDebugEnabled() {
+	if !n.logger.IsLevelEnabled(logger.DEBUG) {
 		return
 	}
 
 	n.requestStart = n.clock.Now()
 
-	tracing := n.logger.IsTraceEnabled()
+	tracing := n.logger.IsLevelEnabled(logger.TRACE)
 
 	if hdr.Request.Type == "Pinger" && hdr.Request.Action == "Ping" {
 		if tracing {
@@ -194,11 +195,11 @@ func (n *rpcObserver) ServerReply(req rpc.Request, hdr *rpc.Header, body interfa
 	// We know that if *at least* debug logging is not enabled, there will be
 	// nothing to do here. Since this is a hot path, we can avoid the call to
 	// DumpRequest below that would otherwise still be paid for every reply.
-	if !n.logger.IsDebugEnabled() {
+	if !n.logger.IsLevelEnabled(logger.DEBUG) {
 		return
 	}
 
-	tracing := n.logger.IsTraceEnabled()
+	tracing := n.logger.IsLevelEnabled(logger.TRACE)
 
 	if req.Type == "Pinger" && req.Action == "Ping" {
 		if tracing {

--- a/apiserver/root.go
+++ b/apiserver/root.go
@@ -156,7 +156,7 @@ func newAPIHandler(
 		}
 	}
 
-	registry, err := registry.NewRegistry(srv.clock, registry.WithLogger(logger.ChildWithTags("registry", corelogger.WATCHERS)))
+	registry, err := registry.NewRegistry(srv.clock, registry.WithLogger(logger.Child("registry", corelogger.WATCHERS)))
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/cmd/juju/application/deployer/bundlehandler.go
+++ b/cmd/juju/application/deployer/bundlehandler.go
@@ -37,6 +37,7 @@ import (
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/devices"
 	"github.com/juju/juju/core/instance"
+	corelogger "github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/lxdprofile"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/environs/config"
@@ -485,7 +486,7 @@ func (h *bundleHandler) getChanges() error {
 		Logger:           logger,
 		Force:            h.force,
 	}
-	if logger.IsTraceEnabled() {
+	if logger.IsLevelEnabled(corelogger.TRACE) {
 		logger.Tracef("bundlechanges.ChangesConfig.Bundle %s", pretty.Sprint(cfg.Bundle))
 		logger.Tracef("bundlechanges.ChangesConfig.BundleURL %s", pretty.Sprint(cfg.BundleURL))
 		logger.Tracef("bundlechanges.ChangesConfig.Model %s", pretty.Sprint(cfg.Model))
@@ -494,7 +495,7 @@ func (h *bundleHandler) getChanges() error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if logger.IsTraceEnabled() {
+	if logger.IsLevelEnabled(corelogger.TRACE) {
 		logger.Tracef("changes %s", pretty.Sprint(changes))
 	}
 	h.changes = changes
@@ -524,7 +525,7 @@ func (h *bundleHandler) handleChanges(ctx context.Context) error {
 	// Deploy the bundle.
 	for i, change := range h.changes {
 		fmt.Fprint(h.ctx.Stdout, fmtChange(change))
-		if logger.IsTraceEnabled() {
+		if logger.IsLevelEnabled(corelogger.TRACE) {
 			logger.Tracef("%d: change %s", i, pretty.Sprint(change))
 		}
 		switch change := change.(type) {
@@ -1107,7 +1108,7 @@ func (h *bundleHandler) addMachine(change *bundlechanges.AddMachineChange) error
 		return errors.Annotatef(r[0].Error, "cannot create machine for holding %s", deployedApps())
 	}
 	machine := r[0].Machine
-	if logger.IsDebugEnabled() {
+	if logger.IsLevelEnabled(corelogger.DEBUG) {
 		// Only do the work in for deployedApps, if debugging is enabled.
 		if p.ContainerType == "" {
 			logger.Debugf("created new machine %s for holding %s", machine, deployedApps())

--- a/cmd/juju/cloud/updatepublicclouds.go
+++ b/cmd/juju/cloud/updatepublicclouds.go
@@ -120,7 +120,7 @@ func (l httpLogger) IsTraceEnabled() bool {
 func PublishedPublicClouds(ctx context.Context, url, key string) (map[string]jujucloud.Cloud, error) {
 	client := jujuhttp.NewClient(
 		jujuhttp.WithLogger(httpLogger{
-			Logger: logger.ChildWithTags("http", corelogger.HTTP),
+			Logger: logger.Child("http", corelogger.HTTP),
 		}),
 	)
 	resp, err := client.Get(ctx, url)

--- a/cmd/juju/cloud/updatepublicclouds.go
+++ b/cmd/juju/cloud/updatepublicclouds.go
@@ -108,9 +108,20 @@ func (c *updatePublicCloudsCommand) Init(args []string) error {
 	return cmd.CheckEmpty(args)
 }
 
+type httpLogger struct {
+	corelogger.Logger
+}
+
+func (l httpLogger) IsTraceEnabled() bool {
+	return l.IsLevelEnabled(corelogger.TRACE)
+}
+
+// PublishedPublicClouds retrieves public cloud information from the given URL.
 func PublishedPublicClouds(ctx context.Context, url, key string) (map[string]jujucloud.Cloud, error) {
 	client := jujuhttp.NewClient(
-		jujuhttp.WithLogger(logger.ChildWithTags("http", corelogger.HTTP)),
+		jujuhttp.WithLogger(httpLogger{
+			Logger: logger.ChildWithTags("http", corelogger.HTTP),
+		}),
 	)
 	resp, err := client.Get(ctx, url)
 	if err != nil {

--- a/cmd/juju/controller/register.go
+++ b/cmd/juju/controller/register.go
@@ -637,7 +637,7 @@ func (c *registerCommand) secretKeyLogin(
 		jujuhttp.WithSkipHostnameVerification(true),
 		jujuhttp.WithCookieJar(cookieJar),
 		jujuhttp.WithLogger(httpLogger{
-			Logger: logger.ChildWithTags("http", corelogger.HTTP),
+			Logger: logger.Child("http", corelogger.HTTP),
 		}),
 	)
 	httpResp, err := httpClient.Do(httpReq)

--- a/cmd/juju/controller/register.go
+++ b/cmd/juju/controller/register.go
@@ -636,7 +636,9 @@ func (c *registerCommand) secretKeyLogin(
 	httpClient := jujuhttp.NewClient(
 		jujuhttp.WithSkipHostnameVerification(true),
 		jujuhttp.WithCookieJar(cookieJar),
-		jujuhttp.WithLogger(logger.ChildWithTags("http", corelogger.HTTP)),
+		jujuhttp.WithLogger(httpLogger{
+			Logger: logger.ChildWithTags("http", corelogger.HTTP),
+		}),
 	)
 	httpResp, err := httpClient.Do(httpReq)
 	if err != nil {
@@ -794,4 +796,12 @@ func genAlreadyRegisteredError(controller, user string) error {
 		return err
 	}
 	return errors.New(buf.String())
+}
+
+type httpLogger struct {
+	corelogger.Logger
+}
+
+func (l httpLogger) IsTraceEnabled() bool {
+	return l.IsLevelEnabled(corelogger.TRACE)
 }

--- a/core/logger/interface.go
+++ b/core/logger/interface.go
@@ -138,10 +138,7 @@ type Logger interface {
 	IsLevelEnabled(Level) bool
 
 	// Child returns a new logger with the given name.
-	Child(name string) Logger
-
-	// ChildWithTags returns a new logger with the given name and tags.
-	ChildWithTags(string, ...string) Logger
+	Child(name string, tags ...string) Logger
 
 	// GetChildByName returns a child logger with the given name.
 	GetChildByName(name string) Logger

--- a/core/logger/interface.go
+++ b/core/logger/interface.go
@@ -134,22 +134,6 @@ type Logger interface {
 	// fmt.Sprintf.
 	Logf(level Level, format string, args ...any)
 
-	// IsEnabled returns true if the given level is enabled for the logger.
-	IsErrorEnabled() bool
-
-	// IsWarningEnabled returns true if the warning level is enabled for the
-	// logger.
-	IsWarningEnabled() bool
-
-	// IsInfoEnabled returns true if the info level is enabled for the logger.
-	IsInfoEnabled() bool
-
-	// IsDebugEnabled returns true if the debug level is enabled for the logger.
-	IsDebugEnabled() bool
-
-	// IsTraceEnabled returns true if the trace level is enabled for the logger.
-	IsTraceEnabled() bool
-
 	// IsLevelEnabled returns true if the given level is enabled for the logger.
 	IsLevelEnabled(Level) bool
 

--- a/core/watcher/registry/registry.go
+++ b/core/watcher/registry/registry.go
@@ -174,15 +174,15 @@ func (r *Registry) loop() error {
 
 // watcherLogDecorator returns a function that wraps a worker.Worker with a
 // LoggingWatcher.
-func watcherLogDecorator(logger logger.Logger) func(worker.Worker) (worker.Worker, error) {
+func watcherLogDecorator(l logger.Logger) func(worker.Worker) (worker.Worker, error) {
 	return func(w worker.Worker) (worker.Worker, error) {
-		if logger == nil {
+		if l == nil {
 			return w, nil
 		}
-		if logger.IsTraceEnabled() {
-			logger.Tracef("starting watcher %T", w)
+		if l.IsLevelEnabled(logger.TRACE) {
+			l.Tracef("starting watcher %T", w)
 		}
-		return NewLoggingWatcher(w, logger), nil
+		return NewLoggingWatcher(w, l), nil
 	}
 }
 
@@ -203,7 +203,7 @@ func NewLoggingWatcher(w worker.Worker, logger logger.Logger) *LoggingWatcher {
 
 // Kill asks the worker to stop and returns immediately.
 func (l *LoggingWatcher) Kill() {
-	if l.logger.IsTraceEnabled() {
+	if l.logger.IsLevelEnabled(logger.TRACE) {
 		l.logger.Tracef("killing watcher %T", l.worker)
 	}
 	l.worker.Kill()
@@ -213,7 +213,7 @@ func (l *LoggingWatcher) Kill() {
 // error encountered when it was running or stopping.
 func (l *LoggingWatcher) Wait() error {
 	err := l.worker.Wait()
-	if l.logger.IsTraceEnabled() {
+	if l.logger.IsLevelEnabled(logger.TRACE) {
 		l.logger.Tracef("watcher %T finished with error %v", l.worker, err)
 	}
 	return errors.Trace(err)

--- a/environs/simplestreams/datasource.go
+++ b/environs/simplestreams/datasource.go
@@ -135,7 +135,7 @@ func NewDataSource(cfg Config) DataSource {
 		jujuhttp.WithSkipHostnameVerification(!cfg.HostnameVerification),
 		jujuhttp.WithCACertificates(cfg.CACertificates...),
 		jujuhttp.WithLogger(httpLogger{
-			Logger: logger.ChildWithTags("http", corelogger.HTTP),
+			Logger: logger.Child("http", corelogger.HTTP),
 		}),
 	)
 	return NewDataSourceWithClient(cfg, client)

--- a/environs/simplestreams/datasource.go
+++ b/environs/simplestreams/datasource.go
@@ -134,7 +134,9 @@ func NewDataSource(cfg Config) DataSource {
 	client := jujuhttp.NewClient(
 		jujuhttp.WithSkipHostnameVerification(!cfg.HostnameVerification),
 		jujuhttp.WithCACertificates(cfg.CACertificates...),
-		jujuhttp.WithLogger(logger.ChildWithTags("http", corelogger.HTTP)),
+		jujuhttp.WithLogger(httpLogger{
+			Logger: logger.ChildWithTags("http", corelogger.HTTP),
+		}),
 	)
 	return NewDataSourceWithClient(cfg, client)
 }
@@ -243,4 +245,12 @@ func (h *urlDataSource) Priority() int {
 // RequireSigned is defined in simplestreams.DataSource.
 func (h *urlDataSource) RequireSigned() bool {
 	return h.requireSigned
+}
+
+type httpLogger struct {
+	corelogger.Logger
+}
+
+func (l httpLogger) IsTraceEnabled() bool {
+	return l.IsLevelEnabled(corelogger.TRACE)
 }

--- a/environs/tools/build.go
+++ b/environs/tools/build.go
@@ -20,6 +20,7 @@ import (
 	"github.com/juju/version/v2"
 
 	"github.com/juju/juju/core/arch"
+	corelogger "github.com/juju/juju/core/logger"
 	coreos "github.com/juju/juju/core/os"
 	"github.com/juju/juju/juju/names"
 	jujuversion "github.com/juju/juju/version"
@@ -299,7 +300,7 @@ func buildJujus(dir string) error {
 		if err != nil {
 			return fmt.Errorf("build command %q failed: %v; %s", args[0], err, out)
 		}
-		if logger.IsTraceEnabled() {
+		if logger.IsLevelEnabled(corelogger.TRACE) {
 			logger.Tracef("Built jujud:\n%s", out)
 		}
 	}

--- a/internal/changestream/eventmultiplexer/eventmultiplexer.go
+++ b/internal/changestream/eventmultiplexer/eventmultiplexer.go
@@ -368,7 +368,7 @@ func (e *EventMultiplexer) gatherSubscriptions(ch changestream.ChangeEvent) []*s
 		subs[id] = e.subscriptions[id]
 	}
 
-	traceEnabled := e.logger.IsTraceEnabled()
+	traceEnabled := e.logger.IsLevelEnabled(logger.TRACE)
 	for _, subOpt := range e.subscriptionsByNS[ch.Namespace()] {
 		if _, ok := subs[subOpt.subscriptionID]; ok {
 			continue

--- a/internal/changestream/stream/stream.go
+++ b/internal/changestream/stream/stream.go
@@ -312,7 +312,7 @@ func (s *Stream) loop() error {
 
 				lower        = int64(math.MaxInt64)
 				upper        = int64(math.MinInt64)
-				traceEnabled = s.logger.IsTraceEnabled()
+				traceEnabled = s.logger.IsLevelEnabled(logger.TRACE)
 			)
 			for _, change := range changes {
 				if traceEnabled {

--- a/internal/charm/services/downloader.go
+++ b/internal/charm/services/downloader.go
@@ -48,7 +48,7 @@ func NewCharmDownloader(cfg CharmDownloaderConfig) (*charmdownloader.Downloader,
 		}),
 	}
 
-	return charmdownloader.NewDownloader(cfg.Logger.ChildWithTags("charmdownloader", corelogger.CHARMHUB), storage, repoFactory), nil
+	return charmdownloader.NewDownloader(cfg.Logger.Child("charmdownloader", corelogger.CHARMHUB), storage, repoFactory), nil
 }
 
 // repoFactoryShim wraps a CharmRepoFactory and is compatible with the

--- a/internal/charm/services/repofactory.go
+++ b/internal/charm/services/repofactory.go
@@ -80,7 +80,7 @@ func (f *CharmRepoFactory) GetCharmRepository(ctx context.Context, src corecharm
 		}
 
 		repo = charmrepo.NewCharmHubRepository(
-			f.logger.ChildWithTags("charmhubrepo", corelogger.CHARMHUB),
+			f.logger.Child("charmhubrepo", corelogger.CHARMHUB),
 			chClient,
 		)
 	default:

--- a/internal/charmhub/client.go
+++ b/internal/charmhub/client.go
@@ -91,7 +91,7 @@ type Client struct {
 
 // NewClient creates a new Charmhub client from the supplied configuration.
 func NewClient(config Config) (*Client, error) {
-	logger := config.Logger.ChildWithTags("client", corelogger.CHARMHUB)
+	logger := config.Logger.Child("client", corelogger.CHARMHUB)
 
 	url := config.URL
 	if url == "" {

--- a/internal/charmhub/http.go
+++ b/internal/charmhub/http.go
@@ -85,14 +85,14 @@ type loggingRequestRecorder struct {
 
 // Record an outgoing request which produced an http.Response.
 func (r loggingRequestRecorder) Record(method string, url *url.URL, res *http.Response, rtt time.Duration) {
-	if r.logger.IsTraceEnabled() {
+	if r.logger.IsLevelEnabled(corelogger.TRACE) {
 		r.logger.Tracef("request (method: %q, host: %q, path: %q, status: %q, duration: %s)", method, url.Host, url.Path, res.Status, rtt)
 	}
 }
 
 // RecordError records an outgoing request which returned an error.
 func (r loggingRequestRecorder) RecordError(method string, url *url.URL, err error) {
-	if r.logger.IsTraceEnabled() {
+	if r.logger.IsLevelEnabled(corelogger.TRACE) {
 		r.logger.Tracef("request error (method: %q, host: %q, path: %q, err: %s)", method, url.Host, url.Path, err)
 	}
 }
@@ -104,7 +104,9 @@ func requestHTTPClient(recorder jujuhttp.RequestRecorder, policy jujuhttp.RetryP
 		return jujuhttp.NewClient(
 			jujuhttp.WithRequestRecorder(recorder),
 			jujuhttp.WithRequestRetrier(policy),
-			jujuhttp.WithLogger(logger.ChildWithTags("transport", corelogger.CHARMHUB, corelogger.HTTP)),
+			jujuhttp.WithLogger(httpLogger{
+				Logger: logger.ChildWithTags("transport", corelogger.CHARMHUB, corelogger.HTTP),
+			}),
 		)
 	}
 }
@@ -230,7 +232,7 @@ func newAPIRequesterLogger(httpClient HTTPClient, logger corelogger.Logger) *api
 
 // Do performs the request and logs the request and response if tracing is enabled.
 func (t *apiRequestLogger) Do(req *http.Request) (*http.Response, error) {
-	if t.logger.IsTraceEnabled() {
+	if t.logger.IsLevelEnabled(corelogger.TRACE) {
 		if data, err := httputil.DumpRequest(req, true); err == nil {
 			t.logger.Tracef("%s request %s", req.Method, data)
 		} else {
@@ -243,7 +245,7 @@ func (t *apiRequestLogger) Do(req *http.Request) (*http.Response, error) {
 		return nil, errors.Trace(err)
 	}
 
-	if t.logger.IsTraceEnabled() {
+	if t.logger.IsLevelEnabled(corelogger.TRACE) {
 		if data, err := httputil.DumpResponse(resp, true); err == nil {
 			t.logger.Tracef("%s response %s", req.Method, data)
 		} else {
@@ -360,4 +362,12 @@ func (c *httpRESTClient) Post(ctx context.Context, path path.Path, headers http.
 	return restResponse{
 		StatusCode: resp.StatusCode,
 	}, nil
+}
+
+type httpLogger struct {
+	corelogger.Logger
+}
+
+func (l httpLogger) IsTraceEnabled() bool {
+	return l.IsLevelEnabled(corelogger.TRACE)
 }

--- a/internal/charmhub/http.go
+++ b/internal/charmhub/http.go
@@ -64,7 +64,7 @@ type HTTPClient interface {
 // DefaultHTTPClient creates a new HTTPClient with the default configuration.
 func DefaultHTTPClient(logger corelogger.Logger) HTTPClient {
 	recorder := loggingRequestRecorder{
-		logger: logger.ChildWithTags("transport.request-recorder", corelogger.METRICS),
+		logger: logger.Child("transport.request-recorder", corelogger.METRICS),
 	}
 	return requestHTTPClient(recorder, defaultRetryPolicy())(logger)
 }
@@ -105,7 +105,7 @@ func requestHTTPClient(recorder jujuhttp.RequestRecorder, policy jujuhttp.RetryP
 			jujuhttp.WithRequestRecorder(recorder),
 			jujuhttp.WithRequestRetrier(policy),
 			jujuhttp.WithLogger(httpLogger{
-				Logger: logger.ChildWithTags("transport", corelogger.CHARMHUB, corelogger.HTTP),
+				Logger: logger.Child("transport", corelogger.CHARMHUB, corelogger.HTTP),
 			}),
 		)
 	}

--- a/internal/charmhub/info.go
+++ b/internal/charmhub/info.go
@@ -68,7 +68,7 @@ func (c *infoClient) Info(ctx context.Context, name string, options ...InfoOptio
 		option(opts)
 	}
 
-	isTraceEnabled := c.logger.IsTraceEnabled()
+	isTraceEnabled := c.logger.IsLevelEnabled(corelogger.TRACE)
 	if isTraceEnabled {
 		c.logger.Tracef("Info(%s)", name)
 	}

--- a/internal/charmhub/refresh.go
+++ b/internal/charmhub/refresh.go
@@ -96,7 +96,7 @@ func newRefreshClient(path path.Path, client RESTClient, logger corelogger.Logge
 
 // Refresh is used to refresh installed charms to a more suitable revision.
 func (c *refreshClient) Refresh(ctx context.Context, config RefreshConfig) ([]transport.RefreshResponse, error) {
-	if c.logger.IsTraceEnabled() {
+	if c.logger.IsLevelEnabled(corelogger.TRACE) {
 		c.logger.Tracef("Refresh(%s)", pretty.Sprint(config))
 	}
 	req, err := config.Build()
@@ -109,7 +109,7 @@ func (c *refreshClient) Refresh(ctx context.Context, config RefreshConfig) ([]tr
 // RefreshWithRequestMetrics is to get refreshed charm data and provide metrics
 // at the same time.  Used as part of the charm revision updater facade.
 func (c *refreshClient) RefreshWithRequestMetrics(ctx context.Context, config RefreshConfig, metrics map[charmmetrics.MetricKey]map[charmmetrics.MetricKey]string) ([]transport.RefreshResponse, error) {
-	if c.logger.IsTraceEnabled() {
+	if c.logger.IsLevelEnabled(corelogger.TRACE) {
 		c.logger.Tracef("RefreshWithRequestMetrics(%s, %+v)", pretty.Sprint(config), metrics)
 	}
 	req, err := config.Build()
@@ -205,7 +205,7 @@ func (c *refreshClient) refresh(ctx context.Context, ensure func(responses []tra
 		results[indexes[result.InstanceKey]] = result
 	}
 
-	if c.logger.IsTraceEnabled() {
+	if c.logger.IsLevelEnabled(corelogger.TRACE) {
 		c.logger.Tracef("Refresh() unmarshalled: %s", pretty.Sprint(results))
 	}
 	return results, nil

--- a/internal/charmhub/resources.go
+++ b/internal/charmhub/resources.go
@@ -45,7 +45,7 @@ func (c *resourcesClient) ListResourceRevisions(ctx context.Context, charm, reso
 		span.End()
 	}()
 
-	isTraceEnabled := c.logger.IsTraceEnabled()
+	isTraceEnabled := c.logger.IsLevelEnabled(corelogger.TRACE)
 	if isTraceEnabled {
 		c.logger.Tracef("ListResourceRevisions(%s, %s)", charm, resource)
 	}

--- a/internal/database/txn/transaction.go
+++ b/internal/database/txn/transaction.go
@@ -263,7 +263,7 @@ func (t *RetryingTxnRunner) run(ctx context.Context, fn func(context.Context) er
 // defaultRetryStrategy returns a function that can be used to apply a default
 // retry strategy to its input operation. It will retry in cases of transient
 // known database errors.
-func defaultRetryStrategy(clock clock.Clock, logger logger.Logger) func(context.Context, func() error) error {
+func defaultRetryStrategy(clock clock.Clock, log logger.Logger) func(context.Context, func() error) error {
 	return func(ctx context.Context, fn func() error) error {
 		err := retry.Call(retry.CallArgs{
 			Func: fn,
@@ -275,8 +275,8 @@ func defaultRetryStrategy(clock clock.Clock, logger logger.Logger) func(context.
 
 				// If the error is potentially retryable then keep going.
 				if IsErrRetryable(err) {
-					if logger.IsTraceEnabled() {
-						logger.Tracef("retrying transaction: %v", err)
+					if log.IsLevelEnabled(logger.TRACE) {
+						log.Tracef("retrying transaction: %v", err)
 					}
 					return false
 				}

--- a/internal/docker/registry/internal/ecr.go
+++ b/internal/docker/registry/internal/ecr.go
@@ -18,6 +18,7 @@ import (
 	"github.com/aws/smithy-go/logging"
 	"github.com/juju/errors"
 
+	corelogger "github.com/juju/juju/core/logger"
 	"github.com/juju/juju/internal/docker"
 	"github.com/juju/juju/internal/tools"
 )
@@ -56,7 +57,7 @@ func getECRClient(ctx context.Context, accessKeyID, secretAccessKey, region stri
 
 	// Enable request and response logging, but only if TRACE is enabled (as
 	// they're probably fairly expensive to produce).
-	if logger.IsTraceEnabled() {
+	if logger.IsLevelEnabled(corelogger.TRACE) {
 		cfg.ClientLogMode = aws.LogRequest | aws.LogResponse | aws.LogRetries
 		cfg.Logger = logging.NewStandardLogger(&ecrLogger{})
 	}

--- a/internal/docker/registry/internal/transports.go
+++ b/internal/docker/registry/internal/transports.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/docker/distribution/registry/client/auth/challenge"
 	"github.com/juju/errors"
+
 	corelogger "github.com/juju/juju/core/logger"
 )
 

--- a/internal/docker/registry/internal/transports.go
+++ b/internal/docker/registry/internal/transports.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/docker/distribution/registry/client/auth/challenge"
 	"github.com/juju/errors"
+	corelogger "github.com/juju/juju/core/logger"
 )
 
 type dynamicTransportFunc func() (http.RoundTripper, error)
@@ -341,7 +342,7 @@ func handleErrorResponse(resp *http.Response) (*http.Response, error) {
 		return nil, errors.Annotatef(err, "reading bad response body with status code %d", resp.StatusCode)
 	}
 	errMsg := fmt.Sprintf("non-successful response status=%d", resp.StatusCode)
-	if logger.IsTraceEnabled() {
+	if logger.IsLevelEnabled(corelogger.TRACE) {
 		logger.Tracef("%s, url %q, body=%q", errMsg, resp.Request.URL.String(), body)
 	}
 	errNew := errors.Errorf

--- a/internal/downloader/utils.go
+++ b/internal/downloader/utils.go
@@ -25,7 +25,7 @@ func NewHTTPBlobOpener(hostnameVerification bool) func(Request) (io.ReadCloser, 
 		client := jujuhttp.NewClient(
 			jujuhttp.WithSkipHostnameVerification(!hostnameVerification),
 			jujuhttp.WithLogger(httpLogger{
-				Logger: logger.ChildWithTags("http", corelogger.HTTP),
+				Logger: logger.Child("http", corelogger.HTTP),
 			}),
 		)
 

--- a/internal/downloader/utils.go
+++ b/internal/downloader/utils.go
@@ -24,7 +24,9 @@ func NewHTTPBlobOpener(hostnameVerification bool) func(Request) (io.ReadCloser, 
 		// TODO(rog) make the download operation interruptible.
 		client := jujuhttp.NewClient(
 			jujuhttp.WithSkipHostnameVerification(!hostnameVerification),
-			jujuhttp.WithLogger(logger.ChildWithTags("http", corelogger.HTTP)),
+			jujuhttp.WithLogger(httpLogger{
+				Logger: logger.ChildWithTags("http", corelogger.HTTP),
+			}),
 		)
 
 		resp, err := client.Get(context.TODO(), req.URL.String())
@@ -60,4 +62,12 @@ func NewSha256Verifier(expected string) func(*os.File) error {
 		}
 		return nil
 	}
+}
+
+type httpLogger struct {
+	corelogger.Logger
+}
+
+func (l httpLogger) IsTraceEnabled() bool {
+	return l.IsLevelEnabled(corelogger.TRACE)
 }

--- a/internal/logger/loggo.go
+++ b/internal/logger/loggo.go
@@ -56,32 +56,6 @@ func (c loggoLogger) Logf(level logger.Level, msg string, args ...any) {
 	c.logger.Logf(loggo.Level(level), msg, args...)
 }
 
-// IsEnabled returns true if the given level is enabled for the logger.
-func (c loggoLogger) IsErrorEnabled() bool {
-	return c.logger.IsErrorEnabled()
-}
-
-// IsWarningEnabled returns true if the warning level is enabled for the
-// logger.
-func (c loggoLogger) IsWarningEnabled() bool {
-	return c.logger.IsWarningEnabled()
-}
-
-// IsInfoEnabled returns true if the info level is enabled for the logger.
-func (c loggoLogger) IsInfoEnabled() bool {
-	return c.logger.IsInfoEnabled()
-}
-
-// IsDebugEnabled returns true if the debug level is enabled for the logger.
-func (c loggoLogger) IsDebugEnabled() bool {
-	return c.logger.IsDebugEnabled()
-}
-
-// IsTraceEnabled returns true if the trace level is enabled for the logger.
-func (c loggoLogger) IsTraceEnabled() bool {
-	return c.logger.IsTraceEnabled()
-}
-
 // IsLevelEnabled returns true if the given level is enabled for the logger.
 func (c loggoLogger) IsLevelEnabled(level logger.Level) bool {
 	return c.logger.IsLevelEnabled(loggo.Level(level))

--- a/internal/logger/loggo.go
+++ b/internal/logger/loggo.go
@@ -62,14 +62,7 @@ func (c loggoLogger) IsLevelEnabled(level logger.Level) bool {
 }
 
 // Child returns a new logger with the given name.
-func (c loggoLogger) Child(name string) logger.Logger {
-	return loggoLogger{
-		logger: c.logger.Child(name),
-	}
-}
-
-// ChildWithTags returns a new logger with the given name and tags.
-func (c loggoLogger) ChildWithTags(name string, tags ...string) logger.Logger {
+func (c loggoLogger) Child(name string, tags ...string) logger.Logger {
 	return loggoLogger{
 		logger: c.logger.ChildWithTags(name, tags...),
 	}

--- a/internal/logger/noop.go
+++ b/internal/logger/noop.go
@@ -46,32 +46,6 @@ func (c noopLogger) Tracef(msg string, args ...any) {
 func (c noopLogger) Logf(level logger.Level, msg string, args ...any) {
 }
 
-// IsEnabled returns true if the given level is enabled for the logger.
-func (c noopLogger) IsErrorEnabled() bool {
-	return false
-}
-
-// IsWarningEnabled returns true if the warning level is enabled for the
-// logger.
-func (c noopLogger) IsWarningEnabled() bool {
-	return false
-}
-
-// IsInfoEnabled returns true if the info level is enabled for the logger.
-func (c noopLogger) IsInfoEnabled() bool {
-	return false
-}
-
-// IsDebugEnabled returns true if the debug level is enabled for the logger.
-func (c noopLogger) IsDebugEnabled() bool {
-	return false
-}
-
-// IsTraceEnabled returns true if the trace level is enabled for the logger.
-func (c noopLogger) IsTraceEnabled() bool {
-	return false
-}
-
 // IsLevelEnabled returns true if the given level is enabled for the logger.
 func (c noopLogger) IsLevelEnabled(level logger.Level) bool {
 	return false

--- a/internal/logger/noop.go
+++ b/internal/logger/noop.go
@@ -52,12 +52,7 @@ func (c noopLogger) IsLevelEnabled(level logger.Level) bool {
 }
 
 // Child returns a new logger with the given name.
-func (c noopLogger) Child(name string) logger.Logger {
-	return c
-}
-
-// ChildWithTags returns a new logger with the given name and tags.
-func (c noopLogger) ChildWithTags(name string, tags ...string) logger.Logger {
+func (c noopLogger) Child(name string, tags ...string) logger.Logger {
 	return c
 }
 

--- a/internal/logger/testing/check.go
+++ b/internal/logger/testing/check.go
@@ -89,11 +89,6 @@ func (c checkLogger) GetChildByName(name string) logger.Logger {
 	return checkLogger{log: c.log, name: name}
 }
 
-func (c checkLogger) IsErrorEnabled() bool   { return c.IsLevelEnabled(logger.ERROR) }
-func (c checkLogger) IsWarningEnabled() bool { return c.IsLevelEnabled(logger.WARNING) }
-func (c checkLogger) IsInfoEnabled() bool    { return c.IsLevelEnabled(logger.INFO) }
-func (c checkLogger) IsDebugEnabled() bool   { return c.IsLevelEnabled(logger.DEBUG) }
-func (c checkLogger) IsTraceEnabled() bool   { return c.IsLevelEnabled(logger.TRACE) }
 func (c checkLogger) IsLevelEnabled(level logger.Level) bool {
 	return level >= c.level
 }

--- a/internal/logger/testing/check.go
+++ b/internal/logger/testing/check.go
@@ -76,11 +76,7 @@ func (c checkLogger) Logf(level logger.Level, msg string, args ...any) {
 	c.log.Logf(formatMsg(loggo.Level(level).String(), c.name, msg), args...)
 }
 
-func (c checkLogger) Child(name string) logger.Logger {
-	return checkLogger{log: c.log, name: name}
-}
-
-func (c checkLogger) ChildWithTags(name string, tags ...string) logger.Logger {
+func (c checkLogger) Child(name string, tags ...string) logger.Logger {
 	return checkLogger{log: c.log, name: name}
 }
 

--- a/internal/provider/azure/internal/azurecli/az.go
+++ b/internal/provider/azure/internal/azurecli/az.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/kr/pretty"
 
+	corelogger "github.com/juju/juju/core/logger"
 	internallogger "github.com/juju/juju/internal/logger"
 )
 
@@ -74,7 +75,7 @@ func (a AzureCLI) run(v interface{}, args ...string) error {
 	if err := json.Unmarshal(b, v); err != nil {
 		return errors.Annotate(err, "cannot unmarshal output")
 	}
-	if logger.IsDebugEnabled() {
+	if logger.IsLevelEnabled(corelogger.DEBUG) {
 		logger.Debugf("az returned: %s", pretty.Sprint(v))
 	}
 	return nil

--- a/internal/provider/azure/internal/tracing/tracing.go
+++ b/internal/provider/azure/internal/tracing/tracing.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 
+	"github.com/juju/juju/core/logger"
 	corelogger "github.com/juju/juju/core/logger"
 )
 
@@ -17,7 +18,7 @@ type LoggingPolicy struct {
 }
 
 func (p *LoggingPolicy) Do(req *policy.Request) (*http.Response, error) {
-	if p.Logger.IsTraceEnabled() {
+	if p.Logger.IsLevelEnabled(logger.TRACE) {
 		dump, err := httputil.DumpRequest(req.Raw(), true)
 		if err != nil {
 			p.Logger.Tracef("failed to dump request: %v", err)
@@ -27,7 +28,7 @@ func (p *LoggingPolicy) Do(req *policy.Request) (*http.Response, error) {
 		}
 	}
 	resp, err := req.Next()
-	if err == nil && p.Logger.IsTraceEnabled() {
+	if err == nil && p.Logger.IsLevelEnabled(logger.TRACE) {
 		dump, err := httputil.DumpResponse(resp, true)
 		if err != nil {
 			p.Logger.Tracef("failed to dump response: %v", err)

--- a/internal/provider/ec2/client.go
+++ b/internal/provider/ec2/client.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/cloud"
+	corelogger "github.com/juju/juju/core/logger"
 	"github.com/juju/juju/environs/cloudspec"
 )
 
@@ -140,7 +141,7 @@ func configFromCloudSpec(
 
 	// Enable request and response logging, but only if TRACE is enabled (as
 	// they're probably fairly expensive to produce).
-	if logger.IsTraceEnabled() {
+	if logger.IsLevelEnabled(corelogger.TRACE) {
 		cfg.ClientLogMode = aws.LogRequest | aws.LogResponse | aws.LogRetries
 		cfg.Logger = logging.NewStandardLogger(&awsLogger{})
 	}

--- a/internal/provider/ec2/environ.go
+++ b/internal/provider/ec2/environ.go
@@ -1489,7 +1489,7 @@ func (e *environ) networkInterfacesForInstance(ctx envcontext.ProviderCallContex
 			logger.Tracef("%s", msg)
 			return errors.New(msg)
 		}
-		if logger.IsTraceEnabled() {
+		if logger.IsLevelEnabled(corelogger.TRACE) {
 			logger.Tracef("found instance %q NICs: %s", instId, pretty.Sprint(resp.NetworkInterfaces))
 		}
 		return nil
@@ -2767,7 +2767,9 @@ func (e *environ) SetCloudSpec(ctx stdcontext.Context, spec environscloudspec.Cl
 	}
 
 	httpClient := jujuhttp.NewClient(
-		jujuhttp.WithLogger(logger.ChildWithTags("http", corelogger.HTTP)),
+		jujuhttp.WithLogger(httpLogger{
+			Logger: logger.ChildWithTags("http", corelogger.HTTP),
+		}),
 	)
 
 	var err error
@@ -2810,4 +2812,12 @@ func CreateTagSpecification(resourceType types.ResourceType, tags map[string]str
 	}
 
 	return spec
+}
+
+type httpLogger struct {
+	corelogger.Logger
+}
+
+func (l httpLogger) IsTraceEnabled() bool {
+	return l.IsLevelEnabled(corelogger.TRACE)
 }

--- a/internal/provider/ec2/environ.go
+++ b/internal/provider/ec2/environ.go
@@ -2768,7 +2768,7 @@ func (e *environ) SetCloudSpec(ctx stdcontext.Context, spec environscloudspec.Cl
 
 	httpClient := jujuhttp.NewClient(
 		jujuhttp.WithLogger(httpLogger{
-			Logger: logger.ChildWithTags("http", corelogger.HTTP),
+			Logger: logger.Child("http", corelogger.HTTP),
 		}),
 	)
 

--- a/internal/provider/ec2/environ_vpc.go
+++ b/internal/provider/ec2/environ_vpc.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/kr/pretty"
 
+	corelogger "github.com/juju/juju/core/logger"
 	corenetwork "github.com/juju/juju/core/network"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/envcontext"
@@ -407,7 +408,7 @@ func checkVPCRouteTableRoutes(vpc *types.Vpc, routeTable *types.RouteTable, gate
 	vpcCIDRBlock := aws.ToString(vpc.CidrBlock)
 	for _, route := range routeTable.Routes {
 		if route.State != types.RouteStateActive {
-			if logger.IsTraceEnabled() {
+			if logger.IsLevelEnabled(corelogger.TRACE) {
 				logger.Tracef("skipping inactive route %s", pretty.Sprint(route))
 			}
 			continue
@@ -427,7 +428,7 @@ func checkVPCRouteTableRoutes(vpc *types.Vpc, routeTable *types.RouteTable, gate
 			logger.Tracef("local route uses expected CIDR %q", vpcCIDRBlock)
 			hasLocalRoute = true
 		default:
-			if logger.IsTraceEnabled() {
+			if logger.IsLevelEnabled(corelogger.TRACE) {
 				logger.Tracef("route %s is neither local nor default (skipping)", pretty.Sprint(route))
 			}
 		}

--- a/internal/provider/gce/environ.go
+++ b/internal/provider/gce/environ.go
@@ -165,7 +165,9 @@ func (e *environ) SetCloudSpec(_ stdcontext.Context, spec environscloudspec.Clou
 		// of the environ.
 		HTTPClient: jujuhttp.NewClient(
 			jujuhttp.WithSkipHostnameVerification(spec.SkipTLSVerify),
-			jujuhttp.WithLogger(logger.ChildWithTags("http", corelogger.HTTP)),
+			jujuhttp.WithLogger(httpLogger{
+				Logger: logger.ChildWithTags("http", corelogger.HTTP),
+			}),
 		),
 	}
 
@@ -286,4 +288,12 @@ func (env *environ) Destroy(ctx envcontext.ProviderCallContext) error {
 func (env *environ) DestroyController(ctx envcontext.ProviderCallContext, controllerUUID string) error {
 	// TODO(wallyworld): destroy hosted model resources
 	return env.Destroy(ctx)
+}
+
+type httpLogger struct {
+	corelogger.Logger
+}
+
+func (l httpLogger) IsTraceEnabled() bool {
+	return l.IsLevelEnabled(corelogger.TRACE)
 }

--- a/internal/provider/gce/environ.go
+++ b/internal/provider/gce/environ.go
@@ -166,7 +166,7 @@ func (e *environ) SetCloudSpec(_ stdcontext.Context, spec environscloudspec.Clou
 		HTTPClient: jujuhttp.NewClient(
 			jujuhttp.WithSkipHostnameVerification(spec.SkipTLSVerify),
 			jujuhttp.WithLogger(httpLogger{
-				Logger: logger.ChildWithTags("http", corelogger.HTTP),
+				Logger: logger.Child("http", corelogger.HTTP),
 			}),
 		),
 	}

--- a/internal/provider/lxd/provider.go
+++ b/internal/provider/lxd/provider.go
@@ -120,7 +120,9 @@ func NewProvider() environs.CloudEnvironProvider {
 	configReader := lxcConfigReader{}
 	factory := NewServerFactory(NewHTTPClientFunc(func() *http.Client {
 		return jujuhttp.NewClient(
-			jujuhttp.WithLogger(logger.ChildWithTags("http", corelogger.HTTP)),
+			jujuhttp.WithLogger(httpLogger{
+				Logger: logger.ChildWithTags("http", corelogger.HTTP),
+			}),
 		).Client()
 	}))
 
@@ -430,4 +432,12 @@ func (lxcConfigReader) ReadConfig(path string) (LXCConfig, error) {
 func (lxcConfigReader) ReadCert(path string) ([]byte, error) {
 	certFile, err := os.ReadFile(path)
 	return certFile, errors.Trace(err)
+}
+
+type httpLogger struct {
+	corelogger.Logger
+}
+
+func (l httpLogger) IsTraceEnabled() bool {
+	return l.IsLevelEnabled(corelogger.TRACE)
 }

--- a/internal/provider/lxd/provider.go
+++ b/internal/provider/lxd/provider.go
@@ -121,7 +121,7 @@ func NewProvider() environs.CloudEnvironProvider {
 	factory := NewServerFactory(NewHTTPClientFunc(func() *http.Client {
 		return jujuhttp.NewClient(
 			jujuhttp.WithLogger(httpLogger{
-				Logger: logger.ChildWithTags("http", corelogger.HTTP),
+				Logger: logger.Child("http", corelogger.HTTP),
 			}),
 		).Client()
 	}))

--- a/internal/provider/oci/environ.go
+++ b/internal/provider/oci/environ.go
@@ -21,6 +21,7 @@ import (
 	corearch "github.com/juju/juju/core/arch"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
+	corelogger "github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/os/ostype"
 	"github.com/juju/juju/environs"
@@ -489,7 +490,7 @@ func (e *Environ) startInstance(
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	if logger.IsTraceEnabled() {
+	if logger.IsLevelEnabled(corelogger.TRACE) {
 		logger.Tracef("Image cache contains: %# v", pretty.Formatter(imgCache))
 	}
 

--- a/internal/provider/openstack/client.go
+++ b/internal/provider/openstack/client.go
@@ -255,7 +255,7 @@ func newClient(
 		jujuhttp.WithSkipHostnameVerification(opts.skipHostnameVerification),
 		jujuhttp.WithCACertificates(opts.caCertificates...),
 		jujuhttp.WithLogger(httpLogger{
-			Logger: logger.ChildWithTags("http", corelogger.HTTP),
+			Logger: logger.Child("http", corelogger.HTTP),
 		}),
 	)
 	return client.NewClient(&cred, authMode, gooseLogger,

--- a/internal/provider/openstack/client.go
+++ b/internal/provider/openstack/client.go
@@ -254,10 +254,20 @@ func newClient(
 	httpClient := jujuhttp.NewClient(
 		jujuhttp.WithSkipHostnameVerification(opts.skipHostnameVerification),
 		jujuhttp.WithCACertificates(opts.caCertificates...),
-		jujuhttp.WithLogger(logger.ChildWithTags("http", corelogger.HTTP)),
+		jujuhttp.WithLogger(httpLogger{
+			Logger: logger.ChildWithTags("http", corelogger.HTTP),
+		}),
 	)
 	return client.NewClient(&cred, authMode, gooseLogger,
 		client.WithHTTPClient(httpClient.Client()),
 		client.WithHTTPHeadersFunc(opts.httpHeadersFunc),
 	), nil
+}
+
+type httpLogger struct {
+	corelogger.Logger
+}
+
+func (l httpLogger) IsTraceEnabled() bool {
+	return l.IsLevelEnabled(corelogger.TRACE)
 }

--- a/internal/provider/vsphere/environ_availzones.go
+++ b/internal/provider/vsphere/environ_availzones.go
@@ -12,6 +12,7 @@ import (
 	"github.com/vmware/govmomi/vim25/mo"
 
 	"github.com/juju/juju/core/instance"
+	corelogger "github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/envcontext"
@@ -89,7 +90,7 @@ func (env *sessionEnviron) AvailabilityZones(ctx envcontext.ProviderCallContext)
 		}
 	}
 
-	if logger.IsDebugEnabled() {
+	if logger.IsLevelEnabled(corelogger.DEBUG) {
 		zoneNames := make([]string, len(zones))
 		for i, zone := range zones {
 			zoneNames[i] = zone.Name()

--- a/internal/resource/charmhub.go
+++ b/internal/resource/charmhub.go
@@ -57,7 +57,7 @@ func newCharmHubClient(st chClientState) (ResourceGetter, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return &CharmHubClient{client: chClient, logger: logger.ChildWithTags("charmhub", corelogger.CHARMHUB)}, nil
+	return &CharmHubClient{client: chClient, logger: logger.Child("charmhub", corelogger.CHARMHUB)}, nil
 }
 
 type CharmHubClient struct {

--- a/internal/s3client/http.go
+++ b/internal/s3client/http.go
@@ -13,6 +13,16 @@ import (
 // store.
 func DefaultHTTPClient(logger logger.Logger) HTTPClient {
 	return jujuhttp.NewClient(
-		jujuhttp.WithLogger(logger),
+		jujuhttp.WithLogger(httpLogger{
+			Logger: logger,
+		}),
 	)
+}
+
+type httpLogger struct {
+	logger.Logger
+}
+
+func (l httpLogger) IsTraceEnabled() bool {
+	return l.IsLevelEnabled(logger.TRACE)
 }

--- a/internal/upgrades/upgradevalidation/validation.go
+++ b/internal/upgrades/upgradevalidation/validation.go
@@ -293,7 +293,7 @@ func getCheckForLXDVersion(cloudspec environscloudspec.CloudSpec) Validator {
 		server, err := NewServerFactory(lxd.NewHTTPClientFunc(func() *http.Client {
 			return jujuhttp.NewClient(
 				jujuhttp.WithLogger(httpLogger{
-					Logger: logger.ChildWithTags("http", corelogger.HTTP),
+					Logger: logger.Child("http", corelogger.HTTP),
 				}),
 			).Client()
 		})).RemoteServer(lxd.CloudSpec{CloudSpec: cloudspec})

--- a/internal/upgrades/upgradevalidation/validation.go
+++ b/internal/upgrades/upgradevalidation/validation.go
@@ -292,7 +292,9 @@ func getCheckForLXDVersion(cloudspec environscloudspec.CloudSpec) Validator {
 		}
 		server, err := NewServerFactory(lxd.NewHTTPClientFunc(func() *http.Client {
 			return jujuhttp.NewClient(
-				jujuhttp.WithLogger(logger.ChildWithTags("http", corelogger.HTTP)),
+				jujuhttp.WithLogger(httpLogger{
+					Logger: logger.ChildWithTags("http", corelogger.HTTP),
+				}),
 			).Client()
 		})).RemoteServer(lxd.CloudSpec{CloudSpec: cloudspec})
 		if err != nil {
@@ -304,4 +306,12 @@ func getCheckForLXDVersion(cloudspec environscloudspec.CloudSpec) Validator {
 		}
 		return nil, errors.Trace(err)
 	}
+}
+
+type httpLogger struct {
+	corelogger.Logger
+}
+
+func (l httpLogger) IsTraceEnabled() bool {
+	return l.IsLevelEnabled(corelogger.TRACE)
 }

--- a/internal/worker/changestreampruner/worker.go
+++ b/internal/worker/changestreampruner/worker.go
@@ -136,7 +136,7 @@ func (w *Pruner) loop() error {
 }
 
 func (w *Pruner) prune() (map[string]int64, error) {
-	traceEnabled := w.cfg.Logger.IsTraceEnabled()
+	traceEnabled := w.cfg.Logger.IsLevelEnabled(logger.TRACE)
 	if traceEnabled {
 		w.cfg.Logger.Tracef("Starting pruning change log")
 	}

--- a/internal/worker/dbaccessor/tracker.go
+++ b/internal/worker/dbaccessor/tracker.go
@@ -327,7 +327,7 @@ func (w *trackedDBWorker) ensureDBAliveAndOpenIfRequired(db *sql.DB) (*sql.DB, e
 	ctx = w.tomb.Context(ctx)
 	defer cancel()
 
-	if w.logger.IsTraceEnabled() {
+	if w.logger.IsLevelEnabled(logger.TRACE) {
 		w.logger.Tracef("ensuring database %q is alive", w.namespace)
 	}
 
@@ -347,7 +347,7 @@ func (w *trackedDBWorker) ensureDBAliveAndOpenIfRequired(db *sql.DB) (*sql.DB, e
 		pingStart := w.clock.Now()
 		var pingAttempts uint32 = 0
 		err := database.Retry(ctx, func() error {
-			if w.logger.IsTraceEnabled() {
+			if w.logger.IsLevelEnabled(logger.TRACE) {
 				w.logger.Tracef("pinging database %q", w.namespace)
 			}
 			pingAttempts++

--- a/internal/worker/filenotifywatcher/watcher.go
+++ b/internal/worker/filenotifywatcher/watcher.go
@@ -171,7 +171,7 @@ func (w *Watcher) loop() error {
 		case <-w.catacomb.Dying():
 			return w.catacomb.ErrDying()
 		case event := <-w.watcher.Events():
-			if w.logger.IsTraceEnabled() {
+			if w.logger.IsLevelEnabled(logger.TRACE) {
 				w.logger.Tracef("inotify event for %v", event)
 			}
 			// Ignore events for other files in the directory.
@@ -184,7 +184,7 @@ func (w *Watcher) loop() error {
 				continue
 			}
 
-			if w.logger.IsTraceEnabled() {
+			if w.logger.IsLevelEnabled(logger.TRACE) {
 				w.logger.Tracef("dispatch event for fileName %q: %v", w.fileName, event)
 			}
 

--- a/internal/worker/peergrouper/worker.go
+++ b/internal/worker/peergrouper/worker.go
@@ -23,6 +23,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/juju/juju/controller"
+	corelogger "github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/watcher"
@@ -630,7 +631,7 @@ func (w *pgWorker) updateReplicaSet() (map[string]*replicaset.Member, error) {
 	if err != nil {
 		return nil, errors.Annotate(err, "computing desired peer group")
 	}
-	if logger.IsDebugEnabled() {
+	if logger.IsLevelEnabled(corelogger.DEBUG) {
 		if desired.isChanged {
 			logger.Debugf("desired peer group members: \n%s", prettyReplicaSetMembers(desired.members))
 		} else {
@@ -786,7 +787,7 @@ func (w *pgWorker) peerGroupInfo() (*peerGroupInfo, error) {
 		return nil, errors.Annotate(err, "cannot get replica set members")
 	}
 
-	if logger.IsTraceEnabled() {
+	if logger.IsLevelEnabled(corelogger.TRACE) {
 		logger.Tracef("read peer group info: %# v\n%# v", pretty.Formatter(sts), pretty.Formatter(members))
 	}
 	return newPeerGroupInfo(w.controllerTrackers, sts.Members, members, w.config.MongoPort)

--- a/internal/worker/presence/presence.go
+++ b/internal/worker/presence/presence.go
@@ -166,7 +166,7 @@ func (w *wrapper) agentLogin(topic string, data apiserver.APIConnection, err err
 		w.logger.Errorf("agentLogin error %v", err)
 		return
 	}
-	if w.logger.IsTraceEnabled() {
+	if w.logger.IsLevelEnabled(logger.TRACE) {
 		agentName := data.AgentTag
 		if data.ControllerAgent {
 			agentName += " (controller)"
@@ -237,7 +237,7 @@ func (w *wrapper) presenceResponse(topic string, data apiserver.PresenceResponse
 	// update the recorder.
 	values := make([]presence.Value, 0, len(data.Connections))
 	for _, conn := range data.Connections {
-		if w.logger.IsTraceEnabled() {
+		if w.logger.IsLevelEnabled(logger.TRACE) {
 			agentName := conn.AgentTag
 			if conn.ControllerAgent {
 				agentName += " (controller)"

--- a/internal/worker/querylogger/logger_mock_test.go
+++ b/internal/worker/querylogger/logger_mock_test.go
@@ -40,17 +40,22 @@ func (m *MockLogger) EXPECT() *MockLoggerMockRecorder {
 }
 
 // Child mocks base method.
-func (m *MockLogger) Child(arg0 string) logger.Logger {
+func (m *MockLogger) Child(arg0 string, arg1 ...string) logger.Logger {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Child", arg0)
+	varargs := []any{arg0}
+	for _, a := range arg1 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Child", varargs...)
 	ret0, _ := ret[0].(logger.Logger)
 	return ret0
 }
 
 // Child indicates an expected call of Child.
-func (mr *MockLoggerMockRecorder) Child(arg0 any) *MockLoggerChildCall {
+func (mr *MockLoggerMockRecorder) Child(arg0 any, arg1 ...any) *MockLoggerChildCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Child", reflect.TypeOf((*MockLogger)(nil).Child), arg0)
+	varargs := append([]any{arg0}, arg1...)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Child", reflect.TypeOf((*MockLogger)(nil).Child), varargs...)
 	return &MockLoggerChildCall{Call: call}
 }
 
@@ -66,56 +71,13 @@ func (c *MockLoggerChildCall) Return(arg0 logger.Logger) *MockLoggerChildCall {
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockLoggerChildCall) Do(f func(string) logger.Logger) *MockLoggerChildCall {
+func (c *MockLoggerChildCall) Do(f func(string, ...string) logger.Logger) *MockLoggerChildCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockLoggerChildCall) DoAndReturn(f func(string) logger.Logger) *MockLoggerChildCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// ChildWithTags mocks base method.
-func (m *MockLogger) ChildWithTags(arg0 string, arg1 ...string) logger.Logger {
-	m.ctrl.T.Helper()
-	varargs := []any{arg0}
-	for _, a := range arg1 {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "ChildWithTags", varargs...)
-	ret0, _ := ret[0].(logger.Logger)
-	return ret0
-}
-
-// ChildWithTags indicates an expected call of ChildWithTags.
-func (mr *MockLoggerMockRecorder) ChildWithTags(arg0 any, arg1 ...any) *MockLoggerChildWithTagsCall {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0}, arg1...)
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChildWithTags", reflect.TypeOf((*MockLogger)(nil).ChildWithTags), varargs...)
-	return &MockLoggerChildWithTagsCall{Call: call}
-}
-
-// MockLoggerChildWithTagsCall wrap *gomock.Call
-type MockLoggerChildWithTagsCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockLoggerChildWithTagsCall) Return(arg0 logger.Logger) *MockLoggerChildWithTagsCall {
-	c.Call = c.Call.Return(arg0)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockLoggerChildWithTagsCall) Do(f func(string, ...string) logger.Logger) *MockLoggerChildWithTagsCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockLoggerChildWithTagsCall) DoAndReturn(f func(string, ...string) logger.Logger) *MockLoggerChildWithTagsCall {
+func (c *MockLoggerChildCall) DoAndReturn(f func(string, ...string) logger.Logger) *MockLoggerChildCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -322,120 +284,6 @@ func (c *MockLoggerInfofCall) DoAndReturn(f func(string, ...any)) *MockLoggerInf
 	return c
 }
 
-// IsDebugEnabled mocks base method.
-func (m *MockLogger) IsDebugEnabled() bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsDebugEnabled")
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// IsDebugEnabled indicates an expected call of IsDebugEnabled.
-func (mr *MockLoggerMockRecorder) IsDebugEnabled() *MockLoggerIsDebugEnabledCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsDebugEnabled", reflect.TypeOf((*MockLogger)(nil).IsDebugEnabled))
-	return &MockLoggerIsDebugEnabledCall{Call: call}
-}
-
-// MockLoggerIsDebugEnabledCall wrap *gomock.Call
-type MockLoggerIsDebugEnabledCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockLoggerIsDebugEnabledCall) Return(arg0 bool) *MockLoggerIsDebugEnabledCall {
-	c.Call = c.Call.Return(arg0)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockLoggerIsDebugEnabledCall) Do(f func() bool) *MockLoggerIsDebugEnabledCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockLoggerIsDebugEnabledCall) DoAndReturn(f func() bool) *MockLoggerIsDebugEnabledCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// IsErrorEnabled mocks base method.
-func (m *MockLogger) IsErrorEnabled() bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsErrorEnabled")
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// IsErrorEnabled indicates an expected call of IsErrorEnabled.
-func (mr *MockLoggerMockRecorder) IsErrorEnabled() *MockLoggerIsErrorEnabledCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsErrorEnabled", reflect.TypeOf((*MockLogger)(nil).IsErrorEnabled))
-	return &MockLoggerIsErrorEnabledCall{Call: call}
-}
-
-// MockLoggerIsErrorEnabledCall wrap *gomock.Call
-type MockLoggerIsErrorEnabledCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockLoggerIsErrorEnabledCall) Return(arg0 bool) *MockLoggerIsErrorEnabledCall {
-	c.Call = c.Call.Return(arg0)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockLoggerIsErrorEnabledCall) Do(f func() bool) *MockLoggerIsErrorEnabledCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockLoggerIsErrorEnabledCall) DoAndReturn(f func() bool) *MockLoggerIsErrorEnabledCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// IsInfoEnabled mocks base method.
-func (m *MockLogger) IsInfoEnabled() bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsInfoEnabled")
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// IsInfoEnabled indicates an expected call of IsInfoEnabled.
-func (mr *MockLoggerMockRecorder) IsInfoEnabled() *MockLoggerIsInfoEnabledCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsInfoEnabled", reflect.TypeOf((*MockLogger)(nil).IsInfoEnabled))
-	return &MockLoggerIsInfoEnabledCall{Call: call}
-}
-
-// MockLoggerIsInfoEnabledCall wrap *gomock.Call
-type MockLoggerIsInfoEnabledCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockLoggerIsInfoEnabledCall) Return(arg0 bool) *MockLoggerIsInfoEnabledCall {
-	c.Call = c.Call.Return(arg0)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockLoggerIsInfoEnabledCall) Do(f func() bool) *MockLoggerIsInfoEnabledCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockLoggerIsInfoEnabledCall) DoAndReturn(f func() bool) *MockLoggerIsInfoEnabledCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // IsLevelEnabled mocks base method.
 func (m *MockLogger) IsLevelEnabled(arg0 logger.Level) bool {
 	m.ctrl.T.Helper()
@@ -470,82 +318,6 @@ func (c *MockLoggerIsLevelEnabledCall) Do(f func(logger.Level) bool) *MockLogger
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockLoggerIsLevelEnabledCall) DoAndReturn(f func(logger.Level) bool) *MockLoggerIsLevelEnabledCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// IsTraceEnabled mocks base method.
-func (m *MockLogger) IsTraceEnabled() bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsTraceEnabled")
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// IsTraceEnabled indicates an expected call of IsTraceEnabled.
-func (mr *MockLoggerMockRecorder) IsTraceEnabled() *MockLoggerIsTraceEnabledCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsTraceEnabled", reflect.TypeOf((*MockLogger)(nil).IsTraceEnabled))
-	return &MockLoggerIsTraceEnabledCall{Call: call}
-}
-
-// MockLoggerIsTraceEnabledCall wrap *gomock.Call
-type MockLoggerIsTraceEnabledCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockLoggerIsTraceEnabledCall) Return(arg0 bool) *MockLoggerIsTraceEnabledCall {
-	c.Call = c.Call.Return(arg0)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockLoggerIsTraceEnabledCall) Do(f func() bool) *MockLoggerIsTraceEnabledCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockLoggerIsTraceEnabledCall) DoAndReturn(f func() bool) *MockLoggerIsTraceEnabledCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// IsWarningEnabled mocks base method.
-func (m *MockLogger) IsWarningEnabled() bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsWarningEnabled")
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// IsWarningEnabled indicates an expected call of IsWarningEnabled.
-func (mr *MockLoggerMockRecorder) IsWarningEnabled() *MockLoggerIsWarningEnabledCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsWarningEnabled", reflect.TypeOf((*MockLogger)(nil).IsWarningEnabled))
-	return &MockLoggerIsWarningEnabledCall{Call: call}
-}
-
-// MockLoggerIsWarningEnabledCall wrap *gomock.Call
-type MockLoggerIsWarningEnabledCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockLoggerIsWarningEnabledCall) Return(arg0 bool) *MockLoggerIsWarningEnabledCall {
-	c.Call = c.Call.Return(arg0)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockLoggerIsWarningEnabledCall) Do(f func() bool) *MockLoggerIsWarningEnabledCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockLoggerIsWarningEnabledCall) DoAndReturn(f func() bool) *MockLoggerIsWarningEnabledCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/unitassigner/unitassigner.go
+++ b/internal/worker/unitassigner/unitassigner.go
@@ -36,7 +36,7 @@ func (u unitAssignerHandler) SetUp() (watcher.StringsWatcher, error) {
 }
 
 func (u unitAssignerHandler) Handle(_ <-chan struct{}, ids []string) error {
-	traceEnabled := u.logger.IsTraceEnabled()
+	traceEnabled := u.logger.IsLevelEnabled(logger.TRACE)
 	if traceEnabled {
 		u.logger.Tracef("Handling unit assignments: %q", ids)
 	}

--- a/internal/worker/uniter/relation/resolver.go
+++ b/internal/worker/uniter/relation/resolver.go
@@ -39,7 +39,7 @@ type relationsResolver struct {
 
 // NextOp implements resolver.Resolver.
 func (r *relationsResolver) NextOp(ctx context.Context, localState resolver.LocalState, remoteState remotestate.Snapshot, opFactory operation.Factory) (_ operation.Operation, err error) {
-	if r.logger.IsTraceEnabled() {
+	if r.logger.IsLevelEnabled(logger.TRACE) {
 		r.logger.Tracef("relation resolver next op for new remote relations %# v", pretty.Formatter(remoteState.Relations))
 		defer func() {
 			if err == resolver.ErrNoOperation {
@@ -328,7 +328,7 @@ func (r *createdRelationsResolver) NextOp(
 	remoteState remotestate.Snapshot,
 	opFactory operation.Factory,
 ) (_ operation.Operation, err error) {
-	if r.logger.IsTraceEnabled() {
+	if r.logger.IsLevelEnabled(logger.TRACE) {
 		r.logger.Tracef("create relation resolver next op for new remote relations %# v", pretty.Formatter(remoteState.Relations))
 		defer func() {
 			if err == resolver.ErrNoOperation {

--- a/internal/worker/uniter/relation/state.go
+++ b/internal/worker/uniter/relation/state.go
@@ -98,10 +98,10 @@ func (s *State) Validate(hi hook.Info) (err error) {
 // It must be called after the respective hook was executed successfully.
 // UpdateStateForHook doesn't validate hi but guarantees that successive
 // changes of the same hi are idempotent.
-func (s *State) UpdateStateForHook(hi hook.Info, logger logger.Logger) {
-	if logger.IsTraceEnabled() {
+func (s *State) UpdateStateForHook(hi hook.Info, log logger.Logger) {
+	if log.IsLevelEnabled(logger.TRACE) {
 		defer func() {
-			logger.Tracef("updated relation state %# v\nfor hook %# v", pretty.Formatter(s), pretty.Formatter(hi))
+			log.Tracef("updated relation state %# v\nfor hook %# v", pretty.Formatter(s), pretty.Formatter(hi))
 		}()
 	}
 	if hi.Kind == hooks.RelationBroken {

--- a/internal/worker/uniter/relation/statemanager.go
+++ b/internal/worker/uniter/relation/statemanager.go
@@ -127,7 +127,7 @@ func (m *stateManager) initialize() error {
 		return errors.Trace(err)
 	}
 	m.relationState = make(map[int]State, len(unitState.RelationState))
-	if m.logger.IsTraceEnabled() {
+	if m.logger.IsLevelEnabled(logger.TRACE) {
 		m.logger.Tracef("initialising state manager: %# v", pretty.Formatter(unitState.RelationState))
 	}
 	for k, v := range unitState.RelationState {

--- a/internal/worker/uniter/relation/statetracker.go
+++ b/internal/worker/uniter/relation/statetracker.go
@@ -120,7 +120,7 @@ func (r *relationStateTracker) loadInitialState(ctx stdcontext.Context) error {
 		r.relationCreated[rel.Id()] = true
 	}
 
-	if r.logger.IsTraceEnabled() {
+	if r.logger.IsLevelEnabled(logger.TRACE) {
 		if mgr, ok := r.stateMgr.(*stateManager); ok {
 			r.logger.Tracef("initialising relation state tracker: %# v", pretty.Formatter(mgr.relationState))
 		}
@@ -226,7 +226,7 @@ func (r *relationStateTracker) joinRelation(ctx stdcontext.Context, rel api.Rela
 }
 
 func (r *relationStateTracker) SynchronizeScopes(ctx stdcontext.Context, remote remotestate.Snapshot) error {
-	isTraceEnabled := r.logger.IsTraceEnabled()
+	isTraceEnabled := r.logger.IsLevelEnabled(logger.TRACE)
 	if isTraceEnabled {
 		r.logger.Tracef("%q synchronise scopes for remote relations %# v", r.unit.Name(), pretty.Formatter(remote.Relations))
 	}

--- a/internal/worker/uniter/resolver.go
+++ b/internal/worker/uniter/resolver.go
@@ -74,7 +74,7 @@ func (s *uniterResolver) NextOp(
 	if remoteState.Life == life.Dead || localState.Removed {
 		return nil, resolver.ErrUnitDead
 	}
-	logger := s.config.Logger
+	log := s.config.Logger
 
 	// Operations for series-upgrade need to be resolved early,
 	// in particular because no other operations should be run when the unit
@@ -101,7 +101,7 @@ func (s *uniterResolver) NextOp(
 			return s.nextOpConflicted(ctx, localState, remoteState, opFactory)
 		}
 		// continue upgrading the charm
-		logger.Infof("resuming charm upgrade")
+		log.Infof("resuming charm upgrade")
 		return s.newUpgradeOperation(ctx, localState, remoteState, opFactory)
 	}
 
@@ -167,7 +167,7 @@ func (s *uniterResolver) NextOp(
 	// If we are to shut down, we don't want to start running any more queued/pending hooks.
 	if remoteState.Shutdown {
 		badge = "shutdown"
-		logger.Debugf("unit agent is shutting down, will not run pending/queued hooks")
+		log.Debugf("unit agent is shutting down, will not run pending/queued hooks")
 		return s.nextOp(ctx, localState, remoteState, opFactory)
 	}
 
@@ -180,12 +180,12 @@ func (s *uniterResolver) NextOp(
 		switch step {
 		case operation.Pending:
 			badge = "resolve hook"
-			logger.Infof("awaiting error resolution for %q hook", localState.Hook.Kind)
+			log.Infof("awaiting error resolution for %q hook", localState.Hook.Kind)
 			return s.nextOpHookError(ctx, localState, remoteState, opFactory)
 
 		case operation.Queued:
 			badge = "queued hook"
-			logger.Infof("found queued %q hook", localState.Hook.Kind)
+			log.Infof("found queued %q hook", localState.Hook.Kind)
 			if localState.Hook.Kind == hooks.Install {
 				// Special case: handle install in nextOp,
 				// so we do nothing when the unit is dying.
@@ -198,7 +198,7 @@ func (s *uniterResolver) NextOp(
 			// we'd have to parse the charm url every time just to check to see
 			// if a wrench existed.
 			badge = "commit hook"
-			if localState.CharmURL != "" && logger.IsTraceEnabled() {
+			if localState.CharmURL != "" && log.IsLevelEnabled(logger.TRACE) {
 				// If it's set, the charm url will parse.
 				curl := jujucharm.MustParseURL(localState.CharmURL)
 				if curl != nil && wrench.IsActive("hooks", fmt.Sprintf("%s-%s-error", curl.Name, localState.Hook.Kind)) {
@@ -207,7 +207,7 @@ func (s *uniterResolver) NextOp(
 				}
 			}
 
-			logger.Infof("committing %q hook", localState.Hook.Kind)
+			log.Infof("committing %q hook", localState.Hook.Kind)
 			return opFactory.NewSkipHook(*localState.Hook)
 
 		default:
@@ -216,7 +216,7 @@ func (s *uniterResolver) NextOp(
 
 	case operation.Continue:
 		badge = "idle"
-		logger.Debugf("no operations in progress; waiting for changes")
+		log.Debugf("no operations in progress; waiting for changes")
 		return s.nextOp(ctx, localState, remoteState, opFactory)
 
 	default:

--- a/internal/worker/uniter/uniter.go
+++ b/internal/worker/uniter/uniter.go
@@ -494,16 +494,16 @@ func (u *Uniter) loop(unitTag names.UnitTag) (err error) {
 				u.logger.Child("leadership"),
 			),
 			CreatedRelations: relation.NewCreatedRelationResolver(
-				u.relationStateTracker, u.logger.ChildWithTags("relation", corelogger.CMR)),
+				u.relationStateTracker, u.logger.Child("relation", corelogger.CMR)),
 			Relations: relation.NewRelationResolver(
-				u.relationStateTracker, u.unit, u.logger.ChildWithTags("relation", corelogger.CMR)),
+				u.relationStateTracker, u.unit, u.logger.Child("relation", corelogger.CMR)),
 			Storage: storage.NewResolver(
 				u.logger.Child("storage"), u.storage, u.modelType),
 			Commands: runcommands.NewCommandsResolver(
 				u.commands, watcher.CommandCompleted,
 			),
 			Secrets: secrets.NewSecretsResolver(
-				u.logger.ChildWithTags("secrets", corelogger.SECRETS),
+				u.logger.Child("secrets", corelogger.SECRETS),
 				u.secretsTracker,
 				watcher.RotateSecretCompleted,
 				watcher.ExpireRevisionCompleted,
@@ -821,7 +821,7 @@ func (u *Uniter) init(ctx stdcontext.Context, unitTag names.UnitTag) (err error)
 	u.storage = storageAttachments
 
 	secretsTracker, err := secrets.NewSecrets(
-		u.secretsClient, unitTag, u.unit, u.logger.ChildWithTags("secrets", corelogger.SECRETS),
+		u.secretsClient, unitTag, u.unit, u.logger.Child("secrets", corelogger.SECRETS),
 	)
 	if err != nil {
 		return errors.Annotatef(err, "cannot create secrets tracker")

--- a/rpc/jsoncodec/codec.go
+++ b/rpc/jsoncodec/codec.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/errors"
 
+	corelogger "github.com/juju/juju/core/logger"
 	internallogger "github.com/juju/juju/internal/logger"
 	"github.com/juju/juju/rpc"
 )
@@ -96,7 +97,7 @@ func (c *Codec) isClosing() bool {
 func (c *Codec) ReadHeader(hdr *rpc.Header) error {
 	var m json.RawMessage
 	if err := c.conn.Receive(&m); err != nil {
-		if logger.IsTraceEnabled() {
+		if logger.IsLevelEnabled(corelogger.TRACE) {
 			logger.Tracef("<- error: %v (closing %v)", err, c.isClosing())
 		}
 
@@ -108,7 +109,7 @@ func (c *Codec) ReadHeader(hdr *rpc.Header) error {
 		return errors.Annotate(err, "receiving message")
 	}
 
-	if logger.IsTraceEnabled() {
+	if logger.IsLevelEnabled(corelogger.TRACE) {
 		logger.Tracef("<- %s", m)
 	}
 	var err error
@@ -159,7 +160,7 @@ func (c *Codec) WriteMessage(hdr *rpc.Header, body interface{}) error {
 	if err != nil {
 		return errors.Annotate(err, "writing message")
 	}
-	if logger.IsTraceEnabled() {
+	if logger.IsLevelEnabled(corelogger.TRACE) {
 		data, err := json.Marshal(msg)
 		if err != nil {
 			logger.Tracef("-> marshal error: %v", err)

--- a/state/database.go
+++ b/state/database.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kr/pretty"
 
 	"github.com/juju/juju/controller"
+	corelogger "github.com/juju/juju/core/logger"
 	"github.com/juju/juju/internal/feature"
 	internallogger "github.com/juju/juju/internal/logger"
 	"github.com/juju/juju/internal/mongo"
@@ -383,14 +384,14 @@ func (db *database) TransactionRunner() (runner jujutxn.Runner, closer SessionCl
 			closer = session.Close
 		}
 		observer := func(t jujutxn.Transaction) {
-			if txnLogger.IsTraceEnabled() {
+			if txnLogger.IsLevelEnabled(corelogger.TRACE) {
 				txnLogger.Tracef("ran transaction in %.3fs (retries: %d) %# v\nerr: %v",
 					t.Duration.Seconds(), t.Attempt, pretty.Formatter(t.Ops), t.Error)
 			}
 		}
 		if db.runTransactionObserver != nil {
 			observer = func(t jujutxn.Transaction) {
-				if txnLogger.IsTraceEnabled() {
+				if txnLogger.IsLevelEnabled(corelogger.TRACE) {
 					txnLogger.Tracef("ran transaction in %.3fs (retries: %d) %# v\nerr: %v",
 						t.Duration.Seconds(), t.Attempt, pretty.Formatter(t.Ops), t.Error)
 				}

--- a/state/pool.go
+++ b/state/pool.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/pubsub/v2"
 	"github.com/juju/worker/v4"
 
+	corelogger "github.com/juju/juju/core/logger"
 	"github.com/juju/juju/internal/feature"
 	internallogger "github.com/juju/juju/internal/logger"
 	"github.com/juju/juju/internal/mongo"
@@ -386,7 +387,7 @@ func (p *StatePool) Close() error {
 		p.mu.Unlock()
 		return nil
 	}
-	if logger.IsTraceEnabled() {
+	if logger.IsLevelEnabled(corelogger.TRACE) {
 		logger.Tracef("state pool closed from:\n%s", debug.Stack())
 	}
 

--- a/state/relationunit.go
+++ b/state/relationunit.go
@@ -18,6 +18,7 @@ import (
 	jujutxn "github.com/juju/txn/v3"
 	"github.com/kr/pretty"
 
+	corelogger "github.com/juju/juju/core/logger"
 	stateerrors "github.com/juju/juju/state/errors"
 )
 
@@ -483,7 +484,7 @@ func (op *LeaveScopeOperation) internalLeaveScope() ([]txn.Op, error) {
 		}
 		ops = append(ops, relOps...)
 	}
-	if rulogger.IsTraceEnabled() {
+	if rulogger.IsLevelEnabled(corelogger.TRACE) {
 		rulogger.Tracef("leave scope ops for %s: %s", op.Description(), pretty.Sprint(ops))
 	}
 	return ops, nil

--- a/state/resources.go
+++ b/state/resources.go
@@ -22,6 +22,7 @@ import (
 	"github.com/juju/names/v5"
 	"github.com/kr/pretty"
 
+	corelogger "github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/core/resources"
 	"github.com/juju/juju/internal/docker"
@@ -494,7 +495,7 @@ func (p *resourcePersistence) listResources(applicationID string, pending bool) 
 			DownloadProgress: downloadProgress[tag],
 		})
 	}
-	if rLogger.IsTraceEnabled() {
+	if rLogger.IsLevelEnabled(corelogger.TRACE) {
 		rLogger.Tracef("found %d docs: %q", len(docs), pretty.Sprint(results))
 	}
 	return results, nil
@@ -1328,7 +1329,7 @@ func newInsertCharmStoreResourceOps(res charmStoreResource) []txn.Op {
 func newUpdateCharmStoreResourceOps(res charmStoreResource) []txn.Op {
 	doc := newCharmStoreResourceDoc(res)
 
-	if rLogger.IsTraceEnabled() {
+	if rLogger.IsLevelEnabled(corelogger.TRACE) {
 		rLogger.Tracef("updating charm store resource %s to %# v", res.id, pretty.Formatter(doc))
 	}
 	return []txn.Op{{
@@ -1355,7 +1356,7 @@ func newUpdateUnitResourceOps(unitID string, stored storedResource, progress *in
 	doc := newUnitResourceDoc(unitID, stored)
 	doc.DownloadProgress = progress
 
-	if rLogger.IsTraceEnabled() {
+	if rLogger.IsLevelEnabled(corelogger.TRACE) {
 		rLogger.Tracef("updating unit resource %s to %# v", unitID, pretty.Formatter(doc))
 	}
 	return []txn.Op{{

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -1460,7 +1460,7 @@ func (w *relationUnitsWatcher) loop() (err error) {
 				return watcher.EnsureErr(w.sw)
 			}
 			gotInitialScopeWatcher = true
-			if w.logger.IsTraceEnabled() {
+			if w.logger.IsLevelEnabled(corelogger.TRACE) {
 				w.logger.Tracef("relationUnitsWatcher %q scope Changes(): %# v", w.sw.prefix, pretty.Formatter(c))
 			}
 			if err = w.mergeScope(&changes, c); err != nil {
@@ -1499,7 +1499,7 @@ func (w *relationUnitsWatcher) loop() (err error) {
 				out = w.out
 			}
 		case out <- changes:
-			if w.logger.IsTraceEnabled() {
+			if w.logger.IsLevelEnabled(corelogger.TRACE) {
 				w.logger.Tracef("relationUnitsWatcher %q sent changes %# v", w.sw.prefix, pretty.Formatter(changes))
 			}
 			sentInitial = true

--- a/state/watcher/txnwatcher.go
+++ b/state/watcher/txnwatcher.go
@@ -311,7 +311,7 @@ func (w *TxnWatcher) loop() error {
 		} else {
 			err = w.sync()
 		}
-		if w.logger.IsTraceEnabled() && wrench.IsActive("txnwatcher", "sync-error") {
+		if w.logger.IsLevelEnabled(logger.TRACE) && wrench.IsActive("txnwatcher", "sync-error") {
 			err = errors.New("test sync watcher error")
 		}
 		if err == nil {


### PR DESCRIPTION
The logger interface was copied from loggo.Logger type. It has a lot
of syntax sugar for accessing log levels, or the difference between Child
and ChildWithTags. In reality you can just use IsLevelEnabled or Child that
redirects to ChildWithTags. The motivation for doing this is to make a concise
logger interface that could be used with loggo, or backed with different
implementations.

The logger interface then becomes:

```go
// Logger is an interface that provides logging methods.
type Logger interface {
	// Critical logs a message at the critical level.
	Criticalf(msg string, args ...any)

	// Error logs a message at the error level.
	Errorf(msg string, args ...any)

	// Warning logs a message at the warning level.
	Warningf(msg string, args ...any)

	// Info logs a message at the info level.
	Infof(msg string, args ...any)

	// Debug logs a message at the debug level.
	Debugf(msg string, args ...any)

	// Trace logs a message at the trace level.
	Tracef(msg string, args ...any)

	// Log logs some information into the test error output.
	// The provided arguments are assembled together into a string with
	// fmt.Sprintf.
	Logf(level Level, format string, args ...any)

	// IsLevelEnabled returns true if the given level is enabled for the logger.
	IsLevelEnabled(Level) bool

	// Child returns a new logger with the given name.
	Child(name string, tags ...string) Logger

	// GetChildByName returns a child logger with the given name.
	GetChildByName(name string) Logger
}
```


There are two additional changes that are still outstanding that will follow this 
change request:

 1. Removal of the `GetChildByName` from the Logger. This sole purpose is access a logger by the absolute name. This is only used in the uniter in one location throughout juju. Instead of requesting it from the current logger and walking it's child/parent relationship, we should pass in the context into the unit, so it can retrieve it from there instead.
 2. Adding context.Context as the first argument. Thus allowing us to start adding trace ids as labels to the logs.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

We need to ensure that tracing is still available.

```
$ juju bootstrap lxd test
$ juju debug-log -m controller
$ juju model-config -m controller logging-config="<root>=TRACE"
```

## Links

**Jira card:** JUJU-

