### PR TITLE
feat: add `facadecheck` script

### DIFF
--- a/scripts/facadecheck/main.go
+++ b/scripts/facadecheck/main.go
@@ -1,0 +1,235 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package main
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io"
+	"net/http"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/juju/collections/set"
+	"github.com/kr/pretty"
+)
+
+func main() {
+	if len(os.Args) <= 2 {
+		panic("must supply two Juju versions as command line args")
+	}
+
+	facadeCompatibilityInfo := compareFacadeVersions(os.Args[1], os.Args[2])
+	printFacadeCompatibility(facadeCompatibilityInfo)
+}
+
+func printFacadeCompatibility(info sharedFacadeVersions) {
+	fmt.Println("Compatible facades:")
+	iterateAlphabetical(info.compatibleVersions, func(facadeName string, versions set.Ints) {
+		fmt.Printf(" - %s (common versions: %s)\n", facadeName, printSetAsList(versions))
+	})
+	fmt.Println()
+
+	fmt.Println("Incompatible facades:")
+	iterateAlphabetical(info.incompatibleFacades, func(facadeName string, versionInfo map[string]facadeInfo) {
+		fmt.Printf(" - %s\n", facadeName)
+		iterateAlphabetical(versionInfo, func(v string, vInfo facadeInfo) {
+			fmt.Printf("   - %s: %s\n", v, vInfo.String())
+		})
+	})
+}
+
+// sharedFacadeVersions contains information about which facade versions are
+// compatible or incompatible between two different versions of Juju.
+type sharedFacadeVersions struct {
+	// compatibleVersions maps each facade name to a list of commonly supported
+	// versions.
+	compatibleVersions map[string]set.Ints
+	// incompatibleFacades maps facadeName -> version -> info about what
+	// versions are supported.
+	incompatibleFacades map[string]map[string]facadeInfo
+}
+
+// facadeInfo contains information about a facade in a given version of Juju -
+// either the supported versions or the fact it doesn't exist in that version.
+type facadeInfo interface {
+	String() string
+}
+
+type facadeIsSupported struct {
+	supportedVersions set.Ints
+}
+
+func (f facadeIsSupported) String() string {
+	return fmt.Sprintf("supported versions: %s", printSetAsList(f.supportedVersions))
+}
+
+type facadeDoesntExist struct{}
+
+func (facadeDoesntExist) String() string {
+	return "doesn't exist"
+}
+
+func compareFacadeVersions(v1, v2 string) sharedFacadeVersions {
+	comparison := sharedFacadeVersions{
+		compatibleVersions:  map[string]set.Ints{},
+		incompatibleFacades: map[string]map[string]facadeInfo{},
+	}
+
+	supportedFacadeVersions1 := getSupportedFacadeVersions(v1)
+	supportedFacadeVersions2 := getSupportedFacadeVersions(v2)
+
+	for facadeName, supportedVersions1 := range supportedFacadeVersions1 {
+		supportedVersions2, ok := supportedFacadeVersions2[facadeName]
+		if !ok {
+			comparison.incompatibleFacades[facadeName] = map[string]facadeInfo{
+				v1: facadeIsSupported{supportedVersions1},
+				v2: facadeDoesntExist{},
+			}
+			continue
+		}
+
+		intersection := supportedVersions1.Intersection(supportedVersions2)
+		if intersection.Size() == 0 {
+			comparison.incompatibleFacades[facadeName] = map[string]facadeInfo{
+				v1: facadeIsSupported{supportedVersions1},
+				v2: facadeIsSupported{supportedVersions2},
+			}
+		} else {
+			comparison.compatibleVersions[facadeName] = intersection
+		}
+	}
+
+	// Check facades supported by v2 but not v1
+	for facadeName, supportedVersions2 := range supportedFacadeVersions2 {
+		_, ok := supportedFacadeVersions1[facadeName]
+		if !ok {
+			comparison.incompatibleFacades[facadeName] = map[string]facadeInfo{
+				v1: facadeDoesntExist{},
+				v2: facadeIsSupported{supportedVersions2},
+			}
+		}
+		// If the facade exists in both versions, it should have been caught in
+		// the loop above.
+	}
+
+	return comparison
+}
+
+// supportedFacadeVersions maps a facade name to a set of supported versions.
+type supportedFacadeVersions map[string]set.Ints
+
+func getSupportedFacadeVersions(ver string) supportedFacadeVersions {
+	resp, err := http.Get(fmt.Sprintf("https://raw.githubusercontent.com/juju/juju/v%s/api/facadeversions.go", ver))
+	check(err)
+	if resp.StatusCode == http.StatusNotFound {
+		resp, err = http.Get(fmt.Sprintf("https://raw.githubusercontent.com/juju/juju/juju-%s/api/facadeversions.go", ver))
+		check(err)
+		if resp.StatusCode == http.StatusNotFound {
+			panic(fmt.Sprintf("could not find version %q on GitHub", ver))
+		}
+	}
+
+	if resp.StatusCode >= 400 {
+		body, _ := io.ReadAll(resp.Body)
+		panic(fmt.Sprintf("GET returned %d: %s", resp.StatusCode, body))
+	}
+
+	defer resp.Body.Close()
+	parsed, err := parser.ParseFile(token.NewFileSet(), "", resp.Body, 0)
+	check(err)
+
+	for _, decl := range parsed.Decls {
+		switch d := decl.(type) {
+		case *ast.FuncDecl: // skip
+		case *ast.GenDecl:
+			for _, spec := range d.Specs {
+				switch s := spec.(type) {
+				case *ast.ImportSpec: // skip
+				case *ast.ValueSpec:
+					if s.Names[0].Name == "facadeVersions" {
+						return getSupportedFacadeVersionsFromValueSpec(s)
+					}
+				default:
+					panic(fmt.Sprintf("unexpected spec type %T", s))
+				}
+			}
+		default:
+			panic(fmt.Sprintf("unexpected decl type %T\n%s", d, pretty.Sprint(d)))
+		}
+	}
+
+	return nil
+}
+
+func getSupportedFacadeVersionsFromValueSpec(s *ast.ValueSpec) supportedFacadeVersions {
+	allSupportedVersions := supportedFacadeVersions{}
+
+	entries := s.Values[0].(*ast.CompositeLit).Elts
+	for _, elt := range entries {
+		kv := elt.(*ast.KeyValueExpr)
+
+		// Parse facade name
+		facadeName := strings.Trim(kv.Key.(*ast.BasicLit).Value, `"`)
+
+		// Parse supported facade versions
+		supportedVersions := set.NewInts()
+		switch v := kv.Value.(type) {
+		case *ast.BasicLit: // older-style
+			maxSupportedVersion, err := strconv.Atoi(v.Value)
+			check(err)
+			for i := 0; i <= maxSupportedVersion; i++ {
+				supportedVersions.Add(i)
+			}
+
+		case *ast.CompositeLit: // newer-style
+			for _, elt := range v.Elts {
+				ver, err := strconv.Atoi(elt.(*ast.BasicLit).Value)
+				check(err)
+				supportedVersions.Add(ver)
+			}
+
+		default:
+			panic(fmt.Sprintf("unexpected expr type %T", v))
+		}
+
+		allSupportedVersions[facadeName] = supportedVersions
+	}
+	return allSupportedVersions
+}
+
+// UTILITY FUNCTIONS
+
+// check panics if the provided error is not nil.
+func check(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+
+func iterateAlphabetical[T any](m map[string]T, f func(k string, v T)) {
+	// Sort keys
+	var keys []string
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	// Iterate in order
+	for _, k := range keys {
+		f(k, m[k])
+	}
+}
+
+func printSetAsList(s set.Ints) string {
+	var strs []string
+	for _, v := range s.SortedValues() {
+		strs = append(strs, fmt.Sprint(v))
+	}
+	return strings.Join(strs, ", ")
+}


### PR DESCRIPTION
Adds a new script `facadecheck` which compares facade compatibility for two versions of Juju. You can run it with `go run ./scripts/facadecheck <version1> <version2>`.

<details>
<summary>facadecheck example</summary>

```
$ go run ./scripts/facadecheck 3.1.0 3.5.2
Compatible facades:
 - Action (common versions: 7)
 - ActionPruner (common versions: 1)
 - Agent (common versions: 3)
 - AgentTools (common versions: 1)
 - AllModelWatcher (common versions: 4)
 - AllWatcher (common versions: 3)
 - Annotations (common versions: 2)
 - Application (common versions: 15, 16, 17)
 - ApplicationOffers (common versions: 4)
 - ApplicationScaler (common versions: 1)
 - Backups (common versions: 3)
 - Block (common versions: 2)
 - Bundle (common versions: 6)
 - CAASAdmission (common versions: 1)
 - CAASAgent (common versions: 2)
 - CAASApplication (common versions: 1)
 - CAASApplicationProvisioner (common versions: 1)
 - CAASFirewaller (common versions: 1)
 - CAASFirewallerSidecar (common versions: 1)
 - CAASModelConfigManager (common versions: 1)
 - CAASModelOperator (common versions: 1)
 - CAASOperator (common versions: 1)
 - CAASOperatorProvisioner (common versions: 1)
 - CAASOperatorUpgrader (common versions: 1)
 - CAASUnitProvisioner (common versions: 2)
 - CharmDownloader (common versions: 1)
 - CharmRevisionUpdater (common versions: 2)
 - Charms (common versions: 5, 6)
 - Cleaner (common versions: 2)
 - Client (common versions: 6)
 - Cloud (common versions: 7)
 - Controller (common versions: 11)
 - CredentialManager (common versions: 1)
 - CredentialValidator (common versions: 2)
 - CrossController (common versions: 1)
 - CrossModelRelations (common versions: 2)
 - Deployer (common versions: 1)
 - DiskManager (common versions: 2)
 - EntityWatcher (common versions: 2)
 - EnvironUpgrader (common versions: 1)
 - ExternalControllerUpdater (common versions: 1)
 - FanConfigurer (common versions: 1)
 - FilesystemAttachmentsWatcher (common versions: 2)
 - Firewaller (common versions: 7)
 - HighAvailability (common versions: 2)
 - HostKeyReporter (common versions: 1)
 - ImageMetadata (common versions: 3)
 - ImageMetadataManager (common versions: 1)
 - InstanceMutater (common versions: 3)
 - InstancePoller (common versions: 4)
 - KeyManager (common versions: 1)
 - KeyUpdater (common versions: 1)
 - LeadershipService (common versions: 2)
 - LifeFlag (common versions: 1)
 - LogForwarding (common versions: 1)
 - Logger (common versions: 1)
 - MachineActions (common versions: 1)
 - MachineManager (common versions: 9, 10)
 - MachineUndertaker (common versions: 1)
 - Machiner (common versions: 5)
 - MeterStatus (common versions: 2)
 - MetricsAdder (common versions: 2)
 - MetricsDebug (common versions: 2)
 - MetricsManager (common versions: 1)
 - MigrationFlag (common versions: 1)
 - MigrationMaster (common versions: 3)
 - MigrationMinion (common versions: 1)
 - MigrationStatusWatcher (common versions: 1)
 - MigrationTarget (common versions: 1)
 - ModelConfig (common versions: 3)
 - ModelGeneration (common versions: 4)
 - ModelManager (common versions: 9)
 - ModelSummaryWatcher (common versions: 1)
 - ModelUpgrader (common versions: 1)
 - NotifyWatcher (common versions: 1)
 - OfferStatusWatcher (common versions: 1)
 - Payloads (common versions: 1)
 - PayloadsHookContext (common versions: 1)
 - Pinger (common versions: 1)
 - Provisioner (common versions: 11)
 - ProxyUpdater (common versions: 2)
 - Reboot (common versions: 2)
 - RelationStatusWatcher (common versions: 1)
 - RelationUnitsWatcher (common versions: 1)
 - RemoteRelationWatcher (common versions: 1)
 - RemoteRelations (common versions: 2)
 - Resources (common versions: 3)
 - ResourcesHookContext (common versions: 1)
 - RetryStrategy (common versions: 1)
 - SSHClient (common versions: 4)
 - SecretBackends (common versions: 1)
 - Secrets (common versions: 1)
 - SecretsManager (common versions: 1)
 - SecretsTriggerWatcher (common versions: 1)
 - Singular (common versions: 2)
 - Spaces (common versions: 6)
 - StatusHistory (common versions: 2)
 - Storage (common versions: 6)
 - StorageProvisioner (common versions: 4)
 - StringsWatcher (common versions: 1)
 - Subnets (common versions: 5)
 - Undertaker (common versions: 1)
 - UnitAssigner (common versions: 1)
 - Uniter (common versions: 18)
 - UpgradeSeries (common versions: 3)
 - UpgradeSteps (common versions: 2)
 - Upgrader (common versions: 1)
 - UserManager (common versions: 3)
 - VolumeAttachmentPlansWatcher (common versions: 1)
 - VolumeAttachmentsWatcher (common versions: 2)

Incompatible facades:
 - AgentLifeFlag
   - 3.1.0: doesn't exist
   - 3.5.2: supported versions: 1
 - CrossModelSecrets
   - 3.1.0: doesn't exist
   - 3.5.2: supported versions: 1
 - FirewallRules
   - 3.1.0: supported versions: 0, 1
   - 3.5.2: doesn't exist
 - RaftLease
   - 3.1.0: supported versions: 0, 1, 2
   - 3.5.2: doesn't exist
 - SecretBackendsManager
   - 3.1.0: doesn't exist
   - 3.5.2: supported versions: 1
 - SecretBackendsRotateWatcher
   - 3.1.0: doesn't exist
   - 3.5.2: supported versions: 1
 - SecretsDrain
   - 3.1.0: doesn't exist
   - 3.5.2: supported versions: 1
 - SecretsRevisionWatcher
   - 3.1.0: doesn't exist
   - 3.5.2: supported versions: 1
 - UserSecretsDrain
   - 3.1.0: doesn't exist
   - 3.5.2: supported versions: 1
 - UserSecretsManager
   - 3.1.0: doesn't exist
   - 3.5.2: supported versions: 1
```
</details>

I also updated the API section of the `architectural-overview.md` doc to talk more about facades and how they are versioned.