### PR TITLE
refactor(apiserver): drop some state calls

### DIFF
--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -120,6 +120,7 @@ func TestingAPIHandler(c *gc.C, pool *state.StatePool, st *state.State, sf servi
 		context.Background(),
 		pool,
 		st,
+		st.ModelUUID(),
 		sf.ControllerConfig(),
 		sf.Access(),
 		sf.Macaroon(),

--- a/apiserver/stateauthenticator/authenticator_test.go
+++ b/apiserver/stateauthenticator/authenticator_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/juju/apiserver/authentication"
 	coreuser "github.com/juju/juju/core/user"
 	"github.com/juju/juju/internal/auth"
+	"github.com/juju/juju/internal/testing"
 	statetesting "github.com/juju/juju/state/testing"
 )
 
@@ -139,7 +140,7 @@ func (s *agentAuthenticatorSuite) setupMocks(c *gc.C) *gomock.Controller {
 	s.bakeryConfigService.EXPECT().GetLocalUsersKey(gomock.Any()).Return(bakery.MustGenerateKey(), nil).MinTimes(1)
 	s.bakeryConfigService.EXPECT().GetLocalUsersThirdPartyKey(gomock.Any()).Return(bakery.MustGenerateKey(), nil).MinTimes(1)
 
-	authenticator, err := NewAuthenticator(context.Background(), s.StatePool, s.State, s.controllerConfigService, s.accessService, s.bakeryConfigService, s.agentAuthenticatorFactory, clock.WallClock)
+	authenticator, err := NewAuthenticator(context.Background(), s.StatePool, s.State, testing.ModelTag.Id(), s.controllerConfigService, s.accessService, s.bakeryConfigService, s.agentAuthenticatorFactory, clock.WallClock)
 	c.Assert(err, jc.ErrorIsNil)
 	s.authenticator = authenticator
 

--- a/apiserver/stateauthenticator/context.go
+++ b/apiserver/stateauthenticator/context.go
@@ -121,6 +121,7 @@ func (OpenLoginAuthorizer) AuthorizeOps(ctx context.Context, authorizedOp bakery
 func newAuthContext(
 	ctx context.Context,
 	st *state.State,
+	controllerModelUUID string,
 	controllerConfigService ControllerConfigService,
 	accessService AccessService,
 	bakeryConfigService BakeryConfigService,
@@ -148,7 +149,7 @@ func newAuthContext(
 		func(ctx context.Context, cond, arg string) error { return nil },
 	)
 
-	location := "juju model " + st.ModelUUID()
+	location := "juju model " + controllerModelUUID
 	var err error
 	ctxt.localUserThirdPartyBakeryKey, err = bakeryConfigService.GetLocalUsersThirdPartyKey(ctx)
 	if err != nil {

--- a/apiserver/stateauthenticator/context_test.go
+++ b/apiserver/stateauthenticator/context_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/juju/juju/apiserver/authentication"
 	"github.com/juju/juju/controller"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
+	"github.com/juju/juju/internal/testing"
 	statetesting "github.com/juju/juju/state/testing"
 )
 
@@ -65,7 +66,7 @@ func (s *macaroonCommonSuite) setupMocks(c *gc.C) *gomock.Controller {
 
 	agentAuthFactory := authentication.NewAgentAuthenticatorFactory(s.State, loggertesting.WrapCheckLog(c))
 
-	authenticator, err := NewAuthenticator(context.Background(), s.StatePool, s.State, s.controllerConfigService, s.accessService, s.bakeryConfigService, agentAuthFactory, s.clock)
+	authenticator, err := NewAuthenticator(context.Background(), s.StatePool, s.State, testing.ModelTag.Id(), s.controllerConfigService, s.accessService, s.bakeryConfigService, agentAuthFactory, s.clock)
 	c.Assert(err, jc.ErrorIsNil)
 	s.authenticator = authenticator
 

--- a/domain/model/state/state_test.go
+++ b/domain/model/state/state_test.go
@@ -164,6 +164,8 @@ func (m *stateSuite) SetUpTest(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
+	userState.UpdateLastModelLogin(context.Background(), m.userName, m.uuid)
+
 	err = modelSt.Activate(context.Background(), m.uuid)
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/internal/worker/httpserverargs/authenticator.go
+++ b/internal/worker/httpserverargs/authenticator.go
@@ -57,6 +57,7 @@ type BakeryConfigService interface {
 type NewStateAuthenticatorFunc func(
 	ctx context.Context,
 	statePool *state.StatePool,
+	controllerModelUUID string,
 	controllerConfigService ControllerConfigService,
 	accessService AccessService,
 	bakeryConfigService BakeryConfigService,
@@ -72,6 +73,7 @@ type NewStateAuthenticatorFunc func(
 func NewStateAuthenticator(
 	ctx context.Context,
 	statePool *state.StatePool,
+	controllerModelUUID string,
 	controllerConfigService ControllerConfigService,
 	accessService AccessService,
 	bakeryConfigService BakeryConfigService,
@@ -84,7 +86,7 @@ func NewStateAuthenticator(
 		return nil, errors.Trace(err)
 	}
 	agentAuthFactory := authentication.NewAgentAuthenticatorFactory(systemState, nil)
-	stateAuthenticator, err := stateauthenticator.NewAuthenticator(ctx, statePool, systemState, controllerConfigService, accessService, bakeryConfigService, agentAuthFactory, clock)
+	stateAuthenticator, err := stateauthenticator.NewAuthenticator(ctx, statePool, systemState, controllerModelUUID, controllerConfigService, accessService, bakeryConfigService, agentAuthFactory, clock)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/internal/worker/httpserverargs/package_test.go
+++ b/internal/worker/httpserverargs/package_test.go
@@ -4,13 +4,13 @@
 package httpserverargs_test
 
 import (
-	"testing"
+	stdtesting "testing"
 
-	gc "gopkg.in/check.v1"
+	"github.com/juju/juju/internal/testing"
 )
 
 //go:generate go run go.uber.org/mock/mockgen -typed -package httpserverargs -destination services_mock_test.go github.com/juju/juju/internal/worker/httpserverargs ControllerConfigService,AccessService
 
-func TestPackage(t *testing.T) {
-	gc.TestingT(t)
+func TestPackage(t *stdtesting.T) {
+	testing.MgoTestPackage(t)
 }

--- a/internal/worker/httpserverargs/worker.go
+++ b/internal/worker/httpserverargs/worker.go
@@ -85,9 +85,16 @@ func newWorker(ctx context.Context, cfg workerConfig) (worker.Worker, error) {
 		return nil, errors.Trace(err)
 	}
 
+	st, err := w.cfg.statePool.SystemState()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	modelUUID := st.ModelUUID()
+
 	authenticator, err := w.cfg.newStateAuthenticatorFn(
 		ctx,
 		w.cfg.statePool,
+		modelUUID,
 		w.managedServices,
 		w.managedServices,
 		w.managedServices,

--- a/juju/testing/apiserver.go
+++ b/juju/testing/apiserver.go
@@ -359,7 +359,7 @@ func (s *ApiServerSuite) setupApiServer(c *gc.C, controllerCfg controller.Config
 	c.Assert(err, jc.ErrorIsNil)
 	agentAuthFactory := authentication.NewAgentAuthenticatorFactory(systemState, nil)
 
-	authenticator, err := stateauthenticator.NewAuthenticator(context.Background(), cfg.StatePool, systemState, factory.ControllerConfig(), factory.Access(), factory.Macaroon(), agentAuthFactory, cfg.Clock)
+	authenticator, err := stateauthenticator.NewAuthenticator(context.Background(), cfg.StatePool, systemState, string(cfg.ControllerModelID), factory.ControllerConfig(), factory.Access(), factory.Macaroon(), agentAuthFactory, cfg.Clock)
 	c.Assert(err, jc.ErrorIsNil)
 	cfg.LocalMacaroonAuthenticator = authenticator
 	err = authenticator.AddHandlers(s.mux)


### PR DESCRIPTION
Drop some state calls in apiserver stateauthenticator.

There were 2 places where we unnecessarily call out to state in stateauthenticator. In both these cases, we simply queried a model uuid

Get the model uuid in different ways.

1) In AuthenticateLoginRequest, the model uuid is included in the function
   params. Wire this up to checkCreds instead and use this.

   NOTE: This fixes a bug we had not noticed. We were using systemstate
   to get the model uuid, which returns the uuid of the controller model
   instead of the model being logged into

2) In newAuthContext, we queried state for the controller model uuid.
   This obviously never changes, so instead we load this uuid in
   httpserverargs worker, and pass it through into NewAuthenticator

This means now the only places we make calls to systemstate are for macaroon related reasons. Once this is backed with DQLite, we will be able to drop state from authContext entirely.

Also, fix a bug that arose from this causing foreign key constraint violations when destroying models. We forgot to clear user_last_login table for a model.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

Apply the following diff:
```
diff --git a/apiserver/stateauthenticator/auth.go b/apiserver/stateauthenticator/auth.go
index 60444dbf08..334e56c58a 100644
--- a/apiserver/stateauthenticator/auth.go
+++ b/apiserver/stateauthenticator/auth.go
@@ -77,6 +77,9 @@ func NewAuthenticator(
        if err != nil {
                return nil, errors.Trace(err)
        }
+
+       logger.Criticalf("controller model UUID: %s", controllerModelUUID)
+
        return &Authenticator{
                statePool:               statePool,
                controllerConfigService: controllerConfigService,
@@ -219,6 +222,8 @@ func (a *Authenticator) checkCreds(
                // For now we'll leave it as is, but we should fix this.
                userTag := entity.Tag().(names.UserTag)
 
+               logger.Criticalf("updating last model login for model: %s", modelUUID)
+
                err = a.authContext.userService.UpdateLastModelLogin(ctx, userTag.Name(), coremodel.UUID(modelUUID))
                if err != nil {
                        logger.Warningf("updating last login time for %v, %v", userTag, err)
```
And compile Juju.

### Run
```
$ juju bootstrap lxd lxd
```
And check the controller logs. You should find:
```
2024-07-16 14:26:03 CRITICAL juju.apiserver.stateauthenticator auth.go:81 controller model UUID: f2661205-6ae2-4840-8c7e-b3749843f8ca
```
Noting that:
```
$ juju show-model controller | yq ".[].model-uuid"
f2661205-6ae2-4840-8c7e-b3749843f8ca
```

### Also run

```
$ juju add-model m
$ juju status -m m
$ juju status -m controller
```
And check the controller logs. You should find:
```
2024-07-16 14:29:52 CRITICAL juju.apiserver.stateauthenticator auth.go:225 updating last model login for model: 90232ac9-f185-4b31-8a13-0ba34009531e
2024-07-16 14:29:56 CRITICAL juju.apiserver.stateauthenticator auth.go:225 updating last model login for model: f2661205-6ae2-4840-8c7e-b3749843f8ca
```
Noting that:
```
$ juju show-model m | yq ".[].model-uuid"
90232ac9-f185-4b31-8a13-0ba34009531e
```

### Destroy the model
```
$ juju destroy-model m --no-prompt
```