### PR TITLE
fix: use unique error for session token login

### DIFF
--- a/api/sessiontokenloginprovider.go
+++ b/api/sessiontokenloginprovider.go
@@ -64,9 +64,8 @@ func (p *sessionTokenLoginProvider) Login(ctx context.Context, caller base.APICa
 	if err == nil {
 		return result, nil
 	}
-
-	if params.ErrCode(err) == params.CodeUnauthorized {
-		// if we fail with an "unauthorized" error, we initiate a
+	if params.ErrCode(err) == params.CodeSessionTokenInvalid {
+		// if we fail because of an invalid session token, we initiate a
 		// new device login.
 		if err := p.initiateDeviceLogin(ctx, caller); err != nil {
 			return nil, errors.Trace(err)

--- a/api/sessiontokenloginprovider.go
+++ b/api/sessiontokenloginprovider.go
@@ -64,7 +64,7 @@ func (p *sessionTokenLoginProvider) Login(ctx context.Context, caller base.APICa
 	if err == nil {
 		return result, nil
 	}
-	if params.ErrCode(err) == params.CodeSessionTokenInvalid {
+	if params.IsCodeSessionTokenInvalid(err) {
 		// if we fail because of an invalid session token, we initiate a
 		// new device login.
 		if err := p.initiateDeviceLogin(ctx, caller); err != nil {

--- a/rpc/params/apierror.go
+++ b/rpc/params/apierror.go
@@ -271,6 +271,12 @@ func IsCodeUnauthorized(err error) bool {
 	return ErrCode(err) == CodeUnauthorized
 }
 
+// IsCodeSessionTokenInvalid returns true if err includes a SessionTokenInvalid
+// error code.
+func IsCodeSessionTokenInvalid(err error) bool {
+	return ErrCode(err) == CodeSessionTokenInvalid
+}
+
 func IsCodeNoCreds(err error) bool {
 	// When we receive this error from an rpc call, rpc.RequestError
 	// is populated with a CodeUnauthorized code and a message that

--- a/rpc/params/apierror.go
+++ b/rpc/params/apierror.go
@@ -150,6 +150,7 @@ const (
 	CodeUserNotFound              = "user not found"
 	CodeModelNotFound             = "model not found"
 	CodeUnauthorized              = "unauthorized access"
+	CodeSessionTokenInvalid       = "session token invalid"
 	CodeLoginExpired              = "login expired"
 	CodeNoCreds                   = "no credentials provided"
 	CodeCannotEnterScope          = "cannot enter scope"


### PR DESCRIPTION
This is a minor but important change for Juju CLI clients interacting with JAAS. Tests have also been updated.

The current implementation of the Juju CLI uses the sessionTokenLoginProvider to login to JAAS. This login method uses the device code login flow, i.e. it:
- Tries to login with the client's session token.
- If the error returned is a specific code, it starts the device flow login described below.
- The server returns a URL where the user must go to login.
- The server polls the server waiting for the user to login.
- The server returns a session token to the client.
- The client tries to login again with the session token.

Currently, the specific error code is `CodeUnauthorized`. This is a poor choice because it is possible for Juju to return this code as a valid error unrelated to login. In cases like these the user is suddenly asked to login again when in fact they should simply be presented with the error.

This PR changes the expected error to a unique code. The code is only used in tests/the login provider. JAAS will use this error in its implementation.

**NB!** Unfortunately this change will cause a breakage between the Juju CLI and JAAS but because JAAS is not in widespread usage yet, it is better to fix the issue before then.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] ~~Code style: imports ordered, good names, simple structure, etc~~
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~~
- [ ] ~~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~~

## QA steps

Requires a JIMM instance to QA:
- Add 2 LXD Juju controllers to JIMM.
- Create a model.
- Initiate and complete a migration of the model.
- Run `juju status` (which retries on failure).
- Observe a loop where a login prompt is repeatedly printed.

With the changes from this PR:
- Build the CLI with the latest changes, no more login loop.

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Jira card:** JAAS Jira card [CSS-9575](https://warthogs.atlassian.net/browse/CSS-9575)



[CSS-9575]: https://warthogs.atlassian.net/browse/CSS-9575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ