### PR TITLE
Fix uses of BOOTSTRAP_PROVIDER. Fix lxd kvm usage.

### DIFF
--- a/acceptancetests/jujupy/client.py
+++ b/acceptancetests/jujupy/client.py
@@ -1881,7 +1881,7 @@ class ModelClient:
             raise
         log.info('backup file {}'.format(output))
         backup_file_pattern = re.compile(
-            '(juju-backup-[0-9-]+\.(t|tar.)gz)'.encode('ascii'))
+            '(juju-backup-[0-9-]+\\.(t|tar.)gz)'.encode('ascii'))
         match = backup_file_pattern.search(output)
         if match is None:
             raise Exception("The backup file was not found in output: %s" %
@@ -2280,7 +2280,7 @@ class ModelClient:
             child.expect(self.REGION_ENDPOINT_PROMPT)
             child.sendline(values['endpoint'])
             match = child.expect([
-                u"Enter another region\? \([yY]/[nN]\):",
+                u"Enter another region\\? \\([yY]/[nN]\\):",
                 u"Can't validate endpoint"
             ])
             if match == 1:
@@ -2292,7 +2292,7 @@ class ModelClient:
 
     def handle_vsphere(self, child, cloud):
         match = child.expect([u"Enter a name for your .* cloud:",
-                              u'Enter the (vCenter address or URL|API endpoint url for the cloud \[\]):'])
+                              u'Enter the (vCenter address or URL|API endpoint url for the cloud \\[\\]):'])
         if match == 0:
             raise NameNotAccepted('Cloud name not accepted.')
         if match == 1:
@@ -2308,7 +2308,7 @@ class ModelClient:
                 raise InvalidEndpoint()
             child.sendline(name)
             child.expect(
-                u'Enter another (datacenter|region)\? \([yY]/[nN]\):')
+                u'Enter another (datacenter|region)\\? \\([yY]/[nN]\\):')
             if num + 1 < len(cloud['regions']):
                 child.sendline('y')
             else:
@@ -2417,7 +2417,7 @@ def register_user_interactively(client, token, controller_name):
         child.sendline(password)
         child.expect(u'Confirm password:')
         child.sendline(password)
-        child.expect(u'Enter a name for this controller( \[.*\])?:')
+        child.expect(u'Enter a name for this controller( \\[.*\\])?:')
         child.sendline(controller_name)
 
         def login_if_need(session):

--- a/acceptancetests/jujupy/tests/test_status.py
+++ b/acceptancetests/jujupy/tests/test_status.py
@@ -80,7 +80,7 @@ class TestStatusItem(TestCase):
                                      current='allocating', message='foo')
         with self.assertRaisesRegexp(
                 StuckAllocatingError,
-                "\('0', 'Stuck allocating.  Last message: foo'\)"):
+                "\\('0', 'Stuck allocating.  Last message: foo'\\)"):
             raise item.to_exception()
 
     def test_to_exception_allocating_unit(self):

--- a/acceptancetests/repository/trusty/haproxy/cm.py
+++ b/acceptancetests/repository/trusty/haproxy/cm.py
@@ -32,7 +32,7 @@ def get_branch_config(config_file):
             line = line.split('#')[0].strip()
             bzr_match = re.match(r'(\S+)\s+'
                                  'lp:([^;]+)'
-                                 '(?:;revno=(\d+))?', line)
+                                 '(?:;revno=(\\d+))?', line)
             if bzr_match:
                 name, branch, revno = bzr_match.group(1, 2, 3)
                 if revno is None:
@@ -42,7 +42,7 @@ def get_branch_config(config_file):
                 branches[name] = (branch, revspec)
                 continue
             dir_match = re.match(r'(\S+)\s+'
-                                 '\(directory\)', line)
+                                 '\\(directory\\)', line)
             if dir_match:
                 name = dir_match.group(1)
                 branches[name] = None

--- a/acceptancetests/tests/test_jujucharm.py
+++ b/acceptancetests/tests/test_jujucharm.py
@@ -118,7 +118,7 @@ class TestCharm(TestCase):
         self.assertIsNone(Charm.NAME_REGEX.match(charm.metadata['name']))
         self.assertRaisesRegexp(
             JujuAssertionError,
-            'Invalid Juju Charm Name, "BAD_NAME" does not match ".*"\.',
+            'Invalid Juju Charm Name, "BAD_NAME" does not match ".*"\\.',
             Charm, 'BAD_NAME', 'A charm with a checked bad name')
 
     def test_ensure_valid_name_anchoring(self):

--- a/scripts/find-bad-doc-comments.py
+++ b/scripts/find-bad-doc-comments.py
@@ -31,8 +31,8 @@ def find_go_files(root):
             yield path.join(directory, filename)
 
 DOC_COMMENT_PATT = '\n\n//.+\n(//.+\n)*func.+\n'
-FIRST_WORD_PATT = '// *(\w+)'
-FUNC_NAME_PATT = 'func(?: \([^)]+\))? (\S+)\('
+FIRST_WORD_PATT = '// *(\\w+)'
+FUNC_NAME_PATT = 'func(?: \\([^)]+\\))? (\\S+)\\('
 
 def extract_doc_comments(text):
     for match in re.finditer(DOC_COMMENT_PATT, text, re.MULTILINE):

--- a/scripts/leadershipclaimer/count-leadership.py
+++ b/scripts/leadershipclaimer/count-leadership.py
@@ -13,9 +13,9 @@ def main(args):
     p.add_argument("--tick", type=float, default=1.0,
             help="seconds between printing status ticks")
     opts = p.parse_args(args)
-    actionsRE = re.compile("\s*(?P<time>\d+\.\d\d\d)s\s+(?P<action>claimed|extended|lost|connected).*in (?P<duration>[0-9m.]+s)")
+    actionsRE = re.compile("\\s*(?P<time>\\d+\\.\\d\\d\\d)s\\s+(?P<action>claimed|extended|lost|connected).*in (?P<duration>[0-9m.]+s)")
     # We don't have minutes if we have 'ms', so match 'ms' first, we might have 'm' if we have 's', so put it before s.
-    durationRE = re.compile("((?P<milliseconds>\d+)ms)?((?P<minutes>\d+)m)?((?P<seconds>\d+(\.\d+)?)s)?")
+    durationRE = re.compile("((?P<milliseconds>\\d+)ms)?((?P<minutes>\\d+)m)?((?P<seconds>\\d+(\\.\\d+)?)s)?")
     totalClaims = 0
     extendedSum = 0
     extendedCount = 0

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -69,10 +69,10 @@ bootstrap() {
 	"azure")
 		cloud="azure"
 		;;
-	"localhost" | "lxd")
-		cloud="localhost"
+	"lxd")
+		cloud="${BOOTSTRAP_CLOUD:-localhost}"
 		;;
-	"lxd-remote" | "vsphere" | "openstack" | "k8s" | "maas")
+	"vsphere" | "openstack" | "k8s" | "maas")
 		cloud="${BOOTSTRAP_CLOUD}"
 		;;
 	"manual")

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -6,7 +6,7 @@ export SHELLCHECK_OPTS="-e SC2230 -e SC2039 -e SC2028 -e SC2002 -e SC2005 -e SC2
 export BOOTSTRAP_REUSE_LOCAL="${BOOTSTRAP_REUSE_LOCAL:-}"
 export BOOTSTRAP_REUSE="${BOOTSTRAP_REUSE:-false}"
 export BOOTSTRAP_PROVIDER="${BOOTSTRAP_PROVIDER:-lxd}"
-export BOOTSTRAP_CLOUD="${BOOTSTRAP_CLOUD:-lxd}"
+export BOOTSTRAP_CLOUD="${BOOTSTRAP_CLOUD:-localhost}"
 export BOOTSTRAP_SERIES="${BOOTSTRAP_SERIES:-}"
 export BOOTSTRAP_ARCH="${BOOTSTRAP_ARCH:-}"
 export BUILD_ARCH="${BUILD_ARCH:-}"
@@ -193,13 +193,6 @@ while getopts "hH?vAs:a:x:rl:p:c:R:S:" opt; do
 
 		CLOUD=$(juju show-controller "${OPTARG}" --format=json 2>/dev/null | jq -r ".[\"${OPTARG}\"] | .details | .cloud")
 		PROVIDER=$(juju clouds --client --all --format=json 2>/dev/null | jq -r ".[\"${CLOUD}\"] | .type")
-		if [[ -z ${PROVIDER} ]]; then
-			PROVIDER="${CLOUD}"
-		fi
-		# We want "ec2" to redirect to "aws". This is needed e.g. for the ck tests
-		if [[ ${PROVIDER} == "ec2" ]]; then
-			PROVIDER="aws"
-		fi
 		export BOOTSTRAP_PROVIDER="${PROVIDER}"
 		export BOOTSTRAP_CLOUD="${CLOUD}"
 		;;

--- a/tests/suites/backup/backup.sh
+++ b/tests/suites/backup/backup.sh
@@ -59,7 +59,7 @@ run_basic_backup_restore() {
 	juju status --format json | jq '.machines | length' | check 1
 
 	# Only do this check if provider is LXD (too hard to do for all providers)
-	if [ "${BOOTSTRAP_PROVIDER}" == "lxd" ] || [ "${BOOTSTRAP_PROVIDER}" == "localhost" ]; then
+	if [ "${BOOTSTRAP_PROVIDER}" == "lxd" ]; then
 		echo "Ensure that both instances are running (restore shouldn't terminate machines)"
 		lxc list --format json | jq --arg name "${id0}" -r '.[] | select(.name==$name) | .state.status' | check Running
 		lxc list --format json | jq --arg name "${id1}" -r '.[] | select(.name==$name) | .state.status' | check Running

--- a/tests/suites/cli/model_defaults.sh
+++ b/tests/suites/cli/model_defaults.sh
@@ -62,7 +62,7 @@ test_model_defaults() {
 		run "run_model_defaults_boolean"
 
 		case "${BOOTSTRAP_PROVIDER-}" in
-		"aws")
+		"ec2")
 			run "run_model_defaults_region_aws"
 			;;
 		*)

--- a/tests/suites/constraints/constraints.sh
+++ b/tests/suites/constraints/constraints.sh
@@ -10,7 +10,7 @@ test_constraints_common() {
 		cd .. || exit
 
 		case "${BOOTSTRAP_PROVIDER:-}" in
-		"lxd" | "lxd-remote" | "localhost")
+		"lxd")
 			run "run_constraints_lxd"
 			;;
 		"openstack")

--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -380,7 +380,7 @@ test_deploy_bundles() {
 
 		# LXD specific profile tests.
 		case "${BOOTSTRAP_PROVIDER:-}" in
-		"lxd" | "localhost")
+		"lxd")
 			run "run_deploy_lxd_profile_bundle_openstack"
 			echo "==> TEST SKIPPED: deploy_lxd_profile_bundle - tests for non LXD only"
 			;;
@@ -392,7 +392,7 @@ test_deploy_bundles() {
 
 		# AWS specific image id tests.
 		case "${BOOTSTRAP_PROVIDER:-}" in
-		"ec2" | "aws")
+		"ec2")
 			check_dependencies aws
 			add_clean_func "run_cleanup_ami"
 			export ami_id

--- a/tests/suites/deploy/deploy_charms.sh
+++ b/tests/suites/deploy/deploy_charms.sh
@@ -24,8 +24,8 @@ run_deploy_charm_placement_directive() {
 	expected_base="ubuntu@20.04"
 	# Setup machines for placement based on provider used for test.
 	# Container in container doesn't work consistently enough,
-	# for test. Use kvm via lxc instead.
-	if [[ ${BOOTSTRAP_PROVIDER} == "lxd" ]] || [[ ${BOOTSTRAP_PROVIDER} == "localhost" ]]; then
+	# for test. Use kvm via lxc instead if it is available.
+	if [[ ${BOOTSTRAP_PROVIDER} == "lxd" ]] && stat /dev/kvm; then
 		juju add-machine --base "${expected_base}" --constraints="virt-type=virtual-machine"
 	else
 		juju add-machine --base "${expected_base}"
@@ -358,7 +358,7 @@ test_deploy_charms() {
 		run "run_deploy_charm_unsupported_series"
 
 		case "${BOOTSTRAP_PROVIDER:-}" in
-		"lxd" | "localhost")
+		"lxd")
 			run "run_deploy_lxd_to_machine"
 			run "run_deploy_lxd_profile_charm"
 			run "run_deploy_local_predeployed_charm"

--- a/tests/suites/deploy/os.sh
+++ b/tests/suites/deploy/os.sh
@@ -10,7 +10,7 @@ test_deploy_os() {
 		cd .. || exit
 
 		case "${BOOTSTRAP_PROVIDER:-}" in
-		"ec2" | "aws")
+		"ec2")
 			#
 			# A handy place to find the current AMIs for centos
 			# https://wiki.centos.org/Cloud/AWS

--- a/tests/suites/manual/deploy_manual.sh
+++ b/tests/suites/manual/deploy_manual.sh
@@ -10,10 +10,10 @@ test_deploy_manual() {
 		cd .. || exit
 
 		case "${BOOTSTRAP_PROVIDER:-}" in
-		"lxd" | "lxd-remote" | "localhost")
+		"lxd")
 			run "run_deploy_manual_lxd"
 			;;
-		"aws" | "ec2")
+		"aws")
 			run "run_deploy_manual_aws"
 			;;
 		*)

--- a/tests/suites/manual/spaces.sh
+++ b/tests/suites/manual/spaces.sh
@@ -10,7 +10,7 @@ test_spaces_manual() {
 		cd .. || exit
 
 		case "${BOOTSTRAP_PROVIDER:-}" in
-		"aws")
+		"ec2")
 			run "run_spaces_manual_aws"
 			;;
 		*)


### PR DESCRIPTION
- BOOTSTRAP_PROVIDER is never aws.
- Stop supporting localhost and lxd-remote values of BOOTSTRAP_PROVIDER (we never use them in CI).
- run_model_defaults_region_aws now will run for ec2
- run_spaces_manual_aws now will run for ec2
- AWS does not support kvm, stop using it if the system does not support it.

## QA steps

Run tests.

## Documentation changes

N/A

## Links

**Jira card:** JUJU-

