### PR TITLE
feat(machine): add state layer for machine cloud instance

### DIFF
--- a/domain/machine/state/machine_cloud_instance.go
+++ b/domain/machine/state/machine_cloud_instance.go
@@ -1,0 +1,153 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/canonical/sqlair"
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/domain"
+)
+
+// HardwareCharacteristics returns the hardware characteristics struct with
+// data retrieved from the machine_cloud_instance table.
+func (st *State) HardwareCharacteristics(
+	ctx context.Context,
+	machineUUID string,
+) (*instance.HardwareCharacteristics, error) {
+	db, err := st.DB()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	retrieveHardwareCharacteristics := `
+SELECT (*) AS (&instanceData.*)
+FROM   machine_cloud_instance 
+WHERE  machine_uuid = $instanceData.machine_uuid`
+	machineUUIDQuery := instanceData{MachineUUID: machineUUID}
+	retrieveHardwareCharacteristicsStmt, err := st.Prepare(retrieveHardwareCharacteristics, machineUUIDQuery, sqlair.M{})
+	if err != nil {
+		return nil, errors.Annotate(err, "preparing retrieve hardware characteristics statement")
+	}
+
+	var row instanceData
+	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		return errors.Trace(tx.Query(ctx, retrieveHardwareCharacteristicsStmt, machineUUIDQuery).Get(&row))
+	}); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, errors.Annotatef(errors.NotFound, "instance data for machine %q", machineUUID)
+		}
+		return nil, errors.Annotatef(domain.CoerceError(err), "querying instance data for machine %q", machineUUID)
+	}
+	return row.toHardwareCharacteristics(), nil
+}
+
+// SetInstanceData sets an entry in the instance data table along with
+// the instance tags and the link to a lxd profile if any.
+func (st *State) SetInstanceData(
+	ctx context.Context,
+	machineUUID string,
+	instanceID instance.Id,
+	hardwareCharacteristics instance.HardwareCharacteristics,
+) error {
+	db, err := st.DB()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	setInstanceData := `
+INSERT INTO machine_cloud_instance (*)
+VALUES ($instanceData.*)
+`
+	setInstanceDataStmt, err := st.Prepare(setInstanceData, instanceData{})
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	setInstanceTags := `
+INSERT INTO instance_tag (*)
+VALUES ($instanceTag.*)
+`
+	setInstanceTagStmt, err := st.Prepare(setInstanceTags, instanceTag{})
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		instanceData := instanceData{
+			MachineUUID:          machineUUID,
+			InstanceID:           string(instanceID),
+			Arch:                 hardwareCharacteristics.Arch,
+			Mem:                  hardwareCharacteristics.Mem,
+			RootDisk:             hardwareCharacteristics.RootDisk,
+			RootDiskSource:       hardwareCharacteristics.RootDiskSource,
+			CPUCores:             hardwareCharacteristics.CpuCores,
+			CPUPower:             hardwareCharacteristics.CpuPower,
+			AvailabilityZoneUUID: hardwareCharacteristics.AvailabilityZone,
+			VirtType:             hardwareCharacteristics.VirtType,
+		}
+		if err := tx.Query(ctx, setInstanceDataStmt, instanceData).Run(); err != nil {
+			return errors.Annotatef(domain.CoerceError(err), "inserting instance data for machine %q", machineUUID)
+		}
+		for _, tag := range *hardwareCharacteristics.Tags {
+			instanceTag := instanceTag{
+				MachineUUID: machineUUID,
+				Tag:         tag,
+			}
+			if err := tx.Query(ctx, setInstanceTagStmt, instanceTag).Run(); err != nil {
+				return errors.Annotatef(domain.CoerceError(err), "inserting instance tag %q for machine %q", tag, machineUUID)
+			}
+		}
+		return nil
+	})
+}
+
+// DeleteInstanceData removes an entry in the instance data table along with
+// the instance tags and the link to a lxd profile if any.
+func (st *State) DeleteInstanceData(
+	ctx context.Context,
+	machineUUID string,
+) error {
+	db, err := st.DB()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	deleteInstanceData := `
+DELETE FROM machine_cloud_instance 
+WHERE machine_uuid=$instanceData.machine_uuid
+`
+	deleteInstanceDataStmt, err := st.Prepare(deleteInstanceData, instanceData{})
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	deleteInstanceTags := `
+DELETE FROM instance_tag 
+WHERE machine_uuid=$instanceTag.machine_uuid
+`
+	deleteInstanceTagStmt, err := st.Prepare(deleteInstanceTags, instanceTag{})
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		instanceData := instanceData{
+			MachineUUID: machineUUID,
+		}
+		if err := tx.Query(ctx, deleteInstanceDataStmt, instanceData).Run(); err != nil {
+			return errors.Annotatef(domain.CoerceError(err), "deleting instance data for machine %q", machineUUID)
+		}
+		instanceTag := instanceTag{
+			MachineUUID: machineUUID,
+		}
+		if err := tx.Query(ctx, deleteInstanceTagStmt, instanceTag).Run(); err != nil {
+			return errors.Annotatef(domain.CoerceError(err), "deleting instance tags for machine %q", machineUUID)
+		}
+		return nil
+	})
+}

--- a/domain/machine/state/machine_cloud_instance_test.go
+++ b/domain/machine/state/machine_cloud_instance_test.go
@@ -1,0 +1,189 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"context"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/instance"
+)
+
+func (s *stateSuite) TestGetHardwareCharacteristics(c *gc.C) {
+	db := s.DB()
+
+	// Create a reference machine.
+	err := s.state.UpsertMachine(context.Background(), "42")
+	c.Assert(err, jc.ErrorIsNil)
+	var machineUUID string
+	row := db.QueryRowContext(context.Background(), "SELECT uuid FROM machine WHERE machine_id=\"42\"")
+	c.Assert(row.Err(), jc.ErrorIsNil)
+	err = row.Scan(&machineUUID)
+	c.Assert(err, jc.ErrorIsNil)
+	// Add a reference AZ.
+	_, err = db.ExecContext(context.Background(), "INSERT INTO availability_zone VALUES(\"az-1\", \"az1\")")
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.state.SetInstanceData(
+		context.Background(),
+		machineUUID,
+		instance.Id("1"),
+		instance.HardwareCharacteristics{
+			Arch:             strptr("arm64"),
+			Mem:              uintptr(1024),
+			RootDisk:         uintptr(256),
+			RootDiskSource:   strptr("/test"),
+			CpuCores:         uintptr(4),
+			CpuPower:         uintptr(75),
+			Tags:             strsliceptr([]string{"tag1", "tag2"}),
+			AvailabilityZone: strptr("az-1"),
+			VirtType:         strptr("virtual-machine"),
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+
+	hc, err := s.state.HardwareCharacteristics(context.Background(), machineUUID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(*hc.Arch, gc.Equals, "arm64")
+	c.Check(*hc.Mem, gc.Equals, uint64(1024))
+	c.Check(*hc.RootDisk, gc.Equals, uint64(256))
+	c.Check(*hc.RootDiskSource, gc.Equals, "/test")
+	c.Check(*hc.CpuCores, gc.Equals, uint64(4))
+	c.Check(*hc.CpuPower, gc.Equals, uint64(75))
+	c.Check(*hc.AvailabilityZone, gc.Equals, "az-1")
+	c.Check(*hc.VirtType, gc.Equals, "virtual-machine")
+}
+
+func (s *stateSuite) TestSetInstanceData(c *gc.C) {
+	db := s.DB()
+
+	// Create a reference machine.
+	err := s.state.UpsertMachine(context.Background(), "42")
+	c.Assert(err, jc.ErrorIsNil)
+	var machineUUID string
+	row := db.QueryRowContext(context.Background(), "SELECT uuid FROM machine WHERE machine_id=\"42\"")
+	c.Assert(row.Err(), jc.ErrorIsNil)
+	err = row.Scan(&machineUUID)
+	c.Assert(err, jc.ErrorIsNil)
+	// Add a reference AZ.
+	_, err = db.ExecContext(context.Background(), "INSERT INTO availability_zone VALUES(\"az-1\", \"az1\")")
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.state.SetInstanceData(
+		context.Background(),
+		machineUUID,
+		instance.Id("1"),
+		instance.HardwareCharacteristics{
+			Arch:             strptr("arm64"),
+			Mem:              uintptr(1024),
+			RootDisk:         uintptr(256),
+			RootDiskSource:   strptr("/test"),
+			CpuCores:         uintptr(4),
+			CpuPower:         uintptr(75),
+			Tags:             strsliceptr([]string{"tag1", "tag2"}),
+			AvailabilityZone: strptr("az-1"),
+			VirtType:         strptr("virtual-machine"),
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+
+	var instanceData instanceData
+	row = db.QueryRowContext(context.Background(), "SELECT * FROM machine_cloud_instance WHERE instance_id=\"1\"")
+	c.Assert(row.Err(), jc.ErrorIsNil)
+	err = row.Scan(
+		&instanceData.MachineUUID,
+		&instanceData.InstanceID,
+		&instanceData.Arch,
+		&instanceData.Mem,
+		&instanceData.RootDisk,
+		&instanceData.RootDiskSource,
+		&instanceData.CPUCores,
+		&instanceData.CPUPower,
+		&instanceData.AvailabilityZoneUUID,
+		&instanceData.VirtType,
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(instanceData.MachineUUID, gc.Equals, machineUUID)
+	c.Check(instanceData.InstanceID, gc.Equals, "1")
+	c.Check(*instanceData.Arch, gc.Equals, "arm64")
+	c.Check(*instanceData.Mem, gc.Equals, uint64(1024))
+	c.Check(*instanceData.RootDisk, gc.Equals, uint64(256))
+	c.Check(*instanceData.RootDiskSource, gc.Equals, "/test")
+	c.Check(*instanceData.CPUCores, gc.Equals, uint64(4))
+	c.Check(*instanceData.CPUPower, gc.Equals, uint64(75))
+	c.Check(*instanceData.AvailabilityZoneUUID, gc.Equals, "az-1")
+	c.Check(*instanceData.VirtType, gc.Equals, "virtual-machine")
+
+	rows, err := db.QueryContext(context.Background(), "SELECT tag FROM instance_tag WHERE machine_uuid=\""+machineUUID+"\"")
+	c.Assert(err, jc.ErrorIsNil)
+	var instanceTags []string
+	for rows.Next() {
+		var tag string
+		err = rows.Scan(&tag)
+		c.Assert(err, jc.ErrorIsNil)
+		instanceTags = append(instanceTags, tag)
+	}
+	c.Check(instanceTags, gc.HasLen, 2)
+	c.Check(instanceTags[0], gc.Equals, "tag1")
+	c.Check(instanceTags[1], gc.Equals, "tag2")
+}
+
+func (s *stateSuite) TestDeleteInstanceData(c *gc.C) {
+	db := s.DB()
+
+	// Create a reference machine.
+	err := s.state.UpsertMachine(context.Background(), "42")
+	c.Assert(err, jc.ErrorIsNil)
+	var machineUUID string
+	row := db.QueryRowContext(context.Background(), "SELECT uuid FROM machine WHERE machine_id=\"42\"")
+	c.Assert(row.Err(), jc.ErrorIsNil)
+	err = row.Scan(&machineUUID)
+	c.Assert(err, jc.ErrorIsNil)
+	// Add a reference AZ.
+	_, err = db.ExecContext(context.Background(), "INSERT INTO availability_zone VALUES(\"az-1\", \"az1\")")
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.state.SetInstanceData(
+		context.Background(),
+		machineUUID,
+		instance.Id("1"),
+		instance.HardwareCharacteristics{
+			Arch:             strptr("arm64"),
+			Mem:              uintptr(1024),
+			RootDisk:         uintptr(256),
+			RootDiskSource:   strptr("/test"),
+			CpuCores:         uintptr(4),
+			CpuPower:         uintptr(75),
+			Tags:             strsliceptr([]string{"tag1", "tag2"}),
+			AvailabilityZone: strptr("az-1"),
+			VirtType:         strptr("virtual-machine"),
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.state.DeleteInstanceData(context.Background(), machineUUID)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Check that all rows've been deleted.
+	rows, err := db.QueryContext(context.Background(), "SELECT * FROM machine_cloud_instance WHERE instance_id=\"1\"")
+	c.Assert(rows.Err(), jc.ErrorIsNil)
+	c.Check(rows.Next(), jc.IsFalse)
+	rows, err = db.QueryContext(context.Background(), "SELECT * FROM instance_tag WHERE machine_uuid=\""+machineUUID+"\"")
+	c.Assert(rows.Err(), jc.ErrorIsNil)
+	c.Check(rows.Next(), jc.IsFalse)
+}
+
+func strptr(s string) *string {
+	return &s
+}
+
+func uintptr(u uint64) *uint64 {
+	return &u
+}
+
+func strsliceptr(s []string) *[]string {
+	return &s
+}

--- a/domain/machine/state/types.go
+++ b/domain/machine/state/types.go
@@ -27,6 +27,17 @@ type instanceTag struct {
 	Tag         string `db:"tag"`
 }
 
+func tagsFromHardwareCharacteristics(machineUUID string, hc *instance.HardwareCharacteristics) []instanceTag {
+	res := make([]instanceTag, len(*hc.Tags))
+	for i, tag := range *hc.Tags {
+		res[i] = instanceTag{
+			MachineUUID: machineUUID,
+			Tag:         tag,
+		}
+	}
+	return res
+}
+
 func (d *instanceData) toHardwareCharacteristics() *instance.HardwareCharacteristics {
 	return &instance.HardwareCharacteristics{
 		Arch:             d.Arch,

--- a/domain/machine/state/types.go
+++ b/domain/machine/state/types.go
@@ -1,0 +1,41 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import "github.com/juju/juju/core/instance"
+
+// instanceData represents the struct to be inserted into the instance_data
+// table.
+type instanceData struct {
+	MachineUUID          string  `db:"machine_uuid"`
+	InstanceID           string  `db:"instance_id"`
+	Arch                 *string `db:"arch"`
+	Mem                  *uint64 `db:"mem"`
+	RootDisk             *uint64 `db:"root_disk"`
+	RootDiskSource       *string `db:"root_disk_source"`
+	CPUCores             *uint64 `db:"cpu_cores"`
+	CPUPower             *uint64 `db:"cpu_power"`
+	AvailabilityZoneUUID *string `db:"availability_zone_uuid"`
+	VirtType             *string `db:"virt_type"`
+}
+
+// instanceTag represents the struct to be inserted into the instance_tag
+// table.
+type instanceTag struct {
+	MachineUUID string `db:"machine_uuid"`
+	Tag         string `db:"tag"`
+}
+
+func (d *instanceData) toHardwareCharacteristics() *instance.HardwareCharacteristics {
+	return &instance.HardwareCharacteristics{
+		Arch:             d.Arch,
+		Mem:              d.Mem,
+		RootDisk:         d.RootDisk,
+		RootDiskSource:   d.RootDiskSource,
+		CpuCores:         d.CPUCores,
+		CpuPower:         d.CPUPower,
+		AvailabilityZone: d.AvailabilityZoneUUID,
+		VirtType:         d.VirtType,
+	}
+}

--- a/domain/schema/model/sql/0016-machine-cloud-instance.sql
+++ b/domain/schema/model/sql/0016-machine-cloud-instance.sql
@@ -1,7 +1,6 @@
-CREATE TABLE instance_data (
+CREATE TABLE machine_cloud_instance (
     machine_uuid TEXT NOT NULL PRIMARY KEY,
     instance_id TEXT NOT NULL,
-    display_name TEXT NOT NULL,
     arch TEXT,
     mem INT,
     root_disk INT,

--- a/domain/schema/schema_test.go
+++ b/domain/schema/schema_test.go
@@ -281,7 +281,7 @@ func (s *schemaSuite) TestModelTables(c *gc.C) {
 		"net_node",
 		"cloud_service",
 		"cloud_container",
-		"instance_data",
+		"machine_cloud_instance",
 		"machine_lxd_profile",
 		"instance_tag",
 


### PR DESCRIPTION
This patch adds a minimal state layer for machine cloud instance on the machine
domain. Only 3 methods for creating, deleting and retrieving (hardware
characteristics) machine cloud instance data are created, along with their unit tests.

Also, the DDL file for creating instance data has been renamed as well
as the table names and the `display_name` column removed from cloud instance.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Only the state layer of the new domain, so nothing other than unit tests to verify at the moment:
```
TEST_PACKAGES="./domain/machine/... -count=1 -race -check.vv" make run-go-tests    
```
## Links

**Jira card:** JUJU-6131

