### PR TITLE
feat: charm domain state

### DIFF
--- a/core/charm/id.go
+++ b/core/charm/id.go
@@ -23,6 +23,15 @@ func NewID() (ID, error) {
 	return ID(uuid.String()), nil
 }
 
+// ParseID returns a new ID from the given string. If the string is not a valid
+// uuid an error satisfying [errors.NotValid] will be returned.
+func ParseID(value string) (ID, error) {
+	if !uuid.IsValidUUIDString(value) {
+		return "", fmt.Errorf("id %q %w", value, errors.NotValid)
+	}
+	return ID(value), nil
+}
+
 // String implements the stringer interface for ID.
 func (u ID) String() string {
 	return string(u)

--- a/domain/charm/service/metadata.go
+++ b/domain/charm/service/metadata.go
@@ -436,6 +436,7 @@ func encodeMetadataRelation(relations map[string]internalcharm.Relation) (map[st
 		}
 
 		result[k] = charm.Relation{
+			Key:       k,
 			Name:      v.Name,
 			Role:      role,
 			Scope:     scope,

--- a/domain/charm/service/metadata_test.go
+++ b/domain/charm/service/metadata_test.go
@@ -87,7 +87,8 @@ var metadataTestCases = [...]struct {
 			Name:  "foo",
 			RunAs: charm.RunAsDefault,
 			Provides: map[string]charm.Relation{
-				"db": {
+				"baz": {
+					Key:       "baz",
 					Name:      "db",
 					Role:      charm.RoleProvider,
 					Interface: "mysql",
@@ -100,7 +101,7 @@ var metadataTestCases = [...]struct {
 		output: internalcharm.Meta{
 			Name: "foo",
 			Provides: map[string]internalcharm.Relation{
-				"db": {
+				"baz": {
 					Name:      "db",
 					Role:      internalcharm.RoleProvider,
 					Interface: "mysql",
@@ -117,7 +118,8 @@ var metadataTestCases = [...]struct {
 			Name:  "foo",
 			RunAs: charm.RunAsDefault,
 			Requires: map[string]charm.Relation{
-				"db": {
+				"baz": {
+					Key:       "baz",
 					Name:      "db",
 					Role:      charm.RoleProvider,
 					Interface: "mysql",
@@ -130,7 +132,7 @@ var metadataTestCases = [...]struct {
 		output: internalcharm.Meta{
 			Name: "foo",
 			Requires: map[string]internalcharm.Relation{
-				"db": {
+				"baz": {
 					Name:      "db",
 					Role:      internalcharm.RoleProvider,
 					Interface: "mysql",
@@ -147,7 +149,8 @@ var metadataTestCases = [...]struct {
 			Name:  "foo",
 			RunAs: charm.RunAsDefault,
 			Peers: map[string]charm.Relation{
-				"db": {
+				"baz": {
+					Key:       "baz",
 					Name:      "db",
 					Role:      charm.RoleProvider,
 					Interface: "mysql",
@@ -160,7 +163,7 @@ var metadataTestCases = [...]struct {
 		output: internalcharm.Meta{
 			Name: "foo",
 			Peers: map[string]internalcharm.Relation{
-				"db": {
+				"baz": {
 					Name:      "db",
 					Role:      internalcharm.RoleProvider,
 					Interface: "mysql",

--- a/domain/charm/service/package_mock_test.go
+++ b/domain/charm/service/package_mock_test.go
@@ -121,45 +121,6 @@ func (c *MockStateGetCharmConfigCall) DoAndReturn(f func(context.Context, charm.
 	return c
 }
 
-// GetCharmIDByLatestRevision mocks base method.
-func (m *MockState) GetCharmIDByLatestRevision(arg0 context.Context, arg1 string) (charm.ID, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCharmIDByLatestRevision", arg0, arg1)
-	ret0, _ := ret[0].(charm.ID)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetCharmIDByLatestRevision indicates an expected call of GetCharmIDByLatestRevision.
-func (mr *MockStateMockRecorder) GetCharmIDByLatestRevision(arg0, arg1 any) *MockStateGetCharmIDByLatestRevisionCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCharmIDByLatestRevision", reflect.TypeOf((*MockState)(nil).GetCharmIDByLatestRevision), arg0, arg1)
-	return &MockStateGetCharmIDByLatestRevisionCall{Call: call}
-}
-
-// MockStateGetCharmIDByLatestRevisionCall wrap *gomock.Call
-type MockStateGetCharmIDByLatestRevisionCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockStateGetCharmIDByLatestRevisionCall) Return(arg0 charm.ID, arg1 error) *MockStateGetCharmIDByLatestRevisionCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockStateGetCharmIDByLatestRevisionCall) Do(f func(context.Context, string) (charm.ID, error)) *MockStateGetCharmIDByLatestRevisionCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetCharmIDByLatestRevisionCall) DoAndReturn(f func(context.Context, string) (charm.ID, error)) *MockStateGetCharmIDByLatestRevisionCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // GetCharmIDByRevision mocks base method.
 func (m *MockState) GetCharmIDByRevision(arg0 context.Context, arg1 string, arg2 int) (charm.ID, error) {
 	m.ctrl.T.Helper()

--- a/domain/charm/service/service.go
+++ b/domain/charm/service/service.go
@@ -40,11 +40,6 @@ type State interface {
 	// If the charm does not exist, a NotFound error is returned.
 	GetCharmIDByRevision(ctx context.Context, name string, revision int) (corecharm.ID, error)
 
-	// GetCharmIDByLatestRevision returns the charm ID by the natural key, for
-	// the latest revision.
-	// If the charm does not exist, a NotFound error is returned.
-	GetCharmIDByLatestRevision(ctx context.Context, name string) (corecharm.ID, error)
-
 	// IsControllerCharm returns whether the charm is a controller charm.
 	// If the charm does not exist, a NotFound error is returned.
 	IsControllerCharm(ctx context.Context, id corecharm.ID) (bool, error)
@@ -123,7 +118,7 @@ func (s *Service) GetCharmID(ctx context.Context, args charm.GetCharmArgs) (core
 		return s.st.GetCharmIDByRevision(ctx, args.Name, *rev)
 	}
 
-	return s.st.GetCharmIDByLatestRevision(ctx, args.Name)
+	return "", charmerrors.NotFound
 }
 
 // IsControllerCharm returns whether the charm is a controller charm.

--- a/domain/charm/service/service_test.go
+++ b/domain/charm/service/service_test.go
@@ -35,15 +35,10 @@ var _ = gc.Suite(&serviceSuite{})
 func (s *serviceSuite) TestGetCharmID(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	id := charmtesting.GenCharmID(c)
-
-	s.state.EXPECT().GetCharmIDByLatestRevision(gomock.Any(), "foo").Return(id, nil)
-
-	result, err := s.service.GetCharmID(context.Background(), domaincharm.GetCharmArgs{
+	_, err := s.service.GetCharmID(context.Background(), domaincharm.GetCharmArgs{
 		Name: "foo",
 	})
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(result, gc.Equals, id)
+	c.Assert(err, jc.ErrorIs, charmerrors.NotFound)
 }
 
 func (s *serviceSuite) TestGetCharmIDInvalidName(c *gc.C) {
@@ -70,17 +65,6 @@ func (s *serviceSuite) TestGetCharmIDWithRevision(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(result, gc.Equals, id)
-}
-
-func (s *serviceSuite) TestGetCharmIDErrorNotFound(c *gc.C) {
-	defer s.setupMocks(c).Finish()
-
-	s.state.EXPECT().GetCharmIDByLatestRevision(gomock.Any(), "foo").Return("", charmerrors.NotFound)
-
-	_, err := s.service.GetCharmID(context.Background(), domaincharm.GetCharmArgs{
-		Name: "foo",
-	})
-	c.Assert(err, jc.ErrorIs, charmerrors.NotFound)
 }
 
 func (s *serviceSuite) TestIsControllerCharm(c *gc.C) {

--- a/domain/charm/state/metadata.go
+++ b/domain/charm/state/metadata.go
@@ -1,0 +1,362 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"fmt"
+
+	"github.com/juju/version/v2"
+
+	"github.com/juju/juju/domain/charm"
+)
+
+type decodeMetadataArgs struct {
+	tags          []charmTag
+	categories    []charmCategory
+	terms         []charmTerm
+	relations     []charmRelation
+	extraBindings []charmExtraBinding
+	storage       []charmStorage
+	devices       []charmDevice
+	payloads      []charmPayload
+	resources     []charmResource
+	containers    []charmContainer
+}
+
+func decodeMetadata(metadata charmMetadata, args decodeMetadataArgs) (charm.Metadata, error) {
+	minVersion, err := version.Parse(metadata.MinJujuVersion)
+	if err != nil {
+		return charm.Metadata{}, fmt.Errorf("cannot parse min juju version %q: %w", metadata.MinJujuVersion, err)
+	}
+
+	runAs, err := decodeRunAs(metadata.RunAs)
+	if err != nil {
+		return charm.Metadata{}, fmt.Errorf("cannot decode run as %q: %w", metadata.RunAs, err)
+	}
+
+	provides, requires, peer, err := decodeRelations(args.relations)
+	if err != nil {
+		return charm.Metadata{}, fmt.Errorf("cannot decode relations: %w", err)
+	}
+
+	storage, err := decodeStorage(args.storage)
+	if err != nil {
+		return charm.Metadata{}, fmt.Errorf("cannot decode storage: %w", err)
+	}
+
+	resources, err := decodeResources(args.resources)
+	if err != nil {
+		return charm.Metadata{}, fmt.Errorf("cannot decode resources: %w", err)
+	}
+
+	containers, err := decodeContainers(args.containers)
+	if err != nil {
+		return charm.Metadata{}, fmt.Errorf("cannot decode containers: %w", err)
+	}
+
+	return charm.Metadata{
+		Name:           metadata.Name,
+		Summary:        metadata.Summary,
+		Description:    metadata.Description,
+		Subordinate:    metadata.Subordinate,
+		MinJujuVersion: minVersion,
+		RunAs:          runAs,
+		Assumes:        metadata.Assumes,
+		Tags:           decodeTags(args.tags),
+		Categories:     decodeCategories(args.categories),
+		Terms:          decodeTerms(args.terms),
+		Provides:       provides,
+		Requires:       requires,
+		Peers:          peer,
+		ExtraBindings:  decodeExtraBindings(args.extraBindings),
+		Storage:        storage,
+		Devices:        decodeDevices(args.devices),
+		PayloadClasses: decodePayloads(args.payloads),
+		Resources:      resources,
+		Containers:     containers,
+	}, nil
+}
+
+func decodeRunAs(runAs string) (charm.RunAs, error) {
+	switch runAs {
+	case "default", "":
+		return charm.RunAsDefault, nil
+	case "root":
+		return charm.RunAsRoot, nil
+	case "sudoer":
+		return charm.RunAsSudoer, nil
+	case "user":
+		return charm.RunAsNonRoot, nil
+	default:
+		return "", fmt.Errorf("unknown run as value %q", runAs)
+	}
+}
+
+func decodeTags(tags []charmTag) []string {
+	var result []string
+	for _, tag := range tags {
+		result = append(result, tag.Tag)
+	}
+	return result
+}
+
+func decodeCategories(categories []charmCategory) []string {
+	var result []string
+	for _, category := range categories {
+		result = append(result, category.Category)
+	}
+	return result
+}
+
+func decodeTerms(terms []charmTerm) []string {
+	var result []string
+	for _, category := range terms {
+		result = append(result, category.Term)
+	}
+	return result
+}
+
+func decodeRelations(relations []charmRelation) (map[string]charm.Relation, map[string]charm.Relation, map[string]charm.Relation, error) {
+	makeRelation := func(relation charmRelation) (charm.Relation, error) {
+		role, err := decodeRelationRole(relation.Role)
+		if err != nil {
+			return charm.Relation{}, fmt.Errorf("cannot decode relation role %q: %w", relation.Role, err)
+		}
+
+		return charm.Relation{
+			Key:       relation.Key,
+			Name:      relation.Name,
+			Interface: relation.Interface,
+			Optional:  relation.Optional,
+			Limit:     relation.Capacity,
+			Role:      role,
+		}, nil
+	}
+
+	var provides, requires, peers map[string]charm.Relation
+	for _, relation := range relations {
+		rel, err := makeRelation(relation)
+		if err != nil {
+			return nil, nil, nil, fmt.Errorf("cannot make relation: %w", err)
+		}
+
+		switch relation.Kind {
+		case "provides":
+			if provides == nil {
+				provides = make(map[string]charm.Relation)
+			}
+			provides[relation.Key] = rel
+		case "requires":
+			if requires == nil {
+				requires = make(map[string]charm.Relation)
+			}
+			requires[relation.Key] = rel
+		case "peers":
+			if peers == nil {
+				peers = make(map[string]charm.Relation)
+			}
+			peers[relation.Key] = rel
+		default:
+			return nil, nil, nil, fmt.Errorf("unknown relation role %q", relation.Kind)
+		}
+	}
+
+	return provides, requires, peers, nil
+}
+
+func decodeRelationRole(role string) (charm.RelationRole, error) {
+	switch role {
+	case "provider":
+		return charm.RoleProvider, nil
+	case "requirer":
+		return charm.RoleRequirer, nil
+	case "peer":
+		return charm.RolePeer, nil
+	default:
+		return "", fmt.Errorf("unknown relation role %q", role)
+	}
+}
+
+func decodeExtraBindings(bindings []charmExtraBinding) map[string]charm.ExtraBinding {
+	if len(bindings) == 0 {
+		return nil
+	}
+
+	result := make(map[string]charm.ExtraBinding)
+	for _, binding := range bindings {
+		result[binding.Key] = charm.ExtraBinding{
+			Name: binding.Name,
+		}
+	}
+	return result
+}
+
+func decodeStorage(storages []charmStorage) (map[string]charm.Storage, error) {
+	if len(storages) == 0 {
+		return nil, nil
+	}
+
+	result := make(map[string]charm.Storage)
+	for _, storage := range storages {
+		// If the storage for the key already exists, then we need to merge the
+		// information. Generally, this will be a property addition.
+		if existing, ok := result[storage.Key]; ok {
+			existing.Properties = append(existing.Properties, storage.Property)
+
+			// Ensure we write it back to the map.
+			result[storage.Key] = existing
+			continue
+		}
+
+		kind, err := decodeStorageType(storage.Kind)
+		if err != nil {
+			return nil, fmt.Errorf("cannot decode storage type %q: %w", storage.Kind, err)
+		}
+
+		// If we've got a property that isn't an empty string, then we need to
+		// add it to the properties list.
+		var properties []string
+		if storage.Property != "" {
+			properties = append(properties, storage.Property)
+		}
+
+		result[storage.Key] = charm.Storage{
+			Name:        storage.Name,
+			Description: storage.Description,
+			Type:        kind,
+			Shared:      storage.Shared,
+			ReadOnly:    storage.ReadOnly,
+			CountMin:    storage.CountMin,
+			CountMax:    storage.CountMax,
+			MinimumSize: storage.MinimumSize,
+			Location:    storage.Location,
+			Properties:  properties,
+		}
+	}
+	return result, nil
+}
+
+func decodeStorageType(kind string) (charm.StorageType, error) {
+	switch kind {
+	case "block":
+		return charm.StorageBlock, nil
+	case "filesystem":
+		return charm.StorageFilesystem, nil
+	default:
+		return "", fmt.Errorf("unknown storage kind %q", kind)
+	}
+}
+
+func decodeDevices(devices []charmDevice) map[string]charm.Device {
+	if len(devices) == 0 {
+		return nil
+	}
+
+	result := make(map[string]charm.Device)
+	for _, device := range devices {
+		result[device.Key] = charm.Device{
+			Name:        device.Name,
+			Description: device.Description,
+			Type:        charm.DeviceType(device.DeviceType),
+			CountMin:    device.CountMin,
+			CountMax:    device.CountMax,
+		}
+	}
+	return result
+}
+
+func decodePayloads(payloads []charmPayload) map[string]charm.PayloadClass {
+	if len(payloads) == 0 {
+		return nil
+	}
+
+	result := make(map[string]charm.PayloadClass)
+	for _, payload := range payloads {
+		result[payload.Key] = charm.PayloadClass{
+			Name: payload.Name,
+			Type: payload.Type,
+		}
+	}
+	return result
+}
+
+func decodeResources(resources []charmResource) (map[string]charm.Resource, error) {
+	if len(resources) == 0 {
+		return nil, nil
+	}
+
+	result := make(map[string]charm.Resource)
+	for _, resource := range resources {
+		kind, err := decodeResourceType(resource.Kind)
+		if err != nil {
+			return nil, fmt.Errorf("cannot parse resource type %q: %w", resource.Kind, err)
+		}
+
+		result[resource.Key] = charm.Resource{
+			Name:        resource.Name,
+			Path:        resource.Path,
+			Description: resource.Description,
+			Type:        kind,
+		}
+	}
+	return result, nil
+}
+
+func decodeResourceType(kind string) (charm.ResourceType, error) {
+	switch kind {
+	case "file":
+		return charm.ResourceTypeFile, nil
+	case "oci-image":
+		return charm.ResourceTypeContainerImage, nil
+	default:
+		return "", fmt.Errorf("unknown resource kind %q", kind)
+	}
+}
+
+func decodeContainers(containers []charmContainer) (map[string]charm.Container, error) {
+	if len(containers) == 0 {
+		return nil, nil
+	}
+
+	result := make(map[string]charm.Container)
+	for _, container := range containers {
+		// If the container for the key already exists, then we need to merge
+		// the information. Generally, this will be a mounts addition.
+		if existing, ok := result[container.Key]; ok {
+			existing.Mounts = append(existing.Mounts, charm.Mount{
+				Storage:  container.Storage,
+				Location: container.Location,
+			})
+
+			// Ensure we write it back to the map.
+			result[container.Key] = existing
+			continue
+		}
+
+		var uid *int
+		if container.Uid >= 0 {
+			uid = &container.Uid
+		}
+		var gid *int
+		if container.Uid >= 0 {
+			gid = &container.Gid
+		}
+
+		var mounts []charm.Mount
+		if container.Storage != "" || container.Location != "" {
+			mounts = append(mounts, charm.Mount{
+				Storage:  container.Storage,
+				Location: container.Location,
+			})
+		}
+
+		result[container.Key] = charm.Container{
+			Resource: container.Resource,
+			Uid:      uid,
+			Gid:      gid,
+			Mounts:   mounts,
+		}
+	}
+	return result, nil
+}

--- a/domain/charm/state/metadata_test.go
+++ b/domain/charm/state/metadata_test.go
@@ -1,0 +1,460 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/domain/charm"
+	schematesting "github.com/juju/juju/domain/schema/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version/v2"
+)
+
+type metadataSuite struct {
+	schematesting.ModelSuite
+}
+
+var _ = gc.Suite(&metadataSuite{})
+
+var metadataTestCases = [...]struct {
+	name      string
+	input     charmMetadata
+	inputArgs decodeMetadataArgs
+	output    charm.Metadata
+}{
+	{
+		name:      "empty",
+		input:     charmMetadata{},
+		inputArgs: decodeMetadataArgs{},
+		output: charm.Metadata{
+			RunAs: charm.RunAsDefault,
+		},
+	},
+	{
+		name: "basic",
+		input: charmMetadata{
+			Name:           "foo",
+			Summary:        "summary",
+			Description:    "description",
+			MinJujuVersion: "2.0.0",
+			RunAs:          "root",
+			Subordinate:    true,
+			Assumes:        []byte("null"),
+		},
+		inputArgs: decodeMetadataArgs{},
+		output: charm.Metadata{
+			Name:           "foo",
+			Summary:        "summary",
+			Description:    "description",
+			MinJujuVersion: version.MustParse("2.0.0"),
+			RunAs:          charm.RunAsRoot,
+			Subordinate:    true,
+			Assumes:        []byte("null"),
+		},
+	},
+	{
+		name:  "tags",
+		input: charmMetadata{},
+		inputArgs: decodeMetadataArgs{
+			tags: []charmTag{
+				{Tag: "tag1"},
+				{Tag: "tag2"},
+			},
+		},
+		output: charm.Metadata{
+			RunAs: charm.RunAsDefault,
+			Tags:  []string{"tag1", "tag2"},
+		},
+	},
+	{
+		name:  "categories",
+		input: charmMetadata{},
+		inputArgs: decodeMetadataArgs{
+			categories: []charmCategory{
+				{Category: "category1"},
+				{Category: "category2"},
+			},
+		},
+		output: charm.Metadata{
+			RunAs:      charm.RunAsDefault,
+			Categories: []string{"category1", "category2"},
+		},
+	},
+	{
+		name:  "terms",
+		input: charmMetadata{},
+		inputArgs: decodeMetadataArgs{
+			terms: []charmTerm{
+				{Term: "term1"},
+				{Term: "term2"},
+			},
+		},
+		output: charm.Metadata{
+			RunAs: charm.RunAsDefault,
+			Terms: []string{"term1", "term2"},
+		},
+	},
+	{
+		name:  "relations",
+		input: charmMetadata{},
+		inputArgs: decodeMetadataArgs{
+			relations: []charmRelation{
+				{
+					Key:       "mysql",
+					Kind:      "provides",
+					Name:      "db1",
+					Role:      "provider",
+					Interface: "mysql",
+					Optional:  true,
+					Capacity:  1,
+					Scope:     "global",
+				},
+				{
+					Key:       "postgres",
+					Kind:      "provides",
+					Name:      "db2",
+					Role:      "provider",
+					Interface: "postgres",
+					Optional:  true,
+					Capacity:  1,
+					Scope:     "global",
+				},
+				{
+					Key:       "wordpress",
+					Kind:      "requires",
+					Name:      "blog",
+					Role:      "requirer",
+					Interface: "wordpress",
+					Optional:  true,
+					Capacity:  2,
+					Scope:     "container",
+				},
+				{
+					Key:       "vault",
+					Kind:      "peers",
+					Name:      "enclave",
+					Role:      "peer",
+					Interface: "vault",
+					Optional:  true,
+					Capacity:  3,
+					Scope:     "global",
+				},
+			},
+		},
+		output: charm.Metadata{
+			RunAs: charm.RunAsDefault,
+			Provides: map[string]charm.Relation{
+				"mysql": {
+					Key:       "mysql",
+					Name:      "db1",
+					Role:      charm.RoleProvider,
+					Interface: "mysql",
+					Optional:  true,
+					Limit:     1,
+					Scope:     charm.ScopeGlobal,
+				},
+				"postgres": {
+					Key:       "postgres",
+					Name:      "db2",
+					Role:      charm.RoleProvider,
+					Interface: "postgres",
+					Optional:  true,
+					Limit:     1,
+					Scope:     charm.ScopeGlobal,
+				},
+			},
+			Requires: map[string]charm.Relation{
+				"wordpress": {
+					Key:       "wordpress",
+					Name:      "blog",
+					Role:      charm.RoleRequirer,
+					Interface: "wordpress",
+					Optional:  true,
+					Limit:     2,
+					Scope:     charm.ScopeContainer,
+				},
+			},
+			Peers: map[string]charm.Relation{
+				"vault": {
+					Key:       "vault",
+					Name:      "enclave",
+					Role:      charm.RolePeer,
+					Interface: "vault",
+					Optional:  true,
+					Limit:     3,
+					Scope:     charm.ScopeGlobal,
+				},
+			},
+		},
+	},
+	{
+		name:  "extra bindings",
+		input: charmMetadata{},
+		inputArgs: decodeMetadataArgs{
+			extraBindings: []charmExtraBinding{
+				{Key: "alpha", Name: "foo"},
+				{Key: "beta", Name: "baz"},
+			},
+		},
+		output: charm.Metadata{
+			RunAs: charm.RunAsDefault,
+			ExtraBindings: map[string]charm.ExtraBinding{
+				"alpha": {Name: "foo"},
+				"beta":  {Name: "baz"},
+			},
+		},
+	},
+	{
+		name:  "storage",
+		input: charmMetadata{},
+		inputArgs: decodeMetadataArgs{
+			storage: []charmStorage{
+				{
+					Key:         "foo",
+					Name:        "name1",
+					Description: "description1",
+					Kind:        "block",
+					Shared:      true,
+					ReadOnly:    true,
+					MinimumSize: 1,
+					CountMin:    2,
+					CountMax:    3,
+					Location:    "location1",
+					Property:    "property1",
+				},
+				{
+					Key:         "foo",
+					Name:        "name1",
+					Description: "description1",
+					Kind:        "block",
+					Shared:      true,
+					ReadOnly:    true,
+					MinimumSize: 1,
+					CountMin:    2,
+					CountMax:    3,
+					Location:    "location1",
+					Property:    "property2",
+				},
+				{
+					Key:         "bar",
+					Name:        "name2",
+					Description: "description2",
+					Kind:        "block",
+					Shared:      true,
+					ReadOnly:    true,
+					MinimumSize: 4,
+					CountMin:    5,
+					CountMax:    6,
+					Location:    "location2",
+					Property:    "property3",
+				},
+			},
+		},
+		output: charm.Metadata{
+			RunAs: charm.RunAsDefault,
+			Storage: map[string]charm.Storage{
+				"foo": {
+					Name:        "name1",
+					Description: "description1",
+					Type:        charm.StorageBlock,
+					Shared:      true,
+					ReadOnly:    true,
+					MinimumSize: 1,
+					CountMin:    2,
+					CountMax:    3,
+					Location:    "location1",
+					Properties:  []string{"property1", "property2"},
+				},
+				"bar": {
+					Name:        "name2",
+					Description: "description2",
+					Type:        charm.StorageBlock,
+					Shared:      true,
+					ReadOnly:    true,
+					MinimumSize: 4,
+					CountMin:    5,
+					CountMax:    6,
+					Location:    "location2",
+					Properties:  []string{"property3"},
+				},
+			},
+		},
+	},
+	{
+		name:  "devices",
+		input: charmMetadata{},
+		inputArgs: decodeMetadataArgs{
+			devices: []charmDevice{
+				{
+					Key:         "alpha",
+					Name:        "foo",
+					Description: "description1",
+					DeviceType:  "block",
+					CountMin:    2,
+					CountMax:    3,
+				},
+				{
+					Key:         "beta",
+					Name:        "baz",
+					Description: "description2",
+					DeviceType:  "filesystem",
+					CountMin:    4,
+					CountMax:    5,
+				},
+			},
+		},
+		output: charm.Metadata{
+			RunAs: charm.RunAsDefault,
+			Devices: map[string]charm.Device{
+				"alpha": {
+					Name:        "foo",
+					Description: "description1",
+					Type:        charm.DeviceType("block"),
+					CountMin:    2,
+					CountMax:    3,
+				},
+				"beta": {
+					Name:        "baz",
+					Description: "description2",
+					Type:        charm.DeviceType("filesystem"),
+					CountMin:    4,
+					CountMax:    5,
+				},
+			},
+		},
+	},
+	{
+		name:  "payloads",
+		input: charmMetadata{},
+		inputArgs: decodeMetadataArgs{
+			payloads: []charmPayload{
+				{
+					Key:  "alpha",
+					Name: "foo",
+					Type: "type1",
+				},
+				{
+					Key:  "beta",
+					Name: "baz",
+					Type: "type2",
+				},
+			},
+		},
+		output: charm.Metadata{
+			RunAs: charm.RunAsDefault,
+			PayloadClasses: map[string]charm.PayloadClass{
+				"alpha": {
+					Name: "foo",
+					Type: "type1",
+				},
+				"beta": {
+					Name: "baz",
+					Type: "type2",
+				},
+			},
+		},
+	},
+	{
+		name:  "resources",
+		input: charmMetadata{},
+		inputArgs: decodeMetadataArgs{
+			resources: []charmResource{
+				{
+					Key:         "alpha",
+					Name:        "foo",
+					Kind:        "file",
+					Path:        "path1",
+					Description: "description1",
+				},
+				{
+					Key:         "beta",
+					Name:        "baz",
+					Kind:        "oci-image",
+					Path:        "path2",
+					Description: "description2",
+				},
+			},
+		},
+		output: charm.Metadata{
+			RunAs: charm.RunAsDefault,
+			Resources: map[string]charm.Resource{
+				"alpha": {
+					Name:        "foo",
+					Type:        charm.ResourceTypeFile,
+					Path:        "path1",
+					Description: "description1",
+				},
+				"beta": {
+					Name:        "baz",
+					Type:        charm.ResourceTypeContainerImage,
+					Path:        "path2",
+					Description: "description2",
+				},
+			},
+		},
+	},
+	{
+		name:  "containers",
+		input: charmMetadata{},
+		inputArgs: decodeMetadataArgs{
+			containers: []charmContainer{
+				{
+					Key:      "alpha",
+					Resource: "foo",
+					Uid:      -1,
+					Gid:      -1,
+					Storage:  "storage1",
+					Location: "location1",
+				},
+				{
+					Key:      "alpha",
+					Resource: "foo",
+					Uid:      -1,
+					Gid:      -1,
+					Storage:  "storage2",
+					Location: "location2",
+				},
+				{
+					Key:      "beta",
+					Resource: "baz",
+					Uid:      1000,
+					Gid:      1001,
+					Storage:  "storage3",
+					Location: "location3",
+				},
+			},
+		},
+		output: charm.Metadata{
+			RunAs: charm.RunAsDefault,
+			Containers: map[string]charm.Container{
+				"alpha": {
+					Resource: "foo",
+					Mounts: []charm.Mount{
+						{Storage: "storage1", Location: "location1"},
+						{Storage: "storage2", Location: "location2"},
+					},
+				},
+				"beta": {
+					Resource: "baz",
+					Uid:      ptr(1000),
+					Gid:      ptr(1001),
+					Mounts: []charm.Mount{
+						{Storage: "storage3", Location: "location3"},
+					},
+				},
+			},
+		},
+	},
+}
+
+func (s *metadataSuite) TestConvertMetadata(c *gc.C) {
+	for _, tc := range metadataTestCases {
+		c.Logf("Running test case %q", tc.name)
+
+		result, err := decodeMetadata(tc.input, tc.inputArgs)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Check(result, gc.DeepEquals, tc.output)
+	}
+}

--- a/domain/charm/state/metadata_test.go
+++ b/domain/charm/state/metadata_test.go
@@ -4,12 +4,12 @@
 package state
 
 import (
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version/v2"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/domain/charm"
 	schematesting "github.com/juju/juju/domain/schema/testing"
-	jc "github.com/juju/testing/checkers"
-	"github.com/juju/version/v2"
 )
 
 type metadataSuite struct {

--- a/domain/charm/state/package_test.go
+++ b/domain/charm/state/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/domain/charm/state/state.go
+++ b/domain/charm/state/state.go
@@ -1,0 +1,368 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/canonical/sqlair"
+	"github.com/juju/errors"
+	corecharm "github.com/juju/juju/core/charm"
+	coredatabase "github.com/juju/juju/core/database"
+	"github.com/juju/juju/domain"
+	charmerrors "github.com/juju/juju/domain/charm/errors"
+)
+
+// State is used to access the database.
+type State struct {
+	*domain.StateBase
+}
+
+// NewState creates a state to access the database.
+func NewState(factory coredatabase.TxnRunnerFactory) *State {
+	return &State{
+		StateBase: domain.NewStateBase(factory),
+	}
+}
+
+// GetCharmIDByRevision returns the charm ID by the natural key, for a
+// specific revision.
+// If the charm does not exist, a NotFound error is returned.
+func (s *State) GetCharmIDByRevision(ctx context.Context, name string, revision int) (corecharm.ID, error) {
+	db, err := s.DB()
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+
+	query := `
+SELECT charm.uuid AS &charmID.*
+FROM charm
+INNER JOIN charm_origin
+ON charm.uuid = charm_origin.charm_uuid
+WHERE charm.name = $charmNameRevision.name
+AND charm_origin.revision = $charmNameRevision.revision;
+`
+	stmt, err := s.Prepare(query, charmID{}, charmNameRevision{})
+	if err != nil {
+		return "", fmt.Errorf("failed to prepare query: %w", err)
+	}
+
+	var id corecharm.ID
+	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		var result charmID
+		if err := tx.Query(ctx, stmt, charmNameRevision{
+			Name:     name,
+			Revision: revision,
+		}).Get(&result); err != nil {
+			if errors.Is(err, sqlair.ErrNoRows) {
+				return charmerrors.NotFound
+			}
+			return fmt.Errorf("failed to get charm ID: %w", err)
+		}
+		id = corecharm.ID(result.UUID)
+		return nil
+	}); err != nil {
+		return "", fmt.Errorf("failed to run transaction: %w", err)
+	}
+	return id, nil
+}
+
+// IsControllerCharm returns whether the charm is a controller charm.
+// If the charm does not exist, a NotFound error is returned.
+func (s *State) IsControllerCharm(ctx context.Context, id corecharm.ID) (bool, error) {
+	db, err := s.DB()
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+
+	query := `
+SELECT name AS &charmName.name
+FROM charm
+WHERE uuid = $charmID.uuid;
+`
+	stmt, err := s.Prepare(query, charmID{}, charmName{})
+	if err != nil {
+		return false, fmt.Errorf("failed to prepare query: %w", err)
+	}
+
+	var isController bool
+	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		var result charmName
+		if err := tx.Query(ctx, stmt, charmID{UUID: id.String()}).Get(&result); err != nil {
+			if errors.Is(err, sqlair.ErrNoRows) {
+				return charmerrors.NotFound
+			}
+			return fmt.Errorf("failed to get charm ID: %w", err)
+		}
+		isController = result.Name == "juju-controller"
+		return nil
+	}); err != nil {
+		return false, fmt.Errorf("failed to run transaction: %w", err)
+	}
+	return isController, nil
+}
+
+// IsSubordinateCharm returns whether the charm is a subordinate charm.
+// If the charm does not exist, a NotFound error is returned.
+func (s *State) IsSubordinateCharm(ctx context.Context, id corecharm.ID) (bool, error) {
+	db, err := s.DB()
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+
+	query := `
+SELECT subordinate AS &charmSubordinate.subordinate
+FROM charm
+WHERE uuid = $charmID.uuid;
+`
+	stmt, err := s.Prepare(query, charmID{}, charmSubordinate{})
+	if err != nil {
+		return false, fmt.Errorf("failed to prepare query: %w", err)
+	}
+
+	var isSubordinate bool
+	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		var result charmSubordinate
+		if err := tx.Query(ctx, stmt, charmID{UUID: id.String()}).Get(&result); err != nil {
+			if errors.Is(err, sqlair.ErrNoRows) {
+				return charmerrors.NotFound
+			}
+			return fmt.Errorf("failed to get charm ID: %w", err)
+		}
+		isSubordinate = result.Subordinate
+		return nil
+	}); err != nil {
+		return false, fmt.Errorf("failed to run transaction: %w", err)
+	}
+	return isSubordinate, nil
+}
+
+// SupportsContainers returns whether the charm supports containers.
+// If the charm does not exist, a NotFound error is returned.
+func (s *State) SupportsContainers(ctx context.Context, id corecharm.ID) (bool, error) {
+	db, err := s.DB()
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+
+	query := `
+SELECT charm_container.charm_uuid AS &charmID.uuid
+FROM charm
+LEFT JOIN charm_container
+ON charm.uuid = charm_container.charm_uuid
+WHERE uuid = $charmID.uuid;
+`
+	stmt, err := s.Prepare(query, charmID{})
+	if err != nil {
+		return false, fmt.Errorf("failed to prepare query: %w", err)
+	}
+
+	var supportsContainers bool
+	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		var result []charmID
+		if err := tx.Query(ctx, stmt, charmID{UUID: id.String()}).GetAll(&result); err != nil {
+			if errors.Is(err, sqlair.ErrNoRows) {
+				return charmerrors.NotFound
+			}
+			return fmt.Errorf("failed to get charm ID: %w", err)
+		}
+		var num int
+		for _, r := range result {
+			if r.UUID == id.String() {
+				num++
+			}
+		}
+		supportsContainers = num > 0
+		return nil
+	}); err != nil {
+		return false, fmt.Errorf("failed to run transaction: %w", err)
+	}
+	return supportsContainers, nil
+}
+
+// IsCharmAvailable returns whether the charm is available for use.
+// If the charm does not exist, a NotFound error is returned.
+func (s *State) IsCharmAvailable(ctx context.Context, id corecharm.ID) (bool, error) {
+	db, err := s.DB()
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+
+	query := `
+SELECT charm_state.available AS &charmAvailable.available
+FROM charm
+INNER JOIN charm_state
+ON charm.uuid = charm_state.charm_uuid
+WHERE uuid = $charmID.uuid;
+`
+	stmt, err := s.Prepare(query, charmID{}, charmAvailable{})
+	if err != nil {
+		return false, fmt.Errorf("failed to prepare query: %w", err)
+	}
+
+	var isAvailable bool
+	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		var result charmAvailable
+		if err := tx.Query(ctx, stmt, charmID{UUID: id.String()}).Get(&result); err != nil {
+			if errors.Is(err, sqlair.ErrNoRows) {
+				return charmerrors.NotFound
+			}
+			return fmt.Errorf("failed to get charm ID: %w", err)
+		}
+		isAvailable = result.Available
+		return nil
+	}); err != nil {
+		return false, fmt.Errorf("failed to run transaction: %w", err)
+	}
+	return isAvailable, nil
+}
+
+// SetCharmAvailable sets the charm as available for use.
+// If the charm does not exist, a NotFound error is returned.
+func (s *State) SetCharmAvailable(ctx context.Context, id corecharm.ID) error {
+	db, err := s.DB()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	selectQuery := `
+SELECT charm.uuid AS &charmID.*
+FROM charm
+WHERE uuid = $charmID.uuid;
+	`
+
+	selectStmt, err := s.Prepare(selectQuery, charmID{})
+	if err != nil {
+		return fmt.Errorf("failed to prepare query: %w", err)
+	}
+
+	updateQuery := `
+UPDATE charm_state
+SET available = true
+WHERE charm_uuid = $charmID.uuid;
+`
+
+	updateStmt, err := s.Prepare(updateQuery, charmID{})
+	if err != nil {
+		return fmt.Errorf("failed to prepare query: %w", err)
+	}
+
+	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		var result charmID
+		if err := tx.Query(ctx, selectStmt, charmID{UUID: id.String()}).Get(&result); err != nil {
+			if errors.Is(err, sqlair.ErrNoRows) {
+				return charmerrors.NotFound
+			}
+			return fmt.Errorf("failed to set charm available: %w", err)
+		}
+
+		if err := tx.Query(ctx, updateStmt, charmID{UUID: id.String()}).Run(); err != nil {
+			return fmt.Errorf("failed to set charm available: %w", err)
+		}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("failed to run transaction: %w", err)
+	}
+
+	return nil
+}
+
+// ReserveCharmRevision defines a placeholder for a new charm revision.
+// The original charm will need to exist, the returning charm ID will be
+// the new charm ID for the revision.
+func (s *State) ReserveCharmRevision(ctx context.Context, id corecharm.ID, revision int) (corecharm.ID, error) {
+	db, err := s.DB()
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+
+	selectQuery := `
+SELECT charm.* AS &charm.*, charm_state.* AS &charmState.*
+FROM charm 
+LEFT JOIN charm_state
+ON charm.uuid = charm_state.charm_uuid
+WHERE uuid = $charmID.uuid;
+`
+	selectStmt, err := s.Prepare(selectQuery, charm{}, charmState{}, charmID{})
+	if err != nil {
+		return "", fmt.Errorf("failed to prepare query: %w", err)
+	}
+
+	insertCharmQuery := `INSERT INTO charm (*) VALUES ($charm.*);`
+	insertCharmStmt, err := s.Prepare(insertCharmQuery, charm{})
+	if err != nil {
+		return "", fmt.Errorf("failed to prepare query: %w", err)
+	}
+
+	insertCharmStateQuery := `INSERT INTO charm_state (*) VALUES ($charmState.*);`
+	insertCharmStateStmt, err := s.Prepare(insertCharmStateQuery, charmState{})
+	if err != nil {
+		return "", fmt.Errorf("failed to prepare query: %w", err)
+	}
+
+	newID, err := corecharm.NewID()
+	if err != nil {
+		return "", fmt.Errorf("failed to reserve charm revision: %w", err)
+	}
+
+	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		var (
+			charmResult       charm
+			charmsStateResult charmState
+		)
+		if err := tx.Query(ctx, selectStmt, charmID{UUID: id.String()}).Get(&charmResult, &charmsStateResult); err != nil {
+			if errors.Is(err, sqlair.ErrNoRows) {
+				return charmerrors.NotFound
+			}
+			return fmt.Errorf("failed to reserve charm revision: %w", err)
+		}
+
+		newCharm := charmResult
+		newCharm.UUID = newID.String()
+		if err := tx.Query(ctx, insertCharmStmt, newCharm).Run(); err != nil {
+			return fmt.Errorf("failed to reserve charm revision: inserting charm: %w", err)
+		}
+
+		// This is defensive, a simple insert should be enough, but if the
+		// charm state is updated, this will at least perform correctly.
+		newCharmState := charmsStateResult
+		newCharmState.CharmUUID = newID.String()
+		newCharmState.Available = false
+		if err := tx.Query(ctx, insertCharmStateStmt, newCharmState).Run(); err != nil {
+			return fmt.Errorf("failed to reserve charm revision: inserting charm state: %w", err)
+		}
+
+		return nil
+	}); err != nil {
+		return "", fmt.Errorf("failed to run transaction: %w", err)
+	}
+
+	return newID, nil
+}
+
+// // GetCharmMetadata returns the metadata for the charm using the charm ID.
+// // If the charm does not exist, a NotFound error is returned.
+// func (s *State) GetCharmMetadata(ctx context.Context, charmID corecharm.ID) (charm.Metadata, error) {}
+//
+// // GetCharmManifest returns the manifest for the charm using the charm ID.
+// // If the charm does not exist, a NotFound error is returned.
+// func (s *State) GetCharmManifest(ctx context.Context, charmID corecharm.ID) (charm.Manifest, error) {}
+//
+// // GetCharmActions returns the actions for the charm using the charm ID.
+// // If the charm does not exist, a NotFound error is returned.
+// func (s *State) GetCharmActions(ctx context.Context, charmID corecharm.ID) (charm.Actions, error) {}
+//
+// // GetCharmConfig returns the config for the charm using the charm ID.
+// // If the charm does not exist, a NotFound error is returned.
+// func (s *State) GetCharmConfig(ctx context.Context, charmID corecharm.ID) (charm.Config, error) {}
+//
+// // GetCharmLXDProfile returns the LXD profile for the charm using the
+// // charm ID.
+// // If the charm does not exist, a NotFound error is returned.
+// func (s *State) GetCharmLXDProfile(ctx context.Context, charmID corecharm.ID) ([]byte, error) {}
+//
+// // SetCharm persists the charm metadata, actions, config and manifest to
+// // state.
+// func (s *State) SetCharm(ctx context.Context, charm charm.Charm) (corecharm.ID, error) {}

--- a/domain/charm/state/state.go
+++ b/domain/charm/state/state.go
@@ -467,7 +467,8 @@ func getCharmTags(ctx context.Context, tx *sqlair.TX, p domain.Preparer, id core
 	query := `
 SELECT charm_tag.* AS &charmTag.*
 FROM charm_tag
-WHERE charm_uuid = $charmID.uuid;
+WHERE charm_uuid = $charmID.uuid
+ORDER BY "index" ASC;
 `
 	stmt, err := p.Prepare(query, charmTag{}, charmID{})
 	if err != nil {
@@ -496,7 +497,8 @@ func getCharmCategories(ctx context.Context, tx *sqlair.TX, p domain.Preparer, i
 	query := `
 SELECT charm_category.* AS &charmCategory.*
 FROM charm_category
-WHERE charm_uuid = $charmID.uuid;
+WHERE charm_uuid = $charmID.uuid
+ORDER BY "index" ASC;
 `
 	stmt, err := p.Prepare(query, charmCategory{}, charmID{})
 	if err != nil {
@@ -525,7 +527,8 @@ func getCharmTerms(ctx context.Context, tx *sqlair.TX, p domain.Preparer, id cor
 	query := `
 SELECT charm_term.* AS &charmTerm.*
 FROM charm_term
-WHERE charm_uuid = $charmID.uuid;
+WHERE charm_uuid = $charmID.uuid
+ORDER BY "index" ASC;
 `
 	stmt, err := p.Prepare(query, charmTerm{}, charmID{})
 	if err != nil {
@@ -607,7 +610,8 @@ func getCharmStorage(ctx context.Context, tx *sqlair.TX, p domain.Preparer, id c
 	query := `
 SELECT v_charm_storage.* AS &charmStorage.*
 FROM v_charm_storage
-WHERE charm_uuid = $charmID.uuid;
+WHERE charm_uuid = $charmID.uuid
+ORDER BY property_index ASC;
 `
 
 	stmt, err := p.Prepare(query, charmStorage{}, charmID{})

--- a/domain/charm/state/state_test.go
+++ b/domain/charm/state/state_test.go
@@ -8,22 +8,20 @@ import (
 	"database/sql"
 
 	jc "github.com/juju/testing/checkers"
+	"github.com/juju/version/v2"
 	gc "gopkg.in/check.v1"
 
 	charmtesting "github.com/juju/juju/core/charm/testing"
+	"github.com/juju/juju/domain/charm"
 	charmerrors "github.com/juju/juju/domain/charm/errors"
-	"github.com/juju/juju/internal/changestream/testing"
+	schematesting "github.com/juju/juju/domain/schema/testing"
 )
 
 type stateSuite struct {
-	testing.ModelSuite
+	schematesting.ModelSuite
 }
 
 var _ = gc.Suite(&stateSuite{})
-
-func (s *stateSuite) SetUpTest(c *gc.C) {
-	s.ModelSuite.SetUpTest(c)
-}
 
 func (s *stateSuite) TestGetCharmIDByRevision(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory())
@@ -150,10 +148,10 @@ func (s *stateSuite) TestSupportsContainersWithContainers(c *gc.C) {
 		_, err := tx.ExecContext(ctx, `INSERT INTO charm (uuid, name) VALUES (?, 'ubuntu')`, id.String())
 		c.Assert(err, jc.ErrorIsNil)
 
-		_, err = tx.ExecContext(ctx, `INSERT INTO charm_container (charm_uuid, name) VALUES (?, 'ubuntu@22.04')`, id.String())
+		_, err = tx.ExecContext(ctx, `INSERT INTO charm_container (charm_uuid, "key") VALUES (?, 'ubuntu@22.04')`, id.String())
 		c.Assert(err, jc.ErrorIsNil)
 
-		_, err = tx.ExecContext(ctx, `INSERT INTO charm_container (charm_uuid, name) VALUES (?, 'ubuntu@20.04')`, id.String())
+		_, err = tx.ExecContext(ctx, `INSERT INTO charm_container (charm_uuid, "key") VALUES (?, 'ubuntu@20.04')`, id.String())
 		c.Assert(err, jc.ErrorIsNil)
 		return nil
 	})
@@ -298,4 +296,735 @@ func (s *stateSuite) TestReserveCharmRevision(c *gc.C) {
 	result, err := st.IsCharmAvailable(context.Background(), newID)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(result, jc.IsFalse)
+}
+
+func (s *stateSuite) TestGetCharmMetadataWithNoCharm(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	id := charmtesting.GenCharmID(c)
+
+	_, err := st.GetCharmMetadata(context.Background(), id)
+	c.Assert(err, jc.ErrorIs, charmerrors.NotFound)
+}
+
+func (s *stateSuite) TestGetCharmMetadata(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	id := charmtesting.GenCharmID(c)
+	uuid := id.String()
+
+	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+INSERT INTO charm (uuid, name, description, summary, subordinate, min_juju_version, run_as_id, assumes) 
+VALUES (?, 'ubuntu', 'description', 'summary', true, '4.0.0', 1, 'null')`, uuid)
+		c.Assert(err, jc.ErrorIsNil)
+
+		_, err = tx.ExecContext(ctx, `INSERT INTO charm_state (charm_uuid, available) VALUES (?, false)`, uuid)
+		c.Assert(err, jc.ErrorIsNil)
+
+		return nil
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	metadata, err := st.GetCharmMetadata(context.Background(), id)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(metadata, gc.DeepEquals, charm.Metadata{
+		Name:           "ubuntu",
+		Summary:        "summary",
+		Description:    "description",
+		Subordinate:    true,
+		RunAs:          charm.RunAsRoot,
+		MinJujuVersion: version.MustParse("4.0.0"),
+		Assumes:        []byte("null"),
+	})
+}
+
+func (s *stateSuite) TestGetCharmMetadataWithTagsAndCategories(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	id := charmtesting.GenCharmID(c)
+	uuid := id.String()
+
+	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+INSERT INTO charm (uuid, name, description, summary, subordinate, min_juju_version, run_as_id, assumes) 
+VALUES (?, 'ubuntu', 'description', 'summary', true, '4.0.0', 1, 'null')`, uuid)
+		c.Assert(err, jc.ErrorIsNil)
+
+		_, err = tx.ExecContext(ctx, `INSERT INTO charm_state (charm_uuid, available) VALUES (?, false)`, uuid)
+		c.Assert(err, jc.ErrorIsNil)
+
+		_, err = tx.ExecContext(ctx, `INSERT INTO charm_category (charm_uuid, value) VALUES (?, 'data'), (?, 'kubernetes')`, uuid, uuid)
+		c.Assert(err, jc.ErrorIsNil)
+
+		_, err = tx.ExecContext(ctx, `INSERT INTO charm_tag (charm_uuid, value) VALUES (?, 'foo'), (?, 'bar')`, uuid, uuid)
+		c.Assert(err, jc.ErrorIsNil)
+
+		return nil
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	metadata, err := st.GetCharmMetadata(context.Background(), id)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(metadata, gc.DeepEquals, charm.Metadata{
+		Name:           "ubuntu",
+		Summary:        "summary",
+		Description:    "description",
+		Subordinate:    true,
+		RunAs:          charm.RunAsRoot,
+		MinJujuVersion: version.MustParse("4.0.0"),
+		Assumes:        []byte("null"),
+		Tags:           []string{"bar", "foo"},
+		Categories:     []string{"data", "kubernetes"},
+	})
+}
+
+func (s *stateSuite) TestGetCharmMetadataWithTerms(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	id := charmtesting.GenCharmID(c)
+	uuid := id.String()
+
+	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+INSERT INTO charm (uuid, name, description, summary, subordinate, min_juju_version, run_as_id, assumes) 
+VALUES (?, 'ubuntu', 'description', 'summary', true, '4.0.0', 1, 'null')`, uuid)
+		c.Assert(err, jc.ErrorIsNil)
+
+		_, err = tx.ExecContext(ctx, `INSERT INTO charm_state (charm_uuid, available) VALUES (?, false)`, uuid)
+		c.Assert(err, jc.ErrorIsNil)
+
+		_, err = tx.ExecContext(ctx, `INSERT INTO charm_term (charm_uuid, value) VALUES (?, 'alpha'), (?, 'beta')`, uuid, uuid)
+		c.Assert(err, jc.ErrorIsNil)
+
+		return nil
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	metadata, err := st.GetCharmMetadata(context.Background(), id)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(metadata, gc.DeepEquals, charm.Metadata{
+		Name:           "ubuntu",
+		Summary:        "summary",
+		Description:    "description",
+		Subordinate:    true,
+		RunAs:          charm.RunAsRoot,
+		MinJujuVersion: version.MustParse("4.0.0"),
+		Assumes:        []byte("null"),
+		Terms:          []string{"alpha", "beta"},
+	})
+}
+
+func (s *stateSuite) TestGetCharmMetadataWithRelation(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	id := charmtesting.GenCharmID(c)
+	uuid := id.String()
+
+	// Ensure that relations are correctly extracted.
+
+	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+INSERT INTO charm (uuid, name, description, summary, subordinate, min_juju_version, run_as_id, assumes) 
+VALUES (?, 'ubuntu', 'description', 'summary', true, '4.0.0', 1, 'null')`, uuid)
+		c.Assert(err, jc.ErrorIsNil)
+
+		_, err = tx.ExecContext(ctx, `INSERT INTO charm_state (charm_uuid, available) VALUES (?, false)`, uuid)
+		c.Assert(err, jc.ErrorIsNil)
+
+		_, err = tx.ExecContext(ctx, `
+INSERT INTO charm_relation (charm_uuid, kind_id, key, name, role_id) 
+VALUES 
+    (?, 0, 'foo', 'baz', 0),
+    (?, 0, 'fred', 'bar', 0),
+    (?, 1, 'foo', 'baz', 1),
+    (?, 2, 'foo', 'baz', 2);`,
+			uuid, uuid, uuid, uuid)
+		c.Assert(err, jc.ErrorIsNil)
+
+		return nil
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	metadata, err := st.GetCharmMetadata(context.Background(), id)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(metadata, gc.DeepEquals, charm.Metadata{
+		Name:           "ubuntu",
+		Summary:        "summary",
+		Description:    "description",
+		Subordinate:    true,
+		RunAs:          charm.RunAsRoot,
+		MinJujuVersion: version.MustParse("4.0.0"),
+		Assumes:        []byte("null"),
+		Provides: map[string]charm.Relation{
+			"foo": {
+				Key:  "foo",
+				Name: "baz",
+				Role: charm.RoleProvider,
+			},
+			"fred": {
+				Key:  "fred",
+				Name: "bar",
+				Role: charm.RoleProvider,
+			},
+		},
+		Requires: map[string]charm.Relation{
+			"foo": {
+				Key:  "foo",
+				Name: "baz",
+				Role: charm.RoleRequirer,
+			},
+		},
+		Peers: map[string]charm.Relation{
+			"foo": {
+				Key:  "foo",
+				Name: "baz",
+				Role: charm.RolePeer,
+			},
+		},
+	})
+}
+
+func (s *stateSuite) TestGetCharmMetadataWithExtraBindings(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	id := charmtesting.GenCharmID(c)
+	uuid := id.String()
+
+	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+INSERT INTO charm (uuid, name, description, summary, subordinate, min_juju_version, run_as_id, assumes) 
+VALUES (?, 'ubuntu', 'description', 'summary', true, '4.0.0', 1, 'null')`, uuid)
+		c.Assert(err, jc.ErrorIsNil)
+
+		_, err = tx.ExecContext(ctx, `INSERT INTO charm_state (charm_uuid, available) VALUES (?, false)`, uuid)
+		c.Assert(err, jc.ErrorIsNil)
+
+		_, err = tx.ExecContext(ctx, `
+INSERT INTO charm_extra_binding (charm_uuid, key, name) 
+VALUES 
+    (?, 'foo', 'bar'),
+    (?, 'fred', 'baz');`,
+			uuid, uuid)
+		c.Assert(err, jc.ErrorIsNil)
+
+		return nil
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	metadata, err := st.GetCharmMetadata(context.Background(), id)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(metadata, gc.DeepEquals, charm.Metadata{
+		Name:           "ubuntu",
+		Summary:        "summary",
+		Description:    "description",
+		Subordinate:    true,
+		RunAs:          charm.RunAsRoot,
+		MinJujuVersion: version.MustParse("4.0.0"),
+		Assumes:        []byte("null"),
+		ExtraBindings: map[string]charm.ExtraBinding{
+			"foo": {
+				Name: "bar",
+			},
+			"fred": {
+				Name: "baz",
+			},
+		},
+	})
+}
+
+func (s *stateSuite) TestGetCharmMetadataWithStorageWithNoProperties(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	id := charmtesting.GenCharmID(c)
+	uuid := id.String()
+
+	// Ensure that storage with no properties is correctly extracted.
+
+	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+INSERT INTO charm (uuid, name, description, summary, subordinate, min_juju_version, run_as_id, assumes) 
+VALUES (?, 'ubuntu', 'description', 'summary', true, '4.0.0', 1, 'null')`, uuid)
+		c.Assert(err, jc.ErrorIsNil)
+
+		_, err = tx.ExecContext(ctx, `INSERT INTO charm_state (charm_uuid, available) VALUES (?, false)`, uuid)
+		c.Assert(err, jc.ErrorIsNil)
+
+		_, err = tx.ExecContext(ctx, `
+INSERT INTO charm_storage (
+    charm_uuid,
+    key,
+    name,
+    description,
+    storage_kind_id,
+    shared,
+    read_only,
+    count_min,
+    count_max,
+    minimum_size_mib,
+    location
+) VALUES 
+    (?, 'foo', 'bar', 'description 1', 1, true, true, 1, 2, 3, '/tmp'),
+    (?, 'fred', 'baz', 'description 2', 0, false, false, 4, 5, 6, '/var/mount');`,
+			uuid, uuid)
+		c.Assert(err, jc.ErrorIsNil)
+
+		return nil
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	metadata, err := st.GetCharmMetadata(context.Background(), id)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(metadata, gc.DeepEquals, charm.Metadata{
+		Name:           "ubuntu",
+		Summary:        "summary",
+		Description:    "description",
+		Subordinate:    true,
+		RunAs:          charm.RunAsRoot,
+		MinJujuVersion: version.MustParse("4.0.0"),
+		Assumes:        []byte("null"),
+		Storage: map[string]charm.Storage{
+			"foo": {
+				Name:        "bar",
+				Type:        charm.StorageFilesystem,
+				Description: "description 1",
+				Shared:      true,
+				ReadOnly:    true,
+				CountMin:    1,
+				CountMax:    2,
+				MinimumSize: 3,
+				Location:    "/tmp",
+			},
+			"fred": {
+				Name:        "baz",
+				Type:        charm.StorageBlock,
+				Description: "description 2",
+				Shared:      false,
+				ReadOnly:    false,
+				CountMin:    4,
+				CountMax:    5,
+				MinimumSize: 6,
+				Location:    "/var/mount",
+			},
+		},
+	})
+}
+
+func (s *stateSuite) TestGetCharmMetadataWithStorageWithProperties(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	id := charmtesting.GenCharmID(c)
+	uuid := id.String()
+
+	// Ensure that storage with properties is correctly extracted.
+
+	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+INSERT INTO charm (uuid, name, description, summary, subordinate, min_juju_version, run_as_id, assumes) 
+VALUES (?, 'ubuntu', 'description', 'summary', true, '4.0.0', 1, 'null')`, uuid)
+		c.Assert(err, jc.ErrorIsNil)
+
+		_, err = tx.ExecContext(ctx, `INSERT INTO charm_state (charm_uuid, available) VALUES (?, false)`, uuid)
+		c.Assert(err, jc.ErrorIsNil)
+
+		_, err = tx.ExecContext(ctx, `
+INSERT INTO charm_storage (
+    charm_uuid,
+    key,
+    name,
+    description,
+    storage_kind_id,
+    shared,
+    read_only,
+    count_min,
+    count_max,
+    minimum_size_mib,
+    location
+) VALUES 
+    (?, 'foo', 'bar', 'description 1', 1, true, true, 1, 2, 3, '/tmp'),
+    (?, 'fred', 'baz', 'description 2', 0, false, false, 4, 5, 6, '/var/mount');`,
+			uuid, uuid)
+		c.Assert(err, jc.ErrorIsNil)
+
+		_, err = tx.ExecContext(ctx, `
+INSERT INTO charm_storage_property (
+    charm_uuid,
+    charm_storage_key,
+    value
+) VALUES
+    (?, 'foo', 'alpha'),
+    (?, 'foo', 'beta');`,
+			uuid, uuid)
+		c.Assert(err, jc.ErrorIsNil)
+
+		return nil
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	metadata, err := st.GetCharmMetadata(context.Background(), id)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(metadata, gc.DeepEquals, charm.Metadata{
+		Name:           "ubuntu",
+		Summary:        "summary",
+		Description:    "description",
+		Subordinate:    true,
+		RunAs:          charm.RunAsRoot,
+		MinJujuVersion: version.MustParse("4.0.0"),
+		Assumes:        []byte("null"),
+		Storage: map[string]charm.Storage{
+			"foo": {
+				Name:        "bar",
+				Type:        charm.StorageFilesystem,
+				Description: "description 1",
+				Shared:      true,
+				ReadOnly:    true,
+				CountMin:    1,
+				CountMax:    2,
+				MinimumSize: 3,
+				Location:    "/tmp",
+				Properties:  []string{"alpha", "beta"},
+			},
+			"fred": {
+				Name:        "baz",
+				Type:        charm.StorageBlock,
+				Description: "description 2",
+				Shared:      false,
+				ReadOnly:    false,
+				CountMin:    4,
+				CountMax:    5,
+				MinimumSize: 6,
+				Location:    "/var/mount",
+			},
+		},
+	})
+}
+
+func (s *stateSuite) TestGetCharmMetadataWithDevices(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	id := charmtesting.GenCharmID(c)
+	uuid := id.String()
+
+	// Ensure that storage with no properties is correctly extracted.
+
+	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+INSERT INTO charm (uuid, name, description, summary, subordinate, min_juju_version, run_as_id, assumes) 
+VALUES (?, 'ubuntu', 'description', 'summary', true, '4.0.0', 1, 'null')`, uuid)
+		c.Assert(err, jc.ErrorIsNil)
+
+		_, err = tx.ExecContext(ctx, `INSERT INTO charm_state (charm_uuid, available) VALUES (?, false)`, uuid)
+		c.Assert(err, jc.ErrorIsNil)
+
+		_, err = tx.ExecContext(ctx, `
+INSERT INTO charm_device (
+    charm_uuid,
+    key,
+    name,
+    description,
+    device_type,
+    count_min,
+    count_max
+) VALUES 
+    (?, 'foo', 'bar', 'description 1', 'gpu', 1, 2),
+    (?, 'fred', 'baz', 'description 2', 'tpu', 3, 4);`,
+			uuid, uuid)
+		c.Assert(err, jc.ErrorIsNil)
+
+		return nil
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	metadata, err := st.GetCharmMetadata(context.Background(), id)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(metadata, gc.DeepEquals, charm.Metadata{
+		Name:           "ubuntu",
+		Summary:        "summary",
+		Description:    "description",
+		Subordinate:    true,
+		RunAs:          charm.RunAsRoot,
+		MinJujuVersion: version.MustParse("4.0.0"),
+		Assumes:        []byte("null"),
+		Devices: map[string]charm.Device{
+			"foo": {
+				Name:        "bar",
+				Type:        charm.DeviceType("gpu"),
+				Description: "description 1",
+				CountMin:    1,
+				CountMax:    2,
+			},
+			"fred": {
+				Name:        "baz",
+				Type:        charm.DeviceType("tpu"),
+				Description: "description 2",
+				CountMin:    3,
+				CountMax:    4,
+			},
+		},
+	})
+}
+
+func (s *stateSuite) TestGetCharmMetadataWithPayloadClasses(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	id := charmtesting.GenCharmID(c)
+	uuid := id.String()
+
+	// Ensure that storage with no properties is correctly extracted.
+
+	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+INSERT INTO charm (uuid, name, description, summary, subordinate, min_juju_version, run_as_id, assumes) 
+VALUES (?, 'ubuntu', 'description', 'summary', true, '4.0.0', 1, 'null')`, uuid)
+		c.Assert(err, jc.ErrorIsNil)
+
+		_, err = tx.ExecContext(ctx, `INSERT INTO charm_state (charm_uuid, available) VALUES (?, false)`, uuid)
+		c.Assert(err, jc.ErrorIsNil)
+
+		_, err = tx.ExecContext(ctx, `
+INSERT INTO charm_payload (
+    charm_uuid,
+    key,
+    name,
+    type
+) VALUES 
+    (?, 'foo', 'bar', 'docker'),
+    (?, 'fred', 'baz', 'kvm');`,
+			uuid, uuid)
+		c.Assert(err, jc.ErrorIsNil)
+
+		return nil
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	metadata, err := st.GetCharmMetadata(context.Background(), id)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(metadata, gc.DeepEquals, charm.Metadata{
+		Name:           "ubuntu",
+		Summary:        "summary",
+		Description:    "description",
+		Subordinate:    true,
+		RunAs:          charm.RunAsRoot,
+		MinJujuVersion: version.MustParse("4.0.0"),
+		Assumes:        []byte("null"),
+		PayloadClasses: map[string]charm.PayloadClass{
+			"foo": {
+				Name: "bar",
+				Type: "docker",
+			},
+			"fred": {
+				Name: "baz",
+				Type: "kvm",
+			},
+		},
+	})
+}
+
+func (s *stateSuite) TestGetCharmMetadataWithResources(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	id := charmtesting.GenCharmID(c)
+	uuid := id.String()
+
+	// Ensure that storage with no properties is correctly extracted.
+
+	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+INSERT INTO charm (uuid, name, description, summary, subordinate, min_juju_version, run_as_id, assumes) 
+VALUES (?, 'ubuntu', 'description', 'summary', true, '4.0.0', 1, 'null')`, uuid)
+		c.Assert(err, jc.ErrorIsNil)
+
+		_, err = tx.ExecContext(ctx, `INSERT INTO charm_state (charm_uuid, available) VALUES (?, false)`, uuid)
+		c.Assert(err, jc.ErrorIsNil)
+
+		_, err = tx.ExecContext(ctx, `
+INSERT INTO charm_resource (
+    charm_uuid,
+    key,
+    name,
+    kind_id,
+    path,
+    description
+) VALUES 
+    (?, 'foo', 'bar', 0, '/tmp/file.txt', 'description 1'),
+    (?, 'fred', 'baz', 1, 'hub.docker.io/jujusolutions', 'description 2');`,
+			uuid, uuid)
+		c.Assert(err, jc.ErrorIsNil)
+
+		return nil
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	metadata, err := st.GetCharmMetadata(context.Background(), id)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(metadata, gc.DeepEquals, charm.Metadata{
+		Name:           "ubuntu",
+		Summary:        "summary",
+		Description:    "description",
+		Subordinate:    true,
+		RunAs:          charm.RunAsRoot,
+		MinJujuVersion: version.MustParse("4.0.0"),
+		Assumes:        []byte("null"),
+		Resources: map[string]charm.Resource{
+			"foo": {
+				Name:        "bar",
+				Type:        charm.ResourceTypeFile,
+				Path:        "/tmp/file.txt",
+				Description: "description 1",
+			},
+			"fred": {
+				Name:        "baz",
+				Type:        charm.ResourceTypeContainerImage,
+				Path:        "hub.docker.io/jujusolutions",
+				Description: "description 2",
+			},
+		},
+	})
+}
+
+func (s *stateSuite) TestGetCharmMetadataWithContainersWithNoMounts(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	id := charmtesting.GenCharmID(c)
+	uuid := id.String()
+
+	// Ensure that storage with no properties is correctly extracted.
+
+	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+INSERT INTO charm (uuid, name, description, summary, subordinate, min_juju_version, run_as_id, assumes) 
+VALUES (?, 'ubuntu', 'description', 'summary', true, '4.0.0', 1, 'null')`, uuid)
+		c.Assert(err, jc.ErrorIsNil)
+
+		_, err = tx.ExecContext(ctx, `INSERT INTO charm_state (charm_uuid, available) VALUES (?, false)`, uuid)
+		c.Assert(err, jc.ErrorIsNil)
+
+		_, err = tx.ExecContext(ctx, `
+INSERT INTO charm_container (
+    charm_uuid,
+    key,
+    resource,
+    uid,
+    gid
+) VALUES 
+    (?, 'foo', 'ubuntu@22.04', 100, 100),
+    (?, 'fred', 'ubuntu@20.04', -1, -1);`,
+			uuid, uuid)
+		c.Assert(err, jc.ErrorIsNil)
+
+		return nil
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	metadata, err := st.GetCharmMetadata(context.Background(), id)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(metadata, gc.DeepEquals, charm.Metadata{
+		Name:           "ubuntu",
+		Summary:        "summary",
+		Description:    "description",
+		Subordinate:    true,
+		RunAs:          charm.RunAsRoot,
+		MinJujuVersion: version.MustParse("4.0.0"),
+		Assumes:        []byte("null"),
+		Containers: map[string]charm.Container{
+			"foo": {
+				Resource: "ubuntu@22.04",
+				Uid:      ptr(100),
+				Gid:      ptr(100),
+			},
+			"fred": {
+				Resource: "ubuntu@20.04",
+			},
+		},
+	})
+}
+
+func (s *stateSuite) TestGetCharmMetadataWithContainersWithMounts(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	id := charmtesting.GenCharmID(c)
+	uuid := id.String()
+
+	// Ensure that storage with no properties is correctly extracted.
+
+	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `
+INSERT INTO charm (uuid, name, description, summary, subordinate, min_juju_version, run_as_id, assumes) 
+VALUES (?, 'ubuntu', 'description', 'summary', true, '4.0.0', 1, 'null')`, uuid)
+		c.Assert(err, jc.ErrorIsNil)
+
+		_, err = tx.ExecContext(ctx, `INSERT INTO charm_state (charm_uuid, available) VALUES (?, false)`, uuid)
+		c.Assert(err, jc.ErrorIsNil)
+
+		_, err = tx.ExecContext(ctx, `
+INSERT INTO charm_container (
+    charm_uuid,
+    key,
+    resource,
+    uid,
+    gid
+) VALUES 
+    (?, 'foo', 'ubuntu@22.04', 100, 100),
+    (?, 'fred', 'ubuntu@20.04', -1, -1);`,
+			uuid, uuid)
+		c.Assert(err, jc.ErrorIsNil)
+
+		_, err = tx.ExecContext(ctx, `
+INSERT INTO charm_container_mount (
+    charm_uuid,
+    "index",
+    charm_container_key,
+    storage,
+    location
+) VALUES
+	(?, 0, 'foo', 'block', '/tmp'),
+	(?, 1, 'foo', 'block', '/dev/nvme0n1'),
+	(?, 0, 'fred', 'file', '/var/log');`,
+			uuid, uuid, uuid)
+		c.Assert(err, jc.ErrorIsNil)
+		return nil
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	metadata, err := st.GetCharmMetadata(context.Background(), id)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(metadata, gc.DeepEquals, charm.Metadata{
+		Name:           "ubuntu",
+		Summary:        "summary",
+		Description:    "description",
+		Subordinate:    true,
+		RunAs:          charm.RunAsRoot,
+		MinJujuVersion: version.MustParse("4.0.0"),
+		Assumes:        []byte("null"),
+		Containers: map[string]charm.Container{
+			"foo": {
+				Resource: "ubuntu@22.04",
+				Uid:      ptr(100),
+				Gid:      ptr(100),
+				Mounts: []charm.Mount{
+					{
+						Storage:  "block",
+						Location: "/tmp",
+					},
+					{
+						Storage:  "block",
+						Location: "/dev/nvme0n1",
+					},
+				},
+			},
+			"fred": {
+				Resource: "ubuntu@20.04",
+				Mounts: []charm.Mount{
+					{
+						Storage:  "file",
+						Location: "/var/log",
+					},
+				},
+			},
+		},
+	})
+}
+
+func ptr[T any](v T) *T {
+	return &v
 }

--- a/domain/charm/state/state_test.go
+++ b/domain/charm/state/state_test.go
@@ -1,0 +1,301 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"context"
+	"database/sql"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	charmtesting "github.com/juju/juju/core/charm/testing"
+	charmerrors "github.com/juju/juju/domain/charm/errors"
+	"github.com/juju/juju/internal/changestream/testing"
+)
+
+type stateSuite struct {
+	testing.ModelSuite
+}
+
+var _ = gc.Suite(&stateSuite{})
+
+func (s *stateSuite) SetUpTest(c *gc.C) {
+	s.ModelSuite.SetUpTest(c)
+}
+
+func (s *stateSuite) TestGetCharmIDByRevision(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	id := charmtesting.GenCharmID(c)
+
+	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `INSERT INTO charm (uuid, name) VALUES (?, 'foo')`, id.String())
+		c.Assert(err, jc.ErrorIsNil)
+
+		_, err = tx.ExecContext(ctx, `INSERT INTO charm_origin (charm_uuid, revision) VALUES (?, 1)`, id.String())
+		c.Assert(err, jc.ErrorIsNil)
+
+		return nil
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	charmID, err := st.GetCharmIDByRevision(context.Background(), "foo", 1)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(charmID, gc.Equals, id)
+}
+
+func (s *stateSuite) TestIsControllerCharmWithNoCharm(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	id := charmtesting.GenCharmID(c)
+
+	_, err := st.IsControllerCharm(context.Background(), id)
+	c.Assert(err, jc.ErrorIs, charmerrors.NotFound)
+}
+
+func (s *stateSuite) TestIsControllerCharmWithControllerCharm(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	id := charmtesting.GenCharmID(c)
+
+	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `INSERT INTO charm (uuid, name) VALUES (?, 'juju-controller')`, id.String())
+		c.Assert(err, jc.ErrorIsNil)
+		return nil
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	result, err := st.IsControllerCharm(context.Background(), id)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(result, jc.IsTrue)
+}
+
+func (s *stateSuite) TestIsControllerCharmWithNoControllerCharm(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	id := charmtesting.GenCharmID(c)
+
+	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `INSERT INTO charm (uuid, name) VALUES (?, 'ubuntu')`, id.String())
+		c.Assert(err, jc.ErrorIsNil)
+		return nil
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	result, err := st.IsControllerCharm(context.Background(), id)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(result, jc.IsFalse)
+}
+
+func (s *stateSuite) TestIsSubordinateCharmWithNoCharm(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	id := charmtesting.GenCharmID(c)
+
+	_, err := st.IsSubordinateCharm(context.Background(), id)
+	c.Assert(err, jc.ErrorIs, charmerrors.NotFound)
+}
+
+func (s *stateSuite) TestIsSubordinateCharmWithSubordinateCharm(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	id := charmtesting.GenCharmID(c)
+
+	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `INSERT INTO charm (uuid, subordinate) VALUES (?, true)`, id.String())
+		c.Assert(err, jc.ErrorIsNil)
+		return nil
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	result, err := st.IsSubordinateCharm(context.Background(), id)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(result, jc.IsTrue)
+}
+
+func (s *stateSuite) TestIsSubordinateCharmWithNoSubordinateCharm(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	id := charmtesting.GenCharmID(c)
+
+	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `INSERT INTO charm (uuid, subordinate) VALUES (?, false)`, id.String())
+		c.Assert(err, jc.ErrorIsNil)
+		return nil
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	result, err := st.IsSubordinateCharm(context.Background(), id)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(result, jc.IsFalse)
+}
+
+func (s *stateSuite) TestSupportsContainersWithNoCharm(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	id := charmtesting.GenCharmID(c)
+
+	_, err := st.SupportsContainers(context.Background(), id)
+	c.Assert(err, jc.ErrorIs, charmerrors.NotFound)
+}
+
+func (s *stateSuite) TestSupportsContainersWithContainers(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	id := charmtesting.GenCharmID(c)
+
+	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `INSERT INTO charm (uuid, name) VALUES (?, 'ubuntu')`, id.String())
+		c.Assert(err, jc.ErrorIsNil)
+
+		_, err = tx.ExecContext(ctx, `INSERT INTO charm_container (charm_uuid, name) VALUES (?, 'ubuntu@22.04')`, id.String())
+		c.Assert(err, jc.ErrorIsNil)
+
+		_, err = tx.ExecContext(ctx, `INSERT INTO charm_container (charm_uuid, name) VALUES (?, 'ubuntu@20.04')`, id.String())
+		c.Assert(err, jc.ErrorIsNil)
+		return nil
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	result, err := st.SupportsContainers(context.Background(), id)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(result, jc.IsTrue)
+}
+
+func (s *stateSuite) TestSupportsContainersWithNoContainers(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	id := charmtesting.GenCharmID(c)
+
+	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `INSERT INTO charm (uuid, subordinate) VALUES (?, 'ubuntu')`, id.String())
+		c.Assert(err, jc.ErrorIsNil)
+		return nil
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	result, err := st.SupportsContainers(context.Background(), id)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(result, jc.IsFalse)
+}
+
+func (s *stateSuite) TestIsCharmAvailableWithNoCharm(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	id := charmtesting.GenCharmID(c)
+
+	_, err := st.IsCharmAvailable(context.Background(), id)
+	c.Assert(err, jc.ErrorIs, charmerrors.NotFound)
+}
+
+func (s *stateSuite) TestIsCharmAvailableWithAvailable(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	id := charmtesting.GenCharmID(c)
+
+	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `INSERT INTO charm (uuid, name) VALUES (?, 'ubuntu')`, id.String())
+		c.Assert(err, jc.ErrorIsNil)
+
+		_, err = tx.ExecContext(ctx, `INSERT INTO charm_state (charm_uuid, available) VALUES (?, true)`, id.String())
+		c.Assert(err, jc.ErrorIsNil)
+		return nil
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	result, err := st.IsCharmAvailable(context.Background(), id)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(result, jc.IsTrue)
+}
+
+func (s *stateSuite) TestIsCharmAvailableWithNotAvailable(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	id := charmtesting.GenCharmID(c)
+
+	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `INSERT INTO charm (uuid, subordinate) VALUES (?, 'ubuntu')`, id.String())
+		c.Assert(err, jc.ErrorIsNil)
+
+		_, err = tx.ExecContext(ctx, `INSERT INTO charm_state (charm_uuid, available) VALUES (?, false)`, id.String())
+		c.Assert(err, jc.ErrorIsNil)
+		return nil
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	result, err := st.IsCharmAvailable(context.Background(), id)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(result, jc.IsFalse)
+}
+
+func (s *stateSuite) TestSetCharmAvailableWithNoCharm(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	id := charmtesting.GenCharmID(c)
+
+	err := st.SetCharmAvailable(context.Background(), id)
+	c.Assert(err, jc.ErrorIs, charmerrors.NotFound)
+}
+
+func (s *stateSuite) TestSetCharmAvailable(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	id := charmtesting.GenCharmID(c)
+
+	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `INSERT INTO charm (uuid, name) VALUES (?, 'ubuntu')`, id.String())
+		c.Assert(err, jc.ErrorIsNil)
+
+		_, err = tx.ExecContext(ctx, `INSERT INTO charm_state (charm_uuid, available) VALUES (?, false)`, id.String())
+		c.Assert(err, jc.ErrorIsNil)
+		return nil
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	result, err := st.IsCharmAvailable(context.Background(), id)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(result, jc.IsFalse)
+
+	err = st.SetCharmAvailable(context.Background(), id)
+	c.Assert(err, jc.ErrorIsNil)
+
+	result, err = st.IsCharmAvailable(context.Background(), id)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(result, jc.IsTrue)
+}
+
+func (s *stateSuite) TestReserveCharmRevisionWithNoCharm(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	id := charmtesting.GenCharmID(c)
+
+	_, err := st.ReserveCharmRevision(context.Background(), id, 1)
+	c.Assert(err, jc.ErrorIs, charmerrors.NotFound)
+}
+
+func (s *stateSuite) TestReserveCharmRevision(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	id := charmtesting.GenCharmID(c)
+
+	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `INSERT INTO charm (uuid, name, run_as_id) VALUES (?, 'ubuntu', 0)`, id.String())
+		c.Assert(err, jc.ErrorIsNil)
+
+		_, err = tx.ExecContext(ctx, `INSERT INTO charm_state (charm_uuid, available) VALUES (?, false)`, id.String())
+		c.Assert(err, jc.ErrorIsNil)
+		return nil
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	newID, err := st.ReserveCharmRevision(context.Background(), id, 1)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(newID, gc.Not(gc.DeepEquals), id)
+
+	// Ensure that the new charm is usable, although should not be available.
+	result, err := st.IsCharmAvailable(context.Background(), newID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(result, jc.IsFalse)
+}

--- a/domain/charm/state/types.go
+++ b/domain/charm/state/types.go
@@ -38,12 +38,6 @@ type charmIDName struct {
 	Name string `db:"name"`
 }
 
-// charmState is used to get the state of a charm.
-type charmState struct {
-	CharmUUID string `db:"charm_uuid"`
-	Available bool   `db:"available"`
-}
-
 // charmMetadata is used to get the metadata of a charm.
 type charmMetadata struct {
 	Name           string `db:"name"`

--- a/domain/charm/state/types.go
+++ b/domain/charm/state/types.go
@@ -1,0 +1,50 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+// These structs represent the persistent charm schema in the database.
+
+// charmID represents a single charm row from the charm table, that only
+// contains the charm id.
+type charmID struct {
+	UUID string `db:"uuid"`
+}
+
+// charmName is used to pass the name to the query.
+type charmName struct {
+	Name string `db:"name"`
+}
+
+// charmNameRevision is used to pass the name and revision to the query.
+type charmNameRevision struct {
+	Name     string `db:"name"`
+	Revision int    `db:"revision"`
+}
+
+// charmAvailable is used to get the available status of a charm.
+type charmAvailable struct {
+	Available bool `db:"available"`
+}
+
+// charmSubordinate is used to get the subordinate status of a charm.
+type charmSubordinate struct {
+	Subordinate bool `db:"subordinate"`
+}
+
+type charm struct {
+	UUID           string `db:"uuid"`
+	Name           string `db:"name"`
+	Summary        string `db:"summary"`
+	Description    string `db:"description"`
+	Subordinate    bool   `db:"subordinate"`
+	MinJujuVersion string `db:"min_juju_version"`
+	RunAsID        string `db:"run_as_id"`
+	Assumes        []byte `db:"assumes"`
+	LXDProfile     []byte `db:"lxd_profile"`
+}
+
+type charmState struct {
+	CharmUUID string `db:"charm_uuid"`
+	Available bool   `db:"available"`
+}

--- a/domain/charm/state/types.go
+++ b/domain/charm/state/types.go
@@ -44,6 +44,7 @@ type charmState struct {
 	Available bool   `db:"available"`
 }
 
+// charmMetadata is used to get the metadata of a charm.
 type charmMetadata struct {
 	Name           string `db:"name"`
 	Summary        string `db:"summary"`
@@ -54,21 +55,28 @@ type charmMetadata struct {
 	RunAs          string `db:"run_as"`
 }
 
+// charmTag is used to get the tags of a charm.
+// This is a row based struct that is normalised form of an array of strings.
 type charmTag struct {
 	CharmUUID string `db:"charm_uuid"`
 	Tag       string `db:"value"`
 }
 
+// charmCategory is used to get the categories of a charm.
+// This is a row based struct that is normalised form of an array of strings.
 type charmCategory struct {
 	CharmUUID string `db:"charm_uuid"`
 	Category  string `db:"value"`
 }
 
+// charmTerm is used to get the terms of a charm.
+// This is a row based struct that is normalised form of an array of strings.
 type charmTerm struct {
 	CharmUUID string `db:"charm_uuid"`
 	Term      string `db:"value"`
 }
 
+// charmRelation is used to get the relations of a charm.
 type charmRelation struct {
 	CharmUUID string `db:"charm_uuid"`
 	Kind      string `db:"kind"`
@@ -81,12 +89,16 @@ type charmRelation struct {
 	Scope     string `db:"scope"`
 }
 
+// charmExtraBinding is used to get the extra bindings of a charm.
 type charmExtraBinding struct {
 	CharmUUID string `db:"charm_uuid"`
 	Key       string `db:"key"`
 	Name      string `db:"name"`
 }
 
+// charmStorage is used to get the storage of a charm.
+// This is a row based struct that is normalised form of an array of strings
+// for the property field.
 type charmStorage struct {
 	CharmUUID   string `db:"charm_uuid"`
 	Key         string `db:"key"`
@@ -102,6 +114,7 @@ type charmStorage struct {
 	Property    string `db:"property"`
 }
 
+// charmDevice is used to get the devices of a charm.
 type charmDevice struct {
 	CharmUUID   string `db:"charm_uuid"`
 	Key         string `db:"key"`
@@ -112,6 +125,7 @@ type charmDevice struct {
 	CountMax    int64  `db:"count_max"`
 }
 
+// charmPayload is used to get the payload of a charm.
 type charmPayload struct {
 	CharmUUID string `db:"charm_uuid"`
 	Key       string `db:"key"`
@@ -119,6 +133,7 @@ type charmPayload struct {
 	Type      string `db:"type"`
 }
 
+// charmResource is used to get the resources of a charm.
 type charmResource struct {
 	CharmUUID   string `db:"charm_uuid"`
 	Key         string `db:"key"`

--- a/domain/charm/state/types.go
+++ b/domain/charm/state/types.go
@@ -6,7 +6,7 @@ package state
 // These structs represent the persistent charm schema in the database.
 
 // charmID represents a single charm row from the charm table, that only
-// contains the charm id.
+// contains the charm ID.
 type charmID struct {
 	UUID string `db:"uuid"`
 }
@@ -32,19 +32,108 @@ type charmSubordinate struct {
 	Subordinate bool `db:"subordinate"`
 }
 
-type charm struct {
-	UUID           string `db:"uuid"`
+// charmIDName is used to get the ID and name of a charm.
+type charmIDName struct {
+	UUID string `db:"uuid"`
+	Name string `db:"name"`
+}
+
+// charmState is used to get the state of a charm.
+type charmState struct {
+	CharmUUID string `db:"charm_uuid"`
+	Available bool   `db:"available"`
+}
+
+type charmMetadata struct {
 	Name           string `db:"name"`
 	Summary        string `db:"summary"`
 	Description    string `db:"description"`
 	Subordinate    bool   `db:"subordinate"`
 	MinJujuVersion string `db:"min_juju_version"`
-	RunAsID        string `db:"run_as_id"`
 	Assumes        []byte `db:"assumes"`
-	LXDProfile     []byte `db:"lxd_profile"`
+	RunAs          string `db:"run_as"`
 }
 
-type charmState struct {
+type charmTag struct {
 	CharmUUID string `db:"charm_uuid"`
-	Available bool   `db:"available"`
+	Tag       string `db:"value"`
+}
+
+type charmCategory struct {
+	CharmUUID string `db:"charm_uuid"`
+	Category  string `db:"value"`
+}
+
+type charmTerm struct {
+	CharmUUID string `db:"charm_uuid"`
+	Term      string `db:"value"`
+}
+
+type charmRelation struct {
+	CharmUUID string `db:"charm_uuid"`
+	Kind      string `db:"kind"`
+	Key       string `db:"key"`
+	Name      string `db:"name"`
+	Role      string `db:"role"`
+	Interface string `db:"interface"`
+	Optional  bool   `db:"optional"`
+	Capacity  int    `db:"capacity"`
+	Scope     string `db:"scope"`
+}
+
+type charmExtraBinding struct {
+	CharmUUID string `db:"charm_uuid"`
+	Key       string `db:"key"`
+	Name      string `db:"name"`
+}
+
+type charmStorage struct {
+	CharmUUID   string `db:"charm_uuid"`
+	Key         string `db:"key"`
+	Name        string `db:"name"`
+	Description string `db:"description"`
+	Kind        string `db:"kind"`
+	Shared      bool   `db:"shared"`
+	ReadOnly    bool   `db:"read_only"`
+	CountMin    int    `db:"count_min"`
+	CountMax    int    `db:"count_max"`
+	MinimumSize uint64 `db:"minimum_size_mib"`
+	Location    string `db:"location"`
+	Property    string `db:"property"`
+}
+
+type charmDevice struct {
+	CharmUUID   string `db:"charm_uuid"`
+	Key         string `db:"key"`
+	Name        string `db:"name"`
+	Description string `db:"description"`
+	DeviceType  string `db:"device_type"`
+	CountMin    int64  `db:"count_min"`
+	CountMax    int64  `db:"count_max"`
+}
+
+type charmPayload struct {
+	CharmUUID string `db:"charm_uuid"`
+	Key       string `db:"key"`
+	Name      string `db:"name"`
+	Type      string `db:"type"`
+}
+
+type charmResource struct {
+	CharmUUID   string `db:"charm_uuid"`
+	Key         string `db:"key"`
+	Name        string `db:"name"`
+	Kind        string `db:"kind"`
+	Path        string `db:"path"`
+	Description string `db:"description"`
+}
+
+type charmContainer struct {
+	CharmUUID string `db:"charm_uuid"`
+	Key       string `db:"key"`
+	Resource  string `db:"resource"`
+	Uid       int    `db:"uid"`
+	Gid       int    `db:"gid"`
+	Storage   string `db:"storage"`
+	Location  string `db:"location"`
 }

--- a/domain/charm/types.go
+++ b/domain/charm/types.go
@@ -103,6 +103,7 @@ const (
 // Relation represents a single relation defined in the charm
 // metadata.yaml file.
 type Relation struct {
+	Key       string
 	Name      string
 	Role      RelationRole
 	Interface string

--- a/domain/schema/model/sql/0011-storage.sql
+++ b/domain/schema/model/sql/0011-storage.sql
@@ -43,7 +43,7 @@ INSERT INTO storage_kind VALUES
 CREATE TABLE application_storage_directive (
     application_uuid TEXT NOT NULL,
     charm_uuid TEXT NOT NULL,
-    storage_name TEXT NOT NULL,
+    storage_key TEXT NOT NULL,
     -- These attributes are filled in by sourcing data from:
     -- user supplied, model config, charm config, opinionated fallbacks.
     -- By the time the row is written, all values are known.
@@ -64,9 +64,9 @@ CREATE TABLE application_storage_directive (
     FOREIGN KEY (application_uuid)
     REFERENCES application (uuid),
     CONSTRAINT fk_application_storage_directive_charm_storage
-    FOREIGN KEY (charm_uuid, storage_name)
-    REFERENCES charm_storage (charm_uuid, name),
-    PRIMARY KEY (application_uuid, charm_uuid, storage_name)
+    FOREIGN KEY (charm_uuid, storage_key)
+    REFERENCES charm_storage (charm_uuid, "key"),
+    PRIMARY KEY (application_uuid, charm_uuid, storage_key)
 );
 
 -- Note that this is not unique; it speeds access by application.
@@ -83,7 +83,7 @@ ON application_storage_directive (application_uuid);
 CREATE TABLE unit_storage_directive (
     unit_uuid TEXT NOT NULL,
     charm_uuid TEXT NOT NULL,
-    storage_name TEXT NOT NULL,
+    storage_key TEXT NOT NULL,
     -- These attributes are filled in by sourcing data from:
     -- user supplied, model config, charm config, opinionated fallbacks.
     -- By the time the row is written, all values are known.
@@ -101,9 +101,9 @@ CREATE TABLE unit_storage_directive (
     size INT NOT NULL,
     count INT NOT NULL,
     CONSTRAINT fk_unit_storage_directive_charm_storage
-    FOREIGN KEY (charm_uuid, storage_name)
-    REFERENCES charm_storage (charm_uuid, name),
-    PRIMARY KEY (unit_uuid, charm_uuid, storage_name)
+    FOREIGN KEY (charm_uuid, storage_key)
+    REFERENCES charm_storage (charm_uuid, "key"),
+    PRIMARY KEY (unit_uuid, charm_uuid, storage_key)
 );
 
 -- Note that this is not unique; it speeds access by unit.

--- a/domain/schema/model/sql/0015-charm.sql
+++ b/domain/schema/model/sql/0015-charm.sql
@@ -237,11 +237,12 @@ ON charm_extra_binding (charm_uuid);
 -- by 3rd party stores.
 CREATE TABLE charm_category (
     charm_uuid TEXT NOT NULL,
+    "index" INT NOT NULL,
     value TEXT NOT NULL,
     CONSTRAINT fk_charm_category_charm
     FOREIGN KEY (charm_uuid)
     REFERENCES charm (uuid),
-    PRIMARY KEY (charm_uuid, value)
+    PRIMARY KEY (charm_uuid, "index", value)
 );
 
 CREATE INDEX idx_charm_category_charm
@@ -250,11 +251,12 @@ ON charm_category (charm_uuid);
 -- charm_tag is a free form tag that can be applied to a charm.
 CREATE TABLE charm_tag (
     charm_uuid TEXT NOT NULL,
+    "index" INT NOT NULL,
     value TEXT NOT NULL,
     CONSTRAINT fk_charm_tag_charm
     FOREIGN KEY (charm_uuid)
     REFERENCES charm (uuid),
-    PRIMARY KEY (charm_uuid, value)
+    PRIMARY KEY (charm_uuid, "index", value)
 );
 
 CREATE INDEX idx_charm_tag_charm
@@ -303,6 +305,7 @@ SELECT
     cs.count_max,
     cs.minimum_size_mib,
     cs.location,
+    csp."index" AS property_index,
     csp.value AS property
 FROM charm_storage AS cs
 LEFT JOIN charm_storage_kind AS csk ON cs.storage_kind_id = csk.id
@@ -314,6 +317,7 @@ ON charm_storage (charm_uuid);
 CREATE TABLE charm_storage_property (
     charm_uuid TEXT NOT NULL,
     charm_storage_key TEXT NOT NULL,
+    "index" INT NOT NULL,
     value TEXT NOT NULL,
     CONSTRAINT fk_charm_storage_property_charm
     FOREIGN KEY (charm_uuid)
@@ -321,7 +325,7 @@ CREATE TABLE charm_storage_property (
     CONSTRAINT fk_charm_storage_property_charm_storage
     FOREIGN KEY (charm_uuid, charm_storage_key)
     REFERENCES charm_storage (charm_uuid, "key"),
-    PRIMARY KEY (charm_uuid, charm_storage_key, value)
+    PRIMARY KEY (charm_uuid, charm_storage_key, "index", value)
 );
 
 CREATE INDEX idx_charm_storage_property_charm
@@ -402,11 +406,12 @@ ON charm_resource (charm_uuid);
 
 CREATE TABLE charm_term (
     charm_uuid TEXT NOT NULL,
+    "index" INT NOT NULL,
     value TEXT NOT NULL,
     CONSTRAINT fk_charm_term_charm
     FOREIGN KEY (charm_uuid)
     REFERENCES charm (uuid),
-    PRIMARY KEY (charm_uuid, value)
+    PRIMARY KEY (charm_uuid, "index", value)
 );
 
 CREATE INDEX idx_charm_term_charm

--- a/domain/schema/model/sql/0015-charm.sql
+++ b/domain/schema/model/sql/0015-charm.sql
@@ -19,7 +19,7 @@ CREATE TABLE charm (
     summary TEXT,
     subordinate BOOLEAN DEFAULT FALSE,
     min_juju_version TEXT,
-    run_as_id INT,
+    run_as_id INT DEFAULT 0,
     -- Assumes is a blob of YAML that will be parsed by the charm to compute
     -- the result of the SAT expression.
     -- As the expression tree is generic, you can't use RI or index into the
@@ -30,6 +30,19 @@ CREATE TABLE charm (
     FOREIGN KEY (run_as_id)
     REFERENCES charm_run_as_kind (id)
 );
+
+CREATE VIEW v_charm AS
+SELECT
+    c.uuid,
+    c.name,
+    c.description,
+    c.summary,
+    c.subordinate,
+    c.min_juju_version,
+    crak.name AS run_as,
+    c.assumes
+FROM charm AS c
+LEFT JOIN charm_run_as_kind AS crak ON c.run_as_id = crak.id;
 
 CREATE TABLE charm_channel (
     charm_uuid TEXT NOT NULL,
@@ -164,6 +177,7 @@ INSERT INTO charm_relation_scope VALUES
 CREATE TABLE charm_relation (
     charm_uuid TEXT NOT NULL,
     kind_id TEXT NOT NULL,
+    "key" TEXT NOT NULL,
     name TEXT,
     role_id TEXT,
     interface TEXT,
@@ -182,19 +196,36 @@ CREATE TABLE charm_relation (
     CONSTRAINT fk_charm_relation_scope
     FOREIGN KEY (scope_id)
     REFERENCES charm_relation_scope (id),
-    PRIMARY KEY (charm_uuid, kind_id, name)
+    PRIMARY KEY (charm_uuid, kind_id, "key")
 );
+
+CREATE VIEW v_charm_relation AS
+SELECT
+    cr.charm_uuid,
+    crk.name AS kind,
+    cr."key",
+    cr.name,
+    crr.name AS role,
+    cr.interface,
+    cr.optional,
+    cr.capacity,
+    crs.name AS scope
+FROM charm_relation AS cr
+LEFT JOIN charm_relation_kind AS crk ON cr.kind_id = crk.id
+LEFT JOIN charm_relation_role AS crr ON cr.role_id = crr.id
+LEFT JOIN charm_relation_scope AS crs ON cr.scope_id = crs.id;
 
 CREATE INDEX idx_charm_relation_charm
 ON charm_relation (charm_uuid);
 
 CREATE TABLE charm_extra_binding (
     charm_uuid TEXT NOT NULL,
-    name TEXT NOT NULL,
+    "key" TEXT NOT NULL,
+    name TEXT,
     CONSTRAINT fk_charm_extra_binding_charm
     FOREIGN KEY (charm_uuid)
     REFERENCES charm (uuid),
-    PRIMARY KEY (charm_uuid, name)
+    PRIMARY KEY (charm_uuid, "key", name)
 );
 
 CREATE INDEX idx_charm_extra_binding_charm
@@ -240,7 +271,8 @@ INSERT INTO charm_storage_kind VALUES
 
 CREATE TABLE charm_storage (
     charm_uuid TEXT NOT NULL,
-    name TEXT NOT NULL,
+    "key" TEXT NOT NULL,
+    name TEXT,
     description TEXT,
     storage_kind_id INT NOT NULL,
     shared BOOLEAN,
@@ -255,23 +287,41 @@ CREATE TABLE charm_storage (
     CONSTRAINT fk_charm_storage_charm
     FOREIGN KEY (charm_uuid)
     REFERENCES charm (uuid),
-    PRIMARY KEY (charm_uuid, name)
+    PRIMARY KEY (charm_uuid, "key")
 );
+
+CREATE VIEW v_charm_storage AS
+SELECT
+    cs.charm_uuid,
+    cs."key",
+    cs.name,
+    cs.description,
+    csk.name AS kind,
+    cs.shared,
+    cs.read_only,
+    cs.count_min,
+    cs.count_max,
+    cs.minimum_size_mib,
+    cs.location,
+    csp.value AS property
+FROM charm_storage AS cs
+LEFT JOIN charm_storage_kind AS csk ON cs.storage_kind_id = csk.id
+LEFT JOIN charm_storage_property AS csp ON cs.charm_uuid = csp.charm_uuid AND cs."key" = csp.charm_storage_key;
 
 CREATE INDEX idx_charm_storage_charm
 ON charm_storage (charm_uuid);
 
 CREATE TABLE charm_storage_property (
     charm_uuid TEXT NOT NULL,
-    charm_storage_name TEXT NOT NULL,
-    value TEXT,
+    charm_storage_key TEXT NOT NULL,
+    value TEXT NOT NULL,
     CONSTRAINT fk_charm_storage_property_charm
     FOREIGN KEY (charm_uuid)
     REFERENCES charm (uuid),
     CONSTRAINT fk_charm_storage_property_charm_storage
-    FOREIGN KEY (charm_storage_name)
-    REFERENCES charm_storage (name),
-    PRIMARY KEY (charm_uuid, charm_storage_name, value)
+    FOREIGN KEY (charm_uuid, charm_storage_key)
+    REFERENCES charm_storage (charm_uuid, "key"),
+    PRIMARY KEY (charm_uuid, charm_storage_key, value)
 );
 
 CREATE INDEX idx_charm_storage_property_charm
@@ -279,6 +329,7 @@ ON charm_storage_property (charm_uuid);
 
 CREATE TABLE charm_device (
     charm_uuid TEXT NOT NULL,
+    "key" TEXT NOT NULL,
     name TEXT,
     description TEXT,
     device_type TEXT,
@@ -287,7 +338,7 @@ CREATE TABLE charm_device (
     CONSTRAINT fk_charm_device_charm
     FOREIGN KEY (charm_uuid)
     REFERENCES charm (uuid),
-    PRIMARY KEY (charm_uuid, name)
+    PRIMARY KEY (charm_uuid, "key")
 );
 
 CREATE INDEX idx_charm_device_charm
@@ -295,12 +346,13 @@ ON charm_device (charm_uuid);
 
 CREATE TABLE charm_payload (
     charm_uuid TEXT NOT NULL,
+    "key" TEXT NOT NULL,
     name TEXT,
     type TEXT,
     CONSTRAINT fk_charm_payload_charm
     FOREIGN KEY (charm_uuid)
     REFERENCES charm (uuid),
-    PRIMARY KEY (charm_uuid, name)
+    PRIMARY KEY (charm_uuid, "key")
 );
 
 CREATE INDEX idx_charm_payload_charm
@@ -320,6 +372,7 @@ INSERT INTO charm_resource_kind VALUES
 
 CREATE TABLE charm_resource (
     charm_uuid TEXT NOT NULL,
+    "key" TEXT NOT NULL,
     name TEXT,
     kind_id INT NOT NULL,
     path TEXT,
@@ -330,8 +383,19 @@ CREATE TABLE charm_resource (
     CONSTRAINT fk_charm_resource_charm_resource_kind
     FOREIGN KEY (kind_id)
     REFERENCES charm_resource_kind (id),
-    PRIMARY KEY (charm_uuid, name)
+    PRIMARY KEY (charm_uuid, "key")
 );
+
+CREATE VIEW v_charm_resource AS
+SELECT
+    cr.charm_uuid,
+    cr."key",
+    cr.name,
+    crk.name AS kind,
+    cr.path,
+    cr.description
+FROM charm_resource AS cr
+LEFT JOIN charm_resource_kind AS crk ON cr.kind_id = crk.id;
 
 CREATE INDEX idx_charm_resource_charm
 ON charm_resource (charm_uuid);
@@ -350,7 +414,7 @@ ON charm_term (charm_uuid);
 
 CREATE TABLE charm_container (
     charm_uuid TEXT NOT NULL,
-    name TEXT,
+    "key" TEXT NOT NULL,
     resource TEXT,
     -- Enforce the optional uid and gid to -1 if not set, otherwise the it might
     -- become 0, which happens to be root.
@@ -359,25 +423,38 @@ CREATE TABLE charm_container (
     CONSTRAINT fk_charm_container_charm
     FOREIGN KEY (charm_uuid)
     REFERENCES charm (uuid),
-    PRIMARY KEY (charm_uuid, resource)
+    PRIMARY KEY (charm_uuid, "key")
 );
+
+CREATE VIEW v_charm_container AS
+SELECT
+    cc.charm_uuid,
+    cc."key",
+    cc.resource,
+    cc.uid,
+    cc.gid,
+    ccm."index",
+    ccm.storage,
+    ccm.location
+FROM charm_container AS cc
+LEFT JOIN charm_container_mount AS ccm ON cc.charm_uuid = ccm.charm_uuid AND cc."key" = ccm.charm_container_key;
 
 CREATE INDEX idx_charm_container_charm
 ON charm_container (charm_uuid);
 
 CREATE TABLE charm_container_mount (
+    "index" INT NOT NULL,
     charm_uuid TEXT NOT NULL,
-    charm_container_name TEXT,
-    name TEXT,
+    charm_container_key TEXT,
     storage TEXT,
     location TEXT,
     CONSTRAINT fk_charm_container_mount_charm
     FOREIGN KEY (charm_uuid)
     REFERENCES charm (uuid),
     CONSTRAINT fk_charm_container_mount_charm_container
-    FOREIGN KEY (charm_container_name)
-    REFERENCES charm_container (name),
-    PRIMARY KEY (charm_uuid, name)
+    FOREIGN KEY (charm_uuid, charm_container_key)
+    REFERENCES charm_container (charm_uuid, "key"),
+    PRIMARY KEY (charm_uuid, charm_container_key, "index")
 );
 
 CREATE INDEX idx_charm_container_mount_charm

--- a/domain/schema/model/sql/0015-charm.sql
+++ b/domain/schema/model/sql/0015-charm.sql
@@ -42,9 +42,6 @@ CREATE TABLE charm_channel (
     PRIMARY KEY (charm_uuid)
 );
 
-CREATE UNIQUE INDEX idx_charm_name
-ON charm (name);
-
 -- The charm_state table exists to store the availability of a charm. The
 -- fact that the charm is in the database indicates that it's a placeholder.
 -- Updating the available flag to true indicates that the charm is now

--- a/domain/schema/schema_test.go
+++ b/domain/schema/schema_test.go
@@ -422,10 +422,12 @@ func (s *schemaSuite) TestModelViews(c *gc.C) {
 
 	// Ensure that each view is present.
 	expected := set.NewStrings(
+		"v_charm",
+		"v_charm_container",
 		"v_charm_relation",
+		"v_charm_resource",
 		"v_charm_storage",
 		"v_charm_url",
-		"v_charm",
 		"v_secret_permission",
 		"v_space_subnet",
 	)

--- a/domain/schema/schema_test.go
+++ b/domain/schema/schema_test.go
@@ -422,7 +422,10 @@ func (s *schemaSuite) TestModelViews(c *gc.C) {
 
 	// Ensure that each view is present.
 	expected := set.NewStrings(
+		"v_charm_relation",
+		"v_charm_storage",
 		"v_charm_url",
+		"v_charm",
 		"v_secret_permission",
 		"v_space_subnet",
 	)

--- a/internal/database/testing/database.go
+++ b/internal/database/testing/database.go
@@ -1,0 +1,50 @@
+// Copyright 2022 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package testing
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+)
+
+func DumpTable(c *gc.C, db *sql.DB, table string) {
+	rows, err := db.Query("SELECT * FROM " + table)
+	c.Assert(err, jc.ErrorIsNil)
+	defer rows.Close()
+
+	cols, err := rows.Columns()
+	c.Assert(err, jc.ErrorIsNil)
+
+	fmt.Fprintln(os.Stdout)
+
+	writer := tabwriter.NewWriter(os.Stdout, 0, 8, 1, '\t', 0)
+	for _, col := range cols {
+		fmt.Fprintf(writer, "%s\t", col)
+	}
+	fmt.Fprintln(writer)
+
+	vals := make([]any, len(cols))
+	for i := range vals {
+		vals[i] = new(any)
+	}
+
+	for rows.Next() {
+		err = rows.Scan(vals...)
+		c.Assert(err, jc.ErrorIsNil)
+
+		for _, val := range vals {
+			fmt.Fprintf(writer, "%v\t", *val.(*any))
+		}
+	}
+	err = rows.Err()
+	c.Assert(err, jc.ErrorIsNil)
+
+	writer.Flush()
+	fmt.Fprintln(os.Stdout)
+}

--- a/internal/database/testing/database.go
+++ b/internal/database/testing/database.go
@@ -13,6 +13,9 @@ import (
 	gc "gopkg.in/check.v1"
 )
 
+// DumpTable dumps the contents of the given table to stdout.
+// This is useful for debugging tests. It is not intended for use
+// in production code.
 func DumpTable(c *gc.C, db *sql.DB, table string) {
 	rows, err := db.Query("SELECT * FROM " + table)
 	c.Assert(err, jc.ErrorIsNil)

--- a/internal/database/testing/notest.go
+++ b/internal/database/testing/notest.go
@@ -1,0 +1,22 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+//go:build notest
+
+package testing
+
+import (
+	_ "unsafe"
+)
+
+// Dear Reader,
+// You have found your way here because you imported github.com/juju/juju/internal/database/testing
+// into code that found its way into a non-test binary.
+// This is bad. Please don't use test code inside a juju binary.
+
+//go:linkname do_not_import_test_code_into_juju
+func do_not_import_test_code_into_juju()
+
+func init() {
+	do_not_import_test_code_into_juju()
+}


### PR DESCRIPTION
The change set adds simple getter and setter methods, along with getting the charm metadata. Getting the charm metadata from the database is quite involved. We have to select from a lot of tables to populate the metadata. This is really wasteful if the code only wants the relations. It is also not time efficient to get all the metadata as row based type. If a charm metadata is fully populated it could result in thousands of rows to populate. Having spoken with others, it was then decided to not use row-based requests for getting metadata. Instead, we'll fallback to multiple selects.
The advantage of doing it this way is that we can reuse the individual methods to expose calls to get just relations or
storage.

There is a potential problem with arrays. Duplicates of values are possible in the charm metadata and we don't prevent that in any part of the library. Also, tables are sets of rows, not ordered rows based on insertion time. The solution was to keep a tracking index column that ensures that we preserve the insertion order and that we use that as the unique key.

Unfortunately, I ran into a sqlair bug[1], so had to change tack and ensure that we could get the right information out that we wanted. This meant that we stuck to the error conditions. If the charm doesn't exist we return NotFound, rather than the default case.

Actions, config, manifest, and LXD profiles will be added in a future PR, as this is already getting difficult to review in one patch.


 1. https://github.com/canonical/sqlair/issues/154

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

The schema should apply nicely.

Regression tests around bootstrap and deployment should be done.

```sh
$ juju bootstrap lxd test --build-agent
$ juju add-model default
$ juju deploy ubuntu
```

## Links

**Jira card:** [JUJU-6015](https://warthogs.atlassian.net/browse/JUJU-6015)



[JUJU-6015]: https://warthogs.atlassian.net/browse/JUJU-6015?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ