### PR TITLE
docs: add version notice to autogenerated docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -46,6 +46,12 @@ jobs:
         run: |
           go run ./scripts/md-gen/controller-config
 
+      - name: Add version notice to generated docs
+        env:
+          DOCS_DIR: ${{ steps.gen.outputs.dir }}
+        run: |
+          go run ./scripts/md-gen/version-notice
+
       - name: pip install requirements
         run: |
           python3 -m venv .venv

--- a/scripts/md-gen/controller-config/main.go
+++ b/scripts/md-gen/controller-config/main.go
@@ -376,7 +376,7 @@ func ensureDefined(data map[string]*keyInfo, key string) {
 	}
 }
 
-// check panics if the provided error is nil.
+// check panics if the provided error is not nil.
 func check(err error) {
 	if err != nil {
 		panic(err)

--- a/scripts/md-gen/version-notice/main.go
+++ b/scripts/md-gen/version-notice/main.go
@@ -1,0 +1,74 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/juju/juju/version"
+)
+
+var VERSION_NOTICE = fmt.Sprintf(`
+[note type=caution]
+The information in this doc is based on Juju version %v,
+and may not accurately reflect other versions of Juju.
+[/note]
+
+`[1:], version.Current.String())
+
+// For every doc in $DOCS_DIR, add VERSION_NOTICE to the top.
+func main() {
+	docsDir := mustEnv("DOCS_DIR") // directory to write output to
+
+	check(filepath.WalkDir(docsDir, func(path string, file fs.DirEntry, err error) error {
+		if file.IsDir() {
+			// skip
+			return nil
+		}
+
+		// Create new temp file to store the output
+		tmpFile, err := os.CreateTemp(docsDir, file.Name())
+		check(err)
+
+		// Write version notice header
+		_, err = tmpFile.WriteString(VERSION_NOTICE)
+		check(err)
+
+		// Open original file and copy all to the new file
+		oldFile, err := os.Open(path)
+		check(err)
+		_, err = io.Copy(tmpFile, oldFile)
+		check(err)
+
+		// Delete old file and move new one to original place
+		check(oldFile.Close())
+		check(os.Remove(path))
+		check(os.Rename(tmpFile.Name(), path))
+		check(tmpFile.Close())
+		return nil
+	}))
+}
+
+// UTILITY FUNCTIONS
+
+// Returns the value of the given environment variable, panicking if the var
+// is not set.
+func mustEnv(key string) string {
+	val, ok := os.LookupEnv(key)
+	if !ok {
+		panic(fmt.Sprintf("env var %q not set", key))
+	}
+	return val
+}
+
+// check panics if the provided error is not nil.
+func check(err error) {
+	if err != nil {
+		panic(err)
+	}
+}


### PR DESCRIPTION
<!-- Why this change is needed and what it does. -->

Currently autogenerated docs are synced from a single version of Juju (currently 3.5). Obviously there are differences between the different versions of Juju, and sadly the autogenerated docs cannot reflect that nuance yet. Long-term, we need to think of a solution to account for differences between Juju versions.

But as a short-term enhancement, we can add a notice to the top of each doc, warning users that this doc is based on a certain version of Juju, and may not be accurate for other versions.

<details>
<summary>This is what it looks like</summary>

![Screenshot from 2024-06-26 14-19-42](https://github.com/juju/juju/assets/90195985/73f8a42d-d959-4b98-a34f-87a53fe94798)
</details>

I've added a new script, `md-gen/version-notice`, which iterates over all files in the `docs` folder and prepends a version notice to each. This is a "post-processing" step - it's done after all the docs have been generated, but before they are published to Discourse. It's possible that in the future, there may be more post-processing we want to do on the docs, at which point we can extend / repurpose this script.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- ~[ ] Go unit tests, with comments saying what you're testing~
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

<!-- Describe steps to verify that the change works. -->

```bash
juju documentation --split --out=./docs --discourse-ids ./.github/discourse-topic-ids.yaml
DOCS_DIR=./docs go run ./scripts/md-gen/version-notice/
```

Check the docs in the `./docs` folder have the notice on top.

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Jira card:** JUJU-6248