### PR TITLE
Remove link to discorse post in docs

### DIFF
--- a/cmd/juju/cloud/addcredential.go
+++ b/cmd/juju/cloud/addcredential.go
@@ -91,10 +91,6 @@ Use --controller option to upload a credential to a controller.
 
 Use --client option to add a credential to the current client.
 
-Further help:
-Please visit https://discourse.charmhub.io/t/1508 for cloud-specific
-instructions.
-
 `
 
 const usageAddCredentialExamples = `

--- a/cmd/juju/cloud/addcredential_test.go
+++ b/cmd/juju/cloud/addcredential_test.go
@@ -917,7 +917,6 @@ Enter credential name:
 Using auth-type "jsonfile".
 
 Enter path to the .json file containing a service account key for your project
-(detailed instructions available at https://discourse.charmhub.io/t/1508).
 Path: 
 `[1:]
 	stderr := `
@@ -973,7 +972,6 @@ Enter your choice, or type Q|q to quit: Enter credential name:
 Using auth-type "jsonfile".
 
 Enter path to the .json file containing a service account key for your project
-(detailed instructions available at https://discourse.charmhub.io/t/1508).
 Path: 
 Credential "blah" added locally for cloud "remote".
 
@@ -1002,7 +1000,6 @@ Enter credential name:
 Using auth-type "jsonfile".
 
 Enter path to the .json file containing a service account key for your project
-(detailed instructions available at https://discourse.charmhub.io/t/1508).
 Path: 
 `[1:]
 	stderr := `

--- a/provider/gce/credentials.go
+++ b/provider/gce/credentials.go
@@ -51,7 +51,7 @@ func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.C
 		cloud.JSONFileAuthType: {{
 			Name: credAttrFile,
 			CredentialAttr: cloud.CredentialAttr{
-				Description: "path to the .json file containing a service account key for your project\n(detailed instructions available at https://discourse.charmhub.io/t/1508).\nPath",
+				Description: "path to the .json file containing a service account key for your project\nPath",
 				FilePath:    true,
 			},
 		}},


### PR DESCRIPTION
<!-- Why this change is needed and what it does. -->
Remove an outdated/irrelevant link from the add-credential documentation. The information is available on the docs and the link to the discourse post no longer adds anything

## QA steps
```
cd ./cmd/juju/cloud
go test ./...
```

## Links

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2049440
**Jira card:** JUJU-3662

