### PR TITLE
fix(loginresultparams): export all fields such that login provider im…

### DIFF
--- a/api/client_credentials_login_provider.go
+++ b/api/client_credentials_login_provider.go
@@ -70,14 +70,14 @@ func (p *clientCredentialsLoginProvider) Login(ctx context.Context, caller base.
 		return nil, errors.Trace(err)
 	}
 	return &LoginResultParams{
-		tag:              tag,
-		modelTag:         result.ModelTag,
-		controllerTag:    result.ControllerTag,
-		servers:          servers,
-		publicDNSName:    result.PublicDNSName,
-		facades:          result.Facades,
-		modelAccess:      modelAccess,
-		controllerAccess: controllerAccess,
-		serverVersion:    serverVersion,
+		Tag:              tag,
+		ModelTag:         result.ModelTag,
+		ControllerTag:    result.ControllerTag,
+		Servers:          servers,
+		PublicDNSName:    result.PublicDNSName,
+		Facades:          result.Facades,
+		ModelAccess:      modelAccess,
+		ControllerAccess: controllerAccess,
+		ServerVersion:    serverVersion,
 	}, nil
 }

--- a/api/interface.go
+++ b/api/interface.go
@@ -129,15 +129,15 @@ func (info *Info) Validate() error {
 
 // LoginResultParams holds the login result parameters.
 type LoginResultParams struct {
-	tag              names.Tag
-	modelTag         string
-	controllerTag    string
-	modelAccess      string
-	controllerAccess string
-	servers          []network.MachineHostPorts
-	facades          []params.FacadeVersions
-	publicDNSName    string
-	serverVersion    version.Number
+	Tag              names.Tag
+	ModelTag         string
+	ControllerTag    string
+	ModelAccess      string
+	ControllerAccess string
+	Servers          []network.MachineHostPorts
+	Facades          []params.FacadeVersions
+	PublicDNSName    string
+	ServerVersion    version.Number
 }
 
 // LoginProvider implements a way to log in when connecting to a controller.

--- a/api/session_token_login_provider.go
+++ b/api/session_token_login_provider.go
@@ -145,14 +145,14 @@ func (p *sessionTokenLoginProvider) login(ctx context.Context, caller base.APICa
 		return nil, errors.Trace(err)
 	}
 	return &LoginResultParams{
-		tag:              tag,
-		modelTag:         result.ModelTag,
-		controllerTag:    result.ControllerTag,
-		servers:          servers,
-		publicDNSName:    result.PublicDNSName,
-		facades:          result.Facades,
-		modelAccess:      modelAccess,
-		controllerAccess: controllerAccess,
-		serverVersion:    serverVersion,
+		Tag:              tag,
+		ModelTag:         result.ModelTag,
+		ControllerTag:    result.ControllerTag,
+		Servers:          servers,
+		PublicDNSName:    result.PublicDNSName,
+		Facades:          result.Facades,
+		ModelAccess:      modelAccess,
+		ControllerAccess: controllerAccess,
+		ServerVersion:    serverVersion,
 	}, nil
 }

--- a/api/state.go
+++ b/api/state.go
@@ -134,12 +134,12 @@ func (st *state) Login(name names.Tag, password, nonce string, ms []macaroon.Sli
 }
 
 func (st *state) setLoginResult(p *LoginResultParams) error {
-	st.authTag = p.tag
-	st.serverVersion = p.serverVersion
+	st.authTag = p.Tag
+	st.serverVersion = p.ServerVersion
 	var modelTag names.ModelTag
-	if p.modelTag != "" {
+	if p.ModelTag != "" {
 		var err error
-		modelTag, err = names.ParseModelTag(p.modelTag)
+		modelTag, err = names.ParseModelTag(p.ModelTag)
 		if err != nil {
 			return errors.Annotatef(err, "invalid model tag in login result")
 		}
@@ -147,19 +147,19 @@ func (st *state) setLoginResult(p *LoginResultParams) error {
 	if modelTag.Id() != st.modelTag.Id() {
 		return errors.Errorf("mismatched model tag in login result (got %q want %q)", modelTag.Id(), st.modelTag.Id())
 	}
-	ctag, err := names.ParseControllerTag(p.controllerTag)
+	ctag, err := names.ParseControllerTag(p.ControllerTag)
 	if err != nil {
-		return errors.Annotatef(err, "invalid controller tag %q returned from login", p.controllerTag)
+		return errors.Annotatef(err, "invalid controller tag %q returned from login", p.ControllerTag)
 	}
 	st.controllerTag = ctag
-	st.controllerAccess = p.controllerAccess
-	st.modelAccess = p.modelAccess
+	st.controllerAccess = p.ControllerAccess
+	st.modelAccess = p.ModelAccess
 
-	hostPorts := p.servers
+	hostPorts := p.Servers
 	// if the connection is not proxied then we will add the connection address
 	// to host ports
 	if !st.IsProxied() {
-		hostPorts, err = addAddress(p.servers, st.addr)
+		hostPorts, err = addAddress(p.Servers, st.addr)
 		if err != nil {
 			if clerr := st.Close(); clerr != nil {
 				err = errors.Annotatef(err, "error closing state: %v", clerr)
@@ -177,10 +177,10 @@ func (st *state) setLoginResult(p *LoginResultParams) error {
 	}
 	st.hostPorts = hostPorts
 
-	st.publicDNSName = p.publicDNSName
+	st.publicDNSName = p.PublicDNSName
 
-	st.facadeVersions = make(map[string][]int, len(p.facades))
-	for _, facade := range p.facades {
+	st.facadeVersions = make(map[string][]int, len(p.Facades))
+	for _, facade := range p.Facades {
 		st.facadeVersions[facade.Name] = facade.Versions
 	}
 

--- a/api/userpass_login_provider.go
+++ b/api/userpass_login_provider.go
@@ -190,14 +190,14 @@ func (p *userpassLoginProvider) Login(ctx context.Context, caller base.APICaller
 		return nil, errors.Trace(err)
 	}
 	return &LoginResultParams{
-		tag:              tag,
-		modelTag:         result.ModelTag,
-		controllerTag:    result.ControllerTag,
-		servers:          servers,
-		publicDNSName:    result.PublicDNSName,
-		facades:          result.Facades,
-		modelAccess:      modelAccess,
-		controllerAccess: controllerAccess,
-		serverVersion:    serverVersion,
+		Tag:              tag,
+		ModelTag:         result.ModelTag,
+		ControllerTag:    result.ControllerTag,
+		Servers:          servers,
+		PublicDNSName:    result.PublicDNSName,
+		Facades:          result.Facades,
+		ModelAccess:      modelAccess,
+		ControllerAccess: controllerAccess,
+		ServerVersion:    serverVersion,
 	}, nil
 }


### PR DESCRIPTION
Due to a mistake in the initial implementation of LoginProviders, the fields were left unexported. This disallows the capability of creating your own LoginProvider to Juju. The specific case here is a JWT login provider which is specific to JIMM and as such we wish to  implement the provider in JIMM.

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [ ] ~Comments saying why design decisions were made~
- [ ] ~Go unit tests, with comments saying what you're testing~
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

<!-- Describe steps to verify that the change works. -->

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/

**Jira card:** JUJU-

