### PR TITLE
Improve storage directive parsing

### DIFF
--- a/cmd/juju/storage/add.go
+++ b/cmd/juju/storage/add.go
@@ -48,11 +48,18 @@ and where to provision it from. <storage-directive> takes the following form:
 <storage-name> is defined in the charm's metadata.yaml file.   
 
 <storage-constraint> is a description of how Juju should provision storage 
-instances for the unit. The following three forms are accepted:
+instances for the unit. They are made up of up to three parts: <storage-pool>,
+<count>, and <size>. They can be provided in any order, but we recommend the
+following:
 
-    <storage-pool>[,<count>][,<size>]
-    <count>[,<size>]
-    <size>
+    <storage-pool>,<count>,<size>
+
+Each parameter is optional, so long as at least one is present. So the following
+storage constraints are also valid:
+
+   <storage-pool>,<size>
+   <count>,<size>
+   <size>
 
 <storage-pool> is the storage pool to provision storage instances from. Must 
 be a name from 'juju storage-pools'.  The default pool is available via 

--- a/storage/constraints.go
+++ b/storage/constraints.go
@@ -61,14 +61,16 @@ func ParseConstraints(s string) (Constraints, error) {
 		if IsValidPoolName(field) {
 			if cons.Pool != "" {
 				return cons, errors.NotValidf("pool name is already set to %q, new value %q", cons.Pool, field)
-			} else {
-				cons.Pool = field
 			}
+			cons.Pool = field
 			continue
 		}
 		if count, ok, err := parseCount(field); ok {
 			if err != nil {
 				return cons, errors.Annotate(err, "cannot parse count")
+			}
+			if cons.Count != 0 {
+				return cons, errors.NotValidf("storage instance count is already set to %d, new value %d", cons.Count, count)
 			}
 			cons.Count = count
 			continue
@@ -76,6 +78,9 @@ func ParseConstraints(s string) (Constraints, error) {
 		if size, ok, err := parseSize(field); ok {
 			if err != nil {
 				return cons, errors.Annotate(err, "cannot parse size")
+			}
+			if cons.Size != 0 {
+				return cons, errors.NotValidf("storage size is already set to %d, new value %d", cons.Size, size)
 			}
 			cons.Size = size
 			continue

--- a/storage/constraints_test.go
+++ b/storage/constraints_test.go
@@ -49,6 +49,11 @@ func (s *ConstraintsSuite) TestParseConstraintsCountSize(c *gc.C) {
 		Count: 3,
 		Size:  1024 * 1024 * 128,
 	})
+	s.testParse(c, "3,p,0.125P", storage.Constraints{
+		Pool:  "p",
+		Count: 3,
+		Size:  1024 * 1024 * 128,
+	})
 }
 
 func (s *ConstraintsSuite) TestParseConstraintsOptions(c *gc.C) {
@@ -75,6 +80,14 @@ func (s *ConstraintsSuite) TestParseMultiplePoolNames(c *gc.C) {
 	s.testParseError(c, "pool1,anyoldjunk", `pool name is already set to "pool1", new value "anyoldjunk" not valid`)
 	s.testParseError(c, "pool1,pool2", `pool name is already set to "pool1", new value "pool2" not valid`)
 	s.testParseError(c, "pool1,pool2,pool3", `pool name is already set to "pool1", new value "pool2" not valid`)
+}
+
+func (s *ConstraintsSuite) TestParseMultipleCounts(c *gc.C) {
+	s.testParseError(c, "pool1,10,20", `storage instance count is already set to 10, new value 20 not valid`)
+}
+
+func (s *ConstraintsSuite) TestParseMultipleStorageSize(c *gc.C) {
+	s.testParseError(c, "pool1,10M,20M", `storage size is already set to 10, new value 20 not valid`)
 }
 
 func (s *ConstraintsSuite) TestParseConstraintsUnknown(c *gc.C) {


### PR DESCRIPTION
Our storage directive parsing is fairly naive. We just split on commas, then iterative over the parts, filling in the parts of a Constraints struct as we go

We check if the pool name is overwritten, returning an error if it is. Do the same for size and count. This will mean that cases like "ebs,1024,3" will fail, instead of passing silently

Update help text to reflect reality for storage constraints

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```
$ juju bootstrap lxd lxd
$ juju add-model m
$ juju deploy postgresql
$ juju add-storage postgresql/0 pgdata=tmpfs,100,3
ERROR cannot parse constraints for storage "pgdata": storage instance count is already set to 100, new value 3 not valid

$ juju add-storage postgresql/0 pgdata=tmpfs,100M,3M
ERROR cannot parse constraints for storage "pgdata": storage size is already set to 100, new value 3 not valid
```

## Links

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/1634254

**Jira card:** [JUJU-3772](https://warthogs.atlassian.net/browse/JUJU-3772)



[JUJU-3772]: https://warthogs.atlassian.net/browse/JUJU-3772?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ