### PR TITLE
fix: watcher for WatchModelMachines

### DIFF
--- a/core/watcher/eventsource/namespace.go
+++ b/core/watcher/eventsource/namespace.go
@@ -129,7 +129,7 @@ func (w *NamespaceWatcher) loop() error {
 			}
 
 			// We have changes. Tick over to dispatch mode.
-			changes = transform.Slice(subChanges, func(c changestream.ChangeEvent) string { return c.Changed() })
+			changes = transform.Slice(changed, func(c changestream.ChangeEvent) string { return c.Changed() })
 			in = nil
 			out = w.out
 		case out <- changes:

--- a/domain/machine/service/package_mock_test.go
+++ b/domain/machine/service/package_mock_test.go
@@ -430,6 +430,45 @@ func (c *MockStateInitialWatchInstanceStatementCall) DoAndReturn(f func() (strin
 	return c
 }
 
+// InitialWatchModelMachinesStatement mocks base method.
+func (m *MockState) InitialWatchModelMachinesStatement() (string, string) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InitialWatchModelMachinesStatement")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(string)
+	return ret0, ret1
+}
+
+// InitialWatchModelMachinesStatement indicates an expected call of InitialWatchModelMachinesStatement.
+func (mr *MockStateMockRecorder) InitialWatchModelMachinesStatement() *MockStateInitialWatchModelMachinesStatementCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitialWatchModelMachinesStatement", reflect.TypeOf((*MockState)(nil).InitialWatchModelMachinesStatement))
+	return &MockStateInitialWatchModelMachinesStatementCall{Call: call}
+}
+
+// MockStateInitialWatchModelMachinesStatementCall wrap *gomock.Call
+type MockStateInitialWatchModelMachinesStatementCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateInitialWatchModelMachinesStatementCall) Return(arg0, arg1 string) *MockStateInitialWatchModelMachinesStatementCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateInitialWatchModelMachinesStatementCall) Do(f func() (string, string)) *MockStateInitialWatchModelMachinesStatementCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateInitialWatchModelMachinesStatementCall) DoAndReturn(f func() (string, string)) *MockStateInitialWatchModelMachinesStatementCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // InitialWatchStatement mocks base method.
 func (m *MockState) InitialWatchStatement() (string, string) {
 	m.ctrl.T.Helper()

--- a/domain/machine/service/service.go
+++ b/domain/machine/service/service.go
@@ -29,6 +29,10 @@ type State interface {
 	// for the machines.
 	InitialWatchStatement() (string, string)
 
+	// InitialWatchModelMachinesStatement returns the table and the initial watch
+	// statement for watching life changes of non-container machines.
+	InitialWatchModelMachinesStatement() (string, string)
+
 	// GetMachineLife returns the life status of the specified machine.
 	// It returns a NotFound if the given machine doesn't exist.
 	GetMachineLife(context.Context, coremachine.Name) (*life.Life, error)
@@ -135,7 +139,7 @@ func (s *Service) DeleteMachine(ctx context.Context, machineName coremachine.Nam
 	return errors.Annotatef(err, "deleting machine %q", machineName)
 }
 
-// GetLife returns the GetMachineLife status of the specified machine.
+// GetMachineLife returns the GetMachineLife status of the specified machine.
 // It returns a NotFound if the given machine doesn't exist.
 func (s *Service) GetMachineLife(ctx context.Context, machineName coremachine.Name) (*life.Life, error) {
 	life, err := s.st.GetMachineLife(ctx, machineName)

--- a/domain/machine/service/service_test.go
+++ b/domain/machine/service/service_test.go
@@ -38,7 +38,7 @@ func (s *serviceSuite) TestCreateMachineSuccess(c *gc.C) {
 
 	s.state.EXPECT().CreateMachine(gomock.Any(), cmachine.Name("666"), gomock.Any(), gomock.Any()).Return(nil)
 
-	_, err := NewService(s.state).CreateMachine(context.Background(), cmachine.Name("666"))
+	_, err := NewService(s.state).CreateMachine(context.Background(), "666")
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -50,7 +50,7 @@ func (s *serviceSuite) TestCreateMachineError(c *gc.C) {
 	rErr := errors.New("boom")
 	s.state.EXPECT().CreateMachine(gomock.Any(), cmachine.Name("666"), gomock.Any(), gomock.Any()).Return(rErr)
 
-	_, err := NewService(s.state).CreateMachine(context.Background(), cmachine.Name("666"))
+	_, err := NewService(s.state).CreateMachine(context.Background(), "666")
 	c.Check(err, jc.ErrorIs, rErr)
 	c.Assert(err, gc.ErrorMatches, `creating machine "666": boom`)
 }
@@ -60,7 +60,7 @@ func (s *serviceSuite) TestDeleteMachineSuccess(c *gc.C) {
 
 	s.state.EXPECT().DeleteMachine(gomock.Any(), cmachine.Name("666")).Return(nil)
 
-	err := NewService(s.state).DeleteMachine(context.Background(), cmachine.Name("666"))
+	err := NewService(s.state).DeleteMachine(context.Background(), "666")
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -72,7 +72,7 @@ func (s *serviceSuite) TestDeleteMachineError(c *gc.C) {
 	rErr := errors.New("boom")
 	s.state.EXPECT().DeleteMachine(gomock.Any(), cmachine.Name("666")).Return(rErr)
 
-	err := NewService(s.state).DeleteMachine(context.Background(), cmachine.Name("666"))
+	err := NewService(s.state).DeleteMachine(context.Background(), "666")
 	c.Check(err, jc.ErrorIs, rErr)
 	c.Assert(err, gc.ErrorMatches, `deleting machine "666": boom`)
 }
@@ -81,12 +81,12 @@ func (s *serviceSuite) TestDeleteMachineError(c *gc.C) {
 func (s *serviceSuite) TestGetLifeSuccess(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	life := life.Alive
-	s.state.EXPECT().GetMachineLife(gomock.Any(), cmachine.Name("666")).Return(&life, nil)
+	alive := life.Alive
+	s.state.EXPECT().GetMachineLife(gomock.Any(), cmachine.Name("666")).Return(&alive, nil)
 
-	l, err := NewService(s.state).GetMachineLife(context.Background(), cmachine.Name("666"))
+	l, err := NewService(s.state).GetMachineLife(context.Background(), "666")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(l, gc.Equals, &life)
+	c.Assert(l, gc.Equals, &alive)
 }
 
 // TestGetLifeError asserts that an error coming from the state layer is
@@ -97,7 +97,7 @@ func (s *serviceSuite) TestGetLifeError(c *gc.C) {
 	rErr := errors.New("boom")
 	s.state.EXPECT().GetMachineLife(gomock.Any(), cmachine.Name("666")).Return(nil, rErr)
 
-	l, err := NewService(s.state).GetMachineLife(context.Background(), cmachine.Name("666"))
+	l, err := NewService(s.state).GetMachineLife(context.Background(), "666")
 	c.Check(l, gc.IsNil)
 	c.Check(err, jc.ErrorIs, rErr)
 	c.Assert(err, gc.ErrorMatches, `getting life status for machine "666": boom`)
@@ -111,7 +111,7 @@ func (s *serviceSuite) TestGetLifeNotFoundError(c *gc.C) {
 
 	s.state.EXPECT().GetMachineLife(gomock.Any(), cmachine.Name("666")).Return(nil, errors.NotFound)
 
-	l, err := NewService(s.state).GetMachineLife(context.Background(), cmachine.Name("666"))
+	l, err := NewService(s.state).GetMachineLife(context.Background(), "666")
 	c.Check(l, gc.IsNil)
 	c.Check(err, jc.ErrorIs, errors.NotFound)
 }
@@ -121,10 +121,9 @@ func (s *serviceSuite) TestGetLifeNotFoundError(c *gc.C) {
 func (s *serviceSuite) TestSetMachineLifeSuccess(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	life := life.Alive
-	s.state.EXPECT().SetMachineLife(gomock.Any(), cmachine.Name("666"), life).Return(nil)
+	s.state.EXPECT().SetMachineLife(gomock.Any(), cmachine.Name("666"), life.Alive).Return(nil)
 
-	err := NewService(s.state).SetMachineLife(context.Background(), cmachine.Name("666"), life)
+	err := NewService(s.state).SetMachineLife(context.Background(), "666", life.Alive)
 	c.Check(err, jc.ErrorIsNil)
 }
 
@@ -134,10 +133,9 @@ func (s *serviceSuite) TestSetMachineLifeError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	rErr := errors.New("boom")
-	life := life.Alive
-	s.state.EXPECT().SetMachineLife(gomock.Any(), cmachine.Name("666"), life).Return(rErr)
+	s.state.EXPECT().SetMachineLife(gomock.Any(), cmachine.Name("666"), life.Alive).Return(rErr)
 
-	err := NewService(s.state).SetMachineLife(context.Background(), cmachine.Name("666"), life)
+	err := NewService(s.state).SetMachineLife(context.Background(), "666", life.Alive)
 	c.Check(err, jc.ErrorIs, rErr)
 	c.Assert(err, gc.ErrorMatches, `setting life status for machine "666": boom`)
 }
@@ -150,7 +148,7 @@ func (s *serviceSuite) TestSetMachineLifeMachineDontExist(c *gc.C) {
 
 	s.state.EXPECT().SetMachineLife(gomock.Any(), cmachine.Name("nonexistent"), life.Alive).Return(errors.NotFound)
 
-	err := NewService(s.state).SetMachineLife(context.Background(), cmachine.Name("nonexistent"), life.Alive)
+	err := NewService(s.state).SetMachineLife(context.Background(), "nonexistent", life.Alive)
 	c.Assert(err, jc.ErrorIs, errors.NotFound)
 }
 
@@ -161,7 +159,7 @@ func (s *serviceSuite) TestEnsureDeadMachineSuccess(c *gc.C) {
 
 	s.state.EXPECT().SetMachineLife(gomock.Any(), cmachine.Name("666"), life.Dead).Return(nil)
 
-	err := NewService(s.state).EnsureDeadMachine(context.Background(), cmachine.Name("666"))
+	err := NewService(s.state).EnsureDeadMachine(context.Background(), "666")
 	c.Check(err, jc.ErrorIsNil)
 }
 
@@ -173,18 +171,18 @@ func (s *serviceSuite) TestEnsureDeadMachineError(c *gc.C) {
 	rErr := errors.New("boom")
 	s.state.EXPECT().SetMachineLife(gomock.Any(), cmachine.Name("666"), life.Dead).Return(rErr)
 
-	err := NewService(s.state).EnsureDeadMachine(context.Background(), cmachine.Name("666"))
+	err := NewService(s.state).EnsureDeadMachine(context.Background(), "666")
 	c.Check(err, jc.ErrorIs, rErr)
 }
 
 func (s *serviceSuite) TestListAllMachinesSuccess(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().AllMachineNames(gomock.Any()).Return([]cmachine.Name{cmachine.Name("666")}, nil)
+	s.state.EXPECT().AllMachineNames(gomock.Any()).Return([]cmachine.Name{"666"}, nil)
 
 	machines, err := NewService(s.state).AllMachineNames(context.Background())
 	c.Check(err, jc.ErrorIsNil)
-	c.Assert(machines, gc.DeepEquals, []cmachine.Name{cmachine.Name("666")})
+	c.Assert(machines, gc.DeepEquals, []cmachine.Name{"666"})
 }
 
 // TestListAllMachinesError asserts that an error coming from the state layer is
@@ -205,7 +203,7 @@ func (s *serviceSuite) TestInstanceIdSuccess(c *gc.C) {
 
 	s.state.EXPECT().InstanceId(gomock.Any(), cmachine.Name("666")).Return("123", nil)
 
-	instanceId, err := NewService(s.state).InstanceId(context.Background(), cmachine.Name("666"))
+	instanceId, err := NewService(s.state).InstanceId(context.Background(), "666")
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(instanceId, gc.Equals, "123")
 }
@@ -218,7 +216,7 @@ func (s *serviceSuite) TestInstanceIdError(c *gc.C) {
 	rErr := errors.New("boom")
 	s.state.EXPECT().InstanceId(gomock.Any(), cmachine.Name("666")).Return("", rErr)
 
-	instanceId, err := NewService(s.state).InstanceId(context.Background(), cmachine.Name("666"))
+	instanceId, err := NewService(s.state).InstanceId(context.Background(), "666")
 	c.Check(err, jc.ErrorIs, rErr)
 	c.Check(instanceId, gc.Equals, "")
 }
@@ -232,7 +230,7 @@ func (s *serviceSuite) TestInstanceIdNotProvisionedError(c *gc.C) {
 
 	s.state.EXPECT().InstanceId(gomock.Any(), cmachine.Name("666")).Return("", errors.NotProvisioned)
 
-	instanceId, err := NewService(s.state).InstanceId(context.Background(), cmachine.Name("666"))
+	instanceId, err := NewService(s.state).InstanceId(context.Background(), "666")
 	c.Check(err, jc.ErrorIs, errors.NotProvisioned)
 	c.Check(instanceId, gc.Equals, "")
 }
@@ -244,7 +242,7 @@ func (s *serviceSuite) TestGetMachineStatusSuccess(c *gc.C) {
 	expectedStatus := status.StatusInfo{Status: corestatus.Started}
 	s.state.EXPECT().GetMachineStatus(gomock.Any(), cmachine.Name("666")).Return(expectedStatus, nil)
 
-	machineStatus, err := NewService(s.state).GetMachineStatus(context.Background(), cmachine.Name("666"))
+	machineStatus, err := NewService(s.state).GetMachineStatus(context.Background(), "666")
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(machineStatus, gc.DeepEquals, expectedStatus)
 }
@@ -257,7 +255,7 @@ func (s *serviceSuite) TestGetMachineStatusError(c *gc.C) {
 	rErr := errors.New("boom")
 	s.state.EXPECT().GetMachineStatus(gomock.Any(), cmachine.Name("666")).Return(status.StatusInfo{}, rErr)
 
-	machineStatus, err := NewService(s.state).GetMachineStatus(context.Background(), cmachine.Name("666"))
+	machineStatus, err := NewService(s.state).GetMachineStatus(context.Background(), "666")
 	c.Check(err, jc.ErrorIs, rErr)
 	c.Check(machineStatus, gc.DeepEquals, status.StatusInfo{})
 }
@@ -269,7 +267,7 @@ func (s *serviceSuite) TestSetMachineStatusSuccess(c *gc.C) {
 	newStatus := status.StatusInfo{Status: corestatus.Started}
 	s.state.EXPECT().SetMachineStatus(gomock.Any(), cmachine.Name("666"), newStatus).Return(nil)
 
-	err := NewService(s.state).SetMachineStatus(context.Background(), cmachine.Name("666"), newStatus)
+	err := NewService(s.state).SetMachineStatus(context.Background(), "666", newStatus)
 	c.Check(err, jc.ErrorIsNil)
 }
 
@@ -282,14 +280,14 @@ func (s *serviceSuite) TestSetMachineStatusError(c *gc.C) {
 	rErr := errors.New("boom")
 	s.state.EXPECT().SetMachineStatus(gomock.Any(), cmachine.Name("666"), newStatus).Return(rErr)
 
-	err := NewService(s.state).SetMachineStatus(context.Background(), cmachine.Name("666"), newStatus)
+	err := NewService(s.state).SetMachineStatus(context.Background(), "666", newStatus)
 	c.Check(err, jc.ErrorIs, rErr)
 }
 
 // TestSetMachineStatusInvalid asserts that an invalid status is passed to the
 // service will result in a InvalidStatus error.
 func (s *serviceSuite) TestSetMachineStatusInvalid(c *gc.C) {
-	err := NewService(nil).SetMachineStatus(context.Background(), cmachine.Name("666"), status.StatusInfo{Status: "invalid"})
+	err := NewService(nil).SetMachineStatus(context.Background(), "666", status.StatusInfo{Status: "invalid"})
 	c.Check(err, jc.ErrorIs, machineerrors.InvalidStatus)
 }
 
@@ -300,7 +298,7 @@ func (s *serviceSuite) TestGetInstanceStatusSuccess(c *gc.C) {
 	expectedStatus := status.StatusInfo{Status: corestatus.Running}
 	s.state.EXPECT().GetInstanceStatus(gomock.Any(), cmachine.Name("666")).Return(expectedStatus, nil)
 
-	instanceStatus, err := NewService(s.state).GetInstanceStatus(context.Background(), cmachine.Name("666"))
+	instanceStatus, err := NewService(s.state).GetInstanceStatus(context.Background(), "666")
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(instanceStatus, gc.DeepEquals, expectedStatus)
 }
@@ -313,7 +311,7 @@ func (s *serviceSuite) TestGetInstanceStatusError(c *gc.C) {
 	rErr := errors.New("boom")
 	s.state.EXPECT().GetInstanceStatus(gomock.Any(), cmachine.Name("666")).Return(status.StatusInfo{}, rErr)
 
-	instanceStatus, err := NewService(s.state).GetInstanceStatus(context.Background(), cmachine.Name("666"))
+	instanceStatus, err := NewService(s.state).GetInstanceStatus(context.Background(), "666")
 	c.Check(err, jc.ErrorIs, rErr)
 	c.Check(instanceStatus, gc.DeepEquals, status.StatusInfo{})
 }
@@ -326,7 +324,7 @@ func (s *serviceSuite) TestSetInstanceStatusSuccess(c *gc.C) {
 	newStatus := status.StatusInfo{Status: corestatus.Running}
 	s.state.EXPECT().SetInstanceStatus(gomock.Any(), cmachine.Name("666"), newStatus).Return(nil)
 
-	err := NewService(s.state).SetInstanceStatus(context.Background(), cmachine.Name("666"), newStatus)
+	err := NewService(s.state).SetInstanceStatus(context.Background(), "666", newStatus)
 	c.Check(err, jc.ErrorIsNil)
 }
 
@@ -339,14 +337,14 @@ func (s *serviceSuite) TestSetInstanceStatusError(c *gc.C) {
 	newStatus := status.StatusInfo{Status: corestatus.Running}
 	s.state.EXPECT().SetInstanceStatus(gomock.Any(), cmachine.Name("666"), newStatus).Return(rErr)
 
-	err := NewService(s.state).SetInstanceStatus(context.Background(), cmachine.Name("666"), newStatus)
+	err := NewService(s.state).SetInstanceStatus(context.Background(), "666", newStatus)
 	c.Check(err, jc.ErrorIs, rErr)
 }
 
 // TestSetInstanceStatusInvalid asserts that an invalid status is passed to the
 // service will result in a InvalidStatus error.
 func (s *serviceSuite) TestSetInstanceStatusInvalid(c *gc.C) {
-	err := NewService(nil).SetInstanceStatus(context.Background(), cmachine.Name("666"), status.StatusInfo{Status: "invalid"})
+	err := NewService(nil).SetInstanceStatus(context.Background(), "666", status.StatusInfo{Status: "invalid"})
 	c.Check(err, jc.ErrorIs, machineerrors.InvalidStatus)
 }
 
@@ -356,30 +354,33 @@ func (s *serviceSuite) TestIsControllerSuccess(c *gc.C) {
 
 	s.state.EXPECT().IsController(gomock.Any(), cmachine.Name("666")).Return(true, nil)
 
-	isController, err := NewService(s.state).IsController(context.Background(), cmachine.Name("666"))
+	isController, err := NewService(s.state).IsController(context.Background(), "666")
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(isController, jc.IsTrue)
 }
 
-// TestIsControllerError asserts that an error coming from the state layer is preserved, passed over to the service layer to be maintained there.
+// TestIsControllerError asserts that an error coming from the state layer is
+// preserved, passed over to the service layer to be maintained there.
 func (s *serviceSuite) TestIsControllerError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	rErr := errors.New("boom")
 	s.state.EXPECT().IsController(gomock.Any(), cmachine.Name("666")).Return(false, rErr)
 
-	isController, err := NewService(s.state).IsController(context.Background(), cmachine.Name("666"))
+	isController, err := NewService(s.state).IsController(context.Background(), "666")
 	c.Check(err, jc.ErrorIs, rErr)
 	c.Check(isController, jc.IsFalse)
 }
 
-// TestIsControllerNotFound asserts that the state layer returns a NotFound Error if a machine is not found with the given machineName, and that error is preserved and passed on to the service layer to be handled there.
+// TestIsControllerNotFound asserts that the state layer returns a NotFound
+// Error if a machine is not found with the given machineName, and that error
+// is preserved and passed on to the service layer to be handled there.
 func (s *serviceSuite) TestIsControllerNotFound(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	s.state.EXPECT().IsController(gomock.Any(), cmachine.Name("666")).Return(false, errors.NotFound)
 
-	isController, err := NewService(s.state).IsController(context.Background(), cmachine.Name("666"))
+	isController, err := NewService(s.state).IsController(context.Background(), "666")
 	c.Check(err, jc.ErrorIs, errors.NotFound)
 	c.Check(isController, jc.IsFalse)
 }
@@ -472,8 +473,8 @@ func (s *serviceSuite) TestMachineShouldRebootOrShutdownDoNothing(c *gc.C) {
 	c.Assert(needReboot, gc.Equals, machine.ShouldDoNothing)
 }
 
-// TestMachineShouldRebootOrShutdownReboot asserts that the reboot action is preserved from the state
-// layer through the service layer.
+// TestMachineShouldRebootOrShutdownReboot asserts that the reboot action is
+// preserved from the state layer through the service layer.
 func (s *serviceSuite) TestMachineShouldRebootOrShutdownReboot(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
@@ -484,8 +485,8 @@ func (s *serviceSuite) TestMachineShouldRebootOrShutdownReboot(c *gc.C) {
 	c.Assert(needReboot, gc.Equals, machine.ShouldReboot)
 }
 
-// TestMachineShouldRebootOrShutdownShutdown asserts that the reboot action is preserved from the state
-// layer through the service layer.
+// TestMachineShouldRebootOrShutdownShutdown asserts that the reboot action is
+// preserved from the state layer through the service layer.
 func (s *serviceSuite) TestMachineShouldRebootOrShutdownShutdown(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
@@ -496,8 +497,9 @@ func (s *serviceSuite) TestMachineShouldRebootOrShutdownShutdown(c *gc.C) {
 	c.Assert(needReboot, gc.Equals, machine.ShouldShutdown)
 }
 
-// TestMachineShouldRebootOrShutdownError asserts that if the state layer returns an Error,
-// this error will be preserved and passed to the service layer
+// TestMachineShouldRebootOrShutdownError asserts that if the state layer
+// returns an Error, this error will be preserved and passed to the service
+// layer.
 func (s *serviceSuite) TestMachineShouldRebootOrShutdownError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 

--- a/domain/machine/service/watcher.go
+++ b/domain/machine/service/watcher.go
@@ -5,14 +5,19 @@ package service
 
 import (
 	"context"
+	"database/sql"
+	"fmt"
+	"github.com/juju/juju/core/machine"
+	"strings"
 
+	"github.com/juju/collections/transform"
 	"github.com/juju/juju/core/changestream"
+	"github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/core/watcher/eventsource"
 )
 
 type WatchableService struct {
-	// Machine Service
 	Service
 	watcherFactory WatcherFactory
 }
@@ -22,8 +27,14 @@ type WatcherFactory interface {
 	// NewNamespaceWatcher returns a new namespace watcher
 	// for events based on the input change mask.
 	NewNamespaceWatcher(
-		namespace string, changeMask changestream.ChangeType,
+		namespace string, changeMask changestream.ChangeType, initialStateQuery eventsource.NamespaceQuery,
+	) (watcher.StringsWatcher, error)
+
+	NewNamespaceMapperWatcher(
+		namespace string,
+		changeMask changestream.ChangeType,
 		initialStateQuery eventsource.NamespaceQuery,
+		mapper eventsource.Mapper,
 	) (watcher.StringsWatcher, error)
 }
 
@@ -37,14 +48,18 @@ func NewWatchableService(st State, watcherFactory WatcherFactory) *WatchableServ
 	}
 }
 
-// WatchMachines returns a StringsWatcher that is subscribed to the changes
-// in the machines table in the model.
-func (s *WatchableService) WatchMachines(ctx context.Context) (watcher.StringsWatcher, error) {
-	table, stmt := s.st.InitialWatchStatement()
-	return s.watcherFactory.NewNamespaceWatcher(
+// WatchModelMachines watches for additions or updates to non-container
+// machines. It is used by workers that need to factor life value changes,
+// and so does not factor machine removals, which are considered to be
+// after their transition to the dead state.
+// It emits machine names rather than UUIDs.
+func (s *WatchableService) WatchModelMachines() (watcher.StringsWatcher, error) {
+	table, stmt := s.st.InitialWatchModelMachinesStatement()
+	return s.watcherFactory.NewNamespaceMapperWatcher(
 		table,
-		changestream.All,
+		changestream.Create|changestream.Update,
 		eventsource.InitialNamespaceChanges(stmt),
+		uuidToNameMapper(noContainersFilter),
 	)
 }
 
@@ -57,4 +72,92 @@ func (s *WatchableService) WatchMachineCloudInstances(ctx context.Context) (watc
 		changestream.All,
 		eventsource.InitialNamespaceChanges(stmt),
 	)
+}
+
+// changeEventShim implements changestream.ChangeEvent and allows the
+// substituting of events in an implementation of eventsource.Mapper.
+type changeEventShim struct {
+	changeType changestream.ChangeType
+	namespace  string
+	changed    string
+}
+
+// Type returns the type of change (create, update, delete).
+func (e changeEventShim) Type() changestream.ChangeType {
+	return e.changeType
+}
+
+// Namespace returns the namespace of the change. This is normally the
+// table name.
+func (e changeEventShim) Namespace() string {
+	return e.namespace
+}
+
+// Changed returns the changed value of event. This logically can be
+// the primary key of the row that was changed or the field of the change
+// that was changed.
+func (e changeEventShim) Changed() string {
+	return e.changed
+}
+
+// uuidToNameMapper is an eventsource.Mapper that converts a slice of
+// changestream.ChangeEvent containing machine UUIDs to another slice of
+// events with the machine names that correspond to the UUIDs.
+// If the input filter is not nil and returns true for any machine UUID/name in
+// the events, those events are omitted.
+func uuidToNameMapper(filter func(string, machine.Name) bool) eventsource.Mapper {
+	return func(
+		ctx context.Context, db database.TxnRunner, events []changestream.ChangeEvent,
+	) ([]changestream.ChangeEvent, error) {
+		// Generate a slice of UUIDs and placeholders for our query
+		// and index the events by those UUIDs.
+		machineUUIDs := make([]any, 0, len(events))
+		placeHolders := make([]string, 0, len(events))
+		eventsByUUID := transform.SliceToMap(events, func(e changestream.ChangeEvent) (string, changestream.ChangeEvent) {
+			machineUUIDs = append(machineUUIDs, e.Changed())
+			placeHolders = append(placeHolders, "?")
+			return e.Changed(), e
+		})
+
+		newEvents := make([]changestream.ChangeEvent, 0, len(events))
+		q := fmt.Sprintf("SELECT uuid, name FROM machine WHERE uuid IN (%s)", strings.Join(placeHolders, ", "))
+
+		if err := db.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+			rows, err := tx.QueryContext(ctx, q, machineUUIDs...)
+			if err != nil {
+				return err
+			}
+			defer func() { _ = rows.Close() }()
+
+			var uuid, name string
+			for rows.Next() {
+				if err := rows.Scan(&uuid, &name); err != nil {
+					return err
+				}
+
+				if filter != nil && filter(uuid, machine.Name(name)) {
+					continue
+				}
+
+				e := eventsByUUID[uuid]
+				newEvents = append(newEvents, changeEventShim{
+					changeType: e.Type(),
+					namespace:  e.Namespace(),
+					changed:    name,
+				})
+			}
+
+			return rows.Err()
+		}); err != nil {
+			return nil, err
+		}
+
+		return newEvents, nil
+	}
+}
+
+// noContainersFilter returns true if the input machine name
+// is one reserved for LXD containers.
+func noContainersFilter(_ string, name machine.Name) bool {
+	return strings.Contains(name.String(), "/")
 }

--- a/domain/machine/service/watcher.go
+++ b/domain/machine/service/watcher.go
@@ -7,12 +7,13 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"github.com/juju/juju/core/machine"
 	"strings"
 
 	"github.com/juju/collections/transform"
+
 	"github.com/juju/juju/core/changestream"
 	"github.com/juju/juju/core/database"
+	"github.com/juju/juju/core/machine"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/core/watcher/eventsource"
 )

--- a/domain/machine/service/watcher_test.go
+++ b/domain/machine/service/watcher_test.go
@@ -1,0 +1,81 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package service
+
+import (
+	"context"
+	"database/sql"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/changestream"
+	schematesting "github.com/juju/juju/domain/schema/testing"
+	"github.com/juju/juju/internal/uuid"
+)
+
+type mapperSuite struct {
+	schematesting.ModelSuite
+}
+
+var _ = gc.Suite(&mapperSuite{})
+
+func (s *mapperSuite) TestUuidToNameMapper(c *gc.C) {
+	uuid0 := uuid.MustNewUUID().String()
+	uuid1 := uuid.MustNewUUID().String()
+	uuid2 := uuid.MustNewUUID().String()
+
+	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		stmt := "INSERT INTO net_node (uuid) VALUES (?)"
+		if _, err := tx.ExecContext(ctx, stmt, uuid0); err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx, stmt, uuid1); err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx, stmt, uuid2); err != nil {
+			return err
+		}
+
+		stmt = "INSERT INTO machine (uuid, name, net_node_uuid, life_id) VALUES (?, ?, ?, ?)"
+		if _, err := tx.ExecContext(ctx, stmt, uuid0, "0", uuid0, 0); err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx, stmt, uuid1, "1", uuid1, 0); err != nil {
+			return err
+		}
+		_, err := tx.ExecContext(ctx, stmt, uuid2, "0/lxd/0", uuid2, 0)
+		return err
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	changesIn := []changestream.ChangeEvent{
+		changeEventShim{
+			changeType: 1,
+			namespace:  "machine",
+			changed:    uuid0,
+		},
+		changeEventShim{
+			changeType: 2,
+			namespace:  "machine",
+			changed:    uuid1,
+		},
+	}
+
+	changesOut, err := uuidToNameMapper(noContainersFilter)(context.Background(), s.TxnRunner(), changesIn)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(changesOut, jc.SameContents, []changestream.ChangeEvent{
+		changeEventShim{
+			changeType: 1,
+			namespace:  "machine",
+			changed:    "0",
+		},
+		changeEventShim{
+			changeType: 2,
+			namespace:  "machine",
+			changed:    "1",
+		},
+	})
+}

--- a/domain/machine/state/state.go
+++ b/domain/machine/state/state.go
@@ -181,6 +181,12 @@ DELETE FROM net_node WHERE uuid IN
 	return errors.Annotatef(err, "deleting machine %q", mName)
 }
 
+// InitialWatchModelMachinesStatement returns the table and the initial watch
+// statement for watching life changes of non-container machines.
+func (st *State) InitialWatchModelMachinesStatement() (string, string) {
+	return "machine", "SELECT uuid FROM machine WHERE name NOT LIKE '%/%'"
+}
+
 // InitialWatchStatement returns the table and the initial watch statement
 // for the machines.
 func (st *State) InitialWatchStatement() (string, string) {

--- a/domain/machine/state/state.go
+++ b/domain/machine/state/state.go
@@ -184,7 +184,7 @@ DELETE FROM net_node WHERE uuid IN
 // InitialWatchModelMachinesStatement returns the table and the initial watch
 // statement for watching life changes of non-container machines.
 func (st *State) InitialWatchModelMachinesStatement() (string, string) {
-	return "machine", "SELECT uuid FROM machine WHERE name NOT LIKE '%/%'"
+	return "machine", "SELECT name FROM machine WHERE name NOT LIKE '%/%'"
 }
 
 // InitialWatchStatement returns the table and the initial watch statement

--- a/domain/machine/watcher_test.go
+++ b/domain/machine/watcher_test.go
@@ -14,69 +14,86 @@ import (
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/watcher/watchertest"
 	"github.com/juju/juju/domain"
-	service "github.com/juju/juju/domain/machine/service"
-	state "github.com/juju/juju/domain/machine/state"
+	life "github.com/juju/juju/domain/life"
+	"github.com/juju/juju/domain/machine/service"
+	"github.com/juju/juju/domain/machine/state"
 	changestreamtesting "github.com/juju/juju/internal/changestream/testing"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 )
 
 type watcherSuite struct {
 	changestreamtesting.ModelSuite
+
+	svc *service.WatchableService
 }
 
 var _ = gc.Suite(&watcherSuite{})
 
-func (s *watcherSuite) TestWatchWithCreate(c *gc.C) {
-	machineService, watcherC := s.machineServiceAndWatcher(c)
+func (s *watcherSuite) SetUpTest(c *gc.C) {
+	s.ModelSuite.SetUpTest(c)
 
-	// Create a machine
-	_, err := machineService.CreateMachine(context.Background(), "machine-1")
-	c.Assert(err, gc.IsNil)
-
-	// Assert the create change
-	watcherC.AssertChange("machine-1")
-}
-
-func (s *watcherSuite) TestWatchWithDelete(c *gc.C) {
-	machineService, watcherC := s.machineServiceAndWatcher(c)
-
-	// Create a machine
-	_, err := machineService.CreateMachine(context.Background(), "machine-1")
-	c.Assert(err, gc.IsNil)
-
-	// Assert the first change
-	watcherC.AssertChange("machine-1")
-
-	// Ensure that the changestream is idle.
-	s.ModelSuite.AssertChangeStreamIdle(c)
-
-	// Delete the machine
-	err = machineService.DeleteMachine(context.Background(), "machine-1")
-	c.Assert(err, gc.IsNil)
-
-	// Assert the second change
-	watcherC.AssertChange("machine-1")
-}
-
-func (s *watcherSuite) TestMachineCloudInstanceWatchWithSet(c *gc.C) {
-	// Set-up watcher and test watcher.
-	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "machine_cloud_instance")
-	svc := service.NewWatchableService(
+	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "machine")
+	s.svc = service.NewWatchableService(
 		state.NewState(
 			func() (database.TxnRunner, error) { return factory() },
 			loggertesting.WrapCheckLog(c),
 		),
 		domain.NewWatcherFactory(factory, loggertesting.WrapCheckLog(c)),
 	)
-	watcher, err := svc.WatchMachineCloudInstances(context.Background())
+}
+
+func (s *watcherSuite) TestWatchModelMachines(c *gc.C) {
+	_, err := s.svc.CreateMachine(context.Background(), "0")
+	c.Assert(err, gc.IsNil)
+
+	_, err = s.svc.CreateMachine(context.Background(), "0/lxd/0")
+	c.Assert(err, gc.IsNil)
+
+	s.AssertChangeStreamIdle(c)
+
+	watcher, err := s.svc.WatchModelMachines()
+	c.Assert(err, gc.IsNil)
+	defer watchertest.CleanKill(c, watcher)
+
+	watcherC := watchertest.NewStringsWatcherC(c, watcher)
+
+	// The initial event should have the machine we created prior,
+	// but not the container.
+	watcherC.AssertChange("0")
+
+	// A new machine triggers an emission.
+	_, err = s.svc.CreateMachine(context.Background(), "1")
+	c.Assert(err, gc.IsNil)
+	watcherC.AssertChange("1")
+
+	// An update triggers an emission.
+	err = s.svc.SetMachineLife(context.Background(), "1", life.Dying)
+	c.Assert(err, gc.IsNil)
+	watcherC.AssertChange("1")
+
+	// A deletion is ignored.
+	err = s.svc.DeleteMachine(context.Background(), "1")
+	c.Assert(err, gc.IsNil)
+
+	// As is a container creation.
+	_, err = s.svc.CreateMachine(context.Background(), "0/lxd/1")
+	c.Assert(err, gc.IsNil)
+
+	s.AssertChangeStreamIdle(c)
+	watcherC.AssertNoChange()
+}
+
+func (s *watcherSuite) TestMachineCloudInstanceWatchWithSet(c *gc.C) {
+	watcher, err := s.svc.WatchMachineCloudInstances(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
+
 	watcherC := watchertest.NewStringsWatcherC(c, watcher)
 	// Initial event.
 	watcherC.AssertOneChange()
 	s.AssertChangeStreamIdle(c)
 
 	// Create a machineUUID and set its cloud instance.
-	machineUUID, err := svc.CreateMachine(context.Background(), "machine-1")
+	machineUUID, err := s.svc.CreateMachine(context.Background(), "machine-1")
 	c.Assert(err, gc.IsNil)
 	hc := instance.HardwareCharacteristics{
 		Mem:      uintptr(1024),
@@ -84,7 +101,7 @@ func (s *watcherSuite) TestMachineCloudInstanceWatchWithSet(c *gc.C) {
 		CpuCores: uintptr(4),
 		CpuPower: uintptr(75),
 	}
-	err = svc.SetMachineCloudInstance(context.Background(), machineUUID, "42", hc)
+	err = s.svc.SetMachineCloudInstance(context.Background(), machineUUID, "42", hc)
 	c.Assert(err, gc.IsNil)
 
 	// Assert the change.
@@ -92,24 +109,16 @@ func (s *watcherSuite) TestMachineCloudInstanceWatchWithSet(c *gc.C) {
 }
 
 func (s *watcherSuite) TestMachineCloudInstanceWatchWithDelete(c *gc.C) {
-	// Set-up watcher and test watcher.
-	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "machine_cloud_instance")
-	svc := service.NewWatchableService(
-		state.NewState(
-			func() (database.TxnRunner, error) { return factory() },
-			loggertesting.WrapCheckLog(c),
-		),
-		domain.NewWatcherFactory(factory, loggertesting.WrapCheckLog(c)),
-	)
-	watcher, err := svc.WatchMachineCloudInstances(context.Background())
+	watcher, err := s.svc.WatchMachineCloudInstances(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
+
 	watcherC := watchertest.NewStringsWatcherC(c, watcher)
 	// Initial event.
 	watcherC.AssertOneChange()
 	s.AssertChangeStreamIdle(c)
 
 	// Create a machineUUID and set its cloud instance.
-	machineUUID, err := svc.CreateMachine(context.Background(), "machine-1")
+	machineUUID, err := s.svc.CreateMachine(context.Background(), "machine-1")
 	c.Assert(err, gc.IsNil)
 	hc := instance.HardwareCharacteristics{
 		Mem:      uintptr(1024),
@@ -117,34 +126,14 @@ func (s *watcherSuite) TestMachineCloudInstanceWatchWithDelete(c *gc.C) {
 		CpuCores: uintptr(4),
 		CpuPower: uintptr(75),
 	}
-	err = svc.SetMachineCloudInstance(context.Background(), machineUUID, "42", hc)
+	err = s.svc.SetMachineCloudInstance(context.Background(), machineUUID, "42", hc)
 	c.Assert(err, gc.IsNil)
 	// Delete the cloud instance.
-	err = svc.DeleteMachineCloudInstance(context.Background(), machineUUID)
+	err = s.svc.DeleteMachineCloudInstance(context.Background(), machineUUID)
 	c.Assert(err, gc.IsNil)
 
 	// Assert the changes.
 	watcherC.AssertChange(machineUUID)
-}
-
-func (s *watcherSuite) machineServiceAndWatcher(c *gc.C) (*service.WatchableService, watchertest.StringsWatcherC) {
-	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "machine")
-	machineService := service.NewWatchableService(
-		state.NewState(
-			func() (database.TxnRunner, error) { return factory() },
-			loggertesting.WrapCheckLog(c),
-		),
-		domain.NewWatcherFactory(factory, loggertesting.WrapCheckLog(c)),
-	)
-
-	watcher, err := machineService.WatchMachines(context.Background())
-	c.Assert(err, gc.IsNil)
-	watcherC := watchertest.NewStringsWatcherC(c, watcher)
-	// Initial event.
-	watcherC.AssertOneChange()
-	s.AssertChangeStreamIdle(c)
-
-	return machineService, watcherC
 }
 
 func uintptr(u uint64) *uint64 {

--- a/domain/schema/model.go
+++ b/domain/schema/model.go
@@ -97,7 +97,7 @@ func ModelDDL() *schema.Schema {
 		triggers.ChangeLogTriggersForSecretRevision("uuid", tableSecretRevision),
 		triggers.ChangeLogTriggersForSecretReference("secret_id", tableSecretReference),
 		triggers.ChangeLogTriggersForSubnet("uuid", tableSubnet),
-		triggers.ChangeLogTriggersForMachine("name", tableMachine),
+		triggers.ChangeLogTriggersForMachine("uuid", tableMachine),
 		triggers.ChangeLogTriggersForMachineCloudInstance("machine_uuid", tableMachineCloudInstance),
 		triggers.ChangeLogTriggersForUserPublicSshKey("id", tableUserPublicSSHKey),
 		triggers.ChangeLogTriggersForCharm("uuid", tableCharm),


### PR DESCRIPTION
The  initial watcher added for machines was an unadorned namespace watcher (all changes), and was accompanied by a change of the change-log trigger value from UUID to name.

This watcher did not actually replicate the functionality of the watcher it was meant to replicate, I.e. the life watcher returned by `WatchModelMachines`.

Here we make the following changes:
- The change-log trigger value is now UUID.
- The watcher for `WatchModelMachines` now uses a mapper to convert UUID to name, and omits:
  - Deleted machines
  - LXD containers

## QA steps

- Bootstrap and add a model.
- `juju add-machine`.
- Model logs should show:
  - The machine gets provisioned.
  - The firewaller starts to watch it.
  - The instance-poller sees it and updates its status.
- `juju remove machine 0 --no-prompt`.
- Logs will show the provisioner, firewaller and instance-poller remove the dead machine.

## Documentation changes

None.

## Links

**Jira card:** [JUJU-6366](https://warthogs.atlassian.net/browse/JUJU-6366)



[JUJU-6366]: https://warthogs.atlassian.net/browse/JUJU-6366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ