### PR TITLE
build: fix dependabot.yml, target-branch is a string.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,4 +24,4 @@ updates:
     assignees:
       - "hpidcock"
       - "anvial"
-    target-branch: 2.9 # these should always go to 2.9 as it may contain security fixes
+    target-branch: "2.9" # these should always go to 2.9 as it may contain security fixes


### PR DESCRIPTION
fix dependabot.yml, target-branch is a string and dependabot's schema does not coerce the type.

`The property '#/updates/1/target-branch' of type number did not match the following type: string`

https://github.com/juju/juju/network/updates -> dependabot tab to see error.