### PR TITLE
fix: charm version

### DIFF
--- a/internal/charm/charmdir.go
+++ b/internal/charm/charmdir.go
@@ -256,7 +256,7 @@ func (dir *CharmDir) ArchiveTo(w io.Writer) error {
 		return err
 	}
 	// We update the version to make sure we don't lag behind
-	dir.version, _, err = dir.MaybeGenerateVersionString()
+	dir.version, _, err = dir.MaybeGenerateVersionString(context.Background(), DefaultVersionReader(dir.logger))
 	if err != nil {
 		// We don't want to stop, even if the version cannot be generated
 		dir.logger.Warningf("trying to generate version string: %v", err)
@@ -444,130 +444,212 @@ func checkFileType(path string, mode os.FileMode) error {
 	return fmt.Errorf(e, path)
 }
 
-type typeCheckerFunc = func(ctx context.Context, charmPath string, CancelFunc func(), logger logger.Logger) bool
+// MaybeGenerateVersionString generates charm version string.
+// We want to know whether parent folders use one of these vcs, that's why we
+// try to execute each one of them
+// The second return value is the detected vcs type.
+func (dir *CharmDir) MaybeGenerateVersionString(ctx context.Context, reader VersionReader) (string, string, error) {
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
 
-type vcsCMD struct {
-	vcsType       string
-	args          []string
-	usesTypeCheck typeCheckerFunc
+	return reader.ReadVersion(ctx, dir.Path)
 }
 
-func (v *vcsCMD) commonErrHandler(err error, charmPath string) error {
-	return errors.Errorf("%q version string generation failed : "+
-		"%v\nThis means that the charm version won't show in juju status. Charm path %q", v.vcsType, err, charmPath)
+type VersionType = string
+
+const (
+	versionTypeNone VersionType = ""
+	versionTypeGit  VersionType = "git"
+	versionTypeHg   VersionType = "hg"
+	versionTypeBzr  VersionType = "bzr"
+	versionTypeFile VersionType = "versionFile"
+)
+
+// VersionReader is an interface that reads the version file.
+type VersionReader interface {
+	ReadVersion(ctx context.Context, path string) (string, VersionType, error)
+}
+
+type versionsReader struct {
+	strategies [4]VersionReader
+	logger     logger.Logger
+}
+
+// DefaultVersionReader returns a VersionReader that reads the version file.
+func DefaultVersionReader(logger logger.Logger) VersionReader {
+	return versionsReader{
+		strategies: [4]VersionReader{
+			gitVersionReader{logger: logger},
+			hgVersionReader{logger: logger},
+			bzrVersionReader{logger: logger},
+			versionFileReader{logger: logger},
+		},
+		logger: logger,
+	}
+}
+
+func (r versionsReader) ReadVersion(ctx context.Context, path string) (string, VersionType, error) {
+	absPath := path
+	if !filepath.IsAbs(absPath) {
+		var err error
+		absPath, err = filepath.Abs(path)
+		if err != nil {
+			return "", "", errors.Annotatef(err, "failed resolving relative path %q", path)
+		}
+	}
+
+	for _, strategy := range r.strategies {
+		ver, verType, err := strategy.ReadVersion(ctx, path)
+		if err != nil {
+			return "", verType, errors.Annotatef(err, "failed reading version from %q", absPath)
+		}
+		if verType != versionTypeNone {
+			return ver, verType, nil
+		}
+	}
+
+	r.logger.Infof("charm is not versioned, charm path %q", absPath)
+	return "", versionTypeNone, nil
+}
+
+type gitVersionReader struct {
+	logger logger.Logger
+}
+
+// GitVersionReader returns just a git version reader.
+func GitVersionReader(logger logger.Logger) VersionReader {
+	return gitVersionReader{logger: logger}
+}
+
+func (r gitVersionReader) ReadVersion(ctx context.Context, path string) (string, VersionType, error) {
+	if !r.usesGit(ctx, path) {
+		return "", versionTypeNone, nil
+	}
+	cmd := exec.CommandContext(ctx, "git", "describe", "--dirty", "--always")
+	// We need to make sure that the working directory will be the one we
+	// execute the commands from.
+	cmd.Dir = path
+	// Version string value is written to stdout if successful.
+	out, err := cmd.Output()
+	if err != nil {
+		// We had an error but we still know that we use a vcs, hence we can
+		// stop here and handle it.
+		return "", versionTypeGit, errors.Errorf("git version string generation failed : "+
+			"%v\nThis means that the charm version won't show in juju status.", err)
+	}
+	output := strings.TrimSuffix(string(out), "\n")
+	return output, versionTypeGit, nil
+
 }
 
 // usesGit first check checks for the easy case of the current charmdir has a
 // git folder.
 // There can be cases when the charmdir actually uses git and is just a subdir,
 // hence the below check
-func usesGit(ctx context.Context, charmPath string, cancelFunc func(), logger logger.Logger) bool {
-	defer cancelFunc()
+func (r gitVersionReader) usesGit(ctx context.Context, charmPath string) bool {
 	if _, err := os.Stat(filepath.Join(charmPath, ".git")); err == nil {
 		return true
 	}
+
 	args := []string{"rev-parse", "--is-inside-work-tree"}
 	execCmd := exec.CommandContext(ctx, "git", args...)
 	execCmd.Dir = charmPath
 
-	_, err := execCmd.Output()
-
-	if ctx.Err() == context.DeadlineExceeded {
-		logger.Debugf("git command timed out for charm in path: %q", charmPath)
-		return false
-	}
-
-	if err == nil {
+	if _, err := execCmd.Output(); err == nil {
 		return true
 	}
 	return false
 }
 
-func usesBzr(ctx context.Context, charmPath string, cancelFunc func(), logger logger.Logger) bool {
-	defer cancelFunc()
-	if _, err := os.Stat(filepath.Join(charmPath, ".bzr")); err == nil {
-		return true
-	}
-	return false
+type hgVersionReader struct {
+	logger logger.Logger
 }
 
-func usesHg(ctx context.Context, charmPath string, cancelFunc func(), logger logger.Logger) bool {
-	defer cancelFunc()
+func (r hgVersionReader) ReadVersion(ctx context.Context, path string) (string, VersionType, error) {
+	if !r.usesHg(path) {
+		return "", versionTypeNone, nil
+	}
+
+	cmd := exec.CommandContext(ctx, "hg", "id", "-n")
+	// We need to make sure that the working directory will be the one we
+	// execute the commands from.
+	cmd.Dir = path
+	// Version string value is written to stdout if successful.
+	out, err := cmd.Output()
+	if err != nil {
+		// We had an error but we still know that we use a vcs, hence we can
+		// stop here and handle it.
+		return "", versionTypeHg, errors.Errorf("hg version string generation failed : "+
+			"%v\nThis means that the charm version won't show in juju status.", err)
+	}
+	output := strings.TrimSuffix(string(out), "\n")
+	return output, versionTypeHg, nil
+
+}
+
+// usesHg first check checks for the easy case of the current charmdir has a
+// hg folder.
+// There can be cases when the charmdir actually uses hg and is just a subdir,
+// hence the below check
+func (r hgVersionReader) usesHg(charmPath string) bool {
 	if _, err := os.Stat(filepath.Join(charmPath, ".hg")); err == nil {
 		return true
 	}
 	return false
 }
 
-// VersionFileVersionType holds the type of the versioned file type, either
-// git, hg, bzr or a raw version file.
-const versionFileVersionType = "versionFile"
+type bzrVersionReader struct {
+	logger logger.Logger
+}
 
-// MaybeGenerateVersionString generates charm version string.
-// We want to know whether parent folders use one of these vcs, that's why we
-// try to execute each one of them
-// The second return value is the detected vcs type.
-func (dir *CharmDir) MaybeGenerateVersionString() (string, string, error) {
-	// vcsStrategies is the strategies to use to access the version file content.
-	vcsStrategies := map[string]vcsCMD{
-		"hg": {
-			vcsType:       "hg",
-			args:          []string{"id", "-n"},
-			usesTypeCheck: usesHg,
-		},
-		"git": {
-			vcsType:       "git",
-			args:          []string{"describe", "--dirty", "--always"},
-			usesTypeCheck: usesGit,
-		},
-		"bzr": {
-			vcsType:       "bzr",
-			args:          []string{"version-info"},
-			usesTypeCheck: usesBzr,
-		},
+func (r bzrVersionReader) ReadVersion(ctx context.Context, path string) (string, VersionType, error) {
+	if !r.usesBzr(path) {
+		return "", versionTypeNone, nil
 	}
 
-	// Nowadays most vcs used are git, we want to make sure that git is the first one we test
-	vcsOrder := [...]string{"git", "hg", "bzr"}
-	cmdWaitTime := 2 * time.Second
-
-	absPath := dir.Path
-	if !filepath.IsAbs(absPath) {
-		var err error
-		absPath, err = filepath.Abs(dir.Path)
-		if err != nil {
-			return "", "", errors.Annotatef(err, "failed resolving relative path %q", dir.Path)
-		}
+	cmd := exec.CommandContext(ctx, "bzr", "version-info")
+	// We need to make sure that the working directory will be the one we
+	// execute the commands from.
+	cmd.Dir = path
+	// Version string value is written to stdout if successful.
+	out, err := cmd.Output()
+	if err != nil {
+		// We had an error but we still know that we use a vcs, hence we can
+		// stop here and handle it.
+		return "", versionTypeBzr, errors.Errorf("bzr version string generation failed : "+
+			"%v\nThis means that the charm version won't show in juju status.", err)
 	}
+	output := strings.TrimSuffix(string(out), "\n")
+	return output, versionTypeBzr, nil
 
-	for _, vcsType := range vcsOrder {
-		vcsCmd := vcsStrategies[vcsType]
-		ctx, cancel := context.WithTimeout(context.Background(), cmdWaitTime)
-		if vcsCmd.usesTypeCheck(ctx, dir.Path, cancel, dir.logger) {
-			cmd := exec.Command(vcsCmd.vcsType, vcsCmd.args...)
-			// We need to make sure that the working directory will be the one we execute the commands from.
-			cmd.Dir = dir.Path
-			// Version string value is written to stdout if successful.
-			out, err := cmd.Output()
-			if err != nil {
-				// We had an error but we still know that we use a vcs, hence we can stop here and handle it.
-				return "", vcsType, vcsCmd.commonErrHandler(err, absPath)
-			}
-			output := strings.TrimSuffix(string(out), "\n")
-			return output, vcsType, nil
-		}
+}
+
+// usesBzr first check checks for the easy case of the current charmdir has a
+// hg folder.
+// There can be cases when the charmdir actually uses bzr and is just a subdir,
+// hence the below check
+func (r bzrVersionReader) usesBzr(charmPath string) bool {
+	if _, err := os.Stat(filepath.Join(charmPath, ".bzr")); err == nil {
+		return true
 	}
+	return false
+}
 
+type versionFileReader struct {
+	logger logger.Logger
+}
+
+func (r versionFileReader) ReadVersion(ctx context.Context, path string) (string, VersionType, error) {
 	// If all strategies fail we fallback to check the version below
-	if file, err := os.Open(dir.join("version")); err == nil {
-		dir.logger.Debugf("charm is not in version control, but uses a version file, charm path %q", absPath)
+	if file, err := os.Open(filepath.Join(path, "version")); err == nil {
+		r.logger.Debugf("charm is not in version control, but uses a version file")
 		ver, err := ReadVersion(file)
 		file.Close()
 		if err != nil {
-			return "", versionFileVersionType, err
+			return "", versionTypeFile, err
 		}
-		return ver, versionFileVersionType, nil
+		return ver, versionTypeFile, nil
 	}
-	dir.logger.Infof("charm is not versioned, charm path %q", absPath)
-	return "", "", nil
+
+	return "", versionTypeNone, nil
 }

--- a/internal/charm/charmdir_test.go
+++ b/internal/charm/charmdir_test.go
@@ -322,7 +322,7 @@ func (s *CharmSuite) TestArchiveToWithVersionStringError(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	defer loggo.RemoveWriter("versionstring-test")
 
-	msg := fmt.Sprintf("failed reading version from %q: git version string generation failed : exit status 128\nThis means that the charm version won't show in juju status.", dir.Path)
+	msg := fmt.Sprintf("failed reading version from %q: git version string generation failed: exit status 128\nThis means that the charm version won't show in juju status.", dir.Path)
 
 	versionReader := charm.DefaultVersionReader(loggertesting.WrapCheckLog(c))
 	_, _, err = dir.MaybeGenerateVersionString(context.Background(), versionReader)
@@ -601,8 +601,7 @@ func (s *CharmSuite) TestMaybeGenerateVersionStringError(c *gc.C) {
 
 	versionReader := charm.DefaultVersionReader(loggertesting.WrapCheckLog(c))
 	version, vcsType, err := dir.MaybeGenerateVersionString(context.Background(), versionReader)
-	msg := fmt.Sprintf("failed reading version from %q: git version string generation failed : exit status 128\nThis means that the charm version won't show in juju status.", dir.Path)
-	c.Assert(err, gc.ErrorMatches, msg)
+	c.Assert(err, jc.ErrorIs, charm.ErrVersionGenerationFailed)
 	c.Assert(version, gc.Equals, "")
 	c.Assert(vcsType, gc.Equals, "git")
 }

--- a/internal/charm/export_test.go
+++ b/internal/charm/export_test.go
@@ -13,6 +13,4 @@ var (
 	ExtraBindingsSchema       = extraBindingsSchema
 	ValidateMetaExtraBindings = validateMetaExtraBindings
 	ParseResourceMeta         = parseResourceMeta
-
-	UsesGit = usesGit
 )


### PR DESCRIPTION
TestMaybeGenerateVersionStringUsesAbsolutePathGitVersion fails if the git binary isn't correctly patched.

The code for checking each version wasn't ideal. The code was dependant on the code inside the function and used the export tests to patch a git check. Instead we now can pass in a version reader to check each vcs. This should improve testability of the code path.

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
$ juju bootstrap lxd test
$ juju add-model default
```

## git

```sh
$ cp -r ~/go/src/github.com/juju/juju/testcharms/charms/dummy-sink ~/tmp/
$ cd ~/tmp/dummy-sink
$ git init
$ git commit -am "Test"
$ juju deploy .
```

Ensure that we capture the right git hash.

```
$ juju status --format=json | jq -r '.applications | .["dummy-sink"] | .["charm-version"]'
```

## no version file

```sh
$ cp -r ~/go/src/github.com/juju/juju/testcharms/charms/dummy-sink ~/tmp/dummy-sink2
$ cd ~/tmp/dummy-sink2
$ juju deploy . dummy-sink2
```

Ensure that it's empty.

```
$ juju status --format=json | jq -r '.applications | .["dummy-sink2"] | .["charm-version"]'
```


## version file

```sh
$ cp -r ~/go/src/github.com/juju/juju/testcharms/charms/dummy-sink ~/tmp/dummy-sink3
$ cd ~/tmp/dummy-sink3
$ echo "hello" > version
$ juju deploy . dummy-sink3
```

Ensure that it says hello.

```
$ juju status --format=json | jq -r '.applications | .["dummy-sink3"] | .["charm-version"]'
```

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/

**Jira card:** [JUJU-6228](https://warthogs.atlassian.net/browse/JUJU-6228)



[JUJU-6228]: https://warthogs.atlassian.net/browse/JUJU-6228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ