### PR TITLE
feat(dqlite): add GetMachineLife in machine domain

### DIFF
--- a/domain/machine/service/package_mock_test.go
+++ b/domain/machine/service/package_mock_test.go
@@ -13,6 +13,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	life "github.com/juju/juju/domain/life"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -111,6 +112,45 @@ func (c *MockStateDeleteMachineCall) Do(f func(context.Context, string) error) *
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockStateDeleteMachineCall) DoAndReturn(f func(context.Context, string) error) *MockStateDeleteMachineCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetLife mocks base method.
+func (m *MockState) GetLife(arg0 context.Context, arg1 string) (*life.Life, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetLife", arg0, arg1)
+	ret0, _ := ret[0].(*life.Life)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetLife indicates an expected call of GetLife.
+func (mr *MockStateMockRecorder) GetLife(arg0, arg1 any) *MockStateGetLifeCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLife", reflect.TypeOf((*MockState)(nil).GetLife), arg0, arg1)
+	return &MockStateGetLifeCall{Call: call}
+}
+
+// MockStateGetLifeCall wrap *gomock.Call
+type MockStateGetLifeCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateGetLifeCall) Return(arg0 *life.Life, arg1 error) *MockStateGetLifeCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateGetLifeCall) Do(f func(context.Context, string) (*life.Life, error)) *MockStateGetLifeCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateGetLifeCall) DoAndReturn(f func(context.Context, string) (*life.Life, error)) *MockStateGetLifeCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/machine/service/package_mock_test.go
+++ b/domain/machine/service/package_mock_test.go
@@ -116,41 +116,41 @@ func (c *MockStateDeleteMachineCall) DoAndReturn(f func(context.Context, string)
 	return c
 }
 
-// GetLife mocks base method.
-func (m *MockState) GetLife(arg0 context.Context, arg1 string) (*life.Life, error) {
+// GetMachineLife mocks base method.
+func (m *MockState) GetMachineLife(arg0 context.Context, arg1 string) (*life.Life, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetLife", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetMachineLife", arg0, arg1)
 	ret0, _ := ret[0].(*life.Life)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetLife indicates an expected call of GetLife.
-func (mr *MockStateMockRecorder) GetLife(arg0, arg1 any) *MockStateGetLifeCall {
+// GetMachineLife indicates an expected call of GetMachineLife.
+func (mr *MockStateMockRecorder) GetMachineLife(arg0, arg1 any) *MockStateGetMachineLifeCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLife", reflect.TypeOf((*MockState)(nil).GetLife), arg0, arg1)
-	return &MockStateGetLifeCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMachineLife", reflect.TypeOf((*MockState)(nil).GetMachineLife), arg0, arg1)
+	return &MockStateGetMachineLifeCall{Call: call}
 }
 
-// MockStateGetLifeCall wrap *gomock.Call
-type MockStateGetLifeCall struct {
+// MockStateGetMachineLifeCall wrap *gomock.Call
+type MockStateGetMachineLifeCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockStateGetLifeCall) Return(arg0 *life.Life, arg1 error) *MockStateGetLifeCall {
+func (c *MockStateGetMachineLifeCall) Return(arg0 *life.Life, arg1 error) *MockStateGetMachineLifeCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetLifeCall) Do(f func(context.Context, string) (*life.Life, error)) *MockStateGetLifeCall {
+func (c *MockStateGetMachineLifeCall) Do(f func(context.Context, string) (*life.Life, error)) *MockStateGetMachineLifeCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetLifeCall) DoAndReturn(f func(context.Context, string) (*life.Life, error)) *MockStateGetLifeCall {
+func (c *MockStateGetMachineLifeCall) DoAndReturn(f func(context.Context, string) (*life.Life, error)) *MockStateGetMachineLifeCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/machine/service/service.go
+++ b/domain/machine/service/service.go
@@ -24,8 +24,8 @@ type State interface {
 	// for the machines.
 	InitialWatchStatement() (string, string)
 
-	// GetLife returns the life status of the specified machine.
-	GetLife(context.Context, string) (*life.Life, error)
+	// GetMachineLife returns the life status of the specified machine.
+	GetMachineLife(context.Context, string) (*life.Life, error)
 }
 
 // Service provides the API for working with machines.
@@ -65,8 +65,8 @@ func (s *Service) DeleteMachine(ctx context.Context, machineId string) error {
 	return errors.Annotatef(err, "deleting machine %q", machineId)
 }
 
-// GetLife returns the GetLife status of the specified machine.
-func (s *Service) GetLife(ctx context.Context, machineId string) (*life.Life, error) {
-	life, err := s.st.GetLife(ctx, machineId)
+// GetLife returns the GetMachineLife status of the specified machine.
+func (s *Service) GetMachineLife(ctx context.Context, machineId string) (*life.Life, error) {
+	life, err := s.st.GetMachineLife(ctx, machineId)
 	return life, errors.Annotatef(err, "getting life status for machine %q", machineId)
 }

--- a/domain/machine/service/service.go
+++ b/domain/machine/service/service.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/errors"
 
+	"github.com/juju/juju/domain/life"
 	"github.com/juju/juju/internal/uuid"
 )
 
@@ -22,6 +23,9 @@ type State interface {
 	// InitialWatchStatement returns the table and the initial watch statement
 	// for the machines.
 	InitialWatchStatement() (string, string)
+
+	// GetLife returns the life status of the specified machine.
+	GetLife(context.Context, string) (*life.Life, error)
 }
 
 // Service provides the API for working with machines.
@@ -59,4 +63,10 @@ func (s *Service) CreateMachine(ctx context.Context, machineId string) (string, 
 func (s *Service) DeleteMachine(ctx context.Context, machineId string) error {
 	err := s.st.DeleteMachine(ctx, machineId)
 	return errors.Annotatef(err, "deleting machine %q", machineId)
+}
+
+// GetLife returns the GetLife status of the specified machine.
+func (s *Service) GetLife(ctx context.Context, machineId string) (*life.Life, error) {
+	life, err := s.st.GetLife(ctx, machineId)
+	return life, errors.Annotatef(err, "getting life status for machine %q", machineId)
 }

--- a/domain/machine/service/service_test.go
+++ b/domain/machine/service/service_test.go
@@ -11,6 +11,8 @@ import (
 	jc "github.com/juju/testing/checkers"
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/domain/life"
 )
 
 type serviceSuite struct {
@@ -64,4 +66,27 @@ func (s *serviceSuite) TestDeleteMachineError(c *gc.C) {
 	err := NewService(s.state).DeleteMachine(context.Background(), "666")
 	c.Check(err, jc.ErrorIs, rErr)
 	c.Assert(err, gc.ErrorMatches, `deleting machine "666": boom`)
+}
+
+func (s *serviceSuite) TestGetLifeSuccess(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	life := life.Alive
+	s.state.EXPECT().GetLife(gomock.Any(), "666").Return(&life, nil)
+
+	l, err := NewService(s.state).GetLife(context.Background(), "666")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(l, gc.Equals, &life)
+}
+
+func (s *serviceSuite) TestGetLifeError(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	rErr := errors.New("boom")
+	s.state.EXPECT().GetLife(gomock.Any(), "666").Return(nil, rErr)
+
+	l, err := NewService(s.state).GetLife(context.Background(), "666")
+	c.Check(l, gc.IsNil)
+	c.Check(err, jc.ErrorIs, rErr)
+	c.Assert(err, gc.ErrorMatches, `getting life status for machine "666": boom`)
 }

--- a/domain/machine/service/service_test.go
+++ b/domain/machine/service/service_test.go
@@ -72,9 +72,9 @@ func (s *serviceSuite) TestGetLifeSuccess(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	life := life.Alive
-	s.state.EXPECT().GetLife(gomock.Any(), "666").Return(&life, nil)
+	s.state.EXPECT().GetMachineLife(gomock.Any(), "666").Return(&life, nil)
 
-	l, err := NewService(s.state).GetLife(context.Background(), "666")
+	l, err := NewService(s.state).GetMachineLife(context.Background(), "666")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(l, gc.Equals, &life)
 }
@@ -83,9 +83,9 @@ func (s *serviceSuite) TestGetLifeError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	rErr := errors.New("boom")
-	s.state.EXPECT().GetLife(gomock.Any(), "666").Return(nil, rErr)
+	s.state.EXPECT().GetMachineLife(gomock.Any(), "666").Return(nil, rErr)
 
-	l, err := NewService(s.state).GetLife(context.Background(), "666")
+	l, err := NewService(s.state).GetMachineLife(context.Background(), "666")
 	c.Check(l, gc.IsNil)
 	c.Check(err, jc.ErrorIs, rErr)
 	c.Assert(err, gc.ErrorMatches, `getting life status for machine "666": boom`)

--- a/domain/machine/state/state.go
+++ b/domain/machine/state/state.go
@@ -172,6 +172,9 @@ func (st *State) GetMachineLife(ctx context.Context, machineId string) (*life.Li
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		result := sqlair.M{}
 		err := tx.Query(ctx, lifeStmt, sqlair.M{"machine_id": machineId}).Get(&result)
+		if errors.Is(err, sqlair.ErrNoRows) {
+			return errors.NotFoundf("machine %q", machineId)
+		}
 		if err != nil {
 			return errors.Annotatef(err, "looking up life for machine %q", machineId)
 		}

--- a/domain/machine/state/state.go
+++ b/domain/machine/state/state.go
@@ -154,3 +154,32 @@ DELETE FROM net_node WHERE uuid IN
 func (s *State) InitialWatchStatement() (string, string) {
 	return "machine", "SELECT machine_id FROM machine"
 }
+
+// GetLife returns the life status of the specified machine.
+func (st *State) GetLife(ctx context.Context, machineId string) (*life.Life, error) {
+	db, err := st.DB()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	queryForLife := `SELECT &M.life_id FROM machine WHERE machine_id = $M.machine_id`
+	lifeStmt, err := st.Prepare(queryForLife, sqlair.M{})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var lifeResult life.Life
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		result := sqlair.M{}
+		err := tx.Query(ctx, lifeStmt, sqlair.M{"machine_id": machineId}).Get(&result)
+		if err != nil {
+			return errors.Annotatef(err, "looking up life for machine %q", machineId)
+		}
+
+		machineLife := result["life_id"].(int64)
+		lifeResult = life.Life(machineLife)
+
+		return nil
+	})
+	return &lifeResult, errors.Annotatef(err, "getting life status for machines %q", machineId)
+}

--- a/domain/machine/state/state.go
+++ b/domain/machine/state/state.go
@@ -155,8 +155,8 @@ func (s *State) InitialWatchStatement() (string, string) {
 	return "machine", "SELECT machine_id FROM machine"
 }
 
-// GetLife returns the life status of the specified machine.
-func (st *State) GetLife(ctx context.Context, machineId string) (*life.Life, error) {
+// GetMachineLife returns the life status of the specified machine.
+func (st *State) GetMachineLife(ctx context.Context, machineId string) (*life.Life, error) {
 	db, err := st.DB()
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/domain/machine/state/state_test.go
+++ b/domain/machine/state/state_test.go
@@ -126,7 +126,7 @@ VALUES (?, ?)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *stateSuite) TestGetLife(c *gc.C) {
+func (s *stateSuite) TestGetMachineLifeSuccess(c *gc.C) {
 	err := s.state.UpsertMachine(context.Background(), "666")
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -134,4 +134,9 @@ func (s *stateSuite) TestGetLife(c *gc.C) {
 	expectedLife := life.Alive
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(*obtainedLife, gc.Equals, expectedLife)
+}
+
+func (s *stateSuite) TestGetMachineLifeNotFound(c *gc.C) {
+	_, err := s.state.GetMachineLife(context.Background(), "666")
+	c.Assert(errors.IsNotFound(err), jc.IsTrue)
 }

--- a/domain/machine/state/state_test.go
+++ b/domain/machine/state/state_test.go
@@ -127,7 +127,7 @@ VALUES (?, ?)
 }
 
 func (s *stateSuite) TestGetMachineLifeSuccess(c *gc.C) {
-	err := s.state.UpsertMachine(context.Background(), "666")
+	err := s.state.CreateMachine(context.Background(), "666", "", "")
 	c.Assert(err, jc.ErrorIsNil)
 
 	obtainedLife, err := s.state.GetMachineLife(context.Background(), "666")

--- a/domain/machine/state/state_test.go
+++ b/domain/machine/state/state_test.go
@@ -12,6 +12,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/blockdevice"
+	"github.com/juju/juju/domain/life"
 	schematesting "github.com/juju/juju/domain/schema/testing"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 	"github.com/juju/juju/internal/uuid"
@@ -123,4 +124,14 @@ VALUES (?, ?)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *stateSuite) TestGetLife(c *gc.C) {
+	err := s.state.UpsertMachine(context.Background(), "666")
+	c.Assert(err, jc.ErrorIsNil)
+
+	obtainedLife, err := s.state.GetLife(context.Background(), "666")
+	expectedLife := life.Alive
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(*obtainedLife, gc.Equals, expectedLife)
 }

--- a/domain/machine/state/state_test.go
+++ b/domain/machine/state/state_test.go
@@ -130,7 +130,7 @@ func (s *stateSuite) TestGetLife(c *gc.C) {
 	err := s.state.UpsertMachine(context.Background(), "666")
 	c.Assert(err, jc.ErrorIsNil)
 
-	obtainedLife, err := s.state.GetLife(context.Background(), "666")
+	obtainedLife, err := s.state.GetMachineLife(context.Background(), "666")
 	expectedLife := life.Alive
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(*obtainedLife, gc.Equals, expectedLife)

--- a/domain/machine/state/types.go
+++ b/domain/machine/state/types.go
@@ -3,7 +3,10 @@
 
 package state
 
-import "github.com/juju/juju/core/instance"
+import (
+	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/domain/life"
+)
 
 // instanceData represents the struct to be inserted into the instance_data
 // table.
@@ -49,4 +52,10 @@ func (d *instanceData) toHardwareCharacteristics() *instance.HardwareCharacteris
 		AvailabilityZone: d.AvailabilityZoneUUID,
 		VirtType:         d.VirtType,
 	}
+}
+
+// machineLife represents the struct to be used for the life_id column within
+// the sqlair statements in the machine domain.
+type machineLife struct {
+	ID life.Life `db:"life_id"`
 }


### PR DESCRIPTION
This adds the `GetMachineLife` service function in the machine domain. This is needed for the provisioner api, to be used [in the Machines function](https://github.com/juju/juju/blob/e7f466c5c55854ae19d4b64552ab0c132603ec7a/api/agent/provisioner/provisioner.go#L100).

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```
 $ TEST_PACKAGES="./domain/machine/... -count=1 -race" make run-go-tests
```

## Links

**Jira card:** JUJU-6232

