### PR TITLE
Asserts controller config defaults to model.

### DIFF
--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -242,7 +242,6 @@ func (b *AgentBootstrap) Initialize(ctx stdcontext.Context) (_ *state.Controller
 	controllerModelCreateFunc := modelbootstrap.CreateModel(controllerModelArgs)
 
 	controllerModelDefaults := modeldefaultsbootstrap.ModelDefaultsProvider(
-		nil,
 		stateParams.ControllerInheritedConfig,
 		stateParams.RegionInheritedConfig[stateParams.ControllerCloudRegion])
 

--- a/domain/modeldefaults/bootstrap/bootstrap.go
+++ b/domain/modeldefaults/bootstrap/bootstrap.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/juju/domain/modeldefaults"
 	"github.com/juju/juju/domain/modeldefaults/service"
+	"github.com/juju/juju/domain/modeldefaults/state"
 	"github.com/juju/juju/environs/config"
 )
 
@@ -15,14 +16,13 @@ import (
 // passed in during bootstrap into a model default provider interface to be used
 // when persisting initial model config. Config passed to this func can be nil.
 func ModelDefaultsProvider(
-	configDefaults map[string]any,
 	controllerConfig map[string]any,
 	cloudRegionConfig map[string]any,
 ) service.ModelDefaultsProviderFunc {
 	return func(ctx context.Context) (modeldefaults.Defaults, error) {
 		defaults := modeldefaults.Defaults{}
 
-		for k, v := range configDefaults {
+		for k, v := range state.ConfigDefaults(ctx) {
 			defaults[k] = modeldefaults.DefaultAttributeValue{
 				Source: config.JujuDefaultSource,
 				Value:  v,

--- a/domain/modeldefaults/bootstrap/bootstrap_test.go
+++ b/domain/modeldefaults/bootstrap/bootstrap_test.go
@@ -8,6 +8,8 @@ import (
 
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/domain/modeldefaults/state"
 )
 
 type bootstrapSuite struct{}
@@ -16,10 +18,6 @@ var _ = gc.Suite(&bootstrapSuite{})
 
 func (_ *bootstrapSuite) TestBootstrapModelDefaults(c *gc.C) {
 	provider := ModelDefaultsProvider(
-		map[string]any{
-			"foo":     "default",
-			"default": "some value",
-		},
 		map[string]any{
 			"foo":        "controller",
 			"controller": "some value",
@@ -31,13 +29,17 @@ func (_ *bootstrapSuite) TestBootstrapModelDefaults(c *gc.C) {
 	)
 
 	defaults, err := provider.ModelDefaults(context.Background())
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(defaults["foo"].Value, gc.Equals, "region")
-	c.Assert(defaults["foo"].Source, gc.Equals, "region")
-	c.Assert(defaults["default"].Value, gc.Equals, "some value")
-	c.Assert(defaults["default"].Source, gc.Equals, "default")
-	c.Assert(defaults["controller"].Value, gc.Equals, "some value")
-	c.Assert(defaults["controller"].Source, gc.Equals, "controller")
-	c.Assert(defaults["region"].Value, gc.Equals, "some value")
-	c.Assert(defaults["region"].Source, gc.Equals, "region")
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(defaults["foo"].Value, gc.Equals, "region")
+	c.Check(defaults["foo"].Source, gc.Equals, "region")
+	c.Check(defaults["controller"].Value, gc.Equals, "some value")
+	c.Check(defaults["controller"].Source, gc.Equals, "controller")
+	c.Check(defaults["region"].Value, gc.Equals, "some value")
+	c.Check(defaults["region"].Source, gc.Equals, "region")
+
+	configDefaults := state.ConfigDefaults(context.Background())
+	for k, v := range configDefaults {
+		c.Check(defaults[k].Value, gc.Equals, v)
+		c.Check(defaults[k].Source, gc.Equals, "default")
+	}
 }

--- a/domain/modeldefaults/state/state.go
+++ b/domain/modeldefaults/state/state.go
@@ -25,8 +25,13 @@ type State struct {
 }
 
 // ConfigDefaults returns the default configuration values set in Juju.
-func (s *State) ConfigDefaults(_ context.Context) map[string]any {
+func ConfigDefaults(_ context.Context) map[string]any {
 	return config.ConfigDefaults()
+}
+
+// ConfigDefaults returns the default configuration values set in Juju.
+func (s *State) ConfigDefaults(ctx context.Context) map[string]any {
+	return ConfigDefaults(ctx)
 }
 
 // ModelCloudDefaults returns the defaults associated with the model's cloud. If

--- a/domain/servicefactory/testing/suite.go
+++ b/domain/servicefactory/testing/suite.go
@@ -160,7 +160,7 @@ func (s *ServiceFactorySuite) SeedModelDatabases(c *gc.C) {
 	fn = modelconfigbootstrap.SetModelConfig(
 		s.ControllerModelUUID,
 		nil,
-		modeldefaultsbootstrap.ModelDefaultsProvider(nil, nil, nil),
+		modeldefaultsbootstrap.ModelDefaultsProvider(nil, nil),
 	)
 	err = fn(ctx, s.ControllerTxnRunner(), s.ModelTxnRunner(c, s.ControllerModelUUID.String()))
 	c.Assert(err, jc.ErrorIsNil)
@@ -184,7 +184,7 @@ func (s *ServiceFactorySuite) SeedModelDatabases(c *gc.C) {
 	fn = modelconfigbootstrap.SetModelConfig(
 		s.DefaultModelUUID,
 		nil,
-		modeldefaultsbootstrap.ModelDefaultsProvider(nil, nil, nil),
+		modeldefaultsbootstrap.ModelDefaultsProvider(nil, nil),
 	)
 	err = fn(ctx, s.ControllerTxnRunner(), s.ModelTxnRunner(c, s.DefaultModelUUID.String()))
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
When bootstrapping model config we were not applying the built in defaults for model config to the model. Fortunately we didn't notice because currently the client generates the defaults during bootstrap and passes them to the controller.

However for tests using the bootstrap methods the defaults were not being applied. This change now forces the bootstrap method to always apply the model defaults on set.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

There is no really way to manually test this at the moment because the Juju client during bootstrap generates the defaults and passes them to the controller. This functionality will go over time but can't disappear till we stop dual writing models.

This was identified when testing with the service factory in apiserver suit. I have added a check in the original bootstrap tests to make sure we are seeing the one of the defaults coming back out.

## Documentation changes

N/A

## Links

**Jira card:** JUJU-6137

