### PR TITLE
feat: send model description on migration

### DIFF
--- a/api/controller/migrationmaster/client.go
+++ b/api/controller/migrationmaster/client.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	charmresource "github.com/juju/charm/v12/resource"
+	"github.com/juju/description/v5"
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 	"github.com/juju/version/v2"
@@ -142,12 +143,23 @@ func (c *Client) ModelInfo() (migration.ModelInfo, error) {
 	if err != nil {
 		return migration.ModelInfo{}, errors.Trace(err)
 	}
+
+	var modelDescription description.Model
+	if bytes := info.ModelDescription; len(bytes) > 0 {
+		var err error
+		modelDescription, err = description.Deserialize(info.ModelDescription)
+		if err != nil {
+			return migration.ModelInfo{}, errors.Trace(err)
+		}
+	}
+
 	return migration.ModelInfo{
 		UUID:                   info.UUID,
 		Name:                   info.Name,
 		Owner:                  owner,
 		AgentVersion:           info.AgentVersion,
 		ControllerAgentVersion: info.ControllerAgentVersion,
+		ModelDescription:       modelDescription,
 	}, nil
 }
 

--- a/api/controller/migrationmaster/client_test.go
+++ b/api/controller/migrationmaster/client_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	charmresource "github.com/juju/charm/v12/resource"
+	"github.com/juju/description/v5"
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 	jujutesting "github.com/juju/testing"
@@ -173,7 +174,7 @@ func (s *ClientSuite) TestSetStatusMessageError(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "boom")
 }
 
-func (s *ClientSuite) TestModelInfo(c *gc.C) {
+func (s *ClientSuite) TestModelInfoWithoutModelDescription(c *gc.C) {
 	var stub jujutesting.Stub
 	owner := names.NewUserTag("owner")
 	apiCaller := apitesting.APICallerFunc(func(objType string, v int, id, request string, arg, result interface{}) error {
@@ -189,16 +190,56 @@ func (s *ClientSuite) TestModelInfo(c *gc.C) {
 	})
 	client := migrationmaster.NewClient(apiCaller, nil)
 	model, err := client.ModelInfo()
+	c.Assert(err, jc.ErrorIsNil)
+
 	stub.CheckCalls(c, []jujutesting.StubCall{
 		{FuncName: "MigrationMaster.ModelInfo", Args: []interface{}{"", nil}},
 	})
-	c.Check(err, jc.ErrorIsNil)
 	c.Check(model, jc.DeepEquals, migration.ModelInfo{
 		UUID:                   "uuid",
 		Name:                   "name",
 		Owner:                  owner,
 		AgentVersion:           version.MustParse("1.2.3"),
 		ControllerAgentVersion: version.MustParse("1.2.4"),
+	})
+}
+
+func (s *ClientSuite) TestModelInfoWithModelDescription(c *gc.C) {
+	modelDescription := description.NewModel(description.ModelArgs{
+		Config: make(map[string]interface{}),
+	})
+	modelDescription.SetStatus(description.StatusArgs{})
+	serialized, err := description.Serialize(modelDescription)
+	c.Assert(err, jc.ErrorIsNil)
+
+	var stub jujutesting.Stub
+	owner := names.NewUserTag("owner")
+	apiCaller := apitesting.APICallerFunc(func(objType string, v int, id, request string, arg, result interface{}) error {
+		stub.AddCall(objType+"."+request, id, arg)
+		*(result.(*params.MigrationModelInfo)) = params.MigrationModelInfo{
+			UUID:                   "uuid",
+			Name:                   "name",
+			OwnerTag:               owner.String(),
+			AgentVersion:           version.MustParse("1.2.3"),
+			ControllerAgentVersion: version.MustParse("1.2.4"),
+			ModelDescription:       serialized,
+		}
+		return nil
+	})
+	client := migrationmaster.NewClient(apiCaller, nil)
+	model, err := client.ModelInfo()
+	c.Assert(err, jc.ErrorIsNil)
+
+	stub.CheckCalls(c, []jujutesting.StubCall{
+		{FuncName: "MigrationMaster.ModelInfo", Args: []interface{}{"", nil}},
+	})
+	c.Check(model, jc.DeepEquals, migration.ModelInfo{
+		UUID:                   "uuid",
+		Name:                   "name",
+		Owner:                  owner,
+		AgentVersion:           version.MustParse("1.2.3"),
+		ControllerAgentVersion: version.MustParse("1.2.4"),
+		ModelDescription:       modelDescription,
 	})
 }
 

--- a/api/controller/migrationtarget/client_test.go
+++ b/api/controller/migrationtarget/client_test.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/juju/description/v5"
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 	jujutesting "github.com/juju/testing"
@@ -56,13 +57,18 @@ func (s *ClientSuite) TestPrechecks(c *gc.C) {
 	ownerTag := names.NewUserTag("owner")
 	vers := version.MustParse("1.2.3")
 	controllerVers := version.MustParse("1.2.5")
+	modelDescription := description.NewModel(description.ModelArgs{})
 
-	err := client.Prechecks(coremigration.ModelInfo{
+	bytes, err := description.Serialize(modelDescription)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = client.Prechecks(coremigration.ModelInfo{
 		UUID:                   "uuid",
 		Owner:                  ownerTag,
 		Name:                   "name",
 		AgentVersion:           vers,
 		ControllerAgentVersion: controllerVers,
+		ModelDescription:       modelDescription,
 	})
 	c.Assert(err, gc.ErrorMatches, "boom")
 
@@ -72,6 +78,7 @@ func (s *ClientSuite) TestPrechecks(c *gc.C) {
 		OwnerTag:               ownerTag.String(),
 		AgentVersion:           vers,
 		ControllerAgentVersion: controllerVers,
+		ModelDescription:       bytes,
 	}
 	stub.CheckCallNames(c, "MigrationTarget.Prechecks")
 

--- a/apiserver/facades/client/controller/export_test.go
+++ b/apiserver/facades/client/controller/export_test.go
@@ -13,8 +13,8 @@ type patcher interface {
 	PatchValue(destination, source interface{})
 }
 
-func SetPrecheckResult(p patcher, err error) {
-	p.PatchValue(&runMigrationPrechecks, func(*state.State, *state.State, *migration.TargetInfo, facade.Presence) error {
+func SetPreCheckResult(p patcher, err error) {
+	p.PatchValue(&runMigrationPreChecks, func(*state.State, *state.State, *migration.TargetInfo, facade.Presence, map[string]string) error {
 		return err
 	})
 }

--- a/apiserver/facades/client/controller/register.go
+++ b/apiserver/facades/client/controller/register.go
@@ -6,6 +6,8 @@ package controller
 import (
 	"reflect"
 
+	"github.com/juju/errors"
+
 	"github.com/juju/juju/apiserver/facade"
 )
 
@@ -27,6 +29,11 @@ func newControllerAPIv11(ctx facade.Context) (*ControllerAPI, error) {
 	factory := ctx.MultiwatcherFactory()
 	controller := ctx.Controller()
 
+	leadership, err := ctx.LeadershipReader(st.ModelUUID())
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	return NewControllerAPI(
 		st,
 		pool,
@@ -36,5 +43,6 @@ func newControllerAPIv11(ctx facade.Context) (*ControllerAPI, error) {
 		hub,
 		factory,
 		controller,
+		leadership,
 	)
 }

--- a/apiserver/facades/controller/migrationmaster/facade.go
+++ b/apiserver/facades/controller/migrationmaster/facade.go
@@ -142,11 +142,27 @@ func (api *API) ModelInfo() (params.MigrationModelInfo, error) {
 		return empty, errors.Annotate(err, "retrieving agent version")
 	}
 
+	leaders, err := api.leadership.Leaders()
+	if err != nil {
+		return empty, errors.Annotatef(err, "retrieving leaders")
+	}
+
+	model, err := api.backend.Export(leaders)
+	if err != nil {
+		return empty, errors.Annotate(err, "retrieving model")
+	}
+
+	modelDescription, err := description.Serialize(model)
+	if err != nil {
+		return empty, errors.Annotate(err, "serializing model")
+	}
+
 	return params.MigrationModelInfo{
-		UUID:         api.backend.ModelUUID(),
-		Name:         name,
-		OwnerTag:     owner.String(),
-		AgentVersion: vers,
+		UUID:             api.backend.ModelUUID(),
+		Name:             name,
+		OwnerTag:         owner.String(),
+		AgentVersion:     vers,
+		ModelDescription: modelDescription,
 	}, nil
 }
 

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -30270,6 +30270,12 @@
                                 }
                             }
                         },
+                        "model-description": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            }
+                        },
                         "name": {
                             "type": "string"
                         },
@@ -31045,6 +31051,12 @@
                                         "type": "integer"
                                     }
                                 }
+                            }
+                        },
+                        "model-description": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
                             }
                         },
                         "name": {

--- a/core/migration/migration.go
+++ b/core/migration/migration.go
@@ -6,6 +6,7 @@ package migration
 import (
 	"time"
 
+	"github.com/juju/description/v5"
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 	"github.com/juju/version/v2"
@@ -68,6 +69,7 @@ type ModelInfo struct {
 	Name                   string
 	AgentVersion           version.Number
 	ControllerAgentVersion version.Number
+	ModelDescription       description.Model
 }
 
 // SourceControllerInfo holds the details required to connect

--- a/rpc/params/migration.go
+++ b/rpc/params/migration.go
@@ -169,6 +169,7 @@ type MigrationModelInfo struct {
 	AgentVersion           version.Number   `json:"agent-version"`
 	ControllerAgentVersion version.Number   `json:"controller-agent-version"`
 	FacadeVersions         map[string][]int `json:"facade-versions,omitempty"`
+	ModelDescription       []byte           `json:"model-description,omitempty"`
 }
 
 // MigrationStatus reports the current status of a model migration.


### PR DESCRIPTION
To improve the robustness of model migration, we need to better understand what is being offered before attempting to migrate. By sending the model description to the target controller, we can fully understand what is on offer, we can run better pre-checks, and can give better and detailed responses based on that.

This patch will start to send the information for Precheck and ModelInfo. It is then expected in 4.0 to be able to make use of that information.

This is currently optional, at a later point we can enforce that information is always present.

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

### 3.6

```sh
$ juju bootstrap lxd src36
$ juju add-model moveme
$ juju deploy ubuntu
```

### 4.0

```sh
$ git checkout <https://github.com/juju/juju/pull/17632>
```

Apply the following diff:

```diff
diff --git a/apiserver/facades/controller/migrationtarget/migrationtarget.go b/apiserver/facades/controller/migrationtarget/migrationtarget.go
index 9738acfe33..d7d761dc3c 100644
--- a/apiserver/facades/controller/migrationtarget/migrationtarget.go
+++ b/apiserver/facades/controller/migrationtarget/migrationtarget.go
@@ -12,6 +12,7 @@ import (

        "github.com/juju/description/v6"
        "github.com/juju/errors"
+       "github.com/juju/loggo/v2"
        "github.com/juju/names/v5"
        "github.com/vallerion/rscanner"

@@ -171,6 +172,8 @@ func (api *API) Prechecks(ctx context.Context, model params.MigrationModelInfo)
                }
        }

+       loggo.GetLogger("migration").Criticalf("Prechecks for model %q", modelDescription.Tag())
+
        // If there are no required migration facade versions, then we
        // don't need to check anything.
        if len(api.requiredMigrationFacadeVersions) > 0 {
```



```sh
$ make juju jujud jujud-controller
$ juju bootstrap lxd src40
```

### Migrate

```sh
$ juju switch src36:moveme
$ juju migrate src36:moveme src40
```

## Links


**Jira card:** [JUJU-6309](https://warthogs.atlassian.net/browse/JUJU-6309)



[JUJU-6309]: https://warthogs.atlassian.net/browse/JUJU-6309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ