### PR TITLE
ci: remove installed lxd for 2.9

### DIFF
--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -45,6 +45,12 @@ jobs:
         if: env.RUN_TEST == 'RUN'
         uses: actions/checkout@v3
 
+      - name: Remove LXD
+        if: env.RUN_TEST == 'RUN'
+        run: |
+          set -euxo pipefail
+          sudo snap remove lxd --purge
+
       - name: Setup LXD
         if: env.RUN_TEST == 'RUN' && matrix.model_type == 'localhost'
         uses: canonical/setup-lxd@90d76101915da56a42a562ba766b1a77019242fd


### PR DESCRIPTION
Noble runner uses lxd 5.21. Downgrading lxd fails. This removes lxd with purge before installing it.

## QA steps

Check lxd upgrade action

