### PR TITLE
Azure image lookup

### DIFF
--- a/apiserver/facades/client/machinemanager/upgradebase.go
+++ b/apiserver/facades/client/machinemanager/upgradebase.go
@@ -310,7 +310,7 @@ func makeUpgradeSeriesValidator(client CharmhubClient) upgradeSeriesValidator {
 }
 
 func baseFromParams(machineTag string, base state.Base, channel string) (corebase.Base, error) {
-	if base.OS != "ubuntu" {
+	if base.OS != corebase.UbuntuOS {
 		return corebase.Base{}, errors.Errorf("%s is running %s and is not valid for Ubuntu series upgrade",
 			machineTag, base.OS)
 	}
@@ -327,7 +327,7 @@ func (s upgradeSeriesValidator) ValidateBase(requestedBase, machineBase corebase
 		return errors.BadRequestf("base missing from args")
 	}
 
-	if requestedBase.OS != "ubuntu" {
+	if requestedBase.OS != corebase.UbuntuOS {
 		return errors.Errorf("base %q is not a valid upgrade target", requestedBase)
 	}
 

--- a/core/base/base.go
+++ b/core/base/base.go
@@ -124,6 +124,25 @@ func (b Base) IsCompatible(other Base) bool {
 	return b.OS == other.OS && b.Channel.Track == other.Channel.Track
 }
 
+// ubuntuLTSes lists the Ubuntu LTS releases that
+// this version of Juju knows about
+var ubuntuLTSes = []Base{
+	MakeDefaultBase(UbuntuOS, "20.04"),
+	MakeDefaultBase(UbuntuOS, "22.04"),
+	MakeDefaultBase(UbuntuOS, "24.04"),
+}
+
+// IsUbuntuLTS returns true if this base is a recognised
+// Ubuntu LTS.
+func (b Base) IsUbuntuLTS() bool {
+	for _, ubuntuLTS := range ubuntuLTSes {
+		if b.IsCompatible(ubuntuLTS) {
+			return true
+		}
+	}
+	return false
+}
+
 // DisplayString returns the base string ignoring risk.
 func (b Base) DisplayString() string {
 	if b.Channel.Track == "" || b.OS == "" {

--- a/core/base/base.go
+++ b/core/base/base.go
@@ -21,6 +21,16 @@ type Base struct {
 	Channel Channel
 }
 
+const (
+	// UbuntuOS is the special value to be places in OS field of a base to
+	// indicate an operating system is an Ubuntu distro
+	UbuntuOS = "ubuntu"
+
+	// CentosOS is the special value to be places in OS field of a base to
+	// indicate an operating system is a CentOS distro
+	CentosOS = "centos"
+)
+
 // ParseBase constructs a Base from the os and channel string.
 func ParseBase(os string, channel string) (Base, error) {
 	if os == "" && channel == "" {
@@ -155,9 +165,9 @@ func GetSeriesFromChannel(name string, channel string) (string, error) {
 func GetSeriesFromBase(v Base) (string, error) {
 	var osSeries map[SeriesName]seriesVersion
 	switch strings.ToLower(v.OS) {
-	case "ubuntu":
+	case UbuntuOS:
 		osSeries = ubuntuSeries
-	case "centos":
+	case CentosOS:
 		osSeries = centosSeries
 	}
 	for s, vers := range osSeries {
@@ -170,7 +180,7 @@ func GetSeriesFromBase(v Base) (string, error) {
 
 // LegacyKubernetesBase is the ubuntu base image for legacy k8s charms.
 func LegacyKubernetesBase() Base {
-	return MakeDefaultBase("ubuntu", "20.04")
+	return MakeDefaultBase(UbuntuOS, "20.04")
 }
 
 // LegacyKubernetesSeries is the ubuntu series for legacy k8s charms.

--- a/core/base/base_test.go
+++ b/core/base/base_test.go
@@ -100,3 +100,41 @@ func (s *BaseSuite) TestParseManifestBases(c *gc.C) {
 	}
 	c.Assert(obtained, jc.DeepEquals, expected)
 }
+
+var ubuntuLTS = []Base{
+	MustParseBaseFromString("ubuntu@20.04"),
+	MustParseBaseFromString("ubuntu@22.04"),
+	MustParseBaseFromString("ubuntu@24.04"),
+	MustParseBaseFromString("ubuntu@24.04/stable"),
+	MustParseBaseFromString("ubuntu@24.04/edge"),
+}
+
+func (s *BaseSuite) TestIsUbuntuLTSForLTSes(c *gc.C) {
+	for i, lts := range ubuntuLTS {
+		c.Logf("Checking index %d base %v", i, lts)
+		c.Check(lts.IsUbuntuLTS(), jc.IsTrue)
+	}
+}
+
+var nonUbuntuLTS = []Base{
+	MustParseBaseFromString("ubuntu@17.04"),
+	MustParseBaseFromString("ubuntu@19.04"),
+	MustParseBaseFromString("ubuntu@21.04"),
+
+	MustParseBaseFromString("ubuntu@18.10"),
+	MustParseBaseFromString("ubuntu@20.10"),
+	MustParseBaseFromString("ubuntu@22.10"),
+
+	MustParseBaseFromString("ubuntu@22.04-blah"),
+	MustParseBaseFromString("ubuntu@22.04.1234"),
+
+	MustParseBaseFromString("centos@7"),
+	MustParseBaseFromString("centos@20.04"),
+}
+
+func (s *BaseSuite) TestIsUbuntuLTSForNonLTSes(c *gc.C) {
+	for i, lts := range nonUbuntuLTS {
+		c.Logf("Checking index %d base %v", i, lts)
+		c.Check(lts.IsUbuntuLTS(), jc.IsFalse)
+	}
+}

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -388,7 +388,7 @@ func bootstrapIAAS(
 		config.PreferredBase(cfg),
 	)
 	if !args.Force && err != nil {
-		// If the series isn't valid at all, then don't prompt users to use
+		// If the base isn't valid at all, then don't prompt users to use
 		// the --force flag.
 		if requestedBootstrapBase.OS != corebase.UbuntuOS {
 			return errors.NotValidf("non-ubuntu bootstrap base %q", requestedBootstrapBase.String())

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -390,8 +390,8 @@ func bootstrapIAAS(
 	if !args.Force && err != nil {
 		// If the series isn't valid at all, then don't prompt users to use
 		// the --force flag.
-		if _, err := corebase.UbuntuBaseVersion(requestedBootstrapBase); err != nil {
-			return errors.NotValidf("base %q", requestedBootstrapBase.String())
+		if requestedBootstrapBase.OS != corebase.UbuntuOS {
+			return errors.NotValidf("non-ubuntu bootstrap base %q", requestedBootstrapBase.String())
 		}
 		return errors.Annotatef(err, "use --force to override")
 	}

--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -1085,9 +1085,6 @@ func newOSProfile(
 	}
 
 	instOS := os.OSTypeForName(instanceConfig.Base.OS)
-	if err != nil {
-		return nil, os.Unknown, errors.Trace(err)
-	}
 	switch instOS {
 	case os.Ubuntu, os.CentOS:
 		// SSH keys are handled by custom data, but must also be

--- a/provider/azure/instancetype.go
+++ b/provider/azure/instancetype.go
@@ -536,7 +536,7 @@ func (env *azureEnviron) findInstanceSpec(
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	image, err := imageutils.SeriesImage(ctx, constraint.Base, imageStream, constraint.Region, client)
+	image, err := imageutils.BaseImage(ctx, constraint.Base, imageStream, constraint.Region, client)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/provider/azure/internal/imageutils/images.go
+++ b/provider/azure/internal/imageutils/images.go
@@ -32,15 +32,17 @@ const (
 	ubuntuPublisher = "Canonical"
 
 	dailyStream = "daily"
+
+	plan = "server-gen1"
 )
 
-// SeriesImage gets an instances.Image for the specified series, image stream
+// BaseImage gets an instances.Image for the specified base, image stream
 // and location. The resulting Image's ID is in the URN format expected by
 // Azure Resource Manager.
 //
 // For Ubuntu, we query the SKUs to determine the most recent point release
 // for a series.
-func SeriesImage(
+func BaseImage(
 	ctx context.ProviderCallContext,
 	base jujubase.Base, stream, location string,
 	client *armcompute.VirtualMachineImagesClient,
@@ -50,12 +52,9 @@ func SeriesImage(
 	var publisher, offering, sku string
 	switch seriesOS {
 	case os.Ubuntu:
-		series, err := jujubase.GetSeriesFromBase(base)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
 		publisher = ubuntuPublisher
-		sku, offering, err = ubuntuSKU(ctx, series, stream, location, client)
+		var err error
+		sku, offering, err = ubuntuSKU(ctx, base, stream, location, client)
 		if err != nil {
 			return nil, errors.Annotatef(err, "selecting SKU for %s", base.DisplayString())
 		}
@@ -81,22 +80,91 @@ func SeriesImage(
 	}, nil
 }
 
-func offerForUbuntuSeries(series string) (string, string, error) {
-	seriesVersion, err := jujubase.SeriesVersion(series)
-	if err != nil {
-		return "", "", errors.Trace(err)
+// legacyUbuntuBases is a slice of bases which use the old-style offer
+// id formatted like "0001-com-ubuntu-server-${series}".
+//
+// Recently Canonical changed the format for images offer ids
+// and SKUs in Azure. The threshold for this change was noble, so if
+// we want to deploy bases before noble, we must branch and use the
+// old format.
+//
+// The old format offer ids have format `0001-com-ubuntu-server-${series}`
+// or `001-com-ubuntu-server-${series}-daily` and have SKUs formatted
+// `${version_number}-lts`, `${version_number}-gen2`, etc.
+//
+// The new format offer ids have format `ubuntu-${version_number}`,
+// `ubuntu-${version_number}-lts`, `ubuntu-${version_number}-lts-daily`,
+// etc. and have SKUs `server`, `server-gen1`m, `server-arm64`, etc.
+//
+// Since there are only a finte number of Ubuntu versions we support
+// before Noble, we hardcode this list. So when new versions of Ubuntu
+// are
+//
+// All Ubuntu images we support outside of this list have offer
+// id like "ubuntu-${version}-lts" or "ubuntu-${version}"
+var legacyUbuntuBases = []jujubase.Base{
+	jujubase.MustParseBaseFromString("ubuntu@20.04"),
+	jujubase.MustParseBaseFromString("ubuntu@20.10"),
+	jujubase.MustParseBaseFromString("ubuntu@21.04"),
+	jujubase.MustParseBaseFromString("ubuntu@21.10"),
+	jujubase.MustParseBaseFromString("ubuntu@22.04"),
+	jujubase.MustParseBaseFromString("ubuntu@22.10"),
+	jujubase.MustParseBaseFromString("ubuntu@23.04"),
+	jujubase.MustParseBaseFromString("ubuntu@23.10"),
+}
+
+func ubuntuBaseIslegacy(base jujubase.Base) bool {
+	for _, oldBase := range legacyUbuntuBases {
+		if base.IsCompatible(oldBase) {
+			return true
+		}
 	}
-	seriesVersion = strings.ReplaceAll(seriesVersion, ".", "_")
-	return fmt.Sprintf("0001-com-ubuntu-server-%s", series), seriesVersion, nil
+	return false
 }
 
 // ubuntuSKU returns the best SKU for the Canonical:UbuntuServer offering,
 // matching the given series.
-func ubuntuSKU(ctx context.ProviderCallContext, series, stream, location string, client *armcompute.VirtualMachineImagesClient) (string, string, error) {
-	offer, seriesVersion, err := offerForUbuntuSeries(series)
+//
+// TODO(jack-w-shaw): Selecting the 'daily' stream is currently broken for legacy
+// Ubuntu SKU selection. See the following lp bug:
+// https://bugs.launchpad.net/juju/+bug/2067717
+func ubuntuSKU(ctx context.ProviderCallContext, base jujubase.Base, stream, location string, client *armcompute.VirtualMachineImagesClient) (string, string, error) {
+	if ubuntuBaseIslegacy(base) {
+		return legacyUbuntuSKU(ctx, base, stream, location, client)
+	}
+
+	offer := fmt.Sprintf("ubuntu-%s", strings.ReplaceAll(base.Channel.Track, ".", "_"))
+	if base.IsUbuntuLTS() {
+		offer = fmt.Sprintf("%s-lts", offer)
+	}
+	if stream == dailyStream {
+		offer = fmt.Sprintf("%s-daily", offer)
+	}
+
+	logger.Debugf("listing SKUs: Location=%s, Publisher=%s, Offer=%s", location, ubuntuPublisher, offer)
+	result, err := client.ListSKUs(ctx, location, ubuntuPublisher, offer, nil)
+	if err != nil {
+		return "", "", errorutils.HandleCredentialError(errors.Annotate(err, "listing Ubuntu SKUs"), ctx)
+	}
+	for _, img := range result.VirtualMachineImageResourceArray {
+		skuName := *img.Name
+		if skuName == plan {
+			logger.Debugf("found Azure SKU Name: %v", skuName)
+			return skuName, offer, nil
+		}
+		logger.Debugf("ignoring Azure SKU Name: %v", skuName)
+	}
+	return "", "", errors.NotFoundf("ubuntu %q SKUs for %v stream", base, stream)
+}
+
+func legacyUbuntuSKU(ctx context.ProviderCallContext, base jujubase.Base, stream, location string, client *armcompute.VirtualMachineImagesClient) (string, string, error) {
+	series, err := jujubase.GetSeriesFromBase(base)
 	if err != nil {
 		return "", "", errors.Trace(err)
 	}
+	offer := fmt.Sprintf("0001-com-ubuntu-server-%s", series)
+	desiredSKUPrefix := strings.ReplaceAll(base.Channel.Track, ".", "_")
+
 	logger.Debugf("listing SKUs: Location=%s, Publisher=%s, Offer=%s", location, ubuntuPublisher, offer)
 	result, err := client.ListSKUs(ctx, location, ubuntuPublisher, offer, nil)
 	if err != nil {
@@ -106,12 +174,12 @@ func ubuntuSKU(ctx context.ProviderCallContext, series, stream, location string,
 	var versions ubuntuVersions
 	for _, img := range result.VirtualMachineImageResourceArray {
 		skuName := *img.Name
-		logger.Debugf("Found Azure SKU Name: %v", skuName)
-		if !strings.HasPrefix(skuName, seriesVersion) {
-			logger.Debugf("ignoring SKU %q (does not match series %q with version %q)", skuName, series, seriesVersion)
+		logger.Debugf("found Azure SKU Name: %v", skuName)
+		if !strings.HasPrefix(skuName, desiredSKUPrefix) {
+			logger.Debugf("ignoring SKU %q (does not match series %q)", skuName, series)
 			continue
 		}
-		version, tag, err := parseUbuntuSKU(skuName)
+		version, tag, err := parselegacyUbuntuSKU(skuName)
 		if err != nil {
 			logger.Errorf("ignoring SKU %q (failed to parse: %s)", skuName, err)
 			continue
@@ -132,7 +200,7 @@ func ubuntuSKU(ctx context.ProviderCallContext, series, stream, location string,
 		versions = append(versions, version)
 	}
 	if len(versions) == 0 {
-		return "", "", errors.NotFoundf("Ubuntu SKUs for %s stream", stream)
+		return "", "", errors.NotFoundf("legacy ubuntu %q SKUs for %s stream", series, stream)
 	}
 	sort.Sort(versions)
 	bestVersion := versions[len(versions)-1]
@@ -145,9 +213,9 @@ type ubuntuVersion struct {
 	Point int
 }
 
-// parseUbuntuSKU splits an UbuntuServer SKU into its
+// parselegacyUbuntuSKU splits an UbuntuServer SKU into its
 // version ("22_04.3") and tag ("LTS") parts.
-func parseUbuntuSKU(sku string) (ubuntuVersion, string, error) {
+func parselegacyUbuntuSKU(sku string) (ubuntuVersion, string, error) {
 	var version ubuntuVersion
 	var tag string
 	var err error

--- a/provider/azure/internal/imageutils/images_test.go
+++ b/provider/azure/internal/imageutils/images_test.go
@@ -45,11 +45,11 @@ func (s *imageutilsSuite) SetUpTest(c *gc.C) {
 	s.callCtx = context.NewEmptyCloudCallContext()
 }
 
-func (s *imageutilsSuite) TestSeriesImage(c *gc.C) {
+func (s *imageutilsSuite) TestBaseImageOldStyle(c *gc.C) {
 	s.mockSender.AppendResponse(azuretesting.NewResponseWithContent(
 		`[{"name": "20_04"}, {"name": "20_04-LTS"}, {"name": "19_04"}]`,
 	))
-	image, err := imageutils.SeriesImage(s.callCtx, corebase.MakeDefaultBase("ubuntu", "20.04"), "released", "westus", s.client)
+	image, err := imageutils.BaseImage(s.callCtx, corebase.MakeDefaultBase("ubuntu", "20.04"), "released", "westus", s.client)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(image, gc.NotNil)
 	c.Assert(image, jc.DeepEquals, &instances.Image{
@@ -59,11 +59,11 @@ func (s *imageutilsSuite) TestSeriesImage(c *gc.C) {
 	})
 }
 
-func (s *imageutilsSuite) TestSeriesImageInvalidSKU(c *gc.C) {
+func (s *imageutilsSuite) TestBaseImageOldStyleInvalidSKU(c *gc.C) {
 	s.mockSender.AppendResponse(azuretesting.NewResponseWithContent(
 		`[{"name": "22_04_invalid"}, {"name": "22_04_5-LTS"}]`,
 	))
-	image, err := imageutils.SeriesImage(s.callCtx, corebase.MakeDefaultBase("ubuntu", "22.04"), "released", "westus", s.client)
+	image, err := imageutils.BaseImage(s.callCtx, corebase.MakeDefaultBase("ubuntu", "22.04"), "released", "westus", s.client)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(image, gc.NotNil)
 	c.Assert(image, jc.DeepEquals, &instances.Image{
@@ -73,14 +73,42 @@ func (s *imageutilsSuite) TestSeriesImageInvalidSKU(c *gc.C) {
 	})
 }
 
-func (s *imageutilsSuite) TestSeriesImageCentOS(c *gc.C) {
+func (s *imageutilsSuite) TestBaseImage(c *gc.C) {
+	s.mockSender.AppendResponse(azuretesting.NewResponseWithContent(
+		`[{"name": "server"}, {"name": "server-gen1"}, {"name": "server-arm64"}]`,
+	))
+	image, err := imageutils.BaseImage(s.callCtx, corebase.MakeDefaultBase("ubuntu", "24.04"), "released", "westus", s.client)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(image, gc.NotNil)
+	c.Assert(image, jc.DeepEquals, &instances.Image{
+		Id:       "Canonical:ubuntu-24_04-lts:server-gen1:latest",
+		Arch:     arch.AMD64,
+		VirtType: "Hyper-V",
+	})
+}
+
+func (s *imageutilsSuite) TestBaseImageNonLTS(c *gc.C) {
+	s.mockSender.AppendResponse(azuretesting.NewResponseWithContent(
+		`[{"name": "server"}, {"name": "server-gen1"}, {"name": "server-arm64"}]`,
+	))
+	image, err := imageutils.BaseImage(s.callCtx, corebase.MakeDefaultBase("ubuntu", "25.04"), "released", "westus", s.client)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(image, gc.NotNil)
+	c.Assert(image, jc.DeepEquals, &instances.Image{
+		Id:       "Canonical:ubuntu-25_04:server-gen1:latest",
+		Arch:     arch.AMD64,
+		VirtType: "Hyper-V",
+	})
+}
+
+func (s *imageutilsSuite) TestBaseImageCentOS(c *gc.C) {
 	for _, cseries := range []string{"7", "8"} {
 		base := corebase.MakeDefaultBase("centos", cseries)
 		s.assertImageId(c, base, "released", "OpenLogic:CentOS:7.3:latest")
 	}
 }
 
-func (s *imageutilsSuite) TestSeriesImageStream(c *gc.C) {
+func (s *imageutilsSuite) TestBaseImageStream(c *gc.C) {
 	s.mockSender.AppendAndRepeatResponse(azuretesting.NewResponseWithContent(
 		`[{"name": "22_04_2"}, {"name": "22_04_3-DAILY"}, {"name": "22_04_1-LTS"}]`), 2)
 	base := corebase.MakeDefaultBase("ubuntu", "22.04")
@@ -88,20 +116,27 @@ func (s *imageutilsSuite) TestSeriesImageStream(c *gc.C) {
 	s.assertImageId(c, base, "released", "Canonical:0001-com-ubuntu-server-jammy:22_04_2:latest")
 }
 
-func (s *imageutilsSuite) TestSeriesImageNotFound(c *gc.C) {
+func (s *imageutilsSuite) TestBaseImageOldStyleNotFound(c *gc.C) {
 	s.mockSender.AppendResponse(azuretesting.NewResponseWithContent(`[]`))
-	image, err := imageutils.SeriesImage(s.callCtx, corebase.MakeDefaultBase("ubuntu", "22.04"), "released", "westus", s.client)
-	c.Assert(err, gc.ErrorMatches, "selecting SKU for ubuntu@22.04: Ubuntu SKUs for released stream not found")
+	image, err := imageutils.BaseImage(s.callCtx, corebase.MakeDefaultBase("ubuntu", "22.04"), "released", "westus", s.client)
+	c.Assert(err, gc.ErrorMatches, `selecting SKU for ubuntu@22.04: legacy ubuntu "jammy" SKUs for released stream not found`)
 	c.Assert(image, gc.IsNil)
 }
 
-func (s *imageutilsSuite) TestSeriesImageStreamNotFound(c *gc.C) {
-	s.mockSender.AppendResponse(azuretesting.NewResponseWithContent(`[{"name": "22_04-beta1"}]`))
-	_, err := imageutils.SeriesImage(s.callCtx, corebase.MakeDefaultBase("ubuntu", "22.04"), "whatever", "westus", s.client)
-	c.Assert(err, gc.ErrorMatches, "selecting SKU for ubuntu@22.04: Ubuntu SKUs for whatever stream not found")
+func (s *imageutilsSuite) TestBaseImageNotFound(c *gc.C) {
+	s.mockSender.AppendResponse(azuretesting.NewResponseWithContent(`[]`))
+	image, err := imageutils.BaseImage(s.callCtx, corebase.MakeDefaultBase("ubuntu", "24.04"), "released", "westus", s.client)
+	c.Assert(err, gc.ErrorMatches, `selecting SKU for ubuntu@24.04: ubuntu "ubuntu@24.04/stable" SKUs for released stream not found`)
+	c.Assert(image, gc.IsNil)
 }
 
-func (s *imageutilsSuite) TestSeriesImageStreamThrewCredentialError(c *gc.C) {
+func (s *imageutilsSuite) TestBaseImageStreamNotFound(c *gc.C) {
+	s.mockSender.AppendResponse(azuretesting.NewResponseWithContent(`[{"name": "22_04-beta1"}]`))
+	_, err := imageutils.BaseImage(s.callCtx, corebase.MakeDefaultBase("ubuntu", "22.04"), "whatever", "westus", s.client)
+	c.Assert(err, gc.ErrorMatches, `selecting SKU for ubuntu@22.04: legacy ubuntu "jammy" SKUs for whatever stream not found`)
+}
+
+func (s *imageutilsSuite) TestBaseImageStreamThrewCredentialError(c *gc.C) {
 	s.mockSender.AppendResponse(azuretesting.NewResponseWithStatus("401 Unauthorized", http.StatusUnauthorized))
 	called := false
 	s.callCtx.InvalidateCredentialFunc = func(string) error {
@@ -109,12 +144,12 @@ func (s *imageutilsSuite) TestSeriesImageStreamThrewCredentialError(c *gc.C) {
 		return nil
 	}
 
-	_, err := imageutils.SeriesImage(s.callCtx, corebase.MakeDefaultBase("ubuntu", "22.04"), "whatever", "westus", s.client)
+	_, err := imageutils.BaseImage(s.callCtx, corebase.MakeDefaultBase("ubuntu", "22.04"), "whatever", "westus", s.client)
 	c.Assert(err.Error(), jc.Contains, "RESPONSE 401")
 	c.Assert(called, jc.IsTrue)
 }
 
-func (s *imageutilsSuite) TestSeriesImageStreamThrewNonCredentialError(c *gc.C) {
+func (s *imageutilsSuite) TestBaseImageStreamThrewNonCredentialError(c *gc.C) {
 	s.mockSender.AppendResponse(azuretesting.NewResponseWithStatus("308 Permanent Redirect", http.StatusPermanentRedirect))
 	called := false
 	s.callCtx.InvalidateCredentialFunc = func(string) error {
@@ -122,13 +157,13 @@ func (s *imageutilsSuite) TestSeriesImageStreamThrewNonCredentialError(c *gc.C) 
 		return nil
 	}
 
-	_, err := imageutils.SeriesImage(s.callCtx, corebase.MakeDefaultBase("ubuntu", "22.04"), "whatever", "westus", s.client)
+	_, err := imageutils.BaseImage(s.callCtx, corebase.MakeDefaultBase("ubuntu", "22.04"), "whatever", "westus", s.client)
 	c.Assert(err.Error(), jc.Contains, "RESPONSE 308")
 	c.Assert(called, jc.IsFalse)
 }
 
 func (s *imageutilsSuite) assertImageId(c *gc.C, base corebase.Base, stream, id string) {
-	image, err := imageutils.SeriesImage(s.callCtx, base, stream, "westus", s.client)
+	image, err := imageutils.BaseImage(s.callCtx, base, stream, "westus", s.client)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(image.Id, gc.Equals, id)
 }

--- a/provider/common/bootstrap.go
+++ b/provider/common/bootstrap.go
@@ -114,8 +114,8 @@ func BootstrapInstance(
 	if !args.Force && err != nil {
 		// If the base isn't valid at all, then don't prompt users to use
 		// the --force flag.
-		if _, err := corebase.UbuntuBaseVersion(requestedBootstrapBase); err != nil {
-			return nil, nil, nil, errors.NotValidf("base %q", requestedBootstrapBase.String())
+		if requestedBootstrapBase.OS != corebase.UbuntuOS {
+			return nil, nil, nil, errors.NotValidf("non-ubuntu bootstrap base %q", requestedBootstrapBase.String())
 		}
 		return nil, nil, nil, errors.Annotatef(err, "use --force to override")
 	}

--- a/provider/dummy/environs.go
+++ b/provider/dummy/environs.go
@@ -1055,7 +1055,7 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, callCtx context.Provi
 
 	bsResult := &environs.BootstrapResult{
 		Arch:                    arch,
-		Base:                    corebase.MakeDefaultBase("ubuntu", "22.04"),
+		Base:                    corebase.MakeDefaultBase(corebase.UbuntuOS, "22.04"),
 		CloudBootstrapFinalizer: finalize,
 	}
 	return bsResult, nil

--- a/provider/equinix/environ.go
+++ b/provider/equinix/environ.go
@@ -45,9 +45,7 @@ import (
 
 var logger = loggo.GetLogger("juju.provider.equinix")
 
-const (
-	sshPort = 22
-)
+const sshPort = 22
 
 type environConfig struct {
 	config *config.Config

--- a/provider/equinix/environ.go
+++ b/provider/equinix/environ.go
@@ -45,7 +45,9 @@ import (
 
 var logger = loggo.GetLogger("juju.provider.equinix")
 
-const sshPort = 22
+const (
+	sshPort = 22
+)
 
 type environConfig struct {
 	config *config.Config
@@ -328,7 +330,7 @@ func getCloudConfig(args environs.StartInstanceParams) (cloudinit.CloudConfig, e
 	// NOTE(achilleasa): this is a hack and is only meant to be used
 	// temporarily; we must ensure that equinix mirrors the official
 	// ubuntu cloud images.
-	if _, err := corebase.GetSeriesFromBase(args.InstanceConfig.Base); err == nil {
+	if args.InstanceConfig.Base.OS == corebase.UbuntuOS {
 		cloudCfg.AddScripts(
 			"apt-get update",
 			"DEBIAN_FRONTEND=noninteractive apt-get --option=Dpkg::Options::=--force-confdef --option=Dpkg::Options::=--force-confold --option=Dpkg::Options::=--force-unsafe-io --assume-yes --quiet install dmidecode snapd",
@@ -340,7 +342,7 @@ func getCloudConfig(args environs.StartInstanceParams) (cloudinit.CloudConfig, e
 	// references the juju-assigned hostname before localhost. Otherwise,
 	// running 'hostname -f' would return localhost whereas 'hostname'
 	// returns the juju-assigned host (see LP1956538).
-	if _, err := corebase.GetSeriesFromBase(args.InstanceConfig.Base); err == nil {
+	if args.InstanceConfig.Base.OS == corebase.UbuntuOS {
 		cloudCfg.AddScripts(
 			`sed -i -e "/127\.0\.0\.1/c\127\.0\.0\.1 $(hostname) localhost" /etc/hosts`,
 		)

--- a/provider/oci/images.go
+++ b/provider/oci/images.go
@@ -39,8 +39,6 @@ const (
 	centOS   = "CentOS"
 	ubuntuOS = "Canonical Ubuntu"
 
-	UbuntuBase = "ubuntu"
-
 	staleImageCacheTimeoutInMinutes = 30
 )
 
@@ -322,7 +320,7 @@ func parseUbuntuImage(img ociCore.Image) (corebase.Base, string, bool) {
 	//   the ubuntu image's metadata) so we need to find a workaround as
 	//   explained in the NOTE a few lines below.
 	channel, postfix, _ := strings.Cut(*img.OperatingSystemVersion, " ")
-	base = corebase.MakeDefaultBase(UbuntuBase, channel)
+	base = corebase.MakeDefaultBase(corebase.UbuntuOS, channel)
 	// if not found, means that the OperatingSystemVersion only contained
 	// the channel.
 	if strings.Contains(*img.DisplayName, "Minimal") ||

--- a/state/charm.go
+++ b/state/charm.go
@@ -81,12 +81,12 @@ func (b Base) String() string {
 
 // UbuntuBase is used in tests.
 func UbuntuBase(channel string) Base {
-	return Base{OS: "ubuntu", Channel: channel + "/stable"}
+	return Base{OS: corebase.UbuntuOS, Channel: channel + "/stable"}
 }
 
 // DefaultLTSBase is used in tests.
 func DefaultLTSBase() Base {
-	return Base{OS: "ubuntu", Channel: jujuversion.DefaultSupportedLTSBase().Channel.String()}
+	return Base{OS: corebase.UbuntuOS, Channel: jujuversion.DefaultSupportedLTSBase().Channel.String()}
 }
 
 // Platform identifies the platform the charm was installed on.

--- a/upgrades/upgradevalidation/validation.go
+++ b/upgrades/upgradevalidation/validation.go
@@ -196,7 +196,7 @@ func checkForDeprecatedUbuntuSeriesForModel(
 	supported := false
 	var deprecatedBases []state.Base
 	for _, vers := range corebase.UbuntuVersions(&supported, nil) {
-		deprecatedBases = append(deprecatedBases, state.Base{OS: "ubuntu", Channel: vers})
+		deprecatedBases = append(deprecatedBases, state.Base{OS: corebase.UbuntuOS, Channel: vers})
 	}
 
 	// sort for tests.

--- a/version/series.go
+++ b/version/series.go
@@ -14,5 +14,5 @@ func DefaultSupportedLTS() string {
 // DefaultSupportedLTSBase returns the latest LTS base that Juju supports
 // and is compatible with.
 func DefaultSupportedLTSBase() corebase.Base {
-	return corebase.MakeDefaultBase("ubuntu", "22.04")
+	return corebase.MakeDefaultBase(corebase.UbuntuOS, "22.04")
 }


### PR DESCRIPTION
Lookup Ubuntu images base on the new offer id + SKU format for Noble and beyond

Since Noble, Ubuntu images in Azure follow a new schemas for offer Id and SKUs.

The old format offer ids have format `0001-com-ubuntu-server-${series}`
or `001-com-ubuntu-server-${series}-daily` and have SKUs formatted
`${version_number}-lts`, `${version_number}-gen2`, etc.

The new format offer ids have format `ubuntu-${version_number}`,
`ubuntu-${version_number}-lts`, `ubuntu-${version_number}-lts-daily`,
etc. and have SKUs `server`, `server-gen1`, `server-arm64`, etc.

Make sure we use the new schema for images Noble and beyond.

Thus far, the commit on top of the PR commit stack

The first two relate to the simple fact that the new offer id will follow a different format 
between LTS releases and non-LTS releases. Therefore, I add a method to bases to
determine if it is a valid Ubuntu LTS. 

The first commit `Add constant for Ubuntu OS in bases` is a backport from https://github.com/juju/juju/pull/17259

the 2nd commit `Add IsUbuntuLTS method to bases` implements this method + adds tests

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

### Add jammy + noble machines

```
$ juju bootstrap azure/centralus azure
$ juju add-model m
$ juju add-machine --base ubuntu@22.04
$ juju add-machine --base ubuntu@24.04
$ juju status
Model  Controller  Cloud/Region     Version  SLA          Timestamp
m      azure1      azure/centralus  3.3.6.1  unsupported  16:03:27+01:00

Machine  State    Address         Inst id    Base          AZ  Message
0        started  172.170.113.25  machine-0  ubuntu@22.04      
1        started  172.170.113.69  machine-1  ubuntu@24.04  
```

Repeat this in a few different regions (I tested `centralus`, `northeurope` & `japaneast`)

### Using `daily` image stream

```
$ juju switch azure
$ juju add-model m2
$ juju model-config image-stream=daily
$ juju add-machine --base ubuntu@24.04
$ juju status
Model  Controller  Cloud/Region     Version  SLA          Timestamp
test2  azure1      azure/centralus  3.3.6.1  unsupported  16:39:26+01:00

Machine  State    Address        Inst id    Base          AZ  Message
0        started  172.169.90.25  machine-0  ubuntu@24.04  

$ juju ssh 0
$ sudo apt update
Hit:1 http://azure.archive.ubuntu.com/ubuntu noble InRelease
Hit:2 http://azure.archive.ubuntu.com/ubuntu noble-updates InRelease
Hit:3 http://azure.archive.ubuntu.com/ubuntu noble-backports InRelease
Hit:4 http://azure.archive.ubuntu.com/ubuntu noble-security InRelease
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
All packages are up to date.
```
^ Notice, no caches needed updating on `apt update`
