### PR TITLE
Quote regexp metadata when using secret labels in regexp queries for dupe checks.

### DIFF
--- a/state/secrets.go
+++ b/state/secrets.go
@@ -5,6 +5,7 @@ package state
 
 import (
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -1333,6 +1334,7 @@ func (st *State) uniqueSecretLabelBaseOps(tag names.Tag, label string) (ops []tx
 		errorMsg   string
 	)
 
+	label = regexp.QuoteMeta(label)
 	switch tag := tag.(type) {
 	case names.ApplicationTag:
 		// Ensure no units use this label for both owner and consumer label.


### PR DESCRIPTION
It turns out some charms are using special chars in secret labels, including regexp symbols. As such, mongo queries which check for duplicate labels fail as the query uses a regexp. This PR is a simple fix which quotes the regexp metadata.

## QA steps

```
$ juju exec -u controller/0 -- secret-add --label "\U.*aaa" foo=bar
secret://f15c6efa-61ec-47b5-89a6-8430e566f927/cpbuplo03na228fsolhg
$ juju exec -u controller/0 -- secret-get --label "\U.*aaa"
foo: bar
$ juju exec -u controller/0 -- secret-add --label "\U.*aaa" foo=bar
secret://f15c6efa-61ec-47b5-89a6-8430e566f927/cpbv76003na2708afobg
creating secrets: secret with label "\\U.*aaa" already exists
```

## Links

**Launchpad bug:** https://bugs.launchpad.net/bugs/2058012

**Jira card:** [JUJU-6078](https://warthogs.atlassian.net/browse/JUJU-6078)



[JUJU-6078]: https://warthogs.atlassian.net/browse/JUJU-6078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ