### PR TITLE
style(sqlair): use SQLair in the externalcontroller domain.

### DIFF
--- a/domain/externalcontroller/doc.go
+++ b/domain/externalcontroller/doc.go
@@ -1,0 +1,6 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package externalcontroller provides a service to keep track of external
+// controllers.
+package externalcontroller


### PR DESCRIPTION
As part of the effort to move from using the database/sql library to SQLair, get rid of all uses of StdTxn.

A todo to use IN, which SQLair now supports is implemented.
Bulk inserts are also used where appropriate.

The NewUpdateStatements function is removed and the prepare functions are moved back to where the queries are run. This function was added to avoid redoing sqlair.Prepare every time we queried but this problem has now been overcome with the use of the State.Prepare function.

Also add a doc.go to externalcontroller domain.
<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps
```
TEST_PACKAGES="./domain/externalcontroller/state/... -count=1 " TEST_FILTER="Suite" make run-go-tests
```


## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->



**Jira card:** [JUJU-5628](https://warthogs.atlassian.net/browse/JUJU-5628)



[JUJU-5628]: https://warthogs.atlassian.net/browse/JUJU-5628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ