### PR TITLE
chore: remove autocert collection from allcollections

### DIFF
--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -160,13 +160,6 @@ func allCollections() CollectionSchema {
 			}},
 		},
 
-		// This collection holds information cached by autocert certificate
-		// acquisition.
-		autocertCacheC: {
-			global:    true,
-			rawAccess: true,
-		},
-
 		// This collection holds the last time the model user connected
 		// to the model.
 		modelUserLastConnectionC: {
@@ -539,7 +532,6 @@ const (
 	actionNotificationsC     = "actionnotifications"
 	actionresultsC           = "actionresults"
 	actionsC                 = "actions"
-	autocertCacheC           = "autocertCache"
 	assignUnitC              = "assignUnits"
 	bakeryStorageItemsC      = "bakeryStorageItems"
 	blocksC                  = "blocks"

--- a/state/migration_internal_test.go
+++ b/state/migration_internal_test.go
@@ -85,9 +85,6 @@ func (s *MigrationSuite) TestKnownCollections(c *gc.C) {
 		// machine removals.
 		cleanupsC,
 		machineRemovalsC,
-		// The autocert cache is non-critical. After migration
-		// you'll just need to acquire new certificates.
-		autocertCacheC,
 		// We don't export the controller model at this stage.
 		controllersC,
 		controllerNodesC,


### PR DESCRIPTION
This patch removes the autocert collection from the allcollections list on the legacy state. This is a late cleanup, since we have already moved the entire autocert cache domain to dqlite.


## Checklist

- [ ] ~Code style: imports ordered, good names, simple structure, etc~
- [ ] ~Comments saying why design decisions were made~
- [ ] ~Go unit tests, with comments saying what you're testing~
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

N/A because we have already removed all the legacy state for autocert cache, this collection wasn't referenced.



## Links

**Jira card:** JUJU-

