### PR TITLE
ci: fix licence check skip

### DIFF
--- a/tests/suites/static_analysis/licence.sh
+++ b/tests/suites/static_analysis/licence.sh
@@ -11,7 +11,7 @@ test_licence() {
 	fi
 	if ! which go-licenses >/dev/null 2>&1; then
 		echo "==> TEST SKIPPED: static licence analysis (go-licenses not installed)"
-		exit 0
+		return
 	fi
 
 	(


### PR DESCRIPTION
Shell tests should not exit 0, they should return. This fixes the licence check skipping when go-licenses is missing.