### PR TITLE
feat(dqlite): Implement NamespaceNotifyWatcher;

### DIFF
--- a/core/watcher/eventsource/value_test.go
+++ b/core/watcher/eventsource/value_test.go
@@ -275,3 +275,259 @@ func (s *valueSuite) TestEnsureCloseOnDirtyKill(c *gc.C) {
 	_, ok := <-w.Changes()
 	c.Assert(ok, jc.IsFalse)
 }
+
+type namespaceNotifyWatcherSuite struct {
+	baseSuite
+}
+
+var _ = gc.Suite(&namespaceNotifyWatcherSuite{})
+
+func (s *namespaceNotifyWatcherSuite) TestNotificationsByPredicate(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	subExp := s.sub.EXPECT()
+
+	// We go through the worker loop minimum 4 times:
+	// - Read initial delta (additional subsequent events aren't guaranteed).
+	// - Dispatch initial notification.
+	// - Read deltas.
+	// - Dispatch notification.
+	// - Pick up tomb.Dying()
+	done := make(chan struct{})
+	subExp.Done().Return(done).MinTimes(4)
+
+	deltas := make(chan []changestream.ChangeEvent)
+	subExp.Changes().Return(deltas)
+
+	subExp.Unsubscribe()
+
+	s.eventsource.EXPECT().Subscribe(
+		subscriptionOptionMatcher{changestream.Namespace("random_namespace", changestream.All)},
+	).Return(s.sub, nil)
+
+	w := NewNamespaceNotifyMapperWatcher(s.newBaseWatcher(c), "random_namespace", changestream.All, func(ctx context.Context, _ database.TxnRunner, e []changestream.ChangeEvent) ([]changestream.ChangeEvent, error) {
+		if len(e) != 1 {
+			c.Fatalf("expected 1 event, got %d", len(e))
+		}
+		if e[0].Changed() == "some-key-value" {
+			return e, nil
+		}
+		return nil, nil
+	})
+	defer workertest.CleanKill(c, w)
+
+	// Initial notification.
+	select {
+	case <-w.Changes():
+	case <-time.After(testing.LongWait):
+		c.Fatal("timed out waiting for initial watcher changes")
+	}
+
+	// Simulate an incoming change from the stream.
+	select {
+	case deltas <- []changestream.ChangeEvent{changeEvent{
+		changeType: 0,
+		namespace:  "random_namespace",
+		changed:    "some-key-value",
+	}}:
+	case <-time.After(testing.LongWait):
+		c.Fatal("timed out dispatching change event")
+	}
+
+	// Notification for change.
+	select {
+	case <-w.Changes():
+	case <-time.After(testing.LongWait):
+		c.Fatal("timed out waiting for initial watcher changes")
+	}
+
+	// Simulate an incoming change from the stream.
+	select {
+	case deltas <- []changestream.ChangeEvent{changeEvent{
+		changeType: 1,
+		namespace:  "random_namespace",
+		changed:    "should-not-match",
+	}}:
+	case <-time.After(testing.LongWait):
+		c.Fatal("timed out dispatching change event")
+	}
+
+	// Notification for change.
+	select {
+	case <-w.Changes():
+		c.Fatal("unexpected changes")
+	case <-time.After(time.Second):
+	}
+
+	workertest.CleanKill(c, w)
+}
+
+func (s *namespaceNotifyWatcherSuite) TestNotificationsByPredicateError(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	subExp := s.sub.EXPECT()
+
+	done := make(chan struct{})
+	subExp.Done().Return(done).MinTimes(1)
+
+	deltas := make(chan []changestream.ChangeEvent)
+	subExp.Changes().Return(deltas)
+
+	subExp.Unsubscribe()
+
+	s.eventsource.EXPECT().Subscribe(
+		subscriptionOptionMatcher{changestream.Namespace("random_namespace", changestream.All)},
+	).Return(s.sub, nil)
+
+	w := NewNamespaceNotifyMapperWatcher(s.newBaseWatcher(c), "random_namespace", changestream.All, func(_ context.Context, _ database.TxnRunner, _ []changestream.ChangeEvent) ([]changestream.ChangeEvent, error) {
+		return nil, errors.Errorf("boom")
+	})
+	defer workertest.DirtyKill(c, w)
+
+	// Initial notification.
+	select {
+	case <-w.Changes():
+	case <-time.After(testing.LongWait):
+		c.Fatal("timed out waiting for initial watcher changes")
+	}
+
+	// Simulate an incoming change from the stream.
+	select {
+	case deltas <- []changestream.ChangeEvent{changeEvent{
+		changeType: 0,
+		namespace:  "random_namespace",
+		changed:    "some-key-value",
+	}}:
+	case <-time.After(testing.LongWait):
+		c.Fatal("timed out dispatching change event")
+	}
+
+	// Notification for change.
+	select {
+	case _, ok := <-w.Changes():
+		// Ensure the channel is closed, when the predicate dies.
+		c.Assert(ok, jc.IsFalse)
+	case <-time.After(testing.LongWait):
+		c.Fatal("timed out waiting for initial watcher changes")
+	}
+
+	err := workertest.CheckKill(c, w)
+	c.Assert(err, gc.ErrorMatches, "boom")
+}
+
+func (s *namespaceNotifyWatcherSuite) TestNotificationsSent(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	subExp := s.sub.EXPECT()
+
+	// We go through the worker loop minimum 4 times:
+	// - Read initial delta (additional subsequent events aren't guaranteed).
+	// - Dispatch initial notification.
+	// - Read deltas.
+	// - Dispatch notification.
+	// - Pick up tomb.Dying()
+	done := make(chan struct{})
+	subExp.Done().Return(done).MinTimes(4)
+
+	deltas := make(chan []changestream.ChangeEvent)
+	subExp.Changes().Return(deltas)
+
+	subExp.Unsubscribe()
+
+	s.eventsource.EXPECT().Subscribe(
+		subscriptionOptionMatcher{changestream.Namespace("random_namespace", changestream.All)},
+	).Return(s.sub, nil)
+
+	w := NewNamespaceNotifyWatcher(s.newBaseWatcher(c), "random_namespace", changestream.All)
+	defer workertest.CleanKill(c, w)
+
+	// Initial notification.
+	select {
+	case <-w.Changes():
+	case <-time.After(testing.LongWait):
+		c.Fatal("timed out waiting for initial watcher changes")
+	}
+
+	// Simulate an incoming change from the stream.
+	select {
+	case deltas <- []changestream.ChangeEvent{changeEvent{
+		changeType: 0,
+		namespace:  "random_namespace",
+		changed:    "some-key-value",
+	}}:
+	case <-time.After(testing.LongWait):
+		c.Fatal("timed out dispatching change event")
+	}
+
+	// Notification for change.
+	select {
+	case <-w.Changes():
+	case <-time.After(testing.LongWait):
+		c.Fatal("timed out waiting for initial watcher changes")
+	}
+
+	workertest.CleanKill(c, w)
+}
+
+func (s *namespaceNotifyWatcherSuite) TestSubscriptionDoneKillsWorker(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	subExp := s.sub.EXPECT()
+	subExp.Changes().Return(make(chan []changestream.ChangeEvent)).AnyTimes()
+
+	done := make(chan struct{})
+	close(done)
+	subExp.Done().Return(done)
+
+	subExp.Unsubscribe()
+
+	s.eventsource.EXPECT().Subscribe(
+		subscriptionOptionMatcher{changestream.Namespace("random_namespace", changestream.All)},
+	).Return(s.sub, nil)
+
+	w := NewNamespaceNotifyWatcher(s.newBaseWatcher(c), "random_namespace", changestream.All)
+	defer workertest.DirtyKill(c, w)
+
+	err := workertest.CheckKilled(c, w)
+	c.Check(err, jc.ErrorIs, ErrSubscriptionClosed)
+}
+
+func (s *namespaceNotifyWatcherSuite) TestEnsureCloseOnCleanKill(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	subExp := s.sub.EXPECT()
+	done := make(chan struct{})
+	subExp.Changes().Return(make(chan []changestream.ChangeEvent)).AnyTimes()
+	subExp.Done().Return(done)
+	subExp.Unsubscribe()
+
+	s.eventsource.EXPECT().Subscribe(
+		subscriptionOptionMatcher{changestream.Namespace("random_namespace", changestream.All)},
+	).Return(s.sub, nil)
+
+	w := NewNamespaceNotifyWatcher(s.newBaseWatcher(c), "random_namespace", changestream.All)
+
+	workertest.CleanKill(c, w)
+	_, ok := <-w.Changes()
+	c.Assert(ok, jc.IsFalse)
+}
+
+func (s *namespaceNotifyWatcherSuite) TestEnsureCloseOnDirtyKill(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	subExp := s.sub.EXPECT()
+	done := make(chan struct{})
+	subExp.Changes().Return(make(chan []changestream.ChangeEvent))
+	subExp.Done().Return(done)
+	subExp.Unsubscribe()
+
+	s.eventsource.EXPECT().Subscribe(
+		subscriptionOptionMatcher{changestream.Namespace("random_namespace", changestream.All)},
+	).Return(s.sub, nil)
+
+	w := NewNamespaceNotifyWatcher(s.newBaseWatcher(c), "random_namespace", changestream.All)
+
+	workertest.DirtyKill(c, w)
+	_, ok := <-w.Changes()
+	c.Assert(ok, jc.IsFalse)
+}

--- a/domain/watcher.go
+++ b/domain/watcher.go
@@ -72,6 +72,32 @@ func (f *WatcherFactory) NewNamespaceMapperWatcher(
 	), nil
 }
 
+// NewNamespaceNotifyWatcher returns a new namespace notify watcher
+// for events based on the input change mask.
+func (f *WatcherFactory) NewNamespaceNotifyWatcher(
+	namespace string, changeMask changestream.ChangeType,
+) (watcher.NotifyWatcher, error) {
+	base, err := f.newBaseWatcher()
+	if err != nil {
+		return nil, errors.Annotate(err, "creating base watcher")
+	}
+
+	return eventsource.NewNamespaceNotifyWatcher(base, namespace, changeMask), nil
+}
+
+// NewNamespaceNotifyMapperWatcher returns a new namespace notify watcher
+// for events based on the input change mask and mapper.
+func (f *WatcherFactory) NewNamespaceNotifyMapperWatcher(
+	namespace string, changeMask changestream.ChangeType, mapper eventsource.Mapper,
+) (watcher.NotifyWatcher, error) {
+	base, err := f.newBaseWatcher()
+	if err != nil {
+		return nil, errors.Annotate(err, "creating base watcher")
+	}
+
+	return eventsource.NewNamespaceNotifyMapperWatcher(base, namespace, changeMask, mapper), nil
+}
+
 // NewValueWatcher returns a watcher for a particular change value
 // in a namespace, based on the input change mask.
 func (f *WatcherFactory) NewValueWatcher(

--- a/domain/watcher_test.go
+++ b/domain/watcher_test.go
@@ -134,6 +134,57 @@ func (s *watcherSuite) TestNewNamespaceMapperWatcherSuccess(c *gc.C) {
 	workertest.CleanKill(c, w)
 }
 
+func (s *watcherSuite) TestNewNamespaceNotifyWatcherSuccess(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+	s.expectSourceWithSub()
+
+	factory := NewWatcherFactory(func() (changestream.WatchableDB, error) {
+		return &watchableDB{
+			TxnRunner:   s.TxnRunner(),
+			EventSource: s.events,
+		}, nil
+	}, nil)
+
+	w, err := factory.NewNamespaceNotifyWatcher("some-namespace", changestream.All)
+	c.Assert(err, jc.ErrorIsNil)
+
+	select {
+	case <-w.Changes():
+	case <-time.After(jujutesting.ShortWait):
+		c.Fatal("timed out waiting for change event")
+	}
+
+	workertest.CleanKill(c, w)
+}
+
+func (s *watcherSuite) TestNewNamespaceNotifyMapperWatcherSuccess(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+	s.expectSourceWithSub()
+
+	factory := NewWatcherFactory(func() (changestream.WatchableDB, error) {
+		return &watchableDB{
+			TxnRunner:   s.TxnRunner(),
+			EventSource: s.events,
+		}, nil
+	}, nil)
+
+	w, err := factory.NewNamespaceNotifyMapperWatcher(
+		"some-namespace", changestream.All,
+		func(ctx context.Context, tr database.TxnRunner, ce []changestream.ChangeEvent) ([]changestream.ChangeEvent, error) {
+			return ce, nil
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+
+	select {
+	case <-w.Changes():
+	case <-time.After(jujutesting.ShortWait):
+		c.Fatal("timed out waiting for change event")
+	}
+
+	workertest.CleanKill(c, w)
+}
+
 func (s *watcherSuite) TestNewValueWatcherSuccess(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	s.expectSourceWithSub()


### PR DESCRIPTION
This PR implements the NamespaceNotifyWatcher for watching changes in a namespace.
This is a similar implementation to ValueWatcher but without the need to provide an expected change value. Any time events matching the change mask occur in the namespace, a notification is emitted.


## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

It's not been used yet, so just run unit tests.

## Documentation changes

No

## Links

**Jira card:** [JUJU-6250](https://warthogs.atlassian.net/browse/JUJU-6250)



[JUJU-6250]: https://warthogs.atlassian.net/browse/JUJU-6250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ