### PR TITLE
fix(bootstrap): fix bug causing bootstrap to fail

### DIFF
--- a/internal/worker/bootstrap/doc.go
+++ b/internal/worker/bootstrap/doc.go
@@ -4,12 +4,19 @@
 // Package bootstrap ensures that when the initial bootstrap process
 // has started that we seed the following:
 //
-//  1. The agent binary is seeded into the objectstore.
-//  2. The controller application has been created, along with the supporting
+//  1. The macaroon config keypairs are generated.
+//  2. The initial juju-metrics user is registered.
+//  3. The agent binary is seeded into the objectstore.
+//  4. The initial storage pools are created.
+//  5. The controller application has been created, along with the supporting
 //     machine and spaces.
-//  3. The controller charm is seeded into the objectstore.
+//  6. The controller charm is seeded into the objectstore.
+//  7. Finally, set a flag to indicate bootstrap has been completed
 //
 // The intention is that the worker is started as soon as possible during
 // bootstrap and that it will uninstall itself once the bootstrap process
 // has completed.
+//
+// If any of these steps fail, the bootstrap worker will restart. So it is
+// important that seeding processes are idempotent.
 package bootstrap

--- a/internal/worker/bootstrap/worker.go
+++ b/internal/worker/bootstrap/worker.go
@@ -20,6 +20,7 @@ import (
 	"github.com/juju/juju/core/permission"
 	usererrors "github.com/juju/juju/domain/access/errors"
 	userservice "github.com/juju/juju/domain/access/service"
+	macaroonerrors "github.com/juju/juju/domain/macaroon/errors"
 	domainstorage "github.com/juju/juju/domain/storage"
 	storageerrors "github.com/juju/juju/domain/storage/errors"
 	storageservice "github.com/juju/juju/domain/storage/service"
@@ -279,7 +280,11 @@ func (w *bootstrapWorker) loop() error {
 }
 
 func (w *bootstrapWorker) seedMacaroonConfig(ctx context.Context) error {
-	return w.cfg.BakeryConfigService.InitialiseBakeryConfig(ctx)
+	err := w.cfg.BakeryConfigService.InitialiseBakeryConfig(ctx)
+	if errors.Is(err, macaroonerrors.BakeryConfigAlreadyInitialised) {
+		return nil
+	}
+	return errors.Trace(err)
 }
 
 func (w *bootstrapWorker) seedInitialUsers(ctx context.Context) error {


### PR DESCRIPTION
We sometimes we've been seeing "bakery config already intialised" errors when bootstraping from the bootstrap worker.

It seems like this is caused by errors further down the workers, causing it to restart.

The bootstrap worker needs to be idempotent. If we see the bakery has already been seeded, we should just continue.

Update doc.go to include the new aspects of state that are seeded, as well as a note to ensure seeding processes are idempotent

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Repeat a few times
```
$ juju bootstrap lxd lxd
```