### PR TITLE
fix(application): caas model application status to respect equivalent severity

### DIFF
--- a/core/status/caas.go
+++ b/core/status/caas.go
@@ -76,9 +76,10 @@ func ApplicationDisplayStatus(applicationStatus, operatorStatus StatusInfo, expe
 		return operatorStatus
 	}
 
-	// Check if the application status has been set to a higher severity status
-	// than the operator status (e.g. set to maintenance by the charm)
-	if statusSeverities[appStatus] > statusSeverities[opStatus] {
+	// Check if the application status has been set to an equivalent or higher
+	// severity status than the operator status (e.g. set to waiting by the
+	// charm)
+	if statusSeverities[appStatus] >= statusSeverities[opStatus] {
 		return applicationStatus
 	}
 

--- a/core/status/caas_test.go
+++ b/core/status/caas_test.go
@@ -280,6 +280,18 @@ func (s *UnitCloudStatusSuite) TestApplicatoinOpeartorStatusChoice(c *gc.C) {
 				Status:  status.Waiting,
 				Message: "unit",
 			},
+			expectWorkload: true,
+			messageCheck:   "unit",
+		},
+		{
+			operatorStatus: status.StatusInfo{
+				Status:  status.Waiting,
+				Message: "operator",
+			},
+			appStatus: status.StatusInfo{
+				Status:  status.Active,
+				Message: "unit",
+			},
 			expectWorkload: false,
 			messageCheck:   "installing agent",
 		},


### PR DESCRIPTION
When selecting between operator and application statuses with the same severity level (e.g. both waiting) on a caas model Juju selects the operator status instead of the application status, which is likely more relevant, as reported by https://bugs.launchpad.net/juju/+bug/2038833/comments/2

Builds on the changes in PR #17572

<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://docs.google.com/document/d/1SYUo9G7qZ_jdoVXpUVamS5VCgHmtZ0QA-wZxKoMS-C0 
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~~
- ~~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~~

## QA steps

<!-- Describe steps to verify that the change works. -->
Using the reproducer in the error report:

```
1. git clone https://github.com/carlcsaposs-canonical/bug-report-juju-status-overrides-charm-app-status.git
2. git checkout waiting
3. charmcraft pack
4. juju bootstrap microk8s deleteme
5. juju deploy ./bar_ubuntu-22.04-amd64.charm -n 3
6. <Wait for idle>
7. juju refresh bar --path ./bar_ubuntu-22.04-amd64.charm
8. juju status --watch 1s
```

Actual behavior (without this change) "bar" app status flickers between waiting status "installing agent" and waiting status "upgrading unit ..."

Expected behavior (with this change) "bar" app status stays at waiting status "upgrading unit ..."

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2038833/comments/2

