### PR TITLE
chore: merge 3.4 into 3.5

### DIFF
--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -451,17 +451,11 @@ func initBootstrapMachine(st *state.State, args InitializeStateParams) (bootstra
 		return nil, errors.Trace(err)
 	}
 
-	spaceAddrs, err := args.BootstrapMachineAddresses.ToSpaceAddresses(st)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
 	base, err := corebase.GetBaseFromSeries(hostSeries)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	m, err := st.AddOneMachine(state.MachineTemplate{
-		Addresses:               spaceAddrs,
 		Base:                    state.Base{OS: base.OS, Channel: base.Channel.String()},
 		Nonce:                   agent.BootstrapNonce,
 		Constraints:             args.BootstrapMachineConstraints,

--- a/agent/agentbootstrap/bootstrap_test.go
+++ b/agent/agentbootstrap/bootstrap_test.go
@@ -198,8 +198,8 @@ func (s *bootstrapSuite) TestInitializeState(c *gc.C) {
 	// Check that the model has been set up.
 	model, err := st.Model()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(model.UUID(), gc.Equals, modelCfg.UUID())
-	c.Assert(model.EnvironVersion(), gc.Equals, 666)
+	c.Check(model.UUID(), gc.Equals, modelCfg.UUID())
+	c.Check(model.EnvironVersion(), gc.Equals, 666)
 
 	// Check that initial admin user has been set up correctly.
 	modelTag := model.Tag().(names.ModelTag)
@@ -207,12 +207,12 @@ func (s *bootstrapSuite) TestInitializeState(c *gc.C) {
 	s.assertCanLogInAsAdmin(c, modelTag, controllerTag, testing.DefaultMongoPassword)
 	user, err := st.User(model.Owner())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(user.PasswordValid(testing.DefaultMongoPassword), jc.IsTrue)
+	c.Check(user.PasswordValid(testing.DefaultMongoPassword), jc.IsTrue)
 
 	// Check controller config
 	controllerCfg, err = st.ControllerConfig()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(controllerCfg, jc.DeepEquals, controller.Config{
+	c.Check(controllerCfg, jc.DeepEquals, controller.Config{
 		"controller-uuid":           testing.ControllerTag.Id(),
 		"ca-cert":                   testing.CACert,
 		"state-port":                1234,
@@ -243,11 +243,11 @@ func (s *bootstrapSuite) TestInitializeState(c *gc.C) {
 	expectedAttrs := expectedCfg.AllAttrs()
 	expectedAttrs["apt-mirror"] = "http://mirror"
 	expectedAttrs["no-proxy"] = "value"
-	c.Assert(newModelCfg.AllAttrs(), jc.DeepEquals, expectedAttrs)
+	c.Check(newModelCfg.AllAttrs(), jc.DeepEquals, expectedAttrs)
 
 	gotModelConstraints, err := st.ModelConstraints()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(gotModelConstraints, gc.DeepEquals, expectModelConstraints)
+	c.Check(gotModelConstraints, gc.DeepEquals, expectModelConstraints)
 
 	// Check that the hosted model has been added, model constraints
 	// set, and its config contains the same authorized-keys as the
@@ -257,47 +257,50 @@ func (s *bootstrapSuite) TestInitializeState(c *gc.C) {
 	defer initialModelSt.Release()
 	gotModelConstraints, err = initialModelSt.ModelConstraints()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(gotModelConstraints, gc.DeepEquals, expectModelConstraints)
+	c.Check(gotModelConstraints, gc.DeepEquals, expectModelConstraints)
+
 	initialModel, err := initialModelSt.Model()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(initialModel.Name(), gc.Equals, "hosted")
-	c.Assert(initialModel.CloudRegion(), gc.Equals, "dummy-region")
-	c.Assert(initialModel.EnvironVersion(), gc.Equals, 123)
+	c.Check(initialModel.Name(), gc.Equals, "hosted")
+	c.Check(initialModel.CloudRegion(), gc.Equals, "dummy-region")
+	c.Check(initialModel.EnvironVersion(), gc.Equals, 123)
+
 	hostedCfg, err := initialModel.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	_, hasUnexpected := hostedCfg.AllAttrs()["not-for-hosted"]
-	c.Assert(hasUnexpected, jc.IsFalse)
-	c.Assert(hostedCfg.AuthorizedKeys(), gc.Equals, newModelCfg.AuthorizedKeys())
+	c.Check(hasUnexpected, jc.IsFalse)
+	c.Check(hostedCfg.AuthorizedKeys(), gc.Equals, newModelCfg.AuthorizedKeys())
 
 	// Check that the bootstrap machine looks correct.
 	m, err := st.Machine("0")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(m.Id(), gc.Equals, "0")
-	c.Assert(m.Jobs(), gc.DeepEquals, []state.MachineJob{state.JobManageModel})
+	c.Check(m.Id(), gc.Equals, "0")
+	c.Check(m.Jobs(), gc.DeepEquals, []state.MachineJob{state.JobManageModel})
+
 	base, err := corebase.ParseBase(m.Base().OS, m.Base().Channel)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(m.Base().String(), gc.Equals, base.String())
-	c.Assert(m.CheckProvisioned(agent.BootstrapNonce), jc.IsTrue)
-	c.Assert(m.Addresses(), jc.DeepEquals, filteredAddrs)
+	c.Check(m.Base().String(), gc.Equals, base.String())
+	c.Check(m.CheckProvisioned(agent.BootstrapNonce), jc.IsTrue)
+
 	gotBootstrapConstraints, err := m.Constraints()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(gotBootstrapConstraints, gc.DeepEquals, expectBootstrapConstraints)
-	c.Assert(err, jc.ErrorIsNil)
+	c.Check(gotBootstrapConstraints, gc.DeepEquals, expectBootstrapConstraints)
+
 	gotHW, err := m.HardwareCharacteristics()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(*gotHW, gc.DeepEquals, expectHW)
+	c.Check(*gotHW, gc.DeepEquals, expectHW)
 
 	// Check that the API host ports are initialised correctly.
 	apiHostPorts, err := st.APIHostPortsForClients()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(apiHostPorts, jc.DeepEquals, []corenetwork.SpaceHostPorts{
+	c.Check(apiHostPorts, jc.DeepEquals, []corenetwork.SpaceHostPorts{
 		corenetwork.SpaceAddressesWithPort(filteredAddrs, 1234),
 	})
 
 	// Check that the state serving info is initialised correctly.
 	stateServingInfo, err := st.StateServingInfo()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(stateServingInfo, jc.DeepEquals, controller.StateServingInfo{
+	c.Check(stateServingInfo, jc.DeepEquals, controller.StateServingInfo{
 		APIPort:        1234,
 		StatePort:      s.mgoInst.Port(),
 		Cert:           testing.ServerCert,
@@ -313,17 +316,18 @@ func (s *bootstrapSuite) TestInitializeState(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	expectedStorageCfg, err := storage.NewConfig("spool", "loop", map[string]interface{}{"foo": "bar"})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(storageCfg, jc.DeepEquals, expectedStorageCfg)
+	c.Check(storageCfg, jc.DeepEquals, expectedStorageCfg)
 
 	// Check that the machine agent's config has been written
 	// and that we can use it to connect to mongo.
 	machine0 := names.NewMachineTag("0")
 	newCfg, err := agent.ReadConfig(agent.ConfigPath(dataDir, machine0))
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(newCfg.Tag(), gc.Equals, machine0)
+	c.Check(newCfg.Tag(), gc.Equals, machine0)
+
 	info, ok := cfg.MongoInfo()
 	c.Assert(ok, jc.IsTrue)
-	c.Assert(info.Password, gc.Not(gc.Equals), testing.DefaultMongoPassword)
+	c.Check(info.Password, gc.Not(gc.Equals), testing.DefaultMongoPassword)
 
 	session, err := mongo.DialWithInfo(*info, mongotest.DialOpts())
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/juju/controller/register.go
+++ b/cmd/juju/controller/register.go
@@ -71,7 +71,7 @@ type registerCommand struct {
 	arg     string
 	replace bool
 
-	// onRunError is executed if non-nil if there is an error at the end
+	// onRunError is executed if non-nil and there is an error at the end
 	// of the Run method.
 	onRunError func()
 }
@@ -171,7 +171,7 @@ func (c *registerCommand) run(ctx *cmd.Context) error {
 	}
 
 	// Check if user is trying to register an already known controller by
-	// by providing the IP of one of its endpoints.
+	// providing the IP of one of its endpoints.
 	if registrationParams.publicHost != "" {
 		if err := ensureNotKnownEndpoint(c.store, registrationParams.publicHost); err != nil {
 			return errors.Trace(err)
@@ -374,12 +374,6 @@ func (c *registerCommand) nonPublicControllerDetails(ctx *cmd.Context, registrat
 	}
 	resp, err := c.secretKeyLogin(controllerDetails, req, controllerName)
 	if err != nil {
-		// If we got here and got an error, the registration token supplied
-		// will be expired.
-		// Log the error as it will be useful for debugging, but give user a
-		// suggestion for the way forward instead of error details.
-		logger.Infof("while validating secret key: %v", err)
-		err = errors.Errorf("Provided registration token may have been expired.\nA controller administrator must reset your user to issue a new token.\nSee %q for more information.", "juju help change-user-password")
 		return errRet(errors.Trace(err))
 	}
 
@@ -585,12 +579,12 @@ func (c *registerCommand) secretKeyLogin(
 ) (_ *params.SecretKeyLoginResponse, err error) {
 	cookieJar, err := c.CookieJar(c.store, controllerName)
 	if err != nil {
-		return nil, errors.Annotate(err, "getting API context")
+		return nil, errors.Annotatef(err, "internal error: cannot get API context")
 	}
 
 	buf, err := json.Marshal(&request)
 	if err != nil {
-		return nil, errors.Annotate(err, "marshalling request")
+		return nil, errors.Annotatef(err, "internal error: cannot marshell controller api request")
 	}
 	r := bytes.NewReader(buf)
 
@@ -610,7 +604,8 @@ func (c *registerCommand) secretKeyLogin(
 	}
 	conn, err := c.apiOpen(apiInfo, opts)
 	if err != nil {
-		return nil, errors.Trace(err)
+		logger.Infof("opening api connection: %s", err)
+		return nil, controllerUnreachableError(controllerName, controllerDetails.APIEndpoints)
 	}
 	apiAddr := conn.Addr()
 	defer func() {
@@ -629,7 +624,7 @@ func (c *registerCommand) secretKeyLogin(
 	urlString := fmt.Sprintf("https://%s/register", apiAddr)
 	httpReq, err := http.NewRequest("POST", urlString, r)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Annotatef(err, "internal error: creating new http request")
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
 	httpReq.Header.Set(httpbakery.BakeryProtocolHeader, fmt.Sprint(bakery.LatestVersion))
@@ -640,21 +635,24 @@ func (c *registerCommand) secretKeyLogin(
 	)
 	httpResp, err := httpClient.Do(httpReq)
 	if err != nil {
-		return nil, errors.Trace(err)
+		logger.Infof("connecting to controller: %s", err)
+		return nil, controllerUnreachableError(controllerName, controllerDetails.APIEndpoints)
 	}
 	defer func() { _ = httpResp.Body.Close() }()
 
 	if httpResp.StatusCode != http.StatusOK {
 		var resp params.ErrorResult
 		if err := json.NewDecoder(httpResp.Body).Decode(&resp); err != nil {
-			return nil, errors.Trace(err)
+			return nil, errors.Annotatef(err, "internal error: cannot decode http response")
 		}
-		return nil, resp.Error
+		logger.Infof("error response, %s", resp.Error)
+		return nil, errors.Errorf("Provided registration token may have expired."+
+			"\nA controller administrator must reset your user to issue a new token.\nSee %q for more information.", "juju help change-user-password")
 	}
 
 	var resp params.SecretKeyLoginResponse
 	if err := json.NewDecoder(httpResp.Body).Decode(&resp); err != nil {
-		return nil, errors.Annotatef(err, "cannot decode login response")
+		return nil, errors.Annotatef(err, "internal error: cannot decode controller response")
 	}
 	return &resp, nil
 }
@@ -794,4 +792,10 @@ func genAlreadyRegisteredError(controller, user string) error {
 		return err
 	}
 	return errors.New(buf.String())
+}
+
+func controllerUnreachableError(name string, endpoints []string) error {
+	return fmt.Errorf("Cannot reach controller %q at: %s."+
+		"\nCheck that the controller ip is reachable from your network.",
+		name, strings.Join(endpoints, ", "))
 }

--- a/cmd/juju/controller/register_test.go
+++ b/cmd/juju/controller/register_test.go
@@ -564,10 +564,8 @@ Enter a name for this controller: »foo
 	s.apiOpenError = errors.New("open failed")
 	err := s.run(c, prompter, registrationData)
 	c.Assert(c.GetTestLog(), gc.Matches, "(.|\n)*open failed(.|\n)*")
-	c.Assert(err, gc.ErrorMatches, `
-Provided registration token may have been expired.
-A controller administrator must reset your user to issue a new token.
-See "juju help change-user-password" for more information.`[1:])
+	c.Assert(err, gc.ErrorMatches, `Cannot reach controller "foo" at: `+s.apiConnection.Addr()+".\n"+
+		"Check that the controller ip is reachable from your network.")
 }
 
 func (s *RegisterSuite) TestRegisterServerError(c *gc.C) {
@@ -596,7 +594,7 @@ Enter a name for this controller: »foo
 	err = s.run(c, prompter, registrationData)
 	c.Assert(c.GetTestLog(), gc.Matches, "(.|\n)* xyz(.|\n)*")
 	c.Assert(err, gc.ErrorMatches, `
-Provided registration token may have been expired.
+Provided registration token may have expired.
 A controller administrator must reset your user to issue a new token.
 See "juju help change-user-password" for more information.`[1:])
 

--- a/tests/suites/manual/deploy_manual.sh
+++ b/tests/suites/manual/deploy_manual.sh
@@ -13,7 +13,7 @@ test_deploy_manual() {
 		"lxd")
 			run "run_deploy_manual_lxd"
 			;;
-		"aws")
+		"ec2")
 			run "run_deploy_manual_aws"
 			;;
 		*)

--- a/tests/suites/manual/util.sh
+++ b/tests/suites/manual/util.sh
@@ -25,7 +25,7 @@ launch_and_wait_addr_ec2() {
 	aws ec2 wait instance-running --instance-ids "${instance_id}"
 	sleep 10
 
-	address=$(aws ec2 describe-instances --instance-ids "${instance_id}" --query 'Reservations[0].Instances[0].PublicDnsName' --output text)
+	address=$(aws ec2 describe-instances --instance-ids "${instance_id}" --query 'Reservations[0].Instances[0].PublicIpAddress' --output text)
 
 	# shellcheck disable=SC2086
 	eval $addr_result="'${address}'"


### PR DESCRIPTION
Merge 3.4 into 3.5. The only conflicts were in go.mod/go.sum which was resolved fully in favour of 3.5.

This merge includes the following commits:
- #17482 from cderici
- #17473 from nvinuesa
- #17480 from jack-w-shaw
- #17452 from Aflynn50
- #17455 from manadart
