### PR TITLE
feat: ensure core/arch package for charms

### DIFF
--- a/core/arch/arches.go
+++ b/core/arch/arches.go
@@ -50,11 +50,11 @@ func (a Arches) String() string {
 
 // The following constants define the machine architectures supported by Juju.
 const (
-	AMD64   = "amd64"
-	ARM64   = "arm64"
-	PPC64EL = "ppc64el"
-	S390X   = "s390x"
-	RISCV64 = "riscv64"
+	AMD64   Arch = "amd64"
+	ARM64   Arch = "arm64"
+	PPC64EL Arch = "ppc64el"
+	S390X   Arch = "s390x"
+	RISCV64 Arch = "riscv64"
 )
 
 // AllSupportedArches records the machine architectures recognised by Juju.
@@ -69,7 +69,7 @@ var AllSupportedArches = []string{
 // UnsupportedArches records the machine architectures not supported by Juju.
 // Note: don't make const to prevent referencing it.
 var UnsupportedArches = []string{
-	"i386", "armhf", "ppc",
+	"i386", "arm", "armhf", "ppc",
 }
 
 // archREs maps regular expressions for matching
@@ -79,7 +79,7 @@ var archREs = []struct {
 	arch string
 }{
 	{Regexp: regexp.MustCompile("amd64|x86_64"), arch: AMD64},
-	{Regexp: regexp.MustCompile("aarch64"), arch: ARM64},
+	{Regexp: regexp.MustCompile("arm64|aarch64"), arch: ARM64},
 	{Regexp: regexp.MustCompile("ppc64|ppc64el|ppc64le"), arch: PPC64EL},
 	{Regexp: regexp.MustCompile("s390x"), arch: S390X},
 	{Regexp: regexp.MustCompile("riscv64|risc$|risc-[vV]64"), arch: RISCV64},

--- a/core/arch/arches_test.go
+++ b/core/arch/arches_test.go
@@ -47,7 +47,6 @@ func (s *archSuite) TestNormaliseArch(c *gc.C) {
 		{raw: "x86_64", arch: "amd64"},
 		{raw: "arm64", arch: "arm64"},
 		{raw: "aarch64", arch: "arm64"},
-		{raw: "arm64", arch: "arm64"},
 		{raw: "ppc64el", arch: "ppc64el"},
 		{raw: "ppc64le", arch: "ppc64el"},
 		{raw: "s390x", arch: "s390x"},

--- a/core/arch/arches_test.go
+++ b/core/arch/arches_test.go
@@ -43,17 +43,18 @@ func (s *archSuite) TestNormaliseArch(c *gc.C) {
 		raw  string
 		arch string
 	}{
-		{"amd64", "amd64"},
-		{"x86_64", "amd64"},
-		{"aarch64", "arm64"},
-		{"arm64", "arm64"},
-		{"ppc64el", "ppc64el"},
-		{"ppc64le", "ppc64el"},
-		{"s390x", "s390x"},
-		{"riscv64", "riscv64"},
-		{"risc", "riscv64"},
-		{"risc-v64", "riscv64"},
-		{"risc-V64", "riscv64"},
+		{raw: "amd64", arch: "amd64"},
+		{raw: "x86_64", arch: "amd64"},
+		{raw: "arm64", arch: "arm64"},
+		{raw: "aarch64", arch: "arm64"},
+		{raw: "arm64", arch: "arm64"},
+		{raw: "ppc64el", arch: "ppc64el"},
+		{raw: "ppc64le", arch: "ppc64el"},
+		{raw: "s390x", arch: "s390x"},
+		{raw: "riscv64", arch: "riscv64"},
+		{raw: "risc", arch: "riscv64"},
+		{raw: "risc-v64", arch: "riscv64"},
+		{raw: "risc-V64", arch: "riscv64"},
 	} {
 		arch := arch.NormaliseArch(test.raw)
 		c.Check(arch, gc.Equals, test.arch)

--- a/core/base/package_test.go
+++ b/core/base/package_test.go
@@ -23,6 +23,7 @@ var _ = gc.Suite(&ImportTest{})
 func (*ImportTest) TestImports(c *gc.C) {
 	found := coretesting.FindJujuCoreImports(c, "github.com/juju/juju/core/base")
 	c.Assert(found, jc.SameContents, []string{
+		"core/arch",
 		"core/logger",
 		"internal/charm",
 		"internal/charm/assumes",

--- a/core/os/ostype/ostype.go
+++ b/core/os/ostype/ostype.go
@@ -3,7 +3,11 @@
 
 package ostype
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/juju/errors"
+)
 
 type OSType int
 
@@ -53,21 +57,13 @@ func (t OSType) IsLinux() bool {
 	return false
 }
 
-var validOSTypeNames map[string]OSType
-
-func init() {
-	osTypes := []OSType{
-		Unknown,
-		Ubuntu,
-		Windows,
-		CentOS,
-		GenericLinux,
-		Kubernetes,
-	}
-	validOSTypeNames = make(map[string]OSType)
-	for _, osType := range osTypes {
-		validOSTypeNames[strings.ToLower(osType.String())] = osType
-	}
+var validOSTypeNames = map[string]OSType{
+	"ubuntu":       Ubuntu,
+	"windows":      Windows,
+	"osx":          OSX,
+	"centos":       CentOS,
+	"genericlinux": GenericLinux,
+	"kubernetes":   Kubernetes,
 }
 
 // IsValidOSTypeName returns true if osType is a
@@ -88,4 +84,13 @@ func OSTypeForName(name string) OSType {
 		return os
 	}
 	return Unknown
+}
+
+// ParseOSType parses a string and returns the corresponding OSType.
+func ParseOSType(s string) (OSType, error) {
+	osType, ok := validOSTypeNames[strings.ToLower(s)]
+	if !ok {
+		return Unknown, errors.NotValidf("unknown os type %q", s)
+	}
+	return osType, nil
 }

--- a/core/os/ostype/ostype_test.go
+++ b/core/os/ostype/ostype_test.go
@@ -31,3 +31,29 @@ func (s *osTypeSuite) TestIsLinux(c *gc.C) {
 	c.Check(OSX.EquivalentTo(Windows), jc.IsFalse)
 	c.Check(GenericLinux.EquivalentTo(OSX), jc.IsFalse)
 }
+
+func (s *osTypeSuite) TestString(c *gc.C) {
+	c.Check(Ubuntu.String(), gc.Equals, "Ubuntu")
+	c.Check(Windows.String(), gc.Equals, "Windows")
+	c.Check(Unknown.String(), gc.Equals, "Unknown")
+}
+
+func (s *osTypeSuite) TestParseOSType(c *gc.C) {
+	tests := []struct {
+		str string
+		t   OSType
+	}{
+		{str: "uBuntu", t: Ubuntu},
+		{str: "winDOwS", t: Windows},
+		{str: "OSX", t: OSX},
+		{str: "CentOS", t: CentOS},
+		{str: "GenericLinux", t: GenericLinux},
+		{str: "Kubernetes", t: Kubernetes},
+	}
+	for i, test := range tests {
+		c.Logf("test %d", i)
+		t, err := ParseOSType(test.str)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Check(t, gc.Equals, test.t)
+	}
+}

--- a/core/settings/package_test.go
+++ b/core/settings/package_test.go
@@ -25,6 +25,7 @@ func (*importSuite) TestImports(c *gc.C) {
 
 	// This package only brings in other core packages.
 	c.Assert(found, jc.SameContents, []string{
+		"core/arch",
 		"core/logger",
 		"internal/charm",
 		"internal/charm/assumes",

--- a/domain/application/errors/errors.go
+++ b/domain/application/errors/errors.go
@@ -43,4 +43,12 @@ const (
 	// CharmManifestNotValid describes an error that occurs when the charm manifest
 	// is not valid.
 	CharmManifestNotValid = errors.ConstError("charm manifest not valid")
+
+	// CharmBaseNameNotValid describes an error that occurs when the charm base
+	// name is not valid.
+	CharmBaseNameNotValid = errors.ConstError("charm base name not valid")
+
+	// CharmBaseNameNotSupported describes an error that occurs when the charm
+	// base name is not supported.
+	CharmBaseNameNotSupported = errors.ConstError("charm base name not supported")
 )

--- a/domain/application/service/charm_test.go
+++ b/domain/application/service/charm_test.go
@@ -322,12 +322,13 @@ func (s *charmServiceSuite) TestSetCharm(c *gc.C) {
 		Revision: 1,
 	}).Return(id, nil)
 
-	got, err := s.service.SetCharm(context.Background(), domaincharm.SetCharmArgs{
+	got, warnings, err := s.service.SetCharm(context.Background(), domaincharm.SetCharmArgs{
 		Charm:    s.charm,
 		Source:   internalcharm.Local,
 		Revision: 1,
 	})
 	c.Assert(err, jc.ErrorIsNil)
+	c.Check(warnings, gc.HasLen, 0)
 	c.Check(got, gc.DeepEquals, id)
 }
 
@@ -336,7 +337,7 @@ func (s *charmServiceSuite) TestSetCharmNoName(c *gc.C) {
 
 	s.charm.EXPECT().Meta().Return(&internalcharm.Meta{})
 
-	_, err := s.service.SetCharm(context.Background(), domaincharm.SetCharmArgs{
+	_, _, err := s.service.SetCharm(context.Background(), domaincharm.SetCharmArgs{
 		Charm:    s.charm,
 		Source:   internalcharm.Local,
 		Revision: 1,
@@ -351,7 +352,7 @@ func (s *charmServiceSuite) TestSetCharmInvalidSource(c *gc.C) {
 		Name: "foo",
 	})
 
-	_, err := s.service.SetCharm(context.Background(), domaincharm.SetCharmArgs{
+	_, _, err := s.service.SetCharm(context.Background(), domaincharm.SetCharmArgs{
 		Charm:    s.charm,
 		Source:   "charmstore",
 		Revision: 1,

--- a/domain/application/service/manifest.go
+++ b/domain/application/service/manifest.go
@@ -8,7 +8,9 @@ import (
 	"strings"
 
 	"github.com/juju/collections/set"
+
 	corearch "github.com/juju/juju/core/arch"
+	"github.com/juju/juju/core/os/ostype"
 	"github.com/juju/juju/domain/application/charm"
 	applicationerrors "github.com/juju/juju/domain/application/errors"
 	internalcharm "github.com/juju/juju/internal/charm"
@@ -113,6 +115,17 @@ func encodeManifestBases(bases []internalcharm.Base) ([]charm.Base, []string, er
 }
 
 func encodeManifestBase(base internalcharm.Base) (charm.Base, []string, error) {
+	if base.Name == "" {
+		return charm.Base{}, nil, applicationerrors.CharmBaseNameNotValid
+	}
+	// Juju only supports Ubuntu bases.
+	baseType, err := ostype.ParseOSType(base.Name)
+	if err != nil {
+		return charm.Base{}, nil, fmt.Errorf("parse base name: %w", err)
+	} else if baseType != ostype.Ubuntu {
+		return charm.Base{}, nil, applicationerrors.CharmBaseNameNotSupported
+	}
+
 	channel, err := encodeManifestChannel(base.Channel)
 	if err != nil {
 		return charm.Base{}, nil, fmt.Errorf("encode channel: %w", err)

--- a/domain/application/watcher_test.go
+++ b/domain/application/watcher_test.go
@@ -47,7 +47,7 @@ func (s *watcherSuite) TestWatchCharm(c *gc.C) {
 
 	var id corecharm.ID
 	harness.AddTest(func(c *gc.C) {
-		id, err = svc.SetCharm(context.Background(), charm.SetCharmArgs{
+		id, _, err = svc.SetCharm(context.Background(), charm.SetCharmArgs{
 			Charm:    &stubCharm{},
 			Source:   internalcharm.CharmHub,
 			Revision: 1,

--- a/internal/charm/base.go
+++ b/internal/charm/base.go
@@ -9,7 +9,8 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/os/v2"
-	"github.com/juju/utils/v4/arch"
+
+	"github.com/juju/juju/core/arch"
 )
 
 // Base represents an OS/Channel.

--- a/internal/charm/base.go
+++ b/internal/charm/base.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
-	"github.com/juju/os/v2"
 
 	"github.com/juju/juju/core/arch"
 )
@@ -26,19 +25,9 @@ func (b Base) Validate() error {
 	if b.Name == "" {
 		return errors.NotValidf("base without name")
 	}
-
-	if b.Name != strings.ToLower(os.Ubuntu.String()) {
-		return errors.NotValidf("os %q", b.Name)
-	}
 	if b.Channel.Empty() {
 		return errors.NotValidf("channel")
 	}
-	for _, v := range b.Architectures {
-		if !arch.IsSupportedArch(v) {
-			return errors.NotValidf("architecture %q", v)
-		}
-	}
-
 	return nil
 }
 

--- a/internal/charm/base_test.go
+++ b/internal/charm/base_test.go
@@ -33,21 +33,6 @@ func (s *baseSuite) TestParseBase(c *gc.C) {
 			parsedBase: charm.Base{},
 			err:        `base string must contain exactly one @. "ubuntu" not valid`,
 		}, {
-			str:        "windows",
-			parsedBase: charm.Base{},
-			err:        `base string must contain exactly one @. "windows" not valid`,
-		}, {
-			str:        "mythicalos@channel",
-			parsedBase: charm.Base{},
-			err:        `invalid base string "mythicalos@channel": os "mythicalos" not valid`,
-		}, {
-			str:        "ubuntu@20.04/stable",
-			parsedBase: charm.Base{Name: strings.ToLower(os.Ubuntu.String()), Channel: mustParseChannel("20.04/stable")},
-		}, {
-			str:        "windows@win10/stable",
-			parsedBase: charm.Base{},
-			err:        `invalid base string "windows@win10/stable": os "windows" not valid`,
-		}, {
 			str:        "ubuntu@20.04/edge",
 			parsedBase: charm.Base{Name: strings.ToLower(os.Ubuntu.String()), Channel: mustParseChannel("20.04/edge")},
 		},
@@ -58,7 +43,7 @@ func (s *baseSuite) TestParseBase(c *gc.C) {
 		if v.err != "" {
 			c.Check(err, gc.ErrorMatches, v.err, comment)
 		} else {
-			c.Check(err, jc.ErrorIsNil, comment)
+			c.Assert(err, jc.ErrorIsNil, comment)
 		}
 		c.Check(s, jc.DeepEquals, v.parsedBase, comment)
 	}
@@ -70,25 +55,8 @@ func (s *baseSuite) TestParseBaseWithArchitectures(c *gc.C) {
 		baseString string
 		archs      []string
 		parsedBase charm.Base
-		err        string
 	}{
 		{
-			baseString: "ubuntu@",
-			str:        "ubuntu on amd64",
-			archs:      []string{"amd64"},
-			parsedBase: charm.Base{},
-			err:        `invalid base string "ubuntu@" with architectures "amd64": channel not valid`,
-		}, {
-			baseString: "ubuntu@",
-			str:        "ubuntu",
-			parsedBase: charm.Base{},
-			err:        `invalid base string "ubuntu@": channel not valid`,
-		}, {
-			baseString: "mythicalos@channel",
-			str:        "mythicalos",
-			parsedBase: charm.Base{},
-			err:        `invalid base string "mythicalos@channel": os "mythicalos" not valid`,
-		}, {
 			baseString: "ubuntu@20.04/stable",
 			archs:      []string{arch.AMD64, "ppc64"},
 			str:        "ubuntu@20.04/stable on amd64, ppc64el",
@@ -96,22 +64,14 @@ func (s *baseSuite) TestParseBaseWithArchitectures(c *gc.C) {
 				Name:          strings.ToLower(os.Ubuntu.String()),
 				Channel:       mustParseChannel("20.04/stable"),
 				Architectures: []string{arch.AMD64, arch.PPC64EL}},
-		}, {
-			baseString: "ubuntu@24.04/stable",
-			archs:      []string{"testme"},
-			str:        "ubuntu@24.04/stable",
-			parsedBase: charm.Base{},
-			err:        `invalid base string "ubuntu@24.04/stable" with architectures "testme": architecture "testme" not valid`,
 		},
 	}
 	for i, v := range tests {
 		comment := gc.Commentf("test %d", i)
 		s, err := charm.ParseBase(v.baseString, v.archs...)
-		if v.err != "" {
-			c.Check(err, gc.ErrorMatches, v.err, comment)
-		} else {
-			c.Check(err, jc.ErrorIsNil, comment)
-		}
+
+		c.Assert(err, jc.ErrorIsNil, comment)
+
 		c.Check(s, jc.DeepEquals, v.parsedBase, comment)
 	}
 }

--- a/internal/charm/base_test.go
+++ b/internal/charm/base_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/juju/os/v2"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/v4/arch"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/core/arch"
 	"github.com/juju/juju/internal/charm"
 )
 

--- a/internal/charm/doc.go
+++ b/internal/charm/doc.go
@@ -1,0 +1,10 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package charm represents the wire protocol for the charm.
+//
+// This whole package should be relocated to api/charm and rpc/charm.
+//
+// There is lots of business logic in the charm package, but this should be
+// strangled out and moved to the domain/application package.
+package charm

--- a/internal/charm/manifest.go
+++ b/internal/charm/manifest.go
@@ -8,8 +8,9 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/schema"
-	"github.com/juju/utils/v4/arch"
 	"gopkg.in/yaml.v2"
+
+	"github.com/juju/juju/core/arch"
 )
 
 // Manifest represents the recording of the building of the charm or bundle.

--- a/internal/charm/url.go
+++ b/internal/charm/url.go
@@ -13,7 +13,8 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/mgo/v3/bson"
-	"github.com/juju/utils/v4/arch"
+
+	"github.com/juju/juju/core/arch"
 )
 
 // Schema represents the different types of valid schemas.


### PR DESCRIPTION
The internal/charm package was using the utils/arch package, which is deprecated. Update the charm package to use the right core package. This means we will do the validation of the manifest file for business logic (anything that isn't just checking for empty strings and valid construction) inside the application domain. The internal/charm package should just be the wire protocol of a charm. When saving the charm to state, this will be checked for the correct architecture.

This PR was split out from  #17779 to make it easier to see what is happening. This means that clients using the charm package will not get full errors without interrogating the server. As in, the business logic is moved to one location and that's the application domain. Simple checks for empty values or nil values are fine. This is an ongoing moving of logic, just the manifest file is done now.

<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://docs.google.com/document/d/1SYUo9G7qZ_jdoVXpUVamS5VCgHmtZ0QA-wZxKoMS-C0 
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
$ juju bootstrap lxd test
$ juju add-model default
$ juju deploy ubuntu
```

```sh
$ juju bootstrap aws test --bootstrap-constraints="arch=arm64 cores=4 mem=16G"
$ juju add-model default
$ juju set-model-constraints arch=arm64
$ juju deploy ubuntu
```

## Links

**Jira card:** [JUJU-6016](https://warthogs.atlassian.net/browse/JUJU-6016)



[JUJU-6016]: https://warthogs.atlassian.net/browse/JUJU-6016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ