### PR TITLE
docs: update copyright in footer of juju.is docs

### DIFF
--- a/scripts/schemadocs/schemadocs.go
+++ b/scripts/schemadocs/schemadocs.go
@@ -303,7 +303,7 @@ nav, main, footer {
 	{{end}}
 </main>
 <footer class="page-footer docs-footer">
-© 2019 Canonical Ltd
+© Copyright © 2024 CC-BY-SA, Canonical Ltd
 </footer>
 </body>
 </html>


### PR DESCRIPTION
The copyright in the footer of juju.is docs was out of date.

## Checklist

~- [ ] Code style: imports ordered, good names, simple structure, etc~
~- [ ] Comments saying why design decisions were made~
~- [ ] Go unit tests, with comments saying what you're testing~
~- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
~- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Check juju.is. The footer should be changed from "© 2024 Canonical Ltd." to "Copyright © 2024 CC-BY-SA, Canonical Ltd".

![image](https://github.com/juju/juju/assets/38667005/a3600317-2791-4e25-b497-c44e3a185e81)


## Documentation changes

This is a documentation website change.

## Links

**Jira card:** [JUJU-6230](https://warthogs.atlassian.net/browse/JUJU-6230)



[JUJU-6230]: https://warthogs.atlassian.net/browse/JUJU-6230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ