### PR TITLE
fix(migration): empty map compared to nil map for credential equality

### DIFF
--- a/state/cloudcredentials_test.go
+++ b/state/cloudcredentials_test.go
@@ -79,7 +79,7 @@ func (s *CloudCredentialsSuite) TestUpdateCloudCredentialsExisting(c *gc.C) {
 	err := s.State.AddCloud(cloud.Cloud{
 		Name:      "stratus",
 		Type:      "low",
-		AuthTypes: cloud.AuthTypes{cloud.AccessKeyAuthType, cloud.UserPassAuthType},
+		AuthTypes: cloud.AuthTypes{cloud.AccessKeyAuthType, cloud.UserPassAuthType, cloud.EmptyAuthType},
 	}, s.Owner.Name())
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -111,8 +111,15 @@ func (s *CloudCredentialsSuite) TestUpdateCloudCredentialsExisting(c *gc.C) {
 	expected.Cloud = "stratus"
 	expected.Name = "foobar"
 	expected.Revoked = true
-
 	c.Assert(out, jc.DeepEquals, expected)
+
+	// Pass an empty map to check it is returned as a nil map.
+	cred = cloud.NewCredential(cloud.EmptyAuthType, map[string]string{})
+	err = s.State.UpdateCloudCredential(tag, cred)
+	c.Assert(err, jc.ErrorIsNil)
+	out, err = s.State.CloudCredential(tag)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(out.Attributes, gc.IsNil)
 }
 
 func assertCredentialCreated(c *gc.C, testSuite ConnSuite) (string, *state.User, names.CloudCredentialTag) {

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -113,7 +113,7 @@ func (ctrl *Controller) Import(model description.Model) (_ *Model, _ *State, err
 			if existingCreds.AuthType != creds.AuthType() {
 				return nil, nil, errors.Errorf("credential auth type mismatch: %q != %q", existingCreds.AuthType, creds.AuthType())
 			}
-			if !reflect.DeepEqual(existingCreds.Attributes, creds.Attributes()) {
+			if !credentialAttributesMatch(existingCreds.Attributes, creds.Attributes()) {
 				return nil, nil, errors.Errorf("credential attribute mismatch: %v != %v", existingCreds.Attributes, creds.Attributes())
 			}
 			if existingCreds.Revoked {
@@ -251,6 +251,13 @@ func (ctrl *Controller) Import(model description.Model) (_ *Model, _ *State, err
 
 	logger.Debugf("import success")
 	return dbModel, newSt, nil
+}
+
+func credentialAttributesMatch(a map[string]string, b map[string]string) bool {
+	if len(a) == 0 && len(b) == 0 {
+		return true
+	}
+	return reflect.DeepEqual(a, b)
 }
 
 // modelConfig creates a config for the model being imported.


### PR DESCRIPTION
When model migrating a manual cloud model, if the empty credentials are updated they won't match due to a nil map being compared to an empty map for equality.

```
machine-0: 21:45:06 ERROR juju.worker.migrationmaster.4709bc migration model data transfer failed, failed to import model into target controller: credential attribute mismatch: map[] != map[]
machine-0: 21:45:06 INFO juju.worker.migrationmaster.4709bc migration setting migration phase to ABORT
machine-0: 21:45:06 INFO juju.worker.migrationmaster.4709bc migration aborted, removing model from target controller: model data transfer failed, failed to import model into target controller: credential attribute mismatch: map[] != map[]
```

## QA steps

- Bootstrap two lxd controllers
- `juju bootstrap lxd a` && `juju bootstrap lxd b`
- `juju add-cloud -f cloud.yaml --controller a --force`
- `juju add-cloud -f cloud.yaml --controller b --force`
- `juju update-credential --controller a -f credential.yaml`
- `juju update-credential --controller b -f credential.yaml`
- `juju update-credential --controller b -f credential.yaml # yes do it twice for controller b`
- `juju add-model m m --credential m --controller a`
- `juju migrate a:admin/m b`
- Migration should succeed to target controller. 

```yaml
# cloud.yaml
clouds:
  m:
    type: manual
    auth-types: [empty]
    endpoint: 1.2.3.4
    regions:
      default: {}
```
```yaml
# credential.yaml
credentials:
  m:
    m:
      auth-type: empty
```


## Documentation changes

N/A

## Links

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2073570

**Jira card:** JUJU-

