### PR TITLE
style(sqlair): use SQLair in controllernode domain

### DIFF
--- a/domain/controllernode/doc.go
+++ b/domain/controllernode/doc.go
@@ -1,0 +1,8 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package controllernode provides the service that keeps track of controller
+// nodes. This is needed when the controller is in high availability mode and
+// has multiple communicating instances. It is primarily used to keep track of
+// the DQLite nodes located in each controller.
+package controllernode

--- a/domain/controllernode/state/types.go
+++ b/domain/controllernode/state/types.go
@@ -1,0 +1,21 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+// dbControllerNode is the database representation of a controller node.
+type dbControllerNode struct {
+	// ControllerID is the nodes controller ID.
+	ControllerID string `db:"controller_id"`
+
+	// DQLiteNodeID is the uint64 from Dqlite NodeInfo, stored as text (due to
+	// db issues when the high bit is set).
+	DQLiteNodeID string `db:"dqlite_node_id"`
+
+	// BindAddress is the IP address (no port) that Dqlite is bound to.
+	BindAddress string `db:"bind_address"`
+}
+
+type dbNamespace struct {
+	Namespace string `db:"namespace"`
+}

--- a/internal/worker/dbaccessor/worker_test.go
+++ b/internal/worker/dbaccessor/worker_test.go
@@ -550,7 +550,7 @@ func (s *workerSuite) setupMocks(c *gc.C) *gomock.Controller {
 // The Kill expectation is soft, because this can be done via parent catacomb,
 // rather than a direct call.
 func (s *workerSuite) expectTrackedDBUpdateNodeAndKill(done chan struct{}) {
-	s.trackedDB.EXPECT().StdTxn(gomock.Any(), gomock.Any())
+	s.trackedDB.EXPECT().Txn(gomock.Any(), gomock.Any())
 	s.trackedDB.EXPECT().Kill().AnyTimes()
 	s.trackedDB.EXPECT().Wait().DoAndReturn(func() error {
 		<-done


### PR DESCRIPTION
<!-- Why this change is needed and what it does. -->
As part of the push to use SQLair everywhere in domain, this PR removes all StdTxn from the controllernode domain and replaces them with Txn.

Also add a doc.go
## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
~~- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~~
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps
```
TEST_PACKAGES="./domain/controllernode/state/... -count=1 " TEST_FILTER="Suite" make run-go-tests
```
<!-- Describe steps to verify that the change works. -->

## Documentation changes
Added doc.go to controllernode domain
<!-- How it affects user workflow (CLI or API). -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Jira card:** [JUJU-5628](https://warthogs.atlassian.net/browse/JUJU-5628)



[JUJU-5628]: https://warthogs.atlassian.net/browse/JUJU-5628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ