### PR TITLE
fix: data race in rpc layer

### DIFF
--- a/rpc/client.go
+++ b/rpc/client.go
@@ -159,9 +159,12 @@ func (conn *Conn) handleResponse(hdr *Header) error {
 		err = conn.readBody(nil, false)
 
 		// If the request has been canceled just return.
+		conn.mutex.Lock()
 		if _, ok := conn.tombstones[reqId]; ok {
+			conn.mutex.Unlock()
 			return nil
 		}
+		conn.mutex.Unlock()
 	case hdr.Error != "":
 		// Report rpcreflect.NoSuchMethodError with CodeNotImplemented.
 		if strings.HasPrefix(hdr.Error, "no such request ") && hdr.ErrorCode == "" {


### PR DESCRIPTION
When attempting to read the tombstones to see if a request was cancelled, there is a potential to a data race. Not only is there a potential data race, I was able to witness it. The real issue is that I was only able to observe the race in the machine logs, not via the debug-logs. Concerning, as what else are we missing out on?

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

I was able to trigger this via a `juju upgrade-controller --build-agent`

```sh
$ juju bootstrap lxd test
$ juju add-model default
$ juju deploy ubuntu
```

Make some changes to the controller code

```sh
$ juju upgrade-controller --build-agent
```

## Links

**Jira card:** [JUJU-6311](https://warthogs.atlassian.net/browse/JUJU-6311)



[JUJU-6311]: https://warthogs.atlassian.net/browse/JUJU-6311?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ