### PR TITLE
ci: in upgrade, cut -beta from the version

### DIFF
--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -80,7 +80,7 @@ jobs:
         run: |
           set -euxo pipefail
           
-          sourceJujuVersion=$(snap info juju | yq ".channels[\"${{ needs.setup.outputs.channel }}\"]" | cut -d' ' -f1)
+          sourceJujuVersion=$(snap info juju | yq ".channels[\"${{ needs.setup.outputs.channel }}\"]" | cut -d' ' -f1 | cut -d'-' -f1)
           echo "source-juju-version=${sourceJujuVersion}" >> $GITHUB_OUTPUT
         id: vars
 


### PR DESCRIPTION
Microk8s upgrade is failing on 3.6. I believe it because of the fact that the version has a '-beta' in it.

## QA steps
Check CI

