### PR TITLE
feat: remove initial model bootstrap arg

### DIFF
--- a/caas/kubernetes/provider/bootstrap_test.go
+++ b/caas/kubernetes/provider/bootstrap_test.go
@@ -97,9 +97,6 @@ func (s *bootstrapSuite) SetUpTest(c *gc.C) {
 	}
 	pcfg.Bootstrap.ControllerModelConfig = s.cfg
 	pcfg.Bootstrap.BootstrapMachineInstanceId = "instance-id"
-	pcfg.Bootstrap.InitialModelConfig = map[string]interface{}{
-		"name": "my-model",
-	}
 	pcfg.Bootstrap.StateServingInfo = controller.StateServingInfo{
 		Cert:         coretesting.ServerCert,
 		PrivateKey:   coretesting.ServerKey,

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -450,22 +450,6 @@ func (k *kubernetesClient) Bootstrap(
 
 		logger.Debugf("controller pod config: \n%+v", pcfg)
 
-		// validate initial model name if we need to create it.
-		if initialModelName, has := pcfg.GetInitialModel(); has {
-			_, err := k.getNamespaceByName(ctx, initialModelName)
-			if err == nil {
-				return errors.NewAlreadyExists(nil,
-					fmt.Sprintf(`
-namespace %q already exists in the cluster,
-please choose a different initial model name then try again.`, initialModelName),
-				)
-			}
-			if !errors.Is(err, errors.NotFound) {
-				return errors.Trace(err)
-			}
-			// hosted model is all good.
-		}
-
 		// we use controller name to name controller namespace in bootstrap time.
 		setControllerNamespace := func(controllerName string, broker *kubernetesClient) error {
 			nsName := DecideControllerNamespace(controllerName)

--- a/cmd/jujud-controller/agent/bootstrap_test.go
+++ b/cmd/jujud-controller/agent/bootstrap_test.go
@@ -423,10 +423,6 @@ func (s *BootstrapSuite) TestInitializeStateArgs(c *gc.C) {
 		c.Assert(args.MongoDialOpts.Direct, jc.IsTrue)
 		c.Assert(args.MongoDialOpts.Timeout, gc.Equals, 30*time.Second)
 		c.Assert(args.MongoDialOpts.SocketTimeout, gc.Equals, 123*time.Second)
-		c.Assert(args.StateInitializationParams.InitialModelConfig, jc.DeepEquals, map[string]interface{}{
-			"name": "my-model",
-			"uuid": s.initialModelUUID,
-		})
 		return nil, errors.New("failed to initialize state")
 	}
 
@@ -567,10 +563,6 @@ func (s *BootstrapSuite) makeTestModel(c *gc.C) {
 	args.ControllerModelConfig = env.Config()
 	hw := instance.MustParseHardware("arch=amd64 mem=8G")
 	args.BootstrapMachineHardwareCharacteristics = &hw
-	args.InitialModelConfig = map[string]interface{}{
-		"name": "my-model",
-		"uuid": s.initialModelUUID,
-	}
 	args.ControllerCloud = cloud.Cloud{
 		Name:      "dummy",
 		Type:      "dummy",

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -106,11 +106,6 @@ type BootstrapParams struct {
 	// cloud.
 	RegionInheritedConfig cloud.RegionConfig
 
-	// InitialModelConfig is the set of config attributes to be overlaid
-	// on the controller config to construct the initial hosted model
-	// config.
-	InitialModelConfig map[string]interface{}
-
 	// Placement, if non-empty, holds an environment-specific placement
 	// directive used to choose the initial instance.
 	Placement string
@@ -788,7 +783,6 @@ func finalizeInstanceBootstrapConfig(
 	icfg.Bootstrap.ControllerConfig = args.ControllerConfig
 	icfg.Bootstrap.ControllerInheritedConfig = args.ControllerInheritedConfig
 	icfg.Bootstrap.RegionInheritedConfig = args.Cloud.RegionConfig
-	icfg.Bootstrap.InitialModelConfig = args.InitialModelConfig
 	icfg.Bootstrap.StoragePools = args.StoragePools
 	icfg.Bootstrap.Timeout = args.DialOpts.Timeout
 	icfg.Bootstrap.JujuDbSnapPath = args.JujuDbSnapPath
@@ -864,7 +858,6 @@ func finalizePodBootstrapConfig(
 	pcfg.Bootstrap.ControllerCloudCredentialName = args.CloudCredentialName
 	pcfg.Bootstrap.ControllerConfig = args.ControllerConfig
 	pcfg.Bootstrap.ControllerInheritedConfig = args.ControllerInheritedConfig
-	pcfg.Bootstrap.InitialModelConfig = args.InitialModelConfig
 	pcfg.Bootstrap.StoragePools = args.StoragePools
 	pcfg.Bootstrap.Timeout = args.DialOpts.Timeout
 	pcfg.Bootstrap.ControllerServiceType = args.ControllerServiceType

--- a/internal/cloudconfig/instancecfg/instancecfg.go
+++ b/internal/cloudconfig/instancecfg/instancecfg.go
@@ -320,11 +320,6 @@ type StateInitializationParams struct {
 	// cloud.
 	RegionInheritedConfig cloud.RegionConfig
 
-	// InitialModelConfig is a set of config attributes to be overlaid
-	// on the controller model config (Config, above) to construct the
-	// initial hosted model config.
-	InitialModelConfig map[string]interface{}
-
 	// BootstrapMachineInstanceId is the instance ID of the bootstrap
 	// machine instance being initialized.
 	BootstrapMachineInstanceId instance.Id
@@ -361,7 +356,6 @@ type stateInitializationParamsInternal struct {
 	ControllerModelEnvironVersion           int                               `yaml:"controller-model-version"`
 	ControllerInheritedConfig               map[string]interface{}            `yaml:"controller-config-defaults,omitempty"`
 	RegionInheritedConfig                   cloud.RegionConfig                `yaml:"region-inherited-config,omitempty"`
-	InitialModelConfig                      map[string]interface{}            `yaml:"initial-model-config,omitempty"`
 	StoragePools                            map[string]storage.Attrs          `yaml:"storage-pools,omitempty"`
 	BootstrapMachineInstanceId              instance.Id                       `yaml:"bootstrap-machine-instance-id,omitempty"`
 	BootstrapMachineConstraints             constraints.Value                 `yaml:"bootstrap-machine-constraints"`
@@ -394,7 +388,6 @@ func (p *StateInitializationParams) Marshal() ([]byte, error) {
 		ControllerModelEnvironVersion:           p.ControllerModelEnvironVersion,
 		ControllerInheritedConfig:               p.ControllerInheritedConfig,
 		RegionInheritedConfig:                   p.RegionInheritedConfig,
-		InitialModelConfig:                      p.InitialModelConfig,
 		StoragePools:                            p.StoragePools,
 		BootstrapMachineInstanceId:              p.BootstrapMachineInstanceId,
 		BootstrapMachineConstraints:             p.BootstrapMachineConstraints,
@@ -442,7 +435,6 @@ func (p *StateInitializationParams) Unmarshal(data []byte) error {
 		ControllerModelEnvironVersion:           internal.ControllerModelEnvironVersion,
 		ControllerInheritedConfig:               internal.ControllerInheritedConfig,
 		RegionInheritedConfig:                   internal.RegionInheritedConfig,
-		InitialModelConfig:                      internal.InitialModelConfig,
 		StoragePools:                            internal.StoragePools,
 		BootstrapMachineInstanceId:              internal.BootstrapMachineInstanceId,
 		BootstrapMachineConstraints:             internal.BootstrapMachineConstraints,

--- a/internal/cloudconfig/podcfg/podcfg.go
+++ b/internal/cloudconfig/podcfg/podcfg.go
@@ -22,12 +22,9 @@ import (
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/tags"
 	"github.com/juju/juju/internal/cloudconfig/instancecfg"
-	internallogger "github.com/juju/juju/internal/logger"
 	"github.com/juju/juju/internal/mongo"
 	"github.com/juju/juju/internal/password"
 )
-
-var logger = internallogger.GetLogger("juju.cloudconfig.podcfg")
 
 // ControllerPodConfig represents initialization information for a new juju caas controller pod.
 type ControllerPodConfig struct {
@@ -241,17 +238,6 @@ See juju help add-k8s for more information.
 // GetPodName returns pod name.
 func (cfg *ControllerPodConfig) GetPodName() string {
 	return "controller-" + cfg.ControllerId
-}
-
-// GetInitialModel checks if hosted model was requested to create.
-func (cfg *ControllerPodConfig) GetInitialModel() (string, bool) {
-	hasInitialModel := len(cfg.Bootstrap.InitialModelConfig) > 0
-	if hasInitialModel {
-		modelName := cfg.Bootstrap.InitialModelConfig[config.NameKey].(string)
-		logger.Debugf("configured initial model %q for bootstrapping", modelName)
-		return modelName, true
-	}
-	return "", false
 }
 
 // VerifyConfig verifies that the BootstrapConfig is valid.

--- a/internal/cloudconfig/userdatacfg_test.go
+++ b/internal/cloudconfig/userdatacfg_test.go
@@ -180,7 +180,6 @@ func (cfg *testInstanceConfig) setControllerCharm(path string) *testInstanceConf
 func (cfg *testInstanceConfig) maybeSetModelConfig(envConfig *config.Config) *testInstanceConfig {
 	if envConfig != nil && cfg.Bootstrap != nil {
 		cfg.Bootstrap.ControllerModelConfig = envConfig
-		cfg.Bootstrap.InitialModelConfig = map[string]interface{}{"name": "my-model"}
 	}
 	return cfg
 }
@@ -1041,7 +1040,6 @@ func (*cloudinitSuite) TestCloudInitVerify(c *gc.C) {
 				StateInitializationParams: instancecfg.StateInitializationParams{
 					BootstrapMachineInstanceId: "i-bootstrap",
 					ControllerModelConfig:      minimalModelConfig(c),
-					InitialModelConfig:         map[string]interface{}{"name": "my-model"},
 				},
 				StateServingInfo: stateServingInfo,
 			},

--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -267,10 +267,13 @@ juju_bootstrap() {
 
 	pre_bootstrap
 
-	command="juju bootstrap ${base} ${cloud_region} ${name} --add-model ${model} --model-default mode= ${BOOTSTRAP_ADDITIONAL_ARGS}"
+	command="juju bootstrap ${base} ${cloud_region} ${name} --model-default mode= ${BOOTSTRAP_ADDITIONAL_ARGS}"
 	# keep $@ here, otherwise hit SC2124
 	${command} "$@" 2>&1 | OUTPUT "${output}"
 	echo "${name}" >>"${TEST_DIR}/jujus"
+
+	# Adding the initial model.
+	juju add-model --show-log "${model}" 2>&1
 
 	post_bootstrap "${name}" "${model}"
 }


### PR DESCRIPTION
Removes the initial model arg during bootstrap. This is left over from 2.x which created a default model during bootstrap. The option to create a default/initial model was left. We no longer want to support this workflow, instead, you should bootstrap and then create a model.

The integration tests used this heavily. Although, the fix is trivial. Creating the model after bootstrap gives us the same result.

Implementation of this reduces the bootstrap complexity quite considerably. We no longer need to support the initial model config with a name. The bootstrap worker can create the initial controller cloud service and thus remove the environ access from the agentbootstrap.

If Bootstrap becomes less of a snowflake, we can march towards just assimilating a machine, rather than bootstraping one in every case.

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

Test a variety of bootstrap methods.

```
$ juju bootstrap lxd test1
$ juju bootstrap lxd test2 --build-agent
$ juju bootstrap aws test3
```

Failure case

```
$ juju bootstrap lxd test --add-model "default"
ERROR option provided but not defined: --add-model
```

## Documentation changes

@tmihoc We're removing the `--add-model` from bootstrap as we don't want to support the workflow any more.

The solution is to call `juju add-model <model name>` after bootstrap has occurred. 

## Links

**Jira card:** [JUJU-6231](https://warthogs.atlassian.net/browse/JUJU-6231)



[JUJU-6231]: https://warthogs.atlassian.net/browse/JUJU-6231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ