### PR TITLE
Rename of model finaliser to activator.

### DIFF
--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -330,7 +330,7 @@ func (m *ModelManagerAPI) createModelNew(
 	}
 
 	// Create the model in the controller database.
-	finaliser, err := m.modelService.CreateModel(ctx, creationArgs)
+	activator, err := m.modelService.CreateModel(ctx, creationArgs)
 	if err != nil {
 		return errors.Annotatef(err, "failed to create model %q", modelUUID)
 	}
@@ -352,9 +352,9 @@ func (m *ModelManagerAPI) createModelNew(
 	}
 
 	// TODO (stickupkid): Once tlm has fixed the CreateModel method to read
-	// from the model database to create the model, move the finaliser call
+	// from the model database to create the model, move the activator call
 	// to the end of the method.
-	if err := finaliser(ctx); err != nil {
+	if err := activator(ctx); err != nil {
 		return errors.Annotatef(err, "failed to finalise model %q", modelUUID)
 	}
 

--- a/domain/cloud/state/state_test.go
+++ b/domain/cloud/state/state_test.go
@@ -612,7 +612,7 @@ func (s *stateSuite) TestCloudIsControllerCloud(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = modelSt.Finalise(context.Background(), modelUUID)
+	err = modelSt.Activate(context.Background(), modelUUID)
 	c.Assert(err, jc.ErrorIsNil)
 
 	clouds, err = st.ListClouds(context.Background())

--- a/domain/credential/state/state_test.go
+++ b/domain/credential/state/state_test.go
@@ -572,7 +572,7 @@ func (s *credentialSuite) TestModelsUsingCloudCredential(c *gc.C) {
 
 	insertOne := func(ctx context.Context, tx *sql.Tx, modelUUID, name string) error {
 		result, err := tx.ExecContext(ctx, fmt.Sprintf(`
-		INSERT INTO model (uuid, name, owner_uuid, life_id, model_type_id, finalised, cloud_uuid, cloud_credential_uuid)
+		INSERT INTO model (uuid, name, owner_uuid, life_id, model_type_id, activated, cloud_uuid, cloud_credential_uuid)
 		SELECT %q, %q, %q, 0, 0, true,
 			(SELECT uuid FROM cloud WHERE cloud.name="stratus"),
 			(SELECT uuid FROM cloud_credential cc WHERE cc.name="foobar")`,

--- a/domain/model/bootstrap/bootstrap.go
+++ b/domain/model/bootstrap/bootstrap.go
@@ -59,7 +59,7 @@ func CreateModel(
 		}
 		args.AgentVersion = agentVersion
 
-		finaliser := state.GetFinaliser()
+		activator := state.GetActivator()
 		return controller.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
 			modelTypeState := modelTypeStateFunc(
 				func(ctx context.Context, cloudName string) (string, error) {
@@ -74,8 +74,8 @@ func CreateModel(
 				return fmt.Errorf("create bootstrap model %q with uuid %q: %w", args.Name, args.UUID, err)
 			}
 
-			if err := finaliser(ctx, tx, args.UUID); err != nil {
-				return fmt.Errorf("finalising bootstrap model %q with uuid %q: %w", args.Name, args.UUID, err)
+			if err := activator(ctx, tx, args.UUID); err != nil {
+				return fmt.Errorf("activating bootstrap model %q with uuid %q: %w", args.Name, args.UUID, err)
 			}
 			return nil
 		})

--- a/domain/model/errors/errors.go
+++ b/domain/model/errors/errors.go
@@ -16,9 +16,9 @@ const (
 	// AlreadyExists describes an error that occurs when a model already exists.
 	AlreadyExists = errors.ConstError("model already exists")
 
-	// AlreadyFinalised describes an error that occurs when an attempt is made
-	// to finalise a model that has already been finalised.
-	AlreadyFinalised = errors.ConstError("model already finalised")
+	// AlreadyActivated describes an error that occurs when an attempt is made
+	// to activate a model that has already been activated.
+	AlreadyActivated = errors.ConstError("model already activated")
 
 	// ModelNamespaceNotFound describes an error that occurs when no database
 	// namespace for a model exists.

--- a/domain/model/modelmigration/import.go
+++ b/domain/model/modelmigration/import.go
@@ -174,7 +174,7 @@ func (i importOperation) Execute(ctx context.Context, model description.Model) e
 
 	// NOTE: Try to get all things that can fail before creating the model in
 	// the database.
-	finaliser, err := i.modelService.CreateModel(ctx, args)
+	activator, err := i.modelService.CreateModel(ctx, args)
 	if err != nil {
 		return fmt.Errorf(
 			"importing model %q with uuid %q during migration: %w",
@@ -186,11 +186,11 @@ func (i importOperation) Execute(ctx context.Context, model description.Model) e
 	// consider adding a rollback operation to undo the changes made by the
 	// import operation.
 
-	// finaliser needs to be called as the last operation to say that we are
+	// activator needs to be called as the last operation to say that we are
 	// happy that the model is ready to rock and roll.
-	if err := finaliser(ctx); err != nil {
+	if err := activator(ctx); err != nil {
 		return fmt.Errorf(
-			"finalising imported model %q with uuid %q: %w", modelName, modelID, err,
+			"activating imported model %q with uuid %q: %w", modelName, modelID, err,
 		)
 	}
 

--- a/domain/model/modelmigration/import_test.go
+++ b/domain/model/modelmigration/import_test.go
@@ -145,16 +145,16 @@ func (i *importSuite) TestModelCreate(c *gc.C) {
 		UUID:  modelUUID,
 	}
 
-	finalised := false
-	finaliser := func(_ context.Context) error {
-		finalised = true
+	activated := false
+	activator := func(_ context.Context) error {
+		activated = true
 		return nil
 	}
 
 	controllerUUID, err := uuid.UUIDFromString(testing.ControllerTag.Id())
 	c.Assert(err, jc.ErrorIsNil)
 
-	i.modelService.EXPECT().CreateModel(gomock.Any(), args).Return(finaliser, nil)
+	i.modelService.EXPECT().CreateModel(gomock.Any(), args).Return(activator, nil)
 	i.readOnlyModelService.EXPECT().CreateModel(gomock.Any(), controllerUUID).Return(nil)
 
 	model := description.NewModel(description.ModelArgs{
@@ -185,7 +185,7 @@ func (i *importSuite) TestModelCreate(c *gc.C) {
 	coordinator := modelmigration.NewCoordinator(modelmigrationtesting.IgnoredSetupOperation(importOp))
 	err = coordinator.Perform(context.Background(), modelmigration.NewScope(nil, nil), model)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(finalised, jc.IsTrue)
+	c.Check(activated, jc.IsTrue)
 }
 
 func (i *importSuite) TestModelCreateRollbacksOnFailure(c *gc.C) {
@@ -216,16 +216,16 @@ func (i *importSuite) TestModelCreateRollbacksOnFailure(c *gc.C) {
 		UUID:  modelUUID,
 	}
 
-	var finalised bool
-	finaliser := func(_ context.Context) error {
-		finalised = true
+	var activated bool
+	activator := func(_ context.Context) error {
+		activated = true
 		return nil
 	}
 
 	controllerUUID, err := uuid.UUIDFromString(testing.ControllerTag.Id())
 	c.Assert(err, jc.ErrorIsNil)
 
-	i.modelService.EXPECT().CreateModel(gomock.Any(), args).Return(finaliser, nil)
+	i.modelService.EXPECT().CreateModel(gomock.Any(), args).Return(activator, nil)
 	i.readOnlyModelService.EXPECT().CreateModel(gomock.Any(), controllerUUID).Return(errors.New("boom"))
 	i.modelService.EXPECT().DeleteModel(gomock.Any(), modelUUID).Return(nil)
 	i.readOnlyModelService.EXPECT().DeleteModel(gomock.Any()).Return(nil)
@@ -261,7 +261,7 @@ func (i *importSuite) TestModelCreateRollbacksOnFailure(c *gc.C) {
 
 	// TODO (stickupkid): This is incorrect until the read-only model is
 	// correctly saved.
-	c.Check(finalised, jc.IsTrue)
+	c.Check(activated, jc.IsTrue)
 }
 
 func (i *importSuite) TestModelCreateRollbacksOnFailureIgnoreNotFoundModel(c *gc.C) {
@@ -292,15 +292,15 @@ func (i *importSuite) TestModelCreateRollbacksOnFailureIgnoreNotFoundModel(c *gc
 		UUID:  modelUUID,
 	}
 
-	finalised := false
-	finaliser := func(_ context.Context) error {
-		finalised = true
+	activated := false
+	activator := func(_ context.Context) error {
+		activated = true
 		return nil
 	}
 	controllerUUID, err := uuid.UUIDFromString(testing.ControllerTag.Id())
 	c.Assert(err, jc.ErrorIsNil)
 
-	i.modelService.EXPECT().CreateModel(gomock.Any(), args).Return(finaliser, nil)
+	i.modelService.EXPECT().CreateModel(gomock.Any(), args).Return(activator, nil)
 	i.readOnlyModelService.EXPECT().CreateModel(gomock.Any(), controllerUUID).Return(errors.New("boom"))
 	i.modelService.EXPECT().DeleteModel(gomock.Any(), modelUUID).Return(modelerrors.NotFound)
 	i.readOnlyModelService.EXPECT().DeleteModel(gomock.Any()).Return(nil)
@@ -336,7 +336,7 @@ func (i *importSuite) TestModelCreateRollbacksOnFailureIgnoreNotFoundModel(c *gc
 
 	// TODO (stickupkid): This is incorrect until the read-only model is
 	// correctly saved.
-	c.Check(finalised, jc.IsTrue)
+	c.Check(activated, jc.IsTrue)
 }
 
 func (i *importSuite) TestModelCreateRollbacksOnFailureIgnoreNotFoundReadOnlyModel(c *gc.C) {
@@ -353,9 +353,9 @@ func (i *importSuite) TestModelCreateRollbacksOnFailureIgnoreNotFoundReadOnlyMod
 	)
 	i.controllerConfigService.EXPECT().ControllerConfig(gomock.Any()).Return(testing.FakeControllerConfig(), nil)
 
-	finalised := false
-	finaliser := func(_ context.Context) error {
-		finalised = true
+	activated := false
+	activator := func(_ context.Context) error {
+		activated = true
 		return nil
 	}
 
@@ -375,7 +375,7 @@ func (i *importSuite) TestModelCreateRollbacksOnFailureIgnoreNotFoundReadOnlyMod
 	controllerUUID, err := uuid.UUIDFromString(testing.ControllerTag.Id())
 	c.Assert(err, jc.ErrorIsNil)
 
-	i.modelService.EXPECT().CreateModel(gomock.Any(), args).Return(finaliser, nil)
+	i.modelService.EXPECT().CreateModel(gomock.Any(), args).Return(activator, nil)
 	i.readOnlyModelService.EXPECT().CreateModel(gomock.Any(), controllerUUID).Return(errors.New("boom"))
 	i.modelService.EXPECT().DeleteModel(gomock.Any(), modelUUID).Return(nil)
 	i.readOnlyModelService.EXPECT().DeleteModel(gomock.Any()).Return(modelerrors.NotFound)
@@ -411,5 +411,5 @@ func (i *importSuite) TestModelCreateRollbacksOnFailureIgnoreNotFoundReadOnlyMod
 
 	// TODO (stickupkid): This is incorrect until the read-only model is
 	// correctly saved.
-	c.Check(finalised, jc.IsTrue)
+	c.Check(activated, jc.IsTrue)
 }

--- a/domain/model/service/state_test.go
+++ b/domain/model/service/state_test.go
@@ -28,7 +28,7 @@ type dummyStateCloud struct {
 type dummyState struct {
 	clouds             map[string]dummyStateCloud
 	models             map[coremodel.UUID]coremodel.Model
-	nonFinalisedModels map[coremodel.UUID]coremodel.Model
+	nonActivatedModels map[coremodel.UUID]coremodel.Model
 	users              map[user.UUID]string
 }
 
@@ -85,7 +85,7 @@ func (d *dummyState) Create(
 		}
 	}
 
-	d.nonFinalisedModels[args.UUID] = coremodel.Model{
+	d.nonActivatedModels[args.UUID] = coremodel.Model{
 		AgentVersion: args.AgentVersion,
 		Name:         args.Name,
 		UUID:         args.UUID,
@@ -100,18 +100,18 @@ func (d *dummyState) Create(
 	return nil
 }
 
-func (d *dummyState) Finalise(
+func (d *dummyState) Activate(
 	_ context.Context,
 	uuid coremodel.UUID,
 ) error {
-	if model, exists := d.nonFinalisedModels[uuid]; exists {
+	if model, exists := d.nonActivatedModels[uuid]; exists {
 		d.models[uuid] = model
-		delete(d.nonFinalisedModels, uuid)
+		delete(d.nonActivatedModels, uuid)
 		return nil
 	}
 
 	if _, exists := d.models[uuid]; exists {
-		return modelerrors.AlreadyFinalised
+		return modelerrors.AlreadyActivated
 	}
 	return modelerrors.NotFound
 }

--- a/domain/model/state/state_test.go
+++ b/domain/model/state/state_test.go
@@ -151,7 +151,7 @@ func (m *stateSuite) SetUpTest(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = modelSt.Finalise(context.Background(), m.uuid)
+	err = modelSt.Activate(context.Background(), m.uuid)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -228,7 +228,7 @@ func (m *stateSuite) TestModelCloudNameAndCredentialController(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = st.Finalise(context.Background(), modelUUID)
+	err = st.Activate(context.Background(), modelUUID)
 	c.Assert(err, jc.ErrorIsNil)
 
 	cloudName, credentialID, err := st.ModelCloudNameAndCredential(
@@ -407,7 +407,7 @@ func (m *stateSuite) TestCreateWithEmptyRegion(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = modelSt.Finalise(context.Background(), testUUID)
+	err = modelSt.Activate(context.Background(), testUUID)
 	c.Assert(err, jc.ErrorIsNil)
 
 	modelInfo, err := modelSt.Get(context.Background(), testUUID)
@@ -454,7 +454,7 @@ func (m *stateSuite) TestCreateWithEmptyRegionUsesControllerRegion(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = modelSt.Finalise(context.Background(), testUUID)
+	err = modelSt.Activate(context.Background(), testUUID)
 	c.Assert(err, jc.ErrorIsNil)
 
 	modelInfo, err := modelSt.Get(context.Background(), testUUID)
@@ -485,7 +485,7 @@ func (m *stateSuite) TestCreateWithEmptyRegionDoesNotUseControllerRegionForDiffe
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = modelSt.Finalise(context.Background(), controllerUUID)
+	err = modelSt.Activate(context.Background(), controllerUUID)
 	c.Assert(err, jc.ErrorIsNil)
 
 	modelInfo, err := modelSt.Get(context.Background(), controllerUUID)
@@ -510,7 +510,7 @@ func (m *stateSuite) TestCreateWithEmptyRegionDoesNotUseControllerRegionForDiffe
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = modelSt.Finalise(context.Background(), testUUID)
+	err = modelSt.Activate(context.Background(), testUUID)
 	c.Assert(err, jc.ErrorIsNil)
 
 	modelInfo, err = modelSt.Get(context.Background(), testUUID)
@@ -722,7 +722,7 @@ func (m *stateSuite) TestSetModelCloudCredentialWithoutRegion(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = modelSt.Finalise(context.Background(), m.uuid)
+	err = modelSt.Activate(context.Background(), m.uuid)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -788,7 +788,7 @@ func (m *stateSuite) TestListModelIDs(c *gc.C) {
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	err = modelSt.Finalise(context.Background(), uuid1)
+	err = modelSt.Activate(context.Background(), uuid1)
 	c.Assert(err, jc.ErrorIsNil)
 
 	uuid2 := modeltesting.GenModelUUID(c)
@@ -810,7 +810,7 @@ func (m *stateSuite) TestListModelIDs(c *gc.C) {
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	err = modelSt.Finalise(context.Background(), uuid2)
+	err = modelSt.Activate(context.Background(), uuid2)
 	c.Assert(err, jc.ErrorIsNil)
 
 	uuids, err := modelSt.ListModelIDs(context.Background())
@@ -899,7 +899,7 @@ func (m *stateSuite) TestModelsOwnedByUser(c *gc.C) {
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(modelSt.Finalise(context.Background(), uuid1), jc.ErrorIsNil)
+	c.Assert(modelSt.Activate(context.Background(), uuid1), jc.ErrorIsNil)
 
 	uuid2 := modeltesting.GenModelUUID(c)
 	err = modelSt.Create(
@@ -920,7 +920,7 @@ func (m *stateSuite) TestModelsOwnedByUser(c *gc.C) {
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(modelSt.Finalise(context.Background(), uuid2), jc.ErrorIsNil)
+	c.Assert(modelSt.Activate(context.Background(), uuid2), jc.ErrorIsNil)
 
 	models, err := modelSt.ListModelsForUser(context.Background(), m.userUUID)
 	c.Assert(err, jc.ErrorIsNil)

--- a/domain/model/state/testing/model.go
+++ b/domain/model/state/testing/model.go
@@ -152,7 +152,7 @@ func CreateTestModel(
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = modelSt.Finalise(context.Background(), modelUUID)
+	err = modelSt.Activate(context.Background(), modelUUID)
 	c.Assert(err, jc.ErrorIsNil)
 
 	return modelUUID

--- a/domain/schema/controller.go
+++ b/domain/schema/controller.go
@@ -237,7 +237,7 @@ WITH controllers AS (
     INNER JOIN user u ON u.uuid = m.owner_uuid
     WHERE m.name = "controller"
     AND u.name = "admin"
-    AND m.finalised = true
+    AND m.activated = true
 )
 SELECT c.uuid,
        c.name,
@@ -474,12 +474,12 @@ INSERT INTO model_type VALUES
 
 CREATE TABLE model (
     uuid                  TEXT PRIMARY KEY,
--- finalised tells us if the model creation process has been completed and
+-- activated tells us if the model creation process has been completed and
 -- we can use this model. The reason for this is model creation still happens
 -- over several transactions with any one of them possibly failing. We write true
 -- to this field when we are happy that the model can safely be used after all
 -- operations have been completed.
-    finalised             BOOLEAN DEFAULT FALSE NOT NULL,
+    activated             BOOLEAN DEFAULT FALSE NOT NULL,
     cloud_uuid            TEXT NOT NULL,
     cloud_region_uuid     TEXT,
     cloud_credential_uuid TEXT,
@@ -510,10 +510,10 @@ CREATE TABLE model (
 -- idx_model_name_owner established an index that stops models being created
 -- with the same name for a given owner.
 CREATE UNIQUE INDEX idx_model_name_owner ON model (name, owner_uuid);
-CREATE INDEX idx_model_finalised ON model (finalised);
+CREATE INDEX idx_model_activated ON model (activated);
 
 --- v_model purpose is to provide an easy access mechanism for models in the
---- system. It will only show models that have been finalised so the caller does
+--- system. It will only show models that have been activated so the caller does
 --- not have to worry about retrieving half complete models.
 CREATE VIEW v_model AS
 SELECT m.uuid AS uuid,
@@ -546,7 +546,7 @@ LEFT JOIN user cco ON cc.owner_uuid = cco.uuid
 INNER JOIN model_type mt ON m.model_type_id = mt.id
 INNER JOIN user o ON m.owner_uuid = o.uuid
 INNER JOIN life l on m.life_id = l.id
-WHERE m.finalised = true;
+WHERE m.activated = true;
 `)
 }
 

--- a/domain/secretbackend/state/state_test.go
+++ b/domain/secretbackend/state/state_test.go
@@ -190,7 +190,7 @@ func (s *stateSuite) createModelWithName(c *gc.C, modelType coremodel.ModelType,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = modelSt.Finalise(context.Background(), modelUUID)
+	err = modelSt.Activate(context.Background(), modelUUID)
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = s.state.SetModelSecretBackend(context.Background(), modelUUID, "my-backend")


### PR DESCRIPTION
Naming things can be hard. Several months ago we introduced the concept of finalising a model during the creation process. This allows a model and all of the model components to be built up over disparate transactions.

We use the keyworld finalised to represent a model and it's finished state during this process. It has been decided to rename finalised to activated better representing what is being done.

This PR is focused on just a rename change and does not change any logic.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Unit tests are sufficient.

## Documentation changes

N/A

