### PR TITLE
fix: go version should not include patch level

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ For example, the following indicates that Go 1.22 is targeted:
 ```
 module github.com/juju/juju
 
-go 1.22.2
+go 1.22
 ```
 
 ### Official distribution

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/juju/juju
 
-go 1.22.4
+go 1.22
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.12.0

--- a/scripts/juju-mongotop/go.mod
+++ b/scripts/juju-mongotop/go.mod
@@ -1,6 +1,6 @@
 module github.com/juju/juju/scripts/juju-mongotop
 
-go 1.20
+go 1.22
 
 require github.com/olekukonko/tablewriter v0.0.5
 


### PR DESCRIPTION
A recent [patch](https://github.com/juju/juju/pull/17633) changed go mod to specify `1.22.4`.
This just needs to be major.minor, so currently `1.22`

## QA steps

unit tests

