### PR TITLE
fix: retry applying lxd profiles

### DIFF
--- a/core/lxdprofile/name.go
+++ b/core/lxdprofile/name.go
@@ -18,7 +18,7 @@ const AppName = "juju"
 
 // Prefix is used to prefix all the lxd profile programmable profiles. If a
 // profile doesn't have the prefix, then it will be removed when ensuring the
-// the validity of the names (see LXDProfileNames)
+// the validity of the names (see FilterLXDProfileNames)
 var Prefix = fmt.Sprintf("%s-", AppName)
 
 // Name returns a serialisable name that we can use to identify profiles
@@ -27,10 +27,10 @@ func Name(modelName, appName string, revision int) string {
 	return fmt.Sprintf("%s%s-%s-%d", Prefix, modelName, appName, revision)
 }
 
-// LXDProfileNames ensures that the LXD profile names are unique yet preserve
+// FilterLXDProfileNames ensures that the LXD profile names are unique yet preserve
 // the same order as the input. It removes certain profile names from the list,
 // for example "default" profile name will be removed.
-func LXDProfileNames(names []string) []string {
+func FilterLXDProfileNames(names []string) []string {
 	// ensure that the ones we have are unique
 	unique := make(map[string]int)
 	for k, v := range names {
@@ -111,10 +111,10 @@ func MatchProfileNameByAppName(names []string, appName string) (string, error) {
 		return "", errors.BadRequestf("no application name specified")
 	}
 	var foundProfile string
-	for _, p := range LXDProfileNames(names) {
+	for _, p := range FilterLXDProfileNames(names) {
 		rev, err := ProfileRevision(p)
 		if err != nil {
-			// "Shouldn't" happen since we used LXDProfileNames...
+			// "Shouldn't" happen since we used FilterLXDProfileNames...
 			if errors.IsBadRequest(err) {
 				continue
 			}

--- a/core/lxdprofile/name_test.go
+++ b/core/lxdprofile/name_test.go
@@ -73,7 +73,7 @@ func (*LXDProfileNameSuite) TestProfileNames(c *gc.C) {
 	}
 	for k, tc := range testCases {
 		c.Logf("running test %d with input %q", k, tc.input)
-		c.Assert(lxdprofile.LXDProfileNames(tc.input), gc.DeepEquals, tc.output)
+		c.Assert(lxdprofile.FilterLXDProfileNames(tc.input), gc.DeepEquals, tc.output)
 	}
 }
 

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -890,6 +890,32 @@ func (s *MachineSuite) TestMachineCharmProfiles(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	saved = all.CharmProfiles(s.machine.Id())
 	c.Assert(saved, jc.SameContents, profiles)
+
+	// set to nil
+	err = s.machine.SetCharmProfiles(nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	saved, err = s.machine.CharmProfiles()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(saved, gc.HasLen, 0)
+
+	all, err = s.Model.AllInstanceData()
+	c.Assert(err, jc.ErrorIsNil)
+	saved = all.CharmProfiles(s.machine.Id())
+	c.Assert(saved, gc.HasLen, 0)
+
+	// set back to non-nil
+	err = s.machine.SetCharmProfiles(profiles)
+	c.Assert(err, jc.ErrorIsNil)
+
+	saved, err = s.machine.CharmProfiles()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(saved, jc.SameContents, profiles)
+
+	all, err = s.Model.AllInstanceData()
+	c.Assert(err, jc.ErrorIsNil)
+	saved = all.CharmProfiles(s.machine.Id())
+	c.Assert(saved, jc.SameContents, profiles)
 }
 
 func (s *MachineSuite) TestMachineAvailabilityZone(c *gc.C) {

--- a/worker/instancemutater/export_test.go
+++ b/worker/instancemutater/export_test.go
@@ -63,6 +63,6 @@ func GatherProfileData(m *MutaterMachine, info *instancemutater.UnitProfileInfo)
 	return m.gatherProfileData(info)
 }
 
-func VerifyCurrentProfiles(m *MutaterMachine, instId string, expectedProfiles []string) (bool, error) {
+func VerifyCurrentProfiles(m *MutaterMachine, instId string, expectedProfiles []string) (bool, []string, error) {
 	return m.verifyCurrentProfiles(instId, expectedProfiles)
 }

--- a/worker/instancemutater/mutater.go
+++ b/worker/instancemutater/mutater.go
@@ -243,7 +243,7 @@ func (m MutaterMachine) processMachineProfileChanges(info *instancemutater.UnitP
 	}
 	if verified {
 		m.logger.Infof("no changes necessary to machine-%s lxd profiles (%v)", m.id, expectedProfiles)
-		return report(m.machineApi.SetCharmProfiles(currentProfiles))
+		return report(m.machineApi.SetCharmProfiles(lxdprofile.FilterLXDProfileNames(currentProfiles)))
 	}
 
 	// Adding a wrench to test charm not running hooks before profile can be applied.
@@ -265,7 +265,7 @@ func (m MutaterMachine) processMachineProfileChanges(info *instancemutater.UnitP
 		return report(err)
 	}
 
-	return report(m.machineApi.SetCharmProfiles(currentProfiles))
+	return report(m.machineApi.SetCharmProfiles(lxdprofile.FilterLXDProfileNames(currentProfiles)))
 }
 
 func (m MutaterMachine) gatherProfileData(info *instancemutater.UnitProfileInfo) ([]lxdprofile.ProfilePost, error) {

--- a/worker/instancemutater/mutater.go
+++ b/worker/instancemutater/mutater.go
@@ -237,13 +237,13 @@ func (m MutaterMachine) processMachineProfileChanges(info *instancemutater.UnitP
 		}
 	}
 
-	verified, err := m.verifyCurrentProfiles(string(info.InstanceId), expectedProfiles)
+	verified, currentProfiles, err := m.verifyCurrentProfiles(string(info.InstanceId), expectedProfiles)
 	if err != nil {
 		return report(errors.Annotatef(err, "%s", m.id))
 	}
 	if verified {
 		m.logger.Infof("no changes necessary to machine-%s lxd profiles (%v)", m.id, expectedProfiles)
-		return report(nil)
+		return report(m.machineApi.SetCharmProfiles(currentProfiles))
 	}
 
 	// Adding a wrench to test charm not running hooks before profile can be applied.
@@ -259,7 +259,7 @@ func (m MutaterMachine) processMachineProfileChanges(info *instancemutater.UnitP
 
 	m.logger.Infof("machine-%s (%s) assign lxd profiles %q, %#v", m.id, string(info.InstanceId), expectedProfiles, post)
 	broker := m.context.getBroker()
-	currentProfiles, err := broker.AssignLXDProfiles(string(info.InstanceId), expectedProfiles, post)
+	currentProfiles, err = broker.AssignLXDProfiles(string(info.InstanceId), expectedProfiles, post)
 	if err != nil {
 		m.logger.Errorf("failure to assign lxd profiles %s to machine-%s: %s", expectedProfiles, m.id, err)
 		return report(err)
@@ -298,21 +298,21 @@ func (m MutaterMachine) gatherProfileData(info *instancemutater.UnitProfileInfo)
 	return result, nil
 }
 
-func (m MutaterMachine) verifyCurrentProfiles(instID string, expectedProfiles []string) (bool, error) {
+func (m MutaterMachine) verifyCurrentProfiles(instID string, expectedProfiles []string) (bool, []string, error) {
 	broker := m.context.getBroker()
 	obtainedProfiles, err := broker.LXDProfileNames(instID)
 	if err != nil {
-		return false, err
+		return false, nil, err
 	}
 
 	if len(obtainedProfiles) == 0 && len(expectedProfiles) == 0 {
-		return true, nil
+		return true, obtainedProfiles, nil
 	} else if len(obtainedProfiles) != len(expectedProfiles) {
-		return false, nil
+		return false, obtainedProfiles, nil
 	}
 
 	obtainedSet := set.NewStrings(obtainedProfiles...)
 	expectedSet := set.NewStrings(expectedProfiles...)
 
-	return obtainedSet.Difference(expectedSet).Size() == 0, nil
+	return obtainedSet.Difference(expectedSet).Size() == 0, obtainedProfiles, nil
 }

--- a/worker/instancemutater/mutater.go
+++ b/worker/instancemutater/mutater.go
@@ -304,16 +304,15 @@ func (m MutaterMachine) verifyCurrentProfiles(instID string, expectedProfiles []
 	if err != nil {
 		return false, err
 	}
+
+	if len(obtainedProfiles) == 0 && len(expectedProfiles) == 0 {
+		return true, nil
+	} else if len(obtainedProfiles) != len(expectedProfiles) {
+		return false, nil
+	}
+
 	obtainedSet := set.NewStrings(obtainedProfiles...)
 	expectedSet := set.NewStrings(expectedProfiles...)
 
-	if obtainedSet.Union(expectedSet).Size() > obtainedSet.Size() {
-		return false, nil
-	}
-
-	if expectedSet.Union(obtainedSet).Size() > expectedSet.Size() {
-		return false, nil
-	}
-
-	return true, nil
+	return obtainedSet.Difference(expectedSet).Size() == 0, nil
 }

--- a/worker/instancemutater/mutater_test.go
+++ b/worker/instancemutater/mutater_test.go
@@ -178,9 +178,10 @@ func (s *mutaterSuite) TestVerifyCurrentProfilesTrue(c *gc.C) {
 	profiles := []string{"default", "juju-testme", "juju-testme-lxd-profile-0"}
 	s.expectLXDProfileNames(profiles, nil)
 
-	ok, err := instancemutater.VerifyCurrentProfiles(s.mutaterMachine, s.instId, profiles)
+	ok, obtained, err := instancemutater.VerifyCurrentProfiles(s.mutaterMachine, s.instId, profiles)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ok, jc.IsTrue)
+	c.Assert(obtained, jc.DeepEquals, profiles)
 }
 
 func (s *mutaterSuite) TestVerifyCurrentProfilesFalseLength(c *gc.C) {
@@ -189,39 +190,46 @@ func (s *mutaterSuite) TestVerifyCurrentProfilesFalseLength(c *gc.C) {
 	profiles := []string{"default", "juju-testme", "juju-testme-lxd-profile-0"}
 	s.expectLXDProfileNames(profiles, nil)
 
-	ok, err := instancemutater.VerifyCurrentProfiles(s.mutaterMachine, s.instId, append(profiles, "juju-testme-next-1"))
+	ok, obtained, err := instancemutater.VerifyCurrentProfiles(s.mutaterMachine, s.instId, append(profiles, "juju-testme-next-1"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ok, jc.IsFalse)
+	c.Assert(obtained, jc.DeepEquals, profiles)
 }
 
 func (s *mutaterSuite) TestVerifyCurrentProfilesFalseContents(c *gc.C) {
 	defer s.setUpMocks(c).Finish()
 
-	s.expectLXDProfileNames([]string{"default", "juju-testme", "juju-testme-lxd-profile-0"}, nil)
+	profiles := []string{"default", "juju-testme", "juju-testme-lxd-profile-0"}
+	s.expectLXDProfileNames(profiles, nil)
 
-	ok, err := instancemutater.VerifyCurrentProfiles(s.mutaterMachine, s.instId, []string{"default", "juju-testme", "juju-testme-lxd-profile-1"})
+	ok, obtained, err := instancemutater.VerifyCurrentProfiles(s.mutaterMachine, s.instId, []string{"default", "juju-testme", "juju-testme-lxd-profile-1"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ok, jc.IsFalse)
+	c.Assert(obtained, jc.DeepEquals, profiles)
 }
 
 func (s *mutaterSuite) TestVerifyCurrentProfilesFalseContentsWithMissingExpectedProfiles(c *gc.C) {
 	defer s.setUpMocks(c).Finish()
 
-	s.expectLXDProfileNames([]string{"default", "juju-testme", "juju-testme-lxd-profile-0"}, nil)
+	profiles := []string{"default", "juju-testme", "juju-testme-lxd-profile-0"}
+	s.expectLXDProfileNames(profiles, nil)
 
-	ok, err := instancemutater.VerifyCurrentProfiles(s.mutaterMachine, s.instId, []string{"default", "juju-testme"})
+	ok, obtained, err := instancemutater.VerifyCurrentProfiles(s.mutaterMachine, s.instId, []string{"default", "juju-testme"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ok, jc.IsFalse)
+	c.Assert(obtained, jc.DeepEquals, profiles)
 }
 
 func (s *mutaterSuite) TestVerifyCurrentProfilesFalseContentsWithMissingProviderProfiles(c *gc.C) {
 	defer s.setUpMocks(c).Finish()
 
-	s.expectLXDProfileNames([]string{"default", "juju-testme"}, nil)
+	profiles := []string{"default", "juju-testme"}
+	s.expectLXDProfileNames(profiles, nil)
 
-	ok, err := instancemutater.VerifyCurrentProfiles(s.mutaterMachine, s.instId, []string{"default", "juju-testme", "juju-testme-lxd-profile-0"})
+	ok, obtained, err := instancemutater.VerifyCurrentProfiles(s.mutaterMachine, s.instId, []string{"default", "juju-testme", "juju-testme-lxd-profile-0"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ok, jc.IsFalse)
+	c.Assert(obtained, jc.DeepEquals, profiles)
 }
 
 func (s *mutaterSuite) TestVerifyCurrentProfilesError(c *gc.C) {
@@ -229,9 +237,10 @@ func (s *mutaterSuite) TestVerifyCurrentProfilesError(c *gc.C) {
 
 	s.expectLXDProfileNames([]string{}, errors.NotFoundf("instId"))
 
-	ok, err := instancemutater.VerifyCurrentProfiles(s.mutaterMachine, s.instId, []string{"default"})
+	ok, obtained, err := instancemutater.VerifyCurrentProfiles(s.mutaterMachine, s.instId, []string{"default"})
 	c.Assert(err, jc.Satisfies, errors.IsNotFound)
 	c.Assert(ok, jc.IsFalse)
+	c.Assert(obtained, gc.IsNil)
 }
 
 func (s *mutaterSuite) setUpMocks(c *gc.C) *gomock.Controller {

--- a/worker/instancemutater/mutater_test.go
+++ b/worker/instancemutater/mutater_test.go
@@ -204,6 +204,26 @@ func (s *mutaterSuite) TestVerifyCurrentProfilesFalseContents(c *gc.C) {
 	c.Assert(ok, jc.IsFalse)
 }
 
+func (s *mutaterSuite) TestVerifyCurrentProfilesFalseContentsWithMissingExpectedProfiles(c *gc.C) {
+	defer s.setUpMocks(c).Finish()
+
+	s.expectLXDProfileNames([]string{"default", "juju-testme", "juju-testme-lxd-profile-0"}, nil)
+
+	ok, err := instancemutater.VerifyCurrentProfiles(s.mutaterMachine, s.instId, []string{"default", "juju-testme"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ok, jc.IsFalse)
+}
+
+func (s *mutaterSuite) TestVerifyCurrentProfilesFalseContentsWithMissingProviderProfiles(c *gc.C) {
+	defer s.setUpMocks(c).Finish()
+
+	s.expectLXDProfileNames([]string{"default", "juju-testme"}, nil)
+
+	ok, err := instancemutater.VerifyCurrentProfiles(s.mutaterMachine, s.instId, []string{"default", "juju-testme", "juju-testme-lxd-profile-0"})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(ok, jc.IsFalse)
+}
+
 func (s *mutaterSuite) TestVerifyCurrentProfilesError(c *gc.C) {
 	defer s.setUpMocks(c).Finish()
 

--- a/worker/instancemutater/mutater_test.go
+++ b/worker/instancemutater/mutater_test.go
@@ -47,11 +47,12 @@ func (s *mutaterSuite) TestProcessMachineProfileChanges(c *gc.C) {
 
 	startingProfiles := []string{"default", "juju-testme"}
 	finishingProfiles := append(startingProfiles, "juju-testme-lxd-profile-1")
+	charmProfiles := []string{"juju-testme-lxd-profile-1"}
 
 	s.expectRefreshLifeAliveStatusIdle()
 	s.expectLXDProfileNames(startingProfiles, nil)
 	s.expectAssignLXDProfiles(finishingProfiles, nil)
-	s.expectSetCharmProfiles(finishingProfiles)
+	s.expectSetCharmProfiles(charmProfiles)
 	s.expectModificationStatusApplied()
 
 	info := s.info(startingProfiles, 1, true)

--- a/worker/instancemutater/worker_test.go
+++ b/worker/instancemutater/worker_test.go
@@ -4,6 +4,7 @@
 package instancemutater_test
 
 import (
+	"fmt"
 	"strconv"
 	"sync"
 	"time"
@@ -202,7 +203,7 @@ func (s *workerEnvironSuite) TestFullWorkflow(c *gc.C) {
 	s.notifyMachineAppLXDProfile(0, 1)
 	s.expectMachineCharmProfilingInfo(0, 3)
 	s.expectLXDProfileNamesTrue()
-	s.expectSetCharmProfiles(0)
+	s.expectSetCharmProfiles(0, 3)
 	s.expectAssignLXDProfiles()
 	s.expectAliveAndSetModificationStatusIdle(0)
 	s.expectModificationStatusApplied(0)
@@ -219,6 +220,7 @@ func (s *workerEnvironSuite) TestVerifyCurrentProfilesTrue(c *gc.C) {
 	s.expectAliveAndSetModificationStatusIdle(0)
 	s.expectMachineCharmProfilingInfo(0, 2)
 	s.expectLXDProfileNamesTrue()
+	s.expectSetCharmProfiles(0, 2)
 	s.expectModificationStatusApplied(0)
 
 	s.cleanKill(c, s.workerForScenario(c))
@@ -256,6 +258,8 @@ func (s *workerEnvironSuite) TestMachineNotifyTwice(c *gc.C) {
 	s.expectMachineCharmProfilingInfo(1, 2)
 	s.expectLXDProfileNamesTrue()
 	s.expectLXDProfileNamesTrue()
+	s.expectSetCharmProfiles(0, 2)
+	s.expectSetCharmProfiles(1, 2)
 	s.expectMachineAliveStatusIdleMachineDead(0, &group)
 
 	s.cleanKill(c, s.workerForScenario(c))
@@ -516,8 +520,8 @@ func (s *workerSuite) expectAssignLXDProfiles() {
 	s.broker.EXPECT().AssignLXDProfiles("juju-23423-0", profiles, gomock.Any()).Return(profiles, nil)
 }
 
-func (s *workerSuite) expectSetCharmProfiles(machine int) {
-	s.machine[machine].EXPECT().SetCharmProfiles([]string{"default", "juju-testing", "juju-testing-one-3"})
+func (s *workerSuite) expectSetCharmProfiles(machine int, rev int) {
+	s.machine[machine].EXPECT().SetCharmProfiles([]string{"default", "juju-testing", fmt.Sprintf("juju-testing-one-%d", rev)})
 }
 
 func (s *workerSuite) expectRemoveAllCharmProfiles(machine int) {

--- a/worker/instancemutater/worker_test.go
+++ b/worker/instancemutater/worker_test.go
@@ -521,12 +521,12 @@ func (s *workerSuite) expectAssignLXDProfiles() {
 }
 
 func (s *workerSuite) expectSetCharmProfiles(machine int, rev int) {
-	s.machine[machine].EXPECT().SetCharmProfiles([]string{"default", "juju-testing", fmt.Sprintf("juju-testing-one-%d", rev)})
+	s.machine[machine].EXPECT().SetCharmProfiles([]string{fmt.Sprintf("juju-testing-one-%d", rev)})
 }
 
 func (s *workerSuite) expectRemoveAllCharmProfiles(machine int) {
 	profiles := []string{"default", "juju-testing"}
-	s.machine[machine].EXPECT().SetCharmProfiles(profiles)
+	s.machine[machine].EXPECT().SetCharmProfiles([]string{})
 	s.broker.EXPECT().AssignLXDProfiles("juju-23423-0", profiles, gomock.Any()).Return(profiles, nil)
 }
 
@@ -741,7 +741,7 @@ func (s *workerContainerSuite) expectAssignLXDProfiles() {
 }
 
 func (s *workerContainerSuite) expectContainerSetCharmProfiles() {
-	s.lxdContainer.EXPECT().SetCharmProfiles([]string{"default", "juju-testing-one-3"})
+	s.lxdContainer.EXPECT().SetCharmProfiles([]string{"juju-testing-one-3"})
 }
 
 // notifyContainers returns a suite behaviour that will cause the instance mutator

--- a/worker/provisioner/provisioner_task.go
+++ b/worker/provisioner/provisioner_task.go
@@ -1583,7 +1583,7 @@ func (task *provisionerTask) gatherCharmLXDProfiles(
 		return nil, errors.Trace(err)
 	}
 
-	return lxdprofile.LXDProfileNames(profileNames), nil
+	return lxdprofile.FilterLXDProfileNames(profileNames), nil
 }
 
 // markMachineFailedInAZ moves the machine in zone from MachineIds to FailedMachineIds


### PR DESCRIPTION
This ensures that if the provider profiles don't match the expected profiles, then return false from the verification process. We can shortcut the whole process by checking if the lengths match before doing any additional computation. Now that we know the sets are the same length, we can use the set difference method to check if both contain the same profiles. We couldn't use the set difference method previously as it was biased to the left side, so any additional items in the right side would be ignored.

Changing the logic gives us more reliable verification of the charm profiles, with the additional tests baking in that the profiles might be different.

Additionally, if the profiles reported back from the broker are already the profiles requested by the charms/model, we reflect this back to the machine entity. The reason for this is that sometimes setting the profiles via the broker can sometimes cause it to actually apply the profiles but report back an error. In this case we can see the profiles when reading from the broker, we can see they match what we expect, but we never reflect this back to the machine entity, leading to units with a charm that depends on that profile being applied to the machine, unable to proceed with startup.

<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://docs.google.com/document/d/1SYUo9G7qZ_jdoVXpUVamS5VCgHmtZ0QA-wZxKoMS-C0 
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Go unit tests, with comments saying what you're testing

## QA steps

Ensure that the units come up correctly.

```sh
$ juju bootstrap lxd test
$ juju deploy microk8s --channel 1.28/stable --config rbac=true --constraints "virt-type=virtual-machine" -n 3
```
 
## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2072769

**Jira card:** [JUJU-6384
](https://warthogs.atlassian.net/browse/JUJU-6384)
