### PR TITLE
chore(ci): update balchua/microk8s-actions to v0.4.3

### DIFF
--- a/.github/workflows/microk8s-tests.yml
+++ b/.github/workflows/microk8s-tests.yml
@@ -44,7 +44,7 @@ jobs:
         sudo systemctl restart docker
         docker system info
 
-    - uses: balchua/microk8s-actions@e99a1ffcd3bb2682d941104cf6c1a215c657903f
+    - uses: balchua/microk8s-actions@13f73436011eb4925c22526f64fb3ecdd81289a9
       with:
         channel: '${{ matrix.microk8s }}'
         # enable now to give microk8s more time to settle down.

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -52,7 +52,7 @@ jobs:
 
     - name: Setup MicroK8s
       if: matrix.cloud == 'microk8s'
-      uses: balchua/microk8s-actions@e99a1ffcd3bb2682d941104cf6c1a215c657903f
+      uses: balchua/microk8s-actions@13f73436011eb4925c22526f64fb3ecdd81289a9
       with:
         channel: "1.28-strict/stable"
         addons: '["dns", "hostpath-storage", "rbac"]'

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -116,7 +116,7 @@ jobs:
 
       - name: Setup k8s
         if: matrix.cloud == 'microk8s'
-        uses: balchua/microk8s-actions@e99a1ffcd3bb2682d941104cf6c1a215c657903f
+        uses: balchua/microk8s-actions@13f73436011eb4925c22526f64fb3ecdd81289a9
         with:
           channel: "1.28-strict/stable"
           addons: '["dns", "hostpath-storage"]'


### PR DESCRIPTION
<!-- Why this change is needed and what it does. -->

This should fix some deprecation warnings in GitHub Actions.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- ~[ ] Code style: imports ordered, good names, simple structure, etc~
- ~[ ] Comments saying why design decisions were made~
- ~[ ] Go unit tests, with comments saying what you're testing~
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

<!-- Describe steps to verify that the change works. -->

GitHub Actions pass below.