### PR TITLE
secrets: return not found instead of permission denied

### DIFF
--- a/apiserver/facades/agent/secretsmanager/secrets_test.go
+++ b/apiserver/facades/agent/secretsmanager/secrets_test.go
@@ -1601,7 +1601,7 @@ func (s *SecretsManagerSuite) TestWatchConsumedSecretsChanges(c *gc.C) {
 			StringsWatcherId: "1",
 			Changes:          []string{uri.String()},
 		}, {
-			Error: &params.Error{Code: "unauthorized access", Message: "permission denied"},
+			Error: &params.Error{Code: "not found", Message: "not found"},
 		}},
 	})
 }

--- a/tests/suites/secrets_iaas/cmr.sh
+++ b/tests/suites/secrets_iaas/cmr.sh
@@ -48,7 +48,7 @@ run_secrets_cmr() {
 	juju switch "model-secrets-offer"
 	juju suspend-relation "$relation_id"
 	juju switch "model-secrets-consume"
-	check_contains "$(juju exec --unit dummy-sink/0 -- secret-get "$secret_uri" 2>&1)" 'permission denied'
+	check_contains "$(juju exec --unit dummy-sink/0 -- secret-get "$secret_uri" 2>&1)" 'not found'
 	echo "Checking: resume relation and access is restored"
 	juju switch "model-secrets-offer"
 	juju resume-relation "$relation_id"
@@ -59,7 +59,7 @@ run_secrets_cmr() {
 	juju switch "model-secrets-offer"
 	juju exec --unit dummy-source/0 -- secret-revoke "$secret_uri" --relation "$relation_id"
 	juju switch "model-secrets-consume"
-	check_contains "$(juju exec --unit dummy-sink/0 -- secret-get "$secret_uri" 2>&1)" 'permission denied'
+	check_contains "$(juju exec --unit dummy-sink/0 -- secret-get "$secret_uri" 2>&1)" 'not found'
 }
 
 test_secrets_cmr() {

--- a/tests/suites/secrets_iaas/juju.sh
+++ b/tests/suites/secrets_iaas/juju.sh
@@ -3,7 +3,7 @@ check_secrets() {
 	juju --show-log deploy etcd
 	juju --show-log integrate etcd easyrsa
 
-	wait_for "active" '.applications["easyrsa"] | ."application-status".current'
+	wait_for "active" '.applications["easyrsa"] | ."application-status".current' 1200
 	wait_for "active" '.applications["etcd"] | ."application-status".current' 900
 	wait_for "easyrsa" "$(idle_condition "easyrsa" 0 0)"
 	wait_for "etcd" "$(idle_condition "etcd" 1 0)"
@@ -73,6 +73,7 @@ run_user_secrets() {
 
 	app_name='easyrsa-user-secrets'
 	juju --show-log deploy easyrsa "$app_name"
+	wait_for "active" ".applications[\"$app_name\"] | .\"application-status\".current" 1200
 
 	# create user secrets.
 	secret_uri=$(juju --show-log add-secret mysecret owned-by="$model_name-1" --info "this is a user secret")

--- a/tests/suites/secrets_iaas/juju.sh
+++ b/tests/suites/secrets_iaas/juju.sh
@@ -53,11 +53,11 @@ check_secrets() {
 
 	echo "Checking: secret-revoke by relation ID"
 	juju exec --unit easyrsa/0 -- secret-revoke "$secret_owned_by_easyrsa" --relation "$relation_id"
-	check_contains "$(juju exec --unit etcd/0 -- secret-get "$secret_owned_by_easyrsa" 2>&1)" 'permission denied'
+	check_contains "$(juju exec --unit etcd/0 -- secret-get "$secret_owned_by_easyrsa" 2>&1)" 'not found'
 
 	echo "Checking: secret-revoke by app name"
 	juju exec --unit easyrsa/0 -- secret-revoke "$secret_owned_by_easyrsa_0" --app etcd
-	check_contains "$(juju exec --unit etcd/0 -- secret-get "$secret_owned_by_easyrsa_0" 2>&1)" 'permission denied'
+	check_contains "$(juju exec --unit etcd/0 -- secret-get "$secret_owned_by_easyrsa_0" 2>&1)" 'not found'
 
 	echo "Checking: secret-remove"
 	juju exec --unit easyrsa/0 -- secret-remove "$secret_owned_by_easyrsa_0"
@@ -85,7 +85,7 @@ run_user_secrets() {
 	check_contains "$(juju --show-log show-secret "$secret_uri" --revisions | yq ".${secret_short_uri}.description")" 'info'
 
 	# grant secret to the app, and now the application can access the revision 2.
-	check_contains "$(juju exec --unit "$app_name"/0 -- secret-get "$secret_uri" 2>&1)" 'permission denied'
+	check_contains "$(juju exec --unit "$app_name"/0 -- secret-get "$secret_uri" 2>&1)" 'not found'
 	juju --show-log grant-secret mysecret "$app_name"
 	check_contains "$(juju exec --unit "$app_name/0" -- secret-get $secret_short_uri)" "owned-by: $model_name-2"
 
@@ -121,7 +121,7 @@ run_user_secrets() {
 	check_contains "$(juju --show-log show-secret $secret_uri --reveal --revision 3 | yq .${secret_short_uri}.content)" "owned-by: $model_name-3"
 
 	juju --show-log revoke-secret mysecret "$app_name"
-	check_contains "$(juju exec --unit "$app_name"/0 -- secret-get "$secret_uri" 2>&1)" 'permission denied'
+	check_contains "$(juju exec --unit "$app_name"/0 -- secret-get "$secret_uri" 2>&1)" 'not found'
 
 	juju --show-log remove-secret mysecret
 	check_contains "$(juju --show-log secrets --format yaml | yq length)" '0'

--- a/tests/suites/secrets_k8s/k8s.sh
+++ b/tests/suites/secrets_k8s/k8s.sh
@@ -81,11 +81,11 @@ run_secrets() {
 
 	echo "Checking: secret-revoke by relation ID"
 	juju exec --unit hello/0 -- secret-revoke "$app_owned_full_uri" --relation "$relation_id"
-	check_contains "$(juju exec --unit nginx/0 -- secret-get "$app_owned_full_uri" 2>&1)" 'permission denied'
+	check_contains "$(juju exec --unit nginx/0 -- secret-get "$app_owned_full_uri" 2>&1)" 'not found'
 
 	echo "Checking: secret-revoke by app name"
 	juju exec --unit hello/0 -- secret-revoke "$unit_owned_short_uri" --app nginx
-	check_contains "$(juju exec --unit nginx/0 -- secret-get "$unit_owned_short_uri" 2>&1)" 'permission denied'
+	check_contains "$(juju exec --unit nginx/0 -- secret-get "$unit_owned_short_uri" 2>&1)" 'not found'
 
 	echo "Checking: secret-remove"
 	juju exec --unit hello/0 -- secret-remove "$unit_owned_short_uri"
@@ -122,7 +122,7 @@ run_user_secrets() {
 	check_contains "$(juju --show-log show-secret "$secret_uri" --revisions | yq ".${secret_short_uri}.description")" 'info'
 
 	# grant secret to hello-kubecon app, and now the application can access the revision 2.
-	check_contains "$(juju exec --unit hello-kubecon/0 -- secret-get "$secret_uri" 2>&1)" 'permission denied'
+	check_contains "$(juju exec --unit hello-kubecon/0 -- secret-get "$secret_uri" 2>&1)" 'not found'
 	juju --show-log grant-secret "$secret_uri" hello-kubecon
 	check_contains "$(juju exec --unit hello-kubecon/0 -- secret-get $secret_short_uri)" "owned-by: $model_name-2"
 
@@ -158,7 +158,7 @@ run_user_secrets() {
 	check_contains "$(juju --show-log show-secret $secret_uri --reveal --revision 3 | yq .${secret_short_uri}.content)" "owned-by: $model_name-3"
 
 	juju --show-log revoke-secret $secret_uri hello-kubecon
-	check_contains "$(juju exec --unit hello-kubecon/0 -- secret-get "$secret_uri" 2>&1)" 'permission denied'
+	check_contains "$(juju exec --unit hello-kubecon/0 -- secret-get "$secret_uri" 2>&1)" 'not found'
 
 	juju --show-log remove-secret $secret_uri
 	check_contains "$(juju --show-log secrets --format yaml | yq length)" '0'


### PR DESCRIPTION
<!-- Why this change is needed and what it does. -->

For inaccessible secrets, `secret-get` was returning `ERROR permission denied`. However, this inadvertently leaks the fact that the requested secret *does* exist, but the requester cannot access it. Instead, we should return "not found", so that a malicious agent cannot gain any information about secrets which they have no access to.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- ~[ ] Code style: imports ordered, good names, simple structure, etc~
- [x] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

<!-- Describe steps to verify that the change works. -->

Run secrets integration tests (suites `secrets_iaas` and `secrets_k8s`)

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2067336

**Jira card:** JUJU-6115