### PR TITLE
fix: peergrouper does not factor pending hosts

### DIFF
--- a/worker/peergrouper/controllertracker.go
+++ b/worker/peergrouper/controllertracker.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/worker/v3/catacomb"
 
 	"github.com/juju/juju/core/network"
+	corestatus "github.com/juju/juju/core/status"
 )
 
 // controllerTracker is a worker which reports changes of interest to
@@ -225,8 +226,8 @@ func (c *controllerTracker) hasNodeChanged() (bool, error) {
 		}
 		return false, errors.Trace(err)
 	}
-	// hasVote doesn't count towards a node change but
-	// we still want to record the latest value.
+	// hasVote doesn't count towards a node change,
+	// but we still want to record the latest value.
 	c.hasVote = c.node.HasVote()
 
 	changed := false
@@ -235,4 +236,13 @@ func (c *controllerTracker) hasNodeChanged() (bool, error) {
 		changed = true
 	}
 	return changed, nil
+}
+
+func (c *controllerTracker) hostPendingProvisioning() (bool, error) {
+	status, err := c.host.Status()
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+
+	return status.Status == corestatus.Pending, nil
 }

--- a/worker/peergrouper/desired.go
+++ b/worker/peergrouper/desired.go
@@ -209,8 +209,8 @@ func (p *peerGroupChanges) initNewReplicaSet() map[string]*replicaset.Member {
 // desiredPeerGroup returns a new Mongo peer-group calculated from the input
 // peerGroupInfo.
 // Returned are the new members indexed by node ID, and a map indicating
-// which controller nodes are set as voters in the new new peer-group.
-// If the new peer-group is does not differ from that indicated by the input
+// which controller nodes are set as voters in the new peer-group.
+// If the new peer-group does not differ from that indicated by the input
 // peerGroupInfo, a nil member map is returned along with the correct voters
 // map.
 // An error is returned if:

--- a/worker/peergrouper/shim.go
+++ b/worker/peergrouper/shim.go
@@ -61,8 +61,14 @@ func (*cloudServiceShim) Life() state.Life {
 	return state.Alive
 }
 
+// Status returns an empty status.
+// All that matters is that we do not indicate "pending" status.
+func (*cloudServiceShim) Status() (status.StatusInfo, error) {
+	return status.StatusInfo{}, nil
+}
+
+// SetStatus is a no-op. We don't record the status of a cloud service entity.
 func (*cloudServiceShim) SetStatus(status.StatusInfo) error {
-	// We don't record the status of a cloud service entity.
 	return nil
 }
 


### PR DESCRIPTION
If the peergrouper sees controllers before they are provisioned and fails to find a single cloud-local address to use for Mongo, it sets a status message to that effect, but assumes they are "running" and uses that as the status value.

This means that the provisioner sees the machines via its watcher, but never provisions them because they no longer have the "pending" status.

By disregarding controller hosts not yet provisioned in the peergrouper, we allow the provisioner to provision them first after which they are correctly factored in replica-set calculation.

Some increased DEBUG logging is also added to the provisioner to aid future issue diagnosis.

## QA steps

Use the MAAS set up for us by Solutions QA, with a cloud called "qamaas".
You need to be in the right LP group have VPN access to the IP range.
- Connect to the VPN.
- `sshuttle -r ubuntu@10.245.222.203 10.244.40.0/21`.
- `juju bootstrap qamaas qamaas --to vault-1.silo1.lab0.solutionsqa --debug`.
- `juju switch controller`.
- `juju bind controller oam-space`.
- `juju controller-config juju-ha-space=oam-space`.
- `juju enable-ha`.
- Logs will indicate over time that the machines get provisioned, and join the replica-set.

## Documentation changes

None.

## Links

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2055170

**Jira card:** [JUJU-6423](https://warthogs.atlassian.net/browse/JUJU-6423)



[JUJU-6423]: https://warthogs.atlassian.net/browse/JUJU-6423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ