### PR TITLE
fix: update yq syntax to match current version

### DIFF
--- a/tests/suites/deploy/deploy_bundles.sh
+++ b/tests/suites/deploy/deploy_bundles.sh
@@ -136,20 +136,20 @@ run_deploy_exported_charmhub_bundle_with_fixed_revisions() {
 	echo "Make a copy of reference yaml"
 	cp ${bundle} "${TEST_DIR}/telegraf_bundle.yaml"
 	if [[ -n ${MODEL_ARCH} ]]; then
-		yq -i "
+		yq -yi "
 			.machines.\"0\".constraints = \"arch=${MODEL_ARCH}\" |
 			.machines.\"1\".constraints = \"arch=${MODEL_ARCH}\"
 		" "${TEST_DIR}/telegraf_bundle.yaml"
 	else
-		yq -i . "${TEST_DIR}/telegraf_bundle.yaml"
+		yq -yi . "${TEST_DIR}/telegraf_bundle.yaml"
 	fi
 	# no need to wait for the bundle to finish deploying to
 	# check the export.
 	echo "Compare export-bundle with telegraf_bundle"
 	juju export-bundle --filename "${TEST_DIR}/exported_bundle.yaml"
 	# Sort keys in both yaml files to get a fair comparison.
-	yq -i 'sort_keys(..)' "${TEST_DIR}/telegraf_bundle.yaml"
-	yq -i 'sort_keys(..)' "${TEST_DIR}/exported_bundle.yaml"
+	yq -yi --sort-keys '..' "${TEST_DIR}/telegraf_bundle.yaml"
+	yq -yi --sort-keys '..' "${TEST_DIR}/exported_bundle.yaml"
 	diff -u "${TEST_DIR}/telegraf_bundle.yaml" "${TEST_DIR}/exported_bundle.yaml"
 
 	destroy_model "test-export-bundles-deploy-with-fixed-revisions"
@@ -168,11 +168,11 @@ run_deploy_exported_charmhub_bundle_with_float_revisions() {
 	cp ${bundle} "${TEST_DIR}/telegraf_bundle_without_revisions.yaml"
 	cp ${bundle_with_fake_revisions} "${TEST_DIR}/telegraf_bundle_with_fake_revisions.yaml"
 	if [[ -n ${MODEL_ARCH} ]]; then
-		yq -i "
+		yq -yi "
       .applications.influxdb.constraints = \"arch=${MODEL_ARCH}\" |
       .applications.juju-qa-test.constraints = \"arch=${MODEL_ARCH}\"
     " "${TEST_DIR}/telegraf_bundle_without_revisions.yaml"
-		yq -i "
+		yq -yi "
       .applications.influxdb.constraints = \"arch=${MODEL_ARCH}\" |
       .applications.juju-qa-test.constraints = \"arch=${MODEL_ARCH}\"
     " "${TEST_DIR}/telegraf_bundle_with_fake_revisions.yaml"
@@ -181,10 +181,10 @@ run_deploy_exported_charmhub_bundle_with_float_revisions() {
 	# Add correct PGP key for influxdb - workaround from
 	# https://bugs.launchpad.net/influxdb-charm/+bug/2004303
 	INFLUXDB_PGP=$(curl -s https://repos.influxdata.com/influxdata-archive_compat.key)
-	yq -i "
+	yq -yi "
 		.applications.influxdb.options.install_keys = \"${INFLUXDB_PGP}\"
 	" "${TEST_DIR}/telegraf_bundle_without_revisions.yaml"
-	yq -i "
+	yq -yi "
 		.applications.influxdb.options.install_keys = \"${INFLUXDB_PGP}\"
 	" "${TEST_DIR}/telegraf_bundle_with_fake_revisions.yaml"
 
@@ -203,14 +203,14 @@ run_deploy_exported_charmhub_bundle_with_float_revisions() {
 
 	echo "Make a copy of reference yaml and insert revisions in it"
 	cp "${TEST_DIR}/telegraf_bundle_with_fake_revisions.yaml" "${TEST_DIR}/telegraf_bundle_with_revisions.yaml"
-	yq -i "
+	yq -yi "
 		.applications.influxdb.revision = ${influxdb_rev} |
 		.applications.telegraf.revision = ${telegraf_rev} |
 		.applications.juju-qa-test.revision = ${juju_qa_test_rev}
 	" "${TEST_DIR}/telegraf_bundle_with_revisions.yaml"
 
 	if [[ -n ${MODEL_ARCH} ]]; then
-		yq -i "
+		yq -yi "
 			.applications.influxdb.constraints = \"arch=${MODEL_ARCH}\" |
 			.applications.juju-qa-test.constraints = \"arch=${MODEL_ARCH}\" |
 			.machines.\"0\".constraints = \"arch=${MODEL_ARCH}\" |
@@ -223,8 +223,8 @@ run_deploy_exported_charmhub_bundle_with_float_revisions() {
 	echo "Compare export-bundle with telegraf_bundle_with_revisions"
 	juju export-bundle --filename "${TEST_DIR}/exported_bundle.yaml"
 	# Sort keys in both yaml files to get a fair comparison.
-	yq -i 'sort_keys(..)' "${TEST_DIR}/telegraf_bundle_with_revisions.yaml"
-	yq -i 'sort_keys(..)' "${TEST_DIR}/exported_bundle.yaml"
+	yq -yi --sort-keys '..' "${TEST_DIR}/telegraf_bundle_with_revisions.yaml"
+	yq -yi --sort-keys '..' "${TEST_DIR}/exported_bundle.yaml"
 	diff -u "${TEST_DIR}/telegraf_bundle_with_revisions.yaml" "${TEST_DIR}/exported_bundle.yaml"
 
 	destroy_model "test-export-bundles-deploy-with-float-revisions"


### PR DESCRIPTION
This fixes the yq syntax in the tests which was causing them to fail.
<!-- Why this change is needed and what it does. -->
I am still getting a failure on a single test on 3.4, and to me its very unclear why its failing. The test does not set out expected behaviour. The yq syntax is no longer causing it to fail though.

Is the diff with the exported bundle meant to be empty? If so I believe this is a genuine test failure and out of scope of this PR.

The results are:
```
➜  ~/C/J/j/tests (update-yq-sytnax-in-bundle-tests) ✗ ./main.sh -v deploy run_deploy_exported_charmhub_bundle_with_fixed_revisions

==> Checking for dependencies
==> Using Juju located at /home/aflynn/go/bin/juju
==> Running subtest: run_deploy_exported_charmhub_bundle_with_fixed_revisions
==> TEST BEGIN: test_deploy (tmp.psW)
SKIPPING: run_deploy_exported_charmhub_bundle_with_fixed_revisions run_deploy_bundle
SKIPPING: run_deploy_exported_charmhub_bundle_with_fixed_revisions run_deploy_bundle_overlay
===> [   ] Running: deploy exported charmhub bundle with fixed revisions

====> Unable to reuse bootstrapped juju
====> Bootstrapping juju (3.4.5:localhost)
====> BOOTSTRAP_ADDITIONAL_ARGS:  --agent-version=3.4.5

    | Creating Juju controller "ctrl-b5hbr63d" on localhost/localhost
    | Looking for packaged Juju agent version 3.4.5 for amd64
    | No packaged binary found, preparing local Juju agent binary
    | To configure your system to better support LXD containers, please see: https://documentation.ubuntu.com/lxd/en/latest/explanation/performance_tuning/
    | Launching controller instance(s) on localhost/localhost...
 - juju-e46bd1-0 (arch=amd64)
    | Installing Juju agent on bootstrap instance
    | Waiting for address
    | Attempting to connect to 10.101.18.162:22
    | Connected to 10.101.18.162
    | Running machine configuration script...
    | Bootstrap agent now started
    | Contacting Juju controller at 10.101.18.162 to verify accessibility...

    | Bootstrap complete, controller "ctrl-b5hbr63d" is now available
    | Controller machines are in the "controller" model
    | Initial model "test-export-bundles-deploy-with-fixed-revisions" added

====> Bootstrapped juju (377s)
Located charm "influxdb" in charm-hub, channel latest/stable
Located charm "juju-qa-test" in charm-hub, channel latest/stable
Located charm "telegraf" in charm-hub, channel latest/stable
Executing changes:
- upload charm influxdb from charm-hub for base ubuntu@20.04/stable with revision 24 with architecture=amd64
- deploy application influxdb from charm-hub on ubuntu@20.04/stable with latest/stable
- upload charm juju-qa-test from charm-hub for base ubuntu@20.04/stable with revision 19 with architecture=amd64
- deploy application juju-qa-test from charm-hub on ubuntu@20.04/stable with latest/stable
  added resource foo-file
- upload charm telegraf from charm-hub for base ubuntu@20.04/stable with revision 53 with architecture=amd64
- deploy application telegraf from charm-hub on ubuntu@20.04/stable with latest/stable
- add new machine 0
- add new machine 1
- add relation telegraf:juju-info - juju-qa-test:juju-info
- add relation telegraf:influxdb-api - influxdb:query
- add unit influxdb/0 to new machine 0
- add unit juju-qa-test/0 to new machine 1
Deploy of bundle completed.
Make a copy of reference yaml
Compare export-bundle with telegraf_bundle
Bundle successfully exported to /home/aflynn/Canonical/Juju/juju2/tests/tmp.psW/exported_bundle.yaml
--- /home/aflynn/Canonical/Juju/juju2/tests/tmp.psW/telegraf_bundle.yaml        2024-07-10 09:56:56.666881792 +0100
+++ /home/aflynn/Canonical/Juju/juju2/tests/tmp.psW/exported_bundle.yaml        2024-07-10 09:56:56.878867679 +0100
@@ -23,8 +23,10 @@
     revision: 53
 default-base: ubuntu@20.04/stable
 machines:
-  '0': {}
-  '1': {}
+  '0':
+    constraints: arch=amd64
+  '1':
+    constraints: arch=amd64
 relations:
   - - telegraf:juju-info
     - juju-qa-test:juju-info
==> Cleaning up
====> Cleaning up pids
====> Completed cleaning up pids
====> Cleaning up jujus
====> Introspection gathering
====> Introspection gathered
====> Removing offers
====> Removed offers
====> Destroying juju (ctrl-b5hbr63d)

    | WARNING This command will destroy the "ctrl-b5hbr63d" controller and all its resources
    | Destroying controller
    | Waiting for model resources to be reclaimed
    | Waiting for 1 model, 2 machines, 4 applications
    | Waiting for 1 model, 2 machines, 4 applications
    | Waiting for 1 model, 2 machines, 4 applications
    | Waiting for 1 model, 2 machines, 4 applications
    | Waiting for 1 model, 2 machines, 4 applications
    | Waiting for 1 model, 2 machines, 4 applications
    | Waiting for 1 model, 2 machines, 4 applications
    | Waiting for 1 model, 2 machines, 4 applications
    | Waiting for 1 model, 2 machines, 4 applications
    | Waiting for 1 model, 2 machines, 4 applications
    | Waiting for 1 model, 2 machines, 4 applications
    | Waiting for 1 model, 2 machines, 4 applications
    | Waiting for 1 model, 2 machines, 4 applications
    | Waiting for 1 model, 2 machines, 2 applications
    | Waiting for 1 model, 2 machines
    | Waiting for 1 model, 2 machines
    | Waiting for 1 model, 2 machines
    | Waiting for 1 model
    | All models reclaimed, cleaning up controller machines

====> Destroyed juju (ctrl-b5hbr63d)
====> Completed cleaning up jujus

==> TESTS DONE: test_deploy
==> RUN OUTPUT: test_deploy_bundles
    | 
    | ====> Unable to reuse bootstrapped juju
    | ====> Bootstrapping juju (3.4.5:localhost)
    | ====> BOOTSTRAP_ADDITIONAL_ARGS:  --agent-version=3.4.5
    | 
    |     | Creating Juju controller "ctrl-b5hbr63d" on localhost/localhost
    |     | Looking for packaged Juju agent version 3.4.5 for amd64
    |     | No packaged binary found, preparing local Juju agent binary
    |     | To configure your system to better support LXD containers, please see: https://documentation.ubuntu.com/lxd/en/latest/explanation/performance_tuning/
    |     | Launching controller instance(s) on localhost/localhost...
 - juju-e46bd1-0 (arch=amd64)mage
    |     | Installing Juju agent on bootstrap instance
    |     | Waiting for address
    |     | Attempting to connect to 10.101.18.162:22
    |     | Connected to 10.101.18.162
    |     | Running machine configuration script...
    |     | Bootstrap agent now started
    |     | Contacting Juju controller at 10.101.18.162 to verify accessibility...
    | 
    |     | Bootstrap complete, controller "ctrl-b5hbr63d" is now available
    |     | Controller machines are in the "controller" model
    |     | Initial model "test-export-bundles-deploy-with-fixed-revisions" added
    | 
    | ====> Bootstrapped juju (377s)
    | Located charm "influxdb" in charm-hub, channel latest/stable
    | Located charm "juju-qa-test" in charm-hub, channel latest/stable
    | Located charm "telegraf" in charm-hub, channel latest/stable
    | Executing changes:
    | - upload charm influxdb from charm-hub for base ubuntu@20.04/stable with revision 24 with architecture=amd64
    | - deploy application influxdb from charm-hub on ubuntu@20.04/stable with latest/stable
    | - upload charm juju-qa-test from charm-hub for base ubuntu@20.04/stable with revision 19 with architecture=amd64
    | - deploy application juju-qa-test from charm-hub on ubuntu@20.04/stable with latest/stable
    |   added resource foo-file
    | - upload charm telegraf from charm-hub for base ubuntu@20.04/stable with revision 53 with architecture=amd64
    | - deploy application telegraf from charm-hub on ubuntu@20.04/stable with latest/stable
    | - add new machine 0
    | - add new machine 1
    | - add relation telegraf:juju-info - juju-qa-test:juju-info
    | - add relation telegraf:influxdb-api - influxdb:query
    | - add unit influxdb/0 to new machine 0
    | - add unit juju-qa-test/0 to new machine 1
    | Deploy of bundle completed.
    | Make a copy of reference yaml
    | Compare export-bundle with telegraf_bundle
    | Bundle successfully exported to /home/aflynn/Canonical/Juju/juju2/tests/tmp.psW/exported_bundle.yaml
    | --- /home/aflynn/Canonical/Juju/juju2/tests/tmp.psW/telegraf_bundle.yaml  2024-07-10 09:56:56.666881792 +0100
    | +++ /home/aflynn/Canonical/Juju/juju2/tests/tmp.psW/exported_bundle.yaml  2024-07-10 09:56:56.878867679 +0100
    | @@ -23,8 +23,10 @@
    |      revision: 53
    |  default-base: ubuntu@20.04/stable
    |  machines:
    | -  '0': {}
    | -  '1': {}
    | +  '0':
    | +    constraints: arch=amd64
    | +  '1':
    | +    constraints: arch=amd64
    |  relations:
    |    - - telegraf:juju-info
    |      - juju-qa-test:juju-info

==> Test result: failure

```

