### PR TITLE
feat: ssh proxy via the controller http api

### DIFF
--- a/api/base/caller.go
+++ b/api/base/caller.go
@@ -5,6 +5,7 @@ package base
 
 import (
 	"context"
+	"crypto/tls"
 	"io"
 	"net/http"
 	"net/url"
@@ -50,6 +51,10 @@ type APICaller interface {
 
 	// BakeryClient returns the bakery client for this connection.
 	BakeryClient() MacaroonDischarger
+
+	// NewHTTPRequest returns a new base authenticated http.Request and
+	// the tls.Dialer to connect with.
+	NewHTTPRequest() (*http.Request, *tls.Dialer, error)
 
 	// Context returns the standard context for this connection.
 	Context() context.Context

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -124,7 +124,7 @@ var facadeVersions = facades.FacadeVersions{
 	"UserSecretsManager":           {1},
 	"Singular":                     {2},
 	"Spaces":                       {6},
-	"SSHClient":                    {4},
+	"SSHClient":                    {4, 5},
 	"StatusHistory":                {2},
 	"Storage":                      {6},
 	"StorageProvisioner":           {4},

--- a/apiserver/facades/client/sshclient/register.go
+++ b/apiserver/facades/client/sshclient/register.go
@@ -21,6 +21,11 @@ func Register(registry facade.FacadeRegistry) {
 	registry.MustRegister("SSHClient", 4, func(ctx facade.Context) (facade.Facade, error) {
 		return newFacade(ctx)
 	}, reflect.TypeOf((*Facade)(nil)))
+	// SSHClient facade version 5 is symbolic. It represents a controller that supports SSH proxying
+	// via HTTP Upgrade.
+	registry.MustRegister("SSHClient", 5, func(ctx facade.Context) (facade.Facade, error) {
+		return newFacade(ctx)
+	}, reflect.TypeOf((*Facade)(nil)))
 }
 
 func newFacade(ctx facade.Context) (*Facade, error) {

--- a/apiserver/facades/client/sshclient/shim.go
+++ b/apiserver/facades/client/sshclient/shim.go
@@ -18,7 +18,7 @@ import (
 type Backend interface {
 	ModelConfig() (*config.Config, error)
 	GetMachineForEntity(tag string) (SSHMachine, error)
-	GetSSHHostKeys(names.MachineTag) (state.SSHHostKeys, error)
+	GetSSHHostKeys(names.Tag) (state.SSHHostKeys, error)
 	ModelTag() names.ModelTag
 	ControllerTag() names.ControllerTag
 	Model() (Model, error)

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -39180,7 +39180,7 @@
     {
         "Name": "SSHClient",
         "Description": "Facade implements the API required by the sshclient worker.",
-        "Version": 4,
+        "Version": 5,
         "AvailableTo": [
             "controller-machine-agent",
             "machine-agent",

--- a/apiserver/sshproxy/caas.go
+++ b/apiserver/sshproxy/caas.go
@@ -1,0 +1,76 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package sshproxy
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"net/http"
+
+	"github.com/juju/names/v5"
+	"golang.org/x/crypto/ssh"
+
+	apiservererrors "github.com/juju/juju/apiserver/errors"
+	"github.com/juju/juju/caas"
+	"github.com/juju/juju/state"
+	"github.com/juju/juju/state/stateenvirons"
+)
+
+func (h *sshHandler) handleCAAS(st *state.PooledState, m *state.Model, w http.ResponseWriter, r *http.Request,
+	entity names.Tag, container string) error {
+	unitTag, ok := entity.(names.UnitTag)
+	if !ok {
+		return fmt.Errorf("%w: entity %v is not a valid unit",
+			apiservererrors.ErrBadRequest, entity)
+	}
+
+	_, err := st.Unit(unitTag.Id())
+	if err != nil {
+		return fmt.Errorf("cannot get unit: %w", err)
+	}
+
+	hostKey, err := st.GetSSHProxyHostKeys(unitTag)
+	if err != nil {
+		return fmt.Errorf("cannot get ssh proxy host keys: %w", err)
+	}
+
+	cfg, err := m.Config()
+	if err != nil {
+		return fmt.Errorf("cannot get model config: %w", err)
+	}
+
+	authorizedKeys := []ssh.PublicKey{}
+	authorizedKeyReader := bufio.NewScanner(bytes.NewReader([]byte(cfg.AuthorizedKeys())))
+	for authorizedKeyReader.Scan() {
+		b := authorizedKeyReader.Bytes()
+		publicKey, _, _, _, err := ssh.ParseAuthorizedKey(b)
+		if err != nil {
+			return fmt.Errorf("cannot parse authorized key: %w\n%q", err, string(b))
+		}
+		authorizedKeys = append(authorizedKeys, publicKey)
+	}
+	err = authorizedKeyReader.Err()
+	if err != nil {
+		return fmt.Errorf("cannot parse authorized keys from model config: %w", err)
+	}
+
+	env, err := stateenvirons.GetNewCAASBrokerFunc(caas.New)(m)
+	if err != nil {
+		return fmt.Errorf("cannot get caas broker: %w", err)
+	}
+
+	conn, err := h.hijack(w)
+	if err != nil {
+		return fmt.Errorf("%w: cannot hijack connection: %v", errConnHijacked, err)
+	}
+	defer conn.Close()
+
+	err = env.HandleSSHConn(conn, unitTag, container, hostKey, authorizedKeys)
+	if err != nil {
+		return fmt.Errorf("%w: cannot handle proxied ssh connection: %v", errConnHijacked, err)
+	}
+
+	return errConnHijacked
+}

--- a/apiserver/sshproxy/handler.go
+++ b/apiserver/sshproxy/handler.go
@@ -1,0 +1,178 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package sshproxy
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	"github.com/juju/names/v5"
+
+	apiservererrors "github.com/juju/juju/apiserver/errors"
+	"github.com/juju/juju/rpc/params"
+	"github.com/juju/juju/state"
+)
+
+const (
+	errConnHijacked errors.ConstError = "connection hijacked"
+)
+
+func Handler(logger loggo.Logger, authFunc func(*http.Request) (*state.PooledState, error)) http.Handler {
+	handler := &sshHandler{
+		logger:   logger,
+		authFunc: authFunc,
+	}
+	router := mux.NewRouter()
+	router.Handle("/model/{model}/machine/{machine:[a-z0-9/]+}/ssh", handler).GetPathRegexp()
+	router.Handle("/model/{model}/application/{application}/unit/{unit}/ssh", handler)
+	return router
+}
+
+type sshHandler struct {
+	logger   loggo.Logger
+	authFunc func(*http.Request) (*state.PooledState, error)
+}
+
+func (h *sshHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	send := func(err error) {
+		if err := sendError(w, err); err != nil {
+			h.logger.Errorf("%v", err)
+		}
+	}
+	if r.Method != "CONNECT" ||
+		strings.ToLower(r.Header.Get("Connection")) != "upgrade" ||
+		strings.ToLower(r.Header.Get("Upgrade")) != "ssh" {
+		send(apiservererrors.ErrBadRequest)
+		return
+	}
+
+	vars := mux.Vars(r)
+	var tag names.Tag
+	if machine, ok := vars["machine"]; ok {
+		if !names.IsValidMachine(machine) {
+			send(apiservererrors.ErrBadRequest)
+			return
+		}
+		tag = names.NewMachineTag(machine)
+	} else if app, ok := vars["application"]; ok {
+		unit, ok := vars["unit"]
+		if !ok {
+			send(apiservererrors.ErrBadRequest)
+			return
+		}
+		unitName := fmt.Sprintf("%s/%s", app, unit)
+		if !names.IsValidUnit(unitName) {
+			send(apiservererrors.ErrBadRequest)
+			return
+		}
+		tag = names.NewUnitTag(unitName)
+	} else {
+		send(apiservererrors.ErrBadRequest)
+		return
+	}
+
+	st, err := h.authFunc(r)
+	if err != nil {
+		send(fmt.Errorf("cannot auth: %w", err))
+		return
+	}
+	defer st.Release()
+
+	m, err := st.Model()
+	if err != nil {
+		send(fmt.Errorf("cannot get model: %w", err))
+		return
+	}
+
+	switch m.Type() {
+	case state.ModelTypeIAAS:
+		err := h.handleIAAS(st, w, r, tag)
+		if err != nil {
+			send(fmt.Errorf("cannot handle for model: %w", err))
+		}
+		return
+	case state.ModelTypeCAAS:
+		err := h.handleCAAS(st, m, w, r, tag, r.URL.Query().Get("container"))
+		if err != nil {
+			send(fmt.Errorf("cannot handle for k8s model: %w", err))
+		}
+		return
+	default:
+		send(apiservererrors.ErrBadRequest)
+		return
+	}
+}
+
+func (h *sshHandler) hijack(w http.ResponseWriter) (net.Conn, error) {
+	conn, buf, err := http.NewResponseController(w).Hijack()
+	if err != nil {
+		return nil, err
+	}
+
+	buf.Writer.Flush()
+	if buf.Reader.Buffered() > 0 {
+		// handle if there is already stuff buffered here...
+	}
+
+	res := http.Response{
+		Proto:      "HTTP/1.1",
+		StatusCode: http.StatusSwitchingProtocols,
+		Status:     "101 Switching Protocols",
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+		Header: http.Header{
+			"Upgrade":    []string{"ssh"},
+			"Connection": []string{"Upgrade"},
+		},
+		ContentLength: 0,
+	}
+	conn.SetWriteDeadline(time.Now().Add(30 * time.Second))
+	err = res.Write(conn)
+	if err != nil {
+		conn.Close()
+		return nil, err
+	}
+
+	conn.SetWriteDeadline(time.Time{})
+	conn.SetReadDeadline(time.Time{})
+	return conn, nil
+}
+
+// sendStatusAndJSON sends an HTTP status code and
+// a JSON-encoded response to a client.
+func sendStatusAndJSON(w http.ResponseWriter, statusCode int, response interface{}) error {
+	body, err := json.Marshal(response)
+	if err != nil {
+		return errors.Errorf("cannot marshal JSON result %#v: %v", response, err)
+	}
+	if statusCode == http.StatusUnauthorized {
+		w.Header().Set("WWW-Authenticate", `Basic realm="juju"`)
+	}
+	w.Header().Set("Content-Type", params.ContentTypeJSON)
+	w.Header().Set("Content-Length", fmt.Sprint(len(body)))
+	w.WriteHeader(statusCode)
+	if _, err := w.Write(body); err != nil {
+		return errors.Annotate(err, "cannot write response")
+	}
+	return nil
+}
+
+// sendError sends a JSON-encoded error response
+// for errors encountered during processing.
+func sendError(w http.ResponseWriter, errToSend error) error {
+	if errors.Is(errToSend, errConnHijacked) {
+		return nil
+	}
+	paramsErr, statusCode := apiservererrors.ServerErrorAndStatus(errToSend)
+	return errors.Trace(sendStatusAndJSON(w, statusCode, &params.ErrorResult{
+		Error: paramsErr,
+	}))
+}

--- a/apiserver/sshproxy/iaas.go
+++ b/apiserver/sshproxy/iaas.go
@@ -1,0 +1,83 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package sshproxy
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+
+	"github.com/juju/names/v5"
+	"golang.org/x/sync/errgroup"
+
+	apiservererrors "github.com/juju/juju/apiserver/errors"
+	"github.com/juju/juju/state"
+)
+
+func (h *sshHandler) handleIAAS(st *state.PooledState, w http.ResponseWriter, r *http.Request, entity names.Tag) error {
+	if unit, ok := entity.(names.UnitTag); ok {
+		unit, err := st.Unit(unit.Id())
+		if err != nil {
+			return err
+		}
+		machineId, err := unit.AssignedMachineId()
+		if err != nil {
+			return err
+		}
+		entity = names.NewMachineTag(machineId)
+	}
+
+	machineTag, ok := entity.(names.MachineTag)
+	if !ok {
+		return fmt.Errorf("unexpected tag %v", entity)
+	}
+
+	machine, err := st.Machine(machineTag.Id())
+	if err != nil {
+		return err
+	}
+
+	for _, addr := range machine.Addresses().Values() {
+		conn, err := net.Dial("tcp", fmt.Sprintf("%s:ssh", addr))
+		if err != nil {
+			h.logger.Errorf("cannot proxy ssh to %s: %v", addr, err)
+			continue
+		}
+		err = h.proxyMachine(w, r, conn)
+		if err != nil {
+			h.logger.Errorf("cannot proxy machine: %v", err)
+		}
+		return errConnHijacked
+	}
+
+	return apiservererrors.ErrTryAgain
+}
+
+func (h *sshHandler) proxyMachine(w http.ResponseWriter, r *http.Request, upstream net.Conn) error {
+	defer upstream.Close()
+
+	conn, err := h.hijack(w)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	eg, _ := errgroup.WithContext(context.Background())
+	eg.Go(func() error {
+		_, err := io.Copy(conn, upstream)
+		return err
+	})
+	eg.Go(func() error {
+		_, err := io.Copy(upstream, conn)
+		return err
+	})
+	err = eg.Wait()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/caas/broker.go
+++ b/caas/broker.go
@@ -6,10 +6,12 @@ package caas
 import (
 	"context"
 	"fmt"
+	"net"
 
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 	"github.com/juju/version/v2"
+	"golang.org/x/crypto/ssh"
 
 	"github.com/juju/juju/caas/specs"
 	"github.com/juju/juju/core/config"
@@ -229,6 +231,9 @@ type Broker interface {
 
 	// ProxyManager provides methods for managing application proxy connections.
 	ProxyManager
+
+	// SSHManager provides termination for an SSH connection.
+	SSHManager
 }
 
 // ApplicationBroker provides an API for accessing the broker interface for
@@ -351,6 +356,11 @@ type CredentialChecker interface {
 // ProxyManager provides the API to get proxier information for applications
 type ProxyManager interface {
 	ProxyToApplication(appName, remotePort string) (proxy.Proxier, error)
+}
+
+// SSHManager provides termination for an SSH connection.
+type SSHManager interface {
+	HandleSSHConn(conn net.Conn, unit names.UnitTag, container string, hostKey ssh.Signer, authorisedKeys []ssh.PublicKey) error
 }
 
 // ServiceManager provides the API to manipulate services.

--- a/caas/kubernetes/provider/sshexec/server.go
+++ b/caas/kubernetes/provider/sshexec/server.go
@@ -1,0 +1,461 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package sshexec
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"path"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/gliderlabs/ssh"
+	"github.com/pkg/sftp"
+	gossh "golang.org/x/crypto/ssh"
+	"gopkg.in/yaml.v3"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/remotecommand"
+	"k8s.io/client-go/util/exec"
+)
+
+func HandleSSHConn(k8s kubernetes.Interface, config *rest.Config, namespace string, pod string, container string,
+	conn net.Conn, hostKey gossh.Signer, authorizedKeys []gossh.PublicKey) {
+	sshd := ssh.Server{}
+	sshd.HostSigners = []ssh.Signer{hostKey}
+	sshd.PublicKeyHandler = func(ctx ssh.Context, untrustedKey ssh.PublicKey) bool {
+		for _, authorizedKey := range authorizedKeys {
+			if ssh.KeysEqual(authorizedKey, untrustedKey) {
+				return true
+			}
+		}
+		return false
+	}
+	sshd.ChannelHandlers = map[string]ssh.ChannelHandler{
+		"session": ssh.DefaultSessionHandler,
+	}
+	sshd.Handle(func(sess ssh.Session) {
+		pty, window, isTty := sess.Pty()
+
+		command := sess.Command()
+		if len(command) == 0 {
+			command = []string{"sh"}
+		}
+
+		req := k8s.CoreV1().RESTClient().Post().
+			Resource("pods").
+			Name(pod).
+			Namespace(namespace).
+			SubResource("exec").
+			Param("container", container).
+			VersionedParams(&corev1.PodExecOptions{
+				Container: container,
+				Command:   command,
+				Stdin:     true,
+				Stdout:    true,
+				Stderr:    !isTty,
+				TTY:       isTty,
+			}, scheme.ParameterCodec)
+		executor, err := remotecommand.NewSPDYExecutor(config, "POST", req.URL())
+		if err != nil {
+			err = fmt.Errorf("cannot create spdy executor: %w", err)
+			fmt.Fprintln(sess, err)
+			sess.Exit(1)
+			return
+		}
+
+		var tsq *termSize
+		if isTty {
+			tsq = &termSize{
+				initial: &pty.Window,
+				changes: window,
+			}
+		}
+
+		streamOpts := remotecommand.StreamOptions{
+			Stdin:             sess,
+			Stdout:            sess,
+			Tty:               isTty,
+			TerminalSizeQueue: tsq,
+		}
+		if !isTty {
+			streamOpts.Stderr = sess.Stderr()
+		}
+
+		err = executor.StreamWithContext(sess.Context(), streamOpts)
+		var statusError *exec.CodeExitError
+		if errors.As(err, &statusError) {
+			fmt.Fprintln(sess, statusError)
+			sess.Exit(statusError.Code)
+			return
+		} else if err != nil {
+			err = fmt.Errorf("cannot open stream: %w", err)
+			fmt.Fprintln(sess, err)
+		}
+		sess.Exit(1)
+	})
+	sshd.SubsystemHandlers = map[string]ssh.SubsystemHandler{
+		"sftp": func(sess ssh.Session) {
+			h := &sftpHandler{
+				k8s:       k8s,
+				config:    config,
+				namespace: namespace,
+				pod:       pod,
+				container: container,
+			}
+			sftpServer := sftp.NewRequestServer(sess, sftp.Handlers{
+				FileGet:  h,
+				FilePut:  h,
+				FileCmd:  h,
+				FileList: h,
+			})
+			err := sftpServer.Serve()
+			if err != nil && !errors.Is(err, io.EOF) {
+				err = fmt.Errorf("cannot serve sftp sessions: %w", err)
+				fmt.Fprintln(sess, err)
+				sess.Exit(1)
+				return
+			}
+			sess.Exit(0)
+		},
+	}
+	sshd.HandleConn(conn)
+}
+
+type termSize struct {
+	initial *ssh.Window
+	changes <-chan ssh.Window
+}
+
+func (t *termSize) Next() *remotecommand.TerminalSize {
+	if t.initial != nil {
+		r := &remotecommand.TerminalSize{
+			Width:  uint16(t.initial.Width),
+			Height: uint16(t.initial.Height),
+		}
+		t.initial = nil
+		return r
+	}
+
+	w, ok := <-t.changes
+	if !ok {
+		return nil
+	}
+
+	return &remotecommand.TerminalSize{
+		Width:  uint16(w.Width),
+		Height: uint16(w.Height),
+	}
+}
+
+type sftpHandler struct {
+	k8s       kubernetes.Interface
+	config    *rest.Config
+	namespace string
+	pod       string
+	container string
+}
+
+func (h *sftpHandler) Fileread(req *sftp.Request) (io.ReaderAt, error) {
+	tempFile, err := os.CreateTemp("", "sftp-temp-*")
+	if err != nil {
+		return nil, fmt.Errorf("cannot create temp file: %w", err)
+	}
+	go func() {
+		<-req.Context().Done()
+		tempFile.Close()
+		os.Remove(tempFile.Name())
+	}()
+	err = h.exec(req.Context(), nil, tempFile, []string{"cat", req.Filepath})
+	if err != nil {
+		return nil, fmt.Errorf("cannot exec cat: %w", err)
+	}
+	_, err = tempFile.Seek(0, 0)
+	if err != nil {
+		return nil, fmt.Errorf("cannot seek temp file back: %w", err)
+	}
+	return tempFile, nil
+}
+
+func (h *sftpHandler) Filewrite(req *sftp.Request) (io.WriterAt, error) {
+	flags := req.Pflags()
+	if flags.Trunc && flags.Creat {
+		err := h.exec(req.Context(), nil, nil, []string{"truncate", req.Filepath})
+		if err != nil {
+			return nil, fmt.Errorf("cannot exec truncate: %w", err)
+		}
+	} else if flags.Trunc && !flags.Creat {
+		err := h.exec(req.Context(), nil, nil, []string{"truncate", "-c", req.Filepath})
+		if err != nil {
+			return nil, fmt.Errorf("cannot excec truncate without create: %w", err)
+		}
+	} else if !flags.Trunc && flags.Creat {
+		err := h.exec(req.Context(), nil, nil, []string{"touch", req.Filepath})
+		if err != nil {
+			return nil, fmt.Errorf("cannot exec touch: %w", err)
+		}
+	}
+	if flags.Append {
+		f := writerAtFunc(func(p []byte, off int64) (int, error) {
+			err := h.exec(req.Context(), bytes.NewReader(p), nil, []string{"dd", "bs=1", "conv=nocreat", "oflag=append", "of=" + req.Filepath})
+			if err != nil {
+				return 0, fmt.Errorf("cannot exec dd with append: %w", err)
+			}
+			return len(p), nil
+		})
+		return f, nil
+	}
+	f := writerAtFunc(func(p []byte, off int64) (int, error) {
+		err := h.exec(req.Context(), bytes.NewReader(p), nil, []string{"dd", "bs=1", "seek=" + strconv.FormatInt(off, 10), "conv=nocreat", "of=" + req.Filepath})
+		if err != nil {
+			return 0, fmt.Errorf("cannot exec dd: %w", err)
+		}
+		return len(p), nil
+	})
+	return f, nil
+}
+
+func (h *sftpHandler) Filecmd(req *sftp.Request) error {
+	switch req.Method {
+	case "Setstat":
+		if req.AttrFlags().Size {
+			err := h.exec(req.Context(), nil, nil, []string{"truncate", "-c", "-s", strconv.FormatUint(req.Attributes().Size, 10), req.Filepath})
+			if err != nil {
+				return fmt.Errorf("cannot exec truncate for Setstat: %w", err)
+			}
+		}
+		if req.AttrFlags().Acmodtime {
+			err := h.exec(req.Context(), nil, nil, []string{"touch", "-c", "-m", "-t", time.Unix(int64(req.Attributes().Mtime), 0).Format("200601021504.05"), req.Filepath})
+			if err != nil {
+				return fmt.Errorf("cannot exec touch for Setstat: %w", err)
+			}
+		}
+		if req.AttrFlags().Permissions {
+			err := h.exec(req.Context(), nil, nil, []string{"chmod", strconv.FormatUint(uint64(req.Attributes().Mode), 8), req.Filepath})
+			if err != nil {
+				return fmt.Errorf("cannot exec chmod for Setstat: %w", err)
+			}
+		}
+		if req.AttrFlags().UidGid {
+			err := h.exec(req.Context(), nil, nil, []string{"chown", fmt.Sprintf("%d:%d", req.Attributes().UID, req.Attributes().GID), req.Filepath})
+			if err != nil {
+				return fmt.Errorf("cannot exec chown for Setstat: %w", err)
+			}
+		}
+		return nil
+	case "Mkdir":
+		err := h.exec(req.Context(), nil, nil, []string{"mkdir", req.Filepath})
+		if err != nil {
+			return fmt.Errorf("cannot exec mkdir: %w", err)
+		}
+		return nil
+	}
+	return fmt.Errorf("unsupported Filecmd: %s", req.Method)
+}
+
+func (h *sftpHandler) Filelist(req *sftp.Request) (sftp.ListerAt, error) {
+	entInfo, err := h.stat(req.Context(), req.Filepath)
+	if err != nil {
+		return nil, fmt.Errorf("cannot stat: %w", err)
+	}
+	if !entInfo.IsDir() {
+		f := ListAtFunc(func(fi []os.FileInfo, i int64) (int, error) {
+			fi[0] = entInfo
+			return 1, io.EOF
+		})
+		return f, nil
+	}
+
+	buffer := &bytes.Buffer{}
+	err = h.exec(req.Context(), nil, buffer, []string{"ls", "-1", req.Filepath})
+	if err != nil {
+		return nil, fmt.Errorf("cannot exec ls: %w", err)
+	}
+	reader := bufio.NewReader(buffer)
+	var files []string
+	for {
+		l, err := reader.ReadString('\n')
+		if errors.Is(err, io.EOF) {
+			break
+		} else if err != nil {
+			return nil, err
+		}
+		fileName := strings.TrimSuffix(l, "\n")
+		files = append(files, fileName)
+	}
+
+	f := ListAtFunc(func(fi []os.FileInfo, i int64) (int, error) {
+		if i >= int64(len(files)) {
+			return 0, io.EOF
+		}
+		filesLeft := files[i:]
+		for k, fileName := range filesLeft {
+			if k >= len(fi) {
+				return k, io.EOF
+			}
+			filePath := path.Join(req.Filepath, fileName)
+			fi[k], err = h.stat(req.Context(), filePath)
+			if err != nil {
+				return 0, fmt.Errorf("cannot stat: %w", err)
+			}
+		}
+		return len(filesLeft), io.EOF
+	})
+	return f, nil
+}
+
+func (h *sftpHandler) stat(ctx context.Context, p string) (os.FileInfo, error) {
+	statYaml := &bytes.Buffer{}
+	err := h.exec(ctx, nil, statYaml, []string{"stat", "-c", "name: %n\nmode: %f\nsize: %s\nmod: %Y\ntype: %F\n", p})
+	if err != nil {
+		return nil, fmt.Errorf("cannot stat: %w", err)
+	}
+	var info struct {
+		Name    string `yaml:"name"`
+		Size    int64  `yaml:"size"`
+		Mode    string `yaml:"mode"`
+		Mod     int64  `yaml:"mod"`
+		EntType string `yaml:"type"`
+	}
+	err = yaml.Unmarshal(statYaml.Bytes(), &info)
+	if err != nil {
+		return nil, fmt.Errorf("cannot unmarshal stat yaml: %w", err)
+	}
+	fileInfo := &fileInfo{
+		name:    path.Base(info.Name),
+		size:    info.Size,
+		modTime: time.Unix(info.Mod, 0),
+		isDir:   info.EntType == "directory",
+	}
+	mode, err := strconv.ParseUint(info.Mode, 16, 32)
+	if err != nil {
+		return nil, fmt.Errorf("cannot parse file mode for stat: %w", err)
+	}
+	fileInfo.mode = fileModeFromUnixMode(uint32(mode))
+	return fileInfo, nil
+}
+
+func (h *sftpHandler) exec(ctx context.Context, stdin io.Reader, stdout io.Writer,
+	command []string) error {
+	req := h.k8s.CoreV1().RESTClient().Post().
+		Resource("pods").
+		Name(h.pod).
+		Namespace(h.namespace).
+		SubResource("exec").
+		Param("container", h.container).
+		VersionedParams(&corev1.PodExecOptions{
+			Container: h.container,
+			Command:   command,
+			Stdin:     stdin != nil,
+			Stdout:    stdout != nil,
+			Stderr:    true,
+			TTY:       false,
+		}, scheme.ParameterCodec)
+	executor, err := remotecommand.NewSPDYExecutor(h.config, "POST", req.URL())
+	if err != nil {
+		return err
+	}
+
+	stderr := &bytes.Buffer{}
+	streamOpts := remotecommand.StreamOptions{
+		Stdin:  stdin,
+		Stdout: stdout,
+		Stderr: stderr,
+	}
+
+	err = executor.StreamWithContext(ctx, streamOpts)
+	var statusError *exec.CodeExitError
+	if errors.As(err, &statusError) {
+		return fmt.Errorf("exec failed: %w\n%s", err, stderr.String())
+	} else if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+type ListAtFunc func([]os.FileInfo, int64) (int, error)
+
+func (f ListAtFunc) ListAt(fi []os.FileInfo, off int64) (int, error) {
+	return f(fi, off)
+}
+
+type fileInfo struct {
+	name    string
+	size    int64
+	mode    os.FileMode
+	modTime time.Time
+	isDir   bool
+}
+
+func (f *fileInfo) Name() string {
+	return f.name
+}
+
+func (f *fileInfo) Size() int64 {
+	return f.size
+}
+
+func (f *fileInfo) Mode() os.FileMode {
+	return f.mode
+}
+
+func (f *fileInfo) ModTime() time.Time {
+	return f.modTime
+}
+
+func (f *fileInfo) IsDir() bool {
+	return f.isDir
+}
+
+func (f *fileInfo) Sys() any {
+	return nil
+}
+
+// Copied mostly from go src
+func fileModeFromUnixMode(mode uint32) os.FileMode {
+	fileMode := os.FileMode(mode & 0777)
+	switch mode & syscall.S_IFMT {
+	case syscall.S_IFBLK:
+		fileMode |= os.ModeDevice
+	case syscall.S_IFCHR:
+		fileMode |= os.ModeDevice | os.ModeCharDevice
+	case syscall.S_IFDIR:
+		fileMode |= os.ModeDir
+	case syscall.S_IFIFO:
+		fileMode |= os.ModeNamedPipe
+	case syscall.S_IFLNK:
+		fileMode |= os.ModeSymlink
+	case syscall.S_IFREG:
+		// nothing to do
+	case syscall.S_IFSOCK:
+		fileMode |= os.ModeSocket
+	}
+	if mode&syscall.S_ISGID != 0 {
+		fileMode |= os.ModeSetgid
+	}
+	if mode&syscall.S_ISUID != 0 {
+		fileMode |= os.ModeSetuid
+	}
+	if mode&syscall.S_ISVTX != 0 {
+		fileMode |= os.ModeSticky
+	}
+	return fileMode
+}
+
+type writerAtFunc func(p []byte, off int64) (n int, err error)
+
+func (w writerAtFunc) WriteAt(p []byte, off int64) (n int, err error) {
+	return w(p, off)
+}

--- a/cmd/juju/commands/main.go
+++ b/cmd/juju/commands/main.go
@@ -390,6 +390,7 @@ func registerCommands(r commandRegistry) {
 	r.Register(action.NewExecCommand(nil))
 	r.Register(ssh.NewSCPCommand(nil, ssh.DefaultSSHRetryStrategy, ssh.DefaultSSHPublicKeyRetryStrategy))
 	r.Register(ssh.NewSSHCommand(nil, nil, ssh.DefaultSSHRetryStrategy, ssh.DefaultSSHPublicKeyRetryStrategy))
+	r.RegisterDeprecated(ssh.NewSSHProxyCommand(), &deprecatedCmdCheck{"ssh directly"})
 	r.Register(application.NewResolvedCommand())
 	r.Register(newDebugLogCommand(nil))
 	r.Register(ssh.NewDebugHooksCommand(nil, ssh.DefaultSSHRetryStrategy, ssh.DefaultSSHPublicKeyRetryStrategy))
@@ -618,4 +619,16 @@ func (cloudToCommandAdapter) PersonalCloudMetadata() (map[string]cloudfile.Cloud
 }
 func (cloudToCommandAdapter) WritePersonalCloudMetadata(cloudsMap map[string]cloudfile.Cloud) error {
 	return cloudfile.WritePersonalCloudMetadata(cloudsMap)
+}
+
+type deprecatedCmdCheck struct {
+	replacement string
+}
+
+func (d deprecatedCmdCheck) Deprecated() (bool, string) {
+	return true, d.replacement
+}
+
+func (deprecatedCmdCheck) Obsolete() bool {
+	return false
 }

--- a/cmd/juju/ssh/ssh_proxy.go
+++ b/cmd/juju/ssh/ssh_proxy.go
@@ -1,0 +1,150 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package ssh
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"sync"
+
+	"github.com/juju/cmd/v3"
+	"github.com/juju/errors"
+	"github.com/juju/gnuflag"
+	"github.com/juju/names/v5"
+
+	jujucmd "github.com/juju/juju/cmd"
+	"github.com/juju/juju/cmd/modelcmd"
+)
+
+func NewSSHProxyCommand() cmd.Command {
+	c := &sshProxyCommand{}
+	return modelcmd.Wrap(c)
+}
+
+// sshProxyCommand is responsible for launching a ssh shell on a given unit or machine.
+type sshProxyCommand struct {
+	modelcmd.ModelCommandBase
+
+	target    names.Tag
+	container string
+}
+
+func (c *sshProxyCommand) SetFlags(f *gnuflag.FlagSet) {
+	f.StringVar(&c.container, "container", "", "container to connect to (k8s only)")
+}
+
+func (c *sshProxyCommand) Info() *cmd.Info {
+	return jujucmd.Info(&cmd.Info{
+		Name:     "ssh-proxy",
+		Args:     "<target>",
+		Purpose:  "",
+		Doc:      "",
+		Examples: "",
+		SeeAlso:  []string{},
+	})
+}
+
+func (c *sshProxyCommand) Init(args []string) (err error) {
+	if len(args) == 0 {
+		return errors.Errorf("no target name specified")
+	}
+	target := args[0]
+	switch {
+	case names.IsValidMachine(target):
+		c.target = names.NewMachineTag(target)
+	case names.IsValidUnit(target):
+		c.target = names.NewUnitTag(target)
+	default:
+		return errors.Errorf("target %q is not a valid machine or unit name", c.target)
+	}
+	return nil
+}
+
+func (c *sshProxyCommand) Run(ctx *cmd.Context) error {
+	apiConn, err := c.NewAPIRoot()
+	if err != nil {
+		return err
+	}
+
+	bestFacadeVersion := apiConn.BestFacadeVersion("SSHClient")
+	if bestFacadeVersion < 5 {
+		return fmt.Errorf("controller does not support ssh proxying")
+	}
+
+	req, dialer, err := apiConn.NewHTTPRequest()
+	if err != nil {
+		return err
+	}
+	switch tag := c.target.(type) {
+	case names.MachineTag:
+		req.URL.Path, err = url.JoinPath(req.URL.Path, "machine", tag.Id(), "ssh")
+		if err != nil {
+			return err
+		}
+	case names.UnitTag:
+		app, err := names.UnitApplication(tag.Id())
+		if err != nil {
+			return err
+		}
+		num, err := names.UnitNumber(tag.Id())
+		if err != nil {
+			return err
+		}
+		req.URL.Path, err = url.JoinPath(req.URL.Path, "application", app, "unit", strconv.Itoa(num), "ssh")
+		if err != nil {
+			return err
+		}
+	}
+	if c.container != "" {
+		q := req.URL.Query()
+		q.Add("container", c.container)
+		req.URL.RawQuery = q.Encode()
+	}
+	req.Method = http.MethodConnect
+	req.Header.Add("Connection", "Upgrade")
+	req.Header.Add("Upgrade", "ssh")
+
+	tlsConn, err := dialer.DialContext(ctx, "tcp", req.URL.Host)
+	if err != nil {
+		return err
+	}
+	defer tlsConn.Close()
+
+	err = req.Write(tlsConn)
+	if err != nil {
+		return err
+	}
+
+	reader := bufio.NewReader(tlsConn)
+	resp, err := http.ReadResponse(reader, req)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusSwitchingProtocols {
+		defer resp.Body.Close()
+		return fmt.Errorf("could not establish ssh proxy: %s", resp.Status)
+	}
+	io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		io.Copy(os.Stdout, tlsConn)
+	}()
+
+	_, err = io.Copy(tlsConn, os.Stdin)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return err
+	}
+
+	wg.Wait()
+	return tlsConn.Close()
+}

--- a/go.mod
+++ b/go.mod
@@ -141,6 +141,7 @@ require (
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 // indirect
 	github.com/Rican7/retry v0.3.1 // indirect
 	github.com/adrg/xdg v0.3.3 // indirect
+	github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.5.4 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.14.10 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.2.9 // indirect
@@ -172,6 +173,7 @@ require (
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/gdamore/encoding v1.0.0 // indirect
 	github.com/gdamore/tcell/v2 v2.5.1 // indirect
+	github.com/gliderlabs/ssh v0.3.7 // indirect
 	github.com/go-jose/go-jose/v3 v3.0.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-macaroon-bakery/macaroonpb v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -90,6 +90,8 @@ github.com/Rican7/retry v0.3.1 h1:scY4IbO8swckzoA/11HgBwaZRJEyY9vaNJshcdhp1Mc=
 github.com/Rican7/retry v0.3.1/go.mod h1:CxSDrhAyXmTMeEuRAnArMu1FHu48vtfjLREWqVl7Vw0=
 github.com/adrg/xdg v0.3.3 h1:s/tV7MdqQnzB1nKY8aqHvAMD+uCiuEDzVB5HLRY849U=
 github.com/adrg/xdg v0.3.3/go.mod h1:61xAR2VZcggl2St4O9ohF5qCKe08+JDmE4VNzPFQvOQ=
+github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
+github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
@@ -246,6 +248,8 @@ github.com/gdamore/tcell/v2 v2.4.1-0.20210905002822-f057f0a857a1/go.mod h1:Az6Jt
 github.com/gdamore/tcell/v2 v2.5.1 h1:zc3LPdpK184lBW7syF2a5C6MV827KmErk9jGVnmsl/I=
 github.com/gdamore/tcell/v2 v2.5.1/go.mod h1:wSkrPaXoiIWZqW/g7Px4xc79di6FTcpB8tvaKJ6uGBo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/gliderlabs/ssh v0.3.7 h1:iV3Bqi942d9huXnzEF2Mt+CY9gLu8DNM4Obd+8bODRE=
+github.com/gliderlabs/ssh v0.3.7/go.mod h1:zpHEXBstFnQYtGnB8k8kQLol82umzn/2/snG7alWVD8=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=

--- a/state/application.go
+++ b/state/application.go
@@ -2966,6 +2966,7 @@ func (a *Application) removeUnitOps(u *Unit, asserts bson.D, op *ForcedOperation
 		removeStatusOp(a.st, u.globalCloudContainerKey()),
 		removeConstraintsOp(u.globalAgentKey()),
 		annotationRemoveOp(a.st, u.globalKey()),
+		removeSSHHostKeyOp(u.globalKey()),
 		newCleanupOp(cleanupRemovedUnit, u.doc.Name, op.Force),
 	}
 	ops = append(ops, portsOps...)


### PR DESCRIPTION
Implements ssh proxying via the controller http API for JAAS and for a simplified ssh/scp client.

**WIP**

TODO:

- [ ] Add support to the `juju ssh` and `juju scp` command to use `juju ssh-proxy` by default.
- [ ] Add testing and clean-up the abstractions.
- [ ] Add deprecations for the k8s ssh client.
- [ ] Add `--no-proxy` arg to `juju ssh` and `juju scp` to use old behaviour.
- [ ] Add shell tests for both k8s and machines.
- [ ] Pull host keys once for each `(unit|machine).model-uuid.juju`.

## QA steps

**WIP**

Machine:
- `ssh -o ProxyCommand="juju ssh-proxy 0" ubuntu@machine-0`
- `ssh -o ProxyCommand="juju ssh-proxy app/0" ubuntu@app-0`

K8s:
- `ssh -o ProxyCommand="juju ssh-proxy app/0 --container charm" app-0`

## Documentation changes

N/A at this point

## Links

**Jira card:** [JUJU-6053](https://warthogs.atlassian.net/browse/JUJU-6053)

**Spec:** [CS187](https://docs.google.com/document/d/1phN2_C-T1aFkEgDU2LIB2KyYEFBwPleKuKOZaKQYHJk/edit)



[JUJU-6053]: https://warthogs.atlassian.net/browse/JUJU-6053?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ