### PR TITLE
Secret rotation watcher

### DIFF
--- a/core/watcher/secrets.go
+++ b/core/watcher/secrets.go
@@ -18,6 +18,16 @@ type SecretTriggerChange struct {
 	NextTriggerTime time.Time
 }
 
+// String returns a string representation of the change.
+func (s SecretTriggerChange) String() string {
+	str := s.URI.String()
+	if s.Revision > 0 {
+		str = fmt.Sprintf("%s/%d", s.URI.String(), s.Revision)
+	}
+	return str
+}
+
+// GoString returns a Go-syntax representation of the change.
 func (s SecretTriggerChange) GoString() string {
 	revMsg := ""
 	if s.Revision > 0 {

--- a/core/watcher/watchertest/secrets.go
+++ b/core/watcher/watchertest/secrets.go
@@ -14,6 +14,63 @@ import (
 	"github.com/juju/juju/testing"
 )
 
+// SecretsTriggerWatcherC embeds a gocheck.C and adds methods to help
+// verify the behaviour of any watcher that uses a
+// <-chan []SecretTriggerChange
+type SecretsTriggerWatcherC struct {
+	*gc.C
+	Watcher watcher.SecretTriggerWatcher
+}
+
+// NewSecretsTriggerWatcherC returns a SecretsTriggerWatcherC that
+// checks for aggressive event coalescence.
+func NewSecretsTriggerWatcherC(c *gc.C, w watcher.SecretTriggerWatcher) SecretsTriggerWatcherC {
+	return SecretsTriggerWatcherC{
+		C:       c,
+		Watcher: w,
+	}
+}
+
+func (c SecretsTriggerWatcherC) AssertNoChange() {
+	select {
+	case actual, ok := <-c.Watcher.Changes():
+		c.Fatalf("watcher sent unexpected change: (%v, %v)", actual, ok)
+	case <-time.After(testing.ShortWait):
+	}
+}
+
+// AssertChange asserts the given changes was reported by the watcher,
+// but does not assume there are no following changes.
+func (c SecretsTriggerWatcherC) AssertChange(expect ...watcher.SecretTriggerChange) {
+	var received []watcher.SecretTriggerChange
+	timeout := time.After(testing.LongWait)
+	for a := testing.LongAttempt.Start(); a.Next(); {
+		select {
+		case actual, ok := <-c.Watcher.Changes():
+			c.Logf("Secrets Trigger Watcher.Changes() => %# v", actual)
+			c.Assert(ok, jc.IsTrue)
+			received = append(received, actual...)
+			if len(received) >= len(expect) {
+				mc := jc.NewMultiChecker()
+				mc.AddExpr(`_[_].NextTriggerTime`, jc.Almost, jc.ExpectedValue)
+				c.Assert(received, mc, expect)
+				return
+			}
+		case <-timeout:
+			c.Fatalf("watcher did not send change")
+		}
+	}
+}
+
+func (c SecretsTriggerWatcherC) AssertClosed() {
+	select {
+	case _, ok := <-c.Watcher.Changes():
+		c.Assert(ok, jc.IsFalse)
+	default:
+		c.Fatalf("watcher not closed")
+	}
+}
+
 // SecretBackendRotateWatcherC embeds a gocheck.C and adds methods to help
 // verify the behaviour of any watcher that uses a
 // <-chan []SecretBackendRotateChange

--- a/domain/secret/service/service.go
+++ b/domain/secret/service/service.go
@@ -86,7 +86,7 @@ type State interface {
 	InitialWatchStatementForRemoteConsumedSecretsChangesFromOfferingSide(appName string) (string, eventsource.NamespaceQuery)
 	GetRemoteConsumedSecretURIsWithChangesFromOfferingSide(ctx context.Context, appName string, secretIDs ...string) ([]string, error)
 
-	// For watching secret retation changes.
+	// For watching secret rotation changes.
 	InitialWatchStatementForSecretsRotationChanges(
 		appOwners domainsecret.ApplicationOwners, unitOwners domainsecret.UnitOwners,
 	) (string, eventsource.NamespaceQuery)
@@ -430,13 +430,13 @@ func (s *SecretService) ListCharmSecrets(ctx context.Context, owners ...CharmSec
 }
 
 // GetSecret returns the secret with the specified URI.
-// If returns [secreterrors.SecretNotFound] is there's no such domainsecret.
+// If returns [secreterrors.SecretNotFound] is there's no such secret.
 func (s *SecretService) GetSecret(ctx context.Context, uri *secrets.URI) (*secrets.SecretMetadata, error) {
 	return s.st.GetSecret(ctx, uri)
 }
 
 // GetUserSecretURIByLabel returns the user secret URI with the specified label.
-// If returns [secreterrors.SecretNotFound] is there's no such domainsecret.
+// If returns [secreterrors.SecretNotFound] is there's no such secret.
 func (s *SecretService) GetUserSecretURIByLabel(ctx context.Context, label string) (*secrets.URI, error) {
 	return s.st.GetUserSecretURIByLabel(ctx, label)
 }
@@ -519,7 +519,7 @@ func (s *SecretService) GetSecretContentFromBackend(ctx context.Context, uri *se
 	}
 }
 
-// ProcessCharmSecretConsumerLabel takes a secret consumer and a uri and label which have been used to consumer the domainsecret.
+// ProcessCharmSecretConsumerLabel takes a secret consumer and a uri and label which have been used to consumer the secret.
 // If the uri is empty, the label and consumer are used to lookup the consumed secret uri.
 // This method returns the resulting uri, and optionally the label to update for the consumer.
 func (s *SecretService) ProcessCharmSecretConsumerLabel(
@@ -652,7 +652,7 @@ func (s *WatchableService) GetSecretBackendID(ctx context.Context) (string, erro
 }
 
 // ChangeSecretBackend sets the secret backend where the specified secret revision is stored.
-// It returns [secreterrors.SecretNotFound] is there's no such domainsecret.
+// It returns [secreterrors.SecretNotFound] is there's no such secret.
 // It returns [secreterrors.PermissionDenied] if the secret cannot be managed by the accessor.
 func (s *SecretService) ChangeSecretBackend(ctx context.Context, uri *secrets.URI, revision int, params ChangeSecretBackendParams) error {
 	if err := s.canManage(ctx, uri, params.Accessor, params.LeaderToken); err != nil {

--- a/domain/secret/service/state_mock_test.go
+++ b/domain/secret/service/state_mock_test.go
@@ -764,6 +764,50 @@ func (c *MockStateGetSecretValueCall) DoAndReturn(f func(context.Context, *secre
 	return c
 }
 
+// GetSecretsRotationChanges mocks base method.
+func (m *MockState) GetSecretsRotationChanges(arg0 context.Context, arg1 secret.ApplicationOwners, arg2 secret.UnitOwners, arg3 ...string) ([]secret.RotationInfo, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{arg0, arg1, arg2}
+	for _, a := range arg3 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "GetSecretsRotationChanges", varargs...)
+	ret0, _ := ret[0].([]secret.RotationInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSecretsRotationChanges indicates an expected call of GetSecretsRotationChanges.
+func (mr *MockStateMockRecorder) GetSecretsRotationChanges(arg0, arg1, arg2 any, arg3 ...any) *MockStateGetSecretsRotationChangesCall {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{arg0, arg1, arg2}, arg3...)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecretsRotationChanges", reflect.TypeOf((*MockState)(nil).GetSecretsRotationChanges), varargs...)
+	return &MockStateGetSecretsRotationChangesCall{Call: call}
+}
+
+// MockStateGetSecretsRotationChangesCall wrap *gomock.Call
+type MockStateGetSecretsRotationChangesCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateGetSecretsRotationChangesCall) Return(arg0 []secret.RotationInfo, arg1 error) *MockStateGetSecretsRotationChangesCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateGetSecretsRotationChangesCall) Do(f func(context.Context, secret.ApplicationOwners, secret.UnitOwners, ...string) ([]secret.RotationInfo, error)) *MockStateGetSecretsRotationChangesCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateGetSecretsRotationChangesCall) DoAndReturn(f func(context.Context, secret.ApplicationOwners, secret.UnitOwners, ...string) ([]secret.RotationInfo, error)) *MockStateGetSecretsRotationChangesCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetURIByConsumerLabel mocks base method.
 func (m *MockState) GetURIByConsumerLabel(arg0 context.Context, arg1, arg2 string) (*secrets.URI, error) {
 	m.ctrl.T.Helper()
@@ -1032,6 +1076,45 @@ func (c *MockStateInitialWatchStatementForRemoteConsumedSecretsChangesFromOfferi
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockStateInitialWatchStatementForRemoteConsumedSecretsChangesFromOfferingSideCall) DoAndReturn(f func(string) (string, eventsource.NamespaceQuery)) *MockStateInitialWatchStatementForRemoteConsumedSecretsChangesFromOfferingSideCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// InitialWatchStatementForSecretsRotationChanges mocks base method.
+func (m *MockState) InitialWatchStatementForSecretsRotationChanges(arg0 secret.ApplicationOwners, arg1 secret.UnitOwners) (string, eventsource.NamespaceQuery) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InitialWatchStatementForSecretsRotationChanges", arg0, arg1)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(eventsource.NamespaceQuery)
+	return ret0, ret1
+}
+
+// InitialWatchStatementForSecretsRotationChanges indicates an expected call of InitialWatchStatementForSecretsRotationChanges.
+func (mr *MockStateMockRecorder) InitialWatchStatementForSecretsRotationChanges(arg0, arg1 any) *MockStateInitialWatchStatementForSecretsRotationChangesCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitialWatchStatementForSecretsRotationChanges", reflect.TypeOf((*MockState)(nil).InitialWatchStatementForSecretsRotationChanges), arg0, arg1)
+	return &MockStateInitialWatchStatementForSecretsRotationChangesCall{Call: call}
+}
+
+// MockStateInitialWatchStatementForSecretsRotationChangesCall wrap *gomock.Call
+type MockStateInitialWatchStatementForSecretsRotationChangesCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateInitialWatchStatementForSecretsRotationChangesCall) Return(arg0 string, arg1 eventsource.NamespaceQuery) *MockStateInitialWatchStatementForSecretsRotationChangesCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateInitialWatchStatementForSecretsRotationChangesCall) Do(f func(secret.ApplicationOwners, secret.UnitOwners) (string, eventsource.NamespaceQuery)) *MockStateInitialWatchStatementForSecretsRotationChangesCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateInitialWatchStatementForSecretsRotationChangesCall) DoAndReturn(f func(secret.ApplicationOwners, secret.UnitOwners) (string, eventsource.NamespaceQuery)) *MockStateInitialWatchStatementForSecretsRotationChangesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/secret/service/watcher.go
+++ b/domain/secret/service/watcher.go
@@ -58,7 +58,7 @@ func (s *WatchableService) WatchConsumedSecretsChanges(ctx context.Context, unit
 	processLocalChanges := func(ctx context.Context, revisionUUIDs ...string) ([]string, error) {
 		return s.st.GetConsumedSecretURIsWithChanges(ctx, unitName, revisionUUIDs...)
 	}
-	sWLocal, err := newStringsWatcher(wLocal, s.logger, processLocalChanges)
+	sWLocal, err := newSecretWatcher(wLocal, true, s.logger, processLocalChanges)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -74,7 +74,7 @@ func (s *WatchableService) WatchConsumedSecretsChanges(ctx context.Context, unit
 	processRemoteChanges := func(ctx context.Context, secretIDs ...string) ([]string, error) {
 		return s.st.GetConsumedRemoteSecretURIsWithChanges(ctx, unitName, secretIDs...)
 	}
-	sWRemote, err := newStringsWatcher(wRemote, s.logger, processRemoteChanges)
+	sWRemote, err := newSecretWatcher(wRemote, true, s.logger, processRemoteChanges)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -95,7 +95,7 @@ func (s *WatchableService) WatchRemoteConsumedSecretsChanges(ctx context.Context
 	processChanges := func(ctx context.Context, secretIDs ...string) ([]string, error) {
 		return s.st.GetRemoteConsumedSecretURIsWithChangesFromOfferingSide(ctx, appName, secretIDs...)
 	}
-	return newStringsWatcher(w, s.logger, processChanges)
+	return newSecretWatcher(w, true, s.logger, processChanges)
 }
 
 // WatchObsolete returns a watcher for notifying when:
@@ -121,107 +121,7 @@ func (s *WatchableService) WatchObsolete(ctx context.Context, owners ...CharmSec
 	processChanges := func(ctx context.Context, revisionUUIDs ...string) ([]string, error) {
 		return s.st.GetRevisionIDsForObsolete(ctx, appOwners, unitOwners, revisionUUIDs...)
 	}
-	return newStringsWatcher(w, s.logger, processChanges)
-}
-
-// stringsWatcher is a watcher that watches for changes to a set of strings.
-type stringsWatcher struct {
-	catacomb catacomb.Catacomb
-	logger   logger.Logger
-
-	sourceWatcher watcher.StringsWatcher
-	handle        func(ctx context.Context, events ...string) ([]string, error)
-
-	out chan []string
-}
-
-func newStringsWatcher(
-	sourceWatcher watcher.StringsWatcher, logger logger.Logger,
-	handle func(ctx context.Context, events ...string) ([]string, error),
-) (*stringsWatcher, error) {
-	w := &stringsWatcher{
-		sourceWatcher: sourceWatcher,
-		logger:        logger,
-		handle:        handle,
-		out:           make(chan []string),
-	}
-	err := catacomb.Invoke(catacomb.Plan{
-		Site: &w.catacomb,
-		Work: w.loop,
-		Init: []worker.Worker{sourceWatcher},
-	})
-	return w, errors.Trace(err)
-}
-
-func (w *stringsWatcher) processChanges(events ...string) ([]string, error) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	return w.handle(w.catacomb.Context(ctx), events...)
-}
-
-func (w *stringsWatcher) loop() error {
-	defer close(w.out)
-
-	var changes set.Strings
-	// To allow the initial event to be sent.
-	out := w.out
-
-	addChanges := func(processed ...string) {
-		if len(processed) == 0 {
-			return
-		}
-		if changes == nil {
-			changes = set.NewStrings()
-		}
-		for _, change := range processed {
-			changes.Add(change)
-		}
-		out = w.out
-	}
-
-	for {
-		select {
-		case <-w.catacomb.Dying():
-			return w.catacomb.ErrDying()
-		case events, ok := <-w.sourceWatcher.Changes():
-			if !ok {
-				return errors.Errorf("event watcher closed")
-			}
-			if len(events) == 0 {
-				continue
-			}
-			processed, err := w.processChanges(events...)
-			if err != nil {
-				return errors.Trace(err)
-			}
-			addChanges(processed...)
-		case out <- changes.Values():
-			changes = nil
-			out = nil
-		}
-	}
-}
-
-// Changes returns the channel of obsolete secret changes.
-func (w *stringsWatcher) Changes() <-chan []string {
-	return w.out
-}
-
-// Stop stops the watcher.
-func (w *stringsWatcher) Stop() error {
-	w.Kill()
-	return w.Wait()
-}
-
-// Kill kills the watcher via its tomb.
-func (w *stringsWatcher) Kill() {
-	w.catacomb.Kill(nil)
-}
-
-// Wait waits for the watcher's tomb to die,
-// and returns the error with which it was killed.
-func (w *stringsWatcher) Wait() error {
-	return w.catacomb.Wait()
+	return newSecretWatcher(w, true, s.logger, processChanges)
 }
 
 // TODO(secrets) - replace with real watcher
@@ -267,9 +167,34 @@ func (s *WatchableService) WatchSecretRevisionsExpiryChanges(ctx context.Context
 }
 
 func (s *WatchableService) WatchSecretsRotationChanges(ctx context.Context, owners ...CharmSecretOwner) (watcher.SecretTriggerWatcher, error) {
-	ch := make(chan []watcher.SecretTriggerChange, 1)
-	ch <- []watcher.SecretTriggerChange{}
-	return newMockTriggerWatcher(ch), nil
+	if len(owners) == 0 {
+		return nil, errors.New("at least one owner must be provided")
+	}
+
+	appOwners, unitOwners := splitCharmSecretOwners(owners...)
+	table, query := s.st.InitialWatchStatementForSecretsRotationChanges(appOwners, unitOwners)
+	w, err := s.watcherFactory.NewNamespaceWatcher(
+		table, changestream.All, query,
+	)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	processChanges := func(ctx context.Context, secretIDs ...string) ([]watcher.SecretTriggerChange, error) {
+		result, err := s.st.GetSecretsRotationChanges(ctx, appOwners, unitOwners, secretIDs...)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		changes := make([]watcher.SecretTriggerChange, len(result))
+		for i, r := range result {
+			changes[i] = watcher.SecretTriggerChange{
+				URI:             r.URI,
+				Revision:        r.Revision,
+				NextTriggerTime: r.NextTriggerTime,
+			}
+		}
+		return changes, nil
+	}
+	return newSecretWatcher(w, true, s.logger, processChanges)
 }
 
 func (s *WatchableService) WatchObsoleteUserSecrets(ctx context.Context) (watcher.NotifyWatcher, error) {
@@ -283,4 +208,116 @@ func (s *WatchableService) WatchSecretBackendChanged(ctx context.Context) (watch
 	ch := make(chan struct{}, 1)
 	ch <- struct{}{}
 	return watchertest.NewMockNotifyWatcher(ch), nil
+}
+
+// secretWatcher is a watcher that watches for secret changes to a set of strings.
+type secretWatcher[T any] struct {
+	catacomb catacomb.Catacomb
+	logger   logger.Logger
+
+	sourceWatcher watcher.StringsWatcher
+	fireOnce      bool
+	handle        func(ctx context.Context, events ...string) ([]T, error)
+
+	out chan []T
+}
+
+func newSecretWatcher[T any](
+	sourceWatcher watcher.StringsWatcher, fireOnce bool, logger logger.Logger,
+	handle func(ctx context.Context, events ...string) ([]T, error),
+) (*secretWatcher[T], error) {
+	w := &secretWatcher[T]{
+		sourceWatcher: sourceWatcher,
+		fireOnce:      fireOnce,
+		logger:        logger,
+		handle:        handle,
+		out:           make(chan []T),
+	}
+	err := catacomb.Invoke(catacomb.Plan{
+		Site: &w.catacomb,
+		Work: w.loop,
+		Init: []worker.Worker{sourceWatcher},
+	})
+	return w, errors.Trace(err)
+}
+
+func (w *secretWatcher[T]) processChanges(events ...string) ([]T, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	return w.handle(w.catacomb.Context(ctx), events...)
+}
+
+func (w *secretWatcher[T]) loop() error {
+	defer close(w.out)
+
+	var (
+		processedIDs set.Strings
+		changes      []T
+	)
+	// To allow the initial event to be sent.
+	out := w.out
+	addChanges := func(events set.Strings) error {
+		if processedIDs == nil {
+			processedIDs = set.NewStrings()
+		}
+		newEvents := events.Difference(processedIDs)
+		if !w.fireOnce {
+			// If we are not firing once, we want to process all received events.
+			newEvents = events
+		}
+		if newEvents.IsEmpty() {
+			return nil
+		}
+
+		processed, err := w.processChanges(newEvents.Values()...)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if len(processed) == 0 {
+			return nil
+		}
+		changes = append(changes, processed...)
+		processedIDs = processedIDs.Union(newEvents)
+		out = w.out
+		return nil
+	}
+
+	for {
+		select {
+		case <-w.catacomb.Dying():
+			return w.catacomb.ErrDying()
+		case events, ok := <-w.sourceWatcher.Changes():
+			if !ok {
+				return errors.Errorf("event watcher closed")
+			}
+			if err := addChanges(set.NewStrings(events...)); err != nil {
+				return errors.Trace(err)
+			}
+		case out <- changes:
+			changes = nil
+			out = nil
+		}
+	}
+}
+
+// Changes returns the channel of secret changes.
+func (w *secretWatcher[T]) Changes() <-chan []T {
+	return w.out
+}
+
+// Stop stops the watcher.
+func (w *secretWatcher[T]) Stop() error {
+	w.Kill()
+	return w.Wait()
+}
+
+// Kill kills the watcher via its tomb.
+func (w *secretWatcher[T]) Kill() {
+	w.catacomb.Kill(nil)
+}
+
+// Wait waits for the watcher's tomb to die,
+// and returns the error with which it was killed.
+func (w *secretWatcher[T]) Wait() error {
+	return w.catacomb.Wait()
 }

--- a/domain/secret/state/state.go
+++ b/domain/secret/state/state.go
@@ -3346,11 +3346,11 @@ FROM   secret_rotation sro
 	}
 	if len(appOwners) > 0 && len(unitOwners) > 0 {
 		queryParams = append(queryParams, appOwners, unitOwners)
-		joins = append(joins,
-			`LEFT JOIN secret_application_owner sao ON sro.secret_id = sao.secret_id`,
-			`LEFT JOIN application ON application.uuid = sao.application_uuid`,
-			`LEFT JOIN secret_unit_owner suo ON sro.secret_id = suo.secret_id`,
-			`LEFT JOIN unit ON unit.uuid = suo.unit_uuid`,
+		joins = append(joins, `
+LEFT JOIN secret_application_owner sao ON sro.secret_id = sao.secret_id
+LEFT JOIN application ON application.uuid = sao.application_uuid
+LEFT JOIN secret_unit_owner suo ON sro.secret_id = suo.secret_id
+LEFT JOIN unit ON unit.uuid = suo.unit_uuid`[1:],
 		)
 		conditions = append(conditions, `(
     sao.application_uuid IS NOT NULL AND application.name IN ($ApplicationOwners[:])
@@ -3358,16 +3358,16 @@ FROM   secret_rotation sro
 )`)
 	} else if len(appOwners) > 0 {
 		queryParams = append(queryParams, appOwners)
-		joins = append(joins,
-			`LEFT JOIN secret_application_owner sao ON sro.secret_id = sao.secret_id`,
-			`LEFT JOIN application ON application.uuid = sao.application_uuid`,
+		joins = append(joins, `
+LEFT JOIN secret_application_owner sao ON sro.secret_id = sao.secret_id
+LEFT JOIN application ON application.uuid = sao.application_uuid`[1:],
 		)
 		conditions = append(conditions, "sao.application_uuid IS NOT NULL AND application.name IN ($ApplicationOwners[:])")
 	} else if len(unitOwners) > 0 {
 		queryParams = append(queryParams, unitOwners)
-		joins = append(joins,
-			`LEFT JOIN secret_unit_owner suo ON sro.secret_id = suo.secret_id`,
-			`LEFT JOIN unit ON unit.uuid = suo.unit_uuid`,
+		joins = append(joins, `
+LEFT JOIN secret_unit_owner suo ON sro.secret_id = suo.secret_id
+LEFT JOIN unit ON unit.uuid = suo.unit_uuid`[1:],
 		)
 		conditions = append(conditions, "suo.unit_uuid IS NOT NULL AND unit.unit_id IN ($UnitOwners[:])")
 	}

--- a/domain/secret/state/state_test.go
+++ b/domain/secret/state/state_test.go
@@ -3308,7 +3308,29 @@ func (s *stateSuite) TestGetSecretsRotationChanges(c *gc.C) {
 		},
 	})
 
+	// The uri2 is not owned by mysql, so it should not be returned.
+	result, err = st.GetSecretsRotationChanges(ctx, domainsecret.ApplicationOwners{"mysql"}, nil, uri1.ID, uri2.ID)
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(result, jc.SameContents, []domainsecret.RotationInfo{
+		{
+			URI:             uri1,
+			Revision:        1,
+			NextTriggerTime: now.Add(1 * time.Hour).UTC(),
+		},
+	})
+
 	result, err = st.GetSecretsRotationChanges(ctx, nil, domainsecret.UnitOwners{"mediawiki/0"})
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(result, jc.SameContents, []domainsecret.RotationInfo{
+		{
+			URI:             uri2,
+			Revision:        2,
+			NextTriggerTime: now.Add(2 * time.Hour).UTC(),
+		},
+	})
+
+	// The uri1 is not owned by mediawiki/0, so it should not be returned.
+	result, err = st.GetSecretsRotationChanges(ctx, nil, domainsecret.UnitOwners{"mediawiki/0"}, uri1.ID, uri2.ID)
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(result, jc.SameContents, []domainsecret.RotationInfo{
 		{

--- a/domain/secret/state/types.go
+++ b/domain/secret/state/types.go
@@ -97,6 +97,12 @@ type secretRotate struct {
 	NextRotateTime time.Time `db:"next_rotation_time"`
 }
 
+type secretRotationChange struct {
+	SecretID       string    `db:"secret_id"`
+	Revision       int       `db:"revision"`
+	NextRotateTime time.Time `db:"next_rotation_time"`
+}
+
 type secretRevision struct {
 	ID         string    `db:"uuid"`
 	SecretID   string    `db:"secret_id"`

--- a/domain/secret/types.go
+++ b/domain/secret/types.go
@@ -85,3 +85,10 @@ type RotationExpiryInfo struct {
 	// LatestRevision is the most recent secret revision.
 	LatestRevision int
 }
+
+// RotationInfo holds information about the rotation of a secret.
+type RotationInfo struct {
+	URI             *secrets.URI
+	Revision        int
+	NextTriggerTime time.Time
+}

--- a/domain/secret/watcher_test.go
+++ b/domain/secret/watcher_test.go
@@ -140,6 +140,7 @@ func (s *watcherSuite) TestWatchObsoleteForAppsAndUnitsOwned(c *gc.C) {
 
 	// Wait for the initial changes.
 	wCAll.AssertChange([]string(nil)...)
+	s.AssertChangeStreamIdle(c)
 
 	// create revision 2, and obsolete revision 1.
 	createNewRevision(c, st, uri1)
@@ -147,6 +148,7 @@ func (s *watcherSuite) TestWatchObsoleteForAppsAndUnitsOwned(c *gc.C) {
 	createNewRevision(c, st, uri3)
 	createNewRevision(c, st, uri4)
 
+	s.AssertChangeStreamIdle(c)
 	wCAll.AssertChange(
 		revID(uri1, 1),
 		revID(uri2, 1),
@@ -159,6 +161,7 @@ func (s *watcherSuite) TestWatchObsoleteForAppsAndUnitsOwned(c *gc.C) {
 	createNewRevision(c, st, uri2)
 	createNewRevision(c, st, uri3)
 
+	s.AssertChangeStreamIdle(c)
 	wCAll.AssertChange(
 		revID(uri1, 2),
 		revID(uri2, 2),
@@ -199,11 +202,13 @@ func (s *watcherSuite) TestWatchObsoleteForAppsOwned(c *gc.C) {
 
 	// Wait for the initial changes.
 	wCSingleApplication.AssertChange([]string(nil)...)
+	s.AssertChangeStreamIdle(c)
 
 	// create revision 2, and obsolete revision 1.
 	createNewRevision(c, st, uri1)
 	createNewRevision(c, st, uri2)
 
+	s.AssertChangeStreamIdle(c)
 	wCSingleApplication.AssertChange(
 		revID(uri1, 1),
 	)
@@ -212,6 +217,7 @@ func (s *watcherSuite) TestWatchObsoleteForAppsOwned(c *gc.C) {
 	createNewRevision(c, st, uri1)
 	createNewRevision(c, st, uri2)
 
+	s.AssertChangeStreamIdle(c)
 	wCSingleApplication.AssertChange(
 		revID(uri1, 2),
 	)
@@ -250,11 +256,13 @@ func (s *watcherSuite) TestWatchObsoleteForUnitsOwned(c *gc.C) {
 
 	// Wait for the initial changes.
 	wCSingleUnit.AssertChange([]string(nil)...)
+	s.AssertChangeStreamIdle(c)
 
 	// create revision 2, and obsolete revision 1.
 	createNewRevision(c, st, uri1)
 	createNewRevision(c, st, uri2)
 
+	s.AssertChangeStreamIdle(c)
 	wCSingleUnit.AssertChange(
 		revID(uri2, 1),
 	)
@@ -263,6 +271,7 @@ func (s *watcherSuite) TestWatchObsoleteForUnitsOwned(c *gc.C) {
 	createNewRevision(c, st, uri1)
 	createNewRevision(c, st, uri2)
 
+	s.AssertChangeStreamIdle(c)
 	wCSingleUnit.AssertChange(
 		revID(uri2, 2),
 	)
@@ -310,23 +319,26 @@ func (s *watcherSuite) TestWatchConsumedSecretsChanges(c *gc.C) {
 
 	// Wait for the initial changes.
 	wC.AssertChange([]string(nil)...)
+	s.AssertChangeStreamIdle(c)
 	wC.AssertNoChange()
 
 	// create revision 2.
 	createNewRevision(c, st, uri1)
 
+	s.AssertChangeStreamIdle(c)
 	wC.AssertChange(
 		uri1.String(),
 	)
 	wC.AssertNoChange()
 
-	// pretend that the agent restarted and the watcher is re-created.
+	// Pretend that the agent restarted and the watcher is re-created.
 	watcher1, err := svc.WatchConsumedSecretsChanges(ctx, "mediawiki/0")
 	c.Assert(err, gc.IsNil)
 	c.Assert(watcher1, gc.NotNil)
 	defer workertest.CleanKill(c, watcher1)
 	wC1 := watchertest.NewStringsWatcherC(c, watcher1)
 	wC1.AssertChange([]string(nil)...)
+	s.AssertChangeStreamIdle(c)
 	wC1.AssertChange(
 		uri1.String(),
 	)
@@ -336,7 +348,7 @@ func (s *watcherSuite) TestWatchConsumedSecretsChanges(c *gc.C) {
 	wC.AssertNoChange()
 	wC1.AssertNoChange()
 
-	// pretend that the agent restarted and the watcher is re-created again.
+	// Pretend that the agent restarted and the watcher is re-created again.
 	// Since we comsume the latest revision already, so there should be no change.
 	watcher2, err := svc.WatchConsumedSecretsChanges(ctx, "mediawiki/0")
 	c.Assert(err, gc.IsNil)
@@ -344,6 +356,7 @@ func (s *watcherSuite) TestWatchConsumedSecretsChanges(c *gc.C) {
 	defer workertest.CleanKill(c, watcher1)
 	wC2 := watchertest.NewStringsWatcherC(c, watcher2)
 	wC2.AssertChange([]string(nil)...)
+	s.AssertChangeStreamIdle(c)
 	wC2.AssertNoChange()
 }
 
@@ -382,33 +395,37 @@ func (s *watcherSuite) TestWatchConsumedRemoteSecretsChanges(c *gc.C) {
 
 	// Wait for the initial changes.
 	wC.AssertChange([]string(nil)...)
+	s.AssertChangeStreamIdle(c)
 	wC.AssertNoChange()
 
 	err = st.UpdateRemoteSecretRevision(ctx, uri1, 2)
 	c.Assert(err, jc.ErrorIsNil)
 
+	s.AssertChangeStreamIdle(c)
 	wC.AssertChange(
 		uri1.String(),
 	)
 	wC.AssertNoChange()
 
-	// pretend that the agent restarted and the watcher is re-created.
+	// Pretend that the agent restarted and the watcher is re-created.
 	watcher1, err := svc.WatchConsumedSecretsChanges(ctx, "mediawiki/0")
 	c.Assert(err, gc.IsNil)
 	c.Assert(watcher1, gc.NotNil)
 	defer workertest.CleanKill(c, watcher1)
 	wC1 := watchertest.NewStringsWatcherC(c, watcher1)
 	wC1.AssertChange([]string(nil)...)
+	s.AssertChangeStreamIdle(c)
 	wC1.AssertChange(
 		uri1.String(),
 	)
 
 	// The consumed revision 2 is the updated current_revision.
 	saveConsumer(uri1, 2, "mediawiki/0")
+	s.AssertChangeStreamIdle(c)
 	wC.AssertNoChange()
 	wC1.AssertNoChange()
 
-	// pretend that the agent restarted and the watcher is re-created again.
+	// Pretend that the agent restarted and the watcher is re-created again.
 	// Since we comsume the latest revision already, so there should be no change.
 	watcher2, err := svc.WatchConsumedSecretsChanges(ctx, "mediawiki/0")
 	c.Assert(err, gc.IsNil)
@@ -416,6 +433,7 @@ func (s *watcherSuite) TestWatchConsumedRemoteSecretsChanges(c *gc.C) {
 	defer workertest.CleanKill(c, watcher1)
 	wC2 := watchertest.NewStringsWatcherC(c, watcher2)
 	wC2.AssertChange([]string(nil)...)
+	s.AssertChangeStreamIdle(c)
 	wC2.AssertNoChange()
 }
 
@@ -460,6 +478,7 @@ func (s *watcherSuite) TestWatchRemoteConsumedSecretsChanges(c *gc.C) {
 
 	// Wait for the initial changes.
 	wC.AssertChange([]string(nil)...)
+	s.AssertChangeStreamIdle(c)
 	wC.AssertNoChange()
 
 	// create revision 2.
@@ -470,9 +489,10 @@ func (s *watcherSuite) TestWatchRemoteConsumedSecretsChanges(c *gc.C) {
 	wC.AssertChange(
 		uri1.String(),
 	)
+	s.AssertChangeStreamIdle(c)
 	wC.AssertNoChange()
 
-	// pretend that the agent restarted and the watcher is re-created.
+	// Pretend that the agent restarted and the watcher is re-created.
 	watcher1, err := svc.WatchRemoteConsumedSecretsChanges(ctx, "mediawiki")
 	c.Assert(err, gc.IsNil)
 	c.Assert(watcher1, gc.NotNil)
@@ -485,10 +505,11 @@ func (s *watcherSuite) TestWatchRemoteConsumedSecretsChanges(c *gc.C) {
 
 	// The consumed revision 2 is the updated current_revision.
 	saveRemoteConsumer(uri1, 2, "mediawiki/0")
+	s.AssertChangeStreamIdle(c)
 	wC.AssertNoChange()
 	wC1.AssertNoChange()
 
-	// pretend that the agent restarted and the watcher is re-created again.
+	// Pretend that the agent restarted and the watcher is re-created again.
 	// Since we comsume the latest revision already, so there should be no change.
 	watcher2, err := svc.WatchRemoteConsumedSecretsChanges(ctx, "mediawiki")
 	c.Assert(err, gc.IsNil)
@@ -496,6 +517,7 @@ func (s *watcherSuite) TestWatchRemoteConsumedSecretsChanges(c *gc.C) {
 	defer workertest.CleanKill(c, watcher1)
 	wC2 := watchertest.NewStringsWatcherC(c, watcher2)
 	wC2.AssertChange([]string(nil)...)
+	s.AssertChangeStreamIdle(c)
 	wC2.AssertNoChange()
 }
 
@@ -536,6 +558,7 @@ func (s *watcherSuite) TestWatchSecretsRotationChanges(c *gc.C) {
 
 	// Wait for the initial changes.
 	wC.AssertChange([]corewatcher.SecretTriggerChange(nil)...)
+	s.AssertChangeStreamIdle(c)
 	wC.AssertNoChange()
 
 	now := time.Now()
@@ -558,9 +581,10 @@ func (s *watcherSuite) TestWatchSecretsRotationChanges(c *gc.C) {
 		},
 	)
 
+	s.AssertChangeStreamIdle(c)
 	wC.AssertNoChange()
 
-	// pretend that the agent restarted and the watcher is re-created.
+	// Pretend that the agent restarted and the watcher is re-created.
 	watcher1, err := svc.WatchSecretsRotationChanges(context.Background(),
 		service.CharmSecretOwner{
 			Kind: service.ApplicationOwner,
@@ -576,5 +600,18 @@ func (s *watcherSuite) TestWatchSecretsRotationChanges(c *gc.C) {
 	defer workertest.CleanKill(c, watcher1)
 	wC1 := watchertest.NewSecretsTriggerWatcherC(c, watcher1)
 	wC1.AssertChange([]corewatcher.SecretTriggerChange(nil)...)
+	wC1.AssertChange(
+		corewatcher.SecretTriggerChange{
+			URI:             uri1,
+			Revision:        1,
+			NextTriggerTime: now.Add(1 * time.Hour),
+		},
+		corewatcher.SecretTriggerChange{
+			URI:             uri2,
+			Revision:        2,
+			NextTriggerTime: now.Add(2 * time.Hour),
+		},
+	)
+	s.AssertChangeStreamIdle(c)
 	wC1.AssertNoChange()
 }


### PR DESCRIPTION
This PR introduces a watcher that monitors changes in secret rotations. When a user establishes a rotation policy for a secret, the SQL trigger we've implemented activates the change stream infrastructure, which in turn triggers an event in the secret rotation watcher within the secret service. This watcher retrieves the secret's URI, its current revision, and the next scheduled rotation time, and then forwards this information to the consumer side.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```
juju exec --unit dummy-source/0 "secret-add data=foo"
secret://07fa70f6-9622-4fee-8f9b-50df07e6ddd9/cp85bfiit0018vbp0ej0

juju exec --unit dummy-source/0 "secret-set cp85bfiit0018vbp0ej0 --rotate hourly"

juju show-status-log dummy-source/0
Time                        Type       Status       Message
...
24 May 2024 18:54:23+10:00  workload   maintenance  Started
24 May 2024 18:54:23+10:00  juju-unit  idle
24 May 2024 18:54:45+10:00  juju-unit  executing    running action juju-exec
24 May 2024 18:54:45+10:00  juju-unit  idle
24 May 2024 18:54:55+10:00  juju-unit  executing    running action juju-exec
24 May 2024 18:54:55+10:00  juju-unit  idle
24 May 2024 18:55:25+10:00  juju-unit  executing    running secret-rotate hook for secret:cp85bfiit0018vbp0ej0
24 May 2024 18:55:25+10:00  juju-unit  idle


juju debug-log --color --replay -m model-secrets-offer
unit-dummy-source-0: 18:55:25 INFO juju.worker.uniter.operation skipped "secret-rotate" hook (missing)
```

## Documentation changes

No

## Links

**Jira card:** JUJU-5894

