### PR TITLE
Remove SuperSubnets from environs networking

### DIFF
--- a/domain/network/service/package_mock_test.go
+++ b/domain/network/service/package_mock_test.go
@@ -923,45 +923,6 @@ func (c *MockProviderSubnetsCall) DoAndReturn(f func(envcontext.ProviderCallCont
 	return c
 }
 
-// SuperSubnets mocks base method.
-func (m *MockProvider) SuperSubnets(arg0 envcontext.ProviderCallContext) ([]string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SuperSubnets", arg0)
-	ret0, _ := ret[0].([]string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// SuperSubnets indicates an expected call of SuperSubnets.
-func (mr *MockProviderMockRecorder) SuperSubnets(arg0 any) *MockProviderSuperSubnetsCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SuperSubnets", reflect.TypeOf((*MockProvider)(nil).SuperSubnets), arg0)
-	return &MockProviderSuperSubnetsCall{Call: call}
-}
-
-// MockProviderSuperSubnetsCall wrap *gomock.Call
-type MockProviderSuperSubnetsCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockProviderSuperSubnetsCall) Return(arg0 []string, arg1 error) *MockProviderSuperSubnetsCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockProviderSuperSubnetsCall) Do(f func(envcontext.ProviderCallContext) ([]string, error)) *MockProviderSuperSubnetsCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockProviderSuperSubnetsCall) DoAndReturn(f func(envcontext.ProviderCallContext) ([]string, error)) *MockProviderSuperSubnetsCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // SupportsContainerAddresses mocks base method.
 func (m *MockProvider) SupportsContainerAddresses(arg0 envcontext.ProviderCallContext) (bool, error) {
 	m.ctrl.T.Helper()

--- a/environs/mocks/package_mock.go
+++ b/environs/mocks/package_mock.go
@@ -1857,45 +1857,6 @@ func (c *MockNetworkingEnvironSubnetsCall) DoAndReturn(f func(envcontext.Provide
 	return c
 }
 
-// SuperSubnets mocks base method.
-func (m *MockNetworkingEnviron) SuperSubnets(arg0 envcontext.ProviderCallContext) ([]string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SuperSubnets", arg0)
-	ret0, _ := ret[0].([]string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// SuperSubnets indicates an expected call of SuperSubnets.
-func (mr *MockNetworkingEnvironMockRecorder) SuperSubnets(arg0 any) *MockNetworkingEnvironSuperSubnetsCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SuperSubnets", reflect.TypeOf((*MockNetworkingEnviron)(nil).SuperSubnets), arg0)
-	return &MockNetworkingEnvironSuperSubnetsCall{Call: call}
-}
-
-// MockNetworkingEnvironSuperSubnetsCall wrap *gomock.Call
-type MockNetworkingEnvironSuperSubnetsCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockNetworkingEnvironSuperSubnetsCall) Return(arg0 []string, arg1 error) *MockNetworkingEnvironSuperSubnetsCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockNetworkingEnvironSuperSubnetsCall) Do(f func(envcontext.ProviderCallContext) ([]string, error)) *MockNetworkingEnvironSuperSubnetsCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockNetworkingEnvironSuperSubnetsCall) DoAndReturn(f func(envcontext.ProviderCallContext) ([]string, error)) *MockNetworkingEnvironSuperSubnetsCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // SupportsContainerAddresses mocks base method.
 func (m *MockNetworkingEnviron) SupportsContainerAddresses(arg0 envcontext.ProviderCallContext) (bool, error) {
 	m.ctrl.T.Helper()

--- a/environs/networking.go
+++ b/environs/networking.go
@@ -30,10 +30,6 @@ type Networking interface {
 		ctx envcontext.ProviderCallContext, inst instance.Id, subnetIds []network.Id,
 	) ([]network.SubnetInfo, error)
 
-	// SuperSubnets returns information about aggregated subnets - eg. global CIDR
-	// for EC2 VPC.
-	SuperSubnets(ctx envcontext.ProviderCallContext) ([]string, error)
-
 	// NetworkInterfaces returns a slice with the network interfaces that
 	// correspond to the given instance IDs. If no instances where found,
 	// but there was no other error, it will return ErrNoInstances. If some

--- a/environs/testing/package_mock.go
+++ b/environs/testing/package_mock.go
@@ -4091,45 +4091,6 @@ func (c *MockNetworkingEnvironSubnetsCall) DoAndReturn(f func(envcontext.Provide
 	return c
 }
 
-// SuperSubnets mocks base method.
-func (m *MockNetworkingEnviron) SuperSubnets(arg0 envcontext.ProviderCallContext) ([]string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SuperSubnets", arg0)
-	ret0, _ := ret[0].([]string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// SuperSubnets indicates an expected call of SuperSubnets.
-func (mr *MockNetworkingEnvironMockRecorder) SuperSubnets(arg0 any) *MockNetworkingEnvironSuperSubnetsCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SuperSubnets", reflect.TypeOf((*MockNetworkingEnviron)(nil).SuperSubnets), arg0)
-	return &MockNetworkingEnvironSuperSubnetsCall{Call: call}
-}
-
-// MockNetworkingEnvironSuperSubnetsCall wrap *gomock.Call
-type MockNetworkingEnvironSuperSubnetsCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockNetworkingEnvironSuperSubnetsCall) Return(arg0 []string, arg1 error) *MockNetworkingEnvironSuperSubnetsCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockNetworkingEnvironSuperSubnetsCall) Do(f func(envcontext.ProviderCallContext) ([]string, error)) *MockNetworkingEnvironSuperSubnetsCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockNetworkingEnvironSuperSubnetsCall) DoAndReturn(f func(envcontext.ProviderCallContext) ([]string, error)) *MockNetworkingEnvironSuperSubnetsCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // SupportsContainerAddresses mocks base method.
 func (m *MockNetworkingEnviron) SupportsContainerAddresses(arg0 envcontext.ProviderCallContext) (bool, error) {
 	m.ctrl.T.Helper()

--- a/internal/provider/azure/environ_network.go
+++ b/internal/provider/azure/environ_network.go
@@ -141,11 +141,6 @@ func (env *azureEnviron) allPublicIPs(ctx envcontext.ProviderCallContext) (map[s
 	return idToIPMap, nil
 }
 
-// SuperSubnets implements environs.NetworkingEnviron.
-func (env *azureEnviron) SuperSubnets(envcontext.ProviderCallContext) ([]string, error) {
-	return nil, errors.NotSupportedf("super subnets")
-}
-
 // SupportsContainerAddresses implements environs.NetworkingEnviron.
 func (env *azureEnviron) SupportsContainerAddresses(envcontext.ProviderCallContext) (bool, error) {
 	return false, nil

--- a/internal/provider/dummy/environs.go
+++ b/internal/provider/dummy/environs.go
@@ -1132,8 +1132,3 @@ func (*environ) LXDProfileNames(string) ([]string, error) {
 func (*environ) AssignLXDProfiles(_ string, profilesNames []string, _ []lxdprofile.ProfilePost) (current []string, err error) {
 	return profilesNames, nil
 }
-
-// SuperSubnets implements environs.SuperSubnets
-func (*environ) SuperSubnets(envcontext.ProviderCallContext) ([]string, error) {
-	return nil, errors.NotSupportedf("super subnets")
-}

--- a/internal/provider/ec2/environ.go
+++ b/internal/provider/ec2/environ.go
@@ -2708,24 +2708,6 @@ func (e *environ) hasDefaultVPC(ctx envcontext.ProviderCallContext) (bool, error
 	return e.defaultVPC != nil, nil
 }
 
-// SuperSubnets implements NetworkingEnviron.SuperSubnets
-func (e *environ) SuperSubnets(ctx envcontext.ProviderCallContext) ([]string, error) {
-	vpcId := e.ecfg().vpcID()
-	if !isVPCIDSet(vpcId) {
-		if hasDefaultVPC, err := e.hasDefaultVPC(ctx); err == nil && hasDefaultVPC {
-			vpcId = aws.ToString(e.defaultVPC.VpcId)
-		}
-	}
-	if !isVPCIDSet(vpcId) {
-		return nil, errors.NotSupportedf("Not a VPC environment")
-	}
-	cidr, err := getVPCCIDR(e.ec2Client, ctx, vpcId)
-	if err != nil {
-		return nil, err
-	}
-	return []string{cidr}, nil
-}
-
 // SetCloudSpec is specified in the environs.Environ interface.
 func (e *environ) SetCloudSpec(ctx stdcontext.Context, spec environscloudspec.CloudSpec) error {
 	if err := validateCloudSpec(spec); err != nil {

--- a/internal/provider/ec2/environ_vpc.go
+++ b/internal/provider/ec2/environ_vpc.go
@@ -391,14 +391,6 @@ func getVPCMainRouteTable(apiClient vpcAPIClient, ctx envcontext.ProviderCallCon
 	return resp.RouteTables[0], nil
 }
 
-func getVPCCIDR(apiClient vpcAPIClient, ctx envcontext.ProviderCallContext, vpcID string) (string, error) {
-	vpc, err := getVPCByID(apiClient, ctx, vpcID)
-	if err != nil {
-		return "", err
-	}
-	return aws.ToString(vpc.CidrBlock), nil
-}
-
 func checkVPCRouteTableRoutes(vpc *types.Vpc, routeTable *types.RouteTable, gateway *types.InternetGateway) error {
 	hasDefaultRoute := false
 	hasLocalRoute := false

--- a/internal/provider/equinix/environ_network.go
+++ b/internal/provider/equinix/environ_network.go
@@ -179,32 +179,6 @@ func (e *environ) NetworkInterfaces(ctx envcontext.ProviderCallContext, ids []in
 	return infos, nil
 }
 
-// SuperSubnets returns information about the reserved private subnets that can
-// be used as underlays when setting up FAN networking.
-func (e *environ) SuperSubnets(envcontext.ProviderCallContext) ([]string, error) {
-	attrs := e.cloud.Credential.Attributes()
-	if attrs == nil {
-		return nil, errors.Trace(fmt.Errorf("empty attribute credentials"))
-	}
-	// We checked the presence of project-id when we were verifying the credentials.
-	projectID := attrs["project-id"]
-
-	ips, err := e.listIPsByProjectIDAndRegion(projectID, e.cloud.Region)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	var privateCIDRs []string
-	for _, ipblock := range ips {
-		if ipblock.Public {
-			continue // we are only interested in private block reservations from the right region
-		}
-		privateCIDRs = append(privateCIDRs, fmt.Sprintf("%s/%d", ipblock.Network, ipblock.CIDR))
-	}
-
-	return privateCIDRs, nil
-}
-
 // SupportsContainerAddresses returns true if the current environment is
 // able to allocate addaddresses for containers.
 func (*environ) SupportsContainerAddresses(envcontext.ProviderCallContext) (bool, error) {

--- a/internal/provider/gce/environ_network.go
+++ b/internal/provider/gce/environ_network.go
@@ -340,19 +340,6 @@ func (e *environ) ReleaseContainerAddresses(envcontext.ProviderCallContext, []co
 	return errors.NotSupportedf("container addresses")
 }
 
-// SuperSubnets implements environs.SuperSubnets
-func (e *environ) SuperSubnets(ctx envcontext.ProviderCallContext) ([]string, error) {
-	subnets, err := e.Subnets(ctx, "", nil)
-	if err != nil {
-		return nil, err
-	}
-	cidrs := make([]string, len(subnets))
-	for i, subnet := range subnets {
-		cidrs[i] = subnet.CIDR
-	}
-	return cidrs, nil
-}
-
 func copyStrings(items []string) []string {
 	if items == nil {
 		return nil

--- a/internal/provider/gce/environ_network_test.go
+++ b/internal/provider/gce/environ_network_test.go
@@ -113,19 +113,6 @@ func (s *environNetSuite) TestGettingAllSubnets(c *gc.C) {
 	}})
 }
 
-func (s *environNetSuite) TestSuperSubnets(c *gc.C) {
-	s.cannedData()
-
-	subnets, err := s.NetEnv.SuperSubnets(s.CallCtx)
-	c.Assert(err, jc.ErrorIsNil)
-
-	c.Assert(subnets, gc.DeepEquals, []string{
-		"10.0.10.0/24",
-		"10.0.20.0/24",
-		"10.240.0.0/16",
-	})
-}
-
 func (s *environNetSuite) TestRestrictingToSubnets(c *gc.C) {
 	s.cannedData()
 

--- a/internal/provider/lxd/environ_network.go
+++ b/internal/provider/lxd/environ_network.go
@@ -402,11 +402,6 @@ func isErrMissingAPIExtension(err error, ext string) bool {
 	return err != nil && strings.Contains(err.Error(), fmt.Sprintf("server is missing the required %q API extension", ext))
 }
 
-// SuperSubnets returns information about aggregated subnet.
-func (*environ) SuperSubnets(envcontext.ProviderCallContext) ([]string, error) {
-	return nil, errors.NotSupportedf("super subnets")
-}
-
 // SupportsSpaces returns whether the current environment supports
 // spaces. The returned error satisfies errors.IsNotSupported(),
 // unless a general API failure occurs.

--- a/internal/provider/maas/environ.go
+++ b/internal/provider/maas/environ.go
@@ -1416,11 +1416,6 @@ func (*maasEnviron) ProviderSpaceInfo(
 	return nil, errors.NotSupportedf("provider space info")
 }
 
-// SuperSubnets implements environs.SuperSubnets
-func (*maasEnviron) SuperSubnets(ctx envcontext.ProviderCallContext) ([]string, error) {
-	return nil, errors.NotSupportedf("super subnets")
-}
-
 // Domains gets the domains managed by MAAS. We only need the name of the
 // domain at present. If more information is needed this function can be
 // updated to parse and return a structure. Client code would need to be

--- a/internal/provider/manual/environ_network.go
+++ b/internal/provider/manual/environ_network.go
@@ -25,11 +25,6 @@ func (e *manualEnviron) Subnets(envcontext.ProviderCallContext, instance.Id, []n
 	return nil, errors.NotSupportedf("subnets")
 }
 
-// SuperSubnets implements environs.NetworkingEnviron.
-func (e *manualEnviron) SuperSubnets(envcontext.ProviderCallContext) ([]string, error) {
-	return nil, errors.NotSupportedf("super subnets")
-}
-
 // SupportsContainerAddresses implements environs.NetworkingEnviron.
 func (e *manualEnviron) SupportsContainerAddresses(envcontext.ProviderCallContext) (bool, error) {
 	return false, nil

--- a/internal/provider/oci/networking.go
+++ b/internal/provider/oci/networking.go
@@ -1010,10 +1010,6 @@ func makeSubnetInfo(subnet ociCore.Subnet) (network.SubnetInfo, error) {
 	return info, nil
 }
 
-func (e *Environ) SuperSubnets(ctx envcontext.ProviderCallContext) ([]string, error) {
-	return nil, errors.NotSupportedf("super subnets")
-}
-
 func (e *Environ) NetworkInterfaces(ctx envcontext.ProviderCallContext, ids []instance.Id) ([]network.InterfaceInfos, error) {
 	var (
 		infos = make([]network.InterfaceInfos, len(ids))

--- a/internal/provider/openstack/local_test.go
+++ b/internal/provider/openstack/local_test.go
@@ -1527,26 +1527,6 @@ func (s *localServerSuite) TestSubnetsWithMissingSubnet(c *gc.C) {
 	c.Assert(subnets, gc.HasLen, 0)
 }
 
-func (s *localServerSuite) TestSuperSubnets(c *gc.C) {
-	env := s.prepareNetworkingEnviron(c, s.env.Config())
-	obtainedSubnets, err := env.SuperSubnets(s.callCtx)
-	c.Assert(err, jc.ErrorIsNil)
-	neutronClient := openstack.GetNeutronClient(s.env)
-	openstackSubnets, err := neutronClient.ListSubnetsV2()
-	c.Assert(err, jc.ErrorIsNil)
-
-	expectedSubnets := make([]string, 0, len(openstackSubnets))
-	for _, subnets := range openstackSubnets {
-		if subnets.NetworkId != "999" {
-			continue
-		}
-		expectedSubnets = append(expectedSubnets, subnets.Cidr)
-	}
-	sort.Strings(obtainedSubnets)
-	sort.Strings(expectedSubnets)
-	c.Check(obtainedSubnets, jc.DeepEquals, expectedSubnets)
-}
-
 func (s *localServerSuite) TestFindImageBadDefaultImage(c *gc.C) {
 	imagetesting.PatchOfficialDataSources(&s.CleanupSuite, "")
 	env := s.Open(c, context.Background(), s.env.Config())

--- a/internal/provider/openstack/provider.go
+++ b/internal/provider/openstack/provider.go
@@ -2397,20 +2397,6 @@ func (e *Environ) SupportsContainerAddresses(envcontext.ProviderCallContext) (bo
 	return false, errors.NotSupportedf("container address")
 }
 
-// SuperSubnets is specified on environs.Networking
-func (e *Environ) SuperSubnets(ctx envcontext.ProviderCallContext) ([]string, error) {
-	subnets, err := e.networking.Subnets("", nil)
-	if err != nil {
-		handleCredentialError(err, ctx)
-		return nil, err
-	}
-	cidrs := make([]string, len(subnets))
-	for i, subnet := range subnets {
-		cidrs[i] = subnet.CIDR
-	}
-	return cidrs, nil
-}
-
 // AllocateContainerAddresses is specified on environs.Networking.
 func (e *Environ) AllocateContainerAddresses(ctx envcontext.ProviderCallContext, hostInstanceID instance.Id, containerTag names.MachineTag, preparedInfo network.InterfaceInfos) (network.InterfaceInfos, error) {
 	return nil, errors.NotSupportedf("allocate container address")

--- a/state/containernetworking.go
+++ b/state/containernetworking.go
@@ -5,11 +5,6 @@ package state
 
 import (
 	stdcontext "context"
-	"fmt"
-	"net"
-	"strings"
-
-	"github.com/juju/errors"
 
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
@@ -24,77 +19,14 @@ func (m *Model) AutoConfigureContainerNetworking(environ environs.BootstrapEnvir
 	if err != nil {
 		return err
 	}
-	fanConfigured, err := m.discoverFan(environ, modelConfig, updateAttrs)
-	if err != nil {
-		return err
-	}
 
 	if modelConfig.ContainerNetworkingMethod() != "" {
 		// Do nothing, user has decided what to do
 	} else if environs.SupportsContainerAddresses(envcontext.WithoutCredentialInvalidator(stdcontext.Background()), environ) {
 		updateAttrs["container-networking-method"] = "provider"
-	} else if fanConfigured {
-		updateAttrs["container-networking-method"] = "fan"
 	} else {
 		updateAttrs["container-networking-method"] = "local"
 	}
 	err = m.UpdateModelConfig(providerConfigSchemaGetter, updateAttrs, nil)
 	return err
-}
-
-func (m *Model) discoverFan(environ environs.BootstrapEnviron, modelConfig *config.Config, updateAttrs map[string]interface{}) (bool, error) {
-	netEnviron, ok := environs.SupportsNetworking(environ)
-	if !ok {
-		// Not a networking environ, nothing to do here
-		return false, nil
-	}
-	fanConfig, err := modelConfig.FanConfig()
-	if err != nil {
-		return false, err
-	}
-	if len(fanConfig) != 0 {
-		logger.Debugf("Not trying to autoconfigure FAN - configured already")
-		return false, nil
-	}
-	subnets, err := netEnviron.SuperSubnets(envcontext.WithoutCredentialInvalidator(stdcontext.Background()))
-	if errors.Is(err, errors.NotSupported) || (err == nil && len(subnets) == 0) {
-		logger.Debugf("Not trying to autoconfigure FAN - SuperSubnets not supported or empty")
-		return false, nil
-	}
-	if err != nil {
-		return false, err
-	}
-	var outputTable []string
-
-	fanOverlays := []string{"252.0.0.0/8", "253.0.0.0/8", "254.0.0.0/8", "250.0.0.0/8", "251.0.0.0/8"}
-	fanOverlayForUnderlay := func(underlay string) string {
-		_, ipNet, err := net.ParseCIDR(underlay)
-		if err != nil {
-			return ""
-		}
-		// We don't create FAN networks for IPv6 networks
-		if ipNet.IP.To4() == nil {
-			return ""
-		}
-		if ones, _ := ipNet.Mask.Size(); ones <= 8 {
-			return ""
-		}
-		if len(fanOverlays) == 0 {
-			return ""
-		}
-		var overlay string
-		overlay, fanOverlays = fanOverlays[0], fanOverlays[1:]
-		return overlay
-	}
-	for _, subnet := range subnets {
-		overlay := fanOverlayForUnderlay(subnet)
-		if overlay != "" {
-			outputTable = append(outputTable, fmt.Sprintf("%s=%s", subnet, overlay))
-		}
-	}
-	if len(outputTable) > 0 {
-		updateAttrs["fan-config"] = strings.Join(outputTable, " ")
-		return true, nil
-	}
-	return false, nil
 }


### PR DESCRIPTION
As part of dropping the support for fan networks in juju 4.0, we are as a first step removing the SuperSubnets function from the environs networking interface and the implementations in all providers.

One step further was taken as well, by removing the fan discovery in container networking auto configure (in legacy state). This means that now the container networking config can either be "provider" or "local". Also, this method will be moved to the networking domain in a future patch.



## Checklist



- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```
go test github.com/juju/juju/state/... -gocheck.v -gocheck.f="ContainerNetworkingSuite"
```

Bootstrapping on aws and adding a model should trigger the container networking auto configure, which should change to `local` (although this hasn't been migrated to dqlite and therefore only visible on the legacy state):
```
juju bootstrap aws c       
juju add-model m
```

## Links


**Jira card:** JUJU-6046

