### PR TITLE
chore: merge 3.6 into main

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -48,7 +48,7 @@ var facadeVersions = facades.FacadeVersions{
 	"Cleaner":                      {2},
 	"Client":                       {6, 7},
 	"Cloud":                        {7},
-	"Controller":                   {11},
+	"Controller":                   {11, 12},
 	"CredentialManager":            {1},
 	"CredentialValidator":          {2},
 	"CrossController":              {1},

--- a/apiserver/facades/client/controller/controller.go
+++ b/apiserver/facades/client/controller/controller.go
@@ -111,9 +111,13 @@ type ControllerAPI struct {
 	controllerTag names.ControllerTag
 }
 
+type ControllerAPIv11 struct {
+	*ControllerAPI
+}
+
 // LatestAPI is used for testing purposes to create the latest
 // controller API.
-var LatestAPI = newControllerAPIv11
+var LatestAPI = makeControllerAPI
 
 // NewControllerAPI creates a new api server endpoint for operations
 // on a controller.
@@ -503,7 +507,7 @@ func (c *ControllerAPI) ListBlockedModels(ctx context.Context) (params.ModelBloc
 // converted to a multi-model facade. Please use the ModelConfig facade's
 // ModelGet method instead:
 // [github.com/juju/juju/apiserver/facades/client/modelconfig.ModelConfigAPI.ModelGet]
-func (c *ControllerAPI) ModelConfig(ctx context.Context) (params.ModelConfigResults, error) {
+func (c *ControllerAPIv11) ModelConfig(ctx context.Context) (params.ModelConfigResults, error) {
 	result := params.ModelConfigResults{}
 	if err := c.checkIsSuperUser(); err != nil {
 		return result, errors.Trace(err)

--- a/apiserver/facades/client/controller/controller_test.go
+++ b/apiserver/facades/client/controller/controller_test.go
@@ -258,7 +258,10 @@ func (s *controllerSuite) TestListBlockedModelsNoBlocks(c *gc.C) {
 }
 
 func (s *controllerSuite) TestModelConfig(c *gc.C) {
-	cfg, err := s.controller.ModelConfig(stdcontext.Background())
+	controller, err := controller.NewControllerAPIv11(context.Background(), s.context)
+	c.Assert(err, jc.ErrorIsNil)
+
+	cfg, err := controller.ModelConfig(stdcontext.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(cfg.Config["name"], jc.DeepEquals, params.ConfigValue{Value: "controller"})
 }

--- a/apiserver/facades/client/controller/destroy_test.go
+++ b/apiserver/facades/client/controller/destroy_test.go
@@ -61,7 +61,7 @@ func (s *destroyControllerSuite) SetUpTest(c *gc.C) {
 	s.authorizer = apiservertesting.FakeAuthorizer{
 		Tag: jujutesting.AdminUser,
 	}
-	testController, err := controller.NewControllerAPIv11(
+	testController, err := controller.LatestAPI(
 		context.Background(),
 		facadetest.ModelContext{
 			State_:          s.ControllerModel(c).State(),

--- a/apiserver/facades/client/controller/export_test.go
+++ b/apiserver/facades/client/controller/export_test.go
@@ -34,5 +34,5 @@ func SetPrecheckResult(p patcher, err error) {
 }
 
 var (
-	NewControllerAPIv11 = newControllerAPIv11
+	NewControllerAPIv11 = makeControllerAPIv11
 )

--- a/apiserver/facades/client/modelupgrader/findagents.go
+++ b/apiserver/facades/client/modelupgrader/findagents.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/controller"
+	"github.com/juju/juju/core/arch"
 	coreos "github.com/juju/juju/core/os"
 	envtools "github.com/juju/juju/environs/tools"
 	"github.com/juju/juju/internal/cloudconfig/podcfg"
@@ -125,6 +126,11 @@ func (m *ModelUpgraderAPI) agentVersionsForCAAS(
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+
+	wantArch := args.Arch
+	if wantArch == "" {
+		wantArch = arch.DefaultArchitecture
+	}
 	for _, tag := range tags {
 		number := tag.AgentVersion()
 		if args.MajorVersion > 0 {
@@ -149,21 +155,21 @@ func (m *ModelUpgraderAPI) agentVersionsForCAAS(
 				continue
 			}
 		}
-		arch, err := reg.GetArchitecture(imageName, number.String())
+		arches, err := reg.GetArchitectures(imageName, number.String())
 		if errors.Is(err, errors.NotFound) {
 			continue
 		}
 		if err != nil {
 			return nil, errors.Annotatef(err, "cannot get architecture for %s:%s", imageName, number.String())
 		}
-		if args.Arch != "" && arch != args.Arch {
+		if !set.NewStrings(arches...).Contains(wantArch) {
 			continue
 		}
 		tools := coretools.Tools{
 			Version: version.Binary{
 				Number:  number,
 				Release: coreos.HostOSTypeName(),
-				Arch:    arch,
+				Arch:    wantArch,
 			},
 		}
 		result = append(result, &tools)

--- a/apiserver/facades/client/modelupgrader/upgrader_test.go
+++ b/apiserver/facades/client/modelupgrader/upgrader_test.go
@@ -767,7 +767,15 @@ func (s *modelUpgradeSuite) TestFindToolsIAAS(c *gc.C) {
 	})
 }
 
+func (s *modelUpgradeSuite) TestFindToolsCAASReleasedDefault(c *gc.C) {
+	s.assertFindToolsCAASReleased(c, "", "amd64")
+}
+
 func (s *modelUpgradeSuite) TestFindToolsCAASReleased(c *gc.C) {
+	s.assertFindToolsCAASReleased(c, "arm64", "arm64")
+}
+
+func (s *modelUpgradeSuite) assertFindToolsCAASReleased(c *gc.C, wantArch, expectArch string) {
 	ctrl := s.setupMocks(c)
 	defer ctrl.Finish()
 
@@ -779,6 +787,9 @@ func (s *modelUpgradeSuite) TestFindToolsCAASReleased(c *gc.C) {
 		{Version: version.MustParseBinary("2.9.9-ubuntu-amd64")},
 		{Version: version.MustParseBinary("2.9.10-ubuntu-amd64")},
 		{Version: version.MustParseBinary("2.9.11-ubuntu-amd64")},
+		{Version: version.MustParseBinary("2.9.9-ubuntu-arm64")},
+		{Version: version.MustParseBinary("2.9.10-ubuntu-arm64")},
+		{Version: version.MustParseBinary("2.9.11-ubuntu-arm64")},
 	}
 	s.PatchValue(&coreos.HostOS, func() ostype.OSType { return ostype.Ubuntu })
 
@@ -788,6 +799,7 @@ func (s *modelUpgradeSuite) TestFindToolsCAASReleased(c *gc.C) {
 			common.FindAgentsParams{
 				MajorVersion: 2, MinorVersion: 9,
 				ModelType: state.ModelTypeCAAS,
+				Arch:      wantArch,
 			},
 		).Return(simpleStreams, nil),
 		s.registryProvider.EXPECT().Tags("jujud-operator").Return(coretools.Versions{
@@ -798,21 +810,21 @@ func (s *modelUpgradeSuite) TestFindToolsCAASReleased(c *gc.C) {
 			image.NewImageInfo(version.MustParse("2.9.11")),
 			image.NewImageInfo(version.MustParse("2.9.12")), // skip: it's not released in simplestream yet.
 		}, nil),
-		s.registryProvider.EXPECT().GetArchitecture("jujud-operator", "2.9.9").Return("amd64", nil),
-		s.registryProvider.EXPECT().GetArchitecture("jujud-operator", "2.9.10.1").Return("amd64", nil),
-		s.registryProvider.EXPECT().GetArchitecture("jujud-operator", "2.9.10").Return("amd64", nil),
-		s.registryProvider.EXPECT().GetArchitecture("jujud-operator", "2.9.11").Return("amd64", nil),
+		s.registryProvider.EXPECT().GetArchitectures("jujud-operator", "2.9.9").Return([]string{"amd64", "arm64"}, nil),
+		s.registryProvider.EXPECT().GetArchitectures("jujud-operator", "2.9.10.1").Return([]string{"amd64", "arm64"}, nil),
+		s.registryProvider.EXPECT().GetArchitectures("jujud-operator", "2.9.10").Return([]string{"amd64", "arm64"}, nil),
+		s.registryProvider.EXPECT().GetArchitectures("jujud-operator", "2.9.11").Return([]string{"amd64", "arm64"}, nil),
 		s.registryProvider.EXPECT().Close().Return(nil),
 	)
 
 	api := s.newFacade(c)
-	result, err := api.FindAgents(stdcontext.Background(), common.FindAgentsParams{MajorVersion: 2, MinorVersion: 9, ModelType: state.ModelTypeCAAS})
+	result, err := api.FindAgents(stdcontext.Background(), common.FindAgentsParams{MajorVersion: 2, MinorVersion: 9, ModelType: state.ModelTypeCAAS, Arch: wantArch})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, coretools.Versions{
-		&coretools.Tools{Version: version.MustParseBinary("2.9.9-ubuntu-amd64")},
-		&coretools.Tools{Version: version.MustParseBinary("2.9.10.1-ubuntu-amd64")},
-		&coretools.Tools{Version: version.MustParseBinary("2.9.10-ubuntu-amd64")},
-		&coretools.Tools{Version: version.MustParseBinary("2.9.11-ubuntu-amd64")},
+		&coretools.Tools{Version: version.MustParseBinary("2.9.9-ubuntu-" + expectArch)},
+		&coretools.Tools{Version: version.MustParseBinary("2.9.10.1-ubuntu-" + expectArch)},
+		&coretools.Tools{Version: version.MustParseBinary("2.9.10-ubuntu-" + expectArch)},
+		&coretools.Tools{Version: version.MustParseBinary("2.9.11-ubuntu-" + expectArch)},
 	})
 }
 
@@ -843,7 +855,7 @@ func (s *modelUpgradeSuite) TestFindToolsCAASReleasedExact(c *gc.C) {
 			image.NewImageInfo(version.MustParse("2.9.11")),
 			image.NewImageInfo(version.MustParse("2.9.12")),
 		}, nil),
-		s.registryProvider.EXPECT().GetArchitecture("jujud-operator", "2.9.10").Return("amd64", nil),
+		s.registryProvider.EXPECT().GetArchitectures("jujud-operator", "2.9.10").Return([]string{"amd64"}, nil),
 		s.registryProvider.EXPECT().Close().Return(nil),
 	)
 
@@ -886,11 +898,11 @@ func (s *modelUpgradeSuite) TestFindToolsCAASNonReleased(c *gc.C) {
 			image.NewImageInfo(version.MustParse("2.9.12")),
 			image.NewImageInfo(version.MustParse("2.9.13")), // skip: it's not released in simplestream yet.
 		}, nil),
-		s.registryProvider.EXPECT().GetArchitecture("jujud-operator", "2.9.9").Return("amd64", nil),
-		s.registryProvider.EXPECT().GetArchitecture("jujud-operator", "2.9.10.1").Return("amd64", nil),
-		s.registryProvider.EXPECT().GetArchitecture("jujud-operator", "2.9.10").Return("amd64", nil),
-		s.registryProvider.EXPECT().GetArchitecture("jujud-operator", "2.9.11").Return("amd64", nil),
-		s.registryProvider.EXPECT().GetArchitecture("jujud-operator", "2.9.12").Return("", errors.NotFoundf("2.9.12")), // This can only happen on a non-official registry account.
+		s.registryProvider.EXPECT().GetArchitectures("jujud-operator", "2.9.9").Return([]string{"amd64", "arm64"}, nil),
+		s.registryProvider.EXPECT().GetArchitectures("jujud-operator", "2.9.10.1").Return([]string{"amd64", "arm64"}, nil),
+		s.registryProvider.EXPECT().GetArchitectures("jujud-operator", "2.9.10").Return([]string{"amd64", "arm64"}, nil),
+		s.registryProvider.EXPECT().GetArchitectures("jujud-operator", "2.9.11").Return([]string{"amd64", "arm64"}, nil),
+		s.registryProvider.EXPECT().GetArchitectures("jujud-operator", "2.9.12").Return(nil, errors.NotFoundf("2.9.12")), // This can only happen on a non-official registry account.
 		s.registryProvider.EXPECT().Close().Return(nil),
 	)
 

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -13683,7 +13683,7 @@
     {
         "Name": "Controller",
         "Description": "ControllerAPI provides the Controller API.",
-        "Version": 11,
+        "Version": 12,
         "AvailableTo": [
             "controller-machine-agent",
             "machine-agent",
@@ -13833,15 +13833,6 @@
                         }
                     },
                     "description": "ListBlockedModels returns a list of all models on the controller\nwhich have a block in place.  The resulting slice is sorted by model\nname, then owner. Callers must be controller administrators to retrieve the\nlist."
-                },
-                "ModelConfig": {
-                    "type": "object",
-                    "properties": {
-                        "Result": {
-                            "$ref": "#/definitions/ModelConfigResults"
-                        }
-                    },
-                    "description": "ModelConfig returns the model config for the controller model.\n\nDeprecated: this facade method will be removed in 4.0 when this facade is\nconverted to a multi-model facade. Please use the ModelConfig facade's\nModelGet method instead:\n[github.com/juju/juju/apiserver/facades/client/modelconfig.ModelConfigAPI.ModelGet]"
                 },
                 "ModelStatus": {
                     "type": "object",
@@ -14030,23 +14021,6 @@
                         }
                     },
                     "additionalProperties": false
-                },
-                "ConfigValue": {
-                    "type": "object",
-                    "properties": {
-                        "source": {
-                            "type": "string"
-                        },
-                        "value": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "value",
-                        "source"
-                    ]
                 },
                 "ControllerAPIInfoResult": {
                     "type": "object",
@@ -14532,23 +14506,6 @@
                         }
                     },
                     "additionalProperties": false
-                },
-                "ModelConfigResults": {
-                    "type": "object",
-                    "properties": {
-                        "config": {
-                            "type": "object",
-                            "patternProperties": {
-                                ".*": {
-                                    "$ref": "#/definitions/ConfigValue"
-                                }
-                            }
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "config"
-                    ]
                 },
                 "ModelFilesystemInfo": {
                     "type": "object",

--- a/caas/kubernetes/provider/application/application.go
+++ b/caas/kubernetes/provider/application/application.go
@@ -77,6 +77,7 @@ var (
 	containerAgentPebbleVersion = version.MustParse("2.9.37")
 	profileDirVersion           = version.MustParse("3.5-beta1")
 	pebbleCopyOnceVersion       = version.MustParse("3.5-beta1")
+	pebbleIdentitiesVersion     = version.MustParse("3.6-beta2")
 )
 
 type app struct {
@@ -1485,6 +1486,7 @@ func (a *app) ApplicationPodSpec(config caas.ApplicationConfig) (*corev1.PodSpec
 			},
 		}, charmContainerExtraVolumeMounts...),
 	}
+	pebbleIdentitiesEnabled := false
 	if requireSecurityContext {
 		switch config.CharmUser {
 		case caas.RunAsRoot:
@@ -1497,12 +1499,16 @@ func (a *app) ApplicationPodSpec(config caas.ApplicationConfig) (*corev1.PodSpec
 				RunAsUser:  pointer.Int64(constants.JujuSudoUserID),
 				RunAsGroup: pointer.Int64(constants.JujuSudoGroupID),
 			}
+			pebbleIdentitiesEnabled = true
 		case caas.RunAsNonRoot:
 			charmContainer.SecurityContext = &corev1.SecurityContext{
 				RunAsUser:  pointer.Int64(constants.JujuUserID),
 				RunAsGroup: pointer.Int64(constants.JujuGroupID),
 			}
+			pebbleIdentitiesEnabled = true
 		}
+		pebbleIdentitiesEnabled = pebbleIdentitiesEnabled &&
+			agentVersionNoBuild.Compare(pebbleIdentitiesVersion) >= 0
 	} else {
 		// Pre-3.5 logic.
 		charmContainer.SecurityContext = &corev1.SecurityContext{
@@ -1525,6 +1531,11 @@ func (a *app) ApplicationPodSpec(config caas.ApplicationConfig) (*corev1.PodSpec
 		})
 	}
 
+	containerExtraArgs := []string{}
+	if pebbleIdentitiesEnabled {
+		containerExtraArgs = append(containerExtraArgs, "--identities", "/charm/etc/pebble/identities.yaml")
+	}
+
 	containerSpecs := []corev1.Container{charmContainer}
 	for i, v := range containers {
 		container := corev1.Container{
@@ -1532,13 +1543,13 @@ func (a *app) ApplicationPodSpec(config caas.ApplicationConfig) (*corev1.PodSpec
 			ImagePullPolicy: corev1.PullIfNotPresent,
 			Image:           v.Image.RegistryPath,
 			Command:         []string{"/charm/bin/pebble"},
-			Args: []string{
+			Args: append([]string{
 				"run",
 				"--create-dirs",
 				"--hold",
 				"--http", fmt.Sprintf(":%s", pebble.WorkloadHealthCheckPort(i)),
 				"--verbose",
-			},
+			}, containerExtraArgs...),
 			Env: append([]corev1.EnvVar{{
 				Name:  "JUJU_CONTAINER_NAME",
 				Value: v.Name,
@@ -1588,6 +1599,14 @@ func (a *app) ApplicationPodSpec(config caas.ApplicationConfig) (*corev1.PodSpec
 				RunAsGroup: pointer.Int64(0),
 			}
 		}
+		if pebbleIdentitiesEnabled {
+			container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
+				Name:      constants.CharmVolumeName,
+				MountPath: "/charm/etc/pebble/identities.yaml",
+				SubPath:   "charm/etc/pebble/identities.yaml",
+				ReadOnly:  true,
+			})
+		}
 		if v.Image.Password != "" {
 			imagePullSecrets = append(imagePullSecrets, corev1.LocalObjectReference{Name: a.imagePullSecretName(v.Name)})
 		}
@@ -1610,7 +1629,7 @@ func (a *app) ApplicationPodSpec(config caas.ApplicationConfig) (*corev1.PodSpec
 	}
 	// (tlm) lp1997253. If the agent version is less then containerAgentPebbleVersion
 	// we need to keep still using the old args supported by the init command
-	if config.AgentVersion.Compare(containerAgentPebbleVersion) < 0 {
+	if agentVersionNoBuild.Compare(containerAgentPebbleVersion) < 0 {
 		charmInitAdditionalMounts = []corev1.VolumeMount{}
 		containerAgentArgs = []string{
 			"init",
@@ -1626,6 +1645,23 @@ func (a *app) ApplicationPodSpec(config caas.ApplicationConfig) (*corev1.PodSpec
 			MountPath: "/containeragent/etc/profile.d",
 			SubPath:   "containeragent/etc/profile.d",
 		})
+	}
+
+	if pebbleIdentitiesEnabled {
+		containerAgentArgs = append(containerAgentArgs, "--pebble-identities-file", "/charm/etc/pebble/identities.yaml")
+		charmInitAdditionalMounts = append(charmInitAdditionalMounts, corev1.VolumeMount{
+			Name:      constants.CharmVolumeName,
+			MountPath: "/charm/etc/pebble/",
+			SubPath:   "charm/etc/pebble/",
+		})
+		uid := 0
+		switch config.CharmUser {
+		case caas.RunAsSudoer:
+			uid = constants.JujuSudoUserID
+		case caas.RunAsNonRoot:
+			uid = constants.JujuUserID
+		}
+		containerAgentArgs = append(containerAgentArgs, "--pebble-charm-identity", strconv.Itoa(uid))
 	}
 
 	appSecret := a.secretName()

--- a/caas/kubernetes/provider/application/application_test.go
+++ b/caas/kubernetes/provider/application/application_test.go
@@ -6,7 +6,6 @@ package application_test
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	jujuclock "github.com/juju/clock"
@@ -37,7 +36,6 @@ import (
 	k8swatchertest "github.com/juju/juju/caas/kubernetes/provider/watcher/test"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/network"
-	"github.com/juju/juju/core/paths"
 	coreresources "github.com/juju/juju/core/resources"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/internal/storage"
@@ -452,350 +450,6 @@ func (s *applicationSuite) assertDelete(c *gc.C, app caas.Application) {
 	c.Assert(statefulSets.Items, gc.IsNil)
 }
 
-func getPodSpec() corev1.PodSpec {
-	jujuDataDir := paths.DataDir(paths.OSUnixLike)
-	return corev1.PodSpec{
-		ServiceAccountName:            "gitlab",
-		AutomountServiceAccountToken:  pointer.BoolPtr(true),
-		ImagePullSecrets:              []corev1.LocalObjectReference{{Name: "gitlab-nginx-secret"}},
-		TerminationGracePeriodSeconds: pointer.Int64Ptr(30),
-		InitContainers: []corev1.Container{{
-			Name:            "charm-init",
-			ImagePullPolicy: corev1.PullIfNotPresent,
-			Image:           "operator/image-path:1.1.1",
-			WorkingDir:      jujuDataDir,
-			Command:         []string{"/opt/containeragent"},
-			Args: []string{
-				"init",
-				"--containeragent-pebble-dir", "/containeragent/pebble",
-				"--charm-modified-version", "9001",
-				"--data-dir", "/var/lib/juju",
-				"--bin-dir", "/charm/bin",
-				"--profile-dir", "/containeragent/etc/profile.d",
-			},
-			Env: []corev1.EnvVar{
-				{
-					Name:  "JUJU_CONTAINER_NAMES",
-					Value: "gitlab,nginx",
-				},
-				{
-					Name: "JUJU_K8S_POD_NAME",
-					ValueFrom: &corev1.EnvVarSource{
-						FieldRef: &corev1.ObjectFieldSelector{
-							FieldPath: "metadata.name",
-						},
-					},
-				},
-				{
-					Name: "JUJU_K8S_POD_UUID",
-					ValueFrom: &corev1.EnvVarSource{
-						FieldRef: &corev1.ObjectFieldSelector{
-							FieldPath: "metadata.uid",
-						},
-					},
-				},
-			},
-			EnvFrom: []corev1.EnvFromSource{
-				{
-					SecretRef: &corev1.SecretEnvSource{
-						LocalObjectReference: corev1.LocalObjectReference{
-							Name: "gitlab-application-config",
-						},
-					},
-				},
-			},
-			VolumeMounts: []corev1.VolumeMount{
-				{
-					Name:      "charm-data",
-					MountPath: jujuDataDir,
-					SubPath:   strings.TrimPrefix(jujuDataDir, "/"),
-				},
-				{
-					Name:      "charm-data",
-					MountPath: "/charm/bin",
-					SubPath:   "charm/bin",
-				},
-				{
-					Name:      "charm-data",
-					MountPath: "/charm/containers",
-					SubPath:   "charm/containers",
-				},
-				{
-					Name:      "charm-data",
-					MountPath: "/containeragent/pebble",
-					SubPath:   "containeragent/pebble",
-				},
-				{
-					Name:      "charm-data",
-					MountPath: "/containeragent/etc/profile.d",
-					SubPath:   "containeragent/etc/profile.d",
-				},
-			},
-		}},
-		Containers: []corev1.Container{{
-			Name:            "charm",
-			ImagePullPolicy: corev1.PullIfNotPresent,
-			Image:           "ubuntu@22.04",
-			WorkingDir:      jujuDataDir,
-			Command:         []string{"/charm/bin/pebble"},
-			Args: []string{
-				"run",
-				"--http", ":38812",
-				"--verbose",
-			},
-			Env: []corev1.EnvVar{
-				{
-					Name:  "JUJU_CONTAINER_NAMES",
-					Value: "gitlab,nginx",
-				},
-				{
-					Name:  constants.EnvAgentHTTPProbePort,
-					Value: constants.AgentHTTPProbePort,
-				},
-			},
-			LivenessProbe: &corev1.Probe{
-				ProbeHandler: corev1.ProbeHandler{
-					HTTPGet: &corev1.HTTPGetAction{
-						Path: "/v1/health?level=alive",
-						Port: intstr.Parse("38812"),
-					},
-				},
-				InitialDelaySeconds: 30,
-				TimeoutSeconds:      1,
-				PeriodSeconds:       5,
-				SuccessThreshold:    1,
-				FailureThreshold:    3,
-			},
-			ReadinessProbe: &corev1.Probe{
-				ProbeHandler: corev1.ProbeHandler{
-					HTTPGet: &corev1.HTTPGetAction{
-						Path: "/v1/health?level=ready",
-						Port: intstr.Parse("38812"),
-					},
-				},
-				InitialDelaySeconds: 30,
-				TimeoutSeconds:      1,
-				PeriodSeconds:       5,
-				SuccessThreshold:    1,
-				FailureThreshold:    1,
-			},
-			StartupProbe: &corev1.Probe{
-				ProbeHandler: corev1.ProbeHandler{
-					HTTPGet: &corev1.HTTPGetAction{
-						Path: "/v1/health?level=alive",
-						Port: intstr.Parse("38812"),
-					},
-				},
-				InitialDelaySeconds: 30,
-				TimeoutSeconds:      1,
-				PeriodSeconds:       5,
-				SuccessThreshold:    1,
-				FailureThreshold:    1,
-			},
-			VolumeMounts: []corev1.VolumeMount{
-				{
-					Name:      "charm-data",
-					MountPath: "/charm/bin",
-					SubPath:   "charm/bin",
-					ReadOnly:  true,
-				},
-				{
-					Name:      "charm-data",
-					MountPath: jujuDataDir,
-					SubPath:   strings.TrimPrefix(jujuDataDir, "/"),
-				},
-				{
-					Name:      "charm-data",
-					MountPath: "/charm/containers",
-					SubPath:   "charm/containers",
-				},
-				{
-					Name:      "charm-data",
-					MountPath: "/var/lib/pebble/default",
-					SubPath:   "containeragent/pebble",
-				},
-				{
-					Name:      "charm-data",
-					MountPath: "/var/log/juju",
-					SubPath:   "containeragent/var/log/juju",
-				},
-				{
-					Name:      "charm-data",
-					MountPath: paths.JujuIntrospect(paths.OSUnixLike),
-					SubPath:   "charm/bin/containeragent",
-					ReadOnly:  true,
-				},
-				{
-					Name:      "charm-data",
-					MountPath: paths.JujuExec(paths.OSUnixLike),
-					SubPath:   "charm/bin/containeragent",
-					ReadOnly:  true,
-				},
-				{
-					Name:      "charm-data",
-					MountPath: "/etc/profile.d/juju-introspection.sh",
-					SubPath:   "containeragent/etc/profile.d/juju-introspection.sh",
-					ReadOnly:  true,
-				},
-				{
-					Name:      "gitlab-database-appuuid",
-					MountPath: "path/to/here",
-				},
-			},
-			SecurityContext: &corev1.SecurityContext{
-				RunAsUser:  int64Ptr(0),
-				RunAsGroup: int64Ptr(0),
-			},
-		}, {
-			Name:            "gitlab",
-			ImagePullPolicy: corev1.PullIfNotPresent,
-			Image:           "docker.io/library/gitlab:latest",
-			Command:         []string{"/charm/bin/pebble"},
-			Args:            []string{"run", "--create-dirs", "--hold", "--http", ":38813", "--verbose"},
-			Env: []corev1.EnvVar{
-				{
-					Name:  "JUJU_CONTAINER_NAME",
-					Value: "gitlab",
-				},
-				{
-					Name:  "PEBBLE_SOCKET",
-					Value: "/charm/container/pebble.socket",
-				},
-				{
-					Name:  "PEBBLE",
-					Value: "/charm/container/pebble",
-				},
-				{
-					Name:  "PEBBLE_COPY_ONCE",
-					Value: "/var/lib/pebble/default",
-				},
-			},
-			LivenessProbe: &corev1.Probe{
-				ProbeHandler: corev1.ProbeHandler{
-					HTTPGet: &corev1.HTTPGetAction{
-						Path: "/v1/health?level=alive",
-						Port: intstr.FromInt(38813),
-					},
-				},
-				InitialDelaySeconds: 30,
-				TimeoutSeconds:      1,
-				PeriodSeconds:       5,
-				SuccessThreshold:    1,
-				FailureThreshold:    3,
-			},
-			ReadinessProbe: &corev1.Probe{
-				ProbeHandler: corev1.ProbeHandler{
-					HTTPGet: &corev1.HTTPGetAction{
-						Path: "/v1/health?level=ready",
-						Port: intstr.FromInt(38813),
-					},
-				},
-				InitialDelaySeconds: 30,
-				TimeoutSeconds:      1,
-				PeriodSeconds:       5,
-				SuccessThreshold:    1,
-				FailureThreshold:    1,
-			},
-			VolumeMounts: []corev1.VolumeMount{
-				{
-					Name:      "charm-data",
-					MountPath: "/charm/bin/pebble",
-					SubPath:   "charm/bin/pebble",
-					ReadOnly:  true,
-				},
-				{
-					Name:      "charm-data",
-					MountPath: "/charm/container",
-					SubPath:   "charm/containers/gitlab",
-				},
-				{
-					Name:      "gitlab-database-appuuid",
-					MountPath: "path/to/here",
-				},
-			},
-			SecurityContext: &corev1.SecurityContext{
-				RunAsUser:  int64Ptr(0),
-				RunAsGroup: int64Ptr(0),
-			},
-		}, {
-			Name:            "nginx",
-			ImagePullPolicy: corev1.PullIfNotPresent,
-			Image:           "docker.io/library/nginx:latest",
-			Command:         []string{"/charm/bin/pebble"},
-			Args:            []string{"run", "--create-dirs", "--hold", "--http", ":38814", "--verbose"},
-			Env: []corev1.EnvVar{
-				{
-					Name:  "JUJU_CONTAINER_NAME",
-					Value: "nginx",
-				},
-				{
-					Name:  "PEBBLE_SOCKET",
-					Value: "/charm/container/pebble.socket",
-				},
-				{
-					Name:  "PEBBLE",
-					Value: "/charm/container/pebble",
-				},
-				{
-					Name:  "PEBBLE_COPY_ONCE",
-					Value: "/var/lib/pebble/default",
-				},
-			},
-			LivenessProbe: &corev1.Probe{
-				ProbeHandler: corev1.ProbeHandler{
-					HTTPGet: &corev1.HTTPGetAction{
-						Path: "/v1/health?level=alive",
-						Port: intstr.FromInt(38814),
-					},
-				},
-				InitialDelaySeconds: 30,
-				TimeoutSeconds:      1,
-				PeriodSeconds:       5,
-				SuccessThreshold:    1,
-				FailureThreshold:    3,
-			},
-			ReadinessProbe: &corev1.Probe{
-				ProbeHandler: corev1.ProbeHandler{
-					HTTPGet: &corev1.HTTPGetAction{
-						Path: "/v1/health?level=ready",
-						Port: intstr.FromInt(38814),
-					},
-				},
-				InitialDelaySeconds: 30,
-				TimeoutSeconds:      1,
-				PeriodSeconds:       5,
-				SuccessThreshold:    1,
-				FailureThreshold:    1,
-			},
-			VolumeMounts: []corev1.VolumeMount{
-				{
-					Name:      "charm-data",
-					MountPath: "/charm/bin/pebble",
-					SubPath:   "charm/bin/pebble",
-					ReadOnly:  true,
-				},
-				{
-					Name:      "charm-data",
-					MountPath: "/charm/container",
-					SubPath:   "charm/containers/nginx",
-				},
-			},
-			SecurityContext: &corev1.SecurityContext{
-				RunAsUser:  int64Ptr(0),
-				RunAsGroup: int64Ptr(0),
-			},
-		}},
-		Volumes: []corev1.Volume{
-			{
-				Name: "charm-data",
-				VolumeSource: corev1.VolumeSource{
-					EmptyDir: &corev1.EmptyDirVolumeSource{},
-				},
-			},
-		},
-	}
-}
-
 func (s *applicationSuite) TestEnsureStateful(c *gc.C) {
 	app, _ := s.getApp(c, caas.DeploymentStateful, false)
 	s.assertEnsure(
@@ -850,7 +504,7 @@ func (s *applicationSuite) TestEnsureStateful(c *gc.C) {
 							Labels:      map[string]string{"app.kubernetes.io/name": "gitlab"},
 							Annotations: map[string]string{"juju.is/version": "3.5-beta1"},
 						},
-						Spec: getPodSpec(),
+						Spec: getPodSpec31(),
 					},
 					VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
 						{
@@ -884,10 +538,10 @@ func (s *applicationSuite) TestEnsureStateful(c *gc.C) {
 	s.assertDelete(c, app)
 }
 
-func (s *applicationSuite) TestEnsureStatefulRootless(c *gc.C) {
+func (s *applicationSuite) TestEnsureStatefulRootless35(c *gc.C) {
 	app, _ := s.getApp(c, caas.DeploymentStateful, false)
 	s.assertEnsure(
-		c, app, false, constraints.Value{}, true, true, "", func() {
+		c, app, false, constraints.Value{}, true, true, "3.5-beta1", func() {
 			svc, err := s.client.CoreV1().Services("test").Get(context.Background(), "gitlab-endpoints", metav1.GetOptions{})
 			c.Assert(err, jc.ErrorIsNil)
 			c.Assert(svc, gc.DeepEquals, &corev1.Service{
@@ -911,7 +565,7 @@ func (s *applicationSuite) TestEnsureStatefulRootless(c *gc.C) {
 				},
 			})
 
-			podSpec := getPodSpec()
+			podSpec := getPodSpec35()
 			podSpec.SecurityContext = &corev1.PodSecurityContext{
 				FSGroup:            int64Ptr(170),
 				SupplementalGroups: []int64{170},
@@ -991,6 +645,95 @@ func (s *applicationSuite) TestEnsureStatefulRootless(c *gc.C) {
 	s.assertDelete(c, app)
 }
 
+func (s *applicationSuite) TestEnsureStatefulRootless(c *gc.C) {
+	app, _ := s.getApp(c, caas.DeploymentStateful, false)
+	s.assertEnsure(
+		c, app, false, constraints.Value{}, true, true, "3.6-beta2", func() {
+			svc, err := s.client.CoreV1().Services("test").Get(context.TODO(), "gitlab-endpoints", metav1.GetOptions{})
+			c.Assert(err, jc.ErrorIsNil)
+			c.Assert(svc, gc.DeepEquals, &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "gitlab-endpoints",
+					Namespace: "test",
+					Labels: map[string]string{
+						"app.kubernetes.io/name":       "gitlab",
+						"app.kubernetes.io/managed-by": "juju",
+					},
+					Annotations: map[string]string{
+						"juju.is/version": "3.6-beta2",
+						"service.alpha.kubernetes.io/tolerate-unready-endpoints": "true",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Selector:                 map[string]string{"app.kubernetes.io/name": "gitlab"},
+					Type:                     corev1.ServiceTypeClusterIP,
+					ClusterIP:                "None",
+					PublishNotReadyAddresses: true,
+				},
+			})
+
+			podSpec := getPodSpec36()
+			ss, err := s.client.AppsV1().StatefulSets("test").Get(context.TODO(), "gitlab", metav1.GetOptions{})
+			c.Assert(err, jc.ErrorIsNil)
+			c.Assert(ss, jc.DeepEquals, &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "gitlab",
+					Namespace: "test",
+					Labels: map[string]string{
+						"app.kubernetes.io/name":       "gitlab",
+						"app.kubernetes.io/managed-by": "juju",
+					},
+					Annotations: map[string]string{
+						"juju.is/version":  "3.6-beta2",
+						"app.juju.is/uuid": "appuuid",
+					},
+				},
+				Spec: appsv1.StatefulSetSpec{
+					Replicas: pointer.Int32Ptr(3),
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"app.kubernetes.io/name": "gitlab",
+						},
+					},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels:      map[string]string{"app.kubernetes.io/name": "gitlab"},
+							Annotations: map[string]string{"juju.is/version": "3.6-beta2"},
+						},
+						Spec: podSpec,
+					},
+					VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "gitlab-database-appuuid",
+								Labels: map[string]string{
+									"storage.juju.is/name":         "database",
+									"app.kubernetes.io/managed-by": "juju",
+								},
+								Annotations: map[string]string{
+									"foo":                  "bar",
+									"storage.juju.is/name": "database",
+								}},
+							Spec: corev1.PersistentVolumeClaimSpec{
+								StorageClassName: pointer.StringPtr("test-workload-storage"),
+								AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+								Resources: corev1.VolumeResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceStorage: k8sresource.MustParse("100Mi"),
+									},
+								},
+							},
+						},
+					},
+					PodManagementPolicy: appsv1.ParallelPodManagement,
+					ServiceName:         "gitlab-endpoints",
+				},
+			})
+		},
+	)
+	s.assertDelete(c, app)
+}
+
 func (s *applicationSuite) TestEnsureTrusted(c *gc.C) {
 	app, _ := s.getApp(c, caas.DeploymentStateful, false)
 	s.assertEnsure(
@@ -1010,7 +753,7 @@ func (s *applicationSuite) TestEnsureUntrusted(c *gc.C) {
 func (s *applicationSuite) TestEnsureStatefulPrivateImageRepo(c *gc.C) {
 	app, _ := s.getApp(c, caas.DeploymentStateful, false)
 
-	podSpec := getPodSpec()
+	podSpec := getPodSpec31()
 	podSpec.ImagePullSecrets = append(
 		[]corev1.LocalObjectReference{
 			{Name: constants.CAASImageRepoSecretName},
@@ -1136,7 +879,7 @@ func (s *applicationSuite) TestEnsureStateless(c *gc.C) {
 				},
 			})
 
-			podSpec := getPodSpec()
+			podSpec := getPodSpec31()
 			podSpec.Volumes = append(podSpec.Volumes, corev1.Volume{
 				Name: "gitlab-database-appuuid",
 				VolumeSource: corev1.VolumeSource{
@@ -1209,7 +952,7 @@ func (s *applicationSuite) TestEnsureDaemon(c *gc.C) {
 				},
 			})
 
-			podSpec := getPodSpec()
+			podSpec := getPodSpec31()
 			podSpec.Volumes = append(podSpec.Volumes, corev1.Volume{
 				Name: "gitlab-database-appuuid",
 				VolumeSource: corev1.VolumeSource{
@@ -2244,7 +1987,7 @@ func (s *applicationSuite) TestUnits(c *gc.C) {
 	app, _ := s.getApp(c, caas.DeploymentStateful, false)
 
 	for i := 0; i < 9; i++ {
-		podSpec := getPodSpec()
+		podSpec := getPodSpec31()
 		podSpec.Volumes = append(podSpec.Volumes,
 			corev1.Volume{
 				Name: "gitlab-database-appuuid",
@@ -2976,7 +2719,7 @@ func (s *applicationSuite) TestEnsureConstraints(c *gc.C) {
 				},
 			})
 
-			ps := getPodSpec()
+			ps := getPodSpec31()
 			ps.NodeSelector = map[string]string{
 				"kubernetes.io/arch": "arm64",
 			}

--- a/caas/kubernetes/provider/application/spec31_test.go
+++ b/caas/kubernetes/provider/application/spec31_test.go
@@ -1,0 +1,359 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package application_test
+
+import (
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/pointer"
+
+	"github.com/juju/juju/caas/kubernetes/provider/constants"
+	"github.com/juju/juju/core/paths"
+)
+
+func getPodSpec31() corev1.PodSpec {
+	jujuDataDir := paths.DataDir(paths.OSUnixLike)
+	return corev1.PodSpec{
+		ServiceAccountName:            "gitlab",
+		AutomountServiceAccountToken:  pointer.BoolPtr(true),
+		ImagePullSecrets:              []corev1.LocalObjectReference{{Name: "gitlab-nginx-secret"}},
+		TerminationGracePeriodSeconds: pointer.Int64Ptr(30),
+		InitContainers: []corev1.Container{{
+			Name:            "charm-init",
+			ImagePullPolicy: corev1.PullIfNotPresent,
+			Image:           "operator/image-path:1.1.1",
+			WorkingDir:      jujuDataDir,
+			Command:         []string{"/opt/containeragent"},
+			Args: []string{
+				"init",
+				"--containeragent-pebble-dir", "/containeragent/pebble",
+				"--charm-modified-version", "9001",
+				"--data-dir", "/var/lib/juju",
+				"--bin-dir", "/charm/bin",
+				"--profile-dir", "/containeragent/etc/profile.d",
+			},
+			Env: []corev1.EnvVar{
+				{
+					Name:  "JUJU_CONTAINER_NAMES",
+					Value: "gitlab,nginx",
+				},
+				{
+					Name: "JUJU_K8S_POD_NAME",
+					ValueFrom: &corev1.EnvVarSource{
+						FieldRef: &corev1.ObjectFieldSelector{
+							FieldPath: "metadata.name",
+						},
+					},
+				},
+				{
+					Name: "JUJU_K8S_POD_UUID",
+					ValueFrom: &corev1.EnvVarSource{
+						FieldRef: &corev1.ObjectFieldSelector{
+							FieldPath: "metadata.uid",
+						},
+					},
+				},
+			},
+			EnvFrom: []corev1.EnvFromSource{
+				{
+					SecretRef: &corev1.SecretEnvSource{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "gitlab-application-config",
+						},
+					},
+				},
+			},
+			VolumeMounts: []corev1.VolumeMount{
+				{
+					Name:      "charm-data",
+					MountPath: jujuDataDir,
+					SubPath:   strings.TrimPrefix(jujuDataDir, "/"),
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/charm/bin",
+					SubPath:   "charm/bin",
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/charm/containers",
+					SubPath:   "charm/containers",
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/containeragent/pebble",
+					SubPath:   "containeragent/pebble",
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/containeragent/etc/profile.d",
+					SubPath:   "containeragent/etc/profile.d",
+				},
+			},
+		}},
+		Containers: []corev1.Container{{
+			Name:            "charm",
+			ImagePullPolicy: corev1.PullIfNotPresent,
+			Image:           "ubuntu@22.04",
+			WorkingDir:      jujuDataDir,
+			Command:         []string{"/charm/bin/pebble"},
+			Args: []string{
+				"run",
+				"--http", ":38812",
+				"--verbose",
+			},
+			Env: []corev1.EnvVar{
+				{
+					Name:  "JUJU_CONTAINER_NAMES",
+					Value: "gitlab,nginx",
+				},
+				{
+					Name:  constants.EnvAgentHTTPProbePort,
+					Value: constants.AgentHTTPProbePort,
+				},
+			},
+			LivenessProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/v1/health?level=alive",
+						Port: intstr.Parse("38812"),
+					},
+				},
+				InitialDelaySeconds: 30,
+				TimeoutSeconds:      1,
+				PeriodSeconds:       5,
+				SuccessThreshold:    1,
+				FailureThreshold:    3,
+			},
+			ReadinessProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/v1/health?level=ready",
+						Port: intstr.Parse("38812"),
+					},
+				},
+				InitialDelaySeconds: 30,
+				TimeoutSeconds:      1,
+				PeriodSeconds:       5,
+				SuccessThreshold:    1,
+				FailureThreshold:    1,
+			},
+			StartupProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/v1/health?level=alive",
+						Port: intstr.Parse("38812"),
+					},
+				},
+				InitialDelaySeconds: 30,
+				TimeoutSeconds:      1,
+				PeriodSeconds:       5,
+				SuccessThreshold:    1,
+				FailureThreshold:    1,
+			},
+			VolumeMounts: []corev1.VolumeMount{
+				{
+					Name:      "charm-data",
+					MountPath: "/charm/bin",
+					SubPath:   "charm/bin",
+					ReadOnly:  true,
+				},
+				{
+					Name:      "charm-data",
+					MountPath: jujuDataDir,
+					SubPath:   strings.TrimPrefix(jujuDataDir, "/"),
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/charm/containers",
+					SubPath:   "charm/containers",
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/var/lib/pebble/default",
+					SubPath:   "containeragent/pebble",
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/var/log/juju",
+					SubPath:   "containeragent/var/log/juju",
+				},
+				{
+					Name:      "charm-data",
+					MountPath: paths.JujuIntrospect(paths.OSUnixLike),
+					SubPath:   "charm/bin/containeragent",
+					ReadOnly:  true,
+				},
+				{
+					Name:      "charm-data",
+					MountPath: paths.JujuExec(paths.OSUnixLike),
+					SubPath:   "charm/bin/containeragent",
+					ReadOnly:  true,
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/etc/profile.d/juju-introspection.sh",
+					SubPath:   "containeragent/etc/profile.d/juju-introspection.sh",
+					ReadOnly:  true,
+				},
+				{
+					Name:      "gitlab-database-appuuid",
+					MountPath: "path/to/here",
+				},
+			},
+			SecurityContext: &corev1.SecurityContext{
+				RunAsUser:  int64Ptr(0),
+				RunAsGroup: int64Ptr(0),
+			},
+		}, {
+			Name:            "gitlab",
+			ImagePullPolicy: corev1.PullIfNotPresent,
+			Image:           "docker.io/library/gitlab:latest",
+			Command:         []string{"/charm/bin/pebble"},
+			Args:            []string{"run", "--create-dirs", "--hold", "--http", ":38813", "--verbose"},
+			Env: []corev1.EnvVar{
+				{
+					Name:  "JUJU_CONTAINER_NAME",
+					Value: "gitlab",
+				},
+				{
+					Name:  "PEBBLE_SOCKET",
+					Value: "/charm/container/pebble.socket",
+				},
+				{
+					Name:  "PEBBLE",
+					Value: "/charm/container/pebble",
+				},
+				{
+					Name:  "PEBBLE_COPY_ONCE",
+					Value: "/var/lib/pebble/default",
+				},
+			},
+			LivenessProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/v1/health?level=alive",
+						Port: intstr.FromInt(38813),
+					},
+				},
+				InitialDelaySeconds: 30,
+				TimeoutSeconds:      1,
+				PeriodSeconds:       5,
+				SuccessThreshold:    1,
+				FailureThreshold:    3,
+			},
+			ReadinessProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/v1/health?level=ready",
+						Port: intstr.FromInt(38813),
+					},
+				},
+				InitialDelaySeconds: 30,
+				TimeoutSeconds:      1,
+				PeriodSeconds:       5,
+				SuccessThreshold:    1,
+				FailureThreshold:    1,
+			},
+			VolumeMounts: []corev1.VolumeMount{
+				{
+					Name:      "charm-data",
+					MountPath: "/charm/bin/pebble",
+					SubPath:   "charm/bin/pebble",
+					ReadOnly:  true,
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/charm/container",
+					SubPath:   "charm/containers/gitlab",
+				},
+				{
+					Name:      "gitlab-database-appuuid",
+					MountPath: "path/to/here",
+				},
+			},
+			SecurityContext: &corev1.SecurityContext{
+				RunAsUser:  int64Ptr(0),
+				RunAsGroup: int64Ptr(0),
+			},
+		}, {
+			Name:            "nginx",
+			ImagePullPolicy: corev1.PullIfNotPresent,
+			Image:           "docker.io/library/nginx:latest",
+			Command:         []string{"/charm/bin/pebble"},
+			Args:            []string{"run", "--create-dirs", "--hold", "--http", ":38814", "--verbose"},
+			Env: []corev1.EnvVar{
+				{
+					Name:  "JUJU_CONTAINER_NAME",
+					Value: "nginx",
+				},
+				{
+					Name:  "PEBBLE_SOCKET",
+					Value: "/charm/container/pebble.socket",
+				},
+				{
+					Name:  "PEBBLE",
+					Value: "/charm/container/pebble",
+				},
+				{
+					Name:  "PEBBLE_COPY_ONCE",
+					Value: "/var/lib/pebble/default",
+				},
+			},
+			LivenessProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/v1/health?level=alive",
+						Port: intstr.FromInt(38814),
+					},
+				},
+				InitialDelaySeconds: 30,
+				TimeoutSeconds:      1,
+				PeriodSeconds:       5,
+				SuccessThreshold:    1,
+				FailureThreshold:    3,
+			},
+			ReadinessProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/v1/health?level=ready",
+						Port: intstr.FromInt(38814),
+					},
+				},
+				InitialDelaySeconds: 30,
+				TimeoutSeconds:      1,
+				PeriodSeconds:       5,
+				SuccessThreshold:    1,
+				FailureThreshold:    1,
+			},
+			VolumeMounts: []corev1.VolumeMount{
+				{
+					Name:      "charm-data",
+					MountPath: "/charm/bin/pebble",
+					SubPath:   "charm/bin/pebble",
+					ReadOnly:  true,
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/charm/container",
+					SubPath:   "charm/containers/nginx",
+				},
+			},
+			SecurityContext: &corev1.SecurityContext{
+				RunAsUser:  int64Ptr(0),
+				RunAsGroup: int64Ptr(0),
+			},
+		}},
+		Volumes: []corev1.Volume{
+			{
+				Name: "charm-data",
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
+			},
+		},
+	}
+}

--- a/caas/kubernetes/provider/application/spec35_test.go
+++ b/caas/kubernetes/provider/application/spec35_test.go
@@ -1,0 +1,364 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package application_test
+
+import (
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/pointer"
+
+	"github.com/juju/juju/caas/kubernetes/provider/constants"
+	"github.com/juju/juju/core/paths"
+)
+
+func getPodSpec35() corev1.PodSpec {
+	jujuDataDir := paths.DataDir(paths.OSUnixLike)
+	return corev1.PodSpec{
+		ServiceAccountName:            "gitlab",
+		AutomountServiceAccountToken:  pointer.BoolPtr(true),
+		ImagePullSecrets:              []corev1.LocalObjectReference{{Name: "gitlab-nginx-secret"}},
+		TerminationGracePeriodSeconds: pointer.Int64Ptr(30),
+		SecurityContext: &corev1.PodSecurityContext{
+			FSGroup:            int64Ptr(170),
+			SupplementalGroups: []int64{170},
+		},
+		InitContainers: []corev1.Container{{
+			Name:            "charm-init",
+			ImagePullPolicy: corev1.PullIfNotPresent,
+			Image:           "operator/image-path:1.1.1",
+			WorkingDir:      jujuDataDir,
+			SecurityContext: &corev1.SecurityContext{
+				RunAsUser:  int64Ptr(170),
+				RunAsGroup: int64Ptr(170),
+			},
+			Command: []string{"/opt/containeragent"},
+			Args: []string{
+				"init",
+				"--containeragent-pebble-dir", "/containeragent/pebble",
+				"--charm-modified-version", "9001",
+				"--data-dir", "/var/lib/juju",
+				"--bin-dir", "/charm/bin",
+				"--profile-dir", "/containeragent/etc/profile.d",
+			},
+			Env: []corev1.EnvVar{
+				{
+					Name:  "JUJU_CONTAINER_NAMES",
+					Value: "gitlab,nginx",
+				},
+				{
+					Name: "JUJU_K8S_POD_NAME",
+					ValueFrom: &corev1.EnvVarSource{
+						FieldRef: &corev1.ObjectFieldSelector{
+							FieldPath: "metadata.name",
+						},
+					},
+				},
+				{
+					Name: "JUJU_K8S_POD_UUID",
+					ValueFrom: &corev1.EnvVarSource{
+						FieldRef: &corev1.ObjectFieldSelector{
+							FieldPath: "metadata.uid",
+						},
+					},
+				},
+			},
+			EnvFrom: []corev1.EnvFromSource{
+				{
+					SecretRef: &corev1.SecretEnvSource{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "gitlab-application-config",
+						},
+					},
+				},
+			},
+			VolumeMounts: []corev1.VolumeMount{
+				{
+					Name:      "charm-data",
+					MountPath: jujuDataDir,
+					SubPath:   strings.TrimPrefix(jujuDataDir, "/"),
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/charm/bin",
+					SubPath:   "charm/bin",
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/charm/containers",
+					SubPath:   "charm/containers",
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/containeragent/pebble",
+					SubPath:   "containeragent/pebble",
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/containeragent/etc/profile.d",
+					SubPath:   "containeragent/etc/profile.d",
+				},
+			},
+		}},
+		Containers: []corev1.Container{{
+			Name:            "charm",
+			ImagePullPolicy: corev1.PullIfNotPresent,
+			Image:           "ubuntu@22.04",
+			WorkingDir:      jujuDataDir,
+			Command:         []string{"/charm/bin/pebble"},
+			Args: []string{
+				"run",
+				"--http", ":38812",
+				"--verbose",
+			},
+			Env: []corev1.EnvVar{
+				{
+					Name:  "JUJU_CONTAINER_NAMES",
+					Value: "gitlab,nginx",
+				},
+				{
+					Name:  constants.EnvAgentHTTPProbePort,
+					Value: constants.AgentHTTPProbePort,
+				},
+			},
+			LivenessProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/v1/health?level=alive",
+						Port: intstr.Parse("38812"),
+					},
+				},
+				InitialDelaySeconds: 30,
+				TimeoutSeconds:      1,
+				PeriodSeconds:       5,
+				SuccessThreshold:    1,
+				FailureThreshold:    3,
+			},
+			ReadinessProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/v1/health?level=ready",
+						Port: intstr.Parse("38812"),
+					},
+				},
+				InitialDelaySeconds: 30,
+				TimeoutSeconds:      1,
+				PeriodSeconds:       5,
+				SuccessThreshold:    1,
+				FailureThreshold:    1,
+			},
+			StartupProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/v1/health?level=alive",
+						Port: intstr.Parse("38812"),
+					},
+				},
+				InitialDelaySeconds: 30,
+				TimeoutSeconds:      1,
+				PeriodSeconds:       5,
+				SuccessThreshold:    1,
+				FailureThreshold:    1,
+			},
+			VolumeMounts: []corev1.VolumeMount{
+				{
+					Name:      "charm-data",
+					MountPath: "/charm/bin",
+					SubPath:   "charm/bin",
+					ReadOnly:  true,
+				},
+				{
+					Name:      "charm-data",
+					MountPath: jujuDataDir,
+					SubPath:   strings.TrimPrefix(jujuDataDir, "/"),
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/charm/containers",
+					SubPath:   "charm/containers",
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/var/lib/pebble/default",
+					SubPath:   "containeragent/pebble",
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/var/log/juju",
+					SubPath:   "containeragent/var/log/juju",
+				},
+				{
+					Name:      "charm-data",
+					MountPath: paths.JujuIntrospect(paths.OSUnixLike),
+					SubPath:   "charm/bin/containeragent",
+					ReadOnly:  true,
+				},
+				{
+					Name:      "charm-data",
+					MountPath: paths.JujuExec(paths.OSUnixLike),
+					SubPath:   "charm/bin/containeragent",
+					ReadOnly:  true,
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/etc/profile.d/juju-introspection.sh",
+					SubPath:   "containeragent/etc/profile.d/juju-introspection.sh",
+					ReadOnly:  true,
+				},
+				{
+					Name:      "gitlab-database-appuuid",
+					MountPath: "path/to/here",
+				},
+			},
+			SecurityContext: &corev1.SecurityContext{
+				RunAsUser:  int64Ptr(170),
+				RunAsGroup: int64Ptr(170),
+			},
+		}, {
+			Name:            "gitlab",
+			ImagePullPolicy: corev1.PullIfNotPresent,
+			Image:           "docker.io/library/gitlab:latest",
+			Command:         []string{"/charm/bin/pebble"},
+			Args:            []string{"run", "--create-dirs", "--hold", "--http", ":38813", "--verbose"},
+			Env: []corev1.EnvVar{
+				{
+					Name:  "JUJU_CONTAINER_NAME",
+					Value: "gitlab",
+				},
+				{
+					Name:  "PEBBLE_SOCKET",
+					Value: "/charm/container/pebble.socket",
+				},
+				{
+					Name:  "PEBBLE",
+					Value: "/charm/container/pebble",
+				},
+				{
+					Name:  "PEBBLE_COPY_ONCE",
+					Value: "/var/lib/pebble/default",
+				},
+			},
+			LivenessProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/v1/health?level=alive",
+						Port: intstr.FromInt(38813),
+					},
+				},
+				InitialDelaySeconds: 30,
+				TimeoutSeconds:      1,
+				PeriodSeconds:       5,
+				SuccessThreshold:    1,
+				FailureThreshold:    3,
+			},
+			ReadinessProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/v1/health?level=ready",
+						Port: intstr.FromInt(38813),
+					},
+				},
+				InitialDelaySeconds: 30,
+				TimeoutSeconds:      1,
+				PeriodSeconds:       5,
+				SuccessThreshold:    1,
+				FailureThreshold:    1,
+			},
+			VolumeMounts: []corev1.VolumeMount{
+				{
+					Name:      "charm-data",
+					MountPath: "/charm/bin/pebble",
+					SubPath:   "charm/bin/pebble",
+					ReadOnly:  true,
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/charm/container",
+					SubPath:   "charm/containers/gitlab",
+				},
+				{
+					Name:      "gitlab-database-appuuid",
+					MountPath: "path/to/here",
+				},
+			},
+			SecurityContext: &corev1.SecurityContext{},
+		}, {
+			Name:            "nginx",
+			ImagePullPolicy: corev1.PullIfNotPresent,
+			Image:           "docker.io/library/nginx:latest",
+			Command:         []string{"/charm/bin/pebble"},
+			Args:            []string{"run", "--create-dirs", "--hold", "--http", ":38814", "--verbose"},
+			Env: []corev1.EnvVar{
+				{
+					Name:  "JUJU_CONTAINER_NAME",
+					Value: "nginx",
+				},
+				{
+					Name:  "PEBBLE_SOCKET",
+					Value: "/charm/container/pebble.socket",
+				},
+				{
+					Name:  "PEBBLE",
+					Value: "/charm/container/pebble",
+				},
+				{
+					Name:  "PEBBLE_COPY_ONCE",
+					Value: "/var/lib/pebble/default",
+				},
+			},
+			LivenessProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/v1/health?level=alive",
+						Port: intstr.FromInt(38814),
+					},
+				},
+				InitialDelaySeconds: 30,
+				TimeoutSeconds:      1,
+				PeriodSeconds:       5,
+				SuccessThreshold:    1,
+				FailureThreshold:    3,
+			},
+			ReadinessProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/v1/health?level=ready",
+						Port: intstr.FromInt(38814),
+					},
+				},
+				InitialDelaySeconds: 30,
+				TimeoutSeconds:      1,
+				PeriodSeconds:       5,
+				SuccessThreshold:    1,
+				FailureThreshold:    1,
+			},
+			VolumeMounts: []corev1.VolumeMount{
+				{
+					Name:      "charm-data",
+					MountPath: "/charm/bin/pebble",
+					SubPath:   "charm/bin/pebble",
+					ReadOnly:  true,
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/charm/container",
+					SubPath:   "charm/containers/nginx",
+				},
+			},
+			SecurityContext: &corev1.SecurityContext{
+				RunAsUser:  int64Ptr(1234),
+				RunAsGroup: int64Ptr(4321),
+			},
+		}},
+		Volumes: []corev1.Volume{
+			{
+				Name: "charm-data",
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
+			},
+		},
+	}
+}

--- a/caas/kubernetes/provider/application/spec36_test.go
+++ b/caas/kubernetes/provider/application/spec36_test.go
@@ -1,0 +1,383 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package application_test
+
+import (
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/pointer"
+
+	"github.com/juju/juju/caas/kubernetes/provider/constants"
+	"github.com/juju/juju/core/paths"
+)
+
+func getPodSpec36() corev1.PodSpec {
+	jujuDataDir := paths.DataDir(paths.OSUnixLike)
+	return corev1.PodSpec{
+		ServiceAccountName:            "gitlab",
+		AutomountServiceAccountToken:  pointer.BoolPtr(true),
+		ImagePullSecrets:              []corev1.LocalObjectReference{{Name: "gitlab-nginx-secret"}},
+		TerminationGracePeriodSeconds: pointer.Int64Ptr(30),
+		SecurityContext: &corev1.PodSecurityContext{
+			FSGroup:            int64Ptr(170),
+			SupplementalGroups: []int64{170},
+		},
+		InitContainers: []corev1.Container{{
+			Name:            "charm-init",
+			ImagePullPolicy: corev1.PullIfNotPresent,
+			Image:           "operator/image-path:1.1.1",
+			WorkingDir:      jujuDataDir,
+			SecurityContext: &corev1.SecurityContext{
+				RunAsUser:  int64Ptr(170),
+				RunAsGroup: int64Ptr(170),
+			},
+			Command: []string{"/opt/containeragent"},
+			Args: []string{
+				"init",
+				"--containeragent-pebble-dir", "/containeragent/pebble",
+				"--charm-modified-version", "9001",
+				"--data-dir", "/var/lib/juju",
+				"--bin-dir", "/charm/bin",
+				"--profile-dir", "/containeragent/etc/profile.d",
+				"--pebble-identities-file", "/charm/etc/pebble/identities.yaml",
+				"--pebble-charm-identity", "170",
+			},
+			Env: []corev1.EnvVar{
+				{
+					Name:  "JUJU_CONTAINER_NAMES",
+					Value: "gitlab,nginx",
+				},
+				{
+					Name: "JUJU_K8S_POD_NAME",
+					ValueFrom: &corev1.EnvVarSource{
+						FieldRef: &corev1.ObjectFieldSelector{
+							FieldPath: "metadata.name",
+						},
+					},
+				},
+				{
+					Name: "JUJU_K8S_POD_UUID",
+					ValueFrom: &corev1.EnvVarSource{
+						FieldRef: &corev1.ObjectFieldSelector{
+							FieldPath: "metadata.uid",
+						},
+					},
+				},
+			},
+			EnvFrom: []corev1.EnvFromSource{
+				{
+					SecretRef: &corev1.SecretEnvSource{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "gitlab-application-config",
+						},
+					},
+				},
+			},
+			VolumeMounts: []corev1.VolumeMount{
+				{
+					Name:      "charm-data",
+					MountPath: jujuDataDir,
+					SubPath:   strings.TrimPrefix(jujuDataDir, "/"),
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/charm/bin",
+					SubPath:   "charm/bin",
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/charm/containers",
+					SubPath:   "charm/containers",
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/containeragent/pebble",
+					SubPath:   "containeragent/pebble",
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/containeragent/etc/profile.d",
+					SubPath:   "containeragent/etc/profile.d",
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/charm/etc/pebble/",
+					SubPath:   "charm/etc/pebble/",
+				},
+			},
+		}},
+		Containers: []corev1.Container{{
+			Name:            "charm",
+			ImagePullPolicy: corev1.PullIfNotPresent,
+			Image:           "ubuntu@22.04",
+			WorkingDir:      jujuDataDir,
+			Command:         []string{"/charm/bin/pebble"},
+			Args: []string{
+				"run",
+				"--http", ":38812",
+				"--verbose",
+			},
+			Env: []corev1.EnvVar{
+				{
+					Name:  "JUJU_CONTAINER_NAMES",
+					Value: "gitlab,nginx",
+				},
+				{
+					Name:  constants.EnvAgentHTTPProbePort,
+					Value: constants.AgentHTTPProbePort,
+				},
+			},
+			LivenessProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/v1/health?level=alive",
+						Port: intstr.Parse("38812"),
+					},
+				},
+				InitialDelaySeconds: 30,
+				TimeoutSeconds:      1,
+				PeriodSeconds:       5,
+				SuccessThreshold:    1,
+				FailureThreshold:    3,
+			},
+			ReadinessProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/v1/health?level=ready",
+						Port: intstr.Parse("38812"),
+					},
+				},
+				InitialDelaySeconds: 30,
+				TimeoutSeconds:      1,
+				PeriodSeconds:       5,
+				SuccessThreshold:    1,
+				FailureThreshold:    1,
+			},
+			StartupProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/v1/health?level=alive",
+						Port: intstr.Parse("38812"),
+					},
+				},
+				InitialDelaySeconds: 30,
+				TimeoutSeconds:      1,
+				PeriodSeconds:       5,
+				SuccessThreshold:    1,
+				FailureThreshold:    1,
+			},
+			VolumeMounts: []corev1.VolumeMount{
+				{
+					Name:      "charm-data",
+					MountPath: "/charm/bin",
+					SubPath:   "charm/bin",
+					ReadOnly:  true,
+				},
+				{
+					Name:      "charm-data",
+					MountPath: jujuDataDir,
+					SubPath:   strings.TrimPrefix(jujuDataDir, "/"),
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/charm/containers",
+					SubPath:   "charm/containers",
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/var/lib/pebble/default",
+					SubPath:   "containeragent/pebble",
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/var/log/juju",
+					SubPath:   "containeragent/var/log/juju",
+				},
+				{
+					Name:      "charm-data",
+					MountPath: paths.JujuIntrospect(paths.OSUnixLike),
+					SubPath:   "charm/bin/containeragent",
+					ReadOnly:  true,
+				},
+				{
+					Name:      "charm-data",
+					MountPath: paths.JujuExec(paths.OSUnixLike),
+					SubPath:   "charm/bin/containeragent",
+					ReadOnly:  true,
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/etc/profile.d/juju-introspection.sh",
+					SubPath:   "containeragent/etc/profile.d/juju-introspection.sh",
+					ReadOnly:  true,
+				},
+				{
+					Name:      "gitlab-database-appuuid",
+					MountPath: "path/to/here",
+				},
+			},
+			SecurityContext: &corev1.SecurityContext{
+				RunAsUser:  int64Ptr(170),
+				RunAsGroup: int64Ptr(170),
+			},
+		}, {
+			Name:            "gitlab",
+			ImagePullPolicy: corev1.PullIfNotPresent,
+			Image:           "docker.io/library/gitlab:latest",
+			Command:         []string{"/charm/bin/pebble"},
+			Args:            []string{"run", "--create-dirs", "--hold", "--http", ":38813", "--verbose", "--identities", "/charm/etc/pebble/identities.yaml"},
+			Env: []corev1.EnvVar{
+				{
+					Name:  "JUJU_CONTAINER_NAME",
+					Value: "gitlab",
+				},
+				{
+					Name:  "PEBBLE_SOCKET",
+					Value: "/charm/container/pebble.socket",
+				},
+				{
+					Name:  "PEBBLE",
+					Value: "/charm/container/pebble",
+				},
+				{
+					Name:  "PEBBLE_COPY_ONCE",
+					Value: "/var/lib/pebble/default",
+				},
+			},
+			LivenessProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/v1/health?level=alive",
+						Port: intstr.FromInt(38813),
+					},
+				},
+				InitialDelaySeconds: 30,
+				TimeoutSeconds:      1,
+				PeriodSeconds:       5,
+				SuccessThreshold:    1,
+				FailureThreshold:    3,
+			},
+			ReadinessProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/v1/health?level=ready",
+						Port: intstr.FromInt(38813),
+					},
+				},
+				InitialDelaySeconds: 30,
+				TimeoutSeconds:      1,
+				PeriodSeconds:       5,
+				SuccessThreshold:    1,
+				FailureThreshold:    1,
+			},
+			VolumeMounts: []corev1.VolumeMount{
+				{
+					Name:      "charm-data",
+					MountPath: "/charm/bin/pebble",
+					SubPath:   "charm/bin/pebble",
+					ReadOnly:  true,
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/charm/container",
+					SubPath:   "charm/containers/gitlab",
+				},
+				{
+					Name:      "charm-data",
+					ReadOnly:  true,
+					MountPath: "/charm/etc/pebble/identities.yaml",
+					SubPath:   "charm/etc/pebble/identities.yaml",
+				},
+				{
+					Name:      "gitlab-database-appuuid",
+					MountPath: "path/to/here",
+				},
+			},
+			SecurityContext: &corev1.SecurityContext{},
+		}, {
+			Name:            "nginx",
+			ImagePullPolicy: corev1.PullIfNotPresent,
+			Image:           "docker.io/library/nginx:latest",
+			Command:         []string{"/charm/bin/pebble"},
+			Args:            []string{"run", "--create-dirs", "--hold", "--http", ":38814", "--verbose", "--identities", "/charm/etc/pebble/identities.yaml"},
+			Env: []corev1.EnvVar{
+				{
+					Name:  "JUJU_CONTAINER_NAME",
+					Value: "nginx",
+				},
+				{
+					Name:  "PEBBLE_SOCKET",
+					Value: "/charm/container/pebble.socket",
+				},
+				{
+					Name:  "PEBBLE",
+					Value: "/charm/container/pebble",
+				},
+				{
+					Name:  "PEBBLE_COPY_ONCE",
+					Value: "/var/lib/pebble/default",
+				},
+			},
+			LivenessProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/v1/health?level=alive",
+						Port: intstr.FromInt(38814),
+					},
+				},
+				InitialDelaySeconds: 30,
+				TimeoutSeconds:      1,
+				PeriodSeconds:       5,
+				SuccessThreshold:    1,
+				FailureThreshold:    3,
+			},
+			ReadinessProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/v1/health?level=ready",
+						Port: intstr.FromInt(38814),
+					},
+				},
+				InitialDelaySeconds: 30,
+				TimeoutSeconds:      1,
+				PeriodSeconds:       5,
+				SuccessThreshold:    1,
+				FailureThreshold:    1,
+			},
+			VolumeMounts: []corev1.VolumeMount{
+				{
+					Name:      "charm-data",
+					MountPath: "/charm/bin/pebble",
+					SubPath:   "charm/bin/pebble",
+					ReadOnly:  true,
+				},
+				{
+					Name:      "charm-data",
+					MountPath: "/charm/container",
+					SubPath:   "charm/containers/nginx",
+				},
+				{
+					Name:      "charm-data",
+					ReadOnly:  true,
+					MountPath: "/charm/etc/pebble/identities.yaml",
+					SubPath:   "charm/etc/pebble/identities.yaml",
+				},
+			},
+			SecurityContext: &corev1.SecurityContext{
+				RunAsUser:  int64Ptr(1234),
+				RunAsGroup: int64Ptr(4321),
+			},
+		}},
+		Volumes: []corev1.Volume{
+			{
+				Name: "charm-data",
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
+			},
+		},
+	}
+}

--- a/cmd/containeragent/initialize/command.go
+++ b/cmd/containeragent/initialize/command.go
@@ -28,7 +28,8 @@ import (
 	"github.com/juju/juju/cmd/constants"
 	"github.com/juju/juju/cmd/containeragent/utils"
 	internallogger "github.com/juju/juju/internal/logger"
-	"github.com/juju/juju/internal/service/pebble/plan"
+	pebbleidentity "github.com/juju/juju/internal/service/pebble/identity"
+	pebbleplan "github.com/juju/juju/internal/service/pebble/plan"
 	"github.com/juju/juju/internal/worker/apicaller"
 	"github.com/juju/juju/internal/worker/introspection"
 )
@@ -51,6 +52,13 @@ type initCommand struct {
 	// containerAgentPebbleDir holds the path to the pebble config dir used on
 	// the container agent.
 	containerAgentPebbleDir string
+
+	// pebbleIdentitiesFile holds the path to the pebble identities for the
+	// workload sidecar containers so that the charm can connect to them.
+	pebbleIdentitiesFile string
+
+	// pebbleCharmIdentity holds the user id for the charm identity.
+	pebbleCharmIdentity int
 
 	dataDir      string
 	binDir       string
@@ -82,6 +90,8 @@ func (c *initCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.StringVar(&c.dataDir, "data-dir", "", "directory for juju data")
 	f.StringVar(&c.binDir, "bin-dir", "", "copy juju binaries to this directory")
 	f.StringVar(&c.profileDir, "profile-dir", "", "install introspection functions to this directory")
+	f.StringVar(&c.pebbleIdentitiesFile, "pebble-identities-file", "", "pebble identities file for configuring workload pebbles to auth with the charm")
+	f.IntVar(&c.pebbleCharmIdentity, "pebble-charm-identity", -1, "charm identity user-id to add to the --pebble-identities-file")
 	f.BoolVar(&c.isController, "controller", false, "set when the charm is colocated with the controller")
 }
 
@@ -230,53 +240,53 @@ func (c *initCommand) writeContainerAgentPebbleConfig() error {
 		extraArgs = append(extraArgs, "--controller")
 	}
 
-	onCheckFailureAction := plan.ActionShutdown
+	onCheckFailureAction := pebbleplan.ActionShutdown
 	if c.isController {
-		onCheckFailureAction = plan.ActionRestart
+		onCheckFailureAction = pebbleplan.ActionRestart
 	}
 
-	containerAgentLayer := plan.Layer{
+	containerAgentLayer := pebbleplan.Layer{
 		Summary: "Juju container agent service",
-		Services: map[string]*plan.Service{
+		Services: map[string]*pebbleplan.Service{
 			"container-agent": {
 				Summary:  "Juju container agent",
-				Override: plan.ReplaceOverride,
+				Override: pebbleplan.ReplaceOverride,
 				Command: fmt.Sprintf("%s unit --data-dir %s --append-env \"PATH=$PATH:%s\" --show-log %s",
 					path.Join(c.binDir, "containeragent"),
 					c.dataDir,
 					c.binDir,
 					strings.Join(extraArgs, " ")),
-				KillDelay: plan.OptionalDuration{Value: 30 * time.Minute, IsSet: true},
-				Startup:   plan.StartupEnabled,
-				OnSuccess: plan.ActionIgnore,
+				KillDelay: pebbleplan.OptionalDuration{Value: 30 * time.Minute, IsSet: true},
+				Startup:   pebbleplan.StartupEnabled,
+				OnSuccess: pebbleplan.ActionIgnore,
 				OnFailure: onCheckFailureAction,
-				OnCheckFailure: map[string]plan.ServiceAction{
-					"liveness":  plan.ActionIgnore,
-					"readiness": plan.ActionIgnore,
+				OnCheckFailure: map[string]pebbleplan.ServiceAction{
+					"liveness":  pebbleplan.ActionIgnore,
+					"readiness": pebbleplan.ActionIgnore,
 				},
 				Environment: map[string]string{
 					constants.EnvHTTPProbePort: constants.DefaultHTTPProbePort,
 				},
 			},
 		},
-		Checks: map[string]*plan.Check{
+		Checks: map[string]*pebbleplan.Check{
 			"readiness": {
-				Override:  plan.ReplaceOverride,
-				Level:     plan.ReadyLevel,
-				Period:    plan.OptionalDuration{Value: 10 * time.Second, IsSet: true},
-				Timeout:   plan.OptionalDuration{Value: 3 * time.Second, IsSet: true},
+				Override:  pebbleplan.ReplaceOverride,
+				Level:     pebbleplan.ReadyLevel,
+				Period:    pebbleplan.OptionalDuration{Value: 10 * time.Second, IsSet: true},
+				Timeout:   pebbleplan.OptionalDuration{Value: 3 * time.Second, IsSet: true},
 				Threshold: 3,
-				HTTP: &plan.HTTPCheck{
+				HTTP: &pebbleplan.HTTPCheck{
 					URL: fmt.Sprintf("http://localhost:%s/readiness", constants.DefaultHTTPProbePort),
 				},
 			},
 			"liveness": {
-				Override:  plan.ReplaceOverride,
-				Level:     plan.AliveLevel,
-				Period:    plan.OptionalDuration{Value: 10 * time.Second, IsSet: true},
-				Timeout:   plan.OptionalDuration{Value: 3 * time.Second, IsSet: true},
+				Override:  pebbleplan.ReplaceOverride,
+				Level:     pebbleplan.AliveLevel,
+				Period:    pebbleplan.OptionalDuration{Value: 10 * time.Second, IsSet: true},
+				Timeout:   pebbleplan.OptionalDuration{Value: 3 * time.Second, IsSet: true},
 				Threshold: 3,
-				HTTP: &plan.HTTPCheck{
+				HTTP: &pebbleplan.HTTPCheck{
 					URL: fmt.Sprintf("http://localhost:%s/liveness", constants.DefaultHTTPProbePort),
 				},
 			},
@@ -298,6 +308,29 @@ func (c *initCommand) writeContainerAgentPebbleConfig() error {
 	if err := c.fileReaderWriter.WriteFile(p, rawConfig, 0664); err != nil {
 		return fmt.Errorf("writing container agent pebble configuration to %q: %w", p, err)
 	}
+
+	if c.pebbleIdentitiesFile != "" {
+		idFile := pebbleidentity.IdentitiesFile{}
+		if c.pebbleCharmIdentity >= 0 {
+			uid := uint32(c.pebbleCharmIdentity)
+			idFile.Identities = map[string]*pebbleidentity.Identity{
+				"charm": {
+					Access: pebbleidentity.AdminAccess,
+					Local: &pebbleidentity.LocalIdentity{
+						UserID: &uid,
+					},
+				},
+			}
+		}
+		rawIDFile, err := yaml.Marshal(&idFile)
+		if err != nil {
+			return fmt.Errorf("cannot format pebble identities file: %w", err)
+		}
+		if err := c.fileReaderWriter.WriteFile(c.pebbleIdentitiesFile, rawIDFile, 0664); err != nil {
+			return fmt.Errorf("writing pebble identities file to %q: %w", c.pebbleIdentitiesFile, err)
+		}
+	}
+
 	return nil
 }
 

--- a/cmd/containeragent/initialize/package_test.go
+++ b/cmd/containeragent/initialize/package_test.go
@@ -114,6 +114,7 @@ func (*importSuite) TestImports(c *gc.C) {
 		"internal/rpcreflect",
 		"internal/scriptrunner",
 		"internal/service/common",
+		"internal/service/pebble/identity",
 		"internal/service/pebble/plan",
 		"internal/service/snap",
 		"internal/service/systemd",

--- a/cmd/juju/action/cancel.go
+++ b/cmd/juju/action/cancel.go
@@ -37,12 +37,26 @@ func (c *cancelCommand) SetFlags(f *gnuflag.FlagSet) {
 const cancelDoc = `
 Cancel pending or running tasks matching given IDs or partial ID prefixes.`
 
+const cancelExamples = `
+To cancel a task by ID:
+
+    juju cancel-task 1
+
+To cancel multiple tasks by ID:
+
+    juju cancel-task 1 2 3
+`
+
 func (c *cancelCommand) Info() *cmd.Info {
 	info := &cmd.Info{
-		Name:    "cancel-task",
-		Args:    "(<task-id>|<task-id-prefix>) [...]",
-		Purpose: "Cancel pending or running tasks.",
-		Doc:     cancelDoc,
+		Name:     "cancel-task",
+		Args:     "(<task-id>|<task-id-prefix>) [...]",
+		Purpose:  "Cancel pending or running tasks.",
+		Doc:      cancelDoc,
+		Examples: cancelExamples,
+		SeeAlso: []string{
+			"show-task",
+		},
 	}
 	return jujucmd.Info(info)
 }

--- a/cmd/juju/action/exec.go
+++ b/cmd/juju/action/exec.go
@@ -123,13 +123,27 @@ those arguments. For example:
 
 `
 
+const example = `
+
+    juju exec --all -- hostname -f
+
+    juju exec --unit hello/0 env
+
+    juju exec --unit controller/0 juju-engine-report
+`
+
 // Info implements Command.Info.
 func (c *execCommand) Info() *cmd.Info {
 	info := jujucmd.Info(&cmd.Info{
-		Name:    "exec",
-		Args:    "<commands>",
-		Purpose: "Run the commands on the remote targets specified.",
-		Doc:     execDoc,
+		Name:     "exec",
+		Args:     "<commands>",
+		Purpose:  "Run the commands on the remote targets specified.",
+		Doc:      execDoc,
+		Examples: example,
+		SeeAlso: []string{
+			"run",
+			"ssh",
+		},
 	})
 	return info
 }

--- a/cmd/juju/action/showtask.go
+++ b/cmd/juju/action/showtask.go
@@ -88,6 +88,7 @@ func (c *showTaskCommand) Info() *cmd.Info {
 		Doc:      showTaskDoc,
 		Examples: showTaskExamples,
 		SeeAlso: []string{
+			"cancel-task",
 			"run",
 			"operations",
 			"show-operation",

--- a/cmd/juju/agree/agree/agree.go
+++ b/cmd/juju/agree/agree/agree.go
@@ -86,6 +86,9 @@ func (c *agreeCommand) Info() *cmd.Info {
 		Purpose:  "Agree to terms.",
 		Doc:      agreeDoc,
 		Examples: agreeExamples,
+		SeeAlso: []string{
+			"agreements",
+		},
 	})
 }
 

--- a/cmd/juju/agree/listagreements/listagreements.go
+++ b/cmd/juju/agree/listagreements/listagreements.go
@@ -39,10 +39,10 @@ In other words, some applications may only be installed if a user agrees to
 accept some terms defined by the charm. 
 
 This command lists the terms that the user has agreed to.
+`
 
-See also:
-    agree
-
+const listAgreementsExamples = `
+    juju agreements
 `
 
 // NewListAgreementsCommand returns a new command that can be
@@ -73,10 +73,14 @@ func (c *listAgreementsCommand) SetFlags(f *gnuflag.FlagSet) {
 // Info implements Command.Info.
 func (c *listAgreementsCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "agreements",
-		Purpose: "List user's agreements.",
-		Doc:     listAgreementsDoc,
-		Aliases: []string{"list-agreements"},
+		Name:     "agreements",
+		Purpose:  "List user's agreements.",
+		Doc:      listAgreementsDoc,
+		Aliases:  []string{"list-agreements"},
+		Examples: listAgreementsExamples,
+		SeeAlso: []string{
+			"agree",
+		},
 	})
 }
 

--- a/cmd/juju/application/bind.go
+++ b/cmd/juju/application/bind.go
@@ -84,6 +84,11 @@ func (c *bindCommand) Info() *cmd.Info {
 		Purpose:  "Change bindings for a deployed application.",
 		Doc:      bindCmdDoc,
 		Examples: bindCmdExamples,
+		SeeAlso: []string{
+			"spaces",
+			"show-space",
+			"show-application",
+		},
 	})
 }
 

--- a/cmd/juju/application/config.go
+++ b/cmd/juju/application/config.go
@@ -114,6 +114,24 @@ settings back to their default value as defined in the charm metadata:
     juju config apache2 --reset servername
     juju config apache2 --reset servername,lb_balancer_timeout
 `
+
+	examples = `
+To view all configuration values for an application, run
+
+    juju config mysql --format json
+
+To set a configuration value for an application, run
+
+    juju config mysql foo=bar
+
+To set some keys and reset others:
+
+    juju config mysql key1=val1 key2=val2 --reset key3,key4
+
+To set a configuration value for an application from a file:
+
+    juju config mysql --file=path/to/cfg.yaml
+`
 )
 
 var appConfigBase = config.ConfigCommandBase{
@@ -149,10 +167,11 @@ type ApplicationAPI interface {
 // Info is part of the cmd.Command interface.
 func (c *configCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "config",
-		Args:    "<application name> [--branch <branch-name>] [--reset <key[,key]>] [<attribute-key>][=<value>] ...]",
-		Purpose: configSummary,
-		Doc:     configDetails,
+		Name:     "config",
+		Args:     "<application name> [--branch <branch-name>] [--reset <key[,key]>] [<attribute-key>][=<value>] ...]",
+		Purpose:  configSummary,
+		Doc:      configDetails,
+		Examples: examples,
 		SeeAlso: []string{
 			"deploy",
 			"status",

--- a/cmd/juju/application/expose.go
+++ b/cmd/juju/application/expose.go
@@ -66,6 +66,24 @@ juju expose apache2 --endpoints logs --to-cidrs 192.168.0.0/24
 
 `[1:]
 
+const example = `
+To expose an application:
+
+    juju expose apache2
+
+To expose an application to one or multiple spaces:
+
+    juju expose apache2 --to-spaces public
+
+To expose an application to one or multiple endpoints:
+
+    juju expose apache2 --endpoints logs
+	
+To expose an application to one or multiple CIDRs:
+
+    juju expose apache2 --to-cidrs 10.0.0.0/24
+`
+
 // NewExposeCommand returns a command to expose applications.
 func NewExposeCommand() modelcmd.ModelCommand {
 	return modelcmd.Wrap(&exposeCommand{})
@@ -85,10 +103,11 @@ type exposeCommand struct {
 
 func (c *exposeCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "expose",
-		Args:    "<application name>",
-		Purpose: usageExposeSummary,
-		Doc:     usageExposeDetails,
+		Name:     "expose",
+		Args:     "<application name>",
+		Purpose:  usageExposeSummary,
+		Doc:      usageExposeDetails,
+		Examples: example,
 		SeeAlso: []string{
 			"unexpose",
 		},

--- a/cmd/juju/application/refresh.go
+++ b/cmd/juju/application/refresh.go
@@ -237,6 +237,20 @@ application; overriding profiles on the container may cause unexpected
 behavior.
 `
 
+const refreshExamples = `
+To refresh the storage constraints for the application foo:
+
+	juju refresh foo --storage cache=ssd,10G
+
+To refresh the application config from a file for application foo:
+
+	juju refresh foo --config config.yaml
+
+To refresh the resources for application foo:
+
+	juju refresh foo --resource bar=/some/file.tgz --resource baz=./docs/cfg.xml
+`
+
 const upgradedApplicationHasUnitsMessage = `
 Upgrading from an older PodSpec style charm to a newer Sidecar charm requires that
 the application be scaled down to 0 units.
@@ -249,10 +263,12 @@ all those units to disappear before continuing.
 
 func (c *refreshCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "refresh",
-		Args:    "<application>",
-		Purpose: "Refresh an application's charm.",
-		Doc:     refreshDoc,
+		Name:     "refresh",
+		Args:     "<application>",
+		Purpose:  "Refresh an application's charm.",
+		Doc:      refreshDoc,
+		SeeAlso:  []string{"deploy"},
+		Examples: refreshExamples,
 	})
 }
 

--- a/cmd/juju/application/removeapplication.go
+++ b/cmd/juju/application/removeapplication.go
@@ -93,6 +93,10 @@ func (c *removeApplicationCommand) Info() *cmd.Info {
 		Purpose:  helpSummaryRmApp,
 		Doc:      helpDetailsRmApp,
 		Examples: helpExamplesRmApp,
+		SeeAlso: []string{
+			"scale-application",
+			"show-application",
+		},
 	})
 }
 

--- a/cmd/juju/application/resolved.go
+++ b/cmd/juju/application/resolved.go
@@ -29,12 +29,22 @@ type resolvedCommand struct {
 	All       bool
 }
 
+const resolvedCommandExamples = `
+
+	juju resolved mysql/0
+
+	juju resolved mysql/0 mysql/1
+
+	juju resolved --all
+`
+
 func (c *resolvedCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "resolved",
-		Args:    "[<unit> ...]",
-		Purpose: "Marks unit errors resolved and re-executes failed hooks.",
-		Aliases: []string{"resolve"},
+		Name:     "resolved",
+		Args:     "[<unit> ...]",
+		Purpose:  "Marks unit errors resolved and re-executes failed hooks.",
+		Aliases:  []string{"resolve"},
+		Examples: resolvedCommandExamples,
 	})
 }
 

--- a/cmd/juju/application/scaleapplication.go
+++ b/cmd/juju/application/scaleapplication.go
@@ -58,6 +58,11 @@ func (c *scaleApplicationCommand) Info() *cmd.Info {
 		Purpose:  "Set the desired number of k8s application units.",
 		Doc:      scaleApplicationDoc,
 		Examples: scaleApplicationExamples,
+		SeeAlso: []string{
+			"remove-application",
+			"add-unit",
+			"remove-unit",
+		},
 	})
 }
 

--- a/cmd/juju/application/showunit.go
+++ b/cmd/juju/application/showunit.go
@@ -25,10 +25,24 @@ or related unit may be shown, or just the application data.
 `
 
 const showUnitExamples = `
+To show information about a unit:
+
     juju show-unit mysql/0
+
+To show information about multiple units:
+
     juju show-unit mysql/0 wordpress/1
+
+To show only the application relation data for a unit:
+
     juju show-unit mysql/0 --app
+
+To show only the relation data for a specific endpoint:
+
     juju show-unit mysql/0 --endpoint db
+
+To show only the relation data for a specific related unit:
+
     juju show-unit mysql/0 --related-unit wordpress/2
 `
 
@@ -61,6 +75,10 @@ func (c *showUnitCommand) Info() *cmd.Info {
 		Purpose:  "Displays information about a unit.",
 		Doc:      showUnitDoc,
 		Examples: showUnitExamples,
+		SeeAlso: []string{
+			"add-unit",
+			"remove-unit",
+		},
 	}
 	return jujucmd.Info(showCmd)
 }

--- a/cmd/juju/application/unexpose.go
+++ b/cmd/juju/application/unexpose.go
@@ -26,24 +26,15 @@ the "juju expose" command, they can be unexposed by running the "juju unexpose"
 command.  
 
 If no additional options are specified, the command will unexpose the
-application (if exposed). For example, to unexpose the apache2 application,
-you can run:
-
-juju unexpose apache2
+application (if exposed).
 
 The --endpoints option may be used to restrict the effect of this command to 
-the list of ports opened for a comma-delimited list of endpoints. For instance,
-to only unexpose the ports opened by apache2 for the "www" endpoint, you can 
-run:
-
-juju unexpose apache2 --endpoints www
+the list of ports opened for a comma-delimited list of endpoints.
 
 Note that when the --endpoints option is provided, the application will still
 remain exposed if any other of its endpoints are still exposed. However, if
 none of its endpoints remain exposed, the application will be instead unexposed. 
-
-See also: 
-    expose`[1:]
+`[1:]
 
 // NewUnexposeCommand returns a command to unexpose applications.
 func NewUnexposeCommand() modelcmd.ModelCommand {
@@ -59,12 +50,26 @@ type unexposeCommand struct {
 	api ApplicationExposeAPI
 }
 
+const unexposeCommandExample = `
+    juju unexpose apache2
+
+To unexpose only the ports that charms have opened for the "www", or "www" and "logs" endpoints:
+
+    juju unexpose apache2 --endpoints www
+
+    juju unexpose apache2 --endpoints www,logs
+`
+
 func (c *unexposeCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "unexpose",
-		Args:    "<application name>",
-		Purpose: usageUnexposeSummary,
-		Doc:     usageUnexposeDetails,
+		Name:     "unexpose",
+		Args:     "<application name>",
+		Purpose:  usageUnexposeSummary,
+		Doc:      usageUnexposeDetails,
+		Examples: unexposeCommandExample,
+		SeeAlso: []string{
+			"expose",
+		},
 	})
 }
 

--- a/cmd/juju/backups/download.go
+++ b/cmd/juju/backups/download.go
@@ -23,6 +23,10 @@ If --filename is not used, the archive is downloaded to a temporary
 location and the filename is printed to stdout.
 `
 
+const examples = `
+    juju download-backup /full/path/to/backup/on/controller
+`
+
 // NewDownloadCommand returns a commant used to download backups.
 func NewDownloadCommand() cmd.Command {
 	return modelcmd.Wrap(&downloadCommand{})
@@ -40,10 +44,14 @@ type downloadCommand struct {
 // Info implements Command.Info.
 func (c *downloadCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "download-backup",
-		Args:    "/full/path/to/backup/on/controller",
-		Purpose: "Download a backup archive file.",
-		Doc:     downloadDoc,
+		Name:     "download-backup",
+		Args:     "/full/path/to/backup/on/controller",
+		Purpose:  "Download a backup archive file.",
+		Doc:      downloadDoc,
+		Examples: examples,
+		SeeAlso: []string{
+			"create-backup",
+		},
 	})
 }
 

--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -148,17 +148,20 @@ GKE or EKS.
 
 When bootstrapping to a k8s cluster Juju does not recognise, there's no
 guarantee a load balancer is available, so Juju defaults to a controller
-service type of ClusterIP. This may not be suitable, so there's 3 bootstrap
+service type of ClusterIP. This may not be suitable, so there are three bootstrap
 options available to tell Juju how to set up the controller service. Part of
 the solution may require a load balancer for the cluster to be set up manually
 first, or perhaps an external k8s service via a FQDN will be used
 (this is a cluster specific implementation decision which Juju needs to be
-informed about so it can set things up correctly). The 3 relevant bootstrap
+informed about so it can set things up correctly). The three relevant bootstrap
 options are (see list of bootstrap config items below for a full explanation):
 
 - controller-service-type
 - controller-external-name
 - controller-external-ips
+
+Juju advertises those addresses to other controllers, so they must be resolveable from
+other controllers for cross-model (cross-controller, actually) relations to work.
 
 If a storage pool is specified using --storage-pool, this will be created
 in the controller model.

--- a/cmd/juju/commands/helptool.go
+++ b/cmd/juju/commands/helptool.go
@@ -106,6 +106,7 @@ func (t *helpToolCommand) Info() *cmd.Info {
 		Purpose:  "Show help on a Juju charm hook tool.",
 		Doc:      helpToolDoc,
 		Examples: helpToolExamples,
+		SeeAlso:  []string{"help"},
 	})
 }
 

--- a/cmd/juju/commands/helptool_test.go
+++ b/cmd/juju/commands/helptool_test.go
@@ -96,6 +96,9 @@ Examples:
 For help on a specific tool, supply the name of that tool, for example:
 
         juju help-tool unit-get
+
+See also:
+ - help
 `)
 }
 

--- a/cmd/juju/commands/version.go
+++ b/cmd/juju/commands/version.go
@@ -17,11 +17,12 @@ const versionDoc = `
 Print only the Juju CLI client version.`
 
 const versionExamplesDoc = `
-To see the version of Juju running on a particular controller, use
-  juju show-controller
+    juju version
 
-To see the version of Juju running on a particular model, use
-  juju show-model`
+Print all version information:
+
+    juju version --all
+`
 
 // versionDetail is populated with version information from juju/juju/cmd
 // and passed into each SuperCommand. It can be printed using `juju version --all`.

--- a/cmd/juju/controller/addmodel.go
+++ b/cmd/juju/controller/addmodel.go
@@ -112,6 +112,12 @@ func (c *addModelCommand) Info() *cmd.Info {
 		Purpose:  "Adds a workload model.",
 		Doc:      strings.TrimSpace(addModelHelpDoc),
 		Examples: addModelHelpExamples,
+		SeeAlso: []string{
+			"model-config",
+			"model-defaults",
+			"add-credential",
+			"autoload-credentials",
+		},
 	})
 }
 

--- a/cmd/juju/machine/show.go
+++ b/cmd/juju/machine/show.go
@@ -46,6 +46,9 @@ func (c *showMachineCommand) Info() *cmd.Info {
 		Purpose:  "Show a machine's status.",
 		Doc:      showMachineCommandDoc,
 		Examples: showMachineExamples,
+		SeeAlso: []string{
+			"add-machine",
+		},
 	})
 }
 

--- a/cmd/juju/model/grantrevoke.go
+++ b/cmd/juju/model/grantrevoke.go
@@ -196,6 +196,7 @@ func (c *grantCommand) Info() *cmd.Info {
 		SeeAlso: []string{
 			"revoke",
 			"add-user",
+			"grant-cloud",
 		},
 	})
 }

--- a/cmd/juju/model/grantrevokecloud.go
+++ b/cmd/juju/model/grantrevokecloud.go
@@ -112,6 +112,7 @@ func (c *grantCloudCommand) Info() *cmd.Info {
 		Doc:      usageGrantCloudDetails,
 		Examples: usageGrantCloudExamples,
 		SeeAlso: []string{
+			"grant",
 			"revoke-cloud",
 			"add-user",
 		},

--- a/cmd/juju/model/retryprovisioning.go
+++ b/cmd/juju/model/retryprovisioning.go
@@ -40,11 +40,21 @@ type RetryProvisioningAPI interface {
 	RetryProvisioning(all bool, machines ...names.MachineTag) ([]params.ErrorResult, error)
 }
 
+const retryProvisioningCommandExamples = `
+
+	juju retry-provisioning 0
+
+	juju retry-provisioning 0 1
+
+	juju retry-provisioning --all
+`
+
 func (c *retryProvisioningCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "retry-provisioning",
-		Args:    "<machine> [...]",
-		Purpose: "Retries provisioning for failed machines.",
+		Name:     "retry-provisioning",
+		Args:     "<machine> [...]",
+		Purpose:  "Retries provisioning for failed machines.",
+		Examples: retryProvisioningCommandExamples,
 	})
 }
 

--- a/cmd/juju/model/show.go
+++ b/cmd/juju/model/show.go
@@ -61,6 +61,9 @@ func (c *showModelCommand) Info() *cmd.Info {
 		Args:    "<model name>",
 		Purpose: "Shows information about the current or specified model.",
 		Doc:     showModelCommandDoc,
+		SeeAlso: []string{
+			"add-model",
+		},
 	})
 }
 

--- a/cmd/juju/resource/list.go
+++ b/cmd/juju/resource/list.go
@@ -50,6 +50,20 @@ func NewListCommand() modelcmd.ModelCommand {
 	return modelcmd.Wrap(c)
 }
 
+const listResourcesExamples = `
+To list resources for an application:
+
+	juju resources mysql
+
+To list resources for a unit:
+
+	juju resources mysql/0
+
+To show detailed information about resources used by a unit:
+
+	juju resources mysql/0 --details
+`
+
 // Info implements cmd.Command.Info.
 func (c *ListCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
@@ -66,6 +80,7 @@ This command shows the resources required by and those in use by an existing
 application or unit in your model.  When run for an application, it will also show any
 updates available for resources from a store.
 `,
+		Examples: listResourcesExamples,
 	})
 }
 

--- a/cmd/juju/resource/upload.go
+++ b/cmd/juju/resource/upload.go
@@ -88,6 +88,13 @@ Note: If you choose (2b): You will need to specify:
 (ii) the username/password required to access the private OCI image.
 
 `
+	attachExample = `
+    juju attach-resource mysql resource-name=foo
+
+    juju attach-resource ubuntu-k8s ubuntu_image=ubuntu
+
+    juju attach-resource redis-k8s redis-image=redis
+`
 )
 
 // Info implements cmd.Command.Info

--- a/cmd/juju/secrets/list.go
+++ b/cmd/juju/secrets/list.go
@@ -70,6 +70,12 @@ func (c *listSecretsCommand) Info() *cmd.Info {
 		Doc:      listSecretsDoc,
 		Examples: listSecretsExamples,
 		Aliases:  []string{"list-secrets"},
+		SeeAlso: []string{
+			"add-secret",
+			"remove-secret",
+			"show-secret",
+			"update-secret",
+		},
 	})
 }
 

--- a/cmd/juju/secrets/show.go
+++ b/cmd/juju/secrets/show.go
@@ -70,6 +70,11 @@ func (c *showSecretsCommand) Info() *cmd.Info {
 		Purpose:  "Shows details for a specific secret.",
 		Doc:      showSecretsDoc,
 		Examples: showSecretsExamples,
+		SeeAlso: []string{
+			"add-secret",
+			"update-secret",
+			"remove-secret",
+		},
 	})
 }
 

--- a/cmd/juju/space/reload.go
+++ b/cmd/juju/space/reload.go
@@ -28,12 +28,23 @@ const ReloadCommandDoc = `
 Reloades spaces and subnets from substrate.
 `
 
+const ReloadCommandExamples = `
+	juju reload-spaces
+`
+
 // Info is defined on the cmd.Command interface.
 func (c *ReloadCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "reload-spaces",
-		Purpose: "Reloads spaces and subnets from substrate.",
-		Doc:     strings.TrimSpace(ReloadCommandDoc),
+		Name:     "reload-spaces",
+		Purpose:  "Reloads spaces and subnets from substrate.",
+		Doc:      strings.TrimSpace(ReloadCommandDoc),
+		Examples: ReloadCommandExamples,
+		SeeAlso: []string{
+			"spaces",
+			"add-space",
+			"show-space",
+			"move-to-space",
+		},
 	})
 }
 

--- a/cmd/juju/ssh/debugcode.go
+++ b/cmd/juju/ssh/debugcode.go
@@ -79,6 +79,10 @@ func (c *debugCodeCommand) Info() *cmd.Info {
 		Purpose:  "Launch a tmux session to debug hooks and/or actions.",
 		Doc:      debugCodeDoc,
 		Examples: usageDebugCodeExamples,
+		SeeAlso: []string{
+			"ssh",
+			"debug-hooks",
+		},
 	})
 }
 

--- a/cmd/juju/ssh/debughooks.go
+++ b/cmd/juju/ssh/debughooks.go
@@ -89,6 +89,10 @@ func (c *debugHooksCommand) Info() *cmd.Info {
 		Doc:      debugHooksDoc,
 		Examples: usageDebugHooksExamples,
 		Aliases:  []string{"debug-hook"},
+		SeeAlso: []string{
+			"ssh",
+			"debug-code",
+		},
 	})
 }
 

--- a/cmd/juju/sshkeys/list_sshkeys.go
+++ b/cmd/juju/sshkeys/list_sshkeys.go
@@ -58,6 +58,10 @@ func (c *listKeysCommand) Info() *cmd.Info {
 		Doc:      usageListSSHKeysDetails,
 		Aliases:  []string{"list-ssh-keys"},
 		Examples: usageListSSHKeysExamples,
+		SeeAlso: []string{
+			"add-ssh-key",
+			"remove-ssh-key",
+		},
 	})
 }
 

--- a/cmd/juju/status/history.go
+++ b/cmd/juju/status/history.go
@@ -62,12 +62,46 @@ The statuses are available for the following types.
  The default is unit.
 `, supportedHistoryKindDescs())
 
+const statusHistoryExamples = `
+Show the status history for the specified unit:
+
+    juju show-status-log mysql/0
+
+Show the status history for the specified unit with the last 30 logs:
+
+    juju show-status-log mysql/0 -n 30
+
+Show the status history for the specified unit with the logs for the past 2 days:
+
+    juju show-status-log mysql/0 -days 2
+
+Show the status history for the specified unit with the logs for any date after 2020-01-01:
+
+    juju show-status-log mysql/0 --from-date 2020-01-01
+
+Show the status history for the specified application:
+
+    juju show-status-log -type application wordpress
+
+Show the status history for the specified machine:
+
+    juju show-status-log 0
+
+Show the status history for the model:
+
+    juju show-status-log -type model
+`
+
 func (c *statusHistoryCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "show-status-log",
-		Args:    "<entity name>",
-		Purpose: "Output past statuses for the specified entity.",
-		Doc:     statusHistoryDoc,
+		Name:     "show-status-log",
+		Args:     "<entity name>",
+		Purpose:  "Output past statuses for the specified entity.",
+		Doc:      statusHistoryDoc,
+		Examples: statusHistoryExamples,
+		SeeAlso: []string{
+			"status",
+		},
 	})
 }
 

--- a/cmd/juju/storage/detach.go
+++ b/cmd/juju/storage/detach.go
@@ -89,6 +89,10 @@ func (c *detachStorageCommand) Info() *cmd.Info {
 		Doc:      detachStorageCommandDoc,
 		Examples: detachStorageCommandExamples,
 		Args:     detachStorageCommandArgs,
+		SeeAlso: []string{
+			"storage",
+			"attach-storage",
+		},
 	})
 }
 

--- a/cmd/juju/storage/import.go
+++ b/cmd/juju/storage/import.go
@@ -123,6 +123,7 @@ func (c *importFilesystemCommand) Info() *cmd.Info {
 		Doc:      importFilesystemCommandDoc,
 		Args:     importFilesystemCommandAgs,
 		Examples: importFilesystemCommandExamples,
+		SeeAlso:  []string{"storage"},
 	})
 }
 

--- a/cmd/juju/storage/list.go
+++ b/cmd/juju/storage/list.go
@@ -29,6 +29,20 @@ const listCommandDoc = `
 List information about storage.
 `
 
+const listCommandExample = `
+List all storage:
+
+    juju storage
+
+List only filesystem storage:
+
+    juju storage --filesystem
+
+List only volume storage:
+
+    juju storage --volume
+`
+
 // listCommand returns storage instances.
 type listCommand struct {
 	StorageCommandBase
@@ -42,11 +56,17 @@ type listCommand struct {
 // Info implements Command.Info.
 func (c *listCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "storage",
-		Args:    "<filesystem|volume> ...",
-		Purpose: "Lists storage details.",
-		Doc:     listCommandDoc,
-		Aliases: []string{"list-storage"},
+		Name:     "storage",
+		Args:     "<filesystem|volume> ...",
+		Purpose:  "Lists storage details.",
+		Doc:      listCommandDoc,
+		Aliases:  []string{"list-storage"},
+		Examples: listCommandExample,
+		SeeAlso: []string{
+			"show-storage",
+			"add-storage",
+			"remove-storage",
+		},
 	})
 }
 
@@ -60,8 +80,8 @@ func (c *listCommand) SetFlags(f *gnuflag.FlagSet) {
 	})
 	// TODO(axw) deprecate these flags, and introduce separate commands
 	// for listing just filesystems or volumes.
-	f.BoolVar(&c.filesystem, "filesystem", false, "List filesystem storage")
-	f.BoolVar(&c.volume, "volume", false, "List volume storage")
+	f.BoolVar(&c.filesystem, "filesystem", false, "List filesystem storage(deprecated)")
+	f.BoolVar(&c.volume, "volume", false, "List volume storage(deprecated)")
 }
 
 // Init implements Command.Init.

--- a/cmd/juju/storage/poollist.go
+++ b/cmd/juju/storage/poollist.go
@@ -47,6 +47,20 @@ Both pool types and names must be valid.
 Valid pool types are pool types that are registered for Juju model.
 `
 
+const poolListCommandExample = `
+List all storage pools:
+
+    juju storage-pools
+
+List only pools of type kubernetes, azure, ebs:
+
+    juju storage-pools --provider kubernetes,azure,ebs
+
+List only pools named pool1 and pool2:
+
+    juju storage-pools --name pool1,pool2
+`
+
 // NewPoolListCommand returns a command that lists storage pools on a model
 func NewPoolListCommand() cmd.Command {
 	cmd := &poolListCommand{}
@@ -73,10 +87,15 @@ func (c *poolListCommand) Init(args []string) (err error) {
 // Info implements Command.Info.
 func (c *poolListCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "storage-pools",
-		Purpose: "List storage pools.",
-		Doc:     poolListCommandDoc,
-		Aliases: []string{"list-storage-pools"},
+		Name:     "storage-pools",
+		Purpose:  "List storage pools.",
+		Doc:      poolListCommandDoc,
+		Aliases:  []string{"list-storage-pools"},
+		Examples: poolListCommandExample,
+		SeeAlso: []string{
+			"create-storage-pool",
+			"remove-storage-pool",
+		},
 	})
 }
 

--- a/cmd/juju/storage/remove.go
+++ b/cmd/juju/storage/remove.go
@@ -75,6 +75,14 @@ func (c *removeStorageCommand) Info() *cmd.Info {
 		Doc:      removeStorageCommandDoc,
 		Args:     removeStorageCommandArgs,
 		Examples: removeStorageCommandExamples,
+		SeeAlso: []string{
+			"add-storage",
+			"attach-storage",
+			"detach-storage",
+			"list-storage",
+			"show-storage",
+			"storage",
+		},
 	})
 }
 

--- a/cmd/juju/storage/show.go
+++ b/cmd/juju/storage/show.go
@@ -33,6 +33,10 @@ separated when more than one ID is desired.
 
 `
 
+const showCommandExample = `
+    juju show-storage storage-id
+`
+
 // showCommand attempts to release storage instance.
 type showCommand struct {
 	StorageCommandBase
@@ -53,10 +57,17 @@ func (c *showCommand) Init(args []string) (err error) {
 // Info implements Command.Info.
 func (c *showCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "show-storage",
-		Args:    "<storage ID> [...]",
-		Purpose: "Shows storage instance information.",
-		Doc:     showCommandDoc,
+		Name:     "show-storage",
+		Args:     "<storage ID> [...]",
+		Purpose:  "Shows storage instance information.",
+		Doc:      showCommandDoc,
+		Examples: showCommandExample,
+		SeeAlso: []string{
+			"storage",
+			"attach-storage",
+			"detach-storage",
+			"remove-storage",
+		},
 	})
 }
 

--- a/cmd/juju/subnet/list.go
+++ b/cmd/juju/subnet/list.go
@@ -47,14 +47,29 @@ output formats include "yaml" (default) and "json". To redirect the
 output to a file, use --output.
 `
 
+const listCommandExample = `
+To list all subnets known to Juju:
+
+    juju subnets
+
+To list subnets associated with a specific network space:
+
+    juju subnets --space my-space
+
+To list subnets associated with a specific availability zone:
+
+    juju subnets --zone my-zone
+`
+
 // Info is defined on the cmd.Command interface.
 func (c *ListCommand) Info() *cmd.Info {
 	return jujucmd.Info(&cmd.Info{
-		Name:    "subnets",
-		Args:    "[--space <name>] [--zone <name>] [--format yaml|json] [--output <path>]",
-		Purpose: "List subnets known to Juju.",
-		Doc:     strings.TrimSpace(listCommandDoc),
-		Aliases: []string{"list-subnets"},
+		Name:     "subnets",
+		Args:     "[--space <name>] [--zone <name>] [--format yaml|json] [--output <path>]",
+		Purpose:  "List subnets known to Juju.",
+		Doc:      strings.TrimSpace(listCommandDoc),
+		Aliases:  []string{"list-subnets"},
+		Examples: listCommandExample,
 	})
 }
 

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/bmizerany/pat v0.0.0-20210406213842-e4b6760bdd6f
 	github.com/canonical/go-dqlite v1.21.0
 	github.com/canonical/lxd v0.0.0-20231214113525-e676fc63c50a
-	github.com/canonical/pebble v1.14.0
+	github.com/canonical/pebble v1.15.0
 	github.com/canonical/sqlair v0.0.0-20240417091145-13970327005b
 	github.com/chzyer/readline v1.5.1
 	github.com/coreos/go-systemd/v22 v22.5.0

--- a/go.sum
+++ b/go.sum
@@ -150,8 +150,8 @@ github.com/canonical/go-flags v0.0.0-20230403090104-105d09a091b8 h1:zGaJEJI9qPVy
 github.com/canonical/go-flags v0.0.0-20230403090104-105d09a091b8/go.mod h1:ZZFeR9K9iGgpwOaLYF9PdT44/+lfSJ9sQz3B+SsGsYU=
 github.com/canonical/lxd v0.0.0-20231214113525-e676fc63c50a h1:Tfo/MzXK5GeG7gzSHqxGeY/669Mhh5ea43dn1mRDnk8=
 github.com/canonical/lxd v0.0.0-20231214113525-e676fc63c50a/go.mod h1:UxfHGKFoRjgu1NUA9EFiR++dKvyAiT0h9HT0ffMlzjc=
-github.com/canonical/pebble v1.14.0 h1:lssD5HWeeJrnrXMhuRRq8c/FZss8WANDG/prgC1u+Wc=
-github.com/canonical/pebble v1.14.0/go.mod h1:V9npURKOudv0IZ/z1mJGd1xyLK51flJIlMCIU0lDJ5Y=
+github.com/canonical/pebble v1.15.0 h1:eWtoe5+yHC0fZ+1wglk2VsPUJZtJbxhGo0XiEAjv6p4=
+github.com/canonical/pebble v1.15.0/go.mod h1:iAy6oxSew0En91FA4WdhmKjiuzS2F+hKgOSA4RGjhGg=
 github.com/canonical/sqlair v0.0.0-20240417091145-13970327005b h1:jgRDcoa03uMllXr5RjGD+qAlG9cMbmAGAZ9d9Adb7Pw=
 github.com/canonical/sqlair v0.0.0-20240417091145-13970327005b/go.mod h1:T+40I2sXshY3KRxx0QQpqqn6hCibSKJ2KHzjBvJj8T4=
 github.com/canonical/x-go v0.0.0-20230522092633-7947a7587f5b h1:Da2fardddn+JDlVEYtrzBLTtyzoyU3nIS0Cf0GvjmwU=

--- a/internal/docker/registry/internal/acr.go
+++ b/internal/docker/registry/internal/acr.go
@@ -33,16 +33,16 @@ func normalizeRepoDetailsAzure(repoDetails *docker.ImageRepoDetails) error {
 	return nil
 }
 
-func (c *azureContainerRegistry) String() string {
+func (c azureContainerRegistry) String() string {
 	return "azurecr.io"
 }
 
 // Match checks if the repository details matches current provider format.
-func (c *azureContainerRegistry) Match() bool {
+func (c azureContainerRegistry) Match() bool {
 	return strings.Contains(c.repoDetails.ServerAddress, "azurecr.io")
 }
 
-func (c *azureContainerRegistry) WrapTransport(...TransportWrapper) error {
+func (c azureContainerRegistry) WrapTransport(...TransportWrapper) error {
 	if c.repoDetails.BasicAuthConfig.Empty() {
 		return errors.NewNotValid(nil, fmt.Sprintf(`username and password are required for registry %q`, c.repoDetails.Repository))
 	}
@@ -57,9 +57,9 @@ func (c azureContainerRegistry) Tags(imageName string) (versions tools.Versions,
 	return c.fetchTags(url, &response)
 }
 
-// GetArchitecture returns the archtecture of the image for the specified tag.
-func (c azureContainerRegistry) GetArchitecture(imageName, tag string) (string, error) {
-	return getArchitecture(imageName, tag, c)
+// GetArchitectures returns the architectures of the image for the specified tag.
+func (c azureContainerRegistry) GetArchitectures(imageName, tag string) ([]string, error) {
+	return getArchitectures(imageName, tag, c)
 }
 
 // GetManifests returns the manifests of the image for the specified tag.

--- a/internal/docker/registry/internal/acr_test.go
+++ b/internal/docker/registry/internal/acr_test.go
@@ -294,10 +294,10 @@ func (s *azureContainerRegistrySuite) assertGetManifestsSchemaVersion1(c *gc.C, 
 func (s *azureContainerRegistrySuite) TestGetManifestsSchemaVersion1(c *gc.C) {
 	s.assertGetManifestsSchemaVersion1(c,
 		`
-{ "schemaVersion": 1, "name": "jujuqa/jujud-operator", "tag": "2.9.13", "architecture": "amd64"}
+{ "schemaVersion": 1, "name": "jujuqa/jujud-operator", "tag": "2.9.13", "architecture": "ppc64le"}
 `[1:],
 		`application/vnd.docker.distribution.manifest.v1+prettyjws`,
-		&internal.ManifestsResult{Architecture: "amd64"},
+		&internal.ManifestsResult{Architectures: []string{"ppc64el"}},
 	)
 }
 
@@ -316,6 +316,23 @@ func (s *azureContainerRegistrySuite) TestGetManifestsSchemaVersion2(c *gc.C) {
 `[1:],
 		`application/vnd.docker.distribution.manifest.v2+prettyjws`,
 		&internal.ManifestsResult{Digest: "sha256:f0609d8a844f7271411c1a9c5d7a898fd9f9c5a4844e3bc7db6d725b54671ac1"},
+	)
+}
+
+func (s *azureContainerRegistrySuite) TestGetManifestsSchemaVersion2List(c *gc.C) {
+	s.assertGetManifestsSchemaVersion1(c,
+		`
+{
+    "schemaVersion": 2,
+    "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+    "manifests": [
+        {"platform": {"architecture": "amd64"}},
+        {"platform": {"architecture": "ppc64le"}}
+    ]
+}
+`[1:],
+		`application/vnd.docker.distribution.manifest.list.v2+prettyjws`,
+		&internal.ManifestsResult{Architectures: []string{"amd64", "ppc64el"}},
 	)
 }
 

--- a/internal/docker/registry/internal/base_client.go
+++ b/internal/docker/registry/internal/base_client.go
@@ -194,12 +194,12 @@ func commonURLGetter(version APIVersion, url url.URL, pathTemplate string, args 
 	return url.String()
 }
 
-func (c baseClient) url(pathTemplate string, args ...interface{}) string {
+func (c *baseClient) url(pathTemplate string, args ...interface{}) string {
 	return commonURLGetter(c.APIVersion(), *c.baseURL, pathTemplate, args...)
 }
 
 // Ping pings the baseClient endpoint.
-func (c baseClient) Ping() error {
+func (c *baseClient) Ping() error {
 	url := c.url("/")
 	logger.Debugf("baseClient ping %q", url)
 	resp, err := c.client.Get(url)
@@ -209,7 +209,7 @@ func (c baseClient) Ping() error {
 	return errors.Trace(unwrapNetError(err))
 }
 
-func (c baseClient) ImageRepoDetails() (o docker.ImageRepoDetails) {
+func (c *baseClient) ImageRepoDetails() (o docker.ImageRepoDetails) {
 	if c.repoDetails != nil {
 		return *c.repoDetails
 	}
@@ -224,7 +224,7 @@ func (c *baseClient) Close() error {
 	return nil
 }
 
-func (c baseClient) getPaginatedJSON(url string, response interface{}) (string, error) {
+func (c *baseClient) getPaginatedJSON(url string, response interface{}) (string, error) {
 	resp, err := c.client.Get(url)
 	logger.Tracef("getPaginatedJSON for %q, err %v", url, err)
 	if err != nil {

--- a/internal/docker/registry/internal/base_manifests.go
+++ b/internal/docker/registry/internal/base_manifests.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
+
+	"github.com/juju/juju/core/arch"
 )
 
 //go:generate go run go.uber.org/mock/mockgen -typed -package mocks -destination mocks/manifests_mock.go github.com/juju/juju/internal/docker/registry/internal ArchitectureGetter
@@ -28,10 +30,23 @@ type manifestsResponseV2 struct {
 	Config        manifestsResponseV2Config `json:"config"`
 }
 
+type manifestResponseV2Platform struct {
+	Architecture string `json:"architecture"`
+}
+
+type manifestResponseV2Manifest struct {
+	Platform manifestResponseV2Platform `json:"platform"`
+}
+
+type manifestsResponseListV2 struct {
+	SchemaVersion int                          `json:"schemaVersion"`
+	Manifests     []manifestResponseV2Manifest `json:"manifests"`
+}
+
 // ManifestsResult is the result of GetManifests.
 type ManifestsResult struct {
-	Architecture string
-	Digest       string
+	Architectures []string
+	Digest        string
 }
 
 // BlobsResponse is the result of GetBlobs.
@@ -45,38 +60,38 @@ type ArchitectureGetter interface {
 	GetBlobs(imageName, digest string) (*BlobsResponse, error)
 }
 
-// GetArchitecture returns the archtecture of the image for the specified tag.
-func (c baseClient) GetArchitecture(imageName, tag string) (string, error) {
-	return getArchitecture(imageName, tag, c)
+// GetArchitectures returns the architectures of the image for the specified tag.
+func (c *baseClient) GetArchitectures(imageName, tag string) ([]string, error) {
+	return getArchitectures(imageName, tag, c)
 }
 
-func getArchitecture(imageName, tag string, client ArchitectureGetter) (string, error) {
+func getArchitectures(imageName, tag string, client ArchitectureGetter) ([]string, error) {
 	manifests, err := client.GetManifests(imageName, tag)
 	if err != nil {
-		return "", errors.Annotatef(err, "can not get manifests for %s:%s", imageName, tag)
+		return nil, errors.Annotatef(err, "can not get manifests for %s:%s", imageName, tag)
 	}
-	if manifests.Architecture == "" && manifests.Digest == "" {
-		return "", errors.New(fmt.Sprintf("faild to get manifests for %q %q", imageName, tag))
+	if len(manifests.Architectures) == 0 && manifests.Digest == "" {
+		return nil, errors.New(fmt.Sprintf("faild to get manifests for %q %q", imageName, tag))
 	}
-	if manifests.Architecture != "" {
-		return manifests.Architecture, nil
+	if len(manifests.Architectures) > 0 {
+		return manifests.Architectures, nil
 	}
 	blobs, err := client.GetBlobs(imageName, manifests.Digest)
 	if err != nil {
-		return "", errors.Trace(err)
+		return nil, errors.Trace(err)
 	}
-	return blobs.Architecture, nil
+	return []string{arch.NormaliseArch(blobs.Architecture)}, nil
 }
 
 // GetManifests returns the manifests of the image for the specified tag.
-func (c baseClient) GetManifests(imageName, tag string) (*ManifestsResult, error) {
+func (c *baseClient) GetManifests(imageName, tag string) (*ManifestsResult, error) {
 	repo := getRepositoryOnly(c.ImageRepoDetails().Repository)
 	url := c.url("/%s/%s/manifests/%s", repo, imageName, tag)
 	return c.GetManifestsCommon(url)
 }
 
 // GetManifestsCommon returns manifests result for the provided url.
-func (c baseClient) GetManifestsCommon(url string) (*ManifestsResult, error) {
+func (c *baseClient) GetManifestsCommon(url string) (*ManifestsResult, error) {
 	resp, err := c.client.Get(url)
 	if err != nil {
 		return nil, errors.Trace(unwrapNetError(err))
@@ -86,8 +101,9 @@ func (c baseClient) GetManifestsCommon(url string) (*ManifestsResult, error) {
 }
 
 const (
-	manifestContentTypeV1 = "application/vnd.docker.distribution.manifest.v1"
-	manifestContentTypeV2 = "application/vnd.docker.distribution.manifest.v2"
+	manifestContentTypeV1     = "application/vnd.docker.distribution.manifest.v1"
+	manifestContentTypeV2     = "application/vnd.docker.distribution.manifest.v2"
+	manifestContentTypeListV2 = "application/vnd.docker.distribution.manifest.list.v2"
 )
 
 func processManifestsResponse(resp *http.Response) (*ManifestsResult, error) {
@@ -107,27 +123,37 @@ func processManifestsResponse(resp *http.Response) (*ManifestsResult, error) {
 		if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
 			return nil, errors.Trace(err)
 		}
-		return &ManifestsResult{Architecture: data.Architecture}, nil
+		return &ManifestsResult{Architectures: []string{arch.NormaliseArch(data.Architecture)}}, nil
 	case manifestContentTypeV2:
 		var data manifestsResponseV2
 		if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
 			return nil, errors.Trace(err)
 		}
 		return &ManifestsResult{Digest: data.Config.Digest}, nil
+	case manifestContentTypeListV2:
+		var data manifestsResponseListV2
+		if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+			return nil, errors.Trace(err)
+		}
+		archs := make([]string, len(data.Manifests))
+		for i, manifest := range data.Manifests {
+			archs[i] = arch.NormaliseArch(manifest.Platform.Architecture)
+		}
+		return &ManifestsResult{Architectures: archs}, nil
 	default:
 		return nil, notSupportedAPIVersionError
 	}
 }
 
-// GetBlobs gets the archtecture of the image for the specified tag via blobs API.
-func (c baseClient) GetBlobs(imageName, digest string) (*BlobsResponse, error) {
+// GetBlobs gets the architecture of the image for the specified tag via blobs API.
+func (c *baseClient) GetBlobs(imageName, digest string) (*BlobsResponse, error) {
 	repo := getRepositoryOnly(c.ImageRepoDetails().Repository)
 	url := c.url("/%s/%s/blobs/%s", repo, imageName, digest)
 	return c.GetBlobsCommon(url)
 }
 
 // GetBlobsCommon returns blobs result for the provided url.
-func (c baseClient) GetBlobsCommon(url string) (*BlobsResponse, error) {
+func (c *baseClient) GetBlobsCommon(url string) (*BlobsResponse, error) {
 	resp, err := c.client.Get(url)
 	logger.Tracef("getting blobs for %q, err %v", url, err)
 	if err != nil {

--- a/internal/docker/registry/internal/base_tags.go
+++ b/internal/docker/registry/internal/base_tags.go
@@ -48,7 +48,7 @@ func fetchTagsV2(c tagFetcher, imageName string) (tools.Versions, error) {
 }
 
 // Tags fetches tags for an OCI image.
-func (c baseClient) Tags(imageName string) (tools.Versions, error) {
+func (c *baseClient) Tags(imageName string) (tools.Versions, error) {
 	switch c.APIVersion() {
 	case APIVersionV2:
 		return fetchTagsV2(c, imageName)
@@ -57,7 +57,7 @@ func (c baseClient) Tags(imageName string) (tools.Versions, error) {
 	}
 }
 
-func (c baseClient) fetchTags(url string, res tagsGetter) (versions tools.Versions, err error) {
+func (c *baseClient) fetchTags(url string, res tagsGetter) (versions tools.Versions, err error) {
 	pushVersions := func(tags []string) {
 		for _, tag := range tags {
 			v, err := version.Parse(tag)

--- a/internal/docker/registry/internal/ecr.go
+++ b/internal/docker/registry/internal/ecr.go
@@ -184,31 +184,31 @@ func (c *elasticContainerRegistry) WrapTransport(...TransportWrapper) (err error
 }
 
 // Ping pings the ecr endpoint.
-func (c elasticContainerRegistry) Ping() error {
+func (c *elasticContainerRegistry) Ping() error {
 	// No ping endpoint available for ecr.
 	return nil
 }
 
 // Tags fetches tags for an OCI image.
-func (c elasticContainerRegistry) Tags(imageName string) (versions tools.Versions, err error) {
+func (c *elasticContainerRegistry) Tags(imageName string) (versions tools.Versions, err error) {
 	url := c.url("/%s/tags/list", imageName)
 	var response tagsResponseV2
 	return c.fetchTags(url, &response)
 }
 
-// GetArchitecture returns the archtecture of the image for the specified tag.
-func (c elasticContainerRegistry) GetArchitecture(imageName, tag string) (string, error) {
-	return getArchitecture(imageName, tag, c)
+// GetArchitectures returns the architectures of the image for the specified tag.
+func (c *elasticContainerRegistry) GetArchitectures(imageName, tag string) ([]string, error) {
+	return getArchitectures(imageName, tag, c)
 }
 
 // GetManifests returns the manifests of the image for the specified tag.
-func (c elasticContainerRegistry) GetManifests(imageName, tag string) (*ManifestsResult, error) {
+func (c *elasticContainerRegistry) GetManifests(imageName, tag string) (*ManifestsResult, error) {
 	url := c.url("/%s/manifests/%s", imageName, tag)
 	return c.GetManifestsCommon(url)
 }
 
 // GetBlobs gets the archtecture of the image for the specified tag via blobs API.
-func (c elasticContainerRegistry) GetBlobs(imageName, digest string) (*BlobsResponse, error) {
+func (c *elasticContainerRegistry) GetBlobs(imageName, digest string) (*BlobsResponse, error) {
 	url := c.url("/%s/blobs/%s", imageName, digest)
 	return c.GetBlobsCommon(url)
 }

--- a/internal/docker/registry/internal/ecr_test.go
+++ b/internal/docker/registry/internal/ecr_test.go
@@ -336,10 +336,10 @@ func (s *elasticContainerRegistrySuite) assertGetManifestsSchemaVersion1(c *gc.C
 func (s *elasticContainerRegistrySuite) TestGetManifestsSchemaVersion1(c *gc.C) {
 	s.assertGetManifestsSchemaVersion1(c,
 		`
-{ "schemaVersion": 1, "name": "jujuqa/jujud-operator", "tag": "2.9.13", "architecture": "amd64"}
+{ "schemaVersion": 1, "name": "jujuqa/jujud-operator", "tag": "2.9.13", "architecture": "ppc64le"}
 `[1:],
 		`application/vnd.docker.distribution.manifest.v1+prettyjws`,
-		&internal.ManifestsResult{Architecture: "amd64"},
+		&internal.ManifestsResult{Architectures: []string{"ppc64el"}},
 	)
 }
 
@@ -358,6 +358,23 @@ func (s *elasticContainerRegistrySuite) TestGetManifestsSchemaVersion2(c *gc.C) 
 `[1:],
 		`application/vnd.docker.distribution.manifest.v2+prettyjws`,
 		&internal.ManifestsResult{Digest: "sha256:f0609d8a844f7271411c1a9c5d7a898fd9f9c5a4844e3bc7db6d725b54671ac1"},
+	)
+}
+
+func (s *elasticContainerRegistrySuite) TestGetManifestsSchemaVersion2List(c *gc.C) {
+	s.assertGetManifestsSchemaVersion1(c,
+		`
+{
+    "schemaVersion": 2,
+    "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+    "manifests": [
+        {"platform": {"architecture": "amd64"}},
+        {"platform": {"architecture": "ppc64le"}}
+    ]
+}
+`[1:],
+		`application/vnd.docker.distribution.manifest.list.v2+prettyjws`,
+		&internal.ManifestsResult{Architectures: []string{"amd64", "ppc64el"}},
 	)
 }
 

--- a/internal/docker/registry/internal/interface.go
+++ b/internal/docker/registry/internal/interface.go
@@ -16,7 +16,7 @@ import (
 type Registry interface {
 	String() string
 	Tags(string) (tools.Versions, error)
-	GetArchitecture(imageName, tag string) (string, error)
+	GetArchitectures(imageName, tag string) ([]string, error)
 	Close() error
 	Ping() error
 	ImageRepoDetails() docker.ImageRepoDetails

--- a/internal/docker/registry/internal/package_test.go
+++ b/internal/docker/registry/internal/package_test.go
@@ -16,15 +16,14 @@ func TestPackage(t *testing.T) {
 }
 
 type (
-	AzureContainerRegistry         = azureContainerRegistry
-	BaseClient                     = baseClient
-	Dockerhub                      = dockerhub
-	GoogleContainerRegistry        = googleContainerRegistry
-	GithubContainerRegistry        = githubContainerRegistry
-	GitlabContainerRegistry        = gitlabContainerRegistry
-	QuayContainerRegistry          = quayContainerRegistry
-	ElasticContainerRegistry       = elasticContainerRegistry
-	ElasticContainerRegistryPublic = elasticContainerRegistryPublic
+	AzureContainerRegistry   = azureContainerRegistry
+	BaseClient               = baseClient
+	Dockerhub                = dockerhub
+	GoogleContainerRegistry  = googleContainerRegistry
+	GithubContainerRegistry  = githubContainerRegistry
+	GitlabContainerRegistry  = gitlabContainerRegistry
+	QuayContainerRegistry    = quayContainerRegistry
+	ElasticContainerRegistry = elasticContainerRegistry
 )
 
 var (
@@ -34,7 +33,7 @@ var (
 	NewTokenTransport                  = newTokenTransport
 	NewElasticContainerRegistryForTest = newElasticContainerRegistryForTest
 	NewAzureContainerRegistry          = newAzureContainerRegistry
-	GetArchitecture                    = getArchitecture
+	GetArchitectures                   = getArchitectures
 	UnwrapNetError                     = unwrapNetError
 )
 

--- a/internal/docker/registry/mocks/registry_mock.go
+++ b/internal/docker/registry/mocks/registry_mock.go
@@ -79,41 +79,41 @@ func (c *MockRegistryCloseCall) DoAndReturn(f func() error) *MockRegistryCloseCa
 	return c
 }
 
-// GetArchitecture mocks base method.
-func (m *MockRegistry) GetArchitecture(arg0, arg1 string) (string, error) {
+// GetArchitectures mocks base method.
+func (m *MockRegistry) GetArchitectures(arg0, arg1 string) ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetArchitecture", arg0, arg1)
-	ret0, _ := ret[0].(string)
+	ret := m.ctrl.Call(m, "GetArchitectures", arg0, arg1)
+	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetArchitecture indicates an expected call of GetArchitecture.
-func (mr *MockRegistryMockRecorder) GetArchitecture(arg0, arg1 any) *MockRegistryGetArchitectureCall {
+// GetArchitectures indicates an expected call of GetArchitectures.
+func (mr *MockRegistryMockRecorder) GetArchitectures(arg0, arg1 any) *MockRegistryGetArchitecturesCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetArchitecture", reflect.TypeOf((*MockRegistry)(nil).GetArchitecture), arg0, arg1)
-	return &MockRegistryGetArchitectureCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetArchitectures", reflect.TypeOf((*MockRegistry)(nil).GetArchitectures), arg0, arg1)
+	return &MockRegistryGetArchitecturesCall{Call: call}
 }
 
-// MockRegistryGetArchitectureCall wrap *gomock.Call
-type MockRegistryGetArchitectureCall struct {
+// MockRegistryGetArchitecturesCall wrap *gomock.Call
+type MockRegistryGetArchitecturesCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockRegistryGetArchitectureCall) Return(arg0 string, arg1 error) *MockRegistryGetArchitectureCall {
+func (c *MockRegistryGetArchitecturesCall) Return(arg0 []string, arg1 error) *MockRegistryGetArchitecturesCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockRegistryGetArchitectureCall) Do(f func(string, string) (string, error)) *MockRegistryGetArchitectureCall {
+func (c *MockRegistryGetArchitecturesCall) Do(f func(string, string) ([]string, error)) *MockRegistryGetArchitecturesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockRegistryGetArchitectureCall) DoAndReturn(f func(string, string) (string, error)) *MockRegistryGetArchitectureCall {
+func (c *MockRegistryGetArchitecturesCall) DoAndReturn(f func(string, string) ([]string, error)) *MockRegistryGetArchitecturesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/service/pebble/identity/doc.go
+++ b/internal/service/pebble/identity/doc.go
@@ -1,0 +1,8 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package identity defines the various types to work with the Pebble identities file.
+//
+// This is a subset of the types in github.com/canonical/pebble/cmd,
+// copied directly from that repository.
+package identity

--- a/internal/service/pebble/identity/identities.go
+++ b/internal/service/pebble/identity/identities.go
@@ -1,0 +1,34 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package identity
+
+type IdentitiesFile struct {
+	Identities map[string]*Identity `json:"identities" yaml:"identities"`
+}
+
+// Identity holds the configuration of a single identity.
+type Identity struct {
+	Access IdentityAccess `json:"access" yaml:"access"`
+
+	// One or more of the following type-specific configuration fields must be
+	// non-nil (currently the only type is "local").
+	Local *LocalIdentity `json:"local,omitempty" yaml:"local,omitempty"`
+}
+
+// IdentityAccess defines the access level for an identity.
+type IdentityAccess string
+
+const (
+	AdminAccess     IdentityAccess = "admin"
+	ReadAccess      IdentityAccess = "read"
+	UntrustedAccess IdentityAccess = "untrusted"
+)
+
+// LocalIdentity holds identity configuration specific to the "local" type
+// (for ucrednet/UID authentication).
+type LocalIdentity struct {
+	// This is a pointer so we can distinguish between not set and 0 (a valid
+	// user-id meaning root).
+	UserID *uint32 `json:"user-id" yaml:"user-id"`
+}

--- a/internal/worker/caasapplicationprovisioner/ops.go
+++ b/internal/worker/caasapplicationprovisioner/ops.go
@@ -214,13 +214,9 @@ func appAlive(ctx context.Context, appName string, app caas.Application,
 	case charm.RunAsRoot:
 		config.CharmUser = caas.RunAsRoot
 	case charm.RunAsSudoer:
-		// TODO(pebble): once pebble supports auth, allow running as non-root.
-		//config.CharmUser = caas.RunAsSudoer
-		config.CharmUser = caas.RunAsRoot
+		config.CharmUser = caas.RunAsSudoer
 	case charm.RunAsNonRoot:
-		// TODO(pebble): once pebble supports auth, allow running as non-root.
-		//config.CharmUser = caas.RunAsNonRoot
-		config.CharmUser = caas.RunAsRoot
+		config.CharmUser = caas.RunAsNonRoot
 	default:
 		return errors.NotValidf("unknown RunAs for CharmUser: %q", ch.Meta().CharmUser)
 	}

--- a/testcharms/charms/sidecar-non-root/hooks/install
+++ b/testcharms/charms/sidecar-non-root/hooks/install
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+status-set maintenance "Setup..."
+juju-log "charm=$UID"
+juju-log "sudo=$(sudo -n echo yes || echo no)"

--- a/testcharms/charms/sidecar-non-root/hooks/rootful-pebble-ready
+++ b/testcharms/charms/sidecar-non-root/hooks/rootful-pebble-ready
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+export PEBBLE_SOCKET=/charm/containers/rootful/pebble.socket
+juju-log "rootful=$(/charm/bin/pebble exec -- bash -c 'echo $UID')"
+
+touch /charm/containers/rootful/ready
+if [ -f "/charm/containers/rootless/ready" ]; then
+    status-set active "Ready."
+fi

--- a/testcharms/charms/sidecar-non-root/hooks/rootless-pebble-ready
+++ b/testcharms/charms/sidecar-non-root/hooks/rootless-pebble-ready
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+export PEBBLE_SOCKET=/charm/containers/rootless/pebble.socket
+juju-log "rootless=$(/charm/bin/pebble exec -- bash -c 'echo $UID')"
+
+touch /charm/containers/rootless/ready
+if [ -f "/charm/containers/rootful/ready" ]; then
+    status-set active "Ready."
+fi

--- a/testcharms/charms/sidecar-non-root/hooks/upgrade-charm
+++ b/testcharms/charms/sidecar-non-root/hooks/upgrade-charm
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+status-set maintenance "Setup..."
+juju-log "charm=$UID"
+juju-log "sudo=$(sudo -n echo yes || echo no)"

--- a/testcharms/charms/sidecar-non-root/manifest.yaml
+++ b/testcharms/charms/sidecar-non-root/manifest.yaml
@@ -1,0 +1,6 @@
+bases:
+  - name: ubuntu
+    channel: 22.04/stable
+    architectures:
+      - amd64
+      - arm64

--- a/testcharms/charms/sidecar-non-root/metadata.yaml
+++ b/testcharms/charms/sidecar-non-root/metadata.yaml
@@ -1,0 +1,15 @@
+name: sidecar-non-root
+summary: sidecar charm with rootless charm and workloads
+description: ""
+containers:
+  rootful:
+    resource: ubuntu
+  rootless:
+    resource: ubuntu
+    uid: 10000
+    gid: 10000
+resources:
+  ubuntu:
+    type: oci-image
+    description: OCI image used for test containers
+charm-user: non-root

--- a/testcharms/charms/sidecar-sudoer/hooks/install
+++ b/testcharms/charms/sidecar-sudoer/hooks/install
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+status-set maintenance "Setup..."
+juju-log "charm=$UID"
+juju-log "sudo=$(sudo -n echo yes || echo no)"

--- a/testcharms/charms/sidecar-sudoer/hooks/rootful-pebble-ready
+++ b/testcharms/charms/sidecar-sudoer/hooks/rootful-pebble-ready
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+export PEBBLE_SOCKET=/charm/containers/rootful/pebble.socket
+juju-log "rootful=$(/charm/bin/pebble exec -- bash -c 'echo $UID')"
+
+touch /charm/containers/rootful/ready
+if [ -f "/charm/containers/rootless/ready" ]; then
+    status-set active "Ready."
+fi

--- a/testcharms/charms/sidecar-sudoer/hooks/rootless-pebble-ready
+++ b/testcharms/charms/sidecar-sudoer/hooks/rootless-pebble-ready
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+export PEBBLE_SOCKET=/charm/containers/rootless/pebble.socket
+juju-log "rootless=$(/charm/bin/pebble exec -- bash -c 'echo $UID')"
+
+touch /charm/containers/rootless/ready
+if [ -f "/charm/containers/rootful/ready" ]; then
+    status-set active "Ready."
+fi

--- a/testcharms/charms/sidecar-sudoer/hooks/upgrade-charm
+++ b/testcharms/charms/sidecar-sudoer/hooks/upgrade-charm
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+status-set maintenance "Setup..."
+juju-log "charm=$UID"
+juju-log "sudo=$(sudo -n echo yes || echo no)"

--- a/testcharms/charms/sidecar-sudoer/manifest.yaml
+++ b/testcharms/charms/sidecar-sudoer/manifest.yaml
@@ -1,0 +1,6 @@
+bases:
+  - name: ubuntu
+    channel: 22.04/stable
+    architectures:
+      - amd64
+      - arm64

--- a/testcharms/charms/sidecar-sudoer/metadata.yaml
+++ b/testcharms/charms/sidecar-sudoer/metadata.yaml
@@ -1,0 +1,15 @@
+name: sidecar-sudoer
+summary: sidecar charm with rootless charm and workloads
+description: ""
+containers:
+  rootful:
+    resource: ubuntu
+  rootless:
+    resource: ubuntu
+    uid: 10000
+    gid: 10000
+resources:
+  ubuntu:
+    type: oci-image
+    description: OCI image used for test containers
+charm-user: sudoer

--- a/tests/suites/cloud_azure/managed_identity.sh
+++ b/tests/suites/cloud_azure/managed_identity.sh
@@ -48,6 +48,7 @@ run_custom_managed_identity() {
 	identity_name=jmid
 	cred_name=${AZURE_CREDENTIAL_NAME:-credentials}
 	subscription=$(juju show-credential --client azure "${cred_name}" | yq .client-credentials.azure."${cred_name}".content.subscription-id)
+	az account set -s "${subscription}"
 
 	add_clean_func "run_cleanup_azure"
 	az group create --name "${group}" --location westus

--- a/tests/suites/sidecar/rootless.sh
+++ b/tests/suites/sidecar/rootless.sh
@@ -1,0 +1,57 @@
+run_non_root_charm() {
+	echo
+
+	file="${TEST_DIR}/test-rootless-non-root-charm.log"
+
+	ensure "test-rootless-non-root-charm" "${file}"
+
+	juju deploy ./testcharms/charms/sidecar-non-root --resource ubuntu=public.ecr.aws/ubuntu/ubuntu:22.04
+
+	wait_for "sidecar-non-root" "$(idle_condition "sidecar-non-root" 0 0)"
+	sleep 10 # wait for logs
+
+	output=$(juju debug-log --replay)
+	check_contains "$output" "charm=170"
+	check_contains "$output" "sudo=no"
+	check_contains "$output" "rootless=10000"
+	check_contains "$output" "rootful=0"
+
+	destroy_model "test-rootless-non-root-charm"
+}
+
+run_sudoer_charm() {
+	echo
+
+	file="${TEST_DIR}/test-rootless-sudoer-charm.log"
+
+	ensure "test-rootless-sudoer-charm" "${file}"
+
+	juju deploy ./testcharms/charms/sidecar-sudoer --resource ubuntu=public.ecr.aws/ubuntu/ubuntu:22.04
+
+	wait_for "sidecar-sudoer" "$(idle_condition "sidecar-sudoer" 0 0)"
+	sleep 10 # wait for logs
+
+	output=$(juju debug-log --replay)
+	check_contains "$output" "charm=171"
+	check_contains "$output" "sudo=yes"
+	check_contains "$output" "rootless=10000"
+	check_contains "$output" "rootful=0"
+
+	destroy_model "test-rootless-sudoer-charm"
+}
+
+test_rootless() {
+	if [ "$(skip 'test_rootless')" ]; then
+		echo "==> TEST SKIPPED: test_rootless"
+		return
+	fi
+
+	(
+		set_verbosity
+
+		cd .. || exit
+
+		run "run_non_root_charm"
+		run "run_sudoer_charm"
+	)
+}

--- a/tests/suites/sidecar/task.sh
+++ b/tests/suites/sidecar/task.sh
@@ -12,6 +12,7 @@ test_sidecar() {
 		test_deploy_and_force_remove_application
 		test_pebble_notices
 		test_pebble_checks
+		test_rootless
 		;;
 	*)
 		echo "==> TEST SKIPPED: sidecar charm tests, not a k8s provider"

--- a/tests/suites/static_analysis/licence.sh
+++ b/tests/suites/static_analysis/licence.sh
@@ -11,7 +11,7 @@ test_licence() {
 	fi
 	if ! which go-licenses >/dev/null 2>&1; then
 		echo "==> TEST SKIPPED: static licence analysis (go-licenses not installed)"
-		exit 0
+		return
 	fi
 
 	(


### PR DESCRIPTION
Merges the following patches:
- #17761
- #17768
- #17578
- #17764
- #17763
- #17762
- #17760
- #17745
- #17486

### Conflicts
- apiserver/facades/client/client/client.go
- apiserver/facades/client/client/client_test.go
- apiserver/facades/client/controller/controller.go
- apiserver/facades/client/controller/controller_test.go
- apiserver/facades/client/controller/destroy_test.go
- apiserver/facades/client/controller/register.go
- apiserver/facades/client/modelupgrader/upgrader_test.go
- caas/kubernetes/provider/application/application_test.go
- cmd/containeragent/initialize/command.go
- cmd/containeragent/initialize/package_test.go
- cmd/juju/metricsdebug/collectmetrics.go
- cmd/juju/metricsdebug/metrics.go
- cmd/juju/waitfor/waitfor.go
- docker/registry/mocks/registry_mock.go
- go.mod
- go.sum
