### PR TITLE
fix: error useage and use sqlair in upgrade domain

### DIFF
--- a/domain/upgrade/errors/errors.go
+++ b/domain/upgrade/errors/errors.go
@@ -8,7 +8,13 @@ import (
 )
 
 const (
-	// ErrUpgradeAlreadyStarted states that the upgrade could not be started.
+	// AlreadyStarted states that the upgrade could not be started.
 	// This error occurs when the upgrade is already in progress.
-	ErrUpgradeAlreadyStarted = errors.ConstError("upgrade already started")
+	AlreadyStarted = errors.ConstError("upgrade already started")
+	// AlreadyExists states that an upgrade operation has already been created.
+	// This error can occur when an upgrade is created.
+	AlreadyExists = errors.ConstError("upgrade already exists")
+	// NotFound states that an upgrade operation cannot be found where one is
+	// expected.
+	NotFound = errors.ConstError("upgrade not found")
 )

--- a/domain/upgrade/state/state.go
+++ b/domain/upgrade/state/state.go
@@ -5,17 +5,17 @@ package state
 
 import (
 	"context"
-	"database/sql"
 
 	"github.com/canonical/sqlair"
 	"github.com/juju/errors"
 	"github.com/juju/version/v2"
 
-	"github.com/juju/juju/core/database"
+	coredatabase "github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/upgrade"
 	"github.com/juju/juju/domain"
 	domainupgrade "github.com/juju/juju/domain/upgrade"
 	upgradeerrors "github.com/juju/juju/domain/upgrade/errors"
+	"github.com/juju/juju/internal/database"
 	"github.com/juju/juju/internal/uuid"
 )
 
@@ -25,7 +25,7 @@ type State struct {
 }
 
 // NewState creates a state to access the database.
-func NewState(factory database.TxnRunnerFactory) *State {
+func NewState(factory coredatabase.TxnRunnerFactory) *State {
 	return &State{
 		StateBase: domain.NewStateBase(factory),
 	}
@@ -44,29 +44,37 @@ func (st *State) CreateUpgrade(ctx context.Context, previousVersion, targetVersi
 	if err != nil {
 		return "", errors.Trace(err)
 	}
-	q := "INSERT INTO upgrade_info (uuid, previous_version, target_version, state_type_id) VALUES (?, ?, ?, ?)"
-
-	err = db.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
-		_, err := tx.ExecContext(ctx, q,
-			upgradeUUID.String(),
-			previousVersion.String(),
-			targetVersion.String(),
-			upgrade.Created,
-		)
-		return errors.Trace(err)
-	})
-
-	if err != nil {
-		return "", errors.Trace(err)
+	info := Info{
+		UUID:            upgradeUUID.String(),
+		PreviousVersion: previousVersion.String(),
+		TargetVersion:   targetVersion.String(),
+		StateIDType:     int(upgrade.Created),
 	}
+
+	stmt, err := st.Prepare(`
+INSERT INTO upgrade_info (*) 
+VALUES ($Info.*)`, info)
+	if err != nil {
+		return "", errors.Annotatef(err, "preparing insert upgrade info statement")
+	}
+
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		return tx.Query(ctx, stmt, info).Run()
+	})
+	if database.IsErrConstraintUnique(err) {
+		return "", upgradeerrors.AlreadyExists
+	} else if err != nil {
+		return "", errors.Trace(domain.CoerceError(err))
+	}
+
 	return domainupgrade.UUID(upgradeUUID.String()), nil
 }
 
 // SetControllerReady marks the supplied controllerID as being ready
 // to start a provided upgrade. All provisioned controllers need to
-// be ready before an upgrade can start
+// be ready before an upgrade can start.
 // A controller node is ready for an upgrade if a row corresponding
-// to the controller is present in upgrade_info_controller_node
+// to the controller is present in upgrade_info_controller_node.
 func (st *State) SetControllerReady(ctx context.Context, upgradeUUID domainupgrade.UUID, controllerID string) error {
 	db, err := st.DB()
 	if err != nil {
@@ -78,91 +86,92 @@ func (st *State) SetControllerReady(ctx context.Context, upgradeUUID domainupgra
 		return errors.Trace(err)
 	}
 
-	lookForReadyNodeQuery := `
-SELECT  controller_node_id AS &infoControllerNode.controller_node_id
-FROM    upgrade_info_controller_node
-WHERE   upgrade_info_uuid = $M.info_uuid
-AND     controller_node_id = $M.controller_id;
-`
-	lookForReadyNodeStmt, err := st.Prepare(lookForReadyNodeQuery, infoControllerNode{}, sqlair.M{})
-	if err != nil {
-		return errors.Annotatef(err, "preparing %q", lookForReadyNodeQuery)
+	controllerNodeInfo := ControllerNodeInfo{
+		UUID:             uuid.String(),
+		UpgradeInfoUUID:  upgradeUUID.String(),
+		ControllerNodeID: controllerID,
 	}
 
-	insertUpgradeNodeQuery := `
-INSERT INTO upgrade_info_controller_node (uuid, controller_node_id, upgrade_info_uuid)
-VALUES ($M.uuid, $M.controller_id, $M.info_uuid);
-`
-	insertUpgradeNodeStmt, err := st.Prepare(insertUpgradeNodeQuery, sqlair.M{})
+	checkExistsNodeStmt, err := st.Prepare(`
+SELECT  &ControllerNodeInfo.controller_node_id
+FROM    upgrade_info_controller_node
+WHERE   upgrade_info_uuid = $ControllerNodeInfo.upgrade_info_uuid
+AND     controller_node_id = $ControllerNodeInfo.controller_node_id;
+`, controllerNodeInfo)
 	if err != nil {
-		return errors.Annotatef(err, "preparing %q", insertUpgradeNodeQuery)
+		return errors.Annotatef(err, "preparing check exists node statement")
 	}
-	return errors.Trace(db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		err := tx.Query(ctx, lookForReadyNodeStmt, sqlair.M{
-			"info_uuid":     upgradeUUID,
-			"controller_id": controllerID,
-		}).Get(&infoControllerNode{})
-		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+
+	insertUpgradeNodeStmt, err := st.Prepare(`
+INSERT INTO upgrade_info_controller_node (uuid, controller_node_id, upgrade_info_uuid)
+VALUES ($ControllerNodeInfo.*);
+`, controllerNodeInfo)
+	if err != nil {
+		return errors.Annotatef(err, "preparing insert upgrade node statement")
+	}
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		err := tx.Query(ctx, checkExistsNodeStmt, controllerNodeInfo).Get(&ControllerNodeInfo{})
+		if err == nil {
+			// The controller node already exists, so return.
+			return nil
+		} else if !errors.Is(err, sqlair.ErrNoRows) {
 			return errors.Trace(err)
 		}
 
-		err = tx.Query(ctx, insertUpgradeNodeStmt, sqlair.M{
-			"uuid":          uuid.String(),
-			"controller_id": controllerID,
-			"info_uuid":     upgradeUUID,
-		}).Run()
-		if err != nil {
+		err = tx.Query(ctx, insertUpgradeNodeStmt, controllerNodeInfo).Run()
+		if database.IsErrConstraintForeignKey(err) {
+			return errors.Annotatef(upgradeerrors.NotFound, "upgrade %q", upgradeUUID)
+		} else if err != nil {
 			return errors.Trace(err)
 		}
 		return nil
-	}))
+	})
+	return errors.Trace(domain.CoerceError(err))
 }
 
 // AllProvisionedControllersReady returns true if and only if all controllers
 // that have been started by the provisioner are ready to start the provided
-// upgrade
+// upgrade.
 func (st *State) AllProvisionedControllersReady(ctx context.Context, upgradeUUID domainupgrade.UUID) (bool, error) {
 	db, err := st.DB()
 	if err != nil {
 		return false, errors.Trace(err)
 	}
-	q := `
-SELECT COUNT(*)
-FROM    controller_node AS node
-        LEFT JOIN upgrade_info_controller_node AS upgrade_node
-            ON node.controller_id = upgrade_node.controller_node_id
-            AND  upgrade_node.upgrade_info_uuid = ?
+	var count Count
+	controllerNodeInfo := ControllerNodeInfo{
+		UpgradeInfoUUID: upgradeUUID.String(),
+	}
+	stmt, err := st.Prepare(`
+SELECT COUNT(*) AS &Count.num
+FROM   controller_node AS node
+       LEFT JOIN upgrade_info_controller_node AS upgrade_node
+       ON node.controller_id = upgrade_node.controller_node_id
+       AND  upgrade_node.upgrade_info_uuid = $ControllerNodeInfo.upgrade_info_uuid
 WHERE  node.dqlite_node_id IS NOT NULL
 AND    upgrade_node.controller_node_id IS NULL;
-`
+`, count, controllerNodeInfo)
+	if err != nil {
+		return false, errors.Annotate(err, "preparing select count provisioned controllers statement")
+	}
 
 	var allReady bool
-	err = db.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
-		rows, err := tx.QueryContext(ctx, q, upgradeUUID)
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		err := tx.Query(ctx, stmt, controllerNodeInfo).Get(&count)
 		if err != nil {
 			return errors.Trace(err)
 		}
-		defer rows.Close()
-
-		for rows.Next() {
-			var unreadyControllers int
-			err = rows.Scan(&unreadyControllers)
-			if err != nil {
-				return errors.Trace(err)
-			}
-			allReady = unreadyControllers == 0
-		}
-
-		return rows.Err()
+		allReady = count.Num == 0
+		return nil
 	})
 	if err != nil {
-		return false, errors.Trace(err)
+		return false, errors.Trace(domain.CoerceError(err))
 	}
 	return allReady, nil
 }
 
-// StartUpgrade starts the provided upgrade if the upgrade already exists.
-// If it's already started, it becomes a no-op.
+// StartUpgrade starts the provided upgrade if the upgrade already exists. If it
+// does not exists it returns a NotFound error. If it's already started, it
+// returns a AlreadyStarted error.
 //
 // TODO (jack-w-shaw) Set `statuses`/`statuseshistory` here
 // to status.Busy once the table has been added
@@ -172,177 +181,149 @@ func (st *State) StartUpgrade(ctx context.Context, upgradeUUID domainupgrade.UUI
 		return errors.Trace(err)
 	}
 
-	getUpgradeStartedQuery := `
-SELECT upgrade_state_type.id 
-FROM upgrade_info 
-	LEFT JOIN upgrade_state_type
-		ON upgrade_info.state_type_id = upgrade_state_type.id
-WHERE uuid = ?
-`
+	info := Info{
+		UUID: upgradeUUID.String(),
+	}
 
-	startUpgradeQuery := "UPDATE upgrade_info SET state_type_id = ? WHERE uuid = ? AND state_type_id = ?"
+	getUpgradeStartedStmt, err := st.Prepare(`
+SELECT &Info.state_type_id 
+FROM   upgrade_info 
+WHERE  uuid = $Info.uuid
+`, info)
+	if err != nil {
+		return errors.Annotate(err, "preparing select started upgrade statement")
+	}
 
-	return errors.Trace(db.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
-		var state int
-		row := tx.QueryRowContext(ctx, getUpgradeStartedQuery, upgradeUUID)
-		if err := row.Scan(&state); err != nil {
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		err := tx.Query(ctx, getUpgradeStartedStmt, info).Get(&info)
+		if errors.Is(err, sqlair.ErrNoRows) {
+			if database.IsErrNotFound(err) {
+				return errors.Annotatef(upgradeerrors.NotFound, "upgrade %q", upgradeUUID)
+			}
+		}
+		if err != nil {
 			return errors.Trace(err)
 		}
 
-		// If the upgrade is already started, we don't need to do anything.
-		if err := upgrade.State(state).TransitionTo(upgrade.Started); err != nil {
+		// If the upgrade is already started, return an error.
+		if err := upgrade.State(info.StateIDType).TransitionTo(upgrade.Started); err != nil {
 			if errors.Is(err, upgrade.ErrAlreadyAtState) {
-				return errors.Annotatef(upgradeerrors.ErrUpgradeAlreadyStarted, "upgrade %q already started", upgradeUUID)
+				return errors.Annotatef(upgradeerrors.AlreadyStarted, "upgrade %q already started", upgradeUUID)
 			}
 			return errors.Trace(err)
 		}
 
-		// Start the upgrade by setting the state to Started.
-		result, err := tx.ExecContext(ctx, startUpgradeQuery, upgrade.Started, upgradeUUID, upgrade.Created)
+		// Start the upgrade by setting the state to "Started".
+		err = st.updateState(ctx, tx, info.UUID, upgrade.Created, upgrade.Started)
 		if err != nil {
-			return errors.Trace(err)
-		}
-		affected, err := result.RowsAffected()
-		if err != nil {
-			return errors.Trace(err)
-		}
-		if num := affected; num != 1 {
-			return errors.Annotatef(upgradeerrors.ErrUpgradeAlreadyStarted, "expected to start upgrade, but %d rows were affected", num)
+			return errors.Annotatef(err, "expected to set upgrade state to started")
 		}
 		return nil
-	}))
+	})
+	return errors.Trace(domain.CoerceError(err))
 }
 
-// SetDBUpgradeCompleted marks the database upgrade as completed
+// SetDBUpgradeCompleted marks the database upgrade as completed.
 func (st *State) SetDBUpgradeCompleted(ctx context.Context, upgradeUUID domainupgrade.UUID) error {
 	db, err := st.DB()
 	if err != nil {
 		return errors.Trace(err)
 	}
 
-	q := `
-UPDATE upgrade_info 
-SET state_type_id = $M.to_state 
-WHERE uuid = $M.info_uuid
-AND state_type_id = $M.from_state;`
-	completedDBUpgradeStmt, err := st.Prepare(q, sqlair.M{})
-	if err != nil {
-		return errors.Annotatef(err, "preparing %q", q)
-	}
-
-	return errors.Trace(db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		var outcome sqlair.Outcome
-		if err = tx.Query(ctx, completedDBUpgradeStmt, sqlair.M{
-			"info_uuid":  upgradeUUID,
-			"from_state": upgrade.Started,
-			"to_state":   upgrade.DBCompleted,
-		}).Get(&outcome); err != nil {
-			return errors.Trace(err)
-		}
-		if num, err := outcome.Result().RowsAffected(); err != nil {
-			return errors.Trace(err)
-		} else if num != 1 {
-			return errors.Errorf("expected to set db upgrade completed, but %d rows were affected", num)
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		err := st.updateState(ctx, tx, upgradeUUID.String(), upgrade.Started, upgrade.DBCompleted)
+		if err != nil {
+			return errors.Annotatef(err, "expected to set upgrade state to db complete")
 		}
 		return nil
-	}))
+	})
+	return errors.Trace(domain.CoerceError(err))
 }
 
-// SetDBUpgradeFailed marks the database upgrade as failed
+// SetDBUpgradeFailed marks the database upgrade as failed.
 func (st *State) SetDBUpgradeFailed(ctx context.Context, upgradeUUID domainupgrade.UUID) error {
 	db, err := st.DB()
 	if err != nil {
 		return errors.Trace(err)
 	}
 
-	q := `
-UPDATE upgrade_info 
-SET state_type_id = $M.to_state 
-WHERE uuid = $M.info_uuid
-AND state_type_id = $M.from_state;`
-	completedDBUpgradeStmt, err := st.Prepare(q, sqlair.M{})
-	if err != nil {
-		return errors.Annotatef(err, "preparing %q", q)
-	}
-
-	return errors.Trace(db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		var outcome sqlair.Outcome
-		if err = tx.Query(ctx, completedDBUpgradeStmt, sqlair.M{
-			"info_uuid":  upgradeUUID,
-			"from_state": upgrade.Started,
-			"to_state":   upgrade.Error,
-		}).Get(&outcome); err != nil {
-			return errors.Trace(err)
-		}
-		if num, err := outcome.Result().RowsAffected(); err != nil {
-			return errors.Trace(err)
-		} else if num != 1 {
-			return errors.Errorf("expected to set db upgrade failed, but %d rows were affected", num)
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		err := st.updateState(ctx, tx, upgradeUUID.String(), upgrade.Started, upgrade.Error)
+		if err != nil {
+			return errors.Annotatef(err, "expected to set upgrade state to error")
 		}
 		return nil
-	}))
+	})
+	return errors.Trace(domain.CoerceError(err))
 }
 
-// SetControllerDone marks the supplied controllerID as having
-// completed its upgrades. When SetControllerDone is called by the
-// all provisioned controller, the upgrade itself will be completed.
+// SetControllerDone marks the supplied controllerID as having completed its
+// upgrades. When SetControllerDone is called by the all provisioned controller,
+// the upgrade itself will be completed.
 //
-// TODO (jack-w-shaw) Set `statuses`/`statuseshistory` here
-// to status.Available when we complete an upgrade
+// TODO (jack-w-shaw) Set `statuses`/`statuseshistory` here to status.Available
+// when we complete an upgrade
 func (st *State) SetControllerDone(ctx context.Context, upgradeUUID domainupgrade.UUID, controllerID string) error {
 	db, err := st.DB()
 	if err != nil {
 		return errors.Trace(err)
 	}
 
-	lookForDoneNodesQuery := `
-SELECT (controller_node_id, node_upgrade_completed_at) AS (&infoControllerNode.*)
-FROM   upgrade_info_controller_node
-WHERE  upgrade_info_uuid = $M.info_uuid
-AND    controller_node_id = $M.controller_id;`
-	lookForDoneNodesStmt, err := st.Prepare(lookForDoneNodesQuery, infoControllerNode{}, sqlair.M{})
-	if err != nil {
-		return errors.Annotatef(err, "preparing select done query")
+	controllerNodeInfo := ControllerNodeInfo{
+		UpgradeInfoUUID:  upgradeUUID.String(),
+		ControllerNodeID: controllerID,
+	}
+	info := Info{
+		UUID: upgradeUUID.String(),
 	}
 
-	setNodeToDoneQuery := `
+	lookForDoneNodesStmt, err := st.Prepare(`
+SELECT (controller_node_id, node_upgrade_completed_at) AS (&ControllerNodeInfo.*)
+FROM   upgrade_info_controller_node
+WHERE  upgrade_info_uuid = $ControllerNodeInfo.upgrade_info_uuid
+AND    controller_node_id = $ControllerNodeInfo.controller_node_id;
+`, controllerNodeInfo)
+	if err != nil {
+		return errors.Annotate(err, "preparing select done query")
+	}
+
+	setNodeToDoneStmt, err := st.Prepare(`
 UPDATE  upgrade_info_controller_node
 SET     node_upgrade_completed_at = DATETIME("now")
-WHERE   upgrade_info_uuid = $M.info_uuid
-AND     controller_node_id = $M.controller_id
+WHERE   upgrade_info_uuid = $ControllerNodeInfo.upgrade_info_uuid
+AND     controller_node_id = $ControllerNodeInfo.controller_node_id
 AND     node_upgrade_completed_at IS NULL;
-`
-	setNodeToDoneStmt, err := st.Prepare(setNodeToDoneQuery, sqlair.M{})
+`, controllerNodeInfo)
 	if err != nil {
 		return errors.Annotatef(err, "preparing update node query")
 	}
 
-	completeUpgradeQuery := `
+	m := sqlair.M{
+		"from_state": upgrade.DBCompleted,
+		"to_state":   upgrade.StepsCompleted,
+	}
+	completeUpgradeStmt, err := st.Prepare(`
 UPDATE upgrade_info
 SET    state_type_id = $M.to_state
-WHERE  uuid = $M.info_uuid AND state_type_id = $M.from_state
+WHERE  uuid = $Info.uuid AND state_type_id = $M.from_state
 AND (
     SELECT COUNT(*)
 	FROM   upgrade_info_controller_node
-    WHERE  upgrade_info_uuid = $M.info_uuid
+    WHERE  upgrade_info_uuid = $Info.uuid
     AND    node_upgrade_completed_at IS NOT NULL
 ) = (
     SELECT COUNT(*) 
-	FROM   upgrade_info_controller_node
-    WHERE  upgrade_info_uuid = $M.info_uuid
+    FROM   upgrade_info_controller_node
+    WHERE  upgrade_info_uuid = $Info.uuid
 );
-`
-	completeUpgradeStmt, err := st.Prepare(completeUpgradeQuery, sqlair.M{})
+`, info, m)
 	if err != nil {
 		return errors.Annotatef(err, "preparing complete upgrade query")
 	}
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		var node infoControllerNode
-		err := tx.Query(ctx, lookForDoneNodesStmt, sqlair.M{
-			"info_uuid":     upgradeUUID,
-			"controller_id": controllerID,
-		}).Get(&node)
+		var node ControllerNodeInfo
+		err := tx.Query(ctx, lookForDoneNodesStmt, controllerNodeInfo).Get(&node)
 		if err != nil {
 			if errors.Is(err, sqlair.ErrNoRows) {
 				return errors.Errorf("controller node %q not ready", controllerID)
@@ -350,24 +331,12 @@ AND (
 			return errors.Trace(err)
 		}
 
-		err = tx.Query(ctx, setNodeToDoneStmt, sqlair.M{
-			"info_uuid":     upgradeUUID,
-			"controller_id": controllerID,
-		}).Run()
+		err = tx.Query(ctx, setNodeToDoneStmt, controllerNodeInfo).Run()
 		if err != nil {
 			return errors.Trace(err)
 		}
 
-		var outcome sqlair.Outcome
-		err = tx.Query(ctx, completeUpgradeStmt, sqlair.M{
-			"info_uuid":  upgradeUUID,
-			"from_state": upgrade.DBCompleted,
-			"to_state":   upgrade.StepsCompleted,
-		}).Get(&outcome)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		return nil
+		return errors.Trace(tx.Query(ctx, completeUpgradeStmt, info, m).Run())
 	})
 	if err != nil {
 		return errors.Trace(err)
@@ -375,53 +344,105 @@ AND (
 	return nil
 }
 
-// ActiveUpgrade returns the uuid of the active upgrade.
-// The active upgrade is any upgrade that is not in the StepsCompleted state.
+// ActiveUpgrade returns the uuid of the active upgrade. The active upgrade is
+// any upgrade that is not in the StepsCompleted state. It returns a NotFound
+// error if there is no active upgrade.
 func (st *State) ActiveUpgrade(ctx context.Context) (domainupgrade.UUID, error) {
 	db, err := st.DB()
 	if err != nil {
 		return "", errors.Trace(err)
 	}
-	var activeUpgrade domainupgrade.UUID
-	q := "SELECT (uuid) FROM upgrade_info WHERE state_type_id < ?"
 
-	err = db.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
-		row := tx.QueryRowContext(ctx, q, upgrade.StepsCompleted)
-		if err := row.Scan(&activeUpgrade); err != nil {
+	info := Info{
+		StateIDType: int(upgrade.StepsCompleted),
+	}
+
+	stmt, err := st.Prepare(`
+SELECT &Info.uuid
+FROM upgrade_info 
+WHERE state_type_id < $Info.state_type_id
+`, info)
+	if err != nil {
+		return "", errors.Annotate(err, "preparing select active upgrade statement")
+	}
+
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		err := tx.Query(ctx, stmt, info).Get(&info)
+		if errors.Is(err, sqlair.ErrNoRows) {
+			return errors.Annotatef(upgradeerrors.NotFound, "active upgrade")
+		} else if err != nil {
 			return errors.Trace(err)
 		}
 		return nil
 	})
-	return activeUpgrade, errors.Trace(err)
+	return domainupgrade.UUID(info.UUID), errors.Trace(domain.CoerceError(err))
 }
 
-// UpgradeInfo returns the upgrade info for the provided upgradeUUID
+// UpgradeInfo returns the upgrade info for the provided upgradeUUID. It returns
+// a NotFound error if the upgrade does not exist.
 func (st *State) UpgradeInfo(ctx context.Context, upgradeUUID domainupgrade.UUID) (upgrade.Info, error) {
 	db, err := st.DB()
 	if err != nil {
 		return upgrade.Info{}, errors.Trace(err)
 	}
-
-	q := `
-SELECT uuid, previous_version, target_version, upgrade_state_type.id 
-FROM upgrade_info 
-	LEFT JOIN upgrade_state_type
-		ON upgrade_info.state_type_id = upgrade_state_type.id
-WHERE uuid = ?
-	`
-
-	var upgradeInfoRow info
-	err = db.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
-		row := tx.QueryRowContext(ctx, q, upgradeUUID)
-		if err := row.Scan(&upgradeInfoRow.UUID, &upgradeInfoRow.PreviousVersion, &upgradeInfoRow.TargetVersion, &upgradeInfoRow.State); err != nil {
-			return errors.Trace(err)
-		}
-		return nil
-	})
-	if err != nil {
-		return upgrade.Info{}, errors.Trace(err)
+	info := Info{
+		UUID: upgradeUUID.String(),
 	}
 
-	result, err := upgradeInfoRow.ToUpgradeInfo()
+	stmt, err := st.Prepare(`
+SELECT &Info.*
+FROM upgrade_info 
+WHERE uuid = $Info.uuid
+`, info)
+
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		err = tx.Query(ctx, stmt, info).Get(&info)
+		if errors.Is(err, sqlair.ErrNoRows) {
+			return errors.Annotatef(upgradeerrors.NotFound, "upgrade %q", upgradeUUID)
+		}
+		return err
+	})
+	if err != nil {
+		return upgrade.Info{}, errors.Trace(domain.CoerceError(err))
+	}
+
+	result, err := info.ToUpgradeInfo()
 	return result, errors.Trace(err)
+}
+
+// updateState updates the state of an ongoing upgrade.
+func (st *State) updateState(ctx context.Context, tx *sqlair.TX, uuid string, from upgrade.State, to upgrade.State) error {
+	if err := from.TransitionTo(to); err != nil {
+		if errors.Is(err, upgrade.ErrAlreadyAtState) {
+			return nil
+		}
+		return errors.Trace(err)
+	}
+
+	info := Info{
+		UUID: uuid,
+	}
+	m := sqlair.M{
+		"from": from,
+		"to":   to,
+	}
+	stmt, err := st.Prepare(`
+UPDATE upgrade_info 
+SET state_type_id = $M.to
+WHERE uuid = $Info.uuid
+AND state_type_id = $M.from;`, info, m)
+	if err != nil {
+		return errors.Annotatef(err, "preparing update from %q to %q statement", from, to)
+	}
+
+	var outcome sqlair.Outcome
+	if err = tx.Query(ctx, stmt, info, m).Get(&outcome); err != nil {
+		return errors.Trace(err)
+	}
+	if num, err := outcome.Result().RowsAffected(); err != nil {
+		return errors.Trace(err)
+	} else if num != 1 {
+		return errors.Errorf("setting from %q to %q, but %d rows were affected", from, to, num)
+	}
+	return nil
 }

--- a/internal/worker/upgradedatabase/worker_test.go
+++ b/internal/worker/upgradedatabase/worker_test.go
@@ -96,7 +96,7 @@ func (s *workerSuite) TestWatchUpgradeCompleted(c *gc.C) {
 	//  - Watch for the upgrade to be failed, but do not act upon it.
 
 	srv := s.upgradeService.EXPECT()
-	srv.CreateUpgrade(gomock.Any(), cfg.FromVersion, cfg.ToVersion).Return(domainupgrade.UUID(""), upgradeerrors.ErrUpgradeAlreadyStarted)
+	srv.CreateUpgrade(gomock.Any(), cfg.FromVersion, cfg.ToVersion).Return(domainupgrade.UUID(""), upgradeerrors.AlreadyExists)
 	srv.ActiveUpgrade(gomock.Any()).Return(s.upgradeUUID, nil)
 	srv.UpgradeInfo(gomock.Any(), s.upgradeUUID).Return(upgrade.Info{State: upgrade.Created}, nil)
 	srv.SetControllerReady(gomock.Any(), s.upgradeUUID, "0").Return(nil)
@@ -157,7 +157,7 @@ func (s *workerSuite) TestWatchUpgradeCompletedErrorSetControllerReady(c *gc.C) 
 	done := make(chan struct{})
 
 	srv := s.upgradeService.EXPECT()
-	srv.CreateUpgrade(gomock.Any(), cfg.FromVersion, cfg.ToVersion).Return(domainupgrade.UUID(""), upgradeerrors.ErrUpgradeAlreadyStarted)
+	srv.CreateUpgrade(gomock.Any(), cfg.FromVersion, cfg.ToVersion).Return(domainupgrade.UUID(""), upgradeerrors.AlreadyExists)
 	srv.ActiveUpgrade(gomock.Any()).Return(s.upgradeUUID, nil)
 	srv.UpgradeInfo(gomock.Any(), s.upgradeUUID).Return(upgrade.Info{State: upgrade.Created}, nil)
 	srv.SetControllerReady(gomock.Any(), s.upgradeUUID, "0").Return(errors.Errorf("boom"))
@@ -213,7 +213,7 @@ func (s *workerSuite) TestWatchUpgradeCompletedErrorSetControllerReadyError(c *g
 	done := make(chan struct{})
 
 	srv := s.upgradeService.EXPECT()
-	srv.CreateUpgrade(gomock.Any(), cfg.FromVersion, cfg.ToVersion).Return(domainupgrade.UUID(""), upgradeerrors.ErrUpgradeAlreadyStarted)
+	srv.CreateUpgrade(gomock.Any(), cfg.FromVersion, cfg.ToVersion).Return(domainupgrade.UUID(""), upgradeerrors.AlreadyExists)
 	srv.ActiveUpgrade(gomock.Any()).Return(s.upgradeUUID, nil)
 	srv.UpgradeInfo(gomock.Any(), s.upgradeUUID).Return(upgrade.Info{State: upgrade.Created}, nil)
 	srv.SetControllerReady(gomock.Any(), s.upgradeUUID, "0").Return(errors.Errorf("boom"))
@@ -260,11 +260,11 @@ func (s *workerSuite) TestWatchUpgradeCompletedNotFound(c *gc.C) {
 	done := make(chan struct{})
 
 	srv := s.upgradeService.EXPECT()
-	srv.CreateUpgrade(gomock.Any(), cfg.FromVersion, cfg.ToVersion).Return(domainupgrade.UUID(""), upgradeerrors.ErrUpgradeAlreadyStarted)
+	srv.CreateUpgrade(gomock.Any(), cfg.FromVersion, cfg.ToVersion).Return(domainupgrade.UUID(""), upgradeerrors.AlreadyExists)
 	srv.ActiveUpgrade(gomock.Any()).Return(s.upgradeUUID, nil)
 	srv.UpgradeInfo(gomock.Any(), s.upgradeUUID).DoAndReturn(func(ctx context.Context, uuid domainupgrade.UUID) (upgrade.Info, error) {
 		defer close(done)
-		return upgrade.Info{State: upgrade.Created}, errors.NotFoundf("boom")
+		return upgrade.Info{State: upgrade.Created}, upgradeerrors.NotFound
 	})
 
 	w, err := NewUpgradeDatabaseWorker(cfg)
@@ -298,7 +298,7 @@ func (s *workerSuite) TestWatchUpgradeCompletedInErrorState(c *gc.C) {
 	done := make(chan struct{})
 
 	srv := s.upgradeService.EXPECT()
-	srv.CreateUpgrade(gomock.Any(), cfg.FromVersion, cfg.ToVersion).Return(domainupgrade.UUID(""), upgradeerrors.ErrUpgradeAlreadyStarted)
+	srv.CreateUpgrade(gomock.Any(), cfg.FromVersion, cfg.ToVersion).Return(domainupgrade.UUID(""), upgradeerrors.AlreadyExists)
 	srv.ActiveUpgrade(gomock.Any()).Return(s.upgradeUUID, nil)
 	srv.UpgradeInfo(gomock.Any(), s.upgradeUUID).DoAndReturn(func(ctx context.Context, uuid domainupgrade.UUID) (upgrade.Info, error) {
 		defer close(done)
@@ -347,7 +347,7 @@ func (s *workerSuite) TestWatchUpgradeFailed(c *gc.C) {
 	sync := make(chan struct{})
 
 	srv := s.upgradeService.EXPECT()
-	srv.CreateUpgrade(gomock.Any(), cfg.FromVersion, cfg.ToVersion).Return(domainupgrade.UUID(""), upgradeerrors.ErrUpgradeAlreadyStarted)
+	srv.CreateUpgrade(gomock.Any(), cfg.FromVersion, cfg.ToVersion).Return(domainupgrade.UUID(""), upgradeerrors.AlreadyExists)
 	srv.ActiveUpgrade(gomock.Any()).Return(s.upgradeUUID, nil)
 	srv.UpgradeInfo(gomock.Any(), s.upgradeUUID).Return(upgrade.Info{State: upgrade.Created}, nil)
 	srv.SetControllerReady(gomock.Any(), s.upgradeUUID, "0").Return(nil)
@@ -399,8 +399,8 @@ func (s *workerSuite) TestWatchUpgradeError(c *gc.C) {
 	//  - Get the active upgrade, but it doesn't exist.
 
 	srv := s.upgradeService.EXPECT()
-	srv.CreateUpgrade(gomock.Any(), cfg.FromVersion, cfg.ToVersion).Return(domainupgrade.UUID(""), upgradeerrors.ErrUpgradeAlreadyStarted)
-	srv.ActiveUpgrade(gomock.Any()).Return(s.upgradeUUID, errors.NotFoundf("no upgrade"))
+	srv.CreateUpgrade(gomock.Any(), cfg.FromVersion, cfg.ToVersion).Return(domainupgrade.UUID(""), upgradeerrors.AlreadyExists)
+	srv.ActiveUpgrade(gomock.Any()).Return(s.upgradeUUID, upgradeerrors.NotFound)
 
 	w, err := NewUpgradeDatabaseWorker(cfg)
 	c.Assert(err, jc.ErrorIsNil)

--- a/internal/worker/upgradesteps/controllerworker.go
+++ b/internal/worker/upgradesteps/controllerworker.go
@@ -36,10 +36,11 @@ type UpgradeService interface {
 	// SetDBUpgradeFailed marks the upgrade as failed in the database.
 	// Manual intervention will be required if this has been invoked.
 	SetDBUpgradeFailed(ctx context.Context, upgradeUUID domainupgrade.UUID) error
-	// ActiveUpgrade returns the uuid of the current active upgrade.
-	// If there are no active upgrades, return a NotFound error
+	// ActiveUpgrade returns the uuid of the current active upgrade. If there
+	// are no active upgrades, return an upgradeerrors.NotFound error.
 	ActiveUpgrade(ctx context.Context) (domainupgrade.UUID, error)
-	// // UpgradeInfo returns the upgrade info for the supplied upgradeUUID.
+	// UpgradeInfo returns the upgrade info for the supplied upgradeUUID. If
+	// there are no active upgrades, return an upgradeerrors.NotFound error.
 	UpgradeInfo(ctx context.Context, upgradeUUID domainupgrade.UUID) (upgrade.Info, error)
 	// WatchForUpgradeState creates a watcher which notifies when the upgrade
 	// has reached the given state.
@@ -136,7 +137,7 @@ func (w *controllerWorker) run() error {
 		return errors.Trace(err)
 	}
 
-	// Verify the the active upgrade information is at the correct state.
+	// Verify the active upgrade information is at the correct state.
 	info, err := w.upgradeService.UpgradeInfo(ctx, upgradeUUID)
 	if err != nil {
 		return errors.Trace(err)


### PR DESCRIPTION
This commit changes the upgrade domain to use SQLair, but some other issues were also found with it while changing.

For one, database errors were escaping from state and being caught at the service layer. It makes a lot more sense to catch these errors next to the queries that caused them, especially when the function has multiple queries in it. I have moved all of the catching of these errors onto the actual state.

There were also some comments that didn't match the error that was given out. I have reworked the errors to match what I believe to be the intended behaviour and fixed the callers of the function.

The generic `NotFound` error was also used here. I have changed that to a specific `upgradeerorros.NotFound`.

There were also some tests for `SetControllerDone` that appeared incomplete. I have fixed these and made behaviour expectations consistent across the comments.

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps
### Unit tests
```
go test -v -tags=libsqlite3,dqlite ./domain/upgrade/... -check.v -check.f Suite
go test -v -tags=libsqlite3,dqlite ./internal/worker/upgradedatabase/... -check.v -check.f Suite
go test -v -tags=libsqlite3,dqlite ./internal/worker/upgradesteps/... -check.v -check.f Suite
```
### Integration tests
First apply this diff to allow the upgrade:
```diff
diff --git a/environs/sync/sync.go b/environs/sync/sync.go
index fa63d84426..f536f5e434 100644
--- a/environs/sync/sync.go
+++ b/environs/sync/sync.go
@@ -316,12 +316,12 @@ func buildAgentTarball(
        builtVersion.Build = 0
        clientVersion := jujuversion.Current
        clientVersion.Build = 0
-       if builtVersion.Number.Compare(clientVersion) != 0 {
-               return nil, errors.Errorf(
-                       "agent binary %v not compatible with bootstrap client %v",
-                       toolsVersion.Number, jujuversion.Current,
-               )
-       }
+       // if builtVersion.Number.Compare(clientVersion) != 0 {
+       //      return nil, errors.Errorf(
+       //              "agent binary %v not compatible with bootstrap client %v",
+       //              toolsVersion.Number, jujuversion.Current,
+       //      )
+       // }
        fileInfo, err := f.Stat()
        if err != nil {
                return nil, errors.Errorf("cannot stat newly made agent binary archive: %v", err)
```

Then update the patch version in `version/version.go`

```diff
diff --git a/version/version.go b/version/version.go
index 33b01db1af..3f599876ed 100644
--- a/version/version.go
+++ b/version/version.go
@@ -18,7 +18,7 @@ import (
 // The presence and format of this constant is very important.
 // The debian/rules build recipe uses this value for the version
 // number of the release package.
-const version = "4.0-beta4"
+const version = "4.0-beta5"

 // UserAgentVersion defines a user agent version used for communication for
 // outside resources.
```

```sh
$ juju bootstrap lxd test --build-agent
$ juju add-model default
$ juju upgrade-controller --build-agent
```



<!-- Describe steps to verify that the change works. -->

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Jira card:** [JUJU-6274](https://warthogs.atlassian.net/browse/JUJU-6274)



[JUJU-6274]: https://warthogs.atlassian.net/browse/JUJU-6274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ