### PR TITLE
fix: use correct LXD profile on state.Charm struct

### DIFF
--- a/.github/workflows/terraform-smoke.yml
+++ b/.github/workflows/terraform-smoke.yml
@@ -17,7 +17,7 @@ jobs:
 
   smoke:
     name: Terraform Smoke
-    runs-on: [self-hosted, linux, x64, aws, xlarge]
+    runs-on: [self-hosted, linux, x64, aws, xxlarge]
     if: github.event.pull_request.draft == false
     steps:
 

--- a/apiserver/common/charms/appcharminfo_test.go
+++ b/apiserver/common/charms/appcharminfo_test.go
@@ -17,7 +17,6 @@ import (
 	facademocks "github.com/juju/juju/apiserver/facade/mocks"
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/rpc/params"
-	"github.com/juju/juju/state"
 )
 
 type appCharmInfoSuite struct{}
@@ -46,7 +45,7 @@ func (s *appCharmInfoSuite) TestBasic(c *gc.C) {
 	ch.EXPECT().Actions().Return(&charm.Actions{})
 	ch.EXPECT().Metrics().Return(&charm.Metrics{})
 	ch.EXPECT().Manifest().Return(&charm.Manifest{})
-	ch.EXPECT().LXDProfile().Return(&state.LXDProfile{})
+	ch.EXPECT().LXDProfile().Return(&charm.LXDProfile{})
 
 	authorizer := facademocks.NewMockAuthorizer(ctrl)
 	authorizer.EXPECT().AuthController().Return(true)

--- a/apiserver/common/charms/charminfo_test.go
+++ b/apiserver/common/charms/charminfo_test.go
@@ -17,7 +17,6 @@ import (
 	facademocks "github.com/juju/juju/apiserver/facade/mocks"
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/rpc/params"
-	"github.com/juju/juju/state"
 )
 
 type charmInfoSuite struct{}
@@ -41,7 +40,7 @@ func (s *charmInfoSuite) TestBasic(c *gc.C) {
 	ch.EXPECT().Actions().Return(&charm.Actions{})
 	ch.EXPECT().Metrics().Return(&charm.Metrics{})
 	ch.EXPECT().Manifest().Return(&charm.Manifest{})
-	ch.EXPECT().LXDProfile().Return(&state.LXDProfile{})
+	ch.EXPECT().LXDProfile().Return(&charm.LXDProfile{})
 	ch.EXPECT().URL().Return("ch:foo-1")
 
 	authorizer := facademocks.NewMockAuthorizer(ctrl)

--- a/apiserver/common/charms/common.go
+++ b/apiserver/common/charms/common.go
@@ -33,7 +33,7 @@ type Charm interface {
 	Manifest() *charm.Manifest
 	Metrics() *charm.Metrics
 	Actions() *charm.Actions
-	LXDProfile() *state.LXDProfile
+	LXDProfile() *charm.LXDProfile
 }
 
 type Model interface {
@@ -334,7 +334,7 @@ func convertCharmExtraBindingMap(bindings map[string]charm.ExtraBinding) map[str
 	return result
 }
 
-func convertCharmLXDProfile(profile *state.LXDProfile) *params.CharmLXDProfile {
+func convertCharmLXDProfile(profile *charm.LXDProfile) *params.CharmLXDProfile {
 	return &params.CharmLXDProfile{
 		Description: profile.Description,
 		Config:      convertCharmLXDProfileConfig(profile.Config),

--- a/apiserver/common/charms/mocks/mocks.go
+++ b/apiserver/common/charms/mocks/mocks.go
@@ -14,7 +14,6 @@ import (
 
 	charm "github.com/juju/charm/v12"
 	charms "github.com/juju/juju/apiserver/common/charms"
-	state "github.com/juju/juju/state"
 	names "github.com/juju/names/v5"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -178,10 +177,10 @@ func (mr *MockCharmMockRecorder) Config() *gomock.Call {
 }
 
 // LXDProfile mocks base method.
-func (m *MockCharm) LXDProfile() *state.LXDProfile {
+func (m *MockCharm) LXDProfile() *charm.LXDProfile {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LXDProfile")
-	ret0, _ := ret[0].(*state.LXDProfile)
+	ret0, _ := ret[0].(*charm.LXDProfile)
 	return ret0
 }
 

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -303,7 +303,7 @@ func (s *applicationSuite) TestApplicationDeployToMachineWithLXDProfile(c *gc.C)
 	c.Assert(expected.Config(), gc.DeepEquals, ch.Config())
 
 	expectedProfile := ch.(charm.LXDProfiler).LXDProfile()
-	c.Assert(expected.LXDProfile(), gc.DeepEquals, &state.LXDProfile{
+	c.Assert(expected.LXDProfile(), gc.DeepEquals, &charm.LXDProfile{
 		Description: expectedProfile.Description,
 		Config:      expectedProfile.Config,
 		Devices:     expectedProfile.Devices,
@@ -357,7 +357,7 @@ func (s *applicationSuite) TestApplicationDeployToMachineWithInvalidLXDProfileAn
 	c.Assert(expected.Config(), gc.DeepEquals, ch.Config())
 
 	expectedProfile := ch.(charm.LXDProfiler).LXDProfile()
-	c.Assert(expected.LXDProfile(), gc.DeepEquals, &state.LXDProfile{
+	c.Assert(expected.LXDProfile(), gc.DeepEquals, &charm.LXDProfile{
 		Description: expectedProfile.Description,
 		Config:      expectedProfile.Config,
 		Devices:     expectedProfile.Devices,

--- a/state/charm.go
+++ b/state/charm.go
@@ -251,7 +251,7 @@ func insertCharmOps(mb modelBackend, info CharmInfo) ([]txn.Op, error) {
 	}
 	lpc, ok := info.Charm.(charm.LXDProfiler)
 	if !ok {
-		return nil, errors.New("charm does no implement LXDProfiler")
+		return nil, errors.New("charm does not implement LXDProfiler")
 	}
 	doc.LXDProfile = safeLXDProfile(lpc.LXDProfile())
 
@@ -490,6 +490,8 @@ type Charm struct {
 	charmURL *charm.URL
 }
 
+var _ charm.LXDProfiler = (*Charm)(nil)
+
 func newCharm(st *State, cdoc *charmDoc) *Charm {
 	// Because we probably just read the doc from state, make sure we
 	// unescape any config option names for "$" and ".". See
@@ -678,8 +680,15 @@ func (c *Charm) Actions() *charm.Actions {
 }
 
 // LXDProfile returns the lxd profile definition of the charm.
-func (c *Charm) LXDProfile() *LXDProfile {
-	return c.doc.LXDProfile
+func (c *Charm) LXDProfile() *charm.LXDProfile {
+	if c.doc.LXDProfile == nil {
+		return nil
+	}
+	return &charm.LXDProfile{
+		Config:      c.doc.LXDProfile.Config,
+		Description: c.doc.LXDProfile.Description,
+		Devices:     c.doc.LXDProfile.Devices,
+	}
 }
 
 // StoragePath returns the storage path of the charm bundle.


### PR DESCRIPTION
The terraform smoke tests fail intermittently deploying a charm. The error is:

 "charm does no implement LXDProfiler"

It turns out that with async charm download we can pass to insertCharmOps() a state.Charm struct. This struct has the method

`func (c *Charm) LXDProfile() *LXDProfile`

where it needs to be

`func (c *Charm) LXDProfile() *charm.LXDProfile`

This PR fixes the method signature so that state.Charm now implements charm.LXDProfiler.

As a drive by, use xxlarge runner for terraform smoke test job.

## QA steps

bootstrap 
juju deploy --revision=1 --channel=stable --base ubuntu@20.04 juju-qa-refresher
juju refresh refresher

## Links

**Jira card:** [JUJU-6326](https://warthogs.atlassian.net/browse/JUJU-6326)



[JUJU-6326]: https://warthogs.atlassian.net/browse/JUJU-6326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ