### PR TITLE
docs(cmd): fix formatting in juju config help

### DIFF
--- a/cmd/juju/application/config.go
+++ b/cmd/juju/application/config.go
@@ -31,37 +31,57 @@ import (
 const (
 	configSummary = `Gets, sets, or resets configuration for a deployed application.`
 	configDetails = `
-To view all configuration values for an application, run
+To view all configuration values for an application:
+
     juju config <app>
+    
 By default, the config will be printed in yaml format. You can instead print it
 in json format using the --format flag:
+
     juju config <app> --format json
 
 To view the value of a single config key, run
+
     juju config <app> key
+    
 To set config values, run
+
     juju config <app> key1=val1 key2=val2 ...
+    
 This sets "key1" to "val1", etc. Using the @ directive, you can set a config
 key's value to the contents of a file:
+
     juju config <app> key=@/tmp/configvalue
+    
 You can also reset config keys to their default values:
+
     juju config <app> --reset key1
     juju config <app> --reset key1,key2,key3
+    
 You may simultaneously set some keys and reset others:
+
     juju config <app> key1=val1 key2=val2 --reset key3,key4
 
 Config values can be imported from a yaml file using the --file flag:
+
     juju config <app> --file=path/to/cfg.yaml
+    
 The yaml file should be in the following format:
+
     apache2:                        # application name
       servername: "example.com"     # key1: val1
       lb_balancer_timeout: 60       # key2: val2
       ...
+      
 This allows you to e.g. save an app's config to a file:
+
     juju config app1 > cfg.yaml
+    
 and then import the config later. You can also read from stdin using "-",
 which allows you to pipe config values from one app to another:
+
     juju config app1 | juju config app2 --file -
+    
 You can simultaneously read config from a yaml file and set/reset config keys
 as above. The command-line args will override any values specified in the file.
 
@@ -70,8 +90,8 @@ branch. A specific branch can be targeted using the --branch option. Changes
 can be immediately be applied to the model by specifying --branch=master. For
 example:
 
-juju config apache2 --branch=master servername=example.com
-juju config apache2 --branch test-branch servername=staging.example.com
+    juju config apache2 --branch=master servername=example.com
+    juju config apache2 --branch test-branch servername=staging.example.com
 
 Rather than specifying each setting name/value inline, the --file flag option
 may be used to provide a list of settings to be updated as a yaml file. The
@@ -80,20 +100,20 @@ name followed by a dictionary of key/value pairs that correspond to the names
 and values of the settings to be set. For instance, to configure apache2,
 the following yaml file can be used:
 
-apache2:
-  servername: "example.com"
-  lb_balancer_timeout: 60
+    apache2:
+      servername: "example.com"
+      lb_balancer_timeout: 60
 
 If the above yaml document is stored in a file called config.yaml, the
 following command can be used to apply the config changes:
 
-juju config apache2 --file config.yaml
+    juju config apache2 --file config.yaml
 
 Finally, the --reset flag can be used to revert one or more configuration
 settings back to their default value as defined in the charm metadata:
 
-juju config apache2 --reset servername
-juju config apache2 --reset servername,lb_balancer_timeout
+    juju config apache2 --reset servername
+    juju config apache2 --reset servername,lb_balancer_timeout
 `
 )
 


### PR DESCRIPTION
Fixed formatting in juju config help so it will display correctly on Discourse.

## Checklist

~- [ ] Code style: imports ordered, good names, simple structure, etc~
~- [ ] Comments saying why design decisions were made~
~- [ ] Go unit tests, with comments saying what you're testing~
~- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
~- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

N/A

## Documentation changes

This is a cmd help documentation change.

## Links

Fixes issue raised in https://discourse.charmhub.io/t/command-juju-config/10139/2

**Jira card:** JUJU-6337

