### PR TITLE
Avoid installing ubuntu-fan package

### DIFF
--- a/internal/cloudconfig/cloudinit/cloudinit_ubuntu.go
+++ b/internal/cloudconfig/cloudinit/cloudinit_ubuntu.go
@@ -240,7 +240,6 @@ func (cfg *ubuntuCloudConfig) addRequiredPackages() {
 		"curl",
 		"cpu-checker",
 		"tmux",
-		"ubuntu-fan",
 	}
 	for _, pack := range packages {
 		cfg.AddPackage(pack)

--- a/internal/cloudconfig/userdatacfg_test.go
+++ b/internal/cloudconfig/userdatacfg_test.go
@@ -718,7 +718,7 @@ func (s *cloudinitSuite) TestCloudInitConfigCloudInitUserData(c *gc.C) {
 	// Verify the settings against cloudinit-userdata
 	cfgPackages := cloudcfg.Packages()
 	expectedPackages := []string{
-		`ubuntu-fan`, // last juju specified package
+		`tmux`, // last juju specified package
 		`python-keystoneclient`,
 		`python-glanceclient`,
 	}


### PR DESCRIPTION
As we are dropping the support for fan networking on juju 4.0+, the installation of this package is no longer needed.

Note that this package's binaries were only used by the fan configurer worker (which is going away in a following PR) and since we are removing the `fan` type config for container networks in https://github.com/juju/juju/pull/17406, the `fanctl` should never be triggered. 

## Checklist


- [X] Code style: imports ordered, good names, simple structure, etc
- [ ] ~Comments saying why design decisions were made~
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```
go test github.com/juju/juju/internal/cloudconfig/... -gocheck.v
```

As explained in the description, no need to trigger the fan configurer worker since that codepath is removed.

## Links


**Jira card:** JUJU-6047

