### PR TITLE
chore(watcher): add PrimeChangeStream for tests with empty changelog table

### DIFF
--- a/domain/machine/watcher_test.go
+++ b/domain/machine/watcher_test.go
@@ -69,5 +69,9 @@ func (s *watcherSuite) machineServiceAndWatcher(c *gc.C) (*service.WatchableServ
 	watcher, err := machineService.WatchMachines(context.Background())
 	c.Assert(err, gc.IsNil)
 	watcherC := watchertest.NewStringsWatcherC(c, watcher)
+	// Initial event.
+	watcherC.AssertOneChange()
+	s.AssertChangeStreamIdle(c)
+
 	return machineService, watcherC
 }

--- a/domain/network/watcher_test.go
+++ b/domain/network/watcher_test.go
@@ -41,6 +41,9 @@ func (s *watcherSuite) TestWatchWithAdd(c *gc.C) {
 	watcher, err := svc.WatchSubnets(context.Background(), set.NewStrings())
 	c.Assert(err, jc.ErrorIsNil)
 	watcherC := watchertest.NewStringsWatcherC(c, watcher)
+	// Initial event.
+	watcherC.AssertOneChange()
+	s.AssertChangeStreamIdle(c)
 
 	// Add a new subnet.
 	subnet := network.SubnetInfo{
@@ -69,6 +72,9 @@ func (s *watcherSuite) TestWatchWithDelete(c *gc.C) {
 	watcher, err := svc.WatchSubnets(context.Background(), set.NewStrings())
 	c.Assert(err, jc.ErrorIsNil)
 	watcherC := watchertest.NewStringsWatcherC(c, watcher)
+	// Initial event.
+	watcherC.AssertOneChange()
+	s.AssertChangeStreamIdle(c)
 
 	// Add a new subnet.
 	subnet := network.SubnetInfo{


### PR DESCRIPTION
This patch (thanks to @SimonRichardson  suggestions) adds the `PrimeChangeStream` method to modelsuite changestream testing used in every test to fill the changelog with some init data and be able to verify that the initial event is fired when we create a watcher on the tests.

_Note: Tests in the `network` and `machine` domain have been updated to include the checks on the initial event._

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```
TEST_PACKAGES="./domain/machine/... -count=1 -race -check.vv" make run-go-tests                
TEST_PACKAGES="./domain/network/... -count=1 -race -check.vv" make run-go-tests                
```


## Links

**Jira card:** JUJU-

