### PR TITLE
fix: handle case of ErrNoRows for GetAll

### DIFF
--- a/domain/externalcontroller/state/state.go
+++ b/domain/externalcontroller/state/state.go
@@ -284,7 +284,7 @@ WHERE  controller_uuid = $Controller.uuid`, controller, Model{})
 	var models []Model
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err := tx.Query(ctx, stmt, controller).GetAll(&models)
-		if err != nil {
+		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return errors.Trace(domain.CoerceError(err))
 		}
 

--- a/domain/externalcontroller/state/state_test.go
+++ b/domain/externalcontroller/state/state_test.go
@@ -337,6 +337,14 @@ func (s *stateSuite) TestModelsForController(c *gc.C) {
 	c.Assert(models, jc.SameContents, []string{"model1"})
 }
 
+func (s *stateSuite) TestModelsForControllerNoRows(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	models, err := st.ModelsForController(ctx.Background(), "ctrl1")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(models, gc.HasLen, 0)
+}
+
 func (s *stateSuite) TestControllersForModels(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory())
 	db := s.DB()


### PR DESCRIPTION
When SQLair was added here, the case where `GetAll` finds no rows and returns `ErrNoRows` was missed in one place. We want to only return an empty list. Not an error.

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps
Run the following script and observe no errors:
```
#! /bin/bash

for c in "cns" "src" "dst"; do juju bootstrap lxd $c; done
juju switch src; juju add-model default; juju deploy ./testcharms/charms/dummy-source --config token=INITIAL; juju offer dummy-source:sink
juju switch cns; juju add-model default; juju consume src:admin/default.dummy-source; juju deploy ./testcharms/charms/dummy-sink; juju relate dummy-source dummy-sink
juju switch dst; juju destroy-model default --no-prompt
juju switch src
watch -c juju status -m default --relations --storage --color
```
