### PR TITLE
Removes WatchConfigChange for unit.

### DIFF
--- a/state/watcher.go
+++ b/state/watcher.go
@@ -2049,20 +2049,6 @@ func (sb *storageBackend) WatchFilesystemAttachment(host names.Tag, f names.File
 	return newEntityWatcher(sb.mb, filesystemAttachmentsC, sb.mb.docID(id))
 }
 
-// WatchConfigSettings returns a watcher for observing changes to the
-// unit's application configuration settings. The unit must have a charm URL
-// set before this method is called, and the returned watcher will be
-// valid only while the unit's charm URL is not changed.
-// TODO(fwereade): this could be much smarter; if it were, uniter.Filter
-// could be somewhat simpler.
-func (u *Unit) WatchConfigSettings() (NotifyWatcher, error) {
-	if u.doc.CharmURL == nil {
-		return nil, fmt.Errorf("unit's charm URL must be set before watching config")
-	}
-	charmConfigKey := applicationCharmConfigKey(u.doc.Application, u.doc.CharmURL)
-	return newEntityWatcher(u.st, settingsC, u.st.docID(charmConfigKey)), nil
-}
-
 // WatchApplicationConfigSettings is the same as WatchConfigSettings but
 // notifies on changes to application configuration not charm configuration.
 func (u *Unit) WatchApplicationConfigSettings() (NotifyWatcher, error) {


### PR DESCRIPTION
When performing the work break down the moving charms to DQlite we have noticed that WatchConfigChange for a unit is not being used. This commit removes the unused code paths to make it easier for this further work to occur.

## Checklist

- ~[ ] Code style: imports ordered, good names, simple structure, etc~
- ~[ ] Comments saying why design decisions were made~
- ~[ ] Go unit tests, with comments saying what you're testing~
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Check the binaries still compile and the code paths have been safely removed.

## Documentation changes

N/A

## Links

**Jira card:** JUJU-6020

