### PR TITLE
feat: set charm

### DIFF
--- a/domain/charm/state/actions.go
+++ b/domain/charm/state/actions.go
@@ -4,6 +4,7 @@
 package state
 
 import (
+	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/domain/charm"
 )
 
@@ -18,6 +19,21 @@ func decodeActions(actions []charmAction) charm.Actions {
 			ExecutionGroup: action.ExecutionGroup,
 			Params:         action.Params,
 		}
+	}
+	return result
+}
+
+func encodeActions(id corecharm.ID, actions charm.Actions) []setCharmAction {
+	result := make([]setCharmAction, 0, len(actions.Actions))
+	for key, action := range actions.Actions {
+		result = append(result, setCharmAction{
+			CharmUUID:      id.String(),
+			Key:            key,
+			Description:    action.Description,
+			Parallel:       action.Parallel,
+			ExecutionGroup: action.ExecutionGroup,
+			Params:         action.Params,
+		})
 	}
 	return result
 }

--- a/domain/charm/state/actions.go
+++ b/domain/charm/state/actions.go
@@ -26,6 +26,9 @@ func decodeActions(actions []charmAction) charm.Actions {
 func encodeActions(id corecharm.ID, actions charm.Actions) []setCharmAction {
 	result := make([]setCharmAction, 0, len(actions.Actions))
 	for key, action := range actions.Actions {
+		if action.Params == nil {
+			action.Params = make([]byte, 0)
+		}
 		result = append(result, setCharmAction{
 			CharmUUID:      id.String(),
 			Key:            key,

--- a/domain/charm/state/actions_test.go
+++ b/domain/charm/state/actions_test.go
@@ -52,7 +52,7 @@ var actionsTestCases = [...]struct {
 	},
 }
 
-func (s *actionsSuite) TestConvertActions(c *gc.C) {
+func (s *actionsSuite) TestDecodeActions(c *gc.C) {
 	for _, tc := range actionsTestCases {
 		c.Logf("Running test case %q", tc.name)
 

--- a/domain/charm/state/actions_test.go
+++ b/domain/charm/state/actions_test.go
@@ -60,3 +60,26 @@ func (s *actionsSuite) TestDecodeActions(c *gc.C) {
 		c.Check(result, gc.DeepEquals, tc.output)
 	}
 }
+
+func (s *actionsSuite) TestEncodeActions(c *gc.C) {
+	for _, tc := range actionsTestCases {
+		c.Logf("Running test case %q", tc.name)
+
+		decoded := decodeActions(tc.input)
+		c.Check(decoded, gc.DeepEquals, tc.output)
+
+		encoded := encodeActions("", decoded)
+
+		result := make([]charmAction, 0, len(tc.input))
+		for _, action := range encoded {
+			result = append(result, charmAction{
+				Key:            action.Key,
+				Description:    action.Description,
+				Parallel:       action.Parallel,
+				ExecutionGroup: action.ExecutionGroup,
+				Params:         action.Params,
+			})
+		}
+		c.Check(result, gc.DeepEquals, tc.input)
+	}
+}

--- a/domain/charm/state/config_test.go
+++ b/domain/charm/state/config_test.go
@@ -4,6 +4,9 @@
 package state
 
 import (
+	"context"
+
+	"github.com/canonical/sqlair"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -138,5 +141,116 @@ func (s *configSuite) TestDecodeConfig(c *gc.C) {
 		result, err := decodeConfig(tc.input)
 		c.Assert(err, jc.ErrorIsNil)
 		c.Check(result, gc.DeepEquals, tc.output)
+	}
+}
+
+func (s *configSuite) TestDecodeConfigType(c *gc.C) {
+	_, err := decodeConfigType("invalid")
+	c.Assert(err, gc.ErrorMatches, `unknown config type "invalid"`)
+}
+
+func (s *configSuite) TestEncodeConfigType(c *gc.C) {
+	_, err := decodeConfigType("invalid")
+	c.Assert(err, gc.ErrorMatches, `unknown config type "invalid"`)
+}
+
+func (s *configSuite) TestEncodeConfigDefaultValue(c *gc.C) {
+	_, err := encodeConfigDefaultValue(int64(0))
+	c.Assert(err, gc.ErrorMatches, `unknown config default value type int64`)
+}
+
+var configTypeTestCases = [...]struct {
+	name   string
+	kind   charm.OptionType
+	input  string
+	output any
+}{
+	{
+		name:   "string",
+		kind:   charm.OptionString,
+		input:  "deadbeef",
+		output: "deadbeef",
+	},
+	{
+		name:   "int",
+		kind:   charm.OptionInt,
+		input:  "42",
+		output: 42,
+	},
+	{
+		name:   "float",
+		kind:   charm.OptionFloat,
+		input:  "42.3",
+		output: 42.3,
+	},
+	{
+		name:   "bool",
+		kind:   charm.OptionBool,
+		input:  "true",
+		output: true,
+	},
+	{
+		name:   "secret",
+		kind:   charm.OptionSecret,
+		input:  "ssh",
+		output: "ssh",
+	},
+}
+
+func (s *configSuite) TestEncodeThenDecodeDefaultValue(c *gc.C) {
+	for _, tc := range configTypeTestCases {
+		c.Logf("Running test case %q", tc.name)
+
+		decoded, err := decodeConfigDefaultValue(tc.kind, tc.input)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Check(decoded, gc.DeepEquals, tc.output)
+
+		encoded, err := encodeConfigDefaultValue(decoded)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Check(encoded, gc.DeepEquals, tc.input)
+	}
+}
+
+func (s *configSuite) TestDecodeConfigTypeError(c *gc.C) {
+	_, err := decodeConfigDefaultValue(charm.OptionType("invalid"), "")
+	c.Assert(err, gc.Not(jc.ErrorIsNil))
+}
+
+type configStateSuite struct {
+	schematesting.ModelSuite
+}
+
+var _ = gc.Suite(&configStateSuite{})
+
+func (s *configStateSuite) TestConfigType(c *gc.C) {
+	type charmConfigType struct {
+		ID   int    `db:"id"`
+		Name string `db:"name"`
+	}
+
+	stmt := sqlair.MustPrepare(`
+SELECT charm_config_type.* AS &charmConfigType.* FROM charm_config_type ORDER BY id;
+`, charmConfigType{})
+
+	var results []charmConfigType
+	err := s.TxnRunner().Txn(context.Background(), func(ctx context.Context, tx *sqlair.TX) error {
+		return tx.Query(ctx, stmt).GetAll(&results)
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, gc.HasLen, 5)
+
+	m := []charm.OptionType{
+		charm.OptionString,
+		charm.OptionInt,
+		charm.OptionFloat,
+		charm.OptionBool,
+		charm.OptionSecret,
+	}
+
+	for i, value := range m {
+		c.Logf("result %d: %#v", i, value)
+		result, err := encodeConfigType(value)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Check(result, gc.DeepEquals, results[i].ID)
 	}
 }

--- a/domain/charm/state/config_test.go
+++ b/domain/charm/state/config_test.go
@@ -131,7 +131,7 @@ var configTestCases = [...]struct {
 	},
 }
 
-func (s *configSuite) TestConvertConfig(c *gc.C) {
+func (s *configSuite) TestDecodeConfig(c *gc.C) {
 	for _, tc := range configTestCases {
 		c.Logf("Running test case %q", tc.name)
 

--- a/domain/charm/state/manifest.go
+++ b/domain/charm/state/manifest.go
@@ -52,6 +52,10 @@ func decodeManifest(manifests []charmManifest) (charm.Manifest, error) {
 		}
 	}
 
+	if len(bases) == 0 {
+		return charm.Manifest{}, nil
+	}
+
 	// Convert the map into a slice using the largest index as the length. This
 	// means that we preserved the order of the bases even faced with holes in
 	// the array.

--- a/domain/charm/state/manifest.go
+++ b/domain/charm/state/manifest.go
@@ -6,7 +6,14 @@ package state
 import (
 	"fmt"
 
+	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/domain/charm"
+)
+
+const (
+	// Default architecture ID used when no architecture is specified.
+	// The default to Juju is amd64.
+	defaultArchitectureID = 0
 )
 
 // decodeManifest decodes the given manifests into a charm.Manifest.
@@ -85,5 +92,92 @@ func decodeManifestChannelRisk(risk string) (charm.ChannelRisk, error) {
 		return charm.RiskEdge, nil
 	default:
 		return "", fmt.Errorf("unknown risk %q", risk)
+	}
+}
+
+func encodeManifest(id corecharm.ID, manifest charm.Manifest) ([]setCharmManifest, error) {
+	result := make([]setCharmManifest, 0, len(manifest.Bases))
+	for index, base := range manifest.Bases {
+		encodedRisk, err := encodeManifestChannelRisk(base.Channel.Risk)
+		if err != nil {
+			return nil, fmt.Errorf("cannot encode risk: %w", err)
+		}
+
+		encodedOS, err := encodeManifestOS(base.Name)
+		if err != nil {
+			return nil, fmt.Errorf("cannot encode OS: %w", err)
+		}
+
+		// No architectures specified, use the default.
+		if len(base.Architectures) == 0 {
+			result = append(result, setCharmManifest{
+				CharmUUID:      id.String(),
+				Index:          index,
+				OSID:           encodedOS,
+				ArchitectureID: defaultArchitectureID,
+				Track:          base.Channel.Track,
+				Risk:           encodedRisk,
+				Branch:         base.Channel.Branch,
+			})
+			continue
+		}
+
+		for _, architecture := range base.Architectures {
+			encodedArch, err := encodeManifestArchitecture(architecture)
+			if err != nil {
+				return nil, fmt.Errorf("cannot encode architecture: %w", err)
+			}
+			result = append(result, setCharmManifest{
+				CharmUUID:      id.String(),
+				Index:          index,
+				OSID:           encodedOS,
+				ArchitectureID: encodedArch,
+				Track:          base.Channel.Track,
+				Risk:           encodedRisk,
+				Branch:         base.Channel.Branch,
+			})
+		}
+	}
+	return result, nil
+}
+
+func encodeManifestChannelRisk(risk charm.ChannelRisk) (string, error) {
+	switch risk {
+	case charm.RiskStable:
+		return "stable", nil
+	case charm.RiskCandidate:
+		return "candidate", nil
+	case charm.RiskBeta:
+		return "beta", nil
+	case charm.RiskEdge:
+		return "edge", nil
+	default:
+		return "", fmt.Errorf("unknown risk %q", risk)
+	}
+}
+
+func encodeManifestOS(os string) (int, error) {
+	switch os {
+	case "ubuntu":
+		return 0, nil
+	default:
+		return -1, fmt.Errorf("unknown OS %q", os)
+	}
+}
+
+func encodeManifestArchitecture(architecture string) (int, error) {
+	switch architecture {
+	case "amd64":
+		return 0, nil
+	case "arm64":
+		return 1, nil
+	case "ppc64el":
+		return 2, nil
+	case "s390x":
+		return 3, nil
+	case "riscv64":
+		return 4, nil
+	default:
+		return -1, fmt.Errorf("unknown architecture %q", architecture)
 	}
 }

--- a/domain/charm/state/manifest_test.go
+++ b/domain/charm/state/manifest_test.go
@@ -1,0 +1,166 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"context"
+
+	"github.com/canonical/sqlair"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/domain/charm"
+	schematesting "github.com/juju/juju/domain/schema/testing"
+)
+
+type manifestSuite struct {
+	schematesting.ModelSuite
+}
+
+var _ = gc.Suite(&manifestSuite{})
+
+var manifestTestCases = [...]struct {
+	name   string
+	input  []charmManifest
+	output charm.Manifest
+}{
+	{
+		name:   "empty",
+		input:  []charmManifest{},
+		output: charm.Manifest{},
+	},
+	{
+		name: "decode base",
+		input: []charmManifest{
+			{
+				Index:        0,
+				OS:           "ubuntu",
+				Track:        "latest",
+				Risk:         "edge",
+				Architecture: "amd64",
+			},
+		},
+		output: charm.Manifest{
+			Bases: []charm.Base{
+				{
+					Name: "ubuntu",
+					Channel: charm.Channel{
+						Track: "latest",
+						Risk:  charm.RiskEdge,
+					},
+					Architectures: []string{"amd64"},
+				},
+			},
+		},
+	},
+	{
+		name: "decode bases",
+		input: []charmManifest{
+			{
+				Index:        0,
+				OS:           "ubuntu",
+				Track:        "latest",
+				Risk:         "edge",
+				Architecture: "amd64",
+			},
+			{
+				Index:        0,
+				OS:           "ubuntu",
+				Track:        "latest",
+				Risk:         "edge",
+				Architecture: "arm64",
+			},
+		},
+		output: charm.Manifest{
+			Bases: []charm.Base{
+				{
+					Name: "ubuntu",
+					Channel: charm.Channel{
+						Track: "latest",
+						Risk:  charm.RiskEdge,
+					},
+					Architectures: []string{"amd64", "arm64"},
+				},
+			},
+		},
+	},
+}
+
+func (s *manifestSuite) TestDecodeManifest(c *gc.C) {
+	for _, tc := range manifestTestCases {
+		c.Logf("Running test case %q", tc.name)
+
+		decoded, err := decodeManifest(tc.input)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Check(decoded, gc.DeepEquals, tc.output)
+	}
+}
+
+type manifestStateSuite struct {
+	schematesting.ModelSuite
+}
+
+var _ = gc.Suite(&manifestStateSuite{})
+
+func (s *manifestStateSuite) TestManifestOS(c *gc.C) {
+	type osType struct {
+		ID   int    `db:"id"`
+		Name string `db:"name"`
+	}
+
+	stmt := sqlair.MustPrepare(`
+SELECT os.* AS &osType.* FROM os ORDER BY id;
+`, osType{})
+
+	var results []osType
+	err := s.TxnRunner().Txn(context.Background(), func(ctx context.Context, tx *sqlair.TX) error {
+		return tx.Query(ctx, stmt).GetAll(&results)
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, gc.HasLen, 1)
+
+	m := []string{
+		"ubuntu",
+	}
+
+	for i, value := range m {
+		c.Logf("result %d: %#v", i, value)
+		result, err := encodeManifestOS(value)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Check(result, gc.DeepEquals, results[i].ID)
+	}
+}
+
+func (s *manifestStateSuite) TestManifestArchitecture(c *gc.C) {
+	type archType struct {
+		ID   int    `db:"id"`
+		Name string `db:"name"`
+	}
+
+	stmt := sqlair.MustPrepare(`
+SELECT architecture.* AS &archType.* FROM architecture ORDER BY id;
+`, archType{})
+
+	var results []archType
+	err := s.TxnRunner().Txn(context.Background(), func(ctx context.Context, tx *sqlair.TX) error {
+		return tx.Query(ctx, stmt).GetAll(&results)
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, gc.HasLen, 5)
+
+	m := []string{
+		"amd64",
+		"arm64",
+		"ppc64el",
+		"s390x",
+		"riscv64",
+	}
+
+	for i, value := range m {
+		c.Logf("result %d: %#v", i, value)
+		result, err := encodeManifestArchitecture(value)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Check(result, gc.DeepEquals, results[i].ID)
+	}
+}

--- a/domain/charm/state/metadata.go
+++ b/domain/charm/state/metadata.go
@@ -414,7 +414,7 @@ func encodeMetadata(id corecharm.ID, metadata charm.Metadata, lxdProfile []byte)
 
 func encodeRunAs(runAs charm.RunAs) (int, error) {
 	switch runAs {
-	case charm.RunAsDefault:
+	case charm.RunAsDefault, "":
 		return 0, nil
 	case charm.RunAsRoot:
 		return 1, nil

--- a/domain/charm/state/state_test.go
+++ b/domain/charm/state/state_test.go
@@ -1810,6 +1810,7 @@ func (s *stateSuite) TestSetCharmThenGetCharmActions(c *gc.C) {
 				Description:    "description2",
 				Parallel:       false,
 				ExecutionGroup: "group2",
+				Params:         make([]byte, 0),
 			},
 		},
 	}

--- a/domain/charm/state/state_test.go
+++ b/domain/charm/state/state_test.go
@@ -1497,6 +1497,50 @@ INSERT INTO charm_manifest_base (
 	})
 }
 
+func (s *stateSuite) TestSetCharmThenGetCharmManifest(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	expected := charm.Manifest{
+		Bases: []charm.Base{
+			{
+				Name: "ubuntu",
+				Channel: charm.Channel{
+					Risk: charm.RiskStable,
+				},
+				Architectures: []string{"amd64", "arm64"},
+			},
+			{
+				Name: "ubuntu",
+				Channel: charm.Channel{
+					Risk:   charm.RiskEdge,
+					Branch: "foo",
+				},
+				Architectures: []string{"amd64"},
+			},
+			{
+				Name: "ubuntu",
+				Channel: charm.Channel{
+					Track:  "4.0",
+					Risk:   charm.RiskBeta,
+					Branch: "baz",
+				},
+				Architectures: []string{"ppc64el"},
+			},
+		},
+	}
+
+	id, err := st.SetCharm(context.Background(), charm.Charm{
+		Metadata: charm.Metadata{
+			Name: "ubuntu",
+		},
+		Manifest: expected,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	got, err := st.GetCharmManifest(context.Background(), id)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(got, gc.DeepEquals, expected)
+}
 func (s *stateSuite) TestGetCharmManifestNotFound(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory())
 
@@ -1614,6 +1658,57 @@ INSERT INTO charm_config (
 	})
 }
 
+func (s *stateSuite) TestSetCharmThenGetCharmConfig(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	expected := charm.Config{
+		Options: map[string]charm.Option{
+			"foo": {
+				Type:        charm.OptionString,
+				Default:     "string",
+				Description: "this is a string",
+			},
+			"bar": {
+				Type:        charm.OptionInt,
+				Default:     42,
+				Description: "this is an int",
+			},
+			"baz": {
+				Type:        charm.OptionBool,
+				Default:     true,
+				Description: "this is a bool",
+			},
+			"alpha": {
+				Type:        charm.OptionFloat,
+				Default:     3.42,
+				Description: "this is a float",
+			},
+			"beta": {
+				Type:        charm.OptionFloat,
+				Default:     float64(3),
+				Description: "this is also a float",
+			},
+			"shh": {
+				Type:        charm.OptionSecret,
+				Default:     "secret",
+				Description: "this is a secret",
+			},
+		},
+	}
+
+	id, err := st.SetCharm(context.Background(), charm.Charm{
+		Metadata: charm.Metadata{
+			Name: "ubuntu",
+		},
+		Config: expected,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	got, err := st.GetCharmConfig(context.Background(), id)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(got, gc.DeepEquals, expected)
+}
+
 func (s *stateSuite) TestGetCharmConfigNotFound(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory())
 
@@ -1691,6 +1786,38 @@ INSERT INTO charm_action (
 			},
 		},
 	})
+}
+
+func (s *stateSuite) TestSetCharmThenGetCharmActions(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	expected := charm.Actions{
+		Actions: map[string]charm.Action{
+			"foo": {
+				Description:    "description1",
+				Parallel:       true,
+				ExecutionGroup: "group1",
+				Params:         []byte("{}"),
+			},
+			"bar": {
+				Description:    "description2",
+				Parallel:       false,
+				ExecutionGroup: "group2",
+			},
+		},
+	}
+
+	id, err := st.SetCharm(context.Background(), charm.Charm{
+		Metadata: charm.Metadata{
+			Name: "ubuntu",
+		},
+		Actions: expected,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	got, err := st.GetCharmActions(context.Background(), id)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(got, gc.DeepEquals, expected)
 }
 
 func (s *stateSuite) TestGetCharmActionsNotFound(c *gc.C) {

--- a/domain/charm/state/state_test.go
+++ b/domain/charm/state/state_test.go
@@ -45,6 +45,13 @@ func (s *stateSuite) TestGetCharmIDByRevision(c *gc.C) {
 	c.Check(charmID, gc.Equals, id)
 }
 
+func (s *stateSuite) TestGetCharmIDByRevisionWithNoCharm(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	_, err := st.GetCharmIDByRevision(context.Background(), "foo", 0)
+	c.Assert(err, jc.ErrorIs, charmerrors.NotFound)
+}
+
 func (s *stateSuite) TestIsControllerCharmWithNoCharm(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory())
 

--- a/domain/charm/state/types.go
+++ b/domain/charm/state/types.go
@@ -288,12 +288,24 @@ type setCharmMount struct {
 // for the all the fields.
 type charmManifest struct {
 	CharmUUID    string `db:"charm_uuid"`
-	Index        int    `db:"idx"`
+	Index        int    `db:"array_index"`
 	Track        string `db:"track"`
 	Risk         string `db:"risk"`
 	Branch       string `db:"branch"`
 	OS           string `db:"os"`
 	Architecture string `db:"architecture"`
+}
+
+// setCharmManifest is used to set the manifest of a charm.
+// This includes the setting of the index.
+type setCharmManifest struct {
+	CharmUUID      string `db:"charm_uuid"`
+	Index          int    `db:"array_index"`
+	Track          string `db:"track"`
+	Risk           string `db:"risk"`
+	Branch         string `db:"branch"`
+	OSID           int    `db:"os_id"`
+	ArchitectureID int    `db:"architecture_id"`
 }
 
 // charmLXDProfile is used to get the LXD profile of a charm.
@@ -312,9 +324,28 @@ type charmConfig struct {
 	Description  string `db:"description"`
 }
 
+// setCharmConfig is used to set the config of a charm.
+type setCharmConfig struct {
+	CharmUUID    string `db:"charm_uuid"`
+	Key          string `db:"key"`
+	TypeID       int    `db:"type_id"`
+	DefaultValue string `db:"default_value"`
+	Description  string `db:"description"`
+}
+
 // charmAction is used to get the actions of a charm.
 // This is a row based struct that is normalised form of a map of actions.
 type charmAction struct {
+	CharmUUID      string `db:"charm_uuid"`
+	Key            string `db:"key"`
+	Description    string `db:"description"`
+	Parallel       bool   `db:"parallel"`
+	ExecutionGroup string `db:"execution_group"`
+	Params         []byte `db:"params"`
+}
+
+// setCharmAction is used to set the actions of a charm.
+type setCharmAction struct {
 	CharmUUID      string `db:"charm_uuid"`
 	Key            string `db:"key"`
 	Description    string `db:"description"`

--- a/domain/charm/state/types.go
+++ b/domain/charm/state/types.go
@@ -49,11 +49,34 @@ type charmMetadata struct {
 	RunAs          string `db:"run_as"`
 }
 
+// setCharmMetadata is used to set the metadata of a charm.
+// This includes the setting of the LXD profile.
+type setCharmMetadata struct {
+	UUID           string `db:"uuid"`
+	Name           string `db:"name"`
+	Summary        string `db:"summary"`
+	Description    string `db:"description"`
+	Subordinate    bool   `db:"subordinate"`
+	MinJujuVersion string `db:"min_juju_version"`
+	Assumes        []byte `db:"assumes"`
+	RunAsID        int    `db:"run_as_id"`
+	LXDProfile     []byte `db:"lxd_profile"`
+}
+
 // charmTag is used to get the tags of a charm.
 // This is a row based struct that is normalised form of an array of strings.
 type charmTag struct {
 	CharmUUID string `db:"charm_uuid"`
 	Tag       string `db:"value"`
+}
+
+// setCharmTag is used to set the tags of a charm.
+// This includes the setting of the index.
+// This is a row based struct that is normalised form of an array of strings.
+type setCharmTag struct {
+	CharmUUID string `db:"charm_uuid"`
+	Tag       string `db:"value"`
+	Index     int    `db:"array_index"`
 }
 
 // charmCategory is used to get the categories of a charm.
@@ -63,11 +86,29 @@ type charmCategory struct {
 	Category  string `db:"value"`
 }
 
+// setCharmCategory is used to set the categories of a charm.
+// This includes the setting of the index.
+// This is a row based struct that is normalised form of an array of strings.
+type setCharmCategory struct {
+	CharmUUID string `db:"charm_uuid"`
+	Category  string `db:"value"`
+	Index     int    `db:"array_index"`
+}
+
 // charmTerm is used to get the terms of a charm.
 // This is a row based struct that is normalised form of an array of strings.
 type charmTerm struct {
 	CharmUUID string `db:"charm_uuid"`
 	Term      string `db:"value"`
+}
+
+// setCharmTerm is used to set the terms of a charm.
+// This includes the setting of the index.
+// This is a row based struct that is normalised form of an array of strings.
+type setCharmTerm struct {
+	CharmUUID string `db:"charm_uuid"`
+	Term      string `db:"value"`
+	Index     int    `db:"array_index"`
 }
 
 // charmRelation is used to get the relations of a charm.
@@ -83,8 +124,28 @@ type charmRelation struct {
 	Scope     string `db:"scope"`
 }
 
+// setCharmRelation is used to set the relations of a charm.
+type setCharmRelation struct {
+	CharmUUID string `db:"charm_uuid"`
+	KindID    int    `db:"kind_id"`
+	Key       string `db:"key"`
+	Name      string `db:"name"`
+	RoleID    int    `db:"role_id"`
+	Interface string `db:"interface"`
+	Optional  bool   `db:"optional"`
+	Capacity  int    `db:"capacity"`
+	ScopeID   int    `db:"scope_id"`
+}
+
 // charmExtraBinding is used to get the extra bindings of a charm.
 type charmExtraBinding struct {
+	CharmUUID string `db:"charm_uuid"`
+	Key       string `db:"key"`
+	Name      string `db:"name"`
+}
+
+// setCharmExtraBinding is used to set the extra bindings of a charm.
+type setCharmExtraBinding struct {
 	CharmUUID string `db:"charm_uuid"`
 	Key       string `db:"key"`
 	Name      string `db:"name"`
@@ -108,8 +169,42 @@ type charmStorage struct {
 	Property    string `db:"property"`
 }
 
+// setCharmStorage is used to set the storage of a charm.
+type setCharmStorage struct {
+	CharmUUID   string `db:"charm_uuid"`
+	Key         string `db:"key"`
+	Name        string `db:"name"`
+	Description string `db:"description"`
+	KindID      int    `db:"storage_kind_id"`
+	Shared      bool   `db:"shared"`
+	ReadOnly    bool   `db:"read_only"`
+	CountMin    int    `db:"count_min"`
+	CountMax    int    `db:"count_max"`
+	MinimumSize uint64 `db:"minimum_size_mib"`
+	Location    string `db:"location"`
+}
+
+// setCharmStorageProperty is used to set the storage property of a charm.
+type setCharmStorageProperty struct {
+	CharmUUID string `db:"charm_uuid"`
+	Key       string `db:"charm_storage_key"`
+	Index     int    `db:"array_index"`
+	Value     string `db:"value"`
+}
+
 // charmDevice is used to get the devices of a charm.
 type charmDevice struct {
+	CharmUUID   string `db:"charm_uuid"`
+	Key         string `db:"key"`
+	Name        string `db:"name"`
+	Description string `db:"description"`
+	DeviceType  string `db:"device_type"`
+	CountMin    int64  `db:"count_min"`
+	CountMax    int64  `db:"count_max"`
+}
+
+// setCharmDevice is used to set the devices of a charm.
+type setCharmDevice struct {
 	CharmUUID   string `db:"charm_uuid"`
 	Key         string `db:"key"`
 	Name        string `db:"name"`
@@ -127,12 +222,30 @@ type charmPayload struct {
 	Type      string `db:"type"`
 }
 
+// setCharmPayload is used to set the payload of a charm.
+type setCharmPayload struct {
+	CharmUUID string `db:"charm_uuid"`
+	Key       string `db:"key"`
+	Name      string `db:"name"`
+	Type      string `db:"type"`
+}
+
 // charmResource is used to get the resources of a charm.
 type charmResource struct {
 	CharmUUID   string `db:"charm_uuid"`
 	Key         string `db:"key"`
 	Name        string `db:"name"`
 	Kind        string `db:"kind"`
+	Path        string `db:"path"`
+	Description string `db:"description"`
+}
+
+// setCharmResource is used to set the resources of a charm.
+type setCharmResource struct {
+	CharmUUID   string `db:"charm_uuid"`
+	Key         string `db:"key"`
+	Name        string `db:"name"`
+	KindID      int    `db:"kind_id"`
 	Path        string `db:"path"`
 	Description string `db:"description"`
 }
@@ -146,6 +259,26 @@ type charmContainer struct {
 	Resource  string `db:"resource"`
 	Uid       int    `db:"uid"`
 	Gid       int    `db:"gid"`
+	Storage   string `db:"storage"`
+	Location  string `db:"location"`
+}
+
+// setCharmContainer is used to set the containers of a charm.
+type setCharmContainer struct {
+	CharmUUID string `db:"charm_uuid"`
+	Key       string `db:"key"`
+	Resource  string `db:"resource"`
+	Uid       int    `db:"uid"`
+	Gid       int    `db:"gid"`
+}
+
+// setCharmMount is used to set the mounts of a charm.
+// This includes the setting of the index.
+// This is a row based struct that is normalised form of an array of strings.
+type setCharmMount struct {
+	CharmUUID string `db:"charm_uuid"`
+	Key       string `db:"charm_container_key"`
+	Index     int    `db:"array_index"`
 	Storage   string `db:"storage"`
 	Location  string `db:"location"`
 }

--- a/domain/schema/model/sql/0015-charm.sql
+++ b/domain/schema/model/sql/0015-charm.sql
@@ -179,11 +179,11 @@ CREATE TABLE charm_relation (
     kind_id TEXT NOT NULL,
     "key" TEXT NOT NULL,
     name TEXT,
-    role_id TEXT,
+    role_id INT,
     interface TEXT,
     optional BOOLEAN,
     capacity INT,
-    scope_id TEXT,
+    scope_id INT,
     CONSTRAINT fk_charm_relation_charm
     FOREIGN KEY (charm_uuid)
     REFERENCES charm (uuid),
@@ -237,12 +237,12 @@ ON charm_extra_binding (charm_uuid);
 -- by 3rd party stores.
 CREATE TABLE charm_category (
     charm_uuid TEXT NOT NULL,
-    "index" INT NOT NULL,
+    array_index INT NOT NULL,
     value TEXT NOT NULL,
     CONSTRAINT fk_charm_category_charm
     FOREIGN KEY (charm_uuid)
     REFERENCES charm (uuid),
-    PRIMARY KEY (charm_uuid, "index", value)
+    PRIMARY KEY (charm_uuid, array_index, value)
 );
 
 CREATE INDEX idx_charm_category_charm
@@ -251,12 +251,12 @@ ON charm_category (charm_uuid);
 -- charm_tag is a free form tag that can be applied to a charm.
 CREATE TABLE charm_tag (
     charm_uuid TEXT NOT NULL,
-    "index" INT NOT NULL,
+    array_index INT NOT NULL,
     value TEXT NOT NULL,
     CONSTRAINT fk_charm_tag_charm
     FOREIGN KEY (charm_uuid)
     REFERENCES charm (uuid),
-    PRIMARY KEY (charm_uuid, "index", value)
+    PRIMARY KEY (charm_uuid, array_index, value)
 );
 
 CREATE INDEX idx_charm_tag_charm
@@ -305,7 +305,7 @@ SELECT
     cs.count_max,
     cs.minimum_size_mib,
     cs.location,
-    csp."index" AS property_index,
+    csp.array_index AS property_index,
     csp.value AS property
 FROM charm_storage AS cs
 LEFT JOIN charm_storage_kind AS csk ON cs.storage_kind_id = csk.id
@@ -317,7 +317,7 @@ ON charm_storage (charm_uuid);
 CREATE TABLE charm_storage_property (
     charm_uuid TEXT NOT NULL,
     charm_storage_key TEXT NOT NULL,
-    "index" INT NOT NULL,
+    array_index INT NOT NULL,
     value TEXT NOT NULL,
     CONSTRAINT fk_charm_storage_property_charm
     FOREIGN KEY (charm_uuid)
@@ -325,7 +325,7 @@ CREATE TABLE charm_storage_property (
     CONSTRAINT fk_charm_storage_property_charm_storage
     FOREIGN KEY (charm_uuid, charm_storage_key)
     REFERENCES charm_storage (charm_uuid, "key"),
-    PRIMARY KEY (charm_uuid, charm_storage_key, "index", value)
+    PRIMARY KEY (charm_uuid, charm_storage_key, array_index, value)
 );
 
 CREATE INDEX idx_charm_storage_property_charm
@@ -406,12 +406,12 @@ ON charm_resource (charm_uuid);
 
 CREATE TABLE charm_term (
     charm_uuid TEXT NOT NULL,
-    "index" INT NOT NULL,
+    array_index INT NOT NULL,
     value TEXT NOT NULL,
     CONSTRAINT fk_charm_term_charm
     FOREIGN KEY (charm_uuid)
     REFERENCES charm (uuid),
-    PRIMARY KEY (charm_uuid, "index", value)
+    PRIMARY KEY (charm_uuid, array_index, value)
 );
 
 CREATE INDEX idx_charm_term_charm
@@ -438,7 +438,7 @@ SELECT
     cc.resource,
     cc.uid,
     cc.gid,
-    ccm."index",
+    ccm.array_index,
     ccm.storage,
     ccm.location
 FROM charm_container AS cc
@@ -448,7 +448,7 @@ CREATE INDEX idx_charm_container_charm
 ON charm_container (charm_uuid);
 
 CREATE TABLE charm_container_mount (
-    "index" INT NOT NULL,
+    array_index INT NOT NULL,
     charm_uuid TEXT NOT NULL,
     charm_container_key TEXT,
     storage TEXT,
@@ -459,7 +459,7 @@ CREATE TABLE charm_container_mount (
     CONSTRAINT fk_charm_container_mount_charm_container
     FOREIGN KEY (charm_uuid, charm_container_key)
     REFERENCES charm_container (charm_uuid, "key"),
-    PRIMARY KEY (charm_uuid, charm_container_key, "index")
+    PRIMARY KEY (charm_uuid, charm_container_key, array_index)
 );
 
 CREATE INDEX idx_charm_container_mount_charm
@@ -489,7 +489,7 @@ CREATE TABLE charm_action (
 
 CREATE TABLE charm_manifest_base (
     charm_uuid TEXT NOT NULL,
-    "index" INT NOT NULL,
+    array_index INT NOT NULL,
     os_id TEXT NOT NULL,
     track TEXT,
     risk TEXT NOT NULL,
@@ -504,13 +504,13 @@ CREATE TABLE charm_manifest_base (
     CONSTRAINT fk_charm_manifest_base_architecture
     FOREIGN KEY (architecture_id)
     REFERENCES architecture (id),
-    PRIMARY KEY (charm_uuid, "index", os_id, track, risk, branch, architecture_id)
+    PRIMARY KEY (charm_uuid, array_index, os_id, track, risk, branch, architecture_id)
 );
 
 CREATE VIEW v_charm_manifest AS
 SELECT
     cmb.charm_uuid,
-    cmb."index" AS idx,
+    cmb.array_index AS idx,
     cmb.track,
     cmb.risk,
     cmb.branch,

--- a/domain/schema/model/sql/0015-charm.sql
+++ b/domain/schema/model/sql/0015-charm.sql
@@ -490,11 +490,11 @@ CREATE TABLE charm_action (
 CREATE TABLE charm_manifest_base (
     charm_uuid TEXT NOT NULL,
     array_index INT NOT NULL,
-    os_id TEXT NOT NULL,
+    os_id INT DEFAULT 0,
     track TEXT,
     risk TEXT NOT NULL,
     branch TEXT,
-    architecture_id TEXT NOT NULL,
+    architecture_id INT DEFAULT 0,
     CONSTRAINT fk_charm_manifest_charm
     FOREIGN KEY (charm_uuid)
     REFERENCES charm (uuid),
@@ -510,7 +510,7 @@ CREATE TABLE charm_manifest_base (
 CREATE VIEW v_charm_manifest AS
 SELECT
     cmb.charm_uuid,
-    cmb.array_index AS idx,
+    cmb.array_index,
     cmb.track,
     cmb.risk,
     cmb.branch,


### PR DESCRIPTION
Adds set charm to the charm domain. The set charm works with partial data, so not all data is required to be present to be able to set the charm initially. Work will be required to locate exactly what is needed to be updated, therefore there will not be an update charm call. It will be broken down to, updateMetadata, updateLXDProfile etc. This should remove the need to write complex queries to update in place.

The code is very laborious, yet plain. It just sets the information in the right places using the database row types. Tweaks to the schema was required to ensure that we insert the right data at the right index. The index field was renamed from `index` to `array_index`, to better reflect its intention.

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

The state tests should pass.


## Links

**Jira card:** [JUJU-6015](https://warthogs.atlassian.net/browse/JUJU-6015)



[JUJU-6015]: https://warthogs.atlassian.net/browse/JUJU-6015?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ