### PR TITLE
fix: panic: InsecureKeyProfile cannot be used outside tests

### DIFF
--- a/core/watcher/todo.go
+++ b/core/watcher/todo.go
@@ -1,0 +1,40 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package watcher
+
+// TODO returns a watcher for type T that sends an initial change
+// with the empty value of type T.
+func TODO[T any]() Watcher[T] {
+	var empty T
+	ch := make(chan T, 1)
+	ch <- empty
+	w := &todoWatcher[T]{
+		ch:   ch,
+		done: make(chan struct{}),
+	}
+	return w
+}
+
+type todoWatcher[T any] struct {
+	ch   chan T
+	done chan struct{}
+}
+
+func (w *todoWatcher[T]) Kill() {
+	select {
+	case <-w.done:
+	default:
+		close(w.done)
+		close(w.ch)
+	}
+}
+
+func (w *todoWatcher[T]) Wait() error {
+	<-w.done
+	return nil
+}
+
+func (w *todoWatcher[T]) Changes() <-chan T {
+	return w.ch
+}

--- a/core/watcher/todo_test.go
+++ b/core/watcher/todo_test.go
@@ -1,0 +1,35 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package watcher_test
+
+import (
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/watcher"
+	"github.com/juju/juju/core/watcher/watchertest"
+)
+
+type todoWatcherSuite struct{}
+
+var _ = gc.Suite(&todoWatcherSuite{})
+
+func (s *todoWatcherSuite) TestStringsWatcher(c *gc.C) {
+	sw := watcher.TODO[[]string]()
+	c.Assert(sw, gc.NotNil)
+
+	swC := watchertest.NewStringsWatcherC(c, sw)
+	swC.AssertOneChange()
+	swC.AssertNoChange()
+	swC.AssertKilled()
+}
+
+func (s *todoWatcherSuite) TestNotifyWatcher(c *gc.C) {
+	nw := watcher.TODO[struct{}]()
+	c.Assert(nw, gc.NotNil)
+
+	nwC := watchertest.NewNotifyWatcherC(c, nw)
+	nwC.AssertOneChange()
+	nwC.AssertNoChange()
+	nwC.AssertKilled()
+}

--- a/core/watcher/watchertest/strings.go
+++ b/core/watcher/watchertest/strings.go
@@ -124,6 +124,16 @@ func (c StringsWatcherC) AssertNoChange() {
 // error before a long time has passed; and (2) that Changes remains open but
 // no values are being sent.
 func (c StringsWatcherC) AssertStops() {
+	c.assertStops(false)
+}
+
+// AssertKilled Kills the watcher and asserts that Wait completes without
+// error before a long time has passed.
+func (c StringsWatcherC) AssertKilled() {
+	c.assertStops(true)
+}
+
+func (c StringsWatcherC) assertStops(changesClosed bool) {
 	c.Watcher.Kill()
 	wait := make(chan error)
 	go func() {
@@ -138,7 +148,9 @@ func (c StringsWatcherC) AssertStops() {
 
 	select {
 	case change, ok := <-c.Watcher.Changes():
-		c.Fatalf("watcher sent unexpected change: (%#v, %v)", change, ok)
+		if ok || !changesClosed {
+			c.Fatalf("watcher sent unexpected change: (%#v, %v)", change, ok)
+		}
 	default:
 	}
 }

--- a/domain/secret/service/watcher.go
+++ b/domain/secret/service/watcher.go
@@ -17,7 +17,6 @@ import (
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/core/watcher/eventsource"
-	"github.com/juju/juju/core/watcher/watchertest"
 	"github.com/juju/juju/internal/secrets/provider"
 )
 
@@ -189,16 +188,12 @@ func (s *WatchableService) WatchSecretsRotationChanges(ctx context.Context, owne
 }
 
 func (s *WatchableService) WatchObsoleteUserSecrets(ctx context.Context) (watcher.NotifyWatcher, error) {
-	ch := make(chan struct{}, 1)
-	ch <- struct{}{}
-	return watchertest.NewMockNotifyWatcher(ch), nil
+	return watcher.TODO[struct{}](), nil
 }
 
 // WatchSecretBackendChanged notifies when the model secret backend has changed.
 func (s *WatchableService) WatchSecretBackendChanged(ctx context.Context) (watcher.NotifyWatcher, error) {
-	ch := make(chan struct{}, 1)
-	ch <- struct{}{}
-	return watchertest.NewMockNotifyWatcher(ch), nil
+	return watcher.TODO[struct{}](), nil
 }
 
 // secretWatcher is a watcher that watches for secret changes to a set of strings.

--- a/testing/notest.go
+++ b/testing/notest.go
@@ -1,0 +1,22 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+//go:build notest
+
+package testing
+
+import (
+	_ "unsafe"
+)
+
+// Dear Reader,
+// You have found your way here because you imported github.com/juju/juju/testing
+// into code that found its way into a non-test binary.
+// This is bad. Please don't use test code inside a juju binary.
+
+//go:linkname do_not_import_test_code_into_juju
+func do_not_import_test_code_into_juju()
+
+func init() {
+	do_not_import_test_code_into_juju()
+}


### PR DESCRIPTION
The modeloperator on k8s was panicking due to test code being imported into the domain/secret/service package.

Firstly this adds a linker failure to prevent the testing package from being linked into the juju binaries.

Secondly this adds a TODO watcher, which is useful in replacing the abuse of the watchertest code.

## QA steps

Bootstrap k8s. Check the controller namespace has the modeloperator and it is healthy.
```
$ kubectl get pods -n controller-minikube
NAME                             READY   STATUS    RESTARTS   AGE
controller-0                     3/3     Running   0          7m41s
modeloperator-7fdff49f69-mcmc6   1/1     Running   0          7m15s
```

## Documentation changes

N/A

## Links

**Jira card:** JUJU-