### PR TITLE
fix(migrate): Migrate from 3.6/edge -> 4.0

### DIFF
--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         # TODO: add microk8s tests
         cloud: ["lxd"]
-        channel: ["local", "3.5/stable"]
+        channel: ["local", "3.6/edge"]
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
3.6 will be our intended LTS, to ensure that we can migrate away from that version juju, move our github action from 3.5/stable to 3.6/edge. Ensuring that we catch our errors early, before it is released.

We can add a 3.5/stable test later if we want to also allow 3.5 to be able to migrate. Currently this is blocked because we've not got an intersection of facade versions. Moving from series to bases forced us to move the lower watermark to drop support for it.

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Github action tests

## QA steps

Ensure that all the github actions pass.


## Links

**Jira card:** JUJU-

