### PR TITLE
feat(cli): Prevent controller-config command to set controller-name to empty string

### DIFF
--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -73,6 +73,8 @@ Used without arguments, bootstrap will step you through the process of
 initializing a Juju cloud environment. Initialization consists of creating
 a 'controller' model and provisioning a machine to act as controller.
 
+Controller names may only contain lowercase letters, digits and hyphens, and
+may not start with a hyphen.
 We recommend you call your controller ‘username-region’ e.g. ‘fred-us-east-1’.
 See --clouds for a list of clouds and credentials.
 See --regions <cloud> for a list of available regions for a given cloud.

--- a/controller/config.go
+++ b/controller/config.go
@@ -1188,6 +1188,13 @@ func Validate(c Config) error {
 			return errors.NotValidf("controller-api-port matching state-port")
 		}
 	}
+
+	if v, ok := c[ControllerName].(string); ok {
+		if !names.IsValidControllerName(v) {
+			return errors.Errorf("%s value must be a valid controller name (lowercase or digit with non-leading hyphen), got %q", ControllerName, v)
+		}
+	}
+
 	if v, ok := c[APIPortOpenDelay].(string); ok {
 		_, err := time.ParseDuration(v)
 		if err != nil {

--- a/controller/config_test.go
+++ b/controller/config_test.go
@@ -373,6 +373,18 @@ var newConfigTests = []struct {
 		controller.QueryTracingThreshold: "-1s",
 	},
 	expectError: `query-tracing-threshold value "-1s" must be a positive duration`,
+}, {
+	about: "empty controller name",
+	config: controller.Config{
+		controller.ControllerName: "",
+	},
+	expectError: `controller-name: expected non-empty controller-name.*`,
+}, {
+	about: "invalid controller name",
+	config: controller.Config{
+		controller.ControllerName: "is_invalid",
+	},
+	expectError: `controller-name value must be a valid controller name.*`,
 }}
 
 func (s *ConfigSuite) TestNewConfig(c *gc.C) {

--- a/controller/configschema.go
+++ b/controller/configschema.go
@@ -22,7 +22,7 @@ var configChecker = schema.FieldMap(schema.Fields{
 	APIPort:                          schema.ForceInt(),
 	APIPortOpenDelay:                 schema.TimeDuration(),
 	ControllerAPIPort:                schema.ForceInt(),
-	ControllerName:                   schema.String(),
+	ControllerName:                   schema.NonEmptyString(ControllerName),
 	StatePort:                        schema.ForceInt(),
 	LoginTokenRefreshURL:             schema.String(),
 	IdentityURL:                      schema.String(),
@@ -164,6 +164,10 @@ that have a very heavy load. If this port is set, this port is used by
 the controllers to talk to each other - used for the local API connection
 as well as the pubsub forwarders, and the raft workers. If this value is
 set, the api-port isn't opened until the controllers have started properly.`,
+	},
+	ControllerName: {
+		Type:        environschema.Tstring,
+		Description: `The canonical name of the controller`,
 	},
 	StatePort: {
 		Type:        environschema.Tint,


### PR DESCRIPTION
The PR https://github.com/juju/juju/pull/11074 introduced the controller-name field as a possible one to be updated through controller-config command. It allows empty string as valid value, which is unexpected.

After this PR, empty value for this field will be rejected.

Moreover, I added this field to the help command.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```sh
juju bootstrap localhost # controller name in juju controller-config should be defaulted to something like localhost-localhost
juju controller-config controller-name= # name refused because empty
juju controller-config controller-name="" # name refused because empty
juju controller-config controller-name="invalid name" # name refused because invalid
juju controller-config controller-name="invalid_name" # name refused because invalid
juju controller-config controller-name="valid-name" # name accepted because valid
juju controller-config -h | grep -A 2 controller-name # should show the documentation of controller-name
```

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->
To be discussed

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2065381

**Jira card:** JUJU-6199

