### PR TITLE
feat(domain): add machine_requires_reboot table in dqlite

### DIFF
--- a/domain/schema/model/sql/0017-machine.sql
+++ b/domain/schema/model/sql/0017-machine.sql
@@ -73,3 +73,11 @@ CREATE TABLE machine_filesystem (
     REFERENCES storage_filesystem (uuid),
     PRIMARY KEY (machine_uuid, filesystem_uuid)
 );
+
+CREATE TABLE machine_requires_reboot (
+    machine_uuid TEXT NOT NULL PRIMARY KEY,
+    created_at DATETIME NOT NULL DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW', 'utc')),
+    CONSTRAINT fk_machine_requires_reboot_machine
+    FOREIGN KEY (machine_uuid)
+    REFERENCES machine (uuid)
+);

--- a/domain/schema/schema_test.go
+++ b/domain/schema/schema_test.go
@@ -313,6 +313,7 @@ func (s *schemaSuite) TestModelTables(c *gc.C) {
 		"machine_tool",
 		"machine_volume",
 		"machine_filesystem",
+		"machine_requires_reboot",
 
 		// Charm
 		"charm",


### PR DESCRIPTION
First step for "Machine Reboots backed with Dqlite" epic.

It just add the required table in the schema.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [X] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [X] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Not required

## Documentation changes

None

## Links

**Jira card:** [JUJU-6303](https://warthogs.atlassian.net/browse/JUJU-6303)



[JUJU-6303]: https://warthogs.atlassian.net/browse/JUJU-6303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ