### PR TITLE
chore(network): remove fan option from container networking config

### DIFF
--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -775,10 +775,6 @@ func Validate(_ctx context.Context, cfg, old *Config) error {
 
 	if v, ok := cfg.defined[ContainerNetworkingMethod].(string); ok {
 		switch v {
-		case "fan":
-			if cfg, err := cfg.FanConfig(); err != nil || cfg == nil {
-				return errors.New("container-networking-method cannot be set to 'fan' without fan-config set")
-			}
 		case "provider": // TODO(wpk) FIXME we should check that the provider supports this setting!
 		case "local":
 		case "": // We'll try to autoconfigure it

--- a/internal/network/containerizer/bridgepolicy_test.go
+++ b/internal/network/containerizer/bridgepolicy_test.go
@@ -1066,24 +1066,6 @@ func (s *bridgePolicySuite) TestFindMissingBridgesForContainerVLANOnBond(c *gc.C
 	c.Check(reconfigureDelay, gc.Equals, 13)
 }
 
-func (s *bridgePolicySuite) TestFindMissingBridgesForContainerNetworkingMethodFAN(c *gc.C) {
-	ctrl := s.setupMocks(c)
-	defer ctrl.Finish()
-
-	s.guest.EXPECT().Constraints().Return(constraints.MustParse("spaces=somespace"), nil)
-
-	s.setupTwoSpaces()
-	s.expectNICWithIP(c, ctrl, "eth0", corenetwork.AlphaSpaceId)
-
-	s.expectMachineAddressesDevices()
-
-	s.containerNetworkingMethod = "fan"
-	bridgePolicy := s.policy()
-
-	_, _, err := bridgePolicy.FindMissingBridgesForContainer(s.machine, s.guest, s.allSubnets)
-	c.Assert(err, gc.ErrorMatches, `host machine "host-id" has no available FAN devices in space\(s\) "somespace"`)
-}
-
 var bridgeNames = map[string]string{
 	"eno0":            "br-eno0",
 	"enovlan.123":     "br-enovlan-123",


### PR DESCRIPTION
This small patch continues the cleanup after dropping the support for fan networking on juju 4.0. This cleanup removes checks for fan networking for containers in the bridge policy.

_Note: This cleanup was brought to attention on https://github.com/juju/juju/pull/17574 where a new container networking init method is being proposed._

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps
Bootstrap on aws and deploy:
```
juju bootstrap aws c
juju add-model m
juju deploy ubuntu --to lxd
```
and make sure there are no errors on the logs.


## Links


**Jira card:** JUJU-

