### PR TITLE
fix(machine): clean up controller units when removing controller machines

### DIFF
--- a/state/cleanup.go
+++ b/state/cleanup.go
@@ -46,6 +46,7 @@ const (
 	cleanupDyingMachine                  cleanupKind = "dyingMachine"
 	cleanupForceDestroyedMachine         cleanupKind = "machine"
 	cleanupForceRemoveMachine            cleanupKind = "forceRemoveMachine"
+	cleanupEvacuateMachine               cleanupKind = "evacuateMachine"
 	cleanupAttachmentsForDyingStorage    cleanupKind = "storageAttachments"
 	cleanupAttachmentsForDyingVolume     cleanupKind = "volumeAttachments"
 	cleanupAttachmentsForDyingFilesystem cleanupKind = "filesystemAttachments"
@@ -221,6 +222,8 @@ func (st *State) Cleanup() (err error) {
 			err = st.cleanupForceRemoveMachine(doc.Prefix, args)
 		case cleanupAttachmentsForDyingStorage:
 			err = st.cleanupAttachmentsForDyingStorage(doc.Prefix, args)
+		case cleanupEvacuateMachine:
+			err = st.cleanupEvacuateMachine(doc.Prefix, args)
 		case cleanupAttachmentsForDyingVolume:
 			err = st.cleanupAttachmentsForDyingVolume(doc.Prefix)
 		case cleanupAttachmentsForDyingFilesystem:
@@ -1434,6 +1437,62 @@ func (st *State) cleanupForceRemoveMachine(machineId string, cleanupArgs []bson.
 		return errors.Trace(err)
 	}
 	return machine.Remove()
+}
+
+// cleanupEvacuateMachine is initiated by machine.Destroy() to gracefully remove units
+// from the machine before then kicking off machine destroy.
+func (st *State) cleanupEvacuateMachine(machineId string, cleanupArgs []bson.Raw) error {
+	if len(cleanupArgs) > 0 {
+		return errors.Errorf("expected no arguments, got %d", len(cleanupArgs))
+	}
+
+	machine, err := st.Machine(machineId)
+	if errors.IsNotFound(err) {
+		return nil
+	} else if err != nil {
+		return errors.Trace(err)
+	}
+	if machine.Life() != Alive {
+		return nil
+	}
+
+	units, err := machine.Units()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	if len(units) == 0 {
+		if err := machine.advanceLifecycle(Dying, false, false, 0); err != nil {
+			return errors.Trace(err)
+		}
+		return nil
+	}
+
+	buildTxn := func(attempt int) ([]txn.Op, error) {
+		if attempt > 0 {
+			units, err = machine.Units()
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+		}
+		var ops []txn.Op
+		for _, unit := range units {
+			destroyOp := unit.DestroyOperation()
+			op, err := destroyOp.Build(attempt)
+			if err != nil && !errors.Is(err, jujutxn.ErrNoOperations) {
+				return nil, errors.Trace(err)
+			}
+			ops = append(ops, op...)
+		}
+		return ops, nil
+	}
+
+	err = st.db().Run(buildTxn)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	return errors.Errorf("waiting for units to be removed from %s", machineId)
 }
 
 // cleanupContainers recursively calls cleanupForceDestroyedMachine on the supplied

--- a/state/enableha_test.go
+++ b/state/enableha_test.go
@@ -525,8 +525,9 @@ func (s *EnableHASuite) TestForceDestroyFromHA(c *gc.C) {
 	err = m0.ForceDestroy(dontWait)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(m0.Refresh(), jc.ErrorIsNil)
-	// Could this actually get all the way to Dead?
-	c.Check(m0.Life(), gc.Equals, state.Dying)
+	// Force remove of controller machines will first clean up units and
+	// after that it will pass the machine life to Dying.
+	c.Check(m0.Life(), gc.Equals, state.Alive)
 	c.Assert(node.Refresh(), jc.ErrorIsNil)
 	c.Assert(node.WantsVote(), jc.IsFalse)
 }

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -374,7 +374,9 @@ func (s *MachineSuite) TestLifeJobManageModelWithControllerCharm(c *gc.C) {
 
 	err = m2.Refresh()
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(m2.Life(), gc.Equals, state.Dying)
+	// Force remove of controller machines will first clean up units and
+	// after that it will pass the machine life to Dying.
+	c.Assert(m2.Life(), gc.Equals, state.Alive)
 
 	cn2, err := s.State.ControllerNode(m2.Id())
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
This patch fixes an issue that appears when trying to remove a controller machine from an HA cluster.

The fix is basically to reintroduce the cleanup that was used before https://github.com/juju/juju/pull/17653.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Set up a HA cluster, remove two controller machines and then the controller should still be usable:
```
juju bootstrap lxc c
juju enable-ha
# Wait until HA replica set converges.

# This will fail:
juju  remove-machine -m controller 2
WARNING This command will perform the following actions:
will remove machine 2
- will remove unit controller/2

This will require `--force`

Continue [y/N]? y
ERROR removing machine failed: machine 2 has unit "controller/2" assigned

# Remove with --force works.
juju remove-machine -m controller 2 --force
# Wait until HA replica set converges.
juju remove-machine -m controller 1 --force
# Wait until HA replica set converges.
juju add-model m
juju deploy ubuntu
```
(The last two steps should work, this means the controller is still usable).

Also, the enable_ha CI tests should pass:
```
cd tests;  ./main.sh controller test_enable_ha
```

## Links

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2073409

**Jira card:** JUJU-6388

