### PR TITLE
fix(upgrade): fix broken upgrade on k8s

### DIFF
--- a/docker/registry/internal/acr.go
+++ b/docker/registry/internal/acr.go
@@ -33,16 +33,16 @@ func normalizeRepoDetailsAzure(repoDetails *docker.ImageRepoDetails) error {
 	return nil
 }
 
-func (c *azureContainerRegistry) String() string {
+func (c azureContainerRegistry) String() string {
 	return "azurecr.io"
 }
 
 // Match checks if the repository details matches current provider format.
-func (c *azureContainerRegistry) Match() bool {
+func (c azureContainerRegistry) Match() bool {
 	return strings.Contains(c.repoDetails.ServerAddress, "azurecr.io")
 }
 
-func (c *azureContainerRegistry) WrapTransport(...TransportWrapper) error {
+func (c azureContainerRegistry) WrapTransport(...TransportWrapper) error {
 	if c.repoDetails.BasicAuthConfig.Empty() {
 		return errors.NewNotValid(nil, fmt.Sprintf(`username and password are required for registry %q`, c.repoDetails.Repository))
 	}
@@ -57,9 +57,9 @@ func (c azureContainerRegistry) Tags(imageName string) (versions tools.Versions,
 	return c.fetchTags(url, &response)
 }
 
-// GetArchitecture returns the archtecture of the image for the specified tag.
-func (c azureContainerRegistry) GetArchitecture(imageName, tag string) (string, error) {
-	return getArchitecture(imageName, tag, c)
+// GetArchitectures returns the architectures of the image for the specified tag.
+func (c azureContainerRegistry) GetArchitectures(imageName, tag string) ([]string, error) {
+	return getArchitectures(imageName, tag, c)
 }
 
 // GetManifests returns the manifests of the image for the specified tag.

--- a/docker/registry/internal/acr_test.go
+++ b/docker/registry/internal/acr_test.go
@@ -294,10 +294,10 @@ func (s *azureContainerRegistrySuite) assertGetManifestsSchemaVersion1(c *gc.C, 
 func (s *azureContainerRegistrySuite) TestGetManifestsSchemaVersion1(c *gc.C) {
 	s.assertGetManifestsSchemaVersion1(c,
 		`
-{ "schemaVersion": 1, "name": "jujuqa/jujud-operator", "tag": "2.9.13", "architecture": "amd64"}
+{ "schemaVersion": 1, "name": "jujuqa/jujud-operator", "tag": "2.9.13", "architecture": "ppc64le"}
 `[1:],
 		`application/vnd.docker.distribution.manifest.v1+prettyjws`,
-		&internal.ManifestsResult{Architecture: "amd64"},
+		&internal.ManifestsResult{Architectures: []string{"ppc64el"}},
 	)
 }
 
@@ -316,6 +316,23 @@ func (s *azureContainerRegistrySuite) TestGetManifestsSchemaVersion2(c *gc.C) {
 `[1:],
 		`application/vnd.docker.distribution.manifest.v2+prettyjws`,
 		&internal.ManifestsResult{Digest: "sha256:f0609d8a844f7271411c1a9c5d7a898fd9f9c5a4844e3bc7db6d725b54671ac1"},
+	)
+}
+
+func (s *azureContainerRegistrySuite) TestGetManifestsSchemaVersion2List(c *gc.C) {
+	s.assertGetManifestsSchemaVersion1(c,
+		`
+{
+    "schemaVersion": 2,
+    "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+    "manifests": [
+        {"platform": {"architecture": "amd64"}},
+        {"platform": {"architecture": "ppc64le"}}
+    ]
+}
+`[1:],
+		`application/vnd.docker.distribution.manifest.list.v2+prettyjws`,
+		&internal.ManifestsResult{Architectures: []string{"amd64", "ppc64el"}},
 	)
 }
 

--- a/docker/registry/internal/base_client.go
+++ b/docker/registry/internal/base_client.go
@@ -194,12 +194,12 @@ func commonURLGetter(version APIVersion, url url.URL, pathTemplate string, args 
 	return url.String()
 }
 
-func (c baseClient) url(pathTemplate string, args ...interface{}) string {
+func (c *baseClient) url(pathTemplate string, args ...interface{}) string {
 	return commonURLGetter(c.APIVersion(), *c.baseURL, pathTemplate, args...)
 }
 
 // Ping pings the baseClient endpoint.
-func (c baseClient) Ping() error {
+func (c *baseClient) Ping() error {
 	url := c.url("/")
 	logger.Debugf("baseClient ping %q", url)
 	resp, err := c.client.Get(url)
@@ -209,7 +209,7 @@ func (c baseClient) Ping() error {
 	return errors.Trace(unwrapNetError(err))
 }
 
-func (c baseClient) ImageRepoDetails() (o docker.ImageRepoDetails) {
+func (c *baseClient) ImageRepoDetails() (o docker.ImageRepoDetails) {
 	if c.repoDetails != nil {
 		return *c.repoDetails
 	}
@@ -224,7 +224,7 @@ func (c *baseClient) Close() error {
 	return nil
 }
 
-func (c baseClient) getPaginatedJSON(url string, response interface{}) (string, error) {
+func (c *baseClient) getPaginatedJSON(url string, response interface{}) (string, error) {
 	resp, err := c.client.Get(url)
 	logger.Tracef("getPaginatedJSON for %q, err %v", url, err)
 	if err != nil {

--- a/docker/registry/internal/base_tags.go
+++ b/docker/registry/internal/base_tags.go
@@ -48,7 +48,7 @@ func fetchTagsV2(c tagFetcher, imageName string) (tools.Versions, error) {
 }
 
 // Tags fetches tags for an OCI image.
-func (c baseClient) Tags(imageName string) (tools.Versions, error) {
+func (c *baseClient) Tags(imageName string) (tools.Versions, error) {
 	switch c.APIVersion() {
 	case APIVersionV2:
 		return fetchTagsV2(c, imageName)
@@ -57,7 +57,7 @@ func (c baseClient) Tags(imageName string) (tools.Versions, error) {
 	}
 }
 
-func (c baseClient) fetchTags(url string, res tagsGetter) (versions tools.Versions, err error) {
+func (c *baseClient) fetchTags(url string, res tagsGetter) (versions tools.Versions, err error) {
 	pushVersions := func(tags []string) {
 		for _, tag := range tags {
 			v, err := version.Parse(tag)

--- a/docker/registry/internal/ecr.go
+++ b/docker/registry/internal/ecr.go
@@ -183,31 +183,31 @@ func (c *elasticContainerRegistry) WrapTransport(...TransportWrapper) (err error
 }
 
 // Ping pings the ecr endpoint.
-func (c elasticContainerRegistry) Ping() error {
+func (c *elasticContainerRegistry) Ping() error {
 	// No ping endpoint available for ecr.
 	return nil
 }
 
 // Tags fetches tags for an OCI image.
-func (c elasticContainerRegistry) Tags(imageName string) (versions tools.Versions, err error) {
+func (c *elasticContainerRegistry) Tags(imageName string) (versions tools.Versions, err error) {
 	url := c.url("/%s/tags/list", imageName)
 	var response tagsResponseV2
 	return c.fetchTags(url, &response)
 }
 
-// GetArchitecture returns the archtecture of the image for the specified tag.
-func (c elasticContainerRegistry) GetArchitecture(imageName, tag string) (string, error) {
-	return getArchitecture(imageName, tag, c)
+// GetArchitectures returns the architectures of the image for the specified tag.
+func (c *elasticContainerRegistry) GetArchitectures(imageName, tag string) ([]string, error) {
+	return getArchitectures(imageName, tag, c)
 }
 
 // GetManifests returns the manifests of the image for the specified tag.
-func (c elasticContainerRegistry) GetManifests(imageName, tag string) (*ManifestsResult, error) {
+func (c *elasticContainerRegistry) GetManifests(imageName, tag string) (*ManifestsResult, error) {
 	url := c.url("/%s/manifests/%s", imageName, tag)
 	return c.GetManifestsCommon(url)
 }
 
 // GetBlobs gets the archtecture of the image for the specified tag via blobs API.
-func (c elasticContainerRegistry) GetBlobs(imageName, digest string) (*BlobsResponse, error) {
+func (c *elasticContainerRegistry) GetBlobs(imageName, digest string) (*BlobsResponse, error) {
 	url := c.url("/%s/blobs/%s", imageName, digest)
 	return c.GetBlobsCommon(url)
 }

--- a/docker/registry/internal/ecr_test.go
+++ b/docker/registry/internal/ecr_test.go
@@ -336,10 +336,10 @@ func (s *elasticContainerRegistrySuite) assertGetManifestsSchemaVersion1(c *gc.C
 func (s *elasticContainerRegistrySuite) TestGetManifestsSchemaVersion1(c *gc.C) {
 	s.assertGetManifestsSchemaVersion1(c,
 		`
-{ "schemaVersion": 1, "name": "jujuqa/jujud-operator", "tag": "2.9.13", "architecture": "amd64"}
+{ "schemaVersion": 1, "name": "jujuqa/jujud-operator", "tag": "2.9.13", "architecture": "ppc64le"}
 `[1:],
 		`application/vnd.docker.distribution.manifest.v1+prettyjws`,
-		&internal.ManifestsResult{Architecture: "amd64"},
+		&internal.ManifestsResult{Architectures: []string{"ppc64el"}},
 	)
 }
 
@@ -358,6 +358,23 @@ func (s *elasticContainerRegistrySuite) TestGetManifestsSchemaVersion2(c *gc.C) 
 `[1:],
 		`application/vnd.docker.distribution.manifest.v2+prettyjws`,
 		&internal.ManifestsResult{Digest: "sha256:f0609d8a844f7271411c1a9c5d7a898fd9f9c5a4844e3bc7db6d725b54671ac1"},
+	)
+}
+
+func (s *elasticContainerRegistrySuite) TestGetManifestsSchemaVersion2List(c *gc.C) {
+	s.assertGetManifestsSchemaVersion1(c,
+		`
+{
+    "schemaVersion": 2,
+    "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+    "manifests": [
+        {"platform": {"architecture": "amd64"}},
+        {"platform": {"architecture": "ppc64le"}}
+    ]
+}
+`[1:],
+		`application/vnd.docker.distribution.manifest.list.v2+prettyjws`,
+		&internal.ManifestsResult{Architectures: []string{"amd64", "ppc64el"}},
 	)
 }
 

--- a/docker/registry/internal/interface.go
+++ b/docker/registry/internal/interface.go
@@ -16,7 +16,7 @@ import (
 type Registry interface {
 	String() string
 	Tags(string) (tools.Versions, error)
-	GetArchitecture(imageName, tag string) (string, error)
+	GetArchitectures(imageName, tag string) ([]string, error)
 	Close() error
 	Ping() error
 	ImageRepoDetails() docker.ImageRepoDetails

--- a/docker/registry/internal/package_test.go
+++ b/docker/registry/internal/package_test.go
@@ -16,15 +16,14 @@ func TestPackage(t *testing.T) {
 }
 
 type (
-	AzureContainerRegistry         = azureContainerRegistry
-	BaseClient                     = baseClient
-	Dockerhub                      = dockerhub
-	GoogleContainerRegistry        = googleContainerRegistry
-	GithubContainerRegistry        = githubContainerRegistry
-	GitlabContainerRegistry        = gitlabContainerRegistry
-	QuayContainerRegistry          = quayContainerRegistry
-	ElasticContainerRegistry       = elasticContainerRegistry
-	ElasticContainerRegistryPublic = elasticContainerRegistryPublic
+	AzureContainerRegistry   = azureContainerRegistry
+	BaseClient               = baseClient
+	Dockerhub                = dockerhub
+	GoogleContainerRegistry  = googleContainerRegistry
+	GithubContainerRegistry  = githubContainerRegistry
+	GitlabContainerRegistry  = gitlabContainerRegistry
+	QuayContainerRegistry    = quayContainerRegistry
+	ElasticContainerRegistry = elasticContainerRegistry
 )
 
 var (
@@ -34,7 +33,7 @@ var (
 	NewTokenTransport                  = newTokenTransport
 	NewElasticContainerRegistryForTest = newElasticContainerRegistryForTest
 	NewAzureContainerRegistry          = newAzureContainerRegistry
-	GetArchitecture                    = getArchitecture
+	GetArchitectures                   = getArchitectures
 	UnwrapNetError                     = unwrapNetError
 )
 

--- a/docker/registry/mocks/registry_mock.go
+++ b/docker/registry/mocks/registry_mock.go
@@ -55,19 +55,19 @@ func (mr *MockRegistryMockRecorder) Close() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockRegistry)(nil).Close))
 }
 
-// GetArchitecture mocks base method.
-func (m *MockRegistry) GetArchitecture(arg0, arg1 string) (string, error) {
+// GetArchitectures mocks base method.
+func (m *MockRegistry) GetArchitectures(arg0, arg1 string) ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetArchitecture", arg0, arg1)
-	ret0, _ := ret[0].(string)
+	ret := m.ctrl.Call(m, "GetArchitectures", arg0, arg1)
+	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetArchitecture indicates an expected call of GetArchitecture.
-func (mr *MockRegistryMockRecorder) GetArchitecture(arg0, arg1 any) *gomock.Call {
+// GetArchitectures indicates an expected call of GetArchitectures.
+func (mr *MockRegistryMockRecorder) GetArchitectures(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetArchitecture", reflect.TypeOf((*MockRegistry)(nil).GetArchitecture), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetArchitectures", reflect.TypeOf((*MockRegistry)(nil).GetArchitectures), arg0, arg1)
 }
 
 // ImageRepoDetails mocks base method.


### PR DESCRIPTION
Upgrades on k8s were broken due to the oci image fat manifest format not being supported by Juju.

The fix is to add this format to what Juju can ingest. The manifest contains multiple architectures, so the GetArchitecture() method is changed to GetArchitectures() and the clients that call it are adapted to suit. The clients are looking for a single arch, so the check becomes does the wanted arch exist in the set.

Also, the arches were not being normalised. The registry returns ppc64le but juju uses ppc64el. We hadn't noticed since only amd64 or arm64 was in common use.

## QA steps

Check bootstrap

`juju bootstrap microk8s --agent-version=3.4.2 --config caas-image-repo=public.ecr.aws/juju`

Change version.go to 3.4.3 and compile and push image to microk8s.
bootstrap a 3.4.3 controller

juju upgrade-controller --dry-run
juju upgrade-controller 

Should pick 3.4.4

## Links

https://bugs.launchpad.net/bugs/2073301

**Jira card:** [JUJU-6391](https://warthogs.atlassian.net/browse/JUJU-6391)



[JUJU-6391]: https://warthogs.atlassian.net/browse/JUJU-6391?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ