### PR TITLE
feat(secrets): wire up the import backend

### DIFF
--- a/domain/secret/modelmigration/export.go
+++ b/domain/secret/modelmigration/export.go
@@ -5,6 +5,7 @@ package modelmigration
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/juju/description/v6"
 	"github.com/juju/errors"
@@ -135,12 +136,13 @@ func (e *exportOperation) Execute(ctx context.Context, model description.Model) 
 			content, ok := allSecrets.Content[md.URI.ID][rev.Revision]
 			if ok && len(content) > 0 {
 				revArg.Content = content
-			}
-			if rev.ValueRef != nil {
+			} else if rev.ValueRef != nil {
 				revArg.ValueRef = &description.SecretValueRefArgs{
 					BackendID:  rev.ValueRef.BackendID,
 					RevisionID: rev.ValueRef.RevisionID,
 				}
+			} else {
+				return fmt.Errorf("missing secret content to export for secret %q", md.URI.ID)
 			}
 			revisionArgsByID[md.URI.ID] = append(revisionArgsByID[md.URI.ID], revArg)
 		}

--- a/domain/secret/modelmigration/import.go
+++ b/domain/secret/modelmigration/import.go
@@ -6,6 +6,7 @@ package modelmigration
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"sort"
 	"strings"
 
@@ -190,26 +191,26 @@ func (i *importOperation) Execute(ctx context.Context, model description.Model) 
 
 		secretRevisions, secretContent, err := i.collateRevisionInfo(secret.Revisions())
 		if err != nil {
-			return errors.Annotate(err, "collating secret revisions")
+			return errors.Annotatef(err, "collating revisions for secret %q", secret.Id())
 		}
 		allSecrets.Revisions[secret.Id()] = secretRevisions
 		allSecrets.Content[secret.Id()] = secretContent
 
 		secretAccess, err := i.collateAccess(secret.ACL())
 		if err != nil {
-			return errors.Annotate(err, "collating secret access")
+			return errors.Annotatef(err, "collating access for secret %q", secret.Id())
 		}
 		allSecrets.Access[secret.Id()] = secretAccess
 
 		secretConsumers, err := i.collateConsumers(secret.Consumers(), secret.LatestRevision())
 		if err != nil {
-			return errors.Annotate(err, "collating secret consumers")
+			return errors.Annotatef(err, "collating consumers for secret %q", secret.Id())
 		}
 		allSecrets.Consumers[secret.Id()] = secretConsumers
 
 		remoteConsumers, err := i.collateRemoteConsumers(secret.RemoteConsumers())
 		if err != nil {
-			return errors.Annotate(err, "collating secret remote consumers")
+			return errors.Annotatef(err, "collating remote consumers for secret %q", secret.Id())
 		}
 		allSecrets.RemoteConsumers[secret.Id()] = remoteConsumers
 	}
@@ -246,6 +247,13 @@ func (i *importOperation) collateRevisionInfo(revisions []description.SecretRevi
 		}
 		var valueRef *secrets.ValueRef
 		if len(dataCopy) == 0 {
+			// This should ever happen, but just in case, avoid a nil pointer dereference.
+			switch v := reflect.ValueOf(rev.ValueRef()); v.Kind() {
+			case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
+				if v.IsNil() {
+					return nil, nil, fmt.Errorf("missing content for secret revision %d", rev.Number())
+				}
+			}
 			valueRef = &secrets.ValueRef{
 				BackendID:  rev.ValueRef().BackendID(),
 				RevisionID: rev.ValueRef().RevisionID(),

--- a/domain/secret/service/access.go
+++ b/domain/secret/service/access.go
@@ -132,13 +132,16 @@ func (s *SecretService) GrantSecretAccess(ctx context.Context, uri *secrets.URI,
 	if err := s.canManage(ctx, uri, params.Accessor, params.LeaderToken); err != nil {
 		return errors.Trace(err)
 	}
+	return s.st.GrantAccess(ctx, uri, grantParams(params))
+}
 
+func grantParams(in SecretAccessParams) domainsecret.GrantParams {
 	p := domainsecret.GrantParams{
-		ScopeID:   params.Scope.ID,
-		SubjectID: params.Subject.ID,
-		RoleID:    domainsecret.MarshallRole(params.Role),
+		ScopeID:   in.Scope.ID,
+		SubjectID: in.Subject.ID,
+		RoleID:    domainsecret.MarshallRole(in.Role),
 	}
-	switch params.Subject.Kind {
+	switch in.Subject.Kind {
 	case UnitAccessor:
 		p.SubjectTypeID = domainsecret.SubjectUnit
 	case ApplicationAccessor:
@@ -149,7 +152,7 @@ func (s *SecretService) GrantSecretAccess(ctx context.Context, uri *secrets.URI,
 		p.SubjectTypeID = domainsecret.SubjectModel
 	}
 
-	switch params.Scope.Kind {
+	switch in.Scope.Kind {
 	case UnitAccessScope:
 		p.ScopeTypeID = domainsecret.ScopeUnit
 	case ApplicationAccessScope:
@@ -159,8 +162,7 @@ func (s *SecretService) GrantSecretAccess(ctx context.Context, uri *secrets.URI,
 	case RelationAccessScope:
 		p.ScopeTypeID = domainsecret.ScopeRelation
 	}
-
-	return s.st.GrantAccess(ctx, uri, p)
+	return p
 }
 
 // RevokeSecretAccess revokes access to the secret for the specified subject.

--- a/domain/secret/service/exportimport.go
+++ b/domain/secret/service/exportimport.go
@@ -63,9 +63,10 @@ func (s *SecretService) GetSecretsForExport(ctx context.Context) (*SecretExport,
 				// Should not happen.
 				return nil, errors.Errorf("unexpected empty secret content for %q", md.URI.ID)
 			}
-			allSecrets.Content[md.URI.ID] = map[int]coresecrets.SecretData{
-				rev.Revision: data,
+			if _, ok := allSecrets.Content[md.URI.ID]; !ok {
+				allSecrets.Content[md.URI.ID] = make(map[int]coresecrets.SecretData)
 			}
+			allSecrets.Content[md.URI.ID][rev.Revision] = data
 		}
 	}
 

--- a/domain/secret/service/exportimport.go
+++ b/domain/secret/service/exportimport.go
@@ -140,7 +140,142 @@ func (s *SecretService) GetSecretsForExport(ctx context.Context) (*SecretExport,
 }
 
 // ImportSecrets saves the supplied secret details to the model.
-func (s *SecretService) ImportSecrets(context.Context, *SecretExport) error {
-	// TODO(secrets)
+func (s *SecretService) ImportSecrets(ctx context.Context, modelSecrets *SecretExport) error {
+	if err := s.importRemoteSecrets(ctx, modelSecrets.RemoteSecrets); err != nil {
+		return errors.Annotate(err, "importing remote secrets")
+	}
+
+	for _, md := range modelSecrets.Secrets {
+		revisions := modelSecrets.Revisions[md.URI.ID]
+		content := modelSecrets.Content[md.URI.ID]
+		if err := s.importSecretRevisions(ctx, md, revisions, content); err != nil {
+			return errors.Annotatef(err, "saving secret %q", md.URI.ID)
+		}
+		for _, sc := range modelSecrets.Consumers[md.URI.ID] {
+			if err := s.st.SaveSecretConsumer(ctx, md.URI, sc.Accessor.ID, &coresecrets.SecretConsumerMetadata{
+				Label:           sc.Label,
+				CurrentRevision: sc.CurrentRevision,
+			}); err != nil {
+				return errors.Annotatef(err, "saving secret consumer %q for %q", sc.Accessor.ID, md.URI.ID)
+			}
+		}
+
+		for _, rc := range modelSecrets.RemoteConsumers[md.URI.ID] {
+			if err := s.st.SaveSecretRemoteConsumer(ctx, md.URI, rc.Accessor.ID, &coresecrets.SecretConsumerMetadata{
+				Label:           rc.Label,
+				CurrentRevision: rc.CurrentRevision,
+			}); err != nil {
+				return errors.Annotatef(err, "saving secret remote consumer %q for %q", rc.Accessor.ID, md.URI.ID)
+			}
+		}
+
+		for _, access := range modelSecrets.Access[md.URI.ID] {
+			p := grantParams(SecretAccessParams{
+				Scope: SecretAccessScope{
+					Kind: access.Scope.Kind,
+					ID:   access.Scope.ID,
+				},
+				Subject: SecretAccessor{
+					Kind: access.Subject.Kind,
+					ID:   access.Subject.ID,
+				},
+				Role: access.Role,
+			})
+			if err := s.st.GrantAccess(ctx, md.URI, p); err != nil {
+				return errors.Annotatef(err, "saving secret access for %s-%s for secret %q",
+					access.Subject.Kind, access.Subject.ID, md.URI.ID)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (s *SecretService) importSecretRevisions(
+	ctx context.Context, md *coresecrets.SecretMetadata,
+	revisions []*coresecrets.SecretRevisionMetadata,
+	content map[int]coresecrets.SecretData,
+) error {
+	for i, rev := range revisions {
+		params := secret.UpsertSecretParams{
+			ValueRef: rev.ValueRef,
+		}
+		if rev.ValueRef == nil {
+			if data, ok := content[rev.Revision]; ok {
+				params.Data = data
+			} else {
+				// Should never happen.
+				return errors.Errorf("missing content for secret %s/%d", md.URI.ID, rev.Revision)
+			}
+		}
+		// The expiry time of the most recent revision
+		// is included in the export.
+		if i == len(revisions)-1 {
+			params.ExpireTime = md.LatestExpireTime
+		}
+		if i == 0 {
+			if err := s.createImportedSecret(ctx, md, params); err != nil {
+				return errors.Annotatef(err, "cannot import secret %q", md.URI.ID)
+			}
+			continue
+		}
+		if err := s.st.UpdateSecret(ctx, md.URI, params); err != nil {
+			return errors.Annotatef(err, "cannot import secret %q revision %d", md.URI.ID, rev.Revision)
+		}
+	}
+	return nil
+}
+
+func (s *SecretService) createImportedSecret(
+	ctx context.Context, md *coresecrets.SecretMetadata, params secret.UpsertSecretParams,
+) error {
+	params.NextRotateTime = md.NextRotateTime
+	if md.RotatePolicy != "" && md.RotatePolicy != coresecrets.RotateNever {
+		policy := secret.MarshallRotatePolicy(&md.RotatePolicy)
+		params.RotatePolicy = &policy
+	}
+	if md.Description != "" {
+		params.Description = &md.Description
+	}
+	if md.Label != "" {
+		params.Label = &md.Label
+	}
+	if md.AutoPrune {
+		params.AutoPrune = &md.AutoPrune
+	}
+	var err error
+	switch md.Owner.Kind {
+	case coresecrets.ModelOwner:
+		err = s.st.CreateUserSecret(ctx, md.Version, md.URI, params)
+	case coresecrets.ApplicationOwner:
+		err = s.st.CreateCharmApplicationSecret(ctx, md.Version, md.URI, md.Owner.ID, params)
+	case coresecrets.UnitOwner:
+		err = s.st.CreateCharmUnitSecret(ctx, md.Version, md.URI, md.Owner.ID, params)
+	default:
+		// Should never happen.
+		return errors.Errorf("cannot import secret %q with owner kind %q", md.URI.ID, md.Owner.Kind)
+	}
+	return err
+}
+
+func (s *SecretService) importRemoteSecrets(ctx context.Context, remoteSecrets []RemoteSecret) error {
+	remoteSecretLatest := make(map[*coresecrets.URI]int)
+	for _, rs := range remoteSecrets {
+		remoteSecretLatest[rs.URI] = rs.LatestRevision
+	}
+	for uri, latest := range remoteSecretLatest {
+		if err := s.st.UpdateRemoteSecretRevision(ctx, uri, latest); err != nil {
+			return errors.Annotatef(err, "saving remote secret reference for %q", uri)
+		}
+	}
+	for _, rs := range remoteSecrets {
+		if err := s.st.SaveSecretConsumer(ctx, rs.URI, rs.Accessor.ID, &coresecrets.SecretConsumerMetadata{
+			Label:           rs.Label,
+			CurrentRevision: rs.CurrentRevision,
+		}); err != nil {
+			return errors.Annotatef(err, "saving remote consumer %s-%s for secret %q",
+				rs.Accessor.Kind, rs.Accessor.ID, rs.URI.ID)
+		}
+	}
 	return nil
 }

--- a/domain/secret/service/exportimport_test.go
+++ b/domain/secret/service/exportimport_test.go
@@ -5,6 +5,7 @@ package service
 
 import (
 	"context"
+	"time"
 
 	jc "github.com/juju/testing/checkers"
 	"go.uber.org/mock/gomock"
@@ -12,6 +13,7 @@ import (
 
 	coresecrets "github.com/juju/juju/core/secrets"
 	domainsecret "github.com/juju/juju/domain/secret"
+	"github.com/juju/juju/internal/testing"
 )
 
 func (s *serviceSuite) TestGetSecretsForExport(c *gc.C) {
@@ -123,4 +125,178 @@ func (s *serviceSuite) TestGetSecretsForExport(c *gc.C) {
 		},
 		RemoteSecrets: nil,
 	})
+}
+
+func (s *serviceSuite) TestImportSecrets(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	uri := coresecrets.NewURI()
+	uri2 := coresecrets.NewURI()
+	uri3 := coresecrets.NewURI()
+	expireTime := time.Now()
+	rotateTime := time.Now()
+	secrets := []*coresecrets.SecretMetadata{{
+		URI:     uri,
+		Version: 0,
+		Owner: coresecrets.Owner{
+			Kind: coresecrets.ApplicationOwner,
+			ID:   "mysql",
+		},
+		Description:            "my secret",
+		Label:                  "a secret",
+		RotatePolicy:           "hourly",
+		LatestRevisionChecksum: "",
+		LatestExpireTime:       ptr(expireTime),
+		NextRotateTime:         ptr(rotateTime),
+	}, {
+		URI:     uri3,
+		Version: 0,
+		Owner: coresecrets.Owner{
+			Kind: coresecrets.ModelOwner,
+			ID:   testing.ModelTag.Id(),
+		},
+		Description:            "a secret",
+		LatestRevisionChecksum: "",
+		AutoPrune:              true,
+	}}
+	revisions := [][]*coresecrets.SecretRevisionMetadata{{{
+		Revision: 1,
+	}, {
+		Revision: 2,
+		ValueRef: &coresecrets.ValueRef{
+			BackendID:  "backend-id",
+			RevisionID: "revision-id",
+		},
+	}}, {{
+		Revision: 5,
+	}}}
+
+	s.state = NewMockState(ctrl)
+
+	s.state.EXPECT().UpdateRemoteSecretRevision(gomock.Any(), uri2, 668)
+	s.state.EXPECT().SaveSecretConsumer(gomock.Any(), uri2, "mysql/0", &coresecrets.SecretConsumerMetadata{
+		Label:           "remote label",
+		CurrentRevision: 666,
+	})
+
+	s.state.EXPECT().CreateCharmApplicationSecret(gomock.Any(), 0, uri, "mysql", domainsecret.UpsertSecretParams{
+		RotatePolicy:   ptr(domainsecret.RotateHourly),
+		ExpireTime:     nil,
+		NextRotateTime: ptr(rotateTime),
+		Description:    ptr(secrets[0].Description),
+		Label:          ptr(secrets[0].Label),
+		AutoPrune:      nil,
+		Data:           map[string]string{"foo": "bar"},
+	})
+	s.state.EXPECT().UpdateSecret(gomock.Any(), uri, domainsecret.UpsertSecretParams{
+		ExpireTime: ptr(expireTime),
+		ValueRef: &coresecrets.ValueRef{
+			BackendID:  "backend-id",
+			RevisionID: "revision-id",
+		},
+	})
+	s.state.EXPECT().SaveSecretConsumer(gomock.Any(), uri, "mysql/0", &coresecrets.SecretConsumerMetadata{
+		Label:           "my label",
+		CurrentRevision: 666,
+	})
+	s.state.EXPECT().SaveSecretRemoteConsumer(gomock.Any(), uri, "remote-app/0", &coresecrets.SecretConsumerMetadata{
+		CurrentRevision: 668,
+	})
+	s.state.EXPECT().GrantAccess(gomock.Any(), uri, domainsecret.GrantParams{
+		ScopeTypeID:   3,
+		ScopeID:       "wordpress:db mysql:server",
+		SubjectTypeID: 0,
+		SubjectID:     "wordpress/0",
+		RoleID:        1,
+	})
+
+	s.state.EXPECT().GrantAccess(gomock.Any(), uri3, domainsecret.GrantParams{
+		ScopeTypeID:   1,
+		ScopeID:       "mysql",
+		SubjectTypeID: 1,
+		SubjectID:     "mysql",
+		RoleID:        1,
+	})
+
+	s.state.EXPECT().CreateUserSecret(gomock.Any(), 0, uri3, domainsecret.UpsertSecretParams{
+		Description: ptr(secrets[1].Description),
+		AutoPrune:   ptr(secrets[1].AutoPrune),
+		Data:        map[string]string{"foo": "baz"},
+	})
+
+	toImport := &SecretExport{
+		Secrets: secrets,
+		Revisions: map[string][]*coresecrets.SecretRevisionMetadata{
+			uri.ID:  revisions[0],
+			uri3.ID: revisions[1],
+		},
+		Content: map[string]map[int]coresecrets.SecretData{
+			uri.ID: {
+				1: {"foo": "bar"},
+			},
+			uri3.ID: {
+				5: {"foo": "baz"},
+			},
+		},
+		Consumers: map[string][]ConsumerInfo{
+			uri.ID: {{
+				SecretConsumerMetadata: coresecrets.SecretConsumerMetadata{
+					Label:           "my label",
+					CurrentRevision: 666,
+				},
+				Accessor: SecretAccessor{
+					Kind: "unit",
+					ID:   "mysql/0",
+				},
+			}},
+		},
+		RemoteConsumers: map[string][]ConsumerInfo{
+			uri.ID: {{
+				SecretConsumerMetadata: coresecrets.SecretConsumerMetadata{
+					CurrentRevision: 668,
+				},
+				Accessor: SecretAccessor{
+					Kind: "unit",
+					ID:   "remote-app/0",
+				},
+			}},
+		},
+		Access: map[string][]SecretAccess{
+			uri.ID: {{
+				Scope: SecretAccessScope{
+					Kind: "relation",
+					ID:   "wordpress:db mysql:server",
+				},
+				Subject: SecretAccessor{
+					Kind: "unit",
+					ID:   "wordpress/0",
+				},
+				Role: "view",
+			}},
+			uri3.ID: {{
+				Scope: SecretAccessScope{
+					Kind: "application",
+					ID:   "mysql",
+				},
+				Subject: SecretAccessor{
+					Kind: "application",
+					ID:   "mysql",
+				},
+				Role: "view",
+			}},
+		},
+		RemoteSecrets: []RemoteSecret{{
+			URI:             uri2,
+			Label:           "remote label",
+			CurrentRevision: 666,
+			LatestRevision:  668,
+			Accessor: SecretAccessor{
+				Kind: "unit",
+				ID:   "mysql/0",
+			},
+		}},
+	}
+	err := s.service(c).ImportSecrets(context.Background(), toImport)
+	c.Assert(err, jc.ErrorIsNil)
 }

--- a/domain/secret/service/exportimport_test.go
+++ b/domain/secret/service/exportimport_test.go
@@ -32,6 +32,8 @@ func (s *serviceSuite) TestGetSecretsForExport(c *gc.C) {
 			BackendID:  "backend-id",
 			RevisionID: "revision-id",
 		},
+	}, {
+		Revision: 3,
 	}}}
 
 	s.state = NewMockState(ctrl)
@@ -40,6 +42,9 @@ func (s *serviceSuite) TestGetSecretsForExport(c *gc.C) {
 	)
 	s.state.EXPECT().GetSecretValue(gomock.Any(), uri, 1).Return(
 		coresecrets.SecretData{"foo": "bar"}, nil, nil,
+	)
+	s.state.EXPECT().GetSecretValue(gomock.Any(), uri, 3).Return(
+		coresecrets.SecretData{"foo": "bar3"}, nil, nil,
 	)
 	s.state.EXPECT().AllSecretGrants(gomock.Any()).Return(
 		map[string][]domainsecret.GrantParams{
@@ -85,6 +90,7 @@ func (s *serviceSuite) TestGetSecretsForExport(c *gc.C) {
 		Content: map[string]map[int]coresecrets.SecretData{
 			uri.ID: {
 				1: {"foo": "bar"},
+				3: {"foo": "bar3"},
 			},
 		},
 		Consumers: map[string][]ConsumerInfo{


### PR DESCRIPTION
The `ImportSecrets` method on the secret service is implemented. This allows models with secrets to be migrated.
The implementation is the reverse of the previously completed method to export secrets. It takes a `SecretExport` struct with all the data and inserts into state.

## QA steps

deploy a cross model scenario with the dummy source and sink charms
create and share a charm secret and read it
create a user secret and allow a charm to read it

migrate consuming model
migrate offering model
check secrets still work
check dump-model on target controller

## Links

**Jira card:** [JUJU-5905](https://warthogs.atlassian.net/browse/JUJU-5905)



[JUJU-5905]: https://warthogs.atlassian.net/browse/JUJU-5905?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ