### PR TITLE
Denote noble as a supported base

### DIFF
--- a/core/base/supported.go
+++ b/core/base/supported.go
@@ -387,6 +387,7 @@ var ubuntuSeries = map[SeriesName]seriesVersion{
 		WorkloadType: ControllerWorkloadType,
 		Version:      "24.04",
 		LTS:          true,
+		Supported:    true,
 		ESMSupported: true,
 	},
 }


### PR DESCRIPTION
Our system to automatically pick up when Ubuntu versions become unsupported doesn't make unsupported bases supported.

We haven't noticed this yet since we marked noble as ESMSupported, which usually we '||' with Supported. However, this is not the case always which leads to some usual bugs

i.e. upgrade-controller thinks noble is deprecated, so will refuse to upgrade a controller with a noble machine in a model

This means for all versions of Juju 3 as of writing:
```
$ juju bootstrap lxd lxd
$ juju add-model m
$ juju add-machine --base ubuntu@24.04
$ juju upgrade-controller --built-agent
ERROR cannot upgrade to "foo" due to issues with these models:
"admin/m":
- the model hosts deprecated ubuntu machine(s): ubuntu@24.04(1)
```

This is bad! Fix this by marking Noble as supported

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made

## QA steps

```
$ juju bootstrap lxd lxd
$ juju add-model m
$ juju add-machine --base ubuntu@24.04
$ juju upgrade-controller --built-agent
no prepackaged agent binaries available, using local agent binary 3.4.4.2 (built from source)
best version:
    3.4.4.2
started upgrade to 3.4.4.2
```

## Links

LP bug: https://bugs.launchpad.net/juju/+bug/2068671