### PR TITLE
feat(domain): crud for machine reboot management in DQLite

### DIFF
--- a/domain/machine/service/package_mock_test.go
+++ b/domain/machine/service/package_mock_test.go
@@ -81,6 +81,44 @@ func (c *MockStateAllMachineNamesCall) DoAndReturn(f func(context.Context) ([]ma
 	return c
 }
 
+// CancelMachineReboot mocks base method.
+func (m *MockState) CancelMachineReboot(arg0 context.Context, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CancelMachineReboot", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CancelMachineReboot indicates an expected call of CancelMachineReboot.
+func (mr *MockStateMockRecorder) CancelMachineReboot(arg0, arg1 any) *MockStateCancelMachineRebootCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CancelMachineReboot", reflect.TypeOf((*MockState)(nil).CancelMachineReboot), arg0, arg1)
+	return &MockStateCancelMachineRebootCall{Call: call}
+}
+
+// MockStateCancelMachineRebootCall wrap *gomock.Call
+type MockStateCancelMachineRebootCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateCancelMachineRebootCall) Return(arg0 error) *MockStateCancelMachineRebootCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateCancelMachineRebootCall) Do(f func(context.Context, string) error) *MockStateCancelMachineRebootCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateCancelMachineRebootCall) DoAndReturn(f func(context.Context, string) error) *MockStateCancelMachineRebootCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // CreateMachine mocks base method.
 func (m *MockState) CreateMachine(arg0 context.Context, arg1 machine.Name, arg2, arg3 string) error {
 	m.ctrl.T.Helper()
@@ -386,6 +424,83 @@ func (c *MockStateInstanceStatusCall) Do(f func(context.Context, machine.Name) (
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockStateInstanceStatusCall) DoAndReturn(f func(context.Context, machine.Name) (string, error)) *MockStateInstanceStatusCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// IsMachineRebootRequired mocks base method.
+func (m *MockState) IsMachineRebootRequired(arg0 context.Context, arg1 string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsMachineRebootRequired", arg0, arg1)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IsMachineRebootRequired indicates an expected call of IsMachineRebootRequired.
+func (mr *MockStateMockRecorder) IsMachineRebootRequired(arg0, arg1 any) *MockStateIsMachineRebootRequiredCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsMachineRebootRequired", reflect.TypeOf((*MockState)(nil).IsMachineRebootRequired), arg0, arg1)
+	return &MockStateIsMachineRebootRequiredCall{Call: call}
+}
+
+// MockStateIsMachineRebootRequiredCall wrap *gomock.Call
+type MockStateIsMachineRebootRequiredCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateIsMachineRebootRequiredCall) Return(arg0 bool, arg1 error) *MockStateIsMachineRebootRequiredCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateIsMachineRebootRequiredCall) Do(f func(context.Context, string) (bool, error)) *MockStateIsMachineRebootRequiredCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateIsMachineRebootRequiredCall) DoAndReturn(f func(context.Context, string) (bool, error)) *MockStateIsMachineRebootRequiredCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// RequireMachineReboot mocks base method.
+func (m *MockState) RequireMachineReboot(arg0 context.Context, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RequireMachineReboot", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RequireMachineReboot indicates an expected call of RequireMachineReboot.
+func (mr *MockStateMockRecorder) RequireMachineReboot(arg0, arg1 any) *MockStateRequireMachineRebootCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequireMachineReboot", reflect.TypeOf((*MockState)(nil).RequireMachineReboot), arg0, arg1)
+	return &MockStateRequireMachineRebootCall{Call: call}
+}
+
+// MockStateRequireMachineRebootCall wrap *gomock.Call
+type MockStateRequireMachineRebootCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateRequireMachineRebootCall) Return(arg0 error) *MockStateRequireMachineRebootCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateRequireMachineRebootCall) Do(f func(context.Context, string) error) *MockStateRequireMachineRebootCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateRequireMachineRebootCall) DoAndReturn(f func(context.Context, string) error) *MockStateRequireMachineRebootCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/machine/service/service.go
+++ b/domain/machine/service/service.go
@@ -53,6 +53,15 @@ type State interface {
 	// DeleteMachineCloudInstance removes an entry in the machine cloud instance table
 	// along with the instance tags and the link to a lxd profile if any.
 	DeleteMachineCloudInstance(context.Context, string) error
+
+	// RequireMachineReboot sets the machine referenced by its UUID as requiring a reboot.
+	RequireMachineReboot(ctx context.Context, uuid string) error
+
+	// CancelMachineReboot cancels the reboot of the machine referenced by its UUID if it has previously been required.
+	CancelMachineReboot(ctx context.Context, uuid string) error
+
+	// IsMachineRebootRequired checks if the machine referenced by its UUID requires a reboot.
+	IsMachineRebootRequired(ctx context.Context, uuid string) (bool, error)
 }
 
 // Service provides the API for working with machines.
@@ -126,4 +135,20 @@ func (s *Service) InstanceStatus(ctx context.Context, machineName machine.Name) 
 		return "", errors.Annotatef(err, "retrieving cloud instance status for machine %q", machineName)
 	}
 	return instanceStatus, nil
+}
+
+// RequireMachineReboot sets the machine referenced by its UUID as requiring a reboot.
+func (s *Service) RequireMachineReboot(ctx context.Context, uuid string) error {
+	return errors.Annotatef(s.st.RequireMachineReboot(ctx, uuid), "requiring a machine reboot for machine with uuid %q", uuid)
+}
+
+// CancelMachineReboot cancels the reboot of the machine referenced by its UUID if it has previously been required.
+func (s *Service) CancelMachineReboot(ctx context.Context, uuid string) error {
+	return errors.Annotatef(s.st.CancelMachineReboot(ctx, uuid), "cancelling a machine reboot for machine with uuid %q", uuid)
+}
+
+// IsMachineRebootRequired checks if the machine referenced by its UUID requires a reboot.
+func (s *Service) IsMachineRebootRequired(ctx context.Context, uuid string) (bool, error) {
+	rebootRequired, err := s.st.IsMachineRebootRequired(ctx, uuid)
+	return rebootRequired, errors.Annotatef(err, "checking if machine with uuid %q is requiring a reboot", uuid)
 }

--- a/domain/machine/state/state.go
+++ b/domain/machine/state/state.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/juju/domain"
 	blockdevice "github.com/juju/juju/domain/blockdevice/state"
 	"github.com/juju/juju/domain/life"
+	"github.com/juju/juju/internal/database"
 )
 
 // State describes retrieval and persistence methods for storage.
@@ -218,4 +219,84 @@ func (st *State) AllMachineNames(ctx context.Context) ([]machine.Name, error) {
 	machineNames := transform.Slice[machineName, machine.Name](results, func(r machineName) machine.Name { return machine.Name(r.Name) })
 
 	return machineNames, nil
+}
+
+type machineReboot struct {
+	UUID string `db:"uuid"`
+}
+
+// RequireMachineReboot sets the machine referenced by its UUID as requiring a reboot.
+//
+// Reboot requests are handled through the "machine_requires_reboot" table which contains only
+// machine UUID for which a reboot has been requested.
+// This function is idempotent.
+func (st *State) RequireMachineReboot(ctx context.Context, uuid string) error {
+	db, err := st.DB()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	setRebootFlag := `INSERT INTO machine_requires_reboot (machine_uuid) VALUES ($machineReboot.uuid)`
+	setRebootFlagStmt, err := sqlair.Prepare(setRebootFlag, machineReboot{})
+	if err != nil {
+		return errors.Trace(err)
+	}
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		return tx.Query(ctx, setRebootFlagStmt, machineReboot{uuid}).Run()
+	})
+	if database.IsErrConstraintPrimaryKey(err) {
+		// if the same uuid is added twice, do nothing (idempotency)
+		return nil
+	}
+	return errors.Annotatef(err, "requiring reboot of machine %q", uuid)
+}
+
+// CancelMachineReboot cancels the reboot of the machine referenced by its UUID if it has
+// previously been required.
+//
+// It basically removes the uuid from the "machine_requires_reboot" table if present.
+// This function is idempotent.
+func (st *State) CancelMachineReboot(ctx context.Context, uuid string) error {
+	db, err := st.DB()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	unsetRebootFlag := `DELETE FROM machine_requires_reboot WHERE machine_uuid = $machineReboot.uuid`
+	unsetRebootFlagStmt, err := sqlair.Prepare(unsetRebootFlag, machineReboot{})
+	if err != nil {
+		return errors.Trace(err)
+	}
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		return tx.Query(ctx, unsetRebootFlagStmt, machineReboot{uuid}).Run()
+	})
+	return errors.Annotatef(err, "cancelling reboot of machine %q", uuid)
+}
+
+// IsMachineRebootRequired checks if the specified machine requires a reboot.
+//
+// It queries the "machine_requires_reboot" table for the machine UUID to determine if a reboot is required.
+// Returns a boolean value indicating if a reboot is required, and an error if any occur during the process.
+func (st *State) IsMachineRebootRequired(ctx context.Context, uuid string) (bool, error) {
+	db, err := st.DB()
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+
+	var isRebootRequired bool
+	isRebootFlag := `SELECT machine_uuid as &machineReboot.uuid  FROM machine_requires_reboot WHERE machine_uuid = $machineReboot.uuid`
+	isRebootFlagStmt, err := sqlair.Prepare(isRebootFlag, machineReboot{})
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		var results machineReboot
+		err := tx.Query(ctx, isRebootFlagStmt, machineReboot{uuid}).Get(&results)
+		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+			return errors.Trace(err)
+		}
+		isRebootRequired = !errors.Is(err, sqlair.ErrNoRows)
+		return nil
+	})
+
+	return isRebootRequired, errors.Annotatef(err, "requiring reboot of machine %q", uuid)
 }


### PR DESCRIPTION
This is the second step to back machine reboot in dqlite. It add the db and service layer to the domain/machine package.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

Unit test should pass.

## Documentation changes

None

## Links

**Jira card:** [JUJU-6306](https://warthogs.atlassian.net/jira/software/c/projects/JUJU/boards/844?assignee=712020%3Ad1cc9962-ecb6-4e6f-b72f-c33add4eeb4a&selectedIssue=JUJU-6306)



[JUJU-6306]: https://warthogs.atlassian.net/browse/JUJU-6306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ