### PR TITLE
feat: larger back-off strategy

### DIFF
--- a/internal/changestream/stream/stream.go
+++ b/internal/changestream/stream/stream.go
@@ -45,7 +45,7 @@ var (
 	// from the database. This is used to prevent the worker from polling
 	// the database too frequently and allow us to attempt to coalesce
 	// changes when there is less activity.
-	backOffStrategy = retry.ExpBackoff(time.Millisecond*10, time.Millisecond*250, 1.5, false)
+	backOffStrategy = retry.ExpBackoff(time.Millisecond*100, time.Second*10, 1.4, false)
 )
 
 // MetricsCollector represents the metrics methods called.


### PR DESCRIPTION
When reviewing the parca results, we spend a _lot_ of time, just polling the database for changes. For complex models with lots of changes having 100 millisecond back-off allows for changes to be coalesced into one term. Yet for models with zero or no changes, we should allow the change stream to back off even more. If there are no changes, we shouldn't attempt to poll.

The theory stands, that models with no activity will get short concentrated bursts of activity, before backing off. Coalescing is not such a need, but is desirable, as opposed to active models with a sustained throughput of changes that will need to take advantage of coalescing. The former will more likely have resources to deal with short bursts of activity, whereas coalescing on active models will allow them to deal with the pressure.

The code currently resets the attempts to 0 upon any changes, allowing it to start polling more frequently. It may be more beneficial to reduce the attempt by half instead of 0 (ensuring it doesn't go to minus). Thus, we don't hit the database for all models at the same time in case there is an outside force coordinating the change (clock synchronisation point for example). This would give us more of a sinusoidal wave rather than the more abrupt sawtooth wave. The former is more compassionate and forgiving of the surrounding infrastructure. The downside is that it _may_ take longer to get changes (we're talking 100s milliseconds in reality).

As part of this work, we should consider adding a jitter to the back-off strategy (this is different from the back-off jitter argument which jitters between the min and max value) to ensure we don't accidentally get synchronisation points between change streams.

### Experiments

With these changes, it will take 15 attempts before reaching the maximum.

| index | attempt | duration |
| :---: | :---: | :---: |
| 0 | 0 | 100ms |
| 1 | 1 | 140ms |
| 2 | 2 | 196ms |
| 3 | 3 | 274ms |
| 4 | 4 | 384ms |
| 5 | 5 | 538ms |
| 6 | 6 | 753ms |
| 7 | 7 | 1.054s |
| 8 | 8 | 1.476s |
| 9 | 9 | 2.066s |
| 10 | 10 | 2.893s |
| 11 | 11 | 4.05s |
| 12 | 12 | 5.669s |
| 13 | 13 | 7.937s |
| 14 | 14 | 10s |
| 15 | 15 | 10s |

If a change is detected at index 6 and at 14, then the results become:

| index | attempt | duration |
| :---: | :---: | :---: |
| 0 | 0 | 100ms |
| 1 | 1 | 140ms |
| 2 | 2 | 196ms |
| 3 | 3 | 274ms |
| 4 | 4 | 384ms |
| 5 | 5 | 538ms |
| 6 | 6 | 753ms |
| 7 | 0 | 100ms |
| 8 | 1 | 140ms |
| 9 | 2 | 196ms |
| 10 | 3 | 274ms |
| 11 | 4 | 384ms |
| 12 | 5 | 538ms |
| 13 | 6 | 753ms |
| 14 | 7 | 1.054s |
| 15 | 0 | 100ms |
| 16 | 1 | 140ms |
| 17 | 2 | 196ms |
| 18 | 3 | 274ms |
| 19 | 4 | 384ms |
| 20 | 5 | 538ms |

Instead, if we divide by 2 at the same index values, the results become:

| index | attempt | duration |
| :---: | :---: | :---: |
| 0 | 0 | 100ms |
| 1 | 1 | 140ms |
| 2 | 2 | 196ms |
| 3 | 3 | 274ms |
| 4 | 4 | 384ms |
| 5 | 5 | 538ms |
| 6 | 6 | 753ms |
| 7 | 3 | 274ms |
| 8 | 4 | 384ms |
| 9 | 5 | 538ms |
| 10 | 6 | 753ms |
| 11 | 7 | 1.054s |
| 12 | 8 | 1.476s |
| 13 | 9 | 2.066s |
| 14 | 10 | 2.893s |
| 15 | 5 | 538ms |
| 16 | 6 | 753ms |
| 17 | 7 | 1.054s |
| 18 | 8 | 1.476s |
| 19 | 9 | 2.066s |
| 20 | 10 | 2.893s |

![chart](https://github.com/juju/juju/assets/2562584/ae00c0f1-9980-4492-9287-07364e8a105e)

The blue line shows the initial back-off with no data at index 6 and 14. The red line shows strategy 1 if we reset the attempt to 0. The orange line shows strategy 2 if we divide by 2.

The basic idea is that we can start to see that if we're less aggressive with resetting back to 0 for our attempts against the database, we take pressure off the db for polling it.

This is a very contrived naive example, but it maybe one that we do want to apply in the future. 

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
$ juju bootstrap lxd test
$ juju add-model default
$ juju deploy ubuntu
```

## Links

**Jira card:** JUJU-

