### PR TITLE
fix: regression in user secret drain

### DIFF
--- a/domain/model/state/state_test.go
+++ b/domain/model/state/state_test.go
@@ -733,9 +733,6 @@ func (m *stateSuite) TestSetModelCloudCredentialWithoutRegion(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = bootstrap.CreateDefaultBackends(coremodel.CAAS)(context.Background(), m.ControllerTxnRunner(), m.TxnRunner())
-	c.Assert(err, jc.ErrorIsNil)
-
 	m.uuid = modeltesting.GenModelUUID(c)
 	modelSt := NewState(m.TxnRunnerFactory())
 	err = modelSt.Create(

--- a/domain/secretbackend/bootstrap/bootstrap.go
+++ b/domain/secretbackend/bootstrap/bootstrap.go
@@ -27,11 +27,9 @@ func CreateDefaultBackends(modelType coremodel.ModelType) internaldatabase.Boots
 			if err != nil {
 				return errors.Trace(err)
 			}
-			if modelType == coremodel.CAAS {
-				err := createBackend(ctx, tx, kubernetes.BackendName, domainsecretbackend.BackendTypeKubernetes)
-				if err != nil {
-					return errors.Trace(err)
-				}
+			err = createBackend(ctx, tx, kubernetes.BackendName, domainsecretbackend.BackendTypeKubernetes)
+			if err != nil {
+				return errors.Trace(err)
 			}
 			return nil
 		})

--- a/domain/secretbackend/bootstrap/bootstrap.go
+++ b/domain/secretbackend/bootstrap/bootstrap.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/juju/juju/core/database"
 	coremodel "github.com/juju/juju/core/model"
-	"github.com/juju/juju/domain"
 	domainsecretbackend "github.com/juju/juju/domain/secretbackend"
 	"github.com/juju/juju/domain/secretbackend/state"
 	internaldatabase "github.com/juju/juju/internal/database"
@@ -36,7 +35,7 @@ func CreateDefaultBackends(modelType coremodel.ModelType) internaldatabase.Boots
 			}
 			return nil
 		})
-		return domain.CoerceError(err)
+		return errors.Trace(err)
 	}
 }
 
@@ -45,7 +44,7 @@ func createBackend(ctx context.Context, tx *sqlair.TX, backendName string, backe
 	if err != nil {
 		return errors.Trace(err)
 	}
-	upsertBackendStmt, err := sqlair.Prepare(`
+	insertBackendStmt, err := sqlair.Prepare(`
 INSERT INTO secret_backend
     (uuid, name, backend_type_id)
 VALUES ($SecretBackend.*)`, state.SecretBackend{})
@@ -53,7 +52,7 @@ VALUES ($SecretBackend.*)`, state.SecretBackend{})
 		return errors.Trace(err)
 	}
 
-	err = tx.Query(ctx, upsertBackendStmt, state.SecretBackend{
+	err = tx.Query(ctx, insertBackendStmt, state.SecretBackend{
 		ID:                  backendUUID.String(),
 		Name:                backendName,
 		BackendTypeID:       backendType,

--- a/domain/secretbackend/bootstrap/bootstrap.go
+++ b/domain/secretbackend/bootstrap/bootstrap.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/juju/core/database"
 	coremodel "github.com/juju/juju/core/model"
+	"github.com/juju/juju/domain"
 	domainsecretbackend "github.com/juju/juju/domain/secretbackend"
 	"github.com/juju/juju/domain/secretbackend/state"
 	internaldatabase "github.com/juju/juju/internal/database"
@@ -22,31 +23,41 @@ import (
 // CreateDefaultBackends inserts the initial secret backends during bootstrap.
 func CreateDefaultBackends(modelType coremodel.ModelType) internaldatabase.BootstrapOpt {
 	return func(ctx context.Context, controller, model database.TxnRunner) error {
-		backendUUID, err := uuid.NewUUID()
-		if err != nil {
-			return errors.Trace(err)
-		}
-		return errors.Trace(controller.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-			upsertBackendStmt, err := sqlair.Prepare(`
-INSERT INTO secret_backend
-    (uuid, name, backend_type_id)
-VALUES ($SecretBackend.*)`, state.SecretBackend{})
+		err := controller.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+			err := createBackend(ctx, tx, juju.BackendName, domainsecretbackend.BackendTypeController)
 			if err != nil {
 				return errors.Trace(err)
 			}
-			backendName := juju.BackendName
-			backendType := domainsecretbackend.BackendTypeController
 			if modelType == coremodel.CAAS {
-				backendName = kubernetes.BackendName
-				backendType = domainsecretbackend.BackendTypeKubernetes
+				err := createBackend(ctx, tx, kubernetes.BackendName, domainsecretbackend.BackendTypeKubernetes)
+				if err != nil {
+					return errors.Trace(err)
+				}
 			}
-			err = tx.Query(ctx, upsertBackendStmt, state.SecretBackend{
-				ID:                  backendUUID.String(),
-				Name:                backendName,
-				BackendTypeID:       backendType,
-				TokenRotateInterval: internaldatabase.NullDuration{},
-			}).Run()
-			return errors.Annotatef(err, "cannot create secret backend %q", backendName)
-		}))
+			return nil
+		})
+		return domain.CoerceError(err)
 	}
+}
+
+func createBackend(ctx context.Context, tx *sqlair.TX, backendName string, backendType domainsecretbackend.BackendType) error {
+	backendUUID, err := uuid.NewUUID()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	upsertBackendStmt, err := sqlair.Prepare(`
+INSERT INTO secret_backend
+    (uuid, name, backend_type_id)
+VALUES ($SecretBackend.*)`, state.SecretBackend{})
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	err = tx.Query(ctx, upsertBackendStmt, state.SecretBackend{
+		ID:                  backendUUID.String(),
+		Name:                backendName,
+		BackendTypeID:       backendType,
+		TokenRotateInterval: internaldatabase.NullDuration{},
+	}).Run()
+	return errors.Annotatef(err, "cannot create secret backend %q", backendName)
 }

--- a/domain/secretbackend/bootstrap/bootstrap_test.go
+++ b/domain/secretbackend/bootstrap/bootstrap_test.go
@@ -31,6 +31,10 @@ func (s *bootstrapSuite) TestCreateDefaultBackendsIAAS(c *gc.C) {
 	c.Assert(row.Scan(&name, &typeID), jc.ErrorIsNil)
 	c.Assert(name, gc.Equals, "internal")
 	c.Assert(typeID, gc.Equals, 0)
+	row = s.DB().QueryRow("SELECT name, backend_type_id FROM secret_backend where backend_type_id = ?", 1) // 1 = kubernetes
+	c.Assert(row.Scan(&name, &typeID), jc.ErrorIsNil)
+	c.Assert(name, gc.Equals, "kubernetes")
+	c.Assert(typeID, gc.Equals, 1)
 }
 
 func (s *bootstrapSuite) TestCreateDefaultBackendsCAAS(c *gc.C) {

--- a/domain/secretbackend/bootstrap/bootstrap_test.go
+++ b/domain/secretbackend/bootstrap/bootstrap_test.go
@@ -27,7 +27,7 @@ func (s *bootstrapSuite) TestCreateDefaultBackendsIAAS(c *gc.C) {
 		name   string
 		typeID int
 	)
-	row := s.DB().QueryRow("SELECT name, backend_type_id FROM secret_backend where backend_type_id = ?", 0) // 0 = controller
+	row := s.DB().QueryRow("SELECT name, backend_type_id FROM secret_backend where backend_type_id = ?", 0) // 0 = internal
 	c.Assert(row.Scan(&name, &typeID), jc.ErrorIsNil)
 	c.Assert(name, gc.Equals, "internal")
 	c.Assert(typeID, gc.Equals, 0)
@@ -41,7 +41,11 @@ func (s *bootstrapSuite) TestCreateDefaultBackendsCAAS(c *gc.C) {
 		name   string
 		typeID int
 	)
-	row := s.DB().QueryRow("SELECT name, backend_type_id FROM secret_backend where backend_type_id = ?", 1) // 1 = kubernetes
+	row := s.DB().QueryRow("SELECT name, backend_type_id FROM secret_backend where backend_type_id = ?", 0) // 0 = internal
+	c.Assert(row.Scan(&name, &typeID), jc.ErrorIsNil)
+	c.Assert(name, gc.Equals, "internal")
+	c.Assert(typeID, gc.Equals, 0)
+	row = s.DB().QueryRow("SELECT name, backend_type_id FROM secret_backend where backend_type_id = ?", 1) // 1 = kubernetes
 	c.Assert(row.Scan(&name, &typeID), jc.ErrorIsNil)
 	c.Assert(name, gc.Equals, "kubernetes")
 	c.Assert(typeID, gc.Equals, 1)

--- a/internal/secrets/provider/vault/provider_test.go
+++ b/internal/secrets/provider/vault/provider_test.go
@@ -329,8 +329,8 @@ func (s *providerSuite) TestBackendConfigForDrain(c *gc.C) {
 	}
 
 	accessor := secrets.Accessor{
-		Kind: secrets.UnitAccessor,
-		ID:   "gitlab/0",
+		Kind: secrets.ModelAccessor,
+		ID:   coretesting.ModelTag.Id(),
 	}
 	cfg, err := p.RestrictedConfig(context.Background(), adminCfg, true, true, accessor, ownedRevs, readRevs)
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
This PR fixes two issues:

- create the `internal` secret backend for a k8s controller because we can have an IaaS model running on a k8s controller.
- the vault policy for user secret drain was `create` and `update`, but it was wrongly changed to `update` and `read` in Dqlite refactoring work, now we revert it back.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

These QA steps were done based on https://github.com/juju/juju/pull/17565

#### k8s model

```
juju model-secret-backend
auto

juju exec --unit snappass-test/0 'secret-add ownedby=snappass-test/0 --owner unit'
secret://f9dd1fcd-0add-4a78-83b1-518b1e4b9a40/cqd1ghjakmoc79v9cvu0

juju exec --unit snappass-test/0 'secret-add ownedby=snappass-test'
secret://f9dd1fcd-0add-4a78-83b1-518b1e4b9a40/cqd1gq3akmoc79v9cvug

juju add-secret foo token=34ae35facd4
secret:cqd1g0bakmoc79v9cvtg

mkubectl -nt1 get secrets -l 'app.kubernetes.io/managed-by = juju'
NAME                               TYPE                                  DATA   AGE
model-exec                         kubernetes.io/service-account-token   3      3m41s
cqd1g0bakmoc79v9cvtg-1             Opaque                                1      2m55s
snappass-test-application-config   Opaque                                5      2m31s
cqd1ghjakmoc79v9cvu0-1             Opaque                                1      2m13s
cqd1gq3akmoc79v9cvug-1             Opaque                                1      99s

juju model-secret-backend myvault1

mkubectl -nt1 get secrets -l 'app.kubernetes.io/managed-by = juju'
NAME                               TYPE                                  DATA   AGE
model-exec                         kubernetes.io/service-account-token   3      5m13s
snappass-test-application-config   Opaque                                5      4m3s

vault kv list -format json t1-${model_uuid: -6}
[
  "cqd1g0bakmoc79v9cvtg-1",
  "cqd1ghjakmoc79v9cvu0-1",
  "cqd1gq3akmoc79v9cvug-1"
]

juju model-secret-backend auto

vault kv list -format json t1-${model_uuid: -6}
{}

mkubectl -nt1 get secrets -l 'app.kubernetes.io/managed-by = juju'
NAME                               TYPE                                  DATA   AGE
model-exec                         kubernetes.io/service-account-token   3      6m22s
snappass-test-application-config   Opaque                                5      5m12s
cqd1g0bakmoc79v9cvtg-1             Opaque                                1      21s
cqd1ghjakmoc79v9cvu0-1             Opaque                                1      21s
cqd1gq3akmoc79v9cvug-1             Opaque                                1      21s
```

## Documentation changes

No

## Links

**Jira card:** [JUJU-5911](https://warthogs.atlassian.net/browse/JUJU-5911)


[JUJU-5911]: https://warthogs.atlassian.net/browse/JUJU-5911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ