### PR TITLE
feat(machine): add parental services for machines

### DIFF
--- a/domain/blockdevice/state/state.go
+++ b/domain/blockdevice/state/state.go
@@ -109,7 +109,7 @@ WHERE  machine.name = $M.name
 		return "", 0, errors.Annotatef(err, "looking up UUID for machine %q", machineId)
 	}
 	if len(result) == 0 {
-		return "", 0, fmt.Errorf("machine %q not found%w", machineId, errors.Hide(machineerrors.NotFound))
+		return "", 0, fmt.Errorf("machine %q not found%w", machineId, errors.Hide(machineerrors.MachineNotFound))
 	}
 	machineLife, ok := result["life_id"].(int64)
 	if !ok {

--- a/domain/keyupdater/service/service_test.go
+++ b/domain/keyupdater/service/service_test.go
@@ -91,17 +91,17 @@ func (s *serviceSuite) TestAuthorisedKeysForMachineNoControllerKeys(c *gc.C) {
 
 // TestAuthorisedKeysForMachineNotFound is asserting that if we ask for
 // authorised keys for a machine that doesn't exist we get back a
-// [machineerrors.NotFound] error.
+// [machineerrors.MachineNotFound] error.
 func (s *serviceSuite) TestAuthorisedKeysForMachineNotFound(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().AuthorisedKeysForMachine(gomock.Any(), coremachine.Name("0")).Return(nil, machineerrors.NotFound)
+	s.state.EXPECT().AuthorisedKeysForMachine(gomock.Any(), coremachine.Name("0")).Return(nil, machineerrors.MachineNotFound)
 
 	_, err := NewService(s.controllerKeyProvider, s.state).GetAuthorisedKeysForMachine(
 		context.Background(),
 		coremachine.Name("0"),
 	)
-	c.Check(err, jc.ErrorIs, machineerrors.NotFound)
+	c.Check(err, jc.ErrorIs, machineerrors.MachineNotFound)
 }
 
 // TestGetInitialAuthorisedKeysForContainerSuccess tests the happy path for

--- a/domain/keyupdater/state/state.go
+++ b/domain/keyupdater/state/state.go
@@ -29,7 +29,7 @@ func (s *State) AllPublicKeysQuery() string {
 
 // AuthorisedKeysForMachine returns a list of authorised public ssh keys for a
 // machine name. If no machine exists for the given machine name an error
-// satisfying [machineerrors.NotFound] will be returned.
+// satisfying [machineerrors.MachineNotFound] will be returned.
 func (s *State) AuthorisedKeysForMachine(
 	ctx context.Context,
 	name coremachine.Name,
@@ -71,7 +71,7 @@ FROM user_public_ssh_key
 		if errors.Is(err, sqlair.ErrNoRows) {
 			return fmt.Errorf(
 				"cannot get authorised keys for machine %q: %w",
-				name, machineerrors.NotFound,
+				name, machineerrors.MachineNotFound,
 			)
 		} else if err != nil {
 			return fmt.Errorf(

--- a/domain/keyupdater/state/state_test.go
+++ b/domain/keyupdater/state/state_test.go
@@ -90,11 +90,11 @@ func (s *stateSuite) SetUpTest(c *gc.C) {
 
 // TestAuthorisedKeysForUnknownMachine is assertint that if we ask for
 // authorised keys for a machine that doesn't exist we get back a
-// [machineerrors.NotFound] error.
+// [machineerrors.MachineNotFound] error.
 func (s *stateSuite) TestAuthorisedKeysForUnknownMachine(c *gc.C) {
 	state := NewState(s.TxnRunnerFactory())
 	_, err := state.AuthorisedKeysForMachine(context.Background(), coremachine.Name("100"))
-	c.Check(err, jc.ErrorIs, machineerrors.NotFound)
+	c.Check(err, jc.ErrorIs, machineerrors.MachineNotFound)
 }
 
 // TestEmptyAuthorisedKeysForMachine tests that if there are no authorised keys

--- a/domain/machine/errors/errors.go
+++ b/domain/machine/errors/errors.go
@@ -30,4 +30,12 @@ const (
 	// MachineAlreadyExists describes an error that occurs when creating a
 	// machine if a machine with the same name already exists.
 	MachineAlreadyExists = errors.ConstError("machine already exists")
+
+	// MachineHasNoParent describes an error that occurs when a machine has no
+	// parent.
+	MachineHasNoParent = errors.ConstError("machine has no parent")
+
+	// GrandParentNotAllowed describes an error that occurs when a parent is
+	// detected for a parent of a machine.
+	GrandParentNotAllowed = errors.ConstError("grandparent not allowed")
 )

--- a/domain/machine/errors/errors.go
+++ b/domain/machine/errors/errors.go
@@ -8,9 +8,9 @@ import (
 )
 
 const (
-	// NotFound describes an error that occurs when the machine being operated
-	// on does not exist.
-	NotFound = errors.ConstError("machine not found")
+	// MachineNotFound describes an error that occurs when the machine being
+	// operated on does not exist.
+	MachineNotFound = errors.ConstError("machine not found")
 
 	// NotProvisioned describes an error that occurs when the machine being
 	// operated on is not provisioned yet.

--- a/domain/machine/errors/errors.go
+++ b/domain/machine/errors/errors.go
@@ -34,8 +34,4 @@ const (
 	// MachineHasNoParent describes an error that occurs when a machine has no
 	// parent.
 	MachineHasNoParent = errors.ConstError("machine has no parent")
-
-	// GrandParentNotAllowed describes an error that occurs when a parent is
-	// detected for a parent of a machine.
-	GrandParentNotAllowed = errors.ConstError("grandparent not allowed")
 )

--- a/domain/machine/errors/errors.go
+++ b/domain/machine/errors/errors.go
@@ -26,4 +26,8 @@ const (
 	// GrandParentNotSupported describes an error that occurs when the operation
 	// found a grandparent machine, as it is not currently supported.
 	GrandParentNotSupported = errors.ConstError("grandparent machine are not supported currently")
+
+	// MachineAlreadyExists describes an error that occurs when creating a
+	// machine if a machine with the same name already exists.
+	MachineAlreadyExists = errors.ConstError("machine already exists")
 )

--- a/domain/machine/service/package_mock_test.go
+++ b/domain/machine/service/package_mock_test.go
@@ -159,6 +159,44 @@ func (c *MockStateCreateMachineCall) DoAndReturn(f func(context.Context, machine
 	return c
 }
 
+// CreateMachineWithParent mocks base method.
+func (m *MockState) CreateMachineWithParent(arg0 context.Context, arg1, arg2 machine.Name, arg3, arg4 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateMachineWithParent", arg0, arg1, arg2, arg3, arg4)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateMachineWithParent indicates an expected call of CreateMachineWithParent.
+func (mr *MockStateMockRecorder) CreateMachineWithParent(arg0, arg1, arg2, arg3, arg4 any) *MockStateCreateMachineWithParentCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateMachineWithParent", reflect.TypeOf((*MockState)(nil).CreateMachineWithParent), arg0, arg1, arg2, arg3, arg4)
+	return &MockStateCreateMachineWithParentCall{Call: call}
+}
+
+// MockStateCreateMachineWithParentCall wrap *gomock.Call
+type MockStateCreateMachineWithParentCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateCreateMachineWithParentCall) Return(arg0 error) *MockStateCreateMachineWithParentCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateCreateMachineWithParentCall) Do(f func(context.Context, machine.Name, machine.Name, string, string) error) *MockStateCreateMachineWithParentCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateCreateMachineWithParentCall) DoAndReturn(f func(context.Context, machine.Name, machine.Name, string, string) error) *MockStateCreateMachineWithParentCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // DeleteMachine mocks base method.
 func (m *MockState) DeleteMachine(arg0 context.Context, arg1 machine.Name) error {
 	m.ctrl.T.Helper()

--- a/domain/machine/service/package_mock_test.go
+++ b/domain/machine/service/package_mock_test.go
@@ -351,6 +351,45 @@ func (c *MockStateGetMachineLifeCall) DoAndReturn(f func(context.Context, machin
 	return c
 }
 
+// GetMachineParentUUID mocks base method.
+func (m *MockState) GetMachineParentUUID(arg0 context.Context, arg1 machine.Name) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMachineParentUUID", arg0, arg1)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetMachineParentUUID indicates an expected call of GetMachineParentUUID.
+func (mr *MockStateMockRecorder) GetMachineParentUUID(arg0, arg1 any) *MockStateGetMachineParentUUIDCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMachineParentUUID", reflect.TypeOf((*MockState)(nil).GetMachineParentUUID), arg0, arg1)
+	return &MockStateGetMachineParentUUIDCall{Call: call}
+}
+
+// MockStateGetMachineParentUUIDCall wrap *gomock.Call
+type MockStateGetMachineParentUUIDCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateGetMachineParentUUIDCall) Return(arg0 string, arg1 error) *MockStateGetMachineParentUUIDCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateGetMachineParentUUIDCall) Do(f func(context.Context, machine.Name) (string, error)) *MockStateGetMachineParentUUIDCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateGetMachineParentUUIDCall) DoAndReturn(f func(context.Context, machine.Name) (string, error)) *MockStateGetMachineParentUUIDCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetMachineStatus mocks base method.
 func (m *MockState) GetMachineStatus(arg0 context.Context, arg1 machine.Name) (status.StatusInfo, error) {
 	m.ctrl.T.Helper()

--- a/domain/machine/service/service.go
+++ b/domain/machine/service/service.go
@@ -108,6 +108,12 @@ type State interface {
 	// IsMachineRebootRequired checks if the machine referenced by its UUID requires a reboot.
 	IsMachineRebootRequired(ctx context.Context, uuid string) (bool, error)
 
+	// GetMachineParentUUID returns the parent UUID of the specified machine.
+	// It returns a NotFound if the machine does not exist.
+	// It returns a MachineHasNoParent if the machine has no parent.
+	// It returns a GrandParentNotAllowed if the machine's parent has a parent.
+	GetMachineParentUUID(ctx context.Context, machineName coremachine.Name) (string, error)
+
 	// ShouldRebootOrShutdown determines whether a machine should reboot or shutdown
 	ShouldRebootOrShutdown(ctx context.Context, uuid string) (machine.RebootAction, error)
 }
@@ -297,6 +303,18 @@ func (s *Service) CancelMachineReboot(ctx context.Context, uuid string) error {
 func (s *Service) IsMachineRebootRequired(ctx context.Context, uuid string) (bool, error) {
 	rebootRequired, err := s.st.IsMachineRebootRequired(ctx, uuid)
 	return rebootRequired, errors.Annotatef(err, "checking if machine with uuid %q is requiring a reboot", uuid)
+}
+
+// GetMachineParentUUID returns the parent UUID of the specified machine.
+// It returns a NotFound if the machine does not exist.
+// It returns a MachineHasNoParent if the machine has no parent.
+// It returns a GrandParentNotAllowed if the machine's parent has a parent.
+func (s *Service) GetMachineParentUUID(ctx context.Context, machineName coremachine.Name) (string, error) {
+	parentUUID, err := s.st.GetMachineParentUUID(ctx, machineName)
+	if err != nil {
+		return "", errors.Annotatef(err, "retrieving parent UUID for machine %q", machineName)
+	}
+	return parentUUID, nil
 }
 
 // ShouldRebootOrShutdown determines whether a machine should reboot or shutdown

--- a/domain/machine/service/service.go
+++ b/domain/machine/service/service.go
@@ -152,7 +152,7 @@ func (s *Service) CreateMachine(ctx context.Context, machineName coremachine.Nam
 // It returns a MachineAlreadyExists error if a machine with the same name
 // already exists.
 // It returns a NotFound error if the parent machine does not exist.
-func (s *Service) CreateMachineWithParent(ctx context.Context, machineName, parentName machine.Name) (string, error) {
+func (s *Service) CreateMachineWithParent(ctx context.Context, machineName, parentName coremachine.Name) (string, error) {
 	// Make a new UUIDs for the net-node and the machine.
 	// We want to do this in the service layer so that if retries are invoked at
 	// the state layer we don't keep regenerating.

--- a/domain/machine/service/service.go
+++ b/domain/machine/service/service.go
@@ -28,7 +28,7 @@ type State interface {
 	// with the parent machine.
 	// It returns a MachineAlreadyExists error if a machine with the same name
 	// already exists.
-	// It returns a NotFound error if the parent machine does not exist.
+	// It returns a MachineNotFound error if the parent machine does not exist.
 
 	CreateMachineWithParent(context.Context, coremachine.Name, coremachine.Name, string, string) error
 
@@ -44,11 +44,11 @@ type State interface {
 	InitialWatchModelMachinesStatement() (string, string)
 
 	// GetMachineLife returns the life status of the specified machine.
-	// It returns a NotFound if the given machine doesn't exist.
+	// It returns a MachineNotFound if the given machine doesn't exist.
 	GetMachineLife(context.Context, coremachine.Name) (*life.Life, error)
 
 	// SetMachineLife sets the life status of the specified machine.
-	// It returns a NotFound if the provided machine doesn't exist.
+	// It returns a MachineNotFound if the provided machine doesn't exist.
 	SetMachineLife(context.Context, coremachine.Name, life.Life) error
 
 	// AllMachineNames retrieves the names of all machines in the model.
@@ -65,22 +65,22 @@ type State interface {
 
 	// GetInstanceStatus returns the cloud specific instance status for this
 	// machine.
-	// It returns NotFound if the machine does not exist.
+	// It returns MachineNotFound if the machine does not exist.
 	// It returns a StatusNotSet if the instance status is not set.
 	GetInstanceStatus(context.Context, coremachine.Name) (status.StatusInfo, error)
 
 	// SetInstanceStatus sets the cloud specific instance status for this
 	// machine.
-	// It returns NotFound if the machine does not exist.
+	// It returns MachineNotFound if the machine does not exist.
 	SetInstanceStatus(context.Context, coremachine.Name, status.StatusInfo) error
 
 	// GetMachineStatus returns the status of the specified machine.
-	// It returns NotFound if the machine does not exist.
+	// It returns MachineNotFound if the machine does not exist.
 	// It returns a StatusNotSet if the status is not set.
 	GetMachineStatus(context.Context, coremachine.Name) (status.StatusInfo, error)
 
 	// SetMachineStatus sets the status of the specified machine.
-	// It returns NotFound if the machine does not exist.
+	// It returns MachineNotFound if the machine does not exist.
 	SetMachineStatus(context.Context, coremachine.Name, status.StatusInfo) error
 
 	// HardwareCharacteristics returns the hardware characteristics struct with
@@ -109,7 +109,7 @@ type State interface {
 	IsMachineRebootRequired(ctx context.Context, uuid string) (bool, error)
 
 	// GetMachineParentUUID returns the parent UUID of the specified machine.
-	// It returns a NotFound if the machine does not exist.
+	// It returns a MachineNotFound if the machine does not exist.
 	// It returns a MachineHasNoParent if the machine has no parent.
 	// It returns a GrandParentNotAllowed if the machine's parent has a parent.
 	GetMachineParentUUID(ctx context.Context, machineName coremachine.Name) (string, error)
@@ -151,7 +151,7 @@ func (s *Service) CreateMachine(ctx context.Context, machineName coremachine.Nam
 // parent.
 // It returns a MachineAlreadyExists error if a machine with the same name
 // already exists.
-// It returns a NotFound error if the parent machine does not exist.
+// It returns a MachineNotFound error if the parent machine does not exist.
 func (s *Service) CreateMachineWithParent(ctx context.Context, machineName, parentName coremachine.Name) (string, error) {
 	// Make a new UUIDs for the net-node and the machine.
 	// We want to do this in the service layer so that if retries are invoked at
@@ -193,7 +193,7 @@ func (s *Service) GetMachineLife(ctx context.Context, machineName coremachine.Na
 }
 
 // SetMachineLife sets the life status of the specified machine.
-// It returns a NotFound if the provided machine doesn't exist.
+// It returns a MachineNotFound if the provided machine doesn't exist.
 func (s *Service) SetMachineLife(ctx context.Context, machineName coremachine.Name, life life.Life) error {
 	err := s.st.SetMachineLife(ctx, machineName, life)
 	return errors.Annotatef(err, "setting life status for machine %q", machineName)
@@ -227,7 +227,7 @@ func (s *Service) InstanceId(ctx context.Context, machineName coremachine.Name) 
 
 // GetInstanceStatus returns the cloud specific instance status for this
 // machine.
-// It returns NotFound if the machine does not exist.
+// It returns MachineNotFound if the machine does not exist.
 // It returns a StatusNotSet if the instance status is not set.
 // Idempotent.
 func (s *Service) GetInstanceStatus(ctx context.Context, machineName coremachine.Name) (status.StatusInfo, error) {
@@ -240,7 +240,7 @@ func (s *Service) GetInstanceStatus(ctx context.Context, machineName coremachine
 
 // SetInstanceStatus sets the cloud specific instance status for this
 // machine.
-// It returns NotFound if the machine does not exist.
+// It returns MachineNotFound if the machine does not exist.
 // It returns InvalidStatus if the given status is not a known status value.
 func (s *Service) SetInstanceStatus(ctx context.Context, machineName coremachine.Name, status status.StatusInfo) error {
 	if !status.Status.KnownInstanceStatus() {
@@ -254,7 +254,7 @@ func (s *Service) SetInstanceStatus(ctx context.Context, machineName coremachine
 }
 
 // GetMachineStatus returns the status of the specified machine.
-// It returns NotFound if the machine does not exist.
+// It returns MachineNotFound if the machine does not exist.
 // It returns a StatusNotSet if the status is not set.
 // Idempotent.
 func (s *Service) GetMachineStatus(ctx context.Context, machineName coremachine.Name) (status.StatusInfo, error) {
@@ -266,7 +266,7 @@ func (s *Service) GetMachineStatus(ctx context.Context, machineName coremachine.
 }
 
 // SetMachineStatus sets the status of the specified machine.
-// It returns NotFound if the machine does not exist.
+// It returns MachineNotFound if the machine does not exist.
 // It returns InvalidStatus if the given status is not a known status value.
 func (s *Service) SetMachineStatus(ctx context.Context, machineName coremachine.Name, status status.StatusInfo) error {
 	if !status.Status.KnownMachineStatus() {
@@ -306,7 +306,7 @@ func (s *Service) IsMachineRebootRequired(ctx context.Context, uuid string) (boo
 }
 
 // GetMachineParentUUID returns the parent UUID of the specified machine.
-// It returns a NotFound if the machine does not exist.
+// It returns a MachineNotFound if the machine does not exist.
 // It returns a MachineHasNoParent if the machine has no parent.
 // It returns a GrandParentNotAllowed if the machine's parent has a parent.
 func (s *Service) GetMachineParentUUID(ctx context.Context, machineName coremachine.Name) (string, error) {

--- a/domain/machine/service/service.go
+++ b/domain/machine/service/service.go
@@ -20,17 +20,16 @@ import (
 // State describes retrieval and persistence methods for machines.
 type State interface {
 	// CreateMachine persists the input machine entity.
-	// It returns the uuid of the created machine.
 	// It returns a MachineAlreadyExists error if a machine with the same name
 	// already exists.
 	CreateMachine(context.Context, coremachine.Name, string, string) error
 
 	// CreateMachineWithparent persists the input machine entity, associating it
 	// with the parent machine.
-	// It returns the uuid of the created machine.
-	// It returns a NotFound error if the parent machine does not exist.
 	// It returns a MachineAlreadyExists error if a machine with the same name
 	// already exists.
+	// It returns a NotFound error if the parent machine does not exist.
+
 	CreateMachineWithParent(context.Context, coremachine.Name, coremachine.Name, string, string) error
 
 	// DeleteMachine deletes the input machine entity.
@@ -126,7 +125,8 @@ func NewService(st State) *Service {
 }
 
 // CreateMachine creates the specified machine.
-// It returns the uuid of the created machine.
+// It returns a MachineAlreadyExists error if a machine with the same name
+// already exists.
 func (s *Service) CreateMachine(ctx context.Context, machineName coremachine.Name) (string, error) {
 	// Make a new UUIDs for the net-node and the machine.
 	// We want to do this in the service layer so that if retries are invoked at
@@ -143,7 +143,8 @@ func (s *Service) CreateMachine(ctx context.Context, machineName coremachine.Nam
 
 // CreateMachineWirhParent creates the specified machine with the specified
 // parent.
-// It returns the uuid of the created machine.
+// It returns a MachineAlreadyExists error if a machine with the same name
+// already exists.
 // It returns a NotFound error if the parent machine does not exist.
 func (s *Service) CreateMachineWithParent(ctx context.Context, machineName, parentName machine.Name) (string, error) {
 	// Make a new UUIDs for the net-node and the machine.

--- a/domain/machine/service/service_test.go
+++ b/domain/machine/service/service_test.go
@@ -33,6 +33,7 @@ func (s *serviceSuite) setupMocks(c *gc.C) *gomock.Controller {
 	return ctrl
 }
 
+// TestCreateMachineSuccess asserts the happy path of the CreateMachine service.
 func (s *serviceSuite) TestCreateMachineSuccess(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
@@ -55,6 +56,70 @@ func (s *serviceSuite) TestCreateMachineError(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `creating machine "666": boom`)
 }
 
+// TestCreateMachineAlreadyExists asserts that the state layer returns a
+// MachineAlreadyExists Error if a machine is already found with the given
+// machineName, and that error is preserved and passed on to the service layer
+// to be handled there.
+func (s *serviceSuite) TestCreateMachineAlreadyExists(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.state.EXPECT().CreateMachine(gomock.Any(), cmachine.Name("666"), gomock.Any(), gomock.Any()).Return(machineerrors.MachineAlreadyExists)
+
+	_, err := NewService(s.state).CreateMachine(context.Background(), cmachine.Name("666"))
+	c.Check(err, jc.ErrorIs, machineerrors.MachineAlreadyExists)
+}
+
+// TestCreateMachineWithParentSuccess asserts the happy path of the
+// CreateMachineWithParent service.
+func (s *serviceSuite) TestCreateMachineWithParentSuccess(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.state.EXPECT().CreateMachineWithParent(gomock.Any(), cmachine.Name("666"), cmachine.Name("parent"), gomock.Any(), gomock.Any()).Return(nil)
+
+	_, err := NewService(s.state).CreateMachineWithParent(context.Background(), cmachine.Name("666"), cmachine.Name("parent"))
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+// TestCreateMachineWithParentError asserts that an error coming from the state
+// layer is preserved, passed over to the service layer to be maintained there.
+func (s *serviceSuite) TestCreateMachineWithParentError(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	rErr := errors.New("boom")
+	s.state.EXPECT().CreateMachineWithParent(gomock.Any(), cmachine.Name("666"), cmachine.Name("parent"), gomock.Any(), gomock.Any()).Return(rErr)
+
+	_, err := NewService(s.state).CreateMachineWithParent(context.Background(), cmachine.Name("666"), cmachine.Name("parent"))
+	c.Check(err, jc.ErrorIs, rErr)
+	c.Assert(err, gc.ErrorMatches, `creating machine "666" with parent "parent": boom`)
+}
+
+// TestCreateMachineWithParentParentNotFound asserts that the state layer
+// returns a NotFound Error if a machine is not found with the given parent
+// machineName, and that error is preserved and passed on to the service layer
+// to be handled there.
+func (s *serviceSuite) TestCreateMachineWithParentParentNotFound(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.state.EXPECT().CreateMachineWithParent(gomock.Any(), cmachine.Name("666"), cmachine.Name("parent"), gomock.Any(), gomock.Any()).Return(errors.NotFound)
+
+	_, err := NewService(s.state).CreateMachineWithParent(context.Background(), cmachine.Name("666"), cmachine.Name("parent"))
+	c.Check(err, jc.ErrorIs, errors.NotFound)
+}
+
+// TestCreateMachineWithParentMachineAlreadyExists asserts that the state layer
+// returns a MachineAlreadyExists Error if a machine is already found with the
+// given machineName, and that error is preserved and passed on to the service
+// layer to be handled there.
+func (s *serviceSuite) TestCreateMachineWithParentMachineAlreadyExists(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.state.EXPECT().CreateMachineWithParent(gomock.Any(), cmachine.Name("666"), cmachine.Name("parent"), gomock.Any(), gomock.Any()).Return(machineerrors.MachineAlreadyExists)
+
+	_, err := NewService(s.state).CreateMachineWithParent(context.Background(), cmachine.Name("666"), cmachine.Name("parent"))
+	c.Check(err, jc.ErrorIs, machineerrors.MachineAlreadyExists)
+}
+
+// TestDeleteMachineSuccess asserts the happy path of the DeleteMachine service.
 func (s *serviceSuite) TestDeleteMachineSuccess(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 

--- a/domain/machine/service/service_test.go
+++ b/domain/machine/service/service_test.go
@@ -578,20 +578,6 @@ func (s *serviceSuite) TestGetMachineParentUUIDMachineHasNoParent(c *gc.C) {
 	c.Check(parentUUID, gc.Equals, "")
 }
 
-// TestGetMachineParentUUIDGrandParentNotAllowed asserts that the state layer
-// returns a GrandParentNotAllowed Error if a machine is found with the given
-// machineName but has a grandparent, and that error is preserved and passed on
-// to the service layer to be handled there.
-func (s *serviceSuite) TestGetMachineParentUUIDGrandParentNotAllowed(c *gc.C) {
-	defer s.setupMocks(c).Finish()
-
-	s.state.EXPECT().GetMachineParentUUID(gomock.Any(), cmachine.Name("666")).Return("", machineerrors.GrandParentNotAllowed)
-
-	parentUUID, err := NewService(s.state).GetMachineParentUUID(context.Background(), cmachine.Name("666"))
-	c.Check(err, jc.ErrorIs, machineerrors.GrandParentNotAllowed)
-	c.Check(parentUUID, gc.Equals, "")
-}
-
 // TestMachineShouldRebootOrShutdownDoNothing asserts that the reboot action is preserved from the state
 // layer through the service layer.
 func (s *serviceSuite) TestMachineShouldRebootOrShutdownDoNothing(c *gc.C) {

--- a/domain/machine/state/reboot.go
+++ b/domain/machine/state/reboot.go
@@ -14,58 +14,61 @@ import (
 	"github.com/juju/juju/internal/database"
 )
 
-// RequireMachineReboot sets the machine referenced by its UUID as requiring a reboot.
+// RequireMachineReboot sets the machine referenced by its UUID as requiring a
+// reboot.
 //
-// Reboot requests are handled through the "machine_requires_reboot" table which contains only
-// machine UUID for which a reboot has been requested.
-// This function is idempotent.
+// Reboot requests are handled through the "machine_requires_reboot" table which
+// contains only machine UUID for which a reboot has been requested. This
+// function is idempotent.
 func (st *State) RequireMachineReboot(ctx context.Context, uuid string) error {
 	db, err := st.DB()
 	if err != nil {
 		return errors.Trace(err)
 	}
-
+	machineUUIDParam := machineUUID{uuid}
 	setRebootFlag := `INSERT INTO machine_requires_reboot (machine_uuid) VALUES ($machineUUID.uuid)`
-	setRebootFlagStmt, err := sqlair.Prepare(setRebootFlag, machineUUID{})
+	setRebootFlagStmt, err := sqlair.Prepare(setRebootFlag, machineUUIDParam)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		err := tx.Query(ctx, setRebootFlagStmt, machineUUID{uuid}).Run()
-		if database.IsErrConstraintPrimaryKey(err) {
-			// if the same uuid is added twice, do nothing (idempotency)
-			return nil
-		}
-		return err
+		return tx.Query(ctx, setRebootFlagStmt, machineUUIDParam).Run()
 	})
+
+	if database.IsErrConstraintPrimaryKey(err) {
+		// if the same uuid is added twice, do nothing (idempotency)
+		return nil
+	}
 	return errors.Annotatef(err, "requiring reboot of machine %q", uuid)
 }
 
-// CancelMachineReboot cancels the reboot of the machine referenced by its UUID if it has
-// previously been required.
+// CancelMachineReboot cancels the reboot of the machine referenced by its UUID
+// if it has previously been required.
 //
-// It basically removes the uuid from the "machine_requires_reboot" table if present.
-// This function is idempotent.
+// It basically removes the uuid from the "machine_requires_reboot" table if
+// present. This function is idempotent.
 func (st *State) CancelMachineReboot(ctx context.Context, uuid string) error {
 	db, err := st.DB()
 	if err != nil {
 		return errors.Trace(err)
 	}
+	machineUUIDParam := machineUUID{uuid}
 	unsetRebootFlag := `DELETE FROM machine_requires_reboot WHERE machine_uuid = $machineUUID.uuid`
-	unsetRebootFlagStmt, err := sqlair.Prepare(unsetRebootFlag, machineUUID{})
+	unsetRebootFlagStmt, err := sqlair.Prepare(unsetRebootFlag, machineUUIDParam)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		return tx.Query(ctx, unsetRebootFlagStmt, machineUUID{uuid}).Run()
+		return tx.Query(ctx, unsetRebootFlagStmt, machineUUIDParam).Run()
 	})
 	return errors.Annotatef(err, "cancelling reboot of machine %q", uuid)
 }
 
 // IsMachineRebootRequired checks if the specified machine requires a reboot.
 //
-// It queries the "machine_requires_reboot" table for the machine UUID to determine if a reboot is required.
-// Returns a boolean value indicating if a reboot is required, and an error if any occur during the process.
+// It queries the "machine_requires_reboot" table for the machine UUID to
+// determine if a reboot is required. Returns a boolean value indicating if a
+// reboot is required, and an error if any occur during the process.
 func (st *State) IsMachineRebootRequired(ctx context.Context, uuid string) (bool, error) {
 	db, err := st.DB()
 	if err != nil {
@@ -73,14 +76,14 @@ func (st *State) IsMachineRebootRequired(ctx context.Context, uuid string) (bool
 	}
 
 	var isRebootRequired bool
+	machineUUIDParam := machineUUID{uuid}
 	isRebootFlag := `SELECT machine_uuid as &machineUUID.uuid  FROM machine_requires_reboot WHERE machine_uuid = $machineUUID.uuid`
-	isRebootFlagStmt, err := sqlair.Prepare(isRebootFlag, machineUUID{})
+	isRebootFlagStmt, err := sqlair.Prepare(isRebootFlag, machineUUIDParam)
 	if err != nil {
 		return false, errors.Trace(err)
 	}
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		var results machineUUID
-		err := tx.Query(ctx, isRebootFlagStmt, machineUUID{uuid}).Get(&results)
+		err := tx.Query(ctx, isRebootFlagStmt, machineUUIDParam).Get(&machineUUIDParam)
 		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return errors.Trace(err)
 		}
@@ -91,16 +94,20 @@ func (st *State) IsMachineRebootRequired(ctx context.Context, uuid string) (bool
 	return isRebootRequired, errors.Annotatef(err, "requiring reboot of machine %q", uuid)
 }
 
-// ShouldRebootOrShutdown determines if a machine should reboot or shutdown based on its state and parent's state.
+// ShouldRebootOrShutdown determines if a machine should reboot or shutdown
+// based on its state and parent's state.
 //
-// The function first checks if a parent machine exists and requires a reboot. If so, it returns ShouldShutdown immediately.
+// The function first checks if a parent machine exists and requires a reboot.
+// If so, it returns ShouldShutdown immediately.
 //
-// If the parent machine does not require a reboot, the function checks if the current machine requires a reboot. If
-// so, it returns ShouldReboot. If neither the parent machine nor the current machine require a reboot, it returns
+// If the parent machine does not require a reboot, the function checks if the
+// current machine requires a reboot. If so, it returns ShouldReboot. If neither
+// the parent machine nor the current machine require a reboot, it returns
 // ShouldDoNothing.
 //
-// The function also check if there is a grandparent machine, which is not supported. In this case, the
-// function returns an errors.GrandParentNotSupported.
+// The function also check if there is a grandparent machine, which is not
+// supported. In this case, the function returns an
+// errors.GrandParentNotSupported.
 //
 // The function returns any error issued through interaction with the database,
 // annotated with the UUID of the machine.
@@ -110,13 +117,17 @@ func (st *State) ShouldRebootOrShutdown(ctx context.Context, uuid string) (machi
 		return machine.ShouldDoNothing, errors.Trace(err)
 	}
 
+	// Prepare query to get parent UUID
+	machineUUIDParam := machineUUID{uuid}
 	getParentQuery := `SELECT machine_parent.parent_uuid as &machineUUID.uuid  FROM machine_parent WHERE machine_uuid = $machineUUID.uuid`
-	getParentStmt, err := sqlair.Prepare(getParentQuery, machineUUID{})
+	getParentStmt, err := sqlair.Prepare(getParentQuery, machineUUIDParam)
 	if err != nil {
 		return machine.ShouldDoNothing, errors.Annotatef(err, "requiring reboot action for machine %q", uuid)
 	}
+
+	// Prepare query to check if a machine requires reboot
 	isRebootFlag := `SELECT machine_uuid as &machineUUID.uuid  FROM machine_requires_reboot WHERE machine_uuid = $machineUUID.uuid`
-	isRebootFlagStmt, err := sqlair.Prepare(isRebootFlag, machineUUID{})
+	isRebootFlagStmt, err := sqlair.Prepare(isRebootFlag, machineUUIDParam)
 	if err != nil {
 		return machine.ShouldDoNothing, errors.Annotatef(err, "requiring reboot action for machine %q", uuid)
 	}
@@ -125,7 +136,7 @@ func (st *State) ShouldRebootOrShutdown(ctx context.Context, uuid string) (machi
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		// Get parent UUID
 		var machine, parentMachine, grandParentMachine machineUUID
-		err := tx.Query(ctx, getParentStmt, machineUUID{uuid}).Get(&parentMachine)
+		err := tx.Query(ctx, getParentStmt, machineUUIDParam).Get(&parentMachine)
 		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return errors.Trace(err)
 		}
@@ -136,12 +147,23 @@ func (st *State) ShouldRebootOrShutdown(ctx context.Context, uuid string) (machi
 			return errors.Trace(err)
 		}
 		if err == nil {
-			// Grandparent are not supported. If you get there, possible cause are:
-			// - db corruption => need investigation, some parent machine have a parent themselves.
-			// - design change => new requirements imply that machine can have grandparent.
-			// In this later case you will need to update above code to fetch all grandparent is
-			// the chain, and check them for reboot. Moreover, be careful of loophole: if we
-			// accept grandparent in the actual representation in DQLite, we may have cycle.
+			// Grandparent are not supported. If you get there, possible cause
+			// are:
+			//
+			// - db corruption => need investigation, some parent machine have a
+			// parent themselves.
+			//
+			// - design change => new requirements imply that machine can have
+			// grandparent.
+			//
+			// In this later case you will need to update above code to fetch
+			// all grandparent is
+			//
+			// the chain, and check them for reboot. Moreover, be careful of
+			// loophole: if we
+			//
+			// accept grandparent in the actual representation in DQLite, we may
+			// have cycle.
 			return errors.Annotatef(machineerrors.GrandParentNotSupported, "found  %q parent of %q parent of %q", grandParentMachine.UUID, parentMachine.UUID, uuid)
 		}
 
@@ -158,7 +180,7 @@ func (st *State) ShouldRebootOrShutdown(ctx context.Context, uuid string) (machi
 		}
 
 		// Check machine reboot status
-		err = tx.Query(ctx, isRebootFlagStmt, machineUUID{uuid}).Get(&machine)
+		err = tx.Query(ctx, isRebootFlagStmt, machineUUIDParam).Get(&machine)
 		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			return errors.Trace(err)
 		}

--- a/domain/machine/state/state_test.go
+++ b/domain/machine/state/state_test.go
@@ -74,6 +74,45 @@ func (s *stateSuite) TestCreateMachine(c *gc.C) {
 	c.Assert(machineID, gc.Equals, "666")
 }
 
+// TestCreateMachineAlreadyExists asserts that a MachineAlreadyExists error is
+// returned when the machine already exists.
+func (s *stateSuite) TestCreateMachineAlreadyExists(c *gc.C) {
+	err := s.state.CreateMachine(context.Background(), "666", "", "")
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.state.CreateMachine(context.Background(), "666", "", "")
+	c.Check(err, jc.ErrorIs, machineerrors.MachineAlreadyExists)
+}
+
+// TestCreateMachineWithParentSuccess asserts the happy path of
+// CreateMachineWithParent at the state layer.
+func (s *stateSuite) TestCreateMachineWithParentSuccess(c *gc.C) {
+	// Create the parent first
+	err := s.state.CreateMachine(context.Background(), "666", "3", "1")
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Create the machine with the created parent
+	err = s.state.CreateMachineWithParent(context.Background(), "667", "666", "4", "2")
+	c.Check(err, jc.ErrorIsNil)
+}
+
+// TestCreateMachineWithParentNotFound asserts that a NotFound error is returned
+// when the parent machine is not found.
+func (s *stateSuite) TestCreateMachineWithParentNotFound(c *gc.C) {
+	err := s.state.CreateMachineWithParent(context.Background(), "667", "666", "4", "2")
+	c.Check(err, jc.ErrorIs, errors.NotFound)
+}
+
+// TestCreateMachineWithparentAlreadyExists asserts that a MachineAlreadyExists
+// error is returned when the machine to be created already exists.
+func (s *stateSuite) TestCreateMachineWithParentAlreadyExists(c *gc.C) {
+	err := s.state.CreateMachine(context.Background(), "666", "", "")
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.state.CreateMachineWithParent(context.Background(), "666", "357", "4", "2")
+	c.Check(err, jc.ErrorIs, machineerrors.MachineAlreadyExists)
+}
+
 // TestDeleteMachine asserts the happy path of DeleteMachine at the state layer.
 func (s *stateSuite) TestDeleteMachine(c *gc.C) {
 	err := s.state.CreateMachine(context.Background(), "666", "", "")

--- a/domain/machine/state/state_test.go
+++ b/domain/machine/state/state_test.go
@@ -100,7 +100,7 @@ func (s *stateSuite) TestCreateMachineWithParentSuccess(c *gc.C) {
 // when the parent machine is not found.
 func (s *stateSuite) TestCreateMachineWithParentNotFound(c *gc.C) {
 	err := s.state.CreateMachineWithParent(context.Background(), "667", "666", "4", "2")
-	c.Check(err, jc.ErrorIs, errors.NotFound)
+	c.Check(err, jc.ErrorIs, machineerrors.MachineNotFound)
 }
 
 // TestCreateMachineWithparentAlreadyExists asserts that a MachineAlreadyExists
@@ -233,7 +233,7 @@ func (s *stateSuite) TestGetMachineLifeSuccess(c *gc.C) {
 // machine is not found.
 func (s *stateSuite) TestGetMachineLifeNotFound(c *gc.C) {
 	_, err := s.state.GetMachineLife(context.Background(), "666")
-	c.Assert(err, jc.ErrorIs, machineerrors.NotFound)
+	c.Assert(err, jc.ErrorIs, machineerrors.MachineNotFound)
 }
 
 func (s *stateSuite) TestListAllMachines(c *gc.C) {
@@ -305,7 +305,7 @@ func (s *stateSuite) TestGetMachineStatusSuccessWithData(c *gc.C) {
 // when the machine is not found.
 func (s *stateSuite) TestGetMachineStatusNotFoundError(c *gc.C) {
 	_, err := s.state.GetMachineStatus(context.Background(), "666")
-	c.Assert(err, jc.ErrorIs, errors.NotFound)
+	c.Assert(err, jc.ErrorIs, machineerrors.MachineNotFound)
 }
 
 // TestGetMachineStatusNotSetError asserts that a StatusNotSet error is returned
@@ -355,7 +355,7 @@ func (s *stateSuite) TestSetMachineStatusSuccessWithData(c *gc.C) {
 // when the machine is not found.
 func (s *stateSuite) TestSetMachineStatusNotFoundError(c *gc.C) {
 	err := s.state.SetMachineStatus(context.Background(), "666", status.StatusInfo{})
-	c.Assert(err, jc.ErrorIs, errors.NotFound)
+	c.Assert(err, jc.ErrorIs, machineerrors.MachineNotFound)
 }
 
 // TestMachineStatusValues asserts the keys and values in the
@@ -474,7 +474,7 @@ func (s *stateSuite) TestSetMachineLifeSuccess(c *gc.C) {
 // provided machine doesn't exist.
 func (s *stateSuite) TestSetMachineLifeNotFoundError(c *gc.C) {
 	err := s.state.SetMachineLife(context.Background(), "666", life.Dead)
-	c.Assert(err, jc.ErrorIs, machineerrors.NotFound)
+	c.Assert(err, jc.ErrorIs, machineerrors.MachineNotFound)
 }
 
 // TestListAllMachinesEmpty asserts that AllMachineNames returns an empty list
@@ -557,7 +557,7 @@ func (s *stateSuite) TestGetMachineParentUUIDSuccess(c *gc.C) {
 // when the machine is not found.
 func (s *stateSuite) TestGetMachineParentUUIDNotFound(c *gc.C) {
 	_, err := s.state.GetMachineParentUUID(context.Background(), "666")
-	c.Assert(err, jc.ErrorIs, errors.NotFound)
+	c.Assert(err, jc.ErrorIs, machineerrors.MachineNotFound)
 }
 
 // TestGetMachineParentUUIDNoParent asserts that a NotFound error is returned

--- a/domain/machine/state/types.go
+++ b/domain/machine/state/types.go
@@ -104,6 +104,13 @@ type machineIsController struct {
 	IsController bool `db:"is_controller"`
 }
 
+// machineParent represents the struct to be used for the columns of the
+// machine_parent table within the sqlair statements in the machine domain.
+type machineParent struct {
+	MachineUUID string `db:"machine_uuid"`
+	ParentUUID  string `db:"parent_uuid"`
+}
+
 // toCoreMachineStatusValue converts an internal status used by machines (per
 // the machine_status_value table) into a core type status.Status.
 func (s *machineStatusWithData) toCoreMachineStatusValue() status.Status {
@@ -175,4 +182,13 @@ func fromCoreInstanceStatusValue(s status.Status) int {
 		internalStatus = 3
 	}
 	return internalStatus
+}
+
+// createMachineArgs represents the struct to be used for the input parameters
+// of the createMachine state method in the machine domain.
+type createMachineArgs struct {
+	name        machine.Name
+	machineUUID string
+	netNodeUUID string
+	parentName  machine.Name
 }


### PR DESCRIPTION
Follow up to https://github.com/juju/juju/pull/17746

Adds `CreateMachineWithParent` and `GetMachineParentUUID`.

`GetMachineParentUUID` guards against grandparents. If a parent is detected for a parent of a machine, a `GrandParentNotAllowed` error is returned.

Additionally it cleans up the `CreateMachine` logic a bit. The most notable change there is that we now return a `MachineAlreadyExists` if the machine to be created already exists. Create was originally written as an Upsert, so before this change a machine already existing was a no op.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```
TEST_PACKAGES="./domain/machine/... -count=1 -race" make run-go-tests
```

## Links

**Jira card:** JUJU-6378

