### PR TITLE
chore: backport storage test changes to 3.6

### DIFF
--- a/tests/suites/storage/persistent_storage.sh
+++ b/tests/suites/storage/persistent_storage.sh
@@ -66,7 +66,8 @@ run_persistent_storage() {
 	echo "Check properties of single filesystem storage unit: PASSED."
 
 	# assert charm removal message for single block and filesystem storage
-	removal_msg=$(juju remove-application dummy-storage 2>&1)
+	echo "Remove application, check that storage is also removed"
+	removal_msg=$(juju remove-application --no-prompt dummy-storage 2>&1)
 	echo "${removal_msg}" | sed -sn 3p | sed 's/^-//' | check "will remove storage single-fs/1"
 	echo "${removal_msg}" | sed -sn 4p | sed 's/^-//' | check "will detach storage single-blk/0"
 	#
@@ -77,6 +78,7 @@ run_persistent_storage() {
 	wait_for "{}" ".applications" # we use this wait_for command as an indicator that the application
 	# status has changed and now we can check for the storage status and assert that indeed the
 	# single filesystem storage unit has been removed successfully.
+	sleep 5 # avoid races, sometimes the storage disappears just after the app
 	assert_storage false '.storage | has("single-fs/1")'
 
 	echo "Checking total number of storage unit(s)."
@@ -110,7 +112,7 @@ run_persistent_storage() {
 	assert_storage "attached" '.volumes | ."0" | .status | .current'
 
 	# remove charm
-	juju remove-application dummy-storage
+	juju remove-application --no-prompt dummy-storage
 	# wait for application to be removed
 	wait_for "{}" ".applications"
 	# persistent storage should remain after remove-application


### PR DESCRIPTION
<!-- Why this change is needed and what it does. -->

The `storage` test suite was a bit out of date, but it was revived and fixed in #17490. This PR backports the storage test changes from that PR, so that we have a point of comparison between 3.6 and 4.0.

The only change noted is the following storage pool appears by default with AWS on 3.6, but not on 4.0:
```
"ebs-ssd":{"provider":"ebs","attrs":{"volume-type":"ssd"}}
```

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- ~[ ] Go unit tests, with comments saying what you're testing~
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

<!-- Describe steps to verify that the change works. -->

Run the storage test suite (on AWS).
```
cd tests
./main.sh -p ec2 -v storage
```

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Jira card:** JUJU-6172