### PR TITLE
docs: fix various typo

### DIFF
--- a/cmd/juju/application/integrate.go
+++ b/cmd/juju/application/integrate.go
@@ -196,7 +196,7 @@ func (c *addRelationCommand) Info() *cmd.Info {
 	addCmd := &cmd.Info{
 		Name:     "integrate",
 		Aliases:  []string{"relate"},
-		Args:     "<application>[:<relation>] <application>[:<relation>]",
+		Args:     "<application>[:<endpoint>] <application>[:<endpoint>]",
 		Purpose:  "Integrate two applications.",
 		Doc:      integrateDoc,
 		Examples: integrateExamples,

--- a/cmd/juju/commands/upgradecontroller.go
+++ b/cmd/juju/commands/upgradecontroller.go
@@ -44,7 +44,7 @@ Upgrades Juju on a controller.`[1:]
 var usageUpgradeControllerDetails = `
 This command upgrades the Juju agent for a controller.
 
-A controller's agent version can be shown with `[1:] + "`juju model-config -m controller agent-\nversion`" + `.
+A controller's agent version can be shown with `[1:] + "`juju model-config -m controller agent-version`" + `.
 A version is denoted by: major.minor.patch
 
 You can upgrade the controller to a new patch version by specifying

--- a/cmd/juju/commands/upgrademodel.go
+++ b/cmd/juju/commands/upgrademodel.go
@@ -33,7 +33,7 @@ var usageUpgradeJujuDetails = `
 Juju provides agent software to every machine it creates. This command
 upgrades that software across an entire model, which is, by default, the
 current model.
-A model's agent version can be shown with `[1:] + "`juju model-config agent-\nversion`" + `.
+A model's agent version can be shown with `[1:] + "`juju model-config agent-version`" + `.
 A version is denoted by: major.minor.patch
 
 If '--agent-version' is not specified, then the upgrade candidate is

--- a/state/application.go
+++ b/state/application.go
@@ -3092,7 +3092,7 @@ func (a *Application) Relations() (relations []*Relation, err error) {
 }
 
 // matchingRelations returns all relations matching the application(s)/endpoint(s) provided
-// There must be 1 or 2 supplied names, of the form <application>[:<relation>]
+// There must be 1 or 2 supplied names, of the form <application>[:<endpoint>]
 func matchingRelations(st *State, names ...string) (relations []*Relation, err error) {
 	defer errors.DeferredAnnotatef(&err, "can't get relations matching %q", strings.Join(names, " "))
 	relationsCollection, closer := st.db().GetCollection(relationsC)

--- a/state/state.go
+++ b/state/state.go
@@ -1906,7 +1906,7 @@ func (st *State) AllApplications() (applications []*Application, err error) {
 
 // InferActiveRelation returns the relation corresponding to the supplied
 // application or endpoint name(s), assuming such a relation exists and is unique.
-// There must be 1 or 2 supplied names, of the form <application>[:<relation>].
+// There must be 1 or 2 supplied names, of the form <application>[:<endpoint>].
 func (st *State) InferActiveRelation(names ...string) (*Relation, error) {
 	candidates, err := matchingRelations(st, names...)
 	if err != nil {
@@ -1931,7 +1931,7 @@ func (st *State) InferActiveRelation(names ...string) (*Relation, error) {
 }
 
 // InferEndpoints returns the endpoints corresponding to the supplied names.
-// There must be 1 or 2 supplied names, of the form <application>[:<relation>].
+// There must be 1 or 2 supplied names, of the form <application>[:<endpoint>].
 // If the supplied names uniquely specify a possible relation, or if they
 // uniquely specify a possible relation once all implicit relations have been
 // filtered, the endpoints corresponding to that relation will be returned.


### PR DESCRIPTION
- Fix typo where the term `relation` was used in comments and documentation of `juju integrate` instead of `endpoint`
- Fix a typo which shows a space between `agent-` and `version` in the command `juju model-config agent-version` in the generated documentation.

After this commit, the command is now correctly displayed as `juju model-config agent-version`.

Signed-off-by: Guillaume Fouillet <guillaume.fouillet@canonical.com>
<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://docs.google.com/document/d/1SYUo9G7qZ_jdoVXpUVamS5VCgHmtZ0QA-wZxKoMS-C0 
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

~- [ ] Code style: imports ordered, good names, simple structure, etc~
~- [ ] Comments saying why design decisions were made~
~- [ ] Go unit tests, with comments saying what you're testing~
~- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
~- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

None

## Documentation changes

Updates generated documentation.

## Links

**Jira card:** 
- [JUJU-6294](https://warthogs.atlassian.net/browse/JUJU-6294)
- [JUJU-5591](https://warthogs.atlassian.net/browse/JUJU-5591)

**Discourse:** https://discourse.charmhub.io/t/command-juju-integrate/10207/2



[JUJU-6294]: https://warthogs.atlassian.net/browse/JUJU-6294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ