### PR TITLE
feat: pebble identities with rootless charms

### DIFF
--- a/caas/kubernetes/provider/application/spec31_test.go
+++ b/caas/kubernetes/provider/application/spec31_test.go
@@ -1,0 +1,359 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package application_test
+
+import (
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/pointer"
+
+	"github.com/juju/juju/caas/kubernetes/provider/constants"
+	"github.com/juju/juju/core/paths"
+)
+
+func getPodSpec31() corev1.PodSpec {
+	jujuDataDir := paths.DataDir(paths.OSUnixLike)
+	return corev1.PodSpec{
+		ServiceAccountName:            "gitlab",
+		AutomountServiceAccountToken:  pointer.BoolPtr(true),
+		ImagePullSecrets:              []corev1.LocalObjectReference{{Name: "gitlab-nginx-secret"}},
+		TerminationGracePeriodSeconds: pointer.Int64Ptr(30),
+		InitContainers: []corev1.Container{{
+			Name:            "charm-init",
+			ImagePullPolicy: corev1.PullIfNotPresent,
+			Image:           "operator/image-path:1.1.1",
+			WorkingDir:      jujuDataDir,
+			Command:         []string{"/opt/containeragent"},
+			Args: []string{
+				"init",
+				"--containeragent-pebble-dir", "/containeragent/pebble",
+				"--charm-modified-version", "9001",
+				"--data-dir", "/var/lib/juju",
+				"--bin-dir", "/charm/bin",
+				"--profile-dir", "/containeragent/etc/profile.d",
+			},
+			Env: []corev1.EnvVar{
+				{
+					Name:  "JUJU_CONTAINER_NAMES",
+					Value: "gitlab,nginx",
+				},
+				{
+					Name: "JUJU_K8S_POD_NAME",
+					ValueFrom: &corev1.EnvVarSource{
+						FieldRef: &corev1.ObjectFieldSelector{
+							FieldPath: "metadata.name",
+						},
+					},
+				},
+				{
+					Name: "JUJU_K8S_POD_UUID",
+					ValueFrom: &corev1.EnvVarSource{
+						FieldRef: &corev1.ObjectFieldSelector{
+							FieldPath: "metadata.uid",
+						},
+					},
+				},
+			},
+			EnvFrom: []corev1.EnvFromSource{
+				{
+					SecretRef: &corev1.SecretEnvSource{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "gitlab-application-config",
+						},
+					},
+				},
+			},
+			VolumeMounts: []corev1.VolumeMount{
+				{
+					Name:      "charm-data",
+					MountPath: jujuDataDir,
+					SubPath:   strings.TrimPrefix(jujuDataDir, "/"),
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/charm/bin",
+					SubPath:   "charm/bin",
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/charm/containers",
+					SubPath:   "charm/containers",
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/containeragent/pebble",
+					SubPath:   "containeragent/pebble",
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/containeragent/etc/profile.d",
+					SubPath:   "containeragent/etc/profile.d",
+				},
+			},
+		}},
+		Containers: []corev1.Container{{
+			Name:            "charm",
+			ImagePullPolicy: corev1.PullIfNotPresent,
+			Image:           "ubuntu@22.04",
+			WorkingDir:      jujuDataDir,
+			Command:         []string{"/charm/bin/pebble"},
+			Args: []string{
+				"run",
+				"--http", ":38812",
+				"--verbose",
+			},
+			Env: []corev1.EnvVar{
+				{
+					Name:  "JUJU_CONTAINER_NAMES",
+					Value: "gitlab,nginx",
+				},
+				{
+					Name:  constants.EnvAgentHTTPProbePort,
+					Value: constants.AgentHTTPProbePort,
+				},
+			},
+			LivenessProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/v1/health?level=alive",
+						Port: intstr.Parse("38812"),
+					},
+				},
+				InitialDelaySeconds: 30,
+				TimeoutSeconds:      1,
+				PeriodSeconds:       5,
+				SuccessThreshold:    1,
+				FailureThreshold:    3,
+			},
+			ReadinessProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/v1/health?level=ready",
+						Port: intstr.Parse("38812"),
+					},
+				},
+				InitialDelaySeconds: 30,
+				TimeoutSeconds:      1,
+				PeriodSeconds:       5,
+				SuccessThreshold:    1,
+				FailureThreshold:    1,
+			},
+			StartupProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/v1/health?level=alive",
+						Port: intstr.Parse("38812"),
+					},
+				},
+				InitialDelaySeconds: 30,
+				TimeoutSeconds:      1,
+				PeriodSeconds:       5,
+				SuccessThreshold:    1,
+				FailureThreshold:    1,
+			},
+			VolumeMounts: []corev1.VolumeMount{
+				{
+					Name:      "charm-data",
+					MountPath: "/charm/bin",
+					SubPath:   "charm/bin",
+					ReadOnly:  true,
+				},
+				{
+					Name:      "charm-data",
+					MountPath: jujuDataDir,
+					SubPath:   strings.TrimPrefix(jujuDataDir, "/"),
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/charm/containers",
+					SubPath:   "charm/containers",
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/var/lib/pebble/default",
+					SubPath:   "containeragent/pebble",
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/var/log/juju",
+					SubPath:   "containeragent/var/log/juju",
+				},
+				{
+					Name:      "charm-data",
+					MountPath: paths.JujuIntrospect(paths.OSUnixLike),
+					SubPath:   "charm/bin/containeragent",
+					ReadOnly:  true,
+				},
+				{
+					Name:      "charm-data",
+					MountPath: paths.JujuExec(paths.OSUnixLike),
+					SubPath:   "charm/bin/containeragent",
+					ReadOnly:  true,
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/etc/profile.d/juju-introspection.sh",
+					SubPath:   "containeragent/etc/profile.d/juju-introspection.sh",
+					ReadOnly:  true,
+				},
+				{
+					Name:      "gitlab-database-appuuid",
+					MountPath: "path/to/here",
+				},
+			},
+			SecurityContext: &corev1.SecurityContext{
+				RunAsUser:  int64Ptr(0),
+				RunAsGroup: int64Ptr(0),
+			},
+		}, {
+			Name:            "gitlab",
+			ImagePullPolicy: corev1.PullIfNotPresent,
+			Image:           "docker.io/library/gitlab:latest",
+			Command:         []string{"/charm/bin/pebble"},
+			Args:            []string{"run", "--create-dirs", "--hold", "--http", ":38813", "--verbose"},
+			Env: []corev1.EnvVar{
+				{
+					Name:  "JUJU_CONTAINER_NAME",
+					Value: "gitlab",
+				},
+				{
+					Name:  "PEBBLE_SOCKET",
+					Value: "/charm/container/pebble.socket",
+				},
+				{
+					Name:  "PEBBLE",
+					Value: "/charm/container/pebble",
+				},
+				{
+					Name:  "PEBBLE_COPY_ONCE",
+					Value: "/var/lib/pebble/default",
+				},
+			},
+			LivenessProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/v1/health?level=alive",
+						Port: intstr.FromInt(38813),
+					},
+				},
+				InitialDelaySeconds: 30,
+				TimeoutSeconds:      1,
+				PeriodSeconds:       5,
+				SuccessThreshold:    1,
+				FailureThreshold:    3,
+			},
+			ReadinessProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/v1/health?level=ready",
+						Port: intstr.FromInt(38813),
+					},
+				},
+				InitialDelaySeconds: 30,
+				TimeoutSeconds:      1,
+				PeriodSeconds:       5,
+				SuccessThreshold:    1,
+				FailureThreshold:    1,
+			},
+			VolumeMounts: []corev1.VolumeMount{
+				{
+					Name:      "charm-data",
+					MountPath: "/charm/bin/pebble",
+					SubPath:   "charm/bin/pebble",
+					ReadOnly:  true,
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/charm/container",
+					SubPath:   "charm/containers/gitlab",
+				},
+				{
+					Name:      "gitlab-database-appuuid",
+					MountPath: "path/to/here",
+				},
+			},
+			SecurityContext: &corev1.SecurityContext{
+				RunAsUser:  int64Ptr(0),
+				RunAsGroup: int64Ptr(0),
+			},
+		}, {
+			Name:            "nginx",
+			ImagePullPolicy: corev1.PullIfNotPresent,
+			Image:           "docker.io/library/nginx:latest",
+			Command:         []string{"/charm/bin/pebble"},
+			Args:            []string{"run", "--create-dirs", "--hold", "--http", ":38814", "--verbose"},
+			Env: []corev1.EnvVar{
+				{
+					Name:  "JUJU_CONTAINER_NAME",
+					Value: "nginx",
+				},
+				{
+					Name:  "PEBBLE_SOCKET",
+					Value: "/charm/container/pebble.socket",
+				},
+				{
+					Name:  "PEBBLE",
+					Value: "/charm/container/pebble",
+				},
+				{
+					Name:  "PEBBLE_COPY_ONCE",
+					Value: "/var/lib/pebble/default",
+				},
+			},
+			LivenessProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/v1/health?level=alive",
+						Port: intstr.FromInt(38814),
+					},
+				},
+				InitialDelaySeconds: 30,
+				TimeoutSeconds:      1,
+				PeriodSeconds:       5,
+				SuccessThreshold:    1,
+				FailureThreshold:    3,
+			},
+			ReadinessProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/v1/health?level=ready",
+						Port: intstr.FromInt(38814),
+					},
+				},
+				InitialDelaySeconds: 30,
+				TimeoutSeconds:      1,
+				PeriodSeconds:       5,
+				SuccessThreshold:    1,
+				FailureThreshold:    1,
+			},
+			VolumeMounts: []corev1.VolumeMount{
+				{
+					Name:      "charm-data",
+					MountPath: "/charm/bin/pebble",
+					SubPath:   "charm/bin/pebble",
+					ReadOnly:  true,
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/charm/container",
+					SubPath:   "charm/containers/nginx",
+				},
+			},
+			SecurityContext: &corev1.SecurityContext{
+				RunAsUser:  int64Ptr(0),
+				RunAsGroup: int64Ptr(0),
+			},
+		}},
+		Volumes: []corev1.Volume{
+			{
+				Name: "charm-data",
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
+			},
+		},
+	}
+}

--- a/caas/kubernetes/provider/application/spec35_test.go
+++ b/caas/kubernetes/provider/application/spec35_test.go
@@ -1,0 +1,364 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package application_test
+
+import (
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/pointer"
+
+	"github.com/juju/juju/caas/kubernetes/provider/constants"
+	"github.com/juju/juju/core/paths"
+)
+
+func getPodSpec35() corev1.PodSpec {
+	jujuDataDir := paths.DataDir(paths.OSUnixLike)
+	return corev1.PodSpec{
+		ServiceAccountName:            "gitlab",
+		AutomountServiceAccountToken:  pointer.BoolPtr(true),
+		ImagePullSecrets:              []corev1.LocalObjectReference{{Name: "gitlab-nginx-secret"}},
+		TerminationGracePeriodSeconds: pointer.Int64Ptr(30),
+		SecurityContext: &corev1.PodSecurityContext{
+			FSGroup:            int64Ptr(170),
+			SupplementalGroups: []int64{170},
+		},
+		InitContainers: []corev1.Container{{
+			Name:            "charm-init",
+			ImagePullPolicy: corev1.PullIfNotPresent,
+			Image:           "operator/image-path:1.1.1",
+			WorkingDir:      jujuDataDir,
+			SecurityContext: &corev1.SecurityContext{
+				RunAsUser:  int64Ptr(170),
+				RunAsGroup: int64Ptr(170),
+			},
+			Command: []string{"/opt/containeragent"},
+			Args: []string{
+				"init",
+				"--containeragent-pebble-dir", "/containeragent/pebble",
+				"--charm-modified-version", "9001",
+				"--data-dir", "/var/lib/juju",
+				"--bin-dir", "/charm/bin",
+				"--profile-dir", "/containeragent/etc/profile.d",
+			},
+			Env: []corev1.EnvVar{
+				{
+					Name:  "JUJU_CONTAINER_NAMES",
+					Value: "gitlab,nginx",
+				},
+				{
+					Name: "JUJU_K8S_POD_NAME",
+					ValueFrom: &corev1.EnvVarSource{
+						FieldRef: &corev1.ObjectFieldSelector{
+							FieldPath: "metadata.name",
+						},
+					},
+				},
+				{
+					Name: "JUJU_K8S_POD_UUID",
+					ValueFrom: &corev1.EnvVarSource{
+						FieldRef: &corev1.ObjectFieldSelector{
+							FieldPath: "metadata.uid",
+						},
+					},
+				},
+			},
+			EnvFrom: []corev1.EnvFromSource{
+				{
+					SecretRef: &corev1.SecretEnvSource{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "gitlab-application-config",
+						},
+					},
+				},
+			},
+			VolumeMounts: []corev1.VolumeMount{
+				{
+					Name:      "charm-data",
+					MountPath: jujuDataDir,
+					SubPath:   strings.TrimPrefix(jujuDataDir, "/"),
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/charm/bin",
+					SubPath:   "charm/bin",
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/charm/containers",
+					SubPath:   "charm/containers",
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/containeragent/pebble",
+					SubPath:   "containeragent/pebble",
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/containeragent/etc/profile.d",
+					SubPath:   "containeragent/etc/profile.d",
+				},
+			},
+		}},
+		Containers: []corev1.Container{{
+			Name:            "charm",
+			ImagePullPolicy: corev1.PullIfNotPresent,
+			Image:           "ubuntu@22.04",
+			WorkingDir:      jujuDataDir,
+			Command:         []string{"/charm/bin/pebble"},
+			Args: []string{
+				"run",
+				"--http", ":38812",
+				"--verbose",
+			},
+			Env: []corev1.EnvVar{
+				{
+					Name:  "JUJU_CONTAINER_NAMES",
+					Value: "gitlab,nginx",
+				},
+				{
+					Name:  constants.EnvAgentHTTPProbePort,
+					Value: constants.AgentHTTPProbePort,
+				},
+			},
+			LivenessProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/v1/health?level=alive",
+						Port: intstr.Parse("38812"),
+					},
+				},
+				InitialDelaySeconds: 30,
+				TimeoutSeconds:      1,
+				PeriodSeconds:       5,
+				SuccessThreshold:    1,
+				FailureThreshold:    3,
+			},
+			ReadinessProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/v1/health?level=ready",
+						Port: intstr.Parse("38812"),
+					},
+				},
+				InitialDelaySeconds: 30,
+				TimeoutSeconds:      1,
+				PeriodSeconds:       5,
+				SuccessThreshold:    1,
+				FailureThreshold:    1,
+			},
+			StartupProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/v1/health?level=alive",
+						Port: intstr.Parse("38812"),
+					},
+				},
+				InitialDelaySeconds: 30,
+				TimeoutSeconds:      1,
+				PeriodSeconds:       5,
+				SuccessThreshold:    1,
+				FailureThreshold:    1,
+			},
+			VolumeMounts: []corev1.VolumeMount{
+				{
+					Name:      "charm-data",
+					MountPath: "/charm/bin",
+					SubPath:   "charm/bin",
+					ReadOnly:  true,
+				},
+				{
+					Name:      "charm-data",
+					MountPath: jujuDataDir,
+					SubPath:   strings.TrimPrefix(jujuDataDir, "/"),
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/charm/containers",
+					SubPath:   "charm/containers",
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/var/lib/pebble/default",
+					SubPath:   "containeragent/pebble",
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/var/log/juju",
+					SubPath:   "containeragent/var/log/juju",
+				},
+				{
+					Name:      "charm-data",
+					MountPath: paths.JujuIntrospect(paths.OSUnixLike),
+					SubPath:   "charm/bin/containeragent",
+					ReadOnly:  true,
+				},
+				{
+					Name:      "charm-data",
+					MountPath: paths.JujuExec(paths.OSUnixLike),
+					SubPath:   "charm/bin/containeragent",
+					ReadOnly:  true,
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/etc/profile.d/juju-introspection.sh",
+					SubPath:   "containeragent/etc/profile.d/juju-introspection.sh",
+					ReadOnly:  true,
+				},
+				{
+					Name:      "gitlab-database-appuuid",
+					MountPath: "path/to/here",
+				},
+			},
+			SecurityContext: &corev1.SecurityContext{
+				RunAsUser:  int64Ptr(170),
+				RunAsGroup: int64Ptr(170),
+			},
+		}, {
+			Name:            "gitlab",
+			ImagePullPolicy: corev1.PullIfNotPresent,
+			Image:           "docker.io/library/gitlab:latest",
+			Command:         []string{"/charm/bin/pebble"},
+			Args:            []string{"run", "--create-dirs", "--hold", "--http", ":38813", "--verbose"},
+			Env: []corev1.EnvVar{
+				{
+					Name:  "JUJU_CONTAINER_NAME",
+					Value: "gitlab",
+				},
+				{
+					Name:  "PEBBLE_SOCKET",
+					Value: "/charm/container/pebble.socket",
+				},
+				{
+					Name:  "PEBBLE",
+					Value: "/charm/container/pebble",
+				},
+				{
+					Name:  "PEBBLE_COPY_ONCE",
+					Value: "/var/lib/pebble/default",
+				},
+			},
+			LivenessProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/v1/health?level=alive",
+						Port: intstr.FromInt(38813),
+					},
+				},
+				InitialDelaySeconds: 30,
+				TimeoutSeconds:      1,
+				PeriodSeconds:       5,
+				SuccessThreshold:    1,
+				FailureThreshold:    3,
+			},
+			ReadinessProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/v1/health?level=ready",
+						Port: intstr.FromInt(38813),
+					},
+				},
+				InitialDelaySeconds: 30,
+				TimeoutSeconds:      1,
+				PeriodSeconds:       5,
+				SuccessThreshold:    1,
+				FailureThreshold:    1,
+			},
+			VolumeMounts: []corev1.VolumeMount{
+				{
+					Name:      "charm-data",
+					MountPath: "/charm/bin/pebble",
+					SubPath:   "charm/bin/pebble",
+					ReadOnly:  true,
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/charm/container",
+					SubPath:   "charm/containers/gitlab",
+				},
+				{
+					Name:      "gitlab-database-appuuid",
+					MountPath: "path/to/here",
+				},
+			},
+			SecurityContext: &corev1.SecurityContext{},
+		}, {
+			Name:            "nginx",
+			ImagePullPolicy: corev1.PullIfNotPresent,
+			Image:           "docker.io/library/nginx:latest",
+			Command:         []string{"/charm/bin/pebble"},
+			Args:            []string{"run", "--create-dirs", "--hold", "--http", ":38814", "--verbose"},
+			Env: []corev1.EnvVar{
+				{
+					Name:  "JUJU_CONTAINER_NAME",
+					Value: "nginx",
+				},
+				{
+					Name:  "PEBBLE_SOCKET",
+					Value: "/charm/container/pebble.socket",
+				},
+				{
+					Name:  "PEBBLE",
+					Value: "/charm/container/pebble",
+				},
+				{
+					Name:  "PEBBLE_COPY_ONCE",
+					Value: "/var/lib/pebble/default",
+				},
+			},
+			LivenessProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/v1/health?level=alive",
+						Port: intstr.FromInt(38814),
+					},
+				},
+				InitialDelaySeconds: 30,
+				TimeoutSeconds:      1,
+				PeriodSeconds:       5,
+				SuccessThreshold:    1,
+				FailureThreshold:    3,
+			},
+			ReadinessProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/v1/health?level=ready",
+						Port: intstr.FromInt(38814),
+					},
+				},
+				InitialDelaySeconds: 30,
+				TimeoutSeconds:      1,
+				PeriodSeconds:       5,
+				SuccessThreshold:    1,
+				FailureThreshold:    1,
+			},
+			VolumeMounts: []corev1.VolumeMount{
+				{
+					Name:      "charm-data",
+					MountPath: "/charm/bin/pebble",
+					SubPath:   "charm/bin/pebble",
+					ReadOnly:  true,
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/charm/container",
+					SubPath:   "charm/containers/nginx",
+				},
+			},
+			SecurityContext: &corev1.SecurityContext{
+				RunAsUser:  int64Ptr(1234),
+				RunAsGroup: int64Ptr(4321),
+			},
+		}},
+		Volumes: []corev1.Volume{
+			{
+				Name: "charm-data",
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
+			},
+		},
+	}
+}

--- a/caas/kubernetes/provider/application/spec36_test.go
+++ b/caas/kubernetes/provider/application/spec36_test.go
@@ -1,0 +1,383 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package application_test
+
+import (
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/pointer"
+
+	"github.com/juju/juju/caas/kubernetes/provider/constants"
+	"github.com/juju/juju/core/paths"
+)
+
+func getPodSpec36() corev1.PodSpec {
+	jujuDataDir := paths.DataDir(paths.OSUnixLike)
+	return corev1.PodSpec{
+		ServiceAccountName:            "gitlab",
+		AutomountServiceAccountToken:  pointer.BoolPtr(true),
+		ImagePullSecrets:              []corev1.LocalObjectReference{{Name: "gitlab-nginx-secret"}},
+		TerminationGracePeriodSeconds: pointer.Int64Ptr(30),
+		SecurityContext: &corev1.PodSecurityContext{
+			FSGroup:            int64Ptr(170),
+			SupplementalGroups: []int64{170},
+		},
+		InitContainers: []corev1.Container{{
+			Name:            "charm-init",
+			ImagePullPolicy: corev1.PullIfNotPresent,
+			Image:           "operator/image-path:1.1.1",
+			WorkingDir:      jujuDataDir,
+			SecurityContext: &corev1.SecurityContext{
+				RunAsUser:  int64Ptr(170),
+				RunAsGroup: int64Ptr(170),
+			},
+			Command: []string{"/opt/containeragent"},
+			Args: []string{
+				"init",
+				"--containeragent-pebble-dir", "/containeragent/pebble",
+				"--charm-modified-version", "9001",
+				"--data-dir", "/var/lib/juju",
+				"--bin-dir", "/charm/bin",
+				"--profile-dir", "/containeragent/etc/profile.d",
+				"--pebble-identities-file", "/charm/etc/pebble/identities.yaml",
+				"--pebble-charm-identity", "170",
+			},
+			Env: []corev1.EnvVar{
+				{
+					Name:  "JUJU_CONTAINER_NAMES",
+					Value: "gitlab,nginx",
+				},
+				{
+					Name: "JUJU_K8S_POD_NAME",
+					ValueFrom: &corev1.EnvVarSource{
+						FieldRef: &corev1.ObjectFieldSelector{
+							FieldPath: "metadata.name",
+						},
+					},
+				},
+				{
+					Name: "JUJU_K8S_POD_UUID",
+					ValueFrom: &corev1.EnvVarSource{
+						FieldRef: &corev1.ObjectFieldSelector{
+							FieldPath: "metadata.uid",
+						},
+					},
+				},
+			},
+			EnvFrom: []corev1.EnvFromSource{
+				{
+					SecretRef: &corev1.SecretEnvSource{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "gitlab-application-config",
+						},
+					},
+				},
+			},
+			VolumeMounts: []corev1.VolumeMount{
+				{
+					Name:      "charm-data",
+					MountPath: jujuDataDir,
+					SubPath:   strings.TrimPrefix(jujuDataDir, "/"),
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/charm/bin",
+					SubPath:   "charm/bin",
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/charm/containers",
+					SubPath:   "charm/containers",
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/containeragent/pebble",
+					SubPath:   "containeragent/pebble",
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/containeragent/etc/profile.d",
+					SubPath:   "containeragent/etc/profile.d",
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/charm/etc/pebble/",
+					SubPath:   "charm/etc/pebble/",
+				},
+			},
+		}},
+		Containers: []corev1.Container{{
+			Name:            "charm",
+			ImagePullPolicy: corev1.PullIfNotPresent,
+			Image:           "ubuntu@22.04",
+			WorkingDir:      jujuDataDir,
+			Command:         []string{"/charm/bin/pebble"},
+			Args: []string{
+				"run",
+				"--http", ":38812",
+				"--verbose",
+			},
+			Env: []corev1.EnvVar{
+				{
+					Name:  "JUJU_CONTAINER_NAMES",
+					Value: "gitlab,nginx",
+				},
+				{
+					Name:  constants.EnvAgentHTTPProbePort,
+					Value: constants.AgentHTTPProbePort,
+				},
+			},
+			LivenessProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/v1/health?level=alive",
+						Port: intstr.Parse("38812"),
+					},
+				},
+				InitialDelaySeconds: 30,
+				TimeoutSeconds:      1,
+				PeriodSeconds:       5,
+				SuccessThreshold:    1,
+				FailureThreshold:    3,
+			},
+			ReadinessProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/v1/health?level=ready",
+						Port: intstr.Parse("38812"),
+					},
+				},
+				InitialDelaySeconds: 30,
+				TimeoutSeconds:      1,
+				PeriodSeconds:       5,
+				SuccessThreshold:    1,
+				FailureThreshold:    1,
+			},
+			StartupProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/v1/health?level=alive",
+						Port: intstr.Parse("38812"),
+					},
+				},
+				InitialDelaySeconds: 30,
+				TimeoutSeconds:      1,
+				PeriodSeconds:       5,
+				SuccessThreshold:    1,
+				FailureThreshold:    1,
+			},
+			VolumeMounts: []corev1.VolumeMount{
+				{
+					Name:      "charm-data",
+					MountPath: "/charm/bin",
+					SubPath:   "charm/bin",
+					ReadOnly:  true,
+				},
+				{
+					Name:      "charm-data",
+					MountPath: jujuDataDir,
+					SubPath:   strings.TrimPrefix(jujuDataDir, "/"),
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/charm/containers",
+					SubPath:   "charm/containers",
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/var/lib/pebble/default",
+					SubPath:   "containeragent/pebble",
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/var/log/juju",
+					SubPath:   "containeragent/var/log/juju",
+				},
+				{
+					Name:      "charm-data",
+					MountPath: paths.JujuIntrospect(paths.OSUnixLike),
+					SubPath:   "charm/bin/containeragent",
+					ReadOnly:  true,
+				},
+				{
+					Name:      "charm-data",
+					MountPath: paths.JujuExec(paths.OSUnixLike),
+					SubPath:   "charm/bin/containeragent",
+					ReadOnly:  true,
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/etc/profile.d/juju-introspection.sh",
+					SubPath:   "containeragent/etc/profile.d/juju-introspection.sh",
+					ReadOnly:  true,
+				},
+				{
+					Name:      "gitlab-database-appuuid",
+					MountPath: "path/to/here",
+				},
+			},
+			SecurityContext: &corev1.SecurityContext{
+				RunAsUser:  int64Ptr(170),
+				RunAsGroup: int64Ptr(170),
+			},
+		}, {
+			Name:            "gitlab",
+			ImagePullPolicy: corev1.PullIfNotPresent,
+			Image:           "docker.io/library/gitlab:latest",
+			Command:         []string{"/charm/bin/pebble"},
+			Args:            []string{"run", "--create-dirs", "--hold", "--http", ":38813", "--verbose", "--identities", "/charm/etc/pebble/identities.yaml"},
+			Env: []corev1.EnvVar{
+				{
+					Name:  "JUJU_CONTAINER_NAME",
+					Value: "gitlab",
+				},
+				{
+					Name:  "PEBBLE_SOCKET",
+					Value: "/charm/container/pebble.socket",
+				},
+				{
+					Name:  "PEBBLE",
+					Value: "/charm/container/pebble",
+				},
+				{
+					Name:  "PEBBLE_COPY_ONCE",
+					Value: "/var/lib/pebble/default",
+				},
+			},
+			LivenessProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/v1/health?level=alive",
+						Port: intstr.FromInt(38813),
+					},
+				},
+				InitialDelaySeconds: 30,
+				TimeoutSeconds:      1,
+				PeriodSeconds:       5,
+				SuccessThreshold:    1,
+				FailureThreshold:    3,
+			},
+			ReadinessProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/v1/health?level=ready",
+						Port: intstr.FromInt(38813),
+					},
+				},
+				InitialDelaySeconds: 30,
+				TimeoutSeconds:      1,
+				PeriodSeconds:       5,
+				SuccessThreshold:    1,
+				FailureThreshold:    1,
+			},
+			VolumeMounts: []corev1.VolumeMount{
+				{
+					Name:      "charm-data",
+					MountPath: "/charm/bin/pebble",
+					SubPath:   "charm/bin/pebble",
+					ReadOnly:  true,
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/charm/container",
+					SubPath:   "charm/containers/gitlab",
+				},
+				{
+					Name:      "charm-data",
+					ReadOnly:  true,
+					MountPath: "/charm/etc/pebble/identities.yaml",
+					SubPath:   "charm/etc/pebble/identities.yaml",
+				},
+				{
+					Name:      "gitlab-database-appuuid",
+					MountPath: "path/to/here",
+				},
+			},
+			SecurityContext: &corev1.SecurityContext{},
+		}, {
+			Name:            "nginx",
+			ImagePullPolicy: corev1.PullIfNotPresent,
+			Image:           "docker.io/library/nginx:latest",
+			Command:         []string{"/charm/bin/pebble"},
+			Args:            []string{"run", "--create-dirs", "--hold", "--http", ":38814", "--verbose", "--identities", "/charm/etc/pebble/identities.yaml"},
+			Env: []corev1.EnvVar{
+				{
+					Name:  "JUJU_CONTAINER_NAME",
+					Value: "nginx",
+				},
+				{
+					Name:  "PEBBLE_SOCKET",
+					Value: "/charm/container/pebble.socket",
+				},
+				{
+					Name:  "PEBBLE",
+					Value: "/charm/container/pebble",
+				},
+				{
+					Name:  "PEBBLE_COPY_ONCE",
+					Value: "/var/lib/pebble/default",
+				},
+			},
+			LivenessProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/v1/health?level=alive",
+						Port: intstr.FromInt(38814),
+					},
+				},
+				InitialDelaySeconds: 30,
+				TimeoutSeconds:      1,
+				PeriodSeconds:       5,
+				SuccessThreshold:    1,
+				FailureThreshold:    3,
+			},
+			ReadinessProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/v1/health?level=ready",
+						Port: intstr.FromInt(38814),
+					},
+				},
+				InitialDelaySeconds: 30,
+				TimeoutSeconds:      1,
+				PeriodSeconds:       5,
+				SuccessThreshold:    1,
+				FailureThreshold:    1,
+			},
+			VolumeMounts: []corev1.VolumeMount{
+				{
+					Name:      "charm-data",
+					MountPath: "/charm/bin/pebble",
+					SubPath:   "charm/bin/pebble",
+					ReadOnly:  true,
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/charm/container",
+					SubPath:   "charm/containers/nginx",
+				},
+				{
+					Name:      "charm-data",
+					ReadOnly:  true,
+					MountPath: "/charm/etc/pebble/identities.yaml",
+					SubPath:   "charm/etc/pebble/identities.yaml",
+				},
+			},
+			SecurityContext: &corev1.SecurityContext{
+				RunAsUser:  int64Ptr(1234),
+				RunAsGroup: int64Ptr(4321),
+			},
+		}},
+		Volumes: []corev1.Volume{
+			{
+				Name: "charm-data",
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
+			},
+		},
+	}
+}

--- a/cmd/containeragent/initialize/package_test.go
+++ b/cmd/containeragent/initialize/package_test.go
@@ -96,6 +96,7 @@ func (*importSuite) TestImports(c *gc.C) {
 		"rpc/jsoncodec",
 		"rpc/params",
 		"service/common",
+		"service/pebble/identity",
 		"service/pebble/plan",
 		"service/snap",
 		"service/systemd",

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/bmizerany/pat v0.0.0-20210406213842-e4b6760bdd6f
 	github.com/canonical/go-dqlite v1.21.0
 	github.com/canonical/lxd v0.0.0-20231214113525-e676fc63c50a
-	github.com/canonical/pebble v1.14.0
+	github.com/canonical/pebble v1.15.0
 	github.com/chzyer/readline v1.5.1
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/docker/distribution v2.8.3+incompatible

--- a/go.sum
+++ b/go.sum
@@ -150,8 +150,8 @@ github.com/canonical/go-flags v0.0.0-20230403090104-105d09a091b8 h1:zGaJEJI9qPVy
 github.com/canonical/go-flags v0.0.0-20230403090104-105d09a091b8/go.mod h1:ZZFeR9K9iGgpwOaLYF9PdT44/+lfSJ9sQz3B+SsGsYU=
 github.com/canonical/lxd v0.0.0-20231214113525-e676fc63c50a h1:Tfo/MzXK5GeG7gzSHqxGeY/669Mhh5ea43dn1mRDnk8=
 github.com/canonical/lxd v0.0.0-20231214113525-e676fc63c50a/go.mod h1:UxfHGKFoRjgu1NUA9EFiR++dKvyAiT0h9HT0ffMlzjc=
-github.com/canonical/pebble v1.14.0 h1:lssD5HWeeJrnrXMhuRRq8c/FZss8WANDG/prgC1u+Wc=
-github.com/canonical/pebble v1.14.0/go.mod h1:V9npURKOudv0IZ/z1mJGd1xyLK51flJIlMCIU0lDJ5Y=
+github.com/canonical/pebble v1.15.0 h1:eWtoe5+yHC0fZ+1wglk2VsPUJZtJbxhGo0XiEAjv6p4=
+github.com/canonical/pebble v1.15.0/go.mod h1:iAy6oxSew0En91FA4WdhmKjiuzS2F+hKgOSA4RGjhGg=
 github.com/canonical/x-go v0.0.0-20230522092633-7947a7587f5b h1:Da2fardddn+JDlVEYtrzBLTtyzoyU3nIS0Cf0GvjmwU=
 github.com/canonical/x-go v0.0.0-20230522092633-7947a7587f5b/go.mod h1:upTK9n6rlqITN9rCN69hdreI37dRDFUk2thlGGD5Cg8=
 github.com/cenkalti/backoff/v3 v3.0.0 h1:ske+9nBpD9qZsTBoF41nW5L+AIuFBKMeze18XQ3eG1c=

--- a/service/pebble/identity/doc.go
+++ b/service/pebble/identity/doc.go
@@ -1,0 +1,8 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package identity defines the various types to work with the Pebble identities file.
+//
+// This is a subset of the types in github.com/canonical/pebble/cmd,
+// copied directly from that repository.
+package identity

--- a/service/pebble/identity/identities.go
+++ b/service/pebble/identity/identities.go
@@ -1,0 +1,34 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package identity
+
+type IdentitiesFile struct {
+	Identities map[string]*Identity `json:"identities" yaml:"identities"`
+}
+
+// Identity holds the configuration of a single identity.
+type Identity struct {
+	Access IdentityAccess `json:"access" yaml:"access"`
+
+	// One or more of the following type-specific configuration fields must be
+	// non-nil (currently the only type is "local").
+	Local *LocalIdentity `json:"local,omitempty" yaml:"local,omitempty"`
+}
+
+// IdentityAccess defines the access level for an identity.
+type IdentityAccess string
+
+const (
+	AdminAccess     IdentityAccess = "admin"
+	ReadAccess      IdentityAccess = "read"
+	UntrustedAccess IdentityAccess = "untrusted"
+)
+
+// LocalIdentity holds identity configuration specific to the "local" type
+// (for ucrednet/UID authentication).
+type LocalIdentity struct {
+	// This is a pointer so we can distinguish between not set and 0 (a valid
+	// user-id meaning root).
+	UserID *uint32 `json:"user-id" yaml:"user-id"`
+}

--- a/testcharms/charms/sidecar-non-root/hooks/install
+++ b/testcharms/charms/sidecar-non-root/hooks/install
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+status-set maintenance "Setup..."
+juju-log "charm=$UID"
+juju-log "sudo=$(sudo -n echo yes || echo no)"

--- a/testcharms/charms/sidecar-non-root/hooks/rootful-pebble-ready
+++ b/testcharms/charms/sidecar-non-root/hooks/rootful-pebble-ready
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+export PEBBLE_SOCKET=/charm/containers/rootful/pebble.socket
+juju-log "rootful=$(/charm/bin/pebble exec -- bash -c 'echo $UID')"
+
+touch /charm/containers/rootful/ready
+if [ -f "/charm/containers/rootless/ready" ]; then
+    status-set active "Ready."
+fi

--- a/testcharms/charms/sidecar-non-root/hooks/rootless-pebble-ready
+++ b/testcharms/charms/sidecar-non-root/hooks/rootless-pebble-ready
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+export PEBBLE_SOCKET=/charm/containers/rootless/pebble.socket
+juju-log "rootless=$(/charm/bin/pebble exec -- bash -c 'echo $UID')"
+
+touch /charm/containers/rootless/ready
+if [ -f "/charm/containers/rootful/ready" ]; then
+    status-set active "Ready."
+fi

--- a/testcharms/charms/sidecar-non-root/hooks/upgrade-charm
+++ b/testcharms/charms/sidecar-non-root/hooks/upgrade-charm
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+status-set maintenance "Setup..."
+juju-log "charm=$UID"
+juju-log "sudo=$(sudo -n echo yes || echo no)"

--- a/testcharms/charms/sidecar-non-root/manifest.yaml
+++ b/testcharms/charms/sidecar-non-root/manifest.yaml
@@ -1,0 +1,6 @@
+bases:
+  - name: ubuntu
+    channel: 22.04/stable
+    architectures:
+      - amd64
+      - arm64

--- a/testcharms/charms/sidecar-non-root/metadata.yaml
+++ b/testcharms/charms/sidecar-non-root/metadata.yaml
@@ -1,0 +1,15 @@
+name: sidecar-non-root
+summary: sidecar charm with rootless charm and workloads
+description: ""
+containers:
+  rootful:
+    resource: ubuntu
+  rootless:
+    resource: ubuntu
+    uid: 10000
+    gid: 10000
+resources:
+  ubuntu:
+    type: oci-image
+    description: OCI image used for test containers
+charm-user: non-root

--- a/testcharms/charms/sidecar-sudoer/hooks/install
+++ b/testcharms/charms/sidecar-sudoer/hooks/install
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+status-set maintenance "Setup..."
+juju-log "charm=$UID"
+juju-log "sudo=$(sudo -n echo yes || echo no)"

--- a/testcharms/charms/sidecar-sudoer/hooks/rootful-pebble-ready
+++ b/testcharms/charms/sidecar-sudoer/hooks/rootful-pebble-ready
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+export PEBBLE_SOCKET=/charm/containers/rootful/pebble.socket
+juju-log "rootful=$(/charm/bin/pebble exec -- bash -c 'echo $UID')"
+
+touch /charm/containers/rootful/ready
+if [ -f "/charm/containers/rootless/ready" ]; then
+    status-set active "Ready."
+fi

--- a/testcharms/charms/sidecar-sudoer/hooks/rootless-pebble-ready
+++ b/testcharms/charms/sidecar-sudoer/hooks/rootless-pebble-ready
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+export PEBBLE_SOCKET=/charm/containers/rootless/pebble.socket
+juju-log "rootless=$(/charm/bin/pebble exec -- bash -c 'echo $UID')"
+
+touch /charm/containers/rootless/ready
+if [ -f "/charm/containers/rootful/ready" ]; then
+    status-set active "Ready."
+fi

--- a/testcharms/charms/sidecar-sudoer/hooks/upgrade-charm
+++ b/testcharms/charms/sidecar-sudoer/hooks/upgrade-charm
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+status-set maintenance "Setup..."
+juju-log "charm=$UID"
+juju-log "sudo=$(sudo -n echo yes || echo no)"

--- a/testcharms/charms/sidecar-sudoer/manifest.yaml
+++ b/testcharms/charms/sidecar-sudoer/manifest.yaml
@@ -1,0 +1,6 @@
+bases:
+  - name: ubuntu
+    channel: 22.04/stable
+    architectures:
+      - amd64
+      - arm64

--- a/testcharms/charms/sidecar-sudoer/metadata.yaml
+++ b/testcharms/charms/sidecar-sudoer/metadata.yaml
@@ -1,0 +1,15 @@
+name: sidecar-sudoer
+summary: sidecar charm with rootless charm and workloads
+description: ""
+containers:
+  rootful:
+    resource: ubuntu
+  rootless:
+    resource: ubuntu
+    uid: 10000
+    gid: 10000
+resources:
+  ubuntu:
+    type: oci-image
+    description: OCI image used for test containers
+charm-user: sudoer

--- a/tests/suites/sidecar/rootless.sh
+++ b/tests/suites/sidecar/rootless.sh
@@ -1,0 +1,57 @@
+run_non_root_charm() {
+	echo
+
+	file="${TEST_DIR}/test-rootless-non-root-charm.log"
+
+	ensure "test-rootless-non-root-charm" "${file}"
+
+	juju deploy ./testcharms/charms/sidecar-non-root --resource ubuntu=public.ecr.aws/ubuntu/ubuntu:22.04
+
+	wait_for "sidecar-non-root" "$(idle_condition "sidecar-non-root" 0 0)"
+	sleep 10 # wait for logs
+
+	output=$(juju debug-log --replay)
+	check_contains "$output" "charm=170"
+	check_contains "$output" "sudo=no"
+	check_contains "$output" "rootless=10000"
+	check_contains "$output" "rootful=0"
+
+	destroy_model "test-rootless-non-root-charm"
+}
+
+run_sudoer_charm() {
+	echo
+
+	file="${TEST_DIR}/test-rootless-sudoer-charm.log"
+
+	ensure "test-rootless-sudoer-charm" "${file}"
+
+	juju deploy ./testcharms/charms/sidecar-sudoer --resource ubuntu=public.ecr.aws/ubuntu/ubuntu:22.04
+
+	wait_for "sidecar-sudoer" "$(idle_condition "sidecar-sudoer" 0 0)"
+	sleep 10 # wait for logs
+
+	output=$(juju debug-log --replay)
+	check_contains "$output" "charm=171"
+	check_contains "$output" "sudo=yes"
+	check_contains "$output" "rootless=10000"
+	check_contains "$output" "rootful=0"
+
+	destroy_model "test-rootless-sudoer-charm"
+}
+
+test_rootless() {
+	if [ "$(skip 'test_rootless')" ]; then
+		echo "==> TEST SKIPPED: test_rootless"
+		return
+	fi
+
+	(
+		set_verbosity
+
+		cd .. || exit
+
+		run "run_non_root_charm"
+		run "run_sudoer_charm"
+	)
+}

--- a/tests/suites/sidecar/task.sh
+++ b/tests/suites/sidecar/task.sh
@@ -12,6 +12,7 @@ test_sidecar() {
 		test_deploy_and_force_remove_application
 		test_pebble_notices
 		test_pebble_checks
+		test_rootless
 		;;
 	*)
 		echo "==> TEST SKIPPED: sidecar charm tests, not a k8s provider"

--- a/worker/caasapplicationprovisioner/ops.go
+++ b/worker/caasapplicationprovisioner/ops.go
@@ -218,13 +218,9 @@ func appAlive(appName string, app caas.Application, password string, lastApplied
 	case charm.RunAsRoot:
 		config.CharmUser = caas.RunAsRoot
 	case charm.RunAsSudoer:
-		// TODO(pebble): once pebble supports auth, allow running as non-root.
-		//config.CharmUser = caas.RunAsSudoer
-		config.CharmUser = caas.RunAsRoot
+		config.CharmUser = caas.RunAsSudoer
 	case charm.RunAsNonRoot:
-		// TODO(pebble): once pebble supports auth, allow running as non-root.
-		//config.CharmUser = caas.RunAsNonRoot
-		config.CharmUser = caas.RunAsRoot
+		config.CharmUser = caas.RunAsNonRoot
 	default:
 		return errors.NotValidf("unknown RunAs for CharmUser: %q", ch.Meta().CharmUser)
 	}


### PR DESCRIPTION
Uses updated pebble version with pebble identities so that the charm container in a k8s deployment can run without root and connect to the pebble instances running in the workload containers (who may be running as a different user).

With this patch the charm can specify in the metadata.yaml a charm-user field with either the values root, non-root or sudoer.

|charm-user|user|user-id|
|-|-|-|
|root|root|0|
|non-root|juju|170|
|sudoer|sjuju|171|

## QA steps

- test root charm can be deployed
- test model with root charm from 3.5 can be model migrated
- test rootless charm can be deployed (with charm-user: non-root and charm-user: sudoer) works
- run integration tests `./main.sh -p k8s -c minikube sidecar test_rootless`

## Documentation changes

Document in metadata.yaml docs the `charm-user` field.

## Links

**Jira card:** JUJU-5130

