### PR TITLE
fix(db): Dqlite HA: too many colons in address

### DIFF
--- a/database/node.go
+++ b/database/node.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
-	"fmt"
 	"io"
 	"net"
 	"os"
@@ -322,7 +321,7 @@ func (m *NodeManager) WithTLSOption() (app.Option, error) {
 // Dqlite as the member of a cluster with peers representing other controllers.
 func (m *NodeManager) WithClusterOption(addrs []string) app.Option {
 	peerAddrs := transform.Slice(addrs, func(addr string) string {
-		return fmt.Sprintf("%s:%d", addr, m.port)
+		return net.JoinHostPort(addr, strconv.Itoa(m.port))
 	})
 
 	m.logger.Debugf("determined Dqlite cluster members: %v", peerAddrs)

--- a/database/node_test.go
+++ b/database/node_test.go
@@ -339,11 +339,22 @@ func (s *nodeManagerSuite) TestWithTLSOptionSuccess(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *nodeManagerSuite) TestWithClusterOptionSuccess(c *gc.C) {
+func (s *nodeManagerSuite) TestWithClusterOptionIPv4Success(c *gc.C) {
 	cfg := fakeAgentConfig{}
 	m := NewNodeManager(cfg, true, stubLogger{}, coredatabase.NoopSlowQueryLogger{})
 
 	dqliteApp, err := app.New(c.MkDir(), m.WithClusterOption([]string{"10.6.6.6"}))
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = dqliteApp.Close()
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *nodeManagerSuite) TestWithClusterOptionIPv6Success(c *gc.C) {
+	cfg := fakeAgentConfig{}
+	m := NewNodeManager(cfg, true, stubLogger{}, coredatabase.NoopSlowQueryLogger{})
+
+	dqliteApp, err := app.New(c.MkDir(), m.WithClusterOption([]string{"::1"}))
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = dqliteApp.Close()


### PR DESCRIPTION
If mongodb returns an IPv6 address when clustering, then dqlite will bork on attempting to serialise the address and port. All IPv6 should be included in a `[]`.

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
$ juju bootstrap lxd test
$ juju enable-ha
$ juju add-model default
$ juju deploy ubuntu
```

Check the logs to ensure that we don't have any warnings.


## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** [https://bugs.launchpad.net/juju/+bug/2069168](https://bugs.launchpad.net/juju/+bug/2069168)

**Jira card:** [JUJU-6166](https://warthogs.atlassian.net/browse/JUJU-6166)



[JUJU-6166]: https://warthogs.atlassian.net/browse/JUJU-6166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ