### PR TITLE
fix(docs): handle schema.NonEmptyString in controller config keys doc generation

### DIFF
--- a/scripts/md-gen/controller-config/main.go
+++ b/scripts/md-gen/controller-config/main.go
@@ -223,11 +223,12 @@ func fillFromConfigCheckerAST(data map[string]*keyInfo, configChecker *ast.GenDe
 // get type from configChecker expressions
 func typeForExpr(expr ast.Expr) string {
 	niceNames := map[string]string{
-		"Bool":         "boolean",
-		"ForceInt":     "integer",
-		"List":         "list",
-		"String":       "string",
-		"TimeDuration": "duration",
+		"Bool":           "boolean",
+		"ForceInt":       "integer",
+		"List":           "list",
+		"String":         "string",
+		"TimeDuration":   "duration",
+		"NonEmptyString": "non-empty string",
 	}
 	niceNameFor := func(rawType string) string {
 		if nn, ok := niceNames[rawType]; ok {
@@ -240,7 +241,8 @@ func typeForExpr(expr ast.Expr) string {
 	rawType := callExpr.Fun.(*ast.SelectorExpr).Sel.Name
 	dataType := niceNameFor(rawType)
 
-	if len(callExpr.Args) > 0 {
+	// Don't recurse for schema.NonEmptyString
+	if rawType != "NonEmptyString" && len(callExpr.Args) > 0 {
 		// add parameter types
 		dataType += "["
 		for i, arg := range callExpr.Args {


### PR DESCRIPTION
#17554 changed the type of `controller-name` to `schema.NonEmptyString` in the controller config schema. The `md-gen/controller-config` script, which generates the [controller config keys doc](https://juju.is/docs/juju/list-of-controller-configuration-keys), did not have logic to handle this schema type. Modify the script to be able to handle this.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- ~[ ] Go unit tests, with comments saying what you're testing~
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

<!-- Describe steps to verify that the change works. -->

Generate the controller config keys doc
```
export DOCS_DIR=./docs
export JUJU_SRC_ROOT=.
go run ./scripts/md-gen/controller-config
```
Check that the "controller-name" section is all good.