### PR TITLE
feat(machine): add AllMachineRemovals on machine service

### DIFF
--- a/domain/machine/service/package_mock_test.go
+++ b/domain/machine/service/package_mock_test.go
@@ -702,6 +702,44 @@ func (c *MockStateIsMachineRebootRequiredCall) DoAndReturn(f func(context.Contex
 	return c
 }
 
+// MarkMachineForRemoval mocks base method.
+func (m *MockState) MarkMachineForRemoval(arg0 context.Context, arg1 machine.Name) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MarkMachineForRemoval", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// MarkMachineForRemoval indicates an expected call of MarkMachineForRemoval.
+func (mr *MockStateMockRecorder) MarkMachineForRemoval(arg0, arg1 any) *MockStateMarkMachineForRemovalCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkMachineForRemoval", reflect.TypeOf((*MockState)(nil).MarkMachineForRemoval), arg0, arg1)
+	return &MockStateMarkMachineForRemovalCall{Call: call}
+}
+
+// MockStateMarkMachineForRemovalCall wrap *gomock.Call
+type MockStateMarkMachineForRemovalCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateMarkMachineForRemovalCall) Return(arg0 error) *MockStateMarkMachineForRemovalCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateMarkMachineForRemovalCall) Do(f func(context.Context, machine.Name) error) *MockStateMarkMachineForRemovalCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateMarkMachineForRemovalCall) DoAndReturn(f func(context.Context, machine.Name) error) *MockStateMarkMachineForRemovalCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // RequireMachineReboot mocks base method.
 func (m *MockState) RequireMachineReboot(arg0 context.Context, arg1 string) error {
 	m.ctrl.T.Helper()

--- a/domain/machine/service/package_mock_test.go
+++ b/domain/machine/service/package_mock_test.go
@@ -83,45 +83,6 @@ func (c *MockStateAllMachineNamesCall) DoAndReturn(f func(context.Context) ([]ma
 	return c
 }
 
-// AllMachineRemovals mocks base method.
-func (m *MockState) AllMachineRemovals(arg0 context.Context) ([]string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AllMachineRemovals", arg0)
-	ret0, _ := ret[0].([]string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// AllMachineRemovals indicates an expected call of AllMachineRemovals.
-func (mr *MockStateMockRecorder) AllMachineRemovals(arg0 any) *MockStateAllMachineRemovalsCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllMachineRemovals", reflect.TypeOf((*MockState)(nil).AllMachineRemovals), arg0)
-	return &MockStateAllMachineRemovalsCall{Call: call}
-}
-
-// MockStateAllMachineRemovalsCall wrap *gomock.Call
-type MockStateAllMachineRemovalsCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockStateAllMachineRemovalsCall) Return(arg0 []string, arg1 error) *MockStateAllMachineRemovalsCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockStateAllMachineRemovalsCall) Do(f func(context.Context) ([]string, error)) *MockStateAllMachineRemovalsCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateAllMachineRemovalsCall) DoAndReturn(f func(context.Context) ([]string, error)) *MockStateAllMachineRemovalsCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // CancelMachineReboot mocks base method.
 func (m *MockState) CancelMachineReboot(arg0 context.Context, arg1 string) error {
 	m.ctrl.T.Helper()
@@ -308,6 +269,45 @@ func (c *MockStateDeleteMachineCloudInstanceCall) Do(f func(context.Context, str
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockStateDeleteMachineCloudInstanceCall) DoAndReturn(f func(context.Context, string) error) *MockStateDeleteMachineCloudInstanceCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetAllMachineRemovals mocks base method.
+func (m *MockState) GetAllMachineRemovals(arg0 context.Context) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAllMachineRemovals", arg0)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAllMachineRemovals indicates an expected call of GetAllMachineRemovals.
+func (mr *MockStateMockRecorder) GetAllMachineRemovals(arg0 any) *MockStateGetAllMachineRemovalsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllMachineRemovals", reflect.TypeOf((*MockState)(nil).GetAllMachineRemovals), arg0)
+	return &MockStateGetAllMachineRemovalsCall{Call: call}
+}
+
+// MockStateGetAllMachineRemovalsCall wrap *gomock.Call
+type MockStateGetAllMachineRemovalsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateGetAllMachineRemovalsCall) Return(arg0 []string, arg1 error) *MockStateGetAllMachineRemovalsCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateGetAllMachineRemovalsCall) Do(f func(context.Context) ([]string, error)) *MockStateGetAllMachineRemovalsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateGetAllMachineRemovalsCall) DoAndReturn(f func(context.Context) ([]string, error)) *MockStateGetAllMachineRemovalsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/machine/service/package_mock_test.go
+++ b/domain/machine/service/package_mock_test.go
@@ -83,6 +83,45 @@ func (c *MockStateAllMachineNamesCall) DoAndReturn(f func(context.Context) ([]ma
 	return c
 }
 
+// AllMachineRemovals mocks base method.
+func (m *MockState) AllMachineRemovals(arg0 context.Context) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AllMachineRemovals", arg0)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AllMachineRemovals indicates an expected call of AllMachineRemovals.
+func (mr *MockStateMockRecorder) AllMachineRemovals(arg0 any) *MockStateAllMachineRemovalsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllMachineRemovals", reflect.TypeOf((*MockState)(nil).AllMachineRemovals), arg0)
+	return &MockStateAllMachineRemovalsCall{Call: call}
+}
+
+// MockStateAllMachineRemovalsCall wrap *gomock.Call
+type MockStateAllMachineRemovalsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateAllMachineRemovalsCall) Return(arg0 []string, arg1 error) *MockStateAllMachineRemovalsCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateAllMachineRemovalsCall) Do(f func(context.Context) ([]string, error)) *MockStateAllMachineRemovalsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateAllMachineRemovalsCall) DoAndReturn(f func(context.Context) ([]string, error)) *MockStateAllMachineRemovalsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // CancelMachineReboot mocks base method.
 func (m *MockState) CancelMachineReboot(arg0 context.Context, arg1 string) error {
 	m.ctrl.T.Helper()

--- a/domain/machine/service/service.go
+++ b/domain/machine/service/service.go
@@ -121,9 +121,9 @@ type State interface {
 	// It returns a MachineNotFound error if the machine does not exist.
 	MarkMachineForRemoval(context.Context, coremachine.Name) error
 
-	// AllMachineRemovals returns the UUIDs of all of the machines that need to
-	// be removed but need provider-level cleanup.
-	AllMachineRemovals(context.Context) ([]string, error)
+	// GetAllMachineRemovals returns the UUIDs of all of the machines that need
+	// to be removed but need provider-level cleanup.
+	GetAllMachineRemovals(context.Context) ([]string, error)
 }
 
 // Service provides the API for working with machines.
@@ -337,10 +337,10 @@ func (s *Service) MarkMachineForRemoval(ctx context.Context, machineName coremac
 	return errors.Annotatef(s.st.MarkMachineForRemoval(ctx, machineName), "marking machine %q for removal", machineName)
 }
 
-// AllMachineRemovals returns the UUIDs of all of the machines that need to
+// GetAllMachineRemovals returns the UUIDs of all of the machines that need to
 // be removed but need provider-level cleanup.
-func (s *Service) AllMachineRemovals(ctx context.Context) ([]string, error) {
-	removals, err := s.st.AllMachineRemovals(ctx)
+func (s *Service) GetAllMachineRemovals(ctx context.Context) ([]string, error) {
+	removals, err := s.st.GetAllMachineRemovals(ctx)
 	if err != nil {
 		return nil, errors.Annotate(err, "retrieving all machines marked to be removed")
 	}

--- a/domain/machine/service/service.go
+++ b/domain/machine/service/service.go
@@ -120,6 +120,10 @@ type State interface {
 	// MarkMachineForRemoval marks the given machine for removal.
 	// It returns a MachineNotFound error if the machine does not exist.
 	MarkMachineForRemoval(context.Context, coremachine.Name) error
+
+	// AllMachineRemovals returns the UUIDs of all of the machines that need to
+	// be removed but need provider-level cleanup.
+	AllMachineRemovals(context.Context) ([]string, error)
 }
 
 // Service provides the API for working with machines.
@@ -331,4 +335,14 @@ func (s *Service) ShouldRebootOrShutdown(ctx context.Context, uuid string) (mach
 // It returns a MachineNotFound error if the machine does not exist.
 func (s *Service) MarkMachineForRemoval(ctx context.Context, machineName coremachine.Name) error {
 	return errors.Annotatef(s.st.MarkMachineForRemoval(ctx, machineName), "marking machine %q for removal", machineName)
+}
+
+// AllMachineRemovals returns the UUIDs of all of the machines that need to
+// be removed but need provider-level cleanup.
+func (s *Service) AllMachineRemovals(ctx context.Context) ([]string, error) {
+	removals, err := s.st.AllMachineRemovals(ctx)
+	if err != nil {
+		return nil, errors.Annotate(err, "retrieving all machines marked to be removed")
+	}
+	return removals, nil
 }

--- a/domain/machine/service/service.go
+++ b/domain/machine/service/service.go
@@ -116,6 +116,10 @@ type State interface {
 
 	// ShouldRebootOrShutdown determines whether a machine should reboot or shutdown
 	ShouldRebootOrShutdown(ctx context.Context, uuid string) (machine.RebootAction, error)
+
+	// MarkMachineForRemoval marks the given machine for removal.
+	// It returns a MachineNotFound error if the machine does not exist.
+	MarkMachineForRemoval(context.Context, coremachine.Name) error
 }
 
 // Service provides the API for working with machines.
@@ -321,4 +325,10 @@ func (s *Service) GetMachineParentUUID(ctx context.Context, machineName coremach
 func (s *Service) ShouldRebootOrShutdown(ctx context.Context, uuid string) (machine.RebootAction, error) {
 	rebootRequired, err := s.st.ShouldRebootOrShutdown(ctx, uuid)
 	return rebootRequired, errors.Annotatef(err, "getting if the machine with uuid %q need to reboot or shutdown", uuid)
+}
+
+// MarkMachineForRemoval marks the given machine for removal.
+// It returns a MachineNotFound error if the machine does not exist.
+func (s *Service) MarkMachineForRemoval(ctx context.Context, machineName coremachine.Name) error {
+	return errors.Annotatef(s.st.MarkMachineForRemoval(ctx, machineName), "marking machine %q for removal", machineName)
 }

--- a/domain/machine/service/service_test.go
+++ b/domain/machine/service/service_test.go
@@ -645,12 +645,10 @@ func (s *serviceSuite) TestMarkMachineForRemovalSuccess(c *gc.C) {
 func (s *serviceSuite) TestMarkMachineForRemovalMachineNotFoundError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	// TODO(cderici): use machineerrors.MachineNotFound on rebase after #17759
-	// lands.
-	s.state.EXPECT().MarkMachineForRemoval(gomock.Any(), cmachine.Name("666")).Return(errors.NotFound)
+	s.state.EXPECT().MarkMachineForRemoval(gomock.Any(), cmachine.Name("666")).Return(machineerrors.MachineNotFound)
 
 	err := NewService(s.state).MarkMachineForRemoval(context.Background(), cmachine.Name("666"))
-	c.Check(err, jc.ErrorIs, errors.NotFound)
+	c.Check(err, jc.ErrorIs, machineerrors.MachineNotFound)
 }
 
 // TestMarkMachineForRemovalError asserts that an error coming from the state

--- a/domain/machine/service/service_test.go
+++ b/domain/machine/service/service_test.go
@@ -665,27 +665,27 @@ func (s *serviceSuite) TestMarkMachineForRemovalError(c *gc.C) {
 	c.Check(err, jc.ErrorIs, rErr)
 }
 
-// TestAllMachineRemovalsSuccess asserts the happy path of the
-// AllMachineRemovals service.
-func (s *serviceSuite) TestAllMachineRemovalsSuccess(c *gc.C) {
+// TestGetAllMachineRemovalsSuccess asserts the happy path of the
+// GetAllMachineRemovals service.
+func (s *serviceSuite) TestGetAllMachineRemovalsSuccess(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().AllMachineRemovals(gomock.Any()).Return([]string{"666"}, nil)
+	s.state.EXPECT().GetAllMachineRemovals(gomock.Any()).Return([]string{"666"}, nil)
 
-	machineRemovals, err := NewService(s.state).AllMachineRemovals(context.Background())
+	machineRemovals, err := NewService(s.state).GetAllMachineRemovals(context.Background())
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(machineRemovals, gc.DeepEquals, []string{"666"})
 }
 
-// TestAllMachineRemovalsError asserts that an error coming from the state layer
-// is preserved, passed over to the service layer to be maintained there.
-func (s *serviceSuite) TestAllMachineRemovalsError(c *gc.C) {
+// TestGetAllMachineRemovalsError asserts that an error coming from the state
+// layer is preserved, passed over to the service layer to be maintained there.
+func (s *serviceSuite) TestGetAllMachineRemovalsError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	rErr := errors.New("boom")
-	s.state.EXPECT().AllMachineRemovals(gomock.Any()).Return(nil, rErr)
+	s.state.EXPECT().GetAllMachineRemovals(gomock.Any()).Return(nil, rErr)
 
-	machineRemovals, err := NewService(s.state).AllMachineRemovals(context.Background())
+	machineRemovals, err := NewService(s.state).GetAllMachineRemovals(context.Background())
 	c.Check(err, jc.ErrorIs, rErr)
 	c.Check(machineRemovals, gc.IsNil)
 }

--- a/domain/machine/service/service_test.go
+++ b/domain/machine/service/service_test.go
@@ -664,3 +664,28 @@ func (s *serviceSuite) TestMarkMachineForRemovalError(c *gc.C) {
 	err := NewService(s.state).MarkMachineForRemoval(context.Background(), cmachine.Name("666"))
 	c.Check(err, jc.ErrorIs, rErr)
 }
+
+// TestAllMachineRemovalsSuccess asserts the happy path of the
+// AllMachineRemovals service.
+func (s *serviceSuite) TestAllMachineRemovalsSuccess(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.state.EXPECT().AllMachineRemovals(gomock.Any()).Return([]string{"666"}, nil)
+
+	machineRemovals, err := NewService(s.state).AllMachineRemovals(context.Background())
+	c.Check(err, jc.ErrorIsNil)
+	c.Assert(machineRemovals, gc.DeepEquals, []string{"666"})
+}
+
+// TestAllMachineRemovalsError asserts that an error coming from the state layer
+// is preserved, passed over to the service layer to be maintained there.
+func (s *serviceSuite) TestAllMachineRemovalsError(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	rErr := errors.New("boom")
+	s.state.EXPECT().AllMachineRemovals(gomock.Any()).Return(nil, rErr)
+
+	machineRemovals, err := NewService(s.state).AllMachineRemovals(context.Background())
+	c.Check(err, jc.ErrorIs, rErr)
+	c.Check(machineRemovals, gc.IsNil)
+}

--- a/domain/machine/state/state.go
+++ b/domain/machine/state/state.go
@@ -711,11 +711,7 @@ VALUES ($machineMarkForRemoval.*)`
 		return tx.Query(ctx, markForRemovalStmt, markForRemovalWithUUID).Run()
 	})
 
-	if err != nil {
-		return errors.Annotatef(err, "marking machine %q for removal", mName)
-	}
-	return nil
->>>>>>> 08c3d64f61 (feat(machine): add MarkForRemoval in the machine domain)
+	return errors.Annotatef(err, "marking machine %q for removal", mName)
 }
 
 // AllMachineRemovals returns the UUIDs of all of the machines that need to be

--- a/domain/machine/state/state_test.go
+++ b/domain/machine/state/state_test.go
@@ -619,11 +619,7 @@ func (s *stateSuite) TestMarkMachineForRemovalSuccess(c *gc.C) {
 
 	var mark bool
 	err = s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
-		err := tx.QueryRowContext(ctx, "SELECT mark_for_removal FROM machine_removals WHERE machine_uuid=?", "123").Scan(&mark)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		return nil
+		return tx.QueryRowContext(ctx, "SELECT mark_for_removal FROM machine_removals WHERE machine_uuid=?", "123").Scan(&mark)
 	})
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(mark, gc.Equals, true)

--- a/domain/machine/state/state_test.go
+++ b/domain/machine/state/state_test.go
@@ -611,7 +611,7 @@ func (s *stateSuite) TestGetMachineParentUUIDNoParent(c *gc.C) {
 // TestMarkMachineForRemovalSuccess asserts the happy path of
 // MarkMachineForRemoval at the state layer.
 func (s *stateSuite) TestMarkMachineForRemovalSuccess(c *gc.C) {
-	err := s.state.CreateMachine(context.Background(), "666", "", "")
+	err := s.state.CreateMachine(context.Background(), "666", "", "123")
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = s.state.MarkMachineForRemoval(context.Background(), "666")
@@ -619,7 +619,7 @@ func (s *stateSuite) TestMarkMachineForRemovalSuccess(c *gc.C) {
 
 	var mark bool
 	err = s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
-		err := tx.QueryRowContext(ctx, "SELECT mark_for_removal FROM machine WHERE name=?", "666").Scan(&mark)
+		err := tx.QueryRowContext(ctx, "SELECT mark_for_removal FROM machine_removals WHERE machine_uuid=?", "123").Scan(&mark)
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/domain/machine/state/state_test.go
+++ b/domain/machine/state/state_test.go
@@ -637,3 +637,26 @@ func (s *stateSuite) TestMarkMachineForRemovalNotFound(c *gc.C) {
 	err := s.state.MarkMachineForRemoval(context.Background(), "666")
 	c.Assert(err, jc.ErrorIs, machineerrors.NotFound)
 }
+
+// TestAllMachineRemovalsSuccess asserts the happy path of AllMachineRemovals at
+// the state layer.
+func (s *stateSuite) TestAllMachineRemovalsSuccess(c *gc.C) {
+	err := s.state.CreateMachine(context.Background(), "666", "", "123")
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.state.MarkMachineForRemoval(context.Background(), "666")
+	c.Check(err, jc.ErrorIsNil)
+
+	machines, err := s.state.AllMachineRemovals(context.Background())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(machines, gc.HasLen, 1)
+	c.Assert(machines[0], gc.Equals, "123")
+}
+
+// TestAllMachineRemovalsEmpty asserts that AllMachineRemovals returns an empty
+// list if there are no machines marked for removal.
+func (s *stateSuite) TestAllMachineRemovalsEmpty(c *gc.C) {
+	machines, err := s.state.AllMachineRemovals(context.Background())
+	c.Check(err, jc.ErrorIsNil)
+	c.Assert(machines, gc.HasLen, 0)
+}

--- a/domain/machine/state/state_test.go
+++ b/domain/machine/state/state_test.go
@@ -617,12 +617,12 @@ func (s *stateSuite) TestMarkMachineForRemovalSuccess(c *gc.C) {
 	err = s.state.MarkMachineForRemoval(context.Background(), "666")
 	c.Check(err, jc.ErrorIsNil)
 
-	var mark bool
+	var machineUUID string
 	err = s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
-		return tx.QueryRowContext(ctx, "SELECT mark_for_removal FROM machine_removals WHERE machine_uuid=?", "123").Scan(&mark)
+		return tx.QueryRowContext(ctx, "SELECT machine_uuid FROM machine_removals WHERE machine_uuid=?", "123").Scan(&machineUUID)
 	})
 	c.Check(err, jc.ErrorIsNil)
-	c.Assert(mark, gc.Equals, true)
+	c.Assert(machineUUID, gc.Equals, "123")
 }
 
 // TestMarkMachineForRemovalSuccessIdempotent asserts that marking a machine for

--- a/domain/machine/state/types.go
+++ b/domain/machine/state/types.go
@@ -93,10 +93,11 @@ type machineName struct {
 	Name machine.Name `db:"name"`
 }
 
-// machineMarkForRemoval represents the struct to be used for the
-// mark_for_removal column within the sqlair statements in the machine domain.
+// machineMarkForRemoval represents the struct to be used for the columns of the
+// machine_removals table within the sqlair statements in the machine domain.
 type machineMarkForRemoval struct {
-	Mark bool `db:"mark_for_removal"`
+	UUID string `db:"machine_uuid"`
+	Mark bool   `db:"mark_for_removal"`
 }
 
 // machineUUID represents the struct to be used for the machine_uuid column

--- a/domain/machine/state/types.go
+++ b/domain/machine/state/types.go
@@ -97,7 +97,6 @@ type machineName struct {
 // machine_removals table within the sqlair statements in the machine domain.
 type machineMarkForRemoval struct {
 	UUID string `db:"machine_uuid"`
-	Mark bool   `db:"mark_for_removal"`
 }
 
 // machineUUID represents the struct to be used for the machine_uuid column

--- a/domain/machine/state/types.go
+++ b/domain/machine/state/types.go
@@ -118,6 +118,30 @@ type machineParent struct {
 	ParentUUID  string `db:"parent_uuid"`
 }
 
+// uuidSliceTransform is a function that is used to transform a slice of
+// machineUUID into a slice of string.
+func (s machineMarkForRemoval) uuidSliceTransform() string {
+	return s.UUID
+}
+
+// nameSliceTransform is a function that is used to transform a slice of
+// machineName into a slice of machine.Name.
+func (s machineName) nameSliceTransform() machine.Name {
+	return s.Name
+}
+
+// dataMapTransformFunc is a function that is used to transform a slice of
+// machineStatusWithData into a map.
+func (s machineStatusWithData) dataMapTransformFunc() (string, interface{}) {
+	return s.Key, s.Data
+}
+
+// dataSliceTransformFunc is a function that is used to transform a map into a
+// slice of machineStatusWithData.
+func dataSliceTransformFunc(key string, value interface{}) []machineStatusWithData {
+	return []machineStatusWithData{{Key: key, Data: value.(string)}}
+}
+
 // toCoreMachineStatusValue converts an internal status used by machines (per
 // the machine_status_value table) into a core type status.Status.
 func (s *machineStatusWithData) toCoreMachineStatusValue() status.Status {

--- a/domain/machine/state/types.go
+++ b/domain/machine/state/types.go
@@ -93,6 +93,12 @@ type machineName struct {
 	Name machine.Name `db:"name"`
 }
 
+// machineMarkForRemoval represents the struct to be used for the
+// mark_for_removal column within the sqlair statements in the machine domain.
+type machineMarkForRemoval struct {
+	Mark bool `db:"mark_for_removal"`
+}
+
 // machineUUID represents the struct to be used for the machine_uuid column
 // within the sqlair statements in the machine domain.
 type machineUUID struct {

--- a/domain/schema/model/sql/0017-machine.sql
+++ b/domain/schema/model/sql/0017-machine.sql
@@ -13,6 +13,7 @@ CREATE TABLE machine (
     agent_started_at DATETIME,
     hostname TEXT,
     is_controller BOOLEAN,
+    mark_for_removal BOOLEAN,
     CONSTRAINT fk_machine_net_node
     FOREIGN KEY (net_node_uuid)
     REFERENCES net_node (uuid),

--- a/domain/schema/model/sql/0017-machine.sql
+++ b/domain/schema/model/sql/0017-machine.sql
@@ -127,11 +127,8 @@ CREATE TABLE machine_status_data (
 -- machine_removals table is a table which represents machines that are marked
 -- for removal.
 -- Being added to this table means that the machine is marked for removal,
--- however, we keep a mark_for_removal column to allow for more granularity in
--- behavior if needed.
 CREATE TABLE machine_removals (
     machine_uuid TEXT NOT NULL PRIMARY KEY,
-    mark_for_removal BOOLEAN NOT NULL,
     CONSTRAINT fk_machine_removals_machine
     FOREIGN KEY (machine_uuid)
     REFERENCES machine (uuid)

--- a/domain/schema/model/sql/0017-machine.sql
+++ b/domain/schema/model/sql/0017-machine.sql
@@ -13,7 +13,6 @@ CREATE TABLE machine (
     agent_started_at DATETIME,
     hostname TEXT,
     is_controller BOOLEAN,
-    mark_for_removal BOOLEAN,
     CONSTRAINT fk_machine_net_node
     FOREIGN KEY (net_node_uuid)
     REFERENCES net_node (uuid),
@@ -123,4 +122,17 @@ CREATE TABLE machine_status_data (
     FOREIGN KEY (machine_uuid)
     REFERENCES machine (uuid),
     PRIMARY KEY (machine_uuid, "key")
+);
+
+-- machine_removals table is a table which represents machines that are marked
+-- for removal.
+-- Being added to this table means that the machine is marked for removal,
+-- however, we keep a mark_for_removal column to allow for more granularity in
+-- behavior if needed.
+CREATE TABLE machine_removals (
+    machine_uuid TEXT NOT NULL PRIMARY KEY,
+    mark_for_removal BOOLEAN NOT NULL,
+    CONSTRAINT fk_machine_removals_machine
+    FOREIGN KEY (machine_uuid)
+    REFERENCES machine (uuid)
 );

--- a/domain/schema/schema_test.go
+++ b/domain/schema/schema_test.go
@@ -321,6 +321,7 @@ func (s *schemaSuite) TestModelTables(c *gc.C) {
 		"machine_requires_reboot",
 		"machine_status",
 		"machine_status_data",
+		"machine_removals",
 
 		// Charm
 		"charm",


### PR DESCRIPTION
This adds `MarkMachineForRemoval` and `AllMachineRemovals` services into the machine domain. These are going to be used by the undertaker (e.g. also the `AllMachineRemovals` will be used internally by the `CompleteMachineRemoval` that's coming soon).

In the old state model, we had a `machineRemovalsC` collection in which the machines to be removed are stored, and the `WatchMachineRemovals` was watching that. 
For the same purpose, this adds the `machine_removals` table to work on, where we'll have a trigger for a machine removal that the `WatchMachineRemovals` on dqlite will use.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```
TEST_PACKAGES="./domain/machine/... -count=1 -race" make run-go-tests
```
```
TEST_PACKAGES="./domain/schema/... -count=1 -race" make run-go-tests
```

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Jira card:** JUJU-6316

