### PR TITLE
 Merge 3.3 to 3.4

### DIFF
--- a/apiserver/facades/client/application/backend.go
+++ b/apiserver/facades/client/application/backend.go
@@ -148,6 +148,7 @@ type CharmMeta interface {
 type Machine interface {
 	Base() state.Base
 	HardwareCharacteristics() (*instance.HardwareCharacteristics, error)
+	Id() string
 	PublicAddress() (network.SpaceAddress, error)
 	IsLockedForSeriesUpgrade() (bool, error)
 	IsParentLockedForSeriesUpgrade() (bool, error)

--- a/apiserver/facades/client/application/deployrepository_mocks_test.go
+++ b/apiserver/facades/client/application/deployrepository_mocks_test.go
@@ -640,6 +640,20 @@ func (mr *MockMachineMockRecorder) HardwareCharacteristics() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HardwareCharacteristics", reflect.TypeOf((*MockMachine)(nil).HardwareCharacteristics))
 }
 
+// Id mocks base method.
+func (m *MockMachine) Id() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Id")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Id indicates an expected call of Id.
+func (mr *MockMachineMockRecorder) Id() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Id", reflect.TypeOf((*MockMachine)(nil).Id))
+}
+
 // IsLockedForSeriesUpgrade mocks base method.
 func (m *MockMachine) IsLockedForSeriesUpgrade() (bool, error) {
 	m.ctrl.T.Helper()

--- a/apiserver/facades/client/application/deployrepository_test.go
+++ b/apiserver/facades/client/application/deployrepository_test.go
@@ -647,28 +647,6 @@ func (s *validatorSuite) TestDeducePlatformSimple(c *gc.C) {
 	c.Assert(plat, gc.DeepEquals, corecharm.Platform{Architecture: "amd64"})
 }
 
-func (s *validatorSuite) TestDeducePlatformRiskInChannel(c *gc.C) {
-	defer s.setupMocks(c).Finish()
-	//model constraint default
-	s.state.EXPECT().ModelConstraints().Return(constraints.Value{Arch: strptr("amd64")}, nil)
-
-	arg := params.DeployFromRepositoryArg{
-		CharmName: "testme",
-		Base: &params.Base{
-			Name:    "ubuntu",
-			Channel: "22.10/stable",
-		},
-	}
-	plat, usedModelDefaultBase, err := s.getValidator().deducePlatform(arg)
-	c.Assert(err, gc.IsNil)
-	c.Assert(usedModelDefaultBase, jc.IsFalse)
-	c.Assert(plat, gc.DeepEquals, corecharm.Platform{
-		Architecture: "amd64",
-		OS:           "ubuntu",
-		Channel:      "22.10",
-	})
-}
-
 func (s *validatorSuite) TestDeducePlatformArgArchBase(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
@@ -686,7 +664,7 @@ func (s *validatorSuite) TestDeducePlatformArgArchBase(c *gc.C) {
 	c.Assert(plat, gc.DeepEquals, corecharm.Platform{
 		Architecture: "arm64",
 		OS:           "ubuntu",
-		Channel:      "22.10",
+		Channel:      "22.10/stable",
 	})
 }
 
@@ -711,7 +689,7 @@ func (s *validatorSuite) TestDeducePlatformModelDefaultBase(c *gc.C) {
 	c.Assert(plat, gc.DeepEquals, corecharm.Platform{
 		Architecture: "amd64",
 		OS:           "ubuntu",
-		Channel:      "22.04",
+		Channel:      "22.04/stable",
 	})
 }
 
@@ -721,16 +699,17 @@ func (s *validatorSuite) TestDeducePlatformPlacementSimpleFound(c *gc.C) {
 	s.state.EXPECT().Machine("0").Return(s.machine, nil)
 	s.machine.EXPECT().Base().Return(state.Base{
 		OS:      "ubuntu",
-		Channel: "18.04",
+		Channel: "22.04",
 	})
 	hwc := &instance.HardwareCharacteristics{Arch: strptr("arm64")}
 	s.machine.EXPECT().HardwareCharacteristics().Return(hwc, nil)
 
 	arg := params.DeployFromRepositoryArg{
 		CharmName: "testme",
-		Placement: []*instance.Placement{{
-			Directive: "0",
-		}},
+		Placement: []*instance.Placement{
+			{Scope: instance.MachineScope, Directive: "0"},
+			{Scope: "lxd"},
+		},
 	}
 	plat, usedModelDefaultBase, err := s.getValidator().deducePlatform(arg)
 	c.Assert(err, gc.IsNil)
@@ -738,27 +717,47 @@ func (s *validatorSuite) TestDeducePlatformPlacementSimpleFound(c *gc.C) {
 	c.Assert(plat, gc.DeepEquals, corecharm.Platform{
 		Architecture: "arm64",
 		OS:           "ubuntu",
-		Channel:      "18.04",
+		Channel:      "22.04",
 	})
+}
+
+func (s *validatorSuite) TestDeducePlatformPlacementNoPanic(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+	s.state.EXPECT().ModelConstraints().Return(constraints.Value{}, nil)
+	s.machine.EXPECT().Id().Return("5/lxd/6")
+	s.state.EXPECT().Machine("5/lxd/6").Return(s.machine, nil)
+	s.machine.EXPECT().Base().Return(state.Base{
+		OS:      "ubuntu",
+		Channel: "22.04",
+	})
+	hwc := &instance.HardwareCharacteristics{}
+	s.machine.EXPECT().HardwareCharacteristics().Return(hwc, nil)
+
+	arg := params.DeployFromRepositoryArg{
+		CharmName: "testme",
+		Placement: []*instance.Placement{
+			{Scope: instance.MachineScope, Directive: "5/lxd/6"},
+			{Scope: "lxd"},
+		},
+	}
+	_, _, err := s.getValidator().deducePlatform(arg)
+	c.Assert(err, gc.NotNil)
 }
 
 func (s *validatorSuite) TestDeducePlatformPlacementSimpleNotFound(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	//model constraint default
 	s.state.EXPECT().ModelConstraints().Return(constraints.Value{Arch: strptr("amd64")}, nil)
-	s.model.EXPECT().Config().Return(config.New(config.UseDefaults, coretesting.FakeConfig()))
-	s.state.EXPECT().Machine("0/lxd/0").Return(nil, errors.NotFoundf("machine 0/lxd/0 not found"))
+	s.state.EXPECT().Machine("0/lxd/0").Return(nil, errors.NotFoundf("machine 0/lxd/0"))
 
 	arg := params.DeployFromRepositoryArg{
 		CharmName: "testme",
 		Placement: []*instance.Placement{{
-			Directive: "0/lxd/0",
+			Scope: instance.MachineScope, Directive: "0/lxd/0",
 		}},
 	}
-	plat, usedModelDefaultBase, err := s.getValidator().deducePlatform(arg)
-	c.Assert(err, gc.IsNil)
-	c.Assert(usedModelDefaultBase, jc.IsFalse)
-	c.Assert(plat, gc.DeepEquals, corecharm.Platform{Architecture: "amd64"})
+	_, _, err := s.getValidator().deducePlatform(arg)
+	c.Assert(err, jc.ErrorIs, errors.NotFound)
 }
 
 func (s *validatorSuite) TestResolvedCharmValidationSubordinate(c *gc.C) {
@@ -785,7 +784,7 @@ func (s *validatorSuite) TestDeducePlatformPlacementMutipleMatch(c *gc.C) {
 	s.state.EXPECT().Machine(gomock.Any()).Return(s.machine, nil).Times(3)
 	s.machine.EXPECT().Base().Return(state.Base{
 		OS:      "ubuntu",
-		Channel: "18.04",
+		Channel: "22.04",
 	}).Times(3)
 	hwc := &instance.HardwareCharacteristics{Arch: strptr("arm64")}
 	s.machine.EXPECT().HardwareCharacteristics().Return(hwc, nil).Times(3)
@@ -793,9 +792,9 @@ func (s *validatorSuite) TestDeducePlatformPlacementMutipleMatch(c *gc.C) {
 	arg := params.DeployFromRepositoryArg{
 		CharmName: "testme",
 		Placement: []*instance.Placement{
-			{Directive: "0"},
-			{Directive: "1"},
-			{Directive: "3"},
+			{Scope: instance.MachineScope, Directive: "0"},
+			{Scope: instance.MachineScope, Directive: "1"},
+			{Scope: instance.MachineScope, Directive: "3"},
 		},
 	}
 	plat, usedModelDefaultBase, err := s.getValidator().deducePlatform(arg)
@@ -804,7 +803,7 @@ func (s *validatorSuite) TestDeducePlatformPlacementMutipleMatch(c *gc.C) {
 	c.Assert(plat, gc.DeepEquals, corecharm.Platform{
 		Architecture: "arm64",
 		OS:           "ubuntu",
-		Channel:      "18.04",
+		Channel:      "22.04",
 	})
 }
 
@@ -815,7 +814,7 @@ func (s *validatorSuite) TestDeducePlatformPlacementMutipleMatchFail(c *gc.C) {
 	s.machine.EXPECT().Base().Return(
 		state.Base{
 			OS:      "ubuntu",
-			Channel: "18.04",
+			Channel: "22.04",
 		}).AnyTimes()
 	gomock.InOrder(
 		s.machine.EXPECT().HardwareCharacteristics().Return(
@@ -829,8 +828,8 @@ func (s *validatorSuite) TestDeducePlatformPlacementMutipleMatchFail(c *gc.C) {
 	arg := params.DeployFromRepositoryArg{
 		CharmName: "testme",
 		Placement: []*instance.Placement{
-			{Directive: "0"},
-			{Directive: "1"},
+			{Scope: instance.MachineScope, Directive: "0"},
+			{Scope: instance.MachineScope, Directive: "1"},
 		},
 	}
 	_, _, err := s.getValidator().deducePlatform(arg)

--- a/apiserver/facades/client/application/mocks/application_mock.go
+++ b/apiserver/facades/client/application/mocks/application_mock.go
@@ -2364,6 +2364,20 @@ func (mr *MockMachineMockRecorder) HardwareCharacteristics() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HardwareCharacteristics", reflect.TypeOf((*MockMachine)(nil).HardwareCharacteristics))
 }
 
+// Id mocks base method.
+func (m *MockMachine) Id() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Id")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Id indicates an expected call of Id.
+func (mr *MockMachineMockRecorder) Id() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Id", reflect.TypeOf((*MockMachine)(nil).Id))
+}
+
 // IsLockedForSeriesUpgrade mocks base method.
 func (m *MockMachine) IsLockedForSeriesUpgrade() (bool, error) {
 	m.ctrl.T.Helper()

--- a/container/kvm/kvm.go
+++ b/container/kvm/kvm.go
@@ -162,7 +162,7 @@ func (manager *containerManager) CreateContainer(
 	networkConfig *container.NetworkConfig,
 	storageConfig *container.StorageConfig,
 	callback environs.StatusCallbackFunc,
-) (_ instances.Instance, hc *instance.HardwareCharacteristics, err error) {
+) (_ instances.Instance, _ *instance.HardwareCharacteristics, err error) {
 
 	name, err := manager.namespace.Hostname(instanceConfig.MachineId)
 	if err != nil {
@@ -182,8 +182,6 @@ func (manager *containerManager) CreateContainer(
 	// object, and doesn't actually construct the underlying kvm container on
 	// disk.
 	kvmContainer := KVMObjectFactory.New(name)
-
-	hc = &instance.HardwareCharacteristics{AvailabilityZone: &manager.availabilityZone}
 
 	// Create the cloud-init.
 	cloudConfig, err := cloudinit.New(instanceConfig.Base.OS)
@@ -237,10 +235,9 @@ func (manager *containerManager) CreateContainer(
 	}
 	startParams.ImageDownloadURL = imURL
 
-	var hardware instance.HardwareCharacteristics
-	hardware, err = instance.ParseHardware(
-		fmt.Sprintf("arch=%s mem=%vM root-disk=%vG cores=%v",
-			startParams.Arch, startParams.Memory, startParams.RootDisk, startParams.CpuCores))
+	hardware, err := instance.ParseHardware(
+		fmt.Sprintf("arch=%s mem=%vM root-disk=%vG cores=%v availability-zone=%s",
+			startParams.Arch, startParams.Memory, startParams.RootDisk, startParams.CpuCores, manager.availabilityZone))
 	if err != nil {
 		return nil, nil, errors.Annotate(err, "failed to parse hardware")
 	}

--- a/container/lxd/manager.go
+++ b/container/lxd/manager.go
@@ -141,7 +141,9 @@ func (m *containerManager) CreateContainer(
 	_ = callback(status.Running, "Container started", nil)
 
 	virtType := string(spec.VirtType)
+	arch := c.Arch()
 	hardware := &instance.HardwareCharacteristics{
+		Arch:             &arch,
 		AvailabilityZone: &m.availabilityZone,
 		VirtType:         &virtType,
 	}

--- a/container/lxd/manager_test.go
+++ b/container/lxd/manager_test.go
@@ -141,6 +141,7 @@ func (s *managerSuite) TestContainerCreateDestroy(c *gc.C) {
 
 	exp.GetInstanceState(hostName).Return(
 		&lxdapi.InstanceState{
+
 			StatusCode: lxdapi.Running,
 			Network: map[string]lxdapi.InstanceStateNetwork{
 				"fan0": {
@@ -152,8 +153,12 @@ func (s *managerSuite) TestContainerCreateDestroy(c *gc.C) {
 				},
 			},
 		}, lxdtesting.ETag, nil).Times(2)
-
-	exp.GetInstance(hostName).Return(&lxdapi.Instance{Name: hostName, Type: "container"}, lxdtesting.ETag, nil)
+	inst := &lxdapi.Instance{
+		Name:        hostName,
+		Type:        "container",
+		InstancePut: lxdapi.InstancePut{Architecture: "amd64"},
+	}
+	exp.GetInstance(hostName).Return(inst, lxdtesting.ETag, nil)
 
 	// Arrangements for the container destruction.
 	stopReq := lxdapi.InstanceStatePut{
@@ -174,6 +179,8 @@ func (s *managerSuite) TestContainerCreateDestroy(c *gc.C) {
 
 	instanceId := instance.Id()
 	c.Check(string(instanceId), gc.Equals, hostName)
+	c.Check(hc.Arch, gc.NotNil)
+	c.Check(*hc.Arch, gc.Equals, "amd64")
 
 	instanceStatus := instance.Status(context.NewEmptyCloudCallContext())
 	c.Check(instanceStatus.Status, gc.Equals, status.Running)
@@ -211,7 +218,12 @@ func (s *managerSuite) TestContainerCreateUpdateIPv4Network(c *gc.C) {
 	s.expectStartOp(ctrl)
 
 	exp.UpdateInstanceState(hostName, lxdapi.InstanceStatePut{Action: "start", Timeout: -1}, "").Return(s.startOp, nil)
-	exp.GetInstance(hostName).Return(&lxdapi.Instance{Name: hostName, Type: "container"}, lxdtesting.ETag, nil)
+	inst := &lxdapi.Instance{
+		Name:        hostName,
+		Type:        "container",
+		InstancePut: lxdapi.InstancePut{Architecture: "amd64"},
+	}
+	exp.GetInstance(hostName).Return(inst, lxdtesting.ETag, nil)
 
 	// Supplying config for a single device with default bridge and without a
 	// CIDR will cause the default bridge to be updated with IPv4 config.

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -449,7 +449,7 @@ func (i *importer) modelUsers() error {
 func (i *importer) machines() error {
 	i.logger.Debugf("importing machines")
 	for _, m := range i.model.Machines() {
-		if err := i.machine(m); err != nil {
+		if err := i.machine(m, ""); err != nil {
 			i.logger.Errorf("error importing machine: %s", err)
 			return errors.Annotate(err, m.Id())
 		}
@@ -459,7 +459,7 @@ func (i *importer) machines() error {
 	return nil
 }
 
-func (i *importer) machine(m description.Machine) error {
+func (i *importer) machine(m description.Machine, arch string) error {
 	// Import this machine, then import its containers.
 	i.logger.Debugf("importing machine %s", m.Id())
 
@@ -516,7 +516,7 @@ func (i *importer) machine(m description.Machine) error {
 	)
 
 	// 3. create op for adding in instance data
-	prereqOps = append(prereqOps, i.machineInstanceOp(mdoc, instance))
+	prereqOps = append(prereqOps, i.machineInstanceOp(mdoc, instance, arch))
 
 	if parentId := container.ParentId(mdoc.Id); parentId != "" {
 		prereqOps = append(prereqOps,
@@ -557,7 +557,9 @@ func (i *importer) machine(m description.Machine) error {
 	// Now that this machine exists in the database, process each of the
 	// containers in this machine.
 	for _, container := range m.Containers() {
-		if err := i.machine(container); err != nil {
+		// Pass the parent machine's architecture when creating an op to fix
+		// a container's data.
+		if err := i.machine(container, m.Instance().Architecture()); err != nil {
 			return errors.Annotate(err, container.Id())
 		}
 	}
@@ -653,7 +655,11 @@ func (i *importer) applicationPortsOp(a description.Application) txn.Op {
 	}
 }
 
-func (i *importer) machineInstanceOp(mdoc *machineDoc, inst description.CloudInstance) txn.Op {
+// machineInstanceOp creates for txn operation for inserting a doc into
+// instance data collection. The parentArch is included to fix data from
+// older versions of juju where the architecture of a container was left
+// empty.
+func (i *importer) machineInstanceOp(mdoc *machineDoc, inst description.CloudInstance, parentArch string) txn.Op {
 	doc := &instanceData{
 		DocID:       mdoc.DocID,
 		MachineId:   mdoc.Id,
@@ -664,6 +670,8 @@ func (i *importer) machineInstanceOp(mdoc *machineDoc, inst description.CloudIns
 
 	if arch := inst.Architecture(); arch != "" {
 		doc.Arch = &arch
+	} else if parentArch != "" {
+		doc.Arch = &parentArch
 	}
 	if mem := inst.Memory(); mem != 0 {
 		doc.Mem = &mem

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -324,41 +324,47 @@ func (s *MigrationImportSuite) TestMeterStatusNotAvailable(c *gc.C) {
 }
 
 func (s *MigrationImportSuite) AssertMachineEqual(c *gc.C, newMachine, oldMachine *state.Machine) {
-	c.Assert(newMachine.Id(), gc.Equals, oldMachine.Id())
-	c.Assert(newMachine.Principals(), jc.DeepEquals, oldMachine.Principals())
-	c.Assert(newMachine.Base().String(), gc.Equals, oldMachine.Base().String())
-	c.Assert(newMachine.ContainerType(), gc.Equals, oldMachine.ContainerType())
+	c.Check(newMachine.Id(), gc.Equals, oldMachine.Id())
+	c.Check(newMachine.Principals(), jc.DeepEquals, oldMachine.Principals())
+	c.Check(newMachine.Base().String(), gc.Equals, oldMachine.Base().String())
+	c.Check(newMachine.ContainerType(), gc.Equals, oldMachine.ContainerType())
 	newHardware, err := newMachine.HardwareCharacteristics()
 	c.Assert(err, jc.ErrorIsNil)
 	oldHardware, err := oldMachine.HardwareCharacteristics()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(newHardware, jc.DeepEquals, oldHardware)
-	c.Assert(newMachine.Jobs(), jc.DeepEquals, oldMachine.Jobs())
-	c.Assert(newMachine.Life(), gc.Equals, oldMachine.Life())
+	if oldMachine.ContainerType() != instance.NONE && oldHardware.Arch == nil {
+		// test that containers have an architecture added during import
+		// if not already there.
+		oldHardware.Arch = strPtr("amd64")
+	}
+	c.Check(newHardware, jc.DeepEquals, oldHardware, gc.Commentf("machine %q", newMachine.Id()))
+
+	c.Check(newMachine.Jobs(), jc.DeepEquals, oldMachine.Jobs())
+	c.Check(newMachine.Life(), gc.Equals, oldMachine.Life())
 	newTools, err := newMachine.AgentTools()
 	c.Assert(err, jc.ErrorIsNil)
 	oldTools, err := oldMachine.AgentTools()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(newTools, jc.DeepEquals, oldTools)
+	c.Check(newTools, jc.DeepEquals, oldTools)
 
 	oldStatus, err := oldMachine.Status()
 	c.Assert(err, jc.ErrorIsNil)
 	newStatus, err := newMachine.Status()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(newStatus, jc.DeepEquals, oldStatus)
+	c.Check(newStatus, jc.DeepEquals, oldStatus)
 
 	oldInstID, oldInstDisplayName, err := oldMachine.InstanceNames()
 	c.Assert(err, jc.ErrorIsNil)
 	newInstID, newInstDisplayName, err := newMachine.InstanceNames()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(newInstID, gc.Equals, oldInstID)
-	c.Assert(newInstDisplayName, gc.Equals, oldInstDisplayName)
+	c.Check(newInstID, gc.Equals, oldInstID)
+	c.Check(newInstDisplayName, gc.Equals, oldInstDisplayName)
 
 	oldStatus, err = oldMachine.InstanceStatus()
 	c.Assert(err, jc.ErrorIsNil)
 	newStatus, err = newMachine.InstanceStatus()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(newStatus, jc.DeepEquals, oldStatus)
+	c.Check(newStatus, jc.DeepEquals, oldStatus)
 }
 
 func (s *MigrationImportSuite) TestMachines(c *gc.C) {
@@ -373,6 +379,8 @@ func (s *MigrationImportSuite) TestMachines(c *gc.C) {
 	machine1 := s.Factory.MakeMachine(c, &factory.MachineParams{
 		Constraints: cons,
 		Characteristics: &instance.HardwareCharacteristics{
+			Arch:           cons.Arch,
+			Mem:            cons.Mem,
 			RootDiskSource: &source,
 		},
 		DisplayName: displayName,
@@ -388,16 +396,22 @@ func (s *MigrationImportSuite) TestMachines(c *gc.C) {
 	c.Assert(hardware, gc.NotNil)
 
 	_ = s.Factory.MakeMachineNested(c, machine1.Id(), nil)
+	_ = s.Factory.MakeMachineNested(c, machine1.Id(), &factory.MachineParams{
+		Constraints: constraints.MustParse("arch=arm64"),
+		Characteristics: &instance.HardwareCharacteristics{
+			Arch: cons.Arch,
+		},
+	})
 
 	allMachines, err := s.State.AllMachines()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(allMachines, gc.HasLen, 2)
+	c.Assert(allMachines, gc.HasLen, 3)
 
 	newModel, newSt := s.importModel(c, s.State)
 
 	importedMachines, err := newSt.AllMachines()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(importedMachines, gc.HasLen, 2)
+	c.Assert(importedMachines, gc.HasLen, 3)
 
 	// AllMachines returns the machines in the same order, yay us.
 	for i, newMachine := range importedMachines {
@@ -406,30 +420,34 @@ func (s *MigrationImportSuite) TestMachines(c *gc.C) {
 
 	// And a few extra checks.
 	parent := importedMachines[0]
-	container := importedMachines[1]
 	containers, err := parent.Containers()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(containers, jc.DeepEquals, []string{container.Id()})
-	parentId, isContainer := container.ParentId()
-	c.Assert(parentId, gc.Equals, parent.Id())
-	c.Assert(isContainer, jc.IsTrue)
+	c.Assert(containers, jc.SameContents, []string{importedMachines[1].Id(), importedMachines[2].Id()})
+	for _, cont := range []*state.Machine{importedMachines[1], importedMachines[2]} {
+		parentId, isContainer := cont.ParentId()
+		c.Assert(parentId, gc.Equals, parent.Id())
+		c.Assert(isContainer, jc.IsTrue)
+	}
 
 	s.assertAnnotations(c, newModel, parent)
 	s.checkStatusHistory(c, machine1, parent, 5)
 
 	newCons, err := parent.Constraints()
-	c.Assert(err, jc.ErrorIsNil)
-	// Can't test the constraints directly, so go through the string repr.
-	c.Assert(newCons.String(), gc.Equals, cons.String())
+	if c.Check(err, jc.ErrorIsNil) {
+		// Can't test the constraints directly, so go through the string repr.
+		c.Check(newCons.String(), gc.Equals, cons.String())
+	}
 
 	// Test the modification status is set to the initial state.
 	modStatus, err := parent.ModificationStatus()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(modStatus.Status, gc.Equals, status.Idle)
+	if c.Check(err, jc.ErrorIsNil) {
+		c.Check(modStatus.Status, gc.Equals, status.Idle)
+	}
 
 	characteristics, err := parent.HardwareCharacteristics()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(*characteristics.RootDiskSource, gc.Equals, "bunyan")
+	if c.Check(err, jc.ErrorIsNil) {
+		c.Check(*characteristics.RootDiskSource, gc.Equals, "bunyan")
+	}
 }
 
 func (s *MigrationImportSuite) TestMachineDevices(c *gc.C) {

--- a/state/upgrades_test.go
+++ b/state/upgrades_test.go
@@ -194,3 +194,75 @@ func (s *upgradesSuite) TestFillInEmptyCharmhubTracks(c *gc.C) {
 	expectedData := upgradedData(applications, expected)
 	s.assertUpgradedData(c, FillInEmptyCharmhubTracks, expectedData)
 }
+
+func (s *upgradesSuite) TestAssignArchToContainers(c *gc.C) {
+	st := s.state
+	instanceDataColl, closer := st.db().GetRawCollection(instanceDataC)
+	defer closer()
+
+	err := instanceDataColl.Insert(bson.M{
+		"_id":        ensureModelUUID(st.ModelUUID(), "0"),
+		"model-uuid": st.ModelUUID(),
+		"machineid":  "0",
+		"arch":       "arm64",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	err = instanceDataColl.Insert(bson.M{
+		"_id":        ensureModelUUID(st.ModelUUID(), "0/lxd/7"),
+		"model-uuid": st.ModelUUID(),
+		"machineid":  "0/lxd/7",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	err = instanceDataColl.Insert(bson.M{
+		"_id":        ensureModelUUID(st.ModelUUID(), "2"),
+		"model-uuid": st.ModelUUID(),
+		"machineid":  "2",
+		"arch":       "amd64",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	err = instanceDataColl.Insert(bson.M{
+		"_id":        ensureModelUUID(st.ModelUUID(), "3"),
+		"model-uuid": st.ModelUUID(),
+		"machineid":  "3",
+		"arch":       "amd64",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	err = instanceDataColl.Insert(bson.M{
+		"_id":        ensureModelUUID(st.ModelUUID(), "3/kvm/2"),
+		"model-uuid": st.ModelUUID(),
+		"machineid":  "3/kvm/2",
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	var expected bsonMById
+	expected = append(expected, bson.M{
+		"_id":        ensureModelUUID(st.ModelUUID(), "0"),
+		"model-uuid": st.ModelUUID(),
+		"machineid":  "0",
+		"arch":       "arm64",
+	}, bson.M{
+		"_id":        ensureModelUUID(st.ModelUUID(), "0/lxd/7"),
+		"model-uuid": st.ModelUUID(),
+		"machineid":  "0/lxd/7",
+		"arch":       "arm64",
+	}, bson.M{
+		"_id":        ensureModelUUID(st.ModelUUID(), "2"),
+		"model-uuid": st.ModelUUID(),
+		"machineid":  "2",
+		"arch":       "amd64",
+	}, bson.M{
+		"_id":        ensureModelUUID(st.ModelUUID(), "3"),
+		"model-uuid": st.ModelUUID(),
+		"machineid":  "3",
+		"arch":       "amd64",
+	}, bson.M{
+		"_id":        ensureModelUUID(st.ModelUUID(), "3/kvm/2"),
+		"model-uuid": st.ModelUUID(),
+		"machineid":  "3/kvm/2",
+		"arch":       "amd64",
+	})
+
+	sort.Sort(expected)
+	expectedData := upgradedData(instanceDataColl, expected)
+	s.assertUpgradedData(c, AssignArchToContainers, expectedData)
+}

--- a/tests/suites/controllercharm/prometheus.sh
+++ b/tests/suites/controllercharm/prometheus.sh
@@ -67,14 +67,13 @@ run_prometheus_multiple_units() {
 	juju status --format json | jq -r "$(active_condition "p2" 1)" | check "p2"
 
 	juju remove-relation p1 controller
-	# Wait until the application p1 settles before health checks
-	wait_for "p1" "$(active_condition "p1" 0)"
 
 	# Check Juju controller is removed from Prometheus targets
 	retry 'check_prometheus_no_target p1 0' 5
 	# Check no errors in controller charm or Prometheus
 	juju status -m controller --format json | jq -r "$(active_condition "controller")" | check "controller"
-	juju status --format json | jq -r "$(active_condition "p1" 0)" | check "p1"
+	# Ensure p1 is still healty
+	wait_for "p1" "$(active_condition "p1" 0)"
 
 	juju remove-application p1 --destroy-storage \
 		--force --no-wait # TODO: remove these flags once storage bug is fixed

--- a/upgrades/backend.go
+++ b/upgrades/backend.go
@@ -12,6 +12,7 @@ import (
 // StateBackend provides an interface for upgrading the global state database.
 type StateBackend interface {
 	FillInEmptyCharmhubTracks() error
+	AssignArchToContainers() error
 }
 
 // Model is an interface providing access to the details of a model within the
@@ -32,4 +33,8 @@ type stateBackend struct {
 
 func (s stateBackend) FillInEmptyCharmhubTracks() error {
 	return state.FillInEmptyCharmhubTracks(s.pool)
+}
+
+func (s stateBackend) AssignArchToContainers() error {
+	return state.AssignArchToContainers(s.pool)
 }

--- a/upgrades/operations.go
+++ b/upgrades/operations.go
@@ -20,6 +20,7 @@ import (
 var stateUpgradeOperations = func() []Operation {
 	steps := []Operation{
 		upgradeToVersion{version.MustParse("3.4.1"), stateStepsFor341()},
+		upgradeToVersion{version.MustParse("3.4.3"), stateStepsFor343()},
 	}
 	return steps
 }

--- a/upgrades/steps_343.go
+++ b/upgrades/steps_343.go
@@ -1,0 +1,16 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades
+
+func stateStepsFor343() []Step {
+	return []Step{
+		&upgradeStep{
+			description: "assign architectures to container's instance data",
+			targets:     []Target{DatabaseMaster},
+			run: func(context Context) error {
+				return context.State().AssignArchToContainers()
+			},
+		},
+	}
+}

--- a/upgrades/steps_343_test.go
+++ b/upgrades/steps_343_test.go
@@ -1,0 +1,26 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upgrades_test
+
+import (
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version/v2"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/upgrades"
+)
+
+var v343 = version.MustParse("3.4.3")
+
+type steps342Suite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&steps342Suite{})
+
+func (s *steps342Suite) TestAssignArchToContainers(c *gc.C) {
+	step := findStateStep(c, v343, "assign architectures to container's instance data")
+	c.Assert(step.Targets(), jc.DeepEquals, []upgrades.Target{upgrades.DatabaseMaster})
+}

--- a/upgrades/upgrade_test.go
+++ b/upgrades/upgrade_test.go
@@ -598,6 +598,7 @@ func (s *upgradeSuite) TestStateUpgradeOperationsVersions(c *gc.C) {
 	versions := extractUpgradeVersions(c, (*upgrades.StateUpgradeOperations)())
 	c.Assert(versions, gc.DeepEquals, []string{
 		"3.4.1",
+		"3.4.3",
 	})
 }
 


### PR DESCRIPTION
This merge includes an upgrade step which requires removing the 3.3.5 upgrade step and replacing with one for 3.4.3.
References to 3.3.[1-5] upgrade steps have been removed including the related upgrades/steps files.

a230a1ac4db99060f4dd4be3b775d0f0efb6af37 includes the changes necessary in upgrades to add an 3.4.3 upgrade step. 

Merge conflicts
- upgrades/operations.go
- upgrades/steps_331.go 
- upgrades/steps_341.go
- upgrades/upgrade_test.go

## QA steps

Use the upgrade test scenario from #17366 using juju 3.4.2 to start and upgrading to the built code.
