### PR TITLE
Remove the fan info field from subnet structs

### DIFF
--- a/api/controller/firewaller/firewaller_test.go
+++ b/api/controller/firewaller/firewaller_test.go
@@ -260,10 +260,6 @@ func (s *firewallerSuite) TestAllSpaceInfos(c *gc.C) {
 					AvailabilityZones: []string{"az1", "az2"},
 					SpaceID:           "42",
 					SpaceName:         "questions-about-the-universe",
-					FanInfo: &network.FanCIDRs{
-						FanLocalUnderlay: "192.168.0.0/16",
-						FanOverlay:       "1.0.0.0/8",
-					},
 				},
 			},
 		},

--- a/apiserver/facades/client/spaces/integrity.go
+++ b/apiserver/facades/client/spaces/integrity.go
@@ -77,18 +77,7 @@ type affectedNetworks struct {
 func newAffectedNetworks(
 	movingSubnets network.IDSet, spaceName string, currentTopology network.SpaceInfos, force bool, logger corelogger.Logger,
 ) (*affectedNetworks, error) {
-
-	// We need to indicate that any moving fan underlays include
-	// their overlays as being affected by a move.
-	movingOverlays, err := currentTopology.FanOverlaysFor(movingSubnets)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	for _, overlay := range movingOverlays {
-		movingSubnets.Add(overlay.ID)
-	}
-
-	// Now get the topology as would result from moving all of these subnets.
+	// Get the topology as would result from moving all of these subnets.
 	newTopology, err := currentTopology.MoveSubnets(movingSubnets, spaceName)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/apiserver/facades/client/spaces/move.go
+++ b/apiserver/facades/client/spaces/move.go
@@ -101,13 +101,6 @@ func (api *API) updateSubnets(ctx context.Context, spaceName string, subnets net
 // a relocation of subnets.
 // An error is returned if validity is violated and force is passed as false.
 func (api *API) ensureSubnetsCanBeMoved(ctx context.Context, subnets network.SubnetInfos, spaceName string, force bool) error {
-	for _, subnet := range subnets {
-		if subnet.FanLocalUnderlay() != "" {
-			return errors.Errorf("subnet %q is a fan overlay of %q and cannot be moved; move the underlay instead",
-				subnet.CIDR, subnet.FanLocalUnderlay())
-		}
-	}
-
 	allSpaces, err := api.networkService.GetAllSpaces(ctx)
 	if err != nil {
 		return errors.Trace(err)

--- a/apiserver/facades/controller/firewaller/firewaller_unit_test.go
+++ b/apiserver/facades/controller/firewaller/firewaller_unit_test.go
@@ -402,10 +402,6 @@ func (s *FirewallerSuite) TestAllSpaceInfos(c *gc.C) {
 					AvailabilityZones: []string{"az1", "az2"},
 					SpaceID:           "42",
 					SpaceName:         "questions-about-the-universe",
-					FanInfo: &network.FanCIDRs{
-						FanLocalUnderlay: "192.168.0.0/16",
-						FanOverlay:       "1.0.0.0/8",
-					},
 				},
 			}},
 		{ID: "99", Name: "special", Subnets: []network.SubnetInfo{

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -18766,22 +18766,6 @@
                     },
                     "additionalProperties": false
                 },
-                "FanConfigEntry": {
-                    "type": "object",
-                    "properties": {
-                        "overlay": {
-                            "type": "string"
-                        },
-                        "underlay": {
-                            "type": "string"
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "underlay",
-                        "overlay"
-                    ]
-                },
                 "IngressRule": {
                     "type": "object",
                     "properties": {
@@ -19250,9 +19234,6 @@
                         },
                         "cidr": {
                             "type": "string"
-                        },
-                        "fan-info": {
-                            "$ref": "#/definitions/FanConfigEntry"
                         },
                         "id": {
                             "type": "string"

--- a/cmd/juju/space/space.go
+++ b/cmd/juju/space/space.go
@@ -16,7 +16,6 @@ import (
 	"github.com/juju/juju/api/client/spaces"
 	"github.com/juju/juju/api/client/subnets"
 	"github.com/juju/juju/cmd/modelcmd"
-	"github.com/juju/juju/core/network"
 	internallogger "github.com/juju/juju/internal/logger"
 	"github.com/juju/juju/rpc/params"
 )
@@ -274,11 +273,6 @@ type SubnetInfo struct {
 	// An empty string indicates it is part of the AlphaSpaceName OR
 	// if the SpaceID is set. Should primarily be used in an networkingEnviron.
 	SpaceName string `json:"space-name,omitempty" yaml:"space-name,omitempty"`
-
-	// FanInfo describes the fan networking setup for the subnet.
-	// It may be empty if this is not a fan subnet,
-	// or if this subnet information comes from a provider.
-	FanInfo *network.FanCIDRs `json:"fan-info,omitempty" yaml:"fan-info,omitempty"`
 }
 
 // SpaceInfo defines a network space.

--- a/core/network/space.go
+++ b/core/network/space.go
@@ -81,37 +81,6 @@ func (s SpaceInfos) AllSubnetInfos() (SubnetInfos, error) {
 	return subs, nil
 }
 
-// FanOverlaysFor returns any subnets in this network topology that are
-// fan overlays for the input subnet IDs.
-func (s SpaceInfos) FanOverlaysFor(subnetIDs IDSet) (SubnetInfos, error) {
-	if len(subnetIDs) == 0 {
-		return nil, nil
-	}
-
-	var located int
-	var allOverlays SubnetInfos
-
-	for _, space := range s {
-		for _, sub := range space.Subnets {
-			if subnetIDs.Contains(sub.ID) {
-				overlays, err := space.Subnets.GetByUnderlayCIDR(sub.CIDR)
-				if err != nil {
-					return nil, errors.Trace(err)
-				}
-				allOverlays = append(allOverlays, overlays...)
-
-				// If we have tested all of the inputs, we can exit early.
-				located++
-				if located >= len(subnetIDs) {
-					return allOverlays, nil
-				}
-			}
-		}
-	}
-
-	return allOverlays, nil
-}
-
 // MoveSubnets returns a new topology representing
 // the movement of subnets to a new network space.
 func (s SpaceInfos) MoveSubnets(subnetIDs IDSet, spaceName string) (SpaceInfos, error) {

--- a/core/network/space_test.go
+++ b/core/network/space_test.go
@@ -139,37 +139,6 @@ func (s *spaceSuite) TestAllSubnetInfos(c *gc.C) {
 	})
 }
 
-func (s *spaceSuite) TestFanOverlaysFor(c *gc.C) {
-	overlay := network.SubnetInfo{
-		ID:   "15",
-		CIDR: "10.1.1.0/16",
-		FanInfo: &network.FanCIDRs{
-			FanLocalUnderlay: "10.0.3.0/24",
-			FanOverlay:       "10.1.0.0/8",
-		},
-	}
-
-	s.spaces = append(s.spaces, network.SpaceInfo{
-		ID:   "4",
-		Name: "space4",
-		Subnets: network.SubnetInfos{
-			{
-				ID:   "14",
-				CIDR: "10.0.3.0/24",
-			},
-			overlay,
-		},
-	})
-
-	overlays, err := s.spaces.FanOverlaysFor(network.MakeIDSet("11"))
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(overlays, gc.HasLen, 0)
-
-	overlays, err = s.spaces.FanOverlaysFor(network.MakeIDSet("14"))
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(overlays, gc.DeepEquals, network.SubnetInfos{overlay})
-}
-
 func (s *spaceSuite) TestMoveSubnets(c *gc.C) {
 	_, err := s.spaces.MoveSubnets(network.MakeIDSet("11", "12"), "space4")
 	c.Check(err, jc.ErrorIs, errors.NotFound)

--- a/core/network/subnet_test.go
+++ b/core/network/subnet_test.go
@@ -187,38 +187,6 @@ func (*subnetSuite) TestSubnetInfosSpaceIDs(c *gc.C) {
 	c.Check(s.SpaceIDs().SortedValues(), jc.DeepEquals, []string{network.AlphaSpaceId, "666"})
 }
 
-func (*subnetSuite) TestSubnetInfosGetByUnderLayCIDR(c *gc.C) {
-	s := network.SubnetInfos{
-		{
-			ID:      "1",
-			FanInfo: &network.FanCIDRs{FanLocalUnderlay: "10.10.10.0/24"},
-		},
-		{
-			ID:      "2",
-			FanInfo: &network.FanCIDRs{FanLocalUnderlay: "20.20.20.0/24"},
-		},
-		{
-			ID:      "3",
-			FanInfo: &network.FanCIDRs{FanLocalUnderlay: "20.20.20.0/24"},
-		},
-	}
-
-	_, err := s.GetByUnderlayCIDR("invalid")
-	c.Check(err, jc.ErrorIs, errors.NotValid)
-
-	overlays, err := s.GetByUnderlayCIDR(s[0].FanLocalUnderlay())
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(overlays, gc.DeepEquals, network.SubnetInfos{s[0]})
-
-	overlays, err = s.GetByUnderlayCIDR(s[1].FanLocalUnderlay())
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(overlays, gc.DeepEquals, network.SubnetInfos{s[1], s[2]})
-
-	overlays, err = s.GetByUnderlayCIDR("30.30.30.0/24")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(overlays, gc.HasLen, 0)
-}
-
 func (*subnetSuite) TestSubnetInfosGetByCIDR(c *gc.C) {
 	s := network.SubnetInfos{
 		{ID: "1", CIDR: "10.10.10.0/25", ProviderId: "1"},
@@ -290,54 +258,6 @@ func (*subnetSuite) TestSubnetInfosGetByAddress(c *gc.C) {
 	subs, err = s.GetByAddress("30.30.30.5")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(subs, gc.HasLen, 0)
-}
-
-func (*subnetSuite) TestSubnetInfosGetBySpaceID(c *gc.C) {
-	s := network.SubnetInfos{
-		{
-			ID:      "1",
-			CIDR:    "10.10.10.0/24",
-			SpaceID: "666",
-		},
-		{
-			ID:      "2",
-			CIDR:    "222.0.0.0/8",
-			FanInfo: &network.FanCIDRs{FanLocalUnderlay: "10.10.10.0/24"},
-		},
-		{
-			ID:      "3",
-			CIDR:    "20.20.20.0/24",
-			SpaceID: "999",
-		},
-		{
-			ID:      "4",
-			CIDR:    "223.0.0.0/8",
-			FanInfo: &network.FanCIDRs{FanLocalUnderlay: "20.20.20.0/24"},
-			// This is to check that we don't get duplicates when retrieving
-			// by the underlay CIDR.
-			SpaceID: "999",
-		},
-	}
-
-	subs, err := s.GetBySpaceID("666")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(subs, gc.DeepEquals, network.SubnetInfos{
-		{
-			ID:      "1",
-			CIDR:    "10.10.10.0/24",
-			SpaceID: "666",
-		},
-		{
-			ID:      "2",
-			CIDR:    "222.0.0.0/8",
-			FanInfo: &network.FanCIDRs{FanLocalUnderlay: "10.10.10.0/24"},
-			SpaceID: "666",
-		},
-	})
-
-	subs, err = s.GetBySpaceID("999")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(subs, gc.DeepEquals, s[2:])
 }
 
 func (*subnetSuite) TestSubnetInfosAllSubnetInfos(c *gc.C) {

--- a/domain/network/modelmigration/export.go
+++ b/domain/network/modelmigration/export.go
@@ -85,8 +85,6 @@ func (e *exportOperation) Execute(ctx context.Context, model description.Model) 
 			SpaceID:           subnet.SpaceID,
 			SpaceName:         subnet.SpaceName,
 			AvailabilityZones: subnet.AvailabilityZones,
-			FanLocalUnderlay:  subnet.FanLocalUnderlay(),
-			FanOverlay:        subnet.FanOverlay(),
 		}
 		model.AddSubnet(args)
 	}

--- a/domain/network/modelmigration/export_test.go
+++ b/domain/network/modelmigration/export_test.go
@@ -63,10 +63,6 @@ func (s *exportSuite) TestExport(c *gc.C) {
 			ProviderId:        "provider-subnet-1",
 			ProviderSpaceId:   "provider-space-1",
 			ProviderNetworkId: "provider-network-1",
-			FanInfo: &network.FanCIDRs{
-				FanLocalUnderlay: "192.168.0.0/12",
-				FanOverlay:       "10.0.0.0/8",
-			},
 		},
 	}
 	s.exportService.EXPECT().GetAllSubnets(gomock.Any()).
@@ -91,8 +87,6 @@ func (s *exportSuite) TestExport(c *gc.C) {
 	c.Assert(actualSubnets[0].ProviderId(), gc.Equals, string(subnets[0].ProviderId))
 	c.Assert(actualSubnets[0].ProviderSpaceId(), gc.Equals, string(subnets[0].ProviderSpaceId))
 	c.Assert(actualSubnets[0].ProviderNetworkId(), gc.Equals, string(subnets[0].ProviderNetworkId))
-	c.Assert(actualSubnets[0].FanLocalUnderlay(), gc.Equals, subnets[0].FanLocalUnderlay())
-	c.Assert(actualSubnets[0].FanOverlay(), gc.Equals, subnets[0].FanOverlay())
 }
 
 func (s *exportSuite) TestExportSpacesNotFound(c *gc.C) {

--- a/domain/network/modelmigration/import.go
+++ b/domain/network/modelmigration/import.go
@@ -91,12 +91,6 @@ func (i *importOperation) Execute(ctx context.Context, model description.Model) 
 			AvailabilityZones: subnet.AvailabilityZones(),
 			ProviderNetworkId: network.Id(subnet.ProviderNetworkId()),
 		}
-		if subnet.FanLocalUnderlay() != "" || subnet.FanOverlay() != "" {
-			subnetInfo.FanInfo = &network.FanCIDRs{
-				FanLocalUnderlay: subnet.FanLocalUnderlay(),
-				FanOverlay:       subnet.FanOverlay(),
-			}
-		}
 
 		importedSpaceID, ok := spaceIDsMap[subnet.SpaceID()]
 		if ok {

--- a/domain/network/modelmigration/import_test.go
+++ b/domain/network/modelmigration/import_test.go
@@ -58,10 +58,6 @@ func (s *importSuite) TestImportSubnetWithoutSpaces(c *gc.C) {
 		ProviderNetworkId: "subnet-provider-network-id",
 		VLANTag:           42,
 		AvailabilityZones: []string{"az1", "az2"},
-		FanInfo: &network.FanCIDRs{
-			FanLocalUnderlay: "192.168.0.0/12",
-			FanOverlay:       "10.0.0.0/8",
-		},
 	})
 
 	op := s.newImportOperation(c)

--- a/domain/network/service/interface.go
+++ b/domain/network/service/interface.go
@@ -48,8 +48,6 @@ type SpaceState interface {
 	UpdateSpace(ctx context.Context, uuid string, name string) error
 	// DeleteSpace deletes the space identified by the passed uuid.
 	DeleteSpace(ctx context.Context, uuid string) error
-	// FanConfig returns the current model's fan config value.
-	FanConfig(ctx context.Context) (string, error)
 }
 
 // SubnetState describes persistence layer methods for the subnet (sub-) domain.

--- a/domain/network/service/package_mock_test.go
+++ b/domain/network/service/package_mock_test.go
@@ -236,45 +236,6 @@ func (c *MockStateDeleteSubnetCall) DoAndReturn(f func(context.Context, string) 
 	return c
 }
 
-// FanConfig mocks base method.
-func (m *MockState) FanConfig(arg0 context.Context) (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FanConfig", arg0)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// FanConfig indicates an expected call of FanConfig.
-func (mr *MockStateMockRecorder) FanConfig(arg0 any) *MockStateFanConfigCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FanConfig", reflect.TypeOf((*MockState)(nil).FanConfig), arg0)
-	return &MockStateFanConfigCall{Call: call}
-}
-
-// MockStateFanConfigCall wrap *gomock.Call
-type MockStateFanConfigCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockStateFanConfigCall) Return(arg0 string, arg1 error) *MockStateFanConfigCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockStateFanConfigCall) Do(f func(context.Context) (string, error)) *MockStateFanConfigCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateFanConfigCall) DoAndReturn(f func(context.Context) (string, error)) *MockStateFanConfigCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // GetAllSpaces mocks base method.
 func (m *MockState) GetAllSpaces(arg0 context.Context) (network.SpaceInfos, error) {
 	m.ctrl.T.Helper()

--- a/domain/network/state/space.go
+++ b/domain/network/state/space.go
@@ -16,7 +16,6 @@ import (
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/domain"
 	networkerrors "github.com/juju/juju/domain/network/errors"
-	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/internal/database"
 )
 
@@ -281,24 +280,4 @@ func (st *State) DeleteSpace(
 		return nil
 	})
 	return domain.CoerceError(err)
-}
-
-// FanConfig returns the current model's fan config value.
-func (st *State) FanConfig(ctx context.Context) (string, error) {
-	db, err := st.DB()
-	if err != nil {
-		return "", errors.Trace(err)
-	}
-
-	var fanConfig string
-	return fanConfig, db.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
-		stmt := `SELECT value FROM model_config WHERE key=?`
-		row := tx.QueryRowContext(ctx, stmt, config.FanConfig)
-		if err := row.Scan(&fanConfig); errors.Is(err, sql.ErrNoRows) {
-			return fmt.Errorf("model config fan config %w %w", networkerrors.ErrSpaceNotFound, err)
-		} else if err != nil {
-			return domain.CoerceError(err)
-		}
-		return nil
-	})
 }

--- a/domain/network/state/space_test.go
+++ b/domain/network/state/space_test.go
@@ -42,7 +42,6 @@ func (s *stateSuite) TestAddSpace(c *gc.C) {
 			VLANTag:           0,
 			AvailabilityZones: []string{"az0", "az1"},
 			SpaceID:           "",
-			FanInfo:           nil,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -100,7 +99,6 @@ func (s *stateSuite) TestAddSpaceFailDuplicateName(c *gc.C) {
 			VLANTag:           0,
 			AvailabilityZones: []string{"az0", "az1"},
 			SpaceID:           "",
-			FanInfo:           nil,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -141,7 +139,6 @@ func (s *stateSuite) TestAddSpaceEmptyProviderID(c *gc.C) {
 			VLANTag:           0,
 			AvailabilityZones: []string{"az0", "az1"},
 			SpaceID:           "",
-			FanInfo:           nil,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -178,7 +175,6 @@ func (s *stateSuite) TestRetrieveSpaceByUUID(c *gc.C) {
 			VLANTag:           0,
 			AvailabilityZones: []string{"az0"},
 			SpaceID:           "",
-			FanInfo:           nil,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -195,7 +191,6 @@ func (s *stateSuite) TestRetrieveSpaceByUUID(c *gc.C) {
 			VLANTag:           0,
 			AvailabilityZones: []string{"az1"},
 			SpaceID:           "",
-			FanInfo:           nil,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -307,7 +302,6 @@ func (s *stateSuite) TestRetrieveAllSpaces(c *gc.C) {
 			VLANTag:           0,
 			AvailabilityZones: []string{"az0", "az1"},
 			SpaceID:           "",
-			FanInfo:           nil,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -323,7 +317,6 @@ func (s *stateSuite) TestRetrieveAllSpaces(c *gc.C) {
 			VLANTag:           0,
 			AvailabilityZones: []string{"az0", "az1"},
 			SpaceID:           "",
-			FanInfo:           nil,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -339,7 +332,6 @@ func (s *stateSuite) TestRetrieveAllSpaces(c *gc.C) {
 			VLANTag:           0,
 			AvailabilityZones: []string{"az2", "az3"},
 			SpaceID:           "",
-			FanInfo:           nil,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -406,7 +398,6 @@ func (s *stateSuite) TestDeleteSpace(c *gc.C) {
 			VLANTag:           0,
 			AvailabilityZones: []string{"az0", "az1"},
 			SpaceID:           "",
-			FanInfo:           nil,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/rpc/params/network.go
+++ b/rpc/params/network.go
@@ -1291,12 +1291,6 @@ func FromNetworkSpaceInfos(allInfos network.SpaceInfos) SpaceInfos {
 		mappedSubnets := make([]SubnetV3, len(si.Subnets))
 		for j, subnetInfo := range si.Subnets {
 			var mappedFanInfo *FanConfigEntry
-			if subnetInfo.FanInfo != nil {
-				mappedFanInfo = &FanConfigEntry{
-					Underlay: subnetInfo.FanInfo.FanLocalUnderlay,
-					Overlay:  subnetInfo.FanInfo.FanOverlay,
-				}
-			}
 
 			mappedSubnets[j] = SubnetV3{
 				SpaceID: subnetInfo.SpaceID,
@@ -1348,10 +1342,6 @@ func ToNetworkSpaceInfos(allInfos SpaceInfos) network.SpaceInfos {
 				AvailabilityZones: subnetInfo.Zones,
 				SpaceID:           subnetInfo.SpaceID,
 				SpaceName:         si.Name,
-			}
-
-			if subnetInfo.FanInfo != nil {
-				mappedSubnets[j].SetFan(subnetInfo.FanInfo.Underlay, subnetInfo.FanInfo.Overlay)
 			}
 		}
 

--- a/rpc/params/network.go
+++ b/rpc/params/network.go
@@ -67,9 +67,8 @@ type SubnetV2 struct {
 type SubnetV3 struct {
 	SubnetV2
 
-	SpaceID  string          `json:"space-id"`
-	FanInfo  *FanConfigEntry `json:"fan-info,omitempty"`
-	IsPublic bool            `json:"is-public,omitempty"`
+	SpaceID  string `json:"space-id"`
+	IsPublic bool   `json:"is-public,omitempty"`
 }
 
 // NetworkRoute describes a special route that should be added for a given
@@ -1290,11 +1289,9 @@ func FromNetworkSpaceInfos(allInfos network.SpaceInfos) SpaceInfos {
 	for i, si := range allInfos {
 		mappedSubnets := make([]SubnetV3, len(si.Subnets))
 		for j, subnetInfo := range si.Subnets {
-			var mappedFanInfo *FanConfigEntry
 
 			mappedSubnets[j] = SubnetV3{
 				SpaceID: subnetInfo.SpaceID,
-				FanInfo: mappedFanInfo,
 
 				SubnetV2: SubnetV2{
 					ID: string(subnetInfo.ID),


### PR DESCRIPTION
As part of the drop of fan networking, this patch removes the `FanInfo` field (and associated structs) from the `SubnetInfo` struct.

Tests and facades that referenced it were fixed or removed depending the case.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

This is mainly removal of unused code at this point, but as QA steps, (just like the previous PR https://github.com/juju/juju/pull/17429) bootstrapping on AWS and not listing fan subnets should still work:
```
juju bootstrap aws c
juju add-model m
juju subnets
subnets:
  172.31.0.0/20:
    type: ipv4
    provider-id: subnet-7d4c9614
    provider-network-id: vpc-8abf64e3
    space: alpha
    zones:
    - eu-west-3a
  172.31.16.0/20:
    type: ipv4
    provider-id: subnet-8641bdfd
    provider-network-id: vpc-8abf64e3
    space: alpha
    zones:
    - eu-west-3b
  172.31.32.0/20:
    type: ipv4
    provider-id: subnet-748c9d3e
    provider-network-id: vpc-8abf64e3
    space: alpha
    zones:
    - eu-west-3c
  172.31.254.0/24:
    type: ipv4
    provider-id: subnet-034e151128f81628c
    provider-network-id: vpc-8abf64e3
    space: alpha
    zones:
    - eu-west-3c
```
Also, to make sure the network config is correctly set by the container init in the provisioner worker, deploying to a container should continue working:
```
juju deploy ubuntu --to lxd
```

Make sure 3.6->4.0 migration isn't broken:
```
juju_36 bootstrap aws 36
juju_36 add-model m
juju_36 deploy ubuntu --to lxd
# install this patch at this point
juju bootstrap aws c40
juju switch c36:admin/m
juju migrate c40
```
## Links

**Jira card:** JUJU-6050

