### PR TITLE
Move storageprovisioner facade to use model config/info services

### DIFF
--- a/apiserver/facades/agent/storageprovisioner/register.go
+++ b/apiserver/facades/agent/storageprovisioner/register.go
@@ -39,6 +39,12 @@ func newFacadeV4(stdCtx context.Context, ctx facade.ModelContext) (*StorageProvi
 		return nil, errors.Trace(err)
 	}
 
+	// Get model UUID
+	modelInfo, err := serviceFactory.ModelInfo().GetModelInfo(stdCtx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	backend, storageBackend, err := NewStateBackends(st)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -50,10 +56,12 @@ func newFacadeV4(stdCtx context.Context, ctx facade.ModelContext) (*StorageProvi
 		storageBackend,
 		serviceFactory.BlockDevice(),
 		serviceFactory.ControllerConfig(),
+		serviceFactory.Config(),
 		ctx.Resources(),
 		ctx.Auth(),
 		registry,
 		serviceFactory.Storage(registry),
 		ctx.Logger().Child("storageprovisioner"),
+		modelInfo.UUID,
 	)
 }

--- a/apiserver/facades/agent/storageprovisioner/service.go
+++ b/apiserver/facades/agent/storageprovisioner/service.go
@@ -1,0 +1,42 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package storageprovisioner
+
+import (
+	"context"
+
+	"github.com/juju/juju/controller"
+	"github.com/juju/juju/core/blockdevice"
+	"github.com/juju/juju/core/watcher"
+	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/internal/storage"
+)
+
+// ControllerConfigService provides access to the controller configuration.
+type ControllerConfigService interface {
+	// ControllerConfig returns the config values for the controller.
+	ControllerConfig(context.Context) (controller.Config, error)
+}
+
+// ModelConfigService is the interface that the provisioner facade uses to get
+// the model config.
+type ModelConfigService interface {
+	// ModelConfig returns the current config for the model.
+	ModelConfig(context.Context) (*config.Config, error)
+}
+
+// BlockDeviceService instances can fetch and watch block devices on a machine.
+type BlockDeviceService interface {
+	// BlockDevices returns the block devices for a specified machine.
+	BlockDevices(ctx context.Context, machineId string) ([]blockdevice.BlockDevice, error)
+	// WatchBlockDevices returns a new NotifyWatcher watching for
+	// changes to block devices associated with the specified machine.
+	WatchBlockDevices(ctx context.Context, machineId string) (watcher.NotifyWatcher, error)
+}
+
+// StoragePoolGetter instances get a storage pool by name.
+type StoragePoolGetter interface {
+	// GetStoragePoolByName returns the storage pool with the specified name.
+	GetStoragePoolByName(ctx context.Context, name string) (*storage.Config, error)
+}

--- a/apiserver/facades/agent/storageprovisioner/shim.go
+++ b/apiserver/facades/agent/storageprovisioner/shim.go
@@ -20,10 +20,8 @@ import (
 
 type Backend interface {
 	state.EntityFinder
-	state.ModelAccessor
 
 	MachineInstanceId(names.MachineTag) (instance.Id, error)
-	ModelTag() names.ModelTag
 	WatchMachine(names.MachineTag) (state.NotifyWatcher, error)
 	WatchApplications() state.StringsWatcher
 }

--- a/apiserver/facades/agent/storageprovisioner/storageprovisioner_caas_test.go
+++ b/apiserver/facades/agent/storageprovisioner/storageprovisioner_caas_test.go
@@ -53,6 +53,8 @@ func (s *caasProvisionerSuite) SetUpTest(c *gc.C) {
 	s.AddCleanup(func(_ *gc.C) { s.resources.StopAll() })
 
 	serviceFactory := s.ControllerServiceFactory(c)
+	modelInfo, err := serviceFactory.ModelInfo().GetModelInfo(context.Background())
+	c.Assert(err, jc.ErrorIsNil)
 
 	broker, err := stateenvirons.GetNewCAASBrokerFunc(caas.New)(m, serviceFactory.Cloud(), serviceFactory.Credential())
 	c.Assert(err, jc.ErrorIsNil)
@@ -74,11 +76,13 @@ func (s *caasProvisionerSuite) SetUpTest(c *gc.C) {
 		storageBackend,
 		s.DefaultModelServiceFactory(c).BlockDevice(),
 		s.ControllerServiceFactory(c).ControllerConfig(),
+		s.ControllerServiceFactory(c).Config(),
 		s.resources,
 		s.authorizer,
 		registry,
 		storageService,
 		loggertesting.WrapCheckLog(c),
+		modelInfo.UUID,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 }
@@ -179,9 +183,11 @@ func (s *caasProvisionerSuite) TestWatchFilesystemAttachments(c *gc.C) {
 	s.setupFilesystems(c)
 	c.Assert(s.resources.Count(), gc.Equals, 0)
 
+	modelInfo, err := s.ControllerServiceFactory(c).ModelInfo().GetModelInfo(context.Background())
+	c.Assert(err, jc.ErrorIsNil)
 	args := params.Entities{Entities: []params.Entity{
 		{Tag: "application-mariadb"},
-		{Tag: names.NewModelTag(s.st.ModelUUID()).String()},
+		{Tag: names.NewModelTag(modelInfo.UUID.String()).String()},
 		{Tag: "environ-adb650da-b77b-4ee8-9cbb-d57a9a592847"},
 		{Tag: "unit-mysql-0"}},
 	}

--- a/apiserver/facades/agent/storageprovisioner/storageprovisioner_test.go
+++ b/apiserver/facades/agent/storageprovisioner/storageprovisioner_test.go
@@ -40,6 +40,9 @@ func (s *provisionerSuite) TestNewStorageProvisionerAPINonMachine(c *gc.C) {
 	authorizer := &apiservertesting.FakeAuthorizer{Tag: tag}
 	backend, storageBackend, err := storageprovisioner.NewStateBackends(s.st)
 	c.Assert(err, jc.ErrorIsNil)
+
+	modelInfo, err := s.ControllerServiceFactory(c).ModelInfo().GetModelInfo(context.Background())
+	c.Assert(err, jc.ErrorIsNil)
 	_, err = storageprovisioner.NewStorageProvisionerAPIv4(
 		context.Background(),
 		nil,
@@ -47,10 +50,12 @@ func (s *provisionerSuite) TestNewStorageProvisionerAPINonMachine(c *gc.C) {
 		storageBackend,
 		s.DefaultModelServiceFactory(c).BlockDevice(),
 		s.ControllerServiceFactory(c).ControllerConfig(),
+		s.ControllerServiceFactory(c).Config(),
 		common.NewResources(),
 		authorizer,
 		nil, nil,
 		loggertesting.WrapCheckLog(c),
+		modelInfo.UUID,
 	)
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 }

--- a/tests/suites/storage/charm_storage.sh
+++ b/tests/suites/storage/charm_storage.sh
@@ -8,6 +8,12 @@ run_charm_storage() {
 
 	ensure "${model_name}" "${file}"
 
+	echo "Assessing default storage pools"
+	juju list-storage-pools -m "${model_name}" --format json | jq '.loop | .provider' | check "loop"
+	juju list-storage-pools -m "${model_name}" --format json | jq '.rootfs | .provider' | check "rootfs"
+	juju list-storage-pools -m "${model_name}" --format json | jq '.tmpfs | .provider' | check "tmpfs"
+	echo "Default storage pools PASSED"
+
 	echo "Assess create-storage-pool"
 	juju create-storage-pool -m "${model_name}" loopy loop size=1G
 	juju create-storage-pool -m "${model_name}" rooty rootfs size=1G
@@ -17,18 +23,10 @@ run_charm_storage() {
 
 	# Assess the above created storage pools.
 	echo "Assessing storage pool"
-	if [ "${BOOTSTRAP_PROVIDER:-}" == "ec2" ]; then
-		juju list-storage-pools -m "${model_name}" --format json | jq '.ebs | .provider' | check "ebs"
-		juju list-storage-pools -m "${model_name}" --format json | jq '.["ebs-ssd"] | .provider' | check "ebs"
-		juju list-storage-pools -m "${model_name}" --format json | jq '.tmpfs | .provider' | check "tmpfs"
-		juju list-storage-pools -m "${model_name}" --format json | jq '.loop | .provider' | check "loop"
-		juju list-storage-pools -m "${model_name}" --format json | jq '.rootfs | .provider' | check "rootfs"
-	else
-		juju list-storage-pools -m "${model_name}" --format json | jq '.rooty | .provider' | check "rootfs"
-		juju list-storage-pools -m "${model_name}" --format json | jq '.tempy | .provider' | check "tmpfs"
-		juju list-storage-pools -m "${model_name}" --format json | jq '.loopy | .provider' | check "loop"
-		juju list-storage-pools -m "${model_name}" --format json | jq '.ebsy | .provider' | check "ebs"
-	fi
+	juju list-storage-pools -m "${model_name}" --format json | jq '.rooty | .provider' | check "rootfs"
+	juju list-storage-pools -m "${model_name}" --format json | jq '.tempy | .provider' | check "tmpfs"
+	juju list-storage-pools -m "${model_name}" --format json | jq '.loopy | .provider' | check "loop"
+	juju list-storage-pools -m "${model_name}" --format json | jq '.ebsy | .provider' | check "ebs"
 	echo "Storage pool PASSED"
 
 	# Assess charm storage with the filesystem storage provider
@@ -39,7 +37,7 @@ run_charm_storage() {
 		assess_rootfs
 	fi
 	# remove the application
-	juju remove-application dummy-storage-fs
+	juju remove-application --no-prompt dummy-storage-fs
 	wait_for "{}" ".applications"
 
 	# Assess charm storage with the filesystem storage provider
@@ -58,7 +56,7 @@ run_charm_storage() {
 		assess_loop_disk2
 	fi
 	# remove the application
-	juju remove-application dummy-storage-lp
+	juju remove-application --no-prompt dummy-storage-lp
 	wait_for "{}" ".applications"
 
 	# Assess tmpfs pool for the filesystem provider
@@ -69,7 +67,7 @@ run_charm_storage() {
 		assess_tmpfs
 	fi
 	# remove the application
-	juju remove-application dummy-storage-tp
+	juju remove-application --no-prompt dummy-storage-tp
 	wait_for "{}" ".applications"
 
 	#Assessing for persistent filesystem
@@ -79,7 +77,7 @@ run_charm_storage() {
 		assess_fs
 	fi
 	# remove application
-	juju remove-application dummy-storage-np
+	juju remove-application --no-prompt dummy-storage-np
 	wait_for "{}" ".applications"
 	# We remove storage data/4 since in Juju 2.3+ it is persistent. Otherwise it will interfere with the next test's results
 	juju remove-storage data/4
@@ -91,7 +89,7 @@ run_charm_storage() {
 		assess_multiple_fs
 	fi
 	# remove application
-	juju remove-application dummy-storage-mp
+	juju remove-application --no-prompt dummy-storage-mp
 	wait_for "{}" ".applications"
 	echo "All charm storage tests PASSED"
 

--- a/tests/suites/storage/persistent_storage.sh
+++ b/tests/suites/storage/persistent_storage.sh
@@ -66,7 +66,8 @@ run_persistent_storage() {
 	echo "Check properties of single filesystem storage unit: PASSED."
 
 	# assert charm removal message for single block and filesystem storage
-	removal_msg=$(juju remove-application dummy-storage 2>&1)
+	echo "Remove application, check that storage is also removed"
+	removal_msg=$(juju remove-application --no-prompt dummy-storage 2>&1)
 	echo "${removal_msg}" | sed -sn 3p | sed 's/^-//' | check "will remove storage single-fs/1"
 	echo "${removal_msg}" | sed -sn 4p | sed 's/^-//' | check "will detach storage single-blk/0"
 	#
@@ -77,6 +78,7 @@ run_persistent_storage() {
 	wait_for "{}" ".applications" # we use this wait_for command as an indicator that the application
 	# status has changed and now we can check for the storage status and assert that indeed the
 	# single filesystem storage unit has been removed successfully.
+	sleep 5 # avoid races, sometimes the storage disappears just after the app
 	assert_storage false '.storage | has("single-fs/1")'
 
 	echo "Checking total number of storage unit(s)."
@@ -110,7 +112,7 @@ run_persistent_storage() {
 	assert_storage "attached" '.volumes | ."0" | .status | .current'
 
 	# remove charm
-	juju remove-application dummy-storage
+	juju remove-application --no-prompt dummy-storage
 	# wait for application to be removed
 	wait_for "{}" ".applications"
 	# persistent storage should remain after remove-application


### PR DESCRIPTION
<!-- Why this change is needed and what it does. -->

This PR moves the storageprovisioner facade over to using the model config service.

I removed the `state.ModelAccessor` methods from the `Backend` interface, and replaced them with a new `ModelConfigService` interface. The correct services are passed in from the service factory upon initialisation of the facade. I added a new `service.go` file and moved existing services there as well.

I modified the existing tests `TestVolumeParams` and `TestFilesystemParams` so that they set and check for custom resource tags in model config.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

<!-- Describe steps to verify that the change works. -->

The only facade methods modified are `VolumeParams` and `FilesystemParams`. They access model config to read the `resource-tags` key. So we just need to check that the resource tags are being set correctly.

<details>
<summary>Test VolumeParams</summary>

Volume params can be tested e.g. by provisioning EBS storage on AWS.

```bash
# Add your credential so you can bootstrap on AWS
juju add-credential aws -f ~/my/aws/juju-cred.yaml

juju bootstrap aws aws
juju add-model m

# Set resource tags
juju model-config resource-tags="origin=v2 owner=Canonical"
juju deploy ./testcharms/charms/dummy-storage --storage single-blk=ebs
```

Go to the AWS dashboard > EC2 > Elastic Block Store > Volumes, find the new volume and check that the tags have been added correctly.

---
</details>

<details>
<summary>Test FilesystemParams</summary>

Filesystem params can be tested by provisioning a filesystem in LXD.

```bash
juju bootstrap lxd lxd
juju add-model m
# Set resource tags
juju model-config resource-tags="origin=v2 owner=Canonical"
# Deploy an application with storage
juju deploy postgresql --storage pgdata=lxd,8G
```

Check in LXD that the resource tags were added correctly to the new volume
```console
$ lxc storage volume show juju juju-86dc6d-filesystem-0
...
config:
  ...
  user.origin: v2
  user.owner: Canonical
...
```

---
</details>

Run the `storage` Bash test suite to check nothing fundamental is broken (must be run on AWS). This suite needed a little TLC but I have also fixed it in this PR.
```
juju add-credential aws -f ~/my/aws/juju-cred.yaml
cd tests
./main.sh -v -p ec2 storage
```

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Jira card:** [JUJU-6099](https://warthogs.atlassian.net/browse/JUJU-6099)

[JUJU-6099]: https://warthogs.atlassian.net/browse/JUJU-6099?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ