### PR TITLE
fix: migrate 3.6 to 4.0

### DIFF
--- a/api/agent/meterstatus/client.go
+++ b/api/agent/meterstatus/client.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/juju/api/base"
 	apiwatcher "github.com/juju/juju/api/watcher"
+	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/rpc/params"
 )
@@ -47,7 +48,7 @@ func (c *Client) MeterStatus() (statusCode, statusInfo string, rErr error) {
 	}
 	err := c.facade.FacadeCall("GetMeterStatus", args, &results)
 	if err != nil {
-		return "", "", errors.Trace(err)
+		return "", "", errors.Trace(apiservererrors.RestoreError(err))
 	}
 	if len(results.Results) != 1 {
 		return "", "", errors.Errorf("expected 1 result, got %d", len(results.Results))
@@ -67,7 +68,7 @@ func (c *Client) WatchMeterStatus() (watcher.NotifyWatcher, error) {
 	}
 	err := c.facade.FacadeCall("WatchMeterStatus", args, &results)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(apiservererrors.RestoreError(err))
 	}
 	if len(results.Results) != 1 {
 		return nil, errors.Errorf("expected 1 result, got %d", len(results.Results))

--- a/api/agent/meterstatus/client_test.go
+++ b/api/agent/meterstatus/client_test.go
@@ -6,12 +6,14 @@ package meterstatus_test
 import (
 	"fmt"
 
+	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/api/agent/meterstatus"
 	"github.com/juju/juju/api/base/testing"
+	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/rpc/params"
 	coretesting "github.com/juju/juju/testing"
 )
@@ -54,6 +56,19 @@ func (s *meterStatusSuite) TestGetMeterStatus(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(statusCode, gc.Equals, "GREEN")
 	c.Assert(statusInfo, gc.Equals, "All ok.")
+}
+
+func (s *meterStatusSuite) TestGetMeterStatusNotImplemented(c *gc.C) {
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		return apiservererrors.ServerError(errors.NotImplementedf("not implemented"))
+	})
+
+	tag := names.NewUnitTag("wp/1")
+	status := meterstatus.NewClient(apiCaller, tag)
+	c.Assert(status, gc.NotNil)
+
+	_, _, err := status.MeterStatus()
+	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
 }
 
 func (s *meterStatusSuite) TestGetMeterStatusResultError(c *gc.C) {
@@ -162,6 +177,19 @@ func (s *meterStatusSuite) TestWatchMeterStatusError(c *gc.C) {
 	c.Assert(called, jc.IsTrue)
 	c.Assert(err, gc.ErrorMatches, "could not retrieve meter status watcher")
 	c.Assert(w, gc.IsNil)
+}
+
+func (s *meterStatusSuite) TestWatchMeterStatusNotImplemented(c *gc.C) {
+	apiCaller := testing.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		return apiservererrors.ServerError(errors.NotImplementedf("not implemented"))
+	})
+
+	tag := names.NewUnitTag("wp/1")
+	status := meterstatus.NewClient(apiCaller, tag)
+	c.Assert(status, gc.NotNil)
+
+	_, err := status.WatchMeterStatus()
+	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
 }
 
 func (s *meterStatusSuite) TestWatchMeterStatusMoreResults(c *gc.C) {

--- a/api/agent/uniter/unit.go
+++ b/api/agent/uniter/unit.go
@@ -71,7 +71,7 @@ func (u *Unit) Refresh() error {
 	}
 	err := u.st.facade.FacadeCall("Refresh", args, &results)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Trace(apiservererrors.RestoreError(err))
 	}
 	if len(results.Results) != 1 {
 		return errors.Errorf("expected 1 result, got %d", len(results.Results))
@@ -102,7 +102,7 @@ func (u *Unit) SetUnitStatus(unitStatus status.Status, info string, data map[str
 	}
 	err := u.st.facade.FacadeCall("SetUnitStatus", args, &result)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Trace(apiservererrors.RestoreError(err))
 	}
 	return result.OneError()
 }
@@ -117,7 +117,7 @@ func (u *Unit) UnitStatus() (params.StatusResult, error) {
 	}
 	err := u.st.facade.FacadeCall("UnitStatus", args, &results)
 	if err != nil {
-		return params.StatusResult{}, errors.Trace(err)
+		return params.StatusResult{}, errors.Trace(apiservererrors.RestoreError(err))
 	}
 	if len(results.Results) != 1 {
 		return params.StatusResult{}, errors.Errorf("expected 1 result, got %d", len(results.Results))
@@ -139,7 +139,7 @@ func (u *Unit) SetAgentStatus(agentStatus status.Status, info string, data map[s
 	}
 	err := u.st.facade.FacadeCall("SetAgentStatus", args, &result)
 	if err != nil {
-		return err
+		return errors.Trace(apiservererrors.RestoreError(err))
 	}
 	return result.OneError()
 }
@@ -155,7 +155,7 @@ func (u *Unit) AddMetrics(metrics []params.Metric) error {
 	}
 	err := u.st.facade.FacadeCall("AddMetrics", args, &result)
 	if err != nil {
-		return errors.Annotate(err, "unable to add metric")
+		return errors.Annotate(errors.Trace(apiservererrors.RestoreError(err)), "unable to add metric")
 	}
 	return result.OneError()
 }
@@ -177,7 +177,7 @@ func (u *Unit) AddMetricBatches(batches []params.MetricBatch) (map[string]error,
 	results := new(params.ErrorResults)
 	err := u.st.facade.FacadeCall("AddMetricBatches", p, results)
 	if err != nil {
-		return nil, errors.Annotate(err, "failed to send metric batches")
+		return nil, errors.Annotate(errors.Trace(apiservererrors.RestoreError(err)), "failed to send metric batches")
 	}
 	for i, result := range results.Results {
 		batchResults[batches[i].UUID] = result.Error
@@ -194,7 +194,7 @@ func (u *Unit) EnsureDead() error {
 	}
 	err := u.st.facade.FacadeCall("EnsureDead", args, &result)
 	if err != nil {
-		return err
+		return errors.Trace(apiservererrors.RestoreError(err))
 	}
 	return result.OneError()
 }
@@ -213,7 +213,7 @@ func (u *Unit) WatchRelations() (watcher.StringsWatcher, error) {
 	}
 	err := u.st.facade.FacadeCall("WatchUnitRelations", args, &results)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(apiservererrors.RestoreError(err))
 	}
 	if len(results.Results) != 1 {
 		return nil, errors.Errorf("expected 1 result, got %d", len(results.Results))
@@ -252,7 +252,7 @@ func (u *Unit) ConfigSettings() (charm.Settings, error) {
 	}
 	err := u.st.facade.FacadeCall("ConfigSettings", args, &results)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(apiservererrors.RestoreError(err))
 	}
 	if len(results.Results) != 1 {
 		return nil, errors.Errorf("expected 1 result, got %d", len(results.Results))
@@ -290,7 +290,7 @@ func (u *Unit) Destroy() error {
 	}
 	err := u.st.facade.FacadeCall("Destroy", args, &result)
 	if err != nil {
-		return err
+		return errors.Trace(apiservererrors.RestoreError(err))
 	}
 	return result.OneError()
 }
@@ -303,7 +303,7 @@ func (u *Unit) DestroyAllSubordinates() error {
 	}
 	err := u.st.facade.FacadeCall("DestroyAllSubordinates", args, &result)
 	if err != nil {
-		return err
+		return errors.Trace(apiservererrors.RestoreError(err))
 	}
 	return result.OneError()
 }
@@ -319,7 +319,7 @@ func (u *Unit) AssignedMachine() (names.MachineTag, error) {
 	}
 	err := u.st.facade.FacadeCall("AssignedMachine", args, &results)
 	if err != nil {
-		return invalidTag, err
+		return invalidTag, errors.Trace(apiservererrors.RestoreError(err))
 	}
 	if len(results.Results) != 1 {
 		return invalidTag, errors.Errorf("expected 1 result, got %d", len(results.Results))
@@ -343,7 +343,7 @@ func (u *Unit) PrincipalName() (string, bool, error) {
 	}
 	err := u.st.facade.FacadeCall("GetPrincipal", args, &results)
 	if err != nil {
-		return "", false, err
+		return "", false, errors.Trace(apiservererrors.RestoreError(err))
 	}
 	if len(results.Results) != 1 {
 		return "", false, errors.Errorf("expected 1 result, got %d", len(results.Results))
@@ -371,7 +371,7 @@ func (u *Unit) HasSubordinates() (bool, error) {
 	}
 	err := u.st.facade.FacadeCall("HasSubordinates", args, &results)
 	if err != nil {
-		return false, err
+		return false, errors.Trace(apiservererrors.RestoreError(err))
 	}
 	if len(results.Results) != 1 {
 		return false, errors.Errorf("expected 1 result, got %d", len(results.Results))
@@ -398,7 +398,7 @@ func (u *Unit) PublicAddress() (string, error) {
 	}
 	err := u.st.facade.FacadeCall("PublicAddress", args, &results)
 	if err != nil {
-		return "", err
+		return "", errors.Trace(apiservererrors.RestoreError(err))
 	}
 	if len(results.Results) != 1 {
 		return "", errors.Errorf("expected 1 result, got %d", len(results.Results))
@@ -425,7 +425,7 @@ func (u *Unit) PrivateAddress() (string, error) {
 	}
 	err := u.st.facade.FacadeCall("PrivateAddress", args, &results)
 	if err != nil {
-		return "", err
+		return "", errors.Trace(apiservererrors.RestoreError(err))
 	}
 	if len(results.Results) != 1 {
 		return "", errors.Errorf("expected 1 result, got %d", len(results.Results))
@@ -444,7 +444,7 @@ func (u *Unit) AvailabilityZone() (string, error) {
 		Entities: []params.Entity{{Tag: u.tag.String()}},
 	}
 	if err := u.st.facade.FacadeCall("AvailabilityZone", args, &results); err != nil {
-		return "", errors.Trace(err)
+		return "", errors.Trace(apiservererrors.RestoreError(err))
 	}
 	if len(results.Results) != 1 {
 		return "", errors.Errorf("expected 1 result, got %d", len(results.Results))
@@ -466,7 +466,7 @@ func (u *Unit) CharmURL() (string, error) {
 	}
 	err := u.st.facade.FacadeCall("CharmURL", args, &results)
 	if err != nil {
-		return "", err
+		return "", errors.Trace(apiservererrors.RestoreError(err))
 	}
 	if len(results.Results) != 1 {
 		return "", errors.Errorf("expected 1 result, got %d", len(results.Results))
@@ -495,7 +495,7 @@ func (u *Unit) SetCharmURL(curl string) error {
 	}
 	err := u.st.facade.FacadeCall("SetCharmURL", args, &result)
 	if err != nil {
-		return err
+		return errors.Trace(apiservererrors.RestoreError(err))
 	}
 	return result.OneError()
 }
@@ -508,7 +508,7 @@ func (u *Unit) ClearResolved() error {
 	}
 	err := u.st.facade.FacadeCall("ClearResolved", args, &result)
 	if err != nil {
-		return err
+		return errors.Trace(apiservererrors.RestoreError(err))
 	}
 	return result.OneError()
 }
@@ -538,7 +538,7 @@ func getHashWatcher(u *Unit, methodName string) (watcher.StringsWatcher, error) 
 	}
 	err := u.st.facade.FacadeCall(methodName, args, &results)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(apiservererrors.RestoreError(err))
 	}
 	if len(results.Results) != 1 {
 		return nil, errors.Errorf("expected 1 result, got %d", len(results.Results))
@@ -572,7 +572,7 @@ func (u *Unit) WatchActionNotifications() (watcher.StringsWatcher, error) {
 	}
 	err := u.st.facade.FacadeCall("WatchActionNotifications", args, &results)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(apiservererrors.RestoreError(err))
 	}
 	if len(results.Results) != 1 {
 		return nil, errors.Errorf("expected 1 result, got %d", len(results.Results))
@@ -599,7 +599,7 @@ func (u *Unit) LogActionMessage(tag names.ActionTag, message string) error {
 	}
 	err := u.st.facade.FacadeCall("LogActionsMessages", args, &result)
 	if err != nil {
-		return err
+		return errors.Trace(apiservererrors.RestoreError(err))
 	}
 	return result.OneError()
 }
@@ -626,7 +626,7 @@ func (u *Unit) RequestReboot() error {
 	}
 	err = u.st.facade.FacadeCall("RequestReboot", args, &result)
 	if err != nil {
-		return err
+		return errors.Trace(apiservererrors.RestoreError(err))
 	}
 	return result.OneError()
 }
@@ -652,7 +652,7 @@ func (u *Unit) RelationsStatus() ([]RelationStatus, error) {
 	var results params.RelationUnitStatusResults
 	err := u.st.facade.FacadeCall("RelationsStatus", args, &results)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(apiservererrors.RestoreError(err))
 	}
 	if len(results.Results) != 1 {
 		return nil, errors.Errorf("expected 1 result, got %d", len(results.Results))
@@ -684,7 +684,7 @@ func (u *Unit) MeterStatus() (statusCode, statusInfo string, rErr error) {
 	}
 	err := u.st.facade.FacadeCall("GetMeterStatus", args, &results)
 	if err != nil {
-		return "", "", errors.Trace(err)
+		return "", "", errors.Trace(apiservererrors.RestoreError(err))
 	}
 	if len(results.Results) != 1 {
 		return "", "", errors.Errorf("expected 1 result, got %d", len(results.Results))
@@ -705,7 +705,7 @@ func (u *Unit) WatchMeterStatus() (watcher.NotifyWatcher, error) {
 	}
 	err := u.st.facade.FacadeCall("WatchMeterStatus", args, &results)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(apiservererrors.RestoreError(err))
 	}
 	if len(results.Results) != 1 {
 		return nil, errors.Errorf("expected 1 result, got %d", len(results.Results))
@@ -734,7 +734,7 @@ func (u *Unit) WatchInstanceData() (watcher.NotifyWatcher, error) {
 	}
 	err := u.st.facade.FacadeCall("WatchInstanceData", args, &results)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(apiservererrors.RestoreError(err))
 	}
 	if len(results.Results) != 1 {
 		return nil, errors.Errorf("expected 1 result, got %d", len(results.Results))
@@ -756,7 +756,7 @@ func (u *Unit) LXDProfileName() (string, error) {
 	}
 	err := u.st.facade.FacadeCall("LXDProfileName", args, &results)
 	if err != nil {
-		return "", err
+		return "", errors.Trace(apiservererrors.RestoreError(err))
 	}
 	if len(results.Results) != 1 {
 		return "", errors.Errorf("expected 1 result, got %d", len(results.Results))
@@ -777,7 +777,7 @@ func (u *Unit) CanApplyLXDProfile() (bool, error) {
 	}
 	err := u.st.facade.FacadeCall("CanApplyLXDProfile", args, &results)
 	if err != nil {
-		return false, err
+		return false, errors.Trace(apiservererrors.RestoreError(err))
 	}
 	if len(results.Results) != 1 {
 		return false, errors.Errorf("expected 1 result, got %d", len(results.Results))
@@ -800,7 +800,7 @@ func (u *Unit) NetworkInfo(bindings []string, relationId *int) (map[string]param
 
 	err := u.st.facade.FacadeCall("NetworkInfo", args, &results)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Trace(apiservererrors.RestoreError(err))
 	}
 
 	return results.Results, nil
@@ -825,7 +825,7 @@ func (u *Unit) CommitHookChanges(req params.CommitHookChangesArgs) error {
 	var results params.ErrorResults
 	err := u.st.facade.FacadeCall("CommitHookChanges", req, &results)
 	if err != nil {
-		return err
+		return errors.Trace(apiservererrors.RestoreError(err))
 	}
 	return apiservererrors.RestoreError(results.OneError())
 }

--- a/api/agent/uniter/unit_test.go
+++ b/api/agent/uniter/unit_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/juju/juju/api/agent/uniter"
 	basetesting "github.com/juju/juju/api/base/testing"
+	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/status"
@@ -54,6 +55,16 @@ func (s *unitSuite) TestUnitAndUnitTag(c *gc.C) {
 	c.Assert(unit.ApplicationTag(), gc.Equals, names.NewApplicationTag("mysql"))
 }
 
+func (s *unitSuite) TestUnitAndUnitTagNotImplemented(c *gc.C) {
+	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		return apiservererrors.ServerError(errors.NotImplementedf("not implemented"))
+	})
+	tag := names.NewUnitTag("mysql/0")
+	client := uniter.NewState(apiCaller, tag)
+	_, err := client.Unit(tag)
+	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
+}
+
 func (s *unitSuite) TestSetAgentStatus(c *gc.C) {
 	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Assert(objType, gc.Equals, "Uniter")
@@ -65,7 +76,7 @@ func (s *unitSuite) TestSetAgentStatus(c *gc.C) {
 		})
 		c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
 		*(result.(*params.ErrorResults)) = params.ErrorResults{
-			Results: []params.ErrorResult{{&params.Error{Message: "biff"}}},
+			Results: []params.ErrorResult{{Error: &params.Error{Message: "biff"}}},
 		}
 		return nil
 	})
@@ -74,6 +85,18 @@ func (s *unitSuite) TestSetAgentStatus(c *gc.C) {
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
 	err := unit.SetAgentStatus(status.Idle, "blah", map[string]interface{}{"foo": "bar"})
 	c.Assert(err, gc.ErrorMatches, "biff")
+}
+
+func (s *unitSuite) TestSetAgentStatusNotImplemented(c *gc.C) {
+	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		return apiservererrors.ServerError(errors.NotImplementedf("not implemented"))
+	})
+	tag := names.NewUnitTag("mysql/0")
+	client := uniter.NewState(apiCaller, tag)
+
+	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
+	err := unit.SetAgentStatus(status.Idle, "blah", map[string]interface{}{"foo": "bar"})
+	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
 }
 
 func (s *unitSuite) TestSetUnitStatus(c *gc.C) {
@@ -87,7 +110,7 @@ func (s *unitSuite) TestSetUnitStatus(c *gc.C) {
 		})
 		c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
 		*(result.(*params.ErrorResults)) = params.ErrorResults{
-			Results: []params.ErrorResult{{&params.Error{Message: "biff"}}},
+			Results: []params.ErrorResult{{Error: &params.Error{Message: "biff"}}},
 		}
 		return nil
 	})
@@ -96,6 +119,18 @@ func (s *unitSuite) TestSetUnitStatus(c *gc.C) {
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
 	err := unit.SetUnitStatus(status.Idle, "blah", map[string]interface{}{"foo": "bar"})
 	c.Assert(err, gc.ErrorMatches, "biff")
+}
+
+func (s *unitSuite) TestSetUnitStatusNotImplemented(c *gc.C) {
+	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		return apiservererrors.ServerError(errors.NotImplementedf("not implemented"))
+	})
+	tag := names.NewUnitTag("mysql/0")
+	client := uniter.NewState(apiCaller, tag)
+
+	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
+	err := unit.SetUnitStatus(status.Idle, "blah", map[string]interface{}{"foo": "bar"})
+	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
 }
 
 func (s *unitSuite) TestUnitStatus(c *gc.C) {
@@ -132,6 +167,18 @@ func (s *unitSuite) TestUnitStatus(c *gc.C) {
 	})
 }
 
+func (s *unitSuite) TestUnitStatusNotImplemented(c *gc.C) {
+	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		return apiservererrors.ServerError(errors.NotImplementedf("not implemented"))
+	})
+	tag := names.NewUnitTag("mysql/0")
+	client := uniter.NewState(apiCaller, tag)
+
+	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
+	_, err := unit.UnitStatus()
+	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
+}
+
 func (s *unitSuite) TestEnsureDead(c *gc.C) {
 	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Assert(objType, gc.Equals, "Uniter")
@@ -139,7 +186,7 @@ func (s *unitSuite) TestEnsureDead(c *gc.C) {
 		c.Assert(arg, gc.DeepEquals, params.Entities{Entities: []params.Entity{{Tag: "unit-mysql-0"}}})
 		c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
 		*(result.(*params.ErrorResults)) = params.ErrorResults{
-			Results: []params.ErrorResult{{&params.Error{Message: "biff"}}},
+			Results: []params.ErrorResult{{Error: &params.Error{Message: "biff"}}},
 		}
 		return nil
 	})
@@ -150,6 +197,18 @@ func (s *unitSuite) TestEnsureDead(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "biff")
 }
 
+func (s *unitSuite) TestEnsureDeadNotImplemented(c *gc.C) {
+	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		return apiservererrors.ServerError(errors.NotImplementedf("not implemented"))
+	})
+	tag := names.NewUnitTag("mysql/0")
+	client := uniter.NewState(apiCaller, tag)
+
+	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
+	err := unit.EnsureDead()
+	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
+}
+
 func (s *unitSuite) TestDestroy(c *gc.C) {
 	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Assert(objType, gc.Equals, "Uniter")
@@ -157,7 +216,7 @@ func (s *unitSuite) TestDestroy(c *gc.C) {
 		c.Assert(arg, gc.DeepEquals, params.Entities{Entities: []params.Entity{{Tag: "unit-mysql-0"}}})
 		c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
 		*(result.(*params.ErrorResults)) = params.ErrorResults{
-			Results: []params.ErrorResult{{&params.Error{Message: "biff"}}},
+			Results: []params.ErrorResult{{Error: &params.Error{Message: "biff"}}},
 		}
 		return nil
 	})
@@ -168,6 +227,18 @@ func (s *unitSuite) TestDestroy(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "biff")
 }
 
+func (s *unitSuite) TestDestroyNotImplemented(c *gc.C) {
+	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		return apiservererrors.ServerError(errors.NotImplementedf("not implemented"))
+	})
+	tag := names.NewUnitTag("mysql/0")
+	client := uniter.NewState(apiCaller, tag)
+
+	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
+	err := unit.Destroy()
+	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
+}
+
 func (s *unitSuite) TestDestroyAllSubordinates(c *gc.C) {
 	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Assert(objType, gc.Equals, "Uniter")
@@ -175,7 +246,7 @@ func (s *unitSuite) TestDestroyAllSubordinates(c *gc.C) {
 		c.Assert(arg, gc.DeepEquals, params.Entities{Entities: []params.Entity{{Tag: "unit-mysql-0"}}})
 		c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
 		*(result.(*params.ErrorResults)) = params.ErrorResults{
-			Results: []params.ErrorResult{{&params.Error{Message: "biff"}}},
+			Results: []params.ErrorResult{{Error: &params.Error{Message: "biff"}}},
 		}
 		return nil
 	})
@@ -184,6 +255,18 @@ func (s *unitSuite) TestDestroyAllSubordinates(c *gc.C) {
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
 	err := unit.DestroyAllSubordinates()
 	c.Assert(err, gc.ErrorMatches, "biff")
+}
+
+func (s *unitSuite) TestDestroyAllSubordinatesNotImplemented(c *gc.C) {
+	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		return apiservererrors.ServerError(errors.NotImplementedf("not implemented"))
+	})
+	tag := names.NewUnitTag("mysql/0")
+	client := uniter.NewState(apiCaller, tag)
+
+	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
+	err := unit.DestroyAllSubordinates()
+	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
 }
 
 func (s *unitSuite) TestRefresh(c *gc.C) {
@@ -211,6 +294,18 @@ func (s *unitSuite) TestRefresh(c *gc.C) {
 	c.Assert(unit.Life(), gc.Equals, life.Dying)
 }
 
+func (s *unitSuite) TestRefreshNotImplemented(c *gc.C) {
+	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		return apiservererrors.ServerError(errors.NotImplementedf("not implemented"))
+	})
+	tag := names.NewUnitTag("mysql/0")
+	client := uniter.NewState(apiCaller, tag)
+
+	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
+	err := unit.Refresh()
+	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
+}
+
 func (s *unitSuite) TestClearResolved(c *gc.C) {
 	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Assert(objType, gc.Equals, "Uniter")
@@ -218,7 +313,7 @@ func (s *unitSuite) TestClearResolved(c *gc.C) {
 		c.Assert(arg, gc.DeepEquals, params.Entities{Entities: []params.Entity{{Tag: "unit-mysql-0"}}})
 		c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
 		*(result.(*params.ErrorResults)) = params.ErrorResults{
-			Results: []params.ErrorResult{{&params.Error{Message: "biff"}}},
+			Results: []params.ErrorResult{{Error: &params.Error{Message: "biff"}}},
 		}
 		return nil
 	})
@@ -227,6 +322,18 @@ func (s *unitSuite) TestClearResolved(c *gc.C) {
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
 	err := unit.ClearResolved()
 	c.Assert(err, gc.ErrorMatches, "biff")
+}
+
+func (s *unitSuite) TestClearResolvedNotImplemented(c *gc.C) {
+	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		return apiservererrors.ServerError(errors.NotImplementedf("not implemented"))
+	})
+	tag := names.NewUnitTag("mysql/0")
+	client := uniter.NewState(apiCaller, tag)
+
+	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
+	err := unit.ClearResolved()
+	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
 }
 
 func (s *unitSuite) TestWatch(c *gc.C) {
@@ -265,6 +372,18 @@ func (s *unitSuite) TestWatch(c *gc.C) {
 	}
 }
 
+func (s *unitSuite) TestWatchNotImplemented(c *gc.C) {
+	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		return apiservererrors.ServerError(errors.NotImplementedf("not implemented"))
+	})
+	tag := names.NewUnitTag("mysql/0")
+	client := uniter.NewState(apiCaller, tag)
+
+	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
+	_, err := unit.Watch()
+	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
+}
+
 func (s *unitSuite) TestWatchRelations(c *gc.C) {
 	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		if objType == "StringsWatcher" {
@@ -297,6 +416,18 @@ func (s *unitSuite) TestWatchRelations(c *gc.C) {
 	wc.AssertChange("666")
 }
 
+func (s *unitSuite) TestWatchRelationsNotImplemented(c *gc.C) {
+	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		return apiservererrors.ServerError(errors.NotImplementedf("not implemented"))
+	})
+	tag := names.NewUnitTag("mysql/0")
+	client := uniter.NewState(apiCaller, tag)
+
+	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
+	_, err := unit.WatchRelations()
+	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
+}
+
 func (s *unitSuite) TestAssignedMachine(c *gc.C) {
 	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Assert(objType, gc.Equals, "Uniter")
@@ -316,6 +447,18 @@ func (s *unitSuite) TestAssignedMachine(c *gc.C) {
 	tag, err := unit.AssignedMachine()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(tag, gc.Equals, names.NewMachineTag("666"))
+}
+
+func (s *unitSuite) TestAssignedMachineNotImplemented(c *gc.C) {
+	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		return apiservererrors.ServerError(errors.NotImplementedf("not implemented"))
+	})
+	tag := names.NewUnitTag("mysql/0")
+	client := uniter.NewState(apiCaller, tag)
+
+	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
+	_, err := unit.AssignedMachine()
+	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
 }
 
 func (s *unitSuite) TestPrincipalName(c *gc.C) {
@@ -341,6 +484,18 @@ func (s *unitSuite) TestPrincipalName(c *gc.C) {
 	c.Assert(ok, jc.IsTrue)
 }
 
+func (s *unitSuite) TestPrincipalNameNotImplemented(c *gc.C) {
+	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		return apiservererrors.ServerError(errors.NotImplementedf("not implemented"))
+	})
+	tag := names.NewUnitTag("mysql/0")
+	client := uniter.NewState(apiCaller, tag)
+
+	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
+	_, _, err := unit.PrincipalName()
+	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
+}
+
 func (s *unitSuite) TestHasSubordinates(c *gc.C) {
 	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Assert(objType, gc.Equals, "Uniter")
@@ -360,6 +515,18 @@ func (s *unitSuite) TestHasSubordinates(c *gc.C) {
 	ok, err := unit.HasSubordinates()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ok, jc.IsTrue)
+}
+
+func (s *unitSuite) TestHasSubordinatesNotImplemented(c *gc.C) {
+	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		return apiservererrors.ServerError(errors.NotImplementedf("not implemented"))
+	})
+	tag := names.NewUnitTag("mysql/0")
+	client := uniter.NewState(apiCaller, tag)
+
+	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
+	_, err := unit.HasSubordinates()
+	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
 }
 
 func (s *unitSuite) TestPublicAddress(c *gc.C) {
@@ -383,6 +550,18 @@ func (s *unitSuite) TestPublicAddress(c *gc.C) {
 	c.Assert(address, gc.Equals, "1.1.1.1")
 }
 
+func (s *unitSuite) TestPublicAddressNotImplemented(c *gc.C) {
+	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		return apiservererrors.ServerError(errors.NotImplementedf("not implemented"))
+	})
+	tag := names.NewUnitTag("mysql/0")
+	client := uniter.NewState(apiCaller, tag)
+
+	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
+	_, err := unit.PublicAddress()
+	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
+}
+
 func (s *unitSuite) TestPrivateAddress(c *gc.C) {
 	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Assert(objType, gc.Equals, "Uniter")
@@ -402,6 +581,18 @@ func (s *unitSuite) TestPrivateAddress(c *gc.C) {
 	address, err := unit.PrivateAddress()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(address, gc.Equals, "1.1.1.1")
+}
+
+func (s *unitSuite) TestPrivateAddressNotImplemented(c *gc.C) {
+	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		return apiservererrors.ServerError(errors.NotImplementedf("not implemented"))
+	})
+	tag := names.NewUnitTag("mysql/0")
+	client := uniter.NewState(apiCaller, tag)
+
+	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
+	_, err := unit.PrivateAddress()
+	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
 }
 
 func (s *unitSuite) TestAvailabilityZone(c *gc.C) {
@@ -425,6 +616,18 @@ func (s *unitSuite) TestAvailabilityZone(c *gc.C) {
 	c.Assert(address, gc.Equals, "a-zone")
 }
 
+func (s *unitSuite) TestAvailabilityZoneNotImplemented(c *gc.C) {
+	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		return apiservererrors.ServerError(errors.NotImplementedf("not implemented"))
+	})
+	tag := names.NewUnitTag("mysql/0")
+	client := uniter.NewState(apiCaller, tag)
+
+	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
+	_, err := unit.AvailabilityZone()
+	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
+}
+
 func (s *unitSuite) TestCharmURL(c *gc.C) {
 	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Assert(objType, gc.Equals, "Uniter")
@@ -446,6 +649,18 @@ func (s *unitSuite) TestCharmURL(c *gc.C) {
 	c.Assert(curl, gc.Equals, "ch:mysql")
 }
 
+func (s *unitSuite) TestCharmURLNotImplemented(c *gc.C) {
+	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		return apiservererrors.ServerError(errors.NotImplementedf("not implemented"))
+	})
+	tag := names.NewUnitTag("mysql/0")
+	client := uniter.NewState(apiCaller, tag)
+
+	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
+	_, err := unit.CharmURL()
+	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
+}
+
 func (s *unitSuite) TestSetCharmURL(c *gc.C) {
 	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Assert(objType, gc.Equals, "Uniter")
@@ -457,7 +672,7 @@ func (s *unitSuite) TestSetCharmURL(c *gc.C) {
 		})
 		c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
 		*(result.(*params.ErrorResults)) = params.ErrorResults{
-			Results: []params.ErrorResult{{&params.Error{Message: "biff"}}},
+			Results: []params.ErrorResult{{Error: &params.Error{Message: "biff"}}},
 		}
 		return nil
 	})
@@ -466,6 +681,18 @@ func (s *unitSuite) TestSetCharmURL(c *gc.C) {
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
 	err := unit.SetCharmURL("ch:mysql")
 	c.Assert(err, gc.ErrorMatches, "biff")
+}
+
+func (s *unitSuite) TestSetCharmURLNotImplemented(c *gc.C) {
+	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		return apiservererrors.ServerError(errors.NotImplementedf("not implemented"))
+	})
+	tag := names.NewUnitTag("mysql/0")
+	client := uniter.NewState(apiCaller, tag)
+
+	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
+	err := unit.SetCharmURL("ch:mysql")
+	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
 }
 
 func (s *unitSuite) TestNetworkInfo(c *gc.C) {
@@ -498,6 +725,20 @@ func (s *unitSuite) TestNetworkInfo(c *gc.C) {
 	c.Assert(result["db"].Error, gc.ErrorMatches, "FAIL")
 }
 
+func (s *unitSuite) TestNetworkInfoNotImplemented(c *gc.C) {
+	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		return apiservererrors.ServerError(errors.NotImplementedf("not implemented"))
+	})
+	tag := names.NewUnitTag("mysql/0")
+	client := uniter.NewState(apiCaller, tag)
+
+	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
+
+	relId := 2
+	_, err := unit.NetworkInfo([]string{"server"}, &relId)
+	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
+}
+
 func (s *unitSuite) TestConfigSettings(c *gc.C) {
 	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Assert(objType, gc.Equals, "Uniter")
@@ -520,6 +761,19 @@ func (s *unitSuite) TestConfigSettings(c *gc.C) {
 	c.Assert(settings, gc.DeepEquals, charm.Settings{
 		"foo": "bar",
 	})
+}
+
+func (s *unitSuite) TestConfigSettingsNotImplemented(c *gc.C) {
+	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		return apiservererrors.ServerError(errors.NotImplementedf("not implemented"))
+	})
+	tag := names.NewUnitTag("mysql/0")
+	client := uniter.NewState(apiCaller, tag)
+
+	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
+
+	_, err := unit.ConfigSettings()
+	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
 }
 
 func (s *unitSuite) TestWatchConfigSettingsHash(c *gc.C) {
@@ -554,6 +808,19 @@ func (s *unitSuite) TestWatchConfigSettingsHash(c *gc.C) {
 	wc.AssertChange("666")
 }
 
+func (s *unitSuite) TestWatchConfigSettingsHashNotImplemented(c *gc.C) {
+	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		return apiservererrors.ServerError(errors.NotImplementedf("not implemented"))
+	})
+	tag := names.NewUnitTag("mysql/0")
+	client := uniter.NewState(apiCaller, tag)
+
+	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
+
+	_, err := unit.WatchConfigSettingsHash()
+	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
+}
+
 func (s *unitSuite) TestWatchTrustConfigSettingsHash(c *gc.C) {
 	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		if objType == "StringsWatcher" {
@@ -586,6 +853,19 @@ func (s *unitSuite) TestWatchTrustConfigSettingsHash(c *gc.C) {
 	wc.AssertChange("666")
 }
 
+func (s *unitSuite) TestWatchTrustConfigSettingsHashNotImplemented(c *gc.C) {
+	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		return apiservererrors.ServerError(errors.NotImplementedf("not implemented"))
+	})
+	tag := names.NewUnitTag("mysql/0")
+	client := uniter.NewState(apiCaller, tag)
+
+	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
+
+	_, err := unit.WatchTrustConfigSettingsHash()
+	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
+}
+
 func (s *unitSuite) TestWatchAddressesHash(c *gc.C) {
 	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		if objType == "StringsWatcher" {
@@ -616,6 +896,19 @@ func (s *unitSuite) TestWatchAddressesHash(c *gc.C) {
 
 	// Initial event.
 	wc.AssertChange("666")
+}
+
+func (s *unitSuite) TestWatchAddressesHashNotImplemented(c *gc.C) {
+	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		return apiservererrors.ServerError(errors.NotImplementedf("not implemented"))
+	})
+	tag := names.NewUnitTag("mysql/0")
+	client := uniter.NewState(apiCaller, tag)
+
+	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
+
+	_, err := unit.WatchAddressesHash()
+	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
 }
 
 func (s *unitSuite) TestWatchUpgradeSeriesNotifications(c *gc.C) {
@@ -654,6 +947,19 @@ func (s *unitSuite) TestWatchUpgradeSeriesNotifications(c *gc.C) {
 	}
 }
 
+func (s *unitSuite) TestWatchUpgradeSeriesNotificationsNotImplemented(c *gc.C) {
+	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		return apiservererrors.ServerError(errors.NotImplementedf("not implemented"))
+	})
+	tag := names.NewUnitTag("mysql/0")
+	client := uniter.NewState(apiCaller, tag)
+
+	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
+
+	_, err := unit.WatchUpgradeSeriesNotifications()
+	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
+}
+
 func (s *unitSuite) TestUpgradeSeriesStatus(c *gc.C) {
 	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Assert(objType, gc.Equals, "Uniter")
@@ -667,7 +973,7 @@ func (s *unitSuite) TestUpgradeSeriesStatus(c *gc.C) {
 		})
 		c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
 		*(result.(*params.ErrorResults)) = params.ErrorResults{
-			Results: []params.ErrorResult{{&params.Error{Message: "biff"}}},
+			Results: []params.ErrorResult{{Error: &params.Error{Message: "biff"}}},
 		}
 		return nil
 	})
@@ -676,6 +982,19 @@ func (s *unitSuite) TestUpgradeSeriesStatus(c *gc.C) {
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
 	err := unit.SetUpgradeSeriesStatus(model.UpgradeSeriesCompleted, "done")
 	c.Assert(err, gc.ErrorMatches, "biff")
+}
+
+func (s *unitSuite) TestUpgradeSeriesStatusNotImplemented(c *gc.C) {
+	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		return apiservererrors.ServerError(errors.NotImplementedf("not implemented"))
+	})
+	tag := names.NewUnitTag("mysql/0")
+	client := uniter.NewState(apiCaller, tag)
+
+	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
+
+	err := unit.SetUpgradeSeriesStatus(model.UpgradeSeriesCompleted, "done")
+	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
 }
 
 func (s *unitSuite) TestSetUpgradeSeriesStatus(c *gc.C) {
@@ -699,6 +1018,19 @@ func (s *unitSuite) TestSetUpgradeSeriesStatus(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(seriesStatus, gc.Equals, model.UpgradeSeriesCompleted)
 	c.Check(target, gc.Equals, "focal")
+}
+
+func (s *unitSuite) TestSetUpgradeSeriesStatusNotImplemented(c *gc.C) {
+	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		return apiservererrors.ServerError(errors.NotImplementedf("not implemented"))
+	})
+	tag := names.NewUnitTag("mysql/0")
+	client := uniter.NewState(apiCaller, tag)
+
+	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
+
+	_, _, err := unit.UpgradeSeriesStatus()
+	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
 }
 
 func (s *unitSuite) TestRelationStatus(c *gc.C) {
@@ -730,6 +1062,19 @@ func (s *unitSuite) TestRelationStatus(c *gc.C) {
 	}})
 }
 
+func (s *unitSuite) TestRelationStatusNotImplemented(c *gc.C) {
+	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		return apiservererrors.ServerError(errors.NotImplementedf("not implemented"))
+	})
+	tag := names.NewUnitTag("mysql/0")
+	client := uniter.NewState(apiCaller, tag)
+
+	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
+
+	_, err := unit.RelationsStatus()
+	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
+}
+
 func (s *unitSuite) TestUnitState(c *gc.C) {
 	unitState := params.UnitStateResult{
 		MeterStatusState: "meter",
@@ -757,6 +1102,19 @@ func (s *unitSuite) TestUnitState(c *gc.C) {
 	c.Assert(result, jc.DeepEquals, unitState)
 }
 
+func (s *unitSuite) TestUnitStateNotImplemented(c *gc.C) {
+	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		return apiservererrors.ServerError(errors.NotImplementedf("not implemented"))
+	})
+	tag := names.NewUnitTag("mysql/0")
+	client := uniter.NewState(apiCaller, tag)
+
+	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
+
+	_, err := unit.State()
+	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
+}
+
 func (s *unitSuite) TestSetState(c *gc.C) {
 	unitState := params.SetUnitStateArg{
 		Tag:           "unit-mysql-0",
@@ -771,7 +1129,7 @@ func (s *unitSuite) TestSetState(c *gc.C) {
 		})
 		c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
 		*(result.(*params.ErrorResults)) = params.ErrorResults{
-			Results: []params.ErrorResult{{&params.Error{Message: "biff"}}},
+			Results: []params.ErrorResult{{Error: &params.Error{Message: "biff"}}},
 		}
 		return nil
 	})
@@ -780,6 +1138,19 @@ func (s *unitSuite) TestSetState(c *gc.C) {
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
 	err := unit.SetState(unitState)
 	c.Assert(err, gc.ErrorMatches, "biff")
+}
+
+func (s *unitSuite) TestSetStateNotImplemented(c *gc.C) {
+	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		return apiservererrors.ServerError(errors.NotImplementedf("not implemented"))
+	})
+	tag := names.NewUnitTag("mysql/0")
+	client := uniter.NewState(apiCaller, tag)
+
+	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
+
+	err := unit.SetState(params.SetUnitStateArg{})
+	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
 }
 
 func (s *unitSuite) TestAddMetricBatch(c *gc.C) {
@@ -807,7 +1178,7 @@ func (s *unitSuite) TestAddMetricBatch(c *gc.C) {
 		})
 		c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
 		*(result.(*params.ErrorResults)) = params.ErrorResults{
-			Results: []params.ErrorResult{{&params.Error{Message: "biff"}}},
+			Results: []params.ErrorResult{{Error: &params.Error{Message: "biff"}}},
 		}
 		return nil
 	})
@@ -819,6 +1190,19 @@ func (s *unitSuite) TestAddMetricBatch(c *gc.C) {
 	c.Assert(result, jc.DeepEquals, map[string]error{
 		uuid: &params.Error{Message: "biff"},
 	})
+}
+
+func (s *unitSuite) TestAddMetricBatchNotImplemented(c *gc.C) {
+	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		return apiservererrors.ServerError(errors.NotImplementedf("not implemented"))
+	})
+	tag := names.NewUnitTag("mysql/0")
+	client := uniter.NewState(apiCaller, tag)
+
+	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
+
+	_, err := unit.AddMetricBatches([]params.MetricBatch{})
+	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
 }
 
 func (s *unitSuite) TestAddMetrics(c *gc.C) {
@@ -838,7 +1222,7 @@ func (s *unitSuite) TestAddMetrics(c *gc.C) {
 		})
 		c.Assert(result, gc.FitsTypeOf, &params.ErrorResults{})
 		*(result.(*params.ErrorResults)) = params.ErrorResults{
-			Results: []params.ErrorResult{{&params.Error{Message: "biff"}}},
+			Results: []params.ErrorResult{{Error: &params.Error{Message: "biff"}}},
 		}
 		return nil
 	})
@@ -847,6 +1231,19 @@ func (s *unitSuite) TestAddMetrics(c *gc.C) {
 	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
 	err := unit.AddMetrics(metrics)
 	c.Assert(err, gc.ErrorMatches, "biff")
+}
+
+func (s *unitSuite) TestAddMetricsNotImplemented(c *gc.C) {
+	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		return apiservererrors.ServerError(errors.NotImplementedf("not implemented"))
+	})
+	tag := names.NewUnitTag("mysql/0")
+	client := uniter.NewState(apiCaller, tag)
+
+	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
+
+	err := unit.AddMetrics([]params.Metric{})
+	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
 }
 
 func (s *unitSuite) TestAddMetricsError(c *gc.C) {
@@ -881,6 +1278,19 @@ func (s *unitSuite) TestMeterStatus(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(code, gc.Equals, "code")
 	c.Assert(info, gc.Equals, "info")
+}
+
+func (s *unitSuite) TestMeterStatusNotImplemented(c *gc.C) {
+	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		return apiservererrors.ServerError(errors.NotImplementedf("not implemented"))
+	})
+	tag := names.NewUnitTag("mysql/0")
+	client := uniter.NewState(apiCaller, tag)
+
+	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
+
+	_, _, err := unit.MeterStatus()
+	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
 }
 
 func (s *unitSuite) TestMeterStatusResultError(c *gc.C) {
@@ -936,6 +1346,19 @@ func (s *unitSuite) TestWatchInstanceData(c *gc.C) {
 	}
 }
 
+func (s *unitSuite) TestWatchInstanceDataNotImplemented(c *gc.C) {
+	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		return apiservererrors.ServerError(errors.NotImplementedf("not implemented"))
+	})
+	tag := names.NewUnitTag("mysql/0")
+	client := uniter.NewState(apiCaller, tag)
+
+	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
+
+	_, err := unit.WatchInstanceData()
+	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
+}
+
 func (s *unitSuite) TestLXDProfileName(c *gc.C) {
 	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Assert(objType, gc.Equals, "Uniter")
@@ -956,6 +1379,19 @@ func (s *unitSuite) TestLXDProfileName(c *gc.C) {
 	c.Assert(profile, gc.Equals, "juju-default-mysql-0")
 }
 
+func (s *unitSuite) TestLXDProfileNameNotImplemented(c *gc.C) {
+	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		return apiservererrors.ServerError(errors.NotImplementedf("not implemented"))
+	})
+	tag := names.NewUnitTag("mysql/0")
+	client := uniter.NewState(apiCaller, tag)
+
+	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
+
+	_, err := unit.LXDProfileName()
+	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
+}
+
 func (s *unitSuite) TestCanApplyLXDProfile(c *gc.C) {
 	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		c.Assert(objType, gc.Equals, "Uniter")
@@ -974,4 +1410,17 @@ func (s *unitSuite) TestCanApplyLXDProfile(c *gc.C) {
 	canApply, err := unit.CanApplyLXDProfile()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(canApply, jc.IsTrue)
+}
+
+func (s *unitSuite) TestCanApplyLXDProfileNotImplemented(c *gc.C) {
+	apiCaller := basetesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
+		return apiservererrors.ServerError(errors.NotImplementedf("not implemented"))
+	})
+	tag := names.NewUnitTag("mysql/0")
+	client := uniter.NewState(apiCaller, tag)
+
+	unit := uniter.CreateUnit(client, names.NewUnitTag("mysql/0"))
+
+	_, err := unit.CanApplyLXDProfile()
+	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
 }

--- a/api/agent/uniter/uniter.go
+++ b/api/agent/uniter/uniter.go
@@ -107,7 +107,7 @@ func (st *State) relation(relationTag, unitTag names.Tag) (params.RelationResult
 	}
 	err := st.facade.FacadeCall("Relation", args, &result)
 	if err != nil {
-		return nothing, err
+		return nothing, errors.Trace(apiservererrors.RestoreError(err))
 	}
 	if len(result.Results) != 1 {
 		return nothing, fmt.Errorf("expected 1 result, got %d", len(result.Results))
@@ -128,7 +128,7 @@ func (st *State) setRelationStatus(id int, status relation.Status) error {
 	}
 	var results params.ErrorResults
 	if err := st.facade.FacadeCall("SetRelationStatus", args, &results); err != nil {
-		return errors.Trace(err)
+		return errors.Trace(apiservererrors.RestoreError(err))
 	}
 	return results.OneError()
 }
@@ -146,7 +146,7 @@ func (st *State) getOneAction(tag *names.ActionTag) (params.ActionResult, error)
 	var results params.ActionResults
 	err := st.facade.FacadeCall("Actions", args, &results)
 	if err != nil {
-		return nothing, err
+		return nothing, errors.Trace(apiservererrors.RestoreError(err))
 	}
 
 	if len(results.Results) > 1 {
@@ -173,7 +173,7 @@ func (st *State) ActionStatus(tag names.ActionTag) (string, error) {
 	var results params.StringResults
 	err := st.facade.FacadeCall("ActionStatus", args, &results)
 	if err != nil {
-		return "", err
+		return "", errors.Trace(apiservererrors.RestoreError(err))
 	}
 
 	if len(results.Results) > 1 {
@@ -223,7 +223,7 @@ func (st *State) ProviderType() (string, error) {
 	var result params.StringResult
 	err := st.facade.FacadeCall("ProviderType", nil, &result)
 	if err != nil {
-		return "", err
+		return "", errors.Trace(apiservererrors.RestoreError(err))
 	}
 	if err := result.Error; err != nil {
 		return "", err
@@ -290,7 +290,7 @@ func (st *State) ActionBegin(tag names.ActionTag) error {
 
 	err := st.facade.FacadeCall("BeginActions", args, &outcome)
 	if err != nil {
-		return err
+		return errors.Trace(apiservererrors.RestoreError(err))
 	}
 	if len(outcome.Results) != 1 {
 		return fmt.Errorf("expected 1 result, got %d", len(outcome.Results))
@@ -319,7 +319,7 @@ func (st *State) ActionFinish(tag names.ActionTag, status string, results map[st
 
 	err := st.facade.FacadeCall("FinishActions", args, &outcome)
 	if err != nil {
-		return err
+		return errors.Trace(apiservererrors.RestoreError(err))
 	}
 	if len(outcome.Results) != 1 {
 		return fmt.Errorf("expected 1 result, got %d", len(outcome.Results))
@@ -340,7 +340,7 @@ func (st *State) RelationById(id int) (*Relation, error) {
 
 	err := st.facade.FacadeCall("RelationById", args, &results)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(apiservererrors.RestoreError(err))
 	}
 	if len(results.Results) != 1 {
 		return nil, fmt.Errorf("expected 1 result, got %d", len(results.Results))
@@ -365,7 +365,7 @@ func (st *State) Model() (*model.Model, error) {
 	var result params.ModelResult
 	err := st.facade.FacadeCall("CurrentModel", nil, &result)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(apiservererrors.RestoreError(err))
 	}
 	if err := result.Error; err != nil {
 		return nil, err
@@ -395,7 +395,7 @@ func processOpenPortRangesByEndpointResults(results params.OpenPortRangesByEndpo
 	for unitTagStr, unitPortRanges := range result.UnitPortRanges {
 		unitTag, err := names.ParseUnitTag(unitTagStr)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, errors.Trace(apiservererrors.RestoreError(err))
 		}
 		portRangeMap[unitTag] = make(network.GroupedPortRanges)
 		for _, group := range unitPortRanges {
@@ -416,7 +416,7 @@ func (st *State) OpenedMachinePortRangesByEndpoint(machineTag names.MachineTag) 
 	}
 	err := st.facade.FacadeCall("OpenedMachinePortRangesByEndpoint", args, &results)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(apiservererrors.RestoreError(err))
 	}
 	return processOpenPortRangesByEndpointResults(results, machineTag)
 }
@@ -429,7 +429,7 @@ func (st *State) OpenedPortRangesByEndpoint() (map[names.UnitTag]network.Grouped
 	}
 	var results params.OpenPortRangesByEndpointResults
 	if err := st.facade.FacadeCall("OpenedPortRangesByEndpoint", nil, &results); err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Trace(apiservererrors.RestoreError(err))
 	}
 	return processOpenPortRangesByEndpointResults(results, st.unitTag)
 }
@@ -449,7 +449,7 @@ func (st *State) WatchRelationUnits(
 	}
 	err := st.facade.FacadeCall("WatchRelationUnits", args, &results)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(apiservererrors.RestoreError(err))
 	}
 	if len(results.Results) != 1 {
 		return nil, fmt.Errorf("expected 1 result, got %d", len(results.Results))
@@ -467,7 +467,7 @@ func (st *State) SLALevel() (string, error) {
 	var result params.StringResult
 	err := st.facade.FacadeCall("SLALevel", nil, &result)
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", errors.Trace(apiservererrors.RestoreError(err))
 	}
 	if err := result.Error; err != nil {
 		return "", errors.Trace(err)
@@ -480,7 +480,7 @@ func (st *State) CloudAPIVersion() (string, error) {
 	var result params.StringResult
 	err := st.facade.FacadeCall("CloudAPIVersion", nil, &result)
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", errors.Trace(apiservererrors.RestoreError(err))
 	}
 	if err := result.Error; err != nil {
 		return "", errors.Trace(err)
@@ -503,7 +503,7 @@ func (st *State) GoalState() (application.GoalState, error) {
 
 	err := st.facade.FacadeCall("GoalStates", args, &result)
 	if err != nil {
-		return gs, err
+		return gs, errors.Trace(apiservererrors.RestoreError(err))
 	}
 	if len(result.Results) != 1 {
 		return gs, errors.Errorf("expected 1 result, got %d", len(result.Results))
@@ -554,7 +554,7 @@ func (st *State) GetPodSpec(appName string) (string, error) {
 		}},
 	}
 	if err := st.facade.FacadeCall("GetPodSpec", args, &result); err != nil {
-		return "", errors.Trace(err)
+		return "", errors.Trace(apiservererrors.RestoreError(err))
 	}
 	if len(result.Results) != 1 {
 		return "", fmt.Errorf("expected 1 result, got %d", len(result.Results))
@@ -581,7 +581,7 @@ func (st *State) GetRawK8sSpec(appName string) (string, error) {
 		}},
 	}
 	if err := st.facade.FacadeCall("GetRawK8sSpec", args, &result); err != nil {
-		return "", errors.Trace(err)
+		return "", errors.Trace(apiservererrors.RestoreError(err))
 	}
 	if len(result.Results) != 1 {
 		return "", fmt.Errorf("expected 1 result, got %d", len(result.Results))
@@ -604,7 +604,7 @@ func (st *State) CloudSpec() (*params.CloudSpec, error) {
 
 	err := st.facade.FacadeCall("CloudSpec", nil, &result)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(apiservererrors.RestoreError(err))
 	}
 	if err := result.Error; err != nil {
 		return nil, err
@@ -621,7 +621,7 @@ func (st *State) UnitWorkloadVersion(tag names.UnitTag) (string, error) {
 	}
 	err := st.facade.FacadeCall("WorkloadVersion", args, &results)
 	if err != nil {
-		return "", err
+		return "", errors.Trace(apiservererrors.RestoreError(err))
 	}
 	if len(results.Results) != 1 {
 		return "", fmt.Errorf("expected 1 result, got %d", len(results.Results))
@@ -644,7 +644,7 @@ func (st *State) SetUnitWorkloadVersion(tag names.UnitTag, version string) error
 	}
 	err := st.facade.FacadeCall("SetWorkloadVersion", args, &result)
 	if err != nil {
-		return err
+		return errors.Trace(apiservererrors.RestoreError(err))
 	}
 	return result.OneError()
 }

--- a/api/agent/uniter/uniter_test.go
+++ b/api/agent/uniter/uniter_test.go
@@ -52,17 +52,17 @@ func (s *uniterSuite) TestOpenedMachinePortRangesByEndpoint(c *gc.C) {
 						"unit-mysql-0": {
 							{
 								Endpoint:   "",
-								PortRanges: []params.PortRange{{100, 200, "tcp"}},
+								PortRanges: []params.PortRange{{FromPort: 100, ToPort: 200, Protocol: "tcp"}},
 							},
 							{
 								Endpoint:   "server",
-								PortRanges: []params.PortRange{{3306, 3306, "tcp"}},
+								PortRanges: []params.PortRange{{FromPort: 3306, ToPort: 3306, Protocol: "tcp"}},
 							},
 						},
 						"unit-wordpress-0": {
 							{
 								Endpoint:   "monitoring-port",
-								PortRanges: []params.PortRange{{1337, 1337, "udp"}},
+								PortRanges: []params.PortRange{{FromPort: 1337, ToPort: 1337, Protocol: "udp"}},
 							},
 						},
 					},
@@ -71,7 +71,7 @@ func (s *uniterSuite) TestOpenedMachinePortRangesByEndpoint(c *gc.C) {
 		}
 		return nil
 	})
-	caller := testing.BestVersionCaller{apiCaller, 17}
+	caller := testing.BestVersionCaller{APICallerFunc: apiCaller, BestVersion: 17}
 	client := uniter.NewState(caller, names.NewUnitTag("mysql/0"))
 
 	portRangesMap, err := client.OpenedMachinePortRangesByEndpoint(names.NewMachineTag("42"))
@@ -100,17 +100,17 @@ func (s *uniterSuite) TestOpenedPortRangesByEndpoint(c *gc.C) {
 						"unit-mysql-0": {
 							{
 								Endpoint:   "",
-								PortRanges: []params.PortRange{{100, 200, "tcp"}},
+								PortRanges: []params.PortRange{{FromPort: 100, ToPort: 200, Protocol: "tcp"}},
 							},
 							{
 								Endpoint:   "server",
-								PortRanges: []params.PortRange{{3306, 3306, "tcp"}},
+								PortRanges: []params.PortRange{{FromPort: 3306, ToPort: 3306, Protocol: "tcp"}},
 							},
 						},
 						"unit-wordpress-0": {
 							{
 								Endpoint:   "monitoring-port",
-								PortRanges: []params.PortRange{{1337, 1337, "udp"}},
+								PortRanges: []params.PortRange{{FromPort: 1337, ToPort: 1337, Protocol: "udp"}},
 							},
 						},
 					},
@@ -119,7 +119,7 @@ func (s *uniterSuite) TestOpenedPortRangesByEndpoint(c *gc.C) {
 		}
 		return nil
 	})
-	caller := testing.BestVersionCaller{apiCaller, 18}
+	caller := testing.BestVersionCaller{APICallerFunc: apiCaller, BestVersion: 18}
 	client := uniter.NewState(caller, names.NewUnitTag("gitlab/0"))
 
 	result, err := client.OpenedPortRangesByEndpoint()
@@ -142,7 +142,7 @@ func (s *uniterSuite) TestOpenedPortRangesByEndpointOldAPINotSupported(c *gc.C) 
 		c.Assert(arg, gc.DeepEquals, params.Entities{Entities: []params.Entity{{Tag: "unit-gitlab-0"}}})
 		return nil
 	})
-	caller := testing.BestVersionCaller{apiCaller, 17}
+	caller := testing.BestVersionCaller{APICallerFunc: apiCaller, BestVersion: 17}
 	client := uniter.NewState(caller, names.NewUnitTag("gitlab/0"))
 
 	_, err := client.OpenedPortRangesByEndpoint()
@@ -160,7 +160,7 @@ func (s *uniterSuite) TestUnitWorkloadVersion(c *gc.C) {
 		}
 		return nil
 	})
-	caller := testing.BestVersionCaller{apiCaller, 17}
+	caller := testing.BestVersionCaller{APICallerFunc: apiCaller, BestVersion: 17}
 	client := uniter.NewState(caller, names.NewUnitTag("mysql/0"))
 
 	workloadVersion, err := client.UnitWorkloadVersion(names.NewUnitTag("mysql/0"))
@@ -179,7 +179,7 @@ func (s *uniterSuite) TestSetUnitWorkloadVersion(c *gc.C) {
 		}
 		return nil
 	})
-	caller := testing.BestVersionCaller{apiCaller, 17}
+	caller := testing.BestVersionCaller{APICallerFunc: apiCaller, BestVersion: 17}
 	client := uniter.NewState(caller, names.NewUnitTag("mysql/0"))
 
 	err := client.SetUnitWorkloadVersion(names.NewUnitTag("mysql/0"), "mysql-1.2.3")

--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -1170,12 +1170,17 @@ func isX509Error(err error) bool {
 // object id, and the specific RPC method. It marshalls the Arguments, and will
 // unmarshall the result into the response object that is supplied.
 func (s *state) APICall(facade string, vers int, id, method string, args, response interface{}) error {
-	return s.client.Call(rpc.Request{
+	err := s.client.Call(rpc.Request{
 		Type:    facade,
 		Version: vers,
 		Id:      id,
 		Action:  method,
 	}, args, response)
+
+	if code := params.ErrCode(err); code == params.CodeNotImplemented {
+		return errors.NewNotImplemented(fmt.Errorf("%w\nre-install your juju client to match the version running on the controller", err), "\njuju client not compatible with server")
+	}
+	return errors.Trace(err)
 }
 
 func (s *state) Close() error {

--- a/api/apiclient_test.go
+++ b/api/apiclient_test.go
@@ -1131,7 +1131,7 @@ func (s *apiclientSuite) TestAPICallErrorBadRequest(c *gc.C) {
 
 	err := conn.APICall("facade", 1, "id", "method", nil, nil)
 	c.Check(err.Error(), gc.Equals, "boom")
-	c.Check(err, jc.Satisfies, errors.IsBadRequest)
+	c.Check(err, jc.ErrorIs, errors.BadRequest)
 	c.Check(clock.waits, gc.HasLen, 0)
 }
 
@@ -1143,8 +1143,7 @@ func (s *apiclientSuite) TestAPICallErrorNotImplemented(c *gc.C) {
 	})
 
 	err := conn.APICall("facade", 1, "id", "method", nil, nil)
-	c.Check(err.Error(), gc.Equals, "boom")
-	c.Check(err, jc.Satisfies, errors.IsBadRequest)
+	c.Check(err, jc.ErrorIs, errors.NotImplemented)
 	c.Check(clock.waits, gc.HasLen, 0)
 }
 

--- a/api/apiclient_test.go
+++ b/api/apiclient_test.go
@@ -36,6 +36,7 @@ import (
 	apiclient "github.com/juju/juju/api/client/client"
 	"github.com/juju/juju/api/common"
 	apitesting "github.com/juju/juju/api/testing"
+	apiservererrors "github.com/juju/juju/apiserver/errors"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/network"
@@ -1121,10 +1122,23 @@ func (s *apiclientSuite) TestAPICallNoError(c *gc.C) {
 	c.Check(clock.waits, gc.HasLen, 0)
 }
 
-func (s *apiclientSuite) TestAPICallError(c *gc.C) {
+func (s *apiclientSuite) TestAPICallErrorBadRequest(c *gc.C) {
 	clock := &fakeClock{}
 	conn := api.NewTestingState(api.TestingStateParams{
 		RPCConnection: newRPCConnection(errors.BadRequestf("boom")),
+		Clock:         clock,
+	})
+
+	err := conn.APICall("facade", 1, "id", "method", nil, nil)
+	c.Check(err.Error(), gc.Equals, "boom")
+	c.Check(err, jc.Satisfies, errors.IsBadRequest)
+	c.Check(clock.waits, gc.HasLen, 0)
+}
+
+func (s *apiclientSuite) TestAPICallErrorNotImplemented(c *gc.C) {
+	clock := &fakeClock{}
+	conn := api.NewTestingState(api.TestingStateParams{
+		RPCConnection: newRPCConnection(apiservererrors.ServerError(errors.NotImplementedf("boom"))),
 		Clock:         clock,
 	})
 

--- a/api/common/unitstate.go
+++ b/api/common/unitstate.go
@@ -8,6 +8,7 @@ import (
 	"github.com/juju/names/v5"
 
 	"github.com/juju/juju/api/base"
+	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/rpc/params"
 )
 
@@ -33,7 +34,7 @@ func (u *UnitStateAPI) State() (params.UnitStateResult, error) {
 	}
 	err := u.facade.FacadeCall("State", args, &results)
 	if err != nil {
-		return params.UnitStateResult{}, err
+		return params.UnitStateResult{}, errors.Trace(apiservererrors.RestoreError(err))
 	}
 	if len(results.Results) != 1 {
 		return params.UnitStateResult{}, errors.Errorf("expected 1 result, got %d", len(results.Results))
@@ -55,7 +56,7 @@ func (u *UnitStateAPI) SetState(unitState params.SetUnitStateArg) error {
 	}
 	err := u.facade.FacadeCall("SetState", args, &results)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Trace(apiservererrors.RestoreError(err))
 	}
 	// Make sure we correctly decode quota-related errors.
 	return maybeRestoreQuotaLimitError(results.OneError())

--- a/api/common/upgradeseries.go
+++ b/api/common/upgradeseries.go
@@ -37,7 +37,7 @@ func (u *UpgradeSeriesAPI) WatchUpgradeSeriesNotifications() (watcher.NotifyWatc
 	}
 	err := u.facade.FacadeCall("WatchUpgradeSeriesNotifications", args, &results)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(apiservererrors.RestoreError(err))
 	}
 	if len(results.Results) != 1 {
 		return nil, errors.Errorf("expected 1 result, got %d", len(results.Results))
@@ -60,7 +60,7 @@ func (u *UpgradeSeriesAPI) UpgradeSeriesUnitStatus() (model.UpgradeSeriesStatus,
 
 	err := u.facade.FacadeCall("UpgradeSeriesUnitStatus", args, &results)
 	if err != nil {
-		return "", "", err
+		return "", "", errors.Trace(apiservererrors.RestoreError(err))
 	}
 	if len(results.Results) != 1 {
 		return "", "", errors.Errorf("expected 1 result, got %d", len(results.Results))
@@ -94,7 +94,7 @@ func (u *UpgradeSeriesAPI) SetUpgradeSeriesUnitStatus(status model.UpgradeSeries
 	}
 	err := u.facade.FacadeCall("SetUpgradeSeriesUnitStatus", args, &results)
 	if err != nil {
-		return err
+		return errors.Trace(apiservererrors.RestoreError(err))
 	}
 	if len(results.Results) != 1 {
 		return errors.Errorf("expected 1 result, got %d", len(results.Results))

--- a/api/common/watch.go
+++ b/api/common/watch.go
@@ -6,10 +6,12 @@ package common
 import (
 	"fmt"
 
+	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 
 	"github.com/juju/juju/api/base"
 	apiwatcher "github.com/juju/juju/api/watcher"
+	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/rpc/params"
 )
@@ -22,7 +24,7 @@ func Watch(facade base.FacadeCaller, method string, tag names.Tag) (watcher.Noti
 	}
 	err := facade.FacadeCall(method, args, &results)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(apiservererrors.RestoreError(err))
 	}
 	if len(results.Results) != 1 {
 		return nil, fmt.Errorf("expected 1 result, got %d", len(results.Results))

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -144,10 +144,7 @@ func (s *loginSuite) TestBadLogin(c *gc.C) {
 			st := s.openAPIWithoutLogin(c, info)
 
 			_, err := apimachiner.NewState(st).Machine(names.NewMachineTag("0"))
-			c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
-				Message: `unknown object type "Machiner"`,
-				Code:    "not implemented",
-			})
+			c.Assert(errors.Cause(err), jc.ErrorIs, errors.NotImplemented)
 
 			// Since these are user login tests, the nonce is empty.
 			err = st.Login(t.tag, t.password, "", nil)
@@ -155,10 +152,7 @@ func (s *loginSuite) TestBadLogin(c *gc.C) {
 			c.Assert(params.ErrCode(err), gc.Equals, t.code)
 
 			_, err = apimachiner.NewState(st).Machine(names.NewMachineTag("0"))
-			c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
-				Message: `unknown object type "Machiner"`,
-				Code:    "not implemented",
-			})
+			c.Assert(errors.Cause(err), jc.ErrorIs, errors.NotImplemented)
 		}()
 	}
 }
@@ -171,10 +165,7 @@ func (s *loginSuite) TestLoginAsDeactivatedUser(c *gc.C) {
 	u := s.Factory.MakeUser(c, &factory.UserParams{Password: password, Disabled: true})
 
 	_, err := apiclient.NewClient(st, coretesting.NoopLogger{}).Status(nil)
-	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
-		Message: `unknown object type "Client"`,
-		Code:    "not implemented",
-	})
+	c.Assert(errors.Cause(err), jc.ErrorIs, errors.NotImplemented)
 
 	// Since these are user login tests, the nonce is empty.
 	err = st.Login(u.Tag(), password, "", nil)
@@ -184,10 +175,7 @@ func (s *loginSuite) TestLoginAsDeactivatedUser(c *gc.C) {
 	})
 
 	_, err = apiclient.NewClient(st, coretesting.NoopLogger{}).Status(nil)
-	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
-		Message: `unknown object type "Client"`,
-		Code:    "not implemented",
-	})
+	c.Assert(errors.Cause(err), jc.ErrorIs, errors.NotImplemented)
 }
 
 func (s *loginSuite) TestLoginAsDeletedUser(c *gc.C) {
@@ -198,10 +186,7 @@ func (s *loginSuite) TestLoginAsDeletedUser(c *gc.C) {
 	u := s.Factory.MakeUser(c, &factory.UserParams{Password: password})
 
 	_, err := apiclient.NewClient(st, coretesting.NoopLogger{}).Status(nil)
-	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
-		Message: `unknown object type "Client"`,
-		Code:    "not implemented",
-	})
+	c.Assert(errors.Cause(err), jc.ErrorIs, errors.NotImplemented)
 
 	err = s.State.RemoveUser(u.UserTag())
 	c.Assert(err, jc.ErrorIsNil)
@@ -214,10 +199,7 @@ func (s *loginSuite) TestLoginAsDeletedUser(c *gc.C) {
 	})
 
 	_, err = apiclient.NewClient(st, coretesting.NoopLogger{}).Status(nil)
-	c.Assert(errors.Cause(err), gc.DeepEquals, &rpc.RequestError{
-		Message: `unknown object type "Client"`,
-		Code:    "not implemented",
-	})
+	c.Assert(errors.Cause(err), jc.ErrorIs, errors.NotImplemented)
 }
 
 func (s *loginSuite) setupManagementSpace(c *gc.C) *state.Space {

--- a/worker/meterstatus/manifold.go
+++ b/worker/meterstatus/manifold.go
@@ -76,6 +76,13 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 			}
 			return newStatusWorker(config, context)
 		},
+		Filter: func(err error) error {
+			if errors.Is(err, errors.NotImplemented) {
+				config.Logger.Infof("meter status worker is deprecated and is no longer required")
+				return nil
+			}
+			return errors.Trace(err)
+		},
 	}
 }
 

--- a/worker/metrics/sender/manifold.go
+++ b/worker/metrics/sender/manifold.go
@@ -79,5 +79,12 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 			}
 			return spool.NewPeriodicWorker(s.Do, period, jworker.NewTimer, s.stop), nil
 		},
+		Filter: func(err error) error {
+			if errors.Is(err, errors.NotImplemented) {
+				logger.Infof("metrics sender is deprecated and is no longer required")
+				return nil
+			}
+			return errors.Trace(err)
+		},
 	}
 }

--- a/worker/metrics/sender/manifold_test.go
+++ b/worker/metrics/sender/manifold_test.go
@@ -69,6 +69,37 @@ func (s *ManifoldSuite) SetUpTest(c *gc.C) {
 	}
 }
 
+// TestErrorFilterNotImplemented ensures that the manifold correctly handles
+// not implemented api calls.
+func (s *ManifoldSuite) TestErrorFilterNotImplemented(c *gc.C) {
+	testCases := []struct {
+		name     string
+		err      error
+		expected error
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: nil,
+		},
+		{
+			name:     "not implemented error",
+			err:      errors.NotImplementedf("not implemented"),
+			expected: nil,
+		},
+		{
+			name:     "any error",
+			err:      errors.NotFound,
+			expected: errors.NotFound,
+		},
+	}
+	for i, test := range testCases {
+		c.Logf("test %d: %s", i, test.name)
+		result := s.manifold.Filter(test.err)
+		c.Check(errors.Cause(result), gc.Equals, test.expected)
+	}
+}
+
 func (s *ManifoldSuite) TestInputs(c *gc.C) {
 	c.Check(s.manifold.Inputs, jc.DeepEquals, []string{"agent", "api-caller", "metric-spool"})
 }

--- a/worker/uniter/runner/context/contextfactory.go
+++ b/worker/uniter/runner/context/contextfactory.go
@@ -385,8 +385,10 @@ func (f *contextFactory) updateContext(ctx *HookContext) (err error) {
 		return err
 	}
 
+	// SLA level is removed in 4.0, so the facade is not available.
+	// Setting the SLA level to empty string is a valid SLA level (slaNone).
 	sla, err := f.state.SLALevel()
-	if err != nil {
+	if err != nil && !errors.Is(err, errors.NotImplemented) {
 		return errors.Annotate(err, "could not retrieve the SLA level")
 	}
 	ctx.slaLevel = sla
@@ -406,8 +408,11 @@ func (f *contextFactory) updateContext(ctx *HookContext) (err error) {
 	ctx.legacyProxySettings = modelConfig.LegacyProxySettings()
 	ctx.jujuProxySettings = modelConfig.JujuProxySettings()
 
+	// MeterStatus is removed in 4.0, so the facade is not available.
+	// Setting meter status code and info to be empty string should be
+	// valid.
 	statusCode, statusInfo, err := f.unit.MeterStatus()
-	if err != nil {
+	if err != nil && !errors.Is(err, errors.NotImplemented) {
 		return errors.Annotate(err, "could not retrieve meter status for unit")
 	}
 	ctx.meterStatus = &meterStatus{


### PR DESCRIPTION
We must ensure that 3.6 can migrate to 4.0 without issues once it lands into the 4.0 controller. This follows on from [2] which unlocks 3.6 to 4.0 from the 4.0 side. 3.6 is expected to be our LTS and 4.0 will be our new shiny. We must always ensure that we can migrate from there to 4.0.

Solving this is done to restore the errors from the APICall to ensure it's converted back to NotImplemented error (along with other errors). We don't do it for all results, but just the calls to the facade, as that's when it caught. For consistency, I've added to all uniter calls, with the aim that in new versions of Juju the API client calls should always do this.

The SLALevel and MeterStatus are both removed in 4.0[1] and so we need to handle when that occurs. The best way is to handle the error and then allow call sites to decide what to do.

Lastly, the meter-status and metric-sender workers will just complain and complain about the issue. So to prevent that, we trap the error in the manifold filter function and return nil. This will mark the worker as complete and won't come up again unless requested. We can't use `dependency.ErrUninstall` as other transitive dependencies bounce and chaos ensues.

The real solution to the problem is to then perform an `upgrade-model`, which will then move it to 4.0.x and everything will become normalized.

 1. https://github.com/juju/juju/pull/16942
 2.  https://github.com/juju/juju/pull/17596

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

For each path, you must also deploy into the model _after_ it's migrated, as it's at that point you'll see errors streaming out.

### 3.6 to 3.6

```sh
$ git checkout 3.6
$ make juju jujud jujud-controller
$ juju bootstrap lxd src36
$ juju add-model moveme
$ juju deploy ubuntu

$ juju bootstrap lxd dst36

$ juju switch src36
$ juju migrate src36:moveme dst36

$ juju deploy ubuntu ubuntux
$ juju debug-log -m dst36:moveme --replay
```

### Setup 3.6 to 4.0

```sh
$ git checkout 3.6
$ make juju jujud jujud-controller
$ juju bootstrap lxd src36
$ juju add-model moveme
$ juju deploy ubuntu

$ git checkout main
$ make juju jujud jujud-controller
$ juju bootstrap lxd dst40

$ juju switch src36
$ juju migrate src36:moveme dst40

$ juju deploy ubuntu ubuntux
$ juju debug-log -m dst40:moveme --replay
```

## Links


**Jira card:** [JUJU-6188](https://warthogs.atlassian.net/browse/JUJU-6188)



[JUJU-6188]: https://warthogs.atlassian.net/browse/JUJU-6188?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ