### PR TITLE
fix(machine): only destroy controller machines with force

### DIFF
--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -46,7 +46,6 @@ const (
 	cleanupDyingMachine                  cleanupKind = "dyingMachine"
 	cleanupForceDestroyedMachine         cleanupKind = "machine"
 	cleanupForceRemoveMachine            cleanupKind = "forceRemoveMachine"
-	cleanupEvacuateMachine               cleanupKind = "evacuateMachine"
 	cleanupAttachmentsForDyingStorage    cleanupKind = "storageAttachments"
 	cleanupAttachmentsForDyingVolume     cleanupKind = "volumeAttachments"
 	cleanupAttachmentsForDyingFilesystem cleanupKind = "filesystemAttachments"
@@ -220,8 +219,6 @@ func (st *State) Cleanup() (err error) {
 			err = st.cleanupForceDestroyedMachine(doc.Prefix, args)
 		case cleanupForceRemoveMachine:
 			err = st.cleanupForceRemoveMachine(doc.Prefix, args)
-		case cleanupEvacuateMachine:
-			err = st.cleanupEvacuateMachine(doc.Prefix, args)
 		case cleanupAttachmentsForDyingStorage:
 			err = st.cleanupAttachmentsForDyingStorage(doc.Prefix, args)
 		case cleanupAttachmentsForDyingVolume:
@@ -1437,62 +1434,6 @@ func (st *State) cleanupForceRemoveMachine(machineId string, cleanupArgs []bson.
 		return errors.Trace(err)
 	}
 	return machine.Remove()
-}
-
-// cleanupEvacuateMachine is initiated by machine.Destroy() to gracefully remove units
-// from the machine before then kicking off machine destroy.
-func (st *State) cleanupEvacuateMachine(machineId string, cleanupArgs []bson.Raw) error {
-	if len(cleanupArgs) > 0 {
-		return errors.Errorf("expected no arguments, got %d", len(cleanupArgs))
-	}
-
-	machine, err := st.Machine(machineId)
-	if errors.IsNotFound(err) {
-		return nil
-	} else if err != nil {
-		return errors.Trace(err)
-	}
-	if machine.Life() != Alive {
-		return nil
-	}
-
-	units, err := machine.Units()
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	if len(units) == 0 {
-		if err := machine.advanceLifecycle(Dying, false, false, 0); err != nil {
-			return errors.Trace(err)
-		}
-		return nil
-	}
-
-	buildTxn := func(attempt int) ([]txn.Op, error) {
-		if attempt > 0 {
-			units, err = machine.Units()
-			if err != nil {
-				return nil, errors.Trace(err)
-			}
-		}
-		var ops []txn.Op
-		for _, unit := range units {
-			destroyOp := unit.DestroyOperation()
-			op, err := destroyOp.Build(attempt)
-			if err != nil && !errors.Is(err, jujutxn.ErrNoOperations) {
-				return nil, errors.Trace(err)
-			}
-			ops = append(ops, op...)
-		}
-		return ops, nil
-	}
-
-	err = st.db().Run(buildTxn)
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	return errors.Errorf("waiting for units to be removed from %s", machineId)
 }
 
 // cleanupContainers recursively calls cleanupForceDestroyedMachine on the supplied

--- a/state/cleanup_test.go
+++ b/state/cleanup_test.go
@@ -6,7 +6,6 @@ package state_test
 import (
 	"bytes"
 	"sort"
-	"strconv"
 	"time"
 
 	"github.com/juju/charm/v12"
@@ -472,64 +471,6 @@ func (s *CleanupSuite) TestDestroyControllerMachineErrors(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "controller 0 is the only controller")
 	s.assertDoesNotNeedCleanup(c)
 	assertLife(c, manager, state.Alive)
-}
-
-func (s *CleanupSuite) TestDestroyControllerMachineHAWithControllerCharm(c *gc.C) {
-	cons := constraints.Value{
-		Mem: newUint64(100),
-	}
-	changes, err := s.State.EnableHA(3, cons, state.UbuntuBase("12.04"), nil)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(changes.Added, gc.HasLen, 3)
-
-	ch := s.AddTestingCharmWithSeries(c, "juju-controller", "")
-	app := s.AddTestingApplicationForBase(c, state.UbuntuBase("12.04"), "controller", ch)
-
-	var machines []*state.Machine
-	var units []*state.Unit
-	for i := 0; i < 3; i++ {
-		m, err := s.State.Machine(strconv.Itoa(i))
-		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(m.Jobs(), gc.DeepEquals, []state.MachineJob{
-			state.JobHostUnits,
-			state.JobManageModel,
-		})
-
-		if i == 0 {
-			node, err := s.State.ControllerNode(m.Id())
-			c.Assert(err, jc.ErrorIsNil)
-			node.SetHasVote(true)
-		}
-
-		u, err := app.AddUnit(state.AddUnitParams{})
-		c.Assert(err, jc.ErrorIsNil)
-		err = u.SetCharmURL(ch.URL())
-		c.Assert(err, jc.ErrorIsNil)
-		err = u.AssignToMachine(m)
-		c.Assert(err, jc.ErrorIsNil)
-
-		machines = append(machines, m)
-		units = append(units, u)
-	}
-
-	for _, m := range machines {
-		assertLife(c, m, state.Alive)
-	}
-	for _, u := range units {
-		assertLife(c, u, state.Alive)
-	}
-
-	s.assertDoesNotNeedCleanup(c)
-	err = machines[2].Destroy()
-	c.Assert(err, jc.ErrorIsNil)
-
-	s.assertNeedsCleanup(c)
-	s.assertNextCleanup(c, "evacuateMachine(2)")
-	s.assertNeedsCleanup(c)
-	s.assertNextCleanup(c, `removedUnit("controller/2")`)
-	s.assertNeedsCleanup(c)
-	s.assertNextCleanup(c, "evacuateMachine(2)")
-	s.assertDoesNotNeedCleanup(c)
 }
 
 const dontWait = time.Duration(0)

--- a/state/machine.go
+++ b/state/machine.go
@@ -604,76 +604,7 @@ func (m *Machine) PasswordValid(password string) bool {
 // a HasAssignedUnitsError.  If the machine has containers, Destroy
 // will return HasContainersError.
 func (m *Machine) Destroy() error {
-	if m.IsManager() && len(m.doc.Principals) > 0 {
-		return errors.Trace(m.destroyControllerWithPrincipals())
-	}
 	return errors.Trace(m.advanceLifecycle(Dying, false, false, 0))
-}
-
-// destroyControllerWithPrincipals is called if the controller has
-// principal units and they are juju- system charms, then gracefully
-// remove them before destroying the machine.
-func (m *Machine) destroyControllerWithPrincipals() error {
-	units, err := m.Units()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	unitsMap := make(map[string]*Unit)
-	for _, unit := range units {
-		unitsMap[unit.String()] = unit
-	}
-	var evacuablePrincipals []string
-	for _, principalUnit := range m.doc.Principals {
-		unit, ok := unitsMap[principalUnit]
-		if !ok {
-			continue
-		}
-		curlStr := unit.CharmURL()
-		if curlStr == nil {
-			continue
-		}
-		curl, err := charm.ParseURL(*curlStr)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		if curl != nil && strings.HasPrefix(curl.Name, "juju-") {
-			evacuablePrincipals = append(evacuablePrincipals, principalUnit)
-		}
-	}
-	if len(m.doc.Principals) != len(evacuablePrincipals) {
-		return stateerrors.NewHasAssignedUnitsError(m.doc.Id, m.doc.Principals)
-	}
-	ops := []txn.Op{
-		{
-			C:  machinesC,
-			Id: m.doc.DocID,
-			Assert: bson.D{
-				{"life", Alive},
-				advanceLifecycleUnitAsserts(evacuablePrincipals),
-			},
-			// To prevent race conditions, we remove the ability for new
-			// units to be deployed to the machine.
-			Update: bson.D{{"$pull", bson.D{{"jobs", JobHostUnits}}}},
-		},
-		newCleanupOp(cleanupEvacuateMachine, m.doc.Id),
-	}
-	if err := m.st.db().RunTransaction(ops); err != nil {
-		return errors.Annotatef(err, "failed to run transaction: %s", pretty.Sprint(ops))
-	}
-	for i, v := range m.doc.Jobs {
-		if v == JobHostUnits {
-			m.doc.Jobs = append(m.doc.Jobs[:i], m.doc.Jobs[i+1:]...)
-			break
-		}
-	}
-	err = m.SetStatus(status.StatusInfo{
-		Status:  status.Stopped,
-		Message: fmt.Sprintf("waiting on dying units %s", strings.Join(evacuablePrincipals, ", ")),
-	})
-	if err != nil {
-		return errors.Trace(err)
-	}
-	return nil
 }
 
 // DestroyWithContainers sets the machine lifecycle to Dying if it is Alive.

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -366,11 +366,11 @@ func (s *MachineSuite) TestLifeJobManageModelWithControllerCharm(c *gc.C) {
 	for i := 0; i < 3; i++ {
 		needsCleanup, err := s.State.NeedsCleanup()
 		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(needsCleanup, jc.IsFalse)
+		c.Assert(needsCleanup, jc.IsTrue)
 	}
 	needsCleanup, err := s.State.NeedsCleanup()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(needsCleanup, jc.IsFalse)
+	c.Assert(needsCleanup, jc.IsTrue)
 
 	err = m2.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
@@ -380,6 +380,8 @@ func (s *MachineSuite) TestLifeJobManageModelWithControllerCharm(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = s.State.RemoveControllerReference(cn2)
 	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(s.State.Cleanup(), jc.ErrorIsNil)
 
 	err = m2.EnsureDead()
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -357,7 +357,7 @@ func (s *MachineSuite) TestLifeJobManageModelWithControllerCharm(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = unit.AssignToMachine(m2)
 	c.Assert(err, jc.ErrorIsNil)
-	err = m2.Destroy()
+	err = m2.ForceDestroy(dontWait)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(m2.Life(), gc.Equals, state.Alive)
@@ -366,9 +366,7 @@ func (s *MachineSuite) TestLifeJobManageModelWithControllerCharm(c *gc.C) {
 	for i := 0; i < 3; i++ {
 		needsCleanup, err := s.State.NeedsCleanup()
 		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(needsCleanup, jc.IsTrue)
-		err = s.State.Cleanup()
-		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(needsCleanup, jc.IsFalse)
 	}
 	needsCleanup, err := s.State.NeedsCleanup()
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
We have an incoherent behavior when destroying machines: 
- In a model machine with a deployed unit, a message is displayed stating that it needs to be destroyed with --force because a unit is deployed. 
- On a controller machine (with the controller unit deployed on it) we also get the displayed message but then it gets destroyed without passing --force.

The fix here is simply to remove a path that ensured graceful cleanup of the controller unit (https://github.com/juju/juju/pull/14204) in the case it was a controller machine. Thus, the resulting path will be the same both for model and controller machines.

## Checklist


- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Bootstrap a controller, create a model and deploy ubuntu:
```
juju bootstrap localhost c
juju add-model m
juju deploy ubuntu
```
If we try to remove the machine `0`, we'll get an error unless we pass `--force` because the ubuntu unit is deployed. This behavior didn't change with this patch.
```
juju remove-machine 0
WARNING This command will perform the following actions:
will remove machine 0
- will remove unit ubuntu/0

This will require `--force`

Continue [y/N]? y
ERROR removing machine failed: machine 0 has unit "ubuntu/0" assigned

juju remove-machine 0 --force
WARNING This command will perform the following actions:
will remove machine 0
- will remove unit ubuntu/0

Continue [y/N]? y

```
Now, lets `enable-ha` on the controller and try to remove one machine:

```
juju enable-ha
juju status -m controller
juju status -m controller
Model       Controller  Cloud/Region         Version  SLA          Timestamp
controller  c           localhost/localhost  3.4.5.1  unsupported  10:58:12+02:00

App         Version  Status  Scale  Charm            Channel     Rev  Exposed  Message
controller           active      3  juju-controller  3.4/stable  101  no

Unit           Workload  Agent  Machine  Public address  Ports  Message
controller/0*  active    idle   0        10.170.236.52
controller/1   active    idle   1        10.170.236.140
controller/2   active    idle   2        10.170.236.196

Machine  State    Address         Inst id        Base          AZ  Message
0        started  10.170.236.52   juju-04fca4-0  ubuntu@22.04      Running
1        started  10.170.236.140  juju-04fca4-1  ubuntu@22.04      Running
2        started  10.170.236.196  juju-04fca4-2  ubuntu@22.04      Running

# This should fail now:
juju  remove-machine -m controller 2
WARNING This command will perform the following actions:
will remove machine 2
- will remove unit controller/2

This will require `--force`

Continue [y/N]? y
ERROR removing machine failed: machine 2 has unit "controller/2" assigned

# But this of course will work:
juju remove-machine -m controller 2 --force
WARNING This command will perform the following actions:
will remove machine 2
- will remove unit controller/2

Continue [y/N]? y

# Also remove machine 1:
juju remove-machine -m controller 1 --force
WARNING This command will perform the following actions:
will remove machine 1
- will remove unit controller/1

Continue [y/N]? y

# Now we are left with only one controller machine (and unit):
juju status -m controller                                  thinkpad: Thu Jul  4 12:24:30 2024

Model       Controller  Cloud/Region         Version  SLA          Timestamp
controller  c           localhost/localhost  3.4.5.1  unsupported  12:24:30+02:00

App         Version  Status  Scale  Charm            Channel     Rev  Exposed  Message
controller           active      1  juju-controller  3.4/stable  101  no

Unit           Workload  Agent  Machine  Public address  Ports  Message
controller/0*  active    idle   0        10.170.236.159

Machine  State    Address         Inst id        Base          AZ  Message
0        started  10.170.236.159  juju-08b221-0  ubuntu@22.04      Running
```
At this point, if you try to remove the machine `0` it'll fail because it's the last controller:
```
juju remove-machine -m controller 0 --force
WARNING This command will perform the following actions:
will remove machine 0
- will remove unit controller/0

Continue [y/N]? y
ERROR removing machine failed: controller 0 is the only controller
```

## Documentation changes

This page https://juju.is/docs/juju/manage-controllers#heading--make-a-controller-highly-available should be updated so the controller removal `juju remove-machine -m controller 1` becomes `juju remove-machine -m controller 1 --force`.
## Links

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2071617

**Jira card:** JUJU-6302

