### PR TITLE
feat(apiserver): add contexts to permissions checks

### DIFF
--- a/apiserver/authentication/interfaces.go
+++ b/apiserver/authentication/interfaces.go
@@ -61,7 +61,7 @@ type AuthParams struct {
 type PermissionDelegator interface {
 	// SubjectPermissions returns the permission the entity has for the
 	// specified subject.
-	SubjectPermissions(entity Entity, subject names.Tag) (permission.Access, error)
+	SubjectPermissions(ctx context.Context, entity Entity, subject names.Tag) (permission.Access, error)
 
 	// PermissionError is a helper implemented by the Authenticator for
 	// returning the appropriate error when an authenticated entity is missing
@@ -80,7 +80,7 @@ type EntityAuthenticator interface {
 //
 // If this returns an error, the handler should return StatusForbidden.
 type Authorizer interface {
-	Authorize(AuthInfo) error
+	Authorize(context.Context, AuthInfo) error
 }
 
 // Entity represents a user, machine, or unit that might be
@@ -126,10 +126,10 @@ type RequestAuthenticator interface {
 // SubjectPermissions is a convenience wrapper around the AuthInfo permissions
 // delegator. errors.NotImplemented is returned if the permission delegator
 // on this AuthInfo is nil.
-func (a *AuthInfo) SubjectPermissions(subject names.Tag) (permission.Access, error) {
+func (a *AuthInfo) SubjectPermissions(ctx context.Context, subject names.Tag) (permission.Access, error) {
 	if a.Delegator == nil {
 		return permission.NoAccess, fmt.Errorf("permissions delegator %w", errors.NotImplemented)
 	}
 
-	return a.Delegator.SubjectPermissions(a.Entity, subject)
+	return a.Delegator.SubjectPermissions(ctx, a.Entity, subject)
 }

--- a/apiserver/authentication/jwt/jwt.go
+++ b/apiserver/authentication/jwt/jwt.go
@@ -110,6 +110,7 @@ func (t TokenEntity) Tag() names.Tag {
 
 // SubjectPermissions implements PermissionDelegator
 func (p *PermissionDelegator) SubjectPermissions(
+	_ context.Context,
 	e authentication.Entity,
 	subject names.Tag,
 ) (a permission.Access, err error) {

--- a/apiserver/authentication/jwt/jwt_test.go
+++ b/apiserver/authentication/jwt/jwt_test.go
@@ -103,15 +103,15 @@ func (s *loginTokenSuite) TestUsesLoginToken(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(authInfo.Entity.Tag().String(), gc.Equals, "user-fred")
-	perm, err := authInfo.SubjectPermissions(modelTag)
+	perm, err := authInfo.SubjectPermissions(context.Background(), modelTag)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(perm, gc.Equals, permission.WriteAccess)
 
-	perm, err = authInfo.SubjectPermissions(testing.ControllerTag)
+	perm, err = authInfo.SubjectPermissions(context.Background(), testing.ControllerTag)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(perm, gc.Equals, permission.LoginAccess)
 
-	perm, err = authInfo.SubjectPermissions(applicationOfferTag)
+	perm, err = authInfo.SubjectPermissions(context.Background(), applicationOfferTag)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(perm, gc.Equals, permission.ConsumeAccess)
 }
@@ -147,7 +147,7 @@ func (s *loginTokenSuite) TestPermissionsForDifferentEntity(c *gc.C) {
 	badUser := jwt.TokenEntity{
 		User: names.NewUserTag("wallyworld"),
 	}
-	perm, err := authInfo.Delegator.SubjectPermissions(badUser, modelTag)
+	perm, err := authInfo.Delegator.SubjectPermissions(context.Background(), badUser, modelTag)
 	c.Assert(err, jc.ErrorIs, apiservererrors.ErrPerm)
 	c.Assert(err, jc.ErrorIs, authentication.ErrorEntityMissingPermission)
 	c.Assert(perm, gc.Equals, permission.NoAccess)
@@ -155,7 +155,7 @@ func (s *loginTokenSuite) TestPermissionsForDifferentEntity(c *gc.C) {
 	badUser = jwt.TokenEntity{
 		User: names.NewUserTag(common.EveryoneTagName),
 	}
-	perm, err = authInfo.Delegator.SubjectPermissions(badUser, modelTag)
+	perm, err = authInfo.Delegator.SubjectPermissions(context.Background(), badUser, modelTag)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(perm, gc.Equals, permission.NoAccess)
 }
@@ -183,7 +183,7 @@ func (s *loginTokenSuite) TestControllerSuperuser(c *gc.C) {
 
 	c.Assert(authInfo.Entity.Tag().String(), gc.Equals, "user-fred")
 
-	perm, err := authInfo.SubjectPermissions(testing.ControllerTag)
+	perm, err := authInfo.SubjectPermissions(context.Background(), testing.ControllerTag)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(perm, gc.Equals, permission.SuperuserAccess)
 }

--- a/apiserver/common/charms/appcharminfo_test.go
+++ b/apiserver/common/charms/appcharminfo_test.go
@@ -75,7 +75,7 @@ func (s *appCharmInfoSuite) TestPermissionDenied(c *gc.C) {
 
 	authorizer := facademocks.NewMockAuthorizer(ctrl)
 	authorizer.EXPECT().AuthController().Return(false)
-	authorizer.EXPECT().HasPermission(permission.ReadAccess, modelTag).
+	authorizer.EXPECT().HasPermission(gomock.Any(), permission.ReadAccess, modelTag).
 		Return(errors.WithType(apiservererrors.ErrPerm, authentication.ErrorEntityMissingPermission))
 
 	// Make the ApplicationCharmInfo call

--- a/apiserver/common/charms/charminfo_test.go
+++ b/apiserver/common/charms/charminfo_test.go
@@ -70,7 +70,7 @@ func (s *charmInfoSuite) TestPermissionDenied(c *gc.C) {
 
 	authorizer := facademocks.NewMockAuthorizer(ctrl)
 	authorizer.EXPECT().AuthController().Return(false)
-	authorizer.EXPECT().HasPermission(permission.ReadAccess, modelTag).
+	authorizer.EXPECT().HasPermission(gomock.Any(), permission.ReadAccess, modelTag).
 		Return(errors.WithType(apiservererrors.ErrPerm, authentication.ErrorEntityMissingPermission))
 
 	// Make the CharmInfo call

--- a/apiserver/common/charms/common.go
+++ b/apiserver/common/charms/common.go
@@ -48,7 +48,7 @@ type CharmInfoAPI struct {
 	state      State
 }
 
-func checkCanRead(authorizer facade.Authorizer, state State) error {
+func checkCanRead(ctx context.Context, authorizer facade.Authorizer, state State) error {
 	model, err := state.Model()
 	if err != nil {
 		return errors.Trace(err)
@@ -56,7 +56,7 @@ func checkCanRead(authorizer facade.Authorizer, state State) error {
 	if authorizer.AuthController() {
 		return nil
 	}
-	return errors.Trace(authorizer.HasPermission(permission.ReadAccess, model.ModelTag()))
+	return errors.Trace(authorizer.HasPermission(ctx, permission.ReadAccess, model.ModelTag()))
 }
 
 // NewCharmInfoAPI provides the signature required for facade registration.
@@ -70,7 +70,7 @@ func NewCharmInfoAPI(st State, authorizer facade.Authorizer) (*CharmInfoAPI, err
 // CharmInfo returns information about the requested charm.
 // NOTE: thumper 2016-06-29, this is not a bulk call and probably should be.
 func (a *CharmInfoAPI) CharmInfo(ctx context.Context, args params.CharmURL) (params.Charm, error) {
-	if err := checkCanRead(a.authorizer, a.state); err != nil {
+	if err := checkCanRead(ctx, a.authorizer, a.state); err != nil {
 		return params.Charm{}, errors.Trace(err)
 	}
 
@@ -98,7 +98,7 @@ func NewApplicationCharmInfoAPI(st State, authorizer facade.Authorizer) (*Applic
 
 // ApplicationCharmInfo fetches charm information for an application.
 func (a *ApplicationCharmInfoAPI) ApplicationCharmInfo(ctx context.Context, args params.Entity) (params.Charm, error) {
-	if err := checkCanRead(a.authorizer, a.state); err != nil {
+	if err := checkCanRead(ctx, a.authorizer, a.state); err != nil {
 		return params.Charm{}, errors.Trace(err)
 	}
 

--- a/apiserver/common/leadership.go
+++ b/apiserver/common/leadership.go
@@ -90,7 +90,7 @@ type LeadershipPinning struct {
 func (a *LeadershipPinning) PinnedLeadership(ctx context.Context) (params.PinnedLeadershipResult, error) {
 	result := params.PinnedLeadershipResult{}
 
-	err := a.authorizer.HasPermission(permission.ReadAccess, a.modelTag)
+	err := a.authorizer.HasPermission(ctx, permission.ReadAccess, a.modelTag)
 	if err != nil {
 		return result, errors.Trace(err)
 	}

--- a/apiserver/common/modelstatus.go
+++ b/apiserver/common/modelstatus.go
@@ -46,7 +46,7 @@ func (c *ModelStatusAPI) ModelStatus(ctx context.Context, req params.Entities) (
 	models := req.Entities
 	status := make([]params.ModelStatus, len(models))
 	for i, model := range models {
-		modelStatus, err := c.modelStatus(model.Tag)
+		modelStatus, err := c.modelStatus(ctx, model.Tag)
 		if err != nil {
 			status[i].Error = apiservererrors.ServerError(err)
 			continue
@@ -56,7 +56,7 @@ func (c *ModelStatusAPI) ModelStatus(ctx context.Context, req params.Entities) (
 	return params.ModelStatusResults{Results: status}, nil
 }
 
-func (c *ModelStatusAPI) modelStatus(tag string) (params.ModelStatus, error) {
+func (c *ModelStatusAPI) modelStatus(ctx context.Context, tag string) (params.ModelStatus, error) {
 	var status params.ModelStatus
 	modelTag, err := names.ParseModelTag(tag)
 	if err != nil {
@@ -76,7 +76,7 @@ func (c *ModelStatusAPI) modelStatus(tag string) (params.ModelStatus, error) {
 	if err != nil {
 		return status, errors.Trace(err)
 	}
-	isAdmin, err := HasModelAdmin(c.authorizer, c.backend.ControllerTag(), model.ModelTag())
+	isAdmin, err := HasModelAdmin(ctx, c.authorizer, c.backend.ControllerTag(), model.ModelTag())
 	if err != nil {
 		return status, errors.Trace(err)
 	}

--- a/apiserver/common/permissions.go
+++ b/apiserver/common/permissions.go
@@ -4,6 +4,8 @@
 package common
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 
@@ -102,12 +104,13 @@ func GetPermission(accessGetter UserAccessFunc, userTag names.UserTag, target na
 // A user has model access if they are a controller superuser,
 // or if they have been explicitly granted admin access to the model.
 func HasModelAdmin(
+	ctx context.Context,
 	authorizer facade.Authorizer,
 	controllerTag names.ControllerTag,
 	modelTag names.ModelTag,
 ) (bool, error) {
 	// superusers have admin for all models.
-	err := authorizer.HasPermission(permission.SuperuserAccess, controllerTag)
+	err := authorizer.HasPermission(ctx, permission.SuperuserAccess, controllerTag)
 	if err != nil && !errors.Is(err, authentication.ErrorEntityMissingPermission) {
 		return false, err
 	}
@@ -116,7 +119,7 @@ func HasModelAdmin(
 		return true, nil
 	}
 
-	err = authorizer.HasPermission(permission.AdminAccess, modelTag)
+	err = authorizer.HasPermission(ctx, permission.AdminAccess, modelTag)
 	if err != nil && !errors.Is(err, authentication.ErrorEntityMissingPermission) {
 		return false, err
 	}

--- a/apiserver/common/permissions_test.go
+++ b/apiserver/common/permissions_test.go
@@ -4,6 +4,8 @@
 package common_test
 
 import (
+	"context"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 	jc "github.com/juju/testing/checkers"
@@ -247,9 +249,9 @@ func (r *PermissionSuite) TestHasModelAdminSuperUser(c *gc.C) {
 	defer ctrl.Finish()
 
 	auth := mocks.NewMockAuthorizer(ctrl)
-	auth.EXPECT().HasPermission(permission.SuperuserAccess, testing.ControllerTag).Return(nil)
+	auth.EXPECT().HasPermission(gomock.Any(), permission.SuperuserAccess, testing.ControllerTag).Return(nil)
 
-	has, err := common.HasModelAdmin(auth, testing.ControllerTag, testing.ModelTag)
+	has, err := common.HasModelAdmin(context.Background(), auth, testing.ControllerTag, testing.ModelTag)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(has, jc.IsTrue)
 }
@@ -259,10 +261,10 @@ func (r *PermissionSuite) TestHasModelAdminYes(c *gc.C) {
 	defer ctrl.Finish()
 
 	auth := mocks.NewMockAuthorizer(ctrl)
-	auth.EXPECT().HasPermission(permission.SuperuserAccess, testing.ControllerTag).Return(authentication.ErrorEntityMissingPermission)
-	auth.EXPECT().HasPermission(permission.AdminAccess, testing.ModelTag).Return(nil)
+	auth.EXPECT().HasPermission(gomock.Any(), permission.SuperuserAccess, testing.ControllerTag).Return(authentication.ErrorEntityMissingPermission)
+	auth.EXPECT().HasPermission(gomock.Any(), permission.AdminAccess, testing.ModelTag).Return(nil)
 
-	has, err := common.HasModelAdmin(auth, testing.ControllerTag, testing.ModelTag)
+	has, err := common.HasModelAdmin(context.Background(), auth, testing.ControllerTag, testing.ModelTag)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(has, jc.IsTrue)
 }
@@ -272,10 +274,10 @@ func (r *PermissionSuite) TestHasModelAdminNo(c *gc.C) {
 	defer ctrl.Finish()
 
 	auth := mocks.NewMockAuthorizer(ctrl)
-	auth.EXPECT().HasPermission(permission.SuperuserAccess, testing.ControllerTag).Return(authentication.ErrorEntityMissingPermission)
-	auth.EXPECT().HasPermission(permission.AdminAccess, testing.ModelTag).Return(authentication.ErrorEntityMissingPermission)
+	auth.EXPECT().HasPermission(gomock.Any(), permission.SuperuserAccess, testing.ControllerTag).Return(authentication.ErrorEntityMissingPermission)
+	auth.EXPECT().HasPermission(gomock.Any(), permission.AdminAccess, testing.ModelTag).Return(authentication.ErrorEntityMissingPermission)
 
-	has, err := common.HasModelAdmin(auth, testing.ControllerTag, testing.ModelTag)
+	has, err := common.HasModelAdmin(context.Background(), auth, testing.ControllerTag, testing.ModelTag)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(has, jc.IsFalse)
 }
@@ -285,11 +287,11 @@ func (r *PermissionSuite) TestHasModelAdminError(c *gc.C) {
 	defer ctrl.Finish()
 
 	auth := mocks.NewMockAuthorizer(ctrl)
-	auth.EXPECT().HasPermission(permission.SuperuserAccess, testing.ControllerTag).Return(authentication.ErrorEntityMissingPermission)
+	auth.EXPECT().HasPermission(gomock.Any(), permission.SuperuserAccess, testing.ControllerTag).Return(authentication.ErrorEntityMissingPermission)
 	someError := errors.New("error")
-	auth.EXPECT().HasPermission(permission.AdminAccess, testing.ModelTag).Return(someError)
+	auth.EXPECT().HasPermission(gomock.Any(), permission.AdminAccess, testing.ModelTag).Return(someError)
 
-	has, err := common.HasModelAdmin(auth, testing.ControllerTag, testing.ModelTag)
+	has, err := common.HasModelAdmin(context.Background(), auth, testing.ControllerTag, testing.ModelTag)
 	c.Assert(err, jc.ErrorIs, someError)
 	c.Assert(has, jc.IsFalse)
 }

--- a/apiserver/common/secrets/mocks/authorizer_mock.go
+++ b/apiserver/common/secrets/mocks/authorizer_mock.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	permission "github.com/juju/juju/core/permission"
@@ -345,17 +346,17 @@ func (c *MockAuthorizerConnectedModelCall) DoAndReturn(f func() string) *MockAut
 }
 
 // EntityHasPermission mocks base method.
-func (m *MockAuthorizer) EntityHasPermission(arg0 names.Tag, arg1 permission.Access, arg2 names.Tag) error {
+func (m *MockAuthorizer) EntityHasPermission(arg0 context.Context, arg1 names.Tag, arg2 permission.Access, arg3 names.Tag) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EntityHasPermission", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "EntityHasPermission", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // EntityHasPermission indicates an expected call of EntityHasPermission.
-func (mr *MockAuthorizerMockRecorder) EntityHasPermission(arg0, arg1, arg2 any) *MockAuthorizerEntityHasPermissionCall {
+func (mr *MockAuthorizerMockRecorder) EntityHasPermission(arg0, arg1, arg2, arg3 any) *MockAuthorizerEntityHasPermissionCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EntityHasPermission", reflect.TypeOf((*MockAuthorizer)(nil).EntityHasPermission), arg0, arg1, arg2)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EntityHasPermission", reflect.TypeOf((*MockAuthorizer)(nil).EntityHasPermission), arg0, arg1, arg2, arg3)
 	return &MockAuthorizerEntityHasPermissionCall{Call: call}
 }
 
@@ -371,13 +372,13 @@ func (c *MockAuthorizerEntityHasPermissionCall) Return(arg0 error) *MockAuthoriz
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockAuthorizerEntityHasPermissionCall) Do(f func(names.Tag, permission.Access, names.Tag) error) *MockAuthorizerEntityHasPermissionCall {
+func (c *MockAuthorizerEntityHasPermissionCall) Do(f func(context.Context, names.Tag, permission.Access, names.Tag) error) *MockAuthorizerEntityHasPermissionCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockAuthorizerEntityHasPermissionCall) DoAndReturn(f func(names.Tag, permission.Access, names.Tag) error) *MockAuthorizerEntityHasPermissionCall {
+func (c *MockAuthorizerEntityHasPermissionCall) DoAndReturn(f func(context.Context, names.Tag, permission.Access, names.Tag) error) *MockAuthorizerEntityHasPermissionCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -421,17 +422,17 @@ func (c *MockAuthorizerGetAuthTagCall) DoAndReturn(f func() names.Tag) *MockAuth
 }
 
 // HasPermission mocks base method.
-func (m *MockAuthorizer) HasPermission(arg0 permission.Access, arg1 names.Tag) error {
+func (m *MockAuthorizer) HasPermission(arg0 context.Context, arg1 permission.Access, arg2 names.Tag) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HasPermission", arg0, arg1)
+	ret := m.ctrl.Call(m, "HasPermission", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // HasPermission indicates an expected call of HasPermission.
-func (mr *MockAuthorizerMockRecorder) HasPermission(arg0, arg1 any) *MockAuthorizerHasPermissionCall {
+func (mr *MockAuthorizerMockRecorder) HasPermission(arg0, arg1, arg2 any) *MockAuthorizerHasPermissionCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasPermission", reflect.TypeOf((*MockAuthorizer)(nil).HasPermission), arg0, arg1)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasPermission", reflect.TypeOf((*MockAuthorizer)(nil).HasPermission), arg0, arg1, arg2)
 	return &MockAuthorizerHasPermissionCall{Call: call}
 }
 
@@ -447,13 +448,13 @@ func (c *MockAuthorizerHasPermissionCall) Return(arg0 error) *MockAuthorizerHasP
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockAuthorizerHasPermissionCall) Do(f func(permission.Access, names.Tag) error) *MockAuthorizerHasPermissionCall {
+func (c *MockAuthorizerHasPermissionCall) Do(f func(context.Context, permission.Access, names.Tag) error) *MockAuthorizerHasPermissionCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockAuthorizerHasPermissionCall) DoAndReturn(f func(permission.Access, names.Tag) error) *MockAuthorizerHasPermissionCall {
+func (c *MockAuthorizerHasPermissionCall) DoAndReturn(f func(context.Context, permission.Access, names.Tag) error) *MockAuthorizerHasPermissionCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/debuglog.go
+++ b/apiserver/debuglog.go
@@ -105,7 +105,7 @@ func (h *debugLogHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			socket.sendError(errors.Annotate(err, "authentication failed"))
 			return
 		}
-		if err := h.authorizer.Authorize(authInfo); err != nil {
+		if err := h.authorizer.Authorize(req.Context(), authInfo); err != nil {
 			socket.sendError(errors.Annotate(err, "authorization failed"))
 			return
 		}

--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -291,7 +291,7 @@ type Patcher interface {
 }
 
 func AssertHasPermission(c *gc.C, handler *apiHandler, access permission.Access, tag names.Tag, expect bool) {
-	err := handler.HasPermission(access, tag)
+	err := handler.HasPermission(context.Background(), access, tag)
 	c.Assert(err == nil, gc.Equals, expect)
 	if expect {
 		c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facade/interface.go
+++ b/apiserver/facade/interface.go
@@ -270,11 +270,11 @@ type Authorizer interface {
 
 	// HasPermission reports whether the given access is allowed for the given
 	// target by the authenticated entity.
-	HasPermission(operation permission.Access, target names.Tag) error
+	HasPermission(ctx context.Context, operation permission.Access, target names.Tag) error
 
 	// EntityHasPermission reports whether the given access is allowed for the given
 	// target by the given entity.
-	EntityHasPermission(entity names.Tag, operation permission.Access, target names.Tag) error
+	EntityHasPermission(ctx context.Context, entity names.Tag, operation permission.Access, target names.Tag) error
 
 	// ConnectedModel returns the UUID of the model to which the API
 	// connection was made.

--- a/apiserver/facade/mocks/facade_mock.go
+++ b/apiserver/facade/mocks/facade_mock.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	permission "github.com/juju/juju/core/permission"
@@ -483,17 +484,17 @@ func (c *MockAuthorizerConnectedModelCall) DoAndReturn(f func() string) *MockAut
 }
 
 // EntityHasPermission mocks base method.
-func (m *MockAuthorizer) EntityHasPermission(arg0 names.Tag, arg1 permission.Access, arg2 names.Tag) error {
+func (m *MockAuthorizer) EntityHasPermission(arg0 context.Context, arg1 names.Tag, arg2 permission.Access, arg3 names.Tag) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EntityHasPermission", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "EntityHasPermission", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // EntityHasPermission indicates an expected call of EntityHasPermission.
-func (mr *MockAuthorizerMockRecorder) EntityHasPermission(arg0, arg1, arg2 any) *MockAuthorizerEntityHasPermissionCall {
+func (mr *MockAuthorizerMockRecorder) EntityHasPermission(arg0, arg1, arg2, arg3 any) *MockAuthorizerEntityHasPermissionCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EntityHasPermission", reflect.TypeOf((*MockAuthorizer)(nil).EntityHasPermission), arg0, arg1, arg2)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EntityHasPermission", reflect.TypeOf((*MockAuthorizer)(nil).EntityHasPermission), arg0, arg1, arg2, arg3)
 	return &MockAuthorizerEntityHasPermissionCall{Call: call}
 }
 
@@ -509,13 +510,13 @@ func (c *MockAuthorizerEntityHasPermissionCall) Return(arg0 error) *MockAuthoriz
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockAuthorizerEntityHasPermissionCall) Do(f func(names.Tag, permission.Access, names.Tag) error) *MockAuthorizerEntityHasPermissionCall {
+func (c *MockAuthorizerEntityHasPermissionCall) Do(f func(context.Context, names.Tag, permission.Access, names.Tag) error) *MockAuthorizerEntityHasPermissionCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockAuthorizerEntityHasPermissionCall) DoAndReturn(f func(names.Tag, permission.Access, names.Tag) error) *MockAuthorizerEntityHasPermissionCall {
+func (c *MockAuthorizerEntityHasPermissionCall) DoAndReturn(f func(context.Context, names.Tag, permission.Access, names.Tag) error) *MockAuthorizerEntityHasPermissionCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -559,17 +560,17 @@ func (c *MockAuthorizerGetAuthTagCall) DoAndReturn(f func() names.Tag) *MockAuth
 }
 
 // HasPermission mocks base method.
-func (m *MockAuthorizer) HasPermission(arg0 permission.Access, arg1 names.Tag) error {
+func (m *MockAuthorizer) HasPermission(arg0 context.Context, arg1 permission.Access, arg2 names.Tag) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HasPermission", arg0, arg1)
+	ret := m.ctrl.Call(m, "HasPermission", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // HasPermission indicates an expected call of HasPermission.
-func (mr *MockAuthorizerMockRecorder) HasPermission(arg0, arg1 any) *MockAuthorizerHasPermissionCall {
+func (mr *MockAuthorizerMockRecorder) HasPermission(arg0, arg1, arg2 any) *MockAuthorizerHasPermissionCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasPermission", reflect.TypeOf((*MockAuthorizer)(nil).HasPermission), arg0, arg1)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasPermission", reflect.TypeOf((*MockAuthorizer)(nil).HasPermission), arg0, arg1, arg2)
 	return &MockAuthorizerHasPermissionCall{Call: call}
 }
 
@@ -585,13 +586,13 @@ func (c *MockAuthorizerHasPermissionCall) Return(arg0 error) *MockAuthorizerHasP
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockAuthorizerHasPermissionCall) Do(f func(permission.Access, names.Tag) error) *MockAuthorizerHasPermissionCall {
+func (c *MockAuthorizerHasPermissionCall) Do(f func(context.Context, permission.Access, names.Tag) error) *MockAuthorizerHasPermissionCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockAuthorizerHasPermissionCall) DoAndReturn(f func(permission.Access, names.Tag) error) *MockAuthorizerHasPermissionCall {
+func (c *MockAuthorizerHasPermissionCall) DoAndReturn(f func(context.Context, permission.Access, names.Tag) error) *MockAuthorizerHasPermissionCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/agent/secretsdrain/mocks/facade_mock.go
+++ b/apiserver/facades/agent/secretsdrain/mocks/facade_mock.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	permission "github.com/juju/juju/core/permission"
@@ -345,17 +346,17 @@ func (c *MockAuthorizerConnectedModelCall) DoAndReturn(f func() string) *MockAut
 }
 
 // EntityHasPermission mocks base method.
-func (m *MockAuthorizer) EntityHasPermission(arg0 names.Tag, arg1 permission.Access, arg2 names.Tag) error {
+func (m *MockAuthorizer) EntityHasPermission(arg0 context.Context, arg1 names.Tag, arg2 permission.Access, arg3 names.Tag) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EntityHasPermission", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "EntityHasPermission", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // EntityHasPermission indicates an expected call of EntityHasPermission.
-func (mr *MockAuthorizerMockRecorder) EntityHasPermission(arg0, arg1, arg2 any) *MockAuthorizerEntityHasPermissionCall {
+func (mr *MockAuthorizerMockRecorder) EntityHasPermission(arg0, arg1, arg2, arg3 any) *MockAuthorizerEntityHasPermissionCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EntityHasPermission", reflect.TypeOf((*MockAuthorizer)(nil).EntityHasPermission), arg0, arg1, arg2)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EntityHasPermission", reflect.TypeOf((*MockAuthorizer)(nil).EntityHasPermission), arg0, arg1, arg2, arg3)
 	return &MockAuthorizerEntityHasPermissionCall{Call: call}
 }
 
@@ -371,13 +372,13 @@ func (c *MockAuthorizerEntityHasPermissionCall) Return(arg0 error) *MockAuthoriz
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockAuthorizerEntityHasPermissionCall) Do(f func(names.Tag, permission.Access, names.Tag) error) *MockAuthorizerEntityHasPermissionCall {
+func (c *MockAuthorizerEntityHasPermissionCall) Do(f func(context.Context, names.Tag, permission.Access, names.Tag) error) *MockAuthorizerEntityHasPermissionCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockAuthorizerEntityHasPermissionCall) DoAndReturn(f func(names.Tag, permission.Access, names.Tag) error) *MockAuthorizerEntityHasPermissionCall {
+func (c *MockAuthorizerEntityHasPermissionCall) DoAndReturn(f func(context.Context, names.Tag, permission.Access, names.Tag) error) *MockAuthorizerEntityHasPermissionCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -421,17 +422,17 @@ func (c *MockAuthorizerGetAuthTagCall) DoAndReturn(f func() names.Tag) *MockAuth
 }
 
 // HasPermission mocks base method.
-func (m *MockAuthorizer) HasPermission(arg0 permission.Access, arg1 names.Tag) error {
+func (m *MockAuthorizer) HasPermission(arg0 context.Context, arg1 permission.Access, arg2 names.Tag) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HasPermission", arg0, arg1)
+	ret := m.ctrl.Call(m, "HasPermission", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // HasPermission indicates an expected call of HasPermission.
-func (mr *MockAuthorizerMockRecorder) HasPermission(arg0, arg1 any) *MockAuthorizerHasPermissionCall {
+func (mr *MockAuthorizerMockRecorder) HasPermission(arg0, arg1, arg2 any) *MockAuthorizerHasPermissionCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasPermission", reflect.TypeOf((*MockAuthorizer)(nil).HasPermission), arg0, arg1)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasPermission", reflect.TypeOf((*MockAuthorizer)(nil).HasPermission), arg0, arg1, arg2)
 	return &MockAuthorizerHasPermissionCall{Call: call}
 }
 
@@ -447,13 +448,13 @@ func (c *MockAuthorizerHasPermissionCall) Return(arg0 error) *MockAuthorizerHasP
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockAuthorizerHasPermissionCall) Do(f func(permission.Access, names.Tag) error) *MockAuthorizerHasPermissionCall {
+func (c *MockAuthorizerHasPermissionCall) Do(f func(context.Context, permission.Access, names.Tag) error) *MockAuthorizerHasPermissionCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockAuthorizerHasPermissionCall) DoAndReturn(f func(permission.Access, names.Tag) error) *MockAuthorizerHasPermissionCall {
+func (c *MockAuthorizerHasPermissionCall) DoAndReturn(f func(context.Context, permission.Access, names.Tag) error) *MockAuthorizerHasPermissionCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/agent/upgradesteps/facade_mock_test.go
+++ b/apiserver/facades/agent/upgradesteps/facade_mock_test.go
@@ -10,6 +10,7 @@
 package upgradesteps_test
 
 import (
+	context "context"
 	reflect "reflect"
 
 	permission "github.com/juju/juju/core/permission"
@@ -483,17 +484,17 @@ func (c *MockAuthorizerConnectedModelCall) DoAndReturn(f func() string) *MockAut
 }
 
 // EntityHasPermission mocks base method.
-func (m *MockAuthorizer) EntityHasPermission(arg0 names.Tag, arg1 permission.Access, arg2 names.Tag) error {
+func (m *MockAuthorizer) EntityHasPermission(arg0 context.Context, arg1 names.Tag, arg2 permission.Access, arg3 names.Tag) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EntityHasPermission", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "EntityHasPermission", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // EntityHasPermission indicates an expected call of EntityHasPermission.
-func (mr *MockAuthorizerMockRecorder) EntityHasPermission(arg0, arg1, arg2 any) *MockAuthorizerEntityHasPermissionCall {
+func (mr *MockAuthorizerMockRecorder) EntityHasPermission(arg0, arg1, arg2, arg3 any) *MockAuthorizerEntityHasPermissionCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EntityHasPermission", reflect.TypeOf((*MockAuthorizer)(nil).EntityHasPermission), arg0, arg1, arg2)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EntityHasPermission", reflect.TypeOf((*MockAuthorizer)(nil).EntityHasPermission), arg0, arg1, arg2, arg3)
 	return &MockAuthorizerEntityHasPermissionCall{Call: call}
 }
 
@@ -509,13 +510,13 @@ func (c *MockAuthorizerEntityHasPermissionCall) Return(arg0 error) *MockAuthoriz
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockAuthorizerEntityHasPermissionCall) Do(f func(names.Tag, permission.Access, names.Tag) error) *MockAuthorizerEntityHasPermissionCall {
+func (c *MockAuthorizerEntityHasPermissionCall) Do(f func(context.Context, names.Tag, permission.Access, names.Tag) error) *MockAuthorizerEntityHasPermissionCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockAuthorizerEntityHasPermissionCall) DoAndReturn(f func(names.Tag, permission.Access, names.Tag) error) *MockAuthorizerEntityHasPermissionCall {
+func (c *MockAuthorizerEntityHasPermissionCall) DoAndReturn(f func(context.Context, names.Tag, permission.Access, names.Tag) error) *MockAuthorizerEntityHasPermissionCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -559,17 +560,17 @@ func (c *MockAuthorizerGetAuthTagCall) DoAndReturn(f func() names.Tag) *MockAuth
 }
 
 // HasPermission mocks base method.
-func (m *MockAuthorizer) HasPermission(arg0 permission.Access, arg1 names.Tag) error {
+func (m *MockAuthorizer) HasPermission(arg0 context.Context, arg1 permission.Access, arg2 names.Tag) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HasPermission", arg0, arg1)
+	ret := m.ctrl.Call(m, "HasPermission", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // HasPermission indicates an expected call of HasPermission.
-func (mr *MockAuthorizerMockRecorder) HasPermission(arg0, arg1 any) *MockAuthorizerHasPermissionCall {
+func (mr *MockAuthorizerMockRecorder) HasPermission(arg0, arg1, arg2 any) *MockAuthorizerHasPermissionCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasPermission", reflect.TypeOf((*MockAuthorizer)(nil).HasPermission), arg0, arg1)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasPermission", reflect.TypeOf((*MockAuthorizer)(nil).HasPermission), arg0, arg1, arg2)
 	return &MockAuthorizerHasPermissionCall{Call: call}
 }
 
@@ -585,13 +586,13 @@ func (c *MockAuthorizerHasPermissionCall) Return(arg0 error) *MockAuthorizerHasP
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockAuthorizerHasPermissionCall) Do(f func(permission.Access, names.Tag) error) *MockAuthorizerHasPermissionCall {
+func (c *MockAuthorizerHasPermissionCall) Do(f func(context.Context, permission.Access, names.Tag) error) *MockAuthorizerHasPermissionCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockAuthorizerHasPermissionCall) DoAndReturn(f func(permission.Access, names.Tag) error) *MockAuthorizerHasPermissionCall {
+func (c *MockAuthorizerHasPermissionCall) DoAndReturn(f func(context.Context, permission.Access, names.Tag) error) *MockAuthorizerHasPermissionCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/client/action/action.go
+++ b/apiserver/facades/client/action/action.go
@@ -69,22 +69,22 @@ func newActionAPI(
 	}, nil
 }
 
-func (a *ActionAPI) checkCanRead() error {
-	return a.authorizer.HasPermission(permission.ReadAccess, a.model.ModelTag())
+func (a *ActionAPI) checkCanRead(ctx context.Context) error {
+	return a.authorizer.HasPermission(ctx, permission.ReadAccess, a.model.ModelTag())
 }
 
-func (a *ActionAPI) checkCanWrite() error {
-	return a.authorizer.HasPermission(permission.WriteAccess, a.model.ModelTag())
+func (a *ActionAPI) checkCanWrite(ctx context.Context) error {
+	return a.authorizer.HasPermission(ctx, permission.WriteAccess, a.model.ModelTag())
 }
 
-func (a *ActionAPI) checkCanAdmin() error {
-	return a.authorizer.HasPermission(permission.AdminAccess, a.model.ModelTag())
+func (a *ActionAPI) checkCanAdmin(ctx context.Context) error {
+	return a.authorizer.HasPermission(ctx, permission.AdminAccess, a.model.ModelTag())
 }
 
 // Actions takes a list of ActionTags, and returns the full Action for
 // each ID.
 func (a *ActionAPI) Actions(ctx context.Context, arg params.Entities) (params.ActionResults, error) {
-	if err := a.checkCanRead(); err != nil {
+	if err := a.checkCanRead(ctx); err != nil {
 		return params.ActionResults{}, errors.Trace(err)
 	}
 
@@ -122,7 +122,7 @@ func (a *ActionAPI) Actions(ctx context.Context, arg params.Entities) (params.Ac
 
 // Cancel attempts to cancel enqueued Actions from running.
 func (a *ActionAPI) Cancel(ctx context.Context, arg params.Entities) (params.ActionResults, error) {
-	if err := a.checkCanWrite(); err != nil {
+	if err := a.checkCanWrite(ctx); err != nil {
 		return params.ActionResults{}, errors.Trace(err)
 	}
 
@@ -172,7 +172,7 @@ func (a *ActionAPI) Cancel(ctx context.Context, arg params.Entities) (params.Act
 // services.
 func (a *ActionAPI) ApplicationsCharmsActions(ctx context.Context, args params.Entities) (params.ApplicationsCharmActionsResults, error) {
 	result := params.ApplicationsCharmActionsResults{Results: make([]params.ApplicationCharmActionsResult, len(args.Entities))}
-	if err := a.checkCanWrite(); err != nil {
+	if err := a.checkCanWrite(ctx); err != nil {
 		return result, errors.Trace(err)
 	}
 

--- a/apiserver/facades/client/action/action_test.go
+++ b/apiserver/facades/client/action/action_test.go
@@ -120,7 +120,7 @@ func (s *actionSuite) TestActions(c *gc.C) {
 			{Receiver: s.mysqlUnit.Tag().String(), Name: "fakeaction", Parameters: map[string]interface{}{"baz": true}},
 		}}
 
-	r, err := s.action.EnqueueOperation(arg)
+	r, err := s.action.EnqueueOperation(context.Background(), arg)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(r.Actions, gc.HasLen, len(arg.Actions))
 
@@ -175,7 +175,7 @@ func (s *actionSuite) TestCancel(c *gc.C) {
 		}},
 	}
 
-	results, err := s.action.EnqueueOperation(tests)
+	results, err := s.action.EnqueueOperation(context.Background(), tests)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Actions, gc.HasLen, 4)
 	for _, res := range results.Actions {
@@ -198,7 +198,7 @@ func (s *actionSuite) TestCancel(c *gc.C) {
 	c.Assert(cancelled.Results, gc.HasLen, 2)
 
 	// Assert the Actions are all in the expected state.
-	operations, err := s.action.ListOperations(params.OperationQueryArgs{
+	operations, err := s.action.ListOperations(context.Background(), params.OperationQueryArgs{
 		Units: []string{
 			s.wordpressUnit.Name(),
 			s.mysqlUnit.Name(),
@@ -233,7 +233,7 @@ func (s *actionSuite) TestAbort(c *gc.C) {
 		}},
 	}
 
-	results, err := s.action.EnqueueOperation(tests)
+	results, err := s.action.EnqueueOperation(context.Background(), tests)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results.Actions, gc.HasLen, 1)
 	c.Assert(results.Actions[0].Error, gc.IsNil)
@@ -261,7 +261,7 @@ func (s *actionSuite) TestAbort(c *gc.C) {
 	c.Assert(cancelled.Results[0].Status, gc.Equals, params.ActionAborting)
 
 	// Assert the Actions are all in the expected state.
-	operations, err := s.action.ListOperations(params.OperationQueryArgs{
+	operations, err := s.action.ListOperations(context.Background(), params.OperationQueryArgs{
 		Units: []string{s.wordpressUnit.Name()},
 	})
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/client/action/operation.go
+++ b/apiserver/facades/client/action/operation.go
@@ -4,6 +4,7 @@
 package action
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -20,8 +21,8 @@ import (
 // EnqueueOperation takes a list of Actions and queues them up to be executed as
 // an operation, each action running as a task on the designated ActionReceiver.
 // We return the ID of the overall operation and each individual task.
-func (a *ActionAPI) EnqueueOperation(arg params.Actions) (params.EnqueuedActions, error) {
-	operationId, actionResults, err := a.enqueue(arg)
+func (a *ActionAPI) EnqueueOperation(ctx context.Context, arg params.Actions) (params.EnqueuedActions, error) {
+	operationId, actionResults, err := a.enqueue(ctx, arg)
 	if err != nil {
 		return params.EnqueuedActions{}, err
 	}
@@ -32,8 +33,8 @@ func (a *ActionAPI) EnqueueOperation(arg params.Actions) (params.EnqueuedActions
 	return results, nil
 }
 
-func (a *ActionAPI) enqueue(arg params.Actions) (string, params.ActionResults, error) {
-	if err := a.checkCanWrite(); err != nil {
+func (a *ActionAPI) enqueue(ctx context.Context, arg params.Actions) (string, params.ActionResults, error) {
+	if err := a.checkCanWrite(ctx); err != nil {
 		return "", params.ActionResults{}, errors.Trace(err)
 	}
 
@@ -126,8 +127,8 @@ func (a *ActionAPI) handleFailedActionEnqueuing(operationID string, response par
 }
 
 // ListOperations fetches the called actions for specified apps/units.
-func (a *ActionAPI) ListOperations(arg params.OperationQueryArgs) (params.OperationResults, error) {
-	if err := a.checkCanRead(); err != nil {
+func (a *ActionAPI) ListOperations(ctx context.Context, arg params.OperationQueryArgs) (params.OperationResults, error) {
+	if err := a.checkCanRead(ctx); err != nil {
 		return params.OperationResults{}, errors.Trace(err)
 	}
 
@@ -211,8 +212,8 @@ func (a *ActionAPI) ListOperations(arg params.OperationQueryArgs) (params.Operat
 }
 
 // Operations fetches the specified operation ids.
-func (a *ActionAPI) Operations(arg params.Entities) (params.OperationResults, error) {
-	if err := a.checkCanRead(); err != nil {
+func (a *ActionAPI) Operations(ctx context.Context, arg params.Entities) (params.OperationResults, error) {
+	if err := a.checkCanRead(ctx); err != nil {
 		return params.OperationResults{}, errors.Trace(err)
 	}
 	results := params.OperationResults{Results: make([]params.OperationResult, len(arg.Entities))}

--- a/apiserver/facades/client/action/operation_test.go
+++ b/apiserver/facades/client/action/operation_test.go
@@ -4,6 +4,7 @@
 package action_test
 
 import (
+	"context"
 	"strconv"
 	"time"
 
@@ -38,7 +39,7 @@ func (s *operationSuite) setupOperations(c *gc.C) {
 			{Receiver: s.mysqlUnit.Tag().String(), Name: "anotherfakeaction", Parameters: map[string]interface{}{}},
 		}}
 
-	r, err := s.action.EnqueueOperation(arg)
+	r, err := s.action.EnqueueOperation(context.Background(), arg)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(r.Actions, gc.HasLen, len(arg.Actions))
 
@@ -68,10 +69,10 @@ func (s *operationSuite) TestListOperationsStatusFilter(c *gc.C) {
 		Actions: []params.Action{
 			{Receiver: s.wordpressUnit.Tag().String(), Name: "fakeaction", Parameters: map[string]interface{}{}},
 		}}
-	_, err := s.action.EnqueueOperation(arg)
+	_, err := s.action.EnqueueOperation(context.Background(), arg)
 	c.Assert(err, jc.ErrorIsNil)
 
-	operations, err := s.action.ListOperations(params.OperationQueryArgs{
+	operations, err := s.action.ListOperations(context.Background(), params.OperationQueryArgs{
 		Status: []string{"running"},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -117,10 +118,10 @@ func (s *operationSuite) TestListOperationsNameFilter(c *gc.C) {
 		Actions: []params.Action{
 			{Receiver: s.wordpressUnit.Tag().String(), Name: "fakeaction", Parameters: map[string]interface{}{}},
 		}}
-	_, err := s.action.EnqueueOperation(arg)
+	_, err := s.action.EnqueueOperation(context.Background(), arg)
 	c.Assert(err, jc.ErrorIsNil)
 
-	operations, err := s.action.ListOperations(params.OperationQueryArgs{
+	operations, err := s.action.ListOperations(context.Background(), params.OperationQueryArgs{
 		ActionNames: []string{"anotherfakeaction"},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -149,10 +150,10 @@ func (s *operationSuite) TestListOperationsAppFilter(c *gc.C) {
 		Actions: []params.Action{
 			{Receiver: s.mysqlUnit.Tag().String(), Name: "fakeaction", Parameters: map[string]interface{}{}},
 		}}
-	_, err := s.action.EnqueueOperation(arg)
+	_, err := s.action.EnqueueOperation(context.Background(), arg)
 	c.Assert(err, jc.ErrorIsNil)
 
-	operations, err := s.action.ListOperations(params.OperationQueryArgs{
+	operations, err := s.action.ListOperations(context.Background(), params.OperationQueryArgs{
 		Applications: []string{"wordpress"},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -187,10 +188,10 @@ func (s *operationSuite) TestListOperationsUnitFilter(c *gc.C) {
 		Actions: []params.Action{
 			{Receiver: s.wordpressUnit.Tag().String(), Name: "fakeaction", Parameters: map[string]interface{}{}},
 		}}
-	_, err := s.action.EnqueueOperation(arg)
+	_, err := s.action.EnqueueOperation(context.Background(), arg)
 	c.Assert(err, jc.ErrorIsNil)
 
-	operations, err := s.action.ListOperations(params.OperationQueryArgs{
+	operations, err := s.action.ListOperations(context.Background(), params.OperationQueryArgs{
 		Units:  []string{"wordpress/0"},
 		Status: []string{"pending"},
 	})
@@ -221,10 +222,10 @@ func (s *operationSuite) TestListOperationsMachineFilter(c *gc.C) {
 				"timeout": 1,
 			}},
 		}}
-	_, err := s.action.EnqueueOperation(arg)
+	_, err := s.action.EnqueueOperation(context.Background(), arg)
 	c.Assert(err, jc.ErrorIsNil)
 
-	operations, err := s.action.ListOperations(params.OperationQueryArgs{
+	operations, err := s.action.ListOperations(context.Background(), params.OperationQueryArgs{
 		Machines: []string{"0"},
 		Status:   []string{"pending"},
 	})
@@ -252,10 +253,10 @@ func (s *operationSuite) TestListOperationsAppAndUnitFilter(c *gc.C) {
 		Actions: []params.Action{
 			{Receiver: s.wordpressUnit.Tag().String(), Name: "fakeaction", Parameters: map[string]interface{}{}},
 		}}
-	_, err := s.action.EnqueueOperation(arg)
+	_, err := s.action.EnqueueOperation(context.Background(), arg)
 	c.Assert(err, jc.ErrorIsNil)
 
-	operations, err := s.action.ListOperations(params.OperationQueryArgs{
+	operations, err := s.action.ListOperations(context.Background(), params.OperationQueryArgs{
 		Applications: []string{"mysql"},
 		Units:        []string{"wordpress/0"},
 		Status:       []string{"running"},
@@ -298,7 +299,7 @@ func (s *operationSuite) TestListOperationsAppAndUnitFilter(c *gc.C) {
 
 func (s *operationSuite) TestOperations(c *gc.C) {
 	s.setupOperations(c)
-	operations, err := s.action.Operations(params.Entities{
+	operations, err := s.action.Operations(context.Background(), params.Entities{
 		Entities: []params.Entity{{Tag: "operation-1"}},
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -391,7 +392,7 @@ func (s *enqueueSuite) TestEnqueueOperation(c *gc.C) {
 			},
 		}}
 
-	r, err := api.EnqueueOperation(arg)
+	r, err := api.EnqueueOperation(context.Background(), arg)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(r.Actions, gc.HasLen, len(arg.Actions))
 	c.Assert(r.Actions[0].Status, gc.Equals, "running")
@@ -434,7 +435,7 @@ func (s *enqueueSuite) TestEnqueueOperationFail(c *gc.C) {
 			{Receiver: "mysql/leader", Name: expectedName, Parameters: map[string]interface{}{}},
 		}}
 
-	r, err := api.EnqueueOperation(arg)
+	r, err := api.EnqueueOperation(context.Background(), arg)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(r.Actions, gc.HasLen, len(arg.Actions))
 	c.Logf("%s", pretty.Sprint(r.Actions))
@@ -481,7 +482,7 @@ func (s *enqueueSuite) TestEnqueueOperationLeadership(c *gc.C) {
 			},
 		}}
 
-	r, err := api.EnqueueOperation(arg)
+	r, err := api.EnqueueOperation(context.Background(), arg)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(r.Actions, gc.HasLen, len(arg.Actions))
 	c.Assert(r.Actions[0].Status, gc.Equals, "running")
@@ -495,7 +496,7 @@ func (s *enqueueSuite) TestEnqueueOperationLeadership(c *gc.C) {
 func (s *enqueueSuite) setupMocks(c *gc.C) *gomock.Controller {
 	ctrl := gomock.NewController(c)
 	s.Authorizer = facademocks.NewMockAuthorizer(ctrl)
-	s.Authorizer.EXPECT().HasPermission(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	s.Authorizer.EXPECT().HasPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	s.Authorizer.EXPECT().AuthClient().Return(true)
 
 	s.model = action.NewMockModel(ctrl)

--- a/apiserver/facades/client/action/run.go
+++ b/apiserver/facades/client/action/run.go
@@ -22,7 +22,7 @@ import (
 // Run the commands specified on the machines identified through the
 // list of machines, units and services.
 func (a *ActionAPI) Run(ctx context.Context, run params.RunParams) (results params.EnqueuedActions, err error) {
-	if err := a.checkCanAdmin(); err != nil {
+	if err := a.checkCanAdmin(ctx); err != nil {
 		return results, err
 	}
 
@@ -47,12 +47,12 @@ func (a *ActionAPI) Run(ctx context.Context, run params.RunParams) (results para
 	if err != nil {
 		return results, errors.Trace(err)
 	}
-	return a.EnqueueOperation(actionParams)
+	return a.EnqueueOperation(ctx, actionParams)
 }
 
 // RunOnAllMachines attempts to run the specified command on all the machines.
 func (a *ActionAPI) RunOnAllMachines(ctx context.Context, run params.RunParams) (results params.EnqueuedActions, err error) {
-	if err := a.checkCanAdmin(); err != nil {
+	if err := a.checkCanAdmin(ctx); err != nil {
 		return results, err
 	}
 
@@ -81,7 +81,7 @@ func (a *ActionAPI) RunOnAllMachines(ctx context.Context, run params.RunParams) 
 	if err != nil {
 		return results, errors.Trace(err)
 	}
-	return a.EnqueueOperation(actionParams)
+	return a.EnqueueOperation(ctx, actionParams)
 }
 
 func (a *ActionAPI) createRunActionsParams(

--- a/apiserver/facades/client/action/run_test.go
+++ b/apiserver/facades/client/action/run_test.go
@@ -136,7 +136,7 @@ func (s *runSuite) TestRunMachineAndApplication(c *gc.C) {
 			Parallel:       &parallel,
 			ExecutionGroup: &executionGroup,
 		})
-	op, err := s.client.EnqueueOperation(arg)
+	op, err := s.client.EnqueueOperation(context.Background(), arg)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(op.Actions, gc.HasLen, 3)
 
@@ -193,7 +193,7 @@ func (s *runSuite) TestRunApplicationWorkload(c *gc.C) {
 			Parallel:        &parallel,
 			ExecutionGroup:  &executionGroup,
 		})
-	op, err := s.client.EnqueueOperation(arg)
+	op, err := s.client.EnqueueOperation(context.Background(), arg)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(op.Actions, gc.HasLen, 2)
 
@@ -239,7 +239,7 @@ func (s *runSuite) TestRunOnAllMachines(c *gc.C) {
 			Parallel:       &parallel,
 			ExecutionGroup: &executionGroup,
 		})
-	op, err := s.client.EnqueueOperation(arg)
+	op, err := s.client.EnqueueOperation(context.Background(), arg)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(op.Actions, gc.HasLen, 3)
 

--- a/apiserver/facades/client/annotations/client.go
+++ b/apiserver/facades/client/annotations/client.go
@@ -30,19 +30,19 @@ type API struct {
 	annotationService AnnotationService
 }
 
-func (api *API) checkCanRead() error {
-	return api.authorizer.HasPermission(permission.ReadAccess, api.modelTag)
+func (api *API) checkCanRead(ctx context.Context) error {
+	return api.authorizer.HasPermission(ctx, permission.ReadAccess, api.modelTag)
 }
 
-func (api *API) checkCanWrite() error {
-	return api.authorizer.HasPermission(permission.WriteAccess, api.modelTag)
+func (api *API) checkCanWrite(ctx context.Context) error {
+	return api.authorizer.HasPermission(ctx, permission.WriteAccess, api.modelTag)
 }
 
 // Get returns annotations for given entities.
 // If annotations cannot be retrieved for a given entity, an error is returned.
 // Each entity is treated independently and, hence, will fail or succeed independently.
 func (api *API) Get(ctx context.Context, args params.Entities) params.AnnotationsGetResults {
-	if err := api.checkCanRead(); err != nil {
+	if err := api.checkCanRead(ctx); err != nil {
 		result := make([]params.AnnotationsGetResult, len(args.Entities))
 		for i := range result {
 			result[i].Error = params.ErrorResult{Error: apiservererrors.ServerError(err)}
@@ -65,7 +65,7 @@ func (api *API) Get(ctx context.Context, args params.Entities) params.Annotation
 
 // Set stores annotations for given entities
 func (api *API) Set(ctx context.Context, args params.AnnotationsSet) params.ErrorResults {
-	if err := api.checkCanWrite(); err != nil {
+	if err := api.checkCanWrite(ctx); err != nil {
 		errorResults := make([]params.ErrorResult, len(args.Annotations))
 		for i := range errorResults {
 			errorResults[i].Error = apiservererrors.ServerError(err)

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -291,18 +291,18 @@ func NewAPIBase(
 	}, nil
 }
 
-func (api *APIBase) checkCanRead() error {
-	return api.authorizer.HasPermission(permission.ReadAccess, api.model.ModelTag())
+func (api *APIBase) checkCanRead(ctx context.Context) error {
+	return api.authorizer.HasPermission(ctx, permission.ReadAccess, api.model.ModelTag())
 }
 
-func (api *APIBase) checkCanWrite() error {
-	return api.authorizer.HasPermission(permission.WriteAccess, api.model.ModelTag())
+func (api *APIBase) checkCanWrite(ctx context.Context) error {
+	return api.authorizer.HasPermission(ctx, permission.WriteAccess, api.model.ModelTag())
 }
 
 // Deploy fetches the charms from the charm store and deploys them
 // using the specified placement directives.
 func (api *APIBase) Deploy(ctx context.Context, args params.ApplicationsDeploy) (params.ErrorResults, error) {
-	if err := api.checkCanWrite(); err != nil {
+	if err := api.checkCanWrite(ctx); err != nil {
 		return params.ErrorResults{}, errors.Trace(err)
 	}
 	result := params.ErrorResults{
@@ -900,7 +900,7 @@ func (api *APIv19) SetCharm(ctx context.Context, argsV1 params.ApplicationSetCha
 
 // SetCharm sets the charm for a given for the application.
 func (api *APIBase) SetCharm(ctx context.Context, args params.ApplicationSetCharmV2) error {
-	if err := api.checkCanWrite(); err != nil {
+	if err := api.checkCanWrite(ctx); err != nil {
 		return err
 	}
 
@@ -1171,7 +1171,7 @@ func charmConfigFromConfigValues(yamlContents map[string]interface{}) (charm.Set
 // GetCharmURLOrigin returns the charm URL and charm origin the given
 // application is running at present.
 func (api *APIBase) GetCharmURLOrigin(ctx context.Context, args params.ApplicationGet) (params.CharmURLOriginResult, error) {
-	if err := api.checkCanWrite(); err != nil {
+	if err := api.checkCanWrite(ctx); err != nil {
 		return params.CharmURLOriginResult{}, errors.Trace(err)
 	}
 	oneApplication, err := api.backend.Application(args.ApplicationName)
@@ -1221,7 +1221,7 @@ func makeParamsCharmOrigin(origin *state.CharmOrigin) (params.CharmOrigin, error
 // CharmRelations implements the server side of Application.CharmRelations.
 func (api *APIBase) CharmRelations(ctx context.Context, p params.ApplicationCharmRelations) (params.ApplicationCharmRelationsResults, error) {
 	var results params.ApplicationCharmRelationsResults
-	if err := api.checkCanRead(); err != nil {
+	if err := api.checkCanRead(ctx); err != nil {
 		return results, errors.Trace(err)
 	}
 
@@ -1243,7 +1243,7 @@ func (api *APIBase) CharmRelations(ctx context.Context, p params.ApplicationChar
 // Expose changes the juju-managed firewall to expose any ports that
 // were also explicitly marked by units as open.
 func (api *APIBase) Expose(ctx context.Context, args params.ApplicationExpose) error {
-	if err := api.checkCanWrite(); err != nil {
+	if err := api.checkCanWrite(ctx); err != nil {
 		return errors.Trace(err)
 	}
 	if err := api.check.ChangeAllowed(ctx); err != nil {
@@ -1316,7 +1316,7 @@ func (api *APIBase) mapExposedEndpointParams(ctx context.Context, params map[str
 // Unexpose changes the juju-managed firewall to unexpose any ports that
 // were also explicitly marked by units as open.
 func (api *APIBase) Unexpose(ctx context.Context, args params.ApplicationUnexpose) error {
-	if err := api.checkCanWrite(); err != nil {
+	if err := api.checkCanWrite(ctx); err != nil {
 		return err
 	}
 	if err := api.check.ChangeAllowed(ctx); err != nil {
@@ -1356,7 +1356,7 @@ func (api *APIBase) AddUnits(ctx context.Context, args params.AddApplicationUnit
 		return params.AddApplicationUnitsResults{}, errors.NotSupportedf("adding units to the controller application")
 	}
 
-	if err := api.checkCanWrite(); err != nil {
+	if err := api.checkCanWrite(ctx); err != nil {
 		return params.AddApplicationUnitsResults{}, errors.Trace(err)
 	}
 	if err := api.check.ChangeAllowed(ctx); err != nil {
@@ -1434,7 +1434,7 @@ func (api *APIBase) DestroyUnit(ctx context.Context, args params.DestroyUnitsPar
 	if api.model.Type() == state.ModelTypeCAAS {
 		return params.DestroyUnitResults{}, errors.NotSupportedf("removing units on a non-container model")
 	}
-	if err := api.checkCanWrite(); err != nil {
+	if err := api.checkCanWrite(ctx); err != nil {
 		return params.DestroyUnitResults{}, errors.Trace(err)
 	}
 	if err := api.check.RemoveAllowed(ctx); err != nil {
@@ -1532,7 +1532,7 @@ func (api *APIBase) DestroyUnit(ctx context.Context, args params.DestroyUnitsPar
 
 // DestroyApplication removes a given set of applications.
 func (api *APIBase) DestroyApplication(ctx context.Context, args params.DestroyApplicationsParams) (params.DestroyApplicationResults, error) {
-	if err := api.checkCanWrite(); err != nil {
+	if err := api.checkCanWrite(ctx); err != nil {
 		return params.DestroyApplicationResults{}, err
 	}
 	if err := api.check.RemoveAllowed(ctx); err != nil {
@@ -1638,7 +1638,7 @@ func (api *APIBase) DestroyApplication(ctx context.Context, args params.DestroyA
 
 // DestroyConsumedApplications removes a given set of consumed (remote) applications.
 func (api *APIBase) DestroyConsumedApplications(ctx context.Context, args params.DestroyConsumedApplicationsParams) (params.ErrorResults, error) {
-	if err := api.checkCanWrite(); err != nil {
+	if err := api.checkCanWrite(ctx); err != nil {
 		return params.ErrorResults{}, err
 	}
 	if err := api.check.RemoveAllowed(ctx); err != nil {
@@ -1683,7 +1683,7 @@ func (api *APIBase) ScaleApplications(ctx context.Context, args params.ScaleAppl
 	if api.model.Type() != state.ModelTypeCAAS {
 		return params.ScaleApplicationResults{}, errors.NotSupportedf("scaling applications on a non-container model")
 	}
-	if err := api.checkCanWrite(); err != nil {
+	if err := api.checkCanWrite(ctx); err != nil {
 		return params.ScaleApplicationResults{}, errors.Trace(err)
 	}
 	if err := api.check.ChangeAllowed(ctx); err != nil {
@@ -1739,7 +1739,7 @@ func (api *APIBase) ScaleApplications(ctx context.Context, args params.ScaleAppl
 
 // GetConstraints returns the constraints for a given application.
 func (api *APIBase) GetConstraints(ctx context.Context, args params.Entities) (params.ApplicationGetConstraintsResults, error) {
-	if err := api.checkCanRead(); err != nil {
+	if err := api.checkCanRead(ctx); err != nil {
 		return params.ApplicationGetConstraintsResults{}, errors.Trace(err)
 	}
 	results := params.ApplicationGetConstraintsResults{
@@ -1772,7 +1772,7 @@ func (api *APIBase) getConstraints(entity string) (constraints.Value, error) {
 
 // SetConstraints sets the constraints for a given application.
 func (api *APIBase) SetConstraints(ctx context.Context, args params.SetConstraints) error {
-	if err := api.checkCanWrite(); err != nil {
+	if err := api.checkCanWrite(ctx); err != nil {
 		return err
 	}
 	if err := api.check.ChangeAllowed(ctx); err != nil {
@@ -1799,7 +1799,7 @@ func (api *APIBase) AddRelation(ctx context.Context, args params.AddRelation) (_
 	if err := api.check.ChangeAllowed(ctx); err != nil {
 		return params.AddRelationResults{}, errors.Trace(err)
 	}
-	if err := api.checkCanWrite(); err != nil {
+	if err := api.checkCanWrite(ctx); err != nil {
 		return params.AddRelationResults{}, errors.Trace(err)
 	}
 
@@ -1861,7 +1861,7 @@ func (api *APIBase) AddRelation(ctx context.Context, args params.AddRelation) (_
 // DestroyRelation removes the relation between the
 // specified endpoints or an id.
 func (api *APIBase) DestroyRelation(ctx context.Context, args params.DestroyRelation) (err error) {
-	if err := api.checkCanWrite(); err != nil {
+	if err := api.checkCanWrite(ctx); err != nil {
 		return err
 	}
 	if err := api.check.RemoveAllowed(ctx); err != nil {
@@ -1887,7 +1887,7 @@ func (api *APIBase) DestroyRelation(ctx context.Context, args params.DestroyRela
 // SetRelationsSuspended sets the suspended status of the specified relations.
 func (api *APIBase) SetRelationsSuspended(ctx context.Context, args params.RelationSuspendedArgs) (params.ErrorResults, error) {
 	var statusResults params.ErrorResults
-	if err := api.checkCanWrite(); err != nil {
+	if err := api.checkCanWrite(ctx); err != nil {
 		return statusResults, errors.Trace(err)
 	}
 	if err := api.check.ChangeAllowed(ctx); err != nil {
@@ -1907,7 +1907,7 @@ func (api *APIBase) SetRelationsSuspended(ctx context.Context, args params.Relat
 			return errors.Errorf("cannot set suspend status for %q which is not associated with an offer", rel.Tag().Id())
 		}
 		if oc != nil && !arg.Suspended && rel.Suspended() {
-			ok, err := commoncrossmodel.CheckCanConsume(api.authorizer, api.backend.ControllerTag(), api.model.ModelTag(), oc)
+			ok, err := commoncrossmodel.CheckCanConsume(ctx, api.authorizer, api.backend.ControllerTag(), api.model.ModelTag(), oc)
 			if err != nil {
 				return errors.Trace(err)
 			}
@@ -1947,7 +1947,7 @@ func (api *APIBase) SetRelationsSuspended(ctx context.Context, args params.Relat
 // relations.
 func (api *APIBase) Consume(ctx context.Context, args params.ConsumeApplicationArgsV5) (params.ErrorResults, error) {
 	var consumeResults params.ErrorResults
-	if err := api.checkCanWrite(); err != nil {
+	if err := api.checkCanWrite(ctx); err != nil {
 		return consumeResults, errors.Trace(err)
 	}
 	if err := api.check.ChangeAllowed(ctx); err != nil {
@@ -2118,7 +2118,7 @@ func (api *APIBase) maybeUpdateExistingApplicationEndpoints(
 // CharmConfig returns charm config for the input list of applications and
 // model generations.
 func (api *APIBase) CharmConfig(ctx context.Context, args params.ApplicationGetArgs) (params.ApplicationGetConfigResults, error) {
-	if err := api.checkCanRead(); err != nil {
+	if err := api.checkCanRead(ctx); err != nil {
 		return params.ApplicationGetConfigResults{}, err
 	}
 	results := params.ApplicationGetConfigResults{
@@ -2134,7 +2134,7 @@ func (api *APIBase) CharmConfig(ctx context.Context, args params.ApplicationGetA
 
 // GetConfig returns the charm config for each of the input applications.
 func (api *APIBase) GetConfig(ctx context.Context, args params.Entities) (params.ApplicationGetConfigResults, error) {
-	if err := api.checkCanRead(); err != nil {
+	if err := api.checkCanRead(ctx); err != nil {
 		return params.ApplicationGetConfigResults{}, err
 	}
 	results := params.ApplicationGetConfigResults{
@@ -2181,7 +2181,7 @@ func (api *APIBase) getCharmConfig(gen string, appName string) (map[string]inter
 // Config map that are set to an empty string. Unset should be used for that.
 func (api *APIBase) SetConfigs(ctx context.Context, args params.ConfigSetArgs) (params.ErrorResults, error) {
 	var result params.ErrorResults
-	if err := api.checkCanWrite(); err != nil {
+	if err := api.checkCanWrite(ctx); err != nil {
 		return result, errors.Trace(err)
 	}
 	if err := api.check.ChangeAllowed(ctx); err != nil {
@@ -2212,7 +2212,7 @@ func (api *APIBase) addAppToBranch(branchName string, appName string) error {
 // UnsetApplicationsConfig implements the server side of Application.UnsetApplicationsConfig.
 func (api *APIBase) UnsetApplicationsConfig(ctx context.Context, args params.ApplicationConfigUnsetArgs) (params.ErrorResults, error) {
 	var result params.ErrorResults
-	if err := api.checkCanWrite(); err != nil {
+	if err := api.checkCanWrite(ctx); err != nil {
 		return result, errors.Trace(err)
 	}
 	if err := api.check.ChangeAllowed(ctx); err != nil {
@@ -2283,7 +2283,7 @@ func (api *APIBase) ResolveUnitErrors(ctx context.Context, p params.UnitsResolve
 	}
 
 	var result params.ErrorResults
-	if err := api.checkCanWrite(); err != nil {
+	if err := api.checkCanWrite(ctx); err != nil {
 		return result, errors.Trace(err)
 	}
 	if err := api.check.ChangeAllowed(ctx); err != nil {
@@ -2424,7 +2424,7 @@ func (api *APIBase) mapExposedEndpointsFromState(ctx context.Context, exposedEnd
 // MergeBindings merges operator-defined bindings with the current bindings for
 // one or more applications.
 func (api *APIBase) MergeBindings(ctx context.Context, in params.ApplicationMergeBindingsArgs) (params.ErrorResults, error) {
-	if err := api.checkCanWrite(); err != nil {
+	if err := api.checkCanWrite(ctx); err != nil {
 		return params.ErrorResults{}, err
 	}
 
@@ -2846,7 +2846,7 @@ func (api *APIBase) Leader(ctx context.Context, entity params.Entity) (params.St
 // local resource is provided, details required for uploading the validated
 // resource will be returned.
 func (api *APIBase) DeployFromRepository(ctx context.Context, args params.DeployFromRepositoryArgs) (params.DeployFromRepositoryResults, error) {
-	if err := api.checkCanWrite(); err != nil {
+	if err := api.checkCanWrite(ctx); err != nil {
 		return params.DeployFromRepositoryResults{}, errors.Trace(err)
 	}
 	if err := api.check.RemoveAllowed(ctx); err != nil {

--- a/apiserver/facades/client/application/get.go
+++ b/apiserver/facades/client/application/get.go
@@ -30,7 +30,7 @@ func (api *APIBase) getConfig(
 	args params.ApplicationGet,
 	describe func(settings charm.Settings, config *charm.Config) map[string]interface{},
 ) (params.ApplicationGetResults, error) {
-	if err := api.checkCanRead(); err != nil {
+	if err := api.checkCanRead(ctx); err != nil {
 		return params.ApplicationGetResults{}, err
 	}
 

--- a/apiserver/facades/client/applicationoffers/base.go
+++ b/apiserver/facades/client/applicationoffers/base.go
@@ -36,20 +36,22 @@ type BaseAPI struct {
 }
 
 // checkAdmin ensures that the specified in user is a model or controller admin.
-func (api *BaseAPI) checkAdmin(user names.UserTag, modelID model.UUID, backend Backend) error {
-	err := api.Authorizer.EntityHasPermission(user, permission.SuperuserAccess, backend.ControllerTag())
+func (api *BaseAPI) checkAdmin(
+	ctx context.Context, user names.UserTag, modelID model.UUID, backend Backend,
+) error {
+	err := api.Authorizer.EntityHasPermission(ctx, user, permission.SuperuserAccess, backend.ControllerTag())
 	if err != nil && !errors.Is(err, authentication.ErrorEntityMissingPermission) {
 		return errors.Trace(err)
 	} else if err == nil {
 		return nil
 	}
 
-	return api.Authorizer.EntityHasPermission(user, permission.AdminAccess, names.NewModelTag(modelID.String()))
+	return api.Authorizer.EntityHasPermission(ctx, user, permission.AdminAccess, names.NewModelTag(modelID.String()))
 }
 
 // checkControllerAdmin ensures that the logged in user is a controller admin.
-func (api *BaseAPI) checkControllerAdmin() error {
-	return api.Authorizer.HasPermission(permission.SuperuserAccess, api.ControllerModel.ControllerTag())
+func (api *BaseAPI) checkControllerAdmin(ctx context.Context) error {
+	return api.Authorizer.HasPermission(ctx, permission.SuperuserAccess, api.ControllerModel.ControllerTag())
 }
 
 // modelForName looks up the model details for the named model and returns
@@ -111,7 +113,7 @@ func (api *BaseAPI) applicationOffersFromModel(
 	// If requireAdmin is true, the user must be a controller superuser
 	// or model admin to proceed.
 	var isAdmin bool
-	err = api.checkAdmin(user, modelInfo.UUID, backend)
+	err = api.checkAdmin(ctx, user, modelInfo.UUID, backend)
 	if err != nil && !errors.Is(err, authentication.ErrorEntityMissingPermission) {
 		return nil, err
 	}

--- a/apiserver/facades/client/block/client.go
+++ b/apiserver/facades/client/block/client.go
@@ -40,19 +40,19 @@ var getState = func(st *state.State, m *state.Model) blockAccess {
 	return stateShim{st, m}
 }
 
-func (a *API) checkCanRead() error {
-	err := a.authorizer.HasPermission(permission.ReadAccess, a.access.ModelTag())
+func (a *API) checkCanRead(ctx context.Context) error {
+	err := a.authorizer.HasPermission(ctx, permission.ReadAccess, a.access.ModelTag())
 	return err
 }
 
-func (a *API) checkCanWrite() error {
-	err := a.authorizer.HasPermission(permission.WriteAccess, a.access.ModelTag())
+func (a *API) checkCanWrite(ctx context.Context) error {
+	err := a.authorizer.HasPermission(ctx, permission.WriteAccess, a.access.ModelTag())
 	return err
 }
 
 // List implements Block.List().
 func (a *API) List(ctx context.Context) (params.BlockResults, error) {
-	if err := a.checkCanRead(); err != nil {
+	if err := a.checkCanRead(ctx); err != nil {
 		return params.BlockResults{}, err
 	}
 
@@ -85,7 +85,7 @@ func convertBlock(b state.Block) params.BlockResult {
 
 // SwitchBlockOn implements Block.SwitchBlockOn().
 func (a *API) SwitchBlockOn(ctx context.Context, args params.BlockSwitchParams) params.ErrorResult {
-	if err := a.checkCanWrite(); err != nil {
+	if err := a.checkCanWrite(ctx); err != nil {
 		return params.ErrorResult{Error: apiservererrors.ServerError(err)}
 	}
 
@@ -95,7 +95,7 @@ func (a *API) SwitchBlockOn(ctx context.Context, args params.BlockSwitchParams) 
 
 // SwitchBlockOff implements Block.SwitchBlockOff().
 func (a *API) SwitchBlockOff(ctx context.Context, args params.BlockSwitchParams) params.ErrorResult {
-	if err := a.checkCanWrite(); err != nil {
+	if err := a.checkCanWrite(ctx); err != nil {
 		return params.ErrorResult{Error: apiservererrors.ServerError(err)}
 	}
 

--- a/apiserver/facades/client/bundle/bundle.go
+++ b/apiserver/facades/client/bundle/bundle.go
@@ -102,8 +102,8 @@ func NewBundleAPI(
 	}, nil
 }
 
-func (b *BundleAPI) checkCanRead() error {
-	return b.authorizer.HasPermission(permission.ReadAccess, b.modelTag)
+func (b *BundleAPI) checkCanRead(ctx context.Context) error {
+	return b.authorizer.HasPermission(ctx, permission.ReadAccess, b.modelTag)
 }
 
 type validators struct {
@@ -210,7 +210,7 @@ func (b *BundleAPI) ExportBundle(ctx context.Context, arg params.ExportBundlePar
 		return params.StringResult{}, apiservererrors.ServerError(failErr)
 	}
 
-	if err := b.checkCanRead(); err != nil {
+	if err := b.checkCanRead(ctx); err != nil {
 		return fail(err)
 	}
 

--- a/apiserver/facades/client/charms/client.go
+++ b/apiserver/facades/client/charms/client.go
@@ -63,13 +63,13 @@ func (a *API) CharmInfo(ctx context.Context, args params.CharmURL) (params.Charm
 	return a.charmInfoAPI.CharmInfo(ctx, args)
 }
 
-func (a *API) checkCanRead() error {
-	err := a.authorizer.HasPermission(permission.ReadAccess, a.tag)
+func (a *API) checkCanRead(ctx context.Context) error {
+	err := a.authorizer.HasPermission(ctx, permission.ReadAccess, a.tag)
 	return err
 }
 
-func (a *API) checkCanWrite() error {
-	err := a.authorizer.HasPermission(permission.SuperuserAccess, a.backendState.ControllerTag())
+func (a *API) checkCanWrite(ctx context.Context) error {
+	err := a.authorizer.HasPermission(ctx, permission.SuperuserAccess, a.backendState.ControllerTag())
 	if err != nil && !errors.Is(err, authentication.ErrorEntityMissingPermission) {
 		return errors.Trace(err)
 	}
@@ -78,7 +78,7 @@ func (a *API) checkCanWrite() error {
 		return nil
 	}
 
-	return a.authorizer.HasPermission(permission.WriteAccess, a.tag)
+	return a.authorizer.HasPermission(ctx, permission.WriteAccess, a.tag)
 }
 
 // NewCharmsAPI is only used for testing.
@@ -107,7 +107,7 @@ func NewCharmsAPI(
 // be filtered to return only the charms with supplied names.
 func (a *API) List(ctx context.Context, args params.CharmsList) (params.CharmsListResult, error) {
 	a.logger.Tracef("List %+v", args)
-	if err := a.checkCanRead(); err != nil {
+	if err := a.checkCanRead(ctx); err != nil {
 		return params.CharmsListResult{}, errors.Trace(err)
 	}
 
@@ -153,7 +153,7 @@ func (a *API) GetDownloadInfos(ctx context.Context, args params.CharmURLAndOrigi
 }
 
 func (a *API) getDownloadInfo(ctx context.Context, arg params.CharmURLAndOrigin) (params.DownloadInfoResult, error) {
-	if err := a.checkCanRead(); err != nil {
+	if err := a.checkCanRead(ctx); err != nil {
 		return params.DownloadInfoResult{}, apiservererrors.ServerError(err)
 	}
 
@@ -244,7 +244,7 @@ func (a *API) addCharmWithAuthorization(ctx context.Context, args params.AddChar
 		return params.CharmOriginResult{}, errors.BadRequestf("base required for Charmhub charms")
 	}
 
-	if err := a.checkCanWrite(); err != nil {
+	if err := a.checkCanWrite(ctx); err != nil {
 		return params.CharmOriginResult{}, err
 	}
 
@@ -318,7 +318,7 @@ func (a *API) queueAsyncCharmDownload(ctx context.Context, args params.AddCharmW
 // preferred channel.  Channel provided via CharmOrigin.
 func (a *API) ResolveCharms(ctx context.Context, args params.ResolveCharmsWithChannel) (params.ResolveCharmWithChannelResults, error) {
 	a.logger.Tracef("ResolveCharms %+v", args)
-	if err := a.checkCanRead(); err != nil {
+	if err := a.checkCanRead(ctx); err != nil {
 		return params.ResolveCharmWithChannelResults{}, errors.Trace(err)
 	}
 	result := params.ResolveCharmWithChannelResults{
@@ -445,7 +445,7 @@ func (a *API) getCharmRepository(ctx context.Context, src corecharm.Source) (cor
 // CheckCharmPlacement checks if a charm is allowed to be placed with in a
 // given application.
 func (a *API) CheckCharmPlacement(ctx context.Context, args params.ApplicationCharmPlacements) (params.ErrorResults, error) {
-	if err := a.checkCanRead(); err != nil {
+	if err := a.checkCanRead(ctx); err != nil {
 		return params.ErrorResults{}, errors.Trace(err)
 	}
 
@@ -585,7 +585,7 @@ func (a *API) getMachineArch(machine charmsinterfaces.Machine) (arch.Arch, error
 
 // ListCharmResources returns a series of resources for a given charm.
 func (a *API) ListCharmResources(ctx context.Context, args params.CharmURLAndOrigins) (params.CharmResourcesResults, error) {
-	if err := a.checkCanRead(); err != nil {
+	if err := a.checkCanRead(ctx); err != nil {
 		return params.CharmResourcesResults{}, errors.Trace(err)
 	}
 	results := params.CharmResourcesResults{

--- a/apiserver/facades/client/charms/client_test.go
+++ b/apiserver/facades/client/charms/client_test.go
@@ -501,7 +501,7 @@ func (s *charmsMockSuite) setupMocks(c *gc.C) *gomock.Controller {
 	ctrl := gomock.NewController(c)
 
 	s.authorizer = apiservermocks.NewMockAuthorizer(ctrl)
-	s.authorizer.EXPECT().HasPermission(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	s.authorizer.EXPECT().HasPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 	s.model = mocks.NewMockBackendModel(ctrl)
 	s.model.EXPECT().ModelTag().Return(names.NewModelTag("deadbeef-abcd-4fd2-967d-db9663db7bea")).AnyTimes()

--- a/apiserver/facades/client/client/client.go
+++ b/apiserver/facades/client/client/client.go
@@ -72,8 +72,8 @@ type ClientV6 struct {
 	*Client
 }
 
-func (c *Client) checkCanRead() error {
-	err := c.api.auth.HasPermission(permission.SuperuserAccess, c.api.stateAccessor.ControllerTag())
+func (c *Client) checkCanRead(ctx context.Context) error {
+	err := c.api.auth.HasPermission(ctx, permission.SuperuserAccess, c.api.stateAccessor.ControllerTag())
 	if err != nil && !errors.Is(err, authentication.ErrorEntityMissingPermission) {
 		return errors.Trace(err)
 	}
@@ -82,11 +82,11 @@ func (c *Client) checkCanRead() error {
 		return nil
 	}
 
-	return c.api.auth.HasPermission(permission.ReadAccess, c.api.stateAccessor.ModelTag())
+	return c.api.auth.HasPermission(ctx, permission.ReadAccess, c.api.stateAccessor.ModelTag())
 }
 
-func (c *Client) checkCanWrite() error {
-	err := c.api.auth.HasPermission(permission.SuperuserAccess, c.api.stateAccessor.ControllerTag())
+func (c *Client) checkCanWrite(ctx context.Context) error {
+	err := c.api.auth.HasPermission(ctx, permission.SuperuserAccess, c.api.stateAccessor.ControllerTag())
 	if err != nil && !errors.Is(err, authentication.ErrorEntityMissingPermission) {
 		return errors.Trace(err)
 	}
@@ -95,11 +95,11 @@ func (c *Client) checkCanWrite() error {
 		return nil
 	}
 
-	return c.api.auth.HasPermission(permission.WriteAccess, c.api.stateAccessor.ModelTag())
+	return c.api.auth.HasPermission(ctx, permission.WriteAccess, c.api.stateAccessor.ModelTag())
 }
 
-func (c *Client) checkIsAdmin() error {
-	err := c.api.auth.HasPermission(permission.SuperuserAccess, c.api.stateAccessor.ControllerTag())
+func (c *Client) checkIsAdmin(ctx context.Context) error {
+	err := c.api.auth.HasPermission(ctx, permission.SuperuserAccess, c.api.stateAccessor.ControllerTag())
 	if err != nil && !errors.Is(err, authentication.ErrorEntityMissingPermission) {
 		return errors.Trace(err)
 	}
@@ -108,7 +108,7 @@ func (c *Client) checkIsAdmin() error {
 		return nil
 	}
 
-	return c.api.auth.HasPermission(permission.AdminAccess, c.api.stateAccessor.ModelTag())
+	return c.api.auth.HasPermission(ctx, permission.AdminAccess, c.api.stateAccessor.ModelTag())
 }
 
 // NewFacade creates a Client facade to handle API requests.
@@ -232,7 +232,7 @@ func (c *Client) WatchAll(ctx context.Context) (params.AllWatcherId, error) {
 // FindTools returns a List containing all tools matching the given parameters.
 // TODO(juju 3.1) - remove, used by 2.9 client only
 func (c *Client) FindTools(ctx context.Context, args params.FindToolsParams) (params.FindToolsResult, error) {
-	if err := c.checkCanWrite(); err != nil {
+	if err := c.checkCanWrite(ctx); err != nil {
 		return params.FindToolsResult{}, err
 	}
 	model, err := c.modelInfoService.GetModelInfo(ctx)

--- a/apiserver/facades/client/client/client_test.go
+++ b/apiserver/facades/client/client/client_test.go
@@ -178,9 +178,9 @@ func (s *findToolsSuite) TestFindToolsIAAS(c *gc.C) {
 	gomock.InOrder(
 		authorizer.EXPECT().AuthClient().Return(true),
 		backend.EXPECT().ControllerTag().Return(coretesting.ControllerTag),
-		authorizer.EXPECT().HasPermission(permission.SuperuserAccess, coretesting.ControllerTag).Return(authentication.ErrorEntityMissingPermission),
+		authorizer.EXPECT().HasPermission(gomock.Any(), permission.SuperuserAccess, coretesting.ControllerTag).Return(authentication.ErrorEntityMissingPermission),
 		backend.EXPECT().ModelTag().Return(coretesting.ModelTag),
-		authorizer.EXPECT().HasPermission(permission.WriteAccess, coretesting.ModelTag).Return(nil),
+		authorizer.EXPECT().HasPermission(gomock.Any(), permission.WriteAccess, coretesting.ModelTag).Return(nil),
 
 		toolsFinder.EXPECT().FindAgents(gomock.Any(), common.FindAgentsParams{MajorVersion: 2}).
 			Return(simpleStreams, nil),
@@ -244,9 +244,9 @@ func (s *findToolsSuite) assertFindToolsCAASReleased(c *gc.C, wantArch, expectAr
 	gomock.InOrder(
 		authorizer.EXPECT().AuthClient().Return(true),
 		backend.EXPECT().ControllerTag().Return(coretesting.ControllerTag),
-		authorizer.EXPECT().HasPermission(permission.SuperuserAccess, coretesting.ControllerTag).Return(authentication.ErrorEntityMissingPermission),
+		authorizer.EXPECT().HasPermission(gomock.Any(), permission.SuperuserAccess, coretesting.ControllerTag).Return(authentication.ErrorEntityMissingPermission),
 		backend.EXPECT().ModelTag().Return(coretesting.ModelTag),
-		authorizer.EXPECT().HasPermission(permission.WriteAccess, coretesting.ModelTag).Return(nil),
+		authorizer.EXPECT().HasPermission(gomock.Any(), permission.WriteAccess, coretesting.ModelTag).Return(nil),
 
 		toolsFinder.EXPECT().FindAgents(gomock.Any(), common.FindAgentsParams{MajorVersion: 2, Arch: wantArch}).
 			Return(simpleStreams, nil),
@@ -335,9 +335,9 @@ func (s *findToolsSuite) TestFindToolsCAASNonReleased(c *gc.C) {
 	gomock.InOrder(
 		authorizer.EXPECT().AuthClient().Return(true),
 		backend.EXPECT().ControllerTag().Return(coretesting.ControllerTag),
-		authorizer.EXPECT().HasPermission(permission.SuperuserAccess, coretesting.ControllerTag).Return(authentication.ErrorEntityMissingPermission),
+		authorizer.EXPECT().HasPermission(gomock.Any(), permission.SuperuserAccess, coretesting.ControllerTag).Return(authentication.ErrorEntityMissingPermission),
 		backend.EXPECT().ModelTag().Return(coretesting.ModelTag),
-		authorizer.EXPECT().HasPermission(permission.WriteAccess, coretesting.ModelTag).Return(nil),
+		authorizer.EXPECT().HasPermission(gomock.Any(), permission.WriteAccess, coretesting.ModelTag).Return(nil),
 
 		toolsFinder.EXPECT().FindAgents(gomock.Any(),
 			common.FindAgentsParams{MajorVersion: 2, AgentStream: envtools.DevelStream}).

--- a/apiserver/facades/client/client/facade_mock_test.go
+++ b/apiserver/facades/client/client/facade_mock_test.go
@@ -10,6 +10,7 @@
 package client_test
 
 import (
+	context "context"
 	reflect "reflect"
 
 	permission "github.com/juju/juju/core/permission"
@@ -345,17 +346,17 @@ func (c *MockAuthorizerConnectedModelCall) DoAndReturn(f func() string) *MockAut
 }
 
 // EntityHasPermission mocks base method.
-func (m *MockAuthorizer) EntityHasPermission(arg0 names.Tag, arg1 permission.Access, arg2 names.Tag) error {
+func (m *MockAuthorizer) EntityHasPermission(arg0 context.Context, arg1 names.Tag, arg2 permission.Access, arg3 names.Tag) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EntityHasPermission", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "EntityHasPermission", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // EntityHasPermission indicates an expected call of EntityHasPermission.
-func (mr *MockAuthorizerMockRecorder) EntityHasPermission(arg0, arg1, arg2 any) *MockAuthorizerEntityHasPermissionCall {
+func (mr *MockAuthorizerMockRecorder) EntityHasPermission(arg0, arg1, arg2, arg3 any) *MockAuthorizerEntityHasPermissionCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EntityHasPermission", reflect.TypeOf((*MockAuthorizer)(nil).EntityHasPermission), arg0, arg1, arg2)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EntityHasPermission", reflect.TypeOf((*MockAuthorizer)(nil).EntityHasPermission), arg0, arg1, arg2, arg3)
 	return &MockAuthorizerEntityHasPermissionCall{Call: call}
 }
 
@@ -371,13 +372,13 @@ func (c *MockAuthorizerEntityHasPermissionCall) Return(arg0 error) *MockAuthoriz
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockAuthorizerEntityHasPermissionCall) Do(f func(names.Tag, permission.Access, names.Tag) error) *MockAuthorizerEntityHasPermissionCall {
+func (c *MockAuthorizerEntityHasPermissionCall) Do(f func(context.Context, names.Tag, permission.Access, names.Tag) error) *MockAuthorizerEntityHasPermissionCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockAuthorizerEntityHasPermissionCall) DoAndReturn(f func(names.Tag, permission.Access, names.Tag) error) *MockAuthorizerEntityHasPermissionCall {
+func (c *MockAuthorizerEntityHasPermissionCall) DoAndReturn(f func(context.Context, names.Tag, permission.Access, names.Tag) error) *MockAuthorizerEntityHasPermissionCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -421,17 +422,17 @@ func (c *MockAuthorizerGetAuthTagCall) DoAndReturn(f func() names.Tag) *MockAuth
 }
 
 // HasPermission mocks base method.
-func (m *MockAuthorizer) HasPermission(arg0 permission.Access, arg1 names.Tag) error {
+func (m *MockAuthorizer) HasPermission(arg0 context.Context, arg1 permission.Access, arg2 names.Tag) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HasPermission", arg0, arg1)
+	ret := m.ctrl.Call(m, "HasPermission", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // HasPermission indicates an expected call of HasPermission.
-func (mr *MockAuthorizerMockRecorder) HasPermission(arg0, arg1 any) *MockAuthorizerHasPermissionCall {
+func (mr *MockAuthorizerMockRecorder) HasPermission(arg0, arg1, arg2 any) *MockAuthorizerHasPermissionCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasPermission", reflect.TypeOf((*MockAuthorizer)(nil).HasPermission), arg0, arg1)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasPermission", reflect.TypeOf((*MockAuthorizer)(nil).HasPermission), arg0, arg1, arg2)
 	return &MockAuthorizerHasPermissionCall{Call: call}
 }
 
@@ -447,13 +448,13 @@ func (c *MockAuthorizerHasPermissionCall) Return(arg0 error) *MockAuthorizerHasP
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockAuthorizerHasPermissionCall) Do(f func(permission.Access, names.Tag) error) *MockAuthorizerHasPermissionCall {
+func (c *MockAuthorizerHasPermissionCall) Do(f func(context.Context, permission.Access, names.Tag) error) *MockAuthorizerHasPermissionCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockAuthorizerHasPermissionCall) DoAndReturn(f func(permission.Access, names.Tag) error) *MockAuthorizerHasPermissionCall {
+func (c *MockAuthorizerHasPermissionCall) DoAndReturn(f func(context.Context, permission.Access, names.Tag) error) *MockAuthorizerHasPermissionCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -147,7 +147,7 @@ func (c *Client) modelStatusHistory(filter status.StatusHistoryFilter) ([]params
 }
 
 // StatusHistory returns a slice of past statuses for several entities.
-func (c *Client) StatusHistory(request params.StatusHistoryRequests) params.StatusHistoryResults {
+func (c *Client) StatusHistory(ctx context.Context, request params.StatusHistoryRequests) params.StatusHistoryResults {
 	results := params.StatusHistoryResults{}
 	// TODO(perrito666) the contents of the loop could be split into
 	// a oneHistory method for clarity.
@@ -158,7 +158,7 @@ func (c *Client) StatusHistory(request params.StatusHistoryRequests) params.Stat
 			Delta:    request.Filter.Delta,
 			Exclude:  set.NewStrings(request.Filter.Exclude...),
 		}
-		if err := c.checkCanRead(); err != nil {
+		if err := c.checkCanRead(ctx); err != nil {
 			history := params.StatusHistoryResult{
 				Error: apiservererrors.ServerError(err),
 			}
@@ -216,7 +216,7 @@ func (c *Client) StatusHistory(request params.StatusHistoryRequests) params.Stat
 
 // FullStatus gives the information needed for juju status over the api
 func (c *Client) FullStatus(ctx context.Context, args params.StatusParams) (params.FullStatus, error) {
-	if err := c.checkCanRead(); err != nil {
+	if err := c.checkCanRead(ctx); err != nil {
 		return params.FullStatus{}, err
 	}
 
@@ -252,7 +252,7 @@ func (c *Client) FullStatus(ctx context.Context, args params.StatusParams) (para
 		return noStatus, errors.Annotate(err, "could not fetch remote applications")
 	}
 	// Only admins can see offer details.
-	if err := c.checkIsAdmin(); err == nil {
+	if err := c.checkIsAdmin(ctx); err == nil {
 		if context.offers, err =
 			fetchOffers(c.api.stateAccessor, context.allAppsUnitsCharmBindings.applications); err != nil {
 			return noStatus, errors.Annotate(err, "could not fetch application offers")

--- a/apiserver/facades/client/client/statushistory_test.go
+++ b/apiserver/facades/client/client/statushistory_test.go
@@ -4,6 +4,7 @@
 package client_test
 
 import (
+	"context"
 	"time"
 
 	"github.com/juju/errors"
@@ -88,7 +89,7 @@ func checkStatusInfo(c *gc.C, obtained []params.DetailedStatus, expected []statu
 }
 
 func (s *statusHistoryTestSuite) TestSizeRequired(c *gc.C) {
-	r := s.api.StatusHistory(params.StatusHistoryRequests{
+	r := s.api.StatusHistory(context.Background(), params.StatusHistoryRequests{
 		Requests: []params.StatusHistoryRequest{{
 			Tag:    "unit-unit-1",
 			Kind:   status.KindUnit.String(),
@@ -100,7 +101,7 @@ func (s *statusHistoryTestSuite) TestSizeRequired(c *gc.C) {
 
 func (s *statusHistoryTestSuite) TestNoConflictingFilters(c *gc.C) {
 	now := time.Now()
-	r := s.api.StatusHistory(params.StatusHistoryRequests{
+	r := s.api.StatusHistory(context.Background(), params.StatusHistoryRequests{
 		Requests: []params.StatusHistoryRequest{{
 			Tag:    "unit-unit-1",
 			Kind:   status.KindUnit.String(),
@@ -110,7 +111,7 @@ func (s *statusHistoryTestSuite) TestNoConflictingFilters(c *gc.C) {
 	c.Assert(r.Results[0].Error.Message, gc.Equals, "cannot validate status history filter: Size and Date together not valid")
 
 	yesterday := time.Hour * 24
-	r = s.api.StatusHistory(params.StatusHistoryRequests{
+	r = s.api.StatusHistory(context.Background(), params.StatusHistoryRequests{
 		Requests: []params.StatusHistoryRequest{{
 			Tag:    "unit-unit-1",
 			Kind:   status.KindUnit.String(),
@@ -119,7 +120,7 @@ func (s *statusHistoryTestSuite) TestNoConflictingFilters(c *gc.C) {
 	c.Assert(r.Results, gc.HasLen, 1)
 	c.Assert(r.Results[0].Error.Message, gc.Equals, "cannot validate status history filter: Size and Delta together not valid")
 
-	r = s.api.StatusHistory(params.StatusHistoryRequests{
+	r = s.api.StatusHistory(context.Background(), params.StatusHistoryRequests{
 		Requests: []params.StatusHistoryRequest{{
 			Tag:    "unit-unit-1",
 			Kind:   status.KindUnit.String(),
@@ -140,7 +141,7 @@ func (s *statusHistoryTestSuite) TestStatusHistoryApplication(c *gc.C) {
 			Message: "running",
 		},
 	})
-	h := s.api.StatusHistory(params.StatusHistoryRequests{
+	h := s.api.StatusHistory(context.Background(), params.StatusHistoryRequests{
 		Requests: []params.StatusHistoryRequest{{
 			Tag:    "application-app",
 			Kind:   status.KindApplication.String(),
@@ -167,7 +168,7 @@ func (s *statusHistoryTestSuite) TestStatusHistoryUnitOnly(c *gc.C) {
 			Status: status.Idle,
 		},
 	})
-	h := s.api.StatusHistory(params.StatusHistoryRequests{
+	h := s.api.StatusHistory(context.Background(), params.StatusHistoryRequests{
 		Requests: []params.StatusHistoryRequest{{
 			Tag:    "unit-unit-0",
 			Kind:   status.KindWorkload.String(),
@@ -197,7 +198,7 @@ func (s *statusHistoryTestSuite) TestStatusHistoryAgentOnly(c *gc.C) {
 			Status: status.Idle,
 		},
 	})
-	h := s.api.StatusHistory(params.StatusHistoryRequests{
+	h := s.api.StatusHistory(context.Background(), params.StatusHistoryRequests{
 		Requests: []params.StatusHistoryRequest{{
 			Tag:    "unit-unit-0",
 			Kind:   status.KindUnitAgent.String(),
@@ -231,7 +232,7 @@ func (s *statusHistoryTestSuite) TestStatusHistoryCombined(c *gc.C) {
 			Status: status.Idle,
 		},
 	})
-	h := s.api.StatusHistory(params.StatusHistoryRequests{
+	h := s.api.StatusHistory(context.Background(), params.StatusHistoryRequests{
 		Requests: []params.StatusHistoryRequest{{
 			Tag:    "unit-unit-0",
 			Kind:   status.KindUnit.String(),
@@ -258,7 +259,7 @@ func (s *statusHistoryTestSuite) TestStatusHistoryModelOnly(c *gc.C) {
 			Message: "invalid creds",
 		},
 	})
-	h := s.api.StatusHistory(params.StatusHistoryRequests{
+	h := s.api.StatusHistory(context.Background(), params.StatusHistoryRequests{
 		Requests: []params.StatusHistoryRequest{{
 			Tag:    "model-deadbeef-0bad-400d-8000-4b1d0d06f00d",
 			Kind:   status.KindModel.String(),

--- a/apiserver/facades/client/cloud/cloud.go
+++ b/apiserver/facades/client/cloud/cloud.go
@@ -65,6 +65,7 @@ var (
 // NewCloudAPI creates a new API server endpoint for managing the controller's
 // cloud definition and cloud credentials.
 func NewCloudAPI(
+	ctx context.Context,
 	controllerTag names.ControllerTag,
 	controllerCloud string,
 	cloudService CloudService,
@@ -76,7 +77,7 @@ func NewCloudAPI(
 		return nil, apiservererrors.ErrPerm
 	}
 
-	err := authorizer.HasPermission(permission.SuperuserAccess, controllerTag)
+	err := authorizer.HasPermission(ctx, permission.SuperuserAccess, controllerTag)
 	if err != nil && !errors.Is(err, errors.NotFound) && !errors.Is(err, authentication.ErrorEntityMissingPermission) {
 		return nil, err
 	}
@@ -125,7 +126,7 @@ func (api *CloudAPI) Clouds(ctx context.Context) (params.CloudsResult, error) {
 	if err != nil {
 		return result, err
 	}
-	err = api.authorizer.HasPermission(permission.SuperuserAccess, api.controllerTag)
+	err = api.authorizer.HasPermission(ctx, permission.SuperuserAccess, api.controllerTag)
 	if err != nil &&
 		!errors.Is(err, authentication.ErrorEntityMissingPermission) &&
 		!errors.Is(err, errors.NotFound) {
@@ -155,7 +156,7 @@ func (api *CloudAPI) Cloud(ctx context.Context, args params.Entities) (params.Cl
 	results := params.CloudResults{
 		Results: make([]params.CloudResult, len(args.Entities)),
 	}
-	err := api.authorizer.HasPermission(permission.SuperuserAccess, api.controllerTag)
+	err := api.authorizer.HasPermission(ctx, permission.SuperuserAccess, api.controllerTag)
 	if err != nil &&
 		!errors.Is(err, authentication.ErrorEntityMissingPermission) &&
 		!errors.Is(err, errors.NotFound) {
@@ -221,7 +222,7 @@ func (api *CloudAPI) CloudInfo(ctx context.Context, args params.Entities) (param
 }
 
 func (api *CloudAPI) getCloudInfo(ctx context.Context, tag names.CloudTag) (*params.CloudInfo, error) {
-	err := api.authorizer.HasPermission(permission.SuperuserAccess, api.controllerTag)
+	err := api.authorizer.HasPermission(ctx, permission.SuperuserAccess, api.controllerTag)
 	if err != nil && !errors.Is(err, errors.NotFound) && !errors.Is(err, authentication.ErrorEntityMissingPermission) {
 		return nil, errors.Trace(err)
 	}
@@ -409,7 +410,7 @@ func (api *CloudAPI) AddCredentials(ctx context.Context, args params.TaggedCrede
 func (api *CloudAPI) UpdateCredentialsCheckModels(ctx context.Context, args params.UpdateCredentialArgs) (params.UpdateCredentialResults, error) {
 	if args.Force {
 		// Only controller admins can ask for an update to be forced.
-		err := api.authorizer.HasPermission(permission.SuperuserAccess, api.controllerTag)
+		err := api.authorizer.HasPermission(ctx, permission.SuperuserAccess, api.controllerTag)
 		if err != nil && !errors.Is(err, errors.NotFound) && !errors.Is(err, authentication.ErrorEntityMissingPermission) {
 			return params.UpdateCredentialResults{}, errors.Trace(err)
 		}
@@ -580,7 +581,7 @@ func (api *CloudAPI) Credential(ctx context.Context, args params.Entities) (para
 
 // AddCloud adds a new cloud, different from the one managed by the controller.
 func (api *CloudAPI) AddCloud(ctx context.Context, cloudArgs params.AddCloudArgs) error {
-	err := api.authorizer.HasPermission(permission.SuperuserAccess, api.controllerTag)
+	err := api.authorizer.HasPermission(ctx, permission.SuperuserAccess, api.controllerTag)
 	if err != nil {
 		return err
 	}
@@ -617,7 +618,7 @@ func (api *CloudAPI) UpdateCloud(ctx context.Context, cloudArgs params.UpdateClo
 	results := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(cloudArgs.Clouds)),
 	}
-	err := api.authorizer.HasPermission(permission.SuperuserAccess, api.controllerTag)
+	err := api.authorizer.HasPermission(ctx, permission.SuperuserAccess, api.controllerTag)
 	if err != nil && !errors.Is(err, errors.NotFound) && !errors.Is(err, authentication.ErrorEntityMissingPermission) {
 		return results, errors.Trace(err)
 	} else if err != nil {
@@ -636,7 +637,7 @@ func (api *CloudAPI) RemoveClouds(ctx context.Context, args params.Entities) (pa
 	result := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Entities)),
 	}
-	err := api.authorizer.HasPermission(permission.SuperuserAccess, api.controllerTag)
+	err := api.authorizer.HasPermission(ctx, permission.SuperuserAccess, api.controllerTag)
 	if err != nil && !errors.Is(err, errors.NotFound) && !errors.Is(err, authentication.ErrorEntityMissingPermission) {
 		return result, errors.Trace(err)
 	}

--- a/apiserver/facades/client/cloud/cloud_test.go
+++ b/apiserver/facades/client/cloud/cloud_test.go
@@ -56,6 +56,7 @@ func (s *cloudSuite) setup(c *gc.C, userTag names.UserTag) *gomock.Controller {
 	s.credentialValidator = mocks.NewMockCredentialValidator(ctrl)
 
 	api, err := cloud.NewCloudAPI(
+		stdcontext.Background(),
 		coretesting.ControllerTag, "dummy",
 		s.cloudService, s.cloudAccessService, s.credService,
 		s.authorizer, loggertesting.WrapCheckLog(c))

--- a/apiserver/facades/client/cloud/register.go
+++ b/apiserver/facades/client/cloud/register.go
@@ -18,12 +18,12 @@ import (
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
 	registry.MustRegister("Cloud", 7, func(stdCtx stdcontext.Context, ctx facade.ModelContext) (facade.Facade, error) {
-		return newFacadeV7(ctx) // Do not set error if forcing credential update.
+		return newFacadeV7(stdCtx, ctx) // Do not set error if forcing credential update.
 	}, reflect.TypeOf((*CloudAPI)(nil)))
 }
 
 // newFacadeV7 is used for API registration.
-func newFacadeV7(context facade.ModelContext) (*CloudAPI, error) {
+func newFacadeV7(stdCtx stdcontext.Context, context facade.ModelContext) (*CloudAPI, error) {
 	serviceFactory := context.ServiceFactory()
 	systemState, err := context.StatePool().SystemState()
 	if err != nil {
@@ -72,6 +72,7 @@ func newFacadeV7(context facade.ModelContext) (*CloudAPI, error) {
 	}
 
 	return NewCloudAPI(
+		stdCtx,
 		systemState.ControllerTag(),
 		controllerInfo.CloudName,
 		serviceFactory.Cloud(),

--- a/apiserver/facades/client/controller/destroy.go
+++ b/apiserver/facades/client/controller/destroy.go
@@ -23,7 +23,7 @@ import (
 // non-Dead hosted models, then an error with the code
 // params.CodeHasHostedModels will be transmitted.
 func (c *ControllerAPI) DestroyController(ctx context.Context, args params.DestroyControllerArgs) error {
-	err := c.authorizer.HasPermission(permission.SuperuserAccess, c.controllerTag)
+	err := c.authorizer.HasPermission(ctx, permission.SuperuserAccess, c.controllerTag)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/apiserver/facades/client/highavailability/highavailability.go
+++ b/apiserver/facades/client/highavailability/highavailability.go
@@ -86,7 +86,7 @@ func (api *HighAvailabilityAPI) EnableHA(
 ) (params.ControllersChangeResults, error) {
 	results := params.ControllersChangeResults{}
 
-	err := api.authorizer.HasPermission(permission.SuperuserAccess, api.st.ControllerTag())
+	err := api.authorizer.HasPermission(ctx, permission.SuperuserAccess, api.st.ControllerTag())
 	if err != nil {
 		return results, apiservererrors.ServerError(apiservererrors.ErrPerm)
 	}
@@ -348,7 +348,7 @@ func (api *HighAvailabilityAPI) ControllerDetails(
 ) (params.ControllerDetailsResults, error) {
 	results := params.ControllerDetailsResults{}
 
-	err := api.authorizer.HasPermission(permission.LoginAccess, api.st.ControllerTag())
+	err := api.authorizer.HasPermission(ctx, permission.LoginAccess, api.st.ControllerTag())
 	if err != nil {
 		return results, apiservererrors.ServerError(apiservererrors.ErrPerm)
 	}

--- a/apiserver/facades/client/imagemetadatamanager/metadata.go
+++ b/apiserver/facades/client/imagemetadatamanager/metadata.go
@@ -34,6 +34,7 @@ type ModelConfigService interface {
 
 // createAPI returns a new image metadata API facade.
 func createAPI(
+	ctx context.Context,
 	st metadataAccess,
 	modelConfigService ModelConfigService,
 	newEnviron func() (environs.Environ, error),
@@ -43,7 +44,7 @@ func createAPI(
 	if !authorizer.AuthClient() {
 		return nil, apiservererrors.ErrPerm
 	}
-	err := authorizer.HasPermission(permission.SuperuserAccess, st.ControllerTag())
+	err := authorizer.HasPermission(ctx, permission.SuperuserAccess, st.ControllerTag())
 	if err != nil {
 		return nil, err
 	}

--- a/apiserver/facades/client/imagemetadatamanager/package_test.go
+++ b/apiserver/facades/client/imagemetadatamanager/package_test.go
@@ -4,6 +4,7 @@
 package imagemetadatamanager_test
 
 import (
+	"context"
 	stdtesting "testing"
 
 	"github.com/juju/names/v5"
@@ -59,7 +60,9 @@ func (s *baseImageMetadataSuite) setupAPI(c *gc.C) (*gomock.Controller, *MockMod
 	modelConfigService := NewMockModelConfigService(ctrl)
 
 	var err error
-	s.api, err = imagemetadatamanager.CreateAPI(s.state, modelConfigService,
+	s.api, err = imagemetadatamanager.CreateAPI(
+		context.Background(),
+		s.state, modelConfigService,
 		func() (environs.Environ, error) {
 			return &mockEnviron{}, nil
 		}, s.resources, s.authorizer)

--- a/apiserver/facades/client/imagemetadatamanager/register.go
+++ b/apiserver/facades/client/imagemetadatamanager/register.go
@@ -17,19 +17,19 @@ import (
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
 	registry.MustRegister("ImageMetadataManager", 1, func(stdCtx context.Context, ctx facade.ModelContext) (facade.Facade, error) {
-		return newAPI(ctx)
+		return newAPI(stdCtx, ctx)
 	}, reflect.TypeOf((*API)(nil)))
 }
 
 // newAPI returns a new cloud image metadata API facade.
-func newAPI(ctx facade.ModelContext) (*API, error) {
-	st := ctx.State()
+func newAPI(ctx context.Context, modelctx facade.ModelContext) (*API, error) {
+	st := modelctx.State()
 	model, err := st.Model()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	newEnviron := func() (environs.Environ, error) {
-		return stateenvirons.GetNewEnvironFunc(environs.New)(model, ctx.ServiceFactory().Cloud(), ctx.ServiceFactory().Credential())
+		return stateenvirons.GetNewEnvironFunc(environs.New)(model, modelctx.ServiceFactory().Cloud(), modelctx.ServiceFactory().Credential())
 	}
-	return createAPI(getState(st), ctx.ServiceFactory().Config(), newEnviron, ctx.Resources(), ctx.Auth())
+	return createAPI(ctx, getState(st), modelctx.ServiceFactory().Config(), newEnviron, modelctx.Resources(), modelctx.Auth())
 }

--- a/apiserver/facades/client/machinemanager/package_mock_test.go
+++ b/apiserver/facades/client/machinemanager/package_mock_test.go
@@ -196,17 +196,17 @@ func (c *MockAuthorizerAuthClientCall) DoAndReturn(f func() bool) *MockAuthorize
 }
 
 // CanRead mocks base method.
-func (m *MockAuthorizer) CanRead() error {
+func (m *MockAuthorizer) CanRead(arg0 context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CanRead")
+	ret := m.ctrl.Call(m, "CanRead", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CanRead indicates an expected call of CanRead.
-func (mr *MockAuthorizerMockRecorder) CanRead() *MockAuthorizerCanReadCall {
+func (mr *MockAuthorizerMockRecorder) CanRead(arg0 any) *MockAuthorizerCanReadCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CanRead", reflect.TypeOf((*MockAuthorizer)(nil).CanRead))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CanRead", reflect.TypeOf((*MockAuthorizer)(nil).CanRead), arg0)
 	return &MockAuthorizerCanReadCall{Call: call}
 }
 
@@ -222,29 +222,29 @@ func (c *MockAuthorizerCanReadCall) Return(arg0 error) *MockAuthorizerCanReadCal
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockAuthorizerCanReadCall) Do(f func() error) *MockAuthorizerCanReadCall {
+func (c *MockAuthorizerCanReadCall) Do(f func(context.Context) error) *MockAuthorizerCanReadCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockAuthorizerCanReadCall) DoAndReturn(f func() error) *MockAuthorizerCanReadCall {
+func (c *MockAuthorizerCanReadCall) DoAndReturn(f func(context.Context) error) *MockAuthorizerCanReadCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // CanWrite mocks base method.
-func (m *MockAuthorizer) CanWrite() error {
+func (m *MockAuthorizer) CanWrite(arg0 context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CanWrite")
+	ret := m.ctrl.Call(m, "CanWrite", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CanWrite indicates an expected call of CanWrite.
-func (mr *MockAuthorizerMockRecorder) CanWrite() *MockAuthorizerCanWriteCall {
+func (mr *MockAuthorizerMockRecorder) CanWrite(arg0 any) *MockAuthorizerCanWriteCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CanWrite", reflect.TypeOf((*MockAuthorizer)(nil).CanWrite))
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CanWrite", reflect.TypeOf((*MockAuthorizer)(nil).CanWrite), arg0)
 	return &MockAuthorizerCanWriteCall{Call: call}
 }
 
@@ -260,13 +260,13 @@ func (c *MockAuthorizerCanWriteCall) Return(arg0 error) *MockAuthorizerCanWriteC
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockAuthorizerCanWriteCall) Do(f func() error) *MockAuthorizerCanWriteCall {
+func (c *MockAuthorizerCanWriteCall) Do(f func(context.Context) error) *MockAuthorizerCanWriteCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockAuthorizerCanWriteCall) DoAndReturn(f func() error) *MockAuthorizerCanWriteCall {
+func (c *MockAuthorizerCanWriteCall) DoAndReturn(f func(context.Context) error) *MockAuthorizerCanWriteCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/client/modelconfig/modelconfig_test.go
+++ b/apiserver/facades/client/modelconfig/modelconfig_test.go
@@ -358,7 +358,7 @@ func (s *modelSecretBackendSuite) TestGetModelSecretBackendFailedPermissionDenie
 	facade, ctrl := s.setup(c)
 	defer ctrl.Finish()
 
-	s.authorizer.EXPECT().HasPermission(permission.ReadAccess, names.NewModelTag(s.modelID.String())).Return(
+	s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.ReadAccess, names.NewModelTag(s.modelID.String())).Return(
 		errors.WithType(apiservererrors.ErrPerm, authentication.ErrorEntityMissingPermission),
 	)
 
@@ -371,7 +371,7 @@ func (s *modelSecretBackendSuite) TestGetModelSecretBackendFailedModelNotFound(c
 	facade, ctrl := s.setup(c)
 	defer ctrl.Finish()
 
-	s.authorizer.EXPECT().HasPermission(permission.ReadAccess, names.NewModelTag(s.modelID.String())).Return(nil)
+	s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.ReadAccess, names.NewModelTag(s.modelID.String())).Return(nil)
 	s.mockModelSecretBackendService.EXPECT().GetModelSecretBackend(gomock.Any()).Return("", modelerrors.NotFound)
 
 	result, err := facade.GetModelSecretBackend(context.Background())
@@ -384,7 +384,7 @@ func (s *modelSecretBackendSuite) TestGetModelSecretBackend(c *gc.C) {
 	facade, ctrl := s.setup(c)
 	defer ctrl.Finish()
 
-	s.authorizer.EXPECT().HasPermission(permission.ReadAccess, names.NewModelTag(s.modelID.String())).Return(nil)
+	s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.ReadAccess, names.NewModelTag(s.modelID.String())).Return(nil)
 	s.mockModelSecretBackendService.EXPECT().GetModelSecretBackend(gomock.Any()).Return("myvault", nil)
 
 	result, err := facade.GetModelSecretBackend(context.Background())
@@ -396,7 +396,7 @@ func (s *modelSecretBackendSuite) TestSetModelSecretBackendFailedPermissionDenie
 	facade, ctrl := s.setup(c)
 	defer ctrl.Finish()
 
-	s.authorizer.EXPECT().HasPermission(permission.WriteAccess, names.NewModelTag(s.modelID.String())).Return(
+	s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.WriteAccess, names.NewModelTag(s.modelID.String())).Return(
 		errors.WithType(apiservererrors.ErrPerm, authentication.ErrorEntityMissingPermission),
 	)
 
@@ -409,7 +409,7 @@ func (s *modelSecretBackendSuite) TestSetModelSecretBackendFailedModelNotFound(c
 	facade, ctrl := s.setup(c)
 	defer ctrl.Finish()
 
-	s.authorizer.EXPECT().HasPermission(permission.WriteAccess, names.NewModelTag(s.modelID.String())).Return(nil)
+	s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.WriteAccess, names.NewModelTag(s.modelID.String())).Return(nil)
 	s.mockModelSecretBackendService.EXPECT().SetModelSecretBackend(gomock.Any(), "myvault").Return(modelerrors.NotFound)
 
 	result, err := facade.SetModelSecretBackend(context.Background(), params.SetModelSecretBackendArg{
@@ -424,7 +424,7 @@ func (s *modelSecretBackendSuite) TestSetModelSecretBackendFailedSecretBackendNo
 	facade, ctrl := s.setup(c)
 	defer ctrl.Finish()
 
-	s.authorizer.EXPECT().HasPermission(permission.WriteAccess, names.NewModelTag(s.modelID.String())).Return(nil)
+	s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.WriteAccess, names.NewModelTag(s.modelID.String())).Return(nil)
 	s.mockModelSecretBackendService.EXPECT().SetModelSecretBackend(gomock.Any(), "myvault").Return(secretbackenderrors.NotFound)
 
 	result, err := facade.SetModelSecretBackend(context.Background(), params.SetModelSecretBackendArg{
@@ -439,7 +439,7 @@ func (s *modelSecretBackendSuite) TestSetModelSecretBackendFailedSecretBackendNo
 	facade, ctrl := s.setup(c)
 	defer ctrl.Finish()
 
-	s.authorizer.EXPECT().HasPermission(permission.WriteAccess, names.NewModelTag(s.modelID.String())).Return(nil)
+	s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.WriteAccess, names.NewModelTag(s.modelID.String())).Return(nil)
 	s.mockModelSecretBackendService.EXPECT().SetModelSecretBackend(gomock.Any(), "myvault").Return(secretbackenderrors.NotValid)
 
 	result, err := facade.SetModelSecretBackend(context.Background(), params.SetModelSecretBackendArg{
@@ -454,7 +454,7 @@ func (s *modelSecretBackendSuite) TestSetModelSecretBackend(c *gc.C) {
 	facade, ctrl := s.setup(c)
 	defer ctrl.Finish()
 
-	s.authorizer.EXPECT().HasPermission(permission.WriteAccess, names.NewModelTag(s.modelID.String())).Return(nil)
+	s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.WriteAccess, names.NewModelTag(s.modelID.String())).Return(nil)
 	s.mockModelSecretBackendService.EXPECT().SetModelSecretBackend(gomock.Any(), "myvault").Return(nil)
 
 	result, err := facade.SetModelSecretBackend(context.Background(), params.SetModelSecretBackendArg{

--- a/apiserver/facades/client/modelgeneration/modelgeneration.go
+++ b/apiserver/facades/client/modelgeneration/modelgeneration.go
@@ -52,7 +52,7 @@ func (api *API) hasAdminAccess(ctx context.Context) error {
 	// We used to cache the result on the api object if the user was a superuser.
 	// We don't do that anymore as permission caching could become invalid
 	// for long lived connections.
-	err := api.authorizer.HasPermission(permission.SuperuserAccess, api.st.ControllerTag())
+	err := api.authorizer.HasPermission(ctx, permission.SuperuserAccess, api.st.ControllerTag())
 	if err != nil && !errors.Is(err, authentication.ErrorEntityMissingPermission) {
 		return err
 	}
@@ -61,7 +61,7 @@ func (api *API) hasAdminAccess(ctx context.Context) error {
 		return nil
 	}
 
-	return api.authorizer.HasPermission(permission.AdminAccess, api.model.ModelTag())
+	return api.authorizer.HasPermission(ctx, permission.AdminAccess, api.model.ModelTag())
 }
 
 // AddBranch adds a new branch with the input name to the model.

--- a/apiserver/facades/client/modelgeneration/modelgeneration_test.go
+++ b/apiserver/facades/client/modelgeneration/modelgeneration_test.go
@@ -241,7 +241,7 @@ func (s *modelGenerationSuite) setupModelGenerationAPI(c *gc.C) *gomock.Controll
 
 	mockAuthorizer := facademocks.NewMockAuthorizer(ctrl)
 	aExp := mockAuthorizer.EXPECT()
-	aExp.HasPermission(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	aExp.HasPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	aExp.GetAuthTag().Return(names.NewUserTag("test-user"))
 	aExp.AuthClient().Return(true)
 

--- a/apiserver/facades/client/modelmanager/listmodelsummaries_test.go
+++ b/apiserver/facades/client/modelmanager/listmodelsummaries_test.go
@@ -76,6 +76,7 @@ func (s *ListModelsWithInfoSuite) SetUpTest(c *gc.C) {
 
 	s.cred = cloud.NewEmptyCredential()
 	api, err := modelmanager.NewModelManagerAPI(
+		stdcontext.Background(),
 		s.st, nil, &mockState{},
 		s.controllerUUID,
 		modelmanager.Services{
@@ -101,6 +102,7 @@ func (s *ListModelsWithInfoSuite) setupMocks(c *gc.C) *gomock.Controller {
 	ctrl := gomock.NewController(c)
 	s.mockAccessService = mocks.NewMockAccessService(ctrl)
 	api, err := modelmanager.NewModelManagerAPI(
+		stdcontext.Background(),
 		s.st, nil, &mockState{},
 		s.controllerUUID,
 		modelmanager.Services{
@@ -138,6 +140,7 @@ func (s *ListModelsWithInfoSuite) createModel(c *gc.C, user names.UserTag) *mock
 func (s *ListModelsWithInfoSuite) setAPIUser(c *gc.C, user names.UserTag) {
 	s.authoriser.Tag = user
 	modelmanager, err := modelmanager.NewModelManagerAPI(
+		stdcontext.Background(),
 		s.st, nil, &mockState{},
 		s.controllerUUID,
 		modelmanager.Services{

--- a/apiserver/facades/client/modelmanager/modelinfo_test.go
+++ b/apiserver/facades/client/modelmanager/modelinfo_test.go
@@ -185,6 +185,7 @@ func (s *modelInfoSuite) getAPI(c *gc.C) (*modelmanager.ModelManagerAPI, *gomock
 	s.mockSecretBackendService = mocks.NewMockSecretBackendService(ctrl)
 	cred := cloud.NewEmptyCredential()
 	api, err := modelmanager.NewModelManagerAPI(
+		context.Background(),
 		s.st, nil, s.ctlrSt,
 		s.controllerUUID,
 		modelmanager.Services{
@@ -217,6 +218,7 @@ func (s *modelInfoSuite) getAPIWithUser(c *gc.C, user names.UserTag) (*modelmana
 	s.authorizer.Tag = user
 	cred := cloud.NewEmptyCredential()
 	api, err := modelmanager.NewModelManagerAPI(
+		context.Background(),
 		s.st, nil, s.ctlrSt,
 		s.controllerUUID,
 		modelmanager.Services{

--- a/apiserver/facades/client/modelmanager/modelmanager_test.go
+++ b/apiserver/facades/client/modelmanager/modelmanager_test.go
@@ -219,6 +219,7 @@ func (s *modelManagerSuite) SetUpTest(c *gc.C) {
 	}
 	cred := cloud.NewEmptyCredential()
 	api, err := modelmanager.NewModelManagerAPI(
+		context.Background(),
 		s.st, s.modelExporter, s.ctlrSt,
 		s.controllerUUID,
 		modelmanager.Services{
@@ -238,6 +239,7 @@ func (s *modelManagerSuite) SetUpTest(c *gc.C) {
 	s.api = api
 	caasCred := cloud.NewCredential(cloud.UserPassAuthType, nil)
 	caasApi, err := modelmanager.NewModelManagerAPI(
+		context.Background(),
 		s.caasSt, s.modelExporter, s.ctlrSt,
 		s.controllerUUID,
 		modelmanager.Services{
@@ -275,6 +277,7 @@ func (s *modelManagerSuite) setAPIUser(c *gc.C, user names.UserTag) {
 		return s.caasBroker, nil
 	}
 	mm, err := modelmanager.NewModelManagerAPI(
+		context.Background(),
 		s.st, s.modelExporter, s.ctlrSt,
 		s.controllerUUID,
 		modelmanager.Services{
@@ -730,6 +733,7 @@ func (s *modelManagerSuite) TestDumpModel(c *gc.C) {
 	defer ctrl.Finish()
 
 	api, err := modelmanager.NewModelManagerAPI(
+		context.Background(),
 		s.st, s.modelExporter, s.ctlrSt,
 		s.controllerUUID,
 		modelmanager.Services{
@@ -1000,6 +1004,7 @@ func (s *modelManagerStateSuite) setAPIUser(c *gc.C, user names.UserTag) {
 	newEnviron := common.EnvironFuncForModel(model, serviceFactory.Cloud(), serviceFactory.Credential(), configGetter)
 	toolsFinder := common.NewToolsFinder(s.controllerConfigService, configGetter, st, urlGetter, newEnviron, s.store)
 	modelmanager, err := modelmanager.NewModelManagerAPI(
+		context.Background(),
 		mockCredentialShim{st}, nil, ctlrSt,
 		s.controllerUUID,
 		modelmanager.Services{
@@ -1029,6 +1034,7 @@ func (s *modelManagerStateSuite) TestNewAPIAcceptsClient(c *gc.C) {
 	serviceFactory := s.ControllerServiceFactory(c)
 
 	endPoint, err := modelmanager.NewModelManagerAPI(
+		context.Background(),
 		mockCredentialShim{st},
 		nil,
 		common.NewModelManagerBackend(s.ConfigSchemaSourceGetter(c), s.ControllerModel(c), s.StatePool()),
@@ -1057,6 +1063,7 @@ func (s *modelManagerStateSuite) TestNewAPIRefusesNonClient(c *gc.C) {
 	serviceFactory := s.ControllerServiceFactory(c)
 
 	endPoint, err := modelmanager.NewModelManagerAPI(
+		context.Background(),
 		mockCredentialShim{st},
 		nil,
 		common.NewModelManagerBackend(s.ConfigSchemaSourceGetter(c), s.ControllerModel(c), s.StatePool()),
@@ -1292,6 +1299,7 @@ func (s *modelManagerStateSuite) TestDestroyOwnModel(c *gc.C) {
 	serviceFactory := s.ControllerServiceFactory(c)
 
 	s.modelmanager, err = modelmanager.NewModelManagerAPI(
+		context.Background(),
 		mockCredentialShim{backend},
 		nil,
 		common.NewModelManagerBackend(s.ConfigSchemaSourceGetter(c), s.ControllerModel(c), s.StatePool()),
@@ -1356,6 +1364,7 @@ func (s *modelManagerStateSuite) TestAdminDestroysOtherModel(c *gc.C) {
 	serviceFactory := s.ControllerServiceFactory(c)
 
 	s.modelmanager, err = modelmanager.NewModelManagerAPI(
+		context.Background(),
 		mockCredentialShim{backend},
 		nil,
 		common.NewModelManagerBackend(s.ConfigSchemaSourceGetter(c), s.ControllerModel(c), s.StatePool()),
@@ -1408,6 +1417,7 @@ func (s *modelManagerStateSuite) TestDestroyModelErrors(c *gc.C) {
 
 	backend := common.NewModelManagerBackend(s.ConfigSchemaSourceGetter(c), model, s.StatePool())
 	s.modelmanager, err = modelmanager.NewModelManagerAPI(
+		context.Background(),
 		mockCredentialShim{backend},
 		nil,
 		common.NewModelManagerBackend(s.ConfigSchemaSourceGetter(c), s.ControllerModel(c), s.StatePool()),
@@ -1511,6 +1521,7 @@ func (s *modelManagerStateSuite) TestModelInfoForMigratedModel(c *gc.C) {
 	anAuthoriser.Tag = user
 	st := common.NewUserAwareModelManagerBackend(s.ConfigSchemaSourceGetter(c), model, s.StatePool(), user)
 	endPoint, err := modelmanager.NewModelManagerAPI(
+		context.Background(),
 		mockCredentialShim{st},
 		nil,
 		common.NewModelManagerBackend(s.ConfigSchemaSourceGetter(c), s.ControllerModel(c), s.StatePool()),

--- a/apiserver/facades/client/modelmanager/register.go
+++ b/apiserver/facades/client/modelmanager/register.go
@@ -22,12 +22,12 @@ import (
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
 	registry.MustRegisterForMultiModel("ModelManager", 10, func(stdCtx context.Context, ctx facade.MultiModelContext) (facade.Facade, error) {
-		return newFacadeV10(ctx)
+		return newFacadeV10(stdCtx, ctx)
 	}, reflect.TypeOf((*ModelManagerAPI)(nil)))
 }
 
 // newFacadeV10 is used for API registration.
-func newFacadeV10(ctx facade.MultiModelContext) (*ModelManagerAPI, error) {
+func newFacadeV10(stdCtx context.Context, ctx facade.MultiModelContext) (*ModelManagerAPI, error) {
 	st := ctx.State()
 	pool := ctx.StatePool()
 	ctlrSt, err := pool.SystemState()
@@ -84,6 +84,7 @@ func newFacadeV10(ctx facade.MultiModelContext) (*ModelManagerAPI, error) {
 
 	secretBackendService := serviceFactory.SecretBackend()
 	return NewModelManagerAPI(
+		stdCtx,
 		backend.(StateBackend),
 		ctx.ModelExporter(backend),
 		common.NewModelManagerBackend(configSchemaSource, ctrlModel, pool),

--- a/apiserver/facades/client/modelupgrader/upgrader.go
+++ b/apiserver/facades/client/modelupgrader/upgrader.go
@@ -101,8 +101,9 @@ func NewModelUpgraderAPI(
 	}, nil
 }
 
-func (m *ModelUpgraderAPI) canUpgrade(model names.ModelTag) error {
+func (m *ModelUpgraderAPI) canUpgrade(ctx context.Context, model names.ModelTag) error {
 	err := m.authorizer.HasPermission(
+		ctx,
 		permission.SuperuserAccess,
 		m.controllerTag,
 	)
@@ -113,7 +114,7 @@ func (m *ModelUpgraderAPI) canUpgrade(model names.ModelTag) error {
 		return nil
 	}
 
-	return m.authorizer.HasPermission(permission.WriteAccess, model)
+	return m.authorizer.HasPermission(ctx, permission.WriteAccess, model)
 }
 
 // ConfigSource describes a type that is able to provide config.
@@ -142,7 +143,7 @@ func (m *ModelUpgraderAPI) UpgradeModel(ctx stdcontext.Context, arg params.Upgra
 	if err != nil {
 		return result, errors.Trace(err)
 	}
-	if err := m.canUpgrade(modelTag); err != nil {
+	if err := m.canUpgrade(ctx, modelTag); err != nil {
 		return result, err
 	}
 

--- a/apiserver/facades/client/secretbackends/secrets.go
+++ b/apiserver/facades/client/secretbackends/secrets.go
@@ -29,8 +29,8 @@ type SecretBackendsAPI struct {
 	backendService SecretBackendService
 }
 
-func (s *SecretBackendsAPI) checkCanAdmin() error {
-	return s.authorizer.HasPermission(permission.SuperuserAccess, names.NewControllerTag(s.controllerUUID))
+func (s *SecretBackendsAPI) checkCanAdmin(ctx context.Context) error {
+	return s.authorizer.HasPermission(ctx, permission.SuperuserAccess, names.NewControllerTag(s.controllerUUID))
 }
 
 // AddSecretBackends adds new secret backends.
@@ -38,7 +38,7 @@ func (s *SecretBackendsAPI) AddSecretBackends(ctx context.Context, args params.A
 	result := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Args)),
 	}
-	if err := s.checkCanAdmin(); err != nil {
+	if err := s.checkCanAdmin(ctx); err != nil {
 		return result, errors.Trace(err)
 	}
 	for i, arg := range args.Args {
@@ -67,7 +67,7 @@ func (s *SecretBackendsAPI) UpdateSecretBackends(ctx context.Context, args param
 	result := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Args)),
 	}
-	if err := s.checkCanAdmin(); err != nil {
+	if err := s.checkCanAdmin(ctx); err != nil {
 		return result, errors.Trace(err)
 	}
 	for i, arg := range args.Args {
@@ -96,7 +96,7 @@ func (s *SecretBackendsAPI) UpdateSecretBackends(ctx context.Context, args param
 // ListSecretBackends lists available secret backends.
 func (s *SecretBackendsAPI) ListSecretBackends(ctx context.Context, arg params.ListSecretBackendsArgs) (params.ListSecretBackendsResults, error) {
 	if arg.Reveal {
-		if err := s.checkCanAdmin(); err != nil {
+		if err := s.checkCanAdmin(ctx); err != nil {
 			return params.ListSecretBackendsResults{}, errors.Trace(err)
 		}
 	}
@@ -130,7 +130,7 @@ func (s *SecretBackendsAPI) RemoveSecretBackends(ctx context.Context, args param
 	result := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Args)),
 	}
-	if err := s.checkCanAdmin(); err != nil {
+	if err := s.checkCanAdmin(ctx); err != nil {
 		return result, errors.Trace(err)
 	}
 	for i, arg := range args.Args {

--- a/apiserver/facades/client/secretbackends/secrets_test.go
+++ b/apiserver/facades/client/secretbackends/secrets_test.go
@@ -53,7 +53,7 @@ func (s *SecretsSuite) TestAddSecretBackends(c *gc.C) {
 	facade, ctrl := s.setup(c)
 	defer ctrl.Finish()
 
-	s.authorizer.EXPECT().HasPermission(permission.SuperuserAccess, coretesting.ControllerTag).Return(nil)
+	s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.SuperuserAccess, coretesting.ControllerTag).Return(nil)
 	addedConfig := map[string]interface{}{
 		"endpoint": "http://vault",
 	}
@@ -102,7 +102,7 @@ func (s *SecretsSuite) TestAddSecretBackendsPermissionDenied(c *gc.C) {
 	facade, ctrl := s.setup(c)
 	defer ctrl.Finish()
 
-	s.authorizer.EXPECT().HasPermission(permission.SuperuserAccess, coretesting.ControllerTag).Return(
+	s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.SuperuserAccess, coretesting.ControllerTag).Return(
 		errors.WithType(apiservererrors.ErrPerm, authentication.ErrorEntityMissingPermission))
 
 	_, err := facade.AddSecretBackends(context.Background(), params.AddSecretBackendArgs{})
@@ -122,7 +122,7 @@ func (s *SecretsSuite) assertListSecretBackends(c *gc.C, reveal bool) {
 	defer ctrl.Finish()
 
 	if reveal {
-		s.authorizer.EXPECT().HasPermission(permission.SuperuserAccess, coretesting.ControllerTag).Return(nil)
+		s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.SuperuserAccess, coretesting.ControllerTag).Return(nil)
 	}
 	s.mockBackendService.EXPECT().BackendSummaryInfo(gomock.Any(), reveal, "myvault").
 		Return([]*secretbackendservice.SecretBackendInfo{
@@ -193,7 +193,7 @@ func (s *SecretsSuite) TestListSecretBackendsPermissionDeniedReveal(c *gc.C) {
 	facade, ctrl := s.setup(c)
 	defer ctrl.Finish()
 
-	s.authorizer.EXPECT().HasPermission(permission.SuperuserAccess, coretesting.ControllerTag).Return(
+	s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.SuperuserAccess, coretesting.ControllerTag).Return(
 		errors.WithType(apiservererrors.ErrPerm, authentication.ErrorEntityMissingPermission))
 
 	_, err := facade.ListSecretBackends(context.Background(), params.ListSecretBackendsArgs{Reveal: true})
@@ -204,7 +204,7 @@ func (s *SecretsSuite) TestUpdateSecretBackends(c *gc.C) {
 	facade, ctrl := s.setup(c)
 	defer ctrl.Finish()
 
-	s.authorizer.EXPECT().HasPermission(permission.SuperuserAccess, coretesting.ControllerTag).Return(nil)
+	s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.SuperuserAccess, coretesting.ControllerTag).Return(nil)
 
 	s.mockBackendService.EXPECT().UpdateSecretBackend(gomock.Any(),
 		secretbackendservice.UpdateSecretBackendParams{
@@ -259,7 +259,7 @@ func (s *SecretsSuite) TestUpdateSecretBackendsPermissionDenied(c *gc.C) {
 	facade, ctrl := s.setup(c)
 	defer ctrl.Finish()
 
-	s.authorizer.EXPECT().HasPermission(permission.SuperuserAccess, coretesting.ControllerTag).Return(
+	s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.SuperuserAccess, coretesting.ControllerTag).Return(
 		errors.WithType(apiservererrors.ErrPerm, authentication.ErrorEntityMissingPermission))
 
 	_, err := facade.UpdateSecretBackends(context.Background(), params.UpdateSecretBackendArgs{})
@@ -270,7 +270,7 @@ func (s *SecretsSuite) TestRemoveSecretBackends(c *gc.C) {
 	facade, ctrl := s.setup(c)
 	defer ctrl.Finish()
 
-	s.authorizer.EXPECT().HasPermission(permission.SuperuserAccess, coretesting.ControllerTag).Return(nil)
+	s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.SuperuserAccess, coretesting.ControllerTag).Return(nil)
 
 	gomock.InOrder(
 		s.mockBackendService.EXPECT().DeleteSecretBackend(gomock.Any(),
@@ -306,7 +306,7 @@ func (s *SecretsSuite) TestRemoveSecretBackendsPermissionDenied(c *gc.C) {
 	facade, ctrl := s.setup(c)
 	defer ctrl.Finish()
 
-	s.authorizer.EXPECT().HasPermission(permission.SuperuserAccess, coretesting.ControllerTag).Return(
+	s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.SuperuserAccess, coretesting.ControllerTag).Return(
 		errors.WithType(apiservererrors.ErrPerm, authentication.ErrorEntityMissingPermission))
 
 	_, err := facade.RemoveSecretBackends(context.Background(), params.RemoveSecretBackendArgs{})

--- a/apiserver/facades/client/secrets/secrets.go
+++ b/apiserver/facades/client/secrets/secrets.go
@@ -41,16 +41,16 @@ type SecretsAPIV1 struct {
 	*SecretsAPI
 }
 
-func (s *SecretsAPI) checkCanRead() error {
-	return s.authorizer.HasPermission(permission.ReadAccess, names.NewModelTag(s.modelUUID))
+func (s *SecretsAPI) checkCanRead(ctx context.Context) error {
+	return s.authorizer.HasPermission(ctx, permission.ReadAccess, names.NewModelTag(s.modelUUID))
 }
 
-func (s *SecretsAPI) checkCanWrite() error {
-	return s.authorizer.HasPermission(permission.WriteAccess, names.NewModelTag(s.modelUUID))
+func (s *SecretsAPI) checkCanWrite(ctx context.Context) error {
+	return s.authorizer.HasPermission(ctx, permission.WriteAccess, names.NewModelTag(s.modelUUID))
 }
 
-func (s *SecretsAPI) checkCanAdmin() error {
-	isAdmin, err := common.HasModelAdmin(s.authorizer, names.NewControllerTag(s.controllerUUID), names.NewModelTag(s.modelUUID))
+func (s *SecretsAPI) checkCanAdmin(ctx context.Context) error {
+	isAdmin, err := common.HasModelAdmin(ctx, s.authorizer, names.NewControllerTag(s.controllerUUID), names.NewModelTag(s.modelUUID))
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -66,11 +66,11 @@ func (s *SecretsAPI) checkCanAdmin() error {
 func (s *SecretsAPI) ListSecrets(ctx context.Context, arg params.ListSecretsArgs) (params.ListSecretResults, error) {
 	result := params.ListSecretResults{}
 	if arg.ShowSecrets {
-		if err := s.checkCanAdmin(); err != nil {
+		if err := s.checkCanAdmin(ctx); err != nil {
 			return result, errors.Trace(err)
 		}
 	} else {
-		if err := s.checkCanRead(); err != nil {
+		if err := s.checkCanRead(ctx); err != nil {
 			return result, errors.Trace(err)
 		}
 	}
@@ -235,7 +235,7 @@ func (s *SecretsAPI) CreateSecrets(ctx context.Context, args params.CreateSecret
 	result := params.StringResults{
 		Results: make([]params.StringResult, len(args.Args)),
 	}
-	if err := s.checkCanWrite(); err != nil {
+	if err := s.checkCanWrite(ctx); err != nil {
 		return result, errors.Trace(err)
 	}
 	for i, arg := range args.Args {
@@ -307,7 +307,7 @@ func (s *SecretsAPI) UpdateSecrets(ctx context.Context, args params.UpdateUserSe
 	result := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Args)),
 	}
-	if err := s.checkCanWrite(); err != nil {
+	if err := s.checkCanWrite(ctx); err != nil {
 		return result, errors.Trace(err)
 	}
 	for i, arg := range args.Args {
@@ -367,7 +367,7 @@ func (s *SecretsAPI) RemoveSecrets(ctx context.Context, args params.DeleteSecret
 		return result, nil
 	}
 
-	if err := s.checkCanWrite(); err != nil {
+	if err := s.checkCanWrite(ctx); err != nil {
 		return result, errors.Trace(err)
 	}
 
@@ -416,7 +416,7 @@ func (s *SecretsAPI) secretsGrantRevoke(ctx context.Context, arg params.GrantRev
 		return results, errors.New("must specify either URI or name")
 	}
 
-	if err := s.checkCanWrite(); err != nil {
+	if err := s.checkCanWrite(ctx); err != nil {
 		return results, errors.Trace(err)
 	}
 

--- a/apiserver/facades/client/secrets/secrets_test.go
+++ b/apiserver/facades/client/secrets/secrets_test.go
@@ -75,9 +75,9 @@ func (s *SecretsSuite) assertListSecrets(c *gc.C, reveal bool) {
 
 	s.expectAuthClient()
 	if reveal {
-		s.authorizer.EXPECT().HasPermission(permission.SuperuserAccess, coretesting.ControllerTag).Return(nil)
+		s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.SuperuserAccess, coretesting.ControllerTag).Return(nil)
 	} else {
-		s.authorizer.EXPECT().HasPermission(permission.ReadAccess, coretesting.ModelTag).Return(nil)
+		s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.ReadAccess, coretesting.ModelTag).Return(nil)
 	}
 
 	facade, err := apisecrets.NewTestAPI(s.authTag, s.authorizer, s.secretService, s.secretBackendService)
@@ -182,7 +182,7 @@ func (s *SecretsSuite) TestListSecretsPermissionDenied(c *gc.C) {
 	defer s.setup(c).Finish()
 
 	s.expectAuthClient()
-	s.authorizer.EXPECT().HasPermission(permission.ReadAccess, coretesting.ModelTag).Return(
+	s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.ReadAccess, coretesting.ModelTag).Return(
 		errors.WithType(apiservererrors.ErrPerm, authentication.ErrorEntityMissingPermission))
 
 	facade, err := apisecrets.NewTestAPI(s.authTag, s.authorizer, s.secretService, s.secretBackendService)
@@ -196,9 +196,9 @@ func (s *SecretsSuite) TestListSecretsPermissionDeniedShow(c *gc.C) {
 	defer s.setup(c).Finish()
 
 	s.expectAuthClient()
-	s.authorizer.EXPECT().HasPermission(permission.SuperuserAccess, coretesting.ControllerTag).Return(
+	s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.SuperuserAccess, coretesting.ControllerTag).Return(
 		errors.WithType(apiservererrors.ErrPerm, authentication.ErrorEntityMissingPermission))
-	s.authorizer.EXPECT().HasPermission(permission.AdminAccess, coretesting.ModelTag).Return(
+	s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.AdminAccess, coretesting.ModelTag).Return(
 		errors.WithType(apiservererrors.ErrPerm, authentication.ErrorEntityMissingPermission))
 
 	facade, err := apisecrets.NewTestAPI(s.authTag, s.authorizer, s.secretService, s.secretBackendService)
@@ -212,7 +212,7 @@ func (s *SecretsSuite) TestCreateSecretsPermissionDenied(c *gc.C) {
 	defer s.setup(c).Finish()
 
 	s.expectAuthClient()
-	s.authorizer.EXPECT().HasPermission(permission.WriteAccess, coretesting.ModelTag).Return(
+	s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.WriteAccess, coretesting.ModelTag).Return(
 		errors.WithType(apiservererrors.ErrPerm, authentication.ErrorEntityMissingPermission))
 
 	facade, err := apisecrets.NewTestAPI(s.authTag, s.authorizer, s.secretService, s.secretBackendService)
@@ -226,7 +226,7 @@ func (s *SecretsSuite) TestCreateSecretsEmptyData(c *gc.C) {
 	defer s.setup(c).Finish()
 
 	s.expectAuthClient()
-	s.authorizer.EXPECT().HasPermission(permission.WriteAccess, coretesting.ModelTag).Return(nil)
+	s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.WriteAccess, coretesting.ModelTag).Return(nil)
 
 	uri := coresecrets.NewURI()
 	uriStrPtr := ptr(uri.String())
@@ -250,7 +250,7 @@ func (s *SecretsSuite) TestCreateSecrets(c *gc.C) {
 	defer s.setup(c).Finish()
 
 	s.expectAuthClient()
-	s.authorizer.EXPECT().HasPermission(permission.WriteAccess, coretesting.ModelTag).Return(nil)
+	s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.WriteAccess, coretesting.ModelTag).Return(nil)
 
 	uri := coresecrets.NewURI()
 	uriStrPtr := ptr(uri.String())
@@ -289,7 +289,7 @@ func (s *SecretsSuite) assertUpdateSecrets(c *gc.C, uri *coresecrets.URI) {
 	defer s.setup(c).Finish()
 
 	s.expectAuthClient()
-	s.authorizer.EXPECT().HasPermission(permission.WriteAccess, coretesting.ModelTag).Return(nil)
+	s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.WriteAccess, coretesting.ModelTag).Return(nil)
 
 	var (
 		uriString, existingLabel string
@@ -347,7 +347,7 @@ func (s *SecretsSuite) TestRemoveSecrets(c *gc.C) {
 
 	uri := coresecrets.NewURI()
 	expectURI := *uri
-	s.authorizer.EXPECT().HasPermission(permission.WriteAccess, coretesting.ModelTag).Return(nil)
+	s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.WriteAccess, coretesting.ModelTag).Return(nil)
 	s.secretService.EXPECT().DeleteSecret(gomock.Any(), &expectURI, secretservice.DeleteSecretParams{
 		Accessor:  secretservice.SecretAccessor{Kind: secretservice.ModelAccessor, ID: coretesting.ModelTag.Id()},
 		Revisions: []int{666},
@@ -373,7 +373,7 @@ func (s *SecretsSuite) TestRemoveSecretsFailedNotModelAdmin(c *gc.C) {
 
 	uri := coresecrets.NewURI()
 	expectURI := *uri
-	s.authorizer.EXPECT().HasPermission(permission.WriteAccess, coretesting.ModelTag).Return(apiservererrors.ErrPerm)
+	s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.WriteAccess, coretesting.ModelTag).Return(apiservererrors.ErrPerm)
 
 	facade, err := apisecrets.NewTestAPI(s.authTag, s.authorizer, s.secretService, s.secretBackendService)
 	c.Assert(err, jc.ErrorIsNil)
@@ -392,7 +392,7 @@ func (s *SecretsSuite) TestRemoveSecretRevision(c *gc.C) {
 
 	uri := coresecrets.NewURI()
 	expectURI := *uri
-	s.authorizer.EXPECT().HasPermission(permission.WriteAccess, coretesting.ModelTag).Return(nil)
+	s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.WriteAccess, coretesting.ModelTag).Return(nil)
 	s.secretService.EXPECT().DeleteSecret(gomock.Any(), &expectURI, secretservice.DeleteSecretParams{
 		Accessor:  secretservice.SecretAccessor{Kind: secretservice.ModelAccessor, ID: coretesting.ModelTag.Id()},
 		Revisions: []int{666},
@@ -415,7 +415,7 @@ func (s *SecretsSuite) TestRemoveSecretRevision(c *gc.C) {
 func (s *SecretsSuite) TestRemoveSecretNotFound(c *gc.C) {
 	defer s.setup(c).Finish()
 	s.expectAuthClient()
-	s.authorizer.EXPECT().HasPermission(permission.WriteAccess, coretesting.ModelTag).Return(nil)
+	s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.WriteAccess, coretesting.ModelTag).Return(nil)
 
 	uri := coresecrets.NewURI()
 	expectURI := *uri
@@ -440,7 +440,7 @@ func (s *SecretsSuite) TestGrantSecret(c *gc.C) {
 	defer s.setup(c).Finish()
 
 	s.expectAuthClient()
-	s.authorizer.EXPECT().HasPermission(permission.WriteAccess, coretesting.ModelTag).Return(nil)
+	s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.WriteAccess, coretesting.ModelTag).Return(nil)
 
 	uri := coresecrets.NewURI()
 	s.secretService.EXPECT().GrantSecretAccess(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
@@ -483,7 +483,7 @@ func (s *SecretsSuite) TestGrantSecretByName(c *gc.C) {
 	defer s.setup(c).Finish()
 
 	s.expectAuthClient()
-	s.authorizer.EXPECT().HasPermission(permission.WriteAccess, coretesting.ModelTag).Return(nil)
+	s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.WriteAccess, coretesting.ModelTag).Return(nil)
 
 	uri := coresecrets.NewURI()
 	s.secretService.EXPECT().GetUserSecretURIByLabel(gomock.Any(), "my-secret").Return(uri, nil)
@@ -527,7 +527,7 @@ func (s *SecretsSuite) TestGrantSecretPermissionDenied(c *gc.C) {
 	defer s.setup(c).Finish()
 
 	s.expectAuthClient()
-	s.authorizer.EXPECT().HasPermission(permission.WriteAccess, coretesting.ModelTag).Return(
+	s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.WriteAccess, coretesting.ModelTag).Return(
 		errors.WithType(apiservererrors.ErrPerm, authentication.ErrorEntityMissingPermission),
 	)
 
@@ -542,7 +542,7 @@ func (s *SecretsSuite) TestRevokeSecret(c *gc.C) {
 	defer s.setup(c).Finish()
 
 	s.expectAuthClient()
-	s.authorizer.EXPECT().HasPermission(permission.WriteAccess, coretesting.ModelTag).Return(nil)
+	s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.WriteAccess, coretesting.ModelTag).Return(nil)
 
 	uri := coresecrets.NewURI()
 	s.secretService.EXPECT().RevokeSecretAccess(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
@@ -585,7 +585,7 @@ func (s *SecretsSuite) TestRevokeSecretPermissionDenied(c *gc.C) {
 	defer s.setup(c).Finish()
 
 	s.expectAuthClient()
-	s.authorizer.EXPECT().HasPermission(permission.WriteAccess, coretesting.ModelTag).Return(
+	s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.WriteAccess, coretesting.ModelTag).Return(
 		errors.WithType(apiservererrors.ErrPerm, authentication.ErrorEntityMissingPermission),
 	)
 

--- a/apiserver/facades/client/spaces/package_test.go
+++ b/apiserver/facades/client/spaces/package_test.go
@@ -59,7 +59,7 @@ func (s *APISuite) SetupMocks(c *gc.C, supportSpaces bool, providerSpaces bool) 
 	s.blockChecker.EXPECT().ChangeAllowed(gomock.Any()).Return(nil).AnyTimes()
 
 	s.authorizer = facademocks.NewMockAuthorizer(ctrl)
-	s.authorizer.EXPECT().HasPermission(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	s.authorizer.EXPECT().HasPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	s.authorizer.EXPECT().AuthClient().Return(true)
 
 	cloudSpec := environscloudspec.CloudSpec{

--- a/apiserver/facades/client/spaces/spaces.go
+++ b/apiserver/facades/client/spaces/spaces.go
@@ -111,7 +111,7 @@ func newAPIWithBacking(cfg apiConfig) (*API, error) {
 // CreateSpaces creates a new Juju network space, associating the
 // specified subnets with it (optional; can be empty).
 func (api *API) CreateSpaces(ctx stdcontext.Context, args params.CreateSpacesParams) (results params.ErrorResults, err error) {
-	err = api.auth.HasPermission(permission.AdminAccess, api.backing.ModelTag())
+	err = api.auth.HasPermission(ctx, permission.AdminAccess, api.backing.ModelTag())
 	if err != nil {
 		return results, err
 	}
@@ -170,7 +170,7 @@ func (api *API) createOneSpace(ctx context.Context, args params.CreateSpaceParam
 
 // ListSpaces lists all the available spaces and their associated subnets.
 func (api *API) ListSpaces(ctx stdcontext.Context) (results params.ListSpacesResults, err error) {
-	err = api.auth.HasPermission(permission.ReadAccess, api.backing.ModelTag())
+	err = api.auth.HasPermission(ctx, permission.ReadAccess, api.backing.ModelTag())
 	if err != nil {
 		return results, err
 	}
@@ -210,7 +210,7 @@ func (api *API) ListSpaces(ctx stdcontext.Context) (results params.ListSpacesRes
 
 // ShowSpace shows the spaces for a set of given entities.
 func (api *API) ShowSpace(ctx stdcontext.Context, entities params.Entities) (params.ShowSpaceResults, error) {
-	err := api.auth.HasPermission(permission.ReadAccess, api.backing.ModelTag())
+	err := api.auth.HasPermission(ctx, permission.ReadAccess, api.backing.ModelTag())
 	if err != nil {
 		return params.ShowSpaceResults{}, err
 	}
@@ -284,7 +284,7 @@ func (api *API) ShowSpace(ctx stdcontext.Context, entities params.Entities) (par
 
 // ReloadSpaces refreshes spaces from substrate
 func (api *API) ReloadSpaces(ctx stdcontext.Context) error {
-	err := api.auth.HasPermission(permission.AdminAccess, api.backing.ModelTag())
+	err := api.auth.HasPermission(ctx, permission.AdminAccess, api.backing.ModelTag())
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -351,7 +351,7 @@ func (api *API) applicationsBoundToSpace(spaceID string, allSpaces network.Space
 // ensureSpacesAreMutable checks that the current user
 // is allowed to edit the Space topology.
 func (api *API) ensureSpacesAreMutable(ctx stdcontext.Context) error {
-	err := api.auth.HasPermission(permission.AdminAccess, api.backing.ModelTag())
+	err := api.auth.HasPermission(ctx, permission.AdminAccess, api.backing.ModelTag())
 	if err != nil {
 		return err
 	}

--- a/apiserver/facades/client/sshclient/authorizer_mock_test.go
+++ b/apiserver/facades/client/sshclient/authorizer_mock_test.go
@@ -10,6 +10,7 @@
 package sshclient_test
 
 import (
+	context "context"
 	reflect "reflect"
 
 	permission "github.com/juju/juju/core/permission"
@@ -345,17 +346,17 @@ func (c *MockAuthorizerConnectedModelCall) DoAndReturn(f func() string) *MockAut
 }
 
 // EntityHasPermission mocks base method.
-func (m *MockAuthorizer) EntityHasPermission(arg0 names.Tag, arg1 permission.Access, arg2 names.Tag) error {
+func (m *MockAuthorizer) EntityHasPermission(arg0 context.Context, arg1 names.Tag, arg2 permission.Access, arg3 names.Tag) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EntityHasPermission", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "EntityHasPermission", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // EntityHasPermission indicates an expected call of EntityHasPermission.
-func (mr *MockAuthorizerMockRecorder) EntityHasPermission(arg0, arg1, arg2 any) *MockAuthorizerEntityHasPermissionCall {
+func (mr *MockAuthorizerMockRecorder) EntityHasPermission(arg0, arg1, arg2, arg3 any) *MockAuthorizerEntityHasPermissionCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EntityHasPermission", reflect.TypeOf((*MockAuthorizer)(nil).EntityHasPermission), arg0, arg1, arg2)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EntityHasPermission", reflect.TypeOf((*MockAuthorizer)(nil).EntityHasPermission), arg0, arg1, arg2, arg3)
 	return &MockAuthorizerEntityHasPermissionCall{Call: call}
 }
 
@@ -371,13 +372,13 @@ func (c *MockAuthorizerEntityHasPermissionCall) Return(arg0 error) *MockAuthoriz
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockAuthorizerEntityHasPermissionCall) Do(f func(names.Tag, permission.Access, names.Tag) error) *MockAuthorizerEntityHasPermissionCall {
+func (c *MockAuthorizerEntityHasPermissionCall) Do(f func(context.Context, names.Tag, permission.Access, names.Tag) error) *MockAuthorizerEntityHasPermissionCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockAuthorizerEntityHasPermissionCall) DoAndReturn(f func(names.Tag, permission.Access, names.Tag) error) *MockAuthorizerEntityHasPermissionCall {
+func (c *MockAuthorizerEntityHasPermissionCall) DoAndReturn(f func(context.Context, names.Tag, permission.Access, names.Tag) error) *MockAuthorizerEntityHasPermissionCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -421,17 +422,17 @@ func (c *MockAuthorizerGetAuthTagCall) DoAndReturn(f func() names.Tag) *MockAuth
 }
 
 // HasPermission mocks base method.
-func (m *MockAuthorizer) HasPermission(arg0 permission.Access, arg1 names.Tag) error {
+func (m *MockAuthorizer) HasPermission(arg0 context.Context, arg1 permission.Access, arg2 names.Tag) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HasPermission", arg0, arg1)
+	ret := m.ctrl.Call(m, "HasPermission", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // HasPermission indicates an expected call of HasPermission.
-func (mr *MockAuthorizerMockRecorder) HasPermission(arg0, arg1 any) *MockAuthorizerHasPermissionCall {
+func (mr *MockAuthorizerMockRecorder) HasPermission(arg0, arg1, arg2 any) *MockAuthorizerHasPermissionCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasPermission", reflect.TypeOf((*MockAuthorizer)(nil).HasPermission), arg0, arg1)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasPermission", reflect.TypeOf((*MockAuthorizer)(nil).HasPermission), arg0, arg1, arg2)
 	return &MockAuthorizerHasPermissionCall{Call: call}
 }
 
@@ -447,13 +448,13 @@ func (c *MockAuthorizerHasPermissionCall) Return(arg0 error) *MockAuthorizerHasP
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockAuthorizerHasPermissionCall) Do(f func(permission.Access, names.Tag) error) *MockAuthorizerHasPermissionCall {
+func (c *MockAuthorizerHasPermissionCall) Do(f func(context.Context, permission.Access, names.Tag) error) *MockAuthorizerHasPermissionCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockAuthorizerHasPermissionCall) DoAndReturn(f func(permission.Access, names.Tag) error) *MockAuthorizerHasPermissionCall {
+func (c *MockAuthorizerHasPermissionCall) DoAndReturn(f func(context.Context, permission.Access, names.Tag) error) *MockAuthorizerHasPermissionCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/client/sshclient/facade.go
+++ b/apiserver/facades/client/sshclient/facade.go
@@ -55,8 +55,8 @@ func internalFacade(
 	}, nil
 }
 
-func (facade *Facade) checkIsModelAdmin() error {
-	err := facade.authorizer.HasPermission(permission.SuperuserAccess, facade.backend.ControllerTag())
+func (facade *Facade) checkIsModelAdmin(ctx stdcontext.Context) error {
+	err := facade.authorizer.HasPermission(ctx, permission.SuperuserAccess, facade.backend.ControllerTag())
 	if err != nil && !errors.Is(err, authentication.ErrorEntityMissingPermission) {
 		return errors.Trace(err)
 	}
@@ -65,13 +65,13 @@ func (facade *Facade) checkIsModelAdmin() error {
 		return nil
 	}
 
-	return facade.authorizer.HasPermission(permission.AdminAccess, facade.backend.ModelTag())
+	return facade.authorizer.HasPermission(ctx, permission.AdminAccess, facade.backend.ModelTag())
 }
 
 // PublicAddress reports the preferred public network address for one
 // or more entities. Machines and units are supported.
 func (facade *Facade) PublicAddress(ctx stdcontext.Context, args params.Entities) (params.SSHAddressResults, error) {
-	if err := facade.checkIsModelAdmin(); err != nil {
+	if err := facade.checkIsModelAdmin(ctx); err != nil {
 		return params.SSHAddressResults{}, errors.Trace(err)
 	}
 
@@ -82,7 +82,7 @@ func (facade *Facade) PublicAddress(ctx stdcontext.Context, args params.Entities
 // PrivateAddress reports the preferred private network address for one or
 // more entities. Machines and units are supported.
 func (facade *Facade) PrivateAddress(ctx stdcontext.Context, args params.Entities) (params.SSHAddressResults, error) {
-	if err := facade.checkIsModelAdmin(); err != nil {
+	if err := facade.checkIsModelAdmin(ctx); err != nil {
 		return params.SSHAddressResults{}, errors.Trace(err)
 	}
 
@@ -94,7 +94,7 @@ func (facade *Facade) PrivateAddress(ctx stdcontext.Context, args params.Entitie
 // entity in args. The result is sorted with public addresses first.
 // Machines and units are supported as entity types.
 func (facade *Facade) AllAddresses(ctx stdcontext.Context, args params.Entities) (params.SSHAddressesResults, error) {
-	if err := facade.checkIsModelAdmin(); err != nil {
+	if err := facade.checkIsModelAdmin(ctx); err != nil {
 		return params.SSHAddressesResults{}, errors.Trace(err)
 	}
 
@@ -183,7 +183,7 @@ func (facade *Facade) getAddressPerEntity(args params.Entities, addressGetter fu
 // PublicKeys returns the public SSH hosts for one or more
 // entities. Machines and units are supported.
 func (facade *Facade) PublicKeys(ctx stdcontext.Context, args params.Entities) (params.SSHPublicKeysResults, error) {
-	if err := facade.checkIsModelAdmin(); err != nil {
+	if err := facade.checkIsModelAdmin(ctx); err != nil {
 		return params.SSHPublicKeysResults{}, errors.Trace(err)
 	}
 
@@ -199,7 +199,7 @@ func (facade *Facade) PublicKeys(ctx stdcontext.Context, args params.Entities) (
 			if err != nil {
 				out.Results[i].Error = apiservererrors.ServerError(err)
 			} else {
-				out.Results[i].PublicKeys = []string(keys)
+				out.Results[i].PublicKeys = keys
 			}
 		}
 	}
@@ -209,7 +209,7 @@ func (facade *Facade) PublicKeys(ctx stdcontext.Context, args params.Entities) (
 // Proxy returns whether SSH connections should be proxied through the
 // controller hosts for the model associated with the API connection.
 func (facade *Facade) Proxy(ctx stdcontext.Context) (params.SSHProxyResult, error) {
-	if err := facade.checkIsModelAdmin(); err != nil {
+	if err := facade.checkIsModelAdmin(ctx); err != nil {
 		return params.SSHProxyResult{}, errors.Trace(err)
 	}
 	config, err := facade.modelConfigService.ModelConfig(ctx)
@@ -224,7 +224,7 @@ func (facade *Facade) Proxy(ctx stdcontext.Context) (params.SSHProxyResult, erro
 func (facade *Facade) ModelCredentialForSSH(ctx stdcontext.Context) (params.CloudSpecResult, error) {
 	var result params.CloudSpecResult
 
-	if err := facade.checkIsModelAdmin(); err != nil {
+	if err := facade.checkIsModelAdmin(ctx); err != nil {
 		return result, err
 	}
 

--- a/apiserver/facades/client/sshclient/facade_test.go
+++ b/apiserver/facades/client/sshclient/facade_test.go
@@ -90,8 +90,8 @@ func (s *facadeSuite) TestNonAuthUserDenied(c *gc.C) {
 
 	gomock.InOrder(
 		s.authorizer.EXPECT().AuthClient().Return(true),
-		s.authorizer.EXPECT().HasPermission(permission.SuperuserAccess, testing.ControllerTag).Return(authentication.ErrorEntityMissingPermission),
-		s.authorizer.EXPECT().HasPermission(permission.AdminAccess, testing.ModelTag).Return(apiservererrors.ErrPerm),
+		s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.SuperuserAccess, testing.ControllerTag).Return(authentication.ErrorEntityMissingPermission),
+		s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.AdminAccess, testing.ModelTag).Return(apiservererrors.ErrPerm),
 	)
 
 	facade, err := sshclient.InternalFacade(
@@ -125,7 +125,7 @@ func (s *facadeSuite) TestSuperUserAuth(c *gc.C) {
 
 	gomock.InOrder(
 		s.authorizer.EXPECT().AuthClient().Return(true),
-		s.authorizer.EXPECT().HasPermission(permission.SuperuserAccess, testing.ControllerTag).Return(nil),
+		s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.SuperuserAccess, testing.ControllerTag).Return(nil),
 	)
 
 	machine0 := NewMockSSHMachine(ctrl)
@@ -167,7 +167,7 @@ func (s *facadeSuite) TestPublicAddress(c *gc.C) {
 
 	gomock.InOrder(
 		s.authorizer.EXPECT().AuthClient().Return(true),
-		s.authorizer.EXPECT().HasPermission(permission.SuperuserAccess, testing.ControllerTag).Return(nil),
+		s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.SuperuserAccess, testing.ControllerTag).Return(nil),
 	)
 
 	machine0 := NewMockSSHMachine(ctrl)
@@ -212,7 +212,7 @@ func (s *facadeSuite) TestPrivateAddress(c *gc.C) {
 
 	gomock.InOrder(
 		s.authorizer.EXPECT().AuthClient().Return(true),
-		s.authorizer.EXPECT().HasPermission(permission.SuperuserAccess, testing.ControllerTag).Return(nil),
+		s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.SuperuserAccess, testing.ControllerTag).Return(nil),
 	)
 
 	machine0 := NewMockSSHMachine(ctrl)
@@ -257,7 +257,7 @@ func (s *facadeSuite) TestAllAddresses(c *gc.C) {
 
 	gomock.InOrder(
 		s.authorizer.EXPECT().AuthClient().Return(true),
-		s.authorizer.EXPECT().HasPermission(permission.SuperuserAccess, testing.ControllerTag).Return(nil),
+		s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.SuperuserAccess, testing.ControllerTag).Return(nil),
 	)
 
 	machine0Addresses := network.SpaceAddresses{
@@ -335,7 +335,7 @@ func (s *facadeSuite) TestPublicKeys(c *gc.C) {
 
 	gomock.InOrder(
 		s.authorizer.EXPECT().AuthClient().Return(true),
-		s.authorizer.EXPECT().HasPermission(permission.SuperuserAccess, testing.ControllerTag).Return(nil),
+		s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.SuperuserAccess, testing.ControllerTag).Return(nil),
 	)
 
 	machine0 := NewMockSSHMachine(ctrl)
@@ -383,7 +383,7 @@ func (s *facadeSuite) TestProxyTrue(c *gc.C) {
 
 	gomock.InOrder(
 		s.authorizer.EXPECT().AuthClient().Return(true),
-		s.authorizer.EXPECT().HasPermission(permission.SuperuserAccess, testing.ControllerTag).Return(nil),
+		s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.SuperuserAccess, testing.ControllerTag).Return(nil),
 	)
 
 	s.modelConfigService.EXPECT().ModelConfig(gomock.Any()).Return(config.New(false, map[string]any{
@@ -418,7 +418,7 @@ func (s *facadeSuite) TestProxyFalse(c *gc.C) {
 
 	gomock.InOrder(
 		s.authorizer.EXPECT().AuthClient().Return(true),
-		s.authorizer.EXPECT().HasPermission(permission.SuperuserAccess, testing.ControllerTag).Return(nil),
+		s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.SuperuserAccess, testing.ControllerTag).Return(nil),
 	)
 
 	s.modelConfigService.EXPECT().ModelConfig(gomock.Any()).Return(config.New(false, map[string]any{
@@ -454,8 +454,8 @@ func (s *facadeSuite) TestModelCredentialForSSHFailedNotAuthorized(c *gc.C) {
 
 	gomock.InOrder(
 		s.authorizer.EXPECT().AuthClient().Return(true),
-		s.authorizer.EXPECT().HasPermission(permission.SuperuserAccess, testing.ControllerTag).Return(authentication.ErrorEntityMissingPermission),
-		s.authorizer.EXPECT().HasPermission(permission.AdminAccess, testing.ModelTag).Return(apiservererrors.ErrPerm),
+		s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.SuperuserAccess, testing.ControllerTag).Return(authentication.ErrorEntityMissingPermission),
+		s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.AdminAccess, testing.ModelTag).Return(apiservererrors.ErrPerm),
 	)
 
 	facade, err := sshclient.InternalFacade(
@@ -485,8 +485,8 @@ func (s *facadeSuite) TestModelCredentialForSSHFailedNonCAASModel(c *gc.C) {
 
 	gomock.InOrder(
 		s.authorizer.EXPECT().AuthClient().Return(true),
-		s.authorizer.EXPECT().HasPermission(permission.SuperuserAccess, testing.ControllerTag).Return(authentication.ErrorEntityMissingPermission),
-		s.authorizer.EXPECT().HasPermission(permission.AdminAccess, testing.ModelTag).Return(nil),
+		s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.SuperuserAccess, testing.ControllerTag).Return(authentication.ErrorEntityMissingPermission),
+		s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.AdminAccess, testing.ModelTag).Return(nil),
 		s.backend.EXPECT().Model().Return(s.model, nil),
 		s.model.EXPECT().Type().Return(state.ModelTypeIAAS),
 	)
@@ -529,8 +529,8 @@ func (s *facadeSuite) TestModelCredentialForSSHFailedBadCredential(c *gc.C) {
 
 	gomock.InOrder(
 		s.authorizer.EXPECT().AuthClient().Return(true),
-		s.authorizer.EXPECT().HasPermission(permission.SuperuserAccess, testing.ControllerTag).Return(authentication.ErrorEntityMissingPermission),
-		s.authorizer.EXPECT().HasPermission(permission.AdminAccess, testing.ModelTag).Return(nil),
+		s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.SuperuserAccess, testing.ControllerTag).Return(authentication.ErrorEntityMissingPermission),
+		s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.AdminAccess, testing.ModelTag).Return(nil),
 		s.backend.EXPECT().Model().Return(s.model, nil),
 		s.model.EXPECT().Type().Return(state.ModelTypeCAAS),
 		s.backend.EXPECT().CloudSpec(gomock.Any()).Return(cloudSpec, nil),
@@ -558,8 +558,8 @@ func (s *facadeSuite) TestModelCredentialForSSH(c *gc.C) {
 	ctrl := s.setupMocks(c)
 	defer ctrl.Finish()
 
-	s.authorizer.EXPECT().HasPermission(permission.SuperuserAccess, testing.ControllerTag).Return(authentication.ErrorEntityMissingPermission)
-	s.authorizer.EXPECT().HasPermission(permission.AdminAccess, testing.ModelTag).Return(nil)
+	s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.SuperuserAccess, testing.ControllerTag).Return(authentication.ErrorEntityMissingPermission)
+	s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.AdminAccess, testing.ModelTag).Return(nil)
 
 	s.assertModelCredentialForSSH(c)
 }
@@ -568,8 +568,8 @@ func (s *facadeSuite) TestModelCredentialForSSHAdminAccess(c *gc.C) {
 	ctrl := s.setupMocks(c)
 	defer ctrl.Finish()
 
-	s.authorizer.EXPECT().HasPermission(permission.AdminAccess, testing.ModelTag).Return(nil)
-	s.authorizer.EXPECT().HasPermission(permission.SuperuserAccess, testing.ControllerTag).Return(authentication.ErrorEntityMissingPermission)
+	s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.AdminAccess, testing.ModelTag).Return(nil)
+	s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.SuperuserAccess, testing.ControllerTag).Return(authentication.ErrorEntityMissingPermission)
 
 	s.assertModelCredentialForSSH(c)
 }
@@ -578,7 +578,7 @@ func (s *facadeSuite) TestModelCredentialForSSHSuperuserAccess(c *gc.C) {
 	ctrl := s.setupMocks(c)
 	defer ctrl.Finish()
 
-	s.authorizer.EXPECT().HasPermission(permission.SuperuserAccess, testing.ControllerTag).Return(nil)
+	s.authorizer.EXPECT().HasPermission(gomock.Any(), permission.SuperuserAccess, testing.ControllerTag).Return(nil)
 
 	s.assertModelCredentialForSSH(c)
 }

--- a/apiserver/facades/client/storage/storage.go
+++ b/apiserver/facades/client/storage/storage.go
@@ -69,8 +69,8 @@ func NewStorageAPI(
 	}
 }
 
-func (a *StorageAPI) checkCanRead() error {
-	err := a.authorizer.HasPermission(permission.SuperuserAccess, a.backend.ControllerTag())
+func (a *StorageAPI) checkCanRead(ctx stdcontext.Context) error {
+	err := a.authorizer.HasPermission(ctx, permission.SuperuserAccess, a.backend.ControllerTag())
 	if err != nil && !errors.Is(err, authentication.ErrorEntityMissingPermission) {
 		return errors.Trace(err)
 	}
@@ -78,18 +78,18 @@ func (a *StorageAPI) checkCanRead() error {
 	if err == nil {
 		return nil
 	}
-	return a.authorizer.HasPermission(permission.ReadAccess, a.backend.ModelTag())
+	return a.authorizer.HasPermission(ctx, permission.ReadAccess, a.backend.ModelTag())
 }
 
-func (a *StorageAPI) checkCanWrite() error {
-	return a.authorizer.HasPermission(permission.WriteAccess, a.backend.ModelTag())
+func (a *StorageAPI) checkCanWrite(ctx stdcontext.Context) error {
+	return a.authorizer.HasPermission(ctx, permission.WriteAccess, a.backend.ModelTag())
 }
 
 // StorageDetails retrieves and returns detailed information about desired
 // storage identified by supplied tags. If specified storage cannot be
 // retrieved, individual error is returned instead of storage information.
 func (a *StorageAPI) StorageDetails(ctx stdcontext.Context, entities params.Entities) (params.StorageDetailsResults, error) {
-	if err := a.checkCanRead(); err != nil {
+	if err := a.checkCanRead(ctx); err != nil {
 		return params.StorageDetailsResults{}, errors.Trace(err)
 	}
 	results := make([]params.StorageDetailsResult, len(entities.Entities))
@@ -116,7 +116,7 @@ func (a *StorageAPI) StorageDetails(ctx stdcontext.Context, entities params.Enti
 
 // ListStorageDetails returns storage matching a filter.
 func (a *StorageAPI) ListStorageDetails(ctx stdcontext.Context, filters params.StorageFilters) (params.StorageDetailsListResults, error) {
-	if err := a.checkCanRead(); err != nil {
+	if err := a.checkCanRead(ctx); err != nil {
 		return params.StorageDetailsListResults{}, errors.Trace(err)
 	}
 	results := params.StorageDetailsListResults{
@@ -170,7 +170,7 @@ func (a *StorageAPI) ListPools(
 	ctx stdcontext.Context,
 	filters params.StoragePoolFilters,
 ) (params.StoragePoolsResults, error) {
-	if err := a.checkCanRead(); err != nil {
+	if err := a.checkCanRead(ctx); err != nil {
 		return params.StoragePoolsResults{}, errors.Trace(err)
 	}
 
@@ -240,7 +240,7 @@ func (a *StorageAPI) CreatePool(ctx stdcontext.Context, p params.StoragePoolArgs
 // an independent list of volumes, or an error if the filter is invalid
 // or the volumes could not be listed.
 func (a *StorageAPI) ListVolumes(ctx stdcontext.Context, filters params.VolumeFilters) (params.VolumeDetailsListResults, error) {
-	if err := a.checkCanRead(); err != nil {
+	if err := a.checkCanRead(ctx); err != nil {
 		return params.VolumeDetailsListResults{}, errors.Trace(err)
 	}
 	results := params.VolumeDetailsListResults{
@@ -346,7 +346,7 @@ func (a *StorageAPI) ListFilesystems(ctx stdcontext.Context, filters params.File
 	results := params.FilesystemDetailsListResults{
 		Results: make([]params.FilesystemDetailsListResult, len(filters.Filters)),
 	}
-	if err := a.checkCanRead(); err != nil {
+	if err := a.checkCanRead(ctx); err != nil {
 		return results, errors.Trace(err)
 	}
 
@@ -446,7 +446,7 @@ func (a *StorageAPI) AddToUnit(ctx stdcontext.Context, args params.StoragesAddPa
 }
 
 func (a *StorageAPI) addToUnit(ctx stdcontext.Context, args params.StoragesAddParams) (params.AddStorageResults, error) {
-	if err := a.checkCanWrite(); err != nil {
+	if err := a.checkCanWrite(ctx); err != nil {
 		return params.AddStorageResults{}, errors.Trace(err)
 	}
 
@@ -502,7 +502,7 @@ func (a *StorageAPI) Remove(ctx stdcontext.Context, args params.RemoveStorage) (
 }
 
 func (a *StorageAPI) remove(ctx stdcontext.Context, args params.RemoveStorage) (params.ErrorResults, error) {
-	if err := a.checkCanWrite(); err != nil {
+	if err := a.checkCanWrite(ctx); err != nil {
 		return params.ErrorResults{}, errors.Trace(err)
 	}
 
@@ -536,7 +536,7 @@ func (a *StorageAPI) DetachStorage(ctx stdcontext.Context, args params.StorageDe
 }
 
 func (a *StorageAPI) internalDetach(ctx stdcontext.Context, args params.StorageAttachmentIds, force *bool, maxWait *time.Duration) (params.ErrorResults, error) {
-	if err := a.checkCanWrite(); err != nil {
+	if err := a.checkCanWrite(ctx); err != nil {
 		return params.ErrorResults{}, errors.Trace(err)
 	}
 
@@ -602,7 +602,7 @@ func (a *StorageAPI) detachStorage(storageTag names.StorageTag, unitTag names.Un
 // Attach attaches existing storage instances to units.
 // A "CHANGE" block can block this operation.
 func (a *StorageAPI) Attach(ctx stdcontext.Context, args params.StorageAttachmentIds) (params.ErrorResults, error) {
-	if err := a.checkCanWrite(); err != nil {
+	if err := a.checkCanWrite(ctx); err != nil {
 		return params.ErrorResults{}, errors.Trace(err)
 	}
 
@@ -633,7 +633,7 @@ func (a *StorageAPI) Attach(ctx stdcontext.Context, args params.StorageAttachmen
 // Import imports existing storage into the model.
 // A "CHANGE" block can block this operation.
 func (a *StorageAPI) Import(ctx stdcontext.Context, args params.BulkImportStorageParams) (params.ImportStorageResults, error) {
-	if err := a.checkCanWrite(); err != nil {
+	if err := a.checkCanWrite(ctx); err != nil {
 		return params.ImportStorageResults{}, errors.Trace(err)
 	}
 
@@ -767,7 +767,7 @@ func (a *StorageAPI) RemovePool(ctx stdcontext.Context, p params.StoragePoolDele
 	results := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(p.Pools)),
 	}
-	if err := a.checkCanWrite(); err != nil {
+	if err := a.checkCanWrite(ctx); err != nil {
 		return results, errors.Trace(err)
 	}
 
@@ -789,7 +789,7 @@ func (a *StorageAPI) UpdatePool(ctx stdcontext.Context, p params.StoragePoolArgs
 	results := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(p.Pools)),
 	}
-	if err := a.checkCanWrite(); err != nil {
+	if err := a.checkCanWrite(ctx); err != nil {
 		return results, errors.Trace(err)
 	}
 	service, _, err := a.storageMetadata()

--- a/apiserver/facades/client/storage/storage_test.go
+++ b/apiserver/facades/client/storage/storage_test.go
@@ -723,9 +723,9 @@ func (s *storageSuite) TestListStorageAsAdminOnNotOwnedModel(c *gc.C) {
 	// Sanity check before running test:
 	// Ensure that the user has NO read access to the model but SuperuserAccess
 	// to the controller it belongs to.
-	err := s.authorizer.HasPermission(permission.ReadAccess, s.state.ModelTag())
+	err := s.authorizer.HasPermission(context.Background(), permission.ReadAccess, s.state.ModelTag())
 	c.Assert(err, jc.ErrorIs, authentication.ErrorEntityMissingPermission)
-	err = s.authorizer.HasPermission(permission.SuperuserAccess, s.state.ControllerTag())
+	err = s.authorizer.HasPermission(context.Background(), permission.SuperuserAccess, s.state.ControllerTag())
 	c.Assert(err, jc.ErrorIsNil)
 
 	// ListStorageDetails should not fail
@@ -743,9 +743,9 @@ func (s *storageSuite) TestListStorageAsNonAdminOnNotOwnedModel(c *gc.C) {
 	// Sanity check before running test:
 	// Ensure that the user has NO read access to the model and NO SuperuserAccess
 	// to the controller it belongs to.
-	err := s.authorizer.HasPermission(permission.ReadAccess, s.state.ModelTag())
+	err := s.authorizer.HasPermission(context.Background(), permission.ReadAccess, s.state.ModelTag())
 	c.Assert(err, jc.ErrorIs, authentication.ErrorEntityMissingPermission)
-	err = s.authorizer.HasPermission(permission.SuperuserAccess, s.state.ControllerTag())
+	err = s.authorizer.HasPermission(context.Background(), permission.SuperuserAccess, s.state.ControllerTag())
 	c.Assert(err, jc.ErrorIs, authentication.ErrorEntityMissingPermission)
 
 	// ListStorageDetails should fail with perm error

--- a/apiserver/facades/client/subnets/subnets.go
+++ b/apiserver/facades/client/subnets/subnets.go
@@ -67,8 +67,8 @@ type API struct {
 	networkService              NetworkService
 }
 
-func (api *API) checkCanRead() error {
-	return api.authorizer.HasPermission(permission.ReadAccess, api.backing.ModelTag())
+func (api *API) checkCanRead(ctx context.Context) error {
+	return api.authorizer.HasPermission(ctx, permission.ReadAccess, api.backing.ModelTag())
 }
 
 // newAPIWithBacking creates a new server-side Subnets API facade with
@@ -99,7 +99,7 @@ func newAPIWithBacking(
 // zone is unusable, unavailable, or deprecated the Available
 // field will be false.
 func (api *API) AllZones(ctx stdcontext.Context) (params.ZoneResults, error) {
-	if err := api.checkCanRead(); err != nil {
+	if err := api.checkCanRead(ctx); err != nil {
 		return params.ZoneResults{}, err
 	}
 	invalidator, err := api.credentialInvalidatorGetter()
@@ -113,7 +113,7 @@ func (api *API) AllZones(ctx stdcontext.Context) (params.ZoneResults, error) {
 // ListSubnets returns the matching subnets after applying
 // optional filters.
 func (api *API) ListSubnets(ctx stdcontext.Context, args params.SubnetsFilters) (results params.ListSubnetsResults, err error) {
-	if err := api.checkCanRead(); err != nil {
+	if err := api.checkCanRead(ctx); err != nil {
 		return params.ListSubnetsResults{}, err
 	}
 
@@ -158,7 +158,7 @@ func (api *API) ListSubnets(ctx stdcontext.Context, args params.SubnetsFilters) 
 func (api *API) SubnetsByCIDR(ctx stdcontext.Context, arg params.CIDRParams) (params.SubnetsResults, error) {
 	result := params.SubnetsResults{}
 
-	if err := api.checkCanRead(); err != nil {
+	if err := api.checkCanRead(ctx); err != nil {
 		return result, err
 	}
 

--- a/apiserver/facades/client/subnets/subnets_test.go
+++ b/apiserver/facades/client/subnets/subnets_test.go
@@ -81,7 +81,7 @@ func (s *SubnetSuite) setupSubnetsAPI(c *gc.C) *gomock.Controller {
 	s.mockBacking = subnets.NewMockBacking(ctrl)
 
 	s.mockAuthorizer = facademocks.NewMockAuthorizer(ctrl)
-	s.mockAuthorizer.EXPECT().HasPermission(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	s.mockAuthorizer.EXPECT().HasPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	s.mockAuthorizer.EXPECT().AuthClient().Return(true)
 
 	s.mockBacking.EXPECT().ModelTag().Return(names.NewModelTag("123"))

--- a/apiserver/facades/client/usermanager/register.go
+++ b/apiserver/facades/client/usermanager/register.go
@@ -34,10 +34,10 @@ func newUserManagerAPI(stdCtx context.Context, ctx facade.ModelContext) (*UserMa
 	// Since we know this is a user tag (because AuthClient is true),
 	// we just do the type assertion to the UserTag.
 	apiUserTag, _ := authorizer.GetAuthTag().(names.UserTag)
-	// Pretty much all of the user manager methods have special casing for admin
+	// Pretty much all the user manager methods have special casing for admin
 	// users, so look once when we start and remember if the user is an admin.
 	st := ctx.State()
-	err := authorizer.HasPermission(permission.SuperuserAccess, st.ControllerTag())
+	err := authorizer.HasPermission(stdCtx, permission.SuperuserAccess, st.ControllerTag())
 	if err != nil && !errors.Is(err, authentication.ErrorEntityMissingPermission) {
 		return nil, errors.Trace(err)
 	}

--- a/apiserver/facades/controller/caasmodelconfigmanager/mocks/auth_mock.go
+++ b/apiserver/facades/controller/caasmodelconfigmanager/mocks/auth_mock.go
@@ -10,6 +10,7 @@
 package mocks
 
 import (
+	context "context"
 	reflect "reflect"
 
 	permission "github.com/juju/juju/core/permission"
@@ -345,17 +346,17 @@ func (c *MockAuthorizerConnectedModelCall) DoAndReturn(f func() string) *MockAut
 }
 
 // EntityHasPermission mocks base method.
-func (m *MockAuthorizer) EntityHasPermission(arg0 names.Tag, arg1 permission.Access, arg2 names.Tag) error {
+func (m *MockAuthorizer) EntityHasPermission(arg0 context.Context, arg1 names.Tag, arg2 permission.Access, arg3 names.Tag) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EntityHasPermission", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "EntityHasPermission", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // EntityHasPermission indicates an expected call of EntityHasPermission.
-func (mr *MockAuthorizerMockRecorder) EntityHasPermission(arg0, arg1, arg2 any) *MockAuthorizerEntityHasPermissionCall {
+func (mr *MockAuthorizerMockRecorder) EntityHasPermission(arg0, arg1, arg2, arg3 any) *MockAuthorizerEntityHasPermissionCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EntityHasPermission", reflect.TypeOf((*MockAuthorizer)(nil).EntityHasPermission), arg0, arg1, arg2)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EntityHasPermission", reflect.TypeOf((*MockAuthorizer)(nil).EntityHasPermission), arg0, arg1, arg2, arg3)
 	return &MockAuthorizerEntityHasPermissionCall{Call: call}
 }
 
@@ -371,13 +372,13 @@ func (c *MockAuthorizerEntityHasPermissionCall) Return(arg0 error) *MockAuthoriz
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockAuthorizerEntityHasPermissionCall) Do(f func(names.Tag, permission.Access, names.Tag) error) *MockAuthorizerEntityHasPermissionCall {
+func (c *MockAuthorizerEntityHasPermissionCall) Do(f func(context.Context, names.Tag, permission.Access, names.Tag) error) *MockAuthorizerEntityHasPermissionCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockAuthorizerEntityHasPermissionCall) DoAndReturn(f func(names.Tag, permission.Access, names.Tag) error) *MockAuthorizerEntityHasPermissionCall {
+func (c *MockAuthorizerEntityHasPermissionCall) DoAndReturn(f func(context.Context, names.Tag, permission.Access, names.Tag) error) *MockAuthorizerEntityHasPermissionCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -421,17 +422,17 @@ func (c *MockAuthorizerGetAuthTagCall) DoAndReturn(f func() names.Tag) *MockAuth
 }
 
 // HasPermission mocks base method.
-func (m *MockAuthorizer) HasPermission(arg0 permission.Access, arg1 names.Tag) error {
+func (m *MockAuthorizer) HasPermission(arg0 context.Context, arg1 permission.Access, arg2 names.Tag) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HasPermission", arg0, arg1)
+	ret := m.ctrl.Call(m, "HasPermission", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // HasPermission indicates an expected call of HasPermission.
-func (mr *MockAuthorizerMockRecorder) HasPermission(arg0, arg1 any) *MockAuthorizerHasPermissionCall {
+func (mr *MockAuthorizerMockRecorder) HasPermission(arg0, arg1, arg2 any) *MockAuthorizerHasPermissionCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasPermission", reflect.TypeOf((*MockAuthorizer)(nil).HasPermission), arg0, arg1)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasPermission", reflect.TypeOf((*MockAuthorizer)(nil).HasPermission), arg0, arg1, arg2)
 	return &MockAuthorizerHasPermissionCall{Call: call}
 }
 
@@ -447,13 +448,13 @@ func (c *MockAuthorizerHasPermissionCall) Return(arg0 error) *MockAuthorizerHasP
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockAuthorizerHasPermissionCall) Do(f func(permission.Access, names.Tag) error) *MockAuthorizerHasPermissionCall {
+func (c *MockAuthorizerHasPermissionCall) Do(f func(context.Context, permission.Access, names.Tag) error) *MockAuthorizerHasPermissionCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockAuthorizerHasPermissionCall) DoAndReturn(f func(permission.Access, names.Tag) error) *MockAuthorizerHasPermissionCall {
+func (c *MockAuthorizerHasPermissionCall) DoAndReturn(f func(context.Context, permission.Access, names.Tag) error) *MockAuthorizerHasPermissionCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
@@ -167,7 +167,7 @@ func (api *CrossModelRelationsAPIv3) PublishRelationChanges(
 				continue
 			}
 		}
-		if err := commoncrossmodel.PublishRelationChange(api.authorizer, api.st, api.modelID, relationTag, applicationTag, change); err != nil {
+		if err := commoncrossmodel.PublishRelationChange(ctx, api.authorizer, api.st, api.modelID, relationTag, applicationTag, change); err != nil {
 			results.Results[i].Error = apiservererrors.ServerError(err)
 			continue
 		}

--- a/apiserver/facades/controller/migrationtarget/migrationtarget.go
+++ b/apiserver/facades/controller/migrationtarget/migrationtarget.go
@@ -153,12 +153,12 @@ func NewAPI(
 	}, nil
 }
 
-func checkAuth(authorizer facade.Authorizer, st *state.State) error {
+func checkAuth(ctx context.Context, authorizer facade.Authorizer, st *state.State) error {
 	if !authorizer.AuthClient() {
 		return errors.Trace(apiservererrors.ErrPerm)
 	}
 
-	return authorizer.HasPermission(permission.SuperuserAccess, st.ControllerTag())
+	return authorizer.HasPermission(ctx, permission.SuperuserAccess, st.ControllerTag())
 }
 
 // Prechecks ensure that the target controller is ready to accept a

--- a/apiserver/facades/controller/migrationtarget/register.go
+++ b/apiserver/facades/controller/migrationtarget/register.go
@@ -23,20 +23,20 @@ import (
 func Register(requiredMigrationFacadeVersions facades.FacadeVersions) func(registry facade.FacadeRegistry) {
 	return func(registry facade.FacadeRegistry) {
 		registry.MustRegister("MigrationTarget", 1, func(stdCtx context.Context, ctx facade.ModelContext) (facade.Facade, error) {
-			return newFacadeV1(ctx)
+			return newFacadeV1(stdCtx, ctx)
 		}, reflect.TypeOf((*APIV1)(nil)))
 		registry.MustRegister("MigrationTarget", 2, func(stdCtx context.Context, ctx facade.ModelContext) (facade.Facade, error) {
-			return newFacadeV2(ctx)
+			return newFacadeV2(stdCtx, ctx)
 		}, reflect.TypeOf((*APIV2)(nil)))
 		registry.MustRegister("MigrationTarget", 3, func(stdCtx context.Context, ctx facade.ModelContext) (facade.Facade, error) {
-			return newFacade(ctx, requiredMigrationFacadeVersions)
+			return newFacade(stdCtx, ctx, requiredMigrationFacadeVersions)
 		}, reflect.TypeOf((*API)(nil)))
 	}
 }
 
 // newFacadeV1 is used for APIV1 registration.
-func newFacadeV1(ctx facade.ModelContext) (*APIV1, error) {
-	api, err := newFacade(ctx, facades.FacadeVersions{})
+func newFacadeV1(stdCtx context.Context, ctx facade.ModelContext) (*APIV1, error) {
+	api, err := newFacade(stdCtx, ctx, facades.FacadeVersions{})
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -44,8 +44,8 @@ func newFacadeV1(ctx facade.ModelContext) (*APIV1, error) {
 }
 
 // newFacadeV2 is used for APIV2 registration.
-func newFacadeV2(ctx facade.ModelContext) (*APIV2, error) {
-	api, err := newFacade(ctx, facades.FacadeVersions{})
+func newFacadeV2(stdCtx context.Context, ctx facade.ModelContext) (*APIV2, error) {
+	api, err := newFacade(stdCtx, ctx, facades.FacadeVersions{})
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -53,10 +53,10 @@ func newFacadeV2(ctx facade.ModelContext) (*APIV2, error) {
 }
 
 // newFacade is used for API registration.
-func newFacade(ctx facade.ModelContext, facadeVersions facades.FacadeVersions) (*API, error) {
+func newFacade(stdCtx context.Context, ctx facade.ModelContext, facadeVersions facades.FacadeVersions) (*API, error) {
 	auth := ctx.Auth()
 	st := ctx.State()
-	if err := checkAuth(auth, st); err != nil {
+	if err := checkAuth(stdCtx, auth, st); err != nil {
 		return nil, errors.Trace(err)
 	}
 

--- a/apiserver/facades/controller/remoterelations/remoterelations.go
+++ b/apiserver/facades/controller/remoterelations/remoterelations.go
@@ -388,7 +388,7 @@ func (api *API) ConsumeRemoteRelationChanges(ctx context.Context, changes params
 			continue
 		}
 		api.logger.Debugf("ConsumeRemoteRelationChanges: rel tag %v; app tag: %v", relationTag, applicationTag)
-		if err := commoncrossmodel.PublishRelationChange(api.authorizer, api.st, api.modelID, relationTag, applicationTag, change); err != nil {
+		if err := commoncrossmodel.PublishRelationChange(ctx, api.authorizer, api.st, api.modelID, relationTag, applicationTag, change); err != nil {
 			results.Results[i].Error = apiservererrors.ServerError(err)
 			continue
 		}

--- a/apiserver/httpcontext/auth.go
+++ b/apiserver/httpcontext/auth.go
@@ -59,7 +59,7 @@ func (h *AuthHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 
 	if h.Authorizer != nil {
-		if err := h.Authorizer.Authorize(authInfo); err != nil {
+		if err := h.Authorizer.Authorize(req.Context(), authInfo); err != nil {
 			http.Error(w,
 				fmt.Sprintf("authorization failed: %s", err),
 				http.StatusForbidden,

--- a/apiserver/httpcontext/auth_test.go
+++ b/apiserver/httpcontext/auth_test.go
@@ -68,7 +68,7 @@ func (s *BasicAuthHandlerSuite) AuthenticateLoginRequest(
 	panic("should not be called")
 }
 
-func (s *BasicAuthHandlerSuite) Authorize(authInfo authentication.AuthInfo) error {
+func (s *BasicAuthHandlerSuite) Authorize(ctx context.Context, authInfo authentication.AuthInfo) error {
 	s.stub.MethodCall(s, "Authorize", authInfo)
 	return s.stub.NextErr()
 }

--- a/apiserver/introspection.go
+++ b/apiserver/introspection.go
@@ -4,7 +4,6 @@
 package apiserver
 
 import (
-	"context"
 	"net/http"
 
 	"github.com/juju/errors"
@@ -56,7 +55,7 @@ func (h introspectionHandler) checkAuth(r *http.Request) error {
 			return "", errors.Trace(err)
 		}
 
-		access, err := accessService.ReadUserAccessForTarget(context.TODO(), subject.Id(), pID)
+		access, err := accessService.ReadUserAccessForTarget(r.Context(), subject.Id(), pID)
 		return access.Access, errors.Trace(err)
 	}
 

--- a/apiserver/root.go
+++ b/apiserver/root.go
@@ -357,8 +357,8 @@ func (r *apiHandler) ConnectedModel() string {
 // to provide a permission error. All permissions errors returned satisfy
 // errors.Is(err, ErrorEntityMissingPermission) to distinguish before errors and
 // no permissions errors. If error is nil then the user has permission.
-func (r *apiHandler) HasPermission(operation permission.Access, target names.Tag) error {
-	return r.EntityHasPermission(r.GetAuthTag(), operation, target)
+func (r *apiHandler) HasPermission(ctx context.Context, operation permission.Access, target names.Tag) error {
+	return r.EntityHasPermission(ctx, r.GetAuthTag(), operation, target)
 }
 
 // EntityHasPermission is responsible for reporting if the supplied entity is
@@ -368,12 +368,14 @@ func (r *apiHandler) HasPermission(operation permission.Access, target names.Tag
 // to provide a permission error. All permissions errors returned satisfy
 // errors.Is(err, ErrorEntityMissingPermission) to distinguish before errors and
 // no permissions errors. If error is nil then the user has permission.
-func (r *apiHandler) EntityHasPermission(entity names.Tag, operation permission.Access, target names.Tag) error {
+func (r *apiHandler) EntityHasPermission(
+	ctx context.Context, entity names.Tag, operation permission.Access, target names.Tag,
+) error {
 	var userAccessFunc common.UserAccessFunc = func(entity names.UserTag, subject names.Tag) (permission.Access, error) {
 		if r.authInfo.Delegator == nil {
 			return permission.NoAccess, fmt.Errorf("permissions %w for auth info", errors.NotImplemented)
 		}
-		return r.authInfo.Delegator.SubjectPermissions(authentication.TagToEntity(entity), subject)
+		return r.authInfo.Delegator.SubjectPermissions(ctx, authentication.TagToEntity(entity), subject)
 	}
 	has, err := common.HasPermission(userAccessFunc, entity, operation, target)
 	if err != nil {

--- a/apiserver/server_test.go
+++ b/apiserver/server_test.go
@@ -367,7 +367,7 @@ func (s *serverSuite) TestAPIHandlerMissingPermissionLoginToken(c *gc.C) {
 	st := s.ControllerModel(c).State()
 	handler, _ := apiserver.TestingAPIHandlerWithToken(c, s.StatePool(), st, serviceFactory, token, delegator)
 	defer handler.Kill()
-	err = handler.HasPermission(permission.AdminAccess, coretesting.ModelTag)
+	err = handler.HasPermission(context.Background(), permission.AdminAccess, coretesting.ModelTag)
 	var reqError *errors.AccessRequiredError
 	c.Assert(jujuerrors.As(err, &reqError), jc.IsTrue)
 	c.Assert(reqError, jc.DeepEquals, &errors.AccessRequiredError{

--- a/apiserver/stateauthenticator/delegator.go
+++ b/apiserver/stateauthenticator/delegator.go
@@ -22,7 +22,7 @@ type PermissionDelegator struct {
 // SubjectPermissions ensures that the input entity is a user,
 // then returns that user's access to the input subject.
 func (p *PermissionDelegator) SubjectPermissions(
-	entity authentication.Entity, target names.Tag,
+	ctx context.Context, entity authentication.Entity, target names.Tag,
 ) (permission.Access, error) {
 	userTag, ok := entity.Tag().(names.UserTag)
 	if !ok {
@@ -35,7 +35,7 @@ func (p *PermissionDelegator) SubjectPermissions(
 		return permission.NoAccess, errors.Trace(err)
 	}
 
-	access, err := p.AccessService.ReadUserAccessForTarget(context.TODO(), userID, permissionID)
+	access, err := p.AccessService.ReadUserAccessForTarget(ctx, userID, permissionID)
 	if err != nil {
 		return permission.NoAccess, errors.Trace(err)
 	}

--- a/apiserver/testing/fakeauthorizer.go
+++ b/apiserver/testing/fakeauthorizer.go
@@ -4,6 +4,7 @@
 package testing
 
 import (
+	"context"
 	"strings"
 
 	"github.com/juju/errors"
@@ -71,7 +72,7 @@ func (fa FakeAuthorizer) GetAuthTag() names.Tag {
 
 // HasPermission returns true if the logged in user is admin or has a name equal to
 // the pre-set admin tag.
-func (fa FakeAuthorizer) HasPermission(operation permission.Access, target names.Tag) error {
+func (fa FakeAuthorizer) HasPermission(ctx context.Context, operation permission.Access, target names.Tag) error {
 	if fa.Tag.Kind() == names.UserTagKind {
 		ut := fa.Tag.(names.UserTag)
 		emptyTag := names.UserTag{}
@@ -143,7 +144,7 @@ func (fa FakeAuthorizer) ConnectedModel() string {
 
 // EntityHasPermission returns true if the passed entity is admin or has a name equal to
 // the pre-set admin tag.
-func (fa FakeAuthorizer) EntityHasPermission(entity names.Tag, operation permission.Access, _ names.Tag) error {
+func (fa FakeAuthorizer) EntityHasPermission(ctx context.Context, entity names.Tag, operation permission.Access, _ names.Tag) error {
 	if entity.Kind() == names.UserTagKind && entity.Id() == "admin" {
 		return nil
 	}

--- a/generate/schemagen/schemagen.go
+++ b/generate/schemagen/schemagen.go
@@ -277,7 +277,7 @@ func (a authorizer) AuthController() bool {
 	return a.kind == kindControllerMachine
 }
 
-func (a authorizer) HasPermission(operation permission.Access, target names.Tag) error {
+func (a authorizer) HasPermission(ctx stdcontext.Context, operation permission.Access, target names.Tag) error {
 	return nil
 }
 


### PR DESCRIPTION
Remove `context.TODO()` and thread through contexts to the required areas in the apiserver.

<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://docs.google.com/document/d/1SYUo9G7qZ_jdoVXpUVamS5VCgHmtZ0QA-wZxKoMS-C0 
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps
Unit tests pass
<!-- Describe steps to verify that the change works. -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Jira card:** [JUJU-6308](https://warthogs.atlassian.net/browse/JUJU-6308)



[JUJU-6308]: https://warthogs.atlassian.net/browse/JUJU-6308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ