### PR TITLE
chore: merge 3.6 into main

### DIFF
--- a/.github/workflows/gen.yml
+++ b/.github/workflows/gen.yml
@@ -51,7 +51,7 @@ jobs:
           #  3. Unique every file, so we only go generate the file once.
           #  4. Using xargs perform go generate in parallel.
           #
-          grep -ir "//go:generate" . | awk -F : '{ print $1 }' | uniq | xargs -n 1 -P 8 -I% go generate -x $(realpath %)
+          grep -ir "//go:generate" --include '*.go' . | awk -F : '{ print $1 }' | uniq | xargs -n 1 -P 8 -I% go generate -x $(realpath %)
 
       - name: "Check diff"
         if: success() || failure()

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,12 +51,12 @@ that Go versions are not incremented during a release cycle. Check the `go.mod`
 file at the root of the project for the targeted version of Go, as this is
 authoritative.
 
-For example, the following indicates that Go 1.21 is targeted:
+For example, the following indicates that Go 1.22 is targeted:
 
 ```
 module github.com/juju/juju
 
-go 1.21.3
+go 1.22.2
 ```
 
 ### Official distribution

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/juju/juju
 
-go 1.21.6
+go 1.22.4
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.12.0

--- a/scripts/schemadocs/schemadocs.go
+++ b/scripts/schemadocs/schemadocs.go
@@ -303,7 +303,7 @@ nav, main, footer {
 	{{end}}
 </main>
 <footer class="page-footer docs-footer">
-© 2019 Canonical Ltd
+© Copyright © 2024 CC-BY-SA, Canonical Ltd
 </footer>
 </body>
 </html>

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -393,7 +393,7 @@ parts:
     after:
       - libdqlite
     plugin: juju-go
-    go-channel: 1.21/stable
+    go-channel: 1.22/stable
     source: .
     go-packages:
       - github.com/juju/juju/cmd/jujud-controller
@@ -417,7 +417,7 @@ parts:
     after:
       - jujud
     plugin: juju-go
-    go-channel: 1.21/stable
+    go-channel: 1.22/stable
     # The source can be your local tree or github
     # source: https://github.com/juju/juju.git
     # If you pull a remote, set source-depth to 1 to make the fetch shorter


### PR DESCRIPTION
Merge 3.6 into main.

The only conflict was the go version `go 1.21.6` -> `go 1.22.4`.