### PR TITLE
test: correct gomock setup in apiserver worker tests

### DIFF
--- a/internal/worker/apiserver/manifold_test.go
+++ b/internal/worker/apiserver/manifold_test.go
@@ -19,7 +19,6 @@ import (
 	dt "github.com/juju/worker/v4/dependency/testing"
 	"github.com/juju/worker/v4/workertest"
 	"github.com/prometheus/client_golang/prometheus"
-	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/agent"
@@ -76,8 +75,6 @@ type ManifoldSuite struct {
 var _ = gc.Suite(&ManifoldSuite{})
 
 func (s *ManifoldSuite) SetUpTest(c *gc.C) {
-	ctrl := gomock.NewController(c)
-	defer ctrl.Finish()
 	s.IsolationSuite.SetUpTest(c)
 
 	s.agent = &mockAgent{}
@@ -95,8 +92,6 @@ func (s *ManifoldSuite) SetUpTest(c *gc.C) {
 	s.stub.ResetCalls()
 	s.serviceFactoryGetter = &stubServiceFactoryGetter{}
 	s.dbDeleter = stubDBDeleter{}
-	s.controllerConfigService = NewMockControllerConfigService(ctrl)
-	s.modelService = NewMockModelService(ctrl)
 
 	s.getter = s.newGetter(nil)
 	s.manifold = apiserver.Manifold(apiserver.ManifoldConfig{

--- a/internal/worker/apiserver/worker_state_test.go
+++ b/internal/worker/apiserver/worker_state_test.go
@@ -65,7 +65,20 @@ func (s *WorkerStateSuite) TearDownTest(c *gc.C) {
 	s.workerFixture.TearDownTest(c)
 }
 
+func (s *WorkerStateSuite) setupMocks(c *gc.C) *gomock.Controller {
+	ctrl := gomock.NewController(c)
+	s.controllerConfigService = NewMockControllerConfigService(ctrl)
+	s.modelService = NewMockModelService(ctrl)
+
+	s.config.ControllerConfigService = s.controllerConfigService
+	s.config.ModelService = s.modelService
+
+	return ctrl
+}
+
 func (s *WorkerStateSuite) TestStart(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
 	s.controllerConfigService.EXPECT().ControllerConfig(gomock.Any()).Return(
 		map[string]any{"controller-uuid": coretesting.ControllerTag.Id()},
 		nil,

--- a/internal/worker/apiserver/worker_test.go
+++ b/internal/worker/apiserver/worker_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/juju/testing"
 	"github.com/juju/worker/v4"
 	"github.com/juju/worker/v4/workertest"
-	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/agent"
@@ -25,6 +24,7 @@ import (
 	"github.com/juju/juju/core/model"
 	modeltesting "github.com/juju/juju/core/model/testing"
 	"github.com/juju/juju/core/presence"
+	"github.com/juju/juju/internal/servicefactory"
 	coretesting "github.com/juju/juju/internal/testing"
 	"github.com/juju/juju/internal/worker/apiserver"
 	"github.com/juju/juju/state"
@@ -51,14 +51,12 @@ type workerFixture struct {
 	objectStoreGetter       stubObjectStoreGetter
 	controllerConfigService *MockControllerConfigService
 	modelService            *MockModelService
-	serviceFactoryGetter    *MockServiceFactoryGetter
+	serviceFactoryGetter    servicefactory.ServiceFactoryGetter
 	controllerUUID          string
 	controllerModelID       model.UUID
 }
 
 func (s *workerFixture) SetUpTest(c *gc.C) {
-	ctrl := gomock.NewController(c)
-	defer ctrl.Finish()
 	s.IsolationSuite.SetUpTest(c)
 	s.agentConfig = mockAgentConfig{
 		dataDir: c.MkDir(),
@@ -76,9 +74,7 @@ func (s *workerFixture) SetUpTest(c *gc.C) {
 	s.logSink = &mockModelLogger{}
 	s.charmhubHTTPClient = &http.Client{}
 	s.sshimporterHTTPClient = &http.Client{}
-	s.controllerConfigService = NewMockControllerConfigService(ctrl)
-	s.modelService = NewMockModelService(ctrl)
-	s.serviceFactoryGetter = NewMockServiceFactoryGetter(ctrl)
+	s.serviceFactoryGetter = &stubServiceFactoryGetter{}
 	s.controllerUUID = coretesting.ControllerTag.Id()
 	s.controllerModelID = modeltesting.GenModelUUID(c)
 	s.stub.ResetCalls()
@@ -178,6 +174,12 @@ func (s *WorkerValidationSuite) TestValidateErrors(c *gc.C) {
 	}, {
 		func(cfg *apiserver.Config) { cfg.ObjectStoreGetter = nil },
 		"nil ObjectStoreGetter not valid",
+	}, {
+		func(cfg *apiserver.Config) { cfg.ControllerConfigService = nil },
+		"nil ControllerConfigService not valid",
+	}, {
+		func(cfg *apiserver.Config) { cfg.ModelService = nil },
+		"nil ModelService not valid",
 	}}
 	for i, test := range tests {
 		c.Logf("test #%d (%s)", i, test.expect)


### PR DESCRIPTION
We should not be setting up mocks inside a test suite's SetUpTest method - this leads to problems in testing as failures on those mocks will not be surfaced.

Refactor the apiserver worker tests so that mocks are setup inside a setupMocks function which is called explicitly. In most cases, we don't actually need to create the mocks, we just need a non-nil value (e.g. for config validation).

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- ~[ ] Comments saying why design decisions were made~
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```
go test ./internal/worker/apiserver
```

## Links

**Jira card:** JUJU-6435, JUJU-6436, JUJU-6437