### PR TITLE
chore(watchers): add generic test watcher including gocheck

### DIFF
--- a/core/watcher/watchertest/secrets.go
+++ b/core/watcher/watchertest/secrets.go
@@ -5,128 +5,49 @@ package watchertest
 
 import (
 	"sort"
-	"time"
 
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/watcher"
-	"github.com/juju/juju/internal/testing"
+	"github.com/juju/juju/internal/utils"
 )
 
-// SecretsTriggerWatcherC embeds a gocheck.C and adds methods to help
-// verify the behaviour of any watcher that uses a
-// <-chan []SecretTriggerChange
-type SecretsTriggerWatcherC struct {
-	*gc.C
-	Watcher watcher.SecretTriggerWatcher
-}
-
-// NewSecretsTriggerWatcherC returns a SecretsTriggerWatcherC that
-// checks for aggressive event coalescence.
-func NewSecretsTriggerWatcherC(c *gc.C, w watcher.SecretTriggerWatcher) SecretsTriggerWatcherC {
-	return SecretsTriggerWatcherC{
-		C:       c,
-		Watcher: w,
-	}
-}
-
-func (c SecretsTriggerWatcherC) AssertNoChange() {
-	select {
-	case actual, ok := <-c.Watcher.Changes():
-		c.Fatalf("watcher sent unexpected change: (%v, %v)", actual, ok)
-	case <-time.After(testing.ShortWait):
-	}
-}
-
-// AssertChange asserts the given changes was reported by the watcher,
-// but does not assume there are no following changes.
-func (c SecretsTriggerWatcherC) AssertChange(expect ...watcher.SecretTriggerChange) {
-	var received []watcher.SecretTriggerChange
-	timeout := time.After(testing.LongWait)
-	for a := testing.LongAttempt.Start(); a.Next(); {
-		select {
-		case actual, ok := <-c.Watcher.Changes():
-			c.Logf("Secrets Trigger Watcher.Changes() => %# v", actual)
-			c.Assert(ok, jc.IsTrue)
-			received = append(received, actual...)
-			if len(received) >= len(expect) {
-				mc := jc.NewMultiChecker()
-				mc.AddExpr(`_[_].NextTriggerTime`, jc.Almost, jc.ExpectedValue)
-				c.Assert(received, mc, expect)
-				return
-			}
-		case <-timeout:
-			c.Fatalf("watcher did not send change")
+// SecretTriggerTimeAssert is an assert function used as parameter for the
+// generic WatcherC. It asserts that the `NextTriggerTime` in the
+// `SecretTriggerChange` is "almost" as the passed expected value.
+// It returns true if the assertion is correct (meaning that the listening
+// loop in WatcherC can break).
+func SecretTriggerTimeAssert(expected ...watcher.SecretTriggerChange) func(c *gc.C, received [][]watcher.SecretTriggerChange) bool {
+	return func(c *gc.C, received [][]watcher.SecretTriggerChange) bool {
+		flattened := utils.Flatten(received)
+		if len(flattened) >= len(expected) {
+			mc := jc.NewMultiChecker()
+			mc.AddExpr(`_[_].NextTriggerTime`, jc.Almost, jc.ExpectedValue)
+			c.Assert(flattened, mc, expected)
+			return true
 		}
+		return false
 	}
 }
 
-func (c SecretsTriggerWatcherC) AssertClosed() {
-	select {
-	case _, ok := <-c.Watcher.Changes():
-		c.Assert(ok, jc.IsFalse)
-	default:
-		c.Fatalf("watcher not closed")
-	}
-}
-
-// SecretBackendRotateWatcherC embeds a gocheck.C and adds methods to help
-// verify the behaviour of any watcher that uses a
-// <-chan []SecretBackendRotateChange
-type SecretBackendRotateWatcherC struct {
-	*gc.C
-	Watcher watcher.SecretBackendRotateWatcher
-}
-
-// NewSecretBackendRotateWatcherC returns a SecretBackendRotateWatcherC that
-// checks for aggressive event coalescence.
-func NewSecretBackendRotateWatcherC(c *gc.C, w watcher.SecretBackendRotateWatcher) SecretBackendRotateWatcherC {
-	return SecretBackendRotateWatcherC{
-		C:       c,
-		Watcher: w,
-	}
-}
-
-func (c SecretBackendRotateWatcherC) AssertNoChange() {
-	select {
-	case actual, ok := <-c.Watcher.Changes():
-		c.Fatalf("watcher sent unexpected change: (%v, %v)", actual, ok)
-	case <-time.After(testing.ShortWait):
-	}
-}
-
-// AssertChanges asserts the given changes was reported by the watcher,
-// but does not assume there are no following changes.
-func (c SecretBackendRotateWatcherC) AssertChanges(expect ...watcher.SecretBackendRotateChange) {
-	var received []watcher.SecretBackendRotateChange
-	timeout := time.After(testing.LongWait)
-	for a := testing.LongAttempt.Start(); a.Next(); {
-		select {
-		case actual, ok := <-c.Watcher.Changes():
-			c.Logf("Secrets Trigger Watcher.Changes() => %# v", actual)
-			c.Assert(ok, jc.IsTrue)
-			sort.Slice(actual, func(i, j int) bool {
-				return actual[i].Name < actual[j].Name
-			})
-			received = append(received, actual...)
-			if len(received) >= len(expect) {
-				mc := jc.NewMultiChecker()
-				mc.AddExpr(`_[_].NextTriggerTime`, jc.Almost, jc.ExpectedValue)
-				c.Assert(received, mc, expect)
-				return
-			}
-		case <-timeout:
-			c.Fatalf("watcher did not send change")
+// SecretBackendRotateTriggerTimeAssert is an assert function used as parameter
+// for the generic WatcherC. It asserts that the `NextTriggerTime` in the
+// `SecretBackendRotateChange` is "almost" as the passed expected value.
+// It returns true if the assertion is correct (meaning that the listening
+// loop in WatcherC can break).
+func SecretBackendRotateTriggerTimeAssert(expected ...watcher.SecretBackendRotateChange) func(c *gc.C, received [][]watcher.SecretBackendRotateChange) bool {
+	return func(c *gc.C, received [][]watcher.SecretBackendRotateChange) bool {
+		flattened := utils.Flatten(received)
+		sort.Slice(flattened, func(i, j int) bool {
+			return flattened[i].Name < flattened[j].Name
+		})
+		if len(flattened) >= len(expected) {
+			mc := jc.NewMultiChecker()
+			mc.AddExpr(`_[_].NextTriggerTime`, jc.Almost, jc.ExpectedValue)
+			c.Assert(flattened, mc, expected)
+			return true
 		}
-	}
-}
-
-func (c SecretBackendRotateWatcherC) AssertClosed() {
-	select {
-	case _, ok := <-c.Watcher.Changes():
-		c.Assert(ok, jc.IsFalse)
-	default:
-		c.Fatalf("watcher not closed")
+		return false
 	}
 }

--- a/core/watcher/watchertest/watcher.go
+++ b/core/watcher/watchertest/watcher.go
@@ -4,11 +4,14 @@
 package watchertest
 
 import (
+	"time"
+
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v4/workertest"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/watcher"
+	"github.com/juju/juju/internal/testing"
 )
 
 // CleanKill calls CheckKill with the supplied arguments, and Checks that the
@@ -42,5 +45,51 @@ func DirtyKill[T any](c *gc.C, w watcher.Watcher[T]) {
 	_, ok := <-w.Changes()
 	if !ok {
 		c.Logf("ignoring failed to close for watcher")
+	}
+}
+
+// WatcherC embeds a gocheck.C and adds methods to help
+// verify the behaviour of generic watchers.
+type WatcherC[T any] struct {
+	C       *gc.C
+	Watcher watcher.Watcher[T]
+}
+
+// NewWatcherC() returns a WatcherC[T].
+func NewWatcherC[T any](c *gc.C, w watcher.Watcher[T]) WatcherC[T] {
+	return WatcherC[T]{
+		C:       c,
+		Watcher: w,
+	}
+}
+
+// AssertNoChange verifies that no changes are received from the watcher during
+// a testing.ShortWait time.
+func (w *WatcherC[T]) AssertNoChange() {
+	select {
+	case actual, ok := <-w.Watcher.Changes():
+		w.C.Fatalf("watcher sent unexpected change: (%v, %v)", actual, ok)
+	case <-time.After(testing.ShortWait):
+	}
+}
+
+// AssertChange asserts the given changes was reported by the watcher,
+// but does not assume there are no following changes.
+func (w *WatcherC[T]) AssertChange(assertion func(c *gc.C, received []T) bool) {
+	var received []T
+	timeout := time.After(testing.LongWait)
+	for a := testing.LongAttempt.Start(); a.Next(); {
+		select {
+		case actual, ok := <-w.Watcher.Changes():
+			w.C.Logf("WatcherC Watcher.Changes() => %# v", actual)
+			w.C.Assert(ok, jc.IsTrue)
+			received = append(received, actual)
+			w.C.Logf("received %+v", received)
+			if assertion(w.C, received) {
+				return
+			}
+		case <-timeout:
+			w.C.Fatalf("watcher did not send change")
+		}
 	}
 }

--- a/domain/secret/service/service_test.go
+++ b/domain/secret/service/service_test.go
@@ -1723,7 +1723,7 @@ func (s *serviceSuite) TestWatchSecretsRotationChanges(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(w, gc.NotNil)
 	defer workertest.CleanKill(c, w)
-	wC := watchertest.NewSecretsTriggerWatcherC(c, w)
+	wC := watchertest.NewWatcherC(c, w)
 
 	select {
 	case ch <- []string{uri1.ID, uri2.ID}:
@@ -1732,16 +1732,18 @@ func (s *serviceSuite) TestWatchSecretsRotationChanges(c *gc.C) {
 	}
 
 	wC.AssertChange(
-		watcher.SecretTriggerChange{
-			URI:             uri1,
-			Revision:        1,
-			NextTriggerTime: now,
-		},
-		watcher.SecretTriggerChange{
-			URI:             uri2,
-			Revision:        2,
-			NextTriggerTime: now.Add(2 * time.Hour),
-		},
+		watchertest.SecretTriggerTimeAssert([]watcher.SecretTriggerChange{
+			{
+				URI:             uri1,
+				Revision:        1,
+				NextTriggerTime: now,
+			},
+			{
+				URI:             uri2,
+				Revision:        2,
+				NextTriggerTime: now.Add(2 * time.Hour),
+			},
+		}...),
 	)
 	wC.AssertNoChange()
 }
@@ -1806,7 +1808,7 @@ func (s *serviceSuite) TestWatchSecretRevisionsExpiryChanges(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(w, gc.NotNil)
 	defer workertest.CleanKill(c, w)
-	wC := watchertest.NewSecretsTriggerWatcherC(c, w)
+	wC := watchertest.NewWatcherC(c, w)
 
 	select {
 	case ch <- []string{"revision-uuid-1", "revision-uuid-2"}:
@@ -1815,16 +1817,18 @@ func (s *serviceSuite) TestWatchSecretRevisionsExpiryChanges(c *gc.C) {
 	}
 
 	wC.AssertChange(
-		watcher.SecretTriggerChange{
-			URI:             uri1,
-			Revision:        1,
-			NextTriggerTime: now,
-		},
-		watcher.SecretTriggerChange{
-			URI:             uri2,
-			Revision:        2,
-			NextTriggerTime: now.Add(2 * time.Hour),
-		},
+		watchertest.SecretTriggerTimeAssert([]watcher.SecretTriggerChange{
+			{
+				URI:             uri1,
+				Revision:        1,
+				NextTriggerTime: now,
+			},
+			{
+				URI:             uri2,
+				Revision:        2,
+				NextTriggerTime: now.Add(2 * time.Hour),
+			},
+		}...),
 	)
 	wC.AssertNoChange()
 }

--- a/domain/secret/watcher_test.go
+++ b/domain/secret/watcher_test.go
@@ -591,10 +591,10 @@ func (s *watcherSuite) TestWatchSecretsRotationChanges(c *gc.C) {
 	c.Assert(watcher, gc.NotNil)
 	defer workertest.CleanKill(c, watcher)
 
-	wc := watchertest.NewSecretsTriggerWatcherC(c, watcher)
+	wc := watchertest.NewWatcherC(c, watcher)
 
 	// Wait for the initial changes.
-	wc.AssertChange([]corewatcher.SecretTriggerChange(nil)...)
+	wc.AssertChange(watchertest.SecretTriggerTimeAssert([]corewatcher.SecretTriggerChange(nil)...))
 	wc.AssertNoChange()
 
 	now := time.Now()
@@ -604,16 +604,18 @@ func (s *watcherSuite) TestWatchSecretsRotationChanges(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	wc.AssertChange(
-		corewatcher.SecretTriggerChange{
-			URI:             uri1,
-			Revision:        1,
-			NextTriggerTime: now.Add(1 * time.Hour),
-		},
-		corewatcher.SecretTriggerChange{
-			URI:             uri2,
-			Revision:        2,
-			NextTriggerTime: now.Add(2 * time.Hour),
-		},
+		watchertest.SecretTriggerTimeAssert([]corewatcher.SecretTriggerChange{
+			{
+				URI:             uri1,
+				Revision:        1,
+				NextTriggerTime: now.Add(1 * time.Hour),
+			},
+			{
+				URI:             uri2,
+				Revision:        2,
+				NextTriggerTime: now.Add(2 * time.Hour),
+			},
+		}...),
 	)
 
 	wc.AssertNoChange()
@@ -632,19 +634,21 @@ func (s *watcherSuite) TestWatchSecretsRotationChanges(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	c.Assert(watcher1, gc.NotNil)
 	defer workertest.CleanKill(c, watcher1)
-	wc1 := watchertest.NewSecretsTriggerWatcherC(c, watcher1)
-	wc1.AssertChange([]corewatcher.SecretTriggerChange(nil)...)
+	wc1 := watchertest.NewWatcherC(c, watcher1)
+	wc1.AssertChange(watchertest.SecretTriggerTimeAssert([]corewatcher.SecretTriggerChange(nil)...))
 	wc1.AssertChange(
-		corewatcher.SecretTriggerChange{
-			URI:             uri1,
-			Revision:        1,
-			NextTriggerTime: now.Add(1 * time.Hour),
-		},
-		corewatcher.SecretTriggerChange{
-			URI:             uri2,
-			Revision:        2,
-			NextTriggerTime: now.Add(2 * time.Hour),
-		},
+		watchertest.SecretTriggerTimeAssert([]corewatcher.SecretTriggerChange{
+			{
+				URI:             uri1,
+				Revision:        1,
+				NextTriggerTime: now.Add(1 * time.Hour),
+			},
+			{
+				URI:             uri2,
+				Revision:        2,
+				NextTriggerTime: now.Add(2 * time.Hour),
+			},
+		}...),
 	)
 	wc1.AssertNoChange()
 }
@@ -683,10 +687,10 @@ func (s *watcherSuite) TestWatchSecretsRevisionExpiryChanges(c *gc.C) {
 	c.Assert(watcher, gc.NotNil)
 	defer workertest.CleanKill(c, watcher)
 
-	wc := watchertest.NewSecretsTriggerWatcherC(c, watcher)
+	wc := watchertest.NewWatcherC(c, watcher)
 
 	// Wait for the initial changes.
-	wc.AssertChange([]corewatcher.SecretTriggerChange(nil)...)
+	wc.AssertChange(watchertest.SecretTriggerTimeAssert([]corewatcher.SecretTriggerChange(nil)...))
 	wc.AssertNoChange()
 
 	now := time.Now()
@@ -704,16 +708,18 @@ func (s *watcherSuite) TestWatchSecretsRevisionExpiryChanges(c *gc.C) {
 
 	s.AssertChangeStreamIdle(c)
 	wc.AssertChange(
-		corewatcher.SecretTriggerChange{
-			URI:             uri1,
-			Revision:        1,
-			NextTriggerTime: now.Add(1 * time.Hour).UTC(),
-		},
-		corewatcher.SecretTriggerChange{
-			URI:             uri2,
-			Revision:        2,
-			NextTriggerTime: now.Add(2 * time.Hour).UTC(),
-		},
+		watchertest.SecretTriggerTimeAssert([]corewatcher.SecretTriggerChange{
+			{
+				URI:             uri1,
+				Revision:        1,
+				NextTriggerTime: now.Add(1 * time.Hour).UTC(),
+			},
+			{
+				URI:             uri2,
+				Revision:        2,
+				NextTriggerTime: now.Add(2 * time.Hour).UTC(),
+			},
+		}...),
 	)
 
 	wc.AssertNoChange()
@@ -732,20 +738,22 @@ func (s *watcherSuite) TestWatchSecretsRevisionExpiryChanges(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 	c.Assert(watcher1, gc.NotNil)
 	defer workertest.CleanKill(c, watcher1)
-	wc1 := watchertest.NewSecretsTriggerWatcherC(c, watcher1)
-	wc1.AssertChange([]corewatcher.SecretTriggerChange(nil)...)
+	wc1 := watchertest.NewWatcherC(c, watcher1)
+	wc1.AssertChange(watchertest.SecretTriggerTimeAssert([]corewatcher.SecretTriggerChange(nil)...))
 	s.AssertChangeStreamIdle(c)
 	wc1.AssertChange(
-		corewatcher.SecretTriggerChange{
-			URI:             uri1,
-			Revision:        1,
-			NextTriggerTime: now.Add(1 * time.Hour).UTC(),
-		},
-		corewatcher.SecretTriggerChange{
-			URI:             uri2,
-			Revision:        2,
-			NextTriggerTime: now.Add(2 * time.Hour).UTC(),
-		},
+		watchertest.SecretTriggerTimeAssert([]corewatcher.SecretTriggerChange{
+			{
+				URI:             uri1,
+				Revision:        1,
+				NextTriggerTime: now.Add(1 * time.Hour).UTC(),
+			},
+			{
+				URI:             uri2,
+				Revision:        2,
+				NextTriggerTime: now.Add(2 * time.Hour).UTC(),
+			},
+		}...),
 	)
 
 	wc1.AssertNoChange()

--- a/internal/utils/array.go
+++ b/internal/utils/array.go
@@ -1,0 +1,15 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package utils
+
+// Flatten takes as argument a nested array of elements T.
+// Example: [["a", "b"], ["c", "d"]] -> ["a", "b", "c", "d"]
+func Flatten[T any](nested [][]T) []T {
+	var flattened []T
+	for _, elem := range nested {
+		flattened = append(flattened, elem...)
+	}
+
+	return flattened
+}

--- a/internal/utils/array_test.go
+++ b/internal/utils/array_test.go
@@ -1,0 +1,46 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package utils
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+)
+
+type utilsSuite struct {
+}
+
+var _ = gc.Suite(&utilsSuite{})
+
+func (*utilsSuite) TestFlattenOneArray(c *gc.C) {
+	given := [][]string{{"a", "b", "c"}}
+	expected := []string{"a", "b", "c"}
+	flattened := Flatten(given)
+
+	c.Check(flattened, jc.SameContents, expected)
+}
+
+func (*utilsSuite) TestFlattenTwoArrays(c *gc.C) {
+	given := [][]string{{"a", "b"}, {"c"}}
+	expected := []string{"a", "b", "c"}
+	flattened := Flatten(given)
+
+	c.Check(flattened, jc.SameContents, expected)
+}
+
+func (*utilsSuite) TestFlattenEmpty(c *gc.C) {
+	given := [][]string{}
+	expected := []string{}
+	flattened := Flatten(given)
+
+	c.Check(flattened, jc.SameContents, expected)
+}
+
+func (*utilsSuite) TestFlattenNestedEmpty(c *gc.C) {
+	given := [][]string{{}}
+	expected := []string{}
+	flattened := Flatten(given)
+
+	c.Check(flattened, jc.SameContents, expected)
+}

--- a/internal/utils/package_test.go
+++ b/internal/utils/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package utils
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestAll(t *testing.T) {
+	gc.TestingT(t)
+}


### PR DESCRIPTION
This commit creates a new generic struct including a watcher and a gocheck struct, used for testing watchers. The goal here is to remove different very similar watcher structs for testing (strings, secrets, etc), and avoid having new ones in the future.

As part of the replacement, secret and secretbackend watcher tests have been updated using the newly created (generic) WatcherC, and removed the similar test watchers. Replacement of the strings watcher will be done in a future patch.

It must be noted that I paid specific attention to not changing any test logic, just the "infrastructure" around the watcher assertions.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Changes only affect tests, so no tests should be broken:
```
TEST_PACKAGES="./domain/secret/... -count=1 -race" make run-go-tests
TEST_PACKAGES="./domain/secretbackend/... -count=1 -race" make run-go-tests
TEST_PACKAGES="./internal/utils/... -count=1 -race" make run-go-tests
```
## Links


**Jira card:** JUJU-

