### PR TITLE
fix: add minor to go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/juju/juju
 
-go 1.22
+go 1.22.4
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.12.0


### PR DESCRIPTION
Unit tests were failing because go needed to have the minor version specified.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
~- [ ] Comments saying why design decisions were made~
~- [ ] Go unit tests, with comments saying what you're testing~
~- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
~- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps
Run CI

