### PR TITLE
feat(sql): STRICT sql tables

### DIFF
--- a/domain/schema/controller/sql/0000-namespace.sql
+++ b/domain/schema/controller/sql/0000-namespace.sql
@@ -2,4 +2,4 @@
 -- controller.
 CREATE TABLE namespace_list (
     namespace TEXT PRIMARY KEY
-);
+) STRICT;

--- a/domain/schema/controller/sql/0001-life.sql
+++ b/domain/schema/controller/sql/0001-life.sql
@@ -1,7 +1,7 @@
 CREATE TABLE life (
     id INT PRIMARY KEY,
     value TEXT NOT NULL
-);
+) STRICT;
 
 INSERT INTO life VALUES
 (0, 'alive'),

--- a/domain/schema/controller/sql/0002-lease.sql
+++ b/domain/schema/controller/sql/0002-lease.sql
@@ -1,7 +1,7 @@
 CREATE TABLE lease_type (
     id INT PRIMARY KEY,
     type TEXT
-);
+) STRICT;
 
 CREATE UNIQUE INDEX idx_lease_type_type
 ON lease_type (type);
@@ -16,12 +16,12 @@ CREATE TABLE lease (
     model_uuid TEXT,
     name TEXT,
     holder TEXT,
-    start TIMESTAMP,
-    expiry TIMESTAMP,
+    start TEXT,
+    expiry TEXT,
     CONSTRAINT fk_lease_lease_type
     FOREIGN KEY (lease_type_id)
     REFERENCES lease_type (id)
-);
+) STRICT;
 
 CREATE UNIQUE INDEX idx_lease_model_type_name
 ON lease (model_uuid, lease_type_id, name);
@@ -38,7 +38,7 @@ CREATE TABLE lease_pin (
     CONSTRAINT fk_lease_pin_lease
     FOREIGN KEY (lease_uuid)
     REFERENCES lease (uuid)
-);
+) STRICT;
 
 CREATE UNIQUE INDEX idx_lease_pin_lease_entity
 ON lease_pin (lease_uuid, entity_id);

--- a/domain/schema/controller/sql/0003-changelog.sql
+++ b/domain/schema/controller/sql/0003-changelog.sql
@@ -1,7 +1,7 @@
 CREATE TABLE change_log_edit_type (
     id INT PRIMARY KEY,
     edit_type TEXT
-);
+) STRICT;
 
 CREATE UNIQUE INDEX idx_change_log_edit_type_edit_type
 ON change_log_edit_type (edit_type);
@@ -17,7 +17,7 @@ CREATE TABLE change_log_namespace (
     id INT PRIMARY KEY,
     namespace TEXT,
     description TEXT
-);
+) STRICT;
 
 CREATE UNIQUE INDEX idx_change_log_namespace_namespace
 ON change_log_namespace (namespace);
@@ -27,14 +27,14 @@ CREATE TABLE change_log (
     edit_type_id INT NOT NULL,
     namespace_id INT NOT NULL,
     changed TEXT NOT NULL,
-    created_at DATETIME NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW', 'utc')),
+    created_at TEXT NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW', 'utc')),
     CONSTRAINT fk_change_log_edit_type
     FOREIGN KEY (edit_type_id)
     REFERENCES change_log_edit_type (id),
     CONSTRAINT fk_change_log_namespace
     FOREIGN KEY (namespace_id)
     REFERENCES change_log_namespace (id)
-);
+) STRICT;
 
 -- The change log witness table is used to track which nodes have seen
 -- which change log entries. This is used to determine when a change log entry
@@ -45,5 +45,5 @@ CREATE TABLE change_log_witness (
     controller_id TEXT PRIMARY KEY,
     lower_bound INT NOT NULL DEFAULT (-1),
     upper_bound INT NOT NULL DEFAULT (-1),
-    updated_at DATETIME NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW', 'utc'))
-);
+    updated_at TEXT NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW', 'utc'))
+) STRICT;

--- a/domain/schema/controller/sql/0005-cloud.sql
+++ b/domain/schema/controller/sql/0005-cloud.sql
@@ -1,7 +1,7 @@
 CREATE TABLE cloud_type (
     id INT PRIMARY KEY,
     type TEXT NOT NULL
-);
+) STRICT;
 
 CREATE UNIQUE INDEX idx_cloud_type_type
 ON cloud_type (type);
@@ -25,7 +25,7 @@ INSERT INTO cloud_type VALUES
 CREATE TABLE auth_type (
     id INT PRIMARY KEY,
     type TEXT
-);
+) STRICT;
 
 CREATE UNIQUE INDEX idx_auth_type_type
 ON auth_type (type);
@@ -52,12 +52,12 @@ CREATE TABLE cloud (
     endpoint TEXT NOT NULL,
     identity_endpoint TEXT,
     storage_endpoint TEXT,
-    skip_tls_verify BOOLEAN NOT NULL,
+    skip_tls_verify INT NOT NULL,
     CONSTRAINT chk_name_empty CHECK (name != ''),
     CONSTRAINT fk_cloud_type
     FOREIGN KEY (cloud_type_id)
     REFERENCES cloud_type (id)
-);
+) STRICT;
 
 -- v_cloud is used to fetch well constructed information about a cloud. This
 -- view also includes information on whether the cloud is the controller
@@ -120,7 +120,7 @@ CREATE TABLE cloud_defaults (
     CONSTRAINT fk_cloud_uuid
     FOREIGN KEY (cloud_uuid)
     REFERENCES cloud (uuid)
-);
+) STRICT;
 
 CREATE TABLE cloud_auth_type (
     cloud_uuid TEXT NOT NULL,
@@ -132,7 +132,7 @@ CREATE TABLE cloud_auth_type (
     FOREIGN KEY (auth_type_id)
     REFERENCES auth_type (id),
     PRIMARY KEY (cloud_uuid, auth_type_id)
-);
+) STRICT;
 
 CREATE UNIQUE INDEX idx_cloud_auth_type_cloud_uuid_auth_type_id
 ON cloud_auth_type (cloud_uuid, auth_type_id);
@@ -147,7 +147,7 @@ CREATE TABLE cloud_region (
     CONSTRAINT fk_cloud_region_cloud
     FOREIGN KEY (cloud_uuid)
     REFERENCES cloud (uuid)
-);
+) STRICT;
 
 CREATE UNIQUE INDEX idx_cloud_region_cloud_uuid_name
 ON cloud_region (cloud_uuid, name);
@@ -164,7 +164,7 @@ CREATE TABLE cloud_region_defaults (
     CONSTRAINT fk_region_uuid
     FOREIGN KEY (region_uuid)
     REFERENCES cloud_region (uuid)
-);
+) STRICT;
 
 CREATE TABLE cloud_ca_cert (
     cloud_uuid TEXT NOT NULL,
@@ -173,7 +173,7 @@ CREATE TABLE cloud_ca_cert (
     FOREIGN KEY (cloud_uuid)
     REFERENCES cloud (uuid),
     PRIMARY KEY (cloud_uuid, ca_cert)
-);
+) STRICT;
 
 CREATE UNIQUE INDEX idx_cloud_ca_cert_cloud_uuid_ca_cert
 ON cloud_ca_cert (cloud_uuid, ca_cert);
@@ -184,8 +184,8 @@ CREATE TABLE cloud_credential (
     auth_type_id TEXT NOT NULL,
     owner_uuid TEXT NOT NULL,
     name TEXT NOT NULL,
-    revoked BOOLEAN,
-    invalid BOOLEAN,
+    revoked INT,
+    invalid INT,
     invalid_reason TEXT,
     CONSTRAINT chk_name_empty CHECK (name != ''),
     CONSTRAINT fk_cloud_credential_cloud
@@ -197,7 +197,7 @@ CREATE TABLE cloud_credential (
     CONSTRAINT fk_cloud_credential_user
     FOREIGN KEY (owner_uuid)
     REFERENCES user (uuid)
-);
+) STRICT;
 
 CREATE UNIQUE INDEX idx_cloud_credential_cloud_uuid_owner_uuid
 ON cloud_credential (cloud_uuid, owner_uuid, name);
@@ -233,7 +233,7 @@ CREATE TABLE cloud_credential_attributes (
     CONSTRAINT fk_cloud_credential_uuid
     FOREIGN KEY (cloud_credential_uuid)
     REFERENCES cloud_credential (uuid)
-);
+) STRICT;
 
 -- v_cloud_credential_attributes is responsible for return a view of all cloud
 -- credentials and their attributes repeated for every attribute.

--- a/domain/schema/controller/sql/0006-external-controller.sql
+++ b/domain/schema/controller/sql/0006-external-controller.sql
@@ -2,7 +2,7 @@ CREATE TABLE external_controller (
     uuid TEXT PRIMARY KEY,
     alias TEXT,
     ca_cert TEXT NOT NULL
-);
+) STRICT;
 
 CREATE TABLE external_controller_address (
     uuid TEXT PRIMARY KEY,
@@ -11,7 +11,7 @@ CREATE TABLE external_controller_address (
     CONSTRAINT fk_external_controller_address_external_controller_uuid
     FOREIGN KEY (controller_uuid)
     REFERENCES external_controller (uuid)
-);
+) STRICT;
 
 CREATE UNIQUE INDEX idx_external_controller_address
 ON external_controller_address (controller_uuid, address);
@@ -22,4 +22,4 @@ CREATE TABLE external_model (
     CONSTRAINT fk_external_model_external_controller_uuid
     FOREIGN KEY (controller_uuid)
     REFERENCES external_controller (uuid)
-);
+) STRICT;

--- a/domain/schema/controller/sql/0007-model.sql
+++ b/domain/schema/controller/sql/0007-model.sql
@@ -6,14 +6,14 @@ CREATE TABLE model_namespace (
     CONSTRAINT fk_model_uuid
     FOREIGN KEY (model_uuid)
     REFERENCES model (uuid)
-);
+) STRICT;
 
 CREATE UNIQUE INDEX idx_namespace_model_uuid ON model_namespace (namespace, model_uuid);
 
 CREATE TABLE model_type (
     id INT PRIMARY KEY,
     type TEXT NOT NULL
-);
+) STRICT;
 
 CREATE UNIQUE INDEX idx_model_type_type
 ON model_type (type);
@@ -29,7 +29,7 @@ CREATE TABLE model (
     -- over several transactions with any one of them possibly failing. We write true
     -- to this field when we are happy that the model can safely be used after all
     -- operations have been completed.
-    activated BOOLEAN DEFAULT FALSE NOT NULL,
+    activated INT NOT NULL,
     cloud_uuid TEXT NOT NULL,
     cloud_region_uuid TEXT,
     cloud_credential_uuid TEXT,
@@ -55,7 +55,7 @@ CREATE TABLE model (
     CONSTRAINT fk_model_life_id
     FOREIGN KEY (life_id)
     REFERENCES life (id)
-);
+) STRICT;
 
 -- idx_model_name_owner established an index that stops models being created
 -- with the same name for a given owner.

--- a/domain/schema/controller/sql/0008-model-agent.sql
+++ b/domain/schema/controller/sql/0008-model-agent.sql
@@ -13,4 +13,4 @@ CREATE TABLE model_agent (
     CONSTRAINT fk_model_agent_model
     FOREIGN KEY (model_uuid)
     REFERENCES model (uuid)
-);
+) STRICT;

--- a/domain/schema/controller/sql/0009-controller-config.sql
+++ b/domain/schema/controller/sql/0009-controller-config.sql
@@ -1,11 +1,11 @@
 CREATE TABLE controller_config (
     "key" TEXT PRIMARY KEY,
     value TEXT
-);
+) STRICT;
 
 CREATE TABLE controller (
     uuid TEXT PRIMARY KEY NOT NULL
-);
+) STRICT;
 
 -- A unique constraint over a constant index ensures only 1 entry matching the 
 -- condition can exist.

--- a/domain/schema/controller/sql/0010-controller-node.sql
+++ b/domain/schema/controller/sql/0010-controller-node.sql
@@ -1,8 +1,10 @@
 CREATE TABLE controller_node (
     controller_id TEXT PRIMARY KEY,
-    dqlite_node_id TEXT,              -- This is the uint64 from Dqlite NodeInfo, stored as text.
-    bind_address TEXT               -- IP address (no port) that Dqlite is bound to. 
-);
+    -- This is the uint64 from Dqlite NodeInfo, stored as text.
+    dqlite_node_id TEXT,
+    -- IP address (no port) that Dqlite is bound to.  
+    bind_address TEXT
+) STRICT;
 
 CREATE UNIQUE INDEX idx_controller_node_dqlite_node
 ON controller_node (dqlite_node_id);

--- a/domain/schema/controller/sql/0011-model-migration.sql
+++ b/domain/schema/controller/sql/0011-model-migration.sql
@@ -5,27 +5,27 @@ CREATE TABLE model_migration (
     target_entity TEXT,
     target_password TEXT,
     target_macaroons TEXT,
-    active BOOLEAN,
-    start_time TIMESTAMP,
-    success_time TIMESTAMP,
-    end_time TIMESTAMP,
+    active INT,
+    start_time TEXT,
+    success_time TEXT,
+    end_time TEXT,
     phase TEXT,
-    phase_changed_time TIMESTAMP,
+    phase_changed_time TEXT,
     status_message TEXT,
     CONSTRAINT fk_model_migration_target_controller
     FOREIGN KEY (target_controller_uuid)
     REFERENCES external_controller (uuid)
-);
+) STRICT;
 
 CREATE TABLE model_migration_status (
     uuid TEXT PRIMARY KEY,
-    start_time TIMESTAMP,
-    success_time TIMESTAMP,
-    end_time TIMESTAMP,
+    start_time TEXT,
+    success_time TEXT,
+    end_time TEXT,
     phase TEXT,
-    phase_changed_time TIMESTAMP,
+    phase_changed_time TEXT,
     status TEXT
-);
+) STRICT;
 
 CREATE TABLE model_migration_user (
     uuid TEXT PRIMARY KEY,
@@ -38,16 +38,16 @@ CREATE TABLE model_migration_user (
     CONSTRAINT fk_model_migration_user_model_migration
     FOREIGN KEY (migration_uuid)
     REFERENCES model_migration (uuid)
-);
+) STRICT;
 
 CREATE TABLE model_migration_minion_sync (
     uuid TEXT PRIMARY KEY,
     migration_uuid TEXT NOT NULL,
     phase TEXT,
     entity_key TEXT,
-    time TIMESTAMP,
-    success BOOLEAN,
+    time TEXT,
+    success INT,
     CONSTRAINT fk_model_migration_minion_sync_model_migration
     FOREIGN KEY (migration_uuid)
     REFERENCES model_migration (uuid)
-);
+) STRICT;

--- a/domain/schema/controller/sql/0012-uprade-info.sql
+++ b/domain/schema/controller/sql/0012-uprade-info.sql
@@ -1,7 +1,7 @@
 CREATE TABLE upgrade_state_type (
     id INT PRIMARY KEY,
     type TEXT
-);
+) STRICT;
 
 CREATE UNIQUE INDEX idx_upgrade_state_type_type
 ON upgrade_state_type (type);
@@ -21,7 +21,7 @@ CREATE TABLE upgrade_info (
     CONSTRAINT fk_upgrade_info_upgrade_state_type
     FOREIGN KEY (state_type_id)
     REFERENCES upgrade_state_type (id)
-);
+) STRICT;
 
 -- A unique constraint over a constant index ensures only 1 entry matching the 
 -- condition can exist. This states, that multiple upgrades can exist if they're
@@ -32,14 +32,14 @@ CREATE TABLE upgrade_info_controller_node (
     uuid TEXT PRIMARY KEY,
     controller_node_id TEXT NOT NULL,
     upgrade_info_uuid TEXT NOT NULL,
-    node_upgrade_completed_at TIMESTAMP,
+    node_upgrade_completed_at TEXT,
     CONSTRAINT fk_controller_node_id
     FOREIGN KEY (controller_node_id)
     REFERENCES controller_node (controller_id),
     CONSTRAINT fk_upgrade_info
     FOREIGN KEY (upgrade_info_uuid)
     REFERENCES upgrade_info (uuid)
-);
+) STRICT;
 
 CREATE UNIQUE INDEX idx_upgrade_info_controller_node
 ON upgrade_info_controller_node (controller_node_id, upgrade_info_uuid);

--- a/domain/schema/controller/sql/0013-autocert-cache.sql
+++ b/domain/schema/controller/sql/0013-autocert-cache.sql
@@ -6,7 +6,7 @@ CREATE TABLE autocert_cache (
     CONSTRAINT fk_autocert_cache_encoding
     FOREIGN KEY (encoding)
     REFERENCES autocert_cache_encoding (id)
-);
+) STRICT;
 
 -- NOTE(nvinuesa): This table only populated with *one* hard-coded value
 -- (x509) because golang's autocert cache doesn't provide encoding in it's
@@ -16,7 +16,7 @@ CREATE TABLE autocert_cache (
 CREATE TABLE autocert_cache_encoding (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     name TEXT NOT NULL
-);
+) STRICT;
 
 INSERT INTO autocert_cache_encoding VALUES
 (0, 'x509');    -- Only x509 certs encoding supported today.

--- a/domain/schema/controller/sql/0014-objectstore-metadata.sql
+++ b/domain/schema/controller/sql/0014-objectstore-metadata.sql
@@ -1,7 +1,7 @@
 CREATE TABLE object_store_metadata_hash_type (
     id INT PRIMARY KEY,
     hash_type TEXT NOT NULL
-);
+) STRICT;
 
 CREATE UNIQUE INDEX idx_object_store_metadata_hash_type_name
 ON object_store_metadata_hash_type (hash_type);
@@ -18,7 +18,7 @@ CREATE TABLE object_store_metadata (
     CONSTRAINT fk_object_store_metadata_hash_type
     FOREIGN KEY (hash_type_id)
     REFERENCES object_store_metadata_hash_type (id)
-);
+) STRICT;
 
 CREATE UNIQUE INDEX idx_object_store_metadata_hash ON object_store_metadata (hash);
 
@@ -28,4 +28,4 @@ CREATE TABLE object_store_metadata_path (
     CONSTRAINT fk_object_store_metadata_metadata_uuid
     FOREIGN KEY (metadata_uuid)
     REFERENCES object_store_metadata (uuid)
-);
+) STRICT;

--- a/domain/schema/controller/sql/0015-user.sql
+++ b/domain/schema/controller/sql/0015-user.sql
@@ -2,23 +2,23 @@ CREATE TABLE user (
     uuid TEXT PRIMARY KEY,
     name TEXT NOT NULL,
     display_name TEXT,
-    removed BOOLEAN NOT NULL DEFAULT FALSE,
+    removed INT NOT NULL,
     created_by_uuid TEXT NOT NULL,
-    created_at TIMESTAMP NOT NULL,
+    created_at TEXT NOT NULL,
     CONSTRAINT fk_user_created_by_user
     FOREIGN KEY (created_by_uuid)
     REFERENCES user (uuid)
-);
+) STRICT;
 
-CREATE UNIQUE INDEX idx_singleton_active_user ON user (name) WHERE removed IS FALSE;
+CREATE UNIQUE INDEX idx_singleton_active_user ON user (name) WHERE removed IS 0;
 
 CREATE TABLE user_authentication (
     user_uuid TEXT PRIMARY KEY,
-    disabled BOOLEAN NOT NULL,
+    disabled INT NOT NULL,
     CONSTRAINT fk_user_authentication_user
     FOREIGN KEY (user_uuid)
     REFERENCES user (uuid)
-);
+) STRICT;
 
 CREATE TABLE user_password (
     user_uuid TEXT PRIMARY KEY,
@@ -27,7 +27,7 @@ CREATE TABLE user_password (
     CONSTRAINT fk_user_password_user
     FOREIGN KEY (user_uuid)
     REFERENCES user_authentication (user_uuid)
-);
+) STRICT;
 
 CREATE TABLE user_activation_key (
     user_uuid TEXT PRIMARY KEY,
@@ -35,7 +35,7 @@ CREATE TABLE user_activation_key (
     CONSTRAINT fk_user_activation_key_user
     FOREIGN KEY (user_uuid)
     REFERENCES user_authentication (user_uuid)
-);
+) STRICT;
 
 CREATE VIEW v_user_auth AS
 SELECT

--- a/domain/schema/controller/sql/0016-flag.sql
+++ b/domain/schema/controller/sql/0016-flag.sql
@@ -1,5 +1,5 @@
 CREATE TABLE flag (
     name TEXT PRIMARY KEY,
-    value BOOLEAN DEFAULT 0,
+    value INT DEFAULT 0,
     description TEXT NOT NULL
-);
+) STRICT;

--- a/domain/schema/controller/sql/0017-user-permission.sql
+++ b/domain/schema/controller/sql/0017-user-permission.sql
@@ -1,7 +1,7 @@
 CREATE TABLE permission_access_type (
     id INT PRIMARY KEY,
     type TEXT NOT NULL
-);
+) STRICT;
 
 CREATE UNIQUE INDEX idx_permission_access_type
 ON permission_access_type (type);
@@ -19,7 +19,7 @@ INSERT INTO permission_access_type VALUES
 CREATE TABLE permission_object_type (
     id INT PRIMARY KEY,
     type TEXT NOT NULL
-);
+) STRICT;
 
 CREATE UNIQUE INDEX idx_permission_object_type
 ON permission_object_type (type);
@@ -41,7 +41,7 @@ CREATE TABLE permission_object_access (
     CONSTRAINT fk_permission_object_type
     FOREIGN KEY (object_type_id)
     REFERENCES permission_object_type (id)
-);
+) STRICT;
 
 CREATE UNIQUE INDEX idx_permission_object_access
 ON permission_object_access (access_type_id, object_type_id);
@@ -73,7 +73,7 @@ CREATE TABLE permission (
     CONSTRAINT fk_permission_object_access
     FOREIGN KEY (access_type_id, object_type_id)
     REFERENCES permission_object_access (access_type_id, object_type_id)
-);
+) STRICT;
 
 -- Allow only 1 combination of grant_on and grant_to
 -- Otherwise we will get conflicting permissions.

--- a/domain/schema/controller/sql/0018-secret-backend.sql
+++ b/domain/schema/controller/sql/0018-secret-backend.sql
@@ -6,7 +6,7 @@ CREATE TABLE secret_backend_type (
     description TEXT,
     CONSTRAINT chk_empty_type
     CHECK (type != '')
-);
+) STRICT;
 
 CREATE UNIQUE INDEX idx_secret_backend_type_type ON secret_backend_type (type);
 
@@ -46,7 +46,7 @@ CREATE TABLE secret_backend_config (
 
 CREATE TABLE secret_backend_rotation (
     backend_uuid TEXT PRIMARY KEY,
-    next_rotation_time DATETIME NOT NULL,
+    next_rotation_time TEXT NOT NULL,
     CONSTRAINT fk_secret_backend_rotation_secret_backend_uuid
     FOREIGN KEY (backend_uuid)
     REFERENCES secret_backend (uuid)

--- a/domain/schema/controller/sql/0019-model-last-login.sql
+++ b/domain/schema/controller/sql/0019-model-last-login.sql
@@ -1,7 +1,7 @@
 CREATE TABLE model_last_login (
     model_uuid TEXT NOT NULL,
     user_uuid TEXT NOT NULL,
-    time TIMESTAMP NOT NULL,
+    time TEXT NOT NULL,
     PRIMARY KEY (model_uuid, user_uuid),
     CONSTRAINT fk_model_last_login_model
     FOREIGN KEY (model_uuid)
@@ -9,7 +9,7 @@ CREATE TABLE model_last_login (
     CONSTRAINT fk_model_last_login_user
     FOREIGN KEY (user_uuid)
     REFERENCES user (uuid)
-);
+) STRICT;
 
 CREATE VIEW v_user_last_login AS
 -- We cannot select last_login as MAX directly here because it returns a sqlite

--- a/domain/schema/model/sql/0001-changelog.sql
+++ b/domain/schema/model/sql/0001-changelog.sql
@@ -1,7 +1,7 @@
 CREATE TABLE change_log_edit_type (
     id INT PRIMARY KEY,
     edit_type TEXT
-);
+) STRICT;
 
 CREATE UNIQUE INDEX idx_change_log_edit_type_edit_type
 ON change_log_edit_type (edit_type);
@@ -17,7 +17,7 @@ CREATE TABLE change_log_namespace (
     id INT PRIMARY KEY,
     namespace TEXT,
     description TEXT
-);
+) STRICT;
 
 CREATE UNIQUE INDEX idx_change_log_namespace_namespace
 ON change_log_namespace (namespace);
@@ -27,7 +27,7 @@ CREATE TABLE change_log (
     edit_type_id INT NOT NULL,
     namespace_id INT NOT NULL,
     changed TEXT NOT NULL,
-    created_at DATETIME NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW', 'utc')),
+    created_at TEXT NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW', 'utc')),
     CONSTRAINT fk_change_log_edit_type
     FOREIGN KEY (edit_type_id)
     REFERENCES change_log_edit_type (id),
@@ -45,5 +45,5 @@ CREATE TABLE change_log_witness (
     controller_id TEXT PRIMARY KEY,
     lower_bound INT NOT NULL DEFAULT (-1),
     upper_bound INT NOT NULL DEFAULT (-1),
-    updated_at DATETIME NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW', 'utc'))
-);
+    updated_at TEXT NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW', 'utc'))
+) STRICT;

--- a/domain/schema/model/sql/0003-read-only-model.sql
+++ b/domain/schema/model/sql/0003-read-only-model.sql
@@ -12,7 +12,7 @@ CREATE TABLE model (
     cloud_region TEXT,
     credential_owner TEXT,
     credential_name TEXT
-);
+) STRICT;
 
 -- A unique constraint over a constant index ensures only 1 entry matching the
 -- condition can exist.

--- a/domain/schema/model/sql/0004-model-config.sql
+++ b/domain/schema/model/sql/0004-model-config.sql
@@ -1,4 +1,4 @@
 CREATE TABLE model_config (
     "key" TEXT PRIMARY KEY,
     value TEXT NOT NULL
-);
+) STRICT;

--- a/domain/schema/model/sql/0005-objectstore-metadata.sql
+++ b/domain/schema/model/sql/0005-objectstore-metadata.sql
@@ -1,7 +1,7 @@
 CREATE TABLE object_store_metadata_hash_type (
     id INT PRIMARY KEY,
     hash_type TEXT NOT NULL
-);
+) STRICT;
 
 CREATE UNIQUE INDEX idx_object_store_metadata_hash_type_name
 ON object_store_metadata_hash_type (hash_type);
@@ -18,7 +18,7 @@ CREATE TABLE object_store_metadata (
     CONSTRAINT fk_object_store_metadata_hash_type
     FOREIGN KEY (hash_type_id)
     REFERENCES object_store_metadata_hash_type (id)
-);
+) STRICT;
 
 CREATE UNIQUE INDEX idx_object_store_metadata_hash ON object_store_metadata (hash);
 
@@ -28,4 +28,4 @@ CREATE TABLE object_store_metadata_path (
     CONSTRAINT fk_object_store_metadata_metadata_uuid
     FOREIGN KEY (metadata_uuid)
     REFERENCES object_store_metadata (uuid)
-);
+) STRICT;

--- a/domain/schema/model/sql/0006-application.sql
+++ b/domain/schema/model/sql/0006-application.sql
@@ -5,7 +5,7 @@ CREATE TABLE application (
     CONSTRAINT fk_application_life
     FOREIGN KEY (life_id)
     REFERENCES life (id)
-);
+) STRICT;
 
 CREATE UNIQUE INDEX idx_application_name
 ON application (name);

--- a/domain/schema/model/sql/0007-charm.sql
+++ b/domain/schema/model/sql/0007-charm.sql
@@ -1,15 +1,15 @@
 CREATE TABLE charm (
     uuid TEXT PRIMARY KEY,
     url TEXT NOT NULL
-);
+) STRICT;
 
 CREATE TABLE charm_storage (
     charm_uuid TEXT NOT NULL,
     name TEXT NOT NULL,
     description TEXT,
     storage_kind_id INT NOT NULL,
-    shared BOOLEAN,
-    read_only BOOLEAN,
+    shared INT,
+    read_only INT,
     count_min INT NOT NULL,
     count_max INT NOT NULL,
     minimum_size_mib INT,
@@ -21,7 +21,7 @@ CREATE TABLE charm_storage (
     FOREIGN KEY (charm_uuid)
     REFERENCES charm (uuid),
     PRIMARY KEY (charm_uuid, name)
-);
+) STRICT;
 
 CREATE INDEX idx_charm_storage_charm
 ON charm_storage (charm_uuid);

--- a/domain/schema/model/sql/0008-network.sql
+++ b/domain/schema/model/sql/0008-network.sql
@@ -1,6 +1,6 @@
 CREATE TABLE net_node (
     uuid TEXT PRIMARY KEY
-);
+) STRICT;
 
 CREATE TABLE cloud_service (
     uuid TEXT PRIMARY KEY,
@@ -12,7 +12,7 @@ CREATE TABLE cloud_service (
     CONSTRAINT fk_cloud_application
     FOREIGN KEY (application_uuid)
     REFERENCES application (uuid)
-);
+) STRICT;
 
 CREATE UNIQUE INDEX idx_cloud_service_net_node
 ON cloud_service (net_node_uuid);
@@ -26,7 +26,7 @@ CREATE TABLE cloud_container (
     CONSTRAINT fk_cloud_container_net_node
     FOREIGN KEY (net_node_uuid)
     REFERENCES net_node (uuid)
-);
+) STRICT;
 
 CREATE UNIQUE INDEX idx_cloud_container_net_node
 ON cloud_container (net_node_uuid);

--- a/domain/schema/model/sql/0009-unit.sql
+++ b/domain/schema/model/sql/0009-unit.sql
@@ -13,7 +13,7 @@ CREATE TABLE unit (
     CONSTRAINT fk_unit_life
     FOREIGN KEY (life_id)
     REFERENCES life (id)
-);
+) STRICT;
 
 CREATE UNIQUE INDEX idx_unit_id
 ON unit (unit_id);
@@ -32,7 +32,7 @@ CREATE TABLE unit_state (
     CONSTRAINT fk_unit_state_unit
     FOREIGN KEY (unit_uuid)
     REFERENCES unit (uuid)
-);
+) STRICT;
 
 -- Local charm state stored upon hook commit with uniter state.
 CREATE TABLE unit_state_charm (
@@ -43,7 +43,7 @@ CREATE TABLE unit_state_charm (
     CONSTRAINT fk_unit_state_charm_unit
     FOREIGN KEY (unit_uuid)
     REFERENCES unit (uuid)
-);
+) STRICT;
 
 -- Local relation state stored upon hook commit with uniter state.
 CREATE TABLE unit_state_relation (
@@ -54,4 +54,4 @@ CREATE TABLE unit_state_relation (
     CONSTRAINT fk_unit_state_relation_unit
     FOREIGN KEY (unit_uuid)
     REFERENCES unit (uuid)
-);
+) STRICT;

--- a/domain/schema/model/sql/0010-space.sql
+++ b/domain/schema/model/sql/0010-space.sql
@@ -1,7 +1,7 @@
 CREATE TABLE space (
     uuid TEXT PRIMARY KEY,
     name TEXT NOT NULL
-);
+) STRICT;
 
 CREATE UNIQUE INDEX idx_spaces_uuid_name
 ON space (name);
@@ -12,7 +12,7 @@ CREATE TABLE provider_space (
     CONSTRAINT fk_provider_space_space_uuid
     FOREIGN KEY (space_uuid)
     REFERENCES space (uuid)
-);
+) STRICT;
 
 CREATE UNIQUE INDEX idx_provider_space_space_uuid
 ON provider_space (space_uuid);

--- a/domain/schema/model/sql/0011-subnet.sql
+++ b/domain/schema/model/sql/0011-subnet.sql
@@ -6,7 +6,7 @@ CREATE TABLE subnet (
     CONSTRAINT fk_subnets_spaces
     FOREIGN KEY (space_uuid)
     REFERENCES space (uuid)
-);
+) STRICT;
 
 CREATE TABLE provider_subnet (
     provider_id TEXT PRIMARY KEY,
@@ -14,7 +14,7 @@ CREATE TABLE provider_subnet (
     CONSTRAINT fk_provider_subnet_subnet_uuid
     FOREIGN KEY (subnet_uuid)
     REFERENCES subnet (uuid)
-);
+) STRICT;
 
 CREATE UNIQUE INDEX idx_provider_subnet_subnet_uuid
 ON provider_subnet (subnet_uuid);
@@ -22,7 +22,7 @@ ON provider_subnet (subnet_uuid);
 CREATE TABLE provider_network (
     uuid TEXT PRIMARY KEY,
     provider_network_id TEXT NOT NULL
-);
+) STRICT;
 
 CREATE UNIQUE INDEX idx_provider_network_id
 ON provider_network (provider_network_id);
@@ -36,12 +36,12 @@ CREATE TABLE provider_network_subnet (
     CONSTRAINT fk_provider_network_subnet_uuid
     FOREIGN KEY (subnet_uuid)
     REFERENCES subnet (uuid)
-);
+) STRICT;
 
 CREATE TABLE availability_zone (
     uuid TEXT PRIMARY KEY,
     name TEXT NOT NULL
-);
+) STRICT;
 
 CREATE UNIQUE INDEX idx_availability_zone_name
 ON availability_zone (name);
@@ -56,4 +56,4 @@ CREATE TABLE availability_zone_subnet (
     CONSTRAINT fk_availability_zone_subnet_uuid
     FOREIGN KEY (subnet_uuid)
     REFERENCES subnet (uuid)
-);
+) STRICT;

--- a/domain/schema/model/sql/0012-blockdevice.sql
+++ b/domain/schema/model/sql/0012-blockdevice.sql
@@ -11,14 +11,14 @@ CREATE TABLE block_device (
     filesystem_type_id INT,
     size_mib INT,
     mount_point TEXT,
-    in_use BOOLEAN,
+    in_use INT,
     CONSTRAINT fk_filesystem_type
     FOREIGN KEY (filesystem_type_id)
     REFERENCES filesystem_type (id),
     CONSTRAINT fk_block_device_machine
     FOREIGN KEY (machine_uuid)
     REFERENCES machine (uuid)
-);
+) STRICT;
 
 CREATE UNIQUE INDEX idx_block_device_name
 ON block_device (machine_uuid, name);
@@ -26,7 +26,7 @@ ON block_device (machine_uuid, name);
 CREATE TABLE filesystem_type (
     id INT PRIMARY KEY,
     name TEXT NOT NULL
-);
+) STRICT;
 
 CREATE UNIQUE INDEX idx_filesystem_type_name
 ON filesystem_type (name);
@@ -49,7 +49,7 @@ CREATE TABLE block_device_link_device (
     FOREIGN KEY (block_device_uuid)
     REFERENCES block_device (uuid),
     PRIMARY KEY (block_device_uuid, name)
-);
+) STRICT;
 
 CREATE UNIQUE INDEX idx_block_device_link_device
 ON block_device_link_device (block_device_uuid, name);

--- a/domain/schema/model/sql/0013-storage.sql
+++ b/domain/schema/model/sql/0013-storage.sql
@@ -8,7 +8,7 @@ CREATE TABLE storage_pool (
     --   - Knowing every possible type up front to populate a look-up or;
     --   - Sourcing the lookup from the provider and keeping it updated. 
     type TEXT NOT NULL
-);
+) STRICT;
 
 CREATE UNIQUE INDEX idx_storage_pool_name
 ON storage_pool (name);
@@ -21,13 +21,13 @@ CREATE TABLE storage_pool_attribute (
     FOREIGN KEY (storage_pool_uuid)
     REFERENCES storage_pool (uuid),
     PRIMARY KEY (storage_pool_uuid, "key")
-);
+) STRICT;
 
 CREATE TABLE storage_kind (
     id INT PRIMARY KEY,
     kind TEXT NOT NULL,
     description TEXT
-);
+) STRICT;
 
 CREATE UNIQUE INDEX idx_storage_kind
 ON storage_kind (kind);
@@ -67,7 +67,7 @@ CREATE TABLE application_storage_directive (
     FOREIGN KEY (charm_uuid, storage_name)
     REFERENCES charm_storage (charm_uuid, name),
     PRIMARY KEY (application_uuid, charm_uuid, storage_name)
-);
+) STRICT;
 
 -- Note that this is not unique; it speeds access by application.
 CREATE INDEX idx_application_storage_directive
@@ -104,7 +104,7 @@ CREATE TABLE unit_storage_directive (
     FOREIGN KEY (charm_uuid, storage_name)
     REFERENCES charm_storage (charm_uuid, name),
     PRIMARY KEY (unit_uuid, charm_uuid, storage_name)
-);
+) STRICT;
 
 -- Note that this is not unique; it speeds access by unit.
 CREATE INDEX idx_unit_storage_directive
@@ -128,7 +128,7 @@ CREATE TABLE storage_instance (
     CONSTRAINT fk_storage_instance_life
     FOREIGN KEY (life_id)
     REFERENCES life (id)
-);
+) STRICT;
 
 -- storage_unit_owner is used to indicate when
 -- a unit is the owner of a storage instance.
@@ -142,7 +142,7 @@ CREATE TABLE storage_unit_owner (
     CONSTRAINT fk_storage_owner_unit
     FOREIGN KEY (unit_uuid)
     REFERENCES unit (uuid)
-);
+) STRICT;
 
 CREATE TABLE storage_attachment (
     storage_instance_uuid TEXT PRIMARY KEY,
@@ -157,7 +157,7 @@ CREATE TABLE storage_attachment (
     CONSTRAINT fk_storage_attachment_life
     FOREIGN KEY (life_id)
     REFERENCES life (id)
-);
+) STRICT;
 
 -- Note that this is not unique; it speeds access by unit.
 CREATE INDEX idx_storage_attachment_unit
@@ -167,7 +167,7 @@ CREATE TABLE storage_provisioning_status (
     id INT PRIMARY KEY,
     name TEXT NOT NULL,
     description TEXT
-);
+) STRICT;
 
 CREATE UNIQUE INDEX idx_storage_provisioning_status
 ON storage_provisioning_status (name);
@@ -186,7 +186,7 @@ CREATE TABLE storage_volume (
     size_mib INT,
     hardware_id TEXT,
     wwn TEXT,
-    persistent BOOLEAN,
+    persistent INT,
     provisioning_status_id INT NOT NULL,
     CONSTRAINT fk_storage_instance_life
     FOREIGN KEY (life_id)
@@ -197,7 +197,7 @@ CREATE TABLE storage_volume (
     CONSTRAINT fk_storage_vol_provisioning_status
     FOREIGN KEY (provisioning_status_id)
     REFERENCES storage_provisioning_status (id)
-);
+) STRICT;
 
 -- An instance can have at most one volume.
 -- A volume can have at most one instance.
@@ -210,7 +210,7 @@ CREATE TABLE storage_instance_volume (
     CONSTRAINT fk_storage_instance_volume_volume
     FOREIGN KEY (storage_volume_uuid)
     REFERENCES storage_volume (uuid)
-);
+) STRICT;
 
 CREATE UNIQUE INDEX idx_storage_instance_volume
 ON storage_instance_volume (storage_volume_uuid);
@@ -221,7 +221,7 @@ CREATE TABLE storage_volume_attachment (
     net_node_uuid TEXT NOT NULL,
     life_id INT NOT NULL,
     block_device_uuid TEXT,
-    read_only BOOLEAN,
+    read_only INT,
     provisioning_status_id INT NOT NULL,
     CONSTRAINT fk_storage_volume_attachment_vol
     FOREIGN KEY (storage_volume_uuid)
@@ -238,7 +238,7 @@ CREATE TABLE storage_volume_attachment (
     CONSTRAINT fk_storage_vol_att_provisioning_status
     FOREIGN KEY (provisioning_status_id)
     REFERENCES storage_provisioning_status (id)
-);
+) STRICT;
 
 CREATE TABLE storage_filesystem (
     uuid TEXT PRIMARY KEY,
@@ -256,7 +256,7 @@ CREATE TABLE storage_filesystem (
     CONSTRAINT fk_storage_fs_provisioning_status
     FOREIGN KEY (provisioning_status_id)
     REFERENCES storage_provisioning_status (id)
-);
+) STRICT;
 
 -- An instance can have at most one filesystem.
 -- A filesystem can have at most one instance.
@@ -269,7 +269,7 @@ CREATE TABLE storage_instance_filesystem (
     CONSTRAINT fk_storage_instance_filesystem_fs
     FOREIGN KEY (storage_filesystem_uuid)
     REFERENCES storage_filesystem (uuid)
-);
+) STRICT;
 
 CREATE UNIQUE INDEX idx_storage_instance_filesystem
 ON storage_instance_filesystem (storage_filesystem_uuid);
@@ -280,7 +280,7 @@ CREATE TABLE storage_filesystem_attachment (
     net_node_uuid TEXT NOT NULL,
     life_id INT NOT NULL,
     mount_point TEXT,
-    read_only BOOLEAN,
+    read_only INT,
     provisioning_status_id INT NOT NULL,
     CONSTRAINT fk_storage_filesystem_attachment_fs
     FOREIGN KEY (storage_filesystem_uuid)
@@ -294,13 +294,13 @@ CREATE TABLE storage_filesystem_attachment (
     CONSTRAINT fk_storage_fs_provisioning_status
     FOREIGN KEY (provisioning_status_id)
     REFERENCES storage_provisioning_status (id)
-);
+) STRICT;
 
 CREATE TABLE storage_volume_device_type (
     id INT PRIMARY KEY,
     name TEXT NOT NULL,
     description TEXT
-);
+) STRICT;
 
 CREATE UNIQUE INDEX idx_storage_volume_dev_type
 ON storage_volume_device_type (name);
@@ -335,7 +335,7 @@ CREATE TABLE storage_volume_attachment_plan (
     CONSTRAINT fk_storage_fs_provisioning_status
     FOREIGN KEY (provisioning_status_id)
     REFERENCES storage_provisioning_status (id)
-);
+) STRICT;
 
 CREATE TABLE storage_volume_attachment_plan_attr (
     uuid TEXT PRIMARY KEY,
@@ -345,7 +345,7 @@ CREATE TABLE storage_volume_attachment_plan_attr (
     CONSTRAINT fk_storage_vol_attach_plan_attr_plan
     FOREIGN KEY (attachment_plan_uuid)
     REFERENCES storage_volume_attachment_plan (attachment_plan_uuid)
-);
+) STRICT;
 
 CREATE UNIQUE INDEX idx_storage_vol_attachment_plan_attr
 ON storage_volume_attachment_plan_attr (attachment_plan_uuid, "key");

--- a/domain/schema/model/sql/0014-secret.sql
+++ b/domain/schema/model/sql/0014-secret.sql
@@ -5,7 +5,7 @@ CREATE TABLE secret_rotate_policy (
     policy TEXT NOT NULL,
     CONSTRAINT chk_empty_policy
     CHECK (policy != '')
-);
+) STRICT;
 
 CREATE UNIQUE INDEX idx_secret_rotate_policy_policy ON secret_rotate_policy (policy);
 
@@ -20,7 +20,7 @@ INSERT INTO secret_rotate_policy VALUES
 
 CREATE TABLE secret (
     id TEXT PRIMARY KEY
-);
+) STRICT;
 
 -- secret_reference stores details about
 -- secrets hosted by another model and
@@ -32,31 +32,31 @@ CREATE TABLE secret_reference (
     CONSTRAINT fk_secret_id
     FOREIGN KEY (secret_id)
     REFERENCES secret (id)
-);
+) STRICT;
 
 CREATE TABLE secret_metadata (
     secret_id TEXT PRIMARY KEY,
     version INT NOT NULL,
     description TEXT,
     rotate_policy_id INT NOT NULL,
-    auto_prune BOOLEAN NOT NULL DEFAULT (FALSE),
-    create_time DATETIME NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW', 'utc')),
-    update_time DATETIME NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW', 'utc')),
+    auto_prune INT NOT NULL DEFAULT (0),
+    create_time TEXT NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW', 'utc')),
+    update_time TEXT NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW', 'utc')),
     CONSTRAINT fk_secret_id
     FOREIGN KEY (secret_id)
     REFERENCES secret (id),
     CONSTRAINT fk_secret_rotate_policy
     FOREIGN KEY (rotate_policy_id)
     REFERENCES secret_rotate_policy (id)
-);
+) STRICT;
 
 CREATE TABLE secret_rotation (
     secret_id TEXT PRIMARY KEY,
-    next_rotation_time DATETIME NOT NULL,
+    next_rotation_time TEXT NOT NULL,
     CONSTRAINT fk_secret_rotation_secret_metadata_id
     FOREIGN KEY (secret_id)
     REFERENCES secret_metadata (secret_id)
-);
+) STRICT;
 
 -- 1:1
 CREATE TABLE secret_value_ref (
@@ -67,7 +67,7 @@ CREATE TABLE secret_value_ref (
     CONSTRAINT fk_secret_value_ref_secret_revision_uuid
     FOREIGN KEY (revision_uuid)
     REFERENCES secret_revision (uuid)
-);
+) STRICT;
 
 -- 1:many
 CREATE TABLE secret_content (
@@ -83,7 +83,7 @@ CREATE TABLE secret_content (
     CONSTRAINT fk_secret_content_secret_revision_uuid
     FOREIGN KEY (revision_uuid)
     REFERENCES secret_revision (uuid)
-);
+) STRICT;
 
 CREATE INDEX idx_secret_content_revision_uuid ON secret_content (revision_uuid);
 
@@ -91,32 +91,32 @@ CREATE TABLE secret_revision (
     uuid TEXT PRIMARY KEY,
     secret_id TEXT NOT NULL,
     revision INT NOT NULL,
-    create_time DATETIME NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW', 'utc')),
+    create_time TEXT NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW', 'utc')),
     CONSTRAINT fk_secret_revision_secret_metadata_id
     FOREIGN KEY (secret_id)
     REFERENCES secret_metadata (secret_id)
-);
+) STRICT;
 
 CREATE UNIQUE INDEX idx_secret_revision_secret_id_revision ON secret_revision (secret_id, revision);
 
 CREATE TABLE secret_revision_obsolete (
     revision_uuid TEXT PRIMARY KEY,
-    obsolete BOOLEAN NOT NULL DEFAULT (FALSE),
+    obsolete INT NOT NULL DEFAULT (0),
     -- pending_delete is true if the revision is to be deleted.
     -- It will not be drained to a new active backend.
-    pending_delete BOOLEAN NOT NULL DEFAULT (FALSE),
+    pending_delete INT NOT NULL DEFAULT (0),
     CONSTRAINT fk_secret_revision_obsolete_revision_uuid
     FOREIGN KEY (revision_uuid)
     REFERENCES secret_revision (uuid)
-);
+) STRICT;
 
 CREATE TABLE secret_revision_expire (
     revision_uuid TEXT PRIMARY KEY,
-    expire_time DATETIME NOT NULL,
+    expire_time TEXT NOT NULL,
     CONSTRAINT fk_secret_revision_expire_revision_uuid
     FOREIGN KEY (revision_uuid)
     REFERENCES secret_revision (uuid)
-);
+) STRICT;
 
 CREATE TABLE secret_application_owner (
     secret_id TEXT NOT NULL,
@@ -129,7 +129,7 @@ CREATE TABLE secret_application_owner (
     FOREIGN KEY (application_uuid)
     REFERENCES application (uuid),
     PRIMARY KEY (secret_id, application_uuid)
-);
+) STRICT;
 
 CREATE INDEX idx_secret_application_owner_secret_id ON secret_application_owner (secret_id);
 -- We need to ensure the label is unique per the application.
@@ -146,7 +146,7 @@ CREATE TABLE secret_unit_owner (
     FOREIGN KEY (unit_uuid)
     REFERENCES unit (uuid),
     PRIMARY KEY (secret_id, unit_uuid)
-);
+) STRICT;
 
 CREATE INDEX idx_secret_unit_owner_secret_id ON secret_unit_owner (secret_id);
 -- We need to ensure the label is unique per unit.
@@ -158,7 +158,7 @@ CREATE TABLE secret_model_owner (
     CONSTRAINT fk_secret_model_owner_secret_metadata_id
     FOREIGN KEY (secret_id)
     REFERENCES secret_metadata (secret_id)
-);
+) STRICT;
 
 CREATE UNIQUE INDEX idx_secret_model_owner_label ON secret_model_owner (label) WHERE label != '';
 
@@ -176,7 +176,7 @@ CREATE TABLE secret_unit_consumer (
     CONSTRAINT fk_secret_unit_consumer_secret_id
     FOREIGN KEY (secret_id)
     REFERENCES secret (id)
-);
+) STRICT;
 
 CREATE UNIQUE INDEX idx_secret_unit_consumer_secret_id_unit_uuid ON secret_unit_consumer (secret_id, unit_uuid);
 CREATE UNIQUE INDEX idx_secret_unit_consumer_label ON secret_unit_consumer (label, unit_uuid) WHERE label != '';
@@ -192,14 +192,14 @@ CREATE TABLE secret_remote_unit_consumer (
     CONSTRAINT fk_secret_remote_unit_consumer_secret_metadata_id
     FOREIGN KEY (secret_id)
     REFERENCES secret_metadata (secret_id)
-);
+) STRICT;
 
 CREATE UNIQUE INDEX idx_secret_remote_unit_consumer_secret_id_unit_id ON secret_remote_unit_consumer (secret_id, unit_id);
 
 CREATE TABLE secret_role (
     id INT PRIMARY KEY,
     role TEXT
-);
+) STRICT;
 
 CREATE UNIQUE INDEX idx_secret_role_role ON secret_role (role);
 
@@ -211,7 +211,7 @@ INSERT INTO secret_role VALUES
 CREATE TABLE secret_grant_subject_type (
     id INT PRIMARY KEY,
     type TEXT
-);
+) STRICT;
 
 INSERT INTO secret_grant_subject_type VALUES
 (0, 'unit'),
@@ -222,7 +222,7 @@ INSERT INTO secret_grant_subject_type VALUES
 CREATE TABLE secret_grant_scope_type (
     id INT PRIMARY KEY,
     type TEXT
-);
+) STRICT;
 
 INSERT INTO secret_grant_scope_type VALUES
 (0, 'unit'),
@@ -261,7 +261,7 @@ CREATE TABLE secret_permission (
     CONSTRAINT fk_secret_permission_secret_grant_scope_type_id
     FOREIGN KEY (scope_type_id)
     REFERENCES secret_grant_scope_type (id)
-);
+) STRICT;
 
 CREATE INDEX idx_secret_permission_secret_id ON secret_permission (secret_id);
 CREATE INDEX idx_secret_permission_subject_uuid_subject_type_id ON secret_permission (subject_uuid, subject_type_id);

--- a/domain/schema/model/sql/0015-annotations.sql
+++ b/domain/schema/model/sql/0015-annotations.sql
@@ -1,7 +1,7 @@
 CREATE TABLE annotation_model (
     "key" TEXT PRIMARY KEY,
     value TEXT NOT NULL
-);
+) STRICT;
 
 CREATE TABLE annotation_application (
     uuid TEXT NOT NULL,
@@ -13,7 +13,7 @@ CREATE TABLE annotation_application (
     -- CONSTRAINT          fk_annotation_application
     --     FOREIGN KEY     (uuid)
     --     REFERENCES      application(uuid)
-);
+) STRICT;
 
 CREATE TABLE annotation_charm (
     uuid TEXT NOT NULL,
@@ -25,7 +25,7 @@ CREATE TABLE annotation_charm (
     -- CONSTRAINT          fk_annotation_charm
     --     FOREIGN KEY     (uuid)
     --     REFERENCES      charm(uuid)
-);
+) STRICT;
 
 CREATE TABLE annotation_machine (
     uuid TEXT NOT NULL,
@@ -37,7 +37,7 @@ CREATE TABLE annotation_machine (
     -- CONSTRAINT          fk_annotation_machine
     --     FOREIGN KEY     (uuid)
     --     REFERENCES      machine(uuid)
-);
+) STRICT;
 
 CREATE TABLE annotation_unit (
     uuid TEXT NOT NULL,
@@ -49,7 +49,7 @@ CREATE TABLE annotation_unit (
     -- CONSTRAINT          fk_annotation_unit
     --     FOREIGN KEY     (uuid)
     --     REFERENCES      unit(uuid)
-);
+) STRICT;
 
 CREATE TABLE annotation_storage_instance (
     uuid TEXT NOT NULL,
@@ -61,7 +61,7 @@ CREATE TABLE annotation_storage_instance (
     -- CONSTRAINT          fk_annotation_storage_instance
     --     FOREIGN KEY     (uuid)
     --     REFERENCES      storage_instance(uuid)
-);
+) STRICT;
 
 CREATE TABLE annotation_storage_volume (
     uuid TEXT NOT NULL,
@@ -73,7 +73,7 @@ CREATE TABLE annotation_storage_volume (
     -- CONSTRAINT          fk_annotation_storage_volume
     --     FOREIGN KEY     (uuid)
     --     REFERENCES      storage_volume(uuid)
-);
+) STRICT;
 
 CREATE TABLE annotation_storage_filesystem (
     uuid TEXT NOT NULL,
@@ -85,4 +85,4 @@ CREATE TABLE annotation_storage_filesystem (
     -- CONSTRAINT          fk_annotation_storage_filesystem
     --     FOREIGN KEY     (uuid)
     --     REFERENCES      storage_filesystem(uuid)
-);
+) STRICT;

--- a/domain/schema/model/sql/0016-instance-data.sql
+++ b/domain/schema/model/sql/0016-instance-data.sql
@@ -16,7 +16,7 @@ CREATE TABLE instance_data (
     CONSTRAINT fk_availability_zone_availability_zone_uuid
     FOREIGN KEY (availability_zone_uuid)
     REFERENCES availability_zone (uuid)
-);
+) STRICT;
 
 CREATE TABLE instance_tag (
     machine_uuid TEXT NOT NULL,
@@ -25,7 +25,7 @@ CREATE TABLE instance_tag (
     CONSTRAINT fk_machine_machine_uuid
     FOREIGN KEY (machine_uuid)
     REFERENCES machine (uuid)
-);
+) STRICT;
 
 CREATE TABLE machine_lxd_profile (
     machine_uuid TEXT NOT NULL,
@@ -37,4 +37,4 @@ CREATE TABLE machine_lxd_profile (
     CONSTRAINT fk_machine_machine_uuid
     FOREIGN KEY (machine_uuid)
     REFERENCES machine (uuid)
-);
+) STRICT;

--- a/domain/schema/model/sql/0017-constraint.sql
+++ b/domain/schema/model/sql/0017-constraint.sql
@@ -10,12 +10,12 @@ CREATE TABLE "constraint" (
     instance_type TEXT,
     container_type_id INT,
     virt_type TEXT,
-    allocate_public_ip BOOLEAN,
+    allocate_public_ip INT,
     image_id TEXT,
     CONSTRAINT fk_constraint_container_type
     FOREIGN KEY (container_type_id)
     REFERENCES container_type (id)
-);
+) STRICT;
 
 CREATE TABLE constraint_tag (
     constraint_uuid TEXT NOT NULL,
@@ -24,12 +24,12 @@ CREATE TABLE constraint_tag (
     FOREIGN KEY (constraint_uuid)
     REFERENCES "constraint" (uuid),
     PRIMARY KEY (constraint_uuid, tag)
-);
+) STRICT;
 
 CREATE TABLE constraint_space (
     constraint_uuid TEXT NOT NULL,
     space TEXT NOT NULL,
-    "exclude" BOOLEAN,
+    "exclude" INT,
     CONSTRAINT fk_constraint_space_constraint
     FOREIGN KEY (constraint_uuid)
     REFERENCES "constraint" (uuid),
@@ -37,7 +37,7 @@ CREATE TABLE constraint_space (
     FOREIGN KEY (space)
     REFERENCES space (name),
     PRIMARY KEY (constraint_uuid, space)
-);
+) STRICT;
 
 CREATE TABLE constraint_zone (
     constraint_uuid TEXT NOT NULL,
@@ -46,4 +46,4 @@ CREATE TABLE constraint_zone (
     FOREIGN KEY (constraint_uuid)
     REFERENCES "constraint" (uuid),
     PRIMARY KEY (constraint_uuid, zone)
-);
+) STRICT;

--- a/domain/schema/model/sql/0018-machine.sql
+++ b/domain/schema/model/sql/0018-machine.sql
@@ -6,19 +6,19 @@ CREATE TABLE machine (
     base TEXT,
     nonce TEXT,
     password_hash TEXT,
-    clean BOOLEAN,
-    force_destroyed BOOLEAN,
+    clean INT,
+    force_destroyed INT,
     placement TEXT,
-    agent_started_at DATETIME,
+    agent_started_at TEXT,
     hostname TEXT,
-    is_controller BOOLEAN,
+    is_controller INT,
     CONSTRAINT fk_machine_net_node
     FOREIGN KEY (net_node_uuid)
     REFERENCES net_node (uuid),
     CONSTRAINT fk_machine_life
     FOREIGN KEY (life_id)
     REFERENCES life (id)
-);
+) STRICT;
 
 CREATE UNIQUE INDEX idx_machine_id
 ON machine (machine_id);
@@ -35,7 +35,7 @@ CREATE TABLE machine_constraint (
     CONSTRAINT fk_machine_constraint_constraint
     FOREIGN KEY (constraint_uuid)
     REFERENCES "constraint" (uuid)
-);
+) STRICT;
 
 CREATE TABLE machine_tool (
     machine_uuid TEXT NOT NULL,
@@ -47,7 +47,7 @@ CREATE TABLE machine_tool (
     FOREIGN KEY (machine_uuid)
     REFERENCES machine (uuid),
     PRIMARY KEY (machine_uuid, tool_url)
-);
+) STRICT;
 
 CREATE TABLE machine_volume (
     machine_uuid TEXT NOT NULL,
@@ -59,7 +59,7 @@ CREATE TABLE machine_volume (
     FOREIGN KEY (volume_uuid)
     REFERENCES storage_volume (uuid),
     PRIMARY KEY (machine_uuid, volume_uuid)
-);
+) STRICT;
 
 CREATE TABLE machine_filesystem (
     machine_uuid TEXT NOT NULL,
@@ -71,4 +71,4 @@ CREATE TABLE machine_filesystem (
     FOREIGN KEY (filesystem_uuid)
     REFERENCES storage_filesystem (uuid),
     PRIMARY KEY (machine_uuid, filesystem_uuid)
-);
+) STRICT;


### PR DESCRIPTION
SQLite by default uses dynamic untyped columns. There is no validation of columns on the way in or out. The proposal is to enable strict tables which will help with locating potential failures with DDL and statement queries.

All DATETIME and TIMESTAMP columns become TEXT. Then BOOLEAN becomes INT (represented as 0 or 1).

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

This hopefully shouldn't cause any issues, but in any case, a set of regression steps should be done:

```
$ juju bootstrap lxd test
$ juju add-model default
$ juju deploy ubuntu
```

## Links


**Jira card:** [JUJU-6163](https://warthogs.atlassian.net/browse/JUJU-6163)



[JUJU-6163]: https://warthogs.atlassian.net/browse/JUJU-6163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ