### PR TITLE
fix: unblock upgrades

### DIFF
--- a/cmd/jujud-controller/agent/machine/manifolds_test.go
+++ b/cmd/jujud-controller/agent/machine/manifolds_test.go
@@ -328,22 +328,11 @@ func (*ManifoldsSuite) TestSingularGuardsUsed(c *gc.C) {
 
 	// Explicitly guarded by ifController.
 	controllerWorkers := set.NewStrings(
-		"audit-config-updater",
 		"certificate-watcher",
-		"change-stream",
-		"change-stream",
-		"control-socket",
 		"controller-agent-config",
 		"db-accessor",
-		"db-accessor",
-		"file-notify-watcher",
 		"file-notify-watcher",
 		"is-primary-controller-flag",
-		"lease-manager",
-		"log-sink",
-		"object-store",
-		"object-store-s3-caller",
-		"query-logger",
 		"query-logger",
 		"s3-http-client",
 		"upgrade-database-flag",
@@ -363,7 +352,14 @@ func (*ManifoldsSuite) TestSingularGuardsUsed(c *gc.C) {
 	// flag. If no worker is guarded then we know that workers are accessing
 	// the database before it has been upgraded.
 	dbUpgradedWorkers := set.NewStrings(
+		"audit-config-updater",
 		"bootstrap",
+		"control-socket",
+		"http-server-args",
+		"log-sink",
+		"object-store",
+		"object-store-s3-caller",
+		"state",
 	)
 
 	// bootstrapWorkers are workers that are run directly run after bootstrap.
@@ -1165,8 +1161,6 @@ var expectedMachineManifoldsWithDependenciesIAAS = map[string][]string{
 		"provider-service-factory",
 		"query-logger",
 		"state-config-watcher",
-		"upgrade-database-flag",
-		"upgrade-database-gate",
 	},
 
 	"ssh-authkeys-updater": {
@@ -1285,7 +1279,6 @@ var expectedMachineManifoldsWithDependenciesIAAS = map[string][]string{
 		"query-logger",
 		"service-factory",
 		"state-config-watcher",
-		"upgrade-database-flag",
 		"upgrade-database-gate",
 	},
 
@@ -1319,8 +1312,6 @@ var expectedMachineManifoldsWithDependenciesIAAS = map[string][]string{
 		"query-logger",
 		"service-factory",
 		"state-config-watcher",
-		"upgrade-database-flag",
-		"upgrade-database-gate",
 		"upgrade-steps-gate",
 	},
 
@@ -1866,8 +1857,6 @@ var expectedMachineManifoldsWithDependenciesCAAS = map[string][]string{
 		"provider-service-factory",
 		"query-logger",
 		"state-config-watcher",
-		"upgrade-database-flag",
-		"upgrade-database-gate",
 	},
 
 	"ssh-identity-writer": {
@@ -1931,7 +1920,6 @@ var expectedMachineManifoldsWithDependenciesCAAS = map[string][]string{
 		"query-logger",
 		"service-factory",
 		"state-config-watcher",
-		"upgrade-database-flag",
 		"upgrade-database-gate",
 	},
 
@@ -1953,8 +1941,6 @@ var expectedMachineManifoldsWithDependenciesCAAS = map[string][]string{
 		"query-logger",
 		"service-factory",
 		"state-config-watcher",
-		"upgrade-database-flag",
-		"upgrade-database-gate",
 		"upgrade-steps-gate",
 	},
 

--- a/cmd/jujud-controller/agent/machine/manifolds_test.go
+++ b/cmd/jujud-controller/agent/machine/manifolds_test.go
@@ -810,8 +810,6 @@ var expectedMachineManifoldsWithDependenciesIAAS = map[string][]string{
 		"provider-service-factory",
 		"query-logger",
 		"state-config-watcher",
-		"upgrade-database-flag",
-		"upgrade-database-gate",
 	},
 
 	"instance-mutater": {
@@ -1588,8 +1586,6 @@ var expectedMachineManifoldsWithDependenciesCAAS = map[string][]string{
 		"provider-service-factory",
 		"query-logger",
 		"state-config-watcher",
-		"upgrade-database-flag",
-		"upgrade-database-gate",
 	},
 
 	"is-bootstrap-flag": {

--- a/domain/schema/controller/sql/0005-cloud.sql
+++ b/domain/schema/controller/sql/0005-cloud.sql
@@ -1,3 +1,7 @@
+-- The cloud and accompanying tables drive the provider tracker. It is not safe 
+-- to modify the cloud or other tables in a patch/build release. Only make 
+-- changes to this table during a major/minor release. Changes to the cloud
+-- table will cause undefined behavior in the provider tracker.
 CREATE TABLE cloud_type (
     id INT PRIMARY KEY,
     type TEXT NOT NULL

--- a/domain/schema/doc.go
+++ b/domain/schema/doc.go
@@ -1,0 +1,25 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package schema contains the schema definitions for all the domains.
+// The schema is broken down into a controller (global) namespace and a set of
+// model namespaces. Each domain package wraps a set of workflows
+// that can affect either the controller or model namespaces. It's generally
+// a good idea not to mix the two, because of a lack atomicity across two
+// different databases (even if attempting to use ATTACH DATABASE in SQLite)
+// can cause inconsistencies or additional complexity.
+//
+// The schema is a set of DDL SQL statements for controller and models. They're
+// independent from each other. Each set of schema is executed in a single
+// transaction, and any error will cause the transaction to be rolled back.
+//
+// Schema triggers are a set of SQL trigger statements that are executed after
+// a row is inserted, updated, or deleted. They're used to drive the watchers
+// and the change stream in a generic way. All triggers should be first
+// implemented as generic generated triggers, unless there's a good reason to
+// implement them as a logical custom trigger.
+//
+// There are parts of the schema that should never be updated in a patch/build
+// release. The provider tracker requires that the underlying schema is never
+// changed. Changing the schema will lead to undefined behavior and data loss.
+package schema

--- a/domain/schema/model/sql/0004-read-only-model.sql
+++ b/domain/schema/model/sql/0004-read-only-model.sql
@@ -1,6 +1,10 @@
 -- The model table represents a readonly denormalised model data. The intended
 -- use is to provide a read-only view of the model data for the purpose of
 -- accessing common model data without the need to span multiple databases.
+--
+-- The model table primarily is used to drive the provider tracker. The model
+-- table should *not* be changed in a patch/build release. The only time to make
+-- changes to this table is during a major/minor release. 
 CREATE TABLE model (
     uuid TEXT NOT NULL PRIMARY KEY,
     controller_uuid TEXT NOT NULL,

--- a/domain/schema/model/sql/0005-model-config.sql
+++ b/domain/schema/model/sql/0005-model-config.sql
@@ -1,3 +1,9 @@
+-- The model_config table is a new table that is used to store configuration 
+-- data for the model.
+--
+-- The provider tracker relies on the model_config table. Do not modify the
+-- model_config table in a patch/build release. Only make changes to this table
+-- during a major/minor release.
 CREATE TABLE model_config (
     "key" TEXT NOT NULL PRIMARY KEY,
     value TEXT NOT NULL


### PR DESCRIPTION
Having `ifDatabaseUpgradeComplete` on the service factory and provider
tracker prevented the upgrade. The provider tracker was waiting for
the upgrade, but couldn't do that because a child worker did the
upgrade. This caused a cycle in the dependency engine, one that was
unresolvable. This was unfortunately determined at runtime, by
releasing the gate.

The solution is to push the `ifDatabaseUpgradeComplete` on all the
service factory dependencies, minus the upgrade database workers
(including the gate and flags). The service factory can record
the process and the upgrade database worker can control/manage
the workflow.

The API server doesn't need a `ifDatabaseUpgradeComplete` on it directly,
as the httpServerArgsName uses the service factory which will then
block both httpServerName and apiServerName (reducing complexity).

There are consequences to pushing the `ifDatabaseUpgradeComplete`
further down the child worker nodes. A lot of the data in the database 
should not be updated in a patch/build release. Additional documentation
has been added to various locations to indicate that this is undefined
behaviour.

It is generally advised that upgrading should only be additive, altering
or removing data in the following areas is generally advised against 
(unless sufficient testing proves otherwise):

 1. read-only model in the model database
 2. model config in the model database
 3. cloud data in the controller database
 4. cloud credential data in the controller database

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

LXD steps:
```
$ export JUJU_BUILD_NUMBER=0
$ make install simplestreams
# start an http server in `_build/simplestreams/tools` with `python3 -m http.server`
$ juju bootstrap localhost --config agent-metadata-url=<ip-for-simplestreams>
$ juju status -m controller
Model       Controller  Cloud/Region  Version    Timestamp
controller  microk8s    microk8s      4.0-beta4  16:02:52+1:00
# increment version/version.go to 4.0-beta5
$ make install simplestreams
$ juju upgrade-controller
best version:
    4.0-beta5
started upgrade to 4.0-beta5
# wait for machine-0 to bounce
# check machine-0 log is now running 4.0-beta5
# check juju status can still connect to the controller
$ juju status
Model       Controller  Cloud/Region  Version    Timestamp
controller  microk8s    microk8s      4.0-beta5  16:14:11+1:00
```

K8s steps:
First, make sure you have an account on [Docker Hub](https://hub.docker.com/) and that you have `docker login`-ed on your local machine.

```
$ export JUJU_BUILD_NUMBER=0
$ export DOCKER_USERNAME=docker.io/<your-docker-username>
$ make seed-repository
$ make install simplestreams push-release-operator-image
# start an http server in `_build/simplestreams/tools` with `python3 -m http.server`
$ juju bootstrap microk8s --config agent-metadata-url=<ip-for-simplestreams> --config caas-image-repo=docker.io/<your-docker-username>
$ juju status -m controller
Model       Controller  Cloud/Region  Version    Timestamp
controller  microk8s    microk8s      4.0-beta4  16:02:52+1:00
# increment version/version.go to 4.0-beta5
$ make install simplestreams push-release-operator-image
$ juju upgrade-controller
best version:
    4.0-beta5
started upgrade to 4.0-beta5
$ juju status
Model       Controller  Cloud/Region  Version    Timestamp
controller  microk8s    microk8s      4.0-beta5  16:14:11+1:00
$ kubectl -ncontroller-microk8s-localhost describe deployment modeloperator | grep jujud-operator:
    Image:      docker.io/<your-docker-username>/jujud-operator:4.0-beta5
```


## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2069837

**Jira card:** [JUJU-6203](https://warthogs.atlassian.net/browse/JUJU-6203)



[JUJU-6203]: https://warthogs.atlassian.net/browse/JUJU-6203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ