### PR TITLE
fix: do not emit hook context ID

### DIFF
--- a/worker/uniter/runner/runner.go
+++ b/worker/uniter/runner/runner.go
@@ -719,7 +719,7 @@ func (runner *runner) startJujucServer(token string, rMode runMode) (*jujuc.Serv
 	// Prepare server.
 	getCmd := func(ctxId, cmdName string) (cmd.Command, error) {
 		if ctxId != runner.context.Id() {
-			return nil, errors.Errorf("expected context id %q, got %q", runner.context.Id(), ctxId)
+			return nil, errors.Errorf("wrong context ID; got %q", ctxId)
 		}
 		return jujuc.NewCommand(runner.context, cmdName)
 	}

--- a/worker/uniter/runner/runner.go
+++ b/worker/uniter/runner/runner.go
@@ -108,11 +108,41 @@ type Runner interface {
 }
 
 // NewRunnerFunc returns a func used to create a Runner backed by the supplied context and paths.
-type NewRunnerFunc func(context context.Context, paths context.Paths, remoteExecutor ExecFunc) Runner
+type NewRunnerFunc func(context context.Context, paths context.Paths, remoteExecutor ExecFunc, options ...Option) Runner
+
+// Option is a functional option for NewRunner.
+type Option func(*options)
+
+type options struct {
+	tokenGenerator TokenGenerator
+}
+
+// WithTokenGenerator returns an Option that sets the token generator for the
+// runner.
+func WithTokenGenerator(tg TokenGenerator) Option {
+	return func(o *options) {
+		o.tokenGenerator = tg
+	}
+}
+
+func newOptions() *options {
+	return &options{
+		tokenGenerator: &tokenGenerator{},
+	}
+}
 
 // NewRunner returns a Runner backed by the supplied context and paths.
-func NewRunner(context context.Context, paths context.Paths, remoteExecutor ExecFunc) Runner {
-	return &runner{context, paths, remoteExecutor}
+func NewRunner(context context.Context, paths context.Paths, remoteExecutor ExecFunc, options ...Option) Runner {
+	opts := newOptions()
+	for _, option := range options {
+		option(opts)
+	}
+	return &runner{
+		context:        context,
+		paths:          paths,
+		remoteExecutor: remoteExecutor,
+		tokenGenerator: opts.tokenGenerator,
+	}
 }
 
 // ExecParams holds all the necessary parameters for ExecFunc.
@@ -152,12 +182,21 @@ func execOnMachine(params ExecParams) (*utilexec.ExecResponse, error) {
 // ExecFunc is the exec func type.
 type ExecFunc func(ExecParams) (*utilexec.ExecResponse, error)
 
+// TokenGenerator is the interface for generating tokens.
+type TokenGenerator interface {
+	// Generate generates a token based on the remote flag.
+	// If remote is false, it returns an empty string. Otherwise, it returns a
+	// random token.
+	Generate(remote bool) (string, error)
+}
+
 // runner implements Runner.
 type runner struct {
 	context context.Context
 	paths   context.Paths
 	// remoteExecutor executes commands on a remote workload pod for CAAS.
 	remoteExecutor ExecFunc
+	tokenGenerator TokenGenerator
 }
 
 func (runner *runner) logger() loggo.Logger {
@@ -207,14 +246,11 @@ func (runner *runner) RunCommands(commands string, runLocation RunLocation) (*ut
 // runCommandsWithTimeout is a helper to abstract common code between run commands and
 // juju-run as an action
 func (runner *runner) runCommandsWithTimeout(commands string, timeout time.Duration, clock clock.Clock, rMode runMode, abort <-chan struct{}) (*utilexec.ExecResponse, error) {
-	var err error
-	token := ""
-	if rMode == runOnRemote {
-		token, err = utils.RandomPassword()
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
+	token, err := runner.tokenGenerator.Generate(rMode == runOnRemote)
+	if err != nil {
+		return nil, errors.Trace(err)
 	}
+
 	srv, err := runner.startJujucServer(token, rMode)
 	if err != nil {
 		return nil, err
@@ -387,13 +423,11 @@ func (runner *runner) RunHook(hookName string) (HookHandlerType, error) {
 }
 
 func (runner *runner) runCharmHookWithLocation(hookName, charmLocation string, rMode runMode) (hookHandlerType HookHandlerType, err error) {
-	token := ""
-	if rMode == runOnRemote {
-		token, err = utils.RandomPassword()
-		if err != nil {
-			return InvalidHookHandler, errors.Trace(err)
-		}
+	token, err := runner.tokenGenerator.Generate(rMode == runOnRemote)
+	if err != nil {
+		return InvalidHookHandler, errors.Trace(err)
 	}
+
 	srv, err := runner.startJujucServer(token, rMode)
 	if err != nil {
 		return InvalidHookHandler, errors.Trace(err)
@@ -788,4 +822,20 @@ type hookProcess struct {
 
 func (p hookProcess) Pid() int {
 	return p.Process.Pid
+}
+
+type tokenGenerator struct{}
+
+// Generate generates a token based on the remote flag.
+// If remote is false, it returns an empty string. Otherwise, it returns a
+// random token.
+func (t *tokenGenerator) Generate(remote bool) (string, error) {
+	if !remote {
+		return "", nil
+	}
+	token, err := utils.RandomPassword()
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	return token, nil
 }

--- a/worker/uniter/util_test.go
+++ b/worker/uniter/util_test.go
@@ -551,7 +551,7 @@ func (s startUniter) step(c *gc.C, ctx *testContext) {
 		MachineLock:          processLock,
 		UpdateStatusSignal:   ctx.updateStatusHookTicker.ReturnTimer(),
 		NewOperationExecutor: operationExecutor,
-		NewProcessRunner: func(context runnercontext.Context, paths runnercontext.Paths, remoteExecutor runner.ExecFunc) runner.Runner {
+		NewProcessRunner: func(context runnercontext.Context, paths runnercontext.Paths, remoteExecutor runner.ExecFunc, options ...runner.Option) runner.Runner {
 			ctx.runner.ctx = context
 			return ctx.runner
 		},


### PR DESCRIPTION
Fixes a potential exploit where a user can run a bash loop attempting to execute hook tools. 

If running while another hook is executing, we log an error with the context ID, making it possible for the user to then use that ID in a following call successfully.

This means an unprivileged user can access anything available via a hook tool such as config, relation data and secrets.

## QA steps
- Bootstrap and deploy ubuntu.
- In one terminal, run `juju ssh 0`, and be ready to run commands here.
- In another terminal, run `juju run --unit ubuntu/0 -- sleep 10` to invoke a running hook context.
- Back in the SSH terminal, run `JUJU_AGENT_SOCKET_NETWORK=unix JUJU_AGENT_SOCKET_ADDRESS=@/var/lib/juju/agents/unit-ubuntu-0/agent.socket JUJU_CONTEXT_ID=0 /var/lib/juju/tools/unit-ubuntu-0/config-get`.
- The returned error should not indicate the running context ID:
`ERROR bad request: wrong context ID; got "0"`

## Links

**Jira card:** [JUJU-6394](https://warthogs.atlassian.net/browse/JUJU-6394)



[JUJU-6394]: https://warthogs.atlassian.net/browse/JUJU-6394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ