### PR TITLE
fix(charm): icmp open-port not supported on caas

### DIFF
--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -2681,6 +2681,11 @@ func (u *UniterAPI) commitHookChangesForOneUnit(unitTag names.UnitTag, changes p
 				return apiservererrors.ErrPerm
 			}
 
+			// ICMP is not supported on CAAS models.
+			if u.m.Type() == state.ModelTypeCAAS && r.Protocol == "icmp" {
+				return errors.NotSupportedf("protocol icmp on caas models")
+			}
+
 			// Pre-2.9 clients (using V15 or V16 of this API) do
 			// not populate the new Endpoint field; this
 			// effectively opens the port for all endpoints and


### PR DESCRIPTION
Currently when a charm calls the `open-port` hook tool with `icmp` on k8s, we commit the change and the firewaller worker freaks out, bounces with an error that's not very useful.

So we validate and bail out at the apiserver (where the business logic
is) before committing the port change so no one down the stream freaks
out (e.g. firewaller worker), and we communicate the error back to the
charm so it can be handled there if need be.

https://bugs.launchpad.net/juju/+bug/2009102

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

For this, we'll need a charm that calls the open-port hook tool. So,

```
mkdir mycharm && cd mycharm && charmcraft init 
```

Go ahead and add `self.unit.open_port("icmp")` on a handler in the `src/charm.py` (I put it at the end of the `_on_httpbin_pebble_ready`).

```
 $ charmcraft pack
./mycharm_ubuntu-22.04-amd64.charm
```

Bootstrap on k8s:

```
juju bootstrap microk8s deleteme && juju add-model test
```

Deploy the charm:
```
juju deploy ./mycharm_ubuntu-22.04-amd64.charm
```

Before this change, you'd see on the controller debug log:

> ``` controller-0: 15:00:50 ERROR juju.worker.dependency "caas-firewaller-embedded" manifold worker returned unexpected error: cannot update service port for application "database": protocol "icmp" for service "icmp" not valid```

Now you should see in the model debug log:

> ```ERROR juju.worker.uniter.context cannot apply changes: protocol icmp on caas models not supported```

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2009102

**Jira card:** JUJU-6177

