### PR TITLE
chore(ci): update GitHub actions dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
     - name: "Checkout"
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: "Set up Go"
       uses: actions/setup-go@v5

--- a/.github/workflows/client-tests.yml
+++ b/.github/workflows/client-tests.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
     - name: "Checkout"
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: "Set up Go"
       uses: actions/setup-go@v5

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.github/workflows/gen.yml
+++ b/.github/workflows/gen.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "Set up Go"
         uses: actions/setup-go@v5

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -20,7 +20,7 @@ jobs:
     if: github.event.pull_request.draft == false
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Set up Go
       uses: actions/setup-go@v5
       with:

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -25,7 +25,7 @@ jobs:
           echo "target=$TARGET_BRANCH" >> "$GITHUB_OUTPUT"
 
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ steps.branch.outputs.source }}

--- a/.github/workflows/microk8s-tests.yml
+++ b/.github/workflows/microk8s-tests.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
     - name: Checking out repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set up Go
       uses: actions/setup-go@v5

--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -29,7 +29,7 @@ jobs:
         sudo DEBIAN_FRONTEND=noninteractive apt install -y expect
 
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup LXD
       if: matrix.cloud == 'localhost'

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -33,7 +33,7 @@ jobs:
         echo "/snap/bin" >> $GITHUB_PATH
 
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup LXD
       uses: canonical/setup-lxd@4e959f8e0d9c5feb27d44c5e4d9a330a782edee0

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -18,10 +18,10 @@ jobs:
     if: github.event.pull_request.draft == false
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Determine which tests to run
-      uses: dorny/paths-filter@v2
+      uses: dorny/paths-filter@v3
       id: filter
       with:
         filters: |
@@ -101,10 +101,10 @@ jobs:
     if: github.event.pull_request.draft == false
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Check if there is anything to test
-      uses: dorny/paths-filter@v2
+      uses: dorny/paths-filter@v3
       id: filter
       with:
         filters: |
@@ -160,10 +160,10 @@ jobs:
         binary: ["jujud", "juju"]
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version-file: 'go.mod'
         cache: true

--- a/.github/workflows/terraform-smoke.yml
+++ b/.github/workflows/terraform-smoke.yml
@@ -29,7 +29,7 @@ jobs:
         sudo DEBIAN_FRONTEND=noninteractive apt install -y expect
 
     - name: Checkout juju
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup LXD
       uses: canonical/setup-lxd@4e959f8e0d9c5feb27d44c5e4d9a330a782edee0
@@ -61,7 +61,7 @@ jobs:
         juju version
 
     - name: Find terraform provider for juju latest release
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: 'juju/terraform-provider-juju'
         #path: terraform-provider-juju

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -29,7 +29,7 @@ jobs:
       channel: ${{ steps.check.outputs.channel }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Check
         id: check
         run: |
@@ -62,7 +62,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup LXD
         if: matrix.cloud == 'localhost'


### PR DESCRIPTION
Our GitHub checks are producing lots of warnings, due to the deprecation of Node 16 in GitHub Actions: 
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/

Update dependent actions to newer versions which use Node 20. Specifically, I have updated the following actions:
- actions/checkout: v3 -> v4
- actions/setup-go: v4 -> v5
- dorny/paths-filter: v2 -> v3

The `balchua/microk8s-actions` action can't yet be updated, as they have not yet released a new version with Node 20. Same with `canonical/has-signed-canonical-cla`.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- ~[ ] Code style: imports ordered, good names, simple structure, etc~
- ~[ ] Comments saying why design decisions were made~
- ~[ ] Go unit tests, with comments saying what you're testing~
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

<!-- Describe steps to verify that the change works. -->

Check all GitHub Actions pass below.