### PR TITLE
Rename controller config watch

### DIFF
--- a/apiserver/facades/controller/caasapplicationprovisioner/mock_test.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/mock_test.go
@@ -46,7 +46,6 @@ type mockState struct {
 	applicationWatcher           *mockStringsWatcher
 	app                          *mockApplication
 	resource                     *mockResources
-	operatorRepo                 string
 	apiHostPortsForAgentsWatcher *statetesting.MockNotifyWatcher
 	isController                 bool
 }
@@ -72,12 +71,6 @@ func (st *mockState) Unit(unit string) (caasapplicationprovisioner.Unit, error) 
 func (st *mockState) WatchApplications() state.StringsWatcher {
 	st.MethodCall(st, "WatchApplications")
 	return st.applicationWatcher
-}
-
-func (st *mockState) ControllerConfig() (controller.Config, error) {
-	cfg := coretesting.FakeControllerConfig()
-	cfg[controller.CAASImageRepo] = st.operatorRepo
-	return cfg, nil
 }
 
 func (st *mockState) APIHostPortsForAgents(controllerConfig controller.Config) ([]network.SpaceHostPorts, error) {
@@ -174,8 +167,8 @@ func (m *mockControllerConfigService) ControllerConfig(_ context.Context) (contr
 	return coretesting.FakeControllerConfig(), nil
 }
 
-func (m *mockControllerConfigService) Watch() (watcher.StringsWatcher, error) {
-	m.MethodCall(m, "Watch")
+func (m *mockControllerConfigService) WatchControllerConfig() (watcher.StringsWatcher, error) {
+	m.MethodCall(m, "WatchControllerConfig")
 	return m.controllerConfigWatcher, nil
 }
 

--- a/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
@@ -53,7 +53,7 @@ import (
 // ControllerConfigService provides the controller configuration.
 type ControllerConfigService interface {
 	ControllerConfig(ctx context.Context) (controller.Config, error)
-	Watch() (corewatcher.StringsWatcher, error)
+	WatchControllerConfig() (corewatcher.StringsWatcher, error)
 }
 
 type APIGroup struct {
@@ -264,7 +264,7 @@ func (a *API) watchProvisioningInfo(ctx context.Context, appName names.Applicati
 	}
 
 	appWatcher := app.Watch()
-	controllerConfigWatcher, err := a.controllerConfigService.Watch()
+	controllerConfigWatcher, err := a.controllerConfigService.WatchControllerConfig()
 	if err != nil {
 		return result, errors.Trace(err)
 	}

--- a/apiserver/facades/controller/caasmodelconfigmanager/facade.go
+++ b/apiserver/facades/controller/caasmodelconfigmanager/facade.go
@@ -18,7 +18,7 @@ import (
 
 // ControllerConfigService provides required controller config watcher for the Facade.
 type ControllerConfigService interface {
-	Watch() (watcher.StringsWatcher, error)
+	WatchControllerConfig() (watcher.StringsWatcher, error)
 }
 
 // Facade allows model config manager clients to watch controller config changes and fetch controller config.
@@ -37,7 +37,7 @@ func (f *Facade) ControllerConfig(ctx context.Context) (params.ControllerConfigR
 
 func (f *Facade) WatchControllerConfig(ctx context.Context) (params.StringsWatchResult, error) {
 	result := params.StringsWatchResult{}
-	w, err := f.controllerConfigService.Watch()
+	w, err := f.controllerConfigService.WatchControllerConfig()
 	if err != nil {
 		return result, errors.Trace(err)
 	}

--- a/apiserver/facades/controller/caasmodeloperator/operator.go
+++ b/apiserver/facades/controller/caasmodeloperator/operator.go
@@ -28,7 +28,7 @@ import (
 
 type ControllerConfigService interface {
 	ControllerConfig(context.Context) (controller.Config, error)
-	Watch() (corewatcher.StringsWatcher, error)
+	WatchControllerConfig() (corewatcher.StringsWatcher, error)
 }
 
 // API represents the controller model operator facade.
@@ -81,7 +81,7 @@ func (a *API) WatchModelOperatorProvisioningInfo(ctx context.Context) (params.No
 		return result, errors.Trace(err)
 	}
 
-	controllerConfigWatcher, err := a.controllerConfigService.Watch()
+	controllerConfigWatcher, err := a.controllerConfigService.WatchControllerConfig()
 	if err != nil {
 		return result, errors.Trace(err)
 	}

--- a/apiserver/facades/controller/caasmodeloperator/operator_test.go
+++ b/apiserver/facades/controller/caasmodeloperator/operator_test.go
@@ -71,7 +71,7 @@ func (m *ModelOperatorSuite) TestWatchProvisioningInfo(c *gc.C) {
 	apiHostPortsForAgentsChanged := make(chan struct{}, 1)
 
 	watcher := watchertest.NewMockStringsWatcher(controllerConfigChanged)
-	m.controllerConfigService.EXPECT().Watch().Return(watcher, nil)
+	m.controllerConfigService.EXPECT().WatchControllerConfig().Return(watcher, nil)
 
 	m.state.apiHostPortsForAgentsWatcher = statetesting.NewMockNotifyWatcher(apiHostPortsForAgentsChanged)
 	m.state.model.modelConfigChanged = statetesting.NewMockNotifyWatcher(modelConfigChanged)

--- a/apiserver/facades/controller/caasmodeloperator/package_mock_test.go
+++ b/apiserver/facades/controller/caasmodeloperator/package_mock_test.go
@@ -80,41 +80,41 @@ func (c *MockControllerConfigServiceControllerConfigCall) DoAndReturn(f func(con
 	return c
 }
 
-// Watch mocks base method.
-func (m *MockControllerConfigService) Watch() (watcher.Watcher[[]string], error) {
+// WatchControllerConfig mocks base method.
+func (m *MockControllerConfigService) WatchControllerConfig() (watcher.Watcher[[]string], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Watch")
+	ret := m.ctrl.Call(m, "WatchControllerConfig")
 	ret0, _ := ret[0].(watcher.Watcher[[]string])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// Watch indicates an expected call of Watch.
-func (mr *MockControllerConfigServiceMockRecorder) Watch() *MockControllerConfigServiceWatchCall {
+// WatchControllerConfig indicates an expected call of WatchControllerConfig.
+func (mr *MockControllerConfigServiceMockRecorder) WatchControllerConfig() *MockControllerConfigServiceWatchControllerConfigCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Watch", reflect.TypeOf((*MockControllerConfigService)(nil).Watch))
-	return &MockControllerConfigServiceWatchCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchControllerConfig", reflect.TypeOf((*MockControllerConfigService)(nil).WatchControllerConfig))
+	return &MockControllerConfigServiceWatchControllerConfigCall{Call: call}
 }
 
-// MockControllerConfigServiceWatchCall wrap *gomock.Call
-type MockControllerConfigServiceWatchCall struct {
+// MockControllerConfigServiceWatchControllerConfigCall wrap *gomock.Call
+type MockControllerConfigServiceWatchControllerConfigCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockControllerConfigServiceWatchCall) Return(arg0 watcher.Watcher[[]string], arg1 error) *MockControllerConfigServiceWatchCall {
+func (c *MockControllerConfigServiceWatchControllerConfigCall) Return(arg0 watcher.Watcher[[]string], arg1 error) *MockControllerConfigServiceWatchControllerConfigCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockControllerConfigServiceWatchCall) Do(f func() (watcher.Watcher[[]string], error)) *MockControllerConfigServiceWatchCall {
+func (c *MockControllerConfigServiceWatchControllerConfigCall) Do(f func() (watcher.Watcher[[]string], error)) *MockControllerConfigServiceWatchControllerConfigCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockControllerConfigServiceWatchCall) DoAndReturn(f func() (watcher.Watcher[[]string], error)) *MockControllerConfigServiceWatchCall {
+func (c *MockControllerConfigServiceWatchControllerConfigCall) DoAndReturn(f func() (watcher.Watcher[[]string], error)) *MockControllerConfigServiceWatchControllerConfigCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/controllerconfig/service/service.go
+++ b/domain/controllerconfig/service/service.go
@@ -256,6 +256,6 @@ var InitialNamespaceChanges = eventsource.InitialNamespaceChanges
 
 // Watch returns a watcher that returns keys for any changes to controller
 // config.
-func (s *WatchableService) Watch() (watcher.StringsWatcher, error) {
+func (s *WatchableService) WatchControllerConfig() (watcher.StringsWatcher, error) {
 	return s.watcherFactory.NewNamespaceWatcher("controller_config", changestream.All, InitialNamespaceChanges(s.st.AllKeysQuery()))
 }

--- a/domain/controllerconfig/service/service_test.go
+++ b/domain/controllerconfig/service/service_test.go
@@ -170,7 +170,7 @@ func (s *serviceSuite) TestWatch(c *gc.C) {
 	})
 	s.watcherFactory.EXPECT().NewNamespaceWatcher("controller_config", changestream.All, gomock.Any()).Return(s.stringsWatcher, nil)
 
-	w, err := NewWatchableService(s.state, s.watcherFactory).Watch()
+	w, err := NewWatchableService(s.state, s.watcherFactory).WatchControllerConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(w, gc.NotNil)
 }

--- a/domain/controllerconfig/watcher_test.go
+++ b/domain/controllerconfig/watcher_test.go
@@ -26,7 +26,7 @@ type watcherSuite struct {
 
 var _ = gc.Suite(&watcherSuite{})
 
-func (s *watcherSuite) TestWatch(c *gc.C) {
+func (s *watcherSuite) TestWatchControllerConfig(c *gc.C) {
 	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "controller_config")
 
 	svc := service.NewWatchableService(state.NewState(func() (database.TxnRunner, error) { return factory() }),
@@ -34,7 +34,7 @@ func (s *watcherSuite) TestWatch(c *gc.C) {
 			loggertesting.WrapCheckLog(c),
 		),
 	)
-	watcher, err := svc.Watch()
+	watcher, err := svc.WatchControllerConfig()
 	c.Assert(err, jc.ErrorIsNil)
 
 	w := watchertest.NewStringsWatcherC(c, watcher)

--- a/internal/worker/auditconfigupdater/servicefactory_mock_test.go
+++ b/internal/worker/auditconfigupdater/servicefactory_mock_test.go
@@ -80,41 +80,41 @@ func (c *MockControllerConfigServiceControllerConfigCall) DoAndReturn(f func(con
 	return c
 }
 
-// Watch mocks base method.
-func (m *MockControllerConfigService) Watch() (watcher.Watcher[[]string], error) {
+// WatchControllerConfig mocks base method.
+func (m *MockControllerConfigService) WatchControllerConfig() (watcher.Watcher[[]string], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Watch")
+	ret := m.ctrl.Call(m, "WatchControllerConfig")
 	ret0, _ := ret[0].(watcher.Watcher[[]string])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// Watch indicates an expected call of Watch.
-func (mr *MockControllerConfigServiceMockRecorder) Watch() *MockControllerConfigServiceWatchCall {
+// WatchControllerConfig indicates an expected call of WatchControllerConfig.
+func (mr *MockControllerConfigServiceMockRecorder) WatchControllerConfig() *MockControllerConfigServiceWatchControllerConfigCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Watch", reflect.TypeOf((*MockControllerConfigService)(nil).Watch))
-	return &MockControllerConfigServiceWatchCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchControllerConfig", reflect.TypeOf((*MockControllerConfigService)(nil).WatchControllerConfig))
+	return &MockControllerConfigServiceWatchControllerConfigCall{Call: call}
 }
 
-// MockControllerConfigServiceWatchCall wrap *gomock.Call
-type MockControllerConfigServiceWatchCall struct {
+// MockControllerConfigServiceWatchControllerConfigCall wrap *gomock.Call
+type MockControllerConfigServiceWatchControllerConfigCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockControllerConfigServiceWatchCall) Return(arg0 watcher.Watcher[[]string], arg1 error) *MockControllerConfigServiceWatchCall {
+func (c *MockControllerConfigServiceWatchControllerConfigCall) Return(arg0 watcher.Watcher[[]string], arg1 error) *MockControllerConfigServiceWatchControllerConfigCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockControllerConfigServiceWatchCall) Do(f func() (watcher.Watcher[[]string], error)) *MockControllerConfigServiceWatchCall {
+func (c *MockControllerConfigServiceWatchControllerConfigCall) Do(f func() (watcher.Watcher[[]string], error)) *MockControllerConfigServiceWatchControllerConfigCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockControllerConfigServiceWatchCall) DoAndReturn(f func() (watcher.Watcher[[]string], error)) *MockControllerConfigServiceWatchCall {
+func (c *MockControllerConfigServiceWatchControllerConfigCall) DoAndReturn(f func() (watcher.Watcher[[]string], error)) *MockControllerConfigServiceWatchControllerConfigCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/auditconfigupdater/worker.go
+++ b/internal/worker/auditconfigupdater/worker.go
@@ -28,9 +28,9 @@ type ControllerConfigService interface {
 	// ControllerConfig returns the config values for the controller.
 	ControllerConfig(ctx context.Context) (controller.Config, error)
 
-	// Watch returns a watcher that returns keys for any changes to controller
-	// config.
-	Watch() (watcher.StringsWatcher, error)
+	// WatchControllerConfig returns a watcher that returns keys for any changes
+	// to controller config.
+	WatchControllerConfig() (watcher.StringsWatcher, error)
 }
 
 // AuditLogFactory is a function that will return an audit log given
@@ -157,7 +157,7 @@ func (u *updater) CurrentConfig() auditlog.Config {
 // watchForConfigChanges starts a watcher for changes to controller config.
 // It returns a channel which will receive events if the watcher fires.
 func (u *updater) watchForConfigChanges(ctx context.Context) (<-chan []string, error) {
-	watcher, err := u.controllerConfigService.Watch()
+	watcher, err := u.controllerConfigService.WatchControllerConfig()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/internal/worker/auditconfigupdater/worker_test.go
+++ b/internal/worker/auditconfigupdater/worker_test.go
@@ -128,7 +128,7 @@ func (s *workerSuite) expectControllerConfigWatcher(c *gc.C) chan []string {
 
 	watcher := watchertest.NewMockStringsWatcher(ch)
 
-	s.controllerConfigService.EXPECT().Watch().Return(watcher, nil)
+	s.controllerConfigService.EXPECT().WatchControllerConfig().Return(watcher, nil)
 
 	return ch
 }

--- a/internal/worker/objectstores3caller/package_test.go
+++ b/internal/worker/objectstores3caller/package_test.go
@@ -75,7 +75,7 @@ func (s *baseSuite) expectControllerConfig(c *gc.C, config controller.Config) {
 }
 
 func (s *baseSuite) expectControllerConfigWatch(c *gc.C) {
-	s.controllerConfigService.EXPECT().Watch().DoAndReturn(func() (watcher.Watcher[[]string], error) {
+	s.controllerConfigService.EXPECT().WatchControllerConfig().DoAndReturn(func() (watcher.Watcher[[]string], error) {
 		ch := make(chan []string)
 		go func() {
 			select {
@@ -89,7 +89,7 @@ func (s *baseSuite) expectControllerConfigWatch(c *gc.C) {
 }
 
 func (s *baseSuite) expectControllerConfigWatchWithChanges(c *gc.C, changes <-chan []string) {
-	s.controllerConfigService.EXPECT().Watch().DoAndReturn(func() (watcher.Watcher[[]string], error) {
+	s.controllerConfigService.EXPECT().WatchControllerConfig().DoAndReturn(func() (watcher.Watcher[[]string], error) {
 		return watchertest.NewMockStringsWatcher(changes), nil
 	})
 }

--- a/internal/worker/objectstores3caller/services_mocks_test.go
+++ b/internal/worker/objectstores3caller/services_mocks_test.go
@@ -80,41 +80,41 @@ func (c *MockControllerConfigServiceControllerConfigCall) DoAndReturn(f func(con
 	return c
 }
 
-// Watch mocks base method.
-func (m *MockControllerConfigService) Watch() (watcher.Watcher[[]string], error) {
+// WatchControllerConfig mocks base method.
+func (m *MockControllerConfigService) WatchControllerConfig() (watcher.Watcher[[]string], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Watch")
+	ret := m.ctrl.Call(m, "WatchControllerConfig")
 	ret0, _ := ret[0].(watcher.Watcher[[]string])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// Watch indicates an expected call of Watch.
-func (mr *MockControllerConfigServiceMockRecorder) Watch() *MockControllerConfigServiceWatchCall {
+// WatchControllerConfig indicates an expected call of WatchControllerConfig.
+func (mr *MockControllerConfigServiceMockRecorder) WatchControllerConfig() *MockControllerConfigServiceWatchControllerConfigCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Watch", reflect.TypeOf((*MockControllerConfigService)(nil).Watch))
-	return &MockControllerConfigServiceWatchCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchControllerConfig", reflect.TypeOf((*MockControllerConfigService)(nil).WatchControllerConfig))
+	return &MockControllerConfigServiceWatchControllerConfigCall{Call: call}
 }
 
-// MockControllerConfigServiceWatchCall wrap *gomock.Call
-type MockControllerConfigServiceWatchCall struct {
+// MockControllerConfigServiceWatchControllerConfigCall wrap *gomock.Call
+type MockControllerConfigServiceWatchControllerConfigCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockControllerConfigServiceWatchCall) Return(arg0 watcher.Watcher[[]string], arg1 error) *MockControllerConfigServiceWatchCall {
+func (c *MockControllerConfigServiceWatchControllerConfigCall) Return(arg0 watcher.Watcher[[]string], arg1 error) *MockControllerConfigServiceWatchControllerConfigCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockControllerConfigServiceWatchCall) Do(f func() (watcher.Watcher[[]string], error)) *MockControllerConfigServiceWatchCall {
+func (c *MockControllerConfigServiceWatchControllerConfigCall) Do(f func() (watcher.Watcher[[]string], error)) *MockControllerConfigServiceWatchControllerConfigCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockControllerConfigServiceWatchCall) DoAndReturn(f func() (watcher.Watcher[[]string], error)) *MockControllerConfigServiceWatchCall {
+func (c *MockControllerConfigServiceWatchControllerConfigCall) DoAndReturn(f func() (watcher.Watcher[[]string], error)) *MockControllerConfigServiceWatchControllerConfigCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/objectstores3caller/worker.go
+++ b/internal/worker/objectstores3caller/worker.go
@@ -42,9 +42,9 @@ const (
 type ControllerConfigService interface {
 	// ControllerConfig returns the current controller configuration.
 	ControllerConfig(context.Context) (controller.Config, error)
-	// Watch returns a watcher that returns keys for any changes to controller
-	// config.
-	Watch() (watcher.StringsWatcher, error)
+	// WatchControllerConfig returns a watcher that returns keys for any changes
+	// to controller config.
+	WatchControllerConfig() (watcher.StringsWatcher, error)
 }
 
 type workerConfig struct {
@@ -157,7 +157,7 @@ func (w *s3Worker) Wait() error {
 }
 
 func (w *s3Worker) loop() (err error) {
-	watcher, err := w.config.ControllerConfigService.Watch()
+	watcher, err := w.config.ControllerConfigService.WatchControllerConfig()
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/internal/worker/peergrouper/controllerconfig_mock_test.go
+++ b/internal/worker/peergrouper/controllerconfig_mock_test.go
@@ -80,41 +80,41 @@ func (c *MockControllerConfigServiceControllerConfigCall) DoAndReturn(f func(con
 	return c
 }
 
-// Watch mocks base method.
-func (m *MockControllerConfigService) Watch() (watcher.Watcher[[]string], error) {
+// WatchControllerConfig mocks base method.
+func (m *MockControllerConfigService) WatchControllerConfig() (watcher.Watcher[[]string], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Watch")
+	ret := m.ctrl.Call(m, "WatchControllerConfig")
 	ret0, _ := ret[0].(watcher.Watcher[[]string])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// Watch indicates an expected call of Watch.
-func (mr *MockControllerConfigServiceMockRecorder) Watch() *MockControllerConfigServiceWatchCall {
+// WatchControllerConfig indicates an expected call of WatchControllerConfig.
+func (mr *MockControllerConfigServiceMockRecorder) WatchControllerConfig() *MockControllerConfigServiceWatchControllerConfigCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Watch", reflect.TypeOf((*MockControllerConfigService)(nil).Watch))
-	return &MockControllerConfigServiceWatchCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchControllerConfig", reflect.TypeOf((*MockControllerConfigService)(nil).WatchControllerConfig))
+	return &MockControllerConfigServiceWatchControllerConfigCall{Call: call}
 }
 
-// MockControllerConfigServiceWatchCall wrap *gomock.Call
-type MockControllerConfigServiceWatchCall struct {
+// MockControllerConfigServiceWatchControllerConfigCall wrap *gomock.Call
+type MockControllerConfigServiceWatchControllerConfigCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockControllerConfigServiceWatchCall) Return(arg0 watcher.Watcher[[]string], arg1 error) *MockControllerConfigServiceWatchCall {
+func (c *MockControllerConfigServiceWatchControllerConfigCall) Return(arg0 watcher.Watcher[[]string], arg1 error) *MockControllerConfigServiceWatchControllerConfigCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockControllerConfigServiceWatchCall) Do(f func() (watcher.Watcher[[]string], error)) *MockControllerConfigServiceWatchCall {
+func (c *MockControllerConfigServiceWatchControllerConfigCall) Do(f func() (watcher.Watcher[[]string], error)) *MockControllerConfigServiceWatchControllerConfigCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockControllerConfigServiceWatchCall) DoAndReturn(f func() (watcher.Watcher[[]string], error)) *MockControllerConfigServiceWatchCall {
+func (c *MockControllerConfigServiceWatchControllerConfigCall) DoAndReturn(f func() (watcher.Watcher[[]string], error)) *MockControllerConfigServiceWatchControllerConfigCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/peergrouper/worker.go
+++ b/internal/worker/peergrouper/worker.go
@@ -40,9 +40,9 @@ type ControllerConfigService interface {
 	// ControllerConfig returns the config values for the controller.
 	ControllerConfig(ctx context.Context) (controller.Config, error)
 
-	// Watch returns a watcher that returns keys for any changes to controller
-	// config.
-	Watch() (watcher.StringsWatcher, error)
+	// WatchControllerConfig returns a watcher that returns keys for any changes
+	// to controller config.
+	WatchControllerConfig() (watcher.StringsWatcher, error)
 }
 
 type State interface {
@@ -444,7 +444,7 @@ func (w *pgWorker) watchForControllerChanges() (<-chan struct{}, error) {
 // watchForConfigChanges starts a watcher for changes to controller config.
 // It returns a channel which will receive events if the watcher fires.
 func (w *pgWorker) watchForConfigChanges(ctx context.Context) (<-chan []string, error) {
-	watcher, err := w.config.ControllerConfigService.Watch()
+	watcher, err := w.config.ControllerConfigService.WatchControllerConfig()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/internal/worker/peergrouper/worker_test.go
+++ b/internal/worker/peergrouper/worker_test.go
@@ -141,7 +141,7 @@ func (s *workerSuite) expectControllerConfigWatcher(c *gc.C) chan []string {
 
 	watcher := watchertest.NewMockStringsWatcher(ch)
 
-	s.controllerConfigService.EXPECT().Watch().Return(watcher, nil)
+	s.controllerConfigService.EXPECT().WatchControllerConfig().Return(watcher, nil)
 
 	return ch
 }


### PR DESCRIPTION
Domains aren't entities so Watch doesn't make sense, we should be explicit with the naming. This then becomes WatchControllerConfig.

This is clean up from the design changes from the original implementation.

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

Tests should pass.

```sh
$ juju bootstrap lxd test
$ juju add-model default
$ juju controller-config
```

