### PR TITLE
feat(macaroon): remove expired root keys

### DIFF
--- a/apiserver/stateauthenticator/context.go
+++ b/apiserver/stateauthenticator/context.go
@@ -371,7 +371,7 @@ func newExternalMacaroonAuth(ctx context.Context, cfg externalMacaroonAuthentica
 		Clock:            cfg.clock,
 		IdentityLocation: idURL,
 	}
-	store := internalmacaroon.NewExpirableStorage(cfg.macaroonService, cfg.expiryTime, clock.WallClock)
+	store := internalmacaroon.NewExpirableStorage(cfg.macaroonService, cfg.expiryTime, cfg.clock)
 	if cfg.identClient == nil {
 		cfg.identClient = &auth
 	}

--- a/apiserver/stateauthenticator/context_integration_test.go
+++ b/apiserver/stateauthenticator/context_integration_test.go
@@ -64,6 +64,7 @@ func (s *macaroonAuthSuite) SetUpTest(c *gc.C) {
 	s.ControllerSuite.SetUpTest(c)
 	s.macaroonService = macaroonservice.NewService(
 		macaroonstate.NewState(s.TxnRunnerFactory()),
+		s.clock,
 	)
 	s.macaroonService.InitialiseBakeryConfig(context.Background())
 }
@@ -154,6 +155,10 @@ func (s *macaroonAuthSuite) TestExpiredKey(c *gc.C) {
 	}
 	mac, err := bsvc.Oven.NewMacaroon(context.Background(), bakery.LatestVersion, cav, bakery.NoOp)
 	c.Assert(err, gc.IsNil)
+
+	// Advance time here because the root key is created during NewMacaroon.
+	// The clock needs to move over here to expire the root key correctly
+	s.clock.Advance(time.Second)
 
 	client := httpbakery.NewClient()
 	ms, err := client.DischargeAll(context.Background(), mac)

--- a/domain/macaroon/service/package_mock_test.go
+++ b/domain/macaroon/service/package_mock_test.go
@@ -43,18 +43,18 @@ func (m *MockState) EXPECT() *MockStateMockRecorder {
 }
 
 // FindLatestKey mocks base method.
-func (m *MockState) FindLatestKey(arg0 context.Context, arg1, arg2, arg3 time.Time) (macaroon.RootKey, error) {
+func (m *MockState) FindLatestKey(arg0 context.Context, arg1, arg2, arg3, arg4 time.Time) (macaroon.RootKey, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FindLatestKey", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "FindLatestKey", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(macaroon.RootKey)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // FindLatestKey indicates an expected call of FindLatestKey.
-func (mr *MockStateMockRecorder) FindLatestKey(arg0, arg1, arg2, arg3 any) *MockStateFindLatestKeyCall {
+func (mr *MockStateMockRecorder) FindLatestKey(arg0, arg1, arg2, arg3, arg4 any) *MockStateFindLatestKeyCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindLatestKey", reflect.TypeOf((*MockState)(nil).FindLatestKey), arg0, arg1, arg2, arg3)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindLatestKey", reflect.TypeOf((*MockState)(nil).FindLatestKey), arg0, arg1, arg2, arg3, arg4)
 	return &MockStateFindLatestKeyCall{Call: call}
 }
 
@@ -70,13 +70,13 @@ func (c *MockStateFindLatestKeyCall) Return(arg0 macaroon.RootKey, arg1 error) *
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateFindLatestKeyCall) Do(f func(context.Context, time.Time, time.Time, time.Time) (macaroon.RootKey, error)) *MockStateFindLatestKeyCall {
+func (c *MockStateFindLatestKeyCall) Do(f func(context.Context, time.Time, time.Time, time.Time, time.Time) (macaroon.RootKey, error)) *MockStateFindLatestKeyCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateFindLatestKeyCall) DoAndReturn(f func(context.Context, time.Time, time.Time, time.Time) (macaroon.RootKey, error)) *MockStateFindLatestKeyCall {
+func (c *MockStateFindLatestKeyCall) DoAndReturn(f func(context.Context, time.Time, time.Time, time.Time, time.Time) (macaroon.RootKey, error)) *MockStateFindLatestKeyCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -121,18 +121,18 @@ func (c *MockStateGetExternalUsersThirdPartyKeyCall) DoAndReturn(f func(context.
 }
 
 // GetKey mocks base method.
-func (m *MockState) GetKey(arg0 context.Context, arg1 []byte) (macaroon.RootKey, error) {
+func (m *MockState) GetKey(arg0 context.Context, arg1 []byte, arg2 time.Time) (macaroon.RootKey, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetKey", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetKey", arg0, arg1, arg2)
 	ret0, _ := ret[0].(macaroon.RootKey)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetKey indicates an expected call of GetKey.
-func (mr *MockStateMockRecorder) GetKey(arg0, arg1 any) *MockStateGetKeyCall {
+func (mr *MockStateMockRecorder) GetKey(arg0, arg1, arg2 any) *MockStateGetKeyCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetKey", reflect.TypeOf((*MockState)(nil).GetKey), arg0, arg1)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetKey", reflect.TypeOf((*MockState)(nil).GetKey), arg0, arg1, arg2)
 	return &MockStateGetKeyCall{Call: call}
 }
 
@@ -148,13 +148,13 @@ func (c *MockStateGetKeyCall) Return(arg0 macaroon.RootKey, arg1 error) *MockSta
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetKeyCall) Do(f func(context.Context, []byte) (macaroon.RootKey, error)) *MockStateGetKeyCall {
+func (c *MockStateGetKeyCall) Do(f func(context.Context, []byte, time.Time) (macaroon.RootKey, error)) *MockStateGetKeyCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetKeyCall) DoAndReturn(f func(context.Context, []byte) (macaroon.RootKey, error)) *MockStateGetKeyCall {
+func (c *MockStateGetKeyCall) DoAndReturn(f func(context.Context, []byte, time.Time) (macaroon.RootKey, error)) *MockStateGetKeyCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/macaroon/service/rootkeys_test.go
+++ b/domain/macaroon/service/rootkeys_test.go
@@ -21,16 +21,25 @@ import (
 var _ dbrootkeystore.ContextBacking = &RootKeyService{}
 
 type rootKeyServiceSuite struct {
-	st *MockState
+	st    *MockState
+	now   time.Time
+	clock macaroon.Clock
 }
 
 var _ = gc.Suite(&rootKeyServiceSuite{})
 
+var moment = time.Now()
+
 var key = dbrootkeystore.RootKey{
 	Id:      []byte("0"),
-	Created: time.Now(),
-	Expires: time.Now().Add(2 * time.Second),
+	Created: moment,
+	Expires: moment.Add(2 * time.Second),
 	RootKey: []byte("key0"),
+}
+
+func (s *rootKeyServiceSuite) SetUpTest(c *gc.C) {
+	s.now = moment
+	s.clock = clockVal(&s.now)
 }
 
 func (s *rootKeyServiceSuite) setupMocks(c *gc.C) *gomock.Controller {
@@ -44,8 +53,8 @@ func (s *rootKeyServiceSuite) TestGetKeyContext(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	id := []byte("0")
-	s.st.EXPECT().GetKey(gomock.Any(), id).Return(encodeRootKey(key), nil)
-	srv := NewRootKeyService(s.st)
+	s.st.EXPECT().GetKey(gomock.Any(), id, s.now).Return(encodeRootKey(key), nil)
+	srv := NewRootKeyService(s.st, s.clock)
 
 	res, err := srv.GetKeyContext(context.Background(), id)
 	c.Assert(err, jc.ErrorIsNil)
@@ -56,8 +65,8 @@ func (s *rootKeyServiceSuite) TestGetKeyContextNotFound(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	id := []byte("0")
-	s.st.EXPECT().GetKey(gomock.Any(), id).Return(macaroon.RootKey{}, macaroonerrors.KeyNotFound)
-	srv := NewRootKeyService(s.st)
+	s.st.EXPECT().GetKey(gomock.Any(), id, s.now).Return(macaroon.RootKey{}, macaroonerrors.KeyNotFound)
+	srv := NewRootKeyService(s.st, s.clock)
 
 	_, err := srv.GetKeyContext(context.Background(), id)
 	c.Assert(err, jc.ErrorIs, bakery.ErrNotFound)
@@ -66,11 +75,11 @@ func (s *rootKeyServiceSuite) TestGetKeyContextNotFound(c *gc.C) {
 func (s *rootKeyServiceSuite) TestFindLatestKeyContext(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	createdAfter := time.Now()
-	expiresAfter := time.Now().Add(-time.Second)
-	expiresBefore := time.Now().Add(time.Second)
-	s.st.EXPECT().FindLatestKey(gomock.Any(), createdAfter, expiresAfter, expiresBefore).Return(encodeRootKey(key), nil)
-	srv := NewRootKeyService(s.st)
+	createdAfter := s.now
+	expiresAfter := s.now.Add(-time.Second)
+	expiresBefore := s.now.Add(time.Second)
+	s.st.EXPECT().FindLatestKey(gomock.Any(), createdAfter, expiresAfter, expiresBefore, s.now).Return(encodeRootKey(key), nil)
+	srv := NewRootKeyService(s.st, s.clock)
 
 	res, err := srv.FindLatestKeyContext(context.Background(), createdAfter, expiresAfter, expiresBefore)
 	c.Assert(err, jc.ErrorIsNil)
@@ -80,11 +89,11 @@ func (s *rootKeyServiceSuite) TestFindLatestKeyContext(c *gc.C) {
 func (s *rootKeyServiceSuite) TestFindLatestKeyContextNotFound(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	createdAfter := time.Now()
-	expiresAfter := time.Now().Add(-time.Second)
-	expiresBefore := time.Now().Add(time.Second)
-	s.st.EXPECT().FindLatestKey(gomock.Any(), createdAfter, expiresAfter, expiresBefore).Return(macaroon.RootKey{}, macaroonerrors.KeyNotFound)
-	srv := NewRootKeyService(s.st)
+	createdAfter := s.now
+	expiresAfter := s.now.Add(-time.Second)
+	expiresBefore := s.now.Add(time.Second)
+	s.st.EXPECT().FindLatestKey(gomock.Any(), createdAfter, expiresAfter, expiresBefore, s.now).Return(macaroon.RootKey{}, macaroonerrors.KeyNotFound)
+	srv := NewRootKeyService(s.st, s.clock)
 
 	res, err := srv.FindLatestKeyContext(context.Background(), createdAfter, expiresAfter, expiresBefore)
 	c.Assert(err, jc.ErrorIsNil)
@@ -95,7 +104,7 @@ func (s *rootKeyServiceSuite) TestInsertKeyContext(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	s.st.EXPECT().InsertKey(gomock.Any(), encodeRootKey(key))
-	srv := NewRootKeyService(s.st)
+	srv := NewRootKeyService(s.st, s.clock)
 
 	err := srv.InsertKeyContext(context.Background(), key)
 	c.Assert(err, jc.ErrorIsNil)
@@ -106,8 +115,20 @@ func (s *rootKeyServiceSuite) TestInsertKeyContextError(c *gc.C) {
 
 	boom := errors.Errorf("boom")
 	s.st.EXPECT().InsertKey(gomock.Any(), encodeRootKey(key)).Return(boom)
-	srv := NewRootKeyService(s.st)
+	srv := NewRootKeyService(s.st, s.clock)
 
 	err := srv.InsertKeyContext(context.Background(), key)
 	c.Assert(err, gc.Equals, boom)
+}
+
+func clockVal(t *time.Time) macaroon.Clock {
+	return clockFunc(func() time.Time {
+		return *t
+	})
+}
+
+type clockFunc func() time.Time
+
+func (f clockFunc) Now() time.Time {
+	return f()
 }

--- a/domain/macaroon/service/service.go
+++ b/domain/macaroon/service/service.go
@@ -3,6 +3,8 @@
 
 package service
 
+import "github.com/juju/juju/domain/macaroon"
+
 // State represents a type for interacting with the underlying
 // storage required for this service
 type State interface {
@@ -19,9 +21,9 @@ type Service struct {
 
 // NewService returns a new Service providing an API to manage
 // macaroon bakery storage
-func NewService(st State) *Service {
+func NewService(st State, clock macaroon.Clock) *Service {
 	return &Service{
 		BakeryConfigService: NewBakeryConfigService(st),
-		RootKeyService:      NewRootKeyService(st),
+		RootKeyService:      NewRootKeyService(st, clock),
 	}
 }

--- a/domain/macaroon/types.go
+++ b/domain/macaroon/types.go
@@ -14,3 +14,9 @@ type RootKey struct {
 	Expires time.Time
 	RootKey []byte
 }
+
+// Clock provides a clock interface used by the macaroon service
+type Clock interface {
+	// Now returns the current clock time.
+	Now() time.Time
+}

--- a/domain/servicefactory/controller.go
+++ b/domain/servicefactory/controller.go
@@ -4,6 +4,8 @@
 package servicefactory
 
 import (
+	"github.com/juju/clock"
+
 	"github.com/juju/juju/core/changestream"
 	"github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/logger"
@@ -191,5 +193,6 @@ func (s *ControllerFactory) SecretBackend() *secretbackendservice.WatchableServi
 func (s *ControllerFactory) Macaroon() *macaroonservice.Service {
 	return macaroonservice.NewService(
 		macaroonstate.NewState(changestream.NewTxnRunnerFactory(s.controllerDB)),
+		clock.WallClock,
 	)
 }


### PR DESCRIPTION
Ensure expired root keys are removed from DQLite. This means they will not clutter up DQLite.

Inject a current time into the state layer via a clock in the service, and remove keys which expired before this time within the same transaction.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

### CMR

```
./main.sh -v cmr
```

### External users

Copy your ec2 credential over to `./cred.yaml` such that:
```
cat ./cred.yaml
credentials:
  aws:
    ec2-robot-external:
      auth-type: access-key
      access-key: ...
      secret-key: ...
```

The run + observe:
```
$ juju bootstrap aws/eu-west-2 aws --config identity-url=https://api.jujucharms.com/identity --config allow-model-access=true
$ juju grant <lp user>@external superuser
$ juju change-user-password
$ juju logout
$ juju login --user <lp user>@external
Welcome, <lp user>@external. You are now logged into "lxd".

Current model set to "admin/controller".

$ juju whoami
Controller:  aws
Model:       admin/controller
User:        <lp user>@external

$ juju add-credential aws -f ./cred.yaml --controller aws --client
Using cloud "aws" from the controller to verify credentials.
Credential "ec2-robot-external" added locally for cloud "aws".

Controller credential "ec2-robot-external" for user "jack-shaw@external" for cloud "aws" on controller "aws" added.
For more information, see ‘juju show-credential aws ec2-robot-external’.

$ juju add-model m --credential ec2-robot-external
Uploading credential 'aws/jack-shaw@external/ec2-robot-external' to controller
Added 'm' model on aws/eu-west-2 with credential 'ec2-robot-external' for user 'jack-shaw'

$ juju deploy ubuntu
$ juju status
Model  Controller  Cloud/Region   Version      Timestamp
m      aws         aws/eu-west-2  4.0-beta4.1  14:46:11+01:00

App     Version  Status   Scale  Charm   Channel        Rev  Exposed  Message
ubuntu           waiting    0/1  ubuntu  latest/stable   24  no       waiting for machine

Unit      Workload  Agent       Machine  Public address  Ports  Message
ubuntu/0  waiting   allocating  0        18.134.209.114         waiting for machine

Machine  State    Address         Inst id              Base          AZ          Message
0        pending  18.134.209.114  i-0790d125c69f15f77  ubuntu@22.04  eu-west-2b  running
```

NOTE: There are still some bugs with external users. They will hopefully be resolved with https://github.com/juju/juju/pull/17752 + other work

### DQLite repl

Log back into admin

```
$ make repl-install
$ juju ssh -m controller 0
$ sudo cat /var/lib/juju/agents/machine-0/agent.conf | yq '.controllercert' | xargs -I% echo % > dqlite.cert
$ sudo cat /var/lib/juju/agents/machine-0/agent.conf | yq '.controllerkey' | xargs -I% echo % > dqlite.key
$ sudo dqlite -s file:///var/lib/juju/dqlite/cluster.yaml -c ./dqlite.cert -k ./dqlite.key controller
dqlite> SELECT * FROM macaroon_root_key
[54 102 ... 102 51]|2024-07-25 13:42:16.570487774 +0000 UTC|2024-07-27 13:42:16.570487774 +0000 UTC|[149 55 ... 107 153]
```

Wait until the macaroon expires (or hack the expiry time with `UPDATE macaroon_root_key SET expires_at = "1721915279"`) and run in another terminal:

```
$ juju logout
$ juju login -u admin
```

And query:

```
dqlite> SELECT * FROM macaroon_root_key;
[52 57 ... 54 101]|2024-07-25 13:50:09.950321744 +0000 UTC|2024-07-27 13:50:09.950321744 +0000 UTC|[253 168 ... 90 249]
```

Notice there is only 1 root key, which has been replaced

