### PR TITLE
feat(apiserver): v12 of Controller facade

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -53,7 +53,7 @@ var facadeVersions = facades.FacadeVersions{
 	"Cleaner":                      {2},
 	"Client":                       {6, 7},
 	"Cloud":                        {7},
-	"Controller":                   {11},
+	"Controller":                   {11, 12},
 	"CredentialManager":            {1},
 	"CredentialValidator":          {2},
 	"CrossController":              {1},

--- a/apiserver/facades/client/controller/controller.go
+++ b/apiserver/facades/client/controller/controller.go
@@ -64,9 +64,13 @@ type ControllerAPI struct {
 	multiwatcherFactory multiwatcher.Factory
 }
 
+type ControllerAPIv11 struct {
+	*ControllerAPI
+}
+
 // LatestAPI is used for testing purposes to create the latest
 // controller API.
-var LatestAPI = newControllerAPIv11
+var LatestAPI = makeControllerAPI
 
 // TestingAPI is an escape hatch for requesting a controller API that won't
 // allow auth to correctly happen for ModelStatus. I'm not convicned this
@@ -435,7 +439,7 @@ func (c *ControllerAPI) ListBlockedModels() (params.ModelBlockInfoList, error) {
 // converted to a multi-model facade. Please use the ModelConfig facade's
 // ModelGet method instead:
 // [github.com/juju/juju/apiserver/facades/client/modelconfig.ModelConfigAPI.ModelGet]
-func (c *ControllerAPI) ModelConfig() (params.ModelConfigResults, error) {
+func (c *ControllerAPIv11) ModelConfig() (params.ModelConfigResults, error) {
 	result := params.ModelConfigResults{}
 	if err := c.checkIsSuperUser(); err != nil {
 		return result, errors.Trace(err)

--- a/apiserver/facades/client/controller/controller_test.go
+++ b/apiserver/facades/client/controller/controller_test.go
@@ -305,7 +305,10 @@ func (s *controllerSuite) TestListBlockedModelsNoBlocks(c *gc.C) {
 }
 
 func (s *controllerSuite) TestModelConfig(c *gc.C) {
-	cfg, err := s.controller.ModelConfig()
+	controller, err := controller.NewControllerAPIv11(s.context)
+	c.Assert(err, jc.ErrorIsNil)
+
+	cfg, err := controller.ModelConfig()
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cfg.Config["name"], jc.DeepEquals, params.ConfigValue{Value: "controller"})
 }

--- a/apiserver/facades/client/controller/destroy_test.go
+++ b/apiserver/facades/client/controller/destroy_test.go
@@ -58,7 +58,7 @@ func (s *destroyControllerSuite) SetUpTest(c *gc.C) {
 	s.authorizer = apiservertesting.FakeAuthorizer{
 		Tag: s.AdminUserTag(c),
 	}
-	testController, err := controller.NewControllerAPIv11(
+	testController, err := controller.LatestAPI(
 		facadetest.Context{
 			State_:     s.State,
 			StatePool_: s.StatePool,

--- a/apiserver/facades/client/controller/export_test.go
+++ b/apiserver/facades/client/controller/export_test.go
@@ -24,5 +24,5 @@ func NewControllerAPIForTest(backend Backend) *ControllerAPI {
 }
 
 var (
-	NewControllerAPIv11 = newControllerAPIv11
+	NewControllerAPIv11 = makeControllerAPIv11
 )

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -18742,7 +18742,7 @@
     {
         "Name": "Controller",
         "Description": "ControllerAPI provides the Controller API.",
-        "Version": 11,
+        "Version": 12,
         "AvailableTo": [
             "controller-machine-agent",
             "machine-agent",
@@ -18892,15 +18892,6 @@
                         }
                     },
                     "description": "ListBlockedModels returns a list of all models on the controller\nwhich have a block in place.  The resulting slice is sorted by model\nname, then owner. Callers must be controller administrators to retrieve the\nlist."
-                },
-                "ModelConfig": {
-                    "type": "object",
-                    "properties": {
-                        "Result": {
-                            "$ref": "#/definitions/ModelConfigResults"
-                        }
-                    },
-                    "description": "ModelConfig returns the model config for the controller model.\n\nDeprecated: this facade method will be removed in 4.0 when this facade is\nconverted to a multi-model facade. Please use the ModelConfig facade's\nModelGet method instead:\n[github.com/juju/juju/apiserver/facades/client/modelconfig.ModelConfigAPI.ModelGet]"
                 },
                 "ModelStatus": {
                     "type": "object",
@@ -19089,23 +19080,6 @@
                         }
                     },
                     "additionalProperties": false
-                },
-                "ConfigValue": {
-                    "type": "object",
-                    "properties": {
-                        "source": {
-                            "type": "string"
-                        },
-                        "value": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "value",
-                        "source"
-                    ]
                 },
                 "ControllerAPIInfoResult": {
                     "type": "object",
@@ -19591,23 +19565,6 @@
                         }
                     },
                     "additionalProperties": false
-                },
-                "ModelConfigResults": {
-                    "type": "object",
-                    "properties": {
-                        "config": {
-                            "type": "object",
-                            "patternProperties": {
-                                ".*": {
-                                    "$ref": "#/definitions/ConfigValue"
-                                }
-                            }
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "config"
-                    ]
                 },
                 "ModelFilesystemInfo": {
                     "type": "object",


### PR DESCRIPTION
v12 has removed the ModelConfig method. This is in preparation for 4.0 where we will change this facade to a multi-model facade. Calls to this facade method were already removed in #17732.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Bootstrap Juju, run `show-controller`, and check that the controller model version displays correctly:
```
$ juju show-controller | grep controller-model-version
    controller-model-version: 3.6-beta2.1
```

Run `upgrade-model` on the controller model, and check that it raises an error:
```
$ juju switch controller
$ juju upgrade-model
ERROR use upgrade-controller to upgrade the controller model
```

Run `destroy-controller` and check that the controller is successfully destroyed.

Bootstrap Juju again, and add the 3.6 controller to a 3.5 client:
```
juju3.6:~$ juju add-user juju35
User "juju35" added
Please send this command to juju35:
    juju register ...

juju3.6:~$ juju grant juju35 superuser
juju3.6:~$ juju grant juju35 admin controller
```
```
juju3.5:~$ juju register ...
```

Now do all the above steps again with the 3.5 client, to ensure compatibility between 3.5 and 3.6.

## Links

**Jira card:** JUJU-6351