### PR TITLE
build: prevent internal/pki/test from linking into juju bins

### DIFF
--- a/internal/pki/test/notest.go
+++ b/internal/pki/test/notest.go
@@ -1,0 +1,22 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+//go:build notest
+
+package test
+
+import (
+	_ "unsafe"
+)
+
+// Dear Reader,
+// You have found your way here because you imported github.com/juju/juju/internal/pki/test
+// into code that found its way into a non-test binary.
+// This is bad. Please don't use test code inside a juju binary.
+
+//go:linkname do_not_import_test_code_into_juju
+func do_not_import_test_code_into_juju()
+
+func init() {
+	do_not_import_test_code_into_juju()
+}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -405,7 +405,7 @@ parts:
       github.com/juju/juju/core/version.build: ""
     go-static: true
     go-strip: true
-    go-buildtags: ["libsqlite3", "dqlite"]
+    go-buildtags: ["libsqlite3", "dqlite", "notest"]
     go-cgo-enabled: "1"
     go-cgo-cc: "musl-gcc"
     go-cgo-cflags: "-I/usr/local/musl/include"
@@ -444,6 +444,7 @@ parts:
       github.com/juju/juju/core/version.build: ""
     go-static: true
     go-strip: true
+    go-buildtags: ["notest"]
     override-build: |
       snapcraftctl build
 


### PR DESCRIPTION
This prevents  internal/pki/test from linking into juju bins, as it is only for tests.
