### PR TITLE
Remove series from charm URL and bundle data

### DIFF
--- a/cmd/juju/application/deployer/bundlehandler_test.go
+++ b/cmd/juju/application/deployer/bundlehandler_test.go
@@ -371,14 +371,14 @@ func (s *BundleDeployRepositorySuite) expectK8sCharm(curl *charm.URL, rev int) *
 	).DoAndReturn(
 		// Ensure the same curl that is provided, is returned.
 		func(curl *charm.URL, origin commoncharm.Origin, switchCharm bool) (*charm.URL, commoncharm.Origin, []corebase.Base, error) {
-			curl = curl.WithRevision(rev).WithSeries("focal").WithArchitecture("amd64")
+			curl = curl.WithRevision(rev).WithArchitecture("amd64")
 			origin.Base = corebase.MakeDefaultBase("ubuntu", "20.04")
 			origin.Revision = &rev
 			origin.Type = "charm"
 			return curl, origin, []corebase.Base{corebase.MustParseBaseFromString("ubuntu@20.04")}, nil
 		}).Times(3)
 
-	fullCurl := curl.WithSeries("focal").WithRevision(rev).WithArchitecture("amd64")
+	fullCurl := curl.WithRevision(rev).WithArchitecture("amd64")
 	s.deployerAPI.EXPECT().AddCharm(
 		fullCurl,
 		gomock.AssignableToTypeOf(commoncharm.Origin{}),
@@ -461,7 +461,6 @@ func (s *BundleDeployRepositorySuite) expectK8sCharmByRevision(curl *charm.URL, 
 		// Ensure the same curl that is provided, is returned.
 		func(curl *charm.URL, origin commoncharm.Origin, switchCharm bool) (*charm.URL, commoncharm.Origin, []corebase.Base, error) {
 			curl = curl.WithRevision(rev)
-			curl = curl.WithSeries("focal")
 			curl = curl.WithArchitecture("amd64")
 			origin.Base = corebase.MakeDefaultBase("ubuntu", "20.04")
 			origin.Revision = &rev
@@ -469,7 +468,7 @@ func (s *BundleDeployRepositorySuite) expectK8sCharmByRevision(curl *charm.URL, 
 			return curl, origin, []corebase.Base{corebase.MustParseBaseFromString("ubuntu@20.04")}, nil
 		}).Times(2)
 
-	fullCurl := curl.WithSeries("focal").WithRevision(rev).WithArchitecture("amd64")
+	fullCurl := curl.WithRevision(rev).WithArchitecture("amd64")
 	s.deployerAPI.EXPECT().AddCharm(
 		fullCurl,
 		gomock.AssignableToTypeOf(commoncharm.Origin{}),

--- a/internal/charm/bundledata_test.go
+++ b/internal/charm/bundledata_test.go
@@ -294,7 +294,6 @@ saas:
 applications:
     wordpress:
       charm: "ch:wordpress"
-      series: "trusty"
       revision: 10
       num_units: 1
 relations:
@@ -310,7 +309,6 @@ relations:
 		Applications: map[string]*charm.ApplicationSpec{
 			"wordpress": {
 				Charm:    "ch:wordpress",
-				Series:   "trusty",
 				Revision: &ten,
 				NumUnits: 1,
 			},
@@ -326,7 +324,6 @@ applications:
     wordpress:
       charm: "wordpress"
       revision: 10
-      series: trusty
       channel: edge
       num_units: 1
 `,
@@ -337,7 +334,6 @@ applications:
 				Channel:  "edge",
 				Revision: &ten,
 				NumUnits: 1,
-				Series:   "trusty",
 			},
 		},
 	},
@@ -406,13 +402,12 @@ func (*bundleDataSuite) TestCodecRoundTrip(c *gc.C) {
 	}
 }
 
-func (*bundleDataSuite) TestParseLocalWithSeries(c *gc.C) {
+func (*bundleDataSuite) TestParseLocal(c *gc.C) {
 	path := "internal/test-charm-repo/quanta/riak"
 	data := fmt.Sprintf(`
         applications:
             dummy:
                 charm: %s
-                series: xenial
                 num_units: 1
     `, path)
 	bd, err := charm.ReadBundleData(strings.NewReader(data))
@@ -421,7 +416,6 @@ func (*bundleDataSuite) TestParseLocalWithSeries(c *gc.C) {
 		Applications: map[string]*charm.ApplicationSpec{
 			"dummy": {
 				Charm:    path,
-				Series:   "xenial",
 				NumUnits: 1,
 			},
 		}})
@@ -446,7 +440,6 @@ var verifyErrorsTests = []struct {
 }{{
 	about: "as many errors as possible",
 	data: `
-series: "9wrong"
 default-base: "invalidbase"
 
 saas:
@@ -459,7 +452,6 @@ machines:
         constraints: 'bad constraints'
         annotations:
             foo: bar
-        series: 'bad series'
         base: 'bad base'
     bogus:
     3:
@@ -499,7 +491,6 @@ applications:
           charm: wordpress
     postgres:
         charm: "postgres"
-        series: trusty
     terracotta:
         charm: "terracotta"
         base: "ubuntu@22.04"
@@ -524,7 +515,6 @@ relations:
     - ["wordpress:db", "riak:db"]
 `,
 	errors: []string{
-		`bundle declares an invalid series "9wrong"`,
 		`bundle declares an invalid base "invalidbase"`,
 		`invalid offer URL "!some-bogus/url" for SAAS apache2`,
 		`invalid storage name "no_underscores" in application "ceph"`,
@@ -549,7 +539,6 @@ relations:
 		`relation ["mysql:db" "mediawiki:db"] is defined more than once`,
 		`invalid placement syntax "bad placement"`,
 		`invalid relation syntax "mediawiki/db"`,
-		`invalid series "bad series" for machine "0"`,
 		`invalid base "bad base" for machine "0"`,
 		`ambiguous relation "riak" refers to a application and a SAAS in this bundle`,
 		`SAAS "riak" already exists with application "riak" name`,
@@ -765,7 +754,6 @@ applications:
         charm: "gitlab-k8s"
         num_units: 3
         to: [foo=baz]
-        series: kubernetes
     redis:
         charm: "redis-k8s"
         scale: 3
@@ -785,7 +773,6 @@ applications:
 			},
 			"gitlab": {
 				Charm:    "gitlab-k8s",
-				Series:   "kubernetes",
 				To:       []string{"foo=baz"},
 				NumUnits: 3,
 			},
@@ -854,7 +841,6 @@ applications:
 func (s *bundleDataSuite) TestKubernetesBundleErrors(c *gc.C) {
 	data := `
 bundle: "kubernetes"
-series: "xenial"
 
 machines:
     0:
@@ -862,7 +848,6 @@ machines:
 applications:
     mariadb:
         charm: "mariadb-k8s"
-        series: "xenial"
         scale: 2
     casandra:
         charm: "casnadra-k8s"

--- a/internal/charm/meta.go
+++ b/internal/charm/meta.go
@@ -821,12 +821,6 @@ func (m Meta) Check(format Format, reasons ...FormatSelectionReason) error {
 		}
 	}
 
-	for _, series := range m.Series {
-		if !IsValidSeries(series) {
-			return errors.Errorf("charm %q declares invalid series: %q", m.Name, series)
-		}
-	}
-
 	names = make(map[string]bool)
 	for name, store := range m.Storage {
 		if store.Location != "" && store.Type != StorageFilesystem {

--- a/internal/charm/meta_test.go
+++ b/internal/charm/meta_test.go
@@ -565,18 +565,6 @@ func (s *MetaSuite) TestSeries(c *gc.C) {
 	c.Assert(meta.Series, gc.DeepEquals, []string{"precise", "trusty", "plan9"})
 }
 
-func (s *MetaSuite) TestCheckInvalidSeries(c *gc.C) {
-	for _, seriesName := range []string{"pre-c1se", "pre^cise", "cp/m", "OpenVMS"} {
-		err := charm.Meta{
-			Name:        "a",
-			Summary:     "b",
-			Description: "c",
-			Series:      []string{seriesName},
-		}.Check(charm.FormatV1)
-		c.Check(err, gc.ErrorMatches, `charm "a" declares invalid series: .*`)
-	}
-}
-
 func (s *MetaSuite) TestMinJujuVersion(c *gc.C) {
 	// series not specified
 	meta, err := charm.ReadMeta(strings.NewReader(dummyMetadata))

--- a/internal/charm/overlay.go
+++ b/internal/charm/overlay.go
@@ -593,9 +593,9 @@ func applyOverlay(base, overlay *BundleDataPart) error {
 		}
 	}
 
-	// If series is set in the config, it overrides the bundle.
-	if series := overlay.Data.Series; series != "" {
-		base.Data.Series = series
+	// If default base is set in the config, it overrides the bundle.
+	if b := overlay.Data.DefaultBase; b != "" {
+		base.Data.DefaultBase = b
 	}
 
 	// Append any additional relations.

--- a/internal/charm/overlay_test.go
+++ b/internal/charm/overlay_test.go
@@ -29,11 +29,9 @@ func (*bundleDataOverlaySuite) TestEmptyBaseApplication(c *gc.C) {
 applications:
   apache2:
 ---
-series: trusty
 applications:
   apache2:
     charm: cs:apache2-42
-    series: bionic
 `[1:]
 
 	_, err := charm.ReadAndMergeBundleData(mustCreateStringDataSource(c, data))
@@ -65,7 +63,6 @@ applications:
 saas:
     apache2:
         url: production:admin/info.apache
-series: bionic
 `[1:]
 
 	expBase := `
@@ -75,7 +72,6 @@ applications:
 saas:
   apache2:
     url: production:admin/info.apache
-series: bionic
 `[1:]
 
 	expOverlay := `
@@ -272,7 +268,6 @@ applications:
 saas:
     apache2:
         url: production:admin/info.apache
-series: bionic
 `
 
 	bd, err := charm.ReadBundleData(strings.NewReader(data))
@@ -311,7 +306,6 @@ applications:
     options:
       foo: bar
       ssl_ca: *ssl_ca
-series: bionic
 `
 
 	bd, err := charm.ReadBundleData(strings.NewReader(data))
@@ -323,25 +317,21 @@ series: bionic
 	c.Assert(charm.VerifyNoOverlayFieldsPresent(static), gc.Equals, nil)
 }
 
-func (*bundleDataOverlaySuite) TestOverrideCharmAndSeries(c *gc.C) {
+func (*bundleDataOverlaySuite) TestOverrideCharm(c *gc.C) {
 	testBundleMergeResult(c, `
 applications:
   apache2:
     charm: apache2
     num_units: 1
 ---
-series: trusty
 applications:
   apache2:
     charm: cs:apache2-42
-    series: bionic
 `, `
 applications:
   apache2:
     charm: cs:apache2-42
-    series: bionic
     num_units: 1
-series: trusty
 `,
 	)
 }
@@ -679,7 +669,6 @@ applications:
     memcached:
         charm: mem
         revision: 47
-        series: trusty
         num_units: 1
         options:
             key: value
@@ -699,7 +688,6 @@ applications:
 defaultwiki: &DEFAULTWIKI
     charm: "mediawiki"
     revision: 5
-    series: trusty
     num_units: 1
     options: &WIKIOPTS
         debug: false
@@ -732,14 +720,12 @@ applications:
   memcached:
     charm: mem
     revision: 47
-    series: trusty
     num_units: 1
     options:
       key: value
   wiki:
     charm: mediawiki
     revision: 5
-    series: trusty
     num_units: 1
     options:
       debug: false

--- a/internal/charm/url_test.go
+++ b/internal/charm/url_test.go
@@ -26,71 +26,71 @@ var urlTests = []struct {
 	exact  string
 	url    *charm.URL
 }{{
-	s:   "local:series/name-1",
-	url: &charm.URL{Schema: "local", Name: "name", Revision: 1, Series: "series", Architecture: ""},
-}, {
-	s:   "local:series/name",
-	url: &charm.URL{Schema: "local", Name: "name", Revision: -1, Series: "series", Architecture: ""},
-}, {
-	s:   "local:series/n0-0n-n0",
-	url: &charm.URL{Schema: "local", Name: "n0-0n-n0", Revision: -1, Series: "series", Architecture: ""},
+	s:   "local:name-1",
+	url: &charm.URL{Schema: "local", Name: "name", Revision: 1, Architecture: ""},
 }, {
 	s:   "local:name",
-	url: &charm.URL{Schema: "local", Name: "name", Revision: -1, Series: "", Architecture: ""},
+	url: &charm.URL{Schema: "local", Name: "name", Revision: -1, Architecture: ""},
 }, {
-	s:   "bs:~user/series/name-1",
+	s:   "local:n0-0n-n0",
+	url: &charm.URL{Schema: "local", Name: "n0-0n-n0", Revision: -1, Architecture: ""},
+}, {
+	s:   "local:name",
+	url: &charm.URL{Schema: "local", Name: "name", Revision: -1, Architecture: ""},
+}, {
+	s:   "bs:~user/name-1",
 	err: `cannot parse URL $URL: schema "bs" not valid`,
 }, {
 	s:   ":foo",
 	err: `cannot parse charm or bundle URL: $URL`,
 }, {
-	s:   "local:~user/series/name",
+	s:   "local:~user/name",
 	err: `local charm or bundle URL with user name: $URL`,
 }, {
 	s:   "local:~user/name",
 	err: `local charm or bundle URL with user name: $URL`,
 }, {
 	s:     "amd64/name",
-	url:   &charm.URL{Schema: "ch", Name: "name", Revision: -1, Series: "", Architecture: "amd64"},
+	url:   &charm.URL{Schema: "ch", Name: "name", Revision: -1, Architecture: "amd64"},
 	exact: "ch:amd64/name",
 }, {
 	s:     "foo",
-	url:   &charm.URL{Schema: "ch", Name: "foo", Revision: -1, Series: "", Architecture: ""},
+	url:   &charm.URL{Schema: "ch", Name: "foo", Revision: -1, Architecture: ""},
 	exact: "ch:foo",
 }, {
 	s:     "foo-1",
 	exact: "ch:foo-1",
-	url:   &charm.URL{Schema: "ch", Name: "foo", Revision: 1, Series: "", Architecture: ""},
+	url:   &charm.URL{Schema: "ch", Name: "foo", Revision: 1, Architecture: ""},
 }, {
 	s:     "n0-n0-n0",
 	exact: "ch:n0-n0-n0",
-	url:   &charm.URL{Schema: "ch", Name: "n0-n0-n0", Revision: -1, Series: "", Architecture: ""},
+	url:   &charm.URL{Schema: "ch", Name: "n0-n0-n0", Revision: -1, Architecture: ""},
 }, {
 	s:     "local:foo",
 	exact: "local:foo",
-	url:   &charm.URL{Schema: "local", Name: "foo", Revision: -1, Series: "", Architecture: ""},
+	url:   &charm.URL{Schema: "local", Name: "foo", Revision: -1, Architecture: ""},
 }, {
-	s:     "arm64/series/bar",
-	url:   &charm.URL{Schema: "ch", Name: "bar", Revision: -1, Series: "series", Architecture: "arm64"},
-	exact: "ch:arm64/series/bar",
+	s:     "arm64/bar",
+	url:   &charm.URL{Schema: "ch", Name: "bar", Revision: -1, Architecture: "arm64"},
+	exact: "ch:arm64/bar",
 }, {
 	s:   "ch:name",
-	url: &charm.URL{Schema: "ch", Name: "name", Revision: -1, Series: "", Architecture: ""},
+	url: &charm.URL{Schema: "ch", Name: "name", Revision: -1, Architecture: ""},
 }, {
 	s:   "ch:name-suffix",
-	url: &charm.URL{Schema: "ch", Name: "name-suffix", Revision: -1, Series: "", Architecture: ""},
+	url: &charm.URL{Schema: "ch", Name: "name-suffix", Revision: -1, Architecture: ""},
 }, {
 	s:   "ch:name-1",
-	url: &charm.URL{Schema: "ch", Name: "name", Revision: 1, Series: "", Architecture: ""},
+	url: &charm.URL{Schema: "ch", Name: "name", Revision: 1, Architecture: ""},
 }, {
-	s:   "ch:focal/istio-gateway-74",
-	url: &charm.URL{Schema: "ch", Name: "istio-gateway", Revision: 74, Series: "focal", Architecture: ""},
+	s:   "ch:istio-gateway-74",
+	url: &charm.URL{Schema: "ch", Name: "istio-gateway", Revision: 74, Architecture: ""},
 }, {
 	s:   "ch:amd64/istio-gateway-74",
-	url: &charm.URL{Schema: "ch", Name: "istio-gateway", Revision: 74, Series: "", Architecture: "amd64"},
+	url: &charm.URL{Schema: "ch", Name: "istio-gateway", Revision: 74, Architecture: "amd64"},
 }, {
 	s:     "ch:arm64/name",
-	url:   &charm.URL{Schema: "ch", Name: "name", Revision: -1, Series: "", Architecture: "arm64"},
+	url:   &charm.URL{Schema: "ch", Name: "name", Revision: -1, Architecture: "arm64"},
 	exact: "ch:arm64/name",
 }, {
 	s:   "ch:~user/name",
@@ -141,7 +141,7 @@ var ensureSchemaTests = []struct {
 	{input: "foo", expected: "ch:foo"},
 	{input: "foo-1", expected: "ch:foo-1"},
 	{input: "~user/foo", expected: "ch:~user/foo"},
-	{input: "series/foo", expected: "ch:series/foo"},
+	{input: "foo", expected: "ch:foo"},
 	{input: "local:foo", expected: "local:foo"},
 	{
 		input: "unknown:foo",
@@ -149,7 +149,7 @@ var ensureSchemaTests = []struct {
 	},
 }
 
-func (s *URLSuite) TestInferURLNoDefaultSeries(c *gc.C) {
+func (s *URLSuite) TestInferURL(c *gc.C) {
 	for i, t := range ensureSchemaTests {
 		c.Logf("%d: %s", i, t.input)
 		inferred, err := charm.EnsureSchema(t.input, charm.CharmHub)
@@ -181,19 +181,6 @@ var validTests = []struct {
 	{valid: charm.IsValidName, string: "wordpress-2", expect: false},
 	{valid: charm.IsValidName, string: "word2-press2", expect: true},
 
-	{valid: charm.IsValidSeries, string: "", expect: false},
-	{valid: charm.IsValidSeries, string: "precise", expect: true},
-	{valid: charm.IsValidSeries, string: "Precise", expect: false},
-	{valid: charm.IsValidSeries, string: "pre cise", expect: false},
-	{valid: charm.IsValidSeries, string: "pre-cise", expect: false},
-	{valid: charm.IsValidSeries, string: "pre^cise", expect: false},
-	{valid: charm.IsValidSeries, string: "prec1se", expect: true},
-	{valid: charm.IsValidSeries, string: "-precise", expect: false},
-	{valid: charm.IsValidSeries, string: "precise-", expect: false},
-	{valid: charm.IsValidSeries, string: "precise-1", expect: false},
-	{valid: charm.IsValidSeries, string: "precise1", expect: true},
-	{valid: charm.IsValidSeries, string: "pre-c1se", expect: false},
-
 	{valid: charm.IsValidArchitecture, string: "amd64", expect: true},
 	{valid: charm.IsValidArchitecture, string: "~amd64", expect: false},
 	{valid: charm.IsValidArchitecture, string: "not-an-arch", expect: false},
@@ -207,17 +194,15 @@ func (s *URLSuite) TestValidCheckers(c *gc.C) {
 }
 
 func (s *URLSuite) TestMustParseURL(c *gc.C) {
-	url := charm.MustParseURL("ch:series/name")
-	c.Assert(url, gc.DeepEquals, &charm.URL{Schema: "ch", Name: "name", Revision: -1, Series: "series", Architecture: ""})
-	f := func() { charm.MustParseURL("local:@@/name") }
-	c.Assert(f, gc.PanicMatches, "cannot parse URL \"local:@@/name\": series name \"@@\" not valid")
+	url := charm.MustParseURL("ch:name")
+	c.Assert(url, gc.DeepEquals, &charm.URL{Schema: "ch", Name: "name", Revision: -1, Architecture: ""})
 }
 
 func (s *URLSuite) TestWithRevision(c *gc.C) {
-	url := charm.MustParseURL("ch:series/name")
+	url := charm.MustParseURL("ch:name")
 	other := url.WithRevision(1)
-	c.Assert(url, gc.DeepEquals, &charm.URL{Schema: "ch", Name: "name", Revision: -1, Series: "series", Architecture: ""})
-	c.Assert(other, gc.DeepEquals, &charm.URL{Schema: "ch", Name: "name", Revision: 1, Series: "series", Architecture: ""})
+	c.Assert(url, gc.DeepEquals, &charm.URL{Schema: "ch", Name: "name", Revision: -1, Architecture: ""})
+	c.Assert(other, gc.DeepEquals, &charm.URL{Schema: "ch", Name: "name", Revision: 1, Architecture: ""})
 
 	// Should always copy. The opposite behavior is error prone.
 	c.Assert(other.WithRevision(1), gc.Not(gc.Equals), other)


### PR DESCRIPTION
Remove references to series in internal charm code related to charm url and bundles

For the case of charm urls, to ensure we can still parse existing charm urls, we do not remove the series attribute as such, but instead make it private. It is then only accessible via stringifying a url. This ensures that parsing then stringifying a charm url does not change it's value.

For the time being keep references to series in charm metadata. Wait until we remove support for this in Juju itself

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Juju compiles

```
juju bootstrap lxd lxd
juju add-model m
juju deploy ubuntu
```

## Links

**Jira card:** [JUJU-5996](https://warthogs.atlassian.net/browse/JUJU-5996)



[JUJU-5996]: https://warthogs.atlassian.net/browse/JUJU-5996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ