### PR TITLE
feat(migration): prevent pre-4.0 models with fan config to be migrated

### DIFF
--- a/api/controller/migrationmaster/client.go
+++ b/api/controller/migrationmaster/client.go
@@ -151,12 +151,15 @@ func (c *Client) ModelInfo() (migration.ModelInfo, error) {
 		return migration.ModelInfo{}, errors.Trace(err)
 	}
 
+	// The model description is marshalled into YAML (description package does
+	// not support JSON) to prevent potential issues with
+	// marshalling/unmarshalling on the target API controller.
 	var modelDescription description.Model
 	if bytes := info.ModelDescription; len(bytes) > 0 {
 		var err error
 		modelDescription, err = description.Deserialize(info.ModelDescription)
 		if err != nil {
-			return migration.ModelInfo{}, errors.Trace(err)
+			return migration.ModelInfo{}, errors.Annotate(err, "failed to marshal model description")
 		}
 	}
 

--- a/api/controller/migrationtarget/client_test.go
+++ b/api/controller/migrationtarget/client_test.go
@@ -87,7 +87,7 @@ func (s *ClientSuite) TestPrechecks(c *gc.C) {
 	mc := jc.NewMultiChecker()
 	mc.AddExpr("_.FacadeVersions", gc.Not(gc.HasLen), 0)
 
-	c.Assert(arg, mc, expectedArg)
+	c.Check(arg, mc, expectedArg)
 }
 
 func (s *ClientSuite) TestImport(c *gc.C) {

--- a/apiserver/facades/client/controller/controller.go
+++ b/apiserver/facades/client/controller/controller.go
@@ -946,7 +946,7 @@ var runMigrationPrechecks = func(
 		}
 	}
 	err = client.Prechecks(modelInfo)
-	return errors.Annotate(err, "target prechecks failed")
+	return errors.Annotate(err, "target prechecks failed 2")
 }
 
 // userList encapsulates information about the users who have been granted

--- a/apiserver/facades/client/controller/register.go
+++ b/apiserver/facades/client/controller/register.go
@@ -21,6 +21,7 @@ func Register(registry facade.FacadeRegistry) {
 
 // newControllerAPIv11 creates a new ControllerAPIv11
 func newControllerAPIv11(stdCtx context.Context, ctx facade.ModelContext) (*ControllerAPI, error) {
+
 	var (
 		st             = ctx.State()
 		authorizer     = ctx.Auth()

--- a/apiserver/facades/controller/migrationtarget/migrationtarget.go
+++ b/apiserver/facades/controller/migrationtarget/migrationtarget.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/juju/description/v6"
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 	"github.com/vallerion/rscanner"
@@ -163,6 +164,15 @@ func checkAuth(authorizer facade.Authorizer, st *state.State) error {
 // Prechecks ensure that the target controller is ready to accept a
 // model migration.
 func (api *API) Prechecks(ctx context.Context, model params.MigrationModelInfo) error {
+	var modelDescription description.Model
+	if serialized := model.ModelDescription; len(serialized) > 0 {
+		var err error
+		modelDescription, err = description.Deserialize(model.ModelDescription)
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+
 	// If there are no required migration facade versions, then we
 	// don't need to check anything.
 	if len(api.requiredMigrationFacadeVersions) > 0 {
@@ -209,7 +219,7 @@ with an earlier version of the target controller and try again.
 	if err != nil {
 		return errors.Annotate(err, "creating backend")
 	}
-	return migration.TargetPrecheck(
+	if err := migration.TargetPrecheck(
 		ctx,
 		backend,
 		migration.PoolShim(api.pool),
@@ -219,10 +229,14 @@ with an earlier version of the target controller and try again.
 			Owner:                  ownerTag,
 			AgentVersion:           model.AgentVersion,
 			ControllerAgentVersion: model.ControllerAgentVersion,
+			ModelDescription:       modelDescription,
 		},
 		api.presence.ModelPresence(controllerState.ModelUUID()),
 		api.upgradeService,
-	)
+	); err != nil {
+		return errors.Annotate(err, "migration target prechecks failed")
+	}
+	return nil
 }
 
 // Import takes a serialized Juju model, deserializes it, and


### PR DESCRIPTION
This patch adds the pre-checks on the target controller (+4.0) for validating that no fan networking is imported into it.

These are the two checks on model configs:
- Make sure fan-config is empty.
- Make sure container-networking-method is not "fan".

The second check was added only as a safeguard, because normally you cannot set it without setting fan-config to some value. And the fan-config being empty is the first check we perform when migrating.

This was done thanks to the work introduced in
https://github.com/juju/juju/pull/17623 which provides the model description on migration prechecks.


## Checklist


- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Bootstrap a 3.6 (must be edge to include the needed changes) controller and a 4.0 (this branch) one, then add some model-config to the 3.6 model:
```
sudo snap install juju_36 --channel 3.6/edge
juju_36 bootstrap lxd src36                    
juju_36 add-model m
juju_36 model-config fan-config=10.0.0.0/16=252.0.0.0/8 
# Build juju from this PR and bootstrap a target controller:
juju bootstrap lxd tgt40
juju switch src36:m
```
Now, when trying to migrate, you should get an error because you have added a fan-config model config:
```
juju migrate src36:m tgt40
ERROR target prechecks failed: migration target prechecks failed: fan networking not supported, fan config 10.0.0.0/16=252.0.0.0/8
```
If you remove the fan-config and try to migrate again, it should work:
```
juju model-config fan-config=
juju migrate src36:m tgt40
Migration started with ID "76ca38dc-e9c9-48ac-886e-d4e930c015ce:0"
```

## Links

**Jira card:** JUJU-6045

