### PR TITLE
test: fix run_spaces_manual_aws missing security group rule

### DIFF
--- a/tests/suites/manual/spaces.sh
+++ b/tests/suites/manual/spaces.sh
@@ -67,6 +67,12 @@ run_spaces_manual_aws() {
 		aws ec2 authorize-security-group-ingress --group-id "${sg_id}" --protocol tcp --port 22 --cidr 0.0.0.0/0
 		aws ec2 authorize-security-group-ingress --group-id "${sg_id}" --protocol tcp --port 17070 --cidr 0.0.0.0/0
 		aws ec2 authorize-security-group-ingress --group-id "${sg_id}" --protocol udp --port 17070 --cidr 0.0.0.0/0
+		# 37017 is required for mongo and aws with public ip to init replica set.
+		# See findSelfInConfig in src/mongo/db/repl/repl_set_config_checks.cpp and isSelf in src/mongo/db/repl/isself.cpp
+		# isSelfFastPath: checks if a host:port matches a local interface mongo is bound to.
+		# isSelfSlowPath: checks if a host:port can be dialed and reaches the current mongo daemon.
+		# Since elastic IPs are not bound to a local interface (instead handled by AWS through routing rules)
+		aws ec2 authorize-security-group-ingress --group-id "${sg_id}" --protocol tcp --port 37017 --cidr 0.0.0.0/0
 		aws ec2 authorize-security-group-ingress --group-id "${sg_id}" --protocol tcp --port 0-65535 --source-group "${sg_id}"
 		aws ec2 authorize-security-group-ingress --group-id "${sg_id}" --protocol udp --port 0-65535 --source-group "${sg_id}"
 	else


### PR DESCRIPTION
Mongo on a manual bootstrapped controller on AWS using the elastic public IPv4 address for the replica set host field results in mongo needing to dial itself via the public ip.

The solution here unfortunately is to open 37017 to the world for run_spaces_manual_aws to pass. Since this is not the component of Juju here at test, this is an appropriate workaround.

## QA steps

N/A - the security group is already created. It was manually updated, see link below.

## Links

https://jenkins.juju.canonical.com/job/test-manual-test-spaces-manual-aws/2064/console

