### PR TITLE
fix(refresh): uniter avoid fetching charm before retrieving sha

### DIFF
--- a/worker/uniter/charm/bundles.go
+++ b/worker/uniter/charm/bundles.go
@@ -72,6 +72,12 @@ func (d *BundlesDir) download(info BundleInfo, target string, abort <-chan struc
 	if err != nil {
 		return errors.Annotatef(err, "failed to get archive sha256 for charm %q", info.URL())
 	}
+	// If the expected sha256 is empty, it means the controller hasn't
+	// downloaded the charm yet.
+	if expectedSha256 == "" {
+		d.logger.Debugf("controller haven't downloaded the charm yet, waiting")
+		return errors.NotYetAvailable
+	}
 	req := downloader.Request{
 		ArchiveSha256: expectedSha256,
 		URL:           curl,

--- a/worker/uniter/charm/manifest_deployer.go
+++ b/worker/uniter/charm/manifest_deployer.go
@@ -259,7 +259,7 @@ func (rbr RetryingBundleReader) Read(bi BundleInfo, abort <-chan struct{}) (Bund
 			return nil
 		},
 		IsFatalError: func(err error) bool {
-			return err != nil && !errors.IsNotYetAvailable(err)
+			return err != nil && !errors.Is(err, errors.NotYetAvailable)
 		},
 	})
 


### PR DESCRIPTION
https://bugs.launchpad.net/juju/+bug/2053242 reports that they see (a self resolving) error in refresh that's caused by a race between the uniter and the controller. Apparently it's causing some automated test failures (and freaking out new users). Essentially the issue is that the uniter tries to fetch the charm before the controller has downloaded it.

The error that they're reporting (with Juju 3.1) is not exactly the same with what I observe when I reproduce (with Juju 3.4).

> ```juju.worker.dependency "uniter" manifold worker returned unexpected error: preparing operation "upgrade to ch:amd64/jammy/zookeeper-121" for zookeeper/0: failed to download charm "ch:amd64/jammy/zookeeper-121" from API server: Get https://10.178.146.204:17070/model/de79be2c-6cc3-4401-8d85-2a27c9c80c7e/charms?file=%2A&url=ch%3Aamd64%2Fjammy%2Fzookeeper-121: cannot retrieve charm: ch:amd64/jammy/zookeeper-121```

What I'm seeing is:

> ```unit-zookeeper-1: 00:28:40 ERROR juju.worker.uniter resolver loop error: preparing operation "upgrade to ch:amd64/jammy/zookeeper-134" for zookeeper/1: failed to download charm "ch:amd64/jammy/zookeeper-134" from API server: download request with archiveSha256 length 0 not valid```

This change fixes the error that I see. 

By having the downloader in the uniter to return `NotYetAvailable` (to the retrying reader) whenever it sees an empty (`""`) sha for the charm returned from the API, because it means that the controller hasn't got the archive yet.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- ~[ ] Go unit tests, with comments saying what you're testing~
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Bootstrap with this change, and deploy `zookeeper revision 114`.
```
 $ juju bootstrap deleteme
 $ juju add-model test
 $ juju deploy zookeeper --channel 3/edge --revision 114 # it's an older revision, we'll refresh it 
```

Watch this settling down on the side: 
```
 $ watch -n1 --color juju status --color
```

While waiting for that, change the logging to debug on the model and fire up a debug-log on the side:
```
 $ juju model-config logging-config="<root>=DEBUG"
 $ juju debug-log
```

After the zookeeper settles, refresh it.
```
 $ juju refresh zookeeper
Added charm-hub charm "zookeeper", revision 134 in channel 3/edge, to the model
no change to endpoints in space "alpha": certificates, cluster, cos-agent, restart, upgrade, zookeeper
```

Take a look at the debug-log output. Without this change, you'll see the error above in the description. 

With this change, 1) you shouldn't see the error, 2) you may see some of these:

```
unit-zookeeper-0: 01:05:41 DEBUG juju.worker.uniter.charm controller haven't downloaded the charm yet, waiting
```

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2053242

**Jira card:** JUJU-6136

