### PR TITLE
fix: relax vm container storage restriction

### DIFF
--- a/cmd/juju/application/deploy_test.go
+++ b/cmd/juju/application/deploy_test.go
@@ -1201,7 +1201,7 @@ func (s *DeploySuite) TestDeployStorageFailContainer(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	container := "lxd:" + machine.Id()
 	err = s.runDeploy(c, charmDir.Path, "--to", container, "--storage", "data=machinescoped,1G")
-	c.Assert(err, gc.ErrorMatches, "adding storage to lxd container not supported")
+	c.Assert(err, gc.ErrorMatches, `adding storage of type "machinescoped" to lxd container not supported`)
 }
 
 func (s *DeploySuite) TestPlacement(c *gc.C) {

--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -26,6 +26,7 @@ import (
 	"github.com/juju/juju/core/devices"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/storage"
+	"github.com/juju/juju/storage/provider"
 )
 
 type deployCharm struct {
@@ -66,11 +67,20 @@ func (d *deployCharm) deploy(
 	}
 	checkPodspec(charmInfo.Charm(), ctx)
 
-	// storage cannot be added to a container.
-	if len(d.storage) > 0 || len(d.attachStorage) > 0 {
-		for _, placement := range d.placement {
-			if t, err := instance.ParseContainerType(placement.Scope); err == nil {
-				return errors.NotSupportedf("adding storage to %s container", string(t))
+	// Check storage on containers is supported.
+	// This is a rather simplistic client side check based on pool name.
+	// When we support passthrough/bindmount etc we'll need to shift this server side.
+	for _, placement := range d.placement {
+		t, err := instance.ParseContainerType(placement.Scope)
+		if err != nil {
+			continue
+		}
+		if len(d.attachStorage) > 0 {
+			return errors.NotSupportedf("attaching storage to %s container", string(t))
+		}
+		for _, s := range d.storage {
+			if !provider.AllowedContainerProvider(storage.ProviderType(s.Pool)) {
+				return errors.NotSupportedf("adding storage of type %q to %s container", s.Pool, string(t))
 			}
 		}
 	}

--- a/state/assign_test.go
+++ b/state/assign_test.go
@@ -1130,7 +1130,7 @@ func (s *assignCleanSuite) TestAssignToMachineErrors(c *gc.C) {
 	}, machine.Id(), instance.LXD)
 	c.Assert(err, jc.ErrorIsNil)
 	err = unit.AssignToMachine(container)
-	c.Assert(err, gc.ErrorMatches, `cannot assign unit "storage-filesystem/0" to machine 0/lxd/0: adding storage to lxd container not supported`)
+	c.Assert(err, gc.ErrorMatches, `cannot assign unit "storage-filesystem/0" to machine 0/lxd/0: adding storage of type "static" to lxd container not supported`)
 }
 
 func (s *assignCleanSuite) TestAssignUnitWithNonDynamicStorageCleanAvailable(c *gc.C) {

--- a/storage/provider/common.go
+++ b/storage/provider/common.go
@@ -24,3 +24,17 @@ var (
 func CommonStorageProviders() storage.ProviderRegistry {
 	return storage.StaticProviderRegistry{Providers: commonStorageProviders}
 }
+
+// AllowedContainerProvider returns true if the specified storage type
+// can be used with a vm container.
+// Currently, this is a very restricted list, just the storage types
+// created on disk or in memory.
+// In future we'll need to look at supporting passthrough/bindmount storage.
+func AllowedContainerProvider(providerType storage.ProviderType) bool {
+	switch providerType {
+	case LoopProviderType, RootfsProviderType, TmpfsProviderType:
+		return true
+	default:
+		return false
+	}
+}

--- a/storage/provider/common_test.go
+++ b/storage/provider/common_test.go
@@ -72,3 +72,10 @@ func testDetachFilesystems(
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(string(data), gc.Equals, fstab)
 }
+
+func (s *providerCommonSuite) TestAllowedContainerProvider(c *gc.C) {
+	c.Assert(provider.AllowedContainerProvider(provider.LoopProviderType), jc.IsTrue)
+	c.Assert(provider.AllowedContainerProvider(provider.RootfsProviderType), jc.IsTrue)
+	c.Assert(provider.AllowedContainerProvider(provider.TmpfsProviderType), jc.IsTrue)
+	c.Assert(provider.AllowedContainerProvider("somestorage"), jc.IsFalse)
+}


### PR DESCRIPTION
When deploying a charm with storage to a container on a VM, we were disallowing all storage, even though loop, rootfs, and tmpfs should be supported.

This PR adds support for just the above 3 type of storage for containers on vm. In the long term we will want to support passthrough/bindmount but for now, we do just what's needed to unblock the data platform charms.

## QA steps

```sh
$ juju bootstrap lxd test --build-agent --constraints="cores=4 mem=8G virt-type=virtual-machine"
$ juju add-model default
$ juju deploy postgresql --base ubuntu@22.04 --to lxd
```

```
Model       Controller  Cloud/Region     Version      SLA          Timestamp
controller  test        google/us-east1  3.6-beta2.1  unsupported  23:22:16+10:00

App         Version  Status       Scale  Charm            Channel     Rev  Exposed  Message
controller           active           1  juju-controller  3.6/stable   83  no       
postgresql           maintenance      1  postgresql       14/stable   429  no       installing PostgreSQL

Unit           Workload     Agent      Machine  Public address  Ports  Message
controller/0*  active       idle       0        34.23.16.202           
postgresql/0*  maintenance  executing  1/lxd/0  253.0.23.195           (install) installing PostgreSQL

Machine  State    Address       Inst id              Base          AZ          Message
0        started  34.23.16.202  juju-238b0d-0        ubuntu@22.04  us-east1-b  RUNNING
1        started  35.229.81.99  juju-238b0d-1        ubuntu@22.04  us-east1-c  RUNNING
1/lxd/0  started  253.0.23.195  juju-238b0d-1-lxd-0  ubuntu@22.04  us-east1-c  Container started

Storage Unit  Storage ID  Type        Pool    Mountpoint                           Size     Status    Message
postgresql/0  pgdata/0    filesystem  rootfs  /var/snap/charmed-postgresql/common  9.5 GiB  attached  
```

## Documentation changes

@tmihoc we'll need to update deploy with storage doc

## Links

**Github bug:** https://github.com/canonical/postgresql-operator/issues/549

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2074379

**Jira card:** JUJU-[6466](https://warthogs.atlassian.net/browse/JUJU-6466)

