### PR TITLE
No longer error out for series in bundles

### DIFF
--- a/cmd/juju/application/deployer/bundle.go
+++ b/cmd/juju/application/deployer/bundle.go
@@ -84,7 +84,7 @@ func (d *deployBundle) deploy(
 	d.accountUser = accountDetails.User
 
 	// Compose bundle to be deployed and check its validity.
-	bundleData, unmarshalErrors, err := bundle.ComposeAndVerifyBundle(d.bundleDataSource, d.bundleOverlayFile)
+	bundleData, unmarshalErrors, err := bundle.ComposeAndVerifyBundle(ctx, d.bundleDataSource, d.bundleOverlayFile)
 	if err != nil {
 		return errors.Annotatef(err, "cannot deploy bundle")
 	}

--- a/cmd/juju/application/diffbundle.go
+++ b/cmd/juju/application/diffbundle.go
@@ -215,7 +215,7 @@ func (c *diffBundleCommand) Run(ctx *cmd.Context) error {
 		return errors.Trace(err)
 	}
 
-	bundle, _, err := appbundle.ComposeAndVerifyBundle(baseSrc, c.bundleOverlays)
+	bundle, _, err := appbundle.ComposeAndVerifyBundle(ctx, baseSrc, c.bundleOverlays)
 	if err != nil {
 		return errors.Trace(err)
 	}


### PR DESCRIPTION
After some further discussion on dropping support for series in bundles, we have decided that erroring out is not the best approach.

This was triggered by realisation of the fact that charmhub still enforces that uploaded bundles contain a series (or 'bundle', but that's only relevant to k8s bundles).

Meaning it is guarenteed that (almost) all bundles in charmhub today would break.

As such, instead of erroring out, we show a different warning stating that the series key is unsuppoirted and will be ignored

The suggested solution to bundle authors to ensure they bundles are supported in 4.0 is to use 'default-base' or 'base' in their bundles instead.

However, 2.9 does not recognise default-base or base. So series needs to be used to be supported by 2.9. As such, we need to support bundles with both series and base provided, as we do in 3.x.

So we will only display this warning if a series is found without a base, since this is the only scenerio which we have dropped support for.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

### Attempt to deploy some bundles 

(Note: charmed-kubernetes rev 1243 contains series on the top level bundle, no where else)
```
$ juju deploy charmed-kubernetes --revision 1243
Located bundle "charmed-kubernetes" in charm-hub, revision 1243
WARNING unsupported key 'series' detected without a base in the base bundle. Ignoring:
- document 0; bundle contains top level series. Please use default-base
Located charm "calico" in charm-hub, channel latest/stable
Located charm "containerd" in charm-hub, channel latest/stable
Located charm "easyrsa" in charm-hub, channel latest/stable
Located charm "etcd" in charm-hub, channel latest/stable
Located charm "kubeapi-load-balancer" in charm-hub, channel latest/stable
Located charm "kubernetes-control-plane" in charm-hub, channel latest/stable
Located charm "kubernetes-worker" in charm-hub, channel latest/stable
Executing changes:
...
```

```
$ cat ./bundle.yaml
default-base: ubuntu@22.04/stable
applications:
  ubuntu:
    charm: ubuntu
    num_units: 1
    to:
    - "0"
machines:
  "0":

$ juju deploy ./bundle.yaml
Located charm "ubuntu" in charm-hub, channel latest/stable
Executing changes:
- upload charm ubuntu from charm-hub for base ubuntu@22.04/stable with architecture=amd64
- deploy application ubuntu from charm-hub on ubuntu@22.04/stable
- add new machine 0
- add unit ubuntu/0 to new machine 0
Deploy of bundle completed.
```

```
# We should also be able to deploy by specifying a directory with a bundle
$ juju deploy .
Located charm "ubuntu" in charm-hub, channel latest/stable
Executing changes:
- upload charm ubuntu from charm-hub for base ubuntu@22.04/stable with architecture=amd64
- deploy application ubuntu from charm-hub on ubuntu@22.04/stable
- add new machine 0
- add unit ubuntu/0 to new machine 0
Deploy of bundle completed.
```

```
$ cat bundle.yaml 
series: jammy
applications:
  ubuntu:
    charm: ubuntu
    series: jammy
    num_units: 1
    to:
    - "0"
machines:
  "0":
    series: jammy

$ juju deploy ./bundle.yaml
WARNING unsupported key 'series' detected without a base in the base bundle. Ignoring:
- document 0; bundle contains top level series. Please use default-base
- document 0; bundle application "ubuntu" contains series. Please use base
- document 0; bundle machine "0" contains series. Please use base
Located charm "ubuntu" in charm-hub, channel latest/stable
Executing changes:
...
```

```
$ cat bundle.yaml 
series: jammy
default-base: ubuntu@22.04
applications:
  ubuntu:
    charm: ubuntu
    series: jammy
    base: ubuntu@22.04
    num_units: 1
    to:
    - "0"
machines:
  "0":
    series: jammy
    base: ubuntu@22.04


$ juju deploy ./bundle.yaml
Located charm "ubuntu" in charm-hub, channel latest/stable
Executing changes:
...
```

### Attempt to deploy some bundles with overlays

```
$ cat bundle.yaml
series: jammy
applications:
  ubuntu:
    charm: ubuntu
    num_units: 1
    to:
    - "0"
machines:
  "0":
---
applications:
  ubuntu:
    series: jammy
machines:
  "0":
    series: jammy

$ juju deploy ./bundle.yaml
WARNING unsupported key 'series' detected without a base in the base bundle. Ignoring:
- document 0; bundle contains top level series. Please use default-base
- document 1; bundle application "ubuntu" contains series. Please use base
- document 1; bundle machine "0" contains series. Please use base
Located charm "ubuntu" in charm-hub, channel latest/stable
Executing changes:
...
```

```
$ cat bundle.yaml
applications:
  ubuntu:
    charm: ubuntu
    num_units: 1
    to:
    - "0"
machines:
  "0":

$ cat overlay1.yaml
applications:
  ubuntu:
    series: jammy
machines:
  "0":
    series: jammy

$ juju deploy ./bundle.yaml --overlay ./overlay1.yaml
WARNING unsupported key 'series' detected without a base in overlay index 0. Ignoring:
- document 0; bundle application "ubuntu" contains series. Please use base
- document 0; bundle machine "0" contains series. Please use base
Executing changes:
...
```

```
$ cat bundle.yaml
applications:
  ubuntu:
    charm: ubuntu
    num_units: 1
    to:
    - "0"
machines:
  "0":

$ cat overlay1.yaml
applications:
  ubuntu:
    series: jammy
machines:
  "0":
    series: jammy

$ cat overlay2.yaml
applications:
  ubuntu:
    series: jammy
machines:
  "0":
    series: jammy

$ juju deploy ./bundle.yaml --overlay ./overlay1.yaml --overlay ./overlay2.yaml
WARNING unsupported key 'series' detected without a base in overlay index 0. Ignoring:
- document 0; bundle application "ubuntu" contains series. Please use base
- document 0; bundle machine "0" contains series. Please use base
WARNING unsupported key 'series' detected without a base in overlay index 1. Ignoring:
- document 0; bundle application "ubuntu" contains series. Please use base
- document 0; bundle machine "0" contains series. Please use base
Executing changes:
...
```

## Links

**Jira card:** [JUJU-5996](https://warthogs.atlassian.net/browse/JUJU-5996)

[JUJU-5996]: https://warthogs.atlassian.net/browse/JUJU-5996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ