### PR TITLE
feat(macaroons): implement root key service + state

### DIFF
--- a/domain/macaroon/errors/errors.go
+++ b/domain/macaroon/errors/errors.go
@@ -1,0 +1,16 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package errors
+
+import "github.com/juju/errors"
+
+const (
+	// KeyNotFound describes an error that occurs when a requested root key
+	// cannot be found
+	KeyNotFound = errors.ConstError("root key not found")
+
+	// KeyAlreadyExists describes an error that occurs when there is a clash
+	// when manipulating root keys
+	KeyAlreadyExists = errors.ConstError("root key already exists")
+)

--- a/domain/macaroon/service/config_test.go
+++ b/domain/macaroon/service/config_test.go
@@ -12,20 +12,20 @@ import (
 	gc "gopkg.in/check.v1"
 )
 
-type serviceSuite struct {
+type configServiceSuite struct {
 	st *MockState
 }
 
-var _ = gc.Suite(&serviceSuite{})
+var _ = gc.Suite(&configServiceSuite{})
 
-func (s *serviceSuite) setupMocks(c *gc.C) *gomock.Controller {
+func (s *configServiceSuite) setupMocks(c *gc.C) *gomock.Controller {
 	ctrl := gomock.NewController(c)
 
 	s.st = NewMockState(ctrl)
 	return ctrl
 }
 
-func (s *serviceSuite) TestInitialise(c *gc.C) {
+func (s *configServiceSuite) TestInitialise(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	s.st.EXPECT().InitialiseBakeryConfig(
@@ -41,7 +41,7 @@ func (s *serviceSuite) TestInitialise(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *serviceSuite) TestGetLocalUsersKey(c *gc.C) {
+func (s *configServiceSuite) TestGetLocalUsersKey(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	testKey := bakery.MustGenerateKey()
@@ -53,7 +53,7 @@ func (s *serviceSuite) TestGetLocalUsersKey(c *gc.C) {
 	c.Assert(key, gc.DeepEquals, testKey)
 }
 
-func (s *serviceSuite) TestGetLocalUsersThirdPartyKey(c *gc.C) {
+func (s *configServiceSuite) TestGetLocalUsersThirdPartyKey(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	testKey := bakery.MustGenerateKey()
@@ -65,7 +65,7 @@ func (s *serviceSuite) TestGetLocalUsersThirdPartyKey(c *gc.C) {
 	c.Assert(key, gc.DeepEquals, testKey)
 }
 
-func (s *serviceSuite) TestGetExternalUsersThirdPartyKey(c *gc.C) {
+func (s *configServiceSuite) TestGetExternalUsersThirdPartyKey(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	testKey := bakery.MustGenerateKey()
@@ -77,7 +77,7 @@ func (s *serviceSuite) TestGetExternalUsersThirdPartyKey(c *gc.C) {
 	c.Assert(key, gc.DeepEquals, testKey)
 }
 
-func (s *serviceSuite) TestGetOffersThirdPartyKey(c *gc.C) {
+func (s *configServiceSuite) TestGetOffersThirdPartyKey(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	testKey := bakery.MustGenerateKey()

--- a/domain/macaroon/service/package_mock_test.go
+++ b/domain/macaroon/service/package_mock_test.go
@@ -12,8 +12,10 @@ package service
 import (
 	context "context"
 	reflect "reflect"
+	time "time"
 
 	bakery "github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
+	macaroon "github.com/juju/juju/domain/macaroon"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -38,6 +40,45 @@ func NewMockState(ctrl *gomock.Controller) *MockState {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockState) EXPECT() *MockStateMockRecorder {
 	return m.recorder
+}
+
+// FindLatestKey mocks base method.
+func (m *MockState) FindLatestKey(arg0 context.Context, arg1, arg2, arg3 time.Time) (macaroon.RootKey, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindLatestKey", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(macaroon.RootKey)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindLatestKey indicates an expected call of FindLatestKey.
+func (mr *MockStateMockRecorder) FindLatestKey(arg0, arg1, arg2, arg3 any) *MockStateFindLatestKeyCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindLatestKey", reflect.TypeOf((*MockState)(nil).FindLatestKey), arg0, arg1, arg2, arg3)
+	return &MockStateFindLatestKeyCall{Call: call}
+}
+
+// MockStateFindLatestKeyCall wrap *gomock.Call
+type MockStateFindLatestKeyCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateFindLatestKeyCall) Return(arg0 macaroon.RootKey, arg1 error) *MockStateFindLatestKeyCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateFindLatestKeyCall) Do(f func(context.Context, time.Time, time.Time, time.Time) (macaroon.RootKey, error)) *MockStateFindLatestKeyCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateFindLatestKeyCall) DoAndReturn(f func(context.Context, time.Time, time.Time, time.Time) (macaroon.RootKey, error)) *MockStateFindLatestKeyCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
 }
 
 // GetExternalUsersThirdPartyKey mocks base method.
@@ -75,6 +116,45 @@ func (c *MockStateGetExternalUsersThirdPartyKeyCall) Do(f func(context.Context) 
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockStateGetExternalUsersThirdPartyKeyCall) DoAndReturn(f func(context.Context) (*bakery.KeyPair, error)) *MockStateGetExternalUsersThirdPartyKeyCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetKey mocks base method.
+func (m *MockState) GetKey(arg0 context.Context, arg1 []byte) (macaroon.RootKey, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetKey", arg0, arg1)
+	ret0, _ := ret[0].(macaroon.RootKey)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetKey indicates an expected call of GetKey.
+func (mr *MockStateMockRecorder) GetKey(arg0, arg1 any) *MockStateGetKeyCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetKey", reflect.TypeOf((*MockState)(nil).GetKey), arg0, arg1)
+	return &MockStateGetKeyCall{Call: call}
+}
+
+// MockStateGetKeyCall wrap *gomock.Call
+type MockStateGetKeyCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateGetKeyCall) Return(arg0 macaroon.RootKey, arg1 error) *MockStateGetKeyCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateGetKeyCall) Do(f func(context.Context, []byte) (macaroon.RootKey, error)) *MockStateGetKeyCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateGetKeyCall) DoAndReturn(f func(context.Context, []byte) (macaroon.RootKey, error)) *MockStateGetKeyCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -230,6 +310,44 @@ func (c *MockStateInitialiseBakeryConfigCall) Do(f func(context.Context, *bakery
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockStateInitialiseBakeryConfigCall) DoAndReturn(f func(context.Context, *bakery.KeyPair, *bakery.KeyPair, *bakery.KeyPair, *bakery.KeyPair) error) *MockStateInitialiseBakeryConfigCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// InsertKey mocks base method.
+func (m *MockState) InsertKey(arg0 context.Context, arg1 macaroon.RootKey) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InsertKey", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// InsertKey indicates an expected call of InsertKey.
+func (mr *MockStateMockRecorder) InsertKey(arg0, arg1 any) *MockStateInsertKeyCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertKey", reflect.TypeOf((*MockState)(nil).InsertKey), arg0, arg1)
+	return &MockStateInsertKeyCall{Call: call}
+}
+
+// MockStateInsertKeyCall wrap *gomock.Call
+type MockStateInsertKeyCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateInsertKeyCall) Return(arg0 error) *MockStateInsertKeyCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateInsertKeyCall) Do(f func(context.Context, macaroon.RootKey) error) *MockStateInsertKeyCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateInsertKeyCall) DoAndReturn(f func(context.Context, macaroon.RootKey) error) *MockStateInsertKeyCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/macaroon/service/rootkeys.go
+++ b/domain/macaroon/service/rootkeys.go
@@ -1,0 +1,133 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package service
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/dbrootkeystore"
+	"github.com/juju/errors"
+
+	"github.com/juju/juju/domain/macaroon"
+	macaroonerrors "github.com/juju/juju/domain/macaroon/errors"
+)
+
+// RootKeyState describes the persistence layer for
+// macaroon root keys
+type RootKeyState interface {
+	// GetKey gets the key with a given id from state. If not key is found, a
+	// macaroonerrors.KeyNotFound error is returned.
+	GetKey(ctx context.Context, id []byte) (macaroon.RootKey, error)
+
+	// FindLatestKey returns the most recently created root key k following all
+	// the conditions:
+	//
+	// k.Created >= createdAfter
+	// k.Expires >= expiresAfter
+	// k.Expires <= expiresBefore
+	//
+	// If no such key was found, return a macaroonerrors.KeyNotFound error
+	FindLatestKey(ctx context.Context, createdAfter, expiresAfter, expiresBefore time.Time) (macaroon.RootKey, error)
+
+	// InsertKey inserts the given root key into state. If a key with matching
+	// id already exists, return a macaroonerrors.KeyAlreadyExists error.
+	InsertKey(ctx context.Context, key macaroon.RootKey) error
+}
+
+// RootKeyService provides the API for macaroon root key storage
+//
+// RootKeyService satisfies dbrootkeystore.Backing and dbrootkeystore.ContextBacking
+// https://github.com/go-macaroon-bakery/macaroon-bakery/blob/f9b21e15a2ed91756aa172972c7178992c7fe6d1/bakery/dbrootkeystore/rootkey.go#L48-L95
+//
+// This means RootKeyService can be used to construct a bakery.RootKeyStore.
+//
+// NOTE: We implement dbrootkeystore.Backing with stub methods. This is because
+// RootKeyStore only requires a ContextBacking, but due to pecularities with
+// the RootKeyStore constructor, we also need to implement Backing.
+// TODO(jack-w-shaw): Once https://github.com/go-macaroon-bakery/macaroon-bakery/pull/301
+// has been released, use NewContextStore & drop Backing stub methods
+type RootKeyService struct {
+	st RootKeyState
+}
+
+// NewRootKeyService returns a new service for managing macaroon root keys
+func NewRootKeyService(st RootKeyState) *RootKeyService {
+	return &RootKeyService{
+		st: st,
+	}
+}
+
+// GetKey is a stub method required to implement dbrootstore.Backing. Do not use
+func (s *RootKeyService) GetKey(id []byte) (dbrootkeystore.RootKey, error) {
+	return dbrootkeystore.RootKey{}, errors.NotImplementedf("GetKey")
+}
+
+// GetKeyContext (dbrootkeystore.GetKeyContext) gets the key
+// with a given id from dqlite.
+//
+// To satisfy dbrootkeystore.ContextBacking specification,
+// if not key is found, a bakery.ErrNotFound error is returned.
+func (s *RootKeyService) GetKeyContext(ctx context.Context, id []byte) (dbrootkeystore.RootKey, error) {
+	key, err := s.st.GetKey(ctx, id)
+	if errors.Is(err, macaroonerrors.KeyNotFound) {
+		return dbrootkeystore.RootKey{}, bakery.ErrNotFound
+	}
+	return decodeRootKey(key), nil
+}
+
+// FindLatestKey is a stub method required to implement dbrootstore.Backing. Do not use
+func (s *RootKeyService) FindLatestKey(createdAfter, expiresAfter, expiresBefore time.Time) (dbrootkeystore.RootKey, error) {
+	return dbrootkeystore.RootKey{}, errors.NotImplementedf("FindLatestKey")
+}
+
+// FindLatestKeyContext (dbrootkeystore.FindLatestKeyContext) returns
+// the most recently created root key k following all
+// the conditions:
+//
+// k.Created >= createdAfter
+// k.Expires >= expiresAfter
+// k.Expires <= expiresBefore
+//
+// To satisfy dbrootkeystore.FindLatestKeyContext specification,
+// if no such key is found, the zero root key is returned with a
+// nil error
+func (s *RootKeyService) FindLatestKeyContext(ctx context.Context, createdAfter, expiresAfter, expiresBefore time.Time) (dbrootkeystore.RootKey, error) {
+	key, err := s.st.FindLatestKey(ctx, createdAfter, expiresAfter, expiresBefore)
+	if errors.Is(err, macaroonerrors.KeyNotFound) {
+		return dbrootkeystore.RootKey{}, nil
+	}
+	return decodeRootKey(key), err
+}
+
+// InsertKey is a stub method required to implement dbrootstore.Backing. Do not use
+func (s *RootKeyService) InsertKey(key dbrootkeystore.RootKey) error {
+	return errors.NotImplementedf("InsertKey")
+}
+
+// InsertKeyContext (dbrootkeystore.InsertKeyContext) inserts
+// the given root key into state. If a key with matching
+// id already exists, return a macaroonerrors.KeyAlreadyExists error.
+func (s *RootKeyService) InsertKeyContext(ctx context.Context, key dbrootkeystore.RootKey) error {
+	return s.st.InsertKey(ctx, encodeRootKey(key))
+}
+
+func encodeRootKey(k dbrootkeystore.RootKey) macaroon.RootKey {
+	return macaroon.RootKey{
+		ID:      k.Id,
+		Created: k.Created,
+		Expires: k.Expires,
+		RootKey: k.RootKey,
+	}
+}
+
+func decodeRootKey(k macaroon.RootKey) dbrootkeystore.RootKey {
+	return dbrootkeystore.RootKey{
+		Id:      k.ID,
+		Created: k.Created,
+		Expires: k.Expires,
+		RootKey: k.RootKey,
+	}
+}

--- a/domain/macaroon/service/rootkeys_test.go
+++ b/domain/macaroon/service/rootkeys_test.go
@@ -1,0 +1,129 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package service
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
+	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/dbrootkeystore"
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	"go.uber.org/mock/gomock"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/domain/macaroon"
+	macaroonerrors "github.com/juju/juju/domain/macaroon/errors"
+)
+
+var _ dbrootkeystore.Backing = &RootKeyService{}
+var _ dbrootkeystore.ContextBacking = &RootKeyService{}
+
+type rootKeyServiceSuite struct {
+	st *MockState
+}
+
+var _ = gc.Suite(&rootKeyServiceSuite{})
+
+var key = dbrootkeystore.RootKey{
+	Id:      []byte("0"),
+	Created: time.Now(),
+	Expires: time.Now().Add(2 * time.Second),
+	RootKey: []byte("key0"),
+}
+
+func (s *rootKeyServiceSuite) setupMocks(c *gc.C) *gomock.Controller {
+	ctrl := gomock.NewController(c)
+
+	s.st = NewMockState(ctrl)
+	return ctrl
+}
+
+func (s *rootKeyServiceSuite) TestStubMethods(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	srv := NewRootKeyService(s.st)
+
+	_, err := srv.GetKey([]byte("0"))
+	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
+
+	_, err = srv.FindLatestKey(time.Now(), time.Now(), time.Now())
+	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
+
+	err = srv.InsertKey(dbrootkeystore.RootKey{})
+	c.Assert(err, jc.ErrorIs, errors.NotImplemented)
+}
+
+func (s *rootKeyServiceSuite) TestGetKeyContext(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	id := []byte("0")
+	s.st.EXPECT().GetKey(gomock.Any(), id).Return(encodeRootKey(key), nil)
+	srv := NewRootKeyService(s.st)
+
+	res, err := srv.GetKeyContext(context.Background(), id)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(res, gc.DeepEquals, key)
+}
+
+func (s *rootKeyServiceSuite) TestGetKeyContextNotFound(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	id := []byte("0")
+	s.st.EXPECT().GetKey(gomock.Any(), id).Return(macaroon.RootKey{}, macaroonerrors.KeyNotFound)
+	srv := NewRootKeyService(s.st)
+
+	_, err := srv.GetKeyContext(context.Background(), id)
+	c.Assert(err, jc.ErrorIs, bakery.ErrNotFound)
+}
+
+func (s *rootKeyServiceSuite) TestFindLatestKeyContext(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	createdAfter := time.Now()
+	expiresAfter := time.Now().Add(-time.Second)
+	expiresBefore := time.Now().Add(time.Second)
+	s.st.EXPECT().FindLatestKey(gomock.Any(), createdAfter, expiresAfter, expiresBefore).Return(encodeRootKey(key), nil)
+	srv := NewRootKeyService(s.st)
+
+	res, err := srv.FindLatestKeyContext(context.Background(), createdAfter, expiresAfter, expiresBefore)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(res, gc.DeepEquals, key)
+}
+
+func (s *rootKeyServiceSuite) TestFindLatestKeyContextNotFound(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	createdAfter := time.Now()
+	expiresAfter := time.Now().Add(-time.Second)
+	expiresBefore := time.Now().Add(time.Second)
+	s.st.EXPECT().FindLatestKey(gomock.Any(), createdAfter, expiresAfter, expiresBefore).Return(macaroon.RootKey{}, macaroonerrors.KeyNotFound)
+	srv := NewRootKeyService(s.st)
+
+	res, err := srv.FindLatestKeyContext(context.Background(), createdAfter, expiresAfter, expiresBefore)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(res, gc.DeepEquals, dbrootkeystore.RootKey{})
+}
+
+func (s *rootKeyServiceSuite) TestInsertKeyContext(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.st.EXPECT().InsertKey(gomock.Any(), encodeRootKey(key))
+	srv := NewRootKeyService(s.st)
+
+	err := srv.InsertKeyContext(context.Background(), key)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *rootKeyServiceSuite) TestInsertKeyContextError(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	boom := errors.Errorf("boom")
+	s.st.EXPECT().InsertKey(gomock.Any(), encodeRootKey(key)).Return(boom)
+	srv := NewRootKeyService(s.st)
+
+	err := srv.InsertKeyContext(context.Background(), key)
+	c.Assert(err, gc.Equals, boom)
+}

--- a/domain/macaroon/service/service.go
+++ b/domain/macaroon/service/service.go
@@ -7,12 +7,14 @@ package service
 // storage required for this service
 type State interface {
 	BakeryConfigState
+	RootKeyState
 }
 
 // Service provides the API for managing the macaroon bakery
 // storage
 type Service struct {
 	*BakeryConfigService
+	*RootKeyService
 }
 
 // NewService returns a new Service providing an API to manage
@@ -20,5 +22,6 @@ type Service struct {
 func NewService(st State) *Service {
 	return &Service{
 		BakeryConfigService: NewBakeryConfigService(st),
+		RootKeyService:      NewRootKeyService(st),
 	}
 }

--- a/domain/macaroon/state/config.go
+++ b/domain/macaroon/state/config.go
@@ -16,8 +16,8 @@ import (
 	internaldatabase "github.com/juju/juju/internal/database"
 )
 
-// BakeryConfigState describes the persistence layer to
-// store bakery config
+// BakeryConfigState describes the persistence layer for
+// the macaroon bakery config
 type BakeryConfigState struct {
 	*domain.StateBase
 }

--- a/domain/macaroon/state/config_test.go
+++ b/domain/macaroon/state/config_test.go
@@ -21,19 +21,19 @@ var (
 	testKey4 = bakery.MustGenerateKey()
 )
 
-type stateSuite struct {
+type configStateSuite struct {
 	testing.ControllerSuite
 }
 
-var _ = gc.Suite(&stateSuite{})
+var _ = gc.Suite(&configStateSuite{})
 
-func (s *stateSuite) TestInitialise(c *gc.C) {
+func (s *configStateSuite) TestInitialise(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory())
 	err := st.InitialiseBakeryConfig(context.Background(), testKey1, testKey2, testKey3, testKey4)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *stateSuite) TestInitialiseMultipleTimesFails(c *gc.C) {
+func (s *configStateSuite) TestInitialiseMultipleTimesFails(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory())
 	err := st.InitialiseBakeryConfig(context.Background(), testKey1, testKey2, testKey3, testKey4)
 	c.Assert(err, jc.ErrorIsNil)
@@ -42,7 +42,7 @@ func (s *stateSuite) TestInitialiseMultipleTimesFails(c *gc.C) {
 	c.Assert(err, jc.ErrorIs, BakeryConfigAlreadyInitialised)
 }
 
-func (s *stateSuite) TestGetKeys(c *gc.C) {
+func (s *configStateSuite) TestGetKeys(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory())
 	err := st.InitialiseBakeryConfig(context.Background(), testKey1, testKey2, testKey3, testKey4)
 	c.Assert(err, jc.ErrorIsNil)
@@ -64,7 +64,7 @@ func (s *stateSuite) TestGetKeys(c *gc.C) {
 	c.Check(keypair, gc.DeepEquals, testKey4)
 }
 
-func (s *stateSuite) TestGetKeysUninitialised(c *gc.C) {
+func (s *configStateSuite) TestGetKeysUninitialised(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory())
 	_, err := st.GetLocalUsersKey(context.Background())
 	c.Check(err, jc.ErrorIs, errors.NotYetAvailable)

--- a/domain/macaroon/state/rootkeys.go
+++ b/domain/macaroon/state/rootkeys.go
@@ -1,0 +1,137 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"context"
+	"time"
+
+	"github.com/canonical/sqlair"
+	"github.com/juju/errors"
+
+	coredatabase "github.com/juju/juju/core/database"
+	"github.com/juju/juju/domain"
+	"github.com/juju/juju/domain/macaroon"
+	macaroonerrors "github.com/juju/juju/domain/macaroon/errors"
+	"github.com/juju/juju/internal/database"
+)
+
+// RootKeyState describes the persistence layer for
+// macaroon root keys
+type RootKeyState struct {
+	*domain.StateBase
+}
+
+// NewRootKeyState return a new macaroon root key state reference
+func NewRootKeyState(factory coredatabase.TxnRunnerFactory) *RootKeyState {
+	return &RootKeyState{
+		StateBase: domain.NewStateBase(factory),
+	}
+}
+
+// GetKey gets the key with a given id from dqlite. If not key is found, a
+// macaroonerrors.KeyNotFound error is returned.
+func (st *RootKeyState) GetKey(ctx context.Context, id []byte) (macaroon.RootKey, error) {
+	db, err := st.DB()
+	if err != nil {
+		return macaroon.RootKey{}, errors.Trace(err)
+	}
+	key := rootKeyID{ID: id}
+	getKeyStmt, err := st.Prepare("SELECT &rootKey.* FROM macaroon_root_key WHERE id = $rootKeyID.id", rootKey{}, key)
+	if err != nil {
+		return macaroon.RootKey{}, errors.Annotate(err, "preparing get root key statement")
+	}
+
+	var result rootKey
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		err := tx.Query(ctx, getKeyStmt, key).Get(&result)
+		if database.IsErrNotFound(err) {
+			return errors.Annotatef(macaroonerrors.KeyNotFound, "key with id %s", string(id))
+		}
+		return domain.CoerceError(err)
+	})
+	return macaroon.RootKey{
+		ID:      result.ID,
+		Created: result.Created,
+		Expires: result.Expires,
+		RootKey: result.RootKey,
+	}, errors.Trace(err)
+}
+
+// FindLatestKey returns the most recently created root key k following all
+// the conditions:
+//
+// k.Created >= createdAfter
+// k.Expires >= expiresAfter
+// k.Expires <= expiresBefore
+//
+// If no such key was found, return a macaroonerrors.KeyNotFound error
+func (st *RootKeyState) FindLatestKey(ctx context.Context, createdAfter, expiresAfter, expiresBefore time.Time) (macaroon.RootKey, error) {
+	db, err := st.DB()
+	if err != nil {
+		return macaroon.RootKey{}, errors.Trace(err)
+	}
+
+	m := sqlair.M{
+		"created_after":  createdAfter,
+		"expires_after":  expiresAfter,
+		"expires_before": expiresBefore,
+	}
+
+	q := `
+SELECT &rootKey.*
+FROM   macaroon_root_key
+WHERE  created_at >= $M.created_after
+AND    expires_at >= $M.expires_after
+AND    expires_at <= $M.expires_before
+ORDER BY created_at DESC
+`
+	stmt, err := st.Prepare(q, rootKey{}, m)
+	if err != nil {
+		return macaroon.RootKey{}, errors.Annotatef(err, "preparing get latest key statement")
+	}
+
+	var result rootKey
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		err := tx.Query(ctx, stmt, m).Get(&result)
+		if database.IsErrNotFound(err) {
+			return macaroonerrors.KeyNotFound
+		}
+		return domain.CoerceError(err)
+	})
+	return macaroon.RootKey{
+		ID:      result.ID,
+		Created: result.Created,
+		Expires: result.Expires,
+		RootKey: result.RootKey,
+	}, errors.Trace(err)
+}
+
+// InsertKey inserts the given root key into dqlite. If a key with matching
+// id already exists, return a macaroonerrors.KeyAlreadyExists error.
+func (st *RootKeyState) InsertKey(ctx context.Context, key macaroon.RootKey) error {
+	db, err := st.DB()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	row := rootKey{
+		ID:      key.ID,
+		Created: key.Created,
+		Expires: key.Expires,
+		RootKey: key.RootKey,
+	}
+	insertKeyStmt, err := st.Prepare("INSERT INTO macaroon_root_key (*) VALUES ($rootKey.*)", row)
+	if err != nil {
+		return errors.Annotate(err, "preparing insert root key statement")
+	}
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		err := tx.Query(ctx, insertKeyStmt, row).Run()
+		if database.IsErrConstraintPrimaryKey(err) {
+			return errors.Annotatef(macaroonerrors.KeyAlreadyExists, "key with id %s", string(key.ID))
+		}
+		return domain.CoerceError(err)
+	})
+	return errors.Trace(err)
+}

--- a/domain/macaroon/state/rootkeys_test.go
+++ b/domain/macaroon/state/rootkeys_test.go
@@ -1,0 +1,174 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"context"
+	"math"
+	"time"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/domain/macaroon"
+	"github.com/juju/juju/domain/macaroon/errors"
+	"github.com/juju/juju/internal/changestream/testing"
+)
+
+type rootKeyStateSuite struct {
+	testing.ControllerSuite
+}
+
+var _ = gc.Suite(&rootKeyStateSuite{})
+
+var (
+	key0 = macaroon.RootKey{
+		ID:      []byte("0"),
+		Created: time.Now(),
+		Expires: time.Now().Add(2 * time.Second),
+		RootKey: []byte("key0"),
+	}
+
+	key1 = macaroon.RootKey{
+		ID:      []byte("1"),
+		Created: time.Now().Add(2 * time.Second),
+		Expires: time.Now().Add(4 * time.Second),
+		RootKey: []byte("key1"),
+	}
+
+	key2 = macaroon.RootKey{
+		ID:      []byte("2"),
+		Created: time.Now().Add(4 * time.Second),
+		Expires: time.Now().Add(8 * time.Second),
+		RootKey: []byte("key2"),
+	}
+
+	key3 = macaroon.RootKey{
+		ID:      []byte("3"),
+		Created: time.Now().Add(6 * time.Second),
+		Expires: time.Now().Add(6 * time.Second),
+		RootKey: []byte("key3"),
+	}
+
+	key4 = macaroon.RootKey{
+		ID:      []byte("4"),
+		Created: time.Now().Add(-time.Second),
+		Expires: time.Now().Add(-time.Second),
+		RootKey: []byte("key4"),
+	}
+)
+
+func (s *rootKeyStateSuite) TestInsertAndGetKey(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+	ctx := context.Background()
+
+	_, err := st.GetKey(ctx, key0.ID)
+	c.Assert(err, jc.ErrorIs, errors.KeyNotFound)
+
+	err = st.InsertKey(ctx, key0)
+	c.Assert(err, jc.ErrorIsNil)
+
+	res, err := st.GetKey(context.Background(), key0.ID)
+	c.Assert(err, jc.ErrorIsNil)
+	compareRootKeys(c, key0, res)
+}
+
+func (s *rootKeyStateSuite) TestInsertKeyIDUniqueness(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+	ctx := context.Background()
+
+	_, err := st.GetKey(ctx, key0.ID)
+	c.Assert(err, jc.ErrorIs, errors.KeyNotFound)
+
+	err = st.InsertKey(ctx, key0)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = st.InsertKey(ctx, key0)
+	c.Assert(err, jc.ErrorIs, errors.KeyAlreadyExists)
+}
+
+func (s *rootKeyStateSuite) TestFindLatestKeyReturnsMostRecent(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+	ctx := context.Background()
+	addAllKeys(c, st)
+
+	res, err := st.FindLatestKey(ctx, time.Unix(0, 0), time.Unix(0, 0), time.Unix(math.MaxInt64, 0))
+	c.Assert(err, jc.ErrorIsNil)
+	compareRootKeys(c, key3, res)
+}
+
+func (s *rootKeyStateSuite) TestFindLatestKeyExpiresAfter(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+	ctx := context.Background()
+	addAllKeys(c, st)
+
+	res, err := st.FindLatestKey(ctx, time.Unix(0, 0), time.Now().Add(7*time.Second), time.Unix(math.MaxInt64, 0))
+	c.Assert(err, jc.ErrorIsNil)
+	compareRootKeys(c, key2, res)
+}
+
+func (s *rootKeyStateSuite) TestFindLatestKeyCreatedAfter(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+	ctx := context.Background()
+	addAllKeys(c, st)
+
+	res, err := st.FindLatestKey(ctx, time.Unix(0, 0), time.Unix(0, 0), time.Unix(math.MaxInt64, 0))
+	c.Assert(err, jc.ErrorIsNil)
+	compareRootKeys(c, key3, res)
+
+	_, err = st.FindLatestKey(ctx, time.Unix(math.MaxInt64, 0), time.Unix(0, 0), time.Unix(math.MaxInt64, 0))
+	c.Assert(err, jc.ErrorIs, errors.KeyNotFound)
+}
+
+func (s *rootKeyStateSuite) TestFindLatestKeyExpiresBefore(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+	ctx := context.Background()
+	addAllKeys(c, st)
+
+	res, err := st.FindLatestKey(ctx, time.Unix(0, 0), time.Unix(0, 0), time.Now().Add(5*time.Second))
+	c.Assert(err, jc.ErrorIsNil)
+	compareRootKeys(c, key1, res)
+
+	res, err = st.FindLatestKey(ctx, time.Unix(0, 0), time.Unix(0, 0), time.Now().Add(3*time.Second))
+	c.Assert(err, jc.ErrorIsNil)
+	compareRootKeys(c, key0, res)
+
+	_, err = st.FindLatestKey(ctx, time.Unix(0, 0), time.Unix(0, 0), time.Now().Add(-2*time.Second))
+	c.Assert(err, jc.ErrorIs, errors.KeyNotFound)
+}
+
+func (s *rootKeyStateSuite) TestFindLatestKeyEquality(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+	ctx := context.Background()
+	addAllKeys(c, st)
+
+	res, err := st.FindLatestKey(ctx, key3.Created, key3.Expires, key3.Expires)
+	c.Assert(err, jc.ErrorIsNil)
+	compareRootKeys(c, key3, res)
+
+	_, err = st.FindLatestKey(ctx, key3.Created.Add(1*time.Millisecond), key3.Expires, key3.Expires)
+	c.Assert(err, jc.ErrorIs, errors.KeyNotFound)
+}
+
+func addAllKeys(c *gc.C, st *State) {
+	ctx := context.Background()
+
+	err := st.InsertKey(ctx, key0)
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.InsertKey(ctx, key1)
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.InsertKey(ctx, key2)
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.InsertKey(ctx, key3)
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.InsertKey(ctx, key4)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func compareRootKeys(c *gc.C, k1, k2 macaroon.RootKey) {
+	c.Assert(k1.ID, gc.DeepEquals, k2.ID)
+	c.Assert(k1.RootKey, gc.DeepEquals, k2.RootKey)
+	c.Assert(k1.Created.Compare(k2.Created), gc.Equals, 0)
+	c.Assert(k1.Expires.Compare(k2.Expires), gc.Equals, 0)
+}

--- a/domain/macaroon/state/state.go
+++ b/domain/macaroon/state/state.go
@@ -11,11 +11,13 @@ import (
 // bakery storage
 type State struct {
 	*BakeryConfigState
+	*RootKeyState
 }
 
 // NewState returns a new state reference
 func NewState(factory database.TxnRunnerFactory) *State {
 	return &State{
 		BakeryConfigState: NewBakeryConfigState(factory),
+		RootKeyState:      NewRootKeyState(factory),
 	}
 }

--- a/domain/macaroon/state/types.go
+++ b/domain/macaroon/state/types.go
@@ -5,6 +5,7 @@ package state
 
 import (
 	"database/sql/driver"
+	"time"
 
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
 	"github.com/juju/errors"
@@ -66,4 +67,17 @@ func (kv *keyScanner) Scan(v any) error {
 // Value implements the driver.Valuer interface
 func (kv *keyScanner) Value() (driver.Value, error) {
 	return kv.key[:], nil
+}
+
+// rootKey holds the state representation of dbrootkeystore.RootKey
+// complete with `db` tags for sqlair
+type rootKey struct {
+	ID      []byte    `db:"id"`
+	Created time.Time `db:"created_at"`
+	Expires time.Time `db:"expires_at"`
+	RootKey []byte    `db:"root_key"`
+}
+
+type rootKeyID struct {
+	ID []byte `db:"id"`
 }

--- a/domain/macaroon/types.go
+++ b/domain/macaroon/types.go
@@ -1,0 +1,16 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package macaroon
+
+import (
+	"time"
+)
+
+// RootKey holds the internal representation of dbrootkeystore.rootKey
+type RootKey struct {
+	ID      []byte
+	Created time.Time
+	Expires time.Time
+	RootKey []byte
+}


### PR DESCRIPTION
Implement macaroon root key service and backing state in DQLite

This service will later be used to construct a bakery.RootKeyStore. As such, the interfaces I have had to implement are nicely described here:

https://github.com/go-macaroon-bakery/macaroon-bakery/blob/f9b21e15a2ed91756aa172972c7178992c7fe6d1/bakery/dbrootkeystore/rootkey.go#L48-L95

Backing, however, only need to be stubs due to peculiarities with the bakery.RootKeyStore constructor.

As a flyby, rename bakery config test suites to be more specific.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```
go test github.com/juju/juju/domain/macaroon/...
```