### PR TITLE
Don't print an error log if no mismatch when determining platforms of machine scoped placement entities

### DIFF
--- a/apiserver/facades/client/application/deployrepository.go
+++ b/apiserver/facades/client/application/deployrepository.go
@@ -741,7 +741,7 @@ func (v *deployFromRepositoryValidator) platformFromPlacement(placements []*inst
 		platform = p
 		platStrings.Add(p.String())
 	}
-	if platStrings.Size() == 1 {
+	if platStrings.Size() != 1 {
 		deployRepoLogger.Errorf("Mismatched platforms for machine scoped placements %s", platStrings.SortedValues())
 	}
 


### PR DESCRIPTION
A typo in the original add of the printing to error log when we know the deploy will fail due to mismatching machine scoped platforms in placement..

Follow on to #17366 

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- ~[ ] Comments saying why design decisions were made~
- ~[ ] Go unit tests, with comments saying what you're testing~
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

When running the following tests, the error message should only be printed for TestDeducePlatformPlacementMutipleMatchFail. 

```
(cd apiserver/facades/client/application; go test -gocheck.v -gocheck.f validatorSuite)
```
