### PR TITLE
fix(openstack): fix model sec group misconfiguration

### DIFF
--- a/provider/openstack/firewaller.go
+++ b/provider/openstack/firewaller.go
@@ -73,6 +73,13 @@ type Firewaller interface {
 	// If the model security group doesn't exist, return a NotFound error
 	ModelIngressRules(ctx context.ProviderCallContext) (firewall.IngressRules, error)
 
+	// DeleteMachineGroup delete's the security group specific to the provided machine.
+	// When in 'instance' firewall mode, each instance in a model is assigned its own
+	// security group, with a lifecycle matching that of the instance itself.
+	// In 'global' mode, all security groups are model scoped, and have lifecycles
+	// matching the model, so this method will remove no groups.
+	DeleteMachineGroup(ctx context.ProviderCallContext, machineId string) error
+
 	// DeleteAllModelGroups deletes all security groups for the
 	// model.
 	DeleteAllModelGroups(ctx context.ProviderCallContext) error
@@ -461,6 +468,10 @@ func (c *neutronFirewaller) DeleteAllControllerGroups(ctx context.ProviderCallCo
 // DeleteAllModelGroups implements Firewaller interface.
 func (c *neutronFirewaller) DeleteAllModelGroups(ctx context.ProviderCallContext) error {
 	return deleteSecurityGroupsMatchingName(ctx, c.deleteSecurityGroups, c.jujuGroupPrefixRegexp())
+}
+
+func (c *neutronFirewaller) DeleteMachineGroup(ctx context.ProviderCallContext, machineID string) error {
+	return deleteSecurityGroupsMatchingName(ctx, c.deleteSecurityGroups, c.machineGroupRegexp(machineID))
 }
 
 // UpdateGroupController implements Firewaller interface.

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -849,7 +849,7 @@ func (s *localServerSuite) TestStartInstanceWaitForActiveDetails(c *gc.C) {
 	c.Assert(insts, gc.HasLen, 0, gc.Commentf("expected launched instance to be terminated if stuck in BUILD state"))
 }
 
-func (s *localServerSuite) TestStartInstanceDeletesSecurityGroupsOnInstanceCreateFailure(c *gc.C) {
+func (s *localServerSuite) TestStartInstanceDeletesMachineSecurityGroupOnInstanceCreateFailure(c *gc.C) {
 	env := s.openEnviron(c, coretesting.Attrs{"firewall-mode": config.FwInstance})
 
 	// Force an error in waitForActiveServerDetails
@@ -864,7 +864,10 @@ func (s *localServerSuite) TestStartInstanceDeletesSecurityGroupsOnInstanceCreat
 	c.Check(inst, gc.IsNil)
 	c.Assert(err, gc.NotNil)
 
-	assertSecurityGroups(c, env, []string{"default"})
+	assertSecurityGroups(c, env, []string{
+		fmt.Sprintf("juju-%s-%s", coretesting.ControllerTag.Id(), coretesting.ModelTag.Id()),
+		"default",
+	})
 }
 
 func (s *localServerSuite) TestStartInstanceDeletesSecurityGroupsOnFailure(c *gc.C) {
@@ -881,7 +884,10 @@ func (s *localServerSuite) TestStartInstanceDeletesSecurityGroupsOnFailure(c *gc
 	_, _, _, err := testing.StartInstance(env, s.callCtx, s.ControllerUUID, "100")
 	c.Assert(err, gc.NotNil)
 
-	assertSecurityGroups(c, env, []string{"default"})
+	assertSecurityGroups(c, env, []string{
+		fmt.Sprintf("juju-%s-%s", coretesting.ControllerTag.Id(), coretesting.ModelTag.Id()),
+		"default",
+	})
 }
 
 func assertSecurityGroups(c *gc.C, env environs.Environ, expected []string) {
@@ -3062,8 +3068,8 @@ func (s *localServerSuite) TestUpdateGroupController(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	groupNamesBefore := set.NewStrings(groupNames...)
 	c.Assert(groupNamesBefore, gc.DeepEquals, set.NewStrings(
-		"juju-deadbeef-1bad-500d-9000-4b1d0d06f00d-deadbeef-0bad-400d-8000-4b1d0d06f00d",
-		"juju-deadbeef-1bad-500d-9000-4b1d0d06f00d-deadbeef-0bad-400d-8000-4b1d0d06f00d-0",
+		fmt.Sprintf("juju-%s-%s", coretesting.ControllerTag.Id(), coretesting.ModelTag.Id()),
+		fmt.Sprintf("juju-%s-%s-0", coretesting.ControllerTag.Id(), coretesting.ModelTag.Id()),
 	))
 
 	firewaller := openstack.GetFirewaller(s.env)
@@ -3074,8 +3080,8 @@ func (s *localServerSuite) TestUpdateGroupController(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	groupNamesAfter := set.NewStrings(groupNames...)
 	c.Assert(groupNamesAfter, gc.DeepEquals, set.NewStrings(
-		"juju-aabbccdd-eeee-ffff-0000-0123456789ab-deadbeef-0bad-400d-8000-4b1d0d06f00d",
-		"juju-aabbccdd-eeee-ffff-0000-0123456789ab-deadbeef-0bad-400d-8000-4b1d0d06f00d-0",
+		fmt.Sprintf("juju-aabbccdd-eeee-ffff-0000-0123456789ab-%s", coretesting.ModelTag.Id()),
+		fmt.Sprintf("juju-aabbccdd-eeee-ffff-0000-0123456789ab-%s-0", coretesting.ModelTag.Id()),
 	))
 }
 

--- a/provider/openstack/provider.go
+++ b/provider/openstack/provider.go
@@ -1273,7 +1273,7 @@ func (e *Environ) startInstance(
 	server, err := tryStartNovaInstance(shortAttempt, e.nova(), opts)
 	if err != nil || server == nil {
 		// Attempt to clean up any security groups we created.
-		if err := e.cleanupGroups(ctx, e.nova(), novaGroupNames); err != nil {
+		if err := e.firewaller.DeleteMachineGroup(ctx, args.InstanceConfig.MachineId); err != nil {
 			// If we failed to clean up the security groups, we need the user
 			// to manually clean them up.
 			logger.Errorf("cannot cleanup security groups: %v", err)
@@ -1349,19 +1349,6 @@ func (e *Environ) startInstance(
 		Instance: inst,
 		Hardware: inst.hardwareCharacteristics(),
 	}, nil
-}
-
-// Clean up any groups that we have created if we fail to start the instance.
-func (e *Environ) cleanupGroups(
-	ctx context.ProviderCallContext,
-	client *nova.Client,
-	groups []nova.SecurityGroupName,
-) error {
-	names := make([]string, len(groups))
-	for i, group := range groups {
-		names[i] = group.Name
-	}
-	return e.firewaller.DeleteGroups(ctx, names...)
 }
 
 func (e *Environ) userFriendlyInvalidNetworkError(err error) error {


### PR DESCRIPTION
When a machine fails to provision, the openstack provider attempted to delete all security groups attached to that instance. Including any model-scoped security groups (and potentially the openstack default sec group!)

This can lead to errors. The firewaller configures the model sec group only when:
1) Once when the first machine is provisioned
2) when a change to ssh-allow is detected

This means if the first machine you attempt to provision fails, the model sec group will be deleted after it's configured. So it won't received it's initial config

Attempting to deleting all secgroups attached to a machine could also lead to countless other unexpected behaviours.

Fix this by only deleting the machine sec group when a machine fails to provision i.e. the sec group unique to the relevant machine. This means we will no longer attempt to delete sec groups potentially attached to other instances.

NOTE: This PR is intended to resolve https://bugs.launchpad.net/juju/+bug/2067629. However, I was only able to replicate this bug under the specific circumstances listed above, so I can't say for sure this will resolve the bug. It certainly resolve _a_ bug though

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Force the first machine added to a model to fail to provision to an openstack model

The way I did this was by deploying a microstack cluster onto my desktop in a VM with limited resources.
```
$ cat ./cloud-init.yaml
fqdn: sunbeam.multipass
$ multipass launch -c 8 -d 100G -m 32G -n sunbeam --cloud-init ./cloud-init.yaml jammy
```
Then follow the instructions here https://microstack.run/docs/single-node.

(However, any openstack cluster will do, so long as you can force a machine to fail to be provisioned)

My openstack cluster only has capacity for 1 juju controller and another m1.small vm. The second m1.small instance will fail with "No valid host was found."

```
$ juju bootstrap --metadata-source /home/ubuntu/simplestreams/ --bootstrap-constraints "allocate-public-ip=true"  openstack/RegionOne stack
$ juju switch controller
$ juju add-machine
(wait)
$ juju add-model m
$ juju add-machine
(wait)
$ juju status
Model  Controller  Cloud/Region         Version  SLA          Timestamp
m      stack       openstack/RegionOne  3.4.4.1  unsupported  12:11:11+01:00

Machine  State  Address  Inst id  Base          AZ  Message
0        down            pending  ubuntu@22.04       with fault "No valid host was found. "
```

Then verify the model sec group still exists
```
$ juju show-model --format json | jq -r '.[]["controller-uuid"]'
3a0484e8-492b-45c2-892d-f23d3f8268e0
$ juju show-model --format json | jq -r '.[]["model-uuid"]'
39e6b06c-b74d-4ec3-815b-5a841129b6ac

$ openstack security group list
+--------------------------------------+----------------------------------------------------------------------------------+------------------------+----------------------------------+------+
| ID                                   | Name                                                                             | Description            | Project                          | Tags |
+--------------------------------------+----------------------------------------------------------------------------------+------------------------+----------------------------------+------+
| 20c903e3-8083-46ee-984d-adb8271e78d1 | juju-3a0484e8-492b-45c2-892d-f23d3f8268e0-1dfbd9c2-4cf6-4cec-8ef5-d4fb04f408cd   | juju group             | 01ee39afa1234a80a7d6ad6704ef9552 | []   |

| 29327957-356a-4a9c-acc5-baf2e77b7e39 | juju-3a0484e8-492b-45c2-892d-f23d3f8268e0-39e6b06c-b74d-4ec3-815b-5a841129b6ac   | juju group             | 01ee39afa1234a80a7d6ad6704ef9552 | []   |
| 8b5d063d-2c16-420d-9d44-bc420d50660a | default                                                                          | Default security group | 01ee39afa1234a80a7d6ad6704ef9552 | []   |
| acfb5dbb-0e94-4495-8f07-daae7c85eb78 | juju-3a0484e8-492b-45c2-892d-f23d3f8268e0-1dfbd9c2-4cf6-4cec-8ef5-d4fb04f408cd-0 | juju group             | 01ee39afa1234a80a7d6ad6704ef9552 | []   |
| bd51ce88-013e-4ed0-9996-b888b263c9c7 | juju-3a0484e8-492b-45c2-892d-f23d3f8268e0-1dfbd9c2-4cf6-4cec-8ef5-d4fb04f408cd-1 | juju group             | 01ee39afa1234a80a7d6ad6704ef9552 | []   |
+--------------------------------------+----------------------------------------------------------------------------------+------------------------+----------------------------------+------+
```
#### ^ NOTE the model group `juju-3a0484e8-492b-45c2-892d-f23d3f8268e0-39e6b06c-b74d-4ec3-815b-5a841129b6ac` is present, and there are no machine groups

```
$ openstack security group show juju-3a0484e8-492b-45c2-892d-f23d3f8268e0-39e6b06c-b74d-4ec3-815b-5a841129b6ac -f json | jq -r '.rules[] | select(.port_range_min == 22) | .remote_ip_prefix'
0.0.0.0/0
::/0
```
#### ^ Observe the sec group is still correctly configured

## Links

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2067629

**Jira card:** [JUJU-6175](https://warthogs.atlassian.net/browse/JUJU-6175)

[JUJU-6175]: https://warthogs.atlassian.net/browse/JUJU-6175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ