### PR TITLE
test: fixes secretexpire worker tests by using Alarm not Timer.

### DIFF
--- a/cmd/output/progress/mocks/clock_mock.go
+++ b/cmd/output/progress/mocks/clock_mock.go
@@ -68,6 +68,48 @@ func (mr *MockClockMockRecorder) AfterFunc(arg0, arg1 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AfterFunc", reflect.TypeOf((*MockClock)(nil).AfterFunc), arg0, arg1)
 }
 
+// At mocks base method.
+func (m *MockClock) At(arg0 time.Time) <-chan time.Time {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "At", arg0)
+	ret0, _ := ret[0].(<-chan time.Time)
+	return ret0
+}
+
+// At indicates an expected call of At.
+func (mr *MockClockMockRecorder) At(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "At", reflect.TypeOf((*MockClock)(nil).At), arg0)
+}
+
+// AtFunc mocks base method.
+func (m *MockClock) AtFunc(arg0 time.Time, arg1 func()) clock.Alarm {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AtFunc", arg0, arg1)
+	ret0, _ := ret[0].(clock.Alarm)
+	return ret0
+}
+
+// AtFunc indicates an expected call of AtFunc.
+func (mr *MockClockMockRecorder) AtFunc(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AtFunc", reflect.TypeOf((*MockClock)(nil).AtFunc), arg0, arg1)
+}
+
+// NewAlarm mocks base method.
+func (m *MockClock) NewAlarm(arg0 time.Time) clock.Alarm {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NewAlarm", arg0)
+	ret0, _ := ret[0].(clock.Alarm)
+	return ret0
+}
+
+// NewAlarm indicates an expected call of NewAlarm.
+func (mr *MockClockMockRecorder) NewAlarm(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewAlarm", reflect.TypeOf((*MockClock)(nil).NewAlarm), arg0)
+}
+
 // NewTimer mocks base method.
 func (m *MockClock) NewTimer(arg0 time.Duration) clock.Timer {
 	m.ctrl.T.Helper()

--- a/container/lxd/mocks/clock_mock.go
+++ b/container/lxd/mocks/clock_mock.go
@@ -68,6 +68,48 @@ func (mr *MockClockMockRecorder) AfterFunc(arg0, arg1 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AfterFunc", reflect.TypeOf((*MockClock)(nil).AfterFunc), arg0, arg1)
 }
 
+// At mocks base method.
+func (m *MockClock) At(arg0 time.Time) <-chan time.Time {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "At", arg0)
+	ret0, _ := ret[0].(<-chan time.Time)
+	return ret0
+}
+
+// At indicates an expected call of At.
+func (mr *MockClockMockRecorder) At(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "At", reflect.TypeOf((*MockClock)(nil).At), arg0)
+}
+
+// AtFunc mocks base method.
+func (m *MockClock) AtFunc(arg0 time.Time, arg1 func()) clock.Alarm {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AtFunc", arg0, arg1)
+	ret0, _ := ret[0].(clock.Alarm)
+	return ret0
+}
+
+// AtFunc indicates an expected call of AtFunc.
+func (mr *MockClockMockRecorder) AtFunc(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AtFunc", reflect.TypeOf((*MockClock)(nil).AtFunc), arg0, arg1)
+}
+
+// NewAlarm mocks base method.
+func (m *MockClock) NewAlarm(arg0 time.Time) clock.Alarm {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NewAlarm", arg0)
+	ret0, _ := ret[0].(clock.Alarm)
+	return ret0
+}
+
+// NewAlarm indicates an expected call of NewAlarm.
+func (mr *MockClockMockRecorder) NewAlarm(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewAlarm", reflect.TypeOf((*MockClock)(nil).NewAlarm), arg0)
+}
+
 // NewTimer mocks base method.
 func (m *MockClock) NewTimer(arg0 time.Duration) clock.Timer {
 	m.ctrl.T.Helper()

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/juju/ansiterm v1.0.0
 	github.com/juju/blobstore/v3 v3.0.2
 	github.com/juju/charm/v12 v12.0.0
-	github.com/juju/clock v1.0.3
+	github.com/juju/clock v1.1.1
 	github.com/juju/cmd/v3 v3.0.14
 	github.com/juju/collections v1.0.4
 	github.com/juju/description/v5 v5.0.4

--- a/go.sum
+++ b/go.sum
@@ -475,8 +475,8 @@ github.com/juju/clock v0.0.0-20190205081909-9c5c9712527c/go.mod h1:nD0vlnrUjcjJh
 github.com/juju/clock v0.0.0-20220202072423-1b0f830854c4/go.mod h1:zDZCPSgCJQINeZtQwHx2/cFk4seaBC8Yiqe8V82xiP0=
 github.com/juju/clock v0.0.0-20220203021603-d9deb868a28a/go.mod h1:GZ/FY8Cqw3KHG6DwRVPUKbSPTAwyrU28xFi5cqZnLsc=
 github.com/juju/clock v1.0.0/go.mod h1:GZ/FY8Cqw3KHG6DwRVPUKbSPTAwyrU28xFi5cqZnLsc=
-github.com/juju/clock v1.0.3 h1:yJHIsWXeU8j3QcBdiess09SzfiXRRrsjKPn2whnMeds=
-github.com/juju/clock v1.0.3/go.mod h1:HIBvJ8kiV/n7UHwKuCkdYL4l/MDECztHR2sAvWDxxf0=
+github.com/juju/clock v1.1.1 h1:NvgHG9DQmOpBevgt6gzkyimdWBooLXDy1cQn89qJzBI=
+github.com/juju/clock v1.1.1/go.mod h1:HIBvJ8kiV/n7UHwKuCkdYL4l/MDECztHR2sAvWDxxf0=
 github.com/juju/cmd v0.0.0-20171107070456-e74f39857ca0/go.mod h1:yWJQHl73rdSX4DHVKGqkAip+huBslxRwS8m9CrOLq18=
 github.com/juju/cmd/v3 v3.0.0-20220202061353-b1cc80b193b0/go.mod h1:EoGJiEG+vbMwO9l+Es0SDTlaQPjH6nLcnnc4NfZB3cY=
 github.com/juju/cmd/v3 v3.0.14 h1:KuuamArSH7vQ6SdQKEHYK2scEMkJTEZKLs8abrlW3XE=

--- a/service/snap/clock_mock_test.go
+++ b/service/snap/clock_mock_test.go
@@ -68,6 +68,48 @@ func (mr *MockClockMockRecorder) AfterFunc(arg0, arg1 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AfterFunc", reflect.TypeOf((*MockClock)(nil).AfterFunc), arg0, arg1)
 }
 
+// At mocks base method.
+func (m *MockClock) At(arg0 time.Time) <-chan time.Time {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "At", arg0)
+	ret0, _ := ret[0].(<-chan time.Time)
+	return ret0
+}
+
+// At indicates an expected call of At.
+func (mr *MockClockMockRecorder) At(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "At", reflect.TypeOf((*MockClock)(nil).At), arg0)
+}
+
+// AtFunc mocks base method.
+func (m *MockClock) AtFunc(arg0 time.Time, arg1 func()) clock.Alarm {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AtFunc", arg0, arg1)
+	ret0, _ := ret[0].(clock.Alarm)
+	return ret0
+}
+
+// AtFunc indicates an expected call of AtFunc.
+func (mr *MockClockMockRecorder) AtFunc(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AtFunc", reflect.TypeOf((*MockClock)(nil).AtFunc), arg0, arg1)
+}
+
+// NewAlarm mocks base method.
+func (m *MockClock) NewAlarm(arg0 time.Time) clock.Alarm {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NewAlarm", arg0)
+	ret0, _ := ret[0].(clock.Alarm)
+	return ret0
+}
+
+// NewAlarm indicates an expected call of NewAlarm.
+func (mr *MockClockMockRecorder) NewAlarm(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewAlarm", reflect.TypeOf((*MockClock)(nil).NewAlarm), arg0)
+}
+
 // NewTimer mocks base method.
 func (m *MockClock) NewTimer(arg0 time.Duration) clock.Timer {
 	m.ctrl.T.Helper()

--- a/state/mocks/clock_mock.go
+++ b/state/mocks/clock_mock.go
@@ -68,6 +68,48 @@ func (mr *MockClockMockRecorder) AfterFunc(arg0, arg1 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AfterFunc", reflect.TypeOf((*MockClock)(nil).AfterFunc), arg0, arg1)
 }
 
+// At mocks base method.
+func (m *MockClock) At(arg0 time.Time) <-chan time.Time {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "At", arg0)
+	ret0, _ := ret[0].(<-chan time.Time)
+	return ret0
+}
+
+// At indicates an expected call of At.
+func (mr *MockClockMockRecorder) At(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "At", reflect.TypeOf((*MockClock)(nil).At), arg0)
+}
+
+// AtFunc mocks base method.
+func (m *MockClock) AtFunc(arg0 time.Time, arg1 func()) clock.Alarm {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AtFunc", arg0, arg1)
+	ret0, _ := ret[0].(clock.Alarm)
+	return ret0
+}
+
+// AtFunc indicates an expected call of AtFunc.
+func (mr *MockClockMockRecorder) AtFunc(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AtFunc", reflect.TypeOf((*MockClock)(nil).AtFunc), arg0, arg1)
+}
+
+// NewAlarm mocks base method.
+func (m *MockClock) NewAlarm(arg0 time.Time) clock.Alarm {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NewAlarm", arg0)
+	ret0, _ := ret[0].(clock.Alarm)
+	return ret0
+}
+
+// NewAlarm indicates an expected call of NewAlarm.
+func (mr *MockClockMockRecorder) NewAlarm(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewAlarm", reflect.TypeOf((*MockClock)(nil).NewAlarm), arg0)
+}
+
 // NewTimer mocks base method.
 func (m *MockClock) NewTimer(arg0 time.Duration) clock.Timer {
 	m.ctrl.T.Helper()

--- a/worker/changestream/clock_mock_test.go
+++ b/worker/changestream/clock_mock_test.go
@@ -68,6 +68,48 @@ func (mr *MockClockMockRecorder) AfterFunc(arg0, arg1 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AfterFunc", reflect.TypeOf((*MockClock)(nil).AfterFunc), arg0, arg1)
 }
 
+// At mocks base method.
+func (m *MockClock) At(arg0 time.Time) <-chan time.Time {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "At", arg0)
+	ret0, _ := ret[0].(<-chan time.Time)
+	return ret0
+}
+
+// At indicates an expected call of At.
+func (mr *MockClockMockRecorder) At(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "At", reflect.TypeOf((*MockClock)(nil).At), arg0)
+}
+
+// AtFunc mocks base method.
+func (m *MockClock) AtFunc(arg0 time.Time, arg1 func()) clock.Alarm {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AtFunc", arg0, arg1)
+	ret0, _ := ret[0].(clock.Alarm)
+	return ret0
+}
+
+// AtFunc indicates an expected call of AtFunc.
+func (mr *MockClockMockRecorder) AtFunc(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AtFunc", reflect.TypeOf((*MockClock)(nil).AtFunc), arg0, arg1)
+}
+
+// NewAlarm mocks base method.
+func (m *MockClock) NewAlarm(arg0 time.Time) clock.Alarm {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NewAlarm", arg0)
+	ret0, _ := ret[0].(clock.Alarm)
+	return ret0
+}
+
+// NewAlarm indicates an expected call of NewAlarm.
+func (mr *MockClockMockRecorder) NewAlarm(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewAlarm", reflect.TypeOf((*MockClock)(nil).NewAlarm), arg0)
+}
+
 // NewTimer mocks base method.
 func (m *MockClock) NewTimer(arg0 time.Duration) clock.Timer {
 	m.ctrl.T.Helper()

--- a/worker/changestream/stream/clock_mock_test.go
+++ b/worker/changestream/stream/clock_mock_test.go
@@ -68,6 +68,48 @@ func (mr *MockClockMockRecorder) AfterFunc(arg0, arg1 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AfterFunc", reflect.TypeOf((*MockClock)(nil).AfterFunc), arg0, arg1)
 }
 
+// At mocks base method.
+func (m *MockClock) At(arg0 time.Time) <-chan time.Time {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "At", arg0)
+	ret0, _ := ret[0].(<-chan time.Time)
+	return ret0
+}
+
+// At indicates an expected call of At.
+func (mr *MockClockMockRecorder) At(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "At", reflect.TypeOf((*MockClock)(nil).At), arg0)
+}
+
+// AtFunc mocks base method.
+func (m *MockClock) AtFunc(arg0 time.Time, arg1 func()) clock.Alarm {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AtFunc", arg0, arg1)
+	ret0, _ := ret[0].(clock.Alarm)
+	return ret0
+}
+
+// AtFunc indicates an expected call of AtFunc.
+func (mr *MockClockMockRecorder) AtFunc(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AtFunc", reflect.TypeOf((*MockClock)(nil).AtFunc), arg0, arg1)
+}
+
+// NewAlarm mocks base method.
+func (m *MockClock) NewAlarm(arg0 time.Time) clock.Alarm {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NewAlarm", arg0)
+	ret0, _ := ret[0].(clock.Alarm)
+	return ret0
+}
+
+// NewAlarm indicates an expected call of NewAlarm.
+func (mr *MockClockMockRecorder) NewAlarm(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewAlarm", reflect.TypeOf((*MockClock)(nil).NewAlarm), arg0)
+}
+
 // NewTimer mocks base method.
 func (m *MockClock) NewTimer(arg0 time.Duration) clock.Timer {
 	m.ctrl.T.Helper()

--- a/worker/dbaccessor/clock_mock_test.go
+++ b/worker/dbaccessor/clock_mock_test.go
@@ -68,6 +68,48 @@ func (mr *MockClockMockRecorder) AfterFunc(arg0, arg1 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AfterFunc", reflect.TypeOf((*MockClock)(nil).AfterFunc), arg0, arg1)
 }
 
+// At mocks base method.
+func (m *MockClock) At(arg0 time.Time) <-chan time.Time {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "At", arg0)
+	ret0, _ := ret[0].(<-chan time.Time)
+	return ret0
+}
+
+// At indicates an expected call of At.
+func (mr *MockClockMockRecorder) At(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "At", reflect.TypeOf((*MockClock)(nil).At), arg0)
+}
+
+// AtFunc mocks base method.
+func (m *MockClock) AtFunc(arg0 time.Time, arg1 func()) clock.Alarm {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AtFunc", arg0, arg1)
+	ret0, _ := ret[0].(clock.Alarm)
+	return ret0
+}
+
+// AtFunc indicates an expected call of AtFunc.
+func (mr *MockClockMockRecorder) AtFunc(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AtFunc", reflect.TypeOf((*MockClock)(nil).AtFunc), arg0, arg1)
+}
+
+// NewAlarm mocks base method.
+func (m *MockClock) NewAlarm(arg0 time.Time) clock.Alarm {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NewAlarm", arg0)
+	ret0, _ := ret[0].(clock.Alarm)
+	return ret0
+}
+
+// NewAlarm indicates an expected call of NewAlarm.
+func (mr *MockClockMockRecorder) NewAlarm(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewAlarm", reflect.TypeOf((*MockClock)(nil).NewAlarm), arg0)
+}
+
 // NewTimer mocks base method.
 func (m *MockClock) NewTimer(arg0 time.Duration) clock.Timer {
 	m.ctrl.T.Helper()

--- a/worker/filenotifywatcher/clock_mock_test.go
+++ b/worker/filenotifywatcher/clock_mock_test.go
@@ -68,6 +68,48 @@ func (mr *MockClockMockRecorder) AfterFunc(arg0, arg1 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AfterFunc", reflect.TypeOf((*MockClock)(nil).AfterFunc), arg0, arg1)
 }
 
+// At mocks base method.
+func (m *MockClock) At(arg0 time.Time) <-chan time.Time {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "At", arg0)
+	ret0, _ := ret[0].(<-chan time.Time)
+	return ret0
+}
+
+// At indicates an expected call of At.
+func (mr *MockClockMockRecorder) At(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "At", reflect.TypeOf((*MockClock)(nil).At), arg0)
+}
+
+// AtFunc mocks base method.
+func (m *MockClock) AtFunc(arg0 time.Time, arg1 func()) clock.Alarm {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AtFunc", arg0, arg1)
+	ret0, _ := ret[0].(clock.Alarm)
+	return ret0
+}
+
+// AtFunc indicates an expected call of AtFunc.
+func (mr *MockClockMockRecorder) AtFunc(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AtFunc", reflect.TypeOf((*MockClock)(nil).AtFunc), arg0, arg1)
+}
+
+// NewAlarm mocks base method.
+func (m *MockClock) NewAlarm(arg0 time.Time) clock.Alarm {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NewAlarm", arg0)
+	ret0, _ := ret[0].(clock.Alarm)
+	return ret0
+}
+
+// NewAlarm indicates an expected call of NewAlarm.
+func (mr *MockClockMockRecorder) NewAlarm(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewAlarm", reflect.TypeOf((*MockClock)(nil).NewAlarm), arg0)
+}
+
 // NewTimer mocks base method.
 func (m *MockClock) NewTimer(arg0 time.Duration) clock.Timer {
 	m.ctrl.T.Helper()

--- a/worker/leaseexpiry/clock_mock_test.go
+++ b/worker/leaseexpiry/clock_mock_test.go
@@ -68,6 +68,48 @@ func (mr *MockClockMockRecorder) AfterFunc(arg0, arg1 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AfterFunc", reflect.TypeOf((*MockClock)(nil).AfterFunc), arg0, arg1)
 }
 
+// At mocks base method.
+func (m *MockClock) At(arg0 time.Time) <-chan time.Time {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "At", arg0)
+	ret0, _ := ret[0].(<-chan time.Time)
+	return ret0
+}
+
+// At indicates an expected call of At.
+func (mr *MockClockMockRecorder) At(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "At", reflect.TypeOf((*MockClock)(nil).At), arg0)
+}
+
+// AtFunc mocks base method.
+func (m *MockClock) AtFunc(arg0 time.Time, arg1 func()) clock.Alarm {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AtFunc", arg0, arg1)
+	ret0, _ := ret[0].(clock.Alarm)
+	return ret0
+}
+
+// AtFunc indicates an expected call of AtFunc.
+func (mr *MockClockMockRecorder) AtFunc(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AtFunc", reflect.TypeOf((*MockClock)(nil).AtFunc), arg0, arg1)
+}
+
+// NewAlarm mocks base method.
+func (m *MockClock) NewAlarm(arg0 time.Time) clock.Alarm {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NewAlarm", arg0)
+	ret0, _ := ret[0].(clock.Alarm)
+	return ret0
+}
+
+// NewAlarm indicates an expected call of NewAlarm.
+func (mr *MockClockMockRecorder) NewAlarm(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewAlarm", reflect.TypeOf((*MockClock)(nil).NewAlarm), arg0)
+}
+
 // NewTimer mocks base method.
 func (m *MockClock) NewTimer(arg0 time.Duration) clock.Timer {
 	m.ctrl.T.Helper()

--- a/worker/querylogger/clock_mock_test.go
+++ b/worker/querylogger/clock_mock_test.go
@@ -68,6 +68,48 @@ func (mr *MockClockMockRecorder) AfterFunc(arg0, arg1 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AfterFunc", reflect.TypeOf((*MockClock)(nil).AfterFunc), arg0, arg1)
 }
 
+// At mocks base method.
+func (m *MockClock) At(arg0 time.Time) <-chan time.Time {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "At", arg0)
+	ret0, _ := ret[0].(<-chan time.Time)
+	return ret0
+}
+
+// At indicates an expected call of At.
+func (mr *MockClockMockRecorder) At(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "At", reflect.TypeOf((*MockClock)(nil).At), arg0)
+}
+
+// AtFunc mocks base method.
+func (m *MockClock) AtFunc(arg0 time.Time, arg1 func()) clock.Alarm {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AtFunc", arg0, arg1)
+	ret0, _ := ret[0].(clock.Alarm)
+	return ret0
+}
+
+// AtFunc indicates an expected call of AtFunc.
+func (mr *MockClockMockRecorder) AtFunc(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AtFunc", reflect.TypeOf((*MockClock)(nil).AtFunc), arg0, arg1)
+}
+
+// NewAlarm mocks base method.
+func (m *MockClock) NewAlarm(arg0 time.Time) clock.Alarm {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NewAlarm", arg0)
+	ret0, _ := ret[0].(clock.Alarm)
+	return ret0
+}
+
+// NewAlarm indicates an expected call of NewAlarm.
+func (mr *MockClockMockRecorder) NewAlarm(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewAlarm", reflect.TypeOf((*MockClock)(nil).NewAlarm), arg0)
+}
+
 // NewTimer mocks base method.
 func (m *MockClock) NewTimer(arg0 time.Duration) clock.Timer {
 	m.ctrl.T.Helper()

--- a/worker/storageprovisioner/mock_test.go
+++ b/worker/storageprovisioner/mock_test.go
@@ -856,6 +856,7 @@ func newMockMachineAccessor(c *gc.C) *mockMachineAccessor {
 }
 
 type mockClock struct {
+	clock.Clock
 	gitjujutesting.Stub
 	now         time.Time
 	onNow       func() time.Time


### PR DESCRIPTION
The secretexpire worker relies on expiring secrets at specific times. This is problematic with test clocks as it
requires the worker to calculate the delay between now and that time. With test clocks, `now` can move very
fast forward, even between calls to Now and Sub. This is very reproducible on heavily loaded machines since
test clocks can have built in synchronisations which leads to a more likely serialisation of events across multiple
threads.

This fix uses new functionality in the juju/clock dep, that adds the concept of an alarm. Alarms are just normal
timers that go off at or after a point in time, rather than on or after an elapsed duration of time. This is merely a
different way to express intent to the testing clocks. To the wall clock, there is no difference.

## QA steps

- `go test -c`
- `stress ./secretexpire.test`

Example with the fix
```
$ stress -p 1024 ./secretexpire.test
5s: 3508 runs so far, 0 failures
10s: 7580 runs so far, 0 failures
15s: 11484 runs so far, 0 failures
20s: 15514 runs so far, 0 failures
25s: 19594 runs so far, 0 failures
30s: 23651 runs so far, 0 failures
35s: 27710 runs so far, 0 failures
40s: 31823 runs so far, 0 failures
```

Example without the fix
```
stress -p 1024 ./secretexpire.test
5s: 3409 runs so far, 0 failures
10s: 7448 runs so far, 0 failures

/tmp/go-stress-20240703T143139-2336999988

----------------------------------------------------------------------
FAIL: secretexpire_test.go:226: workerSuite.TestSecretUpdateBeforeExpiresNotTriggered

[LOG] 0:00.000 DEBUG test got revision expiry secret changes: []watcher.SecretTriggerChange{cq2d8bbn712rj83cas40/666 trigger: in 59m59.999862729s at 2024-07-03T15:31:41+10:00}
[LOG] 0:00.000 DEBUG test computing next expire time for secret revisions map[string]secretexpire.secretRevisionExpiryInfo{"cq2d8bbn712rj83cas40/666":cq2d8bbn712rj83cas40/666 expiry: in 59m59.999842871s at 2024-07-03T15:31:41+10:00}
[LOG] 0:00.000 DEBUG test next secret revision for ["application-mariadb"] will expire in 1h0m0s at 2024-07-03 15:31:41.533540735 +1000 AEST m=+3600.525355118
[LOG] 0:00.051 DEBUG test got revision expiry secret changes: []watcher.SecretTriggerChange{cq2d8bbn712rj83cas40/666 trigger: in 1h59m59.949236489s at 2024-07-03T16:31:41+10:00}
[LOG] 0:00.051 DEBUG test computing next expire time for secret revisions map[string]secretexpire.secretRevisionExpiryInfo{"cq2d8bbn712rj83cas40/666":cq2d8bbn712rj83cas40/666 expiry: in 1h59m59.949213315s at 2024-07-03T16:31:41+10:00}
[LOG] 0:00.051 DEBUG test next secret revision for ["application-mariadb"] will expire in 1h30m0s at 2024-07-03 16:31:41.533540735 +1000 AEST m=+7200.525355118
secretexpire_test.go:256:
    s.expectExpired(c, uri.ID+"/666")
secretexpire_test.go:134:
    c.Fatal("timed out waiting for secrets to be expired")
... Error: timed out waiting for secrets to be expired

OOPS: 10 passed, 1 FAILED
--- FAIL: TestPackage (11.05s)
FAIL


ERROR: exit status 1
```

## Documentation changes

N/A

## Links

N/A
