### PR TITLE
feat: Implementation of keyupdater domain state

### DIFF
--- a/domain/keyupdater/state/controllerkeystate.go
+++ b/domain/keyupdater/state/controllerkeystate.go
@@ -1,0 +1,76 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/canonical/sqlair"
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/core/database"
+	"github.com/juju/juju/domain"
+)
+
+// ControllerKeyState provides a state access layer for accessing a controllers
+// ssh keys via controller config.
+type ControllerKeyState struct {
+	*domain.StateBase
+}
+
+// GetControllerConfigKeys returns the controller config key and values for the
+// keys supplied. If one or more keys supplied do not exist in the controller's
+// config they will be omitted from the final result.
+func (st *ControllerKeyState) GetControllerConfigKeys(
+	ctx context.Context,
+	keys []string,
+) (map[string]string, error) {
+	db, err := st.DB()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	sqlKeys := make(sqlair.S, 0, len(keys))
+	for _, key := range keys {
+		sqlKeys = append(sqlKeys, key)
+	}
+
+	stmt, err := st.Prepare(`
+SELECT &keyValue.*
+FROM v_controller_config
+WHERE key IN ($S[:])
+`, keyValue{}, sqlKeys)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	keyValues := []keyValue{}
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		return tx.Query(ctx, stmt, sqlKeys).GetAll(&keyValues)
+	})
+
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return nil, fmt.Errorf(
+			"cannot get controller config for keys %v: %w",
+			keys, err,
+		)
+	}
+
+	rval := make(map[string]string, len(keyValues))
+	for _, kv := range keyValues {
+		rval[kv.Key] = kv.Value
+	}
+
+	return rval, nil
+}
+
+// NewControllerKeyState constructs a new state for interacting with the
+// underlying authorised keys of a controller via controller config.
+func NewControllerKeyState(factory database.TxnRunnerFactory) *ControllerKeyState {
+	return &ControllerKeyState{
+		StateBase: domain.NewStateBase(factory),
+	}
+}

--- a/domain/keyupdater/state/controllerkeystate.go
+++ b/domain/keyupdater/state/controllerkeystate.go
@@ -15,7 +15,7 @@ import (
 	"github.com/juju/juju/domain"
 )
 
-// ControllerKeyState provides a state access layer for accessing a controllers
+// ControllerKeyState provides a state access layer for accessing a controller's
 // ssh keys via controller config.
 type ControllerKeyState struct {
 	*domain.StateBase

--- a/domain/keyupdater/state/controllerkeystate_test.go
+++ b/domain/keyupdater/state/controllerkeystate_test.go
@@ -1,0 +1,66 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"context"
+	"database/sql"
+
+	gc "gopkg.in/check.v1"
+
+	jc "github.com/juju/testing/checkers"
+
+	"github.com/juju/juju/controller"
+	schematesting "github.com/juju/juju/domain/schema/testing"
+)
+
+type controllerKeyStateSuite struct {
+	schematesting.ControllerSuite
+}
+
+var (
+	_ = gc.Suite(&controllerKeyStateSuite{})
+
+	controllerSSHKeys = `
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIN8h8XBpjS9aBUG5cdoSWubs7wT2Lc/BEZIUQCqoaOZR juju-client-key
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIN8h8XBpjS9aBUG5cdoSWubs7wT2Lc/BEZIUQCqoaOZR juju-system-key`
+)
+
+// ensureControllerConfigSSHKeys is responsible for injecting ssh keys into a
+// controllers config with the key defined in [controller.SystemSSHKeys].
+func (s *controllerKeyStateSuite) ensureControllerConfigSSHKeys(c *gc.C, keys string) {
+	stmt := `
+INSERT INTO controller_config (key, value) VALUES(?, ?)
+`
+
+	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, stmt, controller.SystemSSHKeys, keys)
+		return err
+	})
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+// TestControllerConfigKeysEmpty ensures that if we ask for keys that do not
+// exist in controller config no errors are returned an empty map is returned.
+func (s *controllerKeyStateSuite) TestControllerConfigKeysEmpty(c *gc.C) {
+	kv, err := NewControllerKeyState(s.TxnRunnerFactory()).GetControllerConfigKeys(
+		context.Background(),
+		[]string{"does-not-exist"},
+	)
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(len(kv), gc.Equals, 0)
+}
+
+// TestControllerConfigKeys is asserting the happy path that we can extract the
+// system ssh keys from controller config when they exist.
+func (s *controllerKeyStateSuite) TestControllerConfigKeys(c *gc.C) {
+	s.ensureControllerConfigSSHKeys(c, controllerSSHKeys)
+	kv, err := NewControllerKeyState(s.TxnRunnerFactory()).GetControllerConfigKeys(
+		context.Background(),
+		[]string{controller.SystemSSHKeys},
+	)
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(len(kv), gc.Equals, 1)
+	c.Check(kv[controller.SystemSSHKeys], gc.Equals, controllerSSHKeys)
+}

--- a/domain/keyupdater/state/controllerkeystate_test.go
+++ b/domain/keyupdater/state/controllerkeystate_test.go
@@ -7,9 +7,8 @@ import (
 	"context"
 	"database/sql"
 
-	gc "gopkg.in/check.v1"
-
 	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/controller"
 	schematesting "github.com/juju/juju/domain/schema/testing"

--- a/domain/keyupdater/state/package_test.go
+++ b/domain/keyupdater/state/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/domain/keyupdater/state/state.go
+++ b/domain/keyupdater/state/state.go
@@ -1,0 +1,111 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/canonical/sqlair"
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/core/database"
+	coremachine "github.com/juju/juju/core/machine"
+	"github.com/juju/juju/domain"
+	machineerrors "github.com/juju/juju/domain/machine/errors"
+)
+
+type State struct {
+	*domain.StateBase
+}
+
+// AllPublicKeysQuery returns a state SQL query for fetching the public keys
+// available on a model. This is useful for constructing authorised keys
+// watchers.
+func (s *State) AllPublicKeysQuery() string {
+	return "SELECT public_key FROM user_public_ssh_key"
+}
+
+// AuthorisedKeysForMachine returns a list of authorised public ssh keys for a
+// machine name. If no machine exists for the given machine name an error
+// satisfying [machineerrors.NotFound] will be returned.
+func (s *State) AuthorisedKeysForMachine(
+	ctx context.Context,
+	machineName coremachine.Name,
+) ([]string, error) {
+	db, err := s.DB()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	machineArg := machineID{machineName.String()}
+	machineStmt, err := s.Prepare(`
+SELECT machine_id AS &machineID.*
+FROM machine
+WHERE machine_id = $machineID.machine_id
+`, machineArg)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"preparing select statement for getting machine %q when determining authorised keys: %w",
+			machineName, err,
+		)
+	}
+
+	stmt, err := s.Prepare(`
+SELECT public_key AS &authorisedKey.*
+FROM user_public_ssh_key
+`, authorisedKey{})
+	if err != nil {
+		return nil, fmt.Errorf(
+			"preparing select statement for getting machine %q authorised keys: %w",
+			machineName, err,
+		)
+	}
+
+	authorisedKeys := []authorisedKey{}
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		// Because we have two queries to run and two error paths we need to
+		// handle the errors inside this TX so we can produce the correct error.
+		err := tx.Query(ctx, machineStmt, machineArg).Get(&machineArg)
+		if errors.Is(err, sqlair.ErrNoRows) {
+			return fmt.Errorf(
+				"cannot get authorised keys for machine %q: %w",
+				machineName, machineerrors.NotFound,
+			)
+		} else if err != nil {
+			return fmt.Errorf(
+				"cannot get authorised keys for machine %q: %w",
+				machineName, domain.CoerceError(err),
+			)
+		}
+
+		err = tx.Query(ctx, stmt).GetAll(&authorisedKeys)
+		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+			return fmt.Errorf(
+				"cannot get authorised keys for machine %q: %w",
+				machineName, domain.CoerceError(err),
+			)
+		}
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	rval := make([]string, 0, len(authorisedKeys))
+	for _, authKey := range authorisedKeys {
+		rval = append(rval, authKey.PublicKey)
+	}
+
+	return rval, nil
+}
+
+// NewState constructs a new state for interacting with the underlying
+// authorised keys of a model.
+func NewState(factory database.TxnRunnerFactory) *State {
+	return &State{
+		StateBase: domain.NewStateBase(factory),
+	}
+}

--- a/domain/keyupdater/state/state.go
+++ b/domain/keyupdater/state/state.go
@@ -32,23 +32,23 @@ func (s *State) AllPublicKeysQuery() string {
 // satisfying [machineerrors.NotFound] will be returned.
 func (s *State) AuthorisedKeysForMachine(
 	ctx context.Context,
-	machineName coremachine.Name,
+	name coremachine.Name,
 ) ([]string, error) {
 	db, err := s.DB()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
-	machineArg := machineID{machineName.String()}
+	machineArg := machineName{name.String()}
 	machineStmt, err := s.Prepare(`
-SELECT machine_id AS &machineID.*
+SELECT name AS &machineName.*
 FROM machine
-WHERE machine_id = $machineID.machine_id
+WHERE name = $machineName.name
 `, machineArg)
 	if err != nil {
 		return nil, fmt.Errorf(
 			"preparing select statement for getting machine %q when determining authorised keys: %w",
-			machineName, err,
+			name, err,
 		)
 	}
 
@@ -59,7 +59,7 @@ FROM user_public_ssh_key
 	if err != nil {
 		return nil, fmt.Errorf(
 			"preparing select statement for getting machine %q authorised keys: %w",
-			machineName, err,
+			name, err,
 		)
 	}
 
@@ -71,12 +71,12 @@ FROM user_public_ssh_key
 		if errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf(
 				"cannot get authorised keys for machine %q: %w",
-				machineName, machineerrors.NotFound,
+				name, machineerrors.NotFound,
 			)
 		} else if err != nil {
 			return fmt.Errorf(
 				"cannot get authorised keys for machine %q: %w",
-				machineName, domain.CoerceError(err),
+				name, domain.CoerceError(err),
 			)
 		}
 
@@ -84,7 +84,7 @@ FROM user_public_ssh_key
 		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf(
 				"cannot get authorised keys for machine %q: %w",
-				machineName, domain.CoerceError(err),
+				name, domain.CoerceError(err),
 			)
 		}
 		return nil

--- a/domain/keyupdater/state/state_test.go
+++ b/domain/keyupdater/state/state_test.go
@@ -1,0 +1,165 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"context"
+	"database/sql"
+	"slices"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	coremachine "github.com/juju/juju/core/machine"
+	usertesting "github.com/juju/juju/core/user/testing"
+	"github.com/juju/juju/domain/keymanager"
+	keymanagerstate "github.com/juju/juju/domain/keymanager/state"
+	machineerrors "github.com/juju/juju/domain/machine/errors"
+	schematesting "github.com/juju/juju/domain/schema/testing"
+	"github.com/juju/juju/internal/ssh"
+)
+
+type stateSuite struct {
+	schematesting.ModelSuite
+
+	machineName coremachine.Name
+}
+
+var _ = gc.Suite(&stateSuite{})
+
+var (
+	testingPublicKeys = []string{
+		// ecdsa testing public key
+		"ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBG00bYFLb/sxPcmVRMg8NXZK/ldefElAkC9wD41vABdHZiSRvp+2y9BMNVYzE/FnzKObHtSvGRX65YQgRn7k5p0= juju1@example.com",
+
+		// ed25519 testing public key
+		"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIN8h8XBpjS9aBUG5cdoSWubs7wT2Lc/BEZIUQCqoaOZR juju2@example.com",
+
+		// rsa testing public key
+		"ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDvplNOK3UBpULZKvZf/I5JHci/DufpSxj8yR4yKE2grescJxu6754jPT3xztSeLGD31/oJApJZGkMUAMRenvDqIaq+taRfOUo/l19AlGZc+Edv4bTlJzZ1Lzwex1vvL1doaLb/f76IIUHClGUgIXRceQH1ovHiIWj6nGltuLanG8YTWxlzzK33yhitmZt142DmpX1VUVF5c/Hct6Rav5lKmwej1TDed1KmHzXVoTHEsmWhKsOK27ue5yTuq0GX6LrAYDucF+2MqZCsuddXsPAW1tj5GNZSR7RrKW5q1CI0G7k9gSomuCsRMlCJ3BqID/vUSs/0qOWg4he0HUsYKQSrXIhckuZu+jYP8B80MoXT50ftRidoG/zh/PugBdXTk46FloVClQopG5A2fbqrphADcUUbRUxZ2lWQN+OVHKfEsfV2b8L2aSqZUGlryfW1cirB5JCTDvtv7rUy9/ny9iKA+8tAyKSDF0I901RDDqKc9dSkrHCg2bLnJZDoiRoWczE= juju3@example.com",
+	}
+)
+
+func generatePublicKeys(c *gc.C, publicKeys []string) []keymanager.PublicKey {
+	rval := make([]keymanager.PublicKey, 0, len(publicKeys))
+	for _, pk := range publicKeys {
+		parsedKey, err := ssh.ParsePublicKey(pk)
+		c.Assert(err, jc.ErrorIsNil)
+
+		rval = append(rval, keymanager.PublicKey{
+			Comment:         parsedKey.Comment,
+			FingerprintHash: keymanager.FingerprintHashAlgorithmSHA256,
+			Fingerprint:     parsedKey.Fingerprint(),
+			Key:             pk,
+		})
+	}
+
+	return rval
+}
+
+// ensureNetNode inserts a row into the net_node table, mostly used as a foreign key for entries in
+// other tables (e.g. machine)
+func (s *stateSuite) ensureNetNode(c *gc.C, uuid string) {
+	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+		INSERT INTO net_node (uuid)
+		VALUES (?)`, uuid)
+		return err
+	})
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *stateSuite) ensureMachine(c *gc.C, name coremachine.Name, uuid string) {
+	s.ensureNetNode(c, "node2")
+	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+		INSERT INTO machine (uuid, net_node_uuid, machine_id, life_id)
+		VALUES (?, "node2", ?, "0")`, uuid, name)
+		return err
+	})
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *stateSuite) SetUpTest(c *gc.C) {
+	s.ModelSuite.SetUpTest(c)
+
+	s.machineName = coremachine.Name("0")
+	s.ensureMachine(c, s.machineName, "123")
+}
+
+// TestAuthorisedKeysForUnknownMachine is assertint that if we ask for
+// authorised keys for a machine that doesn't exist we get back a
+// [machineerrors.NotFound] error.
+func (s *stateSuite) TestAuthorisedKeysForUnknownMachine(c *gc.C) {
+	state := NewState(s.TxnRunnerFactory())
+	_, err := state.AuthorisedKeysForMachine(context.Background(), coremachine.Name("100"))
+	c.Check(err, jc.ErrorIs, machineerrors.NotFound)
+}
+
+// TestEmptyAuthorisedKeysForMachine tests that if there are no authorised keys
+// for machine this does not produce an error.
+func (s *stateSuite) TestEmptyAuthorisedKeysForMachine(c *gc.C) {
+	state := NewState(s.TxnRunnerFactory())
+	keys, err := state.AuthorisedKeysForMachine(context.Background(), s.machineName)
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(len(keys), gc.Equals, 0)
+}
+
+// TestAuthorisedKeysForMachine is asserting the happy path of fetching
+// authorised keys for a given machine with no errors.
+func (s *stateSuite) TestAuthorisedKeysForMachine(c *gc.C) {
+	keyManagerState := keymanagerstate.NewState(s.TxnRunnerFactory())
+	keysToAdd := generatePublicKeys(c, testingPublicKeys)
+	userID := usertesting.GenUserUUID(c)
+
+	err := keyManagerState.AddPublicKeysForUser(context.Background(), userID, keysToAdd)
+	c.Check(err, jc.ErrorIsNil)
+
+	keys, err := NewState(s.TxnRunnerFactory()).AuthorisedKeysForMachine(
+		context.Background(),
+		s.machineName,
+	)
+	c.Check(err, jc.ErrorIsNil)
+	slices.Sort(keys)
+	slices.Sort(testingPublicKeys)
+	c.Check(keys, jc.DeepEquals, testingPublicKeys)
+}
+
+// TestAllPublicKeysQuery is testing the query from [State.AllPublicKeysQuery]
+// to make sure that it is returning all public keys in the model.
+func (s *stateSuite) TestAllPublicKeysQuery(c *gc.C) {
+	keyManagerState := keymanagerstate.NewState(s.TxnRunnerFactory())
+	keysToAdd := generatePublicKeys(c, testingPublicKeys)
+	userID := usertesting.GenUserUUID(c)
+
+	err := keyManagerState.AddPublicKeysForUser(context.Background(), userID, keysToAdd)
+	c.Check(err, jc.ErrorIsNil)
+
+	state := NewState(s.TxnRunnerFactory())
+
+	keys := []string{}
+	err = s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		rows, err := tx.QueryContext(ctx, state.AllPublicKeysQuery())
+		if err != nil {
+			return err
+		}
+
+		defer rows.Close()
+		var key string
+		for rows.Next() {
+			if err := rows.Scan(&key); err != nil {
+				return err
+			}
+
+			keys = append(keys, key)
+		}
+
+		return rows.Err()
+	})
+
+	c.Check(err, jc.ErrorIsNil)
+	slices.Sort(keys)
+	slices.Sort(testingPublicKeys)
+	c.Check(keys, jc.DeepEquals, testingPublicKeys)
+}

--- a/domain/keyupdater/state/state_test.go
+++ b/domain/keyupdater/state/state_test.go
@@ -74,7 +74,7 @@ func (s *stateSuite) ensureMachine(c *gc.C, name coremachine.Name, uuid string) 
 	s.ensureNetNode(c, "node2")
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		_, err := tx.ExecContext(ctx, `
-		INSERT INTO machine (uuid, net_node_uuid, machine_id, life_id)
+		INSERT INTO machine (uuid, net_node_uuid, name, life_id)
 		VALUES (?, "node2", ?, "0")`, uuid, name)
 		return err
 	})

--- a/domain/keyupdater/state/types.go
+++ b/domain/keyupdater/state/types.go
@@ -14,7 +14,7 @@ type keyValue struct {
 	Value string `db:"value"`
 }
 
-// machineID represents a single machine id
-type machineID struct {
-	MachineID string `db:"machine_id"`
+// machineName represents a single machine name
+type machineName struct {
+	Name string `db:"name"`
 }

--- a/domain/keyupdater/state/types.go
+++ b/domain/keyupdater/state/types.go
@@ -1,0 +1,20 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+// authorisedKey represents a single authorised key for a machine.
+type authorisedKey struct {
+	PublicKey string `db:"public_key"`
+}
+
+// keyValue represents a single row from the controllers config.
+type keyValue struct {
+	Key   string `db:"key"`
+	Value string `db:"value"`
+}
+
+// machineID represents a single machine id
+type machineID struct {
+	MachineID string `db:"machine_id"`
+}


### PR DESCRIPTION
This commit introduces the state layer required for the keyupdater domain. This is based on the requirements identified in the corresponding services layer.

Extension of PR #17604 and is needed to land #17602

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Unit tests. PR #17602 will be introducing the manual testing that tests this end to end.

## Documentation changes

N/A

## Links

**Jira card:** JUJU-6097

