### PR TITLE
fix: panic during login to migrated model with non-user login

### DIFF
--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -313,8 +313,10 @@ func (a *admin) authenticate(ctx context.Context, req params.LoginRequest) (*aut
 			startPinger = false
 			controllerConn = true
 		}
-	} else if a.root.model == nil {
-		// Anonymous login to unknown model.
+	}
+	if a.root.model == nil {
+		// Login to an unknown or migrated model.
+		// See maybeEmitRedirectError for user logins who are redirected.
 		// Hide the fact that the model does not exist.
 		return nil, errors.Unauthorizedf("invalid entity name or password")
 	}


### PR DESCRIPTION
This PR fixes a panic when a non-anonymous login to a migrated model.
The original code tries to login the ob-server with nil model which should not be allowed.


## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

This was caused by a JaaS [bug](https://bugs.launchpad.net/juju/+bug/2068613) which is not very easy to reproduce.

## Documentation changes

No

## Links


**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2068613

**Jira card:** JUJU-6164

