### PR TITLE
fix(application): caas model application status to respect severity

### DIFF
--- a/core/status/caas_test.go
+++ b/core/status/caas_test.go
@@ -295,6 +295,18 @@ func (s *UnitCloudStatusSuite) TestApplicatoinOpeartorStatusChoice(c *gc.C) {
 			expectWorkload: false,
 			messageCheck:   "operator",
 		},
+		{
+			operatorStatus: status.StatusInfo{
+				Status:  status.Waiting,
+				Message: "operator",
+			},
+			appStatus: status.StatusInfo{
+				Status:  status.Maintenance,
+				Message: "unit",
+			},
+			expectWorkload: true,
+			messageCheck:   "unit",
+		},
 	}
 
 	for i, check := range checks {


### PR DESCRIPTION
When selecting between the operator and application statuses on a caas model Juju doesn't consider the severity of the status of the application, which may be set by the charm to a higher severity status than the operator status (e.g. maintenance > waiting), as reported by https://bugs.launchpad.net/juju/+bug/2038833.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Using the reproducer in the error report:

```
1. git clone https://github.com/carlcsaposs-canonical/bug-report-juju-status-overrides-charm-app-status.git
2. charmcraft pack
3. juju bootstrap microk8s deleteme
4. juju deploy ./bar_ubuntu-22.04-amd64.charm -n 3
5. <Wait for idle>
6. juju refresh bar --path ./bar_ubuntu-22.04-amd64.charm
7. juju status --watch 1s
```

Actual behavior (without this change)
"bar" app status flickers between waiting status "installing agent" and maintenance status "upgrading unit ..."

Expected behavior (with this change)
"bar" app status stays at maintenance status "upgrading unit ..."

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2038833

**Jira card:** JUJU-6176

