### PR TITLE
feat: add machine_parent table to schema

### DIFF
--- a/domain/schema/model/sql/0017-machine.sql
+++ b/domain/schema/model/sql/0017-machine.sql
@@ -27,6 +27,19 @@ ON machine (name);
 CREATE UNIQUE INDEX idx_machine_net_node
 ON machine (net_node_uuid);
 
+-- machine_parent table is a table which represents parents-children relationships of machines.
+-- Each machine can have a single parent or be a parent to multiple children.
+CREATE TABLE machine_parent (
+    machine_uuid TEXT NOT NULL PRIMARY KEY,
+    parent_uuid TEXT NOT NULL,
+    CONSTRAINT fk_machine_parent_machine
+    FOREIGN KEY (machine_uuid)
+    REFERENCES machine (uuid),
+    CONSTRAINT fk_machine_parent_parent
+    FOREIGN KEY (parent_uuid)
+    REFERENCES machine (uuid)
+);
+
 CREATE TABLE machine_constraint (
     machine_uuid TEXT NOT NULL PRIMARY KEY,
     constraint_uuid TEXT NOT NULL,

--- a/domain/schema/schema_test.go
+++ b/domain/schema/schema_test.go
@@ -310,6 +310,7 @@ func (s *schemaSuite) TestModelTables(c *gc.C) {
 
 		// Machine
 		"machine",
+		"machine_parent",
 		"machine_constraint",
 		"machine_tool",
 		"machine_volume",


### PR DESCRIPTION
- Before this commit, the machine_parent table which represents parent-child relationships between machines was not defined previously.
- After this commit, a new table 'machine_parent' is added into the schema within SQL file '0017-machine.sql' and is also included in the schema test file.

<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://docs.google.com/document/d/1SYUo9G7qZ_jdoVXpUVamS5VCgHmtZ0QA-wZxKoMS-C0 
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- ~[ ] Code style: imports ordered, good names, simple structure, etc~
- ~[ ] Comments saying why design decisions were made~
- ~[ ] Go unit tests, with comments saying what you're testing~
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Not required
<!-- Describe steps to verify that the change works. -->

## Documentation changes

None

<!-- How it affects user workflow (CLI or API). -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/

**Jira card:** [JUJU-6377](https://warthogs.atlassian.net/browse/JUJU-6377)



[JUJU-6377]: https://warthogs.atlassian.net/browse/JUJU-6377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ