### PR TITLE
Change sorting of relations output in juju status

### DIFF
--- a/cmd/juju/status/output_tabular.go
+++ b/cmd/juju/status/output_tabular.go
@@ -468,12 +468,16 @@ func printRemoteApplications(tw *ansiterm.TabWriter, remoteApplications map[stri
 }
 
 func printRelations(tw *ansiterm.TabWriter, relations []relationStatus) {
+	// Sort relations by type, then by provider, then by requirer.
 	sort.Slice(relations, func(i, j int) bool {
 		a, b := relations[i], relations[j]
-		if a.Provider == b.Provider {
-			return a.Requirer < b.Requirer
+		if a.Type != b.Type {
+			return a.Type > b.Type
 		}
-		return a.Provider < b.Provider
+		if a.Provider != b.Provider {
+			return a.Provider < b.Provider
+		}
+		return a.Requirer < b.Requirer
 	})
 
 	w := startSection(tw, false, "Integration provider", "Requirer", "Interface", "Type", "Message")


### PR DESCRIPTION
This PR introduces changes to the way relations are sorted in the output of the 'juju status' command. Now, relations are sorted first by their type, then by their provider, and finally by their requirer. This provides a more organized and predictable output for users.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```
juju boostrap lxd lxd
juju add-model test
juju deploy postgresql -n 3 
juju deploy postgresql-test-app -n 3 
juju integrate postgresql:database postgresql-test-app:first-databse
juju status --relations
# Check the relations output ordering
```

## Links

**Jira card:** [JUJU-6074](https://warthogs.atlassian.net/browse/JUJU-6074)



[JUJU-6074]: https://warthogs.atlassian.net/browse/JUJU-6074?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ