### PR TITLE
3.5 into 3.6

### DIFF
--- a/cmd/juju/application/bundle/bundle.go
+++ b/cmd/juju/application/bundle/bundle.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/juju/charm/v12"
+	"github.com/juju/cmd/v3"
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 
@@ -250,7 +251,7 @@ func applicationConfigValue(key string, valueMap interface{}) (interface{}, erro
 // combined bundle data. Returns a slice of errors encountered while
 // processing the bundle. They are for informational purposes and do
 // not require failing the bundle deployment.
-func ComposeAndVerifyBundle(base BundleDataSource, pathToOverlays []string) (*charm.BundleData, []error, error) {
+func ComposeAndVerifyBundle(ctx *cmd.Context, base BundleDataSource, pathToOverlays []string) (*charm.BundleData, []error, error) {
 
 	verifyConstraints := func(s string) error {
 		_, err := constraints.Parse(s)
@@ -285,6 +286,8 @@ func ComposeAndVerifyBundle(base BundleDataSource, pathToOverlays []string) (*ch
 	if err = verifyBundle(bundleData, base.BasePath(), verifyConstraints); err != nil {
 		return nil, nil, errors.Trace(err)
 	}
+
+	deprecationWarningForSeries(ctx, bundleData)
 
 	return bundleData, unMarshallErrors, nil
 }
@@ -353,6 +356,29 @@ func verifyBundle(data *charm.BundleData, bundleDir string, verifyConstraints fu
 		return errors.New("the provided bundle has the following errors:\n" + strings.Join(errs, "\n"))
 	}
 	return errors.Trace(verifyError)
+}
+
+func deprecationWarningForSeries(ctx *cmd.Context, data *charm.BundleData) {
+	includeSeries := false
+	if data.Series != "" {
+		includeSeries = true
+	}
+	for _, m := range data.Machines {
+		if m != nil && m.Series != "" {
+			includeSeries = true
+			break
+		}
+	}
+	for _, app := range data.Applications {
+		if app != nil && app.Series != "" {
+			includeSeries = true
+			break
+		}
+	}
+
+	if includeSeries {
+		ctx.Warningf("series in being deprecated in favour of bases. For more information about the transition to bases see https://discourse.charmhub.io/t/transition-from-series-to-base-in-juju-4-0/14127")
+	}
 }
 
 func verifyMixedSeriesBasesMatch(data *charm.BundleData) error {

--- a/cmd/juju/application/bundle/bundle_test.go
+++ b/cmd/juju/application/bundle/bundle_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/juju/charm/v12"
+	"github.com/juju/cmd/v3"
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"go.uber.org/mock/gomock"
@@ -213,8 +214,10 @@ func (s *composeAndVerifyRepSuite) TestComposeAndVerifyBundleEmpty(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	s.expectEmptyParts()
 	s.expectBasePath()
+	ctx, err := cmd.DefaultContext()
+	c.Assert(err, jc.ErrorIsNil)
 
-	obtained, _, err := ComposeAndVerifyBundle(s.bundleDataSource, nil)
+	obtained, _, err := ComposeAndVerifyBundle(ctx, s.bundleDataSource, nil)
 	c.Assert(err, gc.ErrorMatches, ".*bundle is empty not valid")
 	c.Assert(obtained, gc.IsNil)
 }
@@ -225,8 +228,10 @@ func (s *composeAndVerifyRepSuite) TestComposeAndVerifyBundleUnsupportedConstrai
 	c.Assert(err, jc.ErrorIsNil)
 	s.expectParts(&charm.BundleDataPart{Data: bundleData})
 	s.expectBasePath()
+	ctx, err := cmd.DefaultContext()
+	c.Assert(err, jc.ErrorIsNil)
 
-	obtained, _, err := ComposeAndVerifyBundle(s.bundleDataSource, nil)
+	obtained, _, err := ComposeAndVerifyBundle(ctx, s.bundleDataSource, nil)
 	c.Assert(err, gc.ErrorMatches, "*'image-id' constraint in a base bundle not supported")
 	c.Assert(obtained, gc.IsNil)
 }
@@ -237,8 +242,10 @@ func (s *composeAndVerifyRepSuite) TestComposeAndVerifyBundleNoOverlay(c *gc.C) 
 	c.Assert(err, jc.ErrorIsNil)
 	s.expectParts(&charm.BundleDataPart{Data: bundleData})
 	s.expectBasePath()
+	ctx, err := cmd.DefaultContext()
+	c.Assert(err, jc.ErrorIsNil)
 
-	obtained, _, err := ComposeAndVerifyBundle(s.bundleDataSource, nil)
+	obtained, _, err := ComposeAndVerifyBundle(ctx, s.bundleDataSource, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(obtained, gc.DeepEquals, bundleData)
 }
@@ -250,13 +257,15 @@ func (s *composeAndVerifyRepSuite) TestComposeAndVerifyBundleOverlay(c *gc.C) {
 	s.expectParts(&charm.BundleDataPart{Data: bundleData})
 	s.expectBasePath()
 	s.setupOverlayFile(c)
+	ctx, err := cmd.DefaultContext()
+	c.Assert(err, jc.ErrorIsNil)
 
 	expected := *bundleData
 	expected.Applications["wordpress"].Options = map[string]interface{}{
 		"blog-title": "magic bundle config",
 	}
 
-	obtained, _, err := ComposeAndVerifyBundle(s.bundleDataSource, []string{s.overlayFile})
+	obtained, _, err := ComposeAndVerifyBundle(ctx, s.bundleDataSource, []string{s.overlayFile})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(obtained, gc.DeepEquals, &expected)
 }
@@ -268,13 +277,15 @@ func (s *composeAndVerifyRepSuite) TestComposeAndVerifyBundleOverlayUnsupportedC
 	s.expectParts(&charm.BundleDataPart{Data: bundleData})
 	s.expectBasePath()
 	s.setupOverlayFile(c)
+	ctx, err := cmd.DefaultContext()
+	c.Assert(err, jc.ErrorIsNil)
 
 	expected := *bundleData
 	expected.Applications["wordpress"].Options = map[string]interface{}{
 		"blog-title": "magic bundle config",
 	}
 
-	obtained, _, err := ComposeAndVerifyBundle(s.bundleDataSource, []string{s.overlayFile})
+	obtained, _, err := ComposeAndVerifyBundle(ctx, s.bundleDataSource, []string{s.overlayFile})
 	c.Assert(err, gc.ErrorMatches, "*'image-id' constraint in a base bundle not supported")
 	c.Assert(obtained, gc.IsNil)
 }
@@ -290,13 +301,15 @@ func (s *composeAndVerifyRepSuite) TestComposeAndVerifyBundleOverlayUnmarshallEr
 	})
 	s.expectBasePath()
 	s.setupOverlayFile(c)
+	ctx, err := cmd.DefaultContext()
+	c.Assert(err, jc.ErrorIsNil)
 
 	expected := *bundleData
 	expected.Applications["wordpress"].Options = map[string]interface{}{
 		"blog-title": "magic bundle config",
 	}
 
-	obtained, unmarshallErrors, err := ComposeAndVerifyBundle(s.bundleDataSource, []string{s.overlayFile})
+	obtained, unmarshallErrors, err := ComposeAndVerifyBundle(ctx, s.bundleDataSource, []string{s.overlayFile})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(obtained, gc.DeepEquals, &expected)
 	c.Assert(unmarshallErrors, gc.HasLen, 1)
@@ -309,8 +322,10 @@ func (s *composeAndVerifyRepSuite) TestComposeAndVerifyBundleMixingBaseAndSeries
 	c.Assert(err, jc.ErrorIsNil)
 	s.expectParts(&charm.BundleDataPart{Data: bundleData})
 	s.expectBasePath()
+	ctx, err := cmd.DefaultContext()
+	c.Assert(err, jc.ErrorIsNil)
 
-	obtained, _, err := ComposeAndVerifyBundle(s.bundleDataSource, nil)
+	obtained, _, err := ComposeAndVerifyBundle(ctx, s.bundleDataSource, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(obtained, gc.DeepEquals, bundleData)
 }
@@ -321,8 +336,10 @@ func (s *composeAndVerifyRepSuite) TestComposeAndVerifyBundleMixingBaseAndSeries
 	c.Assert(err, jc.ErrorIsNil)
 	s.expectParts(&charm.BundleDataPart{Data: bundleData})
 	s.expectBasePath()
+	ctx, err := cmd.DefaultContext()
+	c.Assert(err, jc.ErrorIsNil)
 
-	obtained, _, err := ComposeAndVerifyBundle(s.bundleDataSource, []string{s.overlayFile})
+	obtained, _, err := ComposeAndVerifyBundle(ctx, s.bundleDataSource, []string{s.overlayFile})
 	c.Assert(err, gc.ErrorMatches, `(?s)the provided bundle has the following errors:.*application "wordpress" series "jammy" and base "ubuntu@20.04" must match if both supplied.*invalid constraints.*`)
 	c.Assert(obtained, gc.IsNil)
 }

--- a/cmd/juju/application/deployer/bundle.go
+++ b/cmd/juju/application/deployer/bundle.go
@@ -84,7 +84,7 @@ func (d *deployBundle) deploy(
 	d.accountUser = accountDetails.User
 
 	// Compose bundle to be deployed and check its validity.
-	bundleData, unmarshalErrors, err := bundle.ComposeAndVerifyBundle(d.bundleDataSource, d.bundleOverlayFile)
+	bundleData, unmarshalErrors, err := bundle.ComposeAndVerifyBundle(ctx, d.bundleDataSource, d.bundleOverlayFile)
 	if err != nil {
 		return errors.Annotatef(err, "cannot deploy bundle")
 	}

--- a/cmd/juju/application/diffbundle.go
+++ b/cmd/juju/application/diffbundle.go
@@ -230,7 +230,7 @@ func (c *diffBundleCommand) Run(ctx *cmd.Context) error {
 		return errors.Trace(err)
 	}
 
-	bundle, _, err := appbundle.ComposeAndVerifyBundle(baseSrc, c.bundleOverlays)
+	bundle, _, err := appbundle.ComposeAndVerifyBundle(ctx, baseSrc, c.bundleOverlays)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/cmd/juju/cloud/addcredential.go
+++ b/cmd/juju/cloud/addcredential.go
@@ -91,7 +91,6 @@ Use --controller option to upload a credential to a controller.
 
 Use --client option to add a credential to the current client.
 
-
 `
 
 const usageAddCredentialExamples = `

--- a/cmd/juju/cloud/addcredential_test.go
+++ b/cmd/juju/cloud/addcredential_test.go
@@ -917,7 +917,6 @@ Enter credential name:
 Using auth-type "jsonfile".
 
 Enter path to the .json file containing a service account key for your project
-(detailed instructions available at https://discourse.charmhub.io/t/1508).
 Path: 
 `[1:]
 	stderr := `
@@ -973,7 +972,6 @@ Enter your choice, or type Q|q to quit: Enter credential name:
 Using auth-type "jsonfile".
 
 Enter path to the .json file containing a service account key for your project
-(detailed instructions available at https://discourse.charmhub.io/t/1508).
 Path: 
 Credential "blah" added locally for cloud "remote".
 
@@ -1002,7 +1000,6 @@ Enter credential name:
 Using auth-type "jsonfile".
 
 Enter path to the .json file containing a service account key for your project
-(detailed instructions available at https://discourse.charmhub.io/t/1508).
 Path: 
 `[1:]
 	stderr := `

--- a/core/base/base.go
+++ b/core/base/base.go
@@ -124,6 +124,25 @@ func (b Base) IsCompatible(other Base) bool {
 	return b.OS == other.OS && b.Channel.Track == other.Channel.Track
 }
 
+// ubuntuLTSes lists the Ubuntu LTS releases that
+// this version of Juju knows about
+var ubuntuLTSes = []Base{
+	MakeDefaultBase(UbuntuOS, "20.04"),
+	MakeDefaultBase(UbuntuOS, "22.04"),
+	MakeDefaultBase(UbuntuOS, "24.04"),
+}
+
+// IsUbuntuLTS returns true if this base is a recognised
+// Ubuntu LTS.
+func (b Base) IsUbuntuLTS() bool {
+	for _, ubuntuLTS := range ubuntuLTSes {
+		if b.IsCompatible(ubuntuLTS) {
+			return true
+		}
+	}
+	return false
+}
+
 // DisplayString returns the base string ignoring risk.
 func (b Base) DisplayString() string {
 	if b.Channel.Track == "" || b.OS == "" {

--- a/core/base/base_test.go
+++ b/core/base/base_test.go
@@ -100,3 +100,41 @@ func (s *BaseSuite) TestParseManifestBases(c *gc.C) {
 	}
 	c.Assert(obtained, jc.DeepEquals, expected)
 }
+
+var ubuntuLTS = []Base{
+	MustParseBaseFromString("ubuntu@20.04"),
+	MustParseBaseFromString("ubuntu@22.04"),
+	MustParseBaseFromString("ubuntu@24.04"),
+	MustParseBaseFromString("ubuntu@24.04/stable"),
+	MustParseBaseFromString("ubuntu@24.04/edge"),
+}
+
+func (s *BaseSuite) TestIsUbuntuLTSForLTSes(c *gc.C) {
+	for i, lts := range ubuntuLTS {
+		c.Logf("Checking index %d base %v", i, lts)
+		c.Check(lts.IsUbuntuLTS(), jc.IsTrue)
+	}
+}
+
+var nonUbuntuLTS = []Base{
+	MustParseBaseFromString("ubuntu@17.04"),
+	MustParseBaseFromString("ubuntu@19.04"),
+	MustParseBaseFromString("ubuntu@21.04"),
+
+	MustParseBaseFromString("ubuntu@18.10"),
+	MustParseBaseFromString("ubuntu@20.10"),
+	MustParseBaseFromString("ubuntu@22.10"),
+
+	MustParseBaseFromString("ubuntu@22.04-blah"),
+	MustParseBaseFromString("ubuntu@22.04.1234"),
+
+	MustParseBaseFromString("centos@7"),
+	MustParseBaseFromString("centos@20.04"),
+}
+
+func (s *BaseSuite) TestIsUbuntuLTSForNonLTSes(c *gc.C) {
+	for i, lts := range nonUbuntuLTS {
+		c.Logf("Checking index %d base %v", i, lts)
+		c.Check(lts.IsUbuntuLTS(), jc.IsFalse)
+	}
+}

--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -1085,9 +1085,6 @@ func newOSProfile(
 	}
 
 	instOS := ostype.OSTypeForName(instanceConfig.Base.OS)
-	if err != nil {
-		return nil, ostype.Unknown, errors.Trace(err)
-	}
 	switch instOS {
 	case ostype.Ubuntu, ostype.CentOS:
 		// SSH keys are handled by custom data, but must also be

--- a/provider/azure/instancetype.go
+++ b/provider/azure/instancetype.go
@@ -536,7 +536,7 @@ func (env *azureEnviron) findInstanceSpec(
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	image, err := imageutils.SeriesImage(ctx, constraint.Base, imageStream, constraint.Region, client)
+	image, err := imageutils.BaseImage(ctx, constraint.Base, imageStream, constraint.Region, client)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/provider/azure/internal/imageutils/images_test.go
+++ b/provider/azure/internal/imageutils/images_test.go
@@ -45,11 +45,11 @@ func (s *imageutilsSuite) SetUpTest(c *gc.C) {
 	s.callCtx = context.NewEmptyCloudCallContext()
 }
 
-func (s *imageutilsSuite) TestSeriesImage(c *gc.C) {
+func (s *imageutilsSuite) TestBaseImageOldStyle(c *gc.C) {
 	s.mockSender.AppendResponse(azuretesting.NewResponseWithContent(
 		`[{"name": "20_04"}, {"name": "20_04-LTS"}, {"name": "19_04"}]`,
 	))
-	image, err := imageutils.SeriesImage(s.callCtx, corebase.MakeDefaultBase("ubuntu", "20.04"), "released", "westus", s.client)
+	image, err := imageutils.BaseImage(s.callCtx, corebase.MakeDefaultBase("ubuntu", "20.04"), "released", "westus", s.client)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(image, gc.NotNil)
 	c.Assert(image, jc.DeepEquals, &instances.Image{
@@ -59,11 +59,11 @@ func (s *imageutilsSuite) TestSeriesImage(c *gc.C) {
 	})
 }
 
-func (s *imageutilsSuite) TestSeriesImageInvalidSKU(c *gc.C) {
+func (s *imageutilsSuite) TestBaseImageOldStyleInvalidSKU(c *gc.C) {
 	s.mockSender.AppendResponse(azuretesting.NewResponseWithContent(
 		`[{"name": "22_04_invalid"}, {"name": "22_04_5-LTS"}]`,
 	))
-	image, err := imageutils.SeriesImage(s.callCtx, corebase.MakeDefaultBase("ubuntu", "22.04"), "released", "westus", s.client)
+	image, err := imageutils.BaseImage(s.callCtx, corebase.MakeDefaultBase("ubuntu", "22.04"), "released", "westus", s.client)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(image, gc.NotNil)
 	c.Assert(image, jc.DeepEquals, &instances.Image{
@@ -73,14 +73,42 @@ func (s *imageutilsSuite) TestSeriesImageInvalidSKU(c *gc.C) {
 	})
 }
 
-func (s *imageutilsSuite) TestSeriesImageCentOS(c *gc.C) {
+func (s *imageutilsSuite) TestBaseImage(c *gc.C) {
+	s.mockSender.AppendResponse(azuretesting.NewResponseWithContent(
+		`[{"name": "server"}, {"name": "server-gen1"}, {"name": "server-arm64"}]`,
+	))
+	image, err := imageutils.BaseImage(s.callCtx, corebase.MakeDefaultBase("ubuntu", "24.04"), "released", "westus", s.client)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(image, gc.NotNil)
+	c.Assert(image, jc.DeepEquals, &instances.Image{
+		Id:       "Canonical:ubuntu-24_04-lts:server-gen1:latest",
+		Arch:     arch.AMD64,
+		VirtType: "Hyper-V",
+	})
+}
+
+func (s *imageutilsSuite) TestBaseImageNonLTS(c *gc.C) {
+	s.mockSender.AppendResponse(azuretesting.NewResponseWithContent(
+		`[{"name": "server"}, {"name": "server-gen1"}, {"name": "server-arm64"}]`,
+	))
+	image, err := imageutils.BaseImage(s.callCtx, corebase.MakeDefaultBase("ubuntu", "25.04"), "released", "westus", s.client)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(image, gc.NotNil)
+	c.Assert(image, jc.DeepEquals, &instances.Image{
+		Id:       "Canonical:ubuntu-25_04:server-gen1:latest",
+		Arch:     arch.AMD64,
+		VirtType: "Hyper-V",
+	})
+}
+
+func (s *imageutilsSuite) TestBaseImageCentOS(c *gc.C) {
 	for _, cseries := range []string{"7", "8"} {
 		base := corebase.MakeDefaultBase("centos", cseries)
 		s.assertImageId(c, base, "released", "OpenLogic:CentOS:7.3:latest")
 	}
 }
 
-func (s *imageutilsSuite) TestSeriesImageStream(c *gc.C) {
+func (s *imageutilsSuite) TestBaseImageStream(c *gc.C) {
 	s.mockSender.AppendAndRepeatResponse(azuretesting.NewResponseWithContent(
 		`[{"name": "22_04_2"}, {"name": "22_04_3-DAILY"}, {"name": "22_04_1-LTS"}]`), 2)
 	base := corebase.MakeDefaultBase("ubuntu", "22.04")
@@ -88,20 +116,27 @@ func (s *imageutilsSuite) TestSeriesImageStream(c *gc.C) {
 	s.assertImageId(c, base, "released", "Canonical:0001-com-ubuntu-server-jammy:22_04_2:latest")
 }
 
-func (s *imageutilsSuite) TestSeriesImageNotFound(c *gc.C) {
+func (s *imageutilsSuite) TestBaseImageOldStyleNotFound(c *gc.C) {
 	s.mockSender.AppendResponse(azuretesting.NewResponseWithContent(`[]`))
-	image, err := imageutils.SeriesImage(s.callCtx, corebase.MakeDefaultBase("ubuntu", "22.04"), "released", "westus", s.client)
-	c.Assert(err, gc.ErrorMatches, "selecting SKU for ubuntu@22.04: Ubuntu SKUs for released stream not found")
+	image, err := imageutils.BaseImage(s.callCtx, corebase.MakeDefaultBase("ubuntu", "22.04"), "released", "westus", s.client)
+	c.Assert(err, gc.ErrorMatches, `selecting SKU for ubuntu@22.04: legacy ubuntu "jammy" SKUs for released stream not found`)
 	c.Assert(image, gc.IsNil)
 }
 
-func (s *imageutilsSuite) TestSeriesImageStreamNotFound(c *gc.C) {
-	s.mockSender.AppendResponse(azuretesting.NewResponseWithContent(`[{"name": "22_04-beta1"}]`))
-	_, err := imageutils.SeriesImage(s.callCtx, corebase.MakeDefaultBase("ubuntu", "22.04"), "whatever", "westus", s.client)
-	c.Assert(err, gc.ErrorMatches, "selecting SKU for ubuntu@22.04: Ubuntu SKUs for whatever stream not found")
+func (s *imageutilsSuite) TestBaseImageNotFound(c *gc.C) {
+	s.mockSender.AppendResponse(azuretesting.NewResponseWithContent(`[]`))
+	image, err := imageutils.BaseImage(s.callCtx, corebase.MakeDefaultBase("ubuntu", "24.04"), "released", "westus", s.client)
+	c.Assert(err, gc.ErrorMatches, `selecting SKU for ubuntu@24.04: ubuntu "ubuntu@24.04/stable" SKUs for released stream not found`)
+	c.Assert(image, gc.IsNil)
 }
 
-func (s *imageutilsSuite) TestSeriesImageStreamThrewCredentialError(c *gc.C) {
+func (s *imageutilsSuite) TestBaseImageStreamNotFound(c *gc.C) {
+	s.mockSender.AppendResponse(azuretesting.NewResponseWithContent(`[{"name": "22_04-beta1"}]`))
+	_, err := imageutils.BaseImage(s.callCtx, corebase.MakeDefaultBase("ubuntu", "22.04"), "whatever", "westus", s.client)
+	c.Assert(err, gc.ErrorMatches, `selecting SKU for ubuntu@22.04: legacy ubuntu "jammy" SKUs for whatever stream not found`)
+}
+
+func (s *imageutilsSuite) TestBaseImageStreamThrewCredentialError(c *gc.C) {
 	s.mockSender.AppendResponse(azuretesting.NewResponseWithStatus("401 Unauthorized", http.StatusUnauthorized))
 	called := false
 	s.callCtx.InvalidateCredentialFunc = func(string) error {
@@ -109,12 +144,12 @@ func (s *imageutilsSuite) TestSeriesImageStreamThrewCredentialError(c *gc.C) {
 		return nil
 	}
 
-	_, err := imageutils.SeriesImage(s.callCtx, corebase.MakeDefaultBase("ubuntu", "22.04"), "whatever", "westus", s.client)
+	_, err := imageutils.BaseImage(s.callCtx, corebase.MakeDefaultBase("ubuntu", "22.04"), "whatever", "westus", s.client)
 	c.Assert(err.Error(), jc.Contains, "RESPONSE 401")
 	c.Assert(called, jc.IsTrue)
 }
 
-func (s *imageutilsSuite) TestSeriesImageStreamThrewNonCredentialError(c *gc.C) {
+func (s *imageutilsSuite) TestBaseImageStreamThrewNonCredentialError(c *gc.C) {
 	s.mockSender.AppendResponse(azuretesting.NewResponseWithStatus("308 Permanent Redirect", http.StatusPermanentRedirect))
 	called := false
 	s.callCtx.InvalidateCredentialFunc = func(string) error {
@@ -122,13 +157,13 @@ func (s *imageutilsSuite) TestSeriesImageStreamThrewNonCredentialError(c *gc.C) 
 		return nil
 	}
 
-	_, err := imageutils.SeriesImage(s.callCtx, corebase.MakeDefaultBase("ubuntu", "22.04"), "whatever", "westus", s.client)
+	_, err := imageutils.BaseImage(s.callCtx, corebase.MakeDefaultBase("ubuntu", "22.04"), "whatever", "westus", s.client)
 	c.Assert(err.Error(), jc.Contains, "RESPONSE 308")
 	c.Assert(called, jc.IsFalse)
 }
 
 func (s *imageutilsSuite) assertImageId(c *gc.C, base corebase.Base, stream, id string) {
-	image, err := imageutils.SeriesImage(s.callCtx, base, stream, "westus", s.client)
+	image, err := imageutils.BaseImage(s.callCtx, base, stream, "westus", s.client)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(image.Id, gc.Equals, id)
 }

--- a/provider/gce/credentials.go
+++ b/provider/gce/credentials.go
@@ -51,7 +51,7 @@ func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.C
 		cloud.JSONFileAuthType: {{
 			Name: credAttrFile,
 			CredentialAttr: cloud.CredentialAttr{
-				Description: "path to the .json file containing a service account key for your project\n(detailed instructions available at https://discourse.charmhub.io/t/1508).\nPath",
+				Description: "path to the .json file containing a service account key for your project\nPath",
 				FilePath:    true,
 			},
 		}},

--- a/scripts/find-bad-doc-comments.py
+++ b/scripts/find-bad-doc-comments.py
@@ -31,8 +31,8 @@ def find_go_files(root):
             yield path.join(directory, filename)
 
 DOC_COMMENT_PATT = '\n\n//.+\n(//.+\n)*func.+\n'
-FIRST_WORD_PATT = '// *(\w+)'
-FUNC_NAME_PATT = 'func(?: \([^)]+\))? (\S+)\('
+FIRST_WORD_PATT = '// *(\\w+)'
+FUNC_NAME_PATT = 'func(?: \\([^)]+\\))? (\\S+)\\('
 
 def extract_doc_comments(text):
     for match in re.finditer(DOC_COMMENT_PATT, text, re.MULTILINE):

--- a/scripts/leadershipclaimer/count-leadership.py
+++ b/scripts/leadershipclaimer/count-leadership.py
@@ -13,9 +13,9 @@ def main(args):
     p.add_argument("--tick", type=float, default=1.0,
             help="seconds between printing status ticks")
     opts = p.parse_args(args)
-    actionsRE = re.compile("\s*(?P<time>\d+\.\d\d\d)s\s+(?P<action>claimed|extended|lost|connected).*in (?P<duration>[0-9m.]+s)")
+    actionsRE = re.compile("\\s*(?P<time>\\d+\\.\\d\\d\\d)s\\s+(?P<action>claimed|extended|lost|connected).*in (?P<duration>[0-9m.]+s)")
     # We don't have minutes if we have 'ms', so match 'ms' first, we might have 'm' if we have 's', so put it before s.
-    durationRE = re.compile("((?P<milliseconds>\d+)ms)?((?P<minutes>\d+)m)?((?P<seconds>\d+(\.\d+)?)s)?")
+    durationRE = re.compile("((?P<milliseconds>\\d+)ms)?((?P<minutes>\\d+)m)?((?P<seconds>\\d+(\\.\\d+)?)s)?")
     totalClaims = 0
     extendedSum = 0
     extendedCount = 0

--- a/state/secrets.go
+++ b/state/secrets.go
@@ -5,6 +5,7 @@ package state
 
 import (
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -1333,6 +1334,7 @@ func (st *State) uniqueSecretLabelBaseOps(tag names.Tag, label string) (ops []tx
 		errorMsg   string
 	)
 
+	label = regexp.QuoteMeta(label)
 	switch tag := tag.(type) {
 	case names.ApplicationTag:
 		// Ensure no units use this label for both owner and consumer label.

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -69,10 +69,10 @@ bootstrap() {
 	"azure")
 		cloud="azure"
 		;;
-	"localhost" | "lxd")
-		cloud="localhost"
+	"lxd")
+		cloud="${BOOTSTRAP_CLOUD:-localhost}"
 		;;
-	"lxd-remote" | "vsphere" | "openstack" | "k8s" | "maas")
+	"vsphere" | "openstack" | "k8s" | "maas")
 		cloud="${BOOTSTRAP_CLOUD}"
 		;;
 	"manual")

--- a/tests/main.sh
+++ b/tests/main.sh
@@ -6,7 +6,7 @@ export SHELLCHECK_OPTS="-e SC2230 -e SC2039 -e SC2028 -e SC2002 -e SC2005 -e SC2
 export BOOTSTRAP_REUSE_LOCAL="${BOOTSTRAP_REUSE_LOCAL:-}"
 export BOOTSTRAP_REUSE="${BOOTSTRAP_REUSE:-false}"
 export BOOTSTRAP_PROVIDER="${BOOTSTRAP_PROVIDER:-lxd}"
-export BOOTSTRAP_CLOUD="${BOOTSTRAP_CLOUD:-lxd}"
+export BOOTSTRAP_CLOUD="${BOOTSTRAP_CLOUD:-localhost}"
 export BOOTSTRAP_SERIES="${BOOTSTRAP_SERIES:-}"
 export BOOTSTRAP_ARCH="${BOOTSTRAP_ARCH:-}"
 export BUILD_ARCH="${BUILD_ARCH:-}"
@@ -193,13 +193,6 @@ while getopts "hH?vAs:a:x:rl:p:c:R:S:" opt; do
 
 		CLOUD=$(juju show-controller "${OPTARG}" --format=json 2>/dev/null | jq -r ".[\"${OPTARG}\"] | .details | .cloud")
 		PROVIDER=$(juju clouds --client --all --format=json 2>/dev/null | jq -r ".[\"${CLOUD}\"] | .type")
-		if [[ -z ${PROVIDER} ]]; then
-			PROVIDER="${CLOUD}"
-		fi
-		# We want "ec2" to redirect to "aws". This is needed e.g. for the ck tests
-		if [[ ${PROVIDER} == "ec2" ]]; then
-			PROVIDER="aws"
-		fi
 		export BOOTSTRAP_PROVIDER="${PROVIDER}"
 		export BOOTSTRAP_CLOUD="${CLOUD}"
 		;;

--- a/tests/suites/backup/backup.sh
+++ b/tests/suites/backup/backup.sh
@@ -59,7 +59,7 @@ run_basic_backup_restore() {
 	juju status --format json | jq '.machines | length' | check 1
 
 	# Only do this check if provider is LXD (too hard to do for all providers)
-	if [ "${BOOTSTRAP_PROVIDER}" == "lxd" ] || [ "${BOOTSTRAP_PROVIDER}" == "localhost" ]; then
+	if [ "${BOOTSTRAP_PROVIDER}" == "lxd" ]; then
 		echo "Ensure that both instances are running (restore shouldn't terminate machines)"
 		lxc list --format json | jq --arg name "${id0}" -r '.[] | select(.name==$name) | .state.status' | check Running
 		lxc list --format json | jq --arg name "${id1}" -r '.[] | select(.name==$name) | .state.status' | check Running

--- a/tests/suites/cli/model_defaults.sh
+++ b/tests/suites/cli/model_defaults.sh
@@ -62,7 +62,7 @@ test_model_defaults() {
 		run "run_model_defaults_boolean"
 
 		case "${BOOTSTRAP_PROVIDER-}" in
-		"aws")
+		"ec2")
 			run "run_model_defaults_region_aws"
 			;;
 		*)

--- a/tests/suites/constraints/constraints.sh
+++ b/tests/suites/constraints/constraints.sh
@@ -10,7 +10,7 @@ test_constraints_common() {
 		cd .. || exit
 
 		case "${BOOTSTRAP_PROVIDER:-}" in
-		"lxd" | "lxd-remote" | "localhost")
+		"lxd")
 			run "run_constraints_lxd"
 			;;
 		"openstack")

--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -380,7 +380,7 @@ test_deploy_bundles() {
 
 		# LXD specific profile tests.
 		case "${BOOTSTRAP_PROVIDER:-}" in
-		"lxd" | "localhost")
+		"lxd")
 			run "run_deploy_lxd_profile_bundle_openstack"
 			echo "==> TEST SKIPPED: deploy_lxd_profile_bundle - tests for non LXD only"
 			;;
@@ -392,7 +392,7 @@ test_deploy_bundles() {
 
 		# AWS specific image id tests.
 		case "${BOOTSTRAP_PROVIDER:-}" in
-		"ec2" | "aws")
+		"ec2")
 			check_dependencies aws
 			add_clean_func "run_cleanup_ami"
 			export ami_id

--- a/tests/suites/deploy/os.sh
+++ b/tests/suites/deploy/os.sh
@@ -10,7 +10,7 @@ test_deploy_os() {
 		cd .. || exit
 
 		case "${BOOTSTRAP_PROVIDER:-}" in
-		"ec2" | "aws")
+		"ec2")
 			#
 			# A handy place to find the current AMIs for centos
 			# https://wiki.centos.org/Cloud/AWS

--- a/tests/suites/manual/deploy_manual.sh
+++ b/tests/suites/manual/deploy_manual.sh
@@ -10,10 +10,10 @@ test_deploy_manual() {
 		cd .. || exit
 
 		case "${BOOTSTRAP_PROVIDER:-}" in
-		"lxd" | "lxd-remote" | "localhost")
+		"lxd")
 			run "run_deploy_manual_lxd"
 			;;
-		"aws" | "ec2")
+		"aws")
 			run "run_deploy_manual_aws"
 			;;
 		*)

--- a/tests/suites/manual/spaces.sh
+++ b/tests/suites/manual/spaces.sh
@@ -10,7 +10,7 @@ test_spaces_manual() {
 		cd .. || exit
 
 		case "${BOOTSTRAP_PROVIDER:-}" in
-		"aws")
+		"ec2")
 			run "run_spaces_manual_aws"
 			;;
 		*)


### PR DESCRIPTION
Forward merge:
- https://github.com/juju/juju/pull/17348
- https://github.com/juju/juju/pull/17413
- https://github.com/juju/juju/pull/17423
- https://github.com/juju/juju/pull/17436
- https://github.com/juju/juju/pull/17422
- https://github.com/juju/juju/pull/17446
- https://github.com/juju/juju/pull/17448
- https://github.com/juju/juju/pull/17444
- https://github.com/juju/juju/pull/17453
- https://github.com/juju/juju/pull/17440
- https://github.com/juju/juju/pull/17458

Conflicts:
- acceptancetests/jujupy/client.py
- acceptancetests/jujupy/tests/test_status.py
- acceptancetests/repository/trusty/haproxy/cm.py
- acceptancetests/tests/test_jujucharm.py
- cmd/juju/cloud/addcredential.go
- core/base/base.go
- environs/bootstrap/bootstrap.go
- provider/azure/environ.go
- provider/azure/internal/imageutils/images.go
- scripts/win-installer/setup.iss
- snap/snapcraft.yaml
- version/version.go

Conflicts mostly trivial

`provider/azure/internal/imageutils/images.go` took a bit of thought. This conflict resulted from my PR https://github.com/juju/juju/pull/17440