### PR TITLE
Introduces helper for getting controller model.

### DIFF
--- a/domain/model/service/service.go
+++ b/domain/model/service/service.go
@@ -57,6 +57,11 @@ type State interface {
 	// GetModel returns the model associated with the provided uuid.
 	GetModel(context.Context, coremodel.UUID) (coremodel.Model, error)
 
+	// GetModelByName returns the model associated with the given user and name.
+	// If no model exists for the provided user or model name then an error of
+	// [modelerrors.NotFound] will be returned.
+	GetModelByName(context.Context, string, string) (coremodel.Model, error)
+
 	// GetModelType returns the model type for a model with the provided uuid.
 	GetModelType(context.Context, coremodel.UUID) (coremodel.ModelType, error)
 
@@ -339,6 +344,13 @@ func (s *Service) ImportModel(
 	}
 
 	return s.createModel(ctx, args.ID, args.ModelCreationArgs)
+}
+
+// ControllerModel returns the model used for housing the Juju controller.
+// Should no model exist for the controller an error of [modelerrors.NotFound]
+// will be returned.
+func (s *Service) ControllerModel(ctx context.Context) (coremodel.Model, error) {
+	return s.st.GetModelByName(ctx, coremodel.ControllerModelOwnerUsername, coremodel.ControllerModelName)
 }
 
 // Model returns the model associated with the provided uuid.

--- a/domain/model/service/service_test.go
+++ b/domain/model/service/service_test.go
@@ -61,6 +61,28 @@ func (s *serviceSuite) SetUpTest(c *gc.C) {
 	}
 }
 
+// TestControllerModelNameChange is here to make the breaker of this test stop
+// and think. There exists buisness logic in this package that is very dependent
+// on the well known value defined in [coremodel.ControllerModelName]. If this
+// test has broken it means this value has changed and you could be at risk of
+// breaking Juju. Please consider the buisness logic in this package and if
+// changing this well known value is handled correctly for both legacy and
+// future Juju versions!!!
+func (s *serviceSuite) TestControllerModelNameChange(c *gc.C) {
+	c.Assert(coremodel.ControllerModelName, gc.Equals, "controller")
+}
+
+// TestControllerModelOwnerUsername is here to make the breaker of this test
+// stop and think. There exists buisness logic in this package that is very
+// dependent on the well known value defined in
+// [coremodel.ControllerModelOwnerUsername]. If this test has broken it means
+// this value has changed and you could be at risk of breaking Juju. Please
+// consider the buisness logic in this package and if changing this well known
+// value is handled correctly for both legacy and future Juju versions!!!
+func (s *serviceSuite) TestControllerModelOwnerUsername(c *gc.C) {
+	c.Assert(coremodel.ControllerModelOwnerUsername, gc.Equals, "admin")
+}
+
 func (s *serviceSuite) TestCreateModelInvalidArgs(c *gc.C) {
 	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder(), loggertesting.WrapCheckLog(c))
 	_, _, err := svc.CreateModel(context.Background(), model.ModelCreationArgs{})
@@ -757,4 +779,59 @@ func (s *serviceSuite) TestImportModel(c *gc.C) {
 
 	_, exists := s.state.models[modelID]
 	c.Assert(exists, jc.IsTrue)
+}
+
+// TestControllerModelNotFound is testing that if we ask the service for the
+// controller model and it doesn't exist we get back a [modelerrors.NotFound]
+// error. This should be a very unlikely scenario but we need to test the
+// schemantics.
+func (s *serviceSuite) TestControllerModelNotFound(c *gc.C) {
+	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder(), loggertesting.WrapCheckLog(c))
+	_, err := svc.ControllerModel(context.Background())
+	c.Check(err, jc.ErrorIs, modelerrors.NotFound)
+}
+
+// TestControllerModel is asserting the happy path of [Service.ControllerModel].
+func (s *serviceSuite) TestControllerModel(c *gc.C) {
+	adminUUID := usertesting.GenUserUUID(c)
+	s.state.users[adminUUID] = coremodel.ControllerModelOwnerUsername
+
+	cred := credential.Key{
+		Cloud: "aws",
+		Name:  "foobar",
+		Owner: adminUUID.String(),
+	}
+	s.state.clouds["aws"] = dummyStateCloud{
+		Credentials: map[string]credential.Key{
+			cred.String(): cred,
+		},
+		Regions: []string{"myregion"},
+	}
+
+	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder(), loggertesting.WrapCheckLog(c))
+	modelID, activator, err := svc.CreateModel(context.Background(), model.ModelCreationArgs{
+		AgentVersion: jujuversion.Current,
+		Cloud:        "aws",
+		CloudRegion:  "myregion",
+		Credential:   cred,
+		Owner:        adminUUID,
+		Name:         coremodel.ControllerModelName,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(activator(context.Background()), jc.ErrorIsNil)
+
+	model, err := svc.ControllerModel(context.Background())
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(model, gc.DeepEquals, coremodel.Model{
+		Name:         coremodel.ControllerModelName,
+		Life:         life.Alive,
+		UUID:         modelID,
+		ModelType:    coremodel.IAAS,
+		AgentVersion: jujuversion.Current,
+		Cloud:        "aws",
+		CloudRegion:  "myregion",
+		Credential:   cred,
+		Owner:        adminUUID,
+		OwnerName:    coremodel.ControllerModelOwnerUsername,
+	})
 }

--- a/domain/model/service/service_test.go
+++ b/domain/model/service/service_test.go
@@ -62,10 +62,10 @@ func (s *serviceSuite) SetUpTest(c *gc.C) {
 }
 
 // TestControllerModelNameChange is here to make the breaker of this test stop
-// and think. There exists buisness logic in this package that is very dependent
+// and think. There exists business logic in this package that is very dependent
 // on the well known value defined in [coremodel.ControllerModelName]. If this
 // test has broken it means this value has changed and you could be at risk of
-// breaking Juju. Please consider the buisness logic in this package and if
+// breaking Juju. Please consider the business logic in this package and if
 // changing this well known value is handled correctly for both legacy and
 // future Juju versions!!!
 func (s *serviceSuite) TestControllerModelNameChange(c *gc.C) {
@@ -73,11 +73,11 @@ func (s *serviceSuite) TestControllerModelNameChange(c *gc.C) {
 }
 
 // TestControllerModelOwnerUsername is here to make the breaker of this test
-// stop and think. There exists buisness logic in this package that is very
+// stop and think. There exists business logic in this package that is very
 // dependent on the well known value defined in
 // [coremodel.ControllerModelOwnerUsername]. If this test has broken it means
 // this value has changed and you could be at risk of breaking Juju. Please
-// consider the buisness logic in this package and if changing this well known
+// consider the business logic in this package and if changing this well known
 // value is handled correctly for both legacy and future Juju versions!!!
 func (s *serviceSuite) TestControllerModelOwnerUsername(c *gc.C) {
 	c.Assert(coremodel.ControllerModelOwnerUsername, gc.Equals, "admin")

--- a/domain/model/service/state_test.go
+++ b/domain/model/service/state_test.go
@@ -150,6 +150,19 @@ func (d *dummyState) GetModel(
 	return info, nil
 }
 
+func (d *dummyState) GetModelByName(
+	_ context.Context,
+	userName string,
+	modelName string,
+) (coremodel.Model, error) {
+	for _, model := range d.models {
+		if model.OwnerName == userName && model.Name == modelName {
+			return model, nil
+		}
+	}
+	return coremodel.Model{}, modelerrors.NotFound
+}
+
 func (d *dummyState) GetModelType(
 	_ context.Context,
 	uuid coremodel.UUID,


### PR DESCRIPTION
Juju installs itself into a well known model at bootstrap time called the "controller" model. The uuid for this model is unknown and changes from controller to controller. There exists cases where we need to extract this model for use. The only way to reliably do this is to find the model based on the well known name and user that owns the model.

This commit introduces model service helper for retrieving the controller model and hiding the specifics of how this is achieved from the caller.

There is currently no uses of this service. This is an implementation to hopefully address a need for @manadart 

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

There is no call sites for this code at the moment so manual testing won't do anything. Unit tests have been implemented to assert contracts on offer.

## Documentation changes

N/A

## Links

**Jira card:** JUJU-6139

