### PR TITLE
feat(access): add includeDisabled flag in GetAllUsers

### DIFF
--- a/apiserver/facades/client/usermanager/domain_mock_test.go
+++ b/apiserver/facades/client/usermanager/domain_mock_test.go
@@ -160,18 +160,18 @@ func (c *MockAccessServiceEnableUserAuthenticationCall) DoAndReturn(f func(conte
 }
 
 // GetAllUsers mocks base method.
-func (m *MockAccessService) GetAllUsers(arg0 context.Context) ([]user.User, error) {
+func (m *MockAccessService) GetAllUsers(arg0 context.Context, arg1 bool) ([]user.User, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAllUsers", arg0)
+	ret := m.ctrl.Call(m, "GetAllUsers", arg0, arg1)
 	ret0, _ := ret[0].([]user.User)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetAllUsers indicates an expected call of GetAllUsers.
-func (mr *MockAccessServiceMockRecorder) GetAllUsers(arg0 any) *MockAccessServiceGetAllUsersCall {
+func (mr *MockAccessServiceMockRecorder) GetAllUsers(arg0, arg1 any) *MockAccessServiceGetAllUsersCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllUsers", reflect.TypeOf((*MockAccessService)(nil).GetAllUsers), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllUsers", reflect.TypeOf((*MockAccessService)(nil).GetAllUsers), arg0, arg1)
 	return &MockAccessServiceGetAllUsersCall{Call: call}
 }
 
@@ -187,13 +187,13 @@ func (c *MockAccessServiceGetAllUsersCall) Return(arg0 []user.User, arg1 error) 
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockAccessServiceGetAllUsersCall) Do(f func(context.Context) ([]user.User, error)) *MockAccessServiceGetAllUsersCall {
+func (c *MockAccessServiceGetAllUsersCall) Do(f func(context.Context, bool) ([]user.User, error)) *MockAccessServiceGetAllUsersCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockAccessServiceGetAllUsersCall) DoAndReturn(f func(context.Context) ([]user.User, error)) *MockAccessServiceGetAllUsersCall {
+func (c *MockAccessServiceGetAllUsersCall) DoAndReturn(f func(context.Context, bool) ([]user.User, error)) *MockAccessServiceGetAllUsersCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/client/usermanager/usermanager.go
+++ b/apiserver/facades/client/usermanager/usermanager.go
@@ -25,7 +25,7 @@ import (
 
 // AccessService defines the methods to operate with the database.
 type AccessService interface {
-	GetAllUsers(ctx context.Context) ([]coreuser.User, error)
+	GetAllUsers(ctx context.Context, includeDisabled bool) ([]coreuser.User, error)
 	GetUserByName(ctx context.Context, name string) (coreuser.User, error)
 	AddUser(ctx context.Context, arg service.AddUserArg) (coreuser.UUID, []byte, error)
 	EnableUserAuthentication(ctx context.Context, name string) error
@@ -312,7 +312,7 @@ func (api *UserManagerAPI) UserInfo(ctx context.Context, request params.UserInfo
 
 		if isAdmin {
 			// Get all users if isAdmin
-			users, err := api.accessService.GetAllUsers(ctx)
+			users, err := api.accessService.GetAllUsers(ctx, request.IncludeDisabled)
 			if err != nil {
 				return results, errors.Trace(err)
 			}

--- a/domain/access/doc.go
+++ b/domain/access/doc.go
@@ -1,0 +1,7 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package access provides the services for managing users and permissions in
+// Juju. The users side is mainly concerned with authentication and the
+// permissions side with authorization.
+package access

--- a/domain/access/service/service.go
+++ b/domain/access/service/service.go
@@ -72,7 +72,7 @@ type UserState interface {
 	// GetAllUsers will retrieve all users with authentication information
 	// (last login, disabled) from the database. If no users exist an empty slice
 	// will be returned.
-	GetAllUsers(context.Context) ([]user.User, error)
+	GetAllUsers(ctx context.Context, includeDisabled bool) ([]user.User, error)
 
 	// GetUser will retrieve the user with authentication information (last login, disabled)
 	// specified by UUID from the database. If the user does not exist an error that satisfies

--- a/domain/access/service/state_mock_test.go
+++ b/domain/access/service/state_mock_test.go
@@ -393,18 +393,18 @@ func (c *MockStateGetActivationKeyCall) DoAndReturn(f func(context.Context, stri
 }
 
 // GetAllUsers mocks base method.
-func (m *MockState) GetAllUsers(arg0 context.Context) ([]user.User, error) {
+func (m *MockState) GetAllUsers(arg0 context.Context, arg1 bool) ([]user.User, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAllUsers", arg0)
+	ret := m.ctrl.Call(m, "GetAllUsers", arg0, arg1)
 	ret0, _ := ret[0].([]user.User)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetAllUsers indicates an expected call of GetAllUsers.
-func (mr *MockStateMockRecorder) GetAllUsers(arg0 any) *MockStateGetAllUsersCall {
+func (mr *MockStateMockRecorder) GetAllUsers(arg0, arg1 any) *MockStateGetAllUsersCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllUsers", reflect.TypeOf((*MockState)(nil).GetAllUsers), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllUsers", reflect.TypeOf((*MockState)(nil).GetAllUsers), arg0, arg1)
 	return &MockStateGetAllUsersCall{Call: call}
 }
 
@@ -420,13 +420,13 @@ func (c *MockStateGetAllUsersCall) Return(arg0 []user.User, arg1 error) *MockSta
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetAllUsersCall) Do(f func(context.Context) ([]user.User, error)) *MockStateGetAllUsersCall {
+func (c *MockStateGetAllUsersCall) Do(f func(context.Context, bool) ([]user.User, error)) *MockStateGetAllUsersCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetAllUsersCall) DoAndReturn(f func(context.Context) ([]user.User, error)) *MockStateGetAllUsersCall {
+func (c *MockStateGetAllUsersCall) DoAndReturn(f func(context.Context, bool) ([]user.User, error)) *MockStateGetAllUsersCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1225,18 +1225,18 @@ func (c *MockUserStateGetActivationKeyCall) DoAndReturn(f func(context.Context, 
 }
 
 // GetAllUsers mocks base method.
-func (m *MockUserState) GetAllUsers(arg0 context.Context) ([]user.User, error) {
+func (m *MockUserState) GetAllUsers(arg0 context.Context, arg1 bool) ([]user.User, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAllUsers", arg0)
+	ret := m.ctrl.Call(m, "GetAllUsers", arg0, arg1)
 	ret0, _ := ret[0].([]user.User)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetAllUsers indicates an expected call of GetAllUsers.
-func (mr *MockUserStateMockRecorder) GetAllUsers(arg0 any) *MockUserStateGetAllUsersCall {
+func (mr *MockUserStateMockRecorder) GetAllUsers(arg0, arg1 any) *MockUserStateGetAllUsersCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllUsers", reflect.TypeOf((*MockUserState)(nil).GetAllUsers), arg0)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllUsers", reflect.TypeOf((*MockUserState)(nil).GetAllUsers), arg0, arg1)
 	return &MockUserStateGetAllUsersCall{Call: call}
 }
 
@@ -1252,13 +1252,13 @@ func (c *MockUserStateGetAllUsersCall) Return(arg0 []user.User, arg1 error) *Moc
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockUserStateGetAllUsersCall) Do(f func(context.Context) ([]user.User, error)) *MockUserStateGetAllUsersCall {
+func (c *MockUserStateGetAllUsersCall) Do(f func(context.Context, bool) ([]user.User, error)) *MockUserStateGetAllUsersCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockUserStateGetAllUsersCall) DoAndReturn(f func(context.Context) ([]user.User, error)) *MockUserStateGetAllUsersCall {
+func (c *MockUserStateGetAllUsersCall) DoAndReturn(f func(context.Context, bool) ([]user.User, error)) *MockUserStateGetAllUsersCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/access/service/user.go
+++ b/domain/access/service/user.go
@@ -36,8 +36,8 @@ func NewUserService(st UserState) *UserService {
 // GetAllUsers will retrieve all users with authentication information
 // (last login, disabled) from the database. If no users exist an empty slice
 // will be returned.
-func (s *UserService) GetAllUsers(ctx context.Context) ([]user.User, error) {
-	usrs, err := s.st.GetAllUsers(ctx)
+func (s *UserService) GetAllUsers(ctx context.Context, includeDisabled bool) ([]user.User, error) {
+	usrs, err := s.st.GetAllUsers(ctx, includeDisabled)
 	if err != nil {
 		return nil, errors.Annotate(err, "getting all users with auth info")
 	}

--- a/domain/access/service/user_test.go
+++ b/domain/access/service/user_test.go
@@ -308,7 +308,7 @@ func (s *userServiceSuite) TestGetUserByNameNotFound(c *gc.C) {
 func (s *userServiceSuite) TestGetAllUsers(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().GetAllUsers(gomock.Any()).Return([]user.User{
+	s.state.EXPECT().GetAllUsers(gomock.Any(), true).Return([]user.User{
 		{
 			UUID: newUUID(c),
 			Name: "user0",
@@ -319,7 +319,7 @@ func (s *userServiceSuite) TestGetAllUsers(c *gc.C) {
 		},
 	}, nil)
 
-	users, err := s.service().GetAllUsers(context.Background())
+	users, err := s.service().GetAllUsers(context.Background(), true)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(users, gc.HasLen, 2)
 	c.Check(users[0].Name, gc.Equals, "user0")

--- a/domain/access/state/user_test.go
+++ b/domain/access/state/user_test.go
@@ -752,8 +752,8 @@ func (s *userStateSuite) TestGetAllUsersWihAuthInfo(c *gc.C) {
 	err = st.DisableUserAuthentication(context.Background(), "admin2")
 	c.Assert(err, jc.ErrorIsNil)
 
-	// Get all users with auth info.
-	users, err := st.GetAllUsers(context.Background())
+	// Get all users with auth info, including disabled users.
+	users, err := st.GetAllUsers(context.Background(), true)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(users, gc.HasLen, 2)
@@ -773,6 +773,20 @@ func (s *userStateSuite) TestGetAllUsersWihAuthInfo(c *gc.C) {
 	c.Check(users[1].CreatedAt, gc.NotNil)
 	c.Check(users[1].LastLogin, gc.NotNil)
 	c.Check(users[1].Disabled, gc.Equals, true)
+
+	// Get all users with auth info, excluding disabled users
+	users, err = st.GetAllUsers(context.Background(), false)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(users, gc.HasLen, 1)
+
+	c.Check(users[0].Name, gc.Equals, "admin1")
+	c.Check(users[0].DisplayName, gc.Equals, "admin1")
+	c.Check(users[0].CreatorUUID, gc.Equals, admin1UUID)
+	c.Check(users[0].CreatorName, gc.Equals, "admin1")
+	c.Check(users[0].CreatedAt, gc.NotNil)
+	c.Check(users[0].LastLogin, gc.NotNil)
+	c.Check(users[0].Disabled, gc.Equals, false)
 }
 
 // TestUserWithAuthInfo asserts that we can get a user with auth info from the


### PR DESCRIPTION
The `includeDisabled` flag was present in the Mongo function `GetAllUsers` so needed to be added back here to the DQLite equivalent.

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
~- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps
### Unit tests
```
TEST_PACKAGES="./domain/access/state/... -count=1 " TEST_FILTER="Suite" make run-go-tests
TEST_PACKAGES="./apiserver/facades/client/usermanager/... -count=1 " TEST_FILTER="Suite" make run-go-tests
```

### Integration tests
```
$ juju bootstrap lxd test-all-users
$ juju add-model default
$ juju change-user-password admin
$ juju add-user joe
$ juju change-user-password joe
$ juju users
Controller: test-all-users

Name          Display name  Access     Date created   Last connection
admin*        admin         superuser  3 minutes ago  just now
juju-metrics  Juju Metrics  login      3 minutes ago  0001-01-01

$ juju users --all
Controller: test-all-users

Name          Display name  Access     Date created    Last connection
admin*        admin         superuser  3 minutes ago   just now
juju-metrics  Juju Metrics  login      3 minutes ago   0001-01-01
joe                                    40 seconds ago  0001-01-01 (disabled)
```

## Documentation changes
Added doc.go to access domain
<!-- How it affects user workflow (CLI or API). -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Jira card:** [JUJU-6282](https://warthogs.atlassian.net/browse/JUJU-6282)



[JUJU-6282]: https://warthogs.atlassian.net/browse/JUJU-6282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ