### PR TITLE
fix: fix snacraft.yaml jujud build

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -409,9 +409,6 @@ parts:
     go-cgo-cflags: "-I/usr/local/musl/include"
     go-cgo-ldflags: "-luv -lraft -ldqlite -llz4 -lsqlite3"
     go-cgo-ldflags-allow: "(-Wl,-wrap,pthread_create)|(-Wl,-z,now)"
-    override-build: |
-      snapcraftctl build
-      mv ${SNAPCRAFT_PART_INSTALL}/bin/jujud ${SNAPCRAFT_PART_INSTALL}/bin/jujud
 
   juju:
     after:


### PR DESCRIPTION
A small snapcraft yaml fix to repair the building of the juju snap.

```
+ mv /build/snapcraft-juju-c8e48f6ce8fae175befe84541b6a64e1/parts/jujud/install/bin/jujud /build/snapcraft-juju-c8e48f6ce8fae175befe84541b6a64e1/parts/jujud/install/bin/jujud
mv: '/build/snapcraft-juju-c8e48f6ce8fae175befe84541b6a64e1/parts/jujud/install/bin/jujud' and '/build/snapcraft-juju-c8e48f6ce8fae175befe84541b6a64e1/parts/jujud/install/bin/jujud' are the same file
Failed to run 'override-build': Exit code was 1.
Build failed
```

There was leftover code from when the juju-controller stuff was backed out.
