### PR TITLE
fix: add-k8s should reject if the cloud name uses the builtin "microk8s" name

### DIFF
--- a/cmd/juju/caas/add.go
+++ b/cmd/juju/caas/add.go
@@ -876,34 +876,28 @@ func (c *AddCAASCommand) getClusterMetadataFunc(ctx *cmd.Context) provider.GetCl
 }
 
 func (c *AddCAASCommand) verifyName(name string) error {
-	public, _, err := c.cloudMetadataStore.PublicCloudMetadata()
-	if err != nil {
-		return err
+	if name == k8s.K8sCloudMicrok8s {
+		return fmt.Errorf(`%q is the name of a built-in cloud.
+If you want to use Juju with microk8s, the recommended way is to install the strictly confined microk8s snap.
+Using the strictly confined microk8s snap means that Juju and microk8s will work together out of the box.`, name)
 	}
-	msg, err := nameExists(name, public)
+
+	public, _, err := c.cloudMetadataStore.PublicCloudMetadata()
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if msg != "" {
-		return errors.Errorf(msg)
-	}
-	return nil
-}
 
-// nameExists returns either an empty string if the name does not exist, or a
-// non-empty string with an error message if it does exist.
-func nameExists(name string, public map[string]jujucloud.Cloud) (string, error) {
 	if _, ok := public[name]; ok {
-		return fmt.Sprintf("%q is the name of a public cloud", name), nil
+		return fmt.Errorf("%q is the name of a public cloud", name)
 	}
 	builtin, err := common.BuiltInClouds()
 	if err != nil {
-		return "", errors.Trace(err)
+		return errors.Trace(err)
 	}
 	if _, ok := builtin[name]; ok {
-		return fmt.Sprintf("%q is the name of a built-in cloud", name), nil
+		return fmt.Errorf("%q is the name of a built-in cloud", name)
 	}
-	return "", nil
+	return nil
 }
 
 func addCloudToLocal(cloudMetadataStore CloudMetadataStore, newCloud jujucloud.Cloud) error {

--- a/cmd/juju/caas/add_test.go
+++ b/cmd/juju/caas/add_test.go
@@ -510,6 +510,15 @@ func (s *addCAASSuite) TestMissingName(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `missing k8s name.`)
 }
 
+func (s *addCAASSuite) TestInvalidName(c *gc.C) {
+	command := s.makeCommand(c, true, true, true)
+	_, err := s.runCommand(c, nil, command, "microk8s")
+	c.Assert(err, gc.ErrorMatches, `
+"microk8s" is the name of a built-in cloud.
+If you want to use Juju with microk8s, the recommended way is to install the strictly confined microk8s snap.
+Using the strictly confined microk8s snap means that Juju and microk8s will work together out of the box.`[1:])
+}
+
 func (s *addCAASSuite) TestMissingArgs(c *gc.C) {
 	command := s.makeCommand(c, true, true, true)
 	_, err := s.runCommand(c, nil, command)


### PR DESCRIPTION
This PR ensures that the add-k8s command errors if the cloud name is the built-in "microk8s" cloud name.
This situation could happen if Juju cannot detect the microk8s as a built-in cloud(for example, to run Juju3 with classic microk8s).

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```
microk8s config | juju add-k8s microk8s --client
ERROR "microk8s" is the name of a built-in cloud.
If you want to use Juju with microk8s, the recommended way is to install the strictly confined microk8s snap.
Using the strictly confined microk8s snap means that Juju and microk8s will work together out of the box.

```

## Documentation changes

No

## Links

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2067109

**Jira card:** [JUJU-6117](https://warthogs.atlassian.net/browse/JUJU-6117)



[JUJU-6117]: https://warthogs.atlassian.net/browse/JUJU-6117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ