### PR TITLE
fix: resolve symlink exists issue in snapcraft.yaml

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -105,7 +105,9 @@ parts:
     override-build: |
       set -ex
 
-      ln -s $(pwd)/include/sys/queue.h /usr/local/musl/include/sys/queue.h
+      if [ ! -L /usr/local/musl/include/sys/queue.h ]; then
+        ln -s $(pwd)/include/sys/queue.h /usr/local/musl/include/sys/queue.h
+      fi
 
   libtirpc:
     after:


### PR DESCRIPTION
fix: resolve symlink exists issue in snapcraft.yaml

The PR fixes the issue in script with existing symbolic link. Which will now do nothing instead of getting `file is already exists` error.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```
# (optional) install snapcraft
sudo snap install snapcraft --classic

# build juju snap
snapcraft --use-lxd
```

## Links


**Jira card:** JUJU-NOCARD

