### PR TITLE
fix(migration): Return ErrDBNotFound for not found namespace

### DIFF
--- a/core/database/dbmanager.go
+++ b/core/database/dbmanager.go
@@ -21,6 +21,10 @@ const (
 	// ErrDBDead is used to indicate that the database is dead and should no
 	// longer be used.
 	ErrDBDead = errors.ConstError("database is dead")
+
+	// ErrDBNotFound is used to indicate that the requested database does not
+	// exist.
+	ErrDBNotFound = errors.ConstError("database not found")
 )
 
 // DBGetter describes the ability to supply a transaction runner

--- a/domain/model/modelmigration/import_test.go
+++ b/domain/model/modelmigration/import_test.go
@@ -242,6 +242,7 @@ func (i *importSuite) TestModelCreateRollbacksOnFailure(c *gc.C) {
 		c.Assert(opts.DeleteDB(), jc.IsTrue)
 		return nil
 	})
+	i.readOnlyModelService.EXPECT().DeleteModel(gomock.Any()).Return(nil)
 
 	model := description.NewModel(description.ModelArgs{
 		Config: map[string]any{
@@ -321,6 +322,7 @@ func (i *importSuite) TestModelCreateRollbacksOnFailureIgnoreNotFoundModel(c *gc
 	i.modelService.EXPECT().ImportModel(gomock.Any(), args).Return(activator, nil)
 	i.readOnlyModelService.EXPECT().CreateModel(gomock.Any(), controllerUUID).Return(errors.New("boom"))
 	i.modelService.EXPECT().DeleteModel(gomock.Any(), modelUUID, gomock.Any()).Return(modelerrors.NotFound)
+	i.readOnlyModelService.EXPECT().DeleteModel(gomock.Any()).Return(nil)
 
 	model := description.NewModel(description.ModelArgs{
 		Config: map[string]any{
@@ -400,6 +402,7 @@ func (i *importSuite) TestModelCreateRollbacksOnFailureIgnoreNotFoundReadOnlyMod
 	i.modelService.EXPECT().ImportModel(gomock.Any(), args).Return(activator, nil)
 	i.readOnlyModelService.EXPECT().CreateModel(gomock.Any(), controllerUUID).Return(errors.New("boom"))
 	i.modelService.EXPECT().DeleteModel(gomock.Any(), modelUUID, gomock.Any()).Return(nil)
+	i.readOnlyModelService.EXPECT().DeleteModel(gomock.Any()).Return(nil)
 
 	model := description.NewModel(description.ModelArgs{
 		Config: map[string]any{

--- a/domain/model/service/service.go
+++ b/domain/model/service/service.go
@@ -409,9 +409,6 @@ func (s *Service) DeleteModel(
 	// supported in dqlite). For now we do a best effort to remove all items
 	// with in the db.
 	if err := s.modelDeleter.DeleteDB(uuid.String()); err != nil {
-		if errors.Is(err, errors.NotFound) {
-			return modelerrors.NotFound
-		}
 		return fmt.Errorf("delete model: %w", err)
 	}
 

--- a/domain/model/service/service_test.go
+++ b/domain/model/service/service_test.go
@@ -471,11 +471,10 @@ func (s *serviceSuite) TestDeleteModel(c *gc.C) {
 type notFoundDeleter struct{}
 
 func (d notFoundDeleter) DeleteDB(string) error {
-	return errors.NotFound
+	return modelerrors.NotFound
 }
 
 func (s *serviceSuite) TestDeleteModelNotFound(c *gc.C) {
-
 	svc := NewService(s.state, notFoundDeleter{}, DefaultAgentBinaryFinder(), loggertesting.WrapCheckLog(c))
 	err := svc.DeleteModel(context.Background(), modeltesting.GenModelUUID(c), model.WithDeleteDB())
 	c.Assert(err, jc.ErrorIs, modelerrors.NotFound)

--- a/domain/model/state/modelstate.go
+++ b/domain/model/state/modelstate.go
@@ -50,7 +50,6 @@ func (s *ModelState) Create(ctx context.Context, args model.ReadOnlyModelCreatio
 
 // Delete deletes a model.
 func (s *ModelState) Delete(ctx context.Context, uuid coremodel.UUID) error {
-	// TODO (manadart 2024-06-06): Check why we block here prior to PR 17472.
 	db, err := s.DB()
 	if err != nil {
 		return errors.Trace(err)

--- a/internal/worker/dbaccessor/worker.go
+++ b/internal/worker/dbaccessor/worker.go
@@ -1007,7 +1007,7 @@ func (w *dbWorker) ensureNamespace(namespace string) error {
 		return errors.Trace(err)
 	}
 	if !known {
-		return errors.NotFoundf("namespace %q", namespace)
+		return database.ErrDBNotFound
 	}
 	return nil
 }

--- a/internal/worker/dbaccessor/worker_integration_test.go
+++ b/internal/worker/dbaccessor/worker_integration_test.go
@@ -166,8 +166,8 @@ func (s *integrationSuite) TestWorkerAccessingControllerDB(c *gc.C) {
 
 func (s *integrationSuite) TestWorkerAccessingUnknownDB(c *gc.C) {
 	_, err := s.dbGetter.GetDB("foo")
-	c.Assert(err, gc.ErrorMatches, `.*namespace "foo" not found`)
-	c.Assert(err, jc.ErrorIs, errors.NotFound)
+	c.Assert(err, gc.ErrorMatches, `.*"foo": database not found`)
+	c.Assert(err, jc.ErrorIs, coredatabase.ErrDBNotFound)
 }
 
 func (s *integrationSuite) TestWorkerAccessingKnownDB(c *gc.C) {
@@ -205,7 +205,6 @@ func (s *integrationSuite) TestWorkerDeletingControllerDB(c *gc.C) {
 func (s *integrationSuite) TestWorkerDeletingUnknownDB(c *gc.C) {
 	err := s.dbDeleter.DeleteDB("foo")
 	c.Assert(err, gc.ErrorMatches, `.*"foo" not found`)
-	c.Assert(err, jc.ErrorIs, errors.NotFound)
 }
 
 func (s *integrationSuite) TestWorkerDeletingKnownDB(c *gc.C) {
@@ -233,7 +232,8 @@ func (s *integrationSuite) TestWorkerDeletingKnownDB(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, err = s.dbGetter.GetDB("baz")
-	c.Assert(err, gc.ErrorMatches, `.*namespace "baz" not found`)
+	c.Assert(err, gc.ErrorMatches, `.*namespace "baz": database not found`)
+	c.Assert(err, jc.ErrorIs, coredatabase.ErrDBNotFound)
 }
 
 func (s *integrationSuite) TestWorkerDeleteKnownDBKillErr(c *gc.C) {
@@ -278,7 +278,8 @@ func (s *integrationSuite) TestWorkerDeletingKnownDBWithoutGetFirst(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `.*"fred" not found`)
 
 	_, err = s.dbGetter.GetDB("fred")
-	c.Assert(err, gc.ErrorMatches, `.*"fred" not found`)
+	c.Assert(err, gc.ErrorMatches, `.*"fred": database not found`)
+	c.Assert(err, jc.ErrorIs, coredatabase.ErrDBNotFound)
 }
 
 type txnRunner struct {

--- a/internal/worker/dbaccessor/worker_namespace_test.go
+++ b/internal/worker/dbaccessor/worker_namespace_test.go
@@ -68,7 +68,7 @@ func (s *namespaceSuite) TestEnsureNamespaceForModelNotFound(c *gc.C) {
 	ensureStartup(c, dbw)
 
 	err := dbw.ensureNamespace("foo")
-	c.Assert(err, jc.ErrorIs, errors.NotFound)
+	c.Assert(err, jc.ErrorIs, database.ErrDBNotFound)
 
 	workertest.CleanKill(c, w)
 }


### PR DESCRIPTION
This follows on from https://github.com/juju/juju/pull/17478 which presented as a blocked db.

----

If the namespace isn't found we should return a sentinel error, so we prevent constant restarting. If we get into a restarting loop we can't progress the model and we can't roll back.

This reinstates the read-only model rollback. The delete db should only be used sparingly and ideally, we should not require it. The fallback is there as a safety net.

The error for the agent version is still broken, but it forces the problem to exist.

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
$ juju bootstap lxd src
$ juju add-model moveme

$ juju bootstrap lxd dst
$ juju migrate src:moveme dst
```

This will fail, as we still need to fix agent version not correctly set. The rollback should fail because of the location of the failure. The error message can be seen in `juju status -m src:moveme --format=yaml`

## Links

**Jira card:** JUJU-

