### PR TITLE
build: only include jujud and jujuc in the simplestreams tar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -291,7 +291,7 @@ ${BUILD_DIR}/%/bin/pebble: phony_explicit
 ${JUJU_METADATA_SOURCE}/tools/released/juju-${JUJU_VERSION}-%.tgz: phony_explicit juju $(BUILD_AGENT_TARGETS)
 	@echo "Packaging simplestream tools for juju ${JUJU_VERSION} on $*"
 	@mkdir -p ${JUJU_METADATA_SOURCE}/tools/released
-	@tar czf "$@" -C $(call bin_platform_paths,$(subst -,/,$*)) .
+	@tar czf "$@" -C $(call bin_platform_paths,$(subst -,/,$*)) jujud jujuc
 
 .PHONY: simplestreams
 simplestreams: juju juju-metadata ${SIMPLESTREAMS_TARGETS}


### PR DESCRIPTION
The simplestreams make target did not work with the machine upgrade, only with bootstrap/machine deploy. This was because the bins were added with a root directory, rather as multiple top level tar entries. Bootstrap/deploy use system tar, upgrade uses `UnpackTools(...)`.

See `UnpackTools(...)` for more info.

