### PR TITLE
feat(dqlite): add AllMachines, InstanceId and InstanceStatus in machine domain

### DIFF
--- a/apiserver/facades/agent/unitassigner/unitassigner.go
+++ b/apiserver/facades/agent/unitassigner/unitassigner.go
@@ -11,7 +11,7 @@ import (
 
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facade"
-	coremachine "github.com/juju/juju/core/machine"
+	"github.com/juju/juju/core/machine"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
@@ -31,7 +31,7 @@ type statusSetter interface {
 }
 
 type machineService interface {
-	CreateMachine(context.Context, coremachine.ID) (string, error)
+	CreateMachine(context.Context, machine.ID) (string, error)
 }
 
 // NetworkService is the interface that is used to interact with the
@@ -114,7 +114,7 @@ func (a *API) AssignUnits(ctx context.Context, args params.Entities) (params.Err
 func (a *API) saveMachineInfo(ctx context.Context, machineId string) error {
 	// This is temporary - just insert the machine id all al the parent ones.
 	for machineId != "" {
-		if _, err := a.machineService.CreateMachine(ctx, coremachine.ID(machineId)); err != nil {
+		if _, err := a.machineService.CreateMachine(ctx, machine.ID(machineId)); err != nil {
 			return errors.Annotatef(err, "saving info for machine %q", machineId)
 		}
 		parent := names.NewMachineTag(machineId).Parent()

--- a/apiserver/facades/agent/unitassigner/unitassigner.go
+++ b/apiserver/facades/agent/unitassigner/unitassigner.go
@@ -111,17 +111,17 @@ func (a *API) AssignUnits(ctx context.Context, args params.Entities) (params.Err
 	return result, nil
 }
 
-func (a *API) saveMachineInfo(ctx context.Context, machineId string) error {
+func (a *API) saveMachineInfo(ctx context.Context, machineName string) error {
 	// This is temporary - just insert the machine id all al the parent ones.
-	for machineId != "" {
-		if _, err := a.machineService.CreateMachine(ctx, machine.Name(machineId)); err != nil {
-			return errors.Annotatef(err, "saving info for machine %q", machineId)
+	for machineName != "" {
+		if _, err := a.machineService.CreateMachine(ctx, machine.Name(machineName)); err != nil {
+			return errors.Annotatef(err, "saving info for machine %q", machineName)
 		}
-		parent := names.NewMachineTag(machineId).Parent()
+		parent := names.NewMachineTag(machineName).Parent()
 		if parent == nil {
 			break
 		}
-		machineId = parent.Id()
+		machineName = parent.Id()
 	}
 	return nil
 }

--- a/apiserver/facades/agent/unitassigner/unitassigner.go
+++ b/apiserver/facades/agent/unitassigner/unitassigner.go
@@ -31,7 +31,7 @@ type statusSetter interface {
 }
 
 type machineService interface {
-	CreateMachine(context.Context, machine.ID) (string, error)
+	CreateMachine(context.Context, machine.Name) (string, error)
 }
 
 // NetworkService is the interface that is used to interact with the
@@ -114,7 +114,7 @@ func (a *API) AssignUnits(ctx context.Context, args params.Entities) (params.Err
 func (a *API) saveMachineInfo(ctx context.Context, machineId string) error {
 	// This is temporary - just insert the machine id all al the parent ones.
 	for machineId != "" {
-		if _, err := a.machineService.CreateMachine(ctx, machine.ID(machineId)); err != nil {
+		if _, err := a.machineService.CreateMachine(ctx, machine.Name(machineId)); err != nil {
 			return errors.Annotatef(err, "saving info for machine %q", machineId)
 		}
 		parent := names.NewMachineTag(machineId).Parent()

--- a/apiserver/facades/agent/unitassigner/unitassigner.go
+++ b/apiserver/facades/agent/unitassigner/unitassigner.go
@@ -11,6 +11,7 @@ import (
 
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facade"
+	coremachine "github.com/juju/juju/core/machine"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
@@ -30,7 +31,7 @@ type statusSetter interface {
 }
 
 type machineService interface {
-	CreateMachine(context.Context, string) (string, error)
+	CreateMachine(context.Context, coremachine.ID) (string, error)
 }
 
 // NetworkService is the interface that is used to interact with the
@@ -113,7 +114,7 @@ func (a *API) AssignUnits(ctx context.Context, args params.Entities) (params.Err
 func (a *API) saveMachineInfo(ctx context.Context, machineId string) error {
 	// This is temporary - just insert the machine id all al the parent ones.
 	for machineId != "" {
-		if _, err := a.machineService.CreateMachine(ctx, machineId); err != nil {
+		if _, err := a.machineService.CreateMachine(ctx, coremachine.ID(machineId)); err != nil {
 			return errors.Annotatef(err, "saving info for machine %q", machineId)
 		}
 		parent := names.NewMachineTag(machineId).Parent()

--- a/apiserver/facades/agent/unitassigner/unitassigner_test.go
+++ b/apiserver/facades/agent/unitassigner/unitassigner_test.go
@@ -10,6 +10,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/common"
+	coremachine "github.com/juju/juju/core/machine"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
@@ -34,7 +35,7 @@ func (testsuite) TestAssignUnits(c *gc.C) {
 	c.Assert(res.Results, gc.HasLen, 2)
 	c.Assert(res.Results[0].Error, gc.IsNil)
 	c.Assert(res.Results[1].Error, gc.ErrorMatches, `unit "unit-bar-1" not found`)
-	c.Assert(a.machineIds, jc.SameContents, []string{"1", "1/lxd/2"})
+	c.Assert(a.machineIds, jc.SameContents, []coremachine.ID{coremachine.ID("1"), coremachine.ID("1/lxd/2")})
 }
 
 func (testsuite) TestWatchUnitAssignment(c *gc.C) {
@@ -63,10 +64,10 @@ func (testsuite) TestSetStatus(c *gc.C) {
 }
 
 type fakeMachineService struct {
-	machineIds []string
+	machineIds []coremachine.ID
 }
 
-func (f *fakeMachineService) CreateMachine(_ context.Context, machineId string) (string, error) {
+func (f *fakeMachineService) CreateMachine(_ context.Context, machineId coremachine.ID) (string, error) {
 	f.machineIds = append(f.machineIds, machineId)
 	return "", nil
 }

--- a/apiserver/facades/agent/unitassigner/unitassigner_test.go
+++ b/apiserver/facades/agent/unitassigner/unitassigner_test.go
@@ -35,7 +35,7 @@ func (testsuite) TestAssignUnits(c *gc.C) {
 	c.Assert(res.Results, gc.HasLen, 2)
 	c.Assert(res.Results[0].Error, gc.IsNil)
 	c.Assert(res.Results[1].Error, gc.ErrorMatches, `unit "unit-bar-1" not found`)
-	c.Assert(a.machineIds, jc.SameContents, []machine.Name{machine.Name("1"), machine.Name("1/lxd/2")})
+	c.Assert(a.machineNames, jc.SameContents, []machine.Name{machine.Name("1"), machine.Name("1/lxd/2")})
 }
 
 func (testsuite) TestWatchUnitAssignment(c *gc.C) {
@@ -64,11 +64,11 @@ func (testsuite) TestSetStatus(c *gc.C) {
 }
 
 type fakeMachineService struct {
-	machineIds []machine.Name
+	machineNames []machine.Name
 }
 
-func (f *fakeMachineService) CreateMachine(_ context.Context, machineId machine.Name) (string, error) {
-	f.machineIds = append(f.machineIds, machineId)
+func (f *fakeMachineService) CreateMachine(_ context.Context, machineName machine.Name) (string, error) {
+	f.machineNames = append(f.machineNames, machineName)
 	return "", nil
 }
 

--- a/apiserver/facades/agent/unitassigner/unitassigner_test.go
+++ b/apiserver/facades/agent/unitassigner/unitassigner_test.go
@@ -10,7 +10,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/common"
-	coremachine "github.com/juju/juju/core/machine"
+	"github.com/juju/juju/core/machine"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
@@ -35,7 +35,7 @@ func (testsuite) TestAssignUnits(c *gc.C) {
 	c.Assert(res.Results, gc.HasLen, 2)
 	c.Assert(res.Results[0].Error, gc.IsNil)
 	c.Assert(res.Results[1].Error, gc.ErrorMatches, `unit "unit-bar-1" not found`)
-	c.Assert(a.machineIds, jc.SameContents, []coremachine.ID{coremachine.ID("1"), coremachine.ID("1/lxd/2")})
+	c.Assert(a.machineIds, jc.SameContents, []machine.ID{machine.ID("1"), machine.ID("1/lxd/2")})
 }
 
 func (testsuite) TestWatchUnitAssignment(c *gc.C) {
@@ -64,10 +64,10 @@ func (testsuite) TestSetStatus(c *gc.C) {
 }
 
 type fakeMachineService struct {
-	machineIds []coremachine.ID
+	machineIds []machine.ID
 }
 
-func (f *fakeMachineService) CreateMachine(_ context.Context, machineId coremachine.ID) (string, error) {
+func (f *fakeMachineService) CreateMachine(_ context.Context, machineId machine.ID) (string, error) {
 	f.machineIds = append(f.machineIds, machineId)
 	return "", nil
 }

--- a/apiserver/facades/agent/unitassigner/unitassigner_test.go
+++ b/apiserver/facades/agent/unitassigner/unitassigner_test.go
@@ -35,7 +35,7 @@ func (testsuite) TestAssignUnits(c *gc.C) {
 	c.Assert(res.Results, gc.HasLen, 2)
 	c.Assert(res.Results[0].Error, gc.IsNil)
 	c.Assert(res.Results[1].Error, gc.ErrorMatches, `unit "unit-bar-1" not found`)
-	c.Assert(a.machineIds, jc.SameContents, []machine.ID{machine.ID("1"), machine.ID("1/lxd/2")})
+	c.Assert(a.machineIds, jc.SameContents, []machine.Name{machine.Name("1"), machine.Name("1/lxd/2")})
 }
 
 func (testsuite) TestWatchUnitAssignment(c *gc.C) {
@@ -64,10 +64,10 @@ func (testsuite) TestSetStatus(c *gc.C) {
 }
 
 type fakeMachineService struct {
-	machineIds []machine.ID
+	machineIds []machine.Name
 }
 
-func (f *fakeMachineService) CreateMachine(_ context.Context, machineId machine.ID) (string, error) {
+func (f *fakeMachineService) CreateMachine(_ context.Context, machineId machine.Name) (string, error) {
 	f.machineIds = append(f.machineIds, machineId)
 	return "", nil
 }

--- a/apiserver/facades/client/annotations/client_test.go
+++ b/apiserver/facades/client/annotations/client_test.go
@@ -317,7 +317,7 @@ func (s *annotationSuite) ensureMachine(c *gc.C, id, uuid string) {
 	s.ensureNetNode(c, "node2")
 	err := s.ModelTxnRunner(c, s.ControllerModelUUID()).StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		_, err := tx.ExecContext(ctx, `
-		INSERT INTO machine (uuid, net_node_uuid, machine_name, life_id)
+		INSERT INTO machine (uuid, net_node_uuid, name, life_id)
 		VALUES (?, "node2", ?, "0")`, uuid, id)
 		return err
 	})

--- a/apiserver/facades/client/annotations/client_test.go
+++ b/apiserver/facades/client/annotations/client_test.go
@@ -317,7 +317,7 @@ func (s *annotationSuite) ensureMachine(c *gc.C, id, uuid string) {
 	s.ensureNetNode(c, "node2")
 	err := s.ModelTxnRunner(c, s.ControllerModelUUID()).StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		_, err := tx.ExecContext(ctx, `
-		INSERT INTO machine (uuid, net_node_uuid, machine_id, life_id)
+		INSERT INTO machine (uuid, net_node_uuid, machine_name, life_id)
 		VALUES (?, "node2", ?, "0")`, uuid, id)
 		return err
 	})

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/instance"
 	corelogger "github.com/juju/juju/core/logger"
+	"github.com/juju/juju/core/machine"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/core/status"
@@ -2051,7 +2052,7 @@ func (s *ApplicationSuite) TestAddUnits(c *gc.C) {
 	s.backend.EXPECT().Application("postgresql").AnyTimes().Return(app, nil)
 
 	s.networkService.EXPECT().GetAllSpaces(gomock.Any())
-	s.machineService.EXPECT().CreateMachine(gomock.Any(), "99")
+	s.machineService.EXPECT().CreateMachine(gomock.Any(), machine.Name("99"))
 	s.applicationService.EXPECT().AddUnits(gomock.Any(), "postgresql", applicationservice.AddUnitParams{UnitName: &unitName})
 
 	results, err := s.api.AddUnits(context.Background(), params.AddApplicationUnits{
@@ -2091,7 +2092,7 @@ func (s *ApplicationSuite) TestAddUnitsAttachStorage(c *gc.C) {
 	s.backend.EXPECT().Application("postgresql").AnyTimes().Return(app, nil)
 
 	s.networkService.EXPECT().GetAllSpaces(gomock.Any())
-	s.machineService.EXPECT().CreateMachine(gomock.Any(), "99")
+	s.machineService.EXPECT().CreateMachine(gomock.Any(), machine.Name("99"))
 	s.applicationService.EXPECT().AddUnits(gomock.Any(), "postgresql", applicationservice.AddUnitParams{UnitName: &unitName})
 
 	_, err := s.api.AddUnits(context.Background(), params.AddApplicationUnits{

--- a/apiserver/facades/client/application/deploy.go
+++ b/apiserver/facades/client/application/deploy.go
@@ -72,7 +72,7 @@ type UnitAdder interface {
 
 // MachineService instances save a machine to dqlite state.
 type MachineService interface {
-	CreateMachine(context.Context, machine.ID) (string, error)
+	CreateMachine(context.Context, machine.Name) (string, error)
 }
 
 // ApplicationService instances save an application to dqlite state.
@@ -234,7 +234,7 @@ func (api *APIBase) addUnits(
 func saveMachineInfo(ctx context.Context, machineService MachineService, machineId string) error {
 	// This is temporary - just insert the machine id all al the parent ones.
 	for machineId != "" {
-		if _, err := machineService.CreateMachine(ctx, machine.ID(machineId)); err != nil {
+		if _, err := machineService.CreateMachine(ctx, machine.Name(machineId)); err != nil {
 			return errors.Annotatef(err, "saving info for machine %q", machineId)
 		}
 		parent := names.NewMachineTag(machineId).Parent()

--- a/apiserver/facades/client/application/deploy.go
+++ b/apiserver/facades/client/application/deploy.go
@@ -231,17 +231,17 @@ func (api *APIBase) addUnits(
 	return units, nil
 }
 
-func saveMachineInfo(ctx context.Context, machineService MachineService, machineId string) error {
+func saveMachineInfo(ctx context.Context, machineService MachineService, machineName string) error {
 	// This is temporary - just insert the machine id all al the parent ones.
-	for machineId != "" {
-		if _, err := machineService.CreateMachine(ctx, machine.Name(machineId)); err != nil {
-			return errors.Annotatef(err, "saving info for machine %q", machineId)
+	for machineName != "" {
+		if _, err := machineService.CreateMachine(ctx, machine.Name(machineName)); err != nil {
+			return errors.Annotatef(err, "saving info for machine %q", machineName)
 		}
-		parent := names.NewMachineTag(machineId).Parent()
+		parent := names.NewMachineTag(machineName).Parent()
 		if parent == nil {
 			break
 		}
-		machineId = parent.Id()
+		machineName = parent.Id()
 	}
 	return nil
 }

--- a/apiserver/facades/client/application/deploy.go
+++ b/apiserver/facades/client/application/deploy.go
@@ -17,7 +17,7 @@ import (
 	"github.com/juju/juju/core/devices"
 	"github.com/juju/juju/core/instance"
 	corelogger "github.com/juju/juju/core/logger"
-	coremachine "github.com/juju/juju/core/machine"
+	"github.com/juju/juju/core/machine"
 	"github.com/juju/juju/core/objectstore"
 	applicationservice "github.com/juju/juju/domain/application/service"
 	"github.com/juju/juju/environs/bootstrap"
@@ -72,7 +72,7 @@ type UnitAdder interface {
 
 // MachineService instances save a machine to dqlite state.
 type MachineService interface {
-	CreateMachine(context.Context, coremachine.ID) (string, error)
+	CreateMachine(context.Context, machine.ID) (string, error)
 }
 
 // ApplicationService instances save an application to dqlite state.
@@ -234,7 +234,7 @@ func (api *APIBase) addUnits(
 func saveMachineInfo(ctx context.Context, machineService MachineService, machineId string) error {
 	// This is temporary - just insert the machine id all al the parent ones.
 	for machineId != "" {
-		if _, err := machineService.CreateMachine(ctx, coremachine.ID(machineId)); err != nil {
+		if _, err := machineService.CreateMachine(ctx, machine.ID(machineId)); err != nil {
 			return errors.Annotatef(err, "saving info for machine %q", machineId)
 		}
 		parent := names.NewMachineTag(machineId).Parent()

--- a/apiserver/facades/client/application/deploy.go
+++ b/apiserver/facades/client/application/deploy.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/juju/core/devices"
 	"github.com/juju/juju/core/instance"
 	corelogger "github.com/juju/juju/core/logger"
+	coremachine "github.com/juju/juju/core/machine"
 	"github.com/juju/juju/core/objectstore"
 	applicationservice "github.com/juju/juju/domain/application/service"
 	"github.com/juju/juju/environs/bootstrap"
@@ -71,7 +72,7 @@ type UnitAdder interface {
 
 // MachineService instances save a machine to dqlite state.
 type MachineService interface {
-	CreateMachine(context.Context, string) (string, error)
+	CreateMachine(context.Context, coremachine.ID) (string, error)
 }
 
 // ApplicationService instances save an application to dqlite state.
@@ -233,7 +234,7 @@ func (api *APIBase) addUnits(
 func saveMachineInfo(ctx context.Context, machineService MachineService, machineId string) error {
 	// This is temporary - just insert the machine id all al the parent ones.
 	for machineId != "" {
-		if _, err := machineService.CreateMachine(ctx, machineId); err != nil {
+		if _, err := machineService.CreateMachine(ctx, coremachine.ID(machineId)); err != nil {
 			return errors.Annotatef(err, "saving info for machine %q", machineId)
 		}
 		parent := names.NewMachineTag(machineId).Parent()

--- a/apiserver/facades/client/application/domain_mock.go
+++ b/apiserver/facades/client/application/domain_mock.go
@@ -14,6 +14,7 @@ import (
 	reflect "reflect"
 
 	crossmodel "github.com/juju/juju/core/crossmodel"
+	machine "github.com/juju/juju/core/machine"
 	network "github.com/juju/juju/core/network"
 	service "github.com/juju/juju/domain/application/service"
 	storage "github.com/juju/juju/internal/storage"
@@ -44,7 +45,7 @@ func (m *MockMachineService) EXPECT() *MockMachineServiceMockRecorder {
 }
 
 // CreateMachine mocks base method.
-func (m *MockMachineService) CreateMachine(arg0 context.Context, arg1 string) (string, error) {
+func (m *MockMachineService) CreateMachine(arg0 context.Context, arg1 machine.ID) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateMachine", arg0, arg1)
 	ret0, _ := ret[0].(string)
@@ -71,13 +72,13 @@ func (c *MockMachineServiceCreateMachineCall) Return(arg0 string, arg1 error) *M
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceCreateMachineCall) Do(f func(context.Context, string) (string, error)) *MockMachineServiceCreateMachineCall {
+func (c *MockMachineServiceCreateMachineCall) Do(f func(context.Context, machine.ID) (string, error)) *MockMachineServiceCreateMachineCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceCreateMachineCall) DoAndReturn(f func(context.Context, string) (string, error)) *MockMachineServiceCreateMachineCall {
+func (c *MockMachineServiceCreateMachineCall) DoAndReturn(f func(context.Context, machine.ID) (string, error)) *MockMachineServiceCreateMachineCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/client/application/domain_mock.go
+++ b/apiserver/facades/client/application/domain_mock.go
@@ -45,7 +45,7 @@ func (m *MockMachineService) EXPECT() *MockMachineServiceMockRecorder {
 }
 
 // CreateMachine mocks base method.
-func (m *MockMachineService) CreateMachine(arg0 context.Context, arg1 machine.ID) (string, error) {
+func (m *MockMachineService) CreateMachine(arg0 context.Context, arg1 machine.Name) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateMachine", arg0, arg1)
 	ret0, _ := ret[0].(string)
@@ -72,13 +72,13 @@ func (c *MockMachineServiceCreateMachineCall) Return(arg0 string, arg1 error) *M
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceCreateMachineCall) Do(f func(context.Context, machine.ID) (string, error)) *MockMachineServiceCreateMachineCall {
+func (c *MockMachineServiceCreateMachineCall) Do(f func(context.Context, machine.Name) (string, error)) *MockMachineServiceCreateMachineCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceCreateMachineCall) DoAndReturn(f func(context.Context, machine.ID) (string, error)) *MockMachineServiceCreateMachineCall {
+func (c *MockMachineServiceCreateMachineCall) DoAndReturn(f func(context.Context, machine.Name) (string, error)) *MockMachineServiceCreateMachineCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/client/highavailability/highavailability.go
+++ b/apiserver/facades/client/highavailability/highavailability.go
@@ -40,7 +40,7 @@ type NodeService interface {
 
 // MachineService instances save a machine to dqlite state.
 type MachineService interface {
-	CreateMachine(context.Context, machine.ID) (string, error)
+	CreateMachine(context.Context, machine.Name) (string, error)
 }
 
 // ApplicationService instances add units to an application in dqlite state.
@@ -176,7 +176,7 @@ func (api *HighAvailabilityAPI) enableHASingle(ctx context.Context, spec params.
 
 	// Add the dqlite records for new machines.
 	for _, m := range changes.Added {
-		if _, err := api.machineService.CreateMachine(ctx, machine.ID(m)); err != nil {
+		if _, err := api.machineService.CreateMachine(ctx, machine.Name(m)); err != nil {
 			return params.ControllersChanges{}, err
 		}
 	}

--- a/apiserver/facades/client/highavailability/highavailability.go
+++ b/apiserver/facades/client/highavailability/highavailability.go
@@ -21,7 +21,7 @@ import (
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
 	corelogger "github.com/juju/juju/core/logger"
-	coremachine "github.com/juju/juju/core/machine"
+	"github.com/juju/juju/core/machine"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/core/permission"
@@ -40,7 +40,7 @@ type NodeService interface {
 
 // MachineService instances save a machine to dqlite state.
 type MachineService interface {
-	CreateMachine(context.Context, coremachine.ID) (string, error)
+	CreateMachine(context.Context, machine.ID) (string, error)
 }
 
 // ApplicationService instances add units to an application in dqlite state.
@@ -176,7 +176,7 @@ func (api *HighAvailabilityAPI) enableHASingle(ctx context.Context, spec params.
 
 	// Add the dqlite records for new machines.
 	for _, m := range changes.Added {
-		if _, err := api.machineService.CreateMachine(ctx, coremachine.ID(m)); err != nil {
+		if _, err := api.machineService.CreateMachine(ctx, machine.ID(m)); err != nil {
 			return params.ControllersChanges{}, err
 		}
 	}

--- a/apiserver/facades/client/highavailability/highavailability.go
+++ b/apiserver/facades/client/highavailability/highavailability.go
@@ -21,6 +21,7 @@ import (
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
 	corelogger "github.com/juju/juju/core/logger"
+	coremachine "github.com/juju/juju/core/machine"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/core/permission"
@@ -39,7 +40,7 @@ type NodeService interface {
 
 // MachineService instances save a machine to dqlite state.
 type MachineService interface {
-	CreateMachine(context.Context, string) (string, error)
+	CreateMachine(context.Context, coremachine.ID) (string, error)
 }
 
 // ApplicationService instances add units to an application in dqlite state.
@@ -175,7 +176,7 @@ func (api *HighAvailabilityAPI) enableHASingle(ctx context.Context, spec params.
 
 	// Add the dqlite records for new machines.
 	for _, m := range changes.Added {
-		if _, err := api.machineService.CreateMachine(ctx, m); err != nil {
+		if _, err := api.machineService.CreateMachine(ctx, coremachine.ID(m)); err != nil {
 			return params.ControllersChanges{}, err
 		}
 	}

--- a/apiserver/facades/client/machinemanager/machinemanager.go
+++ b/apiserver/facades/client/machinemanager/machinemanager.go
@@ -72,8 +72,8 @@ type Authorizer interface {
 
 // MachineService manages machines.
 type MachineService interface {
-	CreateMachine(context.Context, machine.ID) (string, error)
-	DeleteMachine(context.Context, machine.ID) error
+	CreateMachine(context.Context, machine.Name) (string, error)
+	DeleteMachine(context.Context, machine.Name) error
 }
 
 // CharmhubClient represents a way for querying the charmhub api for information
@@ -397,7 +397,7 @@ func (mm *MachineManagerAPI) saveMachineInfo(ctx context.Context, machineId stri
 	// This is temporary - just insert the machine id all al the parent ones.
 	var errs []error
 	for machineId != "" {
-		if _, err := mm.machineService.CreateMachine(ctx, machine.ID(machineId)); err != nil {
+		if _, err := mm.machineService.CreateMachine(ctx, machine.Name(machineId)); err != nil {
 			errs = append(errs, errors.Annotatef(err, "saving info for machine %q", machineId))
 		}
 		parent := names.NewMachineTag(machineId).Parent()

--- a/apiserver/facades/client/machinemanager/machinemanager.go
+++ b/apiserver/facades/client/machinemanager/machinemanager.go
@@ -22,7 +22,7 @@ import (
 	corebase "github.com/juju/juju/core/base"
 	"github.com/juju/juju/core/instance"
 	corelogger "github.com/juju/juju/core/logger"
-	coremachine "github.com/juju/juju/core/machine"
+	"github.com/juju/juju/core/machine"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/core/permission"
@@ -72,8 +72,8 @@ type Authorizer interface {
 
 // MachineService manages machines.
 type MachineService interface {
-	CreateMachine(context.Context, coremachine.ID) (string, error)
-	DeleteMachine(context.Context, coremachine.ID) error
+	CreateMachine(context.Context, machine.ID) (string, error)
+	DeleteMachine(context.Context, machine.ID) error
 }
 
 // CharmhubClient represents a way for querying the charmhub api for information
@@ -397,7 +397,7 @@ func (mm *MachineManagerAPI) saveMachineInfo(ctx context.Context, machineId stri
 	// This is temporary - just insert the machine id all al the parent ones.
 	var errs []error
 	for machineId != "" {
-		if _, err := mm.machineService.CreateMachine(ctx, coremachine.ID(machineId)); err != nil {
+		if _, err := mm.machineService.CreateMachine(ctx, machine.ID(machineId)); err != nil {
 			errs = append(errs, errors.Annotatef(err, "saving info for machine %q", machineId))
 		}
 		parent := names.NewMachineTag(machineId).Parent()

--- a/apiserver/facades/client/machinemanager/machinemanager.go
+++ b/apiserver/facades/client/machinemanager/machinemanager.go
@@ -22,6 +22,7 @@ import (
 	corebase "github.com/juju/juju/core/base"
 	"github.com/juju/juju/core/instance"
 	corelogger "github.com/juju/juju/core/logger"
+	coremachine "github.com/juju/juju/core/machine"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/core/permission"
@@ -71,8 +72,8 @@ type Authorizer interface {
 
 // MachineService manages machines.
 type MachineService interface {
-	CreateMachine(context.Context, string) (string, error)
-	DeleteMachine(context.Context, string) error
+	CreateMachine(context.Context, coremachine.ID) (string, error)
+	DeleteMachine(context.Context, coremachine.ID) error
 }
 
 // CharmhubClient represents a way for querying the charmhub api for information
@@ -396,7 +397,7 @@ func (mm *MachineManagerAPI) saveMachineInfo(ctx context.Context, machineId stri
 	// This is temporary - just insert the machine id all al the parent ones.
 	var errs []error
 	for machineId != "" {
-		if _, err := mm.machineService.CreateMachine(ctx, machineId); err != nil {
+		if _, err := mm.machineService.CreateMachine(ctx, coremachine.ID(machineId)); err != nil {
 			errs = append(errs, errors.Annotatef(err, "saving info for machine %q", machineId))
 		}
 		parent := names.NewMachineTag(machineId).Parent()

--- a/apiserver/facades/client/machinemanager/machinemanager.go
+++ b/apiserver/facades/client/machinemanager/machinemanager.go
@@ -393,18 +393,18 @@ func (mm *MachineManagerAPI) addOneMachine(ctx context.Context, p params.AddMach
 	return mm.st.AddMachineInsideNewMachine(template, template, p.ContainerType)
 }
 
-func (mm *MachineManagerAPI) saveMachineInfo(ctx context.Context, machineId string) error {
+func (mm *MachineManagerAPI) saveMachineInfo(ctx context.Context, machineName string) error {
 	// This is temporary - just insert the machine id all al the parent ones.
 	var errs []error
-	for machineId != "" {
-		if _, err := mm.machineService.CreateMachine(ctx, machine.Name(machineId)); err != nil {
-			errs = append(errs, errors.Annotatef(err, "saving info for machine %q", machineId))
+	for machineName != "" {
+		if _, err := mm.machineService.CreateMachine(ctx, machine.Name(machineName)); err != nil {
+			errs = append(errs, errors.Annotatef(err, "saving info for machine %q", machineName))
 		}
-		parent := names.NewMachineTag(machineId).Parent()
+		parent := names.NewMachineTag(machineName).Parent()
 		if parent == nil {
 			break
 		}
-		machineId = parent.Id()
+		machineName = parent.Id()
 	}
 	if len(errs) == 0 {
 		return nil

--- a/apiserver/facades/client/machinemanager/machinemanager_test.go
+++ b/apiserver/facades/client/machinemanager/machinemanager_test.go
@@ -27,6 +27,7 @@ import (
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	corebase "github.com/juju/juju/core/base"
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/machine"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/status"
@@ -195,9 +196,9 @@ func (s *AddMachineManagerSuite) TestAddMachines(c *gc.C) {
 			},
 		},
 	}).Return(m1, nil)
-	s.machineService.EXPECT().CreateMachine(gomock.Any(), "666")
-	s.machineService.EXPECT().CreateMachine(gomock.Any(), "667/lxd/1")
-	s.machineService.EXPECT().CreateMachine(gomock.Any(), "667")
+	s.machineService.EXPECT().CreateMachine(gomock.Any(), machine.Name("666"))
+	s.machineService.EXPECT().CreateMachine(gomock.Any(), machine.Name("667/lxd/1"))
+	s.machineService.EXPECT().CreateMachine(gomock.Any(), machine.Name("667"))
 	s.st.EXPECT().AddOneMachine(state.MachineTemplate{
 		Base: state.UbuntuBase("22.04"),
 		Jobs: []state.MachineJob{state.JobHostUnits},

--- a/apiserver/facades/client/machinemanager/package_mock_test.go
+++ b/apiserver/facades/client/machinemanager/package_mock_test.go
@@ -3457,7 +3457,7 @@ func (m *MockMachineService) EXPECT() *MockMachineServiceMockRecorder {
 }
 
 // CreateMachine mocks base method.
-func (m *MockMachineService) CreateMachine(arg0 context.Context, arg1 machine.ID) (string, error) {
+func (m *MockMachineService) CreateMachine(arg0 context.Context, arg1 machine.Name) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateMachine", arg0, arg1)
 	ret0, _ := ret[0].(string)
@@ -3484,19 +3484,19 @@ func (c *MockMachineServiceCreateMachineCall) Return(arg0 string, arg1 error) *M
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceCreateMachineCall) Do(f func(context.Context, machine.ID) (string, error)) *MockMachineServiceCreateMachineCall {
+func (c *MockMachineServiceCreateMachineCall) Do(f func(context.Context, machine.Name) (string, error)) *MockMachineServiceCreateMachineCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceCreateMachineCall) DoAndReturn(f func(context.Context, machine.ID) (string, error)) *MockMachineServiceCreateMachineCall {
+func (c *MockMachineServiceCreateMachineCall) DoAndReturn(f func(context.Context, machine.Name) (string, error)) *MockMachineServiceCreateMachineCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // DeleteMachine mocks base method.
-func (m *MockMachineService) DeleteMachine(arg0 context.Context, arg1 machine.ID) error {
+func (m *MockMachineService) DeleteMachine(arg0 context.Context, arg1 machine.Name) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteMachine", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -3522,13 +3522,13 @@ func (c *MockMachineServiceDeleteMachineCall) Return(arg0 error) *MockMachineSer
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceDeleteMachineCall) Do(f func(context.Context, machine.ID) error) *MockMachineServiceDeleteMachineCall {
+func (c *MockMachineServiceDeleteMachineCall) Do(f func(context.Context, machine.Name) error) *MockMachineServiceDeleteMachineCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceDeleteMachineCall) DoAndReturn(f func(context.Context, machine.ID) error) *MockMachineServiceDeleteMachineCall {
+func (c *MockMachineServiceDeleteMachineCall) DoAndReturn(f func(context.Context, machine.Name) error) *MockMachineServiceDeleteMachineCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/client/machinemanager/package_mock_test.go
+++ b/apiserver/facades/client/machinemanager/package_mock_test.go
@@ -19,6 +19,7 @@ import (
 	controller "github.com/juju/juju/controller"
 	base "github.com/juju/juju/core/base"
 	instance "github.com/juju/juju/core/instance"
+	machine "github.com/juju/juju/core/machine"
 	model "github.com/juju/juju/core/model"
 	network "github.com/juju/juju/core/network"
 	objectstore "github.com/juju/juju/core/objectstore"
@@ -3456,7 +3457,7 @@ func (m *MockMachineService) EXPECT() *MockMachineServiceMockRecorder {
 }
 
 // CreateMachine mocks base method.
-func (m *MockMachineService) CreateMachine(arg0 context.Context, arg1 string) (string, error) {
+func (m *MockMachineService) CreateMachine(arg0 context.Context, arg1 machine.ID) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateMachine", arg0, arg1)
 	ret0, _ := ret[0].(string)
@@ -3483,19 +3484,19 @@ func (c *MockMachineServiceCreateMachineCall) Return(arg0 string, arg1 error) *M
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceCreateMachineCall) Do(f func(context.Context, string) (string, error)) *MockMachineServiceCreateMachineCall {
+func (c *MockMachineServiceCreateMachineCall) Do(f func(context.Context, machine.ID) (string, error)) *MockMachineServiceCreateMachineCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceCreateMachineCall) DoAndReturn(f func(context.Context, string) (string, error)) *MockMachineServiceCreateMachineCall {
+func (c *MockMachineServiceCreateMachineCall) DoAndReturn(f func(context.Context, machine.ID) (string, error)) *MockMachineServiceCreateMachineCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // DeleteMachine mocks base method.
-func (m *MockMachineService) DeleteMachine(arg0 context.Context, arg1 string) error {
+func (m *MockMachineService) DeleteMachine(arg0 context.Context, arg1 machine.ID) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteMachine", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -3521,13 +3522,13 @@ func (c *MockMachineServiceDeleteMachineCall) Return(arg0 error) *MockMachineSer
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceDeleteMachineCall) Do(f func(context.Context, string) error) *MockMachineServiceDeleteMachineCall {
+func (c *MockMachineServiceDeleteMachineCall) Do(f func(context.Context, machine.ID) error) *MockMachineServiceDeleteMachineCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceDeleteMachineCall) DoAndReturn(f func(context.Context, string) error) *MockMachineServiceDeleteMachineCall {
+func (c *MockMachineServiceDeleteMachineCall) DoAndReturn(f func(context.Context, machine.ID) error) *MockMachineServiceDeleteMachineCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/controller/machineundertaker/undertaker.go
+++ b/apiserver/facades/controller/machineundertaker/undertaker.go
@@ -11,6 +11,7 @@ import (
 
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facade"
+	coremachine "github.com/juju/juju/core/machine"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state/watcher"
@@ -26,7 +27,7 @@ type API struct {
 }
 
 type machineRemover interface {
-	DeleteMachine(context.Context, string) error
+	DeleteMachine(context.Context, coremachine.ID) error
 }
 
 // NewAPI implements the API used by the machine undertaker worker to
@@ -134,7 +135,7 @@ func (m *API) CompleteMachineRemovals(ctx context.Context, machines params.Entit
 
 	// Remove the machines from dqlite.
 	for _, id := range machineIDs {
-		if err := m.machineRemover.DeleteMachine(ctx, id); err != nil {
+		if err := m.machineRemover.DeleteMachine(ctx, coremachine.ID(id)); err != nil {
 			return errors.Annotatef(err, "removing machine %q", id)
 		}
 	}

--- a/apiserver/facades/controller/machineundertaker/undertaker.go
+++ b/apiserver/facades/controller/machineundertaker/undertaker.go
@@ -27,7 +27,7 @@ type API struct {
 }
 
 type machineRemover interface {
-	DeleteMachine(context.Context, machine.ID) error
+	DeleteMachine(context.Context, machine.Name) error
 }
 
 // NewAPI implements the API used by the machine undertaker worker to
@@ -135,7 +135,7 @@ func (m *API) CompleteMachineRemovals(ctx context.Context, machines params.Entit
 
 	// Remove the machines from dqlite.
 	for _, id := range machineIDs {
-		if err := m.machineRemover.DeleteMachine(ctx, machine.ID(id)); err != nil {
+		if err := m.machineRemover.DeleteMachine(ctx, machine.Name(id)); err != nil {
 			return errors.Annotatef(err, "removing machine %q", id)
 		}
 	}

--- a/apiserver/facades/controller/machineundertaker/undertaker.go
+++ b/apiserver/facades/controller/machineundertaker/undertaker.go
@@ -11,7 +11,7 @@ import (
 
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facade"
-	coremachine "github.com/juju/juju/core/machine"
+	"github.com/juju/juju/core/machine"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state/watcher"
@@ -27,7 +27,7 @@ type API struct {
 }
 
 type machineRemover interface {
-	DeleteMachine(context.Context, coremachine.ID) error
+	DeleteMachine(context.Context, machine.ID) error
 }
 
 // NewAPI implements the API used by the machine undertaker worker to
@@ -135,7 +135,7 @@ func (m *API) CompleteMachineRemovals(ctx context.Context, machines params.Entit
 
 	// Remove the machines from dqlite.
 	for _, id := range machineIDs {
-		if err := m.machineRemover.DeleteMachine(ctx, coremachine.ID(id)); err != nil {
+		if err := m.machineRemover.DeleteMachine(ctx, machine.ID(id)); err != nil {
 			return errors.Annotatef(err, "removing machine %q", id)
 		}
 	}

--- a/apiserver/facades/controller/machineundertaker/undertaker_test.go
+++ b/apiserver/facades/controller/machineundertaker/undertaker_test.go
@@ -193,8 +193,8 @@ func (*undertakerSuite) TestCompleteMachineRemovals(c *gc.C) {
 	c.Assert(ok, jc.IsTrue)
 	c.Assert(values, gc.DeepEquals, []string{"2", "52"})
 	remover.stub.CheckCalls(c, []testing.StubCall{
-		{"Delete", []any{machine.ID("2")}},
-		{"Delete", []any{machine.ID("52")}},
+		{"Delete", []any{machine.Name("2")}},
+		{"Delete", []any{machine.Name("52")}},
 	})
 }
 
@@ -331,7 +331,7 @@ type mockMachineRemover struct {
 	stub *testing.Stub
 }
 
-func (m *mockMachineRemover) DeleteMachine(_ context.Context, machineId machine.ID) error {
+func (m *mockMachineRemover) DeleteMachine(_ context.Context, machineId machine.Name) error {
 	m.stub.AddCall("Delete", machineId)
 	return nil
 }

--- a/apiserver/facades/controller/machineundertaker/undertaker_test.go
+++ b/apiserver/facades/controller/machineundertaker/undertaker_test.go
@@ -15,6 +15,7 @@ import (
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facades/controller/machineundertaker"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
+	coremachine "github.com/juju/juju/core/machine"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
@@ -192,8 +193,8 @@ func (*undertakerSuite) TestCompleteMachineRemovals(c *gc.C) {
 	c.Assert(ok, jc.IsTrue)
 	c.Assert(values, gc.DeepEquals, []string{"2", "52"})
 	remover.stub.CheckCalls(c, []testing.StubCall{
-		{"Delete", []any{"2"}},
-		{"Delete", []any{"52"}},
+		{"Delete", []any{coremachine.ID("2")}},
+		{"Delete", []any{coremachine.ID("52")}},
 	})
 }
 
@@ -330,7 +331,7 @@ type mockMachineRemover struct {
 	stub *testing.Stub
 }
 
-func (m *mockMachineRemover) DeleteMachine(_ context.Context, machineId string) error {
+func (m *mockMachineRemover) DeleteMachine(_ context.Context, machineId coremachine.ID) error {
 	m.stub.AddCall("Delete", machineId)
 	return nil
 }

--- a/apiserver/facades/controller/machineundertaker/undertaker_test.go
+++ b/apiserver/facades/controller/machineundertaker/undertaker_test.go
@@ -15,7 +15,7 @@ import (
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facades/controller/machineundertaker"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
-	coremachine "github.com/juju/juju/core/machine"
+	"github.com/juju/juju/core/machine"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
@@ -193,8 +193,8 @@ func (*undertakerSuite) TestCompleteMachineRemovals(c *gc.C) {
 	c.Assert(ok, jc.IsTrue)
 	c.Assert(values, gc.DeepEquals, []string{"2", "52"})
 	remover.stub.CheckCalls(c, []testing.StubCall{
-		{"Delete", []any{coremachine.ID("2")}},
-		{"Delete", []any{coremachine.ID("52")}},
+		{"Delete", []any{machine.ID("2")}},
+		{"Delete", []any{machine.ID("52")}},
 	})
 }
 
@@ -331,7 +331,7 @@ type mockMachineRemover struct {
 	stub *testing.Stub
 }
 
-func (m *mockMachineRemover) DeleteMachine(_ context.Context, machineId coremachine.ID) error {
+func (m *mockMachineRemover) DeleteMachine(_ context.Context, machineId machine.ID) error {
 	m.stub.AddCall("Delete", machineId)
 	return nil
 }

--- a/domain/annotation/state/query.go
+++ b/domain/annotation/state/query.go
@@ -70,7 +70,7 @@ WHERE uuid = $M.uuid`, kindName), nil
 
 // uuidQueryForID generates a query and parameters for getting the uuid for a given ID
 // We keep different fields to reference different IDs in separate tables, as follows:
-// machine: TABLE machine, reference field: machine_name
+// machine: TABLE machine, reference field: name
 // unit: TABLE unit, reference field: name
 // application: TABLE application, reference field: name
 // storage_instance: TABLE storage_instance, reference field: name
@@ -84,7 +84,7 @@ func uuidQueryForID(id annotations.ID) (string, sqlair.M, error) {
 	var selector string
 	switch id.Kind {
 	case annotations.KindMachine:
-		selector = "machine_name"
+		selector = "name"
 	case annotations.KindUnit:
 		selector = "name"
 	case annotations.KindApplication:

--- a/domain/annotation/state/query.go
+++ b/domain/annotation/state/query.go
@@ -70,7 +70,7 @@ WHERE uuid = $M.uuid`, kindName), nil
 
 // uuidQueryForID generates a query and parameters for getting the uuid for a given ID
 // We keep different fields to reference different IDs in separate tables, as follows:
-// machine: TABLE machine, reference field: machine_id
+// machine: TABLE machine, reference field: machine_name
 // unit: TABLE unit, reference field: name
 // application: TABLE application, reference field: name
 // storage_instance: TABLE storage_instance, reference field: name
@@ -84,7 +84,7 @@ func uuidQueryForID(id annotations.ID) (string, sqlair.M, error) {
 	var selector string
 	switch id.Kind {
 	case annotations.KindMachine:
-		selector = "machine_id"
+		selector = "machine_name"
 	case annotations.KindUnit:
 		selector = "name"
 	case annotations.KindApplication:

--- a/domain/annotation/state/state_test.go
+++ b/domain/annotation/state/state_test.go
@@ -232,7 +232,7 @@ func (s *stateSuite) TestSetAnnotationsUnsetModel(c *gc.C) {
 func (s *stateSuite) TestUUIDQueryForID(c *gc.C) {
 	// machine
 	kindQuery, kindQueryParam, _ := uuidQueryForID(annotations.ID{Kind: annotations.KindMachine, Name: "my-machine"})
-	c.Check(kindQuery, gc.Equals, `SELECT &M.uuid FROM machine WHERE machine_id = $M.entity_id`)
+	c.Check(kindQuery, gc.Equals, `SELECT &M.uuid FROM machine WHERE machine_name = $M.entity_id`)
 	c.Check(kindQueryParam, gc.DeepEquals, sqlair.M{"entity_id": "my-machine"})
 
 	// application
@@ -311,7 +311,7 @@ func (s *stateSuite) ensureMachine(c *gc.C, id, uuid string) {
 	s.ensureNetNode(c, "node2")
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		_, err := tx.ExecContext(ctx, `
-		INSERT INTO machine (uuid, net_node_uuid, machine_id, life_id)
+		INSERT INTO machine (uuid, net_node_uuid, machine_name, life_id)
 		VALUES (?, "node2", ?, "0")`, uuid, id)
 		return err
 	})

--- a/domain/annotation/state/state_test.go
+++ b/domain/annotation/state/state_test.go
@@ -232,7 +232,7 @@ func (s *stateSuite) TestSetAnnotationsUnsetModel(c *gc.C) {
 func (s *stateSuite) TestUUIDQueryForID(c *gc.C) {
 	// machine
 	kindQuery, kindQueryParam, _ := uuidQueryForID(annotations.ID{Kind: annotations.KindMachine, Name: "my-machine"})
-	c.Check(kindQuery, gc.Equals, `SELECT &M.uuid FROM machine WHERE machine_name = $M.entity_id`)
+	c.Check(kindQuery, gc.Equals, `SELECT &M.uuid FROM machine WHERE name = $M.entity_id`)
 	c.Check(kindQueryParam, gc.DeepEquals, sqlair.M{"entity_id": "my-machine"})
 
 	// application
@@ -311,7 +311,7 @@ func (s *stateSuite) ensureMachine(c *gc.C, id, uuid string) {
 	s.ensureNetNode(c, "node2")
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		_, err := tx.ExecContext(ctx, `
-		INSERT INTO machine (uuid, net_node_uuid, machine_name, life_id)
+		INSERT INTO machine (uuid, net_node_uuid, name, life_id)
 		VALUES (?, "node2", ?, "0")`, uuid, id)
 		return err
 	})

--- a/domain/blockdevice/state/state.go
+++ b/domain/blockdevice/state/state.go
@@ -61,7 +61,7 @@ FROM   block_device bd
        JOIN machine ON bd.machine_uuid = machine.uuid
        LEFT JOIN block_device_link_device bdl ON bd.uuid = bdl.block_device_uuid
        LEFT JOIN filesystem_type fs_type ON bd.filesystem_type_id = fs_type.id
-WHERE  machine.machine_name = $M.machine_name
+WHERE  machine.name = $M.name
 `
 
 	types := []any{
@@ -81,7 +81,7 @@ WHERE  machine.machine_name = $M.machine_name
 		dbDeviceLinks     []DeviceLink
 		dbFilesystemTypes []FilesystemType
 	)
-	machineParam := sqlair.M{"machine_name": machineId}
+	machineParam := sqlair.M{"name": machineId}
 	err = tx.Query(ctx, stmt, machineParam).GetAll(&dbRows, &dbDeviceLinks, &dbFilesystemTypes)
 	if err != nil {
 		if errors.Is(err, sqlair.ErrNoRows) {
@@ -97,7 +97,7 @@ func (st *State) getMachineInfo(ctx context.Context, tx *sqlair.TX, machineId st
 	q := `
 SELECT machine.life_id AS &M.life_id, machine.uuid AS &M.machine_uuid
 FROM   machine
-WHERE  machine.machine_name = $M.machine_name
+WHERE  machine.name = $M.name
 `
 	stmt, err := st.Prepare(q, sqlair.M{})
 	if err != nil {
@@ -105,7 +105,7 @@ WHERE  machine.machine_name = $M.machine_name
 	}
 
 	result := sqlair.M{}
-	err = tx.Query(ctx, stmt, sqlair.M{"machine_name": machineId}).Get(result)
+	err = tx.Query(ctx, stmt, sqlair.M{"name": machineId}).Get(result)
 	if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 		return "", 0, errors.Annotatef(err, "looking up UUID for machine %q", machineId)
 	}
@@ -267,7 +267,7 @@ func (st *State) MachineBlockDevices(ctx context.Context) ([]blockdevice.Machine
 SELECT bd.* AS &BlockDevice.*,
        bdl.* AS &DeviceLink.*,
        fs_type.* AS &FilesystemType.*,
-       machine.machine_name AS &BlockDeviceMachine.*
+       machine.name AS &BlockDeviceMachine.*
 FROM   block_device bd
        JOIN machine ON bd.machine_uuid = machine.uuid
        LEFT JOIN block_device_link_device bdl ON bd.uuid = bdl.block_device_uuid

--- a/domain/blockdevice/state/state.go
+++ b/domain/blockdevice/state/state.go
@@ -61,7 +61,7 @@ FROM   block_device bd
        JOIN machine ON bd.machine_uuid = machine.uuid
        LEFT JOIN block_device_link_device bdl ON bd.uuid = bdl.block_device_uuid
        LEFT JOIN filesystem_type fs_type ON bd.filesystem_type_id = fs_type.id
-WHERE  machine.machine_id = $M.machine_id
+WHERE  machine.machine_name = $M.machine_name
 `
 
 	types := []any{
@@ -81,7 +81,7 @@ WHERE  machine.machine_id = $M.machine_id
 		dbDeviceLinks     []DeviceLink
 		dbFilesystemTypes []FilesystemType
 	)
-	machineParam := sqlair.M{"machine_id": machineId}
+	machineParam := sqlair.M{"machine_name": machineId}
 	err = tx.Query(ctx, stmt, machineParam).GetAll(&dbRows, &dbDeviceLinks, &dbFilesystemTypes)
 	if err != nil {
 		if errors.Is(err, sqlair.ErrNoRows) {
@@ -97,7 +97,7 @@ func (st *State) getMachineInfo(ctx context.Context, tx *sqlair.TX, machineId st
 	q := `
 SELECT machine.life_id AS &M.life_id, machine.uuid AS &M.machine_uuid
 FROM   machine
-WHERE  machine.machine_id = $M.machine_id
+WHERE  machine.machine_name = $M.machine_name
 `
 	stmt, err := st.Prepare(q, sqlair.M{})
 	if err != nil {
@@ -105,7 +105,7 @@ WHERE  machine.machine_id = $M.machine_id
 	}
 
 	result := sqlair.M{}
-	err = tx.Query(ctx, stmt, sqlair.M{"machine_id": machineId}).Get(result)
+	err = tx.Query(ctx, stmt, sqlair.M{"machine_name": machineId}).Get(result)
 	if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 		return "", 0, errors.Annotatef(err, "looking up UUID for machine %q", machineId)
 	}
@@ -267,7 +267,7 @@ func (st *State) MachineBlockDevices(ctx context.Context) ([]blockdevice.Machine
 SELECT bd.* AS &BlockDevice.*,
        bdl.* AS &DeviceLink.*,
        fs_type.* AS &FilesystemType.*,
-       machine.machine_id AS &BlockDeviceMachine.*
+       machine.machine_name AS &BlockDeviceMachine.*
 FROM   block_device bd
        JOIN machine ON bd.machine_uuid = machine.uuid
        LEFT JOIN block_device_link_device bdl ON bd.uuid = bdl.block_device_uuid

--- a/domain/blockdevice/state/state_test.go
+++ b/domain/blockdevice/state/state_test.go
@@ -40,7 +40,7 @@ func (s *stateSuite) createMachineWithLife(c *gc.C, name string, life life.Life)
 	c.Assert(err, jc.ErrorIsNil)
 	machineUUID := uuid.MustNewUUID().String()
 	_, err = db.ExecContext(context.Background(), `
-INSERT INTO machine (uuid, life_id, machine_name, net_node_uuid)
+INSERT INTO machine (uuid, life_id, name, net_node_uuid)
 VALUES (?, ?, ?, ?)
 `, machineUUID, life, name, netNodeUUID)
 	c.Assert(err, jc.ErrorIsNil)

--- a/domain/blockdevice/state/state_test.go
+++ b/domain/blockdevice/state/state_test.go
@@ -40,7 +40,7 @@ func (s *stateSuite) createMachineWithLife(c *gc.C, name string, life life.Life)
 	c.Assert(err, jc.ErrorIsNil)
 	machineUUID := uuid.MustNewUUID().String()
 	_, err = db.ExecContext(context.Background(), `
-INSERT INTO machine (uuid, life_id, machine_id, net_node_uuid)
+INSERT INTO machine (uuid, life_id, machine_name, net_node_uuid)
 VALUES (?, ?, ?, ?)
 `, machineUUID, life, name, netNodeUUID)
 	c.Assert(err, jc.ErrorIsNil)

--- a/domain/blockdevice/state/types.go
+++ b/domain/blockdevice/state/types.go
@@ -39,7 +39,7 @@ type DeviceLink struct {
 }
 
 type BlockDeviceMachine struct {
-	MachineId string `db:"machine_name"`
+	MachineId string `db:"name"`
 }
 
 type BlockDevices []BlockDevice

--- a/domain/blockdevice/state/types.go
+++ b/domain/blockdevice/state/types.go
@@ -39,7 +39,7 @@ type DeviceLink struct {
 }
 
 type BlockDeviceMachine struct {
-	MachineId string `db:"machine_id"`
+	MachineId string `db:"machine_name"`
 }
 
 type BlockDevices []BlockDevice

--- a/domain/blockdevice/watcher_test.go
+++ b/domain/blockdevice/watcher_test.go
@@ -39,7 +39,7 @@ func (s *watcherSuite) createMachine(c *gc.C, name string) string {
 INSERT INTO net_node (uuid) VALUES (?)
 `
 	queryMachine := `
-INSERT INTO machine (uuid, life_id, machine_id, net_node_uuid)
+INSERT INTO machine (uuid, life_id, machine_name, net_node_uuid)
 VALUES (?, ?, ?, ?)
 	`
 

--- a/domain/blockdevice/watcher_test.go
+++ b/domain/blockdevice/watcher_test.go
@@ -39,7 +39,7 @@ func (s *watcherSuite) createMachine(c *gc.C, name string) string {
 INSERT INTO net_node (uuid) VALUES (?)
 `
 	queryMachine := `
-INSERT INTO machine (uuid, life_id, machine_name, net_node_uuid)
+INSERT INTO machine (uuid, life_id, name, net_node_uuid)
 VALUES (?, ?, ?, ?)
 	`
 

--- a/domain/machine/bootstrap/bootstrap.go
+++ b/domain/machine/bootstrap/bootstrap.go
@@ -21,8 +21,8 @@ func InsertMachine(machineId string) internaldatabase.BootstrapOpt {
 	return func(ctx context.Context, controller, model database.TxnRunner) error {
 
 		createMachine := `
-INSERT INTO machine (uuid, net_node_uuid, machine_name, life_id)
-VALUES ($M.machine_uuid, $M.net_node_uuid, $M.machine_name, $M.life_id)
+INSERT INTO machine (uuid, net_node_uuid, name, life_id)
+VALUES ($M.machine_uuid, $M.net_node_uuid, $M.name, $M.life_id)
 `
 		createMachineStmt, err := sqlair.Prepare(createMachine, sqlair.M{})
 		if err != nil {
@@ -48,7 +48,7 @@ VALUES ($M.machine_uuid, $M.net_node_uuid, $M.machine_name, $M.life_id)
 			createParams := sqlair.M{
 				"machine_uuid":  machineUUID.String(),
 				"net_node_uuid": nodeUUID.String(),
-				"machine_name":  machineId,
+				"name":          machineId,
 				"life_id":       life.Alive,
 			}
 			if err := tx.Query(ctx, createNodeStmt, createParams).Run(); err != nil {

--- a/domain/machine/bootstrap/bootstrap.go
+++ b/domain/machine/bootstrap/bootstrap.go
@@ -21,8 +21,8 @@ func InsertMachine(machineId string) internaldatabase.BootstrapOpt {
 	return func(ctx context.Context, controller, model database.TxnRunner) error {
 
 		createMachine := `
-INSERT INTO machine (uuid, net_node_uuid, machine_id, life_id)
-VALUES ($M.machine_uuid, $M.net_node_uuid, $M.machine_id, $M.life_id)
+INSERT INTO machine (uuid, net_node_uuid, machine_name, life_id)
+VALUES ($M.machine_uuid, $M.net_node_uuid, $M.machine_name, $M.life_id)
 `
 		createMachineStmt, err := sqlair.Prepare(createMachine, sqlair.M{})
 		if err != nil {
@@ -48,7 +48,7 @@ VALUES ($M.machine_uuid, $M.net_node_uuid, $M.machine_id, $M.life_id)
 			createParams := sqlair.M{
 				"machine_uuid":  machineUUID.String(),
 				"net_node_uuid": nodeUUID.String(),
-				"machine_id":    machineId,
+				"machine_name":  machineId,
 				"life_id":       life.Alive,
 			}
 			if err := tx.Query(ctx, createNodeStmt, createParams).Run(); err != nil {

--- a/domain/machine/bootstrap/bootstrap_test.go
+++ b/domain/machine/bootstrap/bootstrap_test.go
@@ -23,7 +23,7 @@ func (s *bootstrapSuite) TestInsertBootstrapMachine(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	var machineId string
-	row := s.DB().QueryRow("SELECT machine_name FROM machine")
+	row := s.DB().QueryRow("SELECT name FROM machine")
 	c.Assert(row.Scan(&machineId), jc.ErrorIsNil)
 	c.Assert(machineId, gc.Equals, "666")
 }

--- a/domain/machine/bootstrap/bootstrap_test.go
+++ b/domain/machine/bootstrap/bootstrap_test.go
@@ -23,7 +23,7 @@ func (s *bootstrapSuite) TestInsertBootstrapMachine(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	var machineId string
-	row := s.DB().QueryRow("SELECT machine_id FROM machine")
+	row := s.DB().QueryRow("SELECT machine_name FROM machine")
 	c.Assert(row.Scan(&machineId), jc.ErrorIsNil)
 	c.Assert(machineId, gc.Equals, "666")
 }

--- a/domain/machine/errors/errors.go
+++ b/domain/machine/errors/errors.go
@@ -8,7 +8,11 @@ import (
 )
 
 const (
-	// NotFound describes an error that occurs when the machine being operated on
-	// does not exist.
+	// NotFound describes an error that occurs when the machine being operated
+	// on does not exist.
 	NotFound = errors.ConstError("machine not found")
+
+	// NotProvisioned describes an error that occurs when the machine being
+	// operated on is not provisioned yet.
+	NotProvisioned = errors.ConstError("machine not provisioned")
 )

--- a/domain/machine/modelmigration/import.go
+++ b/domain/machine/modelmigration/import.go
@@ -39,7 +39,7 @@ type importOperation struct {
 // ImportService defines the machine service used to import machines from
 // another controller model to this controller.
 type ImportService interface {
-	CreateMachine(context.Context, machine.ID) (string, error)
+	CreateMachine(context.Context, machine.Name) (string, error)
 }
 
 // Name returns the name of this operation.
@@ -55,7 +55,7 @@ func (i *importOperation) Setup(scope modelmigration.Scope) error {
 func (i *importOperation) Execute(ctx context.Context, model description.Model) error {
 	for _, m := range model.Machines() {
 		// We need skeleton machines in dqlite.
-		if _, err := i.service.CreateMachine(ctx, machine.ID(m.Id())); err != nil {
+		if _, err := i.service.CreateMachine(ctx, machine.Name(m.Id())); err != nil {
 			return fmt.Errorf("importing machine %q: %w", m.Id(), err)
 		}
 	}

--- a/domain/machine/modelmigration/import.go
+++ b/domain/machine/modelmigration/import.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/description/v6"
 
 	"github.com/juju/juju/core/logger"
+	coremachine "github.com/juju/juju/core/machine"
 	"github.com/juju/juju/core/modelmigration"
 	"github.com/juju/juju/domain/machine/service"
 	"github.com/juju/juju/domain/machine/state"
@@ -38,7 +39,7 @@ type importOperation struct {
 // ImportService defines the machine service used to import machines from
 // another controller model to this controller.
 type ImportService interface {
-	CreateMachine(context.Context, string) (string, error)
+	CreateMachine(context.Context, coremachine.ID) (string, error)
 }
 
 // Name returns the name of this operation.
@@ -54,7 +55,7 @@ func (i *importOperation) Setup(scope modelmigration.Scope) error {
 func (i *importOperation) Execute(ctx context.Context, model description.Model) error {
 	for _, m := range model.Machines() {
 		// We need skeleton machines in dqlite.
-		if _, err := i.service.CreateMachine(ctx, m.Id()); err != nil {
+		if _, err := i.service.CreateMachine(ctx, coremachine.ID(m.Id())); err != nil {
 			return fmt.Errorf("importing machine %q: %w", m.Id(), err)
 		}
 	}

--- a/domain/machine/modelmigration/import.go
+++ b/domain/machine/modelmigration/import.go
@@ -10,7 +10,7 @@ import (
 	"github.com/juju/description/v6"
 
 	"github.com/juju/juju/core/logger"
-	coremachine "github.com/juju/juju/core/machine"
+	"github.com/juju/juju/core/machine"
 	"github.com/juju/juju/core/modelmigration"
 	"github.com/juju/juju/domain/machine/service"
 	"github.com/juju/juju/domain/machine/state"
@@ -39,7 +39,7 @@ type importOperation struct {
 // ImportService defines the machine service used to import machines from
 // another controller model to this controller.
 type ImportService interface {
-	CreateMachine(context.Context, coremachine.ID) (string, error)
+	CreateMachine(context.Context, machine.ID) (string, error)
 }
 
 // Name returns the name of this operation.
@@ -55,7 +55,7 @@ func (i *importOperation) Setup(scope modelmigration.Scope) error {
 func (i *importOperation) Execute(ctx context.Context, model description.Model) error {
 	for _, m := range model.Machines() {
 		// We need skeleton machines in dqlite.
-		if _, err := i.service.CreateMachine(ctx, coremachine.ID(m.Id())); err != nil {
+		if _, err := i.service.CreateMachine(ctx, machine.ID(m.Id())); err != nil {
 			return fmt.Errorf("importing machine %q: %w", m.Id(), err)
 		}
 	}

--- a/domain/machine/service/package_mock_test.go
+++ b/domain/machine/service/package_mock_test.go
@@ -13,8 +13,8 @@ import (
 	context "context"
 	reflect "reflect"
 
-	machine "github.com/juju/juju/core/machine"
 	instance "github.com/juju/juju/core/instance"
+	machine "github.com/juju/juju/core/machine"
 	life "github.com/juju/juju/domain/life"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -195,44 +195,6 @@ func (c *MockStateDeleteMachineCloudInstanceCall) DoAndReturn(f func(context.Con
 	return c
 }
 
-// DeleteMachineCloudInstance mocks base method.
-func (m *MockState) DeleteMachineCloudInstance(arg0 context.Context, arg1 string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteMachineCloudInstance", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteMachineCloudInstance indicates an expected call of DeleteMachineCloudInstance.
-func (mr *MockStateMockRecorder) DeleteMachineCloudInstance(arg0, arg1 any) *MockStateDeleteMachineCloudInstanceCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteMachineCloudInstance", reflect.TypeOf((*MockState)(nil).DeleteMachineCloudInstance), arg0, arg1)
-	return &MockStateDeleteMachineCloudInstanceCall{Call: call}
-}
-
-// MockStateDeleteMachineCloudInstanceCall wrap *gomock.Call
-type MockStateDeleteMachineCloudInstanceCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockStateDeleteMachineCloudInstanceCall) Return(arg0 error) *MockStateDeleteMachineCloudInstanceCall {
-	c.Call = c.Call.Return(arg0)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockStateDeleteMachineCloudInstanceCall) Do(f func(context.Context, string) error) *MockStateDeleteMachineCloudInstanceCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateDeleteMachineCloudInstanceCall) DoAndReturn(f func(context.Context, string) error) *MockStateDeleteMachineCloudInstanceCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // GetMachineLife mocks base method.
 func (m *MockState) GetMachineLife(arg0 context.Context, arg1 machine.Name) (*life.Life, error) {
 	m.ctrl.T.Helper()
@@ -268,45 +230,6 @@ func (c *MockStateGetMachineLifeCall) Do(f func(context.Context, machine.Name) (
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockStateGetMachineLifeCall) DoAndReturn(f func(context.Context, machine.Name) (*life.Life, error)) *MockStateGetMachineLifeCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// HardwareCharacteristics mocks base method.
-func (m *MockState) HardwareCharacteristics(arg0 context.Context, arg1 string) (*instance.HardwareCharacteristics, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HardwareCharacteristics", arg0, arg1)
-	ret0, _ := ret[0].(*instance.HardwareCharacteristics)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// HardwareCharacteristics indicates an expected call of HardwareCharacteristics.
-func (mr *MockStateMockRecorder) HardwareCharacteristics(arg0, arg1 any) *MockStateHardwareCharacteristicsCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HardwareCharacteristics", reflect.TypeOf((*MockState)(nil).HardwareCharacteristics), arg0, arg1)
-	return &MockStateHardwareCharacteristicsCall{Call: call}
-}
-
-// MockStateHardwareCharacteristicsCall wrap *gomock.Call
-type MockStateHardwareCharacteristicsCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockStateHardwareCharacteristicsCall) Return(arg0 *instance.HardwareCharacteristics, arg1 error) *MockStateHardwareCharacteristicsCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockStateHardwareCharacteristicsCall) Do(f func(context.Context, string) (*instance.HardwareCharacteristics, error)) *MockStateHardwareCharacteristicsCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateHardwareCharacteristicsCall) DoAndReturn(f func(context.Context, string) (*instance.HardwareCharacteristics, error)) *MockStateHardwareCharacteristicsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -463,83 +386,6 @@ func (c *MockStateInstanceStatusCall) Do(f func(context.Context, machine.Name) (
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockStateInstanceStatusCall) DoAndReturn(f func(context.Context, machine.Name) (string, error)) *MockStateInstanceStatusCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// ListAllMachines mocks base method.
-func (m *MockState) ListAllMachines(arg0 context.Context) ([]machine.ID, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListAllMachines", arg0)
-	ret0, _ := ret[0].([]machine.ID)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListAllMachines indicates an expected call of ListAllMachines.
-func (mr *MockStateMockRecorder) ListAllMachines(arg0 any) *MockStateListAllMachinesCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAllMachines", reflect.TypeOf((*MockState)(nil).ListAllMachines), arg0)
-	return &MockStateListAllMachinesCall{Call: call}
-}
-
-// MockStateListAllMachinesCall wrap *gomock.Call
-type MockStateListAllMachinesCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockStateListAllMachinesCall) Return(arg0 []machine.ID, arg1 error) *MockStateListAllMachinesCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockStateListAllMachinesCall) Do(f func(context.Context) ([]machine.ID, error)) *MockStateListAllMachinesCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateListAllMachinesCall) DoAndReturn(f func(context.Context) ([]machine.ID, error)) *MockStateListAllMachinesCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// SetMachineCloudInstance mocks base method.
-func (m *MockState) SetMachineCloudInstance(arg0 context.Context, arg1 string, arg2 instance.Id, arg3 instance.HardwareCharacteristics) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetMachineCloudInstance", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// SetMachineCloudInstance indicates an expected call of SetMachineCloudInstance.
-func (mr *MockStateMockRecorder) SetMachineCloudInstance(arg0, arg1, arg2, arg3 any) *MockStateSetMachineCloudInstanceCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMachineCloudInstance", reflect.TypeOf((*MockState)(nil).SetMachineCloudInstance), arg0, arg1, arg2, arg3)
-	return &MockStateSetMachineCloudInstanceCall{Call: call}
-}
-
-// MockStateSetMachineCloudInstanceCall wrap *gomock.Call
-type MockStateSetMachineCloudInstanceCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockStateSetMachineCloudInstanceCall) Return(arg0 error) *MockStateSetMachineCloudInstanceCall {
-	c.Call = c.Call.Return(arg0)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockStateSetMachineCloudInstanceCall) Do(f func(context.Context, string, instance.Id, instance.HardwareCharacteristics) error) *MockStateSetMachineCloudInstanceCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateSetMachineCloudInstanceCall) DoAndReturn(f func(context.Context, string, instance.Id, instance.HardwareCharacteristics) error) *MockStateSetMachineCloudInstanceCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/machine/service/package_mock_test.go
+++ b/domain/machine/service/package_mock_test.go
@@ -43,10 +43,10 @@ func (m *MockState) EXPECT() *MockStateMockRecorder {
 }
 
 // AllMachineNames mocks base method.
-func (m *MockState) AllMachineNames(arg0 context.Context) ([]machine.ID, error) {
+func (m *MockState) AllMachineNames(arg0 context.Context) ([]machine.Name, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllMachineNames", arg0)
-	ret0, _ := ret[0].([]machine.ID)
+	ret0, _ := ret[0].([]machine.Name)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -64,25 +64,25 @@ type MockStateAllMachineNamesCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockStateAllMachineNamesCall) Return(arg0 []machine.ID, arg1 error) *MockStateAllMachineNamesCall {
+func (c *MockStateAllMachineNamesCall) Return(arg0 []machine.Name, arg1 error) *MockStateAllMachineNamesCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateAllMachineNamesCall) Do(f func(context.Context) ([]machine.ID, error)) *MockStateAllMachineNamesCall {
+func (c *MockStateAllMachineNamesCall) Do(f func(context.Context) ([]machine.Name, error)) *MockStateAllMachineNamesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateAllMachineNamesCall) DoAndReturn(f func(context.Context) ([]machine.ID, error)) *MockStateAllMachineNamesCall {
+func (c *MockStateAllMachineNamesCall) DoAndReturn(f func(context.Context) ([]machine.Name, error)) *MockStateAllMachineNamesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // CreateMachine mocks base method.
-func (m *MockState) CreateMachine(arg0 context.Context, arg1 machine.ID, arg2, arg3 string) error {
+func (m *MockState) CreateMachine(arg0 context.Context, arg1 machine.Name, arg2, arg3 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateMachine", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
@@ -108,19 +108,19 @@ func (c *MockStateCreateMachineCall) Return(arg0 error) *MockStateCreateMachineC
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateCreateMachineCall) Do(f func(context.Context, machine.ID, string, string) error) *MockStateCreateMachineCall {
+func (c *MockStateCreateMachineCall) Do(f func(context.Context, machine.Name, string, string) error) *MockStateCreateMachineCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateCreateMachineCall) DoAndReturn(f func(context.Context, machine.ID, string, string) error) *MockStateCreateMachineCall {
+func (c *MockStateCreateMachineCall) DoAndReturn(f func(context.Context, machine.Name, string, string) error) *MockStateCreateMachineCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // DeleteMachine mocks base method.
-func (m *MockState) DeleteMachine(arg0 context.Context, arg1 machine.ID) error {
+func (m *MockState) DeleteMachine(arg0 context.Context, arg1 machine.Name) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteMachine", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -146,13 +146,13 @@ func (c *MockStateDeleteMachineCall) Return(arg0 error) *MockStateDeleteMachineC
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateDeleteMachineCall) Do(f func(context.Context, machine.ID) error) *MockStateDeleteMachineCall {
+func (c *MockStateDeleteMachineCall) Do(f func(context.Context, machine.Name) error) *MockStateDeleteMachineCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateDeleteMachineCall) DoAndReturn(f func(context.Context, machine.ID) error) *MockStateDeleteMachineCall {
+func (c *MockStateDeleteMachineCall) DoAndReturn(f func(context.Context, machine.Name) error) *MockStateDeleteMachineCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -234,7 +234,7 @@ func (c *MockStateDeleteMachineCloudInstanceCall) DoAndReturn(f func(context.Con
 }
 
 // GetMachineLife mocks base method.
-func (m *MockState) GetMachineLife(arg0 context.Context, arg1 machine.ID) (*life.Life, error) {
+func (m *MockState) GetMachineLife(arg0 context.Context, arg1 machine.Name) (*life.Life, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMachineLife", arg0, arg1)
 	ret0, _ := ret[0].(*life.Life)
@@ -261,13 +261,13 @@ func (c *MockStateGetMachineLifeCall) Return(arg0 *life.Life, arg1 error) *MockS
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetMachineLifeCall) Do(f func(context.Context, machine.ID) (*life.Life, error)) *MockStateGetMachineLifeCall {
+func (c *MockStateGetMachineLifeCall) Do(f func(context.Context, machine.Name) (*life.Life, error)) *MockStateGetMachineLifeCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetMachineLifeCall) DoAndReturn(f func(context.Context, machine.ID) (*life.Life, error)) *MockStateGetMachineLifeCall {
+func (c *MockStateGetMachineLifeCall) DoAndReturn(f func(context.Context, machine.Name) (*life.Life, error)) *MockStateGetMachineLifeCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -390,7 +390,7 @@ func (c *MockStateInitialWatchStatementCall) DoAndReturn(f func() (string, strin
 }
 
 // InstanceId mocks base method.
-func (m *MockState) InstanceId(arg0 context.Context, arg1 machine.ID) (string, error) {
+func (m *MockState) InstanceId(arg0 context.Context, arg1 machine.Name) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InstanceId", arg0, arg1)
 	ret0, _ := ret[0].(string)
@@ -417,19 +417,19 @@ func (c *MockStateInstanceIdCall) Return(arg0 string, arg1 error) *MockStateInst
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateInstanceIdCall) Do(f func(context.Context, machine.ID) (string, error)) *MockStateInstanceIdCall {
+func (c *MockStateInstanceIdCall) Do(f func(context.Context, machine.Name) (string, error)) *MockStateInstanceIdCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateInstanceIdCall) DoAndReturn(f func(context.Context, machine.ID) (string, error)) *MockStateInstanceIdCall {
+func (c *MockStateInstanceIdCall) DoAndReturn(f func(context.Context, machine.Name) (string, error)) *MockStateInstanceIdCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // InstanceStatus mocks base method.
-func (m *MockState) InstanceStatus(arg0 context.Context, arg1 machine.ID) (string, error) {
+func (m *MockState) InstanceStatus(arg0 context.Context, arg1 machine.Name) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InstanceStatus", arg0, arg1)
 	ret0, _ := ret[0].(string)
@@ -456,13 +456,13 @@ func (c *MockStateInstanceStatusCall) Return(arg0 string, arg1 error) *MockState
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateInstanceStatusCall) Do(f func(context.Context, machine.ID) (string, error)) *MockStateInstanceStatusCall {
+func (c *MockStateInstanceStatusCall) Do(f func(context.Context, machine.Name) (string, error)) *MockStateInstanceStatusCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateInstanceStatusCall) DoAndReturn(f func(context.Context, machine.ID) (string, error)) *MockStateInstanceStatusCall {
+func (c *MockStateInstanceStatusCall) DoAndReturn(f func(context.Context, machine.Name) (string, error)) *MockStateInstanceStatusCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/machine/service/package_mock_test.go
+++ b/domain/machine/service/package_mock_test.go
@@ -41,6 +41,45 @@ func (m *MockState) EXPECT() *MockStateMockRecorder {
 	return m.recorder
 }
 
+// AllMachines mocks base method.
+func (m *MockState) AllMachines(arg0 context.Context) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AllMachines", arg0)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AllMachines indicates an expected call of AllMachines.
+func (mr *MockStateMockRecorder) AllMachines(arg0 any) *MockStateAllMachinesCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllMachines", reflect.TypeOf((*MockState)(nil).AllMachines), arg0)
+	return &MockStateAllMachinesCall{Call: call}
+}
+
+// MockStateAllMachinesCall wrap *gomock.Call
+type MockStateAllMachinesCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateAllMachinesCall) Return(arg0 []string, arg1 error) *MockStateAllMachinesCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateAllMachinesCall) Do(f func(context.Context) ([]string, error)) *MockStateAllMachinesCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateAllMachinesCall) DoAndReturn(f func(context.Context) ([]string, error)) *MockStateAllMachinesCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // CreateMachine mocks base method.
 func (m *MockState) CreateMachine(arg0 context.Context, arg1, arg2, arg3 string) error {
 	m.ctrl.T.Helper()

--- a/domain/machine/service/package_mock_test.go
+++ b/domain/machine/service/package_mock_test.go
@@ -41,45 +41,6 @@ func (m *MockState) EXPECT() *MockStateMockRecorder {
 	return m.recorder
 }
 
-// AllMachines mocks base method.
-func (m *MockState) AllMachines(arg0 context.Context) ([]string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AllMachines", arg0)
-	ret0, _ := ret[0].([]string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// AllMachines indicates an expected call of AllMachines.
-func (mr *MockStateMockRecorder) AllMachines(arg0 any) *MockStateAllMachinesCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllMachines", reflect.TypeOf((*MockState)(nil).AllMachines), arg0)
-	return &MockStateAllMachinesCall{Call: call}
-}
-
-// MockStateAllMachinesCall wrap *gomock.Call
-type MockStateAllMachinesCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockStateAllMachinesCall) Return(arg0 []string, arg1 error) *MockStateAllMachinesCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockStateAllMachinesCall) Do(f func(context.Context) ([]string, error)) *MockStateAllMachinesCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateAllMachinesCall) DoAndReturn(f func(context.Context) ([]string, error)) *MockStateAllMachinesCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // CreateMachine mocks base method.
 func (m *MockState) CreateMachine(arg0 context.Context, arg1, arg2, arg3 string) error {
 	m.ctrl.T.Helper()
@@ -385,6 +346,45 @@ func (c *MockStateInstanceStatusCall) Do(f func(context.Context, string) (string
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockStateInstanceStatusCall) DoAndReturn(f func(context.Context, string) (string, error)) *MockStateInstanceStatusCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// ListAllMachines mocks base method.
+func (m *MockState) ListAllMachines(arg0 context.Context) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListAllMachines", arg0)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListAllMachines indicates an expected call of ListAllMachines.
+func (mr *MockStateMockRecorder) ListAllMachines(arg0 any) *MockStateListAllMachinesCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAllMachines", reflect.TypeOf((*MockState)(nil).ListAllMachines), arg0)
+	return &MockStateListAllMachinesCall{Call: call}
+}
+
+// MockStateListAllMachinesCall wrap *gomock.Call
+type MockStateListAllMachinesCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateListAllMachinesCall) Return(arg0 []string, arg1 error) *MockStateListAllMachinesCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateListAllMachinesCall) Do(f func(context.Context) ([]string, error)) *MockStateListAllMachinesCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateListAllMachinesCall) DoAndReturn(f func(context.Context) ([]string, error)) *MockStateListAllMachinesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/machine/service/package_mock_test.go
+++ b/domain/machine/service/package_mock_test.go
@@ -311,6 +311,45 @@ func (c *MockStateInitialWatchStatementCall) DoAndReturn(f func() (string, strin
 	return c
 }
 
+// InstanceId mocks base method.
+func (m *MockState) InstanceId(arg0 context.Context, arg1 string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InstanceId", arg0, arg1)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// InstanceId indicates an expected call of InstanceId.
+func (mr *MockStateMockRecorder) InstanceId(arg0, arg1 any) *MockStateInstanceIdCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstanceId", reflect.TypeOf((*MockState)(nil).InstanceId), arg0, arg1)
+	return &MockStateInstanceIdCall{Call: call}
+}
+
+// MockStateInstanceIdCall wrap *gomock.Call
+type MockStateInstanceIdCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateInstanceIdCall) Return(arg0 string, arg1 error) *MockStateInstanceIdCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateInstanceIdCall) Do(f func(context.Context, string) (string, error)) *MockStateInstanceIdCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateInstanceIdCall) DoAndReturn(f func(context.Context, string) (string, error)) *MockStateInstanceIdCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // SetMachineCloudInstance mocks base method.
 func (m *MockState) SetMachineCloudInstance(arg0 context.Context, arg1 string, arg2 instance.Id, arg3 instance.HardwareCharacteristics) error {
 	m.ctrl.T.Helper()

--- a/domain/machine/service/package_mock_test.go
+++ b/domain/machine/service/package_mock_test.go
@@ -42,6 +42,45 @@ func (m *MockState) EXPECT() *MockStateMockRecorder {
 	return m.recorder
 }
 
+// AllMachineNames mocks base method.
+func (m *MockState) AllMachineNames(arg0 context.Context) ([]machine.ID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AllMachineNames", arg0)
+	ret0, _ := ret[0].([]machine.ID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AllMachineNames indicates an expected call of AllMachineNames.
+func (mr *MockStateMockRecorder) AllMachineNames(arg0 any) *MockStateAllMachineNamesCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllMachineNames", reflect.TypeOf((*MockState)(nil).AllMachineNames), arg0)
+	return &MockStateAllMachineNamesCall{Call: call}
+}
+
+// MockStateAllMachineNamesCall wrap *gomock.Call
+type MockStateAllMachineNamesCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateAllMachineNamesCall) Return(arg0 []machine.ID, arg1 error) *MockStateAllMachineNamesCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateAllMachineNamesCall) Do(f func(context.Context) ([]machine.ID, error)) *MockStateAllMachineNamesCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateAllMachineNamesCall) DoAndReturn(f func(context.Context) ([]machine.ID, error)) *MockStateAllMachineNamesCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // CreateMachine mocks base method.
 func (m *MockState) CreateMachine(arg0 context.Context, arg1 machine.ID, arg2, arg3 string) error {
 	m.ctrl.T.Helper()

--- a/domain/machine/service/package_mock_test.go
+++ b/domain/machine/service/package_mock_test.go
@@ -350,6 +350,45 @@ func (c *MockStateInstanceIdCall) DoAndReturn(f func(context.Context, string) (s
 	return c
 }
 
+// InstanceStatus mocks base method.
+func (m *MockState) InstanceStatus(arg0 context.Context, arg1 string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InstanceStatus", arg0, arg1)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// InstanceStatus indicates an expected call of InstanceStatus.
+func (mr *MockStateMockRecorder) InstanceStatus(arg0, arg1 any) *MockStateInstanceStatusCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstanceStatus", reflect.TypeOf((*MockState)(nil).InstanceStatus), arg0, arg1)
+	return &MockStateInstanceStatusCall{Call: call}
+}
+
+// MockStateInstanceStatusCall wrap *gomock.Call
+type MockStateInstanceStatusCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateInstanceStatusCall) Return(arg0 string, arg1 error) *MockStateInstanceStatusCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateInstanceStatusCall) Do(f func(context.Context, string) (string, error)) *MockStateInstanceStatusCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateInstanceStatusCall) DoAndReturn(f func(context.Context, string) (string, error)) *MockStateInstanceStatusCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // SetMachineCloudInstance mocks base method.
 func (m *MockState) SetMachineCloudInstance(arg0 context.Context, arg1 string, arg2 instance.Id, arg3 instance.HardwareCharacteristics) error {
 	m.ctrl.T.Helper()

--- a/domain/machine/service/package_mock_test.go
+++ b/domain/machine/service/package_mock_test.go
@@ -13,6 +13,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	machine "github.com/juju/juju/core/machine"
 	instance "github.com/juju/juju/core/instance"
 	life "github.com/juju/juju/domain/life"
 	gomock "go.uber.org/mock/gomock"
@@ -42,7 +43,7 @@ func (m *MockState) EXPECT() *MockStateMockRecorder {
 }
 
 // CreateMachine mocks base method.
-func (m *MockState) CreateMachine(arg0 context.Context, arg1, arg2, arg3 string) error {
+func (m *MockState) CreateMachine(arg0 context.Context, arg1 machine.ID, arg2, arg3 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateMachine", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
@@ -68,19 +69,19 @@ func (c *MockStateCreateMachineCall) Return(arg0 error) *MockStateCreateMachineC
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateCreateMachineCall) Do(f func(context.Context, string, string, string) error) *MockStateCreateMachineCall {
+func (c *MockStateCreateMachineCall) Do(f func(context.Context, machine.ID, string, string) error) *MockStateCreateMachineCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateCreateMachineCall) DoAndReturn(f func(context.Context, string, string, string) error) *MockStateCreateMachineCall {
+func (c *MockStateCreateMachineCall) DoAndReturn(f func(context.Context, machine.ID, string, string) error) *MockStateCreateMachineCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // DeleteMachine mocks base method.
-func (m *MockState) DeleteMachine(arg0 context.Context, arg1 string) error {
+func (m *MockState) DeleteMachine(arg0 context.Context, arg1 machine.ID) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteMachine", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -106,13 +107,51 @@ func (c *MockStateDeleteMachineCall) Return(arg0 error) *MockStateDeleteMachineC
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateDeleteMachineCall) Do(f func(context.Context, string) error) *MockStateDeleteMachineCall {
+func (c *MockStateDeleteMachineCall) Do(f func(context.Context, machine.ID) error) *MockStateDeleteMachineCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateDeleteMachineCall) DoAndReturn(f func(context.Context, string) error) *MockStateDeleteMachineCall {
+func (c *MockStateDeleteMachineCall) DoAndReturn(f func(context.Context, machine.ID) error) *MockStateDeleteMachineCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// DeleteMachineCloudInstance mocks base method.
+func (m *MockState) DeleteMachineCloudInstance(arg0 context.Context, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteMachineCloudInstance", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteMachineCloudInstance indicates an expected call of DeleteMachineCloudInstance.
+func (mr *MockStateMockRecorder) DeleteMachineCloudInstance(arg0, arg1 any) *MockStateDeleteMachineCloudInstanceCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteMachineCloudInstance", reflect.TypeOf((*MockState)(nil).DeleteMachineCloudInstance), arg0, arg1)
+	return &MockStateDeleteMachineCloudInstanceCall{Call: call}
+}
+
+// MockStateDeleteMachineCloudInstanceCall wrap *gomock.Call
+type MockStateDeleteMachineCloudInstanceCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateDeleteMachineCloudInstanceCall) Return(arg0 error) *MockStateDeleteMachineCloudInstanceCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateDeleteMachineCloudInstanceCall) Do(f func(context.Context, string) error) *MockStateDeleteMachineCloudInstanceCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateDeleteMachineCloudInstanceCall) DoAndReturn(f func(context.Context, string) error) *MockStateDeleteMachineCloudInstanceCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -156,7 +195,7 @@ func (c *MockStateDeleteMachineCloudInstanceCall) DoAndReturn(f func(context.Con
 }
 
 // GetMachineLife mocks base method.
-func (m *MockState) GetMachineLife(arg0 context.Context, arg1 string) (*life.Life, error) {
+func (m *MockState) GetMachineLife(arg0 context.Context, arg1 machine.ID) (*life.Life, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMachineLife", arg0, arg1)
 	ret0, _ := ret[0].(*life.Life)
@@ -183,13 +222,52 @@ func (c *MockStateGetMachineLifeCall) Return(arg0 *life.Life, arg1 error) *MockS
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetMachineLifeCall) Do(f func(context.Context, string) (*life.Life, error)) *MockStateGetMachineLifeCall {
+func (c *MockStateGetMachineLifeCall) Do(f func(context.Context, machine.ID) (*life.Life, error)) *MockStateGetMachineLifeCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetMachineLifeCall) DoAndReturn(f func(context.Context, string) (*life.Life, error)) *MockStateGetMachineLifeCall {
+func (c *MockStateGetMachineLifeCall) DoAndReturn(f func(context.Context, machine.ID) (*life.Life, error)) *MockStateGetMachineLifeCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// HardwareCharacteristics mocks base method.
+func (m *MockState) HardwareCharacteristics(arg0 context.Context, arg1 string) (*instance.HardwareCharacteristics, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HardwareCharacteristics", arg0, arg1)
+	ret0, _ := ret[0].(*instance.HardwareCharacteristics)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// HardwareCharacteristics indicates an expected call of HardwareCharacteristics.
+func (mr *MockStateMockRecorder) HardwareCharacteristics(arg0, arg1 any) *MockStateHardwareCharacteristicsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HardwareCharacteristics", reflect.TypeOf((*MockState)(nil).HardwareCharacteristics), arg0, arg1)
+	return &MockStateHardwareCharacteristicsCall{Call: call}
+}
+
+// MockStateHardwareCharacteristicsCall wrap *gomock.Call
+type MockStateHardwareCharacteristicsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateHardwareCharacteristicsCall) Return(arg0 *instance.HardwareCharacteristics, arg1 error) *MockStateHardwareCharacteristicsCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateHardwareCharacteristicsCall) Do(f func(context.Context, string) (*instance.HardwareCharacteristics, error)) *MockStateHardwareCharacteristicsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateHardwareCharacteristicsCall) DoAndReturn(f func(context.Context, string) (*instance.HardwareCharacteristics, error)) *MockStateHardwareCharacteristicsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -273,7 +351,7 @@ func (c *MockStateInitialWatchStatementCall) DoAndReturn(f func() (string, strin
 }
 
 // InstanceId mocks base method.
-func (m *MockState) InstanceId(arg0 context.Context, arg1 string) (string, error) {
+func (m *MockState) InstanceId(arg0 context.Context, arg1 machine.ID) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InstanceId", arg0, arg1)
 	ret0, _ := ret[0].(string)
@@ -300,19 +378,19 @@ func (c *MockStateInstanceIdCall) Return(arg0 string, arg1 error) *MockStateInst
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateInstanceIdCall) Do(f func(context.Context, string) (string, error)) *MockStateInstanceIdCall {
+func (c *MockStateInstanceIdCall) Do(f func(context.Context, machine.ID) (string, error)) *MockStateInstanceIdCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateInstanceIdCall) DoAndReturn(f func(context.Context, string) (string, error)) *MockStateInstanceIdCall {
+func (c *MockStateInstanceIdCall) DoAndReturn(f func(context.Context, machine.ID) (string, error)) *MockStateInstanceIdCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // InstanceStatus mocks base method.
-func (m *MockState) InstanceStatus(arg0 context.Context, arg1 string) (string, error) {
+func (m *MockState) InstanceStatus(arg0 context.Context, arg1 machine.ID) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InstanceStatus", arg0, arg1)
 	ret0, _ := ret[0].(string)
@@ -339,22 +417,22 @@ func (c *MockStateInstanceStatusCall) Return(arg0 string, arg1 error) *MockState
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateInstanceStatusCall) Do(f func(context.Context, string) (string, error)) *MockStateInstanceStatusCall {
+func (c *MockStateInstanceStatusCall) Do(f func(context.Context, machine.ID) (string, error)) *MockStateInstanceStatusCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateInstanceStatusCall) DoAndReturn(f func(context.Context, string) (string, error)) *MockStateInstanceStatusCall {
+func (c *MockStateInstanceStatusCall) DoAndReturn(f func(context.Context, machine.ID) (string, error)) *MockStateInstanceStatusCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // ListAllMachines mocks base method.
-func (m *MockState) ListAllMachines(arg0 context.Context) ([]string, error) {
+func (m *MockState) ListAllMachines(arg0 context.Context) ([]machine.ID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListAllMachines", arg0)
-	ret0, _ := ret[0].([]string)
+	ret0, _ := ret[0].([]machine.ID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -372,19 +450,57 @@ type MockStateListAllMachinesCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockStateListAllMachinesCall) Return(arg0 []string, arg1 error) *MockStateListAllMachinesCall {
+func (c *MockStateListAllMachinesCall) Return(arg0 []machine.ID, arg1 error) *MockStateListAllMachinesCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateListAllMachinesCall) Do(f func(context.Context) ([]string, error)) *MockStateListAllMachinesCall {
+func (c *MockStateListAllMachinesCall) Do(f func(context.Context) ([]machine.ID, error)) *MockStateListAllMachinesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateListAllMachinesCall) DoAndReturn(f func(context.Context) ([]string, error)) *MockStateListAllMachinesCall {
+func (c *MockStateListAllMachinesCall) DoAndReturn(f func(context.Context) ([]machine.ID, error)) *MockStateListAllMachinesCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// SetMachineCloudInstance mocks base method.
+func (m *MockState) SetMachineCloudInstance(arg0 context.Context, arg1 string, arg2 instance.Id, arg3 instance.HardwareCharacteristics) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetMachineCloudInstance", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetMachineCloudInstance indicates an expected call of SetMachineCloudInstance.
+func (mr *MockStateMockRecorder) SetMachineCloudInstance(arg0, arg1, arg2, arg3 any) *MockStateSetMachineCloudInstanceCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMachineCloudInstance", reflect.TypeOf((*MockState)(nil).SetMachineCloudInstance), arg0, arg1, arg2, arg3)
+	return &MockStateSetMachineCloudInstanceCall{Call: call}
+}
+
+// MockStateSetMachineCloudInstanceCall wrap *gomock.Call
+type MockStateSetMachineCloudInstanceCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateSetMachineCloudInstanceCall) Return(arg0 error) *MockStateSetMachineCloudInstanceCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateSetMachineCloudInstanceCall) Do(f func(context.Context, string, instance.Id, instance.HardwareCharacteristics) error) *MockStateSetMachineCloudInstanceCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateSetMachineCloudInstanceCall) DoAndReturn(f func(context.Context, string, instance.Id, instance.HardwareCharacteristics) error) *MockStateSetMachineCloudInstanceCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/machine/service/service.go
+++ b/domain/machine/service/service.go
@@ -17,30 +17,30 @@ import (
 // State describes retrieval and persistence methods for machines.
 type State interface {
 	// CreateMachine persists the input machine entity.
-	CreateMachine(context.Context, machine.ID, string, string) error
+	CreateMachine(context.Context, machine.Name, string, string) error
 
 	// DeleteMachine deletes the input machine entity.
-	DeleteMachine(context.Context, machine.ID) error
+	DeleteMachine(context.Context, machine.Name) error
 
 	// InitialWatchStatement returns the table and the initial watch statement
 	// for the machines.
 	InitialWatchStatement() (string, string)
 
 	// GetMachineLife returns the life status of the specified machine.
-	GetMachineLife(context.Context, machine.ID) (*life.Life, error)
+	GetMachineLife(context.Context, machine.Name) (*life.Life, error)
 
-	// AllMachineNames retrieves the ids of all machines in the model.
+	// AllMachineNames retrieves the names of all machines in the model.
 	// If there's no machine, it returns an empty slice.
-	AllMachineNames(context.Context) ([]machine.ID, error)
+	AllMachineNames(context.Context) ([]machine.Name, error)
 
 	// InstanceId returns the cloud specific instance id for this machine.
 	// If the machine is not provisioned, it returns a NotProvisionedError.
-	InstanceId(context.Context, machine.ID) (string, error)
+	InstanceId(context.Context, machine.Name) (string, error)
 
 	// InstanceStatus returns the cloud specific instance status for this
 	// machine.
 	// If the machine is not provisioned, it returns a NotProvisionedError.
-	InstanceStatus(context.Context, machine.ID) (string, error)
+	InstanceStatus(context.Context, machine.Name) (string, error)
 
 	// HardwareCharacteristics returns the hardware characteristics struct with
 	// data retrieved from the machine cloud instance table.
@@ -68,38 +68,38 @@ func NewService(st State) *Service {
 }
 
 // CreateMachine creates the specified machine.
-func (s *Service) CreateMachine(ctx context.Context, machineId machine.ID) (string, error) {
+func (s *Service) CreateMachine(ctx context.Context, machineName machine.Name) (string, error) {
 	// Make a new UUIDs for the net-node and the machine.
 	// We want to do this in the service layer so that if retries are invoked at
 	// the state layer we don't keep regenerating.
 	nodeUUID, err := uuid.NewUUID()
 	if err != nil {
-		return "", errors.Annotatef(err, "creating machine %q", machineId)
+		return "", errors.Annotatef(err, "creating machine %q", machineName)
 	}
 	machineUUID, err := uuid.NewUUID()
 	if err != nil {
-		return "", errors.Annotatef(err, "creating machine %q", machineId)
+		return "", errors.Annotatef(err, "creating machine %q", machineName)
 	}
 
-	err = s.st.CreateMachine(ctx, machineId, nodeUUID.String(), machineUUID.String())
+	err = s.st.CreateMachine(ctx, machineName, nodeUUID.String(), machineUUID.String())
 
-	return machineUUID.String(), errors.Annotatef(err, "creating machine %q", machineId)
+	return machineUUID.String(), errors.Annotatef(err, "creating machine %q", machineName)
 }
 
 // DeleteMachine deletes the specified machine.
-func (s *Service) DeleteMachine(ctx context.Context, machineId machine.ID) error {
-	err := s.st.DeleteMachine(ctx, machineId)
-	return errors.Annotatef(err, "deleting machine %q", machineId)
+func (s *Service) DeleteMachine(ctx context.Context, machineName machine.Name) error {
+	err := s.st.DeleteMachine(ctx, machineName)
+	return errors.Annotatef(err, "deleting machine %q", machineName)
 }
 
 // GetLife returns the GetMachineLife status of the specified machine.
-func (s *Service) GetMachineLife(ctx context.Context, machineId machine.ID) (*life.Life, error) {
-	life, err := s.st.GetMachineLife(ctx, machineId)
-	return life, errors.Annotatef(err, "getting life status for machine %q", machineId)
+func (s *Service) GetMachineLife(ctx context.Context, machineName machine.Name) (*life.Life, error) {
+	life, err := s.st.GetMachineLife(ctx, machineName)
+	return life, errors.Annotatef(err, "getting life status for machine %q", machineName)
 }
 
-// ListAllMachines returns the ids of all machines in the model.
-func (s *Service) ListAllMachines(ctx context.Context) ([]machine.ID, error) {
+// ListAllMachines returns the names of all machines in the model.
+func (s *Service) ListAllMachines(ctx context.Context) ([]machine.Name, error) {
 	machines, err := s.st.AllMachineNames(ctx)
 	if err != nil {
 		return nil, errors.Annotate(err, "retrieving all machines")
@@ -109,10 +109,10 @@ func (s *Service) ListAllMachines(ctx context.Context) ([]machine.ID, error) {
 
 // InstanceId returns the cloud specific instance id for this machine.
 // If the machine is not provisioned, it returns a NotProvisionedError.
-func (s *Service) InstanceId(ctx context.Context, machineId machine.ID) (string, error) {
-	instanceId, err := s.st.InstanceId(ctx, machineId)
+func (s *Service) InstanceId(ctx context.Context, machineName machine.Name) (string, error) {
+	instanceId, err := s.st.InstanceId(ctx, machineName)
 	if err != nil {
-		return "", errors.Annotatef(err, "retrieving cloud instance id for machine %q", machineId)
+		return "", errors.Annotatef(err, "retrieving cloud instance id for machine %q", machineName)
 	}
 	return instanceId, nil
 }
@@ -120,10 +120,10 @@ func (s *Service) InstanceId(ctx context.Context, machineId machine.ID) (string,
 // InstanceStatus returns the cloud specific instance status for this
 // machine.
 // If the machine is not provisioned, it returns a NotProvisionedError.
-func (s *Service) InstanceStatus(ctx context.Context, machineId machine.ID) (string, error) {
-	instanceStatus, err := s.st.InstanceStatus(ctx, machineId)
+func (s *Service) InstanceStatus(ctx context.Context, machineName machine.Name) (string, error) {
+	instanceStatus, err := s.st.InstanceStatus(ctx, machineName)
 	if err != nil {
-		return "", errors.Annotatef(err, "retrieving cloud instance status for machine %q", machineId)
+		return "", errors.Annotatef(err, "retrieving cloud instance status for machine %q", machineName)
 	}
 	return instanceStatus, nil
 }

--- a/domain/machine/service/service.go
+++ b/domain/machine/service/service.go
@@ -98,8 +98,8 @@ func (s *Service) GetMachineLife(ctx context.Context, machineName machine.Name) 
 	return life, errors.Annotatef(err, "getting life status for machine %q", machineName)
 }
 
-// ListAllMachines returns the names of all machines in the model.
-func (s *Service) ListAllMachines(ctx context.Context) ([]machine.Name, error) {
+// AllMachineNames returns the names of all machines in the model.
+func (s *Service) AllMachineNames(ctx context.Context) ([]machine.Name, error) {
 	machines, err := s.st.AllMachineNames(ctx)
 	if err != nil {
 		return nil, errors.Annotate(err, "retrieving all machines")

--- a/domain/machine/service/service.go
+++ b/domain/machine/service/service.go
@@ -29,9 +29,9 @@ type State interface {
 	// GetMachineLife returns the life status of the specified machine.
 	GetMachineLife(context.Context, machine.ID) (*life.Life, error)
 
-	// ListAllMachines retrieves the ids of all machines in the model.
+	// AllMachineNames retrieves the ids of all machines in the model.
 	// If there's no machine, it returns an empty slice.
-	ListAllMachines(context.Context) ([]machine.ID, error)
+	AllMachineNames(context.Context) ([]machine.ID, error)
 
 	// InstanceId returns the cloud specific instance id for this machine.
 	// If the machine is not provisioned, it returns a NotProvisionedError.
@@ -100,7 +100,7 @@ func (s *Service) GetMachineLife(ctx context.Context, machineId machine.ID) (*li
 
 // ListAllMachines returns the ids of all machines in the model.
 func (s *Service) ListAllMachines(ctx context.Context) ([]machine.ID, error) {
-	machines, err := s.st.ListAllMachines(ctx)
+	machines, err := s.st.AllMachineNames(ctx)
 	if err != nil {
 		return nil, errors.Annotate(err, "retrieving all machines")
 	}

--- a/domain/machine/service/service.go
+++ b/domain/machine/service/service.go
@@ -36,6 +36,11 @@ type State interface {
 	// If the machine is not provisioned, it returns a NotProvisionedError.
 	InstanceId(context.Context, string) (string, error)
 
+	// InstanceStatus returns the provider specific instance status for this
+	// machine.
+	// If the machine is not provisioned, it returns a NotProvisionedError.
+	InstanceStatus(context.Context, string) (string, error)
+
 	// HardwareCharacteristics returns the hardware characteristics struct with
 	// data retrieved from the machine cloud instance table.
 	HardwareCharacteristics(context.Context, string) (*instance.HardwareCharacteristics, error)
@@ -109,4 +114,15 @@ func (s *Service) InstanceId(ctx context.Context, machineId string) (string, err
 		return "", errors.Annotatef(err, "retrieving cloud instance id for machine %q", machineId)
 	}
 	return instanceId, nil
+}
+
+// InstanceStatus returns the provider specific instance status for this
+// machine.
+// If the machine is not provisioned, it returns a NotProvisionedError.
+func (s *Service) InstanceStatus(ctx context.Context, machineId string) (string, error) {
+	instanceStatus, err := s.st.InstanceStatus(ctx, machineId)
+	if err != nil {
+		return "", errors.Annotatef(err, "retrieving cloud instance status for machine %q", machineId)
+	}
+	return instanceStatus, nil
 }

--- a/domain/machine/service/service.go
+++ b/domain/machine/service/service.go
@@ -32,11 +32,11 @@ type State interface {
 	// If there's no machine, it returns an empty slice.
 	ListAllMachines(context.Context) ([]string, error)
 
-	// InstanceId returns the provider specific instance id for this machine.
+	// InstanceId returns the cloud specific instance id for this machine.
 	// If the machine is not provisioned, it returns a NotProvisionedError.
 	InstanceId(context.Context, string) (string, error)
 
-	// InstanceStatus returns the provider specific instance status for this
+	// InstanceStatus returns the cloud specific instance status for this
 	// machine.
 	// If the machine is not provisioned, it returns a NotProvisionedError.
 	InstanceStatus(context.Context, string) (string, error)
@@ -106,7 +106,7 @@ func (s *Service) ListAllMachines(ctx context.Context) ([]string, error) {
 	return machines, nil
 }
 
-// InstanceId returns the provider specific instance id for this machine.
+// InstanceId returns the cloud specific instance id for this machine.
 // If the machine is not provisioned, it returns a NotProvisionedError.
 func (s *Service) InstanceId(ctx context.Context, machineId string) (string, error) {
 	instanceId, err := s.st.InstanceId(ctx, machineId)
@@ -116,7 +116,7 @@ func (s *Service) InstanceId(ctx context.Context, machineId string) (string, err
 	return instanceId, nil
 }
 
-// InstanceStatus returns the provider specific instance status for this
+// InstanceStatus returns the cloud specific instance status for this
 // machine.
 // If the machine is not provisioned, it returns a NotProvisionedError.
 func (s *Service) InstanceStatus(ctx context.Context, machineId string) (string, error) {

--- a/domain/machine/service/service.go
+++ b/domain/machine/service/service.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/core/instance"
+	coremachine "github.com/juju/juju/core/machine"
 	"github.com/juju/juju/domain/life"
 	"github.com/juju/juju/internal/uuid"
 )
@@ -16,30 +17,30 @@ import (
 // State describes retrieval and persistence methods for machines.
 type State interface {
 	// CreateMachine persists the input machine entity.
-	CreateMachine(context.Context, string, string, string) error
+	CreateMachine(context.Context, coremachine.ID, string, string) error
 
 	// DeleteMachine deletes the input machine entity.
-	DeleteMachine(context.Context, string) error
+	DeleteMachine(context.Context, coremachine.ID) error
 
 	// InitialWatchStatement returns the table and the initial watch statement
 	// for the machines.
 	InitialWatchStatement() (string, string)
 
 	// GetMachineLife returns the life status of the specified machine.
-	GetMachineLife(context.Context, string) (*life.Life, error)
+	GetMachineLife(context.Context, coremachine.ID) (*life.Life, error)
 
 	// ListAllMachines retrieves the ids of all machines in the model.
 	// If there's no machine, it returns an empty slice.
-	ListAllMachines(context.Context) ([]string, error)
+	ListAllMachines(context.Context) ([]coremachine.ID, error)
 
 	// InstanceId returns the cloud specific instance id for this machine.
 	// If the machine is not provisioned, it returns a NotProvisionedError.
-	InstanceId(context.Context, string) (string, error)
+	InstanceId(context.Context, coremachine.ID) (string, error)
 
 	// InstanceStatus returns the cloud specific instance status for this
 	// machine.
 	// If the machine is not provisioned, it returns a NotProvisionedError.
-	InstanceStatus(context.Context, string) (string, error)
+	InstanceStatus(context.Context, coremachine.ID) (string, error)
 
 	// HardwareCharacteristics returns the hardware characteristics struct with
 	// data retrieved from the machine cloud instance table.
@@ -67,7 +68,7 @@ func NewService(st State) *Service {
 }
 
 // CreateMachine creates the specified machine.
-func (s *Service) CreateMachine(ctx context.Context, machineId string) (string, error) {
+func (s *Service) CreateMachine(ctx context.Context, machineId coremachine.ID) (string, error) {
 	// Make a new UUIDs for the net-node and the machine.
 	// We want to do this in the service layer so that if retries are invoked at
 	// the state layer we don't keep regenerating.
@@ -86,19 +87,19 @@ func (s *Service) CreateMachine(ctx context.Context, machineId string) (string, 
 }
 
 // DeleteMachine deletes the specified machine.
-func (s *Service) DeleteMachine(ctx context.Context, machineId string) error {
+func (s *Service) DeleteMachine(ctx context.Context, machineId coremachine.ID) error {
 	err := s.st.DeleteMachine(ctx, machineId)
 	return errors.Annotatef(err, "deleting machine %q", machineId)
 }
 
 // GetLife returns the GetMachineLife status of the specified machine.
-func (s *Service) GetMachineLife(ctx context.Context, machineId string) (*life.Life, error) {
+func (s *Service) GetMachineLife(ctx context.Context, machineId coremachine.ID) (*life.Life, error) {
 	life, err := s.st.GetMachineLife(ctx, machineId)
 	return life, errors.Annotatef(err, "getting life status for machine %q", machineId)
 }
 
 // ListAllMachines returns the ids of all machines in the model.
-func (s *Service) ListAllMachines(ctx context.Context) ([]string, error) {
+func (s *Service) ListAllMachines(ctx context.Context) ([]coremachine.ID, error) {
 	machines, err := s.st.ListAllMachines(ctx)
 	if err != nil {
 		return nil, errors.Annotate(err, "retrieving all machines")
@@ -108,7 +109,7 @@ func (s *Service) ListAllMachines(ctx context.Context) ([]string, error) {
 
 // InstanceId returns the cloud specific instance id for this machine.
 // If the machine is not provisioned, it returns a NotProvisionedError.
-func (s *Service) InstanceId(ctx context.Context, machineId string) (string, error) {
+func (s *Service) InstanceId(ctx context.Context, machineId coremachine.ID) (string, error) {
 	instanceId, err := s.st.InstanceId(ctx, machineId)
 	if err != nil {
 		return "", errors.Annotatef(err, "retrieving cloud instance id for machine %q", machineId)
@@ -119,7 +120,7 @@ func (s *Service) InstanceId(ctx context.Context, machineId string) (string, err
 // InstanceStatus returns the cloud specific instance status for this
 // machine.
 // If the machine is not provisioned, it returns a NotProvisionedError.
-func (s *Service) InstanceStatus(ctx context.Context, machineId string) (string, error) {
+func (s *Service) InstanceStatus(ctx context.Context, machineId coremachine.ID) (string, error) {
 	instanceStatus, err := s.st.InstanceStatus(ctx, machineId)
 	if err != nil {
 		return "", errors.Annotatef(err, "retrieving cloud instance status for machine %q", machineId)

--- a/domain/machine/service/service.go
+++ b/domain/machine/service/service.go
@@ -28,9 +28,9 @@ type State interface {
 	// GetMachineLife returns the life status of the specified machine.
 	GetMachineLife(context.Context, string) (*life.Life, error)
 
-	// AllMachines retrieves the ids of all machines in the model.
+	// ListAllMachines retrieves the ids of all machines in the model.
 	// If there's no machine, it returns an empty slice.
-	AllMachines(context.Context) ([]string, error)
+	ListAllMachines(context.Context) ([]string, error)
 
 	// InstanceId returns the provider specific instance id for this machine.
 	// If the machine is not provisioned, it returns a NotProvisionedError.
@@ -99,7 +99,7 @@ func (s *Service) GetMachineLife(ctx context.Context, machineId string) (*life.L
 
 // ListAllMachines returns the ids of all machines in the model.
 func (s *Service) ListAllMachines(ctx context.Context) ([]string, error) {
-	machines, err := s.st.AllMachines(ctx)
+	machines, err := s.st.ListAllMachines(ctx)
 	if err != nil {
 		return nil, errors.Annotate(err, "retrieving all machines")
 	}

--- a/domain/machine/service/service.go
+++ b/domain/machine/service/service.go
@@ -32,6 +32,10 @@ type State interface {
 	// If there's no machine, it returns an empty slice.
 	AllMachines(context.Context) ([]string, error)
 
+	// InstanceId returns the provider specific instance id for this machine.
+	// If the machine is not provisioned, it returns a NotProvisionedError.
+	InstanceId(context.Context, string) (string, error)
+
 	// HardwareCharacteristics returns the hardware characteristics struct with
 	// data retrieved from the machine cloud instance table.
 	HardwareCharacteristics(context.Context, string) (*instance.HardwareCharacteristics, error)
@@ -95,4 +99,14 @@ func (s *Service) ListAllMachines(ctx context.Context) ([]string, error) {
 		return nil, errors.Annotate(err, "retrieving all machines")
 	}
 	return machines, nil
+}
+
+// InstanceId returns the provider specific instance id for this machine.
+// If the machine is not provisioned, it returns a NotProvisionedError.
+func (s *Service) InstanceId(ctx context.Context, machineId string) (string, error) {
+	instanceId, err := s.st.InstanceId(ctx, machineId)
+	if err != nil {
+		return "", errors.Annotatef(err, "retrieving cloud instance id for machine %q", machineId)
+	}
+	return instanceId, nil
 }

--- a/domain/machine/service/service.go
+++ b/domain/machine/service/service.go
@@ -28,6 +28,10 @@ type State interface {
 	// GetMachineLife returns the life status of the specified machine.
 	GetMachineLife(context.Context, string) (*life.Life, error)
 
+	// AllMachines retrieves the ids of all machines in the model.
+	// If there's no machine, it returns an empty slice.
+	AllMachines(context.Context) ([]string, error)
+
 	// HardwareCharacteristics returns the hardware characteristics struct with
 	// data retrieved from the machine cloud instance table.
 	HardwareCharacteristics(context.Context, string) (*instance.HardwareCharacteristics, error)
@@ -82,4 +86,13 @@ func (s *Service) DeleteMachine(ctx context.Context, machineId string) error {
 func (s *Service) GetMachineLife(ctx context.Context, machineId string) (*life.Life, error) {
 	life, err := s.st.GetMachineLife(ctx, machineId)
 	return life, errors.Annotatef(err, "getting life status for machine %q", machineId)
+}
+
+// ListAllMachines returns the ids of all machines in the model.
+func (s *Service) ListAllMachines(ctx context.Context) ([]string, error) {
+	machines, err := s.st.AllMachines(ctx)
+	if err != nil {
+		return nil, errors.Annotate(err, "retrieving all machines")
+	}
+	return machines, nil
 }

--- a/domain/machine/service/service.go
+++ b/domain/machine/service/service.go
@@ -9,7 +9,7 @@ import (
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/core/instance"
-	coremachine "github.com/juju/juju/core/machine"
+	"github.com/juju/juju/core/machine"
 	"github.com/juju/juju/domain/life"
 	"github.com/juju/juju/internal/uuid"
 )
@@ -17,30 +17,30 @@ import (
 // State describes retrieval and persistence methods for machines.
 type State interface {
 	// CreateMachine persists the input machine entity.
-	CreateMachine(context.Context, coremachine.ID, string, string) error
+	CreateMachine(context.Context, machine.ID, string, string) error
 
 	// DeleteMachine deletes the input machine entity.
-	DeleteMachine(context.Context, coremachine.ID) error
+	DeleteMachine(context.Context, machine.ID) error
 
 	// InitialWatchStatement returns the table and the initial watch statement
 	// for the machines.
 	InitialWatchStatement() (string, string)
 
 	// GetMachineLife returns the life status of the specified machine.
-	GetMachineLife(context.Context, coremachine.ID) (*life.Life, error)
+	GetMachineLife(context.Context, machine.ID) (*life.Life, error)
 
 	// ListAllMachines retrieves the ids of all machines in the model.
 	// If there's no machine, it returns an empty slice.
-	ListAllMachines(context.Context) ([]coremachine.ID, error)
+	ListAllMachines(context.Context) ([]machine.ID, error)
 
 	// InstanceId returns the cloud specific instance id for this machine.
 	// If the machine is not provisioned, it returns a NotProvisionedError.
-	InstanceId(context.Context, coremachine.ID) (string, error)
+	InstanceId(context.Context, machine.ID) (string, error)
 
 	// InstanceStatus returns the cloud specific instance status for this
 	// machine.
 	// If the machine is not provisioned, it returns a NotProvisionedError.
-	InstanceStatus(context.Context, coremachine.ID) (string, error)
+	InstanceStatus(context.Context, machine.ID) (string, error)
 
 	// HardwareCharacteristics returns the hardware characteristics struct with
 	// data retrieved from the machine cloud instance table.
@@ -68,7 +68,7 @@ func NewService(st State) *Service {
 }
 
 // CreateMachine creates the specified machine.
-func (s *Service) CreateMachine(ctx context.Context, machineId coremachine.ID) (string, error) {
+func (s *Service) CreateMachine(ctx context.Context, machineId machine.ID) (string, error) {
 	// Make a new UUIDs for the net-node and the machine.
 	// We want to do this in the service layer so that if retries are invoked at
 	// the state layer we don't keep regenerating.
@@ -87,19 +87,19 @@ func (s *Service) CreateMachine(ctx context.Context, machineId coremachine.ID) (
 }
 
 // DeleteMachine deletes the specified machine.
-func (s *Service) DeleteMachine(ctx context.Context, machineId coremachine.ID) error {
+func (s *Service) DeleteMachine(ctx context.Context, machineId machine.ID) error {
 	err := s.st.DeleteMachine(ctx, machineId)
 	return errors.Annotatef(err, "deleting machine %q", machineId)
 }
 
 // GetLife returns the GetMachineLife status of the specified machine.
-func (s *Service) GetMachineLife(ctx context.Context, machineId coremachine.ID) (*life.Life, error) {
+func (s *Service) GetMachineLife(ctx context.Context, machineId machine.ID) (*life.Life, error) {
 	life, err := s.st.GetMachineLife(ctx, machineId)
 	return life, errors.Annotatef(err, "getting life status for machine %q", machineId)
 }
 
 // ListAllMachines returns the ids of all machines in the model.
-func (s *Service) ListAllMachines(ctx context.Context) ([]coremachine.ID, error) {
+func (s *Service) ListAllMachines(ctx context.Context) ([]machine.ID, error) {
 	machines, err := s.st.ListAllMachines(ctx)
 	if err != nil {
 		return nil, errors.Annotate(err, "retrieving all machines")
@@ -109,7 +109,7 @@ func (s *Service) ListAllMachines(ctx context.Context) ([]coremachine.ID, error)
 
 // InstanceId returns the cloud specific instance id for this machine.
 // If the machine is not provisioned, it returns a NotProvisionedError.
-func (s *Service) InstanceId(ctx context.Context, machineId coremachine.ID) (string, error) {
+func (s *Service) InstanceId(ctx context.Context, machineId machine.ID) (string, error) {
 	instanceId, err := s.st.InstanceId(ctx, machineId)
 	if err != nil {
 		return "", errors.Annotatef(err, "retrieving cloud instance id for machine %q", machineId)
@@ -120,7 +120,7 @@ func (s *Service) InstanceId(ctx context.Context, machineId coremachine.ID) (str
 // InstanceStatus returns the cloud specific instance status for this
 // machine.
 // If the machine is not provisioned, it returns a NotProvisionedError.
-func (s *Service) InstanceStatus(ctx context.Context, machineId coremachine.ID) (string, error) {
+func (s *Service) InstanceStatus(ctx context.Context, machineId machine.ID) (string, error) {
 	instanceStatus, err := s.st.InstanceStatus(ctx, machineId)
 	if err != nil {
 		return "", errors.Annotatef(err, "retrieving cloud instance status for machine %q", machineId)

--- a/domain/machine/service/service_test.go
+++ b/domain/machine/service/service_test.go
@@ -111,3 +111,24 @@ func (s *serviceSuite) TestListAllMachinesError(c *gc.C) {
 	c.Check(err, jc.ErrorIs, rErr)
 	c.Assert(machines, gc.IsNil)
 }
+
+func (s *serviceSuite) TestInstanceIdSuccess(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.state.EXPECT().InstanceId(gomock.Any(), "666").Return("123", nil)
+
+	instanceId, err := NewService(s.state).InstanceId(context.Background(), "666")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(instanceId, gc.Equals, "123")
+}
+
+func (s *serviceSuite) TestInstanceIdError(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	rErr := errors.New("boom")
+	s.state.EXPECT().InstanceId(gomock.Any(), "666").Return("", rErr)
+
+	instanceId, err := NewService(s.state).InstanceId(context.Background(), "666")
+	c.Check(err, jc.ErrorIs, rErr)
+	c.Assert(instanceId, gc.Equals, "")
+}

--- a/domain/machine/service/service_test.go
+++ b/domain/machine/service/service_test.go
@@ -12,6 +12,7 @@ import (
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
+	cmachine "github.com/juju/juju/core/machine"
 	"github.com/juju/juju/domain/life"
 )
 
@@ -31,9 +32,9 @@ func (s *serviceSuite) setupMocks(c *gc.C) *gomock.Controller {
 func (s *serviceSuite) TestCreateMachineSuccess(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().CreateMachine(gomock.Any(), "666", gomock.Any(), gomock.Any()).Return(nil)
+	s.state.EXPECT().CreateMachine(gomock.Any(), cmachine.ID("666"), gomock.Any(), gomock.Any()).Return(nil)
 
-	_, err := NewService(s.state).CreateMachine(context.Background(), "666")
+	_, err := NewService(s.state).CreateMachine(context.Background(), cmachine.ID("666"))
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -43,9 +44,9 @@ func (s *serviceSuite) TestCreateMachineError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	rErr := errors.New("boom")
-	s.state.EXPECT().CreateMachine(gomock.Any(), "666", gomock.Any(), gomock.Any()).Return(rErr)
+	s.state.EXPECT().CreateMachine(gomock.Any(), cmachine.ID("666"), gomock.Any(), gomock.Any()).Return(rErr)
 
-	_, err := NewService(s.state).CreateMachine(context.Background(), "666")
+	_, err := NewService(s.state).CreateMachine(context.Background(), cmachine.ID("666"))
 	c.Check(err, jc.ErrorIs, rErr)
 	c.Assert(err, gc.ErrorMatches, `creating machine "666": boom`)
 }
@@ -53,9 +54,9 @@ func (s *serviceSuite) TestCreateMachineError(c *gc.C) {
 func (s *serviceSuite) TestDeleteMachineSuccess(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().DeleteMachine(gomock.Any(), "666").Return(nil)
+	s.state.EXPECT().DeleteMachine(gomock.Any(), cmachine.ID("666")).Return(nil)
 
-	err := NewService(s.state).DeleteMachine(context.Background(), "666")
+	err := NewService(s.state).DeleteMachine(context.Background(), cmachine.ID("666"))
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -65,9 +66,9 @@ func (s *serviceSuite) TestDeleteMachineError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	rErr := errors.New("boom")
-	s.state.EXPECT().DeleteMachine(gomock.Any(), "666").Return(rErr)
+	s.state.EXPECT().DeleteMachine(gomock.Any(), cmachine.ID("666")).Return(rErr)
 
-	err := NewService(s.state).DeleteMachine(context.Background(), "666")
+	err := NewService(s.state).DeleteMachine(context.Background(), cmachine.ID("666"))
 	c.Check(err, jc.ErrorIs, rErr)
 	c.Assert(err, gc.ErrorMatches, `deleting machine "666": boom`)
 }
@@ -76,9 +77,9 @@ func (s *serviceSuite) TestGetLifeSuccess(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	life := life.Alive
-	s.state.EXPECT().GetMachineLife(gomock.Any(), "666").Return(&life, nil)
+	s.state.EXPECT().GetMachineLife(gomock.Any(), cmachine.ID("666")).Return(&life, nil)
 
-	l, err := NewService(s.state).GetMachineLife(context.Background(), "666")
+	l, err := NewService(s.state).GetMachineLife(context.Background(), cmachine.ID("666"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(l, gc.Equals, &life)
 }
@@ -89,9 +90,9 @@ func (s *serviceSuite) TestGetLifeError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	rErr := errors.New("boom")
-	s.state.EXPECT().GetMachineLife(gomock.Any(), "666").Return(nil, rErr)
+	s.state.EXPECT().GetMachineLife(gomock.Any(), cmachine.ID("666")).Return(nil, rErr)
 
-	l, err := NewService(s.state).GetMachineLife(context.Background(), "666")
+	l, err := NewService(s.state).GetMachineLife(context.Background(), cmachine.ID("666"))
 	c.Check(l, gc.IsNil)
 	c.Check(err, jc.ErrorIs, rErr)
 	c.Assert(err, gc.ErrorMatches, `getting life status for machine "666": boom`)
@@ -100,11 +101,11 @@ func (s *serviceSuite) TestGetLifeError(c *gc.C) {
 func (s *serviceSuite) TestListAllMachinesSuccess(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().ListAllMachines(gomock.Any()).Return([]string{"666"}, nil)
+	s.state.EXPECT().ListAllMachines(gomock.Any()).Return([]cmachine.ID{cmachine.ID("666")}, nil)
 
 	machines, err := NewService(s.state).ListAllMachines(context.Background())
 	c.Check(err, jc.ErrorIsNil)
-	c.Assert(machines, gc.DeepEquals, []string{"666"})
+	c.Assert(machines, gc.DeepEquals, []cmachine.ID{cmachine.ID("666")})
 }
 
 // TestListAllMachinesError asserts that an error coming from the state layer is
@@ -123,9 +124,9 @@ func (s *serviceSuite) TestListAllMachinesError(c *gc.C) {
 func (s *serviceSuite) TestInstanceIdSuccess(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().InstanceId(gomock.Any(), "666").Return("123", nil)
+	s.state.EXPECT().InstanceId(gomock.Any(), cmachine.ID("666")).Return("123", nil)
 
-	instanceId, err := NewService(s.state).InstanceId(context.Background(), "666")
+	instanceId, err := NewService(s.state).InstanceId(context.Background(), cmachine.ID("666"))
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(instanceId, gc.Equals, "123")
 }
@@ -136,9 +137,9 @@ func (s *serviceSuite) TestInstanceIdError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	rErr := errors.New("boom")
-	s.state.EXPECT().InstanceId(gomock.Any(), "666").Return("", rErr)
+	s.state.EXPECT().InstanceId(gomock.Any(), cmachine.ID("666")).Return("", rErr)
 
-	instanceId, err := NewService(s.state).InstanceId(context.Background(), "666")
+	instanceId, err := NewService(s.state).InstanceId(context.Background(), cmachine.ID("666"))
 	c.Check(err, jc.ErrorIs, rErr)
 	c.Check(instanceId, gc.Equals, "")
 }
@@ -146,9 +147,9 @@ func (s *serviceSuite) TestInstanceIdError(c *gc.C) {
 func (s *serviceSuite) TestInstanceStatusSuccess(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().InstanceStatus(gomock.Any(), "666").Return("running", nil)
+	s.state.EXPECT().InstanceStatus(gomock.Any(), cmachine.ID("666")).Return("running", nil)
 
-	instanceStatus, err := NewService(s.state).InstanceStatus(context.Background(), "666")
+	instanceStatus, err := NewService(s.state).InstanceStatus(context.Background(), cmachine.ID("666"))
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(instanceStatus, gc.Equals, "running")
 }
@@ -159,9 +160,9 @@ func (s *serviceSuite) TestInstanceStatusError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	rErr := errors.New("boom")
-	s.state.EXPECT().InstanceStatus(gomock.Any(), "666").Return("", rErr)
+	s.state.EXPECT().InstanceStatus(gomock.Any(), cmachine.ID("666")).Return("", rErr)
 
-	instanceStatus, err := NewService(s.state).InstanceStatus(context.Background(), "666")
+	instanceStatus, err := NewService(s.state).InstanceStatus(context.Background(), cmachine.ID("666"))
 	c.Check(err, jc.ErrorIs, rErr)
 	c.Check(instanceStatus, gc.Equals, "")
 }

--- a/domain/machine/service/service_test.go
+++ b/domain/machine/service/service_test.go
@@ -132,3 +132,24 @@ func (s *serviceSuite) TestInstanceIdError(c *gc.C) {
 	c.Check(err, jc.ErrorIs, rErr)
 	c.Assert(instanceId, gc.Equals, "")
 }
+
+func (s *serviceSuite) TestInstanceStatusSuccess(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.state.EXPECT().InstanceStatus(gomock.Any(), "666").Return("running", nil)
+
+	instanceStatus, err := NewService(s.state).InstanceStatus(context.Background(), "666")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(instanceStatus, gc.Equals, "running")
+}
+
+func (s *serviceSuite) TestInstanceStatusError(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	rErr := errors.New("boom")
+	s.state.EXPECT().InstanceStatus(gomock.Any(), "666").Return("", rErr)
+
+	instanceStatus, err := NewService(s.state).InstanceStatus(context.Background(), "666")
+	c.Check(err, jc.ErrorIs, rErr)
+	c.Assert(instanceStatus, gc.Equals, "")
+}

--- a/domain/machine/service/service_test.go
+++ b/domain/machine/service/service_test.go
@@ -94,7 +94,7 @@ func (s *serviceSuite) TestGetLifeError(c *gc.C) {
 func (s *serviceSuite) TestListAllMachinesSuccess(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().AllMachines(gomock.Any()).Return([]string{"666"}, nil)
+	s.state.EXPECT().ListAllMachines(gomock.Any()).Return([]string{"666"}, nil)
 
 	machines, err := NewService(s.state).ListAllMachines(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
@@ -105,7 +105,7 @@ func (s *serviceSuite) TestListAllMachinesError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	rErr := errors.New("boom")
-	s.state.EXPECT().AllMachines(gomock.Any()).Return(nil, rErr)
+	s.state.EXPECT().ListAllMachines(gomock.Any()).Return(nil, rErr)
 
 	machines, err := NewService(s.state).ListAllMachines(context.Background())
 	c.Check(err, jc.ErrorIs, rErr)

--- a/domain/machine/service/service_test.go
+++ b/domain/machine/service/service_test.go
@@ -90,3 +90,24 @@ func (s *serviceSuite) TestGetLifeError(c *gc.C) {
 	c.Check(err, jc.ErrorIs, rErr)
 	c.Assert(err, gc.ErrorMatches, `getting life status for machine "666": boom`)
 }
+
+func (s *serviceSuite) TestListAllMachinesSuccess(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.state.EXPECT().AllMachines(gomock.Any()).Return([]string{"666"}, nil)
+
+	machines, err := NewService(s.state).ListAllMachines(context.Background())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(machines, gc.DeepEquals, []string{"666"})
+}
+
+func (s *serviceSuite) TestListAllMachinesError(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	rErr := errors.New("boom")
+	s.state.EXPECT().AllMachines(gomock.Any()).Return(nil, rErr)
+
+	machines, err := NewService(s.state).ListAllMachines(context.Background())
+	c.Check(err, jc.ErrorIs, rErr)
+	c.Assert(machines, gc.IsNil)
+}

--- a/domain/machine/service/service_test.go
+++ b/domain/machine/service/service_test.go
@@ -114,7 +114,7 @@ func (s *serviceSuite) TestGetLifeNotFoundError(c *gc.C) {
 func (s *serviceSuite) TestListAllMachinesSuccess(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().ListAllMachines(gomock.Any()).Return([]cmachine.ID{cmachine.ID("666")}, nil)
+	s.state.EXPECT().AllMachineNames(gomock.Any()).Return([]cmachine.ID{cmachine.ID("666")}, nil)
 
 	machines, err := NewService(s.state).ListAllMachines(context.Background())
 	c.Check(err, jc.ErrorIsNil)
@@ -127,7 +127,7 @@ func (s *serviceSuite) TestListAllMachinesError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	rErr := errors.New("boom")
-	s.state.EXPECT().ListAllMachines(gomock.Any()).Return(nil, rErr)
+	s.state.EXPECT().AllMachineNames(gomock.Any()).Return(nil, rErr)
 
 	machines, err := NewService(s.state).ListAllMachines(context.Background())
 	c.Check(err, jc.ErrorIs, rErr)

--- a/domain/machine/service/service_test.go
+++ b/domain/machine/service/service_test.go
@@ -99,7 +99,7 @@ func (s *serviceSuite) TestGetLifeError(c *gc.C) {
 }
 
 // TestGetLifeNotFoundError asserts that the state layer returns a NotFound
-// Error if a machine is not found with the given machineId, and that error is
+// Error if a machine is not found with the given machineName, and that error is
 // preserved and passed on to the service layer to be handled there.
 func (s *serviceSuite) TestGetLifeNotFoundError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
@@ -158,7 +158,7 @@ func (s *serviceSuite) TestInstanceIdError(c *gc.C) {
 }
 
 // TestInstanceIdNotProvisionedError asserts that the state layer returns a
-// NotProvisioned Error if an instanceId is not found for the given machineId,
+// NotProvisioned Error if an instanceId is not found for the given machineName,
 // and that error is preserved and passed on to the service layer to be handled
 // there.
 func (s *serviceSuite) TestInstanceIdNotProvisionedError(c *gc.C) {

--- a/domain/machine/service/service_test.go
+++ b/domain/machine/service/service_test.go
@@ -116,7 +116,7 @@ func (s *serviceSuite) TestListAllMachinesSuccess(c *gc.C) {
 
 	s.state.EXPECT().AllMachineNames(gomock.Any()).Return([]cmachine.Name{cmachine.Name("666")}, nil)
 
-	machines, err := NewService(s.state).ListAllMachines(context.Background())
+	machines, err := NewService(s.state).AllMachineNames(context.Background())
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(machines, gc.DeepEquals, []cmachine.Name{cmachine.Name("666")})
 }
@@ -129,7 +129,7 @@ func (s *serviceSuite) TestListAllMachinesError(c *gc.C) {
 	rErr := errors.New("boom")
 	s.state.EXPECT().AllMachineNames(gomock.Any()).Return(nil, rErr)
 
-	machines, err := NewService(s.state).ListAllMachines(context.Background())
+	machines, err := NewService(s.state).AllMachineNames(context.Background())
 	c.Check(err, jc.ErrorIs, rErr)
 	c.Check(machines, gc.IsNil)
 }

--- a/domain/machine/service/service_test.go
+++ b/domain/machine/service/service_test.go
@@ -32,9 +32,9 @@ func (s *serviceSuite) setupMocks(c *gc.C) *gomock.Controller {
 func (s *serviceSuite) TestCreateMachineSuccess(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().CreateMachine(gomock.Any(), cmachine.ID("666"), gomock.Any(), gomock.Any()).Return(nil)
+	s.state.EXPECT().CreateMachine(gomock.Any(), cmachine.Name("666"), gomock.Any(), gomock.Any()).Return(nil)
 
-	_, err := NewService(s.state).CreateMachine(context.Background(), cmachine.ID("666"))
+	_, err := NewService(s.state).CreateMachine(context.Background(), cmachine.Name("666"))
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -44,9 +44,9 @@ func (s *serviceSuite) TestCreateMachineError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	rErr := errors.New("boom")
-	s.state.EXPECT().CreateMachine(gomock.Any(), cmachine.ID("666"), gomock.Any(), gomock.Any()).Return(rErr)
+	s.state.EXPECT().CreateMachine(gomock.Any(), cmachine.Name("666"), gomock.Any(), gomock.Any()).Return(rErr)
 
-	_, err := NewService(s.state).CreateMachine(context.Background(), cmachine.ID("666"))
+	_, err := NewService(s.state).CreateMachine(context.Background(), cmachine.Name("666"))
 	c.Check(err, jc.ErrorIs, rErr)
 	c.Assert(err, gc.ErrorMatches, `creating machine "666": boom`)
 }
@@ -54,9 +54,9 @@ func (s *serviceSuite) TestCreateMachineError(c *gc.C) {
 func (s *serviceSuite) TestDeleteMachineSuccess(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().DeleteMachine(gomock.Any(), cmachine.ID("666")).Return(nil)
+	s.state.EXPECT().DeleteMachine(gomock.Any(), cmachine.Name("666")).Return(nil)
 
-	err := NewService(s.state).DeleteMachine(context.Background(), cmachine.ID("666"))
+	err := NewService(s.state).DeleteMachine(context.Background(), cmachine.Name("666"))
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -66,9 +66,9 @@ func (s *serviceSuite) TestDeleteMachineError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	rErr := errors.New("boom")
-	s.state.EXPECT().DeleteMachine(gomock.Any(), cmachine.ID("666")).Return(rErr)
+	s.state.EXPECT().DeleteMachine(gomock.Any(), cmachine.Name("666")).Return(rErr)
 
-	err := NewService(s.state).DeleteMachine(context.Background(), cmachine.ID("666"))
+	err := NewService(s.state).DeleteMachine(context.Background(), cmachine.Name("666"))
 	c.Check(err, jc.ErrorIs, rErr)
 	c.Assert(err, gc.ErrorMatches, `deleting machine "666": boom`)
 }
@@ -77,9 +77,9 @@ func (s *serviceSuite) TestGetLifeSuccess(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	life := life.Alive
-	s.state.EXPECT().GetMachineLife(gomock.Any(), cmachine.ID("666")).Return(&life, nil)
+	s.state.EXPECT().GetMachineLife(gomock.Any(), cmachine.Name("666")).Return(&life, nil)
 
-	l, err := NewService(s.state).GetMachineLife(context.Background(), cmachine.ID("666"))
+	l, err := NewService(s.state).GetMachineLife(context.Background(), cmachine.Name("666"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(l, gc.Equals, &life)
 }
@@ -90,9 +90,9 @@ func (s *serviceSuite) TestGetLifeError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	rErr := errors.New("boom")
-	s.state.EXPECT().GetMachineLife(gomock.Any(), cmachine.ID("666")).Return(nil, rErr)
+	s.state.EXPECT().GetMachineLife(gomock.Any(), cmachine.Name("666")).Return(nil, rErr)
 
-	l, err := NewService(s.state).GetMachineLife(context.Background(), cmachine.ID("666"))
+	l, err := NewService(s.state).GetMachineLife(context.Background(), cmachine.Name("666"))
 	c.Check(l, gc.IsNil)
 	c.Check(err, jc.ErrorIs, rErr)
 	c.Assert(err, gc.ErrorMatches, `getting life status for machine "666": boom`)
@@ -104,9 +104,9 @@ func (s *serviceSuite) TestGetLifeError(c *gc.C) {
 func (s *serviceSuite) TestGetLifeNotFoundError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().GetMachineLife(gomock.Any(), cmachine.ID("666")).Return(nil, errors.NotFound)
+	s.state.EXPECT().GetMachineLife(gomock.Any(), cmachine.Name("666")).Return(nil, errors.NotFound)
 
-	l, err := NewService(s.state).GetMachineLife(context.Background(), cmachine.ID("666"))
+	l, err := NewService(s.state).GetMachineLife(context.Background(), cmachine.Name("666"))
 	c.Check(l, gc.IsNil)
 	c.Check(err, jc.ErrorIs, errors.NotFound)
 }
@@ -114,11 +114,11 @@ func (s *serviceSuite) TestGetLifeNotFoundError(c *gc.C) {
 func (s *serviceSuite) TestListAllMachinesSuccess(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().AllMachineNames(gomock.Any()).Return([]cmachine.ID{cmachine.ID("666")}, nil)
+	s.state.EXPECT().AllMachineNames(gomock.Any()).Return([]cmachine.Name{cmachine.Name("666")}, nil)
 
 	machines, err := NewService(s.state).ListAllMachines(context.Background())
 	c.Check(err, jc.ErrorIsNil)
-	c.Assert(machines, gc.DeepEquals, []cmachine.ID{cmachine.ID("666")})
+	c.Assert(machines, gc.DeepEquals, []cmachine.Name{cmachine.Name("666")})
 }
 
 // TestListAllMachinesError asserts that an error coming from the state layer is
@@ -137,9 +137,9 @@ func (s *serviceSuite) TestListAllMachinesError(c *gc.C) {
 func (s *serviceSuite) TestInstanceIdSuccess(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().InstanceId(gomock.Any(), cmachine.ID("666")).Return("123", nil)
+	s.state.EXPECT().InstanceId(gomock.Any(), cmachine.Name("666")).Return("123", nil)
 
-	instanceId, err := NewService(s.state).InstanceId(context.Background(), cmachine.ID("666"))
+	instanceId, err := NewService(s.state).InstanceId(context.Background(), cmachine.Name("666"))
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(instanceId, gc.Equals, "123")
 }
@@ -150,9 +150,9 @@ func (s *serviceSuite) TestInstanceIdError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	rErr := errors.New("boom")
-	s.state.EXPECT().InstanceId(gomock.Any(), cmachine.ID("666")).Return("", rErr)
+	s.state.EXPECT().InstanceId(gomock.Any(), cmachine.Name("666")).Return("", rErr)
 
-	instanceId, err := NewService(s.state).InstanceId(context.Background(), cmachine.ID("666"))
+	instanceId, err := NewService(s.state).InstanceId(context.Background(), cmachine.Name("666"))
 	c.Check(err, jc.ErrorIs, rErr)
 	c.Check(instanceId, gc.Equals, "")
 }
@@ -164,9 +164,9 @@ func (s *serviceSuite) TestInstanceIdError(c *gc.C) {
 func (s *serviceSuite) TestInstanceIdNotProvisionedError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().InstanceId(gomock.Any(), cmachine.ID("666")).Return("", errors.NotProvisioned)
+	s.state.EXPECT().InstanceId(gomock.Any(), cmachine.Name("666")).Return("", errors.NotProvisioned)
 
-	instanceId, err := NewService(s.state).InstanceId(context.Background(), cmachine.ID("666"))
+	instanceId, err := NewService(s.state).InstanceId(context.Background(), cmachine.Name("666"))
 	c.Check(err, jc.ErrorIs, errors.NotProvisioned)
 	c.Check(instanceId, gc.Equals, "")
 }
@@ -174,9 +174,9 @@ func (s *serviceSuite) TestInstanceIdNotProvisionedError(c *gc.C) {
 func (s *serviceSuite) TestInstanceStatusSuccess(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().InstanceStatus(gomock.Any(), cmachine.ID("666")).Return("running", nil)
+	s.state.EXPECT().InstanceStatus(gomock.Any(), cmachine.Name("666")).Return("running", nil)
 
-	instanceStatus, err := NewService(s.state).InstanceStatus(context.Background(), cmachine.ID("666"))
+	instanceStatus, err := NewService(s.state).InstanceStatus(context.Background(), cmachine.Name("666"))
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(instanceStatus, gc.Equals, "running")
 }
@@ -187,9 +187,9 @@ func (s *serviceSuite) TestInstanceStatusError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	rErr := errors.New("boom")
-	s.state.EXPECT().InstanceStatus(gomock.Any(), cmachine.ID("666")).Return("", rErr)
+	s.state.EXPECT().InstanceStatus(gomock.Any(), cmachine.Name("666")).Return("", rErr)
 
-	instanceStatus, err := NewService(s.state).InstanceStatus(context.Background(), cmachine.ID("666"))
+	instanceStatus, err := NewService(s.state).InstanceStatus(context.Background(), cmachine.Name("666"))
 	c.Check(err, jc.ErrorIs, rErr)
 	c.Check(instanceStatus, gc.Equals, "")
 }

--- a/domain/machine/service/service_test.go
+++ b/domain/machine/service/service_test.go
@@ -28,7 +28,7 @@ func (s *serviceSuite) setupMocks(c *gc.C) *gomock.Controller {
 	return ctrl
 }
 
-func (s *serviceSuite) TestUpdateSuccess(c *gc.C) {
+func (s *serviceSuite) TestCreateMachineSuccess(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	s.state.EXPECT().CreateMachine(gomock.Any(), "666", gomock.Any(), gomock.Any()).Return(nil)
@@ -37,7 +37,9 @@ func (s *serviceSuite) TestUpdateSuccess(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *serviceSuite) TestUpdateError(c *gc.C) {
+// TestCreateError asserts that an error coming from the state layer is
+// preserved, passed over to the service layer to be maintained there.
+func (s *serviceSuite) TestCreateMachineError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	rErr := errors.New("boom")
@@ -57,6 +59,8 @@ func (s *serviceSuite) TestDeleteMachineSuccess(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
+// TestDeleteMachineError asserts that an error coming from the state layer is
+// preserved, passed over to the service layer to be maintained there.
 func (s *serviceSuite) TestDeleteMachineError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
@@ -79,6 +83,8 @@ func (s *serviceSuite) TestGetLifeSuccess(c *gc.C) {
 	c.Assert(l, gc.Equals, &life)
 }
 
+// TestGetLifeError asserts that an error coming from the state layer is
+// preserved, passed over to the service layer to be maintained there.
 func (s *serviceSuite) TestGetLifeError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
@@ -97,10 +103,12 @@ func (s *serviceSuite) TestListAllMachinesSuccess(c *gc.C) {
 	s.state.EXPECT().ListAllMachines(gomock.Any()).Return([]string{"666"}, nil)
 
 	machines, err := NewService(s.state).ListAllMachines(context.Background())
-	c.Assert(err, jc.ErrorIsNil)
+	c.Check(err, jc.ErrorIsNil)
 	c.Assert(machines, gc.DeepEquals, []string{"666"})
 }
 
+// TestListAllMachinesError asserts that an error coming from the state layer is
+// preserved, passed over to the service layer to be maintained there.
 func (s *serviceSuite) TestListAllMachinesError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
@@ -109,7 +117,7 @@ func (s *serviceSuite) TestListAllMachinesError(c *gc.C) {
 
 	machines, err := NewService(s.state).ListAllMachines(context.Background())
 	c.Check(err, jc.ErrorIs, rErr)
-	c.Assert(machines, gc.IsNil)
+	c.Check(machines, gc.IsNil)
 }
 
 func (s *serviceSuite) TestInstanceIdSuccess(c *gc.C) {
@@ -118,10 +126,12 @@ func (s *serviceSuite) TestInstanceIdSuccess(c *gc.C) {
 	s.state.EXPECT().InstanceId(gomock.Any(), "666").Return("123", nil)
 
 	instanceId, err := NewService(s.state).InstanceId(context.Background(), "666")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(instanceId, gc.Equals, "123")
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(instanceId, gc.Equals, "123")
 }
 
+// TestInstanceIdError asserts that an error coming from the state layer is
+// preserved, passed over to the service layer to be maintained there.
 func (s *serviceSuite) TestInstanceIdError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
@@ -130,7 +140,7 @@ func (s *serviceSuite) TestInstanceIdError(c *gc.C) {
 
 	instanceId, err := NewService(s.state).InstanceId(context.Background(), "666")
 	c.Check(err, jc.ErrorIs, rErr)
-	c.Assert(instanceId, gc.Equals, "")
+	c.Check(instanceId, gc.Equals, "")
 }
 
 func (s *serviceSuite) TestInstanceStatusSuccess(c *gc.C) {
@@ -139,10 +149,12 @@ func (s *serviceSuite) TestInstanceStatusSuccess(c *gc.C) {
 	s.state.EXPECT().InstanceStatus(gomock.Any(), "666").Return("running", nil)
 
 	instanceStatus, err := NewService(s.state).InstanceStatus(context.Background(), "666")
-	c.Assert(err, jc.ErrorIsNil)
+	c.Check(err, jc.ErrorIsNil)
 	c.Assert(instanceStatus, gc.Equals, "running")
 }
 
+// TestInstanceStatusError asserts that an error coming from the state layer is
+// preserved, passed over to the service layer to be maintained there.
 func (s *serviceSuite) TestInstanceStatusError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
@@ -151,5 +163,5 @@ func (s *serviceSuite) TestInstanceStatusError(c *gc.C) {
 
 	instanceStatus, err := NewService(s.state).InstanceStatus(context.Background(), "666")
 	c.Check(err, jc.ErrorIs, rErr)
-	c.Assert(instanceStatus, gc.Equals, "")
+	c.Check(instanceStatus, gc.Equals, "")
 }

--- a/domain/machine/state/machine_cloud_instance.go
+++ b/domain/machine/state/machine_cloud_instance.go
@@ -159,12 +159,12 @@ func (st *State) InstanceId(ctx context.Context, machineName machine.Name) (stri
 		return "", errors.Trace(err)
 	}
 
-	machineIDParam := sqlair.M{"machine_name": machineName}
+	machineIDParam := sqlair.M{"name": machineName}
 	query := `
 SELECT instance_id AS &instanceID.*
 FROM machine AS m
     JOIN machine_cloud_instance AS mci ON m.uuid = mci.machine_uuid
-WHERE m.machine_name = $M.machine_name;
+WHERE m.name = $M.name;
 `
 	queryStmt, err := st.Prepare(query, machineIDParam, instanceID{})
 	if err != nil {

--- a/domain/machine/state/machine_cloud_instance.go
+++ b/domain/machine/state/machine_cloud_instance.go
@@ -11,7 +11,7 @@ import (
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/core/instance"
-	coremachine "github.com/juju/juju/core/machine"
+	"github.com/juju/juju/core/machine"
 	"github.com/juju/juju/domain"
 	machineerrors "github.com/juju/juju/domain/machine/errors"
 )
@@ -153,7 +153,7 @@ WHERE machine_uuid=$instanceTag.machine_uuid
 
 // InstanceId returns the cloud specific instance id for this machine.
 // If the machine is not provisioned, it returns a NotProvisionedError.
-func (st *State) InstanceId(ctx context.Context, machineId coremachine.ID) (string, error) {
+func (st *State) InstanceId(ctx context.Context, machineId machine.ID) (string, error) {
 	db, err := st.DB()
 	if err != nil {
 		return "", errors.Trace(err)
@@ -163,10 +163,10 @@ func (st *State) InstanceId(ctx context.Context, machineId coremachine.ID) (stri
 	query := `
 SELECT instance_id AS &instanceID.*
 FROM machine AS m
-         JOIN machine_cloud_instance AS mci ON m.uuid = mci.machine_uuid
+    JOIN machine_cloud_instance AS mci ON m.uuid = mci.machine_uuid
 WHERE m.machine_id = $M.machine_id;
 `
-	queryStmt, err := st.Prepare(query, sqlair.M{}, instanceID{})
+	queryStmt, err := st.Prepare(query, machineIDParam, instanceID{})
 	if err != nil {
 		return "", errors.Trace(err)
 	}
@@ -194,8 +194,8 @@ WHERE m.machine_id = $M.machine_id;
 // InstanceStatus returns the cloud specific instance status for this
 // machine.
 // If the machine is not provisioned, it returns a NotProvisionedError.
-func (st *State) InstanceStatus(ctx context.Context, machineId coremachine.ID) (string, error) {
+func (st *State) InstanceStatus(ctx context.Context, machineId machine.ID) (string, error) {
 	// TODO(cderici): Implementation for this is deferred until the design for
 	// the domain entity statuses on dqlite is finalized.
-	return "", errors.NotImplemented
+	return "running", nil
 }

--- a/domain/machine/state/machine_cloud_instance.go
+++ b/domain/machine/state/machine_cloud_instance.go
@@ -174,9 +174,6 @@ WHERE m.machine_id = $M.machine_id;
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		result := instanceID{}
 		err := tx.Query(ctx, queryStmt, machineIDParam).Get(&result)
-		if errors.Is(err, sqlair.ErrNoRows) {
-			return errors.Annotatef(machineerrors.NotProvisioned, "machine id: %q", machineId)
-		}
 		if err != nil {
 			return errors.Annotatef(err, "querying instance id for machine %q", machineId)
 		}
@@ -185,6 +182,9 @@ WHERE m.machine_id = $M.machine_id;
 		return nil
 	})
 	if err != nil {
+		if errors.Is(err, sqlair.ErrNoRows) {
+			return "", errors.Annotatef(machineerrors.NotProvisioned, "machine id: %q", machineId)
+		}
 		return "", errors.Trace(err)
 	}
 	return instanceId, nil

--- a/domain/machine/state/machine_cloud_instance.go
+++ b/domain/machine/state/machine_cloud_instance.go
@@ -188,3 +188,12 @@ WHERE m.machine_id = $M.machine_id;
 	}
 	return instanceId, nil
 }
+
+// InstanceStatus returns the provider specific instance status for this
+// machine.
+// If the machine is not provisioned, it returns a NotProvisionedError.
+func (st *State) InstanceStatus(ctx context.Context, machineId string) (string, error) {
+	// TODO(cderici): Implementation for this is deferred until the design for
+	// the domain entity statuses on dqlite is finalized.
+	return "", nil
+}

--- a/domain/machine/state/machine_cloud_instance.go
+++ b/domain/machine/state/machine_cloud_instance.go
@@ -150,7 +150,7 @@ WHERE machine_uuid=$instanceTag.machine_uuid
 	})
 }
 
-// InstanceId returns the provider specific instance id for this machine.
+// InstanceId returns the cloud specific instance id for this machine.
 // If the machine is not provisioned, it returns a NotProvisionedError.
 func (st *State) InstanceId(ctx context.Context, machineId string) (string, error) {
 	db, err := st.DB()
@@ -162,7 +162,7 @@ func (st *State) InstanceId(ctx context.Context, machineId string) (string, erro
 	query := `
 SELECT instance_id AS &instanceID.*
 FROM machine AS m
-		JOIN machine_cloud_instance AS mci ON m.uuid = mci.machine_uuid
+         JOIN machine_cloud_instance AS mci ON m.uuid = mci.machine_uuid
 WHERE m.machine_id = $M.machine_id;
 `
 	queryStmt, err := st.Prepare(query, sqlair.M{}, instanceID{})
@@ -190,11 +190,11 @@ WHERE m.machine_id = $M.machine_id;
 	return instanceId, nil
 }
 
-// InstanceStatus returns the provider specific instance status for this
+// InstanceStatus returns the cloud specific instance status for this
 // machine.
 // If the machine is not provisioned, it returns a NotProvisionedError.
 func (st *State) InstanceStatus(ctx context.Context, machineId string) (string, error) {
 	// TODO(cderici): Implementation for this is deferred until the design for
 	// the domain entity statuses on dqlite is finalized.
-	return "", nil
+	return "", errors.NotImplemented
 }

--- a/domain/machine/state/machine_cloud_instance.go
+++ b/domain/machine/state/machine_cloud_instance.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/core/instance"
+	coremachine "github.com/juju/juju/core/machine"
 	"github.com/juju/juju/domain"
 	machineerrors "github.com/juju/juju/domain/machine/errors"
 )
@@ -152,7 +153,7 @@ WHERE machine_uuid=$instanceTag.machine_uuid
 
 // InstanceId returns the cloud specific instance id for this machine.
 // If the machine is not provisioned, it returns a NotProvisionedError.
-func (st *State) InstanceId(ctx context.Context, machineId string) (string, error) {
+func (st *State) InstanceId(ctx context.Context, machineId coremachine.ID) (string, error) {
 	db, err := st.DB()
 	if err != nil {
 		return "", errors.Trace(err)
@@ -193,7 +194,7 @@ WHERE m.machine_id = $M.machine_id;
 // InstanceStatus returns the cloud specific instance status for this
 // machine.
 // If the machine is not provisioned, it returns a NotProvisionedError.
-func (st *State) InstanceStatus(ctx context.Context, machineId string) (string, error) {
+func (st *State) InstanceStatus(ctx context.Context, machineId coremachine.ID) (string, error) {
 	// TODO(cderici): Implementation for this is deferred until the design for
 	// the domain entity statuses on dqlite is finalized.
 	return "", errors.NotImplemented

--- a/domain/machine/state/machine_cloud_instance_test.go
+++ b/domain/machine/state/machine_cloud_instance_test.go
@@ -20,7 +20,7 @@ func (s *stateSuite) TestGetHardwareCharacteristics(c *gc.C) {
 	err := s.state.CreateMachine(context.Background(), "42", "", "")
 	c.Assert(err, jc.ErrorIsNil)
 	var machineUUID string
-	row := db.QueryRowContext(context.Background(), "SELECT uuid FROM machine WHERE machine_name='42'")
+	row := db.QueryRowContext(context.Background(), "SELECT uuid FROM machine WHERE name='42'")
 	c.Assert(row.Err(), jc.ErrorIsNil)
 	err = row.Scan(&machineUUID)
 	c.Assert(err, jc.ErrorIsNil)
@@ -65,7 +65,7 @@ func (s *stateSuite) TestSetInstanceData(c *gc.C) {
 	err := s.state.CreateMachine(context.Background(), "42", "", "")
 	c.Assert(err, jc.ErrorIsNil)
 	var machineUUID string
-	row := db.QueryRowContext(context.Background(), "SELECT uuid FROM machine WHERE machine_name='42'")
+	row := db.QueryRowContext(context.Background(), "SELECT uuid FROM machine WHERE name='42'")
 	c.Assert(row.Err(), jc.ErrorIsNil)
 	err = row.Scan(&machineUUID)
 	c.Assert(err, jc.ErrorIsNil)
@@ -140,7 +140,7 @@ func (s *stateSuite) TestDeleteInstanceData(c *gc.C) {
 	err := s.state.CreateMachine(context.Background(), "42", "", "")
 	c.Assert(err, jc.ErrorIsNil)
 	var machineUUID string
-	row := db.QueryRowContext(context.Background(), "SELECT uuid FROM machine WHERE machine_name='42'")
+	row := db.QueryRowContext(context.Background(), "SELECT uuid FROM machine WHERE name='42'")
 	c.Assert(row.Err(), jc.ErrorIsNil)
 	err = row.Scan(&machineUUID)
 	c.Assert(err, jc.ErrorIsNil)
@@ -201,7 +201,7 @@ func (s *stateSuite) TestInstanceIdSuccess(c *gc.C) {
 	err := s.state.CreateMachine(context.Background(), "666", "", "")
 	c.Assert(err, jc.ErrorIsNil)
 	var machineUUID string
-	row := db.QueryRowContext(context.Background(), "SELECT uuid FROM machine WHERE machine_name='666'")
+	row := db.QueryRowContext(context.Background(), "SELECT uuid FROM machine WHERE name='666'")
 	c.Assert(row.Err(), jc.ErrorIsNil)
 	err = row.Scan(&machineUUID)
 	c.Assert(err, jc.ErrorIsNil)

--- a/domain/machine/state/machine_cloud_instance_test.go
+++ b/domain/machine/state/machine_cloud_instance_test.go
@@ -118,6 +118,7 @@ func (s *stateSuite) TestSetInstanceData(c *gc.C) {
 	c.Check(*instanceData.VirtType, gc.Equals, "virtual-machine")
 
 	rows, err := db.QueryContext(context.Background(), "SELECT tag FROM instance_tag WHERE machine_uuid='"+machineUUID+"'")
+	c.Assert(err, jc.ErrorIsNil)
 	defer rows.Close()
 	c.Assert(err, jc.ErrorIsNil)
 	var instanceTags []string
@@ -170,11 +171,13 @@ func (s *stateSuite) TestDeleteInstanceData(c *gc.C) {
 
 	// Check that all rows've been deleted.
 	rows, err := db.QueryContext(context.Background(), "SELECT * FROM machine_cloud_instance WHERE instance_id='1'")
+	c.Assert(err, jc.ErrorIsNil)
 	defer rows.Close()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(rows.Err(), jc.ErrorIsNil)
 	c.Check(rows.Next(), jc.IsFalse)
 	rows, err = db.QueryContext(context.Background(), "SELECT * FROM instance_tag WHERE machine_uuid='"+machineUUID+"'")
+	c.Assert(err, jc.ErrorIsNil)
 	defer rows.Close()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(rows.Err(), jc.ErrorIsNil)

--- a/domain/machine/state/machine_cloud_instance_test.go
+++ b/domain/machine/state/machine_cloud_instance_test.go
@@ -200,7 +200,7 @@ func (s *stateSuite) TestInstanceIdSuccess(c *gc.C) {
 	db := s.DB()
 
 	// Create a reference machine.
-	err := s.state.UpsertMachine(context.Background(), "666")
+	err := s.state.CreateMachine(context.Background(), "666", "", "")
 	c.Assert(err, jc.ErrorIsNil)
 	var machineUUID string
 	row := db.QueryRowContext(context.Background(), "SELECT uuid FROM machine WHERE machine_id='666'")
@@ -235,7 +235,7 @@ func (s *stateSuite) TestInstanceIdSuccess(c *gc.C) {
 }
 
 func (s *stateSuite) TestInstanceIdError(c *gc.C) {
-	err := s.state.UpsertMachine(context.Background(), "666")
+	err := s.state.CreateMachine(context.Background(), "666", "", "")
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, err = s.state.InstanceId(context.Background(), "666")

--- a/domain/machine/state/machine_cloud_instance_test.go
+++ b/domain/machine/state/machine_cloud_instance_test.go
@@ -192,3 +192,49 @@ func uintptr(u uint64) *uint64 {
 func strsliceptr(s []string) *[]string {
 	return &s
 }
+
+func (s *stateSuite) TestInstanceIdSuccess(c *gc.C) {
+	db := s.DB()
+
+	// Create a reference machine.
+	err := s.state.UpsertMachine(context.Background(), "666")
+	c.Assert(err, jc.ErrorIsNil)
+	var machineUUID string
+	row := db.QueryRowContext(context.Background(), "SELECT uuid FROM machine WHERE machine_id='666'")
+	c.Assert(row.Err(), jc.ErrorIsNil)
+	err = row.Scan(&machineUUID)
+	c.Assert(err, jc.ErrorIsNil)
+	// Add a reference AZ.
+	_, err = db.ExecContext(context.Background(), "INSERT INTO availability_zone VALUES('az-1', 'az1')")
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.state.SetMachineCloudInstance(
+		context.Background(),
+		machineUUID,
+		instance.Id("123"),
+		instance.HardwareCharacteristics{
+			Arch:             strptr("arm64"),
+			Mem:              uintptr(1024),
+			RootDisk:         uintptr(256),
+			RootDiskSource:   strptr("/test"),
+			CpuCores:         uintptr(4),
+			CpuPower:         uintptr(75),
+			Tags:             strsliceptr([]string{"tag1", "tag2"}),
+			AvailabilityZone: strptr("az-1"),
+			VirtType:         strptr("virtual-machine"),
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+
+	instanceId, err := s.state.InstanceId(context.Background(), "666")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(instanceId, gc.Equals, "123")
+}
+
+func (s *stateSuite) TestInstanceIdError(c *gc.C) {
+	err := s.state.UpsertMachine(context.Background(), "666")
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = s.state.InstanceId(context.Background(), "666")
+	c.Assert(err, gc.ErrorMatches, "machine id: \"666\": machine not provisioned")
+}

--- a/domain/machine/state/machine_cloud_instance_test.go
+++ b/domain/machine/state/machine_cloud_instance_test.go
@@ -20,7 +20,7 @@ func (s *stateSuite) TestGetHardwareCharacteristics(c *gc.C) {
 	err := s.state.CreateMachine(context.Background(), "42", "", "")
 	c.Assert(err, jc.ErrorIsNil)
 	var machineUUID string
-	row := db.QueryRowContext(context.Background(), "SELECT uuid FROM machine WHERE machine_id='42'")
+	row := db.QueryRowContext(context.Background(), "SELECT uuid FROM machine WHERE machine_name='42'")
 	c.Assert(row.Err(), jc.ErrorIsNil)
 	err = row.Scan(&machineUUID)
 	c.Assert(err, jc.ErrorIsNil)
@@ -65,7 +65,7 @@ func (s *stateSuite) TestSetInstanceData(c *gc.C) {
 	err := s.state.CreateMachine(context.Background(), "42", "", "")
 	c.Assert(err, jc.ErrorIsNil)
 	var machineUUID string
-	row := db.QueryRowContext(context.Background(), "SELECT uuid FROM machine WHERE machine_id='42'")
+	row := db.QueryRowContext(context.Background(), "SELECT uuid FROM machine WHERE machine_name='42'")
 	c.Assert(row.Err(), jc.ErrorIsNil)
 	err = row.Scan(&machineUUID)
 	c.Assert(err, jc.ErrorIsNil)
@@ -140,7 +140,7 @@ func (s *stateSuite) TestDeleteInstanceData(c *gc.C) {
 	err := s.state.CreateMachine(context.Background(), "42", "", "")
 	c.Assert(err, jc.ErrorIsNil)
 	var machineUUID string
-	row := db.QueryRowContext(context.Background(), "SELECT uuid FROM machine WHERE machine_id='42'")
+	row := db.QueryRowContext(context.Background(), "SELECT uuid FROM machine WHERE machine_name='42'")
 	c.Assert(row.Err(), jc.ErrorIsNil)
 	err = row.Scan(&machineUUID)
 	c.Assert(err, jc.ErrorIsNil)
@@ -201,7 +201,7 @@ func (s *stateSuite) TestInstanceIdSuccess(c *gc.C) {
 	err := s.state.CreateMachine(context.Background(), "666", "", "")
 	c.Assert(err, jc.ErrorIsNil)
 	var machineUUID string
-	row := db.QueryRowContext(context.Background(), "SELECT uuid FROM machine WHERE machine_id='666'")
+	row := db.QueryRowContext(context.Background(), "SELECT uuid FROM machine WHERE machine_name='666'")
 	c.Assert(row.Err(), jc.ErrorIsNil)
 	err = row.Scan(&machineUUID)
 	c.Assert(err, jc.ErrorIsNil)

--- a/domain/machine/state/state.go
+++ b/domain/machine/state/state.go
@@ -40,16 +40,16 @@ func (st *State) CreateMachine(ctx context.Context, machineName machine.Name, no
 		return errors.Trace(err)
 	}
 
-	machineNameParam := sqlair.M{"machine_name": machineName}
-	query := `SELECT &M.uuid FROM machine WHERE machine_name = $M.machine_name`
+	machineNameParam := sqlair.M{"name": machineName}
+	query := `SELECT &M.uuid FROM machine WHERE name = $M.name`
 	queryStmt, err := st.Prepare(query, machineNameParam)
 	if err != nil {
 		return errors.Trace(err)
 	}
 
 	createMachine := `
-INSERT INTO machine (uuid, net_node_uuid, machine_name, life_id)
-VALUES ($M.machine_uuid, $M.net_node_uuid, $M.machine_name, $M.life_id)
+INSERT INTO machine (uuid, net_node_uuid, name, life_id)
+VALUES ($M.machine_uuid, $M.net_node_uuid, $M.name, $M.life_id)
 `
 	createMachineStmt, err := st.Prepare(createMachine, machineNameParam)
 	if err != nil {
@@ -65,7 +65,7 @@ VALUES ($M.machine_uuid, $M.net_node_uuid, $M.machine_name, $M.life_id)
 	createParams := sqlair.M{
 		"machine_uuid":  machineUUID,
 		"net_node_uuid": nodeUUID,
-		"machine_name":  machineName,
+		"name":          machineName,
 		"life_id":       life.Alive,
 	}
 
@@ -101,15 +101,15 @@ func (st *State) DeleteMachine(ctx context.Context, machineName machine.Name) er
 		return errors.Trace(err)
 	}
 
-	machineNameParam := sqlair.M{"machine_name": machineName}
+	machineNameParam := sqlair.M{"name": machineName}
 
-	queryMachine := `SELECT uuid AS &machineUUID.* FROM machine WHERE machine_name = $M.machine_name`
+	queryMachine := `SELECT uuid AS &machineUUID.* FROM machine WHERE name = $M.name`
 	queryMachineStmt, err := st.Prepare(queryMachine, machineNameParam, machineUUID{})
 	if err != nil {
 		return errors.Trace(err)
 	}
 
-	deleteMachine := `DELETE FROM machine WHERE machine_name = $M.machine_name`
+	deleteMachine := `DELETE FROM machine WHERE name = $M.name`
 	deleteMachineStmt, err := st.Prepare(deleteMachine, machineNameParam)
 	if err != nil {
 		return errors.Trace(err)
@@ -117,7 +117,7 @@ func (st *State) DeleteMachine(ctx context.Context, machineName machine.Name) er
 
 	deleteNode := `
 DELETE FROM net_node WHERE uuid IN
-(SELECT net_node_uuid FROM machine WHERE machine_name = $M.machine_name) 
+(SELECT net_node_uuid FROM machine WHERE name = $M.name) 
 `
 	deleteNodeStmt, err := st.Prepare(deleteNode, machineNameParam)
 	if err != nil {
@@ -156,7 +156,7 @@ DELETE FROM net_node WHERE uuid IN
 // InitialWatchStatement returns the table and the initial watch statement
 // for the machines.
 func (s *State) InitialWatchStatement() (string, string) {
-	return "machine", "SELECT machine_name FROM machine"
+	return "machine", "SELECT name FROM machine"
 }
 
 // GetMachineLife returns the life status of the specified machine.
@@ -166,8 +166,8 @@ func (st *State) GetMachineLife(ctx context.Context, machineName machine.Name) (
 		return nil, errors.Trace(err)
 	}
 
-	machineNameParam := sqlair.M{"machine_name": machineName}
-	queryForLife := `SELECT life_id as &machineLife.life_id FROM machine WHERE machine_name = $M.machine_name`
+	machineNameParam := sqlair.M{"name": machineName}
+	queryForLife := `SELECT life_id as &machineLife.life_id FROM machine WHERE name = $M.name`
 	lifeStmt, err := st.Prepare(queryForLife, machineNameParam, machineLife{})
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -200,7 +200,7 @@ func (st *State) AllMachineNames(ctx context.Context) ([]machine.Name, error) {
 		return nil, errors.Trace(err)
 	}
 
-	query := `SELECT machine_name AS &machineName.* FROM machine`
+	query := `SELECT name AS &machineName.* FROM machine`
 	queryStmt, err := st.Prepare(query, machineName{})
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/domain/machine/state/state.go
+++ b/domain/machine/state/state.go
@@ -11,7 +11,7 @@ import (
 
 	coredb "github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/logger"
-	coremachine "github.com/juju/juju/core/machine"
+	"github.com/juju/juju/core/machine"
 	"github.com/juju/juju/domain"
 	blockdevice "github.com/juju/juju/domain/blockdevice/state"
 	"github.com/juju/juju/domain/life"
@@ -33,7 +33,7 @@ func NewState(factory coredb.TxnRunnerFactory, logger logger.Logger) *State {
 
 // CreateMachine creates or updates the specified machine.
 // TODO - this just creates a minimal row for now.
-func (st *State) CreateMachine(ctx context.Context, machineId coremachine.ID, nodeUUID, machineUUID string) error {
+func (st *State) CreateMachine(ctx context.Context, machineId machine.ID, nodeUUID, machineUUID string) error {
 	db, err := st.DB()
 	if err != nil {
 		return errors.Trace(err)
@@ -93,7 +93,7 @@ VALUES ($M.machine_uuid, $M.net_node_uuid, $M.machine_id, $M.life_id)
 
 // DeleteMachine deletes the specified machine and any dependent child records.
 // TODO - this just deals with child block devices for now.
-func (st *State) DeleteMachine(ctx context.Context, machineId coremachine.ID) error {
+func (st *State) DeleteMachine(ctx context.Context, machineId machine.ID) error {
 	db, err := st.DB()
 	if err != nil {
 		return errors.Trace(err)
@@ -157,7 +157,7 @@ func (s *State) InitialWatchStatement() (string, string) {
 }
 
 // GetMachineLife returns the life status of the specified machine.
-func (st *State) GetMachineLife(ctx context.Context, machineId coremachine.ID) (*life.Life, error) {
+func (st *State) GetMachineLife(ctx context.Context, machineId machine.ID) (*life.Life, error) {
 	db, err := st.DB()
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -190,7 +190,7 @@ func (st *State) GetMachineLife(ctx context.Context, machineId coremachine.ID) (
 }
 
 // ListAllMachines retrieves the ids of all machines in the model.
-func (st *State) ListAllMachines(ctx context.Context) ([]coremachine.ID, error) {
+func (st *State) ListAllMachines(ctx context.Context) ([]machine.ID, error) {
 	db, err := st.DB()
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -210,9 +210,9 @@ func (st *State) ListAllMachines(ctx context.Context) ([]coremachine.ID, error) 
 		return nil, errors.Annotate(err, "querying all machines")
 	}
 
-	var machineIds []coremachine.ID
+	var machineIds []machine.ID
 	for _, result := range results {
-		machineIds = append(machineIds, coremachine.ID(result.ID))
+		machineIds = append(machineIds, machine.ID(result.ID))
 	}
 	return machineIds, nil
 }

--- a/domain/machine/state/state.go
+++ b/domain/machine/state/state.go
@@ -186,8 +186,8 @@ func (st *State) GetMachineLife(ctx context.Context, machineId string) (*life.Li
 	return &lifeResult, errors.Annotatef(err, "getting life status for machines %q", machineId)
 }
 
-// AllMachines retrieves the ids of all machines in the model.
-func (st *State) AllMachines(ctx context.Context) ([]string, error) {
+// ListAllMachines retrieves the ids of all machines in the model.
+func (st *State) ListAllMachines(ctx context.Context) ([]string, error) {
 	db, err := st.DB()
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/domain/machine/state/state.go
+++ b/domain/machine/state/state.go
@@ -7,6 +7,7 @@ import (
 	"context"
 
 	"github.com/canonical/sqlair"
+	"github.com/juju/collections/transform"
 	"github.com/juju/errors"
 
 	coredb "github.com/juju/juju/core/database"
@@ -189,8 +190,8 @@ func (st *State) GetMachineLife(ctx context.Context, machineId machine.ID) (*lif
 	return &lifeResult, errors.Annotatef(err, "getting life status for machines %q", machineId)
 }
 
-// ListAllMachines retrieves the ids of all machines in the model.
-func (st *State) ListAllMachines(ctx context.Context) ([]machine.ID, error) {
+// AllMachineNames retrieves the ids of all machines in the model.
+func (st *State) AllMachineNames(ctx context.Context) ([]machine.ID, error) {
 	db, err := st.DB()
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -210,9 +211,8 @@ func (st *State) ListAllMachines(ctx context.Context) ([]machine.ID, error) {
 		return nil, errors.Annotate(err, "querying all machines")
 	}
 
-	var machineIds []machine.ID
-	for _, result := range results {
-		machineIds = append(machineIds, machine.ID(result.ID))
-	}
+	// Transform the results ([]machineID) into a slice of machine.ID.
+	machineIds := transform.Slice[machineID, machine.ID](results, func(r machineID) machine.ID { return machine.ID(r.ID) })
+
 	return machineIds, nil
 }

--- a/domain/machine/state/state.go
+++ b/domain/machine/state/state.go
@@ -11,6 +11,7 @@ import (
 
 	coredb "github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/logger"
+	coremachine "github.com/juju/juju/core/machine"
 	"github.com/juju/juju/domain"
 	blockdevice "github.com/juju/juju/domain/blockdevice/state"
 	"github.com/juju/juju/domain/life"
@@ -32,7 +33,7 @@ func NewState(factory coredb.TxnRunnerFactory, logger logger.Logger) *State {
 
 // CreateMachine creates or updates the specified machine.
 // TODO - this just creates a minimal row for now.
-func (st *State) CreateMachine(ctx context.Context, machineId, nodeUUID, machineUUID string) error {
+func (st *State) CreateMachine(ctx context.Context, machineId coremachine.ID, nodeUUID, machineUUID string) error {
 	db, err := st.DB()
 	if err != nil {
 		return errors.Trace(err)
@@ -92,7 +93,7 @@ VALUES ($M.machine_uuid, $M.net_node_uuid, $M.machine_id, $M.life_id)
 
 // DeleteMachine deletes the specified machine and any dependent child records.
 // TODO - this just deals with child block devices for now.
-func (st *State) DeleteMachine(ctx context.Context, machineId string) error {
+func (st *State) DeleteMachine(ctx context.Context, machineId coremachine.ID) error {
 	db, err := st.DB()
 	if err != nil {
 		return errors.Trace(err)
@@ -156,7 +157,7 @@ func (s *State) InitialWatchStatement() (string, string) {
 }
 
 // GetMachineLife returns the life status of the specified machine.
-func (st *State) GetMachineLife(ctx context.Context, machineId string) (*life.Life, error) {
+func (st *State) GetMachineLife(ctx context.Context, machineId coremachine.ID) (*life.Life, error) {
 	db, err := st.DB()
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -189,7 +190,7 @@ func (st *State) GetMachineLife(ctx context.Context, machineId string) (*life.Li
 }
 
 // ListAllMachines retrieves the ids of all machines in the model.
-func (st *State) ListAllMachines(ctx context.Context) ([]string, error) {
+func (st *State) ListAllMachines(ctx context.Context) ([]coremachine.ID, error) {
 	db, err := st.DB()
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -209,9 +210,9 @@ func (st *State) ListAllMachines(ctx context.Context) ([]string, error) {
 		return nil, errors.Annotate(err, "querying all machines")
 	}
 
-	var machineIds []string
+	var machineIds []coremachine.ID
 	for _, result := range results {
-		machineIds = append(machineIds, result.ID)
+		machineIds = append(machineIds, coremachine.ID(result.ID))
 	}
 	return machineIds, nil
 }

--- a/domain/machine/state/state_test.go
+++ b/domain/machine/state/state_test.go
@@ -6,6 +6,7 @@ package state
 import (
 	"context"
 	"database/sql"
+	"sort"
 
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
@@ -46,7 +47,7 @@ func (s *stateSuite) TestCreateMachine(c *gc.C) {
 		}
 		return nil
 	})
-	c.Assert(err, jc.ErrorIsNil)
+	c.Check(err, jc.ErrorIsNil)
 	c.Assert(machineID, gc.Equals, "666")
 }
 
@@ -64,7 +65,7 @@ func (s *stateSuite) TestUpdateMachine(c *gc.C) {
 		}
 		return nil
 	})
-	c.Assert(err, jc.ErrorIsNil)
+	c.Check(err, jc.ErrorIsNil)
 	c.Assert(machineID, gc.Equals, "666")
 }
 
@@ -89,7 +90,7 @@ func (s *stateSuite) TestDeleteMachine(c *gc.C) {
 	s.insertBlockDevice(c, bd, bdUUID, "666")
 
 	err = s.state.DeleteMachine(context.Background(), "666")
-	c.Assert(err, jc.ErrorIsNil)
+	c.Check(err, jc.ErrorIsNil)
 
 	var machineCount int
 	err = s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
@@ -99,7 +100,7 @@ func (s *stateSuite) TestDeleteMachine(c *gc.C) {
 		}
 		return nil
 	})
-	c.Assert(err, jc.ErrorIsNil)
+	c.Check(err, jc.ErrorIsNil)
 	c.Assert(machineCount, gc.Equals, 0)
 }
 
@@ -132,7 +133,7 @@ func (s *stateSuite) TestGetMachineLifeSuccess(c *gc.C) {
 
 	obtainedLife, err := s.state.GetMachineLife(context.Background(), "666")
 	expectedLife := life.Alive
-	c.Assert(err, jc.ErrorIsNil)
+	c.Check(err, jc.ErrorIsNil)
 	c.Assert(*obtainedLife, gc.Equals, expectedLife)
 }
 
@@ -150,11 +151,15 @@ func (s *stateSuite) TestListAllMachines(c *gc.C) {
 
 	machines, err := s.state.ListAllMachines(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(machines, gc.DeepEquals, []string{"666", "667"})
+
+	expectedMachines := []string{"666", "667"}
+	sort.Strings(machines)
+	sort.Strings(expectedMachines)
+	c.Assert(machines, gc.DeepEquals, expectedMachines)
 }
 
 func (s *stateSuite) TestListAllMachinesEmpty(c *gc.C) {
 	machines, err := s.state.ListAllMachines(context.Background())
-	c.Assert(err, jc.ErrorIsNil)
+	c.Check(err, jc.ErrorIsNil)
 	c.Assert(machines, gc.HasLen, 0)
 }

--- a/domain/machine/state/state_test.go
+++ b/domain/machine/state/state_test.go
@@ -140,3 +140,21 @@ func (s *stateSuite) TestGetMachineLifeNotFound(c *gc.C) {
 	_, err := s.state.GetMachineLife(context.Background(), "666")
 	c.Assert(errors.IsNotFound(err), jc.IsTrue)
 }
+
+func (s *stateSuite) TestListAllMachines(c *gc.C) {
+	err := s.state.UpsertMachine(context.Background(), "666")
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.state.UpsertMachine(context.Background(), "667")
+	c.Assert(err, jc.ErrorIsNil)
+
+	machines, err := s.state.AllMachines(context.Background())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(machines, gc.DeepEquals, []string{"666", "667"})
+}
+
+func (s *stateSuite) TestListAllMachinesEmpty(c *gc.C) {
+	machines, err := s.state.AllMachines(context.Background())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(machines, gc.HasLen, 0)
+}

--- a/domain/machine/state/state_test.go
+++ b/domain/machine/state/state_test.go
@@ -153,9 +153,13 @@ func (s *stateSuite) TestListAllMachines(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	expectedMachines := []string{"666", "667"}
-	sort.Strings(machines)
+	ms := []string{}
+	for _, m := range machines {
+		ms = append(ms, m.String())
+	}
+	sort.Strings(ms)
 	sort.Strings(expectedMachines)
-	c.Assert(machines, gc.DeepEquals, expectedMachines)
+	c.Assert(ms, gc.DeepEquals, expectedMachines)
 }
 
 func (s *stateSuite) TestListAllMachinesEmpty(c *gc.C) {

--- a/domain/machine/state/state_test.go
+++ b/domain/machine/state/state_test.go
@@ -41,7 +41,7 @@ func (s *stateSuite) TestCreateMachine(c *gc.C) {
 		machineID string
 	)
 	err = s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
-		err := tx.QueryRowContext(ctx, "SELECT machine_id FROM machine").Scan(&machineID)
+		err := tx.QueryRowContext(ctx, "SELECT machine_name FROM machine").Scan(&machineID)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -59,7 +59,7 @@ func (s *stateSuite) TestUpdateMachine(c *gc.C) {
 
 	var machineID string
 	err = s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
-		err := tx.QueryRowContext(ctx, "SELECT machine_id FROM machine").Scan(&machineID)
+		err := tx.QueryRowContext(ctx, "SELECT machine_name FROM machine").Scan(&machineID)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -94,7 +94,7 @@ func (s *stateSuite) TestDeleteMachine(c *gc.C) {
 
 	var machineCount int
 	err = s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
-		err := tx.QueryRowContext(ctx, "SELECT count(*) FROM machine WHERE machine_id=?", "666").Scan(&machineCount)
+		err := tx.QueryRowContext(ctx, "SELECT count(*) FROM machine WHERE machine_name=?", "666").Scan(&machineCount)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -113,7 +113,7 @@ func (s *stateSuite) insertBlockDevice(c *gc.C, bd blockdevice.BlockDevice, bloc
 	}
 	_, err := db.ExecContext(context.Background(), `
 INSERT INTO block_device (uuid, name, label, device_uuid, hardware_id, wwn, bus_address, serial_id, mount_point, filesystem_type_id, Size_mib, in_use, machine_uuid)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 2, ?, ?, (SELECT uuid FROM machine WHERE machine_id=?))
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 2, ?, ?, (SELECT uuid FROM machine WHERE machine_name=?))
 `, blockDeviceUUID, bd.DeviceName, bd.Label, bd.UUID, bd.HardwareId, bd.WWN, bd.BusAddress, bd.SerialId, bd.MountPoint, bd.SizeMiB, inUse, machineId)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/domain/machine/state/state_test.go
+++ b/domain/machine/state/state_test.go
@@ -149,7 +149,7 @@ func (s *stateSuite) TestListAllMachines(c *gc.C) {
 	err = s.state.CreateMachine(context.Background(), "667", "4", "2")
 	c.Assert(err, jc.ErrorIsNil)
 
-	machines, err := s.state.ListAllMachines(context.Background())
+	machines, err := s.state.AllMachineNames(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 
 	expectedMachines := []string{"666", "667"}
@@ -163,7 +163,7 @@ func (s *stateSuite) TestListAllMachines(c *gc.C) {
 }
 
 func (s *stateSuite) TestListAllMachinesEmpty(c *gc.C) {
-	machines, err := s.state.ListAllMachines(context.Background())
+	machines, err := s.state.AllMachineNames(context.Background())
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(machines, gc.HasLen, 0)
 }

--- a/domain/machine/state/state_test.go
+++ b/domain/machine/state/state_test.go
@@ -139,7 +139,7 @@ func (s *stateSuite) TestGetMachineLifeSuccess(c *gc.C) {
 
 func (s *stateSuite) TestGetMachineLifeNotFound(c *gc.C) {
 	_, err := s.state.GetMachineLife(context.Background(), "666")
-	c.Assert(errors.IsNotFound(err), jc.IsTrue)
+	c.Assert(err, jc.ErrorIs, errors.NotFound)
 }
 
 func (s *stateSuite) TestListAllMachines(c *gc.C) {

--- a/domain/machine/state/state_test.go
+++ b/domain/machine/state/state_test.go
@@ -148,13 +148,13 @@ func (s *stateSuite) TestListAllMachines(c *gc.C) {
 	err = s.state.UpsertMachine(context.Background(), "667")
 	c.Assert(err, jc.ErrorIsNil)
 
-	machines, err := s.state.AllMachines(context.Background())
+	machines, err := s.state.ListAllMachines(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(machines, gc.DeepEquals, []string{"666", "667"})
 }
 
 func (s *stateSuite) TestListAllMachinesEmpty(c *gc.C) {
-	machines, err := s.state.AllMachines(context.Background())
+	machines, err := s.state.ListAllMachines(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(machines, gc.HasLen, 0)
 }

--- a/domain/machine/state/state_test.go
+++ b/domain/machine/state/state_test.go
@@ -142,10 +142,10 @@ func (s *stateSuite) TestGetMachineLifeNotFound(c *gc.C) {
 }
 
 func (s *stateSuite) TestListAllMachines(c *gc.C) {
-	err := s.state.UpsertMachine(context.Background(), "666")
+	err := s.state.CreateMachine(context.Background(), "666", "3", "1")
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = s.state.UpsertMachine(context.Background(), "667")
+	err = s.state.CreateMachine(context.Background(), "667", "4", "2")
 	c.Assert(err, jc.ErrorIsNil)
 
 	machines, err := s.state.ListAllMachines(context.Background())

--- a/domain/machine/state/state_test.go
+++ b/domain/machine/state/state_test.go
@@ -41,7 +41,7 @@ func (s *stateSuite) TestCreateMachine(c *gc.C) {
 		machineID string
 	)
 	err = s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
-		err := tx.QueryRowContext(ctx, "SELECT machine_name FROM machine").Scan(&machineID)
+		err := tx.QueryRowContext(ctx, "SELECT name FROM machine").Scan(&machineID)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -59,7 +59,7 @@ func (s *stateSuite) TestUpdateMachine(c *gc.C) {
 
 	var machineID string
 	err = s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
-		err := tx.QueryRowContext(ctx, "SELECT machine_name FROM machine").Scan(&machineID)
+		err := tx.QueryRowContext(ctx, "SELECT name FROM machine").Scan(&machineID)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -94,7 +94,7 @@ func (s *stateSuite) TestDeleteMachine(c *gc.C) {
 
 	var machineCount int
 	err = s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
-		err := tx.QueryRowContext(ctx, "SELECT count(*) FROM machine WHERE machine_name=?", "666").Scan(&machineCount)
+		err := tx.QueryRowContext(ctx, "SELECT count(*) FROM machine WHERE name=?", "666").Scan(&machineCount)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -113,7 +113,7 @@ func (s *stateSuite) insertBlockDevice(c *gc.C, bd blockdevice.BlockDevice, bloc
 	}
 	_, err := db.ExecContext(context.Background(), `
 INSERT INTO block_device (uuid, name, label, device_uuid, hardware_id, wwn, bus_address, serial_id, mount_point, filesystem_type_id, Size_mib, in_use, machine_uuid)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 2, ?, ?, (SELECT uuid FROM machine WHERE machine_name=?))
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 2, ?, ?, (SELECT uuid FROM machine WHERE name=?))
 `, blockDeviceUUID, bd.DeviceName, bd.Label, bd.UUID, bd.HardwareId, bd.WWN, bd.BusAddress, bd.SerialId, bd.MountPoint, bd.SizeMiB, inUse, machineId)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/domain/machine/state/types.go
+++ b/domain/machine/state/types.go
@@ -65,3 +65,9 @@ type machineLife struct {
 type instanceID struct {
 	ID string `db:"instance_id"`
 }
+
+// machineID represents the struct to be used for the machine_id column within
+// the sqlair statements in the machine domain.
+type machineID struct {
+	ID string `db:"machine_id"`
+}

--- a/domain/machine/state/types.go
+++ b/domain/machine/state/types.go
@@ -59,3 +59,9 @@ func (d *instanceData) toHardwareCharacteristics() *instance.HardwareCharacteris
 type machineLife struct {
 	ID life.Life `db:"life_id"`
 }
+
+// instanceID represents the struct to be used for the insatnce_id column within
+// the sqlair statements in the machine domain.
+type instanceID struct {
+	ID string `db:"instance_id"`
+}

--- a/domain/machine/state/types.go
+++ b/domain/machine/state/types.go
@@ -66,10 +66,10 @@ type instanceID struct {
 	ID string `db:"instance_id"`
 }
 
-// machineName represents the struct to be used for the machine_name column
+// machineName represents the struct to be used for the name column
 // within the sqlair statements in the machine domain.
 type machineName struct {
-	Name string `db:"machine_name"`
+	Name string `db:"name"`
 }
 
 // machineUUID represents the struct to be used for the machine_uuid column

--- a/domain/machine/state/types.go
+++ b/domain/machine/state/types.go
@@ -66,8 +66,8 @@ type instanceID struct {
 	ID string `db:"instance_id"`
 }
 
-// machineID represents the struct to be used for the machine_id column within
-// the sqlair statements in the machine domain.
-type machineID struct {
-	ID string `db:"machine_id"`
+// machineName represents the struct to be used for the machine_name column
+// within the sqlair statements in the machine domain.
+type machineName struct {
+	Name string `db:"machine_name"`
 }

--- a/domain/machine/state/types.go
+++ b/domain/machine/state/types.go
@@ -71,3 +71,9 @@ type instanceID struct {
 type machineName struct {
 	Name string `db:"machine_name"`
 }
+
+// machineUUID represents the struct to be used for the machine_uuid column
+// within the sqlair statements in the machine domain.
+type machineUUID struct {
+	UUID string `db:"uuid"`
+}

--- a/domain/schema/model.go
+++ b/domain/schema/model.go
@@ -93,7 +93,7 @@ func ModelDDL() *schema.Schema {
 		triggers.ChangeLogTriggersForSecretRevision("uuid", tableSecretRevision),
 		triggers.ChangeLogTriggersForSecretReference("secret_id", tableSecretReference),
 		triggers.ChangeLogTriggersForSubnet("uuid", tableSubnet),
-		triggers.ChangeLogTriggersForMachine("machine_name", tableMachine),
+		triggers.ChangeLogTriggersForMachine("name", tableMachine),
 		triggers.ChangeLogTriggersForUserPublicSshKey("id", tableUserPublicSSHKey),
 	)
 

--- a/domain/schema/model.go
+++ b/domain/schema/model.go
@@ -93,7 +93,7 @@ func ModelDDL() *schema.Schema {
 		triggers.ChangeLogTriggersForSecretRevision("uuid", tableSecretRevision),
 		triggers.ChangeLogTriggersForSecretReference("secret_id", tableSecretReference),
 		triggers.ChangeLogTriggersForSubnet("uuid", tableSubnet),
-		triggers.ChangeLogTriggersForMachine("machine_id", tableMachine),
+		triggers.ChangeLogTriggersForMachine("machine_name", tableMachine),
 		triggers.ChangeLogTriggersForUserPublicSshKey("id", tableUserPublicSSHKey),
 	)
 

--- a/domain/schema/model/sql/0017-machine.sql
+++ b/domain/schema/model/sql/0017-machine.sql
@@ -1,6 +1,6 @@
 CREATE TABLE machine (
     uuid TEXT NOT NULL PRIMARY KEY,
-    machine_id TEXT NOT NULL,
+    machine_name TEXT NOT NULL,
     net_node_uuid TEXT NOT NULL,
     life_id INT NOT NULL,
     base TEXT,
@@ -21,8 +21,8 @@ CREATE TABLE machine (
     REFERENCES life (id)
 );
 
-CREATE UNIQUE INDEX idx_machine_id
-ON machine (machine_id);
+CREATE UNIQUE INDEX idx_machine_name
+ON machine (machine_name);
 
 CREATE UNIQUE INDEX idx_machine_net_node
 ON machine (net_node_uuid);

--- a/domain/schema/model/sql/0017-machine.sql
+++ b/domain/schema/model/sql/0017-machine.sql
@@ -1,6 +1,6 @@
 CREATE TABLE machine (
     uuid TEXT NOT NULL PRIMARY KEY,
-    machine_name TEXT NOT NULL,
+    name TEXT NOT NULL,
     net_node_uuid TEXT NOT NULL,
     life_id INT NOT NULL,
     base TEXT,
@@ -21,8 +21,8 @@ CREATE TABLE machine (
     REFERENCES life (id)
 );
 
-CREATE UNIQUE INDEX idx_machine_name
-ON machine (machine_name);
+CREATE UNIQUE INDEX idx_name
+ON machine (name);
 
 CREATE UNIQUE INDEX idx_machine_net_node
 ON machine (net_node_uuid);

--- a/domain/schema/model/triggers/machine-triggers.gen.go
+++ b/domain/schema/model/triggers/machine-triggers.gen.go
@@ -26,7 +26,7 @@ END;
 CREATE TRIGGER trg_log_machine_update
 AFTER UPDATE ON machine FOR EACH ROW
 WHEN 
-	NEW.machine_id != OLD.machine_id OR
+	NEW.machine_name != OLD.machine_name OR
 	NEW.net_node_uuid != OLD.net_node_uuid OR
 	NEW.life_id != OLD.life_id OR
 	(NEW.base != OLD.base OR (NEW.base IS NOT NULL AND OLD.base IS NULL) OR (NEW.base IS NULL AND OLD.base IS NOT NULL)) OR

--- a/domain/schema/model/triggers/machine-triggers.gen.go
+++ b/domain/schema/model/triggers/machine-triggers.gen.go
@@ -26,7 +26,7 @@ END;
 CREATE TRIGGER trg_log_machine_update
 AFTER UPDATE ON machine FOR EACH ROW
 WHEN 
-	NEW.machine_name != OLD.machine_name OR
+	NEW.name != OLD.name OR
 	NEW.net_node_uuid != OLD.net_node_uuid OR
 	NEW.life_id != OLD.life_id OR
 	(NEW.base != OLD.base OR (NEW.base IS NOT NULL AND OLD.base IS NULL) OR (NEW.base IS NULL AND OLD.base IS NOT NULL)) OR

--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -165,7 +165,7 @@ func (st *State) NeedsCleanup() (bool, error) {
 // MachineRemover deletes a machine from the dqlite database.
 // This allows us to initially weave some dqlite support into the cleanup workflow.
 type MachineRemover interface {
-	DeleteMachine(context.Context, machine.ID) error
+	DeleteMachine(context.Context, machine.Name) error
 }
 
 // UnitRemover deletes a unit from the dqlite database.
@@ -1474,7 +1474,7 @@ func (st *State) cleanupForceRemoveMachine(ctx context.Context, store objectstor
 	if err := machineToRemove.Remove(store); err != nil {
 		return errors.Trace(err)
 	}
-	return machineRemover.DeleteMachine(ctx, machine.ID(machineId))
+	return machineRemover.DeleteMachine(ctx, machine.Name(machineId))
 }
 
 // cleanupEvacuateMachine is initiated by machine.Destroy() to gracefully remove units
@@ -1555,7 +1555,7 @@ func (st *State) cleanupContainers(ctx context.Context, store objectstore.Object
 		if err := container.Remove(store); err != nil {
 			return err
 		}
-		if err = machineRemover.DeleteMachine(ctx, machine.ID(containerId)); err != nil {
+		if err = machineRemover.DeleteMachine(ctx, machine.Name(containerId)); err != nil {
 			return err
 		}
 	}

--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/names/v5"
 	jujutxn "github.com/juju/txn/v3"
 
+	coremachine "github.com/juju/juju/core/machine"
 	"github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/internal/mongo"
 	stateerrors "github.com/juju/juju/state/errors"
@@ -164,7 +165,7 @@ func (st *State) NeedsCleanup() (bool, error) {
 // MachineRemover deletes a machine from the dqlite database.
 // This allows us to initially weave some dqlite support into the cleanup workflow.
 type MachineRemover interface {
-	DeleteMachine(context.Context, string) error
+	DeleteMachine(context.Context, coremachine.ID) error
 }
 
 // UnitRemover deletes a unit from the dqlite database.
@@ -1473,7 +1474,7 @@ func (st *State) cleanupForceRemoveMachine(ctx context.Context, store objectstor
 	if err := machine.Remove(store); err != nil {
 		return errors.Trace(err)
 	}
-	return machineRemover.DeleteMachine(ctx, machineId)
+	return machineRemover.DeleteMachine(ctx, coremachine.ID(machineId))
 }
 
 // cleanupEvacuateMachine is initiated by machine.Destroy() to gracefully remove units
@@ -1554,7 +1555,7 @@ func (st *State) cleanupContainers(ctx context.Context, store objectstore.Object
 		if err := container.Remove(store); err != nil {
 			return err
 		}
-		if err = machineRemover.DeleteMachine(ctx, containerId); err != nil {
+		if err = machineRemover.DeleteMachine(ctx, coremachine.ID(containerId)); err != nil {
 			return err
 		}
 	}

--- a/state/cleanup_test.go
+++ b/state/cleanup_test.go
@@ -1783,7 +1783,7 @@ func assertUnitInScope(c *gc.C, unit *state.Unit, rel *state.Relation, expected 
 
 type fakeMachineRemover struct{}
 
-func (fakeMachineRemover) DeleteMachine(context.Context, machine.ID) error { return nil }
+func (fakeMachineRemover) DeleteMachine(context.Context, machine.Name) error { return nil }
 
 type fakeUnitRemover struct{}
 

--- a/state/cleanup_test.go
+++ b/state/cleanup_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/instance"
+	coremachine "github.com/juju/juju/core/machine"
 	resourcetesting "github.com/juju/juju/core/resources/testing"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/internal/charm"
@@ -1782,7 +1783,7 @@ func assertUnitInScope(c *gc.C, unit *state.Unit, rel *state.Relation, expected 
 
 type fakeMachineRemover struct{}
 
-func (fakeMachineRemover) DeleteMachine(context.Context, string) error { return nil }
+func (fakeMachineRemover) DeleteMachine(context.Context, coremachine.ID) error { return nil }
 
 type fakeUnitRemover struct{}
 

--- a/state/cleanup_test.go
+++ b/state/cleanup_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/instance"
-	coremachine "github.com/juju/juju/core/machine"
+	"github.com/juju/juju/core/machine"
 	resourcetesting "github.com/juju/juju/core/resources/testing"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/internal/charm"
@@ -1783,7 +1783,7 @@ func assertUnitInScope(c *gc.C, unit *state.Unit, rel *state.Relation, expected 
 
 type fakeMachineRemover struct{}
 
-func (fakeMachineRemover) DeleteMachine(context.Context, coremachine.ID) error { return nil }
+func (fakeMachineRemover) DeleteMachine(context.Context, machine.ID) error { return nil }
 
 type fakeUnitRemover struct{}
 


### PR DESCRIPTION
This adds the following service functions in the machine domain: `AllMachines`, `InstanceId`, and `InstanceStatus`. They are needed for the provisioner api, to be used in the [MachinesWithTransientErrors](https://github.com/juju/juju/blob/034ed117eb114090027104e448aeb9453b39d20d/apiserver/facades/agent/provisioner/provisioner.go#L377) function.

The implementation in the state layer for the `InstanceStatus` is deferred until the design for the domain entity statuses on dqlite is finalized.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```
TEST_PACKAGES="./domain/machine/... -count=1 -race" make run-go-tests
```


## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/

**Jira card:** [JUJU-6233](https://warthogs.atlassian.net/browse/JUJU-6233?atlOrigin=eyJpIjoiNzc0Mjg5ODUwN2IxNDAxMGI5OWI1ZmYzZjNhNmI1NmUiLCJwIjoiaiJ9)



[JUJU-6233]: https://warthogs.atlassian.net/browse/JUJU-6233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ