### PR TITLE
feat: db error metrics

### DIFF
--- a/internal/database/txn/context.go
+++ b/internal/database/txn/context.go
@@ -16,11 +16,15 @@ const (
 type MetricErrorType string
 
 const (
-	sqliteRetryableError MetricErrorType = "sqlite-retryable-error"
+	noRowsError    MetricErrorType = "dqlite-no-rows"
+	retryableError MetricErrorType = "dqlite-retryable-error"
+	unknownError   MetricErrorType = "unknown-error"
 )
 
 // Metrics is the interface that must be implemented by the metrics collector.
 type Metrics interface {
+	// RecordSuccess records a successful operation.
+	RecordSuccess()
 	// RecordError records an error of the given error type.
 	RecordError(MetricErrorType)
 }
@@ -41,5 +45,7 @@ func MetricsFromContext(ctx context.Context) Metrics {
 }
 
 type noopsMetrics struct{}
+
+func (noopsMetrics) RecordSuccess() {}
 
 func (noopsMetrics) RecordError(MetricErrorType) {}

--- a/internal/database/txn/context.go
+++ b/internal/database/txn/context.go
@@ -1,0 +1,45 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package txn
+
+import "context"
+
+// contextKey is a type used for context keys in this package.
+type contextKey string
+
+const (
+	metricsKey contextKey = "metrics"
+)
+
+// MetricErrorType is the type of error that should be recorded.
+type MetricErrorType string
+
+const (
+	sqliteRetryableError MetricErrorType = "sqlite-retryable-error"
+)
+
+// Metrics is the interface that must be implemented by the metrics collector.
+type Metrics interface {
+	// RecordError records an error of the given error type.
+	RecordError(MetricErrorType)
+}
+
+// WithMetrics returns a new context with the given metrics.
+func WithMetrics(ctx context.Context, metrics Metrics) context.Context {
+	return context.WithValue(ctx, metricsKey, metrics)
+}
+
+// MetricsFromContext returns the metrics from the given context.
+// If no metrics are found, then a noops metrics is returned.
+func MetricsFromContext(ctx context.Context) Metrics {
+	metrics, _ := ctx.Value(metricsKey).(Metrics)
+	if metrics == nil {
+		return noopsMetrics{}
+	}
+	return metrics
+}
+
+type noopsMetrics struct{}
+
+func (noopsMetrics) RecordError(MetricErrorType) {}

--- a/internal/worker/dbaccessor/metrics.go
+++ b/internal/worker/dbaccessor/metrics.go
@@ -3,7 +3,11 @@
 
 package dbaccessor
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/juju/juju/internal/database/txn"
+)
 
 const (
 	dbaccessorMetricsNamespace   = "juju"
@@ -14,6 +18,7 @@ const (
 type Collector struct {
 	DBRequests  *prometheus.GaugeVec
 	DBDuration  *prometheus.HistogramVec
+	DBErrors    *prometheus.CounterVec
 	TxnRequests *prometheus.CounterVec
 	TxnRetries  *prometheus.CounterVec
 }
@@ -33,6 +38,12 @@ func NewMetricsCollector() *Collector {
 			Name:      "duration_seconds",
 			Help:      "Total time spent in db requests.",
 		}, []string{"namespace", "result"}),
+		DBErrors: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: dbaccessorMetricsNamespace,
+			Subsystem: dbaccessorSubsystemNamespace,
+			Name:      "errors_total",
+			Help:      "Total number of db errors.",
+		}, []string{"namespace", "error"}),
 		TxnRequests: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: dbaccessorMetricsNamespace,
 			Subsystem: dbaccessorSubsystemNamespace,
@@ -52,6 +63,7 @@ func NewMetricsCollector() *Collector {
 func (c *Collector) Describe(ch chan<- *prometheus.Desc) {
 	c.DBRequests.Describe(ch)
 	c.DBDuration.Describe(ch)
+	c.DBErrors.Describe(ch)
 	c.TxnRequests.Describe(ch)
 	c.TxnRetries.Describe(ch)
 }
@@ -60,6 +72,26 @@ func (c *Collector) Describe(ch chan<- *prometheus.Desc) {
 func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 	c.DBRequests.Collect(ch)
 	c.DBDuration.Collect(ch)
+	c.DBErrors.Collect(ch)
 	c.TxnRequests.Collect(ch)
 	c.TxnRetries.Collect(ch)
+}
+
+// DBMetricsForNamespace returns a Metrics implementation for the given
+// namespace.
+func (c *Collector) DBMetricsForNamespace(namespace string) txn.Metrics {
+	return dbMetrics{
+		collector: c,
+		namespace: namespace,
+	}
+}
+
+type dbMetrics struct {
+	collector *Collector
+	namespace string
+}
+
+// RecordError records an error of the given error type.
+func (m dbMetrics) RecordError(errorType txn.MetricErrorType) {
+	m.collector.DBErrors.WithLabelValues(m.namespace, string(errorType)).Inc()
 }

--- a/internal/worker/dbaccessor/metrics_test.go
+++ b/internal/worker/dbaccessor/metrics_test.go
@@ -28,6 +28,7 @@ func (s *metricsSuite) TestMetricsAreCollected(c *gc.C) {
 		defer close(done)
 		collector.DBDuration.WithLabelValues("foo", "success").Observe(0.1)
 		collector.DBRequests.WithLabelValues("foo").Inc()
+		collector.DBErrors.WithLabelValues("foo", "bar").Inc()
 		collector.TxnRequests.WithLabelValues("foo").Inc()
 		collector.TxnRetries.WithLabelValues("foo").Inc()
 	}()
@@ -55,6 +56,9 @@ juju_db_duration_seconds_bucket{namespace="foo",result="success",le="10"} 1
 juju_db_duration_seconds_bucket{namespace="foo",result="success",le="+Inf"} 1
 juju_db_duration_seconds_sum{namespace="foo",result="success"} 0.1
 juju_db_duration_seconds_count{namespace="foo",result="success"} 1
+# HELP juju_db_errors_total Total number of db errors.
+# TYPE juju_db_errors_total counter
+juju_db_errors_total{error="bar",namespace="foo"} 1
 # HELP juju_db_requests_total Number of active db requests.
 # TYPE juju_db_requests_total gauge
 juju_db_requests_total{namespace="foo"} 1
@@ -70,6 +74,7 @@ juju_db_txn_retries_total{namespace="foo"} 1
 		collector, expected,
 		"juju_db_requests_total",
 		"juju_db_duration_seconds",
+		"juju_db_errors_total",
 		"juju_db_txn_requests_total",
 		"juju_db_txn_retries_total",
 	)

--- a/internal/worker/dbaccessor/metrics_test.go
+++ b/internal/worker/dbaccessor/metrics_test.go
@@ -29,6 +29,7 @@ func (s *metricsSuite) TestMetricsAreCollected(c *gc.C) {
 		collector.DBDuration.WithLabelValues("foo", "success").Observe(0.1)
 		collector.DBRequests.WithLabelValues("foo").Inc()
 		collector.DBErrors.WithLabelValues("foo", "bar").Inc()
+		collector.DBSuccess.WithLabelValues("foo").Inc()
 		collector.TxnRequests.WithLabelValues("foo").Inc()
 		collector.TxnRetries.WithLabelValues("foo").Inc()
 	}()
@@ -62,6 +63,9 @@ juju_db_errors_total{error="bar",namespace="foo"} 1
 # HELP juju_db_requests_total Number of active db requests.
 # TYPE juju_db_requests_total gauge
 juju_db_requests_total{namespace="foo"} 1
+# HELP juju_db_success_total Total number of successful db operations.
+# TYPE juju_db_success_total counter
+juju_db_success_total{namespace="foo"} 1
 # HELP juju_db_txn_requests_total Total number of txn requests including retries.
 # TYPE juju_db_txn_requests_total counter
 juju_db_txn_requests_total{namespace="foo"} 1
@@ -75,6 +79,7 @@ juju_db_txn_retries_total{namespace="foo"} 1
 		"juju_db_requests_total",
 		"juju_db_duration_seconds",
 		"juju_db_errors_total",
+		"juju_db_success_total",
 		"juju_db_txn_requests_total",
 		"juju_db_txn_retries_total",
 	)


### PR DESCRIPTION
We often see db errors when bootstrapping or creating a model, so to better understand that, I've added a metric to witness it. The metric is simple at them moment, it just highlights that there was a retryable error. We might want to expose the underlying error type (not message string) in the future, but we have to be careful about the cardinality.

To prevent having to change the transaction runner for an optional dependency I'm drawing inspiration from the tracing setup. In that vein, I'm passing the metrics through the context. Alternatively, we could create the transaction runner in the db accessor, but I'm not sure it's worth the churn. If this becomes a common pattern, we can change the db accessor to intern the transaction runner.

<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://docs.google.com/document/d/1SYUo9G7qZ_jdoVXpUVamS5VCgHmtZ0QA-wZxKoMS-C0 
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
$ juju bootstrap lxd test
$ juju ssh -m controller 0
$ juju_metrics | grep juju_db_error
# HELP juju_db_errors_total Total number of db errors.
# TYPE juju_db_errors_total counter
juju_db_errors_total{error="sqlite-retryable-error",namespace="f6a16ab1-d50b-4dbe-81e7-1265a9f5ba92"} 58
```

Create 40 models:

```sh
for i in $(seq 1 40); do juju add-model "model-$i"; done
```

Then run the metrics again:

```sh
# HELP juju_db_errors_total Total number of db errors.
# TYPE juju_db_errors_total counter
juju_db_errors_total{error="dqlite-retryable-error",namespace="0168204f-428d-4dfc-8bd8-6d399ede0d4b"} 36
juju_db_errors_total{error="dqlite-retryable-error",namespace="082a6596-3f28-4bae-8d40-323e7faa32a4"} 1
juju_db_errors_total{error="dqlite-retryable-error",namespace="08406653-0400-415e-88a6-5b6b8755e877"} 2
juju_db_errors_total{error="dqlite-retryable-error",namespace="12cecef5-251d-4a23-8080-9cb250a7e2f1"} 1
juju_db_errors_total{error="dqlite-retryable-error",namespace="1890a9a9-9549-4fff-8bef-3fb3dd577e91"} 2
juju_db_errors_total{error="dqlite-retryable-error",namespace="19198f46-f9e7-4cf9-8604-966fed40a343"} 1
juju_db_errors_total{error="dqlite-retryable-error",namespace="1ee3ab00-6afb-4223-8943-7b54a0571732"} 2
juju_db_errors_total{error="dqlite-retryable-error",namespace="2c79ee47-a5a2-4af5-8ae7-17cdd5862a71"} 2
juju_db_errors_total{error="dqlite-retryable-error",namespace="510661bd-f45a-45c9-87c5-3246008c1e79"} 2
juju_db_errors_total{error="dqlite-retryable-error",namespace="53b33b18-de9d-422a-86c3-fc2e9e17478d"} 1
juju_db_errors_total{error="dqlite-retryable-error",namespace="5f281b09-c2be-40d1-8167-82574f55292c"} 1
juju_db_errors_total{error="dqlite-retryable-error",namespace="6882fff9-810e-4825-84e6-e417400febaf"} 1
juju_db_errors_total{error="dqlite-retryable-error",namespace="9bc7712f-0e20-426b-88c0-d1d9f5c9b52a"} 1
juju_db_errors_total{error="dqlite-retryable-error",namespace="a2516167-8243-4613-8928-dbc4a13b4e8e"} 1
juju_db_errors_total{error="dqlite-retryable-error",namespace="a40f2511-1afc-4374-88c1-95b90baa9861"} 2
juju_db_errors_total{error="dqlite-retryable-error",namespace="b3471906-3535-49d8-889d-6a07238946f6"} 1
juju_db_errors_total{error="dqlite-retryable-error",namespace="bd426372-c230-4948-81a6-7a0925d36f39"} 2
juju_db_errors_total{error="dqlite-retryable-error",namespace="c623c7c2-8c9b-45f0-8060-ef823073ddb8"} 2
juju_db_errors_total{error="dqlite-retryable-error",namespace="c8682e63-7b46-4036-8bec-eab8b97bb764"} 2
juju_db_errors_total{error="dqlite-retryable-error",namespace="c96a8d86-5166-465f-8f1d-4d239f5f66cf"} 2
juju_db_errors_total{error="dqlite-retryable-error",namespace="cd4dcd3b-932c-4e2d-82da-0450a3d99b49"} 1
juju_db_errors_total{error="dqlite-retryable-error",namespace="controller"} 2
juju_db_errors_total{error="dqlite-retryable-error",namespace="d24ed665-075e-4aa2-8589-d077a68a6437"} 1
juju_db_errors_total{error="dqlite-retryable-error",namespace="da1000cc-de67-465c-817f-4a8f11b4f7a7"} 2
juju_db_errors_total{error="dqlite-retryable-error",namespace="fdc51912-8313-46b6-8167-a70e6ed995d9"} 2
juju_db_errors_total{error="unknown-error",namespace="0168204f-428d-4dfc-8bd8-6d399ede0d4b"} 5
juju_db_errors_total{error="unknown-error",namespace="controller"} 11
# HELP juju_db_success_total Total number of successful db operations.
# TYPE juju_db_success_total counter
juju_db_success_total{namespace="0168204f-428d-4dfc-8bd8-6d399ede0d4b"} 251
juju_db_success_total{namespace="082a6596-3f28-4bae-8d40-323e7faa32a4"} 90
juju_db_success_total{namespace="08406653-0400-415e-88a6-5b6b8755e877"} 94
juju_db_success_total{namespace="12cecef5-251d-4a23-8080-9cb250a7e2f1"} 93
juju_db_success_total{namespace="1890a9a9-9549-4fff-8bef-3fb3dd577e91"} 87
juju_db_success_total{namespace="19198f46-f9e7-4cf9-8604-966fed40a343"} 86
juju_db_success_total{namespace="1ee3ab00-6afb-4223-8943-7b54a0571732"} 97
juju_db_success_total{namespace="2c79ee47-a5a2-4af5-8ae7-17cdd5862a71"} 98
juju_db_success_total{namespace="37314648-c9bd-41c1-8a93-05fa223d8a9b"} 94
juju_db_success_total{namespace="454f136d-70c0-4d2f-8e5b-cd347625f2ff"} 90
juju_db_success_total{namespace="49081ffc-a57c-43d9-87e1-3ec0e0e01d49"} 86
juju_db_success_total{namespace="4d0741af-a5be-42dd-849d-3d4f27b42cef"} 91
juju_db_success_total{namespace="510661bd-f45a-45c9-87c5-3246008c1e79"} 90
juju_db_success_total{namespace="53b33b18-de9d-422a-86c3-fc2e9e17478d"} 90
juju_db_success_total{namespace="5c5e4ba1-cf73-40f0-8356-4e7602c9a083"} 91
juju_db_success_total{namespace="5da05fbe-49b8-4ef0-8e5f-9e4cbe4493a2"} 98
juju_db_success_total{namespace="5f281b09-c2be-40d1-8167-82574f55292c"} 90
juju_db_success_total{namespace="6882fff9-810e-4825-84e6-e417400febaf"} 90
juju_db_success_total{namespace="6d8ec157-6f43-44ee-8ad5-26abf8b02d30"} 83
juju_db_success_total{namespace="7de6cb82-d842-4417-8341-5b0db867750c"} 87
juju_db_success_total{namespace="96431eda-3056-4a82-81e7-8f63c3bc7945"} 101
juju_db_success_total{namespace="9bc7712f-0e20-426b-88c0-d1d9f5c9b52a"} 98
juju_db_success_total{namespace="9e0b5c96-3352-48f9-87da-ab1e4eef8561"} 93
juju_db_success_total{namespace="a2516167-8243-4613-8928-dbc4a13b4e8e"} 90
juju_db_success_total{namespace="a40f2511-1afc-4374-88c1-95b90baa9861"} 87
juju_db_success_total{namespace="b1b99c62-7820-4b14-88c9-6d7cc4b64912"} 83
juju_db_success_total{namespace="b3471906-3535-49d8-889d-6a07238946f6"} 86
juju_db_success_total{namespace="b9444cb9-a018-4ebc-8553-2c0f8a2abfe4"} 94
juju_db_success_total{namespace="bd426372-c230-4948-81a6-7a0925d36f39"} 87
juju_db_success_total{namespace="c623c7c2-8c9b-45f0-8060-ef823073ddb8"} 94
juju_db_success_total{namespace="c8682e63-7b46-4036-8bec-eab8b97bb764"} 95
juju_db_success_total{namespace="c96a8d86-5166-465f-8f1d-4d239f5f66cf"} 94
juju_db_success_total{namespace="cd4dcd3b-932c-4e2d-82da-0450a3d99b49"} 87
juju_db_success_total{namespace="controller"} 3233
juju_db_success_total{namespace="d1a7df66-8a09-4cc8-8e30-e903fd5790e5"} 98
juju_db_success_total{namespace="d24ed665-075e-4aa2-8589-d077a68a6437"} 98
juju_db_success_total{namespace="d705226d-c5c7-43b5-8163-a008da79a04b"} 91
juju_db_success_total{namespace="d9e8f1cf-e125-45b4-8b8e-b1bdfac06ad8"} 86
juju_db_success_total{namespace="da1000cc-de67-465c-817f-4a8f11b4f7a7"} 91
juju_db_success_total{namespace="f68b06b6-ada6-4ee4-881d-54aed81962f6"} 83
juju_db_success_total{namespace="fd3e77f9-392a-447c-8a90-80a33aa2e296"} 86
juju_db_success_total{namespace="fdc51912-8313-46b6-8167-a70e6ed995d9"} 101
```

## Links

**Jira card:** JUJU-

