### PR TITLE
fix: assert user auth tag

### DIFF
--- a/cmd/juju/application/bind_test.go
+++ b/cmd/juju/application/bind_test.go
@@ -43,6 +43,7 @@ func (s *BindSuite) SetUpTest(c *gc.C) {
 	s.PatchEnvironment("JUJU_COOKIEFILE", cookieFile)
 
 	s.apiConnection = mockAPIConnection{
+		authTag: names.NewUserTag("testuser"),
 		serverVersion: &version.Number{
 			Major: 1,
 			Minor: 2,
@@ -67,6 +68,9 @@ func (s *BindSuite) SetUpTest(c *gc.C) {
 	store.Models["foo"] = &jujuclient.ControllerModels{
 		CurrentModel: "admin/bar",
 		Models:       map[string]jujuclient.ModelDetails{"admin/bar": {ActiveBranch: model.GenerationMaster}},
+	}
+	store.Accounts["foo"] = jujuclient.AccountDetails{
+		User: "testuser",
 	}
 	apiOpen := func(*api.Info, api.DialOpts) (api.Connection, error) {
 		s.AddCall("OpenAPI")
@@ -139,6 +143,7 @@ func (s *BindSuite) TestBindUnknownEndpoint(c *gc.C) {
 
 func (s *BindSuite) setupAPIConnection() {
 	s.apiConnection = mockAPIConnection{
+		authTag: names.NewUserTag("testuser"),
 		serverVersion: &version.Number{
 			Major: 1,
 			Minor: 2,

--- a/cmd/juju/application/refresh_test.go
+++ b/cmd/juju/application/refresh_test.go
@@ -165,7 +165,7 @@ func (s *BaseRefreshSuite) setup(c *gc.C, currentCharmURL, latestCharmURL *charm
 		},
 		charmOrigin: commoncharm.Origin{
 			ID:           "testing",
-			Source:       schemaToOriginScource(currentCharmURL.Schema),
+			Source:       schemaToOriginSource(currentCharmURL.Schema),
 			Risk:         risk,
 			Architecture: arch.DefaultArchitecture,
 			Base:         s.testBase,
@@ -184,7 +184,7 @@ func (s *BaseRefreshSuite) setup(c *gc.C, currentCharmURL, latestCharmURL *charm
 	}
 }
 
-func schemaToOriginScource(schema string) commoncharm.OriginSource {
+func schemaToOriginSource(schema string) commoncharm.OriginSource {
 	switch {
 	case charm.Local.Matches(schema):
 		return commoncharm.OriginLocal
@@ -1242,6 +1242,7 @@ func (s *RefreshSuccessStateSuite) TestCharmPathDifferentNameFails(c *gc.C) {
 type mockAPIConnection struct {
 	api.Connection
 	serverVersion *version.Number
+	authTag       names.Tag
 }
 
 func (m *mockAPIConnection) Addr() string {
@@ -1253,7 +1254,7 @@ func (m *mockAPIConnection) IPAddr() string {
 }
 
 func (m *mockAPIConnection) AuthTag() names.Tag {
-	return names.NewUserTag("testuser")
+	return m.authTag
 }
 
 func (m *mockAPIConnection) PublicDNSName() string {

--- a/cmd/modelcmd/modelcommand_test.go
+++ b/cmd/modelcmd/modelcommand_test.go
@@ -494,7 +494,8 @@ func (s *macaroonLoginSuite) SetUpTest(c *gc.C) {
 	}
 	s.store.Accounts[s.controllerName] = jujuclient.AccountDetails{
 		// External user forces use of macaroons.
-		User: "me@external",
+		User:      testUser,
+		Macaroons: []macaroon.Slice{{}},
 	}
 	s.store.Models[s.controllerName] = &jujuclient.ControllerModels{
 		Models: map[string]jujuclient.ModelDetails{

--- a/juju/api.go
+++ b/juju/api.go
@@ -117,6 +117,12 @@ func NewAPIConnection(args NewAPIConnectionParams) (_ api.Connection, err error)
 		}
 	}()
 
+	// If the account details are set, ensure that the user we've logged in as
+	// matches the user we expected to log in as.
+	if args.AccountDetails != nil && st.AuthTag() != nil && args.AccountDetails.User != st.AuthTag().Id() {
+		return nil, errors.Unauthorizedf("attempted login as %q for user %q", st.AuthTag().Id(), args.AccountDetails.User)
+	}
+
 	// Update API addresses if they've changed. Error is non-fatal.
 	// Note that in the redirection case, we won't update the addresses
 	// of the controller we first connected to. This shouldn't be

--- a/juju/mock_test.go
+++ b/juju/mock_test.go
@@ -24,6 +24,7 @@ type mockAPIState struct {
 	modelTag      string
 	controllerTag string
 	publicDNSName string
+	authTag       names.Tag
 }
 
 type mockedStateFlags int
@@ -59,6 +60,7 @@ func mockedAPIState(flags mockedStateFlags) *mockAPIState {
 		modelTag:      modelTag,
 		controllerTag: testing.ControllerTag.Id(),
 		addr:          addr,
+		authTag:       names.NewUserTag("admin"),
 	}
 }
 
@@ -109,7 +111,7 @@ func (s *mockAPIState) ControllerTag() names.ControllerTag {
 }
 
 func (s *mockAPIState) AuthTag() names.Tag {
-	return names.NewUserTag("admin")
+	return s.authTag
 }
 
 func (s *mockAPIState) ControllerAccess() string {


### PR DESCRIPTION
The returning auth tag from the API open call should be validated against the one the user-supplied. This can especially happen when using the external SSO and the user supplies a different user tag from the one they log in with.

The fix is to validate that information and ensure it matches. If it doesn't match prevent the login from sending back an unauthorized error. This will still keep the existing login details in the `accounts.yaml`.

Future work could auth against any `@external` user, that's out of the scope of this PR.

<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://docs.google.com/document/d/1SYUo9G7qZ_jdoVXpUVamS5VCgHmtZ0QA-wZxKoMS-C0 
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

Ensure you change the admin password, so it's easier to log back in.



```sh
$ juju bootstrap lxd test --config identity-url=https://api.jujucharms.com/identity --config allow-model-access=true
$ juju whoami
Controller:  test
Model:       <no-current-model>
User:        admin
$ juju grant <launchpad username>@external superuser
$ juju grant mary@external login
$ juju change-user-password
$ juju logout
$ juju login -u <launchpad username>@external
$ juju whoami
Controller:  test
Model:       admin/controller
User:        simonrichardson@external
$ juju logout
$ juju login -u mary@external
Opening an authorization web page in your browser.
If it does not open, please open this URL:
https://api.jujucharms.com/identity/login?did=<...>
Opening in existing browser session.
ERROR cannot log into controller "test": attempted login as "<launchpad username>@external" for user "mary@external"
$ juju whoami
You are not logged in to controller "src34" and model "admin/controller".
Run juju login if you want to login.
$ juju status
ERROR attempted login as "simonrichardson@external" for user ""
```

Note: we're clearly still storing the user somewhere, even after logout, so when calling `juju status` afterward it mentions the prior user. This is non-ideal. The follow up bug is https://bugs.launchpad.net/juju/+bug/2072473

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2072337

**Jira card:** [JUJU-6328](https://warthogs.atlassian.net/browse/JUJU-6328)



[JUJU-6328]: https://warthogs.atlassian.net/browse/JUJU-6328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ