### PR TITLE
feat(dqlite): add IsController service on machine domain

### DIFF
--- a/domain/machine/service/package_mock_test.go
+++ b/domain/machine/service/package_mock_test.go
@@ -428,6 +428,45 @@ func (c *MockStateInstanceStatusCall) DoAndReturn(f func(context.Context, machin
 	return c
 }
 
+// IsController mocks base method.
+func (m *MockState) IsController(arg0 context.Context, arg1 machine.Name) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsController", arg0, arg1)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IsController indicates an expected call of IsController.
+func (mr *MockStateMockRecorder) IsController(arg0, arg1 any) *MockStateIsControllerCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsController", reflect.TypeOf((*MockState)(nil).IsController), arg0, arg1)
+	return &MockStateIsControllerCall{Call: call}
+}
+
+// MockStateIsControllerCall wrap *gomock.Call
+type MockStateIsControllerCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateIsControllerCall) Return(arg0 bool, arg1 error) *MockStateIsControllerCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateIsControllerCall) Do(f func(context.Context, machine.Name) (bool, error)) *MockStateIsControllerCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateIsControllerCall) DoAndReturn(f func(context.Context, machine.Name) (bool, error)) *MockStateIsControllerCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // IsMachineRebootRequired mocks base method.
 func (m *MockState) IsMachineRebootRequired(arg0 context.Context, arg1 string) (bool, error) {
 	m.ctrl.T.Helper()

--- a/domain/machine/state/state.go
+++ b/domain/machine/state/state.go
@@ -248,7 +248,7 @@ func (st *State) AllMachineNames(ctx context.Context) ([]machine.Name, error) {
 	}
 
 	// Transform the results ([]machineName) into a slice of machine.Name.
-	machineNames := transform.Slice[machineName, machine.Name](results, func(r machineName) machine.Name { return machine.Name(r.Name) })
+	machineNames := transform.Slice[machineName, machine.Name](results, func(r machineName) machine.Name { return r.Name })
 
 	return machineNames, nil
 }

--- a/domain/machine/state/state.go
+++ b/domain/machine/state/state.go
@@ -96,21 +96,20 @@ VALUES ($M.machine_uuid, $M.net_node_uuid, $M.name, $M.life_id)
 
 // DeleteMachine deletes the specified machine and any dependent child records.
 // TODO - this just deals with child block devices for now.
-func (st *State) DeleteMachine(ctx context.Context, machineName machine.Name) error {
+func (st *State) DeleteMachine(ctx context.Context, mName machine.Name) error {
 	db, err := st.DB()
 	if err != nil {
 		return errors.Trace(err)
 	}
 
-	machineNameParam := sqlair.M{"name": machineName}
-
-	queryMachine := `SELECT uuid AS &machineUUID.* FROM machine WHERE name = $M.name`
+	machineNameParam := machineName{Name: mName}
+	queryMachine := `SELECT uuid AS &machineUUID.* FROM machine WHERE name = $machineName.name`
 	queryMachineStmt, err := st.Prepare(queryMachine, machineNameParam, machineUUID{})
 	if err != nil {
 		return errors.Trace(err)
 	}
 
-	deleteMachine := `DELETE FROM machine WHERE name = $M.name`
+	deleteMachine := `DELETE FROM machine WHERE name = $machineName.name`
 	deleteMachineStmt, err := st.Prepare(deleteMachine, machineNameParam)
 	if err != nil {
 		return errors.Trace(err)
@@ -118,7 +117,7 @@ func (st *State) DeleteMachine(ctx context.Context, machineName machine.Name) er
 
 	deleteNode := `
 DELETE FROM net_node WHERE uuid IN
-(SELECT net_node_uuid FROM machine WHERE name = $M.name) 
+(SELECT net_node_uuid FROM machine WHERE name = $machineName.name)
 `
 	deleteNodeStmt, err := st.Prepare(deleteNode, machineNameParam)
 	if err != nil {
@@ -133,25 +132,25 @@ DELETE FROM net_node WHERE uuid IN
 			return nil
 		}
 		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-			return errors.Annotatef(err, "looking up UUID for machine %q", machineName)
+			return errors.Annotatef(err, "looking up UUID for machine %q", mName)
 		}
 
 		machineUUID := result.UUID
 
 		if err := blockdevice.RemoveMachineBlockDevices(ctx, tx, machineUUID); err != nil {
-			return errors.Annotatef(err, "deleting block devices for machine %q", machineName)
+			return errors.Annotatef(err, "deleting block devices for machine %q", mName)
 		}
 
 		if err := tx.Query(ctx, deleteMachineStmt, machineNameParam).Run(); err != nil {
-			return errors.Annotatef(err, "deleting machine %q", machineName)
+			return errors.Annotatef(err, "deleting machine %q", mName)
 		}
 		if err := tx.Query(ctx, deleteNodeStmt, machineNameParam).Run(); err != nil {
-			return errors.Annotatef(err, "deleting net node for machine  %q", machineName)
+			return errors.Annotatef(err, "deleting net node for machine  %q", mName)
 		}
 
 		return nil
 	})
-	return errors.Annotatef(err, "deleting machine %q", machineName)
+	return errors.Annotatef(err, "deleting machine %q", mName)
 }
 
 // InitialWatchStatement returns the table and the initial watch statement
@@ -162,14 +161,14 @@ func (s *State) InitialWatchStatement() (string, string) {
 
 // GetMachineLife returns the life status of the specified machine.
 // It returns a NotFound if the given machine doesn't exist.
-func (st *State) GetMachineLife(ctx context.Context, machineName machine.Name) (*life.Life, error) {
+func (st *State) GetMachineLife(ctx context.Context, mName machine.Name) (*life.Life, error) {
 	db, err := st.DB()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
-	machineNameParam := sqlair.M{"name": machineName}
-	queryForLife := `SELECT life_id as &machineLife.life_id FROM machine WHERE name = $M.name`
+	machineNameParam := machineName{Name: mName}
+	queryForLife := `SELECT life_id as &machineLife.life_id FROM machine WHERE name = $machineName.name`
 	lifeStmt, err := st.Prepare(queryForLife, machineNameParam, machineLife{})
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -180,7 +179,7 @@ func (st *State) GetMachineLife(ctx context.Context, machineName machine.Name) (
 		result := machineLife{}
 		err := tx.Query(ctx, lifeStmt, machineNameParam).Get(&result)
 		if err != nil {
-			return errors.Annotatef(err, "looking up life for machine %q", machineName)
+			return errors.Annotatef(err, "looking up life for machine %q", mName)
 		}
 
 		lifeResult = result.ID
@@ -189,22 +188,22 @@ func (st *State) GetMachineLife(ctx context.Context, machineName machine.Name) (
 	})
 
 	if err != nil && errors.Is(err, sqlair.ErrNoRows) {
-		return nil, errors.NotFoundf("machine %q", machineName)
+		return nil, errors.NotFoundf("machine %q", mName)
 	}
 
-	return &lifeResult, errors.Annotatef(err, "getting life status for machines %q", machineName)
+	return &lifeResult, errors.Annotatef(err, "getting life status for machines %q", mName)
 }
 
 // IsController returns whether the machine is a controller machine.
 // It returns a NotFound if the given machine doesn't exist.
-func (st *State) IsController(ctx context.Context, machineName machine.Name) (bool, error) {
+func (st *State) IsController(ctx context.Context, mName machine.Name) (bool, error) {
 	db, err := st.DB()
 	if err != nil {
 		return false, errors.Trace(err)
 	}
 
-	machineNameParam := sqlair.M{"name": machineName}
-	query := `SELECT is_controller AS &machineIsController.is_controller FROM machine WHERE name = $M.name`
+	machineNameParam := machineName{Name: mName}
+	query := `SELECT is_controller AS &machineIsController.is_controller FROM machine WHERE name = $machineName.name`
 	queryStmt, err := st.Prepare(query, machineNameParam, machineIsController{})
 	if err != nil {
 		return false, errors.Trace(err)
@@ -215,16 +214,16 @@ func (st *State) IsController(ctx context.Context, machineName machine.Name) (bo
 		result := machineIsController{}
 		err := tx.Query(ctx, queryStmt, machineNameParam).Get(&result)
 		if err != nil {
-			return errors.Annotatef(err, "querying if machine %q is a controller", machineName)
+			return errors.Annotatef(err, "querying if machine %q is a controller", mName)
 		}
 		isController = result.IsController
 		return nil
 	})
 	if err != nil && errors.Is(err, sqlair.ErrNoRows) {
-		return false, errors.NotFoundf("machine %q", machineName)
+		return false, errors.NotFoundf("machine %q", mName)
 	}
 
-	return isController, errors.Annotatef(err, "checking if machine %q is a controller", machineName)
+	return isController, errors.Annotatef(err, "checking if machine %q is a controller", mName)
 }
 
 // AllMachineNames retrieves the names of all machines in the model.

--- a/domain/machine/state/types.go
+++ b/domain/machine/state/types.go
@@ -5,6 +5,7 @@ package state
 
 import (
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/machine"
 	"github.com/juju/juju/domain/life"
 )
 
@@ -69,7 +70,7 @@ type instanceID struct {
 // machineName represents the struct to be used for the name column
 // within the sqlair statements in the machine domain.
 type machineName struct {
-	Name string `db:"name"`
+	Name machine.Name `db:"name"`
 }
 
 // machineUUID represents the struct to be used for the machine_uuid column

--- a/domain/machine/state/types.go
+++ b/domain/machine/state/types.go
@@ -77,3 +77,8 @@ type machineName struct {
 type machineUUID struct {
 	UUID string `db:"uuid"`
 }
+
+// machineIsController represents the struct to be used for the is_controller column within the sqlair statements in the machine domain.
+type machineIsController struct {
+	IsController bool `db:"is_controller"`
+}


### PR DESCRIPTION
Adds the `IsController` service function in the machine domain.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```
TEST_PACKAGES="./domain/machine/... -count=1 -race" make run-go-tests
```