### PR TITLE
ci: unify static analysis jobs under one so none are missed

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -12,38 +12,18 @@ permissions:
   contents: read
 
 jobs:
-  lint:
-    name: Lint
+  checks:
+    name: Checks
     runs-on: [self-hosted, linux, arm64, aws, xxlarge]
     if: github.event.pull_request.draft == false
     steps:
     - name: Checkout
       uses: actions/checkout@v4
 
-    - name: Determine which tests to run
-      uses: dorny/paths-filter@v3
-      id: filter
-      with:
-        filters: |
-          go:
-            - '**.go'
-            - 'go.mod'
-          sh:
-            - '**.sh'
-          python:
-            - '**.py'
-          static-analysis:
-            - '.github/workflows/static-analysis.yml'
-            - 'Makefile'
-            - 'tests/main.sh'
-            - 'tests/includes/**'
-            - 'tests/suites/static_analysis/**'
-
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
         go-version-file: 'go.mod'
-        cache: true
 
     - name: Install Dependencies
       run: |
@@ -57,133 +37,20 @@ jobs:
           libdqlite-dev \
           libsqlite3-dev \
           sqlite3
-        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.54.2
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.55.2
         sudo curl -sSfL https://github.com/mvdan/sh/releases/download/v3.7.0/shfmt_v3.7.0_linux_$(go env GOARCH) -o /usr/bin/shfmt
         sudo chmod +x /usr/bin/shfmt
     
-    - name: Download Dependencies
+    - name: Download Go Dependencies
       run: go mod download
 
-    - name: "Static Analysis: Copyright"
-      if: steps.filter.outputs.static-analysis == 'true' || steps.filter.outputs.go == 'true'
-      run: |
-        STATIC_ANALYSIS_JOB=test_copyright make static-analysis
-      shell: bash
-
-    - name: "Static Analysis: Shell Check"
-      if: steps.filter.outputs.static-analysis == 'true' || steps.filter.outputs.sh == 'true'
-      run: |
-        STATIC_ANALYSIS_JOB=test_static_analysis_shell make static-analysis
-      shell: bash
-
-    - name: "Static Analysis: Go Check"
-      if: steps.filter.outputs.static-analysis == 'true' || steps.filter.outputs.go == 'true'
-      run: |
-        # Explicitly set GOROOT to avoid golangci-lint/issues/3107
-        export "GOROOT=$(go env GOROOT)"
-        export "CGO_LDFLAGS=-L$(pwd)/_deps/juju-dqlite-static-lib-deps -luv -lraft -ldqlite -llz4 -lsqlite3"
-
-        STATIC_ANALYSIS_JOB=test_static_analysis_go make static-analysis
-      shell: bash
-      env:
-        CGO_ENABLED: 1
-        CGO_LDFLAGS_ALLOW: "(-Wl,-wrap,pthread_create)|(-Wl,-z,now)"
-
-    - name: "Static Analysis: Python Check"
-      if: steps.filter.outputs.static-analysis == 'true' || steps.filter.outputs.python == 'true'
-      run: |
-        STATIC_ANALYSIS_JOB=test_static_analysis_python make static-analysis
-      shell: bash
-
-  schema:
-    name: Schema
-    runs-on: [self-hosted, linux, arm64, aws, large]
-    if: github.event.pull_request.draft == false
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-
-    - name: Check if there is anything to test
-      uses: dorny/paths-filter@v3
-      id: filter
-      with:
-        filters: |
-          schema:
-            - 'apiserver/facades/schema.json'
-            - 'generate/schemagen/**'
-            - '**.go'
-            - 'go.mod'
-            - '.github/workflows/static-analysis.yml'
-            - 'Makefile'
-            - 'tests/main.sh'
-            - 'tests/includes/**'
-            - 'tests/suites/static_analysis/schema.sh'
-
-    - name: Set up Go
-      if: steps.filter.outputs.schema == 'true'
-      uses: actions/setup-go@v5
-      with:
-        go-version-file: 'go.mod'
-        cache: true
-
-    - name: Install Dependencies
-      if: steps.filter.outputs.schema == 'true'
-      run: |
-        sudo add-apt-repository ppa:dqlite/dev -y --no-update
-        sudo apt-get update
-        sudo apt-get install -y \
-          expect \
-          libdqlite-dev \
-          libsqlite3-dev \
-          sqlite3
-
-    - name: Schema Check
-      if: steps.filter.outputs.schema == 'true'
-      run: |
-        STATIC_ANALYSIS_JOB=test_schema make static-analysis
+    - name: "Static Analysis"
+      run: make static-analysis
       shell: bash
 
   conventional-commits:
     name: Check conventional commits
     runs-on: ubuntu-latest
     steps:
-        - uses: actions/checkout@v4
-        - uses: wagoid/commitlint-github-action@v6
-
-  go-version:
-    name: Go Version
-    runs-on: [self-hosted, linux, arm64, aws, large]
-    if: github.event.pull_request.draft == false
-    strategy:
-      fail-fast: false
-      matrix:
-        binary: ["jujud", "juju"]
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version-file: 'go.mod'
-        cache: true
-
-    - name: Get go.mod version
-      id: go_mod_version
-      shell: bash
-      run: echo "GO_MOD_VERSION=$(go mod edit -json | jq -r .Go | awk 'BEGIN{FS="."} {print $1"."$2}')" >> $GITHUB_ENV
-
-    - name: Get binary snapcraft.yaml
-      id: get_binary_snapcraft
-      uses: mikefarah/yq@master
-      with:
-        cmd: yq -r '.parts | .["${{ matrix.binary }}"] | .["go-channel"]' snap/snapcraft.yaml
-
-    - name: Ensure go version
-      shell: bash
-      run: |
-        echo ${{ steps.get_binary_snapcraft.outputs.result }} | grep -q "$GO_MOD_VERSION"
-        if [ $? -ne 0 ]; then
-          echo "Go version in go.mod ($mod_version) does not match snapcraft.yaml ($snap_version)"
-          exit 1
-        fi
+    - uses: actions/checkout@v4
+    - uses: wagoid/commitlint-github-action@v6

--- a/api/sessiontokenloginprovider.go
+++ b/api/sessiontokenloginprovider.go
@@ -1,10 +1,6 @@
 // Copyright 2024 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-// loginprovider within the cmd/juju package provides interactive based methods
-// for login normally used by the CLI.
-// These are contrasted with login providers defined elsewhere which may not
-// require interactive login.
 package api
 
 import (

--- a/cmd/internal/loginprovider/doc.go
+++ b/cmd/internal/loginprovider/doc.go
@@ -1,0 +1,5 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package loginprovider contains login providers required only by the Juju CLI.
+package loginprovider

--- a/cmd/internal/loginprovider/tryinorderloginprovider.go
+++ b/cmd/internal/loginprovider/tryinorderloginprovider.go
@@ -1,7 +1,6 @@
 // Copyright 2024 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-// Contains login providers required only by the Juju CLI.
 package loginprovider
 
 import (

--- a/tests/suites/static_analysis/doc_go.py
+++ b/tests/suites/static_analysis/doc_go.py
@@ -86,8 +86,11 @@ def check_package(package):
 
 	comment_files = package_comment_files(package)
 	non_doc_files = [f for f in comment_files if f != 'doc.go']
+	doc_files = [f for f in comment_files if f == 'doc.go']
 	if non_doc_files:
 		errors.append('package comment in non-doc.go files: '+', '.join(non_doc_files))
+	elif not doc_files:
+		return None
 
 	lines = header.splitlines()
 	if len(lines) > 2 and not lines[2].startswith('Package '):

--- a/tests/suites/static_analysis/lint_go.sh
+++ b/tests/suites/static_analysis/lint_go.sh
@@ -15,8 +15,8 @@ run_api_imports() {
 
 run_go() {
 	VER=$(golangci-lint --version | tr -s ' ' | cut -d ' ' -f 4 | cut -d '.' -f 1,2)
-	if [[ ${VER} != "1.54" ]] && [[ ${VER} != "v1.54" ]]; then
-		(echo >&2 -e '\nError: golangci-lint version does not match 1.54. Please upgrade/downgrade to the right version.')
+	if [[ ${VER} != "1.55" ]] && [[ ${VER} != "v1.55" ]]; then
+		(echo >&2 -e '\nError: golangci-lint version does not match 1.55. Please upgrade/downgrade to the right version.')
 		exit 1
 	fi
 	OUT=$(golangci-lint run -c .github/golangci-lint.config.yaml 2>&1)

--- a/tests/suites/static_analysis/task.sh
+++ b/tests/suites/static_analysis/task.sh
@@ -8,8 +8,11 @@ test_static_analysis() {
 
 	test_copyright
 	test_doc_go
-	test_static_analysis_go
+	test_versions
 	test_static_analysis_shell
 	test_static_analysis_python
 	test_schema
+
+	# slow ones go last
+	test_static_analysis_go
 }

--- a/tests/suites/static_analysis/versions.sh
+++ b/tests/suites/static_analysis/versions.sh
@@ -1,0 +1,74 @@
+run_check_go_version() {
+	OUT=$(check_go_version 2>&1 || true)
+	if [ -n "${OUT}" ]; then
+		echo ""
+		echo "$(red 'Found some issues:')"
+		echo "${OUT}"
+		exit 1
+	fi
+}
+
+check_go_version() {
+	exit_code=0
+	target_version="$(go mod edit -json | jq -r .Go | awk 'BEGIN{FS="."} {print $1"."$2}')"
+
+	snapcraft_go_juju_version="$(yq -r '.parts | .["juju"] | .["go-channel"]' snap/snapcraft.yaml)"
+	echo "${snapcraft_go_juju_version}" | grep -q "${target_version}"
+	if [ $? -ne 0 ]; then
+		echo "Go version in go.mod (${target_version}) does not match snapcraft.yaml (${snapcraft_go_juju_version}) for juju"
+		exit_code=1
+	fi
+
+	snapcraft_go_jujud_version="$(yq -r '.parts | .["jujud"] | .["go-channel"]' snap/snapcraft.yaml)"
+	echo "${snapcraft_go_jujud_version}" | grep -q "${target_version}"
+	if [ $? -ne 0 ]; then
+		echo "Go version in go.mod (${target_version}) does not match snapcraft.yaml (${snapcraft_go_jujud_version}) for jujud"
+		exit_code=1
+	fi
+
+	exit "${exit_code}"
+}
+
+run_check_juju_version() {
+	OUT=$(check_juju_version 2>&1 || true)
+	if [ -n "${OUT}" ]; then
+		echo ""
+		echo "$(red 'Found some issues:')"
+		echo "${OUT}"
+		exit 1
+	fi
+}
+
+check_juju_version() {
+	target_version="$(go run version/helper/main.go)"
+
+	snapcraft_juju_version="$(yq -r '.version' snap/snapcraft.yaml)"
+	echo "${snapcraft_juju_version}" | grep -q "${target_version}"
+	if [ $? -ne 0 ]; then
+		echo "Juju version in version/version.go (${target_version}) does not match snapcraft.yaml (${snapcraft_juju_version}) for juju"
+		exit_code=1
+	fi
+
+	win_installer_juju_version="$(cat scripts/win-installer/setup.iss | sed -n 's/.*MyAppVersion="\(.*\)".*/\1/p')"
+	echo "${win_installer_juju_version}" | grep -q "${target_version}"
+	if [ $? -ne 0 ]; then
+		echo "Juju version in version/version.go (${target_version}) does not match setup.iss (${win_installer_juju_version}) for juju"
+		exit_code=1
+	fi
+}
+
+test_versions() {
+	if [ "$(skip 'test_versions')" ]; then
+		echo "==> TEST SKIPPED: versions"
+		return
+	fi
+
+	(
+		set_verbosity
+
+		cd .. || exit
+
+		run_linter "run_check_go_version"
+		run_linter "run_check_juju_version"
+	)
+}


### PR DESCRIPTION
This moves all the static analysis jobs under one job. It fully embraces the
shell static-analysis suite to handle everything. If the ergonomics here are
not nice, we should enhance the shell tests, not the github actions.

## QA steps

Static analysis jobs should pass with no red.

## Documentation changes

N/A

## Links

**Jira card:** JUJU-

