### PR TITLE
Add Dqlite unit state DDL

### DIFF
--- a/domain/schema/model.go
+++ b/domain/schema/model.go
@@ -484,6 +484,39 @@ ON unit (application_uuid);
 
 CREATE INDEX idx_unit_net_node
 ON unit (net_node_uuid);
+
+CREATE TABLE unit_state (
+    unit_uuid       TEXT PRIMARY KEY,
+    uniter_state    TEXT,
+    storage_state   TEXT,
+    secret_state    TEXT,
+    CONSTRAINT      fk_unit_state_unit
+        FOREIGN KEY (unit_uuid)
+        REFERENCES  unit(uuid)
+);
+
+-- Local charm state stored upon hook commit with uniter state.
+CREATE TABLE unit_state_charm (
+    unit_uuid       TEXT,
+    key             TEXT,
+    value           TEXT NOT NULL,
+    PRIMARY KEY     (unit_uuid, key),
+    CONSTRAINT      fk_unit_state_charm_unit
+        FOREIGN KEY (unit_uuid)
+        REFERENCES  unit(uuid)
+);
+
+-- Local relation state stored upon hook commit with uniter state.
+CREATE TABLE unit_state_relation (
+    unit_uuid       TEXT,
+    key             TEXT,
+    value           TEXT NOT NULL,
+    PRIMARY KEY     (unit_uuid, key),
+    CONSTRAINT      fk_unit_state_relation_unit
+        FOREIGN KEY (unit_uuid)
+        REFERENCES  unit(uuid)
+);
+
 `)
 }
 

--- a/domain/schema/model.go
+++ b/domain/schema/model.go
@@ -482,7 +482,7 @@ ON unit (unit_id);
 CREATE INDEX idx_unit_application
 ON unit (application_uuid);
 
-CREATE UNIQUE INDEX idx_unit_net_node
+CREATE INDEX idx_unit_net_node
 ON unit (net_node_uuid);
 `)
 }

--- a/domain/schema/schema_test.go
+++ b/domain/schema/schema_test.go
@@ -259,6 +259,9 @@ func (s *schemaSuite) TestModelTables(c *gc.C) {
 		"cloud_service",
 		"cloud_container",
 		"unit",
+		"unit_state",
+		"unit_state_charm",
+		"unit_state_relation",
 
 		// Charm
 		"charm",

--- a/internal/worker/firewaller/firewaller_test.go
+++ b/internal/worker/firewaller/firewaller_test.go
@@ -2167,7 +2167,7 @@ func (s *GlobalModeSuite) TestRestartPortCount(c *gc.C) {
 	defer ctrl.Finish()
 
 	fw := s.newFirewaller(c, ctrl)
-	defer workertest.CleanKill(c, fw)
+	defer workertest.DirtyKill(c, fw)
 
 	app1 := s.addApplication(ctrl, "wordpress", true)
 	u1, m1, unitsCh1 := s.addUnit(c, ctrl, app1)
@@ -2200,8 +2200,8 @@ func (s *GlobalModeSuite) TestRestartPortCount(c *gc.C) {
 	u2.EXPECT().Life().Return(life.Alive)
 
 	// Start firewaller and check port.
-	fw = s.newFirewaller(c, ctrl)
-	defer workertest.CleanKill(c, fw)
+	fw2 := s.newFirewaller(c, ctrl)
+	defer workertest.CleanKill(c, fw2)
 
 	s.machinesCh <- []string{m1.Tag().Id(), m2.Tag().Id()}
 	unitsCh1 <- []string{u1.Tag().Id()}


### PR DESCRIPTION
This adds tables to hold unit state, which is retrieved by the uniter to compare against local state for determining which hooks to run, and is written during the hook commit stage.

## QA steps

None required at this stage.

## Links

**Jira card:** [JUJU-6026](https://warthogs.atlassian.net/browse/JUJU-6026)



[JUJU-6026]: https://warthogs.atlassian.net/browse/JUJU-6026?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ