### PR TITLE
Feat(migration): Add `Name` method to model migration operations

### DIFF
--- a/core/modelmigration/op_mock_test.go
+++ b/core/modelmigration/op_mock_test.go
@@ -78,6 +78,44 @@ func (c *MockOperationExecuteCall) DoAndReturn(f func(context.Context, descripti
 	return c
 }
 
+// Name mocks base method.
+func (m *MockOperation) Name() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Name")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Name indicates an expected call of Name.
+func (mr *MockOperationMockRecorder) Name() *MockOperationNameCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockOperation)(nil).Name))
+	return &MockOperationNameCall{Call: call}
+}
+
+// MockOperationNameCall wrap *gomock.Call
+type MockOperationNameCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockOperationNameCall) Return(arg0 string) *MockOperationNameCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockOperationNameCall) Do(f func() string) *MockOperationNameCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockOperationNameCall) DoAndReturn(f func() string) *MockOperationNameCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // Rollback mocks base method.
 func (m *MockOperation) Rollback(arg0 context.Context, arg1 description.Model) error {
 	m.ctrl.T.Helper()

--- a/core/modelmigration/package_test.go
+++ b/core/modelmigration/package_test.go
@@ -31,5 +31,6 @@ func (*ImportTest) TestImports(c *gc.C) {
 	// If this test fails with a non-core package, please check the dependencies.
 	c.Assert(found, jc.SameContents, []string{
 		"core/database",
+		"core/logger",
 	})
 }

--- a/domain/application/modelmigration/import.go
+++ b/domain/application/modelmigration/import.go
@@ -46,6 +46,11 @@ type ImportService interface {
 	CreateApplication(context.Context, string, service.AddApplicationParams, ...service.AddUnitParams) error
 }
 
+// Name returns the name of this operation.
+func (i *importOperation) Name() string {
+	return "import applications"
+}
+
 func (i *importOperation) Setup(scope modelmigration.Scope) error {
 	i.service = service.NewService(
 		state.NewState(scope.ModelDB(), i.logger),

--- a/domain/blockdevice/modelmigration/export.go
+++ b/domain/blockdevice/modelmigration/export.go
@@ -38,6 +38,11 @@ type exportOperation struct {
 	service ExportService
 }
 
+// Name returns the name of this operation.
+func (e *exportOperation) Name() string {
+	return "export model configuration"
+}
+
 // Setup implements Operation.
 func (e *exportOperation) Setup(scope modelmigration.Scope) error {
 	// We must not use a watcher during migration, so it's safe to pass a

--- a/domain/blockdevice/modelmigration/import.go
+++ b/domain/blockdevice/modelmigration/import.go
@@ -42,6 +42,11 @@ type importOperation struct {
 	service ImportService
 }
 
+// Name returns the name of this operation.
+func (i *importOperation) Name() string {
+	return "import block devices"
+}
+
 // Setup implements Operation.
 func (i *importOperation) Setup(scope modelmigration.Scope) error {
 	// We must not use a watcher during migration, so it's safe to pass a

--- a/domain/credential/modelmigration/export.go
+++ b/domain/credential/modelmigration/export.go
@@ -40,6 +40,11 @@ type exportOperation struct {
 	service ExportService
 }
 
+// Name returns the name of this operation.
+func (e *exportOperation) Name() string {
+	return "export cloud credential"
+}
+
 // Setup implements Operation.
 func (e *exportOperation) Setup(scope modelmigration.Scope) error {
 	// We must not use a watcher during migration, so it's safe to pass a

--- a/domain/credential/modelmigration/import.go
+++ b/domain/credential/modelmigration/import.go
@@ -45,6 +45,11 @@ type importOperation struct {
 	service ImportService
 }
 
+// Name returns the name of this operation.
+func (i *importOperation) Name() string {
+	return "import cloud credential"
+}
+
 // Setup implements Operation.
 func (i *importOperation) Setup(scope modelmigration.Scope) error {
 	// We must not use a watcher during migration, so it's safe to pass a

--- a/domain/externalcontroller/modelmigration/export.go
+++ b/domain/externalcontroller/modelmigration/export.go
@@ -46,6 +46,11 @@ type exportOperation struct {
 	service ExportService
 }
 
+// Name returns the name of this operation.
+func (e *exportOperation) Name() string {
+	return "export external controllers"
+}
+
 func (e *exportOperation) Setup(scope modelmigration.Scope) error {
 	// We must not use a watcher during migration, so it's safe to pass a
 	// nil watcher factory.

--- a/domain/externalcontroller/modelmigration/import.go
+++ b/domain/externalcontroller/modelmigration/import.go
@@ -36,6 +36,11 @@ type importOperation struct {
 	service ImportService
 }
 
+// Name returns the name of this operation.
+func (i *importOperation) Name() string {
+	return "import external controllers"
+}
+
 func (i *importOperation) Setup(scope modelmigration.Scope) error {
 	// We must not use a watcher during migration, so it's safe to pass a
 	// nil watcher factory.

--- a/domain/lease/modelmigration/import.go
+++ b/domain/lease/modelmigration/import.go
@@ -49,6 +49,11 @@ type importOperation struct {
 	logger  logger.Logger
 }
 
+// Name returns the name of this operation.
+func (i *importOperation) Name() string {
+	return "import leases"
+}
+
 // Setup is called before the operation is executed. It should return an
 // error if the operation cannot be performed.
 func (o *importOperation) Setup(scope modelmigration.Scope) error {

--- a/domain/machine/modelmigration/import.go
+++ b/domain/machine/modelmigration/import.go
@@ -41,6 +41,11 @@ type ImportService interface {
 	CreateMachine(context.Context, string) error
 }
 
+// Name returns the name of this operation.
+func (i *importOperation) Name() string {
+	return "import machines"
+}
+
 func (i *importOperation) Setup(scope modelmigration.Scope) error {
 	i.service = service.NewService(state.NewState(scope.ModelDB(), i.logger))
 	return nil

--- a/domain/model/modelmigration/import.go
+++ b/domain/model/modelmigration/import.go
@@ -99,6 +99,11 @@ type importOperation struct {
 	logger logger.Logger
 }
 
+// Name returns the name of this operation.
+func (i *importOperation) Name() string {
+	return "import model"
+}
+
 // Setup is responsible for taking the model migration scope and creating the
 // needed services used during import.
 func (i *importOperation) Setup(scope modelmigration.Scope) error {

--- a/domain/model/modelmigration/import_test.go
+++ b/domain/model/modelmigration/import_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/juju/juju/domain/model"
 	modelerrors "github.com/juju/juju/domain/model/errors"
 	"github.com/juju/juju/environs/config"
+	loggertesting "github.com/juju/juju/internal/logger/testing"
 	"github.com/juju/juju/internal/uuid"
 	"github.com/juju/juju/testing"
 	jujuversion "github.com/juju/juju/version"
@@ -184,7 +185,10 @@ func (i *importSuite) TestModelCreate(c *gc.C) {
 		readOnlyModelServiceFunc: func(_ coremodel.UUID) ReadOnlyModelService { return i.readOnlyModelService },
 	}
 
-	coordinator := modelmigration.NewCoordinator(modelmigrationtesting.IgnoredSetupOperation(importOp))
+	coordinator := modelmigration.NewCoordinator(
+		loggertesting.WrapCheckLog(c),
+		modelmigrationtesting.IgnoredSetupOperation(importOp),
+	)
 	err = coordinator.Perform(context.Background(), modelmigration.NewScope(nil, nil, nil), model)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(activated, jc.IsTrue)
@@ -265,7 +269,10 @@ func (i *importSuite) TestModelCreateRollbacksOnFailure(c *gc.C) {
 		readOnlyModelServiceFunc: func(_ coremodel.UUID) ReadOnlyModelService { return i.readOnlyModelService },
 	}
 
-	coordinator := modelmigration.NewCoordinator(modelmigrationtesting.IgnoredSetupOperation(importOp))
+	coordinator := modelmigration.NewCoordinator(
+		loggertesting.WrapCheckLog(c),
+		modelmigrationtesting.IgnoredSetupOperation(importOp),
+	)
 	err = coordinator.Perform(context.Background(), modelmigration.NewScope(nil, nil, nil), model)
 	c.Check(err, gc.ErrorMatches, `.*boom.*`)
 
@@ -342,7 +349,10 @@ func (i *importSuite) TestModelCreateRollbacksOnFailureIgnoreNotFoundModel(c *gc
 		readOnlyModelServiceFunc: func(_ coremodel.UUID) ReadOnlyModelService { return i.readOnlyModelService },
 	}
 
-	coordinator := modelmigration.NewCoordinator(modelmigrationtesting.IgnoredSetupOperation(importOp))
+	coordinator := modelmigration.NewCoordinator(
+		loggertesting.WrapCheckLog(c),
+		modelmigrationtesting.IgnoredSetupOperation(importOp),
+	)
 	err = coordinator.Perform(context.Background(), modelmigration.NewScope(nil, nil, nil), model)
 	c.Check(err, gc.ErrorMatches, `.*boom.*`)
 
@@ -419,7 +429,10 @@ func (i *importSuite) TestModelCreateRollbacksOnFailureIgnoreNotFoundReadOnlyMod
 		readOnlyModelServiceFunc: func(_ coremodel.UUID) ReadOnlyModelService { return i.readOnlyModelService },
 	}
 
-	coordinator := modelmigration.NewCoordinator(modelmigrationtesting.IgnoredSetupOperation(importOp))
+	coordinator := modelmigration.NewCoordinator(
+		loggertesting.WrapCheckLog(c),
+		modelmigrationtesting.IgnoredSetupOperation(importOp),
+	)
 	err = coordinator.Perform(context.Background(), modelmigration.NewScope(nil, nil, nil), model)
 	c.Check(err, gc.ErrorMatches, `.*boom.*`)
 

--- a/domain/modelconfig/modelmigration/export.go
+++ b/domain/modelconfig/modelmigration/export.go
@@ -36,6 +36,11 @@ type exportOperation struct {
 	service ExportService
 }
 
+// Name returns the name of this operation.
+func (e *exportOperation) Name() string {
+	return "export model configuration"
+}
+
 // Setup the export operation, this will ensure the service is created
 // and ready to be used.
 func (e *exportOperation) Setup(scope modelmigration.Scope) error {

--- a/domain/modelconfig/modelmigration/import.go
+++ b/domain/modelconfig/modelmigration/import.go
@@ -46,6 +46,11 @@ type importOperation struct {
 	defaultsProvider service.ModelDefaultsProvider
 }
 
+// Name returns the name of this operation.
+func (i *importOperation) Name() string {
+	return "import model configuration"
+}
+
 // Setup the import operation, this will ensure the service is created
 // and ready to be used.
 func (i *importOperation) Setup(scope modelmigration.Scope) error {

--- a/domain/network/modelmigration/export.go
+++ b/domain/network/modelmigration/export.go
@@ -39,6 +39,11 @@ type exportOperation struct {
 	logger        logger.Logger
 }
 
+// Name returns the name of this operation.
+func (e *exportOperation) Name() string {
+	return "export networks"
+}
+
 // Setup implements Operation.
 func (e *exportOperation) Setup(scope modelmigration.Scope) error {
 	e.exportService = service.NewService(

--- a/domain/network/modelmigration/import.go
+++ b/domain/network/modelmigration/import.go
@@ -44,6 +44,11 @@ type importOperation struct {
 	logger        logger.Logger
 }
 
+// Name returns the name of this operation.
+func (i *importOperation) Name() string {
+	return "import networks"
+}
+
 // Setup implements Operation.
 func (i *importOperation) Setup(scope modelmigration.Scope) error {
 	i.importService = service.NewService(

--- a/domain/storage/modelmigration/export.go
+++ b/domain/storage/modelmigration/export.go
@@ -42,6 +42,11 @@ type exportOperation struct {
 	logger   logger.Logger
 }
 
+// Name returns the name of this operation.
+func (e *exportOperation) Name() string {
+	return "export storage"
+}
+
 // Setup implements Operation.
 func (e *exportOperation) Setup(scope modelmigration.Scope) error {
 	e.service = service.NewService(

--- a/domain/storage/modelmigration/import.go
+++ b/domain/storage/modelmigration/import.go
@@ -44,6 +44,11 @@ type importOperation struct {
 	logger   logger.Logger
 }
 
+// Name returns the name of this operation.
+func (i *importOperation) Name() string {
+	return "import storage"
+}
+
 // Setup implements Operation.
 func (i *importOperation) Setup(scope modelmigration.Scope) error {
 	i.service = service.NewService(

--- a/internal/migration/migration.go
+++ b/internal/migration/migration.go
@@ -103,7 +103,7 @@ func (e *ModelExporter) Export(ctx context.Context, model description.Model) (de
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	coordinator := modelmigration.NewCoordinator()
+	coordinator := modelmigration.NewCoordinator(e.logger)
 	migrations.ExportOperations(coordinator, registry, e.logger)
 	if err := coordinator.Perform(ctx, e.scope, model); err != nil {
 		return nil, errors.Trace(err)
@@ -190,7 +190,7 @@ func (i *ModelImporter) ImportModel(ctx context.Context, bytes []byte) (*state.M
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
-	coordinator := modelmigration.NewCoordinator()
+	coordinator := modelmigration.NewCoordinator(i.logger)
 	migrations.ImportOperations(coordinator, i.logger, modelDefaultsProvider, registry)
 	if err := coordinator.Perform(ctx, i.scope(modelUUID.String()), model); err != nil {
 		return nil, nil, errors.Trace(err)


### PR DESCRIPTION
4 -> 4 migrations have been observed to hang indefinitely. 

Analysis showed that this was occurring within the migration coordinator's iteration through the import operations, but insufficient progress logging means that we have no feedback as to the stalled stage.

Here we add a name method to migration operations, which is called by the coordinator to log each operation that it is commencing. We also log on the _target_ controller in addition to returning errors to the source. This should aid in any future diagnostics.

## QA steps

As of right now, migrations still hang. Accessing the target controller directly should now give more step details.
From Harry's comment below:
```
machine-0: 14:00:11 INFO juju.apiserver running operation: import leases
machine-0: 14:00:11 INFO juju.apiserver running operation: import external controllers
machine-0: 14:00:11 INFO juju.apiserver running operation: import cloud credentials
machine-0: 14:00:11 INFO juju.apiserver running operation: import model
machine-0: 14:00:11 ERROR juju.apiserver import failed: execute operation import model: importing model "test" with id "f3d7a50f-3f75-42d6-83b1-0879a12e74aa" during migration: cannot import model with id "f3d7a50f-3f75-42d6-83b1-0879a12e74aa", agent version cannot be zero: agent version not supported
machine-0: 14:00:11 INFO juju.apiserver rolling back operation: import model
```

## Documentation changes

None.

## Links

**Jira card:** [JUJU-6147](https://warthogs.atlassian.net/browse/JUJU-6147)



[JUJU-6147]: https://warthogs.atlassian.net/browse/JUJU-6147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ