### PR TITLE
fix(tests): fix deploy pre deployed test

### DIFF
--- a/tests/suites/deploy/deploy_charms.sh
+++ b/tests/suites/deploy/deploy_charms.sh
@@ -139,7 +139,7 @@ run_deploy_local_predeployed_charm() {
 	juju deploy ./testcharms/charms/lxd-profile --base ubuntu@22.04
 	wait_for "lxd-profile" "$(idle_condition "lxd-profile")"
 
-	juju deploy local:jammy/lxd-profile-0 another-lxd-profile-app
+	juju deploy local:lxd-profile-0 another-lxd-profile-app
 	wait_for "another-lxd-profile-app" "$(idle_condition "another-lxd-profile-app")"
 	wait_for "active" '.applications["another-lxd-profile-app"] | ."application-status".current'
 


### PR DESCRIPTION
We recently removed series from the charm url when we deploy local charms.

This means pre-deployed charms are to be re-deployed with different urls.

In one of our tests, we hard-coded the charm url to deploy a pre-deplyed charm. This is now incorrect, and caused the test to fail.

See: https://jenkins.juju.canonical.com/job/test-deploy-test-deploy-charms-lxd/1323/console

Fix this by removing the series from the charm url

## Checklist

- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing

## QA steps

```
./main.sh -v deploy test_deploy_charms
```
& check that "deploy local predeployed charm" passes