### PR TITLE
docs: add SeeAlso and Example docstrings for juju commands;

### DIFF
--- a/cmd/juju/action/cancel.go
+++ b/cmd/juju/action/cancel.go
@@ -37,12 +37,26 @@ func (c *cancelCommand) SetFlags(f *gnuflag.FlagSet) {
 const cancelDoc = `
 Cancel pending or running tasks matching given IDs or partial ID prefixes.`
 
+const cancelExamples = `
+To cancel a task by ID:
+
+    juju cancel-task 1
+
+To cancel multiple tasks by ID:
+
+    juju cancel-task 1 2 3
+`
+
 func (c *cancelCommand) Info() *cmd.Info {
 	info := &cmd.Info{
-		Name:    "cancel-task",
-		Args:    "(<task-id>|<task-id-prefix>) [...]",
-		Purpose: "Cancel pending or running tasks.",
-		Doc:     cancelDoc,
+		Name:     "cancel-task",
+		Args:     "(<task-id>|<task-id-prefix>) [...]",
+		Purpose:  "Cancel pending or running tasks.",
+		Doc:      cancelDoc,
+		Examples: cancelExamples,
+		SeeAlso: []string{
+			"show-task",
+		},
 	}
 	return jujucmd.Info(info)
 }

--- a/cmd/juju/action/exec.go
+++ b/cmd/juju/action/exec.go
@@ -123,13 +123,27 @@ those arguments. For example:
 
 `
 
+const example = `
+
+    juju exec --all -- hostname -f
+
+    juju exec --unit hello/0 env
+
+    juju exec --unit controller/0 juju-engine-report
+`
+
 // Info implements Command.Info.
 func (c *execCommand) Info() *cmd.Info {
 	info := jujucmd.Info(&cmd.Info{
-		Name:    "exec",
-		Args:    "<commands>",
-		Purpose: "Run the commands on the remote targets specified.",
-		Doc:     execDoc,
+		Name:     "exec",
+		Args:     "<commands>",
+		Purpose:  "Run the commands on the remote targets specified.",
+		Doc:      execDoc,
+		Examples: example,
+		SeeAlso: []string{
+			"run",
+			"ssh",
+		},
 	})
 	return info
 }

--- a/cmd/juju/action/showtask.go
+++ b/cmd/juju/action/showtask.go
@@ -88,6 +88,7 @@ func (c *showTaskCommand) Info() *cmd.Info {
 		Doc:      showTaskDoc,
 		Examples: showTaskExamples,
 		SeeAlso: []string{
+			"cancel-task",
 			"run",
 			"operations",
 			"show-operation",

--- a/cmd/juju/agree/agree/agree.go
+++ b/cmd/juju/agree/agree/agree.go
@@ -86,6 +86,9 @@ func (c *agreeCommand) Info() *cmd.Info {
 		Purpose:  "Agree to terms.",
 		Doc:      agreeDoc,
 		Examples: agreeExamples,
+		SeeAlso: []string{
+			"agreements",
+		},
 	})
 }
 

--- a/cmd/juju/agree/listagreements/listagreements.go
+++ b/cmd/juju/agree/listagreements/listagreements.go
@@ -39,10 +39,10 @@ In other words, some applications may only be installed if a user agrees to
 accept some terms defined by the charm. 
 
 This command lists the terms that the user has agreed to.
+`
 
-See also:
-    agree
-
+const listAgreementsExamples = `
+    juju agreements
 `
 
 // NewListAgreementsCommand returns a new command that can be
@@ -73,10 +73,14 @@ func (c *listAgreementsCommand) SetFlags(f *gnuflag.FlagSet) {
 // Info implements Command.Info.
 func (c *listAgreementsCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "agreements",
-		Purpose: "List user's agreements.",
-		Doc:     listAgreementsDoc,
-		Aliases: []string{"list-agreements"},
+		Name:     "agreements",
+		Purpose:  "List user's agreements.",
+		Doc:      listAgreementsDoc,
+		Aliases:  []string{"list-agreements"},
+		Examples: listAgreementsExamples,
+		SeeAlso: []string{
+			"agree",
+		},
 	})
 }
 

--- a/cmd/juju/application/bind.go
+++ b/cmd/juju/application/bind.go
@@ -84,6 +84,11 @@ func (c *bindCommand) Info() *cmd.Info {
 		Purpose:  "Change bindings for a deployed application.",
 		Doc:      bindCmdDoc,
 		Examples: bindCmdExamples,
+		SeeAlso: []string{
+			"spaces",
+			"show-space",
+			"show-application",
+		},
 	})
 }
 

--- a/cmd/juju/application/config.go
+++ b/cmd/juju/application/config.go
@@ -95,6 +95,24 @@ settings back to their default value as defined in the charm metadata:
 juju config apache2 --reset servername
 juju config apache2 --reset servername,lb_balancer_timeout
 `
+
+	examples = `
+To view all configuration values for an application, run
+
+    juju config mysql --format json
+
+To set a configuration value for an application, run
+
+    juju config mysql foo=bar
+
+To set some keys and reset others:
+
+    juju config mysql key1=val1 key2=val2 --reset key3,key4
+
+To set a configuration value for an application from a file:
+
+    juju config mysql --file=path/to/cfg.yaml
+`
 )
 
 var appConfigBase = config.ConfigCommandBase{
@@ -130,10 +148,11 @@ type ApplicationAPI interface {
 // Info is part of the cmd.Command interface.
 func (c *configCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "config",
-		Args:    "<application name> [--branch <branch-name>] [--reset <key[,key]>] [<attribute-key>][=<value>] ...]",
-		Purpose: configSummary,
-		Doc:     configDetails,
+		Name:     "config",
+		Args:     "<application name> [--branch <branch-name>] [--reset <key[,key]>] [<attribute-key>][=<value>] ...]",
+		Purpose:  configSummary,
+		Doc:      configDetails,
+		Examples: examples,
 		SeeAlso: []string{
 			"deploy",
 			"status",

--- a/cmd/juju/application/expose.go
+++ b/cmd/juju/application/expose.go
@@ -66,6 +66,24 @@ juju expose apache2 --endpoints logs --to-cidrs 192.168.0.0/24
 
 `[1:]
 
+const example = `
+To expose an application:
+
+    juju expose apache2
+
+To expose an application to one or multiple spaces:
+
+    juju expose apache2 --to-spaces public
+
+To expose an application to one or multiple endpoints:
+
+    juju expose apache2 --endpoints logs
+	
+To expose an application to one or multiple CIDRs:
+
+    juju expose apache2 --to-cidrs 10.0.0.0/24
+`
+
 // NewExposeCommand returns a command to expose applications.
 func NewExposeCommand() modelcmd.ModelCommand {
 	return modelcmd.Wrap(&exposeCommand{})
@@ -82,10 +100,11 @@ type exposeCommand struct {
 
 func (c *exposeCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "expose",
-		Args:    "<application name>",
-		Purpose: usageExposeSummary,
-		Doc:     usageExposeDetails,
+		Name:     "expose",
+		Args:     "<application name>",
+		Purpose:  usageExposeSummary,
+		Doc:      usageExposeDetails,
+		Examples: example,
 		SeeAlso: []string{
 			"unexpose",
 		},

--- a/cmd/juju/application/refresh.go
+++ b/cmd/juju/application/refresh.go
@@ -237,6 +237,20 @@ application; overriding profiles on the container may cause unexpected
 behavior.
 `
 
+const refreshExamples = `
+To refresh the storage constraints for the application foo:
+
+	juju refresh foo --storage cache=ssd,10G
+
+To refresh the application config from a file for application foo:
+
+	juju refresh foo --config config.yaml
+
+To refresh the resources for application foo:
+
+	juju refresh foo --resource bar=/some/file.tgz --resource baz=./docs/cfg.xml
+`
+
 const upgradedApplicationHasUnitsMessage = `
 Upgrading from an older PodSpec style charm to a newer Sidecar charm requires that
 the application be scaled down to 0 units.
@@ -249,10 +263,12 @@ all those units to disappear before continuing.
 
 func (c *refreshCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "refresh",
-		Args:    "<application>",
-		Purpose: "Refresh an application's charm.",
-		Doc:     refreshDoc,
+		Name:     "refresh",
+		Args:     "<application>",
+		Purpose:  "Refresh an application's charm.",
+		Doc:      refreshDoc,
+		SeeAlso:  []string{"deploy"},
+		Examples: refreshExamples,
 	})
 }
 

--- a/cmd/juju/application/removeapplication.go
+++ b/cmd/juju/application/removeapplication.go
@@ -93,6 +93,10 @@ func (c *removeApplicationCommand) Info() *cmd.Info {
 		Purpose:  helpSummaryRmApp,
 		Doc:      helpDetailsRmApp,
 		Examples: helpExamplesRmApp,
+		SeeAlso: []string{
+			"scale-application",
+			"show-application",
+		},
 	})
 }
 

--- a/cmd/juju/application/resolved.go
+++ b/cmd/juju/application/resolved.go
@@ -29,12 +29,22 @@ type resolvedCommand struct {
 	All       bool
 }
 
+const resolvedCommandExamples = `
+
+	juju resolved mysql/0
+
+	juju resolved mysql/0 mysql/1
+
+	juju resolved --all
+`
+
 func (c *resolvedCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "resolved",
-		Args:    "[<unit> ...]",
-		Purpose: "Marks unit errors resolved and re-executes failed hooks.",
-		Aliases: []string{"resolve"},
+		Name:     "resolved",
+		Args:     "[<unit> ...]",
+		Purpose:  "Marks unit errors resolved and re-executes failed hooks.",
+		Aliases:  []string{"resolve"},
+		Examples: resolvedCommandExamples,
 	})
 }
 

--- a/cmd/juju/application/scaleapplication.go
+++ b/cmd/juju/application/scaleapplication.go
@@ -58,6 +58,11 @@ func (c *scaleApplicationCommand) Info() *cmd.Info {
 		Purpose:  "Set the desired number of k8s application units.",
 		Doc:      scaleApplicationDoc,
 		Examples: scaleApplicationExamples,
+		SeeAlso: []string{
+			"remove-application",
+			"add-unit",
+			"remove-unit",
+		},
 	})
 }
 

--- a/cmd/juju/application/showunit.go
+++ b/cmd/juju/application/showunit.go
@@ -25,10 +25,24 @@ or related unit may be shown, or just the application data.
 `
 
 const showUnitExamples = `
+To show information about a unit:
+
     juju show-unit mysql/0
+
+To show information about multiple units:
+
     juju show-unit mysql/0 wordpress/1
+
+To show only the application relation data for a unit:
+
     juju show-unit mysql/0 --app
+
+To show only the relation data for a specific endpoint:
+
     juju show-unit mysql/0 --endpoint db
+
+To show only the relation data for a specific related unit:
+
     juju show-unit mysql/0 --related-unit wordpress/2
 `
 
@@ -61,6 +75,10 @@ func (c *showUnitCommand) Info() *cmd.Info {
 		Purpose:  "Displays information about a unit.",
 		Doc:      showUnitDoc,
 		Examples: showUnitExamples,
+		SeeAlso: []string{
+			"add-unit",
+			"remove-unit",
+		},
 	}
 	return jujucmd.Info(showCmd)
 }

--- a/cmd/juju/application/unexpose.go
+++ b/cmd/juju/application/unexpose.go
@@ -26,24 +26,15 @@ the "juju expose" command, they can be unexposed by running the "juju unexpose"
 command.  
 
 If no additional options are specified, the command will unexpose the
-application (if exposed). For example, to unexpose the apache2 application,
-you can run:
-
-juju unexpose apache2
+application (if exposed).
 
 The --endpoints option may be used to restrict the effect of this command to 
-the list of ports opened for a comma-delimited list of endpoints. For instance,
-to only unexpose the ports opened by apache2 for the "www" endpoint, you can 
-run:
-
-juju unexpose apache2 --endpoints www
+the list of ports opened for a comma-delimited list of endpoints.
 
 Note that when the --endpoints option is provided, the application will still
 remain exposed if any other of its endpoints are still exposed. However, if
 none of its endpoints remain exposed, the application will be instead unexposed. 
-
-See also: 
-    expose`[1:]
+`[1:]
 
 // NewUnexposeCommand returns a command to unexpose applications.
 func NewUnexposeCommand() modelcmd.ModelCommand {
@@ -57,12 +48,26 @@ type unexposeCommand struct {
 	ExposedEndpointsList string
 }
 
+const unexposeCommandExample = `
+    juju unexpose apache2
+
+To unexpose only the ports that charms have opened for the "www", or "www" and "logs" endpoints:
+
+    juju unexpose apache2 --endpoints www
+
+    juju unexpose apache2 --endpoints www,logs
+`
+
 func (c *unexposeCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "unexpose",
-		Args:    "<application name>",
-		Purpose: usageUnexposeSummary,
-		Doc:     usageUnexposeDetails,
+		Name:     "unexpose",
+		Args:     "<application name>",
+		Purpose:  usageUnexposeSummary,
+		Doc:      usageUnexposeDetails,
+		Examples: unexposeCommandExample,
+		SeeAlso: []string{
+			"expose",
+		},
 	})
 }
 

--- a/cmd/juju/backups/download.go
+++ b/cmd/juju/backups/download.go
@@ -23,6 +23,10 @@ If --filename is not used, the archive is downloaded to a temporary
 location and the filename is printed to stdout.
 `
 
+const examples = `
+    juju download-backup /full/path/to/backup/on/controller
+`
+
 // NewDownloadCommand returns a commant used to download backups.
 func NewDownloadCommand() cmd.Command {
 	return modelcmd.Wrap(&downloadCommand{})
@@ -40,10 +44,14 @@ type downloadCommand struct {
 // Info implements Command.Info.
 func (c *downloadCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "download-backup",
-		Args:    "/full/path/to/backup/on/controller",
-		Purpose: "Download a backup archive file.",
-		Doc:     downloadDoc,
+		Name:     "download-backup",
+		Args:     "/full/path/to/backup/on/controller",
+		Purpose:  "Download a backup archive file.",
+		Doc:      downloadDoc,
+		Examples: examples,
+		SeeAlso: []string{
+			"create-backup",
+		},
 	})
 }
 

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -150,17 +150,20 @@ GKE or EKS.
 
 When bootstrapping to a k8s cluster Juju does not recognise, there's no
 guarantee a load balancer is available, so Juju defaults to a controller
-service type of ClusterIP. This may not be suitable, so there's 3 bootstrap
+service type of ClusterIP. This may not be suitable, so there are three bootstrap
 options available to tell Juju how to set up the controller service. Part of
 the solution may require a load balancer for the cluster to be set up manually
 first, or perhaps an external k8s service via a FQDN will be used
 (this is a cluster specific implementation decision which Juju needs to be
-informed about so it can set things up correctly). The 3 relevant bootstrap
+informed about so it can set things up correctly). The three relevant bootstrap
 options are (see list of bootstrap config items below for a full explanation):
 
 - controller-service-type
 - controller-external-name
 - controller-external-ips
+
+Juju advertises those addresses to other controllers, so they must be resolveable from
+other controllers for cross-model (cross-controller, actually) relations to work.
 
 If a storage pool is specified using --storage-pool, this will be created
 in the controller model.

--- a/cmd/juju/commands/helptool.go
+++ b/cmd/juju/commands/helptool.go
@@ -117,6 +117,7 @@ func (t *helpToolCommand) Info() *cmd.Info {
 		Purpose:  "Show help on a Juju charm hook tool.",
 		Doc:      helpToolDoc,
 		Examples: helpToolExamples,
+		SeeAlso:  []string{"help"},
 	})
 }
 

--- a/cmd/juju/commands/helptool_test.go
+++ b/cmd/juju/commands/helptool_test.go
@@ -103,6 +103,9 @@ Examples:
 For help on a specific tool, supply the name of that tool, for example:
 
         juju help-tool unit-get
+
+See also:
+ - help
 `)
 }
 

--- a/cmd/juju/commands/list_sshkeys.go
+++ b/cmd/juju/commands/list_sshkeys.go
@@ -58,6 +58,10 @@ func (c *listKeysCommand) Info() *cmd.Info {
 		Doc:      usageListSSHKeysDetails,
 		Aliases:  []string{"list-ssh-keys"},
 		Examples: usageListSSHKeysExamples,
+		SeeAlso: []string{
+			"add-ssh-key",
+			"remove-ssh-key",
+		},
 	})
 }
 

--- a/cmd/juju/commands/version.go
+++ b/cmd/juju/commands/version.go
@@ -17,11 +17,12 @@ const versionDoc = `
 Print only the Juju CLI client version.`
 
 const versionExamplesDoc = `
-To see the version of Juju running on a particular controller, use
-  juju show-controller
+    juju version
 
-To see the version of Juju running on a particular model, use
-  juju show-model`
+Print all version information:
+
+    juju version --all
+`
 
 // versionDetail is populated with version information from juju/juju/cmd
 // and passed into each SuperCommand. It can be printed using `juju version --all`.

--- a/cmd/juju/controller/addmodel.go
+++ b/cmd/juju/controller/addmodel.go
@@ -116,6 +116,12 @@ func (c *addModelCommand) Info() *cmd.Info {
 		Purpose:  "Adds a workload model.",
 		Doc:      strings.TrimSpace(addModelHelpDoc),
 		Examples: addModelHelpExamples,
+		SeeAlso: []string{
+			"model-config",
+			"model-defaults",
+			"add-credential",
+			"autoload-credentials",
+		},
 	})
 }
 

--- a/cmd/juju/machine/show.go
+++ b/cmd/juju/machine/show.go
@@ -46,6 +46,9 @@ func (c *showMachineCommand) Info() *cmd.Info {
 		Purpose:  "Show a machine's status.",
 		Doc:      showMachineCommandDoc,
 		Examples: showMachineExamples,
+		SeeAlso: []string{
+			"add-machine",
+		},
 	})
 }
 

--- a/cmd/juju/metricsdebug/collectmetrics.go
+++ b/cmd/juju/metricsdebug/collectmetrics.go
@@ -32,6 +32,12 @@ You may abort this command and it will continue to run asynchronously.
 Results may be checked by 'juju show-task'.
 `
 
+const examples = `
+    juju collect-metrics myapp
+
+    juju collect-metrics myapp/0
+`
+
 const (
 	// commandTimeout represents the timeout for executing the command itself
 	commandTimeout = 3 * time.Second
@@ -55,10 +61,12 @@ func NewCollectMetricsCommand() cmd.Command {
 // Info implements Command.Info.
 func (c *collectMetricsCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "collect-metrics",
-		Args:    "[application or unit]",
-		Purpose: "Collect metrics on the given unit/application.",
-		Doc:     collectMetricsDoc,
+		Name:     "collect-metrics",
+		Args:     "[application or unit]",
+		Purpose:  "Collect metrics on the given unit/application.",
+		Doc:      collectMetricsDoc,
+		Examples: examples,
+		SeeAlso:  []string{"metrics"},
 	})
 }
 

--- a/cmd/juju/metricsdebug/metrics.go
+++ b/cmd/juju/metricsdebug/metrics.go
@@ -47,6 +47,7 @@ func (c *MetricsCommand) Info() *cmd.Info {
 		Args:    "[tag1[...tagN]]",
 		Purpose: "Retrieve metrics collected by specified entities.",
 		Doc:     metricsDoc,
+		SeeAlso: []string{"collect-metrics"},
 	})
 }
 

--- a/cmd/juju/model/grantrevoke.go
+++ b/cmd/juju/model/grantrevoke.go
@@ -196,6 +196,7 @@ func (c *grantCommand) Info() *cmd.Info {
 		SeeAlso: []string{
 			"revoke",
 			"add-user",
+			"grant-cloud",
 		},
 	})
 }

--- a/cmd/juju/model/grantrevokecloud.go
+++ b/cmd/juju/model/grantrevokecloud.go
@@ -112,6 +112,7 @@ func (c *grantCloudCommand) Info() *cmd.Info {
 		Doc:      usageGrantCloudDetails,
 		Examples: usageGrantCloudExamples,
 		SeeAlso: []string{
+			"grant",
 			"revoke-cloud",
 			"add-user",
 		},

--- a/cmd/juju/model/retryprovisioning.go
+++ b/cmd/juju/model/retryprovisioning.go
@@ -40,11 +40,21 @@ type RetryProvisioningAPI interface {
 	RetryProvisioning(all bool, machines ...names.MachineTag) ([]params.ErrorResult, error)
 }
 
+const retryProvisioningCommandExamples = `
+
+	juju retry-provisioning 0
+
+	juju retry-provisioning 0 1
+
+	juju retry-provisioning --all
+`
+
 func (c *retryProvisioningCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "retry-provisioning",
-		Args:    "<machine> [...]",
-		Purpose: "Retries provisioning for failed machines.",
+		Name:     "retry-provisioning",
+		Args:     "<machine> [...]",
+		Purpose:  "Retries provisioning for failed machines.",
+		Examples: retryProvisioningCommandExamples,
 	})
 }
 

--- a/cmd/juju/model/show.go
+++ b/cmd/juju/model/show.go
@@ -61,6 +61,9 @@ func (c *showModelCommand) Info() *cmd.Info {
 		Args:    "<model name>",
 		Purpose: "Shows information about the current or specified model.",
 		Doc:     showModelCommandDoc,
+		SeeAlso: []string{
+			"add-model",
+		},
 	})
 }
 

--- a/cmd/juju/resource/list.go
+++ b/cmd/juju/resource/list.go
@@ -50,6 +50,20 @@ func NewListCommand() modelcmd.ModelCommand {
 	return modelcmd.Wrap(c)
 }
 
+const listResourcesExamples = `
+To list resources for an application:
+
+	juju resources mysql
+
+To list resources for a unit:
+
+	juju resources mysql/0
+
+To show detailed information about resources used by a unit:
+
+	juju resources mysql/0 --details
+`
+
 // Info implements cmd.Command.Info.
 func (c *ListCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
@@ -66,6 +80,7 @@ This command shows the resources required by and those in use by an existing
 application or unit in your model.  When run for an application, it will also show any
 updates available for resources from a store.
 `,
+		Examples: listResourcesExamples,
 	})
 }
 

--- a/cmd/juju/resource/upload.go
+++ b/cmd/juju/resource/upload.go
@@ -87,6 +87,13 @@ Note: If you choose (2b): You will need to specify:
 (ii) the username/password required to access the private OCI image.
 
 `
+	attachExample = `
+    juju attach-resource mysql resource-name=foo
+
+    juju attach-resource ubuntu-k8s ubuntu_image=ubuntu
+
+    juju attach-resource redis-k8s redis-image=redis
+`
 )
 
 // Info implements cmd.Command.Info

--- a/cmd/juju/secrets/list.go
+++ b/cmd/juju/secrets/list.go
@@ -70,6 +70,12 @@ func (c *listSecretsCommand) Info() *cmd.Info {
 		Doc:      listSecretsDoc,
 		Examples: listSecretsExamples,
 		Aliases:  []string{"list-secrets"},
+		SeeAlso: []string{
+			"add-secret",
+			"remove-secret",
+			"show-secret",
+			"update-secret",
+		},
 	})
 }
 

--- a/cmd/juju/secrets/show.go
+++ b/cmd/juju/secrets/show.go
@@ -70,6 +70,11 @@ func (c *showSecretsCommand) Info() *cmd.Info {
 		Purpose:  "Shows details for a specific secret.",
 		Doc:      showSecretsDoc,
 		Examples: showSecretsExamples,
+		SeeAlso: []string{
+			"add-secret",
+			"update-secret",
+			"remove-secret",
+		},
 	})
 }
 

--- a/cmd/juju/space/reload.go
+++ b/cmd/juju/space/reload.go
@@ -28,12 +28,23 @@ const ReloadCommandDoc = `
 Reloades spaces and subnets from substrate.
 `
 
+const ReloadCommandExamples = `
+	juju reload-spaces
+`
+
 // Info is defined on the cmd.Command interface.
 func (c *ReloadCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "reload-spaces",
-		Purpose: "Reloads spaces and subnets from substrate.",
-		Doc:     strings.TrimSpace(ReloadCommandDoc),
+		Name:     "reload-spaces",
+		Purpose:  "Reloads spaces and subnets from substrate.",
+		Doc:      strings.TrimSpace(ReloadCommandDoc),
+		Examples: ReloadCommandExamples,
+		SeeAlso: []string{
+			"spaces",
+			"add-space",
+			"show-space",
+			"move-to-space",
+		},
 	})
 }
 

--- a/cmd/juju/ssh/debugcode.go
+++ b/cmd/juju/ssh/debugcode.go
@@ -79,6 +79,10 @@ func (c *debugCodeCommand) Info() *cmd.Info {
 		Purpose:  "Launch a tmux session to debug hooks and/or actions.",
 		Doc:      debugCodeDoc,
 		Examples: usageDebugCodeExamples,
+		SeeAlso: []string{
+			"ssh",
+			"debug-hooks",
+		},
 	})
 }
 

--- a/cmd/juju/ssh/debughooks.go
+++ b/cmd/juju/ssh/debughooks.go
@@ -93,6 +93,10 @@ func (c *debugHooksCommand) Info() *cmd.Info {
 		Doc:      debugHooksDoc,
 		Examples: usageDebugHooksExamples,
 		Aliases:  []string{"debug-hook"},
+		SeeAlso: []string{
+			"ssh",
+			"debug-code",
+		},
 	})
 }
 

--- a/cmd/juju/status/history.go
+++ b/cmd/juju/status/history.go
@@ -62,12 +62,46 @@ The statuses are available for the following types.
  The default is unit.
 `, supportedHistoryKindDescs())
 
+const statusHistoryExamples = `
+Show the status history for the specified unit:
+
+    juju show-status-log mysql/0
+
+Show the status history for the specified unit with the last 30 logs:
+
+    juju show-status-log mysql/0 -n 30
+
+Show the status history for the specified unit with the logs for the past 2 days:
+
+    juju show-status-log mysql/0 -days 2
+
+Show the status history for the specified unit with the logs for any date after 2020-01-01:
+
+    juju show-status-log mysql/0 --from-date 2020-01-01
+
+Show the status history for the specified application:
+
+    juju show-status-log -type application wordpress
+
+Show the status history for the specified machine:
+
+    juju show-status-log 0
+
+Show the status history for the model:
+
+    juju show-status-log -type model
+`
+
 func (c *statusHistoryCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "show-status-log",
-		Args:    "<entity name>",
-		Purpose: "Output past statuses for the specified entity.",
-		Doc:     statusHistoryDoc,
+		Name:     "show-status-log",
+		Args:     "<entity name>",
+		Purpose:  "Output past statuses for the specified entity.",
+		Doc:      statusHistoryDoc,
+		Examples: statusHistoryExamples,
+		SeeAlso: []string{
+			"status",
+		},
 	})
 }
 

--- a/cmd/juju/storage/detach.go
+++ b/cmd/juju/storage/detach.go
@@ -89,6 +89,10 @@ func (c *detachStorageCommand) Info() *cmd.Info {
 		Doc:      detachStorageCommandDoc,
 		Examples: detachStorageCommandExamples,
 		Args:     detachStorageCommandArgs,
+		SeeAlso: []string{
+			"storage",
+			"attach-storage",
+		},
 	})
 }
 

--- a/cmd/juju/storage/import.go
+++ b/cmd/juju/storage/import.go
@@ -123,6 +123,7 @@ func (c *importFilesystemCommand) Info() *cmd.Info {
 		Doc:      importFilesystemCommandDoc,
 		Args:     importFilesystemCommandAgs,
 		Examples: importFilesystemCommandExamples,
+		SeeAlso:  []string{"storage"},
 	})
 }
 

--- a/cmd/juju/storage/list.go
+++ b/cmd/juju/storage/list.go
@@ -29,6 +29,20 @@ const listCommandDoc = `
 List information about storage.
 `
 
+const listCommandExample = `
+List all storage:
+
+    juju storage
+
+List only filesystem storage:
+
+    juju storage --filesystem
+
+List only volume storage:
+
+    juju storage --volume
+`
+
 // listCommand returns storage instances.
 type listCommand struct {
 	StorageCommandBase
@@ -42,11 +56,17 @@ type listCommand struct {
 // Info implements Command.Info.
 func (c *listCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "storage",
-		Args:    "<filesystem|volume> ...",
-		Purpose: "Lists storage details.",
-		Doc:     listCommandDoc,
-		Aliases: []string{"list-storage"},
+		Name:     "storage",
+		Args:     "<filesystem|volume> ...",
+		Purpose:  "Lists storage details.",
+		Doc:      listCommandDoc,
+		Aliases:  []string{"list-storage"},
+		Examples: listCommandExample,
+		SeeAlso: []string{
+			"show-storage",
+			"add-storage",
+			"remove-storage",
+		},
 	})
 }
 
@@ -60,8 +80,8 @@ func (c *listCommand) SetFlags(f *gnuflag.FlagSet) {
 	})
 	// TODO(axw) deprecate these flags, and introduce separate commands
 	// for listing just filesystems or volumes.
-	f.BoolVar(&c.filesystem, "filesystem", false, "List filesystem storage")
-	f.BoolVar(&c.volume, "volume", false, "List volume storage")
+	f.BoolVar(&c.filesystem, "filesystem", false, "List filesystem storage(deprecated)")
+	f.BoolVar(&c.volume, "volume", false, "List volume storage(deprecated)")
 }
 
 // Init implements Command.Init.

--- a/cmd/juju/storage/poollist.go
+++ b/cmd/juju/storage/poollist.go
@@ -47,6 +47,20 @@ Both pool types and names must be valid.
 Valid pool types are pool types that are registered for Juju model.
 `
 
+const poolListCommandExample = `
+List all storage pools:
+
+    juju storage-pools
+
+List only pools of type kubernetes, azure, ebs:
+
+    juju storage-pools --provider kubernetes,azure,ebs
+
+List only pools named pool1 and pool2:
+
+    juju storage-pools --name pool1,pool2
+`
+
 // NewPoolListCommand returns a command that lists storage pools on a model
 func NewPoolListCommand() cmd.Command {
 	cmd := &poolListCommand{}
@@ -73,10 +87,15 @@ func (c *poolListCommand) Init(args []string) (err error) {
 // Info implements Command.Info.
 func (c *poolListCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "storage-pools",
-		Purpose: "List storage pools.",
-		Doc:     poolListCommandDoc,
-		Aliases: []string{"list-storage-pools"},
+		Name:     "storage-pools",
+		Purpose:  "List storage pools.",
+		Doc:      poolListCommandDoc,
+		Aliases:  []string{"list-storage-pools"},
+		Examples: poolListCommandExample,
+		SeeAlso: []string{
+			"create-storage-pool",
+			"remove-storage-pool",
+		},
 	})
 }
 

--- a/cmd/juju/storage/remove.go
+++ b/cmd/juju/storage/remove.go
@@ -75,6 +75,14 @@ func (c *removeStorageCommand) Info() *cmd.Info {
 		Doc:      removeStorageCommandDoc,
 		Args:     removeStorageCommandArgs,
 		Examples: removeStorageCommandExamples,
+		SeeAlso: []string{
+			"add-storage",
+			"attach-storage",
+			"detach-storage",
+			"list-storage",
+			"show-storage",
+			"storage",
+		},
 	})
 }
 

--- a/cmd/juju/storage/show.go
+++ b/cmd/juju/storage/show.go
@@ -33,6 +33,10 @@ separated when more than one ID is desired.
 
 `
 
+const showCommandExample = `
+    juju show-storage storage-id
+`
+
 // showCommand attempts to release storage instance.
 type showCommand struct {
 	StorageCommandBase
@@ -53,10 +57,17 @@ func (c *showCommand) Init(args []string) (err error) {
 // Info implements Command.Info.
 func (c *showCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "show-storage",
-		Args:    "<storage ID> [...]",
-		Purpose: "Shows storage instance information.",
-		Doc:     showCommandDoc,
+		Name:     "show-storage",
+		Args:     "<storage ID> [...]",
+		Purpose:  "Shows storage instance information.",
+		Doc:      showCommandDoc,
+		Examples: showCommandExample,
+		SeeAlso: []string{
+			"storage",
+			"attach-storage",
+			"detach-storage",
+			"remove-storage",
+		},
 	})
 }
 

--- a/cmd/juju/subnet/list.go
+++ b/cmd/juju/subnet/list.go
@@ -47,14 +47,29 @@ output formats include "yaml" (default) and "json". To redirect the
 output to a file, use --output.
 `
 
+const listCommandExample = `
+To list all subnets known to Juju:
+
+    juju subnets
+
+To list subnets associated with a specific network space:
+
+    juju subnets --space my-space
+
+To list subnets associated with a specific availability zone:
+
+    juju subnets --zone my-zone
+`
+
 // Info is defined on the cmd.Command interface.
 func (c *ListCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "subnets",
-		Args:    "[--space <name>] [--zone <name>] [--format yaml|json] [--output <path>]",
-		Purpose: "List subnets known to Juju.",
-		Doc:     strings.TrimSpace(listCommandDoc),
-		Aliases: []string{"list-subnets"},
+		Name:     "subnets",
+		Args:     "[--space <name>] [--zone <name>] [--format yaml|json] [--output <path>]",
+		Purpose:  "List subnets known to Juju.",
+		Doc:      strings.TrimSpace(listCommandDoc),
+		Aliases:  []string{"list-subnets"},
+		Examples: listCommandExample,
 	})
 }
 

--- a/cmd/juju/waitfor/waitfor.go
+++ b/cmd/juju/waitfor/waitfor.go
@@ -32,8 +32,14 @@ Built-in functions are provided to help define the goal state. The built-in
 functions are defined in the query package. Examples of built-in functions
 include len, print, forEach (lambda), startsWith and endsWith.
 
-Examples:
+See also:
+    wait-for model
+    wait-for application
+    wait-for machine
+    wait-for unit
+`
 
+const waitForExamples = `
 Waits for the mysql/0 unit to be created and active.
 
     juju wait-for unit mysql/0
@@ -45,12 +51,6 @@ Waits for the mysql application to be active or idle.
 Waits for the model units to all start with ubuntu.
 
     juju wait-for model default --query='forEach(units, unit => startsWith(unit.name, "ubuntu"))'
-
-See also:
-    wait-for model
-    wait-for application
-    wait-for machine
-    wait-for unit
 `
 
 // NewWaitForCommand creates the wait-for supercommand and registers the
@@ -61,6 +61,7 @@ func NewWaitForCommand() cmd.Command {
 		UsagePrefix: "juju",
 		Doc:         waitForDoc,
 		Purpose:     "Wait for an entity to reach a specified state.",
+		Examples:    waitForExamples,
 	})
 
 	waitFor.Register(newApplicationCommand())


### PR DESCRIPTION
This PR is fixing docstrings for juju commands, mainly for adding SeeAlso and Example docs.