### PR TITLE
feat: prevent unit agent bouncing with no upgrade series

### DIFF
--- a/api/client/machinemanager/machinemanager.go
+++ b/api/client/machinemanager/machinemanager.go
@@ -135,7 +135,7 @@ func (client *Client) UpgradeSeriesPrepare(machineName, channel string, force bo
 	}
 	var result params.ErrorResult
 	if err := client.facade.FacadeCall("UpgradeSeriesPrepare", args, &result); err != nil {
-		return errors.Trace(err)
+		return errors.Trace(apiservererrors.RestoreError(err))
 	}
 
 	if err := result.Error; err != nil {
@@ -153,7 +153,7 @@ func (client *Client) UpgradeSeriesComplete(machineName string) error {
 	result := new(params.ErrorResult)
 	err := client.facade.FacadeCall("UpgradeSeriesComplete", args, result)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Trace(apiservererrors.RestoreError(err))
 	}
 	if result.Error != nil {
 		return result.Error
@@ -174,7 +174,7 @@ func (client *Client) UpgradeSeriesValidate(machineName, channel string) ([]stri
 	results := new(params.UpgradeSeriesUnitsResults)
 	err := client.facade.FacadeCall("UpgradeSeriesValidate", args, results)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(apiservererrors.RestoreError(err))
 	}
 	if n := len(results.Results); n != 1 {
 		return nil, errors.Errorf("expected 1 result, got %d", n)
@@ -194,7 +194,7 @@ func (client *Client) WatchUpgradeSeriesNotifications(machineName string) (watch
 	}
 	err := client.facade.FacadeCall("WatchUpgradeSeriesNotifications", args, &results)
 	if err != nil {
-		return nil, "", errors.Trace(err)
+		return nil, "", errors.Trace(apiservererrors.RestoreError(err))
 	}
 	if len(results.Results) != 1 {
 		return nil, "", errors.Errorf("expected 1 result, got %d", len(results.Results))
@@ -221,7 +221,7 @@ func (client *Client) GetUpgradeSeriesMessages(machineName, watcherId string) ([
 	}
 	err := client.facade.FacadeCall("GetUpgradeSeriesMessages", args, &results)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Trace(apiservererrors.RestoreError(err))
 	}
 	if len(results.Results) != 1 {
 		return nil, errors.Errorf("expected 1 result, got %d", len(results.Results))

--- a/api/client/machinemanager/machinemanager_test.go
+++ b/api/client/machinemanager/machinemanager_test.go
@@ -147,7 +147,7 @@ func (s *MachinemanagerSuite) TestRetryProvisioning(c *gc.C) {
 	result, err := client.RetryProvisioning(false, names.NewMachineTag("0"), names.NewMachineTag("1"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, []params.ErrorResult{
-		{&params.Error{Code: "boom"}},
+		{Error: &params.Error{Code: "boom"}},
 		{},
 	})
 }
@@ -171,7 +171,7 @@ func (s *MachinemanagerSuite) TestRetryProvisioningAll(c *gc.C) {
 	result, err := client.RetryProvisioning(true)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, []params.ErrorResult{
-		{&params.Error{Code: "boom"}},
+		{Error: &params.Error{Code: "boom"}},
 		{},
 	})
 }
@@ -202,7 +202,7 @@ func (s *MachinemanagerSuite) TestProvisioningScript(c *gc.C) {
 	c.Assert(script, gc.Equals, "script")
 }
 
-func (s *MachinemanagerSuite) clientToTestDestroyMachinesWithParams(c *gc.C, maxWait *time.Duration, ctrl *gomock.Controller) (*machinemanager.Client, []params.DestroyMachineResult) {
+func (s *MachinemanagerSuite) clientToTestDestroyMachinesWithParams(maxWait *time.Duration, ctrl *gomock.Controller) (*machinemanager.Client, []params.DestroyMachineResult) {
 	expectedResults := []params.DestroyMachineResult{{
 		Error: &params.Error{Message: "boo"},
 	}, {
@@ -235,7 +235,7 @@ func (s *MachinemanagerSuite) TestDestroyMachinesWithParamsNoWait(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
 	noWait := 0 * time.Second
-	client, expected := s.clientToTestDestroyMachinesWithParams(c, &noWait, ctrl)
+	client, expected := s.clientToTestDestroyMachinesWithParams(&noWait, ctrl)
 	results, err := client.DestroyMachinesWithParams(true, true, false, &noWait, "0", "0/lxd/1")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, expected)
@@ -244,8 +244,73 @@ func (s *MachinemanagerSuite) TestDestroyMachinesWithParamsNoWait(c *gc.C) {
 func (s *MachinemanagerSuite) TestDestroyMachinesWithParamsNilWait(c *gc.C) {
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
-	client, expected := s.clientToTestDestroyMachinesWithParams(c, (*time.Duration)(nil), ctrl)
+	client, expected := s.clientToTestDestroyMachinesWithParams((*time.Duration)(nil), ctrl)
 	results, err := client.DestroyMachinesWithParams(true, true, false, (*time.Duration)(nil), "0", "0/lxd/1")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, jc.DeepEquals, expected)
+}
+
+func (s *MachinemanagerSuite) TestUpgradeSeriesPrepare(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("UpgradeSeriesPrepare", gomock.Any(), gomock.Any()).Return(&params.Error{
+		Code: params.CodeNotImplemented,
+	})
+	client := machinemanager.NewClientFromCaller(mockFacadeCaller)
+	err := client.UpgradeSeriesPrepare("machine-0", "24.04/stable", true)
+	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
+}
+
+func (s *MachinemanagerSuite) TestUpgradeSeriesComplete(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("UpgradeSeriesComplete", gomock.Any(), gomock.Any()).Return(&params.Error{
+		Code: params.CodeNotImplemented,
+	})
+	client := machinemanager.NewClientFromCaller(mockFacadeCaller)
+	err := client.UpgradeSeriesComplete("machine-0")
+	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
+}
+
+func (s *MachinemanagerSuite) TestUpgradeSeriesValidate(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("UpgradeSeriesValidate", gomock.Any(), gomock.Any()).Return(&params.Error{
+		Code: params.CodeNotImplemented,
+	})
+	client := machinemanager.NewClientFromCaller(mockFacadeCaller)
+	_, err := client.UpgradeSeriesValidate("machine-0", "24.04/stable")
+	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
+}
+
+func (s *MachinemanagerSuite) TestWatchUpgradeSeriesNotifications(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("WatchUpgradeSeriesNotifications", gomock.Any(), gomock.Any()).Return(&params.Error{
+		Code: params.CodeNotImplemented,
+	})
+	client := machinemanager.NewClientFromCaller(mockFacadeCaller)
+	_, _, err := client.WatchUpgradeSeriesNotifications("machine-0")
+	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
+}
+
+func (s *MachinemanagerSuite) TestGetUpgradeSeriesMessages(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
+	mockFacadeCaller.EXPECT().FacadeCall("GetUpgradeSeriesMessages", gomock.Any(), gomock.Any()).Return(&params.Error{
+		Code: params.CodeNotImplemented,
+	})
+	client := machinemanager.NewClientFromCaller(mockFacadeCaller)
+	_, err := client.GetUpgradeSeriesMessages("machine-0", "0")
+	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
 }

--- a/worker/uniter/agent.go
+++ b/worker/uniter/agent.go
@@ -40,5 +40,9 @@ func reportAgentError(u *Uniter, userMessage string, err error) {
 // setUpgradeSeriesStatus sets the upgrade series status.
 func setUpgradeSeriesStatus(u *Uniter, status model.UpgradeSeriesStatus, reason string) error {
 	err := u.unit.SetUpgradeSeriesStatus(status, reason)
+	// Upgrade series status has been deprecated.
+	if errors.Is(err, errors.NotImplemented) {
+		return nil
+	}
 	return errors.Annotatef(err, "cannot set upgrade series status to %q with reason: %q", status, reason)
 }

--- a/worker/uniter/remotestate/watcher_test.go
+++ b/worker/uniter/remotestate/watcher_test.go
@@ -18,13 +18,12 @@ import (
 	"github.com/juju/juju/core/secrets"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/rpc/params"
-	"github.com/juju/juju/testing"
-	coretesting "github.com/juju/juju/testing"
+	testing "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/uniter/remotestate"
 )
 
 type WatcherSuite struct {
-	coretesting.BaseSuite
+	testing.BaseSuite
 
 	modelType                    model.ModelType
 	sidecar                      bool
@@ -411,7 +410,7 @@ func (s *WatcherSuiteCAAS) TestSnapshot(c *gc.C) {
 	}
 	select {
 	case s.runningStatusWatcher.changes <- struct{}{}:
-	case <-time.After(coretesting.LongWait):
+	case <-time.After(testing.LongWait):
 		c.Fatal("timeout waiting to post running status change")
 	}
 	assertNotifyEvent(c, s.watcher.RemoteStateChanged(), "waiting for remote state change")
@@ -447,7 +446,7 @@ func (s *WatcherSuiteCAAS) TestSnapshot(c *gc.C) {
 	}
 	select {
 	case s.runningStatusWatcher.changes <- struct{}{}:
-	case <-time.After(coretesting.LongWait):
+	case <-time.After(testing.LongWait):
 		c.Fatal("timeout waiting to post running status change")
 	}
 	assertNotifyEvent(c, s.watcher.RemoteStateChanged(), "waiting for remote state change")
@@ -1025,12 +1024,12 @@ func (s *WatcherSuite) TestUpdateStatusIntervalChanges(c *gc.C) {
 // for a specific number is very likely to start failing intermittently
 // again, as in lp:1604955, if the SUT undergoes even subtle changes.
 func (s *WatcherSuite) waitAlarmsStable(c *gc.C) {
-	timeout := time.After(coretesting.LongWait)
+	timeout := time.After(testing.LongWait)
 	for i := 0; ; i++ {
 		c.Logf("waiting for alarm %d", i)
 		select {
 		case <-s.clock.Alarms():
-		case <-time.After(coretesting.ShortWait):
+		case <-time.After(testing.ShortWait):
 			return
 		case <-timeout:
 			c.Fatalf("never stopped setting alarms")


### PR DESCRIPTION
This is a companion PR to https://github.com/juju/juju/pull/17682 

Upgrade series is being removed in 4.0 and so the agent API will return not implemented error. By adding the error checking to the upgrade series calls, we can just continue if the call wasn't called. This should then allow the agent to continue when calls are missing.



<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://docs.google.com/document/d/1SYUo9G7qZ_jdoVXpUVamS5VCgHmtZ0QA-wZxKoMS-C0 
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
$ juju bootstrap lxd src36
$ juju add-model moveme
$ juju deploy ubuntu
```

Build companion [PR](https://github.com/juju/juju/pull/17682)

```sh
$ juju bootstrap lxd dst40
```

Run the migration

```sh
$ juju switch src36
$ juju migrate src36:moveme dst40
$ juju deploy ubuntu ubuntux
```

Ensure that we can also deploy a new charm.


## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links

**Jira card:** [JUJU-6330](https://warthogs.atlassian.net/browse/JUJU-6330)



[JUJU-6330]: https://warthogs.atlassian.net/browse/JUJU-6330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ