### PR TITLE
refactor(deploy): Remove validateCharmBaseWithName

### DIFF
--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -50,7 +50,6 @@ type deployCharm struct {
 	storage          map[string]storage.Directive
 	trust            bool
 
-	validateCharmBaseWithName             func(base corebase.Base, name string, imageStream string) error
 	validateResourcesNeededForLocalDeploy func(charmMeta *charm.Meta) error
 }
 

--- a/cmd/juju/application/deployer/charm_test.go
+++ b/cmd/juju/application/deployer/charm_test.go
@@ -81,9 +81,6 @@ func (s *charmSuite) TestRepositoryCharmDeployDryRunDefaultSeriesForce(c *gc.C) 
 	dCharm := s.newDeployCharm()
 	dCharm.dryRun = true
 	dCharm.force = true
-	dCharm.validateCharmBaseWithName = func(_ corebase.Base, _ string, _ string) error {
-		return nil
-	}
 	repoCharm := &repositoryCharm{
 		deployCharm:      *dCharm,
 		userRequestedURL: s.url,
@@ -220,9 +217,6 @@ func (s *charmSuite) TestDeployFromPredeployed(c *gc.C) {
 	s.deployerAPI.EXPECT().Deploy(gomock.Any()).Return(nil)
 
 	dCharm := s.newDeployCharm()
-	dCharm.validateCharmBaseWithName = func(_ corebase.Base, _ string, _ string) error {
-		return nil
-	}
 	dCharm.validateResourcesNeededForLocalDeploy = func(_ *charm.Meta) error {
 		return nil
 	}


### PR DESCRIPTION
validateCharmBaseWithName was originally intended to validate a user provided OS is supported by a charm when deploying

However, for a while now we have used a BaseSelector, which guarentees a base which is supported by this charm. This validation is now superfluous, and duplicates code in the BaseSelector.

So remove it

See discussion here:
https://github.com/juju/juju/pull/16101#discussion_r1301431892

Fixes:


<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

```
$ juju bootstrap lxd lxd
$ juju add-model m

$ juju info ubuntu
name: ubuntu
publisher: charmers
summary: A pristine Ubuntu Server
description: |
  This simply deploys the Ubuntu Cloud/Server image
store-url: https://charmhub.io/ubuntu
charm-id: DksXQKAQTZfsUmBAGanZAhpoS4dpmXel
supports: ubuntu@18.04, ubuntu@20.04, ubuntu@22.04
subordinate: false
channels: |
  latest/stable:     24  2023-05-26  (24)  2MB  amd64, arm, arm64, i386, ppc64  ubuntu@18.04, ubuntu@20.04, ubuntu@22.04
  latest/candidate:  24  2023-05-19  (24)  2MB  amd64, arm, arm64, i386, ppc64  ubuntu@18.04, ubuntu@20.04, ubuntu@22.04
  latest/beta:       24  2023-05-19  (24)  2MB  amd64, arm, arm64, i386, ppc64  ubuntu@18.04, ubuntu@20.04, ubuntu@22.04
  latest/edge:       24  2023-05-19  (24)  2MB  amd64, arm, arm64, i386, ppc64  ubuntu@18.04, ubuntu@20.04, ubuntu@22.04

$ juju deploy ubuntu focal --base ubuntu@20.04
Deployed "focal" from charm-hub charm "ubuntu", revision 24 in channel latest/stable on ubuntu@20.04/stable

$ juju deploy ubuntu jammy --base ubuntu@22.04
Deployed "jammy" from charm-hub charm "ubuntu", revision 24 in channel latest/stable on ubuntu@22.04/stable

$ juju deploy ubuntu noble --base ubuntu@24.04
ERROR selecting releases: charm or bundle not found for channel "", base "amd64/ubuntu/24.04"
available releases are:
  channel "latest/stable": available bases are: ubuntu@22.04, ubuntu@20.04, ubuntu@20.04, ubuntu@18.04, ubuntu@18.04, ubuntu@16.04, ubuntu@16.04, ubuntu@14.04, ubuntu@12.04, ubuntu@20.10, ubuntu@19.04, ubuntu@18.10, ubuntu@17.10, ubuntu@15.04
  channel "latest/candidate": available bases are: ubuntu@22.04, ubuntu@20.04, ubuntu@20.04, ubuntu@18.04, ubuntu@18.04, ubuntu@16.04, ubuntu@16.04, ubuntu@14.04, ubuntu@12.04, ubuntu@20.10, ubuntu@19.04, ubuntu@18.10, ubuntu@17.10, ubuntu@15.04
  channel "latest/beta": available bases are: ubuntu@22.04, ubuntu@20.04, ubuntu@20.04, ubuntu@18.04, ubuntu@18.04, ubuntu@16.04, ubuntu@16.04, ubuntu@14.04, ubuntu@12.04, ubuntu@20.10, ubuntu@19.04, ubuntu@18.10, ubuntu@17.10, ubuntu@15.04
  channel "latest/edge": available bases are: ubuntu@22.04, ubuntu@20.04, ubuntu@20.04, ubuntu@18.04, ubuntu@18.04, ubuntu@16.04, ubuntu@16.04, ubuntu@14.04, ubuntu@12.04, ubuntu@20.10, ubuntu@19.04, ubuntu@18.10, ubuntu@17.10, ubuntu@15.04

$ juju deploy ubuntu bionic --base ubuntu@18.04
ERROR base: ubuntu@18.04/stable not supported
ERROR failed to deploy charm "ubuntu"
```

## Links

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2032639

