### PR TITLE
fix: surface custom controller charm error

### DIFF
--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -401,7 +401,7 @@ func (c *bootstrapCommand) Init(args []string) (err error) {
 			}
 			ch, err := charm.ReadCharm(c.ControllerCharmPath)
 			if err != nil {
-				return errors.Errorf("--controller-charm-path %q is not a valid charm", c.ControllerCharmPath)
+				return errors.Annotatef(err, "--controller-charm-path %q is not a valid charm", c.ControllerCharmPath)
 			}
 			if ch.Meta().Name != bootstrap.ControllerCharmName {
 				return errors.Errorf("--controller-charm-path %q is not a %q charm", c.ControllerCharmPath,

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -2179,7 +2179,7 @@ func (s *BootstrapSuite) TestBootstrapWithLocalControllerCharm(c *gc.C) {
 			err:       `--controller-charm-path ".*mysql" is not a "juju-controller" charm`,
 		}, {
 			charmPath: c.MkDir(),
-			err:       `--controller-charm-path ".*" is not a valid charm`,
+			err:       `--controller-charm-path ".*" is not a valid charm: .*`,
 		}, {
 			charmPath: "/invalid/path",
 			err:       `problem with --controller-charm-path: .* /invalid/path: .*`,


### PR DESCRIPTION
When bootstrapping with a custom controller charm, if juju cannot parse the charm file it simply returns and error sayign "invalid charm". This is not helpful for a use.

Instead, we append the actual error encountered by ReadCharm rather than hiding it.

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc

## QA steps
```
$ juju download juju-controller --channel 3.4/stable
```
Unzip charm and put some random text in metadata.yaml and re-compress.
```
$ juju bootstrap lxd test-ctrl-charm --controller-charm-path ./juju-controller_r101.charm
ERROR --controller-charm-path "./juju-controller_r101.charm" is not a valid charm: archive file "metadata.yaml" not found
``` 
<!-- Describe steps to verify that the change works. -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Jira card:** [JUJU-6073](https://warthogs.atlassian.net/browse/JUJU-6073)



[JUJU-6073]: https://warthogs.atlassian.net/browse/JUJU-6073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ