### PR TITLE
style(sqlair): use SQLair in the objectstore domain

### DIFF
--- a/domain/objectstore/doc.go
+++ b/domain/objectstore/doc.go
@@ -1,0 +1,9 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package objectstore provides a service to keep track of metadata about
+// objects (binary blobs) that are stored in juju's object store. These objects
+// can be any large blob of data that juju needs to store, for example, a
+// downloaded charm.
+
+package objectstore

--- a/domain/objectstore/service/service.go
+++ b/domain/objectstore/service/service.go
@@ -14,18 +14,16 @@ import (
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/core/watcher/eventsource"
 	"github.com/juju/juju/domain"
-	"github.com/juju/juju/domain/objectstore"
-	"github.com/juju/juju/internal/uuid"
 )
 
 // State describes retrieval and persistence methods for the coreobjectstore.
 type State interface {
 	// GetMetadata returns the persistence metadata for the specified path.
-	GetMetadata(ctx context.Context, path string) (objectstore.Metadata, error)
+	GetMetadata(ctx context.Context, path string) (coreobjectstore.Metadata, error)
 	// PutMetadata adds a new specified path for the persistence metadata.
-	PutMetadata(ctx context.Context, metadata objectstore.Metadata) error
+	PutMetadata(ctx context.Context, metadata coreobjectstore.Metadata) error
 	// ListMetadata returns the persistence metadata for all paths.
-	ListMetadata(ctx context.Context) ([]objectstore.Metadata, error)
+	ListMetadata(ctx context.Context) ([]coreobjectstore.Metadata, error)
 	// RemoveMetadata removes the specified path for the persistence metadata.
 	RemoveMetadata(ctx context.Context, path string) error
 	// InitialWatchStatement returns the table and the initial watch statement
@@ -84,13 +82,7 @@ func (s *Service) ListMetadata(ctx context.Context) ([]coreobjectstore.Metadata,
 
 // PutMetadata adds a new specified path for the persistence metadata.
 func (s *Service) PutMetadata(ctx context.Context, metadata coreobjectstore.Metadata) error {
-	uuid, err := uuid.NewUUID()
-	if err != nil {
-		return err
-	}
-
-	err = s.st.PutMetadata(ctx, objectstore.Metadata{
-		UUID: uuid.String(),
+	err := s.st.PutMetadata(ctx, coreobjectstore.Metadata{
 		Hash: metadata.Hash,
 		Path: metadata.Path,
 		Size: metadata.Size,

--- a/domain/objectstore/service/service_test.go
+++ b/domain/objectstore/service/service_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/juju/juju/core/changestream"
 	coreobjectstore "github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/core/watcher/watchertest"
-	"github.com/juju/juju/domain/objectstore"
 	"github.com/juju/juju/internal/uuid"
 )
 
@@ -39,7 +38,7 @@ func (s *serviceSuite) TestGetMetadata(c *gc.C) {
 		Size: 666,
 	}
 
-	s.state.EXPECT().GetMetadata(gomock.Any(), path).Return(objectstore.Metadata{
+	s.state.EXPECT().GetMetadata(gomock.Any(), path).Return(coreobjectstore.Metadata{
 		Path: metadata.Path,
 		Size: metadata.Size,
 		Hash: metadata.Hash,
@@ -61,7 +60,7 @@ func (s *serviceSuite) TestListMetadata(c *gc.C) {
 		Size: 666,
 	}
 
-	s.state.EXPECT().ListMetadata(gomock.Any()).Return([]objectstore.Metadata{{
+	s.state.EXPECT().ListMetadata(gomock.Any()).Return([]coreobjectstore.Metadata{{
 		Path: metadata.Path,
 		Hash: metadata.Hash,
 		Size: metadata.Size,
@@ -86,7 +85,7 @@ func (s *serviceSuite) TestPutMetadata(c *gc.C) {
 		Size: 666,
 	}
 
-	s.state.EXPECT().PutMetadata(gomock.Any(), gomock.AssignableToTypeOf(objectstore.Metadata{})).DoAndReturn(func(ctx context.Context, data objectstore.Metadata) error {
+	s.state.EXPECT().PutMetadata(gomock.Any(), gomock.AssignableToTypeOf(coreobjectstore.Metadata{})).DoAndReturn(func(ctx context.Context, data coreobjectstore.Metadata) error {
 		c.Check(data.Path, gc.Equals, metadata.Path)
 		c.Check(data.Size, gc.Equals, metadata.Size)
 		c.Check(data.Hash, gc.Equals, metadata.Hash)

--- a/domain/objectstore/service/state_mock_test.go
+++ b/domain/objectstore/service/state_mock_test.go
@@ -14,9 +14,9 @@ import (
 	reflect "reflect"
 
 	changestream "github.com/juju/juju/core/changestream"
+	objectstore "github.com/juju/juju/core/objectstore"
 	watcher "github.com/juju/juju/core/watcher"
 	eventsource "github.com/juju/juju/core/watcher/eventsource"
-	objectstore "github.com/juju/juju/domain/objectstore"
 	gomock "go.uber.org/mock/gomock"
 )
 

--- a/domain/objectstore/state/state.go
+++ b/domain/objectstore/state/state.go
@@ -5,16 +5,18 @@ package state
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 
+	"github.com/canonical/sqlair"
+	"github.com/juju/collections/transform"
 	"github.com/juju/errors"
 
 	coredatabase "github.com/juju/juju/core/database"
+	coreobjectstore "github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/domain"
-	"github.com/juju/juju/domain/objectstore"
 	objectstoreerrors "github.com/juju/juju/domain/objectstore/errors"
 	"github.com/juju/juju/internal/database"
+	"github.com/juju/juju/internal/uuid"
 )
 
 // State implements the domain objectstore state.
@@ -30,110 +32,136 @@ func NewState(factory coredatabase.TxnRunnerFactory) *State {
 }
 
 // GetMetadata returns the persistence metadata for the specified path.
-func (s *State) GetMetadata(ctx context.Context, path string) (objectstore.Metadata, error) {
+func (s *State) GetMetadata(ctx context.Context, path string) (coreobjectstore.Metadata, error) {
 	db, err := s.DB()
 	if err != nil {
-		return objectstore.Metadata{}, errors.Trace(err)
+		return coreobjectstore.Metadata{}, errors.Trace(err)
 	}
 
-	query := `
-SELECT p.path, p.metadata_uuid, m.size, m.hash
+	metadata := dbMetadata{Path: path}
+
+	stmt, err := s.Prepare(`
+SELECT (p.path, m.uuid, m.size, m.hash) AS (&dbMetadata.*)
 FROM object_store_metadata_path p
 LEFT JOIN object_store_metadata m ON p.metadata_uuid = m.uuid
-WHERE path = ?`
+WHERE path = $dbMetadata.path`, metadata)
+	if err != nil {
+		return coreobjectstore.Metadata{}, errors.Annotate(err, "preparing select metadata statement")
+	}
 
-	var metadata objectstore.Metadata
-	err = db.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
-		row := tx.QueryRowContext(ctx, query, path)
-		return row.Scan(&metadata.Path, &metadata.UUID, &metadata.Size, &metadata.Hash)
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		return tx.Query(ctx, stmt, metadata).Get(&metadata)
 	})
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return objectstore.Metadata{}, objectstoreerrors.ErrNotFound
+		if errors.Is(err, sqlair.ErrNoRows) {
+			return coreobjectstore.Metadata{}, objectstoreerrors.ErrNotFound
 		}
-		return objectstore.Metadata{}, errors.Annotatef(domain.CoerceError(err), "retrieving metadata %s", path)
+		return coreobjectstore.Metadata{}, errors.Annotatef(domain.CoerceError(err), "retrieving metadata %s", path)
 	}
-	return metadata, nil
+	return metadata.ToCoreObjectStoreMetadata(), nil
 }
 
 // ListMetadata returns the persistence metadata.
-func (s *State) ListMetadata(ctx context.Context) ([]objectstore.Metadata, error) {
+func (s *State) ListMetadata(ctx context.Context) ([]coreobjectstore.Metadata, error) {
 	db, err := s.DB()
 	if err != nil {
 		return nil, err
 	}
 
-	query := `
-SELECT p.path, p.metadata_uuid, m.size, m.hash
+	stmt, err := s.Prepare(`
+SELECT (p.path, m.uuid, m.size, m.hash) AS (&dbMetadata.*)
 FROM object_store_metadata_path p
-LEFT JOIN object_store_metadata m ON p.metadata_uuid = m.uuid`
+LEFT JOIN object_store_metadata m ON p.metadata_uuid = m.uuid`, dbMetadata{})
+	if err != nil {
+		return nil, errors.Annotate(err, "preparing select metadata statement")
+	}
 
-	var metadata []objectstore.Metadata
-	err = db.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
-		rows, err := tx.QueryContext(ctx, query)
+	var metadata []dbMetadata
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		err := tx.Query(ctx, stmt).GetAll(&metadata)
 		if err != nil {
-			return fmt.Errorf("retrieving metadata: %w", err)
+			return errors.Annotate(domain.CoerceError(err), "retrieving metadata")
 		}
-		defer rows.Close()
-
-		for rows.Next() {
-			var m objectstore.Metadata
-			if err := rows.Scan(&m.Path, &m.UUID, &m.Size, &m.Hash); err != nil {
-				return fmt.Errorf("retrieving metadata: %w", err)
-			}
-			metadata = append(metadata, m)
-		}
-
-		return rows.Err()
+		return nil
 	})
 	if err != nil {
-		return nil, fmt.Errorf("retrieving metadata: %w", err)
+		return nil, errors.Trace(err)
 	}
-	return metadata, nil
+	return transform.Slice(metadata, (dbMetadata).ToCoreObjectStoreMetadata), nil
 }
 
 // PutMetadata adds a new specified path for the persistence metadata.
-func (s *State) PutMetadata(ctx context.Context, metadata objectstore.Metadata) error {
+func (s *State) PutMetadata(ctx context.Context, metadata coreobjectstore.Metadata) error {
 	db, err := s.DB()
 	if err != nil {
 		return errors.Trace(err)
 	}
 
-	matadataQuery := `
-INSERT INTO object_store_metadata (uuid, hash_type_id, hash, size)
-VALUES (?, ?, ?, ?) ON CONFLICT (hash) DO NOTHING`
-	pathQuery := `
-INSERT INTO object_store_metadata_path (path, metadata_uuid)
-VALUES (?, ?)`
-	metadataLookupQuery := `
-SELECT uuid FROM object_store_metadata WHERE hash = ? AND size = ?`
+	uuid, err := uuid.NewUUID()
+	if err != nil {
+		return err
+	}
 
-	err = db.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
-		result, err := tx.ExecContext(ctx, matadataQuery, metadata.UUID, 1, metadata.Hash, metadata.Size)
+	dbMetadata := dbMetadata{
+		UUID:       uuid.String(),
+		Hash:       metadata.Hash,
+		HashTypeID: 1,
+		Size:       metadata.Size,
+	}
+
+	dbMetadataPath := dbMetadataPath{
+		UUID: uuid.String(),
+		Path: metadata.Path,
+	}
+
+	metadataStmt, err := s.Prepare(`
+INSERT INTO object_store_metadata (uuid, hash_type_id, hash, size)
+VALUES ($dbMetadata.*) ON CONFLICT (hash) DO NOTHING`, dbMetadata)
+	if err != nil {
+		return errors.Annotate(err, "preparing insert metadata statement")
+	}
+
+	pathStmt, err := s.Prepare(`
+INSERT INTO object_store_metadata_path (path, metadata_uuid)
+VALUES ($dbMetadataPath.*)`, dbMetadataPath)
+	if err != nil {
+		return errors.Annotate(err, "preparing insert metadata path statement")
+	}
+
+	metadataLookupStmt, err := s.Prepare(`
+SELECT uuid AS &dbMetadataPath.metadata_uuid
+FROM   object_store_metadata 
+WHERE  hash = $dbMetadata.hash 
+AND    size = $dbMetadata.size`, dbMetadata, dbMetadataPath)
+	if err != nil {
+		return errors.Annotate(err, "preparing select metadata statement")
+	}
+
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		var outcome sqlair.Outcome
+		err := tx.Query(ctx, metadataStmt, dbMetadata).Get(&outcome)
 		if err != nil {
 			return errors.Annotatef(err, "inserting metadata")
 		}
 
-		if rows, err := result.RowsAffected(); err != nil {
+		if rows, err := outcome.Result().RowsAffected(); err != nil {
 			return errors.Annotatef(err, "inserting metadata")
 		} else if rows != 1 {
 			// If the rows affected is 0, then the metadata already exists.
 			// We need to get the uuid for the metadata, so that we can insert
 			// the path based on that uuid.
-			row := tx.QueryRowContext(ctx, metadataLookupQuery, metadata.Hash, metadata.Size)
-			if err := row.Scan(&metadata.UUID); err != nil {
-				if errors.Is(err, sql.ErrNoRows) {
-					return objectstoreerrors.ErrHashAndSizeAlreadyExists
-				}
-				return errors.Annotatef(err, "inserting metadata")
+			err := tx.Query(ctx, metadataLookupStmt, dbMetadata).Get(&dbMetadataPath)
+			if errors.Is(err, sqlair.ErrNoRows) {
+				return objectstoreerrors.ErrHashAndSizeAlreadyExists
 			}
+			return errors.Annotatef(err, "inserting metadata")
 		}
 
-		result, err = tx.ExecContext(ctx, pathQuery, metadata.Path, metadata.UUID)
+		err = tx.Query(ctx, pathStmt, dbMetadataPath).Get(&outcome)
 		if err != nil {
 			return errors.Annotatef(err, "inserting metadata path")
 		}
-		if rows, err := result.RowsAffected(); err != nil {
+		if rows, err := outcome.Result().RowsAffected(); err != nil {
 			return errors.Annotatef(err, "inserting metadata path")
 		} else if rows != 1 {
 			return fmt.Errorf("metadata path not inserted")
@@ -155,28 +183,53 @@ func (s *State) RemoveMetadata(ctx context.Context, path string) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	metadataUUIDQuery := `SELECT metadata_uuid FROM object_store_metadata_path WHERE path = ?`
-	pathQuery := `DELETE FROM object_store_metadata_path WHERE path = ?`
-	metadataQuery := `DELETE FROM object_store_metadata WHERE uuid = ? AND NOT EXISTS (SELECT 1 FROM object_store_metadata_path WHERE metadata_uuid = object_store_metadata.uuid)`
 
-	err = db.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+	dbMetadataPath := dbMetadataPath{
+		Path: path,
+	}
+
+	metadataUUIDStmt, err := s.Prepare(`
+SELECT &dbMetadataPath.metadata_uuid 
+FROM object_store_metadata_path 
+WHERE path = $dbMetadataPath.path`, dbMetadataPath)
+	if err != nil {
+		return errors.Annotate(err, "preparing select metadata statement")
+	}
+	pathStmt, err := s.Prepare(`
+DELETE FROM object_store_metadata_path 
+WHERE path = $dbMetadataPath.path`, dbMetadataPath)
+	if err != nil {
+		return errors.Annotate(err, "preparing delete metadata path statement")
+	}
+
+	metadataStmt, err := s.Prepare(`
+DELETE FROM object_store_metadata 
+WHERE uuid = $dbMetadataPath.metadata_uuid 
+AND NOT EXISTS (
+  SELECT 1 
+  FROM   object_store_metadata_path 
+  WHERE  metadata_uuid = object_store_metadata.uuid
+)`, dbMetadataPath)
+	if err != nil {
+		return errors.Annotate(err, "preparing delete metadata statement")
+	}
+
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		// Get the metadata uuid, so we can delete the metadata if there
 		// are no more paths associated with it.
-		var metadataUUID string
-		row := tx.QueryRowContext(ctx, metadataUUIDQuery, path)
-		if err := row.Scan(&metadataUUID); err != nil {
-			if errors.Is(err, sql.ErrNoRows) {
-				return objectstoreerrors.ErrNotFound
-			}
-			return err
+		err := tx.Query(ctx, metadataUUIDStmt, dbMetadataPath).Get(&dbMetadataPath)
+		if errors.Is(err, sqlair.ErrNoRows) {
+			return objectstoreerrors.ErrNotFound
+		} else if err != nil {
+			return errors.Trace(err)
 		}
 
-		if _, err := tx.ExecContext(ctx, pathQuery, path); err != nil {
-			return err
+		if err := tx.Query(ctx, pathStmt, dbMetadataPath).Run(); err != nil {
+			return errors.Trace(err)
 		}
 
-		if _, err := tx.ExecContext(ctx, metadataQuery, metadataUUID); err != nil {
-			return err
+		if err := tx.Query(ctx, metadataStmt, dbMetadataPath).Run(); err != nil {
+			return errors.Trace(err)
 		}
 
 		return nil

--- a/domain/objectstore/state/state.go
+++ b/domain/objectstore/state/state.go
@@ -153,8 +153,9 @@ AND    size = $dbMetadata.size`, dbMetadata, dbMetadataPath)
 			err := tx.Query(ctx, metadataLookupStmt, dbMetadata).Get(&dbMetadataPath)
 			if errors.Is(err, sqlair.ErrNoRows) {
 				return objectstoreerrors.ErrHashAndSizeAlreadyExists
+			} else if err != nil {
+				return errors.Annotatef(err, "inserting metadata")
 			}
-			return errors.Annotatef(err, "inserting metadata")
 		}
 
 		err = tx.Query(ctx, pathStmt, dbMetadataPath).Get(&outcome)

--- a/domain/objectstore/state/state.go
+++ b/domain/objectstore/state/state.go
@@ -79,7 +79,7 @@ LEFT JOIN object_store_metadata m ON p.metadata_uuid = m.uuid`, dbMetadata{})
 	var metadata []dbMetadata
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err := tx.Query(ctx, stmt).GetAll(&metadata)
-		if err != nil {
+		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return errors.Annotate(domain.CoerceError(err), "retrieving metadata")
 		}
 		return nil

--- a/domain/objectstore/state/state_test.go
+++ b/domain/objectstore/state/state_test.go
@@ -10,10 +10,9 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/domain/objectstore"
+	coreobjectstore "github.com/juju/juju/core/objectstore"
 	objectstoreerrors "github.com/juju/juju/domain/objectstore/errors"
 	schematesting "github.com/juju/juju/domain/schema/testing"
-	"github.com/juju/juju/internal/uuid"
 )
 
 type stateSuite struct {
@@ -32,8 +31,7 @@ func (s *stateSuite) TestGetMetadataNotFound(c *gc.C) {
 func (s *stateSuite) TestGetMetadataFound(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory())
 
-	metadata := objectstore.Metadata{
-		UUID: uuid.MustNewUUID().String(),
+	metadata := coreobjectstore.Metadata{
 		Hash: "hash",
 		Path: "blah-foo",
 		Size: 666,
@@ -50,8 +48,7 @@ func (s *stateSuite) TestGetMetadataFound(c *gc.C) {
 func (s *stateSuite) TestListMetadataFound(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory())
 
-	metadata := objectstore.Metadata{
-		UUID: uuid.MustNewUUID().String(),
+	metadata := coreobjectstore.Metadata{
 		Hash: "hash",
 		Path: "blah-foo",
 		Size: 666,
@@ -62,14 +59,13 @@ func (s *stateSuite) TestListMetadataFound(c *gc.C) {
 
 	received, err := st.ListMetadata(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(received, gc.DeepEquals, []objectstore.Metadata{metadata})
+	c.Check(received, gc.DeepEquals, []coreobjectstore.Metadata{metadata})
 }
 
 func (s *stateSuite) TestPutMetadataConflict(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory())
 
-	metadata := objectstore.Metadata{
-		UUID: uuid.MustNewUUID().String(),
+	metadata := coreobjectstore.Metadata{
 		Hash: "hash",
 		Path: "blah-foo",
 		Size: 666,
@@ -86,14 +82,12 @@ func (s *stateSuite) TestPutMetadataConflict(c *gc.C) {
 func (s *stateSuite) TestPutMetadataWithSameHashAndSize(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory())
 
-	metadata1 := objectstore.Metadata{
-		UUID: uuid.MustNewUUID().String(),
+	metadata1 := coreobjectstore.Metadata{
 		Hash: "hash",
 		Path: "blah-foo-1",
 		Size: 666,
 	}
-	metadata2 := objectstore.Metadata{
-		UUID: uuid.MustNewUUID().String(),
+	metadata2 := coreobjectstore.Metadata{
 		Hash: "hash",
 		Path: "blah-foo-2",
 		Size: 666,
@@ -113,14 +107,12 @@ func (s *stateSuite) TestPutMetadataWithSameHashDifferentSize(c *gc.C) {
 	// cause of this, is if the hash is the same, but the size is different.
 	// There is a broken hash function somewhere.
 
-	metadata1 := objectstore.Metadata{
-		UUID: uuid.MustNewUUID().String(),
+	metadata1 := coreobjectstore.Metadata{
 		Hash: "hash",
 		Path: "blah-foo-1",
 		Size: 666,
 	}
-	metadata2 := objectstore.Metadata{
-		UUID: uuid.MustNewUUID().String(),
+	metadata2 := coreobjectstore.Metadata{
 		Hash: "hash",
 		Path: "blah-foo-2",
 		Size: 42,
@@ -137,11 +129,10 @@ func (s *stateSuite) TestPutMetadataMultipleTimes(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory())
 
 	// Ensure that we can add the same metadata multiple times.
-	metadatas := make([]objectstore.Metadata, 10)
+	metadatas := make([]coreobjectstore.Metadata, 10)
 
 	for i := 0; i < 10; i++ {
-		metadatas[i] = objectstore.Metadata{
-			UUID: uuid.MustNewUUID().String(),
+		metadatas[i] = coreobjectstore.Metadata{
 			Hash: fmt.Sprintf("hash-%d", i),
 			Path: fmt.Sprintf("blah-foo-%d", i),
 			Size: 666,
@@ -168,14 +159,12 @@ func (s *stateSuite) TestRemoveMetadataNotExists(c *gc.C) {
 func (s *stateSuite) TestRemoveMetadataDoesNotRemoveMetadataIfReferenced(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory())
 
-	metadata1 := objectstore.Metadata{
-		UUID: uuid.MustNewUUID().String(),
+	metadata1 := coreobjectstore.Metadata{
 		Hash: "hash",
 		Path: "blah-foo-1",
 		Size: 666,
 	}
-	metadata2 := objectstore.Metadata{
-		UUID: uuid.MustNewUUID().String(),
+	metadata2 := coreobjectstore.Metadata{
 		Hash: "hash",
 		Path: "blah-foo-2",
 		Size: 666,
@@ -198,14 +187,12 @@ func (s *stateSuite) TestRemoveMetadataDoesNotRemoveMetadataIfReferenced(c *gc.C
 func (s *stateSuite) TestRemoveMetadataCleansUpEverything(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory())
 
-	metadata1 := objectstore.Metadata{
-		UUID: uuid.MustNewUUID().String(),
+	metadata1 := coreobjectstore.Metadata{
 		Hash: "hash",
 		Path: "blah-foo-1",
 		Size: 666,
 	}
-	metadata2 := objectstore.Metadata{
-		UUID: uuid.MustNewUUID().String(),
+	metadata2 := coreobjectstore.Metadata{
 		Hash: "hash",
 		Path: "blah-foo-2",
 		Size: 666,
@@ -230,8 +217,7 @@ func (s *stateSuite) TestRemoveMetadataCleansUpEverything(c *gc.C) {
 	c.Assert(err, jc.ErrorIs, objectstoreerrors.ErrNotFound)
 
 	// Add a new metadata with the same hash and size.
-	metadata3 := objectstore.Metadata{
-		UUID: uuid.MustNewUUID().String(),
+	metadata3 := coreobjectstore.Metadata{
 		Hash: "hash",
 		Path: "blah-foo-3",
 		Size: 666,
@@ -250,8 +236,7 @@ func (s *stateSuite) TestRemoveMetadataCleansUpEverything(c *gc.C) {
 func (s *stateSuite) TestRemoveMetadataThenAddAgain(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory())
 
-	metadata := objectstore.Metadata{
-		UUID: uuid.MustNewUUID().String(),
+	metadata := coreobjectstore.Metadata{
 		Hash: "hash",
 		Path: "blah-foo-1",
 		Size: 666,
@@ -274,8 +259,7 @@ func (s *stateSuite) TestRemoveMetadataThenAddAgain(c *gc.C) {
 func (s *stateSuite) TestListMetadata(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory())
 
-	metadata := objectstore.Metadata{
-		UUID: uuid.MustNewUUID().String(),
+	metadata := coreobjectstore.Metadata{
 		Hash: "hash",
 		Path: "blah-foo-1",
 		Size: 666,

--- a/domain/objectstore/state/state_test.go
+++ b/domain/objectstore/state/state_test.go
@@ -274,3 +274,11 @@ func (s *stateSuite) TestListMetadata(c *gc.C) {
 
 	c.Check(metadatas[0], gc.DeepEquals, metadata)
 }
+
+func (s *stateSuite) TestListMetadataNoRows(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	metadatas, err := st.ListMetadata(context.Background())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(metadatas, gc.HasLen, 0)
+}

--- a/domain/objectstore/state/types.go
+++ b/domain/objectstore/state/types.go
@@ -1,0 +1,40 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import coreobjectstore "github.com/juju/juju/core/objectstore"
+
+// dbMetadata represents the database serialisable metadata for an object.
+type dbMetadata struct {
+	// UUID is the uuid for the metadata.
+	UUID string `db:"uuid"`
+	// Hash is the hash of the object.
+	Hash string `db:"hash"`
+	// HashTypeID is the id of the type of hash used to generate the hash. It
+	// can be looked up in object_store_metadata_hash_type.
+	HashTypeID uint `db:"hash_type_id"`
+	// Path is the path to the object.
+	Path string `db:"path"`
+	// Size is the size of the object.
+	Size int64 `db:"size"`
+}
+
+// dbMetadataPath represents the database serialisable metadata path for an
+// object.
+type dbMetadataPath struct {
+	// UUID is the uuid for the metadata.
+	UUID string `db:"metadata_uuid"`
+	// Path is the path to the object.
+	Path string `db:"path"`
+}
+
+// ToCoreObjectStoreMetadata transforms de-serialised data from the database to
+// object metadata.
+func (m dbMetadata) ToCoreObjectStoreMetadata() coreobjectstore.Metadata {
+	return coreobjectstore.Metadata{
+		Hash: m.Hash,
+		Path: m.Path,
+		Size: m.Size,
+	}
+}


### PR DESCRIPTION
<!-- Why this change is needed and what it does. -->
This PR switches to use SQLair in the object store, fixes a small bug, and adds a doc.go

The type objectstore.Metadata was local to the objectstore domain. With
the transition to SQLair I required a very similar type just in the
state with the db tags on it. For this reason I have moved the type to
state, tagged it, and replaced it in the service with the core object
store metadata type.

The UUID generation was done in the service layer but now can be done
simply in the state layer.

A small bug is also fixed where if a second piece of metadata pointing to
an object of the same shape were inserted then the path would not get
put into the path table due to an early return.


## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps
```
 TEST_PACKAGES="./domain/objectstore/... -count=1 " TEST_FILTER="Suite" make run-go-tests
```

### Test object store in HA
Start minio as to use as the s3 object store.
```
docker run -p 9000:9000 -p 9001:9001 \
  quay.io/minio/minio server /data --console-address ":9001"
```

Go to http://localhost:9001/access-keys and add an access key, keeping note of the key and secret as env var `S3_KEY` and `S3_SECRET`.
Also make a note of the IP for minio (not the `localhost` one) as `IP_ADDRESS`.

Now bootstrap with the s3 object store specified.
```
$ bootstrap lxd test --build-agent --config="object-store-type=s3" --config="object-store-s3-endpoint=http://${IP_ADDRESS}:9000" --config="object-store-s3-static-key=${S3_KEY}" --config="object-store-s3-static-secret=${S3_SECRET}"
```

Now its deployed try going into HA:
```
$ juju enable-ha
$ juju add-model default
$ juju deploy juju-qa-test --resource foo-file="./tests/suites/resources/foo-file.txt"
$ juju deploy ubuntu -n 3
$ juju destroy-model default
```

## Documentation changes
Added doc.go to the domain
<!-- How it affects user workflow (CLI or API). -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Jira card:** [JUJU-5628](https://warthogs.atlassian.net/browse/JUJU-5628)



[JUJU-5628]: https://warthogs.atlassian.net/browse/JUJU-5628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ