### PR TITLE
chore: remove last deployment type in charm

### DIFF
--- a/internal/charm/meta.go
+++ b/internal/charm/meta.go
@@ -148,42 +148,6 @@ type Device struct {
 	CountMax int64 `bson:"countmax"`
 }
 
-// DeploymentType defines a deployment type.
-type DeploymentType string
-
-const (
-	DeploymentStateless DeploymentType = "stateless"
-	DeploymentStateful  DeploymentType = "stateful"
-	DeploymentDaemon    DeploymentType = "daemon"
-)
-
-// DeploymentMode defines a deployment mode.
-type DeploymentMode string
-
-const (
-	ModeOperator DeploymentMode = "operator"
-	ModeWorkload DeploymentMode = "workload"
-)
-
-// ServiceType defines a service type.
-type ServiceType string
-
-const (
-	ServiceCluster      ServiceType = "cluster"
-	ServiceLoadBalancer ServiceType = "loadbalancer"
-	ServiceExternal     ServiceType = "external"
-	ServiceOmit         ServiceType = "omit"
-)
-
-// Deployment represents a charm's deployment requirements in the charm
-// metadata.yaml file.
-type Deployment struct {
-	DeploymentType DeploymentType `bson:"type"`
-	DeploymentMode DeploymentMode `bson:"mode"`
-	ServiceType    ServiceType    `bson:"service"`
-	MinVersion     string         `bson:"min-version"`
-}
-
 // Relation represents a single relation defined in the charm
 // metadata.yaml file.
 type Relation struct {

--- a/rpc/params/charms.go
+++ b/rpc/params/charms.go
@@ -161,14 +161,6 @@ type CharmPlan struct {
 	Required bool `json:"required"`
 }
 
-// CharmDeployment mirrors charm.Deployment.
-type CharmDeployment struct {
-	DeploymentType string `json:"type"`
-	DeploymentMode string `json:"mode"`
-	ServiceType    string `json:"service"`
-	MinVersion     string `json:"min-version"`
-}
-
 // CharmManifest mirrors charm.Manifest
 type CharmManifest struct {
 	Bases []CharmBase `json:"bases,omitempty"`


### PR DESCRIPTION
There was some left over renaming references of deployment type in the charm package. This removes them from that package. The caas package also has some additional deployment type information which will be required to be removed, but that can be in another patchset.

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

Most of the code was already removed when bringing in the charm
package, this is the last part.

This is the removal of dead code. The tests should pass.

## Links

**Jira card:** [JUJU-6011](https://warthogs.atlassian.net/browse/JUJU-6011)



[JUJU-6011]: https://warthogs.atlassian.net/browse/JUJU-6011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ