### PR TITLE
Ensure relation-ids excludes ids for broken relations

### DIFF
--- a/cmd/juju/commands/helptool_test.go
+++ b/cmd/juju/commands/helptool_test.go
@@ -76,7 +76,7 @@ Currently available charm hook tools are:
     pod-spec-get             get k8s spec information (deprecated)
     pod-spec-set             set k8s spec information (deprecated)
     relation-get             get relation settings
-    relation-ids             list all relation ids with the given relation name
+    relation-ids             list all relation ids for the given endpoint
     relation-list            list relation units
     relation-set             set relation settings
     resource-get             get the path to the locally cached resource file

--- a/worker/uniter/runner/context/context.go
+++ b/worker/uniter/runner/context/context.go
@@ -1328,7 +1328,11 @@ func (ctx *HookContext) Relation(id int) (jujuc.ContextRelation, error) {
 // Implements jujuc.HookContext.ContextRelations, part of runner.Context.
 func (ctx *HookContext) RelationIds() ([]int, error) {
 	ids := []int{}
-	for id := range ctx.relations {
+	for id, r := range ctx.relations {
+		if r.broken {
+			ctx.logger.Debugf("relation %d is broken, excluding from relations-ids", id)
+			continue
+		}
 		ids = append(ids, id)
 	}
 	return ids, nil

--- a/worker/uniter/runner/context/context_test.go
+++ b/worker/uniter/runner/context/context_test.go
@@ -80,6 +80,7 @@ func (s *InterfaceSuite) TestRelationIds(c *gc.C) {
 	relIds, err := ctx.RelationIds()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(relIds, gc.HasLen, 2)
+	c.Assert(relIds, jc.SameContents, []int{0, 1})
 	r, err := ctx.Relation(0)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(r.Name(), gc.Equals, "db")
@@ -87,6 +88,16 @@ func (s *InterfaceSuite) TestRelationIds(c *gc.C) {
 	r, err = ctx.Relation(123)
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 	c.Assert(r, gc.IsNil)
+}
+
+func (s *InterfaceSuite) TestRelationIdsExcludesBroken(c *gc.C) {
+	ctx := s.GetContext(c, -1, "", names.StorageTag{})
+	// Broken relations have no member settings.
+	context.SetRelationBroken(ctx, 1)
+	relIds, err := ctx.RelationIds()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(relIds, gc.HasLen, 1)
+	c.Assert(relIds, jc.SameContents, []int{0})
 }
 
 func (s *InterfaceSuite) TestRelationContext(c *gc.C) {

--- a/worker/uniter/runner/context/contextfactory.go
+++ b/worker/uniter/runner/context/contextfactory.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/juju/juju/api/agent/uniter"
 	"github.com/juju/juju/core/leadership"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/secrets"
@@ -359,7 +360,11 @@ func (f *contextFactory) getContextRelations() map[int]*ContextRelation {
 			cache = NewRelationCache(relationUnit.ReadSettings, memberNames)
 		}
 		relationCaches[id] = cache
-		contextRelations[id] = NewContextRelation(relationUnit, cache)
+		// If there are no members and the relation is dying or suspended, a relation is broken.
+		rel := info.RelationUnit.Relation()
+		relationInactive := rel.Life() != life.Alive || rel.Suspended()
+		broken := relationInactive && len(memberNames) == 0
+		contextRelations[id] = NewContextRelation(relationUnit, cache, broken)
 	}
 	f.relationCaches = relationCaches
 	return contextRelations

--- a/worker/uniter/runner/context/export_test.go
+++ b/worker/uniter/runner/context/export_test.go
@@ -206,6 +206,15 @@ func SetEnvironmentHookContextNotice(context *HookContext, workloadName, noticeI
 	context.noticeKey = noticeKey
 }
 
+// SetRelationBroken sets the relation as broken.
+func SetRelationBroken(context jujuc.Context, relId int) {
+	context.(*HookContext).relations[relId].broken = true
+}
+
+// RelationBroken returns the relation broken state.
+func RelationBroken(context jujuc.Context, relId int) bool {
+	return context.(*HookContext).relations[relId].broken
+}
 func PatchCachedStatus(ctx jujuc.Context, status, info string, data map[string]interface{}) func() {
 	hctx := ctx.(*HookContext)
 	oldStatus := hctx.status

--- a/worker/uniter/runner/context/relation.go
+++ b/worker/uniter/runner/context/relation.go
@@ -80,6 +80,7 @@ type ContextRelation struct {
 	ru           RelationUnit
 	relationId   int
 	endpointName string
+	broken       bool
 
 	// settings allows read and write access to the relation unit settings.
 	settings *uniter.Settings
@@ -93,12 +94,13 @@ type ContextRelation struct {
 
 // NewContextRelation creates a new context for the given relation unit.
 // The unit-name keys of members supplies the initial membership.
-func NewContextRelation(ru RelationUnit, cache *RelationCache) *ContextRelation {
+func NewContextRelation(ru RelationUnit, cache *RelationCache, broken bool) *ContextRelation {
 	return &ContextRelation{
 		ru:           ru,
 		relationId:   ru.Relation().Id(),
 		endpointName: ru.Endpoint().Name,
 		cache:        cache,
+		broken:       broken,
 	}
 }
 

--- a/worker/uniter/runner/context/relation_test.go
+++ b/worker/uniter/runner/context/relation_test.go
@@ -93,7 +93,7 @@ func (s *ContextRelationSuite) TestMemberCaching(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	cache := context.NewRelationCache(s.relUnit.ReadSettings, []string{"u/1"})
-	ctx := context.NewContextRelation(s.relUnit, cache)
+	ctx := context.NewContextRelation(s.relUnit, cache, false)
 
 	// Check that uncached settings are read from state.
 	m, err := ctx.ReadSettings("u/1")
@@ -125,7 +125,7 @@ func (s *ContextRelationSuite) TestNonMemberCaching(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	cache := context.NewRelationCache(s.relUnit.ReadSettings, nil)
-	ctx := context.NewContextRelation(s.relUnit, cache)
+	ctx := context.NewContextRelation(s.relUnit, cache, false)
 
 	// Check that settings are read from state.
 	m, err := ctx.ReadSettings("u/1")
@@ -157,7 +157,7 @@ func (s *ContextRelationSuite) TestSuspended(c *gc.C) {
 	err = s.rel.SetSuspended(true, "")
 	c.Assert(err, jc.ErrorIsNil)
 
-	ctx := context.NewContextRelation(s.relUnit, nil)
+	ctx := context.NewContextRelation(s.relUnit, nil, false)
 	err = s.relUnit.Relation().Refresh()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ctx.Suspended(), jc.IsTrue)
@@ -171,7 +171,7 @@ func (s *ContextRelationSuite) TestSetStatus(c *gc.C) {
 	err = claimer.Claim("u", "u/0", time.Minute)
 	c.Assert(err, jc.ErrorIsNil)
 
-	ctx := context.NewContextRelation(s.relUnit, nil)
+	ctx := context.NewContextRelation(s.relUnit, nil, false)
 	err = ctx.SetStatus(relation.Suspended)
 	c.Assert(err, jc.ErrorIsNil)
 	relStatus, err := s.rel.Status()
@@ -180,7 +180,7 @@ func (s *ContextRelationSuite) TestSetStatus(c *gc.C) {
 }
 
 func (s *ContextRelationSuite) TestRemoteApplicationName(c *gc.C) {
-	ctx := context.NewContextRelation(s.relUnit, nil)
+	ctx := context.NewContextRelation(s.relUnit, nil, false)
 	c.Assert(ctx.RemoteApplicationName(), gc.Equals, "u")
 }
 

--- a/worker/uniter/runner/context/util_test.go
+++ b/worker/uniter/runner/context/util_test.go
@@ -187,7 +187,7 @@ func (s *HookContextSuite) getHookContext(c *gc.C, uuid string, relid int, remot
 	relctxs := map[int]*runnercontext.ContextRelation{}
 	for relId, relUnit := range s.apiRelunits {
 		cache := runnercontext.NewRelationCache(relUnit.ReadSettings, nil)
-		relctxs[relId] = runnercontext.NewContextRelation(&relUnitShim{relUnit}, cache)
+		relctxs[relId] = runnercontext.NewContextRelation(&relUnitShim{relUnit}, cache, false)
 	}
 
 	env, err := s.State.Model()
@@ -233,7 +233,7 @@ func (s *HookContextSuite) getMeteredHookContext(c *gc.C, uuid string, relid int
 	relctxs := map[int]*runnercontext.ContextRelation{}
 	for relId, relUnit := range s.apiRelunits {
 		cache := runnercontext.NewRelationCache(relUnit.ReadSettings, nil)
-		relctxs[relId] = runnercontext.NewContextRelation(&relUnitShim{relUnit}, cache)
+		relctxs[relId] = runnercontext.NewContextRelation(&relUnitShim{relUnit}, cache, false)
 	}
 
 	context, err := runnercontext.NewHookContext(runnercontext.HookContextParams{

--- a/worker/uniter/runner/jujuc/relation-ids.go
+++ b/worker/uniter/runner/jujuc/relation-ids.go
@@ -40,14 +40,15 @@ func (c *RelationIdsCommand) Info() *cmd.Info {
 	if r, err := c.ctx.HookRelation(); err == nil {
 		// There's not much we can do about this error here.
 		args = "[<name>]"
-		doc = fmt.Sprintf("Current default relation name is %q.", r.Name())
+		doc = fmt.Sprintf("Current default endpoint name is %q.", r.Name())
 	} else if !errors.IsNotFound(err) {
 		logger.Errorf("Could not retrieve hook relation: %v", err)
 	}
+	doc += "\nOnly relation ids for relations which are not broken are included."
 	return jujucmd.Info(&cmd.Info{
 		Name:    "relation-ids",
 		Args:    args,
-		Purpose: "list all relation ids with the given relation name",
+		Purpose: "list all relation ids for the given endpoint",
 		Doc:     doc,
 	})
 }
@@ -61,7 +62,7 @@ func (c *RelationIdsCommand) Init(args []string) error {
 		c.Name = args[0]
 		args = args[1:]
 	} else if c.Name == "" {
-		return fmt.Errorf("no relation name specified")
+		return fmt.Errorf("no endpoint name specified")
 	}
 	return cmd.CheckEmpty(args)
 }

--- a/worker/uniter/runner/jujuc/relation-ids_test.go
+++ b/worker/uniter/runner/jujuc/relation-ids_test.go
@@ -44,7 +44,7 @@ var relationIdsTests = []struct {
 		summary: "no default, no name",
 		relid:   -1,
 		code:    2,
-		out:     "(.|\n)*ERROR no relation name specified\n",
+		out:     "(.|\n)*ERROR no endpoint name specified\n",
 	}, {
 		summary: "default name",
 		relid:   1,
@@ -129,7 +129,7 @@ func (s *RelationIdsSuite) TestHelp(c *gc.C) {
 Usage: %s
 
 Summary:
-list all relation ids with the given relation name
+list all relation ids for the given endpoint
 
 Options:
 --format  (= smart)
@@ -141,9 +141,9 @@ Options:
 	for relid, t := range map[int]struct {
 		usage, doc string
 	}{
-		-1: {"relation-ids [options] <name>", ""},
-		0:  {"relation-ids [options] [<name>]", "\nDetails:\nCurrent default relation name is \"x\".\n"},
-		3:  {"relation-ids [options] [<name>]", "\nDetails:\nCurrent default relation name is \"y\".\n"},
+		-1: {"relation-ids [options] <name>", "\nDetails:\nOnly relation ids for relations which are not broken are included.\n"},
+		0:  {"relation-ids [options] [<name>]", "\nDetails:\nCurrent default endpoint name is \"x\".\nOnly relation ids for relations which are not broken are included.\n"},
+		3:  {"relation-ids [options] [<name>]", "\nDetails:\nCurrent default endpoint name is \"y\".\nOnly relation ids for relations which are not broken are included.\n"},
 	} {
 		c.Logf("relid %d", relid)
 		hctx, _ := s.newHookContext(relid, "")


### PR DESCRIPTION
We want to exclude ids of broken relations when listing relation ids. A relation is broken from the context of the unit running a hook if the relation has no members. So this is used when creating the hook context to mark a relation as broken.

Note: this just affects the listing of relation ids. If a relation id is known, it can still be used to access relation data etc.

## QA steps

I hacked up a charm to print the content of relation-ids in a relation departed hook and also the relation broken hook. 
After deploying and relating my test charms...
`juju remove-relation 0`
From the logs
```
unit.dummy-source/1.sink-relation-departed + ids=sink:0
...
unit.dummy-source/1.sink-relation-broken + ids=
```

On k8s, deploy nginx and hello-kubecon and scale both to 0.
Relate them.
$ juju exec -u hello-kubecon/0 -- relation-ids ingress
ingress:0

## Documentation changes

The relation-ids CLI doc has been tweaked to reflect the fact that broken ids are excluded. 

## Links

https://bugs.launchpad.net/juju/+bug/2024583

**Jira card:** [JUJU-6116](https://warthogs.atlassian.net/browse/JUJU-6116)



[JUJU-6116]: https://warthogs.atlassian.net/browse/JUJU-6116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ