### PR TITLE
[JUJU-6065] Removed link to outdated page.

### DIFF
--- a/cmd/juju/cloud/addcredential.go
+++ b/cmd/juju/cloud/addcredential.go
@@ -91,9 +91,6 @@ Use --controller option to upload a credential to a controller.
 
 Use --client option to add a credential to the current client.
 
-Further help:
-Please visit https://discourse.charmhub.io/t/1508 for cloud-specific
-instructions.
 
 `
 


### PR DESCRIPTION
The add-credential help pointed to a page (1) specific to the GCE cloud and (2) out of date. Decided to remove it altogether as too specific and also outside of the scope of Juju docs.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ x] Code style: imports ordered, good names, simple structure, etc
~- [ ] Comments saying why design decisions were made~
~- [ ] Go unit tests, with comments saying what you're testing~
~- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
~- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

N/A

## Documentation changes

This is a documentation change.

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

[**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/](https://bugs.launchpad.net/juju/+bug/2049440)

**Jira card:** JUJU-6065

