### PR TITLE
fix: allow migration from 3.6

### DIFF
--- a/domain/model/service/service.go
+++ b/domain/model/service/service.go
@@ -147,15 +147,14 @@ func NewService(
 }
 
 // DefaultAgentBinaryFinder is a transition implementation of the agent binary
-// finder that will false for any version that is not the current controller
-// version.
+// finder that will true for any version.
 // This will be removed and replaced soon.
 func DefaultAgentBinaryFinder() AgentBinaryFinder {
 	return agentBinaryFinderFn(func(v version.Number) (bool, error) {
-		if v.Compare(jujuversion.Current) == 0 {
-			return true, nil
-		}
-		return false, nil
+		// This is a temporary implementation that will be replaced. We need
+		// to ensure that we always return true for now, so that we can be
+		// sure that the 3.6 LTS release will work with the controller.
+		return true, nil
 	})
 }
 

--- a/domain/model/service/service_test.go
+++ b/domain/model/service/service_test.go
@@ -514,10 +514,8 @@ func (s *serviceSuite) TestAgentVersionUnsupportedGreater(c *gc.C) {
 	c.Assert(exists, jc.IsFalse)
 }
 
-// TestAgentVersionUnsupportedGreater is asserting that if we try and create a
-// model with an agent version that is less then that of the controller the
-// operation fails with a [modelerrors.AgentVersionNotSupported] error. This
-// fails because find tools will report [errors.NotFound].
+// TestAgentVersionUnsupportedLess is asserting that if we try and create a
+// model with an agent version that is less then that of the controller.
 func (s *serviceSuite) TestAgentVersionUnsupportedLess(c *gc.C) {
 	cred := credential.Key{
 		Cloud: "aws",
@@ -544,7 +542,8 @@ func (s *serviceSuite) TestAgentVersionUnsupportedLess(c *gc.C) {
 		Name:         "my-awesome-model",
 	})
 
-	c.Assert(err, jc.ErrorIs, modelerrors.AgentVersionNotSupported)
+	// This is temporary until we implement tools metadata for the controller.
+	c.Assert(err, jc.ErrorIsNil)
 
 	_, exists := s.state.models[id]
 	c.Assert(exists, jc.IsFalse)


### PR DESCRIPTION
The restriction within the model service prevented the migration from 3.6 edge. We don't want that restriction to exist whilst 3.6 is an ongoing LTS. The LTS must be able to migrate to main and we don't want to be in a mad scramble to fix it. This change will mandate that a migration from 3.6 to main must work from the get go.

No exceptions.

--- 

Work is required to fix 3.6 so that the uniter doesn't bounce in the absence of some facades.

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

### Setup 3.6

```sh
$ git checkout 3.6
$ make juju jujud jujud-controller
$ juju bootstrap lxd test36
$ juju add-model moveme
$ juju deploy ubuntu
```

### Setup 4.0

```sh
$ git checkout this-pr
$ make juju jujud jujud-controller
$ juju bootstrap lxd test40
```

### Migrate

```sh
$ juju migrate test36:moveme test40
```


## Links

**Jira card:** [JUJU-6188](https://warthogs.atlassian.net/browse/JUJU-6188)



[JUJU-6188]: https://warthogs.atlassian.net/browse/JUJU-6188?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ