### PR TITLE
feat: set charm additional data

### DIFF
--- a/domain/charm/errors/errors.go
+++ b/domain/charm/errors/errors.go
@@ -12,6 +12,10 @@ const (
 	// a charm using an invalid name.
 	NameNotValid = errors.ConstError("charm name not valid")
 
+	// CharmSourceNotValid describes an error that occurs when attempting to get
+	// a charm using an invalid charm source.
+	CharmSourceNotValid = errors.ConstError("charm source not valid")
+
 	// NotFound describes an error that occurs when a charm cannot be found.
 	NotFound = errors.ConstError("charm not found")
 

--- a/domain/charm/service/charm.go
+++ b/domain/charm/service/charm.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/juju/juju/domain/charm"
+	charmerrors "github.com/juju/juju/domain/charm/errors"
 	internalcharm "github.com/juju/juju/internal/charm"
 )
 
@@ -48,4 +49,15 @@ func encodeCharm(ch internalcharm.Charm) (charm.Charm, error) {
 		Config:     config,
 		LXDProfile: profile,
 	}, nil
+}
+
+func encodeCharmSource(source internalcharm.Schema) (charm.CharmSource, error) {
+	switch source {
+	case internalcharm.Local:
+		return charm.LocalSource, nil
+	case internalcharm.CharmHub:
+		return charm.CharmHubSource, nil
+	default:
+		return "", fmt.Errorf("%w: %v", charmerrors.CharmSourceNotValid, source)
+	}
 }

--- a/domain/charm/service/package_mock_test.go
+++ b/domain/charm/service/package_mock_test.go
@@ -120,6 +120,45 @@ func (c *MockStateGetCharmActionsCall) DoAndReturn(f func(context.Context, charm
 	return c
 }
 
+// GetCharmArchivePath mocks base method.
+func (m *MockState) GetCharmArchivePath(arg0 context.Context, arg1 charm.ID) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCharmArchivePath", arg0, arg1)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetCharmArchivePath indicates an expected call of GetCharmArchivePath.
+func (mr *MockStateMockRecorder) GetCharmArchivePath(arg0, arg1 any) *MockStateGetCharmArchivePathCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCharmArchivePath", reflect.TypeOf((*MockState)(nil).GetCharmArchivePath), arg0, arg1)
+	return &MockStateGetCharmArchivePathCall{Call: call}
+}
+
+// MockStateGetCharmArchivePathCall wrap *gomock.Call
+type MockStateGetCharmArchivePathCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateGetCharmArchivePathCall) Return(arg0 string, arg1 error) *MockStateGetCharmArchivePathCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateGetCharmArchivePathCall) Do(f func(context.Context, charm.ID) (string, error)) *MockStateGetCharmArchivePathCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateGetCharmArchivePathCall) DoAndReturn(f func(context.Context, charm.ID) (string, error)) *MockStateGetCharmArchivePathCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetCharmConfig mocks base method.
 func (m *MockState) GetCharmConfig(arg0 context.Context, arg1 charm.ID) (charm0.Config, error) {
 	m.ctrl.T.Helper()

--- a/domain/charm/service/package_mock_test.go
+++ b/domain/charm/service/package_mock_test.go
@@ -472,18 +472,18 @@ func (c *MockStateReserveCharmRevisionCall) DoAndReturn(f func(context.Context, 
 }
 
 // SetCharm mocks base method.
-func (m *MockState) SetCharm(arg0 context.Context, arg1 charm0.Charm) (charm.ID, error) {
+func (m *MockState) SetCharm(arg0 context.Context, arg1 charm0.Charm, arg2 charm0.SetStateArgs) (charm.ID, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetCharm", arg0, arg1)
+	ret := m.ctrl.Call(m, "SetCharm", arg0, arg1, arg2)
 	ret0, _ := ret[0].(charm.ID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // SetCharm indicates an expected call of SetCharm.
-func (mr *MockStateMockRecorder) SetCharm(arg0, arg1 any) *MockStateSetCharmCall {
+func (mr *MockStateMockRecorder) SetCharm(arg0, arg1, arg2 any) *MockStateSetCharmCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCharm", reflect.TypeOf((*MockState)(nil).SetCharm), arg0, arg1)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCharm", reflect.TypeOf((*MockState)(nil).SetCharm), arg0, arg1, arg2)
 	return &MockStateSetCharmCall{Call: call}
 }
 
@@ -499,13 +499,13 @@ func (c *MockStateSetCharmCall) Return(arg0 charm.ID, arg1 error) *MockStateSetC
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateSetCharmCall) Do(f func(context.Context, charm0.Charm) (charm.ID, error)) *MockStateSetCharmCall {
+func (c *MockStateSetCharmCall) Do(f func(context.Context, charm0.Charm, charm0.SetStateArgs) (charm.ID, error)) *MockStateSetCharmCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateSetCharmCall) DoAndReturn(f func(context.Context, charm0.Charm) (charm.ID, error)) *MockStateSetCharmCall {
+func (c *MockStateSetCharmCall) DoAndReturn(f func(context.Context, charm0.Charm, charm0.SetStateArgs) (charm.ID, error)) *MockStateSetCharmCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/charm/service/service.go
+++ b/domain/charm/service/service.go
@@ -73,6 +73,11 @@ type State interface {
 	// If the charm does not exist, a NotFound error is returned.
 	GetCharmLXDProfile(ctx context.Context, charmID corecharm.ID) ([]byte, error)
 
+	// GetCharmArchivePath returns the archive storage path for the charm using
+	// the charm ID.
+	// If the charm does not exist, a NotFound error is returned.
+	GetCharmArchivePath(ctx context.Context, charmID corecharm.ID) (string, error)
+
 	// IsCharmAvailable returns whether the charm is available for use.
 	// If the charm does not exist, a NotFound error is returned.
 	IsCharmAvailable(ctx context.Context, charmID corecharm.ID) (bool, error)
@@ -264,6 +269,21 @@ func (s *Service) GetCharmLXDProfile(ctx context.Context, id corecharm.ID) (inte
 		return internalcharm.LXDProfile{}, errors.Trace(err)
 	}
 	return decoded, nil
+}
+
+// GetCharmArchivePath returns the archive storage path for the charm using the
+// charm ID.
+// If the charm does not exist, a NotFound error is returned.
+func (s *Service) GetCharmArchivePath(ctx context.Context, id corecharm.ID) (string, error) {
+	if err := id.Validate(); err != nil {
+		return "", fmt.Errorf("charm id: %w", err)
+	}
+
+	path, err := s.st.GetCharmArchivePath(ctx, id)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	return path, nil
 }
 
 // IsCharmAvailable returns whether the charm is available for use. This

--- a/domain/charm/service/service_test.go
+++ b/domain/charm/service/service_test.go
@@ -200,6 +200,36 @@ func (s *serviceSuite) TestGetCharmMetadataInvalidUUID(c *gc.C) {
 	c.Assert(err, jc.ErrorIs, errors.NotValid)
 }
 
+func (s *serviceSuite) TestGetCharmArchivePath(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	id := charmtesting.GenCharmID(c)
+
+	s.state.EXPECT().GetCharmArchivePath(gomock.Any(), id).Return("archive-path", nil)
+
+	path, err := s.service.GetCharmArchivePath(context.Background(), id)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(path, gc.Equals, "archive-path")
+}
+
+func (s *serviceSuite) TestGetCharmArchivePathNotFound(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	id := charmtesting.GenCharmID(c)
+
+	s.state.EXPECT().GetCharmArchivePath(gomock.Any(), id).Return("archive-path", charmerrors.NotFound)
+
+	_, err := s.service.GetCharmArchivePath(context.Background(), id)
+	c.Assert(err, jc.ErrorIs, charmerrors.NotFound)
+}
+
+func (s *serviceSuite) TestGetCharmArchivePathInvalidUUID(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	_, err := s.service.GetCharmArchivePath(context.Background(), "")
+	c.Assert(err, jc.ErrorIs, errors.NotValid)
+}
+
 func (s *serviceSuite) TestSetCharmAvailable(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 

--- a/domain/charm/service/service_test.go
+++ b/domain/charm/service/service_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/juju/juju/core/changestream"
 	charmtesting "github.com/juju/juju/core/charm/testing"
-	"github.com/juju/juju/domain/charm"
 	domaincharm "github.com/juju/juju/domain/charm"
 	charmerrors "github.com/juju/juju/domain/charm/errors"
 	internalcharm "github.com/juju/juju/internal/charm"
@@ -276,20 +275,58 @@ func (s *serviceSuite) TestSetCharm(c *gc.C) {
 
 	id := charmtesting.GenCharmID(c)
 
-	s.charm.EXPECT().Meta().Return(&internalcharm.Meta{})
+	s.charm.EXPECT().Meta().Return(&internalcharm.Meta{
+		Name: "foo",
+	}).Times(2)
 	s.charm.EXPECT().Manifest().Return(&internalcharm.Manifest{})
 	s.charm.EXPECT().Actions().Return(&internalcharm.Actions{})
 	s.charm.EXPECT().Config().Return(&internalcharm.Config{})
 
-	s.state.EXPECT().SetCharm(gomock.Any(), charm.Charm{
-		Metadata: charm.Metadata{
+	s.state.EXPECT().SetCharm(gomock.Any(), domaincharm.Charm{
+		Metadata: domaincharm.Metadata{
+			Name:  "foo",
 			RunAs: "default",
 		},
+	}, domaincharm.SetStateArgs{
+		Source:   domaincharm.LocalSource,
+		Revision: 1,
 	}).Return(id, nil)
 
-	got, err := s.service.SetCharm(context.Background(), s.charm)
+	got, err := s.service.SetCharm(context.Background(), domaincharm.SetCharmArgs{
+		Charm:    s.charm,
+		Source:   internalcharm.Local,
+		Revision: 1,
+	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(got, gc.DeepEquals, id)
+}
+
+func (s *serviceSuite) TestSetCharmNoName(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.charm.EXPECT().Meta().Return(&internalcharm.Meta{})
+
+	_, err := s.service.SetCharm(context.Background(), domaincharm.SetCharmArgs{
+		Charm:    s.charm,
+		Source:   internalcharm.Local,
+		Revision: 1,
+	})
+	c.Assert(err, jc.ErrorIs, charmerrors.NameNotValid)
+}
+
+func (s *serviceSuite) TestSetCharmInvalidSource(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.charm.EXPECT().Meta().Return(&internalcharm.Meta{
+		Name: "foo",
+	})
+
+	_, err := s.service.SetCharm(context.Background(), domaincharm.SetCharmArgs{
+		Charm:    s.charm,
+		Source:   "charmstore",
+		Revision: 1,
+	})
+	c.Assert(err, jc.ErrorIs, charmerrors.CharmSourceNotValid)
 }
 
 func (s *serviceSuite) TestDeleteCharm(c *gc.C) {

--- a/domain/charm/state/metadata.go
+++ b/domain/charm/state/metadata.go
@@ -393,7 +393,7 @@ func decodeContainers(containers []charmContainer) (map[string]charm.Container, 
 	return result, nil
 }
 
-func encodeMetadata(id corecharm.ID, metadata charm.Metadata, lxdProfile []byte) (setCharmMetadata, error) {
+func encodeMetadata(id corecharm.ID, metadata charm.Metadata, lxdProfile []byte, archivePath string) (setCharmMetadata, error) {
 	runAs, err := encodeRunAs(metadata.RunAs)
 	if err != nil {
 		return setCharmMetadata{}, fmt.Errorf("cannot encode run as %q: %w", metadata.RunAs, err)
@@ -409,6 +409,7 @@ func encodeMetadata(id corecharm.ID, metadata charm.Metadata, lxdProfile []byte)
 		RunAsID:        runAs,
 		Assumes:        metadata.Assumes,
 		LXDProfile:     lxdProfile,
+		ArchivePath:    archivePath,
 	}, nil
 }
 

--- a/domain/charm/state/metadata_test.go
+++ b/domain/charm/state/metadata_test.go
@@ -474,7 +474,7 @@ func (s *metadataSuite) TestEncodeMetadata(c *gc.C) {
 		RunAs:          "root",
 		Subordinate:    true,
 		Assumes:        []byte("null"),
-	}, []byte("{}"))
+	}, []byte("{}"), "archive-path")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(result, gc.DeepEquals, setCharmMetadata{
 		UUID:           id.String(),
@@ -486,6 +486,7 @@ func (s *metadataSuite) TestEncodeMetadata(c *gc.C) {
 		Subordinate:    true,
 		Assumes:        []byte("null"),
 		LXDProfile:     []byte("{}"),
+		ArchivePath:    "archive-path",
 	})
 
 }

--- a/domain/charm/state/state_test.go
+++ b/domain/charm/state/state_test.go
@@ -2067,6 +2067,30 @@ func (s *stateSuite) TestGetCharmActionsEmpty(c *gc.C) {
 	})
 }
 
+func (s *stateSuite) TestSetCharmThenGetCharmArchivePath(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	id, err := st.SetCharm(context.Background(), charm.Charm{
+		Metadata: charm.Metadata{
+			Name: "ubuntu",
+		},
+	}, setStateArgs())
+	c.Assert(err, jc.ErrorIsNil)
+
+	got, err := st.GetCharmArchivePath(context.Background(), id)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(got, gc.DeepEquals, "archive")
+}
+
+func (s *stateSuite) TestGetCharmArchivePathNotFound(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	id := charmtesting.GenCharmID(c)
+
+	_, err := st.GetCharmArchivePath(context.Background(), id)
+	c.Assert(err, jc.ErrorIs, charmerrors.NotFound)
+}
+
 func insertCharmState(ctx context.Context, c *gc.C, tx *sql.Tx, uuid string) error {
 	_, err := tx.ExecContext(ctx, `
 INSERT INTO charm (uuid, name, description, summary, subordinate, min_juju_version, run_as_id, assumes) 

--- a/domain/charm/state/state_test.go
+++ b/domain/charm/state/state_test.go
@@ -47,6 +47,29 @@ func (s *stateSuite) TestGetCharmIDByRevision(c *gc.C) {
 	c.Check(charmID, gc.Equals, id)
 }
 
+func (s *stateSuite) TestSetCharmGetCharmIDByRevision(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	expected := charm.Metadata{
+		Name:           "foo",
+		Summary:        "summary",
+		Description:    "description",
+		Subordinate:    true,
+		RunAs:          charm.RunAsRoot,
+		MinJujuVersion: version.MustParse("4.0.0"),
+		Assumes:        []byte("null"),
+	}
+
+	id, err := st.SetCharm(context.Background(), charm.Charm{
+		Metadata: expected,
+	}, setStateArgs())
+	c.Assert(err, jc.ErrorIsNil)
+
+	charmID, err := st.GetCharmIDByRevision(context.Background(), "foo", 1)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(charmID, gc.Equals, id)
+}
+
 func (s *stateSuite) TestGetCharmIDByRevisionWithNoCharm(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory())
 
@@ -1014,7 +1037,7 @@ func (s *stateSuite) TestSetCharmThenGetCharmMetadata(c *gc.C) {
 
 	id, err := st.SetCharm(context.Background(), charm.Charm{
 		Metadata: expected,
-	})
+	}, setStateArgs())
 	c.Assert(err, jc.ErrorIsNil)
 
 	got, err := st.GetCharmMetadata(context.Background(), id)
@@ -1045,7 +1068,7 @@ func (s *stateSuite) TestSetCharmThenGetCharmMetadataWithTagsAndCategories(c *gc
 
 	id, err := st.SetCharm(context.Background(), charm.Charm{
 		Metadata: expected,
-	})
+	}, setStateArgs())
 	c.Assert(err, jc.ErrorIsNil)
 
 	got, err := st.GetCharmMetadata(context.Background(), id)
@@ -1075,7 +1098,7 @@ func (s *stateSuite) TestSetCharmThenGetCharmMetadataWithTerms(c *gc.C) {
 
 	id, err := st.SetCharm(context.Background(), charm.Charm{
 		Metadata: expected,
-	})
+	}, setStateArgs())
 	c.Assert(err, jc.ErrorIsNil)
 
 	got, err := st.GetCharmMetadata(context.Background(), id)
@@ -1134,7 +1157,7 @@ func (s *stateSuite) TestSetCharmThenGetCharmMetadataWithRelations(c *gc.C) {
 
 	id, err := st.SetCharm(context.Background(), charm.Charm{
 		Metadata: expected,
-	})
+	}, setStateArgs())
 	c.Assert(err, jc.ErrorIsNil)
 
 	got, err := st.GetCharmMetadata(context.Background(), id)
@@ -1171,7 +1194,7 @@ func (s *stateSuite) TestSetCharmThenGetCharmMetadataWithExtraBindings(c *gc.C) 
 
 	id, err := st.SetCharm(context.Background(), charm.Charm{
 		Metadata: expected,
-	})
+	}, setStateArgs())
 	c.Assert(err, jc.ErrorIsNil)
 
 	got, err := st.GetCharmMetadata(context.Background(), id)
@@ -1224,7 +1247,7 @@ func (s *stateSuite) TestSetCharmThenGetCharmMetadataWithStorageWithNoProperties
 
 	id, err := st.SetCharm(context.Background(), charm.Charm{
 		Metadata: expected,
-	})
+	}, setStateArgs())
 	c.Assert(err, jc.ErrorIsNil)
 
 	got, err := st.GetCharmMetadata(context.Background(), id)
@@ -1279,7 +1302,7 @@ func (s *stateSuite) TestSetCharmThenGetCharmMetadataWithStorageWithProperties(c
 
 	id, err := st.SetCharm(context.Background(), charm.Charm{
 		Metadata: expected,
-	})
+	}, setStateArgs())
 	c.Assert(err, jc.ErrorIsNil)
 
 	got, err := st.GetCharmMetadata(context.Background(), id)
@@ -1325,7 +1348,7 @@ func (s *stateSuite) TestSetCharmThenGetCharmMetadataWithDevices(c *gc.C) {
 
 	id, err := st.SetCharm(context.Background(), charm.Charm{
 		Metadata: expected,
-	})
+	}, setStateArgs())
 	c.Assert(err, jc.ErrorIsNil)
 
 	got, err := st.GetCharmMetadata(context.Background(), id)
@@ -1364,7 +1387,7 @@ func (s *stateSuite) TestSetCharmThenGetCharmMetadataWithPayloadClasses(c *gc.C)
 
 	id, err := st.SetCharm(context.Background(), charm.Charm{
 		Metadata: expected,
-	})
+	}, setStateArgs())
 	c.Assert(err, jc.ErrorIsNil)
 
 	got, err := st.GetCharmMetadata(context.Background(), id)
@@ -1407,7 +1430,7 @@ func (s *stateSuite) TestSetCharmThenGetCharmMetadataWithResources(c *gc.C) {
 
 	id, err := st.SetCharm(context.Background(), charm.Charm{
 		Metadata: expected,
-	})
+	}, setStateArgs())
 	c.Assert(err, jc.ErrorIsNil)
 
 	got, err := st.GetCharmMetadata(context.Background(), id)
@@ -1446,7 +1469,7 @@ func (s *stateSuite) TestSetCharmThenGetCharmMetadataWithContainersWithNoMounts(
 
 	id, err := st.SetCharm(context.Background(), charm.Charm{
 		Metadata: expected,
-	})
+	}, setStateArgs())
 	c.Assert(err, jc.ErrorIsNil)
 
 	got, err := st.GetCharmMetadata(context.Background(), id)
@@ -1505,7 +1528,7 @@ func (s *stateSuite) TestSetCharmThenGetCharmMetadataWithContainersWithMounts(c 
 
 	id, err := st.SetCharm(context.Background(), charm.Charm{
 		Metadata: expected,
-	})
+	}, setStateArgs())
 	c.Assert(err, jc.ErrorIsNil)
 
 	got, err := st.GetCharmMetadata(context.Background(), id)
@@ -1632,7 +1655,7 @@ func (s *stateSuite) TestSetCharmThenGetCharmManifest(c *gc.C) {
 			Name: "ubuntu",
 		},
 		Manifest: expected,
-	})
+	}, setStateArgs())
 	c.Assert(err, jc.ErrorIsNil)
 
 	got, err := st.GetCharmManifest(context.Background(), id)
@@ -1810,7 +1833,7 @@ func (s *stateSuite) TestSetCharmThenGetCharmConfig(c *gc.C) {
 			Name: "ubuntu",
 		},
 		Config: expected,
-	})
+	}, setStateArgs())
 	c.Assert(err, jc.ErrorIsNil)
 
 	got, err := st.GetCharmConfig(context.Background(), id)
@@ -1928,7 +1951,7 @@ func (s *stateSuite) TestSetCharmThenGetCharmActions(c *gc.C) {
 			Name: "ubuntu",
 		},
 		Actions: expected,
-	})
+	}, setStateArgs())
 	c.Assert(err, jc.ErrorIsNil)
 
 	got, err := st.GetCharmActions(context.Background(), id)
@@ -2034,6 +2057,16 @@ func assertCharmMetadata(c *gc.C, metadata charm.Metadata, expected func() charm
 
 func assertCharmManifest(c *gc.C, manifest charm.Manifest, expected func() charm.Manifest) {
 	c.Check(manifest, gc.DeepEquals, expected())
+}
+
+func setStateArgs() charm.SetStateArgs {
+	return charm.SetStateArgs{
+		Source:      charm.LocalSource,
+		Revision:    1,
+		Hash:        "hash",
+		ArchivePath: "archive",
+		Version:     "deadbeef",
+	}
 }
 
 func ptr[T any](v T) *T {

--- a/domain/charm/state/types.go
+++ b/domain/charm/state/types.go
@@ -81,6 +81,7 @@ type setCharmMetadata struct {
 	Assumes        []byte `db:"assumes"`
 	RunAsID        int    `db:"run_as_id"`
 	LXDProfile     []byte `db:"lxd_profile"`
+	ArchivePath    string `db:"archive_path"`
 }
 
 // charmTag is used to get the tags of a charm.
@@ -372,4 +373,9 @@ type setCharmAction struct {
 	Parallel       bool   `db:"parallel"`
 	ExecutionGroup string `db:"execution_group"`
 	Params         []byte `db:"params"`
+}
+
+// charmArchivePath is used to get the archive path of a charm.
+type charmArchivePath struct {
+	ArchivePath string `db:"archive_path"`
 }

--- a/domain/charm/state/types.go
+++ b/domain/charm/state/types.go
@@ -42,6 +42,22 @@ type charmIDName struct {
 	Name string `db:"name"`
 }
 
+// setCharmHash is used to set the hash of a charm.
+type setCharmHash struct {
+	CharmUUID  string `db:"charm_uuid"`
+	HashKindID int    `db:"hash_kind_id"`
+	Hash       string `db:"hash"`
+}
+
+// setCharmSourceRevisionVersion is used to set the source, revision and
+// version of a charm.
+type setCharmSourceRevisionVersion struct {
+	CharmUUID string `db:"charm_uuid"`
+	SourceID  int    `db:"source_id"`
+	Revision  int    `db:"revision"`
+	Version   string `db:"version"`
+}
+
 // charmMetadata is used to get the metadata of a charm.
 type charmMetadata struct {
 	Name           string `db:"name"`

--- a/domain/charm/types.go
+++ b/domain/charm/types.go
@@ -5,6 +5,8 @@ package charm
 
 import (
 	"github.com/juju/version/v2"
+
+	internalcharm "github.com/juju/juju/internal/charm"
 )
 
 // GetCharmArgs holds the arguments for the GetCharmID method.
@@ -18,6 +20,46 @@ type GetCharmArgs struct {
 	// Revision allows the selection of a specific revision of the charm.
 	// Otherwise, the latest revision is returned.
 	Revision *int
+}
+
+// CharmSource represents the source of a charm.
+type CharmSource string
+
+const (
+	// LocalSource represents a local charm source.
+	LocalSource CharmSource = "local"
+	// CharmHubSource represents a charmhub charm source.
+	CharmHubSource CharmSource = "charmhub"
+)
+
+// SetCharmArgs holds the arguments for the SetCharm method.
+type SetCharmArgs struct {
+	// Charm is the charm to set.
+	Charm internalcharm.Charm
+	// Source is the source of the charm.
+	Source internalcharm.Schema
+	// Revision is the revision of the charm.
+	Revision int
+	// Hash is the hash of the charm.
+	Hash string
+	// ArchivePath is the path to the charm archive path.
+	ArchivePath string
+	// Version is the optional charm version.
+	Version string
+}
+
+// SetStateArgs holds the arguments for the SetState method.
+type SetStateArgs struct {
+	// Source is the source of the charm.
+	Source CharmSource
+	// Revision is the revision of the charm.
+	Revision int
+	// Hash is the hash of the charm.
+	Hash string
+	// ArchivePath is the path to the charm archive path.
+	ArchivePath string
+	// Version is the optional charm version.
+	Version string
 }
 
 // Charm represents a charm from the perspective of the service. This is the

--- a/domain/charm/watcher_test.go
+++ b/domain/charm/watcher_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/watcher/watchertest"
 	"github.com/juju/juju/domain"
+	"github.com/juju/juju/domain/charm"
 	"github.com/juju/juju/domain/charm/service"
 	"github.com/juju/juju/domain/charm/state"
 	changestreamtesting "github.com/juju/juju/internal/changestream/testing"
@@ -45,7 +46,11 @@ func (s *watcherSuite) TestWatchCharm(c *gc.C) {
 
 	var id corecharm.ID
 	harness.AddTest(func(c *gc.C) {
-		id, err = svc.SetCharm(context.Background(), &stubCharm{})
+		id, err = svc.SetCharm(context.Background(), charm.SetCharmArgs{
+			Charm:    &stubCharm{},
+			Source:   internalcharm.CharmHub,
+			Revision: 1,
+		})
 		c.Assert(err, jc.ErrorIsNil)
 	}, func(w watchertest.WatcherC[[]string]) {
 		w.Check(

--- a/domain/schema/model/sql/0015-charm.sql
+++ b/domain/schema/model/sql/0015-charm.sql
@@ -26,6 +26,9 @@ CREATE TABLE charm (
     -- blob without constraining the expression to a specific set of rules.
     assumes TEXT,
     lxd_profile TEXT,
+    -- Archive path is the path to the charm archive on disk. This is used to
+    -- determine the source of the charm.
+    archive_path TEXT,
     CONSTRAINT fk_charm_run_as_kind_charm
     FOREIGN KEY (run_as_id)
     REFERENCES charm_run_as_kind (id)
@@ -89,6 +92,7 @@ CREATE TABLE charm_origin (
     source_id INT,
     id TEXT,
     revision INT,
+    version TEXT,
     CONSTRAINT fk_charm_source_source
     FOREIGN KEY (source_id)
     REFERENCES charm_source (id),
@@ -126,7 +130,7 @@ INSERT INTO hash_kind VALUES
 
 CREATE TABLE charm_hash (
     charm_uuid TEXT NOT NULL,
-    hash_kind_id TEXT NOT NULL,
+    hash_kind_id INT NOT NULL DEFAULT 0,
     hash TEXT NOT NULL,
     CONSTRAINT fk_charm_hash_charm
     FOREIGN KEY (charm_uuid)

--- a/domain/schema/model/triggers/charm.gen.go
+++ b/domain/schema/model/triggers/charm.gen.go
@@ -33,7 +33,8 @@ WHEN
 	(NEW.min_juju_version != OLD.min_juju_version OR (NEW.min_juju_version IS NOT NULL AND OLD.min_juju_version IS NULL) OR (NEW.min_juju_version IS NULL AND OLD.min_juju_version IS NOT NULL)) OR
 	(NEW.run_as_id != OLD.run_as_id OR (NEW.run_as_id IS NOT NULL AND OLD.run_as_id IS NULL) OR (NEW.run_as_id IS NULL AND OLD.run_as_id IS NOT NULL)) OR
 	(NEW.assumes != OLD.assumes OR (NEW.assumes IS NOT NULL AND OLD.assumes IS NULL) OR (NEW.assumes IS NULL AND OLD.assumes IS NOT NULL)) OR
-	(NEW.lxd_profile != OLD.lxd_profile OR (NEW.lxd_profile IS NOT NULL AND OLD.lxd_profile IS NULL) OR (NEW.lxd_profile IS NULL AND OLD.lxd_profile IS NOT NULL)) 
+	(NEW.lxd_profile != OLD.lxd_profile OR (NEW.lxd_profile IS NOT NULL AND OLD.lxd_profile IS NULL) OR (NEW.lxd_profile IS NULL AND OLD.lxd_profile IS NOT NULL)) OR
+	(NEW.archive_path != OLD.archive_path OR (NEW.archive_path IS NOT NULL AND OLD.archive_path IS NULL) OR (NEW.archive_path IS NULL AND OLD.archive_path IS NOT NULL)) 
 BEGIN
     INSERT INTO change_log (edit_type_id, namespace_id, changed, created_at)
     VALUES (2, %[2]d, OLD.%[1]s, DATETIME('now'));


### PR DESCRIPTION
Charms also need to set additional information when written to the state. Revision, version, the SHA256 of the charm, and other additional data. As this data is set only when we first create the charm we also need to pass it in. We don't want to pollute the charm type, so instead we add it as a set of arguments that can be set during the call to set charm.

----

This is the initial work for wiring up the charm. Threading through the charm service to the APIServer will follow.

<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://docs.google.com/document/d/1SYUo9G7qZ_jdoVXpUVamS5VCgHmtZ0QA-wZxKoMS-C0 
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

The tests should pass.

## Links

**Jira card:** [JUJU-6016](https://warthogs.atlassian.net/browse/JUJU-6016)



[JUJU-6016]: https://warthogs.atlassian.net/browse/JUJU-6016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ