### PR TITLE
docs: change non-existant "refreshed" hook to "upgrade-charm"

### DIFF
--- a/cmd/juju/application/refresh.go
+++ b/cmd/juju/application/refresh.go
@@ -229,8 +229,8 @@ is determined by the contents of the charm at the specified path.
 --switch and --revision are mutually exclusive.
 
 Use of the --force-units option is not generally recommended; units upgraded
-while in an error state will not have refreshed hooks executed, and may cause
-unexpected behavior.
+while in an error state will not have upgrade-charm hooks executed, and may
+cause unexpected behavior.
 
 --force option for LXD Profiles is not generally recommended when upgrading an
 application; overriding profiles on the container may cause unexpected


### PR DESCRIPTION
It looks like a search and replace when changing upgrade-charm to refresh also caught the "upgrade-charm" hook. It is changed back.

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

~- [ ] Code style: imports ordered, good names, simple structure, etc~
- [x] Comments saying why design decisions were made~
~- [ ] Go unit tests, with comments saying what you're testing~
~- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
~- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

