### PR TITLE
test: SSH import bash tests

### DIFF
--- a/tests/suites/authorized_keys/user.sh
+++ b/tests/suites/authorized_keys/user.sh
@@ -27,6 +27,10 @@ run_user_ssh_keys() {
 	# Import the ssh keys for tlm from Github.
 	juju import-ssh-key gh:tlm
 	check_contains "$(juju ssh-keys --full)" "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHxsBSstfw6+55P/YPS8PyH6m58hxt3q2RK2OP1P6J/2"
+
+	# Import the ssh keys for wallyworld from Launchpad
+	juju import-ssh-key lp:wallyworld
+	check_contains "$(juju ssh-keys --full)" "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA4OrXnYsxashjP64y5heB1jCgCERz4cTExsqY6n1ANFXP8AlIxLYHx/g4EE1of/DQ0+uDtimQjJfhvwoglmNkOW4WdWQtaFr1qhMivtSDXEnXI7RZQue9xqH6B3u8yweMqMjqr5mLqJ5eY1HEoFtLBh3tHPHKNM62w/Eb2LLCD2JblbuHmFvLnwxGWNp0jMU69DE/bDvKtmOx4idXBGnqTImOCcDTaNy1srSEiJIprwYqJSOXO61pIs9COQVG1EOadqqvgBE0koITMFPPIWm4dBxbh2DREVFSZIz6DuwPwWXaNk8YqcGH5bU4Y7o6I0iUyVrKT4yG0AjMNc1BaEocGQ=="
 }
 
 test_user_ssh_keys() {

--- a/tests/suites/authorized_keys/user.sh
+++ b/tests/suites/authorized_keys/user.sh
@@ -23,6 +23,10 @@ run_user_ssh_keys() {
 	# Remove the SSH key by comment
 	juju remove-ssh-key isgreat@juju.is
 	check_not_contains "$(juju ssh-keys)" "${fingerprint}"
+
+	# Import the ssh keys for tlm from Github.
+	juju import-ssh-key gh:tlm
+	check_contains "$(juju ssh-keys --full)" "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHxsBSstfw6+55P/YPS8PyH6m58hxt3q2RK2OP1P6J/2"
 }
 
 test_user_ssh_keys() {


### PR DESCRIPTION
This adds missing bash tests for authorized keys to import public ssh keys from Github and Launchpad.

We are adding this test now before landing #17602.

## Checklist

- ~[ ] Code style: imports ordered, good names, simple structure, etc~
- ~[ ] Comments saying why design decisions were made~
- ~[ ] Go unit tests, with comments saying what you're testing~
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

`cd tests; ./main.sh authorized-keys`

## Documentation changes

N/A

## Links

**Jira card:** JUJU-6412

