### PR TITLE
fix: idempotent binary storage

### DIFF
--- a/state/binarystorage/binarystorage_test.go
+++ b/state/binarystorage/binarystorage_test.go
@@ -90,6 +90,11 @@ func (s *binaryStorageSuite) TestAddReplaces(c *gc.C) {
 	s.testAdd(c, "def")
 }
 
+func (s *binaryStorageSuite) TestAddMultiple(c *gc.C) {
+	s.testAdd(c, "abc")
+	s.testAdd(c, "abc")
+}
+
 func (s *binaryStorageSuite) testAdd(c *gc.C, content string) {
 	r := bytes.NewReader([]byte(content))
 	addedMetadata := binarystorage.Metadata{


### PR DESCRIPTION
When adding the same binary hash twice, if the hash already exists, we should just handle the error message and still write the binary storage metadata.

Ideally, we would handle the error message outside of the state layer, but this will be re-written at some point. For now, just allow migrations to pass.

<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://docs.google.com/document/d/1SYUo9G7qZ_jdoVXpUVamS5VCgHmtZ0QA-wZxKoMS-C0 
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
$ juju bootstrap lxd src
$ juju bootstrap lxd dst
$ juju switch src
$ juju add-model moveme1
$ juju deploy ubuntu
$ juju add-model moveme2
$ juju deploy ubuntu
$ juju migrate src:moveme1 dst
$ juju migrate src:moveme2 dst
```

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2074042

**Jira card:** JUJU-

