### PR TITLE
fix: leadership tracker worker killed by uniter

### DIFF
--- a/worker/uniter/uniter.go
+++ b/worker/uniter/uniter.go
@@ -305,8 +305,8 @@ func newUniter(uniterParams *UniterParams) func() (worker.Worker, error) {
 				return u.loop(uniterParams.UnitTag)
 			},
 		}
-		if u.modelType == model.CAAS {
-			// For CAAS models, make sure the leadership tracker is killed when the Uniter
+		if u.modelType == model.CAAS && !uniterParams.Sidecar {
+			// For podspec units, make sure the leadership tracker is killed when the Uniter
 			// dies.
 			plan.Init = append(plan.Init, u.leadershipTracker)
 		}


### PR DESCRIPTION
A mistake was made when sidecar charms were introduced since this podspec/operator behaviour of Killing the leadership tracker worker when the uniter exited was enabled for all CAAS units.

This is problematic because the leadership tracker worker's lifecycle is already managed by the dependency engine for the unit agent.

Since the leadership tracker worker would exit cleanly, the dependency engine would not restart it. With the uniter clearly depending on the leadership tracker, the unit was not able to start again.

## QA steps

- Bootstrap k8s
- Deploy a sidecar charm (e.g. snappass-test)
- Watch debug-log
- Cause the uniter to exit (e.g. toggle automatically-retry-hooks `juju model-config automatically-retry-hooks=False/True`)
- Ensure the uniter has bounced, the leadership tracker did not bounce and everything is still happy in `juju status`

## Documentation changes

N/A

## Links

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2068680

**Jira card:** JUJU-

