### PR TITLE
docs(cmd): fix typos, phrasing, information flow in 'juju migrate' help details

### DIFF
--- a/cmd/juju/commands/migrate.go
+++ b/cmd/juju/commands/migrate.go
@@ -60,27 +60,26 @@ type userListAPI interface {
 }
 
 const migrateDoc = `
-migrate begins the migration of a model from its current controller to
-a new controller. This is useful for load balancing when a controller
-is too busy, or as a way to upgrade a model's controller to a newer
-Juju version. Once complete, the model's machine and and unit agents
+The 'migrate' command begins the migration of a workload model from
+its current controller to a new controller. This is useful for load
+balancing when a controller is too busy, or as a way to upgrade a
+model's controller to a newer Juju version.
+
+In order to start a migration, the target controller must be in the
+juju client's local configuration cache. See the 'login' command
+for details of how to do this.
+
+The 'migrate' command only starts a model migration - it does not wait
+for its completion. The progress of a migration can be tracked using
+the 'status' command and by consulting the logs.
+
+Once the migration is complete, the model's machine and unit agents
 will be connected to the new controller. The model will no longer be
 available at the source controller.
 
-Note that only workload models can be migrated. Controller models can
-not be migrated.
-
-If the migration fails for some reason, the model be returned to its
-original state with the model being managed by the original
+If the migration fails for some reason, the model is returned to its
+original state where it is managed by the original
 controller.
-
-In order to start a migration, the target controller must be in the
-juju client's local configuration cache. See the juju "login" command
-for details of how to do this.
-
-This command only starts a model migration - it does not wait for its
-completion. The progress of a migration can be tracked using the
-"status" command and by consulting the logs.
 
 `
 


### PR DESCRIPTION
Fixes typos, phrasing, information flow in 'juju migrate' help details.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc

## QA steps

N/A

## Documentation changes

This is a documentation change.

## Links

**Jira card:** [JUJU-6244](https://warthogs.atlassian.net/browse/JUJU-6244)

**Discourse doc comment:** https://discourse.charmhub.io/t/command-migrate/10121/2




[JUJU-6244]: https://warthogs.atlassian.net/browse/JUJU-6244?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ