### PR TITLE
feat(secrets): wireup export backend

### DIFF
--- a/core/secrets/secret.go
+++ b/core/secrets/secret.go
@@ -275,10 +275,6 @@ type SecretConsumerMetadata struct {
 	// CurrentRevision is current revision the
 	// consumer wants to read.
 	CurrentRevision int
-
-	// TODO(secrets) - this will be removed
-	// LatestRevision is the latest secret revision.
-	LatestRevision int
 }
 
 // SecretRevisionInfo holds info used to read a secret vale.

--- a/domain/secret/grant.go
+++ b/domain/secret/grant.go
@@ -15,6 +15,18 @@ const (
 	RoleManage
 )
 
+// String implements fmt.Stringer.
+func (r Role) String() string {
+	switch r {
+	case RoleView:
+		return string(coresecrets.RoleView)
+	case RoleManage:
+		return string(coresecrets.RoleManage)
+	default:
+		return string(coresecrets.RoleNone)
+	}
+}
+
 // MarshallRole converts a secret role to a db role id.
 func MarshallRole(role coresecrets.SecretRole) Role {
 	switch role {
@@ -75,7 +87,7 @@ func (s GrantSubjectType) String() string {
 	case SubjectModel:
 		return "model"
 	case SubjectRemoteApplication:
-		return "remote application"
+		return "remote-application"
 	}
 	return ""
 }

--- a/domain/secret/modelmigration/export_test.go
+++ b/domain/secret/modelmigration/export_test.go
@@ -197,17 +197,13 @@ func backendSecrets(uri1, uri2, uri3, uri4 *secrets.URI, nextRotate, expire, tim
 			uri3.ID: nil,
 		},
 		RemoteSecrets: []service.RemoteSecret{{
-			URI: uri4,
-			ConsumerInfo: service.ConsumerInfo{
-				SecretConsumerMetadata: secrets.SecretConsumerMetadata{
-					Label:           "mylabel",
-					CurrentRevision: 1,
-					LatestRevision:  666,
-				},
-				Accessor: service.SecretAccessor{
-					Kind: "unit",
-					ID:   "mariadb/0",
-				},
+			URI:             uri4,
+			Label:           "mylabel",
+			CurrentRevision: 1,
+			LatestRevision:  666,
+			Accessor: service.SecretAccessor{
+				Kind: "unit",
+				ID:   "mariadb/0",
 			},
 		}},
 	}

--- a/domain/secret/modelmigration/import.go
+++ b/domain/secret/modelmigration/import.go
@@ -224,15 +224,11 @@ func (i *importOperation) Execute(ctx context.Context, model description.Model) 
 			return errors.Annotate(err, "invalid remote secret consumer")
 		}
 		allSecrets.RemoteSecrets[j] = service.RemoteSecret{
-			URI: &secrets.URI{ID: secret.ID(), SourceUUID: secret.SourceUUID()},
-			ConsumerInfo: service.ConsumerInfo{
-				SecretConsumerMetadata: secrets.SecretConsumerMetadata{
-					Label:           secret.Label(),
-					CurrentRevision: secret.CurrentRevision(),
-					LatestRevision:  secret.LatestRevision(),
-				},
-				Accessor: accessor,
-			},
+			URI:             &secrets.URI{ID: secret.ID(), SourceUUID: secret.SourceUUID()},
+			Label:           secret.Label(),
+			CurrentRevision: secret.CurrentRevision(),
+			LatestRevision:  secret.LatestRevision(),
+			Accessor:        accessor,
 		}
 	}
 

--- a/domain/secret/service/exportimport.go
+++ b/domain/secret/service/exportimport.go
@@ -3,13 +3,140 @@
 
 package service
 
-import "context"
+import (
+	"context"
+
+	"github.com/juju/errors"
+
+	coresecrets "github.com/juju/juju/core/secrets"
+	"github.com/juju/juju/domain/secret"
+)
 
 // GetSecretsForExport returns a result containing all the information needed to
 // export secrets to a model description.
 func (s *SecretService) GetSecretsForExport(ctx context.Context) (*SecretExport, error) {
-	// TODO(secrets)
-	return &SecretExport{}, nil
+	secrets, secretRevisions, err := s.st.ListSecrets(ctx, nil, nil, secret.NilLabels)
+	if err != nil {
+		return nil, errors.Annotate(err, "loading secrets for export")
+	}
+
+	remoteSecrets, err := s.st.AllRemoteSecrets(ctx)
+	if err != nil {
+		return nil, errors.Annotate(err, "loading secrets for export")
+	}
+
+	allSecrets := &SecretExport{
+		Secrets:         secrets,
+		Revisions:       make(map[string][]*coresecrets.SecretRevisionMetadata),
+		Content:         make(map[string]map[int]coresecrets.SecretData),
+		Access:          make(map[string][]SecretAccess),
+		Consumers:       make(map[string][]ConsumerInfo),
+		RemoteConsumers: make(map[string][]ConsumerInfo),
+		RemoteSecrets:   make([]RemoteSecret, len(remoteSecrets)),
+	}
+
+	for i, info := range remoteSecrets {
+		allSecrets.RemoteSecrets[i] = RemoteSecret{
+			URI:             info.URI,
+			Label:           info.Label,
+			CurrentRevision: info.CurrentRevision,
+			LatestRevision:  info.LatestRevision,
+			Accessor: SecretAccessor{
+				Kind: SecretAccessorKind(info.SubjectTypeID.String()),
+				ID:   info.SubjectID,
+			},
+		}
+	}
+
+	for i, md := range secrets {
+		revs := secretRevisions[i]
+		allSecrets.Revisions[md.URI.ID] = revs
+		for _, rev := range revs {
+			if rev.ValueRef != nil {
+				continue
+			}
+			data, _, err := s.st.GetSecretValue(ctx, md.URI, rev.Revision)
+			if err != nil {
+				return nil, errors.Annotatef(err, "loading secret content for %q", md.URI.ID)
+			}
+			if len(data) == 0 {
+				// Should not happen.
+				return nil, errors.Errorf("unexpected empty secret content for %q", md.URI.ID)
+			}
+			allSecrets.Content[md.URI.ID] = map[int]coresecrets.SecretData{
+				rev.Revision: data,
+			}
+		}
+	}
+
+	allGrants, err := s.st.AllSecretGrants(ctx)
+	if err != nil {
+		return nil, errors.Annotate(err, "loading secret grants for export")
+	}
+	for id, grants := range allGrants {
+		secretAccess := make([]SecretAccess, len(grants))
+		for i, grant := range grants {
+			access := SecretAccess{
+				Scope: SecretAccessScope{
+					Kind: SecretAccessScopeKind(grant.ScopeTypeID.String()),
+					ID:   grant.ScopeID,
+				},
+				Subject: SecretAccessor{
+					Kind: SecretAccessorKind(grant.SubjectTypeID.String()),
+					ID:   grant.SubjectID,
+				},
+				Role: coresecrets.SecretRole(grant.RoleID.String()),
+			}
+			secretAccess[i] = access
+		}
+		allSecrets.Access[id] = secretAccess
+	}
+
+	allConsumers, err := s.st.AllSecretConsumers(ctx)
+	if err != nil {
+		return nil, errors.Annotate(err, "loading secret consumers for export")
+	}
+	for id, consumers := range allConsumers {
+		secretConsumers := make([]ConsumerInfo, len(consumers))
+		for i, consumer := range consumers {
+			info := ConsumerInfo{
+				SecretConsumerMetadata: coresecrets.SecretConsumerMetadata{
+					Label:           consumer.Label,
+					CurrentRevision: consumer.CurrentRevision,
+				},
+				Accessor: SecretAccessor{
+					Kind: SecretAccessorKind(consumer.SubjectTypeID.String()),
+					ID:   consumer.SubjectID,
+				},
+			}
+			secretConsumers[i] = info
+		}
+		allSecrets.Consumers[id] = secretConsumers
+	}
+
+	allRemoteConsumers, err := s.st.AllSecretRemoteConsumers(ctx)
+	if err != nil {
+		return nil, errors.Annotate(err, "loading secret remote consumers for export")
+	}
+	for id, consumers := range allRemoteConsumers {
+		secretConsumers := make([]ConsumerInfo, len(consumers))
+		for i, consumer := range consumers {
+			info := ConsumerInfo{
+				SecretConsumerMetadata: coresecrets.SecretConsumerMetadata{
+					Label:           consumer.Label,
+					CurrentRevision: consumer.CurrentRevision,
+				},
+				Accessor: SecretAccessor{
+					Kind: SecretAccessorKind(consumer.SubjectTypeID.String()),
+					ID:   consumer.SubjectID,
+				},
+			}
+			secretConsumers[i] = info
+		}
+		allSecrets.RemoteConsumers[id] = secretConsumers
+	}
+
+	return allSecrets, nil
 }
 
 // ImportSecrets saves the supplied secret details to the model.

--- a/domain/secret/service/exportimport_test.go
+++ b/domain/secret/service/exportimport_test.go
@@ -1,0 +1,126 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package service
+
+import (
+	"context"
+
+	jc "github.com/juju/testing/checkers"
+	"go.uber.org/mock/gomock"
+	gc "gopkg.in/check.v1"
+
+	coresecrets "github.com/juju/juju/core/secrets"
+	domainsecret "github.com/juju/juju/domain/secret"
+)
+
+func (s *serviceSuite) TestGetSecretsForExport(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	uri := coresecrets.NewURI()
+	secrets := []*coresecrets.SecretMetadata{{
+		URI: uri,
+	}}
+	revisions := [][]*coresecrets.SecretRevisionMetadata{{{
+		Revision: 1,
+	}, {
+		Revision: 2,
+		ValueRef: &coresecrets.ValueRef{
+			BackendID:  "backend-id",
+			RevisionID: "revision-id",
+		},
+	}}}
+
+	s.state = NewMockState(ctrl)
+	s.state.EXPECT().ListSecrets(gomock.Any(), nil, nil, domainsecret.NilLabels).Return(
+		secrets, revisions, nil,
+	)
+	s.state.EXPECT().GetSecretValue(gomock.Any(), uri, 1).Return(
+		coresecrets.SecretData{"foo": "bar"}, nil, nil,
+	)
+	s.state.EXPECT().AllSecretGrants(gomock.Any()).Return(
+		map[string][]domainsecret.GrantParams{
+			uri.ID: {{
+				ScopeTypeID:   1,
+				ScopeID:       "wordpress",
+				SubjectTypeID: 1,
+				SubjectID:     "wordpress",
+				RoleID:        2,
+			}},
+		}, nil,
+	)
+	s.state.EXPECT().AllSecretConsumers(gomock.Any()).Return(
+		map[string][]domainsecret.ConsumerInfo{
+			uri.ID: {{
+				SubjectTypeID:   0,
+				SubjectID:       "mysql/0",
+				Label:           "my label",
+				CurrentRevision: 666,
+			}},
+		}, nil,
+	)
+	s.state.EXPECT().AllSecretRemoteConsumers(gomock.Any()).Return(
+		map[string][]domainsecret.ConsumerInfo{
+			uri.ID: {{
+				SubjectTypeID:   0,
+				SubjectID:       "remote-app/0",
+				CurrentRevision: 668,
+			}},
+		}, nil,
+	)
+	s.state.EXPECT().AllRemoteSecrets(gomock.Any()).Return(
+		[]domainsecret.RemoteSecretInfo{}, nil,
+	)
+
+	got, err := s.service(c).GetSecretsForExport(context.Background())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(got, jc.DeepEquals, &SecretExport{
+		Secrets: secrets,
+		Revisions: map[string][]*coresecrets.SecretRevisionMetadata{
+			uri.ID: revisions[0],
+		},
+		Content: map[string]map[int]coresecrets.SecretData{
+			uri.ID: {
+				1: {"foo": "bar"},
+			},
+		},
+		Consumers: map[string][]ConsumerInfo{
+			uri.ID: {{
+				SecretConsumerMetadata: coresecrets.SecretConsumerMetadata{
+					Label:           "my label",
+					CurrentRevision: 666,
+				},
+				Accessor: SecretAccessor{
+					Kind: "unit",
+					ID:   "mysql/0",
+				},
+			}},
+		},
+		RemoteConsumers: map[string][]ConsumerInfo{
+			uri.ID: {{
+				SecretConsumerMetadata: coresecrets.SecretConsumerMetadata{
+					CurrentRevision: 668,
+				},
+				Accessor: SecretAccessor{
+					Kind: "unit",
+					ID:   "remote-app/0",
+				},
+			}},
+		},
+		Access: map[string][]SecretAccess{
+			uri.ID: {{
+				Scope: SecretAccessScope{
+					Kind: "application",
+					ID:   "wordpress",
+				},
+				Subject: SecretAccessor{
+					Kind: "application",
+					ID:   "wordpress",
+				},
+				Role: "manage",
+			}},
+		},
+		RemoteSecrets: nil,
+	})
+}

--- a/domain/secret/service/params.go
+++ b/domain/secret/service/params.go
@@ -170,6 +170,9 @@ type ConsumerInfo struct {
 
 // RemoteSecret holds information about a cross model secret.
 type RemoteSecret struct {
-	URI *secrets.URI
-	ConsumerInfo
+	URI             *secrets.URI
+	Label           string
+	CurrentRevision int
+	LatestRevision  int
+	Accessor        SecretAccessor
 }

--- a/domain/secret/service/service.go
+++ b/domain/secret/service/service.go
@@ -106,6 +106,12 @@ type State interface {
 	GetSecretsRevisionExpiryChanges(
 		ctx context.Context, appOwners domainsecret.ApplicationOwners, unitOwners domainsecret.UnitOwners, revisionUUIDs ...string,
 	) ([]domainsecret.ExpiryInfo, error)
+
+	// Methods for loading secrets to be exported.
+	AllSecretGrants(ctx context.Context) (map[string][]domainsecret.GrantParams, error)
+	AllSecretConsumers(ctx context.Context) (map[string][]domainsecret.ConsumerInfo, error)
+	AllSecretRemoteConsumers(ctx context.Context) (map[string][]domainsecret.ConsumerInfo, error)
+	AllRemoteSecrets(ctx context.Context) ([]domainsecret.RemoteSecretInfo, error)
 }
 
 // WatcherFactory describes methods for creating watchers.

--- a/domain/secret/service/state_mock_test.go
+++ b/domain/secret/service/state_mock_test.go
@@ -43,6 +43,162 @@ func (m *MockState) EXPECT() *MockStateMockRecorder {
 	return m.recorder
 }
 
+// AllRemoteSecrets mocks base method.
+func (m *MockState) AllRemoteSecrets(arg0 context.Context) ([]secret.RemoteSecretInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AllRemoteSecrets", arg0)
+	ret0, _ := ret[0].([]secret.RemoteSecretInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AllRemoteSecrets indicates an expected call of AllRemoteSecrets.
+func (mr *MockStateMockRecorder) AllRemoteSecrets(arg0 any) *MockStateAllRemoteSecretsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllRemoteSecrets", reflect.TypeOf((*MockState)(nil).AllRemoteSecrets), arg0)
+	return &MockStateAllRemoteSecretsCall{Call: call}
+}
+
+// MockStateAllRemoteSecretsCall wrap *gomock.Call
+type MockStateAllRemoteSecretsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateAllRemoteSecretsCall) Return(arg0 []secret.RemoteSecretInfo, arg1 error) *MockStateAllRemoteSecretsCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateAllRemoteSecretsCall) Do(f func(context.Context) ([]secret.RemoteSecretInfo, error)) *MockStateAllRemoteSecretsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateAllRemoteSecretsCall) DoAndReturn(f func(context.Context) ([]secret.RemoteSecretInfo, error)) *MockStateAllRemoteSecretsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// AllSecretConsumers mocks base method.
+func (m *MockState) AllSecretConsumers(arg0 context.Context) (map[string][]secret.ConsumerInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AllSecretConsumers", arg0)
+	ret0, _ := ret[0].(map[string][]secret.ConsumerInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AllSecretConsumers indicates an expected call of AllSecretConsumers.
+func (mr *MockStateMockRecorder) AllSecretConsumers(arg0 any) *MockStateAllSecretConsumersCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllSecretConsumers", reflect.TypeOf((*MockState)(nil).AllSecretConsumers), arg0)
+	return &MockStateAllSecretConsumersCall{Call: call}
+}
+
+// MockStateAllSecretConsumersCall wrap *gomock.Call
+type MockStateAllSecretConsumersCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateAllSecretConsumersCall) Return(arg0 map[string][]secret.ConsumerInfo, arg1 error) *MockStateAllSecretConsumersCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateAllSecretConsumersCall) Do(f func(context.Context) (map[string][]secret.ConsumerInfo, error)) *MockStateAllSecretConsumersCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateAllSecretConsumersCall) DoAndReturn(f func(context.Context) (map[string][]secret.ConsumerInfo, error)) *MockStateAllSecretConsumersCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// AllSecretGrants mocks base method.
+func (m *MockState) AllSecretGrants(arg0 context.Context) (map[string][]secret.GrantParams, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AllSecretGrants", arg0)
+	ret0, _ := ret[0].(map[string][]secret.GrantParams)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AllSecretGrants indicates an expected call of AllSecretGrants.
+func (mr *MockStateMockRecorder) AllSecretGrants(arg0 any) *MockStateAllSecretGrantsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllSecretGrants", reflect.TypeOf((*MockState)(nil).AllSecretGrants), arg0)
+	return &MockStateAllSecretGrantsCall{Call: call}
+}
+
+// MockStateAllSecretGrantsCall wrap *gomock.Call
+type MockStateAllSecretGrantsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateAllSecretGrantsCall) Return(arg0 map[string][]secret.GrantParams, arg1 error) *MockStateAllSecretGrantsCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateAllSecretGrantsCall) Do(f func(context.Context) (map[string][]secret.GrantParams, error)) *MockStateAllSecretGrantsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateAllSecretGrantsCall) DoAndReturn(f func(context.Context) (map[string][]secret.GrantParams, error)) *MockStateAllSecretGrantsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// AllSecretRemoteConsumers mocks base method.
+func (m *MockState) AllSecretRemoteConsumers(arg0 context.Context) (map[string][]secret.ConsumerInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AllSecretRemoteConsumers", arg0)
+	ret0, _ := ret[0].(map[string][]secret.ConsumerInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AllSecretRemoteConsumers indicates an expected call of AllSecretRemoteConsumers.
+func (mr *MockStateMockRecorder) AllSecretRemoteConsumers(arg0 any) *MockStateAllSecretRemoteConsumersCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllSecretRemoteConsumers", reflect.TypeOf((*MockState)(nil).AllSecretRemoteConsumers), arg0)
+	return &MockStateAllSecretRemoteConsumersCall{Call: call}
+}
+
+// MockStateAllSecretRemoteConsumersCall wrap *gomock.Call
+type MockStateAllSecretRemoteConsumersCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateAllSecretRemoteConsumersCall) Return(arg0 map[string][]secret.ConsumerInfo, arg1 error) *MockStateAllSecretRemoteConsumersCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateAllSecretRemoteConsumersCall) Do(f func(context.Context) (map[string][]secret.ConsumerInfo, error)) *MockStateAllSecretRemoteConsumersCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateAllSecretRemoteConsumersCall) DoAndReturn(f func(context.Context) (map[string][]secret.ConsumerInfo, error)) *MockStateAllSecretRemoteConsumersCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // ChangeSecretBackend mocks base method.
 func (m *MockState) ChangeSecretBackend(arg0 context.Context, arg1 *secrets.URI, arg2 int, arg3 *secrets.ValueRef, arg4 secrets.SecretData) error {
 	m.ctrl.T.Helper()

--- a/domain/secret/types.go
+++ b/domain/secret/types.go
@@ -100,3 +100,22 @@ type ExpiryInfo struct {
 	RevisionID      string
 	NextTriggerTime time.Time
 }
+
+// ConsumerInfo holds information about a secret consumer.
+type ConsumerInfo struct {
+	SubjectTypeID   GrantSubjectType
+	SubjectID       string
+	Label           string
+	CurrentRevision int
+}
+
+// RemoteSecretInfo holds information about a remote secret
+// for a given consumer.
+type RemoteSecretInfo struct {
+	URI             *secrets.URI
+	SubjectTypeID   GrantSubjectType
+	SubjectID       string
+	Label           string
+	CurrentRevision int
+	LatestRevision  int
+}


### PR DESCRIPTION
Add the service and facade methods to provide the exported secret data to the migration export coordinator.

This means filling in the service `GetSecretsForExport` method and adding state apis to bulk query the data.

During QA a bug was found with remote secrets. In the consuming model, we save the secret consumer details and for remote secrets, also update the `secret` parent table. We also needed to update the `secret_reference` table to record the latest revision if this is the first time the secret is being accessed.

## QA steps

bootstrap and deploy a cross model relation with the dummy source and sink charms
add a secret in the dummy source unit and grant access
consume the secret in the dummy sink unit
add a user secret
juju dump-model to see the secret export

NB latest revision checksum is empty because that's not implemented yet

```
remote-secrets:
  remote-secrets:
  - consumer: unit-dummy-sink-1
    current-revision: 1
    id: cqgpq8sq27kjj1mqh2vg
    label: ""
    latest-revision: 1
    source-uuid: d2878f8f-fbd2-4887-8b08-728153665a77
  version: 1
secrets:
  secrets:
  - acl:
      model-5b17f392-d2e5-4ffe-83ac-a5d0e278287b:
        role: manage
        scope: model-5b17f392-d2e5-4ffe-83ac-a5d0e278287b
    create-time: "2024-07-25T00:52:44.879952757Z"
    description: ""
    id: cqgq3n4q27kjj1mqh300
    label: mysecret
    latest-revision-checksum: ""
    owner: model-5b17f392-d2e5-4ffe-83ac-a5d0e278287b
    revisions:
    - content:
        foo: YmFy
      create-time: "2024-07-25T00:52:44.879952757Z"
      number: 1
      update-time: "0001-01-01T00:00:00Z"
    rotate-policy: never
    secret-version: 1
    update-time: "2024-07-25T00:52:44.879952757Z"
  - acl:
      application-controller:
        role: manage
        scope: application-controller
    create-time: "2024-07-25T00:53:04.003574956Z"
    description: ""
    id: cqgq3rsq27kjj1mqh30g
    label: ""
    latest-revision-checksum: ""
    owner: application-controller
    revisions:
    - content:
        foo: YmF6
      create-time: "2024-07-25T00:53:04.003574956Z"
      number: 1
      update-time: "0001-01-01T00:00:00Z"
    rotate-policy: never
    secret-version: 1
    update-time: "2024-07-25T00:53:04.003574956Z"
  version: 2
```


## Links

**Jira card:** [JUJU-5905](https://warthogs.atlassian.net/browse/JUJU-5905)



[JUJU-5905]: https://warthogs.atlassian.net/browse/JUJU-5905?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ