### PR TITLE
fix: fix tests

### DIFF
--- a/core/series/supportedseries_linux_test.go
+++ b/core/series/supportedseries_linux_test.go
@@ -33,7 +33,7 @@ func (s *SupportedSeriesLinuxSuite) TestLatestLts(c *gc.C) {
 		latest, want string
 	}{
 		{"testseries", "testseries"},
-		{"", "jammy"},
+		{"", "noble"},
 	}
 	for _, test := range table {
 		SetLatestLtsForTesting(test.latest)
@@ -81,7 +81,7 @@ func (s *SupportedSeriesLinuxSuite) TestWorkloadSeries(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(series.SortedValues(), gc.DeepEquals, []string{
 		"bionic", "centos7", "centos8", "centos9", "focal", "genericlinux", "jammy", "kubernetes",
-		"mantic", "opensuseleap", "trusty", "win10", "win2008r2", "win2012", "win2012hv",
+		"noble", "opensuseleap", "trusty", "win10", "win2008r2", "win2012", "win2012hv",
 		"win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019",
 		"win7", "win8", "win81", "xenial"})
 }

--- a/core/series/supportedseries_test.go
+++ b/core/series/supportedseries_test.go
@@ -37,10 +37,10 @@ func (s *SupportedSeriesSuite) TestSeriesForTypes(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctrlSeries := info.controllerSeries()
-	c.Assert(ctrlSeries, jc.DeepEquals, []string{"mantic", "jammy", "focal", "bionic", "xenial", "trusty"})
+	c.Assert(ctrlSeries, jc.DeepEquals, []string{"jammy", "focal", "bionic", "xenial", "trusty", "noble"})
 
 	wrkSeries := info.workloadSeries(false)
-	c.Assert(wrkSeries, jc.DeepEquals, []string{"mantic", "jammy", "focal", "bionic", "xenial", "trusty", "centos7", "centos8", "centos9", "genericlinux", "kubernetes", "opensuseleap", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81"})
+	c.Assert(wrkSeries, jc.DeepEquals, []string{"jammy", "focal", "bionic", "xenial", "trusty", "centos7", "centos8", "centos9", "genericlinux", "kubernetes", "noble", "opensuseleap", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81"})
 }
 
 func (s *SupportedSeriesSuite) TestSeriesForTypesUsingImageStream(c *gc.C) {
@@ -53,10 +53,10 @@ func (s *SupportedSeriesSuite) TestSeriesForTypesUsingImageStream(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctrlSeries := info.controllerSeries()
-	c.Assert(ctrlSeries, jc.DeepEquals, []string{"mantic", "jammy", "focal", "bionic", "xenial", "trusty"})
+	c.Assert(ctrlSeries, jc.DeepEquals, []string{"jammy", "focal", "bionic", "xenial", "trusty", "noble"})
 
 	wrkSeries := info.workloadSeries(false)
-	c.Assert(wrkSeries, jc.DeepEquals, []string{"mantic", "jammy", "focal", "bionic", "xenial", "trusty", "centos7", "centos8", "centos9", "genericlinux", "kubernetes", "opensuseleap", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81"})
+	c.Assert(wrkSeries, jc.DeepEquals, []string{"jammy", "focal", "bionic", "xenial", "trusty", "centos7", "centos8", "centos9", "genericlinux", "kubernetes", "noble", "opensuseleap", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81"})
 }
 
 func (s *SupportedSeriesSuite) TestSeriesForTypesUsingInvalidImageStream(c *gc.C) {
@@ -69,10 +69,10 @@ func (s *SupportedSeriesSuite) TestSeriesForTypesUsingInvalidImageStream(c *gc.C
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctrlSeries := info.controllerSeries()
-	c.Assert(ctrlSeries, jc.DeepEquals, []string{"mantic", "jammy", "focal", "bionic", "xenial", "trusty"})
+	c.Assert(ctrlSeries, jc.DeepEquals, []string{"jammy", "focal", "bionic", "xenial", "trusty", "noble"})
 
 	wrkSeries := info.workloadSeries(false)
-	c.Assert(wrkSeries, jc.DeepEquals, []string{"mantic", "jammy", "focal", "bionic", "xenial", "trusty", "centos7", "centos8", "centos9", "genericlinux", "kubernetes", "opensuseleap", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81"})
+	c.Assert(wrkSeries, jc.DeepEquals, []string{"jammy", "focal", "bionic", "xenial", "trusty", "centos7", "centos8", "centos9", "genericlinux", "kubernetes", "noble", "opensuseleap", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81"})
 }
 
 func (s *SupportedSeriesSuite) TestSeriesForTypesUsingInvalidSeries(c *gc.C) {
@@ -85,10 +85,10 @@ func (s *SupportedSeriesSuite) TestSeriesForTypesUsingInvalidSeries(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctrlSeries := info.controllerSeries()
-	c.Assert(ctrlSeries, jc.DeepEquals, []string{"mantic", "jammy", "focal", "bionic", "xenial", "trusty"})
+	c.Assert(ctrlSeries, jc.DeepEquals, []string{"jammy", "focal", "bionic", "xenial", "trusty", "noble"})
 
 	wrkSeries := info.workloadSeries(false)
-	c.Assert(wrkSeries, jc.DeepEquals, []string{"mantic", "jammy", "focal", "bionic", "xenial", "trusty", "centos7", "centos8", "centos9", "genericlinux", "kubernetes", "opensuseleap", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81"})
+	c.Assert(wrkSeries, jc.DeepEquals, []string{"jammy", "focal", "bionic", "xenial", "trusty", "centos7", "centos8", "centos9", "genericlinux", "kubernetes", "noble", "opensuseleap", "win10", "win2008r2", "win2012", "win2012hv", "win2012hvr2", "win2012r2", "win2016", "win2016hv", "win2016nano", "win2019", "win7", "win8", "win81"})
 }
 
 var getOSFromSeriesTests = []struct {

--- a/tests/suites/appdata/appdata.sh
+++ b/tests/suites/appdata/appdata.sh
@@ -5,8 +5,8 @@ run_appdata_basic() {
 
 	ensure "appdata-basic" "${file}"
 
-	juju deploy juju-qa-appdata-source
-	juju deploy -n 2 juju-qa-appdata-sink
+	juju deploy juju-qa-appdata-source --series bionic
+	juju deploy -n 2 juju-qa-appdata-sink --series bionic
 	juju relate appdata-source appdata-sink
 
 	wait_for "blocked" "$(workload_status appdata-source 0).current"

--- a/tests/suites/relations/relation_data_exchange.sh
+++ b/tests/suites/relations/relation_data_exchange.sh
@@ -8,8 +8,8 @@ run_relation_data_exchange() {
 	ensure "${model_name}" "${file}"
 
 	echo "Deploy 2 dummy-sink instances and one dummy-source instance"
-	juju deploy ./testcharms/charms/dummy-sink -n 2
-	juju deploy ./testcharms/charms/dummy-source
+	juju deploy ./testcharms/charms/dummy-sink -n 2 --series bionic
+	juju deploy ./testcharms/charms/dummy-source --series bionic
 
 	echo "Establish relation"
 	juju relate dummy-sink dummy-source

--- a/tests/suites/relations/relation_list_app.sh
+++ b/tests/suites/relations/relation_list_app.sh
@@ -11,8 +11,8 @@ run_relation_list_app() {
 	ensure "${model_name}" "${file}"
 
 	echo "Deploy 2 departer instances"
-	juju deploy ./testcharms/charms/dummy-sink
-	juju deploy ./testcharms/charms/dummy-source
+	juju deploy ./testcharms/charms/dummy-sink --series bionic
+	juju deploy ./testcharms/charms/dummy-source --series bionic
 
 	echo "Establish relation"
 	juju relate dummy-sink dummy-source


### PR DESCRIPTION
Fix some failing integration and unit tests

Unit tests were failing because mantic is now no longer a supporter series. Noble has become supported. So swap them out.

Integration test wise, we have been having some trouble with xenial lxd containers in jammy/noble runners. The specific series here isn't an important part of the test, so instead deploy to bionic

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

```
go test ./core/series/
```

```
./main.sh -v appdata
```

```
./main.sh -v relations
```