### PR TITLE
Complete machine schema DDL

### DIFF
--- a/domain/schema/model/sql/0008-network.sql
+++ b/domain/schema/model/sql/0008-network.sql
@@ -2,25 +2,6 @@ CREATE TABLE net_node (
     uuid TEXT PRIMARY KEY
 );
 
-CREATE TABLE machine (
-    uuid            TEXT PRIMARY KEY,
-    machine_id      TEXT NOT NULL,
-    net_node_uuid   TEXT NOT NULL,
-    life_id         INT NOT NULL,
-    CONSTRAINT      fk_machine_net_node
-        FOREIGN KEY (net_node_uuid)
-        REFERENCES  net_node(uuid),
-    CONSTRAINT      fk_machine_life
-        FOREIGN KEY (life_id)
-        REFERENCES  life(id)
-);
-
-CREATE UNIQUE INDEX idx_machine_id
-ON machine (machine_id);
-
-CREATE UNIQUE INDEX idx_machine_net_node
-ON machine (net_node_uuid);
-
 CREATE TABLE cloud_service (
     uuid             TEXT PRIMARY KEY,
     net_node_uuid    TEXT NOT NULL,

--- a/domain/schema/model/sql/0017-constraint.sql
+++ b/domain/schema/model/sql/0017-constraint.sql
@@ -18,8 +18,7 @@ CREATE TABLE "constraint" (
 );
 
 CREATE TABLE constraint_tag (
-    id                  INT PRIMARY KEY,
-    constraint_uuid     TEXT NOT NULL,
+    constraint_uuid     TEXT PRIMARY KEY,
     tag                 TEXT NOT NULL,
     CONSTRAINT          fk_constraint_tag_constraint
         FOREIGN KEY     (constraint_uuid)
@@ -27,9 +26,9 @@ CREATE TABLE constraint_tag (
 );
 
 CREATE TABLE constraint_space (
-    id                  INT PRIMARY KEY,
-    constraint_uuid     TEXT NOT NULL,
+    constraint_uuid     TEXT PRIMARY KEY,
     space               TEXT NOT NULL,
+    exclude             BOOLEAN,
     CONSTRAINT          fk_constraint_space_constraint
         FOREIGN KEY     (constraint_uuid)
         REFERENCES      "constraint"(uuid)
@@ -39,8 +38,7 @@ CREATE TABLE constraint_space (
 );
 
 CREATE TABLE constraint_zone (
-    id                  INT PRIMARY KEY,
-    constraint_uuid     TEXT NOT NULL,
+    constraint_uuid     TEXT PRIMARY KEY,
     zone                TEXT NOT NULL,
     CONSTRAINT          fk_constraint_zone_constraint
         FOREIGN KEY     (constraint_uuid)

--- a/domain/schema/model/sql/0017-constraint.sql
+++ b/domain/schema/model/sql/0017-constraint.sql
@@ -18,15 +18,16 @@ CREATE TABLE "constraint" (
 );
 
 CREATE TABLE constraint_tag (
-    constraint_uuid     TEXT PRIMARY KEY,
+    constraint_uuid     TEXT NOT NULL,
     tag                 TEXT NOT NULL,
     CONSTRAINT          fk_constraint_tag_constraint
         FOREIGN KEY     (constraint_uuid)
-        REFERENCES      "constraint"(uuid)
+        REFERENCES      "constraint"(uuid),
+    PRIMARY KEY         (constraint_uuid, tag)
 );
 
 CREATE TABLE constraint_space (
-    constraint_uuid     TEXT PRIMARY KEY,
+    constraint_uuid     TEXT NOT NULL,
     space               TEXT NOT NULL,
     exclude             BOOLEAN,
     CONSTRAINT          fk_constraint_space_constraint
@@ -34,13 +35,15 @@ CREATE TABLE constraint_space (
         REFERENCES      "constraint"(uuid)
     CONSTRAINT          fk_constraint_space_space
         FOREIGN KEY     (space)
-        REFERENCES      space(name)
+        REFERENCES      space(name),
+    PRIMARY KEY         (constraint_uuid, space)
 );
 
 CREATE TABLE constraint_zone (
-    constraint_uuid     TEXT PRIMARY KEY,
+    constraint_uuid     TEXT NOT NULL,
     zone                TEXT NOT NULL,
     CONSTRAINT          fk_constraint_zone_constraint
         FOREIGN KEY     (constraint_uuid)
-        REFERENCES      "constraint"(uuid)
+        REFERENCES      "constraint"(uuid),
+    PRIMARY KEY         (constraint_uuid, zone)
 );

--- a/domain/schema/model/sql/0017-constraint.sql
+++ b/domain/schema/model/sql/0017-constraint.sql
@@ -1,0 +1,48 @@
+CREATE TABLE "constraint" (
+    uuid                TEXT PRIMARY KEY,
+    arch                TEXT,
+    cpu_cores           INT,
+    cpu_power           INT,
+    mem                 INT,
+    root_disk           INT,
+    root_disk_source    TEXT,
+    instance_role       TEXT,
+    instance_type       TEXT,
+    container_type_id   INT,
+    virt_type           TEXT,
+    allocate_public_ip  BOOLEAN,
+    image_id            TEXT,
+    CONSTRAINT          fk_constraint_container_type
+        FOREIGN KEY     (container_type_id)
+        REFERENCES      container_type(id)
+);
+
+CREATE TABLE constraint_tag (
+    id                  INT PRIMARY KEY,
+    constraint_uuid     TEXT NOT NULL,
+    tag                 TEXT NOT NULL,
+    CONSTRAINT          fk_constraint_tag_constraint
+        FOREIGN KEY     (constraint_uuid)
+        REFERENCES      "constraint"(uuid)
+);
+
+CREATE TABLE constraint_space (
+    id                  INT PRIMARY KEY,
+    constraint_uuid     TEXT NOT NULL,
+    space               TEXT NOT NULL,
+    CONSTRAINT          fk_constraint_space_constraint
+        FOREIGN KEY     (constraint_uuid)
+        REFERENCES      "constraint"(uuid)
+    CONSTRAINT          fk_constraint_space_space
+        FOREIGN KEY     (space)
+        REFERENCES      space(name)
+);
+
+CREATE TABLE constraint_zone (
+    id                  INT PRIMARY KEY,
+    constraint_uuid     TEXT NOT NULL,
+    zone                TEXT NOT NULL,
+    CONSTRAINT          fk_constraint_zone_constraint
+        FOREIGN KEY     (constraint_uuid)
+        REFERENCES      "constraint"(uuid)
+);

--- a/domain/schema/model/sql/0018-machine.sql
+++ b/domain/schema/model/sql/0018-machine.sql
@@ -38,15 +38,14 @@ INSERT INTO container_type VALUES
     (0, 'lxd');
 
 CREATE TABLE machine_constraint (
-    machine_uuid     TEXT NOT NULL,
+    machine_uuid     TEXT PRIMARY KEY,
     constraint_uuid  TEXT NOT NULL,
     CONSTRAINT       fk_machine_constraint_machine
         FOREIGN KEY  (machine_uuid)
         REFERENCES   machine(uuid),
     CONSTRAINT       fk_machine_constraint_constraint
         FOREIGN KEY  (constraint_uuid)
-        REFERENCES   "constraint"(uuid),
-    PRIMARY KEY (machine_uuid, constraint_uuid)
+        REFERENCES   "constraint"(uuid)
 );
 
 CREATE TABLE machine_principal (

--- a/domain/schema/model/sql/0018-machine.sql
+++ b/domain/schema/model/sql/0018-machine.sql
@@ -48,18 +48,6 @@ CREATE TABLE machine_constraint (
         REFERENCES   "constraint"(uuid)
 );
 
-CREATE TABLE machine_principal (
-    machine_uuid      TEXT NOT NULL,
-    unit_uuid         TEXT NOT NULL,
-    CONSTRAINT        fk_machine_principal_machine
-        FOREIGN KEY   (machine_uuid)
-        REFERENCES    machine(uuid),
-    CONSTRAINT        fk_machine_principal_unit
-        FOREIGN KEY   (unit_uuid)
-        REFERENCES    unit(uuid),
-    PRIMARY KEY (machine_uuid, unit_uuid)
-);
-
 CREATE TABLE machine_tool (
     machine_uuid     TEXT NOT NULL,
     tool_url         TEXT NOT NULL,
@@ -103,81 +91,4 @@ CREATE TABLE machine_filesystem (
         FOREIGN KEY  (filesystem_uuid)
         REFERENCES   storage_filesystem(uuid),
     PRIMARY KEY (machine_uuid, filesystem_uuid)
-);
-
-CREATE TABLE address_type (
-    id      INT PRIMARY KEY,
-    value   TEXT NOT NULL
-);
-
-INSERT INTO address_type VALUES
-    (0, 'hostname'),
-    (1, 'ipv4'),
-    (2, 'ipv6');
-
-CREATE TABLE address_scope (
-    id      INT PRIMARY KEY,
-    value   TEXT NOT NULL
-);
-
-INSERT INTO address_scope VALUES
-    (0, 'unknown'),
-    (1, 'public'),
-    (2, 'local-cloud'),
-    (3, 'local-machine'),
-    (4, 'link-local');
-
-CREATE TABLE address_origin (
-    id      INT PRIMARY KEY,
-    value   TEXT NOT NULL
-);
-
-INSERT INTO address_origin VALUES
-    (0, 'unknown'),
-    (1, 'provider'),
-    (2, 'machine');
-
-CREATE TABLE address (
-    uuid            TEXT PRIMARY KEY,
-    value           TEXT NOT NULL,
-    address_type_id TEXT NOT NULL,
-    scope_id        TEXT NOT NULL,
-    origin_id       TEXT NOT NULL,
-    space_id        TEXT NOT NULL,
-    CONSTRAINT      fk_address_address_type
-        FOREIGN KEY (address_type_id)
-        REFERENCES  address_type(id),
-    CONSTRAINT      fk_address_space
-        FOREIGN KEY (scope_id)
-        REFERENCES  address_scope(id),
-    CONSTRAINT      fk_address_origin
-        FOREIGN KEY (origin_id)
-        REFERENCES  address_origin(id),
-    CONSTRAINT      fk_address_space
-        FOREIGN KEY (space_id)
-        REFERENCES  space(uuid)
-);
-
-CREATE TABLE machine_instance_address (
-    machine_uuid     TEXT NOT NULL,
-    address_uuid     TEXT NOT NULL,
-    CONSTRAINT       fk_machine_address_machine
-        FOREIGN KEY  (machine_uuid)
-        REFERENCES   machine(uuid),
-    CONSTRAINT       fk_machine_address_address
-        FOREIGN KEY  (address_uuid)
-        REFERENCES   address(uuid),
-    PRIMARY KEY (machine_uuid, address_uuid)
-);
-
-CREATE TABLE machine_machine_address (
-    machine_uuid            TEXT NOT NULL,
-    machine_address_uuid    TEXT NOT NULL,
-    CONSTRAINT              fk_machine_address_machine
-        FOREIGN KEY         (machine_uuid)
-        REFERENCES          machine(uuid),
-    CONSTRAINT              fk_machine_address_address
-        FOREIGN KEY         (machine_address_uuid)
-        REFERENCES          address(uuid),
-    PRIMARY KEY (machine_uuid, machine_address_uuid)
 );

--- a/domain/schema/model/sql/0018-machine.sql
+++ b/domain/schema/model/sql/0018-machine.sql
@@ -5,22 +5,19 @@ CREATE TABLE machine (
     life_id           INT NOT NULL,
     base              TEXT,
     nonce             TEXT,
-    container_type_id INT,
     password_hash     TEXT,
     clean             BOOLEAN,
     force_destroyed   BOOLEAN,
     placement         TEXT,
     agent_started_at  DATETIME,
     hostname          TEXT,
+    is_controller     BOOLEAN,
     CONSTRAINT        fk_machine_net_node
         FOREIGN KEY   (net_node_uuid)
         REFERENCES    net_node(uuid),
     CONSTRAINT        fk_machine_life
         FOREIGN KEY   (life_id)
-        REFERENCES    life(id),
-    CONSTRAINT        fk_machine_container_type
-        FOREIGN KEY   (container_type_id)
-        REFERENCES    container_type(id)
+        REFERENCES    life(id)
 );
 
 CREATE UNIQUE INDEX idx_machine_id
@@ -28,14 +25,6 @@ ON machine (machine_id);
 
 CREATE UNIQUE INDEX idx_machine_net_node
 ON machine (net_node_uuid);
-
-CREATE TABLE container_type (
-    id    INT PRIMARY KEY,
-    value TEXT NOT NULL
-);
-
-INSERT INTO container_type VALUES
-    (0, 'lxd');
 
 CREATE TABLE machine_constraint (
     machine_uuid     TEXT PRIMARY KEY,
@@ -58,15 +47,6 @@ CREATE TABLE machine_tool (
         FOREIGN KEY  (machine_uuid)
         REFERENCES   machine(uuid),
     PRIMARY KEY (machine_uuid, tool_url)
-);
-
-CREATE TABLE machine_job (
-    machine_uuid     TEXT NOT NULL,
-    machine_job      INT NOT NULL,
-    CONSTRAINT       fk_machine_principal_machine
-        FOREIGN KEY  (machine_uuid)
-        REFERENCES   machine(uuid),
-    PRIMARY KEY (machine_uuid, machine_job)
 );
 
 CREATE TABLE machine_volume (

--- a/domain/schema/model/sql/0018-machine.sql
+++ b/domain/schema/model/sql/0018-machine.sql
@@ -1,0 +1,184 @@
+CREATE TABLE machine (
+    uuid              TEXT PRIMARY KEY,
+    machine_id        TEXT NOT NULL,
+    net_node_uuid     TEXT NOT NULL,
+    life_id           INT NOT NULL,
+    base              TEXT,
+    nonce             TEXT,
+    container_type_id INT,
+    password_hash     TEXT,
+    clean             BOOLEAN,
+    force_destroyed   BOOLEAN,
+    placement         TEXT,
+    agent_started_at  DATETIME,
+    hostname          TEXT,
+    CONSTRAINT        fk_machine_net_node
+        FOREIGN KEY   (net_node_uuid)
+        REFERENCES    net_node(uuid),
+    CONSTRAINT        fk_machine_life
+        FOREIGN KEY   (life_id)
+        REFERENCES    life(id),
+    CONSTRAINT        fk_machine_container_type
+        FOREIGN KEY   (container_type_id)
+        REFERENCES    container_type(id)
+);
+
+CREATE UNIQUE INDEX idx_machine_id
+ON machine (machine_id);
+
+CREATE UNIQUE INDEX idx_machine_net_node
+ON machine (net_node_uuid);
+
+CREATE TABLE container_type (
+    id    INT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+
+INSERT INTO container_type VALUES
+    (0, 'lxd');
+
+CREATE TABLE machine_constraint (
+    machine_uuid     TEXT NOT NULL,
+    constraint_uuid  TEXT NOT NULL,
+    CONSTRAINT       fk_machine_constraint_machine
+        FOREIGN KEY  (machine_uuid)
+        REFERENCES   machine(uuid),
+    CONSTRAINT       fk_machine_constraint_constraint
+        FOREIGN KEY  (constraint_uuid)
+        REFERENCES   "constraint"(uuid),
+    PRIMARY KEY (machine_uuid, constraint_uuid)
+);
+
+CREATE TABLE machine_principal (
+    machine_uuid      TEXT NOT NULL,
+    unit_uuid         TEXT NOT NULL,
+    CONSTRAINT        fk_machine_principal_machine
+        FOREIGN KEY   (machine_uuid)
+        REFERENCES    machine(uuid),
+    CONSTRAINT        fk_machine_principal_unit
+        FOREIGN KEY   (unit_uuid)
+        REFERENCES    unit(uuid),
+    PRIMARY KEY (machine_uuid, unit_uuid)
+);
+
+CREATE TABLE machine_tool (
+    machine_uuid     TEXT NOT NULL,
+    tool_url         TEXT NOT NULL,
+    tool_version     TEXT NOT NULL,
+    tool_sha256      TEXT NOT NULL,
+    tool_size        INT NOT NULL,
+    CONSTRAINT       fk_machine_principal_machine
+        FOREIGN KEY  (machine_uuid)
+        REFERENCES   machine(uuid),
+    PRIMARY KEY (machine_uuid, tool_url)
+);
+
+CREATE TABLE machine_job (
+    machine_uuid     TEXT NOT NULL,
+    machine_job      INT NOT NULL,
+    CONSTRAINT       fk_machine_principal_machine
+        FOREIGN KEY  (machine_uuid)
+        REFERENCES   machine(uuid),
+    PRIMARY KEY (machine_uuid, machine_job)
+);
+
+CREATE TABLE machine_volume (
+    machine_uuid     TEXT NOT NULL,
+    volume_uuid      TEXT NOT NULL,
+    CONSTRAINT       fk_machine_volume_machine
+        FOREIGN KEY  (machine_uuid)
+        REFERENCES   machine(uuid),
+    CONSTRAINT       fk_machine_volume_volume
+        FOREIGN KEY  (volume_uuid)
+        REFERENCES   storage_volume(uuid),
+    PRIMARY KEY (machine_uuid, volume_uuid)
+);
+
+CREATE TABLE machine_filesystem (
+    machine_uuid     TEXT NOT NULL,
+    filesystem_uuid  TEXT NOT NULL,
+    CONSTRAINT       fk_machine_filesystem_machine
+        FOREIGN KEY  (machine_uuid)
+        REFERENCES   machine(uuid),
+    CONSTRAINT       fk_machine_filesystem_filesystem
+        FOREIGN KEY  (filesystem_uuid)
+        REFERENCES   storage_filesystem(uuid),
+    PRIMARY KEY (machine_uuid, filesystem_uuid)
+);
+
+CREATE TABLE address_type (
+    id      INT PRIMARY KEY,
+    value   TEXT NOT NULL
+);
+
+INSERT INTO address_type VALUES
+    (0, 'hostname'),
+    (1, 'ipv4'),
+    (2, 'ipv6');
+
+CREATE TABLE address_scope (
+    id      INT PRIMARY KEY,
+    value   TEXT NOT NULL
+);
+
+INSERT INTO address_scope VALUES
+    (0, 'unknown'),
+    (1, 'public'),
+    (2, 'local-cloud'),
+    (3, 'local-machine'),
+    (4, 'link-local');
+
+CREATE TABLE address_origin (
+    id      INT PRIMARY KEY,
+    value   TEXT NOT NULL
+);
+
+INSERT INTO address_origin VALUES
+    (0, 'unknown'),
+    (1, 'provider'),
+    (2, 'machine');
+
+CREATE TABLE address (
+    uuid            TEXT PRIMARY KEY,
+    value           TEXT NOT NULL,
+    address_type_id TEXT NOT NULL,
+    scope_id        TEXT NOT NULL,
+    origin_id       TEXT NOT NULL,
+    space_id        TEXT NOT NULL,
+    CONSTRAINT      fk_address_address_type
+        FOREIGN KEY (address_type_id)
+        REFERENCES  address_type(id),
+    CONSTRAINT      fk_address_space
+        FOREIGN KEY (scope_id)
+        REFERENCES  address_scope(id),
+    CONSTRAINT      fk_address_origin
+        FOREIGN KEY (origin_id)
+        REFERENCES  address_origin(id),
+    CONSTRAINT      fk_address_space
+        FOREIGN KEY (space_id)
+        REFERENCES  space(uuid)
+);
+
+CREATE TABLE machine_instance_address (
+    machine_uuid     TEXT NOT NULL,
+    address_uuid     TEXT NOT NULL,
+    CONSTRAINT       fk_machine_address_machine
+        FOREIGN KEY  (machine_uuid)
+        REFERENCES   machine(uuid),
+    CONSTRAINT       fk_machine_address_address
+        FOREIGN KEY  (address_uuid)
+        REFERENCES   address(uuid),
+    PRIMARY KEY (machine_uuid, address_uuid)
+);
+
+CREATE TABLE machine_machine_address (
+    machine_uuid            TEXT NOT NULL,
+    machine_address_uuid    TEXT NOT NULL,
+    CONSTRAINT              fk_machine_address_machine
+        FOREIGN KEY         (machine_uuid)
+        REFERENCES          machine(uuid),
+    CONSTRAINT              fk_machine_address_address
+        FOREIGN KEY         (machine_address_uuid)
+        REFERENCES          address(uuid),
+    PRIMARY KEY (machine_uuid, machine_address_uuid)
+);

--- a/domain/schema/schema_test.go
+++ b/domain/schema/schema_test.go
@@ -273,6 +273,28 @@ func (s *schemaSuite) TestModelTables(c *gc.C) {
 		"unit_state_charm",
 		"unit_state_relation",
 
+		// Constraint
+		"constraint",
+		"constraint_tag",
+		"constraint_space",
+		"constraint_zone",
+
+		// Machine
+		"machine",
+		"container_type",
+		"machine_constraint",
+		"machine_principal",
+		"machine_tool",
+		"machine_job",
+		"machine_volume",
+		"machine_filesystem",
+		"machine_instance_address",
+		"machine_machine_address",
+		"address",
+		"address_type",
+		"address_scope",
+		"address_origin",
+
 		// Charm
 		"charm",
 		"charm_storage",

--- a/domain/schema/schema_test.go
+++ b/domain/schema/schema_test.go
@@ -283,17 +283,10 @@ func (s *schemaSuite) TestModelTables(c *gc.C) {
 		"machine",
 		"container_type",
 		"machine_constraint",
-		"machine_principal",
 		"machine_tool",
 		"machine_job",
 		"machine_volume",
 		"machine_filesystem",
-		"machine_instance_address",
-		"machine_machine_address",
-		"address",
-		"address_type",
-		"address_scope",
-		"address_origin",
 
 		// Charm
 		"charm",

--- a/domain/schema/schema_test.go
+++ b/domain/schema/schema_test.go
@@ -281,10 +281,8 @@ func (s *schemaSuite) TestModelTables(c *gc.C) {
 
 		// Machine
 		"machine",
-		"container_type",
 		"machine_constraint",
 		"machine_tool",
-		"machine_job",
 		"machine_volume",
 		"machine_filesystem",
 

--- a/internal/worker/dbaccessor/deletedb.go
+++ b/internal/worker/dbaccessor/deletedb.go
@@ -76,19 +76,19 @@ func deleteDBContents(ctx context.Context, tx *sql.Tx, logger logger.Logger) err
 	// 5. Drop all tables (ignoring sqlite_master)
 	var stmts []string
 	for name := range tables {
-		stmts = append(stmts, fmt.Sprintf("DELETE FROM \"%s\";", name))
+		stmts = append(stmts, fmt.Sprintf("DELETE FROM %q;", name))
 	}
 	for name := range indexes {
-		stmts = append(stmts, fmt.Sprintf("DROP INDEX IF EXISTS \"%s\";", name))
+		stmts = append(stmts, fmt.Sprintf("DROP INDEX IF EXISTS %q;", name))
 	}
 	for name := range triggers {
-		stmts = append(stmts, fmt.Sprintf("DROP TRIGGER IF EXISTS \"%s\";", name))
+		stmts = append(stmts, fmt.Sprintf("DROP TRIGGER IF EXISTS %q;", name))
 	}
 	for name := range views {
-		stmts = append(stmts, fmt.Sprintf("DROP VIEW IF EXISTS \"%s\";", name))
+		stmts = append(stmts, fmt.Sprintf("DROP VIEW IF EXISTS %q;", name))
 	}
 	for name := range tables {
-		stmts = append(stmts, fmt.Sprintf("DROP TABLE IF EXISTS \"%s\";", name))
+		stmts = append(stmts, fmt.Sprintf("DROP TABLE IF EXISTS %q;", name))
 	}
 
 	logger.Debugf("deleting database contents: %d statements", len(stmts))

--- a/internal/worker/dbaccessor/deletedb.go
+++ b/internal/worker/dbaccessor/deletedb.go
@@ -76,19 +76,19 @@ func deleteDBContents(ctx context.Context, tx *sql.Tx, logger logger.Logger) err
 	// 5. Drop all tables (ignoring sqlite_master)
 	var stmts []string
 	for name := range tables {
-		stmts = append(stmts, fmt.Sprintf("DELETE FROM %s;", name))
+		stmts = append(stmts, fmt.Sprintf("DELETE FROM \"%s\";", name))
 	}
 	for name := range indexes {
-		stmts = append(stmts, fmt.Sprintf("DROP INDEX IF EXISTS %s;", name))
+		stmts = append(stmts, fmt.Sprintf("DROP INDEX IF EXISTS \"%s\";", name))
 	}
 	for name := range triggers {
-		stmts = append(stmts, fmt.Sprintf("DROP TRIGGER IF EXISTS %s;", name))
+		stmts = append(stmts, fmt.Sprintf("DROP TRIGGER IF EXISTS \"%s\";", name))
 	}
 	for name := range views {
-		stmts = append(stmts, fmt.Sprintf("DROP VIEW IF EXISTS %s;", name))
+		stmts = append(stmts, fmt.Sprintf("DROP VIEW IF EXISTS \"%s\";", name))
 	}
 	for name := range tables {
-		stmts = append(stmts, fmt.Sprintf("DROP TABLE IF EXISTS %s;", name))
+		stmts = append(stmts, fmt.Sprintf("DROP TABLE IF EXISTS \"%s\";", name))
 	}
 
 	logger.Debugf("deleting database contents: %d statements", len(stmts))


### PR DESCRIPTION
This adds some new fields and tables to complete the machine schema. It also starts the constraints schema to be used by entities including machines.

Here's what the fields for the machine table look like:

```
    uuid                      TEXT PRIMARY KEY,
    machine_id                TEXT NOT NULL,
    net_node_uuid            TEXT NOT NULL,
    life_id                  INT NOT NULL,
    base                      TEXT NOT NULL,
    nonce                     TEXT,
    container_type_id        INT NOT NULL,
    password_hash             TEXT NOT NULL,
    clean                     BOOLEAN,
    force_destroyed           BOOLEAN,
    placement                 TEXT,
    agent_started_at          DATETIME,
    hostname                  TEXT,
```

Additionally some new tables are being added:

- `TABLE machine_constraint` : keeping the constraints (with  different constraint types - arch, mem, etc-) for a machine
- `TABLE machine_tool`: keeping the location and version of the agent tool tarballs for a machine.
-  `TABLE machine_job`: holds the jobs to run on the machine's instance.
-  `TABLE machine_volume`: keeps the parameters for volumes that are to be created and attached to a machine.
-  `TABLE machine_filesystem`: keeps the parameters for filesystems that are to be created and attached to a machine.

To support these, we need to add some additional tables for RI.
```
- constraint (mostly a stub)
- constraint_tag
- constraint_space
- constraint_zone
```

#### Some Design Decisions

- The "address" tables `machine_address` and `machine_machine_address` tables will be dropped from the machine schema, as we won't be keeping addresses directly on the machine table. The addresses will be discovered through the `net_node` (and possibly through the link-layer devices).
(`machine_address` keeps the (cloud instance) addresses to be associated with the a machine -addresses obtained by asking the provider-, and the `machine_machine_address` keeps the addresses -local to the physical machine- to be associated with a machine -obtained from the machine itself-)

- The `machine_principals` will be dropped, as the units on the machine will be discovered via the link between `net_node` and `unit`.
(`machine_principal` keeps the the principal units that will be associated with a machine.)


- We keep out some legacy fields:

```
preferred_public_address
preffered_private_address
```

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- ~[ ] Comments saying why design decisions were made~
- [ ] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

No new functionality, just schema change, so only unit tests and bootstrapping is needed (along with manual review on the schema itself):

```
TEST_PACKAGES="./domain/schema/... -count=1 -race" make run-go-tests
```
```
juju bootstrap localhost c
```

## Links

**Jira card:** JUJU-6072

