### PR TITLE
feat(macaroon): remove expired root keys

### DIFF
--- a/api/package_test.go
+++ b/api/package_test.go
@@ -51,6 +51,7 @@ func (*ImportSuite) TestImports(c *gc.C) {
 		"core/user",
 		"core/version",
 		"core/watcher",
+		"domain/macaroon",
 		"domain/model/errors",
 		"domain/secret/errors",
 		"domain/secretbackend/errors",

--- a/apiserver/service.go
+++ b/apiserver/service.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/user"
 	userservice "github.com/juju/juju/domain/access/service"
+	"github.com/juju/juju/domain/macaroon"
 )
 
 // ControllerConfigService defines the methods required to get the controller
@@ -35,6 +36,8 @@ type UserService interface {
 type MacaroonService interface {
 	dbrootkeystore.ContextBacking
 	BakeryConfigService
+
+	RemoveExpiredKeys(ctx context.Context, clk macaroon.Clock) error
 }
 
 // BakeryConfigService manages macaroon bakery config storage.

--- a/apiserver/stateauthenticator/auth.go
+++ b/apiserver/stateauthenticator/auth.go
@@ -26,6 +26,7 @@ import (
 	"github.com/juju/juju/apiserver/httpcontext"
 	"github.com/juju/juju/controller"
 	coremodel "github.com/juju/juju/core/model"
+	domainmacaroon "github.com/juju/juju/domain/macaroon"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
 )
@@ -60,6 +61,9 @@ type ControllerConfigService interface {
 type MacaroonService interface {
 	dbrootkeystore.ContextBacking
 	BakeryConfigService
+
+	// RemoveExpiredKeys removes all root keys from state which have expired
+	RemoveExpiredKeys(ctx context.Context, clk domainmacaroon.Clock) error
 }
 
 type BakeryConfigService interface {

--- a/apiserver/stateauthenticator/services_mock_test.go
+++ b/apiserver/stateauthenticator/services_mock_test.go
@@ -21,6 +21,7 @@ import (
 	model "github.com/juju/juju/core/model"
 	permission "github.com/juju/juju/core/permission"
 	user "github.com/juju/juju/core/user"
+	macaroon "github.com/juju/juju/domain/macaroon"
 	auth "github.com/juju/juju/internal/auth"
 	state "github.com/juju/juju/state"
 	gomock "go.uber.org/mock/gomock"
@@ -518,6 +519,44 @@ func (c *MockMacaroonServiceInsertKeyContextCall) Do(f func(context.Context, dbr
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockMacaroonServiceInsertKeyContextCall) DoAndReturn(f func(context.Context, dbrootkeystore.RootKey) error) *MockMacaroonServiceInsertKeyContextCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// RemoveExpiredKeys mocks base method.
+func (m *MockMacaroonService) RemoveExpiredKeys(arg0 context.Context, arg1 macaroon.Clock) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveExpiredKeys", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RemoveExpiredKeys indicates an expected call of RemoveExpiredKeys.
+func (mr *MockMacaroonServiceMockRecorder) RemoveExpiredKeys(arg0, arg1 any) *MockMacaroonServiceRemoveExpiredKeysCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveExpiredKeys", reflect.TypeOf((*MockMacaroonService)(nil).RemoveExpiredKeys), arg0, arg1)
+	return &MockMacaroonServiceRemoveExpiredKeysCall{Call: call}
+}
+
+// MockMacaroonServiceRemoveExpiredKeysCall wrap *gomock.Call
+type MockMacaroonServiceRemoveExpiredKeysCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockMacaroonServiceRemoveExpiredKeysCall) Return(arg0 error) *MockMacaroonServiceRemoveExpiredKeysCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockMacaroonServiceRemoveExpiredKeysCall) Do(f func(context.Context, macaroon.Clock) error) *MockMacaroonServiceRemoveExpiredKeysCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockMacaroonServiceRemoveExpiredKeysCall) DoAndReturn(f func(context.Context, macaroon.Clock) error) *MockMacaroonServiceRemoveExpiredKeysCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/cmd/containeragent/initialize/package_test.go
+++ b/cmd/containeragent/initialize/package_test.go
@@ -78,6 +78,7 @@ func (*importSuite) TestImports(c *gc.C) {
 		"core/version",
 		"core/watcher",
 		"domain/secret/errors",
+		"domain/macaroon",
 		"domain/model/errors",
 		"domain/secretbackend/errors",
 		"environs/cloudspec",

--- a/domain/macaroon/service/package_mock_test.go
+++ b/domain/macaroon/service/package_mock_test.go
@@ -351,3 +351,41 @@ func (c *MockStateInsertKeyCall) DoAndReturn(f func(context.Context, macaroon.Ro
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
+
+// RemoveKeysExpiredBefore mocks base method.
+func (m *MockState) RemoveKeysExpiredBefore(arg0 context.Context, arg1 time.Time) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveKeysExpiredBefore", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RemoveKeysExpiredBefore indicates an expected call of RemoveKeysExpiredBefore.
+func (mr *MockStateMockRecorder) RemoveKeysExpiredBefore(arg0, arg1 any) *MockStateRemoveKeysExpiredBeforeCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveKeysExpiredBefore", reflect.TypeOf((*MockState)(nil).RemoveKeysExpiredBefore), arg0, arg1)
+	return &MockStateRemoveKeysExpiredBeforeCall{Call: call}
+}
+
+// MockStateRemoveKeysExpiredBeforeCall wrap *gomock.Call
+type MockStateRemoveKeysExpiredBeforeCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateRemoveKeysExpiredBeforeCall) Return(arg0 error) *MockStateRemoveKeysExpiredBeforeCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateRemoveKeysExpiredBeforeCall) Do(f func(context.Context, time.Time) error) *MockStateRemoveKeysExpiredBeforeCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateRemoveKeysExpiredBeforeCall) DoAndReturn(f func(context.Context, time.Time) error) *MockStateRemoveKeysExpiredBeforeCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}

--- a/domain/macaroon/service/rootkeys.go
+++ b/domain/macaroon/service/rootkeys.go
@@ -35,6 +35,10 @@ type RootKeyState interface {
 	// InsertKey inserts the given root key into state. If a key with matching
 	// id already exists, return a macaroonerrors.KeyAlreadyExists error.
 	InsertKey(ctx context.Context, key macaroon.RootKey) error
+
+	// RemoveKeysExpiredBefore removes all root keys from state with an expiry
+	// before the provided cutoff time
+	RemoveKeysExpiredBefore(ctx context.Context, cutoff time.Time) error
 }
 
 // RootKeyService provides the API for macaroon root key storage
@@ -105,4 +109,10 @@ func decodeRootKey(k macaroon.RootKey) dbrootkeystore.RootKey {
 		Expires: k.Expires,
 		RootKey: k.RootKey,
 	}
+}
+
+// RemoveExpiredKeys removes all root keys from state which have expired.
+func (s *RootKeyService) RemoveExpiredKeys(ctx context.Context, clk macaroon.Clock) error {
+	now := clk.Now()
+	return errors.Trace(s.st.RemoveKeysExpiredBefore(ctx, now))
 }

--- a/domain/macaroon/service/rootkeys_test.go
+++ b/domain/macaroon/service/rootkeys_test.go
@@ -111,3 +111,29 @@ func (s *rootKeyServiceSuite) TestInsertKeyContextError(c *gc.C) {
 	err := srv.InsertKeyContext(context.Background(), key)
 	c.Assert(err, gc.Equals, boom)
 }
+
+func (s *rootKeyServiceSuite) TestRemoveExpiredKeys(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	clk := clockVal(&epoch)
+
+	s.st.EXPECT().RemoveKeysExpiredBefore(gomock.Any(), epoch)
+	srv := NewRootKeyService(s.st)
+
+	err := srv.RemoveExpiredKeys(context.Background(), clk)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+var epoch = time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)
+
+func clockVal(t *time.Time) macaroon.Clock {
+	return clockFunc(func() time.Time {
+		return *t
+	})
+}
+
+type clockFunc func() time.Time
+
+func (f clockFunc) Now() time.Time {
+	return f()
+}

--- a/domain/macaroon/state/rootkeys_test.go
+++ b/domain/macaroon/state/rootkeys_test.go
@@ -156,6 +156,89 @@ func (s *rootKeyStateSuite) TestFindLatestKeyEquality(c *gc.C) {
 	c.Assert(err, jc.ErrorIs, errors.KeyNotFound)
 }
 
+func (s *rootKeyStateSuite) TestRemoveKeysExpiredBeforeNow(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+	ctx := context.Background()
+	addAllKeys(c, st)
+
+	err := st.RemoveKeysExpiredBefore(ctx, now)
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = st.GetKey(ctx, key0.ID)
+	c.Check(err, jc.ErrorIsNil)
+	_, err = st.GetKey(ctx, key1.ID)
+	c.Check(err, jc.ErrorIsNil)
+	_, err = st.GetKey(ctx, key2.ID)
+	c.Check(err, jc.ErrorIsNil)
+	_, err = st.GetKey(ctx, key3.ID)
+	c.Check(err, jc.ErrorIsNil)
+	_, err = st.GetKey(ctx, key4.ID)
+	c.Check(err, jc.ErrorIs, errors.KeyNotFound)
+}
+
+func (s *rootKeyStateSuite) TestRemoveKeysExpiredBeforeNowPlus5(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+	ctx := context.Background()
+	addAllKeys(c, st)
+
+	err := st.RemoveKeysExpiredBefore(ctx, now.Add(5*time.Second))
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = st.GetKey(ctx, key0.ID)
+	c.Check(err, jc.ErrorIs, errors.KeyNotFound)
+	_, err = st.GetKey(ctx, key1.ID)
+	c.Check(err, jc.ErrorIs, errors.KeyNotFound)
+	_, err = st.GetKey(ctx, key2.ID)
+	c.Check(err, jc.ErrorIsNil)
+	_, err = st.GetKey(ctx, key3.ID)
+	c.Check(err, jc.ErrorIsNil)
+	_, err = st.GetKey(ctx, key4.ID)
+	c.Check(err, jc.ErrorIs, errors.KeyNotFound)
+}
+
+func (s *rootKeyStateSuite) TestRemoveKeysExpiredAll(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+	ctx := context.Background()
+	addAllKeys(c, st)
+
+	err := st.RemoveKeysExpiredBefore(ctx, now.Add(10*time.Second))
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = st.GetKey(ctx, key0.ID)
+	c.Check(err, jc.ErrorIs, errors.KeyNotFound)
+	_, err = st.GetKey(ctx, key1.ID)
+	c.Check(err, jc.ErrorIs, errors.KeyNotFound)
+	_, err = st.GetKey(ctx, key2.ID)
+	c.Check(err, jc.ErrorIs, errors.KeyNotFound)
+	_, err = st.GetKey(ctx, key3.ID)
+	c.Check(err, jc.ErrorIs, errors.KeyNotFound)
+	_, err = st.GetKey(ctx, key4.ID)
+	c.Check(err, jc.ErrorIs, errors.KeyNotFound)
+
+	_, err = st.FindLatestKey(ctx, time.Unix(0, 0), time.Unix(0, 0), time.Unix(math.MaxInt64, 0))
+	c.Check(err, jc.ErrorIs, errors.KeyNotFound)
+}
+
+func (s *rootKeyStateSuite) TestRemoveKeysExpiredNone(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+	ctx := context.Background()
+	addAllKeys(c, st)
+
+	err := st.RemoveKeysExpiredBefore(ctx, now.Add(-10*time.Second))
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = st.GetKey(ctx, key0.ID)
+	c.Check(err, jc.ErrorIsNil)
+	_, err = st.GetKey(ctx, key1.ID)
+	c.Check(err, jc.ErrorIsNil)
+	_, err = st.GetKey(ctx, key2.ID)
+	c.Check(err, jc.ErrorIsNil)
+	_, err = st.GetKey(ctx, key3.ID)
+	c.Check(err, jc.ErrorIsNil)
+	_, err = st.GetKey(ctx, key4.ID)
+	c.Check(err, jc.ErrorIsNil)
+}
+
 func addAllKeys(c *gc.C, st *State) {
 	ctx := context.Background()
 

--- a/domain/macaroon/types.go
+++ b/domain/macaroon/types.go
@@ -14,3 +14,9 @@ type RootKey struct {
 	Expires time.Time
 	RootKey []byte
 }
+
+// Clock provides a clock interface used by the macaroon service
+type Clock interface {
+	// Now returns the current clock time.
+	Now() time.Time
+}

--- a/internal/worker/httpserverargs/authenticator.go
+++ b/internal/worker/httpserverargs/authenticator.go
@@ -19,6 +19,7 @@ import (
 	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/permission"
 	coreuser "github.com/juju/juju/core/user"
+	domainmacaroon "github.com/juju/juju/domain/macaroon"
 	"github.com/juju/juju/internal/auth"
 	"github.com/juju/juju/state"
 )
@@ -50,6 +51,8 @@ type AccessService interface {
 type MacaroonService interface {
 	dbrootkeystore.ContextBacking
 	BakeryConfigService
+
+	RemoveExpiredKeys(ctx context.Context, clk domainmacaroon.Clock) error
 }
 
 type BakeryConfigService interface {

--- a/internal/worker/httpserverargs/worker.go
+++ b/internal/worker/httpserverargs/worker.go
@@ -21,6 +21,7 @@ import (
 	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/permission"
 	coreuser "github.com/juju/juju/core/user"
+	domainmacaroon "github.com/juju/juju/domain/macaroon"
 	"github.com/juju/juju/internal/auth"
 	"github.com/juju/juju/state"
 )
@@ -229,6 +230,11 @@ func (b *managedServices) FindLatestKeyContext(ctx context.Context, createdAfter
 // id already exists, return a macaroonerrors.KeyAlreadyExists error.
 func (b *managedServices) InsertKeyContext(ctx context.Context, key dbrootkeystore.RootKey) error {
 	return b.macaroonService.InsertKeyContext(ctx, key)
+}
+
+// RemoveExpiredKeys removes all root keys from state which have expired.
+func (b *managedServices) RemoveExpiredKeys(ctx context.Context, clk domainmacaroon.Clock) error {
+	return b.macaroonService.RemoveExpiredKeys(ctx, clk)
 }
 
 // Kill is part of the worker.Worker interface.


### PR DESCRIPTION
Ensure expired root keys are removed from DQLite. This means they will not clutter up DQLite

We do this by creating and calling a service method which clears expired keys before every call to get keys out of DQLite in our ExpirableStorage implementation

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

### CMR

```
./main.sh -v cmr
```

### External users

Cherry pick the following commits to hotfix a known bug with external users and build juju:
- https://github.com/juju/juju/pull/17752/commits/12437cf19617af9808d546e8fc2a950bd95636e3

Copy your ec2 credential over to `./cred.yaml` such that:
```
cat ./cred.yaml
credentials:
  aws:
    ec2-robot-external:
      auth-type: access-key
      access-key: ...
      secret-key: ...
```

The run + observe:
```
$ juju bootstrap aws/eu-west-2 aws --config identity-url=https://api.jujucharms.com/identity --config allow-model-access=true
$ juju grant <lp user>@external superuser
$ juju change-user-password
$ juju logout
$ juju login --user <lp user>@external
Welcome, <lp user>@external. You are now logged into "lxd".

Current model set to "admin/controller".

$ juju whoami
Controller:  aws
Model:       admin/controller
User:        <lp user>@external

$ juju add-credential aws -f ./cred.yaml --controller aws --client
Using cloud "aws" from the controller to verify credentials.
Credential "ec2-robot-external" added locally for cloud "aws".

Controller credential "ec2-robot-external" for user "jack-shaw@external" for cloud "aws" on controller "aws" added.
For more information, see ‘juju show-credential aws ec2-robot-external’.

$ juju add-model m --credential ec2-robot-external
Uploading credential 'aws/jack-shaw@external/ec2-robot-external' to controller
Added 'm' model on aws/eu-west-2 with credential 'ec2-robot-external' for user 'jack-shaw'

$ juju deploy ubuntu
$ juju status
Model  Controller  Cloud/Region   Version      Timestamp
m      aws         aws/eu-west-2  4.0-beta4.1  14:46:11+01:00

App     Version  Status   Scale  Charm   Channel        Rev  Exposed  Message
ubuntu           waiting    0/1  ubuntu  latest/stable   24  no       waiting for machine

Unit      Workload  Agent       Machine  Public address  Ports  Message
ubuntu/0  waiting   allocating  0        18.134.209.114         waiting for machine

Machine  State    Address         Inst id              Base          AZ          Message
0        pending  18.134.209.114  i-0790d125c69f15f77  ubuntu@22.04  eu-west-2b  running
```

NOTE: There are still some bugs with external users. They will hopefully be resolved with https://github.com/juju/juju/pull/17752 + other work

### DQLite repl

Log back into admin

```
$ make repl-install
$ juju ssh -m controller 0
$ sudo cat /var/lib/juju/agents/machine-0/agent.conf | yq '.controllercert' | xargs -I% echo % > dqlite.cert
$ sudo cat /var/lib/juju/agents/machine-0/agent.conf | yq '.controllerkey' | xargs -I% echo % > dqlite.key
$ sudo dqlite -s file:///var/lib/juju/dqlite/cluster.yaml -c ./dqlite.cert -k ./dqlite.key controller
dqlite> SELECT * FROM macaroon_root_key
[54 102 ... 102 51]|2024-07-25 13:42:16.570487774 +0000 UTC|2024-07-27 13:42:16.570487774 +0000 UTC|[149 55 ... 107 153]
```

Wait until the macaroon expires (or hack the expiry time with `UPDATE macaroon_root_key SET expires_at = "1721915279"`) and run in another terminal:

```
$ juju logout
$ juju login -u admin
```

And query:

```
dqlite> SELECT * FROM macaroon_root_key;
[52 57 ... 54 101]|2024-07-25 13:50:09.950321744 +0000 UTC|2024-07-27 13:50:09.950321744 +0000 UTC|[253 168 ... 90 249]
```

Notice there is only 1 root key, which has been replaced