### PR TITLE
chore: add logging to tryInOrderLoginProviders Login method

### DIFF
--- a/cmd/internal/loginprovider/tryinorderloginprovider.go
+++ b/cmd/internal/loginprovider/tryinorderloginprovider.go
@@ -7,6 +7,7 @@ import (
 	"context"
 
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 
 	"github.com/juju/juju/api"
 	"github.com/juju/juju/api/base"
@@ -17,22 +18,27 @@ import (
 // of the first on that succeeds will be returned.
 // This login provider should only be used when connecting to a controller
 // for the first time when we still don't know which login method.
-func NewTryInOrderLoginProvider(providers ...api.LoginProvider) api.LoginProvider {
+func NewTryInOrderLoginProvider(logger loggo.Logger, providers ...api.LoginProvider) api.LoginProvider {
 	return &tryInOrderLoginProviders{
 		providers: providers,
+		logger:    logger,
 	}
 }
 
 type tryInOrderLoginProviders struct {
 	providers []api.LoginProvider
+	logger    loggo.Logger
 }
 
 // Login implements the LoginProvider.Login method.
 func (p *tryInOrderLoginProviders) Login(ctx context.Context, caller base.APICaller) (*api.LoginResultParams, error) {
 	var lastError error
-	for _, provider := range p.providers {
+	for i, provider := range p.providers {
 		result, err := provider.Login(ctx, caller)
-		if err == nil {
+		if err != nil {
+			p.logger.Debugf("login error using provider %d - %s", i, err.Error())
+		} else {
+			p.logger.Debugf("successful login using provider %d", i)
 			return result, nil
 		}
 		lastError = err

--- a/cmd/internal/loginprovider/tryinorderloginprovider_test.go
+++ b/cmd/internal/loginprovider/tryinorderloginprovider_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 
 	"github.com/juju/errors"
+	"github.com/juju/loggo"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -24,11 +25,12 @@ func (s *tryInOrderLoginProviderSuite) Test(c *gc.C) {
 	p2 := &mockLoginProvider{err: errors.New("provider 2 error")}
 	p3 := &mockLoginProvider{}
 
-	lp := loginprovider.NewTryInOrderLoginProvider(p1, p2)
+	logger := loggo.GetLogger("juju.cmd.loginprovider")
+	lp := loginprovider.NewTryInOrderLoginProvider(logger, p1, p2)
 	_, err := lp.Login(context.Background(), nil)
 	c.Assert(err, gc.ErrorMatches, "provider 2 error")
 
-	lp = loginprovider.NewTryInOrderLoginProvider(p1, p2, p3)
+	lp = loginprovider.NewTryInOrderLoginProvider(logger, p1, p2, p3)
 	_, err = lp.Login(context.Background(), nil)
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/cmd/juju/controller/register.go
+++ b/cmd/juju/controller/register.go
@@ -26,6 +26,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 	jujuhttp "github.com/juju/http/v2"
+	"github.com/juju/loggo"
 	"github.com/juju/names/v5"
 	"golang.org/x/crypto/nacl/secretbox"
 	"golang.org/x/crypto/ssh/terminal"
@@ -278,6 +279,7 @@ func (c *registerCommand) publicControllerDetails(ctx *cmd.Context, host, contro
 	// oauth device flow, failing that it will try to log in using
 	// user-pass or macaroons.
 	dialOpts.LoginProvider = loginprovider.NewTryInOrderLoginProvider(
+		loggo.GetLogger("juju.cmd.loginprovider"),
 		loginprovider.NewSessionTokenLoginProvider(
 			"",
 			func(format string, params ...any) error {

--- a/cmd/juju/user/login.go
+++ b/cmd/juju/user/login.go
@@ -19,6 +19,7 @@ import (
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
+	"github.com/juju/loggo"
 	"github.com/juju/names/v5"
 	"gopkg.in/httprequest.v1"
 
@@ -383,6 +384,7 @@ func (c *loginCommand) publicControllerLogin(
 	}
 
 	dialOpts.LoginProvider = loginprovider.NewTryInOrderLoginProvider(
+		loggo.GetLogger("juju.cmd.loginprovider"),
 		loginprovider.NewSessionTokenLoginProvider(
 			sessionToken,
 			func(format string, params ...any) error {


### PR DESCRIPTION
This PR adds logging to the `tryInOrderLoginProviders`'s Login method.

This is the default login provider which loops through a a set of providers to attempt to login to a controller.

Because we try multiple login providers any errors before the last one are discarded and only the final error is returned to the user. To help debug issues where an earlier login provider was expected to work, I've added debug log lines to print the error that normally would've been returned to the user.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

~~- [ ] Code style: imports ordered, good names, simple structure, etc~~
~~- [ ] Comments saying why design decisions were made~~
~~- [ ] Go unit tests, with comments saying what you're testing~~
~~- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~~
~~- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages`~~

## QA steps

- Bootstrap controller.
- `juju show-controller <new-controller>`
- `juju unregister <controller-name>`
- go build -o new-juju ./cmd/juju
- ./new-juju login <controller-ip> -c test-controller --debug

Output should resemble:
```
14:10:32 DEBUG juju.api try_in_order_login_provider.go:35 login error using provider 0 - this version of Juju does not support login from old clients (not supported) (not supported)
14:10:32 DEBUG juju.api try_in_order_login_provider.go:35 login error using provider 1 - "user-" is not a valid user tag
ERROR cannot log into "10.16.149.230:17070": "user-" is not a valid user tag
```
