### PR TITLE
fix: allow controller to start without reachable JWKS and JAAS bakery

### DIFF
--- a/apiserver/authentication/jwt/jwt_test.go
+++ b/apiserver/authentication/jwt/jwt_test.go
@@ -64,11 +64,10 @@ func (s *loginTokenSuite) TestCacheRegistration(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *loginTokenSuite) TestCacheRegistrationFailureWithBadURL(c *gc.C) {
+func (s *loginTokenSuite) TestCacheRegistrationSucceedsWithBadURL(c *gc.C) {
 	authenticator := jwt.NewAuthenticator("noexisturl")
 	err := authenticator.RegisterJWKSCache(context.Background())
-	// We want to make sure that we get an error for a bad url.
-	c.Assert(err, gc.NotNil)
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *loginTokenSuite) TestAuthenticateLoginRequestNotSupported(c *gc.C) {

--- a/apiserver/common/crossmodel/bakery.go
+++ b/apiserver/common/crossmodel/bakery.go
@@ -176,6 +176,8 @@ var (
 )
 
 // NewJaaSOfferBakery creates a new bakery service for JaaS offer access.
+// Attempts to refresh the bakery information but won't fail on errors
+// to prevent blocking controller startup.
 func NewJaaSOfferBakery(
 	loginTokenRefreshURL, location string,
 	bakeryConfig bakerystorage.BakeryConfig,
@@ -190,7 +192,7 @@ func NewJaaSOfferBakery(
 		OfferBakery:  &OfferBakery{clock: clock.WallClock},
 	}
 	if _, err := offerBakery.RefreshDischargeURL(loginTokenRefreshURL); err != nil {
-		return nil, errors.Trace(err)
+		logger.Errorf("refreshing jaas offer discharger at %q: %s", loginTokenRefreshURL, err)
 	}
 	return offerBakery, nil
 }


### PR DESCRIPTION
At bootstrap time, the config option `login-token-refresh-url` can be set to make a controller retrieve a JWKS (JSON web key set) used for validating that JWT tokens received via login requests are signed by the expected source, used particularly when connecting a Juju controller to JAAS.

When the Juju controller is restarted, the JWKS is fetched. This means that if JAAS is down, the Juju controller (if restarted) can never start. This is a poor failure mode and can cause issues due to the dependencies/ordering. The Juju controller can still function when JAAS is not running and the JWKS is repeatedly refreshed in a separate routine meaning that when JAAS is running again, normal operation will eventually be restored.

One consequence of this change is that the Juju controller can now also complete bootstrap even when the refresh URL is not accessible. This behaviour might not be desirable, as an alternative we could enforce retrieval of the JWKS on bootstrap but be less strict afterwards.

The same story as above is applicable to the cross-model JAAS bakery, where JAAS acts as the discharger for macaroons.

In addition to these changes, it would be nice to print a warning to the user during bootstrap if JAAS is not reachable, but I'm not sure if it's possible to surface a message from the controller to the bootstrap CLI process.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Run,
- Assuming nothing is running at port 10001.
- `juju bootstrap localhost test-controller --config login-token-refresh-url=http://localhost:10001 --debug`
- Previously bootstrap would fail, now the controller should successfully complete bootstrapping.
- SSH into the LXC container running the controller.
- Run `grep -i refresh /var/log/juju/machine-0.log` which should show something similar to
```
2024-06-21 07:14:08 ERROR juju.apiserver.authentication.jwt jwt.go:191 refreshing jwk cache at "http://localhost:10001": failed to fetch "http://localhost:10001": failed to fetch "http://localhost:10001": Get "http://localhost:10001": dial tcp 127.0.0.1:10001: connect: connection refused
2024-06-21 07:14:08 ERROR juju.apiserver.common.crossmodel bakery.go:195 refreshing jaas offer discharger at "http://localhost:10001": Get "http://localhost:10001/macaroons/discharge/info": dial tcp 127.0.0.1:10001: connect: connection refused
```

## Documentation changes
--
<!-- How it affects user workflow (CLI or API). -->

## Links
--
<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->