### PR TITLE
style(sqlair): use SQLair in autocert domain

### DIFF
--- a/domain/autocert/doc.go
+++ b/domain/autocert/doc.go
@@ -1,0 +1,7 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package autocert provides the autocert cache service. This cache can be used
+// by the package golang.org/x/crypto/acme/autocert to cache TLS certificates.
+
+package autocert

--- a/domain/autocert/state/types.go
+++ b/domain/autocert/state/types.go
@@ -1,0 +1,20 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+// dbAutocert is a named certificate to be stored in the database.
+type dbAutocert struct {
+	// UUID is the uuid of the autocert.
+	UUID string `db:"uuid"`
+
+	// Name is the autocert name. It uniquely identifies the certificate.
+	Name string `db:"name"`
+
+	// Data represents the binary (encoded) contents of the autocert.
+	Data string `db:"data"`
+
+	// Encoding is the autocert cache encoding id from the
+	// autocert_cache_encoding table.
+	Encoding int `db:"encoding"`
+}


### PR DESCRIPTION
<!-- Why this change is needed and what it does. -->
As part of the push to use SQLair everywhere in domain, this PR removes all StdTxn from the autocert domain and replaces them with Txn.

All db errors are wrapped with domain.CoerceErr.

I have also added a doc.go to the domain since I did not know what it did and had to ask.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
~~- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~~
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

`TEST_PACKAGES="./domain/autocert/state/... -count=1 " TEST_FILTER="Suite" make run-go-tests`

## Documentation changes
Added doc.go to package

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Jira card:** [JUJU-5628](https://warthogs.atlassian.net/browse/JUJU-5628)



[JUJU-5628]: https://warthogs.atlassian.net/browse/JUJU-5628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ