### PR TITLE
fix: distro-info upgrade getting stuck

### DIFF
--- a/container/lxd/initialisation_test.go
+++ b/container/lxd/initialisation_test.go
@@ -67,8 +67,8 @@ func (s *InitialiserSuite) SetUpTest(c *gc.C) {
 // with an identical signature to manager.RunCommandWithRetry which saves each
 // command it receives in a slice and always returns no output, error code 0
 // and a nil error.
-func getMockRunCommandWithRetry(calledCmds *[]string) func(string, manager.Retryable, manager.RetryPolicy) (string, int, error) {
-	return func(cmd string, _ manager.Retryable, _ manager.RetryPolicy) (string, int, error) {
+func getMockRunCommandWithRetry(calledCmds *[]string) func(string, manager.Retryable, manager.RetryPolicy, []string) (string, int, error) {
+	return func(cmd string, _ manager.Retryable, _ manager.RetryPolicy, _ []string) (string, int, error) {
 		*calledCmds = append(*calledCmds, cmd)
 		return "", 0, nil
 	}

--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/juju/names/v5 v5.0.0
 	github.com/juju/naturalsort v1.0.0
 	github.com/juju/os/v2 v2.2.5
-	github.com/juju/packaging/v3 v3.0.0
+	github.com/juju/packaging/v3 v3.1.0
 	github.com/juju/persistent-cookiejar v1.0.0
 	github.com/juju/proxy v1.0.0
 	github.com/juju/pubsub/v2 v2.0.0

--- a/go.sum
+++ b/go.sum
@@ -547,8 +547,8 @@ github.com/juju/naturalsort v1.0.0 h1:kGmUUy3h8mJ5/SJYaqKOBR3f3owEd5R52Lh+Tjg/dN
 github.com/juju/naturalsort v1.0.0/go.mod h1:Zqa/vGkXr78k47zM6tFmU9phhxKz/PIdqBzpLhJ86zc=
 github.com/juju/os/v2 v2.2.5 h1:Ayw9aC7axKtGgzy3dFRKx84FxasfISMege0iYDsH6io=
 github.com/juju/os/v2 v2.2.5/go.mod h1:igGQLjgRSwUery5ZhV/1pZjZkMwnfkAwWCwh5ZfIg+c=
-github.com/juju/packaging/v3 v3.0.0 h1:ZzuHhR8Ql9z2oeQ0m73x6k58PW65Cgk5wR9Yc1exoOI=
-github.com/juju/packaging/v3 v3.0.0/go.mod h1:WXh/SXqh1du8SFzwb1KC+yZuV4Qc4alWP3MEPqFX9Lw=
+github.com/juju/packaging/v3 v3.1.0 h1:P5RyXSKVLNWqbpr8XcdDI17wYdTGYg7KTHce8DMeoSk=
+github.com/juju/packaging/v3 v3.1.0/go.mod h1:WXh/SXqh1du8SFzwb1KC+yZuV4Qc4alWP3MEPqFX9Lw=
 github.com/juju/persistent-cookiejar v1.0.0 h1:Ag7+QLzqC2m+OYXy2QQnRjb3gTkEBSZagZ6QozwT3EQ=
 github.com/juju/persistent-cookiejar v1.0.0/go.mod h1:zrbmo4nBKaiP/Ez3F67ewkMbzGYfXyMvRtbOfuAwG0w=
 github.com/juju/postgrestest v1.1.0/go.mod h1:/n17Y2T6iFozzXwSCO0JYJ5gSiz2caEtSwAjh/uLXDM=


### PR DESCRIPTION
This brings the `DEBIAN_FRONTEND=noninteractive` env variable to apt-get install (from https://github.com/juju/packaging/pull/24), which is needed for
https://bugs.launchpad.net/juju/+bug/2011637 for auto upgrades/restarts.

<!-- Why this change is needed and what it does. -->

## QA steps

This is a change in the dependency (and it's QAed when it landed [over there](https://github.com/juju/packaging/pull/24) on 3.4), however, it should be QAed on 3.5 as well.

This is for the lp bug https://bugs.launchpad.net/juju/+bug/2011637, and to QA this, we need to trigger an upgrade.

`juju bootstrap localhost testme`

After the controller is up, get in there and downgrade the `distro-info` (to be upgraded later by `juju upgrade-controller`:

```
$ juju ssh -m controller 0
 

ubuntu@juju-07b4a2-0:~$ apt list distro-info -a
Listing... Done
distro-info/jammy-updates,now 1.1ubuntu0.2 amd64 [installed,automatic] <------- 1.1ubuntu0.2 is installed
distro-info/jammy 1.1build1 amd64

# manually downgrade to 1.1build1
ubuntu@juju-07b4a2-0:~$ sudo apt install distro-info=1.1build1

ubuntu@juju-07b4a2-0:~$ apt list distro-info -a
Listing... Done
distro-info/jammy-updates 1.1ubuntu0.2 amd64 [upgradable from: 1.1build1]
distro-info/jammy,now 1.1build1 amd64 [installed,upgradable to: 1.1ubuntu0.2]
```

Now we need to trigger an upgrade on the Juju side, for this, edit the `version/version.go` with `3.5.3` (don't bump the minor, just the patch):
```
// The presence and format of this constant is very important.
// The debian/rules build recipe uses this value for the version
// number of the release package.
const version = "3.5.3"
```

Build and run an upgrade:
```
$ make build && make install
$ juju upgrade-controller --build-agent
no prepackaged agent binaries available, using local agent binary 3.5.3.2 (built from source)
best version:
    3.5.3.2
started upgrade to 3.5.3.2
```

Now take a look at the `juju debug-log -m controller` to see if you can spot that the `updating distro-info` succeeded:
```
...
machine-0: 22:05:01 INFO juju.worker.upgradesteps checking that upgrade can proceed
machine-0: 22:05:01 INFO juju.upgrade updating distro-info
machine-0: 22:05:01 INFO juju.packaging.manager Running: apt-get --option=Dpkg::Options::=--force-confold --option=Dpkg::Options::=--force-unsafe-io --assume-yes --quiet update
machine-0: 22:05:04 INFO juju.packaging.manager Running: apt-get --option=Dpkg::Options::=--force-confold --option=Dpkg::Options::=--force-unsafe-io --assume-yes --quiet install distro-info
machine-0: 22:05:08 INFO juju.worker.upgradesteps signalling that this controller is ready for upgrade
machine-0: 22:05:08 INFO juju.worker.upgradesteps waiting for other controllers to be ready for upgrade
machine-0: 22:05:08 INFO juju.worker.upgradesteps finished waiting - all controllers are ready to run upgrade steps
machine-0: 22:05:08 INFO juju.worker.upgradesteps starting upgrade from 3.5.2.1 to 3.5.3.2 for "machine-0"
machine-0: 22:05:08 INFO juju.upgrade All upgrade steps completed successfully
machine-0: 22:05:08 INFO juju.worker.upgradesteps upgrade to 3.5.3.2 completed successfully.
...
```

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2011637

**Jira card:** JUJU-6135

