### PR TITLE
chore: fix duplicate in Makefile Usage output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -380,7 +380,7 @@ go-client-build: $(BUILD_CLIENT_TARGETS)
 
 .PHONY: go-build
 go-build: go-agent-build go-client-build
-## build: builds all the targets withouth rebuilding a new schema.
+## go-build: builds all the targets without rebuilding a new schema.
 
 .PHONY: release-build
 release-build: go-agent-build


### PR DESCRIPTION
Two makefile targets reported as `build` in the Usage output. Now one is `build` and one `go-build` as intended. Also fix typo in description.

## Checklist


- [ ] ~Code style: imports ordered, good names, simple structure, etc~
- [ ] ~Comments saying why design decisions were made~
- [ ] ~Go unit tests, with comments saying what you're testing~
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

We now have `build` and go-build` targets when displaying the juju make usage msg, rather than two `build` targets.
