### PR TITLE
fix: allow cloud access comparisons against NoAccess

### DIFF
--- a/core/permission/access.go
+++ b/core/permission/access.go
@@ -214,10 +214,12 @@ func (a Access) controllerValue() int {
 
 func (a Access) cloudValue() int {
 	switch a {
-	case AddModelAccess:
+	case NoAccess:
 		return 0
-	case AdminAccess:
+	case AddModelAccess:
 		return 1
+	case AdminAccess:
+		return 2
 	default:
 		return -1
 	}

--- a/core/permission/access_test.go
+++ b/core/permission/access_test.go
@@ -200,7 +200,7 @@ func (*accessSuite) TestGreaterControllerAccessThan(c *gc.C) {
 func (*accessSuite) TestEqualOrGreaterCloudAccessThan(c *gc.C) {
 	// A very boring but necessary test to test explicit responses.
 	var (
-		undefined = permission.NoAccess
+		noaccess  = permission.NoAccess
 		read      = permission.ReadAccess
 		write     = permission.WriteAccess
 		admin     = permission.AdminAccess
@@ -218,13 +218,21 @@ func (*accessSuite) TestEqualOrGreaterCloudAccessThan(c *gc.C) {
 		c.Check(value.EqualOrGreaterControllerAccessThan(write), jc.IsFalse)
 	}
 	// No comparison against a controller permission will return true
-	for _, value := range []permission.Access{undefined, login, superuser} {
+	for _, value := range []permission.Access{noaccess, login, superuser} {
 		c.Check(value.EqualOrGreaterControllerAccessThan(addmodel), jc.IsFalse)
 	}
 
+	c.Check(noaccess.EqualOrGreaterCloudAccessThan(noaccess), jc.IsTrue)
+	c.Check(noaccess.EqualOrGreaterCloudAccessThan(addmodel), jc.IsFalse)
+	c.Check(noaccess.EqualOrGreaterCloudAccessThan(admin), jc.IsFalse)
+
 	c.Check(addmodel.EqualOrGreaterCloudAccessThan(addmodel), jc.IsTrue)
+	c.Check(addmodel.EqualOrGreaterCloudAccessThan(noaccess), jc.IsTrue)
 	c.Check(addmodel.EqualOrGreaterCloudAccessThan(admin), jc.IsFalse)
+
+	c.Check(admin.EqualOrGreaterCloudAccessThan(noaccess), jc.IsTrue)
 	c.Check(admin.EqualOrGreaterCloudAccessThan(addmodel), jc.IsTrue)
+	c.Check(admin.EqualOrGreaterCloudAccessThan(admin), jc.IsTrue)
 }
 
 var validateObjectTypeTest = []struct {


### PR DESCRIPTION
All other permissions can be compared against `NoAccess`. Cloud could not because the `cloudValue` function returned -1 for it and the `EqualOrGreaterCloudAccessThan` function returned false whenever things were -1.

This is fixed by adding `NoAccess` to `cloudValue` and updating the tests.

All the other access levels include the `NoAccess` as the base. This `cloudValue` function is only used by `EqualOrGreaterCloudAccessThan`.

The current implementation would mean this returned:
```
(WriteAccess).EqualOrGreaterCloudAccessThan(NoAccess) == false
```
The function is not that widely used and `cloudValue` was added in an unreviewed PR.

As far as I could tell, in all the other use cases in the co`debase apart from mine, the value passed as the second argument was fixed, and so it would never hit this case.

Fixing this makes the` EqualOrGreaterAccessThan` function behave consistently.

This was originally in #17752 but moved here to a separate PR.
<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://docs.google.com/document/d/1SYUo9G7qZ_jdoVXpUVamS5VCgHmtZ0QA-wZxKoMS-C0 
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing


## QA steps
Unit tests pass
<!-- Describe steps to verify that the change works. -->
