### PR TITLE
fix: change stream test composition

### DIFF
--- a/internal/changestream/stream/package_test.go
+++ b/internal/changestream/stream/package_test.go
@@ -74,8 +74,12 @@ func (s *baseSuite) expectAfter() chan<- time.Time {
 	return ch
 }
 
-func (s *baseSuite) expectAfterAnyTimes() {
+func (s *baseSuite) expectTermAfterAnyTimes() {
 	s.clock.EXPECT().After(defaultWaitTermTimeout).Return(make(chan time.Time)).AnyTimes()
+}
+
+func (s *baseSuite) expectAnyAfterAnyTimes() {
+	s.clock.EXPECT().After(gomock.Any()).Return(make(chan time.Time)).AnyTimes()
 }
 
 func (s *baseSuite) expectBackoffAnyTimes(done chan struct{}) {
@@ -106,5 +110,5 @@ func (s *baseSuite) expectMetrics() {
 }
 
 func (s *baseSuite) expectClock() {
-	s.clock.EXPECT().Now().AnyTimes()
+	s.clock.EXPECT().Now().Return(time.Now()).AnyTimes()
 }

--- a/internal/changestream/stream/stream_test.go
+++ b/internal/changestream/stream/stream_test.go
@@ -85,7 +85,7 @@ func (s *streamSuite) TestOneChange(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	s.expectFileNotifyWatcher()
-	s.expectAfterAnyTimes()
+	s.expectAnyAfterAnyTimes()
 	s.expectTimer()
 	s.expectClock()
 	s.expectMetrics()
@@ -123,7 +123,7 @@ func (s *streamSuite) TestOneChangeDoesNotRepeatSameChange(c *gc.C) {
 	defer close(done)
 
 	s.expectFileNotifyWatcher()
-	s.expectAfterAnyTimes()
+	s.expectTermAfterAnyTimes()
 	s.expectBackoffAnyTimes(done)
 	s.expectTimer()
 	s.expectClock()
@@ -179,7 +179,7 @@ func (s *streamSuite) TestOneChangeWithEmptyResults(c *gc.C) {
 	defer close(done)
 
 	s.expectFileNotifyWatcher()
-	s.expectAfterAnyTimes()
+	s.expectTermAfterAnyTimes()
 	s.expectBackoffAnyTimes(done)
 	s.expectTimer()
 	s.expectClock()
@@ -215,7 +215,7 @@ func (s *streamSuite) TestOneChangeWithClosedAbort(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	s.expectFileNotifyWatcher()
-	s.expectAfterAnyTimes()
+	s.expectTermAfterAnyTimes()
 	s.expectTimer()
 	s.expectClock()
 	s.expectMetrics()
@@ -254,7 +254,7 @@ func (s *streamSuite) TestOneChangeWithDelayedTermDone(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	s.expectFileNotifyWatcher()
-	s.expectAfterAnyTimes()
+	s.expectTermAfterAnyTimes()
 	s.expectTimer()
 	s.expectClock()
 	s.expectMetrics()
@@ -293,7 +293,7 @@ func (s *streamSuite) TestOneChangeWithTermDoneAfterKill(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	s.expectFileNotifyWatcher()
-	s.expectAfterAnyTimes()
+	s.expectTermAfterAnyTimes()
 	s.expectTimer()
 	s.expectClock()
 	s.expectMetrics()
@@ -379,7 +379,7 @@ func (s *streamSuite) TestMultipleTerms(c *gc.C) {
 	defer close(done)
 
 	s.expectFileNotifyWatcher()
-	s.expectAfterAnyTimes()
+	s.expectTermAfterAnyTimes()
 	s.expectBackoffAnyTimes(done)
 	s.expectTimer()
 	s.expectClock()
@@ -484,7 +484,7 @@ func (s *streamSuite) TestSecondTermDoesNotStartUntilFirstTermDone(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	s.expectFileNotifyWatcher()
-	s.expectAfterAnyTimes()
+	s.expectTermAfterAnyTimes()
 	s.expectTimer()
 	s.expectClock()
 	s.expectMetrics()
@@ -559,7 +559,7 @@ func (s *streamSuite) TestSecondTermDoesNotStartUntilFirstTermDone(c *gc.C) {
 func (s *streamSuite) TestMultipleChangesWithSameUUIDCoalesce(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.expectAfterAnyTimes()
+	s.expectTermAfterAnyTimes()
 	s.expectFileNotifyWatcher()
 	s.expectTimer()
 	s.expectClock()
@@ -619,7 +619,7 @@ func (s *streamSuite) TestMultipleChangesWithSameUUIDCoalesce(c *gc.C) {
 func (s *streamSuite) TestMultipleChangesWithNamespaces(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.expectAfterAnyTimes()
+	s.expectTermAfterAnyTimes()
 	s.expectFileNotifyWatcher()
 	s.expectTimer()
 	s.expectClock()
@@ -669,7 +669,7 @@ func (s *streamSuite) TestMultipleChangesWithNamespaces(c *gc.C) {
 func (s *streamSuite) TestMultipleChangesWithNamespacesCoalesce(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.expectAfterAnyTimes()
+	s.expectTermAfterAnyTimes()
 	s.expectFileNotifyWatcher()
 	s.expectTimer()
 	s.expectClock()
@@ -734,7 +734,7 @@ func (s *streamSuite) TestMultipleChangesWithNamespacesCoalesce(c *gc.C) {
 func (s *streamSuite) TestMultipleChangesWithNoNamespacesDoNotCoalesce(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.expectAfterAnyTimes()
+	s.expectTermAfterAnyTimes()
 	s.expectFileNotifyWatcher()
 	s.expectTimer()
 	s.expectClock()
@@ -809,7 +809,7 @@ func (s *streamSuite) TestMultipleChangesWithNoNamespacesDoNotCoalesce(c *gc.C) 
 func (s *streamSuite) TestOneChangeIsBlockedByFile(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.expectAfterAnyTimes()
+	s.expectTermAfterAnyTimes()
 	s.expectTimer()
 	s.expectClock()
 	s.expectMetrics()
@@ -882,7 +882,7 @@ func (s *streamSuite) TestReport(c *gc.C) {
 	done := make(chan struct{})
 	defer close(done)
 
-	s.expectAfterAnyTimes()
+	s.expectTermAfterAnyTimes()
 	s.expectBackoffAnyTimes(done)
 	s.expectFileNotifyWatcher()
 	s.expectClock()
@@ -981,7 +981,7 @@ func (s *streamSuite) TestWatermarkWrite(c *gc.C) {
 	done := make(chan struct{})
 	defer close(done)
 
-	s.expectAfterAnyTimes()
+	s.expectTermAfterAnyTimes()
 	s.expectBackoffAnyTimes(done)
 	s.expectFileNotifyWatcher()
 	s.expectClock()
@@ -1045,7 +1045,7 @@ func (s *streamSuite) TestWatermarkWriteIsIgnored(c *gc.C) {
 	done := make(chan struct{})
 	defer close(done)
 
-	s.expectAfterAnyTimes()
+	s.expectTermAfterAnyTimes()
 	s.expectBackoffAnyTimes(done)
 	s.expectFileNotifyWatcher()
 	s.expectClock()
@@ -1109,7 +1109,7 @@ func (s *streamSuite) TestWatermarkWriteUpdatesToTheLaterOne(c *gc.C) {
 	done := make(chan struct{})
 	defer close(done)
 
-	s.expectAfterAnyTimes()
+	s.expectTermAfterAnyTimes()
 	s.expectBackoffAnyTimes(done)
 	s.expectFileNotifyWatcher()
 	s.expectClock()

--- a/internal/logger/testing/check.go
+++ b/internal/logger/testing/check.go
@@ -42,7 +42,7 @@ func formatMsg(level, name, msg string) string {
 	if name == "" {
 		return fmt.Sprintf("%s: ", level) + msg
 	}
-	return fmt.Sprintf("%s: %s", level, name) + msg
+	return fmt.Sprintf("%s: %s ", level, name) + msg
 }
 
 func (c checkLogger) Criticalf(msg string, args ...any) {


### PR DESCRIPTION
The TestOneChange assumed it would do one and only one loop of the stream. Except that every so often it wouldn't be killed in time and it would start to do another loop. There were no changes to the process, so would get stuck waiting for a time-out because we only mock the term timeout, not the back-off strategy. The solution for just this test is to allow it to be mocked at any time because we don't care for this test. Alternatively, it would be better to pass in two clocks, one for the back-off and another for the other common use cases. This would allow for better control over testing.

In addition to the test changes, to better aid debugging, I've added the long-needed traces support.

<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://docs.google.com/document/d/1SYUo9G7qZ_jdoVXpUVamS5VCgHmtZ0QA-wZxKoMS-C0 
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

This is only a test composition, so just running:

```sh
$ go test -v ./internal/changestream/stream -check.vv -check.f="^TestOneChange" -race -count=100
```

A smoke test is always good though

```sh
$ juju bootstrap lxd test
$ juju add-model default
$ juju deploy ubuntu
```


## Links

**Jira card:** [JUJU-6354](https://warthogs.atlassian.net/browse/JUJU-6354)



[JUJU-6354]: https://warthogs.atlassian.net/browse/JUJU-6354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ