### PR TITLE
feat(machine): add machine cloud instance service layer

### DIFF
--- a/domain/machine/service/machine_cloud_instance.go
+++ b/domain/machine/service/machine_cloud_instance.go
@@ -1,0 +1,43 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package service
+
+import (
+	"context"
+
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/core/instance"
+)
+
+// HardwareCharacteristics returns the hardware characteristics of the
+// of the specified machine.
+func (s *Service) HardwareCharacteristics(ctx context.Context, machineUUID string) (*instance.HardwareCharacteristics, error) {
+	hc, err := s.st.HardwareCharacteristics(ctx, machineUUID)
+	return hc, errors.Annotatef(err, "retrieving hardware characteristics for machine %q", machineUUID)
+}
+
+// SetMachineCloudInstance sets an entry in the machine cloud instance table
+// along with the instance tags and the link to a lxd profile if any.
+func (s *Service) SetMachineCloudInstance(
+	ctx context.Context,
+	machineUUID string,
+	instanceID instance.Id,
+	hardwareCharacteristics instance.HardwareCharacteristics,
+) error {
+	return errors.Annotatef(
+		s.st.SetMachineCloudInstance(ctx, machineUUID, instanceID, hardwareCharacteristics),
+		"setting machine cloud instance for machine %q", machineUUID,
+	)
+}
+
+// DeleteMachineCloudInstance removes an entry in the machine cloud instance table
+// along with the instance tags and the link to a lxd profile if any.
+func (s *Service) DeleteMachineCloudInstance(ctx context.Context, machineUUID string) error {
+	return errors.Annotatef(
+		s.st.DeleteMachineCloudInstance(ctx, machineUUID),
+		"deleting machine cloud instance for machine %q", machineUUID,
+	)
+
+}

--- a/domain/machine/service/machine_cloud_instance_test.go
+++ b/domain/machine/service/machine_cloud_instance_test.go
@@ -1,0 +1,105 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package service
+
+import (
+	"context"
+
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	gomock "go.uber.org/mock/gomock"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/instance"
+)
+
+func (s *serviceSuite) TestRetrieveHardwareCharacteristics(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	expected := &instance.HardwareCharacteristics{
+		Mem:      uintptr(1024),
+		RootDisk: uintptr(256),
+		CpuCores: uintptr(4),
+		CpuPower: uintptr(75),
+	}
+	s.state.EXPECT().HardwareCharacteristics(gomock.Any(), "42").
+		Return(expected, nil)
+
+	hc, err := NewService(s.state).HardwareCharacteristics(context.Background(), "42")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(hc, gc.DeepEquals, expected)
+}
+
+func (s *serviceSuite) TestRetrieveHardwareCharacteristicsFails(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.state.EXPECT().HardwareCharacteristics(gomock.Any(), "42").
+		Return(nil, errors.New("boom"))
+
+	hc, err := NewService(s.state).HardwareCharacteristics(context.Background(), "42")
+	c.Check(hc, gc.IsNil)
+	c.Assert(err, gc.ErrorMatches, "retrieving hardware characteristics for machine \"42\": boom")
+}
+
+func (s *serviceSuite) TestSetMachineCloudInstance(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	hc := instance.HardwareCharacteristics{
+		Mem:      uintptr(1024),
+		RootDisk: uintptr(256),
+		CpuCores: uintptr(4),
+		CpuPower: uintptr(75),
+	}
+	s.state.EXPECT().SetMachineCloudInstance(
+		gomock.Any(),
+		"42",
+		instance.Id("instance-42"),
+		hc,
+	).Return(nil)
+
+	err := NewService(s.state).SetMachineCloudInstance(context.Background(), "42", "instance-42", hc)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *serviceSuite) TestSetMachineCloudInstanceFails(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	hc := instance.HardwareCharacteristics{
+		Mem:      uintptr(1024),
+		RootDisk: uintptr(256),
+		CpuCores: uintptr(4),
+		CpuPower: uintptr(75),
+	}
+	s.state.EXPECT().SetMachineCloudInstance(
+		gomock.Any(),
+		"42",
+		instance.Id("instance-42"),
+		hc,
+	).Return(errors.New("boom"))
+
+	err := NewService(s.state).SetMachineCloudInstance(context.Background(), "42", "instance-42", hc)
+	c.Assert(err, gc.ErrorMatches, "setting machine cloud instance for machine \"42\": boom")
+}
+
+func (s *serviceSuite) TestDeleteMachineCloudInstance(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.state.EXPECT().DeleteMachineCloudInstance(gomock.Any(), "42").Return(nil)
+
+	err := NewService(s.state).DeleteMachineCloudInstance(context.Background(), "42")
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *serviceSuite) TestDeleteMachineCloudInstanceFails(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.state.EXPECT().DeleteMachineCloudInstance(gomock.Any(), "42").Return(errors.New("boom"))
+
+	err := NewService(s.state).DeleteMachineCloudInstance(context.Background(), "42")
+	c.Assert(err, gc.ErrorMatches, "deleting machine cloud instance for machine \"42\": boom")
+}
+
+func uintptr(u uint64) *uint64 {
+	return &u
+}

--- a/domain/machine/service/package_mock_test.go
+++ b/domain/machine/service/package_mock_test.go
@@ -13,6 +13,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	instance "github.com/juju/juju/core/instance"
 	life "github.com/juju/juju/domain/life"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -116,6 +117,44 @@ func (c *MockStateDeleteMachineCall) DoAndReturn(f func(context.Context, string)
 	return c
 }
 
+// DeleteMachineCloudInstance mocks base method.
+func (m *MockState) DeleteMachineCloudInstance(arg0 context.Context, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteMachineCloudInstance", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteMachineCloudInstance indicates an expected call of DeleteMachineCloudInstance.
+func (mr *MockStateMockRecorder) DeleteMachineCloudInstance(arg0, arg1 any) *MockStateDeleteMachineCloudInstanceCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteMachineCloudInstance", reflect.TypeOf((*MockState)(nil).DeleteMachineCloudInstance), arg0, arg1)
+	return &MockStateDeleteMachineCloudInstanceCall{Call: call}
+}
+
+// MockStateDeleteMachineCloudInstanceCall wrap *gomock.Call
+type MockStateDeleteMachineCloudInstanceCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateDeleteMachineCloudInstanceCall) Return(arg0 error) *MockStateDeleteMachineCloudInstanceCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateDeleteMachineCloudInstanceCall) Do(f func(context.Context, string) error) *MockStateDeleteMachineCloudInstanceCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateDeleteMachineCloudInstanceCall) DoAndReturn(f func(context.Context, string) error) *MockStateDeleteMachineCloudInstanceCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetMachineLife mocks base method.
 func (m *MockState) GetMachineLife(arg0 context.Context, arg1 string) (*life.Life, error) {
 	m.ctrl.T.Helper()
@@ -155,6 +194,45 @@ func (c *MockStateGetMachineLifeCall) DoAndReturn(f func(context.Context, string
 	return c
 }
 
+// HardwareCharacteristics mocks base method.
+func (m *MockState) HardwareCharacteristics(arg0 context.Context, arg1 string) (*instance.HardwareCharacteristics, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HardwareCharacteristics", arg0, arg1)
+	ret0, _ := ret[0].(*instance.HardwareCharacteristics)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// HardwareCharacteristics indicates an expected call of HardwareCharacteristics.
+func (mr *MockStateMockRecorder) HardwareCharacteristics(arg0, arg1 any) *MockStateHardwareCharacteristicsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HardwareCharacteristics", reflect.TypeOf((*MockState)(nil).HardwareCharacteristics), arg0, arg1)
+	return &MockStateHardwareCharacteristicsCall{Call: call}
+}
+
+// MockStateHardwareCharacteristicsCall wrap *gomock.Call
+type MockStateHardwareCharacteristicsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateHardwareCharacteristicsCall) Return(arg0 *instance.HardwareCharacteristics, arg1 error) *MockStateHardwareCharacteristicsCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateHardwareCharacteristicsCall) Do(f func(context.Context, string) (*instance.HardwareCharacteristics, error)) *MockStateHardwareCharacteristicsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateHardwareCharacteristicsCall) DoAndReturn(f func(context.Context, string) (*instance.HardwareCharacteristics, error)) *MockStateHardwareCharacteristicsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // InitialWatchStatement mocks base method.
 func (m *MockState) InitialWatchStatement() (string, string) {
 	m.ctrl.T.Helper()
@@ -190,6 +268,44 @@ func (c *MockStateInitialWatchStatementCall) Do(f func() (string, string)) *Mock
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockStateInitialWatchStatementCall) DoAndReturn(f func() (string, string)) *MockStateInitialWatchStatementCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// SetMachineCloudInstance mocks base method.
+func (m *MockState) SetMachineCloudInstance(arg0 context.Context, arg1 string, arg2 instance.Id, arg3 instance.HardwareCharacteristics) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetMachineCloudInstance", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetMachineCloudInstance indicates an expected call of SetMachineCloudInstance.
+func (mr *MockStateMockRecorder) SetMachineCloudInstance(arg0, arg1, arg2, arg3 any) *MockStateSetMachineCloudInstanceCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMachineCloudInstance", reflect.TypeOf((*MockState)(nil).SetMachineCloudInstance), arg0, arg1, arg2, arg3)
+	return &MockStateSetMachineCloudInstanceCall{Call: call}
+}
+
+// MockStateSetMachineCloudInstanceCall wrap *gomock.Call
+type MockStateSetMachineCloudInstanceCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateSetMachineCloudInstanceCall) Return(arg0 error) *MockStateSetMachineCloudInstanceCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateSetMachineCloudInstanceCall) Do(f func(context.Context, string, instance.Id, instance.HardwareCharacteristics) error) *MockStateSetMachineCloudInstanceCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateSetMachineCloudInstanceCall) DoAndReturn(f func(context.Context, string, instance.Id, instance.HardwareCharacteristics) error) *MockStateSetMachineCloudInstanceCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/machine/service/service.go
+++ b/domain/machine/service/service.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/errors"
 
+	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/domain/life"
 	"github.com/juju/juju/internal/uuid"
 )
@@ -26,6 +27,18 @@ type State interface {
 
 	// GetMachineLife returns the life status of the specified machine.
 	GetMachineLife(context.Context, string) (*life.Life, error)
+
+	// HardwareCharacteristics returns the hardware characteristics struct with
+	// data retrieved from the machine cloud instance table.
+	HardwareCharacteristics(context.Context, string) (*instance.HardwareCharacteristics, error)
+
+	// SetMachineCloudInstance sets an entry in the machine cloud instance table
+	// along with the instance tags and the link to a lxd profile if any.
+	SetMachineCloudInstance(context.Context, string, instance.Id, instance.HardwareCharacteristics) error
+
+	// DeleteMachineCloudInstance removes an entry in the machine cloud instance table
+	// along with the instance tags and the link to a lxd profile if any.
+	DeleteMachineCloudInstance(context.Context, string) error
 }
 
 // Service provides the API for working with machines.


### PR DESCRIPTION
This patch adds the service layer methods for setting and deleting machine cloud instance data and retrieving hardware characteristics of a machine cloud instance on the machine domain.

## Checklist


- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ]  ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

This (sub)domain is not wired up yet, so nothing other than unit tests to verify, nothing can break:

```
TEST_PACKAGES="./domain/machine/... -count=1 -race -check.vv" make run-go-tests
```

## Links

**Jira card:** JUJU-6283