### PR TITLE
Remove support for fan subnets on the network domain

### DIFF
--- a/domain/network/service/interface.go
+++ b/domain/network/service/interface.go
@@ -74,7 +74,4 @@ type SubnetState interface {
 	// AllSubnetsQuery returns the SQL query that finds all subnet UUIDs from the
 	// subnet table, needed for the subnets watcher.
 	AllSubnetsQuery(ctx context.Context, db database.TxnRunner) ([]string, error)
-	// AllAssociatedSubnetsQuery returns the SQL query that finds all associated
-	// subnet UUIDs from the subnet_association table, needed for the subnets watcher.
-	AllAssociatedSubnetsQuery(ctx context.Context, db database.TxnRunner) ([]string, error)
 }

--- a/domain/network/service/package_mock_test.go
+++ b/domain/network/service/package_mock_test.go
@@ -121,45 +121,6 @@ func (c *MockStateAddSubnetCall) DoAndReturn(f func(context.Context, network.Sub
 	return c
 }
 
-// AllAssociatedSubnetsQuery mocks base method.
-func (m *MockState) AllAssociatedSubnetsQuery(arg0 context.Context, arg1 database.TxnRunner) ([]string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AllAssociatedSubnetsQuery", arg0, arg1)
-	ret0, _ := ret[0].([]string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// AllAssociatedSubnetsQuery indicates an expected call of AllAssociatedSubnetsQuery.
-func (mr *MockStateMockRecorder) AllAssociatedSubnetsQuery(arg0, arg1 any) *MockStateAllAssociatedSubnetsQueryCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllAssociatedSubnetsQuery", reflect.TypeOf((*MockState)(nil).AllAssociatedSubnetsQuery), arg0, arg1)
-	return &MockStateAllAssociatedSubnetsQueryCall{Call: call}
-}
-
-// MockStateAllAssociatedSubnetsQueryCall wrap *gomock.Call
-type MockStateAllAssociatedSubnetsQueryCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockStateAllAssociatedSubnetsQueryCall) Return(arg0 []string, arg1 error) *MockStateAllAssociatedSubnetsQueryCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockStateAllAssociatedSubnetsQueryCall) Do(f func(context.Context, database.TxnRunner) ([]string, error)) *MockStateAllAssociatedSubnetsQueryCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateAllAssociatedSubnetsQueryCall) DoAndReturn(f func(context.Context, database.TxnRunner) ([]string, error)) *MockStateAllAssociatedSubnetsQueryCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // AllSubnetsQuery mocks base method.
 func (m *MockState) AllSubnetsQuery(arg0 context.Context, arg1 database.TxnRunner) ([]string, error) {
 	m.ctrl.T.Helper()

--- a/domain/network/service/watcher.go
+++ b/domain/network/service/watcher.go
@@ -7,7 +7,6 @@ import (
 	"context"
 
 	"github.com/juju/collections/set"
-	"github.com/juju/errors"
 
 	"github.com/juju/juju/core/changestream"
 	"github.com/juju/juju/core/logger"
@@ -44,26 +43,12 @@ func NewWatchableService(st State, provider providertracker.ProviderGetter[Provi
 func (s *WatchableService) WatchSubnets(ctx context.Context, subnetUUIDsToWatch set.Strings) (watcher.StringsWatcher, error) {
 	filter := subnetUUIDsFilter(subnetUUIDsToWatch)
 
-	subnetWatcher, err := s.watcherFactory.NewNamespaceMapperWatcher(
+	return s.watcherFactory.NewNamespaceMapperWatcher(
 		"subnet",
 		changestream.All,
 		s.st.AllSubnetsQuery,
 		eventsource.FilterEvents(filter),
 	)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	subnetAssociationWatcher, err := s.watcherFactory.NewNamespaceMapperWatcher(
-		"subnet_association",
-		changestream.All,
-		s.st.AllAssociatedSubnetsQuery,
-		eventsource.FilterEvents(filter),
-	)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	return eventsource.NewMultiStringsWatcher(ctx, subnetWatcher, subnetAssociationWatcher)
 }
 
 // subnetUUIDsFilter filters the returned subnet UUIDs from the changelog

--- a/domain/network/state/types.go
+++ b/domain/network/state/types.go
@@ -19,8 +19,6 @@ type Subnet struct {
 	VLANtag int `db:"vlan_tag"`
 	// SpaceUUID is the space UUID.
 	SpaceUUID string `db:"space_uuid"`
-	// SubnetType indicates if the subnet is a fan overlay or a base subnet.
-	SubnetType int `db:"subnet_type_id"`
 }
 
 // ProviderSubnet represents a single row from the provider_subnet table.
@@ -109,12 +107,6 @@ type SpaceSubnetRow struct {
 
 	// SubnetAZ is the availability zones on the subnet.
 	SubnetAZ string `db:"subnet_az"`
-
-	// SubnetOverlayCIDR is the subnet's overlay cidr in a fan setup.
-	SubnetOverlayCIDR sql.NullString `db:"subnet_overlay_cidr"`
-
-	// SubnetUnderlayCIDR is the subnet's underlay cidr in a fan setup.
-	SubnetUnderlayCIDR sql.NullString `db:"subnet_underlay_cidr"`
 }
 
 // Alias type to a slice of Space/Subnet rows.
@@ -193,13 +185,6 @@ func (s SpaceSubnetRow) ToSubnetInfo() *network.SubnetInfo {
 	}
 	if s.SubnetProviderSpaceUUID.Valid {
 		sInfo.ProviderSpaceId = network.Id(s.SubnetProviderSpaceUUID.String)
-	}
-	if s.SubnetUnderlayCIDR.Valid {
-		underlay := ""
-		if s.SubnetUnderlayCIDR.Valid {
-			underlay = s.SubnetUnderlayCIDR.String
-		}
-		sInfo.SetFan(underlay, "")
 	}
 	if s.SubnetSpaceUUID.Valid {
 		sInfo.SpaceID = s.SubnetSpaceUUID.String

--- a/domain/network/watcher_test.go
+++ b/domain/network/watcher_test.go
@@ -55,45 +55,6 @@ func (s *watcherSuite) TestWatchWithAdd(c *gc.C) {
 	watcherC.AssertChange(createdSubnetID.String())
 }
 
-func (s *watcherSuite) TestWatchWithSubnetAssociation(c *gc.C) {
-	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "subnet")
-
-	svc := service.NewWatchableService(
-		state.NewState(func() (database.TxnRunner, error) { return factory() }, loggertesting.WrapCheckLog(c)),
-		nil,
-		domain.NewWatcherFactory(factory,
-			loggertesting.WrapCheckLog(c),
-		),
-		loggertesting.WrapCheckLog(c),
-	)
-	watcher, err := svc.WatchSubnets(context.Background(), set.NewStrings())
-	c.Assert(err, jc.ErrorIsNil)
-	watcherC := watchertest.NewStringsWatcherC(c, watcher)
-
-	// Add a new subnet.
-	createdSubnetID0, err := svc.AddSubnet(context.Background(), network.SubnetInfo{
-		CIDR:              "192.168.0.0/20",
-		ProviderId:        "subnet-provider-id-0",
-		ProviderNetworkId: "subnet-provider-network-id-0",
-	})
-	c.Assert(err, jc.ErrorIsNil)
-	createdSubnetID1, err := svc.AddSubnet(context.Background(), network.SubnetInfo{
-		CIDR:              "10.0.0.0/12",
-		ProviderId:        "subnet-provider-id-1",
-		ProviderNetworkId: "subnet-provider-network-id-1",
-		FanInfo: &network.FanCIDRs{
-			FanLocalUnderlay: "192.168.0.0/20",
-			FanOverlay:       "10.0.0.0/8",
-		},
-	})
-	c.Assert(err, jc.ErrorIsNil)
-	// Get the changes, we know we must get 3 changes, 2 for the newly
-	// created subnets and the other one for the association between the
-	// two subnets (which should contain the UUID of the first created
-	// subnet which is the underlay).
-	watcherC.AssertChange(createdSubnetID0.String(), createdSubnetID0.String(), createdSubnetID1.String())
-}
-
 func (s *watcherSuite) TestWatchWithDelete(c *gc.C) {
 	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "subnet")
 

--- a/domain/schema/schema_test.go
+++ b/domain/schema/schema_test.go
@@ -273,10 +273,6 @@ func (s *schemaSuite) TestModelTables(c *gc.C) {
 
 		// Subnets
 		"subnet",
-		"subnet_association_type",
-		"subnet_type",
-		"subnet_type_association_type",
-		"subnet_association",
 		"provider_subnet",
 		"provider_network",
 		"provider_network_subnet",
@@ -461,10 +457,6 @@ func (s *schemaSuite) TestModelTriggers(c *gc.C) {
 		"trg_log_storage_volume_delete",
 
 		"trg_secret_permission_immutable_update",
-
-		"trg_log_subnet_association_delete",
-		"trg_log_subnet_association_insert",
-		"trg_log_subnet_association_update",
 
 		"trg_log_subnet_delete",
 		"trg_log_subnet_insert",


### PR DESCRIPTION
As part of the drop of fan networking support on juju 4.0, we are now removing the modelling of fan networks on the new network domain.

This removes the subnet association tables and the subnet type tables along with their references and all queries that used them. From this patch forward, only (flat hierarchy) subnets are stored without any association between them.



## Checklist


- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps
Bootstrap on AWS and make sure no fan subnets are returned:
```
juju bootstrap aws c
juju add-model m
juju subnets
subnets:
  172.31.0.0/20:
    type: ipv4
    provider-id: subnet-7d4c9614
    provider-network-id: vpc-8abf64e3
    space: alpha
    zones:
    - eu-west-3a
  172.31.16.0/20:
    type: ipv4
    provider-id: subnet-8641bdfd
    provider-network-id: vpc-8abf64e3
    space: alpha
    zones:
    - eu-west-3b
  172.31.32.0/20:
    type: ipv4
    provider-id: subnet-748c9d3e
    provider-network-id: vpc-8abf64e3
    space: alpha
    zones:
    - eu-west-3c
  172.31.254.0/24:
    type: ipv4
    provider-id: subnet-034e151128f81628c
    provider-network-id: vpc-8abf64e3
    space: alpha
    zones:
    - eu-west-3c
```  


## Links

**Jira card:** JUJU-6045

