### PR TITLE
chore: pass an io.Writer instead of a callback function for session token login

### DIFF
--- a/cmd/juju/controller/register.go
+++ b/cmd/juju/controller/register.go
@@ -280,10 +280,7 @@ func (c *registerCommand) publicControllerDetails(ctx *cmd.Context, host, contro
 	dialOpts.LoginProvider = loginprovider.NewTryInOrderLoginProvider(
 		loginprovider.NewSessionTokenLoginProvider(
 			"",
-			func(format string, params ...any) error {
-				_, err := fmt.Fprintf(ctx.Stderr, format, params...)
-				return err
-			},
+			ctx.Stderr,
 			func(sessionToken string) error {
 				return c.store.UpdateAccount(controllerName, jujuclient.AccountDetails{
 					Type:         jujuclient.OAuth2DeviceFlowAccountDetailsType,

--- a/cmd/juju/user/login.go
+++ b/cmd/juju/user/login.go
@@ -385,10 +385,7 @@ func (c *loginCommand) publicControllerLogin(
 	dialOpts.LoginProvider = loginprovider.NewTryInOrderLoginProvider(
 		loginprovider.NewSessionTokenLoginProvider(
 			sessionToken,
-			func(format string, params ...any) error {
-				_, err := fmt.Fprintf(ctx.Stderr, format, params...)
-				return err
-			},
+			ctx.Stderr,
 			func(sessionToken string) error {
 				return c.ClientStore().UpdateAccount(controllerName, jujuclient.AccountDetails{
 					Type:         jujuclient.OAuth2DeviceFlowAccountDetailsType,


### PR DESCRIPTION
This PR modifies the way the `sessionTokenLoginProvider` is instantiated. Currently the struct accepts a callback function to dictate how to print the device code to the user (used for login with an external IdP). The print was missing the addition of a new-line character to avoid run-on lines in the terminal and I found that I would've had to change the message to include a `\n` or change the print logic (to check for a missing new line and add one) in two places, so instead of doing that I have refactored things a bit.

The `newSessionTokenLoginProvider` constructor now accepts an io.Writer instead of a callback function. The logic for creating the message is kept closer to the SessionTokenLoginProvider, the interface provides the logic to write the message and the callback can be removed.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [ ] ~~Comments saying why design decisions were made~~
- [x] Go unit tests, with comments saying what you're testing (fixed tests)
- [ ] ~~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~~
- [ ] ~~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~~

## QA steps

QA requires a JIMM server running in order to test OAuth device flow login. One can follow the tutorial [here](https://canonical-jaas-documentation.readthedocs-hosted.com/en/latest/explanation/jaas_overview/) (very lengthy) to stand up JIMM and then do the following,
- `go build -o juju-client ./cmd/juju`
- `./juju-client login jimm.test.localhost:443 -c jimm-k8s --debug`

Output should resemble the following,
```
Please visit https://kratos.10.64.140.46.nip.io/iam-hydra/oauth2/device/verify and enter code AFHQOBGY to log in.
Welcome, kian.parvin@canonical.com. You are now logged into "jimm-k8s".
```
Previously both lines were printed without a line break.
