### PR TITLE
Fix: avoid setting machine provider addresses at bootstrap

### DIFF
--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -451,17 +451,11 @@ func initBootstrapMachine(st *state.State, args InitializeStateParams) (bootstra
 		return nil, errors.Trace(err)
 	}
 
-	spaceAddrs, err := args.BootstrapMachineAddresses.ToSpaceAddresses(st)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
 	base, err := corebase.GetBaseFromSeries(hostSeries)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	m, err := st.AddOneMachine(state.MachineTemplate{
-		Addresses:               spaceAddrs,
 		Base:                    state.Base{OS: base.OS, Channel: base.Channel.String()},
 		Nonce:                   agent.BootstrapNonce,
 		Constraints:             args.BootstrapMachineConstraints,

--- a/agent/agentbootstrap/bootstrap_test.go
+++ b/agent/agentbootstrap/bootstrap_test.go
@@ -198,8 +198,8 @@ func (s *bootstrapSuite) TestInitializeState(c *gc.C) {
 	// Check that the model has been set up.
 	model, err := st.Model()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(model.UUID(), gc.Equals, modelCfg.UUID())
-	c.Assert(model.EnvironVersion(), gc.Equals, 666)
+	c.Check(model.UUID(), gc.Equals, modelCfg.UUID())
+	c.Check(model.EnvironVersion(), gc.Equals, 666)
 
 	// Check that initial admin user has been set up correctly.
 	modelTag := model.Tag().(names.ModelTag)
@@ -207,12 +207,12 @@ func (s *bootstrapSuite) TestInitializeState(c *gc.C) {
 	s.assertCanLogInAsAdmin(c, modelTag, controllerTag, testing.DefaultMongoPassword)
 	user, err := st.User(model.Owner())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(user.PasswordValid(testing.DefaultMongoPassword), jc.IsTrue)
+	c.Check(user.PasswordValid(testing.DefaultMongoPassword), jc.IsTrue)
 
 	// Check controller config
 	controllerCfg, err = st.ControllerConfig()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(controllerCfg, jc.DeepEquals, controller.Config{
+	c.Check(controllerCfg, jc.DeepEquals, controller.Config{
 		"controller-uuid":           testing.ControllerTag.Id(),
 		"ca-cert":                   testing.CACert,
 		"state-port":                1234,
@@ -243,11 +243,11 @@ func (s *bootstrapSuite) TestInitializeState(c *gc.C) {
 	expectedAttrs := expectedCfg.AllAttrs()
 	expectedAttrs["apt-mirror"] = "http://mirror"
 	expectedAttrs["no-proxy"] = "value"
-	c.Assert(newModelCfg.AllAttrs(), jc.DeepEquals, expectedAttrs)
+	c.Check(newModelCfg.AllAttrs(), jc.DeepEquals, expectedAttrs)
 
 	gotModelConstraints, err := st.ModelConstraints()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(gotModelConstraints, gc.DeepEquals, expectModelConstraints)
+	c.Check(gotModelConstraints, gc.DeepEquals, expectModelConstraints)
 
 	// Check that the hosted model has been added, model constraints
 	// set, and its config contains the same authorized-keys as the
@@ -257,47 +257,50 @@ func (s *bootstrapSuite) TestInitializeState(c *gc.C) {
 	defer initialModelSt.Release()
 	gotModelConstraints, err = initialModelSt.ModelConstraints()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(gotModelConstraints, gc.DeepEquals, expectModelConstraints)
+	c.Check(gotModelConstraints, gc.DeepEquals, expectModelConstraints)
+
 	initialModel, err := initialModelSt.Model()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(initialModel.Name(), gc.Equals, "hosted")
-	c.Assert(initialModel.CloudRegion(), gc.Equals, "dummy-region")
-	c.Assert(initialModel.EnvironVersion(), gc.Equals, 123)
+	c.Check(initialModel.Name(), gc.Equals, "hosted")
+	c.Check(initialModel.CloudRegion(), gc.Equals, "dummy-region")
+	c.Check(initialModel.EnvironVersion(), gc.Equals, 123)
+
 	hostedCfg, err := initialModel.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	_, hasUnexpected := hostedCfg.AllAttrs()["not-for-hosted"]
-	c.Assert(hasUnexpected, jc.IsFalse)
-	c.Assert(hostedCfg.AuthorizedKeys(), gc.Equals, newModelCfg.AuthorizedKeys())
+	c.Check(hasUnexpected, jc.IsFalse)
+	c.Check(hostedCfg.AuthorizedKeys(), gc.Equals, newModelCfg.AuthorizedKeys())
 
 	// Check that the bootstrap machine looks correct.
 	m, err := st.Machine("0")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(m.Id(), gc.Equals, "0")
-	c.Assert(m.Jobs(), gc.DeepEquals, []state.MachineJob{state.JobManageModel})
+	c.Check(m.Id(), gc.Equals, "0")
+	c.Check(m.Jobs(), gc.DeepEquals, []state.MachineJob{state.JobManageModel})
+
 	base, err := corebase.ParseBase(m.Base().OS, m.Base().Channel)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(m.Base().String(), gc.Equals, base.String())
-	c.Assert(m.CheckProvisioned(agent.BootstrapNonce), jc.IsTrue)
-	c.Assert(m.Addresses(), jc.DeepEquals, filteredAddrs)
+	c.Check(m.Base().String(), gc.Equals, base.String())
+	c.Check(m.CheckProvisioned(agent.BootstrapNonce), jc.IsTrue)
+
 	gotBootstrapConstraints, err := m.Constraints()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(gotBootstrapConstraints, gc.DeepEquals, expectBootstrapConstraints)
-	c.Assert(err, jc.ErrorIsNil)
+	c.Check(gotBootstrapConstraints, gc.DeepEquals, expectBootstrapConstraints)
+
 	gotHW, err := m.HardwareCharacteristics()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(*gotHW, gc.DeepEquals, expectHW)
+	c.Check(*gotHW, gc.DeepEquals, expectHW)
 
 	// Check that the API host ports are initialised correctly.
 	apiHostPorts, err := st.APIHostPortsForClients()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(apiHostPorts, jc.DeepEquals, []corenetwork.SpaceHostPorts{
+	c.Check(apiHostPorts, jc.DeepEquals, []corenetwork.SpaceHostPorts{
 		corenetwork.SpaceAddressesWithPort(filteredAddrs, 1234),
 	})
 
 	// Check that the state serving info is initialised correctly.
 	stateServingInfo, err := st.StateServingInfo()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(stateServingInfo, jc.DeepEquals, controller.StateServingInfo{
+	c.Check(stateServingInfo, jc.DeepEquals, controller.StateServingInfo{
 		APIPort:        1234,
 		StatePort:      s.mgoInst.Port(),
 		Cert:           testing.ServerCert,
@@ -313,17 +316,18 @@ func (s *bootstrapSuite) TestInitializeState(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	expectedStorageCfg, err := storage.NewConfig("spool", "loop", map[string]interface{}{"foo": "bar"})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(storageCfg, jc.DeepEquals, expectedStorageCfg)
+	c.Check(storageCfg, jc.DeepEquals, expectedStorageCfg)
 
 	// Check that the machine agent's config has been written
 	// and that we can use it to connect to mongo.
 	machine0 := names.NewMachineTag("0")
 	newCfg, err := agent.ReadConfig(agent.ConfigPath(dataDir, machine0))
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(newCfg.Tag(), gc.Equals, machine0)
+	c.Check(newCfg.Tag(), gc.Equals, machine0)
+
 	info, ok := cfg.MongoInfo()
 	c.Assert(ok, jc.IsTrue)
-	c.Assert(info.Password, gc.Not(gc.Equals), testing.DefaultMongoPassword)
+	c.Check(info.Password, gc.Not(gc.Equals), testing.DefaultMongoPassword)
 
 	session, err := mongo.DialWithInfo(*info, mongotest.DialOpts())
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
At bootstrap we set provider addresses for the bootstrap machine. This turns out to cause an issue when:
- The provider is `manual`.
- The deployment uses spaces.
- Use of the `juju-mgmt-space` or `juju-ctrl-space` controller configuration values are used.

The reason for this is that provider addresses supersede machine-discovered addresses, and the manual provider actually has no _provider_, so this undecorated address never gets updated.

Some time ago we removed the logic that sets provider addresses in the machines collection upon provisioning. This was because it was not necessary and we could rely on the normal address discovery work-flow (including space decoration) to populate such values.

It is not necessary to set machine addresses at bootstrap. We already use the bootstrap addresses to configure Mongo, API host-ports and agent config. We can let address discovery work in the instance-poller/on-machine workflow.

Here we remove the address setting at bootstrap.

## QA steps

The check is for regression. I bootstrapped to the following substrates without issue:
- LXD
- EC2
- MAAS

## Links

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2067617

**Jira card:** [JUJU-6106](https://warthogs.atlassian.net/browse/JUJU-6106)

