### PR TITLE
API context common packages

### DIFF
--- a/api/agent/machiner/machine.go
+++ b/api/agent/machiner/machine.go
@@ -89,8 +89,8 @@ func (m *Machine) EnsureDead() error {
 }
 
 // Watch returns a watcher for observing changes to the machine.
-func (m *Machine) Watch() (watcher.NotifyWatcher, error) {
-	return common.Watch(m.client.facade, "Watch", m.tag)
+func (m *Machine) Watch(ctx context.Context) (watcher.NotifyWatcher, error) {
+	return common.Watch(ctx, m.client.facade, "Watch", m.tag)
 }
 
 // Jobs returns a list of jobs for the machine.

--- a/api/agent/machiner/machiner_test.go
+++ b/api/agent/machiner/machiner_test.go
@@ -242,7 +242,7 @@ func (s *machinerSuite) TestWatch(c *gc.C) {
 	client := machiner.NewClient(apiCaller)
 	m, err := client.Machine(context.Background(), tag)
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = m.Watch()
+	_, err = m.Watch(context.Background())
 	c.Assert(err, gc.ErrorMatches, "FAIL")
 	c.Assert(calls, gc.Equals, 2)
 }

--- a/api/agent/uniter/application.go
+++ b/api/agent/uniter/application.go
@@ -43,8 +43,8 @@ func (s *Application) String() string {
 }
 
 // Watch returns a watcher for observing changes to an application.
-func (s *Application) Watch() (watcher.NotifyWatcher, error) {
-	return common.Watch(s.client.facade, "Watch", s.tag)
+func (s *Application) Watch(ctx context.Context) (watcher.NotifyWatcher, error) {
+	return common.Watch(ctx, s.client.facade, "Watch", s.tag)
 }
 
 // Life returns the application's current life state.

--- a/api/agent/uniter/application_test.go
+++ b/api/agent/uniter/application_test.go
@@ -128,7 +128,7 @@ func (s *applicationSuite) TestWatch(c *gc.C) {
 	app, err := client.Application(context.Background(), names.NewApplicationTag("mysql"))
 	c.Assert(err, jc.ErrorIsNil)
 
-	w, err := app.Watch()
+	w, err := app.Watch(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	wc := watchertest.NewNotifyWatcherC(c, w)
 	defer wc.AssertStops()

--- a/api/agent/uniter/unit.go
+++ b/api/agent/uniter/unit.go
@@ -160,8 +160,8 @@ func (u *Unit) EnsureDead() error {
 }
 
 // Watch returns a watcher for observing changes to the unit.
-func (u *Unit) Watch() (watcher.NotifyWatcher, error) {
-	return common.Watch(u.client.facade, "Watch", u.tag)
+func (u *Unit) Watch(ctx context.Context) (watcher.NotifyWatcher, error) {
+	return common.Watch(ctx, u.client.facade, "Watch", u.tag)
 }
 
 // WatchRelations returns a StringsWatcher that notifies of changes to
@@ -547,8 +547,8 @@ func (u *Unit) WatchActionNotifications() (watcher.StringsWatcher, error) {
 
 // WatchUpgradeSeriesNotifications returns a NotifyWatcher for observing the
 // state of a series upgrade.
-func (u *Unit) WatchUpgradeSeriesNotifications() (watcher.NotifyWatcher, error) {
-	return u.client.WatchUpgradeSeriesNotifications()
+func (u *Unit) WatchUpgradeSeriesNotifications(ctx context.Context) (watcher.NotifyWatcher, error) {
+	return u.client.WatchUpgradeSeriesNotifications(ctx)
 }
 
 // LogActionMessage logs a progress message for the specified action.
@@ -565,13 +565,13 @@ func (u *Unit) LogActionMessage(tag names.ActionTag, message string) error {
 }
 
 // UpgradeSeriesStatus returns the upgrade series status of a unit from remote state
-func (u *Unit) UpgradeSeriesStatus() (model.UpgradeSeriesStatus, string, error) {
-	return u.client.UpgradeSeriesUnitStatus()
+func (u *Unit) UpgradeSeriesStatus(ctx context.Context) (model.UpgradeSeriesStatus, string, error) {
+	return u.client.UpgradeSeriesUnitStatus(ctx)
 }
 
 // SetUpgradeSeriesStatus sets the upgrade series status of the unit in the remote state
-func (u *Unit) SetUpgradeSeriesStatus(status model.UpgradeSeriesStatus, reason string) error {
-	return u.client.SetUpgradeSeriesUnitStatus(status, reason)
+func (u *Unit) SetUpgradeSeriesStatus(ctx context.Context, status model.UpgradeSeriesStatus, reason string) error {
+	return u.client.SetUpgradeSeriesUnitStatus(ctx, status, reason)
 }
 
 // RequestReboot sets the reboot flag for its machine agent
@@ -726,14 +726,14 @@ func (u *Unit) NetworkInfo(bindings []string, relationId *int) (map[string]param
 
 // State returns the state persisted by the charm running in this unit
 // and the state internal to the uniter for this unit.
-func (u *Unit) State() (params.UnitStateResult, error) {
-	return u.client.State()
+func (u *Unit) State(ctx context.Context) (params.UnitStateResult, error) {
+	return u.client.State(ctx)
 }
 
 // SetState sets the state persisted by the charm running in this unit
 // and the state internal to the uniter for this unit.
-func (u *Unit) SetState(unitState params.SetUnitStateArg) error {
-	return u.client.SetState(unitState)
+func (u *Unit) SetState(ctx context.Context, unitState params.SetUnitStateArg) error {
+	return u.client.SetState(ctx, unitState)
 }
 
 // CommitHookChanges batches together all required API calls for applying

--- a/api/agent/uniter/unit_test.go
+++ b/api/agent/uniter/unit_test.go
@@ -250,7 +250,7 @@ func (s *unitSuite) TestWatch(c *gc.C) {
 	client := uniter.NewClient(apiCaller, names.NewUnitTag("mysql/0"))
 
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
-	w, err := unit.Watch()
+	w, err := unit.Watch(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	wc := watchertest.NewNotifyWatcherC(c, w)
 	defer wc.AssertStops()
@@ -639,7 +639,7 @@ func (s *unitSuite) TestWatchUpgradeSeriesNotifications(c *gc.C) {
 	client := uniter.NewClient(apiCaller, names.NewUnitTag("mysql/0"))
 
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
-	w, err := unit.WatchUpgradeSeriesNotifications()
+	w, err := unit.WatchUpgradeSeriesNotifications(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	wc := watchertest.NewNotifyWatcherC(c, w)
 	defer wc.AssertStops()
@@ -673,7 +673,7 @@ func (s *unitSuite) TestUpgradeSeriesStatus(c *gc.C) {
 	client := uniter.NewClient(apiCaller, names.NewUnitTag("mysql/0"))
 
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
-	err := unit.SetUpgradeSeriesStatus(model.UpgradeSeriesCompleted, "done")
+	err := unit.SetUpgradeSeriesStatus(context.Background(), model.UpgradeSeriesCompleted, "done")
 	c.Assert(err, gc.ErrorMatches, "biff")
 }
 
@@ -694,7 +694,7 @@ func (s *unitSuite) TestSetUpgradeSeriesStatus(c *gc.C) {
 	client := uniter.NewClient(apiCaller, names.NewUnitTag("mysql/0"))
 
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
-	seriesStatus, target, err := unit.UpgradeSeriesStatus()
+	seriesStatus, target, err := unit.UpgradeSeriesStatus(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(seriesStatus, gc.Equals, model.UpgradeSeriesCompleted)
 	c.Check(target, gc.Equals, "focal")
@@ -750,7 +750,7 @@ func (s *unitSuite) TestUnitState(c *gc.C) {
 	client := uniter.NewClient(apiCaller, names.NewUnitTag("mysql/0"))
 
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
-	result, err := unit.State()
+	result, err := unit.State(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, unitState)
 }
@@ -776,7 +776,7 @@ func (s *unitSuite) TestSetState(c *gc.C) {
 	client := uniter.NewClient(apiCaller, names.NewUnitTag("mysql/0"))
 
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
-	err := unit.SetState(unitState)
+	err := unit.SetState(context.Background(), unitState)
 	c.Assert(err, gc.ErrorMatches, "biff")
 }
 

--- a/api/client/modelmanager/modelmanager_test.go
+++ b/api/client/modelmanager/modelmanager_test.go
@@ -4,6 +4,7 @@
 package modelmanager_test
 
 import (
+	"context"
 	"regexp"
 	"time"
 
@@ -325,7 +326,7 @@ func (s *modelmanagerSuite) TestModelStatus(c *gc.C) {
 	mockFacadeCaller.EXPECT().FacadeCall(gomock.Any(), "ModelStatus", args, res).SetArg(3, ress).Return(nil)
 	client := common.NewModelStatusAPI(mockFacadeCaller)
 
-	results, err := client.ModelStatus(coretesting.ModelTag, coretesting.ModelTag)
+	results, err := client.ModelStatus(context.Background(), coretesting.ModelTag, coretesting.ModelTag)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results[0], jc.DeepEquals, base.ModelStatus{
 		UUID:               coretesting.ModelTag.Id(),
@@ -354,7 +355,7 @@ func (s *modelmanagerSuite) TestModelStatusEmpty(c *gc.C) {
 	mockFacadeCaller.EXPECT().FacadeCall(gomock.Any(), "ModelStatus", args, res).SetArg(3, ress).Return(nil)
 	client := common.NewModelStatusAPI(mockFacadeCaller)
 
-	results, err := client.ModelStatus()
+	results, err := client.ModelStatus(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, []base.ModelStatus{})
 }
@@ -375,7 +376,7 @@ func (s *modelmanagerSuite) TestModelStatusError(c *gc.C) {
 	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
 	mockFacadeCaller.EXPECT().FacadeCall(gomock.Any(), "ModelStatus", args, res).Return(errors.New("model error"))
 	client := common.NewModelStatusAPI(mockFacadeCaller)
-	out, err := client.ModelStatus(coretesting.ModelTag, coretesting.ModelTag)
+	out, err := client.ModelStatus(context.Background(), coretesting.ModelTag, coretesting.ModelTag)
 	c.Assert(err, gc.ErrorMatches, "model error")
 	c.Assert(out, gc.IsNil)
 }

--- a/api/common/apiaddresser.go
+++ b/api/common/apiaddresser.go
@@ -28,9 +28,9 @@ func NewAPIAddresser(facade base.FacadeCaller) *APIAddresser {
 }
 
 // APIAddresses returns the list of addresses used to connect to the API.
-func (a *APIAddresser) APIAddresses() ([]string, error) {
+func (a *APIAddresser) APIAddresses(ctx context.Context) ([]string, error) {
 	var result params.StringsResult
-	err := a.facade.FacadeCall(context.TODO(), "APIAddresses", nil, &result)
+	err := a.facade.FacadeCall(ctx, "APIAddresses", nil, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -42,9 +42,9 @@ func (a *APIAddresser) APIAddresses() ([]string, error) {
 }
 
 // APIHostPorts returns the host/port addresses of the API servers.
-func (a *APIAddresser) APIHostPorts() ([]network.ProviderHostPorts, error) {
+func (a *APIAddresser) APIHostPorts(ctx context.Context) ([]network.ProviderHostPorts, error) {
 	var result params.APIHostPortsResult
-	err := a.facade.FacadeCall(context.TODO(), "APIHostPorts", nil, &result)
+	err := a.facade.FacadeCall(ctx, "APIHostPorts", nil, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -52,9 +52,9 @@ func (a *APIAddresser) APIHostPorts() ([]network.ProviderHostPorts, error) {
 }
 
 // WatchAPIHostPorts watches the host/port addresses of the API servers.
-func (a *APIAddresser) WatchAPIHostPorts() (watcher.NotifyWatcher, error) {
+func (a *APIAddresser) WatchAPIHostPorts(ctx context.Context) (watcher.NotifyWatcher, error) {
 	var result params.NotifyWatchResult
-	err := a.facade.FacadeCall(context.TODO(), "WatchAPIHostPorts", nil, &result)
+	err := a.facade.FacadeCall(ctx, "WatchAPIHostPorts", nil, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/api/common/apiaddresser_test.go
+++ b/api/common/apiaddresser_test.go
@@ -4,6 +4,7 @@
 package common_test
 
 import (
+	"context"
 	"time"
 
 	jujutesting "github.com/juju/testing"
@@ -38,7 +39,7 @@ func (s *apiaddresserSuite) TestAPIAddresses(c *gc.C) {
 	facade.EXPECT().FacadeCall(gomock.Any(), "APIAddresses", nil, gomock.Any()).SetArg(3, result).Return(nil)
 
 	client := common.NewAPIAddresser(facade)
-	addresses, err := client.APIAddresses()
+	addresses, err := client.APIAddresses(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(addresses, gc.DeepEquals, []string{"0.1.2.3:1234"})
 }
@@ -81,7 +82,7 @@ func (s *apiaddresserSuite) TestAPIHostPorts(c *gc.C) {
 		{corenetwork.ProviderHostPort{ProviderAddress: corenetwork.NewMachineAddress("3.4.5.6").AsProviderAddress(), NetPort: 3456}},
 	}
 
-	serverAddrs, err := client.APIHostPorts()
+	serverAddrs, err := client.APIHostPorts(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(serverAddrs, gc.DeepEquals, expectServerAddrs)
 }
@@ -100,7 +101,7 @@ func (s *apiaddresserSuite) TestWatchAPIHostPorts(c *gc.C) {
 	facade.EXPECT().RawAPICaller().Return(caller)
 
 	client := common.NewAPIAddresser(facade)
-	w, err := client.WatchAPIHostPorts()
+	w, err := client.WatchAPIHostPorts(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 
 	// watch for the changes

--- a/api/common/controllerconfig.go
+++ b/api/common/controllerconfig.go
@@ -24,9 +24,9 @@ func NewControllerConfig(facade base.FacadeCaller) *ControllerConfigAPI {
 }
 
 // ControllerConfig returns the current controller configuration.
-func (e *ControllerConfigAPI) ControllerConfig() (controller.Config, error) {
+func (e *ControllerConfigAPI) ControllerConfig(ctx context.Context) (controller.Config, error) {
 	var result params.ControllerConfigResult
-	err := e.facade.FacadeCall(context.TODO(), "ControllerConfig", nil, &result)
+	err := e.facade.FacadeCall(ctx, "ControllerConfig", nil, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/api/common/leadership.go
+++ b/api/common/leadership.go
@@ -41,9 +41,9 @@ func NewLeadershipPinningAPIFromFacade(facade base.FacadeCaller) *LeadershipPinn
 // PinnedLeadership returns a collection of application names for which
 // leadership is currently pinned, with the entities requiring each
 // application's pinned behaviour.
-func (a *LeadershipPinningAPI) PinnedLeadership() (map[string][]names.Tag, error) {
+func (a *LeadershipPinningAPI) PinnedLeadership(ctx context.Context) (map[string][]names.Tag, error) {
 	var callResult params.PinnedLeadershipResult
-	err := a.facade.FacadeCall(context.TODO(), "PinnedLeadership", nil, &callResult)
+	err := a.facade.FacadeCall(ctx, "PinnedLeadership", nil, &callResult)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -73,8 +73,8 @@ func (a *LeadershipPinningAPI) PinnedLeadership() (map[string][]names.Tag, error
 // If the caller is not a machine agent, an error will be returned.
 // The return is a collection of applications determined to be running on the
 // machine, with the result of each individual pin operation.
-func (a *LeadershipPinningAPI) PinMachineApplications() (map[string]error, error) {
-	res, err := a.pinMachineAppsOps("PinMachineApplications")
+func (a *LeadershipPinningAPI) PinMachineApplications(ctx context.Context) (map[string]error, error) {
+	res, err := a.pinMachineAppsOps(ctx, "PinMachineApplications")
 	return res, errors.Trace(err)
 }
 
@@ -83,16 +83,16 @@ func (a *LeadershipPinningAPI) PinMachineApplications() (map[string]error, error
 // If the caller is not a machine agent, an error will be returned.
 // The return is a collection of applications determined to be running on the
 // machine, with the result of each individual unpin operation.
-func (a *LeadershipPinningAPI) UnpinMachineApplications() (map[string]error, error) {
-	res, err := a.pinMachineAppsOps("UnpinMachineApplications")
+func (a *LeadershipPinningAPI) UnpinMachineApplications(ctx context.Context) (map[string]error, error) {
+	res, err := a.pinMachineAppsOps(ctx, "UnpinMachineApplications")
 	return res, errors.Trace(err)
 }
 
 // pinMachineAppsOps makes a facade call to the input method name and
 // transforms the response into map.
-func (a *LeadershipPinningAPI) pinMachineAppsOps(callName string) (map[string]error, error) {
+func (a *LeadershipPinningAPI) pinMachineAppsOps(ctx context.Context, callName string) (map[string]error, error) {
 	var callResult params.PinApplicationsResults
-	err := a.facade.FacadeCall(context.TODO(), callName, nil, &callResult)
+	err := a.facade.FacadeCall(ctx, callName, nil, &callResult)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/api/common/leadership_test.go
+++ b/api/common/leadership_test.go
@@ -4,6 +4,7 @@
 package common_test
 
 import (
+	"context"
 	"errors"
 
 	"github.com/juju/names/v5"
@@ -41,7 +42,7 @@ func (s *LeadershipSuite) TestPinnedLeadership(c *gc.C) {
 	resultSource := params.PinnedLeadershipResult{Result: pinned}
 	s.facade.EXPECT().FacadeCall(gomock.Any(), "PinnedLeadership", nil, gomock.Any()).SetArg(3, resultSource)
 
-	res, err := s.client.PinnedLeadership()
+	res, err := s.client.PinnedLeadership(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(res, gc.DeepEquals, map[string][]names.Tag{"redis": {names.NewMachineTag("0"), names.NewMachineTag("1")}})
 }
@@ -52,7 +53,7 @@ func (s *LeadershipSuite) TestPinnedLeadershipError(c *gc.C) {
 	resultSource := params.PinnedLeadershipResult{Error: apiservererrors.ServerError(errors.New("splat"))}
 	s.facade.EXPECT().FacadeCall(gomock.Any(), "PinnedLeadership", nil, gomock.Any()).SetArg(3, resultSource)
 
-	_, err := s.client.PinnedLeadership()
+	_, err := s.client.PinnedLeadership(context.Background())
 	c.Assert(err, gc.ErrorMatches, "splat")
 }
 
@@ -62,7 +63,7 @@ func (s *LeadershipSuite) TestPinMachineApplicationsSuccess(c *gc.C) {
 	resultSource := params.PinApplicationsResults{Results: s.pinApplicationsServerSuccessResults()}
 	s.facade.EXPECT().FacadeCall(gomock.Any(), "PinMachineApplications", nil, gomock.Any()).SetArg(3, resultSource)
 
-	res, err := s.client.PinMachineApplications()
+	res, err := s.client.PinMachineApplications(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(res, gc.DeepEquals, s.pinApplicationsClientSuccessResults())
 }
@@ -76,7 +77,7 @@ func (s *LeadershipSuite) TestPinMachineApplicationsPartialError(c *gc.C) {
 	resultSource := params.PinApplicationsResults{Results: results}
 	s.facade.EXPECT().FacadeCall(gomock.Any(), "PinMachineApplications", nil, gomock.Any()).SetArg(3, resultSource)
 
-	res, err := s.client.PinMachineApplications()
+	res, err := s.client.PinMachineApplications(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 
 	exp := s.pinApplicationsClientSuccessResults()
@@ -90,7 +91,7 @@ func (s *LeadershipSuite) TestUnpinMachineApplicationsSuccess(c *gc.C) {
 	resultSource := params.PinApplicationsResults{Results: s.pinApplicationsServerSuccessResults()}
 	s.facade.EXPECT().FacadeCall(gomock.Any(), "UnpinMachineApplications", nil, gomock.Any()).SetArg(3, resultSource)
 
-	res, err := s.client.UnpinMachineApplications()
+	res, err := s.client.UnpinMachineApplications(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(res, gc.DeepEquals, s.pinApplicationsClientSuccessResults())
 }
@@ -113,7 +114,7 @@ func (s *LeadershipSuite) TestUnpinMachineApplicationsPartialError(c *gc.C) {
 	resultSource := params.PinApplicationsResults{Results: results}
 	s.facade.EXPECT().FacadeCall(gomock.Any(), "UnpinMachineApplications", nil, gomock.Any()).SetArg(3, resultSource)
 
-	res, err := s.client.UnpinMachineApplications()
+	res, err := s.client.UnpinMachineApplications(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 
 	exp := s.pinApplicationsClientSuccessResults()

--- a/api/common/life.go
+++ b/api/common/life.go
@@ -23,7 +23,7 @@ func Life(ctx context.Context, caller base.FacadeCaller, tags []names.Tag) ([]pa
 	var result params.LifeResults
 	entities := make([]params.Entity, len(tags))
 	for i, t := range tags {
-		entities[i] = params.Entity{t.String()}
+		entities[i] = params.Entity{Tag: t.String()}
 	}
 	args := params.Entities{Entities: entities}
 	if err := caller.FacadeCall(ctx, "Life", args, &result); err != nil {

--- a/api/common/modelstatus.go
+++ b/api/common/modelstatus.go
@@ -28,7 +28,7 @@ func NewModelStatusAPI(facade base.FacadeCaller) *ModelStatusAPI {
 }
 
 // ModelStatus returns a status summary for each model tag passed in.
-func (c *ModelStatusAPI) ModelStatus(tags ...names.ModelTag) ([]base.ModelStatus, error) {
+func (c *ModelStatusAPI) ModelStatus(ctx context.Context, tags ...names.ModelTag) ([]base.ModelStatus, error) {
 	result := params.ModelStatusResults{}
 	models := make([]params.Entity, len(tags))
 	for i, tag := range tags {
@@ -37,7 +37,7 @@ func (c *ModelStatusAPI) ModelStatus(tags ...names.ModelTag) ([]base.ModelStatus
 	req := params.Entities{
 		Entities: models,
 	}
-	if err := c.facade.FacadeCall(context.TODO(), "ModelStatus", req, &result); err != nil {
+	if err := c.facade.FacadeCall(ctx, "ModelStatus", req, &result); err != nil {
 		return nil, err
 	}
 	if len(result.Results) != len(tags) {

--- a/api/common/modelwatcher.go
+++ b/api/common/modelwatcher.go
@@ -30,9 +30,9 @@ func NewModelWatcher(facade base.FacadeCaller) *ModelWatcher {
 
 // WatchForModelConfigChanges return a NotifyWatcher waiting for the
 // model configuration to change.
-func (e *ModelWatcher) WatchForModelConfigChanges() (watcher.NotifyWatcher, error) {
+func (e *ModelWatcher) WatchForModelConfigChanges(ctx context.Context) (watcher.NotifyWatcher, error) {
 	var result params.NotifyWatchResult
-	err := e.facade.FacadeCall(context.TODO(), "WatchForModelConfigChanges", nil, &result)
+	err := e.facade.FacadeCall(ctx, "WatchForModelConfigChanges", nil, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -42,7 +42,7 @@ func (e *ModelWatcher) WatchForModelConfigChanges() (watcher.NotifyWatcher, erro
 // ModelConfig returns the current model configuration.
 func (e *ModelWatcher) ModelConfig(ctx context.Context) (*config.Config, error) {
 	var result params.ModelConfigResult
-	err := e.facade.FacadeCall(context.TODO(), "ModelConfig", nil, &result)
+	err := e.facade.FacadeCall(ctx, "ModelConfig", nil, &result)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -54,10 +54,10 @@ func (e *ModelWatcher) ModelConfig(ctx context.Context) (*config.Config, error) 
 }
 
 // UpdateStatusHookInterval returns the current update status hook interval.
-func (e *ModelWatcher) UpdateStatusHookInterval() (time.Duration, error) {
+func (e *ModelWatcher) UpdateStatusHookInterval(ctx context.Context) (time.Duration, error) {
 	// TODO(wallyworld) - lp:1602237 - this needs to have it's own backend implementation.
 	// For now, we'll piggyback off the ModelConfig API.
-	modelConfig, err := e.ModelConfig(context.Background())
+	modelConfig, err := e.ModelConfig(ctx)
 	if err != nil {
 		return 0, err
 	}
@@ -66,8 +66,8 @@ func (e *ModelWatcher) UpdateStatusHookInterval() (time.Duration, error) {
 
 // WatchUpdateStatusHookInterval returns a NotifyWatcher that fires when the
 // update status hook interval changes.
-func (e *ModelWatcher) WatchUpdateStatusHookInterval() (watcher.NotifyWatcher, error) {
+func (e *ModelWatcher) WatchUpdateStatusHookInterval(ctx context.Context) (watcher.NotifyWatcher, error) {
 	// TODO(wallyworld) - lp:1602237 - this needs to have it's own backend implementation.
 	// For now, we'll piggyback off the ModelConfig API.
-	return e.WatchForModelConfigChanges()
+	return e.WatchForModelConfigChanges(ctx)
 }

--- a/api/common/modelwatcher_test.go
+++ b/api/common/modelwatcher_test.go
@@ -61,7 +61,7 @@ func (s *modelwatcherTests) TestWatchForModelConfigChanges(c *gc.C) {
 	facade.EXPECT().RawAPICaller().Return(caller)
 
 	client := common.NewModelWatcher(facade)
-	w, err := client.WatchForModelConfigChanges()
+	w, err := client.WatchForModelConfigChanges(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 
 	// watch for the changes

--- a/api/common/unitstate.go
+++ b/api/common/unitstate.go
@@ -28,12 +28,12 @@ func NewUniterStateAPI(facade base.FacadeCaller, tag names.UnitTag) *UnitStateAP
 
 // State returns the state persisted by the charm running in this unit
 // and the state internal to the uniter for this unit.
-func (u *UnitStateAPI) State() (params.UnitStateResult, error) {
+func (u *UnitStateAPI) State(ctx context.Context) (params.UnitStateResult, error) {
 	var results params.UnitStateResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: u.tag.String()}},
 	}
-	err := u.facade.FacadeCall(context.TODO(), "State", args, &results)
+	err := u.facade.FacadeCall(ctx, "State", args, &results)
 	if err != nil {
 		return params.UnitStateResult{}, err
 	}
@@ -49,13 +49,13 @@ func (u *UnitStateAPI) State() (params.UnitStateResult, error) {
 
 // SetState sets the state persisted by the charm running in this unit
 // and the state internal to the uniter for this unit.
-func (u *UnitStateAPI) SetState(unitState params.SetUnitStateArg) error {
+func (u *UnitStateAPI) SetState(ctx context.Context, unitState params.SetUnitStateArg) error {
 	unitState.Tag = u.tag.String()
 	var results params.ErrorResults
 	args := params.SetUnitStateArgs{
 		Args: []params.SetUnitStateArg{unitState},
 	}
-	err := u.facade.FacadeCall(context.TODO(), "SetState", args, &results)
+	err := u.facade.FacadeCall(ctx, "SetState", args, &results)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/api/common/unitstate_test.go
+++ b/api/common/unitstate_test.go
@@ -4,6 +4,8 @@
 package common_test
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 	"github.com/juju/testing"
@@ -42,7 +44,7 @@ func (s *unitStateSuite) TestSetStateSingleResult(c *gc.C) {
 		return nil
 	}
 	api := common.NewUniterStateAPI(&facadeCaller, s.tag)
-	err := api.SetState(params.SetUnitStateArg{
+	err := api.SetState(context.Background(), params.SetUnitStateArg{
 		CharmState: &map[string]string{"one": "two"},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -60,7 +62,7 @@ func (s *unitStateSuite) TestSetStateReturnsQuotaExceededError(c *gc.C) {
 
 	// The client should reconstruct the quota error from the server response
 	api := common.NewUniterStateAPI(&facadeCaller, s.tag)
-	err := api.SetState(params.SetUnitStateArg{
+	err := api.SetState(context.Background(), params.SetUnitStateArg{
 		CharmState: &map[string]string{"one": "two"},
 	})
 	c.Assert(err, jc.ErrorIs, errors.QuotaLimitExceeded, gc.Commentf("expected the client to reconstruct QuotaLimitExceeded error from server response"))
@@ -83,7 +85,7 @@ func (s *unitStateSuite) TestSetStateMultipleReturnsError(c *gc.C) {
 	}
 
 	api := common.NewUniterStateAPI(&facadeCaller, s.tag)
-	err := api.SetState(params.SetUnitStateArg{
+	err := api.SetState(context.Background(), params.SetUnitStateArg{
 		CharmState: &map[string]string{"one": "two"},
 	})
 	c.Assert(err, gc.ErrorMatches, "expected 1 result, got 2")
@@ -108,7 +110,7 @@ func (s *unitStateSuite) TestStateSingleResult(c *gc.C) {
 	}
 
 	api := common.NewUniterStateAPI(&facadeCaller, s.tag)
-	obtainedUnitState, err := api.State()
+	obtainedUnitState, err := api.State(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(expectedCharmState, gc.DeepEquals, obtainedUnitState.CharmState)
 	c.Assert(expectedUniterState, gc.DeepEquals, obtainedUnitState.UniterState)
@@ -127,6 +129,6 @@ func (s *unitStateSuite) TestStateMultipleReturnsError(c *gc.C) {
 	}
 
 	api := common.NewUniterStateAPI(&facadeCaller, s.tag)
-	_, err := api.State()
+	_, err := api.State(context.Background())
 	c.Assert(err, gc.ErrorMatches, "expected 1 result, got 2")
 }

--- a/api/common/upgradeseries.go
+++ b/api/common/upgradeseries.go
@@ -32,12 +32,12 @@ func NewUpgradeSeriesAPI(facade base.FacadeCaller, tag names.Tag) *UpgradeSeries
 
 // WatchUpgradeSeriesNotifications returns a NotifyWatcher for observing the state of
 // a series upgrade.
-func (u *UpgradeSeriesAPI) WatchUpgradeSeriesNotifications() (watcher.NotifyWatcher, error) {
+func (u *UpgradeSeriesAPI) WatchUpgradeSeriesNotifications(ctx context.Context) (watcher.NotifyWatcher, error) {
 	var results params.NotifyWatchResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: u.tag.String()}},
 	}
-	err := u.facade.FacadeCall(context.TODO(), "WatchUpgradeSeriesNotifications", args, &results)
+	err := u.facade.FacadeCall(ctx, "WatchUpgradeSeriesNotifications", args, &results)
 	if err != nil {
 		return nil, err
 	}
@@ -54,13 +54,13 @@ func (u *UpgradeSeriesAPI) WatchUpgradeSeriesNotifications() (watcher.NotifyWatc
 
 // UpgradeSeriesUnitStatus returns the upgrade series status of a
 // unit from remote state.
-func (u *UpgradeSeriesAPI) UpgradeSeriesUnitStatus() (model.UpgradeSeriesStatus, string, error) {
+func (u *UpgradeSeriesAPI) UpgradeSeriesUnitStatus(ctx context.Context) (model.UpgradeSeriesStatus, string, error) {
 	var results params.UpgradeSeriesStatusResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: u.tag.String()}},
 	}
 
-	err := u.facade.FacadeCall(context.TODO(), "UpgradeSeriesUnitStatus", args, &results)
+	err := u.facade.FacadeCall(ctx, "UpgradeSeriesUnitStatus", args, &results)
 	if err != nil {
 		return "", "", err
 	}
@@ -85,7 +85,7 @@ func (u *UpgradeSeriesAPI) UpgradeSeriesUnitStatus() (model.UpgradeSeriesStatus,
 
 // SetUpgradeSeriesUnitStatus sets the upgrade series status of the
 // unit in the remote state.
-func (u *UpgradeSeriesAPI) SetUpgradeSeriesUnitStatus(status model.UpgradeSeriesStatus, reason string) error {
+func (u *UpgradeSeriesAPI) SetUpgradeSeriesUnitStatus(ctx context.Context, status model.UpgradeSeriesStatus, reason string) error {
 	var results params.ErrorResults
 	args := params.UpgradeSeriesStatusParams{
 		Params: []params.UpgradeSeriesStatusParam{{
@@ -94,7 +94,7 @@ func (u *UpgradeSeriesAPI) SetUpgradeSeriesUnitStatus(status model.UpgradeSeries
 			Message: reason,
 		}},
 	}
-	err := u.facade.FacadeCall(context.TODO(), "SetUpgradeSeriesUnitStatus", args, &results)
+	err := u.facade.FacadeCall(ctx, "SetUpgradeSeriesUnitStatus", args, &results)
 	if err != nil {
 		return err
 	}

--- a/api/common/upgradeseries_test.go
+++ b/api/common/upgradeseries_test.go
@@ -4,6 +4,8 @@
 package common_test
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 	"github.com/juju/testing"
@@ -58,7 +60,7 @@ func (s *upgradeSeriesSuite) TestWatchUpgradeSeriesNotifications(c *gc.C) {
 	facadeCaller.ReturnRawAPICaller = apitesting.BestVersionCaller{APICallerFunc: apiCaller, BestVersion: 1}
 
 	api := common.NewUpgradeSeriesAPI(&facadeCaller, s.tag)
-	_, err := api.WatchUpgradeSeriesNotifications()
+	_, err := api.WatchUpgradeSeriesNotifications(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -78,7 +80,7 @@ func (s *upgradeSeriesSuite) TestUpgradeSeriesStatusWithComplete(c *gc.C) {
 		return nil
 	}
 
-	sts, target, err := common.NewUpgradeSeriesAPI(&facadeCaller, s.tag).UpgradeSeriesUnitStatus()
+	sts, target, err := common.NewUpgradeSeriesAPI(&facadeCaller, s.tag).UpgradeSeriesUnitStatus(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(sts, gc.Equals, model.UpgradeSeriesCompleted)
 	c.Check(target, gc.Equals, "focal")
@@ -102,7 +104,7 @@ func (s *upgradeSeriesSuite) TestUpgradeSeriesStatusNotFound(c *gc.C) {
 		return nil
 	}
 	api := common.NewUpgradeSeriesAPI(&facadeCaller, s.tag)
-	_, _, err := api.UpgradeSeriesUnitStatus()
+	_, _, err := api.UpgradeSeriesUnitStatus(context.Background())
 	c.Assert(err, gc.ErrorMatches, "testing")
 	c.Check(err, jc.ErrorIs, errors.NotFound)
 }
@@ -123,7 +125,7 @@ func (s *upgradeSeriesSuite) TestUpgradeSeriesStatusMultiple(c *gc.C) {
 		return nil
 	}
 	api := common.NewUpgradeSeriesAPI(&facadeCaller, s.tag)
-	_, _, err := api.UpgradeSeriesUnitStatus()
+	_, _, err := api.UpgradeSeriesUnitStatus(context.Background())
 	c.Assert(err, gc.ErrorMatches, "expected 1 result, got 2")
 }
 
@@ -145,7 +147,7 @@ func (s *upgradeSeriesSuite) TestSetUpgradeSeriesStatus(c *gc.C) {
 		return nil
 	}
 	api := common.NewUpgradeSeriesAPI(&facadeCaller, s.tag)
-	err := api.SetUpgradeSeriesUnitStatus(model.UpgradeSeriesError, "")
+	err := api.SetUpgradeSeriesUnitStatus(context.Background(), model.UpgradeSeriesError, "")
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -165,7 +167,7 @@ func (s *upgradeSeriesSuite) TestSetUpgradeSeriesStatusNotOne(c *gc.C) {
 		return nil
 	}
 	api := common.NewUpgradeSeriesAPI(&facadeCaller, s.tag)
-	err := api.SetUpgradeSeriesUnitStatus(model.UpgradeSeriesError, "")
+	err := api.SetUpgradeSeriesUnitStatus(context.Background(), model.UpgradeSeriesError, "")
 	c.Assert(err, gc.ErrorMatches, "expected 1 result, got 0")
 }
 
@@ -187,6 +189,6 @@ func (s *upgradeSeriesSuite) TestSetUpgradeSeriesStatusResultError(c *gc.C) {
 		return nil
 	}
 	api := common.NewUpgradeSeriesAPI(&facadeCaller, s.tag)
-	err := api.SetUpgradeSeriesUnitStatus(model.UpgradeSeriesError, "")
+	err := api.SetUpgradeSeriesUnitStatus(context.Background(), model.UpgradeSeriesError, "")
 	c.Assert(err, gc.ErrorMatches, "error in call")
 }

--- a/api/common/watch.go
+++ b/api/common/watch.go
@@ -16,12 +16,12 @@ import (
 )
 
 // Watch starts a NotifyWatcher for the entity with the specified tag.
-func Watch(facade base.FacadeCaller, method string, tag names.Tag) (watcher.NotifyWatcher, error) {
+func Watch(ctx context.Context, facade base.FacadeCaller, method string, tag names.Tag) (watcher.NotifyWatcher, error) {
 	var results params.NotifyWatchResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: tag.String()}},
 	}
-	err := facade.FacadeCall(context.TODO(), method, args, &results)
+	err := facade.FacadeCall(ctx, method, args, &results)
 	if err != nil {
 		return nil, err
 	}

--- a/api/controller/caasapplicationprovisioner/client.go
+++ b/api/controller/caasapplicationprovisioner/client.go
@@ -349,8 +349,8 @@ func (c *Client) UpdateUnits(arg params.UpdateApplicationUnits) (*params.UpdateA
 
 // WatchApplication returns a NotifyWatcher that notifies of
 // changes to the application in the current model.
-func (c *Client) WatchApplication(appName string) (watcher.NotifyWatcher, error) {
-	return common.Watch(c.facade, "Watch", names.NewApplicationTag(appName))
+func (c *Client) WatchApplication(ctx context.Context, appName string) (watcher.NotifyWatcher, error) {
+	return common.Watch(ctx, c.facade, "Watch", names.NewApplicationTag(appName))
 }
 
 // ClearApplicationResources clears the flag which indicates an

--- a/api/controller/caasapplicationprovisioner/client_test.go
+++ b/api/controller/caasapplicationprovisioner/client_test.go
@@ -4,6 +4,8 @@
 package caasapplicationprovisioner_test
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 	"github.com/juju/testing"
@@ -398,7 +400,7 @@ func (s *provisionerSuite) TestWatchApplication(c *gc.C) {
 		}
 		return nil
 	})
-	watcher, err := client.WatchApplication("gitlab")
+	watcher, err := client.WatchApplication(context.Background(), "gitlab")
 	c.Assert(watcher, gc.IsNil)
 	c.Assert(err, gc.ErrorMatches, "FAIL")
 }

--- a/api/controller/caasfirewaller/client.go
+++ b/api/controller/caasfirewaller/client.go
@@ -134,12 +134,12 @@ func (c *Client) WatchApplications() (watcher.StringsWatcher, error) {
 
 // WatchApplication returns a NotifyWatcher that notifies of
 // changes to the application in the current model.
-func (c *Client) WatchApplication(appName string) (watcher.NotifyWatcher, error) {
+func (c *Client) WatchApplication(ctx context.Context, appName string) (watcher.NotifyWatcher, error) {
 	appTag, err := applicationTag(appName)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return common.Watch(c.facade, "Watch", appTag)
+	return common.Watch(ctx, c.facade, "Watch", appTag)
 }
 
 // Life returns the lifecycle state for the specified CAAS application

--- a/api/controller/caasfirewaller/client_test.go
+++ b/api/controller/caasfirewaller/client_test.go
@@ -4,6 +4,8 @@
 package caasfirewaller_test
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 	"github.com/juju/testing"
@@ -22,7 +24,7 @@ import (
 
 type clientCommmon interface {
 	WatchApplications() (watcher.StringsWatcher, error)
-	WatchApplication(string) (watcher.NotifyWatcher, error)
+	WatchApplication(context.Context, string) (watcher.NotifyWatcher, error)
 	IsExposed(string) (bool, error)
 	ApplicationConfig(string) (config.ConfigAttributes, error)
 	Life(string) (life.Value, error)
@@ -251,7 +253,7 @@ func (s *firewallerSuite) TestWatchApplication(c *gc.C) {
 	})
 
 	client := s.newFunc(apiCaller)
-	watcher, err := client.WatchApplication("gitlab")
+	watcher, err := client.WatchApplication(context.Background(), "gitlab")
 	c.Assert(watcher, gc.IsNil)
 	c.Assert(err, gc.ErrorMatches, "FAIL")
 }

--- a/api/controller/caasmodelconfigmanager/client_test.go
+++ b/api/controller/caasmodelconfigmanager/client_test.go
@@ -4,6 +4,8 @@
 package caasmodelconfigmanager_test
 
 import (
+	"context"
+
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -46,7 +48,7 @@ func (s *caasmodelconfigmanagerSuite) TestControllerConfig(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	cfg, err := client.ControllerConfig()
+	cfg, err := client.ControllerConfig(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cfg, jc.DeepEquals, controller.Config{
 		"caas-image-repo": `

--- a/api/controller/caasunitprovisioner/client.go
+++ b/api/controller/caasunitprovisioner/client.go
@@ -68,12 +68,12 @@ func (c *Client) WatchApplications() (watcher.StringsWatcher, error) {
 
 // WatchApplication returns a NotifyWatcher that notifies of
 // changes to the application in the current model.
-func (c *Client) WatchApplication(appName string) (watcher.NotifyWatcher, error) {
+func (c *Client) WatchApplication(ctx context.Context, appName string) (watcher.NotifyWatcher, error) {
 	appTag, err := applicationTag(appName)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return common.Watch(c.facade, "Watch", appTag)
+	return common.Watch(ctx, c.facade, "Watch", appTag)
 }
 
 // WatchApplicationScale returns a NotifyWatcher that notifies of

--- a/api/controller/controller/controller_test.go
+++ b/api/controller/controller/controller_test.go
@@ -4,6 +4,7 @@
 package controller_test
 
 import (
+	"context"
 	"encoding/json"
 	"time"
 
@@ -289,7 +290,7 @@ func (s *Suite) TestModelStatusEmpty(c *gc.C) {
 	})
 
 	client := controller.NewClient(apiCaller)
-	results, err := client.ModelStatus()
+	results, err := client.ModelStatus(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, []base.ModelStatus{})
 }
@@ -330,7 +331,7 @@ func (s *Suite) TestModelStatus(c *gc.C) {
 	}
 
 	client := controller.NewClient(apiCaller)
-	results, err := client.ModelStatus(coretesting.ModelTag, coretesting.ModelTag)
+	results, err := client.ModelStatus(context.Background(), coretesting.ModelTag, coretesting.ModelTag)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results[0], jc.DeepEquals, base.ModelStatus{
 		UUID:               coretesting.ModelTag.Id(),
@@ -350,7 +351,7 @@ func (s *Suite) TestModelStatusError(c *gc.C) {
 			return errors.New("model error")
 		})
 	client := controller.NewClient(apiCaller)
-	out, err := client.ModelStatus(coretesting.ModelTag, coretesting.ModelTag)
+	out, err := client.ModelStatus(context.Background(), coretesting.ModelTag, coretesting.ModelTag)
 	c.Assert(err, gc.ErrorMatches, "model error")
 	c.Assert(out, gc.IsNil)
 }
@@ -527,7 +528,7 @@ func (s *Suite) TestControllerConfig(c *gc.C) {
 	})
 
 	client := controller.NewClient(apiCaller)
-	m, err := client.ControllerConfig()
+	m, err := client.ControllerConfig(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(m, jc.DeepEquals, corecontroller.Config{"api-port": 666})
 }

--- a/api/controller/environupgrader/upgrader.go
+++ b/api/controller/environupgrader/upgrader.go
@@ -94,8 +94,8 @@ func (c *Client) SetModelEnvironVersion(tag names.ModelTag, v int) error {
 
 // WatchModelEnvironVersion starts a NotifyWatcher that notifies the caller upon
 // changes to the environ version of the model with the specified tag.
-func (c *Client) WatchModelEnvironVersion(tag names.ModelTag) (watcher.NotifyWatcher, error) {
-	return common.Watch(c.facade, "WatchModelEnvironVersion", tag)
+func (c *Client) WatchModelEnvironVersion(ctx context.Context, tag names.ModelTag) (watcher.NotifyWatcher, error) {
+	return common.Watch(ctx, c.facade, "WatchModelEnvironVersion", tag)
 }
 
 // SetModelStatus sets the status of a model.

--- a/api/controller/firewaller/application.go
+++ b/api/controller/firewaller/application.go
@@ -32,8 +32,8 @@ func (s *Application) Tag() names.ApplicationTag {
 }
 
 // Watch returns a watcher for observing changes to an application.
-func (s *Application) Watch() (watcher.NotifyWatcher, error) {
-	return common.Watch(s.client.facade, "Watch", s.tag)
+func (s *Application) Watch(ctx context.Context) (watcher.NotifyWatcher, error) {
+	return common.Watch(ctx, s.client.facade, "Watch", s.tag)
 }
 
 // ExposeInfo returns a flag to indicate whether an application is exposed

--- a/api/controller/firewaller/application_test.go
+++ b/api/controller/firewaller/application_test.go
@@ -58,7 +58,7 @@ func (s *applicationSuite) TestWatch(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	app, err := u.Application()
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = app.Watch()
+	_, err = app.Watch(context.Background())
 	c.Assert(err, gc.ErrorMatches, "FAIL")
 	c.Assert(calls, gc.Equals, 2)
 }

--- a/api/controller/instancepoller/instancepoller_test.go
+++ b/api/controller/instancepoller/instancepoller_test.go
@@ -113,7 +113,7 @@ func (s *InstancePollerSuite) TestWatchForModelConfigChangesClientError(c *gc.C)
 	apiCaller := clientErrorAPICaller(c, "WatchForModelConfigChanges", nil)
 
 	api := instancepoller.NewAPI(apiCaller)
-	w, err := api.WatchForModelConfigChanges()
+	w, err := api.WatchForModelConfigChanges(context.Background())
 	c.Assert(err, gc.ErrorMatches, "client error!")
 	c.Assert(apiCaller.CallCount, gc.Equals, 1)
 	c.Assert(w, gc.IsNil)

--- a/api/watcher/watcher_test.go
+++ b/api/watcher/watcher_test.go
@@ -148,7 +148,7 @@ func (s *watcherSuite) TestWatchMachine(c *gc.C) {
 	m, err := client.Machine(context.Background(), names.NewMachineTag("666"))
 	c.Assert(err, jc.ErrorIsNil)
 
-	w, err := m.Watch()
+	w, err := m.Watch(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	defer workertest.CleanKill(c, w)
 
@@ -183,7 +183,7 @@ func (s *watcherSuite) TestNotifyWatcherStopsWithPendingSend(c *gc.C) {
 	m, err := client.Machine(context.Background(), names.NewMachineTag("666"))
 	c.Assert(err, jc.ErrorIsNil)
 
-	w, err := m.Watch()
+	w, err := m.Watch(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	defer workertest.CleanKill(c, w)
 

--- a/cmd/juju/commands/mocks/controller_mock.go
+++ b/cmd/juju/commands/mocks/controller_mock.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	controller "github.com/juju/juju/controller"
@@ -119,18 +120,18 @@ func (c *MockControllerAPICloudSpecCall) DoAndReturn(f func(names.ModelTag) (clo
 }
 
 // ControllerConfig mocks base method.
-func (m *MockControllerAPI) ControllerConfig() (controller.Config, error) {
+func (m *MockControllerAPI) ControllerConfig(arg0 context.Context) (controller.Config, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ControllerConfig")
+	ret := m.ctrl.Call(m, "ControllerConfig", arg0)
 	ret0, _ := ret[0].(controller.Config)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ControllerConfig indicates an expected call of ControllerConfig.
-func (mr *MockControllerAPIMockRecorder) ControllerConfig() *MockControllerAPIControllerConfigCall {
+func (mr *MockControllerAPIMockRecorder) ControllerConfig(arg0 any) *MockControllerAPIControllerConfigCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ControllerConfig", reflect.TypeOf((*MockControllerAPI)(nil).ControllerConfig))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ControllerConfig", reflect.TypeOf((*MockControllerAPI)(nil).ControllerConfig), arg0)
 	return &MockControllerAPIControllerConfigCall{Call: call}
 }
 
@@ -146,13 +147,13 @@ func (c *MockControllerAPIControllerConfigCall) Return(arg0 controller.Config, a
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockControllerAPIControllerConfigCall) Do(f func() (controller.Config, error)) *MockControllerAPIControllerConfigCall {
+func (c *MockControllerAPIControllerConfigCall) Do(f func(context.Context) (controller.Config, error)) *MockControllerAPIControllerConfigCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockControllerAPIControllerConfigCall) DoAndReturn(f func() (controller.Config, error)) *MockControllerAPIControllerConfigCall {
+func (c *MockControllerAPIControllerConfigCall) DoAndReturn(f func(context.Context) (controller.Config, error)) *MockControllerAPIControllerConfigCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/cmd/juju/commands/upgradecontroller.go
+++ b/cmd/juju/commands/upgradecontroller.go
@@ -94,7 +94,7 @@ type upgradeControllerCommand struct {
 // ControllerAPI defines the controller API methods.
 type ControllerAPI interface {
 	CloudSpec(modelTag names.ModelTag) (environscloudspec.CloudSpec, error)
-	ControllerConfig() (controller.Config, error)
+	ControllerConfig(context.Context) (controller.Config, error)
 	ModelConfig() (map[string]interface{}, error)
 	Close() error
 }

--- a/cmd/juju/controller/config.go
+++ b/cmd/juju/controller/config.go
@@ -5,6 +5,7 @@ package controller
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"strings"
@@ -159,7 +160,7 @@ func (c *configCommand) Init(args []string) error {
 
 type controllerAPI interface {
 	Close() error
-	ControllerConfig() (controller.Config, error)
+	ControllerConfig(context.Context) (controller.Config, error)
 	ConfigSet(map[string]interface{}) error
 }
 
@@ -209,7 +210,7 @@ func (c *configCommand) Run(ctx *cmd.Context) error {
 
 // getAllConfig returns the entire configuration for the selected controller.
 func (c *configCommand) getAllConfig(client controllerAPI, ctx *cmd.Context) error {
-	attrs, err := client.ControllerConfig()
+	attrs, err := client.ControllerConfig(ctx.Context)
 	if err != nil {
 		return err
 	}
@@ -223,7 +224,7 @@ func (c *configCommand) getConfig(client controllerAPI, ctx *cmd.Context) error 
 	if err != nil {
 		return errors.Trace(err)
 	}
-	attrs, err := client.ControllerConfig()
+	attrs, err := client.ControllerConfig(ctx.Context)
 	if err != nil {
 		return err
 	}

--- a/cmd/juju/controller/config_test.go
+++ b/cmd/juju/controller/config_test.go
@@ -4,6 +4,7 @@
 package controller_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -256,7 +257,7 @@ func (f *fakeControllerAPI) Close() error {
 	return nil
 }
 
-func (f *fakeControllerAPI) ControllerConfig() (jujucontroller.Config, error) {
+func (f *fakeControllerAPI) ControllerConfig(context.Context) (jujucontroller.Config, error) {
 	if f.err != nil {
 		return nil, f.err
 	}

--- a/cmd/juju/controller/destroy.go
+++ b/cmd/juju/controller/destroy.go
@@ -5,6 +5,7 @@ package controller
 
 import (
 	"bytes"
+	"context"
 	stdcontext "context"
 	"fmt"
 	"text/template"
@@ -150,7 +151,7 @@ type destroyControllerAPI interface {
 	ListBlockedModels() ([]params.ModelBlockInfo, error)
 	ModelStatus(models ...names.ModelTag) ([]base.ModelStatus, error)
 	AllModels() ([]base.UserModel, error)
-	ControllerConfig() (controller.Config, error)
+	ControllerConfig(context.Context) (controller.Config, error)
 }
 
 // Info implements Command.Info.
@@ -662,7 +663,7 @@ func (c *destroyCommandBase) getControllerEnvironFromAPI(
 	if err != nil {
 		return nil, errors.Annotate(err, "getting cloud spec from API")
 	}
-	ctrlCfg, err := api.ControllerConfig()
+	ctrlCfg, err := api.ControllerConfig(ctx)
 	if err != nil {
 		return nil, errors.Annotate(err, "getting controller config from API")
 	}

--- a/cmd/juju/controller/destroy.go
+++ b/cmd/juju/controller/destroy.go
@@ -149,7 +149,7 @@ type destroyControllerAPI interface {
 	CloudSpec(names.ModelTag) (environscloudspec.CloudSpec, error)
 	DestroyController(controllerapi.DestroyControllerParams) error
 	ListBlockedModels() ([]params.ModelBlockInfo, error)
-	ModelStatus(models ...names.ModelTag) ([]base.ModelStatus, error)
+	ModelStatus(ctx context.Context, models ...names.ModelTag) ([]base.ModelStatus, error)
 	AllModels() ([]base.UserModel, error)
 	ControllerConfig(context.Context) (controller.Config, error)
 }

--- a/cmd/juju/controller/destroy_test.go
+++ b/cmd/juju/controller/destroy_test.go
@@ -114,7 +114,7 @@ func (f *fakeDestroyAPI) ListBlockedModels() ([]params.ModelBlockInfo, error) {
 	return f.blocks, f.NextErr()
 }
 
-func (f *fakeDestroyAPI) ModelStatus(tags ...names.ModelTag) ([]base.ModelStatus, error) {
+func (f *fakeDestroyAPI) ModelStatus(_ context.Context, tags ...names.ModelTag) ([]base.ModelStatus, error) {
 	f.MethodCall(f, "ModelStatus", tags)
 	status := make([]base.ModelStatus, len(tags))
 	for i, tag := range tags {

--- a/cmd/juju/controller/destroy_test.go
+++ b/cmd/juju/controller/destroy_test.go
@@ -5,6 +5,7 @@ package controller_test
 
 import (
 	"bytes"
+	"context"
 	"time"
 
 	"github.com/juju/cmd/v4"
@@ -87,7 +88,7 @@ func (f *fakeDestroyAPI) ModelConfig() (map[string]interface{}, error) {
 	return testing.FakeConfig(), nil
 }
 
-func (f *fakeDestroyAPI) ControllerConfig() (jujucontroller.Config, error) {
+func (f *fakeDestroyAPI) ControllerConfig(context.Context) (jujucontroller.Config, error) {
 	f.MethodCall(f, "ControllerConfig")
 	if err := f.NextErr(); err != nil {
 		return nil, err

--- a/cmd/juju/controller/export_test.go
+++ b/cmd/juju/controller/export_test.go
@@ -4,6 +4,7 @@
 package controller
 
 import (
+	"context"
 	"time"
 
 	"github.com/juju/clock"
@@ -173,7 +174,7 @@ func FmtModelStatus(data ModelData) string {
 }
 
 func NewData(api destroyControllerAPI, ctrUUID string) (environmentStatus, error) {
-	return newData(api, ctrUUID)
+	return newData(context.Background(), api, ctrUUID)
 }
 
 var (

--- a/cmd/juju/controller/kill.go
+++ b/cmd/juju/controller/kill.go
@@ -206,7 +206,7 @@ func (c *killCommand) DirectDestroyRemaining(
 	}
 	ctrlUUID := ""
 	// try to get controller UUID or just ignore.
-	if ctrlCfg, err := api.ControllerConfig(); err == nil {
+	if ctrlCfg, err := api.ControllerConfig(ctx.Context); err == nil {
 		ctrlUUID = ctrlCfg.ControllerUUID()
 	} else {
 		logger.Warningf("getting controller config from API: %v", err)

--- a/cmd/juju/controller/killstatus.go
+++ b/cmd/juju/controller/killstatus.go
@@ -4,6 +4,7 @@
 package controller
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -60,7 +61,7 @@ func newTimedStatusUpdater(ctx *cmd.Context, api destroyControllerAPI, controlle
 
 		// If we hit an error, status.HostedModelCount will be 0, the polling
 		// loop will stop and we'll go directly to destroying the model.
-		envStatus, err := newData(api, controllerModelUUID)
+		envStatus, err := newData(ctx.Context, api, controllerModelUUID)
 		if err != nil {
 			ctx.Infof("Unable to get the controller summary from the API: %s.", err)
 		}
@@ -69,7 +70,7 @@ func newTimedStatusUpdater(ctx *cmd.Context, api destroyControllerAPI, controlle
 	}
 }
 
-func newData(api destroyControllerAPI, controllerModelUUID string) (environmentStatus, error) {
+func newData(ctx context.Context, api destroyControllerAPI, controllerModelUUID string) (environmentStatus, error) {
 	models, err := api.AllModels()
 	if err != nil {
 		return environmentStatus{
@@ -93,7 +94,7 @@ func newData(api destroyControllerAPI, controllerModelUUID string) (environmentS
 		modelName[model.UUID] = model.Name
 	}
 
-	status, err := api.ModelStatus(modelTags...)
+	status, err := api.ModelStatus(ctx, modelTags...)
 	if err != nil {
 		return environmentStatus{
 			Controller:   ctrData{},

--- a/cmd/juju/controller/listcontrollers.go
+++ b/cmd/juju/controller/listcontrollers.go
@@ -4,6 +4,7 @@
 package controller
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"sync"
@@ -109,7 +110,7 @@ func (c *listControllersCommand) Run(ctx *cmd.Context) error {
 					return
 				}
 				defer client.Close()
-				if err := c.refreshControllerDetails(client, name); err != nil {
+				if err := c.refreshControllerDetails(ctx, client, name); err != nil {
 					fmt.Fprintf(ctx.GetStderr(), "error updating cached details for %q: %v\n", name, err)
 				}
 			}()
@@ -138,7 +139,7 @@ func (c *listControllersCommand) Run(ctx *cmd.Context) error {
 	return c.out.Write(ctx, controllerSet)
 }
 
-func (c *listControllersCommand) refreshControllerDetails(client ControllerAccessAPI, controllerName string) error {
+func (c *listControllersCommand) refreshControllerDetails(ctx context.Context, client ControllerAccessAPI, controllerName string) error {
 	// First, get all the models the user can see, and their details.
 	allModels, err := client.AllModels()
 	if err != nil {
@@ -157,7 +158,7 @@ func (c *listControllersCommand) refreshControllerDetails(client ControllerAcces
 			controllerModelUUID = m.UUID
 		}
 	}
-	modelStatus, err := client.ModelStatus(modelTags...)
+	modelStatus, err := client.ModelStatus(ctx, modelTags...)
 	if err != nil {
 		return err
 	}

--- a/cmd/juju/controller/showcontroller.go
+++ b/cmd/juju/controller/showcontroller.go
@@ -4,6 +4,7 @@
 package controller
 
 import (
+	"context"
 	"fmt"
 	"sync"
 
@@ -98,7 +99,7 @@ func (c *showControllerCommand) SetClientStore(store jujuclient.ClientStore) {
 type ControllerAccessAPI interface {
 	GetControllerAccess(user string) (permission.Access, error)
 	ModelConfig() (map[string]interface{}, error)
-	ModelStatus(models ...names.ModelTag) ([]base.ModelStatus, error)
+	ModelStatus(ctx context.Context, models ...names.ModelTag) ([]base.ModelStatus, error)
 	AllModels() ([]base.UserModel, error)
 	MongoVersion() (string, error)
 	IdentityProviderURL() (string, error)
@@ -214,7 +215,7 @@ func (c *showControllerCommand) Run(ctx *cmd.Context) error {
 				controllerModelUUID = m.UUID
 			}
 		}
-		modelStatusResults, err := client.ModelStatus(modelTags...)
+		modelStatusResults, err := client.ModelStatus(ctx.Context, modelTags...)
 		if err != nil {
 			details.Errors = append(details.Errors, err.Error())
 		}

--- a/cmd/juju/controller/showcontroller_test.go
+++ b/cmd/juju/controller/showcontroller_test.go
@@ -4,6 +4,7 @@
 package controller_test
 
 import (
+	"context"
 	"regexp"
 
 	"github.com/juju/cmd/v4"
@@ -637,7 +638,7 @@ func (*fakeController) ModelConfig() (map[string]interface{}, error) {
 	return map[string]interface{}{"agent-version": "999.99.99"}, nil
 }
 
-func (c *fakeController) ModelStatus(models ...names.ModelTag) (result []base.ModelStatus, _ error) {
+func (c *fakeController) ModelStatus(_ context.Context, models ...names.ModelTag) (result []base.ModelStatus, _ error) {
 	if c.emptyModelStatus {
 		return result, nil
 	}

--- a/cmd/juju/model/destroy_test.go
+++ b/cmd/juju/model/destroy_test.go
@@ -5,6 +5,7 @@ package model_test
 
 import (
 	"bytes"
+	"context"
 	"time"
 
 	"github.com/juju/clock/testclock"
@@ -53,7 +54,7 @@ func (f *fakeAPI) DestroyModel(tag names.ModelTag, destroyStorage *bool, force *
 	return f.NextErr()
 }
 
-func (f *fakeAPI) ModelStatus(models ...names.ModelTag) ([]base.ModelStatus, error) {
+func (f *fakeAPI) ModelStatus(_ context.Context, models ...names.ModelTag) ([]base.ModelStatus, error) {
 	var err error
 	if f.statusCallCount < len(f.modelInfoErr) {
 		modelInfoErr := f.modelInfoErr[f.statusCallCount]

--- a/cmd/juju/ssh/export_test.go
+++ b/cmd/juju/ssh/export_test.go
@@ -4,6 +4,8 @@
 package ssh
 
 import (
+	"context"
+
 	"github.com/juju/retry"
 
 	k8sexec "github.com/juju/juju/caas/kubernetes/provider/exec"
@@ -59,8 +61,8 @@ func (c *sshContainer) SetArgs(args []string) {
 	c.setArgs(args)
 }
 
-func (c *sshContainer) InitRun(mc ModelCommand) (err error) {
-	return c.initRun(mc)
+func (c *sshContainer) InitRun(ctx context.Context, mc ModelCommand) (err error) {
+	return c.initRun(ctx, mc)
 }
 
 func (c *sshContainer) Namespace() string {
@@ -75,7 +77,7 @@ type SSHContainerInterfaceForTest interface {
 	GetExecClient() (k8sexec.Executor, error)
 	ModelName() string
 	SetArgs([]string)
-	InitRun(mc ModelCommand) (err error)
+	InitRun(ctx context.Context, mc ModelCommand) (err error)
 	Namespace() string
 }
 

--- a/cmd/juju/ssh/interface.go
+++ b/cmd/juju/ssh/interface.go
@@ -4,6 +4,8 @@
 package ssh
 
 import (
+	"context"
+
 	"github.com/juju/names/v5"
 
 	"github.com/juju/juju/api/client/application"
@@ -62,5 +64,5 @@ type SSHClientAPI interface {
 
 // SSHControllerAPI defines controller related APIs.
 type SSHControllerAPI interface {
-	ControllerConfig() (controller.Config, error)
+	ControllerConfig(context.Context) (controller.Config, error)
 }

--- a/cmd/juju/ssh/mocks/package_mock.go
+++ b/cmd/juju/ssh/mocks/package_mock.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	io "io"
 	os "os"
 	reflect "reflect"
@@ -811,18 +812,18 @@ func (m *MockSSHControllerAPI) EXPECT() *MockSSHControllerAPIMockRecorder {
 }
 
 // ControllerConfig mocks base method.
-func (m *MockSSHControllerAPI) ControllerConfig() (controller.Config, error) {
+func (m *MockSSHControllerAPI) ControllerConfig(arg0 context.Context) (controller.Config, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ControllerConfig")
+	ret := m.ctrl.Call(m, "ControllerConfig", arg0)
 	ret0, _ := ret[0].(controller.Config)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ControllerConfig indicates an expected call of ControllerConfig.
-func (mr *MockSSHControllerAPIMockRecorder) ControllerConfig() *MockSSHControllerAPIControllerConfigCall {
+func (mr *MockSSHControllerAPIMockRecorder) ControllerConfig(arg0 any) *MockSSHControllerAPIControllerConfigCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ControllerConfig", reflect.TypeOf((*MockSSHControllerAPI)(nil).ControllerConfig))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ControllerConfig", reflect.TypeOf((*MockSSHControllerAPI)(nil).ControllerConfig), arg0)
 	return &MockSSHControllerAPIControllerConfigCall{Call: call}
 }
 
@@ -838,13 +839,13 @@ func (c *MockSSHControllerAPIControllerConfigCall) Return(arg0 controller.Config
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSSHControllerAPIControllerConfigCall) Do(f func() (controller.Config, error)) *MockSSHControllerAPIControllerConfigCall {
+func (c *MockSSHControllerAPIControllerConfigCall) Do(f func(context.Context) (controller.Config, error)) *MockSSHControllerAPIControllerConfigCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSSHControllerAPIControllerConfigCall) DoAndReturn(f func() (controller.Config, error)) *MockSSHControllerAPIControllerConfigCall {
+func (c *MockSSHControllerAPIControllerConfigCall) DoAndReturn(f func(context.Context) (controller.Config, error)) *MockSSHControllerAPIControllerConfigCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/cmd/juju/ssh/scp.go
+++ b/cmd/juju/ssh/scp.go
@@ -184,7 +184,7 @@ func (c *scpCommand) Init(args []string) (err error) {
 // Run resolves c.Target to a machine, or host of a unit and
 // forks ssh with c.Args, if provided.
 func (c *scpCommand) Run(ctx *cmd.Context) error {
-	if err := c.provider.initRun(&c.ModelCommandBase); err != nil {
+	if err := c.provider.initRun(ctx.Context, &c.ModelCommandBase); err != nil {
 		return errors.Trace(err)
 	}
 	defer c.provider.cleanupRun()

--- a/cmd/juju/ssh/ssh.go
+++ b/cmd/juju/ssh/ssh.go
@@ -4,6 +4,7 @@
 package ssh
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strconv"
@@ -234,7 +235,7 @@ type ModelCommand interface {
 
 // sshProvider is implemented by either a CaaS or IaaS model instance.
 type sshProvider interface {
-	initRun(ModelCommand) error
+	initRun(context.Context, ModelCommand) error
 	cleanupRun()
 	setLeaderAPI(leaderAPI LeaderAPI)
 	setHostChecker(checker jujussh.ReachableChecker)
@@ -257,7 +258,7 @@ type sshProvider interface {
 // Run resolves the given target to a machine or unit, then opens
 // an SSH connection to this target.
 func (c *sshCommand) Run(ctx *cmd.Context) error {
-	if err := c.provider.initRun(&c.ModelCommandBase); err != nil {
+	if err := c.provider.initRun(ctx.Context, &c.ModelCommandBase); err != nil {
 		return errors.Trace(err)
 	}
 	defer c.provider.cleanupRun()

--- a/cmd/juju/ssh/ssh_container.go
+++ b/cmd/juju/ssh/ssh_container.go
@@ -84,7 +84,7 @@ func (c *sshContainer) setPublicKeyRetryStrategy(_ retry.CallArgs) {}
 
 // initRun initializes the API connection if required. It must be called
 // at the top of the command's Run method.
-func (c *sshContainer) initRun(mc ModelCommand) (err error) {
+func (c *sshContainer) initRun(ctx context.Context, mc ModelCommand) (err error) {
 	if c.modelName, err = mc.ModelIdentifier(); err != nil {
 		return errors.Trace(err)
 	}
@@ -119,7 +119,7 @@ func (c *sshContainer) initRun(mc ModelCommand) (err error) {
 		if c.controllerAPI == nil {
 			c.controllerAPI = controllerapi.NewClient(cAPI)
 		}
-		controllerCfg, err := c.controllerAPI.ControllerConfig()
+		controllerCfg, err := c.controllerAPI.ControllerConfig(ctx)
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/cmd/juju/ssh/ssh_container_test.go
+++ b/cmd/juju/ssh/ssh_container_test.go
@@ -576,10 +576,10 @@ func (s *sshContainerSuite) TestNamespaceControllerModel(c *gc.C) {
 	mc.EXPECT().ModelIdentifier().Return("admin/controller", nil)
 	mc.EXPECT().NewControllerAPIRoot().Return(nil, nil)
 	mc.EXPECT().NewAPIRoot().Return(nil, nil)
-	s.controllerAPI.EXPECT().ControllerConfig().Return(
+	s.controllerAPI.EXPECT().ControllerConfig(gomock.Any()).Return(
 		controller.Config{"controller-name": "foobar"}, nil)
 
-	err := s.sshC.InitRun(mc)
+	err := s.sshC.InitRun(context.Background(), mc)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.sshC.Namespace(), gc.Equals, "controller-foobar")
 }

--- a/cmd/juju/ssh/ssh_machine.go
+++ b/cmd/juju/ssh/ssh_machine.go
@@ -5,6 +5,7 @@ package ssh
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io"
 	"net"
@@ -135,7 +136,7 @@ func (c *sshMachine) setPublicKeyRetryStrategy(retryStrategy retry.CallArgs) {
 // command's Run method.
 //
 // The sshClient, apiAddr and proxy fields are initialized after this call.
-func (c *sshMachine) initRun(mc ModelCommand) (err error) {
+func (c *sshMachine) initRun(ctx context.Context, mc ModelCommand) (err error) {
 	if c.modelName, err = mc.ModelIdentifier(); err != nil {
 		return errors.Trace(err)
 	}

--- a/domain/objectstore/service/service.go
+++ b/domain/objectstore/service/service.go
@@ -127,9 +127,6 @@ func NewWatchableService(st State, watcherFactory WatcherFactory) *WatchableServ
 	}
 }
 
-// It's for testing.
-var InitialNamespaceChanges = eventsource.InitialNamespaceChanges
-
 // Watch returns a watcher that emits the path changes that either have been
 // added or removed.
 func (s *WatchableService) Watch() (watcher.StringsWatcher, error) {
@@ -137,6 +134,6 @@ func (s *WatchableService) Watch() (watcher.StringsWatcher, error) {
 	return s.watcherFactory.NewNamespaceWatcher(
 		table,
 		changestream.All,
-		InitialNamespaceChanges(stmt),
+		eventsource.InitialNamespaceChanges(stmt),
 	)
 }

--- a/domain/objectstore/service/service_test.go
+++ b/domain/objectstore/service/service_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/juju/juju/core/changestream"
 	coreobjectstore "github.com/juju/juju/core/objectstore"
-	"github.com/juju/juju/core/watcher/eventsource"
 	"github.com/juju/juju/core/watcher/watchertest"
 	"github.com/juju/juju/domain/objectstore"
 	"github.com/juju/juju/internal/uuid"
@@ -120,10 +119,6 @@ func (s *serviceSuite) TestWatch(c *gc.C) {
 	stmt := "SELECT key FROM objectstore"
 	s.state.EXPECT().InitialWatchStatement().Return(table, stmt)
 
-	s.PatchValue(&InitialNamespaceChanges, func(selectAll string) eventsource.NamespaceQuery {
-		c.Assert(selectAll, gc.Equals, stmt)
-		return nil
-	})
 	s.watcherFactory.EXPECT().NewNamespaceWatcher(table, changestream.All, gomock.Any()).Return(watcher, nil)
 
 	w, err := NewWatchableService(s.state, s.watcherFactory).Watch()

--- a/internal/worker/agentconfigupdater/manifold.go
+++ b/internal/worker/agentconfigupdater/manifold.go
@@ -97,7 +97,7 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
-			controllerConfig, err := apiState.ControllerConfig()
+			controllerConfig, err := apiState.ControllerConfig(ctx)
 			if err != nil {
 				return nil, errors.Annotate(err, "getting controller config")
 			}

--- a/internal/worker/apiaddressupdater/apiaddressupdater.go
+++ b/internal/worker/apiaddressupdater/apiaddressupdater.go
@@ -20,8 +20,8 @@ import (
 // APIAddresser is an interface that is provided to NewAPIAddressUpdater
 // which can be used to watch for API address changes.
 type APIAddresser interface {
-	APIHostPorts() ([]corenetwork.ProviderHostPorts, error)
-	WatchAPIHostPorts() (watcher.NotifyWatcher, error)
+	APIHostPorts(context.Context) ([]corenetwork.ProviderHostPorts, error)
+	WatchAPIHostPorts(context.Context) (watcher.NotifyWatcher, error)
 }
 
 // APIAddressSetter is an interface that is provided to NewAPIAddressUpdater
@@ -81,13 +81,13 @@ func NewAPIAddressUpdater(config Config) (worker.Worker, error) {
 }
 
 // SetUp is part of the watcher.NotifyHandler interface.
-func (c *APIAddressUpdater) SetUp(_ context.Context) (watcher.NotifyWatcher, error) {
-	return c.config.Addresser.WatchAPIHostPorts()
+func (c *APIAddressUpdater) SetUp(ctx context.Context) (watcher.NotifyWatcher, error) {
+	return c.config.Addresser.WatchAPIHostPorts(ctx)
 }
 
 // Handle is part of the watcher.NotifyHandler interface.
-func (c *APIAddressUpdater) Handle(_ context.Context) error {
-	hps, err := c.getAddresses()
+func (c *APIAddressUpdater) Handle(ctx context.Context) error {
+	hps, err := c.getAddresses(ctx)
 	if err != nil {
 		return err
 	}
@@ -124,8 +124,8 @@ func (c *APIAddressUpdater) Handle(_ context.Context) error {
 	return nil
 }
 
-func (c *APIAddressUpdater) getAddresses() ([]corenetwork.ProviderHostPorts, error) {
-	addresses, err := c.config.Addresser.APIHostPorts()
+func (c *APIAddressUpdater) getAddresses(ctx context.Context) ([]corenetwork.ProviderHostPorts, error) {
+	addresses, err := c.config.Addresser.APIHostPorts(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error getting addresses: %v", err)
 	}

--- a/internal/worker/apiaddressupdater/apiaddressupdater_test.go
+++ b/internal/worker/apiaddressupdater/apiaddressupdater_test.go
@@ -53,7 +53,7 @@ func (s *APIAddressUpdaterSuite) TestStartStop(c *gc.C) {
 	client := mocks.NewMockAPIAddresser(ctrl)
 	ch := make(chan struct{}, 1)
 	watch := watchertest.NewMockNotifyWatcher(ch)
-	client.EXPECT().WatchAPIHostPorts().Return(watch, nil)
+	client.EXPECT().WatchAPIHostPorts(gomock.Any()).Return(watch, nil)
 
 	worker, err := apiaddressupdater.NewAPIAddressUpdater(
 		apiaddressupdater.Config{
@@ -76,8 +76,8 @@ func (s *APIAddressUpdaterSuite) assertInitialUpdate(c *gc.C, ctrl *gomock.Contr
 	}
 
 	client := mocks.NewMockAPIAddresser(ctrl)
-	client.EXPECT().WatchAPIHostPorts().Return(watch, nil).MinTimes(1)
-	client.EXPECT().APIHostPorts().Return([]corenetwork.ProviderHostPorts{result}, nil)
+	client.EXPECT().WatchAPIHostPorts(gomock.Any()).Return(watch, nil).MinTimes(1)
+	client.EXPECT().APIHostPorts(gomock.Any()).Return([]corenetwork.ProviderHostPorts{result}, nil)
 
 	w, err := apiaddressupdater.NewAPIAddressUpdater(
 		apiaddressupdater.Config{
@@ -126,7 +126,7 @@ func (s *APIAddressUpdaterSuite) TestAddressChange(c *gc.C) {
 		corenetwork.ProviderHostPort{ProviderAddress: corenetwork.NewMachineAddress("10.0.0.1").AsProviderAddress(), NetPort: 1234},
 	}
 
-	client.EXPECT().APIHostPorts().Return([]corenetwork.ProviderHostPorts{result}, nil)
+	client.EXPECT().APIHostPorts(gomock.Any()).Return([]corenetwork.ProviderHostPorts{result}, nil)
 
 	ch <- struct{}{}
 
@@ -147,7 +147,7 @@ func (s *APIAddressUpdaterSuite) TestAddressChangeEmpty(c *gc.C) {
 	w, client, ch := s.assertInitialUpdate(c, ctrl, setter)
 	defer workertest.CleanKill(c, w)
 
-	client.EXPECT().APIHostPorts().Return([]corenetwork.ProviderHostPorts{}, nil)
+	client.EXPECT().APIHostPorts(gomock.Any()).Return([]corenetwork.ProviderHostPorts{}, nil)
 
 	ch <- struct{}{}
 
@@ -205,7 +205,7 @@ func (s *APIAddressUpdaterSuite) TestBridgeAddressesFiltering(c *gc.C) {
 	w, client, ch := s.assertInitialUpdate(c, ctrl, setter)
 	defer workertest.CleanKill(c, w)
 
-	client.EXPECT().APIHostPorts().Return(initialServers, nil)
+	client.EXPECT().APIHostPorts(gomock.Any()).Return(initialServers, nil)
 
 	ch <- struct{}{}
 
@@ -238,7 +238,7 @@ func (s *APIAddressUpdaterSuite) TestBridgeAddressesFiltering(c *gc.C) {
 		c.Check(servers, jc.DeepEquals, []corenetwork.HostPorts{expServer1, expServerInit})
 	}
 
-	client.EXPECT().APIHostPorts().Return(updatedServers, nil)
+	client.EXPECT().APIHostPorts(gomock.Any()).Return(updatedServers, nil)
 
 	ch <- struct{}{}
 

--- a/internal/worker/apiaddressupdater/mocks/facade_mock.go
+++ b/internal/worker/apiaddressupdater/mocks/facade_mock.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	network "github.com/juju/juju/core/network"
@@ -41,18 +42,18 @@ func (m *MockAPIAddresser) EXPECT() *MockAPIAddresserMockRecorder {
 }
 
 // APIHostPorts mocks base method.
-func (m *MockAPIAddresser) APIHostPorts() ([]network.ProviderHostPorts, error) {
+func (m *MockAPIAddresser) APIHostPorts(arg0 context.Context) ([]network.ProviderHostPorts, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "APIHostPorts")
+	ret := m.ctrl.Call(m, "APIHostPorts", arg0)
 	ret0, _ := ret[0].([]network.ProviderHostPorts)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // APIHostPorts indicates an expected call of APIHostPorts.
-func (mr *MockAPIAddresserMockRecorder) APIHostPorts() *MockAPIAddresserAPIHostPortsCall {
+func (mr *MockAPIAddresserMockRecorder) APIHostPorts(arg0 any) *MockAPIAddresserAPIHostPortsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIHostPorts", reflect.TypeOf((*MockAPIAddresser)(nil).APIHostPorts))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIHostPorts", reflect.TypeOf((*MockAPIAddresser)(nil).APIHostPorts), arg0)
 	return &MockAPIAddresserAPIHostPortsCall{Call: call}
 }
 
@@ -68,30 +69,30 @@ func (c *MockAPIAddresserAPIHostPortsCall) Return(arg0 []network.ProviderHostPor
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockAPIAddresserAPIHostPortsCall) Do(f func() ([]network.ProviderHostPorts, error)) *MockAPIAddresserAPIHostPortsCall {
+func (c *MockAPIAddresserAPIHostPortsCall) Do(f func(context.Context) ([]network.ProviderHostPorts, error)) *MockAPIAddresserAPIHostPortsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockAPIAddresserAPIHostPortsCall) DoAndReturn(f func() ([]network.ProviderHostPorts, error)) *MockAPIAddresserAPIHostPortsCall {
+func (c *MockAPIAddresserAPIHostPortsCall) DoAndReturn(f func(context.Context) ([]network.ProviderHostPorts, error)) *MockAPIAddresserAPIHostPortsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // WatchAPIHostPorts mocks base method.
-func (m *MockAPIAddresser) WatchAPIHostPorts() (watcher.Watcher[struct{}], error) {
+func (m *MockAPIAddresser) WatchAPIHostPorts(arg0 context.Context) (watcher.Watcher[struct{}], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchAPIHostPorts")
+	ret := m.ctrl.Call(m, "WatchAPIHostPorts", arg0)
 	ret0, _ := ret[0].(watcher.Watcher[struct{}])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // WatchAPIHostPorts indicates an expected call of WatchAPIHostPorts.
-func (mr *MockAPIAddresserMockRecorder) WatchAPIHostPorts() *MockAPIAddresserWatchAPIHostPortsCall {
+func (mr *MockAPIAddresserMockRecorder) WatchAPIHostPorts(arg0 any) *MockAPIAddresserWatchAPIHostPortsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchAPIHostPorts", reflect.TypeOf((*MockAPIAddresser)(nil).WatchAPIHostPorts))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchAPIHostPorts", reflect.TypeOf((*MockAPIAddresser)(nil).WatchAPIHostPorts), arg0)
 	return &MockAPIAddresserWatchAPIHostPortsCall{Call: call}
 }
 
@@ -107,13 +108,13 @@ func (c *MockAPIAddresserWatchAPIHostPortsCall) Return(arg0 watcher.Watcher[stru
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockAPIAddresserWatchAPIHostPortsCall) Do(f func() (watcher.Watcher[struct{}], error)) *MockAPIAddresserWatchAPIHostPortsCall {
+func (c *MockAPIAddresserWatchAPIHostPortsCall) Do(f func(context.Context) (watcher.Watcher[struct{}], error)) *MockAPIAddresserWatchAPIHostPortsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockAPIAddresserWatchAPIHostPortsCall) DoAndReturn(f func() (watcher.Watcher[struct{}], error)) *MockAPIAddresserWatchAPIHostPortsCall {
+func (c *MockAPIAddresserWatchAPIHostPortsCall) DoAndReturn(f func(context.Context) (watcher.Watcher[struct{}], error)) *MockAPIAddresserWatchAPIHostPortsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/caasapplicationprovisioner/mocks/facade_mock.go
+++ b/internal/worker/caasapplicationprovisioner/mocks/facade_mock.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	charms "github.com/juju/juju/api/common/charms"
@@ -625,18 +626,18 @@ func (c *MockCAASProvisionerFacadeUpdateUnitsCall) DoAndReturn(f func(params.Upd
 }
 
 // WatchApplication mocks base method.
-func (m *MockCAASProvisionerFacade) WatchApplication(arg0 string) (watcher.Watcher[struct{}], error) {
+func (m *MockCAASProvisionerFacade) WatchApplication(arg0 context.Context, arg1 string) (watcher.Watcher[struct{}], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchApplication", arg0)
+	ret := m.ctrl.Call(m, "WatchApplication", arg0, arg1)
 	ret0, _ := ret[0].(watcher.Watcher[struct{}])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // WatchApplication indicates an expected call of WatchApplication.
-func (mr *MockCAASProvisionerFacadeMockRecorder) WatchApplication(arg0 any) *MockCAASProvisionerFacadeWatchApplicationCall {
+func (mr *MockCAASProvisionerFacadeMockRecorder) WatchApplication(arg0, arg1 any) *MockCAASProvisionerFacadeWatchApplicationCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchApplication", reflect.TypeOf((*MockCAASProvisionerFacade)(nil).WatchApplication), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchApplication", reflect.TypeOf((*MockCAASProvisionerFacade)(nil).WatchApplication), arg0, arg1)
 	return &MockCAASProvisionerFacadeWatchApplicationCall{Call: call}
 }
 
@@ -652,13 +653,13 @@ func (c *MockCAASProvisionerFacadeWatchApplicationCall) Return(arg0 watcher.Watc
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockCAASProvisionerFacadeWatchApplicationCall) Do(f func(string) (watcher.Watcher[struct{}], error)) *MockCAASProvisionerFacadeWatchApplicationCall {
+func (c *MockCAASProvisionerFacadeWatchApplicationCall) Do(f func(context.Context, string) (watcher.Watcher[struct{}], error)) *MockCAASProvisionerFacadeWatchApplicationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockCAASProvisionerFacadeWatchApplicationCall) DoAndReturn(f func(string) (watcher.Watcher[struct{}], error)) *MockCAASProvisionerFacadeWatchApplicationCall {
+func (c *MockCAASProvisionerFacadeWatchApplicationCall) DoAndReturn(f func(context.Context, string) (watcher.Watcher[struct{}], error)) *MockCAASProvisionerFacadeWatchApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/caasapplicationprovisioner/worker.go
+++ b/internal/worker/caasapplicationprovisioner/worker.go
@@ -53,7 +53,7 @@ type CAASProvisionerFacade interface {
 	Units(appName string) ([]params.CAASUnit, error)
 	ApplicationOCIResources(appName string) (map[string]resources.DockerImageDetails, error)
 	UpdateUnits(arg params.UpdateApplicationUnits) (*params.UpdateApplicationUnitsInfo, error)
-	WatchApplication(appName string) (watcher.NotifyWatcher, error)
+	WatchApplication(ctx context.Context, appName string) (watcher.NotifyWatcher, error)
 	ClearApplicationResources(appName string) error
 	WatchUnits(application string) (watcher.StringsWatcher, error)
 	RemoveUnit(unitName string) error

--- a/internal/worker/caasbroker/broker.go
+++ b/internal/worker/caasbroker/broker.go
@@ -24,7 +24,7 @@ import (
 type ConfigAPI interface {
 	CloudSpec(context.Context) (environscloudspec.CloudSpec, error)
 	ModelConfig(context.Context) (*config.Config, error)
-	ControllerConfig() (controller.Config, error)
+	ControllerConfig(context.Context) (controller.Config, error)
 	WatchForModelConfigChanges() (watcher.NotifyWatcher, error)
 	WatchCloudSpecChanges() (watcher.NotifyWatcher, error)
 }
@@ -67,23 +67,23 @@ type Tracker struct {
 //
 // The caller is responsible for Kill()ing the returned Tracker and Wait()ing
 // for any errors it might return.
-func NewTracker(config Config) (*Tracker, error) {
+func NewTracker(ctx context.Context, config Config) (*Tracker, error) {
 	if err := config.Validate(); err != nil {
 		return nil, errors.Trace(err)
 	}
-	cloudSpec, err := config.ConfigAPI.CloudSpec(context.TODO())
+	cloudSpec, err := config.ConfigAPI.CloudSpec(ctx)
 	if err != nil {
 		return nil, errors.Annotate(err, "cannot get cloud information")
 	}
-	cfg, err := config.ConfigAPI.ModelConfig(context.TODO())
+	cfg, err := config.ConfigAPI.ModelConfig(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	ctrlCfg, err := config.ConfigAPI.ControllerConfig()
+	ctrlCfg, err := config.ConfigAPI.ControllerConfig(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	broker, err := config.NewContainerBrokerFunc(context.TODO(), environs.OpenParams{
+	broker, err := config.NewContainerBrokerFunc(ctx, environs.OpenParams{
 		ControllerUUID: ctrlCfg.ControllerUUID(),
 		Cloud:          cloudSpec,
 		Config:         cfg,

--- a/internal/worker/caasbroker/fixture_test.go
+++ b/internal/worker/caasbroker/fixture_test.go
@@ -90,7 +90,7 @@ func (context *runContext) ModelConfig(_ context.Context) (*config.Config, error
 	return config.New(config.UseDefaults, context.config)
 }
 
-func (context *runContext) ControllerConfig() (controller.Config, error) {
+func (context *runContext) ControllerConfig(_ context.Context) (controller.Config, error) {
 	context.mu.Lock()
 	defer context.mu.Unlock()
 	context.stub.AddCall("ControllerConfig")

--- a/internal/worker/caasbroker/fixture_test.go
+++ b/internal/worker/caasbroker/fixture_test.go
@@ -135,7 +135,7 @@ func (context *runContext) CloseCloudSpecNotify() {
 }
 
 // WatchForModelConfigChanges is part of the environ.ConfigObserver interface.
-func (context *runContext) WatchForModelConfigChanges() (watcher.NotifyWatcher, error) {
+func (context *runContext) WatchForModelConfigChanges(_ context.Context) (watcher.NotifyWatcher, error) {
 	context.mu.Lock()
 	defer context.mu.Unlock()
 	context.stub.AddCall("WatchForModelConfigChanges")

--- a/internal/worker/caasbroker/manifold.go
+++ b/internal/worker/caasbroker/manifold.go
@@ -44,7 +44,7 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
-			w, err := NewTracker(Config{
+			w, err := NewTracker(ctx, Config{
 				ConfigAPI:              api,
 				NewContainerBrokerFunc: config.NewContainerBrokerFunc,
 				Logger:                 config.Logger,

--- a/internal/worker/caasfirewaller/applicationworker_test.go
+++ b/internal/worker/caasfirewaller/applicationworker_test.go
@@ -112,7 +112,7 @@ func (s *appWorkerSuite) TestWorker(c *gc.C) {
 	}
 
 	gomock.InOrder(
-		s.firewallerAPI.EXPECT().WatchApplication(s.appName).Return(s.appsWatcher, nil),
+		s.firewallerAPI.EXPECT().WatchApplication(gomock.Any(), s.appName).Return(s.appsWatcher, nil),
 		s.firewallerAPI.EXPECT().WatchOpenedPorts().Return(s.portsWatcher, nil),
 		s.broker.EXPECT().Application(s.appName, caas.DeploymentStateful).Return(s.brokerApp),
 

--- a/internal/worker/caasfirewaller/client.go
+++ b/internal/worker/caasfirewaller/client.go
@@ -4,6 +4,8 @@
 package caasfirewaller
 
 import (
+	"context"
+
 	charmscommon "github.com/juju/juju/api/common/charms"
 	"github.com/juju/juju/core/config"
 	"github.com/juju/juju/core/life"
@@ -25,7 +27,7 @@ type Client interface {
 // model, and fetching their details.
 type CAASFirewallerAPI interface {
 	WatchApplications() (watcher.StringsWatcher, error)
-	WatchApplication(string) (watcher.NotifyWatcher, error)
+	WatchApplication(context.Context, string) (watcher.NotifyWatcher, error)
 	WatchOpenedPorts() (watcher.StringsWatcher, error)
 	GetOpenedPorts(appName string) (network.GroupedPortRanges, error)
 

--- a/internal/worker/caasfirewaller/mocks/client_mock.go
+++ b/internal/worker/caasfirewaller/mocks/client_mock.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	charms "github.com/juju/juju/api/common/charms"
@@ -239,18 +240,18 @@ func (c *MockClientLifeCall) DoAndReturn(f func(string) (life.Value, error)) *Mo
 }
 
 // WatchApplication mocks base method.
-func (m *MockClient) WatchApplication(arg0 string) (watcher.Watcher[struct{}], error) {
+func (m *MockClient) WatchApplication(arg0 context.Context, arg1 string) (watcher.Watcher[struct{}], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchApplication", arg0)
+	ret := m.ctrl.Call(m, "WatchApplication", arg0, arg1)
 	ret0, _ := ret[0].(watcher.Watcher[struct{}])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // WatchApplication indicates an expected call of WatchApplication.
-func (mr *MockClientMockRecorder) WatchApplication(arg0 any) *MockClientWatchApplicationCall {
+func (mr *MockClientMockRecorder) WatchApplication(arg0, arg1 any) *MockClientWatchApplicationCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchApplication", reflect.TypeOf((*MockClient)(nil).WatchApplication), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchApplication", reflect.TypeOf((*MockClient)(nil).WatchApplication), arg0, arg1)
 	return &MockClientWatchApplicationCall{Call: call}
 }
 
@@ -266,13 +267,13 @@ func (c *MockClientWatchApplicationCall) Return(arg0 watcher.Watcher[struct{}], 
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockClientWatchApplicationCall) Do(f func(string) (watcher.Watcher[struct{}], error)) *MockClientWatchApplicationCall {
+func (c *MockClientWatchApplicationCall) Do(f func(context.Context, string) (watcher.Watcher[struct{}], error)) *MockClientWatchApplicationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockClientWatchApplicationCall) DoAndReturn(f func(string) (watcher.Watcher[struct{}], error)) *MockClientWatchApplicationCall {
+func (c *MockClientWatchApplicationCall) DoAndReturn(f func(context.Context, string) (watcher.Watcher[struct{}], error)) *MockClientWatchApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -535,18 +536,18 @@ func (c *MockCAASFirewallerAPIIsExposedCall) DoAndReturn(f func(string) (bool, e
 }
 
 // WatchApplication mocks base method.
-func (m *MockCAASFirewallerAPI) WatchApplication(arg0 string) (watcher.Watcher[struct{}], error) {
+func (m *MockCAASFirewallerAPI) WatchApplication(arg0 context.Context, arg1 string) (watcher.Watcher[struct{}], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchApplication", arg0)
+	ret := m.ctrl.Call(m, "WatchApplication", arg0, arg1)
 	ret0, _ := ret[0].(watcher.Watcher[struct{}])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // WatchApplication indicates an expected call of WatchApplication.
-func (mr *MockCAASFirewallerAPIMockRecorder) WatchApplication(arg0 any) *MockCAASFirewallerAPIWatchApplicationCall {
+func (mr *MockCAASFirewallerAPIMockRecorder) WatchApplication(arg0, arg1 any) *MockCAASFirewallerAPIWatchApplicationCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchApplication", reflect.TypeOf((*MockCAASFirewallerAPI)(nil).WatchApplication), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchApplication", reflect.TypeOf((*MockCAASFirewallerAPI)(nil).WatchApplication), arg0, arg1)
 	return &MockCAASFirewallerAPIWatchApplicationCall{Call: call}
 }
 
@@ -562,13 +563,13 @@ func (c *MockCAASFirewallerAPIWatchApplicationCall) Return(arg0 watcher.Watcher[
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockCAASFirewallerAPIWatchApplicationCall) Do(f func(string) (watcher.Watcher[struct{}], error)) *MockCAASFirewallerAPIWatchApplicationCall {
+func (c *MockCAASFirewallerAPIWatchApplicationCall) Do(f func(context.Context, string) (watcher.Watcher[struct{}], error)) *MockCAASFirewallerAPIWatchApplicationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockCAASFirewallerAPIWatchApplicationCall) DoAndReturn(f func(string) (watcher.Watcher[struct{}], error)) *MockCAASFirewallerAPIWatchApplicationCall {
+func (c *MockCAASFirewallerAPIWatchApplicationCall) DoAndReturn(f func(context.Context, string) (watcher.Watcher[struct{}], error)) *MockCAASFirewallerAPIWatchApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/caasmodelconfigmanager/mocks/facade_mock.go
+++ b/internal/worker/caasmodelconfigmanager/mocks/facade_mock.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	controller "github.com/juju/juju/controller"
@@ -41,18 +42,18 @@ func (m *MockFacade) EXPECT() *MockFacadeMockRecorder {
 }
 
 // ControllerConfig mocks base method.
-func (m *MockFacade) ControllerConfig() (controller.Config, error) {
+func (m *MockFacade) ControllerConfig(arg0 context.Context) (controller.Config, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ControllerConfig")
+	ret := m.ctrl.Call(m, "ControllerConfig", arg0)
 	ret0, _ := ret[0].(controller.Config)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ControllerConfig indicates an expected call of ControllerConfig.
-func (mr *MockFacadeMockRecorder) ControllerConfig() *MockFacadeControllerConfigCall {
+func (mr *MockFacadeMockRecorder) ControllerConfig(arg0 any) *MockFacadeControllerConfigCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ControllerConfig", reflect.TypeOf((*MockFacade)(nil).ControllerConfig))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ControllerConfig", reflect.TypeOf((*MockFacade)(nil).ControllerConfig), arg0)
 	return &MockFacadeControllerConfigCall{Call: call}
 }
 
@@ -68,13 +69,13 @@ func (c *MockFacadeControllerConfigCall) Return(arg0 controller.Config, arg1 err
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockFacadeControllerConfigCall) Do(f func() (controller.Config, error)) *MockFacadeControllerConfigCall {
+func (c *MockFacadeControllerConfigCall) Do(f func(context.Context) (controller.Config, error)) *MockFacadeControllerConfigCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockFacadeControllerConfigCall) DoAndReturn(f func() (controller.Config, error)) *MockFacadeControllerConfigCall {
+func (c *MockFacadeControllerConfigCall) DoAndReturn(f func(context.Context) (controller.Config, error)) *MockFacadeControllerConfigCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/caasmodelconfigmanager/package_test.go
+++ b/internal/worker/caasmodelconfigmanager/package_test.go
@@ -9,6 +9,9 @@ import (
 	gc "gopkg.in/check.v1"
 )
 
+//go:generate go run go.uber.org/mock/mockgen -typed -package mocks -destination mocks/facade_mock.go github.com/juju/juju/internal/worker/caasmodelconfigmanager Facade
+//go:generate go run go.uber.org/mock/mockgen -typed -package mocks -destination mocks/broker_mock.go github.com/juju/juju/internal/worker/caasmodelconfigmanager CAASBroker
+
 func TestPackage(t *stdtesting.T) {
 	gc.TestingT(t)
 }

--- a/internal/worker/caasmodelconfigmanager/worker.go
+++ b/internal/worker/caasmodelconfigmanager/worker.go
@@ -231,5 +231,5 @@ func (w *manager) ensureImageRepoSecret(ctx context.Context, reg registry.Regist
 }
 
 func (w *manager) scopedContext() (context.Context, context.CancelFunc) {
-	return context.WithCancel(context.Background())
+	return context.WithCancel(w.catacomb.Context(context.Background()))
 }

--- a/internal/worker/caasmodelconfigmanager/worker_test.go
+++ b/internal/worker/caasmodelconfigmanager/worker_test.go
@@ -160,7 +160,7 @@ func (s *workerSuite) TestWorkerTokenRefreshRequired(c *gc.C) {
 			return watchertest.NewMockStringsWatcher(controllerConfigChangedChan), nil
 		}),
 		// 1st round.
-		s.facade.EXPECT().ControllerConfig().Return(s.controllerConfig, nil),
+		s.facade.EXPECT().ControllerConfig(gomock.Any()).Return(s.controllerConfig, nil),
 		s.reg.EXPECT().Ping().Return(nil),
 		s.reg.EXPECT().ShouldRefreshAuth().Return(true, time.Duration(0)),
 		s.reg.EXPECT().RefreshAuth().Return(nil),
@@ -223,7 +223,7 @@ func (s *workerSuite) TestWorkerTokenRefreshNotRequiredThenRetry(c *gc.C) {
 			return watchertest.NewMockStringsWatcher(controllerConfigChangedChan), nil
 		}),
 		// 1st round.
-		s.facade.EXPECT().ControllerConfig().Return(s.controllerConfig, nil),
+		s.facade.EXPECT().ControllerConfig(gomock.Any()).Return(s.controllerConfig, nil),
 		s.reg.EXPECT().Ping().Return(nil),
 		s.reg.EXPECT().ShouldRefreshAuth().Return(true, time.Duration(0)),
 		s.reg.EXPECT().RefreshAuth().Return(nil),
@@ -289,7 +289,7 @@ func (s *workerSuite) TestWorkerNoOpsForPublicRepo(c *gc.C) {
 			controllerConfigChangedChan <- []string{controller.CAASImageRepo}
 			return watchertest.NewMockStringsWatcher(controllerConfigChangedChan), nil
 		}),
-		s.facade.EXPECT().ControllerConfig().DoAndReturn(func() (controller.Config, error) {
+		s.facade.EXPECT().ControllerConfig(gomock.Any()).DoAndReturn(func(context.Context) (controller.Config, error) {
 			close(done)
 			return s.controllerConfig, nil
 		}),

--- a/internal/worker/environupgrader/manifold.go
+++ b/internal/worker/environupgrader/manifold.go
@@ -29,11 +29,11 @@ type ManifoldConfig struct {
 	Logger        logger.Logger
 
 	NewFacade                    func(base.APICaller) (Facade, error)
-	NewWorker                    func(Config) (worker.Worker, error)
+	NewWorker                    func(context.Context, Config) (worker.Worker, error)
 	NewCredentialValidatorFacade func(base.APICaller) (common.CredentialAPI, error)
 }
 
-func (config ManifoldConfig) start(context context.Context, getter dependency.Getter) (worker.Worker, error) {
+func (config ManifoldConfig) start(ctx context.Context, getter dependency.Getter) (worker.Worker, error) {
 	var environ environs.Environ
 	if err := getter.Get(config.EnvironName, &environ); err != nil {
 		if errors.Cause(err) != dependency.ErrMissing {
@@ -65,7 +65,7 @@ func (config ManifoldConfig) start(context context.Context, getter dependency.Ge
 		return nil, errors.Trace(err)
 	}
 
-	worker, err := config.NewWorker(Config{
+	worker, err := config.NewWorker(ctx, Config{
 		Facade:        facade,
 		Environ:       environ,
 		GateUnlocker:  gate,

--- a/internal/worker/environupgrader/manifold_test.go
+++ b/internal/worker/environupgrader/manifold_test.go
@@ -108,7 +108,7 @@ func (*ManifoldSuite) TestNewWorkerError(c *gc.C) {
 		NewFacade: func(_ base.APICaller) (environupgrader.Facade, error) {
 			return expectFacade, nil
 		},
-		NewWorker: func(config environupgrader.Config) (worker.Worker, error) {
+		NewWorker: func(_ context.Context, config environupgrader.Config) (worker.Worker, error) {
 			c.Check(config.Facade, gc.Equals, expectFacade)
 			return nil, errors.New("boof")
 		},
@@ -136,7 +136,7 @@ func (*ManifoldSuite) TestNewWorkerSuccessWithEnviron(c *gc.C) {
 		NewFacade: func(_ base.APICaller) (environupgrader.Facade, error) {
 			return struct{ environupgrader.Facade }{}, nil
 		},
-		NewWorker: func(config environupgrader.Config) (worker.Worker, error) {
+		NewWorker: func(_ context.Context, config environupgrader.Config) (worker.Worker, error) {
 			newWorkerConfig = config
 			return expectWorker, nil
 		},
@@ -164,7 +164,7 @@ func (*ManifoldSuite) TestNewWorkerSuccessWithoutEnviron(c *gc.C) {
 		NewFacade: func(_ base.APICaller) (environupgrader.Facade, error) {
 			return struct{ environupgrader.Facade }{}, nil
 		},
-		NewWorker: func(config environupgrader.Config) (worker.Worker, error) {
+		NewWorker: func(_ context.Context, config environupgrader.Config) (worker.Worker, error) {
 			newWorkerConfig = config
 			return expectWorker, nil
 		},

--- a/internal/worker/environupgrader/worker_test.go
+++ b/internal/worker/environupgrader/worker_test.go
@@ -32,7 +32,7 @@ type WorkerSuite struct {
 var _ = gc.Suite(&WorkerSuite{})
 
 func (*WorkerSuite) TestNewWorkerValidatesConfig(c *gc.C) {
-	_, err := environupgrader.NewWorker(environupgrader.Config{})
+	_, err := environupgrader.NewWorker(context.Background(), environupgrader.Config{})
 	c.Assert(err, gc.ErrorMatches, "nil Facade not valid")
 }
 
@@ -40,7 +40,7 @@ func (*WorkerSuite) TestNewWorker(c *gc.C) {
 	mockFacade := mockFacade{current: 123, target: 124}
 	mockEnviron := mockEnviron{}
 	mockGateUnlocker := mockGateUnlocker{}
-	w, err := environupgrader.NewWorker(environupgrader.Config{
+	w, err := environupgrader.NewWorker(context.Background(), environupgrader.Config{
 		Facade:        &mockFacade,
 		Environ:       &mockEnviron,
 		GateUnlocker:  &mockGateUnlocker,
@@ -66,7 +66,7 @@ func (*WorkerSuite) TestNewWorkerModelRemovedUninstalls(c *gc.C) {
 	mockFacade.SetErrors(&params.Error{Code: params.CodeNotFound})
 	mockEnviron := mockEnviron{}
 	mockGateUnlocker := mockGateUnlocker{}
-	w, err := environupgrader.NewWorker(environupgrader.Config{
+	w, err := environupgrader.NewWorker(context.Background(), environupgrader.Config{
 		Facade:        &mockFacade,
 		Environ:       &mockEnviron,
 		GateUnlocker:  &mockGateUnlocker,
@@ -88,7 +88,7 @@ func (*WorkerSuite) TestNonUpgradeable(c *gc.C) {
 	mockFacade := mockFacade{current: 123, target: 124}
 	mockEnviron := struct{ environs.Environ }{} // not an Upgrader
 	mockGateUnlocker := mockGateUnlocker{}
-	w, err := environupgrader.NewWorker(environupgrader.Config{
+	w, err := environupgrader.NewWorker(context.Background(), environupgrader.Config{
 		Facade:        &mockFacade,
 		Environ:       &mockEnviron,
 		GateUnlocker:  &mockGateUnlocker,
@@ -141,7 +141,7 @@ func (*WorkerSuite) TestRunUpgradeOperations(c *gc.C) {
 		}},
 	}
 	mockGateUnlocker := mockGateUnlocker{}
-	w, err := environupgrader.NewWorker(environupgrader.Config{
+	w, err := environupgrader.NewWorker(context.Background(), environupgrader.Config{
 		Facade:        &mockFacade,
 		Environ:       &mockEnviron,
 		GateUnlocker:  &mockGateUnlocker,
@@ -193,7 +193,7 @@ func (*WorkerSuite) TestRunUpgradeOperationsStepError(c *gc.C) {
 		}},
 	}
 	mockGateUnlocker := mockGateUnlocker{}
-	w, err := environupgrader.NewWorker(environupgrader.Config{
+	w, err := environupgrader.NewWorker(context.Background(), environupgrader.Config{
 		Facade:        &mockFacade,
 		Environ:       &mockEnviron,
 		GateUnlocker:  &mockGateUnlocker,
@@ -224,7 +224,7 @@ func (*WorkerSuite) TestWaitForUpgrade(c *gc.C) {
 		watcher: newMockNotifyWatcher(ch),
 	}
 	mockGateUnlocker := mockGateUnlocker{}
-	w, err := environupgrader.NewWorker(environupgrader.Config{
+	w, err := environupgrader.NewWorker(context.Background(), environupgrader.Config{
 		Facade:        &mockFacade,
 		Environ:       nil, // not responsible for running upgrades
 		GateUnlocker:  &mockGateUnlocker,
@@ -276,7 +276,7 @@ func (*WorkerSuite) TestModelNotFoundWhenRunning(c *gc.C) {
 		target:  125,
 		watcher: newMockNotifyWatcher(ch),
 	}
-	w, err := environupgrader.NewWorker(environupgrader.Config{
+	w, err := environupgrader.NewWorker(context.Background(), environupgrader.Config{
 		Facade:        &mockFacade,
 		Environ:       nil, // not responsible for running upgrades
 		GateUnlocker:  &mockGateUnlocker{},
@@ -348,7 +348,7 @@ func (f *mockFacade) SetModelEnvironVersion(tag names.ModelTag, v int) error {
 	return f.NextErr()
 }
 
-func (f *mockFacade) WatchModelEnvironVersion(tag names.ModelTag) (watcher.NotifyWatcher, error) {
+func (f *mockFacade) WatchModelEnvironVersion(_ context.Context, tag names.ModelTag) (watcher.NotifyWatcher, error) {
 	f.MethodCall(f, "WatchModelEnvironVersion", tag)
 	if err := f.NextErr(); err != nil {
 		return nil, err

--- a/internal/worker/firewaller/firewaller.go
+++ b/internal/worker/firewaller/firewaller.go
@@ -261,6 +261,9 @@ func (fw *Firewaller) setUp() error {
 }
 
 func (fw *Firewaller) loop() error {
+	ctx, cancel := fw.scopedContext()
+	defer cancel()
+
 	if err := fw.setUp(); err != nil {
 		return errors.Trace(err)
 	}
@@ -301,7 +304,7 @@ func (fw *Firewaller) loop() error {
 				return errors.New("machines watcher closed")
 			}
 			for _, machineId := range change {
-				if err := fw.machineLifeChanged(context.TODO(), names.NewMachineTag(machineId)); err != nil {
+				if err := fw.machineLifeChanged(ctx, names.NewMachineTag(machineId)); err != nil {
 					return err
 				}
 			}
@@ -309,9 +312,9 @@ func (fw *Firewaller) loop() error {
 				reconciled = true
 				var err error
 				if fw.globalMode {
-					err = fw.reconcileGlobal()
+					err = fw.reconcileGlobal(ctx)
 				} else {
-					err = fw.reconcileInstances(context.TODO())
+					err = fw.reconcileInstances(ctx)
 				}
 				if err != nil {
 					return errors.Trace(err)
@@ -330,7 +333,7 @@ func (fw *Firewaller) loop() error {
 			}
 			for _, portsGlobalKey := range change {
 				machineTag := names.NewMachineTag(portsGlobalKey)
-				if err := fw.openedPortsChanged(context.TODO(), machineTag); err != nil {
+				if err := fw.openedPortsChanged(ctx, machineTag); err != nil {
 					return errors.Trace(err)
 				}
 			}
@@ -339,7 +342,7 @@ func (fw *Firewaller) loop() error {
 				return errors.New("remote relations watcher closed")
 			}
 			for _, relationKey := range change {
-				if err := fw.relationLifeChanged(context.TODO(), names.NewRelationTag(relationKey)); err != nil {
+				if err := fw.relationLifeChanged(ctx, names.NewRelationTag(relationKey)); err != nil {
 					return err
 				}
 			}
@@ -348,18 +351,18 @@ func (fw *Firewaller) loop() error {
 				return errors.New("subnet watcher closed")
 			}
 
-			if err := fw.subnetsChanged(context.TODO()); err != nil {
+			if err := fw.subnetsChanged(ctx); err != nil {
 				return errors.Trace(err)
 			}
 		case change := <-fw.localRelationsChange:
 			// We have a notification that the remote (consuming) model
 			// has changed egress networks so need to update the local
 			// model to allow those networks through the firewall.
-			if err := fw.relationIngressChanged(context.TODO(), change); err != nil {
+			if err := fw.relationIngressChanged(ctx, change); err != nil {
 				return errors.Trace(err)
 			}
 		case change := <-fw.unitsChange:
-			if err := fw.unitsChanged(context.TODO(), change); err != nil {
+			if err := fw.unitsChanged(ctx, change); err != nil {
 				return errors.Trace(err)
 			}
 		case change := <-fw.exposedChange:
@@ -369,7 +372,7 @@ func (fw *Firewaller) loop() error {
 			for _, unitd := range change.applicationd.unitds {
 				unitds = append(unitds, unitd)
 			}
-			if err := fw.flushUnits(context.TODO(), unitds); err != nil {
+			if err := fw.flushUnits(ctx, unitds); err != nil {
 				return errors.Annotate(err, "cannot change firewall ports")
 			}
 		}
@@ -571,10 +574,7 @@ func (fw *Firewaller) startApplication(app Application) error {
 	err = catacomb.Invoke(catacomb.Plan{
 		Site: &applicationd.catacomb,
 		Work: func() error {
-			ctx, cancel := context.WithCancel(applicationd.catacomb.Context(context.Background()))
-			defer cancel()
-
-			return applicationd.watchLoop(ctx, exposed, exposedEndpoints)
+			return applicationd.watchLoop(exposed, exposedEndpoints)
 		},
 	})
 	if err != nil {
@@ -589,16 +589,15 @@ func (fw *Firewaller) startApplication(app Application) error {
 // reconcileGlobal compares the initially started watcher for machines,
 // units and applications with the opened and closed ports globally and
 // opens and closes the appropriate ports for the whole environment.
-func (fw *Firewaller) reconcileGlobal() error {
+func (fw *Firewaller) reconcileGlobal(ctx context.Context) error {
 	var machines []*machineData
 	for _, machined := range fw.machineds {
 		machines = append(machines, machined)
 	}
-	want, err := fw.gatherIngressRules(machines...)
+	want, err := fw.gatherIngressRules(ctx, machines...)
 	if err != nil {
 		return err
 	}
-	ctx := stdcontext.Background()
 	initialPortRanges, err := fw.environFirewaller.IngressRules(fw.cloudCallContextFunc(ctx))
 	if err != nil {
 		return err
@@ -810,7 +809,7 @@ func (fw *Firewaller) flushMachine(ctx context.Context, machined *machineData) e
 			fw.flushMachineNotify(machined.tag.Id())
 		}
 	}()
-	want, err := fw.gatherIngressRules(machined)
+	want, err := fw.gatherIngressRules(ctx, machined)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -824,7 +823,7 @@ func (fw *Firewaller) flushMachine(ctx context.Context, machined *machineData) e
 
 // gatherIngressRules returns the ingress rules to open and close
 // for the specified machines.
-func (fw *Firewaller) gatherIngressRules(machines ...*machineData) (firewall.IngressRules, error) {
+func (fw *Firewaller) gatherIngressRules(ctx context.Context, machines ...*machineData) (firewall.IngressRules, error) {
 	var want firewall.IngressRules
 	for _, machined := range machines {
 		for unitTag := range machined.openedPortRangesByEndpoint {
@@ -834,7 +833,7 @@ func (fw *Firewaller) gatherIngressRules(machines ...*machineData) (firewall.Ing
 				continue
 			}
 
-			unitRules, err := fw.ingressRulesForMachineUnit(machined, unitd)
+			unitRules, err := fw.ingressRulesForMachineUnit(ctx, machined, unitd)
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
@@ -856,7 +855,7 @@ func (fw *Firewaller) gatherIngressRules(machines ...*machineData) (firewall.Ing
 	return want, nil
 }
 
-func (fw *Firewaller) ingressRulesForMachineUnit(machine *machineData, unit *unitData) (firewall.IngressRules, error) {
+func (fw *Firewaller) ingressRulesForMachineUnit(ctx context.Context, machine *machineData, unit *unitData) (firewall.IngressRules, error) {
 	unitPortRanges := machine.openedPortRangesByEndpoint[unit.tag]
 	if len(unitPortRanges) == 0 {
 		return nil, nil // no ports opened by the charm
@@ -865,10 +864,13 @@ func (fw *Firewaller) ingressRulesForMachineUnit(machine *machineData, unit *uni
 	var rules firewall.IngressRules
 	var err error
 	if unit.applicationd.exposed {
-		rules = fw.ingressRulesForExposedMachineUnit(machine, unit, unitPortRanges)
+		rules = fw.ingressRulesForExposedMachineUnit(unit, unitPortRanges)
 	} else {
-		if rules, err = fw.ingressRulesForNonExposedMachineUnit(unit.applicationd.application.Tag(),
-			unitPortRanges); err != nil {
+		if rules, err = fw.ingressRulesForNonExposedMachineUnit(
+			ctx,
+			unit.applicationd.application.Tag(),
+			unitPortRanges,
+		); err != nil {
 			return nil, errors.Trace(err)
 		}
 	}
@@ -880,10 +882,11 @@ func (fw *Firewaller) ingressRulesForMachineUnit(machine *machineData, unit *uni
 	return rules, nil
 }
 
-func (fw *Firewaller) ingressRulesForNonExposedMachineUnit(appTag names.ApplicationTag,
+func (fw *Firewaller) ingressRulesForNonExposedMachineUnit(ctx context.Context,
+	appTag names.ApplicationTag,
 	openUnitPortRanges network.GroupedPortRanges) (firewall.IngressRules, error) {
 	// Not exposed, so add any ingress rules required by remote relations.
-	srcCIDRs, err := fw.updateForRemoteRelationIngress(appTag)
+	srcCIDRs, err := fw.updateForRemoteRelationIngress(ctx, appTag)
 	if err != nil || len(srcCIDRs) == 0 {
 		return nil, errors.Trace(err)
 	}
@@ -896,8 +899,7 @@ func (fw *Firewaller) ingressRulesForNonExposedMachineUnit(appTag names.Applicat
 	return rules, nil
 }
 
-func (fw *Firewaller) ingressRulesForExposedMachineUnit(machine *machineData, unit *unitData,
-	openUnitPortRanges network.GroupedPortRanges) firewall.IngressRules {
+func (fw *Firewaller) ingressRulesForExposedMachineUnit(unit *unitData, openUnitPortRanges network.GroupedPortRanges) firewall.IngressRules {
 	var (
 		exposedEndpoints = unit.applicationd.exposedEndpoints
 		rules            firewall.IngressRules
@@ -969,7 +971,7 @@ func (fw *Firewaller) ingressRulesForExposedMachineUnit(machine *machineData, un
 // TODO(wallyworld) - consider making this configurable.
 const maxAllowedCIDRS = 20
 
-func (fw *Firewaller) updateForRemoteRelationIngress(appTag names.ApplicationTag) (set.Strings, error) {
+func (fw *Firewaller) updateForRemoteRelationIngress(ctx context.Context, appTag names.ApplicationTag) (set.Strings, error) {
 	fw.logger.Debugf("finding egress rules for %v", appTag)
 	// Now create the rules for any remote relations of which the
 	// unit's application is a part.
@@ -999,7 +1001,7 @@ func (fw *Firewaller) updateForRemoteRelationIngress(appTag names.ApplicationTag
 
 	// If there's still too many after merging, look for any firewall whitelist.
 	if cidrs.Size() > maxAllowedCIDRS {
-		cfg, err := fw.firewallerApi.ModelConfig(context.TODO())
+		cfg, err := fw.firewallerApi.ModelConfig(ctx)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -1231,6 +1233,10 @@ func (fw *Firewaller) Wait() error {
 	return fw.catacomb.Wait()
 }
 
+func (fw *Firewaller) scopedContext() (context.Context, context.CancelFunc) {
+	return context.WithCancel(fw.catacomb.Context(context.Background()))
+}
+
 // unitsChange contains the changed units for one specific machine.
 type unitsChange struct {
 	machined *machineData
@@ -1311,7 +1317,10 @@ type applicationData struct {
 }
 
 // watchLoop watches the application's exposed flag for changes.
-func (ad *applicationData) watchLoop(ctx context.Context, curExposed bool, curExposedEndpoints map[string]params.ExposedEndpoint) error {
+func (ad *applicationData) watchLoop(curExposed bool, curExposedEndpoints map[string]params.ExposedEndpoint) error {
+	ctx, cancel := ad.scopedContext()
+	defer cancel()
+
 	appWatcher, err := ad.application.Watch(ctx)
 	if err != nil {
 		if params.IsCodeNotFound(err) {
@@ -1395,6 +1404,10 @@ func (ad *applicationData) Kill() {
 // Wait is part of the worker.Worker interface.
 func (ad *applicationData) Wait() error {
 	return ad.catacomb.Wait()
+}
+
+func (ad *applicationData) scopedContext() (context.Context, context.CancelFunc) {
+	return context.WithCancel(ad.catacomb.Context(context.Background()))
 }
 
 // relationLifeChanged manages the workers to process ingress changes for
@@ -1510,6 +1523,9 @@ func (fw *Firewaller) startRelation(rel *params.RemoteRelation, role charm.Relat
 
 // watchLoop watches the relation for networks added or removed.
 func (rd *remoteRelationData) watchLoop() error {
+	ctx, cancel := rd.scopedContext()
+	defer cancel()
+
 	defer func() {
 		if rd.crossModelFirewallerFacade != nil {
 			rd.crossModelFirewallerFacade.Close()
@@ -1530,9 +1546,9 @@ func (rd *remoteRelationData) watchLoop() error {
 	}
 
 	if rd.endpointRole == charm.RoleRequirer {
-		return rd.requirerEndpointLoop(context.TODO())
+		return rd.requirerEndpointLoop(ctx)
 	}
-	return rd.providerEndpointLoop()
+	return rd.providerEndpointLoop(ctx)
 }
 
 func (rd *remoteRelationData) requirerEndpointLoop(ctx context.Context) error {
@@ -1573,10 +1589,10 @@ func (rd *remoteRelationData) requirerEndpointLoop(ctx context.Context) error {
 	}
 }
 
-func (rd *remoteRelationData) providerEndpointLoop() error {
+func (rd *remoteRelationData) providerEndpointLoop(ctx context.Context) error {
 	rd.fw.logger.Debugf("starting provider endpoint loop for %v on %v ", rd.tag.Id(), rd.localApplicationTag.Id())
 	// Watch for ingress changes requested by the consuming model.
-	ingressAddressWatcher, err := rd.ingressAddressWatcher(context.TODO())
+	ingressAddressWatcher, err := rd.ingressAddressWatcher(ctx)
 	if err != nil {
 		if !params.IsCodeNotFound(err) && !params.IsCodeNotSupported(err) {
 			return errors.Trace(err)
@@ -1629,6 +1645,10 @@ func (rd *remoteRelationData) ingressAddressWatcher(ctx context.Context) (watche
 		}
 		return rd.crossModelFirewallerFacade.WatchEgressAddressesForRelation(ctx, arg)
 	}
+}
+
+func (rd *remoteRelationData) scopedContext() (context.Context, context.CancelFunc) {
+	return context.WithCancel(rd.catacomb.Context(context.Background()))
 }
 
 type remoteRelationNetworkChange struct {

--- a/internal/worker/firewaller/firewaller_test.go
+++ b/internal/worker/firewaller/firewaller_test.go
@@ -295,7 +295,7 @@ func (s *firewallerBaseSuite) addModelMachine(ctrl *gomock.Controller, manual bo
 func (s *firewallerBaseSuite) addApplication(ctrl *gomock.Controller, appName string, exposed bool) *mocks.MockApplication {
 	app := mocks.NewMockApplication(ctrl)
 	appWatch := watchertest.NewMockNotifyWatcher(s.applicationsCh)
-	app.EXPECT().Watch().Return(appWatch, nil).AnyTimes()
+	app.EXPECT().Watch(gomock.Any()).Return(appWatch, nil).AnyTimes()
 	app.EXPECT().Name().Return(appName).AnyTimes()
 	app.EXPECT().Tag().Return(names.NewApplicationTag(appName)).AnyTimes()
 	app.EXPECT().ExposeInfo().Return(exposed, map[string]params.ExposedEndpoint{

--- a/internal/worker/firewaller/interface.go
+++ b/internal/worker/firewaller/interface.go
@@ -4,6 +4,7 @@
 package firewaller
 
 import (
+	"context"
 	stdcontext "context"
 	"io"
 
@@ -115,6 +116,6 @@ type Unit interface {
 type Application interface {
 	Name() string
 	Tag() names.ApplicationTag
-	Watch() (watcher.NotifyWatcher, error)
+	Watch(context.Context) (watcher.NotifyWatcher, error)
 	ExposeInfo() (bool, map[string]params.ExposedEndpoint, error)
 }

--- a/internal/worker/firewaller/mocks/entity_mocks.go
+++ b/internal/worker/firewaller/mocks/entity_mocks.go
@@ -672,18 +672,18 @@ func (c *MockApplicationTagCall) DoAndReturn(f func() names.ApplicationTag) *Moc
 }
 
 // Watch mocks base method.
-func (m *MockApplication) Watch() (watcher.Watcher[struct{}], error) {
+func (m *MockApplication) Watch(arg0 context.Context) (watcher.Watcher[struct{}], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Watch")
+	ret := m.ctrl.Call(m, "Watch", arg0)
 	ret0, _ := ret[0].(watcher.Watcher[struct{}])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Watch indicates an expected call of Watch.
-func (mr *MockApplicationMockRecorder) Watch() *MockApplicationWatchCall {
+func (mr *MockApplicationMockRecorder) Watch(arg0 any) *MockApplicationWatchCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Watch", reflect.TypeOf((*MockApplication)(nil).Watch))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Watch", reflect.TypeOf((*MockApplication)(nil).Watch), arg0)
 	return &MockApplicationWatchCall{Call: call}
 }
 
@@ -699,13 +699,13 @@ func (c *MockApplicationWatchCall) Return(arg0 watcher.Watcher[struct{}], arg1 e
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationWatchCall) Do(f func() (watcher.Watcher[struct{}], error)) *MockApplicationWatchCall {
+func (c *MockApplicationWatchCall) Do(f func(context.Context) (watcher.Watcher[struct{}], error)) *MockApplicationWatchCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationWatchCall) DoAndReturn(f func() (watcher.Watcher[struct{}], error)) *MockApplicationWatchCall {
+func (c *MockApplicationWatchCall) DoAndReturn(f func(context.Context) (watcher.Watcher[struct{}], error)) *MockApplicationWatchCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/machiner/machiner.go
+++ b/internal/worker/machiner/machiner.go
@@ -92,7 +92,7 @@ func (mr *Machiner) SetUp(ctx context.Context) (watcher.NotifyWatcher, error) {
 		// Can happen when the machiner is restarting after a failure in EnsureDead.
 		// Since we're dying or dead, no need handle the machine addresses.
 		logger.Infof("%q not alive", mr.config.Tag)
-		return m.Watch()
+		return m.Watch(ctx)
 	case mr.config.ClearMachineAddressesOnStart:
 		logger.Debugf("machiner configured to reset machine %q addresses to empty", mr.config.Tag)
 		if err := m.SetMachineAddresses(nil); err != nil {
@@ -113,7 +113,7 @@ func (mr *Machiner) SetUp(ctx context.Context) (watcher.NotifyWatcher, error) {
 	}
 	logger.Infof("%q started", mr.config.Tag)
 
-	return m.Watch()
+	return m.Watch(ctx)
 }
 
 var interfaceAddrs = net.InterfaceAddrs

--- a/internal/worker/machiner/mock_test.go
+++ b/internal/worker/machiner/mock_test.go
@@ -68,7 +68,7 @@ func (m *mockMachine) SetStatus(status status.Status, info string, data map[stri
 	return m.NextErr()
 }
 
-func (m *mockMachine) Watch() (watcher.NotifyWatcher, error) {
+func (m *mockMachine) Watch(_ context.Context) (watcher.NotifyWatcher, error) {
 	m.MethodCall(m, "Watch")
 	if err := m.NextErr(); err != nil {
 		return nil, err

--- a/internal/worker/machiner/state.go
+++ b/internal/worker/machiner/state.go
@@ -27,7 +27,7 @@ type Machine interface {
 	EnsureDead() error
 	SetMachineAddresses(addresses []network.MachineAddress) error
 	SetStatus(machineStatus status.Status, info string, data map[string]interface{}) error
-	Watch() (watcher.NotifyWatcher, error)
+	Watch(context.Context) (watcher.NotifyWatcher, error)
 	SetObservedNetworkConfig(netConfig []params.NetworkConfig) error
 }
 

--- a/internal/worker/provisioner/export_test.go
+++ b/internal/worker/provisioner/export_test.go
@@ -71,7 +71,7 @@ func SetupToStartMachine(
 	version *version.Number,
 	pInfoResult params.ProvisioningInfoResult,
 ) (environs.StartInstanceParams, error) {
-	return p.(*provisionerTask).setupToStartMachine(machine, version, pInfoResult)
+	return p.(*provisionerTask).setupToStartMachine(context.Background(), machine, version, pInfoResult)
 }
 
 func MachineSupportsContainers(

--- a/internal/worker/provisioner/mocks/provisioner.go
+++ b/internal/worker/provisioner/mocks/provisioner.go
@@ -592,18 +592,18 @@ func (m *MockControllerAPI) EXPECT() *MockControllerAPIMockRecorder {
 }
 
 // APIAddresses mocks base method.
-func (m *MockControllerAPI) APIAddresses() ([]string, error) {
+func (m *MockControllerAPI) APIAddresses(arg0 context.Context) ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "APIAddresses")
+	ret := m.ctrl.Call(m, "APIAddresses", arg0)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // APIAddresses indicates an expected call of APIAddresses.
-func (mr *MockControllerAPIMockRecorder) APIAddresses() *MockControllerAPIAPIAddressesCall {
+func (mr *MockControllerAPIMockRecorder) APIAddresses(arg0 any) *MockControllerAPIAPIAddressesCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIAddresses", reflect.TypeOf((*MockControllerAPI)(nil).APIAddresses))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIAddresses", reflect.TypeOf((*MockControllerAPI)(nil).APIAddresses), arg0)
 	return &MockControllerAPIAPIAddressesCall{Call: call}
 }
 
@@ -619,13 +619,13 @@ func (c *MockControllerAPIAPIAddressesCall) Return(arg0 []string, arg1 error) *M
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockControllerAPIAPIAddressesCall) Do(f func() ([]string, error)) *MockControllerAPIAPIAddressesCall {
+func (c *MockControllerAPIAPIAddressesCall) Do(f func(context.Context) ([]string, error)) *MockControllerAPIAPIAddressesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockControllerAPIAPIAddressesCall) DoAndReturn(f func() ([]string, error)) *MockControllerAPIAPIAddressesCall {
+func (c *MockControllerAPIAPIAddressesCall) DoAndReturn(f func(context.Context) ([]string, error)) *MockControllerAPIAPIAddressesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/provisioner/mocks/provisioner.go
+++ b/internal/worker/provisioner/mocks/provisioner.go
@@ -670,18 +670,18 @@ func (c *MockControllerAPICACertCall) DoAndReturn(f func() (string, error)) *Moc
 }
 
 // ControllerConfig mocks base method.
-func (m *MockControllerAPI) ControllerConfig() (controller.Config, error) {
+func (m *MockControllerAPI) ControllerConfig(arg0 context.Context) (controller.Config, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ControllerConfig")
+	ret := m.ctrl.Call(m, "ControllerConfig", arg0)
 	ret0, _ := ret[0].(controller.Config)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ControllerConfig indicates an expected call of ControllerConfig.
-func (mr *MockControllerAPIMockRecorder) ControllerConfig() *MockControllerAPIControllerConfigCall {
+func (mr *MockControllerAPIMockRecorder) ControllerConfig(arg0 any) *MockControllerAPIControllerConfigCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ControllerConfig", reflect.TypeOf((*MockControllerAPI)(nil).ControllerConfig))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ControllerConfig", reflect.TypeOf((*MockControllerAPI)(nil).ControllerConfig), arg0)
 	return &MockControllerAPIControllerConfigCall{Call: call}
 }
 
@@ -697,13 +697,13 @@ func (c *MockControllerAPIControllerConfigCall) Return(arg0 controller.Config, a
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockControllerAPIControllerConfigCall) Do(f func() (controller.Config, error)) *MockControllerAPIControllerConfigCall {
+func (c *MockControllerAPIControllerConfigCall) Do(f func(context.Context) (controller.Config, error)) *MockControllerAPIControllerConfigCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockControllerAPIControllerConfigCall) DoAndReturn(f func() (controller.Config, error)) *MockControllerAPIControllerConfigCall {
+func (c *MockControllerAPIControllerConfigCall) DoAndReturn(f func(context.Context) (controller.Config, error)) *MockControllerAPIControllerConfigCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/provisioner/mocks/provisioner.go
+++ b/internal/worker/provisioner/mocks/provisioner.go
@@ -787,18 +787,18 @@ func (c *MockControllerAPIModelUUIDCall) DoAndReturn(f func() (string, error)) *
 }
 
 // WatchForModelConfigChanges mocks base method.
-func (m *MockControllerAPI) WatchForModelConfigChanges() (watcher.Watcher[struct{}], error) {
+func (m *MockControllerAPI) WatchForModelConfigChanges(arg0 context.Context) (watcher.Watcher[struct{}], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchForModelConfigChanges")
+	ret := m.ctrl.Call(m, "WatchForModelConfigChanges", arg0)
 	ret0, _ := ret[0].(watcher.Watcher[struct{}])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // WatchForModelConfigChanges indicates an expected call of WatchForModelConfigChanges.
-func (mr *MockControllerAPIMockRecorder) WatchForModelConfigChanges() *MockControllerAPIWatchForModelConfigChangesCall {
+func (mr *MockControllerAPIMockRecorder) WatchForModelConfigChanges(arg0 any) *MockControllerAPIWatchForModelConfigChangesCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchForModelConfigChanges", reflect.TypeOf((*MockControllerAPI)(nil).WatchForModelConfigChanges))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchForModelConfigChanges", reflect.TypeOf((*MockControllerAPI)(nil).WatchForModelConfigChanges), arg0)
 	return &MockControllerAPIWatchForModelConfigChangesCall{Call: call}
 }
 
@@ -814,13 +814,13 @@ func (c *MockControllerAPIWatchForModelConfigChangesCall) Return(arg0 watcher.Wa
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockControllerAPIWatchForModelConfigChangesCall) Do(f func() (watcher.Watcher[struct{}], error)) *MockControllerAPIWatchForModelConfigChangesCall {
+func (c *MockControllerAPIWatchForModelConfigChangesCall) Do(f func(context.Context) (watcher.Watcher[struct{}], error)) *MockControllerAPIWatchForModelConfigChangesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockControllerAPIWatchForModelConfigChangesCall) DoAndReturn(f func() (watcher.Watcher[struct{}], error)) *MockControllerAPIWatchForModelConfigChangesCall {
+func (c *MockControllerAPIWatchForModelConfigChangesCall) DoAndReturn(f func(context.Context) (watcher.Watcher[struct{}], error)) *MockControllerAPIWatchForModelConfigChangesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/provisioner/provisioner.go
+++ b/internal/worker/provisioner/provisioner.go
@@ -138,7 +138,7 @@ func (p *provisioner) getStartTask(ctx context.Context, harvestMode config.Harve
 		return nil, errors.Errorf("agent's tag is not a machine or controller agent tag, got %T", hostTag)
 	}
 
-	modelCfg, err := p.controllerAPI.ModelConfig(context.TODO())
+	modelCfg, err := p.controllerAPI.ModelConfig(ctx)
 	if err != nil {
 		return nil, errors.Annotate(err, "could not retrieve the model config.")
 	}
@@ -214,12 +214,15 @@ func NewEnvironProvisioner(
 }
 
 func (p *environProvisioner) loop() error {
+	ctx, cancel := p.scopedContext()
+	defer cancel()
+
 	// TODO(mjs channeling axw) - It would be better if there were
 	// APIs to watch and fetch provisioner specific config instead of
 	// watcher for all changes to model config. This would avoid the
 	// need for a full model config.
 	var modelConfigChanges <-chan struct{}
-	modelWatcher, err := p.controllerAPI.WatchForModelConfigChanges()
+	modelWatcher, err := p.controllerAPI.WatchForModelConfigChanges(ctx)
 	if err != nil {
 		return loggedErrorStack(p.logger, errors.Trace(err))
 	}
@@ -228,14 +231,14 @@ func (p *environProvisioner) loop() error {
 	}
 	modelConfigChanges = modelWatcher.Changes()
 
-	modelConfig, err := p.controllerAPI.ModelConfig(context.TODO())
+	modelConfig, err := p.controllerAPI.ModelConfig(ctx)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	p.configObserver.notify(modelConfig)
 	harvestMode := modelConfig.ProvisionerHarvestMode()
 	workerCount := modelConfig.NumProvisionWorkers()
-	task, err := p.getStartTask(context.TODO(), harvestMode, workerCount)
+	task, err := p.getStartTask(ctx, harvestMode, workerCount)
 	if err != nil {
 		return loggedErrorStack(p.logger, errors.Trace(err))
 	}
@@ -251,12 +254,12 @@ func (p *environProvisioner) loop() error {
 			if !ok {
 				return errors.New("model configuration watcher closed")
 			}
-			modelConfig, err := p.controllerAPI.ModelConfig(context.TODO())
+			modelConfig, err := p.controllerAPI.ModelConfig(ctx)
 			if err != nil {
 				return errors.Annotate(err, "cannot load model configuration")
 			}
 
-			if err := p.setConfig(context.TODO(), modelConfig); err != nil {
+			if err := p.setConfig(ctx, modelConfig); err != nil {
 				return errors.Annotate(err, "loaded invalid model configuration")
 			}
 			task.SetHarvestMode(modelConfig.ProvisionerHarvestMode())
@@ -281,6 +284,10 @@ func (p *environProvisioner) setConfig(ctx context.Context, modelConfig *config.
 	}
 	p.configObserver.notify(modelConfig)
 	return nil
+}
+
+func (p *environProvisioner) scopedContext() (context.Context, context.CancelFunc) {
+	return context.WithCancel(p.catacomb.Context(context.Background()))
 }
 
 // NewContainerProvisioner returns a new Provisioner. When new machines
@@ -324,7 +331,10 @@ func NewContainerProvisioner(
 }
 
 func (p *containerProvisioner) loop() error {
-	modelWatcher, err := p.controllerAPI.WatchForModelConfigChanges()
+	ctx, cancel := p.scopedContext()
+	defer cancel()
+
+	modelWatcher, err := p.controllerAPI.WatchForModelConfigChanges(ctx)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -332,7 +342,7 @@ func (p *containerProvisioner) loop() error {
 		return errors.Trace(err)
 	}
 
-	modelConfig, err := p.controllerAPI.ModelConfig(context.TODO())
+	modelConfig, err := p.controllerAPI.ModelConfig(ctx)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -340,7 +350,7 @@ func (p *containerProvisioner) loop() error {
 	harvestMode := modelConfig.ProvisionerHarvestMode()
 	workerCount := modelConfig.NumContainerProvisionWorkers()
 
-	task, err := p.getStartTask(context.TODO(), harvestMode, workerCount)
+	task, err := p.getStartTask(ctx, harvestMode, workerCount)
 	if err != nil {
 		return loggedErrorStack(p.logger, errors.Trace(err))
 	}
@@ -356,7 +366,7 @@ func (p *containerProvisioner) loop() error {
 			if !ok {
 				return errors.New("model configuration watch closed")
 			}
-			modelConfig, err := p.controllerAPI.ModelConfig(context.TODO())
+			modelConfig, err := p.controllerAPI.ModelConfig(ctx)
 			if err != nil {
 				return errors.Annotate(err, "cannot load model configuration")
 			}
@@ -398,4 +408,8 @@ func (p *containerProvisioner) getMachineWatcher(ctx context.Context) (watcher.S
 
 func (p *containerProvisioner) getRetryWatcher() (watcher.NotifyWatcher, error) {
 	return nil, errors.NotImplementedf("getRetryWatcher")
+}
+
+func (p *containerProvisioner) scopedContext() (context.Context, context.CancelFunc) {
+	return context.WithCancel(p.catacomb.Context(context.Background()))
 }

--- a/internal/worker/provisioner/provisioner.go
+++ b/internal/worker/provisioner/provisioner.go
@@ -143,7 +143,7 @@ func (p *provisioner) getStartTask(ctx context.Context, harvestMode config.Harve
 		return nil, errors.Annotate(err, "could not retrieve the model config.")
 	}
 
-	controllerCfg, err := p.controllerAPI.ControllerConfig()
+	controllerCfg, err := p.controllerAPI.ControllerConfig(ctx)
 	if err != nil {
 		return nil, errors.Annotate(err, "could not retrieve the controller config.")
 	}

--- a/internal/worker/provisioner/provisioner_task.go
+++ b/internal/worker/provisioner/provisioner_task.go
@@ -98,8 +98,8 @@ type ControllerAPI interface {
 	ControllerConfig(context.Context) (controller.Config, error)
 	CACert() (string, error)
 	ModelUUID() (string, error)
-	ModelConfig(stdcontext.Context) (*config.Config, error)
-	WatchForModelConfigChanges() (watcher.NotifyWatcher, error)
+	ModelConfig(context.Context) (*config.Config, error)
+	WatchForModelConfigChanges(context.Context) (watcher.NotifyWatcher, error)
 	APIAddresses(context.Context) ([]string, error)
 }
 

--- a/internal/worker/provisioner/provisioner_task.go
+++ b/internal/worker/provisioner/provisioner_task.go
@@ -4,6 +4,7 @@
 package provisioner
 
 import (
+	"context"
 	stdcontext "context"
 	"fmt"
 	"math/rand"
@@ -94,7 +95,7 @@ type ToolsFinder interface {
 
 // ControllerAPI describes API methods for querying a controller.
 type ControllerAPI interface {
-	ControllerConfig() (controller.Config, error)
+	ControllerConfig(context.Context) (controller.Config, error)
 	CACert() (string, error)
 	ModelUUID() (string, error)
 	ModelConfig(stdcontext.Context) (*config.Config, error)

--- a/internal/worker/provisioner/provisioner_task_test.go
+++ b/internal/worker/provisioner/provisioner_task_test.go
@@ -1508,7 +1508,7 @@ func (s *ProvisionerTaskSuite) setUpMocks(c *gc.C) *gomock.Controller {
 }
 
 func (s *ProvisionerTaskSuite) expectAuth() {
-	s.controllerAPI.EXPECT().APIAddresses().Return([]string{"10.0.0.1"}, nil).AnyTimes()
+	s.controllerAPI.EXPECT().APIAddresses(gomock.Any()).Return([]string{"10.0.0.1"}, nil).AnyTimes()
 	s.controllerAPI.EXPECT().ModelUUID().Return(coretesting.ModelTag.Id(), nil).AnyTimes()
 	s.controllerAPI.EXPECT().CACert().Return(coretesting.CACert, nil).AnyTimes()
 }

--- a/internal/worker/provisioner/provisioner_test.go
+++ b/internal/worker/provisioner/provisioner_test.go
@@ -66,7 +66,7 @@ func (s *CommonProvisionerSuite) setUpMocks(c *gc.C) *gomock.Controller {
 func (s *CommonProvisionerSuite) expectStartup(c *gc.C) {
 	s.modelConfigCh = make(chan struct{})
 	watchCfg := watchertest.NewMockNotifyWatcher(s.modelConfigCh)
-	s.controllerAPI.EXPECT().WatchForModelConfigChanges().Return(watchCfg, nil)
+	s.controllerAPI.EXPECT().WatchForModelConfigChanges(gomock.Any()).Return(watchCfg, nil)
 
 	cfg := coretesting.CustomModelConfig(c, coretesting.Attrs{config.ProvisionerHarvestModeKey: config.HarvestDestroyed.String()})
 	s.controllerAPI.EXPECT().ModelConfig(gomock.Any()).Return(cfg, nil).MaxTimes(2)

--- a/internal/worker/provisioner/provisioner_test.go
+++ b/internal/worker/provisioner/provisioner_test.go
@@ -80,7 +80,7 @@ func (s *CommonProvisionerSuite) expectStartup(c *gc.C) {
 }
 
 func (s *CommonProvisionerSuite) expectAuth() {
-	s.controllerAPI.EXPECT().APIAddresses().Return([]string{"10.0.0.1"}, nil).AnyTimes()
+	s.controllerAPI.EXPECT().APIAddresses(gomock.Any()).Return([]string{"10.0.0.1"}, nil).AnyTimes()
 	s.controllerAPI.EXPECT().ModelUUID().Return(coretesting.ModelTag.Id(), nil).AnyTimes()
 	s.controllerAPI.EXPECT().CACert().Return(coretesting.CACert, nil).AnyTimes()
 }

--- a/internal/worker/provisioner/provisioner_test.go
+++ b/internal/worker/provisioner/provisioner_test.go
@@ -4,6 +4,7 @@
 package provisioner_test
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -72,7 +73,7 @@ func (s *CommonProvisionerSuite) expectStartup(c *gc.C) {
 
 	s.provisionerStarted = make(chan bool)
 	controllerCfg := coretesting.FakeControllerConfig()
-	s.controllerAPI.EXPECT().ControllerConfig().DoAndReturn(func() (controller.Config, error) {
+	s.controllerAPI.EXPECT().ControllerConfig(gomock.Any()).DoAndReturn(func(context.Context) (controller.Config, error) {
 		defer close(s.provisionerStarted)
 		return controllerCfg, nil
 	})

--- a/internal/worker/stateconverter/converter.go
+++ b/internal/worker/stateconverter/converter.go
@@ -67,7 +67,7 @@ func (c *converter) SetUp(ctx context.Context) (watcher.NotifyWatcher, error) {
 		return nil, errors.Trace(err)
 	}
 	c.machine = m
-	return m.Watch()
+	return m.Watch(ctx)
 }
 
 // Handle implements NotifyWatchHandler's Handle method.  If the change means

--- a/internal/worker/stateconverter/converter_test.go
+++ b/internal/worker/stateconverter/converter_test.go
@@ -29,7 +29,7 @@ type converterSuite struct {
 func (s *converterSuite) TestSetUp(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	s.machiner.EXPECT().Machine(gomock.Any(), gomock.Any()).Return(s.machine, nil)
-	s.machine.EXPECT().Watch().Return(nil, nil)
+	s.machine.EXPECT().Watch(gomock.Any()).Return(nil, nil)
 
 	conv := s.newConverter(c)
 	_, err := conv.SetUp(context.Background())
@@ -51,7 +51,7 @@ func (s *converterSuite) TestSetupWatchErr(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	s.machiner.EXPECT().Machine(gomock.Any(), gomock.Any()).Return(s.machine, nil)
 	expectedError := errors.NotValidf("machine tag")
-	s.machine.EXPECT().Watch().Return(nil, expectedError)
+	s.machine.EXPECT().Watch(gomock.Any()).Return(nil, expectedError)
 
 	conv := s.newConverter(c)
 	w, err := conv.SetUp(context.Background())
@@ -62,7 +62,7 @@ func (s *converterSuite) TestSetupWatchErr(c *gc.C) {
 func (s *converterSuite) TestHandle(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	s.machiner.EXPECT().Machine(gomock.Any(), gomock.Any()).Return(s.machine, nil)
-	s.machine.EXPECT().Watch().Return(nil, nil)
+	s.machine.EXPECT().Watch(gomock.Any()).Return(nil, nil)
 	jobs := params.JobsResult{Jobs: []model.MachineJob{model.JobHostUnits, model.JobManageModel}}
 	s.machine.EXPECT().Jobs().Return(&jobs, nil)
 
@@ -78,7 +78,7 @@ func (s *converterSuite) TestHandle(c *gc.C) {
 func (s *converterSuite) TestHandleNotController(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	s.machiner.EXPECT().Machine(gomock.Any(), gomock.Any()).Return(s.machine, nil)
-	s.machine.EXPECT().Watch().Return(nil, nil)
+	s.machine.EXPECT().Watch(gomock.Any()).Return(nil, nil)
 	jobs := params.JobsResult{Jobs: []model.MachineJob{model.JobHostUnits}}
 	s.machine.EXPECT().Jobs().Return(&jobs, nil)
 
@@ -92,7 +92,7 @@ func (s *converterSuite) TestHandleNotController(c *gc.C) {
 func (s *converterSuite) TestHandleJobsError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	s.machiner.EXPECT().Machine(gomock.Any(), gomock.Any()).Return(s.machine, nil).AnyTimes()
-	s.machine.EXPECT().Watch().Return(nil, nil).AnyTimes()
+	s.machine.EXPECT().Watch(gomock.Any()).Return(nil, nil).AnyTimes()
 	jobs := params.JobsResult{Jobs: []model.MachineJob{model.JobHostUnits, model.JobManageModel}}
 	s.machine.EXPECT().Jobs().Return(&jobs, nil)
 	expectedError := errors.New("foo")

--- a/internal/worker/stateconverter/interfaces.go
+++ b/internal/worker/stateconverter/interfaces.go
@@ -22,5 +22,5 @@ type Machiner interface {
 // a machiner's machine.
 type Machine interface {
 	Jobs() (*params.JobsResult, error)
-	Watch() (watcher.NotifyWatcher, error)
+	Watch(context.Context) (watcher.NotifyWatcher, error)
 }

--- a/internal/worker/stateconverter/mocks/machiner_mock.go
+++ b/internal/worker/stateconverter/mocks/machiner_mock.go
@@ -145,18 +145,18 @@ func (c *MockMachineJobsCall) DoAndReturn(f func() (*params.JobsResult, error)) 
 }
 
 // Watch mocks base method.
-func (m *MockMachine) Watch() (watcher.Watcher[struct{}], error) {
+func (m *MockMachine) Watch(arg0 context.Context) (watcher.Watcher[struct{}], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Watch")
+	ret := m.ctrl.Call(m, "Watch", arg0)
 	ret0, _ := ret[0].(watcher.Watcher[struct{}])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Watch indicates an expected call of Watch.
-func (mr *MockMachineMockRecorder) Watch() *MockMachineWatchCall {
+func (mr *MockMachineMockRecorder) Watch(arg0 any) *MockMachineWatchCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Watch", reflect.TypeOf((*MockMachine)(nil).Watch))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Watch", reflect.TypeOf((*MockMachine)(nil).Watch), arg0)
 	return &MockMachineWatchCall{Call: call}
 }
 
@@ -172,13 +172,13 @@ func (c *MockMachineWatchCall) Return(arg0 watcher.Watcher[struct{}], arg1 error
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineWatchCall) Do(f func() (watcher.Watcher[struct{}], error)) *MockMachineWatchCall {
+func (c *MockMachineWatchCall) Do(f func(context.Context) (watcher.Watcher[struct{}], error)) *MockMachineWatchCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineWatchCall) DoAndReturn(f func() (watcher.Watcher[struct{}], error)) *MockMachineWatchCall {
+func (c *MockMachineWatchCall) DoAndReturn(f func(context.Context) (watcher.Watcher[struct{}], error)) *MockMachineWatchCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/uniter/agent.go
+++ b/internal/worker/uniter/agent.go
@@ -4,6 +4,8 @@
 package uniter
 
 import (
+	stdcontext "context"
+
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/core/model"
@@ -38,7 +40,7 @@ func reportAgentError(u *Uniter, userMessage string, err error) {
 }
 
 // setUpgradeSeriesStatus sets the upgrade series status.
-func setUpgradeSeriesStatus(u *Uniter, status model.UpgradeSeriesStatus, reason string) error {
-	err := u.unit.SetUpgradeSeriesStatus(status, reason)
+func setUpgradeSeriesStatus(ctx stdcontext.Context, u *Uniter, status model.UpgradeSeriesStatus, reason string) error {
+	err := u.unit.SetUpgradeSeriesStatus(ctx, status, reason)
 	return errors.Annotatef(err, "cannot set upgrade series status to %q with reason: %q", status, reason)
 }

--- a/internal/worker/uniter/api/domain_mocks.go
+++ b/internal/worker/uniter/api/domain_mocks.go
@@ -1165,17 +1165,17 @@ func (c *MockUnitSetCharmURLCall) DoAndReturn(f func(string) error) *MockUnitSet
 }
 
 // SetState mocks base method.
-func (m *MockUnit) SetState(arg0 params.SetUnitStateArg) error {
+func (m *MockUnit) SetState(arg0 context.Context, arg1 params.SetUnitStateArg) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetState", arg0)
+	ret := m.ctrl.Call(m, "SetState", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetState indicates an expected call of SetState.
-func (mr *MockUnitMockRecorder) SetState(arg0 any) *MockUnitSetStateCall {
+func (mr *MockUnitMockRecorder) SetState(arg0, arg1 any) *MockUnitSetStateCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetState", reflect.TypeOf((*MockUnit)(nil).SetState), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetState", reflect.TypeOf((*MockUnit)(nil).SetState), arg0, arg1)
 	return &MockUnitSetStateCall{Call: call}
 }
 
@@ -1191,13 +1191,13 @@ func (c *MockUnitSetStateCall) Return(arg0 error) *MockUnitSetStateCall {
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockUnitSetStateCall) Do(f func(params.SetUnitStateArg) error) *MockUnitSetStateCall {
+func (c *MockUnitSetStateCall) Do(f func(context.Context, params.SetUnitStateArg) error) *MockUnitSetStateCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockUnitSetStateCall) DoAndReturn(f func(params.SetUnitStateArg) error) *MockUnitSetStateCall {
+func (c *MockUnitSetStateCall) DoAndReturn(f func(context.Context, params.SetUnitStateArg) error) *MockUnitSetStateCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1241,17 +1241,17 @@ func (c *MockUnitSetUnitStatusCall) DoAndReturn(f func(context.Context, status.S
 }
 
 // SetUpgradeSeriesStatus mocks base method.
-func (m *MockUnit) SetUpgradeSeriesStatus(arg0 model.UpgradeSeriesStatus, arg1 string) error {
+func (m *MockUnit) SetUpgradeSeriesStatus(arg0 context.Context, arg1 model.UpgradeSeriesStatus, arg2 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetUpgradeSeriesStatus", arg0, arg1)
+	ret := m.ctrl.Call(m, "SetUpgradeSeriesStatus", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetUpgradeSeriesStatus indicates an expected call of SetUpgradeSeriesStatus.
-func (mr *MockUnitMockRecorder) SetUpgradeSeriesStatus(arg0, arg1 any) *MockUnitSetUpgradeSeriesStatusCall {
+func (mr *MockUnitMockRecorder) SetUpgradeSeriesStatus(arg0, arg1, arg2 any) *MockUnitSetUpgradeSeriesStatusCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUpgradeSeriesStatus", reflect.TypeOf((*MockUnit)(nil).SetUpgradeSeriesStatus), arg0, arg1)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUpgradeSeriesStatus", reflect.TypeOf((*MockUnit)(nil).SetUpgradeSeriesStatus), arg0, arg1, arg2)
 	return &MockUnitSetUpgradeSeriesStatusCall{Call: call}
 }
 
@@ -1267,30 +1267,30 @@ func (c *MockUnitSetUpgradeSeriesStatusCall) Return(arg0 error) *MockUnitSetUpgr
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockUnitSetUpgradeSeriesStatusCall) Do(f func(model.UpgradeSeriesStatus, string) error) *MockUnitSetUpgradeSeriesStatusCall {
+func (c *MockUnitSetUpgradeSeriesStatusCall) Do(f func(context.Context, model.UpgradeSeriesStatus, string) error) *MockUnitSetUpgradeSeriesStatusCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockUnitSetUpgradeSeriesStatusCall) DoAndReturn(f func(model.UpgradeSeriesStatus, string) error) *MockUnitSetUpgradeSeriesStatusCall {
+func (c *MockUnitSetUpgradeSeriesStatusCall) DoAndReturn(f func(context.Context, model.UpgradeSeriesStatus, string) error) *MockUnitSetUpgradeSeriesStatusCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // State mocks base method.
-func (m *MockUnit) State() (params.UnitStateResult, error) {
+func (m *MockUnit) State(arg0 context.Context) (params.UnitStateResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "State")
+	ret := m.ctrl.Call(m, "State", arg0)
 	ret0, _ := ret[0].(params.UnitStateResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // State indicates an expected call of State.
-func (mr *MockUnitMockRecorder) State() *MockUnitStateCall {
+func (mr *MockUnitMockRecorder) State(arg0 any) *MockUnitStateCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "State", reflect.TypeOf((*MockUnit)(nil).State))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "State", reflect.TypeOf((*MockUnit)(nil).State), arg0)
 	return &MockUnitStateCall{Call: call}
 }
 
@@ -1306,13 +1306,13 @@ func (c *MockUnitStateCall) Return(arg0 params.UnitStateResult, arg1 error) *Moc
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockUnitStateCall) Do(f func() (params.UnitStateResult, error)) *MockUnitStateCall {
+func (c *MockUnitStateCall) Do(f func(context.Context) (params.UnitStateResult, error)) *MockUnitStateCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockUnitStateCall) DoAndReturn(f func() (params.UnitStateResult, error)) *MockUnitStateCall {
+func (c *MockUnitStateCall) DoAndReturn(f func(context.Context) (params.UnitStateResult, error)) *MockUnitStateCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1395,9 +1395,9 @@ func (c *MockUnitUnitStatusCall) DoAndReturn(f func(context.Context) (params.Sta
 }
 
 // UpgradeSeriesStatus mocks base method.
-func (m *MockUnit) UpgradeSeriesStatus() (model.UpgradeSeriesStatus, string, error) {
+func (m *MockUnit) UpgradeSeriesStatus(arg0 context.Context) (model.UpgradeSeriesStatus, string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpgradeSeriesStatus")
+	ret := m.ctrl.Call(m, "UpgradeSeriesStatus", arg0)
 	ret0, _ := ret[0].(model.UpgradeSeriesStatus)
 	ret1, _ := ret[1].(string)
 	ret2, _ := ret[2].(error)
@@ -1405,9 +1405,9 @@ func (m *MockUnit) UpgradeSeriesStatus() (model.UpgradeSeriesStatus, string, err
 }
 
 // UpgradeSeriesStatus indicates an expected call of UpgradeSeriesStatus.
-func (mr *MockUnitMockRecorder) UpgradeSeriesStatus() *MockUnitUpgradeSeriesStatusCall {
+func (mr *MockUnitMockRecorder) UpgradeSeriesStatus(arg0 any) *MockUnitUpgradeSeriesStatusCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpgradeSeriesStatus", reflect.TypeOf((*MockUnit)(nil).UpgradeSeriesStatus))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpgradeSeriesStatus", reflect.TypeOf((*MockUnit)(nil).UpgradeSeriesStatus), arg0)
 	return &MockUnitUpgradeSeriesStatusCall{Call: call}
 }
 
@@ -1423,30 +1423,30 @@ func (c *MockUnitUpgradeSeriesStatusCall) Return(arg0 model.UpgradeSeriesStatus,
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockUnitUpgradeSeriesStatusCall) Do(f func() (model.UpgradeSeriesStatus, string, error)) *MockUnitUpgradeSeriesStatusCall {
+func (c *MockUnitUpgradeSeriesStatusCall) Do(f func(context.Context) (model.UpgradeSeriesStatus, string, error)) *MockUnitUpgradeSeriesStatusCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockUnitUpgradeSeriesStatusCall) DoAndReturn(f func() (model.UpgradeSeriesStatus, string, error)) *MockUnitUpgradeSeriesStatusCall {
+func (c *MockUnitUpgradeSeriesStatusCall) DoAndReturn(f func(context.Context) (model.UpgradeSeriesStatus, string, error)) *MockUnitUpgradeSeriesStatusCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // Watch mocks base method.
-func (m *MockUnit) Watch() (watcher.Watcher[struct{}], error) {
+func (m *MockUnit) Watch(arg0 context.Context) (watcher.Watcher[struct{}], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Watch")
+	ret := m.ctrl.Call(m, "Watch", arg0)
 	ret0, _ := ret[0].(watcher.Watcher[struct{}])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Watch indicates an expected call of Watch.
-func (mr *MockUnitMockRecorder) Watch() *MockUnitWatchCall {
+func (mr *MockUnitMockRecorder) Watch(arg0 any) *MockUnitWatchCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Watch", reflect.TypeOf((*MockUnit)(nil).Watch))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Watch", reflect.TypeOf((*MockUnit)(nil).Watch), arg0)
 	return &MockUnitWatchCall{Call: call}
 }
 
@@ -1462,13 +1462,13 @@ func (c *MockUnitWatchCall) Return(arg0 watcher.Watcher[struct{}], arg1 error) *
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockUnitWatchCall) Do(f func() (watcher.Watcher[struct{}], error)) *MockUnitWatchCall {
+func (c *MockUnitWatchCall) Do(f func(context.Context) (watcher.Watcher[struct{}], error)) *MockUnitWatchCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockUnitWatchCall) DoAndReturn(f func() (watcher.Watcher[struct{}], error)) *MockUnitWatchCall {
+func (c *MockUnitWatchCall) DoAndReturn(f func(context.Context) (watcher.Watcher[struct{}], error)) *MockUnitWatchCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1747,18 +1747,18 @@ func (c *MockUnitWatchTrustConfigSettingsHashCall) DoAndReturn(f func() (watcher
 }
 
 // WatchUpgradeSeriesNotifications mocks base method.
-func (m *MockUnit) WatchUpgradeSeriesNotifications() (watcher.Watcher[struct{}], error) {
+func (m *MockUnit) WatchUpgradeSeriesNotifications(arg0 context.Context) (watcher.Watcher[struct{}], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchUpgradeSeriesNotifications")
+	ret := m.ctrl.Call(m, "WatchUpgradeSeriesNotifications", arg0)
 	ret0, _ := ret[0].(watcher.Watcher[struct{}])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // WatchUpgradeSeriesNotifications indicates an expected call of WatchUpgradeSeriesNotifications.
-func (mr *MockUnitMockRecorder) WatchUpgradeSeriesNotifications() *MockUnitWatchUpgradeSeriesNotificationsCall {
+func (mr *MockUnitMockRecorder) WatchUpgradeSeriesNotifications(arg0 any) *MockUnitWatchUpgradeSeriesNotificationsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchUpgradeSeriesNotifications", reflect.TypeOf((*MockUnit)(nil).WatchUpgradeSeriesNotifications))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchUpgradeSeriesNotifications", reflect.TypeOf((*MockUnit)(nil).WatchUpgradeSeriesNotifications), arg0)
 	return &MockUnitWatchUpgradeSeriesNotificationsCall{Call: call}
 }
 
@@ -1774,13 +1774,13 @@ func (c *MockUnitWatchUpgradeSeriesNotificationsCall) Return(arg0 watcher.Watche
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockUnitWatchUpgradeSeriesNotificationsCall) Do(f func() (watcher.Watcher[struct{}], error)) *MockUnitWatchUpgradeSeriesNotificationsCall {
+func (c *MockUnitWatchUpgradeSeriesNotificationsCall) Do(f func(context.Context) (watcher.Watcher[struct{}], error)) *MockUnitWatchUpgradeSeriesNotificationsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockUnitWatchUpgradeSeriesNotificationsCall) DoAndReturn(f func() (watcher.Watcher[struct{}], error)) *MockUnitWatchUpgradeSeriesNotificationsCall {
+func (c *MockUnitWatchUpgradeSeriesNotificationsCall) DoAndReturn(f func(context.Context) (watcher.Watcher[struct{}], error)) *MockUnitWatchUpgradeSeriesNotificationsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -2812,18 +2812,18 @@ func (c *MockApplicationTagCall) DoAndReturn(f func() names.ApplicationTag) *Moc
 }
 
 // Watch mocks base method.
-func (m *MockApplication) Watch() (watcher.Watcher[struct{}], error) {
+func (m *MockApplication) Watch(arg0 context.Context) (watcher.Watcher[struct{}], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Watch")
+	ret := m.ctrl.Call(m, "Watch", arg0)
 	ret0, _ := ret[0].(watcher.Watcher[struct{}])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Watch indicates an expected call of Watch.
-func (mr *MockApplicationMockRecorder) Watch() *MockApplicationWatchCall {
+func (mr *MockApplicationMockRecorder) Watch(arg0 any) *MockApplicationWatchCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Watch", reflect.TypeOf((*MockApplication)(nil).Watch))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Watch", reflect.TypeOf((*MockApplication)(nil).Watch), arg0)
 	return &MockApplicationWatchCall{Call: call}
 }
 
@@ -2839,13 +2839,13 @@ func (c *MockApplicationWatchCall) Return(arg0 watcher.Watcher[struct{}], arg1 e
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationWatchCall) Do(f func() (watcher.Watcher[struct{}], error)) *MockApplicationWatchCall {
+func (c *MockApplicationWatchCall) Do(f func(context.Context) (watcher.Watcher[struct{}], error)) *MockApplicationWatchCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationWatchCall) DoAndReturn(f func() (watcher.Watcher[struct{}], error)) *MockApplicationWatchCall {
+func (c *MockApplicationWatchCall) DoAndReturn(f func(context.Context) (watcher.Watcher[struct{}], error)) *MockApplicationWatchCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/uniter/api/interface.go
+++ b/internal/worker/uniter/api/interface.go
@@ -43,7 +43,7 @@ type Unit interface {
 	LXDProfileName() (string, error)
 	CanApplyLXDProfile() (bool, error)
 	CharmURL() (string, error)
-	Watch() (watcher.NotifyWatcher, error)
+	Watch(stdcontext.Context) (watcher.NotifyWatcher, error)
 
 	// Used by runner.context.
 
@@ -55,8 +55,8 @@ type Unit interface {
 	RequestReboot() error
 	SetUnitStatus(ctx stdcontext.Context, unitStatus status.Status, info string, data map[string]interface{}) error
 	SetAgentStatus(agentStatus status.Status, info string, data map[string]interface{}) error
-	State() (params.UnitStateResult, error)
-	SetState(unitState params.SetUnitStateArg) error
+	State(ctx stdcontext.Context) (params.UnitStateResult, error)
+	SetState(ctx stdcontext.Context, unitState params.SetUnitStateArg) error
 	Tag() names.UnitTag
 	UnitStatus(stdcontext.Context) (params.StatusResult, error)
 	CommitHookChanges(params.CommitHookChangesArgs) error
@@ -73,11 +73,11 @@ type Unit interface {
 	WatchTrustConfigSettingsHash() (watcher.StringsWatcher, error)
 	WatchRelations() (watcher.StringsWatcher, error)
 	WatchAddressesHash() (watcher.StringsWatcher, error)
-	WatchUpgradeSeriesNotifications() (watcher.NotifyWatcher, error)
+	WatchUpgradeSeriesNotifications(ctx stdcontext.Context) (watcher.NotifyWatcher, error)
 	WatchActionNotifications() (watcher.StringsWatcher, error)
 	WatchStorage() (watcher.StringsWatcher, error)
 	WatchInstanceData() (watcher.NotifyWatcher, error)
-	UpgradeSeriesStatus() (model.UpgradeSeriesStatus, string, error)
+	UpgradeSeriesStatus(ctx stdcontext.Context) (model.UpgradeSeriesStatus, string, error)
 
 	// Used by relationer.
 
@@ -87,7 +87,7 @@ type Unit interface {
 
 	// Used by operation.Callbacks.
 
-	SetUpgradeSeriesStatus(upgradeSeriesStatus model.UpgradeSeriesStatus, reason string) error
+	SetUpgradeSeriesStatus(ctx stdcontext.Context, upgradeSeriesStatus model.UpgradeSeriesStatus, reason string) error
 	SetCharmURL(curl string) error
 }
 
@@ -103,7 +103,7 @@ type Application interface {
 	// Used by remotestate watcher.
 
 	WatchLeadershipSettings() (watcher.NotifyWatcher, error)
-	Watch() (watcher.NotifyWatcher, error)
+	Watch(ctx stdcontext.Context) (watcher.NotifyWatcher, error)
 	Refresh(stdcontext.Context) error
 }
 

--- a/internal/worker/uniter/api/interface_generics.go
+++ b/internal/worker/uniter/api/interface_generics.go
@@ -45,7 +45,7 @@ type UniterClient interface {
 	APIAddresses(context.Context) ([]string, error)
 	WatchRelationUnits(context.Context, names.RelationTag, names.UnitTag) (watcher.RelationUnitsWatcher, error)
 	WatchStorageAttachment(names.StorageTag, names.UnitTag) (watcher.NotifyWatcher, error)
-	WatchUpdateStatusHookInterval() (watcher.NotifyWatcher, error)
-	UpdateStatusHookInterval() (time.Duration, error)
+	WatchUpdateStatusHookInterval(context.Context) (watcher.NotifyWatcher, error)
+	UpdateStatusHookInterval(context.Context) (time.Duration, error)
 	StorageAttachmentLife([]params.StorageAttachmentId) ([]params.LifeResult, error)
 }

--- a/internal/worker/uniter/api/interface_generics.go
+++ b/internal/worker/uniter/api/interface_generics.go
@@ -42,7 +42,7 @@ type UniterClient interface {
 	OpenedPortRangesByEndpoint(ctx context.Context) (map[names.UnitTag]network.GroupedPortRanges, error)
 	LeadershipSettings() uniter.LeadershipSettingsAccessor
 	CloudAPIVersion(context.Context) (string, error)
-	APIAddresses() ([]string, error)
+	APIAddresses(context.Context) ([]string, error)
 	WatchRelationUnits(context.Context, names.RelationTag, names.UnitTag) (watcher.RelationUnitsWatcher, error)
 	WatchStorageAttachment(names.StorageTag, names.UnitTag) (watcher.NotifyWatcher, error)
 	WatchUpdateStatusHookInterval() (watcher.NotifyWatcher, error)

--- a/internal/worker/uniter/api/uniter_mocks.go
+++ b/internal/worker/uniter/api/uniter_mocks.go
@@ -49,18 +49,18 @@ func (m *MockUniterClient) EXPECT() *MockUniterClientMockRecorder {
 }
 
 // APIAddresses mocks base method.
-func (m *MockUniterClient) APIAddresses() ([]string, error) {
+func (m *MockUniterClient) APIAddresses(arg0 context.Context) ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "APIAddresses")
+	ret := m.ctrl.Call(m, "APIAddresses", arg0)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // APIAddresses indicates an expected call of APIAddresses.
-func (mr *MockUniterClientMockRecorder) APIAddresses() *MockUniterClientAPIAddressesCall {
+func (mr *MockUniterClientMockRecorder) APIAddresses(arg0 any) *MockUniterClientAPIAddressesCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIAddresses", reflect.TypeOf((*MockUniterClient)(nil).APIAddresses))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "APIAddresses", reflect.TypeOf((*MockUniterClient)(nil).APIAddresses), arg0)
 	return &MockUniterClientAPIAddressesCall{Call: call}
 }
 
@@ -76,13 +76,13 @@ func (c *MockUniterClientAPIAddressesCall) Return(arg0 []string, arg1 error) *Mo
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockUniterClientAPIAddressesCall) Do(f func() ([]string, error)) *MockUniterClientAPIAddressesCall {
+func (c *MockUniterClientAPIAddressesCall) Do(f func(context.Context) ([]string, error)) *MockUniterClientAPIAddressesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockUniterClientAPIAddressesCall) DoAndReturn(f func() ([]string, error)) *MockUniterClientAPIAddressesCall {
+func (c *MockUniterClientAPIAddressesCall) DoAndReturn(f func(context.Context) ([]string, error)) *MockUniterClientAPIAddressesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/uniter/api/uniter_mocks.go
+++ b/internal/worker/uniter/api/uniter_mocks.go
@@ -1018,18 +1018,18 @@ func (c *MockUniterClientUnitWorkloadVersionCall) DoAndReturn(f func(context.Con
 }
 
 // UpdateStatusHookInterval mocks base method.
-func (m *MockUniterClient) UpdateStatusHookInterval() (time.Duration, error) {
+func (m *MockUniterClient) UpdateStatusHookInterval(arg0 context.Context) (time.Duration, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateStatusHookInterval")
+	ret := m.ctrl.Call(m, "UpdateStatusHookInterval", arg0)
 	ret0, _ := ret[0].(time.Duration)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // UpdateStatusHookInterval indicates an expected call of UpdateStatusHookInterval.
-func (mr *MockUniterClientMockRecorder) UpdateStatusHookInterval() *MockUniterClientUpdateStatusHookIntervalCall {
+func (mr *MockUniterClientMockRecorder) UpdateStatusHookInterval(arg0 any) *MockUniterClientUpdateStatusHookIntervalCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateStatusHookInterval", reflect.TypeOf((*MockUniterClient)(nil).UpdateStatusHookInterval))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateStatusHookInterval", reflect.TypeOf((*MockUniterClient)(nil).UpdateStatusHookInterval), arg0)
 	return &MockUniterClientUpdateStatusHookIntervalCall{Call: call}
 }
 
@@ -1045,13 +1045,13 @@ func (c *MockUniterClientUpdateStatusHookIntervalCall) Return(arg0 time.Duration
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockUniterClientUpdateStatusHookIntervalCall) Do(f func() (time.Duration, error)) *MockUniterClientUpdateStatusHookIntervalCall {
+func (c *MockUniterClientUpdateStatusHookIntervalCall) Do(f func(context.Context) (time.Duration, error)) *MockUniterClientUpdateStatusHookIntervalCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockUniterClientUpdateStatusHookIntervalCall) DoAndReturn(f func() (time.Duration, error)) *MockUniterClientUpdateStatusHookIntervalCall {
+func (c *MockUniterClientUpdateStatusHookIntervalCall) DoAndReturn(f func(context.Context) (time.Duration, error)) *MockUniterClientUpdateStatusHookIntervalCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1135,18 +1135,18 @@ func (c *MockUniterClientWatchStorageAttachmentCall) DoAndReturn(f func(names.St
 }
 
 // WatchUpdateStatusHookInterval mocks base method.
-func (m *MockUniterClient) WatchUpdateStatusHookInterval() (watcher.NotifyWatcher, error) {
+func (m *MockUniterClient) WatchUpdateStatusHookInterval(arg0 context.Context) (watcher.NotifyWatcher, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchUpdateStatusHookInterval")
+	ret := m.ctrl.Call(m, "WatchUpdateStatusHookInterval", arg0)
 	ret0, _ := ret[0].(watcher.NotifyWatcher)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // WatchUpdateStatusHookInterval indicates an expected call of WatchUpdateStatusHookInterval.
-func (mr *MockUniterClientMockRecorder) WatchUpdateStatusHookInterval() *MockUniterClientWatchUpdateStatusHookIntervalCall {
+func (mr *MockUniterClientMockRecorder) WatchUpdateStatusHookInterval(arg0 any) *MockUniterClientWatchUpdateStatusHookIntervalCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchUpdateStatusHookInterval", reflect.TypeOf((*MockUniterClient)(nil).WatchUpdateStatusHookInterval))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchUpdateStatusHookInterval", reflect.TypeOf((*MockUniterClient)(nil).WatchUpdateStatusHookInterval), arg0)
 	return &MockUniterClientWatchUpdateStatusHookIntervalCall{Call: call}
 }
 
@@ -1162,13 +1162,13 @@ func (c *MockUniterClientWatchUpdateStatusHookIntervalCall) Return(arg0 watcher.
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockUniterClientWatchUpdateStatusHookIntervalCall) Do(f func() (watcher.NotifyWatcher, error)) *MockUniterClientWatchUpdateStatusHookIntervalCall {
+func (c *MockUniterClientWatchUpdateStatusHookIntervalCall) Do(f func(context.Context) (watcher.NotifyWatcher, error)) *MockUniterClientWatchUpdateStatusHookIntervalCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockUniterClientWatchUpdateStatusHookIntervalCall) DoAndReturn(f func() (watcher.NotifyWatcher, error)) *MockUniterClientWatchUpdateStatusHookIntervalCall {
+func (c *MockUniterClientWatchUpdateStatusHookIntervalCall) DoAndReturn(f func(context.Context) (watcher.NotifyWatcher, error)) *MockUniterClientWatchUpdateStatusHookIntervalCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/uniter/entity_mocks_test.go
+++ b/internal/worker/uniter/entity_mocks_test.go
@@ -107,7 +107,7 @@ func (ctx *testContext) makeUnit(c *gc.C, unitTag names.UnitTag, l life.Value) *
 	u.EXPECT().ApplicationTag().Return(appTag).AnyTimes()
 	u.EXPECT().Refresh(gomock.Any()).Return(nil).AnyTimes()
 	u.EXPECT().ProviderID().Return("").AnyTimes()
-	u.EXPECT().UpgradeSeriesStatus().Return(model.UpgradeSeriesNotStarted, "", nil).AnyTimes()
+	u.EXPECT().UpgradeSeriesStatus(gomock.Any()).Return(model.UpgradeSeriesNotStarted, "", nil).AnyTimes()
 	u.EXPECT().PrincipalName().Return("u", false, nil).AnyTimes()
 	u.EXPECT().EnsureDead().DoAndReturn(func() error {
 		u.mu.Lock()
@@ -189,7 +189,7 @@ func (ctx *testContext) makeUnit(c *gc.C, unitTag names.UnitTag, l life.Value) *
 		return nil
 	}).AnyTimes()
 
-	getState := func() (params.UnitStateResult, error) {
+	getState := func(context.Context) (params.UnitStateResult, error) {
 		ctx.stateMu.Lock()
 		defer ctx.stateMu.Unlock()
 		result := params.UnitStateResult{
@@ -199,7 +199,7 @@ func (ctx *testContext) makeUnit(c *gc.C, unitTag names.UnitTag, l life.Value) *
 		}
 		return result, nil
 	}
-	u.EXPECT().State().DoAndReturn(getState).AnyTimes()
+	u.EXPECT().State(gomock.Any()).DoAndReturn(getState).AnyTimes()
 
 	u.EXPECT().RelationsStatus().DoAndReturn(func() ([]apiuniter.RelationStatus, error) {
 		u.mu.Lock()

--- a/internal/worker/uniter/op_callbacks.go
+++ b/internal/worker/uniter/op_callbacks.go
@@ -75,7 +75,7 @@ func (opc *operationCallbacks) CommitHook(ctx stdcontext.Context, hi hook.Info) 
 	case hi.Kind.IsRelation():
 		return opc.u.relationStateTracker.CommitHook(ctx, hi)
 	case hi.Kind.IsStorage():
-		return opc.u.storage.CommitHook(hi)
+		return opc.u.storage.CommitHook(ctx, hi)
 	case hi.Kind.IsSecret():
 		return opc.u.secretsTracker.CommitHook(ctx, hi)
 	}
@@ -151,8 +151,8 @@ func (opc *operationCallbacks) SetExecutingStatus(message string) error {
 }
 
 // SetUpgradeSeriesStatus is part of the operation.Callbacks interface.
-func (opc *operationCallbacks) SetUpgradeSeriesStatus(upgradeSeriesStatus model.UpgradeSeriesStatus, reason string) error {
-	return setUpgradeSeriesStatus(opc.u, upgradeSeriesStatus, reason)
+func (opc *operationCallbacks) SetUpgradeSeriesStatus(ctx stdcontext.Context, upgradeSeriesStatus model.UpgradeSeriesStatus, reason string) error {
+	return setUpgradeSeriesStatus(ctx, opc.u, upgradeSeriesStatus, reason)
 }
 
 // RemoteInit is part of the operation.Callbacks interface.
@@ -173,6 +173,6 @@ func (opc *operationCallbacks) SetSecretRotated(uri string, oldRevision int) err
 }
 
 // SecretsRemoved is part of the operation.Callbacks interface.
-func (opc *operationCallbacks) SecretsRemoved(uris []string) error {
-	return opc.u.secretsTracker.SecretsRemoved(uris)
+func (opc *operationCallbacks) SecretsRemoved(ctx stdcontext.Context, uris []string) error {
+	return opc.u.secretsTracker.SecretsRemoved(ctx, uris)
 }

--- a/internal/worker/uniter/operation/interface.go
+++ b/internal/worker/uniter/operation/interface.go
@@ -231,14 +231,14 @@ type Callbacks interface {
 	// upgrade the status of a running series upgrade before or after
 	// upgrade series hook code completes and, for display purposes, to
 	// supply a reason as to why it is making the change.
-	SetUpgradeSeriesStatus(status model.UpgradeSeriesStatus, reason string) error
+	SetUpgradeSeriesStatus(ctx stdcontext.Context, status model.UpgradeSeriesStatus, reason string) error
 
 	// SetSecretRotated updates the secret rotation status.
 	SetSecretRotated(url string, originalRevision int) error
 
 	// SecretsRemoved updates the unit secret state when
 	// secrets are removed.
-	SecretsRemoved(uris []string) error
+	SecretsRemoved(ctx stdcontext.Context, uris []string) error
 
 	// RemoteInit copies the charm to the remote instance. CAAS only.
 	RemoteInit(runningStatus remotestate.ContainerRunningStatus, abort <-chan struct{}) error

--- a/internal/worker/uniter/operation/mocks/interface_mock.go
+++ b/internal/worker/uniter/operation/mocks/interface_mock.go
@@ -1247,17 +1247,17 @@ func (c *MockCallbacksRemoteInitCall) DoAndReturn(f func(remotestate.ContainerRu
 }
 
 // SecretsRemoved mocks base method.
-func (m *MockCallbacks) SecretsRemoved(arg0 []string) error {
+func (m *MockCallbacks) SecretsRemoved(arg0 context.Context, arg1 []string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SecretsRemoved", arg0)
+	ret := m.ctrl.Call(m, "SecretsRemoved", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SecretsRemoved indicates an expected call of SecretsRemoved.
-func (mr *MockCallbacksMockRecorder) SecretsRemoved(arg0 any) *MockCallbacksSecretsRemovedCall {
+func (mr *MockCallbacksMockRecorder) SecretsRemoved(arg0, arg1 any) *MockCallbacksSecretsRemovedCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SecretsRemoved", reflect.TypeOf((*MockCallbacks)(nil).SecretsRemoved), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SecretsRemoved", reflect.TypeOf((*MockCallbacks)(nil).SecretsRemoved), arg0, arg1)
 	return &MockCallbacksSecretsRemovedCall{Call: call}
 }
 
@@ -1273,13 +1273,13 @@ func (c *MockCallbacksSecretsRemovedCall) Return(arg0 error) *MockCallbacksSecre
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockCallbacksSecretsRemovedCall) Do(f func([]string) error) *MockCallbacksSecretsRemovedCall {
+func (c *MockCallbacksSecretsRemovedCall) Do(f func(context.Context, []string) error) *MockCallbacksSecretsRemovedCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockCallbacksSecretsRemovedCall) DoAndReturn(f func([]string) error) *MockCallbacksSecretsRemovedCall {
+func (c *MockCallbacksSecretsRemovedCall) DoAndReturn(f func(context.Context, []string) error) *MockCallbacksSecretsRemovedCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1399,17 +1399,17 @@ func (c *MockCallbacksSetSecretRotatedCall) DoAndReturn(f func(string, int) erro
 }
 
 // SetUpgradeSeriesStatus mocks base method.
-func (m *MockCallbacks) SetUpgradeSeriesStatus(arg0 model.UpgradeSeriesStatus, arg1 string) error {
+func (m *MockCallbacks) SetUpgradeSeriesStatus(arg0 context.Context, arg1 model.UpgradeSeriesStatus, arg2 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetUpgradeSeriesStatus", arg0, arg1)
+	ret := m.ctrl.Call(m, "SetUpgradeSeriesStatus", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetUpgradeSeriesStatus indicates an expected call of SetUpgradeSeriesStatus.
-func (mr *MockCallbacksMockRecorder) SetUpgradeSeriesStatus(arg0, arg1 any) *MockCallbacksSetUpgradeSeriesStatusCall {
+func (mr *MockCallbacksMockRecorder) SetUpgradeSeriesStatus(arg0, arg1, arg2 any) *MockCallbacksSetUpgradeSeriesStatusCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUpgradeSeriesStatus", reflect.TypeOf((*MockCallbacks)(nil).SetUpgradeSeriesStatus), arg0, arg1)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUpgradeSeriesStatus", reflect.TypeOf((*MockCallbacks)(nil).SetUpgradeSeriesStatus), arg0, arg1, arg2)
 	return &MockCallbacksSetUpgradeSeriesStatusCall{Call: call}
 }
 
@@ -1425,13 +1425,13 @@ func (c *MockCallbacksSetUpgradeSeriesStatusCall) Return(arg0 error) *MockCallba
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockCallbacksSetUpgradeSeriesStatusCall) Do(f func(model.UpgradeSeriesStatus, string) error) *MockCallbacksSetUpgradeSeriesStatusCall {
+func (c *MockCallbacksSetUpgradeSeriesStatusCall) Do(f func(context.Context, model.UpgradeSeriesStatus, string) error) *MockCallbacksSetUpgradeSeriesStatusCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockCallbacksSetUpgradeSeriesStatusCall) DoAndReturn(f func(model.UpgradeSeriesStatus, string) error) *MockCallbacksSetUpgradeSeriesStatusCall {
+func (c *MockCallbacksSetUpgradeSeriesStatusCall) DoAndReturn(f func(context.Context, model.UpgradeSeriesStatus, string) error) *MockCallbacksSetUpgradeSeriesStatusCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/uniter/operation/mocks/uniterstaterw_mock.go
+++ b/internal/worker/uniter/operation/mocks/uniterstaterw_mock.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	params "github.com/juju/juju/rpc/params"
@@ -40,17 +41,17 @@ func (m *MockUnitStateReadWriter) EXPECT() *MockUnitStateReadWriterMockRecorder 
 }
 
 // SetState mocks base method.
-func (m *MockUnitStateReadWriter) SetState(arg0 params.SetUnitStateArg) error {
+func (m *MockUnitStateReadWriter) SetState(arg0 context.Context, arg1 params.SetUnitStateArg) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetState", arg0)
+	ret := m.ctrl.Call(m, "SetState", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetState indicates an expected call of SetState.
-func (mr *MockUnitStateReadWriterMockRecorder) SetState(arg0 any) *MockUnitStateReadWriterSetStateCall {
+func (mr *MockUnitStateReadWriterMockRecorder) SetState(arg0, arg1 any) *MockUnitStateReadWriterSetStateCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetState", reflect.TypeOf((*MockUnitStateReadWriter)(nil).SetState), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetState", reflect.TypeOf((*MockUnitStateReadWriter)(nil).SetState), arg0, arg1)
 	return &MockUnitStateReadWriterSetStateCall{Call: call}
 }
 
@@ -66,30 +67,30 @@ func (c *MockUnitStateReadWriterSetStateCall) Return(arg0 error) *MockUnitStateR
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockUnitStateReadWriterSetStateCall) Do(f func(params.SetUnitStateArg) error) *MockUnitStateReadWriterSetStateCall {
+func (c *MockUnitStateReadWriterSetStateCall) Do(f func(context.Context, params.SetUnitStateArg) error) *MockUnitStateReadWriterSetStateCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockUnitStateReadWriterSetStateCall) DoAndReturn(f func(params.SetUnitStateArg) error) *MockUnitStateReadWriterSetStateCall {
+func (c *MockUnitStateReadWriterSetStateCall) DoAndReturn(f func(context.Context, params.SetUnitStateArg) error) *MockUnitStateReadWriterSetStateCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // State mocks base method.
-func (m *MockUnitStateReadWriter) State() (params.UnitStateResult, error) {
+func (m *MockUnitStateReadWriter) State(arg0 context.Context) (params.UnitStateResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "State")
+	ret := m.ctrl.Call(m, "State", arg0)
 	ret0, _ := ret[0].(params.UnitStateResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // State indicates an expected call of State.
-func (mr *MockUnitStateReadWriterMockRecorder) State() *MockUnitStateReadWriterStateCall {
+func (mr *MockUnitStateReadWriterMockRecorder) State(arg0 any) *MockUnitStateReadWriterStateCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "State", reflect.TypeOf((*MockUnitStateReadWriter)(nil).State))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "State", reflect.TypeOf((*MockUnitStateReadWriter)(nil).State), arg0)
 	return &MockUnitStateReadWriterStateCall{Call: call}
 }
 
@@ -105,13 +106,13 @@ func (c *MockUnitStateReadWriterStateCall) Return(arg0 params.UnitStateResult, a
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockUnitStateReadWriterStateCall) Do(f func() (params.UnitStateResult, error)) *MockUnitStateReadWriterStateCall {
+func (c *MockUnitStateReadWriterStateCall) Do(f func(context.Context) (params.UnitStateResult, error)) *MockUnitStateReadWriterStateCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockUnitStateReadWriterStateCall) DoAndReturn(f func() (params.UnitStateResult, error)) *MockUnitStateReadWriterStateCall {
+func (c *MockUnitStateReadWriterStateCall) DoAndReturn(f func(context.Context) (params.UnitStateResult, error)) *MockUnitStateReadWriterStateCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/uniter/operation/runhook.go
+++ b/internal/worker/uniter/operation/runhook.go
@@ -227,9 +227,9 @@ func (rh *runHook) beforeHook(ctx stdcontext.Context, state State) error {
 			Info:   "cleaning up prior to charm deletion",
 		})
 	case hooks.PreSeriesUpgrade:
-		err = rh.callbacks.SetUpgradeSeriesStatus(model.UpgradeSeriesPrepareRunning, "pre-series-upgrade hook running")
+		err = rh.callbacks.SetUpgradeSeriesStatus(ctx, model.UpgradeSeriesPrepareRunning, "pre-series-upgrade hook running")
 	case hooks.PostSeriesUpgrade:
-		err = rh.callbacks.SetUpgradeSeriesStatus(model.UpgradeSeriesCompleteRunning, "post-series-upgrade hook running")
+		err = rh.callbacks.SetUpgradeSeriesStatus(ctx, model.UpgradeSeriesCompleteRunning, "post-series-upgrade hook running")
 	}
 
 	if err != nil {
@@ -325,10 +325,10 @@ func (rh *runHook) Commit(ctx stdcontext.Context, state State) (*State, error) {
 		}
 	case hooks.PreSeriesUpgrade:
 		message := createUpgradeSeriesStatusMessage(rh.name, rh.hookFound)
-		err = rh.callbacks.SetUpgradeSeriesStatus(model.UpgradeSeriesPrepareCompleted, message)
+		err = rh.callbacks.SetUpgradeSeriesStatus(ctx, model.UpgradeSeriesPrepareCompleted, message)
 	case hooks.PostSeriesUpgrade:
 		message := createUpgradeSeriesStatusMessage(rh.name, rh.hookFound)
-		err = rh.callbacks.SetUpgradeSeriesStatus(model.UpgradeSeriesCompleted, message)
+		err = rh.callbacks.SetUpgradeSeriesStatus(ctx, model.UpgradeSeriesCompleted, message)
 	case hooks.SecretRotate:
 		var info map[string]jujuc.SecretMetadata
 		info, err = rh.runner.Context().SecretMetadata()

--- a/internal/worker/uniter/operation/secrets.go
+++ b/internal/worker/uniter/operation/secrets.go
@@ -23,7 +23,7 @@ func (op *noOpSecretsRemoved) String() string {
 
 // Commit is part of the Operation interface.
 func (op *noOpSecretsRemoved) Commit(ctx context.Context, state State) (*State, error) {
-	if err := op.callbacks.SecretsRemoved(op.uris); err != nil {
+	if err := op.callbacks.SecretsRemoved(ctx, op.uris); err != nil {
 		return nil, errors.Trace(err)
 	}
 	// make no change to state

--- a/internal/worker/uniter/operation/util_test.go
+++ b/internal/worker/uniter/operation/util_test.go
@@ -188,7 +188,7 @@ func (cb *PrepareHookCallbacks) SetExecutingStatus(message string) error {
 	return nil
 }
 
-func (cb *PrepareHookCallbacks) SetUpgradeSeriesStatus(model.UpgradeSeriesStatus, string) error {
+func (cb *PrepareHookCallbacks) SetUpgradeSeriesStatus(context.Context, model.UpgradeSeriesStatus, string) error {
 	return nil
 }
 

--- a/internal/worker/uniter/relation/interface.go
+++ b/internal/worker/uniter/relation/interface.go
@@ -96,7 +96,7 @@ type StateManager interface {
 
 	// SetRelation persists the given state, overwriting the previous
 	// state for a given id or creating state at a new id.
-	SetRelation(*State) error
+	SetRelation(stdcontext.Context, *State) error
 
 	// RelationFound returns true if the state manager has a
 	// state for the given id.
@@ -118,11 +118,11 @@ type UnitGetter interface {
 type UnitStateReadWriter interface {
 	// SetState sets the state persisted by the charm running in this unit
 	// and the state internal to the uniter for this unit.
-	SetState(unitState params.SetUnitStateArg) error
+	SetState(ctx stdcontext.Context, unitState params.SetUnitStateArg) error
 
 	// State returns the state persisted by the charm running in this unit
 	// and the state internal to the uniter for this unit.
-	State() (params.UnitStateResult, error)
+	State(ctx stdcontext.Context) (params.UnitStateResult, error)
 }
 
 // StateTrackerClient encapsulates the uniter client API methods
@@ -161,7 +161,7 @@ type Relationer interface {
 	// Join initializes local state and causes the unit to enter its relation
 	// scope, allowing its counterpart units to detect its presence and settings
 	// changes.
-	Join() error
+	Join(ctx stdcontext.Context) error
 
 	// PrepareHook checks that the relation is in a state such that it makes
 	// sense to execute the supplied hook, and ensures that the relation context

--- a/internal/worker/uniter/relation/mocks/mock_relationer.go
+++ b/internal/worker/uniter/relation/mocks/mock_relationer.go
@@ -195,17 +195,17 @@ func (c *MockRelationerIsImplicitCall) DoAndReturn(f func() bool) *MockRelatione
 }
 
 // Join mocks base method.
-func (m *MockRelationer) Join() error {
+func (m *MockRelationer) Join(arg0 context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Join")
+	ret := m.ctrl.Call(m, "Join", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Join indicates an expected call of Join.
-func (mr *MockRelationerMockRecorder) Join() *MockRelationerJoinCall {
+func (mr *MockRelationerMockRecorder) Join(arg0 any) *MockRelationerJoinCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Join", reflect.TypeOf((*MockRelationer)(nil).Join))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Join", reflect.TypeOf((*MockRelationer)(nil).Join), arg0)
 	return &MockRelationerJoinCall{Call: call}
 }
 
@@ -221,13 +221,13 @@ func (c *MockRelationerJoinCall) Return(arg0 error) *MockRelationerJoinCall {
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockRelationerJoinCall) Do(f func() error) *MockRelationerJoinCall {
+func (c *MockRelationerJoinCall) Do(f func(context.Context) error) *MockRelationerJoinCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockRelationerJoinCall) DoAndReturn(f func() error) *MockRelationerJoinCall {
+func (c *MockRelationerJoinCall) DoAndReturn(f func(context.Context) error) *MockRelationerJoinCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/uniter/relation/mocks/mock_state_manager.go
+++ b/internal/worker/uniter/relation/mocks/mock_state_manager.go
@@ -194,17 +194,17 @@ func (c *MockStateManagerRemoveRelationCall) DoAndReturn(f func(context.Context,
 }
 
 // SetRelation mocks base method.
-func (m *MockStateManager) SetRelation(arg0 *relation.State) error {
+func (m *MockStateManager) SetRelation(arg0 context.Context, arg1 *relation.State) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetRelation", arg0)
+	ret := m.ctrl.Call(m, "SetRelation", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetRelation indicates an expected call of SetRelation.
-func (mr *MockStateManagerMockRecorder) SetRelation(arg0 any) *MockStateManagerSetRelationCall {
+func (mr *MockStateManagerMockRecorder) SetRelation(arg0, arg1 any) *MockStateManagerSetRelationCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetRelation", reflect.TypeOf((*MockStateManager)(nil).SetRelation), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetRelation", reflect.TypeOf((*MockStateManager)(nil).SetRelation), arg0, arg1)
 	return &MockStateManagerSetRelationCall{Call: call}
 }
 
@@ -220,13 +220,13 @@ func (c *MockStateManagerSetRelationCall) Return(arg0 error) *MockStateManagerSe
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateManagerSetRelationCall) Do(f func(*relation.State) error) *MockStateManagerSetRelationCall {
+func (c *MockStateManagerSetRelationCall) Do(f func(context.Context, *relation.State) error) *MockStateManagerSetRelationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateManagerSetRelationCall) DoAndReturn(f func(*relation.State) error) *MockStateManagerSetRelationCall {
+func (c *MockStateManagerSetRelationCall) DoAndReturn(f func(context.Context, *relation.State) error) *MockStateManagerSetRelationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/uniter/relation/relationer.go
+++ b/internal/worker/uniter/relation/relationer.go
@@ -77,7 +77,7 @@ func (r *relationer) RelationUnit() api.RelationUnit {
 // Join initializes local state and causes the unit to enter its relation
 // scope, allowing its counterpart units to detect its presence and settings
 // changes.
-func (r *relationer) Join() error {
+func (r *relationer) Join(ctx stdcontext.Context) error {
 	if r.dying {
 		return errors.New("dying relationer must not join!")
 	}
@@ -87,7 +87,7 @@ func (r *relationer) Join() error {
 	if !r.stateMgr.RelationFound(r.relationId) {
 		// Add a state for the new relation to the state manager.
 		st := NewState(r.relationId)
-		if err := r.stateMgr.SetRelation(st); err != nil {
+		if err := r.stateMgr.SetRelation(ctx, st); err != nil {
 			return err
 		}
 	}
@@ -156,5 +156,5 @@ func (r *relationer) CommitHook(ctx stdcontext.Context, hi hook.Info) error {
 		return errors.Trace(err)
 	}
 	st.UpdateStateForHook(hi, r.logger)
-	return r.stateMgr.SetRelation(st)
+	return r.stateMgr.SetRelation(ctx, st)
 }

--- a/internal/worker/uniter/relation/relationer_test.go
+++ b/internal/worker/uniter/relation/relationer_test.go
@@ -98,7 +98,7 @@ func (s *relationerSuite) TestIfDyingFailJoin(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Try to Join
-	err = r.Join()
+	err = r.Join(context.Background())
 	c.Assert(err, gc.ErrorMatches, `dying relationer must not join!`)
 }
 
@@ -202,7 +202,7 @@ func (s *relationerSuite) TestJoinRelation(c *gc.C) {
 
 	r := s.newRelationer(c)
 
-	err := r.Join()
+	err := r.Join(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -214,7 +214,7 @@ func (s *relationerSuite) TestJoinRelationNotFound(c *gc.C) {
 	s.expectSetRelation()
 
 	r := s.newRelationer(c)
-	err := r.Join()
+	err := r.Join(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -286,7 +286,7 @@ func (s *relationerSuite) expectRelationFound(found bool) {
 }
 
 func (s *relationerSuite) expectSetRelation() {
-	s.stateManager.EXPECT().SetRelation(gomock.Any()).Return(nil)
+	s.stateManager.EXPECT().SetRelation(gomock.Any(), gomock.Any()).Return(nil)
 }
 
 func (s *relationerSuite) expectStateManagerRelation(err error) {

--- a/internal/worker/uniter/relation/statemanager_test.go
+++ b/internal/worker/uniter/relation/statemanager_test.go
@@ -32,7 +32,7 @@ func (s *stateManagerSuite) TestNewStateManagerHasState(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	states := s.setupFourStates(c)
 
-	mgr, err := relation.NewStateManager(s.mockUnitRW, loggertesting.WrapCheckLog(c))
+	mgr, err := relation.NewStateManager(context.Background(), s.mockUnitRW, loggertesting.WrapCheckLog(c))
 	c.Assert(err, jc.ErrorIsNil)
 	for _, st := range states {
 		v, err := mgr.Relation(st.RelationId)
@@ -45,7 +45,7 @@ func (s *stateManagerSuite) TestNewStateManagerNoState(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	s.expectStateEmpty()
 
-	mgr, err := relation.NewStateManager(s.mockUnitRW, loggertesting.WrapCheckLog(c))
+	mgr, err := relation.NewStateManager(context.Background(), s.mockUnitRW, loggertesting.WrapCheckLog(c))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(mgr.KnownIDs(), gc.HasLen, 0)
 }
@@ -54,7 +54,7 @@ func (s *stateManagerSuite) TestNewStateManagerErr(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	s.expectStateEmptyError()
 
-	_, err := relation.NewStateManager(s.mockUnitRW, loggertesting.WrapCheckLog(c))
+	_, err := relation.NewStateManager(context.Background(), s.mockUnitRW, loggertesting.WrapCheckLog(c))
 	c.Assert(err, jc.ErrorIs, errors.BadRequest)
 }
 
@@ -62,7 +62,7 @@ func (s *stateManagerSuite) TestKnownIds(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	states := s.setupFourStates(c)
 
-	mgr, err := relation.NewStateManager(s.mockUnitRW, loggertesting.WrapCheckLog(c))
+	mgr, err := relation.NewStateManager(context.Background(), s.mockUnitRW, loggertesting.WrapCheckLog(c))
 	c.Assert(err, jc.ErrorIsNil)
 	ids := mgr.KnownIDs()
 	intSet := set.NewInts(ids...)
@@ -76,7 +76,7 @@ func (s *stateManagerSuite) TestRelation(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	states := s.setupFourStates(c)
 
-	mgr, err := relation.NewStateManager(s.mockUnitRW, loggertesting.WrapCheckLog(c))
+	mgr, err := relation.NewStateManager(context.Background(), s.mockUnitRW, loggertesting.WrapCheckLog(c))
 	c.Assert(err, jc.ErrorIsNil)
 	st, err := mgr.Relation(states[1].RelationId)
 	c.Assert(err, jc.ErrorIsNil)
@@ -87,7 +87,7 @@ func (s *stateManagerSuite) TestRelationNotFound(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	_ = s.setupFourStates(c)
 
-	mgr, err := relation.NewStateManager(s.mockUnitRW, loggertesting.WrapCheckLog(c))
+	mgr, err := relation.NewStateManager(context.Background(), s.mockUnitRW, loggertesting.WrapCheckLog(c))
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = mgr.Relation(42)
 	c.Assert(err, jc.ErrorIs, errors.NotFound)
@@ -103,9 +103,9 @@ func (s *stateManagerSuite) TestSetNew(c *gc.C) {
 	}
 	s.expectSetState(c, *st2)
 
-	mgr, err := relation.NewStateManager(s.mockUnitRW, loggertesting.WrapCheckLog(c))
+	mgr, err := relation.NewStateManager(context.Background(), s.mockUnitRW, loggertesting.WrapCheckLog(c))
 	c.Assert(err, jc.ErrorIsNil)
-	err = mgr.SetRelation(st2)
+	err = mgr.SetRelation(context.Background(), st2)
 	c.Assert(err, jc.ErrorIsNil)
 	found := mgr.RelationFound(456)
 	c.Assert(found, jc.IsTrue)
@@ -115,14 +115,14 @@ func (s *stateManagerSuite) TestSetChangeExisting(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	states := s.setupFourStates(c)
 
-	mgr, err := relation.NewStateManager(s.mockUnitRW, loggertesting.WrapCheckLog(c))
+	mgr, err := relation.NewStateManager(context.Background(), s.mockUnitRW, loggertesting.WrapCheckLog(c))
 	c.Assert(err, jc.ErrorIsNil)
 
 	states[3].ChangedPending = "foo/1"
 	s.expectSetState(c, states...)
 	st := states[3]
 
-	err = mgr.SetRelation(&st)
+	err = mgr.SetRelation(context.Background(), &st)
 	c.Assert(err, jc.ErrorIsNil)
 
 	obtained, err := mgr.Relation(st.RelationId)
@@ -135,12 +135,12 @@ func (s *stateManagerSuite) TestSetChangeExistingFail(c *gc.C) {
 	states := s.setupFourStates(c)
 	s.expectSetStateError()
 
-	mgr, err := relation.NewStateManager(s.mockUnitRW, loggertesting.WrapCheckLog(c))
+	mgr, err := relation.NewStateManager(context.Background(), s.mockUnitRW, loggertesting.WrapCheckLog(c))
 	c.Assert(err, jc.ErrorIsNil)
 
 	st := states[3]
 	st.ChangedPending = "foo/1"
-	err = mgr.SetRelation(&st)
+	err = mgr.SetRelation(context.Background(), &st)
 	c.Assert(err, jc.ErrorIs, errors.BadRequest)
 
 	obtained, err := mgr.Relation(st.RelationId)
@@ -154,7 +154,7 @@ func (s *stateManagerSuite) TestRemove(c *gc.C) {
 	s.expectState(c, state)
 	s.expectSetStateEmpty(c)
 
-	mgr, err := relation.NewStateManager(s.mockUnitRW, loggertesting.WrapCheckLog(c))
+	mgr, err := relation.NewStateManager(context.Background(), s.mockUnitRW, loggertesting.WrapCheckLog(c))
 	c.Assert(err, jc.ErrorIsNil)
 	err = mgr.RemoveRelation(context.Background(), 1, s.mockUnitGetter, map[string]bool{})
 	c.Assert(err, jc.ErrorIsNil)
@@ -166,7 +166,7 @@ func (s *stateManagerSuite) TestRemoveNotFound(c *gc.C) {
 	stateTwo.Members = map[string]int64{"foo/1": 0}
 	s.expectState(c, stateTwo)
 
-	mgr, err := relation.NewStateManager(s.mockUnitRW, loggertesting.WrapCheckLog(c))
+	mgr, err := relation.NewStateManager(context.Background(), s.mockUnitRW, loggertesting.WrapCheckLog(c))
 	c.Assert(err, jc.ErrorIsNil)
 	err = mgr.RemoveRelation(context.Background(), 1, s.mockUnitGetter, map[string]bool{})
 	c.Assert(err, jc.ErrorIs, errors.NotFound)
@@ -179,7 +179,7 @@ func (s *stateManagerSuite) TestRemoveFailHasMembers(c *gc.C) {
 	s.expectState(c, stateTwo)
 	s.mockUnitGetter.EXPECT().Unit(gomock.Any(), names.NewUnitTag("foo/1")).Return(nil, nil)
 
-	mgr, err := relation.NewStateManager(s.mockUnitRW, loggertesting.WrapCheckLog(c))
+	mgr, err := relation.NewStateManager(context.Background(), s.mockUnitRW, loggertesting.WrapCheckLog(c))
 	c.Assert(err, jc.ErrorIsNil)
 	err = mgr.RemoveRelation(context.Background(), 99, s.mockUnitGetter, map[string]bool{})
 	c.Assert(err, gc.ErrorMatches, `*has members: \[foo/1\]`)
@@ -197,7 +197,7 @@ func (s *stateManagerSuite) TestRemoveIgnoresMissingUnits(c *gc.C) {
 	var tw loggo.TestWriter
 	c.Assert(loggo.RegisterWriter("relations-tester", &tw), gc.IsNil)
 
-	mgr, err := relation.NewStateManager(s.mockUnitRW, logger)
+	mgr, err := relation.NewStateManager(context.Background(), s.mockUnitRW, logger)
 	c.Assert(err, jc.ErrorIsNil)
 	err = mgr.RemoveRelation(context.Background(), 99, s.mockUnitGetter, map[string]bool{})
 	c.Assert(err, jc.ErrorIsNil)
@@ -217,7 +217,7 @@ func (s *stateManagerSuite) TestRemoveCachesUnits(c *gc.C) {
 	s.expectSetState(c, stateThree)
 	s.mockUnitGetter.EXPECT().Unit(gomock.Any(), names.NewUnitTag("foo/1")).Return(nil, &params.Error{Code: "not found"})
 
-	mgr, err := relation.NewStateManager(s.mockUnitRW, loggertesting.WrapCheckLog(c))
+	mgr, err := relation.NewStateManager(context.Background(), s.mockUnitRW, loggertesting.WrapCheckLog(c))
 	c.Assert(err, jc.ErrorIsNil)
 	knownUnits := make(map[string]bool)
 	err = mgr.RemoveRelation(context.Background(), 99, s.mockUnitGetter, knownUnits)
@@ -235,7 +235,7 @@ func (s *stateManagerSuite) TestRemoveFailRequest(c *gc.C) {
 	s.expectState(c, stateTwo)
 	s.expectSetStateError()
 
-	mgr, err := relation.NewStateManager(s.mockUnitRW, loggertesting.WrapCheckLog(c))
+	mgr, err := relation.NewStateManager(context.Background(), s.mockUnitRW, loggertesting.WrapCheckLog(c))
 	c.Assert(err, jc.ErrorIsNil)
 	err = mgr.RemoveRelation(context.Background(), 99, s.mockUnitGetter, map[string]bool{})
 	c.Assert(err, jc.ErrorIs, errors.BadRequest)
@@ -276,12 +276,12 @@ func (s *stateManagerSuite) setupFourStates(c *gc.C) []relation.State {
 
 func (s *stateManagerSuite) expectStateEmpty() {
 	exp := s.mockUnitRW.EXPECT()
-	exp.State().Return(params.UnitStateResult{}, nil)
+	exp.State(gomock.Any()).Return(params.UnitStateResult{}, nil)
 }
 
 func (s *stateManagerSuite) expectStateEmptyError() {
 	exp := s.mockUnitRW.EXPECT()
-	exp.State().Return(params.UnitStateResult{}, errors.BadRequestf("testing"))
+	exp.State(gomock.Any()).Return(params.UnitStateResult{}, errors.BadRequestf("testing"))
 }
 
 func (s *stateManagerSuite) expectSetState(c *gc.C, states ...relation.State) {
@@ -292,17 +292,17 @@ func (s *stateManagerSuite) expectSetState(c *gc.C, states ...relation.State) {
 		expectedStates[s.RelationId] = str
 	}
 	exp := s.mockUnitRW.EXPECT()
-	exp.SetState(unitStateMatcher{c: c, expected: expectedStates}).Return(nil)
+	exp.SetState(gomock.Any(), unitStateMatcher{c: c, expected: expectedStates}).Return(nil)
 }
 
 func (s *stateManagerSuite) expectSetStateEmpty(c *gc.C) {
 	exp := s.mockUnitRW.EXPECT()
-	exp.SetState(unitStateMatcher{c: c, expected: map[int]string{}}).Return(nil)
+	exp.SetState(gomock.Any(), unitStateMatcher{c: c, expected: map[int]string{}}).Return(nil)
 }
 
 func (s *stateManagerSuite) expectSetStateError() {
 	exp := s.mockUnitRW.EXPECT()
-	exp.SetState(gomock.Any()).Return(errors.BadRequestf("testing"))
+	exp.SetState(gomock.Any(), gomock.Any()).Return(errors.BadRequestf("testing"))
 }
 
 func (s *stateManagerSuite) expectState(c *gc.C, states ...relation.State) {
@@ -314,7 +314,7 @@ func (s *stateManagerSuite) expectState(c *gc.C, states ...relation.State) {
 		relationMap[state.RelationId] = strState
 	}
 	exp := s.mockUnitRW.EXPECT()
-	exp.State().Return(params.UnitStateResult{
+	exp.State(gomock.Any()).Return(params.UnitStateResult{
 		RelationState: relationMap,
 	}, nil)
 }

--- a/internal/worker/uniter/relation/statetracker.go
+++ b/internal/worker/uniter/relation/statetracker.go
@@ -79,7 +79,7 @@ func NewRelationStateTracker(ctx stdcontext.Context, cfg RelationStateTrackerCon
 		logger:          cfg.Logger,
 		newRelationer:   NewRelationer,
 	}
-	r.stateMgr, err = NewStateManager(r.unit, r.logger)
+	r.stateMgr, err = NewStateManager(ctx, r.unit, r.logger)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -173,7 +173,7 @@ func (r *relationStateTracker) joinRelation(ctx stdcontext.Context, rel api.Rela
 		return errors.Trace(err)
 	}
 	relationer := r.newRelationer(ru, r.stateMgr, r.client, r.logger)
-	unitWatcher, err := r.unit.Watch()
+	unitWatcher, err := r.unit.Watch(ctx)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -199,7 +199,7 @@ func (r *relationStateTracker) joinRelation(ctx stdcontext.Context, rel api.Rela
 			if !ok {
 				return errors.New("unit watcher closed")
 			}
-			err := relationer.Join()
+			err := relationer.Join(ctx)
 			if params.IsCodeCannotEnterScopeYet(err) {
 				r.logger.Infof("cannot enter scope for relation %q; waiting for subordinate to be removed", rel)
 				continue

--- a/internal/worker/uniter/relation/statetracker_test.go
+++ b/internal/worker/uniter/relation/statetracker_test.go
@@ -620,7 +620,7 @@ func (s *baseStateTrackerSuite) expectRelationerCommitHookFail() {
 }
 
 func (s *baseStateTrackerSuite) expectRelationerJoin() {
-	s.relationer.EXPECT().Join().Return(nil)
+	s.relationer.EXPECT().Join(gomock.Any()).Return(nil)
 }
 
 func (s *baseStateTrackerSuite) expectRelationerRelationUnit() {
@@ -716,7 +716,7 @@ func (s *baseStateTrackerSuite) expectRelationsStatus(status []uniter.RelationSt
 func (s *baseStateTrackerSuite) expectWatch(c *gc.C) {
 	s.unitChanges = make(chan struct{})
 	s.watcher = watchertest.NewMockNotifyWatcher(s.unitChanges)
-	s.unit.EXPECT().Watch().DoAndReturn(func() (watcher.Watcher[struct{}], error) {
+	s.unit.EXPECT().Watch(gomock.Any()).DoAndReturn(func(stdcontext.Context) (watcher.Watcher[struct{}], error) {
 		go func() {
 			select {
 			case s.unitChanges <- struct{}{}:

--- a/internal/worker/uniter/remotestate/interface.go
+++ b/internal/worker/uniter/remotestate/interface.go
@@ -42,8 +42,8 @@ type UniterClient interface {
 	Unit(context.Context, names.UnitTag) (api.Unit, error)
 	WatchRelationUnits(context.Context, names.RelationTag, names.UnitTag) (watcher.RelationUnitsWatcher, error)
 	WatchStorageAttachment(names.StorageTag, names.UnitTag) (watcher.NotifyWatcher, error)
-	WatchUpdateStatusHookInterval() (watcher.NotifyWatcher, error)
-	UpdateStatusHookInterval() (time.Duration, error)
+	WatchUpdateStatusHookInterval(context.Context) (watcher.NotifyWatcher, error)
+	UpdateStatusHookInterval(context.Context) (time.Duration, error)
 }
 
 type Charm interface {

--- a/internal/worker/uniter/remotestate/mock_test.go
+++ b/internal/worker/uniter/remotestate/mock_test.go
@@ -207,11 +207,11 @@ func (m *mockUniterClient) WatchStorageAttachment(
 	return watcher, nil
 }
 
-func (m *mockUniterClient) UpdateStatusHookInterval() (time.Duration, error) {
+func (m *mockUniterClient) UpdateStatusHookInterval(context.Context) (time.Duration, error) {
 	return m.updateStatusInterval, nil
 }
 
-func (m *mockUniterClient) WatchUpdateStatusHookInterval() (watcher.NotifyWatcher, error) {
+func (m *mockUniterClient) WatchUpdateStatusHookInterval(context.Context) (watcher.NotifyWatcher, error) {
 	return m.updateStatusIntervalWatcher, nil
 }
 
@@ -262,7 +262,7 @@ func (u *mockUnit) Tag() names.UnitTag {
 	return u.tag
 }
 
-func (u *mockUnit) Watch() (watcher.NotifyWatcher, error) {
+func (u *mockUnit) Watch(context.Context) (watcher.NotifyWatcher, error) {
 	return u.unitWatcher, nil
 }
 
@@ -290,7 +290,7 @@ func (u *mockUnit) WatchRelations() (watcher.StringsWatcher, error) {
 	return u.relationsWatcher, nil
 }
 
-func (u *mockUnit) WatchUpgradeSeriesNotifications() (watcher.NotifyWatcher, error) {
+func (u *mockUnit) WatchUpgradeSeriesNotifications(context.Context) (watcher.NotifyWatcher, error) {
 	return u.upgradeSeriesWatcher, nil
 }
 
@@ -298,11 +298,11 @@ func (u *mockUnit) WatchInstanceData() (watcher.NotifyWatcher, error) {
 	return u.instanceDataWatcher, nil
 }
 
-func (u *mockUnit) UpgradeSeriesStatus() (model.UpgradeSeriesStatus, string, error) {
+func (u *mockUnit) UpgradeSeriesStatus(context.Context) (model.UpgradeSeriesStatus, string, error) {
 	return model.UpgradeSeriesPrepareStarted, "ubuntu@20.04", nil
 }
 
-func (u *mockUnit) SetUpgradeSeriesStatus(status model.UpgradeSeriesStatus, reason string) error {
+func (u *mockUnit) SetUpgradeSeriesStatus(ctx context.Context, status model.UpgradeSeriesStatus, reason string) error {
 	return nil
 }
 
@@ -337,7 +337,7 @@ func (s *mockApplication) Tag() names.ApplicationTag {
 	return s.tag
 }
 
-func (s *mockApplication) Watch() (watcher.NotifyWatcher, error) {
+func (s *mockApplication) Watch(context.Context) (watcher.NotifyWatcher, error) {
 	return s.applicationWatcher, nil
 }
 

--- a/internal/worker/uniter/resolver_test.go
+++ b/internal/worker/uniter/resolver_test.go
@@ -94,9 +94,9 @@ func (s *rebootResolverSuite) SetUpTest(_ *gc.C) {
 }
 
 func (s *baseResolverSuite) SetUpTest(c *gc.C, modelType model.ModelType, rebootDetected bool) {
-	attachments, err := storage.NewAttachments(&dummyStorageAccessor{}, names.NewUnitTag("u/0"), &fakeRW{}, nil)
+	attachments, err := storage.NewAttachments(context.Background(), &dummyStorageAccessor{}, names.NewUnitTag("u/0"), &fakeRW{}, nil)
 	c.Assert(err, jc.ErrorIsNil)
-	secretsTracker, err := secrets.NewSecrets(&dummySecretsAccessor{}, names.NewUnitTag("u/0"), &fakeRW{}, nil)
+	secretsTracker, err := secrets.NewSecrets(context.Background(), &dummySecretsAccessor{}, names.NewUnitTag("u/0"), &fakeRW{}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	logger := loggertesting.WrapCheckLog(c)
 
@@ -863,11 +863,11 @@ func (s *baseResolverSuite) setupForceCharmModifiedTrue() {
 type fakeRW struct {
 }
 
-func (m *fakeRW) State() (params.UnitStateResult, error) {
+func (m *fakeRW) State(context.Context) (params.UnitStateResult, error) {
 	return params.UnitStateResult{}, nil
 }
 
-func (m *fakeRW) SetState(_ params.SetUnitStateArg) error {
+func (m *fakeRW) SetState(context.Context, params.SetUnitStateArg) error {
 	return nil
 }
 

--- a/internal/worker/uniter/runner/context/contextfactory.go
+++ b/internal/worker/uniter/runner/context/contextfactory.go
@@ -374,7 +374,7 @@ func (f *contextFactory) getContextRelations() map[int]*ContextRelation {
 func (f *contextFactory) updateContext(stdCtx context.Context, ctx *HookContext) (err error) {
 	defer func() { err = errors.Trace(err) }()
 
-	ctx.apiAddrs, err = f.client.APIAddresses()
+	ctx.apiAddrs, err = f.client.APIAddresses(stdCtx)
 	if err != nil {
 		return err
 	}

--- a/internal/worker/uniter/runner/context/contextfactory_test.go
+++ b/internal/worker/uniter/runner/context/contextfactory_test.go
@@ -57,7 +57,7 @@ func (s *ContextFactorySuite) setupContextFactory(c *gc.C, ctrl *gomock.Controll
 		ModelType: s.modelType,
 	}, nil)
 	s.uniter.EXPECT().LeadershipSettings().Return(&stubLeadershipSettingsAccessor{}).AnyTimes()
-	s.uniter.EXPECT().APIAddresses().Return([]string{"10.6.6.6"}, nil).AnyTimes()
+	s.uniter.EXPECT().APIAddresses(gomock.Any()).Return([]string{"10.6.6.6"}, nil).AnyTimes()
 	s.uniter.EXPECT().CloudAPIVersion(gomock.Any()).Return("6.6.6", nil).AnyTimes()
 
 	cfg := coretesting.ModelConfig(c)

--- a/internal/worker/uniter/runner/jujuc/context.go
+++ b/internal/worker/uniter/runner/jujuc/context.go
@@ -124,16 +124,16 @@ type workloadHookContext interface {
 // that is stored within the context.
 type unitCharmStateContext interface {
 	// GetCharmState returns a copy of the charm state.
-	GetCharmState() (map[string]string, error)
+	GetCharmState(context.Context) (map[string]string, error)
 
 	// GetCharmStateValue returns the value of the given key.
-	GetCharmStateValue(string) (string, error)
+	GetCharmStateValue(context.Context, string) (string, error)
 
 	// DeleteCharmStateValue deletes the key/value pair for the given key.
-	DeleteCharmStateValue(string) error
+	DeleteCharmStateValue(context.Context, string) error
 
 	// SetCharmStateValue sets the key to the specified value.
-	SetCharmStateValue(string, string) error
+	SetCharmStateValue(context.Context, string, string) error
 }
 
 // ContextUnit is the part of a hook context related to the unit.

--- a/internal/worker/uniter/runner/jujuc/jujuctesting/unitcachehook.go
+++ b/internal/worker/uniter/runner/jujuc/jujuctesting/unitcachehook.go
@@ -4,6 +4,7 @@
 package jujuctesting
 
 import (
+	"context"
 	"sync"
 )
 
@@ -25,7 +26,7 @@ func (u *UnitCharmState) SetCharmState(newCharmState map[string]string) {
 }
 
 // GetCharmState implements jujuc.unitCharmStateContext.
-func (c *ContextUnitCharmState) GetCharmState() (map[string]string, error) {
+func (c *ContextUnitCharmState) GetCharmState(_ context.Context) (map[string]string, error) {
 	c.stub.AddCall("GetCharmState")
 	_ = c.stub.NextErr()
 	c.info.mu.Lock()
@@ -43,7 +44,7 @@ func (c *ContextUnitCharmState) GetCharmState() (map[string]string, error) {
 }
 
 // GetCharmStateValue implements jujuc.unitCharmStateContext.
-func (c *ContextUnitCharmState) GetCharmStateValue(key string) (string, error) {
+func (c *ContextUnitCharmState) GetCharmStateValue(_ context.Context, key string) (string, error) {
 	c.stub.AddCall("GetSCharmStateValue")
 	c.info.mu.Lock()
 	defer c.info.mu.Unlock()
@@ -53,7 +54,7 @@ func (c *ContextUnitCharmState) GetCharmStateValue(key string) (string, error) {
 }
 
 // DeleteCharmStateValue implements jujuc.unitCharmStateContext.
-func (c *ContextUnitCharmState) DeleteCharmStateValue(key string) error {
+func (c *ContextUnitCharmState) DeleteCharmStateValue(_ context.Context, key string) error {
 	c.stub.AddCall("DeleteCharmStateValue")
 	_ = c.stub.NextErr()
 	c.info.mu.Lock()
@@ -65,7 +66,7 @@ func (c *ContextUnitCharmState) DeleteCharmStateValue(key string) error {
 }
 
 // SetCharmStateValue implements jujuc.unitCharmStateContext.
-func (c *ContextUnitCharmState) SetCharmStateValue(key string, value string) error {
+func (c *ContextUnitCharmState) SetCharmStateValue(_ context.Context, key string, value string) error {
 	c.stub.AddCall("SetCharmStateValue")
 	_ = c.stub.NextErr()
 	c.info.mu.Lock()

--- a/internal/worker/uniter/runner/jujuc/mocks/context_mock.go
+++ b/internal/worker/uniter/runner/jujuc/mocks/context_mock.go
@@ -359,17 +359,17 @@ func (c *MockContextCreateSecretCall) DoAndReturn(f func(*jujuc.SecretCreateArgs
 }
 
 // DeleteCharmStateValue mocks base method.
-func (m *MockContext) DeleteCharmStateValue(arg0 string) error {
+func (m *MockContext) DeleteCharmStateValue(arg0 context.Context, arg1 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteCharmStateValue", arg0)
+	ret := m.ctrl.Call(m, "DeleteCharmStateValue", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteCharmStateValue indicates an expected call of DeleteCharmStateValue.
-func (mr *MockContextMockRecorder) DeleteCharmStateValue(arg0 any) *MockContextDeleteCharmStateValueCall {
+func (mr *MockContextMockRecorder) DeleteCharmStateValue(arg0, arg1 any) *MockContextDeleteCharmStateValueCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCharmStateValue", reflect.TypeOf((*MockContext)(nil).DeleteCharmStateValue), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCharmStateValue", reflect.TypeOf((*MockContext)(nil).DeleteCharmStateValue), arg0, arg1)
 	return &MockContextDeleteCharmStateValueCall{Call: call}
 }
 
@@ -385,13 +385,13 @@ func (c *MockContextDeleteCharmStateValueCall) Return(arg0 error) *MockContextDe
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockContextDeleteCharmStateValueCall) Do(f func(string) error) *MockContextDeleteCharmStateValueCall {
+func (c *MockContextDeleteCharmStateValueCall) Do(f func(context.Context, string) error) *MockContextDeleteCharmStateValueCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockContextDeleteCharmStateValueCall) DoAndReturn(f func(string) error) *MockContextDeleteCharmStateValueCall {
+func (c *MockContextDeleteCharmStateValueCall) DoAndReturn(f func(context.Context, string) error) *MockContextDeleteCharmStateValueCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -474,18 +474,18 @@ func (c *MockContextFlushPayloadsCall) DoAndReturn(f func() error) *MockContextF
 }
 
 // GetCharmState mocks base method.
-func (m *MockContext) GetCharmState() (map[string]string, error) {
+func (m *MockContext) GetCharmState(arg0 context.Context) (map[string]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCharmState")
+	ret := m.ctrl.Call(m, "GetCharmState", arg0)
 	ret0, _ := ret[0].(map[string]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetCharmState indicates an expected call of GetCharmState.
-func (mr *MockContextMockRecorder) GetCharmState() *MockContextGetCharmStateCall {
+func (mr *MockContextMockRecorder) GetCharmState(arg0 any) *MockContextGetCharmStateCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCharmState", reflect.TypeOf((*MockContext)(nil).GetCharmState))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCharmState", reflect.TypeOf((*MockContext)(nil).GetCharmState), arg0)
 	return &MockContextGetCharmStateCall{Call: call}
 }
 
@@ -501,30 +501,30 @@ func (c *MockContextGetCharmStateCall) Return(arg0 map[string]string, arg1 error
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockContextGetCharmStateCall) Do(f func() (map[string]string, error)) *MockContextGetCharmStateCall {
+func (c *MockContextGetCharmStateCall) Do(f func(context.Context) (map[string]string, error)) *MockContextGetCharmStateCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockContextGetCharmStateCall) DoAndReturn(f func() (map[string]string, error)) *MockContextGetCharmStateCall {
+func (c *MockContextGetCharmStateCall) DoAndReturn(f func(context.Context) (map[string]string, error)) *MockContextGetCharmStateCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetCharmStateValue mocks base method.
-func (m *MockContext) GetCharmStateValue(arg0 string) (string, error) {
+func (m *MockContext) GetCharmStateValue(arg0 context.Context, arg1 string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCharmStateValue", arg0)
+	ret := m.ctrl.Call(m, "GetCharmStateValue", arg0, arg1)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetCharmStateValue indicates an expected call of GetCharmStateValue.
-func (mr *MockContextMockRecorder) GetCharmStateValue(arg0 any) *MockContextGetCharmStateValueCall {
+func (mr *MockContextMockRecorder) GetCharmStateValue(arg0, arg1 any) *MockContextGetCharmStateValueCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCharmStateValue", reflect.TypeOf((*MockContext)(nil).GetCharmStateValue), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCharmStateValue", reflect.TypeOf((*MockContext)(nil).GetCharmStateValue), arg0, arg1)
 	return &MockContextGetCharmStateValueCall{Call: call}
 }
 
@@ -540,13 +540,13 @@ func (c *MockContextGetCharmStateValueCall) Return(arg0 string, arg1 error) *Moc
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockContextGetCharmStateValueCall) Do(f func(string) (string, error)) *MockContextGetCharmStateValueCall {
+func (c *MockContextGetCharmStateValueCall) Do(f func(context.Context, string) (string, error)) *MockContextGetCharmStateValueCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockContextGetCharmStateValueCall) DoAndReturn(f func(string) (string, error)) *MockContextGetCharmStateValueCall {
+func (c *MockContextGetCharmStateValueCall) DoAndReturn(f func(context.Context, string) (string, error)) *MockContextGetCharmStateValueCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1594,17 +1594,17 @@ func (c *MockContextSetApplicationStatusCall) DoAndReturn(f func(context.Context
 }
 
 // SetCharmStateValue mocks base method.
-func (m *MockContext) SetCharmStateValue(arg0, arg1 string) error {
+func (m *MockContext) SetCharmStateValue(arg0 context.Context, arg1, arg2 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetCharmStateValue", arg0, arg1)
+	ret := m.ctrl.Call(m, "SetCharmStateValue", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetCharmStateValue indicates an expected call of SetCharmStateValue.
-func (mr *MockContextMockRecorder) SetCharmStateValue(arg0, arg1 any) *MockContextSetCharmStateValueCall {
+func (mr *MockContextMockRecorder) SetCharmStateValue(arg0, arg1, arg2 any) *MockContextSetCharmStateValueCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCharmStateValue", reflect.TypeOf((*MockContext)(nil).SetCharmStateValue), arg0, arg1)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCharmStateValue", reflect.TypeOf((*MockContext)(nil).SetCharmStateValue), arg0, arg1, arg2)
 	return &MockContextSetCharmStateValueCall{Call: call}
 }
 
@@ -1620,13 +1620,13 @@ func (c *MockContextSetCharmStateValueCall) Return(arg0 error) *MockContextSetCh
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockContextSetCharmStateValueCall) Do(f func(string, string) error) *MockContextSetCharmStateValueCall {
+func (c *MockContextSetCharmStateValueCall) Do(f func(context.Context, string, string) error) *MockContextSetCharmStateValueCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockContextSetCharmStateValueCall) DoAndReturn(f func(string, string) error) *MockContextSetCharmStateValueCall {
+func (c *MockContextSetCharmStateValueCall) DoAndReturn(f func(context.Context, string, string) error) *MockContextSetCharmStateValueCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/uniter/runner/jujuc/restricted.go
+++ b/internal/worker/uniter/runner/jujuc/restricted.go
@@ -35,22 +35,22 @@ func (*RestrictedContext) GoalState(context.Context) (*application.GoalState, er
 }
 
 // GetCharmState implements jujuc.unitCharmStateContext.
-func (*RestrictedContext) GetCharmState() (map[string]string, error) {
+func (*RestrictedContext) GetCharmState(context.Context) (map[string]string, error) {
 	return nil, ErrRestrictedContext
 }
 
 // GetCharmStateValue implements jujuc.unitCharmStateContext.
-func (*RestrictedContext) GetCharmStateValue(string) (string, error) {
+func (*RestrictedContext) GetCharmStateValue(context.Context, string) (string, error) {
 	return "", ErrRestrictedContext
 }
 
 // DeleteCharmStateValue implements jujuc.unitCharmStateContext.
-func (*RestrictedContext) DeleteCharmStateValue(string) error {
+func (*RestrictedContext) DeleteCharmStateValue(context.Context, string) error {
 	return ErrRestrictedContext
 }
 
 // SetCharmStateValue implements jujuc.unitCharmStateContext.
-func (*RestrictedContext) SetCharmStateValue(string, string) error {
+func (*RestrictedContext) SetCharmStateValue(context.Context, string, string) error {
 	return ErrRestrictedContext
 }
 

--- a/internal/worker/uniter/runner/jujuc/state-delete.go
+++ b/internal/worker/uniter/runner/jujuc/state-delete.go
@@ -56,7 +56,7 @@ func (c *StateDeleteCommand) Run(ctx *cmd.Context) error {
 	if c.Key == "" {
 		return nil
 	}
-	err := c.ctx.DeleteCharmStateValue(c.Key)
+	err := c.ctx.DeleteCharmStateValue(ctx, c.Key)
 	if err != nil {
 		return err
 	}

--- a/internal/worker/uniter/runner/jujuc/state-get.go
+++ b/internal/worker/uniter/runner/jujuc/state-get.go
@@ -73,14 +73,14 @@ func (c *StateGetCommand) Init(args []string) error {
 // Run implements part of the cmd.Command interface.
 func (c *StateGetCommand) Run(ctx *cmd.Context) error {
 	if c.key == "" {
-		cache, err := c.ctx.GetCharmState()
+		cache, err := c.ctx.GetCharmState(ctx)
 		if err != nil {
 			return err
 		}
 		return c.out.Write(ctx, cache)
 	}
 
-	value, err := c.ctx.GetCharmStateValue(c.key)
+	value, err := c.ctx.GetCharmStateValue(ctx, c.key)
 	notFound := errors.Is(err, errors.NotFound)
 	if err != nil && (!notFound || (notFound && c.strict)) {
 		return err

--- a/internal/worker/uniter/runner/jujuc/state-set.go
+++ b/internal/worker/uniter/runner/jujuc/state-set.go
@@ -93,7 +93,7 @@ func (c *StateSetCommand) Run(ctx *cmd.Context) error {
 	}
 
 	for k, v := range c.StateValues {
-		if err := c.ctx.SetCharmStateValue(k, v); err != nil {
+		if err := c.ctx.SetCharmStateValue(ctx, k, v); err != nil {
 			return err
 		}
 	}

--- a/internal/worker/uniter/runner/jujuc/state_test.go
+++ b/internal/worker/uniter/runner/jujuc/state_test.go
@@ -22,20 +22,20 @@ func (s *stateSuite) setupMocks(c *gc.C) *gomock.Controller {
 }
 
 func (s *stateSuite) expectStateSetOne() {
-	s.mockContext.EXPECT().SetCharmStateValue("one", "two").Return(nil)
+	s.mockContext.EXPECT().SetCharmStateValue(gomock.Any(), "one", "two").Return(nil)
 }
 
 func (s *stateSuite) expectStateSetOneEmpty() {
-	s.mockContext.EXPECT().SetCharmStateValue("one", "").Return(nil)
+	s.mockContext.EXPECT().SetCharmStateValue(gomock.Any(), "one", "").Return(nil)
 }
 
 func (s *stateSuite) expectStateSetTwo() {
 	s.expectStateSetOne()
-	s.mockContext.EXPECT().SetCharmStateValue("three", "four").Return(nil)
+	s.mockContext.EXPECT().SetCharmStateValue(gomock.Any(), "three", "four").Return(nil)
 }
 
 func (s *stateSuite) expectStateDeleteOne() {
-	s.mockContext.EXPECT().DeleteCharmStateValue("five").Return(nil)
+	s.mockContext.EXPECT().DeleteCharmStateValue(gomock.Any(), "five").Return(nil)
 }
 
 func (s *stateSuite) expectStateGetTwo() {
@@ -43,17 +43,17 @@ func (s *stateSuite) expectStateGetTwo() {
 		"one":   "two",
 		"three": "four",
 	}
-	s.mockContext.EXPECT().GetCharmState().Return(setupCache, nil)
+	s.mockContext.EXPECT().GetCharmState(gomock.Any()).Return(setupCache, nil)
 }
 
 func (s *stateSuite) expectStateGetValueOne() {
-	s.mockContext.EXPECT().GetCharmStateValue("one").Return("two", nil)
+	s.mockContext.EXPECT().GetCharmStateValue(gomock.Any(), "one").Return("two", nil)
 }
 
 func (s *stateSuite) expectStateGetValueNotFound() {
-	s.mockContext.EXPECT().GetCharmStateValue("five").Return("", errors.NotFoundf("%q", "five"))
+	s.mockContext.EXPECT().GetCharmStateValue(gomock.Any(), "five").Return("", errors.NotFoundf("%q", "five"))
 }
 
 func (s *stateSuite) expectStateGetValueEmpty() {
-	s.mockContext.EXPECT().GetCharmStateValue("five").Return("", nil)
+	s.mockContext.EXPECT().GetCharmStateValue(gomock.Any(), "five").Return("", nil)
 }

--- a/internal/worker/uniter/runner/mocks/context_mock.go
+++ b/internal/worker/uniter/runner/mocks/context_mock.go
@@ -400,17 +400,17 @@ func (c *MockContextCreateSecretCall) DoAndReturn(f func(*jujuc.SecretCreateArgs
 }
 
 // DeleteCharmStateValue mocks base method.
-func (m *MockContext) DeleteCharmStateValue(arg0 string) error {
+func (m *MockContext) DeleteCharmStateValue(arg0 context.Context, arg1 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteCharmStateValue", arg0)
+	ret := m.ctrl.Call(m, "DeleteCharmStateValue", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteCharmStateValue indicates an expected call of DeleteCharmStateValue.
-func (mr *MockContextMockRecorder) DeleteCharmStateValue(arg0 any) *MockContextDeleteCharmStateValueCall {
+func (mr *MockContextMockRecorder) DeleteCharmStateValue(arg0, arg1 any) *MockContextDeleteCharmStateValueCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCharmStateValue", reflect.TypeOf((*MockContext)(nil).DeleteCharmStateValue), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCharmStateValue", reflect.TypeOf((*MockContext)(nil).DeleteCharmStateValue), arg0, arg1)
 	return &MockContextDeleteCharmStateValueCall{Call: call}
 }
 
@@ -426,13 +426,13 @@ func (c *MockContextDeleteCharmStateValueCall) Return(arg0 error) *MockContextDe
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockContextDeleteCharmStateValueCall) Do(f func(string) error) *MockContextDeleteCharmStateValueCall {
+func (c *MockContextDeleteCharmStateValueCall) Do(f func(context.Context, string) error) *MockContextDeleteCharmStateValueCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockContextDeleteCharmStateValueCall) DoAndReturn(f func(string) error) *MockContextDeleteCharmStateValueCall {
+func (c *MockContextDeleteCharmStateValueCall) DoAndReturn(f func(context.Context, string) error) *MockContextDeleteCharmStateValueCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -553,18 +553,18 @@ func (c *MockContextFlushPayloadsCall) DoAndReturn(f func() error) *MockContextF
 }
 
 // GetCharmState mocks base method.
-func (m *MockContext) GetCharmState() (map[string]string, error) {
+func (m *MockContext) GetCharmState(arg0 context.Context) (map[string]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCharmState")
+	ret := m.ctrl.Call(m, "GetCharmState", arg0)
 	ret0, _ := ret[0].(map[string]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetCharmState indicates an expected call of GetCharmState.
-func (mr *MockContextMockRecorder) GetCharmState() *MockContextGetCharmStateCall {
+func (mr *MockContextMockRecorder) GetCharmState(arg0 any) *MockContextGetCharmStateCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCharmState", reflect.TypeOf((*MockContext)(nil).GetCharmState))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCharmState", reflect.TypeOf((*MockContext)(nil).GetCharmState), arg0)
 	return &MockContextGetCharmStateCall{Call: call}
 }
 
@@ -580,30 +580,30 @@ func (c *MockContextGetCharmStateCall) Return(arg0 map[string]string, arg1 error
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockContextGetCharmStateCall) Do(f func() (map[string]string, error)) *MockContextGetCharmStateCall {
+func (c *MockContextGetCharmStateCall) Do(f func(context.Context) (map[string]string, error)) *MockContextGetCharmStateCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockContextGetCharmStateCall) DoAndReturn(f func() (map[string]string, error)) *MockContextGetCharmStateCall {
+func (c *MockContextGetCharmStateCall) DoAndReturn(f func(context.Context) (map[string]string, error)) *MockContextGetCharmStateCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetCharmStateValue mocks base method.
-func (m *MockContext) GetCharmStateValue(arg0 string) (string, error) {
+func (m *MockContext) GetCharmStateValue(arg0 context.Context, arg1 string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCharmStateValue", arg0)
+	ret := m.ctrl.Call(m, "GetCharmStateValue", arg0, arg1)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetCharmStateValue indicates an expected call of GetCharmStateValue.
-func (mr *MockContextMockRecorder) GetCharmStateValue(arg0 any) *MockContextGetCharmStateValueCall {
+func (mr *MockContextMockRecorder) GetCharmStateValue(arg0, arg1 any) *MockContextGetCharmStateValueCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCharmStateValue", reflect.TypeOf((*MockContext)(nil).GetCharmStateValue), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCharmStateValue", reflect.TypeOf((*MockContext)(nil).GetCharmStateValue), arg0, arg1)
 	return &MockContextGetCharmStateValueCall{Call: call}
 }
 
@@ -619,13 +619,13 @@ func (c *MockContextGetCharmStateValueCall) Return(arg0 string, arg1 error) *Moc
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockContextGetCharmStateValueCall) Do(f func(string) (string, error)) *MockContextGetCharmStateValueCall {
+func (c *MockContextGetCharmStateValueCall) Do(f func(context.Context, string) (string, error)) *MockContextGetCharmStateValueCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockContextGetCharmStateValueCall) DoAndReturn(f func(string) (string, error)) *MockContextGetCharmStateValueCall {
+func (c *MockContextGetCharmStateValueCall) DoAndReturn(f func(context.Context, string) (string, error)) *MockContextGetCharmStateValueCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1900,17 +1900,17 @@ func (c *MockContextSetApplicationStatusCall) DoAndReturn(f func(context.Context
 }
 
 // SetCharmStateValue mocks base method.
-func (m *MockContext) SetCharmStateValue(arg0, arg1 string) error {
+func (m *MockContext) SetCharmStateValue(arg0 context.Context, arg1, arg2 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetCharmStateValue", arg0, arg1)
+	ret := m.ctrl.Call(m, "SetCharmStateValue", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetCharmStateValue indicates an expected call of SetCharmStateValue.
-func (mr *MockContextMockRecorder) SetCharmStateValue(arg0, arg1 any) *MockContextSetCharmStateValueCall {
+func (mr *MockContextMockRecorder) SetCharmStateValue(arg0, arg1, arg2 any) *MockContextSetCharmStateValueCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCharmStateValue", reflect.TypeOf((*MockContext)(nil).SetCharmStateValue), arg0, arg1)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCharmStateValue", reflect.TypeOf((*MockContext)(nil).SetCharmStateValue), arg0, arg1, arg2)
 	return &MockContextSetCharmStateValueCall{Call: call}
 }
 
@@ -1926,13 +1926,13 @@ func (c *MockContextSetCharmStateValueCall) Return(arg0 error) *MockContextSetCh
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockContextSetCharmStateValueCall) Do(f func(string, string) error) *MockContextSetCharmStateValueCall {
+func (c *MockContextSetCharmStateValueCall) Do(f func(context.Context, string, string) error) *MockContextSetCharmStateValueCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockContextSetCharmStateValueCall) DoAndReturn(f func(string, string) error) *MockContextSetCharmStateValueCall {
+func (c *MockContextSetCharmStateValueCall) DoAndReturn(f func(context.Context, string, string) error) *MockContextSetCharmStateValueCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/uniter/runner/util_test.go
+++ b/internal/worker/uniter/runner/util_test.go
@@ -115,7 +115,7 @@ func (s *ContextSuite) setupFactory(c *gc.C, ctrl *gomock.Controller) {
 		ModelType: types.IAAS,
 	}, nil).AnyTimes()
 	s.uniter.EXPECT().LeadershipSettings().Return(&stubLeadershipSettingsAccessor{}).AnyTimes()
-	s.uniter.EXPECT().APIAddresses().Return([]string{"10.6.6.6"}, nil).AnyTimes()
+	s.uniter.EXPECT().APIAddresses(gomock.Any()).Return([]string{"10.6.6.6"}, nil).AnyTimes()
 	s.uniter.EXPECT().CloudAPIVersion(gomock.Any()).Return("6.6.6", nil).AnyTimes()
 
 	cfg := coretesting.ModelConfig(c)

--- a/internal/worker/uniter/secrets/interface.go
+++ b/internal/worker/uniter/secrets/interface.go
@@ -32,7 +32,7 @@ type SecretStateTracker interface {
 
 	// SecretsRemoved updates the unit secrets state
 	// when secrets are removed.
-	SecretsRemoved(uris []string) error
+	SecretsRemoved(ctx context.Context, uris []string) error
 
 	// Report provides information for the engine report.
 	Report() map[string]interface{}

--- a/internal/worker/uniter/secrets/mocks/tracker_mock.go
+++ b/internal/worker/uniter/secrets/mocks/tracker_mock.go
@@ -231,17 +231,17 @@ func (c *MockSecretStateTrackerSecretObsoleteRevisionsCall) DoAndReturn(f func(s
 }
 
 // SecretsRemoved mocks base method.
-func (m *MockSecretStateTracker) SecretsRemoved(arg0 []string) error {
+func (m *MockSecretStateTracker) SecretsRemoved(arg0 context.Context, arg1 []string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SecretsRemoved", arg0)
+	ret := m.ctrl.Call(m, "SecretsRemoved", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SecretsRemoved indicates an expected call of SecretsRemoved.
-func (mr *MockSecretStateTrackerMockRecorder) SecretsRemoved(arg0 any) *MockSecretStateTrackerSecretsRemovedCall {
+func (mr *MockSecretStateTrackerMockRecorder) SecretsRemoved(arg0, arg1 any) *MockSecretStateTrackerSecretsRemovedCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SecretsRemoved", reflect.TypeOf((*MockSecretStateTracker)(nil).SecretsRemoved), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SecretsRemoved", reflect.TypeOf((*MockSecretStateTracker)(nil).SecretsRemoved), arg0, arg1)
 	return &MockSecretStateTrackerSecretsRemovedCall{Call: call}
 }
 
@@ -257,13 +257,13 @@ func (c *MockSecretStateTrackerSecretsRemovedCall) Return(arg0 error) *MockSecre
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSecretStateTrackerSecretsRemovedCall) Do(f func([]string) error) *MockSecretStateTrackerSecretsRemovedCall {
+func (c *MockSecretStateTrackerSecretsRemovedCall) Do(f func(context.Context, []string) error) *MockSecretStateTrackerSecretsRemovedCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSecretStateTrackerSecretsRemovedCall) DoAndReturn(f func([]string) error) *MockSecretStateTrackerSecretsRemovedCall {
+func (c *MockSecretStateTrackerSecretsRemovedCall) DoAndReturn(f func(context.Context, []string) error) *MockSecretStateTrackerSecretsRemovedCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/uniter/secrets/resolver_test.go
+++ b/internal/worker/uniter/secrets/resolver_test.go
@@ -504,7 +504,7 @@ func (s *secretDeletedSuite) TestCommit(c *gc.C) {
 	_, err = op.Execute(context.Background(), operation.State{})
 	c.Assert(err, gc.Equals, operation.ErrSkipExecute)
 
-	s.mockCallbacks.EXPECT().SecretsRemoved([]string{"secret:9m4e2mr0ui3e8a215n4g"}).Return(nil)
+	s.mockCallbacks.EXPECT().SecretsRemoved(gomock.Any(), []string{"secret:9m4e2mr0ui3e8a215n4g"}).Return(nil)
 
 	_, err = op.Commit(context.Background(), operation.State{})
 	c.Assert(err, jc.ErrorIsNil)

--- a/internal/worker/uniter/secrets/secrets_test.go
+++ b/internal/worker/uniter/secrets/secrets_test.go
@@ -49,7 +49,7 @@ func (s *secretsSuite) yamlString(c *gc.C, st *secrets.State) string {
 func (s *secretsSuite) TestCommitSecretChanged(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.stateReadWriter.EXPECT().State().Return(params.UnitStateResult{SecretState: s.yamlString(c,
+	s.stateReadWriter.EXPECT().State(gomock.Any()).Return(params.UnitStateResult{SecretState: s.yamlString(c,
 		&secrets.State{
 			ConsumedSecretInfo: map[string]int{
 				"secret:666e2mr0ui3e8a215n4g": 664,
@@ -63,14 +63,14 @@ func (s *secretsSuite) TestCommitSecretChanged(c *gc.C) {
 	)
 	s.secretsClient.EXPECT().SecretMetadata().Return(nil, nil)
 
-	s.stateReadWriter.EXPECT().SetState(params.SetUnitStateArg{SecretState: ptr(s.yamlString(c,
+	s.stateReadWriter.EXPECT().SetState(gomock.Any(), params.SetUnitStateArg{SecretState: ptr(s.yamlString(c,
 		&secrets.State{
 			ConsumedSecretInfo:      map[string]int{"secret:9m4e2mr0ui3e8a215n4g": 667},
 			SecretObsoleteRevisions: map[string][]int{},
 		},
 	))})
 
-	s.stateReadWriter.EXPECT().SetState(params.SetUnitStateArg{SecretState: ptr(s.yamlString(c,
+	s.stateReadWriter.EXPECT().SetState(gomock.Any(), params.SetUnitStateArg{SecretState: ptr(s.yamlString(c,
 		&secrets.State{
 			ConsumedSecretInfo:      map[string]int{"secret:9m4e2mr0ui3e8a215n4g": 666},
 			SecretObsoleteRevisions: map[string][]int{},
@@ -78,7 +78,7 @@ func (s *secretsSuite) TestCommitSecretChanged(c *gc.C) {
 	))})
 
 	tag := names.NewUnitTag("foo/0")
-	tracker, err := secrets.NewSecrets(s.secretsClient, tag, s.stateReadWriter, loggertesting.WrapCheckLog(c))
+	tracker, err := secrets.NewSecrets(context.Background(), s.secretsClient, tag, s.stateReadWriter, loggertesting.WrapCheckLog(c))
 	c.Assert(err, jc.ErrorIsNil)
 
 	info := hook.Info{
@@ -93,7 +93,7 @@ func (s *secretsSuite) TestCommitSecretChanged(c *gc.C) {
 func (s *secretsSuite) TestCommitSecretRemove(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.stateReadWriter.EXPECT().State().Return(params.UnitStateResult{SecretState: s.yamlString(c,
+	s.stateReadWriter.EXPECT().State(gomock.Any()).Return(params.UnitStateResult{SecretState: s.yamlString(c,
 		&secrets.State{
 			SecretObsoleteRevisions: map[string][]int{
 				"secret:666e2mr0ui3e8a215n4g": {664},
@@ -103,7 +103,7 @@ func (s *secretsSuite) TestCommitSecretRemove(c *gc.C) {
 	)}, nil)
 	s.secretsClient.EXPECT().SecretMetadata().Return(
 		[]coresecrets.SecretOwnerMetadata{{Metadata: coresecrets.SecretMetadata{URI: &coresecrets.URI{ID: "9m4e2mr0ui3e8a215n4g"}}}}, nil)
-	s.stateReadWriter.EXPECT().SetState(params.SetUnitStateArg{SecretState: ptr(s.yamlString(c,
+	s.stateReadWriter.EXPECT().SetState(gomock.Any(), params.SetUnitStateArg{SecretState: ptr(s.yamlString(c,
 		&secrets.State{
 			ConsumedSecretInfo: map[string]int{},
 			SecretObsoleteRevisions: map[string][]int{
@@ -111,7 +111,7 @@ func (s *secretsSuite) TestCommitSecretRemove(c *gc.C) {
 		},
 	))})
 
-	s.stateReadWriter.EXPECT().SetState(params.SetUnitStateArg{SecretState: ptr(s.yamlString(c,
+	s.stateReadWriter.EXPECT().SetState(gomock.Any(), params.SetUnitStateArg{SecretState: ptr(s.yamlString(c,
 		&secrets.State{
 			ConsumedSecretInfo: map[string]int{},
 			SecretObsoleteRevisions: map[string][]int{
@@ -120,7 +120,7 @@ func (s *secretsSuite) TestCommitSecretRemove(c *gc.C) {
 	))})
 
 	tag := names.NewUnitTag("foo/0")
-	tracker, err := secrets.NewSecrets(s.secretsClient, tag, s.stateReadWriter, loggertesting.WrapCheckLog(c))
+	tracker, err := secrets.NewSecrets(context.Background(), s.secretsClient, tag, s.stateReadWriter, loggertesting.WrapCheckLog(c))
 	c.Assert(err, jc.ErrorIsNil)
 
 	info := hook.Info{
@@ -135,7 +135,7 @@ func (s *secretsSuite) TestCommitSecretRemove(c *gc.C) {
 func (s *secretsSuite) TestCommitNoOpSecretsRemoved(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.stateReadWriter.EXPECT().State().Return(params.UnitStateResult{SecretState: s.yamlString(c,
+	s.stateReadWriter.EXPECT().State(gomock.Any()).Return(params.UnitStateResult{SecretState: s.yamlString(c,
 		&secrets.State{
 			SecretObsoleteRevisions: map[string][]int{
 				"secret:666e2mr0ui3e8a215n4g": {664},
@@ -159,7 +159,7 @@ func (s *secretsSuite) TestCommitNoOpSecretsRemoved(c *gc.C) {
 			{Metadata: coresecrets.SecretMetadata{URI: &coresecrets.URI{ID: "9m4e2mr0ui3e8a215n4g"}}},
 			{Metadata: coresecrets.SecretMetadata{URI: &coresecrets.URI{ID: "666e2mr0ui3e8a215n4g"}}},
 		}, nil)
-	s.stateReadWriter.EXPECT().SetState(params.SetUnitStateArg{SecretState: ptr(s.yamlString(c,
+	s.stateReadWriter.EXPECT().SetState(gomock.Any(), params.SetUnitStateArg{SecretState: ptr(s.yamlString(c,
 		&secrets.State{
 			ConsumedSecretInfo: map[string]int{
 				"secret:9m4e2mr0ui3e8a215n4g": 667,
@@ -170,9 +170,9 @@ func (s *secretsSuite) TestCommitNoOpSecretsRemoved(c *gc.C) {
 	))})
 
 	tag := names.NewUnitTag("foo/0")
-	tracker, err := secrets.NewSecrets(s.secretsClient, tag, s.stateReadWriter, loggertesting.WrapCheckLog(c))
+	tracker, err := secrets.NewSecrets(context.Background(), s.secretsClient, tag, s.stateReadWriter, loggertesting.WrapCheckLog(c))
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = tracker.SecretsRemoved([]string{"secret:666e2mr0ui3e8a215n4g"})
+	err = tracker.SecretsRemoved(context.Background(), []string{"secret:666e2mr0ui3e8a215n4g"})
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/internal/worker/uniter/secrets/state.go
+++ b/internal/worker/uniter/secrets/state.go
@@ -4,6 +4,8 @@
 package secrets
 
 import (
+	"context"
+
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 	"gopkg.in/yaml.v2"
@@ -73,8 +75,8 @@ type stateOps struct {
 // UnitStateReadWriter encapsulates the methods from a state.Unit
 // required to set and get unit state.
 type UnitStateReadWriter interface {
-	State() (params.UnitStateResult, error)
-	SetState(unitState params.SetUnitStateArg) error
+	State(context.Context) (params.UnitStateResult, error)
+	SetState(ctx context.Context, unitState params.SetUnitStateArg) error
 }
 
 // NewStateOps returns a new StateOps.
@@ -84,9 +86,9 @@ func NewStateOps(rw UnitStateReadWriter) *stateOps {
 
 // Read reads secrets state from the controller. If the saved State
 // does not exist it returns NotFound and a new state.
-func (f *stateOps) Read() (*State, error) {
+func (f *stateOps) Read(ctx context.Context) (*State, error) {
 	var st State
-	unitState, err := f.unitStateRW.State()
+	unitState, err := f.unitStateRW.State(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -100,7 +102,7 @@ func (f *stateOps) Read() (*State, error) {
 }
 
 // Write stores the supplied secrets state to the controller.
-func (f *stateOps) Write(st *State) error {
+func (f *stateOps) Write(ctx context.Context, st *State) error {
 	if st == nil {
 		return errors.Trace(errors.BadRequestf("arg is nil"))
 	}
@@ -110,5 +112,5 @@ func (f *stateOps) Write(st *State) error {
 		return errors.Trace(err)
 	}
 	str = string(data)
-	return f.unitStateRW.SetState(params.SetUnitStateArg{SecretState: &str})
+	return f.unitStateRW.SetState(ctx, params.SetUnitStateArg{SecretState: &str})
 }

--- a/internal/worker/uniter/storage/attachments_test.go
+++ b/internal/worker/uniter/storage/attachments_test.go
@@ -75,7 +75,7 @@ func (s *attachmentsSuite) TestNewAttachments(c *gc.C) {
 		},
 	}
 
-	_, err := storage.NewAttachments(st, unitTag, s.mockStateOps, abort)
+	_, err := storage.NewAttachments(context.Background(), st, unitTag, s.mockStateOps, abort)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -108,7 +108,7 @@ func (s *attachmentsSuite) assertNewAttachments(c *gc.C, storageTag names.Storag
 		},
 	}
 
-	att, err := storage.NewAttachments(storSt, unitTag, s.mockStateOps, abort)
+	att, err := storage.NewAttachments(context.Background(), storSt, unitTag, s.mockStateOps, abort)
 	c.Assert(err, jc.ErrorIsNil)
 	return att
 }
@@ -161,7 +161,7 @@ func (s *attachmentsSuite) TestAttachmentsUpdateShortCircuitDeath(c *gc.C) {
 		},
 	}
 
-	att, err := storage.NewAttachments(st, unitTag, s.mockStateOps, abort)
+	att, err := storage.NewAttachments(context.Background(), st, unitTag, s.mockStateOps, abort)
 	c.Assert(err, jc.ErrorIsNil)
 	r := storage.NewResolver(loggertesting.WrapCheckLog(c), att, s.modelType)
 
@@ -226,7 +226,7 @@ func (s *attachmentsSuite) testAttachmentsStorage(c *gc.C, opState operation.Sta
 		},
 	}
 
-	att, err := storage.NewAttachments(st, unitTag, s.mockStateOps, abort)
+	att, err := storage.NewAttachments(context.Background(), st, unitTag, s.mockStateOps, abort)
 	c.Assert(err, jc.ErrorIsNil)
 	r := storage.NewResolver(loggertesting.WrapCheckLog(c), att, s.modelType)
 
@@ -261,7 +261,7 @@ func (s *caasAttachmentsSuite) TestAttachmentsStorageNotStarted(c *gc.C) {
 		},
 	}
 
-	att, err := storage.NewAttachments(st, unitTag, s.mockStateOps, abort)
+	att, err := storage.NewAttachments(context.Background(), st, unitTag, s.mockStateOps, abort)
 	c.Assert(err, jc.ErrorIsNil)
 	r := storage.NewResolver(loggertesting.WrapCheckLog(c), att, s.modelType)
 
@@ -307,7 +307,7 @@ func (s *attachmentsSuite) TestAttachmentsCommitHook(c *gc.C) {
 		},
 	}
 
-	att, err := storage.NewAttachments(st, unitTag, s.mockStateOps, abort)
+	att, err := storage.NewAttachments(context.Background(), st, unitTag, s.mockStateOps, abort)
 	c.Assert(err, jc.ErrorIsNil)
 	r := storage.NewResolver(loggertesting.WrapCheckLog(c), att, s.modelType)
 
@@ -331,7 +331,7 @@ func (s *attachmentsSuite) TestAttachmentsCommitHook(c *gc.C) {
 
 	s.storSt.Attach(storageTag.Id())
 	s.expectSetState(c, "")
-	err = att.CommitHook(hook.Info{
+	err = att.CommitHook(context.Background(), hook.Info{
 		Kind:      hooks.StorageAttached,
 		StorageId: storageTag.Id(),
 	})
@@ -341,7 +341,7 @@ func (s *attachmentsSuite) TestAttachmentsCommitHook(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.expectSetState(c, "")
 	c.Assert(removed, jc.IsFalse)
-	err = att.CommitHook(hook.Info{
+	err = att.CommitHook(context.Background(), hook.Info{
 		Kind:      hooks.StorageDetaching,
 		StorageId: storageTag.Id(),
 	})
@@ -387,7 +387,7 @@ func (s *attachmentsSuite) TestAttachmentsSetDying(c *gc.C) {
 		},
 	}
 
-	att, err := storage.NewAttachments(st, unitTag, s.mockStateOps, abort)
+	att, err := storage.NewAttachments(context.Background(), st, unitTag, s.mockStateOps, abort)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(att.Pending(), gc.Equals, 1)
 	r := storage.NewResolver(loggertesting.WrapCheckLog(c), att, s.modelType)
@@ -428,7 +428,7 @@ func (s *attachmentsSuite) TestAttachmentsWaitPending(c *gc.C) {
 		},
 	}
 
-	att, err := storage.NewAttachments(st, unitTag, s.mockStateOps, abort)
+	att, err := storage.NewAttachments(context.Background(), st, unitTag, s.mockStateOps, abort)
 	c.Assert(err, jc.ErrorIsNil)
 	r := storage.NewResolver(loggertesting.WrapCheckLog(c), att, s.modelType)
 

--- a/internal/worker/uniter/storage/mockstateopssuite_test.go
+++ b/internal/worker/uniter/storage/mockstateopssuite_test.go
@@ -38,13 +38,13 @@ func (s *mockStateOpsSuite) expectSetState(c *gc.C, errStr string) {
 	}
 
 	mExp := s.mockStateOps.EXPECT()
-	mExp.SetState(unitStateMatcher{c: c, expected: strStorageState}).Return(err)
+	mExp.SetState(gomock.Any(), unitStateMatcher{c: c, expected: strStorageState}).Return(err)
 }
 
 func (s *mockStateOpsSuite) expectSetStateEmpty(c *gc.C) {
 	var strStorageState string
 	mExp := s.mockStateOps.EXPECT()
-	mExp.SetState(unitStateMatcher{c: c, expected: strStorageState}).Return(nil)
+	mExp.SetState(gomock.Any(), unitStateMatcher{c: c, expected: strStorageState}).Return(nil)
 }
 
 func (s *mockStateOpsSuite) expectState(c *check.C) {
@@ -53,12 +53,12 @@ func (s *mockStateOpsSuite) expectState(c *check.C) {
 	strStorageState := string(data)
 
 	mExp := s.mockStateOps.EXPECT()
-	mExp.State().Return(params.UnitStateResult{StorageState: strStorageState}, nil)
+	mExp.State(gomock.Any()).Return(params.UnitStateResult{StorageState: strStorageState}, nil)
 }
 
 func (s *mockStateOpsSuite) expectStateNotFound() {
 	mExp := s.mockStateOps.EXPECT()
-	mExp.State().Return(params.UnitStateResult{StorageState: ""}, nil)
+	mExp.State(gomock.Any()).Return(params.UnitStateResult{StorageState: ""}, nil)
 }
 
 type unitStateMatcher struct {

--- a/internal/worker/uniter/storage/state.go
+++ b/internal/worker/uniter/storage/state.go
@@ -4,6 +4,8 @@
 package storage
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"gopkg.in/yaml.v2"
 
@@ -74,8 +76,8 @@ type stateOps struct {
 // UnitStateReadWriter encapsulates the methods from a state.Unit
 // required to set and get unit state.
 type UnitStateReadWriter interface {
-	State() (params.UnitStateResult, error)
-	SetState(unitState params.SetUnitStateArg) error
+	State(context.Context) (params.UnitStateResult, error)
+	SetState(ctx context.Context, unitState params.SetUnitStateArg) error
 }
 
 // NewStateOps returns a new StateOps.
@@ -85,9 +87,9 @@ func NewStateOps(rw UnitStateReadWriter) *stateOps {
 
 // Read reads a storage State from the controller. If the saved State
 // does not exist it returns NotFound and a new state.
-func (f *stateOps) Read() (*State, error) {
+func (f *stateOps) Read(ctx context.Context) (*State, error) {
 	var stor map[string]bool
-	unitState, err := f.unitStateRW.State()
+	unitState, err := f.unitStateRW.State(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -102,7 +104,7 @@ func (f *stateOps) Read() (*State, error) {
 
 // Write stores the supplied State storage map on the controller.  If
 // the storage map is empty, all data will be removed.
-func (f *stateOps) Write(st *State) error {
+func (f *stateOps) Write(ctx context.Context, st *State) error {
 	if st == nil {
 		return errors.Trace(errors.BadRequestf("arg is nil"))
 	}
@@ -114,5 +116,5 @@ func (f *stateOps) Write(st *State) error {
 		}
 		str = string(data)
 	}
-	return f.unitStateRW.SetState(params.SetUnitStateArg{StorageState: &str})
+	return f.unitStateRW.SetState(ctx, params.SetUnitStateArg{StorageState: &str})
 }

--- a/internal/worker/uniter/storage/state_test.go
+++ b/internal/worker/uniter/storage/state_test.go
@@ -4,6 +4,8 @@
 package storage_test
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 	jc "github.com/juju/testing/checkers"
@@ -126,7 +128,7 @@ func (s *stateOpsSuite) TestRead(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	s.expectState(c)
 	ops := storage.NewStateOps(s.mockStateOps)
-	obtainedSt, err := ops.Read()
+	obtainedSt, err := ops.Read(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(storage.Storage(obtainedSt), gc.DeepEquals, storage.Storage(s.storSt))
 }
@@ -135,7 +137,7 @@ func (s *stateOpsSuite) TestReadNotFound(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	s.expectStateNotFound()
 	ops := storage.NewStateOps(s.mockStateOps)
-	obtainedSt, err := ops.Read()
+	obtainedSt, err := ops.Read(context.Background())
 	c.Assert(err, jc.ErrorIs, errors.NotFound)
 	c.Assert(obtainedSt, gc.NotNil)
 }
@@ -144,7 +146,7 @@ func (s *stateOpsSuite) TestWrite(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	s.expectSetState(c, "")
 	ops := storage.NewStateOps(s.mockStateOps)
-	err := ops.Write(s.storSt)
+	err := ops.Write(context.Background(), s.storSt)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -152,13 +154,13 @@ func (s *stateOpsSuite) TestWriteEmpty(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	s.expectSetStateEmpty(c)
 	ops := storage.NewStateOps(s.mockStateOps)
-	err := ops.Write(storage.NewState())
+	err := ops.Write(context.Background(), storage.NewState())
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *stateOpsSuite) TestWriteNilState(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	ops := storage.NewStateOps(s.mockStateOps)
-	err := ops.Write(nil)
+	err := ops.Write(context.Background(), nil)
 	c.Assert(err, jc.ErrorIs, errors.BadRequest)
 }

--- a/internal/worker/uniter/uniter_test.go
+++ b/internal/worker/uniter/uniter_test.go
@@ -1521,8 +1521,8 @@ func (s *UniterSuite) TestTranslateResolverError(c *gc.C) {
 }
 
 func executorFunc(c *gc.C) uniter.NewOperationExecutorFunc {
-	return func(unitName string, cfg operation.ExecutorConfig) (operation.Executor, error) {
-		e, err := operation.NewExecutor(unitName, cfg)
+	return func(ctx context.Context, unitName string, cfg operation.ExecutorConfig) (operation.Executor, error) {
+		e, err := operation.NewExecutor(ctx, unitName, cfg)
 		c.Assert(err, jc.ErrorIsNil)
 		return &mockExecutor{e}, nil
 	}

--- a/internal/worker/uniter/util_test.go
+++ b/internal/worker/uniter/util_test.go
@@ -256,7 +256,7 @@ func (ctx *testContext) sendRelationUnitChange(c *gc.C, msg string, ruc watcher.
 
 func (ctx *testContext) expectHookContext(c *gc.C) {
 	ctx.payloads.EXPECT().List().Return(nil, nil).AnyTimes()
-	ctx.api.EXPECT().APIAddresses().Return([]string{"10.6.6.6"}, nil).AnyTimes()
+	ctx.api.EXPECT().APIAddresses(gomock.Any()).Return([]string{"10.6.6.6"}, nil).AnyTimes()
 	ctx.api.EXPECT().CloudAPIVersion(gomock.Any()).Return("6.6.6", nil).AnyTimes()
 
 	cfg := coretesting.ModelConfig(c)

--- a/internal/worker/upgradeseries/mocks/package_mock.go
+++ b/internal/worker/upgradeseries/mocks/package_mock.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	base "github.com/juju/juju/core/base"
@@ -120,18 +121,18 @@ func (c *MockFacadeMachineStatusCall) DoAndReturn(f func() (model.UpgradeSeriesS
 }
 
 // PinMachineApplications mocks base method.
-func (m *MockFacade) PinMachineApplications() (map[string]error, error) {
+func (m *MockFacade) PinMachineApplications(arg0 context.Context) (map[string]error, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PinMachineApplications")
+	ret := m.ctrl.Call(m, "PinMachineApplications", arg0)
 	ret0, _ := ret[0].(map[string]error)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // PinMachineApplications indicates an expected call of PinMachineApplications.
-func (mr *MockFacadeMockRecorder) PinMachineApplications() *MockFacadePinMachineApplicationsCall {
+func (mr *MockFacadeMockRecorder) PinMachineApplications(arg0 any) *MockFacadePinMachineApplicationsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PinMachineApplications", reflect.TypeOf((*MockFacade)(nil).PinMachineApplications))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PinMachineApplications", reflect.TypeOf((*MockFacade)(nil).PinMachineApplications), arg0)
 	return &MockFacadePinMachineApplicationsCall{Call: call}
 }
 
@@ -147,13 +148,13 @@ func (c *MockFacadePinMachineApplicationsCall) Return(arg0 map[string]error, arg
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockFacadePinMachineApplicationsCall) Do(f func() (map[string]error, error)) *MockFacadePinMachineApplicationsCall {
+func (c *MockFacadePinMachineApplicationsCall) Do(f func(context.Context) (map[string]error, error)) *MockFacadePinMachineApplicationsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockFacadePinMachineApplicationsCall) DoAndReturn(f func() (map[string]error, error)) *MockFacadePinMachineApplicationsCall {
+func (c *MockFacadePinMachineApplicationsCall) DoAndReturn(f func(context.Context) (map[string]error, error)) *MockFacadePinMachineApplicationsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -351,18 +352,18 @@ func (c *MockFacadeUnitsPreparedCall) DoAndReturn(f func() ([]names.UnitTag, err
 }
 
 // UnpinMachineApplications mocks base method.
-func (m *MockFacade) UnpinMachineApplications() (map[string]error, error) {
+func (m *MockFacade) UnpinMachineApplications(arg0 context.Context) (map[string]error, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UnpinMachineApplications")
+	ret := m.ctrl.Call(m, "UnpinMachineApplications", arg0)
 	ret0, _ := ret[0].(map[string]error)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // UnpinMachineApplications indicates an expected call of UnpinMachineApplications.
-func (mr *MockFacadeMockRecorder) UnpinMachineApplications() *MockFacadeUnpinMachineApplicationsCall {
+func (mr *MockFacadeMockRecorder) UnpinMachineApplications(arg0 any) *MockFacadeUnpinMachineApplicationsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnpinMachineApplications", reflect.TypeOf((*MockFacade)(nil).UnpinMachineApplications))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnpinMachineApplications", reflect.TypeOf((*MockFacade)(nil).UnpinMachineApplications), arg0)
 	return &MockFacadeUnpinMachineApplicationsCall{Call: call}
 }
 
@@ -378,30 +379,30 @@ func (c *MockFacadeUnpinMachineApplicationsCall) Return(arg0 map[string]error, a
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockFacadeUnpinMachineApplicationsCall) Do(f func() (map[string]error, error)) *MockFacadeUnpinMachineApplicationsCall {
+func (c *MockFacadeUnpinMachineApplicationsCall) Do(f func(context.Context) (map[string]error, error)) *MockFacadeUnpinMachineApplicationsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockFacadeUnpinMachineApplicationsCall) DoAndReturn(f func() (map[string]error, error)) *MockFacadeUnpinMachineApplicationsCall {
+func (c *MockFacadeUnpinMachineApplicationsCall) DoAndReturn(f func(context.Context) (map[string]error, error)) *MockFacadeUnpinMachineApplicationsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // WatchUpgradeSeriesNotifications mocks base method.
-func (m *MockFacade) WatchUpgradeSeriesNotifications() (watcher.Watcher[struct{}], error) {
+func (m *MockFacade) WatchUpgradeSeriesNotifications(arg0 context.Context) (watcher.Watcher[struct{}], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchUpgradeSeriesNotifications")
+	ret := m.ctrl.Call(m, "WatchUpgradeSeriesNotifications", arg0)
 	ret0, _ := ret[0].(watcher.Watcher[struct{}])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // WatchUpgradeSeriesNotifications indicates an expected call of WatchUpgradeSeriesNotifications.
-func (mr *MockFacadeMockRecorder) WatchUpgradeSeriesNotifications() *MockFacadeWatchUpgradeSeriesNotificationsCall {
+func (mr *MockFacadeMockRecorder) WatchUpgradeSeriesNotifications(arg0 any) *MockFacadeWatchUpgradeSeriesNotificationsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchUpgradeSeriesNotifications", reflect.TypeOf((*MockFacade)(nil).WatchUpgradeSeriesNotifications))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchUpgradeSeriesNotifications", reflect.TypeOf((*MockFacade)(nil).WatchUpgradeSeriesNotifications), arg0)
 	return &MockFacadeWatchUpgradeSeriesNotificationsCall{Call: call}
 }
 
@@ -417,13 +418,13 @@ func (c *MockFacadeWatchUpgradeSeriesNotificationsCall) Return(arg0 watcher.Watc
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockFacadeWatchUpgradeSeriesNotificationsCall) Do(f func() (watcher.Watcher[struct{}], error)) *MockFacadeWatchUpgradeSeriesNotificationsCall {
+func (c *MockFacadeWatchUpgradeSeriesNotificationsCall) Do(f func(context.Context) (watcher.Watcher[struct{}], error)) *MockFacadeWatchUpgradeSeriesNotificationsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockFacadeWatchUpgradeSeriesNotificationsCall) DoAndReturn(f func() (watcher.Watcher[struct{}], error)) *MockFacadeWatchUpgradeSeriesNotificationsCall {
+func (c *MockFacadeWatchUpgradeSeriesNotificationsCall) DoAndReturn(f func(context.Context) (watcher.Watcher[struct{}], error)) *MockFacadeWatchUpgradeSeriesNotificationsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/upgradeseries/shim.go
+++ b/internal/worker/upgradeseries/shim.go
@@ -4,6 +4,8 @@
 package upgradeseries
 
 import (
+	"context"
+
 	"github.com/juju/names/v5"
 
 	"github.com/juju/juju/api/agent/upgradeseries"
@@ -16,7 +18,7 @@ import (
 // Facade exposes the API surface required by the upgrade-series worker.
 type Facade interface {
 	// Getters
-	WatchUpgradeSeriesNotifications() (watcher.NotifyWatcher, error)
+	WatchUpgradeSeriesNotifications(context.Context) (watcher.NotifyWatcher, error)
 	MachineStatus() (model.UpgradeSeriesStatus, error)
 	UnitsPrepared() ([]names.UnitTag, error)
 	UnitsCompleted() ([]names.UnitTag, error)
@@ -25,8 +27,8 @@ type Facade interface {
 	StartUnitCompletion(reason string) error
 	SetMachineStatus(status model.UpgradeSeriesStatus, reason string) error
 	FinishUpgradeSeries(corebase.Base) error
-	PinMachineApplications() (map[string]error, error)
-	UnpinMachineApplications() (map[string]error, error)
+	PinMachineApplications(context.Context) (map[string]error, error)
+	UnpinMachineApplications(context.Context) (map[string]error, error)
 	SetInstanceStatus(model.UpgradeSeriesStatus, string) error
 }
 

--- a/internal/worker/upgradeseries/worker_test.go
+++ b/internal/worker/upgradeseries/worker_test.go
@@ -294,7 +294,7 @@ func (s *workerSuite) expectMachineCompletedFinishUpgradeSeries() {
 	exp.FinishUpgradeSeries(b).Return(nil)
 
 	s.expectSetInstanceStatus(model.UpgradeSeriesCompleted, "success")
-	exp.UnpinMachineApplications().Return(map[string]error{
+	exp.UnpinMachineApplications(gomock.Any()).Return(map[string]error{
 		"mysql":     nil,
 		"wordpress": nil,
 	}, nil)
@@ -343,7 +343,7 @@ func (s *workerSuite) expectUnitsPrepared(units ...string) {
 // often be in the Test... method instead of its partner expectation
 // method.
 func (s *workerSuite) expectPinLeadership() {
-	s.facade.EXPECT().PinMachineApplications().Return(map[string]error{
+	s.facade.EXPECT().PinMachineApplications(gomock.Any()).Return(map[string]error{
 		"mysql":     nil,
 		"wordpress": nil,
 	}, nil)
@@ -384,7 +384,7 @@ func (s *workerSuite) notify(times int) {
 	s.notifyWorker.EXPECT().Kill().AnyTimes()
 	s.notifyWorker.EXPECT().Wait().Return(nil).AnyTimes()
 
-	s.facade.EXPECT().WatchUpgradeSeriesNotifications().Return(
+	s.facade.EXPECT().WatchUpgradeSeriesNotifications(gomock.Any()).Return(
 		&fakeWatcher{
 			Worker: s.notifyWorker,
 			ch:     ch,


### PR DESCRIPTION
Adds context.Context to the first argument of the api/common type methods. This is the ongoing process of removing context.TODO from the api packages. There are a lot of these to do, so I'm working them through piecemeal.

The rationale for this is to allow tracing from the api clients to the apiserver. Thus we'll be able to trace all the calls to and from the agents. This with parca should give us insights to Juju when running in production.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
$ juju bootstrap lxd test
$ juju add-model default
$ juju deploy ubuntu
```


