### PR TITLE
chore: increment juju to 2.9.51

### DIFF
--- a/scripts/win-installer/setup.iss
+++ b/scripts/win-installer/setup.iss
@@ -4,7 +4,7 @@
 #if GetEnv('JUJU_VERSION') != ""
 #define MyAppVersion=GetEnv('JUJU_VERSION')
 #else
-#define MyAppVersion="2.9.50"
+#define MyAppVersion="2.9.51"
 #endif
 
 #define MyAppName "Juju"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: juju
-version: 2.9.50
+version: 2.9.51
 summary: Juju - a model-driven operator lifecycle manager for K8s and machines
 license: AGPL-3.0
 description: |

--- a/version/version.go
+++ b/version/version.go
@@ -19,7 +19,7 @@ import (
 // The presence and format of this constant is very important.
 // The debian/rules build recipe uses this value for the version
 // number of the release package.
-const version = "2.9.50"
+const version = "2.9.51"
 
 // UserAgentVersion defines a user agent version used for communication for
 // outside resources.


### PR DESCRIPTION
chore: increment juju to 2.9.51

The [PR created by the bot](https://github.com/juju/juju/pull/17809) was targeting the wrong branch (2.9-release).

This PR simply rebases the commit onto 2.9