### PR TITLE
test: fix TestSeriesTools to use a supported series even on noble

### DIFF
--- a/apiserver/common/tools_test.go
+++ b/apiserver/common/tools_test.go
@@ -129,7 +129,7 @@ func (s *getToolsSuite) TestSeriesTools(c *gc.C) {
 
 	current := coretesting.CurrentVersion()
 	currentCopy := current
-	currentCopy.Release = coretesting.HostSeries(c)
+	currentCopy.Release = "jammy"
 	configAttrs := map[string]interface{}{
 		"name":                 "some-name",
 		"type":                 "some-type",


### PR DESCRIPTION
Fixes TestSeriesTools to pass when running on noble.

```
tools_test.go:160:
    result, err := tg.Tools(args)
/home/jenkins/go/pkg/mod/go.uber.org/mock@v0.2.0/gomock/controller.go:165:
    h.t.Fatalf(format, args...)
... Error: Unexpected call to *mocks.MockToolsFinder.FindTools([{2.9.50 -1 -1 amd64  noble }]) at /home/jenkins/go/src/github.com/juju/juju/apiserver/common/tools.go:177 because: 
expected call at /home/jenkins/go/src/github.com/juju/juju/apiserver/common/tools_test.go:145 doesn't match the argument at index 0.
Got: {2.9.50 -1 -1 amd64  noble } (params.FindToolsParams)
Want: is equal to {2.9.50 -1 -1 amd64 noble  } (params.FindToolsParams)
```

## QA steps

Run unit test

## Documentation changes

N/A

## Links

https://jenkins.juju.canonical.com/job/github-make-check-juju/16331/consoleText

