### PR TITLE
feat: charm domain service - set charm

### DIFF
--- a/domain/charm/errors/errors.go
+++ b/domain/charm/errors/errors.go
@@ -22,4 +22,12 @@ const (
 	// RevisionNotValid describes an error that occurs when attempting to get
 	// a charm using an invalid revision.
 	RevisionNotValid = errors.ConstError("charm revision not valid")
+
+	// MetadataNotValid describes an error that occurs when the charm metadata
+	// is not valid.
+	MetadataNotValid = errors.ConstError("charm metadata not valid")
+
+	// ManifestNotValid describes an error that occurs when the charm manifest
+	// is not valid.
+	ManifestNotValid = errors.ConstError("charm manifest not valid")
 )

--- a/domain/charm/service/actions.go
+++ b/domain/charm/service/actions.go
@@ -46,3 +46,40 @@ func decodeActionParams(params []byte) (map[string]any, error) {
 	}
 	return result, nil
 }
+
+func encodeActions(actions *internalcharm.Actions) (charm.Actions, error) {
+	if actions == nil || len(actions.ActionSpecs) == 0 {
+		return charm.Actions{}, nil
+	}
+
+	result := make(map[string]charm.Action)
+	for name, action := range actions.ActionSpecs {
+		params, err := encodeActionParams(action.Params)
+		if err != nil {
+			return charm.Actions{}, fmt.Errorf("encode action params: %w", err)
+		}
+
+		result[name] = charm.Action{
+			Description:    action.Description,
+			Parallel:       action.Parallel,
+			ExecutionGroup: action.ExecutionGroup,
+			Params:         params,
+		}
+	}
+	return charm.Actions{
+		Actions: result,
+	}, nil
+}
+
+func encodeActionParams(params map[string]any) ([]byte, error) {
+	if len(params) == 0 {
+		return nil, nil
+	}
+
+	result, err := json.Marshal(params)
+	if err != nil {
+		return nil, fmt.Errorf("marshal: %w", err)
+	}
+
+	return result, nil
+}

--- a/domain/charm/service/actions_test.go
+++ b/domain/charm/service/actions_test.go
@@ -57,7 +57,7 @@ var actionsTestCases = [...]struct {
 					Description:    "description1",
 					Parallel:       true,
 					ExecutionGroup: "group1",
-					Params:         []byte(`{"remote-sync":{"description":"Sync a file to a remote host.","params":{"file":{"description":"The file to send out.","type":"string","format":"uri"},"remote-uri":{"description":"The host to sync to.","type":"string","format":"uri"},"util":{"description":"The util to perform the sync (rsync or scp.)","type":"string","enum":["rsync","scp"]}},"required":["file","remote-uri"]}}`),
+					Params:         []byte(`{"remote-sync":{"description":"Sync a file to a remote host.","params":{"file":{"description":"The file to send out.","format":"uri","type":"string"},"remote-uri":{"description":"The host to sync to.","format":"uri","type":"string"},"util":{"description":"The util to perform the sync (rsync or scp.)","enum":["rsync","scp"],"type":"string"}},"required":["file","remote-uri"]}}`),
 				},
 			},
 		},
@@ -103,5 +103,10 @@ func (s *metadataSuite) TestConvertActions(c *gc.C) {
 		result, err := decodeActions(tc.input)
 		c.Assert(err, jc.ErrorIsNil)
 		c.Check(result, gc.DeepEquals, tc.output)
+
+		// Ensure that the conversion is idempotent.
+		converted, err := encodeActions(&result)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Check(converted, jc.DeepEquals, tc.input)
 	}
 }

--- a/domain/charm/service/charm.go
+++ b/domain/charm/service/charm.go
@@ -1,0 +1,51 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package service
+
+import (
+	"fmt"
+
+	"github.com/juju/juju/domain/charm"
+	internalcharm "github.com/juju/juju/internal/charm"
+)
+
+// encodeCharm encodes a charm to the service representation.
+// Returns an error if the charm metadata cannot be encoded.
+func encodeCharm(ch internalcharm.Charm) (charm.Charm, error) {
+	metadata, err := encodeMetadata(ch.Meta())
+	if err != nil {
+		return charm.Charm{}, fmt.Errorf("encode metadata: %w", err)
+	}
+
+	manifest, err := encodeManifest(ch.Manifest())
+	if err != nil {
+		return charm.Charm{}, fmt.Errorf("encode manifest: %w", err)
+	}
+
+	actions, err := encodeActions(ch.Actions())
+	if err != nil {
+		return charm.Charm{}, fmt.Errorf("encode actions: %w", err)
+	}
+
+	config, err := encodeConfig(ch.Config())
+	if err != nil {
+		return charm.Charm{}, fmt.Errorf("encode config: %w", err)
+	}
+
+	var profile []byte
+	if lxdProfile, ok := ch.(internalcharm.LXDProfiler); ok {
+		profile, err = encodeLXDProfile(lxdProfile.LXDProfile())
+		if err != nil {
+			return charm.Charm{}, fmt.Errorf("encode lxd profile: %w", err)
+		}
+	}
+
+	return charm.Charm{
+		Metadata:   metadata,
+		Manifest:   manifest,
+		Actions:    actions,
+		Config:     config,
+		LXDProfile: profile,
+	}, nil
+}

--- a/domain/charm/service/config.go
+++ b/domain/charm/service/config.go
@@ -58,3 +58,52 @@ func decodeOptionType(t charm.OptionType) (string, error) {
 		return "", fmt.Errorf("unknown option type %q", t)
 	}
 }
+
+func encodeConfig(config *internalcharm.Config) (charm.Config, error) {
+	if len(config.Options) == 0 {
+		return charm.Config{}, nil
+	}
+
+	result := make(map[string]charm.Option)
+	for name, option := range config.Options {
+		opt, err := encodeConfigOption(option)
+		if err != nil {
+			return charm.Config{}, fmt.Errorf("encode config option: %w", err)
+		}
+
+		result[name] = opt
+	}
+	return charm.Config{
+		Options: result,
+	}, nil
+}
+
+func encodeConfigOption(option internalcharm.Option) (charm.Option, error) {
+	t, err := encodeOptionType(option.Type)
+	if err != nil {
+		return charm.Option{}, fmt.Errorf("encode option type: %w", err)
+	}
+
+	return charm.Option{
+		Type:        t,
+		Description: option.Description,
+		Default:     option.Default,
+	}, nil
+}
+
+func encodeOptionType(t string) (charm.OptionType, error) {
+	switch t {
+	case "string":
+		return charm.OptionString, nil
+	case "int":
+		return charm.OptionInt, nil
+	case "float":
+		return charm.OptionFloat, nil
+	case "boolean":
+		return charm.OptionBool, nil
+	case "secret":
+		return charm.OptionSecret, nil
+	default:
+		return "", fmt.Errorf("unknown option type %q", t)
+	}
+}

--- a/domain/charm/service/config_test.go
+++ b/domain/charm/service/config_test.go
@@ -98,5 +98,10 @@ func (s *metadataSuite) TestConvertConfig(c *gc.C) {
 		result, err := decodeConfig(tc.input)
 		c.Assert(err, jc.ErrorIsNil)
 		c.Check(result, gc.DeepEquals, tc.output)
+
+		// Ensure that the conversion is idempotent.
+		converted, err := encodeConfig(&result)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Check(converted, jc.DeepEquals, tc.input)
 	}
 }

--- a/domain/charm/service/lxdprofile.go
+++ b/domain/charm/service/lxdprofile.go
@@ -15,10 +15,37 @@ func decodeLXDProfile(profile []byte) (internalcharm.LXDProfile, error) {
 		return internalcharm.LXDProfile{}, nil
 	}
 
-	var result internalcharm.LXDProfile
+	var result lxdProfile
 	if err := json.Unmarshal(profile, &result); err != nil {
-		return result, fmt.Errorf("unmarshal lxd profile: %w", err)
+		return internalcharm.LXDProfile{}, fmt.Errorf("unmarshal lxd profile: %w", err)
+	}
+
+	return internalcharm.LXDProfile{
+		Config:      result.Config,
+		Description: result.Description,
+		Devices:     result.Devices,
+	}, nil
+}
+
+func encodeLXDProfile(profile *internalcharm.LXDProfile) ([]byte, error) {
+	if profile.Empty() && profile.Description == "" {
+		return nil, nil
+	}
+
+	result, err := json.Marshal(lxdProfile{
+		Config:      profile.Config,
+		Description: profile.Description,
+		Devices:     profile.Devices,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal lxd profile: %w", err)
 	}
 
 	return result, nil
+}
+
+type lxdProfile struct {
+	Config      map[string]string            `json:"config,omitempty"`
+	Description string                       `json:"description,omitempty"`
+	Devices     map[string]map[string]string `json:"devices,omitempty"`
 }

--- a/domain/charm/service/lxdprofile_test.go
+++ b/domain/charm/service/lxdprofile_test.go
@@ -27,7 +27,7 @@ var lxdProfileTestCases = [...]struct {
 	},
 	{
 		name:  "profile config",
-		input: []byte(`{"config": {"limits.cpu": "2", "limits.memory": "2GB"}}`),
+		input: []byte(`{"config":{"limits.cpu":"2","limits.memory":"2GB"}}`),
 		output: internalcharm.LXDProfile{
 			Config: map[string]string{
 				"limits.cpu":    "2",
@@ -37,14 +37,14 @@ var lxdProfileTestCases = [...]struct {
 	},
 	{
 		name:  "profile description",
-		input: []byte(`{"description": "description"}`),
+		input: []byte(`{"description":"description"}`),
 		output: internalcharm.LXDProfile{
 			Description: "description",
 		},
 	},
 	{
 		name:  "profile devices",
-		input: []byte(`{"devices": {"eth0": {"nictype": "bridged", "parent": "lxdbr0"}}}`),
+		input: []byte(`{"devices":{"eth0":{"nictype":"bridged","parent":"lxdbr0"}}}`),
 		output: internalcharm.LXDProfile{
 			Devices: map[string]map[string]string{
 				"eth0": {
@@ -63,5 +63,10 @@ func (s *metadataSuite) TestConvertLXDProfile(c *gc.C) {
 		result, err := decodeLXDProfile(tc.input)
 		c.Assert(err, jc.ErrorIsNil)
 		c.Check(result, gc.DeepEquals, tc.output)
+
+		// Ensure that the conversion is idempotent.
+		converted, err := encodeLXDProfile(&result)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Check(converted, jc.DeepEquals, tc.input)
 	}
 }

--- a/domain/charm/service/manifest_test.go
+++ b/domain/charm/service/manifest_test.go
@@ -66,5 +66,10 @@ func (s *metadataSuite) TestConvertManifest(c *gc.C) {
 		result, err := decodeManifest(tc.input)
 		c.Assert(err, jc.ErrorIsNil)
 		c.Check(result, gc.DeepEquals, tc.output)
+
+		// Ensure that the conversion is idempotent.
+		converted, err := encodeManifest(&result)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Check(converted, jc.DeepEquals, tc.input)
 	}
 }

--- a/domain/charm/service/metadata_test.go
+++ b/domain/charm/service/metadata_test.go
@@ -366,5 +366,10 @@ func (s *metadataSuite) TestConvertMetadata(c *gc.C) {
 		result, err := decodeMetadata(tc.input)
 		c.Assert(err, jc.ErrorIsNil)
 		c.Check(result, gc.DeepEquals, tc.output)
+
+		// Ensure that the conversion is idempotent.
+		converted, err := encodeMetadata(&result)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Check(converted, jc.DeepEquals, tc.input)
 	}
 }

--- a/domain/charm/service/package_mock_test.go
+++ b/domain/charm/service/package_mock_test.go
@@ -472,6 +472,45 @@ func (c *MockStateReserveCharmRevisionCall) DoAndReturn(f func(context.Context, 
 	return c
 }
 
+// SetCharm mocks base method.
+func (m *MockState) SetCharm(arg0 context.Context, arg1 charm0.Charm) (charm.ID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetCharm", arg0, arg1)
+	ret0, _ := ret[0].(charm.ID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SetCharm indicates an expected call of SetCharm.
+func (mr *MockStateMockRecorder) SetCharm(arg0, arg1 any) *MockStateSetCharmCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCharm", reflect.TypeOf((*MockState)(nil).SetCharm), arg0, arg1)
+	return &MockStateSetCharmCall{Call: call}
+}
+
+// MockStateSetCharmCall wrap *gomock.Call
+type MockStateSetCharmCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateSetCharmCall) Return(arg0 charm.ID, arg1 error) *MockStateSetCharmCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateSetCharmCall) Do(f func(context.Context, charm0.Charm) (charm.ID, error)) *MockStateSetCharmCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateSetCharmCall) DoAndReturn(f func(context.Context, charm0.Charm) (charm.ID, error)) *MockStateSetCharmCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // SetCharmAvailable mocks base method.
 func (m *MockState) SetCharmAvailable(arg0 context.Context, arg1 charm.ID) error {
 	m.ctrl.T.Helper()

--- a/domain/charm/service/service.go
+++ b/domain/charm/service/service.go
@@ -90,6 +90,10 @@ type State interface {
 	// The original charm will need to exist, the returning charm ID will be
 	// the new charm ID for the revision.
 	ReserveCharmRevision(ctx context.Context, id corecharm.ID, revision int) (corecharm.ID, error)
+
+	// SetCharm persists the charm metadata, actions, config and manifest to
+	// state.
+	SetCharm(ctx context.Context, charm charm.Charm) (corecharm.ID, error)
 }
 
 // Service provides the API for working with charms.
@@ -308,6 +312,23 @@ func (s *Service) ReserveCharmRevision(ctx context.Context, id corecharm.ID, rev
 		return "", errors.Trace(err)
 	}
 	return newID, nil
+}
+
+// SetCharm persists the charm metadata, actions, config and manifest to
+// state.
+func (s *Service) SetCharm(ctx context.Context, charm internalcharm.Charm) (corecharm.ID, error) {
+	ch, err := encodeCharm(charm)
+	if err != nil {
+		return "", fmt.Errorf("encode charm: %w", err)
+	}
+
+	charmID, err := s.st.SetCharm(ctx, ch)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+
+	return charmID, nil
+
 }
 
 // WatchableService provides the API for working with charms and the

--- a/domain/charm/types.go
+++ b/domain/charm/types.go
@@ -20,6 +20,24 @@ type GetCharmArgs struct {
 	Revision *int
 }
 
+// Charm represents a charm from the perspective of the service. This is the
+// golden source of charm information. If the charm changes at the wire format
+// level, we should be able to map it to this struct.
+type Charm struct {
+	// Metadata holds the metadata of the charm.
+	Metadata Metadata
+	// Manifest holds the manifest of the charm. It defines the bases that
+	// the charm supports.
+	Manifest Manifest
+	// Actions holds the actions of the charm.
+	Actions Actions
+	// Config holds the configuration options of the charm.
+	Config Config
+	// LXDProfile holds the LXD profile of the charm. It allows the charm to
+	// specify the LXD profile that should be used when deploying the charm.
+	LXDProfile []byte
+}
+
 // Metadata represents the metadata of a charm from the perspective of the
 // service. This is the golden source of charm metadata. If the charm changes
 // at the wire format level, we should be able to map it to this struct.


### PR DESCRIPTION
This follows on from the initial scaffolding PR[1], by adding all the encoding logic to set a charm. This ensures that we can encode and decode the charm metadata, manifest actions, config and lxd profile data.

By making parts of the charm data optional when setting it, the plan is to drop setting essential metadata. We will have all the data we need to make a successful requestion.

Landing this then unlocks the state implementation. Wire up of state can then come later.

 1. https://github.com/juju/juju/pull/17569

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

Tests pass in `domain/service/charm`

## Links

**Jira card:** [JUJU-6014](https://warthogs.atlassian.net/browse/JUJU-6014)



[JUJU-6014]: https://warthogs.atlassian.net/browse/JUJU-6014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ