### PR TITLE
docs(cmd): Updates remove ssh key docs.

### DIFF
--- a/cmd/juju/sshkeys/remove_sshkeys.go
+++ b/cmd/juju/sshkeys/remove_sshkeys.go
@@ -21,10 +21,9 @@ var usageRemoveSSHKeyDetails = `
 Juju maintains a per-model cache of public SSH keys which it copies to
 each unit. This command will remove a specified key (or space separated
 list of keys) from the model cache and all current units deployed in that
-model. The keys to be removed may be specified by the key's fingerprint using a
-sah256 sum, or by the text label associated with them. Invalid keys in the model
-cache can be removed by specifying the key verbatim.
-
+model. The keys to be removed may be specified by the key's fingerprint
+using a SHA256 sum or by the text label associated with them. Keys may also be
+removed by specifying the key verbatim.
 `[1:]
 
 const usageRemoveSSHKeyExamples = `


### PR DESCRIPTION
In 4.0 we are changing the fingerprint has to sha256 and also allowing the user to remove keys via their verbatim definition. This change makes the cmd docs for removing ssh keys reflect the changes made.

This change reflects the changes made in #17500

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- ~[ ] Code style: imports ordered, good names, simple structure, etc~
- ~[ ] Comments saying why design decisions were made~
- ~[ ] Go unit tests, with comments saying what you're testing~
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

N/A

## Documentation changes

Changes the cmd documentation that will be updated when we release 4.0.

## Links

**Jira card:** JUJU-6097

