### PR TITLE
Add OTEL trace id to goroutine labels

### DIFF
--- a/core/trace/context.go
+++ b/core/trace/context.go
@@ -98,6 +98,12 @@ func ScopeFromContext(ctx context.Context) (string, string, int) {
 	return traceID, spanID, flags
 }
 
+// TraceIDFromContext returns the traceID from the context.
+func TraceIDFromContext(ctx context.Context) string {
+	traceID, _ := ctx.Value(traceIDContextKey).(string)
+	return traceID
+}
+
 // NoopTracer is a tracer that does nothing.
 type NoopTracer struct{}
 

--- a/core/trace/tracer.go
+++ b/core/trace/tracer.go
@@ -14,6 +14,11 @@ import (
 )
 
 const (
+	// OTELTraceID is the trace ID key used in the go label.
+	OTELTraceID = "otel.traceid"
+)
+
+const (
 	// ErrTracerDying is used to indicate to *third parties* that the
 	// tracer worker is dying, instead of catacomb.ErrDying, which is
 	// unsuitable for propagating inter-worker.


### PR DESCRIPTION
To better integrate with 3rd party applications[1] and to identify goroutines that are related to OTEL traces, this adds labels to a goroutine.

This is another step forward to better understand the performance characteristics of how Juju operates in theatre.

 1. https://www.polarsignals.com/blog/posts/2024/03/05/correlating-tracing-with-profiling-using-ebpf

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
$ sudo snap install parca-agent
$ sudo snap set parca-agent metadata-external-labels=machine=<machine>
$ sudo snap set parca-agent remote-store-bearer-token=<token>
$ juju bootstrap lxd test
```

See the labels added to the profiles.


