### PR TITLE
fix: ensure we release state

### DIFF
--- a/apiserver/facades/client/controller/controller.go
+++ b/apiserver/facades/client/controller/controller.go
@@ -285,10 +285,11 @@ func (c *ControllerAPI) DashboardConnectionInfo() (params.DashboardConnectionInf
 				continue
 			}
 
-			model, _, err := c.statePool.GetModel(rel.ModelUUID())
+			model, ph, err := c.statePool.GetModel(rel.ModelUUID())
 			if err != nil {
 				return rval, errors.Trace(err)
 			}
+			defer ph.Release()
 
 			relatedEps, err := rel.RelatedEndpoints(controllerApp.Name())
 			if err != nil {

--- a/worker/certupdater/manifold.go
+++ b/worker/certupdater/manifold.go
@@ -86,6 +86,7 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 
 	st, err := statePool.SystemState()
 	if err != nil {
+		_ = stTracker.Done()
 		return nil, errors.Trace(err)
 	}
 	addressWatcher, err := config.NewMachineAddressWatcher(st, agentConfig.Tag().Id())

--- a/worker/migrationmaster/worker.go
+++ b/worker/migrationmaster/worker.go
@@ -595,6 +595,8 @@ func (w *Worker) transferLogs(targetInfo coremigration.TargetInfo, modelUUID str
 	if err != nil {
 		return errors.Annotate(err, "connecting to target API")
 	}
+	defer conn.Close()
+
 	targetClient := migrationtarget.NewClient(conn)
 	latestLogTime, err := targetClient.LatestLogTime(modelUUID)
 	if err != nil {

--- a/worker/migrationmaster/worker_test.go
+++ b/worker/migrationmaster/worker_test.go
@@ -289,6 +289,7 @@ func (s *Suite) TestSuccessfulMigration(c *gc.C) {
 			latestLogTimeCall,
 			{"StreamModelLog", []interface{}{time.Time{}}},
 			openDestLogStreamCall,
+			apiCloseCall,
 			{"facade.SetPhase", []interface{}{coremigration.REAP}},
 
 			// REAP
@@ -354,6 +355,7 @@ func (s *Suite) TestMigrationResume(c *gc.C) {
 			latestLogTimeCall,
 			{"StreamModelLog", []interface{}{time.Time{}}},
 			openDestLogStreamCall,
+			apiCloseCall,
 			{"facade.SetPhase", []interface{}{coremigration.REAP}},
 			{"facade.Reap", nil},
 			{"facade.SetPhase", []interface{}{coremigration.DONE}},
@@ -745,6 +747,7 @@ func (s *Suite) TestSUCCESSMinionWaitFailedMachine(c *gc.C) {
 			latestLogTimeCall,
 			{"StreamModelLog", []interface{}{time.Time{}}},
 			openDestLogStreamCall,
+			apiCloseCall,
 			{"facade.SetPhase", []interface{}{coremigration.REAP}},
 			{"facade.Reap", nil},
 			{"facade.SetPhase", []interface{}{coremigration.DONE}},
@@ -777,6 +780,7 @@ func (s *Suite) TestSUCCESSMinionWaitFailedUnit(c *gc.C) {
 			latestLogTimeCall,
 			{"StreamModelLog", []interface{}{time.Time{}}},
 			openDestLogStreamCall,
+			apiCloseCall,
 			{"facade.SetPhase", []interface{}{coremigration.REAP}},
 			{"facade.Reap", nil},
 			{"facade.SetPhase", []interface{}{coremigration.DONE}},
@@ -819,6 +823,7 @@ func (s *Suite) TestSUCCESSMinionWaitTimeout(c *gc.C) {
 			latestLogTimeCall,
 			{"StreamModelLog", []interface{}{time.Time{}}},
 			openDestLogStreamCall,
+			apiCloseCall,
 			{"facade.SetPhase", []interface{}{coremigration.REAP}},
 			{"facade.Reap", nil},
 			{"facade.SetPhase", []interface{}{coremigration.DONE}},
@@ -929,6 +934,7 @@ func (s *Suite) TestLogTransferErrorGettingStartTime(c *gc.C) {
 			{"facade.MinionReportTimeout", nil},
 			apiOpenControllerCall,
 			latestLogTimeCall,
+			apiCloseCall,
 		},
 	))
 }
@@ -945,6 +951,7 @@ func (s *Suite) TestLogTransferErrorOpeningLogSource(c *gc.C) {
 			apiOpenControllerCall,
 			latestLogTimeCall,
 			{"StreamModelLog", []interface{}{time.Time{}}},
+			apiCloseCall,
 		},
 	))
 }
@@ -962,6 +969,7 @@ func (s *Suite) TestLogTransferErrorOpeningLogDest(c *gc.C) {
 			latestLogTimeCall,
 			{"StreamModelLog", []interface{}{time.Time{}}},
 			openDestLogStreamCall,
+			apiCloseCall,
 		},
 	))
 }
@@ -981,6 +989,7 @@ func (s *Suite) TestLogTransferErrorWriting(c *gc.C) {
 			latestLogTimeCall,
 			{"StreamModelLog", []interface{}{time.Time{}}},
 			openDestLogStreamCall,
+			apiCloseCall,
 		},
 	))
 	c.Assert(s.connection.logStream.closeCount, gc.Equals, 1)
@@ -1017,6 +1026,7 @@ func (s *Suite) TestLogTransferSendsRecords(c *gc.C) {
 			latestLogTimeCall,
 			{"StreamModelLog", []interface{}{time.Time{}}},
 			openDestLogStreamCall,
+			apiCloseCall,
 			{"facade.SetPhase", []interface{}{coremigration.REAP}},
 			{"facade.Reap", nil},
 			{"facade.SetPhase", []interface{}{coremigration.DONE}},
@@ -1070,7 +1080,7 @@ func (s *Suite) TestLogTransferReportsProgress(c *gc.C) {
 	})
 }
 
-func (s *Suite) TestLogTransfer_ChecksLatestTime(c *gc.C) {
+func (s *Suite) TestLogTransferChecksLatestTime(c *gc.C) {
 	s.facade.queueStatus(s.makeStatus(coremigration.LOGTRANSFER))
 	t := time.Date(2016, 12, 2, 10, 39, 10, 20, time.UTC)
 	s.connection.latestLogTime = t
@@ -1084,6 +1094,7 @@ func (s *Suite) TestLogTransfer_ChecksLatestTime(c *gc.C) {
 			latestLogTimeCall,
 			{"StreamModelLog", []interface{}{t}},
 			openDestLogStreamCall,
+			apiCloseCall,
 			{"facade.SetPhase", []interface{}{coremigration.REAP}},
 			{"facade.Reap", nil},
 			{"facade.SetPhase", []interface{}{coremigration.DONE}},

--- a/worker/peergrouper/manifold.go
+++ b/worker/peergrouper/manifold.go
@@ -100,6 +100,7 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 
 	st, err := statePool.SystemState()
 	if err != nil {
+		_ = stTracker.Done()
 		return nil, errors.Trace(err)
 	}
 	mongoSession := st.MongoSession()


### PR DESCRIPTION
The controller dashboard leaks the statepool. Essentially it's missing the call to release. I wouldn't expect it to be called that often, so probably not the source of our leaks.

In addition the call to the SystemState can fail and also doesn't call system state release. We should release it on error.

Finially, I've removed the defer and explicitly called release when we're in a error state.

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made

## QA steps

<!-- Describe steps to verify that the change works. -->

## Links

**Jira card:** [JUJU-6245
](https://warthogs.atlassian.net/browse/JUJU-6245)
