### PR TITLE
fix(auth): fix external user auth

### DIFF
--- a/cmd/modelcmd/base.go
+++ b/cmd/modelcmd/base.go
@@ -235,16 +235,12 @@ func (c *CommandBase) NewAPIRootWithDialOpts(
 	} else {
 		u := names.NewUserTag(accountDetails.User)
 		if !u.IsLocal() {
-			if len(accountDetails.Macaroons) == 0 {
-				accountDetails = &jujuclient.AccountDetails{}
-			} else {
-				// If the account has macaroon set, use those to login
-				// to avoid an unnecessary auth round trip.
-				// Used for embedded commands.
-				accountDetails = &jujuclient.AccountDetails{
-					User:      u.Id(),
-					Macaroons: accountDetails.Macaroons,
-				}
+			// If the account has macaroon set, use those to login
+			// to avoid an unnecessary auth round trip.
+			// Used for embedded commands.
+			accountDetails = &jujuclient.AccountDetails{
+				User:      u.Id(),
+				Macaroons: accountDetails.Macaroons,
 			}
 		}
 	}


### PR DESCRIPTION
When establishing api connections, we recently begun asserting that the authenticated user name matches the name of the user in the store.

However, this revealed a bug with external users. In NewAPIRootWithDialOpts, we would clear the account details unnecessarily, including the username, if no macaroons are provided.

Change this to not clear the username.

This means we can collapse an if statement, as nowhere do we distinguish between a 0 length array and nil for the Macaroons slice

A potential side effect of this would be to include the user Tag in apiInfo in connectionInfo. However, we are saved here because we only set the tag for local users.

## QA steps

```
$ juju bootstrap lxd lxd --config identity-url=https://api.jujucharms.com/identity --config allow-model-access=true
$ juju grant <lp user>@external superuser
$ juju change-user-password
$ juju logout
$ juju login --user <lp user>@external

$ juju whoami

$ juju add-model m
```