### PR TITLE
feat: juju switch to previous controller or model

### DIFF
--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -889,9 +889,15 @@ func (s *BootstrapSuite) TestBootstrapPropagatesStoreErrors(c *gc.C) {
 	store.CurrentControllerFunc = func() (string, error) {
 		return "arthur", nil
 	}
+	store.PreviousControllerFunc = func() (string, bool, error) {
+		return "", false, errors.NotFound
+	}
 	store.CurrentModelFunc = func(controller string) (string, error) {
 		c.Assert(controller, gc.Equals, "arthur")
 		return "sword", nil
+	}
+	store.PreviousModelFunc = func(controller string) (string, error) {
+		return "", errors.NotFound
 	}
 	store.ModelByNameFunc = func(controller, model string) (*jujuclient.ModelDetails, error) {
 		c.Assert(controller, gc.Equals, "arthur")

--- a/cmd/juju/commands/mocks/jujuclient_mock.go
+++ b/cmd/juju/commands/mocks/jujuclient_mock.go
@@ -553,6 +553,85 @@ func (c *MockClientStoreModelByNameCall) DoAndReturn(f func(string, string) (*ju
 	return c
 }
 
+// PreviousController mocks base method.
+func (m *MockClientStore) PreviousController() (string, bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PreviousController")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// PreviousController indicates an expected call of PreviousController.
+func (mr *MockClientStoreMockRecorder) PreviousController() *MockClientStorePreviousControllerCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PreviousController", reflect.TypeOf((*MockClientStore)(nil).PreviousController))
+	return &MockClientStorePreviousControllerCall{Call: call}
+}
+
+// MockClientStorePreviousControllerCall wrap *gomock.Call
+type MockClientStorePreviousControllerCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockClientStorePreviousControllerCall) Return(arg0 string, arg1 bool, arg2 error) *MockClientStorePreviousControllerCall {
+	c.Call = c.Call.Return(arg0, arg1, arg2)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockClientStorePreviousControllerCall) Do(f func() (string, bool, error)) *MockClientStorePreviousControllerCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockClientStorePreviousControllerCall) DoAndReturn(f func() (string, bool, error)) *MockClientStorePreviousControllerCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// PreviousModel mocks base method.
+func (m *MockClientStore) PreviousModel(arg0 string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PreviousModel", arg0)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PreviousModel indicates an expected call of PreviousModel.
+func (mr *MockClientStoreMockRecorder) PreviousModel(arg0 any) *MockClientStorePreviousModelCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PreviousModel", reflect.TypeOf((*MockClientStore)(nil).PreviousModel), arg0)
+	return &MockClientStorePreviousModelCall{Call: call}
+}
+
+// MockClientStorePreviousModelCall wrap *gomock.Call
+type MockClientStorePreviousModelCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockClientStorePreviousModelCall) Return(arg0 string, arg1 error) *MockClientStorePreviousModelCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockClientStorePreviousModelCall) Do(f func(string) (string, error)) *MockClientStorePreviousModelCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockClientStorePreviousModelCall) DoAndReturn(f func(string) (string, error)) *MockClientStorePreviousModelCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // RemoveAccount mocks base method.
 func (m *MockClientStore) RemoveAccount(arg0 string) error {
 	m.ctrl.T.Helper()

--- a/cmd/juju/commands/switch.go
+++ b/cmd/juju/commands/switch.go
@@ -106,8 +106,8 @@ func (c *switchCommand) Run(ctx *cmd.Context) (resultErr error) {
 		if currentName == "" {
 			return common.MissingModelNameError("switch")
 		}
-		fmt.Fprintf(ctx.Stdout, "%s\n", currentName)
-		return nil
+		_, err = fmt.Fprintf(ctx.Stdout, "%s\n", currentName)
+		return err
 	}
 	currentName, err := c.name(store, currentControllerName, false)
 	if err != nil {

--- a/cmd/juju/commands/switch.go
+++ b/cmd/juju/commands/switch.go
@@ -6,9 +6,11 @@ package commands
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/juju/cmd/v4"
 	"github.com/juju/errors"
+	"github.com/juju/gnuflag"
 
 	jujucmd "github.com/juju/juju/cmd"
 	"github.com/juju/juju/cmd/juju/common"
@@ -30,8 +32,10 @@ type switchCommand struct {
 	modelcmd.CommandBase
 	RefreshModels func(jujuclient.ClientStore, string) error
 
-	Store  jujuclient.ClientStore
-	Target string
+	Store                 jujuclient.ClientStore
+	controllerOrModelName string
+	modelName             string
+	controllerName        string
 }
 
 var usageSummary = `
@@ -40,14 +44,21 @@ Selects or identifies the current controller and model.`[1:]
 var usageDetails = `
 When used without an argument, the command shows the current controller
 and its active model.
+
 When a single argument without a colon is provided juju first looks for a
 controller by that name and switches to it, and if it's not found it tries
-to switch to a model within current controller. mycontroller: switches to
-default model in mycontroller, :mymodel switches to mymodel in current
-controller and mycontroller:mymodel switches to mymodel on mycontroller.
+to switch to a model within current controller. 
+
+Colon allows to disambiguate model over controller:
+- mycontroller: switches to default model in mycontroller, 
+- :mymodel switches to mymodel in current controller 
+- mycontroller:mymodel switches to mymodel on mycontroller.
+
+The special arguments - (hyphen) instead of a model or a controller allows to return 
+to previous model or controller. It can be used as main argument or as flag argument.
+
 The `[1:] + "`juju models`" + ` command can be used to determine the active model
 (of any controller). An asterisk denotes it.
-
 `
 
 const usageExamples = `
@@ -57,6 +68,12 @@ const usageExamples = `
     juju switch mycontroller:mymodel
     juju switch mycontroller:
     juju switch :mymodel
+    juju switch -m mymodel
+	juju switch -m mycontroller:mymodel
+	juju switch -c mycontroller
+    juju switch - # switch to previous controller:model
+    juju switch -m - # switch to previous controller on its current model
+    juju switch -c - # switch to previous model on the current controller
 `
 
 func (c *switchCommand) Info() *cmd.Info {
@@ -74,10 +91,104 @@ func (c *switchCommand) Info() *cmd.Info {
 	})
 }
 
+// SetFlags implements Command.SetFlags.
+func (c *switchCommand) SetFlags(f *gnuflag.FlagSet) {
+	c.CommandBase.SetFlags(f)
+	f.StringVar(&c.modelName, "m", "", "Model to operate in. Accepts [<controller name>:]<model name>")
+	f.StringVar(&c.modelName, "model", "", "")
+	f.StringVar(&c.controllerName, "c", "", "Controller to operate in")
+	f.StringVar(&c.controllerName, "controller", "", "")
+}
+
 func (c *switchCommand) Init(args []string) error {
-	var err error
-	c.Target, err = cmd.ZeroOrOneArgs(args)
-	return err
+	if c.modelName != "" && c.controllerName != "" {
+		return errors.Trace(fmt.Errorf("cannot specify both a --model and --controller"))
+	}
+
+	if c.controllerName != "" {
+		err := cmd.CheckEmpty(args)
+		if err != nil {
+			return errors.Trace(err)
+		}
+	} else if c.modelName != "" {
+		err := cmd.CheckEmpty(args)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		// This means we can support arguments like `juju switch -m mycontroller:mymodel`
+		c.parseModelName(c.modelName)
+	} else {
+		target, err := cmd.ZeroOrOneArgs(args)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		// if the target does not contain a ":", it is an ambiguous target so
+		// we cannot parse it as a model name
+		if strings.Contains(target, ":") {
+			c.parseModelName(target)
+		} else {
+			c.controllerOrModelName = target
+		}
+	}
+
+	// expand "-" syntactic sugar where it's found
+	if c.controllerName == "-" {
+		previous, _, err := c.Store.PreviousController()
+		if err != nil {
+			return errors.Trace(err)
+		}
+		c.controllerName = previous
+	}
+
+	if c.modelName == "-" {
+		controller, err := c.Store.CurrentController()
+		if err != nil {
+			return errors.Trace(err)
+		}
+		previous, err := c.Store.PreviousModel(controller)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		c.modelName = previous
+	}
+
+	if c.controllerOrModelName == "-" {
+		c.controllerOrModelName = ""
+
+		previousController, changedController, err := c.Store.PreviousController()
+		if err != nil && !errors.Is(err, errors.NotFound) {
+			return errors.Trace(err)
+		}
+
+		// if the last switch was intra-controller (i.e. changedController is true), we need
+		// to figure out from which model and switch back there. Otherwise (i.e. inter-controller),
+		// it is sufficient to switch to just the previous controller.
+		if changedController {
+			c.controllerName = previousController
+		} else {
+			c.controllerName, err = c.Store.CurrentController()
+			if err != nil {
+				return errors.Trace(err)
+			}
+			previousModel, err := c.Store.PreviousModel(c.controllerName)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			c.modelName = previousModel
+		}
+	}
+
+	return nil
+}
+
+func (c *switchCommand) parseModelName(name string) {
+	parts := strings.SplitN(name, ":", 2)
+	if len(parts) == 1 {
+		c.modelName = parts[0]
+		return
+	}
+	c.controllerName = parts[0]
+	c.modelName = parts[1]
 }
 
 // SetClientStore implements Command.SetClientStore.
@@ -98,7 +209,7 @@ func (c *switchCommand) Run(ctx *cmd.Context) (resultErr error) {
 	} else if err != nil {
 		return errors.Trace(err)
 	}
-	if c.Target == "" {
+	if c.controllerOrModelName == "" && c.modelName == "" && c.controllerName == "" {
 		currentName, err := c.name(store, currentControllerName, true)
 		if err != nil {
 			return errors.Trace(err)
@@ -109,17 +220,17 @@ func (c *switchCommand) Run(ctx *cmd.Context) (resultErr error) {
 		_, err = fmt.Fprintf(ctx.Stdout, "%s\n", currentName)
 		return err
 	}
-	currentName, err := c.name(store, currentControllerName, false)
+	sourceName, err := c.name(store, currentControllerName, false)
 	if err != nil {
 		return errors.Trace(err)
 	}
 
-	var newName string
+	var targetName string
 	defer func() {
 		if resultErr != nil {
 			return
 		}
-		logSwitch(ctx, currentName, &newName)
+		logSwitch(ctx, sourceName, targetName)
 	}()
 
 	// Switch is an alternative way of dealing with models rather than using
@@ -133,82 +244,58 @@ func (c *switchCommand) Run(ctx *cmd.Context) (resultErr error) {
 		return errors.Errorf("cannot switch when JUJU_MODEL is overriding the model (set to %q)", model)
 	}
 
-	// If the target identifies a controller, or we want a controller explicitly,
-	// then set that as the current controller.
-	var newControllerName = c.Target
-	var forceController = false
-	if c.Target[len(c.Target)-1] == ':' {
-		forceController = true
-		newControllerName = c.Target[:len(c.Target)-1]
-	}
-	if _, err = store.ControllerByName(newControllerName); err == nil {
-		if newControllerName == currentControllerName {
-			newName = currentName
-			return nil
-		} else {
-			newName, err = c.name(store, newControllerName, false)
-			if err != nil {
-				return errors.Trace(err)
-			}
-			return errors.Trace(store.SetCurrentController(newControllerName))
-		}
-	} else if !errors.Is(err, errors.NotFound) || forceController {
-		return errors.Trace(err)
-	}
-
-	// The target is not a controller, so check for a model with
-	// the given name. The name can be qualified with the controller
-	// name (<controller>:<model>), or unqualified; in the latter
-	// case, the model must exist in the current controller.
-	newControllerName, modelName := modelcmd.SplitModelName(c.Target)
-	if newControllerName != "" {
-		if _, err = store.ControllerByName(newControllerName); err != nil {
+	// juju switch something (ambiguous)
+	if c.controllerOrModelName != "" {
+		// Is it an existing controller ?
+		targetName, err = c.trySwitchToController(store, c.controllerOrModelName)
+		if err != nil && !errors.Is(err, errors.NotFound) {
 			return errors.Trace(err)
 		}
-	} else {
-		if currentControllerName == "" {
-			return unknownSwitchTargetError(c.Target)
+		if err == nil {
+			return // switch successful
 		}
-		newControllerName = currentControllerName
+		// Is an existing model in current controller ?
+		if currentControllerName == "" {
+			return unknownSwitchTargetError(c.controllerOrModelName)
+		}
+		targetName, err = c.trySwitchToModel(store, currentControllerName, c.controllerOrModelName)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		return
 	}
-	modelName, err = store.QualifiedModelName(newControllerName, modelName)
+
+	// Juju switch non ambiguous
+	if c.modelName == "" {
+		targetName, err = c.trySwitchToController(store, c.controllerName)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		return
+	}
+
+	if c.controllerName == "" {
+		if currentControllerName == "" {
+			return unknownSwitchTargetError(c.modelName)
+		}
+		c.controllerName = currentControllerName
+	}
+	targetName, err = c.trySwitchToModel(store, c.controllerName, c.modelName)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	newName = modelcmd.JoinModelName(newControllerName, modelName)
-
-	err = store.SetCurrentModel(newControllerName, modelName)
-	if errors.Is(err, errors.NotFound) {
-		// The model isn't known locally, so we must query the controller.
-		if err := c.RefreshModels(store, newControllerName); err != nil {
-			return errors.Annotate(err, "refreshing models cache")
-		}
-		err := store.SetCurrentModel(newControllerName, modelName)
-		if errors.Is(err, errors.NotFound) {
-			return unknownSwitchTargetError(c.Target)
-		} else if err != nil {
-			return errors.Trace(err)
-		}
-	} else if err != nil {
-		return errors.Trace(err)
-	}
-	if currentControllerName != newControllerName {
-		if err := store.SetCurrentController(newControllerName); err != nil {
-			return errors.Trace(err)
-		}
-	}
-	return nil
+	return
 }
 
 func unknownSwitchTargetError(name string) error {
 	return errors.Errorf("%q is not the name of a model or controller", name)
 }
 
-func logSwitch(ctx *cmd.Context, oldName string, newName *string) {
-	if *newName == oldName {
+func logSwitch(ctx *cmd.Context, oldName string, newName string) {
+	if newName == oldName {
 		ctx.Infof("%s (no change)", oldName)
 	} else {
-		ctx.Infof("%s -> %s", oldName, *newName)
+		ctx.Infof("%s -> %s", oldName, newName)
 	}
 }
 
@@ -231,4 +318,45 @@ func (c *switchCommand) name(store jujuclient.ModelGetter, controllerName string
 		return controllerName, nil
 	}
 	return fmt.Sprintf("%s (controller)", controllerName), nil
+}
+
+func (c *switchCommand) trySwitchToController(store jujuclient.ClientStore, controller string) (string, error) {
+	// Check that the controller actually exists
+	_, err := store.ControllerByName(controller)
+	if err != nil {
+		// If something get wrong
+		return "", errors.Trace(err)
+	}
+	targetName, err := c.name(store, controller, false)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	return targetName, errors.Trace(store.SetCurrentController(controller))
+}
+
+func (c *switchCommand) trySwitchToModel(store modelcmd.QualifyingClientStore, controller string, model string) (string, error) {
+	if err := store.SetCurrentController(controller); err != nil {
+		return "", errors.Trace(err)
+	}
+	modelName, err := store.QualifiedModelName(controller, model)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+
+	err = store.SetCurrentModel(controller, modelName)
+	if errors.Is(err, errors.NotFound) {
+		// The model isn't known locally, so we must query the controller.
+		if err := c.RefreshModels(store, controller); err != nil {
+			return "", errors.Annotate(err, "refreshing models cache")
+		}
+		err := store.SetCurrentModel(controller, modelName)
+		if errors.Is(err, errors.NotFound) {
+			return "", unknownSwitchTargetError(controller + ":" + model)
+		} else if err != nil {
+			return "", errors.Trace(err)
+		}
+	} else if err != nil {
+		return "", errors.Trace(err)
+	}
+	return modelcmd.JoinModelName(controller, modelName), nil
 }

--- a/cmd/juju/commands/switch_test.go
+++ b/cmd/juju/commands/switch_test.go
@@ -48,11 +48,11 @@ func (s *SwitchSimpleSuite) refreshModels(store jujuclient.ClientStore, controll
 }
 
 func (s *SwitchSimpleSuite) run(c *gc.C, args ...string) (*cmd.Context, error) {
-	cmd := &switchCommand{
+	switchCmd := &switchCommand{
 		Store:         s.stubStore,
 		RefreshModels: s.refreshModels,
 	}
-	return cmdtesting.RunCommand(c, modelcmd.WrapBase(cmd), args...)
+	return cmdtesting.RunCommand(c, modelcmd.WrapBase(switchCmd), args...)
 }
 
 func (s *SwitchSimpleSuite) TestNoArgs(c *gc.C) {
@@ -321,14 +321,16 @@ func (s *SwitchSimpleSuite) TestSwitchUnknownCurrentControllerRefreshModelsFails
 }
 
 func (s *SwitchSimpleSuite) TestSettingWhenModelEnvVarSet(c *gc.C) {
-	os.Setenv("JUJU_MODEL", "using-model")
-	_, err := s.run(c, "erewhemos-2")
+	err := os.Setenv("JUJU_MODEL", "using-model")
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = s.run(c, "erewhemos-2")
 	c.Assert(err, gc.ErrorMatches, `cannot switch when JUJU_MODEL is overriding the model \(set to "using-model"\)`)
 }
 
 func (s *SwitchSimpleSuite) TestSettingWhenControllerEnvVarSet(c *gc.C) {
-	os.Setenv("JUJU_CONTROLLER", "using-controller")
-	_, err := s.run(c, "erewhemos-2")
+	err := os.Setenv("JUJU_CONTROLLER", "using-controller")
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = s.run(c, "erewhemos-2")
 	c.Assert(err, gc.ErrorMatches, `cannot switch when JUJU_CONTROLLER is overriding the controller \(set to "using-controller"\)`)
 }
 

--- a/cmd/juju/commands/switch_test.go
+++ b/cmd/juju/commands/switch_test.go
@@ -100,15 +100,6 @@ func (s *SwitchSimpleSuite) TestSwitchWritesCurrentController(c *gc.C) {
 	})
 }
 
-func (s *SwitchSimpleSuite) TestSwitchWithCurrentController(c *gc.C) {
-	s.store.CurrentControllerName = "old"
-	s.addController(c, "old")
-	s.addController(c, "new")
-	context, err := s.run(c, "new")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(cmdtesting.Stderr(context), gc.Equals, "old (controller) -> new (controller)\n")
-}
-
 func (s *SwitchSimpleSuite) TestSwitchLocalControllerWithCurrent(c *gc.C) {
 	s.store.CurrentControllerName = "old"
 	s.addController(c, "old")

--- a/cmd/juju/commands/switch_test.go
+++ b/cmd/juju/commands/switch_test.go
@@ -129,6 +129,8 @@ func (s *SwitchSimpleSuite) TestSwitchSameController(c *gc.C) {
 		{"ControllerByName", []interface{}{"same"}},
 		{"CurrentModel", []interface{}{"same"}},
 		{"ControllerByName", []interface{}{"same"}},
+		{"CurrentModel", []interface{}{"same"}},
+		{"SetCurrentController", []interface{}{"same"}},
 	})
 }
 
@@ -146,6 +148,7 @@ func (s *SwitchSimpleSuite) TestSwitchControllerToModel(c *gc.C) {
 		{"ControllerByName", []interface{}{"ctrl"}},
 		{"CurrentModel", []interface{}{"ctrl"}},
 		{"ControllerByName", []interface{}{"mymodel"}},
+		{"SetCurrentController", []interface{}{"ctrl"}},
 		{"AccountDetails", []interface{}{"ctrl"}},
 		{"SetCurrentModel", []interface{}{"ctrl", "admin/mymodel"}},
 	})
@@ -166,11 +169,9 @@ func (s *SwitchSimpleSuite) TestSwitchControllerToModelDifferentController(c *gc
 		{"CurrentController", nil},
 		{"ControllerByName", []interface{}{"old"}},
 		{"CurrentModel", []interface{}{"old"}},
-		{"ControllerByName", []interface{}{"new:mymodel"}},
-		{"ControllerByName", []interface{}{"new"}},
+		{"SetCurrentController", []interface{}{"new"}},
 		{"AccountDetails", []interface{}{"new"}},
 		{"SetCurrentModel", []interface{}{"new", "admin/mymodel"}},
-		{"SetCurrentController", []interface{}{"new"}},
 	})
 	c.Assert(s.store.Models["new"].CurrentModel, gc.Equals, "admin/mymodel")
 }
@@ -223,11 +224,9 @@ func (s *SwitchSimpleSuite) TestSwitchLocalControllerToModelDifferentController(
 		{"CurrentController", nil},
 		{"ControllerByName", []interface{}{"old"}},
 		{"CurrentModel", []interface{}{"old"}},
-		{"ControllerByName", []interface{}{"new:mymodel"}},
-		{"ControllerByName", []interface{}{"new"}},
+		{"SetCurrentController", []interface{}{"new"}},
 		{"AccountDetails", []interface{}{"new"}},
 		{"SetCurrentModel", []interface{}{"new", "admin/mymodel"}},
-		{"SetCurrentController", []interface{}{"new"}},
 	})
 	c.Assert(s.store.Models["new"].CurrentModel, gc.Equals, "admin/mymodel")
 }
@@ -247,11 +246,9 @@ func (s *SwitchSimpleSuite) TestSwitchControllerToDifferentControllerCurrentMode
 		{"CurrentController", nil},
 		{"ControllerByName", []interface{}{"old"}},
 		{"CurrentModel", []interface{}{"old"}},
-		{"ControllerByName", []interface{}{"new:mymodel"}},
-		{"ControllerByName", []interface{}{"new"}},
+		{"SetCurrentController", []interface{}{"new"}},
 		{"AccountDetails", []interface{}{"new"}},
 		{"SetCurrentModel", []interface{}{"new", "admin/mymodel"}},
-		{"SetCurrentController", []interface{}{"new"}},
 	})
 }
 
@@ -298,7 +295,7 @@ func (s *SwitchSimpleSuite) TestSwitchUnknownCurrentControllerRefreshModelsStill
 	s.store.CurrentControllerName = "ctrl"
 	s.addController(c, "ctrl")
 	_, err := s.run(c, "unknown")
-	c.Assert(err, gc.ErrorMatches, `"unknown" is not the name of a model or controller`)
+	c.Assert(err, gc.ErrorMatches, `"ctrl:unknown" is not the name of a model or controller`)
 	s.CheckCallNames(c, "RefreshModels")
 }
 
@@ -354,6 +351,7 @@ func (s *SwitchSimpleSuite) TestSwitchCurrentModelInStore(c *gc.C) {
 		{"ControllerByName", []interface{}{"same"}},
 		{"CurrentModel", []interface{}{"same"}},
 		{"ControllerByName", []interface{}{"mymodel"}},
+		{"SetCurrentController", []interface{}{"same"}},
 		{"AccountDetails", []interface{}{"same"}},
 		{"SetCurrentModel", []interface{}{"same", "admin/mymodel"}},
 	})
@@ -364,5 +362,231 @@ func (s *SwitchSimpleSuite) TestSwitchCurrentModelNoLongerInStore(c *gc.C) {
 	s.addController(c, "same")
 	s.store.Models["same"] = &jujuclient.ControllerModels{CurrentModel: "admin/mymodel"}
 	_, err := s.run(c, "mymodel")
-	c.Assert(err, gc.ErrorMatches, `"mymodel" is not the name of a model or controller`)
+	c.Assert(err, gc.ErrorMatches, `"same:mymodel" is not the name of a model or controller`)
+}
+
+func (s *SwitchSimpleSuite) TestSwitchPreviousControllerAndModelThroughFlagsShouldFail(c *gc.C) {
+	s.store.CurrentControllerName = "currentCtrl"
+	s.store.PreviousControllerName = "previousCtrl"
+	s.addController(c, "currentCtrl")
+	s.addController(c, "previousCtrl")
+
+	// juju switch -m model -c controller: # Should fails
+	_, err := s.run(c, "-m", "model", "-c", "controller")
+
+	c.Assert(err, gc.ErrorMatches, "cannot specify both a --model and --controller")
+}
+
+func (s *SwitchSimpleSuite) TestSwitchPreviousController(c *gc.C) {
+	s.store.CurrentControllerName = "currentCtrl"
+	s.store.PreviousControllerName = "previousCtrl"
+	s.addController(c, "currentCtrl")
+	s.addController(c, "previousCtrl")
+
+	// juju switch -c - # Should switch to previous controller
+	context, err := s.run(c, "-c", "-")
+
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stderr(context), gc.Equals, "currentCtrl (controller) -> previousCtrl (controller)\n")
+}
+
+func (s *SwitchSimpleSuite) TestSwitchPreviousControllerWhichDoesntExists(c *gc.C) {
+	s.store.CurrentControllerName = "currentCtrl"
+	s.store.PreviousControllerName = "noCtrl"
+	s.addController(c, "currentCtrl")
+
+	// juju switch --controller - # previous controller may have been deleted, should do nothing
+	_, err := s.run(c, "--controller", "-")
+
+	c.Assert(err, gc.ErrorMatches, "controller noCtrl not found")
+}
+
+func (s *SwitchSimpleSuite) TestSwitchPreviousControllerWhichIsEmpty(c *gc.C) {
+	s.store.CurrentControllerName = "currentCtrl"
+	s.addController(c, "currentCtrl")
+
+	// juju switch -c - # no previous controller may have been deleted, should do nothing
+	_, err := s.run(c, "-c", "-")
+
+	c.Assert(err, gc.ErrorMatches, "previous controller not found")
+}
+
+func (s *SwitchSimpleSuite) TestSwitchPreviousModel(c *gc.C) {
+	s.store.CurrentControllerName = "ctrl"
+	s.addController(c, "ctrl")
+	s.store.Models["ctrl"] = &jujuclient.ControllerModels{
+		Models: map[string]jujuclient.ModelDetails{"admin/current-model": {},
+			"admin/previous-model": {}},
+		CurrentModel:  "admin/current-model",
+		PreviousModel: "admin/previous-model",
+	}
+
+	// juju switch --model - # Should switch to previous model in current controller
+	context, err := s.run(c, "--model", "-")
+
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stderr(context), gc.Equals, "ctrl:admin/current-model -> ctrl:admin/previous-model\n")
+	c.Assert(s.store.Models["ctrl"].CurrentModel, gc.Equals, "admin/previous-model")
+	c.Assert(s.store.Models["ctrl"].PreviousModel, gc.Equals, "admin/current-model")
+}
+
+func (s *SwitchSimpleSuite) TestSwitchPreviousModelWhichDoesntExits(c *gc.C) {
+	s.store.CurrentControllerName = "ctrl"
+	s.addController(c, "ctrl")
+	s.store.Models["ctrl"] = &jujuclient.ControllerModels{
+		Models:        map[string]jujuclient.ModelDetails{"admin/current-model": {}},
+		CurrentModel:  "admin/current-model",
+		PreviousModel: "admin/previous-model",
+	}
+
+	// juju switch -m - # previous model may have been deleted, should do nothing
+	_, err := s.run(c, "-m", "-")
+
+	c.Assert(err, gc.ErrorMatches, `"ctrl:admin/previous-model" is not the name of a model or controller`)
+}
+
+func (s *SwitchSimpleSuite) TestSwitchPreviousModelWhichIsEmpty(c *gc.C) {
+	s.store.CurrentControllerName = "ctrl"
+	s.addController(c, "ctrl")
+	s.store.Models["ctrl"] = &jujuclient.ControllerModels{
+		Models:       map[string]jujuclient.ModelDetails{"admin/current-model": {}},
+		CurrentModel: "admin/current-model",
+	}
+
+	// juju switch -m - # previous model may have been deleted, should do nothing
+	_, err := s.run(c, "-m", "-")
+
+	c.Assert(err, gc.ErrorMatches, `previous model for controller ctrl not found`)
+}
+
+func (s *SwitchSimpleSuite) TestSwitchPreviousAcrossControllers(c *gc.C) {
+	s.store.CurrentControllerName = "current-ctrl"
+	s.store.PreviousControllerName = "previous-ctrl"
+	s.store.HasControllerChangedOnPreviousSwitch = true
+	s.addController(c, "current-ctrl")
+	s.addController(c, "previous-ctrl")
+	s.store.Models["current-ctrl"] = &jujuclient.ControllerModels{
+		Models: map[string]jujuclient.ModelDetails{"admin/current-model": {},
+			"admin/previous-model": {}},
+		CurrentModel:  "admin/current-model",
+		PreviousModel: "admin/previous-model",
+	}
+	s.store.Models["previous-ctrl"] = &jujuclient.ControllerModels{
+		Models: map[string]jujuclient.ModelDetails{"admin/current-model": {},
+			"admin/previous-model": {}},
+		CurrentModel:  "admin/current-model",
+		PreviousModel: "admin/previous-model",
+	}
+
+	// juju switch -
+	context, err := s.run(c, "-")
+
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stderr(context), gc.Equals, "current-ctrl:admin/current-model -> previous-ctrl:admin/current-model\n")
+	c.Assert(s.store.Models["current-ctrl"].CurrentModel, gc.Equals, "admin/current-model")
+	c.Assert(s.store.Models["current-ctrl"].PreviousModel, gc.Equals, "admin/previous-model")
+	c.Assert(s.store.Models["previous-ctrl"].CurrentModel, gc.Equals, "admin/current-model")
+	c.Assert(s.store.Models["previous-ctrl"].PreviousModel, gc.Equals, "admin/previous-model")
+}
+
+func (s *SwitchSimpleSuite) TestSwitchPreviousAcrossModels(c *gc.C) {
+	s.store.CurrentControllerName = "current-ctrl"
+	s.store.PreviousControllerName = "current-ctrl"
+	s.store.HasControllerChangedOnPreviousSwitch = false
+	s.addController(c, "current-ctrl")
+	s.addController(c, "another-ctrl")
+	s.store.Models["current-ctrl"] = &jujuclient.ControllerModels{
+		Models: map[string]jujuclient.ModelDetails{"admin/current-model": {},
+			"admin/previous-model": {}},
+		CurrentModel:  "admin/current-model",
+		PreviousModel: "admin/previous-model",
+	}
+
+	// juju switch -
+	context, err := s.run(c, "-")
+
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stderr(context), gc.Equals, "current-ctrl:admin/current-model -> current-ctrl:admin/previous-model\n")
+	c.Assert(s.store.Models["current-ctrl"].CurrentModel, gc.Equals, "admin/previous-model")
+	c.Assert(s.store.Models["current-ctrl"].PreviousModel, gc.Equals, "admin/current-model")
+}
+
+func (s *SwitchSimpleSuite) TestSwitchPreviousAcrossModels2(c *gc.C) {
+	s.store.CurrentControllerName = "current-ctrl"
+	s.store.PreviousControllerName = "current-ctrl"
+	s.addController(c, "current-ctrl")
+	s.addController(c, "another-ctrl")
+	s.store.Models["current-ctrl"] = &jujuclient.ControllerModels{
+		Models: map[string]jujuclient.ModelDetails{"admin/current-model": {},
+			"admin/previous-model": {}},
+		CurrentModel:  "admin/current-model",
+		PreviousModel: "admin/previous-model",
+	}
+
+	// juju switch -
+	context, err := s.run(c, "-")
+
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmdtesting.Stderr(context), gc.Equals, "current-ctrl:admin/current-model -> current-ctrl:admin/previous-model\n")
+	c.Assert(s.store.Models["current-ctrl"].CurrentModel, gc.Equals, "admin/previous-model")
+	c.Assert(s.store.Models["current-ctrl"].PreviousModel, gc.Equals, "admin/current-model")
+}
+
+func (s *SwitchSimpleSuite) TestSwitchPreviousControllerTwice(c *gc.C) {
+	s.store.CurrentControllerName = "currentCtrl"
+	s.store.PreviousControllerName = "previousCtrl"
+	s.addController(c, "currentCtrl")
+	s.addController(c, "previousCtrl")
+
+	// juju switch --controller - && juju switch -c - # Should return to current controller
+	_, err := s.run(c, "--controller", "-")
+	c.Assert(err, jc.ErrorIsNil)
+	context, err := s.run(c, "-c", "-")
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(cmdtesting.Stderr(context), gc.Equals, "previousCtrl (controller) -> currentCtrl (controller)\n")
+}
+
+func (s *SwitchSimpleSuite) TestSwitchPreviousModelTwice(c *gc.C) {
+	s.store.CurrentControllerName = "ctrl"
+	s.addController(c, "ctrl")
+	s.store.Models["ctrl"] = &jujuclient.ControllerModels{
+		Models: map[string]jujuclient.ModelDetails{"admin/current-model": {},
+			"admin/previous-model": {}},
+		CurrentModel:  "admin/current-model",
+		PreviousModel: "admin/previous-model",
+	}
+
+	// juju switch --model - && juju switch -m -  # Should switch to current model in current controller
+	_, err := s.run(c, "--model", "-")
+	c.Assert(err, jc.ErrorIsNil)
+	context, err := s.run(c, "-m", "-")
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(cmdtesting.Stderr(context), gc.Equals, "ctrl:admin/previous-model -> ctrl:admin/current-model\n")
+	c.Assert(s.store.Models["ctrl"].CurrentModel, gc.Equals, "admin/current-model")
+	c.Assert(s.store.Models["ctrl"].PreviousModel, gc.Equals, "admin/previous-model")
+}
+
+func (s *SwitchSimpleSuite) TestSwitchPreviousModelThenController(c *gc.C) {
+	s.store.CurrentControllerName = "ctrl-1"
+	s.store.PreviousControllerName = "ctrl-2"
+	s.addController(c, "ctrl-1")
+	s.addController(c, "ctrl-2")
+	s.store.Models["ctrl-1"] = &jujuclient.ControllerModels{
+		Models: map[string]jujuclient.ModelDetails{"admin/current-model": {},
+			"admin/previous-model": {}},
+		CurrentModel:  "admin/current-model",
+		PreviousModel: "admin/previous-model",
+	}
+
+	// juju switch --model - && juju switch -c -  # Should switch to previous model in current controller, then go to the previous controller
+	_, err := s.run(c, "--model", "-")
+	c.Assert(err, jc.ErrorIsNil)
+	context, err := s.run(c, "-c", "-")
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(cmdtesting.Stderr(context), gc.Equals, "ctrl-1:admin/previous-model -> ctrl-2 (controller)\n")
+	c.Assert(s.store.Models["ctrl-1"].CurrentModel, gc.Equals, "admin/previous-model")
+	c.Assert(s.store.Models["ctrl-1"].PreviousModel, gc.Equals, "admin/current-model")
 }

--- a/cmd/juju/commands/switch_test.go
+++ b/cmd/juju/commands/switch_test.go
@@ -72,7 +72,7 @@ func (s *SwitchSimpleSuite) TestUnknownControllerNameReturnsError(c *gc.C) {
 	s.addController(c, "a-controller")
 	s.store.CurrentControllerName = "a-controller"
 	_, err := s.run(c, "another-controller:modela")
-	c.Assert(err, gc.ErrorMatches, "controller another-controller not found")
+	c.Assert(err, gc.ErrorMatches, "invalid target model: controller another-controller not found")
 }
 
 func (s *SwitchSimpleSuite) TestNoArgsCurrentModel(c *gc.C) {
@@ -295,7 +295,7 @@ func (s *SwitchSimpleSuite) TestSwitchUnknownCurrentControllerRefreshModelsStill
 	s.store.CurrentControllerName = "ctrl"
 	s.addController(c, "ctrl")
 	_, err := s.run(c, "unknown")
-	c.Assert(err, gc.ErrorMatches, `"ctrl:unknown" is not the name of a model or controller`)
+	c.Assert(err, gc.ErrorMatches, `cannot determine if "unknown" is a valid model: "ctrl:unknown" is not the name of a model or controller`)
 	s.CheckCallNames(c, "RefreshModels")
 }
 
@@ -304,7 +304,7 @@ func (s *SwitchSimpleSuite) TestSwitchUnknownCurrentControllerRefreshModelsFails
 	s.addController(c, "ctrl")
 	s.SetErrors(errors.New("not very refreshing"))
 	_, err := s.run(c, "unknown")
-	c.Assert(err, gc.ErrorMatches, "refreshing models cache: not very refreshing")
+	c.Assert(err, gc.ErrorMatches, "cannot determine if \"unknown\" is a valid model: refreshing models cache: not very refreshing")
 	s.CheckCallNames(c, "RefreshModels")
 }
 
@@ -362,7 +362,7 @@ func (s *SwitchSimpleSuite) TestSwitchCurrentModelNoLongerInStore(c *gc.C) {
 	s.addController(c, "same")
 	s.store.Models["same"] = &jujuclient.ControllerModels{CurrentModel: "admin/mymodel"}
 	_, err := s.run(c, "mymodel")
-	c.Assert(err, gc.ErrorMatches, `"same:mymodel" is not the name of a model or controller`)
+	c.Assert(err, gc.ErrorMatches, `cannot determine if "mymodel" is a valid model: "same:mymodel" is not the name of a model or controller`)
 }
 
 func (s *SwitchSimpleSuite) TestSwitchPreviousControllerAndModelThroughFlagsShouldFail(c *gc.C) {
@@ -398,7 +398,7 @@ func (s *SwitchSimpleSuite) TestSwitchPreviousControllerWhichDoesntExists(c *gc.
 	// juju switch --controller - # previous controller may have been deleted, should do nothing
 	_, err := s.run(c, "--controller", "-")
 
-	c.Assert(err, gc.ErrorMatches, "controller noCtrl not found")
+	c.Assert(err, gc.ErrorMatches, "invalid target controller: controller noCtrl not found")
 }
 
 func (s *SwitchSimpleSuite) TestSwitchPreviousControllerWhichIsEmpty(c *gc.C) {
@@ -408,7 +408,7 @@ func (s *SwitchSimpleSuite) TestSwitchPreviousControllerWhichIsEmpty(c *gc.C) {
 	// juju switch -c - # no previous controller may have been deleted, should do nothing
 	_, err := s.run(c, "-c", "-")
 
-	c.Assert(err, gc.ErrorMatches, "previous controller not found")
+	c.Assert(err, gc.ErrorMatches, "interpreting \"--controller -\": previous controller not found")
 }
 
 func (s *SwitchSimpleSuite) TestSwitchPreviousModel(c *gc.C) {
@@ -442,7 +442,7 @@ func (s *SwitchSimpleSuite) TestSwitchPreviousModelWhichDoesntExits(c *gc.C) {
 	// juju switch -m - # previous model may have been deleted, should do nothing
 	_, err := s.run(c, "-m", "-")
 
-	c.Assert(err, gc.ErrorMatches, `"ctrl:admin/previous-model" is not the name of a model or controller`)
+	c.Assert(err, gc.ErrorMatches, `invalid target model: "ctrl:admin/previous-model" is not the name of a model or controller`)
 }
 
 func (s *SwitchSimpleSuite) TestSwitchPreviousModelWhichIsEmpty(c *gc.C) {
@@ -456,7 +456,7 @@ func (s *SwitchSimpleSuite) TestSwitchPreviousModelWhichIsEmpty(c *gc.C) {
 	// juju switch -m - # previous model may have been deleted, should do nothing
 	_, err := s.run(c, "-m", "-")
 
-	c.Assert(err, gc.ErrorMatches, `previous model for controller ctrl not found`)
+	c.Assert(err, gc.ErrorMatches, `interpreting "--model -": previous model for controller ctrl not found`)
 }
 
 func (s *SwitchSimpleSuite) TestSwitchPreviousAcrossControllers(c *gc.C) {

--- a/cmd/juju/controller/addmodel.go
+++ b/cmd/juju/controller/addmodel.go
@@ -281,6 +281,9 @@ func (c *addModelCommand) Run(ctx *cmd.Context) error {
 			return errors.Trace(err)
 		}
 		if !c.noSwitch {
+			if err := store.SetCurrentController(controllerName); err != nil {
+				return errors.Trace(err)
+			}
 			if err := store.SetCurrentModel(controllerName, c.Name); err != nil {
 				return errors.Trace(err)
 			}

--- a/cmd/juju/controller/addmodel_test.go
+++ b/cmd/juju/controller/addmodel_test.go
@@ -661,6 +661,24 @@ func (s *AddModelSuite) TestAddStoresValues(c *gc.C) {
 	})
 }
 
+func (s *AddModelSuite) TestSwitch(c *gc.C) {
+	s.SetFeatureFlags(featureflag.Branches)
+	const controllerName = "test-master"
+
+	// if the previous switch was on another controller, add model would have switch to model
+	s.store.HasControllerChangedOnPreviousSwitch = true
+
+	_, err := s.run(c, "test")
+	c.Assert(err, jc.ErrorIsNil)
+
+	modelName, err := s.store.CurrentModel(controllerName)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(s.store.HasControllerChangedOnPreviousSwitch, gc.Equals, false)
+	c.Check(s.store.CurrentControllerName, gc.Equals, controllerName)
+	c.Check(modelName, gc.Equals, "bob/test")
+}
+
 func (s *AddModelSuite) TestNoSwitch(c *gc.C) {
 	s.SetFeatureFlags(featureflag.Branches)
 	const controllerName = "test-master"

--- a/cmd/juju/user/utils_clientstore_mock_test.go
+++ b/cmd/juju/user/utils_clientstore_mock_test.go
@@ -551,6 +551,85 @@ func (c *MockClientStoreModelByNameCall) DoAndReturn(f func(string, string) (*ju
 	return c
 }
 
+// PreviousController mocks base method.
+func (m *MockClientStore) PreviousController() (string, bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PreviousController")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// PreviousController indicates an expected call of PreviousController.
+func (mr *MockClientStoreMockRecorder) PreviousController() *MockClientStorePreviousControllerCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PreviousController", reflect.TypeOf((*MockClientStore)(nil).PreviousController))
+	return &MockClientStorePreviousControllerCall{Call: call}
+}
+
+// MockClientStorePreviousControllerCall wrap *gomock.Call
+type MockClientStorePreviousControllerCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockClientStorePreviousControllerCall) Return(arg0 string, arg1 bool, arg2 error) *MockClientStorePreviousControllerCall {
+	c.Call = c.Call.Return(arg0, arg1, arg2)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockClientStorePreviousControllerCall) Do(f func() (string, bool, error)) *MockClientStorePreviousControllerCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockClientStorePreviousControllerCall) DoAndReturn(f func() (string, bool, error)) *MockClientStorePreviousControllerCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// PreviousModel mocks base method.
+func (m *MockClientStore) PreviousModel(arg0 string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PreviousModel", arg0)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PreviousModel indicates an expected call of PreviousModel.
+func (mr *MockClientStoreMockRecorder) PreviousModel(arg0 any) *MockClientStorePreviousModelCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PreviousModel", reflect.TypeOf((*MockClientStore)(nil).PreviousModel), arg0)
+	return &MockClientStorePreviousModelCall{Call: call}
+}
+
+// MockClientStorePreviousModelCall wrap *gomock.Call
+type MockClientStorePreviousModelCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockClientStorePreviousModelCall) Return(arg0 string, arg1 error) *MockClientStorePreviousModelCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockClientStorePreviousModelCall) Do(f func(string) (string, error)) *MockClientStorePreviousModelCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockClientStorePreviousModelCall) DoAndReturn(f func(string) (string, error)) *MockClientStorePreviousModelCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // RemoveAccount mocks base method.
 func (m *MockClientStore) RemoveAccount(arg0 string) error {
 	m.ctrl.T.Helper()

--- a/jujuclient/controllers.go
+++ b/jujuclient/controllers.go
@@ -72,4 +72,10 @@ type Controllers struct {
 
 	// CurrentController is the name of the active controller.
 	CurrentController string `yaml:"current-controller,omitempty"`
+
+	// PreviousController is the name of the previous active controller.
+	PreviousController string `yaml:"previous-controller,omitempty"`
+
+	// HasControllerChangedOnPreviousSwitch represents whether the controller has changed during the previous switch.
+	HasControllerChangedOnPreviousSwitch bool `yaml:"has-controller-changed-on-previous-switch"`
 }

--- a/jujuclient/controllersfile_test.go
+++ b/jujuclient/controllersfile_test.go
@@ -50,6 +50,7 @@ controllers:
         controller-machine-count: 0
         active-controller-machine-count: 0
 current-controller: mallards
+has-controller-changed-on-previous-switch: false
 `
 
 func (s *ControllersFileSuite) TestWriteFile(c *gc.C) {
@@ -133,6 +134,7 @@ controllers:
         controller-machine-count: 0
         active-controller-machine-count: 0%s
 current-controller: aws-test
+has-controller-changed-on-previous-switch: false
 `
 	modelCount := `
         model-count: 2`

--- a/jujuclient/file.go
+++ b/jujuclient/file.go
@@ -816,12 +816,12 @@ func (s *store) AllCredentials() (map[string]cloud.CloudCredential, error) {
 	}
 	cloudNames := credentialCollection.CloudNames()
 	cloudCredentials := make(map[string]cloud.CloudCredential)
-	for _, cloud := range cloudNames {
-		v, err := credentialCollection.CloudCredential(cloud)
+	for _, cloudName := range cloudNames {
+		v, err := credentialCollection.CloudCredential(cloudName)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		cloudCredentials[cloud] = *v
+		cloudCredentials[cloudName] = *v
 	}
 	return cloudCredentials, nil
 }

--- a/jujuclient/file.go
+++ b/jujuclient/file.go
@@ -115,6 +115,25 @@ func (s *store) CurrentController() (string, error) {
 	return controllers.CurrentController, nil
 }
 
+// PreviousController implements ControllerGetter
+func (s *store) PreviousController() (string, bool, error) {
+	releaser, err := s.acquireLock()
+	if err != nil {
+		return "", false, errors.Annotate(err,
+			"cannot acquire lock file to get the previous controller name",
+		)
+	}
+	defer releaser.Release()
+	controllers, err := ReadControllersFile(JujuControllersPath())
+	if err != nil {
+		return "", false, errors.Trace(err)
+	}
+	if controllers.PreviousController == "" {
+		return "", false, errors.NotFoundf("previous controller")
+	}
+	return controllers.PreviousController, controllers.HasControllerChangedOnPreviousSwitch, nil
+}
+
 // ControllerByName implements ControllersGetter.
 func (s *store) ControllerByName(name string) (*ControllerDetails, error) {
 	if err := ValidateControllerName(name); err != nil {
@@ -266,10 +285,11 @@ func (s *store) SetCurrentController(name string) error {
 	if _, ok := controllers.Controllers[name]; !ok {
 		return errors.NotFoundf("controller %v", name)
 	}
-	if controllers.CurrentController == name {
-		return nil
+	controllers.HasControllerChangedOnPreviousSwitch = controllers.CurrentController != name
+	if controllers.HasControllerChangedOnPreviousSwitch {
+		controllers.PreviousController = controllers.CurrentController
+		controllers.CurrentController = name
 	}
-	controllers.CurrentController = name
 	return WriteControllersFile(controllers)
 }
 
@@ -436,6 +456,7 @@ func (s *store) SetCurrentModel(controllerName, modelName string) error {
 					modelName,
 				)
 			}
+			models.PreviousModel = models.CurrentModel
 			models.CurrentModel = modelName
 			return true, nil
 		},
@@ -533,6 +554,38 @@ Use "juju switch" to select one of the following models:
 		return "", errors.NewNotFound(nil, msg)
 	}
 	return controllerModels.CurrentModel, nil
+}
+
+// PreviousModel implements ModelGetter.
+func (s *store) PreviousModel(controllerName string) (string, error) {
+	if err := ValidateControllerName(controllerName); err != nil {
+		return "", errors.Trace(err)
+	}
+
+	releaser, err := s.acquireLock()
+	if err != nil {
+		return "", errors.Annotatef(err,
+			"cannot acquire lock file for getting current model for controller %s", controllerName,
+		)
+	}
+	defer releaser.Release()
+
+	all, err := ReadModelsFile(JujuModelsPath())
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	controllerModels, ok := all[controllerName]
+	if !ok {
+		return "", errors.NotFoundf(
+			"previous model for controller %s",
+			controllerName,
+		)
+	}
+
+	if controllerModels.PreviousModel == "" {
+		return "", errors.NotFoundf("previous model for controller %s", controllerName)
+	}
+	return controllerModels.PreviousModel, nil
 }
 
 // ModelByName implements ModelGetter.

--- a/jujuclient/interface.go
+++ b/jujuclient/interface.go
@@ -231,6 +231,12 @@ type ControllerGetter interface {
 	// If there is no current controller, an error satisfying
 	// errors.IsNotFound will be returned.
 	CurrentController() (string, error)
+
+	// PreviousController returns the name of the previous controller used.
+	// If there is no previous controller (for instance controller has never been switched),
+	// an error satisfying errors.IsNotFound will be returned.
+	// It also retrieve if the last switch update the current controller or just shift the model
+	PreviousController() (string, bool, error)
 }
 
 // ModelUpdater stores model details.
@@ -277,6 +283,12 @@ type ModelGetter interface {
 	// model for the controller, an error satisfying
 	// errors.IsNotFound is returned.
 	CurrentModel(controllerName string) (string, error)
+
+	// PreviousModel returns the name of the previous model for
+	// the specified controller. If there is no previous
+	// model for the controller, an error satisfying
+	// errors.IsNotFound is returned.
+	PreviousModel(controllerName string) (string, error)
 
 	// ModelByName returns the model with the specified controller,
 	// and model name. If a model with the specified name does not

--- a/jujuclient/jujuclienttesting/stub.go
+++ b/jujuclient/jujuclienttesting/stub.go
@@ -21,12 +21,14 @@ type StubStore struct {
 	RemoveControllerFunc         func(name string) error
 	SetCurrentControllerFunc     func(name string) error
 	CurrentControllerFunc        func() (string, error)
+	PreviousControllerFunc       func() (string, bool, error)
 
 	UpdateModelFunc     func(controller, model string, details jujuclient.ModelDetails) error
 	SetCurrentModelFunc func(controller, model string) error
 	RemoveModelFunc     func(controller, model string) error
 	AllModelsFunc       func(controller string) (map[string]jujuclient.ModelDetails, error)
 	CurrentModelFunc    func(controller string) (string, error)
+	PreviousModelFunc   func(controller string) (string, error)
 	ModelByNameFunc     func(controller, model string) (*jujuclient.ModelDetails, error)
 	SetModelsFunc       func(controllerName string, models map[string]jujuclient.ModelDetails) error
 
@@ -72,6 +74,9 @@ func NewStubStore() *StubStore {
 	result.CurrentControllerFunc = func() (string, error) {
 		return "", result.Stub.NextErr()
 	}
+	result.PreviousControllerFunc = func() (string, bool, error) {
+		return "", false, result.Stub.NextErr()
+	}
 
 	result.UpdateModelFunc = func(controller, model string, details jujuclient.ModelDetails) error {
 		return result.Stub.NextErr()
@@ -86,6 +91,9 @@ func NewStubStore() *StubStore {
 		return nil, result.Stub.NextErr()
 	}
 	result.CurrentModelFunc = func(controller string) (string, error) {
+		return "", result.Stub.NextErr()
+	}
+	result.PreviousModelFunc = func(controller string) (string, error) {
 		return "", result.Stub.NextErr()
 	}
 	result.ModelByNameFunc = func(controller, model string) (*jujuclient.ModelDetails, error) {
@@ -140,12 +148,14 @@ func WrapClientStore(underlying jujuclient.ClientStore) *StubStore {
 	stub.RemoveControllerFunc = underlying.RemoveController
 	stub.SetCurrentControllerFunc = underlying.SetCurrentController
 	stub.CurrentControllerFunc = underlying.CurrentController
+	stub.PreviousControllerFunc = underlying.PreviousController
 	stub.UpdateModelFunc = underlying.UpdateModel
 	stub.SetModelsFunc = underlying.SetModels
 	stub.SetCurrentModelFunc = underlying.SetCurrentModel
 	stub.RemoveModelFunc = underlying.RemoveModel
 	stub.AllModelsFunc = underlying.AllModels
 	stub.CurrentModelFunc = underlying.CurrentModel
+	stub.PreviousModelFunc = underlying.PreviousModel
 	stub.ModelByNameFunc = underlying.ModelByName
 	stub.UpdateAccountFunc = underlying.UpdateAccount
 	stub.AccountDetailsFunc = underlying.AccountDetails
@@ -204,6 +214,12 @@ func (c *StubStore) CurrentController() (string, error) {
 	return c.CurrentControllerFunc()
 }
 
+// PreviousController implements ControllersGetter.PreviousController.
+func (c *StubStore) PreviousController() (string, bool, error) {
+	c.MethodCall(c, "PreviousController")
+	return c.PreviousControllerFunc()
+}
+
 // UpdateModel implements ModelUpdater.
 func (c *StubStore) UpdateModel(controller, model string, details jujuclient.ModelDetails) error {
 	c.MethodCall(c, "UpdateModel", controller, model, details)
@@ -238,6 +254,12 @@ func (c *StubStore) AllModels(controller string) (map[string]jujuclient.ModelDet
 func (c *StubStore) CurrentModel(controller string) (string, error) {
 	c.MethodCall(c, "CurrentModel", controller)
 	return c.CurrentModelFunc(controller)
+}
+
+// PreviousModel implements ModelGetter.
+func (c *StubStore) PreviousModel(controller string) (string, error) {
+	c.MethodCall(c, "PreviousModel", controller)
+	return c.PreviousModelFunc(controller)
 }
 
 // ModelByName implements ModelGetter.

--- a/jujuclient/mem.go
+++ b/jujuclient/mem.go
@@ -19,14 +19,16 @@ var _ ClientStore = (*MemStore)(nil)
 type MemStore struct {
 	mu sync.Mutex
 
-	Controllers           map[string]ControllerDetails
-	CurrentControllerName string
-	Models                map[string]*ControllerModels
-	Accounts              map[string]AccountDetails
-	Credentials           map[string]cloud.CloudCredential
-	BootstrapConfig       map[string]BootstrapConfig
-	CookieJars            map[string]*cookiejar.Jar
-	ImmutableAccount      bool
+	Controllers                          map[string]ControllerDetails
+	CurrentControllerName                string
+	PreviousControllerName               string
+	HasControllerChangedOnPreviousSwitch bool
+	Models                               map[string]*ControllerModels
+	Accounts                             map[string]AccountDetails
+	Credentials                          map[string]cloud.CloudCredential
+	BootstrapConfig                      map[string]BootstrapConfig
+	CookieJars                           map[string]*cookiejar.Jar
+	ImmutableAccount                     bool
 }
 
 // NewMemStore returns a new MemStore.
@@ -102,6 +104,17 @@ func (c *MemStore) CurrentController() (string, error) {
 	return c.CurrentControllerName, nil
 }
 
+// PreviousController implements ControllerGetter.PreviousController
+func (c *MemStore) PreviousController() (string, bool, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.PreviousControllerName == "" {
+		return "", false, errors.NotFoundf("previous controller")
+	}
+	return c.PreviousControllerName, c.HasControllerChangedOnPreviousSwitch, nil
+}
+
 // SetCurrentController implements ControllerUpdater.SetCurrentController
 func (c *MemStore) SetCurrentController(name string) error {
 	c.mu.Lock()
@@ -113,7 +126,11 @@ func (c *MemStore) SetCurrentController(name string) error {
 	if _, ok := c.Controllers[name]; !ok {
 		return errors.NotFoundf("controller %s", name)
 	}
-	c.CurrentControllerName = name
+	c.HasControllerChangedOnPreviousSwitch = c.CurrentControllerName != name
+	if c.HasControllerChangedOnPreviousSwitch {
+		c.PreviousControllerName = c.CurrentControllerName
+		c.CurrentControllerName = name
+	}
 	return nil
 }
 
@@ -277,6 +294,7 @@ func (c *MemStore) SetCurrentModel(controllerName, modelName string) error {
 	if _, ok := controllerModels.Models[modelName]; !ok {
 		return errors.NotFoundf("model %s:%s", controllerName, modelName)
 	}
+	controllerModels.PreviousModel = controllerModels.CurrentModel
 	controllerModels.CurrentModel = modelName
 	return nil
 }
@@ -334,6 +352,24 @@ func (c *MemStore) CurrentModel(controller string) (string, error) {
 		return "", errors.NotFoundf("current model for controller %s", controller)
 	}
 	return controllerModels.CurrentModel, nil
+}
+
+// PreviousModel implements ModelGetter.
+func (c *MemStore) PreviousModel(controller string) (string, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if err := ValidateControllerName(controller); err != nil {
+		return "", errors.Trace(err)
+	}
+	controllerModels, ok := c.Models[controller]
+	if !ok {
+		return "", errors.NotFoundf("previous model for controller %s", controller)
+	}
+	if controllerModels.PreviousModel == "" {
+		return "", errors.NotFoundf("previous model for controller %s", controller)
+	}
+	return controllerModels.PreviousModel, nil
 }
 
 // ModelByName implements ModelGetter.

--- a/jujuclient/models.go
+++ b/jujuclient/models.go
@@ -93,8 +93,8 @@ func addModelType(models map[string]*ControllerModels) error {
 // migrateLocalModelUsers strips any @local domains from any qualified model names.
 func migrateLocalModelUsers(usermodels map[string]*ControllerModels) error {
 	changes := false
-	for _, modelDetails := range usermodels {
-		for name, model := range modelDetails.Models {
+	for _, userModel := range usermodels {
+		for name, modelDetails := range userModel.Models {
 			migratedName, changed, err := migrateModelName(name)
 			if err != nil {
 				return errors.Trace(err)
@@ -102,18 +102,18 @@ func migrateLocalModelUsers(usermodels map[string]*ControllerModels) error {
 			if !changed {
 				continue
 			}
-			delete(modelDetails.Models, name)
-			modelDetails.Models[migratedName] = model
+			delete(userModel.Models, name)
+			userModel.Models[migratedName] = modelDetails
 			changes = true
 		}
-		migratedName, changed, err := migrateModelName(modelDetails.CurrentModel)
+		migratedName, changed, err := migrateModelName(userModel.CurrentModel)
 		if err != nil {
 			return errors.Trace(err)
 		}
 		if !changed {
 			continue
 		}
-		modelDetails.CurrentModel = migratedName
+		userModel.CurrentModel = migratedName
 	}
 	if changes {
 		return WriteModelsFile(usermodels)

--- a/jujuclient/models.go
+++ b/jujuclient/models.go
@@ -170,6 +170,9 @@ type ControllerModels struct {
 
 	// CurrentModel is the name of the active model for the account.
 	CurrentModel string `yaml:"current-model,omitempty"`
+
+	// PreviousModel is the name of the previous model for the account.
+	PreviousModel string `yaml:"previous-model,omitempty"`
 }
 
 // JoinOwnerModelName returns a model name qualified with the model owner.


### PR DESCRIPTION
It implements a new behavior to `juju switch`, similar to well known shell command `cd -`

It also introduce a flag-based way to switch, through `-c` and `-m` flags (as done in other command):
* `juju switch -m a-model` equivalent to `juju switch :a-model`
* `juju switch -c a-controller` equivalent to `juju switch a-controller:`

To implements the behavior similar with `cd -`, this PR introduce the placeholder `-` which mean "previous". So:

* `juju switch -` # switch to previous state controller:model (current model of previous controller if the controller has changed, previous model of current controller if model has changed)
* `juju switch -m -` # switch to previous model, current controller
* `juju switch -c -` # switch to previous controller

I also added two related but independent commit:

* A commit to remove a duplicate TU for the switch command
* A commit which remove several golang warning from the files I have modified.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Unit test: `TEST_PACKAGES="./cmd/juju/commands/... -count=1 -race -check.vv" make run-go-tests`

However jujucli state is stored in a file which use handled by [jujuclient/file.go] which has no UT (and the store implemented there is replace by a in-memory store and thus uncovered). It requires few manual testing.

```sh
# providing we have 
# ctrl1 with m1 & m2
# ctrl2 with m1 & m2

# Arrange
juju switch ctrl1:m1 # set previous model for ctrl1
juju switch m2  # set current model for ctrl1
juju switch ctrl2:m1  # set previous model for ctrl2
juju switch m2  # set current model for ctrl2

# Assert
juju switch -c - # ctrl2:m2 -> ctrl1:m2 (switch controller)
juju switch -m - # ctrl1:m2 -> ctrl1:m1 (switch model)
juju switch - # ctrl1:m1 -> ctrl1:m2 (switch model)
juju switch ctrl2:m1 # ctrl1:m2 -> ctrl2:m1 (switch controller & model)
juju switch - # ctrl2:m1 -> ctrl1:m2 (switch controller)
juju add-model m3 # ctrl1:m2 -> ctrl1:m3 (switch model)
juju switch - # ctrl1:m3 -> ctrl1:m2 (switch model)
```

## Documentation changes

[juju switch](https://juju.is/docs/juju/juju-switch) command documentation need to be updated 

## Links

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/1988426

**Jira card:** [JUJU-6168](https://warthogs.atlassian.net/browse/JUJU-6168)

[JUJU-6168]: https://warthogs.atlassian.net/browse/JUJU-6168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ