### PR TITLE
fix(tests): fix controller removal on enable-ha integration tests

### DIFF
--- a/tests/suites/controller/enable_ha.sh
+++ b/tests/suites/controller/enable_ha.sh
@@ -136,8 +136,8 @@ run_enable_ha() {
 	wait_for "controller" "$(idle_condition "controller" 0 2)"
 
 	juju switch enable-ha
-	juju remove-machine -m controller 1
-	juju remove-machine -m controller 2
+	juju remove-machine -m controller 1 --force
+	juju remove-machine -m controller 2 --force
 
 	wait_for_controller_machines_tear_down 1
 


### PR DESCRIPTION
With the changes included in https://github.com/juju/juju/pull/17653 we now can only destroy controller machines with the --force flag, exactly like any other machine which has deployed (even non-controller) units on it.

This fix is simply adding the --force flags to the enable-ha integration tests, which should have been done in that previous patch.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] ~Code style: imports ordered, good names, simple structure, etc~
- [ ] ~Comments saying why design decisions were made~
- [ ] ~Go unit tests, with comments saying what you're testing~
- [X] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Run the integration test:

```
cd tests; ./main.sh controller test_enable_ha
```

## Links


**Jira card:** JUJU-

