### PR TITLE
test: ignore poorly formed unit test in internal/charm

### DIFF
--- a/internal/charm/charmdir_test.go
+++ b/internal/charm/charmdir_test.go
@@ -666,6 +666,8 @@ func (s *CharmSuite) TestNoVCSMaybeGenerateVersionString(c *gc.C) {
 
 // TestMaybeGenerateVersionStringUsesAbsolutePathGitVersion verifies that using a relative path still works.
 func (s *CharmSuite) TestMaybeGenerateVersionStringUsesAbsolutePathGitVersion(c *gc.C) {
+	c.Skip("this test assumes we are in a git root")
+
 	// Read the relativePath from the testing folder.
 	relativePath := charmDirPath(c, "dummy")
 	dir, err := charm.ReadCharmDir(relativePath)


### PR DESCRIPTION
TestMaybeGenerateVersionStringUsesAbsolutePathGitVersion test assumes it is running inside a git root.
This is not true of everywhere this test can run.

## QA steps

N/A

## Documentation changes

N/A

## Links

https://jenkins.juju.canonical.com/job/unit-tests-amd64/2634/consoleText
