### PR TITLE
fix: model migration due to zero agent version

### DIFF
--- a/domain/model/modelmigration/import_test.go
+++ b/domain/model/modelmigration/import_test.go
@@ -162,14 +162,14 @@ func (i *importSuite) TestModelCreate(c *gc.C) {
 
 	model := description.NewModel(description.ModelArgs{
 		Config: map[string]any{
-			config.NameKey: "test-model",
-			config.UUIDKey: modelUUID.String(),
+			config.NameKey:         "test-model",
+			config.UUIDKey:         modelUUID.String(),
+			config.AgentVersionKey: jujuversion.Current.String(),
 		},
-		Cloud:              "AWS",
-		CloudRegion:        "region1",
-		Owner:              names.NewUserTag("tlm"),
-		LatestToolsVersion: jujuversion.Current,
-		Type:               coremodel.CAAS.String(),
+		Cloud:       "AWS",
+		CloudRegion: "region1",
+		Owner:       names.NewUserTag("tlm"),
+		Type:        coremodel.CAAS.String(),
 	})
 
 	model.SetCloudCredential(description.CloudCredentialArgs{
@@ -245,14 +245,14 @@ func (i *importSuite) TestModelCreateRollbacksOnFailure(c *gc.C) {
 
 	model := description.NewModel(description.ModelArgs{
 		Config: map[string]any{
-			config.NameKey: "test-model",
-			config.UUIDKey: modelUUID.String(),
+			config.NameKey:         "test-model",
+			config.UUIDKey:         modelUUID.String(),
+			config.AgentVersionKey: jujuversion.Current.String(),
 		},
-		Cloud:              "AWS",
-		CloudRegion:        "region1",
-		Owner:              names.NewUserTag("tlm"),
-		LatestToolsVersion: jujuversion.Current,
-		Type:               coremodel.CAAS.String(),
+		Cloud:       "AWS",
+		CloudRegion: "region1",
+		Owner:       names.NewUserTag("tlm"),
+		Type:        coremodel.CAAS.String(),
 	})
 
 	model.SetCloudCredential(description.CloudCredentialArgs{
@@ -324,14 +324,14 @@ func (i *importSuite) TestModelCreateRollbacksOnFailureIgnoreNotFoundModel(c *gc
 
 	model := description.NewModel(description.ModelArgs{
 		Config: map[string]any{
-			config.NameKey: "test-model",
-			config.UUIDKey: modelUUID.String(),
+			config.NameKey:         "test-model",
+			config.UUIDKey:         modelUUID.String(),
+			config.AgentVersionKey: jujuversion.Current.String(),
 		},
-		Cloud:              "AWS",
-		CloudRegion:        "region1",
-		Owner:              names.NewUserTag("tlm"),
-		LatestToolsVersion: jujuversion.Current,
-		Type:               coremodel.CAAS.String(),
+		Cloud:       "AWS",
+		CloudRegion: "region1",
+		Owner:       names.NewUserTag("tlm"),
+		Type:        coremodel.CAAS.String(),
 	})
 
 	model.SetCloudCredential(description.CloudCredentialArgs{
@@ -403,14 +403,14 @@ func (i *importSuite) TestModelCreateRollbacksOnFailureIgnoreNotFoundReadOnlyMod
 
 	model := description.NewModel(description.ModelArgs{
 		Config: map[string]any{
-			config.NameKey: "test-model",
-			config.UUIDKey: modelUUID.String(),
+			config.NameKey:         "test-model",
+			config.UUIDKey:         modelUUID.String(),
+			config.AgentVersionKey: jujuversion.Current.String(),
 		},
-		Cloud:              "AWS",
-		CloudRegion:        "region1",
-		Owner:              names.NewUserTag("tlm"),
-		LatestToolsVersion: jujuversion.Current,
-		Type:               coremodel.CAAS.String(),
+		Cloud:       "AWS",
+		CloudRegion: "region1",
+		Owner:       names.NewUserTag("tlm"),
+		Type:        coremodel.CAAS.String(),
 	})
 
 	model.SetCloudCredential(description.CloudCredentialArgs{


### PR DESCRIPTION
LatestToolsVersion was incorrectly used to seed agent version in model importing. LatestToolsVersion is literally the latest tools version as seen from simple streams. In the case for 4.0 this value is zero (there isn't anything for 4.0 maj-min).

This change uses the `agent-version` value in model config.

@tlm will need to come back and improve this logic with changes in juju/description.

## QA steps

- Bootstrap two controllers
- Add a model
- Deploy an app
- Migrate from controller 1 to 2
- Check it is all healthy

## Documentation changes

N/A

## Links

**Jira card:** JUJU-