### PR TITLE
feat(domain): add macaroon_root_key table

### DIFF
--- a/domain/schema/controller/sql/0020-macaroon.sql
+++ b/domain/schema/controller/sql/0020-macaroon.sql
@@ -12,3 +12,10 @@ CREATE TABLE bakery_config (
 -- A unique constraint over a constant index ensures only 1 entry matching the
 -- condition can exist.
 CREATE UNIQUE INDEX idx_singleton_bakery_config ON bakery_config ((1));
+
+CREATE TABLE macaroon_root_key (
+    id BLOB PRIMARY KEY,
+    created_at TIMESTAMP NOT NULL,
+    expires_at TIMESTAMP NOT NULL,
+    root_key BLOB NOT NULL
+);

--- a/domain/schema/controller/sql/0020-macaroon.sql
+++ b/domain/schema/controller/sql/0020-macaroon.sql
@@ -1,12 +1,12 @@
 CREATE TABLE bakery_config (
-    local_users_private_key BLOB NOT NULL,
-    local_users_public_key BLOB NOT NULL,
-    local_users_third_party_private_key BLOB NOT NULL,
-    local_users_third_party_public_key BLOB NOT NULL,
-    external_users_third_party_private_key BLOB NOT NULL,
-    external_users_third_party_public_key BLOB NOT NULL,
-    offers_third_party_private_key BLOB NOT NULL,
-    offers_third_party_public_key BLOB NOT NULL
+    local_users_private_key TEXT NOT NULL,
+    local_users_public_key TEXT NOT NULL,
+    local_users_third_party_private_key TEXT NOT NULL,
+    local_users_third_party_public_key TEXT NOT NULL,
+    external_users_third_party_private_key TEXT NOT NULL,
+    external_users_third_party_public_key TEXT NOT NULL,
+    offers_third_party_private_key TEXT NOT NULL,
+    offers_third_party_public_key TEXT NOT NULL
 );
 
 -- A unique constraint over a constant index ensures only 1 entry matching the
@@ -14,8 +14,8 @@ CREATE TABLE bakery_config (
 CREATE UNIQUE INDEX idx_singleton_bakery_config ON bakery_config ((1));
 
 CREATE TABLE macaroon_root_key (
-    id BLOB PRIMARY KEY,
+    id TEXT PRIMARY KEY,
     created_at TIMESTAMP NOT NULL,
     expires_at TIMESTAMP NOT NULL,
-    root_key BLOB NOT NULL
+    root_key TEXT NOT NULL
 );

--- a/domain/schema/schema_test.go
+++ b/domain/schema/schema_test.go
@@ -184,6 +184,7 @@ func (s *schemaSuite) TestControllerTables(c *gc.C) {
 
 		// macaroon bakery
 		"bakery_config",
+		"macaroon_root_key",
 	)
 	got := readEntityNames(c, s.DB(), "table")
 	wanted := expected.Union(internalTableNames)


### PR DESCRIPTION
Add macaroon_root_key table

This will store macaroon bakery root keys. See:
https://github.com/go-macaroon-bakery/macaroon-bakery/blob/f9b21e15a2ed91756aa172972c7178992c7fe6d1/bakery/dbrootkeystore/rootkey.go#L118-L128 

Later, this table will be used to implement a ContextBacking from macaroon-bakery. See:
https://github.com/go-macaroon-bakery/macaroon-bakery/blob/f9b21e15a2ed91756aa172972c7178992c7fe6d1/bakery/dbrootkeystore/rootkey.go#L72-L95

Af a flyby, replace BLOB data types with TEXT

## QA steps

```
juju bootstrap lxd lxd
```