### PR TITLE
chore: bump Go version to 1.22

### DIFF
--- a/.github/api-client-allowed-list.txt
+++ b/.github/api-client-allowed-list.txt
@@ -1,7 +1,7 @@
 archive
 bufio
 bytes
-compress
+cmp
 compress
 container
 context
@@ -55,6 +55,7 @@ path
 reflect
 regexp
 runtime
+slices
 sort
 strconv
 strings

--- a/.github/workflows/gen.yml
+++ b/.github/workflows/gen.yml
@@ -51,7 +51,7 @@ jobs:
           #  3. Unique every file, so we only go generate the file once.
           #  4. Using xargs perform go generate in parallel.
           #
-          grep -ir "//go:generate" . | awk -F : '{ print $1 }' | uniq | xargs -n 1 -P 8 -I% go generate -x $(realpath %)
+          grep -ir "//go:generate" --include '*.go' . | awk -F : '{ print $1 }' | uniq | xargs -n 1 -P 8 -I% go generate -x $(realpath %)
 
       - name: "Check diff"
         if: success() || failure()

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,12 +51,12 @@ that Go versions are not incremented during a release cycle. Check the `go.mod`
 file at the root of the project for the targeted version of Go, as this is
 authoritative.
 
-For example, the following indicates that Go 1.21 is targeted:
+For example, the following indicates that Go 1.22 is targeted:
 
 ```
 module github.com/juju/juju
 
-go 1.21.3
+go 1.22.2
 ```
 
 ### Official distribution

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/juju/juju
 
-go 1.21
+go 1.22
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.12.0

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -393,7 +393,7 @@ parts:
     after:
       - libdqlite
     plugin: juju-go
-    go-channel: 1.21/stable
+    go-channel: 1.22/stable
     source: .
     go-packages:
       - github.com/juju/juju/cmd/jujud
@@ -414,7 +414,7 @@ parts:
     after:
       - jujud
     plugin: juju-go
-    go-channel: 1.21/stable
+    go-channel: 1.22/stable
     # The source can be your local tree or github
     # source: https://github.com/juju/juju.git
     # If you pull a remote, set source-depth to 1 to make the fetch shorter


### PR DESCRIPTION
Triviality to use the latest Go version for the 3.6 release.

