### PR TITLE
fix(waitfor): nil pointer exception in wait-for

### DIFF
--- a/cmd/juju/waitfor/unit.go
+++ b/cmd/juju/waitfor/unit.go
@@ -230,6 +230,11 @@ func (m UnitScope) GetIdents() []string {
 func (m UnitScope) GetIdentValue(name string) (query.Box, error) {
 	m.ctx.RecordIdent(name)
 
+	// UnitInfo could be nil - handle it here to avoid nil pointer dereference
+	if m.UnitInfo == nil {
+		return nil, errors.New("internal error: UnitInfo is missing")
+	}
+
 	switch name {
 	case "name":
 		return query.NewString(m.UnitInfo.Name), nil

--- a/cmd/juju/waitfor/unit_test.go
+++ b/cmd/juju/waitfor/unit_test.go
@@ -97,11 +97,26 @@ func (s *unitScopeSuite) TestGetIdentValue(c *gc.C) {
 }
 
 func (s *unitScopeSuite) TestGetIdentValueError(c *gc.C) {
-	scope := UnitScope{
-		ctx:      MakeScopeContext(),
+	tests := []struct {
+		Field    string
+		UnitInfo *params.UnitInfo
+		Err      string
+	}{{
+		Field:    "bad",
 		UnitInfo: &params.UnitInfo{},
+		Err:      `"bad" on UnitInfo.*`,
+	}, {
+		Field:    "application",
+		UnitInfo: nil,
+		Err:      "internal error: UnitInfo is missing",
+	}}
+	for _, test := range tests {
+		scope := UnitScope{
+			ctx:      MakeScopeContext(),
+			UnitInfo: test.UnitInfo,
+		}
+		result, err := scope.GetIdentValue(test.Field)
+		c.Assert(err, gc.ErrorMatches, test.Err)
+		c.Assert(result, gc.IsNil)
 	}
-	result, err := scope.GetIdentValue("bad")
-	c.Assert(err, gc.ErrorMatches, `"bad" on UnitInfo.*`)
-	c.Assert(result, gc.IsNil)
 }


### PR DESCRIPTION
<!-- Why this change is needed and what it does. -->

Occasionally, we see `juju wait-for` panic while waiting for something to come up, e.g. [lp#2040554](https://bugs.launchpad.net/juju/+bug/2040554). The panic happened on this line:
https://github.com/juju/juju/blob/211bbd16cda9e96bc8d19421b07a4fa1b280061d/cmd/juju/waitfor/unit.go#L259

This could only happen if `m.UnitInfo` is nil, which is possible due to AllWatcher backing state, where the status is not known. To guard against this, add a pre-check to return "unknown" if `m.UnitInfo` is nil. Add a unit test covering this case.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

<!-- Describe steps to verify that the change works. -->

Due to the intermittent nature of this bug, it is very hard to manually QA.

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2040554

**Jira card:** JUJU-6114

