### PR TITLE
feat: state get implementations

### DIFF
--- a/domain/charm/state/actions.go
+++ b/domain/charm/state/actions.go
@@ -1,0 +1,23 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"github.com/juju/juju/domain/charm"
+)
+
+func decodeActions(actions []charmAction) charm.Actions {
+	result := charm.Actions{
+		Actions: make(map[string]charm.Action),
+	}
+	for _, action := range actions {
+		result.Actions[action.Key] = charm.Action{
+			Description:    action.Description,
+			Parallel:       action.Parallel,
+			ExecutionGroup: action.ExecutionGroup,
+			Params:         action.Params,
+		}
+	}
+	return result
+}

--- a/domain/charm/state/actions_test.go
+++ b/domain/charm/state/actions_test.go
@@ -1,0 +1,62 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/domain/charm"
+	schematesting "github.com/juju/juju/domain/schema/testing"
+)
+
+type actionsSuite struct {
+	schematesting.ModelSuite
+}
+
+var _ = gc.Suite(&actionsSuite{})
+
+var actionsTestCases = [...]struct {
+	name   string
+	input  []charmAction
+	output charm.Actions
+}{
+	{
+		name:  "empty",
+		input: []charmAction{},
+		output: charm.Actions{
+			Actions: make(map[string]charm.Action),
+		},
+	},
+	{
+		name: "single",
+		input: []charmAction{
+			{
+				Key:            "action",
+				Description:    "description",
+				Parallel:       true,
+				ExecutionGroup: "group",
+				Params:         []byte("{}"),
+			},
+		},
+		output: charm.Actions{
+			Actions: map[string]charm.Action{
+				"action": {
+					Description:    "description",
+					Parallel:       true,
+					ExecutionGroup: "group",
+					Params:         []byte("{}"),
+				},
+			},
+		},
+	},
+}
+
+func (s *actionsSuite) TestConvertActions(c *gc.C) {
+	for _, tc := range actionsTestCases {
+		c.Logf("Running test case %q", tc.name)
+
+		result := decodeActions(tc.input)
+		c.Check(result, gc.DeepEquals, tc.output)
+	}
+}

--- a/domain/charm/state/config.go
+++ b/domain/charm/state/config.go
@@ -1,0 +1,67 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/juju/juju/domain/charm"
+)
+
+func decodeConfig(configs []charmConfig) (charm.Config, error) {
+	result := charm.Config{
+		Options: make(map[string]charm.Option),
+	}
+	for _, config := range configs {
+		optionType, err := decodeConfigType(config.Type)
+		if err != nil {
+			return charm.Config{}, fmt.Errorf("cannot decode config type %q: %w", config.Type, err)
+		}
+
+		defaultValue, err := decodeConfigDefaultValue(optionType, config.DefaultValue)
+		if err != nil {
+			return charm.Config{}, fmt.Errorf("cannot decode config default value %q: %w", config.DefaultValue, err)
+		}
+
+		result.Options[config.Key] = charm.Option{
+			Type:        optionType,
+			Description: config.Description,
+			Default:     defaultValue,
+		}
+	}
+	return result, nil
+}
+
+func decodeConfigType(t string) (charm.OptionType, error) {
+	switch t {
+	case "string":
+		return charm.OptionString, nil
+	case "int":
+		return charm.OptionInt, nil
+	case "float":
+		return charm.OptionFloat, nil
+	case "boolean":
+		return charm.OptionBool, nil
+	case "secret":
+		return charm.OptionSecret, nil
+	default:
+		return "", fmt.Errorf("unknown config type %q", t)
+	}
+}
+
+func decodeConfigDefaultValue(t charm.OptionType, value string) (any, error) {
+	switch t {
+	case charm.OptionString, charm.OptionSecret:
+		return value, nil
+	case charm.OptionInt:
+		return strconv.Atoi(value)
+	case charm.OptionFloat:
+		return strconv.ParseFloat(value, 64)
+	case charm.OptionBool:
+		return strconv.ParseBool(value)
+	default:
+		return nil, fmt.Errorf("unknown config type %q", t)
+	}
+}

--- a/domain/charm/state/config_test.go
+++ b/domain/charm/state/config_test.go
@@ -1,0 +1,142 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/domain/charm"
+	schematesting "github.com/juju/juju/domain/schema/testing"
+)
+
+type configSuite struct {
+	schematesting.ModelSuite
+}
+
+var _ = gc.Suite(&configSuite{})
+
+var configTestCases = [...]struct {
+	name   string
+	input  []charmConfig
+	output charm.Config
+}{
+	{
+		name:  "empty",
+		input: []charmConfig{},
+		output: charm.Config{
+			Options: make(map[string]charm.Option),
+		},
+	},
+	{
+		name: "string",
+		input: []charmConfig{
+			{
+				Key:          "string",
+				Type:         "string",
+				Description:  "description",
+				DefaultValue: "default",
+			},
+		},
+		output: charm.Config{
+			Options: map[string]charm.Option{
+				"string": {
+					Type:        charm.OptionString,
+					Description: "description",
+					Default:     "default",
+				},
+			},
+		},
+	},
+	{
+		name: "secret",
+		input: []charmConfig{
+			{
+				Key:          "secret",
+				Type:         "secret",
+				Description:  "description",
+				DefaultValue: "default",
+			},
+		},
+		output: charm.Config{
+			Options: map[string]charm.Option{
+				"secret": {
+					Type:        charm.OptionSecret,
+					Description: "description",
+					Default:     "default",
+				},
+			},
+		},
+	},
+	{
+		name: "int",
+		input: []charmConfig{
+			{
+				Key:          "int",
+				Type:         "int",
+				Description:  "description",
+				DefaultValue: "1",
+			},
+		},
+		output: charm.Config{
+			Options: map[string]charm.Option{
+				"int": {
+					Type:        charm.OptionInt,
+					Description: "description",
+					Default:     1,
+				},
+			},
+		},
+	},
+	{
+		name: "float",
+		input: []charmConfig{
+			{
+				Key:          "float",
+				Type:         "float",
+				Description:  "description",
+				DefaultValue: "4.2",
+			},
+		},
+		output: charm.Config{
+			Options: map[string]charm.Option{
+				"float": {
+					Type:        charm.OptionFloat,
+					Description: "description",
+					Default:     4.2,
+				},
+			},
+		},
+	},
+	{
+		name: "boolean",
+		input: []charmConfig{
+			{
+				Key:          "boolean",
+				Type:         "boolean",
+				Description:  "description",
+				DefaultValue: "true",
+			},
+		},
+		output: charm.Config{
+			Options: map[string]charm.Option{
+				"boolean": {
+					Type:        charm.OptionBool,
+					Description: "description",
+					Default:     true,
+				},
+			},
+		},
+	},
+}
+
+func (s *configSuite) TestConvertConfig(c *gc.C) {
+	for _, tc := range configTestCases {
+		c.Logf("Running test case %q", tc.name)
+
+		result, err := decodeConfig(tc.input)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Check(result, gc.DeepEquals, tc.output)
+	}
+}

--- a/domain/charm/state/manifest.go
+++ b/domain/charm/state/manifest.go
@@ -1,0 +1,89 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"fmt"
+
+	"github.com/juju/juju/domain/charm"
+)
+
+// decodeManifest decodes the given manifests into a charm.Manifest.
+// It should respect the order of the bases in the manifest. Although the
+// order of architectures within a base is not guaranteed.
+func decodeManifest(manifests []charmManifest) (charm.Manifest, error) {
+	bases := make(map[int]charm.Base)
+
+	var largestIndex int
+	for _, base := range manifests {
+		channel, err := decodeManifestChannel(base)
+		if err != nil {
+			return charm.Manifest{}, fmt.Errorf("cannot decode channel: %w", err)
+		}
+
+		if b, ok := bases[base.Index]; ok {
+			b.Architectures = append(b.Architectures, base.Architecture)
+			bases[base.Index] = b
+
+			continue
+		}
+
+		var architectures []string
+		if base.Architecture != "" {
+			architectures = append(architectures, base.Architecture)
+		}
+
+		bases[base.Index] = charm.Base{
+			Name:          base.OS,
+			Channel:       channel,
+			Architectures: architectures,
+		}
+
+		if base.Index > largestIndex {
+			largestIndex = base.Index
+		}
+	}
+
+	// Convert the map into a slice using the largest index as the length. This
+	// means that we preserved the order of the bases even faced with holes in
+	// the array.
+	result := make([]charm.Base, largestIndex+1)
+	for index, base := range bases {
+		result[index] = base
+	}
+
+	return charm.Manifest{
+		Bases: result,
+	}, nil
+}
+
+// decodeManifestChannel decodes the given base into a charm.Channel.
+func decodeManifestChannel(base charmManifest) (charm.Channel, error) {
+	risk, err := decodeManifestChannelRisk(base.Risk)
+	if err != nil {
+		return charm.Channel{}, fmt.Errorf("cannot decode risk: %w", err)
+	}
+
+	return charm.Channel{
+		Track:  base.Track,
+		Risk:   risk,
+		Branch: base.Branch,
+	}, nil
+}
+
+// decodeManifestChannelRisk decodes the given risk into a charm.ChannelRisk.
+func decodeManifestChannelRisk(risk string) (charm.ChannelRisk, error) {
+	switch risk {
+	case "stable":
+		return charm.RiskStable, nil
+	case "candidate":
+		return charm.RiskCandidate, nil
+	case "beta":
+		return charm.RiskBeta, nil
+	case "edge":
+		return charm.RiskEdge, nil
+	default:
+		return "", fmt.Errorf("unknown risk %q", risk)
+	}
+}

--- a/domain/charm/state/state.go
+++ b/domain/charm/state/state.go
@@ -458,7 +458,7 @@ func (s *State) GetCharmManifest(ctx context.Context, id corecharm.ID) (charm.Ma
 	ident := charmID{UUID: id.String()}
 
 	query := `
-SELECT v_charm_manifest.* AS &charmManifest.*
+SELECT &charmManifest.*
 FROM v_charm_manifest
 WHERE charm_uuid = $charmID.uuid
 ORDER BY "idx" ASC;
@@ -497,7 +497,7 @@ func (s *State) GetCharmLXDProfile(ctx context.Context, id corecharm.ID) ([]byte
 	ident := charmID{UUID: id.String()}
 
 	query := `
-SELECT charm.* AS &charmLXDProfile.*
+SELECT &charmLXDProfile.*
 FROM charm
 WHERE uuid = $charmID.uuid;
 `
@@ -534,12 +534,12 @@ func (s *State) GetCharmConfig(ctx context.Context, id corecharm.ID) (charm.Conf
 	ident := charmID{UUID: id.String()}
 
 	charmQuery := `
-SELECT charm.* AS &charmID.*
+SELECT &charmID.*
 FROM charm
 WHERE uuid = $charmID.uuid;
 `
 	configQuery := `
-SELECT v_charm_config.* AS &charmConfig.*
+SELECT &charmConfig.*
 FROM v_charm_config
 WHERE charm_uuid = $charmID.uuid;
 `
@@ -586,12 +586,12 @@ func (s *State) GetCharmActions(ctx context.Context, id corecharm.ID) (charm.Act
 	ident := charmID{UUID: id.String()}
 
 	charmQuery := `
-SELECT charm.* AS &charmID.*
+SELECT &charmID.*
 FROM charm
 WHERE uuid = $charmID.uuid;
 `
 	actionQuery := `
-SELECT charm_action.* AS &charmAction.*
+SELECT &charmAction.*
 FROM charm_action
 WHERE charm_uuid = $charmID.uuid;
 `
@@ -630,11 +630,7 @@ WHERE charm_uuid = $charmID.uuid;
 // getCharmMetadata returns the metadata for the charm using the charm ID.
 // This is the core metadata for the charm.
 func getCharmMetadata(ctx context.Context, tx *sqlair.TX, p domain.Preparer, ident charmID) (charmMetadata, error) {
-	query := `
-SELECT v_charm.* AS &charmMetadata.*
-FROM v_charm
-WHERE uuid = $charmID.uuid;
-`
+	query := `SELECT &charmMetadata.* FROM v_charm WHERE uuid = $charmID.uuid;`
 	stmt, err := p.Prepare(query, charmMetadata{}, ident)
 	if err != nil {
 		return charmMetadata{}, fmt.Errorf("failed to prepare query: %w", err)
@@ -660,7 +656,7 @@ WHERE uuid = $charmID.uuid;
 // Tags are expected to be unique, no duplicates are expected.
 func getCharmTags(ctx context.Context, tx *sqlair.TX, p domain.Preparer, ident charmID) ([]charmTag, error) {
 	query := `
-SELECT charm_tag.* AS &charmTag.*
+SELECT &charmTag.*
 FROM charm_tag
 WHERE charm_uuid = $charmID.uuid
 ORDER BY "index" ASC;
@@ -690,7 +686,7 @@ ORDER BY "index" ASC;
 // Categories are expected to be unique, no duplicates are expected.
 func getCharmCategories(ctx context.Context, tx *sqlair.TX, p domain.Preparer, ident charmID) ([]charmCategory, error) {
 	query := `
-SELECT charm_category.* AS &charmCategory.*
+SELECT &charmCategory.*
 FROM charm_category
 WHERE charm_uuid = $charmID.uuid
 ORDER BY "index" ASC;
@@ -720,7 +716,7 @@ ORDER BY "index" ASC;
 // Terms are expected to be unique, no duplicates are expected.
 func getCharmTerms(ctx context.Context, tx *sqlair.TX, p domain.Preparer, ident charmID) ([]charmTerm, error) {
 	query := `
-SELECT charm_term.* AS &charmTerm.*
+SELECT &charmTerm.*
 FROM charm_term
 WHERE charm_uuid = $charmID.uuid
 ORDER BY "index" ASC;
@@ -748,7 +744,7 @@ ORDER BY "index" ASC;
 // the caller will handle this case.
 func getCharmRelations(ctx context.Context, tx *sqlair.TX, p domain.Preparer, ident charmID) ([]charmRelation, error) {
 	query := `
-SELECT v_charm_relation.* AS &charmRelation.*
+SELECT &charmRelation.*
 FROM v_charm_relation
 WHERE charm_uuid = $charmID.uuid;
 	`
@@ -776,7 +772,7 @@ WHERE charm_uuid = $charmID.uuid;
 // the caller will handle this case.
 func getCharmExtraBindings(ctx context.Context, tx *sqlair.TX, p domain.Preparer, ident charmID) ([]charmExtraBinding, error) {
 	query := `
-SELECT charm_extra_binding.* AS &charmExtraBinding.*
+SELECT &charmExtraBinding.*
 FROM charm_extra_binding
 WHERE charm_uuid = $charmID.uuid;
 `
@@ -803,7 +799,7 @@ WHERE charm_uuid = $charmID.uuid;
 // Charm properties are expected to be unique, no duplicates are expected.
 func getCharmStorage(ctx context.Context, tx *sqlair.TX, p domain.Preparer, ident charmID) ([]charmStorage, error) {
 	query := `
-SELECT v_charm_storage.* AS &charmStorage.*
+SELECT &charmStorage.*
 FROM v_charm_storage
 WHERE charm_uuid = $charmID.uuid
 ORDER BY property_index ASC;
@@ -830,7 +826,7 @@ ORDER BY property_index ASC;
 // the caller will handle this case.
 func getCharmDevices(ctx context.Context, tx *sqlair.TX, p domain.Preparer, ident charmID) ([]charmDevice, error) {
 	query := `
-SELECT charm_device.* AS &charmDevice.*
+SELECT &charmDevice.*
 FROM charm_device
 WHERE charm_uuid = $charmID.uuid;
 `
@@ -856,7 +852,7 @@ WHERE charm_uuid = $charmID.uuid;
 // the caller will handle this case.
 func getCharmPayloads(ctx context.Context, tx *sqlair.TX, p domain.Preparer, ident charmID) ([]charmPayload, error) {
 	query := `
-SELECT charm_payload.* AS &charmPayload.*
+SELECT &charmPayload.*
 FROM charm_payload
 WHERE charm_uuid = $charmID.uuid;
 `
@@ -882,7 +878,7 @@ WHERE charm_uuid = $charmID.uuid;
 // the caller will handle this case.
 func getCharmResources(ctx context.Context, tx *sqlair.TX, p domain.Preparer, ident charmID) ([]charmResource, error) {
 	query := `
-SELECT v_charm_resource.* AS &charmResource.*
+SELECT &charmResource.*
 FROM v_charm_resource
 WHERE charm_uuid = $charmID.uuid;
 `
@@ -908,7 +904,7 @@ WHERE charm_uuid = $charmID.uuid;
 // the caller will handle this case.
 func getCharmContainers(ctx context.Context, tx *sqlair.TX, p domain.Preparer, ident charmID) ([]charmContainer, error) {
 	query := `
-SELECT v_charm_container.* AS &charmContainer.*
+SELECT &charmContainer.*
 FROM v_charm_container
 WHERE charm_uuid = $charmID.uuid
 ORDER BY "index" ASC;

--- a/domain/charm/state/state_test.go
+++ b/domain/charm/state/state_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"database/sql"
 
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/version/v2"
 	gc "gopkg.in/check.v1"
@@ -344,19 +345,26 @@ func (s *stateSuite) TestGetCharmMetadataWithTagsAndCategories(c *gc.C) {
 
 	var expected charm.Metadata
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
-		expected = insertCharmMetadata(ctx, c, tx, uuid)
+		var err error
+		if expected, err = insertCharmMetadata(ctx, c, tx, uuid); err != nil {
+			return errors.Trace(err)
+		}
 
-		_, err := tx.ExecContext(ctx, `
+		_, err = tx.ExecContext(ctx, `
 INSERT INTO charm_category (charm_uuid, "index", value)
 VALUES (?, 0, 'data'), (?, 1, 'kubernetes'), (?, 2, 'kubernetes')
 `, uuid, uuid, uuid)
-		c.Assert(err, jc.ErrorIsNil)
+		if err != nil {
+			return errors.Trace(err)
+		}
 
 		_, err = tx.ExecContext(ctx, `
 INSERT INTO charm_tag (charm_uuid, "index", value)
 VALUES (?, 0, 'foo'), (?, 1, 'foo'), (?, 2,'bar')
 `, uuid, uuid, uuid)
-		c.Assert(err, jc.ErrorIsNil)
+		if err != nil {
+			return errors.Trace(err)
+		}
 
 		return nil
 	})
@@ -382,13 +390,18 @@ func (s *stateSuite) TestGetCharmMetadataWithTerms(c *gc.C) {
 
 	var expected charm.Metadata
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
-		expected = insertCharmMetadata(ctx, c, tx, uuid)
+		var err error
+		if expected, err = insertCharmMetadata(ctx, c, tx, uuid); err != nil {
+			return errors.Trace(err)
+		}
 
-		_, err := tx.ExecContext(ctx, `
+		_, err = tx.ExecContext(ctx, `
 INSERT INTO charm_term (charm_uuid, "index", value) 
 VALUES (?, 0, 'alpha'), (?, 1, 'beta'), (?, 2, 'beta')
 `, uuid, uuid, uuid)
-		c.Assert(err, jc.ErrorIsNil)
+		if err != nil {
+			return errors.Trace(err)
+		}
 
 		return nil
 	})
@@ -413,9 +426,12 @@ func (s *stateSuite) TestGetCharmMetadataWithRelation(c *gc.C) {
 
 	var expected charm.Metadata
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
-		expected = insertCharmMetadata(ctx, c, tx, uuid)
+		var err error
+		if expected, err = insertCharmMetadata(ctx, c, tx, uuid); err != nil {
+			return errors.Trace(err)
+		}
 
-		_, err := tx.ExecContext(ctx, `
+		_, err = tx.ExecContext(ctx, `
 INSERT INTO charm_relation (charm_uuid, kind_id, key, name, role_id, scope_id) 
 VALUES 
     (?, 0, 'foo', 'baz', 0, 0),
@@ -423,7 +439,9 @@ VALUES
     (?, 1, 'foo', 'baz', 1, 1),
     (?, 2, 'foo', 'baz', 2, 0);`,
 			uuid, uuid, uuid, uuid)
-		c.Assert(err, jc.ErrorIsNil)
+		if err != nil {
+			return errors.Trace(err)
+		}
 
 		return nil
 	})
@@ -475,15 +493,20 @@ func (s *stateSuite) TestGetCharmMetadataWithExtraBindings(c *gc.C) {
 
 	var expected charm.Metadata
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
-		expected = insertCharmMetadata(ctx, c, tx, uuid)
+		var err error
+		if expected, err = insertCharmMetadata(ctx, c, tx, uuid); err != nil {
+			return errors.Trace(err)
+		}
 
-		_, err := tx.ExecContext(ctx, `
+		_, err = tx.ExecContext(ctx, `
 INSERT INTO charm_extra_binding (charm_uuid, key, name) 
 VALUES 
     (?, 'foo', 'bar'),
     (?, 'fred', 'baz');`,
 			uuid, uuid)
-		c.Assert(err, jc.ErrorIsNil)
+		if err != nil {
+			return errors.Trace(err)
+		}
 
 		return nil
 	})
@@ -515,9 +538,12 @@ func (s *stateSuite) TestGetCharmMetadataWithStorageWithNoProperties(c *gc.C) {
 
 	var expected charm.Metadata
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
-		expected = insertCharmMetadata(ctx, c, tx, uuid)
+		var err error
+		if expected, err = insertCharmMetadata(ctx, c, tx, uuid); err != nil {
+			return errors.Trace(err)
+		}
 
-		_, err := tx.ExecContext(ctx, `
+		_, err = tx.ExecContext(ctx, `
 INSERT INTO charm_storage (
     charm_uuid,
     key,
@@ -534,7 +560,9 @@ INSERT INTO charm_storage (
     (?, 'foo', 'bar', 'description 1', 1, true, true, 1, 2, 3, '/tmp'),
     (?, 'fred', 'baz', 'description 2', 0, false, false, 4, 5, 6, '/var/mount');`,
 			uuid, uuid)
-		c.Assert(err, jc.ErrorIsNil)
+		if err != nil {
+			return errors.Trace(err)
+		}
 
 		return nil
 	})
@@ -582,9 +610,12 @@ func (s *stateSuite) TestGetCharmMetadataWithStorageWithProperties(c *gc.C) {
 
 	var expected charm.Metadata
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
-		expected = insertCharmMetadata(ctx, c, tx, uuid)
+		var err error
+		if expected, err = insertCharmMetadata(ctx, c, tx, uuid); err != nil {
+			return errors.Trace(err)
+		}
 
-		_, err := tx.ExecContext(ctx, `
+		_, err = tx.ExecContext(ctx, `
 INSERT INTO charm_storage (
     charm_uuid,
     key,
@@ -601,7 +632,9 @@ INSERT INTO charm_storage (
     (?, 'foo', 'bar', 'description 1', 1, true, true, 1, 2, 3, '/tmp'),
     (?, 'fred', 'baz', 'description 2', 0, false, false, 4, 5, 6, '/var/mount');`,
 			uuid, uuid)
-		c.Assert(err, jc.ErrorIsNil)
+		if err != nil {
+			return errors.Trace(err)
+		}
 
 		_, err = tx.ExecContext(ctx, `
 INSERT INTO charm_storage_property (
@@ -614,7 +647,9 @@ INSERT INTO charm_storage_property (
     (?, 'foo', 1, 'beta'),
     (?, 'foo', 2, 'beta');`,
 			uuid, uuid, uuid)
-		c.Assert(err, jc.ErrorIsNil)
+		if err != nil {
+			return errors.Trace(err)
+		}
 
 		return nil
 	})
@@ -661,9 +696,12 @@ func (s *stateSuite) TestGetCharmMetadataWithDevices(c *gc.C) {
 
 	var expected charm.Metadata
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
-		expected = insertCharmMetadata(ctx, c, tx, uuid)
+		var err error
+		if expected, err = insertCharmMetadata(ctx, c, tx, uuid); err != nil {
+			return errors.Trace(err)
+		}
 
-		_, err := tx.ExecContext(ctx, `
+		_, err = tx.ExecContext(ctx, `
 INSERT INTO charm_device (
     charm_uuid,
     key,
@@ -676,7 +714,9 @@ INSERT INTO charm_device (
     (?, 'foo', 'bar', 'description 1', 'gpu', 1, 2),
     (?, 'fred', 'baz', 'description 2', 'tpu', 3, 4);`,
 			uuid, uuid)
-		c.Assert(err, jc.ErrorIsNil)
+		if err != nil {
+			return errors.Trace(err)
+		}
 
 		return nil
 	})
@@ -714,9 +754,12 @@ func (s *stateSuite) TestGetCharmMetadataWithPayloadClasses(c *gc.C) {
 
 	var expected charm.Metadata
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
-		expected = insertCharmMetadata(ctx, c, tx, uuid)
+		var err error
+		if expected, err = insertCharmMetadata(ctx, c, tx, uuid); err != nil {
+			return errors.Trace(err)
+		}
 
-		_, err := tx.ExecContext(ctx, `
+		_, err = tx.ExecContext(ctx, `
 INSERT INTO charm_payload (
     charm_uuid,
     key,
@@ -726,7 +769,9 @@ INSERT INTO charm_payload (
     (?, 'foo', 'bar', 'docker'),
     (?, 'fred', 'baz', 'kvm');`,
 			uuid, uuid)
-		c.Assert(err, jc.ErrorIsNil)
+		if err != nil {
+			return errors.Trace(err)
+		}
 
 		return nil
 	})
@@ -758,9 +803,12 @@ func (s *stateSuite) TestGetCharmMetadataWithResources(c *gc.C) {
 
 	var expected charm.Metadata
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
-		expected = insertCharmMetadata(ctx, c, tx, uuid)
+		var err error
+		if expected, err = insertCharmMetadata(ctx, c, tx, uuid); err != nil {
+			return errors.Trace(err)
+		}
 
-		_, err := tx.ExecContext(ctx, `
+		_, err = tx.ExecContext(ctx, `
 INSERT INTO charm_resource (
     charm_uuid,
     key,
@@ -772,7 +820,9 @@ INSERT INTO charm_resource (
     (?, 'foo', 'bar', 0, '/tmp/file.txt', 'description 1'),
     (?, 'fred', 'baz', 1, 'hub.docker.io/jujusolutions', 'description 2');`,
 			uuid, uuid)
-		c.Assert(err, jc.ErrorIsNil)
+		if err != nil {
+			return errors.Trace(err)
+		}
 
 		return nil
 	})
@@ -808,9 +858,12 @@ func (s *stateSuite) TestGetCharmMetadataWithContainersWithNoMounts(c *gc.C) {
 
 	var expected charm.Metadata
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
-		expected = insertCharmMetadata(ctx, c, tx, uuid)
+		var err error
+		if expected, err = insertCharmMetadata(ctx, c, tx, uuid); err != nil {
+			return errors.Trace(err)
+		}
 
-		_, err := tx.ExecContext(ctx, `
+		_, err = tx.ExecContext(ctx, `
 INSERT INTO charm_container (
     charm_uuid,
     key,
@@ -821,7 +874,9 @@ INSERT INTO charm_container (
     (?, 'foo', 'ubuntu@22.04', 100, 100),
     (?, 'fred', 'ubuntu@20.04', -1, -1);`,
 			uuid, uuid)
-		c.Assert(err, jc.ErrorIsNil)
+		if err != nil {
+			return errors.Trace(err)
+		}
 
 		return nil
 	})
@@ -853,9 +908,12 @@ func (s *stateSuite) TestGetCharmMetadataWithContainersWithMounts(c *gc.C) {
 
 	var expected charm.Metadata
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
-		expected = insertCharmMetadata(ctx, c, tx, uuid)
+		var err error
+		if expected, err = insertCharmMetadata(ctx, c, tx, uuid); err != nil {
+			return errors.Trace(err)
+		}
 
-		_, err := tx.ExecContext(ctx, `
+		_, err = tx.ExecContext(ctx, `
 INSERT INTO charm_container (
     charm_uuid,
     key,
@@ -866,7 +924,9 @@ INSERT INTO charm_container (
     (?, 'foo', 'ubuntu@22.04', 100, 100),
     (?, 'fred', 'ubuntu@20.04', -1, -1);`,
 			uuid, uuid)
-		c.Assert(err, jc.ErrorIsNil)
+		if err != nil {
+			return errors.Trace(err)
+		}
 
 		_, err = tx.ExecContext(ctx, `
 INSERT INTO charm_container_mount (
@@ -880,7 +940,9 @@ INSERT INTO charm_container_mount (
     (?, 1, 'foo', 'block', '/dev/nvme0n1'),
     (?, 0, 'fred', 'file', '/var/log');`,
 			uuid, uuid, uuid)
-		c.Assert(err, jc.ErrorIsNil)
+		if err != nil {
+			return errors.Trace(err)
+		}
 		return nil
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -927,9 +989,12 @@ func (s *stateSuite) TestGetCharmManifest(c *gc.C) {
 
 	var expected charm.Manifest
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
-		expected = insertCharmManifest(ctx, c, tx, uuid)
+		var err error
+		if expected, err = insertCharmManifest(ctx, c, tx, uuid); err != nil {
+			return errors.Trace(err)
+		}
 
-		_, err := tx.ExecContext(ctx, `
+		_, err = tx.ExecContext(ctx, `
 INSERT INTO charm_manifest_base (
     charm_uuid,
 	"index",
@@ -944,7 +1009,9 @@ INSERT INTO charm_manifest_base (
 	(?, 1, 0, '', 'edge', 'foo', 0),
 	(?, 2, 0, '4.0', 'beta', 'baz', 2);`,
 			uuid, uuid, uuid, uuid)
-		c.Assert(err, jc.ErrorIsNil)
+		if err != nil {
+			return errors.Trace(err)
+		}
 		return nil
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -983,18 +1050,252 @@ INSERT INTO charm_manifest_base (
 	})
 }
 
-func insertCharmState(ctx context.Context, c *gc.C, tx *sql.Tx, uuid string) {
+func (s *stateSuite) TestGetCharmManifestNotFound(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	id := charmtesting.GenCharmID(c)
+
+	_, err := st.GetCharmManifest(context.Background(), id)
+	c.Assert(err, jc.ErrorIs, charmerrors.NotFound)
+}
+
+func (s *stateSuite) TestGetCharmLXDProfile(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	id := charmtesting.GenCharmID(c)
+	uuid := id.String()
+
+	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		if err := insertCharmState(ctx, c, tx, uuid); err != nil {
+			return errors.Trace(err)
+		}
+
+		_, err := tx.ExecContext(ctx, `
+UPDATE charm 
+SET lxd_profile = ?
+WHERE uuid = ?
+`, `{"profile": []}`, uuid)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		return nil
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	profile, err := st.GetCharmLXDProfile(context.Background(), id)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(profile, gc.DeepEquals, []byte(`{"profile": []}`))
+}
+
+func (s *stateSuite) TestGetCharmLXDProfileNotFound(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	id := charmtesting.GenCharmID(c)
+
+	_, err := st.GetCharmLXDProfile(context.Background(), id)
+	c.Assert(err, jc.ErrorIs, charmerrors.NotFound)
+}
+
+func (s *stateSuite) TestGetCharmConfig(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	id := charmtesting.GenCharmID(c)
+	uuid := id.String()
+
+	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		if err := insertCharmState(ctx, c, tx, uuid); err != nil {
+			return errors.Trace(err)
+		}
+
+		_, err := tx.ExecContext(ctx, `
+INSERT INTO charm_config (
+    charm_uuid,
+	"key",
+    type_id,
+    default_value,
+    description
+) VALUES 
+    (?, 'foo', 0, 'string', 'this is a string'),
+    (?, 'bar', 1, '42', 'this is an int'),
+	(?, 'baz', 3, 'true', 'this is a bool'),
+	(?, 'alpha', 2, '3.42', 'this is a float'),
+	(?, 'beta', 2, '3', 'this is also a float'),
+	(?, 'shh', 4, 'secret', 'this is a secret');`,
+			uuid, uuid, uuid, uuid, uuid, uuid)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		return nil
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	config, err := st.GetCharmConfig(context.Background(), id)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(config, gc.DeepEquals, charm.Config{
+		Options: map[string]charm.Option{
+			"foo": {
+				Type:        charm.OptionString,
+				Default:     "string",
+				Description: "this is a string",
+			},
+			"bar": {
+				Type:        charm.OptionInt,
+				Default:     42,
+				Description: "this is an int",
+			},
+			"baz": {
+				Type:        charm.OptionBool,
+				Default:     true,
+				Description: "this is a bool",
+			},
+			"alpha": {
+				Type:        charm.OptionFloat,
+				Default:     3.42,
+				Description: "this is a float",
+			},
+			"beta": {
+				Type:        charm.OptionFloat,
+				Default:     float64(3),
+				Description: "this is also a float",
+			},
+			"shh": {
+				Type:        charm.OptionSecret,
+				Default:     "secret",
+				Description: "this is a secret",
+			},
+		},
+	})
+}
+
+func (s *stateSuite) TestGetCharmConfigNotFound(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	id := charmtesting.GenCharmID(c)
+
+	_, err := st.GetCharmConfig(context.Background(), id)
+	c.Assert(err, jc.ErrorIs, charmerrors.NotFound)
+}
+
+func (s *stateSuite) TestGetCharmConfigEmpty(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	id := charmtesting.GenCharmID(c)
+	uuid := id.String()
+
+	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		if err := insertCharmState(ctx, c, tx, uuid); err != nil {
+			return errors.Trace(err)
+		}
+		return nil
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	config, err := st.GetCharmConfig(context.Background(), id)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(config, gc.DeepEquals, charm.Config{
+		Options: map[string]charm.Option{},
+	})
+}
+
+func (s *stateSuite) TestGetCharmActions(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	id := charmtesting.GenCharmID(c)
+	uuid := id.String()
+
+	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		if err := insertCharmState(ctx, c, tx, uuid); err != nil {
+			return errors.Trace(err)
+		}
+
+		_, err := tx.ExecContext(ctx, `
+INSERT INTO charm_action (
+    charm_uuid,
+	"key",
+    description,
+    parallel,
+    execution_group,
+	params
+) VALUES 
+    (?, 'foo', 'description1', true, 'group1', '{}'),
+    (?, 'bar', 'description2', false, 'group2', null);`,
+			uuid, uuid, uuid, uuid, uuid, uuid)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		return nil
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	config, err := st.GetCharmActions(context.Background(), id)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(config, gc.DeepEquals, charm.Actions{
+		Actions: map[string]charm.Action{
+			"foo": {
+				Description:    "description1",
+				Parallel:       true,
+				ExecutionGroup: "group1",
+				Params:         []byte("{}"),
+			},
+			"bar": {
+				Description:    "description2",
+				Parallel:       false,
+				ExecutionGroup: "group2",
+			},
+		},
+	})
+}
+
+func (s *stateSuite) TestGetCharmActionsNotFound(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	id := charmtesting.GenCharmID(c)
+
+	_, err := st.GetCharmActions(context.Background(), id)
+	c.Assert(err, jc.ErrorIs, charmerrors.NotFound)
+}
+
+func (s *stateSuite) TestGetCharmActionsEmpty(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	id := charmtesting.GenCharmID(c)
+	uuid := id.String()
+
+	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		if err := insertCharmState(ctx, c, tx, uuid); err != nil {
+			return errors.Trace(err)
+		}
+		return nil
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	config, err := st.GetCharmActions(context.Background(), id)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(config, gc.DeepEquals, charm.Actions{
+		Actions: map[string]charm.Action{},
+	})
+}
+
+func insertCharmState(ctx context.Context, c *gc.C, tx *sql.Tx, uuid string) error {
 	_, err := tx.ExecContext(ctx, `
 INSERT INTO charm (uuid, name, description, summary, subordinate, min_juju_version, run_as_id, assumes) 
 VALUES (?, 'ubuntu', 'description', 'summary', true, '4.0.0', 1, 'null')`, uuid)
-	c.Assert(err, jc.ErrorIsNil)
+	if err != nil {
+		return errors.Trace(err)
+	}
 
 	_, err = tx.ExecContext(ctx, `INSERT INTO charm_state (charm_uuid, available) VALUES (?, false)`, uuid)
-	c.Assert(err, jc.ErrorIsNil)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	return nil
 }
 
-func insertCharmMetadata(ctx context.Context, c *gc.C, tx *sql.Tx, uuid string) charm.Metadata {
-	insertCharmState(ctx, c, tx, uuid)
+func insertCharmMetadata(ctx context.Context, c *gc.C, tx *sql.Tx, uuid string) (charm.Metadata, error) {
+	if err := insertCharmState(ctx, c, tx, uuid); err != nil {
+		return charm.Metadata{}, errors.Trace(err)
+	}
 
 	return charm.Metadata{
 		Name:           "ubuntu",
@@ -1004,13 +1305,15 @@ func insertCharmMetadata(ctx context.Context, c *gc.C, tx *sql.Tx, uuid string) 
 		RunAs:          charm.RunAsRoot,
 		MinJujuVersion: version.MustParse("4.0.0"),
 		Assumes:        []byte("null"),
-	}
+	}, nil
 }
 
-func insertCharmManifest(ctx context.Context, c *gc.C, tx *sql.Tx, uuid string) charm.Manifest {
-	insertCharmState(ctx, c, tx, uuid)
+func insertCharmManifest(ctx context.Context, c *gc.C, tx *sql.Tx, uuid string) (charm.Manifest, error) {
+	if err := insertCharmState(ctx, c, tx, uuid); err != nil {
+		return charm.Manifest{}, errors.Trace(err)
+	}
 
-	return charm.Manifest{}
+	return charm.Manifest{}, nil
 }
 
 func assertCharmMetadata(c *gc.C, metadata charm.Metadata, expected func() charm.Metadata) {

--- a/domain/charm/state/state_test.go
+++ b/domain/charm/state/state_test.go
@@ -1219,7 +1219,7 @@ INSERT INTO charm_action (
 ) VALUES 
     (?, 'foo', 'description1', true, 'group1', '{}'),
     (?, 'bar', 'description2', false, 'group2', null);`,
-			uuid, uuid, uuid, uuid, uuid, uuid)
+			uuid, uuid)
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/domain/charm/state/state_test.go
+++ b/domain/charm/state/state_test.go
@@ -314,7 +314,7 @@ func (s *stateSuite) TestGetCharmMetadata(c *gc.C) {
 	uuid := id.String()
 
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
-		insertCharmState(ctx, c, tx, uuid)
+		insertCharmMetadata(ctx, c, tx, uuid)
 
 		return nil
 	})
@@ -344,7 +344,7 @@ func (s *stateSuite) TestGetCharmMetadataWithTagsAndCategories(c *gc.C) {
 
 	var expected charm.Metadata
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
-		expected = insertCharmState(ctx, c, tx, uuid)
+		expected = insertCharmMetadata(ctx, c, tx, uuid)
 
 		_, err := tx.ExecContext(ctx, `
 INSERT INTO charm_category (charm_uuid, "index", value)
@@ -382,7 +382,7 @@ func (s *stateSuite) TestGetCharmMetadataWithTerms(c *gc.C) {
 
 	var expected charm.Metadata
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
-		expected = insertCharmState(ctx, c, tx, uuid)
+		expected = insertCharmMetadata(ctx, c, tx, uuid)
 
 		_, err := tx.ExecContext(ctx, `
 INSERT INTO charm_term (charm_uuid, "index", value) 
@@ -413,7 +413,7 @@ func (s *stateSuite) TestGetCharmMetadataWithRelation(c *gc.C) {
 
 	var expected charm.Metadata
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
-		expected = insertCharmState(ctx, c, tx, uuid)
+		expected = insertCharmMetadata(ctx, c, tx, uuid)
 
 		_, err := tx.ExecContext(ctx, `
 INSERT INTO charm_relation (charm_uuid, kind_id, key, name, role_id, scope_id) 
@@ -475,7 +475,7 @@ func (s *stateSuite) TestGetCharmMetadataWithExtraBindings(c *gc.C) {
 
 	var expected charm.Metadata
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
-		expected = insertCharmState(ctx, c, tx, uuid)
+		expected = insertCharmMetadata(ctx, c, tx, uuid)
 
 		_, err := tx.ExecContext(ctx, `
 INSERT INTO charm_extra_binding (charm_uuid, key, name) 
@@ -515,7 +515,7 @@ func (s *stateSuite) TestGetCharmMetadataWithStorageWithNoProperties(c *gc.C) {
 
 	var expected charm.Metadata
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
-		expected = insertCharmState(ctx, c, tx, uuid)
+		expected = insertCharmMetadata(ctx, c, tx, uuid)
 
 		_, err := tx.ExecContext(ctx, `
 INSERT INTO charm_storage (
@@ -582,7 +582,7 @@ func (s *stateSuite) TestGetCharmMetadataWithStorageWithProperties(c *gc.C) {
 
 	var expected charm.Metadata
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
-		expected = insertCharmState(ctx, c, tx, uuid)
+		expected = insertCharmMetadata(ctx, c, tx, uuid)
 
 		_, err := tx.ExecContext(ctx, `
 INSERT INTO charm_storage (
@@ -661,7 +661,7 @@ func (s *stateSuite) TestGetCharmMetadataWithDevices(c *gc.C) {
 
 	var expected charm.Metadata
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
-		expected = insertCharmState(ctx, c, tx, uuid)
+		expected = insertCharmMetadata(ctx, c, tx, uuid)
 
 		_, err := tx.ExecContext(ctx, `
 INSERT INTO charm_device (
@@ -714,7 +714,7 @@ func (s *stateSuite) TestGetCharmMetadataWithPayloadClasses(c *gc.C) {
 
 	var expected charm.Metadata
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
-		expected = insertCharmState(ctx, c, tx, uuid)
+		expected = insertCharmMetadata(ctx, c, tx, uuid)
 
 		_, err := tx.ExecContext(ctx, `
 INSERT INTO charm_payload (
@@ -758,7 +758,7 @@ func (s *stateSuite) TestGetCharmMetadataWithResources(c *gc.C) {
 
 	var expected charm.Metadata
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
-		expected = insertCharmState(ctx, c, tx, uuid)
+		expected = insertCharmMetadata(ctx, c, tx, uuid)
 
 		_, err := tx.ExecContext(ctx, `
 INSERT INTO charm_resource (
@@ -808,7 +808,7 @@ func (s *stateSuite) TestGetCharmMetadataWithContainersWithNoMounts(c *gc.C) {
 
 	var expected charm.Metadata
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
-		expected = insertCharmState(ctx, c, tx, uuid)
+		expected = insertCharmMetadata(ctx, c, tx, uuid)
 
 		_, err := tx.ExecContext(ctx, `
 INSERT INTO charm_container (
@@ -853,7 +853,7 @@ func (s *stateSuite) TestGetCharmMetadataWithContainersWithMounts(c *gc.C) {
 
 	var expected charm.Metadata
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
-		expected = insertCharmState(ctx, c, tx, uuid)
+		expected = insertCharmMetadata(ctx, c, tx, uuid)
 
 		_, err := tx.ExecContext(ctx, `
 INSERT INTO charm_container (
@@ -919,7 +919,71 @@ INSERT INTO charm_container_mount (
 	})
 }
 
-func insertCharmState(ctx context.Context, c *gc.C, tx *sql.Tx, uuid string) charm.Metadata {
+func (s *stateSuite) TestGetCharmManifest(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	id := charmtesting.GenCharmID(c)
+	uuid := id.String()
+
+	var expected charm.Manifest
+	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		expected = insertCharmManifest(ctx, c, tx, uuid)
+
+		_, err := tx.ExecContext(ctx, `
+INSERT INTO charm_manifest_base (
+    charm_uuid,
+	"index",
+    os_id,
+    track,
+    risk,
+    branch,
+	architecture_id
+) VALUES 
+    (?, 0, 0, '', 'stable', '', 0),
+    (?, 0, 0, '', 'stable', '', 1),
+	(?, 1, 0, '', 'edge', 'foo', 0),
+	(?, 2, 0, '4.0', 'beta', 'baz', 2);`,
+			uuid, uuid, uuid, uuid)
+		c.Assert(err, jc.ErrorIsNil)
+		return nil
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	manifest, err := st.GetCharmManifest(context.Background(), id)
+	c.Assert(err, jc.ErrorIsNil)
+
+	assertCharmManifest(c, manifest, func() charm.Manifest {
+		expected.Bases = []charm.Base{
+			{
+				Name: "ubuntu",
+				Channel: charm.Channel{
+					Risk: charm.RiskStable,
+				},
+				Architectures: []string{"amd64", "arm64"},
+			},
+			{
+				Name: "ubuntu",
+				Channel: charm.Channel{
+					Risk:   charm.RiskEdge,
+					Branch: "foo",
+				},
+				Architectures: []string{"amd64"},
+			},
+			{
+				Name: "ubuntu",
+				Channel: charm.Channel{
+					Track:  "4.0",
+					Risk:   charm.RiskBeta,
+					Branch: "baz",
+				},
+				Architectures: []string{"ppc64el"},
+			},
+		}
+		return expected
+	})
+}
+
+func insertCharmState(ctx context.Context, c *gc.C, tx *sql.Tx, uuid string) {
 	_, err := tx.ExecContext(ctx, `
 INSERT INTO charm (uuid, name, description, summary, subordinate, min_juju_version, run_as_id, assumes) 
 VALUES (?, 'ubuntu', 'description', 'summary', true, '4.0.0', 1, 'null')`, uuid)
@@ -927,6 +991,10 @@ VALUES (?, 'ubuntu', 'description', 'summary', true, '4.0.0', 1, 'null')`, uuid)
 
 	_, err = tx.ExecContext(ctx, `INSERT INTO charm_state (charm_uuid, available) VALUES (?, false)`, uuid)
 	c.Assert(err, jc.ErrorIsNil)
+}
+
+func insertCharmMetadata(ctx context.Context, c *gc.C, tx *sql.Tx, uuid string) charm.Metadata {
+	insertCharmState(ctx, c, tx, uuid)
 
 	return charm.Metadata{
 		Name:           "ubuntu",
@@ -939,8 +1007,18 @@ VALUES (?, 'ubuntu', 'description', 'summary', true, '4.0.0', 1, 'null')`, uuid)
 	}
 }
 
+func insertCharmManifest(ctx context.Context, c *gc.C, tx *sql.Tx, uuid string) charm.Manifest {
+	insertCharmState(ctx, c, tx, uuid)
+
+	return charm.Manifest{}
+}
+
 func assertCharmMetadata(c *gc.C, metadata charm.Metadata, expected func() charm.Metadata) {
 	c.Check(metadata, gc.DeepEquals, expected())
+}
+
+func assertCharmManifest(c *gc.C, manifest charm.Manifest, expected func() charm.Manifest) {
+	c.Check(manifest, gc.DeepEquals, expected())
 }
 
 func ptr[T any](v T) *T {

--- a/domain/charm/state/types.go
+++ b/domain/charm/state/types.go
@@ -137,6 +137,9 @@ type charmResource struct {
 	Description string `db:"description"`
 }
 
+// charmContainer is used to get the containers of a charm.
+// This is a row based struct that is normalised form of an array of strings
+// for the storage and location field.
 type charmContainer struct {
 	CharmUUID string `db:"charm_uuid"`
 	Key       string `db:"key"`
@@ -145,4 +148,17 @@ type charmContainer struct {
 	Gid       int    `db:"gid"`
 	Storage   string `db:"storage"`
 	Location  string `db:"location"`
+}
+
+// charmManifest is used to get the manifest of a charm.
+// This is a row based struct that is normalised form of an array of strings
+// for the all the fields.
+type charmManifest struct {
+	CharmUUID    string `db:"charm_uuid"`
+	Index        int    `db:"idx"`
+	Track        string `db:"track"`
+	Risk         string `db:"risk"`
+	Branch       string `db:"branch"`
+	OS           string `db:"os"`
+	Architecture string `db:"architecture"`
 }

--- a/domain/charm/state/types.go
+++ b/domain/charm/state/types.go
@@ -162,3 +162,30 @@ type charmManifest struct {
 	OS           string `db:"os"`
 	Architecture string `db:"architecture"`
 }
+
+// charmLXDProfile is used to get the LXD profile of a charm.
+type charmLXDProfile struct {
+	UUID       string `db:"uuid"`
+	LXDProfile []byte `db:"lxd_profile"`
+}
+
+// charmConfig is used to get the config of a charm.
+// This is a row based struct that is normalised form of a map of config.
+type charmConfig struct {
+	CharmUUID    string `db:"charm_uuid"`
+	Key          string `db:"key"`
+	Type         string `db:"type"`
+	DefaultValue string `db:"default_value"`
+	Description  string `db:"description"`
+}
+
+// charmAction is used to get the actions of a charm.
+// This is a row based struct that is normalised form of a map of actions.
+type charmAction struct {
+	CharmUUID      string `db:"charm_uuid"`
+	Key            string `db:"key"`
+	Description    string `db:"description"`
+	Parallel       bool   `db:"parallel"`
+	ExecutionGroup string `db:"execution_group"`
+	Params         []byte `db:"params"`
+}

--- a/domain/schema/model/sql/0015-charm.sql
+++ b/domain/schema/model/sql/0015-charm.sql
@@ -476,7 +476,7 @@ LEFT JOIN charm_source AS cs ON co.source_id = cs.id;
 
 CREATE TABLE charm_action (
     charm_uuid TEXT NOT NULL,
-    name TEXT NOT NULL,
+    "key" TEXT NOT NULL,
     description TEXT,
     parallel BOOLEAN,
     execution_group TEXT,
@@ -484,7 +484,7 @@ CREATE TABLE charm_action (
     CONSTRAINT fk_charm_actions_charm
     FOREIGN KEY (charm_uuid)
     REFERENCES charm (uuid),
-    PRIMARY KEY (charm_uuid, name)
+    PRIMARY KEY (charm_uuid, "key")
 );
 
 CREATE TABLE charm_manifest_base (
@@ -510,7 +510,7 @@ CREATE TABLE charm_manifest_base (
 CREATE VIEW v_charm_manifest AS
 SELECT
     cmb.charm_uuid,
-    cmb."index" AS "idx",
+    cmb."index" AS idx,
     cmb.track,
     cmb.risk,
     cmb.branch,
@@ -537,7 +537,7 @@ INSERT INTO charm_config_type VALUES
 
 CREATE TABLE charm_config (
     charm_uuid TEXT NOT NULL,
-    name TEXT NOT NULL,
+    "key" TEXT NOT NULL,
     type_id TEXT,
     default_value TEXT,
     description TEXT,
@@ -547,5 +547,15 @@ CREATE TABLE charm_config (
     CONSTRAINT fk_charm_config_charm_config_type
     FOREIGN KEY (type_id)
     REFERENCES charm_config_type (id),
-    PRIMARY KEY (charm_uuid, name)
+    PRIMARY KEY (charm_uuid, "key")
 );
+
+CREATE VIEW v_charm_config AS
+SELECT
+    cc.charm_uuid,
+    cc."key",
+    cct.name AS type,
+    cc.default_value,
+    cc.description
+FROM charm_config AS cc
+LEFT JOIN charm_config_type AS cct ON cc.type_id = cct.id;

--- a/domain/schema/model/sql/0015-charm.sql
+++ b/domain/schema/model/sql/0015-charm.sql
@@ -489,6 +489,7 @@ CREATE TABLE charm_action (
 
 CREATE TABLE charm_manifest_base (
     charm_uuid TEXT NOT NULL,
+    "index" INT NOT NULL,
     os_id TEXT NOT NULL,
     track TEXT,
     risk TEXT NOT NULL,
@@ -503,8 +504,21 @@ CREATE TABLE charm_manifest_base (
     CONSTRAINT fk_charm_manifest_base_architecture
     FOREIGN KEY (architecture_id)
     REFERENCES architecture (id),
-    PRIMARY KEY (charm_uuid, os_id, track, risk, branch, architecture_id)
+    PRIMARY KEY (charm_uuid, "index", os_id, track, risk, branch, architecture_id)
 );
+
+CREATE VIEW v_charm_manifest AS
+SELECT
+    cmb.charm_uuid,
+    cmb."index" AS "idx",
+    cmb.track,
+    cmb.risk,
+    cmb.branch,
+    os.name AS os,
+    architecture.name AS architecture
+FROM charm_manifest_base AS cmb
+LEFT JOIN os ON cmb.os_id = os.id
+LEFT JOIN architecture ON cmb.architecture_id = architecture.id;
 
 CREATE TABLE charm_config_type (
     id INT PRIMARY KEY,

--- a/domain/schema/schema_test.go
+++ b/domain/schema/schema_test.go
@@ -424,7 +424,9 @@ func (s *schemaSuite) TestModelViews(c *gc.C) {
 	// Ensure that each view is present.
 	expected := set.NewStrings(
 		"v_charm",
+		"v_charm_config",
 		"v_charm_container",
+		"v_charm_manifest",
 		"v_charm_relation",
 		"v_charm_resource",
 		"v_charm_storage",


### PR DESCRIPTION
Adds state get implementations, the set charm is going to be in subsequent PR, as I believe that it will take a lot of time to correctly implement. Manifest, actions, config, and LXD profiles are row-based structs, which is the normal form, unlike charm metadata. The manifest bases are defined as an array and an index was added to the state schema to ensure correct ordering was maintained (although we do run into another sqlair bug[1]). Architectures will not be guaranteed to be in order, because we're storing the base array and the architectures as one flat row. If we did want to do that, we should create another table that kept track of that one as well. For now, the order of architectures shouldn't matter as we don't pick one over the other.

 1. https://github.com/canonical/sqlair/issues/155

<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://docs.google.com/document/d/1SYUo9G7qZ_jdoVXpUVamS5VCgHmtZ0QA-wZxKoMS-C0 
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

The state tests should pass. Once the `SetCharm` is implemented in subsequent PRs then we should start to see full end to end tests, which would better validate all the state implementation.


## Links


**Jira card:** [JUJU-6015](https://warthogs.atlassian.net/browse/JUJU-6015)



[JUJU-6015]: https://warthogs.atlassian.net/browse/JUJU-6015?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ