### PR TITLE
feat: use controller UUID in access perms

### DIFF
--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -225,7 +225,13 @@ func (b *AgentBootstrap) Initialize(ctx stdcontext.Context) (_ *state.Controller
 	adminUserUUID, addAdminUser := userbootstrap.AddUserWithPassword(
 		b.adminUser.Name(),
 		auth.NewPassword(info.Password),
-		permission.ControllerForAccess(permission.SuperuserAccess, controllerUUID.String()),
+		permission.AccessSpec{
+			Access: permission.SuperuserAccess,
+			Target: permission.ID{
+				ObjectType: permission.Controller,
+				Key:        controllerUUID.String(),
+			},
+		},
 	)
 
 	controllerModelArgs := modeldomain.ModelCreationArgs{

--- a/apiserver/admin.go
+++ b/apiserver/admin.go
@@ -468,7 +468,7 @@ func (a *admin) checkUserPermissions(authInfo authentication.AuthInfo, controlle
 			common.EveryoneTagName,
 			permission.ID{
 				ObjectType: permission.Controller,
-				Key:        "controller",
+				Key:        a.root.shared.controllerUUID,
 			},
 		)
 		if err != nil && !errors.Is(err, accesserrors.UserNotFound) && !errors.Is(err, accesserrors.PermissionNotFound) {

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -183,7 +183,7 @@ func (s *loginSuite) TestLoginAsDeactivatedUser(c *gc.C) {
 		DisplayName: "Charlie Brown",
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword(pass)),
-		Permission:  permission.ControllerForAccess(permission.LoginAccess),
+		Permission:  permission.ControllerForAccess(permission.LoginAccess, s.ControllerUUID),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -217,7 +217,7 @@ func (s *loginSuite) TestLoginAsDeletedUser(c *gc.C) {
 		DisplayName: "Charlie Brown",
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword(pass)),
-		Permission:  permission.ControllerForAccess(permission.LoginAccess),
+		Permission:  permission.ControllerForAccess(permission.LoginAccess, s.ControllerUUID),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -440,7 +440,7 @@ func (s *loginSuite) infoForNewUser(c *gc.C, info *api.Info) *api.Info {
 		DisplayName: "Charlie Brown",
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword(pass)),
-		Permission:  permission.ControllerForAccess(permission.LoginAccess),
+		Permission:  permission.ControllerForAccess(permission.LoginAccess, s.ControllerUUID),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -697,7 +697,7 @@ func (s *loginSuite) TestOtherModel(c *gc.C) {
 		DisplayName: "Charlie Brown",
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword(pass)),
-		Permission:  permission.ControllerForAccess(permission.LoginAccess),
+		Permission:  permission.ControllerForAccess(permission.LoginAccess, s.ControllerUUID),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -867,7 +867,7 @@ func (s *loginSuite) loginLocalUser(c *gc.C, info *api.Info) (names.UserTag, par
 		DisplayName: "Charlie Brown",
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword(pass)),
-		Permission:  permission.ControllerForAccess(permission.LoginAccess),
+		Permission:  permission.ControllerForAccess(permission.LoginAccess, s.ControllerUUID),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -962,7 +962,7 @@ func (s *loginSuite) TestLoginUpdatesLastLoginAndConnection(c *gc.C) {
 		DisplayName: "Bob Brown",
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword("password")),
-		Permission:  permission.ControllerForAccess(permission.LoginAccess),
+		Permission:  permission.ControllerForAccess(permission.LoginAccess, s.ControllerUUID),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1095,7 +1095,7 @@ func (s *loginV3Suite) TestClientLoginToControllerNoAccessToControllerModel(c *g
 		DisplayName: "Bob Brown",
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword("password")),
-		Permission:  permission.ControllerForAccess(permission.LoginAccess),
+		Permission:  permission.ControllerForAccess(permission.LoginAccess, s.ControllerUUID),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/admin_test.go
+++ b/apiserver/admin_test.go
@@ -183,7 +183,13 @@ func (s *loginSuite) TestLoginAsDeactivatedUser(c *gc.C) {
 		DisplayName: "Charlie Brown",
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword(pass)),
-		Permission:  permission.ControllerForAccess(permission.LoginAccess, s.ControllerUUID),
+		Permission: permission.AccessSpec{
+			Access: permission.LoginAccess,
+			Target: permission.ID{
+				ObjectType: permission.Controller,
+				Key:        s.ControllerUUID,
+			},
+		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -217,7 +223,13 @@ func (s *loginSuite) TestLoginAsDeletedUser(c *gc.C) {
 		DisplayName: "Charlie Brown",
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword(pass)),
-		Permission:  permission.ControllerForAccess(permission.LoginAccess, s.ControllerUUID),
+		Permission: permission.AccessSpec{
+			Access: permission.LoginAccess,
+			Target: permission.ID{
+				ObjectType: permission.Controller,
+				Key:        s.ControllerUUID,
+			},
+		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -440,7 +452,13 @@ func (s *loginSuite) infoForNewUser(c *gc.C, info *api.Info) *api.Info {
 		DisplayName: "Charlie Brown",
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword(pass)),
-		Permission:  permission.ControllerForAccess(permission.LoginAccess, s.ControllerUUID),
+		Permission: permission.AccessSpec{
+			Access: permission.LoginAccess,
+			Target: permission.ID{
+				ObjectType: permission.Controller,
+				Key:        s.ControllerUUID,
+			},
+		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -697,7 +715,13 @@ func (s *loginSuite) TestOtherModel(c *gc.C) {
 		DisplayName: "Charlie Brown",
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword(pass)),
-		Permission:  permission.ControllerForAccess(permission.LoginAccess, s.ControllerUUID),
+		Permission: permission.AccessSpec{
+			Access: permission.LoginAccess,
+			Target: permission.ID{
+				ObjectType: permission.Controller,
+				Key:        s.ControllerUUID,
+			},
+		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -867,7 +891,13 @@ func (s *loginSuite) loginLocalUser(c *gc.C, info *api.Info) (names.UserTag, par
 		DisplayName: "Charlie Brown",
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword(pass)),
-		Permission:  permission.ControllerForAccess(permission.LoginAccess, s.ControllerUUID),
+		Permission: permission.AccessSpec{
+			Access: permission.LoginAccess,
+			Target: permission.ID{
+				ObjectType: permission.Controller,
+				Key:        s.ControllerUUID,
+			},
+		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -962,7 +992,13 @@ func (s *loginSuite) TestLoginUpdatesLastLoginAndConnection(c *gc.C) {
 		DisplayName: "Bob Brown",
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword("password")),
-		Permission:  permission.ControllerForAccess(permission.LoginAccess, s.ControllerUUID),
+		Permission: permission.AccessSpec{
+			Access: permission.LoginAccess,
+			Target: permission.ID{
+				ObjectType: permission.Controller,
+				Key:        s.ControllerUUID,
+			},
+		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1095,7 +1131,13 @@ func (s *loginV3Suite) TestClientLoginToControllerNoAccessToControllerModel(c *g
 		DisplayName: "Bob Brown",
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword("password")),
-		Permission:  permission.ControllerForAccess(permission.LoginAccess, s.ControllerUUID),
+		Permission: permission.AccessSpec{
+			Access: permission.LoginAccess,
+			Target: permission.ID{
+				ObjectType: permission.Controller,
+				Key:        s.ControllerUUID,
+			},
+		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/auditconfig_test.go
+++ b/apiserver/auditconfig_test.go
@@ -234,7 +234,7 @@ func (s *auditConfigSuite) createModelAdminUser(c *gc.C, userTag names.UserTag, 
 		DisplayName: userTag.Name(),
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword(password)),
-		Permission:  permission.ControllerForAccess(permission.LoginAccess),
+		Permission:  permission.ControllerForAccess(permission.LoginAccess, s.ControllerUUID),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/auditconfig_test.go
+++ b/apiserver/auditconfig_test.go
@@ -234,7 +234,13 @@ func (s *auditConfigSuite) createModelAdminUser(c *gc.C, userTag names.UserTag, 
 		DisplayName: userTag.Name(),
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword(password)),
-		Permission:  permission.ControllerForAccess(permission.LoginAccess, s.ControllerUUID),
+		Permission: permission.AccessSpec{
+			Access: permission.LoginAccess,
+			Target: permission.ID{
+				ObjectType: permission.Controller,
+				Key:        s.ControllerUUID,
+			},
+		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/authentication/agent_test.go
+++ b/apiserver/authentication/agent_test.go
@@ -43,7 +43,13 @@ func (s *agentAuthenticatorSuite) SetUpTest(c *gc.C) {
 		DisplayName: "Bob Brown",
 		Password:    ptr(auth.NewPassword("password")),
 		CreatorUUID: s.AdminUserUUID,
-		Permission:  permission.ControllerForAccess(permission.LoginAccess, s.ControllerUUID),
+		Permission: permission.AccessSpec{
+			Access: permission.LoginAccess,
+			Target: permission.ID{
+				ObjectType: permission.Controller,
+				Key:        s.ControllerUUID,
+			},
+		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	user, err := userService.GetUser(context.Background(), userUUID)

--- a/apiserver/authentication/agent_test.go
+++ b/apiserver/authentication/agent_test.go
@@ -43,7 +43,7 @@ func (s *agentAuthenticatorSuite) SetUpTest(c *gc.C) {
 		DisplayName: "Bob Brown",
 		Password:    ptr(auth.NewPassword("password")),
 		CreatorUUID: s.AdminUserUUID,
-		Permission:  permission.ControllerForAccess(permission.LoginAccess),
+		Permission:  permission.ControllerForAccess(permission.LoginAccess, s.ControllerUUID),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	user, err := userService.GetUser(context.Background(), userUUID)

--- a/apiserver/authentication/user_test.go
+++ b/apiserver/authentication/user_test.go
@@ -94,7 +94,7 @@ func (s *userAuthenticatorSuite) TestValidUserLogin(c *gc.C) {
 		DisplayName: "Bob Brown",
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword("password")),
-		Permission:  permission.ControllerForAccess(permission.LoginAccess),
+		Permission:  permission.ControllerForAccess(permission.LoginAccess, s.ControllerUUID),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -117,7 +117,7 @@ func (s *userAuthenticatorSuite) TestDisabledUserLogin(c *gc.C) {
 		DisplayName: "Bob Brown",
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword("password")),
-		Permission:  permission.ControllerForAccess(permission.LoginAccess),
+		Permission:  permission.ControllerForAccess(permission.LoginAccess, s.ControllerUUID),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	err = userService.DisableUserAuthentication(context.Background(), "bobbrown")
@@ -141,7 +141,7 @@ func (s *userAuthenticatorSuite) TestRemovedUserLogin(c *gc.C) {
 		DisplayName: "Bob Brown",
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword("password")),
-		Permission:  permission.ControllerForAccess(permission.LoginAccess),
+		Permission:  permission.ControllerForAccess(permission.LoginAccess, s.ControllerUUID),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	err = userService.RemoveUser(context.Background(), "bobbrown")
@@ -165,7 +165,7 @@ func (s *userAuthenticatorSuite) TestUserLoginWrongPassword(c *gc.C) {
 		DisplayName: "Bob Brown",
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword("password")),
-		Permission:  permission.ControllerForAccess(permission.LoginAccess),
+		Permission:  permission.ControllerForAccess(permission.LoginAccess, s.ControllerUUID),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -186,7 +186,7 @@ func (s *userAuthenticatorSuite) TestValidMacaroonUserLogin(c *gc.C) {
 		Name:        "bob",
 		DisplayName: "Bob Brown",
 		CreatorUUID: s.AdminUserUUID,
-		Permission:  permission.ControllerForAccess(permission.LoginAccess),
+		Permission:  permission.ControllerForAccess(permission.LoginAccess, s.ControllerUUID),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -222,7 +222,7 @@ func (s *userAuthenticatorSuite) TestInvalidMacaroonUserLogin(c *gc.C) {
 		Name:        "bobbrown",
 		DisplayName: "Bob Brown",
 		CreatorUUID: s.AdminUserUUID,
-		Permission:  permission.ControllerForAccess(permission.LoginAccess),
+		Permission:  permission.ControllerForAccess(permission.LoginAccess, s.ControllerUUID),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -252,7 +252,7 @@ func (s *userAuthenticatorSuite) TestDisabledMacaroonUserLogin(c *gc.C) {
 		Name:        "bobbrown",
 		DisplayName: "Bob Brown",
 		CreatorUUID: s.AdminUserUUID,
-		Permission:  permission.ControllerForAccess(permission.LoginAccess),
+		Permission:  permission.ControllerForAccess(permission.LoginAccess, s.ControllerUUID),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	err = userService.DisableUserAuthentication(context.Background(), "bobbrown")
@@ -284,7 +284,7 @@ func (s *userAuthenticatorSuite) TestRemovedMacaroonUserLogin(c *gc.C) {
 		Name:        "bobbrown",
 		DisplayName: "Bob Brown",
 		CreatorUUID: s.AdminUserUUID,
-		Permission:  permission.ControllerForAccess(permission.LoginAccess),
+		Permission:  permission.ControllerForAccess(permission.LoginAccess, s.ControllerUUID),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	err = userService.RemoveUser(context.Background(), "bobbrown")

--- a/apiserver/authentication/user_test.go
+++ b/apiserver/authentication/user_test.go
@@ -94,7 +94,13 @@ func (s *userAuthenticatorSuite) TestValidUserLogin(c *gc.C) {
 		DisplayName: "Bob Brown",
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword("password")),
-		Permission:  permission.ControllerForAccess(permission.LoginAccess, s.ControllerUUID),
+		Permission: permission.AccessSpec{
+			Access: permission.LoginAccess,
+			Target: permission.ID{
+				ObjectType: permission.Controller,
+				Key:        s.ControllerUUID,
+			},
+		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -117,7 +123,13 @@ func (s *userAuthenticatorSuite) TestDisabledUserLogin(c *gc.C) {
 		DisplayName: "Bob Brown",
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword("password")),
-		Permission:  permission.ControllerForAccess(permission.LoginAccess, s.ControllerUUID),
+		Permission: permission.AccessSpec{
+			Access: permission.LoginAccess,
+			Target: permission.ID{
+				ObjectType: permission.Controller,
+				Key:        s.ControllerUUID,
+			},
+		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	err = userService.DisableUserAuthentication(context.Background(), "bobbrown")
@@ -141,7 +153,13 @@ func (s *userAuthenticatorSuite) TestRemovedUserLogin(c *gc.C) {
 		DisplayName: "Bob Brown",
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword("password")),
-		Permission:  permission.ControllerForAccess(permission.LoginAccess, s.ControllerUUID),
+		Permission: permission.AccessSpec{
+			Access: permission.LoginAccess,
+			Target: permission.ID{
+				ObjectType: permission.Controller,
+				Key:        s.ControllerUUID,
+			},
+		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	err = userService.RemoveUser(context.Background(), "bobbrown")
@@ -165,7 +183,13 @@ func (s *userAuthenticatorSuite) TestUserLoginWrongPassword(c *gc.C) {
 		DisplayName: "Bob Brown",
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword("password")),
-		Permission:  permission.ControllerForAccess(permission.LoginAccess, s.ControllerUUID),
+		Permission: permission.AccessSpec{
+			Access: permission.LoginAccess,
+			Target: permission.ID{
+				ObjectType: permission.Controller,
+				Key:        s.ControllerUUID,
+			},
+		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -186,7 +210,13 @@ func (s *userAuthenticatorSuite) TestValidMacaroonUserLogin(c *gc.C) {
 		Name:        "bob",
 		DisplayName: "Bob Brown",
 		CreatorUUID: s.AdminUserUUID,
-		Permission:  permission.ControllerForAccess(permission.LoginAccess, s.ControllerUUID),
+		Permission: permission.AccessSpec{
+			Access: permission.LoginAccess,
+			Target: permission.ID{
+				ObjectType: permission.Controller,
+				Key:        s.ControllerUUID,
+			},
+		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -222,7 +252,13 @@ func (s *userAuthenticatorSuite) TestInvalidMacaroonUserLogin(c *gc.C) {
 		Name:        "bobbrown",
 		DisplayName: "Bob Brown",
 		CreatorUUID: s.AdminUserUUID,
-		Permission:  permission.ControllerForAccess(permission.LoginAccess, s.ControllerUUID),
+		Permission: permission.AccessSpec{
+			Access: permission.LoginAccess,
+			Target: permission.ID{
+				ObjectType: permission.Controller,
+				Key:        s.ControllerUUID,
+			},
+		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -252,7 +288,13 @@ func (s *userAuthenticatorSuite) TestDisabledMacaroonUserLogin(c *gc.C) {
 		Name:        "bobbrown",
 		DisplayName: "Bob Brown",
 		CreatorUUID: s.AdminUserUUID,
-		Permission:  permission.ControllerForAccess(permission.LoginAccess, s.ControllerUUID),
+		Permission: permission.AccessSpec{
+			Access: permission.LoginAccess,
+			Target: permission.ID{
+				ObjectType: permission.Controller,
+				Key:        s.ControllerUUID,
+			},
+		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	err = userService.DisableUserAuthentication(context.Background(), "bobbrown")
@@ -284,7 +326,13 @@ func (s *userAuthenticatorSuite) TestRemovedMacaroonUserLogin(c *gc.C) {
 		Name:        "bobbrown",
 		DisplayName: "Bob Brown",
 		CreatorUUID: s.AdminUserUUID,
-		Permission:  permission.ControllerForAccess(permission.LoginAccess, s.ControllerUUID),
+		Permission: permission.AccessSpec{
+			Access: permission.LoginAccess,
+			Target: permission.ID{
+				ObjectType: permission.Controller,
+				Key:        s.ControllerUUID,
+			},
+		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	err = userService.RemoveUser(context.Background(), "bobbrown")

--- a/apiserver/charms_test.go
+++ b/apiserver/charms_test.go
@@ -529,7 +529,7 @@ func (s *charmsSuite) TestMigrateCharmUnauthorized(c *gc.C) {
 		DisplayName: "Bob Brown",
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword("hunter2")),
-		Permission:  permission.ControllerForAccess(permission.LoginAccess),
+		Permission:  permission.ControllerForAccess(permission.LoginAccess, s.ControllerUUID),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/charms_test.go
+++ b/apiserver/charms_test.go
@@ -529,7 +529,13 @@ func (s *charmsSuite) TestMigrateCharmUnauthorized(c *gc.C) {
 		DisplayName: "Bob Brown",
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword("hunter2")),
-		Permission:  permission.ControllerForAccess(permission.LoginAccess, s.ControllerUUID),
+		Permission: permission.AccessSpec{
+			Access: permission.LoginAccess,
+			Target: permission.ID{
+				ObjectType: permission.Controller,
+				Key:        s.ControllerUUID,
+			},
+		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/facades/agent/caasapplication/application_test.go
+++ b/apiserver/facades/agent/caasapplication/application_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/juju/juju/apiserver/facades/agent/caasapplication"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/caas"
-	controllerconfigbootstrap "github.com/juju/juju/domain/controllerconfig/bootstrap"
 	"github.com/juju/juju/domain/servicefactory/testing"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 	"github.com/juju/juju/internal/storage/provider"
@@ -42,10 +41,6 @@ type CAASApplicationSuite struct {
 
 func (s *CAASApplicationSuite) SetUpTest(c *gc.C) {
 	s.ServiceFactorySuite.SetUpTest(c)
-
-	controllerConfig := coretesting.FakeControllerConfig()
-	err := controllerconfigbootstrap.InsertInitialControllerConfig(controllerConfig)(context.Background(), s.TxnRunner(), s.NoopTxnRunner())
-	c.Assert(err, jc.ErrorIsNil)
 
 	s.clock = testclock.NewClock(time.Now())
 

--- a/apiserver/facades/agent/caasapplication/application_test.go
+++ b/apiserver/facades/agent/caasapplication/application_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/juju/juju/domain/servicefactory/testing"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 	"github.com/juju/juju/internal/storage/provider"
-	coretesting "github.com/juju/juju/internal/testing"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
 )

--- a/apiserver/facades/client/client/api_test.go
+++ b/apiserver/facades/client/client/api_test.go
@@ -426,7 +426,7 @@ func (s *baseSuite) setUpScenario(c *gc.C) (entities []names.Tag) {
 		DisplayName: "Bob Brown",
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword(userPassword)),
-		Permission:  permission.ControllerForAccess(permission.LoginAccess),
+		Permission:  permission.ControllerForAccess(permission.LoginAccess, s.ControllerUUID),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/facades/client/client/api_test.go
+++ b/apiserver/facades/client/client/api_test.go
@@ -426,7 +426,13 @@ func (s *baseSuite) setUpScenario(c *gc.C) (entities []names.Tag) {
 		DisplayName: "Bob Brown",
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword(userPassword)),
-		Permission:  permission.ControllerForAccess(permission.LoginAccess, s.ControllerUUID),
+		Permission: permission.AccessSpec{
+			Access: permission.LoginAccess,
+			Target: permission.ID{
+				ObjectType: permission.Controller,
+				Key:        s.ControllerUUID,
+			},
+		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/facades/client/cloud/cloud.go
+++ b/apiserver/facades/client/cloud/cloud.go
@@ -19,6 +19,7 @@ import (
 	corelogger "github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/domain/access"
+	accesserrors "github.com/juju/juju/domain/access/errors"
 	"github.com/juju/juju/domain/credential/service"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/rpc/params"
@@ -727,7 +728,7 @@ func (api *CloudAPI) internalCredentialContents(ctx context.Context, args params
 
 		// get model access
 		models, err := api.cloudAccessService.AllModelAccessForCloudCredential(ctx, key)
-		if err != nil && !errors.Is(err, errors.NotFound) {
+		if err != nil && !errors.Is(err, accesserrors.PermissionNotFound) {
 			return params.CredentialContentResult{Error: apiservererrors.ServerError(err)}
 		}
 		info.Models = make([]params.ModelAccess, len(models))

--- a/apiserver/facades/client/controller/controller.go
+++ b/apiserver/facades/client/controller/controller.go
@@ -652,7 +652,13 @@ func (c *ControllerAPI) GetControllerAccess(ctx context.Context, req params.Enti
 			results.Results[i].Error = apiservererrors.ServerError(apiservererrors.ErrPerm)
 			continue
 		}
-		spec := permission.ControllerForAccess(permission.SuperuserAccess, c.controllerTag.Id())
+		spec := permission.AccessSpec{
+			Access: permission.SuperuserAccess,
+			Target: permission.ID{
+				ObjectType: permission.Controller,
+				Key:        c.controllerTag.Id(),
+			},
+		}
 		accessLevel, err := c.accessService.ReadUserAccessLevelForTarget(ctx, userTag.Id(), spec.Target)
 		if err != nil {
 			results.Results[i].Error = apiservererrors.ServerError(err)
@@ -798,11 +804,17 @@ func (c *ControllerAPI) ModifyControllerAccess(ctx context.Context, args params.
 		}
 
 		updateArgs := access.UpdatePermissionArgs{
-			AccessSpec: permission.ControllerForAccess(permission.Access(arg.Access), c.controllerTag.Id()),
-			AddUser:    true,
-			ApiUser:    c.apiUser.Id(),
-			Change:     permission.AccessChange(string(arg.Action)),
-			Subject:    targetUserTag.Id(),
+			AccessSpec: permission.AccessSpec{
+				Access: permission.Access(arg.Access),
+				Target: permission.ID{
+					ObjectType: permission.Controller,
+					Key:        c.controllerTag.Id(),
+				},
+			},
+			AddUser: true,
+			ApiUser: c.apiUser.Id(),
+			Change:  permission.AccessChange(string(arg.Action)),
+			Subject: targetUserTag.Id(),
 		}
 		err = c.accessService.UpdatePermission(ctx, updateArgs)
 		result.Results[i].Error = apiservererrors.ServerError(err)

--- a/apiserver/facades/client/controller/controller.go
+++ b/apiserver/facades/client/controller/controller.go
@@ -652,7 +652,7 @@ func (c *ControllerAPI) GetControllerAccess(ctx context.Context, req params.Enti
 			results.Results[i].Error = apiservererrors.ServerError(apiservererrors.ErrPerm)
 			continue
 		}
-		spec := permission.ControllerForAccess(permission.SuperuserAccess)
+		spec := permission.ControllerForAccess(permission.SuperuserAccess, c.controllerTag.Id())
 		accessLevel, err := c.accessService.ReadUserAccessLevelForTarget(ctx, userTag.Id(), spec.Target)
 		if err != nil {
 			results.Results[i].Error = apiservererrors.ServerError(err)
@@ -798,7 +798,7 @@ func (c *ControllerAPI) ModifyControllerAccess(ctx context.Context, args params.
 		}
 
 		updateArgs := access.UpdatePermissionArgs{
-			AccessSpec: permission.ControllerForAccess(permission.Access(arg.Access)),
+			AccessSpec: permission.ControllerForAccess(permission.Access(arg.Access), c.controllerTag.Id()),
 			AddUser:    true,
 			ApiUser:    c.apiUser.Id(),
 			Change:     permission.AccessChange(string(arg.Action)),

--- a/apiserver/facades/client/controller/controller_test.go
+++ b/apiserver/facades/client/controller/controller_test.go
@@ -87,6 +87,7 @@ func (s *controllerSuite) SetUpTest(c *gc.C) {
 
 	s.StateSuite.ControllerConfig = controllerCfg
 	s.StateSuite.SetUpTest(c)
+	s.ServiceFactorySuite.ControllerConfig = controllerCfg
 	s.ServiceFactorySuite.SetUpTest(c)
 	jujujujutesting.SeedDatabase(c, s.ControllerSuite.TxnRunner(), s.ServiceFactoryGetter(c)(s.ControllerModelUUID), controllerCfg)
 
@@ -1012,7 +1013,7 @@ func (s *accessSuite) TestModifyControllerAccess(c *gc.C) {
 	userName := "test-user"
 
 	updateArgs := access.UpdatePermissionArgs{
-		AccessSpec: permission.ControllerForAccess(permission.SuperuserAccess),
+		AccessSpec: permission.ControllerForAccess(permission.SuperuserAccess, testing.ControllerTag.Id()),
 		AddUser:    true,
 		ApiUser:    "test-admin",
 		Change:     permission.Grant,
@@ -1038,7 +1039,7 @@ func (s *accessSuite) TestGetControllerAccessPermissions(c *gc.C) {
 	userTag := names.NewUserTag(userName)
 	differentUser := "different-test-user"
 
-	target := permission.ControllerForAccess(permission.SuperuserAccess)
+	target := permission.ControllerForAccess(permission.SuperuserAccess, testing.ControllerTag.Id())
 	s.accessService.EXPECT().ReadUserAccessLevelForTarget(gomock.Any(), userName, target.Target).Return(permission.SuperuserAccess, nil)
 
 	s.authorizer = apiservertesting.FakeAuthorizer{

--- a/apiserver/facades/client/controller/controller_test.go
+++ b/apiserver/facades/client/controller/controller_test.go
@@ -1013,11 +1013,17 @@ func (s *accessSuite) TestModifyControllerAccess(c *gc.C) {
 	userName := "test-user"
 
 	updateArgs := access.UpdatePermissionArgs{
-		AccessSpec: permission.ControllerForAccess(permission.SuperuserAccess, testing.ControllerTag.Id()),
-		AddUser:    true,
-		ApiUser:    "test-admin",
-		Change:     permission.Grant,
-		Subject:    userName,
+		AccessSpec: permission.AccessSpec{
+			Access: permission.SuperuserAccess,
+			Target: permission.ID{
+				ObjectType: permission.Controller,
+				Key:        testing.ControllerTag.Id(),
+			},
+		},
+		AddUser: true,
+		ApiUser: "test-admin",
+		Change:  permission.Grant,
+		Subject: userName,
 	}
 	s.accessService.EXPECT().UpdatePermission(gomock.Any(), updateArgs).Return(nil)
 
@@ -1039,7 +1045,13 @@ func (s *accessSuite) TestGetControllerAccessPermissions(c *gc.C) {
 	userTag := names.NewUserTag(userName)
 	differentUser := "different-test-user"
 
-	target := permission.ControllerForAccess(permission.SuperuserAccess, testing.ControllerTag.Id())
+	target := permission.AccessSpec{
+		Access: permission.SuperuserAccess,
+		Target: permission.ID{
+			ObjectType: permission.Controller,
+			Key:        testing.ControllerTag.Id(),
+		},
+	}
 	s.accessService.EXPECT().ReadUserAccessLevelForTarget(gomock.Any(), userName, target.Target).Return(permission.SuperuserAccess, nil)
 
 	s.authorizer = apiservertesting.FakeAuthorizer{

--- a/apiserver/facades/client/usermanager/register.go
+++ b/apiserver/facades/client/usermanager/register.go
@@ -60,5 +60,6 @@ func newUserManagerAPI(stdCtx context.Context, ctx facade.ModelContext) (*UserMa
 		apiUser,
 		isAdmin,
 		ctx.Logger().Child("usermanager"),
+		ctx.ControllerUUID(),
 	)
 }

--- a/apiserver/facades/client/usermanager/usermanager.go
+++ b/apiserver/facades/client/usermanager/usermanager.go
@@ -132,7 +132,13 @@ func (api *UserManagerAPI) addOneUser(ctx context.Context, arg params.AddUser) p
 		Name:        arg.Username,
 		DisplayName: arg.DisplayName,
 		CreatorUUID: api.apiUser.UUID,
-		Permission:  permission.ControllerForAccess(permission.LoginAccess, api.controllerUUID),
+		Permission: permission.AccessSpec{
+			Access: permission.LoginAccess,
+			Target: permission.ID{
+				ObjectType: permission.Controller,
+				Key:        api.controllerUUID,
+			},
+		},
 	}
 	if arg.Password != "" {
 		pass := auth.NewPassword(arg.Password)

--- a/apiserver/facades/client/usermanager/usermanager_test.go
+++ b/apiserver/facades/client/usermanager/usermanager_test.go
@@ -64,7 +64,13 @@ func (s *userManagerSuite) TestAddUser(c *gc.C) {
 		DisplayName: "Foo Bar",
 		Password:    &pass,
 		CreatorUUID: s.apiUser.UUID,
-		Permission:  permission.ControllerForAccess(permission.LoginAccess, s.ControllerUUID),
+		Permission: permission.AccessSpec{
+			Access: permission.LoginAccess,
+			Target: permission.ID{
+				ObjectType: permission.Controller,
+				Key:        s.ControllerUUID,
+			},
+		},
 	}).Return(newUserUUID(c), nil, nil)
 
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
@@ -94,7 +100,13 @@ func (s *userManagerSuite) TestAddUserWithSecretKey(c *gc.C) {
 		Name:        "foobar",
 		DisplayName: "Foo Bar",
 		CreatorUUID: s.apiUser.UUID,
-		Permission:  permission.ControllerForAccess(permission.LoginAccess, s.ControllerUUID),
+		Permission: permission.AccessSpec{
+			Access: permission.LoginAccess,
+			Target: permission.ID{
+				ObjectType: permission.Controller,
+				Key:        s.ControllerUUID,
+			},
+		},
 	}).Return(newUserUUID(c), []byte("secret-key"), nil)
 
 	args := params.AddUsers{

--- a/apiserver/facades/client/usermanager/usermanager_test.go
+++ b/apiserver/facades/client/usermanager/usermanager_test.go
@@ -64,7 +64,7 @@ func (s *userManagerSuite) TestAddUser(c *gc.C) {
 		DisplayName: "Foo Bar",
 		Password:    &pass,
 		CreatorUUID: s.apiUser.UUID,
-		Permission:  permission.ControllerForAccess(permission.LoginAccess),
+		Permission:  permission.ControllerForAccess(permission.LoginAccess, s.ControllerUUID),
 	}).Return(newUserUUID(c), nil, nil)
 
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
@@ -94,7 +94,7 @@ func (s *userManagerSuite) TestAddUserWithSecretKey(c *gc.C) {
 		Name:        "foobar",
 		DisplayName: "Foo Bar",
 		CreatorUUID: s.apiUser.UUID,
-		Permission:  permission.ControllerForAccess(permission.LoginAccess),
+		Permission:  permission.ControllerForAccess(permission.LoginAccess, s.ControllerUUID),
 	}).Return(newUserUUID(c), []byte("secret-key"), nil)
 
 	args := params.AddUsers{
@@ -317,19 +317,19 @@ func (s *userManagerSuite) TestUserInfo(c *gc.C) {
 
 	exp.ReadUserAccessForTarget(gomock.Any(), "foobar", permission.ID{
 		ObjectType: permission.Controller,
-		Key:        "controller",
+		Key:        s.ControllerUUID,
 	}).Return(permission.UserAccess{Access: permission.LoginAccess}, nil)
 
 	// No access granted directly to the external user.
 	exp.ReadUserAccessForTarget(gomock.Any(), "mary@external", permission.ID{
 		ObjectType: permission.Controller,
-		Key:        "controller",
+		Key:        s.ControllerUUID,
 	}).Return(permission.UserAccess{Access: permission.NoAccess}, nil)
 
 	// But the special everyone group does have access.
 	exp.ReadUserAccessForTarget(gomock.Any(), "everyone@external", permission.ID{
 		ObjectType: permission.Controller,
-		Key:        "controller",
+		Key:        s.ControllerUUID,
 	}).Return(permission.UserAccess{Access: permission.SuperuserAccess}, nil)
 
 	args := params.UserInfoRequest{
@@ -424,7 +424,7 @@ func (s *userManagerSuite) TestUserInfoAll(c *gc.C) {
 	// users have NoPermissions.
 	s.accessService.EXPECT().ReadUserAccessForTarget(gomock.Any(), "fred", permission.ID{
 		ObjectType: permission.Controller,
-		Key:        "controller",
+		Key:        s.ControllerUUID,
 	}).Return(permission.UserAccess{Access: permission.LoginAccess}, nil).Times(2)
 
 	results, err := s.api.UserInfo(context.Background(), params.UserInfoRequest{})
@@ -470,7 +470,7 @@ func (s *userManagerSuite) TestUserInfoNonControllerAdmin(c *gc.C) {
 
 	s.accessService.EXPECT().ReadUserAccessForTarget(gomock.Any(), "aardvark", permission.ID{
 		ObjectType: permission.Controller,
-		Key:        "controller",
+		Key:        s.ControllerUUID,
 	}).Return(permission.UserAccess{Access: permission.LoginAccess}, nil)
 
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
@@ -512,13 +512,13 @@ func (s *userManagerSuite) TestUserInfoEveryonePermission(c *gc.C) {
 	// No access granted directly to the user.
 	s.accessService.EXPECT().ReadUserAccessForTarget(gomock.Any(), "aardvark@external", permission.ID{
 		ObjectType: permission.Controller,
-		Key:        "controller",
+		Key:        s.ControllerUUID,
 	}).Return(permission.UserAccess{Access: permission.NoAccess}, nil)
 
 	// But the special everyone group does have access.
 	s.accessService.EXPECT().ReadUserAccessForTarget(gomock.Any(), "everyone@external", permission.ID{
 		ObjectType: permission.Controller,
-		Key:        "controller",
+		Key:        s.ControllerUUID,
 	}).Return(permission.UserAccess{Access: permission.SuperuserAccess}, nil)
 
 	args := params.UserInfoRequest{Entities: []params.Entity{{Tag: names.NewUserTag("aardvark@external").String()}}}
@@ -1055,6 +1055,7 @@ func (s *userManagerSuite) setUpAPI(c *gc.C) *gomock.Controller {
 		s.apiUser,
 		s.apiUser.Name == "admin",
 		ctx.Logger(),
+		s.ControllerUUID,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/introspection_test.go
+++ b/apiserver/introspection_test.go
@@ -47,7 +47,7 @@ func (s *introspectionSuite) TestAccess(c *gc.C) {
 		DisplayName: "Bob Brown",
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword("hunter2")),
-		Permission:  permission.ControllerForAccess(permission.LoginAccess),
+		Permission:  permission.ControllerForAccess(permission.LoginAccess, s.ControllerUUID),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -74,7 +74,7 @@ func (s *introspectionSuite) TestAccessDenied(c *gc.C) {
 		DisplayName: "Bob Brown",
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword("hunter2")),
-		Permission:  permission.ControllerForAccess(permission.LoginAccess),
+		Permission:  permission.ControllerForAccess(permission.LoginAccess, s.ControllerUUID),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/introspection_test.go
+++ b/apiserver/introspection_test.go
@@ -47,7 +47,13 @@ func (s *introspectionSuite) TestAccess(c *gc.C) {
 		DisplayName: "Bob Brown",
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword("hunter2")),
-		Permission:  permission.ControllerForAccess(permission.LoginAccess, s.ControllerUUID),
+		Permission: permission.AccessSpec{
+			Access: permission.LoginAccess,
+			Target: permission.ID{
+				ObjectType: permission.Controller,
+				Key:        s.ControllerUUID,
+			},
+		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -74,7 +80,13 @@ func (s *introspectionSuite) TestAccessDenied(c *gc.C) {
 		DisplayName: "Bob Brown",
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword("hunter2")),
-		Permission:  permission.ControllerForAccess(permission.LoginAccess, s.ControllerUUID),
+		Permission: permission.AccessSpec{
+			Access: permission.LoginAccess,
+			Target: permission.ID{
+				ObjectType: permission.Controller,
+				Key:        s.ControllerUUID,
+			},
+		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/objects_test.go
+++ b/apiserver/objects_test.go
@@ -571,7 +571,7 @@ func (s *putCharmObjectSuite) TestMigrateCharmUnauthorized(c *gc.C) {
 		DisplayName: "Bob Brown",
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword("hunter2")),
-		Permission:  permission.ControllerForAccess(permission.LoginAccess),
+		Permission:  permission.ControllerForAccess(permission.LoginAccess, s.ControllerUUID),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/objects_test.go
+++ b/apiserver/objects_test.go
@@ -571,7 +571,13 @@ func (s *putCharmObjectSuite) TestMigrateCharmUnauthorized(c *gc.C) {
 		DisplayName: "Bob Brown",
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword("hunter2")),
-		Permission:  permission.ControllerForAccess(permission.LoginAccess, s.ControllerUUID),
+		Permission: permission.AccessSpec{
+			Access: permission.LoginAccess,
+			Target: permission.ID{
+				ObjectType: permission.Controller,
+				Key:        s.ControllerUUID,
+			},
+		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/pubsub_test.go
+++ b/apiserver/pubsub_test.go
@@ -72,7 +72,13 @@ func (s *pubsubSuite) TestRejectsUserLogins(c *gc.C) {
 		DisplayName: "Bob Brown",
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword("hunter2")),
-		Permission:  permission.ControllerForAccess(permission.LoginAccess, s.ControllerUUID),
+		Permission: permission.AccessSpec{
+			Access: permission.LoginAccess,
+			Target: permission.ID{
+				ObjectType: permission.Controller,
+				Key:        s.ControllerUUID,
+			},
+		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/pubsub_test.go
+++ b/apiserver/pubsub_test.go
@@ -72,7 +72,7 @@ func (s *pubsubSuite) TestRejectsUserLogins(c *gc.C) {
 		DisplayName: "Bob Brown",
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword("hunter2")),
-		Permission:  permission.ControllerForAccess(permission.LoginAccess),
+		Permission:  permission.ControllerForAccess(permission.LoginAccess, s.ControllerUUID),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/ratelimit_test.go
+++ b/apiserver/ratelimit_test.go
@@ -113,7 +113,13 @@ func (s *rateLimitSuite) infoForNewUser(c *gc.C, info *api.Info, name string) *a
 		Name:        userTag.Name(),
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword("hunter2")),
-		Permission:  permission.ControllerForAccess(permission.LoginAccess, s.ControllerUUID),
+		Permission: permission.AccessSpec{
+			Access: permission.LoginAccess,
+			Target: permission.ID{
+				ObjectType: permission.Controller,
+				Key:        s.ControllerUUID,
+			},
+		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/ratelimit_test.go
+++ b/apiserver/ratelimit_test.go
@@ -113,7 +113,7 @@ func (s *rateLimitSuite) infoForNewUser(c *gc.C, info *api.Info, name string) *a
 		Name:        userTag.Name(),
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword("hunter2")),
-		Permission:  permission.ControllerForAccess(permission.LoginAccess),
+		Permission:  permission.ControllerForAccess(permission.LoginAccess, s.ControllerUUID),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/registration_test.go
+++ b/apiserver/registration_test.go
@@ -54,7 +54,13 @@ func (s *registrationSuite) SetUpTest(c *gc.C) {
 	s.userUUID, _, err = s.userService.AddUser(context.Background(), service.AddUserArg{
 		Name:        "bob",
 		CreatorUUID: s.AdminUserUUID,
-		Permission:  permission.ControllerForAccess(permission.LoginAccess, s.ControllerUUID),
+		Permission: permission.AccessSpec{
+			Access: permission.LoginAccess,
+			Target: permission.ID{
+				ObjectType: permission.Controller,
+				Key:        s.ControllerUUID,
+			},
+		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/registration_test.go
+++ b/apiserver/registration_test.go
@@ -54,7 +54,7 @@ func (s *registrationSuite) SetUpTest(c *gc.C) {
 	s.userUUID, _, err = s.userService.AddUser(context.Background(), service.AddUserArg{
 		Name:        "bob",
 		CreatorUUID: s.AdminUserUUID,
-		Permission:  permission.ControllerForAccess(permission.LoginAccess),
+		Permission:  permission.ControllerForAccess(permission.LoginAccess, s.ControllerUUID),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/server_test.go
+++ b/apiserver/server_test.go
@@ -267,7 +267,13 @@ func (s *serverSuite) bootstrapHasPermissionTest(c *gc.C) (state.Entity, names.C
 		DisplayName: "Foo Bar",
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword("password")),
-		Permission:  permission.ControllerForAccess(permission.LoginAccess, s.ControllerUUID),
+		Permission: permission.AccessSpec{
+			Access: permission.LoginAccess,
+			Target: permission.ID{
+				ObjectType: permission.Controller,
+				Key:        s.ControllerUUID,
+			},
+		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -302,10 +308,16 @@ func (s *serverSuite) TestAPIHandlerHasPermissionSuperUser(c *gc.C) {
 	defer handler.Kill()
 
 	err := serviceFactory.Access().UpdatePermission(context.Background(), access.UpdatePermissionArgs{
-		AccessSpec: permission.ControllerForAccess(permission.SuperuserAccess, s.ControllerUUID),
-		ApiUser:    "admin",
-		Change:     permission.Grant,
-		Subject:    u.Tag().Id(),
+		AccessSpec: permission.AccessSpec{
+			Access: permission.SuperuserAccess,
+			Target: permission.ID{
+				ObjectType: permission.Controller,
+				Key:        s.ControllerUUID,
+			},
+		},
+		ApiUser: "admin",
+		Change:  permission.Grant,
+		Subject: u.Tag().Id(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/server_test.go
+++ b/apiserver/server_test.go
@@ -267,7 +267,7 @@ func (s *serverSuite) bootstrapHasPermissionTest(c *gc.C) (state.Entity, names.C
 		DisplayName: "Foo Bar",
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword("password")),
-		Permission:  permission.ControllerForAccess(permission.LoginAccess),
+		Permission:  permission.ControllerForAccess(permission.LoginAccess, s.ControllerUUID),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -302,7 +302,7 @@ func (s *serverSuite) TestAPIHandlerHasPermissionSuperUser(c *gc.C) {
 	defer handler.Kill()
 
 	err := serviceFactory.Access().UpdatePermission(context.Background(), access.UpdatePermissionArgs{
-		AccessSpec: permission.ControllerForAccess(permission.SuperuserAccess),
+		AccessSpec: permission.ControllerForAccess(permission.SuperuserAccess, s.ControllerUUID),
 		ApiUser:    "admin",
 		Change:     permission.Grant,
 		Subject:    u.Tag().Id(),

--- a/apiserver/stateauthenticator/delegator.go
+++ b/apiserver/stateauthenticator/delegator.go
@@ -30,22 +30,9 @@ func (p *PermissionDelegator) SubjectPermissions(
 	}
 	userID := userTag.Id()
 
-	var permissionID permission.ID
-	// TODO (manadart 2024-05-27): Follow up with this.
-	// checkUserPermissions in admin.go checks for access to a controller tag,
-	// which is constituted by a controller ID, but we appear to be granting
-	// access to an entity called "controller".
-	if _, ok := target.(names.ControllerTag); ok {
-		permissionID = permission.ID{
-			ObjectType: permission.Controller,
-			Key:        "controller",
-		}
-	} else {
-		var err error
-		permissionID, err = permission.ParseTagForID(target)
-		if err != nil {
-			return permission.NoAccess, errors.Trace(err)
-		}
+	permissionID, err := permission.ParseTagForID(target)
+	if err != nil {
+		return permission.NoAccess, errors.Trace(err)
 	}
 
 	access, err := p.AccessService.ReadUserAccessForTarget(context.TODO(), userID, permissionID)

--- a/apiserver/tools_integration_test.go
+++ b/apiserver/tools_integration_test.go
@@ -138,7 +138,13 @@ func (s *toolsWithMacaroonsIntegrationSuite) TestCanPostWithLocalLogin(c *gc.C) 
 		DisplayName: "Bob Brown",
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword(password)),
-		Permission:  permission.ControllerForAccess(permission.LoginAccess, s.ControllerUUID),
+		Permission: permission.AccessSpec{
+			Access: permission.LoginAccess,
+			Target: permission.ID{
+				ObjectType: permission.Controller,
+				Key:        s.ControllerUUID,
+			},
+		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/tools_integration_test.go
+++ b/apiserver/tools_integration_test.go
@@ -138,7 +138,7 @@ func (s *toolsWithMacaroonsIntegrationSuite) TestCanPostWithLocalLogin(c *gc.C) 
 		DisplayName: "Bob Brown",
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword(password)),
-		Permission:  permission.ControllerForAccess(permission.LoginAccess),
+		Permission:  permission.ControllerForAccess(permission.LoginAccess, s.ControllerUUID),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/tools_test.go
+++ b/apiserver/tools_test.go
@@ -348,7 +348,7 @@ func (s *toolsSuite) TestMigrateToolsForUser(c *gc.C) {
 		DisplayName: "Bob Brown",
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword("hunter2")),
-		Permission:  permission.ControllerForAccess(permission.LoginAccess),
+		Permission:  permission.ControllerForAccess(permission.LoginAccess, s.ControllerUUID),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/tools_test.go
+++ b/apiserver/tools_test.go
@@ -348,7 +348,13 @@ func (s *toolsSuite) TestMigrateToolsForUser(c *gc.C) {
 		DisplayName: "Bob Brown",
 		CreatorUUID: s.AdminUserUUID,
 		Password:    ptr(auth.NewPassword("hunter2")),
-		Permission:  permission.ControllerForAccess(permission.LoginAccess, s.ControllerUUID),
+		Permission: permission.AccessSpec{
+			Access: permission.LoginAccess,
+			Target: permission.ID{
+				ObjectType: permission.Controller,
+				Key:        s.ControllerUUID,
+			},
+		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/core/permission/user.go
+++ b/core/permission/user.go
@@ -69,17 +69,12 @@ func (u UserAccessSpec) Validate() error {
 
 // ControllerForAccess is the access spec for the controller
 // login access.
-func ControllerForAccess(access Access) AccessSpec {
+func ControllerForAccess(access Access, controllerUUID string) AccessSpec {
 	return AccessSpec{
 		Access: access,
 		Target: ID{
 			ObjectType: Controller,
-			// This should be controllerNS from the core/database package, but
-			// using that import will cause the whole of the core/database
-			// package into the api client package.
-			// For now I've created a test to ensure that the value is correct.
-			// TODO (stickupkid): Move controllerNS to a namespace package.
-			Key: "controller",
+			Key:        controllerUUID,
 		},
 	}
 }

--- a/core/permission/user.go
+++ b/core/permission/user.go
@@ -66,15 +66,3 @@ func (u UserAccessSpec) Validate() error {
 	}
 	return nil
 }
-
-// ControllerForAccess is the access spec for the controller
-// login access.
-func ControllerForAccess(access Access, controllerUUID string) AccessSpec {
-	return AccessSpec{
-		Access: access,
-		Target: ID{
-			ObjectType: Controller,
-			Key:        controllerUUID,
-		},
-	}
-}

--- a/core/permission/user_test.go
+++ b/core/permission/user_test.go
@@ -6,8 +6,8 @@ package permission_test
 import (
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/permission"
+	"github.com/juju/juju/testing"
 )
 
 type userSuite struct{}
@@ -15,8 +15,9 @@ type userSuite struct{}
 var _ = gc.Suite(&userSuite{})
 
 func (s *userSuite) TestControllerForAccess(c *gc.C) {
-	spec := permission.ControllerForAccess(permission.ReadAccess)
-	c.Assert(spec.Target.Key, gc.Equals, database.ControllerNS)
+	controllerUUID := testing.ControllerTag.Id()
+	spec := permission.ControllerForAccess(permission.ReadAccess, controllerUUID)
+	c.Assert(spec.Target.Key, gc.Equals, controllerUUID)
 }
 
 var validateRevokeAccessTest = []struct {

--- a/core/permission/user_test.go
+++ b/core/permission/user_test.go
@@ -7,18 +7,11 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/permission"
-	"github.com/juju/juju/testing"
 )
 
 type userSuite struct{}
 
 var _ = gc.Suite(&userSuite{})
-
-func (s *userSuite) TestControllerForAccess(c *gc.C) {
-	controllerUUID := testing.ControllerTag.Id()
-	spec := permission.ControllerForAccess(permission.ReadAccess, controllerUUID)
-	c.Assert(spec.Target.Key, gc.Equals, controllerUUID)
-}
 
 var validateRevokeAccessTest = []struct {
 	spec     permission.AccessSpec

--- a/domain/access/bootstrap/bootstrap_test.go
+++ b/domain/access/bootstrap/bootstrap_test.go
@@ -9,7 +9,6 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/permission"
 	schematesting "github.com/juju/juju/domain/schema/testing"
 	"github.com/juju/juju/internal/auth"
@@ -17,9 +16,16 @@ import (
 
 type bootstrapSuite struct {
 	schematesting.ControllerSuite
+
+	controllerUUID string
 }
 
 var _ = gc.Suite(&bootstrapSuite{})
+
+func (s *bootstrapSuite) SetUpTest(c *gc.C) {
+	s.ControllerSuite.SetUpTest(c)
+	s.controllerUUID = s.SeedControllerUUID(c)
+}
 
 func (s *bootstrapSuite) TestAddUser(c *gc.C) {
 	ctx := context.Background()
@@ -27,7 +33,7 @@ func (s *bootstrapSuite) TestAddUser(c *gc.C) {
 		Access: permission.SuperuserAccess,
 		Target: permission.ID{
 			ObjectType: permission.Controller,
-			Key:        database.ControllerNS,
+			Key:        s.controllerUUID,
 		},
 	})
 	err := addAdminUser(ctx, s.TxnRunner(), s.NoopTxnRunner())
@@ -48,7 +54,7 @@ func (s *bootstrapSuite) TestAddUserWithPassword(c *gc.C) {
 		Access: permission.SuperuserAccess,
 		Target: permission.ID{
 			ObjectType: permission.Controller,
-			Key:        database.ControllerNS,
+			Key:        s.controllerUUID,
 		},
 	})
 	err := addAdminUser(ctx, s.TxnRunner(), s.NoopTxnRunner())

--- a/domain/access/service/user_test.go
+++ b/domain/access/service/user_test.go
@@ -66,7 +66,13 @@ func (s *userServiceSuite) TestAddUserAlreadyExists(c *gc.C) {
 	_, _, err := s.service().AddUser(context.Background(), AddUserArg{
 		Name:        "valid",
 		CreatorUUID: newUUID(c),
-		Permission:  permission.ControllerForAccess(permission.LoginAccess, jujutesting.ControllerTag.Id()),
+		Permission: permission.AccessSpec{
+			Access: permission.LoginAccess,
+			Target: permission.ID{
+				ObjectType: permission.Controller,
+				Key:        jujutesting.ControllerTag.Id(),
+			},
+		},
 	})
 	c.Assert(err, jc.ErrorIs, usererrors.UserAlreadyExists)
 }
@@ -82,7 +88,13 @@ func (s *userServiceSuite) TestAddUserCreatorUUIDNotFound(c *gc.C) {
 	_, _, err := s.service().AddUser(context.Background(), AddUserArg{
 		Name:        "valid",
 		CreatorUUID: newUUID(c),
-		Permission:  permission.ControllerForAccess(permission.LoginAccess, jujutesting.ControllerTag.Id()),
+		Permission: permission.AccessSpec{
+			Access: permission.LoginAccess,
+			Target: permission.ID{
+				ObjectType: permission.Controller,
+				Key:        jujutesting.ControllerTag.Id(),
+			},
+		},
 	})
 	c.Assert(err, jc.ErrorIs, usererrors.UserCreatorUUIDNotFound)
 }
@@ -94,7 +106,13 @@ func (s *userServiceSuite) TestAddUserWithPassword(c *gc.C) {
 	userUUID := newUUID(c)
 	creatorUUID := newUUID(c)
 
-	perms := permission.ControllerForAccess(permission.LoginAccess, jujutesting.ControllerTag.Id())
+	perms := permission.AccessSpec{
+		Access: permission.LoginAccess,
+		Target: permission.ID{
+			ObjectType: permission.Controller,
+			Key:        jujutesting.ControllerTag.Id(),
+		},
+	}
 
 	s.state.EXPECT().AddUserWithPasswordHash(
 		gomock.Any(), userUUID, "valid", "display", creatorUUID, perms, gomock.Any(), gomock.Any()).Return(nil)
@@ -130,7 +148,13 @@ func (s *userServiceSuite) TestAddUserWithPasswordNotValid(c *gc.C) {
 		DisplayName: "display",
 		Password:    &badPass,
 		CreatorUUID: creatorUUID,
-		Permission:  permission.ControllerForAccess(permission.LoginAccess, jujutesting.ControllerTag.Id()),
+		Permission: permission.AccessSpec{
+			Access: permission.LoginAccess,
+			Target: permission.ID{
+				ObjectType: permission.Controller,
+				Key:        jujutesting.ControllerTag.Id(),
+			},
+		},
 	})
 	c.Assert(err, jc.ErrorIs, auth.ErrPasswordNotValid)
 }

--- a/domain/access/service/user_test.go
+++ b/domain/access/service/user_test.go
@@ -25,6 +25,7 @@ import (
 	usererrors "github.com/juju/juju/domain/access/errors"
 	usertesting "github.com/juju/juju/domain/access/testing"
 	"github.com/juju/juju/internal/auth"
+	jujutesting "github.com/juju/juju/testing"
 )
 
 type userServiceSuite struct {
@@ -65,7 +66,7 @@ func (s *userServiceSuite) TestAddUserAlreadyExists(c *gc.C) {
 	_, _, err := s.service().AddUser(context.Background(), AddUserArg{
 		Name:        "valid",
 		CreatorUUID: newUUID(c),
-		Permission:  permission.ControllerForAccess(permission.LoginAccess),
+		Permission:  permission.ControllerForAccess(permission.LoginAccess, jujutesting.ControllerTag.Id()),
 	})
 	c.Assert(err, jc.ErrorIs, usererrors.UserAlreadyExists)
 }
@@ -81,7 +82,7 @@ func (s *userServiceSuite) TestAddUserCreatorUUIDNotFound(c *gc.C) {
 	_, _, err := s.service().AddUser(context.Background(), AddUserArg{
 		Name:        "valid",
 		CreatorUUID: newUUID(c),
-		Permission:  permission.ControllerForAccess(permission.LoginAccess),
+		Permission:  permission.ControllerForAccess(permission.LoginAccess, jujutesting.ControllerTag.Id()),
 	})
 	c.Assert(err, jc.ErrorIs, usererrors.UserCreatorUUIDNotFound)
 }
@@ -93,7 +94,7 @@ func (s *userServiceSuite) TestAddUserWithPassword(c *gc.C) {
 	userUUID := newUUID(c)
 	creatorUUID := newUUID(c)
 
-	perms := permission.ControllerForAccess(permission.LoginAccess)
+	perms := permission.ControllerForAccess(permission.LoginAccess, jujutesting.ControllerTag.Id())
 
 	s.state.EXPECT().AddUserWithPasswordHash(
 		gomock.Any(), userUUID, "valid", "display", creatorUUID, perms, gomock.Any(), gomock.Any()).Return(nil)
@@ -129,7 +130,7 @@ func (s *userServiceSuite) TestAddUserWithPasswordNotValid(c *gc.C) {
 		DisplayName: "display",
 		Password:    &badPass,
 		CreatorUUID: creatorUUID,
-		Permission:  permission.ControllerForAccess(permission.LoginAccess),
+		Permission:  permission.ControllerForAccess(permission.LoginAccess, jujutesting.ControllerTag.Id()),
 	})
 	c.Assert(err, jc.ErrorIs, auth.ErrPasswordNotValid)
 }

--- a/domain/access/service/user_test.go
+++ b/domain/access/service/user_test.go
@@ -25,7 +25,7 @@ import (
 	usererrors "github.com/juju/juju/domain/access/errors"
 	usertesting "github.com/juju/juju/domain/access/testing"
 	"github.com/juju/juju/internal/auth"
-	jujutesting "github.com/juju/juju/testing"
+	jujutesting "github.com/juju/juju/internal/testing"
 )
 
 type userServiceSuite struct {

--- a/domain/access/state/permission_test.go
+++ b/domain/access/state/permission_test.go
@@ -27,6 +27,7 @@ import (
 type permissionStateSuite struct {
 	schematesting.ControllerSuite
 
+	controllerUUID   string
 	modelUUID        coremodel.UUID
 	defaultModelUUID coremodel.UUID
 	debug            bool
@@ -36,6 +37,7 @@ var _ = gc.Suite(&permissionStateSuite{})
 
 func (s *permissionStateSuite) SetUpTest(c *gc.C) {
 	s.ControllerSuite.SetUpTest(c)
+	s.controllerUUID = s.SeedControllerUUID(c)
 
 	// Setup to add permissions for user bob on the model
 
@@ -109,7 +111,7 @@ func (s *permissionStateSuite) TestCreatePermissionController(c *gc.C) {
 		User: "bob",
 		AccessSpec: corepermission.AccessSpec{
 			Target: corepermission.ID{
-				Key:        "controller",
+				Key:        s.controllerUUID,
 				ObjectType: corepermission.Controller,
 			},
 			Access: corepermission.SuperuserAccess,
@@ -120,7 +122,7 @@ func (s *permissionStateSuite) TestCreatePermissionController(c *gc.C) {
 
 	c.Check(userAccess.UserID, gc.Equals, "123")
 	c.Check(userAccess.UserTag, gc.Equals, names.NewUserTag("bob"))
-	c.Check(userAccess.Object.Id(), gc.Equals, "controller")
+	c.Check(userAccess.Object.Id(), gc.Equals, s.controllerUUID)
 	c.Check(userAccess.Access, gc.Equals, corepermission.SuperuserAccess)
 	c.Check(userAccess.DisplayName, gc.Equals, "bob")
 	c.Check(userAccess.UserName, gc.Equals, "bob")
@@ -150,7 +152,7 @@ func (s *permissionStateSuite) TestCreatePermissionForControllerWithBadInfo(c *g
 	st := NewPermissionState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
 	// The only valid key for an object type of Controller is
-	// 'controller'
+	// the controller UUID.
 	_, err := st.CreatePermission(context.Background(), uuid.MustNewUUID(), corepermission.UserAccessSpec{
 		User: "bob",
 		AccessSpec: corepermission.AccessSpec{
@@ -299,7 +301,7 @@ func (s *permissionStateSuite) TestReadUserAccessForTarget(c *gc.C) {
 	st := NewPermissionState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
 	target := corepermission.ID{
-		Key:        "controller",
+		Key:        s.controllerUUID,
 		ObjectType: corepermission.Controller,
 	}
 	createUserAccess, err := st.CreatePermission(context.Background(), uuid.MustNewUUID(), corepermission.UserAccessSpec{
@@ -486,7 +488,7 @@ func (s *permissionStateSuite) TestUpsertPermissionGrantNewUser(c *gc.C) {
 		User: "admin",
 		AccessSpec: corepermission.AccessSpec{
 			Target: corepermission.ID{
-				Key:        "controller",
+				Key:        s.controllerUUID,
 				ObjectType: corepermission.Controller,
 			},
 			Access: corepermission.SuperuserAccess,
@@ -722,7 +724,7 @@ func (s *permissionStateSuite) setupForRead(c *gc.C, st *PermissionState) {
 		User: "admin",
 		AccessSpec: corepermission.AccessSpec{
 			Target: corepermission.ID{
-				Key:        "controller",
+				Key:        s.controllerUUID,
 				ObjectType: corepermission.Controller,
 			},
 			Access: corepermission.SuperuserAccess,

--- a/domain/controllerconfig/bootstrap/bootstrap.go
+++ b/domain/controllerconfig/bootstrap/bootstrap.go
@@ -5,6 +5,7 @@ package bootstrap
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/canonical/sqlair"
 	"github.com/juju/errors"
@@ -68,8 +69,12 @@ func InsertInitialControllerConfig(cfg jujucontroller.Config) internaldatabase.B
 			}
 
 			// Update the attributes.
-			if err := tx.Query(ctx, insertStmt, updateKeyValues).Run(); err != nil {
-				return errors.Trace(err)
+			if len(updateKeyValues) > 0 {
+				if err := tx.Query(ctx, insertStmt, updateKeyValues).Run(); err != nil {
+					return errors.Trace(err)
+				}
+			} else {
+				return fmt.Errorf("no controller config values to insert at bootstrap")
 			}
 
 			return nil

--- a/domain/controllerconfig/bootstrap/bootstrap_test.go
+++ b/domain/controllerconfig/bootstrap/bootstrap_test.go
@@ -31,3 +31,9 @@ func (s *bootstrapSuite) TestInsertInitialControllerConfig(c *gc.C) {
 
 	c.Check(cert, gc.Equals, testing.CACert)
 }
+
+func (s *bootstrapSuite) TestInsertMinimalControllerConfig(c *gc.C) {
+	cfg := controller.Config{}
+	err := InsertInitialControllerConfig(cfg)(context.Background(), s.TxnRunner(), s.NoopTxnRunner())
+	c.Assert(err, gc.ErrorMatches, "no controller config values to insert at bootstrap")
+}

--- a/domain/credential/bootstrap/bootstrap_test.go
+++ b/domain/credential/bootstrap/bootstrap_test.go
@@ -44,7 +44,13 @@ func (s *bootstrapSuite) TestInsertInitialControllerConfig(c *gc.C) {
 		"fred",
 		"test user",
 		userUUID,
-		permission.ControllerForAccess(permission.SuperuserAccess, s.controllerUUID),
+		permission.AccessSpec{
+			Access: permission.SuperuserAccess,
+			Target: permission.ID{
+				ObjectType: permission.Controller,
+				Key:        s.controllerUUID,
+			},
+		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/domain/credential/bootstrap/bootstrap_test.go
+++ b/domain/credential/bootstrap/bootstrap_test.go
@@ -21,9 +21,16 @@ import (
 
 type bootstrapSuite struct {
 	schematesting.ControllerSuite
+
+	controllerUUID string
 }
 
 var _ = gc.Suite(&bootstrapSuite{})
+
+func (s *bootstrapSuite) SetUpTest(c *gc.C) {
+	s.ControllerSuite.SetUpTest(c)
+	s.controllerUUID = s.SeedControllerUUID(c)
+}
 
 func (s *bootstrapSuite) TestInsertInitialControllerConfig(c *gc.C) {
 	ctx := context.Background()
@@ -37,7 +44,7 @@ func (s *bootstrapSuite) TestInsertInitialControllerConfig(c *gc.C) {
 		"fred",
 		"test user",
 		userUUID,
-		permission.ControllerForAccess(permission.SuperuserAccess),
+		permission.ControllerForAccess(permission.SuperuserAccess, s.controllerUUID),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/domain/credential/state/state_test.go
+++ b/domain/credential/state/state_test.go
@@ -69,7 +69,13 @@ func (s *credentialSuite) addOwner(c *gc.C, name string) user.UUID {
 		name,
 		"test user",
 		userUUID,
-		permission.ControllerForAccess(permission.SuperuserAccess, s.controllerUUID),
+		permission.AccessSpec{
+			Access: permission.SuperuserAccess,
+			Target: permission.ID{
+				ObjectType: permission.Controller,
+				Key:        s.controllerUUID,
+			},
+		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	return userUUID

--- a/domain/credential/state/state_test.go
+++ b/domain/credential/state/state_test.go
@@ -37,14 +37,17 @@ import (
 
 type credentialSuite struct {
 	changestreamtesting.ControllerSuite
-	userUUID user.UUID
-	userName string
+	userUUID       user.UUID
+	userName       string
+	controllerUUID string
 }
 
 var _ = gc.Suite(&credentialSuite{})
 
 func (s *credentialSuite) SetUpTest(c *gc.C) {
 	s.ControllerSuite.SetUpTest(c)
+
+	s.controllerUUID = s.SeedControllerUUID(c)
 
 	s.userName = "test-user"
 	s.userUUID = s.addOwner(c, s.userName)
@@ -66,7 +69,7 @@ func (s *credentialSuite) addOwner(c *gc.C, name string) user.UUID {
 		name,
 		"test user",
 		userUUID,
-		permission.ControllerForAccess(permission.SuperuserAccess),
+		permission.ControllerForAccess(permission.SuperuserAccess, s.controllerUUID),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	return userUUID

--- a/domain/model/bootstrap/bootstrap_test.go
+++ b/domain/model/bootstrap/bootstrap_test.go
@@ -35,7 +35,8 @@ type baseSuite struct {
 func (s *baseSuite) SetUpTest(c *gc.C) {
 	s.ControllerSuite.SetUpTest(c)
 
-	uuid, fn := userbootstrap.AddUser(coreuser.AdminUserName, permission.ControllerForAccess(permission.SuperuserAccess))
+	controllerUUID := s.SeedControllerUUID(c)
+	uuid, fn := userbootstrap.AddUser(coreuser.AdminUserName, permission.ControllerForAccess(permission.SuperuserAccess, controllerUUID))
 	err := fn(context.Background(), s.ControllerTxnRunner(), s.NoopTxnRunner())
 	c.Assert(err, jc.ErrorIsNil)
 	s.adminUserUUID = uuid

--- a/domain/model/bootstrap/bootstrap_test.go
+++ b/domain/model/bootstrap/bootstrap_test.go
@@ -36,7 +36,15 @@ func (s *baseSuite) SetUpTest(c *gc.C) {
 	s.ControllerSuite.SetUpTest(c)
 
 	controllerUUID := s.SeedControllerUUID(c)
-	uuid, fn := userbootstrap.AddUser(coreuser.AdminUserName, permission.ControllerForAccess(permission.SuperuserAccess, controllerUUID))
+	uuid, fn := userbootstrap.AddUser(
+		coreuser.AdminUserName,
+		permission.AccessSpec{
+			Access: permission.SuperuserAccess,
+			Target: permission.ID{
+				ObjectType: permission.Controller,
+				Key:        controllerUUID,
+			},
+		})
 	err := fn(context.Background(), s.ControllerTxnRunner(), s.NoopTxnRunner())
 	c.Assert(err, jc.ErrorIsNil)
 	s.adminUserUUID = uuid

--- a/domain/model/state/state_test.go
+++ b/domain/model/state/state_test.go
@@ -44,6 +44,8 @@ import (
 type stateSuite struct {
 	schematesting.ControllerSuite
 
+	controllerUUID string
+
 	uuid     coremodel.UUID
 	userUUID user.UUID
 	userName string
@@ -60,6 +62,7 @@ func (m *stateSuite) SetUpTest(c *gc.C) {
 	m.userUUID = userUUID
 	m.userName = "test-user"
 	c.Assert(err, jc.ErrorIsNil)
+	m.controllerUUID = m.SeedControllerUUID(c)
 	userState := accessstate.NewState(m.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 	err = userState.AddUser(
 		context.Background(),
@@ -67,7 +70,7 @@ func (m *stateSuite) SetUpTest(c *gc.C) {
 		m.userName,
 		m.userName,
 		m.userUUID,
-		permission.ControllerForAccess(permission.SuperuserAccess),
+		permission.ControllerForAccess(permission.SuperuserAccess, m.controllerUUID),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -207,7 +210,7 @@ func (m *stateSuite) TestModelCloudNameAndCredentialController(c *gc.C) {
 		coremodel.ControllerModelOwnerUsername,
 		coremodel.ControllerModelOwnerUsername,
 		userUUID,
-		permission.ControllerForAccess(permission.SuperuserAccess),
+		permission.ControllerForAccess(permission.SuperuserAccess, m.controllerUUID),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/domain/model/state/state_test.go
+++ b/domain/model/state/state_test.go
@@ -70,7 +70,13 @@ func (m *stateSuite) SetUpTest(c *gc.C) {
 		m.userName,
 		m.userName,
 		m.userUUID,
-		permission.ControllerForAccess(permission.SuperuserAccess, m.controllerUUID),
+		permission.AccessSpec{
+			Access: permission.SuperuserAccess,
+			Target: permission.ID{
+				ObjectType: permission.Controller,
+				Key:        m.controllerUUID,
+			},
+		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -210,7 +216,13 @@ func (m *stateSuite) TestModelCloudNameAndCredentialController(c *gc.C) {
 		coremodel.ControllerModelOwnerUsername,
 		coremodel.ControllerModelOwnerUsername,
 		userUUID,
-		permission.ControllerForAccess(permission.SuperuserAccess, m.controllerUUID),
+		permission.AccessSpec{
+			Access: permission.SuperuserAccess,
+			Target: permission.ID{
+				ObjectType: permission.Controller,
+				Key:        m.controllerUUID,
+			},
+		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/domain/modelconfig/bootstrap/bootstrap_test.go
+++ b/domain/modelconfig/bootstrap/bootstrap_test.go
@@ -49,7 +49,16 @@ func (s *bootstrapSuite) SetUpTest(c *gc.C) {
 	s.ModelSuite.SetUpTest(c)
 
 	controllerUUID := s.SeedControllerUUID(c)
-	userID, fn := userbootstrap.AddUser(coreuser.AdminUserName, permission.ControllerForAccess(permission.SuperuserAccess, controllerUUID))
+	userID, fn := userbootstrap.AddUser(
+		coreuser.AdminUserName,
+		permission.AccessSpec{
+			Access: permission.SuperuserAccess,
+			Target: permission.ID{
+				ObjectType: permission.Controller,
+				Key:        controllerUUID,
+			},
+		},
+	)
 	err := fn(context.Background(), s.ControllerTxnRunner(), s.ControllerSuite.NoopTxnRunner())
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/domain/modelconfig/bootstrap/bootstrap_test.go
+++ b/domain/modelconfig/bootstrap/bootstrap_test.go
@@ -48,7 +48,8 @@ func (s *bootstrapSuite) SetUpTest(c *gc.C) {
 	s.ControllerSuite.SetUpTest(c)
 	s.ModelSuite.SetUpTest(c)
 
-	userID, fn := userbootstrap.AddUser(coreuser.AdminUserName, permission.ControllerForAccess(permission.SuperuserAccess))
+	controllerUUID := s.SeedControllerUUID(c)
+	userID, fn := userbootstrap.AddUser(coreuser.AdminUserName, permission.ControllerForAccess(permission.SuperuserAccess, controllerUUID))
 	err := fn(context.Background(), s.ControllerTxnRunner(), s.ControllerSuite.NoopTxnRunner())
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/domain/modelconfig/modelconfig_test.go
+++ b/domain/modelconfig/modelconfig_test.go
@@ -51,7 +51,16 @@ func (s *modelConfigSuite) SetUpTest(c *gc.C) {
 
 	controllerUUID := s.SeedControllerUUID(c)
 
-	userID, fn := userbootstrap.AddUser(coreuser.AdminUserName, permission.ControllerForAccess(permission.SuperuserAccess, controllerUUID))
+	userID, fn := userbootstrap.AddUser(
+		coreuser.AdminUserName,
+		permission.AccessSpec{
+			Access: permission.SuperuserAccess,
+			Target: permission.ID{
+				ObjectType: permission.Controller,
+				Key:        controllerUUID,
+			},
+		},
+	)
 	err := fn(context.Background(), s.ControllerTxnRunner(), s.ControllerSuite.NoopTxnRunner())
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/domain/modelconfig/modelconfig_test.go
+++ b/domain/modelconfig/modelconfig_test.go
@@ -49,7 +49,9 @@ func (s *modelConfigSuite) SetUpTest(c *gc.C) {
 	s.ControllerSuite.SetUpTest(c)
 	s.ModelSuite.SetUpTest(c)
 
-	userID, fn := userbootstrap.AddUser(coreuser.AdminUserName, permission.ControllerForAccess(permission.SuperuserAccess))
+	controllerUUID := s.SeedControllerUUID(c)
+
+	userID, fn := userbootstrap.AddUser(coreuser.AdminUserName, permission.ControllerForAccess(permission.SuperuserAccess, controllerUUID))
 	err := fn(context.Background(), s.ControllerTxnRunner(), s.ControllerSuite.NoopTxnRunner())
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/domain/schema/controller/sql/0017-user-permission.sql
+++ b/domain/schema/controller/sql/0017-user-permission.sql
@@ -116,7 +116,7 @@ FROM v_permission AS p
 INNER JOIN cloud ON p.grant_on = cloud.name
 WHERE p.object_type = 'cloud';
 
--- All controller permissions
+-- All controller permissions, verifying the controller does exists.
 CREATE VIEW v_permission_controller AS
 SELECT
     p.uuid,
@@ -125,4 +125,5 @@ SELECT
     p.access_type,
     p.object_type
 FROM v_permission AS p
-WHERE p.grant_on = 'controller' AND p.object_type = 'controller';
+INNER JOIN controller ON p.grant_on = controller.uuid
+WHERE p.object_type = 'controller';

--- a/domain/schema/testing/controllersuite.go
+++ b/domain/schema/testing/controllersuite.go
@@ -14,7 +14,7 @@ import (
 	"github.com/juju/juju/domain/schema"
 	"github.com/juju/juju/internal/database"
 	"github.com/juju/juju/internal/database/testing"
-	jujutesting "github.com/juju/juju/testing"
+	jujutesting "github.com/juju/juju/internal/testing"
 )
 
 // ControllerSuite is used to provide a sql.DB reference to tests.

--- a/domain/schema/testing/controllersuite.go
+++ b/domain/schema/testing/controllersuite.go
@@ -5,6 +5,7 @@ package testing
 
 import (
 	"context"
+	"database/sql"
 
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -13,6 +14,7 @@ import (
 	"github.com/juju/juju/domain/schema"
 	"github.com/juju/juju/internal/database"
 	"github.com/juju/juju/internal/database/testing"
+	jujutesting "github.com/juju/juju/testing"
 )
 
 // ControllerSuite is used to provide a sql.DB reference to tests.
@@ -47,4 +49,16 @@ func (s *ControllerSuite) ApplyDDLForRunner(c *gc.C, runner coredatabase.TxnRunn
 // ControllerTxnRunner returns a txn runner attached to the controller database.
 func (s *ControllerSuite) ControllerTxnRunner() coredatabase.TxnRunner {
 	return s.TxnRunner()
+}
+
+// SeedControllerUUID sets the uuid in the controller table to the default
+// testing value. It does not add any other controller config.
+func (s *ControllerSuite) SeedControllerUUID(c *gc.C) string {
+	controllerUUID := jujutesting.ControllerTag.Id()
+	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `INSERT INTO controller (uuid) VALUES (?)`, controllerUUID)
+		return err
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	return controllerUUID
 }

--- a/domain/secretbackend/state/state_test.go
+++ b/domain/secretbackend/state/state_test.go
@@ -53,12 +53,8 @@ var _ = gc.Suite(&stateSuite{})
 func (s *stateSuite) SetUpTest(c *gc.C) {
 	s.ControllerSuite.SetUpTest(c)
 
-	s.setupController(c)
-	s.state = NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
-}
-
-func (s *stateSuite) setupController(c *gc.C) {
 	s.controllerUUID = s.SeedControllerUUID(c)
+	s.state = NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 }
 
 func (s *stateSuite) createModel(c *gc.C, modelType coremodel.ModelType) coremodel.UUID {
@@ -129,7 +125,13 @@ func (s *stateSuite) createModelWithName(c *gc.C, modelType coremodel.ModelType,
 		userUUID,
 		// TODO (stickupkid): This should be AdminAccess, but we don't have
 		// a model to set the user as the owner of.
-		permission.ControllerForAccess(permission.SuperuserAccess, s.controllerUUID),
+		permission.AccessSpec{
+			Access: permission.SuperuserAccess,
+			Target: permission.ID{
+				ObjectType: permission.Controller,
+				Key:        s.controllerUUID,
+			},
+		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/domain/secretbackend/state/state_test.go
+++ b/domain/secretbackend/state/state_test.go
@@ -41,6 +41,8 @@ type stateSuite struct {
 	schematesting.ControllerSuite
 	state *State
 
+	controllerUUID string
+
 	internalBackendID   string
 	kubernetesBackendID string
 	vaultBackendID      string
@@ -51,17 +53,12 @@ var _ = gc.Suite(&stateSuite{})
 func (s *stateSuite) SetUpTest(c *gc.C) {
 	s.ControllerSuite.SetUpTest(c)
 
+	s.setupController(c)
 	s.state = NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 }
 
-func (s *stateSuite) setupController(c *gc.C) string {
-	controllerUUID := uuid.MustNewUUID().String()
-	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
-		_, err := tx.ExecContext(ctx, `INSERT INTO controller (uuid) VALUES (?)`, controllerUUID)
-		return err
-	})
-	c.Assert(err, jc.ErrorIsNil)
-	return controllerUUID
+func (s *stateSuite) setupController(c *gc.C) {
+	s.controllerUUID = s.SeedControllerUUID(c)
 }
 
 func (s *stateSuite) createModel(c *gc.C, modelType coremodel.ModelType) coremodel.UUID {
@@ -132,7 +129,7 @@ func (s *stateSuite) createModelWithName(c *gc.C, modelType coremodel.ModelType,
 		userUUID,
 		// TODO (stickupkid): This should be AdminAccess, but we don't have
 		// a model to set the user as the owner of.
-		permission.ControllerForAccess(permission.SuperuserAccess),
+		permission.ControllerForAccess(permission.SuperuserAccess, s.controllerUUID),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -356,7 +353,7 @@ func (s *stateSuite) TestCreateSecretBackendWithNoRotateNoConfig(c *gc.C) {
 	}, nil)
 }
 
-func (s *stateSuite) TestupsertSecretBackendInvalidArg(c *gc.C) {
+func (s *stateSuite) TestUpsertSecretBackendInvalidArg(c *gc.C) {
 	_, err := s.state.upsertSecretBackend(context.Background(), nil, upsertSecretBackendParams{})
 	c.Check(err, gc.ErrorMatches, `secret backend not valid: ID is missing`)
 
@@ -1330,13 +1327,12 @@ func (s *stateSuite) TestSetModelSecretBackendModelNotFound(c *gc.C) {
 }
 
 func (s *stateSuite) TestGetModelSecretBackendDetails(c *gc.C) {
-	controllerUUID := s.setupController(c)
 	modelUUID := s.createModel(c, coremodel.IAAS)
 
 	result, err := s.state.GetModelSecretBackendDetails(context.Background(), modelUUID)
 	c.Assert(err, gc.IsNil)
 	c.Assert(result, gc.Equals, secretbackend.ModelSecretBackend{
-		ControllerUUID:  controllerUUID,
+		ControllerUUID:  s.controllerUUID,
 		ID:              modelUUID,
 		Name:            "my-model",
 		Type:            "iaas",

--- a/domain/servicefactory/testing/suite.go
+++ b/domain/servicefactory/testing/suite.go
@@ -104,7 +104,13 @@ func (s *ServiceFactorySuite) SeedAdminUser(c *gc.C) {
 	uuid, fn := userbootstrap.AddUserWithPassword(
 		coreuser.AdminUserName,
 		password,
-		permission.ControllerForAccess(permission.SuperuserAccess, jujutesting.ControllerTag.Id()),
+		permission.AccessSpec{
+			Access: permission.SuperuserAccess,
+			Target: permission.ID{
+				ObjectType: permission.Controller,
+				Key:        jujutesting.ControllerTag.Id(),
+			},
+		},
 	)
 	s.AdminUserUUID = uuid
 	err := fn(context.Background(), s.ControllerTxnRunner(), s.NoopTxnRunner())

--- a/internal/worker/bootstrap/worker.go
+++ b/internal/worker/bootstrap/worker.go
@@ -307,7 +307,13 @@ func (w *bootstrapWorker) seedInitialUsers(ctx context.Context) error {
 		DisplayName: "Juju Metrics",
 		Password:    &password,
 		CreatorUUID: adminUser.UUID,
-		Permission:  permission.ControllerForAccess(permission.LoginAccess, controllerUUID),
+		Permission: permission.AccessSpec{
+			Access: permission.LoginAccess,
+			Target: permission.ID{
+				ObjectType: permission.Controller,
+				Key:        controllerUUID,
+			},
+		},
 	})
 	// User already exists, we don't need to do anything in this scenario.
 	if errors.Is(err, usererrors.UserAlreadyExists) {

--- a/internal/worker/bootstrap/worker.go
+++ b/internal/worker/bootstrap/worker.go
@@ -285,6 +285,13 @@ func (w *bootstrapWorker) seedMacaroonConfig(ctx context.Context) error {
 func (w *bootstrapWorker) seedInitialUsers(ctx context.Context) error {
 	// Any failure should be retryable, so we can re-attempt to bootstrap.
 
+	controllerCfg, err := w.cfg.ControllerConfigService.ControllerConfig(ctx)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	controllerUUID := controllerCfg.ControllerUUID()
+
 	adminUser, err := w.cfg.UserService.GetUserByName(ctx, "admin")
 	if err != nil {
 		return errors.Annotatef(err, "getting admin user")
@@ -300,7 +307,7 @@ func (w *bootstrapWorker) seedInitialUsers(ctx context.Context) error {
 		DisplayName: "Juju Metrics",
 		Password:    &password,
 		CreatorUUID: adminUser.UUID,
-		Permission:  permission.ControllerForAccess(permission.LoginAccess),
+		Permission:  permission.ControllerForAccess(permission.LoginAccess, controllerUUID),
 	})
 	// User already exists, we don't need to do anything in this scenario.
 	if errors.Is(err, usererrors.UserAlreadyExists) {

--- a/internal/worker/bootstrap/worker_test.go
+++ b/internal/worker/bootstrap/worker_test.go
@@ -315,7 +315,7 @@ func (s *workerSuite) expectControllerConfig() {
 	s.controllerConfigService.EXPECT().ControllerConfig(gomock.Any()).
 		Return(controller.Config{
 			controller.ControllerUUIDKey: "test-uuid",
-		}, nil).Times(2)
+		}, nil).Times(3)
 }
 
 func (s *workerSuite) expectUser(c *gc.C) {

--- a/juju/testing/macaroonsuite.go
+++ b/juju/testing/macaroonsuite.go
@@ -107,7 +107,13 @@ func (s *MacaroonSuite) AddModelUser(c *gc.C, username string) {
 // a controller user with the specified access.
 func (s *MacaroonSuite) AddControllerUser(c *gc.C, username string, access permission.Access) {
 	accessService := s.ControllerServiceFactory(c).Access()
-	perm := permission.ControllerForAccess(access, s.ControllerUUID)
+	perm := permission.AccessSpec{
+		Access: access,
+		Target: permission.ID{
+			ObjectType: permission.Controller,
+			Key:        s.ControllerUUID,
+		},
+	}
 
 	_, _, err := accessService.AddUser(context.Background(), service.AddUserArg{
 		Name:        username,

--- a/juju/testing/macaroonsuite.go
+++ b/juju/testing/macaroonsuite.go
@@ -107,7 +107,7 @@ func (s *MacaroonSuite) AddModelUser(c *gc.C, username string) {
 // a controller user with the specified access.
 func (s *MacaroonSuite) AddControllerUser(c *gc.C, username string, access permission.Access) {
 	accessService := s.ControllerServiceFactory(c).Access()
-	perm := permission.ControllerForAccess(access)
+	perm := permission.ControllerForAccess(access, s.ControllerUUID)
 
 	_, _, err := accessService.AddUser(context.Background(), service.AddUserArg{
 		Name:        username,


### PR DESCRIPTION
The controller access permission used the controller namespace
"controller" as the target of the permission. For all other permissions
the UUID of the target entity is used. It should be the same here.

The controller access permission is changed to use the controller UUID.
This has required piping the UUID through all the appropriate places.
<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://docs.google.com/document/d/1SYUo9G7qZ_jdoVXpUVamS5VCgHmtZ0QA-wZxKoMS-C0 
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps
```
juju bootstrap lxd test-user
juju add-model default
juju change-user-password admin
juju add-user alastair
juju change-user-password alastair
juju logout
juju login -u alastair -c test-user
```
Should now be able to access model.

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Jira card:** [JUJU-6260](https://warthogs.atlassian.net/browse/JUJU-6260)



[JUJU-6260]: https://warthogs.atlassian.net/browse/JUJU-6260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ