### PR TITLE
refactor(network): refactor large SELECTs into table views and use SQLair

### DIFF
--- a/domain/network/state/space.go
+++ b/domain/network/state/space.go
@@ -76,7 +76,13 @@ VALUES ($ProviderSpace.*)`, providerSpace)
 		// Update all subnets (including their fan overlays) to include
 		// the space uuid.
 		for _, subnetID := range subnetIDs {
-			if err := st.updateSubnetSpaceID(ctx, tx, subnetID, uuid); err != nil {
+			if err := st.updateSubnetSpaceID(
+				ctx,
+				tx,
+				Subnet{
+					UUID:      subnetID,
+					SpaceUUID: uuid,
+				}); err != nil {
 				return errors.Annotatef(err, "updating subnet %q using space uuid %q", subnetID, uuid)
 			}
 		}

--- a/domain/network/state/space.go
+++ b/domain/network/state/space.go
@@ -236,6 +236,9 @@ func (st *State) UpdateSpace(
 UPDATE space
 SET    name = $Space.name
 WHERE  uuid = $Space.uuid;`, space)
+	if err != nil {
+		return errors.Annotate(err, "preparing update space statement")
+	}
 	var outcome sqlair.Outcome
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err := tx.Query(ctx, stmt, space).Get(&outcome)

--- a/domain/network/state/space.go
+++ b/domain/network/state/space.go
@@ -103,15 +103,7 @@ func (st *State) GetSpace(
 
 	space := Space{UUID: uuid}
 	spacesStmt, err := st.Prepare(`
-SELECT (uuid,
-       name,
-       provider_id,
-       subnet_uuid,
-       subnet_cidr,
-       subnet_vlan_tag,
-       subnet_provider_id,
-       subnet_provider_network_id,
-       subnet_az) AS (&SpaceSubnetRow.*)
+SELECT &SpaceSubnetRow.*
 FROM   v_space_subnet
 WHERE  uuid = $Space.uuid;`, SpaceSubnetRow{}, space)
 	if err != nil {
@@ -149,15 +141,7 @@ func (st *State) GetSpaceByName(
 
 	// Append the space.name condition to the query.
 	q := `
-SELECT (uuid,
-       name,
-       provider_id,
-       subnet_uuid,
-       subnet_cidr,
-       subnet_vlan_tag,
-       subnet_provider_id,
-       subnet_provider_network_id,
-       subnet_az) AS (&SpaceSubnetRow.*)
+SELECT &SpaceSubnetRow.*
 FROM   v_space_subnet
 WHERE  name = $Space.name;`
 
@@ -189,15 +173,7 @@ func (st *State) GetAllSpaces(
 	}
 
 	s, err := st.Prepare(`
-SELECT (uuid,
-       name,
-       provider_id,
-       subnet_uuid,
-       subnet_cidr,
-       subnet_vlan_tag,
-       subnet_provider_id,
-       subnet_provider_network_id,
-       subnet_az) AS (&SpaceSubnetRow.*)
+SELECT &SpaceSubnetRow.*
 FROM   v_space_subnet
 `, SpaceSubnetRow{})
 	if err != nil {

--- a/domain/network/state/space.go
+++ b/domain/network/state/space.go
@@ -112,7 +112,7 @@ SELECT (uuid,
        subnet_provider_id,
        subnet_provider_network_id,
        subnet_az) AS (&SpaceSubnetRow.*)
-FROM   v_space
+FROM   v_space_subnet
 WHERE  uuid = $Space.uuid;`, SpaceSubnetRow{}, space)
 	if err != nil {
 		return nil, errors.Annotate(err, "preparing select space statement")
@@ -158,7 +158,7 @@ SELECT (uuid,
        subnet_provider_id,
        subnet_provider_network_id,
        subnet_az) AS (&SpaceSubnetRow.*)
-FROM   v_space
+FROM   v_space_subnet
 WHERE  name = $Space.name;`
 
 	s, err := st.Prepare(q, SpaceSubnetRow{}, space)
@@ -198,7 +198,7 @@ SELECT (uuid,
        subnet_provider_id,
        subnet_provider_network_id,
        subnet_az) AS (&SpaceSubnetRow.*)
-FROM   v_space
+FROM   v_space_subnet
 `, SpaceSubnetRow{})
 	if err != nil {
 		return nil, errors.Annotatef(err, "preparing select all spaces statement")

--- a/domain/network/state/subnet.go
+++ b/domain/network/state/subnet.go
@@ -273,7 +273,7 @@ func (st *State) GetAllSubnets(
 	// Append the space uuid condition to the query only if it's passed to the function.
 	q := `
 SELECT &SubnetRow.*
-FROM   v_subnet
+FROM   v_space_subnet
 `
 
 	s, err := st.Prepare(q, SubnetRow{})
@@ -307,7 +307,7 @@ func (st *State) GetSubnet(
 	// Append the space uuid condition to the query only if it's passed to the function.
 	q := `
 SELECT &SubnetRow.*
-FROM   v_subnet
+FROM   v_space_subnet
 WHERE  subnet_uuid = $M.id;`
 
 	stmt, err := st.Prepare(q, SubnetRow{}, sqlair.M{})
@@ -343,7 +343,7 @@ func (st *State) GetSubnetsByCIDR(
 	// Append the where clause to the query.
 	q := `
 SELECT &SubnetRow.*
-FROM   v_subnet
+FROM   v_space_subnet
 WHERE  subnet_cidr = $M.cidr`
 
 	s, err := st.Prepare(q, SubnetRow{}, sqlair.M{})

--- a/domain/network/state/subnet.go
+++ b/domain/network/state/subnet.go
@@ -43,31 +43,6 @@ func (st *State) AllSubnetsQuery(ctx context.Context, db database.TxnRunner) ([]
 	})
 }
 
-// AllAssociatedSubnetsQuery returns the SQL query that finds all associated
-// subnet UUIDs from the subnet_association table, needed for the subnets watcher.
-func (st *State) AllAssociatedSubnetsQuery(ctx context.Context, db database.TxnRunner) ([]string, error) {
-	var associatedSubnetUUIDs []string
-
-	return associatedSubnetUUIDs, db.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
-		stmt := "SELECT associated_subnet_uuid FROM subnet_association"
-		rows, err := tx.QueryContext(ctx, stmt)
-		if err != nil {
-			return errors.Trace(domain.CoerceError(err))
-		}
-		defer rows.Close()
-
-		for rows.Next() {
-			var associatedSubnetUUID string
-			if err := rows.Scan(&associatedSubnetUUID); err != nil {
-				return errors.Trace(domain.CoerceError(err))
-			}
-			associatedSubnetUUIDs = append(associatedSubnetUUIDs, associatedSubnetUUID)
-		}
-
-		return nil
-	})
-}
-
 // UpsertSubnets updates or adds each one of the provided subnets in one
 // transaction.
 func (st *State) UpsertSubnets(ctx context.Context, subnets []network.SubnetInfo) error {

--- a/domain/network/state/types.go
+++ b/domain/network/state/types.go
@@ -62,55 +62,56 @@ type ProviderSpace struct {
 	ProviderID network.Id `db:"provider_id"`
 }
 
-// SpaceSubnetRow represents a single row from the database when
-// space is joined with provider_space, subnet, subnet_type,
-// subnet_association, subject_subnet_type_uuid, subnet_association_type,
-// provider_subnet, provider_network, provider_network_subnet,
-// availability_zone and availability_zone_subnet.
-// This type is also used for deserializing only subnets, which has the same
-// fields except UUID, Name and ProviderID.
-type SpaceSubnetRow struct {
-	// UUID is the space UUID.
-	UUID string `db:"uuid"`
+// SubnetRow represents the subnet fields of a single row from the
+// v_space_subnets view.
+type SubnetRow struct {
+	// UUID is the subnet UUID.
+	UUID string `db:"subnet_uuid"`
 
-	// Name is the space name.
-	Name string `db:"name"`
+	// CIDR is the one of the subnet's cidr.
+	CIDR string `db:"subnet_cidr"`
 
-	// ProviderID is the space provider id.
-	ProviderID sql.NullString `db:"provider_id"`
+	// VLANTag is the subnet's vlan tag.
+	VLANTag int `db:"subnet_vlan_tag"`
 
-	// Subnet fields
+	// ProviderID is the subnet's provider id.
+	ProviderID string `db:"subnet_provider_id"`
 
-	// SubnetUUID is the subnet SubnetUUID.
-	SubnetUUID string `db:"subnet_uuid"`
+	// ProviderNetworkID is the subnet's provider network id.
+	ProviderNetworkID string `db:"subnet_provider_network_id"`
 
-	// SubnetCIDR is the one of the subnet's cidr.
-	SubnetCIDR string `db:"subnet_cidr"`
+	// ProviderSpaceUUID is the subnet's space uuid.
+	ProviderSpaceUUID sql.NullString `db:"subnet_provider_space_uuid"`
 
-	// SubnetVLANTag is the subnet's vlan tag.
-	SubnetVLANTag int `db:"subnet_vlan_tag"`
+	// SpaceUUID is the space uuid.
+	SpaceUUID sql.NullString `db:"subnet_space_uuid"`
 
-	// SubnetProviderID is the subnet's provider id.
-	SubnetProviderID string `db:"subnet_provider_id"`
+	// SpaceName is the name of the space the subnet is associated with.
+	SpaceName sql.NullString `db:"subnet_space_name"`
 
-	// SubnetProviderNetworkID is the subnet's provider network id.
-	SubnetProviderNetworkID string `db:"subnet_provider_network_id"`
-
-	// SubnetProviderSpaceUUID is the subnet's space uuid.
-	SubnetProviderSpaceUUID sql.NullString `db:"subnet_provider_space_uuid"`
-
-	// SubnetSpaceUUID is the space uuid.
-	SubnetSpaceUUID sql.NullString `db:"subnet_space_uuid"`
-
-	// SubnetSpaceName is the name of the space the subnet is associated with.
-	SubnetSpaceName sql.NullString `db:"subnet_space_name"`
-
-	// SubnetAZ is the availability zones on the subnet.
-	SubnetAZ string `db:"subnet_az"`
+	// AZ is the availability zones on the subnet.
+	AZ string `db:"subnet_az"`
 }
 
-// Alias type to a slice of Space/Subnet rows.
+// SpaceSubnetRow represents a single row from the v_space_subnets view.
+type SpaceSubnetRow struct {
+	// UUID is the space UUID.
+	SpaceUUID string `db:"uuid"`
+
+	// Name is the space name.
+	SpaceName string `db:"name"`
+
+	// ProviderID is the space provider id.
+	SpaceProviderID sql.NullString `db:"provider_id"`
+
+	SubnetRow
+}
+
+// Alias type to a slice of Space and Subnet rows.
 type SpaceSubnetRows []SpaceSubnetRow
+
+// Alias type to a slice of Subnet rows.
+type SubnetRows []SubnetRow
 
 // ToSpaceInfos converts Spaces to a slice of network.SpaceInfo structs.
 // This method makes sure only unique subnets are mapped and flattens them into
@@ -124,45 +125,44 @@ func (sp SpaceSubnetRows) ToSpaceInfos() network.SpaceInfos {
 	uniqueSubnets := make(map[string]map[string]network.SubnetInfo)
 	uniqueSpaces := make(map[string]network.SpaceInfo)
 
-	for _, space := range sp {
+	for _, spaceSubnet := range sp {
 		spInfo := network.SpaceInfo{
-			ID:   space.UUID,
-			Name: network.SpaceName(space.Name),
+			ID:   spaceSubnet.SpaceUUID,
+			Name: network.SpaceName(spaceSubnet.SpaceName),
 		}
 
-		if space.ProviderID.Valid {
-			spInfo.ProviderId = network.Id(space.ProviderID.String)
+		if spaceSubnet.SpaceProviderID.Valid {
+			spInfo.ProviderId = network.Id(spaceSubnet.SpaceProviderID.String)
 		}
-		uniqueSpaces[space.UUID] = spInfo
+		uniqueSpaces[spaceSubnet.SpaceUUID] = spInfo
 
-		snInfo := space.ToSubnetInfo()
+		snInfo := spaceSubnet.SubnetRow.ToSubnetInfo()
 		if snInfo != nil {
-			if _, ok := uniqueSubnets[space.UUID]; !ok {
-				uniqueSubnets[space.UUID] = make(map[string]network.SubnetInfo)
+			if _, ok := uniqueSubnets[spaceSubnet.SpaceUUID]; !ok {
+				uniqueSubnets[spaceSubnet.SpaceUUID] = make(map[string]network.SubnetInfo)
 			}
 
-			snInfo.SpaceID = space.UUID
-			snInfo.SpaceName = space.Name
+			snInfo.SpaceID = spaceSubnet.SpaceUUID
+			snInfo.SpaceName = spaceSubnet.SpaceName
 
-			if space.ProviderID.Valid {
-				snInfo.ProviderSpaceId = network.Id(space.ProviderID.String)
+			if spaceSubnet.SpaceProviderID.Valid {
+				snInfo.ProviderSpaceId = network.Id(spaceSubnet.SpaceProviderID.String)
 			}
-			uniqueSubnets[space.UUID][space.SubnetUUID] = *snInfo
+			uniqueSubnets[spaceSubnet.SpaceUUID][spaceSubnet.UUID] = *snInfo
 
-			if _, ok := uniqueAZs[space.UUID]; !ok {
-				uniqueAZs[space.UUID] = make(map[string]map[string]string)
+			if _, ok := uniqueAZs[spaceSubnet.SpaceUUID]; !ok {
+				uniqueAZs[spaceSubnet.SpaceUUID] = make(map[string]map[string]string)
 			}
-			if _, ok := uniqueAZs[space.UUID][space.SubnetUUID]; !ok {
-				uniqueAZs[space.UUID][space.SubnetUUID] = make(map[string]string)
+			if _, ok := uniqueAZs[spaceSubnet.SpaceUUID][spaceSubnet.UUID]; !ok {
+				uniqueAZs[spaceSubnet.SpaceUUID][spaceSubnet.UUID] = make(map[string]string)
 			}
-			uniqueAZs[space.UUID][space.SubnetUUID][space.SubnetAZ] = space.SubnetAZ
+			uniqueAZs[spaceSubnet.SpaceUUID][spaceSubnet.UUID][spaceSubnet.AZ] = spaceSubnet.AZ
 		}
 	}
 
 	// Iterate through every space and flatten its subnets.
 	for spaceUUID, space := range uniqueSpaces {
 		space.Subnets = flattenAZs(uniqueSubnets[spaceUUID], uniqueAZs[spaceUUID])
-
 		res = append(res, space)
 	}
 
@@ -171,26 +171,26 @@ func (sp SpaceSubnetRows) ToSpaceInfos() network.SpaceInfos {
 
 // ToSubnetInfo deserializes a row containing subnet fields to a SubnetInfo
 // struct.
-func (s SpaceSubnetRow) ToSubnetInfo() *network.SubnetInfo {
+func (s SubnetRow) ToSubnetInfo() *network.SubnetInfo {
 	// Make sure we don't add empty rows as empty subnets.
-	if s.SubnetUUID == "" {
+	if s.UUID == "" {
 		return nil
 	}
 	sInfo := network.SubnetInfo{
-		ID:                network.Id(s.SubnetUUID),
-		CIDR:              s.SubnetCIDR,
-		VLANTag:           s.SubnetVLANTag,
-		ProviderId:        network.Id(s.SubnetProviderID),
-		ProviderNetworkId: network.Id(s.SubnetProviderNetworkID),
+		ID:                network.Id(s.UUID),
+		CIDR:              s.CIDR,
+		VLANTag:           s.VLANTag,
+		ProviderId:        network.Id(s.ProviderID),
+		ProviderNetworkId: network.Id(s.ProviderNetworkID),
 	}
-	if s.SubnetProviderSpaceUUID.Valid {
-		sInfo.ProviderSpaceId = network.Id(s.SubnetProviderSpaceUUID.String)
+	if s.ProviderSpaceUUID.Valid {
+		sInfo.ProviderSpaceId = network.Id(s.ProviderSpaceUUID.String)
 	}
-	if s.SubnetSpaceUUID.Valid {
-		sInfo.SpaceID = s.SubnetSpaceUUID.String
+	if s.SpaceUUID.Valid {
+		sInfo.SpaceID = s.SpaceUUID.String
 	}
-	if s.SubnetSpaceName.Valid {
-		sInfo.SpaceName = s.SubnetSpaceName.String
+	if s.SpaceName.Valid {
+		sInfo.SpaceName = s.SpaceName.String
 	}
 
 	return &sInfo
@@ -200,7 +200,7 @@ func (s SpaceSubnetRow) ToSubnetInfo() *network.SubnetInfo {
 // This method makes sure only unique AZs are mapped and flattens them into
 // each subnet.
 // No sorting is applied.
-func (sn SpaceSubnetRows) ToSubnetInfos() network.SubnetInfos {
+func (sn SubnetRows) ToSubnetInfos() network.SubnetInfos {
 	// Prepare structs for unique subnets.
 	uniqueAZs := make(map[string]map[string]string)
 	uniqueSubnets := make(map[string]network.SubnetInfo)
@@ -208,12 +208,12 @@ func (sn SpaceSubnetRows) ToSubnetInfos() network.SubnetInfos {
 	for _, subnet := range sn {
 		subnetInfo := subnet.ToSubnetInfo()
 		if subnetInfo != nil {
-			uniqueSubnets[subnet.SubnetUUID] = *subnetInfo
+			uniqueSubnets[subnet.UUID] = *subnetInfo
 
-			if _, ok := uniqueAZs[subnet.SubnetUUID]; !ok {
-				uniqueAZs[subnet.SubnetUUID] = make(map[string]string)
+			if _, ok := uniqueAZs[subnet.UUID]; !ok {
+				uniqueAZs[subnet.UUID] = make(map[string]string)
 			}
-			uniqueAZs[subnet.SubnetUUID][subnet.SubnetAZ] = subnet.SubnetAZ
+			uniqueAZs[subnet.UUID][subnet.AZ] = subnet.AZ
 		}
 	}
 

--- a/domain/network/state/types.go
+++ b/domain/network/state/types.go
@@ -95,6 +95,10 @@ type SubnetRow struct {
 
 // SpaceSubnetRow represents a single row from the v_space_subnets view.
 type SpaceSubnetRow struct {
+	// SubnetRow is embedded by SpaceSubnetRow since every row corresponds to a
+	// subnet of the space. This allows SubnetRow to be
+	SubnetRow
+
 	// UUID is the space UUID.
 	SpaceUUID string `db:"uuid"`
 
@@ -103,14 +107,12 @@ type SpaceSubnetRow struct {
 
 	// ProviderID is the space provider id.
 	SpaceProviderID sql.NullString `db:"provider_id"`
-
-	SubnetRow
 }
 
-// Alias type to a slice of Space and Subnet rows.
+// SpaceSubnetRows is a slice of SpaceSubnet rows.
 type SpaceSubnetRows []SpaceSubnetRow
 
-// Alias type to a slice of Subnet rows.
+// SubnetRows is a slice of Subnet rows.
 type SubnetRows []SubnetRow
 
 // ToSpaceInfos converts Spaces to a slice of network.SpaceInfo structs.

--- a/domain/network/state/types.go
+++ b/domain/network/state/types.go
@@ -161,12 +161,6 @@ func (sp SpaceSubnetRows) ToSpaceInfos() network.SpaceInfos {
 				uniqueSubnets[spaceSubnet.SpaceUUID] = make(map[string]network.SubnetInfo)
 			}
 
-			snInfo.SpaceID = spaceSubnet.SpaceUUID
-			snInfo.SpaceName = spaceSubnet.SpaceName
-
-			if spaceSubnet.SpaceProviderID.Valid {
-				snInfo.ProviderSpaceId = network.Id(spaceSubnet.SpaceProviderID.String)
-			}
 			uniqueSubnets[spaceSubnet.SpaceUUID][spaceSubnet.UUID] = *snInfo
 
 			if _, ok := uniqueAZs[spaceSubnet.SpaceUUID]; !ok {

--- a/domain/network/state/types.go
+++ b/domain/network/state/types.go
@@ -62,6 +62,23 @@ type ProviderSpace struct {
 	ProviderID network.Id `db:"provider_id"`
 }
 
+// AvailabilityZone represents a row from the availability_zone table.
+type AvailabilityZone struct {
+	// Name is the name of the availability zone.
+	Name string `db:"name"`
+	// UUID is the unique ID of the availability zone.
+	UUID string `db:"uuid"`
+}
+
+// AvailabilityZoneSubnet represents a row from the availability_zone_subnet
+// table.
+type AvailabilityZoneSubnet struct {
+	// UUID is the unique ID of the availability zone.
+	AZUUID string `db:"availability_zone_uuid"`
+	// SubnetUUID is the unique ID of the Subnet.
+	SubnetUUID string `db:"subnet_uuid"`
+}
+
 // SubnetRow represents the subnet fields of a single row from the
 // v_space_subnets view.
 type SubnetRow struct {

--- a/domain/schema/model/sql/0008-space.sql
+++ b/domain/schema/model/sql/0008-space.sql
@@ -20,7 +20,7 @@ ON provider_space (space_uuid);
 INSERT INTO space VALUES
 (0, 'alpha');
 
-CREATE VIEW v_space AS
+CREATE VIEW v_space_subnet AS
 SELECT
     space.uuid,
     space.name,
@@ -28,9 +28,12 @@ SELECT
     subnet.uuid AS subnet_uuid,
     subnet.cidr AS subnet_cidr,
     subnet.vlan_tag AS subnet_vlan_tag,
+    subnet.space_uuid AS subnet_space_uuid,
+    space.name AS subnet_space_name,
     provider_subnet.provider_id AS subnet_provider_id,
     provider_network.provider_network_id AS subnet_provider_network_id,
-    availability_zone.name AS subnet_az
+    availability_zone.name AS subnet_az,
+    provider_space.provider_id AS subnet_provider_space_uuid
 FROM space
 LEFT JOIN provider_space
     ON space.uuid = provider_space.space_uuid

--- a/domain/schema/model/sql/0008-space.sql
+++ b/domain/schema/model/sql/0008-space.sql
@@ -19,3 +19,30 @@ ON provider_space (space_uuid);
 
 INSERT INTO space VALUES
 (0, 'alpha');
+
+CREATE VIEW v_space AS
+SELECT
+    space.uuid,
+    space.name,
+    provider_space.provider_id,
+    subnet.uuid                          AS subnet_uuid,
+    subnet.cidr                          AS subnet_cidr,
+    subnet.vlan_tag                      AS subnet_vlan_tag,
+    provider_subnet.provider_id          AS subnet_provider_id,
+    provider_network.provider_network_id AS subnet_provider_network_id,
+    availability_zone.name               AS subnet_az
+FROM space
+    LEFT JOIN provider_space
+    ON space.uuid = provider_space.space_uuid
+    LEFT JOIN subnet
+    ON space.uuid = subnet.space_uuid
+    LEFT JOIN provider_subnet
+    ON subnet.uuid = provider_subnet.subnet_uuid
+    LEFT JOIN provider_network_subnet
+    ON subnet.uuid = provider_network_subnet.subnet_uuid
+    LEFT JOIN provider_network
+    ON provider_network_subnet.provider_network_uuid = provider_network.uuid
+    LEFT JOIN availability_zone_subnet
+    ON availability_zone_subnet.subnet_uuid = subnet.uuid
+    LEFT JOIN availability_zone
+    ON availability_zone_subnet.availability_zone_uuid = availability_zone.uuid;

--- a/domain/schema/model/sql/0008-space.sql
+++ b/domain/schema/model/sql/0008-space.sql
@@ -25,24 +25,24 @@ SELECT
     space.uuid,
     space.name,
     provider_space.provider_id,
-    subnet.uuid                          AS subnet_uuid,
-    subnet.cidr                          AS subnet_cidr,
-    subnet.vlan_tag                      AS subnet_vlan_tag,
-    provider_subnet.provider_id          AS subnet_provider_id,
+    subnet.uuid AS subnet_uuid,
+    subnet.cidr AS subnet_cidr,
+    subnet.vlan_tag AS subnet_vlan_tag,
+    provider_subnet.provider_id AS subnet_provider_id,
     provider_network.provider_network_id AS subnet_provider_network_id,
-    availability_zone.name               AS subnet_az
+    availability_zone.name AS subnet_az
 FROM space
-    LEFT JOIN provider_space
+LEFT JOIN provider_space
     ON space.uuid = provider_space.space_uuid
-    LEFT JOIN subnet
+LEFT JOIN subnet
     ON space.uuid = subnet.space_uuid
-    LEFT JOIN provider_subnet
+LEFT JOIN provider_subnet
     ON subnet.uuid = provider_subnet.subnet_uuid
-    LEFT JOIN provider_network_subnet
+LEFT JOIN provider_network_subnet
     ON subnet.uuid = provider_network_subnet.subnet_uuid
-    LEFT JOIN provider_network
+LEFT JOIN provider_network
     ON provider_network_subnet.provider_network_uuid = provider_network.uuid
-    LEFT JOIN availability_zone_subnet
-    ON availability_zone_subnet.subnet_uuid = subnet.uuid
-    LEFT JOIN availability_zone
+LEFT JOIN availability_zone_subnet
+    ON subnet.uuid = availability_zone_subnet.subnet_uuid
+LEFT JOIN availability_zone
     ON availability_zone_subnet.availability_zone_uuid = availability_zone.uuid;

--- a/domain/schema/model/sql/0009-subnet.sql
+++ b/domain/schema/model/sql/0009-subnet.sql
@@ -57,30 +57,3 @@ CREATE TABLE availability_zone_subnet (
     FOREIGN KEY (subnet_uuid)
     REFERENCES subnet (uuid)
 );
-
-CREATE VIEW v_subnet AS
-SELECT
-    subnet.uuid AS subnet_uuid,
-    subnet.cidr AS subnet_cidr,
-    subnet.vlan_tag AS subnet_vlan_tag,
-    subnet.space_uuid AS subnet_space_uuid,
-    space.name AS subnet_space_name,
-    provider_subnet.provider_id AS subnet_provider_id,
-    provider_network.provider_network_id AS subnet_provider_network_id,
-    availability_zone.name AS subnet_az,
-    provider_space.provider_id AS subnet_provider_space_uuid
-FROM subnet
-LEFT JOIN space
-    ON subnet.space_uuid = space.uuid
-INNER JOIN provider_subnet
-    ON subnet.uuid = provider_subnet.subnet_uuid
-INNER JOIN provider_network_subnet
-    ON subnet.uuid = provider_network_subnet.subnet_uuid
-INNER JOIN provider_network
-    ON provider_network_subnet.provider_network_uuid = provider_network.uuid
-LEFT JOIN availability_zone_subnet
-    ON subnet.uuid = availability_zone_subnet.subnet_uuid
-LEFT JOIN availability_zone
-    ON availability_zone_subnet.availability_zone_uuid = availability_zone.uuid
-LEFT JOIN provider_space
-    ON subnet.space_uuid = provider_space.space_uuid;

--- a/domain/schema/model/sql/0009-subnet.sql
+++ b/domain/schema/model/sql/0009-subnet.sql
@@ -57,3 +57,30 @@ CREATE TABLE availability_zone_subnet (
     FOREIGN KEY (subnet_uuid)
     REFERENCES subnet (uuid)
 );
+
+CREATE VIEW v_subnet AS
+SELECT
+    subnet.uuid                          AS subnet_uuid,
+    subnet.cidr                          AS subnet_cidr,
+    subnet.vlan_tag                      AS subnet_vlan_tag,
+    subnet.space_uuid                    AS subnet_space_uuid,
+    space.name                           AS subnet_space_name,
+    provider_subnet.provider_id          AS subnet_provider_id,
+    provider_network.provider_network_id AS subnet_provider_network_id,
+    availability_zone.name               AS subnet_az,
+    provider_space.provider_id           AS subnet_provider_space_uuid
+FROM subnet
+         LEFT JOIN space
+                   ON subnet.space_uuid = space.uuid
+         JOIN provider_subnet
+              ON subnet.uuid = provider_subnet.subnet_uuid
+         JOIN provider_network_subnet
+              ON subnet.uuid = provider_network_subnet.subnet_uuid
+         JOIN provider_network
+              ON provider_network_subnet.provider_network_uuid = provider_network.uuid
+         LEFT JOIN availability_zone_subnet
+                   ON availability_zone_subnet.subnet_uuid = subnet.uuid
+         LEFT JOIN availability_zone
+                   ON availability_zone_subnet.availability_zone_uuid = availability_zone.uuid
+         LEFT JOIN provider_space
+                   ON subnet.space_uuid = provider_space.space_uuid;

--- a/domain/schema/model/sql/0009-subnet.sql
+++ b/domain/schema/model/sql/0009-subnet.sql
@@ -60,27 +60,27 @@ CREATE TABLE availability_zone_subnet (
 
 CREATE VIEW v_subnet AS
 SELECT
-    subnet.uuid                          AS subnet_uuid,
-    subnet.cidr                          AS subnet_cidr,
-    subnet.vlan_tag                      AS subnet_vlan_tag,
-    subnet.space_uuid                    AS subnet_space_uuid,
-    space.name                           AS subnet_space_name,
-    provider_subnet.provider_id          AS subnet_provider_id,
+    subnet.uuid AS subnet_uuid,
+    subnet.cidr AS subnet_cidr,
+    subnet.vlan_tag AS subnet_vlan_tag,
+    subnet.space_uuid AS subnet_space_uuid,
+    space.name AS subnet_space_name,
+    provider_subnet.provider_id AS subnet_provider_id,
     provider_network.provider_network_id AS subnet_provider_network_id,
-    availability_zone.name               AS subnet_az,
-    provider_space.provider_id           AS subnet_provider_space_uuid
+    availability_zone.name AS subnet_az,
+    provider_space.provider_id AS subnet_provider_space_uuid
 FROM subnet
-         LEFT JOIN space
-                   ON subnet.space_uuid = space.uuid
-         JOIN provider_subnet
-              ON subnet.uuid = provider_subnet.subnet_uuid
-         JOIN provider_network_subnet
-              ON subnet.uuid = provider_network_subnet.subnet_uuid
-         JOIN provider_network
-              ON provider_network_subnet.provider_network_uuid = provider_network.uuid
-         LEFT JOIN availability_zone_subnet
-                   ON availability_zone_subnet.subnet_uuid = subnet.uuid
-         LEFT JOIN availability_zone
-                   ON availability_zone_subnet.availability_zone_uuid = availability_zone.uuid
-         LEFT JOIN provider_space
-                   ON subnet.space_uuid = provider_space.space_uuid;
+LEFT JOIN space
+    ON subnet.space_uuid = space.uuid
+INNER JOIN provider_subnet
+    ON subnet.uuid = provider_subnet.subnet_uuid
+INNER JOIN provider_network_subnet
+    ON subnet.uuid = provider_network_subnet.subnet_uuid
+INNER JOIN provider_network
+    ON provider_network_subnet.provider_network_uuid = provider_network.uuid
+LEFT JOIN availability_zone_subnet
+    ON subnet.uuid = availability_zone_subnet.subnet_uuid
+LEFT JOIN availability_zone
+    ON availability_zone_subnet.availability_zone_uuid = availability_zone.uuid
+LEFT JOIN provider_space
+    ON subnet.space_uuid = provider_space.space_uuid;

--- a/domain/schema/schema_test.go
+++ b/domain/schema/schema_test.go
@@ -424,6 +424,8 @@ func (s *schemaSuite) TestModelViews(c *gc.C) {
 	expected := set.NewStrings(
 		"v_charm_url",
 		"v_secret_permission",
+		"v_space",
+		"v_subnet",
 	)
 	c.Assert(readEntityNames(c, s.DB(), "view"), jc.SameContents, expected.SortedValues())
 }

--- a/domain/schema/schema_test.go
+++ b/domain/schema/schema_test.go
@@ -424,8 +424,7 @@ func (s *schemaSuite) TestModelViews(c *gc.C) {
 	expected := set.NewStrings(
 		"v_charm_url",
 		"v_secret_permission",
-		"v_space",
-		"v_subnet",
+		"v_space_subnet",
 	)
 	c.Assert(readEntityNames(c, s.DB(), "view"), jc.SameContents, expected.SortedValues())
 }


### PR DESCRIPTION
This PR refactors two large queries in network/state into views and uses SQLair over the whole domain.

In network/state there were two huge queries that were used multiple times with small clauses appended. These were better served as being views.

By turning them into views it was also possible to separate out the types used for serialisation, which had previously been a single type. The code to process these types did not significantly change as I was able to use struct embedding to capture the structure and retain methods on the types.


## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing

## QA steps
### Unit tests (using DQLite)
```
TEST_PACKAGES="./domain/network/... -count=1 " TEST_FILTER="Suite" make run-go-tests
TEST_PACKAGES="./domain/schema/... -count=1 " TEST_FILTER="Suite" make run-go-tests
```

### Integration tests
```
cd tests
./main.sh -v network
./main.sh -v cmr
```
<!-- Describe steps to verify that the change works. -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->


**Jira card:** [JUJU-6192](https://warthogs.atlassian.net/browse/JUJU-6192)



[JUJU-6192]: https://warthogs.atlassian.net/browse/JUJU-6192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ