### PR TITLE
docs(controller-config): fix wording on agent controller config keys

### DIFF
--- a/controller/config.go
+++ b/controller/config.go
@@ -165,12 +165,12 @@ const (
 	// which should be more than enough time for a debugging session.
 	MaxDebugLogDuration = "max-debug-log-duration"
 
-	// AgentLogfileMaxSize is the maximum file size in MB of each agent log
-	// file.
+	// AgentLogfileMaxSize is the maximum file size of each agent log file,
+	// in MB.
 	AgentLogfileMaxSize = "agent-logfile-max-size"
 
-	// AgentLogfileMaxBackups is the number of old agent log files to keep
-	// (compressed; saved on each unit, synced to the controller).
+	// AgentLogfileMaxBackups is the maximum number of old agent log files
+	// to keep (compressed; saved on each unit, synced to the controller).
 	AgentLogfileMaxBackups = "agent-logfile-max-backups"
 
 	// ModelLogfileMaxSize is the maximum size of the log file written out by the

--- a/controller/config.go
+++ b/controller/config.go
@@ -56,11 +56,11 @@ const (
 	ControllerResourceDownloadLimit = "controller-resource-download-limit"
 
 	// AgentRateLimitMax is the maximum size of the token bucket used to
-	// ratelimit the agent connections.
+	// ratelimit the agent connections to the API server.
 	AgentRateLimitMax = "agent-ratelimit-max"
 
-	// AgentRateLimitRate is the time taken to add a new token to the bucket.
-	// This effectively says that we can have a new agent connect per duration specified.
+	// AgentRateLimitRate is the interval at which a new token is added to
+	// the token bucket, in milliseconds (ms).
 	AgentRateLimitRate = "agent-ratelimit-rate"
 
 	// APIPortOpenDelay is a duration that the controller will wait
@@ -165,12 +165,12 @@ const (
 	// which should be more than enough time for a debugging session.
 	MaxDebugLogDuration = "max-debug-log-duration"
 
-	// AgentLogfileMaxSize is the maximum file size in MB of each
-	// agent/controller log file.
+	// AgentLogfileMaxSize is the maximum file size in MB of each agent log
+	// file.
 	AgentLogfileMaxSize = "agent-logfile-max-size"
 
-	// AgentLogfileMaxBackups is the number of old agent/controller log files
-	// to keep (compressed).
+	// AgentLogfileMaxBackups is the number of old agent log files to keep
+	// (compressed; saved on each unit, synced to the controller).
 	AgentLogfileMaxBackups = "agent-logfile-max-backups"
 
 	// ModelLogfileMaxSize is the maximum size of the log file written out by the


### PR DESCRIPTION
This patch improves the wording on these four controller config keys:
- agent-ratelimit-max
- agent-ratelimit-rate
- agent-logfile-max-size
- agent-logfile-max-backups

<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://docs.google.com/document/d/1SYUo9G7qZ_jdoVXpUVamS5VCgHmtZ0QA-wZxKoMS-C0 
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

<!-- Describe steps to verify that the change works. -->

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/

**Jira card:** JUJU-

