### PR TITLE
fix: unit agent lost on migration success

### DIFF
--- a/worker/migrationminion/manifold.go
+++ b/worker/migrationminion/manifold.go
@@ -20,6 +20,8 @@ type Logger interface {
 	Errorf(string, ...interface{})
 	Infof(string, ...interface{})
 	Debugf(string, ...interface{})
+	Warningf(string, ...interface{})
+	Criticalf(string, ...interface{})
 }
 
 // ManifoldConfig defines the names of the manifolds on which a
@@ -98,6 +100,7 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 		Clock:             config.Clock,
 		APIOpen:           config.APIOpen,
 		ValidateMigration: config.ValidateMigration,
+		NewFacade:         config.NewFacade,
 		Logger:            config.Logger,
 	})
 	if err != nil {

--- a/worker/migrationminion/worker_test.go
+++ b/worker/migrationminion/worker_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/juju/juju/core/migration"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/watcher"
+	"github.com/juju/juju/rpc"
 	coretesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/fortress"
 	"github.com/juju/juju/worker/migrationminion"
@@ -366,6 +367,73 @@ func (s *Suite) TestSUCCESS(c *gc.C) {
 	s.stub.CheckCall(c, 2, "Report", "id", migration.SUCCESS, true)
 }
 
+func (s *Suite) TestSUCCESSCantConnectNotReportForTryAgainError(c *gc.C) {
+	s.client.watcher.changes <- watcher.MigrationStatus{
+		MigrationId: "id",
+		Phase:       migration.SUCCESS,
+	}
+	s.agent.conf.tag = names.NewUnitTag("app/0")
+	s.agent.conf.dir = "/var/lib/juju/agents/unit-app-0"
+	s.config.APIOpen = func(*api.Info, api.DialOpts) (api.Connection, error) {
+		s.stub.AddCall("API open")
+		return nil, apiservererrors.ErrTryAgain
+	}
+	s.stub.SetErrors(rpc.ErrShutdown)
+	w, err := migrationminion.New(s.config)
+	c.Assert(err, jc.ErrorIsNil)
+	defer workertest.DirtyKill(c, w)
+
+	// Advance time enough for all of the retries to be exhausted.
+	sleepTime := 100 * time.Millisecond
+	for i := 0; i < 9; i++ {
+		err := s.clock.WaitAdvance(sleepTime, coretesting.ShortWait, 1)
+		c.Assert(err, jc.ErrorIsNil)
+		sleepTime = sleepTime * 2
+	}
+
+	s.waitForStubCalls(c, []string{
+		"Watch",
+		"Lockdown",
+		"Report",
+		"API open",
+		"API open",
+		"API open",
+		"API open",
+		"API open",
+		"API open",
+		"API open",
+		"API open",
+		"API open",
+		"API open",
+	})
+}
+
+func (s *Suite) TestSUCCESSRetryReport(c *gc.C) {
+	s.client.watcher.changes <- watcher.MigrationStatus{
+		MigrationId: "id",
+		Phase:       migration.SUCCESS,
+	}
+	s.agent.conf.tag = names.NewUnitTag("app/0")
+	s.agent.conf.dir = "/var/lib/juju/agents/unit-app-0"
+	s.config.NewFacade = func(a base.APICaller) (migrationminion.Facade, error) {
+		return s.config.Facade, nil
+	}
+
+	s.stub.SetErrors(rpc.ErrShutdown)
+	w, err := migrationminion.New(s.config)
+	c.Assert(err, jc.ErrorIsNil)
+	defer workertest.CleanKill(c, w)
+
+	s.waitForStubCalls(c, []string{
+		"Watch",
+		"Lockdown",
+		"Report",
+		"API open",
+		"Report",
+		"API close",
+	})
+}
+
 func (s *Suite) waitForStubCalls(c *gc.C, expectedCallNames []string) {
 	waitForStubCalls(c, s.stub, expectedCallNames...)
 }
@@ -433,7 +501,7 @@ func (c *stubMinionClient) Watch() (watcher.MigrationStatusWatcher, error) {
 
 func (c *stubMinionClient) Report(id string, phase migration.Phase, success bool) error {
 	c.stub.MethodCall(c, "Report", id, phase, success)
-	return nil
+	return c.stub.NextErr()
 }
 
 func newStubWatcher() *stubWatcher {
@@ -476,6 +544,9 @@ func (ma *stubAgent) ChangeConfig(f agent.ConfigMutator) error {
 type stubAgentConfig struct {
 	agent.ConfigSetter
 
+	tag names.Tag
+	dir string
+
 	mu     sync.Mutex
 	addrs  []string
 	caCert string
@@ -509,6 +580,14 @@ func (mc *stubAgentConfig) APIInfo() (*api.Info, bool) {
 		Tag:      agentTag,
 		Password: agentPassword,
 	}, true
+}
+
+func (mc *stubAgentConfig) Tag() names.Tag {
+	return mc.tag
+}
+
+func (mc *stubAgentConfig) Dir() string {
+	return mc.dir
 }
 
 type stubConnection struct {


### PR DESCRIPTION
During the migration minion's SUCCESS phase, at the point of no return, the api connection can fail.
This leads to the doSUCCESS handler being unable to report the SUCCESS phase as being successful to the source controller. When this errors, the target IPs and CA certs are not saved to the agent config.

This issue was seen with unit agents failing to use the target controller, but the machine agent using the target controller successfully. This would show the unit agent on the machine as lost.

This fix attempts to make the reporting back to the source controller more robust to connection issues. If for some reason, we fail these retry attempts, we now have a very angry critical log message to inform the admin of this situation.

## QA steps

This is very difficult to get it to fail. The best I've had is to run this until it fails, which took many hours.
```
export BOOTSTRAP_PROVIDER=ec2
export BOOTSTRAP_CLOUD=aws
run-one-until-failure ./main.sh -v -s '"test_model_config,test_model_destroy,test_model_metrics,test_model_migration,test_model_migration_saas_external,test_model_migration_version,test_model_multi,test_model_status"' model test_model_migration_saas_common
```

This is the unit agent output we expect now in the case of the api connection going away:
```
2024-06-06 23:46:43 INFO juju.worker.migrationminion worker.go:147 migration phase is now: VALIDATION
2024-06-06 23:46:43 INFO juju.worker.migrationminion worker.go:277 reporting back for phase VALIDATION: true
2024-06-06 23:46:43 INFO juju.worker.migrationminion worker.go:147 migration phase is now: SUCCESS
2024-06-06 23:46:43 INFO juju.worker.migrationminion worker.go:277 reporting back for phase SUCCESS: true
2024-06-06 23:46:43 WARNING juju.worker.migrationminion worker.go:289 report migration status failed: failed to report phase progress: connection is shut down
2024-06-06 23:46:43 INFO juju.worker.migrationminion worker.go:300 reporting back for phase SUCCESS: true
2024-06-06 23:46:47 INFO juju.worker.migrationminion worker.go:147 migration phase is now: NONE
2024-06-06 23:46:48 INFO juju.worker.migrationminion worker.go:147 migration phase is now: NONE
```

## Documentation changes

N/A

## Links

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2068682

**Jira card:** JUJU-

