### PR TITLE
docs: update top level markdown files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -457,5 +457,6 @@ beyond the workflow and the [issue tracker](https://bugs.launchpad.net/juju/+bug
 
 Use the following links to contact the community:
 
- - Mattermost chat: [https://chat.charmhub.io/](https://chat.charmhub.io/)
+ - Matrix juju chat: [https://matrix.to/#/#charmhub-juju:ubuntu.com](https://matrix.to/#/#charmhub-juju:ubuntu.com)
+ - Matrix juju development chat: [https://matrix.to/#/#charmhub-jujudev:ubuntu.com](https://matrix.to/#/#charmhub-jujudev:ubuntu.com)
  - Discourse forum: [https://discourse.charmhub.io/](https://discourse.charmhub.io/)

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ snap remove multipass
 
 Read our [Code of conduct](https://ubuntu.com/community/code-of-conduct) and:
 
-- Join our chat: [Mattermost](https://chat.charmhub.io/charmhub/channels/juju), [Freenode IRC](https://webchat.freenode.net/#juju)
+- Join our chat: [Matrix](https://matrix.to/#/#charmhub-juju:ubuntu.com)
 - Join our forum: [Discourse](https://discourse.charmhub.io/)
 
 
@@ -157,4 +157,4 @@ Read our [Code of conduct](https://ubuntu.com/community/code-of-conduct) and:
 ### Make your mark
 
 - Read our [documentation contributor guidelines](https://discourse.charmhub.io/t/documentation-guidelines-for-contributors/1245) and help improve a doc 
-- Read our [codebase contributor guidelines](https://github.com/juju/juju/blob/3.3/CONTRIBUTING.md) and help improve the codebase
+- Read our [codebase contributor guidelines](CONTRIBUTING.md) and help improve the codebase


### PR DESCRIPTION
Fixing a broken link for `codebase contributor guidelines`, found a few other links to update related to public channels for chatting on juju and juju development.

## Checklist

- [ ] ~Code style: imports ordered, good names, simple structure, etc~
- [ ] ~Comments saying why design decisions were made~
- [ ] ~Go unit tests, with comments saying what you're testing~
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Verify links:
- In the rendered README, click on the link for `codebase contributor guidelines`, should go to the local CONTRIBUTING.
- In the rendered README, click on the link for `Matrix`.
- In the rendered CONTRIBUTING, click on the link for `https://matrix.to/#/#charmhub-juju:ubuntu.com`.
- In the rendered CONTRIBUTING, click on the link for `https://matrix.to/#/#charmhub-jujudev:ubuntu.com`.


