### PR TITLE
Add instance data sql schema

### DIFF
--- a/domain/schema/model.go
+++ b/domain/schema/model.go
@@ -405,24 +405,16 @@ CREATE TABLE instance_tag (
         REFERENCES  machine(uuid)
 );
 
-CREATE TABLE lxd_profile (
-    uuid            TEXT PRIMARY KEY,
-    name            TEXT NOT NULL
-);
-
-CREATE UNIQUE INDEX idx_lxd_profile_name
-ON lxd_profile (name);
-
-CREATE TABLE instance_data_charm_profile (
-    uuid                TEXT PRIMARY KEY,
-    lxd_profile_uuid    TEXT NOT NULL,
+CREATE TABLE machine_lxd_profile (
     machine_uuid        TEXT NOT NULL,
+    lxd_profile_uuid    TEXT NOT NULL,
+    -- TODO(nvinuesa): lxd_profile_uuid should be a foreign key to the 
+    -- charm_lxd_profile uuid and therefore the CONSTRAINT should be added when 
+    -- that table is implemented.
+    PRIMARY KEY (machine_uuid, lxd_profile_uuid),
     CONSTRAINT          fk_machine_machine_uuid
         FOREIGN KEY     (machine_uuid)
-        REFERENCES      machine(uuid),
-    CONSTRAINT          fk_lxd_profile_lxd_profile_uuid
-        FOREIGN KEY     (lxd_profile_uuid)
-        REFERENCES      lxd_profile(uuid)
+        REFERENCES      machine(uuid)
 );
 `)
 }

--- a/domain/schema/model.go
+++ b/domain/schema/model.go
@@ -332,6 +332,7 @@ CREATE TABLE machine (
     machine_id      TEXT NOT NULL,
     net_node_uuid   TEXT NOT NULL,
     life_id         INT NOT NULL,
+    keep_instance   BOOLEAN,
     CONSTRAINT      fk_machine_net_node
         FOREIGN KEY (net_node_uuid)
         REFERENCES  net_node(uuid),
@@ -374,6 +375,64 @@ CREATE TABLE cloud_container (
 
 CREATE UNIQUE INDEX idx_cloud_container_net_node
 ON cloud_container (net_node_uuid);
+
+CREATE TABLE instance_data (
+    uuid            	   TEXT PRIMARY KEY,
+    machine_uuid    	   TEXT NOT NULL,
+    instance_id 	   TEXT NOT NULL,
+    display_name 	   TEXT NOT NULL,
+    arch            	   TEXT,
+    mod 	    	   INT,
+    root_disk 	    	   INT,
+    root_disk_source       TEXT,
+    cpu_cores 		   INT,
+    cpu_power 		   INT,
+    availability_zone_uuid TEXT,
+    virt_type 		   TEXT,
+    CONSTRAINT             fk_machine_machine_uuid
+        FOREIGN KEY            (machine_uuid)
+        REFERENCES             machine(uuid),
+    CONSTRAINT             fk_availability_zone_availability_zone_uuid
+        FOREIGN KEY            (availability_zone_uuid)
+        REFERENCES             availability_zone(uuid)
+);
+
+CREATE TABLE instance_tag (
+    uuid            TEXT PRIMARY KEY,
+    tag 	    TEXT NOT NULL
+);
+
+CREATE TABLE instance_tag_reference (
+    uuid            TEXT PRIMARY KEY,
+    tag_uuid 	    TEXT NOT NULL,
+    instance_uuid   TEXT NOT NULL,
+    CONSTRAINT      fk_instance_tag_tag_uuid
+        FOREIGN KEY     (tag_uuid)
+        REFERENCES      instance_tag(uuid),
+    CONSTRAINT      fk_instance_data_instance_uuid
+        FOREIGN KEY     (instance_uuid)
+        REFERENCES      instance_data(uuid)
+);
+
+CREATE TABLE lxd_profile (
+    uuid            TEXT PRIMARY KEY,
+    profile_id 	    TEXT NOT NULL
+);
+
+CREATE UNIQUE INDEX idx_lxd_profile_profile_id
+ON lxd_profile (profile_id);
+
+CREATE TABLE charm_profile (
+    uuid 		TEXT PRIMARY KEY,
+    lxd_profile_uuid    TEXT NOT NULL,
+    machine_uuid 	TEXT NOT NULL,
+    CONSTRAINT          fk_machine_machine_uuid
+        FOREIGN KEY         (machine_uuid)
+        REFERENCES          machine(uuid),
+    CONSTRAINT          fk_lxd_profile_lxd_profile_uuid
+        FOREIGN KEY         (lxd_profile_uuid)
+        REFERENCES          lxd_profile(uuid)
+);
 `)
 }
 

--- a/domain/schema/model.go
+++ b/domain/schema/model.go
@@ -390,11 +390,11 @@ CREATE TABLE instance_data (
     availability_zone_uuid TEXT,
     virt_type 		   TEXT,
     CONSTRAINT             fk_machine_machine_uuid
-        FOREIGN KEY            (machine_uuid)
-        REFERENCES             machine(uuid),
+        FOREIGN KEY        (machine_uuid)
+        REFERENCES         machine(uuid),
     CONSTRAINT             fk_availability_zone_availability_zone_uuid
-        FOREIGN KEY            (availability_zone_uuid)
-        REFERENCES             availability_zone(uuid)
+        FOREIGN KEY        (availability_zone_uuid)
+        REFERENCES         availability_zone(uuid)
 );
 
 CREATE TABLE instance_tag (
@@ -407,11 +407,11 @@ CREATE TABLE instance_tag_reference (
     tag_uuid 	    TEXT NOT NULL,
     instance_uuid   TEXT NOT NULL,
     CONSTRAINT      fk_instance_tag_tag_uuid
-        FOREIGN KEY     (tag_uuid)
-        REFERENCES      instance_tag(uuid),
+        FOREIGN KEY (tag_uuid)
+        REFERENCES  instance_tag(uuid),
     CONSTRAINT      fk_instance_data_instance_uuid
-        FOREIGN KEY     (instance_uuid)
-        REFERENCES      instance_data(uuid)
+        FOREIGN KEY (instance_uuid)
+        REFERENCES  instance_data(uuid)
 );
 
 CREATE TABLE lxd_profile (
@@ -427,11 +427,11 @@ CREATE TABLE charm_profile (
     lxd_profile_uuid    TEXT NOT NULL,
     machine_uuid 	TEXT NOT NULL,
     CONSTRAINT          fk_machine_machine_uuid
-        FOREIGN KEY         (machine_uuid)
-        REFERENCES          machine(uuid),
+        FOREIGN KEY     (machine_uuid)
+        REFERENCES      machine(uuid),
     CONSTRAINT          fk_lxd_profile_lxd_profile_uuid
-        FOREIGN KEY         (lxd_profile_uuid)
-        REFERENCES          lxd_profile(uuid)
+        FOREIGN KEY     (lxd_profile_uuid)
+        REFERENCES      lxd_profile(uuid)
 );
 `)
 }

--- a/domain/schema/model.go
+++ b/domain/schema/model.go
@@ -377,18 +377,17 @@ CREATE UNIQUE INDEX idx_cloud_container_net_node
 ON cloud_container (net_node_uuid);
 
 CREATE TABLE instance_data (
-    uuid            	   TEXT PRIMARY KEY,
-    machine_uuid    	   TEXT NOT NULL,
-    instance_id 	   TEXT NOT NULL,
-    display_name 	   TEXT NOT NULL,
-    arch            	   TEXT,
-    mod 	    	   INT,
-    root_disk 	    	   INT,
+    machine_uuid           TEXT PRIMARY KEY,
+    instance_id            TEXT NOT NULL,
+    display_name           TEXT NOT NULL,
+    arch                   TEXT,
+    mem                    INT,
+    root_disk              INT,
     root_disk_source       TEXT,
-    cpu_cores 		   INT,
-    cpu_power 		   INT,
+    cpu_cores              INT,
+    cpu_power              INT,
     availability_zone_uuid TEXT,
-    virt_type 		   TEXT,
+    virt_type              TEXT,
     CONSTRAINT             fk_machine_machine_uuid
         FOREIGN KEY        (machine_uuid)
         REFERENCES         machine(uuid),
@@ -398,34 +397,26 @@ CREATE TABLE instance_data (
 );
 
 CREATE TABLE instance_tag (
-    uuid            TEXT PRIMARY KEY,
-    tag 	    TEXT NOT NULL
-);
-
-CREATE TABLE instance_tag_reference (
-    uuid            TEXT PRIMARY KEY,
-    tag_uuid 	    TEXT NOT NULL,
-    instance_uuid   TEXT NOT NULL,
-    CONSTRAINT      fk_instance_tag_tag_uuid
-        FOREIGN KEY (tag_uuid)
-        REFERENCES  instance_tag(uuid),
-    CONSTRAINT      fk_instance_data_instance_uuid
-        FOREIGN KEY (instance_uuid)
-        REFERENCES  instance_data(uuid)
+    machine_uuid    TEXT NOT NULL,
+    tag             TEXT NOT NULL,
+    PRIMARY KEY (machine_uuid, tag),
+    CONSTRAINT      fk_machine_machine_uuid
+        FOREIGN KEY (machine_uuid)
+        REFERENCES  machine(uuid)
 );
 
 CREATE TABLE lxd_profile (
     uuid            TEXT PRIMARY KEY,
-    profile_id 	    TEXT NOT NULL
+    name            TEXT NOT NULL
 );
 
-CREATE UNIQUE INDEX idx_lxd_profile_profile_id
-ON lxd_profile (profile_id);
+CREATE UNIQUE INDEX idx_lxd_profile_name
+ON lxd_profile (name);
 
-CREATE TABLE charm_profile (
-    uuid 		TEXT PRIMARY KEY,
+CREATE TABLE instance_data_charm_profile (
+    uuid                TEXT PRIMARY KEY,
     lxd_profile_uuid    TEXT NOT NULL,
-    machine_uuid 	TEXT NOT NULL,
+    machine_uuid        TEXT NOT NULL,
     CONSTRAINT          fk_machine_machine_uuid
         FOREIGN KEY     (machine_uuid)
         REFERENCES      machine(uuid),

--- a/domain/schema/schema_test.go
+++ b/domain/schema/schema_test.go
@@ -263,9 +263,8 @@ func (s *schemaSuite) TestModelTables(c *gc.C) {
 		"cloud_container",
 		"instance_data",
 		"lxd_profile",
-		"charm_profile",
+		"instance_data_charm_profile",
 		"instance_tag",
-		"instance_tag_reference",
 
 		// Unit
 		"unit",

--- a/domain/schema/schema_test.go
+++ b/domain/schema/schema_test.go
@@ -262,8 +262,7 @@ func (s *schemaSuite) TestModelTables(c *gc.C) {
 		"cloud_service",
 		"cloud_container",
 		"instance_data",
-		"lxd_profile",
-		"instance_data_charm_profile",
+		"machine_lxd_profile",
 		"instance_tag",
 
 		// Unit

--- a/domain/schema/schema_test.go
+++ b/domain/schema/schema_test.go
@@ -224,6 +224,9 @@ func (s *schemaSuite) TestModelTables(c *gc.C) {
 
 	// Ensure that each table is present.
 	expected := set.NewStrings(
+		// Application
+		"application",
+
 		// Annotations
 		"annotation_application",
 		"annotation_charm",
@@ -253,11 +256,18 @@ func (s *schemaSuite) TestModelTables(c *gc.C) {
 		"object_store_metadata_path",
 		"object_store_metadata_hash_type",
 
-		"application",
+		// Node
 		"machine",
 		"net_node",
 		"cloud_service",
 		"cloud_container",
+		"instance_data",
+		"lxd_profile",
+		"charm_profile",
+		"instance_tag",
+		"instance_tag_reference",
+
+		// Unit
 		"unit",
 		"unit_state",
 		"unit_state_charm",
@@ -267,11 +277,11 @@ func (s *schemaSuite) TestModelTables(c *gc.C) {
 		"charm",
 		"charm_storage",
 
-		// Spaces
+		// Space
 		"space",
 		"provider_space",
 
-		// Subnets
+		// Subnet
 		"subnet",
 		"provider_subnet",
 		"provider_network",


### PR DESCRIPTION
This patch adds the new tables, index and constraints for the instance data sub-domain in the machine domain.

Five tables are added here:
 - instance_data: Contains the hardware caracteristics of a machine that was actually instanciated by the provider.
 - lxd_profile: Contains the known names of the lxd profiles. This is currently only used for the charm profiles, but later any reference to the lxd profiles should use this table.
 - charm_profile: Is only a join table between machines and lxd profiles. Will be used as a replacement for CharmProfiles in the legacy state.
 - instance_tag: Contains the list of known tags used to identify a machine.
 - instance_tag_reference: Is a join table between instance tags and instance data.

Also, keep_instance is added as a boolean column to the machine table.


## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [ ] ~Comments saying why design decisions were made~
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

This is only a new schema add, so unit tests and bootstrapping should be enough:

```
TEST_PACKAGES="./domain/schema/... -count=1 -race" make run-go-tests
```
```
juju bootstrap localhost c
```

## Links

**Jira card:** JUJU-6028

