### PR TITLE
Follow up on controllercharm prometheus test fix

### DIFF
--- a/tests/suites/controllercharm/prometheus.sh
+++ b/tests/suites/controllercharm/prometheus.sh
@@ -67,14 +67,13 @@ run_prometheus_multiple_units() {
 	juju status --format json | jq -r "$(active_condition "p2" 1)" | check "p2"
 
 	juju remove-relation p1 controller
-	# Wait until the application p1 settles before health checks
-	wait_for "p1" "$(active_condition "p1" 0)"
 
 	# Check Juju controller is removed from Prometheus targets
 	retry 'check_prometheus_no_target p1 0' 5
 	# Check no errors in controller charm or Prometheus
 	juju status -m controller --format json | jq -r "$(active_condition "controller")" | check "controller"
-	juju status --format json | jq -r "$(active_condition "p1" 0)" | check "p1"
+	# Ensure p1 is still healty
+	wait_for "p1" "$(active_condition "p1" 0)"
 
 	juju remove-application p1 --destroy-storage \
 		--force --no-wait # TODO: remove these flags once storage bug is fixed


### PR DESCRIPTION
Follow up on #17353, attempting to unblock ci-gating tests to unblock 3.3+ releases.

It replaces the last check for p1 in the test with a ` wait_for`, which will timeout if p1 doesn't go into healty active state.