### PR TITLE
feat: add github action to ensure consistency

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -171,7 +171,7 @@ jobs:
     - name: Get go.mod version
       id: go_mod_version
       shell: bash
-      run: echo "GO_MOD_VERSION=$(go mod edit -json | jq -r .Go)" >> $GITHUB_ENV
+      run: echo "GO_MOD_VERSION=$(go mod edit -json | jq -r .Go | awk 'BEGIN{FS="."} {print $1"."$2}')" >> $GITHUB_ENV
 
     - name: Get binary snapcraft.yaml
       id: get_binary_snapcraft

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -149,3 +149,41 @@ jobs:
     steps:
         - uses: actions/checkout@v4
         - uses: wagoid/commitlint-github-action@v6
+
+  go-version:
+    name: Go Version
+    runs-on: [self-hosted, linux, arm64, aws, large]
+    if: github.event.pull_request.draft == false
+    strategy:
+      fail-fast: false
+      matrix:
+        binary: ["jujud", "juju"]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version-file: 'go.mod'
+        cache: true
+
+    - name: Get go.mod version
+      id: go_mod_version
+      shell: bash
+      run: echo "GO_MOD_VERSION=$(go mod edit -json | jq -r .Go)" >> $GITHUB_ENV
+
+    - name: Get binary snapcraft.yaml
+      id: get_binary_snapcraft
+      uses: mikefarah/yq@master
+      with:
+        cmd: yq -r '.parts | .["${{ matrix.binary }}"] | .["go-channel"]' snap/snapcraft.yaml
+
+    - name: Ensure go version
+      shell: bash
+      run: |
+        echo ${{ steps.get_binary_snapcraft.outputs.result }} | grep -q "$GO_MOD_VERSION"
+        if [ $? -ne 0 ]; then
+          echo "Go version in go.mod ($mod_version) does not match snapcraft.yaml ($snap_version)"
+          exit 1
+        fi

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -391,7 +391,7 @@ parts:
     after:
       - libdqlite
     plugin: juju-go
-    go-channel: 1.20/stable
+    go-channel: 1.21/stable
     source: .
     go-packages:
       - github.com/juju/juju/cmd/jujud


### PR DESCRIPTION
Ensure the go.mod is the authoritative source for the go version when building. The static analysis job then ensures that the snapcraft.yaml file mirrors the go version.

Attempting to understand the go version of production builds that haven't been correctly updated is a mindfield.

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made

## QA steps

The new go version for juju and jujud complete.


## Links


**Jira card:** [JUJU-6246](https://warthogs.atlassian.net/browse/JUJU-6246)



[JUJU-6246]: https://warthogs.atlassian.net/browse/JUJU-6246?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ