### PR TITLE
Fix aws provider name to ec2 in manual test

### DIFF
--- a/tests/suites/manual/deploy_manual.sh
+++ b/tests/suites/manual/deploy_manual.sh
@@ -13,7 +13,7 @@ test_deploy_manual() {
 		"lxd")
 			run "run_deploy_manual_lxd"
 			;;
-		"aws")
+		"ec2")
 			run "run_deploy_manual_aws"
 			;;
 		*)

--- a/tests/suites/manual/util.sh
+++ b/tests/suites/manual/util.sh
@@ -25,7 +25,7 @@ launch_and_wait_addr_ec2() {
 	aws ec2 wait instance-running --instance-ids "${instance_id}"
 	sleep 10
 
-	address=$(aws ec2 describe-instances --instance-ids "${instance_id}" --query 'Reservations[0].Instances[0].PublicDnsName' --output text)
+	address=$(aws ec2 describe-instances --instance-ids "${instance_id}" --query 'Reservations[0].Instances[0].PublicIpAddress' --output text)
 
 	# shellcheck disable=SC2086
 	eval $addr_result="'${address}'"


### PR DESCRIPTION
In a previous PR, we accidentally set the provider to the wrong string "aws" instead of "ec2" like it is everywhere else

Fix this

Also, as a fly by, change aws query to look for "PublicIpAddress" instead of "PublicDnsName". Under some circumstances, PublicDnsName is empty

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

```
./main.sh -v -c aws -p ec2 -R eu-west-2 manual
```