### PR TITLE
feat(schema): construct port range schema

### DIFF
--- a/domain/schema/model/sql/0022-port-ranges.sql
+++ b/domain/schema/model/sql/0022-port-ranges.sql
@@ -1,0 +1,38 @@
+CREATE TABLE protocol (
+    id INT PRIMARY KEY,
+    protocol TEXT NOT NULL
+);
+
+INSERT INTO protocol VALUES
+(0, 'icmp'),
+(1, 'tcp'),
+(2, 'udp');
+
+CREATE TABLE port_range (
+    unit_endpoint_uuid TEXT NOT NULL,
+    protocol_id INT NOT NULL,
+    from_port INT,
+    to_port INT,
+    -- We disallow overlapping port ranges, however this cannot
+    -- reasonably be enforced in the schema. Including the from_port
+    -- in the primary key is as far as we go here. Non-overlapping
+    -- ranges must be enforced in the service/state layer.
+    PRIMARY KEY (unit_endpoint_uuid, protocol_id, from_port),
+    CONSTRAINT fk_port_range_protocol
+    FOREIGN KEY (protocol_id)
+    REFERENCES protocol (id),
+    CONSTRAINT fk_port_range_unit_endpoint
+    FOREIGN KEY (unit_endpoint_uuid)
+    REFERENCES unit_endpoint (uuid)
+);
+
+CREATE TABLE unit_endpoint (
+    uuid TEXT PRIMARY KEY,
+    endpoint TEXT NOT NULL,
+    unit_uuid TEXT NOT NULL,
+    CONSTRAINT fk_endpoint_unit
+    FOREIGN KEY (unit_uuid)
+    REFERENCES unit (uuid)
+);
+
+CREATE UNIQUE INDEX idx_unit_endpoint_endpoint_unit_uuid ON unit_endpoint (endpoint, unit_uuid);

--- a/domain/schema/schema_test.go
+++ b/domain/schema/schema_test.go
@@ -418,6 +418,11 @@ func (s *schemaSuite) TestModelTables(c *gc.C) {
 		// Status
 		"machine_status_values",
 		"instance_status_values",
+
+		// Opened Ports
+		"protocol",
+		"port_range",
+		"unit_endpoint",
 	)
 	got := readEntityNames(c, s.DB(), "table")
 	wanted := expected.Union(internalTableNames)


### PR DESCRIPTION
This is the schema that will be used to back opened ports state & service.

This service will be used to replace Mongo backed ports state

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made

## QA steps

```
juju bootstrap lxd lxd
```