### PR TITLE
style: use SQLair in the lease domain

### DIFF
--- a/domain/lease/doc.go
+++ b/domain/lease/doc.go
@@ -1,0 +1,13 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package lease provides the service for creating and tracking leases.
+//
+// Leases are used in Juju to track responsibility for tasks that need a
+// singular owner. This can be required in many places where there are multiple
+// equivalent instances of a process. For example, when juju is running in high
+// availability mode with multiple controllers, there should only be one machine
+// provisioner per model. The leases can be used to ensure only one of the
+// controller instances runs the provisioner for a given model.
+
+package lease

--- a/domain/lease/state/types.go
+++ b/domain/lease/state/types.go
@@ -1,0 +1,54 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"database/sql/driver"
+	"fmt"
+	"math"
+	"time"
+)
+
+// Lease represents a lease to be serialised to the database.
+type Lease struct {
+	// UUID is the unique id of the lease.
+	UUID string `db:"uuid"`
+	// Type is the name of the type.
+	Type string `db:"type"`
+	// ModelUUID is the UUID of the model the lease is for.
+	ModelUUID string `db:"model_uuid"`
+	// Name is the name of the lease.
+	Name string `db:"name"`
+	// Holder is the holder of the lease.
+	Holder string `db:"holder"`
+	// Start is the lease start time.
+	Start time.Time `db:"start"`
+	// Duration is the duration of the lease. It is used only when inserting an
+	// expiry time, the actual time is calculated from the duration by the
+	// database.
+	Duration LeaseDuration `db:"duration"`
+	// Expiry is the lease expiry time. Expiry is only used to read expiry
+	// times, Duration is used for writing.
+	Expiry time.Time `db:"expiry"`
+}
+
+type LeaseDuration time.Duration
+
+// Value implements the Valuer interface for scanning
+func (d LeaseDuration) Value() (driver.Value, error) {
+	return fmt.Sprintf("+%d seconds", int64(math.Ceil(time.Duration(d).Seconds()))), nil
+}
+
+// LeasePin represents a lease pin to be serialised to the database.
+type LeasePin struct {
+	// UUID is the unique identifier of the lease pin.
+	UUID string `db:"uuid"`
+	// EntityID is the id of the entity requesting the pin.
+	EntityID string `db:"entity_id"`
+}
+
+// Count is used count leases.
+type Count struct {
+	Num int `db:"num"`
+}


### PR DESCRIPTION
Switch to using SQLair in the lease domain. Also add `domain.Coerce` error wrapper where needed.

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps
To QA, we can go into HA and deploy a few units. To go into HA we need a non-file backed object store.

Start minio as to use as the s3 object store.
```
docker run -p 9000:9000 -p 9001:9001 \
  quay.io/minio/minio server /data --console-address ":9001"
```

Go to http://localhost:9001/access-keys and add an access key, keeping note of the key and secret as env var `S3_KEY` and `S3_SECRET`.
Also make a note of the IP for minio (not the `localhost` one) as `IP_ADDRESS`.

Now bootstrap with the s3 object store specified.
```
$ bootstrap lxd test --build-agent --config="object-store-type=s3" --config="object-store-s3-endpoint=http://${IP_ADDRESS}:9000" --config="object-store-s3-static-key=${S3_KEY}" --config="object-store-s3-static-secret=${S3_SECRET}"
```

Now its deployed try going into HA:
```
$ juju enable-ha
$ juju add-model default
$ juju deploy juju-qa-test --resource foo-file="./tests/suites/resources/foo-file.txt"
$ juju deploy ubuntu -n 3
$ juju destroy-model default
```


<!-- Describe steps to verify that the change works. -->

## Documentation changes
Added doc.go to the lease domain.
<!-- How it affects user workflow (CLI or API). -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Jira card:** https://warthogs.atlassian.net/browse/JUJU-6191

