### PR TITLE
fix(upgrade): noble upgrade support

### DIFF
--- a/apiserver/facades/client/modelupgrader/upgrader_test.go
+++ b/apiserver/facades/client/modelupgrader/upgrader_test.go
@@ -42,7 +42,8 @@ var winVersions = []string{
 	"win2016", "win2016hv", "win2019", "win7", "win8", "win81", "win10",
 }
 
-var ubuntuVersions = []string{
+// unsupportedUbuntuVersions are the ubuntu versions that juju does not support.
+var unsupportedUbuntuVersions = []string{
 	"12.04",
 	"12.10",
 	"13.04",
@@ -65,7 +66,6 @@ var ubuntuVersions = []string{
 	"22.10",
 	"23.04",
 	"23.10",
-	"24.04",
 }
 
 var controllerCfg = controller.Config{
@@ -257,7 +257,7 @@ func (s *modelUpgradeSuite) assertUpgradeModelForControllerModelJuju3(c *gc.C, d
 	// - check if the model has win machines;
 	ctrlState.EXPECT().MachineCountForBase(makeBases("windows", winVersions)).Return(nil, nil)
 	// - check if the model has deprecated ubuntu machines;
-	ctrlState.EXPECT().MachineCountForBase(makeBases("ubuntu", ubuntuVersions)).Return(nil, nil)
+	ctrlState.EXPECT().MachineCountForBase(makeBases("ubuntu", unsupportedUbuntuVersions)).Return(nil, nil)
 	// - check LXD version.
 	// - check if model has charm store charms;
 	ctrlState.EXPECT().AllCharmURLs().Return(nil, errors.NotFoundf("charms"))
@@ -277,7 +277,7 @@ func (s *modelUpgradeSuite) assertUpgradeModelForControllerModelJuju3(c *gc.C, d
 	// - check if the model has win machines;
 	state1.EXPECT().MachineCountForBase(makeBases("windows", winVersions)).Return(nil, nil)
 	// - check if the model has deprecated ubuntu machines;
-	state1.EXPECT().MachineCountForBase(makeBases("ubuntu", ubuntuVersions)).Return(nil, nil)
+	state1.EXPECT().MachineCountForBase(makeBases("ubuntu", unsupportedUbuntuVersions)).Return(nil, nil)
 	// - check if model has charm store charms;
 	state1.EXPECT().AllCharmURLs().Return(nil, errors.NotFoundf("charms"))
 	// - check LXD version.
@@ -383,7 +383,7 @@ func (s *modelUpgradeSuite) TestUpgradeModelForControllerDyingHostedModelJuju3(c
 	// - check if the model has win machines;
 	ctrlState.EXPECT().MachineCountForBase(makeBases("windows", winVersions)).Return(nil, nil)
 	// - check if the model has deprecated ubuntu machines;
-	ctrlState.EXPECT().MachineCountForBase(makeBases("ubuntu", ubuntuVersions)).Return(nil, nil)
+	ctrlState.EXPECT().MachineCountForBase(makeBases("ubuntu", unsupportedUbuntuVersions)).Return(nil, nil)
 	// - check LXD version.
 	// - check if model has charm store charms;
 	ctrlState.EXPECT().AllCharmURLs().Return(nil, errors.NotFoundf("charms"))
@@ -488,7 +488,7 @@ func (s *modelUpgradeSuite) TestUpgradeModelForControllerModelJuju3Failed(c *gc.
 	// - check if the model has win machines;
 	ctrlState.EXPECT().MachineCountForBase(makeBases("windows", winVersions)).Return(map[string]int{"win10": 1, "win7": 2}, nil)
 	// - check if the model has deprecated ubuntu machines;
-	ctrlState.EXPECT().MachineCountForBase(makeBases("ubuntu", ubuntuVersions)).Return(map[string]int{"xenial": 2}, nil)
+	ctrlState.EXPECT().MachineCountForBase(makeBases("ubuntu", unsupportedUbuntuVersions)).Return(map[string]int{"xenial": 2}, nil)
 	// - check if model has charm store charms;
 	ctrlState.EXPECT().AllCharmURLs().Return(nil, errors.NotFoundf("charms"))
 	// - check LXD version.
@@ -509,7 +509,7 @@ func (s *modelUpgradeSuite) TestUpgradeModelForControllerModelJuju3Failed(c *gc.
 	// - check if the model has win machines;
 	state1.EXPECT().MachineCountForBase(makeBases("windows", winVersions)).Return(map[string]int{"win10": 1, "win7": 3}, nil)
 	// - check if the model has deprecated ubuntu machines;
-	state1.EXPECT().MachineCountForBase(makeBases("ubuntu", ubuntuVersions)).Return(map[string]int{
+	state1.EXPECT().MachineCountForBase(makeBases("ubuntu", unsupportedUbuntuVersions)).Return(map[string]int{
 		"artful": 1, "cosmic": 2, "disco": 3, "eoan": 4, "groovy": 5,
 		"hirsute": 6, "impish": 7, "precise": 8, "quantal": 9, "raring": 10,
 		"saucy": 11, "trusty": 12, "utopic": 13, "vivid": 14, "wily": 15,
@@ -597,7 +597,7 @@ func (s *modelUpgradeSuite) assertUpgradeModelJuju3(c *gc.C, ctrlModelVers strin
 	// - check if the model has win machines;
 	st.EXPECT().MachineCountForBase(makeBases("windows", winVersions)).Return(nil, nil)
 	// - check if the model has deprecated ubuntu machines;
-	st.EXPECT().MachineCountForBase(makeBases("ubuntu", ubuntuVersions)).Return(nil, nil)
+	st.EXPECT().MachineCountForBase(makeBases("ubuntu", unsupportedUbuntuVersions)).Return(nil, nil)
 	// - check LXD version.
 	serverFactory.EXPECT().RemoteServer(s.cloudSpec).Return(server, nil)
 	server.EXPECT().ServerVersion().Return("5.2")
@@ -678,7 +678,7 @@ func (s *modelUpgradeSuite) TestUpgradeModelJuju3Failed(c *gc.C) {
 	// - check if the model has win machines;
 	st.EXPECT().MachineCountForBase(makeBases("windows", winVersions)).Return(map[string]int{"win10": 1, "win7": 3}, nil)
 	// - check if the model has deprecated ubuntu machines;
-	st.EXPECT().MachineCountForBase(makeBases("ubuntu", ubuntuVersions)).Return(map[string]int{
+	st.EXPECT().MachineCountForBase(makeBases("ubuntu", unsupportedUbuntuVersions)).Return(map[string]int{
 		"artful": 1, "cosmic": 2, "disco": 3, "eoan": 4, "groovy": 5,
 		"hirsute": 6, "impish": 7, "precise": 8, "quantal": 9, "raring": 10,
 		"saucy": 11, "trusty": 12, "utopic": 13, "vivid": 14, "wily": 15,

--- a/cmd/juju/application/deployer/bundlehandler_test.go
+++ b/cmd/juju/application/deployer/bundlehandler_test.go
@@ -267,8 +267,8 @@ func (s *BundleDeployRepositorySuite) TestDeployKubernetesBundleSuccess(c *gc.C)
 	s.expectEmptyModelToStart(c)
 	s.expectWatchAll()
 
-	mariadbCurl := charm.MustParseURL("ch:jammy/mariadb-k8s")
-	gitlabCurl := charm.MustParseURL("ch:jammy/gitlab-k8s")
+	mariadbCurl := charm.MustParseURL("ch:noble/mariadb-k8s")
+	gitlabCurl := charm.MustParseURL("ch:noble/gitlab-k8s")
 	chUnits := []charmUnit{
 		{
 			charmMetaSeries:      []string{"kubernetes"},
@@ -287,8 +287,8 @@ func (s *BundleDeployRepositorySuite) TestDeployKubernetesBundleSuccess(c *gc.C)
 	s.runDeploy(c, kubernetesGitlabBundle)
 
 	c.Assert(s.deployArgs, gc.HasLen, 2)
-	s.assertDeployArgs(c, gitlabCurl.String(), "gitlab", "ubuntu", "22.04")
-	s.assertDeployArgs(c, mariadbCurl.String(), "mariadb", "ubuntu", "22.04")
+	s.assertDeployArgs(c, gitlabCurl.String(), "gitlab", "ubuntu", "24.04")
+	s.assertDeployArgs(c, mariadbCurl.String(), "mariadb", "ubuntu", "24.04")
 	s.assertDeployArgsStorage(c, "mariadb", map[string]storage.Constraints{"database": {Pool: "mariadb-pv", Size: 0x14, Count: 0x1}})
 	s.assertDeployArgsConfig(c, "mariadb", map[string]interface{}{"dataset-size": "70%"})
 
@@ -1256,7 +1256,7 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleUnitPlacedInApplication(c 
 	s.expectWatchAll()
 	s.expectResolveCharm(nil)
 
-	wordpressCurl := charm.MustParseURL("ch:jammy/wordpress")
+	wordpressCurl := charm.MustParseURL("ch:noble/wordpress")
 	s.expectResolveCharm(nil)
 	charmInfo := &apicharms.CharmInfo{
 		Revision: wordpressCurl.Revision,
@@ -1277,7 +1277,7 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleUnitPlacedInApplication(c 
 		{Entity: &params.UnitInfo{Name: "wordpress/1", MachineId: "1"}},
 	}, nil)
 
-	djangoCurl := charm.MustParseURL("ch:jammy/django")
+	djangoCurl := charm.MustParseURL("ch:noble/django")
 	s.expectResolveCharm(nil)
 	charmInfo2 := &apicharms.CharmInfo{
 		Revision: djangoCurl.Revision,
@@ -1327,7 +1327,7 @@ func (s *BundleDeployRepositorySuite) TestDeployBundlePeerContainer(c *gc.C) {
 	s.expectAddContainer("0", "0/lxd/1", "", "lxd")
 	s.expectAddContainer("1", "1/lxd/1", "", "lxd")
 
-	wordpressCurl := charm.MustParseURL("ch:jammy/wordpress")
+	wordpressCurl := charm.MustParseURL("ch:noble/wordpress")
 	s.expectResolveCharm(nil)
 	charmInfo := &apicharms.CharmInfo{
 		URL: wordpressCurl.String(),
@@ -1341,7 +1341,7 @@ func (s *BundleDeployRepositorySuite) TestDeployBundlePeerContainer(c *gc.C) {
 	s.expectAddOneUnit("wordpress", "0/lxd/0", "0")
 	s.expectAddOneUnit("wordpress", "1/lxd/0", "1")
 
-	djangoCurl := charm.MustParseURL("ch:jammy/django")
+	djangoCurl := charm.MustParseURL("ch:noble/django")
 	s.expectResolveCharm(nil)
 	charmInfo2 := &apicharms.CharmInfo{
 		URL: djangoCurl.String(),
@@ -1543,8 +1543,8 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleAnnotations(c *gc.C) {
 	s.expectEmptyModelToStart(c)
 	s.expectWatchAll()
 
-	djangoCurl := charm.MustParseURL("ch:jammy/django")
-	memCurl := charm.MustParseURL("ch:jammy/mem")
+	djangoCurl := charm.MustParseURL("ch:noble/django")
+	memCurl := charm.MustParseURL("ch:noble/mem")
 	chUnits := []charmUnit{
 		{
 			curl:                 memCurl,
@@ -1761,12 +1761,12 @@ func (s *BundleDeployRepositorySuite) TestDeployBundleExpose(c *gc.C) {
 	s.expectEmptyModelToStart(c)
 	s.expectWatchAll()
 
-	wordpressCurl := charm.MustParseURL("ch:jammy/wordpress")
+	wordpressCurl := charm.MustParseURL("ch:noble/wordpress")
 	chUnits := []charmUnit{
 		{
 			charmMetaSeries:      []string{"jammy", "focal"},
 			curl:                 wordpressCurl,
-			machineUbuntuVersion: "22.04",
+			machineUbuntuVersion: "24.04",
 		},
 	}
 	s.setupCharmUnits(chUnits)
@@ -1781,7 +1781,7 @@ applications:
 `
 	s.runDeploy(c, content)
 
-	s.assertDeployArgs(c, wordpressCurl.String(), "wordpress", "ubuntu", "22.04")
+	s.assertDeployArgs(c, wordpressCurl.String(), "wordpress", "ubuntu", "24.04")
 	c.Check(s.output.String(), gc.Equals, ""+
 		"Located charm \"wordpress\" in charm-hub\n"+
 		"Executing changes:\n"+

--- a/cmd/juju/application/deployer/deployer.go
+++ b/cmd/juju/application/deployer/deployer.go
@@ -91,7 +91,7 @@ func NewDeployerFactory(dep DeployerDependencies) DeployerFactory {
 }
 
 // GetDeployer returns the correct deployer to use based on the cfg provided.
-// A ModelConfigGetter needed to find the deployer.
+// A ModelConfigGetter is needed to find the deployer.
 func (d *factory) GetDeployer(cfg DeployerConfig, getter ModelConfigGetter, resolver Resolver) (Deployer, error) {
 	// Determine the type of deploy we have
 	var dk DeployerKind

--- a/core/base/supported.go
+++ b/core/base/supported.go
@@ -387,6 +387,7 @@ var ubuntuSeries = map[SeriesName]seriesVersion{
 		WorkloadType: ControllerWorkloadType,
 		Version:      "24.04",
 		LTS:          true,
+		Supported:    true,
 		ESMSupported: true,
 	},
 }

--- a/core/base/supportedseries_linux_test.go
+++ b/core/base/supportedseries_linux_test.go
@@ -33,7 +33,7 @@ func (s *SupportedSeriesLinuxSuite) TestLatestLts(c *gc.C) {
 		latest, want string
 	}{
 		{"testseries", "testseries"},
-		{"", "jammy"},
+		{"", "noble"},
 	}
 	for _, test := range table {
 		SetLatestLtsForTesting(test.latest)

--- a/core/charm/baseselector.go
+++ b/core/charm/baseselector.go
@@ -132,8 +132,8 @@ func (s BaseSelector) validate(supportedCharmBases, supportedJujuBases []base.Ba
 // Order of preference is:
 //   - user requested with --base or defined by bundle when deploying
 //   - model default, if set, acts like --base
-//   - juju's default supported Ubuntu LTS (if compatible with valid charm bases)
 //   - the latest known Ubuntu LTS (if compatible with valid charm bases)
+//   - juju's default supported Ubuntu LTS (if compatible with valid charm bases)
 //   - the first supported base in the charm manifest
 //   - in the case of local charms with no manifest nor base in metadata,
 //     base must be provided by the user.
@@ -157,13 +157,6 @@ func (s BaseSelector) CharmBase() (selectedBase base.Base, err error) {
 		return s.userRequested(s.defaultBase)
 	}
 
-	// Try juju's current default supported Ubuntu LTS
-	jujuDefaultBase, err := BaseForCharm(version.DefaultSupportedLTSBase(), s.supportedBases)
-	if err == nil {
-		s.logger.Infof(msgLatestLTSBase, version.DefaultSupportedLTSBase())
-		return jujuDefaultBase, nil
-	}
-
 	// Prefer latest Ubuntu LTS.
 	preferredBase, err := BaseForCharm(base.LatestLTSBase(), s.supportedBases)
 	if err == nil {
@@ -171,6 +164,13 @@ func (s BaseSelector) CharmBase() (selectedBase base.Base, err error) {
 		return preferredBase, nil
 	} else if errors.Is(err, MissingBaseError) {
 		return base.Base{}, err
+	}
+
+	// Try juju's current default supported Ubuntu LTS
+	jujuDefaultBase, err := BaseForCharm(version.DefaultSupportedLTSBase(), s.supportedBases)
+	if err == nil {
+		s.logger.Infof(msgLatestLTSBase, version.DefaultSupportedLTSBase())
+		return jujuDefaultBase, nil
 	}
 
 	// Last chance, the first base in the charm's manifest

--- a/core/charm/baseselector_test.go
+++ b/core/charm/baseselector_test.go
@@ -146,7 +146,7 @@ func (s *baseSelectorSuite) TestCharmBase(c *gc.C) {
 			selector: BaseSelector{
 				supportedBases: []base.Base{utopic, vivid, jujuDefault, latest},
 			},
-			expectedBase: latest,
+			expectedBase: jujuDefault,
 		},
 	}
 

--- a/core/charm/baseselector_test.go
+++ b/core/charm/baseselector_test.go
@@ -150,10 +150,6 @@ func (s *baseSelectorSuite) TestCharmBase(c *gc.C) {
 		},
 	}
 
-	// Use bionic for LTS for all calls.
-	previous := base.SetLatestLtsForTesting("focal")
-	defer base.SetLatestLtsForTesting(previous)
-
 	for i, test := range deployBasesTests {
 		c.Logf("test %d [%s]", i, test.title)
 		test.selector.logger = s.logger

--- a/core/charm/baseselector_test.go
+++ b/core/charm/baseselector_test.go
@@ -146,7 +146,7 @@ func (s *baseSelectorSuite) TestCharmBase(c *gc.C) {
 			selector: BaseSelector{
 				supportedBases: []base.Base{utopic, vivid, jujuDefault, latest},
 			},
-			expectedBase: jujuDefault,
+			expectedBase: latest,
 		},
 	}
 

--- a/provider/ec2/series_test.go
+++ b/provider/ec2/series_test.go
@@ -134,6 +134,61 @@ const testImageMetadataProduct = `
 {
  "content_id": "com.ubuntu.cloud:released:aws",
  "products": {
+    "com.ubuntu.cloud:server:24.04:amd64": {
+      "release": "noble",
+      "version": "24.04",
+      "arch": "amd64",
+      "versions": {
+        "20121218": {
+          "items": {
+            "usee1pi": {
+              "root_store": "instance",
+              "virt": "pv",
+              "region": "us-east-1",
+              "id": "ami-02204111"
+            },
+            "usww1pe": {
+              "root_store": "ssd",
+              "virt": "pv",
+              "region": "eu-west-1",
+              "id": "ami-02204116"
+            },
+            "apne1pe": {
+              "root_store": "ssd",
+              "virt": "pv",
+              "region": "ap-northeast-1",
+              "id": "ami-02204126"
+            },
+            "apne1he": {
+              "root_store": "ssd",
+              "virt": "hvm",
+              "region": "ap-northeast-1",
+              "id": "ami-02204187"
+            },
+            "test1peebs": {
+              "root_store": "ssd",
+              "virt": "pv",
+              "region": "test",
+              "id": "ami-02204133"
+            },
+            "test1pessd": {
+              "root_store": "ebs",
+              "virt": "pv",
+              "region": "test",
+              "id": "ami-02204139"
+            },
+            "test1he": {
+              "root_store": "ssd",
+              "virt": "hvm",
+              "region": "test",
+              "id": "ami-02204135"
+            }
+          },
+          "pubname": "ubuntu-noble-24.04-amd64-server-20121218",
+          "label": "release"
+        }
+      }
+    },
     "com.ubuntu.cloud:server:22.04:amd64": {
       "release": "jammy",
       "version": "22.04",

--- a/testcharms/charm-hub/charms/juju-qa-test/charmcraft.yaml
+++ b/testcharms/charm-hub/charms/juju-qa-test/charmcraft.yaml
@@ -11,19 +11,17 @@ parts:
       - actions.yaml
       - metadata.yaml
       - config.yaml
+
 bases:
     - build-on:
         - name: "ubuntu"
-          channel: "20.04"
-        - name: "ubuntu"
           channel: "22.04"
+        - name: "ubuntu"
+          channel: "24.04"
       run-on:
         - name: "ubuntu"
-          channel: "16.04"
+          channel: "22.04"
           architectures: ["amd64", "arm64"]
         - name: "ubuntu"
-          channel: "18.04"
-          architectures: ["amd64", "arm64"]
-        - name: "ubuntu"
-          channel: "20.04"
+          channel: "24.04"
           architectures: ["amd64", "arm64"]

--- a/testing/environ.go
+++ b/testing/environ.go
@@ -42,6 +42,7 @@ var (
 	FakeSupportedJujuBases = []corebase.Base{
 		corebase.MustParseBaseFromString("ubuntu@20.04"),
 		corebase.MustParseBaseFromString("ubuntu@22.04"),
+		corebase.MustParseBaseFromString("ubuntu@24.04"),
 		jujuversion.DefaultSupportedLTSBase(),
 	}
 )

--- a/upgrades/upgradevalidation/migrate_test.go
+++ b/upgrades/upgradevalidation/migrate_test.go
@@ -23,7 +23,7 @@ var winVersions = []string{
 	"win2016", "win2016hv", "win2019", "win7", "win8", "win81", "win10",
 }
 
-var ubuntuVersions = []string{
+var unsupportedUbuntuVersions = []string{
 	"12.04",
 	"12.10",
 	"13.04",
@@ -46,7 +46,6 @@ var ubuntuVersions = []string{
 	"22.10",
 	"23.04",
 	"23.10",
-	"24.04",
 }
 
 func makeBases(os string, vers []string) []state.Base {
@@ -119,7 +118,7 @@ func (s *migrateSuite) setupMocks(c *gc.C) (*gomock.Controller, environscloudspe
 	s.st.EXPECT().HasUpgradeSeriesLocks().Return(false, nil)
 	// - check if the model has win machines;
 	s.st.EXPECT().MachineCountForBase(makeBases("windows", winVersions)).Return(nil, nil)
-	s.st.EXPECT().MachineCountForBase(makeBases("ubuntu", ubuntuVersions)).Return(nil, nil)
+	s.st.EXPECT().MachineCountForBase(makeBases("ubuntu", unsupportedUbuntuVersions)).Return(nil, nil)
 	// - check no charm store charms
 	s.st.EXPECT().AllCharmURLs().Return([]*string{}, errors.NotFoundf("charm urls"))
 

--- a/upgrades/upgradevalidation/upgrade_test.go
+++ b/upgrades/upgradevalidation/upgrade_test.go
@@ -74,7 +74,7 @@ func (s *upgradeValidationSuite) TestValidatorsForControllerUpgradeJuju3(c *gc.C
 	statePool.EXPECT().MongoVersion().Return("4.4", nil)
 	// - check if the model has win machines;
 	ctrlState.EXPECT().MachineCountForBase(makeBases("windows", winVersions)).Return(nil, nil)
-	ctrlState.EXPECT().MachineCountForBase(makeBases("ubuntu", ubuntuVersions)).Return(nil, nil)
+	ctrlState.EXPECT().MachineCountForBase(makeBases("ubuntu", unsupportedUbuntuVersions)).Return(nil, nil)
 	// - check no charm store charms
 	ctrlState.EXPECT().AllCharmURLs().Return([]*string{}, errors.NotFoundf("charm urls"))
 	// - check LXD version.
@@ -87,7 +87,7 @@ func (s *upgradeValidationSuite) TestValidatorsForControllerUpgradeJuju3(c *gc.C
 	model1.EXPECT().MigrationMode().Return(state.MigrationModeNone)
 	// - check if the model has win machines;
 	state1.EXPECT().MachineCountForBase(makeBases("windows", winVersions)).Return(nil, nil)
-	state1.EXPECT().MachineCountForBase(makeBases("ubuntu", ubuntuVersions)).Return(nil, nil)
+	state1.EXPECT().MachineCountForBase(makeBases("ubuntu", unsupportedUbuntuVersions)).Return(nil, nil)
 	// - check no charm store charms
 	state1.EXPECT().AllCharmURLs().Return([]*string{}, errors.NotFoundf("charm urls"))
 	// - check LXD version.
@@ -130,7 +130,7 @@ func (s *upgradeValidationSuite) TestValidatorsForModelUpgradeJuju3(c *gc.C) {
 	state.EXPECT().HasUpgradeSeriesLocks().Return(false, nil)
 	// - check if the model has win machines.
 	state.EXPECT().MachineCountForBase(makeBases("windows", winVersions)).Return(nil, nil)
-	state.EXPECT().MachineCountForBase(makeBases("ubuntu", ubuntuVersions)).Return(nil, nil)
+	state.EXPECT().MachineCountForBase(makeBases("ubuntu", unsupportedUbuntuVersions)).Return(nil, nil)
 	// - check LXD version.
 	serverFactory.EXPECT().RemoteServer(cloudSpec).Return(server, nil)
 	server.EXPECT().ServerVersion().Return("5.2")

--- a/upgrades/upgradevalidation/validation_test.go
+++ b/upgrades/upgradevalidation/validation_test.go
@@ -134,7 +134,7 @@ func (s *upgradeValidationSuite) TestCheckForDeprecatedUbuntuSeriesForModel(c *g
 	defer ctrl.Finish()
 
 	st := mocks.NewMockState(ctrl)
-	st.EXPECT().MachineCountForBase(makeBases("ubuntu", ubuntuVersions)).Return(map[string]int{"xenial": 1, "vivid": 2, "trusty": 3}, nil)
+	st.EXPECT().MachineCountForBase(makeBases("ubuntu", unsupportedUbuntuVersions)).Return(map[string]int{"xenial": 1, "vivid": 2, "trusty": 3}, nil)
 
 	blocker, err := upgradevalidation.CheckForDeprecatedUbuntuSeriesForModel("", nil, st, nil)
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
When upgrading a 3.4 controller that had charms deployed to noble there is an error saying that noble is deprecated. This is because Noble is not marked as "supported" in the list of supported ubuntu versions.

Marking it as supported however, raises another problem. When a charm is deployed the supported base resolver first checks for the latest LTS. This means that any new charms deployed would be default go to noble.

To fix this, I have swapped the preference in the supported base resolver for the latest LTS, with the juju default supported LTS base. Now it will try to deploy to noble only if the charm does not deploy to the juju default supported base (which is currently jammy)

Also in this PR:
In [upgrader_test.go](https://github.com/juju/juju/pull/17513/files#diff-6972f1b636a8694b7b87d984c6b4877d61cd166dca69accb93eea8a29b48c1da) `ubuntuVersions` actually listed unsupported ubuntu versions. This was changed and noble was removed from this list.

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing

## QA steps
Go to /testcharms/charm-hub/charms/juju-qa-test
Add the following to the charmcraft.yaml:
```
bases:
    - build-on:
        - name: "ubuntu"
          channel: "22.04"
        - name: "ubuntu"
          channel: "24.04"
      run-on:
        - name: "ubuntu"
          channel: "22.04"
          architectures: ["amd64"]
        - name: "ubuntu"
          channel: "24.04"
          architectures: ["amd64"]

```
Then do:
```
$ charmcraft pack
```
Now, to test do:
```
$ juju bootstrap lxd
```
Observe that the controller is on `ubuntu@22.04`.
```
$ juju add-model default
$ juju deploy ./juju-qa-test_ubuntu-22.04-amd64-arm64_ubuntu-24.04-amd64-arm64.charm
Located local charm "juju-qa-test", revision 0
Deploying "juju-qa-test" from local charm "juju-qa-test", revision 0 on ubuntu@24.04/stable
```
Observe that by default it deploys to `ubuntu@24.04`.
Now test an upgrade.
```
$ juju upgrade-controller --build-agent
no prepackaged agent binaries available, using local agent binary 3.4.4.2 (built from source)
best version:
    3.4.4.2
started upgrade to 3.4.4.2
```

<!-- Describe steps to verify that the change works. -->

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2068671

