### PR TITLE
style(sqlair): use SQLair in the flag domain

### DIFF
--- a/domain/flag/doc.go
+++ b/domain/flag/doc.go
@@ -1,0 +1,6 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package flag provides a service that keeps track of global boolean
+// operational flags. For example, whether juju has finished bootstrap.
+package flag

--- a/domain/flag/state/types.go
+++ b/domain/flag/state/types.go
@@ -1,0 +1,11 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+// dbFlag represents a flag to be serialised to the database.
+type dbFlag struct {
+	Name        string `db:"name"`
+	Value       bool   `db:"value"`
+	Description string `db:"description"`
+}


### PR DESCRIPTION
Replace uses of StdTxn with Txn in the flag domain.

This involved adding a new `dbFlag` type and modifying the queries

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps
```
TEST_PACKAGES="./domain/flag/state/... -count=1 " TEST_FILTER="Suite" make run-go-tests
```
<!-- Describe steps to verify that the change works. -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Jira card:** [JUJU-5628](https://warthogs.atlassian.net/browse/JUJU-5628)




[JUJU-5628]: https://warthogs.atlassian.net/browse/JUJU-5628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ