### PR TITLE
Removing unused charm watcher.

### DIFF
--- a/state/watcher.go
+++ b/state/watcher.go
@@ -2049,14 +2049,6 @@ func (sb *storageBackend) WatchFilesystemAttachment(host names.Tag, f names.File
 	return newEntityWatcher(sb.mb, filesystemAttachmentsC, sb.mb.docID(id))
 }
 
-// WatchCharmConfig returns a watcher for observing changes to the
-// application's charm configuration settings. The returned watcher will be
-// valid only while the application's charm URL is not changed.
-func (a *Application) WatchCharmConfig() (NotifyWatcher, error) {
-	configKey := a.charmConfigKey()
-	return newEntityWatcher(a.st, settingsC, a.st.docID(configKey)), nil
-}
-
 // WatchConfigSettings returns a watcher for observing changes to the
 // unit's application configuration settings. The unit must have a charm URL
 // set before this method is called, and the returned watcher will be


### PR DESCRIPTION
As part of the work investigating moving charms to DQlite we have found there exists a WatchCharmConfig watcher that isn't being used inside of Juju.

This can safely be removed as part of the transition.

## Checklist

- ~[ ] Code style: imports ordered, good names, simple structure, etc~
- ~[ ] Comments saying why design decisions were made~
- ~[ ] Go unit tests, with comments saying what you're testing~
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Removing unused code. Confirm there are no code paths by compiling.

## Documentation changes

N/A

## Links

**Jira card:** JUJU-6020

