### PR TITLE
test: explicitly set the current az subscription

### DIFF
--- a/tests/suites/cloud_azure/managed_identity.sh
+++ b/tests/suites/cloud_azure/managed_identity.sh
@@ -48,6 +48,7 @@ run_custom_managed_identity() {
 	identity_name=jmid
 	cred_name=${AZURE_CREDENTIAL_NAME:-credentials}
 	subscription=$(juju show-credential --client azure "${cred_name}" | yq .client-credentials.azure."${cred_name}".content.subscription-id)
+	az account set -s "${subscription}"
 
 	add_clean_func "run_cleanup_azure"
 	az group create --name "${group}" --location westus


### PR DESCRIPTION
A trivial fix for an Azure ci test.

In the managed identity test, the az cli appears to be using a different subscription on jenkins runners. So set the subscription we want to use before running the commands.
