### PR TITLE
chore: api/agent context aware

### DIFF
--- a/api/agent/keyupdater/authorisedkeys.go
+++ b/api/agent/keyupdater/authorisedkeys.go
@@ -33,12 +33,12 @@ func NewClient(caller base.APICaller, options ...Option) *Client {
 }
 
 // AuthorisedKeys returns the authorised ssh keys for the machine specified by machineTag.
-func (c *Client) AuthorisedKeys(tag names.MachineTag) ([]string, error) {
+func (c *Client) AuthorisedKeys(ctx context.Context, tag names.MachineTag) ([]string, error) {
 	var results params.StringsResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: tag.String()}},
 	}
-	err := c.facade.FacadeCall(context.TODO(), "AuthorisedKeys", args, &results)
+	err := c.facade.FacadeCall(ctx, "AuthorisedKeys", args, &results)
 	if err != nil {
 		// TODO: Not directly tested
 		return nil, err
@@ -56,12 +56,12 @@ func (c *Client) AuthorisedKeys(tag names.MachineTag) ([]string, error) {
 
 // WatchAuthorisedKeys returns a notify watcher that looks for changes in the
 // authorised ssh keys for the machine specified by machineTag.
-func (c *Client) WatchAuthorisedKeys(tag names.MachineTag) (watcher.NotifyWatcher, error) {
+func (c *Client) WatchAuthorisedKeys(ctx context.Context, tag names.MachineTag) (watcher.NotifyWatcher, error) {
 	var results params.NotifyWatchResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: tag.String()}},
 	}
-	err := c.facade.FacadeCall(context.TODO(), "WatchAuthorisedKeys", args, &results)
+	err := c.facade.FacadeCall(ctx, "WatchAuthorisedKeys", args, &results)
 	if err != nil {
 		// TODO: Not directly tested
 		return nil, err

--- a/api/agent/keyupdater/authorisedkeys_test.go
+++ b/api/agent/keyupdater/authorisedkeys_test.go
@@ -4,6 +4,8 @@
 package keyupdater_test
 
 import (
+	"context"
+
 	"github.com/juju/names/v5"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -39,7 +41,7 @@ func (s *keyupdaterSuite) TestAuthorisedKeys(c *gc.C) {
 	})
 	tag := names.NewMachineTag("666")
 	client := keyupdater.NewClient(apiCaller)
-	keys, err := client.AuthorisedKeys(tag)
+	keys, err := client.AuthorisedKeys(context.Background(), tag)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(keys, gc.DeepEquals, []string{"key1", "key2"})
 }
@@ -62,6 +64,6 @@ func (s *keyupdaterSuite) TestWatchAuthorisedKeys(c *gc.C) {
 	})
 	tag := names.NewMachineTag("666")
 	client := keyupdater.NewClient(apiCaller)
-	_, err := client.WatchAuthorisedKeys(tag)
+	_, err := client.WatchAuthorisedKeys(context.Background(), tag)
 	c.Assert(err, gc.ErrorMatches, "FAIL")
 }

--- a/api/agent/leadership/client_test.go
+++ b/api/agent/leadership/client_test.go
@@ -4,6 +4,7 @@
 package leadership_test
 
 import (
+	"context"
 	"time"
 
 	"github.com/juju/errors"
@@ -70,7 +71,7 @@ func (s *ClientSuite) TestClaimLeadershipTranslation(c *gc.C) {
 	})
 
 	client := leadership.NewClient(apiCaller)
-	err := client.ClaimLeadership(StubApplicationNm, StubUnitNm, claimTime)
+	err := client.ClaimLeadership(context.Background(), StubApplicationNm, StubUnitNm, claimTime)
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(numStubCalls, gc.Equals, 1)
 }
@@ -93,7 +94,7 @@ func (s *ClientSuite) TestClaimLeadershipDeniedError(c *gc.C) {
 	})
 
 	client := leadership.NewClient(apiCaller)
-	err := client.ClaimLeadership(StubApplicationNm, StubUnitNm, 0)
+	err := client.ClaimLeadership(context.Background(), StubApplicationNm, StubUnitNm, 0)
 	c.Check(numStubCalls, gc.Equals, 1)
 	c.Check(err, gc.Equals, coreleadership.ErrClaimDenied)
 }
@@ -116,7 +117,7 @@ func (s *ClientSuite) TestClaimLeadershipUnknownError(c *gc.C) {
 	})
 
 	client := leadership.NewClient(apiCaller)
-	err := client.ClaimLeadership(StubApplicationNm, StubUnitNm, 0)
+	err := client.ClaimLeadership(context.Background(), StubApplicationNm, StubUnitNm, 0)
 	c.Check(numStubCalls, gc.Equals, 1)
 	c.Check(err, gc.ErrorMatches, errMsg)
 }
@@ -130,7 +131,7 @@ func (s *ClientSuite) TestClaimLeadershipFacadeCallError(c *gc.C) {
 	})
 
 	client := leadership.NewClient(apiCaller)
-	err := client.ClaimLeadership(StubApplicationNm, StubUnitNm, 0)
+	err := client.ClaimLeadership(context.Background(), StubApplicationNm, StubUnitNm, 0)
 	c.Check(numStubCalls, gc.Equals, 1)
 	c.Check(err, gc.ErrorMatches, "error making a leadership claim: "+errMsg)
 }
@@ -151,7 +152,7 @@ func (s *ClientSuite) TestBlockUntilLeadershipReleasedTranslation(c *gc.C) {
 	})
 
 	client := leadership.NewClient(apiCaller)
-	err := client.BlockUntilLeadershipReleased(StubApplicationNm, nil)
+	err := client.BlockUntilLeadershipReleased(context.Background(), StubApplicationNm, nil)
 
 	c.Check(numStubCalls, gc.Equals, 1)
 	c.Check(err, jc.ErrorIsNil)
@@ -172,7 +173,7 @@ func (s *ClientSuite) TestBlockUntilLeadershipReleasedError(c *gc.C) {
 	})
 
 	client := leadership.NewClient(apiCaller)
-	err := client.BlockUntilLeadershipReleased(StubApplicationNm, nil)
+	err := client.BlockUntilLeadershipReleased(context.Background(), StubApplicationNm, nil)
 
 	c.Check(numStubCalls, gc.Equals, 1)
 	c.Check(err, gc.ErrorMatches, "error blocking on leadership release: splat")
@@ -187,7 +188,7 @@ func (s *ClientSuite) TestBlockUntilLeadershipReleasedFacadeCallError(c *gc.C) {
 	})
 
 	client := leadership.NewClient(apiCaller)
-	err := client.BlockUntilLeadershipReleased(StubApplicationNm, nil)
+	err := client.BlockUntilLeadershipReleased(context.Background(), StubApplicationNm, nil)
 	c.Check(numStubCalls, gc.Equals, 1)
 	c.Check(err, gc.ErrorMatches, "error blocking on leadership release: "+errMsg)
 }

--- a/api/agent/lifeflag/client.go
+++ b/api/agent/lifeflag/client.go
@@ -4,6 +4,8 @@
 package lifeflag
 
 import (
+	"context"
+
 	"github.com/juju/names/v5"
 
 	"github.com/juju/juju/api/base"
@@ -21,8 +23,8 @@ var WithTracer = base.WithTracer
 
 // Client is the client used for connecting to the life flag facade.
 type Client interface {
-	Life(names.Tag) (life.Value, error)
-	Watch(names.Tag) (watcher.NotifyWatcher, error)
+	Life(context.Context, names.Tag) (life.Value, error)
+	Watch(context.Context, names.Tag) (watcher.NotifyWatcher, error)
 }
 
 // NewClient creates a new life flag client.

--- a/api/agent/logger/logger.go
+++ b/api/agent/logger/logger.go
@@ -35,12 +35,12 @@ func NewClient(caller base.APICaller, options ...Option) *Client {
 
 // LoggingConfig returns the loggo configuration string for the agent
 // specified by agentTag.
-func (c *Client) LoggingConfig(agentTag names.Tag) (string, error) {
+func (c *Client) LoggingConfig(ctx context.Context, agentTag names.Tag) (string, error) {
 	var results params.StringResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: agentTag.String()}},
 	}
-	err := c.facade.FacadeCall(context.TODO(), "LoggingConfig", args, &results)
+	err := c.facade.FacadeCall(ctx, "LoggingConfig", args, &results)
 	if err != nil {
 		// TODO: Not directly tested
 		return "", err
@@ -58,12 +58,12 @@ func (c *Client) LoggingConfig(agentTag names.Tag) (string, error) {
 
 // WatchLoggingConfig returns a notify watcher that looks for changes in the
 // logging-config for the agent specified by agentTag.
-func (c *Client) WatchLoggingConfig(agentTag names.Tag) (watcher.NotifyWatcher, error) {
+func (c *Client) WatchLoggingConfig(ctx context.Context, agentTag names.Tag) (watcher.NotifyWatcher, error) {
 	var results params.NotifyWatchResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: agentTag.String()}},
 	}
-	err := c.facade.FacadeCall(context.TODO(), "WatchLoggingConfig", args, &results)
+	err := c.facade.FacadeCall(ctx, "WatchLoggingConfig", args, &results)
 	if err != nil {
 		// TODO: Not directly tested
 		return nil, err

--- a/api/agent/logger/logger_test.go
+++ b/api/agent/logger/logger_test.go
@@ -4,6 +4,8 @@
 package logger_test
 
 import (
+	"context"
+
 	"github.com/juju/names/v5"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -38,7 +40,7 @@ func (s *loggerSuite) TestLoggingConfig(c *gc.C) {
 
 	client := logger.NewClient(apiCaller)
 	tag := names.NewMachineTag("666")
-	result, err := client.LoggingConfig(tag)
+	result, err := client.LoggingConfig(context.Background(), tag)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.Equals, "juju.worker=TRACE")
 }
@@ -63,6 +65,6 @@ func (s *loggerSuite) TestWatchLoggingConfig(c *gc.C) {
 
 	client := logger.NewClient(apiCaller)
 	tag := names.NewMachineTag("666")
-	_, err := client.WatchLoggingConfig(tag)
+	_, err := client.WatchLoggingConfig(context.Background(), tag)
 	c.Assert(err, gc.ErrorMatches, "FAIL")
 }

--- a/api/agent/machineactions/machineactions.go
+++ b/api/agent/machineactions/machineactions.go
@@ -34,13 +34,13 @@ func NewClient(caller base.APICaller, options ...Option) *Client {
 // WatchActionNotifications returns a StringsWatcher for observing the
 // IDs of Actions added to the Machine. The initial event will contain the
 // IDs of any Actions pending at the time the Watcher is made.
-func (c *Client) WatchActionNotifications(agent names.MachineTag) (watcher.StringsWatcher, error) {
+func (c *Client) WatchActionNotifications(ctx context.Context, agent names.MachineTag) (watcher.StringsWatcher, error) {
 	var results params.StringsWatchResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: agent.String()}},
 	}
 
-	err := c.facade.FacadeCall(context.TODO(), "WatchActionNotifications", args, &results)
+	err := c.facade.FacadeCall(ctx, "WatchActionNotifications", args, &results)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -57,7 +57,7 @@ func (c *Client) WatchActionNotifications(agent names.MachineTag) (watcher.Strin
 	return w, nil
 }
 
-func (c *Client) getOneAction(tag names.ActionTag) (params.ActionResult, error) {
+func (c *Client) getOneAction(ctx context.Context, tag names.ActionTag) (params.ActionResult, error) {
 	nothing := params.ActionResult{}
 
 	args := params.Entities{
@@ -65,7 +65,7 @@ func (c *Client) getOneAction(tag names.ActionTag) (params.ActionResult, error) 
 	}
 
 	var results params.ActionResults
-	err := c.facade.FacadeCall(context.TODO(), "Actions", args, &results)
+	err := c.facade.FacadeCall(ctx, "Actions", args, &results)
 	if err != nil {
 		return nothing, errors.Trace(err)
 	}
@@ -83,8 +83,8 @@ func (c *Client) getOneAction(tag names.ActionTag) (params.ActionResult, error) 
 }
 
 // Action returns the Action with the given tag.
-func (c *Client) Action(tag names.ActionTag) (*Action, error) {
-	result, err := c.getOneAction(tag)
+func (c *Client) Action(ctx context.Context, tag names.ActionTag) (*Action, error) {
+	result, err := c.getOneAction(ctx, tag)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -103,14 +103,14 @@ func (c *Client) Action(tag names.ActionTag) (*Action, error) {
 }
 
 // ActionBegin marks an action as running.
-func (c *Client) ActionBegin(tag names.ActionTag) error {
+func (c *Client) ActionBegin(ctx context.Context, tag names.ActionTag) error {
 	var results params.ErrorResults
 
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: tag.String()}},
 	}
 
-	err := c.facade.FacadeCall(context.TODO(), "BeginActions", args, &results)
+	err := c.facade.FacadeCall(ctx, "BeginActions", args, &results)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -119,7 +119,7 @@ func (c *Client) ActionBegin(tag names.ActionTag) error {
 }
 
 // ActionFinish captures the structured output of an action.
-func (c *Client) ActionFinish(tag names.ActionTag, status string, actionResults map[string]interface{}, message string) error {
+func (c *Client) ActionFinish(ctx context.Context, tag names.ActionTag, status string, actionResults map[string]interface{}, message string) error {
 	var results params.ErrorResults
 
 	args := params.ActionExecutionResults{
@@ -131,7 +131,7 @@ func (c *Client) ActionFinish(tag names.ActionTag, status string, actionResults 
 		}},
 	}
 
-	err := c.facade.FacadeCall(context.TODO(), "FinishActions", args, &results)
+	err := c.facade.FacadeCall(ctx, "FinishActions", args, &results)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -140,14 +140,14 @@ func (c *Client) ActionFinish(tag names.ActionTag, status string, actionResults 
 }
 
 // RunningActions returns a list of actions running for the given machine tag.
-func (c *Client) RunningActions(agent names.MachineTag) ([]params.ActionResult, error) {
+func (c *Client) RunningActions(ctx context.Context, agent names.MachineTag) ([]params.ActionResult, error) {
 	var results params.ActionsByReceivers
 
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: agent.String()}},
 	}
 
-	err := c.facade.FacadeCall(context.TODO(), "RunningActions", args, &results)
+	err := c.facade.FacadeCall(ctx, "RunningActions", args, &results)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/api/agent/machineactions/machineactions_test.go
+++ b/api/agent/machineactions/machineactions_test.go
@@ -5,6 +5,8 @@
 package machineactions_test
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 	jujutesting "github.com/juju/testing"
@@ -27,8 +29,8 @@ func (s *ClientSuite) TestWatchFails(c *gc.C) {
 	tag := names.NewMachineTag("2")
 	expectErr := errors.Errorf("kuso")
 	expectedCalls := []jujutesting.StubCall{{
-		"MachineActions.WatchActionNotifications",
-		[]interface{}{"", params.Entities{
+		FuncName: "MachineActions.WatchActionNotifications",
+		Args: []interface{}{"", params.Entities{
 			Entities: []params.Entity{{Tag: tag.String()}},
 		}},
 	}}
@@ -43,7 +45,7 @@ func (s *ClientSuite) TestWatchFails(c *gc.C) {
 	})
 
 	client := machineactions.NewClient(apiCaller)
-	w, err := client.WatchActionNotifications(tag)
+	w, err := client.WatchActionNotifications(context.Background(), tag)
 	c.Assert(errors.Cause(err), gc.Equals, expectErr)
 	c.Assert(w, gc.IsNil)
 	stub.CheckCalls(c, expectedCalls)
@@ -56,8 +58,8 @@ func (s *ClientSuite) TestWatchResultError(c *gc.C) {
 		Code:    params.CodeNotAssigned,
 	}
 	expectedCalls := []jujutesting.StubCall{{
-		"MachineActions.WatchActionNotifications",
-		[]interface{}{"", params.Entities{
+		FuncName: "MachineActions.WatchActionNotifications",
+		Args: []interface{}{"", params.Entities{
 			Entities: []params.Entity{{Tag: tag.String()}},
 		}},
 	}}
@@ -73,7 +75,7 @@ func (s *ClientSuite) TestWatchResultError(c *gc.C) {
 	})
 
 	client := machineactions.NewClient(apiCaller)
-	w, err := client.WatchActionNotifications(tag)
+	w, err := client.WatchActionNotifications(context.Background(), tag)
 	c.Assert(errors.Cause(err), gc.Equals, expectErr)
 	c.Assert(w, gc.IsNil)
 	stub.CheckCalls(c, expectedCalls)
@@ -82,8 +84,8 @@ func (s *ClientSuite) TestWatchResultError(c *gc.C) {
 func (s *ClientSuite) TestWatchResultTooMany(c *gc.C) {
 	tag := names.NewMachineTag("2")
 	expectedCalls := []jujutesting.StubCall{{
-		"MachineActions.WatchActionNotifications",
-		[]interface{}{"", params.Entities{
+		FuncName: "MachineActions.WatchActionNotifications",
+		Args: []interface{}{"", params.Entities{
 			Entities: []params.Entity{{Tag: tag.String()}},
 		}},
 	}}
@@ -98,7 +100,7 @@ func (s *ClientSuite) TestWatchResultTooMany(c *gc.C) {
 	})
 
 	client := machineactions.NewClient(apiCaller)
-	w, err := client.WatchActionNotifications(tag)
+	w, err := client.WatchActionNotifications(context.Background(), tag)
 	c.Assert(err, gc.ErrorMatches, "expected 1 result, got 2")
 	c.Assert(w, gc.IsNil)
 	stub.CheckCalls(c, expectedCalls)
@@ -107,8 +109,8 @@ func (s *ClientSuite) TestWatchResultTooMany(c *gc.C) {
 func (s *ClientSuite) TestActionBeginSuccess(c *gc.C) {
 	tag := names.NewActionTag(uuid.MustNewUUID().String())
 	expectedCalls := []jujutesting.StubCall{{
-		"MachineActions.BeginActions",
-		[]interface{}{"", params.Entities{
+		FuncName: "MachineActions.BeginActions",
+		Args: []interface{}{"", params.Entities{
 			Entities: []params.Entity{{Tag: tag.String()}},
 		}},
 	}}
@@ -125,7 +127,7 @@ func (s *ClientSuite) TestActionBeginSuccess(c *gc.C) {
 	})
 
 	client := machineactions.NewClient(apiCaller)
-	err := client.ActionBegin(tag)
+	err := client.ActionBegin(context.Background(), tag)
 	c.Assert(err, jc.ErrorIsNil)
 	stub.CheckCalls(c, expectedCalls)
 }
@@ -133,8 +135,8 @@ func (s *ClientSuite) TestActionBeginSuccess(c *gc.C) {
 func (s *ClientSuite) TestActionBeginError(c *gc.C) {
 	tag := names.NewActionTag(uuid.MustNewUUID().String())
 	expectedCalls := []jujutesting.StubCall{{
-		"MachineActions.BeginActions",
-		[]interface{}{"", params.Entities{
+		FuncName: "MachineActions.BeginActions",
+		Args: []interface{}{"", params.Entities{
 			Entities: []params.Entity{{Tag: tag.String()}},
 		}},
 	}}
@@ -148,7 +150,7 @@ func (s *ClientSuite) TestActionBeginError(c *gc.C) {
 	})
 
 	client := machineactions.NewClient(apiCaller)
-	err := client.ActionBegin(tag)
+	err := client.ActionBegin(context.Background(), tag)
 	c.Assert(errors.Cause(err), gc.Equals, expectedErr)
 	stub.CheckCalls(c, expectedCalls)
 }
@@ -156,8 +158,8 @@ func (s *ClientSuite) TestActionBeginError(c *gc.C) {
 func (s *ClientSuite) TestActionBeginResultError(c *gc.C) {
 	tag := names.NewActionTag(uuid.MustNewUUID().String())
 	expectedCalls := []jujutesting.StubCall{{
-		"MachineActions.BeginActions",
-		[]interface{}{"", params.Entities{
+		FuncName: "MachineActions.BeginActions",
+		Args: []interface{}{"", params.Entities{
 			Entities: []params.Entity{{Tag: tag.String()}},
 		}},
 	}}
@@ -178,7 +180,7 @@ func (s *ClientSuite) TestActionBeginResultError(c *gc.C) {
 	})
 
 	client := machineactions.NewClient(apiCaller)
-	err := client.ActionBegin(tag)
+	err := client.ActionBegin(context.Background(), tag)
 	c.Assert(errors.Cause(err), gc.Equals, expectedErr)
 	stub.CheckCalls(c, expectedCalls)
 }
@@ -186,8 +188,8 @@ func (s *ClientSuite) TestActionBeginResultError(c *gc.C) {
 func (s *ClientSuite) TestActionBeginTooManyResults(c *gc.C) {
 	tag := names.NewActionTag(uuid.MustNewUUID().String())
 	expectedCalls := []jujutesting.StubCall{{
-		"MachineActions.BeginActions",
-		[]interface{}{"", params.Entities{
+		FuncName: "MachineActions.BeginActions",
+		Args: []interface{}{"", params.Entities{
 			Entities: []params.Entity{{Tag: tag.String()}},
 		}},
 	}}
@@ -202,7 +204,7 @@ func (s *ClientSuite) TestActionBeginTooManyResults(c *gc.C) {
 	})
 
 	client := machineactions.NewClient(apiCaller)
-	err := client.ActionBegin(tag)
+	err := client.ActionBegin(context.Background(), tag)
 	c.Assert(err, gc.ErrorMatches, "expected 1 result, got 2")
 	stub.CheckCalls(c, expectedCalls)
 }
@@ -213,8 +215,8 @@ func (s *ClientSuite) TestActionFinishSuccess(c *gc.C) {
 	actionResults := map[string]interface{}{"stub": "stub"}
 	message := "stubmsg"
 	expectedCalls := []jujutesting.StubCall{{
-		"MachineActions.FinishActions",
-		[]interface{}{"", params.ActionExecutionResults{
+		FuncName: "MachineActions.FinishActions",
+		Args: []interface{}{"", params.ActionExecutionResults{
 			Results: []params.ActionExecutionResult{{
 				ActionTag: tag.String(),
 				Status:    status,
@@ -235,7 +237,7 @@ func (s *ClientSuite) TestActionFinishSuccess(c *gc.C) {
 	})
 
 	client := machineactions.NewClient(apiCaller)
-	err := client.ActionFinish(tag, status, actionResults, message)
+	err := client.ActionFinish(context.Background(), tag, status, actionResults, message)
 	c.Assert(err, jc.ErrorIsNil)
 	stub.CheckCalls(c, expectedCalls)
 }
@@ -243,8 +245,8 @@ func (s *ClientSuite) TestActionFinishSuccess(c *gc.C) {
 func (s *ClientSuite) TestActionFinishError(c *gc.C) {
 	tag := names.NewActionTag(uuid.MustNewUUID().String())
 	expectedCalls := []jujutesting.StubCall{{
-		"MachineActions.FinishActions",
-		[]interface{}{"", params.ActionExecutionResults{
+		FuncName: "MachineActions.FinishActions",
+		Args: []interface{}{"", params.ActionExecutionResults{
 			Results: []params.ActionExecutionResult{{
 				ActionTag: tag.String(),
 				Status:    "",
@@ -263,7 +265,7 @@ func (s *ClientSuite) TestActionFinishError(c *gc.C) {
 	})
 
 	client := machineactions.NewClient(apiCaller)
-	err := client.ActionFinish(tag, "", nil, "")
+	err := client.ActionFinish(context.Background(), tag, "", nil, "")
 	c.Assert(errors.Cause(err), gc.Equals, expectedErr)
 	stub.CheckCalls(c, expectedCalls)
 }
@@ -271,8 +273,8 @@ func (s *ClientSuite) TestActionFinishError(c *gc.C) {
 func (s *ClientSuite) TestActionFinishResultError(c *gc.C) {
 	tag := names.NewActionTag(uuid.MustNewUUID().String())
 	expectedCalls := []jujutesting.StubCall{{
-		"MachineActions.FinishActions",
-		[]interface{}{"", params.ActionExecutionResults{
+		FuncName: "MachineActions.FinishActions",
+		Args: []interface{}{"", params.ActionExecutionResults{
 			Results: []params.ActionExecutionResult{{
 				ActionTag: tag.String(),
 				Status:    "",
@@ -291,14 +293,14 @@ func (s *ClientSuite) TestActionFinishResultError(c *gc.C) {
 		stub.AddCall(objType+"."+request, id, arg)
 		c.Check(result, gc.FitsTypeOf, &params.ErrorResults{})
 		*(result.(*params.ErrorResults)) = params.ErrorResults{
-			Results: []params.ErrorResult{{expectedErr}},
+			Results: []params.ErrorResult{{Error: expectedErr}},
 		}
 
 		return nil
 	})
 
 	client := machineactions.NewClient(apiCaller)
-	err := client.ActionFinish(tag, "", nil, "")
+	err := client.ActionFinish(context.Background(), tag, "", nil, "")
 	c.Assert(errors.Cause(err), gc.Equals, expectedErr)
 	stub.CheckCalls(c, expectedCalls)
 }
@@ -306,8 +308,8 @@ func (s *ClientSuite) TestActionFinishResultError(c *gc.C) {
 func (s *ClientSuite) TestActionFinishTooManyResults(c *gc.C) {
 	tag := names.NewActionTag(uuid.MustNewUUID().String())
 	expectedCalls := []jujutesting.StubCall{{
-		"MachineActions.FinishActions",
-		[]interface{}{"", params.ActionExecutionResults{
+		FuncName: "MachineActions.FinishActions",
+		Args: []interface{}{"", params.ActionExecutionResults{
 			Results: []params.ActionExecutionResult{{
 				ActionTag: tag.String(),
 				Status:    "",
@@ -327,7 +329,7 @@ func (s *ClientSuite) TestActionFinishTooManyResults(c *gc.C) {
 	})
 
 	client := machineactions.NewClient(apiCaller)
-	err := client.ActionFinish(tag, "", nil, "")
+	err := client.ActionFinish(context.Background(), tag, "", nil, "")
 	c.Assert(err, gc.ErrorMatches, "expected 1 result, got 2")
 	stub.CheckCalls(c, expectedCalls)
 }
@@ -335,8 +337,8 @@ func (s *ClientSuite) TestActionFinishTooManyResults(c *gc.C) {
 func (s *ClientSuite) TestGetActionSuccess(c *gc.C) {
 	tag := names.NewActionTag(uuid.MustNewUUID().String())
 	expectedCalls := []jujutesting.StubCall{{
-		"MachineActions.Actions",
-		[]interface{}{"", params.Entities{
+		FuncName: "MachineActions.Actions",
+		Args: []interface{}{"", params.Entities{
 			Entities: []params.Entity{{Tag: tag.String()}},
 		}},
 	}}
@@ -363,7 +365,7 @@ func (s *ClientSuite) TestGetActionSuccess(c *gc.C) {
 	})
 
 	client := machineactions.NewClient(apiCaller)
-	action, err := client.Action(tag)
+	action, err := client.Action(context.Background(), tag)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(action.Name(), gc.Equals, expectedName)
 	c.Assert(action.Params(), gc.DeepEquals, expectedParams)
@@ -375,8 +377,8 @@ func (s *ClientSuite) TestGetActionSuccess(c *gc.C) {
 func (s *ClientSuite) TestGetActionError(c *gc.C) {
 	tag := names.NewActionTag(uuid.MustNewUUID().String())
 	expectedCalls := []jujutesting.StubCall{{
-		"MachineActions.Actions",
-		[]interface{}{"", params.Entities{
+		FuncName: "MachineActions.Actions",
+		Args: []interface{}{"", params.Entities{
 			Entities: []params.Entity{{Tag: tag.String()}},
 		}},
 	}}
@@ -390,7 +392,7 @@ func (s *ClientSuite) TestGetActionError(c *gc.C) {
 	})
 
 	client := machineactions.NewClient(apiCaller)
-	action, err := client.Action(tag)
+	action, err := client.Action(context.Background(), tag)
 	c.Assert(errors.Cause(err), gc.Equals, expectedErr)
 	c.Assert(action, gc.IsNil)
 	stub.CheckCalls(c, expectedCalls)
@@ -399,8 +401,8 @@ func (s *ClientSuite) TestGetActionError(c *gc.C) {
 func (s *ClientSuite) TestGetActionResultError(c *gc.C) {
 	tag := names.NewActionTag(uuid.MustNewUUID().String())
 	expectedCalls := []jujutesting.StubCall{{
-		"MachineActions.Actions",
-		[]interface{}{"", params.Entities{
+		FuncName: "MachineActions.Actions",
+		Args: []interface{}{"", params.Entities{
 			Entities: []params.Entity{{Tag: tag.String()}},
 		}},
 	}}
@@ -422,7 +424,7 @@ func (s *ClientSuite) TestGetActionResultError(c *gc.C) {
 	})
 
 	client := machineactions.NewClient(apiCaller)
-	action, err := client.Action(tag)
+	action, err := client.Action(context.Background(), tag)
 	c.Assert(errors.Cause(err), gc.Equals, expectedErr)
 	c.Assert(action, gc.IsNil)
 	stub.CheckCalls(c, expectedCalls)
@@ -431,8 +433,8 @@ func (s *ClientSuite) TestGetActionResultError(c *gc.C) {
 func (s *ClientSuite) TestGetActionTooManyResults(c *gc.C) {
 	tag := names.NewActionTag(uuid.MustNewUUID().String())
 	expectedCalls := []jujutesting.StubCall{{
-		"MachineActions.Actions",
-		[]interface{}{"", params.Entities{
+		FuncName: "MachineActions.Actions",
+		Args: []interface{}{"", params.Entities{
 			Entities: []params.Entity{{Tag: tag.String()}},
 		}},
 	}}
@@ -447,7 +449,7 @@ func (s *ClientSuite) TestGetActionTooManyResults(c *gc.C) {
 	})
 
 	client := machineactions.NewClient(apiCaller)
-	action, err := client.Action(tag)
+	action, err := client.Action(context.Background(), tag)
 	c.Assert(err, gc.ErrorMatches, "expected only 1 action query result, got 2")
 	c.Assert(action, gc.IsNil)
 	stub.CheckCalls(c, expectedCalls)
@@ -456,8 +458,8 @@ func (s *ClientSuite) TestGetActionTooManyResults(c *gc.C) {
 func (s *ClientSuite) TestRunningActionSuccess(c *gc.C) {
 	tag := names.NewMachineTag(uuid.MustNewUUID().String())
 	expectedCalls := []jujutesting.StubCall{{
-		"MachineActions.RunningActions",
-		[]interface{}{"", params.Entities{
+		FuncName: "MachineActions.RunningActions",
+		Args: []interface{}{"", params.Entities{
 			Entities: []params.Entity{{Tag: tag.String()}},
 		}},
 	}}
@@ -479,7 +481,7 @@ func (s *ClientSuite) TestRunningActionSuccess(c *gc.C) {
 	})
 
 	client := machineactions.NewClient(apiCaller)
-	actions, err := client.RunningActions(tag)
+	actions, err := client.RunningActions(context.Background(), tag)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(actions, jc.DeepEquals, actionsList)
 	stub.CheckCalls(c, expectedCalls)
@@ -488,8 +490,8 @@ func (s *ClientSuite) TestRunningActionSuccess(c *gc.C) {
 func (s *ClientSuite) TestRunningActionsError(c *gc.C) {
 	tag := names.NewMachineTag(uuid.MustNewUUID().String())
 	expectedCalls := []jujutesting.StubCall{{
-		"MachineActions.RunningActions",
-		[]interface{}{"", params.Entities{
+		FuncName: "MachineActions.RunningActions",
+		Args: []interface{}{"", params.Entities{
 			Entities: []params.Entity{{Tag: tag.String()}},
 		}},
 	}}
@@ -503,7 +505,7 @@ func (s *ClientSuite) TestRunningActionsError(c *gc.C) {
 	})
 
 	client := machineactions.NewClient(apiCaller)
-	actions, err := client.RunningActions(tag)
+	actions, err := client.RunningActions(context.Background(), tag)
 	c.Assert(errors.Cause(err), gc.Equals, expectedErr)
 	c.Assert(actions, gc.IsNil)
 	stub.CheckCalls(c, expectedCalls)
@@ -512,8 +514,8 @@ func (s *ClientSuite) TestRunningActionsError(c *gc.C) {
 func (s *ClientSuite) TestRunningActionsResultError(c *gc.C) {
 	tag := names.NewMachineTag(uuid.MustNewUUID().String())
 	expectedCalls := []jujutesting.StubCall{{
-		"MachineActions.RunningActions",
-		[]interface{}{"", params.Entities{
+		FuncName: "MachineActions.RunningActions",
+		Args: []interface{}{"", params.Entities{
 			Entities: []params.Entity{{Tag: tag.String()}},
 		}},
 	}}
@@ -535,7 +537,7 @@ func (s *ClientSuite) TestRunningActionsResultError(c *gc.C) {
 	})
 
 	client := machineactions.NewClient(apiCaller)
-	action, err := client.RunningActions(tag)
+	action, err := client.RunningActions(context.Background(), tag)
 	c.Assert(errors.Cause(err), gc.Equals, expectedErr)
 	c.Assert(action, gc.IsNil)
 	stub.CheckCalls(c, expectedCalls)
@@ -544,8 +546,8 @@ func (s *ClientSuite) TestRunningActionsResultError(c *gc.C) {
 func (s *ClientSuite) TestRunningActionsTooManyResults(c *gc.C) {
 	tag := names.NewMachineTag(uuid.MustNewUUID().String())
 	expectedCalls := []jujutesting.StubCall{{
-		"MachineActions.RunningActions",
-		[]interface{}{"", params.Entities{
+		FuncName: "MachineActions.RunningActions",
+		Args: []interface{}{"", params.Entities{
 			Entities: []params.Entity{{Tag: tag.String()}},
 		}},
 	}}
@@ -560,7 +562,7 @@ func (s *ClientSuite) TestRunningActionsTooManyResults(c *gc.C) {
 	})
 
 	client := machineactions.NewClient(apiCaller)
-	actions, err := client.RunningActions(tag)
+	actions, err := client.RunningActions(context.Background(), tag)
 	c.Assert(err, gc.ErrorMatches, "expected 1 result, got 2")
 	c.Assert(actions, gc.IsNil)
 	stub.CheckCalls(c, expectedCalls)

--- a/api/agent/machiner/machine.go
+++ b/api/agent/machiner/machine.go
@@ -45,14 +45,14 @@ func (m *Machine) Refresh(ctx context.Context) error {
 }
 
 // SetStatus sets the status of the machine.
-func (m *Machine) SetStatus(status status.Status, info string, data map[string]interface{}) error {
+func (m *Machine) SetStatus(ctx context.Context, status status.Status, info string, data map[string]interface{}) error {
 	var result params.ErrorResults
 	args := params.SetStatus{
 		Entities: []params.EntityStatusArgs{
 			{Tag: m.tag.String(), Status: status.String(), Info: info, Data: data},
 		},
 	}
-	err := m.client.facade.FacadeCall(context.TODO(), "SetStatus", args, &result)
+	err := m.client.facade.FacadeCall(ctx, "SetStatus", args, &result)
 	if err != nil {
 		return err
 	}
@@ -60,14 +60,14 @@ func (m *Machine) SetStatus(status status.Status, info string, data map[string]i
 }
 
 // SetMachineAddresses sets the machine determined addresses of the machine.
-func (m *Machine) SetMachineAddresses(addresses []network.MachineAddress) error {
+func (m *Machine) SetMachineAddresses(ctx context.Context, addresses []network.MachineAddress) error {
 	var result params.ErrorResults
 	args := params.SetMachinesAddresses{
 		MachineAddresses: []params.MachineAddresses{
 			{Tag: m.Tag().String(), Addresses: params.FromMachineAddresses(addresses...)},
 		},
 	}
-	err := m.client.facade.FacadeCall(context.TODO(), "SetMachineAddresses", args, &result)
+	err := m.client.facade.FacadeCall(ctx, "SetMachineAddresses", args, &result)
 	if err != nil {
 		return err
 	}
@@ -76,12 +76,12 @@ func (m *Machine) SetMachineAddresses(addresses []network.MachineAddress) error 
 
 // EnsureDead sets the machine lifecycle to Dead if it is Alive or
 // Dying. It does nothing otherwise.
-func (m *Machine) EnsureDead() error {
+func (m *Machine) EnsureDead(ctx context.Context) error {
 	var result params.ErrorResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: m.tag.String()}},
 	}
-	err := m.client.facade.FacadeCall(context.TODO(), "EnsureDead", args, &result)
+	err := m.client.facade.FacadeCall(ctx, "EnsureDead", args, &result)
 	if err != nil {
 		return err
 	}
@@ -94,12 +94,12 @@ func (m *Machine) Watch(ctx context.Context) (watcher.NotifyWatcher, error) {
 }
 
 // Jobs returns a list of jobs for the machine.
-func (m *Machine) Jobs() (*params.JobsResult, error) {
+func (m *Machine) Jobs(ctx context.Context) (*params.JobsResult, error) {
 	var results params.JobsResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: m.Tag().String()}},
 	}
-	err := m.client.facade.FacadeCall(context.TODO(), "Jobs", args, &results)
+	err := m.client.facade.FacadeCall(ctx, "Jobs", args, &results)
 	if err != nil {
 		return nil, errors.Annotate(err, "error from FacadeCall")
 	}
@@ -115,12 +115,12 @@ func (m *Machine) Jobs() (*params.JobsResult, error) {
 
 // SetObservedNetworkConfig sets the machine network config as observed on the
 // machine.
-func (m *Machine) SetObservedNetworkConfig(netConfig []params.NetworkConfig) error {
+func (m *Machine) SetObservedNetworkConfig(ctx context.Context, netConfig []params.NetworkConfig) error {
 	args := params.SetMachineNetworkConfig{
 		Tag:    m.Tag().String(),
 		Config: netConfig,
 	}
-	err := m.client.facade.FacadeCall(context.TODO(), "SetObservedNetworkConfig", args, nil)
+	err := m.client.facade.FacadeCall(ctx, "SetObservedNetworkConfig", args, nil)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -129,7 +129,7 @@ func (m *Machine) SetObservedNetworkConfig(netConfig []params.NetworkConfig) err
 
 // RecordAgentStartInformation reports the host name of the machine and updates
 // the start time for the agent.
-func (m *Machine) RecordAgentStartInformation(hostname string) error {
+func (m *Machine) RecordAgentStartInformation(ctx context.Context, hostname string) error {
 	var result params.ErrorResults
 	args := params.RecordAgentStartInformationArgs{
 		Args: []params.RecordAgentStartInformationArg{
@@ -139,7 +139,7 @@ func (m *Machine) RecordAgentStartInformation(hostname string) error {
 			},
 		},
 	}
-	err := m.client.facade.FacadeCall(context.TODO(), "RecordAgentStartInformation", args, &result)
+	err := m.client.facade.FacadeCall(ctx, "RecordAgentStartInformation", args, &result)
 
 	if err != nil {
 		return err

--- a/api/agent/machiner/machiner_test.go
+++ b/api/agent/machiner/machiner_test.go
@@ -91,7 +91,7 @@ func (s *machinerSuite) TestSetStatus(c *gc.C) {
 	client := machiner.NewClient(apiCaller)
 	m, err := client.Machine(context.Background(), tag)
 	c.Assert(err, jc.ErrorIsNil)
-	err = m.SetStatus(status.Error, "failed", data)
+	err = m.SetStatus(context.Background(), status.Error, "failed", data)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(calls, gc.Equals, 2)
 }
@@ -125,7 +125,7 @@ func (s *machinerSuite) TestEnsureDead(c *gc.C) {
 	client := machiner.NewClient(apiCaller)
 	m, err := client.Machine(context.Background(), tag)
 	c.Assert(err, jc.ErrorIsNil)
-	err = m.EnsureDead()
+	err = m.EnsureDead(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -202,7 +202,7 @@ func (s *machinerSuite) TestSetMachineAddresses(c *gc.C) {
 	client := machiner.NewClient(apiCaller)
 	m, err := client.Machine(context.Background(), tag)
 	c.Assert(err, jc.ErrorIsNil)
-	err = m.SetMachineAddresses([]network.MachineAddress{{
+	err = m.SetMachineAddresses(context.Background(), []network.MachineAddress{{
 		Value:       "10.0.0.1",
 		Type:        network.IPv6Address,
 		Scope:       network.ScopeCloudLocal,
@@ -284,6 +284,6 @@ func (s *machinerSuite) TestRecordAgentStartInformation(c *gc.C) {
 	client := machiner.NewClient(apiCaller)
 	m, err := client.Machine(context.Background(), tag)
 	c.Assert(err, jc.ErrorIsNil)
-	err = m.RecordAgentStartInformation("hostname")
+	err = m.RecordAgentStartInformation(context.Background(), "hostname")
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/api/agent/migrationflag/facade.go
+++ b/api/agent/migrationflag/facade.go
@@ -41,9 +41,9 @@ type Facade struct {
 }
 
 // Phase returns the current migration.Phase for the supplied model UUID.
-func (facade *Facade) Phase(uuid string) (migration.Phase, error) {
+func (facade *Facade) Phase(ctx context.Context, uuid string) (migration.Phase, error) {
 	results := params.PhaseResults{}
-	err := facade.call("Phase", uuid, &results)
+	err := facade.call(ctx, "Phase", uuid, &results)
 	if err != nil {
 		return migration.UNKNOWN, errors.Trace(err)
 	}
@@ -64,9 +64,9 @@ func (facade *Facade) Phase(uuid string) (migration.Phase, error) {
 
 // Watch returns a NotifyWatcher that will inform of potential changes
 // to the result of Phase for the supplied model UUID.
-func (facade *Facade) Watch(uuid string) (watcher.NotifyWatcher, error) {
+func (facade *Facade) Watch(ctx context.Context, uuid string) (watcher.NotifyWatcher, error) {
 	results := params.NotifyWatchResults{}
-	err := facade.call("Watch", uuid, &results)
+	err := facade.call(ctx, "Watch", uuid, &results)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -84,10 +84,10 @@ func (facade *Facade) Watch(uuid string) (watcher.NotifyWatcher, error) {
 
 // call converts the supplied model uuid into a params.Entities and
 // invokes the facade caller.
-func (facade *Facade) call(name, uuid string, results interface{}) error {
+func (facade *Facade) call(ctx context.Context, name, uuid string, results interface{}) error {
 	model := names.NewModelTag(uuid).String()
-	args := params.Entities{[]params.Entity{{model}}}
-	err := facade.caller.FacadeCall(context.TODO(), name, args, results)
+	args := params.Entities{Entities: []params.Entity{{model}}}
+	err := facade.caller.FacadeCall(ctx, name, args, results)
 	return errors.Trace(err)
 }
 

--- a/api/agent/migrationflag/facade_test.go
+++ b/api/agent/migrationflag/facade_test.go
@@ -4,6 +4,7 @@
 package migrationflag_test
 
 import (
+	"context"
 	"errors"
 
 	"github.com/juju/testing"
@@ -31,7 +32,7 @@ func (*FacadeSuite) TestPhaseCallError(c *gc.C) {
 	})
 	facade := migrationflag.NewFacade(apiCaller, nil)
 
-	phase, err := facade.Phase(someUUID)
+	phase, err := facade.Phase(context.Background(), someUUID)
 	c.Check(err, gc.ErrorMatches, "bork")
 	c.Check(phase, gc.Equals, migration.UNKNOWN)
 	checkCalls(c, stub, "Phase")
@@ -44,7 +45,7 @@ func (*FacadeSuite) TestPhaseNoResults(c *gc.C) {
 	})
 	facade := migrationflag.NewFacade(apiCaller, nil)
 
-	phase, err := facade.Phase(someUUID)
+	phase, err := facade.Phase(context.Background(), someUUID)
 	c.Check(err, gc.ErrorMatches, "expected 1 result, got 0")
 	c.Check(phase, gc.Equals, migration.UNKNOWN)
 	checkCalls(c, stub, "Phase")
@@ -63,7 +64,7 @@ func (*FacadeSuite) TestPhaseExtraResults(c *gc.C) {
 	})
 	facade := migrationflag.NewFacade(apiCaller, nil)
 
-	phase, err := facade.Phase(someUUID)
+	phase, err := facade.Phase(context.Background(), someUUID)
 	c.Check(err, gc.ErrorMatches, "expected 1 result, got 2")
 	c.Check(phase, gc.Equals, migration.UNKNOWN)
 	checkCalls(c, stub, "Phase")
@@ -81,7 +82,7 @@ func (*FacadeSuite) TestPhaseError(c *gc.C) {
 	})
 	facade := migrationflag.NewFacade(apiCaller, nil)
 
-	phase, err := facade.Phase(someUUID)
+	phase, err := facade.Phase(context.Background(), someUUID)
 	c.Check(err, gc.ErrorMatches, "mneh")
 	c.Check(phase, gc.Equals, migration.UNKNOWN)
 	checkCalls(c, stub, "Phase")
@@ -97,7 +98,7 @@ func (*FacadeSuite) TestPhaseInvalid(c *gc.C) {
 	})
 	facade := migrationflag.NewFacade(apiCaller, nil)
 
-	phase, err := facade.Phase(someUUID)
+	phase, err := facade.Phase(context.Background(), someUUID)
 	c.Check(err, gc.ErrorMatches, `unknown phase "COLLABORATE"`)
 	c.Check(phase, gc.Equals, migration.UNKNOWN)
 	checkCalls(c, stub, "Phase")
@@ -113,7 +114,7 @@ func (*FacadeSuite) TestPhaseSuccess(c *gc.C) {
 	})
 	facade := migrationflag.NewFacade(apiCaller, nil)
 
-	phase, err := facade.Phase(someUUID)
+	phase, err := facade.Phase(context.Background(), someUUID)
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(phase, gc.Equals, migration.ABORT)
 	checkCalls(c, stub, "Phase")
@@ -126,7 +127,7 @@ func (*FacadeSuite) TestWatchCallError(c *gc.C) {
 	})
 	facade := migrationflag.NewFacade(apiCaller, nil)
 
-	watch, err := facade.Watch(someUUID)
+	watch, err := facade.Watch(context.Background(), someUUID)
 	c.Check(err, gc.ErrorMatches, "bork")
 	c.Check(watch, gc.IsNil)
 	checkCalls(c, stub, "Watch")
@@ -139,7 +140,7 @@ func (*FacadeSuite) TestWatchNoResults(c *gc.C) {
 	})
 	facade := migrationflag.NewFacade(apiCaller, nil)
 
-	watch, err := facade.Watch(someUUID)
+	watch, err := facade.Watch(context.Background(), someUUID)
 	c.Check(err, gc.ErrorMatches, "expected 1 result, got 0")
 	c.Check(watch, gc.IsNil)
 	checkCalls(c, stub, "Watch")
@@ -158,7 +159,7 @@ func (*FacadeSuite) TestWatchExtraResults(c *gc.C) {
 	})
 	facade := migrationflag.NewFacade(apiCaller, nil)
 
-	watch, err := facade.Watch(someUUID)
+	watch, err := facade.Watch(context.Background(), someUUID)
 	c.Check(err, gc.ErrorMatches, "expected 1 result, got 2")
 	c.Check(watch, gc.IsNil)
 	checkCalls(c, stub, "Watch")
@@ -176,7 +177,7 @@ func (*FacadeSuite) TestWatchError(c *gc.C) {
 	})
 	facade := migrationflag.NewFacade(apiCaller, nil)
 
-	watch, err := facade.Watch(someUUID)
+	watch, err := facade.Watch(context.Background(), someUUID)
 	c.Check(err, gc.ErrorMatches, "snfl")
 	c.Check(watch, gc.IsNil)
 	checkCalls(c, stub, "Watch")
@@ -202,7 +203,7 @@ func (*FacadeSuite) TestWatchSuccess(c *gc.C) {
 	}
 	facade := migrationflag.NewFacade(apiCaller, newWatcher)
 
-	watch, err := facade.Watch(someUUID)
+	watch, err := facade.Watch(context.Background(), someUUID)
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(watch, gc.Equals, expectWatch)
 	checkCalls(c, stub, "Watch")

--- a/api/agent/migrationminion/client.go
+++ b/api/agent/migrationminion/client.go
@@ -33,9 +33,9 @@ type Client struct {
 
 // Watch returns a watcher which reports when the status changes for
 // the migration for the model associated with the API connection.
-func (c *Client) Watch() (watcher.MigrationStatusWatcher, error) {
+func (c *Client) Watch(ctx context.Context) (watcher.MigrationStatusWatcher, error) {
 	var result params.NotifyWatchResult
-	err := c.caller.FacadeCall(context.TODO(), "Watch", nil, &result)
+	err := c.caller.FacadeCall(ctx, "Watch", nil, &result)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -48,12 +48,12 @@ func (c *Client) Watch() (watcher.MigrationStatusWatcher, error) {
 
 // Report allows a migration minion to report if it successfully
 // completed its activities for a given migration phase.
-func (c *Client) Report(migrationId string, phase migration.Phase, success bool) error {
+func (c *Client) Report(ctx context.Context, migrationId string, phase migration.Phase, success bool) error {
 	args := params.MinionReport{
 		MigrationId: migrationId,
 		Phase:       phase.String(),
 		Success:     success,
 	}
-	err := c.caller.FacadeCall(context.TODO(), "Report", args, nil)
+	err := c.caller.FacadeCall(ctx, "Report", args, nil)
 	return errors.Trace(err)
 }

--- a/api/agent/migrationminion/client_test.go
+++ b/api/agent/migrationminion/client_test.go
@@ -4,6 +4,7 @@
 package migrationminion_test
 
 import (
+	"context"
 	"time"
 
 	"github.com/juju/errors"
@@ -43,7 +44,7 @@ func (s *ClientSuite) TestWatch(c *gc.C) {
 	})
 
 	client := migrationminion.NewClient(apiCaller)
-	w, err := client.Watch()
+	w, err := client.Watch(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	defer worker.Stop(w)
 
@@ -56,9 +57,9 @@ func (s *ClientSuite) TestWatch(c *gc.C) {
 	case err := <-errC:
 		c.Assert(err, gc.ErrorMatches, "boom")
 		expectedCalls := []jujutesting.StubCall{
-			{"Migrationminion.Watch", []interface{}{"", nil}},
-			{"MigrationStatusWatcher.Next", []interface{}{"abc", nil}},
-			{"MigrationStatusWatcher.Stop", []interface{}{"abc", nil}},
+			{FuncName: "Migrationminion.Watch", Args: []interface{}{"", nil}},
+			{FuncName: "MigrationStatusWatcher.Next", Args: []interface{}{"abc", nil}},
+			{FuncName: "MigrationStatusWatcher.Stop", Args: []interface{}{"abc", nil}},
 		}
 		// The Stop API call happens in a separate goroutine which
 		// might execute after the worker has exited so wait for the
@@ -79,7 +80,7 @@ func (s *ClientSuite) TestWatchErr(c *gc.C) {
 		return errors.New("boom")
 	})
 	client := migrationminion.NewClient(apiCaller)
-	_, err := client.Watch()
+	_, err := client.Watch(context.Background())
 	c.Assert(err, gc.ErrorMatches, "boom")
 }
 
@@ -91,11 +92,11 @@ func (s *ClientSuite) TestReport(c *gc.C) {
 	})
 
 	client := migrationminion.NewClient(apiCaller)
-	err := client.Report("id", migration.IMPORT, true)
+	err := client.Report(context.Background(), "id", migration.IMPORT, true)
 	c.Assert(err, jc.ErrorIsNil)
 
 	stub.CheckCalls(c, []jujutesting.StubCall{
-		{"MigrationMinion.Report", []interface{}{params.MinionReport{
+		{FuncName: "MigrationMinion.Report", Args: []interface{}{params.MinionReport{
 			MigrationId: "id",
 			Phase:       "IMPORT",
 			Success:     true,
@@ -109,6 +110,6 @@ func (s *ClientSuite) TestReportError(c *gc.C) {
 	})
 
 	client := migrationminion.NewClient(apiCaller)
-	err := client.Report("id", migration.IMPORT, true)
+	err := client.Report(context.Background(), "id", migration.IMPORT, true)
 	c.Assert(err, gc.ErrorMatches, "boom")
 }

--- a/api/agent/provisioner/machine.go
+++ b/api/agent/provisioner/machine.go
@@ -26,7 +26,7 @@ type MachineProvisioner interface {
 
 	// ModelAgentVersion returns the agent version the machine's model is currently
 	// running or an error.
-	ModelAgentVersion() (*version.Number, error)
+	ModelAgentVersion(ctx context.Context) (*version.Number, error)
 
 	// MachineTag returns the identifier for the machine as the most specific type.
 	MachineTag() names.MachineTag
@@ -44,46 +44,47 @@ type MachineProvisioner interface {
 	Refresh(context.Context) error
 
 	// SetInstanceStatus sets the status for the provider instance.
-	SetInstanceStatus(status status.Status, message string, data map[string]interface{}) error
+	SetInstanceStatus(ctx context.Context, status status.Status, message string, data map[string]interface{}) error
 
 	// InstanceStatus returns the status of the provider instance.
-	InstanceStatus() (status.Status, string, error)
+	InstanceStatus(ctx context.Context) (status.Status, string, error)
 
 	// SetStatus sets the status of the machine.
-	SetStatus(status status.Status, info string, data map[string]interface{}) error
+	SetStatus(ctx context.Context, status status.Status, info string, data map[string]interface{}) error
 
 	// Status returns the status of the machine.
-	Status() (status.Status, string, error)
+	Status(ctx context.Context) (status.Status, string, error)
 
 	// SetModificationStatus sets the status of the machine changes whilst it's
 	// running. Example of this could be LXD profiles being applied.
-	SetModificationStatus(status status.Status, message string, data map[string]interface{}) error
+	SetModificationStatus(ctx context.Context, status status.Status, message string, data map[string]interface{}) error
 
 	// EnsureDead sets the machine lifecycle to Dead if it is Alive or
 	// Dying. It does nothing otherwise.
-	EnsureDead() error
+	EnsureDead(ctx context.Context) error
 
 	// Remove removes the machine from state. It will fail if the machine
 	// is not Dead.
-	Remove() error
+	Remove(ctx context.Context) error
 
 	// MarkForRemoval indicates that the machine is ready to have any
 	// provider-level resources cleaned up and be removed.
-	MarkForRemoval() error
+	MarkForRemoval(ctx context.Context) error
 
 	// AvailabilityZone returns an underlying provider's availability zone
 	// for a machine.
-	AvailabilityZone() (string, error)
+	AvailabilityZone(ctx context.Context) (string, error)
 
 	// DistributionGroup returns a slice of instance.Ids
 	// that belong to the same distribution group as this
 	// Machine. The provisioner may use this information
 	// to distribute instances for high availability.
-	DistributionGroup() ([]instance.Id, error)
+	DistributionGroup(ctx context.Context) ([]instance.Id, error)
 
 	// SetInstanceInfo sets the provider specific instance id, nonce, metadata,
 	// network config for this machine. Once set, the instance id cannot be changed.
 	SetInstanceInfo(
+		ctx context.Context,
 		id instance.Id, displayName string, nonce string, characteristics *instance.HardwareCharacteristics,
 		networkConfig []params.NetworkConfig, volumes []params.Volume,
 		volumeAttachments map[string]params.VolumeAttachmentInfo, charmProfiles []string,
@@ -91,30 +92,30 @@ type MachineProvisioner interface {
 
 	// InstanceId returns the provider specific instance id for the
 	// machine or an CodeNotProvisioned error, if not set.
-	InstanceId() (instance.Id, error)
+	InstanceId(ctx context.Context) (instance.Id, error)
 
 	// KeepInstance returns the value of the keep-instance
 	// for the machine.
-	KeepInstance() (bool, error)
+	KeepInstance(ctx context.Context) (bool, error)
 
 	// SetPassword sets the machine's password.
-	SetPassword(password string) error
+	SetPassword(ctx context.Context, password string) error
 
 	// WatchContainers returns a StringsWatcher that notifies of changes
 	// to the lifecycles of containers of the specified type on the machine.
-	WatchContainers(ctype instance.ContainerType) (watcher.StringsWatcher, error)
+	WatchContainers(ctx context.Context, ctype instance.ContainerType) (watcher.StringsWatcher, error)
 
 	// SetSupportedContainers updates the list of containers supported by this machine.
-	SetSupportedContainers(containerTypes ...instance.ContainerType) error
+	SetSupportedContainers(ctx context.Context, containerTypes ...instance.ContainerType) error
 
 	// SupportsNoContainers records the fact that this machine doesn't support any containers.
-	SupportsNoContainers() error
+	SupportsNoContainers(ctx context.Context) error
 
 	// SupportedContainers returns a list of containers supported by this machine.
-	SupportedContainers() ([]instance.ContainerType, bool, error)
+	SupportedContainers(ctx context.Context) ([]instance.ContainerType, bool, error)
 
 	// SetCharmProfiles records the given slice of charm profile names.
-	SetCharmProfiles([]string) error
+	SetCharmProfiles(context.Context, []string) error
 }
 
 // Machine represents a juju machine as seen by the provisioner worker.
@@ -130,8 +131,8 @@ func (m *Machine) Tag() names.Tag {
 }
 
 // ModelAgentVersion implements MachineProvisioner.ModelAgentVersion.
-func (m *Machine) ModelAgentVersion() (*version.Number, error) {
-	mc, err := m.st.ModelConfig(context.Background())
+func (m *Machine) ModelAgentVersion(ctx context.Context) (*version.Number, error) {
+	mc, err := m.st.ModelConfig(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -174,12 +175,12 @@ func (m *Machine) Refresh(ctx context.Context) error {
 }
 
 // SetInstanceStatus implements MachineProvisioner.SetInstanceStatus.
-func (m *Machine) SetInstanceStatus(status status.Status, message string, data map[string]interface{}) error {
+func (m *Machine) SetInstanceStatus(ctx context.Context, status status.Status, message string, data map[string]interface{}) error {
 	var result params.ErrorResults
 	args := params.SetStatus{Entities: []params.EntityStatusArgs{
 		{Tag: m.tag.String(), Status: status.String(), Info: message, Data: data},
 	}}
-	err := m.st.facade.FacadeCall(context.TODO(), "SetInstanceStatus", args, &result)
+	err := m.st.facade.FacadeCall(ctx, "SetInstanceStatus", args, &result)
 	if err != nil {
 		return err
 	}
@@ -187,12 +188,12 @@ func (m *Machine) SetInstanceStatus(status status.Status, message string, data m
 }
 
 // InstanceStatus implements MachineProvisioner.InstanceStatus.
-func (m *Machine) InstanceStatus() (status.Status, string, error) {
+func (m *Machine) InstanceStatus(ctx context.Context) (status.Status, string, error) {
 	var results params.StatusResults
 	args := params.Entities{Entities: []params.Entity{
 		{Tag: m.tag.String()},
 	}}
-	err := m.st.facade.FacadeCall(context.TODO(), "InstanceStatus", args, &results)
+	err := m.st.facade.FacadeCall(ctx, "InstanceStatus", args, &results)
 	if err != nil {
 		return "", "", err
 	}
@@ -208,14 +209,14 @@ func (m *Machine) InstanceStatus() (status.Status, string, error) {
 }
 
 // SetStatus implements MachineProvisioner.SetStatus.
-func (m *Machine) SetStatus(status status.Status, info string, data map[string]interface{}) error {
+func (m *Machine) SetStatus(ctx context.Context, status status.Status, info string, data map[string]interface{}) error {
 	var result params.ErrorResults
 	args := params.SetStatus{
 		Entities: []params.EntityStatusArgs{
 			{Tag: m.tag.String(), Status: status.String(), Info: info, Data: data},
 		},
 	}
-	err := m.st.facade.FacadeCall(context.TODO(), "SetStatus", args, &result)
+	err := m.st.facade.FacadeCall(ctx, "SetStatus", args, &result)
 	if err != nil {
 		return err
 	}
@@ -223,12 +224,12 @@ func (m *Machine) SetStatus(status status.Status, info string, data map[string]i
 }
 
 // Status implements MachineProvisioner.Status.
-func (m *Machine) Status() (status.Status, string, error) {
+func (m *Machine) Status(ctx context.Context) (status.Status, string, error) {
 	var results params.StatusResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: m.tag.String()}},
 	}
-	err := m.st.facade.FacadeCall(context.TODO(), "Status", args, &results)
+	err := m.st.facade.FacadeCall(ctx, "Status", args, &results)
 	if err != nil {
 		return "", "", err
 	}
@@ -244,14 +245,14 @@ func (m *Machine) Status() (status.Status, string, error) {
 }
 
 // SetModificationStatus implements MachineProvisioner.SetModificationStatus.
-func (m *Machine) SetModificationStatus(status status.Status, info string, data map[string]interface{}) error {
+func (m *Machine) SetModificationStatus(ctx context.Context, status status.Status, info string, data map[string]interface{}) error {
 	var result params.ErrorResults
 	args := params.SetStatus{
 		Entities: []params.EntityStatusArgs{
 			{Tag: m.tag.String(), Status: status.String(), Info: info, Data: data},
 		},
 	}
-	err := m.st.facade.FacadeCall(context.TODO(), "SetModificationStatus", args, &result)
+	err := m.st.facade.FacadeCall(ctx, "SetModificationStatus", args, &result)
 	if err != nil {
 		return err
 	}
@@ -259,12 +260,12 @@ func (m *Machine) SetModificationStatus(status status.Status, info string, data 
 }
 
 // EnsureDead implements MachineProvisioner.EnsureDead.
-func (m *Machine) EnsureDead() error {
+func (m *Machine) EnsureDead(ctx context.Context) error {
 	var result params.ErrorResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: m.tag.String()}},
 	}
-	err := m.st.facade.FacadeCall(context.TODO(), "EnsureDead", args, &result)
+	err := m.st.facade.FacadeCall(ctx, "EnsureDead", args, &result)
 	if err != nil {
 		return err
 	}
@@ -272,12 +273,12 @@ func (m *Machine) EnsureDead() error {
 }
 
 // Remove implements MachineProvisioner.Remove.
-func (m *Machine) Remove() error {
+func (m *Machine) Remove(ctx context.Context) error {
 	var result params.ErrorResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: m.tag.String()}},
 	}
-	err := m.st.facade.FacadeCall(context.TODO(), "Remove", args, &result)
+	err := m.st.facade.FacadeCall(ctx, "Remove", args, &result)
 	if err != nil {
 		return err
 	}
@@ -285,12 +286,12 @@ func (m *Machine) Remove() error {
 }
 
 // MarkForRemoval implements MachineProvisioner.MarkForRemoval.
-func (m *Machine) MarkForRemoval() error {
+func (m *Machine) MarkForRemoval(ctx context.Context) error {
 	var result params.ErrorResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: m.tag.String()}},
 	}
-	err := m.st.facade.FacadeCall(context.TODO(), "MarkMachinesForRemoval", args, &result)
+	err := m.st.facade.FacadeCall(ctx, "MarkMachinesForRemoval", args, &result)
 	if err != nil {
 		return err
 	}
@@ -298,12 +299,12 @@ func (m *Machine) MarkForRemoval() error {
 }
 
 // AvailabilityZone implements MachineProvisioner.AvailabilityZone.
-func (m *Machine) AvailabilityZone() (string, error) {
+func (m *Machine) AvailabilityZone(ctx context.Context) (string, error) {
 	var results params.StringResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: m.tag.String()}},
 	}
-	err := m.st.facade.FacadeCall(context.TODO(), "AvailabilityZone", args, &results)
+	err := m.st.facade.FacadeCall(ctx, "AvailabilityZone", args, &results)
 	if err != nil {
 		return "", err
 	}
@@ -318,12 +319,12 @@ func (m *Machine) AvailabilityZone() (string, error) {
 }
 
 // DistributionGroup implements MachineProvisioner.DistributionGroup.
-func (m *Machine) DistributionGroup() ([]instance.Id, error) {
+func (m *Machine) DistributionGroup(ctx context.Context) ([]instance.Id, error) {
 	var results params.DistributionGroupResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: m.tag.String()}},
 	}
-	err := m.st.facade.FacadeCall(context.TODO(), "DistributionGroup", args, &results)
+	err := m.st.facade.FacadeCall(ctx, "DistributionGroup", args, &results)
 	if err != nil {
 		return nil, err
 	}
@@ -339,6 +340,7 @@ func (m *Machine) DistributionGroup() ([]instance.Id, error) {
 
 // SetInstanceInfo implements MachineProvisioner.SetInstanceInfo.
 func (m *Machine) SetInstanceInfo(
+	ctx context.Context,
 	id instance.Id, displayName string, nonce string, characteristics *instance.HardwareCharacteristics,
 	networkConfig []params.NetworkConfig, volumes []params.Volume,
 	volumeAttachments map[string]params.VolumeAttachmentInfo, charmProfiles []string,
@@ -357,7 +359,7 @@ func (m *Machine) SetInstanceInfo(
 			CharmProfiles:     charmProfiles,
 		}},
 	}
-	err := m.st.facade.FacadeCall(context.TODO(), "SetInstanceInfo", args, &result)
+	err := m.st.facade.FacadeCall(ctx, "SetInstanceInfo", args, &result)
 	if err != nil {
 		return err
 	}
@@ -365,12 +367,12 @@ func (m *Machine) SetInstanceInfo(
 }
 
 // InstanceId implements MachineProvisioner.InstanceId.
-func (m *Machine) InstanceId() (instance.Id, error) {
+func (m *Machine) InstanceId(ctx context.Context) (instance.Id, error) {
 	var results params.StringResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: m.tag.String()}},
 	}
-	err := m.st.facade.FacadeCall(context.TODO(), "InstanceId", args, &results)
+	err := m.st.facade.FacadeCall(ctx, "InstanceId", args, &results)
 	if err != nil {
 		return "", err
 	}
@@ -385,12 +387,12 @@ func (m *Machine) InstanceId() (instance.Id, error) {
 }
 
 // KeepInstance implements MachineProvisioner.KeepInstance.
-func (m *Machine) KeepInstance() (bool, error) {
+func (m *Machine) KeepInstance(ctx context.Context) (bool, error) {
 	var results params.BoolResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: m.tag.String()}},
 	}
-	err := m.st.facade.FacadeCall(context.TODO(), "KeepInstance", args, &results)
+	err := m.st.facade.FacadeCall(ctx, "KeepInstance", args, &results)
 	if err != nil {
 		return false, err
 	}
@@ -408,14 +410,14 @@ func (m *Machine) KeepInstance() (bool, error) {
 }
 
 // SetPassword implements MachineProvisioner.SetPassword.
-func (m *Machine) SetPassword(password string) error {
+func (m *Machine) SetPassword(ctx context.Context, password string) error {
 	var result params.ErrorResults
 	args := params.EntityPasswords{
 		Changes: []params.EntityPassword{
 			{Tag: m.tag.String(), Password: password},
 		},
 	}
-	err := m.st.facade.FacadeCall(context.TODO(), "SetPasswords", args, &result)
+	err := m.st.facade.FacadeCall(ctx, "SetPasswords", args, &result)
 	if err != nil {
 		return err
 	}
@@ -423,7 +425,7 @@ func (m *Machine) SetPassword(password string) error {
 }
 
 // WatchContainers implements MachineProvisioner.WatchContainers.
-func (m *Machine) WatchContainers(ctype instance.ContainerType) (watcher.StringsWatcher, error) {
+func (m *Machine) WatchContainers(ctx context.Context, ctype instance.ContainerType) (watcher.StringsWatcher, error) {
 	if string(ctype) == "" {
 		return nil, fmt.Errorf("container type must be specified")
 	}
@@ -443,7 +445,7 @@ func (m *Machine) WatchContainers(ctype instance.ContainerType) (watcher.Strings
 			{MachineTag: m.tag.String(), ContainerType: string(ctype)},
 		},
 	}
-	err := m.st.facade.FacadeCall(context.TODO(), "WatchContainers", args, &results)
+	err := m.st.facade.FacadeCall(ctx, "WatchContainers", args, &results)
 	if err != nil {
 		return nil, err
 	}
@@ -459,14 +461,14 @@ func (m *Machine) WatchContainers(ctype instance.ContainerType) (watcher.Strings
 }
 
 // SetSupportedContainers implements MachineProvisioner.SetSupportedContainers.
-func (m *Machine) SetSupportedContainers(containerTypes ...instance.ContainerType) error {
+func (m *Machine) SetSupportedContainers(ctx context.Context, containerTypes ...instance.ContainerType) error {
 	var results params.ErrorResults
 	args := params.MachineContainersParams{
 		Params: []params.MachineContainers{
 			{MachineTag: m.tag.String(), ContainerTypes: containerTypes},
 		},
 	}
-	err := m.st.facade.FacadeCall(context.TODO(), "SetSupportedContainers", args, &results)
+	err := m.st.facade.FacadeCall(ctx, "SetSupportedContainers", args, &results)
 	if err != nil {
 		return err
 	}
@@ -481,19 +483,19 @@ func (m *Machine) SetSupportedContainers(containerTypes ...instance.ContainerTyp
 }
 
 // SupportsNoContainers implements MachineProvisioner.SupportsNoContainers.
-func (m *Machine) SupportsNoContainers() error {
-	return m.SetSupportedContainers([]instance.ContainerType{}...)
+func (m *Machine) SupportsNoContainers(ctx context.Context) error {
+	return m.SetSupportedContainers(ctx, []instance.ContainerType{}...)
 }
 
 // SupportedContainers implements MachineProvisioner.SupportedContainers.
-func (m *Machine) SupportedContainers() ([]instance.ContainerType, bool, error) {
+func (m *Machine) SupportedContainers(ctx context.Context) ([]instance.ContainerType, bool, error) {
 	var results params.MachineContainerResults
 	args := params.Entities{
 		Entities: []params.Entity{
 			{Tag: m.tag.String()},
 		},
 	}
-	err := m.st.facade.FacadeCall(context.TODO(), "SupportedContainers", args, &results)
+	err := m.st.facade.FacadeCall(ctx, "SupportedContainers", args, &results)
 	if err != nil {
 		return nil, false, err
 	}
@@ -509,7 +511,7 @@ func (m *Machine) SupportedContainers() ([]instance.ContainerType, bool, error) 
 }
 
 // SetCharmProfiles implements MachineProvisioner.SetCharmProfiles.
-func (m *Machine) SetCharmProfiles(profiles []string) error {
+func (m *Machine) SetCharmProfiles(ctx context.Context, profiles []string) error {
 	var results params.ErrorResults
 	args := params.SetProfileArgs{
 		Args: []params.SetProfileArg{
@@ -519,7 +521,7 @@ func (m *Machine) SetCharmProfiles(profiles []string) error {
 			},
 		},
 	}
-	err := m.st.facade.FacadeCall(context.TODO(), "SetCharmProfiles", args, &results)
+	err := m.st.facade.FacadeCall(ctx, "SetCharmProfiles", args, &results)
 	if err != nil {
 		return err
 	}

--- a/api/agent/provisioner/mocks/machine_mock.go
+++ b/api/agent/provisioner/mocks/machine_mock.go
@@ -47,18 +47,18 @@ func (m *MockMachineProvisioner) EXPECT() *MockMachineProvisionerMockRecorder {
 }
 
 // AvailabilityZone mocks base method.
-func (m *MockMachineProvisioner) AvailabilityZone() (string, error) {
+func (m *MockMachineProvisioner) AvailabilityZone(arg0 context.Context) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AvailabilityZone")
+	ret := m.ctrl.Call(m, "AvailabilityZone", arg0)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // AvailabilityZone indicates an expected call of AvailabilityZone.
-func (mr *MockMachineProvisionerMockRecorder) AvailabilityZone() *MockMachineProvisionerAvailabilityZoneCall {
+func (mr *MockMachineProvisionerMockRecorder) AvailabilityZone(arg0 any) *MockMachineProvisionerAvailabilityZoneCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AvailabilityZone", reflect.TypeOf((*MockMachineProvisioner)(nil).AvailabilityZone))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AvailabilityZone", reflect.TypeOf((*MockMachineProvisioner)(nil).AvailabilityZone), arg0)
 	return &MockMachineProvisionerAvailabilityZoneCall{Call: call}
 }
 
@@ -74,30 +74,30 @@ func (c *MockMachineProvisionerAvailabilityZoneCall) Return(arg0 string, arg1 er
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineProvisionerAvailabilityZoneCall) Do(f func() (string, error)) *MockMachineProvisionerAvailabilityZoneCall {
+func (c *MockMachineProvisionerAvailabilityZoneCall) Do(f func(context.Context) (string, error)) *MockMachineProvisionerAvailabilityZoneCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineProvisionerAvailabilityZoneCall) DoAndReturn(f func() (string, error)) *MockMachineProvisionerAvailabilityZoneCall {
+func (c *MockMachineProvisionerAvailabilityZoneCall) DoAndReturn(f func(context.Context) (string, error)) *MockMachineProvisionerAvailabilityZoneCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // DistributionGroup mocks base method.
-func (m *MockMachineProvisioner) DistributionGroup() ([]instance.Id, error) {
+func (m *MockMachineProvisioner) DistributionGroup(arg0 context.Context) ([]instance.Id, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DistributionGroup")
+	ret := m.ctrl.Call(m, "DistributionGroup", arg0)
 	ret0, _ := ret[0].([]instance.Id)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // DistributionGroup indicates an expected call of DistributionGroup.
-func (mr *MockMachineProvisionerMockRecorder) DistributionGroup() *MockMachineProvisionerDistributionGroupCall {
+func (mr *MockMachineProvisionerMockRecorder) DistributionGroup(arg0 any) *MockMachineProvisionerDistributionGroupCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DistributionGroup", reflect.TypeOf((*MockMachineProvisioner)(nil).DistributionGroup))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DistributionGroup", reflect.TypeOf((*MockMachineProvisioner)(nil).DistributionGroup), arg0)
 	return &MockMachineProvisionerDistributionGroupCall{Call: call}
 }
 
@@ -113,29 +113,29 @@ func (c *MockMachineProvisionerDistributionGroupCall) Return(arg0 []instance.Id,
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineProvisionerDistributionGroupCall) Do(f func() ([]instance.Id, error)) *MockMachineProvisionerDistributionGroupCall {
+func (c *MockMachineProvisionerDistributionGroupCall) Do(f func(context.Context) ([]instance.Id, error)) *MockMachineProvisionerDistributionGroupCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineProvisionerDistributionGroupCall) DoAndReturn(f func() ([]instance.Id, error)) *MockMachineProvisionerDistributionGroupCall {
+func (c *MockMachineProvisionerDistributionGroupCall) DoAndReturn(f func(context.Context) ([]instance.Id, error)) *MockMachineProvisionerDistributionGroupCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // EnsureDead mocks base method.
-func (m *MockMachineProvisioner) EnsureDead() error {
+func (m *MockMachineProvisioner) EnsureDead(arg0 context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnsureDead")
+	ret := m.ctrl.Call(m, "EnsureDead", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // EnsureDead indicates an expected call of EnsureDead.
-func (mr *MockMachineProvisionerMockRecorder) EnsureDead() *MockMachineProvisionerEnsureDeadCall {
+func (mr *MockMachineProvisionerMockRecorder) EnsureDead(arg0 any) *MockMachineProvisionerEnsureDeadCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureDead", reflect.TypeOf((*MockMachineProvisioner)(nil).EnsureDead))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureDead", reflect.TypeOf((*MockMachineProvisioner)(nil).EnsureDead), arg0)
 	return &MockMachineProvisionerEnsureDeadCall{Call: call}
 }
 
@@ -151,13 +151,13 @@ func (c *MockMachineProvisionerEnsureDeadCall) Return(arg0 error) *MockMachinePr
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineProvisionerEnsureDeadCall) Do(f func() error) *MockMachineProvisionerEnsureDeadCall {
+func (c *MockMachineProvisionerEnsureDeadCall) Do(f func(context.Context) error) *MockMachineProvisionerEnsureDeadCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineProvisionerEnsureDeadCall) DoAndReturn(f func() error) *MockMachineProvisionerEnsureDeadCall {
+func (c *MockMachineProvisionerEnsureDeadCall) DoAndReturn(f func(context.Context) error) *MockMachineProvisionerEnsureDeadCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -201,18 +201,18 @@ func (c *MockMachineProvisionerIdCall) DoAndReturn(f func() string) *MockMachine
 }
 
 // InstanceId mocks base method.
-func (m *MockMachineProvisioner) InstanceId() (instance.Id, error) {
+func (m *MockMachineProvisioner) InstanceId(arg0 context.Context) (instance.Id, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InstanceId")
+	ret := m.ctrl.Call(m, "InstanceId", arg0)
 	ret0, _ := ret[0].(instance.Id)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // InstanceId indicates an expected call of InstanceId.
-func (mr *MockMachineProvisionerMockRecorder) InstanceId() *MockMachineProvisionerInstanceIdCall {
+func (mr *MockMachineProvisionerMockRecorder) InstanceId(arg0 any) *MockMachineProvisionerInstanceIdCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstanceId", reflect.TypeOf((*MockMachineProvisioner)(nil).InstanceId))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstanceId", reflect.TypeOf((*MockMachineProvisioner)(nil).InstanceId), arg0)
 	return &MockMachineProvisionerInstanceIdCall{Call: call}
 }
 
@@ -228,21 +228,21 @@ func (c *MockMachineProvisionerInstanceIdCall) Return(arg0 instance.Id, arg1 err
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineProvisionerInstanceIdCall) Do(f func() (instance.Id, error)) *MockMachineProvisionerInstanceIdCall {
+func (c *MockMachineProvisionerInstanceIdCall) Do(f func(context.Context) (instance.Id, error)) *MockMachineProvisionerInstanceIdCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineProvisionerInstanceIdCall) DoAndReturn(f func() (instance.Id, error)) *MockMachineProvisionerInstanceIdCall {
+func (c *MockMachineProvisionerInstanceIdCall) DoAndReturn(f func(context.Context) (instance.Id, error)) *MockMachineProvisionerInstanceIdCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // InstanceStatus mocks base method.
-func (m *MockMachineProvisioner) InstanceStatus() (status.Status, string, error) {
+func (m *MockMachineProvisioner) InstanceStatus(arg0 context.Context) (status.Status, string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InstanceStatus")
+	ret := m.ctrl.Call(m, "InstanceStatus", arg0)
 	ret0, _ := ret[0].(status.Status)
 	ret1, _ := ret[1].(string)
 	ret2, _ := ret[2].(error)
@@ -250,9 +250,9 @@ func (m *MockMachineProvisioner) InstanceStatus() (status.Status, string, error)
 }
 
 // InstanceStatus indicates an expected call of InstanceStatus.
-func (mr *MockMachineProvisionerMockRecorder) InstanceStatus() *MockMachineProvisionerInstanceStatusCall {
+func (mr *MockMachineProvisionerMockRecorder) InstanceStatus(arg0 any) *MockMachineProvisionerInstanceStatusCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstanceStatus", reflect.TypeOf((*MockMachineProvisioner)(nil).InstanceStatus))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstanceStatus", reflect.TypeOf((*MockMachineProvisioner)(nil).InstanceStatus), arg0)
 	return &MockMachineProvisionerInstanceStatusCall{Call: call}
 }
 
@@ -268,30 +268,30 @@ func (c *MockMachineProvisionerInstanceStatusCall) Return(arg0 status.Status, ar
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineProvisionerInstanceStatusCall) Do(f func() (status.Status, string, error)) *MockMachineProvisionerInstanceStatusCall {
+func (c *MockMachineProvisionerInstanceStatusCall) Do(f func(context.Context) (status.Status, string, error)) *MockMachineProvisionerInstanceStatusCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineProvisionerInstanceStatusCall) DoAndReturn(f func() (status.Status, string, error)) *MockMachineProvisionerInstanceStatusCall {
+func (c *MockMachineProvisionerInstanceStatusCall) DoAndReturn(f func(context.Context) (status.Status, string, error)) *MockMachineProvisionerInstanceStatusCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // KeepInstance mocks base method.
-func (m *MockMachineProvisioner) KeepInstance() (bool, error) {
+func (m *MockMachineProvisioner) KeepInstance(arg0 context.Context) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "KeepInstance")
+	ret := m.ctrl.Call(m, "KeepInstance", arg0)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // KeepInstance indicates an expected call of KeepInstance.
-func (mr *MockMachineProvisionerMockRecorder) KeepInstance() *MockMachineProvisionerKeepInstanceCall {
+func (mr *MockMachineProvisionerMockRecorder) KeepInstance(arg0 any) *MockMachineProvisionerKeepInstanceCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "KeepInstance", reflect.TypeOf((*MockMachineProvisioner)(nil).KeepInstance))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "KeepInstance", reflect.TypeOf((*MockMachineProvisioner)(nil).KeepInstance), arg0)
 	return &MockMachineProvisionerKeepInstanceCall{Call: call}
 }
 
@@ -307,13 +307,13 @@ func (c *MockMachineProvisionerKeepInstanceCall) Return(arg0 bool, arg1 error) *
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineProvisionerKeepInstanceCall) Do(f func() (bool, error)) *MockMachineProvisionerKeepInstanceCall {
+func (c *MockMachineProvisionerKeepInstanceCall) Do(f func(context.Context) (bool, error)) *MockMachineProvisionerKeepInstanceCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineProvisionerKeepInstanceCall) DoAndReturn(f func() (bool, error)) *MockMachineProvisionerKeepInstanceCall {
+func (c *MockMachineProvisionerKeepInstanceCall) DoAndReturn(f func(context.Context) (bool, error)) *MockMachineProvisionerKeepInstanceCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -395,17 +395,17 @@ func (c *MockMachineProvisionerMachineTagCall) DoAndReturn(f func() names.Machin
 }
 
 // MarkForRemoval mocks base method.
-func (m *MockMachineProvisioner) MarkForRemoval() error {
+func (m *MockMachineProvisioner) MarkForRemoval(arg0 context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MarkForRemoval")
+	ret := m.ctrl.Call(m, "MarkForRemoval", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // MarkForRemoval indicates an expected call of MarkForRemoval.
-func (mr *MockMachineProvisionerMockRecorder) MarkForRemoval() *MockMachineProvisionerMarkForRemovalCall {
+func (mr *MockMachineProvisionerMockRecorder) MarkForRemoval(arg0 any) *MockMachineProvisionerMarkForRemovalCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkForRemoval", reflect.TypeOf((*MockMachineProvisioner)(nil).MarkForRemoval))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkForRemoval", reflect.TypeOf((*MockMachineProvisioner)(nil).MarkForRemoval), arg0)
 	return &MockMachineProvisionerMarkForRemovalCall{Call: call}
 }
 
@@ -421,30 +421,30 @@ func (c *MockMachineProvisionerMarkForRemovalCall) Return(arg0 error) *MockMachi
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineProvisionerMarkForRemovalCall) Do(f func() error) *MockMachineProvisionerMarkForRemovalCall {
+func (c *MockMachineProvisionerMarkForRemovalCall) Do(f func(context.Context) error) *MockMachineProvisionerMarkForRemovalCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineProvisionerMarkForRemovalCall) DoAndReturn(f func() error) *MockMachineProvisionerMarkForRemovalCall {
+func (c *MockMachineProvisionerMarkForRemovalCall) DoAndReturn(f func(context.Context) error) *MockMachineProvisionerMarkForRemovalCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // ModelAgentVersion mocks base method.
-func (m *MockMachineProvisioner) ModelAgentVersion() (*version.Number, error) {
+func (m *MockMachineProvisioner) ModelAgentVersion(arg0 context.Context) (*version.Number, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ModelAgentVersion")
+	ret := m.ctrl.Call(m, "ModelAgentVersion", arg0)
 	ret0, _ := ret[0].(*version.Number)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ModelAgentVersion indicates an expected call of ModelAgentVersion.
-func (mr *MockMachineProvisionerMockRecorder) ModelAgentVersion() *MockMachineProvisionerModelAgentVersionCall {
+func (mr *MockMachineProvisionerMockRecorder) ModelAgentVersion(arg0 any) *MockMachineProvisionerModelAgentVersionCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModelAgentVersion", reflect.TypeOf((*MockMachineProvisioner)(nil).ModelAgentVersion))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModelAgentVersion", reflect.TypeOf((*MockMachineProvisioner)(nil).ModelAgentVersion), arg0)
 	return &MockMachineProvisionerModelAgentVersionCall{Call: call}
 }
 
@@ -460,13 +460,13 @@ func (c *MockMachineProvisionerModelAgentVersionCall) Return(arg0 *version.Numbe
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineProvisionerModelAgentVersionCall) Do(f func() (*version.Number, error)) *MockMachineProvisionerModelAgentVersionCall {
+func (c *MockMachineProvisionerModelAgentVersionCall) Do(f func(context.Context) (*version.Number, error)) *MockMachineProvisionerModelAgentVersionCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineProvisionerModelAgentVersionCall) DoAndReturn(f func() (*version.Number, error)) *MockMachineProvisionerModelAgentVersionCall {
+func (c *MockMachineProvisionerModelAgentVersionCall) DoAndReturn(f func(context.Context) (*version.Number, error)) *MockMachineProvisionerModelAgentVersionCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -510,17 +510,17 @@ func (c *MockMachineProvisionerRefreshCall) DoAndReturn(f func(context.Context) 
 }
 
 // Remove mocks base method.
-func (m *MockMachineProvisioner) Remove() error {
+func (m *MockMachineProvisioner) Remove(arg0 context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Remove")
+	ret := m.ctrl.Call(m, "Remove", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Remove indicates an expected call of Remove.
-func (mr *MockMachineProvisionerMockRecorder) Remove() *MockMachineProvisionerRemoveCall {
+func (mr *MockMachineProvisionerMockRecorder) Remove(arg0 any) *MockMachineProvisionerRemoveCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Remove", reflect.TypeOf((*MockMachineProvisioner)(nil).Remove))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Remove", reflect.TypeOf((*MockMachineProvisioner)(nil).Remove), arg0)
 	return &MockMachineProvisionerRemoveCall{Call: call}
 }
 
@@ -536,29 +536,29 @@ func (c *MockMachineProvisionerRemoveCall) Return(arg0 error) *MockMachineProvis
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineProvisionerRemoveCall) Do(f func() error) *MockMachineProvisionerRemoveCall {
+func (c *MockMachineProvisionerRemoveCall) Do(f func(context.Context) error) *MockMachineProvisionerRemoveCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineProvisionerRemoveCall) DoAndReturn(f func() error) *MockMachineProvisionerRemoveCall {
+func (c *MockMachineProvisionerRemoveCall) DoAndReturn(f func(context.Context) error) *MockMachineProvisionerRemoveCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // SetCharmProfiles mocks base method.
-func (m *MockMachineProvisioner) SetCharmProfiles(arg0 []string) error {
+func (m *MockMachineProvisioner) SetCharmProfiles(arg0 context.Context, arg1 []string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetCharmProfiles", arg0)
+	ret := m.ctrl.Call(m, "SetCharmProfiles", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetCharmProfiles indicates an expected call of SetCharmProfiles.
-func (mr *MockMachineProvisionerMockRecorder) SetCharmProfiles(arg0 any) *MockMachineProvisionerSetCharmProfilesCall {
+func (mr *MockMachineProvisionerMockRecorder) SetCharmProfiles(arg0, arg1 any) *MockMachineProvisionerSetCharmProfilesCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCharmProfiles", reflect.TypeOf((*MockMachineProvisioner)(nil).SetCharmProfiles), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCharmProfiles", reflect.TypeOf((*MockMachineProvisioner)(nil).SetCharmProfiles), arg0, arg1)
 	return &MockMachineProvisionerSetCharmProfilesCall{Call: call}
 }
 
@@ -574,29 +574,29 @@ func (c *MockMachineProvisionerSetCharmProfilesCall) Return(arg0 error) *MockMac
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineProvisionerSetCharmProfilesCall) Do(f func([]string) error) *MockMachineProvisionerSetCharmProfilesCall {
+func (c *MockMachineProvisionerSetCharmProfilesCall) Do(f func(context.Context, []string) error) *MockMachineProvisionerSetCharmProfilesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineProvisionerSetCharmProfilesCall) DoAndReturn(f func([]string) error) *MockMachineProvisionerSetCharmProfilesCall {
+func (c *MockMachineProvisionerSetCharmProfilesCall) DoAndReturn(f func(context.Context, []string) error) *MockMachineProvisionerSetCharmProfilesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // SetInstanceInfo mocks base method.
-func (m *MockMachineProvisioner) SetInstanceInfo(arg0 instance.Id, arg1, arg2 string, arg3 *instance.HardwareCharacteristics, arg4 []params.NetworkConfig, arg5 []params.Volume, arg6 map[string]params.VolumeAttachmentInfo, arg7 []string) error {
+func (m *MockMachineProvisioner) SetInstanceInfo(arg0 context.Context, arg1 instance.Id, arg2, arg3 string, arg4 *instance.HardwareCharacteristics, arg5 []params.NetworkConfig, arg6 []params.Volume, arg7 map[string]params.VolumeAttachmentInfo, arg8 []string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetInstanceInfo", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+	ret := m.ctrl.Call(m, "SetInstanceInfo", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetInstanceInfo indicates an expected call of SetInstanceInfo.
-func (mr *MockMachineProvisionerMockRecorder) SetInstanceInfo(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7 any) *MockMachineProvisionerSetInstanceInfoCall {
+func (mr *MockMachineProvisionerMockRecorder) SetInstanceInfo(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8 any) *MockMachineProvisionerSetInstanceInfoCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetInstanceInfo", reflect.TypeOf((*MockMachineProvisioner)(nil).SetInstanceInfo), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetInstanceInfo", reflect.TypeOf((*MockMachineProvisioner)(nil).SetInstanceInfo), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
 	return &MockMachineProvisionerSetInstanceInfoCall{Call: call}
 }
 
@@ -612,29 +612,29 @@ func (c *MockMachineProvisionerSetInstanceInfoCall) Return(arg0 error) *MockMach
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineProvisionerSetInstanceInfoCall) Do(f func(instance.Id, string, string, *instance.HardwareCharacteristics, []params.NetworkConfig, []params.Volume, map[string]params.VolumeAttachmentInfo, []string) error) *MockMachineProvisionerSetInstanceInfoCall {
+func (c *MockMachineProvisionerSetInstanceInfoCall) Do(f func(context.Context, instance.Id, string, string, *instance.HardwareCharacteristics, []params.NetworkConfig, []params.Volume, map[string]params.VolumeAttachmentInfo, []string) error) *MockMachineProvisionerSetInstanceInfoCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineProvisionerSetInstanceInfoCall) DoAndReturn(f func(instance.Id, string, string, *instance.HardwareCharacteristics, []params.NetworkConfig, []params.Volume, map[string]params.VolumeAttachmentInfo, []string) error) *MockMachineProvisionerSetInstanceInfoCall {
+func (c *MockMachineProvisionerSetInstanceInfoCall) DoAndReturn(f func(context.Context, instance.Id, string, string, *instance.HardwareCharacteristics, []params.NetworkConfig, []params.Volume, map[string]params.VolumeAttachmentInfo, []string) error) *MockMachineProvisionerSetInstanceInfoCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // SetInstanceStatus mocks base method.
-func (m *MockMachineProvisioner) SetInstanceStatus(arg0 status.Status, arg1 string, arg2 map[string]any) error {
+func (m *MockMachineProvisioner) SetInstanceStatus(arg0 context.Context, arg1 status.Status, arg2 string, arg3 map[string]any) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetInstanceStatus", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "SetInstanceStatus", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetInstanceStatus indicates an expected call of SetInstanceStatus.
-func (mr *MockMachineProvisionerMockRecorder) SetInstanceStatus(arg0, arg1, arg2 any) *MockMachineProvisionerSetInstanceStatusCall {
+func (mr *MockMachineProvisionerMockRecorder) SetInstanceStatus(arg0, arg1, arg2, arg3 any) *MockMachineProvisionerSetInstanceStatusCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetInstanceStatus", reflect.TypeOf((*MockMachineProvisioner)(nil).SetInstanceStatus), arg0, arg1, arg2)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetInstanceStatus", reflect.TypeOf((*MockMachineProvisioner)(nil).SetInstanceStatus), arg0, arg1, arg2, arg3)
 	return &MockMachineProvisionerSetInstanceStatusCall{Call: call}
 }
 
@@ -650,29 +650,29 @@ func (c *MockMachineProvisionerSetInstanceStatusCall) Return(arg0 error) *MockMa
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineProvisionerSetInstanceStatusCall) Do(f func(status.Status, string, map[string]any) error) *MockMachineProvisionerSetInstanceStatusCall {
+func (c *MockMachineProvisionerSetInstanceStatusCall) Do(f func(context.Context, status.Status, string, map[string]any) error) *MockMachineProvisionerSetInstanceStatusCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineProvisionerSetInstanceStatusCall) DoAndReturn(f func(status.Status, string, map[string]any) error) *MockMachineProvisionerSetInstanceStatusCall {
+func (c *MockMachineProvisionerSetInstanceStatusCall) DoAndReturn(f func(context.Context, status.Status, string, map[string]any) error) *MockMachineProvisionerSetInstanceStatusCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // SetModificationStatus mocks base method.
-func (m *MockMachineProvisioner) SetModificationStatus(arg0 status.Status, arg1 string, arg2 map[string]any) error {
+func (m *MockMachineProvisioner) SetModificationStatus(arg0 context.Context, arg1 status.Status, arg2 string, arg3 map[string]any) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetModificationStatus", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "SetModificationStatus", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetModificationStatus indicates an expected call of SetModificationStatus.
-func (mr *MockMachineProvisionerMockRecorder) SetModificationStatus(arg0, arg1, arg2 any) *MockMachineProvisionerSetModificationStatusCall {
+func (mr *MockMachineProvisionerMockRecorder) SetModificationStatus(arg0, arg1, arg2, arg3 any) *MockMachineProvisionerSetModificationStatusCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetModificationStatus", reflect.TypeOf((*MockMachineProvisioner)(nil).SetModificationStatus), arg0, arg1, arg2)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetModificationStatus", reflect.TypeOf((*MockMachineProvisioner)(nil).SetModificationStatus), arg0, arg1, arg2, arg3)
 	return &MockMachineProvisionerSetModificationStatusCall{Call: call}
 }
 
@@ -688,29 +688,29 @@ func (c *MockMachineProvisionerSetModificationStatusCall) Return(arg0 error) *Mo
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineProvisionerSetModificationStatusCall) Do(f func(status.Status, string, map[string]any) error) *MockMachineProvisionerSetModificationStatusCall {
+func (c *MockMachineProvisionerSetModificationStatusCall) Do(f func(context.Context, status.Status, string, map[string]any) error) *MockMachineProvisionerSetModificationStatusCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineProvisionerSetModificationStatusCall) DoAndReturn(f func(status.Status, string, map[string]any) error) *MockMachineProvisionerSetModificationStatusCall {
+func (c *MockMachineProvisionerSetModificationStatusCall) DoAndReturn(f func(context.Context, status.Status, string, map[string]any) error) *MockMachineProvisionerSetModificationStatusCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // SetPassword mocks base method.
-func (m *MockMachineProvisioner) SetPassword(arg0 string) error {
+func (m *MockMachineProvisioner) SetPassword(arg0 context.Context, arg1 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetPassword", arg0)
+	ret := m.ctrl.Call(m, "SetPassword", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetPassword indicates an expected call of SetPassword.
-func (mr *MockMachineProvisionerMockRecorder) SetPassword(arg0 any) *MockMachineProvisionerSetPasswordCall {
+func (mr *MockMachineProvisionerMockRecorder) SetPassword(arg0, arg1 any) *MockMachineProvisionerSetPasswordCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetPassword", reflect.TypeOf((*MockMachineProvisioner)(nil).SetPassword), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetPassword", reflect.TypeOf((*MockMachineProvisioner)(nil).SetPassword), arg0, arg1)
 	return &MockMachineProvisionerSetPasswordCall{Call: call}
 }
 
@@ -726,29 +726,29 @@ func (c *MockMachineProvisionerSetPasswordCall) Return(arg0 error) *MockMachineP
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineProvisionerSetPasswordCall) Do(f func(string) error) *MockMachineProvisionerSetPasswordCall {
+func (c *MockMachineProvisionerSetPasswordCall) Do(f func(context.Context, string) error) *MockMachineProvisionerSetPasswordCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineProvisionerSetPasswordCall) DoAndReturn(f func(string) error) *MockMachineProvisionerSetPasswordCall {
+func (c *MockMachineProvisionerSetPasswordCall) DoAndReturn(f func(context.Context, string) error) *MockMachineProvisionerSetPasswordCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // SetStatus mocks base method.
-func (m *MockMachineProvisioner) SetStatus(arg0 status.Status, arg1 string, arg2 map[string]any) error {
+func (m *MockMachineProvisioner) SetStatus(arg0 context.Context, arg1 status.Status, arg2 string, arg3 map[string]any) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetStatus", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "SetStatus", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetStatus indicates an expected call of SetStatus.
-func (mr *MockMachineProvisionerMockRecorder) SetStatus(arg0, arg1, arg2 any) *MockMachineProvisionerSetStatusCall {
+func (mr *MockMachineProvisionerMockRecorder) SetStatus(arg0, arg1, arg2, arg3 any) *MockMachineProvisionerSetStatusCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetStatus", reflect.TypeOf((*MockMachineProvisioner)(nil).SetStatus), arg0, arg1, arg2)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetStatus", reflect.TypeOf((*MockMachineProvisioner)(nil).SetStatus), arg0, arg1, arg2, arg3)
 	return &MockMachineProvisionerSetStatusCall{Call: call}
 }
 
@@ -764,22 +764,22 @@ func (c *MockMachineProvisionerSetStatusCall) Return(arg0 error) *MockMachinePro
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineProvisionerSetStatusCall) Do(f func(status.Status, string, map[string]any) error) *MockMachineProvisionerSetStatusCall {
+func (c *MockMachineProvisionerSetStatusCall) Do(f func(context.Context, status.Status, string, map[string]any) error) *MockMachineProvisionerSetStatusCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineProvisionerSetStatusCall) DoAndReturn(f func(status.Status, string, map[string]any) error) *MockMachineProvisionerSetStatusCall {
+func (c *MockMachineProvisionerSetStatusCall) DoAndReturn(f func(context.Context, status.Status, string, map[string]any) error) *MockMachineProvisionerSetStatusCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // SetSupportedContainers mocks base method.
-func (m *MockMachineProvisioner) SetSupportedContainers(arg0 ...instance.ContainerType) error {
+func (m *MockMachineProvisioner) SetSupportedContainers(arg0 context.Context, arg1 ...instance.ContainerType) error {
 	m.ctrl.T.Helper()
-	varargs := []any{}
-	for _, a := range arg0 {
+	varargs := []any{arg0}
+	for _, a := range arg1 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "SetSupportedContainers", varargs...)
@@ -788,9 +788,10 @@ func (m *MockMachineProvisioner) SetSupportedContainers(arg0 ...instance.Contain
 }
 
 // SetSupportedContainers indicates an expected call of SetSupportedContainers.
-func (mr *MockMachineProvisionerMockRecorder) SetSupportedContainers(arg0 ...any) *MockMachineProvisionerSetSupportedContainersCall {
+func (mr *MockMachineProvisionerMockRecorder) SetSupportedContainers(arg0 any, arg1 ...any) *MockMachineProvisionerSetSupportedContainersCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSupportedContainers", reflect.TypeOf((*MockMachineProvisioner)(nil).SetSupportedContainers), arg0...)
+	varargs := append([]any{arg0}, arg1...)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSupportedContainers", reflect.TypeOf((*MockMachineProvisioner)(nil).SetSupportedContainers), varargs...)
 	return &MockMachineProvisionerSetSupportedContainersCall{Call: call}
 }
 
@@ -806,21 +807,21 @@ func (c *MockMachineProvisionerSetSupportedContainersCall) Return(arg0 error) *M
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineProvisionerSetSupportedContainersCall) Do(f func(...instance.ContainerType) error) *MockMachineProvisionerSetSupportedContainersCall {
+func (c *MockMachineProvisionerSetSupportedContainersCall) Do(f func(context.Context, ...instance.ContainerType) error) *MockMachineProvisionerSetSupportedContainersCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineProvisionerSetSupportedContainersCall) DoAndReturn(f func(...instance.ContainerType) error) *MockMachineProvisionerSetSupportedContainersCall {
+func (c *MockMachineProvisionerSetSupportedContainersCall) DoAndReturn(f func(context.Context, ...instance.ContainerType) error) *MockMachineProvisionerSetSupportedContainersCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // Status mocks base method.
-func (m *MockMachineProvisioner) Status() (status.Status, string, error) {
+func (m *MockMachineProvisioner) Status(arg0 context.Context) (status.Status, string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Status")
+	ret := m.ctrl.Call(m, "Status", arg0)
 	ret0, _ := ret[0].(status.Status)
 	ret1, _ := ret[1].(string)
 	ret2, _ := ret[2].(error)
@@ -828,9 +829,9 @@ func (m *MockMachineProvisioner) Status() (status.Status, string, error) {
 }
 
 // Status indicates an expected call of Status.
-func (mr *MockMachineProvisionerMockRecorder) Status() *MockMachineProvisionerStatusCall {
+func (mr *MockMachineProvisionerMockRecorder) Status(arg0 any) *MockMachineProvisionerStatusCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Status", reflect.TypeOf((*MockMachineProvisioner)(nil).Status))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Status", reflect.TypeOf((*MockMachineProvisioner)(nil).Status), arg0)
 	return &MockMachineProvisionerStatusCall{Call: call}
 }
 
@@ -846,13 +847,13 @@ func (c *MockMachineProvisionerStatusCall) Return(arg0 status.Status, arg1 strin
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineProvisionerStatusCall) Do(f func() (status.Status, string, error)) *MockMachineProvisionerStatusCall {
+func (c *MockMachineProvisionerStatusCall) Do(f func(context.Context) (status.Status, string, error)) *MockMachineProvisionerStatusCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineProvisionerStatusCall) DoAndReturn(f func() (status.Status, string, error)) *MockMachineProvisionerStatusCall {
+func (c *MockMachineProvisionerStatusCall) DoAndReturn(f func(context.Context) (status.Status, string, error)) *MockMachineProvisionerStatusCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -896,9 +897,9 @@ func (c *MockMachineProvisionerStringCall) DoAndReturn(f func() string) *MockMac
 }
 
 // SupportedContainers mocks base method.
-func (m *MockMachineProvisioner) SupportedContainers() ([]instance.ContainerType, bool, error) {
+func (m *MockMachineProvisioner) SupportedContainers(arg0 context.Context) ([]instance.ContainerType, bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SupportedContainers")
+	ret := m.ctrl.Call(m, "SupportedContainers", arg0)
 	ret0, _ := ret[0].([]instance.ContainerType)
 	ret1, _ := ret[1].(bool)
 	ret2, _ := ret[2].(error)
@@ -906,9 +907,9 @@ func (m *MockMachineProvisioner) SupportedContainers() ([]instance.ContainerType
 }
 
 // SupportedContainers indicates an expected call of SupportedContainers.
-func (mr *MockMachineProvisionerMockRecorder) SupportedContainers() *MockMachineProvisionerSupportedContainersCall {
+func (mr *MockMachineProvisionerMockRecorder) SupportedContainers(arg0 any) *MockMachineProvisionerSupportedContainersCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SupportedContainers", reflect.TypeOf((*MockMachineProvisioner)(nil).SupportedContainers))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SupportedContainers", reflect.TypeOf((*MockMachineProvisioner)(nil).SupportedContainers), arg0)
 	return &MockMachineProvisionerSupportedContainersCall{Call: call}
 }
 
@@ -924,29 +925,29 @@ func (c *MockMachineProvisionerSupportedContainersCall) Return(arg0 []instance.C
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineProvisionerSupportedContainersCall) Do(f func() ([]instance.ContainerType, bool, error)) *MockMachineProvisionerSupportedContainersCall {
+func (c *MockMachineProvisionerSupportedContainersCall) Do(f func(context.Context) ([]instance.ContainerType, bool, error)) *MockMachineProvisionerSupportedContainersCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineProvisionerSupportedContainersCall) DoAndReturn(f func() ([]instance.ContainerType, bool, error)) *MockMachineProvisionerSupportedContainersCall {
+func (c *MockMachineProvisionerSupportedContainersCall) DoAndReturn(f func(context.Context) ([]instance.ContainerType, bool, error)) *MockMachineProvisionerSupportedContainersCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // SupportsNoContainers mocks base method.
-func (m *MockMachineProvisioner) SupportsNoContainers() error {
+func (m *MockMachineProvisioner) SupportsNoContainers(arg0 context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SupportsNoContainers")
+	ret := m.ctrl.Call(m, "SupportsNoContainers", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SupportsNoContainers indicates an expected call of SupportsNoContainers.
-func (mr *MockMachineProvisionerMockRecorder) SupportsNoContainers() *MockMachineProvisionerSupportsNoContainersCall {
+func (mr *MockMachineProvisionerMockRecorder) SupportsNoContainers(arg0 any) *MockMachineProvisionerSupportsNoContainersCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SupportsNoContainers", reflect.TypeOf((*MockMachineProvisioner)(nil).SupportsNoContainers))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SupportsNoContainers", reflect.TypeOf((*MockMachineProvisioner)(nil).SupportsNoContainers), arg0)
 	return &MockMachineProvisionerSupportsNoContainersCall{Call: call}
 }
 
@@ -962,13 +963,13 @@ func (c *MockMachineProvisionerSupportsNoContainersCall) Return(arg0 error) *Moc
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineProvisionerSupportsNoContainersCall) Do(f func() error) *MockMachineProvisionerSupportsNoContainersCall {
+func (c *MockMachineProvisionerSupportsNoContainersCall) Do(f func(context.Context) error) *MockMachineProvisionerSupportsNoContainersCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineProvisionerSupportsNoContainersCall) DoAndReturn(f func() error) *MockMachineProvisionerSupportsNoContainersCall {
+func (c *MockMachineProvisionerSupportsNoContainersCall) DoAndReturn(f func(context.Context) error) *MockMachineProvisionerSupportsNoContainersCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1012,18 +1013,18 @@ func (c *MockMachineProvisionerTagCall) DoAndReturn(f func() names.Tag) *MockMac
 }
 
 // WatchContainers mocks base method.
-func (m *MockMachineProvisioner) WatchContainers(arg0 instance.ContainerType) (watcher.Watcher[[]string], error) {
+func (m *MockMachineProvisioner) WatchContainers(arg0 context.Context, arg1 instance.ContainerType) (watcher.Watcher[[]string], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchContainers", arg0)
+	ret := m.ctrl.Call(m, "WatchContainers", arg0, arg1)
 	ret0, _ := ret[0].(watcher.Watcher[[]string])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // WatchContainers indicates an expected call of WatchContainers.
-func (mr *MockMachineProvisionerMockRecorder) WatchContainers(arg0 any) *MockMachineProvisionerWatchContainersCall {
+func (mr *MockMachineProvisionerMockRecorder) WatchContainers(arg0, arg1 any) *MockMachineProvisionerWatchContainersCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchContainers", reflect.TypeOf((*MockMachineProvisioner)(nil).WatchContainers), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchContainers", reflect.TypeOf((*MockMachineProvisioner)(nil).WatchContainers), arg0, arg1)
 	return &MockMachineProvisionerWatchContainersCall{Call: call}
 }
 
@@ -1039,13 +1040,13 @@ func (c *MockMachineProvisionerWatchContainersCall) Return(arg0 watcher.Watcher[
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineProvisionerWatchContainersCall) Do(f func(instance.ContainerType) (watcher.Watcher[[]string], error)) *MockMachineProvisionerWatchContainersCall {
+func (c *MockMachineProvisionerWatchContainersCall) Do(f func(context.Context, instance.ContainerType) (watcher.Watcher[[]string], error)) *MockMachineProvisionerWatchContainersCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineProvisionerWatchContainersCall) DoAndReturn(f func(instance.ContainerType) (watcher.Watcher[[]string], error)) *MockMachineProvisionerWatchContainersCall {
+func (c *MockMachineProvisionerWatchContainersCall) DoAndReturn(f func(context.Context, instance.ContainerType) (watcher.Watcher[[]string], error)) *MockMachineProvisionerWatchContainersCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/api/agent/provisioner/provisioner_test.go
+++ b/api/agent/provisioner/provisioner_test.go
@@ -104,7 +104,7 @@ func (s *provisionerSuite) TestMachinesWithTransientErrors(c *gc.C) {
 	s.expectCall(caller, "MachinesWithTransientErrors", nil, results)
 
 	client := provisioner.NewClient(caller)
-	result, err := client.MachinesWithTransientErrors()
+	result, err := client.MachinesWithTransientErrors(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	machine := result[0].Machine
 	c.Assert(machine, gc.FitsTypeOf, &provisioner.Machine{})
@@ -137,7 +137,7 @@ func (s *provisionerSuite) TestDistributionGroupByMachineId(c *gc.C) {
 	s.expectCall(caller, "DistributionGroupByMachineId", args, results)
 
 	client := provisioner.NewClient(caller)
-	result, err := client.DistributionGroupByMachineId(names.NewMachineTag("666"))
+	result, err := client.DistributionGroupByMachineId(context.Background(), names.NewMachineTag("666"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, []provisioner.DistributionGroupResult{{
 		MachineIds: []string{"id-1", "id-2"},
@@ -161,7 +161,7 @@ func (s *provisionerSuite) TestProvisioningInfo(c *gc.C) {
 	s.expectCall(caller, "ProvisioningInfo", args, results)
 
 	client := provisioner.NewClient(caller)
-	result, err := client.ProvisioningInfo([]names.MachineTag{names.NewMachineTag("666")})
+	result, err := client.ProvisioningInfo(context.Background(), []names.MachineTag{names.NewMachineTag("666")})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, results)
 }
@@ -188,7 +188,7 @@ func (s *provisionerSuite) TestHostChangesForContainer(c *gc.C) {
 	s.expectCall(caller, "HostChangesForContainers", args, results)
 
 	client := provisioner.NewClient(caller)
-	result, delay, err := client.HostChangesForContainer(names.NewMachineTag("666"))
+	result, delay, err := client.HostChangesForContainer(context.Background(), names.NewMachineTag("666"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, []network.DeviceToBridge{{
 		DeviceName: "host",
@@ -213,7 +213,7 @@ func (s *provisionerSuite) TestContainerManagerConfig(c *gc.C) {
 	s.expectCall(caller, "ContainerManagerConfig", args, results)
 
 	client := provisioner.NewClient(caller)
-	result, err := client.ContainerManagerConfig(args)
+	result, err := client.ContainerManagerConfig(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, results)
 }
@@ -242,7 +242,7 @@ func (s *provisionerSuite) TestFindTools(c *gc.C) {
 	s.expectCall(caller, "FindTools", args, results)
 
 	client := provisioner.NewClient(caller)
-	result, err := client.FindTools(vers, "ubuntu", "arm64")
+	result, err := client.FindTools(context.Background(), vers, "ubuntu", "arm64")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, tools.List{{
 		Version: version.MustParseBinary("6.6.6-ubuntu-arm64"),
@@ -264,7 +264,7 @@ func (s *provisionerSuite) TestContainerConfig(c *gc.C) {
 	s.expectCall(caller, "ContainerConfig", nil, cfg)
 
 	client := provisioner.NewClient(caller)
-	result, err := client.ContainerConfig()
+	result, err := client.ContainerConfig(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, cfg)
 }
@@ -281,7 +281,7 @@ func (s *provisionerSuite) TestWatchModelMachines(c *gc.C) {
 	s.expectCall(caller, "WatchModelMachines", nil, results)
 
 	client := provisioner.NewClient(caller)
-	_, err := client.WatchModelMachines()
+	_, err := client.WatchModelMachines(context.Background())
 	c.Assert(err, gc.ErrorMatches, "FAIL")
 }
 
@@ -321,7 +321,7 @@ func (s *provisionerSuite) TestSetStatus(c *gc.C) {
 	}
 	s.expectCall(caller, "SetStatus", args, results)
 
-	err := machine.SetStatus(status.Error, "failed", map[string]interface{}{"foo": "bar"})
+	err := machine.SetStatus(context.Background(), status.Error, "failed", map[string]interface{}{"foo": "bar"})
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -343,7 +343,7 @@ func (s *provisionerSuite) TestStatus(c *gc.C) {
 
 	s.expectCall(caller, "Status", args, results)
 
-	st, info, err := machine.Status()
+	st, info, err := machine.Status(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(st, gc.Equals, status.Error)
 	c.Assert(info, gc.Equals, "failed")
@@ -368,7 +368,7 @@ func (s *provisionerSuite) TestSetInstanceStatus(c *gc.C) {
 	}
 	s.expectCall(caller, "SetInstanceStatus", args, results)
 
-	err := machine.SetInstanceStatus(status.Error, "failed", map[string]interface{}{"foo": "bar"})
+	err := machine.SetInstanceStatus(context.Background(), status.Error, "failed", map[string]interface{}{"foo": "bar"})
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -390,7 +390,7 @@ func (s *provisionerSuite) TestInstanceStatus(c *gc.C) {
 
 	s.expectCall(caller, "InstanceStatus", args, results)
 
-	st, info, err := machine.InstanceStatus()
+	st, info, err := machine.InstanceStatus(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(st, gc.Equals, status.Error)
 	c.Assert(info, gc.Equals, "failed")
@@ -411,7 +411,7 @@ func (s *provisionerSuite) TestEnsureDead(c *gc.C) {
 
 	s.expectCall(caller, "EnsureDead", args, results)
 
-	err := machine.EnsureDead()
+	err := machine.EnsureDead(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -430,7 +430,7 @@ func (s *provisionerSuite) TestRemove(c *gc.C) {
 
 	s.expectCall(caller, "Remove", args, results)
 
-	err := machine.Remove()
+	err := machine.Remove(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -449,7 +449,7 @@ func (s *provisionerSuite) TestMarkForRemoval(c *gc.C) {
 
 	s.expectCall(caller, "MarkMachinesForRemoval", args, results)
 
-	err := machine.MarkForRemoval()
+	err := machine.MarkForRemoval(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -488,7 +488,7 @@ func (s *provisionerSuite) TestInstanceId(c *gc.C) {
 
 	s.expectCall(caller, "InstanceId", args, results)
 
-	id, err := machine.InstanceId()
+	id, err := machine.InstanceId(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(id, gc.Equals, instance.Id("id-666"))
 }
@@ -533,6 +533,7 @@ func (s *provisionerSuite) TestSetInstanceInfo(c *gc.C) {
 	s.expectCall(caller, "SetInstanceInfo", args, results)
 
 	err := machine.SetInstanceInfo(
+		context.Background(),
 		"i-will", "my machine", "fake_nonce", &hwChars, nil, volumes, volumeAttachments, []string{"profile1"},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -555,7 +556,7 @@ func (s *provisionerSuite) TestAvailabilityZone(c *gc.C) {
 
 	s.expectCall(caller, "AvailabilityZone", args, results)
 
-	zone, err := machine.AvailabilityZone()
+	zone, err := machine.AvailabilityZone(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(zone, gc.Equals, "az-666")
 }
@@ -578,7 +579,7 @@ func (s *provisionerSuite) TestSetCharmProfiles(c *gc.C) {
 
 	s.expectCall(caller, "SetCharmProfiles", args, results)
 
-	err := machine.SetCharmProfiles([]string{"profile"})
+	err := machine.SetCharmProfiles(context.Background(), []string{"profile"})
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -597,7 +598,7 @@ func (s *provisionerSuite) TestKeepInstance(c *gc.C) {
 
 	s.expectCall(caller, "KeepInstance", args, results)
 
-	result, err := machine.KeepInstance()
+	result, err := machine.KeepInstance(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.IsTrue)
 }
@@ -617,7 +618,7 @@ func (s *provisionerSuite) TestDistributionGroup(c *gc.C) {
 
 	s.expectCall(caller, "DistributionGroup", args, results)
 
-	result, err := machine.DistributionGroup()
+	result, err := machine.DistributionGroup(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.SameContents, []instance.Id{"id-1", "id-2"})
 }
@@ -642,7 +643,7 @@ func (s *provisionerSuite) TestWatchContainers(c *gc.C) {
 
 	s.expectCall(caller, "WatchContainers", args, results)
 
-	_, err := machine.WatchContainers(instance.LXD)
+	_, err := machine.WatchContainers(context.Background(), instance.LXD)
 	c.Assert(err, gc.ErrorMatches, "FAIL")
 }
 
@@ -652,7 +653,7 @@ func (s *provisionerSuite) TestWatchContainersUnSupportedContainers(c *gc.C) {
 
 	_, machine := s.setupMachines(c, ctrl)
 
-	_, err := machine.WatchContainers("foo")
+	_, err := machine.WatchContainers(context.Background(), "foo")
 	c.Assert(err, gc.ErrorMatches, `unsupported container type "foo"`)
 }
 
@@ -673,7 +674,7 @@ func (s *provisionerSuite) TestSetSupportedContainers(c *gc.C) {
 	}
 	s.expectCall(caller, "SetSupportedContainers", args, results)
 
-	err := machine.SetSupportedContainers([]instance.ContainerType{"lxd"}...)
+	err := machine.SetSupportedContainers(context.Background(), []instance.ContainerType{"lxd"}...)
 	c.Assert(err, jc.ErrorIsNil)
 
 }
@@ -693,7 +694,7 @@ func (s *provisionerSuite) TestSupportedContainers(c *gc.C) {
 
 	s.expectCall(caller, "SupportedContainers", args, results)
 
-	result, determined, err := machine.SupportedContainers()
+	result, determined, err := machine.SupportedContainers(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.SameContents, []instance.ContainerType{"lxd"})
 	c.Assert(determined, jc.IsTrue)
@@ -735,7 +736,7 @@ func (s *provisionerContainerSuite) TestPrepareContainerInterfaceInfoNoValues(c 
 	s.expectCall(caller, "PrepareContainerInterfaceInfo", args, results)
 	provisionerApi := provisioner.NewClient(caller)
 
-	networkInfo, err := provisionerApi.PrepareContainerInterfaceInfo(s.containerTag)
+	networkInfo, err := provisionerApi.PrepareContainerInterfaceInfo(context.Background(), s.containerTag)
 	c.Assert(err, gc.IsNil)
 	c.Check(networkInfo, jc.DeepEquals, corenetwork.InterfaceInfos{})
 }
@@ -784,7 +785,7 @@ func (s *provisionerContainerSuite) TestPrepareContainerInterfaceInfoSingleNIC(c
 	s.expectCall(caller, "PrepareContainerInterfaceInfo", args, results)
 	provisionerApi := provisioner.NewClient(caller)
 
-	networkInfo, err := provisionerApi.PrepareContainerInterfaceInfo(s.containerTag)
+	networkInfo, err := provisionerApi.PrepareContainerInterfaceInfo(context.Background(), s.containerTag)
 	c.Assert(err, gc.IsNil)
 	c.Check(networkInfo, jc.DeepEquals, corenetwork.InterfaceInfos{{
 		DeviceIndex:         1,
@@ -855,7 +856,7 @@ func (s *provisionerContainerSuite) TestGetContainerProfileInfo(c *gc.C) {
 	s.expectCall(caller, "GetContainerProfileInfo", args, results)
 	provisionerApi := provisioner.NewClient(caller)
 
-	obtainedResults, err := provisionerApi.GetContainerProfileInfo(s.containerTag)
+	obtainedResults, err := provisionerApi.GetContainerProfileInfo(context.Background(), s.containerTag)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(obtainedResults, gc.DeepEquals, []*provisioner.LXDProfileResult{
 		{

--- a/api/agent/proxyupdater/proxyupdater.go
+++ b/api/agent/proxyupdater/proxyupdater.go
@@ -50,12 +50,12 @@ func NewAPI(caller base.APICaller, tag names.Tag, options ...Option) (*API, erro
 
 // WatchForProxyConfigAndAPIHostPortChanges returns a NotifyWatcher waiting for
 // changes in the proxy configuration or API host ports
-func (api *API) WatchForProxyConfigAndAPIHostPortChanges() (watcher.NotifyWatcher, error) {
+func (api *API) WatchForProxyConfigAndAPIHostPortChanges(ctx context.Context) (watcher.NotifyWatcher, error) {
 	var results params.NotifyWatchResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: api.tag.String()}},
 	}
-	err := api.facade.FacadeCall(context.TODO(), "WatchForProxyConfigAndAPIHostPortChanges", args, &results)
+	err := api.facade.FacadeCall(ctx, "WatchForProxyConfigAndAPIHostPortChanges", args, &results)
 	if err != nil {
 		return nil, err
 	}
@@ -96,14 +96,14 @@ type ProxyConfiguration struct {
 }
 
 // ProxyConfig returns the proxy settings for the current model.
-func (api *API) ProxyConfig() (ProxyConfiguration, error) {
+func (api *API) ProxyConfig(ctx context.Context) (ProxyConfiguration, error) {
 	var empty ProxyConfiguration
 
 	var results params.ProxyConfigResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: api.tag.String()}},
 	}
-	err := api.facade.FacadeCall(context.TODO(), "ProxyConfig", args, &results)
+	err := api.facade.FacadeCall(ctx, "ProxyConfig", args, &results)
 	if err != nil {
 		return empty, err
 	}

--- a/api/agent/proxyupdater/proxyupdater_test.go
+++ b/api/agent/proxyupdater/proxyupdater_test.go
@@ -4,6 +4,8 @@
 package proxyupdater_test
 
 import (
+	"context"
+
 	"github.com/juju/names/v5"
 	"github.com/juju/proxy"
 	jc "github.com/juju/testing/checkers"
@@ -71,7 +73,7 @@ func (s *ProxyUpdaterSuite) TestWatchForProxyConfigAndAPIHostPortChanges(c *gc.C
 		Results: res,
 	})
 
-	watcher, err := api.WatchForProxyConfigAndAPIHostPortChanges()
+	watcher, err := api.WatchForProxyConfigAndAPIHostPortChanges(context.Background())
 	c.Check(*called, jc.GreaterThan, 0)
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(watcher, gc.Equals, fake)
@@ -111,7 +113,7 @@ func (s *ProxyUpdaterSuite) TestProxyConfig(c *gc.C) {
 		},
 	})
 
-	config, err := api.ProxyConfig()
+	config, err := api.ProxyConfig(context.Background())
 	c.Assert(*called, gc.Equals, 1)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(config.LegacyProxy, jc.DeepEquals, proxy.Settings{

--- a/api/agent/reboot/reboot.go
+++ b/api/agent/reboot/reboot.go
@@ -28,16 +28,16 @@ var WithTracer = base.WithTracer
 type Client interface {
 	// WatchForRebootEvent returns a watcher.NotifyWatcher that
 	// reacts to reboot flag changes.
-	WatchForRebootEvent() (watcher.NotifyWatcher, error)
+	WatchForRebootEvent(context.Context) (watcher.NotifyWatcher, error)
 
 	// RequestReboot sets the reboot flag for the calling machine.
-	RequestReboot() error
+	RequestReboot(context.Context) error
 
 	// ClearReboot clears the reboot flag for the calling machine.
-	ClearReboot() error
+	ClearReboot(context.Context) error
 
 	// GetRebootAction returns the reboot action for the calling machine.
-	GetRebootAction() (params.RebootAction, error)
+	GetRebootAction(context.Context) (params.RebootAction, error)
 }
 
 var _ Client = (*client)(nil)
@@ -68,10 +68,10 @@ func NewFromConnection(c api.Connection) (Client, error) {
 }
 
 // WatchForRebootEvent implements Client.WatchForRebootEvent
-func (c *client) WatchForRebootEvent() (watcher.NotifyWatcher, error) {
+func (c *client) WatchForRebootEvent(ctx context.Context) (watcher.NotifyWatcher, error) {
 	var result params.NotifyWatchResult
 
-	if err := c.facade.FacadeCall(context.TODO(), "WatchForRebootEvent", nil, &result); err != nil {
+	if err := c.facade.FacadeCall(ctx, "WatchForRebootEvent", nil, &result); err != nil {
 		return nil, err
 	}
 	if result.Error != nil {
@@ -83,13 +83,13 @@ func (c *client) WatchForRebootEvent() (watcher.NotifyWatcher, error) {
 }
 
 // RequestReboot implements Client.RequestReboot
-func (c *client) RequestReboot() error {
+func (c *client) RequestReboot(ctx context.Context) error {
 	var results params.ErrorResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: c.machineTag.String()}},
 	}
 
-	err := c.facade.FacadeCall(context.TODO(), "RequestReboot", args, &results)
+	err := c.facade.FacadeCall(ctx, "RequestReboot", args, &results)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -104,13 +104,13 @@ func (c *client) RequestReboot() error {
 }
 
 // ClearReboot implements Client.ClearReboot
-func (c *client) ClearReboot() error {
+func (c *client) ClearReboot(ctx context.Context) error {
 	var results params.ErrorResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: c.machineTag.String()}},
 	}
 
-	err := c.facade.FacadeCall(context.TODO(), "ClearReboot", args, &results)
+	err := c.facade.FacadeCall(ctx, "ClearReboot", args, &results)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -127,13 +127,13 @@ func (c *client) ClearReboot() error {
 }
 
 // GetRebootAction implements Client.GetRebootAction
-func (c *client) GetRebootAction() (params.RebootAction, error) {
+func (c *client) GetRebootAction(ctx context.Context) (params.RebootAction, error) {
 	var results params.RebootActionResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: c.machineTag.String()}},
 	}
 
-	err := c.facade.FacadeCall(context.TODO(), "GetRebootAction", args, &results)
+	err := c.facade.FacadeCall(ctx, "GetRebootAction", args, &results)
 	if err != nil {
 		return params.ShouldDoNothing, err
 	}

--- a/api/agent/reboot/reboot_test.go
+++ b/api/agent/reboot/reboot_test.go
@@ -7,6 +7,7 @@
 package reboot_test
 
 import (
+	"context"
 	stdtesting "testing"
 
 	"github.com/juju/names/v5"
@@ -45,7 +46,7 @@ func (s *machineRebootSuite) TestWatchForRebootEvent(c *gc.C) {
 	})
 	tag := names.NewMachineTag("666")
 	client := reboot.NewClient(apiCaller, tag)
-	_, err := client.WatchForRebootEvent()
+	_, err := client.WatchForRebootEvent(context.Background())
 	c.Assert(err, gc.ErrorMatches, "FAIL")
 }
 
@@ -66,7 +67,7 @@ func (s *machineRebootSuite) TestRequestReboot(c *gc.C) {
 	})
 	tag := names.NewMachineTag("666")
 	client := reboot.NewClient(apiCaller, tag)
-	err := client.RequestReboot()
+	err := client.RequestReboot(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -87,7 +88,7 @@ func (s *machineRebootSuite) TestRequestRebootError(c *gc.C) {
 	})
 	tag := names.NewMachineTag("666")
 	client := reboot.NewClient(apiCaller, tag)
-	err := client.RequestReboot()
+	err := client.RequestReboot(context.Background())
 	c.Assert(err, gc.ErrorMatches, "FAIL")
 }
 
@@ -110,7 +111,7 @@ func (s *machineRebootSuite) TestGetRebootAction(c *gc.C) {
 	})
 	tag := names.NewMachineTag("666")
 	client := reboot.NewClient(apiCaller, tag)
-	rAction, err := client.GetRebootAction()
+	rAction, err := client.GetRebootAction(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(rAction, gc.Equals, params.ShouldDoNothing)
 }
@@ -136,7 +137,7 @@ func (s *machineRebootSuite) TestGetRebootActionMultipleResults(c *gc.C) {
 	})
 	tag := names.NewMachineTag("666")
 	client := reboot.NewClient(apiCaller, tag)
-	_, err := client.GetRebootAction()
+	_, err := client.GetRebootAction(context.Background())
 	c.Assert(err, gc.ErrorMatches, "expected 1 result, got 2")
 }
 
@@ -157,7 +158,7 @@ func (s *machineRebootSuite) TestClearReboot(c *gc.C) {
 	})
 	tag := names.NewMachineTag("666")
 	client := reboot.NewClient(apiCaller, tag)
-	err := client.ClearReboot()
+	err := client.ClearReboot(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -178,6 +179,6 @@ func (s *machineRebootSuite) TestClearRebootError(c *gc.C) {
 	})
 	tag := names.NewMachineTag("666")
 	client := reboot.NewClient(apiCaller, tag)
-	err := client.ClearReboot()
+	err := client.ClearReboot(context.Background())
 	c.Assert(err, gc.ErrorMatches, "FAIL")
 }

--- a/api/agent/retrystrategy/retrystrategy.go
+++ b/api/agent/retrystrategy/retrystrategy.go
@@ -35,12 +35,12 @@ func NewClient(apiCaller base.APICaller, options ...Option) *Client {
 }
 
 // RetryStrategy returns the configuration for the agent specified by the agentTag.
-func (c *Client) RetryStrategy(agentTag names.Tag) (params.RetryStrategy, error) {
+func (c *Client) RetryStrategy(ctx context.Context, agentTag names.Tag) (params.RetryStrategy, error) {
 	var results params.RetryStrategyResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: agentTag.String()}},
 	}
-	err := c.facade.FacadeCall(context.TODO(), "RetryStrategy", args, &results)
+	err := c.facade.FacadeCall(ctx, "RetryStrategy", args, &results)
 	if err != nil {
 		return params.RetryStrategy{}, errors.Trace(err)
 	}
@@ -57,12 +57,12 @@ func (c *Client) RetryStrategy(agentTag names.Tag) (params.RetryStrategy, error)
 // WatchRetryStrategy returns a notify watcher that looks for changes in the
 // retry strategy config for the agent specified by agentTag
 // Right now only the boolean that decides whether we retry can be modified.
-func (c *Client) WatchRetryStrategy(agentTag names.Tag) (watcher.NotifyWatcher, error) {
+func (c *Client) WatchRetryStrategy(ctx context.Context, agentTag names.Tag) (watcher.NotifyWatcher, error) {
 	var results params.NotifyWatchResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: agentTag.String()}},
 	}
-	err := c.facade.FacadeCall(context.TODO(), "WatchRetryStrategy", args, &results)
+	err := c.facade.FacadeCall(ctx, "WatchRetryStrategy", args, &results)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/api/agent/retrystrategy/retrystrategy_test.go
+++ b/api/agent/retrystrategy/retrystrategy_test.go
@@ -5,6 +5,7 @@
 package retrystrategy_test
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/juju/names/v5"
@@ -50,7 +51,7 @@ func (s *retryStrategySuite) TestRetryStrategyOk(c *gc.C) {
 	client := retrystrategy.NewClient(apiCaller)
 	c.Assert(client, gc.NotNil)
 
-	retryStrategy, err := client.RetryStrategy(tag)
+	retryStrategy, err := client.RetryStrategy(context.Background(), tag)
 	c.Assert(called, jc.IsTrue)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(retryStrategy, jc.DeepEquals, expectedRetryStrategy)
@@ -83,7 +84,7 @@ func (s *retryStrategySuite) TestRetryStrategyResultError(c *gc.C) {
 	client := retrystrategy.NewClient(apiCaller)
 	c.Assert(client, gc.NotNil)
 
-	retryStrategy, err := client.RetryStrategy(tag)
+	retryStrategy, err := client.RetryStrategy(context.Background(), tag)
 	c.Assert(called, jc.IsTrue)
 	c.Assert(err, gc.ErrorMatches, "splat")
 	c.Assert(retryStrategy, jc.DeepEquals, params.RetryStrategy{})
@@ -111,7 +112,7 @@ func (s *retryStrategySuite) TestRetryStrategyMoreResults(c *gc.C) {
 	client := retrystrategy.NewClient(apiCaller)
 	c.Assert(client, gc.NotNil)
 
-	retryStrategy, err := client.RetryStrategy(tag)
+	retryStrategy, err := client.RetryStrategy(context.Background(), tag)
 	c.Assert(called, jc.IsTrue)
 	c.Assert(err, gc.ErrorMatches, "expected 1 result, got 2")
 	c.Assert(retryStrategy, jc.DeepEquals, params.RetryStrategy{})
@@ -137,7 +138,7 @@ func (s *retryStrategySuite) TestRetryStrategyError(c *gc.C) {
 	client := retrystrategy.NewClient(apiCaller)
 	c.Assert(client, gc.NotNil)
 
-	retryStrategy, err := client.RetryStrategy(tag)
+	retryStrategy, err := client.RetryStrategy(context.Background(), tag)
 	c.Assert(called, jc.IsTrue)
 	c.Assert(err, gc.ErrorMatches, "impossibru")
 	c.Assert(retryStrategy, jc.DeepEquals, params.RetryStrategy{})
@@ -165,7 +166,7 @@ func (s *retryStrategySuite) TestWatchRetryStrategyError(c *gc.C) {
 	client := retrystrategy.NewClient(apiCaller)
 	c.Assert(client, gc.NotNil)
 
-	w, err := client.WatchRetryStrategy(tag)
+	w, err := client.WatchRetryStrategy(context.Background(), tag)
 	c.Assert(called, jc.IsTrue)
 	c.Assert(err, gc.ErrorMatches, "sosorry")
 	c.Assert(w, gc.IsNil)
@@ -198,7 +199,7 @@ func (s *retryStrategySuite) TestWatchRetryStrategyResultError(c *gc.C) {
 	client := retrystrategy.NewClient(apiCaller)
 	c.Assert(client, gc.NotNil)
 
-	w, err := client.WatchRetryStrategy(tag)
+	w, err := client.WatchRetryStrategy(context.Background(), tag)
 	c.Assert(called, jc.IsTrue)
 	c.Assert(err, gc.ErrorMatches, "rigged")
 	c.Assert(w, gc.IsNil)
@@ -226,7 +227,7 @@ func (s *retryStrategySuite) TestWatchRetryStrategyMoreResults(c *gc.C) {
 	client := retrystrategy.NewClient(apiCaller)
 	c.Assert(client, gc.NotNil)
 
-	w, err := client.WatchRetryStrategy(tag)
+	w, err := client.WatchRetryStrategy(context.Background(), tag)
 	c.Assert(called, jc.IsTrue)
 	c.Assert(err, gc.ErrorMatches, "expected 1 result, got 2")
 	c.Assert(w, gc.IsNil)

--- a/api/agent/secretsmanager/client_test.go
+++ b/api/agent/secretsmanager/client_test.go
@@ -4,6 +4,7 @@
 package secretsmanager_test
 
 import (
+	"context"
 	"time"
 
 	"github.com/juju/names/v5"
@@ -64,7 +65,7 @@ func (s *SecretsSuite) TestGetSecretBackendConfig(c *gc.C) {
 		return nil
 	})
 	client := secretsmanager.NewClient(apiCaller)
-	result, err := client.GetSecretBackendConfig(ptr("active-id"))
+	result, err := client.GetSecretBackendConfig(context.Background(), ptr("active-id"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, &provider.ModelBackendConfigInfo{
 		ActiveID: "active-id",
@@ -107,7 +108,7 @@ func (s *SecretsSuite) TestGetBackendConfigForDraining(c *gc.C) {
 		return nil
 	})
 	client := secretsmanager.NewClient(apiCaller)
-	result, activeID, err := client.GetBackendConfigForDrain(ptr("active-id"))
+	result, activeID, err := client.GetBackendConfigForDrain(context.Background(), ptr("active-id"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, &provider.ModelBackendConfig{
 		ControllerUUID: coretesting.ControllerTag.Id(),
@@ -143,7 +144,7 @@ func (s *SecretsSuite) TestCreateSecretURIs(c *gc.C) {
 		return nil
 	})
 	client := secretsmanager.NewClient(apiCaller)
-	result, err := client.CreateSecretURIs(2)
+	result, err := client.CreateSecretURIs(context.Background(), 2)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, []*coresecrets.URI{uri, uri2})
 }
@@ -172,7 +173,7 @@ func (s *SecretsSuite) TestGetContentInfo(c *gc.C) {
 		return nil
 	})
 	client := secretsmanager.NewClient(apiCaller)
-	content, backendConfig, draining, err := client.GetContentInfo(uri, "label", true, true)
+	content, backendConfig, draining, err := client.GetContentInfo(context.Background(), uri, "label", true, true)
 	c.Assert(err, jc.ErrorIsNil)
 	value := coresecrets.NewSecretValue(map[string]string{"foo": "bar"})
 	c.Assert(content, jc.DeepEquals, &secrets.ContentParams{SecretValue: value})
@@ -217,7 +218,7 @@ func (s *SecretsSuite) TestGetContentInfoExternal(c *gc.C) {
 		return nil
 	})
 	client := secretsmanager.NewClient(apiCaller)
-	content, backendConfig, draining, err := client.GetContentInfo(uri, "label", true, true)
+	content, backendConfig, draining, err := client.GetContentInfo(context.Background(), uri, "label", true, true)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(content, jc.DeepEquals, &secrets.ContentParams{ValueRef: &coresecrets.ValueRef{
 		BackendID:  "backend-id",
@@ -257,7 +258,7 @@ func (s *SecretsSuite) TestGetContentInfoLabelArgOnly(c *gc.C) {
 		return nil
 	})
 	client := secretsmanager.NewClient(apiCaller)
-	content, backendConfig, draining, err := client.GetContentInfo(nil, "label", true, true)
+	content, backendConfig, draining, err := client.GetContentInfo(context.Background(), nil, "label", true, true)
 	c.Assert(err, jc.ErrorIsNil)
 	value := coresecrets.NewSecretValue(map[string]string{"foo": "bar"})
 	c.Assert(content, jc.DeepEquals, &secrets.ContentParams{SecretValue: value})
@@ -276,7 +277,7 @@ func (s *SecretsSuite) TestGetContentInfoError(c *gc.C) {
 	})
 	uri := coresecrets.NewURI()
 	client := secretsmanager.NewClient(apiCaller)
-	content, backendConfig, _, err := client.GetContentInfo(uri, "", true, true)
+	content, backendConfig, _, err := client.GetContentInfo(context.Background(), uri, "", true, true)
 	c.Assert(err, gc.ErrorMatches, "boom")
 	c.Assert(content, gc.IsNil)
 	c.Assert(backendConfig, gc.IsNil)
@@ -303,7 +304,7 @@ func (s *SecretsSuite) TestGetRevisionContentInfo(c *gc.C) {
 		return nil
 	})
 	client := secretsmanager.NewClient(apiCaller)
-	content, backendConfig, draining, err := client.GetRevisionContentInfo(uri, 666, true)
+	content, backendConfig, draining, err := client.GetRevisionContentInfo(context.Background(), uri, 666, true)
 	c.Assert(err, jc.ErrorIsNil)
 	value := coresecrets.NewSecretValue(map[string]string{"foo": "bar"})
 	c.Assert(content, jc.DeepEquals, &secrets.ContentParams{SecretValue: value})
@@ -345,7 +346,7 @@ func (s *SecretsSuite) TestGetRevisionContentInfoExternal(c *gc.C) {
 		return nil
 	})
 	client := secretsmanager.NewClient(apiCaller)
-	content, backendConfig, draining, err := client.GetRevisionContentInfo(uri, 666, true)
+	content, backendConfig, draining, err := client.GetRevisionContentInfo(context.Background(), uri, 666, true)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(content, jc.DeepEquals, &secrets.ContentParams{ValueRef: &coresecrets.ValueRef{
 		BackendID:  "backend-id",
@@ -374,7 +375,7 @@ func (s *SecretsSuite) TestGetRevisionContentInfoError(c *gc.C) {
 	})
 	uri := coresecrets.NewURI()
 	client := secretsmanager.NewClient(apiCaller)
-	config, backendConfig, _, err := client.GetRevisionContentInfo(uri, 666, true)
+	config, backendConfig, _, err := client.GetRevisionContentInfo(context.Background(), uri, 666, true)
 	c.Assert(err, gc.ErrorMatches, "boom")
 	c.Assert(config, gc.IsNil)
 	c.Assert(backendConfig, gc.IsNil)
@@ -420,7 +421,7 @@ func (s *SecretsSuite) TestSecretMetadata(c *gc.C) {
 		return nil
 	})
 	client := secretsmanager.NewClient(apiCaller)
-	result, err := client.SecretMetadata()
+	result, err := client.SecretMetadata(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.HasLen, 1)
 	for _, info := range result {
@@ -460,7 +461,7 @@ func (s *SecretsSuite) TestWatchConsumedSecretsChanges(c *gc.C) {
 		return nil
 	})
 	client := secretsmanager.NewClient(apiCaller)
-	_, err := client.WatchConsumedSecretsChanges("foo/0")
+	_, err := client.WatchConsumedSecretsChanges(context.Background(), "foo/0")
 	c.Assert(err, gc.ErrorMatches, "FAIL")
 }
 
@@ -490,8 +491,10 @@ func (s *SecretsSuite) GetConsumerSecretsRevisionInfo(c *gc.C) {
 	})
 	var info map[string]coresecrets.SecretRevisionInfo
 	client := secretsmanager.NewClient(apiCaller)
-	info, err := client.GetConsumerSecretsRevisionInfo("foo-0", []string{
-		"secret:9m4e2mr0ui3e8a215n4g", "secret:8n3e2mr0ui3e8a215n5h", "secret:7c5e2mr0ui3e8a2154r2"})
+	info, err := client.GetConsumerSecretsRevisionInfo(
+		context.Background(),
+		"foo-0", []string{
+			"secret:9m4e2mr0ui3e8a215n4g", "secret:8n3e2mr0ui3e8a215n5h", "secret:7c5e2mr0ui3e8a2154r2"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info, jc.DeepEquals, map[string]coresecrets.SecretRevisionInfo{})
 }
@@ -512,7 +515,7 @@ func (s *SecretsSuite) TestWatchObsolete(c *gc.C) {
 		return nil
 	})
 	client := secretsmanager.NewClient(apiCaller)
-	_, err := client.WatchObsolete(names.NewUnitTag("foo/0"))
+	_, err := client.WatchObsolete(context.Background(), names.NewUnitTag("foo/0"))
 	c.Assert(err, gc.ErrorMatches, "FAIL")
 }
 
@@ -532,7 +535,7 @@ func (s *SecretsSuite) TestWatchSecretsRotationChanges(c *gc.C) {
 		return nil
 	})
 	client := secretsmanager.NewClient(apiCaller)
-	_, err := client.WatchSecretsRotationChanges(names.NewApplicationTag("app"))
+	_, err := client.WatchSecretsRotationChanges(context.Background(), names.NewApplicationTag("app"))
 	c.Assert(err, gc.ErrorMatches, "FAIL")
 }
 
@@ -557,7 +560,7 @@ func (s *SecretsSuite) TestSecretRotated(c *gc.C) {
 		return nil
 	})
 	client := secretsmanager.NewClient(apiCaller)
-	err := client.SecretRotated("secret:9m4e2mr0ui3e8a215n4g", 666)
+	err := client.SecretRotated(context.Background(), "secret:9m4e2mr0ui3e8a215n4g", 666)
 	c.Assert(err, gc.ErrorMatches, "boom")
 }
 
@@ -577,7 +580,7 @@ func (s *SecretsSuite) TestWatchSecretRevisionsExpiryChanges(c *gc.C) {
 		return nil
 	})
 	client := secretsmanager.NewClient(apiCaller)
-	_, err := client.WatchSecretRevisionsExpiryChanges(names.NewApplicationTag("app"))
+	_, err := client.WatchSecretRevisionsExpiryChanges(context.Background(), names.NewApplicationTag("app"))
 	c.Assert(err, gc.ErrorMatches, "FAIL")
 }
 
@@ -605,7 +608,7 @@ func (s *SecretsSuite) TestGrant(c *gc.C) {
 		return nil
 	})
 	client := secretsmanager.NewClient(apiCaller)
-	err := client.Grant(uri, &secretsmanager.SecretRevokeGrantArgs{
+	err := client.Grant(context.Background(), uri, &secretsmanager.SecretRevokeGrantArgs{
 		UnitName:    ptr("wordpress/0"),
 		RelationKey: ptr("wordpress:db mysql:server"),
 		Role:        coresecrets.RoleView,
@@ -637,7 +640,7 @@ func (s *SecretsSuite) TestRevoke(c *gc.C) {
 		return nil
 	})
 	client := secretsmanager.NewClient(apiCaller)
-	err := client.Revoke(uri, &secretsmanager.SecretRevokeGrantArgs{
+	err := client.Revoke(context.Background(), uri, &secretsmanager.SecretRevokeGrantArgs{
 		ApplicationName: ptr("wordpress"),
 		RelationKey:     ptr("wordpress:db mysql:server"),
 		Role:            coresecrets.RoleView,

--- a/api/agent/storageprovisioner/provisioner_test.go
+++ b/api/agent/storageprovisioner/provisioner_test.go
@@ -4,6 +4,7 @@
 package storageprovisioner_test
 
 import (
+	"context"
 	"errors"
 
 	"github.com/juju/names/v5"
@@ -39,7 +40,7 @@ func (s *provisionerSuite) TestWatchApplications(c *gc.C) {
 
 	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
-	watcher, err := st.WatchApplications()
+	watcher, err := st.WatchApplications(context.Background())
 	c.Assert(watcher, gc.IsNil)
 	c.Assert(err, gc.ErrorMatches, "FAIL")
 }
@@ -66,7 +67,7 @@ func (s *provisionerSuite) TestWatchVolumes(c *gc.C) {
 
 	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = st.WatchVolumes(names.NewMachineTag("123"))
+	_, err = st.WatchVolumes(context.Background(), names.NewMachineTag("123"))
 	c.Check(err, gc.ErrorMatches, "FAIL")
 	c.Check(callCount, gc.Equals, 1)
 }
@@ -93,7 +94,7 @@ func (s *provisionerSuite) TestWatchFilesystems(c *gc.C) {
 
 	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = st.WatchFilesystems(names.NewMachineTag("123"))
+	_, err = st.WatchFilesystems(context.Background(), names.NewMachineTag("123"))
 	c.Check(err, gc.ErrorMatches, "FAIL")
 	c.Check(callCount, gc.Equals, 1)
 }
@@ -120,7 +121,7 @@ func (s *provisionerSuite) TestWatchVolumeAttachments(c *gc.C) {
 
 	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = st.WatchVolumeAttachments(names.NewMachineTag("123"))
+	_, err = st.WatchVolumeAttachments(context.Background(), names.NewMachineTag("123"))
 	c.Check(err, gc.ErrorMatches, "FAIL")
 	c.Check(callCount, gc.Equals, 1)
 }
@@ -147,7 +148,7 @@ func (s *provisionerSuite) TestWatchVolumeAttachmentPlans(c *gc.C) {
 
 	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = st.WatchVolumeAttachmentPlans(names.NewMachineTag("123"))
+	_, err = st.WatchVolumeAttachmentPlans(context.Background(), names.NewMachineTag("123"))
 	c.Check(err, gc.ErrorMatches, "FAIL")
 	c.Check(callCount, gc.Equals, 1)
 }
@@ -174,7 +175,7 @@ func (s *provisionerSuite) TestWatchFilesystemAttachments(c *gc.C) {
 
 	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = st.WatchFilesystemAttachments(names.NewMachineTag("123"))
+	_, err = st.WatchFilesystemAttachments(context.Background(), names.NewMachineTag("123"))
 	c.Check(err, gc.ErrorMatches, "FAIL")
 	c.Check(callCount, gc.Equals, 1)
 }
@@ -199,7 +200,7 @@ func (s *provisionerSuite) TestWatchBlockDevices(c *gc.C) {
 
 	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = st.WatchBlockDevices(names.NewMachineTag("123"))
+	_, err = st.WatchBlockDevices(context.Background(), names.NewMachineTag("123"))
 	c.Check(err, gc.ErrorMatches, "FAIL")
 }
 
@@ -230,7 +231,7 @@ func (s *provisionerSuite) TestVolumes(c *gc.C) {
 
 	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
-	volumes, err := st.Volumes([]names.VolumeTag{names.NewVolumeTag("100")})
+	volumes, err := st.Volumes(context.Background(), []names.VolumeTag{names.NewVolumeTag("100")})
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(callCount, gc.Equals, 1)
 	c.Assert(volumes, jc.DeepEquals, []params.VolumeResult{{
@@ -271,7 +272,7 @@ func (s *provisionerSuite) TestFilesystems(c *gc.C) {
 
 	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
-	filesystems, err := st.Filesystems([]names.FilesystemTag{names.NewFilesystemTag("100")})
+	filesystems, err := st.Filesystems(context.Background(), []names.FilesystemTag{names.NewFilesystemTag("100")})
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(callCount, gc.Equals, 1)
 	c.Assert(filesystems, jc.DeepEquals, []params.FilesystemResult{{
@@ -317,7 +318,7 @@ func (s *provisionerSuite) TestVolumeAttachments(c *gc.C) {
 
 	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
-	volumes, err := st.VolumeAttachments([]params.MachineStorageId{{
+	volumes, err := st.VolumeAttachments(context.Background(), []params.MachineStorageId{{
 		MachineTag: "machine-100", AttachmentTag: "volume-100",
 	}})
 	c.Check(err, jc.ErrorIsNil)
@@ -367,7 +368,7 @@ func (s *provisionerSuite) TestVolumeAttachmentPlans(c *gc.C) {
 
 	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
-	volumes, err := st.VolumeAttachmentPlans([]params.MachineStorageId{{
+	volumes, err := st.VolumeAttachmentPlans(context.Background(), []params.MachineStorageId{{
 		MachineTag: "machine-100", AttachmentTag: "volume-100",
 	}})
 	c.Check(err, jc.ErrorIsNil)
@@ -403,7 +404,7 @@ func (s *provisionerSuite) TestVolumeBlockDevices(c *gc.C) {
 
 	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
-	volumes, err := st.VolumeBlockDevices([]params.MachineStorageId{{
+	volumes, err := st.VolumeBlockDevices(context.Background(), []params.MachineStorageId{{
 		MachineTag: "machine-100", AttachmentTag: "volume-100",
 	}})
 	c.Check(err, jc.ErrorIsNil)
@@ -442,7 +443,7 @@ func (s *provisionerSuite) TestFilesystemAttachments(c *gc.C) {
 
 	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
-	filesystems, err := st.FilesystemAttachments([]params.MachineStorageId{{
+	filesystems, err := st.FilesystemAttachments(context.Background(), []params.MachineStorageId{{
 		MachineTag: "machine-100", AttachmentTag: "filesystem-100",
 	}})
 	c.Check(err, jc.ErrorIsNil)
@@ -474,7 +475,7 @@ func (s *provisionerSuite) TestVolumeParams(c *gc.C) {
 
 	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
-	volumeParams, err := st.VolumeParams([]names.VolumeTag{names.NewVolumeTag("100")})
+	volumeParams, err := st.VolumeParams(context.Background(), []names.VolumeTag{names.NewVolumeTag("100")})
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(callCount, gc.Equals, 1)
 	c.Assert(volumeParams, jc.DeepEquals, []params.VolumeParamsResult{{
@@ -506,7 +507,7 @@ func (s *provisionerSuite) TestRemoveVolumeParams(c *gc.C) {
 
 	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
-	volumeParams, err := st.RemoveVolumeParams([]names.VolumeTag{names.NewVolumeTag("100")})
+	volumeParams, err := st.RemoveVolumeParams(context.Background(), []names.VolumeTag{names.NewVolumeTag("100")})
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(volumeParams, jc.DeepEquals, []params.RemoveVolumeParamsResult{{
 		Result: params.RemoveVolumeParams{
@@ -541,7 +542,7 @@ func (s *provisionerSuite) TestFilesystemParams(c *gc.C) {
 
 	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
-	filesystemParams, err := st.FilesystemParams([]names.FilesystemTag{names.NewFilesystemTag("100")})
+	filesystemParams, err := st.FilesystemParams(context.Background(), []names.FilesystemTag{names.NewFilesystemTag("100")})
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(callCount, gc.Equals, 1)
 	c.Assert(filesystemParams, jc.DeepEquals, []params.FilesystemParamsResult{{
@@ -573,7 +574,7 @@ func (s *provisionerSuite) TestRemoveFilesystemParams(c *gc.C) {
 
 	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
-	filesystemParams, err := st.RemoveFilesystemParams([]names.FilesystemTag{names.NewFilesystemTag("100")})
+	filesystemParams, err := st.RemoveFilesystemParams(context.Background(), []names.FilesystemTag{names.NewFilesystemTag("100")})
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(filesystemParams, jc.DeepEquals, []params.RemoveFilesystemParamsResult{{
 		Result: params.RemoveFilesystemParams{
@@ -615,7 +616,7 @@ func (s *provisionerSuite) TestVolumeAttachmentParams(c *gc.C) {
 
 	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
-	volumeParams, err := st.VolumeAttachmentParams([]params.MachineStorageId{{
+	volumeParams, err := st.VolumeAttachmentParams(context.Background(), []params.MachineStorageId{{
 		MachineTag: "machine-100", AttachmentTag: "volume-100",
 	}})
 	c.Check(err, jc.ErrorIsNil)
@@ -655,7 +656,7 @@ func (s *provisionerSuite) TestFilesystemAttachmentParams(c *gc.C) {
 
 	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
-	filesystemParams, err := st.FilesystemAttachmentParams([]params.MachineStorageId{{
+	filesystemParams, err := st.FilesystemAttachmentParams(context.Background(), []params.MachineStorageId{{
 		MachineTag: "machine-100", AttachmentTag: "filesystem-100",
 	}})
 	c.Check(err, jc.ErrorIsNil)
@@ -697,7 +698,7 @@ func (s *provisionerSuite) TestSetVolumeInfo(c *gc.C) {
 			VolumeId: "123", HardwareId: "abc", Size: 1024, Persistent: true,
 		},
 	}}
-	errorResults, err := st.SetVolumeInfo(volumes)
+	errorResults, err := st.SetVolumeInfo(context.Background(), volumes)
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(callCount, gc.Equals, 1)
 	c.Assert(errorResults, gc.HasLen, 1)
@@ -763,7 +764,7 @@ func (s *provisionerSuite) TestCreateVolumeAttachmentPlan(c *gc.C) {
 
 	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
-	errorResults, err := st.CreateVolumeAttachmentPlans(attachmentPlan)
+	errorResults, err := st.CreateVolumeAttachmentPlans(context.Background(), attachmentPlan)
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(callCount, gc.Equals, 1)
 	c.Assert(errorResults, gc.HasLen, 1)
@@ -829,7 +830,7 @@ func (s *provisionerSuite) TestSetVolumeAttachmentPlanBlockInfo(c *gc.C) {
 
 	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
-	errorResults, err := st.SetVolumeAttachmentPlanBlockInfo(attachmentPlan)
+	errorResults, err := st.SetVolumeAttachmentPlanBlockInfo(context.Background(), attachmentPlan)
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(callCount, gc.Equals, 1)
 	c.Assert(errorResults, gc.HasLen, 1)
@@ -858,7 +859,7 @@ func (s *provisionerSuite) TestRemoveVolumeAttachmentPlan(c *gc.C) {
 
 	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
-	errorResults, err := st.RemoveVolumeAttachmentPlan([]params.MachineStorageId{{
+	errorResults, err := st.RemoveVolumeAttachmentPlan(context.Background(), []params.MachineStorageId{{
 		MachineTag: "machine-100", AttachmentTag: "volume-100",
 	}})
 	c.Check(err, jc.ErrorIsNil)
@@ -900,7 +901,7 @@ func (s *provisionerSuite) TestSetFilesystemInfo(c *gc.C) {
 			Size:         1024,
 		},
 	}}
-	errorResults, err := st.SetFilesystemInfo(filesystems)
+	errorResults, err := st.SetFilesystemInfo(context.Background(), filesystems)
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(callCount, gc.Equals, 1)
 	c.Assert(errorResults, gc.HasLen, 1)
@@ -933,7 +934,7 @@ func (s *provisionerSuite) TestSetVolumeAttachmentInfo(c *gc.C) {
 
 	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
-	errorResults, err := st.SetVolumeAttachmentInfo(volumeAttachments)
+	errorResults, err := st.SetVolumeAttachmentInfo(context.Background(), volumeAttachments)
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(callCount, gc.Equals, 1)
 	c.Assert(errorResults, gc.HasLen, 1)
@@ -966,7 +967,7 @@ func (s *provisionerSuite) TestSetFilesystemAttachmentInfo(c *gc.C) {
 
 	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
-	errorResults, err := st.SetFilesystemAttachmentInfo(filesystemAttachments)
+	errorResults, err := st.SetFilesystemAttachmentInfo(context.Background(), filesystemAttachments)
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(callCount, gc.Equals, 1)
 	c.Assert(errorResults, gc.HasLen, 1)
@@ -1002,13 +1003,13 @@ func (s *provisionerSuite) testOpWithTags(
 
 func (s *provisionerSuite) TestRemove(c *gc.C) {
 	s.testOpWithTags(c, "Remove", func(st *storageprovisioner.Client, tags []names.Tag) ([]params.ErrorResult, error) {
-		return st.Remove(tags)
+		return st.Remove(context.Background(), tags)
 	})
 }
 
 func (s *provisionerSuite) TestEnsureDead(c *gc.C) {
 	s.testOpWithTags(c, "EnsureDead", func(st *storageprovisioner.Client, tags []names.Tag) ([]params.ErrorResult, error) {
-		return st.EnsureDead(tags)
+		return st.EnsureDead(context.Background(), tags)
 	})
 }
 
@@ -1031,7 +1032,7 @@ func (s *provisionerSuite) TestLife(c *gc.C) {
 	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
 	volumes := []names.Tag{names.NewVolumeTag("100")}
-	lifeResults, err := st.Life(volumes)
+	lifeResults, err := st.Life(context.Background(), volumes)
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(callCount, gc.Equals, 1)
 	c.Assert(lifeResults, jc.DeepEquals, []params.LifeResult{{Life: life.Alive}})
@@ -1049,84 +1050,84 @@ func (s *provisionerSuite) testClientError(c *gc.C, apiCall func(*storageprovisi
 
 func (s *provisionerSuite) TestWatchVolumesClientError(c *gc.C) {
 	s.testClientError(c, func(st *storageprovisioner.Client) error {
-		_, err := st.WatchVolumes(names.NewMachineTag("123"))
+		_, err := st.WatchVolumes(context.Background(), names.NewMachineTag("123"))
 		return err
 	})
 }
 
 func (s *provisionerSuite) TestVolumesClientError(c *gc.C) {
 	s.testClientError(c, func(st *storageprovisioner.Client) error {
-		_, err := st.Volumes(nil)
+		_, err := st.Volumes(context.Background(), nil)
 		return err
 	})
 }
 
 func (s *provisionerSuite) TestVolumeParamsClientError(c *gc.C) {
 	s.testClientError(c, func(st *storageprovisioner.Client) error {
-		_, err := st.VolumeParams(nil)
+		_, err := st.VolumeParams(context.Background(), nil)
 		return err
 	})
 }
 
 func (s *provisionerSuite) TestRemoveVolumeParamsClientError(c *gc.C) {
 	s.testClientError(c, func(st *storageprovisioner.Client) error {
-		_, err := st.RemoveVolumeParams(nil)
+		_, err := st.RemoveVolumeParams(context.Background(), nil)
 		return err
 	})
 }
 
 func (s *provisionerSuite) TestFilesystemParamsClientError(c *gc.C) {
 	s.testClientError(c, func(st *storageprovisioner.Client) error {
-		_, err := st.FilesystemParams(nil)
+		_, err := st.FilesystemParams(context.Background(), nil)
 		return err
 	})
 }
 
 func (s *provisionerSuite) TestRemoveFilesystemParamsClientError(c *gc.C) {
 	s.testClientError(c, func(st *storageprovisioner.Client) error {
-		_, err := st.RemoveFilesystemParams(nil)
+		_, err := st.RemoveFilesystemParams(context.Background(), nil)
 		return err
 	})
 }
 
 func (s *provisionerSuite) TestRemoveClientError(c *gc.C) {
 	s.testClientError(c, func(st *storageprovisioner.Client) error {
-		_, err := st.Remove(nil)
+		_, err := st.Remove(context.Background(), nil)
 		return err
 	})
 }
 
 func (s *provisionerSuite) TestRemoveAttachmentsClientError(c *gc.C) {
 	s.testClientError(c, func(st *storageprovisioner.Client) error {
-		_, err := st.RemoveAttachments(nil)
+		_, err := st.RemoveAttachments(context.Background(), nil)
 		return err
 	})
 }
 
 func (s *provisionerSuite) TestSetVolumeInfoClientError(c *gc.C) {
 	s.testClientError(c, func(st *storageprovisioner.Client) error {
-		_, err := st.SetVolumeInfo(nil)
+		_, err := st.SetVolumeInfo(context.Background(), nil)
 		return err
 	})
 }
 
 func (s *provisionerSuite) TestEnsureDeadClientError(c *gc.C) {
 	s.testClientError(c, func(st *storageprovisioner.Client) error {
-		_, err := st.EnsureDead(nil)
+		_, err := st.EnsureDead(context.Background(), nil)
 		return err
 	})
 }
 
 func (s *provisionerSuite) TestLifeClientError(c *gc.C) {
 	s.testClientError(c, func(st *storageprovisioner.Client) error {
-		_, err := st.Life(nil)
+		_, err := st.Life(context.Background(), nil)
 		return err
 	})
 }
 
 func (s *provisionerSuite) TestAttachmentLifeClientError(c *gc.C) {
 	s.testClientError(c, func(st *storageprovisioner.Client) error {
-		_, err := st.AttachmentLife(nil)
+		_, err := st.AttachmentLife(context.Background(), nil)
 		return err
 	})
 }
@@ -1142,7 +1143,7 @@ func (s *provisionerSuite) TestWatchVolumesServerError(c *gc.C) {
 	})
 	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = st.WatchVolumes(names.NewMachineTag("123"))
+	_, err = st.WatchVolumes(context.Background(), names.NewMachineTag("123"))
 	c.Check(err, gc.ErrorMatches, "MSG")
 }
 
@@ -1157,7 +1158,7 @@ func (s *provisionerSuite) TestVolumesServerError(c *gc.C) {
 	})
 	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
-	results, err := st.Volumes([]names.VolumeTag{names.NewVolumeTag("100")})
+	results, err := st.Volumes(context.Background(), []names.VolumeTag{names.NewVolumeTag("100")})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.HasLen, 1)
 	c.Check(results[0].Error, gc.ErrorMatches, "MSG")
@@ -1174,7 +1175,7 @@ func (s *provisionerSuite) TestVolumeParamsServerError(c *gc.C) {
 	})
 	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
-	results, err := st.VolumeParams([]names.VolumeTag{names.NewVolumeTag("100")})
+	results, err := st.VolumeParams(context.Background(), []names.VolumeTag{names.NewVolumeTag("100")})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.HasLen, 1)
 	c.Check(results[0].Error, gc.ErrorMatches, "MSG")
@@ -1191,7 +1192,7 @@ func (s *provisionerSuite) TestRemoveVolumeParamsServerError(c *gc.C) {
 	})
 	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
-	results, err := st.RemoveVolumeParams([]names.VolumeTag{names.NewVolumeTag("100")})
+	results, err := st.RemoveVolumeParams(context.Background(), []names.VolumeTag{names.NewVolumeTag("100")})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.HasLen, 1)
 	c.Check(results[0].Error, gc.ErrorMatches, "MSG")
@@ -1208,7 +1209,7 @@ func (s *provisionerSuite) TestFilesystemParamsServerError(c *gc.C) {
 	})
 	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
-	results, err := st.FilesystemParams([]names.FilesystemTag{names.NewFilesystemTag("100")})
+	results, err := st.FilesystemParams(context.Background(), []names.FilesystemTag{names.NewFilesystemTag("100")})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.HasLen, 1)
 	c.Check(results[0].Error, gc.ErrorMatches, "MSG")
@@ -1225,7 +1226,7 @@ func (s *provisionerSuite) TestRemoveFilesystemParamsServerError(c *gc.C) {
 	})
 	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
-	results, err := st.RemoveFilesystemParams([]names.FilesystemTag{names.NewFilesystemTag("100")})
+	results, err := st.RemoveFilesystemParams(context.Background(), []names.FilesystemTag{names.NewFilesystemTag("100")})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.HasLen, 1)
 	c.Check(results[0].Error, gc.ErrorMatches, "MSG")
@@ -1242,7 +1243,7 @@ func (s *provisionerSuite) TestSetVolumeInfoServerError(c *gc.C) {
 	})
 	st, err := storageprovisioner.NewClient(apiCaller)
 	c.Assert(err, jc.ErrorIsNil)
-	results, err := st.SetVolumeInfo([]params.Volume{{
+	results, err := st.SetVolumeInfo(context.Background(), []params.Volume{{
 		VolumeTag: names.NewVolumeTag("100").String(),
 	}})
 	c.Assert(err, jc.ErrorIsNil)
@@ -1272,13 +1273,13 @@ func (s *provisionerSuite) testServerError(c *gc.C, apiCall func(*storageprovisi
 
 func (s *provisionerSuite) TestRemoveServerError(c *gc.C) {
 	s.testServerError(c, func(st *storageprovisioner.Client, tags []names.Tag) ([]params.ErrorResult, error) {
-		return st.Remove(tags)
+		return st.Remove(context.Background(), tags)
 	})
 }
 
 func (s *provisionerSuite) TestEnsureDeadServerError(c *gc.C) {
 	s.testServerError(c, func(st *storageprovisioner.Client, tags []names.Tag) ([]params.ErrorResult, error) {
-		return st.EnsureDead(tags)
+		return st.EnsureDead(context.Background(), tags)
 	})
 }
 
@@ -1296,7 +1297,7 @@ func (s *provisionerSuite) TestLifeServerError(c *gc.C) {
 	tags := []names.Tag{
 		names.NewVolumeTag("100"),
 	}
-	results, err := st.Life(tags)
+	results, err := st.Life(context.Background(), tags)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.HasLen, 1)
 	c.Check(results[0].Error, gc.ErrorMatches, "MSG")

--- a/api/agent/unitassigner/unitassigner.go
+++ b/api/agent/unitassigner/unitassigner.go
@@ -38,14 +38,14 @@ func New(caller base.APICaller, options ...Option) API {
 // AssignUnits tells the controller to run whatever unit assignments it has.
 // Unit assignments for units that no longer exist will return an error that
 // satisfies errors.IsNotFound.
-func (a API) AssignUnits(tags []names.UnitTag) ([]error, error) {
+func (a API) AssignUnits(ctx context.Context, tags []names.UnitTag) ([]error, error) {
 	entities := make([]params.Entity, len(tags))
 	for i, tag := range tags {
 		entities[i] = params.Entity{Tag: tag.String()}
 	}
 	args := params.Entities{Entities: entities}
 	var result params.ErrorResults
-	if err := a.facade.FacadeCall(context.TODO(), "AssignUnits", args, &result); err != nil {
+	if err := a.facade.FacadeCall(ctx, "AssignUnits", args, &result); err != nil {
 		return nil, err
 	}
 
@@ -68,9 +68,9 @@ func convertNotFound(err error) error {
 
 // WatchUnitAssignments watches the server for new unit assignments to be
 // created.
-func (a API) WatchUnitAssignments() (watcher.StringsWatcher, error) {
+func (a API) WatchUnitAssignments(ctx context.Context) (watcher.StringsWatcher, error) {
 	var result params.StringsWatchResult
-	err := a.facade.FacadeCall(context.TODO(), "WatchUnitAssignments", nil, &result)
+	err := a.facade.FacadeCall(ctx, "WatchUnitAssignments", nil, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -82,9 +82,9 @@ func (a API) WatchUnitAssignments() (watcher.StringsWatcher, error) {
 }
 
 // SetAgentStatus sets the status of the unit agents.
-func (a API) SetAgentStatus(args params.SetStatus) error {
+func (a API) SetAgentStatus(ctx context.Context, args params.SetStatus) error {
 	var result params.ErrorResults
-	err := a.facade.FacadeCall(context.TODO(), "SetAgentStatus", args, &result)
+	err := a.facade.FacadeCall(ctx, "SetAgentStatus", args, &result)
 	if err != nil {
 		return err
 	}

--- a/api/agent/unitassigner/unitassigner_test.go
+++ b/api/agent/unitassigner/unitassigner_test.go
@@ -28,7 +28,7 @@ func (testsuite) TestAssignUnits(c *gc.C) {
 		}}}
 	api := New(f)
 	ids := []names.UnitTag{names.NewUnitTag("mysql/0"), names.NewUnitTag("mysql/1")}
-	errs, err := api.AssignUnits(ids)
+	errs, err := api.AssignUnits(context.Background(), ids)
 	c.Assert(f.request, gc.Equals, "AssignUnits")
 	c.Assert(f.params, gc.DeepEquals,
 		params.Entities{[]params.Entity{
@@ -47,7 +47,7 @@ func (testsuite) TestAssignUnitsNotFound(c *gc.C) {
 		}}}
 	api := New(f)
 	ids := []names.UnitTag{names.NewUnitTag("mysql/0")}
-	errs, err := api.AssignUnits(ids)
+	errs, err := api.AssignUnits(context.Background(), ids)
 	f.Lock()
 	c.Assert(f.request, gc.Equals, "AssignUnits")
 	c.Assert(f.params, gc.DeepEquals,
@@ -66,7 +66,7 @@ func (testsuite) TestWatchUnitAssignment(c *gc.C) {
 		response: params.StringsWatchResult{},
 	}
 	api := New(f)
-	w, err := api.WatchUnitAssignments()
+	w, err := api.WatchUnitAssignments(context.Background())
 	f.Lock()
 	c.Assert(f.request, gc.Equals, "WatchUnitAssignments")
 	c.Assert(f.params, gc.IsNil)

--- a/api/agent/uniter/action_test.go
+++ b/api/agent/uniter/action_test.go
@@ -146,7 +146,7 @@ func (s *actionSuite) TestLogActionMessage(c *gc.C) {
 	client := uniter.NewClient(caller, names.NewUnitTag("mysql/0"))
 
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
-	err := unit.LogActionMessage(names.NewActionTag("666"), "hello")
+	err := unit.LogActionMessage(context.Background(), names.NewActionTag("666"), "hello")
 	c.Assert(err, gc.ErrorMatches, "biff")
 }
 
@@ -173,7 +173,7 @@ func (s *actionSuite) TestWatchActionNotifications(c *gc.C) {
 	client := uniter.NewClient(apiCaller, names.NewUnitTag("mysql/0"))
 
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
-	w, err := unit.WatchActionNotifications()
+	w, err := unit.WatchActionNotifications(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	wc := watchertest.NewStringsWatcherC(c, w)
 	defer wc.AssertStops()
@@ -189,7 +189,7 @@ func (s *actionSuite) TestWatchActionNotificationsError(c *gc.C) {
 	client := uniter.NewClient(apiCaller, names.NewUnitTag("mysql/0"))
 
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
-	_, err := unit.WatchActionNotifications()
+	_, err := unit.WatchActionNotifications(context.Background())
 	c.Assert(err, gc.ErrorMatches, "boom")
 }
 
@@ -209,7 +209,7 @@ func (s *actionSuite) TestWatchActionNotificationsErrorResults(c *gc.C) {
 	client := uniter.NewClient(apiCaller, names.NewUnitTag("mysql/0"))
 
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
-	_, err := unit.WatchActionNotifications()
+	_, err := unit.WatchActionNotifications(context.Background())
 	c.Assert(err, gc.ErrorMatches, "boom")
 }
 
@@ -222,7 +222,7 @@ func (s *actionSuite) TestWatchActionNotificationsNoResults(c *gc.C) {
 	client := uniter.NewClient(apiCaller, names.NewUnitTag("mysql/0"))
 
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
-	_, err := unit.WatchActionNotifications()
+	_, err := unit.WatchActionNotifications(context.Background())
 	c.Assert(err, gc.ErrorMatches, "expected 1 result, got 0")
 }
 
@@ -237,6 +237,6 @@ func (s *actionSuite) TestWatchActionNotificationsMoreResults(c *gc.C) {
 	client := uniter.NewClient(apiCaller, names.NewUnitTag("mysql/0"))
 
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
-	_, err := unit.WatchActionNotifications()
+	_, err := unit.WatchActionNotifications(context.Background())
 	c.Assert(err, gc.ErrorMatches, "expected 1 result, got 2")
 }

--- a/api/agent/uniter/application.go
+++ b/api/agent/uniter/application.go
@@ -65,12 +65,12 @@ func (s *Application) Refresh(ctx context.Context) error {
 
 // CharmModifiedVersion increments every time the charm, or any part of it, is
 // changed in some way.
-func (s *Application) CharmModifiedVersion() (int, error) {
+func (s *Application) CharmModifiedVersion(ctx context.Context) (int, error) {
 	var results params.IntResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: s.tag.String()}},
 	}
-	err := s.client.facade.FacadeCall(context.TODO(), "CharmModifiedVersion", args, &results)
+	err := s.client.facade.FacadeCall(ctx, "CharmModifiedVersion", args, &results)
 	if err != nil {
 		return -1, err
 	}
@@ -92,12 +92,12 @@ func (s *Application) CharmModifiedVersion() (int, error) {
 //
 // NOTE: This differs from state.Application.CharmURL() by returning
 // an error instead as well, because it needs to make an API call.
-func (s *Application) CharmURL() (string, bool, error) {
+func (s *Application) CharmURL(ctx context.Context) (string, bool, error) {
 	var results params.StringBoolResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: s.tag.String()}},
 	}
-	err := s.client.facade.FacadeCall(context.TODO(), "CharmURL", args, &results)
+	err := s.client.facade.FacadeCall(ctx, "CharmURL", args, &results)
 	if err != nil {
 		return "", false, err
 	}
@@ -116,7 +116,7 @@ func (s *Application) CharmURL() (string, bool, error) {
 
 // SetStatus sets the status of the application if the passed unitName,
 // corresponding to the calling unit, is of the leader.
-func (s *Application) SetStatus(unitName string, appStatus status.Status, info string, data map[string]interface{}) error {
+func (s *Application) SetStatus(ctx context.Context, unitName string, appStatus status.Status, info string, data map[string]interface{}) error {
 	tag := names.NewUnitTag(unitName)
 	var result params.ErrorResults
 	args := params.SetStatus{
@@ -129,7 +129,7 @@ func (s *Application) SetStatus(unitName string, appStatus status.Status, info s
 			},
 		},
 	}
-	err := s.client.facade.FacadeCall(context.TODO(), "SetApplicationStatus", args, &result)
+	err := s.client.facade.FacadeCall(ctx, "SetApplicationStatus", args, &result)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -138,7 +138,7 @@ func (s *Application) SetStatus(unitName string, appStatus status.Status, info s
 
 // Status returns the status of the application if the passed unitName,
 // corresponding to the calling unit, is of the leader.
-func (s *Application) Status(unitName string) (params.ApplicationStatusResult, error) {
+func (s *Application) Status(ctx context.Context, unitName string) (params.ApplicationStatusResult, error) {
 	tag := names.NewUnitTag(unitName)
 	var results params.ApplicationStatusResults
 	args := params.Entities{
@@ -148,7 +148,7 @@ func (s *Application) Status(unitName string) (params.ApplicationStatusResult, e
 			},
 		},
 	}
-	err := s.client.facade.FacadeCall(context.TODO(), "ApplicationStatus", args, &results)
+	err := s.client.facade.FacadeCall(ctx, "ApplicationStatus", args, &results)
 	if err != nil {
 		return params.ApplicationStatusResult{}, errors.Trace(err)
 	}
@@ -161,6 +161,6 @@ func (s *Application) Status(unitName string) (params.ApplicationStatusResult, e
 
 // WatchLeadershipSettings returns a watcher which can be used to wait
 // for leadership settings changes to be made for the application.
-func (s *Application) WatchLeadershipSettings() (watcher.NotifyWatcher, error) {
-	return s.client.leadershipSettings.WatchLeadershipSettings(s.tag.Id())
+func (s *Application) WatchLeadershipSettings(ctx context.Context) (watcher.NotifyWatcher, error) {
+	return s.client.leadershipSettings.WatchLeadershipSettings(ctx, s.tag.Id())
 }

--- a/api/agent/uniter/application_test.go
+++ b/api/agent/uniter/application_test.go
@@ -158,7 +158,7 @@ func (s *applicationSuite) TestCharmURL(c *gc.C) {
 	app, err := client.Application(context.Background(), names.NewApplicationTag("mysql"))
 	c.Assert(err, jc.ErrorIsNil)
 
-	curl, force, err := app.CharmURL()
+	curl, force, err := app.CharmURL(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(curl, gc.Equals, "ch:mysql")
 	c.Assert(force, jc.IsTrue)
@@ -169,7 +169,7 @@ func (s *applicationSuite) TestCharmModifiedVersion(c *gc.C) {
 	app, err := client.Application(context.Background(), names.NewApplicationTag("mysql"))
 	c.Assert(err, jc.ErrorIsNil)
 
-	ver, err := app.CharmModifiedVersion()
+	ver, err := app.CharmModifiedVersion(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ver, gc.Equals, 1)
 }
@@ -179,7 +179,7 @@ func (s *applicationSuite) TestSetApplicationStatus(c *gc.C) {
 	app, err := client.Application(context.Background(), names.NewApplicationTag("mysql"))
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = app.SetStatus("mysql/0", status.Blocked, "app blocked", map[string]interface{}{"foo": "bar"})
+	err = app.SetStatus(context.Background(), "mysql/0", status.Blocked, "app blocked", map[string]interface{}{"foo": "bar"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(s.statusSet, jc.IsTrue)
 }
@@ -189,7 +189,7 @@ func (s *applicationSuite) TestApplicationStatus(c *gc.C) {
 	app, err := client.Application(context.Background(), names.NewApplicationTag("mysql"))
 	c.Assert(err, jc.ErrorIsNil)
 
-	status, err := app.Status("mysql/0")
+	status, err := app.Status(context.Background(), "mysql/0")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(status, jc.DeepEquals, params.ApplicationStatusResult{
 		Application: params.StatusResult{Status: "alive"},

--- a/api/agent/uniter/charm.go
+++ b/api/agent/uniter/charm.go
@@ -36,12 +36,12 @@ func (c *Charm) URL() string {
 // TODO(dimitern): 2013-09-06 bug 1221834
 // Cache the result after getting it once for the same charm URL,
 // because it's immutable.
-func (c *Charm) ArchiveSha256() (string, error) {
+func (c *Charm) ArchiveSha256(ctx context.Context) (string, error) {
 	var results params.StringResults
 	args := params.CharmURLs{
 		URLs: []params.CharmURL{{URL: c.curl}},
 	}
-	err := c.client.facade.FacadeCall(context.TODO(), "CharmArchiveSha256", args, &results)
+	err := c.client.facade.FacadeCall(ctx, "CharmArchiveSha256", args, &results)
 	if err != nil {
 		return "", err
 	}
@@ -57,12 +57,12 @@ func (c *Charm) ArchiveSha256() (string, error) {
 
 // LXDProfileRequired returns true if this charm requires an
 // lxd profile to be applied.
-func (c *Charm) LXDProfileRequired() (bool, error) {
+func (c *Charm) LXDProfileRequired(ctx context.Context) (bool, error) {
 	var results params.BoolResults
 	args := params.CharmURLs{
 		URLs: []params.CharmURL{{URL: c.curl}},
 	}
-	err := c.client.facade.FacadeCall(context.TODO(), "LXDProfileRequired", args, &results)
+	err := c.client.facade.FacadeCall(ctx, "LXDProfileRequired", args, &results)
 	if err != nil {
 		return false, err
 	}

--- a/api/agent/uniter/charm_test.go
+++ b/api/agent/uniter/charm_test.go
@@ -4,6 +4,8 @@
 package uniter_test
 
 import (
+	"context"
+
 	"github.com/juju/names/v5"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -60,7 +62,7 @@ func (s *charmSuite) TestArchiveSha256(c *gc.C) {
 	client := uniter.NewClient(apiCaller, names.NewUnitTag("mysql/0"))
 	ch, err := client.Charm(curl)
 	c.Assert(err, jc.ErrorIsNil)
-	sha, err := ch.ArchiveSha256()
+	sha, err := ch.ArchiveSha256(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(sha, gc.Equals, "deadbeef")
 }
@@ -85,7 +87,7 @@ func (s *charmSuite) TestLXDProfileRequired(c *gc.C) {
 	client := uniter.NewClient(apiCaller, names.NewUnitTag("mysql/0"))
 	ch, err := client.Charm(curl)
 	c.Assert(err, jc.ErrorIsNil)
-	required, err := ch.LXDProfileRequired()
+	required, err := ch.LXDProfileRequired(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(required, jc.IsTrue)
 }

--- a/api/agent/uniter/leadership.go
+++ b/api/agent/uniter/leadership.go
@@ -34,8 +34,8 @@ type LeadershipSettings struct {
 // Merge merges the provided settings into the leadership settings for
 // the given application and unit. Only leaders of a given application may perform
 // this operation.
-func (ls *LeadershipSettings) Merge(appId, unitId string, settings map[string]string) error {
-	results, err := ls.bulkMerge(ls.prepareMerge(appId, unitId, settings))
+func (ls *LeadershipSettings) Merge(ctx context.Context, appId, unitId string, settings map[string]string) error {
+	results, err := ls.bulkMerge(ctx, ls.prepareMerge(appId, unitId, settings))
 	if err != nil {
 		return errors.Annotatef(err, "failed to call leadership api")
 	}
@@ -50,8 +50,8 @@ func (ls *LeadershipSettings) Merge(appId, unitId string, settings map[string]st
 
 // Read retrieves the leadership settings for the given application
 // ID. Anyone may perform this operation.
-func (ls *LeadershipSettings) Read(appId string) (map[string]string, error) {
-	results, err := ls.bulkRead(ls.prepareRead(appId))
+func (ls *LeadershipSettings) Read(ctx context.Context, appId string) (map[string]string, error) {
+	results, err := ls.bulkRead(ctx, ls.prepareRead(appId))
 	if err != nil {
 		return nil, errors.Annotatef(err, "failed to call leadership api")
 	}
@@ -66,10 +66,10 @@ func (ls *LeadershipSettings) Read(appId string) (map[string]string, error) {
 
 // WatchLeadershipSettings returns a watcher which can be used to wait
 // for leadership settings changes to be made for a given application ID.
-func (ls *LeadershipSettings) WatchLeadershipSettings(appId string) (watcher.NotifyWatcher, error) {
+func (ls *LeadershipSettings) WatchLeadershipSettings(ctx context.Context, appId string) (watcher.NotifyWatcher, error) {
 	var results params.NotifyWatchResults
 	if err := ls.facadeCaller(
-		context.TODO(),
+		ctx,
 		"WatchLeadershipSettings",
 		params.Entities{[]params.Entity{{names.NewApplicationTag(appId).String()}}},
 		&results,
@@ -105,7 +105,7 @@ func (ls *LeadershipSettings) prepareRead(appId string) params.Entity {
 // Bulk calls.
 //
 
-func (ls *LeadershipSettings) bulkMerge(args ...params.MergeLeadershipSettingsParam) (*params.ErrorResults, error) {
+func (ls *LeadershipSettings) bulkMerge(ctx context.Context, args ...params.MergeLeadershipSettingsParam) (*params.ErrorResults, error) {
 	// Don't make the jump over the network if we don't have to.
 	if len(args) <= 0 {
 		return &params.ErrorResults{}, nil
@@ -113,10 +113,10 @@ func (ls *LeadershipSettings) bulkMerge(args ...params.MergeLeadershipSettingsPa
 
 	bulkArgs := params.MergeLeadershipSettingsBulkParams{Params: args}
 	var results params.ErrorResults
-	return &results, ls.facadeCaller(context.TODO(), "Merge", bulkArgs, &results)
+	return &results, ls.facadeCaller(ctx, "Merge", bulkArgs, &results)
 }
 
-func (ls *LeadershipSettings) bulkRead(args ...params.Entity) (*params.GetLeadershipSettingsBulkResults, error) {
+func (ls *LeadershipSettings) bulkRead(ctx context.Context, args ...params.Entity) (*params.GetLeadershipSettingsBulkResults, error) {
 
 	// Don't make the jump over the network if we don't have to.
 	if len(args) <= 0 {
@@ -125,5 +125,5 @@ func (ls *LeadershipSettings) bulkRead(args ...params.Entity) (*params.GetLeader
 
 	bulkArgs := params.Entities{Entities: args}
 	var results params.GetLeadershipSettingsBulkResults
-	return &results, ls.facadeCaller(context.TODO(), "Read", bulkArgs, &results)
+	return &results, ls.facadeCaller(ctx, "Read", bulkArgs, &results)
 }

--- a/api/agent/uniter/leadership_test.go
+++ b/api/agent/uniter/leadership_test.go
@@ -87,7 +87,7 @@ func (s *leadershipSuite) TestReadSuccess(c *gc.C) {
 				},
 			}}
 		})
-		settings, err := s.ls.Read("foobar")
+		settings, err := s.ls.Read(context.Background(), "foobar")
 		c.Check(err, jc.ErrorIsNil)
 		c.Check(settings, jc.DeepEquals, map[string]string{
 			"foo": "bar",
@@ -105,7 +105,7 @@ func (s *leadershipSuite) TestReadFailure(c *gc.C) {
 				Error: &params.Error{Message: "pow"},
 			}}
 		})
-		settings, err := s.ls.Read("foobar")
+		settings, err := s.ls.Read(context.Background(), "foobar")
 		c.Check(err, gc.ErrorMatches, "failed to read leadership settings: pow")
 		c.Check(settings, gc.IsNil)
 	})
@@ -115,7 +115,7 @@ func (s *leadershipSuite) TestReadError(c *gc.C) {
 	s.CheckCalls(c, s.expectReadCalls(), func() {
 		s.addResponder(nil)
 		s.stub.SetErrors(errors.New("blart"))
-		settings, err := s.ls.Read("foobar")
+		settings, err := s.ls.Read(context.Background(), "foobar")
 		c.Check(err, gc.ErrorMatches, "failed to call leadership api: blart")
 		c.Check(settings, gc.IsNil)
 	})
@@ -124,7 +124,7 @@ func (s *leadershipSuite) TestReadError(c *gc.C) {
 func (s *leadershipSuite) TestReadNoResults(c *gc.C) {
 	s.CheckCalls(c, s.expectReadCalls(), func() {
 		s.addResponder(nil)
-		settings, err := s.ls.Read("foobar")
+		settings, err := s.ls.Read(context.Background(), "foobar")
 		c.Check(err, gc.ErrorMatches, "expected 1 result from leadership api, got 0")
 		c.Check(settings, gc.IsNil)
 	})
@@ -158,7 +158,7 @@ func (s *leadershipSuite) TestMergeSuccess(c *gc.C) {
 				Error: nil,
 			}}
 		})
-		err := s.ls.Merge("foobar", "foobar/0", map[string]string{
+		err := s.ls.Merge(context.Background(), "foobar", "foobar/0", map[string]string{
 			"foo": "bar",
 			"baz": "qux",
 		})
@@ -175,7 +175,7 @@ func (s *leadershipSuite) TestMergeFailure(c *gc.C) {
 				Error: &params.Error{Message: "zap"},
 			}}
 		})
-		err := s.ls.Merge("foobar", "foobar/0", map[string]string{
+		err := s.ls.Merge(context.Background(), "foobar", "foobar/0", map[string]string{
 			"foo": "bar",
 			"baz": "qux",
 		})
@@ -187,7 +187,7 @@ func (s *leadershipSuite) TestMergeError(c *gc.C) {
 	s.CheckCalls(c, s.expectMergeCalls(), func() {
 		s.addResponder(nil)
 		s.stub.SetErrors(errors.New("dink"))
-		err := s.ls.Merge("foobar", "foobar/0", map[string]string{
+		err := s.ls.Merge(context.Background(), "foobar", "foobar/0", map[string]string{
 			"foo": "bar",
 			"baz": "qux",
 		})
@@ -198,7 +198,7 @@ func (s *leadershipSuite) TestMergeError(c *gc.C) {
 func (s *leadershipSuite) TestMergeNoResults(c *gc.C) {
 	s.CheckCalls(c, s.expectMergeCalls(), func() {
 		s.addResponder(nil)
-		err := s.ls.Merge("foobar", "foobar/0", map[string]string{
+		err := s.ls.Merge(context.Background(), "foobar", "foobar/0", map[string]string{
 			"foo": "bar",
 			"baz": "qux",
 		})
@@ -235,7 +235,7 @@ func (s *leadershipSuite) TestWatchSuccess(c *gc.C) {
 				NotifyWatcherId: "123",
 			}}
 		})
-		watcher, err := s.ls.WatchLeadershipSettings("foobar")
+		watcher, err := s.ls.WatchLeadershipSettings(context.Background(), "foobar")
 		c.Check(err, jc.ErrorIsNil)
 		c.Check(watcher, gc.Equals, mockWatcher)
 	})
@@ -250,7 +250,7 @@ func (s *leadershipSuite) TestWatchFailure(c *gc.C) {
 				Error: &params.Error{Message: "blah"},
 			}}
 		})
-		watcher, err := s.ls.WatchLeadershipSettings("foobar")
+		watcher, err := s.ls.WatchLeadershipSettings(context.Background(), "foobar")
 		c.Check(err, gc.ErrorMatches, "failed to watch leadership settings: blah")
 		c.Check(watcher, gc.IsNil)
 	})
@@ -260,7 +260,7 @@ func (s *leadershipSuite) TestWatchError(c *gc.C) {
 	s.CheckCalls(c, s.expectWatchCalls(), func() {
 		s.addResponder(nil)
 		s.stub.SetErrors(errors.New("snerk"))
-		watcher, err := s.ls.WatchLeadershipSettings("foobar")
+		watcher, err := s.ls.WatchLeadershipSettings(context.Background(), "foobar")
 		c.Check(err, gc.ErrorMatches, "failed to call leadership api: snerk")
 		c.Check(watcher, gc.IsNil)
 	})
@@ -269,7 +269,7 @@ func (s *leadershipSuite) TestWatchError(c *gc.C) {
 func (s *leadershipSuite) TestWatchNoResults(c *gc.C) {
 	s.CheckCalls(c, s.expectWatchCalls(), func() {
 		s.addResponder(nil)
-		watcher, err := s.ls.WatchLeadershipSettings("foobar")
+		watcher, err := s.ls.WatchLeadershipSettings(context.Background(), "foobar")
 		c.Check(err, gc.ErrorMatches, "expected 1 result from leadership api, got 0")
 		c.Check(watcher, gc.IsNil)
 	})

--- a/api/agent/uniter/payload.go
+++ b/api/agent/uniter/payload.go
@@ -29,11 +29,11 @@ func NewPayloadFacadeClient(caller base.APICaller) *PayloadFacadeClient {
 }
 
 // Track calls the Track API server method.
-func (c PayloadFacadeClient) Track(payloads ...payloads.Payload) ([]payloads.Result, error) {
+func (c PayloadFacadeClient) Track(ctx context.Context, payloads ...payloads.Payload) ([]payloads.Result, error) {
 	args := payloads2TrackArgs(payloads)
 
 	var rs params.PayloadResults
-	if err := c.FacadeCall(context.TODO(), "Track", &args, &rs); err != nil {
+	if err := c.FacadeCall(ctx, "Track", &args, &rs); err != nil {
 		return nil, errors.Trace(err)
 	}
 
@@ -41,10 +41,10 @@ func (c PayloadFacadeClient) Track(payloads ...payloads.Payload) ([]payloads.Res
 }
 
 // List calls the List API server method.
-func (c PayloadFacadeClient) List(fullIDs ...string) ([]payloads.Result, error) {
+func (c PayloadFacadeClient) List(ctx context.Context, fullIDs ...string) ([]payloads.Result, error) {
 	var ids []string
 	if len(fullIDs) > 0 {
-		actual, err := c.lookUp(fullIDs)
+		actual, err := c.lookUp(ctx, fullIDs)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -53,7 +53,7 @@ func (c PayloadFacadeClient) List(fullIDs ...string) ([]payloads.Result, error) 
 	args := ids2Args(ids)
 
 	var rs params.PayloadResults
-	if err := c.FacadeCall(context.TODO(), "List", &args, &rs); err != nil {
+	if err := c.FacadeCall(ctx, "List", &args, &rs); err != nil {
 		return nil, errors.Trace(err)
 	}
 
@@ -61,7 +61,7 @@ func (c PayloadFacadeClient) List(fullIDs ...string) ([]payloads.Result, error) 
 }
 
 // LookUp calls the LookUp API server method.
-func (c PayloadFacadeClient) LookUp(fullIDs ...string) ([]payloads.Result, error) {
+func (c PayloadFacadeClient) LookUp(ctx context.Context, fullIDs ...string) ([]payloads.Result, error) {
 	if len(fullIDs) == 0 {
 		// Unlike List(), LookUp doesn't fall back to looking up all IDs.
 		return nil, nil
@@ -69,7 +69,7 @@ func (c PayloadFacadeClient) LookUp(fullIDs ...string) ([]payloads.Result, error
 	args := fullIDs2LookUpArgs(fullIDs)
 
 	var rs params.PayloadResults
-	if err := c.FacadeCall(context.TODO(), "LookUp", &args, &rs); err != nil {
+	if err := c.FacadeCall(ctx, "LookUp", &args, &rs); err != nil {
 		return nil, err
 	}
 
@@ -77,15 +77,15 @@ func (c PayloadFacadeClient) LookUp(fullIDs ...string) ([]payloads.Result, error
 }
 
 // SetStatus calls the SetStatus API server method.
-func (c PayloadFacadeClient) SetStatus(status string, fullIDs ...string) ([]payloads.Result, error) {
-	ids, err := c.lookUp(fullIDs)
+func (c PayloadFacadeClient) SetStatus(ctx context.Context, status string, fullIDs ...string) ([]payloads.Result, error) {
+	ids, err := c.lookUp(ctx, fullIDs)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	args := ids2SetStatusArgs(ids, status)
 
 	var rs params.PayloadResults
-	if err := c.FacadeCall(context.TODO(), "SetStatus", &args, &rs); err != nil {
+	if err := c.FacadeCall(ctx, "SetStatus", &args, &rs); err != nil {
 		return nil, err
 	}
 
@@ -93,23 +93,23 @@ func (c PayloadFacadeClient) SetStatus(status string, fullIDs ...string) ([]payl
 }
 
 // Untrack calls the Untrack API server method.
-func (c PayloadFacadeClient) Untrack(fullIDs ...string) ([]payloads.Result, error) {
-	ids, err := c.lookUp(fullIDs)
+func (c PayloadFacadeClient) Untrack(ctx context.Context, fullIDs ...string) ([]payloads.Result, error) {
+	ids, err := c.lookUp(ctx, fullIDs)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	args := ids2Args(ids)
 
 	var rs params.PayloadResults
-	if err := c.FacadeCall(context.TODO(), "Untrack", &args, &rs); err != nil {
+	if err := c.FacadeCall(ctx, "Untrack", &args, &rs); err != nil {
 		return nil, err
 	}
 
 	return api2results(rs)
 }
 
-func (c PayloadFacadeClient) lookUp(fullIDs []string) ([]string, error) {
-	results, err := c.LookUp(fullIDs...)
+func (c PayloadFacadeClient) lookUp(ctx context.Context, fullIDs []string) ([]string, error) {
+	results, err := c.LookUp(ctx, fullIDs...)
 	if err != nil {
 		return nil, errors.Annotate(err, "while looking up IDs")
 	}

--- a/api/agent/uniter/payload_test.go
+++ b/api/agent/uniter/payload_test.go
@@ -69,7 +69,7 @@ func (s *clientSuite) TestTrack(c *gc.C) {
 
 	pl, err := api.API2Payload(s.payload)
 	c.Assert(err, jc.ErrorIsNil)
-	results, err := pclient.Track(pl.Payload)
+	results, err := pclient.Track(context.Background(), pl.Payload)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(numStubCalls, gc.Equals, 1)
@@ -109,7 +109,7 @@ func (s *clientSuite) TestList(c *gc.C) {
 
 	pclient := uniter.NewPayloadFacadeClient(s.facade)
 
-	results, err := pclient.List("idfoo/bar")
+	results, err := pclient.List(context.Background(), "idfoo/bar")
 	c.Assert(err, jc.ErrorIsNil)
 
 	expected, err := api.API2Payload(s.payload)
@@ -159,7 +159,7 @@ func (s *clientSuite) TestLookUpOkay(c *gc.C) {
 	s.facade.responses = append(s.facade.responses, response)
 
 	pclient := uniter.NewPayloadFacadeClient(s.facade)
-	results, err := pclient.LookUp("idfoo/bar")
+	results, err := pclient.LookUp(context.Background(), "idfoo/bar")
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(results, jc.DeepEquals, []payloads.Result{{
@@ -212,7 +212,7 @@ func (s *clientSuite) TestLookUpMulti(c *gc.C) {
 	s.facade.responses = append(s.facade.responses, response)
 
 	pclient := uniter.NewPayloadFacadeClient(s.facade)
-	results, err := pclient.LookUp("idfoo/bar", "idbaz/bam", "spam/eggs")
+	results, err := pclient.LookUp(context.Background(), "idfoo/bar", "idbaz/bam", "spam/eggs")
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(results, gc.HasLen, 3)
@@ -281,7 +281,7 @@ func (s *clientSuite) TestSetStatus(c *gc.C) {
 	s.facade.responses = append(s.facade.responses, responses...)
 
 	pclient := uniter.NewPayloadFacadeClient(s.facade)
-	results, err := pclient.SetStatus(payloads.StateRunning, "idfoo/bar")
+	results, err := pclient.SetStatus(context.Background(), payloads.StateRunning, "idfoo/bar")
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(results, jc.DeepEquals, []payloads.Result{{
@@ -344,7 +344,7 @@ func (s *clientSuite) TestUntrack(c *gc.C) {
 	s.facade.responses = append(s.facade.responses, responses...)
 
 	pclient := uniter.NewPayloadFacadeClient(s.facade)
-	results, err := pclient.Untrack("idfoo/bar")
+	results, err := pclient.Untrack(context.Background(), "idfoo/bar")
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(results, jc.DeepEquals, []payloads.Result{{

--- a/api/agent/uniter/relationunit.go
+++ b/api/agent/uniter/relationunit.go
@@ -58,7 +58,7 @@ func (ru *RelationUnit) Endpoint() Endpoint {
 // NOTE: Unlike state.RelatioUnit.EnterScope(), this method does not take
 // settings, because uniter only uses this to supply the unit's private
 // address, but this is not done at the server-side by the API.
-func (ru *RelationUnit) EnterScope() error {
+func (ru *RelationUnit) EnterScope(ctx context.Context) error {
 	var result params.ErrorResults
 	args := params.RelationUnits{
 		RelationUnits: []params.RelationUnit{{
@@ -66,7 +66,7 @@ func (ru *RelationUnit) EnterScope() error {
 			Unit:     ru.unitTag.String(),
 		}},
 	}
-	err := ru.client.facade.FacadeCall(context.TODO(), "EnterScope", args, &result)
+	err := ru.client.facade.FacadeCall(ctx, "EnterScope", args, &result)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -78,7 +78,7 @@ func (ru *RelationUnit) EnterScope() error {
 // of the relation; if the relation is dying when its last member unit
 // leaves, it is removed immediately. It is not an error to leave a scope
 // that the unit is not, or never was, a member of.
-func (ru *RelationUnit) LeaveScope() error {
+func (ru *RelationUnit) LeaveScope(ctx context.Context) error {
 	var result params.ErrorResults
 	args := params.RelationUnits{
 		RelationUnits: []params.RelationUnit{{
@@ -86,7 +86,7 @@ func (ru *RelationUnit) LeaveScope() error {
 			Unit:     ru.unitTag.String(),
 		}},
 	}
-	err := ru.client.facade.FacadeCall(context.TODO(), "LeaveScope", args, &result)
+	err := ru.client.facade.FacadeCall(ctx, "LeaveScope", args, &result)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -95,7 +95,7 @@ func (ru *RelationUnit) LeaveScope() error {
 
 // Settings returns a Settings which allows access to the unit's settings
 // within the relation.
-func (ru *RelationUnit) Settings() (*Settings, error) {
+func (ru *RelationUnit) Settings(ctx context.Context) (*Settings, error) {
 	var results params.SettingsResults
 	args := params.RelationUnits{
 		RelationUnits: []params.RelationUnit{{
@@ -103,7 +103,7 @@ func (ru *RelationUnit) Settings() (*Settings, error) {
 			Unit:     ru.unitTag.String(),
 		}},
 	}
-	err := ru.client.facade.FacadeCall(context.TODO(), "ReadSettings", args, &results)
+	err := ru.client.facade.FacadeCall(ctx, "ReadSettings", args, &results)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -120,13 +120,13 @@ func (ru *RelationUnit) Settings() (*Settings, error) {
 // ApplicationSettings returns a Settings which allows access to this unit's
 // application settings within the relation. This can only be used from the
 // leader unit. Calling it from a non-Leader generates a NotLeader error.
-func (ru *RelationUnit) ApplicationSettings() (*Settings, error) {
+func (ru *RelationUnit) ApplicationSettings(ctx context.Context) (*Settings, error) {
 	var result params.SettingsResult
 	arg := params.RelationUnit{
 		Relation: ru.relation.tag.String(),
 		Unit:     ru.unitTag.String(),
 	}
-	if err := ru.client.facade.FacadeCall(context.TODO(), "ReadLocalApplicationSettings", arg, &result); err != nil {
+	if err := ru.client.facade.FacadeCall(ctx, "ReadLocalApplicationSettings", arg, &result); err != nil {
 		return nil, errors.Trace(err)
 	} else if result.Error != nil {
 		return nil, errors.Trace(result.Error)
@@ -141,7 +141,7 @@ func (ru *RelationUnit) ApplicationSettings() (*Settings, error) {
 // unit is not grounds for an error, because the unit settings are
 // guaranteed to persist for the lifetime of the relation, regardless
 // of the lifetime of the unit.
-func (ru *RelationUnit) ReadSettings(name string) (params.Settings, error) {
+func (ru *RelationUnit) ReadSettings(ctx context.Context, name string) (params.Settings, error) {
 	var tag names.Tag
 	if names.IsValidUnit(name) {
 		tag = names.NewUnitTag(name)
@@ -158,7 +158,7 @@ func (ru *RelationUnit) ReadSettings(name string) (params.Settings, error) {
 			RemoteUnit: tag.String(),
 		}},
 	}
-	err := ru.client.facade.FacadeCall(context.TODO(), "ReadRemoteSettings", args, &results)
+	err := ru.client.facade.FacadeCall(ctx, "ReadRemoteSettings", args, &results)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/api/agent/uniter/relationunit_test.go
+++ b/api/agent/uniter/relationunit_test.go
@@ -128,19 +128,19 @@ func (s *relationUnitSuite) TestEndpoint(c *gc.C) {
 
 func (s *relationUnitSuite) TestEnterScope(c *gc.C) {
 	relUnit := s.getRelationUnit(c)
-	err := relUnit.EnterScope()
+	err := relUnit.EnterScope(context.Background())
 	c.Assert(err, gc.ErrorMatches, "boom")
 }
 
 func (s *relationUnitSuite) TestLeaveScope(c *gc.C) {
 	relUnit := s.getRelationUnit(c)
-	err := relUnit.LeaveScope()
+	err := relUnit.LeaveScope(context.Background())
 	c.Assert(err, gc.ErrorMatches, "bam")
 }
 
 func (s *relationUnitSuite) TestSettings(c *gc.C) {
 	relUnit := s.getRelationUnit(c)
-	gotSettings, err := relUnit.Settings()
+	gotSettings, err := relUnit.Settings(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(gotSettings.Map(), gc.DeepEquals, params.Settings{
 		"some":  "settings",
@@ -150,7 +150,7 @@ func (s *relationUnitSuite) TestSettings(c *gc.C) {
 
 func (s *relationUnitSuite) TestApplicationSettings(c *gc.C) {
 	relUnit := s.getRelationUnit(c)
-	gotSettings, err := relUnit.ApplicationSettings()
+	gotSettings, err := relUnit.ApplicationSettings(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(gotSettings.Map(), gc.DeepEquals, params.Settings{
 		"foo": "bar",

--- a/api/agent/uniter/resource.go
+++ b/api/agent/uniter/resource.go
@@ -70,7 +70,7 @@ func (c *ResourcesFacadeClient) GetResource(ctx context.Context, resourceName st
 	}
 
 	// HACK(katco): Combine this into one request?
-	resourceInfo, err := c.getResourceInfo(resourceName)
+	resourceInfo, err := c.getResourceInfo(ctx, resourceName)
 	if err != nil {
 		return resources.Resource{}, nil, errors.Trace(err)
 	}
@@ -80,13 +80,13 @@ func (c *ResourcesFacadeClient) GetResource(ctx context.Context, resourceName st
 	return resourceInfo, response.Body, nil
 }
 
-func (c *ResourcesFacadeClient) getResourceInfo(resourceName string) (resources.Resource, error) {
+func (c *ResourcesFacadeClient) getResourceInfo(ctx context.Context, resourceName string) (resources.Resource, error) {
 	var response params.UnitResourcesResult
 
 	args := params.ListUnitResourcesArgs{
 		ResourceNames: []string{resourceName},
 	}
-	if err := c.FacadeCall(context.TODO(), "GetResourceInfo", &args, &response); err != nil {
+	if err := c.FacadeCall(ctx, "GetResourceInfo", &args, &response); err != nil {
 		return resources.Resource{}, errors.Annotate(err, "could not get resource info")
 	}
 	if response.Error != nil {

--- a/api/agent/uniter/storage.go
+++ b/api/agent/uniter/storage.go
@@ -27,12 +27,12 @@ func NewStorageAccessor(facade base.FacadeCaller) *StorageAccessor {
 }
 
 // UnitStorageAttachments returns the IDs of a unit's storage attachments.
-func (sa *StorageAccessor) UnitStorageAttachments(unitTag names.UnitTag) ([]params.StorageAttachmentId, error) {
+func (sa *StorageAccessor) UnitStorageAttachments(ctx context.Context, unitTag names.UnitTag) ([]params.StorageAttachmentId, error) {
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: unitTag.String()}},
 	}
 	var results params.StorageAttachmentIdsResults
-	err := sa.facade.FacadeCall(context.TODO(), "UnitStorageAttachments", args, &results)
+	err := sa.facade.FacadeCall(ctx, "UnitStorageAttachments", args, &results)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -48,12 +48,12 @@ func (sa *StorageAccessor) UnitStorageAttachments(unitTag names.UnitTag) ([]para
 
 // DestroyUnitStorageAttachments ensures that the specified unit's storage
 // attachments will be removed at some point in the future.
-func (sa *StorageAccessor) DestroyUnitStorageAttachments(unitTag names.UnitTag) error {
+func (sa *StorageAccessor) DestroyUnitStorageAttachments(ctx context.Context, unitTag names.UnitTag) error {
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: unitTag.String()}},
 	}
 	var results params.ErrorResults
-	err := sa.facade.FacadeCall(context.TODO(), "DestroyUnitStorageAttachments", args, &results)
+	err := sa.facade.FacadeCall(ctx, "DestroyUnitStorageAttachments", args, &results)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -70,12 +70,12 @@ func (sa *StorageAccessor) DestroyUnitStorageAttachments(unitTag names.UnitTag) 
 // WatchUnitStorageAttachments starts a watcher for changes to storage
 // attachments related to the unit. The watcher will return the
 // IDs of the corresponding storage instances.
-func (sa *StorageAccessor) WatchUnitStorageAttachments(unitTag names.UnitTag) (watcher.StringsWatcher, error) {
+func (sa *StorageAccessor) WatchUnitStorageAttachments(ctx context.Context, unitTag names.UnitTag) (watcher.StringsWatcher, error) {
 	var results params.StringsWatchResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: unitTag.String()}},
 	}
-	err := sa.facade.FacadeCall(context.TODO(), "WatchUnitStorageAttachments", args, &results)
+	err := sa.facade.FacadeCall(ctx, "WatchUnitStorageAttachments", args, &results)
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +92,7 @@ func (sa *StorageAccessor) WatchUnitStorageAttachments(unitTag names.UnitTag) (w
 
 // StorageAttachment returns the storage attachment with the specified
 // unit and storage tags.
-func (sa *StorageAccessor) StorageAttachment(storageTag names.StorageTag, unitTag names.UnitTag) (params.StorageAttachment, error) {
+func (sa *StorageAccessor) StorageAttachment(ctx context.Context, storageTag names.StorageTag, unitTag names.UnitTag) (params.StorageAttachment, error) {
 	args := params.StorageAttachmentIds{
 		Ids: []params.StorageAttachmentId{{
 			StorageTag: storageTag.String(),
@@ -100,7 +100,7 @@ func (sa *StorageAccessor) StorageAttachment(storageTag names.StorageTag, unitTa
 		}},
 	}
 	var results params.StorageAttachmentResults
-	err := sa.facade.FacadeCall(context.TODO(), "StorageAttachments", args, &results)
+	err := sa.facade.FacadeCall(ctx, "StorageAttachments", args, &results)
 	if err != nil {
 		return params.StorageAttachment{}, errors.Trace(err)
 	}
@@ -116,10 +116,10 @@ func (sa *StorageAccessor) StorageAttachment(storageTag names.StorageTag, unitTa
 
 // StorageAttachmentLife returns the lifecycle state of the storage attachments
 // with the specified IDs.
-func (sa *StorageAccessor) StorageAttachmentLife(ids []params.StorageAttachmentId) ([]params.LifeResult, error) {
+func (sa *StorageAccessor) StorageAttachmentLife(ctx context.Context, ids []params.StorageAttachmentId) ([]params.LifeResult, error) {
 	args := params.StorageAttachmentIds{ids}
 	var results params.LifeResults
-	err := sa.facade.FacadeCall(context.TODO(), "StorageAttachmentLife", args, &results)
+	err := sa.facade.FacadeCall(ctx, "StorageAttachmentLife", args, &results)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -131,7 +131,7 @@ func (sa *StorageAccessor) StorageAttachmentLife(ids []params.StorageAttachmentI
 
 // WatchStorageAttachments starts a watcher for changes to the info
 // of the storage attachment with the specified unit and storage tags.
-func (sa *StorageAccessor) WatchStorageAttachment(storageTag names.StorageTag, unitTag names.UnitTag) (watcher.NotifyWatcher, error) {
+func (sa *StorageAccessor) WatchStorageAttachment(ctx context.Context, storageTag names.StorageTag, unitTag names.UnitTag) (watcher.NotifyWatcher, error) {
 	var results params.NotifyWatchResults
 	args := params.StorageAttachmentIds{
 		Ids: []params.StorageAttachmentId{{
@@ -139,7 +139,7 @@ func (sa *StorageAccessor) WatchStorageAttachment(storageTag names.StorageTag, u
 			UnitTag:    unitTag.String(),
 		}},
 	}
-	err := sa.facade.FacadeCall(context.TODO(), "WatchStorageAttachments", args, &results)
+	err := sa.facade.FacadeCall(ctx, "WatchStorageAttachments", args, &results)
 	if err != nil {
 		return nil, err
 	}
@@ -157,7 +157,7 @@ func (sa *StorageAccessor) WatchStorageAttachment(storageTag names.StorageTag, u
 // RemoveStorageAttachment removes the storage attachment with the
 // specified unit and storage tags from state. This method is only
 // expected to succeed if the storage attachment is Dead.
-func (sa *StorageAccessor) RemoveStorageAttachment(storageTag names.StorageTag, unitTag names.UnitTag) error {
+func (sa *StorageAccessor) RemoveStorageAttachment(ctx context.Context, storageTag names.StorageTag, unitTag names.UnitTag) error {
 	var results params.ErrorResults
 	args := params.StorageAttachmentIds{
 		Ids: []params.StorageAttachmentId{{
@@ -165,7 +165,7 @@ func (sa *StorageAccessor) RemoveStorageAttachment(storageTag names.StorageTag, 
 			UnitTag:    unitTag.String(),
 		}},
 	}
-	err := sa.facade.FacadeCall(context.TODO(), "RemoveStorageAttachments", args, &results)
+	err := sa.facade.FacadeCall(ctx, "RemoveStorageAttachments", args, &results)
 	if err != nil {
 		return err
 	}

--- a/api/agent/uniter/storage_test.go
+++ b/api/agent/uniter/storage_test.go
@@ -4,6 +4,8 @@
 package uniter_test
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 	jc "github.com/juju/testing/checkers"
@@ -49,7 +51,7 @@ func (s *storageSuite) TestUnitStorageAttachments(c *gc.C) {
 
 	caller := testing.BestVersionCaller{apiCaller, 2}
 	client := uniter.NewClient(caller, names.NewUnitTag("mysql/0"))
-	attachmentIds, err := client.UnitStorageAttachments(names.NewUnitTag("mysql/0"))
+	attachmentIds, err := client.UnitStorageAttachments(context.Background(), names.NewUnitTag("mysql/0"))
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(called, jc.IsTrue)
 	c.Assert(attachmentIds, gc.DeepEquals, storageAttachmentIds)
@@ -75,7 +77,7 @@ func (s *storageSuite) TestDestroyUnitStorageAttachments(c *gc.C) {
 
 	caller := testing.BestVersionCaller{apiCaller, 2}
 	client := uniter.NewClient(caller, names.NewUnitTag("mysql/0"))
-	err := client.DestroyUnitStorageAttachments(names.NewUnitTag("mysql/0"))
+	err := client.DestroyUnitStorageAttachments(context.Background(), names.NewUnitTag("mysql/0"))
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(called, jc.IsTrue)
 }
@@ -89,7 +91,7 @@ func (s *storageSuite) TestStorageAttachmentResultCountMismatch(c *gc.C) {
 	})
 	caller := testing.BestVersionCaller{apiCaller, 2}
 	client := uniter.NewClient(caller, names.NewUnitTag("mysql/0"))
-	_, err := client.UnitStorageAttachments(names.NewUnitTag("mysql/0"))
+	_, err := client.UnitStorageAttachments(context.Background(), names.NewUnitTag("mysql/0"))
 	c.Assert(err, gc.ErrorMatches, "expected 1 result, got 2")
 }
 
@@ -99,7 +101,7 @@ func (s *storageSuite) TestAPIErrors(c *gc.C) {
 	})
 	caller := testing.BestVersionCaller{apiCaller, 2}
 	client := uniter.NewClient(caller, names.NewUnitTag("mysql/0"))
-	_, err := client.UnitStorageAttachments(names.NewUnitTag("mysql/0"))
+	_, err := client.UnitStorageAttachments(context.Background(), names.NewUnitTag("mysql/0"))
 	c.Check(err, gc.ErrorMatches, "bad")
 }
 
@@ -125,7 +127,7 @@ func (s *storageSuite) TestWatchUnitStorageAttachments(c *gc.C) {
 
 	caller := testing.BestVersionCaller{apiCaller, 2}
 	client := uniter.NewClient(caller, names.NewUnitTag("mysql/0"))
-	_, err := client.WatchUnitStorageAttachments(names.NewUnitTag("mysql/0"))
+	_, err := client.WatchUnitStorageAttachments(context.Background(), names.NewUnitTag("mysql/0"))
 	c.Check(err, gc.ErrorMatches, "FAIL")
 	c.Check(called, jc.IsTrue)
 }
@@ -155,7 +157,7 @@ func (s *storageSuite) TestWatchStorageAttachments(c *gc.C) {
 
 	caller := testing.BestVersionCaller{apiCaller, 2}
 	client := uniter.NewClient(caller, names.NewUnitTag("mysql/0"))
-	_, err := client.WatchStorageAttachment(names.NewStorageTag("data/0"), names.NewUnitTag("mysql/0"))
+	_, err := client.WatchStorageAttachment(context.Background(), names.NewStorageTag("data/0"), names.NewUnitTag("mysql/0"))
 	c.Check(err, gc.ErrorMatches, "FAIL")
 	c.Check(called, jc.IsTrue)
 }
@@ -193,7 +195,7 @@ func (s *storageSuite) TestStorageAttachments(c *gc.C) {
 
 	caller := testing.BestVersionCaller{apiCaller, 2}
 	client := uniter.NewClient(caller, names.NewUnitTag("mysql/0"))
-	attachment, err := client.StorageAttachment(names.NewStorageTag("data/0"), names.NewUnitTag("mysql/0"))
+	attachment, err := client.StorageAttachment(context.Background(), names.NewStorageTag("data/0"), names.NewUnitTag("mysql/0"))
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(called, jc.IsTrue)
 	c.Assert(attachment, gc.DeepEquals, storageAttachment)
@@ -222,7 +224,7 @@ func (s *storageSuite) TestStorageAttachmentLife(c *gc.C) {
 
 	caller := testing.BestVersionCaller{apiCaller, 2}
 	client := uniter.NewClient(caller, names.NewUnitTag("mysql/0"))
-	results, err := client.StorageAttachmentLife([]params.StorageAttachmentId{{
+	results, err := client.StorageAttachmentLife(context.Background(), []params.StorageAttachmentId{{
 		StorageTag: "storage-data-0",
 		UnitTag:    "unit-mysql-0",
 	}})
@@ -253,6 +255,6 @@ func (s *storageSuite) TestRemoveStorageAttachment(c *gc.C) {
 
 	caller := testing.BestVersionCaller{apiCaller, 2}
 	client := uniter.NewClient(caller, names.NewUnitTag("mysql/0"))
-	err := client.RemoveStorageAttachment(names.NewStorageTag("data/0"), names.NewUnitTag("mysql/0"))
+	err := client.RemoveStorageAttachment(context.Background(), names.NewStorageTag("data/0"), names.NewUnitTag("mysql/0"))
 	c.Check(err, gc.ErrorMatches, "yoink")
 }

--- a/api/agent/uniter/unit.go
+++ b/api/agent/uniter/unit.go
@@ -130,14 +130,14 @@ func (u *Unit) UnitStatus(ctx context.Context) (params.StatusResult, error) {
 }
 
 // SetAgentStatus sets the status of the unit agent.
-func (u *Unit) SetAgentStatus(agentStatus status.Status, info string, data map[string]interface{}) error {
+func (u *Unit) SetAgentStatus(ctx context.Context, agentStatus status.Status, info string, data map[string]interface{}) error {
 	var result params.ErrorResults
 	args := params.SetStatus{
 		Entities: []params.EntityStatusArgs{
 			{Tag: u.tag.String(), Status: agentStatus.String(), Info: info, Data: data},
 		},
 	}
-	err := u.client.facade.FacadeCall(context.TODO(), "SetAgentStatus", args, &result)
+	err := u.client.facade.FacadeCall(ctx, "SetAgentStatus", args, &result)
 	if err != nil {
 		return errors.Trace(apiservererrors.RestoreError(err))
 	}
@@ -146,12 +146,12 @@ func (u *Unit) SetAgentStatus(agentStatus status.Status, info string, data map[s
 
 // EnsureDead sets the unit lifecycle to Dead if it is Alive or
 // Dying. It does nothing otherwise.
-func (u *Unit) EnsureDead() error {
+func (u *Unit) EnsureDead(ctx context.Context) error {
 	var result params.ErrorResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: u.tag.String()}},
 	}
-	err := u.client.facade.FacadeCall(context.TODO(), "EnsureDead", args, &result)
+	err := u.client.facade.FacadeCall(ctx, "EnsureDead", args, &result)
 	if err != nil {
 		return errors.Trace(apiservererrors.RestoreError(err))
 	}
@@ -165,12 +165,12 @@ func (u *Unit) Watch(ctx context.Context) (watcher.NotifyWatcher, error) {
 
 // WatchRelations returns a StringsWatcher that notifies of changes to
 // the lifecycles of relations involving u.
-func (u *Unit) WatchRelations() (watcher.StringsWatcher, error) {
+func (u *Unit) WatchRelations(ctx context.Context) (watcher.StringsWatcher, error) {
 	var results params.StringsWatchResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: u.tag.String()}},
 	}
-	err := u.client.facade.FacadeCall(context.TODO(), "WatchUnitRelations", args, &results)
+	err := u.client.facade.FacadeCall(ctx, "WatchUnitRelations", args, &results)
 	if err != nil {
 		return nil, errors.Trace(apiservererrors.RestoreError(err))
 	}
@@ -204,12 +204,12 @@ func (u *Unit) Application(ctx context.Context) (*Application, error) {
 // available to the unit. Unset values will be replaced with the default
 // value for the associated option, and may thus be nil when no default is
 // specified.
-func (u *Unit) ConfigSettings() (charm.Settings, error) {
+func (u *Unit) ConfigSettings(ctx context.Context) (charm.Settings, error) {
 	var results params.ConfigSettingsResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: u.tag.String()}},
 	}
-	err := u.client.facade.FacadeCall(context.TODO(), "ConfigSettings", args, &results)
+	err := u.client.facade.FacadeCall(ctx, "ConfigSettings", args, &results)
 	if err != nil {
 		return nil, errors.Trace(apiservererrors.RestoreError(err))
 	}
@@ -242,12 +242,12 @@ func (u *Unit) ApplicationTag() names.ApplicationTag {
 // life is just set to Dying; but if a principal unit that is not assigned
 // to a provisioned machine is Destroyed, it will be removed from state
 // directly.
-func (u *Unit) Destroy() error {
+func (u *Unit) Destroy(ctx context.Context) error {
 	var result params.ErrorResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: u.tag.String()}},
 	}
-	err := u.client.facade.FacadeCall(context.TODO(), "Destroy", args, &result)
+	err := u.client.facade.FacadeCall(ctx, "Destroy", args, &result)
 	if err != nil {
 		return errors.Trace(apiservererrors.RestoreError(err))
 	}
@@ -255,12 +255,12 @@ func (u *Unit) Destroy() error {
 }
 
 // DestroyAllSubordinates destroys all subordinates of the unit.
-func (u *Unit) DestroyAllSubordinates() error {
+func (u *Unit) DestroyAllSubordinates(ctx context.Context) error {
 	var result params.ErrorResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: u.tag.String()}},
 	}
-	err := u.client.facade.FacadeCall(context.TODO(), "DestroyAllSubordinates", args, &result)
+	err := u.client.facade.FacadeCall(ctx, "DestroyAllSubordinates", args, &result)
 	if err != nil {
 		return errors.Trace(apiservererrors.RestoreError(err))
 	}
@@ -270,13 +270,13 @@ func (u *Unit) DestroyAllSubordinates() error {
 // AssignedMachine returns the unit's assigned machine tag or an error
 // satisfying params.IsCodeNotAssigned when the unit has no assigned
 // machine..
-func (u *Unit) AssignedMachine() (names.MachineTag, error) {
+func (u *Unit) AssignedMachine(ctx context.Context) (names.MachineTag, error) {
 	var invalidTag names.MachineTag
 	var results params.StringResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: u.tag.String()}},
 	}
-	err := u.client.facade.FacadeCall(context.TODO(), "AssignedMachine", args, &results)
+	err := u.client.facade.FacadeCall(ctx, "AssignedMachine", args, &results)
 	if err != nil {
 		return invalidTag, errors.Trace(apiservererrors.RestoreError(err))
 	}
@@ -295,12 +295,12 @@ func (u *Unit) AssignedMachine() (names.MachineTag, error) {
 //
 // NOTE: This differs from state.Unit.PrincipalName() by returning an
 // error as well, because it needs to make an API call.
-func (u *Unit) PrincipalName() (string, bool, error) {
+func (u *Unit) PrincipalName(ctx context.Context) (string, bool, error) {
 	var results params.StringBoolResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: u.tag.String()}},
 	}
-	err := u.client.facade.FacadeCall(context.TODO(), "GetPrincipal", args, &results)
+	err := u.client.facade.FacadeCall(ctx, "GetPrincipal", args, &results)
 	if err != nil {
 		return "", false, errors.Trace(apiservererrors.RestoreError(err))
 	}
@@ -323,12 +323,12 @@ func (u *Unit) PrincipalName() (string, bool, error) {
 }
 
 // HasSubordinates returns the tags of any subordinate units.
-func (u *Unit) HasSubordinates() (bool, error) {
+func (u *Unit) HasSubordinates(ctx context.Context) (bool, error) {
 	var results params.BoolResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: u.tag.String()}},
 	}
-	err := u.client.facade.FacadeCall(context.TODO(), "HasSubordinates", args, &results)
+	err := u.client.facade.FacadeCall(ctx, "HasSubordinates", args, &results)
 	if err != nil {
 		return false, errors.Trace(apiservererrors.RestoreError(err))
 	}
@@ -350,12 +350,12 @@ func (u *Unit) HasSubordinates() (bool, error) {
 //
 // TODO(dimitern): We might be able to drop this, once we have machine
 // addresses implemented fully. See also LP bug 1221798.
-func (u *Unit) PublicAddress() (string, error) {
+func (u *Unit) PublicAddress(ctx context.Context) (string, error) {
 	var results params.StringResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: u.tag.String()}},
 	}
-	err := u.client.facade.FacadeCall(context.TODO(), "PublicAddress", args, &results)
+	err := u.client.facade.FacadeCall(ctx, "PublicAddress", args, &results)
 	if err != nil {
 		return "", errors.Trace(apiservererrors.RestoreError(err))
 	}
@@ -377,12 +377,12 @@ func (u *Unit) PublicAddress() (string, error) {
 //
 // TODO(dimitern): We might be able to drop this, once we have machine
 // addresses implemented fully. See also LP bug 1221798.
-func (u *Unit) PrivateAddress() (string, error) {
+func (u *Unit) PrivateAddress(ctx context.Context) (string, error) {
 	var results params.StringResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: u.tag.String()}},
 	}
-	err := u.client.facade.FacadeCall(context.TODO(), "PrivateAddress", args, &results)
+	err := u.client.facade.FacadeCall(ctx, "PrivateAddress", args, &results)
 	if err != nil {
 		return "", errors.Trace(apiservererrors.RestoreError(err))
 	}
@@ -397,12 +397,12 @@ func (u *Unit) PrivateAddress() (string, error) {
 }
 
 // AvailabilityZone returns the availability zone of the unit.
-func (u *Unit) AvailabilityZone() (string, error) {
+func (u *Unit) AvailabilityZone(ctx context.Context) (string, error) {
 	var results params.StringResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: u.tag.String()}},
 	}
-	if err := u.client.facade.FacadeCall(context.TODO(), "AvailabilityZone", args, &results); err != nil {
+	if err := u.client.facade.FacadeCall(ctx, "AvailabilityZone", args, &results); err != nil {
 		return "", errors.Trace(apiservererrors.RestoreError(err))
 	}
 	if len(results.Results) != 1 {
@@ -418,12 +418,12 @@ func (u *Unit) AvailabilityZone() (string, error) {
 var ErrNoCharmURLSet = errors.New("unit has no charm url set")
 
 // CharmURL returns the charm URL this unit is currently using.
-func (u *Unit) CharmURL() (string, error) {
+func (u *Unit) CharmURL(ctx context.Context) (string, error) {
 	var results params.StringBoolResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: u.tag.String()}},
 	}
-	err := u.client.facade.FacadeCall(context.TODO(), "CharmURL", args, &results)
+	err := u.client.facade.FacadeCall(ctx, "CharmURL", args, &results)
 	if err != nil {
 		return "", errors.Trace(apiservererrors.RestoreError(err))
 	}
@@ -442,7 +442,7 @@ func (u *Unit) CharmURL() (string, error) {
 
 // SetCharmURL marks the unit as currently using the supplied charm URL.
 // An error will be returned if the unit is dead, or the charm URL not known.
-func (u *Unit) SetCharmURL(curl string) error {
+func (u *Unit) SetCharmURL(ctx context.Context, curl string) error {
 	if curl == "" {
 		return errors.Errorf("charm URL cannot be nil")
 	}
@@ -452,7 +452,7 @@ func (u *Unit) SetCharmURL(curl string) error {
 			{Tag: u.tag.String(), CharmURL: curl},
 		},
 	}
-	err := u.client.facade.FacadeCall(context.TODO(), "SetCharmURL", args, &result)
+	err := u.client.facade.FacadeCall(ctx, "SetCharmURL", args, &result)
 	if err != nil {
 		return errors.Trace(apiservererrors.RestoreError(err))
 	}
@@ -460,12 +460,12 @@ func (u *Unit) SetCharmURL(curl string) error {
 }
 
 // ClearResolved removes any resolved setting on the unit.
-func (u *Unit) ClearResolved() error {
+func (u *Unit) ClearResolved(ctx context.Context) error {
 	var result params.ErrorResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: u.tag.String()}},
 	}
-	err := u.client.facade.FacadeCall(context.TODO(), "ClearResolved", args, &result)
+	err := u.client.facade.FacadeCall(ctx, "ClearResolved", args, &result)
 	if err != nil {
 		return errors.Trace(apiservererrors.RestoreError(err))
 	}
@@ -478,24 +478,24 @@ func (u *Unit) ClearResolved() error {
 // it was last seen by the uniter). The unit must have a charm URL set
 // before this method is called, and the returned watcher will be
 // valid only while the unit's charm URL is not changed.
-func (u *Unit) WatchConfigSettingsHash() (watcher.StringsWatcher, error) {
-	return getHashWatcher(u, "WatchConfigSettingsHash")
+func (u *Unit) WatchConfigSettingsHash(ctx context.Context) (watcher.StringsWatcher, error) {
+	return getHashWatcher(ctx, u, "WatchConfigSettingsHash")
 }
 
 // WatchTrustConfigSettingsHash returns a watcher for observing changes to
 // the unit's application configuration settings (with a hash of the
 // settings content so we can determine whether it has changed since
 // it was last seen by the uniter).
-func (u *Unit) WatchTrustConfigSettingsHash() (watcher.StringsWatcher, error) {
-	return getHashWatcher(u, "WatchTrustConfigSettingsHash")
+func (u *Unit) WatchTrustConfigSettingsHash(ctx context.Context) (watcher.StringsWatcher, error) {
+	return getHashWatcher(ctx, u, "WatchTrustConfigSettingsHash")
 }
 
-func getHashWatcher(u *Unit, methodName string) (watcher.StringsWatcher, error) {
+func getHashWatcher(ctx context.Context, u *Unit, methodName string) (watcher.StringsWatcher, error) {
 	var results params.StringsWatchResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: u.tag.String()}},
 	}
-	err := u.client.facade.FacadeCall(context.TODO(), methodName, args, &results)
+	err := u.client.facade.FacadeCall(ctx, methodName, args, &results)
 	if err != nil {
 		return nil, errors.Trace(apiservererrors.RestoreError(err))
 	}
@@ -517,19 +517,19 @@ func getHashWatcher(u *Unit, methodName string) (watcher.StringsWatcher, error) 
 // only while the unit's assigned machine is not changed.
 // For CAAS models, the watcher observes changes to the address
 // of the pod associated with the unit.
-func (u *Unit) WatchAddressesHash() (watcher.StringsWatcher, error) {
-	return getHashWatcher(u, "WatchUnitAddressesHash")
+func (u *Unit) WatchAddressesHash(ctx context.Context) (watcher.StringsWatcher, error) {
+	return getHashWatcher(ctx, u, "WatchUnitAddressesHash")
 }
 
 // WatchActionNotifications returns a StringsWatcher for observing the
 // ids of Actions added to the Unit. The initial event will contain the
 // ids of any Actions pending at the time the Watcher is made.
-func (u *Unit) WatchActionNotifications() (watcher.StringsWatcher, error) {
+func (u *Unit) WatchActionNotifications(ctx context.Context) (watcher.StringsWatcher, error) {
 	var results params.StringsWatchResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: u.tag.String()}},
 	}
-	err := u.client.facade.FacadeCall(context.TODO(), "WatchActionNotifications", args, &results)
+	err := u.client.facade.FacadeCall(ctx, "WatchActionNotifications", args, &results)
 	if err != nil {
 		return nil, errors.Trace(apiservererrors.RestoreError(err))
 	}
@@ -545,12 +545,12 @@ func (u *Unit) WatchActionNotifications() (watcher.StringsWatcher, error) {
 }
 
 // LogActionMessage logs a progress message for the specified action.
-func (u *Unit) LogActionMessage(tag names.ActionTag, message string) error {
+func (u *Unit) LogActionMessage(ctx context.Context, tag names.ActionTag, message string) error {
 	var result params.ErrorResults
 	args := params.ActionMessageParams{
 		Messages: []params.EntityString{{Tag: tag.String(), Value: message}},
 	}
-	err := u.client.facade.FacadeCall(context.TODO(), "LogActionsMessages", args, &result)
+	err := u.client.facade.FacadeCall(ctx, "LogActionsMessages", args, &result)
 	if err != nil {
 		return errors.Trace(apiservererrors.RestoreError(err))
 	}
@@ -558,8 +558,8 @@ func (u *Unit) LogActionMessage(tag names.ActionTag, message string) error {
 }
 
 // RequestReboot sets the reboot flag for its machine agent
-func (u *Unit) RequestReboot() error {
-	machineId, err := u.AssignedMachine()
+func (u *Unit) RequestReboot(ctx context.Context) error {
+	machineId, err := u.AssignedMachine(ctx)
 	if err != nil {
 		return err
 	}
@@ -567,7 +567,7 @@ func (u *Unit) RequestReboot() error {
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: machineId.String()}},
 	}
-	err = u.client.facade.FacadeCall(context.TODO(), "RequestReboot", args, &result)
+	err = u.client.facade.FacadeCall(ctx, "RequestReboot", args, &result)
 	if err != nil {
 		return errors.Trace(apiservererrors.RestoreError(err))
 	}
@@ -588,12 +588,12 @@ type RelationStatus struct {
 
 // RelationsStatus returns the tags of the relations the unit has joined
 // and entered scope, or the relation is suspended.
-func (u *Unit) RelationsStatus() ([]RelationStatus, error) {
+func (u *Unit) RelationsStatus(ctx context.Context) ([]RelationStatus, error) {
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: u.tag.String()}},
 	}
 	var results params.RelationUnitStatusResults
-	err := u.client.facade.FacadeCall(context.TODO(), "RelationsStatus", args, &results)
+	err := u.client.facade.FacadeCall(ctx, "RelationsStatus", args, &results)
 	if err != nil {
 		return nil, errors.Trace(apiservererrors.RestoreError(err))
 	}
@@ -621,19 +621,19 @@ func (u *Unit) RelationsStatus() ([]RelationStatus, error) {
 
 // WatchStorage returns a watcher for observing changes to the
 // unit's storage attachments.
-func (u *Unit) WatchStorage() (watcher.StringsWatcher, error) {
-	return u.client.WatchUnitStorageAttachments(u.tag)
+func (u *Unit) WatchStorage(ctx context.Context) (watcher.StringsWatcher, error) {
+	return u.client.WatchUnitStorageAttachments(ctx, u.tag)
 }
 
 // WatchInstanceData returns a watcher for observing changes to the
 // instanceData of the unit's machine.  Primarily used for watching
 // LXDProfile changes.
-func (u *Unit) WatchInstanceData() (watcher.NotifyWatcher, error) {
+func (u *Unit) WatchInstanceData(ctx context.Context) (watcher.NotifyWatcher, error) {
 	var results params.NotifyWatchResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: u.tag.String()}},
 	}
-	err := u.client.facade.FacadeCall(context.TODO(), "WatchInstanceData", args, &results)
+	err := u.client.facade.FacadeCall(ctx, "WatchInstanceData", args, &results)
 	if err != nil {
 		return nil, errors.Trace(apiservererrors.RestoreError(err))
 	}
@@ -650,12 +650,12 @@ func (u *Unit) WatchInstanceData() (watcher.NotifyWatcher, error) {
 
 // LXDProfileName returns the name of the lxd profile applied to the unit's
 // machine for the current charm version.
-func (u *Unit) LXDProfileName() (string, error) {
+func (u *Unit) LXDProfileName(ctx context.Context) (string, error) {
 	var results params.StringResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: u.tag.String()}},
 	}
-	err := u.client.facade.FacadeCall(context.TODO(), "LXDProfileName", args, &results)
+	err := u.client.facade.FacadeCall(ctx, "LXDProfileName", args, &results)
 	if err != nil {
 		return "", errors.Trace(apiservererrors.RestoreError(err))
 	}
@@ -671,12 +671,12 @@ func (u *Unit) LXDProfileName() (string, error) {
 
 // CanApplyLXDProfile returns true if an lxd profile can be applied to
 // this unit, e.g. this is an lxd machine or container and not maunal
-func (u *Unit) CanApplyLXDProfile() (bool, error) {
+func (u *Unit) CanApplyLXDProfile(ctx context.Context) (bool, error) {
 	var results params.BoolResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: u.tag.String()}},
 	}
-	err := u.client.facade.FacadeCall(context.TODO(), "CanApplyLXDProfile", args, &results)
+	err := u.client.facade.FacadeCall(ctx, "CanApplyLXDProfile", args, &results)
 	if err != nil {
 		return false, errors.Trace(apiservererrors.RestoreError(err))
 	}
@@ -691,7 +691,7 @@ func (u *Unit) CanApplyLXDProfile() (bool, error) {
 }
 
 // NetworkInfo returns network interfaces/addresses for specified bindings.
-func (u *Unit) NetworkInfo(bindings []string, relationId *int) (map[string]params.NetworkInfoResult, error) {
+func (u *Unit) NetworkInfo(ctx context.Context, bindings []string, relationId *int) (map[string]params.NetworkInfoResult, error) {
 	var results params.NetworkInfoResults
 	args := params.NetworkInfoParams{
 		Unit:       u.tag.String(),
@@ -699,7 +699,7 @@ func (u *Unit) NetworkInfo(bindings []string, relationId *int) (map[string]param
 		RelationId: relationId,
 	}
 
-	err := u.client.facade.FacadeCall(context.TODO(), "NetworkInfo", args, &results)
+	err := u.client.facade.FacadeCall(ctx, "NetworkInfo", args, &results)
 	if err != nil {
 		return nil, errors.Trace(apiservererrors.RestoreError(err))
 	}
@@ -722,9 +722,9 @@ func (u *Unit) SetState(ctx context.Context, unitState params.SetUnitStateArg) e
 // CommitHookChanges batches together all required API calls for applying
 // a set of changes after a hook successfully completes and executes them in a
 // single transaction.
-func (u *Unit) CommitHookChanges(req params.CommitHookChangesArgs) error {
+func (u *Unit) CommitHookChanges(ctx context.Context, req params.CommitHookChangesArgs) error {
 	var results params.ErrorResults
-	err := u.client.facade.FacadeCall(context.TODO(), "CommitHookChanges", req, &results)
+	err := u.client.facade.FacadeCall(ctx, "CommitHookChanges", req, &results)
 	if err != nil {
 		return errors.Trace(apiservererrors.RestoreError(err))
 	}

--- a/api/agent/uniter/unit_test.go
+++ b/api/agent/uniter/unit_test.go
@@ -82,7 +82,7 @@ func (s *unitSuite) TestSetAgentStatus(c *gc.C) {
 	client := uniter.NewClient(apiCaller, names.NewUnitTag("mysql/0"))
 
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
-	err := unit.SetAgentStatus(status.Idle, "blah", map[string]interface{}{"foo": "bar"})
+	err := unit.SetAgentStatus(context.Background(), status.Idle, "blah", map[string]interface{}{"foo": "bar"})
 	c.Assert(err, gc.ErrorMatches, "biff")
 }
 
@@ -94,7 +94,7 @@ func (s *unitSuite) TestSetAgentStatusNotImplemented(c *gc.C) {
 	client := uniter.NewClient(apiCaller, tag)
 
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
-	err := unit.SetAgentStatus(status.Idle, "blah", map[string]interface{}{"foo": "bar"})
+	err := unit.SetAgentStatus(context.Background(), status.Idle, "blah", map[string]interface{}{"foo": "bar"})
 	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
 }
 
@@ -192,7 +192,7 @@ func (s *unitSuite) TestEnsureDead(c *gc.C) {
 	client := uniter.NewClient(apiCaller, names.NewUnitTag("mysql/0"))
 
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
-	err := unit.EnsureDead()
+	err := unit.EnsureDead(context.Background())
 	c.Assert(err, gc.ErrorMatches, "biff")
 }
 
@@ -204,7 +204,7 @@ func (s *unitSuite) TestEnsureDeadNotImplemented(c *gc.C) {
 	client := uniter.NewClient(apiCaller, tag)
 
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
-	err := unit.EnsureDead()
+	err := unit.EnsureDead(context.Background())
 	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
 }
 
@@ -222,7 +222,7 @@ func (s *unitSuite) TestDestroy(c *gc.C) {
 	client := uniter.NewClient(apiCaller, names.NewUnitTag("mysql/0"))
 
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
-	err := unit.Destroy()
+	err := unit.Destroy(context.Background())
 	c.Assert(err, gc.ErrorMatches, "biff")
 }
 
@@ -234,7 +234,7 @@ func (s *unitSuite) TestDestroyNotImplemented(c *gc.C) {
 	client := uniter.NewClient(apiCaller, tag)
 
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
-	err := unit.Destroy()
+	err := unit.Destroy(context.Background())
 	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
 }
 
@@ -252,7 +252,7 @@ func (s *unitSuite) TestDestroyAllSubordinates(c *gc.C) {
 	client := uniter.NewClient(apiCaller, names.NewUnitTag("mysql/0"))
 
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
-	err := unit.DestroyAllSubordinates()
+	err := unit.DestroyAllSubordinates(context.Background())
 	c.Assert(err, gc.ErrorMatches, "biff")
 }
 
@@ -264,7 +264,7 @@ func (s *unitSuite) TestDestroyAllSubordinatesNotImplemented(c *gc.C) {
 	client := uniter.NewClient(apiCaller, tag)
 
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
-	err := unit.DestroyAllSubordinates()
+	err := unit.DestroyAllSubordinates(context.Background())
 	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
 }
 
@@ -319,7 +319,7 @@ func (s *unitSuite) TestClearResolved(c *gc.C) {
 	client := uniter.NewClient(apiCaller, names.NewUnitTag("mysql/0"))
 
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
-	err := unit.ClearResolved()
+	err := unit.ClearResolved(context.Background())
 	c.Assert(err, gc.ErrorMatches, "biff")
 }
 
@@ -331,7 +331,7 @@ func (s *unitSuite) TestClearResolvedNotImplemented(c *gc.C) {
 	client := uniter.NewClient(apiCaller, tag)
 
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
-	err := unit.ClearResolved()
+	err := unit.ClearResolved(context.Background())
 	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
 }
 
@@ -406,7 +406,7 @@ func (s *unitSuite) TestWatchRelations(c *gc.C) {
 	client := uniter.NewClient(apiCaller, names.NewUnitTag("mysql/0"))
 
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
-	w, err := unit.WatchRelations()
+	w, err := unit.WatchRelations(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	wc := watchertest.NewStringsWatcherC(c, w)
 	defer wc.AssertStops()
@@ -423,7 +423,7 @@ func (s *unitSuite) TestWatchRelationsNotImplemented(c *gc.C) {
 	client := uniter.NewClient(apiCaller, tag)
 
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
-	_, err := unit.WatchRelations()
+	_, err := unit.WatchRelations(context.Background())
 	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
 }
 
@@ -443,7 +443,7 @@ func (s *unitSuite) TestAssignedMachine(c *gc.C) {
 	client := uniter.NewClient(apiCaller, names.NewUnitTag("mysql/0"))
 
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
-	tag, err := unit.AssignedMachine()
+	tag, err := unit.AssignedMachine(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(tag, gc.Equals, names.NewMachineTag("666"))
 }
@@ -456,7 +456,7 @@ func (s *unitSuite) TestAssignedMachineNotImplemented(c *gc.C) {
 	client := uniter.NewClient(apiCaller, tag)
 
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
-	_, err := unit.AssignedMachine()
+	_, err := unit.AssignedMachine(context.Background())
 	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
 }
 
@@ -477,7 +477,7 @@ func (s *unitSuite) TestPrincipalName(c *gc.C) {
 	client := uniter.NewClient(apiCaller, names.NewUnitTag("mysql/0"))
 
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
-	name, ok, err := unit.PrincipalName()
+	name, ok, err := unit.PrincipalName(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(name, gc.Equals, "wordpress/0")
 	c.Assert(ok, jc.IsTrue)
@@ -491,7 +491,7 @@ func (s *unitSuite) TestPrincipalNameNotImplemented(c *gc.C) {
 	client := uniter.NewClient(apiCaller, tag)
 
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
-	_, _, err := unit.PrincipalName()
+	_, _, err := unit.PrincipalName(context.Background())
 	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
 }
 
@@ -511,7 +511,7 @@ func (s *unitSuite) TestHasSubordinates(c *gc.C) {
 	client := uniter.NewClient(apiCaller, names.NewUnitTag("mysql/0"))
 
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
-	ok, err := unit.HasSubordinates()
+	ok, err := unit.HasSubordinates(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ok, jc.IsTrue)
 }
@@ -524,7 +524,7 @@ func (s *unitSuite) TestHasSubordinatesNotImplemented(c *gc.C) {
 	client := uniter.NewClient(apiCaller, tag)
 
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
-	_, err := unit.HasSubordinates()
+	_, err := unit.HasSubordinates(context.Background())
 	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
 }
 
@@ -544,7 +544,7 @@ func (s *unitSuite) TestPublicAddress(c *gc.C) {
 	client := uniter.NewClient(apiCaller, names.NewUnitTag("mysql/0"))
 
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
-	address, err := unit.PublicAddress()
+	address, err := unit.PublicAddress(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(address, gc.Equals, "1.1.1.1")
 }
@@ -557,7 +557,7 @@ func (s *unitSuite) TestPublicAddressNotImplemented(c *gc.C) {
 	client := uniter.NewClient(apiCaller, tag)
 
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
-	_, err := unit.PublicAddress()
+	_, err := unit.PublicAddress(context.Background())
 	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
 }
 
@@ -577,7 +577,7 @@ func (s *unitSuite) TestPrivateAddress(c *gc.C) {
 	client := uniter.NewClient(apiCaller, names.NewUnitTag("mysql/0"))
 
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
-	address, err := unit.PrivateAddress()
+	address, err := unit.PrivateAddress(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(address, gc.Equals, "1.1.1.1")
 }
@@ -590,7 +590,7 @@ func (s *unitSuite) TestPrivateAddressNotImplemented(c *gc.C) {
 	client := uniter.NewClient(apiCaller, tag)
 
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
-	_, err := unit.PrivateAddress()
+	_, err := unit.PrivateAddress(context.Background())
 	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
 }
 
@@ -610,7 +610,7 @@ func (s *unitSuite) TestAvailabilityZone(c *gc.C) {
 	client := uniter.NewClient(apiCaller, names.NewUnitTag("mysql/0"))
 
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
-	address, err := unit.AvailabilityZone()
+	address, err := unit.AvailabilityZone(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(address, gc.Equals, "a-zone")
 }
@@ -623,7 +623,7 @@ func (s *unitSuite) TestAvailabilityZoneNotImplemented(c *gc.C) {
 	client := uniter.NewClient(apiCaller, tag)
 
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
-	_, err := unit.AvailabilityZone()
+	_, err := unit.AvailabilityZone(context.Background())
 	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
 }
 
@@ -643,7 +643,7 @@ func (s *unitSuite) TestCharmURL(c *gc.C) {
 	client := uniter.NewClient(apiCaller, names.NewUnitTag("mysql/0"))
 
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
-	curl, err := unit.CharmURL()
+	curl, err := unit.CharmURL(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(curl, gc.Equals, "ch:mysql")
 }
@@ -656,7 +656,7 @@ func (s *unitSuite) TestCharmURLNotImplemented(c *gc.C) {
 	client := uniter.NewClient(apiCaller, tag)
 
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
-	_, err := unit.CharmURL()
+	_, err := unit.CharmURL(context.Background())
 	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
 }
 
@@ -678,7 +678,7 @@ func (s *unitSuite) TestSetCharmURL(c *gc.C) {
 	client := uniter.NewClient(apiCaller, names.NewUnitTag("mysql/0"))
 
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
-	err := unit.SetCharmURL("ch:mysql")
+	err := unit.SetCharmURL(context.Background(), "ch:mysql")
 	c.Assert(err, gc.ErrorMatches, "biff")
 }
 
@@ -690,7 +690,7 @@ func (s *unitSuite) TestSetCharmURLNotImplemented(c *gc.C) {
 	client := uniter.NewClient(apiCaller, tag)
 
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
-	err := unit.SetCharmURL("ch:mysql")
+	err := unit.SetCharmURL(context.Background(), "ch:mysql")
 	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
 }
 
@@ -719,7 +719,7 @@ func (s *unitSuite) TestNetworkInfo(c *gc.C) {
 	client := uniter.NewClient(apiCaller, names.NewUnitTag("mysql/0"))
 
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
-	result, err := unit.NetworkInfo([]string{"server"}, &relId)
+	result, err := unit.NetworkInfo(context.Background(), []string{"server"}, &relId)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result["db"].Error, gc.ErrorMatches, "FAIL")
 }
@@ -734,7 +734,7 @@ func (s *unitSuite) TestNetworkInfoNotImplemented(c *gc.C) {
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
 
 	relId := 2
-	_, err := unit.NetworkInfo([]string{"server"}, &relId)
+	_, err := unit.NetworkInfo(context.Background(), []string{"server"}, &relId)
 	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
 }
 
@@ -755,7 +755,7 @@ func (s *unitSuite) TestConfigSettings(c *gc.C) {
 	client := uniter.NewClient(apiCaller, names.NewUnitTag("mysql/0"))
 
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
-	settings, err := unit.ConfigSettings()
+	settings, err := unit.ConfigSettings(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(settings, gc.DeepEquals, charm.Settings{
 		"foo": "bar",
@@ -771,7 +771,7 @@ func (s *unitSuite) TestConfigSettingsNotImplemented(c *gc.C) {
 
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
 
-	_, err := unit.ConfigSettings()
+	_, err := unit.ConfigSettings(context.Background())
 	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
 }
 
@@ -798,7 +798,7 @@ func (s *unitSuite) TestWatchConfigSettingsHash(c *gc.C) {
 	client := uniter.NewClient(apiCaller, names.NewUnitTag("mysql/0"))
 
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
-	w, err := unit.WatchConfigSettingsHash()
+	w, err := unit.WatchConfigSettingsHash(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	wc := watchertest.NewStringsWatcherC(c, w)
 	defer wc.AssertStops()
@@ -816,7 +816,7 @@ func (s *unitSuite) TestWatchConfigSettingsHashNotImplemented(c *gc.C) {
 
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
 
-	_, err := unit.WatchConfigSettingsHash()
+	_, err := unit.WatchConfigSettingsHash(context.Background())
 	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
 }
 
@@ -843,7 +843,7 @@ func (s *unitSuite) TestWatchTrustConfigSettingsHash(c *gc.C) {
 	client := uniter.NewClient(apiCaller, names.NewUnitTag("mysql/0"))
 
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
-	w, err := unit.WatchTrustConfigSettingsHash()
+	w, err := unit.WatchTrustConfigSettingsHash(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	wc := watchertest.NewStringsWatcherC(c, w)
 	defer wc.AssertStops()
@@ -861,7 +861,7 @@ func (s *unitSuite) TestWatchTrustConfigSettingsHashNotImplemented(c *gc.C) {
 
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
 
-	_, err := unit.WatchTrustConfigSettingsHash()
+	_, err := unit.WatchTrustConfigSettingsHash(context.Background())
 	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
 }
 
@@ -888,7 +888,7 @@ func (s *unitSuite) TestWatchAddressesHash(c *gc.C) {
 	client := uniter.NewClient(apiCaller, names.NewUnitTag("mysql/0"))
 
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
-	w, err := unit.WatchAddressesHash()
+	w, err := unit.WatchAddressesHash(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	wc := watchertest.NewStringsWatcherC(c, w)
 	defer wc.AssertStops()
@@ -906,7 +906,7 @@ func (s *unitSuite) TestWatchAddressesHashNotImplemented(c *gc.C) {
 
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
 
-	_, err := unit.WatchAddressesHash()
+	_, err := unit.WatchAddressesHash(context.Background())
 	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
 }
 
@@ -930,7 +930,7 @@ func (s *unitSuite) TestRelationStatus(c *gc.C) {
 	client := uniter.NewClient(apiCaller, names.NewUnitTag("mysql/0"))
 
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
-	relStatus, err := unit.RelationsStatus()
+	relStatus, err := unit.RelationsStatus(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(relStatus, jc.DeepEquals, []uniter.RelationStatus{{
 		Tag:       names.NewRelationTag("wordpress:server mysql:db"),
@@ -948,7 +948,7 @@ func (s *unitSuite) TestRelationStatusNotImplemented(c *gc.C) {
 
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
 
-	_, err := unit.RelationsStatus()
+	_, err := unit.RelationsStatus(context.Background())
 	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
 }
 
@@ -1051,7 +1051,7 @@ func (s *unitSuite) TestWatchInstanceData(c *gc.C) {
 	client := uniter.NewClient(apiCaller, names.NewUnitTag("mysql/0"))
 
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
-	w, err := unit.WatchInstanceData()
+	w, err := unit.WatchInstanceData(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	wc := watchertest.NewNotifyWatcherC(c, w)
 	defer wc.AssertStops()
@@ -1074,7 +1074,7 @@ func (s *unitSuite) TestWatchInstanceDataNotImplemented(c *gc.C) {
 
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
 
-	_, err := unit.WatchInstanceData()
+	_, err := unit.WatchInstanceData(context.Background())
 	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
 }
 
@@ -1093,7 +1093,7 @@ func (s *unitSuite) TestLXDProfileName(c *gc.C) {
 	})
 	client := uniter.NewClient(apiCaller, names.NewUnitTag("mysql/0"))
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
-	profile, err := unit.LXDProfileName()
+	profile, err := unit.LXDProfileName(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(profile, gc.Equals, "juju-default-mysql-0")
 }
@@ -1107,7 +1107,7 @@ func (s *unitSuite) TestLXDProfileNameNotImplemented(c *gc.C) {
 
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
 
-	_, err := unit.LXDProfileName()
+	_, err := unit.LXDProfileName(context.Background())
 	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
 }
 
@@ -1126,7 +1126,7 @@ func (s *unitSuite) TestCanApplyLXDProfile(c *gc.C) {
 	})
 	client := uniter.NewClient(apiCaller, names.NewUnitTag("mysql/0"))
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
-	canApply, err := unit.CanApplyLXDProfile()
+	canApply, err := unit.CanApplyLXDProfile(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(canApply, jc.IsTrue)
 }
@@ -1140,6 +1140,6 @@ func (s *unitSuite) TestCanApplyLXDProfileNotImplemented(c *gc.C) {
 
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
 
-	_, err := unit.CanApplyLXDProfile()
+	_, err := unit.CanApplyLXDProfile(context.Background())
 	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
 }

--- a/api/agent/uniter/uniter.go
+++ b/api/agent/uniter/uniter.go
@@ -169,8 +169,8 @@ func (client *Client) getOneAction(ctx context.Context, tag *names.ActionTag) (p
 // to use the concrete `api/uniter/LeadershipSettings` type, thus
 // simplifying testing.
 type LeadershipSettingsAccessor interface {
-	Read(applicationName string) (map[string]string, error)
-	Merge(applicationName, unitName string, settings map[string]string) error
+	Read(ctx context.Context, applicationName string) (map[string]string, error)
+	Merge(ctx context.Context, applicationName, unitName string, settings map[string]string) error
 }
 
 // LeadershipSettings returns the client's leadership settings api.

--- a/api/agent/upgrader/upgrader.go
+++ b/api/agent/upgrader/upgrader.go
@@ -37,7 +37,7 @@ func NewClient(caller base.APICaller, options ...Option) *Client {
 // SetVersion sets the tools version associated with the entity with
 // the given tag, which must be the tag of the entity that the
 // upgrader is running on behalf of.
-func (st *Client) SetVersion(tag string, v version.Binary) error {
+func (st *Client) SetVersion(ctx context.Context, tag string, v version.Binary) error {
 	var results params.ErrorResults
 	args := params.EntitiesVersion{
 		AgentTools: []params.EntityVersion{{
@@ -45,19 +45,19 @@ func (st *Client) SetVersion(tag string, v version.Binary) error {
 			Tools: &params.Version{Version: v},
 		}},
 	}
-	err := st.facade.FacadeCall(context.TODO(), "SetTools", args, &results)
+	err := st.facade.FacadeCall(ctx, "SetTools", args, &results)
 	if err != nil {
 		return err
 	}
 	return results.OneError()
 }
 
-func (st *Client) DesiredVersion(tag string) (version.Number, error) {
+func (st *Client) DesiredVersion(ctx context.Context, tag string) (version.Number, error) {
 	var results params.VersionResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: tag}},
 	}
-	err := st.facade.FacadeCall(context.TODO(), "DesiredVersion", args, &results)
+	err := st.facade.FacadeCall(ctx, "DesiredVersion", args, &results)
 	if err != nil {
 		return version.Number{}, err
 	}
@@ -76,12 +76,12 @@ func (st *Client) DesiredVersion(tag string) (version.Number, error) {
 
 // Tools returns the agent tools that should run on the given entity,
 // along with a flag whether to disable SSL hostname verification.
-func (st *Client) Tools(tag string) (tools.List, error) {
+func (st *Client) Tools(ctx context.Context, tag string) (tools.List, error) {
 	var results params.ToolsResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: tag}},
 	}
-	err := st.facade.FacadeCall(context.TODO(), "Tools", args, &results)
+	err := st.facade.FacadeCall(ctx, "Tools", args, &results)
 	if err != nil {
 		return nil, err
 	}
@@ -95,12 +95,12 @@ func (st *Client) Tools(tag string) (tools.List, error) {
 	return result.ToolsList, nil
 }
 
-func (st *Client) WatchAPIVersion(agentTag string) (watcher.NotifyWatcher, error) {
+func (st *Client) WatchAPIVersion(ctx context.Context, agentTag string) (watcher.NotifyWatcher, error) {
 	var results params.NotifyWatchResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: agentTag}},
 	}
-	err := st.facade.FacadeCall(context.TODO(), "WatchAPIVersion", args, &results)
+	err := st.facade.FacadeCall(ctx, "WatchAPIVersion", args, &results)
 	if err != nil {
 		return nil, err
 	}

--- a/api/agent/upgrader/upgrader_test.go
+++ b/api/agent/upgrader/upgrader_test.go
@@ -4,6 +4,8 @@
 package upgrader_test
 
 import (
+	"context"
+
 	jujutesting "github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -41,7 +43,7 @@ func (s *machineUpgraderSuite) TestSetVersion(c *gc.C) {
 
 	})
 	client := upgrader.NewClient(apiCaller)
-	err := client.SetVersion("machine-666", coretesting.CurrentVersion())
+	err := client.SetVersion(context.Background(), "machine-666", coretesting.CurrentVersion())
 	c.Assert(err, gc.ErrorMatches, "FAIL")
 }
 
@@ -63,7 +65,7 @@ func (s *machineUpgraderSuite) TestTools(c *gc.C) {
 
 	})
 	client := upgrader.NewClient(apiCaller)
-	t, err := client.Tools("machine-666")
+	t, err := client.Tools(context.Background(), "machine-666")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(t, jc.DeepEquals, toolsResult)
 }
@@ -85,7 +87,7 @@ func (s *machineUpgraderSuite) TestWatchAPIVersion(c *gc.C) {
 
 	})
 	client := upgrader.NewClient(apiCaller)
-	_, err := client.WatchAPIVersion("machine-666")
+	_, err := client.WatchAPIVersion(context.Background(), "machine-666")
 	c.Assert(err, gc.ErrorMatches, "FAIL")
 }
 
@@ -107,7 +109,7 @@ func (s *machineUpgraderSuite) TestDesiredVersion(c *gc.C) {
 
 	})
 	client := upgrader.NewClient(apiCaller)
-	v, err := client.DesiredVersion("machine-666")
+	v, err := client.DesiredVersion(context.Background(), "machine-666")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(v, jc.DeepEquals, versResult)
 }

--- a/api/agent/upgradesteps/upgradesteps.go
+++ b/api/agent/upgradesteps/upgradesteps.go
@@ -41,10 +41,10 @@ func NewClientFromFacade(facadeCaller base.FacadeCaller) *Client {
 }
 
 // ResetKVMMachineModificationStatusIdle
-func (c *Client) ResetKVMMachineModificationStatusIdle(tag names.Tag) error {
+func (c *Client) ResetKVMMachineModificationStatusIdle(ctx context.Context, tag names.Tag) error {
 	var result params.ErrorResult
 	arg := params.Entity{tag.String()}
-	err := c.facade.FacadeCall(context.TODO(), "ResetKVMMachineModificationStatusIdle", arg, &result)
+	err := c.facade.FacadeCall(ctx, "ResetKVMMachineModificationStatusIdle", arg, &result)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -56,10 +56,10 @@ func (c *Client) ResetKVMMachineModificationStatusIdle(tag names.Tag) error {
 
 // WriteAgentState writes the given internal agent state for the provided
 // units. Currently this call only handles the uniter's state.
-func (c *Client) WriteAgentState(args []params.SetUnitStateArg) error {
+func (c *Client) WriteAgentState(ctx context.Context, args []params.SetUnitStateArg) error {
 	var result params.ErrorResults
 	arg := params.SetUnitStateArgs{Args: args}
-	err := c.facade.FacadeCall(context.TODO(), "WriteAgentState", arg, &result)
+	err := c.facade.FacadeCall(ctx, "WriteAgentState", arg, &result)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/api/agent/upgradesteps/upgradesteps_test.go
+++ b/api/agent/upgradesteps/upgradesteps_test.go
@@ -4,6 +4,8 @@
 package upgradesteps_test
 
 import (
+	"context"
+
 	"github.com/juju/names/v5"
 	jc "github.com/juju/testing/checkers"
 	"go.uber.org/mock/gomock"
@@ -41,7 +43,7 @@ func (s *upgradeStepsSuite) TestWriteAgentState(c *gc.C) {
 	s.expectWriteAgentStateSuccess(c, args)
 
 	client := upgradesteps.NewClientFromFacade(s.fCaller)
-	err := client.WriteAgentState([]params.SetUnitStateArg{
+	err := client.WriteAgentState(context.Background(), []params.SetUnitStateArg{
 		{Tag: uTag0.String(), UniterState: &str0},
 		{Tag: uTag1.String(), UniterState: &str1},
 	})
@@ -59,7 +61,7 @@ func (s *upgradeStepsSuite) TestWriteAgentStateError(c *gc.C) {
 	s.expectWriteAgentStateError(c, args)
 
 	client := upgradesteps.NewClientFromFacade(s.fCaller)
-	err := client.WriteAgentState([]params.SetUnitStateArg{
+	err := client.WriteAgentState(context.Background(), []params.SetUnitStateArg{
 		{Tag: uTag0.String(), UniterState: &str0},
 	})
 	c.Assert(err, gc.ErrorMatches, "did not find")

--- a/api/client/charms/client.go
+++ b/api/client/charms/client.go
@@ -176,7 +176,7 @@ func (c *Client) CheckCharmPlacement(applicationName string, curl *charm.URL) er
 }
 
 // ListCharmResources returns a list of associated resources for a given charm.
-func (c *Client) ListCharmResources(curl string, origin apicharm.Origin) ([]charmresource.Resource, error) {
+func (c *Client) ListCharmResources(ctx context.Context, curl string, origin apicharm.Origin) ([]charmresource.Resource, error) {
 	args := params.CharmURLAndOrigins{
 		Entities: []params.CharmURLAndOrigin{{
 			CharmURL: curl,
@@ -184,7 +184,7 @@ func (c *Client) ListCharmResources(curl string, origin apicharm.Origin) ([]char
 		}},
 	}
 	var results params.CharmResourcesResults
-	if err := c.facade.FacadeCall(context.TODO(), "ListCharmResources", args, &results); err != nil {
+	if err := c.facade.FacadeCall(ctx, "ListCharmResources", args, &results); err != nil {
 		return nil, errors.Trace(err)
 	}
 

--- a/api/client/charms/client_test.go
+++ b/api/client/charms/client_test.go
@@ -4,6 +4,7 @@
 package charms_test
 
 import (
+	context "context"
 	"os"
 
 	"github.com/juju/errors"
@@ -279,7 +280,7 @@ func (s *charmsMockSuite) TestListCharmResources(c *gc.C) {
 	client := charms.NewClientWithFacade(mockFacadeCaller, nil)
 	origin, err := apicharm.APICharmOrigin(noChannelParamsOrigin)
 	c.Assert(err, jc.ErrorIsNil)
-	got, err := client.ListCharmResources(curl, origin)
+	got, err := client.ListCharmResources(context.Background(), curl, origin)
 	c.Assert(err, gc.IsNil)
 
 	want := []charmresource.Resource{{

--- a/api/common/charms/common.go
+++ b/api/common/charms/common.go
@@ -28,10 +28,10 @@ func NewCharmInfoClient(facade base.FacadeCaller) *CharmInfoClient {
 }
 
 // CharmInfo returns information about the requested charm.
-func (c *CharmInfoClient) CharmInfo(charmURL string) (*CharmInfo, error) {
+func (c *CharmInfoClient) CharmInfo(ctx context.Context, charmURL string) (*CharmInfo, error) {
 	args := params.CharmURL{URL: charmURL}
 	var info params.Charm
-	if err := c.facade.FacadeCall(context.TODO(), "CharmInfo", args, &info); err != nil {
+	if err := c.facade.FacadeCall(ctx, "CharmInfo", args, &info); err != nil {
 		return nil, errors.Trace(err)
 	}
 	return convertCharm(&info)
@@ -49,10 +49,10 @@ func NewApplicationCharmInfoClient(facade base.FacadeCaller) *ApplicationCharmIn
 }
 
 // ApplicationCharmInfo returns information about an application's charm.
-func (c *ApplicationCharmInfoClient) ApplicationCharmInfo(appName string) (*CharmInfo, error) {
+func (c *ApplicationCharmInfoClient) ApplicationCharmInfo(ctx context.Context, appName string) (*CharmInfo, error) {
 	args := params.Entity{Tag: names.NewApplicationTag(appName).String()}
 	var info params.Charm
-	if err := c.facade.FacadeCall(context.TODO(), "ApplicationCharmInfo", args, &info); err != nil {
+	if err := c.facade.FacadeCall(ctx, "ApplicationCharmInfo", args, &info); err != nil {
 		return nil, errors.Trace(err)
 	}
 	return convertCharm(&info)
@@ -261,7 +261,7 @@ func convertCharmExtraBindingMap(bindings map[string]string) map[string]charm.Ex
 	}
 	result := make(map[string]charm.ExtraBinding)
 	for key, value := range bindings {
-		result[key] = charm.ExtraBinding{value}
+		result[key] = charm.ExtraBinding{Name: value}
 	}
 	return result
 }

--- a/api/common/charms/common_test.go
+++ b/api/common/charms/common_test.go
@@ -4,6 +4,8 @@
 package charms_test
 
 import (
+	"context"
+
 	"github.com/juju/version/v2"
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
@@ -93,7 +95,7 @@ func (s *suite) TestCharmInfo(c *gc.C) {
 	mockFacadeCaller.EXPECT().FacadeCall(gomock.Any(), "CharmInfo", args, info).SetArg(3, params).Return(nil)
 
 	client := apicommoncharms.NewCharmInfoClient(mockFacadeCaller)
-	got, err := client.CharmInfo(url)
+	got, err := client.CharmInfo(context.Background(), url)
 	c.Assert(err, gc.IsNil)
 
 	want := &apicommoncharms.CharmInfo{
@@ -185,7 +187,7 @@ func (s *suite) TestApplicationCharmInfo(c *gc.C) {
 	mockFacadeCaller.EXPECT().FacadeCall(gomock.Any(), "ApplicationCharmInfo", args, info).SetArg(3, params).Return(nil)
 
 	client := apicommoncharms.NewApplicationCharmInfoClient(mockFacadeCaller)
-	got, err := client.ApplicationCharmInfo("foobar")
+	got, err := client.ApplicationCharmInfo(context.Background(), "foobar")
 	c.Assert(err, gc.IsNil)
 
 	want := &apicommoncharms.CharmInfo{

--- a/api/common/cloudspec/cloudspec.go
+++ b/api/common/cloudspec/cloudspec.go
@@ -32,10 +32,10 @@ func NewCloudSpecAPI(facade base.FacadeCaller, modelTag names.ModelTag) *CloudSp
 
 // WatchCloudSpecChanges returns a NotifyWatcher waiting for the
 // model's cloud to change.
-func (api *CloudSpecAPI) WatchCloudSpecChanges() (watcher.NotifyWatcher, error) {
+func (api *CloudSpecAPI) WatchCloudSpecChanges(ctx context.Context) (watcher.NotifyWatcher, error) {
 	var results params.NotifyWatchResults
-	args := params.Entities{Entities: []params.Entity{{api.modelTag.String()}}}
-	err := api.facade.FacadeCall(context.TODO(), "WatchCloudSpecsChanges", args, &results)
+	args := params.Entities{Entities: []params.Entity{{Tag: api.modelTag.String()}}}
+	err := api.facade.FacadeCall(ctx, "WatchCloudSpecsChanges", args, &results)
 	if err != nil {
 		return nil, err
 	}
@@ -53,8 +53,8 @@ func (api *CloudSpecAPI) WatchCloudSpecChanges() (watcher.NotifyWatcher, error) 
 // with the API facade.
 func (api *CloudSpecAPI) CloudSpec(ctx context.Context) (environscloudspec.CloudSpec, error) {
 	var results params.CloudSpecResults
-	args := params.Entities{Entities: []params.Entity{{api.modelTag.String()}}}
-	err := api.facade.FacadeCall(context.TODO(), "CloudSpec", args, &results)
+	args := params.Entities{Entities: []params.Entity{{Tag: api.modelTag.String()}}}
+	err := api.facade.FacadeCall(ctx, "CloudSpec", args, &results)
 	if err != nil {
 		return environscloudspec.CloudSpec{}, err
 	}

--- a/api/common/cloudspec/cloudspec_test.go
+++ b/api/common/cloudspec/cloudspec_test.go
@@ -102,7 +102,7 @@ func (s *CloudSpecSuite) TestWatchCloudSpecChanges(c *gc.C) {
 		return nil
 	}
 	api := cloudspec.NewCloudSpecAPI(&facadeCaller, coretesting.ModelTag)
-	w, err := api.WatchCloudSpecChanges()
+	w, err := api.WatchCloudSpecChanges(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(w, gc.NotNil)
 	c.Assert(called, jc.IsTrue)

--- a/api/common/lifeflag/facade.go
+++ b/api/common/lifeflag/facade.go
@@ -54,12 +54,12 @@ const ErrEntityNotFound = errors.ConstError("entity not found")
 // Watch returns a NotifyWatcher that sends a value whenever the
 // entity's life value may have changed; or ErrEntityNotFound; or some
 // other error.
-func (c *Client) Watch(entity names.Tag) (watcher.NotifyWatcher, error) {
+func (c *Client) Watch(ctx context.Context, entity names.Tag) (watcher.NotifyWatcher, error) {
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: entity.String()}},
 	}
 	var results params.NotifyWatchResults
-	err := c.caller.FacadeCall(context.TODO(), "Watch", args, &results)
+	err := c.caller.FacadeCall(ctx, "Watch", args, &results)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -79,12 +79,12 @@ func (c *Client) Watch(entity names.Tag) (watcher.NotifyWatcher, error) {
 
 // Life returns the entity's life value; or ErrEntityNotFound; or some
 // other error.
-func (c *Client) Life(entity names.Tag) (life.Value, error) {
+func (c *Client) Life(ctx context.Context, entity names.Tag) (life.Value, error) {
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: entity.String()}},
 	}
 	var results params.LifeResults
-	err := c.caller.FacadeCall(context.TODO(), "Life", args, &results)
+	err := c.caller.FacadeCall(ctx, "Life", args, &results)
 	if err != nil {
 		return "", errors.Trace(err)
 	}

--- a/api/common/lifeflag/facade_test.go
+++ b/api/common/lifeflag/facade_test.go
@@ -4,6 +4,8 @@
 package lifeflag_test
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 	"github.com/juju/testing"
@@ -37,7 +39,7 @@ func (*FacadeSuite) TestLifeCall(c *gc.C) {
 	})
 	facade := lifeflag.NewClient(caller, "LifeFlag")
 
-	facade.Life(names.NewApplicationTag("blah"))
+	facade.Life(context.Background(), names.NewApplicationTag("blah"))
 	c.Check(called, jc.IsTrue)
 }
 
@@ -47,7 +49,7 @@ func (*FacadeSuite) TestLifeCallError(c *gc.C) {
 	})
 	facade := lifeflag.NewClient(caller, "LifeFlag")
 
-	result, err := facade.Life(names.NewApplicationTag("blah"))
+	result, err := facade.Life(context.Background(), names.NewApplicationTag("blah"))
 	c.Check(err, gc.ErrorMatches, "crunch belch")
 	c.Check(result, gc.Equals, life.Value(""))
 }
@@ -58,7 +60,7 @@ func (*FacadeSuite) TestLifeNoResultsError(c *gc.C) {
 	})
 	facade := lifeflag.NewClient(caller, "LifeFlag")
 
-	result, err := facade.Life(names.NewApplicationTag("blah"))
+	result, err := facade.Life(context.Background(), names.NewApplicationTag("blah"))
 	c.Check(err, gc.ErrorMatches, "expected 1 Life result, got 0")
 	c.Check(result, gc.Equals, life.Value(""))
 }
@@ -74,7 +76,7 @@ func (*FacadeSuite) TestLifeExtraResultsError(c *gc.C) {
 	})
 	facade := lifeflag.NewClient(caller, "LifeFlag")
 
-	result, err := facade.Life(names.NewApplicationTag("blah"))
+	result, err := facade.Life(context.Background(), names.NewApplicationTag("blah"))
 	c.Check(err, gc.ErrorMatches, "expected 1 Life result, got 2")
 	c.Check(result, gc.Equals, life.Value(""))
 }
@@ -92,7 +94,7 @@ func (*FacadeSuite) TestLifeNotFoundError(c *gc.C) {
 	})
 	facade := lifeflag.NewClient(caller, "LifeFlag")
 
-	result, err := facade.Life(names.NewApplicationTag("blah"))
+	result, err := facade.Life(context.Background(), names.NewApplicationTag("blah"))
 	c.Check(err, gc.Equals, lifeflag.ErrEntityNotFound)
 	c.Check(result, gc.Equals, life.Value(""))
 }
@@ -108,7 +110,7 @@ func (*FacadeSuite) TestLifeInvalidResultError(c *gc.C) {
 	})
 	facade := lifeflag.NewClient(caller, "LifeFlag")
 
-	result, err := facade.Life(names.NewApplicationTag("blah"))
+	result, err := facade.Life(context.Background(), names.NewApplicationTag("blah"))
 	c.Check(err, gc.ErrorMatches, `life value "decomposed" not valid`)
 	c.Check(result, gc.Equals, life.Value(""))
 }
@@ -124,7 +126,7 @@ func (*FacadeSuite) TestLifeSuccess(c *gc.C) {
 	})
 	facade := lifeflag.NewClient(caller, "LifeFlag")
 
-	result, err := facade.Life(names.NewApplicationTag("blah"))
+	result, err := facade.Life(context.Background(), names.NewApplicationTag("blah"))
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(result, gc.Equals, life.Dying)
 }
@@ -141,7 +143,7 @@ func (*FacadeSuite) TestWatchCall(c *gc.C) {
 	})
 	facade := lifeflag.NewClient(caller, "LifeFlag")
 
-	facade.Watch(names.NewApplicationTag("blah"))
+	facade.Watch(context.Background(), names.NewApplicationTag("blah"))
 	c.Check(called, jc.IsTrue)
 }
 
@@ -151,7 +153,7 @@ func (*FacadeSuite) TestWatchCallError(c *gc.C) {
 	})
 	facade := lifeflag.NewClient(caller, "LifeFlag")
 
-	watcher, err := facade.Watch(names.NewApplicationTag("blah"))
+	watcher, err := facade.Watch(context.Background(), names.NewApplicationTag("blah"))
 	c.Check(err, gc.ErrorMatches, "crunch belch")
 	c.Check(watcher, gc.IsNil)
 }
@@ -162,7 +164,7 @@ func (*FacadeSuite) TestWatchNoResultsError(c *gc.C) {
 	})
 	facade := lifeflag.NewClient(caller, "LifeFlag")
 
-	watcher, err := facade.Watch(names.NewApplicationTag("blah"))
+	watcher, err := facade.Watch(context.Background(), names.NewApplicationTag("blah"))
 	c.Check(err, gc.ErrorMatches, "expected 1 Watch result, got 0")
 	c.Check(watcher, gc.IsNil)
 }
@@ -178,7 +180,7 @@ func (*FacadeSuite) TestWatchExtraResultsError(c *gc.C) {
 	})
 	facade := lifeflag.NewClient(caller, "LifeFlag")
 
-	watcher, err := facade.Watch(names.NewApplicationTag("blah"))
+	watcher, err := facade.Watch(context.Background(), names.NewApplicationTag("blah"))
 	c.Check(err, gc.ErrorMatches, "expected 1 Watch result, got 2")
 	c.Check(watcher, gc.IsNil)
 }
@@ -196,7 +198,7 @@ func (*FacadeSuite) TestWatchNotFoundError(c *gc.C) {
 	})
 	facade := lifeflag.NewClient(caller, "LifeFlag")
 
-	watcher, err := facade.Watch(names.NewApplicationTag("blah"))
+	watcher, err := facade.Watch(context.Background(), names.NewApplicationTag("blah"))
 	c.Check(err, gc.Equals, lifeflag.ErrEntityNotFound)
 	c.Check(watcher, gc.IsNil)
 }
@@ -224,7 +226,7 @@ func (*FacadeSuite) TestWatchSuccess(c *gc.C) {
 		}
 	})
 	facade := lifeflag.NewClient(caller, "LifeFlag")
-	watcher, err := facade.Watch(names.NewApplicationTag("blah"))
+	watcher, err := facade.Watch(context.Background(), names.NewApplicationTag("blah"))
 	c.Check(err, jc.ErrorIsNil)
 	workertest.CheckKilled(c, watcher)
 }

--- a/api/common/secretbackends/client.go
+++ b/api/common/secretbackends/client.go
@@ -30,14 +30,14 @@ func NewClient(facade base.FacadeCaller) *Client {
 
 // GetSecretBackendConfig fetches the config needed to make a secret backend client.
 // If backendID is nil, fetch the current active backend config.
-func (c *Client) GetSecretBackendConfig(backendID *string) (*provider.ModelBackendConfigInfo, error) {
+func (c *Client) GetSecretBackendConfig(ctx context.Context, backendID *string) (*provider.ModelBackendConfigInfo, error) {
 	var results params.SecretBackendConfigResults
 
 	args := params.SecretBackendArgs{}
 	if backendID != nil {
 		args.BackendIDs = []string{*backendID}
 	}
-	err := c.facade.FacadeCall(context.TODO(), "GetSecretBackendConfigs", args, &results)
+	err := c.facade.FacadeCall(ctx, "GetSecretBackendConfigs", args, &results)
 	if err != nil && !errors.Is(params.TranslateWellKnownError(err), secretbackenderrors.NotFound) {
 		return nil, errors.Trace(err)
 	}
@@ -70,13 +70,13 @@ func (c *Client) GetSecretBackendConfig(backendID *string) (*provider.ModelBacke
 }
 
 // GetBackendConfigForDrain fetches the config needed to make a secret backend client for the drain worker.
-func (c *Client) GetBackendConfigForDrain(backendID *string) (*provider.ModelBackendConfig, string, error) {
+func (c *Client) GetBackendConfigForDrain(ctx context.Context, backendID *string) (*provider.ModelBackendConfig, string, error) {
 	var result params.SecretBackendConfigResults
 	arg := params.SecretBackendArgs{ForDrain: true}
 	if backendID != nil {
 		arg.BackendIDs = []string{*backendID}
 	}
-	err := c.facade.FacadeCall(context.TODO(), "GetSecretBackendConfigs", arg, &result)
+	err := c.facade.FacadeCall(ctx, "GetSecretBackendConfigs", arg, &result)
 	if err != nil && !errors.Is(params.TranslateWellKnownError(err), secretbackenderrors.NotFound) {
 		return nil, "", errors.Trace(err)
 	}
@@ -102,7 +102,7 @@ func (c *Client) GetBackendConfigForDrain(backendID *string) (*provider.ModelBac
 }
 
 // GetContentInfo returns info about the content of a secret.
-func (c *Client) GetContentInfo(uri *coresecrets.URI, label string, refresh, peek bool) (*secrets.ContentParams, *provider.ModelBackendConfig, bool, error) {
+func (c *Client) GetContentInfo(ctx context.Context, uri *coresecrets.URI, label string, refresh, peek bool) (*secrets.ContentParams, *provider.ModelBackendConfig, bool, error) {
 	arg := params.GetSecretContentArg{
 		Label:   label,
 		Refresh: refresh,
@@ -115,7 +115,7 @@ func (c *Client) GetContentInfo(uri *coresecrets.URI, label string, refresh, pee
 	var results params.SecretContentResults
 
 	if err := c.facade.FacadeCall(
-		context.TODO(),
+		ctx,
 		"GetSecretContentInfo", params.GetSecretContentArgs{Args: []params.GetSecretContentArg{arg}}, &results,
 	); err != nil {
 		return nil, nil, false, errors.Trace(err)
@@ -165,7 +165,7 @@ func (c *Client) processSecretContentResults(results params.SecretContentResults
 
 // GetRevisionContentInfo returns info about the content of a secret revision.
 // If pendingDelete is true, the revision is marked for deletion.
-func (c *Client) GetRevisionContentInfo(uri *coresecrets.URI, revision int, pendingDelete bool) (*secrets.ContentParams, *provider.ModelBackendConfig, bool, error) {
+func (c *Client) GetRevisionContentInfo(ctx context.Context, uri *coresecrets.URI, revision int, pendingDelete bool) (*secrets.ContentParams, *provider.ModelBackendConfig, bool, error) {
 	arg := params.SecretRevisionArg{
 		URI:           uri.String(),
 		Revisions:     []int{revision},
@@ -175,7 +175,7 @@ func (c *Client) GetRevisionContentInfo(uri *coresecrets.URI, revision int, pend
 	var results params.SecretContentResults
 
 	if err := c.facade.FacadeCall(
-		context.TODO(),
+		ctx,
 		"GetSecretRevisionContentInfo", arg, &results,
 	); err != nil {
 		return nil, nil, false, errors.Trace(err)

--- a/api/common/secretbackends/client_test.go
+++ b/api/common/secretbackends/client_test.go
@@ -4,6 +4,8 @@
 package secretbackends_test
 
 import (
+	"context"
+
 	jc "github.com/juju/testing/checkers"
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
@@ -65,7 +67,7 @@ func (s *SecretsSuite) TestGetSecretBackendConfig(c *gc.C) {
 	).Return(nil)
 
 	client := secretbackends.NewClient(apiCaller)
-	result, err := client.GetSecretBackendConfig(ptr("active-id"))
+	result, err := client.GetSecretBackendConfig(context.Background(), ptr("active-id"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, &provider.ModelBackendConfigInfo{
 		ActiveID: "active-id",
@@ -112,7 +114,7 @@ func (s *SecretsSuite) TestGetBackendConfigForDraing(c *gc.C) {
 	).Return(nil)
 
 	client := secretbackends.NewClient(apiCaller)
-	result, activeID, err := client.GetBackendConfigForDrain(ptr("active-id"))
+	result, activeID, err := client.GetBackendConfigForDrain(context.Background(), ptr("active-id"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, &provider.ModelBackendConfig{
 		ControllerUUID: coretesting.ControllerTag.Id(),
@@ -154,7 +156,7 @@ func (s *SecretsSuite) TestGetContentInfo(c *gc.C) {
 	).Return(nil)
 
 	client := secretbackends.NewClient(apiCaller)
-	content, backendConfig, draining, err := client.GetContentInfo(uri, "label", true, true)
+	content, backendConfig, draining, err := client.GetContentInfo(context.Background(), uri, "label", true, true)
 	c.Assert(err, jc.ErrorIsNil)
 	value := coresecrets.NewSecretValue(map[string]string{"foo": "bar"})
 	c.Assert(content, jc.DeepEquals, &secrets.ContentParams{SecretValue: value})
@@ -203,7 +205,7 @@ func (s *SecretsSuite) TestGetContentInfoExternal(c *gc.C) {
 	).Return(nil)
 
 	client := secretbackends.NewClient(apiCaller)
-	content, backendConfig, draining, err := client.GetContentInfo(uri, "label", true, true)
+	content, backendConfig, draining, err := client.GetContentInfo(context.Background(), uri, "label", true, true)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(content, jc.DeepEquals, &secrets.ContentParams{ValueRef: &coresecrets.ValueRef{
 		BackendID:  "backend-id",
@@ -247,7 +249,7 @@ func (s *SecretsSuite) TestGetContentInfoLabelArgOnly(c *gc.C) {
 	).Return(nil)
 
 	client := secretbackends.NewClient(apiCaller)
-	content, backendConfig, draining, err := client.GetContentInfo(nil, "label", true, true)
+	content, backendConfig, draining, err := client.GetContentInfo(context.Background(), nil, "label", true, true)
 	c.Assert(err, jc.ErrorIsNil)
 	value := coresecrets.NewSecretValue(map[string]string{"foo": "bar"})
 	c.Assert(content, jc.DeepEquals, &secrets.ContentParams{SecretValue: value})
@@ -282,7 +284,7 @@ func (s *SecretsSuite) TestGetContentInfoError(c *gc.C) {
 	).Return(nil)
 
 	client := secretbackends.NewClient(apiCaller)
-	content, backendConfig, _, err := client.GetContentInfo(uri, "", true, true)
+	content, backendConfig, _, err := client.GetContentInfo(context.Background(), uri, "", true, true)
 	c.Assert(err, gc.ErrorMatches, "boom")
 	c.Assert(content, gc.IsNil)
 	c.Assert(backendConfig, gc.IsNil)
@@ -313,7 +315,7 @@ func (s *SecretsSuite) TestGetRevisionContentInfo(c *gc.C) {
 	).Return(nil)
 
 	client := secretbackends.NewClient(apiCaller)
-	content, backendConfig, draining, err := client.GetRevisionContentInfo(uri, 666, true)
+	content, backendConfig, draining, err := client.GetRevisionContentInfo(context.Background(), uri, 666, true)
 	c.Assert(err, jc.ErrorIsNil)
 	value := coresecrets.NewSecretValue(map[string]string{"foo": "bar"})
 	c.Assert(content, jc.DeepEquals, &secrets.ContentParams{SecretValue: value})
@@ -359,7 +361,7 @@ func (s *SecretsSuite) TestGetRevisionContentInfoExternal(c *gc.C) {
 	).Return(nil)
 
 	client := secretbackends.NewClient(apiCaller)
-	content, backendConfig, draining, err := client.GetRevisionContentInfo(uri, 666, true)
+	content, backendConfig, draining, err := client.GetRevisionContentInfo(context.Background(), uri, 666, true)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(content, jc.DeepEquals, &secrets.ContentParams{ValueRef: &coresecrets.ValueRef{
 		BackendID:  "backend-id",
@@ -402,7 +404,7 @@ func (s *SecretsSuite) TestGetRevisionContentInfoError(c *gc.C) {
 	).Return(nil)
 
 	client := secretbackends.NewClient(apiCaller)
-	config, backendConfig, _, err := client.GetRevisionContentInfo(uri, 666, true)
+	config, backendConfig, _, err := client.GetRevisionContentInfo(context.Background(), uri, 666, true)
 	c.Assert(err, gc.ErrorMatches, "boom")
 	c.Assert(config, gc.IsNil)
 	c.Assert(backendConfig, gc.IsNil)

--- a/api/common/secretsdrain/client.go
+++ b/api/common/secretsdrain/client.go
@@ -27,9 +27,9 @@ func NewClient(facade base.FacadeCaller) *Client {
 }
 
 // GetSecretsToDrain returns metadata for the secrets that need to be drained.
-func (c *Client) GetSecretsToDrain() ([]coresecrets.SecretMetadataForDrain, error) {
+func (c *Client) GetSecretsToDrain(ctx context.Context) ([]coresecrets.SecretMetadataForDrain, error) {
 	var results params.SecretRevisionsToDrainResults
-	err := c.facade.FacadeCall(context.TODO(), "GetSecretsToDrain", nil, &results)
+	err := c.facade.FacadeCall(ctx, "GetSecretsToDrain", nil, &results)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -81,7 +81,7 @@ func (r ChangeSecretBackendResult) ErrorCount() (out int) {
 }
 
 // ChangeSecretBackend updates the backend for the specified secret after migration done.
-func (c *Client) ChangeSecretBackend(metaRevisions []ChangeSecretBackendArg) (ChangeSecretBackendResult, error) {
+func (c *Client) ChangeSecretBackend(ctx context.Context, metaRevisions []ChangeSecretBackendArg) (ChangeSecretBackendResult, error) {
 	var results params.ErrorResults
 	out := ChangeSecretBackendResult{Results: make([]error, len(metaRevisions))}
 	args := params.ChangeSecretBackendArgs{Args: make([]params.ChangeSecretBackendArg, len(metaRevisions))}
@@ -99,7 +99,7 @@ func (c *Client) ChangeSecretBackend(metaRevisions []ChangeSecretBackendArg) (Ch
 		}
 		args.Args[i] = arg
 	}
-	err := c.facade.FacadeCall(context.TODO(), "ChangeSecretBackend", args, &results)
+	err := c.facade.FacadeCall(ctx, "ChangeSecretBackend", args, &results)
 	if err != nil {
 		return out, errors.Trace(err)
 	}
@@ -113,9 +113,9 @@ func (c *Client) ChangeSecretBackend(metaRevisions []ChangeSecretBackendArg) (Ch
 }
 
 // WatchSecretBackendChanged sets up a watcher to notify of changes to the secret backend.
-func (c *Client) WatchSecretBackendChanged() (watcher.NotifyWatcher, error) {
+func (c *Client) WatchSecretBackendChanged(ctx context.Context) (watcher.NotifyWatcher, error) {
 	var result params.NotifyWatchResult
-	if err := c.facade.FacadeCall(context.TODO(), "WatchSecretBackendChanged", nil, &result); err != nil {
+	if err := c.facade.FacadeCall(ctx, "WatchSecretBackendChanged", nil, &result); err != nil {
 		return nil, errors.Trace(err)
 	}
 	if result.Error != nil {

--- a/api/common/secretsdrain/client_test.go
+++ b/api/common/secretsdrain/client_test.go
@@ -4,6 +4,8 @@
 package secretsdrain_test
 
 import (
+	"context"
+
 	jc "github.com/juju/testing/checkers"
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
@@ -55,7 +57,7 @@ func (s *secretsDrainSuite) TestGetSecretsToDrain(c *gc.C) {
 	).Return(nil)
 
 	client := secretsdrain.NewClient(apiCaller)
-	result, err := client.GetSecretsToDrain()
+	result, err := client.GetSecretsToDrain(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.HasLen, 1)
 	for _, info := range result {
@@ -102,7 +104,7 @@ func (s *secretsDrainSuite) TestChangeSecretBackend(c *gc.C) {
 		gomock.Any(),
 	).SetArg(
 		3, params.ErrorResults{
-			[]params.ErrorResult{
+			Results: []params.ErrorResult{
 				{Error: nil},
 			},
 		},
@@ -110,6 +112,7 @@ func (s *secretsDrainSuite) TestChangeSecretBackend(c *gc.C) {
 
 	client := secretsdrain.NewClient(apiCaller)
 	result, err := client.ChangeSecretBackend(
+		context.Background(),
 		[]secretsdrain.ChangeSecretBackendArg{
 			{
 				URI:      uri,
@@ -139,6 +142,6 @@ func (s *secretsDrainSuite) TestWatchSecretBackendChanged(c *gc.C) {
 	).Return(nil)
 
 	client := secretsdrain.NewClient(apiCaller)
-	_, err := client.WatchSecretBackendChanged()
+	_, err := client.WatchSecretBackendChanged(context.Background())
 	c.Assert(err, gc.ErrorMatches, "FAIL")
 }

--- a/api/controller/lifeflag/client.go
+++ b/api/controller/lifeflag/client.go
@@ -4,6 +4,8 @@
 package lifeflag
 
 import (
+	"context"
+
 	"github.com/juju/names/v5"
 
 	"github.com/juju/juju/api/base"
@@ -28,8 +30,8 @@ const (
 
 // Client is the client used for connecting to the life flag facade.
 type Client interface {
-	Life(names.Tag) (life.Value, error)
-	Watch(names.Tag) (watcher.NotifyWatcher, error)
+	Life(context.Context, names.Tag) (life.Value, error)
+	Watch(context.Context, names.Tag) (watcher.NotifyWatcher, error)
 }
 
 // NewClient creates a new life flag client.

--- a/api/watcher/watcher_test.go
+++ b/api/watcher/watcher_test.go
@@ -287,7 +287,7 @@ func (s *watcherSuite) TestWatchMachineStorage(c *gc.C) {
 
 	client, err := storageprovisioner.NewClient(caller)
 	c.Assert(err, jc.ErrorIsNil)
-	w, err := client.WatchVolumeAttachments(names.NewMachineTag("666"))
+	w, err := client.WatchVolumeAttachments(context.Background(), names.NewMachineTag("666"))
 	c.Assert(err, jc.ErrorIsNil)
 	defer workertest.CleanKill(c, w)
 
@@ -497,7 +497,7 @@ func (s *watcherSuite) TestOfferStatusWatcher(c *gc.C) {
 	assertChange(status.Active, "finished")
 }
 
-func (s *watcherSuite) assertSecretsTriggerWatcher(c *gc.C, caller *apimocks.MockAPICaller, apiName string, watchFunc func(ownerTags ...names.Tag) (corewatcher.SecretTriggerWatcher, error)) {
+func (s *watcherSuite) assertSecretsTriggerWatcher(c *gc.C, caller *apimocks.MockAPICaller, apiName string, watchFunc func(ctx context.Context, ownerTags ...names.Tag) (corewatcher.SecretTriggerWatcher, error)) {
 	watcherID, eventCh := setupWatcher[*params.SecretTriggerWatchResult](c, caller, "SecretsTriggerWatcher")
 
 	args := params.Entities{
@@ -515,7 +515,7 @@ func (s *watcherSuite) assertSecretsTriggerWatcher(c *gc.C, caller *apimocks.Moc
 	}
 	caller.EXPECT().APICall(gomock.Any(), "SecretsManager", 666, "", apiName, args, gomock.Any()).SetArg(6, initialResults).Return(nil)
 
-	w, err := watchFunc(names.NewApplicationTag("mysql"))
+	w, err := watchFunc(context.Background(), names.NewApplicationTag("mysql"))
 	c.Assert(err, jc.ErrorIsNil)
 	defer workertest.CleanKill(c, w)
 
@@ -667,7 +667,7 @@ func (s *migrationSuite) TestMigrationStatusWatcher(c *gc.C) {
 	caller.EXPECT().APICall(gomock.Any(), "MigrationMinion", 666, "", "Watch", nil, gomock.Any()).SetArg(6, initialResult).Return(nil)
 
 	client := migrationminion.NewClient(caller)
-	w, err := client.Watch()
+	w, err := client.Watch(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	defer func() {
 		c.Assert(worker.Stop(w), jc.ErrorIsNil)

--- a/apiserver/facades/agent/leadership/leadership.go
+++ b/apiserver/facades/agent/leadership/leadership.go
@@ -81,7 +81,7 @@ func (m *leadershipService) ClaimLeadership(ctx context.Context, args params.Cla
 			result.Error = apiservererrors.ServerError(apiservererrors.ErrPerm)
 			continue
 		}
-		if err = m.claimer.ClaimLeadership(applicationTag.Id(), unitTag.Id(), duration); err != nil {
+		if err = m.claimer.ClaimLeadership(ctx, applicationTag.Id(), unitTag.Id(), duration); err != nil {
 			result.Error = apiservererrors.ServerError(err)
 		}
 	}
@@ -104,7 +104,7 @@ func (m *leadershipService) BlockUntilLeadershipReleased(ctx context.Context, ap
 		return params.ErrorResult{Error: apiservererrors.ServerError(apiservererrors.ErrPerm)}, nil
 	}
 
-	if err := m.claimer.BlockUntilLeadershipReleased(applicationTag.Id(), ctx.Done()); err != nil {
+	if err := m.claimer.BlockUntilLeadershipReleased(ctx, applicationTag.Id(), ctx.Done()); err != nil {
 		return params.ErrorResult{Error: apiservererrors.ServerError(err)}, nil
 	}
 	return params.ErrorResult{}, nil

--- a/apiserver/facades/agent/leadership/leadership_test.go
+++ b/apiserver/facades/agent/leadership/leadership_test.go
@@ -35,20 +35,20 @@ const (
 )
 
 type stubClaimer struct {
-	ClaimLeadershipFn              func(sid, uid string, duration time.Duration) error
-	BlockUntilLeadershipReleasedFn func(serviceId string, cancel <-chan struct{}) error
+	ClaimLeadershipFn              func(ctx context.Context, sid, uid string, duration time.Duration) error
+	BlockUntilLeadershipReleasedFn func(ctx context.Context, serviceId string, cancel <-chan struct{}) error
 }
 
-func (m *stubClaimer) ClaimLeadership(sid, uid string, duration time.Duration) error {
+func (m *stubClaimer) ClaimLeadership(ctx context.Context, sid, uid string, duration time.Duration) error {
 	if m.ClaimLeadershipFn != nil {
-		return m.ClaimLeadershipFn(sid, uid, duration)
+		return m.ClaimLeadershipFn(ctx, sid, uid, duration)
 	}
 	return nil
 }
 
-func (m *stubClaimer) BlockUntilLeadershipReleased(serviceId string, cancel <-chan struct{}) error {
+func (m *stubClaimer) BlockUntilLeadershipReleased(ctx context.Context, serviceId string, cancel <-chan struct{}) error {
 	if m.BlockUntilLeadershipReleasedFn != nil {
-		return m.BlockUntilLeadershipReleasedFn(serviceId, cancel)
+		return m.BlockUntilLeadershipReleasedFn(ctx, serviceId, cancel)
 	}
 	return nil
 }
@@ -97,7 +97,7 @@ func newLeadershipService(
 
 func (s *leadershipSuite) TestClaimLeadershipTranslation(c *gc.C) {
 	claimer := &stubClaimer{
-		ClaimLeadershipFn: func(sid, uid string, duration time.Duration) error {
+		ClaimLeadershipFn: func(ctx context.Context, sid, uid string, duration time.Duration) error {
 			c.Check(sid, gc.Equals, StubAppNm)
 			c.Check(uid, gc.Equals, StubUnitNm)
 			expectDuration := time.Duration(299.9 * float64(time.Second))
@@ -124,7 +124,7 @@ func (s *leadershipSuite) TestClaimLeadershipTranslation(c *gc.C) {
 
 func (s *leadershipSuite) TestClaimLeadershipApplicationAgent(c *gc.C) {
 	claimer := &stubClaimer{
-		ClaimLeadershipFn: func(sid, uid string, duration time.Duration) error {
+		ClaimLeadershipFn: func(ctx context.Context, sid, uid string, duration time.Duration) error {
 			c.Check(sid, gc.Equals, StubAppNm)
 			c.Check(uid, gc.Equals, StubUnitNm)
 			expectDuration := time.Duration(299.9 * float64(time.Second))
@@ -154,7 +154,7 @@ func (s *leadershipSuite) TestClaimLeadershipApplicationAgent(c *gc.C) {
 
 func (s *leadershipSuite) TestClaimLeadershipDeniedError(c *gc.C) {
 	claimer := &stubClaimer{
-		ClaimLeadershipFn: func(sid, uid string, duration time.Duration) error {
+		ClaimLeadershipFn: func(ctx context.Context, sid, uid string, duration time.Duration) error {
 			c.Check(sid, gc.Equals, StubAppNm)
 			c.Check(uid, gc.Equals, StubUnitNm)
 			expectDuration := time.Duration(5.001 * float64(time.Second))
@@ -249,7 +249,7 @@ func (s *leadershipSuite) TestClaimLeadershipDurationTooLong(c *gc.C) {
 
 func (s *leadershipSuite) TestBlockUntilLeadershipReleasedTranslation(c *gc.C) {
 	claimer := &stubClaimer{
-		BlockUntilLeadershipReleasedFn: func(sid string, cancel <-chan struct{}) error {
+		BlockUntilLeadershipReleasedFn: func(ctx context.Context, sid string, cancel <-chan struct{}) error {
 			c.Check(sid, gc.Equals, StubAppNm)
 			return nil
 		},
@@ -269,7 +269,7 @@ func (s *leadershipSuite) TestBlockUntilLeadershipReleasedContext(c *gc.C) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	claimer := &stubClaimer{
-		BlockUntilLeadershipReleasedFn: func(sid string, cancel <-chan struct{}) error {
+		BlockUntilLeadershipReleasedFn: func(ctx context.Context, sid string, cancel <-chan struct{}) error {
 			c.Check(sid, gc.Equals, StubAppNm)
 			c.Check(cancel, gc.Equals, ctx.Done())
 			return coreleadership.ErrBlockCancelled

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -2985,7 +2985,7 @@ func (s *uniterSuite) TestStorageAttachments(c *gc.C) {
 	uniter, err := apiuniter.NewFromConnection(api)
 	c.Assert(err, jc.ErrorIsNil)
 
-	attachments, err := uniter.UnitStorageAttachments(unit.UnitTag())
+	attachments, err := uniter.UnitStorageAttachments(context.Background(), unit.UnitTag())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(attachments, gc.DeepEquals, []params.StorageAttachmentId{{
 		StorageTag: "storage-data-0",

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -293,7 +293,7 @@ func (s *applicationSuite) TestApplicationDeployToMachine(c *gc.C) {
 	c.Assert(charm.Meta(), gc.DeepEquals, ch.Meta())
 	c.Assert(charm.Config(), gc.DeepEquals, ch.Config())
 
-	errs, err := unitassignerapi.New(s.OpenControllerModelAPI(c)).AssignUnits([]names.UnitTag{names.NewUnitTag("application-name/0")})
+	errs, err := unitassignerapi.New(s.OpenControllerModelAPI(c)).AssignUnits(context.Background(), []names.UnitTag{names.NewUnitTag("application-name/0")})
 	c.Assert(errs, gc.DeepEquals, []error{nil})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -349,7 +349,7 @@ func (s *applicationSuite) TestApplicationDeployToMachineWithLXDProfile(c *gc.C)
 		Devices:     expectedProfile.Devices,
 	})
 
-	errs, err := unitassignerapi.New(s.OpenControllerModelAPI(c)).AssignUnits([]names.UnitTag{names.NewUnitTag("application-name/0")})
+	errs, err := unitassignerapi.New(s.OpenControllerModelAPI(c)).AssignUnits(context.Background(), []names.UnitTag{names.NewUnitTag("application-name/0")})
 	c.Assert(errs, gc.DeepEquals, []error{nil})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -405,7 +405,7 @@ func (s *applicationSuite) TestApplicationDeployToMachineWithInvalidLXDProfileAn
 		Devices:     expectedProfile.Devices,
 	})
 
-	errs, err := unitassignerapi.New(s.OpenControllerModelAPI(c)).AssignUnits([]names.UnitTag{names.NewUnitTag("application-name/0")})
+	errs, err := unitassignerapi.New(s.OpenControllerModelAPI(c)).AssignUnits(context.Background(), []names.UnitTag{names.NewUnitTag("application-name/0")})
 	c.Assert(errs, gc.DeepEquals, []error{nil})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/leadership.go
+++ b/apiserver/leadership.go
@@ -4,6 +4,7 @@
 package apiserver
 
 import (
+	"context"
 	"time"
 
 	"github.com/juju/errors"
@@ -49,7 +50,7 @@ type leadershipClaimer struct {
 }
 
 // ClaimLeadership is part of the leadership.Claimer interface.
-func (m leadershipClaimer) ClaimLeadership(applicationName, unitName string, duration time.Duration) error {
+func (m leadershipClaimer) ClaimLeadership(ctx context.Context, applicationName, unitName string, duration time.Duration) error {
 	err := m.claimer.Claim(applicationName, unitName, duration)
 	if errors.Cause(err) == lease.ErrClaimDenied {
 		return leadership.ErrClaimDenied
@@ -58,7 +59,7 @@ func (m leadershipClaimer) ClaimLeadership(applicationName, unitName string, dur
 }
 
 // BlockUntilLeadershipReleased is part of the leadership.Claimer interface.
-func (m leadershipClaimer) BlockUntilLeadershipReleased(applicationName string, cancel <-chan struct{}) error {
+func (m leadershipClaimer) BlockUntilLeadershipReleased(ctx context.Context, applicationName string, cancel <-chan struct{}) error {
 	err := m.claimer.WaitUntilExpired(applicationName, cancel)
 	if errors.Cause(err) == lease.ErrWaitCancelled {
 		return leadership.ErrBlockCancelled

--- a/cmd/containeragent/unit/manifolds.go
+++ b/cmd/containeragent/unit/manifolds.go
@@ -500,6 +500,6 @@ const (
 
 type noopStatusSetter struct{}
 
-func (noopStatusSetter) SetStatus(setableStatus status.Status, info string, data map[string]any) error {
+func (noopStatusSetter) SetStatus(ctx context.Context, setableStatus status.Status, info string, data map[string]any) error {
 	return nil
 }

--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -1285,7 +1285,7 @@ func (f *fakeDeployAPI) AddCharmWithAuthorization(
 	return results[0].(commoncharm.Origin), jujutesting.TypeAssertError(results[1])
 }
 
-func (f *fakeDeployAPI) CharmInfo(url string) (*apicommoncharms.CharmInfo, error) {
+func (f *fakeDeployAPI) CharmInfo(ctx context.Context, url string) (*apicommoncharms.CharmInfo, error) {
 	results := f.MethodCall(f, "CharmInfo", url)
 	return results[0].(*apicommoncharms.CharmInfo), jujutesting.TypeAssertError(results[1])
 }

--- a/cmd/juju/application/deployer/bundlehandler.go
+++ b/cmd/juju/application/deployer/bundlehandler.go
@@ -820,7 +820,7 @@ func (h *bundleHandler) addApplication(ctx context.Context, change *bundlechange
 		return errors.Trace(err)
 	}
 
-	charmInfo, err := h.deployAPI.CharmInfo(chID.URL)
+	charmInfo, err := h.deployAPI.CharmInfo(ctx, chID.URL)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -1252,7 +1252,7 @@ func (h *bundleHandler) upgradeCharm(ctx context.Context, change *bundlechanges.
 }
 
 func (h *bundleHandler) upgradeCharmResources(ctx context.Context, chID application.CharmID, param bundlechanges.UpgradeCharmParams) (map[string]string, error) {
-	meta, err := utils.GetMetaResources(chID.URL, h.deployAPI)
+	meta, err := utils.GetMetaResources(ctx, chID.URL, h.deployAPI)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -1262,7 +1262,7 @@ func (h *bundleHandler) upgradeCharmResources(ctx context.Context, chID applicat
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	filtered, err := utils.GetUpgradeResources(chID, charms.NewClient(h.deployAPI), resourceLister, param.Application, resMap, meta)
+	filtered, err := utils.GetUpgradeResources(ctx, chID, charms.NewClient(h.deployAPI), resourceLister, param.Application, resMap, meta)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/cmd/juju/application/deployer/bundlehandler_test.go
+++ b/cmd/juju/application/deployer/bundlehandler_test.go
@@ -2384,7 +2384,7 @@ func (m charmInterfaceMatcher) String() string {
 }
 
 func (s *BundleDeployRepositorySuite) expectCharmInfo(name string, info *apicharms.CharmInfo) {
-	s.deployerAPI.EXPECT().CharmInfo(name).Return(info, nil)
+	s.deployerAPI.EXPECT().CharmInfo(gomock.Any(), name).Return(info, nil)
 }
 
 func (s *BundleDeployRepositorySuite) expectDeploy() {

--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -71,7 +71,7 @@ func (d *deployCharm) deploy(
 	deployAPI DeployerAPI,
 ) (rErr error) {
 	id := d.id
-	charmInfo, err := deployAPI.CharmInfo(id.URL)
+	charmInfo, err := deployAPI.CharmInfo(ctx, id.URL)
 	if err != nil {
 		return err
 	}

--- a/cmd/juju/application/deployer/charm_test.go
+++ b/cmd/juju/application/deployer/charm_test.go
@@ -262,7 +262,7 @@ func (s *charmSuite) newDeployCharm() *deployCharm {
 func (s *charmSuite) setupMocks(c *gc.C) *gomock.Controller {
 	ctrl := gomock.NewController(c)
 	s.deployerAPI = mocks.NewMockDeployerAPI(ctrl)
-	s.deployerAPI.EXPECT().CharmInfo(gomock.Any()).Return(s.charmInfo, nil).AnyTimes()
+	s.deployerAPI.EXPECT().CharmInfo(gomock.Any(), gomock.Any()).Return(s.charmInfo, nil).AnyTimes()
 	s.deployerAPI.EXPECT().ModelUUID().Return("dead-beef", true).AnyTimes()
 
 	s.modelCommand = mocks.NewMockModelCommand(ctrl)

--- a/cmd/juju/application/deployer/deployer.go
+++ b/cmd/juju/application/deployer/deployer.go
@@ -129,7 +129,7 @@ func (d *factory) GetDeployer(ctx context.Context, cfg DeployerConfig, deployAPI
 	} else if isLocalSchema(d.charmOrBundle) {
 		// Go for local pre-deployed charm
 		var localPreDeployedCharmErr error
-		if dk, localPreDeployedCharmErr = d.localPreDeployedCharmDeployer(deployAPI); localPreDeployedCharmErr != nil {
+		if dk, localPreDeployedCharmErr = d.localPreDeployedCharmDeployer(ctx, deployAPI); localPreDeployedCharmErr != nil {
 			return nil, errors.Trace(localPreDeployedCharmErr)
 		}
 	} else {
@@ -262,7 +262,7 @@ func (d *factory) localCharmDeployer(getter ModelConfigGetter) (DeployerKind, er
 	return &localCharmDeployerKind{base, imageStream, ch, curl}, nil
 }
 
-func (d *factory) localPreDeployedCharmDeployer(deployAPI CharmDeployAPI) (DeployerKind, error) {
+func (d *factory) localPreDeployedCharmDeployer(ctx context.Context, deployAPI CharmDeployAPI) (DeployerKind, error) {
 	// If the charm's schema is local, we should definitively attempt
 	// to deploy a charm that's already deployed in the
 	// environment.
@@ -274,7 +274,7 @@ func (d *factory) localPreDeployedCharmDeployer(deployAPI CharmDeployAPI) (Deplo
 		return nil, errors.Errorf("cannot interpret as a redeployment of a local charm from the controller")
 	}
 
-	charmInfo, err := deployAPI.CharmInfo(userCharmURL.String())
+	charmInfo, err := deployAPI.CharmInfo(ctx, userCharmURL.String())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/cmd/juju/application/deployer/deployer_test.go
+++ b/cmd/juju/application/deployer/deployer_test.go
@@ -64,7 +64,7 @@ func (s *deployerSuite) TestGetDeployerPredeployedLocalCharm(c *gc.C) {
 	s.expectStat(ch, errors.NotFoundf("file"))
 	cfg.CharmOrBundle = ch
 
-	s.charmDeployAPI.EXPECT().CharmInfo("local:test-charm").Return(&charms.CharmInfo{
+	s.charmDeployAPI.EXPECT().CharmInfo(gomock.Any(), "local:test-charm").Return(&charms.CharmInfo{
 		Meta: &charm.Meta{
 			Name: "wordpress",
 		},

--- a/cmd/juju/application/deployer/interface.go
+++ b/cmd/juju/application/deployer/interface.go
@@ -55,7 +55,7 @@ type ModelAPI interface {
 // command needs for charms.
 type CharmDeployAPI interface {
 	ModelConfigGetter
-	CharmInfo(string) (*apicharms.CharmInfo, error)
+	CharmInfo(context.Context, string) (*apicharms.CharmInfo, error)
 }
 
 // OfferAPI represents the methods of the API the deploy command needs
@@ -88,7 +88,7 @@ type DeployerAPI interface {
 	ListSpaces() ([]apiparams.Space, error)
 	Deploy(application.DeployArgs) error
 	Status(*client.StatusArgs) (*apiparams.FullStatus, error)
-	ListCharmResources(curl string, origin commoncharm.Origin) ([]charmresource.Resource, error)
+	ListCharmResources(ctx context.Context, curl string, origin commoncharm.Origin) ([]charmresource.Resource, error)
 }
 
 type ApplicationAPI interface {

--- a/cmd/juju/application/deployer/mocks/deploy_mock.go
+++ b/cmd/juju/application/deployer/mocks/deploy_mock.go
@@ -403,18 +403,18 @@ func (c *MockDeployerAPIBestFacadeVersionCall) DoAndReturn(f func(string) int) *
 }
 
 // CharmInfo mocks base method.
-func (m *MockDeployerAPI) CharmInfo(arg0 string) (*charms.CharmInfo, error) {
+func (m *MockDeployerAPI) CharmInfo(arg0 context.Context, arg1 string) (*charms.CharmInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CharmInfo", arg0)
+	ret := m.ctrl.Call(m, "CharmInfo", arg0, arg1)
 	ret0, _ := ret[0].(*charms.CharmInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CharmInfo indicates an expected call of CharmInfo.
-func (mr *MockDeployerAPIMockRecorder) CharmInfo(arg0 any) *MockDeployerAPICharmInfoCall {
+func (mr *MockDeployerAPIMockRecorder) CharmInfo(arg0, arg1 any) *MockDeployerAPICharmInfoCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CharmInfo", reflect.TypeOf((*MockDeployerAPI)(nil).CharmInfo), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CharmInfo", reflect.TypeOf((*MockDeployerAPI)(nil).CharmInfo), arg0, arg1)
 	return &MockDeployerAPICharmInfoCall{Call: call}
 }
 
@@ -430,13 +430,13 @@ func (c *MockDeployerAPICharmInfoCall) Return(arg0 *charms.CharmInfo, arg1 error
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockDeployerAPICharmInfoCall) Do(f func(string) (*charms.CharmInfo, error)) *MockDeployerAPICharmInfoCall {
+func (c *MockDeployerAPICharmInfoCall) Do(f func(context.Context, string) (*charms.CharmInfo, error)) *MockDeployerAPICharmInfoCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockDeployerAPICharmInfoCall) DoAndReturn(f func(string) (*charms.CharmInfo, error)) *MockDeployerAPICharmInfoCall {
+func (c *MockDeployerAPICharmInfoCall) DoAndReturn(f func(context.Context, string) (*charms.CharmInfo, error)) *MockDeployerAPICharmInfoCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1038,18 +1038,18 @@ func (c *MockDeployerAPIHTTPClientCall) DoAndReturn(f func() (*httprequest.Clien
 }
 
 // ListCharmResources mocks base method.
-func (m *MockDeployerAPI) ListCharmResources(arg0 string, arg1 charm.Origin) ([]resource.Resource, error) {
+func (m *MockDeployerAPI) ListCharmResources(arg0 context.Context, arg1 string, arg2 charm.Origin) ([]resource.Resource, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListCharmResources", arg0, arg1)
+	ret := m.ctrl.Call(m, "ListCharmResources", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]resource.Resource)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListCharmResources indicates an expected call of ListCharmResources.
-func (mr *MockDeployerAPIMockRecorder) ListCharmResources(arg0, arg1 any) *MockDeployerAPIListCharmResourcesCall {
+func (mr *MockDeployerAPIMockRecorder) ListCharmResources(arg0, arg1, arg2 any) *MockDeployerAPIListCharmResourcesCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCharmResources", reflect.TypeOf((*MockDeployerAPI)(nil).ListCharmResources), arg0, arg1)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCharmResources", reflect.TypeOf((*MockDeployerAPI)(nil).ListCharmResources), arg0, arg1, arg2)
 	return &MockDeployerAPIListCharmResourcesCall{Call: call}
 }
 
@@ -1065,13 +1065,13 @@ func (c *MockDeployerAPIListCharmResourcesCall) Return(arg0 []resource.Resource,
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockDeployerAPIListCharmResourcesCall) Do(f func(string, charm.Origin) ([]resource.Resource, error)) *MockDeployerAPIListCharmResourcesCall {
+func (c *MockDeployerAPIListCharmResourcesCall) Do(f func(context.Context, string, charm.Origin) ([]resource.Resource, error)) *MockDeployerAPIListCharmResourcesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockDeployerAPIListCharmResourcesCall) DoAndReturn(f func(string, charm.Origin) ([]resource.Resource, error)) *MockDeployerAPIListCharmResourcesCall {
+func (c *MockDeployerAPIListCharmResourcesCall) DoAndReturn(f func(context.Context, string, charm.Origin) ([]resource.Resource, error)) *MockDeployerAPIListCharmResourcesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/cmd/juju/application/deployer/mocks/deployer_mock.go
+++ b/cmd/juju/application/deployer/mocks/deployer_mock.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	httpbakery "github.com/go-macaroon-bakery/macaroon-bakery/v3/httpbakery"
@@ -402,18 +403,18 @@ func (m *MockCharmDeployAPI) EXPECT() *MockCharmDeployAPIMockRecorder {
 }
 
 // CharmInfo mocks base method.
-func (m *MockCharmDeployAPI) CharmInfo(arg0 string) (*charms.CharmInfo, error) {
+func (m *MockCharmDeployAPI) CharmInfo(arg0 context.Context, arg1 string) (*charms.CharmInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CharmInfo", arg0)
+	ret := m.ctrl.Call(m, "CharmInfo", arg0, arg1)
 	ret0, _ := ret[0].(*charms.CharmInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CharmInfo indicates an expected call of CharmInfo.
-func (mr *MockCharmDeployAPIMockRecorder) CharmInfo(arg0 any) *MockCharmDeployAPICharmInfoCall {
+func (mr *MockCharmDeployAPIMockRecorder) CharmInfo(arg0, arg1 any) *MockCharmDeployAPICharmInfoCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CharmInfo", reflect.TypeOf((*MockCharmDeployAPI)(nil).CharmInfo), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CharmInfo", reflect.TypeOf((*MockCharmDeployAPI)(nil).CharmInfo), arg0, arg1)
 	return &MockCharmDeployAPICharmInfoCall{Call: call}
 }
 
@@ -429,13 +430,13 @@ func (c *MockCharmDeployAPICharmInfoCall) Return(arg0 *charms.CharmInfo, arg1 er
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockCharmDeployAPICharmInfoCall) Do(f func(string) (*charms.CharmInfo, error)) *MockCharmDeployAPICharmInfoCall {
+func (c *MockCharmDeployAPICharmInfoCall) Do(f func(context.Context, string) (*charms.CharmInfo, error)) *MockCharmDeployAPICharmInfoCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockCharmDeployAPICharmInfoCall) DoAndReturn(f func(string) (*charms.CharmInfo, error)) *MockCharmDeployAPICharmInfoCall {
+func (c *MockCharmDeployAPICharmInfoCall) DoAndReturn(f func(context.Context, string) (*charms.CharmInfo, error)) *MockCharmDeployAPICharmInfoCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/cmd/juju/application/refresh.go
+++ b/cmd/juju/application/refresh.go
@@ -477,7 +477,7 @@ func (c *refreshCommand) Run(ctx *cmd.Context) error {
 
 	// Print out the updated endpoint binding plan.
 	charmsClient := c.NewCharmClient(apiRoot)
-	charmInfo, err := charmsClient.CharmInfo(curl.String())
+	charmInfo, err := charmsClient.CharmInfo(ctx, curl.String())
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -579,11 +579,12 @@ func (c *refreshCommand) upgradeResources(
 		return nil, errors.Trace(err)
 	}
 	charmsClient := c.NewCharmClient(apiRoot)
-	meta, err := utils.GetMetaResources(chID.URL, charmsClient)
+	meta, err := utils.GetMetaResources(ctx, chID.URL, charmsClient)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	filtered, err := utils.GetUpgradeResources(
+		ctx,
 		chID,
 		charmsClient,
 		resourceLister,

--- a/cmd/juju/application/refresh_test.go
+++ b/cmd/juju/application/refresh_test.go
@@ -1155,7 +1155,7 @@ type mockCharmClient struct {
 	charmResources []charmresource.Resource
 }
 
-func (m *mockCharmClient) CharmInfo(curl string) (*apicommoncharms.CharmInfo, error) {
+func (m *mockCharmClient) CharmInfo(ctx context.Context, curl string) (*apicommoncharms.CharmInfo, error) {
 	m.MethodCall(m, "CharmInfo", curl)
 	if err := m.NextErr(); err != nil {
 		return nil, err
@@ -1163,7 +1163,7 @@ func (m *mockCharmClient) CharmInfo(curl string) (*apicommoncharms.CharmInfo, er
 	return m.charmInfo, nil
 }
 
-func (m *mockCharmClient) ListCharmResources(curl string, origin commoncharm.Origin) ([]charmresource.Resource, error) {
+func (m *mockCharmClient) ListCharmResources(ctx context.Context, curl string, origin commoncharm.Origin) ([]charmresource.Resource, error) {
 	m.MethodCall(m, "ListCharmResources", curl, origin)
 	if err := m.NextErr(); err != nil {
 		return nil, err

--- a/cmd/juju/application/utils/interface.go
+++ b/cmd/juju/application/utils/interface.go
@@ -4,6 +4,8 @@
 package utils
 
 import (
+	"context"
+
 	apicharm "github.com/juju/juju/api/common/charm"
 	"github.com/juju/juju/api/common/charms"
 	"github.com/juju/juju/core/resources"
@@ -16,8 +18,8 @@ import (
 // CharmClient defines a subset of the charms facade, as required
 // by the upgrade-charm command and to GetMetaResources.
 type CharmClient interface {
-	CharmInfo(string) (*charms.CharmInfo, error)
-	ListCharmResources(curl string, origin apicharm.Origin) ([]charmresource.Resource, error)
+	CharmInfo(context.Context, string) (*charms.CharmInfo, error)
+	ListCharmResources(ctx context.Context, curl string, origin apicharm.Origin) ([]charmresource.Resource, error)
 }
 
 // ResourceLister defines a subset of the resources facade, as required

--- a/cmd/juju/application/utils/mocks/charmresource_mock.go
+++ b/cmd/juju/application/utils/mocks/charmresource_mock.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	charm "github.com/juju/juju/api/common/charm"
@@ -42,18 +43,18 @@ func (m *MockCharmClient) EXPECT() *MockCharmClientMockRecorder {
 }
 
 // CharmInfo mocks base method.
-func (m *MockCharmClient) CharmInfo(arg0 string) (*charms.CharmInfo, error) {
+func (m *MockCharmClient) CharmInfo(arg0 context.Context, arg1 string) (*charms.CharmInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CharmInfo", arg0)
+	ret := m.ctrl.Call(m, "CharmInfo", arg0, arg1)
 	ret0, _ := ret[0].(*charms.CharmInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CharmInfo indicates an expected call of CharmInfo.
-func (mr *MockCharmClientMockRecorder) CharmInfo(arg0 any) *MockCharmClientCharmInfoCall {
+func (mr *MockCharmClientMockRecorder) CharmInfo(arg0, arg1 any) *MockCharmClientCharmInfoCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CharmInfo", reflect.TypeOf((*MockCharmClient)(nil).CharmInfo), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CharmInfo", reflect.TypeOf((*MockCharmClient)(nil).CharmInfo), arg0, arg1)
 	return &MockCharmClientCharmInfoCall{Call: call}
 }
 
@@ -69,30 +70,30 @@ func (c *MockCharmClientCharmInfoCall) Return(arg0 *charms.CharmInfo, arg1 error
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockCharmClientCharmInfoCall) Do(f func(string) (*charms.CharmInfo, error)) *MockCharmClientCharmInfoCall {
+func (c *MockCharmClientCharmInfoCall) Do(f func(context.Context, string) (*charms.CharmInfo, error)) *MockCharmClientCharmInfoCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockCharmClientCharmInfoCall) DoAndReturn(f func(string) (*charms.CharmInfo, error)) *MockCharmClientCharmInfoCall {
+func (c *MockCharmClientCharmInfoCall) DoAndReturn(f func(context.Context, string) (*charms.CharmInfo, error)) *MockCharmClientCharmInfoCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // ListCharmResources mocks base method.
-func (m *MockCharmClient) ListCharmResources(arg0 string, arg1 charm.Origin) ([]resource.Resource, error) {
+func (m *MockCharmClient) ListCharmResources(arg0 context.Context, arg1 string, arg2 charm.Origin) ([]resource.Resource, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListCharmResources", arg0, arg1)
+	ret := m.ctrl.Call(m, "ListCharmResources", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]resource.Resource)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListCharmResources indicates an expected call of ListCharmResources.
-func (mr *MockCharmClientMockRecorder) ListCharmResources(arg0, arg1 any) *MockCharmClientListCharmResourcesCall {
+func (mr *MockCharmClientMockRecorder) ListCharmResources(arg0, arg1, arg2 any) *MockCharmClientListCharmResourcesCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCharmResources", reflect.TypeOf((*MockCharmClient)(nil).ListCharmResources), arg0, arg1)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCharmResources", reflect.TypeOf((*MockCharmClient)(nil).ListCharmResources), arg0, arg1, arg2)
 	return &MockCharmClientListCharmResourcesCall{Call: call}
 }
 
@@ -108,13 +109,13 @@ func (c *MockCharmClientListCharmResourcesCall) Return(arg0 []resource.Resource,
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockCharmClientListCharmResourcesCall) Do(f func(string, charm.Origin) ([]resource.Resource, error)) *MockCharmClientListCharmResourcesCall {
+func (c *MockCharmClientListCharmResourcesCall) Do(f func(context.Context, string, charm.Origin) ([]resource.Resource, error)) *MockCharmClientListCharmResourcesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockCharmClientListCharmResourcesCall) DoAndReturn(f func(string, charm.Origin) ([]resource.Resource, error)) *MockCharmClientListCharmResourcesCall {
+func (c *MockCharmClientListCharmResourcesCall) DoAndReturn(f func(context.Context, string, charm.Origin) ([]resource.Resource, error)) *MockCharmClientListCharmResourcesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/cmd/juju/application/utils/utils.go
+++ b/cmd/juju/application/utils/utils.go
@@ -4,6 +4,7 @@
 package utils
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -30,8 +31,8 @@ var logger = internallogger.GetLogger("juju.cmd.juju.application.utils")
 
 // GetMetaResources retrieves metadata resources for the given
 // charmURL.
-func GetMetaResources(charmURL string, client CharmClient) (map[string]charmresource.Meta, error) {
-	charmInfo, err := client.CharmInfo(charmURL)
+func GetMetaResources(ctx context.Context, charmURL string, client CharmClient) (map[string]charmresource.Meta, error) {
+	charmInfo, err := client.CharmInfo(ctx, charmURL)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -79,6 +80,7 @@ func flagWithMinus(name string) string {
 // GetUpgradeResources returns a map of resources which require
 // refresh.
 func GetUpgradeResources(
+	ctx context.Context,
 	newCharmID application.CharmID,
 	repositoryResourceLister CharmClient,
 	resourceLister ResourceLister,
@@ -89,7 +91,7 @@ func GetUpgradeResources(
 	if len(meta) == 0 {
 		return nil, nil
 	}
-	available, err := getAvailableRepositoryResources(newCharmID, repositoryResourceLister)
+	available, err := getAvailableRepositoryResources(ctx, newCharmID, repositoryResourceLister)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -115,12 +117,12 @@ func getCurrentResources(
 
 // getAvailableRepositoryResources gets the current resources for this
 // charm available in the repository.
-func getAvailableRepositoryResources(newCharmID application.CharmID, repositoryResourceLister CharmClient) (map[string]charmresource.Resource, error) {
+func getAvailableRepositoryResources(ctx context.Context, newCharmID application.CharmID, repositoryResourceLister CharmClient) (map[string]charmresource.Resource, error) {
 	if repositoryResourceLister == nil || !corecharm.CharmHub.Matches(newCharmID.Origin.Source.String()) {
 		// not required for local charms
 		return nil, nil
 	}
-	available, err := repositoryResourceLister.ListCharmResources(newCharmID.URL, newCharmID.Origin)
+	available, err := repositoryResourceLister.ListCharmResources(ctx, newCharmID.URL, newCharmID.Origin)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/cmd/juju/commands/helptool.go
+++ b/cmd/juju/commands/helptool.go
@@ -29,7 +29,7 @@ func (dummyHookContext) AddMetrics(_, _ string, _ time.Time) error {
 func (dummyHookContext) UnitName() string {
 	return ""
 }
-func (dummyHookContext) PublicAddress() (string, error) {
+func (dummyHookContext) PublicAddress(context.Context) (string, error) {
 	return "", errors.NotFoundf("PublicAddress")
 }
 func (dummyHookContext) PrivateAddress() (string, error) {
@@ -47,7 +47,7 @@ func (dummyHookContext) ClosePort(protocol string, port int) error {
 func (dummyHookContext) OpenedPorts() []network.PortRange {
 	return nil
 }
-func (dummyHookContext) ConfigSettings() (charm.Settings, error) {
+func (dummyHookContext) ConfigSettings(ctx context.Context) (charm.Settings, error) {
 	return charm.NewConfig().DefaultSettings(), nil
 }
 func (dummyHookContext) HookRelation() (jujuc.ContextRelation, error) {
@@ -74,7 +74,7 @@ func (dummyHookContext) HookStorageInstance() (*storage.StorageInstance, error) 
 	return nil, errors.NotFoundf("HookStorageInstance")
 }
 
-func (dummyHookContext) HookStorage() (jujuc.ContextStorageAttachment, error) {
+func (dummyHookContext) HookStorage(context.Context) (jujuc.ContextStorageAttachment, error) {
 	return nil, errors.NotFoundf("HookStorage")
 }
 

--- a/cmd/juju/resource/stub_test.go
+++ b/cmd/juju/resource/stub_test.go
@@ -21,7 +21,7 @@ type stubCharmStore struct {
 	ReturnListResources [][]charmresource.Resource
 }
 
-func (s *stubCharmStore) ListResources(charms []jujuresource.CharmID) ([][]charmresource.Resource, error) {
+func (s *stubCharmStore) ListResources(ctx context.Context, charms []jujuresource.CharmID) ([][]charmresource.Resource, error) {
 	s.stub.AddCall("ListResources", charms)
 	if err := s.stub.NextErr(); err != nil {
 		return nil, errors.Trace(err)

--- a/cmd/juju/ssh/debugcode_test.go
+++ b/cmd/juju/ssh/debugcode_test.go
@@ -36,7 +36,7 @@ func (s *DebugCodeSuite) TestArgFormatting(c *gc.C) {
 
 	charmAPI := mocks.NewMockCharmAPI(ctrl)
 	chInfo := &charms.CharmInfo{Meta: &meta, Actions: &actions}
-	charmAPI.EXPECT().CharmInfo("ch:mysql").Return(chInfo, nil)
+	charmAPI.EXPECT().CharmInfo(gomock.Any(), "ch:mysql").Return(chInfo, nil)
 	charmAPI.EXPECT().Close().Return(nil)
 
 	s.setHostChecker(validAddresses("0.public"))

--- a/cmd/juju/ssh/debughooks.go
+++ b/cmd/juju/ssh/debughooks.go
@@ -4,6 +4,7 @@
 package ssh
 
 import (
+	"context"
 	"encoding/base64"
 	"fmt"
 	"strings"
@@ -149,7 +150,7 @@ func (c *debugHooksCommand) closeAPIs() {
 	}
 }
 
-func (c *debugHooksCommand) validateHooksOrActions() error {
+func (c *debugHooksCommand) validateHooksOrActions(ctx context.Context) error {
 	if len(c.hooks) == 0 {
 		return nil
 	}
@@ -177,7 +178,7 @@ func (c *debugHooksCommand) validateHooksOrActions() error {
 		return err
 	}
 
-	charmInfo, err := c.charmAPI.CharmInfo(curl.String())
+	charmInfo, err := c.charmAPI.CharmInfo(ctx, curl.String())
 	if err != nil {
 		return err
 	}
@@ -241,7 +242,7 @@ func (c *debugHooksCommand) commonRun(
 	hooks []string,
 	debugAt string,
 ) (err error) {
-	err = c.validateHooksOrActions()
+	err = c.validateHooksOrActions(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/juju/ssh/debughooks_test.go
+++ b/cmd/juju/ssh/debughooks_test.go
@@ -151,7 +151,7 @@ func (s *DebugHooksSuite) TestDebugHooksCommand(c *gc.C) {
 
 		charmAPI := mocks.NewMockCharmAPI(ctrl)
 		chInfo := &charms.CharmInfo{Meta: &meta, Actions: &actions}
-		charmAPI.EXPECT().CharmInfo("ch:mysql").Return(chInfo, nil)
+		charmAPI.EXPECT().CharmInfo(gomock.Any(), "ch:mysql").Return(chInfo, nil)
 		charmAPI.EXPECT().Close().Return(nil)
 
 		hooksCmd := NewDebugHooksCommandForTest(app, ssh, status, charmAPI, t.hostChecker, baseTestingRetryStrategy, baseTestingRetryStrategy)
@@ -177,7 +177,7 @@ func (s *DebugHooksSuite) TestDebugHooksArgFormatting(c *gc.C) {
 
 	charmAPI := mocks.NewMockCharmAPI(ctrl)
 	chInfo := &charms.CharmInfo{Meta: &meta, Actions: &actions}
-	charmAPI.EXPECT().CharmInfo("ch:mysql").Return(chInfo, nil)
+	charmAPI.EXPECT().CharmInfo(gomock.Any(), "ch:mysql").Return(chInfo, nil)
 	charmAPI.EXPECT().Close().Return(nil)
 
 	s.setHostChecker(validAddresses("0.public"))

--- a/cmd/juju/ssh/export_test.go
+++ b/cmd/juju/ssh/export_test.go
@@ -37,8 +37,8 @@ func (c *sshContainer) CleanupRun() {
 	c.cleanupRun()
 }
 
-func (c *sshContainer) ResolveTarget(target string) (*resolvedTarget, error) {
-	return c.resolveTarget(target)
+func (c *sshContainer) ResolveTarget(ctx context.Context, target string) (*resolvedTarget, error) {
+	return c.resolveTarget(ctx, target)
 }
 
 func (c *sshContainer) SSH(ctx Context, enablePty bool, target *resolvedTarget) error {
@@ -71,7 +71,7 @@ func (c *sshContainer) Namespace() string {
 
 type SSHContainerInterfaceForTest interface {
 	CleanupRun()
-	ResolveTarget(string) (*resolvedTarget, error)
+	ResolveTarget(context.Context, string) (*resolvedTarget, error)
 	SSH(Context, bool, *resolvedTarget) error
 	Copy(ctx Context) error
 	GetExecClient() (k8sexec.Executor, error)

--- a/cmd/juju/ssh/interface.go
+++ b/cmd/juju/ssh/interface.go
@@ -43,7 +43,7 @@ type ApplicationAPI interface {
 
 // CharmAPI defines charm related APIs.
 type CharmAPI interface {
-	CharmInfo(charmURL string) (*charms.CharmInfo, error)
+	CharmInfo(ctx context.Context, charmURL string) (*charms.CharmInfo, error)
 	Close() error
 }
 

--- a/cmd/juju/ssh/mocks/package_mock.go
+++ b/cmd/juju/ssh/mocks/package_mock.go
@@ -1330,18 +1330,18 @@ func (m *MockCharmAPI) EXPECT() *MockCharmAPIMockRecorder {
 }
 
 // CharmInfo mocks base method.
-func (m *MockCharmAPI) CharmInfo(arg0 string) (*charms.CharmInfo, error) {
+func (m *MockCharmAPI) CharmInfo(arg0 context.Context, arg1 string) (*charms.CharmInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CharmInfo", arg0)
+	ret := m.ctrl.Call(m, "CharmInfo", arg0, arg1)
 	ret0, _ := ret[0].(*charms.CharmInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CharmInfo indicates an expected call of CharmInfo.
-func (mr *MockCharmAPIMockRecorder) CharmInfo(arg0 any) *MockCharmAPICharmInfoCall {
+func (mr *MockCharmAPIMockRecorder) CharmInfo(arg0, arg1 any) *MockCharmAPICharmInfoCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CharmInfo", reflect.TypeOf((*MockCharmAPI)(nil).CharmInfo), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CharmInfo", reflect.TypeOf((*MockCharmAPI)(nil).CharmInfo), arg0, arg1)
 	return &MockCharmAPICharmInfoCall{Call: call}
 }
 
@@ -1357,13 +1357,13 @@ func (c *MockCharmAPICharmInfoCall) Return(arg0 *charms.CharmInfo, arg1 error) *
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockCharmAPICharmInfoCall) Do(f func(string) (*charms.CharmInfo, error)) *MockCharmAPICharmInfoCall {
+func (c *MockCharmAPICharmInfoCall) Do(f func(context.Context, string) (*charms.CharmInfo, error)) *MockCharmAPICharmInfoCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockCharmAPICharmInfoCall) DoAndReturn(f func(string) (*charms.CharmInfo, error)) *MockCharmAPICharmInfoCall {
+func (c *MockCharmAPICharmInfoCall) DoAndReturn(f func(context.Context, string) (*charms.CharmInfo, error)) *MockCharmAPICharmInfoCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/cmd/juju/ssh/ssh.go
+++ b/cmd/juju/ssh/ssh.go
@@ -239,7 +239,7 @@ type sshProvider interface {
 	cleanupRun()
 	setLeaderAPI(leaderAPI LeaderAPI)
 	setHostChecker(checker jujussh.ReachableChecker)
-	resolveTarget(string) (*resolvedTarget, error)
+	resolveTarget(context.Context, string) (*resolvedTarget, error)
 	maybePopulateTargetViaField(*resolvedTarget, func(*client.StatusArgs) (*params.FullStatus, error)) error
 	maybeResolveLeaderUnit(string) (string, error)
 	ssh(ctx Context, enablePty bool, target *resolvedTarget) error
@@ -263,7 +263,7 @@ func (c *sshCommand) Run(ctx *cmd.Context) error {
 	}
 	defer c.provider.cleanupRun()
 
-	target, err := c.provider.resolveTarget(c.provider.getTarget())
+	target, err := c.provider.resolveTarget(ctx, c.provider.getTarget())
 	if err != nil {
 		return err
 	}

--- a/cmd/juju/ssh/ssh_container_test.go
+++ b/cmd/juju/ssh/ssh_container_test.go
@@ -116,12 +116,12 @@ func (s *sshContainerSuite) TestResolveTargetForWorkloadPod(c *gc.C) {
 			Return([]application.UnitInfo{
 				{ProviderId: "mariadb-k8s-0", Charm: "test-charm-url"},
 			}, nil),
-		s.charmAPI.EXPECT().CharmInfo("test-charm-url").
+		s.charmAPI.EXPECT().CharmInfo(gomock.Any(), "test-charm-url").
 			Return(&charms.CharmInfo{
 				Meta: &charm.Meta{},
 			}, nil),
 	)
-	target, err := s.sshC.ResolveTarget("mariadb-k8s/0")
+	target, err := s.sshC.ResolveTarget(context.Background(), "mariadb-k8s/0")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(target.GetEntity(), gc.DeepEquals, "mariadb-k8s-0")
 }
@@ -131,7 +131,7 @@ func (s *sshContainerSuite) TestResolveTargetForController(c *gc.C) {
 	ctrl := s.setUpController(c, "")
 	defer ctrl.Finish()
 
-	target, err := s.sshC.ResolveTarget("0")
+	target, err := s.sshC.ResolveTarget(context.Background(), "0")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(target.GetEntity(), gc.DeepEquals, "controller-0")
 }
@@ -141,7 +141,7 @@ func (s *sshContainerSuite) TestResolveTargetForControllerInvalidTarget(c *gc.C)
 	ctrl := s.setUpController(c, "")
 	defer ctrl.Finish()
 
-	_, err := s.sshC.ResolveTarget("1")
+	_, err := s.sshC.ResolveTarget(context.Background(), "1")
 	c.Assert(err, gc.ErrorMatches, `target "1" not found`)
 }
 
@@ -154,7 +154,7 @@ func (s *sshContainerSuite) TestResolveTargetForSidecarCharm(c *gc.C) {
 			Return([]application.UnitInfo{
 				{ProviderId: "mariadb-k8s-0", Charm: "test-charm-url"},
 			}, nil),
-		s.charmAPI.EXPECT().CharmInfo("test-charm-url").
+		s.charmAPI.EXPECT().CharmInfo(gomock.Any(), "test-charm-url").
 			Return(&charms.CharmInfo{
 				Manifest: &charm.Manifest{
 					Bases: []charm.Base{{
@@ -168,7 +168,7 @@ func (s *sshContainerSuite) TestResolveTargetForSidecarCharm(c *gc.C) {
 				Meta: &charm.Meta{},
 			}, nil),
 	)
-	target, err := s.sshC.ResolveTarget("mariadb-k8s/0")
+	target, err := s.sshC.ResolveTarget(context.Background(), "mariadb-k8s/0")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(target.GetEntity(), gc.DeepEquals, "mariadb-k8s-0")
 }
@@ -182,7 +182,7 @@ func (s *sshContainerSuite) TestResolveCharmTargetForSidecarCharm(c *gc.C) {
 			Return([]application.UnitInfo{
 				{ProviderId: "mariadb-k8s-0", Charm: "test-charm-url"},
 			}, nil),
-		s.charmAPI.EXPECT().CharmInfo("test-charm-url").
+		s.charmAPI.EXPECT().CharmInfo(gomock.Any(), "test-charm-url").
 			Return(&charms.CharmInfo{
 				Manifest: &charm.Manifest{
 					Bases: []charm.Base{{
@@ -196,7 +196,7 @@ func (s *sshContainerSuite) TestResolveCharmTargetForSidecarCharm(c *gc.C) {
 				Meta: &charm.Meta{},
 			}, nil),
 	)
-	target, err := s.sshC.ResolveTarget("mariadb-k8s/0")
+	target, err := s.sshC.ResolveTarget(context.Background(), "mariadb-k8s/0")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(target.GetEntity(), gc.DeepEquals, "mariadb-k8s-0")
 }
@@ -210,7 +210,7 @@ func (s *sshContainerSuite) TestResolveTargetForSidecarCharmWithContainer(c *gc.
 			Return([]application.UnitInfo{
 				{ProviderId: "mariadb-k8s-0", Charm: "test-charm-url"},
 			}, nil),
-		s.charmAPI.EXPECT().CharmInfo("test-charm-url").
+		s.charmAPI.EXPECT().CharmInfo(gomock.Any(), "test-charm-url").
 			Return(&charms.CharmInfo{
 				Meta: &charm.Meta{
 					Containers: map[string]charm.Container{
@@ -228,7 +228,7 @@ func (s *sshContainerSuite) TestResolveTargetForSidecarCharmWithContainer(c *gc.
 				},
 			}, nil),
 	)
-	target, err := s.sshC.ResolveTarget("mariadb-k8s/0")
+	target, err := s.sshC.ResolveTarget(context.Background(), "mariadb-k8s/0")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(target.GetEntity(), gc.DeepEquals, "mariadb-k8s-0")
 }
@@ -242,7 +242,7 @@ func (s *sshContainerSuite) TestResolveTargetForSidecarCharmWithContainerMissing
 			Return([]application.UnitInfo{
 				{ProviderId: "mariadb-k8s-0", Charm: "test-charm-url"},
 			}, nil),
-		s.charmAPI.EXPECT().CharmInfo("test-charm-url").
+		s.charmAPI.EXPECT().CharmInfo(gomock.Any(), "test-charm-url").
 			Return(&charms.CharmInfo{
 				Meta: &charm.Meta{
 					Containers: map[string]charm.Container{
@@ -260,7 +260,7 @@ func (s *sshContainerSuite) TestResolveTargetForSidecarCharmWithContainerMissing
 				},
 			}, nil),
 	)
-	_, err := s.sshC.ResolveTarget("mariadb-k8s/0")
+	_, err := s.sshC.ResolveTarget(context.Background(), "mariadb-k8s/0")
 	c.Assert(err, gc.ErrorMatches, `container "bad-test-container" must be one of charm, test-container`)
 }
 
@@ -273,12 +273,12 @@ func (s *sshContainerSuite) TestResolveTargetForWorkloadPodNoProviderID(c *gc.C)
 			Return([]application.UnitInfo{
 				{ProviderId: "", Charm: "test-charm-url"},
 			}, nil),
-		s.charmAPI.EXPECT().CharmInfo("test-charm-url").
+		s.charmAPI.EXPECT().CharmInfo(gomock.Any(), "test-charm-url").
 			Return(&charms.CharmInfo{
 				Meta: &charm.Meta{},
 			}, nil),
 	)
-	_, err := s.sshC.ResolveTarget("mariadb-k8s/0")
+	_, err := s.sshC.ResolveTarget(context.Background(), "mariadb-k8s/0")
 	c.Assert(err, gc.ErrorMatches, `container for unit "mariadb-k8s/0" is not ready yet`)
 }
 
@@ -486,7 +486,7 @@ func (s *sshContainerSuite) TestCopyFromWorkloadPod(c *gc.C) {
 			Return([]application.UnitInfo{
 				{ProviderId: "mariadb-k8s-0", Charm: "test-charm-url"},
 			}, nil),
-		s.charmAPI.EXPECT().CharmInfo("test-charm-url").
+		s.charmAPI.EXPECT().CharmInfo(gomock.Any(), "test-charm-url").
 			Return(&charms.CharmInfo{
 				Meta: &charm.Meta{},
 			}, nil),
@@ -516,7 +516,7 @@ func (s *sshContainerSuite) TestCopyToWorkloadPod(c *gc.C) {
 			Return([]application.UnitInfo{
 				{ProviderId: "mariadb-k8s-0", Charm: "test-charm-url"},
 			}, nil),
-		s.charmAPI.EXPECT().CharmInfo("test-charm-url").
+		s.charmAPI.EXPECT().CharmInfo(gomock.Any(), "test-charm-url").
 			Return(&charms.CharmInfo{
 				Meta: &charm.Meta{},
 			}, nil),
@@ -546,7 +546,7 @@ func (s *sshContainerSuite) TestCopyToWorkloadPodWithContainerSpecified(c *gc.C)
 			Return([]application.UnitInfo{
 				{ProviderId: "mariadb-k8s-0", Charm: "test-charm-url"},
 			}, nil),
-		s.charmAPI.EXPECT().CharmInfo("test-charm-url").
+		s.charmAPI.EXPECT().CharmInfo(gomock.Any(), "test-charm-url").
 			Return(&charms.CharmInfo{
 				Meta: &charm.Meta{
 					Containers: map[string]charm.Container{

--- a/cmd/juju/ssh/ssh_machine.go
+++ b/cmd/juju/ssh/ssh_machine.go
@@ -227,8 +227,8 @@ func (c *sshMachine) ssh(ctx Context, enablePty bool, target *resolvedTarget) er
 	return cmd.Run()
 }
 
-func (c *sshMachine) copy(_ Context) error {
-	args, targets, err := c.expandSCPArgs(c.getArgs())
+func (c *sshMachine) copy(ctx Context) error {
+	args, targets, err := c.expandSCPArgs(ctx, c.getArgs())
 	if err != nil {
 		return err
 	}
@@ -256,7 +256,7 @@ func (c *sshMachine) copy(_ Context) error {
 // 0:some/path or application/0:some/path, and translates them into
 // ubuntu@machine:some/path so they can be passed as arguments to scp, and pass
 // the rest verbatim on to scp
-func (c *sshMachine) expandSCPArgs(args []string) ([]string, []*resolvedTarget, error) {
+func (c *sshMachine) expandSCPArgs(ctx context.Context, args []string) ([]string, []*resolvedTarget, error) {
 	outArgs := make([]string, len(args))
 	var targets []*resolvedTarget
 	for i, arg := range args {
@@ -267,7 +267,7 @@ func (c *sshMachine) expandSCPArgs(args []string) ([]string, []*resolvedTarget, 
 			continue
 		}
 
-		target, err := c.resolveTarget(v[0])
+		target, err := c.resolveTarget(ctx, v[0])
 		if err != nil {
 			return nil, nil, err
 		}
@@ -415,7 +415,7 @@ func (c *sshMachine) ensureAPIClient(mc ModelCommand) error {
 	return nil
 }
 
-func (c *sshMachine) resolveTarget(target string) (*resolvedTarget, error) {
+func (c *sshMachine) resolveTarget(ctx context.Context, target string) (*resolvedTarget, error) {
 	// If the user specified a leader unit, try to resolve it to the
 	// appropriate unit name and override the requested target name.
 	resolvedTargetName, err := c.maybeResolveLeaderUnit(target)

--- a/cmd/jujud-controller/agent/machine.go
+++ b/cmd/jujud-controller/agent/machine.go
@@ -4,6 +4,7 @@
 package agent
 
 import (
+	"context"
 	stdcontext "context"
 	"fmt"
 	"net/http"
@@ -801,7 +802,7 @@ func (a *MachineAgent) machineStartup(ctx stdcontext.Context, apiConn api.Connec
 type noopStatusSetter struct{}
 
 // SetStatus implements upgradesteps.StatusSetter
-func (a *noopStatusSetter) SetStatus(_ status.Status, _ string, _ map[string]interface{}) error {
+func (a *noopStatusSetter) SetStatus(_ context.Context, _ status.Status, _ string, _ map[string]interface{}) error {
 	return nil
 }
 
@@ -834,7 +835,7 @@ func (a *MachineAgent) recordAgentStartInformation(ctx stdcontext.Context, apiCo
 		return errors.Annotatef(err, "cannot load machine %s from state", a.CurrentConfig().Tag())
 	}
 
-	if err := m.RecordAgentStartInformation(hostname); err != nil {
+	if err := m.RecordAgentStartInformation(ctx, hostname); err != nil {
 		return errors.Annotate(err, "cannot record agent start information")
 	}
 	return nil
@@ -887,12 +888,12 @@ func (a *MachineAgent) setupContainerSupport(ctx stdcontext.Context, st api.Conn
 	logger.Debugf("Supported container types %q", supportedContainers)
 
 	if len(supportedContainers) == 0 {
-		if err := m.SupportsNoContainers(); err != nil {
+		if err := m.SupportsNoContainers(ctx); err != nil {
 			return errors.Annotatef(err, "clearing supported supportedContainers for %s", mTag)
 		}
 		return nil
 	}
-	err = m.SetSupportedContainers(supportedContainers...)
+	err = m.SetSupportedContainers(ctx, supportedContainers...)
 	if err != nil {
 		return errors.Annotatef(err, "setting supported supportedContainers for %s", mTag)
 	}

--- a/cmd/jujud/agent/machine.go
+++ b/cmd/jujud/agent/machine.go
@@ -4,6 +4,7 @@
 package agent
 
 import (
+	"context"
 	stdcontext "context"
 	"net/http"
 	"os"
@@ -676,7 +677,7 @@ func (a *MachineAgent) machineStartup(ctx stdcontext.Context, apiConn api.Connec
 type noopStatusSetter struct{}
 
 // SetStatus implements upgradesteps.StatusSetter
-func (a *noopStatusSetter) SetStatus(_ status.Status, _ string, _ map[string]interface{}) error {
+func (a *noopStatusSetter) SetStatus(_ context.Context, _ status.Status, _ string, _ map[string]interface{}) error {
 	return nil
 }
 
@@ -709,7 +710,7 @@ func (a *MachineAgent) recordAgentStartInformation(ctx stdcontext.Context, apiCo
 		return errors.Annotatef(err, "cannot load machine %s from state", a.CurrentConfig().Tag())
 	}
 
-	if err := m.RecordAgentStartInformation(hostname); err != nil {
+	if err := m.RecordAgentStartInformation(ctx, hostname); err != nil {
 		return errors.Annotate(err, "cannot record agent start information")
 	}
 	return nil
@@ -762,12 +763,12 @@ func (a *MachineAgent) setupContainerSupport(ctx stdcontext.Context, st api.Conn
 	logger.Debugf("Supported container types %q", supportedContainers)
 
 	if len(supportedContainers) == 0 {
-		if err := m.SupportsNoContainers(); err != nil {
+		if err := m.SupportsNoContainers(ctx); err != nil {
 			return errors.Annotatef(err, "clearing supported supportedContainers for %s", mTag)
 		}
 		return nil
 	}
-	err = m.SetSupportedContainers(supportedContainers...)
+	err = m.SetSupportedContainers(ctx, supportedContainers...)
 	if err != nil {
 		return errors.Annotatef(err, "setting supported supportedContainers for %s", mTag)
 	}

--- a/core/leadership/interface.go
+++ b/core/leadership/interface.go
@@ -4,6 +4,7 @@
 package leadership
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -61,12 +62,12 @@ type Claimer interface {
 	// ClaimLeadership claims leadership of the named application on behalf of the
 	// named unit. If no error is returned, leadership will be guaranteed for
 	// at least the supplied duration from the point when the call was made.
-	ClaimLeadership(applicationId, unitId string, duration time.Duration) error
+	ClaimLeadership(ctx context.Context, applicationId, unitId string, duration time.Duration) error
 
 	// BlockUntilLeadershipReleased blocks until the named application is known
 	// to have no leader, in which case it returns no error; or until the
 	// manager is stopped, in which case it will fail.
-	BlockUntilLeadershipReleased(applicationId string, cancel <-chan struct{}) (err error)
+	BlockUntilLeadershipReleased(ctx context.Context, applicationId string, cancel <-chan struct{}) (err error)
 }
 
 // Revoker exposes leadership revocation capabilities.

--- a/core/watcher/strings_test.go
+++ b/core/watcher/strings_test.go
@@ -4,6 +4,7 @@
 package watcher_test
 
 import (
+	"context"
 	"sync"
 	"time"
 
@@ -63,7 +64,7 @@ type stringsHandler struct {
 	setupDone     chan struct{}
 }
 
-func (sh *stringsHandler) SetUp() (watcher.StringsWatcher, error) {
+func (sh *stringsHandler) SetUp(ctx context.Context) (watcher.StringsWatcher, error) {
 	defer func() { sh.setupDone <- struct{}{} }()
 	sh.mu.Lock()
 	defer sh.mu.Unlock()
@@ -84,7 +85,7 @@ func (sh *stringsHandler) TearDown() error {
 	return sh.teardownError
 }
 
-func (sh *stringsHandler) Handle(_ <-chan struct{}, changes []string) error {
+func (sh *stringsHandler) Handle(ctx context.Context, changes []string) error {
 	sh.mu.Lock()
 	defer sh.mu.Unlock()
 	sh.actions = append(sh.actions, "handler")

--- a/environs/broker.go
+++ b/environs/broker.go
@@ -4,6 +4,8 @@
 package environs
 
 import (
+	"context"
+
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/lxdprofile"
@@ -19,7 +21,7 @@ import (
 )
 
 // StatusCallbackFunc represents a function that can be called to report a status.
-type StatusCallbackFunc func(settableStatus status.Status, info string, data map[string]interface{}) error
+type StatusCallbackFunc func(ctx context.Context, settableStatus status.Status, info string, data map[string]interface{}) error
 
 // StartInstanceParams holds parameters for the
 // InstanceBroker.StartInstance method.

--- a/internal/container/broker/broker_test.go
+++ b/internal/container/broker/broker_test.go
@@ -119,7 +119,7 @@ var fakeInterfaceInfo = corenetwork.InterfaceInfo{
 
 func fakeContainerConfig() params.ContainerConfig {
 	return params.ContainerConfig{
-		UpdateBehavior:          &params.UpdateBehavior{true, true},
+		UpdateBehavior:          &params.UpdateBehavior{EnableOSRefreshUpdate: true, EnableOSUpgrade: true},
 		ProviderType:            "fake",
 		AuthorizedKeys:          coretesting.FakeAuthKeys,
 		SSLHostnameVerification: true,
@@ -140,7 +140,7 @@ func NewFakeAPI() *fakeAPI {
 	}
 }
 
-func (f *fakeAPI) ContainerConfig() (params.ContainerConfig, error) {
+func (f *fakeAPI) ContainerConfig(ctx context.Context) (params.ContainerConfig, error) {
 	f.MethodCall(f, "ContainerConfig")
 	if err := f.NextErr(); err != nil {
 		return params.ContainerConfig{}, err
@@ -148,7 +148,7 @@ func (f *fakeAPI) ContainerConfig() (params.ContainerConfig, error) {
 	return f.fakeContainerConfig, nil
 }
 
-func (f *fakeAPI) PrepareContainerInterfaceInfo(tag names.MachineTag) (corenetwork.InterfaceInfos, error) {
+func (f *fakeAPI) PrepareContainerInterfaceInfo(ctx context.Context, tag names.MachineTag) (corenetwork.InterfaceInfos, error) {
 	f.MethodCall(f, "PrepareContainerInterfaceInfo", tag)
 	if err := f.NextErr(); err != nil {
 		return nil, err
@@ -156,7 +156,7 @@ func (f *fakeAPI) PrepareContainerInterfaceInfo(tag names.MachineTag) (corenetwo
 	return corenetwork.InterfaceInfos{f.fakeInterfaceInfo}, nil
 }
 
-func (f *fakeAPI) GetContainerInterfaceInfo(tag names.MachineTag) (corenetwork.InterfaceInfos, error) {
+func (f *fakeAPI) GetContainerInterfaceInfo(ctx context.Context, tag names.MachineTag) (corenetwork.InterfaceInfos, error) {
 	f.MethodCall(f, "GetContainerInterfaceInfo", tag)
 	if err := f.NextErr(); err != nil {
 		return nil, err
@@ -164,7 +164,7 @@ func (f *fakeAPI) GetContainerInterfaceInfo(tag names.MachineTag) (corenetwork.I
 	return corenetwork.InterfaceInfos{f.fakeInterfaceInfo}, nil
 }
 
-func (f *fakeAPI) ReleaseContainerAddresses(tag names.MachineTag) error {
+func (f *fakeAPI) ReleaseContainerAddresses(ctx context.Context, tag names.MachineTag) error {
 	f.MethodCall(f, "ReleaseContainerAddresses", tag)
 	if err := f.NextErr(); err != nil {
 		return err
@@ -172,7 +172,7 @@ func (f *fakeAPI) ReleaseContainerAddresses(tag names.MachineTag) error {
 	return nil
 }
 
-func (f *fakeAPI) SetHostMachineNetworkConfig(hostMachineTag names.MachineTag, netConfig []params.NetworkConfig) error {
+func (f *fakeAPI) SetHostMachineNetworkConfig(ctx context.Context, hostMachineTag names.MachineTag, netConfig []params.NetworkConfig) error {
 	f.MethodCall(f, "SetHostMachineNetworkConfig", hostMachineTag.String(), netConfig)
 	if err := f.NextErr(); err != nil {
 		return err
@@ -180,7 +180,7 @@ func (f *fakeAPI) SetHostMachineNetworkConfig(hostMachineTag names.MachineTag, n
 	return nil
 }
 
-func (f *fakeAPI) HostChangesForContainer(machineTag names.MachineTag) ([]network.DeviceToBridge, int, error) {
+func (f *fakeAPI) HostChangesForContainer(ctx context.Context, machineTag names.MachineTag) ([]network.DeviceToBridge, int, error) {
 	f.MethodCall(f, "HostChangesForContainer", machineTag)
 	if err := f.NextErr(); err != nil {
 		return nil, 0, err
@@ -188,7 +188,7 @@ func (f *fakeAPI) HostChangesForContainer(machineTag names.MachineTag) ([]networ
 	return []network.DeviceToBridge{f.fakeDeviceToBridge}, 0, nil
 }
 
-func (f *fakeAPI) PrepareHost(containerTag names.MachineTag, log corelogger.Logger, abort <-chan struct{}) error {
+func (f *fakeAPI) PrepareHost(ctx context.Context, containerTag names.MachineTag, log corelogger.Logger, abort <-chan struct{}) error {
 	// This is not actually part of the API, however it is something that the
 	// Brokers should be calling, and putting it here means we get a wholistic
 	// view of when what function is getting called.
@@ -197,12 +197,12 @@ func (f *fakeAPI) PrepareHost(containerTag names.MachineTag, log corelogger.Logg
 		return err
 	}
 	if f.fakePreparer != nil {
-		return f.fakePreparer(containerTag, log, abort)
+		return f.fakePreparer(ctx, containerTag, log, abort)
 	}
 	return nil
 }
 
-func (f *fakeAPI) GetContainerProfileInfo(containerTag names.MachineTag) ([]*apiprovisioner.LXDProfileResult, error) {
+func (f *fakeAPI) GetContainerProfileInfo(ctx context.Context, containerTag names.MachineTag) ([]*apiprovisioner.LXDProfileResult, error) {
 	f.MethodCall(f, "GetContainerProfileInfo", containerTag)
 	if err := f.NextErr(); err != nil {
 		return nil, err
@@ -315,8 +315,8 @@ func makePossibleTools() coretools.List {
 	}}
 }
 
-func makeNoOpStatusCallback() func(settableStatus status.Status, info string, data map[string]interface{}) error {
-	return func(_ status.Status, _ string, _ map[string]interface{}) error {
+func makeNoOpStatusCallback() func(ctx context.Context, settableStatus status.Status, info string, data map[string]interface{}) error {
+	return func(_ context.Context, _ status.Status, _ string, _ map[string]interface{}) error {
 		return nil
 	}
 }

--- a/internal/container/broker/lxd-broker_test.go
+++ b/internal/container/broker/lxd-broker_test.go
@@ -211,8 +211,8 @@ func (s *lxdBrokerSuite) TestStartInstanceWithLXDProfile(c *gc.C) {
 	containerTag := names.NewMachineTag("1-lxd-0")
 
 	mockApi := mocks.NewMockAPICalls(ctrl)
-	mockApi.EXPECT().PrepareContainerInterfaceInfo(gomock.Eq(containerTag)).Return(corenetwork.InterfaceInfos{fakeInterfaceInfo}, nil)
-	mockApi.EXPECT().ContainerConfig().Return(fakeContainerConfig(), nil)
+	mockApi.EXPECT().PrepareContainerInterfaceInfo(gomock.Any(), gomock.Eq(containerTag)).Return(corenetwork.InterfaceInfos{fakeInterfaceInfo}, nil)
+	mockApi.EXPECT().ContainerConfig(gomock.Any()).Return(fakeContainerConfig(), nil)
 
 	put := lxdprofile.Profile{
 		Config: map[string]string{
@@ -230,7 +230,7 @@ func (s *lxdBrokerSuite) TestStartInstanceWithLXDProfile(c *gc.C) {
 		Devices: put.Devices,
 		Name:    "juju-test-profile",
 	}
-	mockApi.EXPECT().GetContainerProfileInfo(gomock.Eq(containerTag)).Return([]*apiprovisioner.LXDProfileResult{result}, nil)
+	mockApi.EXPECT().GetContainerProfileInfo(gomock.Any(), gomock.Eq(containerTag)).Return([]*apiprovisioner.LXDProfileResult{result}, nil)
 
 	mockManager := testing.NewMockTestLXDManager(ctrl)
 	mockManager.EXPECT().MaybeWriteLXDProfile("juju-test-profile", put).Return(nil)
@@ -243,7 +243,9 @@ func (s *lxdBrokerSuite) TestStartInstanceWithLXDProfile(c *gc.C) {
 	).Return(&inst, &hw, nil)
 
 	broker, err := broker.NewLXDBroker(
-		func(containerTag names.MachineTag, log corelogger.Logger, abort <-chan struct{}) error { return nil },
+		func(ctx context.Context, containerTag names.MachineTag, log corelogger.Logger, abort <-chan struct{}) error {
+			return nil
+		},
 		mockApi, mockManager, s.agentConfig)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -258,8 +260,8 @@ func (s *lxdBrokerSuite) TestStartInstanceWithNoNameLXDProfile(c *gc.C) {
 	containerTag := names.NewMachineTag("1-lxd-0")
 
 	mockApi := mocks.NewMockAPICalls(ctrl)
-	mockApi.EXPECT().PrepareContainerInterfaceInfo(gomock.Eq(containerTag)).Return(corenetwork.InterfaceInfos{fakeInterfaceInfo}, nil)
-	mockApi.EXPECT().ContainerConfig().Return(fakeContainerConfig(), nil)
+	mockApi.EXPECT().PrepareContainerInterfaceInfo(gomock.Any(), gomock.Eq(containerTag)).Return(corenetwork.InterfaceInfos{fakeInterfaceInfo}, nil)
+	mockApi.EXPECT().ContainerConfig(gomock.Any()).Return(fakeContainerConfig(), nil)
 
 	put := &charm.LXDProfile{
 		Config: map[string]string{
@@ -270,12 +272,14 @@ func (s *lxdBrokerSuite) TestStartInstanceWithNoNameLXDProfile(c *gc.C) {
 		Config: put.Config,
 		Name:   "",
 	}
-	mockApi.EXPECT().GetContainerProfileInfo(gomock.Eq(containerTag)).Return([]*apiprovisioner.LXDProfileResult{result}, nil)
+	mockApi.EXPECT().GetContainerProfileInfo(gomock.Any(), gomock.Eq(containerTag)).Return([]*apiprovisioner.LXDProfileResult{result}, nil)
 
 	mockManager := testing.NewMockTestLXDManager(ctrl)
 
 	broker, err := broker.NewLXDBroker(
-		func(containerTag names.MachineTag, log corelogger.Logger, abort <-chan struct{}) error { return nil },
+		func(ctx context.Context, containerTag names.MachineTag, log corelogger.Logger, abort <-chan struct{}) error {
+			return nil
+		},
 		mockApi, mockManager, s.agentConfig)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -296,7 +300,9 @@ func (s *lxdBrokerSuite) TestStartInstanceWithLXDProfileReturnsLXDProfileNames(c
 	}, nil)
 
 	broker, err := broker.NewLXDBroker(
-		func(containerTag names.MachineTag, log corelogger.Logger, abort <-chan struct{}) error { return nil },
+		func(ctx context.Context, containerTag names.MachineTag, log corelogger.Logger, abort <-chan struct{}) error {
+			return nil
+		},
 		mockApi, mockManager, s.agentConfig)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/internal/container/broker/mocks/apicalls_mock.go
+++ b/internal/container/broker/mocks/apicalls_mock.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	provisioner "github.com/juju/juju/api/agent/provisioner"
@@ -44,18 +45,18 @@ func (m *MockAPICalls) EXPECT() *MockAPICallsMockRecorder {
 }
 
 // ContainerConfig mocks base method.
-func (m *MockAPICalls) ContainerConfig() (params.ContainerConfig, error) {
+func (m *MockAPICalls) ContainerConfig(arg0 context.Context) (params.ContainerConfig, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ContainerConfig")
+	ret := m.ctrl.Call(m, "ContainerConfig", arg0)
 	ret0, _ := ret[0].(params.ContainerConfig)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ContainerConfig indicates an expected call of ContainerConfig.
-func (mr *MockAPICallsMockRecorder) ContainerConfig() *MockAPICallsContainerConfigCall {
+func (mr *MockAPICallsMockRecorder) ContainerConfig(arg0 any) *MockAPICallsContainerConfigCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerConfig", reflect.TypeOf((*MockAPICalls)(nil).ContainerConfig))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerConfig", reflect.TypeOf((*MockAPICalls)(nil).ContainerConfig), arg0)
 	return &MockAPICallsContainerConfigCall{Call: call}
 }
 
@@ -71,30 +72,30 @@ func (c *MockAPICallsContainerConfigCall) Return(arg0 params.ContainerConfig, ar
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockAPICallsContainerConfigCall) Do(f func() (params.ContainerConfig, error)) *MockAPICallsContainerConfigCall {
+func (c *MockAPICallsContainerConfigCall) Do(f func(context.Context) (params.ContainerConfig, error)) *MockAPICallsContainerConfigCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockAPICallsContainerConfigCall) DoAndReturn(f func() (params.ContainerConfig, error)) *MockAPICallsContainerConfigCall {
+func (c *MockAPICallsContainerConfigCall) DoAndReturn(f func(context.Context) (params.ContainerConfig, error)) *MockAPICallsContainerConfigCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetContainerProfileInfo mocks base method.
-func (m *MockAPICalls) GetContainerProfileInfo(arg0 names.MachineTag) ([]*provisioner.LXDProfileResult, error) {
+func (m *MockAPICalls) GetContainerProfileInfo(arg0 context.Context, arg1 names.MachineTag) ([]*provisioner.LXDProfileResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetContainerProfileInfo", arg0)
+	ret := m.ctrl.Call(m, "GetContainerProfileInfo", arg0, arg1)
 	ret0, _ := ret[0].([]*provisioner.LXDProfileResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetContainerProfileInfo indicates an expected call of GetContainerProfileInfo.
-func (mr *MockAPICallsMockRecorder) GetContainerProfileInfo(arg0 any) *MockAPICallsGetContainerProfileInfoCall {
+func (mr *MockAPICallsMockRecorder) GetContainerProfileInfo(arg0, arg1 any) *MockAPICallsGetContainerProfileInfoCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContainerProfileInfo", reflect.TypeOf((*MockAPICalls)(nil).GetContainerProfileInfo), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContainerProfileInfo", reflect.TypeOf((*MockAPICalls)(nil).GetContainerProfileInfo), arg0, arg1)
 	return &MockAPICallsGetContainerProfileInfoCall{Call: call}
 }
 
@@ -110,21 +111,21 @@ func (c *MockAPICallsGetContainerProfileInfoCall) Return(arg0 []*provisioner.LXD
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockAPICallsGetContainerProfileInfoCall) Do(f func(names.MachineTag) ([]*provisioner.LXDProfileResult, error)) *MockAPICallsGetContainerProfileInfoCall {
+func (c *MockAPICallsGetContainerProfileInfoCall) Do(f func(context.Context, names.MachineTag) ([]*provisioner.LXDProfileResult, error)) *MockAPICallsGetContainerProfileInfoCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockAPICallsGetContainerProfileInfoCall) DoAndReturn(f func(names.MachineTag) ([]*provisioner.LXDProfileResult, error)) *MockAPICallsGetContainerProfileInfoCall {
+func (c *MockAPICallsGetContainerProfileInfoCall) DoAndReturn(f func(context.Context, names.MachineTag) ([]*provisioner.LXDProfileResult, error)) *MockAPICallsGetContainerProfileInfoCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // HostChangesForContainer mocks base method.
-func (m *MockAPICalls) HostChangesForContainer(arg0 names.MachineTag) ([]network0.DeviceToBridge, int, error) {
+func (m *MockAPICalls) HostChangesForContainer(arg0 context.Context, arg1 names.MachineTag) ([]network0.DeviceToBridge, int, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HostChangesForContainer", arg0)
+	ret := m.ctrl.Call(m, "HostChangesForContainer", arg0, arg1)
 	ret0, _ := ret[0].([]network0.DeviceToBridge)
 	ret1, _ := ret[1].(int)
 	ret2, _ := ret[2].(error)
@@ -132,9 +133,9 @@ func (m *MockAPICalls) HostChangesForContainer(arg0 names.MachineTag) ([]network
 }
 
 // HostChangesForContainer indicates an expected call of HostChangesForContainer.
-func (mr *MockAPICallsMockRecorder) HostChangesForContainer(arg0 any) *MockAPICallsHostChangesForContainerCall {
+func (mr *MockAPICallsMockRecorder) HostChangesForContainer(arg0, arg1 any) *MockAPICallsHostChangesForContainerCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HostChangesForContainer", reflect.TypeOf((*MockAPICalls)(nil).HostChangesForContainer), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HostChangesForContainer", reflect.TypeOf((*MockAPICalls)(nil).HostChangesForContainer), arg0, arg1)
 	return &MockAPICallsHostChangesForContainerCall{Call: call}
 }
 
@@ -150,30 +151,30 @@ func (c *MockAPICallsHostChangesForContainerCall) Return(arg0 []network0.DeviceT
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockAPICallsHostChangesForContainerCall) Do(f func(names.MachineTag) ([]network0.DeviceToBridge, int, error)) *MockAPICallsHostChangesForContainerCall {
+func (c *MockAPICallsHostChangesForContainerCall) Do(f func(context.Context, names.MachineTag) ([]network0.DeviceToBridge, int, error)) *MockAPICallsHostChangesForContainerCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockAPICallsHostChangesForContainerCall) DoAndReturn(f func(names.MachineTag) ([]network0.DeviceToBridge, int, error)) *MockAPICallsHostChangesForContainerCall {
+func (c *MockAPICallsHostChangesForContainerCall) DoAndReturn(f func(context.Context, names.MachineTag) ([]network0.DeviceToBridge, int, error)) *MockAPICallsHostChangesForContainerCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // PrepareContainerInterfaceInfo mocks base method.
-func (m *MockAPICalls) PrepareContainerInterfaceInfo(arg0 names.MachineTag) (network.InterfaceInfos, error) {
+func (m *MockAPICalls) PrepareContainerInterfaceInfo(arg0 context.Context, arg1 names.MachineTag) (network.InterfaceInfos, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PrepareContainerInterfaceInfo", arg0)
+	ret := m.ctrl.Call(m, "PrepareContainerInterfaceInfo", arg0, arg1)
 	ret0, _ := ret[0].(network.InterfaceInfos)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // PrepareContainerInterfaceInfo indicates an expected call of PrepareContainerInterfaceInfo.
-func (mr *MockAPICallsMockRecorder) PrepareContainerInterfaceInfo(arg0 any) *MockAPICallsPrepareContainerInterfaceInfoCall {
+func (mr *MockAPICallsMockRecorder) PrepareContainerInterfaceInfo(arg0, arg1 any) *MockAPICallsPrepareContainerInterfaceInfoCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareContainerInterfaceInfo", reflect.TypeOf((*MockAPICalls)(nil).PrepareContainerInterfaceInfo), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareContainerInterfaceInfo", reflect.TypeOf((*MockAPICalls)(nil).PrepareContainerInterfaceInfo), arg0, arg1)
 	return &MockAPICallsPrepareContainerInterfaceInfoCall{Call: call}
 }
 
@@ -189,29 +190,29 @@ func (c *MockAPICallsPrepareContainerInterfaceInfoCall) Return(arg0 network.Inte
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockAPICallsPrepareContainerInterfaceInfoCall) Do(f func(names.MachineTag) (network.InterfaceInfos, error)) *MockAPICallsPrepareContainerInterfaceInfoCall {
+func (c *MockAPICallsPrepareContainerInterfaceInfoCall) Do(f func(context.Context, names.MachineTag) (network.InterfaceInfos, error)) *MockAPICallsPrepareContainerInterfaceInfoCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockAPICallsPrepareContainerInterfaceInfoCall) DoAndReturn(f func(names.MachineTag) (network.InterfaceInfos, error)) *MockAPICallsPrepareContainerInterfaceInfoCall {
+func (c *MockAPICallsPrepareContainerInterfaceInfoCall) DoAndReturn(f func(context.Context, names.MachineTag) (network.InterfaceInfos, error)) *MockAPICallsPrepareContainerInterfaceInfoCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // ReleaseContainerAddresses mocks base method.
-func (m *MockAPICalls) ReleaseContainerAddresses(arg0 names.MachineTag) error {
+func (m *MockAPICalls) ReleaseContainerAddresses(arg0 context.Context, arg1 names.MachineTag) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReleaseContainerAddresses", arg0)
+	ret := m.ctrl.Call(m, "ReleaseContainerAddresses", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ReleaseContainerAddresses indicates an expected call of ReleaseContainerAddresses.
-func (mr *MockAPICallsMockRecorder) ReleaseContainerAddresses(arg0 any) *MockAPICallsReleaseContainerAddressesCall {
+func (mr *MockAPICallsMockRecorder) ReleaseContainerAddresses(arg0, arg1 any) *MockAPICallsReleaseContainerAddressesCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReleaseContainerAddresses", reflect.TypeOf((*MockAPICalls)(nil).ReleaseContainerAddresses), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReleaseContainerAddresses", reflect.TypeOf((*MockAPICalls)(nil).ReleaseContainerAddresses), arg0, arg1)
 	return &MockAPICallsReleaseContainerAddressesCall{Call: call}
 }
 
@@ -227,29 +228,29 @@ func (c *MockAPICallsReleaseContainerAddressesCall) Return(arg0 error) *MockAPIC
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockAPICallsReleaseContainerAddressesCall) Do(f func(names.MachineTag) error) *MockAPICallsReleaseContainerAddressesCall {
+func (c *MockAPICallsReleaseContainerAddressesCall) Do(f func(context.Context, names.MachineTag) error) *MockAPICallsReleaseContainerAddressesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockAPICallsReleaseContainerAddressesCall) DoAndReturn(f func(names.MachineTag) error) *MockAPICallsReleaseContainerAddressesCall {
+func (c *MockAPICallsReleaseContainerAddressesCall) DoAndReturn(f func(context.Context, names.MachineTag) error) *MockAPICallsReleaseContainerAddressesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // SetHostMachineNetworkConfig mocks base method.
-func (m *MockAPICalls) SetHostMachineNetworkConfig(arg0 names.MachineTag, arg1 []params.NetworkConfig) error {
+func (m *MockAPICalls) SetHostMachineNetworkConfig(arg0 context.Context, arg1 names.MachineTag, arg2 []params.NetworkConfig) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetHostMachineNetworkConfig", arg0, arg1)
+	ret := m.ctrl.Call(m, "SetHostMachineNetworkConfig", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetHostMachineNetworkConfig indicates an expected call of SetHostMachineNetworkConfig.
-func (mr *MockAPICallsMockRecorder) SetHostMachineNetworkConfig(arg0, arg1 any) *MockAPICallsSetHostMachineNetworkConfigCall {
+func (mr *MockAPICallsMockRecorder) SetHostMachineNetworkConfig(arg0, arg1, arg2 any) *MockAPICallsSetHostMachineNetworkConfigCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetHostMachineNetworkConfig", reflect.TypeOf((*MockAPICalls)(nil).SetHostMachineNetworkConfig), arg0, arg1)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetHostMachineNetworkConfig", reflect.TypeOf((*MockAPICalls)(nil).SetHostMachineNetworkConfig), arg0, arg1, arg2)
 	return &MockAPICallsSetHostMachineNetworkConfigCall{Call: call}
 }
 
@@ -265,13 +266,13 @@ func (c *MockAPICallsSetHostMachineNetworkConfigCall) Return(arg0 error) *MockAP
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockAPICallsSetHostMachineNetworkConfigCall) Do(f func(names.MachineTag, []params.NetworkConfig) error) *MockAPICallsSetHostMachineNetworkConfigCall {
+func (c *MockAPICallsSetHostMachineNetworkConfigCall) Do(f func(context.Context, names.MachineTag, []params.NetworkConfig) error) *MockAPICallsSetHostMachineNetworkConfigCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockAPICallsSetHostMachineNetworkConfigCall) DoAndReturn(f func(names.MachineTag, []params.NetworkConfig) error) *MockAPICallsSetHostMachineNetworkConfigCall {
+func (c *MockAPICallsSetHostMachineNetworkConfigCall) DoAndReturn(f func(context.Context, names.MachineTag, []params.NetworkConfig) error) *MockAPICallsSetHostMachineNetworkConfigCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/container/lxd/image.go
+++ b/internal/container/lxd/image.go
@@ -54,7 +54,7 @@ func (s *Server) FindImage(
 	callback environs.StatusCallbackFunc,
 ) (SourcedImage, error) {
 	if callback != nil {
-		_ = callback(status.Provisioning, "acquiring LXD image", nil)
+		_ = callback(ctx, status.Provisioning, "acquiring LXD image", nil)
 	}
 
 	// First we check if we have the image locally.
@@ -174,7 +174,8 @@ func (s *Server) FindImage(
 // CopyRemoteImage accepts an image sourced from a remote server and copies it
 // to the local cache
 func (s *Server) CopyRemoteImage(
-	ctx context.Context, sourced SourcedImage, aliases []string, callback environs.StatusCallbackFunc,
+	ctx context.Context, sourced SourcedImage, aliases []string,
+	callback environs.StatusCallbackFunc,
 ) error {
 	logger.Debugf("Copying image from remote server")
 
@@ -192,7 +193,7 @@ func (s *Server) CopyRemoteImage(
 		}
 		for _, key := range []string{"fs_progress", "download_progress"} {
 			if value, ok := op.Metadata[key]; ok {
-				_ = callback(status.Provisioning, fmt.Sprintf("Retrieving image: %s", value.(string)), nil)
+				_ = callback(ctx, status.Provisioning, fmt.Sprintf("Retrieving image: %s", value.(string)), nil)
 				return
 			}
 		}
@@ -246,7 +247,7 @@ func (s *Server) CopyRemoteImage(
 		},
 		NotifyFunc: func(_ error, attempt int) {
 			if callback != nil {
-				_ = callback(status.Provisioning, fmt.Sprintf("Failed remote LXD image download. Retrying. Attempt number %d", attempt+1), nil)
+				_ = callback(ctx, status.Provisioning, fmt.Sprintf("Failed remote LXD image download. Retrying. Attempt number %d", attempt+1), nil)
 			}
 		},
 	})

--- a/internal/container/lxd/manager.go
+++ b/internal/container/lxd/manager.go
@@ -125,20 +125,20 @@ func (m *containerManager) CreateContainer(
 		return nil, nil, errors.Trace(err)
 	}
 
-	_ = callback(status.Provisioning, "Creating container spec", nil)
+	_ = callback(ctx, status.Provisioning, "Creating container spec", nil)
 	spec, err := m.getContainerSpec(ctx, instanceConfig, cons, base, networkConfig, callback)
 	if err != nil {
-		_ = callback(status.ProvisioningError, fmt.Sprintf("Creating container spec: %v", err), nil)
+		_ = callback(ctx, status.ProvisioningError, fmt.Sprintf("Creating container spec: %v", err), nil)
 		return nil, nil, errors.Trace(err)
 	}
 
-	_ = callback(status.Provisioning, "Creating container", nil)
+	_ = callback(ctx, status.Provisioning, "Creating container", nil)
 	c, err := m.server.CreateContainerFromSpec(spec)
 	if err != nil {
-		_ = callback(status.ProvisioningError, fmt.Sprintf("Creating container: %v", err), nil)
+		_ = callback(ctx, status.ProvisioningError, fmt.Sprintf("Creating container: %v", err), nil)
 		return nil, nil, errors.Trace(err)
 	}
-	_ = callback(status.Running, "Container started", nil)
+	_ = callback(ctx, status.Running, "Container started", nil)
 
 	virtType := string(spec.VirtType)
 	arch := c.Arch()

--- a/internal/container/lxd/testing/suite.go
+++ b/internal/container/lxd/testing/suite.go
@@ -4,6 +4,8 @@
 package testing
 
 import (
+	context "context"
+
 	lxdapi "github.com/canonical/lxd/shared/api"
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
@@ -17,7 +19,9 @@ const ETag = "eTag"
 
 // NoOpCallback can be passed to methods that receive a callback for setting
 // status messages.
-var NoOpCallback = func(st status.Status, info string, data map[string]interface{}) error { return nil }
+var NoOpCallback = func(ctx context.Context, st status.Status, info string, data map[string]interface{}) error {
+	return nil
+}
 
 // BaseSuite facilitates LXD testing.
 // Do not instantiate this suite directly.

--- a/internal/container/testing/common.go
+++ b/internal/container/testing/common.go
@@ -68,9 +68,13 @@ func CreateContainerWithMachineAndNetworkAndStorageConfig(
 	networkConfig *container.NetworkConfig,
 	storageConfig *container.StorageConfig,
 ) instances.Instance {
-	callback := func(settableStatus status.Status, info string, data map[string]interface{}) error { return nil }
+	callback := func(ctx context.Context, settableStatus status.Status, info string, data map[string]interface{}) error {
+		return nil
+	}
 	inst, hardware, err := manager.CreateContainer(
-		context.Background(), instanceConfig, constraints.Value{}, corebase.MakeDefaultBase("ubuntu", "18.04"), networkConfig, storageConfig, callback)
+		context.Background(),
+		instanceConfig, constraints.Value{}, corebase.MakeDefaultBase("ubuntu", "18.04"),
+		networkConfig, storageConfig, callback)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(hardware, gc.NotNil)
 	c.Assert(hardware.String(), gc.Not(gc.Equals), "")

--- a/internal/provider/ec2/local_test.go
+++ b/internal/provider/ec2/local_test.go
@@ -70,7 +70,7 @@ var localConfigAttrs = coretesting.FakeConfig().Merge(coretesting.Attrs{
 	"agent-version": coretesting.FakeVersionNumber.String(),
 })
 
-func fakeCallback(_ status.Status, _ string, _ map[string]interface{}) error {
+func fakeCallback(_ context.Context, _ status.Status, _ string, _ map[string]interface{}) error {
 	return nil
 }
 

--- a/internal/provider/lxd/environ_broker.go
+++ b/internal/provider/lxd/environ_broker.go
@@ -4,6 +4,7 @@
 package lxd
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -41,7 +42,7 @@ func (env *environ) StartInstance(
 	if err != nil {
 		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
 		if args.StatusCallback != nil {
-			_ = args.StatusCallback(status.ProvisioningError, err.Error(), nil)
+			_ = args.StatusCallback(ctx, status.ProvisioningError, err.Error(), nil)
 		}
 		return nil, errors.Trace(err)
 	}
@@ -106,9 +107,9 @@ func (env *environ) newContainer(
 	// are made, instead of at a higher level in the package, so as not to
 	// assume that all providers will have the same need to be implemented
 	// in the same way.
-	statusCallback := func(currentStatus status.Status, msg string, data map[string]interface{}) error {
+	statusCallback := func(ctx context.Context, currentStatus status.Status, msg string, data map[string]interface{}) error {
 		if args.StatusCallback != nil {
-			_ = args.StatusCallback(currentStatus, msg, nil)
+			_ = args.StatusCallback(ctx, currentStatus, msg, nil)
 		}
 		return nil
 	}
@@ -135,12 +136,12 @@ func (env *environ) newContainer(
 		return nil, errors.Trace(err)
 	}
 
-	_ = statusCallback(status.Allocating, "Creating container", nil)
+	_ = statusCallback(ctx, status.Allocating, "Creating container", nil)
 	container, err := target.CreateContainerFromSpec(cSpec)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	_ = statusCallback(status.Running, "Container started", nil)
+	_ = statusCallback(ctx, status.Running, "Container started", nil)
 	return container, nil
 }
 

--- a/internal/provider/openstack/local_test.go
+++ b/internal/provider/openstack/local_test.go
@@ -2477,7 +2477,7 @@ func (s *localServerSuite) TestStartInstanceWithEmptyNonceFails(c *gc.C) {
 	possibleTools := coretools.List(envtesting.AssertUploadFakeToolsVersions(
 		c, s.toolsMetadataStorage, "released", "released", version.MustParseBinary("5.4.5-ubuntu-amd64"),
 	))
-	fakeCallback := func(_ status.Status, _ string, _ map[string]interface{}) error {
+	fakeCallback := func(_ context.Context, _ status.Status, _ string, _ map[string]interface{}) error {
 		return nil
 	}
 	params := environs.StartInstanceParams{

--- a/internal/provider/openstack/provider.go
+++ b/internal/provider/openstack/provider.go
@@ -1179,12 +1179,15 @@ func (e *Environ) startInstance(
 				return nil
 			},
 			NotifyFunc: func(lastError error, attempt int) {
-				_ = args.StatusCallback(status.Provisioning,
+				_ = args.StatusCallback(
+					ctx,
+					status.Provisioning,
 					fmt.Sprintf("%s, wait 10 seconds before retry, attempt %d", lastError, attempt), nil)
 			},
 			IsFatalError: func(err error) bool {
 				return err != errStillBuilding
 			},
+			Stop: ctx.Done(),
 		})
 		if err != nil {
 			return nil, err

--- a/internal/provider/vsphere/environ_broker.go
+++ b/internal/provider/vsphere/environ_broker.go
@@ -83,7 +83,7 @@ func (env *environ) Region() (simplestreams.CloudSpec, error) {
 func (env *sessionEnviron) StartInstance(ctx envcontext.ProviderCallContext, args environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
 	vm, hw, err := env.newRawInstance(ctx, args)
 	if err != nil {
-		_ = args.StatusCallback(status.ProvisioningError, fmt.Sprint(err), nil)
+		_ = args.StatusCallback(ctx, status.ProvisioningError, fmt.Sprint(err), nil)
 		return nil, errors.Trace(err)
 	}
 
@@ -150,7 +150,7 @@ func (env *sessionEnviron) newRawInstance(
 		updateProgressInterval = bootstrapUpdateProgressInterval
 	}
 	updateProgress := func(message string) {
-		_ = args.StatusCallback(status.Provisioning, message, nil)
+		_ = args.StatusCallback(ctx, status.Provisioning, message, nil)
 	}
 
 	statusUpdateArgs := vsphereclient.StatusUpdateParams{

--- a/internal/provider/vsphere/environ_broker_test.go
+++ b/internal/provider/vsphere/environ_broker_test.go
@@ -82,7 +82,7 @@ func (s *legacyEnvironBrokerSuite) createStartInstanceArgs(c *gc.C) environs.Sta
 		InstanceConfig:   instanceConfig,
 		Tools:            tools,
 		Constraints:      cons,
-		StatusCallback: func(status status.Status, info string, data map[string]interface{}) error {
+		StatusCallback: func(ctx context.Context, status status.Status, info string, data map[string]interface{}) error {
 			s.statusCallbackStub.AddCall("StatusCallback", status, info, data)
 			return s.statusCallbackStub.NextErr()
 		},

--- a/internal/secrets/interface.go
+++ b/internal/secrets/interface.go
@@ -4,6 +4,8 @@
 package secrets
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 
@@ -77,39 +79,39 @@ func (p *UpdateParams) Validate() error {
 type JujuAPIClient interface {
 	// GetContentInfo returns info about the content of a secret and the backend config
 	// needed to make a backend client if necessary.
-	GetContentInfo(uri *secrets.URI, label string, refresh, peek bool) (*ContentParams, *provider.ModelBackendConfig, bool, error)
+	GetContentInfo(ctx context.Context, uri *secrets.URI, label string, refresh, peek bool) (*ContentParams, *provider.ModelBackendConfig, bool, error)
 	// GetRevisionContentInfo returns info about the content of a secret revision and the backend config
 	// needed to make a backend client if necessary.
 	// If pendingDelete is true, the revision is marked for deletion.
-	GetRevisionContentInfo(uri *secrets.URI, revision int, pendingDelete bool) (*ContentParams, *provider.ModelBackendConfig, bool, error)
+	GetRevisionContentInfo(ctx context.Context, uri *secrets.URI, revision int, pendingDelete bool) (*ContentParams, *provider.ModelBackendConfig, bool, error)
 	// GetSecretBackendConfig fetches the config needed to make secret backend clients.
 	// If backendID is nil, return the current active backend (if any).
-	GetSecretBackendConfig(backendID *string) (*provider.ModelBackendConfigInfo, error)
+	GetSecretBackendConfig(ctx context.Context, backendID *string) (*provider.ModelBackendConfigInfo, error)
 
 	// GetBackendConfigForDrain fetches the config needed to make a secret backend client for the drain worker.
-	GetBackendConfigForDrain(backendID *string) (*provider.ModelBackendConfig, string, error)
+	GetBackendConfigForDrain(ctx context.Context, backendID *string) (*provider.ModelBackendConfig, string, error)
 }
 
 // BackendsClient provides access to a client which can access secret backends.
 type BackendsClient interface {
 	// GetContent returns the content of a secret, either from an external backend if
 	// one is configured, or from Juju.
-	GetContent(uri *secrets.URI, label string, refresh, peek bool) (secrets.SecretValue, error)
+	GetContent(ctx context.Context, uri *secrets.URI, label string, refresh, peek bool) (secrets.SecretValue, error)
 
 	// GetRevisionContent returns the content of a secret revision, either from an external backend if
 	// one is configured, or from Juju.
-	GetRevisionContent(uri *secrets.URI, revision int) (secrets.SecretValue, error)
+	GetRevisionContent(ctx context.Context, uri *secrets.URI, revision int) (secrets.SecretValue, error)
 
 	// SaveContent saves the content of a secret to an external backend returning the backend id.
-	SaveContent(uri *secrets.URI, revision int, value secrets.SecretValue) (secrets.ValueRef, error)
+	SaveContent(ctx context.Context, uri *secrets.URI, revision int, value secrets.SecretValue) (secrets.ValueRef, error)
 
 	// DeleteContent deletes a secret from an external backend
 	// if it exists there.
-	DeleteContent(uri *secrets.URI, revision int) error
+	DeleteContent(ctx context.Context, uri *secrets.URI, revision int) error
 
 	// DeleteExternalContent deletes a secret from an external backend.
-	DeleteExternalContent(ref secrets.ValueRef) error
+	DeleteExternalContent(ctx context.Context, ref secrets.ValueRef) error
 
 	// GetBackend returns the secret client for the provided backend ID.
-	GetBackend(backendID *string, forDrain bool) (provider.SecretsBackend, string, error)
+	GetBackend(ctx context.Context, backendID *string, forDrain bool) (provider.SecretsBackend, string, error)
 }

--- a/internal/secrets/mocks/jujuapi_mocks.go
+++ b/internal/secrets/mocks/jujuapi_mocks.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	secrets "github.com/juju/juju/core/secrets"
@@ -42,9 +43,9 @@ func (m *MockJujuAPIClient) EXPECT() *MockJujuAPIClientMockRecorder {
 }
 
 // GetBackendConfigForDrain mocks base method.
-func (m *MockJujuAPIClient) GetBackendConfigForDrain(arg0 *string) (*provider.ModelBackendConfig, string, error) {
+func (m *MockJujuAPIClient) GetBackendConfigForDrain(arg0 context.Context, arg1 *string) (*provider.ModelBackendConfig, string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBackendConfigForDrain", arg0)
+	ret := m.ctrl.Call(m, "GetBackendConfigForDrain", arg0, arg1)
 	ret0, _ := ret[0].(*provider.ModelBackendConfig)
 	ret1, _ := ret[1].(string)
 	ret2, _ := ret[2].(error)
@@ -52,9 +53,9 @@ func (m *MockJujuAPIClient) GetBackendConfigForDrain(arg0 *string) (*provider.Mo
 }
 
 // GetBackendConfigForDrain indicates an expected call of GetBackendConfigForDrain.
-func (mr *MockJujuAPIClientMockRecorder) GetBackendConfigForDrain(arg0 any) *MockJujuAPIClientGetBackendConfigForDrainCall {
+func (mr *MockJujuAPIClientMockRecorder) GetBackendConfigForDrain(arg0, arg1 any) *MockJujuAPIClientGetBackendConfigForDrainCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackendConfigForDrain", reflect.TypeOf((*MockJujuAPIClient)(nil).GetBackendConfigForDrain), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackendConfigForDrain", reflect.TypeOf((*MockJujuAPIClient)(nil).GetBackendConfigForDrain), arg0, arg1)
 	return &MockJujuAPIClientGetBackendConfigForDrainCall{Call: call}
 }
 
@@ -70,21 +71,21 @@ func (c *MockJujuAPIClientGetBackendConfigForDrainCall) Return(arg0 *provider.Mo
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockJujuAPIClientGetBackendConfigForDrainCall) Do(f func(*string) (*provider.ModelBackendConfig, string, error)) *MockJujuAPIClientGetBackendConfigForDrainCall {
+func (c *MockJujuAPIClientGetBackendConfigForDrainCall) Do(f func(context.Context, *string) (*provider.ModelBackendConfig, string, error)) *MockJujuAPIClientGetBackendConfigForDrainCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockJujuAPIClientGetBackendConfigForDrainCall) DoAndReturn(f func(*string) (*provider.ModelBackendConfig, string, error)) *MockJujuAPIClientGetBackendConfigForDrainCall {
+func (c *MockJujuAPIClientGetBackendConfigForDrainCall) DoAndReturn(f func(context.Context, *string) (*provider.ModelBackendConfig, string, error)) *MockJujuAPIClientGetBackendConfigForDrainCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetContentInfo mocks base method.
-func (m *MockJujuAPIClient) GetContentInfo(arg0 *secrets.URI, arg1 string, arg2, arg3 bool) (*secrets0.ContentParams, *provider.ModelBackendConfig, bool, error) {
+func (m *MockJujuAPIClient) GetContentInfo(arg0 context.Context, arg1 *secrets.URI, arg2 string, arg3, arg4 bool) (*secrets0.ContentParams, *provider.ModelBackendConfig, bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetContentInfo", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "GetContentInfo", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(*secrets0.ContentParams)
 	ret1, _ := ret[1].(*provider.ModelBackendConfig)
 	ret2, _ := ret[2].(bool)
@@ -93,9 +94,9 @@ func (m *MockJujuAPIClient) GetContentInfo(arg0 *secrets.URI, arg1 string, arg2,
 }
 
 // GetContentInfo indicates an expected call of GetContentInfo.
-func (mr *MockJujuAPIClientMockRecorder) GetContentInfo(arg0, arg1, arg2, arg3 any) *MockJujuAPIClientGetContentInfoCall {
+func (mr *MockJujuAPIClientMockRecorder) GetContentInfo(arg0, arg1, arg2, arg3, arg4 any) *MockJujuAPIClientGetContentInfoCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContentInfo", reflect.TypeOf((*MockJujuAPIClient)(nil).GetContentInfo), arg0, arg1, arg2, arg3)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContentInfo", reflect.TypeOf((*MockJujuAPIClient)(nil).GetContentInfo), arg0, arg1, arg2, arg3, arg4)
 	return &MockJujuAPIClientGetContentInfoCall{Call: call}
 }
 
@@ -111,21 +112,21 @@ func (c *MockJujuAPIClientGetContentInfoCall) Return(arg0 *secrets0.ContentParam
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockJujuAPIClientGetContentInfoCall) Do(f func(*secrets.URI, string, bool, bool) (*secrets0.ContentParams, *provider.ModelBackendConfig, bool, error)) *MockJujuAPIClientGetContentInfoCall {
+func (c *MockJujuAPIClientGetContentInfoCall) Do(f func(context.Context, *secrets.URI, string, bool, bool) (*secrets0.ContentParams, *provider.ModelBackendConfig, bool, error)) *MockJujuAPIClientGetContentInfoCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockJujuAPIClientGetContentInfoCall) DoAndReturn(f func(*secrets.URI, string, bool, bool) (*secrets0.ContentParams, *provider.ModelBackendConfig, bool, error)) *MockJujuAPIClientGetContentInfoCall {
+func (c *MockJujuAPIClientGetContentInfoCall) DoAndReturn(f func(context.Context, *secrets.URI, string, bool, bool) (*secrets0.ContentParams, *provider.ModelBackendConfig, bool, error)) *MockJujuAPIClientGetContentInfoCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetRevisionContentInfo mocks base method.
-func (m *MockJujuAPIClient) GetRevisionContentInfo(arg0 *secrets.URI, arg1 int, arg2 bool) (*secrets0.ContentParams, *provider.ModelBackendConfig, bool, error) {
+func (m *MockJujuAPIClient) GetRevisionContentInfo(arg0 context.Context, arg1 *secrets.URI, arg2 int, arg3 bool) (*secrets0.ContentParams, *provider.ModelBackendConfig, bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRevisionContentInfo", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "GetRevisionContentInfo", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*secrets0.ContentParams)
 	ret1, _ := ret[1].(*provider.ModelBackendConfig)
 	ret2, _ := ret[2].(bool)
@@ -134,9 +135,9 @@ func (m *MockJujuAPIClient) GetRevisionContentInfo(arg0 *secrets.URI, arg1 int, 
 }
 
 // GetRevisionContentInfo indicates an expected call of GetRevisionContentInfo.
-func (mr *MockJujuAPIClientMockRecorder) GetRevisionContentInfo(arg0, arg1, arg2 any) *MockJujuAPIClientGetRevisionContentInfoCall {
+func (mr *MockJujuAPIClientMockRecorder) GetRevisionContentInfo(arg0, arg1, arg2, arg3 any) *MockJujuAPIClientGetRevisionContentInfoCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRevisionContentInfo", reflect.TypeOf((*MockJujuAPIClient)(nil).GetRevisionContentInfo), arg0, arg1, arg2)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRevisionContentInfo", reflect.TypeOf((*MockJujuAPIClient)(nil).GetRevisionContentInfo), arg0, arg1, arg2, arg3)
 	return &MockJujuAPIClientGetRevisionContentInfoCall{Call: call}
 }
 
@@ -152,30 +153,30 @@ func (c *MockJujuAPIClientGetRevisionContentInfoCall) Return(arg0 *secrets0.Cont
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockJujuAPIClientGetRevisionContentInfoCall) Do(f func(*secrets.URI, int, bool) (*secrets0.ContentParams, *provider.ModelBackendConfig, bool, error)) *MockJujuAPIClientGetRevisionContentInfoCall {
+func (c *MockJujuAPIClientGetRevisionContentInfoCall) Do(f func(context.Context, *secrets.URI, int, bool) (*secrets0.ContentParams, *provider.ModelBackendConfig, bool, error)) *MockJujuAPIClientGetRevisionContentInfoCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockJujuAPIClientGetRevisionContentInfoCall) DoAndReturn(f func(*secrets.URI, int, bool) (*secrets0.ContentParams, *provider.ModelBackendConfig, bool, error)) *MockJujuAPIClientGetRevisionContentInfoCall {
+func (c *MockJujuAPIClientGetRevisionContentInfoCall) DoAndReturn(f func(context.Context, *secrets.URI, int, bool) (*secrets0.ContentParams, *provider.ModelBackendConfig, bool, error)) *MockJujuAPIClientGetRevisionContentInfoCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetSecretBackendConfig mocks base method.
-func (m *MockJujuAPIClient) GetSecretBackendConfig(arg0 *string) (*provider.ModelBackendConfigInfo, error) {
+func (m *MockJujuAPIClient) GetSecretBackendConfig(arg0 context.Context, arg1 *string) (*provider.ModelBackendConfigInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetSecretBackendConfig", arg0)
+	ret := m.ctrl.Call(m, "GetSecretBackendConfig", arg0, arg1)
 	ret0, _ := ret[0].(*provider.ModelBackendConfigInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetSecretBackendConfig indicates an expected call of GetSecretBackendConfig.
-func (mr *MockJujuAPIClientMockRecorder) GetSecretBackendConfig(arg0 any) *MockJujuAPIClientGetSecretBackendConfigCall {
+func (mr *MockJujuAPIClientMockRecorder) GetSecretBackendConfig(arg0, arg1 any) *MockJujuAPIClientGetSecretBackendConfigCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecretBackendConfig", reflect.TypeOf((*MockJujuAPIClient)(nil).GetSecretBackendConfig), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecretBackendConfig", reflect.TypeOf((*MockJujuAPIClient)(nil).GetSecretBackendConfig), arg0, arg1)
 	return &MockJujuAPIClientGetSecretBackendConfigCall{Call: call}
 }
 
@@ -191,13 +192,13 @@ func (c *MockJujuAPIClientGetSecretBackendConfigCall) Return(arg0 *provider.Mode
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockJujuAPIClientGetSecretBackendConfigCall) Do(f func(*string) (*provider.ModelBackendConfigInfo, error)) *MockJujuAPIClientGetSecretBackendConfigCall {
+func (c *MockJujuAPIClientGetSecretBackendConfigCall) Do(f func(context.Context, *string) (*provider.ModelBackendConfigInfo, error)) *MockJujuAPIClientGetSecretBackendConfigCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockJujuAPIClientGetSecretBackendConfigCall) DoAndReturn(f func(*string) (*provider.ModelBackendConfigInfo, error)) *MockJujuAPIClientGetSecretBackendConfigCall {
+func (c *MockJujuAPIClientGetSecretBackendConfigCall) DoAndReturn(f func(context.Context, *string) (*provider.ModelBackendConfigInfo, error)) *MockJujuAPIClientGetSecretBackendConfigCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/upgradesteps/package_test.go
+++ b/internal/upgradesteps/package_test.go
@@ -67,7 +67,7 @@ func (s *baseSuite) expectUpgradeVersion(ver version.Number) {
 }
 
 func (s *baseSuite) expectStatus(status status.Status) {
-	s.statusSetter.EXPECT().SetStatus(status, gomock.Any(), nil).Return(nil)
+	s.statusSetter.EXPECT().SetStatus(gomock.Any(), status, gomock.Any(), nil).Return(nil)
 }
 
 func (s *baseSuite) newBaseWorker(c *gc.C, from, to version.Number) *BaseWorker {

--- a/internal/upgradesteps/status_mock_test.go
+++ b/internal/upgradesteps/status_mock_test.go
@@ -10,6 +10,7 @@
 package upgradesteps
 
 import (
+	context "context"
 	reflect "reflect"
 
 	status "github.com/juju/juju/core/status"
@@ -40,17 +41,17 @@ func (m *MockStatusSetter) EXPECT() *MockStatusSetterMockRecorder {
 }
 
 // SetStatus mocks base method.
-func (m *MockStatusSetter) SetStatus(arg0 status.Status, arg1 string, arg2 map[string]any) error {
+func (m *MockStatusSetter) SetStatus(arg0 context.Context, arg1 status.Status, arg2 string, arg3 map[string]any) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetStatus", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "SetStatus", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetStatus indicates an expected call of SetStatus.
-func (mr *MockStatusSetterMockRecorder) SetStatus(arg0, arg1, arg2 any) *MockStatusSetterSetStatusCall {
+func (mr *MockStatusSetterMockRecorder) SetStatus(arg0, arg1, arg2, arg3 any) *MockStatusSetterSetStatusCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetStatus", reflect.TypeOf((*MockStatusSetter)(nil).SetStatus), arg0, arg1, arg2)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetStatus", reflect.TypeOf((*MockStatusSetter)(nil).SetStatus), arg0, arg1, arg2, arg3)
 	return &MockStatusSetterSetStatusCall{Call: call}
 }
 
@@ -66,13 +67,13 @@ func (c *MockStatusSetterSetStatusCall) Return(arg0 error) *MockStatusSetterSetS
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStatusSetterSetStatusCall) Do(f func(status.Status, string, map[string]any) error) *MockStatusSetterSetStatusCall {
+func (c *MockStatusSetterSetStatusCall) Do(f func(context.Context, status.Status, string, map[string]any) error) *MockStatusSetterSetStatusCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStatusSetterSetStatusCall) DoAndReturn(f func(status.Status, string, map[string]any) error) *MockStatusSetterSetStatusCall {
+func (c *MockStatusSetterSetStatusCall) DoAndReturn(f func(context.Context, status.Status, string, map[string]any) error) *MockStatusSetterSetStatusCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/applicationscaler/worker.go
+++ b/internal/worker/applicationscaler/worker.go
@@ -4,6 +4,8 @@
 package applicationscaler
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/worker/v4"
 
@@ -43,7 +45,7 @@ func New(config Config) (worker.Worker, error) {
 		return nil, errors.Trace(err)
 	}
 	swConfig := watcher.StringsConfig{
-		Handler: &handler{config},
+		Handler: &handler{config: config},
 	}
 	return watcher.NewStringsWorker(swConfig)
 }
@@ -55,12 +57,12 @@ type handler struct {
 }
 
 // SetUp is part of the watcher.StringsHandler interface.
-func (handler *handler) SetUp() (watcher.StringsWatcher, error) {
+func (handler *handler) SetUp(ctx context.Context) (watcher.StringsWatcher, error) {
 	return handler.config.Facade.Watch()
 }
 
 // Handle is part of the watcher.StringsHandler interface.
-func (handler *handler) Handle(_ <-chan struct{}, applications []string) error {
+func (handler *handler) Handle(ctx context.Context, applications []string) error {
 	return handler.config.Facade.Rescale(applications)
 }
 

--- a/internal/worker/authenticationworker/mocks/updater_mocks.go
+++ b/internal/worker/authenticationworker/mocks/updater_mocks.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	watcher "github.com/juju/juju/core/watcher"
@@ -41,18 +42,18 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // AuthorisedKeys mocks base method.
-func (m *MockClient) AuthorisedKeys(arg0 names.MachineTag) ([]string, error) {
+func (m *MockClient) AuthorisedKeys(arg0 context.Context, arg1 names.MachineTag) ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AuthorisedKeys", arg0)
+	ret := m.ctrl.Call(m, "AuthorisedKeys", arg0, arg1)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // AuthorisedKeys indicates an expected call of AuthorisedKeys.
-func (mr *MockClientMockRecorder) AuthorisedKeys(arg0 any) *MockClientAuthorisedKeysCall {
+func (mr *MockClientMockRecorder) AuthorisedKeys(arg0, arg1 any) *MockClientAuthorisedKeysCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthorisedKeys", reflect.TypeOf((*MockClient)(nil).AuthorisedKeys), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthorisedKeys", reflect.TypeOf((*MockClient)(nil).AuthorisedKeys), arg0, arg1)
 	return &MockClientAuthorisedKeysCall{Call: call}
 }
 
@@ -68,30 +69,30 @@ func (c *MockClientAuthorisedKeysCall) Return(arg0 []string, arg1 error) *MockCl
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockClientAuthorisedKeysCall) Do(f func(names.MachineTag) ([]string, error)) *MockClientAuthorisedKeysCall {
+func (c *MockClientAuthorisedKeysCall) Do(f func(context.Context, names.MachineTag) ([]string, error)) *MockClientAuthorisedKeysCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockClientAuthorisedKeysCall) DoAndReturn(f func(names.MachineTag) ([]string, error)) *MockClientAuthorisedKeysCall {
+func (c *MockClientAuthorisedKeysCall) DoAndReturn(f func(context.Context, names.MachineTag) ([]string, error)) *MockClientAuthorisedKeysCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // WatchAuthorisedKeys mocks base method.
-func (m *MockClient) WatchAuthorisedKeys(arg0 names.MachineTag) (watcher.Watcher[struct{}], error) {
+func (m *MockClient) WatchAuthorisedKeys(arg0 context.Context, arg1 names.MachineTag) (watcher.Watcher[struct{}], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchAuthorisedKeys", arg0)
+	ret := m.ctrl.Call(m, "WatchAuthorisedKeys", arg0, arg1)
 	ret0, _ := ret[0].(watcher.Watcher[struct{}])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // WatchAuthorisedKeys indicates an expected call of WatchAuthorisedKeys.
-func (mr *MockClientMockRecorder) WatchAuthorisedKeys(arg0 any) *MockClientWatchAuthorisedKeysCall {
+func (mr *MockClientMockRecorder) WatchAuthorisedKeys(arg0, arg1 any) *MockClientWatchAuthorisedKeysCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchAuthorisedKeys", reflect.TypeOf((*MockClient)(nil).WatchAuthorisedKeys), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchAuthorisedKeys", reflect.TypeOf((*MockClient)(nil).WatchAuthorisedKeys), arg0, arg1)
 	return &MockClientWatchAuthorisedKeysCall{Call: call}
 }
 
@@ -107,13 +108,13 @@ func (c *MockClientWatchAuthorisedKeysCall) Return(arg0 watcher.Watcher[struct{}
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockClientWatchAuthorisedKeysCall) Do(f func(names.MachineTag) (watcher.Watcher[struct{}], error)) *MockClientWatchAuthorisedKeysCall {
+func (c *MockClientWatchAuthorisedKeysCall) Do(f func(context.Context, names.MachineTag) (watcher.Watcher[struct{}], error)) *MockClientWatchAuthorisedKeysCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockClientWatchAuthorisedKeysCall) DoAndReturn(f func(names.MachineTag) (watcher.Watcher[struct{}], error)) *MockClientWatchAuthorisedKeysCall {
+func (c *MockClientWatchAuthorisedKeysCall) DoAndReturn(f func(context.Context, names.MachineTag) (watcher.Watcher[struct{}], error)) *MockClientWatchAuthorisedKeysCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/authenticationworker/worker_test.go
+++ b/internal/worker/authenticationworker/worker_test.go
@@ -94,15 +94,15 @@ func (s *workerSuite) TestKeyUpdateRetainsExisting(c *gc.C) {
 
 	tag := names.NewMachineTag("666")
 	client := mocks.NewMockClient(ctrl)
-	client.EXPECT().AuthorisedKeys(tag).Return(s.existingModelKeys, nil)
-	client.EXPECT().WatchAuthorisedKeys(tag).Return(watch, nil)
+	client.EXPECT().AuthorisedKeys(gomock.Any(), tag).Return(s.existingModelKeys, nil)
+	client.EXPECT().WatchAuthorisedKeys(gomock.Any(), tag).Return(watch, nil)
 
 	authWorker, err := authenticationworker.NewWorker(client, agentConfig(c, names.NewMachineTag("666")))
 	c.Assert(err, jc.ErrorIsNil)
 	defer workertest.CleanKill(c, authWorker)
 
 	newKeyWithCommentPrefix := sshtesting.ValidKeyThree.Key + " Juju:user@host"
-	client.EXPECT().AuthorisedKeys(tag).Return([]string{newKeyWithCommentPrefix}, nil)
+	client.EXPECT().AuthorisedKeys(gomock.Any(), tag).Return([]string{newKeyWithCommentPrefix}, nil)
 
 	ch <- struct{}{}
 
@@ -120,15 +120,15 @@ func (s *workerSuite) TestNewKeysInJujuAreSavedOnStartup(c *gc.C) {
 
 	tag := names.NewMachineTag("666")
 	client := mocks.NewMockClient(ctrl)
-	client.EXPECT().AuthorisedKeys(tag).Return([]string{existingKey}, nil)
-	client.EXPECT().WatchAuthorisedKeys(tag).Return(watch, nil)
+	client.EXPECT().AuthorisedKeys(gomock.Any(), tag).Return([]string{existingKey}, nil)
+	client.EXPECT().WatchAuthorisedKeys(gomock.Any(), tag).Return(watch, nil)
 
 	authWorker, err := authenticationworker.NewWorker(client, agentConfig(c, names.NewMachineTag("666")))
 	c.Assert(err, jc.ErrorIsNil)
 	defer workertest.CleanKill(c, authWorker)
 
 	newKeyWithCommentPrefix := sshtesting.ValidKeyThree.Key + " Juju:user@host"
-	client.EXPECT().AuthorisedKeys(tag).Return([]string{newKeyWithCommentPrefix}, nil)
+	client.EXPECT().AuthorisedKeys(gomock.Any(), tag).Return([]string{newKeyWithCommentPrefix}, nil)
 
 	ch <- struct{}{}
 
@@ -147,8 +147,8 @@ func (s *workerSuite) TestDeleteKey(c *gc.C) {
 
 	tag := names.NewMachineTag("666")
 	client := mocks.NewMockClient(ctrl)
-	client.EXPECT().AuthorisedKeys(tag).Return(append(s.existingModelKeys, anotherKey), nil).Times(2)
-	client.EXPECT().WatchAuthorisedKeys(tag).Return(watch, nil)
+	client.EXPECT().AuthorisedKeys(gomock.Any(), tag).Return(append(s.existingModelKeys, anotherKey), nil).Times(2)
+	client.EXPECT().WatchAuthorisedKeys(gomock.Any(), tag).Return(watch, nil)
 
 	authWorker, err := authenticationworker.NewWorker(client, agentConfig(c, names.NewMachineTag("666")))
 	c.Assert(err, jc.ErrorIsNil)
@@ -160,7 +160,7 @@ func (s *workerSuite) TestDeleteKey(c *gc.C) {
 	s.waitSSHKeys(c, append(s.existingKeys, s.existingEnvKey, anotherKeyWithCommentPrefix))
 
 	// Delete the original key and check anotherKey plus the existing keys remain.
-	client.EXPECT().AuthorisedKeys(tag).Return([]string{anotherKey}, nil)
+	client.EXPECT().AuthorisedKeys(gomock.Any(), tag).Return([]string{anotherKey}, nil)
 	ch <- struct{}{}
 
 	s.waitSSHKeys(c, append(s.existingKeys, anotherKeyWithCommentPrefix))
@@ -175,8 +175,8 @@ func (s *workerSuite) TestMultipleChanges(c *gc.C) {
 
 	tag := names.NewMachineTag("666")
 	client := mocks.NewMockClient(ctrl)
-	client.EXPECT().AuthorisedKeys(tag).Return(s.existingModelKeys, nil)
-	client.EXPECT().WatchAuthorisedKeys(tag).Return(watch, nil)
+	client.EXPECT().AuthorisedKeys(gomock.Any(), tag).Return(s.existingModelKeys, nil)
+	client.EXPECT().WatchAuthorisedKeys(gomock.Any(), tag).Return(watch, nil)
 
 	authWorker, err := authenticationworker.NewWorker(client, agentConfig(c, names.NewMachineTag("666")))
 	c.Assert(err, jc.ErrorIsNil)
@@ -186,7 +186,7 @@ func (s *workerSuite) TestMultipleChanges(c *gc.C) {
 	// added: key 3
 	// deleted: key 1 (existing env key)
 	yetAnotherKeyWithComment := sshtesting.ValidKeyThree.Key + " Juju:yetanother@host"
-	client.EXPECT().AuthorisedKeys(tag).Return([]string{yetAnotherKeyWithComment}, nil)
+	client.EXPECT().AuthorisedKeys(gomock.Any(), tag).Return([]string{yetAnotherKeyWithComment}, nil)
 
 	ch <- struct{}{}
 
@@ -203,13 +203,13 @@ func (s *workerSuite) TestWorkerRestart(c *gc.C) {
 	tag := names.NewMachineTag("666")
 	client := mocks.NewMockClient(ctrl)
 
-	client.EXPECT().WatchAuthorisedKeys(tag).Return(watch, nil).MinTimes(1)
+	client.EXPECT().WatchAuthorisedKeys(gomock.Any(), tag).Return(watch, nil).MinTimes(1)
 
 	yetAnotherKeyWithCommentPrefix := sshtesting.ValidKeyThree.Key + " Juju:yetanother@host"
 
 	gomock.InOrder(
-		client.EXPECT().AuthorisedKeys(tag).Return(s.existingModelKeys, nil).Times(2),
-		client.EXPECT().AuthorisedKeys(tag).Return([]string{yetAnotherKeyWithCommentPrefix}, nil),
+		client.EXPECT().AuthorisedKeys(gomock.Any(), tag).Return(s.existingModelKeys, nil).Times(2),
+		client.EXPECT().AuthorisedKeys(gomock.Any(), tag).Return([]string{yetAnotherKeyWithCommentPrefix}, nil),
 	)
 
 	authWorker, err := authenticationworker.NewWorker(client, agentConfig(c, names.NewMachineTag("666")))

--- a/internal/worker/caasapplicationprovisioner/application.go
+++ b/internal/worker/caasapplicationprovisioner/application.go
@@ -137,7 +137,7 @@ func (a *appWorker) loop() error {
 	}
 
 	// Ensure the charm is to a v2 charm.
-	isOk, err := a.ops.CheckCharmFormat(a.name, a.facade, a.logger)
+	isOk, err := a.ops.CheckCharmFormat(ctx, a.name, a.facade, a.logger)
 	if !isOk || err != nil {
 		return errors.Trace(err)
 	}
@@ -241,7 +241,7 @@ func (a *appWorker) loop() error {
 				appProvisionChanges = appProvisionWatcher.Changes()
 			}
 			if !a.statusOnly {
-				err = a.ops.AppAlive(a.name, app, a.password, &a.lastApplied, a.facade, a.clock, a.logger)
+				err = a.ops.AppAlive(ctx, a.name, app, a.password, &a.lastApplied, a.facade, a.clock, a.logger)
 				if errors.Is(err, errors.NotProvisioned) {
 					// State not ready for this application to be provisioned yet.
 					// Usually because the charm has not yet been downloaded.

--- a/internal/worker/caasapplicationprovisioner/application_test.go
+++ b/internal/worker/caasapplicationprovisioner/application_test.go
@@ -4,6 +4,7 @@
 package caasapplicationprovisioner_test
 
 import (
+	"context"
 	"time"
 
 	"github.com/juju/clock"
@@ -162,7 +163,7 @@ func (s *ApplicationWorkerSuite) TestWorker(c *gc.C) {
 		broker.EXPECT().Application("test", caas.DeploymentStateful).Return(app),
 		facade.EXPECT().Life("test").Return(life.Alive, nil),
 
-		ops.EXPECT().CheckCharmFormat("test", gomock.Any(), gomock.Any()).Return(true, nil),
+		ops.EXPECT().CheckCharmFormat(gomock.Any(), "test", gomock.Any(), gomock.Any()).Return(true, nil),
 
 		facade.EXPECT().SetPassword("test", gomock.Any()).Return(nil),
 
@@ -174,7 +175,7 @@ func (s *ApplicationWorkerSuite) TestWorker(c *gc.C) {
 		facade.EXPECT().Life("test").Return(life.Alive, nil),
 		facade.EXPECT().ProvisioningState("test").Return(nil, nil),
 		facade.EXPECT().WatchProvisioningInfo("test").Return(watchertest.NewMockNotifyWatcher(provisioningInfoChan), nil),
-		ops.EXPECT().AppAlive("test", app, gomock.Any(), gomock.Any(), facade, clk, s.logger).Return(nil),
+		ops.EXPECT().AppAlive(gomock.Any(), "test", app, gomock.Any(), gomock.Any(), facade, clk, s.logger).Return(nil),
 		app.EXPECT().Watch(gomock.Any()).Return(watchertest.NewMockNotifyWatcher(appChan), nil),
 		app.EXPECT().WatchReplicas().DoAndReturn(func() (watcher.NotifyWatcher, error) {
 			scaleChan <- struct{}{}
@@ -217,7 +218,7 @@ func (s *ApplicationWorkerSuite) TestWorker(c *gc.C) {
 
 		// provisioningInfoChan fired
 		facade.EXPECT().Life("test").Return(life.Alive, nil),
-		ops.EXPECT().AppAlive("test", app, gomock.Any(), gomock.Any(), facade, clk, s.logger).DoAndReturn(func(s1 string, _ caas.Application, s2 string, ac *caas.ApplicationConfig, _ caasapplicationprovisioner.CAASProvisionerFacade, c clock.Clock, _ logger.Logger) error {
+		ops.EXPECT().AppAlive(gomock.Any(), "test", app, gomock.Any(), gomock.Any(), facade, clk, s.logger).DoAndReturn(func(_ context.Context, s1 string, _ caas.Application, s2 string, ac *caas.ApplicationConfig, _ caasapplicationprovisioner.CAASProvisionerFacade, c clock.Clock, _ logger.Logger) error {
 			provisioningInfoChan <- struct{}{}
 			return nil
 		}),
@@ -265,7 +266,7 @@ func (s *ApplicationWorkerSuite) TestWorkerStatusOnly(c *gc.C) {
 		broker.EXPECT().Application("test", caas.DeploymentStateful).Return(app),
 		facade.EXPECT().Life("test").Return(life.Alive, nil),
 
-		ops.EXPECT().CheckCharmFormat("test", gomock.Any(), gomock.Any()).Return(true, nil),
+		ops.EXPECT().CheckCharmFormat(gomock.Any(), "test", gomock.Any(), gomock.Any()).Return(true, nil),
 
 		unitFacade.EXPECT().WatchApplicationScale("test").Return(watchertest.NewMockNotifyWatcher(scaleChan), nil),
 		unitFacade.EXPECT().WatchApplicationTrustHash("test").Return(watchertest.NewMockStringsWatcher(trustChan), nil),

--- a/internal/worker/caasapplicationprovisioner/mocks/facade_mock.go
+++ b/internal/worker/caasapplicationprovisioner/mocks/facade_mock.go
@@ -47,18 +47,18 @@ func (m *MockCAASProvisionerFacade) EXPECT() *MockCAASProvisionerFacadeMockRecor
 }
 
 // ApplicationCharmInfo mocks base method.
-func (m *MockCAASProvisionerFacade) ApplicationCharmInfo(arg0 string) (*charms.CharmInfo, error) {
+func (m *MockCAASProvisionerFacade) ApplicationCharmInfo(arg0 context.Context, arg1 string) (*charms.CharmInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ApplicationCharmInfo", arg0)
+	ret := m.ctrl.Call(m, "ApplicationCharmInfo", arg0, arg1)
 	ret0, _ := ret[0].(*charms.CharmInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ApplicationCharmInfo indicates an expected call of ApplicationCharmInfo.
-func (mr *MockCAASProvisionerFacadeMockRecorder) ApplicationCharmInfo(arg0 any) *MockCAASProvisionerFacadeApplicationCharmInfoCall {
+func (mr *MockCAASProvisionerFacadeMockRecorder) ApplicationCharmInfo(arg0, arg1 any) *MockCAASProvisionerFacadeApplicationCharmInfoCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplicationCharmInfo", reflect.TypeOf((*MockCAASProvisionerFacade)(nil).ApplicationCharmInfo), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplicationCharmInfo", reflect.TypeOf((*MockCAASProvisionerFacade)(nil).ApplicationCharmInfo), arg0, arg1)
 	return &MockCAASProvisionerFacadeApplicationCharmInfoCall{Call: call}
 }
 
@@ -74,13 +74,13 @@ func (c *MockCAASProvisionerFacadeApplicationCharmInfoCall) Return(arg0 *charms.
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockCAASProvisionerFacadeApplicationCharmInfoCall) Do(f func(string) (*charms.CharmInfo, error)) *MockCAASProvisionerFacadeApplicationCharmInfoCall {
+func (c *MockCAASProvisionerFacadeApplicationCharmInfoCall) Do(f func(context.Context, string) (*charms.CharmInfo, error)) *MockCAASProvisionerFacadeApplicationCharmInfoCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockCAASProvisionerFacadeApplicationCharmInfoCall) DoAndReturn(f func(string) (*charms.CharmInfo, error)) *MockCAASProvisionerFacadeApplicationCharmInfoCall {
+func (c *MockCAASProvisionerFacadeApplicationCharmInfoCall) DoAndReturn(f func(context.Context, string) (*charms.CharmInfo, error)) *MockCAASProvisionerFacadeApplicationCharmInfoCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -125,18 +125,18 @@ func (c *MockCAASProvisionerFacadeApplicationOCIResourcesCall) DoAndReturn(f fun
 }
 
 // CharmInfo mocks base method.
-func (m *MockCAASProvisionerFacade) CharmInfo(arg0 string) (*charms.CharmInfo, error) {
+func (m *MockCAASProvisionerFacade) CharmInfo(arg0 context.Context, arg1 string) (*charms.CharmInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CharmInfo", arg0)
+	ret := m.ctrl.Call(m, "CharmInfo", arg0, arg1)
 	ret0, _ := ret[0].(*charms.CharmInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CharmInfo indicates an expected call of CharmInfo.
-func (mr *MockCAASProvisionerFacadeMockRecorder) CharmInfo(arg0 any) *MockCAASProvisionerFacadeCharmInfoCall {
+func (mr *MockCAASProvisionerFacadeMockRecorder) CharmInfo(arg0, arg1 any) *MockCAASProvisionerFacadeCharmInfoCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CharmInfo", reflect.TypeOf((*MockCAASProvisionerFacade)(nil).CharmInfo), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CharmInfo", reflect.TypeOf((*MockCAASProvisionerFacade)(nil).CharmInfo), arg0, arg1)
 	return &MockCAASProvisionerFacadeCharmInfoCall{Call: call}
 }
 
@@ -152,13 +152,13 @@ func (c *MockCAASProvisionerFacadeCharmInfoCall) Return(arg0 *charms.CharmInfo, 
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockCAASProvisionerFacadeCharmInfoCall) Do(f func(string) (*charms.CharmInfo, error)) *MockCAASProvisionerFacadeCharmInfoCall {
+func (c *MockCAASProvisionerFacadeCharmInfoCall) Do(f func(context.Context, string) (*charms.CharmInfo, error)) *MockCAASProvisionerFacadeCharmInfoCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockCAASProvisionerFacadeCharmInfoCall) DoAndReturn(f func(string) (*charms.CharmInfo, error)) *MockCAASProvisionerFacadeCharmInfoCall {
+func (c *MockCAASProvisionerFacadeCharmInfoCall) DoAndReturn(f func(context.Context, string) (*charms.CharmInfo, error)) *MockCAASProvisionerFacadeCharmInfoCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/caasapplicationprovisioner/mocks/ops_mock.go
+++ b/internal/worker/caasapplicationprovisioner/mocks/ops_mock.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	clock "github.com/juju/clock"
@@ -45,17 +46,17 @@ func (m *MockApplicationOps) EXPECT() *MockApplicationOpsMockRecorder {
 }
 
 // AppAlive mocks base method.
-func (m *MockApplicationOps) AppAlive(arg0 string, arg1 caas.Application, arg2 string, arg3 *caas.ApplicationConfig, arg4 caasapplicationprovisioner.CAASProvisionerFacade, arg5 clock.Clock, arg6 logger.Logger) error {
+func (m *MockApplicationOps) AppAlive(arg0 context.Context, arg1 string, arg2 caas.Application, arg3 string, arg4 *caas.ApplicationConfig, arg5 caasapplicationprovisioner.CAASProvisionerFacade, arg6 clock.Clock, arg7 logger.Logger) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AppAlive", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
+	ret := m.ctrl.Call(m, "AppAlive", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // AppAlive indicates an expected call of AppAlive.
-func (mr *MockApplicationOpsMockRecorder) AppAlive(arg0, arg1, arg2, arg3, arg4, arg5, arg6 any) *MockApplicationOpsAppAliveCall {
+func (mr *MockApplicationOpsMockRecorder) AppAlive(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7 any) *MockApplicationOpsAppAliveCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppAlive", reflect.TypeOf((*MockApplicationOps)(nil).AppAlive), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppAlive", reflect.TypeOf((*MockApplicationOps)(nil).AppAlive), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
 	return &MockApplicationOpsAppAliveCall{Call: call}
 }
 
@@ -71,13 +72,13 @@ func (c *MockApplicationOpsAppAliveCall) Return(arg0 error) *MockApplicationOpsA
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationOpsAppAliveCall) Do(f func(string, caas.Application, string, *caas.ApplicationConfig, caasapplicationprovisioner.CAASProvisionerFacade, clock.Clock, logger.Logger) error) *MockApplicationOpsAppAliveCall {
+func (c *MockApplicationOpsAppAliveCall) Do(f func(context.Context, string, caas.Application, string, *caas.ApplicationConfig, caasapplicationprovisioner.CAASProvisionerFacade, clock.Clock, logger.Logger) error) *MockApplicationOpsAppAliveCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationOpsAppAliveCall) DoAndReturn(f func(string, caas.Application, string, *caas.ApplicationConfig, caasapplicationprovisioner.CAASProvisionerFacade, clock.Clock, logger.Logger) error) *MockApplicationOpsAppAliveCall {
+func (c *MockApplicationOpsAppAliveCall) DoAndReturn(f func(context.Context, string, caas.Application, string, *caas.ApplicationConfig, caasapplicationprovisioner.CAASProvisionerFacade, clock.Clock, logger.Logger) error) *MockApplicationOpsAppAliveCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -159,18 +160,18 @@ func (c *MockApplicationOpsAppDyingCall) DoAndReturn(f func(string, caas.Applica
 }
 
 // CheckCharmFormat mocks base method.
-func (m *MockApplicationOps) CheckCharmFormat(arg0 string, arg1 caasapplicationprovisioner.CAASProvisionerFacade, arg2 logger.Logger) (bool, error) {
+func (m *MockApplicationOps) CheckCharmFormat(arg0 context.Context, arg1 string, arg2 caasapplicationprovisioner.CAASProvisionerFacade, arg3 logger.Logger) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CheckCharmFormat", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "CheckCharmFormat", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CheckCharmFormat indicates an expected call of CheckCharmFormat.
-func (mr *MockApplicationOpsMockRecorder) CheckCharmFormat(arg0, arg1, arg2 any) *MockApplicationOpsCheckCharmFormatCall {
+func (mr *MockApplicationOpsMockRecorder) CheckCharmFormat(arg0, arg1, arg2, arg3 any) *MockApplicationOpsCheckCharmFormatCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckCharmFormat", reflect.TypeOf((*MockApplicationOps)(nil).CheckCharmFormat), arg0, arg1, arg2)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckCharmFormat", reflect.TypeOf((*MockApplicationOps)(nil).CheckCharmFormat), arg0, arg1, arg2, arg3)
 	return &MockApplicationOpsCheckCharmFormatCall{Call: call}
 }
 
@@ -186,13 +187,13 @@ func (c *MockApplicationOpsCheckCharmFormatCall) Return(arg0 bool, arg1 error) *
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationOpsCheckCharmFormatCall) Do(f func(string, caasapplicationprovisioner.CAASProvisionerFacade, logger.Logger) (bool, error)) *MockApplicationOpsCheckCharmFormatCall {
+func (c *MockApplicationOpsCheckCharmFormatCall) Do(f func(context.Context, string, caasapplicationprovisioner.CAASProvisionerFacade, logger.Logger) (bool, error)) *MockApplicationOpsCheckCharmFormatCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationOpsCheckCharmFormatCall) DoAndReturn(f func(string, caasapplicationprovisioner.CAASProvisionerFacade, logger.Logger) (bool, error)) *MockApplicationOpsCheckCharmFormatCall {
+func (c *MockApplicationOpsCheckCharmFormatCall) DoAndReturn(f func(context.Context, string, caasapplicationprovisioner.CAASProvisionerFacade, logger.Logger) (bool, error)) *MockApplicationOpsCheckCharmFormatCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/caasapplicationprovisioner/ops_test.go
+++ b/internal/worker/caasapplicationprovisioner/ops_test.go
@@ -4,6 +4,8 @@
 package caasapplicationprovisioner_test
 
 import (
+	"context"
+
 	"github.com/juju/clock/testclock"
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
@@ -59,12 +61,10 @@ func (s *OpsSuite) TestCheckCharmFormatV1(c *gc.C) {
 
 	facade := mocks.NewMockCAASProvisionerFacade(ctrl)
 
-	gomock.InOrder(
-		// Wait till charm is v2
-		facade.EXPECT().ApplicationCharmInfo("test").Return(charmInfoV1, nil),
-	)
+	// Wait till charm is v2
+	facade.EXPECT().ApplicationCharmInfo(gomock.Any(), "test").Return(charmInfoV1, nil)
 
-	isOk, err := caasapplicationprovisioner.AppOps.CheckCharmFormat("test", facade, s.logger)
+	isOk, err := caasapplicationprovisioner.AppOps.CheckCharmFormat(context.Background(), "test", facade, s.logger)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(isOk, jc.IsFalse)
 }
@@ -80,12 +80,10 @@ func (s *OpsSuite) TestCheckCharmFormatV2(c *gc.C) {
 
 	facade := mocks.NewMockCAASProvisionerFacade(ctrl)
 
-	gomock.InOrder(
-		// Wait till charm is v2
-		facade.EXPECT().ApplicationCharmInfo("test").Return(charmInfoV2, nil),
-	)
+	// Wait till charm is v2
+	facade.EXPECT().ApplicationCharmInfo(gomock.Any(), "test").Return(charmInfoV2, nil)
 
-	isOk, err := caasapplicationprovisioner.AppOps.CheckCharmFormat("test", facade, s.logger)
+	isOk, err := caasapplicationprovisioner.AppOps.CheckCharmFormat(context.Background(), "test", facade, s.logger)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(isOk, jc.IsTrue)
 }
@@ -96,13 +94,11 @@ func (s *OpsSuite) TestCheckCharmFormatNotFound(c *gc.C) {
 
 	facade := mocks.NewMockCAASProvisionerFacade(ctrl)
 
-	gomock.InOrder(
-		facade.EXPECT().ApplicationCharmInfo("test").DoAndReturn(func(appName string) (*charmscommon.CharmInfo, error) {
-			return nil, errors.NotFoundf("test charm")
-		}),
-	)
+	facade.EXPECT().ApplicationCharmInfo(gomock.Any(), "test").DoAndReturn(func(_ context.Context, appName string) (*charmscommon.CharmInfo, error) {
+		return nil, errors.NotFoundf("test charm")
+	})
 
-	isOk, err := caasapplicationprovisioner.AppOps.CheckCharmFormat("test", facade, s.logger)
+	isOk, err := caasapplicationprovisioner.AppOps.CheckCharmFormat(context.Background(), "test", facade, s.logger)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(isOk, jc.IsFalse)
 }
@@ -546,7 +542,7 @@ func (s *OpsSuite) TestAppAlive(c *gc.C) {
 	}
 	gomock.InOrder(
 		facade.EXPECT().ProvisioningInfo("test").Return(pi, nil),
-		facade.EXPECT().CharmInfo("ch:my-app").Return(&charmInfo, nil),
+		facade.EXPECT().CharmInfo(gomock.Any(), "ch:my-app").Return(&charmInfo, nil),
 		app.EXPECT().Exists().Return(ds, nil),
 		app.EXPECT().Exists().Return(caas.DeploymentState{}, nil),
 		facade.EXPECT().ApplicationOCIResources("test").Return(oci, nil),
@@ -556,7 +552,7 @@ func (s *OpsSuite) TestAppAlive(c *gc.C) {
 		}),
 	)
 
-	err := caasapplicationprovisioner.AppOps.AppAlive("test", app, password, &lastApplied, facade, clk, s.logger)
+	err := caasapplicationprovisioner.AppOps.AppAlive(context.Background(), "test", app, password, &lastApplied, facade, clk, s.logger)
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/internal/worker/caasapplicationprovisioner/worker.go
+++ b/internal/worker/caasapplicationprovisioner/worker.go
@@ -47,8 +47,8 @@ type CAASProvisionerFacade interface {
 	WatchApplications() (watcher.StringsWatcher, error)
 	SetPassword(string, string) error
 	Life(string) (life.Value, error)
-	CharmInfo(string) (*charmscommon.CharmInfo, error)
-	ApplicationCharmInfo(string) (*charmscommon.CharmInfo, error)
+	CharmInfo(context.Context, string) (*charmscommon.CharmInfo, error)
+	ApplicationCharmInfo(context.Context, string) (*charmscommon.CharmInfo, error)
 	SetOperatorStatus(appName string, status status.Status, message string, data map[string]interface{}) error
 	Units(appName string) ([]params.CAASUnit, error)
 	ApplicationOCIResources(appName string) (map[string]resources.DockerImageDetails, error)

--- a/internal/worker/caasbroker/broker.go
+++ b/internal/worker/caasbroker/broker.go
@@ -26,7 +26,7 @@ type ConfigAPI interface {
 	ModelConfig(context.Context) (*config.Config, error)
 	ControllerConfig(context.Context) (controller.Config, error)
 	WatchForModelConfigChanges(context.Context) (watcher.NotifyWatcher, error)
-	WatchCloudSpecChanges() (watcher.NotifyWatcher, error)
+	WatchCloudSpecChanges(context.Context) (watcher.NotifyWatcher, error)
 }
 
 // Config describes the dependencies of a Tracker.
@@ -137,7 +137,7 @@ func (t *Tracker) loop() error {
 	if cloudSpecSetter, ok = t.broker.(environs.CloudSpecSetter); !ok {
 		logger.Warningf("cloud type %v doesn't support dynamic changing of cloud spec", t.broker.Config().Type())
 	} else {
-		cloudWatcher, err := t.config.ConfigAPI.WatchCloudSpecChanges()
+		cloudWatcher, err := t.config.ConfigAPI.WatchCloudSpecChanges(ctx)
 		if err != nil {
 			return errors.Annotate(err, "cannot watch environ cloud spec")
 		}

--- a/internal/worker/caasbroker/fixture_test.go
+++ b/internal/worker/caasbroker/fixture_test.go
@@ -145,7 +145,7 @@ func (context *runContext) WatchForModelConfigChanges(_ context.Context) (watche
 	return context.watcher, nil
 }
 
-func (context *runContext) WatchCloudSpecChanges() (watcher.NotifyWatcher, error) {
+func (context *runContext) WatchCloudSpecChanges(_ context.Context) (watcher.NotifyWatcher, error) {
 	context.mu.Lock()
 	defer context.mu.Unlock()
 	context.stub.AddCall("WatchCloudSpecChanges")

--- a/internal/worker/caasfirewaller/client.go
+++ b/internal/worker/caasfirewaller/client.go
@@ -34,7 +34,7 @@ type CAASFirewallerAPI interface {
 	IsExposed(string) (bool, error)
 	ApplicationConfig(string) (config.ConfigAttributes, error)
 
-	ApplicationCharmInfo(appName string) (*charmscommon.CharmInfo, error)
+	ApplicationCharmInfo(ctx context.Context, appName string) (*charmscommon.CharmInfo, error)
 }
 
 // LifeGetter provides an interface for getting the

--- a/internal/worker/caasfirewaller/mocks/client_mock.go
+++ b/internal/worker/caasfirewaller/mocks/client_mock.go
@@ -45,18 +45,18 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // ApplicationCharmInfo mocks base method.
-func (m *MockClient) ApplicationCharmInfo(arg0 string) (*charms.CharmInfo, error) {
+func (m *MockClient) ApplicationCharmInfo(arg0 context.Context, arg1 string) (*charms.CharmInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ApplicationCharmInfo", arg0)
+	ret := m.ctrl.Call(m, "ApplicationCharmInfo", arg0, arg1)
 	ret0, _ := ret[0].(*charms.CharmInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ApplicationCharmInfo indicates an expected call of ApplicationCharmInfo.
-func (mr *MockClientMockRecorder) ApplicationCharmInfo(arg0 any) *MockClientApplicationCharmInfoCall {
+func (mr *MockClientMockRecorder) ApplicationCharmInfo(arg0, arg1 any) *MockClientApplicationCharmInfoCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplicationCharmInfo", reflect.TypeOf((*MockClient)(nil).ApplicationCharmInfo), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplicationCharmInfo", reflect.TypeOf((*MockClient)(nil).ApplicationCharmInfo), arg0, arg1)
 	return &MockClientApplicationCharmInfoCall{Call: call}
 }
 
@@ -72,13 +72,13 @@ func (c *MockClientApplicationCharmInfoCall) Return(arg0 *charms.CharmInfo, arg1
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockClientApplicationCharmInfoCall) Do(f func(string) (*charms.CharmInfo, error)) *MockClientApplicationCharmInfoCall {
+func (c *MockClientApplicationCharmInfoCall) Do(f func(context.Context, string) (*charms.CharmInfo, error)) *MockClientApplicationCharmInfoCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockClientApplicationCharmInfoCall) DoAndReturn(f func(string) (*charms.CharmInfo, error)) *MockClientApplicationCharmInfoCall {
+func (c *MockClientApplicationCharmInfoCall) DoAndReturn(f func(context.Context, string) (*charms.CharmInfo, error)) *MockClientApplicationCharmInfoCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -380,18 +380,18 @@ func (m *MockCAASFirewallerAPI) EXPECT() *MockCAASFirewallerAPIMockRecorder {
 }
 
 // ApplicationCharmInfo mocks base method.
-func (m *MockCAASFirewallerAPI) ApplicationCharmInfo(arg0 string) (*charms.CharmInfo, error) {
+func (m *MockCAASFirewallerAPI) ApplicationCharmInfo(arg0 context.Context, arg1 string) (*charms.CharmInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ApplicationCharmInfo", arg0)
+	ret := m.ctrl.Call(m, "ApplicationCharmInfo", arg0, arg1)
 	ret0, _ := ret[0].(*charms.CharmInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ApplicationCharmInfo indicates an expected call of ApplicationCharmInfo.
-func (mr *MockCAASFirewallerAPIMockRecorder) ApplicationCharmInfo(arg0 any) *MockCAASFirewallerAPIApplicationCharmInfoCall {
+func (mr *MockCAASFirewallerAPIMockRecorder) ApplicationCharmInfo(arg0, arg1 any) *MockCAASFirewallerAPIApplicationCharmInfoCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplicationCharmInfo", reflect.TypeOf((*MockCAASFirewallerAPI)(nil).ApplicationCharmInfo), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplicationCharmInfo", reflect.TypeOf((*MockCAASFirewallerAPI)(nil).ApplicationCharmInfo), arg0, arg1)
 	return &MockCAASFirewallerAPIApplicationCharmInfoCall{Call: call}
 }
 
@@ -407,13 +407,13 @@ func (c *MockCAASFirewallerAPIApplicationCharmInfoCall) Return(arg0 *charms.Char
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockCAASFirewallerAPIApplicationCharmInfoCall) Do(f func(string) (*charms.CharmInfo, error)) *MockCAASFirewallerAPIApplicationCharmInfoCall {
+func (c *MockCAASFirewallerAPIApplicationCharmInfoCall) Do(f func(context.Context, string) (*charms.CharmInfo, error)) *MockCAASFirewallerAPIApplicationCharmInfoCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockCAASFirewallerAPIApplicationCharmInfoCall) DoAndReturn(f func(string) (*charms.CharmInfo, error)) *MockCAASFirewallerAPIApplicationCharmInfoCall {
+func (c *MockCAASFirewallerAPIApplicationCharmInfoCall) DoAndReturn(f func(context.Context, string) (*charms.CharmInfo, error)) *MockCAASFirewallerAPIApplicationCharmInfoCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/caasfirewaller/worker_test.go
+++ b/internal/worker/caasfirewaller/worker_test.go
@@ -146,23 +146,23 @@ func (s *workerSuite) TestStartStop(c *gc.C) {
 		Meta:     &charm.Meta{},
 		Manifest: &charm.Manifest{Bases: []charm.Base{{}}}, // bases make it a v2 charm
 	}
-	s.firewallerAPI.EXPECT().ApplicationCharmInfo("app1").Return(charmInfo, nil)
+	s.firewallerAPI.EXPECT().ApplicationCharmInfo(gomock.Any(), "app1").Return(charmInfo, nil)
 	s.lifeGetter.EXPECT().Life("app1").Return(life.Alive, nil)
 	// Added app1's worker to catacomb.
 	app1Worker.EXPECT().Wait().Return(nil)
 
-	s.firewallerAPI.EXPECT().ApplicationCharmInfo("app2").Return(charmInfo, nil)
+	s.firewallerAPI.EXPECT().ApplicationCharmInfo(gomock.Any(), "app2").Return(charmInfo, nil)
 	s.lifeGetter.EXPECT().Life("app2").Return(life.Alive, nil)
 	// Added app2's worker to catacomb.
 	app2Worker.EXPECT().Wait().Return(nil)
 
-	s.firewallerAPI.EXPECT().ApplicationCharmInfo("app1").Return(charmInfo, nil)
+	s.firewallerAPI.EXPECT().ApplicationCharmInfo(gomock.Any(), "app1").Return(charmInfo, nil)
 	s.lifeGetter.EXPECT().Life("app1").Return(life.Value(""), errors.NotFoundf("%q", "app1"))
 	// Stopped app1's worker because it's removed.
 	app1Worker.EXPECT().Kill()
 	app1Worker.EXPECT().Wait().Return(nil)
 
-	s.firewallerAPI.EXPECT().ApplicationCharmInfo("app2").Return(charmInfo, nil)
+	s.firewallerAPI.EXPECT().ApplicationCharmInfo(gomock.Any(), "app2").Return(charmInfo, nil)
 	s.lifeGetter.EXPECT().Life("app2").Return(life.Dead, nil)
 	// Stopped app2's worker because it's dead.
 	app2Worker.EXPECT().Kill()
@@ -186,7 +186,7 @@ func (s *workerSuite) TestV1CharmSkipsProcessing(c *gc.C) {
 		Meta:     &charm.Meta{},
 		Manifest: &charm.Manifest{},
 	}
-	s.firewallerAPI.EXPECT().ApplicationCharmInfo("app1").Return(charmInfo, nil)
+	s.firewallerAPI.EXPECT().ApplicationCharmInfo(gomock.Any(), "app1").Return(charmInfo, nil)
 
 	w, err := caasfirewaller.NewWorkerForTest(s.config, nil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -202,7 +202,7 @@ func (s *workerSuite) TestNotFoundCharmSkipsProcessing(c *gc.C) {
 		s.applicationChanges <- []string{"app1"}
 	}()
 
-	s.firewallerAPI.EXPECT().ApplicationCharmInfo("app1").Return(nil, errors.NotFoundf("app1"))
+	s.firewallerAPI.EXPECT().ApplicationCharmInfo(gomock.Any(), "app1").Return(nil, errors.NotFoundf("app1"))
 
 	w, err := caasfirewaller.NewWorkerForTest(s.config, nil)
 	c.Assert(err, jc.ErrorIsNil)

--- a/internal/worker/caasupgrader/mock_test.go
+++ b/internal/worker/caasupgrader/mock_test.go
@@ -20,18 +20,18 @@ type mockUpgraderClient struct {
 	watcher watcher.NotifyWatcher
 }
 
-func (m *mockUpgraderClient) DesiredVersion(tag string) (version.Number, error) {
+func (m *mockUpgraderClient) DesiredVersion(_ context.Context, tag string) (version.Number, error) {
 	m.Stub.AddCall("DesiredVersion", tag)
 	return m.desired, nil
 }
 
-func (m *mockUpgraderClient) SetVersion(tag string, v version.Binary) error {
+func (m *mockUpgraderClient) SetVersion(_ context.Context, tag string, v version.Binary) error {
 	m.Stub.AddCall("SetVersion", tag, v)
 	m.actual = v
 	return nil
 }
 
-func (m *mockUpgraderClient) WatchAPIVersion(agentTag string) (watcher.NotifyWatcher, error) {
+func (m *mockUpgraderClient) WatchAPIVersion(_ context.Context, agentTag string) (watcher.NotifyWatcher, error) {
 	return m.watcher, nil
 }
 

--- a/internal/worker/containerbroker/broker.go
+++ b/internal/worker/containerbroker/broker.go
@@ -44,7 +44,7 @@ type Config struct {
 type State interface {
 	broker.APICalls
 	Machines(context.Context, ...names.MachineTag) ([]provisioner.MachineResult, error)
-	ContainerManagerConfig(params.ContainerManagerConfigParams) (params.ContainerManagerConfig, error)
+	ContainerManagerConfig(context.Context, params.ContainerManagerConfigParams) (params.ContainerManagerConfig, error)
 }
 
 // Validate returns an error if the config cannot be used to start a Tracker.
@@ -108,13 +108,14 @@ func NewTracker(ctx context.Context, config Config) (*Tracker, error) {
 	// types to prevent confusion.
 	containerType := instance.LXD
 	managerConfigResult, err := provisioner.ContainerManagerConfig(
+		ctx,
 		params.ContainerManagerConfigParams{Type: containerType},
 	)
 	if err != nil {
 		return nil, errors.Annotate(err, "generating container manager config")
 	}
 	managerConfig := container.ManagerConfig(managerConfigResult.ManagerConfig)
-	managerConfigWithZones, err := broker.ConfigureAvailabilityZone(managerConfig, result[0].Machine)
+	managerConfigWithZones, err := broker.ConfigureAvailabilityZone(ctx, managerConfig, result[0].Machine)
 	if err != nil {
 		return nil, errors.Annotate(err, "configuring availability zones")
 	}

--- a/internal/worker/containerbroker/broker_test.go
+++ b/internal/worker/containerbroker/broker_test.go
@@ -245,10 +245,10 @@ func (s *trackerSuite) expectDeadMachines() {
 }
 
 func (s *trackerSuite) expectContainerConfig() {
-	s.state.EXPECT().ContainerManagerConfig(params.ContainerManagerConfigParams{
+	s.state.EXPECT().ContainerManagerConfig(gomock.Any(), params.ContainerManagerConfigParams{
 		Type: instance.LXD,
 	}).Return(params.ContainerManagerConfig{
 		ManagerConfig: make(map[string]string),
 	}, nil)
-	s.machine.EXPECT().AvailabilityZone().Return("0", nil)
+	s.machine.EXPECT().AvailabilityZone(gomock.Any()).Return("0", nil)
 }

--- a/internal/worker/containerbroker/mocks/machine_mock.go
+++ b/internal/worker/containerbroker/mocks/machine_mock.go
@@ -47,18 +47,18 @@ func (m *MockMachineProvisioner) EXPECT() *MockMachineProvisionerMockRecorder {
 }
 
 // AvailabilityZone mocks base method.
-func (m *MockMachineProvisioner) AvailabilityZone() (string, error) {
+func (m *MockMachineProvisioner) AvailabilityZone(arg0 context.Context) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AvailabilityZone")
+	ret := m.ctrl.Call(m, "AvailabilityZone", arg0)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // AvailabilityZone indicates an expected call of AvailabilityZone.
-func (mr *MockMachineProvisionerMockRecorder) AvailabilityZone() *MockMachineProvisionerAvailabilityZoneCall {
+func (mr *MockMachineProvisionerMockRecorder) AvailabilityZone(arg0 any) *MockMachineProvisionerAvailabilityZoneCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AvailabilityZone", reflect.TypeOf((*MockMachineProvisioner)(nil).AvailabilityZone))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AvailabilityZone", reflect.TypeOf((*MockMachineProvisioner)(nil).AvailabilityZone), arg0)
 	return &MockMachineProvisionerAvailabilityZoneCall{Call: call}
 }
 
@@ -74,30 +74,30 @@ func (c *MockMachineProvisionerAvailabilityZoneCall) Return(arg0 string, arg1 er
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineProvisionerAvailabilityZoneCall) Do(f func() (string, error)) *MockMachineProvisionerAvailabilityZoneCall {
+func (c *MockMachineProvisionerAvailabilityZoneCall) Do(f func(context.Context) (string, error)) *MockMachineProvisionerAvailabilityZoneCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineProvisionerAvailabilityZoneCall) DoAndReturn(f func() (string, error)) *MockMachineProvisionerAvailabilityZoneCall {
+func (c *MockMachineProvisionerAvailabilityZoneCall) DoAndReturn(f func(context.Context) (string, error)) *MockMachineProvisionerAvailabilityZoneCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // DistributionGroup mocks base method.
-func (m *MockMachineProvisioner) DistributionGroup() ([]instance.Id, error) {
+func (m *MockMachineProvisioner) DistributionGroup(arg0 context.Context) ([]instance.Id, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DistributionGroup")
+	ret := m.ctrl.Call(m, "DistributionGroup", arg0)
 	ret0, _ := ret[0].([]instance.Id)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // DistributionGroup indicates an expected call of DistributionGroup.
-func (mr *MockMachineProvisionerMockRecorder) DistributionGroup() *MockMachineProvisionerDistributionGroupCall {
+func (mr *MockMachineProvisionerMockRecorder) DistributionGroup(arg0 any) *MockMachineProvisionerDistributionGroupCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DistributionGroup", reflect.TypeOf((*MockMachineProvisioner)(nil).DistributionGroup))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DistributionGroup", reflect.TypeOf((*MockMachineProvisioner)(nil).DistributionGroup), arg0)
 	return &MockMachineProvisionerDistributionGroupCall{Call: call}
 }
 
@@ -113,29 +113,29 @@ func (c *MockMachineProvisionerDistributionGroupCall) Return(arg0 []instance.Id,
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineProvisionerDistributionGroupCall) Do(f func() ([]instance.Id, error)) *MockMachineProvisionerDistributionGroupCall {
+func (c *MockMachineProvisionerDistributionGroupCall) Do(f func(context.Context) ([]instance.Id, error)) *MockMachineProvisionerDistributionGroupCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineProvisionerDistributionGroupCall) DoAndReturn(f func() ([]instance.Id, error)) *MockMachineProvisionerDistributionGroupCall {
+func (c *MockMachineProvisionerDistributionGroupCall) DoAndReturn(f func(context.Context) ([]instance.Id, error)) *MockMachineProvisionerDistributionGroupCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // EnsureDead mocks base method.
-func (m *MockMachineProvisioner) EnsureDead() error {
+func (m *MockMachineProvisioner) EnsureDead(arg0 context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnsureDead")
+	ret := m.ctrl.Call(m, "EnsureDead", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // EnsureDead indicates an expected call of EnsureDead.
-func (mr *MockMachineProvisionerMockRecorder) EnsureDead() *MockMachineProvisionerEnsureDeadCall {
+func (mr *MockMachineProvisionerMockRecorder) EnsureDead(arg0 any) *MockMachineProvisionerEnsureDeadCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureDead", reflect.TypeOf((*MockMachineProvisioner)(nil).EnsureDead))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureDead", reflect.TypeOf((*MockMachineProvisioner)(nil).EnsureDead), arg0)
 	return &MockMachineProvisionerEnsureDeadCall{Call: call}
 }
 
@@ -151,13 +151,13 @@ func (c *MockMachineProvisionerEnsureDeadCall) Return(arg0 error) *MockMachinePr
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineProvisionerEnsureDeadCall) Do(f func() error) *MockMachineProvisionerEnsureDeadCall {
+func (c *MockMachineProvisionerEnsureDeadCall) Do(f func(context.Context) error) *MockMachineProvisionerEnsureDeadCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineProvisionerEnsureDeadCall) DoAndReturn(f func() error) *MockMachineProvisionerEnsureDeadCall {
+func (c *MockMachineProvisionerEnsureDeadCall) DoAndReturn(f func(context.Context) error) *MockMachineProvisionerEnsureDeadCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -201,18 +201,18 @@ func (c *MockMachineProvisionerIdCall) DoAndReturn(f func() string) *MockMachine
 }
 
 // InstanceId mocks base method.
-func (m *MockMachineProvisioner) InstanceId() (instance.Id, error) {
+func (m *MockMachineProvisioner) InstanceId(arg0 context.Context) (instance.Id, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InstanceId")
+	ret := m.ctrl.Call(m, "InstanceId", arg0)
 	ret0, _ := ret[0].(instance.Id)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // InstanceId indicates an expected call of InstanceId.
-func (mr *MockMachineProvisionerMockRecorder) InstanceId() *MockMachineProvisionerInstanceIdCall {
+func (mr *MockMachineProvisionerMockRecorder) InstanceId(arg0 any) *MockMachineProvisionerInstanceIdCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstanceId", reflect.TypeOf((*MockMachineProvisioner)(nil).InstanceId))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstanceId", reflect.TypeOf((*MockMachineProvisioner)(nil).InstanceId), arg0)
 	return &MockMachineProvisionerInstanceIdCall{Call: call}
 }
 
@@ -228,21 +228,21 @@ func (c *MockMachineProvisionerInstanceIdCall) Return(arg0 instance.Id, arg1 err
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineProvisionerInstanceIdCall) Do(f func() (instance.Id, error)) *MockMachineProvisionerInstanceIdCall {
+func (c *MockMachineProvisionerInstanceIdCall) Do(f func(context.Context) (instance.Id, error)) *MockMachineProvisionerInstanceIdCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineProvisionerInstanceIdCall) DoAndReturn(f func() (instance.Id, error)) *MockMachineProvisionerInstanceIdCall {
+func (c *MockMachineProvisionerInstanceIdCall) DoAndReturn(f func(context.Context) (instance.Id, error)) *MockMachineProvisionerInstanceIdCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // InstanceStatus mocks base method.
-func (m *MockMachineProvisioner) InstanceStatus() (status.Status, string, error) {
+func (m *MockMachineProvisioner) InstanceStatus(arg0 context.Context) (status.Status, string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InstanceStatus")
+	ret := m.ctrl.Call(m, "InstanceStatus", arg0)
 	ret0, _ := ret[0].(status.Status)
 	ret1, _ := ret[1].(string)
 	ret2, _ := ret[2].(error)
@@ -250,9 +250,9 @@ func (m *MockMachineProvisioner) InstanceStatus() (status.Status, string, error)
 }
 
 // InstanceStatus indicates an expected call of InstanceStatus.
-func (mr *MockMachineProvisionerMockRecorder) InstanceStatus() *MockMachineProvisionerInstanceStatusCall {
+func (mr *MockMachineProvisionerMockRecorder) InstanceStatus(arg0 any) *MockMachineProvisionerInstanceStatusCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstanceStatus", reflect.TypeOf((*MockMachineProvisioner)(nil).InstanceStatus))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstanceStatus", reflect.TypeOf((*MockMachineProvisioner)(nil).InstanceStatus), arg0)
 	return &MockMachineProvisionerInstanceStatusCall{Call: call}
 }
 
@@ -268,30 +268,30 @@ func (c *MockMachineProvisionerInstanceStatusCall) Return(arg0 status.Status, ar
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineProvisionerInstanceStatusCall) Do(f func() (status.Status, string, error)) *MockMachineProvisionerInstanceStatusCall {
+func (c *MockMachineProvisionerInstanceStatusCall) Do(f func(context.Context) (status.Status, string, error)) *MockMachineProvisionerInstanceStatusCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineProvisionerInstanceStatusCall) DoAndReturn(f func() (status.Status, string, error)) *MockMachineProvisionerInstanceStatusCall {
+func (c *MockMachineProvisionerInstanceStatusCall) DoAndReturn(f func(context.Context) (status.Status, string, error)) *MockMachineProvisionerInstanceStatusCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // KeepInstance mocks base method.
-func (m *MockMachineProvisioner) KeepInstance() (bool, error) {
+func (m *MockMachineProvisioner) KeepInstance(arg0 context.Context) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "KeepInstance")
+	ret := m.ctrl.Call(m, "KeepInstance", arg0)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // KeepInstance indicates an expected call of KeepInstance.
-func (mr *MockMachineProvisionerMockRecorder) KeepInstance() *MockMachineProvisionerKeepInstanceCall {
+func (mr *MockMachineProvisionerMockRecorder) KeepInstance(arg0 any) *MockMachineProvisionerKeepInstanceCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "KeepInstance", reflect.TypeOf((*MockMachineProvisioner)(nil).KeepInstance))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "KeepInstance", reflect.TypeOf((*MockMachineProvisioner)(nil).KeepInstance), arg0)
 	return &MockMachineProvisionerKeepInstanceCall{Call: call}
 }
 
@@ -307,13 +307,13 @@ func (c *MockMachineProvisionerKeepInstanceCall) Return(arg0 bool, arg1 error) *
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineProvisionerKeepInstanceCall) Do(f func() (bool, error)) *MockMachineProvisionerKeepInstanceCall {
+func (c *MockMachineProvisionerKeepInstanceCall) Do(f func(context.Context) (bool, error)) *MockMachineProvisionerKeepInstanceCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineProvisionerKeepInstanceCall) DoAndReturn(f func() (bool, error)) *MockMachineProvisionerKeepInstanceCall {
+func (c *MockMachineProvisionerKeepInstanceCall) DoAndReturn(f func(context.Context) (bool, error)) *MockMachineProvisionerKeepInstanceCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -395,17 +395,17 @@ func (c *MockMachineProvisionerMachineTagCall) DoAndReturn(f func() names.Machin
 }
 
 // MarkForRemoval mocks base method.
-func (m *MockMachineProvisioner) MarkForRemoval() error {
+func (m *MockMachineProvisioner) MarkForRemoval(arg0 context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MarkForRemoval")
+	ret := m.ctrl.Call(m, "MarkForRemoval", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // MarkForRemoval indicates an expected call of MarkForRemoval.
-func (mr *MockMachineProvisionerMockRecorder) MarkForRemoval() *MockMachineProvisionerMarkForRemovalCall {
+func (mr *MockMachineProvisionerMockRecorder) MarkForRemoval(arg0 any) *MockMachineProvisionerMarkForRemovalCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkForRemoval", reflect.TypeOf((*MockMachineProvisioner)(nil).MarkForRemoval))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkForRemoval", reflect.TypeOf((*MockMachineProvisioner)(nil).MarkForRemoval), arg0)
 	return &MockMachineProvisionerMarkForRemovalCall{Call: call}
 }
 
@@ -421,30 +421,30 @@ func (c *MockMachineProvisionerMarkForRemovalCall) Return(arg0 error) *MockMachi
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineProvisionerMarkForRemovalCall) Do(f func() error) *MockMachineProvisionerMarkForRemovalCall {
+func (c *MockMachineProvisionerMarkForRemovalCall) Do(f func(context.Context) error) *MockMachineProvisionerMarkForRemovalCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineProvisionerMarkForRemovalCall) DoAndReturn(f func() error) *MockMachineProvisionerMarkForRemovalCall {
+func (c *MockMachineProvisionerMarkForRemovalCall) DoAndReturn(f func(context.Context) error) *MockMachineProvisionerMarkForRemovalCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // ModelAgentVersion mocks base method.
-func (m *MockMachineProvisioner) ModelAgentVersion() (*version.Number, error) {
+func (m *MockMachineProvisioner) ModelAgentVersion(arg0 context.Context) (*version.Number, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ModelAgentVersion")
+	ret := m.ctrl.Call(m, "ModelAgentVersion", arg0)
 	ret0, _ := ret[0].(*version.Number)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ModelAgentVersion indicates an expected call of ModelAgentVersion.
-func (mr *MockMachineProvisionerMockRecorder) ModelAgentVersion() *MockMachineProvisionerModelAgentVersionCall {
+func (mr *MockMachineProvisionerMockRecorder) ModelAgentVersion(arg0 any) *MockMachineProvisionerModelAgentVersionCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModelAgentVersion", reflect.TypeOf((*MockMachineProvisioner)(nil).ModelAgentVersion))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModelAgentVersion", reflect.TypeOf((*MockMachineProvisioner)(nil).ModelAgentVersion), arg0)
 	return &MockMachineProvisionerModelAgentVersionCall{Call: call}
 }
 
@@ -460,13 +460,13 @@ func (c *MockMachineProvisionerModelAgentVersionCall) Return(arg0 *version.Numbe
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineProvisionerModelAgentVersionCall) Do(f func() (*version.Number, error)) *MockMachineProvisionerModelAgentVersionCall {
+func (c *MockMachineProvisionerModelAgentVersionCall) Do(f func(context.Context) (*version.Number, error)) *MockMachineProvisionerModelAgentVersionCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineProvisionerModelAgentVersionCall) DoAndReturn(f func() (*version.Number, error)) *MockMachineProvisionerModelAgentVersionCall {
+func (c *MockMachineProvisionerModelAgentVersionCall) DoAndReturn(f func(context.Context) (*version.Number, error)) *MockMachineProvisionerModelAgentVersionCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -510,17 +510,17 @@ func (c *MockMachineProvisionerRefreshCall) DoAndReturn(f func(context.Context) 
 }
 
 // Remove mocks base method.
-func (m *MockMachineProvisioner) Remove() error {
+func (m *MockMachineProvisioner) Remove(arg0 context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Remove")
+	ret := m.ctrl.Call(m, "Remove", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Remove indicates an expected call of Remove.
-func (mr *MockMachineProvisionerMockRecorder) Remove() *MockMachineProvisionerRemoveCall {
+func (mr *MockMachineProvisionerMockRecorder) Remove(arg0 any) *MockMachineProvisionerRemoveCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Remove", reflect.TypeOf((*MockMachineProvisioner)(nil).Remove))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Remove", reflect.TypeOf((*MockMachineProvisioner)(nil).Remove), arg0)
 	return &MockMachineProvisionerRemoveCall{Call: call}
 }
 
@@ -536,29 +536,29 @@ func (c *MockMachineProvisionerRemoveCall) Return(arg0 error) *MockMachineProvis
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineProvisionerRemoveCall) Do(f func() error) *MockMachineProvisionerRemoveCall {
+func (c *MockMachineProvisionerRemoveCall) Do(f func(context.Context) error) *MockMachineProvisionerRemoveCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineProvisionerRemoveCall) DoAndReturn(f func() error) *MockMachineProvisionerRemoveCall {
+func (c *MockMachineProvisionerRemoveCall) DoAndReturn(f func(context.Context) error) *MockMachineProvisionerRemoveCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // SetCharmProfiles mocks base method.
-func (m *MockMachineProvisioner) SetCharmProfiles(arg0 []string) error {
+func (m *MockMachineProvisioner) SetCharmProfiles(arg0 context.Context, arg1 []string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetCharmProfiles", arg0)
+	ret := m.ctrl.Call(m, "SetCharmProfiles", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetCharmProfiles indicates an expected call of SetCharmProfiles.
-func (mr *MockMachineProvisionerMockRecorder) SetCharmProfiles(arg0 any) *MockMachineProvisionerSetCharmProfilesCall {
+func (mr *MockMachineProvisionerMockRecorder) SetCharmProfiles(arg0, arg1 any) *MockMachineProvisionerSetCharmProfilesCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCharmProfiles", reflect.TypeOf((*MockMachineProvisioner)(nil).SetCharmProfiles), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCharmProfiles", reflect.TypeOf((*MockMachineProvisioner)(nil).SetCharmProfiles), arg0, arg1)
 	return &MockMachineProvisionerSetCharmProfilesCall{Call: call}
 }
 
@@ -574,29 +574,29 @@ func (c *MockMachineProvisionerSetCharmProfilesCall) Return(arg0 error) *MockMac
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineProvisionerSetCharmProfilesCall) Do(f func([]string) error) *MockMachineProvisionerSetCharmProfilesCall {
+func (c *MockMachineProvisionerSetCharmProfilesCall) Do(f func(context.Context, []string) error) *MockMachineProvisionerSetCharmProfilesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineProvisionerSetCharmProfilesCall) DoAndReturn(f func([]string) error) *MockMachineProvisionerSetCharmProfilesCall {
+func (c *MockMachineProvisionerSetCharmProfilesCall) DoAndReturn(f func(context.Context, []string) error) *MockMachineProvisionerSetCharmProfilesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // SetInstanceInfo mocks base method.
-func (m *MockMachineProvisioner) SetInstanceInfo(arg0 instance.Id, arg1, arg2 string, arg3 *instance.HardwareCharacteristics, arg4 []params.NetworkConfig, arg5 []params.Volume, arg6 map[string]params.VolumeAttachmentInfo, arg7 []string) error {
+func (m *MockMachineProvisioner) SetInstanceInfo(arg0 context.Context, arg1 instance.Id, arg2, arg3 string, arg4 *instance.HardwareCharacteristics, arg5 []params.NetworkConfig, arg6 []params.Volume, arg7 map[string]params.VolumeAttachmentInfo, arg8 []string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetInstanceInfo", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+	ret := m.ctrl.Call(m, "SetInstanceInfo", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetInstanceInfo indicates an expected call of SetInstanceInfo.
-func (mr *MockMachineProvisionerMockRecorder) SetInstanceInfo(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7 any) *MockMachineProvisionerSetInstanceInfoCall {
+func (mr *MockMachineProvisionerMockRecorder) SetInstanceInfo(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8 any) *MockMachineProvisionerSetInstanceInfoCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetInstanceInfo", reflect.TypeOf((*MockMachineProvisioner)(nil).SetInstanceInfo), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetInstanceInfo", reflect.TypeOf((*MockMachineProvisioner)(nil).SetInstanceInfo), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
 	return &MockMachineProvisionerSetInstanceInfoCall{Call: call}
 }
 
@@ -612,29 +612,29 @@ func (c *MockMachineProvisionerSetInstanceInfoCall) Return(arg0 error) *MockMach
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineProvisionerSetInstanceInfoCall) Do(f func(instance.Id, string, string, *instance.HardwareCharacteristics, []params.NetworkConfig, []params.Volume, map[string]params.VolumeAttachmentInfo, []string) error) *MockMachineProvisionerSetInstanceInfoCall {
+func (c *MockMachineProvisionerSetInstanceInfoCall) Do(f func(context.Context, instance.Id, string, string, *instance.HardwareCharacteristics, []params.NetworkConfig, []params.Volume, map[string]params.VolumeAttachmentInfo, []string) error) *MockMachineProvisionerSetInstanceInfoCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineProvisionerSetInstanceInfoCall) DoAndReturn(f func(instance.Id, string, string, *instance.HardwareCharacteristics, []params.NetworkConfig, []params.Volume, map[string]params.VolumeAttachmentInfo, []string) error) *MockMachineProvisionerSetInstanceInfoCall {
+func (c *MockMachineProvisionerSetInstanceInfoCall) DoAndReturn(f func(context.Context, instance.Id, string, string, *instance.HardwareCharacteristics, []params.NetworkConfig, []params.Volume, map[string]params.VolumeAttachmentInfo, []string) error) *MockMachineProvisionerSetInstanceInfoCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // SetInstanceStatus mocks base method.
-func (m *MockMachineProvisioner) SetInstanceStatus(arg0 status.Status, arg1 string, arg2 map[string]any) error {
+func (m *MockMachineProvisioner) SetInstanceStatus(arg0 context.Context, arg1 status.Status, arg2 string, arg3 map[string]any) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetInstanceStatus", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "SetInstanceStatus", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetInstanceStatus indicates an expected call of SetInstanceStatus.
-func (mr *MockMachineProvisionerMockRecorder) SetInstanceStatus(arg0, arg1, arg2 any) *MockMachineProvisionerSetInstanceStatusCall {
+func (mr *MockMachineProvisionerMockRecorder) SetInstanceStatus(arg0, arg1, arg2, arg3 any) *MockMachineProvisionerSetInstanceStatusCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetInstanceStatus", reflect.TypeOf((*MockMachineProvisioner)(nil).SetInstanceStatus), arg0, arg1, arg2)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetInstanceStatus", reflect.TypeOf((*MockMachineProvisioner)(nil).SetInstanceStatus), arg0, arg1, arg2, arg3)
 	return &MockMachineProvisionerSetInstanceStatusCall{Call: call}
 }
 
@@ -650,29 +650,29 @@ func (c *MockMachineProvisionerSetInstanceStatusCall) Return(arg0 error) *MockMa
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineProvisionerSetInstanceStatusCall) Do(f func(status.Status, string, map[string]any) error) *MockMachineProvisionerSetInstanceStatusCall {
+func (c *MockMachineProvisionerSetInstanceStatusCall) Do(f func(context.Context, status.Status, string, map[string]any) error) *MockMachineProvisionerSetInstanceStatusCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineProvisionerSetInstanceStatusCall) DoAndReturn(f func(status.Status, string, map[string]any) error) *MockMachineProvisionerSetInstanceStatusCall {
+func (c *MockMachineProvisionerSetInstanceStatusCall) DoAndReturn(f func(context.Context, status.Status, string, map[string]any) error) *MockMachineProvisionerSetInstanceStatusCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // SetModificationStatus mocks base method.
-func (m *MockMachineProvisioner) SetModificationStatus(arg0 status.Status, arg1 string, arg2 map[string]any) error {
+func (m *MockMachineProvisioner) SetModificationStatus(arg0 context.Context, arg1 status.Status, arg2 string, arg3 map[string]any) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetModificationStatus", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "SetModificationStatus", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetModificationStatus indicates an expected call of SetModificationStatus.
-func (mr *MockMachineProvisionerMockRecorder) SetModificationStatus(arg0, arg1, arg2 any) *MockMachineProvisionerSetModificationStatusCall {
+func (mr *MockMachineProvisionerMockRecorder) SetModificationStatus(arg0, arg1, arg2, arg3 any) *MockMachineProvisionerSetModificationStatusCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetModificationStatus", reflect.TypeOf((*MockMachineProvisioner)(nil).SetModificationStatus), arg0, arg1, arg2)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetModificationStatus", reflect.TypeOf((*MockMachineProvisioner)(nil).SetModificationStatus), arg0, arg1, arg2, arg3)
 	return &MockMachineProvisionerSetModificationStatusCall{Call: call}
 }
 
@@ -688,29 +688,29 @@ func (c *MockMachineProvisionerSetModificationStatusCall) Return(arg0 error) *Mo
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineProvisionerSetModificationStatusCall) Do(f func(status.Status, string, map[string]any) error) *MockMachineProvisionerSetModificationStatusCall {
+func (c *MockMachineProvisionerSetModificationStatusCall) Do(f func(context.Context, status.Status, string, map[string]any) error) *MockMachineProvisionerSetModificationStatusCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineProvisionerSetModificationStatusCall) DoAndReturn(f func(status.Status, string, map[string]any) error) *MockMachineProvisionerSetModificationStatusCall {
+func (c *MockMachineProvisionerSetModificationStatusCall) DoAndReturn(f func(context.Context, status.Status, string, map[string]any) error) *MockMachineProvisionerSetModificationStatusCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // SetPassword mocks base method.
-func (m *MockMachineProvisioner) SetPassword(arg0 string) error {
+func (m *MockMachineProvisioner) SetPassword(arg0 context.Context, arg1 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetPassword", arg0)
+	ret := m.ctrl.Call(m, "SetPassword", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetPassword indicates an expected call of SetPassword.
-func (mr *MockMachineProvisionerMockRecorder) SetPassword(arg0 any) *MockMachineProvisionerSetPasswordCall {
+func (mr *MockMachineProvisionerMockRecorder) SetPassword(arg0, arg1 any) *MockMachineProvisionerSetPasswordCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetPassword", reflect.TypeOf((*MockMachineProvisioner)(nil).SetPassword), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetPassword", reflect.TypeOf((*MockMachineProvisioner)(nil).SetPassword), arg0, arg1)
 	return &MockMachineProvisionerSetPasswordCall{Call: call}
 }
 
@@ -726,29 +726,29 @@ func (c *MockMachineProvisionerSetPasswordCall) Return(arg0 error) *MockMachineP
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineProvisionerSetPasswordCall) Do(f func(string) error) *MockMachineProvisionerSetPasswordCall {
+func (c *MockMachineProvisionerSetPasswordCall) Do(f func(context.Context, string) error) *MockMachineProvisionerSetPasswordCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineProvisionerSetPasswordCall) DoAndReturn(f func(string) error) *MockMachineProvisionerSetPasswordCall {
+func (c *MockMachineProvisionerSetPasswordCall) DoAndReturn(f func(context.Context, string) error) *MockMachineProvisionerSetPasswordCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // SetStatus mocks base method.
-func (m *MockMachineProvisioner) SetStatus(arg0 status.Status, arg1 string, arg2 map[string]any) error {
+func (m *MockMachineProvisioner) SetStatus(arg0 context.Context, arg1 status.Status, arg2 string, arg3 map[string]any) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetStatus", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "SetStatus", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetStatus indicates an expected call of SetStatus.
-func (mr *MockMachineProvisionerMockRecorder) SetStatus(arg0, arg1, arg2 any) *MockMachineProvisionerSetStatusCall {
+func (mr *MockMachineProvisionerMockRecorder) SetStatus(arg0, arg1, arg2, arg3 any) *MockMachineProvisionerSetStatusCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetStatus", reflect.TypeOf((*MockMachineProvisioner)(nil).SetStatus), arg0, arg1, arg2)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetStatus", reflect.TypeOf((*MockMachineProvisioner)(nil).SetStatus), arg0, arg1, arg2, arg3)
 	return &MockMachineProvisionerSetStatusCall{Call: call}
 }
 
@@ -764,22 +764,22 @@ func (c *MockMachineProvisionerSetStatusCall) Return(arg0 error) *MockMachinePro
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineProvisionerSetStatusCall) Do(f func(status.Status, string, map[string]any) error) *MockMachineProvisionerSetStatusCall {
+func (c *MockMachineProvisionerSetStatusCall) Do(f func(context.Context, status.Status, string, map[string]any) error) *MockMachineProvisionerSetStatusCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineProvisionerSetStatusCall) DoAndReturn(f func(status.Status, string, map[string]any) error) *MockMachineProvisionerSetStatusCall {
+func (c *MockMachineProvisionerSetStatusCall) DoAndReturn(f func(context.Context, status.Status, string, map[string]any) error) *MockMachineProvisionerSetStatusCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // SetSupportedContainers mocks base method.
-func (m *MockMachineProvisioner) SetSupportedContainers(arg0 ...instance.ContainerType) error {
+func (m *MockMachineProvisioner) SetSupportedContainers(arg0 context.Context, arg1 ...instance.ContainerType) error {
 	m.ctrl.T.Helper()
-	varargs := []any{}
-	for _, a := range arg0 {
+	varargs := []any{arg0}
+	for _, a := range arg1 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "SetSupportedContainers", varargs...)
@@ -788,9 +788,10 @@ func (m *MockMachineProvisioner) SetSupportedContainers(arg0 ...instance.Contain
 }
 
 // SetSupportedContainers indicates an expected call of SetSupportedContainers.
-func (mr *MockMachineProvisionerMockRecorder) SetSupportedContainers(arg0 ...any) *MockMachineProvisionerSetSupportedContainersCall {
+func (mr *MockMachineProvisionerMockRecorder) SetSupportedContainers(arg0 any, arg1 ...any) *MockMachineProvisionerSetSupportedContainersCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSupportedContainers", reflect.TypeOf((*MockMachineProvisioner)(nil).SetSupportedContainers), arg0...)
+	varargs := append([]any{arg0}, arg1...)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSupportedContainers", reflect.TypeOf((*MockMachineProvisioner)(nil).SetSupportedContainers), varargs...)
 	return &MockMachineProvisionerSetSupportedContainersCall{Call: call}
 }
 
@@ -806,21 +807,21 @@ func (c *MockMachineProvisionerSetSupportedContainersCall) Return(arg0 error) *M
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineProvisionerSetSupportedContainersCall) Do(f func(...instance.ContainerType) error) *MockMachineProvisionerSetSupportedContainersCall {
+func (c *MockMachineProvisionerSetSupportedContainersCall) Do(f func(context.Context, ...instance.ContainerType) error) *MockMachineProvisionerSetSupportedContainersCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineProvisionerSetSupportedContainersCall) DoAndReturn(f func(...instance.ContainerType) error) *MockMachineProvisionerSetSupportedContainersCall {
+func (c *MockMachineProvisionerSetSupportedContainersCall) DoAndReturn(f func(context.Context, ...instance.ContainerType) error) *MockMachineProvisionerSetSupportedContainersCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // Status mocks base method.
-func (m *MockMachineProvisioner) Status() (status.Status, string, error) {
+func (m *MockMachineProvisioner) Status(arg0 context.Context) (status.Status, string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Status")
+	ret := m.ctrl.Call(m, "Status", arg0)
 	ret0, _ := ret[0].(status.Status)
 	ret1, _ := ret[1].(string)
 	ret2, _ := ret[2].(error)
@@ -828,9 +829,9 @@ func (m *MockMachineProvisioner) Status() (status.Status, string, error) {
 }
 
 // Status indicates an expected call of Status.
-func (mr *MockMachineProvisionerMockRecorder) Status() *MockMachineProvisionerStatusCall {
+func (mr *MockMachineProvisionerMockRecorder) Status(arg0 any) *MockMachineProvisionerStatusCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Status", reflect.TypeOf((*MockMachineProvisioner)(nil).Status))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Status", reflect.TypeOf((*MockMachineProvisioner)(nil).Status), arg0)
 	return &MockMachineProvisionerStatusCall{Call: call}
 }
 
@@ -846,13 +847,13 @@ func (c *MockMachineProvisionerStatusCall) Return(arg0 status.Status, arg1 strin
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineProvisionerStatusCall) Do(f func() (status.Status, string, error)) *MockMachineProvisionerStatusCall {
+func (c *MockMachineProvisionerStatusCall) Do(f func(context.Context) (status.Status, string, error)) *MockMachineProvisionerStatusCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineProvisionerStatusCall) DoAndReturn(f func() (status.Status, string, error)) *MockMachineProvisionerStatusCall {
+func (c *MockMachineProvisionerStatusCall) DoAndReturn(f func(context.Context) (status.Status, string, error)) *MockMachineProvisionerStatusCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -896,9 +897,9 @@ func (c *MockMachineProvisionerStringCall) DoAndReturn(f func() string) *MockMac
 }
 
 // SupportedContainers mocks base method.
-func (m *MockMachineProvisioner) SupportedContainers() ([]instance.ContainerType, bool, error) {
+func (m *MockMachineProvisioner) SupportedContainers(arg0 context.Context) ([]instance.ContainerType, bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SupportedContainers")
+	ret := m.ctrl.Call(m, "SupportedContainers", arg0)
 	ret0, _ := ret[0].([]instance.ContainerType)
 	ret1, _ := ret[1].(bool)
 	ret2, _ := ret[2].(error)
@@ -906,9 +907,9 @@ func (m *MockMachineProvisioner) SupportedContainers() ([]instance.ContainerType
 }
 
 // SupportedContainers indicates an expected call of SupportedContainers.
-func (mr *MockMachineProvisionerMockRecorder) SupportedContainers() *MockMachineProvisionerSupportedContainersCall {
+func (mr *MockMachineProvisionerMockRecorder) SupportedContainers(arg0 any) *MockMachineProvisionerSupportedContainersCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SupportedContainers", reflect.TypeOf((*MockMachineProvisioner)(nil).SupportedContainers))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SupportedContainers", reflect.TypeOf((*MockMachineProvisioner)(nil).SupportedContainers), arg0)
 	return &MockMachineProvisionerSupportedContainersCall{Call: call}
 }
 
@@ -924,29 +925,29 @@ func (c *MockMachineProvisionerSupportedContainersCall) Return(arg0 []instance.C
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineProvisionerSupportedContainersCall) Do(f func() ([]instance.ContainerType, bool, error)) *MockMachineProvisionerSupportedContainersCall {
+func (c *MockMachineProvisionerSupportedContainersCall) Do(f func(context.Context) ([]instance.ContainerType, bool, error)) *MockMachineProvisionerSupportedContainersCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineProvisionerSupportedContainersCall) DoAndReturn(f func() ([]instance.ContainerType, bool, error)) *MockMachineProvisionerSupportedContainersCall {
+func (c *MockMachineProvisionerSupportedContainersCall) DoAndReturn(f func(context.Context) ([]instance.ContainerType, bool, error)) *MockMachineProvisionerSupportedContainersCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // SupportsNoContainers mocks base method.
-func (m *MockMachineProvisioner) SupportsNoContainers() error {
+func (m *MockMachineProvisioner) SupportsNoContainers(arg0 context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SupportsNoContainers")
+	ret := m.ctrl.Call(m, "SupportsNoContainers", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SupportsNoContainers indicates an expected call of SupportsNoContainers.
-func (mr *MockMachineProvisionerMockRecorder) SupportsNoContainers() *MockMachineProvisionerSupportsNoContainersCall {
+func (mr *MockMachineProvisionerMockRecorder) SupportsNoContainers(arg0 any) *MockMachineProvisionerSupportsNoContainersCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SupportsNoContainers", reflect.TypeOf((*MockMachineProvisioner)(nil).SupportsNoContainers))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SupportsNoContainers", reflect.TypeOf((*MockMachineProvisioner)(nil).SupportsNoContainers), arg0)
 	return &MockMachineProvisionerSupportsNoContainersCall{Call: call}
 }
 
@@ -962,13 +963,13 @@ func (c *MockMachineProvisionerSupportsNoContainersCall) Return(arg0 error) *Moc
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineProvisionerSupportsNoContainersCall) Do(f func() error) *MockMachineProvisionerSupportsNoContainersCall {
+func (c *MockMachineProvisionerSupportsNoContainersCall) Do(f func(context.Context) error) *MockMachineProvisionerSupportsNoContainersCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineProvisionerSupportsNoContainersCall) DoAndReturn(f func() error) *MockMachineProvisionerSupportsNoContainersCall {
+func (c *MockMachineProvisionerSupportsNoContainersCall) DoAndReturn(f func(context.Context) error) *MockMachineProvisionerSupportsNoContainersCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1012,18 +1013,18 @@ func (c *MockMachineProvisionerTagCall) DoAndReturn(f func() names.Tag) *MockMac
 }
 
 // WatchContainers mocks base method.
-func (m *MockMachineProvisioner) WatchContainers(arg0 instance.ContainerType) (watcher.Watcher[[]string], error) {
+func (m *MockMachineProvisioner) WatchContainers(arg0 context.Context, arg1 instance.ContainerType) (watcher.Watcher[[]string], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchContainers", arg0)
+	ret := m.ctrl.Call(m, "WatchContainers", arg0, arg1)
 	ret0, _ := ret[0].(watcher.Watcher[[]string])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // WatchContainers indicates an expected call of WatchContainers.
-func (mr *MockMachineProvisionerMockRecorder) WatchContainers(arg0 any) *MockMachineProvisionerWatchContainersCall {
+func (mr *MockMachineProvisionerMockRecorder) WatchContainers(arg0, arg1 any) *MockMachineProvisionerWatchContainersCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchContainers", reflect.TypeOf((*MockMachineProvisioner)(nil).WatchContainers), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchContainers", reflect.TypeOf((*MockMachineProvisioner)(nil).WatchContainers), arg0, arg1)
 	return &MockMachineProvisionerWatchContainersCall{Call: call}
 }
 
@@ -1039,13 +1040,13 @@ func (c *MockMachineProvisionerWatchContainersCall) Return(arg0 watcher.Watcher[
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineProvisionerWatchContainersCall) Do(f func(instance.ContainerType) (watcher.Watcher[[]string], error)) *MockMachineProvisionerWatchContainersCall {
+func (c *MockMachineProvisionerWatchContainersCall) Do(f func(context.Context, instance.ContainerType) (watcher.Watcher[[]string], error)) *MockMachineProvisionerWatchContainersCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineProvisionerWatchContainersCall) DoAndReturn(f func(instance.ContainerType) (watcher.Watcher[[]string], error)) *MockMachineProvisionerWatchContainersCall {
+func (c *MockMachineProvisionerWatchContainersCall) DoAndReturn(f func(context.Context, instance.ContainerType) (watcher.Watcher[[]string], error)) *MockMachineProvisionerWatchContainersCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/containerbroker/mocks/state_mock.go
+++ b/internal/worker/containerbroker/mocks/state_mock.go
@@ -45,18 +45,18 @@ func (m *MockState) EXPECT() *MockStateMockRecorder {
 }
 
 // ContainerConfig mocks base method.
-func (m *MockState) ContainerConfig() (params.ContainerConfig, error) {
+func (m *MockState) ContainerConfig(arg0 context.Context) (params.ContainerConfig, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ContainerConfig")
+	ret := m.ctrl.Call(m, "ContainerConfig", arg0)
 	ret0, _ := ret[0].(params.ContainerConfig)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ContainerConfig indicates an expected call of ContainerConfig.
-func (mr *MockStateMockRecorder) ContainerConfig() *MockStateContainerConfigCall {
+func (mr *MockStateMockRecorder) ContainerConfig(arg0 any) *MockStateContainerConfigCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerConfig", reflect.TypeOf((*MockState)(nil).ContainerConfig))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerConfig", reflect.TypeOf((*MockState)(nil).ContainerConfig), arg0)
 	return &MockStateContainerConfigCall{Call: call}
 }
 
@@ -72,30 +72,30 @@ func (c *MockStateContainerConfigCall) Return(arg0 params.ContainerConfig, arg1 
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateContainerConfigCall) Do(f func() (params.ContainerConfig, error)) *MockStateContainerConfigCall {
+func (c *MockStateContainerConfigCall) Do(f func(context.Context) (params.ContainerConfig, error)) *MockStateContainerConfigCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateContainerConfigCall) DoAndReturn(f func() (params.ContainerConfig, error)) *MockStateContainerConfigCall {
+func (c *MockStateContainerConfigCall) DoAndReturn(f func(context.Context) (params.ContainerConfig, error)) *MockStateContainerConfigCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // ContainerManagerConfig mocks base method.
-func (m *MockState) ContainerManagerConfig(arg0 params.ContainerManagerConfigParams) (params.ContainerManagerConfig, error) {
+func (m *MockState) ContainerManagerConfig(arg0 context.Context, arg1 params.ContainerManagerConfigParams) (params.ContainerManagerConfig, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ContainerManagerConfig", arg0)
+	ret := m.ctrl.Call(m, "ContainerManagerConfig", arg0, arg1)
 	ret0, _ := ret[0].(params.ContainerManagerConfig)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ContainerManagerConfig indicates an expected call of ContainerManagerConfig.
-func (mr *MockStateMockRecorder) ContainerManagerConfig(arg0 any) *MockStateContainerManagerConfigCall {
+func (mr *MockStateMockRecorder) ContainerManagerConfig(arg0, arg1 any) *MockStateContainerManagerConfigCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerManagerConfig", reflect.TypeOf((*MockState)(nil).ContainerManagerConfig), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerManagerConfig", reflect.TypeOf((*MockState)(nil).ContainerManagerConfig), arg0, arg1)
 	return &MockStateContainerManagerConfigCall{Call: call}
 }
 
@@ -111,30 +111,30 @@ func (c *MockStateContainerManagerConfigCall) Return(arg0 params.ContainerManage
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateContainerManagerConfigCall) Do(f func(params.ContainerManagerConfigParams) (params.ContainerManagerConfig, error)) *MockStateContainerManagerConfigCall {
+func (c *MockStateContainerManagerConfigCall) Do(f func(context.Context, params.ContainerManagerConfigParams) (params.ContainerManagerConfig, error)) *MockStateContainerManagerConfigCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateContainerManagerConfigCall) DoAndReturn(f func(params.ContainerManagerConfigParams) (params.ContainerManagerConfig, error)) *MockStateContainerManagerConfigCall {
+func (c *MockStateContainerManagerConfigCall) DoAndReturn(f func(context.Context, params.ContainerManagerConfigParams) (params.ContainerManagerConfig, error)) *MockStateContainerManagerConfigCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetContainerProfileInfo mocks base method.
-func (m *MockState) GetContainerProfileInfo(arg0 names.MachineTag) ([]*provisioner.LXDProfileResult, error) {
+func (m *MockState) GetContainerProfileInfo(arg0 context.Context, arg1 names.MachineTag) ([]*provisioner.LXDProfileResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetContainerProfileInfo", arg0)
+	ret := m.ctrl.Call(m, "GetContainerProfileInfo", arg0, arg1)
 	ret0, _ := ret[0].([]*provisioner.LXDProfileResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetContainerProfileInfo indicates an expected call of GetContainerProfileInfo.
-func (mr *MockStateMockRecorder) GetContainerProfileInfo(arg0 any) *MockStateGetContainerProfileInfoCall {
+func (mr *MockStateMockRecorder) GetContainerProfileInfo(arg0, arg1 any) *MockStateGetContainerProfileInfoCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContainerProfileInfo", reflect.TypeOf((*MockState)(nil).GetContainerProfileInfo), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContainerProfileInfo", reflect.TypeOf((*MockState)(nil).GetContainerProfileInfo), arg0, arg1)
 	return &MockStateGetContainerProfileInfoCall{Call: call}
 }
 
@@ -150,21 +150,21 @@ func (c *MockStateGetContainerProfileInfoCall) Return(arg0 []*provisioner.LXDPro
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetContainerProfileInfoCall) Do(f func(names.MachineTag) ([]*provisioner.LXDProfileResult, error)) *MockStateGetContainerProfileInfoCall {
+func (c *MockStateGetContainerProfileInfoCall) Do(f func(context.Context, names.MachineTag) ([]*provisioner.LXDProfileResult, error)) *MockStateGetContainerProfileInfoCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetContainerProfileInfoCall) DoAndReturn(f func(names.MachineTag) ([]*provisioner.LXDProfileResult, error)) *MockStateGetContainerProfileInfoCall {
+func (c *MockStateGetContainerProfileInfoCall) DoAndReturn(f func(context.Context, names.MachineTag) ([]*provisioner.LXDProfileResult, error)) *MockStateGetContainerProfileInfoCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // HostChangesForContainer mocks base method.
-func (m *MockState) HostChangesForContainer(arg0 names.MachineTag) ([]network0.DeviceToBridge, int, error) {
+func (m *MockState) HostChangesForContainer(arg0 context.Context, arg1 names.MachineTag) ([]network0.DeviceToBridge, int, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HostChangesForContainer", arg0)
+	ret := m.ctrl.Call(m, "HostChangesForContainer", arg0, arg1)
 	ret0, _ := ret[0].([]network0.DeviceToBridge)
 	ret1, _ := ret[1].(int)
 	ret2, _ := ret[2].(error)
@@ -172,9 +172,9 @@ func (m *MockState) HostChangesForContainer(arg0 names.MachineTag) ([]network0.D
 }
 
 // HostChangesForContainer indicates an expected call of HostChangesForContainer.
-func (mr *MockStateMockRecorder) HostChangesForContainer(arg0 any) *MockStateHostChangesForContainerCall {
+func (mr *MockStateMockRecorder) HostChangesForContainer(arg0, arg1 any) *MockStateHostChangesForContainerCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HostChangesForContainer", reflect.TypeOf((*MockState)(nil).HostChangesForContainer), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HostChangesForContainer", reflect.TypeOf((*MockState)(nil).HostChangesForContainer), arg0, arg1)
 	return &MockStateHostChangesForContainerCall{Call: call}
 }
 
@@ -190,13 +190,13 @@ func (c *MockStateHostChangesForContainerCall) Return(arg0 []network0.DeviceToBr
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateHostChangesForContainerCall) Do(f func(names.MachineTag) ([]network0.DeviceToBridge, int, error)) *MockStateHostChangesForContainerCall {
+func (c *MockStateHostChangesForContainerCall) Do(f func(context.Context, names.MachineTag) ([]network0.DeviceToBridge, int, error)) *MockStateHostChangesForContainerCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateHostChangesForContainerCall) DoAndReturn(f func(names.MachineTag) ([]network0.DeviceToBridge, int, error)) *MockStateHostChangesForContainerCall {
+func (c *MockStateHostChangesForContainerCall) DoAndReturn(f func(context.Context, names.MachineTag) ([]network0.DeviceToBridge, int, error)) *MockStateHostChangesForContainerCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -246,18 +246,18 @@ func (c *MockStateMachinesCall) DoAndReturn(f func(context.Context, ...names.Mac
 }
 
 // PrepareContainerInterfaceInfo mocks base method.
-func (m *MockState) PrepareContainerInterfaceInfo(arg0 names.MachineTag) (network.InterfaceInfos, error) {
+func (m *MockState) PrepareContainerInterfaceInfo(arg0 context.Context, arg1 names.MachineTag) (network.InterfaceInfos, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PrepareContainerInterfaceInfo", arg0)
+	ret := m.ctrl.Call(m, "PrepareContainerInterfaceInfo", arg0, arg1)
 	ret0, _ := ret[0].(network.InterfaceInfos)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // PrepareContainerInterfaceInfo indicates an expected call of PrepareContainerInterfaceInfo.
-func (mr *MockStateMockRecorder) PrepareContainerInterfaceInfo(arg0 any) *MockStatePrepareContainerInterfaceInfoCall {
+func (mr *MockStateMockRecorder) PrepareContainerInterfaceInfo(arg0, arg1 any) *MockStatePrepareContainerInterfaceInfoCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareContainerInterfaceInfo", reflect.TypeOf((*MockState)(nil).PrepareContainerInterfaceInfo), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareContainerInterfaceInfo", reflect.TypeOf((*MockState)(nil).PrepareContainerInterfaceInfo), arg0, arg1)
 	return &MockStatePrepareContainerInterfaceInfoCall{Call: call}
 }
 
@@ -273,29 +273,29 @@ func (c *MockStatePrepareContainerInterfaceInfoCall) Return(arg0 network.Interfa
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStatePrepareContainerInterfaceInfoCall) Do(f func(names.MachineTag) (network.InterfaceInfos, error)) *MockStatePrepareContainerInterfaceInfoCall {
+func (c *MockStatePrepareContainerInterfaceInfoCall) Do(f func(context.Context, names.MachineTag) (network.InterfaceInfos, error)) *MockStatePrepareContainerInterfaceInfoCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStatePrepareContainerInterfaceInfoCall) DoAndReturn(f func(names.MachineTag) (network.InterfaceInfos, error)) *MockStatePrepareContainerInterfaceInfoCall {
+func (c *MockStatePrepareContainerInterfaceInfoCall) DoAndReturn(f func(context.Context, names.MachineTag) (network.InterfaceInfos, error)) *MockStatePrepareContainerInterfaceInfoCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // ReleaseContainerAddresses mocks base method.
-func (m *MockState) ReleaseContainerAddresses(arg0 names.MachineTag) error {
+func (m *MockState) ReleaseContainerAddresses(arg0 context.Context, arg1 names.MachineTag) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReleaseContainerAddresses", arg0)
+	ret := m.ctrl.Call(m, "ReleaseContainerAddresses", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ReleaseContainerAddresses indicates an expected call of ReleaseContainerAddresses.
-func (mr *MockStateMockRecorder) ReleaseContainerAddresses(arg0 any) *MockStateReleaseContainerAddressesCall {
+func (mr *MockStateMockRecorder) ReleaseContainerAddresses(arg0, arg1 any) *MockStateReleaseContainerAddressesCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReleaseContainerAddresses", reflect.TypeOf((*MockState)(nil).ReleaseContainerAddresses), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReleaseContainerAddresses", reflect.TypeOf((*MockState)(nil).ReleaseContainerAddresses), arg0, arg1)
 	return &MockStateReleaseContainerAddressesCall{Call: call}
 }
 
@@ -311,29 +311,29 @@ func (c *MockStateReleaseContainerAddressesCall) Return(arg0 error) *MockStateRe
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateReleaseContainerAddressesCall) Do(f func(names.MachineTag) error) *MockStateReleaseContainerAddressesCall {
+func (c *MockStateReleaseContainerAddressesCall) Do(f func(context.Context, names.MachineTag) error) *MockStateReleaseContainerAddressesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateReleaseContainerAddressesCall) DoAndReturn(f func(names.MachineTag) error) *MockStateReleaseContainerAddressesCall {
+func (c *MockStateReleaseContainerAddressesCall) DoAndReturn(f func(context.Context, names.MachineTag) error) *MockStateReleaseContainerAddressesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // SetHostMachineNetworkConfig mocks base method.
-func (m *MockState) SetHostMachineNetworkConfig(arg0 names.MachineTag, arg1 []params.NetworkConfig) error {
+func (m *MockState) SetHostMachineNetworkConfig(arg0 context.Context, arg1 names.MachineTag, arg2 []params.NetworkConfig) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetHostMachineNetworkConfig", arg0, arg1)
+	ret := m.ctrl.Call(m, "SetHostMachineNetworkConfig", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetHostMachineNetworkConfig indicates an expected call of SetHostMachineNetworkConfig.
-func (mr *MockStateMockRecorder) SetHostMachineNetworkConfig(arg0, arg1 any) *MockStateSetHostMachineNetworkConfigCall {
+func (mr *MockStateMockRecorder) SetHostMachineNetworkConfig(arg0, arg1, arg2 any) *MockStateSetHostMachineNetworkConfigCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetHostMachineNetworkConfig", reflect.TypeOf((*MockState)(nil).SetHostMachineNetworkConfig), arg0, arg1)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetHostMachineNetworkConfig", reflect.TypeOf((*MockState)(nil).SetHostMachineNetworkConfig), arg0, arg1, arg2)
 	return &MockStateSetHostMachineNetworkConfigCall{Call: call}
 }
 
@@ -349,13 +349,13 @@ func (c *MockStateSetHostMachineNetworkConfigCall) Return(arg0 error) *MockState
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateSetHostMachineNetworkConfigCall) Do(f func(names.MachineTag, []params.NetworkConfig) error) *MockStateSetHostMachineNetworkConfigCall {
+func (c *MockStateSetHostMachineNetworkConfigCall) Do(f func(context.Context, names.MachineTag, []params.NetworkConfig) error) *MockStateSetHostMachineNetworkConfigCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateSetHostMachineNetworkConfigCall) DoAndReturn(f func(names.MachineTag, []params.NetworkConfig) error) *MockStateSetHostMachineNetworkConfigCall {
+func (c *MockStateSetHostMachineNetworkConfigCall) DoAndReturn(f func(context.Context, names.MachineTag, []params.NetworkConfig) error) *MockStateSetHostMachineNetworkConfigCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/deployer/deployer.go
+++ b/internal/worker/deployer/deployer.go
@@ -104,7 +104,7 @@ func (d *Deployer) Report() map[string]interface{} {
 
 // SetUp is called by the NewStringsWorker to create the watcher that drives the
 // worker.
-func (d *Deployer) SetUp() (watcher.StringsWatcher, error) {
+func (d *Deployer) SetUp(ctx context.Context) (watcher.StringsWatcher, error) {
 	d.logger.Tracef("SetUp")
 	tag := d.ctx.AgentConfig().Tag()
 	machineTag, ok := tag.(names.MachineTag)
@@ -117,7 +117,7 @@ func (d *Deployer) SetUp() (watcher.StringsWatcher, error) {
 		return nil, err
 	}
 	d.logger.Tracef("getting units watcher")
-	machineUnitsWatcher, err := machine.WatchUnits(context.TODO())
+	machineUnitsWatcher, err := machine.WatchUnits(ctx)
 	if err != nil {
 		d.logger.Tracef("error: %v", err)
 		return nil, err
@@ -131,7 +131,7 @@ func (d *Deployer) SetUp() (watcher.StringsWatcher, error) {
 	d.logger.Tracef("deployed units: %v", deployed)
 	for _, unitName := range deployed {
 		d.deployed.Add(unitName)
-		if err := d.changed(context.TODO(), unitName); err != nil {
+		if err := d.changed(ctx, unitName); err != nil {
 			return nil, err
 		}
 	}
@@ -139,10 +139,10 @@ func (d *Deployer) SetUp() (watcher.StringsWatcher, error) {
 }
 
 // Handle is called for new value in the StringsWatcher.
-func (d *Deployer) Handle(_ <-chan struct{}, unitNames []string) error {
+func (d *Deployer) Handle(ctx context.Context, unitNames []string) error {
 	d.logger.Tracef("Handle: %v", unitNames)
 	for _, unitName := range unitNames {
-		if err := d.changed(context.TODO(), unitName); err != nil {
+		if err := d.changed(ctx, unitName); err != nil {
 			return err
 		}
 	}

--- a/internal/worker/leadership/util_test.go
+++ b/internal/worker/leadership/util_test.go
@@ -4,6 +4,7 @@
 package leadership_test
 
 import (
+	"context"
 	"time"
 
 	"github.com/juju/testing"
@@ -17,12 +18,12 @@ type StubClaimer struct {
 	releases chan struct{}
 }
 
-func (stub *StubClaimer) ClaimLeadership(serviceName, unitName string, duration time.Duration) error {
+func (stub *StubClaimer) ClaimLeadership(_ context.Context, serviceName, unitName string, duration time.Duration) error {
 	stub.MethodCall(stub, "ClaimLeadership", serviceName, unitName, duration)
 	return stub.NextErr()
 }
 
-func (stub *StubClaimer) BlockUntilLeadershipReleased(serviceName string, cancel <-chan struct{}) error {
+func (stub *StubClaimer) BlockUntilLeadershipReleased(_ context.Context, serviceName string, cancel <-chan struct{}) error {
 	stub.MethodCall(stub, "BlockUntilLeadershipReleased", serviceName)
 	select {
 	case <-cancel:

--- a/internal/worker/lifeflag/manifold.go
+++ b/internal/worker/lifeflag/manifold.go
@@ -35,7 +35,7 @@ type ManifoldConfig struct {
 	NotFoundIsDead bool
 
 	NewFacade func(base.APICaller) (Facade, error)
-	NewWorker func(Config) (worker.Worker, error)
+	NewWorker func(context.Context, Config) (worker.Worker, error)
 }
 
 func (config ManifoldConfig) start(context context.Context, getter dependency.Getter) (worker.Worker, error) {
@@ -59,7 +59,7 @@ func (config ManifoldConfig) start(context context.Context, getter dependency.Ge
 		config.Entity = agent.CurrentConfig().Tag()
 	}
 
-	worker, err := config.NewWorker(Config{
+	worker, err := config.NewWorker(context, Config{
 		Facade:         facade,
 		Entity:         config.Entity,
 		Result:         config.Result,

--- a/internal/worker/lifeflag/manifold_test.go
+++ b/internal/worker/lifeflag/manifold_test.go
@@ -95,7 +95,7 @@ func (*ManifoldSuite) TestNewWorkerError(c *gc.C) {
 		NewFacade: func(_ base.APICaller) (lifeflag.Facade, error) {
 			return expectFacade, nil
 		},
-		NewWorker: func(config lifeflag.Config) (worker.Worker, error) {
+		NewWorker: func(_ context.Context, config lifeflag.Config) (worker.Worker, error) {
 			c.Check(config.Facade, gc.Equals, expectFacade)
 			c.Check(config.Entity, gc.Equals, expectEntity)
 			c.Check(config.Result, gc.NotNil) // uncomparable
@@ -118,7 +118,7 @@ func (*ManifoldSuite) TestNewWorkerSuccess(c *gc.C) {
 		NewFacade: func(_ base.APICaller) (lifeflag.Facade, error) {
 			return struct{ lifeflag.Facade }{}, nil
 		},
-		NewWorker: func(_ lifeflag.Config) (worker.Worker, error) {
+		NewWorker: func(_ context.Context, _ lifeflag.Config) (worker.Worker, error) {
 			return expectWorker, nil
 		},
 	})
@@ -140,7 +140,7 @@ func (*ManifoldSuite) TestNewWorkerSuccessWithAgentName(c *gc.C) {
 		NewFacade: func(_ base.APICaller) (lifeflag.Facade, error) {
 			return struct{ lifeflag.Facade }{}, nil
 		},
-		NewWorker: func(config lifeflag.Config) (worker.Worker, error) {
+		NewWorker: func(_ context.Context, config lifeflag.Config) (worker.Worker, error) {
 			c.Check(config.Entity, gc.Equals, names.NewUnitTag("ubuntu/0"))
 			return expectWorker, nil
 		},

--- a/internal/worker/lifeflag/shim.go
+++ b/internal/worker/lifeflag/shim.go
@@ -4,12 +4,14 @@
 package lifeflag
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/worker/v4"
 )
 
-func NewWorker(config Config) (worker.Worker, error) {
-	worker, err := New(config)
+func NewWorker(ctx context.Context, config Config) (worker.Worker, error) {
+	worker, err := New(ctx, config)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/internal/worker/lifeflag/util_test.go
+++ b/internal/worker/lifeflag/util_test.go
@@ -4,6 +4,8 @@
 package lifeflag_test
 
 import (
+	"context"
+
 	"github.com/juju/names/v5"
 	"github.com/juju/testing"
 	"github.com/juju/worker/v4"
@@ -25,7 +27,7 @@ type mockFacade struct {
 	lifeResults []life.Value
 }
 
-func (mock *mockFacade) Life(entity names.Tag) (life.Value, error) {
+func (mock *mockFacade) Life(_ context.Context, entity names.Tag) (life.Value, error) {
 	mock.stub.AddCall("Life", entity)
 	if err := mock.stub.NextErr(); err != nil {
 		return "", err
@@ -39,7 +41,7 @@ func (mock *mockFacade) nextLife() life.Value {
 	return result
 }
 
-func (mock *mockFacade) Watch(entity names.Tag) (watcher.NotifyWatcher, error) {
+func (mock *mockFacade) Watch(_ context.Context, entity names.Tag) (watcher.NotifyWatcher, error) {
 	mock.stub.AddCall("Watch", entity)
 	if err := mock.stub.NextErr(); err != nil {
 		return nil, err

--- a/internal/worker/lifeflag/validate_test.go
+++ b/internal/worker/lifeflag/validate_test.go
@@ -4,6 +4,8 @@
 package lifeflag_test
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -50,7 +52,7 @@ func checkInvalid(c *gc.C, config lifeflag.Config, message string) {
 	err := config.Validate()
 	check(err)
 
-	worker, err := lifeflag.New(config)
+	worker, err := lifeflag.New(context.Background(), config)
 	c.Check(worker, gc.IsNil)
 	check(err)
 }

--- a/internal/worker/lifeflag/worker_test.go
+++ b/internal/worker/lifeflag/worker_test.go
@@ -4,6 +4,7 @@
 package lifeflag_test
 
 import (
+	"context"
 	"errors"
 
 	"github.com/juju/names/v5"
@@ -32,7 +33,7 @@ func (*WorkerSuite) TestCreateNotFoundError(c *gc.C) {
 		Result: explode,
 	}
 
-	worker, err := lifeflag.New(config)
+	worker, err := lifeflag.New(context.Background(), config)
 	c.Check(worker, gc.IsNil)
 	c.Check(err, jc.ErrorIs, apilifeflag.ErrEntityNotFound)
 	checkCalls(c, stub, "Life")
@@ -47,7 +48,7 @@ func (*WorkerSuite) TestCreateRandomError(c *gc.C) {
 		Result: explode,
 	}
 
-	worker, err := lifeflag.New(config)
+	worker, err := lifeflag.New(context.Background(), config)
 	c.Check(worker, gc.IsNil)
 	c.Check(err, gc.ErrorMatches, "boom splat")
 	checkCalls(c, stub, "Life")
@@ -62,7 +63,7 @@ func (*WorkerSuite) TestWatchNotFoundError(c *gc.C) {
 		Result: never,
 	}
 
-	worker, err := lifeflag.New(config)
+	worker, err := lifeflag.New(context.Background(), config)
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(worker.Check(), jc.IsFalse)
 
@@ -80,7 +81,7 @@ func (*WorkerSuite) TestWatchRandomError(c *gc.C) {
 		Result: never,
 	}
 
-	worker, err := lifeflag.New(config)
+	worker, err := lifeflag.New(context.Background(), config)
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(worker.Check(), jc.IsFalse)
 
@@ -98,7 +99,7 @@ func (*WorkerSuite) TestLifeNotFoundError(c *gc.C) {
 		Result: never,
 	}
 
-	worker, err := lifeflag.New(config)
+	worker, err := lifeflag.New(context.Background(), config)
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(worker.Check(), jc.IsFalse)
 
@@ -116,7 +117,7 @@ func (*WorkerSuite) TestLifeRandomError(c *gc.C) {
 		Result: never,
 	}
 
-	worker, err := lifeflag.New(config)
+	worker, err := lifeflag.New(context.Background(), config)
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(worker.Check(), jc.IsFalse)
 
@@ -133,7 +134,7 @@ func (*WorkerSuite) TestResultImmediateRealChange(c *gc.C) {
 		Result: life.IsNotAlive,
 	}
 
-	worker, err := lifeflag.New(config)
+	worker, err := lifeflag.New(context.Background(), config)
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(worker.Check(), jc.IsFalse)
 
@@ -149,7 +150,7 @@ func (*WorkerSuite) TestResultSubsequentRealChange(c *gc.C) {
 		Entity: testEntity,
 		Result: life.IsNotDead,
 	}
-	worker, err := lifeflag.New(config)
+	worker, err := lifeflag.New(context.Background(), config)
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(worker.Check(), jc.IsTrue)
 
@@ -165,7 +166,7 @@ func (*WorkerSuite) TestResultNoRealChange(c *gc.C) {
 		Entity: testEntity,
 		Result: life.IsNotDead,
 	}
-	worker, err := lifeflag.New(config)
+	worker, err := lifeflag.New(context.Background(), config)
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(worker.Check(), jc.IsTrue)
 

--- a/internal/worker/logger/logger_test.go
+++ b/internal/worker/logger/logger_test.go
@@ -4,6 +4,7 @@
 package logger_test
 
 import (
+	"context"
 	"time"
 
 	"github.com/juju/errors"
@@ -166,12 +167,12 @@ type mockAPI struct {
 	watchingTag names.Tag
 }
 
-func (m *mockAPI) LoggingConfig(agentTag names.Tag) (string, error) {
+func (m *mockAPI) LoggingConfig(_ context.Context, agentTag names.Tag) (string, error) {
 	m.loggingTag = agentTag
 	return m.config, nil
 }
 
-func (m *mockAPI) WatchLoggingConfig(agentTag names.Tag) (watcher.NotifyWatcher, error) {
+func (m *mockAPI) WatchLoggingConfig(_ context.Context, agentTag names.Tag) (watcher.NotifyWatcher, error) {
 	m.watchingTag = agentTag
 	return m.watcher, nil
 }

--- a/internal/worker/machineactions/mocks/mock_facade.go
+++ b/internal/worker/machineactions/mocks/mock_facade.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	machineactions "github.com/juju/juju/api/agent/machineactions"
@@ -43,18 +44,18 @@ func (m *MockFacade) EXPECT() *MockFacadeMockRecorder {
 }
 
 // Action mocks base method.
-func (m *MockFacade) Action(arg0 names.ActionTag) (*machineactions.Action, error) {
+func (m *MockFacade) Action(arg0 context.Context, arg1 names.ActionTag) (*machineactions.Action, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Action", arg0)
+	ret := m.ctrl.Call(m, "Action", arg0, arg1)
 	ret0, _ := ret[0].(*machineactions.Action)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Action indicates an expected call of Action.
-func (mr *MockFacadeMockRecorder) Action(arg0 any) *MockFacadeActionCall {
+func (mr *MockFacadeMockRecorder) Action(arg0, arg1 any) *MockFacadeActionCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Action", reflect.TypeOf((*MockFacade)(nil).Action), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Action", reflect.TypeOf((*MockFacade)(nil).Action), arg0, arg1)
 	return &MockFacadeActionCall{Call: call}
 }
 
@@ -70,29 +71,29 @@ func (c *MockFacadeActionCall) Return(arg0 *machineactions.Action, arg1 error) *
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockFacadeActionCall) Do(f func(names.ActionTag) (*machineactions.Action, error)) *MockFacadeActionCall {
+func (c *MockFacadeActionCall) Do(f func(context.Context, names.ActionTag) (*machineactions.Action, error)) *MockFacadeActionCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockFacadeActionCall) DoAndReturn(f func(names.ActionTag) (*machineactions.Action, error)) *MockFacadeActionCall {
+func (c *MockFacadeActionCall) DoAndReturn(f func(context.Context, names.ActionTag) (*machineactions.Action, error)) *MockFacadeActionCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // ActionBegin mocks base method.
-func (m *MockFacade) ActionBegin(arg0 names.ActionTag) error {
+func (m *MockFacade) ActionBegin(arg0 context.Context, arg1 names.ActionTag) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ActionBegin", arg0)
+	ret := m.ctrl.Call(m, "ActionBegin", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ActionBegin indicates an expected call of ActionBegin.
-func (mr *MockFacadeMockRecorder) ActionBegin(arg0 any) *MockFacadeActionBeginCall {
+func (mr *MockFacadeMockRecorder) ActionBegin(arg0, arg1 any) *MockFacadeActionBeginCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ActionBegin", reflect.TypeOf((*MockFacade)(nil).ActionBegin), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ActionBegin", reflect.TypeOf((*MockFacade)(nil).ActionBegin), arg0, arg1)
 	return &MockFacadeActionBeginCall{Call: call}
 }
 
@@ -108,29 +109,29 @@ func (c *MockFacadeActionBeginCall) Return(arg0 error) *MockFacadeActionBeginCal
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockFacadeActionBeginCall) Do(f func(names.ActionTag) error) *MockFacadeActionBeginCall {
+func (c *MockFacadeActionBeginCall) Do(f func(context.Context, names.ActionTag) error) *MockFacadeActionBeginCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockFacadeActionBeginCall) DoAndReturn(f func(names.ActionTag) error) *MockFacadeActionBeginCall {
+func (c *MockFacadeActionBeginCall) DoAndReturn(f func(context.Context, names.ActionTag) error) *MockFacadeActionBeginCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // ActionFinish mocks base method.
-func (m *MockFacade) ActionFinish(arg0 names.ActionTag, arg1 string, arg2 map[string]any, arg3 string) error {
+func (m *MockFacade) ActionFinish(arg0 context.Context, arg1 names.ActionTag, arg2 string, arg3 map[string]any, arg4 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ActionFinish", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "ActionFinish", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ActionFinish indicates an expected call of ActionFinish.
-func (mr *MockFacadeMockRecorder) ActionFinish(arg0, arg1, arg2, arg3 any) *MockFacadeActionFinishCall {
+func (mr *MockFacadeMockRecorder) ActionFinish(arg0, arg1, arg2, arg3, arg4 any) *MockFacadeActionFinishCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ActionFinish", reflect.TypeOf((*MockFacade)(nil).ActionFinish), arg0, arg1, arg2, arg3)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ActionFinish", reflect.TypeOf((*MockFacade)(nil).ActionFinish), arg0, arg1, arg2, arg3, arg4)
 	return &MockFacadeActionFinishCall{Call: call}
 }
 
@@ -146,30 +147,30 @@ func (c *MockFacadeActionFinishCall) Return(arg0 error) *MockFacadeActionFinishC
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockFacadeActionFinishCall) Do(f func(names.ActionTag, string, map[string]any, string) error) *MockFacadeActionFinishCall {
+func (c *MockFacadeActionFinishCall) Do(f func(context.Context, names.ActionTag, string, map[string]any, string) error) *MockFacadeActionFinishCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockFacadeActionFinishCall) DoAndReturn(f func(names.ActionTag, string, map[string]any, string) error) *MockFacadeActionFinishCall {
+func (c *MockFacadeActionFinishCall) DoAndReturn(f func(context.Context, names.ActionTag, string, map[string]any, string) error) *MockFacadeActionFinishCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // RunningActions mocks base method.
-func (m *MockFacade) RunningActions(arg0 names.MachineTag) ([]params.ActionResult, error) {
+func (m *MockFacade) RunningActions(arg0 context.Context, arg1 names.MachineTag) ([]params.ActionResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RunningActions", arg0)
+	ret := m.ctrl.Call(m, "RunningActions", arg0, arg1)
 	ret0, _ := ret[0].([]params.ActionResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // RunningActions indicates an expected call of RunningActions.
-func (mr *MockFacadeMockRecorder) RunningActions(arg0 any) *MockFacadeRunningActionsCall {
+func (mr *MockFacadeMockRecorder) RunningActions(arg0, arg1 any) *MockFacadeRunningActionsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunningActions", reflect.TypeOf((*MockFacade)(nil).RunningActions), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunningActions", reflect.TypeOf((*MockFacade)(nil).RunningActions), arg0, arg1)
 	return &MockFacadeRunningActionsCall{Call: call}
 }
 
@@ -185,30 +186,30 @@ func (c *MockFacadeRunningActionsCall) Return(arg0 []params.ActionResult, arg1 e
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockFacadeRunningActionsCall) Do(f func(names.MachineTag) ([]params.ActionResult, error)) *MockFacadeRunningActionsCall {
+func (c *MockFacadeRunningActionsCall) Do(f func(context.Context, names.MachineTag) ([]params.ActionResult, error)) *MockFacadeRunningActionsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockFacadeRunningActionsCall) DoAndReturn(f func(names.MachineTag) ([]params.ActionResult, error)) *MockFacadeRunningActionsCall {
+func (c *MockFacadeRunningActionsCall) DoAndReturn(f func(context.Context, names.MachineTag) ([]params.ActionResult, error)) *MockFacadeRunningActionsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // WatchActionNotifications mocks base method.
-func (m *MockFacade) WatchActionNotifications(arg0 names.MachineTag) (watcher.Watcher[[]string], error) {
+func (m *MockFacade) WatchActionNotifications(arg0 context.Context, arg1 names.MachineTag) (watcher.Watcher[[]string], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchActionNotifications", arg0)
+	ret := m.ctrl.Call(m, "WatchActionNotifications", arg0, arg1)
 	ret0, _ := ret[0].(watcher.Watcher[[]string])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // WatchActionNotifications indicates an expected call of WatchActionNotifications.
-func (mr *MockFacadeMockRecorder) WatchActionNotifications(arg0 any) *MockFacadeWatchActionNotificationsCall {
+func (mr *MockFacadeMockRecorder) WatchActionNotifications(arg0, arg1 any) *MockFacadeWatchActionNotificationsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchActionNotifications", reflect.TypeOf((*MockFacade)(nil).WatchActionNotifications), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchActionNotifications", reflect.TypeOf((*MockFacade)(nil).WatchActionNotifications), arg0, arg1)
 	return &MockFacadeWatchActionNotificationsCall{Call: call}
 }
 
@@ -224,13 +225,13 @@ func (c *MockFacadeWatchActionNotificationsCall) Return(arg0 watcher.Watcher[[]s
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockFacadeWatchActionNotificationsCall) Do(f func(names.MachineTag) (watcher.Watcher[[]string], error)) *MockFacadeWatchActionNotificationsCall {
+func (c *MockFacadeWatchActionNotificationsCall) Do(f func(context.Context, names.MachineTag) (watcher.Watcher[[]string], error)) *MockFacadeWatchActionNotificationsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockFacadeWatchActionNotificationsCall) DoAndReturn(f func(names.MachineTag) (watcher.Watcher[[]string], error)) *MockFacadeWatchActionNotificationsCall {
+func (c *MockFacadeWatchActionNotificationsCall) DoAndReturn(f func(context.Context, names.MachineTag) (watcher.Watcher[[]string], error)) *MockFacadeWatchActionNotificationsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/machiner/mock_test.go
+++ b/internal/worker/machiner/mock_test.go
@@ -48,22 +48,22 @@ func (m *mockMachine) Life() life.Value {
 	return m.life
 }
 
-func (m *mockMachine) EnsureDead() error {
+func (m *mockMachine) EnsureDead(context.Context) error {
 	m.MethodCall(m, "EnsureDead")
 	return m.NextErr()
 }
 
-func (m *mockMachine) SetMachineAddresses(addresses []network.MachineAddress) error {
+func (m *mockMachine) SetMachineAddresses(_ context.Context, addresses []network.MachineAddress) error {
 	m.MethodCall(m, "SetMachineAddresses", addresses)
 	return m.NextErr()
 }
 
-func (m *mockMachine) SetObservedNetworkConfig(netConfig []params.NetworkConfig) error {
+func (m *mockMachine) SetObservedNetworkConfig(_ context.Context, netConfig []params.NetworkConfig) error {
 	m.MethodCall(m, "SetObservedNetworkConfig", netConfig)
 	return m.NextErr()
 }
 
-func (m *mockMachine) SetStatus(status status.Status, info string, data map[string]interface{}) error {
+func (m *mockMachine) SetStatus(_ context.Context, status status.Status, info string, data map[string]interface{}) error {
 	m.MethodCall(m, "SetStatus", status, info, data)
 	return m.NextErr()
 }

--- a/internal/worker/machiner/state.go
+++ b/internal/worker/machiner/state.go
@@ -24,11 +24,11 @@ type MachineAccessor interface {
 type Machine interface {
 	Refresh(context.Context) error
 	Life() life.Value
-	EnsureDead() error
-	SetMachineAddresses(addresses []network.MachineAddress) error
-	SetStatus(machineStatus status.Status, info string, data map[string]interface{}) error
+	EnsureDead(context.Context) error
+	SetMachineAddresses(ctx context.Context, addresses []network.MachineAddress) error
+	SetStatus(ctx context.Context, machineStatus status.Status, info string, data map[string]interface{}) error
 	Watch(context.Context) (watcher.NotifyWatcher, error)
-	SetObservedNetworkConfig(netConfig []params.NetworkConfig) error
+	SetObservedNetworkConfig(ctx context.Context, netConfig []params.NetworkConfig) error
 }
 
 type APIMachineAccessor struct {

--- a/internal/worker/migrationflag/manifold.go
+++ b/internal/worker/migrationflag/manifold.go
@@ -27,7 +27,7 @@ type ManifoldConfig struct {
 	Check         Predicate
 
 	NewFacade func(base.APICaller) (Facade, error)
-	NewWorker func(Config) (worker.Worker, error)
+	NewWorker func(context.Context, Config) (worker.Worker, error)
 }
 
 // validate is called by start to check for bad configuration.
@@ -64,7 +64,7 @@ func (config ManifoldConfig) start(context context.Context, getter dependency.Ge
 	if !ok {
 		return nil, errors.New("API connection is controller-only (should never happen)")
 	}
-	worker, err := config.NewWorker(Config{
+	worker, err := config.NewWorker(context, Config{
 		Facade: facade,
 		Model:  modelTag.Id(),
 		Check:  config.Check,

--- a/internal/worker/migrationflag/manifold_test.go
+++ b/internal/worker/migrationflag/manifold_test.go
@@ -135,7 +135,7 @@ func (*ManifoldSuite) TestStartNewWorkerError(c *gc.C) {
 	config.NewFacade = func(base.APICaller) (migrationflag.Facade, error) {
 		return expectFacade, nil
 	}
-	config.NewWorker = func(workerConfig migrationflag.Config) (worker.Worker, error) {
+	config.NewWorker = func(ctx context.Context, workerConfig migrationflag.Config) (worker.Worker, error) {
 		c.Check(workerConfig.Facade, gc.Equals, expectFacade)
 		c.Check(workerConfig.Model, gc.Equals, validUUID)
 		c.Check(workerConfig.Check, gc.NotNil) // uncomparable
@@ -157,7 +157,7 @@ func (*ManifoldSuite) TestStartSuccess(c *gc.C) {
 	config.NewFacade = func(base.APICaller) (migrationflag.Facade, error) {
 		return &struct{ migrationflag.Facade }{}, nil
 	}
-	config.NewWorker = func(migrationflag.Config) (worker.Worker, error) {
+	config.NewWorker = func(context.Context, migrationflag.Config) (worker.Worker, error) {
 		return expectWorker, nil
 	}
 	manifold := migrationflag.Manifold(config)

--- a/internal/worker/migrationflag/shim.go
+++ b/internal/worker/migrationflag/shim.go
@@ -4,6 +4,8 @@
 package migrationflag
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/worker/v4"
 
@@ -19,8 +21,8 @@ func NewFacade(apiCaller base.APICaller) (Facade, error) {
 }
 
 // NewWorker creates a *Worker and returns it as a worker.Worker.
-func NewWorker(config Config) (worker.Worker, error) {
-	worker, err := New(config)
+func NewWorker(ctx context.Context, config Config) (worker.Worker, error) {
+	worker, err := New(ctx, config)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/internal/worker/migrationflag/util_test.go
+++ b/internal/worker/migrationflag/util_test.go
@@ -40,7 +40,7 @@ type mockFacade struct {
 }
 
 // Phase is part of the migrationflag.Facade interface.
-func (mock *mockFacade) Phase(uuid string) (migration.Phase, error) {
+func (mock *mockFacade) Phase(_ context.Context, uuid string) (migration.Phase, error) {
 	mock.stub.AddCall("Phase", uuid)
 	if err := mock.stub.NextErr(); err != nil {
 		return 0, err
@@ -56,7 +56,7 @@ func (mock *mockFacade) nextPhase() migration.Phase {
 }
 
 // Watch is part of the migrationflag.Facade interface.
-func (mock *mockFacade) Watch(uuid string) (watcher.NotifyWatcher, error) {
+func (mock *mockFacade) Watch(_ context.Context, uuid string) (watcher.NotifyWatcher, error) {
 	mock.stub.AddCall("Watch", uuid)
 	if err := mock.stub.NextErr(); err != nil {
 		return nil, err
@@ -113,7 +113,7 @@ func panicFacade(base.APICaller) (migrationflag.Facade, error) {
 }
 
 // panicWorker is a NewWorker that should not be called.
-func panicWorker(migrationflag.Config) (worker.Worker, error) {
+func panicWorker(context.Context, migrationflag.Config) (worker.Worker, error) {
 	panic("panicWorker")
 }
 
@@ -141,7 +141,7 @@ func checkNotValid(c *gc.C, config migrationflag.Config, expect string) {
 	err := config.Validate()
 	check(err)
 
-	worker, err := migrationflag.New(config)
+	worker, err := migrationflag.New(context.Background(), config)
 	c.Check(worker, gc.IsNil)
 	check(err)
 }

--- a/internal/worker/migrationflag/worker_test.go
+++ b/internal/worker/migrationflag/worker_test.go
@@ -4,6 +4,8 @@
 package migrationflag_test
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -29,7 +31,7 @@ func (*WorkerSuite) TestPhaseErrorOnStartup(c *gc.C) {
 		Model:  validUUID,
 		Check:  panicCheck,
 	}
-	worker, err := migrationflag.New(config)
+	worker, err := migrationflag.New(context.Background(), config)
 	c.Check(worker, gc.IsNil)
 	c.Check(err, gc.ErrorMatches, "gaah")
 	checkCalls(c, stub, "Phase")
@@ -44,7 +46,7 @@ func (*WorkerSuite) TestWatchError(c *gc.C) {
 		Model:  validUUID,
 		Check:  neverCheck,
 	}
-	worker, err := migrationflag.New(config)
+	worker, err := migrationflag.New(context.Background(), config)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(worker.Check(), jc.IsFalse)
 
@@ -62,7 +64,7 @@ func (*WorkerSuite) TestPhaseErrorWhileRunning(c *gc.C) {
 		Model:  validUUID,
 		Check:  neverCheck,
 	}
-	worker, err := migrationflag.New(config)
+	worker, err := migrationflag.New(context.Background(), config)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(worker.Check(), jc.IsFalse)
 
@@ -81,7 +83,7 @@ func (*WorkerSuite) TestImmediatePhaseChange(c *gc.C) {
 		Model:  validUUID,
 		Check:  isQuiesce,
 	}
-	worker, err := migrationflag.New(config)
+	worker, err := migrationflag.New(context.Background(), config)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(worker.Check(), jc.IsTrue)
 
@@ -100,7 +102,7 @@ func (*WorkerSuite) TestSubsequentPhaseChange(c *gc.C) {
 		Model:  validUUID,
 		Check:  isQuiesce,
 	}
-	worker, err := migrationflag.New(config)
+	worker, err := migrationflag.New(context.Background(), config)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(worker.Check(), jc.IsFalse)
 
@@ -122,7 +124,7 @@ func (*WorkerSuite) TestNoRelevantPhaseChange(c *gc.C) {
 		Model:  validUUID,
 		Check:  isQuiesce,
 	}
-	worker, err := migrationflag.New(config)
+	worker, err := migrationflag.New(context.Background(), config)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(worker.Check(), jc.IsFalse)
 

--- a/internal/worker/migrationminion/worker_test.go
+++ b/internal/worker/migrationminion/worker_test.go
@@ -492,7 +492,7 @@ type stubMinionClient struct {
 	watchErr error
 }
 
-func (c *stubMinionClient) Watch() (watcher.MigrationStatusWatcher, error) {
+func (c *stubMinionClient) Watch(ctx context.Context) (watcher.MigrationStatusWatcher, error) {
 	c.stub.MethodCall(c, "Watch")
 	if c.watchErr != nil {
 		return nil, c.watchErr
@@ -500,7 +500,7 @@ func (c *stubMinionClient) Watch() (watcher.MigrationStatusWatcher, error) {
 	return c.watcher, nil
 }
 
-func (c *stubMinionClient) Report(id string, phase migration.Phase, success bool) error {
+func (c *stubMinionClient) Report(ctx context.Context, id string, phase migration.Phase, success bool) error {
 	c.stub.MethodCall(c, "Report", id, phase, success)
 	return c.stub.NextErr()
 }

--- a/internal/worker/provisioner/container_initialisation_test.go
+++ b/internal/worker/provisioner/container_initialisation_test.go
@@ -73,7 +73,7 @@ func (s *containerSetupSuite) testInitialiseContainers(c *gc.C, containerType in
 	cs := s.setUpContainerSetup(c, containerType)
 	abort := make(chan struct{})
 	close(abort)
-	err := cs.initialiseContainers(abort)
+	err := cs.initialiseContainers(context.Background(), abort)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -92,7 +92,7 @@ func (s *containerSetupSuite) TestContainerManagerConfigError(c *gc.C) {
 	cs := s.setUpContainerSetup(c, instance.LXD)
 	abort := make(chan struct{})
 	close(abort)
-	err := cs.initialiseContainers(abort)
+	err := cs.initialiseContainers(context.Background(), abort)
 	c.Assert(err, gc.ErrorMatches, ".*generating container manager config: boom")
 }
 

--- a/internal/worker/provisioner/containermanifold_test.go
+++ b/internal/worker/provisioner/containermanifold_test.go
@@ -101,7 +101,7 @@ func (s *containerManifoldSuite) TestContainerProvisioningManifold(c *gc.C) {
 		{Machine: s.machine},
 	}
 	s.getter.EXPECT().Machines(gomock.Any(), []names.MachineTag{tag}).Return(retval, nil)
-	s.machine.EXPECT().SupportedContainers().Return([]instance.ContainerType{instance.LXD}, true, nil)
+	s.machine.EXPECT().SupportedContainers(gomock.Any()).Return([]instance.ContainerType{instance.LXD}, true, nil)
 	s.machine.EXPECT().Life().Return(life.Alive)
 	cfg := provisioner.ContainerManifoldConfig{
 		Logger:        loggertesting.WrapCheckLog(c),
@@ -120,7 +120,7 @@ func (s *containerManifoldSuite) TestContainerProvisioningManifoldContainersNotK
 		{Machine: s.machine},
 	}
 	s.getter.EXPECT().Machines(gomock.Any(), []names.MachineTag{tag}).Return(retval, nil)
-	s.machine.EXPECT().SupportedContainers().Return(nil, false, nil)
+	s.machine.EXPECT().SupportedContainers(gomock.Any()).Return(nil, false, nil)
 	s.machine.EXPECT().Life().Return(life.Alive)
 	cfg := provisioner.ContainerManifoldConfig{
 		Logger:        loggertesting.WrapCheckLog(c),
@@ -138,7 +138,7 @@ func (s *containerManifoldSuite) TestContainerProvisioningManifoldNoContainerSup
 		{Machine: s.machine},
 	}
 	s.getter.EXPECT().Machines(gomock.Any(), []names.MachineTag{tag}).Return(retval, nil)
-	s.machine.EXPECT().SupportedContainers().Return(nil, true, nil)
+	s.machine.EXPECT().SupportedContainers(gomock.Any()).Return(nil, true, nil)
 	s.machine.EXPECT().Life().Return(life.Alive)
 	cfg := provisioner.ContainerManifoldConfig{
 		Logger:        loggertesting.WrapCheckLog(c),

--- a/internal/worker/provisioner/containerprovisioner_test.go
+++ b/internal/worker/provisioner/containerprovisioner_test.go
@@ -115,7 +115,7 @@ func (s *lxdProvisionerSuite) TestContainerStartedAndStopped(c *gc.C) {
 	s.machinesAPI.EXPECT().Machines(gomock.Any(), cTag).Return([]apiprovisioner.MachineResult{{
 		Machine: c666,
 	}}, nil).Times(2)
-	s.machinesAPI.EXPECT().ProvisioningInfo([]names.MachineTag{cTag}).Return(params.ProvisioningInfoResults{
+	s.machinesAPI.EXPECT().ProvisioningInfo(gomock.Any(), []names.MachineTag{cTag}).Return(params.ProvisioningInfoResults{
 		Results: []params.ProvisioningInfoResult{{
 			Result: &params.ProvisioningInfo{
 				ControllerConfig: coretesting.FakeControllerConfig(),

--- a/internal/worker/provisioner/containerworker_test.go
+++ b/internal/worker/provisioner/containerworker_test.go
@@ -4,6 +4,7 @@
 package provisioner_test
 
 import (
+	"context"
 	"sync"
 	"time"
 
@@ -177,10 +178,10 @@ func (s *containerWorkerSuite) setUpContainerWorker(c *gc.C) worker.Worker {
 	cs := provisioner.NewContainerSetup(args)
 
 	// Stub out network config getter.
-	watcherFunc := func() (watcher.StringsWatcher, error) {
+	watcherFunc := func(context.Context) (watcher.StringsWatcher, error) {
 		return s.stringsWatcher, nil
 	}
-	w, err := provisioner.NewContainerSetupAndProvisioner(cs, watcherFunc)
+	w, err := provisioner.NewContainerSetupAndProvisioner(context.Background(), cs, watcherFunc)
 	c.Assert(err, jc.ErrorIsNil)
 
 	return w
@@ -296,7 +297,7 @@ func (s *containerWorkerSuite) expectContainerManagerConfig(cType instance.Conta
 		"Provisioner", 0, "", "ContainerManagerConfig", params.ContainerManagerConfigParams{Type: cType}, gomock.Any(),
 	).SetArg(6, resultSource).MinTimes(1)
 
-	s.machine.EXPECT().AvailabilityZone().Return("az1", nil)
+	s.machine.EXPECT().AvailabilityZone(gomock.Any()).Return("az1", nil)
 }
 
 // cleanKill waits for notifications to be processed, then waits for the input

--- a/internal/worker/provisioner/export_test.go
+++ b/internal/worker/provisioner/export_test.go
@@ -33,7 +33,7 @@ func SetObserver(p Provisioner, observer chan<- *config.Config) {
 }
 
 func GetRetryWatcher(p Provisioner) (watcher.NotifyWatcher, error) {
-	return p.getRetryWatcher()
+	return p.getRetryWatcher(context.Background())
 }
 
 var (

--- a/internal/worker/provisioner/mocks/provisioner.go
+++ b/internal/worker/provisioner/mocks/provisioner.go
@@ -51,18 +51,18 @@ func (m *MockContainerMachine) EXPECT() *MockContainerMachineMockRecorder {
 }
 
 // AvailabilityZone mocks base method.
-func (m *MockContainerMachine) AvailabilityZone() (string, error) {
+func (m *MockContainerMachine) AvailabilityZone(arg0 context.Context) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AvailabilityZone")
+	ret := m.ctrl.Call(m, "AvailabilityZone", arg0)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // AvailabilityZone indicates an expected call of AvailabilityZone.
-func (mr *MockContainerMachineMockRecorder) AvailabilityZone() *MockContainerMachineAvailabilityZoneCall {
+func (mr *MockContainerMachineMockRecorder) AvailabilityZone(arg0 any) *MockContainerMachineAvailabilityZoneCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AvailabilityZone", reflect.TypeOf((*MockContainerMachine)(nil).AvailabilityZone))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AvailabilityZone", reflect.TypeOf((*MockContainerMachine)(nil).AvailabilityZone), arg0)
 	return &MockContainerMachineAvailabilityZoneCall{Call: call}
 }
 
@@ -78,13 +78,13 @@ func (c *MockContainerMachineAvailabilityZoneCall) Return(arg0 string, arg1 erro
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockContainerMachineAvailabilityZoneCall) Do(f func() (string, error)) *MockContainerMachineAvailabilityZoneCall {
+func (c *MockContainerMachineAvailabilityZoneCall) Do(f func(context.Context) (string, error)) *MockContainerMachineAvailabilityZoneCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockContainerMachineAvailabilityZoneCall) DoAndReturn(f func() (string, error)) *MockContainerMachineAvailabilityZoneCall {
+func (c *MockContainerMachineAvailabilityZoneCall) DoAndReturn(f func(context.Context) (string, error)) *MockContainerMachineAvailabilityZoneCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -128,9 +128,9 @@ func (c *MockContainerMachineLifeCall) DoAndReturn(f func() life.Value) *MockCon
 }
 
 // SupportedContainers mocks base method.
-func (m *MockContainerMachine) SupportedContainers() ([]instance.ContainerType, bool, error) {
+func (m *MockContainerMachine) SupportedContainers(arg0 context.Context) ([]instance.ContainerType, bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SupportedContainers")
+	ret := m.ctrl.Call(m, "SupportedContainers", arg0)
 	ret0, _ := ret[0].([]instance.ContainerType)
 	ret1, _ := ret[1].(bool)
 	ret2, _ := ret[2].(error)
@@ -138,9 +138,9 @@ func (m *MockContainerMachine) SupportedContainers() ([]instance.ContainerType, 
 }
 
 // SupportedContainers indicates an expected call of SupportedContainers.
-func (mr *MockContainerMachineMockRecorder) SupportedContainers() *MockContainerMachineSupportedContainersCall {
+func (mr *MockContainerMachineMockRecorder) SupportedContainers(arg0 any) *MockContainerMachineSupportedContainersCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SupportedContainers", reflect.TypeOf((*MockContainerMachine)(nil).SupportedContainers))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SupportedContainers", reflect.TypeOf((*MockContainerMachine)(nil).SupportedContainers), arg0)
 	return &MockContainerMachineSupportedContainersCall{Call: call}
 }
 
@@ -156,30 +156,30 @@ func (c *MockContainerMachineSupportedContainersCall) Return(arg0 []instance.Con
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockContainerMachineSupportedContainersCall) Do(f func() ([]instance.ContainerType, bool, error)) *MockContainerMachineSupportedContainersCall {
+func (c *MockContainerMachineSupportedContainersCall) Do(f func(context.Context) ([]instance.ContainerType, bool, error)) *MockContainerMachineSupportedContainersCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockContainerMachineSupportedContainersCall) DoAndReturn(f func() ([]instance.ContainerType, bool, error)) *MockContainerMachineSupportedContainersCall {
+func (c *MockContainerMachineSupportedContainersCall) DoAndReturn(f func(context.Context) ([]instance.ContainerType, bool, error)) *MockContainerMachineSupportedContainersCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // WatchContainers mocks base method.
-func (m *MockContainerMachine) WatchContainers(arg0 instance.ContainerType) (watcher.Watcher[[]string], error) {
+func (m *MockContainerMachine) WatchContainers(arg0 context.Context, arg1 instance.ContainerType) (watcher.Watcher[[]string], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchContainers", arg0)
+	ret := m.ctrl.Call(m, "WatchContainers", arg0, arg1)
 	ret0, _ := ret[0].(watcher.Watcher[[]string])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // WatchContainers indicates an expected call of WatchContainers.
-func (mr *MockContainerMachineMockRecorder) WatchContainers(arg0 any) *MockContainerMachineWatchContainersCall {
+func (mr *MockContainerMachineMockRecorder) WatchContainers(arg0, arg1 any) *MockContainerMachineWatchContainersCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchContainers", reflect.TypeOf((*MockContainerMachine)(nil).WatchContainers), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchContainers", reflect.TypeOf((*MockContainerMachine)(nil).WatchContainers), arg0, arg1)
 	return &MockContainerMachineWatchContainersCall{Call: call}
 }
 
@@ -195,13 +195,13 @@ func (c *MockContainerMachineWatchContainersCall) Return(arg0 watcher.Watcher[[]
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockContainerMachineWatchContainersCall) Do(f func(instance.ContainerType) (watcher.Watcher[[]string], error)) *MockContainerMachineWatchContainersCall {
+func (c *MockContainerMachineWatchContainersCall) Do(f func(context.Context, instance.ContainerType) (watcher.Watcher[[]string], error)) *MockContainerMachineWatchContainersCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockContainerMachineWatchContainersCall) DoAndReturn(f func(instance.ContainerType) (watcher.Watcher[[]string], error)) *MockContainerMachineWatchContainersCall {
+func (c *MockContainerMachineWatchContainersCall) DoAndReturn(f func(context.Context, instance.ContainerType) (watcher.Watcher[[]string], error)) *MockContainerMachineWatchContainersCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -297,18 +297,18 @@ func (m *MockContainerProvisionerAPI) EXPECT() *MockContainerProvisionerAPIMockR
 }
 
 // ContainerConfig mocks base method.
-func (m *MockContainerProvisionerAPI) ContainerConfig() (params.ContainerConfig, error) {
+func (m *MockContainerProvisionerAPI) ContainerConfig(arg0 context.Context) (params.ContainerConfig, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ContainerConfig")
+	ret := m.ctrl.Call(m, "ContainerConfig", arg0)
 	ret0, _ := ret[0].(params.ContainerConfig)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ContainerConfig indicates an expected call of ContainerConfig.
-func (mr *MockContainerProvisionerAPIMockRecorder) ContainerConfig() *MockContainerProvisionerAPIContainerConfigCall {
+func (mr *MockContainerProvisionerAPIMockRecorder) ContainerConfig(arg0 any) *MockContainerProvisionerAPIContainerConfigCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerConfig", reflect.TypeOf((*MockContainerProvisionerAPI)(nil).ContainerConfig))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerConfig", reflect.TypeOf((*MockContainerProvisionerAPI)(nil).ContainerConfig), arg0)
 	return &MockContainerProvisionerAPIContainerConfigCall{Call: call}
 }
 
@@ -324,30 +324,30 @@ func (c *MockContainerProvisionerAPIContainerConfigCall) Return(arg0 params.Cont
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockContainerProvisionerAPIContainerConfigCall) Do(f func() (params.ContainerConfig, error)) *MockContainerProvisionerAPIContainerConfigCall {
+func (c *MockContainerProvisionerAPIContainerConfigCall) Do(f func(context.Context) (params.ContainerConfig, error)) *MockContainerProvisionerAPIContainerConfigCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockContainerProvisionerAPIContainerConfigCall) DoAndReturn(f func() (params.ContainerConfig, error)) *MockContainerProvisionerAPIContainerConfigCall {
+func (c *MockContainerProvisionerAPIContainerConfigCall) DoAndReturn(f func(context.Context) (params.ContainerConfig, error)) *MockContainerProvisionerAPIContainerConfigCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // ContainerManagerConfig mocks base method.
-func (m *MockContainerProvisionerAPI) ContainerManagerConfig(arg0 params.ContainerManagerConfigParams) (params.ContainerManagerConfig, error) {
+func (m *MockContainerProvisionerAPI) ContainerManagerConfig(arg0 context.Context, arg1 params.ContainerManagerConfigParams) (params.ContainerManagerConfig, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ContainerManagerConfig", arg0)
+	ret := m.ctrl.Call(m, "ContainerManagerConfig", arg0, arg1)
 	ret0, _ := ret[0].(params.ContainerManagerConfig)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ContainerManagerConfig indicates an expected call of ContainerManagerConfig.
-func (mr *MockContainerProvisionerAPIMockRecorder) ContainerManagerConfig(arg0 any) *MockContainerProvisionerAPIContainerManagerConfigCall {
+func (mr *MockContainerProvisionerAPIMockRecorder) ContainerManagerConfig(arg0, arg1 any) *MockContainerProvisionerAPIContainerManagerConfigCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerManagerConfig", reflect.TypeOf((*MockContainerProvisionerAPI)(nil).ContainerManagerConfig), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainerManagerConfig", reflect.TypeOf((*MockContainerProvisionerAPI)(nil).ContainerManagerConfig), arg0, arg1)
 	return &MockContainerProvisionerAPIContainerManagerConfigCall{Call: call}
 }
 
@@ -363,30 +363,30 @@ func (c *MockContainerProvisionerAPIContainerManagerConfigCall) Return(arg0 para
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockContainerProvisionerAPIContainerManagerConfigCall) Do(f func(params.ContainerManagerConfigParams) (params.ContainerManagerConfig, error)) *MockContainerProvisionerAPIContainerManagerConfigCall {
+func (c *MockContainerProvisionerAPIContainerManagerConfigCall) Do(f func(context.Context, params.ContainerManagerConfigParams) (params.ContainerManagerConfig, error)) *MockContainerProvisionerAPIContainerManagerConfigCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockContainerProvisionerAPIContainerManagerConfigCall) DoAndReturn(f func(params.ContainerManagerConfigParams) (params.ContainerManagerConfig, error)) *MockContainerProvisionerAPIContainerManagerConfigCall {
+func (c *MockContainerProvisionerAPIContainerManagerConfigCall) DoAndReturn(f func(context.Context, params.ContainerManagerConfigParams) (params.ContainerManagerConfig, error)) *MockContainerProvisionerAPIContainerManagerConfigCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetContainerProfileInfo mocks base method.
-func (m *MockContainerProvisionerAPI) GetContainerProfileInfo(arg0 names.MachineTag) ([]*provisioner.LXDProfileResult, error) {
+func (m *MockContainerProvisionerAPI) GetContainerProfileInfo(arg0 context.Context, arg1 names.MachineTag) ([]*provisioner.LXDProfileResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetContainerProfileInfo", arg0)
+	ret := m.ctrl.Call(m, "GetContainerProfileInfo", arg0, arg1)
 	ret0, _ := ret[0].([]*provisioner.LXDProfileResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetContainerProfileInfo indicates an expected call of GetContainerProfileInfo.
-func (mr *MockContainerProvisionerAPIMockRecorder) GetContainerProfileInfo(arg0 any) *MockContainerProvisionerAPIGetContainerProfileInfoCall {
+func (mr *MockContainerProvisionerAPIMockRecorder) GetContainerProfileInfo(arg0, arg1 any) *MockContainerProvisionerAPIGetContainerProfileInfoCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContainerProfileInfo", reflect.TypeOf((*MockContainerProvisionerAPI)(nil).GetContainerProfileInfo), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContainerProfileInfo", reflect.TypeOf((*MockContainerProvisionerAPI)(nil).GetContainerProfileInfo), arg0, arg1)
 	return &MockContainerProvisionerAPIGetContainerProfileInfoCall{Call: call}
 }
 
@@ -402,21 +402,21 @@ func (c *MockContainerProvisionerAPIGetContainerProfileInfoCall) Return(arg0 []*
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockContainerProvisionerAPIGetContainerProfileInfoCall) Do(f func(names.MachineTag) ([]*provisioner.LXDProfileResult, error)) *MockContainerProvisionerAPIGetContainerProfileInfoCall {
+func (c *MockContainerProvisionerAPIGetContainerProfileInfoCall) Do(f func(context.Context, names.MachineTag) ([]*provisioner.LXDProfileResult, error)) *MockContainerProvisionerAPIGetContainerProfileInfoCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockContainerProvisionerAPIGetContainerProfileInfoCall) DoAndReturn(f func(names.MachineTag) ([]*provisioner.LXDProfileResult, error)) *MockContainerProvisionerAPIGetContainerProfileInfoCall {
+func (c *MockContainerProvisionerAPIGetContainerProfileInfoCall) DoAndReturn(f func(context.Context, names.MachineTag) ([]*provisioner.LXDProfileResult, error)) *MockContainerProvisionerAPIGetContainerProfileInfoCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // HostChangesForContainer mocks base method.
-func (m *MockContainerProvisionerAPI) HostChangesForContainer(arg0 names.MachineTag) ([]network0.DeviceToBridge, int, error) {
+func (m *MockContainerProvisionerAPI) HostChangesForContainer(arg0 context.Context, arg1 names.MachineTag) ([]network0.DeviceToBridge, int, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HostChangesForContainer", arg0)
+	ret := m.ctrl.Call(m, "HostChangesForContainer", arg0, arg1)
 	ret0, _ := ret[0].([]network0.DeviceToBridge)
 	ret1, _ := ret[1].(int)
 	ret2, _ := ret[2].(error)
@@ -424,9 +424,9 @@ func (m *MockContainerProvisionerAPI) HostChangesForContainer(arg0 names.Machine
 }
 
 // HostChangesForContainer indicates an expected call of HostChangesForContainer.
-func (mr *MockContainerProvisionerAPIMockRecorder) HostChangesForContainer(arg0 any) *MockContainerProvisionerAPIHostChangesForContainerCall {
+func (mr *MockContainerProvisionerAPIMockRecorder) HostChangesForContainer(arg0, arg1 any) *MockContainerProvisionerAPIHostChangesForContainerCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HostChangesForContainer", reflect.TypeOf((*MockContainerProvisionerAPI)(nil).HostChangesForContainer), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HostChangesForContainer", reflect.TypeOf((*MockContainerProvisionerAPI)(nil).HostChangesForContainer), arg0, arg1)
 	return &MockContainerProvisionerAPIHostChangesForContainerCall{Call: call}
 }
 
@@ -442,30 +442,30 @@ func (c *MockContainerProvisionerAPIHostChangesForContainerCall) Return(arg0 []n
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockContainerProvisionerAPIHostChangesForContainerCall) Do(f func(names.MachineTag) ([]network0.DeviceToBridge, int, error)) *MockContainerProvisionerAPIHostChangesForContainerCall {
+func (c *MockContainerProvisionerAPIHostChangesForContainerCall) Do(f func(context.Context, names.MachineTag) ([]network0.DeviceToBridge, int, error)) *MockContainerProvisionerAPIHostChangesForContainerCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockContainerProvisionerAPIHostChangesForContainerCall) DoAndReturn(f func(names.MachineTag) ([]network0.DeviceToBridge, int, error)) *MockContainerProvisionerAPIHostChangesForContainerCall {
+func (c *MockContainerProvisionerAPIHostChangesForContainerCall) DoAndReturn(f func(context.Context, names.MachineTag) ([]network0.DeviceToBridge, int, error)) *MockContainerProvisionerAPIHostChangesForContainerCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // PrepareContainerInterfaceInfo mocks base method.
-func (m *MockContainerProvisionerAPI) PrepareContainerInterfaceInfo(arg0 names.MachineTag) (network.InterfaceInfos, error) {
+func (m *MockContainerProvisionerAPI) PrepareContainerInterfaceInfo(arg0 context.Context, arg1 names.MachineTag) (network.InterfaceInfos, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PrepareContainerInterfaceInfo", arg0)
+	ret := m.ctrl.Call(m, "PrepareContainerInterfaceInfo", arg0, arg1)
 	ret0, _ := ret[0].(network.InterfaceInfos)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // PrepareContainerInterfaceInfo indicates an expected call of PrepareContainerInterfaceInfo.
-func (mr *MockContainerProvisionerAPIMockRecorder) PrepareContainerInterfaceInfo(arg0 any) *MockContainerProvisionerAPIPrepareContainerInterfaceInfoCall {
+func (mr *MockContainerProvisionerAPIMockRecorder) PrepareContainerInterfaceInfo(arg0, arg1 any) *MockContainerProvisionerAPIPrepareContainerInterfaceInfoCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareContainerInterfaceInfo", reflect.TypeOf((*MockContainerProvisionerAPI)(nil).PrepareContainerInterfaceInfo), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareContainerInterfaceInfo", reflect.TypeOf((*MockContainerProvisionerAPI)(nil).PrepareContainerInterfaceInfo), arg0, arg1)
 	return &MockContainerProvisionerAPIPrepareContainerInterfaceInfoCall{Call: call}
 }
 
@@ -481,29 +481,29 @@ func (c *MockContainerProvisionerAPIPrepareContainerInterfaceInfoCall) Return(ar
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockContainerProvisionerAPIPrepareContainerInterfaceInfoCall) Do(f func(names.MachineTag) (network.InterfaceInfos, error)) *MockContainerProvisionerAPIPrepareContainerInterfaceInfoCall {
+func (c *MockContainerProvisionerAPIPrepareContainerInterfaceInfoCall) Do(f func(context.Context, names.MachineTag) (network.InterfaceInfos, error)) *MockContainerProvisionerAPIPrepareContainerInterfaceInfoCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockContainerProvisionerAPIPrepareContainerInterfaceInfoCall) DoAndReturn(f func(names.MachineTag) (network.InterfaceInfos, error)) *MockContainerProvisionerAPIPrepareContainerInterfaceInfoCall {
+func (c *MockContainerProvisionerAPIPrepareContainerInterfaceInfoCall) DoAndReturn(f func(context.Context, names.MachineTag) (network.InterfaceInfos, error)) *MockContainerProvisionerAPIPrepareContainerInterfaceInfoCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // ReleaseContainerAddresses mocks base method.
-func (m *MockContainerProvisionerAPI) ReleaseContainerAddresses(arg0 names.MachineTag) error {
+func (m *MockContainerProvisionerAPI) ReleaseContainerAddresses(arg0 context.Context, arg1 names.MachineTag) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReleaseContainerAddresses", arg0)
+	ret := m.ctrl.Call(m, "ReleaseContainerAddresses", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ReleaseContainerAddresses indicates an expected call of ReleaseContainerAddresses.
-func (mr *MockContainerProvisionerAPIMockRecorder) ReleaseContainerAddresses(arg0 any) *MockContainerProvisionerAPIReleaseContainerAddressesCall {
+func (mr *MockContainerProvisionerAPIMockRecorder) ReleaseContainerAddresses(arg0, arg1 any) *MockContainerProvisionerAPIReleaseContainerAddressesCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReleaseContainerAddresses", reflect.TypeOf((*MockContainerProvisionerAPI)(nil).ReleaseContainerAddresses), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReleaseContainerAddresses", reflect.TypeOf((*MockContainerProvisionerAPI)(nil).ReleaseContainerAddresses), arg0, arg1)
 	return &MockContainerProvisionerAPIReleaseContainerAddressesCall{Call: call}
 }
 
@@ -519,29 +519,29 @@ func (c *MockContainerProvisionerAPIReleaseContainerAddressesCall) Return(arg0 e
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockContainerProvisionerAPIReleaseContainerAddressesCall) Do(f func(names.MachineTag) error) *MockContainerProvisionerAPIReleaseContainerAddressesCall {
+func (c *MockContainerProvisionerAPIReleaseContainerAddressesCall) Do(f func(context.Context, names.MachineTag) error) *MockContainerProvisionerAPIReleaseContainerAddressesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockContainerProvisionerAPIReleaseContainerAddressesCall) DoAndReturn(f func(names.MachineTag) error) *MockContainerProvisionerAPIReleaseContainerAddressesCall {
+func (c *MockContainerProvisionerAPIReleaseContainerAddressesCall) DoAndReturn(f func(context.Context, names.MachineTag) error) *MockContainerProvisionerAPIReleaseContainerAddressesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // SetHostMachineNetworkConfig mocks base method.
-func (m *MockContainerProvisionerAPI) SetHostMachineNetworkConfig(arg0 names.MachineTag, arg1 []params.NetworkConfig) error {
+func (m *MockContainerProvisionerAPI) SetHostMachineNetworkConfig(arg0 context.Context, arg1 names.MachineTag, arg2 []params.NetworkConfig) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetHostMachineNetworkConfig", arg0, arg1)
+	ret := m.ctrl.Call(m, "SetHostMachineNetworkConfig", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetHostMachineNetworkConfig indicates an expected call of SetHostMachineNetworkConfig.
-func (mr *MockContainerProvisionerAPIMockRecorder) SetHostMachineNetworkConfig(arg0, arg1 any) *MockContainerProvisionerAPISetHostMachineNetworkConfigCall {
+func (mr *MockContainerProvisionerAPIMockRecorder) SetHostMachineNetworkConfig(arg0, arg1, arg2 any) *MockContainerProvisionerAPISetHostMachineNetworkConfigCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetHostMachineNetworkConfig", reflect.TypeOf((*MockContainerProvisionerAPI)(nil).SetHostMachineNetworkConfig), arg0, arg1)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetHostMachineNetworkConfig", reflect.TypeOf((*MockContainerProvisionerAPI)(nil).SetHostMachineNetworkConfig), arg0, arg1, arg2)
 	return &MockContainerProvisionerAPISetHostMachineNetworkConfigCall{Call: call}
 }
 
@@ -557,13 +557,13 @@ func (c *MockContainerProvisionerAPISetHostMachineNetworkConfigCall) Return(arg0
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockContainerProvisionerAPISetHostMachineNetworkConfigCall) Do(f func(names.MachineTag, []params.NetworkConfig) error) *MockContainerProvisionerAPISetHostMachineNetworkConfigCall {
+func (c *MockContainerProvisionerAPISetHostMachineNetworkConfigCall) Do(f func(context.Context, names.MachineTag, []params.NetworkConfig) error) *MockContainerProvisionerAPISetHostMachineNetworkConfigCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockContainerProvisionerAPISetHostMachineNetworkConfigCall) DoAndReturn(f func(names.MachineTag, []params.NetworkConfig) error) *MockContainerProvisionerAPISetHostMachineNetworkConfigCall {
+func (c *MockContainerProvisionerAPISetHostMachineNetworkConfigCall) DoAndReturn(f func(context.Context, names.MachineTag, []params.NetworkConfig) error) *MockContainerProvisionerAPISetHostMachineNetworkConfigCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -631,18 +631,18 @@ func (c *MockControllerAPIAPIAddressesCall) DoAndReturn(f func(context.Context) 
 }
 
 // CACert mocks base method.
-func (m *MockControllerAPI) CACert() (string, error) {
+func (m *MockControllerAPI) CACert(arg0 context.Context) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CACert")
+	ret := m.ctrl.Call(m, "CACert", arg0)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CACert indicates an expected call of CACert.
-func (mr *MockControllerAPIMockRecorder) CACert() *MockControllerAPICACertCall {
+func (mr *MockControllerAPIMockRecorder) CACert(arg0 any) *MockControllerAPICACertCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CACert", reflect.TypeOf((*MockControllerAPI)(nil).CACert))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CACert", reflect.TypeOf((*MockControllerAPI)(nil).CACert), arg0)
 	return &MockControllerAPICACertCall{Call: call}
 }
 
@@ -658,13 +658,13 @@ func (c *MockControllerAPICACertCall) Return(arg0 string, arg1 error) *MockContr
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockControllerAPICACertCall) Do(f func() (string, error)) *MockControllerAPICACertCall {
+func (c *MockControllerAPICACertCall) Do(f func(context.Context) (string, error)) *MockControllerAPICACertCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockControllerAPICACertCall) DoAndReturn(f func() (string, error)) *MockControllerAPICACertCall {
+func (c *MockControllerAPICACertCall) DoAndReturn(f func(context.Context) (string, error)) *MockControllerAPICACertCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -748,18 +748,18 @@ func (c *MockControllerAPIModelConfigCall) DoAndReturn(f func(context.Context) (
 }
 
 // ModelUUID mocks base method.
-func (m *MockControllerAPI) ModelUUID() (string, error) {
+func (m *MockControllerAPI) ModelUUID(arg0 context.Context) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ModelUUID")
+	ret := m.ctrl.Call(m, "ModelUUID", arg0)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ModelUUID indicates an expected call of ModelUUID.
-func (mr *MockControllerAPIMockRecorder) ModelUUID() *MockControllerAPIModelUUIDCall {
+func (mr *MockControllerAPIMockRecorder) ModelUUID(arg0 any) *MockControllerAPIModelUUIDCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModelUUID", reflect.TypeOf((*MockControllerAPI)(nil).ModelUUID))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModelUUID", reflect.TypeOf((*MockControllerAPI)(nil).ModelUUID), arg0)
 	return &MockControllerAPIModelUUIDCall{Call: call}
 }
 
@@ -775,13 +775,13 @@ func (c *MockControllerAPIModelUUIDCall) Return(arg0 string, arg1 error) *MockCo
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockControllerAPIModelUUIDCall) Do(f func() (string, error)) *MockControllerAPIModelUUIDCall {
+func (c *MockControllerAPIModelUUIDCall) Do(f func(context.Context) (string, error)) *MockControllerAPIModelUUIDCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockControllerAPIModelUUIDCall) DoAndReturn(f func() (string, error)) *MockControllerAPIModelUUIDCall {
+func (c *MockControllerAPIModelUUIDCall) DoAndReturn(f func(context.Context) (string, error)) *MockControllerAPIModelUUIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -893,18 +893,18 @@ func (c *MockMachinesAPIMachinesCall) DoAndReturn(f func(context.Context, ...nam
 }
 
 // MachinesWithTransientErrors mocks base method.
-func (m *MockMachinesAPI) MachinesWithTransientErrors() ([]provisioner.MachineStatusResult, error) {
+func (m *MockMachinesAPI) MachinesWithTransientErrors(arg0 context.Context) ([]provisioner.MachineStatusResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MachinesWithTransientErrors")
+	ret := m.ctrl.Call(m, "MachinesWithTransientErrors", arg0)
 	ret0, _ := ret[0].([]provisioner.MachineStatusResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // MachinesWithTransientErrors indicates an expected call of MachinesWithTransientErrors.
-func (mr *MockMachinesAPIMockRecorder) MachinesWithTransientErrors() *MockMachinesAPIMachinesWithTransientErrorsCall {
+func (mr *MockMachinesAPIMockRecorder) MachinesWithTransientErrors(arg0 any) *MockMachinesAPIMachinesWithTransientErrorsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MachinesWithTransientErrors", reflect.TypeOf((*MockMachinesAPI)(nil).MachinesWithTransientErrors))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MachinesWithTransientErrors", reflect.TypeOf((*MockMachinesAPI)(nil).MachinesWithTransientErrors), arg0)
 	return &MockMachinesAPIMachinesWithTransientErrorsCall{Call: call}
 }
 
@@ -920,30 +920,30 @@ func (c *MockMachinesAPIMachinesWithTransientErrorsCall) Return(arg0 []provision
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachinesAPIMachinesWithTransientErrorsCall) Do(f func() ([]provisioner.MachineStatusResult, error)) *MockMachinesAPIMachinesWithTransientErrorsCall {
+func (c *MockMachinesAPIMachinesWithTransientErrorsCall) Do(f func(context.Context) ([]provisioner.MachineStatusResult, error)) *MockMachinesAPIMachinesWithTransientErrorsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachinesAPIMachinesWithTransientErrorsCall) DoAndReturn(f func() ([]provisioner.MachineStatusResult, error)) *MockMachinesAPIMachinesWithTransientErrorsCall {
+func (c *MockMachinesAPIMachinesWithTransientErrorsCall) DoAndReturn(f func(context.Context) ([]provisioner.MachineStatusResult, error)) *MockMachinesAPIMachinesWithTransientErrorsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // ProvisioningInfo mocks base method.
-func (m *MockMachinesAPI) ProvisioningInfo(arg0 []names.MachineTag) (params.ProvisioningInfoResults, error) {
+func (m *MockMachinesAPI) ProvisioningInfo(arg0 context.Context, arg1 []names.MachineTag) (params.ProvisioningInfoResults, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ProvisioningInfo", arg0)
+	ret := m.ctrl.Call(m, "ProvisioningInfo", arg0, arg1)
 	ret0, _ := ret[0].(params.ProvisioningInfoResults)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ProvisioningInfo indicates an expected call of ProvisioningInfo.
-func (mr *MockMachinesAPIMockRecorder) ProvisioningInfo(arg0 any) *MockMachinesAPIProvisioningInfoCall {
+func (mr *MockMachinesAPIMockRecorder) ProvisioningInfo(arg0, arg1 any) *MockMachinesAPIProvisioningInfoCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProvisioningInfo", reflect.TypeOf((*MockMachinesAPI)(nil).ProvisioningInfo), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProvisioningInfo", reflect.TypeOf((*MockMachinesAPI)(nil).ProvisioningInfo), arg0, arg1)
 	return &MockMachinesAPIProvisioningInfoCall{Call: call}
 }
 
@@ -959,30 +959,30 @@ func (c *MockMachinesAPIProvisioningInfoCall) Return(arg0 params.ProvisioningInf
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachinesAPIProvisioningInfoCall) Do(f func([]names.MachineTag) (params.ProvisioningInfoResults, error)) *MockMachinesAPIProvisioningInfoCall {
+func (c *MockMachinesAPIProvisioningInfoCall) Do(f func(context.Context, []names.MachineTag) (params.ProvisioningInfoResults, error)) *MockMachinesAPIProvisioningInfoCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachinesAPIProvisioningInfoCall) DoAndReturn(f func([]names.MachineTag) (params.ProvisioningInfoResults, error)) *MockMachinesAPIProvisioningInfoCall {
+func (c *MockMachinesAPIProvisioningInfoCall) DoAndReturn(f func(context.Context, []names.MachineTag) (params.ProvisioningInfoResults, error)) *MockMachinesAPIProvisioningInfoCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // WatchMachineErrorRetry mocks base method.
-func (m *MockMachinesAPI) WatchMachineErrorRetry() (watcher.Watcher[struct{}], error) {
+func (m *MockMachinesAPI) WatchMachineErrorRetry(arg0 context.Context) (watcher.Watcher[struct{}], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchMachineErrorRetry")
+	ret := m.ctrl.Call(m, "WatchMachineErrorRetry", arg0)
 	ret0, _ := ret[0].(watcher.Watcher[struct{}])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // WatchMachineErrorRetry indicates an expected call of WatchMachineErrorRetry.
-func (mr *MockMachinesAPIMockRecorder) WatchMachineErrorRetry() *MockMachinesAPIWatchMachineErrorRetryCall {
+func (mr *MockMachinesAPIMockRecorder) WatchMachineErrorRetry(arg0 any) *MockMachinesAPIWatchMachineErrorRetryCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchMachineErrorRetry", reflect.TypeOf((*MockMachinesAPI)(nil).WatchMachineErrorRetry))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchMachineErrorRetry", reflect.TypeOf((*MockMachinesAPI)(nil).WatchMachineErrorRetry), arg0)
 	return &MockMachinesAPIWatchMachineErrorRetryCall{Call: call}
 }
 
@@ -998,30 +998,30 @@ func (c *MockMachinesAPIWatchMachineErrorRetryCall) Return(arg0 watcher.Watcher[
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachinesAPIWatchMachineErrorRetryCall) Do(f func() (watcher.Watcher[struct{}], error)) *MockMachinesAPIWatchMachineErrorRetryCall {
+func (c *MockMachinesAPIWatchMachineErrorRetryCall) Do(f func(context.Context) (watcher.Watcher[struct{}], error)) *MockMachinesAPIWatchMachineErrorRetryCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachinesAPIWatchMachineErrorRetryCall) DoAndReturn(f func() (watcher.Watcher[struct{}], error)) *MockMachinesAPIWatchMachineErrorRetryCall {
+func (c *MockMachinesAPIWatchMachineErrorRetryCall) DoAndReturn(f func(context.Context) (watcher.Watcher[struct{}], error)) *MockMachinesAPIWatchMachineErrorRetryCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // WatchModelMachines mocks base method.
-func (m *MockMachinesAPI) WatchModelMachines() (watcher.Watcher[[]string], error) {
+func (m *MockMachinesAPI) WatchModelMachines(arg0 context.Context) (watcher.Watcher[[]string], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchModelMachines")
+	ret := m.ctrl.Call(m, "WatchModelMachines", arg0)
 	ret0, _ := ret[0].(watcher.Watcher[[]string])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // WatchModelMachines indicates an expected call of WatchModelMachines.
-func (mr *MockMachinesAPIMockRecorder) WatchModelMachines() *MockMachinesAPIWatchModelMachinesCall {
+func (mr *MockMachinesAPIMockRecorder) WatchModelMachines(arg0 any) *MockMachinesAPIWatchModelMachinesCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchModelMachines", reflect.TypeOf((*MockMachinesAPI)(nil).WatchModelMachines))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchModelMachines", reflect.TypeOf((*MockMachinesAPI)(nil).WatchModelMachines), arg0)
 	return &MockMachinesAPIWatchModelMachinesCall{Call: call}
 }
 
@@ -1037,13 +1037,13 @@ func (c *MockMachinesAPIWatchModelMachinesCall) Return(arg0 watcher.Watcher[[]st
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachinesAPIWatchModelMachinesCall) Do(f func() (watcher.Watcher[[]string], error)) *MockMachinesAPIWatchModelMachinesCall {
+func (c *MockMachinesAPIWatchModelMachinesCall) Do(f func(context.Context) (watcher.Watcher[[]string], error)) *MockMachinesAPIWatchModelMachinesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachinesAPIWatchModelMachinesCall) DoAndReturn(f func() (watcher.Watcher[[]string], error)) *MockMachinesAPIWatchModelMachinesCall {
+func (c *MockMachinesAPIWatchModelMachinesCall) DoAndReturn(f func(context.Context) (watcher.Watcher[[]string], error)) *MockMachinesAPIWatchModelMachinesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/provisioner/provisioner.go
+++ b/internal/worker/provisioner/provisioner.go
@@ -36,7 +36,7 @@ var (
 type Provisioner interface {
 	worker.Worker
 	getMachineWatcher(context.Context) (watcher.StringsWatcher, error)
-	getRetryWatcher() (watcher.NotifyWatcher, error)
+	getRetryWatcher(context.Context) (watcher.NotifyWatcher, error)
 }
 
 // environProvisioner represents a running provisioning worker for machine nodes
@@ -129,7 +129,7 @@ func (p *provisioner) getStartTask(ctx context.Context, harvestMode config.Harve
 	if err != nil {
 		return nil, err
 	}
-	retryWatcher, err := p.getRetryWatcher()
+	retryWatcher, err := p.getRetryWatcher(ctx)
 	if err != nil && !errors.Is(err, errors.NotImplemented) {
 		return nil, err
 	}
@@ -268,12 +268,12 @@ func (p *environProvisioner) loop() error {
 	}
 }
 
-func (p *environProvisioner) getMachineWatcher(_ context.Context) (watcher.StringsWatcher, error) {
-	return p.machinesAPI.WatchModelMachines()
+func (p *environProvisioner) getMachineWatcher(ctx context.Context) (watcher.StringsWatcher, error) {
+	return p.machinesAPI.WatchModelMachines(ctx)
 }
 
-func (p *environProvisioner) getRetryWatcher() (watcher.NotifyWatcher, error) {
-	return p.machinesAPI.WatchMachineErrorRetry()
+func (p *environProvisioner) getRetryWatcher(ctx context.Context) (watcher.NotifyWatcher, error) {
+	return p.machinesAPI.WatchMachineErrorRetry(ctx)
 }
 
 // setConfig updates the environment configuration and notifies
@@ -403,10 +403,10 @@ func (p *containerProvisioner) getMachineWatcher(ctx context.Context) (watcher.S
 	if err != nil {
 		return nil, err
 	}
-	return machine.WatchContainers(p.containerType)
+	return machine.WatchContainers(ctx, p.containerType)
 }
 
-func (p *containerProvisioner) getRetryWatcher() (watcher.NotifyWatcher, error) {
+func (p *containerProvisioner) getRetryWatcher(ctx context.Context) (watcher.NotifyWatcher, error) {
 	return nil, errors.NotImplementedf("getRetryWatcher")
 }
 

--- a/internal/worker/proxyupdater/proxyupdater.go
+++ b/internal/worker/proxyupdater/proxyupdater.go
@@ -50,8 +50,8 @@ func (c *Config) Validate() error {
 // API is an interface that is provided to New
 // which can be used to fetch the API host ports
 type API interface {
-	ProxyConfig() (proxyupdater.ProxyConfiguration, error)
-	WatchForProxyConfigAndAPIHostPortChanges() (watcher.NotifyWatcher, error)
+	ProxyConfig(context.Context) (proxyupdater.ProxyConfiguration, error)
+	WatchForProxyConfigAndAPIHostPortChanges(context.Context) (watcher.NotifyWatcher, error)
 }
 
 // proxyWorker is responsible for monitoring the juju environment
@@ -280,8 +280,8 @@ func (w *proxyWorker) handleAptProxyValues(aptSettings proxy.Settings, aptMirror
 	return
 }
 
-func (w *proxyWorker) onChange() error {
-	config, err := w.config.API.ProxyConfig()
+func (w *proxyWorker) onChange(ctx context.Context) error {
+	config, err := w.config.API.ProxyConfig(ctx)
 	if err != nil {
 		return err
 	}
@@ -293,20 +293,20 @@ func (w *proxyWorker) onChange() error {
 }
 
 // SetUp is defined on the worker.NotifyWatchHandler interface.
-func (w *proxyWorker) SetUp(_ context.Context) (watcher.NotifyWatcher, error) {
+func (w *proxyWorker) SetUp(ctx context.Context) (watcher.NotifyWatcher, error) {
 	// We need to set this up initially as the NotifyWorker sucks up the first
 	// event.
-	err := w.onChange()
+	err := w.onChange(ctx)
 	if err != nil {
 		return nil, err
 	}
 	w.first = false
-	return w.config.API.WatchForProxyConfigAndAPIHostPortChanges()
+	return w.config.API.WatchForProxyConfigAndAPIHostPortChanges(ctx)
 }
 
 // Handle is defined on the worker.NotifyWatchHandler interface.
-func (w *proxyWorker) Handle(_ context.Context) error {
-	return w.onChange()
+func (w *proxyWorker) Handle(ctx context.Context) error {
+	return w.onChange(ctx)
 }
 
 // TearDown is defined on the worker.NotifyWatchHandler interface.

--- a/internal/worker/proxyupdater/proxyupdater_test.go
+++ b/internal/worker/proxyupdater/proxyupdater_test.go
@@ -4,6 +4,7 @@
 package proxyupdater_test
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -67,11 +68,11 @@ func NewFakeAPI() *fakeAPI {
 	return f
 }
 
-func (api fakeAPI) ProxyConfig() (proxyupdaterapi.ProxyConfiguration, error) {
+func (api fakeAPI) ProxyConfig(context.Context) (proxyupdaterapi.ProxyConfiguration, error) {
 	return api.proxies, api.Err
 }
 
-func (api *fakeAPI) WatchForProxyConfigAndAPIHostPortChanges() (watcher.NotifyWatcher, error) {
+func (api *fakeAPI) WatchForProxyConfigAndAPIHostPortChanges(context.Context) (watcher.NotifyWatcher, error) {
 	if api.Watcher == nil {
 		w := newNotAWatcher()
 		api.Watcher = &w

--- a/internal/worker/reboot/mocks/facade_mock.go
+++ b/internal/worker/reboot/mocks/facade_mock.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	watcher "github.com/juju/juju/core/watcher"
@@ -41,17 +42,17 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // ClearReboot mocks base method.
-func (m *MockClient) ClearReboot() error {
+func (m *MockClient) ClearReboot(arg0 context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ClearReboot")
+	ret := m.ctrl.Call(m, "ClearReboot", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ClearReboot indicates an expected call of ClearReboot.
-func (mr *MockClientMockRecorder) ClearReboot() *MockClientClearRebootCall {
+func (mr *MockClientMockRecorder) ClearReboot(arg0 any) *MockClientClearRebootCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClearReboot", reflect.TypeOf((*MockClient)(nil).ClearReboot))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClearReboot", reflect.TypeOf((*MockClient)(nil).ClearReboot), arg0)
 	return &MockClientClearRebootCall{Call: call}
 }
 
@@ -67,30 +68,30 @@ func (c *MockClientClearRebootCall) Return(arg0 error) *MockClientClearRebootCal
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockClientClearRebootCall) Do(f func() error) *MockClientClearRebootCall {
+func (c *MockClientClearRebootCall) Do(f func(context.Context) error) *MockClientClearRebootCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockClientClearRebootCall) DoAndReturn(f func() error) *MockClientClearRebootCall {
+func (c *MockClientClearRebootCall) DoAndReturn(f func(context.Context) error) *MockClientClearRebootCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetRebootAction mocks base method.
-func (m *MockClient) GetRebootAction() (params.RebootAction, error) {
+func (m *MockClient) GetRebootAction(arg0 context.Context) (params.RebootAction, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRebootAction")
+	ret := m.ctrl.Call(m, "GetRebootAction", arg0)
 	ret0, _ := ret[0].(params.RebootAction)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetRebootAction indicates an expected call of GetRebootAction.
-func (mr *MockClientMockRecorder) GetRebootAction() *MockClientGetRebootActionCall {
+func (mr *MockClientMockRecorder) GetRebootAction(arg0 any) *MockClientGetRebootActionCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRebootAction", reflect.TypeOf((*MockClient)(nil).GetRebootAction))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRebootAction", reflect.TypeOf((*MockClient)(nil).GetRebootAction), arg0)
 	return &MockClientGetRebootActionCall{Call: call}
 }
 
@@ -106,29 +107,29 @@ func (c *MockClientGetRebootActionCall) Return(arg0 params.RebootAction, arg1 er
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockClientGetRebootActionCall) Do(f func() (params.RebootAction, error)) *MockClientGetRebootActionCall {
+func (c *MockClientGetRebootActionCall) Do(f func(context.Context) (params.RebootAction, error)) *MockClientGetRebootActionCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockClientGetRebootActionCall) DoAndReturn(f func() (params.RebootAction, error)) *MockClientGetRebootActionCall {
+func (c *MockClientGetRebootActionCall) DoAndReturn(f func(context.Context) (params.RebootAction, error)) *MockClientGetRebootActionCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // RequestReboot mocks base method.
-func (m *MockClient) RequestReboot() error {
+func (m *MockClient) RequestReboot(arg0 context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RequestReboot")
+	ret := m.ctrl.Call(m, "RequestReboot", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RequestReboot indicates an expected call of RequestReboot.
-func (mr *MockClientMockRecorder) RequestReboot() *MockClientRequestRebootCall {
+func (mr *MockClientMockRecorder) RequestReboot(arg0 any) *MockClientRequestRebootCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestReboot", reflect.TypeOf((*MockClient)(nil).RequestReboot))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestReboot", reflect.TypeOf((*MockClient)(nil).RequestReboot), arg0)
 	return &MockClientRequestRebootCall{Call: call}
 }
 
@@ -144,30 +145,30 @@ func (c *MockClientRequestRebootCall) Return(arg0 error) *MockClientRequestReboo
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockClientRequestRebootCall) Do(f func() error) *MockClientRequestRebootCall {
+func (c *MockClientRequestRebootCall) Do(f func(context.Context) error) *MockClientRequestRebootCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockClientRequestRebootCall) DoAndReturn(f func() error) *MockClientRequestRebootCall {
+func (c *MockClientRequestRebootCall) DoAndReturn(f func(context.Context) error) *MockClientRequestRebootCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // WatchForRebootEvent mocks base method.
-func (m *MockClient) WatchForRebootEvent() (watcher.Watcher[struct{}], error) {
+func (m *MockClient) WatchForRebootEvent(arg0 context.Context) (watcher.Watcher[struct{}], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchForRebootEvent")
+	ret := m.ctrl.Call(m, "WatchForRebootEvent", arg0)
 	ret0, _ := ret[0].(watcher.Watcher[struct{}])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // WatchForRebootEvent indicates an expected call of WatchForRebootEvent.
-func (mr *MockClientMockRecorder) WatchForRebootEvent() *MockClientWatchForRebootEventCall {
+func (mr *MockClientMockRecorder) WatchForRebootEvent(arg0 any) *MockClientWatchForRebootEventCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchForRebootEvent", reflect.TypeOf((*MockClient)(nil).WatchForRebootEvent))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchForRebootEvent", reflect.TypeOf((*MockClient)(nil).WatchForRebootEvent), arg0)
 	return &MockClientWatchForRebootEventCall{Call: call}
 }
 
@@ -183,13 +184,13 @@ func (c *MockClientWatchForRebootEventCall) Return(arg0 watcher.Watcher[struct{}
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockClientWatchForRebootEventCall) Do(f func() (watcher.Watcher[struct{}], error)) *MockClientWatchForRebootEventCall {
+func (c *MockClientWatchForRebootEventCall) Do(f func(context.Context) (watcher.Watcher[struct{}], error)) *MockClientWatchForRebootEventCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockClientWatchForRebootEventCall) DoAndReturn(f func() (watcher.Watcher[struct{}], error)) *MockClientWatchForRebootEventCall {
+func (c *MockClientWatchForRebootEventCall) DoAndReturn(f func(context.Context) (watcher.Watcher[struct{}], error)) *MockClientWatchForRebootEventCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/reboot/reboot.go
+++ b/internal/worker/reboot/reboot.go
@@ -47,13 +47,13 @@ func NewReboot(client reboot.Client, agentTag names.Tag, machineLock machinelock
 	return w, errors.Trace(err)
 }
 
-func (r *Reboot) SetUp(_ context.Context) (watcher.NotifyWatcher, error) {
-	watcher, err := r.client.WatchForRebootEvent()
+func (r *Reboot) SetUp(ctx context.Context) (watcher.NotifyWatcher, error) {
+	watcher, err := r.client.WatchForRebootEvent(ctx)
 	return watcher, errors.Trace(err)
 }
 
-func (r *Reboot) Handle(_ context.Context) error {
-	rAction, err := r.client.GetRebootAction()
+func (r *Reboot) Handle(ctx context.Context) error {
+	rAction, err := r.client.GetRebootAction(ctx)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -90,7 +90,7 @@ func (r *Reboot) Handle(_ context.Context) error {
 		// that the machine agent is also a controller, and the apiserver has been
 		// shut down. It is better to clear the flag and not reboot on a weird
 		// error rather than get into a reboot loop because we can't shutdown.
-		if err := r.client.ClearReboot(); err != nil {
+		if err := r.client.ClearReboot(ctx); err != nil {
 			logger.Infof("unable to clear reboot flag: %v", err)
 		}
 	}

--- a/internal/worker/reboot/reboot_test.go
+++ b/internal/worker/reboot/reboot_test.go
@@ -33,7 +33,7 @@ func (s *rebootSuite) TestStartStop(c *gc.C) {
 	watch := watchertest.NewMockNotifyWatcher(ch)
 
 	client := mocks.NewMockClient(ctrl)
-	client.EXPECT().WatchForRebootEvent().Return(watch, nil)
+	client.EXPECT().WatchForRebootEvent(gomock.Any()).Return(watch, nil)
 	lock := mocks.NewMockLock(ctrl)
 
 	w, err := reboot.NewReboot(client, names.NewMachineTag("666"), lock)
@@ -53,9 +53,9 @@ func (s *rebootSuite) TestWorkerReboot(c *gc.C) {
 	ch <- struct{}{}
 
 	client := mocks.NewMockClient(ctrl)
-	client.EXPECT().WatchForRebootEvent().Return(watch, nil)
-	client.EXPECT().GetRebootAction().Return(params.ShouldReboot, nil)
-	client.EXPECT().ClearReboot().Return(nil)
+	client.EXPECT().WatchForRebootEvent(gomock.Any()).Return(watch, nil)
+	client.EXPECT().GetRebootAction(gomock.Any()).Return(params.ShouldReboot, nil)
+	client.EXPECT().ClearReboot(gomock.Any()).Return(nil)
 
 	lock := mocks.NewMockLock(ctrl)
 	lock.EXPECT().Acquire(machinelock.Spec{
@@ -79,9 +79,9 @@ func (s *rebootSuite) TestContainerShutdown(c *gc.C) {
 	ch <- struct{}{}
 
 	client := mocks.NewMockClient(ctrl)
-	client.EXPECT().WatchForRebootEvent().Return(watch, nil)
-	client.EXPECT().GetRebootAction().Return(params.ShouldShutdown, nil)
-	client.EXPECT().ClearReboot().Return(nil)
+	client.EXPECT().WatchForRebootEvent(gomock.Any()).Return(watch, nil)
+	client.EXPECT().GetRebootAction(gomock.Any()).Return(params.ShouldShutdown, nil)
+	client.EXPECT().ClearReboot(gomock.Any()).Return(nil)
 
 	lock := mocks.NewMockLock(ctrl)
 	lock.EXPECT().Acquire(machinelock.Spec{

--- a/internal/worker/retrystrategy/fixture_test.go
+++ b/internal/worker/retrystrategy/fixture_test.go
@@ -5,6 +5,7 @@
 package retrystrategy_test
 
 import (
+	"context"
 	"time"
 
 	"github.com/juju/names/v5"
@@ -82,7 +83,7 @@ func newStubFacade(c *gc.C, stub *testing.Stub, initialStrategy params.RetryStra
 }
 
 // WatchRetryStrategy is part of the retrystrategy Facade
-func (f *stubFacade) WatchRetryStrategy(agentTag names.Tag) (watcher.NotifyWatcher, error) {
+func (f *stubFacade) WatchRetryStrategy(ctx context.Context, agentTag names.Tag) (watcher.NotifyWatcher, error) {
 	f.c.Assert(agentTag, gc.Equals, f.stubTag)
 	f.stub.AddCall("WatchRetryStrategy", agentTag)
 	err := f.stub.NextErr()
@@ -93,7 +94,7 @@ func (f *stubFacade) WatchRetryStrategy(agentTag names.Tag) (watcher.NotifyWatch
 }
 
 // RetryStrategy is part of the retrystrategy Facade
-func (f *stubFacade) RetryStrategy(agentTag names.Tag) (params.RetryStrategy, error) {
+func (f *stubFacade) RetryStrategy(ctx context.Context, agentTag names.Tag) (params.RetryStrategy, error) {
 	f.c.Assert(agentTag, gc.Equals, f.stubTag)
 	f.stub.AddCall("RetryStrategy", agentTag)
 	f.count = f.count + 1

--- a/internal/worker/retrystrategy/manifold.go
+++ b/internal/worker/retrystrategy/manifold.go
@@ -39,10 +39,10 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 	return manifold
 }
 
-func (mc ManifoldConfig) start(_ context.Context, a agent.Agent, apiCaller base.APICaller) (worker.Worker, error) {
+func (mc ManifoldConfig) start(ctx context.Context, a agent.Agent, apiCaller base.APICaller) (worker.Worker, error) {
 	agentTag := a.CurrentConfig().Tag()
 	retryStrategyFacade := mc.NewFacade(apiCaller)
-	initialRetryStrategy, err := retryStrategyFacade.RetryStrategy(agentTag)
+	initialRetryStrategy, err := retryStrategyFacade.RetryStrategy(ctx, agentTag)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/internal/worker/retrystrategy/manifold_test.go
+++ b/internal/worker/retrystrategy/manifold_test.go
@@ -223,11 +223,11 @@ type fakeFacade struct {
 	retrystrategy.Facade
 }
 
-func (mock *fakeFacade) RetryStrategy(agentTag names.Tag) (params.RetryStrategy, error) {
+func (mock *fakeFacade) RetryStrategy(ctx context.Context, agentTag names.Tag) (params.RetryStrategy, error) {
 	return fakeStrategy, nil
 }
 
-func (mock *fakeFacade) WatchRetryStrategy(agentTag names.Tag) (watcher.NotifyWatcher, error) {
+func (mock *fakeFacade) WatchRetryStrategy(ctx context.Context, agentTag names.Tag) (watcher.NotifyWatcher, error) {
 	return newStubWatcher(), nil
 }
 
@@ -236,7 +236,7 @@ type fakeFacadeErr struct {
 	err error
 }
 
-func (mock *fakeFacadeErr) RetryStrategy(agentTag names.Tag) (params.RetryStrategy, error) {
+func (mock *fakeFacadeErr) RetryStrategy(ctx context.Context, agentTag names.Tag) (params.RetryStrategy, error) {
 	return params.RetryStrategy{}, mock.err
 }
 

--- a/internal/worker/retrystrategy/worker.go
+++ b/internal/worker/retrystrategy/worker.go
@@ -19,8 +19,8 @@ import (
 
 // Facade defines the capabilities required by the worker from the API.
 type Facade interface {
-	RetryStrategy(names.Tag) (params.RetryStrategy, error)
-	WatchRetryStrategy(names.Tag) (watcher.NotifyWatcher, error)
+	RetryStrategy(context.Context, names.Tag) (params.RetryStrategy, error)
+	WatchRetryStrategy(context.Context, names.Tag) (watcher.NotifyWatcher, error)
 }
 
 // WorkerConfig defines the worker's dependencies.
@@ -79,15 +79,15 @@ type retryStrategyHandler struct {
 }
 
 // SetUp is part of the watcher.NotifyHandler interface.
-func (h retryStrategyHandler) SetUp(_ context.Context) (watcher.NotifyWatcher, error) {
-	return h.config.Facade.WatchRetryStrategy(h.config.AgentTag)
+func (h retryStrategyHandler) SetUp(ctx context.Context) (watcher.NotifyWatcher, error) {
+	return h.config.Facade.WatchRetryStrategy(ctx, h.config.AgentTag)
 }
 
 // Handle is part of the watcher.NotifyHandler interface.
 // Whenever a valid change is encountered the worker bounces,
 // making the dependents bounce and get the new value
-func (h retryStrategyHandler) Handle(_ context.Context) error {
-	newRetryStrategy, err := h.config.Facade.RetryStrategy(h.config.AgentTag)
+func (h retryStrategyHandler) Handle(ctx context.Context) error {
+	newRetryStrategy, err := h.config.Facade.RetryStrategy(ctx, h.config.AgentTag)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/internal/worker/secretbackendrotate/rotate_test.go
+++ b/internal/worker/secretbackendrotate/rotate_test.go
@@ -33,14 +33,6 @@ type workerSuite struct {
 
 var _ = gc.Suite(&workerSuite{})
 
-func (s *workerSuite) SetUpTest(c *gc.C) {
-	s.BaseSuite.SetUpTest(c)
-}
-
-func (s *workerSuite) TearDownTest(c *gc.C) {
-	s.BaseSuite.TearDownTest(c)
-}
-
 func (s *workerSuite) setup(c *gc.C) *gomock.Controller {
 	ctrl := gomock.NewController(c)
 

--- a/internal/worker/secretexpire/mocks/client_mock.go
+++ b/internal/worker/secretexpire/mocks/client_mock.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	watcher "github.com/juju/juju/core/watcher"
@@ -41,9 +42,9 @@ func (m *MockSecretManagerFacade) EXPECT() *MockSecretManagerFacadeMockRecorder 
 }
 
 // WatchSecretRevisionsExpiryChanges mocks base method.
-func (m *MockSecretManagerFacade) WatchSecretRevisionsExpiryChanges(ownerTags ...names.Tag) (watcher.SecretTriggerWatcher, error) {
+func (m *MockSecretManagerFacade) WatchSecretRevisionsExpiryChanges(ctx context.Context, ownerTags ...names.Tag) (watcher.SecretTriggerWatcher, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{}
+	varargs := []any{ctx}
 	for _, a := range ownerTags {
 		varargs = append(varargs, a)
 	}
@@ -54,9 +55,10 @@ func (m *MockSecretManagerFacade) WatchSecretRevisionsExpiryChanges(ownerTags ..
 }
 
 // WatchSecretRevisionsExpiryChanges indicates an expected call of WatchSecretRevisionsExpiryChanges.
-func (mr *MockSecretManagerFacadeMockRecorder) WatchSecretRevisionsExpiryChanges(ownerTags ...any) *MockSecretManagerFacadeWatchSecretRevisionsExpiryChangesCall {
+func (mr *MockSecretManagerFacadeMockRecorder) WatchSecretRevisionsExpiryChanges(ctx any, ownerTags ...any) *MockSecretManagerFacadeWatchSecretRevisionsExpiryChangesCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchSecretRevisionsExpiryChanges", reflect.TypeOf((*MockSecretManagerFacade)(nil).WatchSecretRevisionsExpiryChanges), ownerTags...)
+	varargs := append([]any{ctx}, ownerTags...)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchSecretRevisionsExpiryChanges", reflect.TypeOf((*MockSecretManagerFacade)(nil).WatchSecretRevisionsExpiryChanges), varargs...)
 	return &MockSecretManagerFacadeWatchSecretRevisionsExpiryChangesCall{Call: call}
 }
 
@@ -72,13 +74,13 @@ func (c *MockSecretManagerFacadeWatchSecretRevisionsExpiryChangesCall) Return(ar
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSecretManagerFacadeWatchSecretRevisionsExpiryChangesCall) Do(f func(...names.Tag) (watcher.SecretTriggerWatcher, error)) *MockSecretManagerFacadeWatchSecretRevisionsExpiryChangesCall {
+func (c *MockSecretManagerFacadeWatchSecretRevisionsExpiryChangesCall) Do(f func(context.Context, ...names.Tag) (watcher.SecretTriggerWatcher, error)) *MockSecretManagerFacadeWatchSecretRevisionsExpiryChangesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSecretManagerFacadeWatchSecretRevisionsExpiryChangesCall) DoAndReturn(f func(...names.Tag) (watcher.SecretTriggerWatcher, error)) *MockSecretManagerFacadeWatchSecretRevisionsExpiryChangesCall {
+func (c *MockSecretManagerFacadeWatchSecretRevisionsExpiryChangesCall) DoAndReturn(f func(context.Context, ...names.Tag) (watcher.SecretTriggerWatcher, error)) *MockSecretManagerFacadeWatchSecretRevisionsExpiryChangesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/secretexpire/secretexpire_test.go
+++ b/internal/worker/secretexpire/secretexpire_test.go
@@ -93,7 +93,7 @@ func (s *workerSuite) testValidateConfig(c *gc.C, f func(*secretexpire.Config), 
 }
 
 func (s *workerSuite) expectWorker() {
-	s.facade.EXPECT().WatchSecretRevisionsExpiryChanges(s.config.SecretOwners).Return(s.triggerWatcher, nil)
+	s.facade.EXPECT().WatchSecretRevisionsExpiryChanges(gomock.Any(), s.config.SecretOwners).Return(s.triggerWatcher, nil)
 	s.triggerWatcher.EXPECT().Changes().AnyTimes().Return(s.expiryConfigChanges)
 	s.triggerWatcher.EXPECT().Kill().MaxTimes(1)
 	s.triggerWatcher.EXPECT().Wait().Return(nil).MinTimes(1)

--- a/internal/worker/secretrotate/mocks/client_mock.go
+++ b/internal/worker/secretrotate/mocks/client_mock.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	watcher "github.com/juju/juju/core/watcher"
@@ -41,9 +42,9 @@ func (m *MockSecretManagerFacade) EXPECT() *MockSecretManagerFacadeMockRecorder 
 }
 
 // WatchSecretsRotationChanges mocks base method.
-func (m *MockSecretManagerFacade) WatchSecretsRotationChanges(ownerTags ...names.Tag) (watcher.SecretTriggerWatcher, error) {
+func (m *MockSecretManagerFacade) WatchSecretsRotationChanges(ctx context.Context, ownerTags ...names.Tag) (watcher.SecretTriggerWatcher, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{}
+	varargs := []any{ctx}
 	for _, a := range ownerTags {
 		varargs = append(varargs, a)
 	}
@@ -54,9 +55,10 @@ func (m *MockSecretManagerFacade) WatchSecretsRotationChanges(ownerTags ...names
 }
 
 // WatchSecretsRotationChanges indicates an expected call of WatchSecretsRotationChanges.
-func (mr *MockSecretManagerFacadeMockRecorder) WatchSecretsRotationChanges(ownerTags ...any) *MockSecretManagerFacadeWatchSecretsRotationChangesCall {
+func (mr *MockSecretManagerFacadeMockRecorder) WatchSecretsRotationChanges(ctx any, ownerTags ...any) *MockSecretManagerFacadeWatchSecretsRotationChangesCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchSecretsRotationChanges", reflect.TypeOf((*MockSecretManagerFacade)(nil).WatchSecretsRotationChanges), ownerTags...)
+	varargs := append([]any{ctx}, ownerTags...)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchSecretsRotationChanges", reflect.TypeOf((*MockSecretManagerFacade)(nil).WatchSecretsRotationChanges), varargs...)
 	return &MockSecretManagerFacadeWatchSecretsRotationChangesCall{Call: call}
 }
 
@@ -72,13 +74,13 @@ func (c *MockSecretManagerFacadeWatchSecretsRotationChangesCall) Return(arg0 wat
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSecretManagerFacadeWatchSecretsRotationChangesCall) Do(f func(...names.Tag) (watcher.SecretTriggerWatcher, error)) *MockSecretManagerFacadeWatchSecretsRotationChangesCall {
+func (c *MockSecretManagerFacadeWatchSecretsRotationChangesCall) Do(f func(context.Context, ...names.Tag) (watcher.SecretTriggerWatcher, error)) *MockSecretManagerFacadeWatchSecretsRotationChangesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSecretManagerFacadeWatchSecretsRotationChangesCall) DoAndReturn(f func(...names.Tag) (watcher.SecretTriggerWatcher, error)) *MockSecretManagerFacadeWatchSecretsRotationChangesCall {
+func (c *MockSecretManagerFacadeWatchSecretsRotationChangesCall) DoAndReturn(f func(context.Context, ...names.Tag) (watcher.SecretTriggerWatcher, error)) *MockSecretManagerFacadeWatchSecretsRotationChangesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/secretrotate/secretrotate_test.go
+++ b/internal/worker/secretrotate/secretrotate_test.go
@@ -35,14 +35,6 @@ type workerSuite struct {
 
 var _ = gc.Suite(&workerSuite{})
 
-func (s *workerSuite) SetUpTest(c *gc.C) {
-	s.BaseSuite.SetUpTest(c)
-}
-
-func (s *workerSuite) TearDownTest(c *gc.C) {
-	s.BaseSuite.TearDownTest(c)
-}
-
 func (s *workerSuite) setup(c *gc.C) *gomock.Controller {
 	ctrl := gomock.NewController(c)
 
@@ -92,7 +84,7 @@ func (s *workerSuite) testValidateConfig(c *gc.C, f func(*secretrotate.Config), 
 }
 
 func (s *workerSuite) expectWorker() {
-	s.facade.EXPECT().WatchSecretsRotationChanges(s.config.SecretOwners).Return(s.rotateWatcher, nil)
+	s.facade.EXPECT().WatchSecretsRotationChanges(gomock.Any(), s.config.SecretOwners).Return(s.rotateWatcher, nil)
 	s.rotateWatcher.EXPECT().Changes().AnyTimes().Return(s.rotateConfigChanges)
 	s.rotateWatcher.EXPECT().Kill().MaxTimes(1)
 	s.rotateWatcher.EXPECT().Wait().Return(nil).MinTimes(1)

--- a/internal/worker/secretsdrainworker/mocks/secrets_mock.go
+++ b/internal/worker/secretsdrainworker/mocks/secrets_mock.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	secrets "github.com/juju/juju/core/secrets"
@@ -41,17 +42,17 @@ func (m *MockBackendsClient) EXPECT() *MockBackendsClientMockRecorder {
 }
 
 // DeleteContent mocks base method.
-func (m *MockBackendsClient) DeleteContent(arg0 *secrets.URI, arg1 int) error {
+func (m *MockBackendsClient) DeleteContent(arg0 context.Context, arg1 *secrets.URI, arg2 int) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteContent", arg0, arg1)
+	ret := m.ctrl.Call(m, "DeleteContent", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteContent indicates an expected call of DeleteContent.
-func (mr *MockBackendsClientMockRecorder) DeleteContent(arg0, arg1 any) *MockBackendsClientDeleteContentCall {
+func (mr *MockBackendsClientMockRecorder) DeleteContent(arg0, arg1, arg2 any) *MockBackendsClientDeleteContentCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteContent", reflect.TypeOf((*MockBackendsClient)(nil).DeleteContent), arg0, arg1)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteContent", reflect.TypeOf((*MockBackendsClient)(nil).DeleteContent), arg0, arg1, arg2)
 	return &MockBackendsClientDeleteContentCall{Call: call}
 }
 
@@ -67,29 +68,29 @@ func (c *MockBackendsClientDeleteContentCall) Return(arg0 error) *MockBackendsCl
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockBackendsClientDeleteContentCall) Do(f func(*secrets.URI, int) error) *MockBackendsClientDeleteContentCall {
+func (c *MockBackendsClientDeleteContentCall) Do(f func(context.Context, *secrets.URI, int) error) *MockBackendsClientDeleteContentCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockBackendsClientDeleteContentCall) DoAndReturn(f func(*secrets.URI, int) error) *MockBackendsClientDeleteContentCall {
+func (c *MockBackendsClientDeleteContentCall) DoAndReturn(f func(context.Context, *secrets.URI, int) error) *MockBackendsClientDeleteContentCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // DeleteExternalContent mocks base method.
-func (m *MockBackendsClient) DeleteExternalContent(arg0 secrets.ValueRef) error {
+func (m *MockBackendsClient) DeleteExternalContent(arg0 context.Context, arg1 secrets.ValueRef) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteExternalContent", arg0)
+	ret := m.ctrl.Call(m, "DeleteExternalContent", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteExternalContent indicates an expected call of DeleteExternalContent.
-func (mr *MockBackendsClientMockRecorder) DeleteExternalContent(arg0 any) *MockBackendsClientDeleteExternalContentCall {
+func (mr *MockBackendsClientMockRecorder) DeleteExternalContent(arg0, arg1 any) *MockBackendsClientDeleteExternalContentCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteExternalContent", reflect.TypeOf((*MockBackendsClient)(nil).DeleteExternalContent), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteExternalContent", reflect.TypeOf((*MockBackendsClient)(nil).DeleteExternalContent), arg0, arg1)
 	return &MockBackendsClientDeleteExternalContentCall{Call: call}
 }
 
@@ -105,21 +106,21 @@ func (c *MockBackendsClientDeleteExternalContentCall) Return(arg0 error) *MockBa
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockBackendsClientDeleteExternalContentCall) Do(f func(secrets.ValueRef) error) *MockBackendsClientDeleteExternalContentCall {
+func (c *MockBackendsClientDeleteExternalContentCall) Do(f func(context.Context, secrets.ValueRef) error) *MockBackendsClientDeleteExternalContentCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockBackendsClientDeleteExternalContentCall) DoAndReturn(f func(secrets.ValueRef) error) *MockBackendsClientDeleteExternalContentCall {
+func (c *MockBackendsClientDeleteExternalContentCall) DoAndReturn(f func(context.Context, secrets.ValueRef) error) *MockBackendsClientDeleteExternalContentCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetBackend mocks base method.
-func (m *MockBackendsClient) GetBackend(arg0 *string, arg1 bool) (provider.SecretsBackend, string, error) {
+func (m *MockBackendsClient) GetBackend(arg0 context.Context, arg1 *string, arg2 bool) (provider.SecretsBackend, string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBackend", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetBackend", arg0, arg1, arg2)
 	ret0, _ := ret[0].(provider.SecretsBackend)
 	ret1, _ := ret[1].(string)
 	ret2, _ := ret[2].(error)
@@ -127,9 +128,9 @@ func (m *MockBackendsClient) GetBackend(arg0 *string, arg1 bool) (provider.Secre
 }
 
 // GetBackend indicates an expected call of GetBackend.
-func (mr *MockBackendsClientMockRecorder) GetBackend(arg0, arg1 any) *MockBackendsClientGetBackendCall {
+func (mr *MockBackendsClientMockRecorder) GetBackend(arg0, arg1, arg2 any) *MockBackendsClientGetBackendCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackend", reflect.TypeOf((*MockBackendsClient)(nil).GetBackend), arg0, arg1)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackend", reflect.TypeOf((*MockBackendsClient)(nil).GetBackend), arg0, arg1, arg2)
 	return &MockBackendsClientGetBackendCall{Call: call}
 }
 
@@ -145,30 +146,30 @@ func (c *MockBackendsClientGetBackendCall) Return(arg0 provider.SecretsBackend, 
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockBackendsClientGetBackendCall) Do(f func(*string, bool) (provider.SecretsBackend, string, error)) *MockBackendsClientGetBackendCall {
+func (c *MockBackendsClientGetBackendCall) Do(f func(context.Context, *string, bool) (provider.SecretsBackend, string, error)) *MockBackendsClientGetBackendCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockBackendsClientGetBackendCall) DoAndReturn(f func(*string, bool) (provider.SecretsBackend, string, error)) *MockBackendsClientGetBackendCall {
+func (c *MockBackendsClientGetBackendCall) DoAndReturn(f func(context.Context, *string, bool) (provider.SecretsBackend, string, error)) *MockBackendsClientGetBackendCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetContent mocks base method.
-func (m *MockBackendsClient) GetContent(arg0 *secrets.URI, arg1 string, arg2, arg3 bool) (secrets.SecretValue, error) {
+func (m *MockBackendsClient) GetContent(arg0 context.Context, arg1 *secrets.URI, arg2 string, arg3, arg4 bool) (secrets.SecretValue, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetContent", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "GetContent", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(secrets.SecretValue)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetContent indicates an expected call of GetContent.
-func (mr *MockBackendsClientMockRecorder) GetContent(arg0, arg1, arg2, arg3 any) *MockBackendsClientGetContentCall {
+func (mr *MockBackendsClientMockRecorder) GetContent(arg0, arg1, arg2, arg3, arg4 any) *MockBackendsClientGetContentCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContent", reflect.TypeOf((*MockBackendsClient)(nil).GetContent), arg0, arg1, arg2, arg3)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContent", reflect.TypeOf((*MockBackendsClient)(nil).GetContent), arg0, arg1, arg2, arg3, arg4)
 	return &MockBackendsClientGetContentCall{Call: call}
 }
 
@@ -184,30 +185,30 @@ func (c *MockBackendsClientGetContentCall) Return(arg0 secrets.SecretValue, arg1
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockBackendsClientGetContentCall) Do(f func(*secrets.URI, string, bool, bool) (secrets.SecretValue, error)) *MockBackendsClientGetContentCall {
+func (c *MockBackendsClientGetContentCall) Do(f func(context.Context, *secrets.URI, string, bool, bool) (secrets.SecretValue, error)) *MockBackendsClientGetContentCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockBackendsClientGetContentCall) DoAndReturn(f func(*secrets.URI, string, bool, bool) (secrets.SecretValue, error)) *MockBackendsClientGetContentCall {
+func (c *MockBackendsClientGetContentCall) DoAndReturn(f func(context.Context, *secrets.URI, string, bool, bool) (secrets.SecretValue, error)) *MockBackendsClientGetContentCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetRevisionContent mocks base method.
-func (m *MockBackendsClient) GetRevisionContent(arg0 *secrets.URI, arg1 int) (secrets.SecretValue, error) {
+func (m *MockBackendsClient) GetRevisionContent(arg0 context.Context, arg1 *secrets.URI, arg2 int) (secrets.SecretValue, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRevisionContent", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetRevisionContent", arg0, arg1, arg2)
 	ret0, _ := ret[0].(secrets.SecretValue)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetRevisionContent indicates an expected call of GetRevisionContent.
-func (mr *MockBackendsClientMockRecorder) GetRevisionContent(arg0, arg1 any) *MockBackendsClientGetRevisionContentCall {
+func (mr *MockBackendsClientMockRecorder) GetRevisionContent(arg0, arg1, arg2 any) *MockBackendsClientGetRevisionContentCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRevisionContent", reflect.TypeOf((*MockBackendsClient)(nil).GetRevisionContent), arg0, arg1)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRevisionContent", reflect.TypeOf((*MockBackendsClient)(nil).GetRevisionContent), arg0, arg1, arg2)
 	return &MockBackendsClientGetRevisionContentCall{Call: call}
 }
 
@@ -223,30 +224,30 @@ func (c *MockBackendsClientGetRevisionContentCall) Return(arg0 secrets.SecretVal
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockBackendsClientGetRevisionContentCall) Do(f func(*secrets.URI, int) (secrets.SecretValue, error)) *MockBackendsClientGetRevisionContentCall {
+func (c *MockBackendsClientGetRevisionContentCall) Do(f func(context.Context, *secrets.URI, int) (secrets.SecretValue, error)) *MockBackendsClientGetRevisionContentCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockBackendsClientGetRevisionContentCall) DoAndReturn(f func(*secrets.URI, int) (secrets.SecretValue, error)) *MockBackendsClientGetRevisionContentCall {
+func (c *MockBackendsClientGetRevisionContentCall) DoAndReturn(f func(context.Context, *secrets.URI, int) (secrets.SecretValue, error)) *MockBackendsClientGetRevisionContentCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // SaveContent mocks base method.
-func (m *MockBackendsClient) SaveContent(arg0 *secrets.URI, arg1 int, arg2 secrets.SecretValue) (secrets.ValueRef, error) {
+func (m *MockBackendsClient) SaveContent(arg0 context.Context, arg1 *secrets.URI, arg2 int, arg3 secrets.SecretValue) (secrets.ValueRef, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SaveContent", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "SaveContent", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(secrets.ValueRef)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // SaveContent indicates an expected call of SaveContent.
-func (mr *MockBackendsClientMockRecorder) SaveContent(arg0, arg1, arg2 any) *MockBackendsClientSaveContentCall {
+func (mr *MockBackendsClientMockRecorder) SaveContent(arg0, arg1, arg2, arg3 any) *MockBackendsClientSaveContentCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveContent", reflect.TypeOf((*MockBackendsClient)(nil).SaveContent), arg0, arg1, arg2)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveContent", reflect.TypeOf((*MockBackendsClient)(nil).SaveContent), arg0, arg1, arg2, arg3)
 	return &MockBackendsClientSaveContentCall{Call: call}
 }
 
@@ -262,13 +263,13 @@ func (c *MockBackendsClientSaveContentCall) Return(arg0 secrets.ValueRef, arg1 e
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockBackendsClientSaveContentCall) Do(f func(*secrets.URI, int, secrets.SecretValue) (secrets.ValueRef, error)) *MockBackendsClientSaveContentCall {
+func (c *MockBackendsClientSaveContentCall) Do(f func(context.Context, *secrets.URI, int, secrets.SecretValue) (secrets.ValueRef, error)) *MockBackendsClientSaveContentCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockBackendsClientSaveContentCall) DoAndReturn(f func(*secrets.URI, int, secrets.SecretValue) (secrets.ValueRef, error)) *MockBackendsClientSaveContentCall {
+func (c *MockBackendsClientSaveContentCall) DoAndReturn(f func(context.Context, *secrets.URI, int, secrets.SecretValue) (secrets.ValueRef, error)) *MockBackendsClientSaveContentCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/secretsdrainworker/mocks/secretsdrainworker_mock.go
+++ b/internal/worker/secretsdrainworker/mocks/secretsdrainworker_mock.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	secretsdrain "github.com/juju/juju/api/common/secretsdrain"
@@ -42,18 +43,18 @@ func (m *MockSecretsDrainFacade) EXPECT() *MockSecretsDrainFacadeMockRecorder {
 }
 
 // ChangeSecretBackend mocks base method.
-func (m *MockSecretsDrainFacade) ChangeSecretBackend(arg0 []secretsdrain.ChangeSecretBackendArg) (secretsdrain.ChangeSecretBackendResult, error) {
+func (m *MockSecretsDrainFacade) ChangeSecretBackend(arg0 context.Context, arg1 []secretsdrain.ChangeSecretBackendArg) (secretsdrain.ChangeSecretBackendResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ChangeSecretBackend", arg0)
+	ret := m.ctrl.Call(m, "ChangeSecretBackend", arg0, arg1)
 	ret0, _ := ret[0].(secretsdrain.ChangeSecretBackendResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ChangeSecretBackend indicates an expected call of ChangeSecretBackend.
-func (mr *MockSecretsDrainFacadeMockRecorder) ChangeSecretBackend(arg0 any) *MockSecretsDrainFacadeChangeSecretBackendCall {
+func (mr *MockSecretsDrainFacadeMockRecorder) ChangeSecretBackend(arg0, arg1 any) *MockSecretsDrainFacadeChangeSecretBackendCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChangeSecretBackend", reflect.TypeOf((*MockSecretsDrainFacade)(nil).ChangeSecretBackend), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChangeSecretBackend", reflect.TypeOf((*MockSecretsDrainFacade)(nil).ChangeSecretBackend), arg0, arg1)
 	return &MockSecretsDrainFacadeChangeSecretBackendCall{Call: call}
 }
 
@@ -69,30 +70,30 @@ func (c *MockSecretsDrainFacadeChangeSecretBackendCall) Return(arg0 secretsdrain
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSecretsDrainFacadeChangeSecretBackendCall) Do(f func([]secretsdrain.ChangeSecretBackendArg) (secretsdrain.ChangeSecretBackendResult, error)) *MockSecretsDrainFacadeChangeSecretBackendCall {
+func (c *MockSecretsDrainFacadeChangeSecretBackendCall) Do(f func(context.Context, []secretsdrain.ChangeSecretBackendArg) (secretsdrain.ChangeSecretBackendResult, error)) *MockSecretsDrainFacadeChangeSecretBackendCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSecretsDrainFacadeChangeSecretBackendCall) DoAndReturn(f func([]secretsdrain.ChangeSecretBackendArg) (secretsdrain.ChangeSecretBackendResult, error)) *MockSecretsDrainFacadeChangeSecretBackendCall {
+func (c *MockSecretsDrainFacadeChangeSecretBackendCall) DoAndReturn(f func(context.Context, []secretsdrain.ChangeSecretBackendArg) (secretsdrain.ChangeSecretBackendResult, error)) *MockSecretsDrainFacadeChangeSecretBackendCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetSecretsToDrain mocks base method.
-func (m *MockSecretsDrainFacade) GetSecretsToDrain() ([]secrets.SecretMetadataForDrain, error) {
+func (m *MockSecretsDrainFacade) GetSecretsToDrain(arg0 context.Context) ([]secrets.SecretMetadataForDrain, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetSecretsToDrain")
+	ret := m.ctrl.Call(m, "GetSecretsToDrain", arg0)
 	ret0, _ := ret[0].([]secrets.SecretMetadataForDrain)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetSecretsToDrain indicates an expected call of GetSecretsToDrain.
-func (mr *MockSecretsDrainFacadeMockRecorder) GetSecretsToDrain() *MockSecretsDrainFacadeGetSecretsToDrainCall {
+func (mr *MockSecretsDrainFacadeMockRecorder) GetSecretsToDrain(arg0 any) *MockSecretsDrainFacadeGetSecretsToDrainCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecretsToDrain", reflect.TypeOf((*MockSecretsDrainFacade)(nil).GetSecretsToDrain))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecretsToDrain", reflect.TypeOf((*MockSecretsDrainFacade)(nil).GetSecretsToDrain), arg0)
 	return &MockSecretsDrainFacadeGetSecretsToDrainCall{Call: call}
 }
 
@@ -108,30 +109,30 @@ func (c *MockSecretsDrainFacadeGetSecretsToDrainCall) Return(arg0 []secrets.Secr
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSecretsDrainFacadeGetSecretsToDrainCall) Do(f func() ([]secrets.SecretMetadataForDrain, error)) *MockSecretsDrainFacadeGetSecretsToDrainCall {
+func (c *MockSecretsDrainFacadeGetSecretsToDrainCall) Do(f func(context.Context) ([]secrets.SecretMetadataForDrain, error)) *MockSecretsDrainFacadeGetSecretsToDrainCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSecretsDrainFacadeGetSecretsToDrainCall) DoAndReturn(f func() ([]secrets.SecretMetadataForDrain, error)) *MockSecretsDrainFacadeGetSecretsToDrainCall {
+func (c *MockSecretsDrainFacadeGetSecretsToDrainCall) DoAndReturn(f func(context.Context) ([]secrets.SecretMetadataForDrain, error)) *MockSecretsDrainFacadeGetSecretsToDrainCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // WatchSecretBackendChanged mocks base method.
-func (m *MockSecretsDrainFacade) WatchSecretBackendChanged() (watcher.Watcher[struct{}], error) {
+func (m *MockSecretsDrainFacade) WatchSecretBackendChanged(arg0 context.Context) (watcher.Watcher[struct{}], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchSecretBackendChanged")
+	ret := m.ctrl.Call(m, "WatchSecretBackendChanged", arg0)
 	ret0, _ := ret[0].(watcher.Watcher[struct{}])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // WatchSecretBackendChanged indicates an expected call of WatchSecretBackendChanged.
-func (mr *MockSecretsDrainFacadeMockRecorder) WatchSecretBackendChanged() *MockSecretsDrainFacadeWatchSecretBackendChangedCall {
+func (mr *MockSecretsDrainFacadeMockRecorder) WatchSecretBackendChanged(arg0 any) *MockSecretsDrainFacadeWatchSecretBackendChangedCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchSecretBackendChanged", reflect.TypeOf((*MockSecretsDrainFacade)(nil).WatchSecretBackendChanged))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchSecretBackendChanged", reflect.TypeOf((*MockSecretsDrainFacade)(nil).WatchSecretBackendChanged), arg0)
 	return &MockSecretsDrainFacadeWatchSecretBackendChangedCall{Call: call}
 }
 
@@ -147,13 +148,13 @@ func (c *MockSecretsDrainFacadeWatchSecretBackendChangedCall) Return(arg0 watche
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSecretsDrainFacadeWatchSecretBackendChangedCall) Do(f func() (watcher.Watcher[struct{}], error)) *MockSecretsDrainFacadeWatchSecretBackendChangedCall {
+func (c *MockSecretsDrainFacadeWatchSecretBackendChangedCall) Do(f func(context.Context) (watcher.Watcher[struct{}], error)) *MockSecretsDrainFacadeWatchSecretBackendChangedCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSecretsDrainFacadeWatchSecretBackendChangedCall) DoAndReturn(f func() (watcher.Watcher[struct{}], error)) *MockSecretsDrainFacadeWatchSecretBackendChangedCall {
+func (c *MockSecretsDrainFacadeWatchSecretBackendChangedCall) DoAndReturn(f func(context.Context) (watcher.Watcher[struct{}], error)) *MockSecretsDrainFacadeWatchSecretBackendChangedCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/stateconverter/converter.go
+++ b/internal/worker/stateconverter/converter.go
@@ -73,9 +73,9 @@ func (c *converter) SetUp(ctx context.Context) (watcher.NotifyWatcher, error) {
 // Handle implements NotifyWatchHandler's Handle method.  If the change means
 // that the machine is now expected to manage the environment,
 // we throw a fatal error to instigate agent restart.
-func (c *converter) Handle(_ context.Context) error {
+func (c *converter) Handle(ctx context.Context) error {
 	c.logger.Tracef("Calling Handle for %s", c.machineTag)
-	results, err := c.machine.Jobs()
+	results, err := c.machine.Jobs(ctx)
 	if err != nil {
 		return errors.Annotate(err, "can't get jobs for machine")
 	}

--- a/internal/worker/stateconverter/converter_test.go
+++ b/internal/worker/stateconverter/converter_test.go
@@ -64,7 +64,7 @@ func (s *converterSuite) TestHandle(c *gc.C) {
 	s.machiner.EXPECT().Machine(gomock.Any(), gomock.Any()).Return(s.machine, nil)
 	s.machine.EXPECT().Watch(gomock.Any()).Return(nil, nil)
 	jobs := params.JobsResult{Jobs: []model.MachineJob{model.JobHostUnits, model.JobManageModel}}
-	s.machine.EXPECT().Jobs().Return(&jobs, nil)
+	s.machine.EXPECT().Jobs(gomock.Any()).Return(&jobs, nil)
 
 	conv := s.newConverter(c)
 	_, err := conv.SetUp(context.Background())
@@ -80,7 +80,7 @@ func (s *converterSuite) TestHandleNotController(c *gc.C) {
 	s.machiner.EXPECT().Machine(gomock.Any(), gomock.Any()).Return(s.machine, nil)
 	s.machine.EXPECT().Watch(gomock.Any()).Return(nil, nil)
 	jobs := params.JobsResult{Jobs: []model.MachineJob{model.JobHostUnits}}
-	s.machine.EXPECT().Jobs().Return(&jobs, nil)
+	s.machine.EXPECT().Jobs(gomock.Any()).Return(&jobs, nil)
 
 	conv := s.newConverter(c)
 	_, err := conv.SetUp(context.Background())
@@ -94,9 +94,9 @@ func (s *converterSuite) TestHandleJobsError(c *gc.C) {
 	s.machiner.EXPECT().Machine(gomock.Any(), gomock.Any()).Return(s.machine, nil).AnyTimes()
 	s.machine.EXPECT().Watch(gomock.Any()).Return(nil, nil).AnyTimes()
 	jobs := params.JobsResult{Jobs: []model.MachineJob{model.JobHostUnits, model.JobManageModel}}
-	s.machine.EXPECT().Jobs().Return(&jobs, nil)
+	s.machine.EXPECT().Jobs(gomock.Any()).Return(&jobs, nil)
 	expectedError := errors.New("foo")
-	s.machine.EXPECT().Jobs().Return(nil, expectedError)
+	s.machine.EXPECT().Jobs(gomock.Any()).Return(nil, expectedError)
 
 	conv := s.newConverter(c)
 	_, err := conv.SetUp(context.Background())

--- a/internal/worker/stateconverter/interfaces.go
+++ b/internal/worker/stateconverter/interfaces.go
@@ -21,6 +21,6 @@ type Machiner interface {
 // Machine represents necessary methods for this worker from the
 // a machiner's machine.
 type Machine interface {
-	Jobs() (*params.JobsResult, error)
+	Jobs(context.Context) (*params.JobsResult, error)
 	Watch(context.Context) (watcher.NotifyWatcher, error)
 }

--- a/internal/worker/stateconverter/mocks/machiner_mock.go
+++ b/internal/worker/stateconverter/mocks/machiner_mock.go
@@ -106,18 +106,18 @@ func (m *MockMachine) EXPECT() *MockMachineMockRecorder {
 }
 
 // Jobs mocks base method.
-func (m *MockMachine) Jobs() (*params.JobsResult, error) {
+func (m *MockMachine) Jobs(arg0 context.Context) (*params.JobsResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Jobs")
+	ret := m.ctrl.Call(m, "Jobs", arg0)
 	ret0, _ := ret[0].(*params.JobsResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Jobs indicates an expected call of Jobs.
-func (mr *MockMachineMockRecorder) Jobs() *MockMachineJobsCall {
+func (mr *MockMachineMockRecorder) Jobs(arg0 any) *MockMachineJobsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Jobs", reflect.TypeOf((*MockMachine)(nil).Jobs))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Jobs", reflect.TypeOf((*MockMachine)(nil).Jobs), arg0)
 	return &MockMachineJobsCall{Call: call}
 }
 
@@ -133,13 +133,13 @@ func (c *MockMachineJobsCall) Return(arg0 *params.JobsResult, arg1 error) *MockM
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineJobsCall) Do(f func() (*params.JobsResult, error)) *MockMachineJobsCall {
+func (c *MockMachineJobsCall) Do(f func(context.Context) (*params.JobsResult, error)) *MockMachineJobsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineJobsCall) DoAndReturn(f func() (*params.JobsResult, error)) *MockMachineJobsCall {
+func (c *MockMachineJobsCall) DoAndReturn(f func(context.Context) (*params.JobsResult, error)) *MockMachineJobsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/storageprovisioner/blockdevices.go
+++ b/internal/worker/storageprovisioner/blockdevices.go
@@ -4,6 +4,7 @@
 package storageprovisioner
 
 import (
+	"context"
 	stdcontext "context"
 
 	"github.com/juju/collections/set"
@@ -18,8 +19,8 @@ import (
 // machineBlockDevicesChanged is called when the block devices of the scoped
 // machine have been seen to have changed. This triggers a refresh of all
 // block devices for attached volumes backing pending filesystems.
-func machineBlockDevicesChanged(ctx *context) error {
-	volumeTags := make([]names.VolumeTag, 0, len(ctx.incompleteFilesystemParams))
+func machineBlockDevicesChanged(ctx context.Context, deps *dependencies) error {
+	volumeTags := make([]names.VolumeTag, 0, len(deps.incompleteFilesystemParams))
 	// We must query volumes for both incomplete filesystems
 	// and incomplete filesystem attachments, because even
 	// though a filesystem attachment cannot exist without a
@@ -27,19 +28,19 @@ func machineBlockDevicesChanged(ctx *context) error {
 	// in different sessions, and there is no guarantee that
 	// the block device will remain attached to the machine
 	// in between.
-	for _, params := range ctx.incompleteFilesystemParams {
+	for _, params := range deps.incompleteFilesystemParams {
 		if params.Volume == (names.VolumeTag{}) {
 			// Filesystem is not volume-backed.
 			continue
 		}
-		if _, ok := ctx.volumeBlockDevices[params.Volume]; ok {
+		if _, ok := deps.volumeBlockDevices[params.Volume]; ok {
 			// Backing-volume's block device is already attached.
 			continue
 		}
 		volumeTags = append(volumeTags, params.Volume)
 	}
-	for _, params := range ctx.incompleteFilesystemAttachmentParams {
-		filesystem, ok := ctx.filesystems[params.Filesystem]
+	for _, params := range deps.incompleteFilesystemAttachmentParams {
+		filesystem, ok := deps.filesystems[params.Filesystem]
 		if !ok {
 			continue
 		}
@@ -47,7 +48,7 @@ func machineBlockDevicesChanged(ctx *context) error {
 			// Filesystem is not volume-backed.
 			continue
 		}
-		if _, ok := ctx.volumeBlockDevices[filesystem.Volume]; ok {
+		if _, ok := deps.volumeBlockDevices[filesystem.Volume]; ok {
 			// Backing-volume's block device is already attached.
 			continue
 		}
@@ -64,9 +65,9 @@ func machineBlockDevicesChanged(ctx *context) error {
 	}
 	// Gather any already attached volume backed filesystem attachments
 	// so we can see if the UUID of the attachment has been newly set.
-	mountedAttachments := make([]storage.FilesystemAttachmentParams, 0, len(ctx.filesystemAttachments))
-	for _, attach := range ctx.filesystemAttachments {
-		filesystem, ok := ctx.filesystems[attach.Filesystem]
+	mountedAttachments := make([]storage.FilesystemAttachmentParams, 0, len(deps.filesystemAttachments))
+	for _, attach := range deps.filesystemAttachments {
+		filesystem, ok := deps.filesystems[attach.Filesystem]
 		if !ok {
 			continue
 		}
@@ -74,7 +75,7 @@ func machineBlockDevicesChanged(ctx *context) error {
 			// Filesystem is not volume-backed.
 			continue
 		}
-		if _, ok := ctx.volumeBlockDevices[filesystem.Volume]; !ok {
+		if _, ok := deps.volumeBlockDevices[filesystem.Volume]; !ok {
 			continue
 		}
 		mountedAttachments = append(mountedAttachments, storage.FilesystemAttachmentParams{
@@ -98,7 +99,7 @@ func machineBlockDevicesChanged(ctx *context) error {
 	if len(volumeTags) == 0 {
 		return nil
 	}
-	updatedVolumes, err := refreshVolumeBlockDevices(ctx, volumeTags)
+	updatedVolumes, err := refreshVolumeBlockDevices(ctx, deps, volumeTags)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -112,7 +113,7 @@ func machineBlockDevicesChanged(ctx *context) error {
 	}
 	var toUpdate []storage.FilesystemAttachmentParams
 	for _, a := range mountedAttachments {
-		filesystem, ok := ctx.filesystems[a.Filesystem]
+		filesystem, ok := deps.filesystems[a.Filesystem]
 		if !ok {
 			continue
 		}
@@ -123,37 +124,37 @@ func machineBlockDevicesChanged(ctx *context) error {
 	if len(toUpdate) == 0 {
 		return nil
 	}
-	ctx.config.Logger.Debugf("refreshing mounted filesystems: %#v", toUpdate)
-	_, err = ctx.managedFilesystemSource.AttachFilesystems(ctx.config.CloudCallContextFunc(stdcontext.Background()), toUpdate)
+	deps.config.Logger.Debugf("refreshing mounted filesystems: %#v", toUpdate)
+	_, err = deps.managedFilesystemSource.AttachFilesystems(deps.config.CloudCallContextFunc(stdcontext.Background()), toUpdate)
 	return err
 }
 
 // processPendingVolumeBlockDevices is called before waiting for any events,
 // to force a block-device query for any volumes for which we have not
 // previously observed block devices.
-func processPendingVolumeBlockDevices(ctx *context) error {
-	if len(ctx.pendingVolumeBlockDevices) == 0 {
-		ctx.config.Logger.Tracef("no pending volume block devices")
+func processPendingVolumeBlockDevices(ctx context.Context, deps *dependencies) error {
+	if len(deps.pendingVolumeBlockDevices) == 0 {
+		deps.config.Logger.Tracef("no pending volume block devices")
 		return nil
 	}
-	volumeTags := make([]names.VolumeTag, len(ctx.pendingVolumeBlockDevices))
-	for i, tag := range ctx.pendingVolumeBlockDevices.SortedValues() {
+	volumeTags := make([]names.VolumeTag, len(deps.pendingVolumeBlockDevices))
+	for i, tag := range deps.pendingVolumeBlockDevices.SortedValues() {
 		volumeTags[i] = tag.(names.VolumeTag)
 	}
 	// Clear out the pending set, so we don't force-refresh again.
-	ctx.pendingVolumeBlockDevices = names.NewSet()
-	_, err := refreshVolumeBlockDevices(ctx, volumeTags)
+	deps.pendingVolumeBlockDevices = names.NewSet()
+	_, err := refreshVolumeBlockDevices(ctx, deps, volumeTags)
 	return err
 }
 
 // refreshVolumeBlockDevices refreshes the block devices for the specified volumes.
 // It returns any volumes which have had the UUID newly set.
-func refreshVolumeBlockDevices(ctx *context, volumeTags []names.VolumeTag) ([]names.VolumeTag, error) {
-	machineTag, ok := ctx.config.Scope.(names.MachineTag)
+func refreshVolumeBlockDevices(ctx context.Context, deps *dependencies, volumeTags []names.VolumeTag) ([]names.VolumeTag, error) {
+	machineTag, ok := deps.config.Scope.(names.MachineTag)
 	if !ok {
 		// This function should only be called by machine-scoped
 		// storage provisioners.
-		ctx.config.Logger.Warningf("refresh block devices, expected machine tag, got %v", ctx.config.Scope)
+		deps.config.Logger.Warningf("refresh block devices, expected machine tag, got %v", deps.config.Scope)
 		return nil, nil
 	}
 	ids := make([]params.MachineStorageId, len(volumeTags))
@@ -164,29 +165,29 @@ func refreshVolumeBlockDevices(ctx *context, volumeTags []names.VolumeTag) ([]na
 		}
 	}
 	var volumesWithUpdatedUUID []names.VolumeTag
-	results, err := ctx.config.Volumes.VolumeBlockDevices(ids)
+	results, err := deps.config.Volumes.VolumeBlockDevices(ctx, ids)
 	if err != nil {
 		return nil, errors.Annotate(err, "refreshing volume block devices")
 	}
 	for i, result := range results {
 		if result.Error == nil {
-			existing, ok := ctx.volumeBlockDevices[volumeTags[i]]
+			existing, ok := deps.volumeBlockDevices[volumeTags[i]]
 			if ok && existing.UUID == "" && result.Result.UUID != "" {
 				volumesWithUpdatedUUID = append(volumesWithUpdatedUUID, volumeTags[i])
 			}
-			ctx.volumeBlockDevices[volumeTags[i]] = blockDeviceFromParams(result.Result)
-			for _, params := range ctx.incompleteFilesystemParams {
+			deps.volumeBlockDevices[volumeTags[i]] = blockDeviceFromParams(result.Result)
+			for _, params := range deps.incompleteFilesystemParams {
 				if params.Volume == volumeTags[i] {
-					updatePendingFilesystem(ctx, params)
+					updatePendingFilesystem(deps, params)
 				}
 			}
-			for id, params := range ctx.incompleteFilesystemAttachmentParams {
-				filesystem, ok := ctx.filesystems[params.Filesystem]
+			for id, params := range deps.incompleteFilesystemAttachmentParams {
+				filesystem, ok := deps.filesystems[params.Filesystem]
 				if !ok {
 					continue
 				}
 				if filesystem.Volume == volumeTags[i] {
-					updatePendingFilesystemAttachment(ctx, id, params)
+					updatePendingFilesystemAttachment(deps, id, params)
 				}
 			}
 		} else if params.IsCodeNotProvisioned(result.Error) || params.IsCodeNotFound(result.Error) {

--- a/internal/worker/storageprovisioner/mock_test.go
+++ b/internal/worker/storageprovisioner/mock_test.go
@@ -4,6 +4,7 @@
 package storageprovisioner_test
 
 import (
+	"context"
 	"time"
 
 	"github.com/juju/clock"
@@ -95,7 +96,7 @@ type mockApplicationsWatcher struct {
 	watcher *watchertest.MockStringsWatcher
 }
 
-func (w *mockApplicationsWatcher) WatchApplications() (watcher.StringsWatcher, error) {
+func (w *mockApplicationsWatcher) WatchApplications(_ context.Context) (watcher.StringsWatcher, error) {
 	return w.watcher, nil
 }
 
@@ -161,23 +162,23 @@ func (m *mockVolumeAccessor) provisionVolume(tag names.VolumeTag) params.Volume 
 	return v
 }
 
-func (w *mockVolumeAccessor) WatchVolumes(names.Tag) (watcher.StringsWatcher, error) {
+func (w *mockVolumeAccessor) WatchVolumes(context.Context, names.Tag) (watcher.StringsWatcher, error) {
 	return w.volumesWatcher, nil
 }
 
-func (w *mockVolumeAccessor) WatchVolumeAttachments(names.Tag) (watcher.MachineStorageIDsWatcher, error) {
+func (w *mockVolumeAccessor) WatchVolumeAttachments(context.Context, names.Tag) (watcher.MachineStorageIDsWatcher, error) {
 	return w.attachmentsWatcher, nil
 }
 
-func (w *mockVolumeAccessor) WatchBlockDevices(tag names.MachineTag) (watcher.NotifyWatcher, error) {
+func (w *mockVolumeAccessor) WatchBlockDevices(_ context.Context, tag names.MachineTag) (watcher.NotifyWatcher, error) {
 	return w.blockDevicesWatcher, nil
 }
 
-func (w *mockVolumeAccessor) WatchVolumeAttachmentPlans(names.Tag) (watcher.MachineStorageIDsWatcher, error) {
+func (w *mockVolumeAccessor) WatchVolumeAttachmentPlans(context.Context, names.Tag) (watcher.MachineStorageIDsWatcher, error) {
 	return w.attachmentPlansWatcher, nil
 }
 
-func (v *mockVolumeAccessor) Volumes(volumes []names.VolumeTag) ([]params.VolumeResult, error) {
+func (v *mockVolumeAccessor) Volumes(_ context.Context, volumes []names.VolumeTag) ([]params.VolumeResult, error) {
 	var result []params.VolumeResult
 	for _, tag := range volumes {
 		if vol, ok := v.provisionedVolumes[tag.String()]; ok {
@@ -191,7 +192,7 @@ func (v *mockVolumeAccessor) Volumes(volumes []names.VolumeTag) ([]params.Volume
 	return result, nil
 }
 
-func (v *mockVolumeAccessor) VolumeAttachments(ids []params.MachineStorageId) ([]params.VolumeAttachmentResult, error) {
+func (v *mockVolumeAccessor) VolumeAttachments(_ context.Context, ids []params.MachineStorageId) ([]params.VolumeAttachmentResult, error) {
 	var result []params.VolumeAttachmentResult
 	for _, id := range ids {
 		if att, ok := v.provisionedAttachments[id]; ok {
@@ -205,7 +206,7 @@ func (v *mockVolumeAccessor) VolumeAttachments(ids []params.MachineStorageId) ([
 	return result, nil
 }
 
-func (v *mockVolumeAccessor) VolumeBlockDevices(ids []params.MachineStorageId) ([]params.BlockDeviceResult, error) {
+func (v *mockVolumeAccessor) VolumeBlockDevices(_ context.Context, ids []params.MachineStorageId) ([]params.BlockDeviceResult, error) {
 	var result []params.BlockDeviceResult
 	for _, id := range ids {
 		if dev, ok := v.blockDevices[id]; ok {
@@ -219,7 +220,7 @@ func (v *mockVolumeAccessor) VolumeBlockDevices(ids []params.MachineStorageId) (
 	return result, nil
 }
 
-func (v *mockVolumeAccessor) VolumeParams(volumes []names.VolumeTag) ([]params.VolumeParamsResult, error) {
+func (v *mockVolumeAccessor) VolumeParams(_ context.Context, volumes []names.VolumeTag) ([]params.VolumeParamsResult, error) {
 	var result []params.VolumeParamsResult
 	for _, tag := range volumes {
 		volumeParams := params.VolumeParams{
@@ -247,7 +248,7 @@ func (v *mockVolumeAccessor) VolumeParams(volumes []names.VolumeTag) ([]params.V
 	return result, nil
 }
 
-func (v *mockVolumeAccessor) RemoveVolumeParams(volumes []names.VolumeTag) ([]params.RemoveVolumeParamsResult, error) {
+func (v *mockVolumeAccessor) RemoveVolumeParams(_ context.Context, volumes []names.VolumeTag) ([]params.RemoveVolumeParamsResult, error) {
 	var result []params.RemoveVolumeParamsResult
 	for _, tag := range volumes {
 		v, ok := v.provisionedVolumes[tag.String()]
@@ -267,7 +268,7 @@ func (v *mockVolumeAccessor) RemoveVolumeParams(volumes []names.VolumeTag) ([]pa
 	return result, nil
 }
 
-func (v *mockVolumeAccessor) VolumeAttachmentParams(ids []params.MachineStorageId) ([]params.VolumeAttachmentParamsResult, error) {
+func (v *mockVolumeAccessor) VolumeAttachmentParams(_ context.Context, ids []params.MachineStorageId) ([]params.VolumeAttachmentParamsResult, error) {
 	var result []params.VolumeAttachmentParamsResult
 	for _, id := range ids {
 		// Parameters are returned regardless of whether the attachment
@@ -284,36 +285,36 @@ func (v *mockVolumeAccessor) VolumeAttachmentParams(ids []params.MachineStorageI
 	return result, nil
 }
 
-func (v *mockVolumeAccessor) SetVolumeInfo(volumes []params.Volume) ([]params.ErrorResult, error) {
+func (v *mockVolumeAccessor) SetVolumeInfo(_ context.Context, volumes []params.Volume) ([]params.ErrorResult, error) {
 	if v.setVolumeInfo != nil {
 		return v.setVolumeInfo(volumes)
 	}
 	return make([]params.ErrorResult, len(volumes)), nil
 }
 
-func (v *mockVolumeAccessor) SetVolumeAttachmentInfo(volumeAttachments []params.VolumeAttachment) ([]params.ErrorResult, error) {
+func (v *mockVolumeAccessor) SetVolumeAttachmentInfo(_ context.Context, volumeAttachments []params.VolumeAttachment) ([]params.ErrorResult, error) {
 	if v.setVolumeAttachmentInfo != nil {
 		return v.setVolumeAttachmentInfo(volumeAttachments)
 	}
 	return make([]params.ErrorResult, len(volumeAttachments)), nil
 }
 
-func (v *mockVolumeAccessor) CreateVolumeAttachmentPlans(volumeAttachmentPlans []params.VolumeAttachmentPlan) ([]params.ErrorResult, error) {
+func (v *mockVolumeAccessor) CreateVolumeAttachmentPlans(_ context.Context, volumeAttachmentPlans []params.VolumeAttachmentPlan) ([]params.ErrorResult, error) {
 	if v.createVolumeAttachmentPlans != nil {
 		return v.createVolumeAttachmentPlans(volumeAttachmentPlans)
 	}
 	return make([]params.ErrorResult, len(volumeAttachmentPlans)), nil
 }
 
-func (v *mockVolumeAccessor) RemoveVolumeAttachmentPlan(machineIds []params.MachineStorageId) ([]params.ErrorResult, error) {
+func (v *mockVolumeAccessor) RemoveVolumeAttachmentPlan(_ context.Context, machineIds []params.MachineStorageId) ([]params.ErrorResult, error) {
 	return make([]params.ErrorResult, len(machineIds)), nil
 }
 
-func (v *mockVolumeAccessor) SetVolumeAttachmentPlanBlockInfo(volumeAttachmentPlans []params.VolumeAttachmentPlan) ([]params.ErrorResult, error) {
+func (v *mockVolumeAccessor) SetVolumeAttachmentPlanBlockInfo(_ context.Context, volumeAttachmentPlans []params.VolumeAttachmentPlan) ([]params.ErrorResult, error) {
 	return make([]params.ErrorResult, len(volumeAttachmentPlans)), nil
 }
 
-func (v *mockVolumeAccessor) VolumeAttachmentPlans([]params.MachineStorageId) ([]params.VolumeAttachmentPlanResult, error) {
+func (v *mockVolumeAccessor) VolumeAttachmentPlans(context.Context, []params.MachineStorageId) ([]params.VolumeAttachmentPlanResult, error) {
 	return []params.VolumeAttachmentPlanResult{}, nil
 }
 
@@ -354,16 +355,16 @@ func (m *mockFilesystemAccessor) provisionFilesystem(tag names.FilesystemTag) pa
 	return f
 }
 
-func (w *mockFilesystemAccessor) WatchFilesystems(tag names.Tag) (watcher.StringsWatcher, error) {
+func (w *mockFilesystemAccessor) WatchFilesystems(_ context.Context, tag names.Tag) (watcher.StringsWatcher, error) {
 	w.AddCall("WatchFilesystems", tag)
 	return w.filesystemsWatcher, nil
 }
 
-func (w *mockFilesystemAccessor) WatchFilesystemAttachments(names.Tag) (watcher.MachineStorageIDsWatcher, error) {
+func (w *mockFilesystemAccessor) WatchFilesystemAttachments(context.Context, names.Tag) (watcher.MachineStorageIDsWatcher, error) {
 	return w.attachmentsWatcher, nil
 }
 
-func (v *mockFilesystemAccessor) Filesystems(filesystems []names.FilesystemTag) ([]params.FilesystemResult, error) {
+func (v *mockFilesystemAccessor) Filesystems(_ context.Context, filesystems []names.FilesystemTag) ([]params.FilesystemResult, error) {
 	var result []params.FilesystemResult
 	for _, tag := range filesystems {
 		if vol, ok := v.provisionedFilesystems[tag.String()]; ok {
@@ -377,7 +378,7 @@ func (v *mockFilesystemAccessor) Filesystems(filesystems []names.FilesystemTag) 
 	return result, nil
 }
 
-func (v *mockFilesystemAccessor) FilesystemAttachments(ids []params.MachineStorageId) ([]params.FilesystemAttachmentResult, error) {
+func (v *mockFilesystemAccessor) FilesystemAttachments(_ context.Context, ids []params.MachineStorageId) ([]params.FilesystemAttachmentResult, error) {
 	var result []params.FilesystemAttachmentResult
 	for _, id := range ids {
 		if att, ok := v.provisionedAttachments[id]; ok {
@@ -391,7 +392,7 @@ func (v *mockFilesystemAccessor) FilesystemAttachments(ids []params.MachineStora
 	return result, nil
 }
 
-func (v *mockFilesystemAccessor) FilesystemParams(filesystems []names.FilesystemTag) ([]params.FilesystemParamsResult, error) {
+func (v *mockFilesystemAccessor) FilesystemParams(_ context.Context, filesystems []names.FilesystemTag) ([]params.FilesystemParamsResult, error) {
 	results := make([]params.FilesystemParamsResult, len(filesystems))
 	for i, tag := range filesystems {
 		filesystemParams := params.FilesystemParams{
@@ -412,7 +413,7 @@ func (v *mockFilesystemAccessor) FilesystemParams(filesystems []names.Filesystem
 	return results, nil
 }
 
-func (v *mockFilesystemAccessor) RemoveFilesystemParams(filesystems []names.FilesystemTag) ([]params.RemoveFilesystemParamsResult, error) {
+func (v *mockFilesystemAccessor) RemoveFilesystemParams(_ context.Context, filesystems []names.FilesystemTag) ([]params.RemoveFilesystemParamsResult, error) {
 	results := make([]params.RemoveFilesystemParamsResult, len(filesystems))
 	for i, tag := range filesystems {
 		f, ok := v.provisionedFilesystems[tag.String()]
@@ -432,7 +433,7 @@ func (v *mockFilesystemAccessor) RemoveFilesystemParams(filesystems []names.File
 	return results, nil
 }
 
-func (f *mockFilesystemAccessor) FilesystemAttachmentParams(ids []params.MachineStorageId) ([]params.FilesystemAttachmentParamsResult, error) {
+func (f *mockFilesystemAccessor) FilesystemAttachmentParams(_ context.Context, ids []params.MachineStorageId) ([]params.FilesystemAttachmentParamsResult, error) {
 	var result []params.FilesystemAttachmentParamsResult
 	for _, id := range ids {
 		// Parameters are returned regardless of whether the attachment
@@ -451,14 +452,14 @@ func (f *mockFilesystemAccessor) FilesystemAttachmentParams(ids []params.Machine
 	return result, nil
 }
 
-func (f *mockFilesystemAccessor) SetFilesystemInfo(filesystems []params.Filesystem) ([]params.ErrorResult, error) {
+func (f *mockFilesystemAccessor) SetFilesystemInfo(_ context.Context, filesystems []params.Filesystem) ([]params.ErrorResult, error) {
 	if f.setFilesystemInfo != nil {
 		return f.setFilesystemInfo(filesystems)
 	}
 	return make([]params.ErrorResult, len(filesystems)), nil
 }
 
-func (f *mockFilesystemAccessor) SetFilesystemAttachmentInfo(filesystemAttachments []params.FilesystemAttachment) ([]params.ErrorResult, error) {
+func (f *mockFilesystemAccessor) SetFilesystemAttachmentInfo(_ context.Context, filesystemAttachments []params.FilesystemAttachment) ([]params.ErrorResult, error) {
 	if f.setFilesystemAttachmentInfo != nil {
 		return f.setFilesystemAttachmentInfo(filesystemAttachments)
 	}
@@ -484,7 +485,7 @@ type mockLifecycleManager struct {
 	remove            func([]names.Tag) ([]params.ErrorResult, error)
 }
 
-func (m *mockLifecycleManager) Life(tags []names.Tag) ([]params.LifeResult, error) {
+func (m *mockLifecycleManager) Life(ctx context.Context, tags []names.Tag) ([]params.LifeResult, error) {
 	if m.life != nil {
 		return m.life(tags)
 	}
@@ -507,7 +508,7 @@ func (m *mockLifecycleManager) Life(tags []names.Tag) ([]params.LifeResult, erro
 	return result, nil
 }
 
-func (m *mockLifecycleManager) AttachmentLife(ids []params.MachineStorageId) ([]params.LifeResult, error) {
+func (m *mockLifecycleManager) AttachmentLife(_ context.Context, ids []params.MachineStorageId) ([]params.LifeResult, error) {
 	if m.attachmentLife != nil {
 		return m.attachmentLife(ids)
 	}
@@ -528,14 +529,14 @@ func (m *mockLifecycleManager) AttachmentLife(ids []params.MachineStorageId) ([]
 	return result, nil
 }
 
-func (m *mockLifecycleManager) Remove(tags []names.Tag) ([]params.ErrorResult, error) {
+func (m *mockLifecycleManager) Remove(_ context.Context, tags []names.Tag) ([]params.ErrorResult, error) {
 	if m.remove != nil {
 		return m.remove(tags)
 	}
 	return make([]params.ErrorResult, len(tags)), nil
 }
 
-func (m *mockLifecycleManager) RemoveAttachments(ids []params.MachineStorageId) ([]params.ErrorResult, error) {
+func (m *mockLifecycleManager) RemoveAttachments(_ context.Context, ids []params.MachineStorageId) ([]params.ErrorResult, error) {
 	if m.removeAttachments != nil {
 		return m.removeAttachments(ids)
 	}
@@ -614,8 +615,8 @@ func (s *dummyVolumeSource) CreateVolumes(ctx envcontext.ProviderCallContext, pa
 	for i, p := range params {
 		persistent, _ := p.Attributes["persistent"].(bool)
 		results[i].Volume = &storage.Volume{
-			p.Tag,
-			storage.VolumeInfo{
+			Tag: p.Tag,
+			VolumeInfo: storage.VolumeInfo{
 				Size:       p.Size,
 				HardwareId: "serial-" + p.Tag.Id(),
 				VolumeId:   "id-" + p.Tag.Id(),
@@ -657,9 +658,9 @@ func (s *dummyVolumeSource) AttachVolumes(ctx envcontext.ProviderCallContext, pa
 			panic("AttachVolumes called with unprovisioned machine")
 		}
 		results[i].VolumeAttachment = &storage.VolumeAttachment{
-			p.Volume,
-			p.Machine,
-			storage.VolumeAttachmentInfo{
+			Volume:  p.Volume,
+			Machine: p.Machine,
+			VolumeAttachmentInfo: storage.VolumeAttachmentInfo{
 				DeviceName: "/dev/sda" + p.Volume.Id(),
 				ReadOnly:   p.ReadOnly,
 			},
@@ -737,9 +738,9 @@ func (s *dummyFilesystemSource) AttachFilesystems(ctx envcontext.ProviderCallCon
 			panic("AttachFilesystems called with unprovisioned machine")
 		}
 		results[i].FilesystemAttachment = &storage.FilesystemAttachment{
-			p.Filesystem,
-			p.Machine,
-			storage.FilesystemAttachmentInfo{
+			Filesystem: p.Filesystem,
+			Machine:    p.Machine,
+			FilesystemAttachmentInfo: storage.FilesystemAttachmentInfo{
 				Path: "/srv/" + p.FilesystemId,
 			},
 		}
@@ -806,9 +807,9 @@ func (s *mockManagedFilesystemSource) AttachFilesystems(ctx envcontext.ProviderC
 			continue
 		}
 		results[i].FilesystemAttachment = &storage.FilesystemAttachment{
-			arg.Filesystem,
-			arg.Machine,
-			storage.FilesystemAttachmentInfo{
+			Filesystem: arg.Filesystem,
+			Machine:    arg.Machine,
+			FilesystemAttachmentInfo: storage.FilesystemAttachmentInfo{
 				Path:     "/mnt/" + blockDevice.DeviceName,
 				ReadOnly: arg.ReadOnly,
 			},
@@ -829,11 +830,11 @@ type mockMachineAccessor struct {
 	watcher     *mockNotifyWatcher
 }
 
-func (a *mockMachineAccessor) WatchMachine(names.MachineTag) (watcher.NotifyWatcher, error) {
+func (a *mockMachineAccessor) WatchMachine(context.Context, names.MachineTag) (watcher.NotifyWatcher, error) {
 	return a.watcher, nil
 }
 
-func (a *mockMachineAccessor) InstanceIds(tags []names.MachineTag) ([]params.StringResult, error) {
+func (a *mockMachineAccessor) InstanceIds(_ context.Context, tags []names.MachineTag) ([]params.StringResult, error) {
 	results := make([]params.StringResult, len(tags))
 	for i, tag := range tags {
 		instanceId, ok := a.instanceIds[tag]
@@ -913,7 +914,7 @@ type mockStatusSetter struct {
 	setStatus func([]params.EntityStatusArgs) error
 }
 
-func (m *mockStatusSetter) SetStatus(args []params.EntityStatusArgs) error {
+func (m *mockStatusSetter) SetStatus(ctx context.Context, args []params.EntityStatusArgs) error {
 	if m.setStatus != nil {
 		return m.setStatus(args)
 	}

--- a/internal/worker/storageprovisioner/schedule.go
+++ b/internal/worker/storageprovisioner/schedule.go
@@ -21,15 +21,15 @@ const maxRetryDelay = 30 * time.Minute
 // calculating the current time once, we guarantee
 // that operations with the same delay will be
 // batched together.
-func scheduleOperations(ctx *context, ops ...scheduleOp) {
+func scheduleOperations(deps *dependencies, ops ...scheduleOp) {
 	if len(ops) == 0 {
 		return
 	}
-	now := ctx.config.Clock.Now()
+	now := deps.config.Clock.Now()
 	for _, op := range ops {
 		k := op.key()
 		d := op.delay()
-		ctx.schedule.Add(k, op, now.Add(d))
+		deps.schedule.Add(k, op, now.Add(d))
 	}
 }
 

--- a/internal/worker/storageprovisioner/storageprovisioner.go
+++ b/internal/worker/storageprovisioner/storageprovisioner.go
@@ -4,6 +4,8 @@
 package storageprovisioner
 
 import (
+	"context"
+	stdcontext "context"
 	"time"
 
 	"github.com/juju/errors"
@@ -33,56 +35,56 @@ var newManagedFilesystemSource = provider.NewManagedFilesystemSource
 type VolumeAccessor interface {
 	// WatchBlockDevices watches for changes to the block devices of the
 	// specified machine.
-	WatchBlockDevices(names.MachineTag) (watcher.NotifyWatcher, error)
+	WatchBlockDevices(stdcontext.Context, names.MachineTag) (watcher.NotifyWatcher, error)
 
 	// WatchVolumes watches for changes to volumes that this storage
 	// provisioner is responsible for.
-	WatchVolumes(scope names.Tag) (watcher.StringsWatcher, error)
+	WatchVolumes(ctx stdcontext.Context, scope names.Tag) (watcher.StringsWatcher, error)
 
 	// WatchVolumeAttachments watches for changes to volume attachments
 	// that this storage provisioner is responsible for.
-	WatchVolumeAttachments(scope names.Tag) (watcher.MachineStorageIDsWatcher, error)
+	WatchVolumeAttachments(ctx stdcontext.Context, scope names.Tag) (watcher.MachineStorageIDsWatcher, error)
 
 	// WatchVolumeAttachmentPlans watches for changes to volume attachments
 	// destined for this machine. It allows the machine agent to do any extra
 	// initialization of the attachment, such as logging into the iSCSI target
-	WatchVolumeAttachmentPlans(scope names.Tag) (watcher.MachineStorageIDsWatcher, error)
+	WatchVolumeAttachmentPlans(ctx stdcontext.Context, scope names.Tag) (watcher.MachineStorageIDsWatcher, error)
 
 	// Volumes returns details of volumes with the specified tags.
-	Volumes([]names.VolumeTag) ([]params.VolumeResult, error)
+	Volumes(stdcontext.Context, []names.VolumeTag) ([]params.VolumeResult, error)
 
 	// VolumeBlockDevices returns details of block devices corresponding to
 	// the specified volume attachment IDs.
-	VolumeBlockDevices([]params.MachineStorageId) ([]params.BlockDeviceResult, error)
+	VolumeBlockDevices(stdcontext.Context, []params.MachineStorageId) ([]params.BlockDeviceResult, error)
 
 	// VolumeAttachments returns details of volume attachments with
 	// the specified tags.
-	VolumeAttachments([]params.MachineStorageId) ([]params.VolumeAttachmentResult, error)
+	VolumeAttachments(stdcontext.Context, []params.MachineStorageId) ([]params.VolumeAttachmentResult, error)
 
-	VolumeAttachmentPlans([]params.MachineStorageId) ([]params.VolumeAttachmentPlanResult, error)
+	VolumeAttachmentPlans(stdcontext.Context, []params.MachineStorageId) ([]params.VolumeAttachmentPlanResult, error)
 
 	// VolumeParams returns the parameters for creating the volumes
 	// with the specified tags.
-	VolumeParams([]names.VolumeTag) ([]params.VolumeParamsResult, error)
+	VolumeParams(stdcontext.Context, []names.VolumeTag) ([]params.VolumeParamsResult, error)
 
 	// RemoveVolumeParams returns the parameters for destroying or
 	// releasing the volumes with the specified tags.
-	RemoveVolumeParams([]names.VolumeTag) ([]params.RemoveVolumeParamsResult, error)
+	RemoveVolumeParams(stdcontext.Context, []names.VolumeTag) ([]params.RemoveVolumeParamsResult, error)
 
 	// VolumeAttachmentParams returns the parameters for creating the
 	// volume attachments with the specified tags.
-	VolumeAttachmentParams([]params.MachineStorageId) ([]params.VolumeAttachmentParamsResult, error)
+	VolumeAttachmentParams(stdcontext.Context, []params.MachineStorageId) ([]params.VolumeAttachmentParamsResult, error)
 
 	// SetVolumeInfo records the details of newly provisioned volumes.
-	SetVolumeInfo([]params.Volume) ([]params.ErrorResult, error)
+	SetVolumeInfo(stdcontext.Context, []params.Volume) ([]params.ErrorResult, error)
 
 	// SetVolumeAttachmentInfo records the details of newly provisioned
 	// volume attachments.
-	SetVolumeAttachmentInfo([]params.VolumeAttachment) ([]params.ErrorResult, error)
+	SetVolumeAttachmentInfo(stdcontext.Context, []params.VolumeAttachment) ([]params.ErrorResult, error)
 
-	CreateVolumeAttachmentPlans(volumeAttachmentPlans []params.VolumeAttachmentPlan) ([]params.ErrorResult, error)
-	RemoveVolumeAttachmentPlan([]params.MachineStorageId) ([]params.ErrorResult, error)
-	SetVolumeAttachmentPlanBlockInfo(volumeAttachmentPlans []params.VolumeAttachmentPlan) ([]params.ErrorResult, error)
+	CreateVolumeAttachmentPlans(ctx stdcontext.Context, volumeAttachmentPlans []params.VolumeAttachmentPlan) ([]params.ErrorResult, error)
+	RemoveVolumeAttachmentPlan(stdcontext.Context, []params.MachineStorageId) ([]params.ErrorResult, error)
+	SetVolumeAttachmentPlanBlockInfo(ctx stdcontext.Context, volumeAttachmentPlans []params.VolumeAttachmentPlan) ([]params.ErrorResult, error)
 }
 
 // FilesystemAccessor defines an interface used to allow a storage provisioner
@@ -90,47 +92,47 @@ type VolumeAccessor interface {
 type FilesystemAccessor interface {
 	// WatchFilesystems watches for changes to filesystems that this
 	// storage provisioner is responsible for.
-	WatchFilesystems(scope names.Tag) (watcher.StringsWatcher, error)
+	WatchFilesystems(ctx stdcontext.Context, scope names.Tag) (watcher.StringsWatcher, error)
 
 	// WatchFilesystemAttachments watches for changes to filesystem attachments
 	// that this storage provisioner is responsible for.
-	WatchFilesystemAttachments(scope names.Tag) (watcher.MachineStorageIDsWatcher, error)
+	WatchFilesystemAttachments(ctx stdcontext.Context, scope names.Tag) (watcher.MachineStorageIDsWatcher, error)
 
 	// Filesystems returns details of filesystems with the specified tags.
-	Filesystems([]names.FilesystemTag) ([]params.FilesystemResult, error)
+	Filesystems(stdcontext.Context, []names.FilesystemTag) ([]params.FilesystemResult, error)
 
 	// FilesystemAttachments returns details of filesystem attachments with
 	// the specified tags.
-	FilesystemAttachments([]params.MachineStorageId) ([]params.FilesystemAttachmentResult, error)
+	FilesystemAttachments(stdcontext.Context, []params.MachineStorageId) ([]params.FilesystemAttachmentResult, error)
 
 	// FilesystemParams returns the parameters for creating the filesystems
 	// with the specified tags.
-	FilesystemParams([]names.FilesystemTag) ([]params.FilesystemParamsResult, error)
+	FilesystemParams(stdcontext.Context, []names.FilesystemTag) ([]params.FilesystemParamsResult, error)
 
 	// RemoveFilesystemParams returns the parameters for destroying or
 	// releasing the filesystems with the specified tags.
-	RemoveFilesystemParams([]names.FilesystemTag) ([]params.RemoveFilesystemParamsResult, error)
+	RemoveFilesystemParams(stdcontext.Context, []names.FilesystemTag) ([]params.RemoveFilesystemParamsResult, error)
 
 	// FilesystemAttachmentParams returns the parameters for creating the
 	// filesystem attachments with the specified tags.
-	FilesystemAttachmentParams([]params.MachineStorageId) ([]params.FilesystemAttachmentParamsResult, error)
+	FilesystemAttachmentParams(stdcontext.Context, []params.MachineStorageId) ([]params.FilesystemAttachmentParamsResult, error)
 
 	// SetFilesystemInfo records the details of newly provisioned filesystems.
-	SetFilesystemInfo([]params.Filesystem) ([]params.ErrorResult, error)
+	SetFilesystemInfo(stdcontext.Context, []params.Filesystem) ([]params.ErrorResult, error)
 
 	// SetFilesystemAttachmentInfo records the details of newly provisioned
 	// filesystem attachments.
-	SetFilesystemAttachmentInfo([]params.FilesystemAttachment) ([]params.ErrorResult, error)
+	SetFilesystemAttachmentInfo(stdcontext.Context, []params.FilesystemAttachment) ([]params.ErrorResult, error)
 }
 
 // MachineAccessor defines an interface used to allow a storage provisioner
 // worker to perform machine related operations.
 type MachineAccessor interface {
 	// WatchMachine watches for changes to the specified machine.
-	WatchMachine(names.MachineTag) (watcher.NotifyWatcher, error)
+	WatchMachine(stdcontext.Context, names.MachineTag) (watcher.NotifyWatcher, error)
 
 	// InstanceIds returns the instance IDs of each machine.
-	InstanceIds([]names.MachineTag) ([]params.StringResult, error)
+	InstanceIds(stdcontext.Context, []names.MachineTag) ([]params.StringResult, error)
 }
 
 // LifecycleManager defines an interface used to enable a storage provisioner
@@ -138,23 +140,23 @@ type MachineAccessor interface {
 // attachments.
 type LifecycleManager interface {
 	// Life returns the lifecycle state of the specified entities.
-	Life([]names.Tag) ([]params.LifeResult, error)
+	Life(stdcontext.Context, []names.Tag) ([]params.LifeResult, error)
 
 	// Remove removes the specified entities from state.
-	Remove([]names.Tag) ([]params.ErrorResult, error)
+	Remove(stdcontext.Context, []names.Tag) ([]params.ErrorResult, error)
 
 	// AttachmentLife returns the lifecycle state of the specified
 	// machine/entity attachments.
-	AttachmentLife([]params.MachineStorageId) ([]params.LifeResult, error)
+	AttachmentLife(stdcontext.Context, []params.MachineStorageId) ([]params.LifeResult, error)
 
 	// RemoveAttachments removes the specified machine/entity attachments
 	// from state.
-	RemoveAttachments([]params.MachineStorageId) ([]params.ErrorResult, error)
+	RemoveAttachments(stdcontext.Context, []params.MachineStorageId) ([]params.ErrorResult, error)
 }
 
 // StatusSetter defines an interface used to set the status of entities.
 type StatusSetter interface {
-	SetStatus([]params.EntityStatusArgs) error
+	SetStatus(stdcontext.Context, []params.EntityStatusArgs) error
 }
 
 // NewStorageProvisioner returns a Worker which manages
@@ -199,6 +201,9 @@ func (w *storageProvisioner) Wait() error {
 }
 
 func (w *storageProvisioner) loop() error {
+	ctx, cancel := w.scopedContext()
+	defer cancel()
+
 	var (
 		volumesChanges               watcher.StringsChannel
 		filesystemsChanges           watcher.StringsChannel
@@ -212,7 +217,7 @@ func (w *storageProvisioner) loop() error {
 	// Machine-scoped provisioners need to watch block devices, to create
 	// volume-backed filesystems.
 	if machineTag, ok := w.config.Scope.(names.MachineTag); ok {
-		machineBlockDevicesWatcher, err := w.config.Volumes.WatchBlockDevices(machineTag)
+		machineBlockDevicesWatcher, err := w.config.Volumes.WatchBlockDevices(ctx, machineTag)
 		if err != nil {
 			return errors.Annotate(err, "watching block devices")
 		}
@@ -221,7 +226,7 @@ func (w *storageProvisioner) loop() error {
 		}
 		machineBlockDevicesChanges = machineBlockDevicesWatcher.Changes()
 
-		volumeAttachmentPlansWatcher, err := w.config.Volumes.WatchVolumeAttachmentPlans(machineTag)
+		volumeAttachmentPlansWatcher, err := w.config.Volumes.WatchVolumeAttachmentPlans(ctx, machineTag)
 		if err != nil {
 			return errors.Annotate(err, "watching volume attachment plans")
 		}
@@ -232,7 +237,7 @@ func (w *storageProvisioner) loop() error {
 		volumeAttachmentPlansChanges = volumeAttachmentPlansWatcher.Changes()
 	}
 
-	ctx := context{
+	deps := dependencies{
 		kill:                                 w.catacomb.Kill,
 		addWorker:                            w.catacomb.Add,
 		config:                               w.config,
@@ -250,18 +255,18 @@ func (w *storageProvisioner) loop() error {
 		incompleteFilesystemAttachmentParams: make(map[params.MachineStorageId]storage.FilesystemAttachmentParams),
 		pendingVolumeBlockDevices:            names.NewSet(),
 	}
-	ctx.managedFilesystemSource = newManagedFilesystemSource(
-		ctx.volumeBlockDevices, ctx.filesystems,
+	deps.managedFilesystemSource = newManagedFilesystemSource(
+		deps.volumeBlockDevices, deps.filesystems,
 	)
 	// Units don't use managed volume backed filesystems.
-	if ctx.isApplicationKind() {
-		ctx.managedFilesystemSource = &noopFilesystemSource{}
+	if deps.isApplicationKind() {
+		deps.managedFilesystemSource = &noopFilesystemSource{}
 	}
 
 	// Units don't have unit-scoped volumes - all volumes are
 	// associated with the model (namespace).
-	if !ctx.isApplicationKind() {
-		volumesWatcher, err := w.config.Volumes.WatchVolumes(w.config.Scope)
+	if !deps.isApplicationKind() {
+		volumesWatcher, err := w.config.Volumes.WatchVolumes(ctx, w.config.Scope)
 		if err != nil {
 			return errors.Annotate(err, "watching volumes")
 		}
@@ -271,7 +276,7 @@ func (w *storageProvisioner) loop() error {
 		volumesChanges = volumesWatcher.Changes()
 	}
 
-	filesystemsWatcher, err := w.config.Filesystems.WatchFilesystems(w.config.Scope)
+	filesystemsWatcher, err := w.config.Filesystems.WatchFilesystems(ctx, w.config.Scope)
 	if err != nil {
 		return errors.Annotate(err, "watching filesystems")
 	}
@@ -280,7 +285,7 @@ func (w *storageProvisioner) loop() error {
 	}
 	filesystemsChanges = filesystemsWatcher.Changes()
 
-	volumeAttachmentsWatcher, err := w.config.Volumes.WatchVolumeAttachments(w.config.Scope)
+	volumeAttachmentsWatcher, err := w.config.Volumes.WatchVolumeAttachments(ctx, w.config.Scope)
 	if err != nil {
 		return errors.Annotate(err, "watching volume attachments")
 	}
@@ -289,7 +294,7 @@ func (w *storageProvisioner) loop() error {
 	}
 	volumeAttachmentsChanges = volumeAttachmentsWatcher.Changes()
 
-	filesystemAttachmentsWatcher, err := w.config.Filesystems.WatchFilesystemAttachments(w.config.Scope)
+	filesystemAttachmentsWatcher, err := w.config.Filesystems.WatchFilesystemAttachments(ctx, w.config.Scope)
 	if err != nil {
 		return errors.Annotate(err, "watching filesystem attachments")
 	}
@@ -301,7 +306,7 @@ func (w *storageProvisioner) loop() error {
 	for {
 
 		// Check if block devices need to be refreshed.
-		if err := processPendingVolumeBlockDevices(&ctx); err != nil {
+		if err := processPendingVolumeBlockDevices(ctx, &deps); err != nil {
 			return errors.Annotate(err, "processing pending block devices")
 		}
 
@@ -312,7 +317,7 @@ func (w *storageProvisioner) loop() error {
 			if !ok {
 				return errors.New("volumes watcher closed")
 			}
-			if err := volumesChanged(&ctx, changes); err != nil {
+			if err := volumesChanged(ctx, &deps, changes); err != nil {
 				return errors.Trace(err)
 			}
 		case changes, ok := <-volumeAttachmentsChanges:
@@ -324,24 +329,24 @@ func (w *storageProvisioner) loop() error {
 			// volumes, and reveals itself during a reboot of a machine. All
 			// the watcher changes come at once, but the order of the select
 			// case statements is not guaranteed.
-			if err := w.processDependentChanges(&ctx, volumesChanges, volumesChanged); err != nil {
+			if err := w.processDependentChanges(ctx, &deps, volumesChanges, volumesChanged); err != nil {
 				return errors.Trace(err)
 			}
-			if err := volumeAttachmentsChanged(&ctx, changes); err != nil {
+			if err := volumeAttachmentsChanged(ctx, &deps, changes); err != nil {
 				return errors.Trace(err)
 			}
 		case changes, ok := <-volumeAttachmentPlansChanges:
 			if !ok {
 				return errors.New("volume attachment plans watcher closed")
 			}
-			if err := volumeAttachmentPlansChanged(&ctx, changes); err != nil {
+			if err := volumeAttachmentPlansChanged(ctx, &deps, changes); err != nil {
 				return errors.Trace(err)
 			}
 		case changes, ok := <-filesystemsChanges:
 			if !ok {
 				return errors.New("filesystems watcher closed")
 			}
-			if err := filesystemsChanged(&ctx, changes); err != nil {
+			if err := filesystemsChanged(ctx, &deps, changes); err != nil {
 				return errors.Trace(err)
 			}
 		case changes, ok := <-filesystemAttachmentsChanges:
@@ -353,26 +358,26 @@ func (w *storageProvisioner) loop() error {
 			// filesystems, and reveals itself during a reboot of a machine. All
 			// the watcher changes come at once, but the order of the select
 			// case statements is not guaranteed.
-			if err := w.processDependentChanges(&ctx, filesystemsChanges, filesystemsChanged); err != nil {
+			if err := w.processDependentChanges(ctx, &deps, filesystemsChanges, filesystemsChanged); err != nil {
 				return errors.Trace(err)
 			}
-			if err := filesystemAttachmentsChanged(&ctx, changes); err != nil {
+			if err := filesystemAttachmentsChanged(ctx, &deps, changes); err != nil {
 				return errors.Trace(err)
 			}
 		case _, ok := <-machineBlockDevicesChanges:
 			if !ok {
 				return errors.New("machine block devices watcher closed")
 			}
-			if err := machineBlockDevicesChanged(&ctx); err != nil {
+			if err := machineBlockDevicesChanged(ctx, &deps); err != nil {
 				return errors.Trace(err)
 			}
 		case machineTag := <-machineChanges:
-			if err := refreshMachine(&ctx, machineTag); err != nil {
+			if err := refreshMachine(ctx, &deps, machineTag); err != nil {
 				return errors.Trace(err)
 			}
-		case <-ctx.schedule.Next():
+		case <-deps.schedule.Next():
 			// Ready to pick something(s) off the pending queue.
-			if err := processSchedule(&ctx); err != nil {
+			if err := processSchedule(ctx, &deps); err != nil {
 				return errors.Trace(err)
 			}
 		}
@@ -383,7 +388,7 @@ func (w *storageProvisioner) loop() error {
 // there are any changes, it calls the given function, repeating until there are
 // no more changes.
 // If there are no changes, it returns with no error.
-func (w *storageProvisioner) processDependentChanges(ctx *context, source watcher.StringsChannel, fn func(*context, []string) error) error {
+func (w *storageProvisioner) processDependentChanges(ctx context.Context, deps *dependencies, source watcher.StringsChannel, fn func(context.Context, *dependencies, []string) error) error {
 	for {
 		select {
 		case <-w.catacomb.Dying():
@@ -392,7 +397,7 @@ func (w *storageProvisioner) processDependentChanges(ctx *context, source watche
 			if !ok {
 				return errors.New("watcher closed")
 			}
-			if err := fn(ctx, changes); err != nil {
+			if err := fn(ctx, deps, changes); err != nil {
 				return errors.Trace(err)
 			}
 		case <-time.After(defaultDependentChangesTimeout):
@@ -402,9 +407,13 @@ func (w *storageProvisioner) processDependentChanges(ctx *context, source watche
 	}
 }
 
+func (w *storageProvisioner) scopedContext() (stdcontext.Context, stdcontext.CancelFunc) {
+	return stdcontext.WithCancel(w.catacomb.Context(stdcontext.Background()))
+}
+
 // processSchedule executes scheduled operations.
-func processSchedule(ctx *context) error {
-	ready := ctx.schedule.Ready(ctx.config.Clock.Now())
+func processSchedule(ctx context.Context, deps *dependencies) error {
+	ready := deps.schedule.Ready(deps.config.Clock.Now())
 	createVolumeOps := make(map[names.VolumeTag]*createVolumeOp)
 	removeVolumeOps := make(map[names.VolumeTag]*removeVolumeOp)
 	attachVolumeOps := make(map[params.MachineStorageId]*attachVolumeOp)
@@ -436,49 +445,49 @@ func processSchedule(ctx *context) error {
 		}
 	}
 	if len(removeVolumeOps) > 0 {
-		if err := removeVolumes(ctx, removeVolumeOps); err != nil {
+		if err := removeVolumes(ctx, deps, removeVolumeOps); err != nil {
 			return errors.Annotate(err, "removing volumes")
 		}
 	}
 	if len(createVolumeOps) > 0 {
-		if err := createVolumes(ctx, createVolumeOps); err != nil {
+		if err := createVolumes(ctx, deps, createVolumeOps); err != nil {
 			return errors.Annotate(err, "creating volumes")
 		}
 	}
 	if len(detachVolumeOps) > 0 {
-		if err := detachVolumes(ctx, detachVolumeOps); err != nil {
+		if err := detachVolumes(ctx, deps, detachVolumeOps); err != nil {
 			return errors.Annotate(err, "detaching volumes")
 		}
 	}
 	if len(attachVolumeOps) > 0 {
-		if err := attachVolumes(ctx, attachVolumeOps); err != nil {
+		if err := attachVolumes(ctx, deps, attachVolumeOps); err != nil {
 			return errors.Annotate(err, "attaching volumes")
 		}
 	}
 	if len(removeFilesystemOps) > 0 {
-		if err := removeFilesystems(ctx, removeFilesystemOps); err != nil {
+		if err := removeFilesystems(ctx, deps, removeFilesystemOps); err != nil {
 			return errors.Annotate(err, "removing filesystems")
 		}
 	}
 	if len(createFilesystemOps) > 0 {
-		if err := createFilesystems(ctx, createFilesystemOps); err != nil {
+		if err := createFilesystems(ctx, deps, createFilesystemOps); err != nil {
 			return errors.Annotate(err, "creating filesystems")
 		}
 	}
 	if len(detachFilesystemOps) > 0 {
-		if err := detachFilesystems(ctx, detachFilesystemOps); err != nil {
+		if err := detachFilesystems(ctx, deps, detachFilesystemOps); err != nil {
 			return errors.Annotate(err, "detaching filesystems")
 		}
 	}
 	if len(attachFilesystemOps) > 0 {
-		if err := attachFilesystems(ctx, attachFilesystemOps); err != nil {
+		if err := attachFilesystems(ctx, deps, attachFilesystemOps); err != nil {
 			return errors.Annotate(err, "attaching filesystems")
 		}
 	}
 	return nil
 }
 
-type context struct {
+type dependencies struct {
 	kill      func(error)
 	addWorker func(worker.Worker) error
 	config    Config
@@ -555,6 +564,6 @@ type context struct {
 	managedFilesystemSource storage.FilesystemSource
 }
 
-func (c *context) isApplicationKind() bool {
+func (c *dependencies) isApplicationKind() bool {
 	return c.config.Scope.Kind() == names.ApplicationTagKind
 }

--- a/internal/worker/storageprovisioner/storageprovisioner_test.go
+++ b/internal/worker/storageprovisioner/storageprovisioner_test.go
@@ -39,7 +39,7 @@ func (s *storageProvisionerSuite) SetUpTest(c *gc.C) {
 	s.BaseSuite.SetUpTest(c)
 	s.provider = &dummyProvider{dynamic: true}
 	s.registry = storage.StaticProviderRegistry{
-		map[storage.ProviderType]storage.Provider{
+		Providers: map[storage.ProviderType]storage.Provider{
 			"dummy": s.provider,
 		},
 	}
@@ -449,9 +449,9 @@ func (s *storageProvisionerSuite) TestAttachVolumeRetry(c *gc.C) {
 		}
 		return []storage.AttachVolumesResult{{
 			VolumeAttachment: &storage.VolumeAttachment{
-				args[0].Volume,
-				args[0].Machine,
-				storage.VolumeAttachmentInfo{
+				Volume:  args[0].Volume,
+				Machine: args[0].Machine,
+				VolumeAttachmentInfo: storage.VolumeAttachmentInfo{
 					DeviceName: "/dev/sda1",
 				},
 			},
@@ -531,9 +531,9 @@ func (s *storageProvisionerSuite) TestAttachFilesystemRetry(c *gc.C) {
 		}
 		return []storage.AttachFilesystemsResult{{
 			FilesystemAttachment: &storage.FilesystemAttachment{
-				args[0].Filesystem,
-				args[0].Machine,
-				storage.FilesystemAttachmentInfo{
+				Filesystem: args[0].Filesystem,
+				Machine:    args[0].Machine,
+				FilesystemAttachmentInfo: storage.FilesystemAttachmentInfo{
 					Path: "/oh/over/there",
 				},
 			},

--- a/internal/worker/unitassigner/unitassigner_test.go
+++ b/internal/worker/unitassigner/unitassigner_test.go
@@ -4,6 +4,7 @@
 package unitassigner
 
 import (
+	"context"
 	"errors"
 
 	"github.com/juju/names/v5"
@@ -27,12 +28,12 @@ func newHandler(c *gc.C, api UnitAssigner) unitAssignerHandler {
 func (testsuite) TestSetup(c *gc.C) {
 	f := &fakeAPI{}
 	ua := newHandler(c, f)
-	_, err := ua.SetUp()
+	_, err := ua.SetUp(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(f.calledWatch, jc.IsTrue)
 
 	f.err = errors.New("boo")
-	_, err = ua.SetUp()
+	_, err = ua.SetUp(context.Background())
 	c.Assert(err, gc.Equals, f.err)
 }
 
@@ -81,17 +82,17 @@ type fakeAPI struct {
 	assignErrs  []error
 }
 
-func (f *fakeAPI) AssignUnits(tags []names.UnitTag) ([]error, error) {
+func (f *fakeAPI) AssignUnits(ctx context.Context, tags []names.UnitTag) ([]error, error) {
 	f.assignTags = tags
 	return f.assignErrs, f.err
 }
 
-func (f *fakeAPI) WatchUnitAssignments() (watcher.StringsWatcher, error) {
+func (f *fakeAPI) WatchUnitAssignments(ctx context.Context) (watcher.StringsWatcher, error) {
 	f.calledWatch = true
 	return nil, f.err
 }
 
-func (f *fakeAPI) SetAgentStatus(args params.SetStatus) error {
+func (f *fakeAPI) SetAgentStatus(ctx context.Context, args params.SetStatus) error {
 	f.status = args
 	return f.err
 }

--- a/internal/worker/uniter/agent.go
+++ b/internal/worker/uniter/agent.go
@@ -4,11 +4,13 @@
 package uniter
 
 import (
+	stdcontext "context"
+
 	"github.com/juju/juju/core/status"
 )
 
 // setAgentStatus sets the unit's status if it has changed since last time this method was called.
-func setAgentStatus(u *Uniter, agentStatus status.Status, info string, data map[string]interface{}) error {
+func setAgentStatus(ctx stdcontext.Context, u *Uniter, agentStatus status.Status, info string, data map[string]interface{}) error {
 	u.setStatusMutex.Lock()
 	defer u.setStatusMutex.Unlock()
 	if u.lastReportedStatus == agentStatus && u.lastReportedMessage == info {
@@ -17,18 +19,18 @@ func setAgentStatus(u *Uniter, agentStatus status.Status, info string, data map[
 	u.lastReportedStatus = agentStatus
 	u.lastReportedMessage = info
 	u.logger.Debugf("[AGENT-STATUS] %s: %s", agentStatus, info)
-	return u.unit.SetAgentStatus(agentStatus, info, data)
+	return u.unit.SetAgentStatus(ctx, agentStatus, info, data)
 }
 
 // reportAgentError reports if there was an error performing an agent operation.
-func reportAgentError(u *Uniter, userMessage string, err error) {
+func reportAgentError(ctx stdcontext.Context, u *Uniter, userMessage string, err error) {
 	// If a non-nil error is reported (e.g. due to an operation failing),
 	// set the agent status to Failed.
 	if err == nil {
 		return
 	}
 	u.logger.Errorf("%s: %v", userMessage, err)
-	err2 := setAgentStatus(u, status.Failed, userMessage, nil)
+	err2 := setAgentStatus(ctx, u, status.Failed, userMessage, nil)
 	if err2 != nil {
 		u.logger.Errorf("updating agent status: %v", err2)
 	}

--- a/internal/worker/uniter/api/domain_mocks.go
+++ b/internal/worker/uniter/api/domain_mocks.go
@@ -163,18 +163,18 @@ func (c *MockUnitApplicationTagCall) DoAndReturn(f func() names.ApplicationTag) 
 }
 
 // AssignedMachine mocks base method.
-func (m *MockUnit) AssignedMachine() (names.MachineTag, error) {
+func (m *MockUnit) AssignedMachine(arg0 context.Context) (names.MachineTag, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AssignedMachine")
+	ret := m.ctrl.Call(m, "AssignedMachine", arg0)
 	ret0, _ := ret[0].(names.MachineTag)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // AssignedMachine indicates an expected call of AssignedMachine.
-func (mr *MockUnitMockRecorder) AssignedMachine() *MockUnitAssignedMachineCall {
+func (mr *MockUnitMockRecorder) AssignedMachine(arg0 any) *MockUnitAssignedMachineCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssignedMachine", reflect.TypeOf((*MockUnit)(nil).AssignedMachine))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssignedMachine", reflect.TypeOf((*MockUnit)(nil).AssignedMachine), arg0)
 	return &MockUnitAssignedMachineCall{Call: call}
 }
 
@@ -190,30 +190,30 @@ func (c *MockUnitAssignedMachineCall) Return(arg0 names.MachineTag, arg1 error) 
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockUnitAssignedMachineCall) Do(f func() (names.MachineTag, error)) *MockUnitAssignedMachineCall {
+func (c *MockUnitAssignedMachineCall) Do(f func(context.Context) (names.MachineTag, error)) *MockUnitAssignedMachineCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockUnitAssignedMachineCall) DoAndReturn(f func() (names.MachineTag, error)) *MockUnitAssignedMachineCall {
+func (c *MockUnitAssignedMachineCall) DoAndReturn(f func(context.Context) (names.MachineTag, error)) *MockUnitAssignedMachineCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // AvailabilityZone mocks base method.
-func (m *MockUnit) AvailabilityZone() (string, error) {
+func (m *MockUnit) AvailabilityZone(arg0 context.Context) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AvailabilityZone")
+	ret := m.ctrl.Call(m, "AvailabilityZone", arg0)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // AvailabilityZone indicates an expected call of AvailabilityZone.
-func (mr *MockUnitMockRecorder) AvailabilityZone() *MockUnitAvailabilityZoneCall {
+func (mr *MockUnitMockRecorder) AvailabilityZone(arg0 any) *MockUnitAvailabilityZoneCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AvailabilityZone", reflect.TypeOf((*MockUnit)(nil).AvailabilityZone))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AvailabilityZone", reflect.TypeOf((*MockUnit)(nil).AvailabilityZone), arg0)
 	return &MockUnitAvailabilityZoneCall{Call: call}
 }
 
@@ -229,30 +229,30 @@ func (c *MockUnitAvailabilityZoneCall) Return(arg0 string, arg1 error) *MockUnit
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockUnitAvailabilityZoneCall) Do(f func() (string, error)) *MockUnitAvailabilityZoneCall {
+func (c *MockUnitAvailabilityZoneCall) Do(f func(context.Context) (string, error)) *MockUnitAvailabilityZoneCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockUnitAvailabilityZoneCall) DoAndReturn(f func() (string, error)) *MockUnitAvailabilityZoneCall {
+func (c *MockUnitAvailabilityZoneCall) DoAndReturn(f func(context.Context) (string, error)) *MockUnitAvailabilityZoneCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // CanApplyLXDProfile mocks base method.
-func (m *MockUnit) CanApplyLXDProfile() (bool, error) {
+func (m *MockUnit) CanApplyLXDProfile(arg0 context.Context) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CanApplyLXDProfile")
+	ret := m.ctrl.Call(m, "CanApplyLXDProfile", arg0)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CanApplyLXDProfile indicates an expected call of CanApplyLXDProfile.
-func (mr *MockUnitMockRecorder) CanApplyLXDProfile() *MockUnitCanApplyLXDProfileCall {
+func (mr *MockUnitMockRecorder) CanApplyLXDProfile(arg0 any) *MockUnitCanApplyLXDProfileCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CanApplyLXDProfile", reflect.TypeOf((*MockUnit)(nil).CanApplyLXDProfile))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CanApplyLXDProfile", reflect.TypeOf((*MockUnit)(nil).CanApplyLXDProfile), arg0)
 	return &MockUnitCanApplyLXDProfileCall{Call: call}
 }
 
@@ -268,30 +268,30 @@ func (c *MockUnitCanApplyLXDProfileCall) Return(arg0 bool, arg1 error) *MockUnit
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockUnitCanApplyLXDProfileCall) Do(f func() (bool, error)) *MockUnitCanApplyLXDProfileCall {
+func (c *MockUnitCanApplyLXDProfileCall) Do(f func(context.Context) (bool, error)) *MockUnitCanApplyLXDProfileCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockUnitCanApplyLXDProfileCall) DoAndReturn(f func() (bool, error)) *MockUnitCanApplyLXDProfileCall {
+func (c *MockUnitCanApplyLXDProfileCall) DoAndReturn(f func(context.Context) (bool, error)) *MockUnitCanApplyLXDProfileCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // CharmURL mocks base method.
-func (m *MockUnit) CharmURL() (string, error) {
+func (m *MockUnit) CharmURL(arg0 context.Context) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CharmURL")
+	ret := m.ctrl.Call(m, "CharmURL", arg0)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CharmURL indicates an expected call of CharmURL.
-func (mr *MockUnitMockRecorder) CharmURL() *MockUnitCharmURLCall {
+func (mr *MockUnitMockRecorder) CharmURL(arg0 any) *MockUnitCharmURLCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CharmURL", reflect.TypeOf((*MockUnit)(nil).CharmURL))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CharmURL", reflect.TypeOf((*MockUnit)(nil).CharmURL), arg0)
 	return &MockUnitCharmURLCall{Call: call}
 }
 
@@ -307,29 +307,29 @@ func (c *MockUnitCharmURLCall) Return(arg0 string, arg1 error) *MockUnitCharmURL
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockUnitCharmURLCall) Do(f func() (string, error)) *MockUnitCharmURLCall {
+func (c *MockUnitCharmURLCall) Do(f func(context.Context) (string, error)) *MockUnitCharmURLCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockUnitCharmURLCall) DoAndReturn(f func() (string, error)) *MockUnitCharmURLCall {
+func (c *MockUnitCharmURLCall) DoAndReturn(f func(context.Context) (string, error)) *MockUnitCharmURLCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // ClearResolved mocks base method.
-func (m *MockUnit) ClearResolved() error {
+func (m *MockUnit) ClearResolved(arg0 context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ClearResolved")
+	ret := m.ctrl.Call(m, "ClearResolved", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ClearResolved indicates an expected call of ClearResolved.
-func (mr *MockUnitMockRecorder) ClearResolved() *MockUnitClearResolvedCall {
+func (mr *MockUnitMockRecorder) ClearResolved(arg0 any) *MockUnitClearResolvedCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClearResolved", reflect.TypeOf((*MockUnit)(nil).ClearResolved))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClearResolved", reflect.TypeOf((*MockUnit)(nil).ClearResolved), arg0)
 	return &MockUnitClearResolvedCall{Call: call}
 }
 
@@ -345,29 +345,29 @@ func (c *MockUnitClearResolvedCall) Return(arg0 error) *MockUnitClearResolvedCal
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockUnitClearResolvedCall) Do(f func() error) *MockUnitClearResolvedCall {
+func (c *MockUnitClearResolvedCall) Do(f func(context.Context) error) *MockUnitClearResolvedCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockUnitClearResolvedCall) DoAndReturn(f func() error) *MockUnitClearResolvedCall {
+func (c *MockUnitClearResolvedCall) DoAndReturn(f func(context.Context) error) *MockUnitClearResolvedCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // CommitHookChanges mocks base method.
-func (m *MockUnit) CommitHookChanges(arg0 params.CommitHookChangesArgs) error {
+func (m *MockUnit) CommitHookChanges(arg0 context.Context, arg1 params.CommitHookChangesArgs) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CommitHookChanges", arg0)
+	ret := m.ctrl.Call(m, "CommitHookChanges", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CommitHookChanges indicates an expected call of CommitHookChanges.
-func (mr *MockUnitMockRecorder) CommitHookChanges(arg0 any) *MockUnitCommitHookChangesCall {
+func (mr *MockUnitMockRecorder) CommitHookChanges(arg0, arg1 any) *MockUnitCommitHookChangesCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CommitHookChanges", reflect.TypeOf((*MockUnit)(nil).CommitHookChanges), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CommitHookChanges", reflect.TypeOf((*MockUnit)(nil).CommitHookChanges), arg0, arg1)
 	return &MockUnitCommitHookChangesCall{Call: call}
 }
 
@@ -383,30 +383,30 @@ func (c *MockUnitCommitHookChangesCall) Return(arg0 error) *MockUnitCommitHookCh
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockUnitCommitHookChangesCall) Do(f func(params.CommitHookChangesArgs) error) *MockUnitCommitHookChangesCall {
+func (c *MockUnitCommitHookChangesCall) Do(f func(context.Context, params.CommitHookChangesArgs) error) *MockUnitCommitHookChangesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockUnitCommitHookChangesCall) DoAndReturn(f func(params.CommitHookChangesArgs) error) *MockUnitCommitHookChangesCall {
+func (c *MockUnitCommitHookChangesCall) DoAndReturn(f func(context.Context, params.CommitHookChangesArgs) error) *MockUnitCommitHookChangesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // ConfigSettings mocks base method.
-func (m *MockUnit) ConfigSettings() (charm.Settings, error) {
+func (m *MockUnit) ConfigSettings(arg0 context.Context) (charm.Settings, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ConfigSettings")
+	ret := m.ctrl.Call(m, "ConfigSettings", arg0)
 	ret0, _ := ret[0].(charm.Settings)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ConfigSettings indicates an expected call of ConfigSettings.
-func (mr *MockUnitMockRecorder) ConfigSettings() *MockUnitConfigSettingsCall {
+func (mr *MockUnitMockRecorder) ConfigSettings(arg0 any) *MockUnitConfigSettingsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConfigSettings", reflect.TypeOf((*MockUnit)(nil).ConfigSettings))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConfigSettings", reflect.TypeOf((*MockUnit)(nil).ConfigSettings), arg0)
 	return &MockUnitConfigSettingsCall{Call: call}
 }
 
@@ -422,29 +422,29 @@ func (c *MockUnitConfigSettingsCall) Return(arg0 charm.Settings, arg1 error) *Mo
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockUnitConfigSettingsCall) Do(f func() (charm.Settings, error)) *MockUnitConfigSettingsCall {
+func (c *MockUnitConfigSettingsCall) Do(f func(context.Context) (charm.Settings, error)) *MockUnitConfigSettingsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockUnitConfigSettingsCall) DoAndReturn(f func() (charm.Settings, error)) *MockUnitConfigSettingsCall {
+func (c *MockUnitConfigSettingsCall) DoAndReturn(f func(context.Context) (charm.Settings, error)) *MockUnitConfigSettingsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // Destroy mocks base method.
-func (m *MockUnit) Destroy() error {
+func (m *MockUnit) Destroy(arg0 context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Destroy")
+	ret := m.ctrl.Call(m, "Destroy", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Destroy indicates an expected call of Destroy.
-func (mr *MockUnitMockRecorder) Destroy() *MockUnitDestroyCall {
+func (mr *MockUnitMockRecorder) Destroy(arg0 any) *MockUnitDestroyCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Destroy", reflect.TypeOf((*MockUnit)(nil).Destroy))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Destroy", reflect.TypeOf((*MockUnit)(nil).Destroy), arg0)
 	return &MockUnitDestroyCall{Call: call}
 }
 
@@ -460,29 +460,29 @@ func (c *MockUnitDestroyCall) Return(arg0 error) *MockUnitDestroyCall {
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockUnitDestroyCall) Do(f func() error) *MockUnitDestroyCall {
+func (c *MockUnitDestroyCall) Do(f func(context.Context) error) *MockUnitDestroyCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockUnitDestroyCall) DoAndReturn(f func() error) *MockUnitDestroyCall {
+func (c *MockUnitDestroyCall) DoAndReturn(f func(context.Context) error) *MockUnitDestroyCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // DestroyAllSubordinates mocks base method.
-func (m *MockUnit) DestroyAllSubordinates() error {
+func (m *MockUnit) DestroyAllSubordinates(arg0 context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DestroyAllSubordinates")
+	ret := m.ctrl.Call(m, "DestroyAllSubordinates", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DestroyAllSubordinates indicates an expected call of DestroyAllSubordinates.
-func (mr *MockUnitMockRecorder) DestroyAllSubordinates() *MockUnitDestroyAllSubordinatesCall {
+func (mr *MockUnitMockRecorder) DestroyAllSubordinates(arg0 any) *MockUnitDestroyAllSubordinatesCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DestroyAllSubordinates", reflect.TypeOf((*MockUnit)(nil).DestroyAllSubordinates))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DestroyAllSubordinates", reflect.TypeOf((*MockUnit)(nil).DestroyAllSubordinates), arg0)
 	return &MockUnitDestroyAllSubordinatesCall{Call: call}
 }
 
@@ -498,29 +498,29 @@ func (c *MockUnitDestroyAllSubordinatesCall) Return(arg0 error) *MockUnitDestroy
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockUnitDestroyAllSubordinatesCall) Do(f func() error) *MockUnitDestroyAllSubordinatesCall {
+func (c *MockUnitDestroyAllSubordinatesCall) Do(f func(context.Context) error) *MockUnitDestroyAllSubordinatesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockUnitDestroyAllSubordinatesCall) DoAndReturn(f func() error) *MockUnitDestroyAllSubordinatesCall {
+func (c *MockUnitDestroyAllSubordinatesCall) DoAndReturn(f func(context.Context) error) *MockUnitDestroyAllSubordinatesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // EnsureDead mocks base method.
-func (m *MockUnit) EnsureDead() error {
+func (m *MockUnit) EnsureDead(arg0 context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnsureDead")
+	ret := m.ctrl.Call(m, "EnsureDead", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // EnsureDead indicates an expected call of EnsureDead.
-func (mr *MockUnitMockRecorder) EnsureDead() *MockUnitEnsureDeadCall {
+func (mr *MockUnitMockRecorder) EnsureDead(arg0 any) *MockUnitEnsureDeadCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureDead", reflect.TypeOf((*MockUnit)(nil).EnsureDead))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureDead", reflect.TypeOf((*MockUnit)(nil).EnsureDead), arg0)
 	return &MockUnitEnsureDeadCall{Call: call}
 }
 
@@ -536,30 +536,30 @@ func (c *MockUnitEnsureDeadCall) Return(arg0 error) *MockUnitEnsureDeadCall {
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockUnitEnsureDeadCall) Do(f func() error) *MockUnitEnsureDeadCall {
+func (c *MockUnitEnsureDeadCall) Do(f func(context.Context) error) *MockUnitEnsureDeadCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockUnitEnsureDeadCall) DoAndReturn(f func() error) *MockUnitEnsureDeadCall {
+func (c *MockUnitEnsureDeadCall) DoAndReturn(f func(context.Context) error) *MockUnitEnsureDeadCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // HasSubordinates mocks base method.
-func (m *MockUnit) HasSubordinates() (bool, error) {
+func (m *MockUnit) HasSubordinates(arg0 context.Context) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HasSubordinates")
+	ret := m.ctrl.Call(m, "HasSubordinates", arg0)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // HasSubordinates indicates an expected call of HasSubordinates.
-func (mr *MockUnitMockRecorder) HasSubordinates() *MockUnitHasSubordinatesCall {
+func (mr *MockUnitMockRecorder) HasSubordinates(arg0 any) *MockUnitHasSubordinatesCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasSubordinates", reflect.TypeOf((*MockUnit)(nil).HasSubordinates))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasSubordinates", reflect.TypeOf((*MockUnit)(nil).HasSubordinates), arg0)
 	return &MockUnitHasSubordinatesCall{Call: call}
 }
 
@@ -575,30 +575,30 @@ func (c *MockUnitHasSubordinatesCall) Return(arg0 bool, arg1 error) *MockUnitHas
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockUnitHasSubordinatesCall) Do(f func() (bool, error)) *MockUnitHasSubordinatesCall {
+func (c *MockUnitHasSubordinatesCall) Do(f func(context.Context) (bool, error)) *MockUnitHasSubordinatesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockUnitHasSubordinatesCall) DoAndReturn(f func() (bool, error)) *MockUnitHasSubordinatesCall {
+func (c *MockUnitHasSubordinatesCall) DoAndReturn(f func(context.Context) (bool, error)) *MockUnitHasSubordinatesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // LXDProfileName mocks base method.
-func (m *MockUnit) LXDProfileName() (string, error) {
+func (m *MockUnit) LXDProfileName(arg0 context.Context) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LXDProfileName")
+	ret := m.ctrl.Call(m, "LXDProfileName", arg0)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // LXDProfileName indicates an expected call of LXDProfileName.
-func (mr *MockUnitMockRecorder) LXDProfileName() *MockUnitLXDProfileNameCall {
+func (mr *MockUnitMockRecorder) LXDProfileName(arg0 any) *MockUnitLXDProfileNameCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LXDProfileName", reflect.TypeOf((*MockUnit)(nil).LXDProfileName))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LXDProfileName", reflect.TypeOf((*MockUnit)(nil).LXDProfileName), arg0)
 	return &MockUnitLXDProfileNameCall{Call: call}
 }
 
@@ -614,13 +614,13 @@ func (c *MockUnitLXDProfileNameCall) Return(arg0 string, arg1 error) *MockUnitLX
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockUnitLXDProfileNameCall) Do(f func() (string, error)) *MockUnitLXDProfileNameCall {
+func (c *MockUnitLXDProfileNameCall) Do(f func(context.Context) (string, error)) *MockUnitLXDProfileNameCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockUnitLXDProfileNameCall) DoAndReturn(f func() (string, error)) *MockUnitLXDProfileNameCall {
+func (c *MockUnitLXDProfileNameCall) DoAndReturn(f func(context.Context) (string, error)) *MockUnitLXDProfileNameCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -664,17 +664,17 @@ func (c *MockUnitLifeCall) DoAndReturn(f func() life.Value) *MockUnitLifeCall {
 }
 
 // LogActionMessage mocks base method.
-func (m *MockUnit) LogActionMessage(arg0 names.ActionTag, arg1 string) error {
+func (m *MockUnit) LogActionMessage(arg0 context.Context, arg1 names.ActionTag, arg2 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LogActionMessage", arg0, arg1)
+	ret := m.ctrl.Call(m, "LogActionMessage", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // LogActionMessage indicates an expected call of LogActionMessage.
-func (mr *MockUnitMockRecorder) LogActionMessage(arg0, arg1 any) *MockUnitLogActionMessageCall {
+func (mr *MockUnitMockRecorder) LogActionMessage(arg0, arg1, arg2 any) *MockUnitLogActionMessageCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LogActionMessage", reflect.TypeOf((*MockUnit)(nil).LogActionMessage), arg0, arg1)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LogActionMessage", reflect.TypeOf((*MockUnit)(nil).LogActionMessage), arg0, arg1, arg2)
 	return &MockUnitLogActionMessageCall{Call: call}
 }
 
@@ -690,13 +690,13 @@ func (c *MockUnitLogActionMessageCall) Return(arg0 error) *MockUnitLogActionMess
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockUnitLogActionMessageCall) Do(f func(names.ActionTag, string) error) *MockUnitLogActionMessageCall {
+func (c *MockUnitLogActionMessageCall) Do(f func(context.Context, names.ActionTag, string) error) *MockUnitLogActionMessageCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockUnitLogActionMessageCall) DoAndReturn(f func(names.ActionTag, string) error) *MockUnitLogActionMessageCall {
+func (c *MockUnitLogActionMessageCall) DoAndReturn(f func(context.Context, names.ActionTag, string) error) *MockUnitLogActionMessageCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -740,18 +740,18 @@ func (c *MockUnitNameCall) DoAndReturn(f func() string) *MockUnitNameCall {
 }
 
 // NetworkInfo mocks base method.
-func (m *MockUnit) NetworkInfo(arg0 []string, arg1 *int) (map[string]params.NetworkInfoResult, error) {
+func (m *MockUnit) NetworkInfo(arg0 context.Context, arg1 []string, arg2 *int) (map[string]params.NetworkInfoResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NetworkInfo", arg0, arg1)
+	ret := m.ctrl.Call(m, "NetworkInfo", arg0, arg1, arg2)
 	ret0, _ := ret[0].(map[string]params.NetworkInfoResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // NetworkInfo indicates an expected call of NetworkInfo.
-func (mr *MockUnitMockRecorder) NetworkInfo(arg0, arg1 any) *MockUnitNetworkInfoCall {
+func (mr *MockUnitMockRecorder) NetworkInfo(arg0, arg1, arg2 any) *MockUnitNetworkInfoCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NetworkInfo", reflect.TypeOf((*MockUnit)(nil).NetworkInfo), arg0, arg1)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NetworkInfo", reflect.TypeOf((*MockUnit)(nil).NetworkInfo), arg0, arg1, arg2)
 	return &MockUnitNetworkInfoCall{Call: call}
 }
 
@@ -767,21 +767,21 @@ func (c *MockUnitNetworkInfoCall) Return(arg0 map[string]params.NetworkInfoResul
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockUnitNetworkInfoCall) Do(f func([]string, *int) (map[string]params.NetworkInfoResult, error)) *MockUnitNetworkInfoCall {
+func (c *MockUnitNetworkInfoCall) Do(f func(context.Context, []string, *int) (map[string]params.NetworkInfoResult, error)) *MockUnitNetworkInfoCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockUnitNetworkInfoCall) DoAndReturn(f func([]string, *int) (map[string]params.NetworkInfoResult, error)) *MockUnitNetworkInfoCall {
+func (c *MockUnitNetworkInfoCall) DoAndReturn(f func(context.Context, []string, *int) (map[string]params.NetworkInfoResult, error)) *MockUnitNetworkInfoCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // PrincipalName mocks base method.
-func (m *MockUnit) PrincipalName() (string, bool, error) {
+func (m *MockUnit) PrincipalName(arg0 context.Context) (string, bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PrincipalName")
+	ret := m.ctrl.Call(m, "PrincipalName", arg0)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(bool)
 	ret2, _ := ret[2].(error)
@@ -789,9 +789,9 @@ func (m *MockUnit) PrincipalName() (string, bool, error) {
 }
 
 // PrincipalName indicates an expected call of PrincipalName.
-func (mr *MockUnitMockRecorder) PrincipalName() *MockUnitPrincipalNameCall {
+func (mr *MockUnitMockRecorder) PrincipalName(arg0 any) *MockUnitPrincipalNameCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrincipalName", reflect.TypeOf((*MockUnit)(nil).PrincipalName))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrincipalName", reflect.TypeOf((*MockUnit)(nil).PrincipalName), arg0)
 	return &MockUnitPrincipalNameCall{Call: call}
 }
 
@@ -807,30 +807,30 @@ func (c *MockUnitPrincipalNameCall) Return(arg0 string, arg1 bool, arg2 error) *
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockUnitPrincipalNameCall) Do(f func() (string, bool, error)) *MockUnitPrincipalNameCall {
+func (c *MockUnitPrincipalNameCall) Do(f func(context.Context) (string, bool, error)) *MockUnitPrincipalNameCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockUnitPrincipalNameCall) DoAndReturn(f func() (string, bool, error)) *MockUnitPrincipalNameCall {
+func (c *MockUnitPrincipalNameCall) DoAndReturn(f func(context.Context) (string, bool, error)) *MockUnitPrincipalNameCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // PrivateAddress mocks base method.
-func (m *MockUnit) PrivateAddress() (string, error) {
+func (m *MockUnit) PrivateAddress(arg0 context.Context) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PrivateAddress")
+	ret := m.ctrl.Call(m, "PrivateAddress", arg0)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // PrivateAddress indicates an expected call of PrivateAddress.
-func (mr *MockUnitMockRecorder) PrivateAddress() *MockUnitPrivateAddressCall {
+func (mr *MockUnitMockRecorder) PrivateAddress(arg0 any) *MockUnitPrivateAddressCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrivateAddress", reflect.TypeOf((*MockUnit)(nil).PrivateAddress))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrivateAddress", reflect.TypeOf((*MockUnit)(nil).PrivateAddress), arg0)
 	return &MockUnitPrivateAddressCall{Call: call}
 }
 
@@ -846,13 +846,13 @@ func (c *MockUnitPrivateAddressCall) Return(arg0 string, arg1 error) *MockUnitPr
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockUnitPrivateAddressCall) Do(f func() (string, error)) *MockUnitPrivateAddressCall {
+func (c *MockUnitPrivateAddressCall) Do(f func(context.Context) (string, error)) *MockUnitPrivateAddressCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockUnitPrivateAddressCall) DoAndReturn(f func() (string, error)) *MockUnitPrivateAddressCall {
+func (c *MockUnitPrivateAddressCall) DoAndReturn(f func(context.Context) (string, error)) *MockUnitPrivateAddressCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -896,18 +896,18 @@ func (c *MockUnitProviderIDCall) DoAndReturn(f func() string) *MockUnitProviderI
 }
 
 // PublicAddress mocks base method.
-func (m *MockUnit) PublicAddress() (string, error) {
+func (m *MockUnit) PublicAddress(arg0 context.Context) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PublicAddress")
+	ret := m.ctrl.Call(m, "PublicAddress", arg0)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // PublicAddress indicates an expected call of PublicAddress.
-func (mr *MockUnitMockRecorder) PublicAddress() *MockUnitPublicAddressCall {
+func (mr *MockUnitMockRecorder) PublicAddress(arg0 any) *MockUnitPublicAddressCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PublicAddress", reflect.TypeOf((*MockUnit)(nil).PublicAddress))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PublicAddress", reflect.TypeOf((*MockUnit)(nil).PublicAddress), arg0)
 	return &MockUnitPublicAddressCall{Call: call}
 }
 
@@ -923,13 +923,13 @@ func (c *MockUnitPublicAddressCall) Return(arg0 string, arg1 error) *MockUnitPub
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockUnitPublicAddressCall) Do(f func() (string, error)) *MockUnitPublicAddressCall {
+func (c *MockUnitPublicAddressCall) Do(f func(context.Context) (string, error)) *MockUnitPublicAddressCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockUnitPublicAddressCall) DoAndReturn(f func() (string, error)) *MockUnitPublicAddressCall {
+func (c *MockUnitPublicAddressCall) DoAndReturn(f func(context.Context) (string, error)) *MockUnitPublicAddressCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -973,18 +973,18 @@ func (c *MockUnitRefreshCall) DoAndReturn(f func(context.Context) error) *MockUn
 }
 
 // RelationsStatus mocks base method.
-func (m *MockUnit) RelationsStatus() ([]uniter.RelationStatus, error) {
+func (m *MockUnit) RelationsStatus(arg0 context.Context) ([]uniter.RelationStatus, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RelationsStatus")
+	ret := m.ctrl.Call(m, "RelationsStatus", arg0)
 	ret0, _ := ret[0].([]uniter.RelationStatus)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // RelationsStatus indicates an expected call of RelationsStatus.
-func (mr *MockUnitMockRecorder) RelationsStatus() *MockUnitRelationsStatusCall {
+func (mr *MockUnitMockRecorder) RelationsStatus(arg0 any) *MockUnitRelationsStatusCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RelationsStatus", reflect.TypeOf((*MockUnit)(nil).RelationsStatus))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RelationsStatus", reflect.TypeOf((*MockUnit)(nil).RelationsStatus), arg0)
 	return &MockUnitRelationsStatusCall{Call: call}
 }
 
@@ -1000,29 +1000,29 @@ func (c *MockUnitRelationsStatusCall) Return(arg0 []uniter.RelationStatus, arg1 
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockUnitRelationsStatusCall) Do(f func() ([]uniter.RelationStatus, error)) *MockUnitRelationsStatusCall {
+func (c *MockUnitRelationsStatusCall) Do(f func(context.Context) ([]uniter.RelationStatus, error)) *MockUnitRelationsStatusCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockUnitRelationsStatusCall) DoAndReturn(f func() ([]uniter.RelationStatus, error)) *MockUnitRelationsStatusCall {
+func (c *MockUnitRelationsStatusCall) DoAndReturn(f func(context.Context) ([]uniter.RelationStatus, error)) *MockUnitRelationsStatusCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // RequestReboot mocks base method.
-func (m *MockUnit) RequestReboot() error {
+func (m *MockUnit) RequestReboot(arg0 context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RequestReboot")
+	ret := m.ctrl.Call(m, "RequestReboot", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RequestReboot indicates an expected call of RequestReboot.
-func (mr *MockUnitMockRecorder) RequestReboot() *MockUnitRequestRebootCall {
+func (mr *MockUnitMockRecorder) RequestReboot(arg0 any) *MockUnitRequestRebootCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestReboot", reflect.TypeOf((*MockUnit)(nil).RequestReboot))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestReboot", reflect.TypeOf((*MockUnit)(nil).RequestReboot), arg0)
 	return &MockUnitRequestRebootCall{Call: call}
 }
 
@@ -1038,13 +1038,13 @@ func (c *MockUnitRequestRebootCall) Return(arg0 error) *MockUnitRequestRebootCal
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockUnitRequestRebootCall) Do(f func() error) *MockUnitRequestRebootCall {
+func (c *MockUnitRequestRebootCall) Do(f func(context.Context) error) *MockUnitRequestRebootCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockUnitRequestRebootCall) DoAndReturn(f func() error) *MockUnitRequestRebootCall {
+func (c *MockUnitRequestRebootCall) DoAndReturn(f func(context.Context) error) *MockUnitRequestRebootCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1088,17 +1088,17 @@ func (c *MockUnitResolvedCall) DoAndReturn(f func() params.ResolvedMode) *MockUn
 }
 
 // SetAgentStatus mocks base method.
-func (m *MockUnit) SetAgentStatus(arg0 status.Status, arg1 string, arg2 map[string]any) error {
+func (m *MockUnit) SetAgentStatus(arg0 context.Context, arg1 status.Status, arg2 string, arg3 map[string]any) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetAgentStatus", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "SetAgentStatus", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetAgentStatus indicates an expected call of SetAgentStatus.
-func (mr *MockUnitMockRecorder) SetAgentStatus(arg0, arg1, arg2 any) *MockUnitSetAgentStatusCall {
+func (mr *MockUnitMockRecorder) SetAgentStatus(arg0, arg1, arg2, arg3 any) *MockUnitSetAgentStatusCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetAgentStatus", reflect.TypeOf((*MockUnit)(nil).SetAgentStatus), arg0, arg1, arg2)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetAgentStatus", reflect.TypeOf((*MockUnit)(nil).SetAgentStatus), arg0, arg1, arg2, arg3)
 	return &MockUnitSetAgentStatusCall{Call: call}
 }
 
@@ -1114,29 +1114,29 @@ func (c *MockUnitSetAgentStatusCall) Return(arg0 error) *MockUnitSetAgentStatusC
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockUnitSetAgentStatusCall) Do(f func(status.Status, string, map[string]any) error) *MockUnitSetAgentStatusCall {
+func (c *MockUnitSetAgentStatusCall) Do(f func(context.Context, status.Status, string, map[string]any) error) *MockUnitSetAgentStatusCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockUnitSetAgentStatusCall) DoAndReturn(f func(status.Status, string, map[string]any) error) *MockUnitSetAgentStatusCall {
+func (c *MockUnitSetAgentStatusCall) DoAndReturn(f func(context.Context, status.Status, string, map[string]any) error) *MockUnitSetAgentStatusCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // SetCharmURL mocks base method.
-func (m *MockUnit) SetCharmURL(arg0 string) error {
+func (m *MockUnit) SetCharmURL(arg0 context.Context, arg1 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetCharmURL", arg0)
+	ret := m.ctrl.Call(m, "SetCharmURL", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetCharmURL indicates an expected call of SetCharmURL.
-func (mr *MockUnitMockRecorder) SetCharmURL(arg0 any) *MockUnitSetCharmURLCall {
+func (mr *MockUnitMockRecorder) SetCharmURL(arg0, arg1 any) *MockUnitSetCharmURLCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCharmURL", reflect.TypeOf((*MockUnit)(nil).SetCharmURL), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCharmURL", reflect.TypeOf((*MockUnit)(nil).SetCharmURL), arg0, arg1)
 	return &MockUnitSetCharmURLCall{Call: call}
 }
 
@@ -1152,13 +1152,13 @@ func (c *MockUnitSetCharmURLCall) Return(arg0 error) *MockUnitSetCharmURLCall {
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockUnitSetCharmURLCall) Do(f func(string) error) *MockUnitSetCharmURLCall {
+func (c *MockUnitSetCharmURLCall) Do(f func(context.Context, string) error) *MockUnitSetCharmURLCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockUnitSetCharmURLCall) DoAndReturn(f func(string) error) *MockUnitSetCharmURLCall {
+func (c *MockUnitSetCharmURLCall) DoAndReturn(f func(context.Context, string) error) *MockUnitSetCharmURLCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1395,18 +1395,18 @@ func (c *MockUnitWatchCall) DoAndReturn(f func(context.Context) (watcher.Watcher
 }
 
 // WatchActionNotifications mocks base method.
-func (m *MockUnit) WatchActionNotifications() (watcher.Watcher[[]string], error) {
+func (m *MockUnit) WatchActionNotifications(arg0 context.Context) (watcher.Watcher[[]string], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchActionNotifications")
+	ret := m.ctrl.Call(m, "WatchActionNotifications", arg0)
 	ret0, _ := ret[0].(watcher.Watcher[[]string])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // WatchActionNotifications indicates an expected call of WatchActionNotifications.
-func (mr *MockUnitMockRecorder) WatchActionNotifications() *MockUnitWatchActionNotificationsCall {
+func (mr *MockUnitMockRecorder) WatchActionNotifications(arg0 any) *MockUnitWatchActionNotificationsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchActionNotifications", reflect.TypeOf((*MockUnit)(nil).WatchActionNotifications))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchActionNotifications", reflect.TypeOf((*MockUnit)(nil).WatchActionNotifications), arg0)
 	return &MockUnitWatchActionNotificationsCall{Call: call}
 }
 
@@ -1422,30 +1422,30 @@ func (c *MockUnitWatchActionNotificationsCall) Return(arg0 watcher.Watcher[[]str
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockUnitWatchActionNotificationsCall) Do(f func() (watcher.Watcher[[]string], error)) *MockUnitWatchActionNotificationsCall {
+func (c *MockUnitWatchActionNotificationsCall) Do(f func(context.Context) (watcher.Watcher[[]string], error)) *MockUnitWatchActionNotificationsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockUnitWatchActionNotificationsCall) DoAndReturn(f func() (watcher.Watcher[[]string], error)) *MockUnitWatchActionNotificationsCall {
+func (c *MockUnitWatchActionNotificationsCall) DoAndReturn(f func(context.Context) (watcher.Watcher[[]string], error)) *MockUnitWatchActionNotificationsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // WatchAddressesHash mocks base method.
-func (m *MockUnit) WatchAddressesHash() (watcher.Watcher[[]string], error) {
+func (m *MockUnit) WatchAddressesHash(arg0 context.Context) (watcher.Watcher[[]string], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchAddressesHash")
+	ret := m.ctrl.Call(m, "WatchAddressesHash", arg0)
 	ret0, _ := ret[0].(watcher.Watcher[[]string])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // WatchAddressesHash indicates an expected call of WatchAddressesHash.
-func (mr *MockUnitMockRecorder) WatchAddressesHash() *MockUnitWatchAddressesHashCall {
+func (mr *MockUnitMockRecorder) WatchAddressesHash(arg0 any) *MockUnitWatchAddressesHashCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchAddressesHash", reflect.TypeOf((*MockUnit)(nil).WatchAddressesHash))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchAddressesHash", reflect.TypeOf((*MockUnit)(nil).WatchAddressesHash), arg0)
 	return &MockUnitWatchAddressesHashCall{Call: call}
 }
 
@@ -1461,30 +1461,30 @@ func (c *MockUnitWatchAddressesHashCall) Return(arg0 watcher.Watcher[[]string], 
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockUnitWatchAddressesHashCall) Do(f func() (watcher.Watcher[[]string], error)) *MockUnitWatchAddressesHashCall {
+func (c *MockUnitWatchAddressesHashCall) Do(f func(context.Context) (watcher.Watcher[[]string], error)) *MockUnitWatchAddressesHashCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockUnitWatchAddressesHashCall) DoAndReturn(f func() (watcher.Watcher[[]string], error)) *MockUnitWatchAddressesHashCall {
+func (c *MockUnitWatchAddressesHashCall) DoAndReturn(f func(context.Context) (watcher.Watcher[[]string], error)) *MockUnitWatchAddressesHashCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // WatchConfigSettingsHash mocks base method.
-func (m *MockUnit) WatchConfigSettingsHash() (watcher.Watcher[[]string], error) {
+func (m *MockUnit) WatchConfigSettingsHash(arg0 context.Context) (watcher.Watcher[[]string], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchConfigSettingsHash")
+	ret := m.ctrl.Call(m, "WatchConfigSettingsHash", arg0)
 	ret0, _ := ret[0].(watcher.Watcher[[]string])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // WatchConfigSettingsHash indicates an expected call of WatchConfigSettingsHash.
-func (mr *MockUnitMockRecorder) WatchConfigSettingsHash() *MockUnitWatchConfigSettingsHashCall {
+func (mr *MockUnitMockRecorder) WatchConfigSettingsHash(arg0 any) *MockUnitWatchConfigSettingsHashCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchConfigSettingsHash", reflect.TypeOf((*MockUnit)(nil).WatchConfigSettingsHash))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchConfigSettingsHash", reflect.TypeOf((*MockUnit)(nil).WatchConfigSettingsHash), arg0)
 	return &MockUnitWatchConfigSettingsHashCall{Call: call}
 }
 
@@ -1500,30 +1500,30 @@ func (c *MockUnitWatchConfigSettingsHashCall) Return(arg0 watcher.Watcher[[]stri
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockUnitWatchConfigSettingsHashCall) Do(f func() (watcher.Watcher[[]string], error)) *MockUnitWatchConfigSettingsHashCall {
+func (c *MockUnitWatchConfigSettingsHashCall) Do(f func(context.Context) (watcher.Watcher[[]string], error)) *MockUnitWatchConfigSettingsHashCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockUnitWatchConfigSettingsHashCall) DoAndReturn(f func() (watcher.Watcher[[]string], error)) *MockUnitWatchConfigSettingsHashCall {
+func (c *MockUnitWatchConfigSettingsHashCall) DoAndReturn(f func(context.Context) (watcher.Watcher[[]string], error)) *MockUnitWatchConfigSettingsHashCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // WatchInstanceData mocks base method.
-func (m *MockUnit) WatchInstanceData() (watcher.Watcher[struct{}], error) {
+func (m *MockUnit) WatchInstanceData(arg0 context.Context) (watcher.Watcher[struct{}], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchInstanceData")
+	ret := m.ctrl.Call(m, "WatchInstanceData", arg0)
 	ret0, _ := ret[0].(watcher.Watcher[struct{}])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // WatchInstanceData indicates an expected call of WatchInstanceData.
-func (mr *MockUnitMockRecorder) WatchInstanceData() *MockUnitWatchInstanceDataCall {
+func (mr *MockUnitMockRecorder) WatchInstanceData(arg0 any) *MockUnitWatchInstanceDataCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchInstanceData", reflect.TypeOf((*MockUnit)(nil).WatchInstanceData))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchInstanceData", reflect.TypeOf((*MockUnit)(nil).WatchInstanceData), arg0)
 	return &MockUnitWatchInstanceDataCall{Call: call}
 }
 
@@ -1539,30 +1539,30 @@ func (c *MockUnitWatchInstanceDataCall) Return(arg0 watcher.Watcher[struct{}], a
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockUnitWatchInstanceDataCall) Do(f func() (watcher.Watcher[struct{}], error)) *MockUnitWatchInstanceDataCall {
+func (c *MockUnitWatchInstanceDataCall) Do(f func(context.Context) (watcher.Watcher[struct{}], error)) *MockUnitWatchInstanceDataCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockUnitWatchInstanceDataCall) DoAndReturn(f func() (watcher.Watcher[struct{}], error)) *MockUnitWatchInstanceDataCall {
+func (c *MockUnitWatchInstanceDataCall) DoAndReturn(f func(context.Context) (watcher.Watcher[struct{}], error)) *MockUnitWatchInstanceDataCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // WatchRelations mocks base method.
-func (m *MockUnit) WatchRelations() (watcher.Watcher[[]string], error) {
+func (m *MockUnit) WatchRelations(arg0 context.Context) (watcher.Watcher[[]string], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchRelations")
+	ret := m.ctrl.Call(m, "WatchRelations", arg0)
 	ret0, _ := ret[0].(watcher.Watcher[[]string])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // WatchRelations indicates an expected call of WatchRelations.
-func (mr *MockUnitMockRecorder) WatchRelations() *MockUnitWatchRelationsCall {
+func (mr *MockUnitMockRecorder) WatchRelations(arg0 any) *MockUnitWatchRelationsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchRelations", reflect.TypeOf((*MockUnit)(nil).WatchRelations))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchRelations", reflect.TypeOf((*MockUnit)(nil).WatchRelations), arg0)
 	return &MockUnitWatchRelationsCall{Call: call}
 }
 
@@ -1578,30 +1578,30 @@ func (c *MockUnitWatchRelationsCall) Return(arg0 watcher.Watcher[[]string], arg1
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockUnitWatchRelationsCall) Do(f func() (watcher.Watcher[[]string], error)) *MockUnitWatchRelationsCall {
+func (c *MockUnitWatchRelationsCall) Do(f func(context.Context) (watcher.Watcher[[]string], error)) *MockUnitWatchRelationsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockUnitWatchRelationsCall) DoAndReturn(f func() (watcher.Watcher[[]string], error)) *MockUnitWatchRelationsCall {
+func (c *MockUnitWatchRelationsCall) DoAndReturn(f func(context.Context) (watcher.Watcher[[]string], error)) *MockUnitWatchRelationsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // WatchStorage mocks base method.
-func (m *MockUnit) WatchStorage() (watcher.Watcher[[]string], error) {
+func (m *MockUnit) WatchStorage(arg0 context.Context) (watcher.Watcher[[]string], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchStorage")
+	ret := m.ctrl.Call(m, "WatchStorage", arg0)
 	ret0, _ := ret[0].(watcher.Watcher[[]string])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // WatchStorage indicates an expected call of WatchStorage.
-func (mr *MockUnitMockRecorder) WatchStorage() *MockUnitWatchStorageCall {
+func (mr *MockUnitMockRecorder) WatchStorage(arg0 any) *MockUnitWatchStorageCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchStorage", reflect.TypeOf((*MockUnit)(nil).WatchStorage))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchStorage", reflect.TypeOf((*MockUnit)(nil).WatchStorage), arg0)
 	return &MockUnitWatchStorageCall{Call: call}
 }
 
@@ -1617,30 +1617,30 @@ func (c *MockUnitWatchStorageCall) Return(arg0 watcher.Watcher[[]string], arg1 e
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockUnitWatchStorageCall) Do(f func() (watcher.Watcher[[]string], error)) *MockUnitWatchStorageCall {
+func (c *MockUnitWatchStorageCall) Do(f func(context.Context) (watcher.Watcher[[]string], error)) *MockUnitWatchStorageCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockUnitWatchStorageCall) DoAndReturn(f func() (watcher.Watcher[[]string], error)) *MockUnitWatchStorageCall {
+func (c *MockUnitWatchStorageCall) DoAndReturn(f func(context.Context) (watcher.Watcher[[]string], error)) *MockUnitWatchStorageCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // WatchTrustConfigSettingsHash mocks base method.
-func (m *MockUnit) WatchTrustConfigSettingsHash() (watcher.Watcher[[]string], error) {
+func (m *MockUnit) WatchTrustConfigSettingsHash(arg0 context.Context) (watcher.Watcher[[]string], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchTrustConfigSettingsHash")
+	ret := m.ctrl.Call(m, "WatchTrustConfigSettingsHash", arg0)
 	ret0, _ := ret[0].(watcher.Watcher[[]string])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // WatchTrustConfigSettingsHash indicates an expected call of WatchTrustConfigSettingsHash.
-func (mr *MockUnitMockRecorder) WatchTrustConfigSettingsHash() *MockUnitWatchTrustConfigSettingsHashCall {
+func (mr *MockUnitMockRecorder) WatchTrustConfigSettingsHash(arg0 any) *MockUnitWatchTrustConfigSettingsHashCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchTrustConfigSettingsHash", reflect.TypeOf((*MockUnit)(nil).WatchTrustConfigSettingsHash))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchTrustConfigSettingsHash", reflect.TypeOf((*MockUnit)(nil).WatchTrustConfigSettingsHash), arg0)
 	return &MockUnitWatchTrustConfigSettingsHashCall{Call: call}
 }
 
@@ -1656,13 +1656,13 @@ func (c *MockUnitWatchTrustConfigSettingsHashCall) Return(arg0 watcher.Watcher[[
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockUnitWatchTrustConfigSettingsHashCall) Do(f func() (watcher.Watcher[[]string], error)) *MockUnitWatchTrustConfigSettingsHashCall {
+func (c *MockUnitWatchTrustConfigSettingsHashCall) Do(f func(context.Context) (watcher.Watcher[[]string], error)) *MockUnitWatchTrustConfigSettingsHashCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockUnitWatchTrustConfigSettingsHashCall) DoAndReturn(f func() (watcher.Watcher[[]string], error)) *MockUnitWatchTrustConfigSettingsHashCall {
+func (c *MockUnitWatchTrustConfigSettingsHashCall) DoAndReturn(f func(context.Context) (watcher.Watcher[[]string], error)) *MockUnitWatchTrustConfigSettingsHashCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -2132,18 +2132,18 @@ func (m *MockRelationUnit) EXPECT() *MockRelationUnitMockRecorder {
 }
 
 // ApplicationSettings mocks base method.
-func (m *MockRelationUnit) ApplicationSettings() (*uniter.Settings, error) {
+func (m *MockRelationUnit) ApplicationSettings(arg0 context.Context) (*uniter.Settings, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ApplicationSettings")
+	ret := m.ctrl.Call(m, "ApplicationSettings", arg0)
 	ret0, _ := ret[0].(*uniter.Settings)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ApplicationSettings indicates an expected call of ApplicationSettings.
-func (mr *MockRelationUnitMockRecorder) ApplicationSettings() *MockRelationUnitApplicationSettingsCall {
+func (mr *MockRelationUnitMockRecorder) ApplicationSettings(arg0 any) *MockRelationUnitApplicationSettingsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplicationSettings", reflect.TypeOf((*MockRelationUnit)(nil).ApplicationSettings))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplicationSettings", reflect.TypeOf((*MockRelationUnit)(nil).ApplicationSettings), arg0)
 	return &MockRelationUnitApplicationSettingsCall{Call: call}
 }
 
@@ -2159,13 +2159,13 @@ func (c *MockRelationUnitApplicationSettingsCall) Return(arg0 *uniter.Settings, 
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockRelationUnitApplicationSettingsCall) Do(f func() (*uniter.Settings, error)) *MockRelationUnitApplicationSettingsCall {
+func (c *MockRelationUnitApplicationSettingsCall) Do(f func(context.Context) (*uniter.Settings, error)) *MockRelationUnitApplicationSettingsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockRelationUnitApplicationSettingsCall) DoAndReturn(f func() (*uniter.Settings, error)) *MockRelationUnitApplicationSettingsCall {
+func (c *MockRelationUnitApplicationSettingsCall) DoAndReturn(f func(context.Context) (*uniter.Settings, error)) *MockRelationUnitApplicationSettingsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -2209,17 +2209,17 @@ func (c *MockRelationUnitEndpointCall) DoAndReturn(f func() uniter.Endpoint) *Mo
 }
 
 // EnterScope mocks base method.
-func (m *MockRelationUnit) EnterScope() error {
+func (m *MockRelationUnit) EnterScope(arg0 context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnterScope")
+	ret := m.ctrl.Call(m, "EnterScope", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // EnterScope indicates an expected call of EnterScope.
-func (mr *MockRelationUnitMockRecorder) EnterScope() *MockRelationUnitEnterScopeCall {
+func (mr *MockRelationUnitMockRecorder) EnterScope(arg0 any) *MockRelationUnitEnterScopeCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnterScope", reflect.TypeOf((*MockRelationUnit)(nil).EnterScope))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnterScope", reflect.TypeOf((*MockRelationUnit)(nil).EnterScope), arg0)
 	return &MockRelationUnitEnterScopeCall{Call: call}
 }
 
@@ -2235,29 +2235,29 @@ func (c *MockRelationUnitEnterScopeCall) Return(arg0 error) *MockRelationUnitEnt
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockRelationUnitEnterScopeCall) Do(f func() error) *MockRelationUnitEnterScopeCall {
+func (c *MockRelationUnitEnterScopeCall) Do(f func(context.Context) error) *MockRelationUnitEnterScopeCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockRelationUnitEnterScopeCall) DoAndReturn(f func() error) *MockRelationUnitEnterScopeCall {
+func (c *MockRelationUnitEnterScopeCall) DoAndReturn(f func(context.Context) error) *MockRelationUnitEnterScopeCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // LeaveScope mocks base method.
-func (m *MockRelationUnit) LeaveScope() error {
+func (m *MockRelationUnit) LeaveScope(arg0 context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LeaveScope")
+	ret := m.ctrl.Call(m, "LeaveScope", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // LeaveScope indicates an expected call of LeaveScope.
-func (mr *MockRelationUnitMockRecorder) LeaveScope() *MockRelationUnitLeaveScopeCall {
+func (mr *MockRelationUnitMockRecorder) LeaveScope(arg0 any) *MockRelationUnitLeaveScopeCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LeaveScope", reflect.TypeOf((*MockRelationUnit)(nil).LeaveScope))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LeaveScope", reflect.TypeOf((*MockRelationUnit)(nil).LeaveScope), arg0)
 	return &MockRelationUnitLeaveScopeCall{Call: call}
 }
 
@@ -2273,30 +2273,30 @@ func (c *MockRelationUnitLeaveScopeCall) Return(arg0 error) *MockRelationUnitLea
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockRelationUnitLeaveScopeCall) Do(f func() error) *MockRelationUnitLeaveScopeCall {
+func (c *MockRelationUnitLeaveScopeCall) Do(f func(context.Context) error) *MockRelationUnitLeaveScopeCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockRelationUnitLeaveScopeCall) DoAndReturn(f func() error) *MockRelationUnitLeaveScopeCall {
+func (c *MockRelationUnitLeaveScopeCall) DoAndReturn(f func(context.Context) error) *MockRelationUnitLeaveScopeCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // ReadSettings mocks base method.
-func (m *MockRelationUnit) ReadSettings(arg0 string) (params.Settings, error) {
+func (m *MockRelationUnit) ReadSettings(arg0 context.Context, arg1 string) (params.Settings, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadSettings", arg0)
+	ret := m.ctrl.Call(m, "ReadSettings", arg0, arg1)
 	ret0, _ := ret[0].(params.Settings)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ReadSettings indicates an expected call of ReadSettings.
-func (mr *MockRelationUnitMockRecorder) ReadSettings(arg0 any) *MockRelationUnitReadSettingsCall {
+func (mr *MockRelationUnitMockRecorder) ReadSettings(arg0, arg1 any) *MockRelationUnitReadSettingsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadSettings", reflect.TypeOf((*MockRelationUnit)(nil).ReadSettings), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadSettings", reflect.TypeOf((*MockRelationUnit)(nil).ReadSettings), arg0, arg1)
 	return &MockRelationUnitReadSettingsCall{Call: call}
 }
 
@@ -2312,13 +2312,13 @@ func (c *MockRelationUnitReadSettingsCall) Return(arg0 params.Settings, arg1 err
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockRelationUnitReadSettingsCall) Do(f func(string) (params.Settings, error)) *MockRelationUnitReadSettingsCall {
+func (c *MockRelationUnitReadSettingsCall) Do(f func(context.Context, string) (params.Settings, error)) *MockRelationUnitReadSettingsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockRelationUnitReadSettingsCall) DoAndReturn(f func(string) (params.Settings, error)) *MockRelationUnitReadSettingsCall {
+func (c *MockRelationUnitReadSettingsCall) DoAndReturn(f func(context.Context, string) (params.Settings, error)) *MockRelationUnitReadSettingsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -2362,18 +2362,18 @@ func (c *MockRelationUnitRelationCall) DoAndReturn(f func() Relation) *MockRelat
 }
 
 // Settings mocks base method.
-func (m *MockRelationUnit) Settings() (*uniter.Settings, error) {
+func (m *MockRelationUnit) Settings(arg0 context.Context) (*uniter.Settings, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Settings")
+	ret := m.ctrl.Call(m, "Settings", arg0)
 	ret0, _ := ret[0].(*uniter.Settings)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Settings indicates an expected call of Settings.
-func (mr *MockRelationUnitMockRecorder) Settings() *MockRelationUnitSettingsCall {
+func (mr *MockRelationUnitMockRecorder) Settings(arg0 any) *MockRelationUnitSettingsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Settings", reflect.TypeOf((*MockRelationUnit)(nil).Settings))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Settings", reflect.TypeOf((*MockRelationUnit)(nil).Settings), arg0)
 	return &MockRelationUnitSettingsCall{Call: call}
 }
 
@@ -2389,13 +2389,13 @@ func (c *MockRelationUnitSettingsCall) Return(arg0 *uniter.Settings, arg1 error)
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockRelationUnitSettingsCall) Do(f func() (*uniter.Settings, error)) *MockRelationUnitSettingsCall {
+func (c *MockRelationUnitSettingsCall) Do(f func(context.Context) (*uniter.Settings, error)) *MockRelationUnitSettingsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockRelationUnitSettingsCall) DoAndReturn(f func() (*uniter.Settings, error)) *MockRelationUnitSettingsCall {
+func (c *MockRelationUnitSettingsCall) DoAndReturn(f func(context.Context) (*uniter.Settings, error)) *MockRelationUnitSettingsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -2424,18 +2424,18 @@ func (m *MockApplication) EXPECT() *MockApplicationMockRecorder {
 }
 
 // CharmModifiedVersion mocks base method.
-func (m *MockApplication) CharmModifiedVersion() (int, error) {
+func (m *MockApplication) CharmModifiedVersion(arg0 context.Context) (int, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CharmModifiedVersion")
+	ret := m.ctrl.Call(m, "CharmModifiedVersion", arg0)
 	ret0, _ := ret[0].(int)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CharmModifiedVersion indicates an expected call of CharmModifiedVersion.
-func (mr *MockApplicationMockRecorder) CharmModifiedVersion() *MockApplicationCharmModifiedVersionCall {
+func (mr *MockApplicationMockRecorder) CharmModifiedVersion(arg0 any) *MockApplicationCharmModifiedVersionCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CharmModifiedVersion", reflect.TypeOf((*MockApplication)(nil).CharmModifiedVersion))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CharmModifiedVersion", reflect.TypeOf((*MockApplication)(nil).CharmModifiedVersion), arg0)
 	return &MockApplicationCharmModifiedVersionCall{Call: call}
 }
 
@@ -2451,21 +2451,21 @@ func (c *MockApplicationCharmModifiedVersionCall) Return(arg0 int, arg1 error) *
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationCharmModifiedVersionCall) Do(f func() (int, error)) *MockApplicationCharmModifiedVersionCall {
+func (c *MockApplicationCharmModifiedVersionCall) Do(f func(context.Context) (int, error)) *MockApplicationCharmModifiedVersionCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationCharmModifiedVersionCall) DoAndReturn(f func() (int, error)) *MockApplicationCharmModifiedVersionCall {
+func (c *MockApplicationCharmModifiedVersionCall) DoAndReturn(f func(context.Context) (int, error)) *MockApplicationCharmModifiedVersionCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // CharmURL mocks base method.
-func (m *MockApplication) CharmURL() (string, bool, error) {
+func (m *MockApplication) CharmURL(arg0 context.Context) (string, bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CharmURL")
+	ret := m.ctrl.Call(m, "CharmURL", arg0)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(bool)
 	ret2, _ := ret[2].(error)
@@ -2473,9 +2473,9 @@ func (m *MockApplication) CharmURL() (string, bool, error) {
 }
 
 // CharmURL indicates an expected call of CharmURL.
-func (mr *MockApplicationMockRecorder) CharmURL() *MockApplicationCharmURLCall {
+func (mr *MockApplicationMockRecorder) CharmURL(arg0 any) *MockApplicationCharmURLCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CharmURL", reflect.TypeOf((*MockApplication)(nil).CharmURL))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CharmURL", reflect.TypeOf((*MockApplication)(nil).CharmURL), arg0)
 	return &MockApplicationCharmURLCall{Call: call}
 }
 
@@ -2491,13 +2491,13 @@ func (c *MockApplicationCharmURLCall) Return(arg0 string, arg1 bool, arg2 error)
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationCharmURLCall) Do(f func() (string, bool, error)) *MockApplicationCharmURLCall {
+func (c *MockApplicationCharmURLCall) Do(f func(context.Context) (string, bool, error)) *MockApplicationCharmURLCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationCharmURLCall) DoAndReturn(f func() (string, bool, error)) *MockApplicationCharmURLCall {
+func (c *MockApplicationCharmURLCall) DoAndReturn(f func(context.Context) (string, bool, error)) *MockApplicationCharmURLCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -2579,17 +2579,17 @@ func (c *MockApplicationRefreshCall) DoAndReturn(f func(context.Context) error) 
 }
 
 // SetStatus mocks base method.
-func (m *MockApplication) SetStatus(arg0 string, arg1 status.Status, arg2 string, arg3 map[string]any) error {
+func (m *MockApplication) SetStatus(arg0 context.Context, arg1 string, arg2 status.Status, arg3 string, arg4 map[string]any) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetStatus", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "SetStatus", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetStatus indicates an expected call of SetStatus.
-func (mr *MockApplicationMockRecorder) SetStatus(arg0, arg1, arg2, arg3 any) *MockApplicationSetStatusCall {
+func (mr *MockApplicationMockRecorder) SetStatus(arg0, arg1, arg2, arg3, arg4 any) *MockApplicationSetStatusCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetStatus", reflect.TypeOf((*MockApplication)(nil).SetStatus), arg0, arg1, arg2, arg3)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetStatus", reflect.TypeOf((*MockApplication)(nil).SetStatus), arg0, arg1, arg2, arg3, arg4)
 	return &MockApplicationSetStatusCall{Call: call}
 }
 
@@ -2605,30 +2605,30 @@ func (c *MockApplicationSetStatusCall) Return(arg0 error) *MockApplicationSetSta
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationSetStatusCall) Do(f func(string, status.Status, string, map[string]any) error) *MockApplicationSetStatusCall {
+func (c *MockApplicationSetStatusCall) Do(f func(context.Context, string, status.Status, string, map[string]any) error) *MockApplicationSetStatusCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationSetStatusCall) DoAndReturn(f func(string, status.Status, string, map[string]any) error) *MockApplicationSetStatusCall {
+func (c *MockApplicationSetStatusCall) DoAndReturn(f func(context.Context, string, status.Status, string, map[string]any) error) *MockApplicationSetStatusCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // Status mocks base method.
-func (m *MockApplication) Status(arg0 string) (params.ApplicationStatusResult, error) {
+func (m *MockApplication) Status(arg0 context.Context, arg1 string) (params.ApplicationStatusResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Status", arg0)
+	ret := m.ctrl.Call(m, "Status", arg0, arg1)
 	ret0, _ := ret[0].(params.ApplicationStatusResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Status indicates an expected call of Status.
-func (mr *MockApplicationMockRecorder) Status(arg0 any) *MockApplicationStatusCall {
+func (mr *MockApplicationMockRecorder) Status(arg0, arg1 any) *MockApplicationStatusCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Status", reflect.TypeOf((*MockApplication)(nil).Status), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Status", reflect.TypeOf((*MockApplication)(nil).Status), arg0, arg1)
 	return &MockApplicationStatusCall{Call: call}
 }
 
@@ -2644,13 +2644,13 @@ func (c *MockApplicationStatusCall) Return(arg0 params.ApplicationStatusResult, 
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationStatusCall) Do(f func(string) (params.ApplicationStatusResult, error)) *MockApplicationStatusCall {
+func (c *MockApplicationStatusCall) Do(f func(context.Context, string) (params.ApplicationStatusResult, error)) *MockApplicationStatusCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationStatusCall) DoAndReturn(f func(string) (params.ApplicationStatusResult, error)) *MockApplicationStatusCall {
+func (c *MockApplicationStatusCall) DoAndReturn(f func(context.Context, string) (params.ApplicationStatusResult, error)) *MockApplicationStatusCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -2733,18 +2733,18 @@ func (c *MockApplicationWatchCall) DoAndReturn(f func(context.Context) (watcher.
 }
 
 // WatchLeadershipSettings mocks base method.
-func (m *MockApplication) WatchLeadershipSettings() (watcher.Watcher[struct{}], error) {
+func (m *MockApplication) WatchLeadershipSettings(arg0 context.Context) (watcher.Watcher[struct{}], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchLeadershipSettings")
+	ret := m.ctrl.Call(m, "WatchLeadershipSettings", arg0)
 	ret0, _ := ret[0].(watcher.Watcher[struct{}])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // WatchLeadershipSettings indicates an expected call of WatchLeadershipSettings.
-func (mr *MockApplicationMockRecorder) WatchLeadershipSettings() *MockApplicationWatchLeadershipSettingsCall {
+func (mr *MockApplicationMockRecorder) WatchLeadershipSettings(arg0 any) *MockApplicationWatchLeadershipSettingsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchLeadershipSettings", reflect.TypeOf((*MockApplication)(nil).WatchLeadershipSettings))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchLeadershipSettings", reflect.TypeOf((*MockApplication)(nil).WatchLeadershipSettings), arg0)
 	return &MockApplicationWatchLeadershipSettingsCall{Call: call}
 }
 
@@ -2760,13 +2760,13 @@ func (c *MockApplicationWatchLeadershipSettingsCall) Return(arg0 watcher.Watcher
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationWatchLeadershipSettingsCall) Do(f func() (watcher.Watcher[struct{}], error)) *MockApplicationWatchLeadershipSettingsCall {
+func (c *MockApplicationWatchLeadershipSettingsCall) Do(f func(context.Context) (watcher.Watcher[struct{}], error)) *MockApplicationWatchLeadershipSettingsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationWatchLeadershipSettingsCall) DoAndReturn(f func() (watcher.Watcher[struct{}], error)) *MockApplicationWatchLeadershipSettingsCall {
+func (c *MockApplicationWatchLeadershipSettingsCall) DoAndReturn(f func(context.Context) (watcher.Watcher[struct{}], error)) *MockApplicationWatchLeadershipSettingsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -2795,18 +2795,18 @@ func (m *MockCharm) EXPECT() *MockCharmMockRecorder {
 }
 
 // ArchiveSha256 mocks base method.
-func (m *MockCharm) ArchiveSha256() (string, error) {
+func (m *MockCharm) ArchiveSha256(arg0 context.Context) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ArchiveSha256")
+	ret := m.ctrl.Call(m, "ArchiveSha256", arg0)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ArchiveSha256 indicates an expected call of ArchiveSha256.
-func (mr *MockCharmMockRecorder) ArchiveSha256() *MockCharmArchiveSha256Call {
+func (mr *MockCharmMockRecorder) ArchiveSha256(arg0 any) *MockCharmArchiveSha256Call {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ArchiveSha256", reflect.TypeOf((*MockCharm)(nil).ArchiveSha256))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ArchiveSha256", reflect.TypeOf((*MockCharm)(nil).ArchiveSha256), arg0)
 	return &MockCharmArchiveSha256Call{Call: call}
 }
 
@@ -2822,30 +2822,30 @@ func (c *MockCharmArchiveSha256Call) Return(arg0 string, arg1 error) *MockCharmA
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockCharmArchiveSha256Call) Do(f func() (string, error)) *MockCharmArchiveSha256Call {
+func (c *MockCharmArchiveSha256Call) Do(f func(context.Context) (string, error)) *MockCharmArchiveSha256Call {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockCharmArchiveSha256Call) DoAndReturn(f func() (string, error)) *MockCharmArchiveSha256Call {
+func (c *MockCharmArchiveSha256Call) DoAndReturn(f func(context.Context) (string, error)) *MockCharmArchiveSha256Call {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // LXDProfileRequired mocks base method.
-func (m *MockCharm) LXDProfileRequired() (bool, error) {
+func (m *MockCharm) LXDProfileRequired(arg0 context.Context) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LXDProfileRequired")
+	ret := m.ctrl.Call(m, "LXDProfileRequired", arg0)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // LXDProfileRequired indicates an expected call of LXDProfileRequired.
-func (mr *MockCharmMockRecorder) LXDProfileRequired() *MockCharmLXDProfileRequiredCall {
+func (mr *MockCharmMockRecorder) LXDProfileRequired(arg0 any) *MockCharmLXDProfileRequiredCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LXDProfileRequired", reflect.TypeOf((*MockCharm)(nil).LXDProfileRequired))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LXDProfileRequired", reflect.TypeOf((*MockCharm)(nil).LXDProfileRequired), arg0)
 	return &MockCharmLXDProfileRequiredCall{Call: call}
 }
 
@@ -2861,13 +2861,13 @@ func (c *MockCharmLXDProfileRequiredCall) Return(arg0 bool, arg1 error) *MockCha
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockCharmLXDProfileRequiredCall) Do(f func() (bool, error)) *MockCharmLXDProfileRequiredCall {
+func (c *MockCharmLXDProfileRequiredCall) Do(f func(context.Context) (bool, error)) *MockCharmLXDProfileRequiredCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockCharmLXDProfileRequiredCall) DoAndReturn(f func() (bool, error)) *MockCharmLXDProfileRequiredCall {
+func (c *MockCharmLXDProfileRequiredCall) DoAndReturn(f func(context.Context) (bool, error)) *MockCharmLXDProfileRequiredCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/uniter/api/interface.go
+++ b/internal/worker/uniter/api/interface.go
@@ -4,7 +4,7 @@
 package api
 
 import (
-	stdcontext "context"
+	context "context"
 
 	"github.com/juju/names/v5"
 
@@ -25,7 +25,7 @@ import (
 // ProviderIDGetter defines the API to get provider ID.
 type ProviderIDGetter interface {
 	ProviderID() string
-	Refresh(ctx stdcontext.Context) error
+	Refresh(ctx context.Context) error
 	Name() string
 }
 
@@ -33,129 +33,129 @@ type ProviderIDGetter interface {
 type Unit interface {
 	ProviderIDGetter
 	Life() life.Value
-	Refresh(stdcontext.Context) error
+	Refresh(context.Context) error
 	ApplicationTag() names.ApplicationTag
-	EnsureDead() error
-	ClearResolved() error
-	DestroyAllSubordinates() error
-	HasSubordinates() (bool, error)
-	LXDProfileName() (string, error)
-	CanApplyLXDProfile() (bool, error)
-	CharmURL() (string, error)
-	Watch(stdcontext.Context) (watcher.NotifyWatcher, error)
+	EnsureDead(context.Context) error
+	ClearResolved(context.Context) error
+	DestroyAllSubordinates(context.Context) error
+	HasSubordinates(context.Context) (bool, error)
+	LXDProfileName(context.Context) (string, error)
+	CanApplyLXDProfile(context.Context) (bool, error)
+	CharmURL(context.Context) (string, error)
+	Watch(context.Context) (watcher.NotifyWatcher, error)
 
 	// Used by runner.context.
 
 	ApplicationName() string
-	ConfigSettings() (charm.Settings, error)
-	LogActionMessage(names.ActionTag, string) error
+	ConfigSettings(context.Context) (charm.Settings, error)
+	LogActionMessage(context.Context, names.ActionTag, string) error
 	Name() string
-	NetworkInfo(bindings []string, relationId *int) (map[string]params.NetworkInfoResult, error)
-	RequestReboot() error
-	SetUnitStatus(ctx stdcontext.Context, unitStatus status.Status, info string, data map[string]interface{}) error
-	SetAgentStatus(agentStatus status.Status, info string, data map[string]interface{}) error
-	State(ctx stdcontext.Context) (params.UnitStateResult, error)
-	SetState(ctx stdcontext.Context, unitState params.SetUnitStateArg) error
+	NetworkInfo(ctx context.Context, bindings []string, relationId *int) (map[string]params.NetworkInfoResult, error)
+	RequestReboot(context.Context) error
+	SetUnitStatus(ctx context.Context, unitStatus status.Status, info string, data map[string]interface{}) error
+	SetAgentStatus(ctx context.Context, agentStatus status.Status, info string, data map[string]interface{}) error
+	State(ctx context.Context) (params.UnitStateResult, error)
+	SetState(ctx context.Context, unitState params.SetUnitStateArg) error
 	Tag() names.UnitTag
-	UnitStatus(stdcontext.Context) (params.StatusResult, error)
-	CommitHookChanges(params.CommitHookChangesArgs) error
-	PublicAddress() (string, error)
-	PrincipalName() (string, bool, error)
-	AssignedMachine() (names.MachineTag, error)
-	AvailabilityZone() (string, error)
-	PrivateAddress() (string, error)
+	UnitStatus(context.Context) (params.StatusResult, error)
+	CommitHookChanges(context.Context, params.CommitHookChangesArgs) error
+	PublicAddress(context.Context) (string, error)
+	PrincipalName(context.Context) (string, bool, error)
+	AssignedMachine(context.Context) (names.MachineTag, error)
+	AvailabilityZone(context.Context) (string, error)
+	PrivateAddress(context.Context) (string, error)
 	Resolved() params.ResolvedMode
 
 	// Used by remotestate watcher.
 
-	WatchConfigSettingsHash() (watcher.StringsWatcher, error)
-	WatchTrustConfigSettingsHash() (watcher.StringsWatcher, error)
-	WatchRelations() (watcher.StringsWatcher, error)
-	WatchAddressesHash() (watcher.StringsWatcher, error)
-	WatchActionNotifications() (watcher.StringsWatcher, error)
-	WatchStorage() (watcher.StringsWatcher, error)
-	WatchInstanceData() (watcher.NotifyWatcher, error)
+	WatchConfigSettingsHash(context.Context) (watcher.StringsWatcher, error)
+	WatchTrustConfigSettingsHash(context.Context) (watcher.StringsWatcher, error)
+	WatchRelations(context.Context) (watcher.StringsWatcher, error)
+	WatchAddressesHash(context.Context) (watcher.StringsWatcher, error)
+	WatchActionNotifications(context.Context) (watcher.StringsWatcher, error)
+	WatchStorage(context.Context) (watcher.StringsWatcher, error)
+	WatchInstanceData(context.Context) (watcher.NotifyWatcher, error)
 
 	// Used by relationer.
 
-	Application(stdcontext.Context) (Application, error)
-	RelationsStatus() ([]uniter.RelationStatus, error)
-	Destroy() error
+	Application(context.Context) (Application, error)
+	RelationsStatus(context.Context) ([]uniter.RelationStatus, error)
+	Destroy(context.Context) error
 
 	// Used by operation.Callbacks.
 
-	SetCharmURL(curl string) error
+	SetCharmURL(ctx context.Context, curl string) error
 }
 
 // Application defines the methods on uniter.api.Application.
 type Application interface {
 	Life() life.Value
 	Tag() names.ApplicationTag
-	Status(unitName string) (params.ApplicationStatusResult, error)
-	SetStatus(unitName string, appStatus status.Status, info string, data map[string]interface{}) error
-	CharmModifiedVersion() (int, error)
-	CharmURL() (string, bool, error)
+	Status(ctx context.Context, unitName string) (params.ApplicationStatusResult, error)
+	SetStatus(ctx context.Context, unitName string, appStatus status.Status, info string, data map[string]interface{}) error
+	CharmModifiedVersion(context.Context) (int, error)
+	CharmURL(context.Context) (string, bool, error)
 
 	// Used by remotestate watcher.
 
-	WatchLeadershipSettings() (watcher.NotifyWatcher, error)
-	Watch(ctx stdcontext.Context) (watcher.NotifyWatcher, error)
-	Refresh(stdcontext.Context) error
+	WatchLeadershipSettings(context.Context) (watcher.NotifyWatcher, error)
+	Watch(context.Context) (watcher.NotifyWatcher, error)
+	Refresh(context.Context) error
 }
 
 // Relation defines the methods on uniter.api.Relation.
 type Relation interface {
-	Endpoint(stdcontext.Context) (*uniter.Endpoint, error)
+	Endpoint(context.Context) (*uniter.Endpoint, error)
 	Id() int
 	Life() life.Value
 	OtherApplication() string
-	Refresh(stdcontext.Context) error
-	SetStatus(ctx stdcontext.Context, status2 relation.Status) error
+	Refresh(context.Context) error
+	SetStatus(ctx context.Context, status2 relation.Status) error
 	String() string
 	Suspended() bool
 	Tag() names.RelationTag
-	Unit(stdcontext.Context, names.UnitTag) (RelationUnit, error)
+	Unit(context.Context, names.UnitTag) (RelationUnit, error)
 	UpdateSuspended(bool)
 }
 
 // RelationUnit defines the methods on uniter.api.RelationUnit.
 type RelationUnit interface {
-	ApplicationSettings() (*uniter.Settings, error)
+	ApplicationSettings(context.Context) (*uniter.Settings, error)
 	Endpoint() uniter.Endpoint
-	EnterScope() error
-	LeaveScope() error
+	EnterScope(context.Context) error
+	LeaveScope(context.Context) error
 	Relation() Relation
-	ReadSettings(name string) (params.Settings, error)
-	Settings() (*uniter.Settings, error)
+	ReadSettings(ctx context.Context, name string) (params.Settings, error)
+	Settings(context.Context) (*uniter.Settings, error)
 }
 
 // Charm defines the methods on uniter.api.Charm.
 type Charm interface {
 	URL() string
-	LXDProfileRequired() (bool, error)
-	ArchiveSha256() (string, error)
+	LXDProfileRequired(context.Context) (bool, error)
+	ArchiveSha256(context.Context) (string, error)
 }
 
 // SecretsAccessor is used by the hook context to access the secrets backend.
 type SecretsAccessor interface {
-	CreateSecretURIs(int) ([]*secrets.URI, error)
-	SecretMetadata() ([]secrets.SecretOwnerMetadata, error)
-	SecretRotated(uri string, oldRevision int) error
+	CreateSecretURIs(context.Context, int) ([]*secrets.URI, error)
+	SecretMetadata(context.Context) ([]secrets.SecretOwnerMetadata, error)
+	SecretRotated(ctx context.Context, uri string, oldRevision int) error
 }
 
 // SecretsWatcher is used by the remote state watcher.
 type SecretsWatcher interface {
-	WatchConsumedSecretsChanges(unitName string) (watcher.StringsWatcher, error)
-	GetConsumerSecretsRevisionInfo(string, []string) (map[string]secrets.SecretRevisionInfo, error)
-	WatchObsolete(ownerTags ...names.Tag) (watcher.StringsWatcher, error)
+	WatchConsumedSecretsChanges(ctx context.Context, unitName string) (watcher.StringsWatcher, error)
+	GetConsumerSecretsRevisionInfo(context.Context, string, []string) (map[string]secrets.SecretRevisionInfo, error)
+	WatchObsolete(ctx context.Context, ownerTags ...names.Tag) (watcher.StringsWatcher, error)
 }
 
 // SecretsBackend provides access to a secrets backend.
 type SecretsBackend interface {
-	GetContent(uri *secrets.URI, label string, refresh, peek bool) (secrets.SecretValue, error)
-	SaveContent(uri *secrets.URI, revision int, value secrets.SecretValue) (secrets.ValueRef, error)
-	DeleteContent(uri *secrets.URI, revision int) error
-	DeleteExternalContent(ref secrets.ValueRef) error
+	GetContent(ctx context.Context, uri *secrets.URI, label string, refresh, peek bool) (secrets.SecretValue, error)
+	SaveContent(ctx context.Context, uri *secrets.URI, revision int, value secrets.SecretValue) (secrets.ValueRef, error)
+	DeleteContent(ctx context.Context, uri *secrets.URI, revision int) error
+	DeleteExternalContent(ctx context.Context, ref secrets.ValueRef) error
 }
 
 // SecretsClient provides access to the secrets manager facade.
@@ -167,8 +167,8 @@ type SecretsClient interface {
 // StorageAccessor is an interface for accessing information about
 // storage attachments.
 type StorageAccessor interface {
-	StorageAttachment(names.StorageTag, names.UnitTag) (params.StorageAttachment, error)
-	UnitStorageAttachments(names.UnitTag) ([]params.StorageAttachmentId, error)
-	DestroyUnitStorageAttachments(names.UnitTag) error
-	RemoveStorageAttachment(names.StorageTag, names.UnitTag) error
+	StorageAttachment(context.Context, names.StorageTag, names.UnitTag) (params.StorageAttachment, error)
+	UnitStorageAttachments(context.Context, names.UnitTag) ([]params.StorageAttachmentId, error)
+	DestroyUnitStorageAttachments(context.Context, names.UnitTag) error
+	RemoveStorageAttachment(context.Context, names.StorageTag, names.UnitTag) error
 }

--- a/internal/worker/uniter/api/interface_generics.go
+++ b/internal/worker/uniter/api/interface_generics.go
@@ -30,8 +30,6 @@ type UniterClient interface {
 	RelationById(context.Context, int) (Relation, error)
 	Model(context.Context) (*types.Model, error)
 	ModelConfig(context.Context) (*config.Config, error)
-	UnitStorageAttachments(unitTag names.UnitTag) ([]params.StorageAttachmentId, error)
-	StorageAttachment(storageTag names.StorageTag, unitTag names.UnitTag) (params.StorageAttachment, error)
 	GoalState(context.Context) (application.GoalState, error)
 	CloudSpec(context.Context) (*params.CloudSpec, error)
 	ActionBegin(ctx context.Context, tag names.ActionTag) error
@@ -44,8 +42,8 @@ type UniterClient interface {
 	CloudAPIVersion(context.Context) (string, error)
 	APIAddresses(context.Context) ([]string, error)
 	WatchRelationUnits(context.Context, names.RelationTag, names.UnitTag) (watcher.RelationUnitsWatcher, error)
-	WatchStorageAttachment(names.StorageTag, names.UnitTag) (watcher.NotifyWatcher, error)
+	WatchStorageAttachment(context.Context, names.StorageTag, names.UnitTag) (watcher.NotifyWatcher, error)
 	WatchUpdateStatusHookInterval(context.Context) (watcher.NotifyWatcher, error)
 	UpdateStatusHookInterval(context.Context) (time.Duration, error)
-	StorageAttachmentLife([]params.StorageAttachmentId) ([]params.LifeResult, error)
+	StorageAttachmentLife(context.Context, []params.StorageAttachmentId) ([]params.LifeResult, error)
 }

--- a/internal/worker/uniter/api/secrets_mocks.go
+++ b/internal/worker/uniter/api/secrets_mocks.go
@@ -10,6 +10,7 @@
 package api
 
 import (
+	context "context"
 	reflect "reflect"
 
 	secrets "github.com/juju/juju/core/secrets"
@@ -42,18 +43,18 @@ func (m *MockSecretsClient) EXPECT() *MockSecretsClientMockRecorder {
 }
 
 // CreateSecretURIs mocks base method.
-func (m *MockSecretsClient) CreateSecretURIs(arg0 int) ([]*secrets.URI, error) {
+func (m *MockSecretsClient) CreateSecretURIs(arg0 context.Context, arg1 int) ([]*secrets.URI, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateSecretURIs", arg0)
+	ret := m.ctrl.Call(m, "CreateSecretURIs", arg0, arg1)
 	ret0, _ := ret[0].([]*secrets.URI)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateSecretURIs indicates an expected call of CreateSecretURIs.
-func (mr *MockSecretsClientMockRecorder) CreateSecretURIs(arg0 any) *MockSecretsClientCreateSecretURIsCall {
+func (mr *MockSecretsClientMockRecorder) CreateSecretURIs(arg0, arg1 any) *MockSecretsClientCreateSecretURIsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSecretURIs", reflect.TypeOf((*MockSecretsClient)(nil).CreateSecretURIs), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSecretURIs", reflect.TypeOf((*MockSecretsClient)(nil).CreateSecretURIs), arg0, arg1)
 	return &MockSecretsClientCreateSecretURIsCall{Call: call}
 }
 
@@ -69,30 +70,30 @@ func (c *MockSecretsClientCreateSecretURIsCall) Return(arg0 []*secrets.URI, arg1
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSecretsClientCreateSecretURIsCall) Do(f func(int) ([]*secrets.URI, error)) *MockSecretsClientCreateSecretURIsCall {
+func (c *MockSecretsClientCreateSecretURIsCall) Do(f func(context.Context, int) ([]*secrets.URI, error)) *MockSecretsClientCreateSecretURIsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSecretsClientCreateSecretURIsCall) DoAndReturn(f func(int) ([]*secrets.URI, error)) *MockSecretsClientCreateSecretURIsCall {
+func (c *MockSecretsClientCreateSecretURIsCall) DoAndReturn(f func(context.Context, int) ([]*secrets.URI, error)) *MockSecretsClientCreateSecretURIsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetConsumerSecretsRevisionInfo mocks base method.
-func (m *MockSecretsClient) GetConsumerSecretsRevisionInfo(arg0 string, arg1 []string) (map[string]secrets.SecretRevisionInfo, error) {
+func (m *MockSecretsClient) GetConsumerSecretsRevisionInfo(arg0 context.Context, arg1 string, arg2 []string) (map[string]secrets.SecretRevisionInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetConsumerSecretsRevisionInfo", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetConsumerSecretsRevisionInfo", arg0, arg1, arg2)
 	ret0, _ := ret[0].(map[string]secrets.SecretRevisionInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetConsumerSecretsRevisionInfo indicates an expected call of GetConsumerSecretsRevisionInfo.
-func (mr *MockSecretsClientMockRecorder) GetConsumerSecretsRevisionInfo(arg0, arg1 any) *MockSecretsClientGetConsumerSecretsRevisionInfoCall {
+func (mr *MockSecretsClientMockRecorder) GetConsumerSecretsRevisionInfo(arg0, arg1, arg2 any) *MockSecretsClientGetConsumerSecretsRevisionInfoCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConsumerSecretsRevisionInfo", reflect.TypeOf((*MockSecretsClient)(nil).GetConsumerSecretsRevisionInfo), arg0, arg1)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConsumerSecretsRevisionInfo", reflect.TypeOf((*MockSecretsClient)(nil).GetConsumerSecretsRevisionInfo), arg0, arg1, arg2)
 	return &MockSecretsClientGetConsumerSecretsRevisionInfoCall{Call: call}
 }
 
@@ -108,30 +109,30 @@ func (c *MockSecretsClientGetConsumerSecretsRevisionInfoCall) Return(arg0 map[st
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSecretsClientGetConsumerSecretsRevisionInfoCall) Do(f func(string, []string) (map[string]secrets.SecretRevisionInfo, error)) *MockSecretsClientGetConsumerSecretsRevisionInfoCall {
+func (c *MockSecretsClientGetConsumerSecretsRevisionInfoCall) Do(f func(context.Context, string, []string) (map[string]secrets.SecretRevisionInfo, error)) *MockSecretsClientGetConsumerSecretsRevisionInfoCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSecretsClientGetConsumerSecretsRevisionInfoCall) DoAndReturn(f func(string, []string) (map[string]secrets.SecretRevisionInfo, error)) *MockSecretsClientGetConsumerSecretsRevisionInfoCall {
+func (c *MockSecretsClientGetConsumerSecretsRevisionInfoCall) DoAndReturn(f func(context.Context, string, []string) (map[string]secrets.SecretRevisionInfo, error)) *MockSecretsClientGetConsumerSecretsRevisionInfoCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // SecretMetadata mocks base method.
-func (m *MockSecretsClient) SecretMetadata() ([]secrets.SecretOwnerMetadata, error) {
+func (m *MockSecretsClient) SecretMetadata(arg0 context.Context) ([]secrets.SecretOwnerMetadata, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SecretMetadata")
+	ret := m.ctrl.Call(m, "SecretMetadata", arg0)
 	ret0, _ := ret[0].([]secrets.SecretOwnerMetadata)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // SecretMetadata indicates an expected call of SecretMetadata.
-func (mr *MockSecretsClientMockRecorder) SecretMetadata() *MockSecretsClientSecretMetadataCall {
+func (mr *MockSecretsClientMockRecorder) SecretMetadata(arg0 any) *MockSecretsClientSecretMetadataCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SecretMetadata", reflect.TypeOf((*MockSecretsClient)(nil).SecretMetadata))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SecretMetadata", reflect.TypeOf((*MockSecretsClient)(nil).SecretMetadata), arg0)
 	return &MockSecretsClientSecretMetadataCall{Call: call}
 }
 
@@ -147,29 +148,29 @@ func (c *MockSecretsClientSecretMetadataCall) Return(arg0 []secrets.SecretOwnerM
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSecretsClientSecretMetadataCall) Do(f func() ([]secrets.SecretOwnerMetadata, error)) *MockSecretsClientSecretMetadataCall {
+func (c *MockSecretsClientSecretMetadataCall) Do(f func(context.Context) ([]secrets.SecretOwnerMetadata, error)) *MockSecretsClientSecretMetadataCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSecretsClientSecretMetadataCall) DoAndReturn(f func() ([]secrets.SecretOwnerMetadata, error)) *MockSecretsClientSecretMetadataCall {
+func (c *MockSecretsClientSecretMetadataCall) DoAndReturn(f func(context.Context) ([]secrets.SecretOwnerMetadata, error)) *MockSecretsClientSecretMetadataCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // SecretRotated mocks base method.
-func (m *MockSecretsClient) SecretRotated(arg0 string, arg1 int) error {
+func (m *MockSecretsClient) SecretRotated(arg0 context.Context, arg1 string, arg2 int) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SecretRotated", arg0, arg1)
+	ret := m.ctrl.Call(m, "SecretRotated", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SecretRotated indicates an expected call of SecretRotated.
-func (mr *MockSecretsClientMockRecorder) SecretRotated(arg0, arg1 any) *MockSecretsClientSecretRotatedCall {
+func (mr *MockSecretsClientMockRecorder) SecretRotated(arg0, arg1, arg2 any) *MockSecretsClientSecretRotatedCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SecretRotated", reflect.TypeOf((*MockSecretsClient)(nil).SecretRotated), arg0, arg1)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SecretRotated", reflect.TypeOf((*MockSecretsClient)(nil).SecretRotated), arg0, arg1, arg2)
 	return &MockSecretsClientSecretRotatedCall{Call: call}
 }
 
@@ -185,30 +186,30 @@ func (c *MockSecretsClientSecretRotatedCall) Return(arg0 error) *MockSecretsClie
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSecretsClientSecretRotatedCall) Do(f func(string, int) error) *MockSecretsClientSecretRotatedCall {
+func (c *MockSecretsClientSecretRotatedCall) Do(f func(context.Context, string, int) error) *MockSecretsClientSecretRotatedCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSecretsClientSecretRotatedCall) DoAndReturn(f func(string, int) error) *MockSecretsClientSecretRotatedCall {
+func (c *MockSecretsClientSecretRotatedCall) DoAndReturn(f func(context.Context, string, int) error) *MockSecretsClientSecretRotatedCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // WatchConsumedSecretsChanges mocks base method.
-func (m *MockSecretsClient) WatchConsumedSecretsChanges(arg0 string) (watcher.Watcher[[]string], error) {
+func (m *MockSecretsClient) WatchConsumedSecretsChanges(arg0 context.Context, arg1 string) (watcher.Watcher[[]string], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchConsumedSecretsChanges", arg0)
+	ret := m.ctrl.Call(m, "WatchConsumedSecretsChanges", arg0, arg1)
 	ret0, _ := ret[0].(watcher.Watcher[[]string])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // WatchConsumedSecretsChanges indicates an expected call of WatchConsumedSecretsChanges.
-func (mr *MockSecretsClientMockRecorder) WatchConsumedSecretsChanges(arg0 any) *MockSecretsClientWatchConsumedSecretsChangesCall {
+func (mr *MockSecretsClientMockRecorder) WatchConsumedSecretsChanges(arg0, arg1 any) *MockSecretsClientWatchConsumedSecretsChangesCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchConsumedSecretsChanges", reflect.TypeOf((*MockSecretsClient)(nil).WatchConsumedSecretsChanges), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchConsumedSecretsChanges", reflect.TypeOf((*MockSecretsClient)(nil).WatchConsumedSecretsChanges), arg0, arg1)
 	return &MockSecretsClientWatchConsumedSecretsChangesCall{Call: call}
 }
 
@@ -224,22 +225,22 @@ func (c *MockSecretsClientWatchConsumedSecretsChangesCall) Return(arg0 watcher.W
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSecretsClientWatchConsumedSecretsChangesCall) Do(f func(string) (watcher.Watcher[[]string], error)) *MockSecretsClientWatchConsumedSecretsChangesCall {
+func (c *MockSecretsClientWatchConsumedSecretsChangesCall) Do(f func(context.Context, string) (watcher.Watcher[[]string], error)) *MockSecretsClientWatchConsumedSecretsChangesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSecretsClientWatchConsumedSecretsChangesCall) DoAndReturn(f func(string) (watcher.Watcher[[]string], error)) *MockSecretsClientWatchConsumedSecretsChangesCall {
+func (c *MockSecretsClientWatchConsumedSecretsChangesCall) DoAndReturn(f func(context.Context, string) (watcher.Watcher[[]string], error)) *MockSecretsClientWatchConsumedSecretsChangesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // WatchObsolete mocks base method.
-func (m *MockSecretsClient) WatchObsolete(arg0 ...names.Tag) (watcher.Watcher[[]string], error) {
+func (m *MockSecretsClient) WatchObsolete(arg0 context.Context, arg1 ...names.Tag) (watcher.Watcher[[]string], error) {
 	m.ctrl.T.Helper()
-	varargs := []any{}
-	for _, a := range arg0 {
+	varargs := []any{arg0}
+	for _, a := range arg1 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "WatchObsolete", varargs...)
@@ -249,9 +250,10 @@ func (m *MockSecretsClient) WatchObsolete(arg0 ...names.Tag) (watcher.Watcher[[]
 }
 
 // WatchObsolete indicates an expected call of WatchObsolete.
-func (mr *MockSecretsClientMockRecorder) WatchObsolete(arg0 ...any) *MockSecretsClientWatchObsoleteCall {
+func (mr *MockSecretsClientMockRecorder) WatchObsolete(arg0 any, arg1 ...any) *MockSecretsClientWatchObsoleteCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchObsolete", reflect.TypeOf((*MockSecretsClient)(nil).WatchObsolete), arg0...)
+	varargs := append([]any{arg0}, arg1...)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchObsolete", reflect.TypeOf((*MockSecretsClient)(nil).WatchObsolete), varargs...)
 	return &MockSecretsClientWatchObsoleteCall{Call: call}
 }
 
@@ -267,13 +269,13 @@ func (c *MockSecretsClientWatchObsoleteCall) Return(arg0 watcher.Watcher[[]strin
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSecretsClientWatchObsoleteCall) Do(f func(...names.Tag) (watcher.Watcher[[]string], error)) *MockSecretsClientWatchObsoleteCall {
+func (c *MockSecretsClientWatchObsoleteCall) Do(f func(context.Context, ...names.Tag) (watcher.Watcher[[]string], error)) *MockSecretsClientWatchObsoleteCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSecretsClientWatchObsoleteCall) DoAndReturn(f func(...names.Tag) (watcher.Watcher[[]string], error)) *MockSecretsClientWatchObsoleteCall {
+func (c *MockSecretsClientWatchObsoleteCall) DoAndReturn(f func(context.Context, ...names.Tag) (watcher.Watcher[[]string], error)) *MockSecretsClientWatchObsoleteCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -302,17 +304,17 @@ func (m *MockSecretsBackend) EXPECT() *MockSecretsBackendMockRecorder {
 }
 
 // DeleteContent mocks base method.
-func (m *MockSecretsBackend) DeleteContent(arg0 *secrets.URI, arg1 int) error {
+func (m *MockSecretsBackend) DeleteContent(arg0 context.Context, arg1 *secrets.URI, arg2 int) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteContent", arg0, arg1)
+	ret := m.ctrl.Call(m, "DeleteContent", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteContent indicates an expected call of DeleteContent.
-func (mr *MockSecretsBackendMockRecorder) DeleteContent(arg0, arg1 any) *MockSecretsBackendDeleteContentCall {
+func (mr *MockSecretsBackendMockRecorder) DeleteContent(arg0, arg1, arg2 any) *MockSecretsBackendDeleteContentCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteContent", reflect.TypeOf((*MockSecretsBackend)(nil).DeleteContent), arg0, arg1)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteContent", reflect.TypeOf((*MockSecretsBackend)(nil).DeleteContent), arg0, arg1, arg2)
 	return &MockSecretsBackendDeleteContentCall{Call: call}
 }
 
@@ -328,29 +330,29 @@ func (c *MockSecretsBackendDeleteContentCall) Return(arg0 error) *MockSecretsBac
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSecretsBackendDeleteContentCall) Do(f func(*secrets.URI, int) error) *MockSecretsBackendDeleteContentCall {
+func (c *MockSecretsBackendDeleteContentCall) Do(f func(context.Context, *secrets.URI, int) error) *MockSecretsBackendDeleteContentCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSecretsBackendDeleteContentCall) DoAndReturn(f func(*secrets.URI, int) error) *MockSecretsBackendDeleteContentCall {
+func (c *MockSecretsBackendDeleteContentCall) DoAndReturn(f func(context.Context, *secrets.URI, int) error) *MockSecretsBackendDeleteContentCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // DeleteExternalContent mocks base method.
-func (m *MockSecretsBackend) DeleteExternalContent(arg0 secrets.ValueRef) error {
+func (m *MockSecretsBackend) DeleteExternalContent(arg0 context.Context, arg1 secrets.ValueRef) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteExternalContent", arg0)
+	ret := m.ctrl.Call(m, "DeleteExternalContent", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteExternalContent indicates an expected call of DeleteExternalContent.
-func (mr *MockSecretsBackendMockRecorder) DeleteExternalContent(arg0 any) *MockSecretsBackendDeleteExternalContentCall {
+func (mr *MockSecretsBackendMockRecorder) DeleteExternalContent(arg0, arg1 any) *MockSecretsBackendDeleteExternalContentCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteExternalContent", reflect.TypeOf((*MockSecretsBackend)(nil).DeleteExternalContent), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteExternalContent", reflect.TypeOf((*MockSecretsBackend)(nil).DeleteExternalContent), arg0, arg1)
 	return &MockSecretsBackendDeleteExternalContentCall{Call: call}
 }
 
@@ -366,30 +368,30 @@ func (c *MockSecretsBackendDeleteExternalContentCall) Return(arg0 error) *MockSe
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSecretsBackendDeleteExternalContentCall) Do(f func(secrets.ValueRef) error) *MockSecretsBackendDeleteExternalContentCall {
+func (c *MockSecretsBackendDeleteExternalContentCall) Do(f func(context.Context, secrets.ValueRef) error) *MockSecretsBackendDeleteExternalContentCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSecretsBackendDeleteExternalContentCall) DoAndReturn(f func(secrets.ValueRef) error) *MockSecretsBackendDeleteExternalContentCall {
+func (c *MockSecretsBackendDeleteExternalContentCall) DoAndReturn(f func(context.Context, secrets.ValueRef) error) *MockSecretsBackendDeleteExternalContentCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetContent mocks base method.
-func (m *MockSecretsBackend) GetContent(arg0 *secrets.URI, arg1 string, arg2, arg3 bool) (secrets.SecretValue, error) {
+func (m *MockSecretsBackend) GetContent(arg0 context.Context, arg1 *secrets.URI, arg2 string, arg3, arg4 bool) (secrets.SecretValue, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetContent", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "GetContent", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(secrets.SecretValue)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetContent indicates an expected call of GetContent.
-func (mr *MockSecretsBackendMockRecorder) GetContent(arg0, arg1, arg2, arg3 any) *MockSecretsBackendGetContentCall {
+func (mr *MockSecretsBackendMockRecorder) GetContent(arg0, arg1, arg2, arg3, arg4 any) *MockSecretsBackendGetContentCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContent", reflect.TypeOf((*MockSecretsBackend)(nil).GetContent), arg0, arg1, arg2, arg3)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetContent", reflect.TypeOf((*MockSecretsBackend)(nil).GetContent), arg0, arg1, arg2, arg3, arg4)
 	return &MockSecretsBackendGetContentCall{Call: call}
 }
 
@@ -405,30 +407,30 @@ func (c *MockSecretsBackendGetContentCall) Return(arg0 secrets.SecretValue, arg1
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSecretsBackendGetContentCall) Do(f func(*secrets.URI, string, bool, bool) (secrets.SecretValue, error)) *MockSecretsBackendGetContentCall {
+func (c *MockSecretsBackendGetContentCall) Do(f func(context.Context, *secrets.URI, string, bool, bool) (secrets.SecretValue, error)) *MockSecretsBackendGetContentCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSecretsBackendGetContentCall) DoAndReturn(f func(*secrets.URI, string, bool, bool) (secrets.SecretValue, error)) *MockSecretsBackendGetContentCall {
+func (c *MockSecretsBackendGetContentCall) DoAndReturn(f func(context.Context, *secrets.URI, string, bool, bool) (secrets.SecretValue, error)) *MockSecretsBackendGetContentCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // SaveContent mocks base method.
-func (m *MockSecretsBackend) SaveContent(arg0 *secrets.URI, arg1 int, arg2 secrets.SecretValue) (secrets.ValueRef, error) {
+func (m *MockSecretsBackend) SaveContent(arg0 context.Context, arg1 *secrets.URI, arg2 int, arg3 secrets.SecretValue) (secrets.ValueRef, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SaveContent", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "SaveContent", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(secrets.ValueRef)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // SaveContent indicates an expected call of SaveContent.
-func (mr *MockSecretsBackendMockRecorder) SaveContent(arg0, arg1, arg2 any) *MockSecretsBackendSaveContentCall {
+func (mr *MockSecretsBackendMockRecorder) SaveContent(arg0, arg1, arg2, arg3 any) *MockSecretsBackendSaveContentCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveContent", reflect.TypeOf((*MockSecretsBackend)(nil).SaveContent), arg0, arg1, arg2)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveContent", reflect.TypeOf((*MockSecretsBackend)(nil).SaveContent), arg0, arg1, arg2, arg3)
 	return &MockSecretsBackendSaveContentCall{Call: call}
 }
 
@@ -444,13 +446,13 @@ func (c *MockSecretsBackendSaveContentCall) Return(arg0 secrets.ValueRef, arg1 e
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSecretsBackendSaveContentCall) Do(f func(*secrets.URI, int, secrets.SecretValue) (secrets.ValueRef, error)) *MockSecretsBackendSaveContentCall {
+func (c *MockSecretsBackendSaveContentCall) Do(f func(context.Context, *secrets.URI, int, secrets.SecretValue) (secrets.ValueRef, error)) *MockSecretsBackendSaveContentCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSecretsBackendSaveContentCall) DoAndReturn(f func(*secrets.URI, int, secrets.SecretValue) (secrets.ValueRef, error)) *MockSecretsBackendSaveContentCall {
+func (c *MockSecretsBackendSaveContentCall) DoAndReturn(f func(context.Context, *secrets.URI, int, secrets.SecretValue) (secrets.ValueRef, error)) *MockSecretsBackendSaveContentCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/uniter/api/shim.go
+++ b/internal/worker/uniter/api/shim.go
@@ -28,7 +28,7 @@ func (s UniterClientShim) Unit(ctx context.Context, tag names.UnitTag) (Unit, er
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return UnitShim{u}, nil
+	return UnitShim{Unit: u}, nil
 }
 
 func (s UniterClientShim) Relation(ctx context.Context, tag names.RelationTag) (Relation, error) {
@@ -36,7 +36,7 @@ func (s UniterClientShim) Relation(ctx context.Context, tag names.RelationTag) (
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return relationShim{r}, nil
+	return relationShim{Relation: r}, nil
 }
 
 func (s UniterClientShim) RelationById(ctx context.Context, id int) (Relation, error) {
@@ -44,7 +44,7 @@ func (s UniterClientShim) RelationById(ctx context.Context, id int) (Relation, e
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return relationShim{r}, nil
+	return relationShim{Relation: r}, nil
 }
 
 func (s UniterClientShim) Application(ctx context.Context, tag names.ApplicationTag) (Application, error) {
@@ -68,7 +68,7 @@ func (s relationShim) Unit(ctx context.Context, tag names.UnitTag) (RelationUnit
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return RelationUnitShim{ru}, nil
+	return RelationUnitShim{RelationUnit: ru}, nil
 }
 
 type RelationUnitShim struct {
@@ -76,5 +76,5 @@ type RelationUnitShim struct {
 }
 
 func (s RelationUnitShim) Relation() Relation {
-	return relationShim{s.RelationUnit.Relation()}
+	return relationShim{Relation: s.RelationUnit.Relation()}
 }

--- a/internal/worker/uniter/api/uniter_mocks.go
+++ b/internal/worker/uniter/api/uniter_mocks.go
@@ -398,17 +398,17 @@ func (c *MockUniterClientCloudSpecCall) DoAndReturn(f func(context.Context) (*pa
 }
 
 // DestroyUnitStorageAttachments mocks base method.
-func (m *MockUniterClient) DestroyUnitStorageAttachments(arg0 names.UnitTag) error {
+func (m *MockUniterClient) DestroyUnitStorageAttachments(arg0 context.Context, arg1 names.UnitTag) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DestroyUnitStorageAttachments", arg0)
+	ret := m.ctrl.Call(m, "DestroyUnitStorageAttachments", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DestroyUnitStorageAttachments indicates an expected call of DestroyUnitStorageAttachments.
-func (mr *MockUniterClientMockRecorder) DestroyUnitStorageAttachments(arg0 any) *MockUniterClientDestroyUnitStorageAttachmentsCall {
+func (mr *MockUniterClientMockRecorder) DestroyUnitStorageAttachments(arg0, arg1 any) *MockUniterClientDestroyUnitStorageAttachmentsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DestroyUnitStorageAttachments", reflect.TypeOf((*MockUniterClient)(nil).DestroyUnitStorageAttachments), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DestroyUnitStorageAttachments", reflect.TypeOf((*MockUniterClient)(nil).DestroyUnitStorageAttachments), arg0, arg1)
 	return &MockUniterClientDestroyUnitStorageAttachmentsCall{Call: call}
 }
 
@@ -424,13 +424,13 @@ func (c *MockUniterClientDestroyUnitStorageAttachmentsCall) Return(arg0 error) *
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockUniterClientDestroyUnitStorageAttachmentsCall) Do(f func(names.UnitTag) error) *MockUniterClientDestroyUnitStorageAttachmentsCall {
+func (c *MockUniterClientDestroyUnitStorageAttachmentsCall) Do(f func(context.Context, names.UnitTag) error) *MockUniterClientDestroyUnitStorageAttachmentsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockUniterClientDestroyUnitStorageAttachmentsCall) DoAndReturn(f func(names.UnitTag) error) *MockUniterClientDestroyUnitStorageAttachmentsCall {
+func (c *MockUniterClientDestroyUnitStorageAttachmentsCall) DoAndReturn(f func(context.Context, names.UnitTag) error) *MockUniterClientDestroyUnitStorageAttachmentsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -747,17 +747,17 @@ func (c *MockUniterClientRelationByIdCall) DoAndReturn(f func(context.Context, i
 }
 
 // RemoveStorageAttachment mocks base method.
-func (m *MockUniterClient) RemoveStorageAttachment(arg0 names.StorageTag, arg1 names.UnitTag) error {
+func (m *MockUniterClient) RemoveStorageAttachment(arg0 context.Context, arg1 names.StorageTag, arg2 names.UnitTag) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RemoveStorageAttachment", arg0, arg1)
+	ret := m.ctrl.Call(m, "RemoveStorageAttachment", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RemoveStorageAttachment indicates an expected call of RemoveStorageAttachment.
-func (mr *MockUniterClientMockRecorder) RemoveStorageAttachment(arg0, arg1 any) *MockUniterClientRemoveStorageAttachmentCall {
+func (mr *MockUniterClientMockRecorder) RemoveStorageAttachment(arg0, arg1, arg2 any) *MockUniterClientRemoveStorageAttachmentCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveStorageAttachment", reflect.TypeOf((*MockUniterClient)(nil).RemoveStorageAttachment), arg0, arg1)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveStorageAttachment", reflect.TypeOf((*MockUniterClient)(nil).RemoveStorageAttachment), arg0, arg1, arg2)
 	return &MockUniterClientRemoveStorageAttachmentCall{Call: call}
 }
 
@@ -773,13 +773,13 @@ func (c *MockUniterClientRemoveStorageAttachmentCall) Return(arg0 error) *MockUn
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockUniterClientRemoveStorageAttachmentCall) Do(f func(names.StorageTag, names.UnitTag) error) *MockUniterClientRemoveStorageAttachmentCall {
+func (c *MockUniterClientRemoveStorageAttachmentCall) Do(f func(context.Context, names.StorageTag, names.UnitTag) error) *MockUniterClientRemoveStorageAttachmentCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockUniterClientRemoveStorageAttachmentCall) DoAndReturn(f func(names.StorageTag, names.UnitTag) error) *MockUniterClientRemoveStorageAttachmentCall {
+func (c *MockUniterClientRemoveStorageAttachmentCall) DoAndReturn(f func(context.Context, names.StorageTag, names.UnitTag) error) *MockUniterClientRemoveStorageAttachmentCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -823,18 +823,18 @@ func (c *MockUniterClientSetUnitWorkloadVersionCall) DoAndReturn(f func(context.
 }
 
 // StorageAttachment mocks base method.
-func (m *MockUniterClient) StorageAttachment(arg0 names.StorageTag, arg1 names.UnitTag) (params.StorageAttachment, error) {
+func (m *MockUniterClient) StorageAttachment(arg0 context.Context, arg1 names.StorageTag, arg2 names.UnitTag) (params.StorageAttachment, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StorageAttachment", arg0, arg1)
+	ret := m.ctrl.Call(m, "StorageAttachment", arg0, arg1, arg2)
 	ret0, _ := ret[0].(params.StorageAttachment)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // StorageAttachment indicates an expected call of StorageAttachment.
-func (mr *MockUniterClientMockRecorder) StorageAttachment(arg0, arg1 any) *MockUniterClientStorageAttachmentCall {
+func (mr *MockUniterClientMockRecorder) StorageAttachment(arg0, arg1, arg2 any) *MockUniterClientStorageAttachmentCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StorageAttachment", reflect.TypeOf((*MockUniterClient)(nil).StorageAttachment), arg0, arg1)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StorageAttachment", reflect.TypeOf((*MockUniterClient)(nil).StorageAttachment), arg0, arg1, arg2)
 	return &MockUniterClientStorageAttachmentCall{Call: call}
 }
 
@@ -850,30 +850,30 @@ func (c *MockUniterClientStorageAttachmentCall) Return(arg0 params.StorageAttach
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockUniterClientStorageAttachmentCall) Do(f func(names.StorageTag, names.UnitTag) (params.StorageAttachment, error)) *MockUniterClientStorageAttachmentCall {
+func (c *MockUniterClientStorageAttachmentCall) Do(f func(context.Context, names.StorageTag, names.UnitTag) (params.StorageAttachment, error)) *MockUniterClientStorageAttachmentCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockUniterClientStorageAttachmentCall) DoAndReturn(f func(names.StorageTag, names.UnitTag) (params.StorageAttachment, error)) *MockUniterClientStorageAttachmentCall {
+func (c *MockUniterClientStorageAttachmentCall) DoAndReturn(f func(context.Context, names.StorageTag, names.UnitTag) (params.StorageAttachment, error)) *MockUniterClientStorageAttachmentCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // StorageAttachmentLife mocks base method.
-func (m *MockUniterClient) StorageAttachmentLife(arg0 []params.StorageAttachmentId) ([]params.LifeResult, error) {
+func (m *MockUniterClient) StorageAttachmentLife(arg0 context.Context, arg1 []params.StorageAttachmentId) ([]params.LifeResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StorageAttachmentLife", arg0)
+	ret := m.ctrl.Call(m, "StorageAttachmentLife", arg0, arg1)
 	ret0, _ := ret[0].([]params.LifeResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // StorageAttachmentLife indicates an expected call of StorageAttachmentLife.
-func (mr *MockUniterClientMockRecorder) StorageAttachmentLife(arg0 any) *MockUniterClientStorageAttachmentLifeCall {
+func (mr *MockUniterClientMockRecorder) StorageAttachmentLife(arg0, arg1 any) *MockUniterClientStorageAttachmentLifeCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StorageAttachmentLife", reflect.TypeOf((*MockUniterClient)(nil).StorageAttachmentLife), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StorageAttachmentLife", reflect.TypeOf((*MockUniterClient)(nil).StorageAttachmentLife), arg0, arg1)
 	return &MockUniterClientStorageAttachmentLifeCall{Call: call}
 }
 
@@ -889,13 +889,13 @@ func (c *MockUniterClientStorageAttachmentLifeCall) Return(arg0 []params.LifeRes
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockUniterClientStorageAttachmentLifeCall) Do(f func([]params.StorageAttachmentId) ([]params.LifeResult, error)) *MockUniterClientStorageAttachmentLifeCall {
+func (c *MockUniterClientStorageAttachmentLifeCall) Do(f func(context.Context, []params.StorageAttachmentId) ([]params.LifeResult, error)) *MockUniterClientStorageAttachmentLifeCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockUniterClientStorageAttachmentLifeCall) DoAndReturn(f func([]params.StorageAttachmentId) ([]params.LifeResult, error)) *MockUniterClientStorageAttachmentLifeCall {
+func (c *MockUniterClientStorageAttachmentLifeCall) DoAndReturn(f func(context.Context, []params.StorageAttachmentId) ([]params.LifeResult, error)) *MockUniterClientStorageAttachmentLifeCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -940,18 +940,18 @@ func (c *MockUniterClientUnitCall) DoAndReturn(f func(context.Context, names.Uni
 }
 
 // UnitStorageAttachments mocks base method.
-func (m *MockUniterClient) UnitStorageAttachments(arg0 names.UnitTag) ([]params.StorageAttachmentId, error) {
+func (m *MockUniterClient) UnitStorageAttachments(arg0 context.Context, arg1 names.UnitTag) ([]params.StorageAttachmentId, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UnitStorageAttachments", arg0)
+	ret := m.ctrl.Call(m, "UnitStorageAttachments", arg0, arg1)
 	ret0, _ := ret[0].([]params.StorageAttachmentId)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // UnitStorageAttachments indicates an expected call of UnitStorageAttachments.
-func (mr *MockUniterClientMockRecorder) UnitStorageAttachments(arg0 any) *MockUniterClientUnitStorageAttachmentsCall {
+func (mr *MockUniterClientMockRecorder) UnitStorageAttachments(arg0, arg1 any) *MockUniterClientUnitStorageAttachmentsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnitStorageAttachments", reflect.TypeOf((*MockUniterClient)(nil).UnitStorageAttachments), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnitStorageAttachments", reflect.TypeOf((*MockUniterClient)(nil).UnitStorageAttachments), arg0, arg1)
 	return &MockUniterClientUnitStorageAttachmentsCall{Call: call}
 }
 
@@ -967,13 +967,13 @@ func (c *MockUniterClientUnitStorageAttachmentsCall) Return(arg0 []params.Storag
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockUniterClientUnitStorageAttachmentsCall) Do(f func(names.UnitTag) ([]params.StorageAttachmentId, error)) *MockUniterClientUnitStorageAttachmentsCall {
+func (c *MockUniterClientUnitStorageAttachmentsCall) Do(f func(context.Context, names.UnitTag) ([]params.StorageAttachmentId, error)) *MockUniterClientUnitStorageAttachmentsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockUniterClientUnitStorageAttachmentsCall) DoAndReturn(f func(names.UnitTag) ([]params.StorageAttachmentId, error)) *MockUniterClientUnitStorageAttachmentsCall {
+func (c *MockUniterClientUnitStorageAttachmentsCall) DoAndReturn(f func(context.Context, names.UnitTag) ([]params.StorageAttachmentId, error)) *MockUniterClientUnitStorageAttachmentsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1096,18 +1096,18 @@ func (c *MockUniterClientWatchRelationUnitsCall) DoAndReturn(f func(context.Cont
 }
 
 // WatchStorageAttachment mocks base method.
-func (m *MockUniterClient) WatchStorageAttachment(arg0 names.StorageTag, arg1 names.UnitTag) (watcher.NotifyWatcher, error) {
+func (m *MockUniterClient) WatchStorageAttachment(arg0 context.Context, arg1 names.StorageTag, arg2 names.UnitTag) (watcher.NotifyWatcher, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchStorageAttachment", arg0, arg1)
+	ret := m.ctrl.Call(m, "WatchStorageAttachment", arg0, arg1, arg2)
 	ret0, _ := ret[0].(watcher.NotifyWatcher)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // WatchStorageAttachment indicates an expected call of WatchStorageAttachment.
-func (mr *MockUniterClientMockRecorder) WatchStorageAttachment(arg0, arg1 any) *MockUniterClientWatchStorageAttachmentCall {
+func (mr *MockUniterClientMockRecorder) WatchStorageAttachment(arg0, arg1, arg2 any) *MockUniterClientWatchStorageAttachmentCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchStorageAttachment", reflect.TypeOf((*MockUniterClient)(nil).WatchStorageAttachment), arg0, arg1)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchStorageAttachment", reflect.TypeOf((*MockUniterClient)(nil).WatchStorageAttachment), arg0, arg1, arg2)
 	return &MockUniterClientWatchStorageAttachmentCall{Call: call}
 }
 
@@ -1123,13 +1123,13 @@ func (c *MockUniterClientWatchStorageAttachmentCall) Return(arg0 watcher.NotifyW
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockUniterClientWatchStorageAttachmentCall) Do(f func(names.StorageTag, names.UnitTag) (watcher.NotifyWatcher, error)) *MockUniterClientWatchStorageAttachmentCall {
+func (c *MockUniterClientWatchStorageAttachmentCall) Do(f func(context.Context, names.StorageTag, names.UnitTag) (watcher.NotifyWatcher, error)) *MockUniterClientWatchStorageAttachmentCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockUniterClientWatchStorageAttachmentCall) DoAndReturn(f func(names.StorageTag, names.UnitTag) (watcher.NotifyWatcher, error)) *MockUniterClientWatchStorageAttachmentCall {
+func (c *MockUniterClientWatchStorageAttachmentCall) DoAndReturn(f func(context.Context, names.StorageTag, names.UnitTag) (watcher.NotifyWatcher, error)) *MockUniterClientWatchStorageAttachmentCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/uniter/charm/charm.go
+++ b/internal/worker/uniter/charm/charm.go
@@ -4,6 +4,7 @@
 package charm
 
 import (
+	"context"
 	"errors"
 
 	"github.com/juju/collections/set"
@@ -35,7 +36,7 @@ type BundleInfo interface {
 	URL() string
 
 	// ArchiveSha256 returns the hex-encoded SHA-256 digest of the bundle data.
-	ArchiveSha256() (string, error)
+	ArchiveSha256(context.Context) (string, error)
 }
 
 // BundleReader provides a mechanism for getting a Bundle from a BundleInfo.
@@ -44,7 +45,7 @@ type BundleReader interface {
 	// Read returns the bundle identified by the supplied info. The abort chan
 	// can be used to notify an implementation that it need not complete the
 	// operation, and can immediately error out if it is convenient to do so.
-	Read(bi BundleInfo, abort <-chan struct{}) (Bundle, error)
+	Read(ctx context.Context, bi BundleInfo, abort <-chan struct{}) (Bundle, error)
 }
 
 // Deployer is responsible for installing and upgrading charms.
@@ -55,7 +56,7 @@ type Deployer interface {
 	// notify an implementation that it need not complete the operation, and
 	// can immediately error out if it convenient to do so. It must always
 	// be safe to restage the same bundle, or to stage a new bundle.
-	Stage(info BundleInfo, abort <-chan struct{}) error
+	Stage(ctx context.Context, info BundleInfo, abort <-chan struct{}) error
 
 	// Deploy will install or upgrade the most recently staged bundle.
 	// Behaviour is undefined if Stage has not been called. Failures that

--- a/internal/worker/uniter/charm/charm_test.go
+++ b/internal/worker/uniter/charm/charm_test.go
@@ -4,6 +4,7 @@
 package charm_test
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -36,7 +37,7 @@ func (br *bundleReader) EnableWaitForAbort() (stopWaiting chan struct{}) {
 }
 
 // Read implements the BundleReader interface.
-func (br *bundleReader) Read(info charm.BundleInfo, abort <-chan struct{}) (charm.Bundle, error) {
+func (br *bundleReader) Read(ctx context.Context, info charm.BundleInfo, abort <-chan struct{}) (charm.Bundle, error) {
 	bundle, ok := br.bundles[info.URL()]
 	if !ok {
 		return nil, fmt.Errorf("no such charm!")

--- a/internal/worker/uniter/charm/manifest_deployer_test.go
+++ b/internal/worker/uniter/charm/manifest_deployer_test.go
@@ -4,6 +4,7 @@
 package charm_test
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 	"time"
@@ -55,7 +56,7 @@ func (s *ManifestDeployerSuite) addCharm(c *gc.C, revision int, content ...ft.En
 
 func (s *ManifestDeployerSuite) deployCharm(c *gc.C, revision int, content ...ft.Entry) charm.BundleInfo {
 	info := s.addCharm(c, revision, content...)
-	err := s.deployer.Stage(info, nil)
+	err := s.deployer.Stage(context.Background(), info, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.deployer.Deploy()
 	c.Assert(err, jc.ErrorIsNil)
@@ -76,7 +77,7 @@ func (s *ManifestDeployerSuite) TestAbortStageWhenClosed(c *gc.C) {
 	errors := make(chan error)
 	s.bundles.EnableWaitForAbort()
 	go func() {
-		errors <- s.deployer.Stage(info, abort)
+		errors <- s.deployer.Stage(context.Background(), info, abort)
 	}()
 	close(abort)
 	err := <-errors
@@ -89,7 +90,7 @@ func (s *ManifestDeployerSuite) TestDontAbortStageWhenNotClosed(c *gc.C) {
 	errors := make(chan error)
 	stopWaiting := s.bundles.EnableWaitForAbort()
 	go func() {
-		errors <- s.deployer.Stage(info, abort)
+		errors <- s.deployer.Stage(context.Background(), info, abort)
 	}()
 	close(stopWaiting)
 	err := <-errors
@@ -103,61 +104,61 @@ func (s *ManifestDeployerSuite) TestDeployWithoutStage(c *gc.C) {
 
 func (s *ManifestDeployerSuite) TestInstall(c *gc.C) {
 	s.deployCharm(c, 1,
-		ft.File{"some-file", "hello", 0644},
-		ft.Dir{"some-dir", 0755},
-		ft.Symlink{"some-dir/some-link", "../some-file"},
+		ft.File{Path: "some-file", Data: "hello", Perm: 0644},
+		ft.Dir{Path: "some-dir", Perm: 0755},
+		ft.Symlink{Path: "some-dir/some-link", Link: "../some-file"},
 	)
 }
 
 func (s *ManifestDeployerSuite) TestUpgradeOverwrite(c *gc.C) {
 	s.deployCharm(c, 1,
-		ft.File{"some-file", "hello", 0644},
-		ft.Dir{"some-dir", 0755},
-		ft.File{"some-dir/another-file", "to be removed", 0755},
-		ft.Dir{"another-dir", 0755},
-		ft.Symlink{"another-dir/some-link", "../some-file"},
+		ft.File{Path: "some-file", Data: "hello", Perm: 0644},
+		ft.Dir{Path: "some-dir", Perm: 0755},
+		ft.File{Path: "some-dir/another-file", Data: "to be removed", Perm: 0755},
+		ft.Dir{Path: "another-dir", Perm: 0755},
+		ft.Symlink{Path: "another-dir/some-link", Link: "../some-file"},
 	)
 	// Replace each of file, dir, and symlink with a different entry; in
 	// the case of dir, checking that contained files are also removed.
 	s.deployCharm(c, 2,
-		ft.Symlink{"some-file", "no-longer-a-file"},
-		ft.File{"some-dir", "no-longer-a-dir", 0644},
-		ft.Dir{"another-dir", 0755},
-		ft.Dir{"another-dir/some-link", 0755},
+		ft.Symlink{Path: "some-file", Link: "no-longer-a-file"},
+		ft.File{Path: "some-dir", Data: "no-longer-a-dir", Perm: 0644},
+		ft.Dir{Path: "another-dir", Perm: 0755},
+		ft.Dir{Path: "another-dir/some-link", Perm: 0755},
 	)
 }
 
 func (s *ManifestDeployerSuite) TestUpgradePreserveUserFiles(c *gc.C) {
 	originalCharmContent := ft.Entries{
-		ft.File{"charm-file", "to-be-removed", 0644},
-		ft.Dir{"charm-dir", 0755},
+		ft.File{Path: "charm-file", Data: "to-be-removed", Perm: 0644},
+		ft.Dir{Path: "charm-dir", Perm: 0755},
 	}
 	s.deployCharm(c, 1, originalCharmContent...)
 
 	// Add user files we expect to keep to the target dir.
 	preserveUserContent := ft.Entries{
-		ft.File{"user-file", "to-be-preserved", 0644},
-		ft.Dir{"user-dir", 0755},
-		ft.File{"user-dir/user-file", "also-preserved", 0644},
+		ft.File{Path: "user-file", Data: "to-be-preserved", Perm: 0644},
+		ft.Dir{Path: "user-dir", Perm: 0755},
+		ft.File{Path: "user-dir/user-file", Data: "also-preserved", Perm: 0644},
 	}.Create(c, s.targetPath)
 
 	// Add some user files we expect to be removed.
 	removeUserContent := ft.Entries{
-		ft.File{"charm-dir/user-file", "whoops-removed", 0755},
+		ft.File{Path: "charm-dir/user-file", Data: "whoops-removed", Perm: 0755},
 	}.Create(c, s.targetPath)
 
 	// Add some user files we expect to be replaced.
 	ft.Entries{
-		ft.File{"replace-file", "original", 0644},
-		ft.Dir{"replace-dir", 0755},
-		ft.Symlink{"replace-symlink", "replace-file"},
+		ft.File{Path: "replace-file", Data: "original", Perm: 0644},
+		ft.Dir{Path: "replace-dir", Perm: 0755},
+		ft.Symlink{Path: "replace-symlink", Link: "replace-file"},
 	}.Create(c, s.targetPath)
 
 	// Deploy an upgrade; all new content overwrites the old...
 	s.deployCharm(c, 2,
-		ft.File{"replace-file", "updated", 0644},
-		ft.Dir{"replace-dir", 0755},
-		ft.Symlink{"replace-symlink", "replace-dir"},
+		ft.File{Path: "replace-file", Data: "updated", Perm: 0644},
+		ft.Dir{Path: "replace-dir", Perm: 0755},
+		ft.Symlink{Path: "replace-symlink", Link: "replace-dir"},
 	)
 
 	// ...and other files are preserved or removed according to
@@ -170,15 +171,15 @@ func (s *ManifestDeployerSuite) TestUpgradePreserveUserFiles(c *gc.C) {
 func (s *ManifestDeployerSuite) TestUpgradeConflictResolveRetrySameCharm(c *gc.C) {
 	// Create base install.
 	s.deployCharm(c, 1,
-		ft.File{"shared-file", "old", 0755},
-		ft.File{"old-file", "old", 0644},
+		ft.File{Path: "shared-file", Data: "old", Perm: 0755},
+		ft.File{Path: "old-file", Data: "old", Perm: 0644},
 	)
 
 	// Create mock upgrade charm that can (claim to) fail to expand...
 	failDeploy := true
 	upgradeContent := ft.Entries{
-		ft.File{"shared-file", "new", 0755},
-		ft.File{"new-file", "new", 0644},
+		ft.File{Path: "shared-file", Data: "new", Perm: 0755},
+		ft.File{Path: "new-file", Data: "new", Perm: 0644},
 	}
 	mockCharm := mockBundle{
 		paths: set.NewStrings(upgradeContent.Paths()...),
@@ -191,7 +192,7 @@ func (s *ManifestDeployerSuite) TestUpgradeConflictResolveRetrySameCharm(c *gc.C
 		},
 	}
 	info := s.addMockCharm(2, mockCharm)
-	err := s.deployer.Stage(info, nil)
+	err := s.deployer.Stage(context.Background(), info, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// ...and see it fail to expand. We're not too bothered about the actual
@@ -209,22 +210,22 @@ func (s *ManifestDeployerSuite) TestUpgradeConflictResolveRetrySameCharm(c *gc.C
 
 	// ...we end up with the right stuff in play.
 	s.assertCharm(c, 2, upgradeContent...)
-	ft.Removed{"old-file"}.Check(c, s.targetPath)
+	ft.Removed{Path: "old-file"}.Check(c, s.targetPath)
 }
 
 func (s *ManifestDeployerSuite) TestUpgradeConflictRevertRetryDifferentCharm(c *gc.C) {
 	// Create base install and add a user file.
 	s.deployCharm(c, 1,
-		ft.File{"shared-file", "old", 0755},
-		ft.File{"old-file", "old", 0644},
+		ft.File{Path: "shared-file", Data: "old", Perm: 0755},
+		ft.File{Path: "old-file", Data: "old", Perm: 0644},
 	)
-	userFile := ft.File{"user-file", "user", 0644}.Create(c, s.targetPath)
+	userFile := ft.File{Path: "user-file", Data: "user", Perm: 0644}.Create(c, s.targetPath)
 
 	// Create a charm upgrade that never works (but still writes a bunch of files),
 	// and deploy it.
 	badUpgradeContent := ft.Entries{
-		ft.File{"shared-file", "bad", 0644},
-		ft.File{"bad-file", "bad", 0644},
+		ft.File{Path: "shared-file", Data: "bad", Perm: 0644},
+		ft.File{Path: "bad-file", Data: "bad", Perm: 0644},
 	}
 	badCharm := mockBundle{
 		paths: set.NewStrings(badUpgradeContent.Paths()...),
@@ -234,7 +235,7 @@ func (s *ManifestDeployerSuite) TestUpgradeConflictRevertRetryDifferentCharm(c *
 		},
 	}
 	badInfo := s.addMockCharm(2, badCharm)
-	err := s.deployer.Stage(badInfo, nil)
+	err := s.deployer.Stage(context.Background(), badInfo, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.deployer.Deploy()
 	c.Assert(err, gc.Equals, charm.ErrConflict)
@@ -243,12 +244,12 @@ func (s *ManifestDeployerSuite) TestUpgradeConflictRevertRetryDifferentCharm(c *
 	// error, and deploy it; check user files are preserved, and nothing from
 	// charm 1 or 2 is.
 	s.deployCharm(c, 3,
-		ft.File{"shared-file", "new", 0755},
-		ft.File{"new-file", "new", 0644},
+		ft.File{Path: "shared-file", Data: "new", Perm: 0755},
+		ft.File{Path: "new-file", Data: "new", Perm: 0644},
 	)
 	userFile.Check(c, s.targetPath)
-	ft.Removed{"old-file"}.Check(c, s.targetPath)
-	ft.Removed{"bad-file"}.Check(c, s.targetPath)
+	ft.Removed{Path: "old-file"}.Check(c, s.targetPath)
+	ft.Removed{Path: "bad-file"}.Check(c, s.targetPath)
 }
 
 var _ = gc.Suite(&RetryingBundleReaderSuite{})
@@ -265,7 +266,7 @@ func (s *RetryingBundleReaderSuite) TestReadBundleMaxAttemptsExceeded(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	s.bundleInfo.EXPECT().URL().Return("ch:focal/dummy-1").AnyTimes()
-	s.bundleReader.EXPECT().Read(gomock.Any(), gomock.Any()).Return(nil, errors.NotYetAvailablef("still in the oven")).AnyTimes()
+	s.bundleReader.EXPECT().Read(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.NotYetAvailablef("still in the oven")).AnyTimes()
 
 	go func() {
 		// We retry 10 times in total so we need to advance the clock 9
@@ -276,7 +277,7 @@ func (s *RetryingBundleReaderSuite) TestReadBundleMaxAttemptsExceeded(c *gc.C) {
 		}
 	}()
 
-	_, err := s.rbr.Read(s.bundleInfo, nil)
+	_, err := s.rbr.Read(context.Background(), s.bundleInfo, nil)
 	c.Assert(err, jc.ErrorIs, errors.NotFound)
 }
 
@@ -285,8 +286,8 @@ func (s *RetryingBundleReaderSuite) TestReadBundleEventuallySucceeds(c *gc.C) {
 
 	s.bundleInfo.EXPECT().URL().Return("ch:focal/dummy-1").AnyTimes()
 	gomock.InOrder(
-		s.bundleReader.EXPECT().Read(gomock.Any(), gomock.Any()).Return(nil, errors.NotYetAvailablef("still in the oven")),
-		s.bundleReader.EXPECT().Read(gomock.Any(), gomock.Any()).Return(s.bundle, nil),
+		s.bundleReader.EXPECT().Read(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.NotYetAvailablef("still in the oven")),
+		s.bundleReader.EXPECT().Read(gomock.Any(), gomock.Any(), gomock.Any()).Return(s.bundle, nil),
 	)
 
 	go func() {
@@ -295,7 +296,7 @@ func (s *RetryingBundleReaderSuite) TestReadBundleEventuallySucceeds(c *gc.C) {
 		c.Assert(s.clock.WaitAdvance(10*time.Second, time.Second, 1), jc.ErrorIsNil)
 	}()
 
-	got, err := s.rbr.Read(s.bundleInfo, nil)
+	got, err := s.rbr.Read(context.Background(), s.bundleInfo, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(got, gc.Equals, s.bundle)
 }

--- a/internal/worker/uniter/charm/mocks/mocks.go
+++ b/internal/worker/uniter/charm/mocks/mocks.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	set "github.com/juju/collections/set"
@@ -41,18 +42,18 @@ func (m *MockBundleReader) EXPECT() *MockBundleReaderMockRecorder {
 }
 
 // Read mocks base method.
-func (m *MockBundleReader) Read(arg0 charm.BundleInfo, arg1 <-chan struct{}) (charm.Bundle, error) {
+func (m *MockBundleReader) Read(arg0 context.Context, arg1 charm.BundleInfo, arg2 <-chan struct{}) (charm.Bundle, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Read", arg0, arg1)
+	ret := m.ctrl.Call(m, "Read", arg0, arg1, arg2)
 	ret0, _ := ret[0].(charm.Bundle)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Read indicates an expected call of Read.
-func (mr *MockBundleReaderMockRecorder) Read(arg0, arg1 any) *MockBundleReaderReadCall {
+func (mr *MockBundleReaderMockRecorder) Read(arg0, arg1, arg2 any) *MockBundleReaderReadCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockBundleReader)(nil).Read), arg0, arg1)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockBundleReader)(nil).Read), arg0, arg1, arg2)
 	return &MockBundleReaderReadCall{Call: call}
 }
 
@@ -68,13 +69,13 @@ func (c *MockBundleReaderReadCall) Return(arg0 charm.Bundle, arg1 error) *MockBu
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockBundleReaderReadCall) Do(f func(charm.BundleInfo, <-chan struct{}) (charm.Bundle, error)) *MockBundleReaderReadCall {
+func (c *MockBundleReaderReadCall) Do(f func(context.Context, charm.BundleInfo, <-chan struct{}) (charm.Bundle, error)) *MockBundleReaderReadCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockBundleReaderReadCall) DoAndReturn(f func(charm.BundleInfo, <-chan struct{}) (charm.Bundle, error)) *MockBundleReaderReadCall {
+func (c *MockBundleReaderReadCall) DoAndReturn(f func(context.Context, charm.BundleInfo, <-chan struct{}) (charm.Bundle, error)) *MockBundleReaderReadCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -103,18 +104,18 @@ func (m *MockBundleInfo) EXPECT() *MockBundleInfoMockRecorder {
 }
 
 // ArchiveSha256 mocks base method.
-func (m *MockBundleInfo) ArchiveSha256() (string, error) {
+func (m *MockBundleInfo) ArchiveSha256(arg0 context.Context) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ArchiveSha256")
+	ret := m.ctrl.Call(m, "ArchiveSha256", arg0)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ArchiveSha256 indicates an expected call of ArchiveSha256.
-func (mr *MockBundleInfoMockRecorder) ArchiveSha256() *MockBundleInfoArchiveSha256Call {
+func (mr *MockBundleInfoMockRecorder) ArchiveSha256(arg0 any) *MockBundleInfoArchiveSha256Call {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ArchiveSha256", reflect.TypeOf((*MockBundleInfo)(nil).ArchiveSha256))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ArchiveSha256", reflect.TypeOf((*MockBundleInfo)(nil).ArchiveSha256), arg0)
 	return &MockBundleInfoArchiveSha256Call{Call: call}
 }
 
@@ -130,13 +131,13 @@ func (c *MockBundleInfoArchiveSha256Call) Return(arg0 string, arg1 error) *MockB
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockBundleInfoArchiveSha256Call) Do(f func() (string, error)) *MockBundleInfoArchiveSha256Call {
+func (c *MockBundleInfoArchiveSha256Call) Do(f func(context.Context) (string, error)) *MockBundleInfoArchiveSha256Call {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockBundleInfoArchiveSha256Call) DoAndReturn(f func() (string, error)) *MockBundleInfoArchiveSha256Call {
+func (c *MockBundleInfoArchiveSha256Call) DoAndReturn(f func(context.Context) (string, error)) *MockBundleInfoArchiveSha256Call {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/uniter/mock_test.go
+++ b/internal/worker/uniter/mock_test.go
@@ -20,7 +20,7 @@ type dummyStorageAccessor struct {
 	api.StorageAccessor
 }
 
-func (*dummyStorageAccessor) UnitStorageAttachments(_ names.UnitTag) ([]params.StorageAttachmentId, error) {
+func (*dummyStorageAccessor) UnitStorageAttachments(ctx context.Context, _ names.UnitTag) ([]params.StorageAttachmentId, error) {
 	return nil, nil
 }
 
@@ -28,11 +28,11 @@ type dummySecretsAccessor struct {
 	api.SecretsClient
 }
 
-func (a *dummySecretsAccessor) SecretMetadata() ([]secrets.SecretOwnerMetadata, error) {
+func (a *dummySecretsAccessor) SecretMetadata(context.Context) ([]secrets.SecretOwnerMetadata, error) {
 	return nil, nil
 }
 
-func (*dummySecretsAccessor) GetConsumerSecretsRevisionInfo(string, []string) (map[string]secrets.SecretRevisionInfo, error) {
+func (*dummySecretsAccessor) GetConsumerSecretsRevisionInfo(context.Context, string, []string) (map[string]secrets.SecretRevisionInfo, error) {
 	return nil, nil
 }
 

--- a/internal/worker/uniter/mockdeployer_test.go
+++ b/internal/worker/uniter/mockdeployer_test.go
@@ -4,6 +4,7 @@
 package uniter_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 
@@ -22,10 +23,10 @@ type mockDeployer struct {
 	err      error
 }
 
-func (m *mockDeployer) Stage(info charm.BundleInfo, abort <-chan struct{}) error {
+func (m *mockDeployer) Stage(ctx context.Context, info charm.BundleInfo, abort <-chan struct{}) error {
 	m.staged = info.URL()
 	var err error
-	m.bundle, err = m.bundles.Read(info, abort)
+	m.bundle, err = m.bundles.Read(ctx, info, abort)
 	return err
 }
 

--- a/internal/worker/uniter/op_callbacks.go
+++ b/internal/worker/uniter/op_callbacks.go
@@ -141,13 +141,13 @@ func (opc *operationCallbacks) GetArchiveInfo(url string) (charm.BundleInfo, err
 }
 
 // SetCurrentCharm is part of the operation.Callbacks interface.
-func (opc *operationCallbacks) SetCurrentCharm(charmURL string) error {
-	return opc.u.unit.SetCharmURL(charmURL)
+func (opc *operationCallbacks) SetCurrentCharm(ctx stdcontext.Context, charmURL string) error {
+	return opc.u.unit.SetCharmURL(ctx, charmURL)
 }
 
 // SetExecutingStatus is part of the operation.Callbacks interface.
-func (opc *operationCallbacks) SetExecutingStatus(message string) error {
-	return setAgentStatus(opc.u, status.Executing, message, nil)
+func (opc *operationCallbacks) SetExecutingStatus(ctx stdcontext.Context, message string) error {
+	return setAgentStatus(ctx, opc.u, status.Executing, message, nil)
 }
 
 // RemoteInit is part of the operation.Callbacks interface.
@@ -163,8 +163,8 @@ func (opc *operationCallbacks) RemoteInit(runningStatus remotestate.ContainerRun
 }
 
 // SetSecretRotated is part of the operation.Callbacks interface.
-func (opc *operationCallbacks) SetSecretRotated(uri string, oldRevision int) error {
-	return opc.u.secretsClient.SecretRotated(uri, oldRevision)
+func (opc *operationCallbacks) SetSecretRotated(ctx stdcontext.Context, uri string, oldRevision int) error {
+	return opc.u.secretsClient.SecretRotated(ctx, uri, oldRevision)
 }
 
 // SecretsRemoved is part of the operation.Callbacks interface.

--- a/internal/worker/uniter/operation/deploy.go
+++ b/internal/worker/uniter/operation/deploy.go
@@ -56,7 +56,7 @@ func (d *deploy) Prepare(ctx context.Context, state State) (*State, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	if err := d.deployer.Stage(info, d.abort); err != nil {
+	if err := d.deployer.Stage(ctx, info, d.abort); err != nil {
 		return nil, errors.Trace(err)
 	}
 	// note: yes, this *should* be in Prepare, not Execute. Before we can safely
@@ -66,7 +66,7 @@ func (d *deploy) Prepare(ctx context.Context, state State) (*State, error) {
 	// race with a new application-charm-url change on the controller, and lead to
 	// failures on resume in which we try to obtain archive info for a charm that
 	// has already been removed from the controller.
-	if err := d.callbacks.SetCurrentCharm(d.charmURL); err != nil {
+	if err := d.callbacks.SetCurrentCharm(ctx, d.charmURL); err != nil {
 		return nil, errors.Trace(err)
 	}
 	return d.getState(state, Pending), nil

--- a/internal/worker/uniter/operation/interface.go
+++ b/internal/worker/uniter/operation/interface.go
@@ -193,7 +193,7 @@ type Callbacks interface {
 	CommitHook(ctx stdcontext.Context, info hook.Info) error
 
 	// SetExecutingStatus sets the agent state to "Executing" with a message.
-	SetExecutingStatus(string) error
+	SetExecutingStatus(stdcontext.Context, string) error
 
 	// NotifyHook* exist so that we can defer worrying about how to untangle the
 	// callbacks inserted for uniter_test. They're only used by RunHook operations.
@@ -220,10 +220,10 @@ type Callbacks interface {
 	// *before* recording local state referencing that charm, to ensure there's
 	// no path by which the controller can legitimately garbage collect that
 	// charm or the application's settings for it. It's only used by Deploy operations.
-	SetCurrentCharm(charmURL string) error
+	SetCurrentCharm(ctx stdcontext.Context, charmURL string) error
 
 	// SetSecretRotated updates the secret rotation status.
-	SetSecretRotated(url string, originalRevision int) error
+	SetSecretRotated(ctx stdcontext.Context, url string, originalRevision int) error
 
 	// SecretsRemoved updates the unit secret state when
 	// secrets are removed.

--- a/internal/worker/uniter/operation/mocks/interface_mock.go
+++ b/internal/worker/uniter/operation/mocks/interface_mock.go
@@ -1245,17 +1245,17 @@ func (c *MockCallbacksSecretsRemovedCall) DoAndReturn(f func(context.Context, []
 }
 
 // SetCurrentCharm mocks base method.
-func (m *MockCallbacks) SetCurrentCharm(arg0 string) error {
+func (m *MockCallbacks) SetCurrentCharm(arg0 context.Context, arg1 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetCurrentCharm", arg0)
+	ret := m.ctrl.Call(m, "SetCurrentCharm", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetCurrentCharm indicates an expected call of SetCurrentCharm.
-func (mr *MockCallbacksMockRecorder) SetCurrentCharm(arg0 any) *MockCallbacksSetCurrentCharmCall {
+func (mr *MockCallbacksMockRecorder) SetCurrentCharm(arg0, arg1 any) *MockCallbacksSetCurrentCharmCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCurrentCharm", reflect.TypeOf((*MockCallbacks)(nil).SetCurrentCharm), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCurrentCharm", reflect.TypeOf((*MockCallbacks)(nil).SetCurrentCharm), arg0, arg1)
 	return &MockCallbacksSetCurrentCharmCall{Call: call}
 }
 
@@ -1271,29 +1271,29 @@ func (c *MockCallbacksSetCurrentCharmCall) Return(arg0 error) *MockCallbacksSetC
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockCallbacksSetCurrentCharmCall) Do(f func(string) error) *MockCallbacksSetCurrentCharmCall {
+func (c *MockCallbacksSetCurrentCharmCall) Do(f func(context.Context, string) error) *MockCallbacksSetCurrentCharmCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockCallbacksSetCurrentCharmCall) DoAndReturn(f func(string) error) *MockCallbacksSetCurrentCharmCall {
+func (c *MockCallbacksSetCurrentCharmCall) DoAndReturn(f func(context.Context, string) error) *MockCallbacksSetCurrentCharmCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // SetExecutingStatus mocks base method.
-func (m *MockCallbacks) SetExecutingStatus(arg0 string) error {
+func (m *MockCallbacks) SetExecutingStatus(arg0 context.Context, arg1 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetExecutingStatus", arg0)
+	ret := m.ctrl.Call(m, "SetExecutingStatus", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetExecutingStatus indicates an expected call of SetExecutingStatus.
-func (mr *MockCallbacksMockRecorder) SetExecutingStatus(arg0 any) *MockCallbacksSetExecutingStatusCall {
+func (mr *MockCallbacksMockRecorder) SetExecutingStatus(arg0, arg1 any) *MockCallbacksSetExecutingStatusCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetExecutingStatus", reflect.TypeOf((*MockCallbacks)(nil).SetExecutingStatus), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetExecutingStatus", reflect.TypeOf((*MockCallbacks)(nil).SetExecutingStatus), arg0, arg1)
 	return &MockCallbacksSetExecutingStatusCall{Call: call}
 }
 
@@ -1309,29 +1309,29 @@ func (c *MockCallbacksSetExecutingStatusCall) Return(arg0 error) *MockCallbacksS
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockCallbacksSetExecutingStatusCall) Do(f func(string) error) *MockCallbacksSetExecutingStatusCall {
+func (c *MockCallbacksSetExecutingStatusCall) Do(f func(context.Context, string) error) *MockCallbacksSetExecutingStatusCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockCallbacksSetExecutingStatusCall) DoAndReturn(f func(string) error) *MockCallbacksSetExecutingStatusCall {
+func (c *MockCallbacksSetExecutingStatusCall) DoAndReturn(f func(context.Context, string) error) *MockCallbacksSetExecutingStatusCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // SetSecretRotated mocks base method.
-func (m *MockCallbacks) SetSecretRotated(arg0 string, arg1 int) error {
+func (m *MockCallbacks) SetSecretRotated(arg0 context.Context, arg1 string, arg2 int) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetSecretRotated", arg0, arg1)
+	ret := m.ctrl.Call(m, "SetSecretRotated", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetSecretRotated indicates an expected call of SetSecretRotated.
-func (mr *MockCallbacksMockRecorder) SetSecretRotated(arg0, arg1 any) *MockCallbacksSetSecretRotatedCall {
+func (mr *MockCallbacksMockRecorder) SetSecretRotated(arg0, arg1, arg2 any) *MockCallbacksSetSecretRotatedCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSecretRotated", reflect.TypeOf((*MockCallbacks)(nil).SetSecretRotated), arg0, arg1)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSecretRotated", reflect.TypeOf((*MockCallbacks)(nil).SetSecretRotated), arg0, arg1, arg2)
 	return &MockCallbacksSetSecretRotatedCall{Call: call}
 }
 
@@ -1347,13 +1347,13 @@ func (c *MockCallbacksSetSecretRotatedCall) Return(arg0 error) *MockCallbacksSet
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockCallbacksSetSecretRotatedCall) Do(f func(string, int) error) *MockCallbacksSetSecretRotatedCall {
+func (c *MockCallbacksSetSecretRotatedCall) Do(f func(context.Context, string, int) error) *MockCallbacksSetSecretRotatedCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockCallbacksSetSecretRotatedCall) DoAndReturn(f func(string, int) error) *MockCallbacksSetSecretRotatedCall {
+func (c *MockCallbacksSetSecretRotatedCall) DoAndReturn(f func(context.Context, string, int) error) *MockCallbacksSetSecretRotatedCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/uniter/operation/runaction.go
+++ b/internal/worker/uniter/operation/runaction.go
@@ -88,7 +88,7 @@ func (ra *runAction) Prepare(ctx context.Context, state State) (*State, error) {
 // Execute is part of the Operation interface.
 func (ra *runAction) Execute(ctx context.Context, state State) (*State, error) {
 	message := fmt.Sprintf("running action %s", ra.name)
-	if err := ra.callbacks.SetExecutingStatus(message); err != nil {
+	if err := ra.callbacks.SetExecutingStatus(ctx, message); err != nil {
 		return nil, err
 	}
 

--- a/internal/worker/uniter/operation/runcommands.go
+++ b/internal/worker/uniter/operation/runcommands.go
@@ -67,7 +67,7 @@ func (rc *runCommands) Prepare(ctx stdcontext.Context, state State) (*State, err
 // Execute is part of the Operation interface.
 func (rc *runCommands) Execute(ctx stdcontext.Context, state State) (*State, error) {
 	rc.logger.Tracef("run commands: %s", rc)
-	if err := rc.callbacks.SetExecutingStatus("running commands"); err != nil {
+	if err := rc.callbacks.SetExecutingStatus(ctx, "running commands"); err != nil {
 		return nil, errors.Trace(err)
 	}
 

--- a/internal/worker/uniter/operation/runhook.go
+++ b/internal/worker/uniter/operation/runhook.go
@@ -140,7 +140,7 @@ func (rh *runHook) Execute(ctx stdcontext.Context, state State) (*State, error) 
 	// records when it is running the update-status hook. If the
 	// hook fails, that is recorded.
 	if hooks.Kind(rh.name) != hooks.UpdateStatus {
-		if err := rh.callbacks.SetExecutingStatus(message); err != nil {
+		if err := rh.callbacks.SetExecutingStatus(ctx, message); err != nil {
 			return nil, err
 		}
 	}
@@ -323,7 +323,7 @@ func (rh *runHook) Commit(ctx stdcontext.Context, state State) (*State, error) {
 			originalRevision = m.LatestRevision
 		}
 		rh.logger.Debugf("set secret rotated for %q, original rev %v", rh.info.SecretURI, originalRevision)
-		err = rh.callbacks.SetSecretRotated(rh.info.SecretURI, originalRevision)
+		err = rh.callbacks.SetSecretRotated(ctx, rh.info.SecretURI, originalRevision)
 	}
 	if err != nil {
 		return nil, err

--- a/internal/worker/uniter/operation/util_test.go
+++ b/internal/worker/uniter/operation/util_test.go
@@ -56,7 +56,7 @@ func (cb *DeployCallbacks) GetArchiveInfo(charmURL string) (charm.BundleInfo, er
 	return cb.MockGetArchiveInfo.Call(charmURL)
 }
 
-func (cb *DeployCallbacks) SetCurrentCharm(charmURL string) error {
+func (cb *DeployCallbacks) SetCurrentCharm(ctx context.Context, charmURL string) error {
 	return cb.MockSetCurrentCharm.Call(charmURL)
 }
 
@@ -98,7 +98,7 @@ type MockDeployer struct {
 	MockNotifyResolved *MockNoArgs
 }
 
-func (d *MockDeployer) Stage(info charm.BundleInfo, abort <-chan struct{}) error {
+func (d *MockDeployer) Stage(ctx context.Context, info charm.BundleInfo, abort <-chan struct{}) error {
 	return d.MockStage.Call(info, abort)
 }
 
@@ -131,7 +131,7 @@ func (cb *RunActionCallbacks) FailAction(_ context.Context, actionId, message st
 	return cb.MockFailAction.Call(actionId, message)
 }
 
-func (cb *RunActionCallbacks) SetExecutingStatus(message string) error {
+func (cb *RunActionCallbacks) SetExecutingStatus(_ context.Context, message string) error {
 	cb.mut.Lock()
 	defer cb.mut.Unlock()
 	cb.executingMessage = message
@@ -156,7 +156,7 @@ type RunCommandsCallbacks struct {
 	executingMessage string
 }
 
-func (cb *RunCommandsCallbacks) SetExecutingStatus(message string) error {
+func (cb *RunCommandsCallbacks) SetExecutingStatus(_ context.Context, message string) error {
 	cb.executingMessage = message
 	return nil
 }
@@ -182,7 +182,7 @@ func (cb *PrepareHookCallbacks) PrepareHook(_ context.Context, hookInfo hook.Inf
 	return cb.MockPrepareHook.Call(hookInfo)
 }
 
-func (cb *PrepareHookCallbacks) SetExecutingStatus(message string) error {
+func (cb *PrepareHookCallbacks) SetExecutingStatus(_ context.Context, message string) error {
 	cb.executingMessage = message
 	return nil
 }
@@ -237,7 +237,7 @@ func (cb *CommitHookCallbacks) CommitHook(_ context.Context, hookInfo hook.Info)
 	return cb.MockCommitHook.Call(hookInfo)
 }
 
-func (cb *CommitHookCallbacks) SetSecretRotated(url string, oldRevision int) error {
+func (cb *CommitHookCallbacks) SetSecretRotated(_ context.Context, url string, oldRevision int) error {
 	cb.rotatedSecretURI = url
 	cb.rotatedOldRevision = oldRevision
 	return nil

--- a/internal/worker/uniter/relation/interface.go
+++ b/internal/worker/uniter/relation/interface.go
@@ -81,7 +81,7 @@ type RelationStateTracker interface {
 
 // SubordinateDestroyer destroys all subordinates of a unit.
 type SubordinateDestroyer interface {
-	DestroyAllSubordinates() error
+	DestroyAllSubordinates(stdcontext.Context) error
 }
 
 // StateManager encapsulates methods required to handle relation

--- a/internal/worker/uniter/relation/mocks/mock_subordinate_destroyer.go
+++ b/internal/worker/uniter/relation/mocks/mock_subordinate_destroyer.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "go.uber.org/mock/gomock"
@@ -39,17 +40,17 @@ func (m *MockSubordinateDestroyer) EXPECT() *MockSubordinateDestroyerMockRecorde
 }
 
 // DestroyAllSubordinates mocks base method.
-func (m *MockSubordinateDestroyer) DestroyAllSubordinates() error {
+func (m *MockSubordinateDestroyer) DestroyAllSubordinates(arg0 context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DestroyAllSubordinates")
+	ret := m.ctrl.Call(m, "DestroyAllSubordinates", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DestroyAllSubordinates indicates an expected call of DestroyAllSubordinates.
-func (mr *MockSubordinateDestroyerMockRecorder) DestroyAllSubordinates() *MockSubordinateDestroyerDestroyAllSubordinatesCall {
+func (mr *MockSubordinateDestroyerMockRecorder) DestroyAllSubordinates(arg0 any) *MockSubordinateDestroyerDestroyAllSubordinatesCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DestroyAllSubordinates", reflect.TypeOf((*MockSubordinateDestroyer)(nil).DestroyAllSubordinates))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DestroyAllSubordinates", reflect.TypeOf((*MockSubordinateDestroyer)(nil).DestroyAllSubordinates), arg0)
 	return &MockSubordinateDestroyerDestroyAllSubordinatesCall{Call: call}
 }
 
@@ -65,13 +66,13 @@ func (c *MockSubordinateDestroyerDestroyAllSubordinatesCall) Return(arg0 error) 
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSubordinateDestroyerDestroyAllSubordinatesCall) Do(f func() error) *MockSubordinateDestroyerDestroyAllSubordinatesCall {
+func (c *MockSubordinateDestroyerDestroyAllSubordinatesCall) Do(f func(context.Context) error) *MockSubordinateDestroyerDestroyAllSubordinatesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSubordinateDestroyerDestroyAllSubordinatesCall) DoAndReturn(f func() error) *MockSubordinateDestroyerDestroyAllSubordinatesCall {
+func (c *MockSubordinateDestroyerDestroyAllSubordinatesCall) DoAndReturn(f func(context.Context) error) *MockSubordinateDestroyerDestroyAllSubordinatesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/uniter/relation/relationer.go
+++ b/internal/worker/uniter/relation/relationer.go
@@ -93,7 +93,7 @@ func (r *relationer) Join(ctx stdcontext.Context) error {
 	}
 	// uniter.RelationUnit.EnterScope() sets the unit's private address
 	// internally automatically, so no need to set it here.
-	return r.ru.EnterScope()
+	return r.ru.EnterScope(ctx)
 }
 
 // SetDying informs the relationer that the unit is departing the relation,
@@ -111,7 +111,7 @@ func (r *relationer) SetDying(ctx stdcontext.Context) error {
 // die is run when the relationer has no further responsibilities; it leaves
 // relation scope, and removes relation state.
 func (r *relationer) die(ctx stdcontext.Context) error {
-	err := r.ru.LeaveScope()
+	err := r.ru.LeaveScope(ctx)
 	if err != nil && !params.IsCodeNotFoundOrCodeUnauthorized(err) {
 		return errors.Annotatef(err, "leaving scope of relation %q", r.ru.Relation())
 	}

--- a/internal/worker/uniter/relation/relationer_test.go
+++ b/internal/worker/uniter/relation/relationer_test.go
@@ -119,7 +119,7 @@ func (s *relationerSuite) TestCommitHookRelationRemoved(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	// Setup for test
 	s.expectEndpoint(endpoint())
-	s.relationUnit.EXPECT().LeaveScope().Return(&params.Error{Code: "not found"})
+	s.relationUnit.EXPECT().LeaveScope(gomock.Any()).Return(&params.Error{Code: "not found"})
 	s.expectRemoveRelation()
 
 	r := s.newRelationer(c)
@@ -237,7 +237,7 @@ func (s *relationerSuite) setupMocks(c *gc.C) *gomock.Controller {
 
 func implicitRelationEndpoint() apiuniter.Endpoint {
 	return apiuniter.Endpoint{
-		charm.Relation{
+		Relation: charm.Relation{
 			Role:      charm.RoleProvider,
 			Name:      "juju-info",
 			Interface: "juju-info",
@@ -246,7 +246,7 @@ func implicitRelationEndpoint() apiuniter.Endpoint {
 
 func endpoint() apiuniter.Endpoint {
 	return apiuniter.Endpoint{
-		charm.Relation{
+		Relation: charm.Relation{
 			Role:      charm.RoleRequirer,
 			Name:      "mysql",
 			Interface: "db",
@@ -260,11 +260,11 @@ func (s *relationerSuite) expectEndpoint(ep apiuniter.Endpoint) {
 }
 
 func (s *relationerSuite) expectLeaveScope() {
-	s.relationUnit.EXPECT().LeaveScope().Return(nil)
+	s.relationUnit.EXPECT().LeaveScope(gomock.Any()).Return(nil)
 }
 
 func (s *relationerSuite) expectEnterScope() {
-	s.relationUnit.EXPECT().EnterScope().Return(nil)
+	s.relationUnit.EXPECT().EnterScope(gomock.Any()).Return(nil)
 }
 
 func (s *relationerSuite) expectRelationUnitRelation() {

--- a/internal/worker/uniter/relation/resolver.go
+++ b/internal/worker/uniter/relation/resolver.go
@@ -47,7 +47,7 @@ func (r *relationsResolver) NextOp(ctx context.Context, localState resolver.Loca
 			}
 		}()
 	}
-	if err := r.maybeDestroySubordinates(remoteState); err != nil {
+	if err := r.maybeDestroySubordinates(ctx, remoteState); err != nil {
 		return nil, errors.Trace(err)
 	}
 
@@ -98,7 +98,7 @@ func (r *relationsResolver) NextOp(ctx context.Context, localState resolver.Loca
 // maybeDestroySubordinates checks whether the remote state indicates that the
 // unit is dying and ensures that any related subordinates are properly
 // destroyed.
-func (r *relationsResolver) maybeDestroySubordinates(remoteState remotestate.Snapshot) error {
+func (r *relationsResolver) maybeDestroySubordinates(ctx context.Context, remoteState remotestate.Snapshot) error {
 	if remoteState.Life != life.Dying {
 		return nil
 	}
@@ -118,7 +118,7 @@ func (r *relationsResolver) maybeDestroySubordinates(remoteState remotestate.Sna
 	}
 
 	if destroyAllSubordinates {
-		return r.subordinateDestroyer.DestroyAllSubordinates()
+		return r.subordinateDestroyer.DestroyAllSubordinates(ctx)
 	}
 
 	return nil

--- a/internal/worker/uniter/relation/resolver_test.go
+++ b/internal/worker/uniter/relation/resolver_test.go
@@ -1163,7 +1163,7 @@ func (s *relationResolverSuite) TestPrincipalDyingDestroysSubordinates(c *gc.C) 
 	}
 
 	destroyer := mocks.NewMockSubordinateDestroyer(ctrl)
-	destroyer.EXPECT().DestroyAllSubordinates().Return(nil)
+	destroyer.EXPECT().DestroyAllSubordinates(gomock.Any()).Return(nil)
 	relationResolver := s.newRelationResolver(c, r, destroyer)
 	_, err := relationResolver.NextOp(stdcontext.Background(), localState, remoteState, &mockOperations{})
 	c.Assert(err, jc.ErrorIsNil)
@@ -1632,7 +1632,7 @@ func (s *mockRelationResolverSuite) TestPrincipalDyingDestroysSubordinates(c *gc
 	s.expectStateFound(1)
 	s.expectRemoteApplication(1, "")
 	destroyer := mocks.NewMockSubordinateDestroyer(ctrl)
-	destroyer.EXPECT().DestroyAllSubordinates().Return(nil)
+	destroyer.EXPECT().DestroyAllSubordinates(gomock.Any()).Return(nil)
 
 	relationsResolver := s.newRelationResolver(c, s.mockRelStTracker, destroyer)
 	op, err := relationsResolver.NextOp(stdcontext.Background(), localState, remoteState, &mockOperations{})

--- a/internal/worker/uniter/relation/statetracker.go
+++ b/internal/worker/uniter/relation/statetracker.go
@@ -59,7 +59,7 @@ type relationStateTracker struct {
 
 // NewRelationStateTracker returns a new RelationStateTracker instance.
 func NewRelationStateTracker(ctx stdcontext.Context, cfg RelationStateTrackerConfig) (RelationStateTracker, error) {
-	principalName, subordinate, err := cfg.Unit.PrincipalName()
+	principalName, subordinate, err := cfg.Unit.PrincipalName(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -92,7 +92,7 @@ func NewRelationStateTracker(ctx stdcontext.Context, cfg RelationStateTrackerCon
 // loadInitialState reconciles the local state with the remote
 // state of the corresponding relations.
 func (r *relationStateTracker) loadInitialState(ctx stdcontext.Context) error {
-	relationStatus, err := r.unit.RelationsStatus()
+	relationStatus, err := r.unit.RelationsStatus(ctx)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -306,13 +306,13 @@ func (r *relationStateTracker) SynchronizeScopes(ctx stdcontext.Context, remote 
 	}
 
 	if r.subordinate {
-		return r.maybeSetSubordinateDying()
+		return r.maybeSetSubordinateDying(ctx)
 	}
 
 	return nil
 }
 
-func (r *relationStateTracker) maybeSetSubordinateDying() error {
+func (r *relationStateTracker) maybeSetSubordinateDying(ctx stdcontext.Context) error {
 	// If no Alive relations remain between a subordinate unit's application
 	// and its principal's application, the subordinate must become Dying.
 	principalApp, err := names.UnitApplication(r.principalName)
@@ -329,7 +329,7 @@ func (r *relationStateTracker) maybeSetSubordinateDying() error {
 			return nil
 		}
 	}
-	return r.unit.Destroy()
+	return r.unit.Destroy(ctx)
 }
 
 // setDying notifies the relationer identified by the supplied id that the

--- a/internal/worker/uniter/relation/statetracker_test.go
+++ b/internal/worker/uniter/relation/statetracker_test.go
@@ -702,15 +702,15 @@ func (s *baseStateTrackerSuite) expectUnitName() {
 }
 
 func (s *baseStateTrackerSuite) expectUnitDestroy() {
-	s.unit.EXPECT().Destroy().Return(nil)
+	s.unit.EXPECT().Destroy(gomock.Any()).Return(nil)
 }
 
 func (s *baseStateTrackerSuite) expectRelationsStatusEmpty() {
-	s.unit.EXPECT().RelationsStatus().Return([]uniter.RelationStatus{}, nil)
+	s.unit.EXPECT().RelationsStatus(gomock.Any()).Return([]uniter.RelationStatus{}, nil)
 }
 
 func (s *baseStateTrackerSuite) expectRelationsStatus(status []uniter.RelationStatus) {
-	s.unit.EXPECT().RelationsStatus().Return(status, nil)
+	s.unit.EXPECT().RelationsStatus(gomock.Any()).Return(status, nil)
 }
 
 func (s *baseStateTrackerSuite) expectWatch(c *gc.C) {

--- a/internal/worker/uniter/remotestate/interface.go
+++ b/internal/worker/uniter/remotestate/interface.go
@@ -37,11 +37,11 @@ type UpdateStatusTimerFunc func(duration time.Duration) Waiter
 type UniterClient interface {
 	Charm(url string) (api.Charm, error)
 	Relation(ctx context.Context, tag names.RelationTag) (api.Relation, error)
-	StorageAttachment(names.StorageTag, names.UnitTag) (params.StorageAttachment, error)
-	StorageAttachmentLife([]params.StorageAttachmentId) ([]params.LifeResult, error)
+	StorageAttachment(context.Context, names.StorageTag, names.UnitTag) (params.StorageAttachment, error)
+	StorageAttachmentLife(context.Context, []params.StorageAttachmentId) ([]params.LifeResult, error)
 	Unit(context.Context, names.UnitTag) (api.Unit, error)
 	WatchRelationUnits(context.Context, names.RelationTag, names.UnitTag) (watcher.RelationUnitsWatcher, error)
-	WatchStorageAttachment(names.StorageTag, names.UnitTag) (watcher.NotifyWatcher, error)
+	WatchStorageAttachment(context.Context, names.StorageTag, names.UnitTag) (watcher.NotifyWatcher, error)
 	WatchUpdateStatusHookInterval(context.Context) (watcher.NotifyWatcher, error)
 	UpdateStatusHookInterval(context.Context) (time.Duration, error)
 }

--- a/internal/worker/uniter/remotestate/mock_test.go
+++ b/internal/worker/uniter/remotestate/mock_test.go
@@ -126,7 +126,7 @@ type mockCharm struct {
 	required bool
 }
 
-func (c *mockCharm) LXDProfileRequired() (bool, error) {
+func (c *mockCharm) LXDProfileRequired(_ context.Context) (bool, error) {
 	return c.required, nil
 }
 
@@ -139,6 +139,7 @@ func (m *mockUniterClient) Relation(_ context.Context, tag names.RelationTag) (a
 }
 
 func (m *mockUniterClient) StorageAttachment(
+	_ context.Context,
 	storageTag names.StorageTag, unitTag names.UnitTag,
 ) (params.StorageAttachment, error) {
 	if unitTag != m.unit.tag {
@@ -158,6 +159,7 @@ func (m *mockUniterClient) StorageAttachment(
 }
 
 func (m *mockUniterClient) StorageAttachmentLife(
+	_ context.Context,
 	ids []params.StorageAttachmentId,
 ) ([]params.LifeResult, error) {
 	results := make([]params.LifeResult, len(ids))
@@ -195,6 +197,7 @@ func (m *mockUniterClient) WatchRelationUnits(
 }
 
 func (m *mockUniterClient) WatchStorageAttachment(
+	_ context.Context,
 	storageTag names.StorageTag, unitTag names.UnitTag,
 ) (watcher.NotifyWatcher, error) {
 	if unitTag != m.unit.tag {
@@ -237,7 +240,7 @@ func (u *mockUnit) Life() life.Value {
 	return u.life
 }
 
-func (u *mockUnit) LXDProfileName() (string, error) {
+func (u *mockUnit) LXDProfileName(_ context.Context) (string, error) {
 	return u.lxdProfileName, nil
 }
 
@@ -265,31 +268,31 @@ func (u *mockUnit) Watch(context.Context) (watcher.NotifyWatcher, error) {
 	return u.unitWatcher, nil
 }
 
-func (u *mockUnit) WatchAddressesHash() (watcher.StringsWatcher, error) {
+func (u *mockUnit) WatchAddressesHash(_ context.Context) (watcher.StringsWatcher, error) {
 	return u.addressesWatcher, nil
 }
 
-func (u *mockUnit) WatchConfigSettingsHash() (watcher.StringsWatcher, error) {
+func (u *mockUnit) WatchConfigSettingsHash(_ context.Context) (watcher.StringsWatcher, error) {
 	return u.configSettingsWatcher, nil
 }
 
-func (u *mockUnit) WatchTrustConfigSettingsHash() (watcher.StringsWatcher, error) {
+func (u *mockUnit) WatchTrustConfigSettingsHash(_ context.Context) (watcher.StringsWatcher, error) {
 	return u.applicationConfigSettingsWatcher, nil
 }
 
-func (u *mockUnit) WatchStorage() (watcher.StringsWatcher, error) {
+func (u *mockUnit) WatchStorage(_ context.Context) (watcher.StringsWatcher, error) {
 	return u.storageWatcher, nil
 }
 
-func (u *mockUnit) WatchActionNotifications() (watcher.StringsWatcher, error) {
+func (u *mockUnit) WatchActionNotifications(_ context.Context) (watcher.StringsWatcher, error) {
 	return u.actionWatcher, nil
 }
 
-func (u *mockUnit) WatchRelations() (watcher.StringsWatcher, error) {
+func (u *mockUnit) WatchRelations(_ context.Context) (watcher.StringsWatcher, error) {
 	return u.relationsWatcher, nil
 }
 
-func (u *mockUnit) WatchInstanceData() (watcher.NotifyWatcher, error) {
+func (u *mockUnit) WatchInstanceData(_ context.Context) (watcher.NotifyWatcher, error) {
 	return u.instanceDataWatcher, nil
 }
 
@@ -304,11 +307,11 @@ type mockApplication struct {
 	leaderSettingsWatcher *mockNotifyWatcher
 }
 
-func (s *mockApplication) CharmModifiedVersion() (int, error) {
+func (s *mockApplication) CharmModifiedVersion(_ context.Context) (int, error) {
 	return s.charmModifiedVersion, nil
 }
 
-func (s *mockApplication) CharmURL() (string, bool, error) {
+func (s *mockApplication) CharmURL(_ context.Context) (string, bool, error) {
 	return s.curl, s.forceUpgrade, nil
 }
 
@@ -328,7 +331,7 @@ func (s *mockApplication) Watch(context.Context) (watcher.NotifyWatcher, error) 
 	return s.applicationWatcher, nil
 }
 
-func (s *mockApplication) WatchLeadershipSettings() (watcher.NotifyWatcher, error) {
+func (s *mockApplication) WatchLeadershipSettings(_ context.Context) (watcher.NotifyWatcher, error) {
 	return s.leaderSettingsWatcher, nil
 }
 
@@ -416,12 +419,12 @@ type mockSecretsClient struct {
 	owners                  []names.Tag
 }
 
-func (m *mockSecretsClient) WatchConsumedSecretsChanges(unitName string) (watcher.StringsWatcher, error) {
+func (m *mockSecretsClient) WatchConsumedSecretsChanges(_ context.Context, unitName string) (watcher.StringsWatcher, error) {
 	m.unitName = unitName
 	return m.secretsWatcher, nil
 }
 
-func (m *mockSecretsClient) GetConsumerSecretsRevisionInfo(unitName string, uris []string) (map[string]secrets.SecretRevisionInfo, error) {
+func (m *mockSecretsClient) GetConsumerSecretsRevisionInfo(_ context.Context, unitName string, uris []string) (map[string]secrets.SecretRevisionInfo, error) {
 	if unitName != m.unitName {
 		return nil, errors.NotFoundf("unit %q", unitName)
 	}
@@ -438,7 +441,7 @@ func (m *mockSecretsClient) GetConsumerSecretsRevisionInfo(unitName string, uris
 	return result, nil
 }
 
-func (m *mockSecretsClient) WatchObsolete(owners ...names.Tag) (watcher.StringsWatcher, error) {
+func (m *mockSecretsClient) WatchObsolete(_ context.Context, owners ...names.Tag) (watcher.StringsWatcher, error) {
 	m.owners = owners
 	return m.secretsRevisionsWatcher, nil
 }

--- a/internal/worker/uniter/resolver.go
+++ b/internal/worker/uniter/resolver.go
@@ -27,7 +27,7 @@ import (
 type ResolverConfig struct {
 	ModelType           model.ModelType
 	ClearResolved       func() error
-	ReportHookError     func(hook.Info) error
+	ReportHookError     func(stdcontext.Context, hook.Info) error
 	ShouldRetryHooks    bool
 	StartRetryHookTimer func()
 	StopRetryHookTimer  func()
@@ -269,7 +269,7 @@ func (s *uniterResolver) nextOpHookError(
 ) (operation.Operation, error) {
 
 	// Report the hook error.
-	if err := s.config.ReportHookError(*localState.Hook); err != nil {
+	if err := s.config.ReportHookError(ctx, *localState.Hook); err != nil {
 		return nil, errors.Trace(err)
 	}
 

--- a/internal/worker/uniter/resolver_test.go
+++ b/internal/worker/uniter/resolver_test.go
@@ -104,7 +104,7 @@ func (s *baseResolverSuite) SetUpTest(c *gc.C, modelType model.ModelType, reboot
 	s.lastOptionalResolver = &fakeResolver{}
 	s.resolverConfig = uniter.ResolverConfig{
 		ClearResolved:       func() error { return s.clearResolved() },
-		ReportHookError:     func(info hook.Info) error { return s.reportHookError(info) },
+		ReportHookError:     func(_ context.Context, info hook.Info) error { return s.reportHookError(info) },
 		StartRetryHookTimer: func() { s.stub.AddCall("StartRetryHookTimer") },
 		StopRetryHookTimer:  func() { s.stub.AddCall("StopRetryHookTimer") },
 		ShouldRetryHooks:    true,
@@ -728,7 +728,7 @@ func (m *fakeRW) SetState(context.Context, params.SetUnitStateArg) error {
 type fakeDeployer struct {
 }
 
-func (m *fakeDeployer) Stage(_ unitercharm.BundleInfo, _ <-chan struct{}) error {
+func (m *fakeDeployer) Stage(_ context.Context, _ unitercharm.BundleInfo, _ <-chan struct{}) error {
 	return nil
 }
 

--- a/internal/worker/uniter/runcommands/mock_test.go
+++ b/internal/worker/uniter/runcommands/mock_test.go
@@ -49,7 +49,7 @@ type mockCallbacks struct {
 	operation.Callbacks
 }
 
-func (c *mockCallbacks) SetExecutingStatus(status string) error {
+func (c *mockCallbacks) SetExecutingStatus(_ context.Context, status string) error {
 	c.MethodCall(c, "SetExecutingStatus", status)
 	return c.NextErr()
 }

--- a/internal/worker/uniter/runner/context/cache.go
+++ b/internal/worker/uniter/runner/context/cache.go
@@ -4,6 +4,7 @@
 package context
 
 import (
+	"context"
 	"sort"
 
 	"github.com/juju/errors"
@@ -12,7 +13,7 @@ import (
 )
 
 // SettingsFunc returns the relation settings for a unit.
-type SettingsFunc func(unitName string) (params.Settings, error)
+type SettingsFunc func(ctx context.Context, unitName string) (params.Settings, error)
 
 // SettingsMap is a map from unit name to relation settings.
 type SettingsMap map[string]params.Settings
@@ -68,7 +69,7 @@ func (cache *RelationCache) MemberNames() (memberNames []string) {
 
 // Settings returns the settings of the named remote unit. It's valid to get
 // the settings of any unit that has ever been in the relation.
-func (cache *RelationCache) Settings(unitName string) (params.Settings, error) {
+func (cache *RelationCache) Settings(ctx context.Context, unitName string) (params.Settings, error) {
 	// TODO(jam): 2019-10-10 We should probably validate that 'unitName' is a valid
 	//  application name and not a unit name. ReadSettings used to validate that
 	//  it was a valid unit name, but now it can be a unitName or appName
@@ -79,7 +80,7 @@ func (cache *RelationCache) Settings(unitName string) (params.Settings, error) {
 		}
 		if settings == nil {
 			var err error
-			settings, err = cache.readSettings(unitName)
+			settings, err = cache.readSettings(ctx, unitName)
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
@@ -94,14 +95,14 @@ func (cache *RelationCache) Settings(unitName string) (params.Settings, error) {
 }
 
 // ApplicationSettings returns the relation settings of the named application.
-func (cache *RelationCache) ApplicationSettings(appName string) (params.Settings, error) {
+func (cache *RelationCache) ApplicationSettings(ctx context.Context, appName string) (params.Settings, error) {
 	// TODO(jam): 2019-10-10 We should probably validate that 'appName' is a valid
 	//  application name and not a unit name. ReadSettings used to validate that
 	//  it was a valid unit name, but now it can be a unitName or appName
 	settings, found := cache.applications[appName]
 	if !found {
 		var err error
-		settings, err = cache.readSettings(appName)
+		settings, err = cache.readSettings(ctx, appName)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/internal/worker/uniter/runner/context/contextfactory_test.go
+++ b/internal/worker/uniter/runner/context/contextfactory_test.go
@@ -50,7 +50,7 @@ func (s *ContextFactorySuite) SetUpTest(c *gc.C) {
 func (s *ContextFactorySuite) setupContextFactory(c *gc.C, ctrl *gomock.Controller) {
 	s.setupUniter(ctrl)
 
-	s.unit.EXPECT().PrincipalName().Return("", false, nil)
+	s.unit.EXPECT().PrincipalName(gomock.Any()).Return("", false, nil)
 	s.uniter.EXPECT().Model(gomock.Any()).Return(&types.Model{
 		Name:      "test-model",
 		UUID:      coretesting.ModelTag.Id(),
@@ -64,7 +64,7 @@ func (s *ContextFactorySuite) setupContextFactory(c *gc.C, ctrl *gomock.Controll
 	s.uniter.EXPECT().ModelConfig(gomock.Any()).Return(cfg, nil).AnyTimes()
 
 	s.payloads = contextmocks.NewMockPayloadAPIClient(ctrl)
-	s.payloads.EXPECT().List().Return(nil, nil).AnyTimes()
+	s.payloads.EXPECT().List(gomock.Any()).Return(nil, nil).AnyTimes()
 
 	contextFactory, err := context.NewContextFactory(stdcontext.Background(), context.FactoryConfig{
 		Uniter:           s.uniter,
@@ -163,7 +163,7 @@ func (s *ContextFactorySuite) TestNewHookContextWithStorage(c *gc.C) {
 	defer ctrl.Finish()
 	s.setupContextFactory(c, ctrl)
 
-	s.uniter.EXPECT().StorageAttachment(names.NewStorageTag("data/0"), names.NewUnitTag("u/0")).Return(params.StorageAttachment{
+	s.uniter.EXPECT().StorageAttachment(gomock.Any(), names.NewStorageTag("data/0"), names.NewUnitTag("u/0")).Return(params.StorageAttachment{
 		Kind:     params.StorageKindBlock,
 		Location: "/dev/sdb",
 	}, nil).AnyTimes()
@@ -339,8 +339,8 @@ func (s *ContextFactorySuite) TestNewHookContextPrunesNonMemberCaches(c *gc.C) {
 	s.updateCache(0, "rel0/0", params.Settings{"keep": "me"})
 	s.updateCache(0, "rel0/1", params.Settings{"drop": "me"})
 
-	s.relunits[0].EXPECT().ReadSettings("rel0/0").Return(nil, nil).AnyTimes()
-	s.relunits[0].EXPECT().ReadSettings("rel0/1").Return(nil, nil).AnyTimes()
+	s.relunits[0].EXPECT().ReadSettings(gomock.Any(), "rel0/0").Return(nil, nil).AnyTimes()
+	s.relunits[0].EXPECT().ReadSettings(gomock.Any(), "rel0/1").Return(nil, nil).AnyTimes()
 
 	ctx, err := s.factory.HookContext(stdcontext.Background(), hook.Info{Kind: hooks.Install})
 	c.Assert(err, jc.ErrorIsNil)
@@ -359,7 +359,7 @@ func (s *ContextFactorySuite) TestNewHookContextPrunesNonMemberCaches(c *gc.C) {
 
 	// Verify that the settings really were cached by trying to look them up.
 	// Nothing's really in scope, so the call would fail if they weren't.
-	settings0, err = relCtx.ReadSettings("rel0/0")
+	settings0, err = relCtx.ReadSettings(stdcontext.Background(), "rel0/0")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(settings0, jc.DeepEquals, params.Settings{"keep": "me"})
 }

--- a/internal/worker/uniter/runner/context/env_test.go
+++ b/internal/worker/uniter/runner/context/env_test.go
@@ -174,7 +174,7 @@ func (s *EnvSuite) TestHostEnv(c *gc.C) {
 	defer ctrl.Finish()
 
 	state := api.NewMockUniterClient(ctrl)
-	state.EXPECT().StorageAttachment(names.NewStorageTag("data/0"), names.NewUnitTag("this-unit/123")).Return(params.StorageAttachment{
+	state.EXPECT().StorageAttachment(gomock.Any(), names.NewStorageTag("data/0"), names.NewUnitTag("this-unit/123")).Return(params.StorageAttachment{
 		Kind:     params.StorageKindBlock,
 		Location: "/dev/sdb",
 	}, nil).AnyTimes()

--- a/internal/worker/uniter/runner/context/export_test.go
+++ b/internal/worker/uniter/runner/context/export_test.go
@@ -5,6 +5,7 @@ package context
 
 import (
 	"context"
+	stdcontext "context"
 
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
@@ -80,15 +81,15 @@ func NewHookContext(c *gc.C, hcParams HookContextParams) (*HookContext, error) {
 	}
 	// Get and cache the addresses.
 	var err error
-	ctx.publicAddress, err = hcParams.Unit.PublicAddress()
+	ctx.publicAddress, err = hcParams.Unit.PublicAddress(stdcontext.Background())
 	if err != nil && !params.IsCodeNoAddressSet(err) {
 		return nil, err
 	}
-	ctx.privateAddress, err = hcParams.Unit.PrivateAddress()
+	ctx.privateAddress, err = hcParams.Unit.PrivateAddress(stdcontext.Background())
 	if err != nil && !params.IsCodeNoAddressSet(err) {
 		return nil, err
 	}
-	ctx.availabilityZone, err = hcParams.Unit.AvailabilityZone()
+	ctx.availabilityZone, err = hcParams.Unit.AvailabilityZone(stdcontext.Background())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/worker/uniter/runner/context/flush_test.go
+++ b/internal/worker/uniter/runner/context/flush_test.go
@@ -45,12 +45,12 @@ func (s *FlushContextSuite) TestRunHookRelationFlushingError(c *gc.C) {
 	// Mess with multiple relation settings.
 	relCtx0, err := ctx.Relation(0)
 	c.Assert(err, jc.ErrorIsNil)
-	node0, err := relCtx0.Settings()
+	node0, err := relCtx0.Settings(stdcontext.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	node0.Set("foo", "1")
 	relCtx1, err := ctx.Relation(1)
 	c.Assert(err, jc.ErrorIsNil)
-	node1, err := relCtx1.Settings()
+	node1, err := relCtx1.Settings(stdcontext.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	node1.Set("bar", "2")
 
@@ -68,12 +68,12 @@ func (s *FlushContextSuite) TestRunHookRelationFlushingSuccess(c *gc.C) {
 	// Mess with multiple relation settings.
 	relCtx0, err := ctx.Relation(0)
 	c.Assert(err, jc.ErrorIsNil)
-	node0, err := relCtx0.Settings()
+	node0, err := relCtx0.Settings(stdcontext.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	node0.Set("baz", "3")
 	relCtx1, err := ctx.Relation(1)
 	c.Assert(err, jc.ErrorIsNil)
-	node1, err := relCtx1.Settings()
+	node1, err := relCtx1.Settings(stdcontext.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	node1.Set("qux", "4")
 
@@ -92,7 +92,7 @@ func (s *FlushContextSuite) TestRunHookRelationFlushingSuccess(c *gc.C) {
 		}},
 	}
 
-	s.unit.EXPECT().CommitHookChanges(hookCommitMatcher{c, params.CommitHookChangesArgs{
+	s.unit.EXPECT().CommitHookChanges(gomock.Any(), hookCommitMatcher{c: c, expected: params.CommitHookChangesArgs{
 		Args: []params.CommitHookChangesArg{arg},
 	}}).Return(nil)
 
@@ -117,8 +117,8 @@ func (s *FlushContextSuite) TestRebootAfterHook(c *gc.C) {
 	c.Assert(err, gc.Equals, expErr)
 
 	// Flush the context without an error and check that reboot is triggered.
-	s.unit.EXPECT().SetAgentStatus(status.Rebooting, "", nil).Return(nil)
-	s.unit.EXPECT().RequestReboot().Return(nil)
+	s.unit.EXPECT().SetAgentStatus(gomock.Any(), status.Rebooting, "", nil).Return(nil)
+	s.unit.EXPECT().RequestReboot(gomock.Any()).Return(nil)
 	err = ctx.Flush(stdcontext.Background(), "some badge", nil)
 	c.Assert(err, gc.Equals, context.ErrReboot)
 }
@@ -166,8 +166,8 @@ func (s *FlushContextSuite) TestRebootNowWhenHookFails(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Flush the context with an error and check that reboot is triggered regardless.
-	s.unit.EXPECT().SetAgentStatus(status.Rebooting, "", nil).Return(nil)
-	s.unit.EXPECT().RequestReboot().Return(nil)
+	s.unit.EXPECT().SetAgentStatus(gomock.Any(), status.Rebooting, "", nil).Return(nil)
+	s.unit.EXPECT().RequestReboot(gomock.Any()).Return(nil)
 
 	expErr := errors.New("hook execution failed")
 	err = ctx.Flush(stdcontext.Background(), "some badge", expErr)
@@ -193,8 +193,8 @@ func (s *FlushContextSuite) TestRebootNow(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Flush the context without an error and check that reboot is triggered.
-	s.unit.EXPECT().SetAgentStatus(status.Rebooting, "", nil).Return(nil)
-	s.unit.EXPECT().RequestReboot().Return(nil)
+	s.unit.EXPECT().SetAgentStatus(gomock.Any(), status.Rebooting, "", nil).Return(nil)
+	s.unit.EXPECT().RequestReboot(gomock.Any()).Return(nil)
 
 	err = ctx.Flush(stdcontext.Background(), "some badge", nil)
 	c.Assert(err, gc.Equals, context.ErrRequeueAndReboot)
@@ -244,7 +244,7 @@ func (s *FlushContextSuite) TestRunHookOpensAndClosesPendingPorts(c *gc.C) {
 	err = ctx.ClosePortRange("", network.MustParsePortRange("50-80/tcp"))
 	c.Assert(err, jc.ErrorIsNil) // still pending -> no longer pending
 
-	s.unit.EXPECT().CommitHookChanges(hookCommitMatcher{c, params.CommitHookChangesArgs{
+	s.unit.EXPECT().CommitHookChanges(gomock.Any(), hookCommitMatcher{c: c, expected: params.CommitHookChangesArgs{
 		Args: []params.CommitHookChangesArg{{
 			Tag: s.unit.Tag().String(),
 			OpenPorts: []params.EntityPortRange{{
@@ -342,7 +342,7 @@ func (s *FlushContextSuite) TestRunHookUpdatesSecrets(c *gc.C) {
 		}},
 	}
 
-	s.unit.EXPECT().CommitHookChanges(hookCommitMatcher{c, params.CommitHookChangesArgs{
+	s.unit.EXPECT().CommitHookChanges(gomock.Any(), hookCommitMatcher{c: c, expected: params.CommitHookChangesArgs{
 		Args: []params.CommitHookChangesArg{arg},
 	}}).Return(nil)
 

--- a/internal/worker/uniter/runner/context/mocks/leadership_mock.go
+++ b/internal/worker/uniter/runner/context/mocks/leadership_mock.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "go.uber.org/mock/gomock"
@@ -78,18 +79,18 @@ func (c *MockLeadershipContextIsLeaderCall) DoAndReturn(f func() (bool, error)) 
 }
 
 // LeaderSettings mocks base method.
-func (m *MockLeadershipContext) LeaderSettings() (map[string]string, error) {
+func (m *MockLeadershipContext) LeaderSettings(arg0 context.Context) (map[string]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LeaderSettings")
+	ret := m.ctrl.Call(m, "LeaderSettings", arg0)
 	ret0, _ := ret[0].(map[string]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // LeaderSettings indicates an expected call of LeaderSettings.
-func (mr *MockLeadershipContextMockRecorder) LeaderSettings() *MockLeadershipContextLeaderSettingsCall {
+func (mr *MockLeadershipContextMockRecorder) LeaderSettings(arg0 any) *MockLeadershipContextLeaderSettingsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LeaderSettings", reflect.TypeOf((*MockLeadershipContext)(nil).LeaderSettings))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LeaderSettings", reflect.TypeOf((*MockLeadershipContext)(nil).LeaderSettings), arg0)
 	return &MockLeadershipContextLeaderSettingsCall{Call: call}
 }
 
@@ -105,29 +106,29 @@ func (c *MockLeadershipContextLeaderSettingsCall) Return(arg0 map[string]string,
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockLeadershipContextLeaderSettingsCall) Do(f func() (map[string]string, error)) *MockLeadershipContextLeaderSettingsCall {
+func (c *MockLeadershipContextLeaderSettingsCall) Do(f func(context.Context) (map[string]string, error)) *MockLeadershipContextLeaderSettingsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockLeadershipContextLeaderSettingsCall) DoAndReturn(f func() (map[string]string, error)) *MockLeadershipContextLeaderSettingsCall {
+func (c *MockLeadershipContextLeaderSettingsCall) DoAndReturn(f func(context.Context) (map[string]string, error)) *MockLeadershipContextLeaderSettingsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // WriteLeaderSettings mocks base method.
-func (m *MockLeadershipContext) WriteLeaderSettings(arg0 map[string]string) error {
+func (m *MockLeadershipContext) WriteLeaderSettings(arg0 context.Context, arg1 map[string]string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WriteLeaderSettings", arg0)
+	ret := m.ctrl.Call(m, "WriteLeaderSettings", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // WriteLeaderSettings indicates an expected call of WriteLeaderSettings.
-func (mr *MockLeadershipContextMockRecorder) WriteLeaderSettings(arg0 any) *MockLeadershipContextWriteLeaderSettingsCall {
+func (mr *MockLeadershipContextMockRecorder) WriteLeaderSettings(arg0, arg1 any) *MockLeadershipContextWriteLeaderSettingsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteLeaderSettings", reflect.TypeOf((*MockLeadershipContext)(nil).WriteLeaderSettings), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteLeaderSettings", reflect.TypeOf((*MockLeadershipContext)(nil).WriteLeaderSettings), arg0, arg1)
 	return &MockLeadershipContextWriteLeaderSettingsCall{Call: call}
 }
 
@@ -143,13 +144,13 @@ func (c *MockLeadershipContextWriteLeaderSettingsCall) Return(arg0 error) *MockL
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockLeadershipContextWriteLeaderSettingsCall) Do(f func(map[string]string) error) *MockLeadershipContextWriteLeaderSettingsCall {
+func (c *MockLeadershipContextWriteLeaderSettingsCall) Do(f func(context.Context, map[string]string) error) *MockLeadershipContextWriteLeaderSettingsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockLeadershipContextWriteLeaderSettingsCall) DoAndReturn(f func(map[string]string) error) *MockLeadershipContextWriteLeaderSettingsCall {
+func (c *MockLeadershipContextWriteLeaderSettingsCall) DoAndReturn(f func(context.Context, map[string]string) error) *MockLeadershipContextWriteLeaderSettingsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/uniter/runner/context/mocks/payload_mock.go
+++ b/internal/worker/uniter/runner/context/mocks/payload_mock.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	payloads "github.com/juju/juju/core/payloads"
@@ -40,10 +41,10 @@ func (m *MockPayloadAPIClient) EXPECT() *MockPayloadAPIClientMockRecorder {
 }
 
 // List mocks base method.
-func (m *MockPayloadAPIClient) List(arg0 ...string) ([]payloads.Result, error) {
+func (m *MockPayloadAPIClient) List(arg0 context.Context, arg1 ...string) ([]payloads.Result, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{}
-	for _, a := range arg0 {
+	varargs := []any{arg0}
+	for _, a := range arg1 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "List", varargs...)
@@ -53,9 +54,10 @@ func (m *MockPayloadAPIClient) List(arg0 ...string) ([]payloads.Result, error) {
 }
 
 // List indicates an expected call of List.
-func (mr *MockPayloadAPIClientMockRecorder) List(arg0 ...any) *MockPayloadAPIClientListCall {
+func (mr *MockPayloadAPIClientMockRecorder) List(arg0 any, arg1 ...any) *MockPayloadAPIClientListCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockPayloadAPIClient)(nil).List), arg0...)
+	varargs := append([]any{arg0}, arg1...)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockPayloadAPIClient)(nil).List), varargs...)
 	return &MockPayloadAPIClientListCall{Call: call}
 }
 
@@ -71,22 +73,22 @@ func (c *MockPayloadAPIClientListCall) Return(arg0 []payloads.Result, arg1 error
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockPayloadAPIClientListCall) Do(f func(...string) ([]payloads.Result, error)) *MockPayloadAPIClientListCall {
+func (c *MockPayloadAPIClientListCall) Do(f func(context.Context, ...string) ([]payloads.Result, error)) *MockPayloadAPIClientListCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockPayloadAPIClientListCall) DoAndReturn(f func(...string) ([]payloads.Result, error)) *MockPayloadAPIClientListCall {
+func (c *MockPayloadAPIClientListCall) DoAndReturn(f func(context.Context, ...string) ([]payloads.Result, error)) *MockPayloadAPIClientListCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // SetStatus mocks base method.
-func (m *MockPayloadAPIClient) SetStatus(arg0 string, arg1 ...string) ([]payloads.Result, error) {
+func (m *MockPayloadAPIClient) SetStatus(arg0 context.Context, arg1 string, arg2 ...string) ([]payloads.Result, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0}
-	for _, a := range arg1 {
+	varargs := []any{arg0, arg1}
+	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "SetStatus", varargs...)
@@ -96,9 +98,9 @@ func (m *MockPayloadAPIClient) SetStatus(arg0 string, arg1 ...string) ([]payload
 }
 
 // SetStatus indicates an expected call of SetStatus.
-func (mr *MockPayloadAPIClientMockRecorder) SetStatus(arg0 any, arg1 ...any) *MockPayloadAPIClientSetStatusCall {
+func (mr *MockPayloadAPIClientMockRecorder) SetStatus(arg0, arg1 any, arg2 ...any) *MockPayloadAPIClientSetStatusCall {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0}, arg1...)
+	varargs := append([]any{arg0, arg1}, arg2...)
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetStatus", reflect.TypeOf((*MockPayloadAPIClient)(nil).SetStatus), varargs...)
 	return &MockPayloadAPIClientSetStatusCall{Call: call}
 }
@@ -115,22 +117,22 @@ func (c *MockPayloadAPIClientSetStatusCall) Return(arg0 []payloads.Result, arg1 
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockPayloadAPIClientSetStatusCall) Do(f func(string, ...string) ([]payloads.Result, error)) *MockPayloadAPIClientSetStatusCall {
+func (c *MockPayloadAPIClientSetStatusCall) Do(f func(context.Context, string, ...string) ([]payloads.Result, error)) *MockPayloadAPIClientSetStatusCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockPayloadAPIClientSetStatusCall) DoAndReturn(f func(string, ...string) ([]payloads.Result, error)) *MockPayloadAPIClientSetStatusCall {
+func (c *MockPayloadAPIClientSetStatusCall) DoAndReturn(f func(context.Context, string, ...string) ([]payloads.Result, error)) *MockPayloadAPIClientSetStatusCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // Track mocks base method.
-func (m *MockPayloadAPIClient) Track(arg0 ...payloads.Payload) ([]payloads.Result, error) {
+func (m *MockPayloadAPIClient) Track(arg0 context.Context, arg1 ...payloads.Payload) ([]payloads.Result, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{}
-	for _, a := range arg0 {
+	varargs := []any{arg0}
+	for _, a := range arg1 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "Track", varargs...)
@@ -140,9 +142,10 @@ func (m *MockPayloadAPIClient) Track(arg0 ...payloads.Payload) ([]payloads.Resul
 }
 
 // Track indicates an expected call of Track.
-func (mr *MockPayloadAPIClientMockRecorder) Track(arg0 ...any) *MockPayloadAPIClientTrackCall {
+func (mr *MockPayloadAPIClientMockRecorder) Track(arg0 any, arg1 ...any) *MockPayloadAPIClientTrackCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Track", reflect.TypeOf((*MockPayloadAPIClient)(nil).Track), arg0...)
+	varargs := append([]any{arg0}, arg1...)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Track", reflect.TypeOf((*MockPayloadAPIClient)(nil).Track), varargs...)
 	return &MockPayloadAPIClientTrackCall{Call: call}
 }
 
@@ -158,22 +161,22 @@ func (c *MockPayloadAPIClientTrackCall) Return(arg0 []payloads.Result, arg1 erro
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockPayloadAPIClientTrackCall) Do(f func(...payloads.Payload) ([]payloads.Result, error)) *MockPayloadAPIClientTrackCall {
+func (c *MockPayloadAPIClientTrackCall) Do(f func(context.Context, ...payloads.Payload) ([]payloads.Result, error)) *MockPayloadAPIClientTrackCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockPayloadAPIClientTrackCall) DoAndReturn(f func(...payloads.Payload) ([]payloads.Result, error)) *MockPayloadAPIClientTrackCall {
+func (c *MockPayloadAPIClientTrackCall) DoAndReturn(f func(context.Context, ...payloads.Payload) ([]payloads.Result, error)) *MockPayloadAPIClientTrackCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // Untrack mocks base method.
-func (m *MockPayloadAPIClient) Untrack(arg0 ...string) ([]payloads.Result, error) {
+func (m *MockPayloadAPIClient) Untrack(arg0 context.Context, arg1 ...string) ([]payloads.Result, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{}
-	for _, a := range arg0 {
+	varargs := []any{arg0}
+	for _, a := range arg1 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "Untrack", varargs...)
@@ -183,9 +186,10 @@ func (m *MockPayloadAPIClient) Untrack(arg0 ...string) ([]payloads.Result, error
 }
 
 // Untrack indicates an expected call of Untrack.
-func (mr *MockPayloadAPIClientMockRecorder) Untrack(arg0 ...any) *MockPayloadAPIClientUntrackCall {
+func (mr *MockPayloadAPIClientMockRecorder) Untrack(arg0 any, arg1 ...any) *MockPayloadAPIClientUntrackCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Untrack", reflect.TypeOf((*MockPayloadAPIClient)(nil).Untrack), arg0...)
+	varargs := append([]any{arg0}, arg1...)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Untrack", reflect.TypeOf((*MockPayloadAPIClient)(nil).Untrack), varargs...)
 	return &MockPayloadAPIClientUntrackCall{Call: call}
 }
 
@@ -201,13 +205,13 @@ func (c *MockPayloadAPIClientUntrackCall) Return(arg0 []payloads.Result, arg1 er
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockPayloadAPIClientUntrackCall) Do(f func(...string) ([]payloads.Result, error)) *MockPayloadAPIClientUntrackCall {
+func (c *MockPayloadAPIClientUntrackCall) Do(f func(context.Context, ...string) ([]payloads.Result, error)) *MockPayloadAPIClientUntrackCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockPayloadAPIClientUntrackCall) DoAndReturn(f func(...string) ([]payloads.Result, error)) *MockPayloadAPIClientUntrackCall {
+func (c *MockPayloadAPIClientUntrackCall) DoAndReturn(f func(context.Context, ...string) ([]payloads.Result, error)) *MockPayloadAPIClientUntrackCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/uniter/runner/context/payloads/context_test.go
+++ b/internal/worker/uniter/runner/context/payloads/context_test.go
@@ -4,6 +4,8 @@
 package payloads_test
 
 import (
+	"context"
+
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"go.uber.org/mock/gomock"
@@ -32,7 +34,7 @@ func (s *contextSuite) TestNewContext(c *gc.C) {
 			Name: "class",
 		},
 	}
-	client.EXPECT().List().Return([]corepayloads.Result{{
+	client.EXPECT().List(gomock.Any()).Return([]corepayloads.Result{{
 		ID: "id",
 		Payload: &corepayloads.FullPayloadInfo{
 			Payload: pl,
@@ -40,7 +42,7 @@ func (s *contextSuite) TestNewContext(c *gc.C) {
 		},
 	}}, nil)
 
-	ctx, err := payloads.NewContext(client)
+	ctx, err := payloads.NewContext(context.Background(), client)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(payloads.ContextPayloads(ctx), jc.DeepEquals, map[string]corepayloads.Payload{
 		"class": pl,
@@ -63,7 +65,7 @@ func (s *contextSuite) TestTrackPayloads(c *gc.C) {
 			Name: "class",
 		},
 	}
-	client.EXPECT().List().Return([]corepayloads.Result{{
+	client.EXPECT().List(gomock.Any()).Return([]corepayloads.Result{{
 		ID: "id",
 		Payload: &corepayloads.FullPayloadInfo{
 			Payload: pl,
@@ -81,7 +83,7 @@ func (s *contextSuite) TestTrackPayloads(c *gc.C) {
 		},
 	}
 
-	ctx, err := payloads.NewContext(client)
+	ctx, err := payloads.NewContext(context.Background(), client)
 	c.Assert(err, jc.ErrorIsNil)
 	err = ctx.TrackPayload(pl2)
 	c.Assert(err, jc.ErrorIsNil)
@@ -106,7 +108,7 @@ func (s *contextSuite) TestTrackPayloadsFlush(c *gc.C) {
 			Name: "class",
 		},
 	}
-	client.EXPECT().List().Return([]corepayloads.Result{{
+	client.EXPECT().List(gomock.Any()).Return([]corepayloads.Result{{
 		ID: "id",
 		Payload: &corepayloads.FullPayloadInfo{
 			Payload: pl,
@@ -123,13 +125,13 @@ func (s *contextSuite) TestTrackPayloadsFlush(c *gc.C) {
 			Type: "type",
 		},
 	}
-	client.EXPECT().Track(pl2)
+	client.EXPECT().Track(gomock.Any(), pl2)
 
-	ctx, err := payloads.NewContext(client)
+	ctx, err := payloads.NewContext(context.Background(), client)
 	c.Assert(err, jc.ErrorIsNil)
 	err = ctx.TrackPayload(pl2)
 	c.Assert(err, jc.ErrorIsNil)
-	err = ctx.FlushPayloads()
+	err = ctx.FlushPayloads(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 
 	result, err := ctx.Payloads()
@@ -153,7 +155,7 @@ func (s *contextSuite) TestFlushNotDirty(c *gc.C) {
 			Name: "class",
 		},
 	}
-	client.EXPECT().List().Return([]corepayloads.Result{{
+	client.EXPECT().List(gomock.Any()).Return([]corepayloads.Result{{
 		ID: "id",
 		Payload: &corepayloads.FullPayloadInfo{
 			Payload: pl,
@@ -161,9 +163,9 @@ func (s *contextSuite) TestFlushNotDirty(c *gc.C) {
 		},
 	}}, nil)
 
-	ctx, err := payloads.NewContext(client)
+	ctx, err := payloads.NewContext(context.Background(), client)
 	c.Assert(err, jc.ErrorIsNil)
-	err = ctx.FlushPayloads()
+	err = ctx.FlushPayloads(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 
 	result, err := ctx.Payloads()
@@ -189,7 +191,7 @@ func (s *contextSuite) TestTrackOverwritePayloads(c *gc.C) {
 		},
 		Unit: "a/0",
 	}
-	client.EXPECT().List().Return([]corepayloads.Result{{
+	client.EXPECT().List(gomock.Any()).Return([]corepayloads.Result{{
 		ID: "id",
 		Payload: &corepayloads.FullPayloadInfo{
 			Payload: pl,
@@ -198,13 +200,13 @@ func (s *contextSuite) TestTrackOverwritePayloads(c *gc.C) {
 	}}, nil)
 
 	pl.Status = "stopping"
-	client.EXPECT().Track(pl)
+	client.EXPECT().Track(gomock.Any(), pl)
 
-	ctx, err := payloads.NewContext(client)
+	ctx, err := payloads.NewContext(context.Background(), client)
 	c.Assert(err, jc.ErrorIsNil)
 	err = ctx.TrackPayload(pl)
 	c.Assert(err, jc.ErrorIsNil)
-	err = ctx.FlushPayloads()
+	err = ctx.FlushPayloads(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 
 	result, err := ctx.Payloads()
@@ -227,7 +229,7 @@ func (s *contextSuite) TestUnTrackPayloads(c *gc.C) {
 			Name: "class",
 		},
 	}
-	client.EXPECT().List().Return([]corepayloads.Result{{
+	client.EXPECT().List(gomock.Any()).Return([]corepayloads.Result{{
 		ID: "id",
 		Payload: &corepayloads.FullPayloadInfo{
 			Payload: pl,
@@ -235,11 +237,11 @@ func (s *contextSuite) TestUnTrackPayloads(c *gc.C) {
 		},
 	}}, nil)
 
-	client.EXPECT().Untrack("class/id")
+	client.EXPECT().Untrack(gomock.Any(), "class/id")
 
-	ctx, err := payloads.NewContext(client)
+	ctx, err := payloads.NewContext(context.Background(), client)
 	c.Assert(err, jc.ErrorIsNil)
-	err = ctx.UntrackPayload("class", "id")
+	err = ctx.UntrackPayload(context.Background(), "class", "id")
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(payloads.ContextPayloads(ctx), jc.DeepEquals, map[string]corepayloads.Payload{})
@@ -257,7 +259,7 @@ func (s *contextSuite) TestSetPayloadStatus(c *gc.C) {
 			Name: "class",
 		},
 	}
-	client.EXPECT().List().Return([]corepayloads.Result{{
+	client.EXPECT().List(gomock.Any()).Return([]corepayloads.Result{{
 		ID: "id",
 		Payload: &corepayloads.FullPayloadInfo{
 			Payload: pl,
@@ -265,11 +267,11 @@ func (s *contextSuite) TestSetPayloadStatus(c *gc.C) {
 		},
 	}}, nil)
 
-	client.EXPECT().SetStatus("stopping", "class/id")
+	client.EXPECT().SetStatus(gomock.Any(), "stopping", "class/id")
 
-	ctx, err := payloads.NewContext(client)
+	ctx, err := payloads.NewContext(context.Background(), client)
 	c.Assert(err, jc.ErrorIsNil)
-	err = ctx.SetPayloadStatus("class", "id", "stopping")
+	err = ctx.SetPayloadStatus(context.Background(), "class", "id", "stopping")
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -285,7 +287,7 @@ func (s *contextSuite) TestGetPayload(c *gc.C) {
 			Name: "class",
 		},
 	}
-	client.EXPECT().List().Return([]corepayloads.Result{{
+	client.EXPECT().List(gomock.Any()).Return([]corepayloads.Result{{
 		ID: "id",
 		Payload: &corepayloads.FullPayloadInfo{
 			Payload: pl,
@@ -293,7 +295,7 @@ func (s *contextSuite) TestGetPayload(c *gc.C) {
 		},
 	}}, nil)
 
-	ctx, err := payloads.NewContext(client)
+	ctx, err := payloads.NewContext(context.Background(), client)
 	c.Assert(err, jc.ErrorIsNil)
 	result, err := ctx.GetPayload("class", "id")
 	c.Assert(err, jc.ErrorIsNil)
@@ -315,7 +317,7 @@ func (s *contextSuite) TestTrackedPayload(c *gc.C) {
 		},
 		Unit: "a/0",
 	}
-	client.EXPECT().List().Return([]corepayloads.Result{{
+	client.EXPECT().List(gomock.Any()).Return([]corepayloads.Result{{
 		ID: "id",
 		Payload: &corepayloads.FullPayloadInfo{
 			Payload: pl,
@@ -325,7 +327,7 @@ func (s *contextSuite) TestTrackedPayload(c *gc.C) {
 
 	pl.Status = "stopping"
 
-	ctx, err := payloads.NewContext(client)
+	ctx, err := payloads.NewContext(context.Background(), client)
 	c.Assert(err, jc.ErrorIsNil)
 	err = ctx.TrackPayload(pl)
 	c.Assert(err, jc.ErrorIsNil)

--- a/internal/worker/uniter/runner/context/relation.go
+++ b/internal/worker/uniter/runner/context/relation.go
@@ -21,7 +21,7 @@ import (
 type RelationUnit interface {
 	// ApplicationSettings returns a Settings which allows access to this unit's
 	// application settings within the relation.
-	ApplicationSettings() (*uniter.Settings, error)
+	ApplicationSettings(context.Context) (*uniter.Settings, error)
 
 	// Endpoint returns the relation endpoint that defines the unit's
 	// participation in the relation.
@@ -29,14 +29,14 @@ type RelationUnit interface {
 
 	// ReadSettings returns a map holding the settings of the unit with the
 	// supplied name within this relation.
-	ReadSettings(name string) (params.Settings, error)
+	ReadSettings(ctx context.Context, name string) (params.Settings, error)
 
 	// Relation returns the relation associated with the unit.
 	Relation() api.Relation
 
 	// Settings returns a Settings which allows access to the unit's settings
 	// within the relation.
-	Settings() (*uniter.Settings, error)
+	Settings(context.Context) (*uniter.Settings, error)
 }
 
 type RelationInfo struct {
@@ -73,84 +73,84 @@ func NewContextRelation(ru RelationUnit, cache *RelationCache, broken bool) *Con
 	}
 }
 
-func (ctx *ContextRelation) Id() int {
-	return ctx.relationId
+func (c *ContextRelation) Id() int {
+	return c.relationId
 }
 
-func (ctx *ContextRelation) Name() string {
-	return ctx.endpointName
+func (c *ContextRelation) Name() string {
+	return c.endpointName
 }
 
-func (ctx *ContextRelation) RelationTag() names.RelationTag {
-	return ctx.ru.Relation().Tag()
+func (c *ContextRelation) RelationTag() names.RelationTag {
+	return c.ru.Relation().Tag()
 }
 
-func (ctx *ContextRelation) FakeId() string {
-	return fmt.Sprintf("%s:%d", ctx.endpointName, ctx.relationId)
+func (c *ContextRelation) FakeId() string {
+	return fmt.Sprintf("%s:%d", c.endpointName, c.relationId)
 }
 
-func (ctx *ContextRelation) UnitNames() []string {
-	return ctx.cache.MemberNames()
+func (c *ContextRelation) UnitNames() []string {
+	return c.cache.MemberNames()
 }
 
-func (ctx *ContextRelation) ReadSettings(unit string) (settings params.Settings, err error) {
-	return ctx.cache.Settings(unit)
+func (c *ContextRelation) ReadSettings(ctx context.Context, unit string) (settings params.Settings, err error) {
+	return c.cache.Settings(ctx, unit)
 }
 
-func (ctx *ContextRelation) ReadApplicationSettings(app string) (settings params.Settings, err error) {
-	return ctx.cache.ApplicationSettings(app)
+func (c *ContextRelation) ReadApplicationSettings(ctx context.Context, app string) (settings params.Settings, err error) {
+	return c.cache.ApplicationSettings(ctx, app)
 }
 
-func (ctx *ContextRelation) Settings() (jujuc.Settings, error) {
-	if ctx.settings == nil {
-		node, err := ctx.ru.Settings()
+func (c *ContextRelation) Settings(ctx context.Context) (jujuc.Settings, error) {
+	if c.settings == nil {
+		node, err := c.ru.Settings(ctx)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		ctx.settings = node
+		c.settings = node
 	}
-	return ctx.settings, nil
+	return c.settings, nil
 }
 
-func (ctx *ContextRelation) ApplicationSettings() (jujuc.Settings, error) {
-	if ctx.applicationSettings == nil {
-		settings, err := ctx.ru.ApplicationSettings()
+func (c *ContextRelation) ApplicationSettings(ctx context.Context) (jujuc.Settings, error) {
+	if c.applicationSettings == nil {
+		settings, err := c.ru.ApplicationSettings(ctx)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		ctx.applicationSettings = settings
+		c.applicationSettings = settings
 	}
-	return ctx.applicationSettings, nil
+	return c.applicationSettings, nil
 }
 
 // FinalSettings returns the changes made to the relation settings (unit and application)
-func (ctx *ContextRelation) FinalSettings() (unitSettings, appSettings params.Settings) {
-	if ctx.applicationSettings != nil && ctx.applicationSettings.IsDirty() {
-		appSettings = ctx.applicationSettings.FinalResult()
+func (c *ContextRelation) FinalSettings() (unitSettings, appSettings params.Settings) {
+	if c.applicationSettings != nil && c.applicationSettings.IsDirty() {
+		appSettings = c.applicationSettings.FinalResult()
 	}
-	if ctx.settings != nil {
-		unitSettings = ctx.settings.FinalResult()
+	if c.settings != nil {
+		unitSettings = c.settings.FinalResult()
 	}
 	return unitSettings, appSettings
 }
 
 // Suspended returns true if the relation is suspended.
-func (ctx *ContextRelation) Suspended() bool {
-	return ctx.ru.Relation().Suspended()
+func (c *ContextRelation) Suspended() bool {
+	return c.ru.Relation().Suspended()
 }
 
 // SetStatus sets the relation's status.
-func (ctx *ContextRelation) SetStatus(stdCtx context.Context, status relation.Status) error {
-	return errors.Trace(ctx.ru.Relation().SetStatus(stdCtx, status))
+func (c *ContextRelation) SetStatus(ctx context.Context, status relation.Status) error {
+	return errors.Trace(c.ru.Relation().SetStatus(ctx, status))
 }
 
 // RemoteApplicationName returns the application on the other end of this
 // relation from the perspective of this unit.
-func (ctx *ContextRelation) RemoteApplicationName() string {
-	return ctx.ru.Relation().OtherApplication()
+func (c *ContextRelation) RemoteApplicationName() string {
+	return c.ru.Relation().OtherApplication()
 }
 
 // Life returns the relation's current life state.
-func (ctx *ContextRelation) Life() life.Value {
-	return ctx.ru.Relation().Life()
+func (c *ContextRelation) Life() life.Value {
+	return c.ru.Relation().Life()
 }

--- a/internal/worker/uniter/runner/context/relation_test.go
+++ b/internal/worker/uniter/runner/context/relation_test.go
@@ -41,19 +41,19 @@ func (s *ContextRelationSuite) setUp(c *gc.C) *gomock.Controller {
 func (s *ContextRelationSuite) assertSettingsCaching(c *gc.C, members ...string) {
 	defer s.setUp(c).Finish()
 
-	s.relUnit.EXPECT().ReadSettings("u/1").Return(params.Settings{"blib": "blob"}, nil)
+	s.relUnit.EXPECT().ReadSettings(stdcontext.Background(), "u/1").Return(params.Settings{"blib": "blob"}, nil)
 
 	cache := context.NewRelationCache(s.relUnit.ReadSettings, members)
 	ctx := context.NewContextRelation(s.relUnit, cache, false)
 
 	// Check that uncached settings are read once.
-	m, err := ctx.ReadSettings("u/1")
+	m, err := ctx.ReadSettings(stdcontext.Background(), "u/1")
 	c.Assert(err, jc.ErrorIsNil)
 	expectSettings := convertMap(map[string]interface{}{"blib": "blob"})
 	c.Assert(m, gc.DeepEquals, expectSettings)
 
 	// Check that another call does not hit the api.
-	m, err = ctx.ReadSettings("u/1")
+	m, err = ctx.ReadSettings(stdcontext.Background(), "u/1")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(m, gc.DeepEquals, expectSettings)
 }

--- a/internal/worker/uniter/runner/context/storage_test.go
+++ b/internal/worker/uniter/runner/context/storage_test.go
@@ -64,7 +64,7 @@ func (s *StorageSuite) assertUnitStorageAdded(c *gc.C, ctrl *gomock.Controller, 
 		c.Check(err, jc.ErrorIsNil)
 	}
 
-	s.unit.EXPECT().CommitHookChanges(hookCommitMatcher{c, params.CommitHookChangesArgs{
+	s.unit.EXPECT().CommitHookChanges(gomock.Any(), hookCommitMatcher{c: c, expected: params.CommitHookChangesArgs{
 		Args: []params.CommitHookChangesArg{arg},
 	}}).Return(nil)
 

--- a/internal/worker/uniter/runner/factory_test.go
+++ b/internal/worker/uniter/runner/factory_test.go
@@ -146,7 +146,7 @@ func (s *FactorySuite) TestNewHookRunnerWithStorage(c *gc.C) {
 	defer ctrl.Finish()
 	s.setupFactory(c, ctrl)
 
-	s.uniter.EXPECT().StorageAttachment(names.NewStorageTag("data/0"), names.NewUnitTag("u/0")).Return(params.StorageAttachment{
+	s.uniter.EXPECT().StorageAttachment(gomock.Any(), names.NewStorageTag("data/0"), names.NewUnitTag("u/0")).Return(params.StorageAttachment{
 		Kind:     params.StorageKindBlock,
 		Location: "/dev/sdb",
 	}, nil).AnyTimes()

--- a/internal/worker/uniter/runner/jujuc/action-log.go
+++ b/internal/worker/uniter/runner/jujuc/action-log.go
@@ -40,5 +40,5 @@ func (c *ActionLogCommand) Init(args []string) error {
 }
 
 func (c *ActionLogCommand) Run(ctx *cmd.Context) error {
-	return c.ctx.LogActionMessage(c.Message)
+	return c.ctx.LogActionMessage(ctx, c.Message)
 }

--- a/internal/worker/uniter/runner/jujuc/action-log_test.go
+++ b/internal/worker/uniter/runner/jujuc/action-log_test.go
@@ -4,6 +4,7 @@
 package jujuc_test
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/juju/cmd/v4"
@@ -23,7 +24,7 @@ type actionLogContext struct {
 	logMessage string
 }
 
-func (ctx *actionLogContext) LogActionMessage(message string) error {
+func (ctx *actionLogContext) LogActionMessage(_ context.Context, message string) error {
 	ctx.logMessage = message
 	return nil
 }
@@ -32,7 +33,7 @@ type nonActionLogContext struct {
 	jujuc.Context
 }
 
-func (ctx *nonActionLogContext) LogActionMessage(message string) error {
+func (ctx *nonActionLogContext) LogActionMessage(_ context.Context, message string) error {
 	return fmt.Errorf("not running an action")
 }
 

--- a/internal/worker/uniter/runner/jujuc/config-get.go
+++ b/internal/worker/uniter/runner/jujuc/config-get.go
@@ -58,7 +58,7 @@ func (c *ConfigGetCommand) Init(args []string) error {
 }
 
 func (c *ConfigGetCommand) Run(ctx *cmd.Context) error {
-	settings, err := c.ctx.ConfigSettings()
+	settings, err := c.ctx.ConfigSettings(ctx)
 	if err != nil {
 		return err
 	}

--- a/internal/worker/uniter/runner/jujuc/context.go
+++ b/internal/worker/uniter/runner/jujuc/context.go
@@ -106,7 +106,7 @@ type actionHookContext interface {
 	SetActionFailed() error
 
 	// LogActionMessage records a progress message for the Action.
-	LogActionMessage(string) error
+	LogActionMessage(context.Context, string) error
 }
 
 // WorkloadHookContext is the context for a workload hook.
@@ -143,7 +143,7 @@ type ContextUnit interface {
 
 	// ConfigSettings returns the current application
 	// configuration of the executing unit.
-	ConfigSettings() (charm.Settings, error)
+	ConfigSettings(context.Context) (charm.Settings, error)
 
 	// GoalState returns the goal state for the current unit.
 	GoalState(context.Context) (*application.GoalState, error)
@@ -198,10 +198,10 @@ type SecretMetadata struct {
 // ContextSecrets is the part of a hook context related to secrets.
 type ContextSecrets interface {
 	// GetSecret returns the value of the specified secret.
-	GetSecret(*secrets.URI, string, bool, bool) (secrets.SecretValue, error)
+	GetSecret(context.Context, *secrets.URI, string, bool, bool) (secrets.SecretValue, error)
 
 	// CreateSecret creates a secret with the specified data.
-	CreateSecret(*SecretCreateArgs) (*secrets.URI, error)
+	CreateSecret(context.Context, *SecretCreateArgs) (*secrets.URI, error)
 
 	// UpdateSecret creates a secret with the specified data.
 	UpdateSecret(*secrets.URI, *SecretUpdateArgs) error
@@ -253,7 +253,7 @@ type ContextInstance interface {
 type ContextNetworking interface {
 	// PublicAddress returns the executing unit's public address or an
 	// error if it is not available.
-	PublicAddress() (string, error)
+	PublicAddress(context.Context) (string, error)
 
 	// PrivateAddress returns the executing unit's private address or an
 	// error if it is not available.
@@ -272,7 +272,7 @@ type ContextNetworking interface {
 	OpenedPortRanges() network.GroupedPortRanges
 
 	// NetworkInfo returns the network info for the given bindings on the given relation.
-	NetworkInfo(bindingNames []string, relationId int) (map[string]params.NetworkInfoResult, error)
+	NetworkInfo(ctx context.Context, bindingNames []string, relationId int) (map[string]params.NetworkInfoResult, error)
 }
 
 // ContextLeadership is the part of a hook context related to the
@@ -285,11 +285,11 @@ type ContextLeadership interface {
 	// LeaderSettings returns the current leader settings. Once leader settings
 	// have been read in a given context, they will not be updated other than
 	// via successful calls to WriteLeaderSettings.
-	LeaderSettings() (map[string]string, error)
+	LeaderSettings(context.Context) (map[string]string, error)
 
 	// WriteLeaderSettings writes the supplied settings directly to state, or
 	// fails if the local unit is not the application's leader.
-	WriteLeaderSettings(map[string]string) error
+	WriteLeaderSettings(context.Context, map[string]string) error
 }
 
 // ContextStorage is the part of a hook context related to storage
@@ -297,17 +297,17 @@ type ContextLeadership interface {
 type ContextStorage interface {
 	// StorageTags returns a list of tags for storage instances
 	// attached to the unit or an error if they are not available.
-	StorageTags() ([]names.StorageTag, error)
+	StorageTags(context.Context) ([]names.StorageTag, error)
 
 	// Storage returns the ContextStorageAttachment with the supplied
 	// tag if it was found, and an error if it was not found or is not
 	// available to the context.
-	Storage(names.StorageTag) (ContextStorageAttachment, error)
+	Storage(context.Context, names.StorageTag) (ContextStorageAttachment, error)
 
 	// HookStorage returns the storage attachment associated
 	// the executing hook if it was found, and an error if it
 	// was not found or is not available.
-	HookStorage() (ContextStorageAttachment, error)
+	HookStorage(context.Context) (ContextStorageAttachment, error)
 
 	// AddUnitStorage saves storage directives in the context.
 	AddUnitStorage(map[string]params.StorageDirectives) error
@@ -329,13 +329,13 @@ type ContextPayloads interface {
 	// TrackPayload records the payload info in the hook context.
 	TrackPayload(payload payloads.Payload) error
 	// UntrackPayload removes the payload from our list of payloads to track.
-	UntrackPayload(class, id string) error
+	UntrackPayload(ctx context.Context, class, id string) error
 	// SetPayloadStatus sets the status of the payload.
-	SetPayloadStatus(class, id, status string) error
+	SetPayloadStatus(ctx context.Context, class, id, status string) error
 	// ListPayloads returns the list of registered payload IDs.
 	ListPayloads() ([]string, error)
 	// FlushPayloads pushes the hook context data out to state.
-	FlushPayloads() error
+	FlushPayloads(context.Context) error
 }
 
 // ContextRelations exposes the relations associated with the unit.
@@ -371,20 +371,20 @@ type ContextRelation interface {
 
 	// Settings allows read/write access to the local unit's settings in
 	// this relation.
-	Settings() (Settings, error)
+	Settings(context.Context) (Settings, error)
 
 	// ApplicationSettings allows read/write access to the application settings in
 	// this relation, but only if the current unit is leader.
-	ApplicationSettings() (Settings, error)
+	ApplicationSettings(context.Context) (Settings, error)
 
 	// UnitNames returns a list of the remote units in the relation.
 	UnitNames() []string
 
 	// ReadSettings returns the settings of any remote unit in the relation.
-	ReadSettings(unit string) (params.Settings, error)
+	ReadSettings(ctx context.Context, unit string) (params.Settings, error)
 
 	// ReadApplicationSettings returns the application settings of any remote unit in the relation.
-	ReadApplicationSettings(app string) (params.Settings, error)
+	ReadApplicationSettings(ctx context.Context, app string) (params.Settings, error)
 
 	// Suspended returns true if the relation is suspended.
 	Suspended() bool

--- a/internal/worker/uniter/runner/jujuc/jujuctesting/action.go
+++ b/internal/worker/uniter/runner/jujuc/jujuctesting/action.go
@@ -4,6 +4,8 @@
 package jujuctesting
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 )
 
@@ -45,7 +47,7 @@ func (c *ContextActionHook) UpdateActionResults(keys []string, value interface{}
 }
 
 // LogActionMessage implements jujuc.ActionHookContext.
-func (c *ContextActionHook) LogActionMessage(message string) error {
+func (c *ContextActionHook) LogActionMessage(_ context.Context, message string) error {
 	c.stub.AddCall("LogActionMessage", message)
 	if err := c.stub.NextErr(); err != nil {
 		return errors.Trace(err)

--- a/internal/worker/uniter/runner/jujuc/jujuctesting/leadership.go
+++ b/internal/worker/uniter/runner/jujuc/jujuctesting/leadership.go
@@ -4,6 +4,8 @@
 package jujuctesting
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 )
 
@@ -30,7 +32,7 @@ func (c *ContextLeader) IsLeader() (bool, error) {
 }
 
 // LeaderSettings implements jujuc.ContextLeader.
-func (c *ContextLeader) LeaderSettings() (map[string]string, error) {
+func (c *ContextLeader) LeaderSettings(_ context.Context) (map[string]string, error) {
 	c.stub.AddCall("LeaderSettings")
 	if err := c.stub.NextErr(); err != nil {
 		return nil, errors.Trace(err)
@@ -40,7 +42,7 @@ func (c *ContextLeader) LeaderSettings() (map[string]string, error) {
 }
 
 // WriteLeaderSettings implements jujuc.ContextLeader.
-func (c *ContextLeader) WriteLeaderSettings(settings map[string]string) error {
+func (c *ContextLeader) WriteLeaderSettings(_ context.Context, settings map[string]string) error {
 	c.stub.AddCall("WriteLeaderSettings")
 	if err := c.stub.NextErr(); err != nil {
 		return errors.Trace(err)

--- a/internal/worker/uniter/runner/jujuc/jujuctesting/networking.go
+++ b/internal/worker/uniter/runner/jujuc/jujuctesting/networking.go
@@ -4,6 +4,8 @@
 package jujuctesting
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -56,7 +58,7 @@ type ContextNetworking struct {
 }
 
 // PublicAddress implements jujuc.ContextNetworking.
-func (c *ContextNetworking) PublicAddress() (string, error) {
+func (c *ContextNetworking) PublicAddress(_ context.Context) (string, error) {
 	c.stub.AddCall("PublicAddress")
 
 	return c.info.PublicAddress, c.stub.NextErr()
@@ -102,7 +104,7 @@ func (c *ContextNetworking) OpenedPortRanges() network.GroupedPortRanges {
 }
 
 // NetworkInfo implements jujuc.ContextNetworking.
-func (c *ContextNetworking) NetworkInfo(bindingNames []string, relationId int) (map[string]params.NetworkInfoResult, error) {
+func (c *ContextNetworking) NetworkInfo(_ context.Context, bindingNames []string, relationId int) (map[string]params.NetworkInfoResult, error) {
 	c.stub.AddCall("NetworkInfo", bindingNames, relationId)
 	if err := c.stub.NextErr(); err != nil {
 		return nil, errors.Trace(err)

--- a/internal/worker/uniter/runner/jujuc/jujuctesting/payloads.go
+++ b/internal/worker/uniter/runner/jujuc/jujuctesting/payloads.go
@@ -3,7 +3,11 @@
 
 package jujuctesting
 
-import "github.com/juju/juju/core/payloads"
+import (
+	"context"
+
+	"github.com/juju/juju/core/payloads"
+)
 
 // ContextPayloads is a test double for jujuc.ContextResources.
 type ContextPayloads struct {
@@ -23,13 +27,13 @@ func (c *ContextPayloads) TrackPayload(payload payloads.Payload) error {
 }
 
 // UntrackPayload implements jujuc.ContextPayloads.
-func (c *ContextPayloads) UntrackPayload(class, id string) error {
+func (c *ContextPayloads) UntrackPayload(_ context.Context, class, id string) error {
 	c.stub.AddCall("UntrackPayload", class, id)
 	return nil
 }
 
 // SetPayloadStatus implements jujuc.ContextPayloads.
-func (c *ContextPayloads) SetPayloadStatus(class, id, status string) error {
+func (c *ContextPayloads) SetPayloadStatus(_ context.Context, class, id, status string) error {
 	c.stub.AddCall("SetPayloadStatus", class, id, status)
 	return nil
 }
@@ -41,7 +45,7 @@ func (c *ContextPayloads) ListPayloads() ([]string, error) {
 }
 
 // FlushPayloads implements jujuc.ContextPayloads.
-func (c *ContextPayloads) FlushPayloads() error {
+func (c *ContextPayloads) FlushPayloads(_ context.Context) error {
 	c.stub.AddCall("FlushPayloads")
 	return nil
 }

--- a/internal/worker/uniter/runner/jujuc/jujuctesting/relation.go
+++ b/internal/worker/uniter/runner/jujuc/jujuctesting/relation.go
@@ -109,7 +109,7 @@ func (r *ContextRelation) Life() life.Value {
 }
 
 // Settings implements jujuc.ContextRelation.
-func (r *ContextRelation) Settings() (jujuc.Settings, error) {
+func (r *ContextRelation) Settings(_ context.Context) (jujuc.Settings, error) {
 	r.stub.AddCall("Settings")
 	if err := r.stub.NextErr(); err != nil {
 		return nil, errors.Trace(err)
@@ -123,7 +123,7 @@ func (r *ContextRelation) Settings() (jujuc.Settings, error) {
 }
 
 // ApplicationSettings implements jujuc.ContextRelation.
-func (r *ContextRelation) ApplicationSettings() (jujuc.Settings, error) {
+func (r *ContextRelation) ApplicationSettings(context.Context) (jujuc.Settings, error) {
 	r.stub.AddCall("ApplicationSettings")
 	if err := r.stub.NextErr(); err != nil {
 		return nil, errors.Trace(err)
@@ -146,7 +146,7 @@ func (r *ContextRelation) UnitNames() []string {
 }
 
 // ReadSettings implements jujuc.ContextRelation.
-func (r *ContextRelation) ReadSettings(name string) (params.Settings, error) {
+func (r *ContextRelation) ReadSettings(_ context.Context, name string) (params.Settings, error) {
 	r.stub.AddCall("ReadSettings", name)
 	if err := r.stub.NextErr(); err != nil {
 		return nil, errors.Trace(err)
@@ -160,7 +160,7 @@ func (r *ContextRelation) ReadSettings(name string) (params.Settings, error) {
 }
 
 // ReadApplicationSettings implements jujuc.ContextRelation.
-func (r *ContextRelation) ReadApplicationSettings(name string) (params.Settings, error) {
+func (r *ContextRelation) ReadApplicationSettings(_ context.Context, name string) (params.Settings, error) {
 	r.stub.AddCall("ReadApplicationSettings", name)
 	if err := r.stub.NextErr(); err != nil {
 		return nil, errors.Trace(err)

--- a/internal/worker/uniter/runner/jujuc/jujuctesting/secrets.go
+++ b/internal/worker/uniter/runner/jujuc/jujuctesting/secrets.go
@@ -4,6 +4,8 @@
 package jujuctesting
 
 import (
+	"context"
+
 	"github.com/juju/juju/core/secrets"
 	"github.com/juju/juju/internal/worker/uniter/runner/jujuc"
 )
@@ -17,13 +19,13 @@ type ContextSecrets struct {
 }
 
 // GetSecret implements jujuc.ContextSecrets.
-func (c *ContextSecrets) GetSecret(uri *secrets.URI, label string, refresh, peek bool) (secrets.SecretValue, error) {
+func (c *ContextSecrets) GetSecret(_ context.Context, uri *secrets.URI, label string, refresh, peek bool) (secrets.SecretValue, error) {
 	c.stub.AddCall("GetSecret", uri.String(), label, refresh, peek)
 	return c.SecretValue, nil
 }
 
 // CreateSecret implements jujuc.ContextSecrets.
-func (c *ContextSecrets) CreateSecret(args *jujuc.SecretCreateArgs) (*secrets.URI, error) {
+func (c *ContextSecrets) CreateSecret(_ context.Context, args *jujuc.SecretCreateArgs) (*secrets.URI, error) {
 	c.stub.AddCall("CreateSecret", args)
 	uri, _ := secrets.ParseURI("secret:9m4e2mr0ui3e8a215n4g")
 	return uri, nil

--- a/internal/worker/uniter/runner/jujuc/jujuctesting/storage.go
+++ b/internal/worker/uniter/runner/jujuc/jujuctesting/storage.go
@@ -4,6 +4,7 @@
 package jujuctesting
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/juju/errors"
@@ -82,7 +83,7 @@ type ContextStorage struct {
 }
 
 // StorageTags implements jujuc.ContextStorage.
-func (c *ContextStorage) StorageTags() ([]names.StorageTag, error) {
+func (c *ContextStorage) StorageTags(_ context.Context) ([]names.StorageTag, error) {
 	c.stub.AddCall("StorageTags")
 
 	tags := names.NewSet()
@@ -97,7 +98,7 @@ func (c *ContextStorage) StorageTags() ([]names.StorageTag, error) {
 }
 
 // Storage implements jujuc.ContextStorage.
-func (c *ContextStorage) Storage(tag names.StorageTag) (jujuc.ContextStorageAttachment, error) {
+func (c *ContextStorage) Storage(_ context.Context, tag names.StorageTag) (jujuc.ContextStorageAttachment, error) {
 	c.stub.AddCall("Storage")
 
 	storage, ok := c.info.Storage[tag]
@@ -110,10 +111,10 @@ func (c *ContextStorage) Storage(tag names.StorageTag) (jujuc.ContextStorageAtta
 }
 
 // HookStorage implements jujuc.ContextStorage.
-func (c *ContextStorage) HookStorage() (jujuc.ContextStorageAttachment, error) {
+func (c *ContextStorage) HookStorage(ctx context.Context) (jujuc.ContextStorageAttachment, error) {
 	c.stub.AddCall("HookStorage")
 
-	return c.Storage(c.info.StorageTag)
+	return c.Storage(ctx, c.info.StorageTag)
 }
 
 // AddUnitStorage implements jujuc.ContextStorage.

--- a/internal/worker/uniter/runner/jujuc/jujuctesting/unit.go
+++ b/internal/worker/uniter/runner/jujuc/jujuctesting/unit.go
@@ -38,7 +38,7 @@ func (c *ContextUnit) UnitName() string {
 }
 
 // ConfigSettings implements jujuc.ContextUnit.
-func (c *ContextUnit) ConfigSettings() (charm.Settings, error) {
+func (c *ContextUnit) ConfigSettings(context.Context) (charm.Settings, error) {
 	c.stub.AddCall("ConfigSettings")
 	if err := c.stub.NextErr(); err != nil {
 		return nil, errors.Trace(err)

--- a/internal/worker/uniter/runner/jujuc/leader-get.go
+++ b/internal/worker/uniter/runner/jujuc/leader-get.go
@@ -63,7 +63,7 @@ func (c *leaderGetCommand) Init(args []string) error {
 
 // Run is part of the cmd.Command interface.
 func (c *leaderGetCommand) Run(ctx *cmd.Context) error {
-	settings, err := c.ctx.LeaderSettings()
+	settings, err := c.ctx.LeaderSettings(ctx)
 	if err != nil {
 		return errors.Annotatef(err, "cannot read leadership settings")
 	}

--- a/internal/worker/uniter/runner/jujuc/leader-get_test.go
+++ b/internal/worker/uniter/runner/jujuc/leader-get_test.go
@@ -4,6 +4,8 @@
 package jujuc_test
 
 import (
+	"context"
+
 	"github.com/juju/cmd/v4"
 	"github.com/juju/cmd/v4/cmdtesting"
 	"github.com/juju/errors"
@@ -170,7 +172,7 @@ type leaderGetContext struct {
 	err      error
 }
 
-func (c *leaderGetContext) LeaderSettings() (map[string]string, error) {
+func (c *leaderGetContext) LeaderSettings(_ context.Context) (map[string]string, error) {
 	c.called = true
 	return c.settings, c.err
 }

--- a/internal/worker/uniter/runner/jujuc/leader-set.go
+++ b/internal/worker/uniter/runner/jujuc/leader-set.go
@@ -45,7 +45,7 @@ func (c *leaderSetCommand) Init(args []string) (err error) {
 }
 
 // Run is part of the cmd.Command interface.
-func (c *leaderSetCommand) Run(_ *cmd.Context) error {
-	err := c.ctx.WriteLeaderSettings(c.settings)
+func (c *leaderSetCommand) Run(ctx *cmd.Context) error {
+	err := c.ctx.WriteLeaderSettings(ctx, c.settings)
 	return errors.Annotatef(err, "cannot write leadership settings")
 }

--- a/internal/worker/uniter/runner/jujuc/leader-set_test.go
+++ b/internal/worker/uniter/runner/jujuc/leader-set_test.go
@@ -4,6 +4,8 @@
 package jujuc_test
 
 import (
+	"context"
+
 	"github.com/juju/cmd/v4"
 	"github.com/juju/cmd/v4/cmdtesting"
 	"github.com/juju/errors"
@@ -88,7 +90,7 @@ type leaderSetContext struct {
 	err         error
 }
 
-func (s *leaderSetContext) WriteLeaderSettings(settings map[string]string) error {
+func (s *leaderSetContext) WriteLeaderSettings(_ context.Context, settings map[string]string) error {
 	s.gotSettings = settings
 	return s.err
 }

--- a/internal/worker/uniter/runner/jujuc/mocks/context_mock.go
+++ b/internal/worker/uniter/runner/jujuc/mocks/context_mock.go
@@ -281,18 +281,18 @@ func (c *MockContextCloudSpecCall) DoAndReturn(f func(context.Context) (*params.
 }
 
 // ConfigSettings mocks base method.
-func (m *MockContext) ConfigSettings() (charm.Settings, error) {
+func (m *MockContext) ConfigSettings(arg0 context.Context) (charm.Settings, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ConfigSettings")
+	ret := m.ctrl.Call(m, "ConfigSettings", arg0)
 	ret0, _ := ret[0].(charm.Settings)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ConfigSettings indicates an expected call of ConfigSettings.
-func (mr *MockContextMockRecorder) ConfigSettings() *MockContextConfigSettingsCall {
+func (mr *MockContextMockRecorder) ConfigSettings(arg0 any) *MockContextConfigSettingsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConfigSettings", reflect.TypeOf((*MockContext)(nil).ConfigSettings))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConfigSettings", reflect.TypeOf((*MockContext)(nil).ConfigSettings), arg0)
 	return &MockContextConfigSettingsCall{Call: call}
 }
 
@@ -308,30 +308,30 @@ func (c *MockContextConfigSettingsCall) Return(arg0 charm.Settings, arg1 error) 
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockContextConfigSettingsCall) Do(f func() (charm.Settings, error)) *MockContextConfigSettingsCall {
+func (c *MockContextConfigSettingsCall) Do(f func(context.Context) (charm.Settings, error)) *MockContextConfigSettingsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockContextConfigSettingsCall) DoAndReturn(f func() (charm.Settings, error)) *MockContextConfigSettingsCall {
+func (c *MockContextConfigSettingsCall) DoAndReturn(f func(context.Context) (charm.Settings, error)) *MockContextConfigSettingsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // CreateSecret mocks base method.
-func (m *MockContext) CreateSecret(arg0 *jujuc.SecretCreateArgs) (*secrets.URI, error) {
+func (m *MockContext) CreateSecret(arg0 context.Context, arg1 *jujuc.SecretCreateArgs) (*secrets.URI, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateSecret", arg0)
+	ret := m.ctrl.Call(m, "CreateSecret", arg0, arg1)
 	ret0, _ := ret[0].(*secrets.URI)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateSecret indicates an expected call of CreateSecret.
-func (mr *MockContextMockRecorder) CreateSecret(arg0 any) *MockContextCreateSecretCall {
+func (mr *MockContextMockRecorder) CreateSecret(arg0, arg1 any) *MockContextCreateSecretCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSecret", reflect.TypeOf((*MockContext)(nil).CreateSecret), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSecret", reflect.TypeOf((*MockContext)(nil).CreateSecret), arg0, arg1)
 	return &MockContextCreateSecretCall{Call: call}
 }
 
@@ -347,13 +347,13 @@ func (c *MockContextCreateSecretCall) Return(arg0 *secrets.URI, arg1 error) *Moc
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockContextCreateSecretCall) Do(f func(*jujuc.SecretCreateArgs) (*secrets.URI, error)) *MockContextCreateSecretCall {
+func (c *MockContextCreateSecretCall) Do(f func(context.Context, *jujuc.SecretCreateArgs) (*secrets.URI, error)) *MockContextCreateSecretCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockContextCreateSecretCall) DoAndReturn(f func(*jujuc.SecretCreateArgs) (*secrets.URI, error)) *MockContextCreateSecretCall {
+func (c *MockContextCreateSecretCall) DoAndReturn(f func(context.Context, *jujuc.SecretCreateArgs) (*secrets.URI, error)) *MockContextCreateSecretCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -436,17 +436,17 @@ func (c *MockContextDownloadResourceCall) DoAndReturn(f func(context.Context, st
 }
 
 // FlushPayloads mocks base method.
-func (m *MockContext) FlushPayloads() error {
+func (m *MockContext) FlushPayloads(arg0 context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FlushPayloads")
+	ret := m.ctrl.Call(m, "FlushPayloads", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // FlushPayloads indicates an expected call of FlushPayloads.
-func (mr *MockContextMockRecorder) FlushPayloads() *MockContextFlushPayloadsCall {
+func (mr *MockContextMockRecorder) FlushPayloads(arg0 any) *MockContextFlushPayloadsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FlushPayloads", reflect.TypeOf((*MockContext)(nil).FlushPayloads))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FlushPayloads", reflect.TypeOf((*MockContext)(nil).FlushPayloads), arg0)
 	return &MockContextFlushPayloadsCall{Call: call}
 }
 
@@ -462,13 +462,13 @@ func (c *MockContextFlushPayloadsCall) Return(arg0 error) *MockContextFlushPaylo
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockContextFlushPayloadsCall) Do(f func() error) *MockContextFlushPayloadsCall {
+func (c *MockContextFlushPayloadsCall) Do(f func(context.Context) error) *MockContextFlushPayloadsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockContextFlushPayloadsCall) DoAndReturn(f func() error) *MockContextFlushPayloadsCall {
+func (c *MockContextFlushPayloadsCall) DoAndReturn(f func(context.Context) error) *MockContextFlushPayloadsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -629,18 +629,18 @@ func (c *MockContextGetPayloadCall) DoAndReturn(f func(string, string) (*payload
 }
 
 // GetSecret mocks base method.
-func (m *MockContext) GetSecret(arg0 *secrets.URI, arg1 string, arg2, arg3 bool) (secrets.SecretValue, error) {
+func (m *MockContext) GetSecret(arg0 context.Context, arg1 *secrets.URI, arg2 string, arg3, arg4 bool) (secrets.SecretValue, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetSecret", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "GetSecret", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(secrets.SecretValue)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetSecret indicates an expected call of GetSecret.
-func (mr *MockContextMockRecorder) GetSecret(arg0, arg1, arg2, arg3 any) *MockContextGetSecretCall {
+func (mr *MockContextMockRecorder) GetSecret(arg0, arg1, arg2, arg3, arg4 any) *MockContextGetSecretCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecret", reflect.TypeOf((*MockContext)(nil).GetSecret), arg0, arg1, arg2, arg3)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecret", reflect.TypeOf((*MockContext)(nil).GetSecret), arg0, arg1, arg2, arg3, arg4)
 	return &MockContextGetSecretCall{Call: call}
 }
 
@@ -656,13 +656,13 @@ func (c *MockContextGetSecretCall) Return(arg0 secrets.SecretValue, arg1 error) 
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockContextGetSecretCall) Do(f func(*secrets.URI, string, bool, bool) (secrets.SecretValue, error)) *MockContextGetSecretCall {
+func (c *MockContextGetSecretCall) Do(f func(context.Context, *secrets.URI, string, bool, bool) (secrets.SecretValue, error)) *MockContextGetSecretCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockContextGetSecretCall) DoAndReturn(f func(*secrets.URI, string, bool, bool) (secrets.SecretValue, error)) *MockContextGetSecretCall {
+func (c *MockContextGetSecretCall) DoAndReturn(f func(context.Context, *secrets.URI, string, bool, bool) (secrets.SecretValue, error)) *MockContextGetSecretCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -784,18 +784,18 @@ func (c *MockContextHookRelationCall) DoAndReturn(f func() (jujuc.ContextRelatio
 }
 
 // HookStorage mocks base method.
-func (m *MockContext) HookStorage() (jujuc.ContextStorageAttachment, error) {
+func (m *MockContext) HookStorage(arg0 context.Context) (jujuc.ContextStorageAttachment, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HookStorage")
+	ret := m.ctrl.Call(m, "HookStorage", arg0)
 	ret0, _ := ret[0].(jujuc.ContextStorageAttachment)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // HookStorage indicates an expected call of HookStorage.
-func (mr *MockContextMockRecorder) HookStorage() *MockContextHookStorageCall {
+func (mr *MockContextMockRecorder) HookStorage(arg0 any) *MockContextHookStorageCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HookStorage", reflect.TypeOf((*MockContext)(nil).HookStorage))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HookStorage", reflect.TypeOf((*MockContext)(nil).HookStorage), arg0)
 	return &MockContextHookStorageCall{Call: call}
 }
 
@@ -811,13 +811,13 @@ func (c *MockContextHookStorageCall) Return(arg0 jujuc.ContextStorageAttachment,
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockContextHookStorageCall) Do(f func() (jujuc.ContextStorageAttachment, error)) *MockContextHookStorageCall {
+func (c *MockContextHookStorageCall) Do(f func(context.Context) (jujuc.ContextStorageAttachment, error)) *MockContextHookStorageCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockContextHookStorageCall) DoAndReturn(f func() (jujuc.ContextStorageAttachment, error)) *MockContextHookStorageCall {
+func (c *MockContextHookStorageCall) DoAndReturn(f func(context.Context) (jujuc.ContextStorageAttachment, error)) *MockContextHookStorageCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -862,18 +862,18 @@ func (c *MockContextIsLeaderCall) DoAndReturn(f func() (bool, error)) *MockConte
 }
 
 // LeaderSettings mocks base method.
-func (m *MockContext) LeaderSettings() (map[string]string, error) {
+func (m *MockContext) LeaderSettings(arg0 context.Context) (map[string]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LeaderSettings")
+	ret := m.ctrl.Call(m, "LeaderSettings", arg0)
 	ret0, _ := ret[0].(map[string]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // LeaderSettings indicates an expected call of LeaderSettings.
-func (mr *MockContextMockRecorder) LeaderSettings() *MockContextLeaderSettingsCall {
+func (mr *MockContextMockRecorder) LeaderSettings(arg0 any) *MockContextLeaderSettingsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LeaderSettings", reflect.TypeOf((*MockContext)(nil).LeaderSettings))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LeaderSettings", reflect.TypeOf((*MockContext)(nil).LeaderSettings), arg0)
 	return &MockContextLeaderSettingsCall{Call: call}
 }
 
@@ -889,13 +889,13 @@ func (c *MockContextLeaderSettingsCall) Return(arg0 map[string]string, arg1 erro
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockContextLeaderSettingsCall) Do(f func() (map[string]string, error)) *MockContextLeaderSettingsCall {
+func (c *MockContextLeaderSettingsCall) Do(f func(context.Context) (map[string]string, error)) *MockContextLeaderSettingsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockContextLeaderSettingsCall) DoAndReturn(f func() (map[string]string, error)) *MockContextLeaderSettingsCall {
+func (c *MockContextLeaderSettingsCall) DoAndReturn(f func(context.Context) (map[string]string, error)) *MockContextLeaderSettingsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -940,17 +940,17 @@ func (c *MockContextListPayloadsCall) DoAndReturn(f func() ([]string, error)) *M
 }
 
 // LogActionMessage mocks base method.
-func (m *MockContext) LogActionMessage(arg0 string) error {
+func (m *MockContext) LogActionMessage(arg0 context.Context, arg1 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LogActionMessage", arg0)
+	ret := m.ctrl.Call(m, "LogActionMessage", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // LogActionMessage indicates an expected call of LogActionMessage.
-func (mr *MockContextMockRecorder) LogActionMessage(arg0 any) *MockContextLogActionMessageCall {
+func (mr *MockContextMockRecorder) LogActionMessage(arg0, arg1 any) *MockContextLogActionMessageCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LogActionMessage", reflect.TypeOf((*MockContext)(nil).LogActionMessage), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LogActionMessage", reflect.TypeOf((*MockContext)(nil).LogActionMessage), arg0, arg1)
 	return &MockContextLogActionMessageCall{Call: call}
 }
 
@@ -966,30 +966,30 @@ func (c *MockContextLogActionMessageCall) Return(arg0 error) *MockContextLogActi
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockContextLogActionMessageCall) Do(f func(string) error) *MockContextLogActionMessageCall {
+func (c *MockContextLogActionMessageCall) Do(f func(context.Context, string) error) *MockContextLogActionMessageCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockContextLogActionMessageCall) DoAndReturn(f func(string) error) *MockContextLogActionMessageCall {
+func (c *MockContextLogActionMessageCall) DoAndReturn(f func(context.Context, string) error) *MockContextLogActionMessageCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // NetworkInfo mocks base method.
-func (m *MockContext) NetworkInfo(arg0 []string, arg1 int) (map[string]params.NetworkInfoResult, error) {
+func (m *MockContext) NetworkInfo(arg0 context.Context, arg1 []string, arg2 int) (map[string]params.NetworkInfoResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NetworkInfo", arg0, arg1)
+	ret := m.ctrl.Call(m, "NetworkInfo", arg0, arg1, arg2)
 	ret0, _ := ret[0].(map[string]params.NetworkInfoResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // NetworkInfo indicates an expected call of NetworkInfo.
-func (mr *MockContextMockRecorder) NetworkInfo(arg0, arg1 any) *MockContextNetworkInfoCall {
+func (mr *MockContextMockRecorder) NetworkInfo(arg0, arg1, arg2 any) *MockContextNetworkInfoCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NetworkInfo", reflect.TypeOf((*MockContext)(nil).NetworkInfo), arg0, arg1)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NetworkInfo", reflect.TypeOf((*MockContext)(nil).NetworkInfo), arg0, arg1, arg2)
 	return &MockContextNetworkInfoCall{Call: call}
 }
 
@@ -1005,13 +1005,13 @@ func (c *MockContextNetworkInfoCall) Return(arg0 map[string]params.NetworkInfoRe
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockContextNetworkInfoCall) Do(f func([]string, int) (map[string]params.NetworkInfoResult, error)) *MockContextNetworkInfoCall {
+func (c *MockContextNetworkInfoCall) Do(f func(context.Context, []string, int) (map[string]params.NetworkInfoResult, error)) *MockContextNetworkInfoCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockContextNetworkInfoCall) DoAndReturn(f func([]string, int) (map[string]params.NetworkInfoResult, error)) *MockContextNetworkInfoCall {
+func (c *MockContextNetworkInfoCall) DoAndReturn(f func(context.Context, []string, int) (map[string]params.NetworkInfoResult, error)) *MockContextNetworkInfoCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1132,18 +1132,18 @@ func (c *MockContextPrivateAddressCall) DoAndReturn(f func() (string, error)) *M
 }
 
 // PublicAddress mocks base method.
-func (m *MockContext) PublicAddress() (string, error) {
+func (m *MockContext) PublicAddress(arg0 context.Context) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PublicAddress")
+	ret := m.ctrl.Call(m, "PublicAddress", arg0)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // PublicAddress indicates an expected call of PublicAddress.
-func (mr *MockContextMockRecorder) PublicAddress() *MockContextPublicAddressCall {
+func (mr *MockContextMockRecorder) PublicAddress(arg0 any) *MockContextPublicAddressCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PublicAddress", reflect.TypeOf((*MockContext)(nil).PublicAddress))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PublicAddress", reflect.TypeOf((*MockContext)(nil).PublicAddress), arg0)
 	return &MockContextPublicAddressCall{Call: call}
 }
 
@@ -1159,13 +1159,13 @@ func (c *MockContextPublicAddressCall) Return(arg0 string, arg1 error) *MockCont
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockContextPublicAddressCall) Do(f func() (string, error)) *MockContextPublicAddressCall {
+func (c *MockContextPublicAddressCall) Do(f func(context.Context) (string, error)) *MockContextPublicAddressCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockContextPublicAddressCall) DoAndReturn(f func() (string, error)) *MockContextPublicAddressCall {
+func (c *MockContextPublicAddressCall) DoAndReturn(f func(context.Context) (string, error)) *MockContextPublicAddressCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1632,17 +1632,17 @@ func (c *MockContextSetCharmStateValueCall) DoAndReturn(f func(context.Context, 
 }
 
 // SetPayloadStatus mocks base method.
-func (m *MockContext) SetPayloadStatus(arg0, arg1, arg2 string) error {
+func (m *MockContext) SetPayloadStatus(arg0 context.Context, arg1, arg2, arg3 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetPayloadStatus", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "SetPayloadStatus", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetPayloadStatus indicates an expected call of SetPayloadStatus.
-func (mr *MockContextMockRecorder) SetPayloadStatus(arg0, arg1, arg2 any) *MockContextSetPayloadStatusCall {
+func (mr *MockContextMockRecorder) SetPayloadStatus(arg0, arg1, arg2, arg3 any) *MockContextSetPayloadStatusCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetPayloadStatus", reflect.TypeOf((*MockContext)(nil).SetPayloadStatus), arg0, arg1, arg2)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetPayloadStatus", reflect.TypeOf((*MockContext)(nil).SetPayloadStatus), arg0, arg1, arg2, arg3)
 	return &MockContextSetPayloadStatusCall{Call: call}
 }
 
@@ -1658,13 +1658,13 @@ func (c *MockContextSetPayloadStatusCall) Return(arg0 error) *MockContextSetPayl
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockContextSetPayloadStatusCall) Do(f func(string, string, string) error) *MockContextSetPayloadStatusCall {
+func (c *MockContextSetPayloadStatusCall) Do(f func(context.Context, string, string, string) error) *MockContextSetPayloadStatusCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockContextSetPayloadStatusCall) DoAndReturn(f func(string, string, string) error) *MockContextSetPayloadStatusCall {
+func (c *MockContextSetPayloadStatusCall) DoAndReturn(f func(context.Context, string, string, string) error) *MockContextSetPayloadStatusCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1746,18 +1746,18 @@ func (c *MockContextSetUnitWorkloadVersionCall) DoAndReturn(f func(context.Conte
 }
 
 // Storage mocks base method.
-func (m *MockContext) Storage(arg0 names.StorageTag) (jujuc.ContextStorageAttachment, error) {
+func (m *MockContext) Storage(arg0 context.Context, arg1 names.StorageTag) (jujuc.ContextStorageAttachment, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Storage", arg0)
+	ret := m.ctrl.Call(m, "Storage", arg0, arg1)
 	ret0, _ := ret[0].(jujuc.ContextStorageAttachment)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Storage indicates an expected call of Storage.
-func (mr *MockContextMockRecorder) Storage(arg0 any) *MockContextStorageCall {
+func (mr *MockContextMockRecorder) Storage(arg0, arg1 any) *MockContextStorageCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Storage", reflect.TypeOf((*MockContext)(nil).Storage), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Storage", reflect.TypeOf((*MockContext)(nil).Storage), arg0, arg1)
 	return &MockContextStorageCall{Call: call}
 }
 
@@ -1773,30 +1773,30 @@ func (c *MockContextStorageCall) Return(arg0 jujuc.ContextStorageAttachment, arg
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockContextStorageCall) Do(f func(names.StorageTag) (jujuc.ContextStorageAttachment, error)) *MockContextStorageCall {
+func (c *MockContextStorageCall) Do(f func(context.Context, names.StorageTag) (jujuc.ContextStorageAttachment, error)) *MockContextStorageCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockContextStorageCall) DoAndReturn(f func(names.StorageTag) (jujuc.ContextStorageAttachment, error)) *MockContextStorageCall {
+func (c *MockContextStorageCall) DoAndReturn(f func(context.Context, names.StorageTag) (jujuc.ContextStorageAttachment, error)) *MockContextStorageCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // StorageTags mocks base method.
-func (m *MockContext) StorageTags() ([]names.StorageTag, error) {
+func (m *MockContext) StorageTags(arg0 context.Context) ([]names.StorageTag, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StorageTags")
+	ret := m.ctrl.Call(m, "StorageTags", arg0)
 	ret0, _ := ret[0].([]names.StorageTag)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // StorageTags indicates an expected call of StorageTags.
-func (mr *MockContextMockRecorder) StorageTags() *MockContextStorageTagsCall {
+func (mr *MockContextMockRecorder) StorageTags(arg0 any) *MockContextStorageTagsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StorageTags", reflect.TypeOf((*MockContext)(nil).StorageTags))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StorageTags", reflect.TypeOf((*MockContext)(nil).StorageTags), arg0)
 	return &MockContextStorageTagsCall{Call: call}
 }
 
@@ -1812,13 +1812,13 @@ func (c *MockContextStorageTagsCall) Return(arg0 []names.StorageTag, arg1 error)
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockContextStorageTagsCall) Do(f func() ([]names.StorageTag, error)) *MockContextStorageTagsCall {
+func (c *MockContextStorageTagsCall) Do(f func(context.Context) ([]names.StorageTag, error)) *MockContextStorageTagsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockContextStorageTagsCall) DoAndReturn(f func() ([]names.StorageTag, error)) *MockContextStorageTagsCall {
+func (c *MockContextStorageTagsCall) DoAndReturn(f func(context.Context) ([]names.StorageTag, error)) *MockContextStorageTagsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1978,17 +1978,17 @@ func (c *MockContextUnitWorkloadVersionCall) DoAndReturn(f func(context.Context)
 }
 
 // UntrackPayload mocks base method.
-func (m *MockContext) UntrackPayload(arg0, arg1 string) error {
+func (m *MockContext) UntrackPayload(arg0 context.Context, arg1, arg2 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UntrackPayload", arg0, arg1)
+	ret := m.ctrl.Call(m, "UntrackPayload", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UntrackPayload indicates an expected call of UntrackPayload.
-func (mr *MockContextMockRecorder) UntrackPayload(arg0, arg1 any) *MockContextUntrackPayloadCall {
+func (mr *MockContextMockRecorder) UntrackPayload(arg0, arg1, arg2 any) *MockContextUntrackPayloadCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UntrackPayload", reflect.TypeOf((*MockContext)(nil).UntrackPayload), arg0, arg1)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UntrackPayload", reflect.TypeOf((*MockContext)(nil).UntrackPayload), arg0, arg1, arg2)
 	return &MockContextUntrackPayloadCall{Call: call}
 }
 
@@ -2004,13 +2004,13 @@ func (c *MockContextUntrackPayloadCall) Return(arg0 error) *MockContextUntrackPa
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockContextUntrackPayloadCall) Do(f func(string, string) error) *MockContextUntrackPayloadCall {
+func (c *MockContextUntrackPayloadCall) Do(f func(context.Context, string, string) error) *MockContextUntrackPayloadCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockContextUntrackPayloadCall) DoAndReturn(f func(string, string) error) *MockContextUntrackPayloadCall {
+func (c *MockContextUntrackPayloadCall) DoAndReturn(f func(context.Context, string, string) error) *MockContextUntrackPayloadCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -2131,17 +2131,17 @@ func (c *MockContextWorkloadNameCall) DoAndReturn(f func() (string, error)) *Moc
 }
 
 // WriteLeaderSettings mocks base method.
-func (m *MockContext) WriteLeaderSettings(arg0 map[string]string) error {
+func (m *MockContext) WriteLeaderSettings(arg0 context.Context, arg1 map[string]string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WriteLeaderSettings", arg0)
+	ret := m.ctrl.Call(m, "WriteLeaderSettings", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // WriteLeaderSettings indicates an expected call of WriteLeaderSettings.
-func (mr *MockContextMockRecorder) WriteLeaderSettings(arg0 any) *MockContextWriteLeaderSettingsCall {
+func (mr *MockContextMockRecorder) WriteLeaderSettings(arg0, arg1 any) *MockContextWriteLeaderSettingsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteLeaderSettings", reflect.TypeOf((*MockContext)(nil).WriteLeaderSettings), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteLeaderSettings", reflect.TypeOf((*MockContext)(nil).WriteLeaderSettings), arg0, arg1)
 	return &MockContextWriteLeaderSettingsCall{Call: call}
 }
 
@@ -2157,13 +2157,13 @@ func (c *MockContextWriteLeaderSettingsCall) Return(arg0 error) *MockContextWrit
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockContextWriteLeaderSettingsCall) Do(f func(map[string]string) error) *MockContextWriteLeaderSettingsCall {
+func (c *MockContextWriteLeaderSettingsCall) Do(f func(context.Context, map[string]string) error) *MockContextWriteLeaderSettingsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockContextWriteLeaderSettingsCall) DoAndReturn(f func(map[string]string) error) *MockContextWriteLeaderSettingsCall {
+func (c *MockContextWriteLeaderSettingsCall) DoAndReturn(f func(context.Context, map[string]string) error) *MockContextWriteLeaderSettingsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/uniter/runner/jujuc/mocks/context_relation_mock.go
+++ b/internal/worker/uniter/runner/jujuc/mocks/context_relation_mock.go
@@ -45,18 +45,18 @@ func (m *MockContextRelation) EXPECT() *MockContextRelationMockRecorder {
 }
 
 // ApplicationSettings mocks base method.
-func (m *MockContextRelation) ApplicationSettings() (jujuc.Settings, error) {
+func (m *MockContextRelation) ApplicationSettings(arg0 context.Context) (jujuc.Settings, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ApplicationSettings")
+	ret := m.ctrl.Call(m, "ApplicationSettings", arg0)
 	ret0, _ := ret[0].(jujuc.Settings)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ApplicationSettings indicates an expected call of ApplicationSettings.
-func (mr *MockContextRelationMockRecorder) ApplicationSettings() *MockContextRelationApplicationSettingsCall {
+func (mr *MockContextRelationMockRecorder) ApplicationSettings(arg0 any) *MockContextRelationApplicationSettingsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplicationSettings", reflect.TypeOf((*MockContextRelation)(nil).ApplicationSettings))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplicationSettings", reflect.TypeOf((*MockContextRelation)(nil).ApplicationSettings), arg0)
 	return &MockContextRelationApplicationSettingsCall{Call: call}
 }
 
@@ -72,13 +72,13 @@ func (c *MockContextRelationApplicationSettingsCall) Return(arg0 jujuc.Settings,
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockContextRelationApplicationSettingsCall) Do(f func() (jujuc.Settings, error)) *MockContextRelationApplicationSettingsCall {
+func (c *MockContextRelationApplicationSettingsCall) Do(f func(context.Context) (jujuc.Settings, error)) *MockContextRelationApplicationSettingsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockContextRelationApplicationSettingsCall) DoAndReturn(f func() (jujuc.Settings, error)) *MockContextRelationApplicationSettingsCall {
+func (c *MockContextRelationApplicationSettingsCall) DoAndReturn(f func(context.Context) (jujuc.Settings, error)) *MockContextRelationApplicationSettingsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -236,18 +236,18 @@ func (c *MockContextRelationNameCall) DoAndReturn(f func() string) *MockContextR
 }
 
 // ReadApplicationSettings mocks base method.
-func (m *MockContextRelation) ReadApplicationSettings(arg0 string) (params.Settings, error) {
+func (m *MockContextRelation) ReadApplicationSettings(arg0 context.Context, arg1 string) (params.Settings, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadApplicationSettings", arg0)
+	ret := m.ctrl.Call(m, "ReadApplicationSettings", arg0, arg1)
 	ret0, _ := ret[0].(params.Settings)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ReadApplicationSettings indicates an expected call of ReadApplicationSettings.
-func (mr *MockContextRelationMockRecorder) ReadApplicationSettings(arg0 any) *MockContextRelationReadApplicationSettingsCall {
+func (mr *MockContextRelationMockRecorder) ReadApplicationSettings(arg0, arg1 any) *MockContextRelationReadApplicationSettingsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadApplicationSettings", reflect.TypeOf((*MockContextRelation)(nil).ReadApplicationSettings), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadApplicationSettings", reflect.TypeOf((*MockContextRelation)(nil).ReadApplicationSettings), arg0, arg1)
 	return &MockContextRelationReadApplicationSettingsCall{Call: call}
 }
 
@@ -263,30 +263,30 @@ func (c *MockContextRelationReadApplicationSettingsCall) Return(arg0 params.Sett
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockContextRelationReadApplicationSettingsCall) Do(f func(string) (params.Settings, error)) *MockContextRelationReadApplicationSettingsCall {
+func (c *MockContextRelationReadApplicationSettingsCall) Do(f func(context.Context, string) (params.Settings, error)) *MockContextRelationReadApplicationSettingsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockContextRelationReadApplicationSettingsCall) DoAndReturn(f func(string) (params.Settings, error)) *MockContextRelationReadApplicationSettingsCall {
+func (c *MockContextRelationReadApplicationSettingsCall) DoAndReturn(f func(context.Context, string) (params.Settings, error)) *MockContextRelationReadApplicationSettingsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // ReadSettings mocks base method.
-func (m *MockContextRelation) ReadSettings(arg0 string) (params.Settings, error) {
+func (m *MockContextRelation) ReadSettings(arg0 context.Context, arg1 string) (params.Settings, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadSettings", arg0)
+	ret := m.ctrl.Call(m, "ReadSettings", arg0, arg1)
 	ret0, _ := ret[0].(params.Settings)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ReadSettings indicates an expected call of ReadSettings.
-func (mr *MockContextRelationMockRecorder) ReadSettings(arg0 any) *MockContextRelationReadSettingsCall {
+func (mr *MockContextRelationMockRecorder) ReadSettings(arg0, arg1 any) *MockContextRelationReadSettingsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadSettings", reflect.TypeOf((*MockContextRelation)(nil).ReadSettings), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadSettings", reflect.TypeOf((*MockContextRelation)(nil).ReadSettings), arg0, arg1)
 	return &MockContextRelationReadSettingsCall{Call: call}
 }
 
@@ -302,13 +302,13 @@ func (c *MockContextRelationReadSettingsCall) Return(arg0 params.Settings, arg1 
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockContextRelationReadSettingsCall) Do(f func(string) (params.Settings, error)) *MockContextRelationReadSettingsCall {
+func (c *MockContextRelationReadSettingsCall) Do(f func(context.Context, string) (params.Settings, error)) *MockContextRelationReadSettingsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockContextRelationReadSettingsCall) DoAndReturn(f func(string) (params.Settings, error)) *MockContextRelationReadSettingsCall {
+func (c *MockContextRelationReadSettingsCall) DoAndReturn(f func(context.Context, string) (params.Settings, error)) *MockContextRelationReadSettingsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -428,18 +428,18 @@ func (c *MockContextRelationSetStatusCall) DoAndReturn(f func(context.Context, r
 }
 
 // Settings mocks base method.
-func (m *MockContextRelation) Settings() (jujuc.Settings, error) {
+func (m *MockContextRelation) Settings(arg0 context.Context) (jujuc.Settings, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Settings")
+	ret := m.ctrl.Call(m, "Settings", arg0)
 	ret0, _ := ret[0].(jujuc.Settings)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Settings indicates an expected call of Settings.
-func (mr *MockContextRelationMockRecorder) Settings() *MockContextRelationSettingsCall {
+func (mr *MockContextRelationMockRecorder) Settings(arg0 any) *MockContextRelationSettingsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Settings", reflect.TypeOf((*MockContextRelation)(nil).Settings))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Settings", reflect.TypeOf((*MockContextRelation)(nil).Settings), arg0)
 	return &MockContextRelationSettingsCall{Call: call}
 }
 
@@ -455,13 +455,13 @@ func (c *MockContextRelationSettingsCall) Return(arg0 jujuc.Settings, arg1 error
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockContextRelationSettingsCall) Do(f func() (jujuc.Settings, error)) *MockContextRelationSettingsCall {
+func (c *MockContextRelationSettingsCall) Do(f func(context.Context) (jujuc.Settings, error)) *MockContextRelationSettingsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockContextRelationSettingsCall) DoAndReturn(f func() (jujuc.Settings, error)) *MockContextRelationSettingsCall {
+func (c *MockContextRelationSettingsCall) DoAndReturn(f func(context.Context) (jujuc.Settings, error)) *MockContextRelationSettingsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/uniter/runner/jujuc/network-get.go
+++ b/internal/worker/uniter/runner/jujuc/network-get.go
@@ -108,7 +108,7 @@ func (c *NetworkGetCommand) Init(args []string) error {
 }
 
 func (c *NetworkGetCommand) Run(ctx *cmd.Context) error {
-	netInfo, err := c.ctx.NetworkInfo([]string{c.bindingName}, c.RelationId)
+	netInfo, err := c.ctx.NetworkInfo(ctx, []string{c.bindingName}, c.RelationId)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/internal/worker/uniter/runner/jujuc/payload-register.go
+++ b/internal/worker/uniter/runner/jujuc/payload-register.go
@@ -84,7 +84,7 @@ func (c *PayloadRegisterCmd) Run(ctx *cmd.Context) error {
 
 	// We flush to state immediately so that status reflects the
 	// payload correctly.
-	if err := c.ctx.FlushPayloads(); err != nil {
+	if err := c.ctx.FlushPayloads(ctx); err != nil {
 		return errors.Trace(err)
 	}
 

--- a/internal/worker/uniter/runner/jujuc/payload-register_test.go
+++ b/internal/worker/uniter/runner/jujuc/payload-register_test.go
@@ -55,7 +55,7 @@ func (s *registerSuite) TestRun(c *gc.C) {
 		Unit:   "a-application/0",
 	}
 	hctx.EXPECT().TrackPayload(payload).Return(nil)
-	hctx.EXPECT().FlushPayloads()
+	hctx.EXPECT().FlushPayloads(gomock.Any())
 
 	com, err := jujuc.NewCommand(hctx, "payload-register")
 	c.Assert(err, jc.ErrorIsNil)

--- a/internal/worker/uniter/runner/jujuc/payload-status-set.go
+++ b/internal/worker/uniter/runner/jujuc/payload-status-set.go
@@ -58,7 +58,7 @@ func (c *PayloadStatusSetCmd) Run(ctx *cmd.Context) error {
 		return errors.Trace(err)
 	}
 
-	if err := c.ctx.SetPayloadStatus(c.class, c.id, c.status); err != nil {
+	if err := c.ctx.SetPayloadStatus(ctx, c.class, c.id, c.status); err != nil {
 		return errors.Trace(err)
 	}
 
@@ -66,7 +66,7 @@ func (c *PayloadStatusSetCmd) Run(ctx *cmd.Context) error {
 
 	// We flush to state immediately so that status reflects the
 	// payload correctly.
-	if err := c.ctx.FlushPayloads(); err != nil {
+	if err := c.ctx.FlushPayloads(ctx); err != nil {
 		return errors.Trace(err)
 	}
 

--- a/internal/worker/uniter/runner/jujuc/payload-status-set_test.go
+++ b/internal/worker/uniter/runner/jujuc/payload-status-set_test.go
@@ -51,8 +51,8 @@ func (s *PayloadStatusSetSuiye) TestStatusSet(c *gc.C) {
 	defer ctrl.Finish()
 
 	hctx := mocks.NewMockContext(ctrl)
-	hctx.EXPECT().SetPayloadStatus("class", "id", "stopped").Return(nil)
-	hctx.EXPECT().FlushPayloads()
+	hctx.EXPECT().SetPayloadStatus(gomock.Any(), "class", "id", "stopped").Return(nil)
+	hctx.EXPECT().FlushPayloads(gomock.Any())
 
 	com, err := jujuc.NewCommand(hctx, "payload-status-set")
 	c.Assert(err, jc.ErrorIsNil)

--- a/internal/worker/uniter/runner/jujuc/payload-unregister.go
+++ b/internal/worker/uniter/runner/jujuc/payload-unregister.go
@@ -63,7 +63,7 @@ func (c *PayloadUnregisterCmd) Run(ctx *cmd.Context) error {
 
 	// TODO(ericsnow) Verify that Untrack gives a meaningful error when
 	// the ID is not found.
-	if err := c.ctx.UntrackPayload(c.class, c.id); err != nil {
+	if err := c.ctx.UntrackPayload(ctx, c.class, c.id); err != nil {
 		return errors.Trace(err)
 	}
 
@@ -71,7 +71,7 @@ func (c *PayloadUnregisterCmd) Run(ctx *cmd.Context) error {
 
 	// We flush to state immediately so that status reflects the
 	// payload correctly.
-	if err := c.ctx.FlushPayloads(); err != nil {
+	if err := c.ctx.FlushPayloads(ctx); err != nil {
 		return errors.Trace(err)
 	}
 

--- a/internal/worker/uniter/runner/jujuc/payload-unregister_test.go
+++ b/internal/worker/uniter/runner/jujuc/payload-unregister_test.go
@@ -25,8 +25,8 @@ func (s *PayloadUnregisterSuite) TestRun(c *gc.C) {
 	defer ctrl.Finish()
 
 	hctx := mocks.NewMockContext(ctrl)
-	hctx.EXPECT().UntrackPayload("class", "id").Return(nil)
-	hctx.EXPECT().FlushPayloads()
+	hctx.EXPECT().UntrackPayload(gomock.Any(), "class", "id").Return(nil)
+	hctx.EXPECT().FlushPayloads(gomock.Any())
 
 	com, err := jujuc.NewCommand(hctx, "payload-unregister")
 	c.Assert(err, jc.ErrorIsNil)

--- a/internal/worker/uniter/runner/jujuc/relation-get.go
+++ b/internal/worker/uniter/runner/jujuc/relation-get.go
@@ -4,6 +4,7 @@
 package jujuc
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/juju/cmd/v4"
@@ -180,7 +181,7 @@ func (c *RelationGetCommand) Run(ctx *cmd.Context) error {
 		settingsReaderFn = c.readRemoteUnitOrAppSettings
 	}
 
-	settings, err := settingsReaderFn(r)
+	settings, err := settingsReaderFn(ctx, r)
 	if err != nil {
 		return err
 	}
@@ -218,16 +219,16 @@ func (c *RelationGetCommand) mustReadSettingsFromController() (bool, error) {
 	return true, nil
 }
 
-func (c *RelationGetCommand) readLocalUnitOrAppSettings(r ContextRelation) (params.Settings, error) {
+func (c *RelationGetCommand) readLocalUnitOrAppSettings(ctx context.Context, r ContextRelation) (params.Settings, error) {
 	var (
 		node Settings
 		err  error
 	)
 
 	if c.Application {
-		node, err = r.ApplicationSettings()
+		node, err = r.ApplicationSettings(ctx)
 	} else {
-		node, err = r.Settings()
+		node, err = r.Settings(ctx)
 	}
 	if err != nil {
 		return nil, err
@@ -236,10 +237,10 @@ func (c *RelationGetCommand) readLocalUnitOrAppSettings(r ContextRelation) (para
 	return node.Map(), nil
 }
 
-func (c *RelationGetCommand) readRemoteUnitOrAppSettings(r ContextRelation) (params.Settings, error) {
+func (c *RelationGetCommand) readRemoteUnitOrAppSettings(ctx context.Context, r ContextRelation) (params.Settings, error) {
 	if !c.Application {
-		return r.ReadSettings(c.UnitOrAppName)
+		return r.ReadSettings(ctx, c.UnitOrAppName)
 	}
 
-	return r.ReadApplicationSettings(c.UnitOrAppName)
+	return r.ReadApplicationSettings(ctx, c.UnitOrAppName)
 }

--- a/internal/worker/uniter/runner/jujuc/relation-set.go
+++ b/internal/worker/uniter/runner/jujuc/relation-set.go
@@ -153,12 +153,12 @@ func (c *RelationSetCommand) Run(ctx *cmd.Context) (err error) {
 		} else if isLeader == false {
 			return errors.Errorf("cannot write relation settings")
 		}
-		settings, err = r.ApplicationSettings()
+		settings, err = r.ApplicationSettings(ctx)
 		if err != nil {
 			return errors.Annotate(err, "cannot read relation application settings")
 		}
 	} else {
-		settings, err = r.Settings()
+		settings, err = r.Settings(ctx)
 		if err != nil {
 			return errors.Annotate(err, "cannot read relation settings")
 		}

--- a/internal/worker/uniter/runner/jujuc/restricted.go
+++ b/internal/worker/uniter/runner/jujuc/restricted.go
@@ -27,7 +27,9 @@ var ErrRestrictedContext = errors.NotImplementedf("not implemented for restricte
 type RestrictedContext struct{}
 
 // ConfigSettings implements hooks.Context.
-func (*RestrictedContext) ConfigSettings() (charm.Settings, error) { return nil, ErrRestrictedContext }
+func (*RestrictedContext) ConfigSettings(context.Context) (charm.Settings, error) {
+	return nil, ErrRestrictedContext
+}
 
 // GoalState implements hooks.Context.
 func (*RestrictedContext) GoalState(context.Context) (*application.GoalState, error) {
@@ -88,7 +90,9 @@ func (*RestrictedContext) RequestReboot(prio RebootPriority) error {
 }
 
 // PublicAddress implements hooks.Context.
-func (*RestrictedContext) PublicAddress() (string, error) { return "", ErrRestrictedContext }
+func (*RestrictedContext) PublicAddress(_ context.Context) (string, error) {
+	return "", ErrRestrictedContext
+}
 
 // PrivateAddress implements hooks.Context.
 func (*RestrictedContext) PrivateAddress() (string, error) { return "", ErrRestrictedContext }
@@ -107,7 +111,7 @@ func (*RestrictedContext) ClosePortRange(string, network.PortRange) error {
 func (*RestrictedContext) OpenedPortRanges() network.GroupedPortRanges { return nil }
 
 // NetworkInfo implements hooks.Context.
-func (*RestrictedContext) NetworkInfo(bindingNames []string, relationId int) (map[string]params.NetworkInfoResult, error) {
+func (*RestrictedContext) NetworkInfo(_ context.Context, bindingNames []string, relationId int) (map[string]params.NetworkInfoResult, error) {
 	return map[string]params.NetworkInfoResult{}, ErrRestrictedContext
 }
 
@@ -115,12 +119,14 @@ func (*RestrictedContext) NetworkInfo(bindingNames []string, relationId int) (ma
 func (*RestrictedContext) IsLeader() (bool, error) { return false, ErrRestrictedContext }
 
 // LeaderSettings implements hooks.Context.
-func (*RestrictedContext) LeaderSettings() (map[string]string, error) {
+func (*RestrictedContext) LeaderSettings(_ context.Context) (map[string]string, error) {
 	return nil, ErrRestrictedContext
 }
 
 // WriteLeaderSettings implements hooks.Context.
-func (*RestrictedContext) WriteLeaderSettings(map[string]string) error { return ErrRestrictedContext }
+func (*RestrictedContext) WriteLeaderSettings(context.Context, map[string]string) error {
+	return ErrRestrictedContext
+}
 
 // AddMetric implements hooks.Context.
 func (*RestrictedContext) AddMetric(string, string, time.Time) error { return ErrRestrictedContext }
@@ -131,15 +137,17 @@ func (*RestrictedContext) AddMetricLabels(string, string, time.Time, map[string]
 }
 
 // StorageTags implements hooks.Context.
-func (*RestrictedContext) StorageTags() ([]names.StorageTag, error) { return nil, ErrRestrictedContext }
+func (*RestrictedContext) StorageTags(_ context.Context) ([]names.StorageTag, error) {
+	return nil, ErrRestrictedContext
+}
 
 // Storage implements hooks.Context.
-func (*RestrictedContext) Storage(names.StorageTag) (ContextStorageAttachment, error) {
+func (*RestrictedContext) Storage(context.Context, names.StorageTag) (ContextStorageAttachment, error) {
 	return nil, ErrRestrictedContext
 }
 
 // HookStorage implements hooks.Context.
-func (*RestrictedContext) HookStorage() (ContextStorageAttachment, error) {
+func (*RestrictedContext) HookStorage(_ context.Context) (ContextStorageAttachment, error) {
 	return nil, ErrRestrictedContext
 }
 
@@ -164,12 +172,12 @@ func (ctx *RestrictedContext) TrackPayload(payload payloads.Payload) error {
 }
 
 // UntrackPayload implements hooks.Context.
-func (ctx *RestrictedContext) UntrackPayload(class, id string) error {
+func (ctx *RestrictedContext) UntrackPayload(_ context.Context, class, id string) error {
 	return ErrRestrictedContext
 }
 
 // SetPayloadStatus implements hooks.Context.
-func (ctx *RestrictedContext) SetPayloadStatus(class, id, status string) error {
+func (ctx *RestrictedContext) SetPayloadStatus(_ context.Context, class, id, status string) error {
 	return ErrRestrictedContext
 }
 
@@ -179,7 +187,7 @@ func (ctx *RestrictedContext) ListPayloads() ([]string, error) {
 }
 
 // FlushPayloads pushes the hook context data out to state.
-func (ctx *RestrictedContext) FlushPayloads() error {
+func (ctx *RestrictedContext) FlushPayloads(_ context.Context) error {
 	return ErrRestrictedContext
 }
 
@@ -213,7 +221,9 @@ func (*RestrictedContext) UpdateActionResults(keys []string, value interface{}) 
 }
 
 // LogActionMessage implements hooks.Context.
-func (*RestrictedContext) LogActionMessage(string) error { return ErrRestrictedContext }
+func (*RestrictedContext) LogActionMessage(context.Context, string) error {
+	return ErrRestrictedContext
+}
 
 // SetActionMessage implements hooks.Context.
 func (*RestrictedContext) SetActionMessage(string) error { return ErrRestrictedContext }
@@ -237,12 +247,12 @@ func (*RestrictedContext) WorkloadName() (string, error) {
 }
 
 // GetSecret implements runner.Context.
-func (ctx *RestrictedContext) GetSecret(*secrets.URI, string, bool, bool) (secrets.SecretValue, error) {
+func (ctx *RestrictedContext) GetSecret(context.Context, *secrets.URI, string, bool, bool) (secrets.SecretValue, error) {
 	return nil, ErrRestrictedContext
 }
 
 // CreateSecret implements runner.Context.
-func (ctx *RestrictedContext) CreateSecret(args *SecretCreateArgs) (*secrets.URI, error) {
+func (ctx *RestrictedContext) CreateSecret(_ context.Context, args *SecretCreateArgs) (*secrets.URI, error) {
 	return nil, ErrRestrictedContext
 }
 

--- a/internal/worker/uniter/runner/jujuc/secret-add.go
+++ b/internal/worker/uniter/runner/jujuc/secret-add.go
@@ -184,7 +184,7 @@ func (c *secretAddCommand) Run(ctx *cmd.Context) error {
 		SecretUpdateArgs: *updateArgs,
 		Owner:            owner,
 	}
-	uri, err := c.ctx.CreateSecret(arg)
+	uri, err := c.ctx.CreateSecret(ctx, arg)
 	if err != nil {
 		return err
 	}

--- a/internal/worker/uniter/runner/jujuc/secret-get.go
+++ b/internal/worker/uniter/runner/jujuc/secret-get.go
@@ -98,7 +98,7 @@ func (c *secretGetCommand) Init(args []string) (err error) {
 
 // Run implements cmd.Command.
 func (c *secretGetCommand) Run(ctx *cmd.Context) error {
-	value, err := c.ctx.GetSecret(c.secretUri, c.label, c.refresh, c.peek)
+	value, err := c.ctx.GetSecret(ctx, c.secretUri, c.label, c.refresh, c.peek)
 	if err != nil {
 		return err
 	}

--- a/internal/worker/uniter/runner/jujuc/storage-get.go
+++ b/internal/worker/uniter/runner/jujuc/storage-get.go
@@ -4,6 +4,8 @@
 package jujuc
 
 import (
+	"context"
+
 	"github.com/juju/cmd/v4"
 	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
@@ -22,9 +24,9 @@ type StorageGetCommand struct {
 	out             cmd.Output
 }
 
-func NewStorageGetCommand(ctx Context) (cmd.Command, error) {
-	c := &StorageGetCommand{ctx: ctx}
-	sV, err := newStorageIdValue(ctx, &c.storageTag)
+func NewStorageGetCommand(cmdCtx Context) (cmd.Command, error) {
+	c := &StorageGetCommand{ctx: cmdCtx}
+	sV, err := newStorageIdValue(context.TODO(), cmdCtx, &c.storageTag)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -62,7 +64,7 @@ func (c *StorageGetCommand) Init(args []string) error {
 }
 
 func (c *StorageGetCommand) Run(ctx *cmd.Context) error {
-	storage, err := c.ctx.Storage(c.storageTag)
+	storage, err := c.ctx.Storage(ctx, c.storageTag)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/internal/worker/uniter/runner/jujuc/storage-list.go
+++ b/internal/worker/uniter/runner/jujuc/storage-list.go
@@ -57,7 +57,7 @@ func (c *StorageListCommand) Init(args []string) (err error) {
 }
 
 func (c *StorageListCommand) Run(ctx *cmd.Context) error {
-	tags, err := c.ctx.StorageTags()
+	tags, err := c.ctx.StorageTags(ctx)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/internal/worker/uniter/runner/jujuc/unit-get.go
+++ b/internal/worker/uniter/runner/jujuc/unit-get.go
@@ -54,7 +54,7 @@ func (c *UnitGetCommand) Run(ctx *cmd.Context) error {
 	var err error
 	if c.Key == "private-address" {
 		var networkInfos map[string]params.NetworkInfoResult
-		networkInfos, err = c.ctx.NetworkInfo([]string{""}, -1)
+		networkInfos, err = c.ctx.NetworkInfo(ctx, []string{""}, -1)
 		if err == nil {
 			if networkInfos[""].Error != nil {
 				err = errors.Trace(networkInfos[""].Error)
@@ -77,7 +77,7 @@ func (c *UnitGetCommand) Run(ctx *cmd.Context) error {
 			}
 		}
 	} else {
-		value, err = c.ctx.PublicAddress()
+		value, err = c.ctx.PublicAddress(ctx)
 	}
 	if err != nil {
 		return errors.Trace(err)

--- a/internal/worker/uniter/runner/mocks/context_mock.go
+++ b/internal/worker/uniter/runner/mocks/context_mock.go
@@ -322,18 +322,18 @@ func (c *MockContextCloudSpecCall) DoAndReturn(f func(context.Context) (*params.
 }
 
 // ConfigSettings mocks base method.
-func (m *MockContext) ConfigSettings() (charm.Settings, error) {
+func (m *MockContext) ConfigSettings(arg0 context.Context) (charm.Settings, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ConfigSettings")
+	ret := m.ctrl.Call(m, "ConfigSettings", arg0)
 	ret0, _ := ret[0].(charm.Settings)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ConfigSettings indicates an expected call of ConfigSettings.
-func (mr *MockContextMockRecorder) ConfigSettings() *MockContextConfigSettingsCall {
+func (mr *MockContextMockRecorder) ConfigSettings(arg0 any) *MockContextConfigSettingsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConfigSettings", reflect.TypeOf((*MockContext)(nil).ConfigSettings))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConfigSettings", reflect.TypeOf((*MockContext)(nil).ConfigSettings), arg0)
 	return &MockContextConfigSettingsCall{Call: call}
 }
 
@@ -349,30 +349,30 @@ func (c *MockContextConfigSettingsCall) Return(arg0 charm.Settings, arg1 error) 
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockContextConfigSettingsCall) Do(f func() (charm.Settings, error)) *MockContextConfigSettingsCall {
+func (c *MockContextConfigSettingsCall) Do(f func(context.Context) (charm.Settings, error)) *MockContextConfigSettingsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockContextConfigSettingsCall) DoAndReturn(f func() (charm.Settings, error)) *MockContextConfigSettingsCall {
+func (c *MockContextConfigSettingsCall) DoAndReturn(f func(context.Context) (charm.Settings, error)) *MockContextConfigSettingsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // CreateSecret mocks base method.
-func (m *MockContext) CreateSecret(arg0 *jujuc.SecretCreateArgs) (*secrets.URI, error) {
+func (m *MockContext) CreateSecret(arg0 context.Context, arg1 *jujuc.SecretCreateArgs) (*secrets.URI, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateSecret", arg0)
+	ret := m.ctrl.Call(m, "CreateSecret", arg0, arg1)
 	ret0, _ := ret[0].(*secrets.URI)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateSecret indicates an expected call of CreateSecret.
-func (mr *MockContextMockRecorder) CreateSecret(arg0 any) *MockContextCreateSecretCall {
+func (mr *MockContextMockRecorder) CreateSecret(arg0, arg1 any) *MockContextCreateSecretCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSecret", reflect.TypeOf((*MockContext)(nil).CreateSecret), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSecret", reflect.TypeOf((*MockContext)(nil).CreateSecret), arg0, arg1)
 	return &MockContextCreateSecretCall{Call: call}
 }
 
@@ -388,13 +388,13 @@ func (c *MockContextCreateSecretCall) Return(arg0 *secrets.URI, arg1 error) *Moc
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockContextCreateSecretCall) Do(f func(*jujuc.SecretCreateArgs) (*secrets.URI, error)) *MockContextCreateSecretCall {
+func (c *MockContextCreateSecretCall) Do(f func(context.Context, *jujuc.SecretCreateArgs) (*secrets.URI, error)) *MockContextCreateSecretCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockContextCreateSecretCall) DoAndReturn(f func(*jujuc.SecretCreateArgs) (*secrets.URI, error)) *MockContextCreateSecretCall {
+func (c *MockContextCreateSecretCall) DoAndReturn(f func(context.Context, *jujuc.SecretCreateArgs) (*secrets.URI, error)) *MockContextCreateSecretCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -515,17 +515,17 @@ func (c *MockContextFlushCall) DoAndReturn(f func(context.Context, string, error
 }
 
 // FlushPayloads mocks base method.
-func (m *MockContext) FlushPayloads() error {
+func (m *MockContext) FlushPayloads(arg0 context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FlushPayloads")
+	ret := m.ctrl.Call(m, "FlushPayloads", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // FlushPayloads indicates an expected call of FlushPayloads.
-func (mr *MockContextMockRecorder) FlushPayloads() *MockContextFlushPayloadsCall {
+func (mr *MockContextMockRecorder) FlushPayloads(arg0 any) *MockContextFlushPayloadsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FlushPayloads", reflect.TypeOf((*MockContext)(nil).FlushPayloads))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FlushPayloads", reflect.TypeOf((*MockContext)(nil).FlushPayloads), arg0)
 	return &MockContextFlushPayloadsCall{Call: call}
 }
 
@@ -541,13 +541,13 @@ func (c *MockContextFlushPayloadsCall) Return(arg0 error) *MockContextFlushPaylo
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockContextFlushPayloadsCall) Do(f func() error) *MockContextFlushPayloadsCall {
+func (c *MockContextFlushPayloadsCall) Do(f func(context.Context) error) *MockContextFlushPayloadsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockContextFlushPayloadsCall) DoAndReturn(f func() error) *MockContextFlushPayloadsCall {
+func (c *MockContextFlushPayloadsCall) DoAndReturn(f func(context.Context) error) *MockContextFlushPayloadsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -708,18 +708,18 @@ func (c *MockContextGetPayloadCall) DoAndReturn(f func(string, string) (*payload
 }
 
 // GetSecret mocks base method.
-func (m *MockContext) GetSecret(arg0 *secrets.URI, arg1 string, arg2, arg3 bool) (secrets.SecretValue, error) {
+func (m *MockContext) GetSecret(arg0 context.Context, arg1 *secrets.URI, arg2 string, arg3, arg4 bool) (secrets.SecretValue, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetSecret", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "GetSecret", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(secrets.SecretValue)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetSecret indicates an expected call of GetSecret.
-func (mr *MockContextMockRecorder) GetSecret(arg0, arg1, arg2, arg3 any) *MockContextGetSecretCall {
+func (mr *MockContextMockRecorder) GetSecret(arg0, arg1, arg2, arg3, arg4 any) *MockContextGetSecretCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecret", reflect.TypeOf((*MockContext)(nil).GetSecret), arg0, arg1, arg2, arg3)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecret", reflect.TypeOf((*MockContext)(nil).GetSecret), arg0, arg1, arg2, arg3, arg4)
 	return &MockContextGetSecretCall{Call: call}
 }
 
@@ -735,13 +735,13 @@ func (c *MockContextGetSecretCall) Return(arg0 secrets.SecretValue, arg1 error) 
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockContextGetSecretCall) Do(f func(*secrets.URI, string, bool, bool) (secrets.SecretValue, error)) *MockContextGetSecretCall {
+func (c *MockContextGetSecretCall) Do(f func(context.Context, *secrets.URI, string, bool, bool) (secrets.SecretValue, error)) *MockContextGetSecretCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockContextGetSecretCall) DoAndReturn(f func(*secrets.URI, string, bool, bool) (secrets.SecretValue, error)) *MockContextGetSecretCall {
+func (c *MockContextGetSecretCall) DoAndReturn(f func(context.Context, *secrets.URI, string, bool, bool) (secrets.SecretValue, error)) *MockContextGetSecretCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -901,18 +901,18 @@ func (c *MockContextHookRelationCall) DoAndReturn(f func() (jujuc.ContextRelatio
 }
 
 // HookStorage mocks base method.
-func (m *MockContext) HookStorage() (jujuc.ContextStorageAttachment, error) {
+func (m *MockContext) HookStorage(arg0 context.Context) (jujuc.ContextStorageAttachment, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HookStorage")
+	ret := m.ctrl.Call(m, "HookStorage", arg0)
 	ret0, _ := ret[0].(jujuc.ContextStorageAttachment)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // HookStorage indicates an expected call of HookStorage.
-func (mr *MockContextMockRecorder) HookStorage() *MockContextHookStorageCall {
+func (mr *MockContextMockRecorder) HookStorage(arg0 any) *MockContextHookStorageCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HookStorage", reflect.TypeOf((*MockContext)(nil).HookStorage))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HookStorage", reflect.TypeOf((*MockContext)(nil).HookStorage), arg0)
 	return &MockContextHookStorageCall{Call: call}
 }
 
@@ -928,13 +928,13 @@ func (c *MockContextHookStorageCall) Return(arg0 jujuc.ContextStorageAttachment,
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockContextHookStorageCall) Do(f func() (jujuc.ContextStorageAttachment, error)) *MockContextHookStorageCall {
+func (c *MockContextHookStorageCall) Do(f func(context.Context) (jujuc.ContextStorageAttachment, error)) *MockContextHookStorageCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockContextHookStorageCall) DoAndReturn(f func() (jujuc.ContextStorageAttachment, error)) *MockContextHookStorageCall {
+func (c *MockContextHookStorageCall) DoAndReturn(f func(context.Context) (jujuc.ContextStorageAttachment, error)) *MockContextHookStorageCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1056,18 +1056,18 @@ func (c *MockContextIsLeaderCall) DoAndReturn(f func() (bool, error)) *MockConte
 }
 
 // LeaderSettings mocks base method.
-func (m *MockContext) LeaderSettings() (map[string]string, error) {
+func (m *MockContext) LeaderSettings(arg0 context.Context) (map[string]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LeaderSettings")
+	ret := m.ctrl.Call(m, "LeaderSettings", arg0)
 	ret0, _ := ret[0].(map[string]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // LeaderSettings indicates an expected call of LeaderSettings.
-func (mr *MockContextMockRecorder) LeaderSettings() *MockContextLeaderSettingsCall {
+func (mr *MockContextMockRecorder) LeaderSettings(arg0 any) *MockContextLeaderSettingsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LeaderSettings", reflect.TypeOf((*MockContext)(nil).LeaderSettings))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LeaderSettings", reflect.TypeOf((*MockContext)(nil).LeaderSettings), arg0)
 	return &MockContextLeaderSettingsCall{Call: call}
 }
 
@@ -1083,13 +1083,13 @@ func (c *MockContextLeaderSettingsCall) Return(arg0 map[string]string, arg1 erro
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockContextLeaderSettingsCall) Do(f func() (map[string]string, error)) *MockContextLeaderSettingsCall {
+func (c *MockContextLeaderSettingsCall) Do(f func(context.Context) (map[string]string, error)) *MockContextLeaderSettingsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockContextLeaderSettingsCall) DoAndReturn(f func() (map[string]string, error)) *MockContextLeaderSettingsCall {
+func (c *MockContextLeaderSettingsCall) DoAndReturn(f func(context.Context) (map[string]string, error)) *MockContextLeaderSettingsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1134,17 +1134,17 @@ func (c *MockContextListPayloadsCall) DoAndReturn(f func() ([]string, error)) *M
 }
 
 // LogActionMessage mocks base method.
-func (m *MockContext) LogActionMessage(arg0 string) error {
+func (m *MockContext) LogActionMessage(arg0 context.Context, arg1 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LogActionMessage", arg0)
+	ret := m.ctrl.Call(m, "LogActionMessage", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // LogActionMessage indicates an expected call of LogActionMessage.
-func (mr *MockContextMockRecorder) LogActionMessage(arg0 any) *MockContextLogActionMessageCall {
+func (mr *MockContextMockRecorder) LogActionMessage(arg0, arg1 any) *MockContextLogActionMessageCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LogActionMessage", reflect.TypeOf((*MockContext)(nil).LogActionMessage), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LogActionMessage", reflect.TypeOf((*MockContext)(nil).LogActionMessage), arg0, arg1)
 	return &MockContextLogActionMessageCall{Call: call}
 }
 
@@ -1160,13 +1160,13 @@ func (c *MockContextLogActionMessageCall) Return(arg0 error) *MockContextLogActi
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockContextLogActionMessageCall) Do(f func(string) error) *MockContextLogActionMessageCall {
+func (c *MockContextLogActionMessageCall) Do(f func(context.Context, string) error) *MockContextLogActionMessageCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockContextLogActionMessageCall) DoAndReturn(f func(string) error) *MockContextLogActionMessageCall {
+func (c *MockContextLogActionMessageCall) DoAndReturn(f func(context.Context, string) error) *MockContextLogActionMessageCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1210,18 +1210,18 @@ func (c *MockContextModelTypeCall) DoAndReturn(f func() model.ModelType) *MockCo
 }
 
 // NetworkInfo mocks base method.
-func (m *MockContext) NetworkInfo(arg0 []string, arg1 int) (map[string]params.NetworkInfoResult, error) {
+func (m *MockContext) NetworkInfo(arg0 context.Context, arg1 []string, arg2 int) (map[string]params.NetworkInfoResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NetworkInfo", arg0, arg1)
+	ret := m.ctrl.Call(m, "NetworkInfo", arg0, arg1, arg2)
 	ret0, _ := ret[0].(map[string]params.NetworkInfoResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // NetworkInfo indicates an expected call of NetworkInfo.
-func (mr *MockContextMockRecorder) NetworkInfo(arg0, arg1 any) *MockContextNetworkInfoCall {
+func (mr *MockContextMockRecorder) NetworkInfo(arg0, arg1, arg2 any) *MockContextNetworkInfoCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NetworkInfo", reflect.TypeOf((*MockContext)(nil).NetworkInfo), arg0, arg1)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NetworkInfo", reflect.TypeOf((*MockContext)(nil).NetworkInfo), arg0, arg1, arg2)
 	return &MockContextNetworkInfoCall{Call: call}
 }
 
@@ -1237,13 +1237,13 @@ func (c *MockContextNetworkInfoCall) Return(arg0 map[string]params.NetworkInfoRe
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockContextNetworkInfoCall) Do(f func([]string, int) (map[string]params.NetworkInfoResult, error)) *MockContextNetworkInfoCall {
+func (c *MockContextNetworkInfoCall) Do(f func(context.Context, []string, int) (map[string]params.NetworkInfoResult, error)) *MockContextNetworkInfoCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockContextNetworkInfoCall) DoAndReturn(f func([]string, int) (map[string]params.NetworkInfoResult, error)) *MockContextNetworkInfoCall {
+func (c *MockContextNetworkInfoCall) DoAndReturn(f func(context.Context, []string, int) (map[string]params.NetworkInfoResult, error)) *MockContextNetworkInfoCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1402,18 +1402,18 @@ func (c *MockContextPrivateAddressCall) DoAndReturn(f func() (string, error)) *M
 }
 
 // PublicAddress mocks base method.
-func (m *MockContext) PublicAddress() (string, error) {
+func (m *MockContext) PublicAddress(arg0 context.Context) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PublicAddress")
+	ret := m.ctrl.Call(m, "PublicAddress", arg0)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // PublicAddress indicates an expected call of PublicAddress.
-func (mr *MockContextMockRecorder) PublicAddress() *MockContextPublicAddressCall {
+func (mr *MockContextMockRecorder) PublicAddress(arg0 any) *MockContextPublicAddressCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PublicAddress", reflect.TypeOf((*MockContext)(nil).PublicAddress))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PublicAddress", reflect.TypeOf((*MockContext)(nil).PublicAddress), arg0)
 	return &MockContextPublicAddressCall{Call: call}
 }
 
@@ -1429,13 +1429,13 @@ func (c *MockContextPublicAddressCall) Return(arg0 string, arg1 error) *MockCont
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockContextPublicAddressCall) Do(f func() (string, error)) *MockContextPublicAddressCall {
+func (c *MockContextPublicAddressCall) Do(f func(context.Context) (string, error)) *MockContextPublicAddressCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockContextPublicAddressCall) DoAndReturn(f func() (string, error)) *MockContextPublicAddressCall {
+func (c *MockContextPublicAddressCall) DoAndReturn(f func(context.Context) (string, error)) *MockContextPublicAddressCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1938,17 +1938,17 @@ func (c *MockContextSetCharmStateValueCall) DoAndReturn(f func(context.Context, 
 }
 
 // SetPayloadStatus mocks base method.
-func (m *MockContext) SetPayloadStatus(arg0, arg1, arg2 string) error {
+func (m *MockContext) SetPayloadStatus(arg0 context.Context, arg1, arg2, arg3 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetPayloadStatus", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "SetPayloadStatus", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetPayloadStatus indicates an expected call of SetPayloadStatus.
-func (mr *MockContextMockRecorder) SetPayloadStatus(arg0, arg1, arg2 any) *MockContextSetPayloadStatusCall {
+func (mr *MockContextMockRecorder) SetPayloadStatus(arg0, arg1, arg2, arg3 any) *MockContextSetPayloadStatusCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetPayloadStatus", reflect.TypeOf((*MockContext)(nil).SetPayloadStatus), arg0, arg1, arg2)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetPayloadStatus", reflect.TypeOf((*MockContext)(nil).SetPayloadStatus), arg0, arg1, arg2, arg3)
 	return &MockContextSetPayloadStatusCall{Call: call}
 }
 
@@ -1964,13 +1964,13 @@ func (c *MockContextSetPayloadStatusCall) Return(arg0 error) *MockContextSetPayl
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockContextSetPayloadStatusCall) Do(f func(string, string, string) error) *MockContextSetPayloadStatusCall {
+func (c *MockContextSetPayloadStatusCall) Do(f func(context.Context, string, string, string) error) *MockContextSetPayloadStatusCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockContextSetPayloadStatusCall) DoAndReturn(f func(string, string, string) error) *MockContextSetPayloadStatusCall {
+func (c *MockContextSetPayloadStatusCall) DoAndReturn(f func(context.Context, string, string, string) error) *MockContextSetPayloadStatusCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -2088,18 +2088,18 @@ func (c *MockContextSetUnitWorkloadVersionCall) DoAndReturn(f func(context.Conte
 }
 
 // Storage mocks base method.
-func (m *MockContext) Storage(arg0 names.StorageTag) (jujuc.ContextStorageAttachment, error) {
+func (m *MockContext) Storage(arg0 context.Context, arg1 names.StorageTag) (jujuc.ContextStorageAttachment, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Storage", arg0)
+	ret := m.ctrl.Call(m, "Storage", arg0, arg1)
 	ret0, _ := ret[0].(jujuc.ContextStorageAttachment)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Storage indicates an expected call of Storage.
-func (mr *MockContextMockRecorder) Storage(arg0 any) *MockContextStorageCall {
+func (mr *MockContextMockRecorder) Storage(arg0, arg1 any) *MockContextStorageCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Storage", reflect.TypeOf((*MockContext)(nil).Storage), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Storage", reflect.TypeOf((*MockContext)(nil).Storage), arg0, arg1)
 	return &MockContextStorageCall{Call: call}
 }
 
@@ -2115,30 +2115,30 @@ func (c *MockContextStorageCall) Return(arg0 jujuc.ContextStorageAttachment, arg
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockContextStorageCall) Do(f func(names.StorageTag) (jujuc.ContextStorageAttachment, error)) *MockContextStorageCall {
+func (c *MockContextStorageCall) Do(f func(context.Context, names.StorageTag) (jujuc.ContextStorageAttachment, error)) *MockContextStorageCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockContextStorageCall) DoAndReturn(f func(names.StorageTag) (jujuc.ContextStorageAttachment, error)) *MockContextStorageCall {
+func (c *MockContextStorageCall) DoAndReturn(f func(context.Context, names.StorageTag) (jujuc.ContextStorageAttachment, error)) *MockContextStorageCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // StorageTags mocks base method.
-func (m *MockContext) StorageTags() ([]names.StorageTag, error) {
+func (m *MockContext) StorageTags(arg0 context.Context) ([]names.StorageTag, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StorageTags")
+	ret := m.ctrl.Call(m, "StorageTags", arg0)
 	ret0, _ := ret[0].([]names.StorageTag)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // StorageTags indicates an expected call of StorageTags.
-func (mr *MockContextMockRecorder) StorageTags() *MockContextStorageTagsCall {
+func (mr *MockContextMockRecorder) StorageTags(arg0 any) *MockContextStorageTagsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StorageTags", reflect.TypeOf((*MockContext)(nil).StorageTags))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StorageTags", reflect.TypeOf((*MockContext)(nil).StorageTags), arg0)
 	return &MockContextStorageTagsCall{Call: call}
 }
 
@@ -2154,13 +2154,13 @@ func (c *MockContextStorageTagsCall) Return(arg0 []names.StorageTag, arg1 error)
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockContextStorageTagsCall) Do(f func() ([]names.StorageTag, error)) *MockContextStorageTagsCall {
+func (c *MockContextStorageTagsCall) Do(f func(context.Context) ([]names.StorageTag, error)) *MockContextStorageTagsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockContextStorageTagsCall) DoAndReturn(f func() ([]names.StorageTag, error)) *MockContextStorageTagsCall {
+func (c *MockContextStorageTagsCall) DoAndReturn(f func(context.Context) ([]names.StorageTag, error)) *MockContextStorageTagsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -2320,17 +2320,17 @@ func (c *MockContextUnitWorkloadVersionCall) DoAndReturn(f func(context.Context)
 }
 
 // UntrackPayload mocks base method.
-func (m *MockContext) UntrackPayload(arg0, arg1 string) error {
+func (m *MockContext) UntrackPayload(arg0 context.Context, arg1, arg2 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UntrackPayload", arg0, arg1)
+	ret := m.ctrl.Call(m, "UntrackPayload", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UntrackPayload indicates an expected call of UntrackPayload.
-func (mr *MockContextMockRecorder) UntrackPayload(arg0, arg1 any) *MockContextUntrackPayloadCall {
+func (mr *MockContextMockRecorder) UntrackPayload(arg0, arg1, arg2 any) *MockContextUntrackPayloadCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UntrackPayload", reflect.TypeOf((*MockContext)(nil).UntrackPayload), arg0, arg1)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UntrackPayload", reflect.TypeOf((*MockContext)(nil).UntrackPayload), arg0, arg1, arg2)
 	return &MockContextUntrackPayloadCall{Call: call}
 }
 
@@ -2346,13 +2346,13 @@ func (c *MockContextUntrackPayloadCall) Return(arg0 error) *MockContextUntrackPa
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockContextUntrackPayloadCall) Do(f func(string, string) error) *MockContextUntrackPayloadCall {
+func (c *MockContextUntrackPayloadCall) Do(f func(context.Context, string, string) error) *MockContextUntrackPayloadCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockContextUntrackPayloadCall) DoAndReturn(f func(string, string) error) *MockContextUntrackPayloadCall {
+func (c *MockContextUntrackPayloadCall) DoAndReturn(f func(context.Context, string, string) error) *MockContextUntrackPayloadCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -2473,17 +2473,17 @@ func (c *MockContextWorkloadNameCall) DoAndReturn(f func() (string, error)) *Moc
 }
 
 // WriteLeaderSettings mocks base method.
-func (m *MockContext) WriteLeaderSettings(arg0 map[string]string) error {
+func (m *MockContext) WriteLeaderSettings(arg0 context.Context, arg1 map[string]string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WriteLeaderSettings", arg0)
+	ret := m.ctrl.Call(m, "WriteLeaderSettings", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // WriteLeaderSettings indicates an expected call of WriteLeaderSettings.
-func (mr *MockContextMockRecorder) WriteLeaderSettings(arg0 any) *MockContextWriteLeaderSettingsCall {
+func (mr *MockContextMockRecorder) WriteLeaderSettings(arg0, arg1 any) *MockContextWriteLeaderSettingsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteLeaderSettings", reflect.TypeOf((*MockContext)(nil).WriteLeaderSettings), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteLeaderSettings", reflect.TypeOf((*MockContext)(nil).WriteLeaderSettings), arg0, arg1)
 	return &MockContextWriteLeaderSettingsCall{Call: call}
 }
 
@@ -2499,13 +2499,13 @@ func (c *MockContextWriteLeaderSettingsCall) Return(arg0 error) *MockContextWrit
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockContextWriteLeaderSettingsCall) Do(f func(map[string]string) error) *MockContextWriteLeaderSettingsCall {
+func (c *MockContextWriteLeaderSettingsCall) Do(f func(context.Context, map[string]string) error) *MockContextWriteLeaderSettingsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockContextWriteLeaderSettingsCall) DoAndReturn(f func(map[string]string) error) *MockContextWriteLeaderSettingsCall {
+func (c *MockContextWriteLeaderSettingsCall) DoAndReturn(f func(context.Context, map[string]string) error) *MockContextWriteLeaderSettingsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/uniter/runner/testing/utils.go
+++ b/internal/worker/uniter/runner/testing/utils.go
@@ -4,6 +4,7 @@
 package testing
 
 import (
+	"context"
 	"path/filepath"
 
 	"github.com/juju/errors"
@@ -125,13 +126,13 @@ type SecretsContextAccessor struct {
 	jujusecrets.BackendsClient
 }
 
-func (s SecretsContextAccessor) CreateSecretURIs(int) ([]*secrets.URI, error) {
+func (s SecretsContextAccessor) CreateSecretURIs(context.Context, int) ([]*secrets.URI, error) {
 	return []*secrets.URI{{
 		ID: "8m4e2mr0ui3e8a215n4g",
 	}}, nil
 }
 
-func (s SecretsContextAccessor) SecretMetadata() ([]secrets.SecretOwnerMetadata, error) {
+func (s SecretsContextAccessor) SecretMetadata(context.Context) ([]secrets.SecretOwnerMetadata, error) {
 	uri, _ := secrets.ParseURI("secret:9m4e2mr0ui3e8a215n4g")
 	return []secrets.SecretOwnerMetadata{{
 		Metadata: secrets.SecretMetadata{
@@ -147,10 +148,10 @@ func (s SecretsContextAccessor) SecretMetadata() ([]secrets.SecretOwnerMetadata,
 	}}, nil
 }
 
-func (s SecretsContextAccessor) SaveContent(uri *secrets.URI, revision int, value secrets.SecretValue) (secrets.ValueRef, error) {
+func (s SecretsContextAccessor) SaveContent(_ context.Context, uri *secrets.URI, revision int, value secrets.SecretValue) (secrets.ValueRef, error) {
 	return secrets.ValueRef{}, errors.NotSupportedf("")
 }
 
-func (s SecretsContextAccessor) DeleteContent(uri *secrets.URI, revision int) error {
+func (s SecretsContextAccessor) DeleteContent(_ context.Context, uri *secrets.URI, revision int) error {
 	return errors.NotSupportedf("")
 }

--- a/internal/worker/uniter/runner/util_test.go
+++ b/internal/worker/uniter/runner/util_test.go
@@ -74,7 +74,7 @@ func (s *ContextSuite) AddContextRelation(c *gc.C, ctrl *gomock.Controller, name
 	relUnit := uniterapi.NewMockRelationUnit(ctrl)
 	relUnit.EXPECT().Relation().Return(rel).AnyTimes()
 	relUnit.EXPECT().Endpoint().Return(apiuniter.Endpoint{Relation: charm.Relation{Name: "db"}}).AnyTimes()
-	relUnit.EXPECT().Settings().Return(
+	relUnit.EXPECT().Settings(gomock.Any()).Return(
 		apiuniter.NewSettings(rel.Tag().String(), names.NewUnitTag("u/0").String(), params.Settings{}), nil,
 	).AnyTimes()
 
@@ -86,12 +86,12 @@ func (s *ContextSuite) setupUnit(ctrl *gomock.Controller) names.MachineTag {
 	s.unit = uniterapi.NewMockUnit(ctrl)
 	s.unit.EXPECT().Tag().Return(unitTag).AnyTimes()
 	s.unit.EXPECT().Name().Return(unitTag.Id()).AnyTimes()
-	s.unit.EXPECT().PublicAddress().Return("u-0.testing.invalid", nil).AnyTimes()
-	s.unit.EXPECT().PrivateAddress().Return("u-0.testing.invalid", nil).AnyTimes()
-	s.unit.EXPECT().AvailabilityZone().Return("a-zone", nil).AnyTimes()
+	s.unit.EXPECT().PublicAddress(gomock.Any()).Return("u-0.testing.invalid", nil).AnyTimes()
+	s.unit.EXPECT().PrivateAddress(gomock.Any()).Return("u-0.testing.invalid", nil).AnyTimes()
+	s.unit.EXPECT().AvailabilityZone(gomock.Any()).Return("a-zone", nil).AnyTimes()
 
 	machineTag := names.NewMachineTag("0")
-	s.unit.EXPECT().AssignedMachine().Return(machineTag, nil).AnyTimes()
+	s.unit.EXPECT().AssignedMachine(gomock.Any()).Return(machineTag, nil).AnyTimes()
 	return machineTag
 }
 
@@ -108,7 +108,7 @@ func (s *ContextSuite) setupUniter(ctrl *gomock.Controller) names.MachineTag {
 func (s *ContextSuite) setupFactory(c *gc.C, ctrl *gomock.Controller) {
 	s.setupUniter(ctrl)
 
-	s.unit.EXPECT().PrincipalName().Return("", false, nil).AnyTimes()
+	s.unit.EXPECT().PrincipalName(gomock.Any()).Return("", false, nil).AnyTimes()
 	s.uniter.EXPECT().Model(stdcontext.Background()).Return(&types.Model{
 		Name:      "test-model",
 		UUID:      coretesting.ModelTag.Id(),
@@ -122,7 +122,7 @@ func (s *ContextSuite) setupFactory(c *gc.C, ctrl *gomock.Controller) {
 	s.uniter.EXPECT().ModelConfig(gomock.Any()).Return(cfg, nil).AnyTimes()
 
 	s.payloads = mocks.NewMockPayloadAPIClient(ctrl)
-	s.payloads.EXPECT().List().Return(nil, nil).AnyTimes()
+	s.payloads.EXPECT().List(gomock.Any()).Return(nil, nil).AnyTimes()
 
 	contextFactory, err := context.NewContextFactory(stdcontext.Background(), context.FactoryConfig{
 		Uniter:           s.uniter,
@@ -266,11 +266,11 @@ type stubLeadershipSettingsAccessor struct {
 	results map[string]string
 }
 
-func (s *stubLeadershipSettingsAccessor) Read(_ string) (result map[string]string, _ error) {
+func (s *stubLeadershipSettingsAccessor) Read(_ stdcontext.Context, _ string) (result map[string]string, _ error) {
 	return result, nil
 }
 
-func (s *stubLeadershipSettingsAccessor) Merge(_, _ string, settings map[string]string) error {
+func (s *stubLeadershipSettingsAccessor) Merge(_ stdcontext.Context, _, _ string, settings map[string]string) error {
 	if s.results == nil {
 		s.results = make(map[string]string)
 	}

--- a/internal/worker/uniter/secrets/mocks/client_mock.go
+++ b/internal/worker/uniter/secrets/mocks/client_mock.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	secrets "github.com/juju/juju/core/secrets"
@@ -42,18 +43,18 @@ func (m *MockSecretsClient) EXPECT() *MockSecretsClientMockRecorder {
 }
 
 // CreateSecretURIs mocks base method.
-func (m *MockSecretsClient) CreateSecretURIs(arg0 int) ([]*secrets.URI, error) {
+func (m *MockSecretsClient) CreateSecretURIs(arg0 context.Context, arg1 int) ([]*secrets.URI, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateSecretURIs", arg0)
+	ret := m.ctrl.Call(m, "CreateSecretURIs", arg0, arg1)
 	ret0, _ := ret[0].([]*secrets.URI)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateSecretURIs indicates an expected call of CreateSecretURIs.
-func (mr *MockSecretsClientMockRecorder) CreateSecretURIs(arg0 any) *MockSecretsClientCreateSecretURIsCall {
+func (mr *MockSecretsClientMockRecorder) CreateSecretURIs(arg0, arg1 any) *MockSecretsClientCreateSecretURIsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSecretURIs", reflect.TypeOf((*MockSecretsClient)(nil).CreateSecretURIs), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSecretURIs", reflect.TypeOf((*MockSecretsClient)(nil).CreateSecretURIs), arg0, arg1)
 	return &MockSecretsClientCreateSecretURIsCall{Call: call}
 }
 
@@ -69,30 +70,30 @@ func (c *MockSecretsClientCreateSecretURIsCall) Return(arg0 []*secrets.URI, arg1
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSecretsClientCreateSecretURIsCall) Do(f func(int) ([]*secrets.URI, error)) *MockSecretsClientCreateSecretURIsCall {
+func (c *MockSecretsClientCreateSecretURIsCall) Do(f func(context.Context, int) ([]*secrets.URI, error)) *MockSecretsClientCreateSecretURIsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSecretsClientCreateSecretURIsCall) DoAndReturn(f func(int) ([]*secrets.URI, error)) *MockSecretsClientCreateSecretURIsCall {
+func (c *MockSecretsClientCreateSecretURIsCall) DoAndReturn(f func(context.Context, int) ([]*secrets.URI, error)) *MockSecretsClientCreateSecretURIsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetConsumerSecretsRevisionInfo mocks base method.
-func (m *MockSecretsClient) GetConsumerSecretsRevisionInfo(arg0 string, arg1 []string) (map[string]secrets.SecretRevisionInfo, error) {
+func (m *MockSecretsClient) GetConsumerSecretsRevisionInfo(arg0 context.Context, arg1 string, arg2 []string) (map[string]secrets.SecretRevisionInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetConsumerSecretsRevisionInfo", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetConsumerSecretsRevisionInfo", arg0, arg1, arg2)
 	ret0, _ := ret[0].(map[string]secrets.SecretRevisionInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetConsumerSecretsRevisionInfo indicates an expected call of GetConsumerSecretsRevisionInfo.
-func (mr *MockSecretsClientMockRecorder) GetConsumerSecretsRevisionInfo(arg0, arg1 any) *MockSecretsClientGetConsumerSecretsRevisionInfoCall {
+func (mr *MockSecretsClientMockRecorder) GetConsumerSecretsRevisionInfo(arg0, arg1, arg2 any) *MockSecretsClientGetConsumerSecretsRevisionInfoCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConsumerSecretsRevisionInfo", reflect.TypeOf((*MockSecretsClient)(nil).GetConsumerSecretsRevisionInfo), arg0, arg1)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConsumerSecretsRevisionInfo", reflect.TypeOf((*MockSecretsClient)(nil).GetConsumerSecretsRevisionInfo), arg0, arg1, arg2)
 	return &MockSecretsClientGetConsumerSecretsRevisionInfoCall{Call: call}
 }
 
@@ -108,30 +109,30 @@ func (c *MockSecretsClientGetConsumerSecretsRevisionInfoCall) Return(arg0 map[st
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSecretsClientGetConsumerSecretsRevisionInfoCall) Do(f func(string, []string) (map[string]secrets.SecretRevisionInfo, error)) *MockSecretsClientGetConsumerSecretsRevisionInfoCall {
+func (c *MockSecretsClientGetConsumerSecretsRevisionInfoCall) Do(f func(context.Context, string, []string) (map[string]secrets.SecretRevisionInfo, error)) *MockSecretsClientGetConsumerSecretsRevisionInfoCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSecretsClientGetConsumerSecretsRevisionInfoCall) DoAndReturn(f func(string, []string) (map[string]secrets.SecretRevisionInfo, error)) *MockSecretsClientGetConsumerSecretsRevisionInfoCall {
+func (c *MockSecretsClientGetConsumerSecretsRevisionInfoCall) DoAndReturn(f func(context.Context, string, []string) (map[string]secrets.SecretRevisionInfo, error)) *MockSecretsClientGetConsumerSecretsRevisionInfoCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // SecretMetadata mocks base method.
-func (m *MockSecretsClient) SecretMetadata() ([]secrets.SecretOwnerMetadata, error) {
+func (m *MockSecretsClient) SecretMetadata(arg0 context.Context) ([]secrets.SecretOwnerMetadata, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SecretMetadata")
+	ret := m.ctrl.Call(m, "SecretMetadata", arg0)
 	ret0, _ := ret[0].([]secrets.SecretOwnerMetadata)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // SecretMetadata indicates an expected call of SecretMetadata.
-func (mr *MockSecretsClientMockRecorder) SecretMetadata() *MockSecretsClientSecretMetadataCall {
+func (mr *MockSecretsClientMockRecorder) SecretMetadata(arg0 any) *MockSecretsClientSecretMetadataCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SecretMetadata", reflect.TypeOf((*MockSecretsClient)(nil).SecretMetadata))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SecretMetadata", reflect.TypeOf((*MockSecretsClient)(nil).SecretMetadata), arg0)
 	return &MockSecretsClientSecretMetadataCall{Call: call}
 }
 
@@ -147,29 +148,29 @@ func (c *MockSecretsClientSecretMetadataCall) Return(arg0 []secrets.SecretOwnerM
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSecretsClientSecretMetadataCall) Do(f func() ([]secrets.SecretOwnerMetadata, error)) *MockSecretsClientSecretMetadataCall {
+func (c *MockSecretsClientSecretMetadataCall) Do(f func(context.Context) ([]secrets.SecretOwnerMetadata, error)) *MockSecretsClientSecretMetadataCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSecretsClientSecretMetadataCall) DoAndReturn(f func() ([]secrets.SecretOwnerMetadata, error)) *MockSecretsClientSecretMetadataCall {
+func (c *MockSecretsClientSecretMetadataCall) DoAndReturn(f func(context.Context) ([]secrets.SecretOwnerMetadata, error)) *MockSecretsClientSecretMetadataCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // SecretRotated mocks base method.
-func (m *MockSecretsClient) SecretRotated(arg0 string, arg1 int) error {
+func (m *MockSecretsClient) SecretRotated(arg0 context.Context, arg1 string, arg2 int) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SecretRotated", arg0, arg1)
+	ret := m.ctrl.Call(m, "SecretRotated", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SecretRotated indicates an expected call of SecretRotated.
-func (mr *MockSecretsClientMockRecorder) SecretRotated(arg0, arg1 any) *MockSecretsClientSecretRotatedCall {
+func (mr *MockSecretsClientMockRecorder) SecretRotated(arg0, arg1, arg2 any) *MockSecretsClientSecretRotatedCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SecretRotated", reflect.TypeOf((*MockSecretsClient)(nil).SecretRotated), arg0, arg1)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SecretRotated", reflect.TypeOf((*MockSecretsClient)(nil).SecretRotated), arg0, arg1, arg2)
 	return &MockSecretsClientSecretRotatedCall{Call: call}
 }
 
@@ -185,30 +186,30 @@ func (c *MockSecretsClientSecretRotatedCall) Return(arg0 error) *MockSecretsClie
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSecretsClientSecretRotatedCall) Do(f func(string, int) error) *MockSecretsClientSecretRotatedCall {
+func (c *MockSecretsClientSecretRotatedCall) Do(f func(context.Context, string, int) error) *MockSecretsClientSecretRotatedCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSecretsClientSecretRotatedCall) DoAndReturn(f func(string, int) error) *MockSecretsClientSecretRotatedCall {
+func (c *MockSecretsClientSecretRotatedCall) DoAndReturn(f func(context.Context, string, int) error) *MockSecretsClientSecretRotatedCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // WatchConsumedSecretsChanges mocks base method.
-func (m *MockSecretsClient) WatchConsumedSecretsChanges(arg0 string) (watcher.Watcher[[]string], error) {
+func (m *MockSecretsClient) WatchConsumedSecretsChanges(arg0 context.Context, arg1 string) (watcher.Watcher[[]string], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchConsumedSecretsChanges", arg0)
+	ret := m.ctrl.Call(m, "WatchConsumedSecretsChanges", arg0, arg1)
 	ret0, _ := ret[0].(watcher.Watcher[[]string])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // WatchConsumedSecretsChanges indicates an expected call of WatchConsumedSecretsChanges.
-func (mr *MockSecretsClientMockRecorder) WatchConsumedSecretsChanges(arg0 any) *MockSecretsClientWatchConsumedSecretsChangesCall {
+func (mr *MockSecretsClientMockRecorder) WatchConsumedSecretsChanges(arg0, arg1 any) *MockSecretsClientWatchConsumedSecretsChangesCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchConsumedSecretsChanges", reflect.TypeOf((*MockSecretsClient)(nil).WatchConsumedSecretsChanges), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchConsumedSecretsChanges", reflect.TypeOf((*MockSecretsClient)(nil).WatchConsumedSecretsChanges), arg0, arg1)
 	return &MockSecretsClientWatchConsumedSecretsChangesCall{Call: call}
 }
 
@@ -224,22 +225,22 @@ func (c *MockSecretsClientWatchConsumedSecretsChangesCall) Return(arg0 watcher.W
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSecretsClientWatchConsumedSecretsChangesCall) Do(f func(string) (watcher.Watcher[[]string], error)) *MockSecretsClientWatchConsumedSecretsChangesCall {
+func (c *MockSecretsClientWatchConsumedSecretsChangesCall) Do(f func(context.Context, string) (watcher.Watcher[[]string], error)) *MockSecretsClientWatchConsumedSecretsChangesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSecretsClientWatchConsumedSecretsChangesCall) DoAndReturn(f func(string) (watcher.Watcher[[]string], error)) *MockSecretsClientWatchConsumedSecretsChangesCall {
+func (c *MockSecretsClientWatchConsumedSecretsChangesCall) DoAndReturn(f func(context.Context, string) (watcher.Watcher[[]string], error)) *MockSecretsClientWatchConsumedSecretsChangesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // WatchObsolete mocks base method.
-func (m *MockSecretsClient) WatchObsolete(arg0 ...names.Tag) (watcher.Watcher[[]string], error) {
+func (m *MockSecretsClient) WatchObsolete(arg0 context.Context, arg1 ...names.Tag) (watcher.Watcher[[]string], error) {
 	m.ctrl.T.Helper()
-	varargs := []any{}
-	for _, a := range arg0 {
+	varargs := []any{arg0}
+	for _, a := range arg1 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "WatchObsolete", varargs...)
@@ -249,9 +250,10 @@ func (m *MockSecretsClient) WatchObsolete(arg0 ...names.Tag) (watcher.Watcher[[]
 }
 
 // WatchObsolete indicates an expected call of WatchObsolete.
-func (mr *MockSecretsClientMockRecorder) WatchObsolete(arg0 ...any) *MockSecretsClientWatchObsoleteCall {
+func (mr *MockSecretsClientMockRecorder) WatchObsolete(arg0 any, arg1 ...any) *MockSecretsClientWatchObsoleteCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchObsolete", reflect.TypeOf((*MockSecretsClient)(nil).WatchObsolete), arg0...)
+	varargs := append([]any{arg0}, arg1...)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchObsolete", reflect.TypeOf((*MockSecretsClient)(nil).WatchObsolete), varargs...)
 	return &MockSecretsClientWatchObsoleteCall{Call: call}
 }
 
@@ -267,13 +269,13 @@ func (c *MockSecretsClientWatchObsoleteCall) Return(arg0 watcher.Watcher[[]strin
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSecretsClientWatchObsoleteCall) Do(f func(...names.Tag) (watcher.Watcher[[]string], error)) *MockSecretsClientWatchObsoleteCall {
+func (c *MockSecretsClientWatchObsoleteCall) Do(f func(context.Context, ...names.Tag) (watcher.Watcher[[]string], error)) *MockSecretsClientWatchObsoleteCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSecretsClientWatchObsoleteCall) DoAndReturn(f func(...names.Tag) (watcher.Watcher[[]string], error)) *MockSecretsClientWatchObsoleteCall {
+func (c *MockSecretsClientWatchObsoleteCall) DoAndReturn(f func(context.Context, ...names.Tag) (watcher.Watcher[[]string], error)) *MockSecretsClientWatchObsoleteCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/uniter/secrets/resolver_test.go
+++ b/internal/worker/uniter/secrets/resolver_test.go
@@ -167,7 +167,7 @@ func (s *triggerSecretsSuite) TestRotateCommit(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.mockCallbacks.EXPECT().CommitHook(gomock.Any(), hi).Return(nil)
-	s.mockCallbacks.EXPECT().SetSecretRotated(uri.String(), 666).Return(nil)
+	s.mockCallbacks.EXPECT().SetSecretRotated(gomock.Any(), uri.String(), 666).Return(nil)
 
 	_, err = op.Commit(context.Background(), operation.State{})
 	c.Assert(err, jc.ErrorIsNil)

--- a/internal/worker/uniter/secrets/secrets.go
+++ b/internal/worker/uniter/secrets/secrets.go
@@ -13,7 +13,6 @@ import (
 	"github.com/juju/names/v5"
 
 	"github.com/juju/juju/core/logger"
-	coresecrets "github.com/juju/juju/core/secrets"
 	"github.com/juju/juju/internal/worker/uniter/api"
 	"github.com/juju/juju/internal/worker/uniter/hook"
 )
@@ -21,7 +20,6 @@ import (
 // SecretsClient is used by the secrets tracker to access the Juju model.
 type SecretsClient interface {
 	api.SecretsClient
-	SecretMetadata() ([]coresecrets.SecretOwnerMetadata, error)
 }
 
 // Secrets generates storage hooks in response to changes to
@@ -73,7 +71,7 @@ func (s *Secrets) init(ctx context.Context) error {
 		for uri := range s.secretsState.ConsumedSecretInfo {
 			uris.Add(uri)
 		}
-		info, err := s.client.GetConsumerSecretsRevisionInfo(s.unitTag.Id(), uris.SortedValues())
+		info, err := s.client.GetConsumerSecretsRevisionInfo(ctx, s.unitTag.Id(), uris.SortedValues())
 		if err != nil {
 			return errors.Annotate(err, "getting consumed secret info")
 		}
@@ -86,7 +84,7 @@ func (s *Secrets) init(ctx context.Context) error {
 			s.secretsState.ConsumedSecretInfo = updated
 		}
 	}
-	metadata, err := s.client.SecretMetadata()
+	metadata, err := s.client.SecretMetadata(ctx)
 	if err != nil {
 		return errors.Annotate(err, "reading secret metadata")
 	}

--- a/internal/worker/uniter/secrets/secrets_test.go
+++ b/internal/worker/uniter/secrets/secrets_test.go
@@ -57,11 +57,12 @@ func (s *secretsSuite) TestCommitSecretChanged(c *gc.C) {
 			},
 		},
 	)}, nil)
-	s.secretsClient.EXPECT().GetConsumerSecretsRevisionInfo("foo/0",
+	s.secretsClient.EXPECT().GetConsumerSecretsRevisionInfo(
+		gomock.Any(), "foo/0",
 		[]string{"secret:666e2mr0ui3e8a215n4g", "secret:9m4e2mr0ui3e8a215n4g"}).Return(
 		map[string]coresecrets.SecretRevisionInfo{"secret:9m4e2mr0ui3e8a215n4g": {LatestRevision: 667}}, nil,
 	)
-	s.secretsClient.EXPECT().SecretMetadata().Return(nil, nil)
+	s.secretsClient.EXPECT().SecretMetadata(gomock.Any()).Return(nil, nil)
 
 	s.stateReadWriter.EXPECT().SetState(gomock.Any(), params.SetUnitStateArg{SecretState: ptr(s.yamlString(c,
 		&secrets.State{
@@ -101,7 +102,7 @@ func (s *secretsSuite) TestCommitSecretRemove(c *gc.C) {
 			},
 		},
 	)}, nil)
-	s.secretsClient.EXPECT().SecretMetadata().Return(
+	s.secretsClient.EXPECT().SecretMetadata(gomock.Any()).Return(
 		[]coresecrets.SecretOwnerMetadata{{Metadata: coresecrets.SecretMetadata{URI: &coresecrets.URI{ID: "9m4e2mr0ui3e8a215n4g"}}}}, nil)
 	s.stateReadWriter.EXPECT().SetState(gomock.Any(), params.SetUnitStateArg{SecretState: ptr(s.yamlString(c,
 		&secrets.State{
@@ -147,14 +148,15 @@ func (s *secretsSuite) TestCommitNoOpSecretsRemoved(c *gc.C) {
 			},
 		},
 	)}, nil)
-	s.secretsClient.EXPECT().GetConsumerSecretsRevisionInfo("foo/0",
+	s.secretsClient.EXPECT().GetConsumerSecretsRevisionInfo(
+		gomock.Any(), "foo/0",
 		[]string{"secret:666e2mr0ui3e8a215n4g", "secret:9m4e2mr0ui3e8a215n4g"}).Return(
 		map[string]coresecrets.SecretRevisionInfo{
 			"secret:666e2mr0ui3e8a215n4g": {LatestRevision: 666},
 			"secret:9m4e2mr0ui3e8a215n4g": {LatestRevision: 667},
 		}, nil,
 	)
-	s.secretsClient.EXPECT().SecretMetadata().Return(
+	s.secretsClient.EXPECT().SecretMetadata(gomock.Any()).Return(
 		[]coresecrets.SecretOwnerMetadata{
 			{Metadata: coresecrets.SecretMetadata{URI: &coresecrets.URI{ID: "9m4e2mr0ui3e8a215n4g"}}},
 			{Metadata: coresecrets.SecretMetadata{URI: &coresecrets.URI{ID: "666e2mr0ui3e8a215n4g"}}},

--- a/internal/worker/uniter/storage/attachments.go
+++ b/internal/worker/uniter/storage/attachments.go
@@ -58,7 +58,7 @@ func NewAttachments(
 func (a *Attachments) init(ctx context.Context) error {
 	// Query all remote, known storage attachments for the unit,
 	// so we can store current context, and find pending storage.
-	attachmentIds, err := a.client.UnitStorageAttachments(a.unitTag)
+	attachmentIds, err := a.client.UnitStorageAttachments(ctx, a.unitTag)
 	if err != nil {
 		return errors.Annotate(err, "getting unit attachments")
 	}
@@ -101,8 +101,8 @@ func (a *Attachments) init(ctx context.Context) error {
 
 // SetDying ensures that any unprovisioned storage attachments are removed
 // from State.
-func (a *Attachments) SetDying() error {
-	if err := a.client.DestroyUnitStorageAttachments(a.unitTag); err != nil {
+func (a *Attachments) SetDying(ctx context.Context) error {
+	if err := a.client.DestroyUnitStorageAttachments(ctx, a.unitTag); err != nil {
 		return errors.Trace(err)
 	}
 	return nil
@@ -142,15 +142,15 @@ func (a *Attachments) CommitHook(ctx context.Context, hi hook.Info) error {
 	case hooks.StorageAttached:
 		a.pending.Remove(storageTag)
 	case hooks.StorageDetaching:
-		if err := a.removeStorageAttachment(storageTag); err != nil {
+		if err := a.removeStorageAttachment(ctx, storageTag); err != nil {
 			return errors.Trace(err)
 		}
 	}
 	return nil
 }
 
-func (a *Attachments) removeStorageAttachment(tag names.StorageTag) error {
-	if err := a.client.RemoveStorageAttachment(tag, a.unitTag); err != nil {
+func (a *Attachments) removeStorageAttachment(ctx context.Context, tag names.StorageTag) error {
+	if err := a.client.RemoveStorageAttachment(ctx, tag, a.unitTag); err != nil {
 		return errors.Annotate(err, "removing storage attachment")
 	}
 	a.pending.Remove(tag)

--- a/internal/worker/uniter/storage/mock_test.go
+++ b/internal/worker/uniter/storage/mock_test.go
@@ -22,19 +22,19 @@ type mockStorageAccessor struct {
 	remove                        func(names.StorageTag, names.UnitTag) error
 }
 
-func (m *mockStorageAccessor) StorageAttachment(s names.StorageTag, u names.UnitTag) (params.StorageAttachment, error) {
+func (m *mockStorageAccessor) StorageAttachment(ctx context.Context, s names.StorageTag, u names.UnitTag) (params.StorageAttachment, error) {
 	return m.storageAttachment(s, u)
 }
 
-func (m *mockStorageAccessor) UnitStorageAttachments(u names.UnitTag) ([]params.StorageAttachmentId, error) {
+func (m *mockStorageAccessor) UnitStorageAttachments(ctx context.Context, u names.UnitTag) ([]params.StorageAttachmentId, error) {
 	return m.unitStorageAttachments(u)
 }
 
-func (m *mockStorageAccessor) DestroyUnitStorageAttachments(u names.UnitTag) error {
+func (m *mockStorageAccessor) DestroyUnitStorageAttachments(ctx context.Context, u names.UnitTag) error {
 	return m.destroyUnitStorageAttachments(u)
 }
 
-func (m *mockStorageAccessor) RemoveStorageAttachment(s names.StorageTag, u names.UnitTag) error {
+func (m *mockStorageAccessor) RemoveStorageAttachment(ctx context.Context, s names.StorageTag, u names.UnitTag) error {
 	return m.remove(s, u)
 }
 

--- a/internal/worker/upgrader/mocks/upgrader_mocks.go
+++ b/internal/worker/upgrader/mocks/upgrader_mocks.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	watcher "github.com/juju/juju/core/watcher"
@@ -42,18 +43,18 @@ func (m *MockUpgraderClient) EXPECT() *MockUpgraderClientMockRecorder {
 }
 
 // DesiredVersion mocks base method.
-func (m *MockUpgraderClient) DesiredVersion(arg0 string) (version.Number, error) {
+func (m *MockUpgraderClient) DesiredVersion(arg0 context.Context, arg1 string) (version.Number, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DesiredVersion", arg0)
+	ret := m.ctrl.Call(m, "DesiredVersion", arg0, arg1)
 	ret0, _ := ret[0].(version.Number)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // DesiredVersion indicates an expected call of DesiredVersion.
-func (mr *MockUpgraderClientMockRecorder) DesiredVersion(arg0 any) *MockUpgraderClientDesiredVersionCall {
+func (mr *MockUpgraderClientMockRecorder) DesiredVersion(arg0, arg1 any) *MockUpgraderClientDesiredVersionCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DesiredVersion", reflect.TypeOf((*MockUpgraderClient)(nil).DesiredVersion), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DesiredVersion", reflect.TypeOf((*MockUpgraderClient)(nil).DesiredVersion), arg0, arg1)
 	return &MockUpgraderClientDesiredVersionCall{Call: call}
 }
 
@@ -69,29 +70,29 @@ func (c *MockUpgraderClientDesiredVersionCall) Return(arg0 version.Number, arg1 
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockUpgraderClientDesiredVersionCall) Do(f func(string) (version.Number, error)) *MockUpgraderClientDesiredVersionCall {
+func (c *MockUpgraderClientDesiredVersionCall) Do(f func(context.Context, string) (version.Number, error)) *MockUpgraderClientDesiredVersionCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockUpgraderClientDesiredVersionCall) DoAndReturn(f func(string) (version.Number, error)) *MockUpgraderClientDesiredVersionCall {
+func (c *MockUpgraderClientDesiredVersionCall) DoAndReturn(f func(context.Context, string) (version.Number, error)) *MockUpgraderClientDesiredVersionCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // SetVersion mocks base method.
-func (m *MockUpgraderClient) SetVersion(arg0 string, arg1 version.Binary) error {
+func (m *MockUpgraderClient) SetVersion(arg0 context.Context, arg1 string, arg2 version.Binary) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetVersion", arg0, arg1)
+	ret := m.ctrl.Call(m, "SetVersion", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetVersion indicates an expected call of SetVersion.
-func (mr *MockUpgraderClientMockRecorder) SetVersion(arg0, arg1 any) *MockUpgraderClientSetVersionCall {
+func (mr *MockUpgraderClientMockRecorder) SetVersion(arg0, arg1, arg2 any) *MockUpgraderClientSetVersionCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetVersion", reflect.TypeOf((*MockUpgraderClient)(nil).SetVersion), arg0, arg1)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetVersion", reflect.TypeOf((*MockUpgraderClient)(nil).SetVersion), arg0, arg1, arg2)
 	return &MockUpgraderClientSetVersionCall{Call: call}
 }
 
@@ -107,30 +108,30 @@ func (c *MockUpgraderClientSetVersionCall) Return(arg0 error) *MockUpgraderClien
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockUpgraderClientSetVersionCall) Do(f func(string, version.Binary) error) *MockUpgraderClientSetVersionCall {
+func (c *MockUpgraderClientSetVersionCall) Do(f func(context.Context, string, version.Binary) error) *MockUpgraderClientSetVersionCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockUpgraderClientSetVersionCall) DoAndReturn(f func(string, version.Binary) error) *MockUpgraderClientSetVersionCall {
+func (c *MockUpgraderClientSetVersionCall) DoAndReturn(f func(context.Context, string, version.Binary) error) *MockUpgraderClientSetVersionCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // Tools mocks base method.
-func (m *MockUpgraderClient) Tools(arg0 string) (tools.List, error) {
+func (m *MockUpgraderClient) Tools(arg0 context.Context, arg1 string) (tools.List, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Tools", arg0)
+	ret := m.ctrl.Call(m, "Tools", arg0, arg1)
 	ret0, _ := ret[0].(tools.List)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Tools indicates an expected call of Tools.
-func (mr *MockUpgraderClientMockRecorder) Tools(arg0 any) *MockUpgraderClientToolsCall {
+func (mr *MockUpgraderClientMockRecorder) Tools(arg0, arg1 any) *MockUpgraderClientToolsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tools", reflect.TypeOf((*MockUpgraderClient)(nil).Tools), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tools", reflect.TypeOf((*MockUpgraderClient)(nil).Tools), arg0, arg1)
 	return &MockUpgraderClientToolsCall{Call: call}
 }
 
@@ -146,30 +147,30 @@ func (c *MockUpgraderClientToolsCall) Return(arg0 tools.List, arg1 error) *MockU
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockUpgraderClientToolsCall) Do(f func(string) (tools.List, error)) *MockUpgraderClientToolsCall {
+func (c *MockUpgraderClientToolsCall) Do(f func(context.Context, string) (tools.List, error)) *MockUpgraderClientToolsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockUpgraderClientToolsCall) DoAndReturn(f func(string) (tools.List, error)) *MockUpgraderClientToolsCall {
+func (c *MockUpgraderClientToolsCall) DoAndReturn(f func(context.Context, string) (tools.List, error)) *MockUpgraderClientToolsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // WatchAPIVersion mocks base method.
-func (m *MockUpgraderClient) WatchAPIVersion(arg0 string) (watcher.Watcher[struct{}], error) {
+func (m *MockUpgraderClient) WatchAPIVersion(arg0 context.Context, arg1 string) (watcher.Watcher[struct{}], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchAPIVersion", arg0)
+	ret := m.ctrl.Call(m, "WatchAPIVersion", arg0, arg1)
 	ret0, _ := ret[0].(watcher.Watcher[struct{}])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // WatchAPIVersion indicates an expected call of WatchAPIVersion.
-func (mr *MockUpgraderClientMockRecorder) WatchAPIVersion(arg0 any) *MockUpgraderClientWatchAPIVersionCall {
+func (mr *MockUpgraderClientMockRecorder) WatchAPIVersion(arg0, arg1 any) *MockUpgraderClientWatchAPIVersionCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchAPIVersion", reflect.TypeOf((*MockUpgraderClient)(nil).WatchAPIVersion), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchAPIVersion", reflect.TypeOf((*MockUpgraderClient)(nil).WatchAPIVersion), arg0, arg1)
 	return &MockUpgraderClientWatchAPIVersionCall{Call: call}
 }
 
@@ -185,13 +186,13 @@ func (c *MockUpgraderClientWatchAPIVersionCall) Return(arg0 watcher.Watcher[stru
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockUpgraderClientWatchAPIVersionCall) Do(f func(string) (watcher.Watcher[struct{}], error)) *MockUpgraderClientWatchAPIVersionCall {
+func (c *MockUpgraderClientWatchAPIVersionCall) Do(f func(context.Context, string) (watcher.Watcher[struct{}], error)) *MockUpgraderClientWatchAPIVersionCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockUpgraderClientWatchAPIVersionCall) DoAndReturn(f func(string) (watcher.Watcher[struct{}], error)) *MockUpgraderClientWatchAPIVersionCall {
+func (c *MockUpgraderClientWatchAPIVersionCall) DoAndReturn(f func(context.Context, string) (watcher.Watcher[struct{}], error)) *MockUpgraderClientWatchAPIVersionCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/upgrader/upgrader_test.go
+++ b/internal/worker/upgrader/upgrader_test.go
@@ -131,9 +131,9 @@ func (s *UpgraderSuite) TestUpgraderSetsTools(c *gc.C) {
 	ch <- struct{}{}
 
 	client := mocks.NewMockUpgraderClient(ctrl)
-	client.EXPECT().SetVersion("machine-666", vers)
-	client.EXPECT().DesiredVersion("machine-666").Return(vers.Number, nil)
-	client.EXPECT().WatchAPIVersion("machine-666").Return(watch, nil)
+	client.EXPECT().SetVersion(gomock.Any(), "machine-666", vers)
+	client.EXPECT().DesiredVersion(gomock.Any(), "machine-666").Return(vers.Number, nil)
+	client.EXPECT().WatchAPIVersion(gomock.Any(), "machine-666").Return(watch, nil)
 
 	u := s.makeUpgrader(c, client)
 	s.waitForUpgradeCheck(c)
@@ -152,17 +152,17 @@ func (s *UpgraderSuite) TestUpgraderSetVersion(c *gc.C) {
 	ch <- struct{}{}
 
 	client := mocks.NewMockUpgraderClient(ctrl)
-	client.EXPECT().SetVersion("machine-666", vers)
-	client.EXPECT().DesiredVersion("machine-666").Return(vers.Number, nil)
-	client.EXPECT().WatchAPIVersion("machine-666").Return(watch, nil)
+	client.EXPECT().SetVersion(gomock.Any(), "machine-666", vers)
+	client.EXPECT().DesiredVersion(gomock.Any(), "machine-666").Return(vers.Number, nil)
+	client.EXPECT().WatchAPIVersion(gomock.Any(), "machine-666").Return(watch, nil)
 
 	u := s.makeUpgrader(c, client)
 	s.waitForUpgradeCheck(c)
 
 	newVersion := vers
 	newVersion.Minor++
-	client.EXPECT().DesiredVersion("machine-666").Return(newVersion.Number, nil)
-	client.EXPECT().Tools("machine-666").Return(coretools.List{}, nil)
+	client.EXPECT().DesiredVersion(gomock.Any(), "machine-666").Return(newVersion.Number, nil)
+	client.EXPECT().Tools(gomock.Any(), "machine-666").Return(coretools.List{}, nil)
 
 	ch <- struct{}{}
 
@@ -180,7 +180,7 @@ func (s *UpgraderSuite) TestUpgraderWaitsForUpgradeStepsGate(c *gc.C) {
 	defer ctrl.Finish()
 
 	client := mocks.NewMockUpgraderClient(ctrl)
-	client.EXPECT().SetVersion("machine-666", vers)
+	client.EXPECT().SetVersion(gomock.Any(), "machine-666", vers)
 
 	u := s.makeUpgrader(c, client)
 	workertest.CheckAlive(c, u)
@@ -207,9 +207,9 @@ func (s *UpgraderSuite) TestUpgraderUpgradesImmediately(c *gc.C) {
 	ch <- struct{}{}
 
 	client := mocks.NewMockUpgraderClient(ctrl)
-	client.EXPECT().SetVersion("machine-666", vers)
-	client.EXPECT().DesiredVersion("machine-666").Return(newVersion.Number, nil)
-	client.EXPECT().WatchAPIVersion("machine-666").Return(watch, nil)
+	client.EXPECT().SetVersion(gomock.Any(), "machine-666", vers)
+	client.EXPECT().DesiredVersion(gomock.Any(), "machine-666").Return(newVersion.Number, nil)
+	client.EXPECT().WatchAPIVersion(gomock.Any(), "machine-666").Return(watch, nil)
 
 	u := s.makeUpgrader(c, client)
 	err := workertest.CheckKilled(c, u)
@@ -241,13 +241,13 @@ func (s *UpgraderSuite) TestUpgraderRetryAndChanged(c *gc.C) {
 	ch <- struct{}{}
 
 	client := mocks.NewMockUpgraderClient(ctrl)
-	client.EXPECT().SetVersion("machine-666", vers)
-	client.EXPECT().WatchAPIVersion("machine-666").Return(watch, nil)
+	client.EXPECT().SetVersion(gomock.Any(), "machine-666", vers)
+	client.EXPECT().WatchAPIVersion(gomock.Any(), "machine-666").Return(watch, nil)
 
 	retryCount := 3
 
-	client.EXPECT().DesiredVersion("machine-666").Return(newVersion.Number, nil).Times(retryCount + 1)
-	client.EXPECT().Tools("machine-666").Return(coretools.List{{
+	client.EXPECT().DesiredVersion(gomock.Any(), "machine-666").Return(newVersion.Number, nil).Times(retryCount + 1)
+	client.EXPECT().Tools(gomock.Any(), "machine-666").Return(coretools.List{{
 		URL: "http://invalid",
 	}}, nil).Times(retryCount + 1)
 
@@ -269,8 +269,8 @@ func (s *UpgraderSuite) TestUpgraderRetryAndChanged(c *gc.C) {
 		c, s.store, "released", "released",
 		newerVersion)[0]
 
-	client.EXPECT().DesiredVersion("machine-666").Return(newerVersion.Number, nil)
-	client.EXPECT().Tools("machine-666").Return(coretools.List{newTools}, nil)
+	client.EXPECT().DesiredVersion(gomock.Any(), "machine-666").Return(newerVersion.Number, nil)
+	client.EXPECT().Tools(gomock.Any(), "machine-666").Return(coretools.List{newTools}, nil)
 	ch <- struct{}{}
 
 	done := make(chan error)
@@ -326,8 +326,8 @@ func (s *UpgraderSuite) TestUsesAlreadyDownloadedToolsIfAvailable(c *gc.C) {
 	watch := watchertest.NewMockNotifyWatcher(ch)
 
 	client := mocks.NewMockUpgraderClient(ctrl)
-	client.EXPECT().SetVersion("machine-666", vers)
-	client.EXPECT().WatchAPIVersion("machine-666").Return(watch, nil)
+	client.EXPECT().SetVersion(gomock.Any(), "machine-666", vers)
+	client.EXPECT().WatchAPIVersion(gomock.Any(), "machine-666").Return(watch, nil)
 
 	newVersion := vers
 	newVersion.Minor++
@@ -337,7 +337,7 @@ func (s *UpgraderSuite) TestUsesAlreadyDownloadedToolsIfAvailable(c *gc.C) {
 	// downloaded tools without looking in environment storage.
 	envtesting.InstallFakeDownloadedTools(c, s.dataDir, newVersion)
 
-	client.EXPECT().DesiredVersion("machine-666").Return(newVersion.Number, nil)
+	client.EXPECT().DesiredVersion(gomock.Any(), "machine-666").Return(newVersion.Number, nil)
 	ch <- struct{}{}
 
 	u := s.makeUpgrader(c, client)
@@ -372,10 +372,10 @@ func (s *UpgraderSuite) TestUpgraderAllowsDowngradingMinorVersions(c *gc.C) {
 		oldVersion)[0]
 
 	client := mocks.NewMockUpgraderClient(ctrl)
-	client.EXPECT().SetVersion("machine-666", vers)
-	client.EXPECT().WatchAPIVersion("machine-666").Return(watch, nil)
-	client.EXPECT().DesiredVersion("machine-666").Return(oldVersion.Number, nil)
-	client.EXPECT().Tools("machine-666").Return(coretools.List{downgradeTools}, nil)
+	client.EXPECT().SetVersion(gomock.Any(), "machine-666", vers)
+	client.EXPECT().WatchAPIVersion(gomock.Any(), "machine-666").Return(watch, nil)
+	client.EXPECT().DesiredVersion(gomock.Any(), "machine-666").Return(oldVersion.Number, nil)
+	client.EXPECT().Tools(gomock.Any(), "machine-666").Return(coretools.List{downgradeTools}, nil)
 
 	u := s.makeUpgrader(c, client)
 	err := workertest.CheckKilled(c, u)
@@ -412,9 +412,9 @@ func (s *UpgraderSuite) TestUpgraderForbidsDowngradingToMajorVersion(c *gc.C) {
 		oldVersion)[0]
 
 	client := mocks.NewMockUpgraderClient(ctrl)
-	client.EXPECT().SetVersion("machine-666", vers)
-	client.EXPECT().WatchAPIVersion("machine-666").Return(watch, nil)
-	client.EXPECT().DesiredVersion("machine-666").Return(oldVersion.Number, nil)
+	client.EXPECT().SetVersion(gomock.Any(), "machine-666", vers)
+	client.EXPECT().WatchAPIVersion(gomock.Any(), "machine-666").Return(watch, nil)
+	client.EXPECT().DesiredVersion(gomock.Any(), "machine-666").Return(oldVersion.Number, nil)
 
 	u := s.makeUpgrader(c, client)
 	s.waitForUpgradeCheck(c)
@@ -449,10 +449,10 @@ func (s *UpgraderSuite) TestUpgraderAllowsDowngradingPatchVersions(c *gc.C) {
 		oldVersion)[0]
 
 	client := mocks.NewMockUpgraderClient(ctrl)
-	client.EXPECT().SetVersion("machine-666", vers)
-	client.EXPECT().WatchAPIVersion("machine-666").Return(watch, nil)
-	client.EXPECT().DesiredVersion("machine-666").Return(oldVersion.Number, nil)
-	client.EXPECT().Tools("machine-666").Return(coretools.List{downgradeTools}, nil)
+	client.EXPECT().SetVersion(gomock.Any(), "machine-666", vers)
+	client.EXPECT().WatchAPIVersion(gomock.Any(), "machine-666").Return(watch, nil)
+	client.EXPECT().DesiredVersion(gomock.Any(), "machine-666").Return(oldVersion.Number, nil)
+	client.EXPECT().Tools(gomock.Any(), "machine-666").Return(coretools.List{downgradeTools}, nil)
 
 	u := s.makeUpgrader(c, client)
 	err := workertest.CheckKilled(c, u)
@@ -493,10 +493,10 @@ func (s *UpgraderSuite) TestUpgraderAllowsDowngradeToPriorMinorVersion(c *gc.C) 
 		c, s.store, "released", "released", downgradeVersion)[0]
 
 	client := mocks.NewMockUpgraderClient(ctrl)
-	client.EXPECT().SetVersion("machine-666", origTools.Version)
-	client.EXPECT().WatchAPIVersion("machine-666").Return(watch, nil)
-	client.EXPECT().DesiredVersion("machine-666").Return(downgradeVersion.Number, nil)
-	client.EXPECT().Tools("machine-666").Return(coretools.List{prevTools}, nil)
+	client.EXPECT().SetVersion(gomock.Any(), "machine-666", origTools.Version)
+	client.EXPECT().WatchAPIVersion(gomock.Any(), "machine-666").Return(watch, nil)
+	client.EXPECT().DesiredVersion(gomock.Any(), "machine-666").Return(downgradeVersion.Number, nil)
+	client.EXPECT().Tools(gomock.Any(), "machine-666").Return(coretools.List{prevTools}, nil)
 
 	u := s.makeUpgrader(c, client)
 	err := workertest.CheckKilled(c, u)
@@ -530,10 +530,10 @@ func (s *UpgraderSuite) TestChecksSpaceBeforeDownloading(c *gc.C) {
 		version.MustParseBinary("5.4.5-ubuntu-amd64"))[0]
 
 	client := mocks.NewMockUpgraderClient(ctrl)
-	client.EXPECT().SetVersion("machine-666", oldTools.Version)
-	client.EXPECT().WatchAPIVersion("machine-666").Return(watch, nil)
-	client.EXPECT().DesiredVersion("machine-666").Return(newTools.Version.Number, nil)
-	client.EXPECT().Tools("machine-666").Return(coretools.List{newTools}, nil)
+	client.EXPECT().SetVersion(gomock.Any(), "machine-666", oldTools.Version)
+	client.EXPECT().WatchAPIVersion(gomock.Any(), "machine-666").Return(watch, nil)
+	client.EXPECT().DesiredVersion(gomock.Any(), "machine-666").Return(newTools.Version.Number, nil)
+	client.EXPECT().Tools(gomock.Any(), "machine-666").Return(coretools.List{newTools}, nil)
 
 	var diskSpaceStub testing.Stub
 	diskSpaceStub.SetErrors(nil, errors.Errorf("full-up"))

--- a/internal/worker/upgradesteps/controllerworker.go
+++ b/internal/worker/upgradesteps/controllerworker.go
@@ -190,7 +190,7 @@ func (w *controllerWorker) run() error {
 			// All the controllers have completed their upgrade steps, so
 			// we can now proceed with the upgrade.
 			w.logger.Infof("upgrade to %v completed successfully.", w.base.ToVersion)
-			_ = w.base.StatusSetter.SetStatus(status.Started, "", nil)
+			_ = w.base.StatusSetter.SetStatus(ctx, status.Started, "", nil)
 			w.base.UpgradeCompleteLock.Unlock()
 
 			return nil
@@ -258,7 +258,7 @@ func (w *controllerWorker) addWatcher(ctx context.Context, watcher eventsource.W
 func (w *controllerWorker) abort(ctx context.Context, upgradeUUID domainupgrade.UUID, err error) error {
 	// Set the status to error, we can't proceed with the upgrade.
 	// Ignore the error as it's not critical if it fails.
-	_ = w.base.StatusSetter.SetStatus(status.Error, "failed to perform upgrade steps, check logs.", nil)
+	_ = w.base.StatusSetter.SetStatus(ctx, status.Error, "failed to perform upgrade steps, check logs.", nil)
 
 	w.logger.Errorf("aborting upgrade steps: %v, manual intervention is required", err)
 	if err := w.upgradeService.SetDBUpgradeFailed(ctx, upgradeUUID); err != nil {

--- a/internal/worker/upgradesteps/controllerworker_test.go
+++ b/internal/worker/upgradesteps/controllerworker_test.go
@@ -436,7 +436,7 @@ func (s *controllerWorkerSuite) expectAbort(c *gc.C) chan struct{} {
 	done := make(chan struct{})
 	// Return an error during setting status and set db upgrade failed when
 	// aborting to ensure that we ignore it.
-	s.statusSetter.EXPECT().SetStatus(status.Error, gomock.Any(), gomock.Any()).Return(errors.New("should never be the cause of a failure"))
+	s.statusSetter.EXPECT().SetStatus(gomock.Any(), status.Error, gomock.Any(), gomock.Any()).Return(errors.New("should never be the cause of a failure"))
 	s.upgradeService.EXPECT().SetDBUpgradeFailed(gomock.Any(), s.upgradeUUID).DoAndReturn(func(ctx context.Context, uuid domainupgrade.UUID) error {
 		defer close(done)
 		return errors.New("this should still abort the work flow")
@@ -448,7 +448,7 @@ func (s *controllerWorkerSuite) expectComplete(c *gc.C) chan struct{} {
 	done := make(chan struct{})
 	// Return an error during setting status and set db upgrade failed when
 	// aborting to ensure that we ignore it.
-	s.statusSetter.EXPECT().SetStatus(status.Started, gomock.Any(), gomock.Any()).Return(errors.New("should never be the cause of a failure"))
+	s.statusSetter.EXPECT().SetStatus(gomock.Any(), status.Started, gomock.Any(), gomock.Any()).Return(errors.New("should never be the cause of a failure"))
 	s.lock.EXPECT().Unlock().Do(func() {
 		close(done)
 	})

--- a/internal/worker/upgradesteps/status_mock_test.go
+++ b/internal/worker/upgradesteps/status_mock_test.go
@@ -10,6 +10,7 @@
 package upgradesteps
 
 import (
+	context "context"
 	reflect "reflect"
 
 	status "github.com/juju/juju/core/status"
@@ -40,17 +41,17 @@ func (m *MockStatusSetter) EXPECT() *MockStatusSetterMockRecorder {
 }
 
 // SetStatus mocks base method.
-func (m *MockStatusSetter) SetStatus(arg0 status.Status, arg1 string, arg2 map[string]any) error {
+func (m *MockStatusSetter) SetStatus(arg0 context.Context, arg1 status.Status, arg2 string, arg3 map[string]any) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetStatus", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "SetStatus", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetStatus indicates an expected call of SetStatus.
-func (mr *MockStatusSetterMockRecorder) SetStatus(arg0, arg1, arg2 any) *MockStatusSetterSetStatusCall {
+func (mr *MockStatusSetterMockRecorder) SetStatus(arg0, arg1, arg2, arg3 any) *MockStatusSetterSetStatusCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetStatus", reflect.TypeOf((*MockStatusSetter)(nil).SetStatus), arg0, arg1, arg2)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetStatus", reflect.TypeOf((*MockStatusSetter)(nil).SetStatus), arg0, arg1, arg2, arg3)
 	return &MockStatusSetterSetStatusCall{Call: call}
 }
 
@@ -66,13 +67,13 @@ func (c *MockStatusSetterSetStatusCall) Return(arg0 error) *MockStatusSetterSetS
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStatusSetterSetStatusCall) Do(f func(status.Status, string, map[string]any) error) *MockStatusSetterSetStatusCall {
+func (c *MockStatusSetterSetStatusCall) Do(f func(context.Context, status.Status, string, map[string]any) error) *MockStatusSetterSetStatusCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStatusSetterSetStatusCall) DoAndReturn(f func(status.Status, string, map[string]any) error) *MockStatusSetterSetStatusCall {
+func (c *MockStatusSetterSetStatusCall) DoAndReturn(f func(context.Context, status.Status, string, map[string]any) error) *MockStatusSetterSetStatusCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/upgradestepsmachine/machineworker.go
+++ b/internal/worker/upgradestepsmachine/machineworker.go
@@ -103,7 +103,7 @@ func (w *machineWorker) run() error {
 
 	// Upgrade succeeded - signal that the upgrade is complete.
 	w.logger.Infof("upgrade to %v completed successfully.", w.base.ToVersion)
-	_ = w.base.StatusSetter.SetStatus(status.Started, "", nil)
+	_ = w.base.StatusSetter.SetStatus(ctx, status.Started, "", nil)
 	w.base.UpgradeCompleteLock.Unlock()
 	return nil
 }

--- a/internal/worker/upgradestepsmachine/manifold.go
+++ b/internal/worker/upgradestepsmachine/manifold.go
@@ -23,7 +23,7 @@ import (
 // StatusSetter defines the single method required to set an agent's
 // status.
 type StatusSetter interface {
-	SetStatus(setableStatus status.Status, info string, data map[string]any) error
+	SetStatus(ctx context.Context, setableStatus status.Status, info string, data map[string]any) error
 }
 
 type (

--- a/internal/worker/upgradestepsmachine/package_test.go
+++ b/internal/worker/upgradestepsmachine/package_test.go
@@ -88,5 +88,5 @@ func (s *baseSuite) expectUpgradeVersion(ver version.Number) {
 }
 
 func (s *baseSuite) expectStatus(status status.Status) {
-	s.statusSetter.EXPECT().SetStatus(status, gomock.Any(), nil).Return(nil)
+	s.statusSetter.EXPECT().SetStatus(gomock.Any(), status, gomock.Any(), nil).Return(nil)
 }

--- a/internal/worker/upgradestepsmachine/status_mock_test.go
+++ b/internal/worker/upgradestepsmachine/status_mock_test.go
@@ -10,6 +10,7 @@
 package upgradestepsmachine
 
 import (
+	context "context"
 	reflect "reflect"
 
 	status "github.com/juju/juju/core/status"
@@ -40,17 +41,17 @@ func (m *MockStatusSetter) EXPECT() *MockStatusSetterMockRecorder {
 }
 
 // SetStatus mocks base method.
-func (m *MockStatusSetter) SetStatus(arg0 status.Status, arg1 string, arg2 map[string]any) error {
+func (m *MockStatusSetter) SetStatus(arg0 context.Context, arg1 status.Status, arg2 string, arg3 map[string]any) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetStatus", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "SetStatus", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetStatus indicates an expected call of SetStatus.
-func (mr *MockStatusSetterMockRecorder) SetStatus(arg0, arg1, arg2 any) *MockStatusSetterSetStatusCall {
+func (mr *MockStatusSetterMockRecorder) SetStatus(arg0, arg1, arg2, arg3 any) *MockStatusSetterSetStatusCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetStatus", reflect.TypeOf((*MockStatusSetter)(nil).SetStatus), arg0, arg1, arg2)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetStatus", reflect.TypeOf((*MockStatusSetter)(nil).SetStatus), arg0, arg1, arg2, arg3)
 	return &MockStatusSetterSetStatusCall{Call: call}
 }
 
@@ -66,13 +67,13 @@ func (c *MockStatusSetterSetStatusCall) Return(arg0 error) *MockStatusSetterSetS
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStatusSetterSetStatusCall) Do(f func(status.Status, string, map[string]any) error) *MockStatusSetterSetStatusCall {
+func (c *MockStatusSetterSetStatusCall) Do(f func(context.Context, status.Status, string, map[string]any) error) *MockStatusSetterSetStatusCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStatusSetterSetStatusCall) DoAndReturn(f func(status.Status, string, map[string]any) error) *MockStatusSetterSetStatusCall {
+func (c *MockStatusSetterSetStatusCall) DoAndReturn(f func(context.Context, status.Status, string, map[string]any) error) *MockStatusSetterSetStatusCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/juju/testing/instance.go
+++ b/juju/testing/instance.go
@@ -31,7 +31,7 @@ import (
 	"github.com/juju/juju/testing"
 )
 
-func fakeCallback(_ status.Status, _ string, _ map[string]interface{}) error {
+func fakeCallback(_ context.Context, _ status.Status, _ string, _ map[string]interface{}) error {
 	return nil
 }
 

--- a/scripts/leadershipclaimer/leadershipclaimer.go
+++ b/scripts/leadershipclaimer/leadershipclaimer.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"net"
@@ -178,7 +179,7 @@ func claimLoop(holderTag names.UnitTag, claimer coreleadership.Claimer, claimDur
 		select {
 		case <-next:
 			start := time.Now()
-			err := claimer.ClaimLeadership(leaseName, holderTag.Id(), claimDuration)
+			err := claimer.ClaimLeadership(context.Background(), leaseName, holderTag.Id(), claimDuration)
 			now := time.Now()
 			sinceStart := now.Sub(agentStart).Round(time.Millisecond).Seconds()
 			reqDuration := now.Sub(start).Round(time.Millisecond)
@@ -226,7 +227,7 @@ func claimLoop(holderTag names.UnitTag, claimer coreleadership.Claimer, claimDur
 					isLeaderTime = time.Time{}
 					// Note: the 'cancel' channel does nothing
 					start := now
-					err := claimer.BlockUntilLeadershipReleased(leaseName, nil)
+					err := claimer.BlockUntilLeadershipReleased(context.Background(), leaseName, nil)
 					now = time.Now()
 					sinceStart = now.Sub(agentStart).Round(time.Millisecond).Seconds()
 					reqDuration := now.Sub(start).Round(time.Millisecond)


### PR DESCRIPTION
Threads through the `context.Context` for every method in the
`api/agent` package. This is a long and laborious set of manual changes.
The motivation behind this, is to allow observability from all agents
to the controller. The premise is to understand better how
calls interact with the server. This can help us better diagnose
the behaviour in the system and identify and fix bugs or
performance issues.

The client and controller API packages will follow in due course.

All of the code changes are mechanical, they're just either passing
in a context.Context from the parent caller or creating a scoped
context for things like workers.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
$ juju bootstrap lxd test
$ juju add-model default
$ juju deploy ubuntu
```

## Links


~~**Jira card:** JUJU-~~ (external contribution)

