### PR TITLE
refactor: machine id to machine name

### DIFF
--- a/core/machine/machine.go
+++ b/core/machine/machine.go
@@ -7,36 +7,21 @@ import (
 	"fmt"
 
 	"github.com/juju/errors"
-
-	"github.com/juju/juju/internal/uuid"
 )
 
-// ID is a unique identifier for a machine.
-type ID string
+// Name is a unique name identifier for a machine.
+type Name string
 
-// NewId makes and returns a new machine [ID].
-func NewId() (ID, error) {
-	uuid, err := uuid.NewUUID()
-	if err != nil {
-		return "", fmt.Errorf("generating new machine id: %w", err)
-	}
-
-	return ID(uuid.String()), nil
-}
-
-// Validate returns an error if the [ID] is invalid. The error returned
+// Validate returns an error if the [Name] is invalid. The error returned
 // satisfies [errors.NotValid].
-func (i ID) Validate() error {
-	if i == "" {
-		return fmt.Errorf("empty machine id%w", errors.Hide(errors.NotValid))
-	}
-	if !uuid.IsValidUUIDString(string(i)) {
-		return fmt.Errorf("invalid machine id: %q%w", i, errors.Hide(errors.NotValid))
+func (n Name) Validate() error {
+	if n == "" {
+		return fmt.Errorf("empty machine name%w", errors.Hide(errors.NotValid))
 	}
 	return nil
 }
 
-// String returns the [ID] as a string.
-func (i ID) String() string {
+// String returns the [Name] as a string.
+func (i Name) String() string {
 	return string(i)
 }

--- a/core/machine/machine_test.go
+++ b/core/machine/machine_test.go
@@ -7,8 +7,6 @@ import (
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
-
-	"github.com/juju/juju/internal/uuid"
 )
 
 type machineSuite struct {
@@ -16,29 +14,25 @@ type machineSuite struct {
 
 var _ = gc.Suite(&machineSuite{})
 
-// TestIdValidate is testing several good and not so good machine id's to check
+// TestNameValidate is testing good and not so good machine names to check
 // that the validate method produces the correct result.
-func (*machineSuite) TestIdValidate(c *gc.C) {
+func (*machineSuite) TestNameValidate(c *gc.C) {
 	tests := []struct {
-		id  string
-		err error
+		name string
+		err  error
 	}{
 		{
-			id:  "",
-			err: errors.NotValid,
+			name: "",
+			err:  errors.NotValid,
 		},
 		{
-			id:  "invalid",
-			err: errors.NotValid,
-		},
-		{
-			id: uuid.MustNewUUID().String(),
+			name: "40",
 		},
 	}
 
 	for i, test := range tests {
-		c.Logf("test %d: %q", i, test.id)
-		err := ID(test.id).Validate()
+		c.Logf("test %d: %q", i, test.name)
+		err := Name(test.name).Validate()
 
 		if test.err == nil {
 			c.Check(err, gc.IsNil)


### PR DESCRIPTION
In a previous commit I had introduced the concept of a strong type for machine id. This was not correct as we currently use the machines name to uniquely refer to machines in the Juju model. This change renames id to machine name and updates the usage.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

N/A no usages of this at the moment.

## Documentation changes

N/A

## Links

**Jira card:** JUJU-6097

