### PR TITLE
Change charm in deploy test to fix failing arm64 test

### DIFF
--- a/tests/suites/deploy/deploy_charms.sh
+++ b/tests/suites/deploy/deploy_charms.sh
@@ -36,7 +36,7 @@ run_deploy_charm_placement_directive() {
 	# If 0/lxd/0 is started, so must machine 0 be.
 	wait_for_container_agent_status "0/lxd/0" "started"
 
-	juju deploy ubuntu-lite -n 2 --to 0,0/lxd/0
+	juju deploy jameinel-ubuntu-lite -n 2 --to 0,0/lxd/0
 	wait_for "ubuntu-lite" "$(idle_condition "ubuntu-lite")"
 
 	# Verify based used to create the machines was used during


### PR DESCRIPTION
Not long ago, we changed the charm in this test from jameinel-ubuntu-lite to ubuntu-lite

However, ubuntu-lite has no releases foir arm64, leading to failed tests

Switch this back to jameinel-ubuntu-lite

## QA steps

Run the integration test on an amd64 and arm64 machine

```
BOOTSTRAP_ARCH="$arch" BUILD_ARCH="$arch" MODEL_ARCH="$arch" ./main.sh -v deploy test_deploy_charms
```

and verify that `run_deploy_charm_placement_directive` is successful