### PR TITLE
docs(network): add network domain package documentation

### DIFF
--- a/domain/network/doc.go
+++ b/domain/network/doc.go
@@ -1,0 +1,12 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package network provides the service for managing juju's networking aspects,
+// namely spaces and subnets.
+//
+// Subnets are always discovered from the underlaying network (as present in
+// the provider), and inserted into the DB at bootstrap.
+// Spaces are a domain concept, and they are a grouping of subnets which allows
+// for easier network (and application/integrations) isolation. Spaces can also
+// be discovered from the underlaying provider, only available on MAAS.
+package network


### PR DESCRIPTION
Small patch to add `doc.go` package documentation to the `network` domain.

## Checklist

- [ ] ~Code style: imports ordered, good names, simple structure, etc~
- [X] Comments saying why design decisions were made
- [ ] ~Go unit tests, with comments saying what you're testing~
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

N/A

## Documentation changes

New package documentation, nothing to change in public docs.

## Links

**Jira card:** JUJU-

