### PR TITLE
docs: title should be `Command 'juju <name>'`

### DIFF
--- a/scripts/discourse-sync/main.py
+++ b/scripts/discourse-sync/main.py
@@ -247,7 +247,7 @@ def removesuffix(text, suffix):
 def post_title(doc_name: str) -> str:
     if doc_name == 'index':
         return 'Juju CLI commands'
-    return f"Command '{doc_name}'"
+    return f"Command 'juju {doc_name}'"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Why this change is needed and what it does. -->

Per @tmihoc's request, generated CLI reference docs should be titled e.g. `Command 'juju bootstrap'` instead of `Command 'bootstrap'`.

I have already run a custom Python script to update the existing docs. This PR just modifies the default title provided by the `discourse-sync` script, so that new command docs created using `python3 ./scripts/discourse-sync/main.py create <doc-name>` will have the correct title.