### PR TITLE
Model id creation in service layer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,3 +13,8 @@
 
 # Charmhub
 /charmhub/**                    @hmlanigan @SimonRichardson
+
+# Model domain packages
+/core/model/**                  @tlm
+/domain/model/**                @tlm
+/domain/modelconfig/**          @tlm

--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -237,9 +237,8 @@ func (b *AgentBootstrap) Initialize(ctx stdcontext.Context) (_ *state.Controller
 		Cloud:        stateParams.ControllerCloud.Name,
 		CloudRegion:  stateParams.ControllerCloudRegion,
 		Credential:   credential.KeyFromTag(cloudCredTag),
-		UUID:         controllerModelUUID,
 	}
-	controllerModelCreateFunc := modelbootstrap.CreateModel(controllerModelArgs)
+	controllerModelCreateFunc := modelbootstrap.CreateModel(controllerModelUUID, controllerModelArgs)
 
 	controllerModelDefaults := modeldefaultsbootstrap.ModelDefaultsProvider(
 		nil,
@@ -262,8 +261,8 @@ func (b *AgentBootstrap) Initialize(ctx stdcontext.Context) (_ *state.Controller
 		cloudbootstrap.SetCloudDefaults(stateParams.ControllerCloud.Name, stateParams.ControllerInheritedConfig),
 		secretbackendbootstrap.CreateDefaultBackends(model.ModelType(modelType)),
 		controllerModelCreateFunc,
-		modelbootstrap.CreateReadOnlyModel(controllerModelArgs.UUID, controllerUUID),
-		modelconfigbootstrap.SetModelConfig(controllerModelArgs.UUID, stateParams.ControllerModelConfig.AllAttrs(), controllerModelDefaults),
+		modelbootstrap.CreateReadOnlyModel(controllerModelUUID, controllerUUID),
+		modelconfigbootstrap.SetModelConfig(controllerModelUUID, stateParams.ControllerModelConfig.AllAttrs(), controllerModelDefaults),
 	}
 	if !isCAAS {
 		// TODO(wallyworld) - this is just a placeholder for now

--- a/apiserver/facades/client/modelmanager/mocks/service_mock.go
+++ b/apiserver/facades/client/modelmanager/mocks/service_mock.go
@@ -248,12 +248,13 @@ func (m *MockModelService) EXPECT() *MockModelServiceMockRecorder {
 }
 
 // CreateModel mocks base method.
-func (m *MockModelService) CreateModel(arg0 context.Context, arg1 model0.ModelCreationArgs) (func(context.Context) error, error) {
+func (m *MockModelService) CreateModel(arg0 context.Context, arg1 model0.ModelCreationArgs) (model.UUID, func(context.Context) error, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateModel", arg0, arg1)
-	ret0, _ := ret[0].(func(context.Context) error)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret0, _ := ret[0].(model.UUID)
+	ret1, _ := ret[1].(func(context.Context) error)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // CreateModel indicates an expected call of CreateModel.
@@ -269,19 +270,19 @@ type MockModelServiceCreateModelCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockModelServiceCreateModelCall) Return(arg0 func(context.Context) error, arg1 error) *MockModelServiceCreateModelCall {
-	c.Call = c.Call.Return(arg0, arg1)
+func (c *MockModelServiceCreateModelCall) Return(arg0 model.UUID, arg1 func(context.Context) error, arg2 error) *MockModelServiceCreateModelCall {
+	c.Call = c.Call.Return(arg0, arg1, arg2)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockModelServiceCreateModelCall) Do(f func(context.Context, model0.ModelCreationArgs) (func(context.Context) error, error)) *MockModelServiceCreateModelCall {
+func (c *MockModelServiceCreateModelCall) Do(f func(context.Context, model0.ModelCreationArgs) (model.UUID, func(context.Context) error, error)) *MockModelServiceCreateModelCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockModelServiceCreateModelCall) DoAndReturn(f func(context.Context, model0.ModelCreationArgs) (func(context.Context) error, error)) *MockModelServiceCreateModelCall {
+func (c *MockModelServiceCreateModelCall) DoAndReturn(f func(context.Context, model0.ModelCreationArgs) (model.UUID, func(context.Context) error, error)) *MockModelServiceCreateModelCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/client/modelmanager/modelmanager_test.go
+++ b/apiserver/facades/client/modelmanager/modelmanager_test.go
@@ -1177,31 +1177,6 @@ func (s *modelManagerStateSuite) TestCreateModelValidatesConfig(c *gc.C) {
 	)
 }
 
-func (s *modelManagerStateSuite) TestCreateModelBadConfig(c *gc.C) {
-	defer s.setupMocks(c).Finish()
-
-	owner := names.NewUserTag("admin")
-	s.setAPIUser(c, owner)
-	for i, test := range []struct {
-		key      string
-		value    interface{}
-		errMatch string
-	}{
-		{
-			key:      "uuid",
-			value:    "anything",
-			errMatch: `failed to create config: uuid is generated, you cannot specify one`,
-		},
-	} {
-		c.Logf("%d: %s", i, test.key)
-		args := createArgs(owner)
-		args.Config[test.key] = test.value
-		_, err := s.modelmanager.CreateModel(stdcontext.Background(), args)
-		c.Assert(err, gc.ErrorMatches, test.errMatch)
-
-	}
-}
-
 func (s *modelManagerStateSuite) TestCreateModelSameAgentVersion(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 

--- a/apiserver/facades/client/modelmanager/services.go
+++ b/apiserver/facades/client/modelmanager/services.go
@@ -50,8 +50,8 @@ type ModelConfigService interface {
 
 // ModelService defines a interface for interacting with the underlying state.
 type ModelService interface {
-	// CreateModel creates a model.
-	CreateModel(context.Context, model.ModelCreationArgs) (func(context.Context) error, error)
+	// CreateModel creates a model returning the resultant model's new id.
+	CreateModel(context.Context, model.ModelCreationArgs) (coremodel.UUID, func(context.Context) error, error)
 
 	// DefaultModelCloudNameAndCredential returns the default cloud name and
 	// credential that should be used for newly created models that haven't had

--- a/domain/cloud/state/state_test.go
+++ b/domain/cloud/state/state_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/juju/juju/internal/changestream/testing"
 	jujudb "github.com/juju/juju/internal/database"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
+	"github.com/juju/juju/internal/secrets/provider/juju"
 	"github.com/juju/juju/internal/uuid"
 )
 
@@ -602,12 +603,13 @@ func (s *stateSuite) TestCloudIsControllerCloud(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = modelSt.Create(
 		context.Background(),
+		modelUUID,
 		coremodel.IAAS,
 		model.ModelCreationArgs{
-			Cloud: testCloud.Name,
-			Name:  coremodel.ControllerModelName,
-			Owner: user.UUID(s.adminUUID.String()),
-			UUID:  modelUUID,
+			Cloud:         testCloud.Name,
+			Name:          coremodel.ControllerModelName,
+			Owner:         user.UUID(s.adminUUID.String()),
+			SecretBackend: juju.BackendName,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/domain/model/bootstrap/bootstrap_test.go
+++ b/domain/model/bootstrap/bootstrap_test.go
@@ -72,20 +72,19 @@ type bootstrapSuite struct {
 var _ = gc.Suite(&bootstrapSuite{})
 
 func (s *bootstrapSuite) TestUUIDIsRespected(c *gc.C) {
-	modelUUID := modeltesting.GenModelUUID(c)
-
-	fn := CreateModel(model.ModelCreationArgs{
-		AgentVersion: jujuversion.Current,
-		Cloud:        s.cloudName,
-		Credential: credential.Key{
-			Cloud: s.cloudName,
-			Name:  s.credentialName,
-			Owner: coreuser.AdminUserName,
-		},
-		Name:  "test",
-		Owner: s.adminUserUUID,
-		UUID:  modelUUID,
-	})
+	fn := CreateModel(
+		modeltesting.GenModelUUID(c),
+		model.ModelCreationArgs{
+			AgentVersion: jujuversion.Current,
+			Cloud:        s.cloudName,
+			Credential: credential.Key{
+				Cloud: s.cloudName,
+				Name:  s.credentialName,
+				Owner: coreuser.AdminUserName,
+			},
+			Name:  "test",
+			Owner: s.adminUserUUID,
+		})
 
 	err := fn(context.Background(), s.ControllerTxnRunner(), s.NoopTxnRunner())
 	c.Assert(err, jc.ErrorIsNil)
@@ -117,11 +116,10 @@ func (s *modelBootstrapSuite) TestCreateReadOnlyModel(c *gc.C) {
 		},
 		Name:  "test",
 		Owner: s.adminUserUUID,
-		UUID:  modelUUID,
 	}
 
 	// Create a model and then create a read-only model from it.
-	fn := CreateModel(args)
+	fn := CreateModel(modelUUID, args)
 	err := fn(context.Background(), s.ControllerTxnRunner(), s.NoopTxnRunner())
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/domain/model/errors/errors.go
+++ b/domain/model/errors/errors.go
@@ -27,4 +27,8 @@ const (
 	// NotFound describes an error that occurs when the model being operated on
 	// does not exist.
 	NotFound = errors.ConstError("model not found")
+
+	// SecretBackendAlreadySet describes an error that occurs when a model's
+	// secret backend has already been set.
+	SecretBackendAlreadySet = errors.ConstError("secret backend already set")
 )

--- a/domain/model/modelmigration/import_test.go
+++ b/domain/model/modelmigration/import_test.go
@@ -131,18 +131,20 @@ func (i *importSuite) TestModelCreate(c *gc.C) {
 	)
 	i.controllerConfigService.EXPECT().ControllerConfig(gomock.Any()).Return(testing.FakeControllerConfig(), nil)
 
-	args := model.ModelCreationArgs{
-		AgentVersion: jujuversion.Current,
-		Cloud:        "AWS",
-		CloudRegion:  "region1",
-		Credential: credential.Key{
-			Name:  "my-credential",
-			Owner: "tlm",
-			Cloud: "AWS",
+	args := model.ModelImportArgs{
+		ModelCreationArgs: model.ModelCreationArgs{
+			AgentVersion: jujuversion.Current,
+			Cloud:        "AWS",
+			CloudRegion:  "region1",
+			Credential: credential.Key{
+				Name:  "my-credential",
+				Owner: "tlm",
+				Cloud: "AWS",
+			},
+			Name:  "test-model",
+			Owner: userUUID,
 		},
-		Name:  "test-model",
-		Owner: userUUID,
-		UUID:  modelUUID,
+		ID: modelUUID,
 	}
 
 	activated := false
@@ -154,7 +156,7 @@ func (i *importSuite) TestModelCreate(c *gc.C) {
 	controllerUUID, err := uuid.UUIDFromString(testing.ControllerTag.Id())
 	c.Assert(err, jc.ErrorIsNil)
 
-	i.modelService.EXPECT().CreateModel(gomock.Any(), args).Return(activator, nil)
+	i.modelService.EXPECT().ImportModel(gomock.Any(), args).Return(activator, nil)
 	i.readOnlyModelService.EXPECT().CreateModel(gomock.Any(), controllerUUID).Return(nil)
 
 	model := description.NewModel(description.ModelArgs{
@@ -202,18 +204,20 @@ func (i *importSuite) TestModelCreateRollbacksOnFailure(c *gc.C) {
 	)
 	i.controllerConfigService.EXPECT().ControllerConfig(gomock.Any()).Return(testing.FakeControllerConfig(), nil)
 
-	args := model.ModelCreationArgs{
-		AgentVersion: jujuversion.Current,
-		Cloud:        "AWS",
-		CloudRegion:  "region1",
-		Credential: credential.Key{
-			Name:  "my-credential",
-			Owner: "tlm",
-			Cloud: "AWS",
+	args := model.ModelImportArgs{
+		ModelCreationArgs: model.ModelCreationArgs{
+			AgentVersion: jujuversion.Current,
+			Cloud:        "AWS",
+			CloudRegion:  "region1",
+			Credential: credential.Key{
+				Name:  "my-credential",
+				Owner: "tlm",
+				Cloud: "AWS",
+			},
+			Name:  "test-model",
+			Owner: userUUID,
 		},
-		Name:  "test-model",
-		Owner: userUUID,
-		UUID:  modelUUID,
+		ID: modelUUID,
 	}
 
 	var activated bool
@@ -224,7 +228,7 @@ func (i *importSuite) TestModelCreateRollbacksOnFailure(c *gc.C) {
 	controllerUUID, err := uuid.UUIDFromString(testing.ControllerTag.Id())
 	c.Assert(err, jc.ErrorIsNil)
 
-	i.modelService.EXPECT().CreateModel(gomock.Any(), args).Return(activator, nil)
+	i.modelService.EXPECT().ImportModel(gomock.Any(), args).Return(activator, nil)
 	i.readOnlyModelService.EXPECT().CreateModel(gomock.Any(), controllerUUID).Return(errors.New("boom"))
 	i.modelService.EXPECT().DeleteModel(gomock.Any(), modelUUID, gomock.Any()).DoAndReturn(func(_ context.Context, _ coremodel.UUID, options ...model.DeleteModelOption) error {
 		opts := model.DefaultDeleteModelOptions()
@@ -284,18 +288,20 @@ func (i *importSuite) TestModelCreateRollbacksOnFailureIgnoreNotFoundModel(c *gc
 	)
 	i.controllerConfigService.EXPECT().ControllerConfig(gomock.Any()).Return(testing.FakeControllerConfig(), nil)
 
-	args := model.ModelCreationArgs{
-		AgentVersion: jujuversion.Current,
-		Cloud:        "AWS",
-		CloudRegion:  "region1",
-		Credential: credential.Key{
-			Name:  "my-credential",
-			Owner: "tlm",
-			Cloud: "AWS",
+	args := model.ModelImportArgs{
+		ModelCreationArgs: model.ModelCreationArgs{
+			AgentVersion: jujuversion.Current,
+			Cloud:        "AWS",
+			CloudRegion:  "region1",
+			Credential: credential.Key{
+				Name:  "my-credential",
+				Owner: "tlm",
+				Cloud: "AWS",
+			},
+			Name:  "test-model",
+			Owner: userUUID,
 		},
-		Name:  "test-model",
-		Owner: userUUID,
-		UUID:  modelUUID,
+		ID: modelUUID,
 	}
 
 	activated := false
@@ -306,7 +312,7 @@ func (i *importSuite) TestModelCreateRollbacksOnFailureIgnoreNotFoundModel(c *gc
 	controllerUUID, err := uuid.UUIDFromString(testing.ControllerTag.Id())
 	c.Assert(err, jc.ErrorIsNil)
 
-	i.modelService.EXPECT().CreateModel(gomock.Any(), args).Return(activator, nil)
+	i.modelService.EXPECT().ImportModel(gomock.Any(), args).Return(activator, nil)
 	i.readOnlyModelService.EXPECT().CreateModel(gomock.Any(), controllerUUID).Return(errors.New("boom"))
 	i.modelService.EXPECT().DeleteModel(gomock.Any(), modelUUID, gomock.Any()).Return(modelerrors.NotFound)
 	i.readOnlyModelService.EXPECT().DeleteModel(gomock.Any()).Return(nil)
@@ -365,22 +371,25 @@ func (i *importSuite) TestModelCreateRollbacksOnFailureIgnoreNotFoundReadOnlyMod
 		return nil
 	}
 
-	args := model.ModelCreationArgs{
-		AgentVersion: jujuversion.Current,
-		Cloud:        "AWS",
-		CloudRegion:  "region1",
-		Credential: credential.Key{
-			Name:  "my-credential",
-			Owner: "tlm",
-			Cloud: "AWS",
+	args := model.ModelImportArgs{
+		ModelCreationArgs: model.ModelCreationArgs{
+			AgentVersion: jujuversion.Current,
+			Cloud:        "AWS",
+			CloudRegion:  "region1",
+			Credential: credential.Key{
+				Name:  "my-credential",
+				Owner: "tlm",
+				Cloud: "AWS",
+			},
+			Name:  "test-model",
+			Owner: userUUID,
 		},
-		Name:  "test-model",
-		Owner: userUUID,
-		UUID:  modelUUID,
+		ID: modelUUID,
 	}
 	controllerUUID, err := uuid.UUIDFromString(testing.ControllerTag.Id())
 	c.Assert(err, jc.ErrorIsNil)
-	i.modelService.EXPECT().CreateModel(gomock.Any(), args).Return(activator, nil)
+
+	i.modelService.EXPECT().ImportModel(gomock.Any(), args).Return(activator, nil)
 	i.readOnlyModelService.EXPECT().CreateModel(gomock.Any(), controllerUUID).Return(errors.New("boom"))
 	i.modelService.EXPECT().DeleteModel(gomock.Any(), modelUUID, gomock.Any()).Return(nil)
 	i.readOnlyModelService.EXPECT().DeleteModel(gomock.Any()).Return(modelerrors.NotFound)

--- a/domain/model/modelmigration/migrations_mock_test.go
+++ b/domain/model/modelmigration/migrations_mock_test.go
@@ -44,45 +44,6 @@ func (m *MockModelService) EXPECT() *MockModelServiceMockRecorder {
 	return m.recorder
 }
 
-// CreateModel mocks base method.
-func (m *MockModelService) CreateModel(arg0 context.Context, arg1 model0.ModelCreationArgs) (func(context.Context) error, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateModel", arg0, arg1)
-	ret0, _ := ret[0].(func(context.Context) error)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CreateModel indicates an expected call of CreateModel.
-func (mr *MockModelServiceMockRecorder) CreateModel(arg0, arg1 any) *MockModelServiceCreateModelCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateModel", reflect.TypeOf((*MockModelService)(nil).CreateModel), arg0, arg1)
-	return &MockModelServiceCreateModelCall{Call: call}
-}
-
-// MockModelServiceCreateModelCall wrap *gomock.Call
-type MockModelServiceCreateModelCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockModelServiceCreateModelCall) Return(arg0 func(context.Context) error, arg1 error) *MockModelServiceCreateModelCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockModelServiceCreateModelCall) Do(f func(context.Context, model0.ModelCreationArgs) (func(context.Context) error, error)) *MockModelServiceCreateModelCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockModelServiceCreateModelCall) DoAndReturn(f func(context.Context, model0.ModelCreationArgs) (func(context.Context) error, error)) *MockModelServiceCreateModelCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // DeleteModel mocks base method.
 func (m *MockModelService) DeleteModel(arg0 context.Context, arg1 model.UUID, arg2 ...model0.DeleteModelOption) error {
 	m.ctrl.T.Helper()
@@ -126,41 +87,41 @@ func (c *MockModelServiceDeleteModelCall) DoAndReturn(f func(context.Context, mo
 	return c
 }
 
-// ModelType mocks base method.
-func (m *MockModelService) ModelType(arg0 context.Context, arg1 model.UUID) (model.ModelType, error) {
+// ImportModel mocks base method.
+func (m *MockModelService) ImportModel(arg0 context.Context, arg1 model0.ModelImportArgs) (func(context.Context) error, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ModelType", arg0, arg1)
-	ret0, _ := ret[0].(model.ModelType)
+	ret := m.ctrl.Call(m, "ImportModel", arg0, arg1)
+	ret0, _ := ret[0].(func(context.Context) error)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ModelType indicates an expected call of ModelType.
-func (mr *MockModelServiceMockRecorder) ModelType(arg0, arg1 any) *MockModelServiceModelTypeCall {
+// ImportModel indicates an expected call of ImportModel.
+func (mr *MockModelServiceMockRecorder) ImportModel(arg0, arg1 any) *MockModelServiceImportModelCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModelType", reflect.TypeOf((*MockModelService)(nil).ModelType), arg0, arg1)
-	return &MockModelServiceModelTypeCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImportModel", reflect.TypeOf((*MockModelService)(nil).ImportModel), arg0, arg1)
+	return &MockModelServiceImportModelCall{Call: call}
 }
 
-// MockModelServiceModelTypeCall wrap *gomock.Call
-type MockModelServiceModelTypeCall struct {
+// MockModelServiceImportModelCall wrap *gomock.Call
+type MockModelServiceImportModelCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockModelServiceModelTypeCall) Return(arg0 model.ModelType, arg1 error) *MockModelServiceModelTypeCall {
+func (c *MockModelServiceImportModelCall) Return(arg0 func(context.Context) error, arg1 error) *MockModelServiceImportModelCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockModelServiceModelTypeCall) Do(f func(context.Context, model.UUID) (model.ModelType, error)) *MockModelServiceModelTypeCall {
+func (c *MockModelServiceImportModelCall) Do(f func(context.Context, model0.ModelImportArgs) (func(context.Context) error, error)) *MockModelServiceImportModelCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockModelServiceModelTypeCall) DoAndReturn(f func(context.Context, model.UUID) (model.ModelType, error)) *MockModelServiceModelTypeCall {
+func (c *MockModelServiceImportModelCall) DoAndReturn(f func(context.Context, model0.ModelImportArgs) (func(context.Context) error, error)) *MockModelServiceImportModelCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/model/state/state.go
+++ b/domain/model/state/state.go
@@ -156,7 +156,6 @@ func Create(
 	// Creates a record for the newly created model and register the target
 	// agent version.
 	if err := createModelAgent(ctx, tx, modelID, input.AgentVersion); err != nil {
-
 		return fmt.Errorf(
 			"creating model %q with id %q agent: %w",
 			input.Name, modelID, err,

--- a/domain/model/state/state.go
+++ b/domain/model/state/state.go
@@ -16,15 +16,15 @@ import (
 	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/core/user"
+	coreuser "github.com/juju/juju/core/user"
 	"github.com/juju/juju/domain"
 	usererrors "github.com/juju/juju/domain/access/errors"
 	clouderrors "github.com/juju/juju/domain/cloud/errors"
 	"github.com/juju/juju/domain/life"
 	"github.com/juju/juju/domain/model"
 	modelerrors "github.com/juju/juju/domain/model/errors"
+	secretbackenderrors "github.com/juju/juju/domain/secretbackend/errors"
 	jujudb "github.com/juju/juju/internal/database"
-	"github.com/juju/juju/internal/secrets/provider/juju"
-	"github.com/juju/juju/internal/secrets/provider/kubernetes"
 	internaluuid "github.com/juju/juju/internal/uuid"
 )
 
@@ -88,14 +88,20 @@ WHERE c.name = ?
 	}
 }
 
-// Create is responsible for creating a new moddel from start to finish. It will
+// Create is responsible for creating a new model from start to finish. It will
 // register the model existence and associate all of the model metadata.
-// If a model already exists with the same name and owner then an error
-// satisfying modelerrors.AlreadyExists will be returned.
-// If the model type is not found then an error satisfying errors.NotSupported
-// will be returned.
+//
+// The following errors can be expected:
+// - [modelerrors.AlreadyExists] when a model already exists with the same name
+// and owner
+// - [errors.NotSupported] When the new models type cannot be found.
+// - [errors.NotFound] Should the provided cloud and region not be found.
+// - [usererrors.NotFound] When the model owner does not exist.
+// - [secretbackenderrors.NotFound] When the secret backend for the model
+// cannot be found.
 func (s *State) Create(
 	ctx context.Context,
+	modelID coremodel.UUID,
 	modelType coremodel.ModelType,
 	input model.ModelCreationArgs,
 ) error {
@@ -105,36 +111,72 @@ func (s *State) Create(
 	}
 
 	return db.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
-		return Create(ctx, tx, modelType, input)
+		return Create(ctx, tx, modelID, modelType, input)
 	})
 }
 
 // Create is responsible for creating a new model from start to finish. It will
 // register the model existence and associate all of the model metadata.
-// If a model already exists with the same name and owner then an error
-// satisfying modelerrors.AlreadyExists will be returned.
-// If the model type is not found then an error satisfying errors.NotSupported
-// will be returned.
+//
+// The following errors can be expected:
+// - [modelerrors.AlreadyExists] when a model already exists with the same name
+// and owner
+// - [errors.NotSupported] When the new models type cannot be found.
+// - [errors.NotFound] Should the provided cloud and region not be found.
+// - [usererrors.NotFound] When the model owner does not exist.
+// - [secretbackenderrors.NotFound] When the secret backend for the model
+// cannot be found.
 func Create(
 	ctx context.Context,
 	tx *sql.Tx,
+	modelID coremodel.UUID,
 	modelType coremodel.ModelType,
 	input model.ModelCreationArgs,
 ) error {
-	if err := createModel(ctx, tx, modelType, input); err != nil {
-		return fmt.Errorf("creating model %q: %w", input.UUID, err)
+	// This function is responsible for driving all of the facets of model
+	// creation.
+
+	// Create the initial model and associated metadata.
+	if err := createModel(ctx, tx, modelID, modelType, input); err != nil {
+		return fmt.Errorf(
+			"creating initial model %q with id %q: %w",
+			input.Name, modelID, err,
+		)
 	}
 
-	if err := createModelAgent(ctx, tx, input.UUID, input.AgentVersion); err != nil {
-		return fmt.Errorf("creating model %q agent: %w", input.UUID, err)
+	// Add permissions for the model owner to be an admin of the newly created
+	// model.
+	if err := addAdminPermissions(ctx, tx, modelID, input.Owner); err != nil {
+		return fmt.Errorf(
+			"adding admin permissions to model %q with id %q for owner %q: %w",
+			input.Name, modelID, input.Owner, err,
+		)
 	}
 
-	if err := setModelSecretBackend(ctx, tx, input.UUID, modelType); err != nil {
-		return err
+	// Creates a record for the newly created model and register the target
+	// agent version.
+	if err := createModelAgent(ctx, tx, modelID, input.AgentVersion); err != nil {
+
+		return fmt.Errorf(
+			"creating model %q with id %q agent: %w",
+			input.Name, modelID, err,
+		)
 	}
 
-	if _, err := registerModelNamespace(ctx, tx, input.UUID); err != nil {
-		return fmt.Errorf("registering model %q namespace: %w", input.UUID, err)
+	// Sets the secret backend to be used for the newly created model.
+	if err := setModelSecretBackend(ctx, tx, modelID, input.SecretBackend); err != nil {
+		return fmt.Errorf(
+			"setting model %q with id %q secret backend: %w",
+			input.Name, modelID, err,
+		)
+	}
+
+	// Register a DQlite namespace for the model.
+	if _, err := registerModelNamespace(ctx, tx, modelID); err != nil {
+		return fmt.Errorf(
+			"registering model %q with id %q database namespace: %w",
+			input.Name, modelID, err,
+		)
 	}
 
 	return nil
@@ -279,10 +321,11 @@ WHERE uuid = ?
 	return model, nil
 }
 
-// createModelAgent is responsible for create a new model's agent record for the
-// given model UUID. If a model agent record already exists for the given model
-// uuid then an error satisfying [modelerrors.AlreadyExists] is returned. If no
-// model exists for the provided UUID then a [modelerrors.NotFound] is returned.
+// createModelAgent is responsible for creating a new model's agent record for
+// the given model id. If a model agent record already exists for the given
+// model uuid then an error satisfying [modelerrors.AlreadyExists] is returned.
+// If no model exists for the provided UUID then a [modelerrors.NotFound] is
+// returned.
 func createModelAgent(
 	ctx context.Context,
 	tx *sql.Tx,
@@ -319,49 +362,70 @@ INSERT INTO model_agent (model_uuid, previous_version, target_version)
 	return nil
 }
 
+// setModelSecretBackend sets the secret backend for a given model id. If the
+// secret backend does not exist a [secretbackenderrors.NotFound] error will be
+// returned. Should the model already have a secret backend set an error
+// satisfying [modelerrors.SecretBackendAlreadySet].
 func setModelSecretBackend(
 	ctx context.Context,
 	tx *sql.Tx,
-	modelUUID coremodel.UUID,
-	modelType coremodel.ModelType,
+	modelID coremodel.UUID,
+	backend string,
 ) error {
-	stmt := `
-INSERT INTO model_secret_backend (model_uuid, secret_backend_uuid)
-    VALUES (?, (SELECT uuid FROM secret_backend WHERE name = ?) )
+	backendFindStmt := `
+SELECT uuid from secret_backend WHERE name = ?
 `
 
-	backendName := juju.BackendName
-	if modelType == coremodel.CAAS {
-		backendName = kubernetes.BackendName
+	var backendUUID string
+	err := tx.QueryRowContext(ctx, backendFindStmt, backend).Scan(&backendUUID)
+
+	if errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf(
+			"setting model %q secret backend to %q: %w",
+			modelID, backend, secretbackenderrors.NotFound,
+		)
+	} else if err != nil {
+		return fmt.Errorf(
+			"setting model %q secret backend to %q: %w",
+			modelID, backend, err,
+		)
 	}
-	res, err := tx.ExecContext(ctx, stmt, modelUUID, backendName)
+
+	stmt := `
+INSERT INTO model_secret_backend (model_uuid, secret_backend_uuid) VALUES (?, ?)
+`
+
+	res, err := tx.ExecContext(ctx, stmt, modelID, backendUUID)
 	if jujudb.IsErrConstraintPrimaryKey(err) {
 		return fmt.Errorf(
-			"%w for uuid %q while setting model secret backend",
-			modelerrors.AlreadyExists, modelUUID,
+			"model for id %q %w", modelID, modelerrors.SecretBackendAlreadySet,
 		)
 	} else if jujudb.IsErrConstraintForeignKey(err) {
 		return fmt.Errorf(
-			"%w for uuid %q while setting model secret backend",
+			"%w for id %q while setting model secret backend to %q",
 			modelerrors.NotFound,
-			modelUUID,
+			modelID,
+			backend,
 		)
 	} else if err != nil {
-		return fmt.Errorf("setting model %q secret backend %q: %w", modelUUID, backendName, err)
+		return fmt.Errorf(
+			"setting model for id %q secret backend %q: %w",
+			modelID, backend, err,
+		)
 	}
 
 	if num, err := res.RowsAffected(); err != nil {
 		return errors.Trace(err)
 	} else if num != 1 {
-		return fmt.Errorf("creating model secet backend record, expected 1 row to be inserted got %d", num)
+		return fmt.Errorf("creating model secret backend record, expected 1 row to be inserted got %d", num)
 	}
 
 	return nil
 }
 
 // createModel is responsible for creating a new model record
-// for the given model UUID. If a model record already exists for the
-// given model uuid then an error satisfying modelerrors.AlreadyExists is
+// for the given model ID. If a model record already exists for the
+// given model id then an error satisfying modelerrors.AlreadyExists is
 // returned. Conversely, should the owner already have a model that exists with
 // the provided name then a modelerrors.AlreadyExists error will be returned. If
 // the model type supplied is not found then a errors.NotSupported error is
@@ -377,6 +441,7 @@ INSERT INTO model_secret_backend (model_uuid, secret_backend_uuid)
 func createModel(
 	ctx context.Context,
 	tx *sql.Tx,
+	modelID coremodel.UUID,
 	modelType coremodel.ModelType,
 	input model.ModelCreationArgs,
 ) error {
@@ -437,14 +502,14 @@ WHERE model_type.type = ?
 `
 
 	res, err := tx.ExecContext(ctx, stmt,
-		input.UUID.String(), cloudUUID, life.Alive, input.Name, input.Owner, modelType,
+		modelID, cloudUUID, life.Alive, input.Name, input.Owner, modelType,
 	)
 	if jujudb.IsErrConstraintPrimaryKey(err) {
-		return fmt.Errorf("%w for uuid %q", modelerrors.AlreadyExists, input.UUID)
+		return fmt.Errorf("%w for id %q", modelerrors.AlreadyExists, modelID)
 	} else if jujudb.IsErrConstraintUnique(err) {
 		return fmt.Errorf("%w for name %q and owner %q", modelerrors.AlreadyExists, input.Name, input.Owner)
 	} else if err != nil {
-		return fmt.Errorf("setting model %q information: %w", input.UUID, err)
+		return fmt.Errorf("setting model %q information: %w", modelID, err)
 	}
 
 	if num, err := res.RowsAffected(); err != nil {
@@ -453,19 +518,15 @@ WHERE model_type.type = ?
 		return fmt.Errorf("creating model metadata, expected 1 row to be inserted, got %d", num)
 	}
 
-	if err := setCloudRegion(ctx, input.UUID, input.Cloud, input.CloudRegion, tx); err != nil {
-		return fmt.Errorf("setting cloud region for model %q: %w", input.UUID, err)
+	if err := setCloudRegion(ctx, modelID, input.Cloud, input.CloudRegion, tx); err != nil {
+		return fmt.Errorf("setting cloud region for model %q: %w", modelID, err)
 	}
 
 	if !input.Credential.IsZero() {
-		err := updateCredential(ctx, tx, input.UUID, input.Credential)
+		err := updateCredential(ctx, tx, modelID, input.Credential)
 		if err != nil {
-			return fmt.Errorf("setting cloud credential for model %q: %w", input.UUID, err)
+			return fmt.Errorf("setting cloud credential for model %q: %w", modelID, err)
 		}
-	}
-
-	if err = addOwnerPermissions(ctx, tx, input.UUID.String(), input.Owner.String()); err != nil {
-		return err
 	}
 
 	return nil
@@ -1121,9 +1182,15 @@ AND cloud_uuid = ?
 	return nil
 }
 
-// addOwnerPermissions inserts an Admin permission for the owner on the given
-// model during create model. The caller has already validated the user exists.
-func addOwnerPermissions(ctx context.Context, tx *sql.Tx, modelUUID, ownerUUID string) error {
+// addAdminPermission adds an Admin permission for the supplied user to the
+// given model. If the user already has admin permissions onto the model a
+// [usererrors.PermissionAlreadyExists] error is returned.
+func addAdminPermissions(
+	ctx context.Context,
+	tx *sql.Tx,
+	modelUUID coremodel.UUID,
+	ownerUUID coreuser.UUID,
+) error {
 	permUUID, err := internaluuid.NewUUID()
 	if err != nil {
 		return err

--- a/domain/model/state/testing/model.go
+++ b/domain/model/state/testing/model.go
@@ -136,6 +136,7 @@ func CreateTestModel(
 	modelSt := modelstate.NewState(txnRunner)
 	err = modelSt.Create(
 		context.Background(),
+		modelUUID,
 		coremodel.IAAS,
 		model.ModelCreationArgs{
 			AgentVersion: version.Current,
@@ -145,9 +146,9 @@ func CreateTestModel(
 				Owner: name,
 				Name:  "foobar",
 			},
-			Name:  name,
-			Owner: userUUID,
-			UUID:  modelUUID,
+			Name:          name,
+			Owner:         userUUID,
+			SecretBackend: juju.BackendName,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/domain/modelconfig/bootstrap/bootstrap_test.go
+++ b/domain/modelconfig/bootstrap/bootstrap_test.go
@@ -77,18 +77,20 @@ func (s *bootstrapSuite) SetUpTest(c *gc.C) {
 	testing.CreateInternalSecretBackend(c, s.ControllerTxnRunner())
 
 	modelUUID := modeltesting.GenModelUUID(c)
-	modelFn := modelbootstrap.CreateModel(model.ModelCreationArgs{
-		AgentVersion: jujuversion.Current,
-		Cloud:        cloudName,
-		Credential: credential.Key{
-			Cloud: cloudName,
-			Name:  credentialName,
-			Owner: coreuser.AdminUserName,
+	modelFn := modelbootstrap.CreateModel(
+		modelUUID,
+		model.ModelCreationArgs{
+			AgentVersion: jujuversion.Current,
+			Cloud:        cloudName,
+			Credential: credential.Key{
+				Cloud: cloudName,
+				Name:  credentialName,
+				Owner: coreuser.AdminUserName,
+			},
+			Name:  "test",
+			Owner: userID,
 		},
-		Name:  "test",
-		Owner: userID,
-		UUID:  modelUUID,
-	})
+	)
 	s.modelID = modelUUID
 
 	err = modelFn(context.Background(), s.ControllerTxnRunner(), s.ControllerSuite.NoopTxnRunner())

--- a/domain/modelconfig/modelconfig_test.go
+++ b/domain/modelconfig/modelconfig_test.go
@@ -78,7 +78,7 @@ func (s *modelConfigSuite) SetUpTest(c *gc.C) {
 	testing.CreateInternalSecretBackend(c, s.ControllerTxnRunner())
 
 	modelUUID := modeltesting.GenModelUUID(c)
-	modelFn := modelbootstrap.CreateModel(domainmodel.ModelCreationArgs{
+	modelFn := modelbootstrap.CreateModel(modelUUID, domainmodel.ModelCreationArgs{
 		AgentVersion: jujuversion.Current,
 		Cloud:        cloudName,
 		Credential: credential.Key{
@@ -88,7 +88,6 @@ func (s *modelConfigSuite) SetUpTest(c *gc.C) {
 		},
 		Name:  "test",
 		Owner: userID,
-		UUID:  modelUUID,
 	})
 	s.modelID = modelUUID
 

--- a/domain/modelconfig/service/service.go
+++ b/domain/modelconfig/service/service.go
@@ -213,14 +213,20 @@ func (s *Service) SetModelConfig(
 		return fmt.Errorf("getting model defaults: %w", err)
 	}
 
+	// We want to make a copy of cfg so that we don't modify the users input.
+	cfgCopy := make(map[string]any, len(cfg))
+	for k, v := range cfg {
+		cfgCopy[k] = v
+	}
+
 	for k, v := range defaults {
-		applyVal := v.ApplyStrategy(cfg[k])
+		applyVal := v.ApplyStrategy(cfgCopy[k])
 		if applyVal != nil {
-			cfg[k] = applyVal
+			cfgCopy[k] = applyVal
 		}
 	}
 
-	setCfg, err := config.New(config.NoDefaults, cfg)
+	setCfg, err := config.New(config.NoDefaults, cfgCopy)
 	if err != nil {
 		return fmt.Errorf("constructing new model config with model defaults: %w", err)
 	}

--- a/domain/secretbackend/state/state_test.go
+++ b/domain/secretbackend/state/state_test.go
@@ -173,6 +173,7 @@ func (s *stateSuite) createModelWithName(c *gc.C, modelType coremodel.ModelType,
 	modelSt := modelestate.NewState(s.TxnRunnerFactory())
 	err = modelSt.Create(
 		context.Background(),
+		modelUUID,
 		modelType,
 		model.ModelCreationArgs{
 			AgentVersion: version.Current,
@@ -183,9 +184,9 @@ func (s *stateSuite) createModelWithName(c *gc.C, modelType coremodel.ModelType,
 				Owner: "test-user",
 				Name:  "foobar",
 			},
-			Name:  name,
-			Owner: userUUID,
-			UUID:  modelUUID,
+			Name:          name,
+			Owner:         userUUID,
+			SecretBackend: "my-backend",
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/domain/servicefactory/testing/suite.go
+++ b/domain/servicefactory/testing/suite.go
@@ -145,10 +145,9 @@ func (s *ServiceFactorySuite) SeedModelDatabases(c *gc.C) {
 		Credential:   s.CredentialKey,
 		Name:         coremodel.ControllerModelName,
 		Owner:        s.AdminUserUUID,
-		UUID:         s.ControllerModelUUID,
 	}
 
-	fn := modelbootstrap.CreateModel(controllerArgs)
+	fn := modelbootstrap.CreateModel(s.ControllerModelUUID, controllerArgs)
 	c.Assert(backendbootstrap.CreateDefaultBackends(coremodel.IAAS)(
 		ctx, s.ControllerTxnRunner(), s.ModelTxnRunner(c, s.ControllerModelUUID.String())), jc.ErrorIsNil)
 	err = fn(ctx, s.ControllerTxnRunner(), s.NoopTxnRunner())
@@ -171,10 +170,9 @@ func (s *ServiceFactorySuite) SeedModelDatabases(c *gc.C) {
 		Credential:   s.CredentialKey,
 		Name:         "test",
 		Owner:        s.AdminUserUUID,
-		UUID:         s.DefaultModelUUID,
 	}
 
-	fn = modelbootstrap.CreateModel(modelArgs)
+	fn = modelbootstrap.CreateModel(s.DefaultModelUUID, modelArgs)
 	err = fn(ctx, s.ControllerTxnRunner(), s.NoopTxnRunner())
 	c.Assert(err, jc.ErrorIsNil)
 


### PR DESCRIPTION

Reworks model creation id generation.
    
When creating models in DQlite via the service we use a
ModelCreationArgs struct that drives all of the meta data associated with
the model. Via previous changes we were putting the responsibility back
on to the caller of the create model process to generate model id.
    
This is an anti pattern that we want to remove entirely as it should the
services layer generating this and returning it to the caller. This
change the caller now receives the model id back as a return value.
    
There still exists two cases where the model id will be supplied
upfront. The first is via model migration where we are importing a model
that already exists and so we must use the id that has already been
established. The second is during a controller bootstrap when making the
controller model. This second case we can eventually get rid of and move
to the same pattern as the rest of the call sites but it will require
some big re-work to the Juju client at a later stage.
    
This commit also makes changes to secret back end selection for newly
created models. In previous commits a decision was made to pick a models
"default" secret back end in the sate layer. There was no reason to have
done this as all the context required is at the services layer. The code
has been moved one level up and removes the need to do more computation
inside of a transaction.
    
Renamed owner permission function for new models so that it now reflects
intent correctly. That is when creating a new model we wish to grant the
owner of the model admin permissions.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

This change is a re-work of what we already had. However while unit tests will be enough it would also be good to run a `juju bootstrap` and also add a few models and delete them.

## Documentation changes

N/A

