### PR TITLE
Revert to rootful containers to preserve pre-3.5 behaviour.

### DIFF
--- a/caas/kubernetes/provider/application/application.go
+++ b/caas/kubernetes/provider/application/application.go
@@ -1502,6 +1502,12 @@ func (a *app) ApplicationPodSpec(config caas.ApplicationConfig) (*corev1.PodSpec
 				RunAsGroup: pointer.Int64(constants.JujuGroupID),
 			}
 		}
+	} else {
+		// Pre-3.5 logic.
+		charmContainer.SecurityContext = &corev1.SecurityContext{
+			RunAsUser:  pointer.Int64(0),
+			RunAsGroup: pointer.Int64(0),
+		}
 	}
 
 	containerExtraEnv := []corev1.EnvVar{{
@@ -1573,6 +1579,12 @@ func (a *app) ApplicationPodSpec(config caas.ApplicationConfig) (*corev1.PodSpec
 			}
 			if v.Gid != nil {
 				container.SecurityContext.RunAsGroup = pointer.Int64(int64(*v.Gid))
+			}
+		} else {
+			// Pre-3.5 logic.
+			container.SecurityContext = &corev1.SecurityContext{
+				RunAsUser:  pointer.Int64(0),
+				RunAsGroup: pointer.Int64(0),
 			}
 		}
 		if v.Image.Password != "" {
@@ -1691,6 +1703,9 @@ func (a *app) ApplicationPodSpec(config caas.ApplicationConfig) (*corev1.PodSpec
 				RunAsGroup: pointer.Int64(constants.JujuGroupID),
 			}
 		}
+	} else {
+		// Pre-3.5 logic.
+		charmInitContainer.SecurityContext = nil
 	}
 
 	automountToken := true

--- a/caas/kubernetes/provider/application/application_test.go
+++ b/caas/kubernetes/provider/application/application_test.go
@@ -643,6 +643,10 @@ func getPodSpec() corev1.PodSpec {
 					MountPath: "path/to/here",
 				},
 			},
+			SecurityContext: &corev1.SecurityContext{
+				RunAsUser:  int64Ptr(0),
+				RunAsGroup: int64Ptr(0),
+			},
 		}, {
 			Name:            "gitlab",
 			ImagePullPolicy: corev1.PullIfNotPresent,
@@ -710,6 +714,10 @@ func getPodSpec() corev1.PodSpec {
 					MountPath: "path/to/here",
 				},
 			},
+			SecurityContext: &corev1.SecurityContext{
+				RunAsUser:  int64Ptr(0),
+				RunAsGroup: int64Ptr(0),
+			},
 		}, {
 			Name:            "nginx",
 			ImagePullPolicy: corev1.PullIfNotPresent,
@@ -772,6 +780,10 @@ func getPodSpec() corev1.PodSpec {
 					MountPath: "/charm/container",
 					SubPath:   "charm/containers/nginx",
 				},
+			},
+			SecurityContext: &corev1.SecurityContext{
+				RunAsUser:  int64Ptr(0),
+				RunAsGroup: int64Ptr(0),
 			},
 		}},
 		Volumes: []corev1.Volume{


### PR DESCRIPTION
This restores compatibility with charms made for 3.4 and prior. 
This behaviour is now almost identical to 3.5.0 behaviour except importantly the charm-init container does not have a explicit security context.

## QA steps

Steps in both:
#17415
#17070

Additional steps:
`juju deploy jupyter-ui --channel 1.8/stable --trust`

```
juju status
Model     Controller  Cloud/Region  Version  SLA          Timestamp
kubeflow  minikube    minikube      3.5.2    unsupported  14:38:16+10:00

App                 Version  Status  Scale  Charm               Channel     Rev  Address         Exposed  Message
jupyter-ui                   active      1  jupyter-ui          1.8/stable  858  10.97.31.15     no
kubeflow-dashboard           active      1  kubeflow-dashboard  1.8/edge    497  10.107.252.185  no
kubeflow-profiles            active      1  kubeflow-profiles   1.8/stable  355  10.101.158.241  no
rootlesstest                 active      1  rootlesstest                      1  10.108.79.85    no

Unit                   Workload  Agent  Address      Ports  Message
jupyter-ui/0*          active    idle   10.244.0.13
kubeflow-dashboard/0*  active    idle   10.244.0.14
kubeflow-profiles/0*   active    idle   10.244.0.16
rootlesstest/0*        active    idle   10.244.0.15
```

## Documentation changes

N/A

## Links

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2067636

**Jira card:** JUJU-6119