### PR TITLE
feat: update dqlite build script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -240,7 +240,7 @@ define run_cgo_build
 	@env PATH="${MUSL_BIN_PATH}:${PATH}" \
 		CC="musl-gcc" \
 		CGO_CFLAGS="-I${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH}/include" \
-		CGO_LDFLAGS="-L${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH} -luv -lraft -ldqlite -llz4 -lsqlite3" \
+		CGO_LDFLAGS="-L${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH} -luv -ldqlite -lraft -llz4 -lsqlite3" \
 		CGO_LDFLAGS_ALLOW="(-Wl,-wrap,pthread_create)|(-Wl,-z,now)" \
 		LD_LIBRARY_PATH="${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH}" \
 		CGO_ENABLED=1 \
@@ -270,7 +270,7 @@ define run_cgo_install
 	@env PATH="${MUSL_BIN_PATH}:${PATH}" \
 		CC="musl-gcc" \
 		CGO_CFLAGS="-I${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH}/include" \
-		CGO_LDFLAGS="-L${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH} -luv -lraft -ldqlite -llz4 -lsqlite3" \
+		CGO_LDFLAGS="-L${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH} -luv -ldqlite -lraft -llz4 -lsqlite3" \
 		CGO_LDFLAGS_ALLOW="(-Wl,-wrap,pthread_create)|(-Wl,-z,now)" \
 		LD_LIBRARY_PATH="${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH}" \
 		CGO_ENABLED=1 \
@@ -424,7 +424,7 @@ run-tests: musl-install-if-missing dqlite-install-if-missing
 		PATH="${MUSL_BIN_PATH}:${PATH}" \
 		CC="musl-gcc" \
 		CGO_CFLAGS="-I${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH}/include" \
-		CGO_LDFLAGS="-L${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH} -luv -lraft -ldqlite -llz4 -lsqlite3" \
+		CGO_LDFLAGS="-L${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH} -luv -ldqlite -lraft -llz4 -lsqlite3" \
 		CGO_LDFLAGS_ALLOW="(-Wl,-wrap,pthread_create)|(-Wl,-z,now)" \
 		LD_LIBRARY_PATH="${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH}" \
 		CGO_ENABLED=1 \
@@ -442,7 +442,7 @@ run-go-tests: musl-install-if-missing dqlite-install-if-missing
 	@PATH="${MUSL_BIN_PATH}:${PATH}" \
 		CC="musl-gcc" \
 		CGO_CFLAGS="-I${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH}/include" \
-		CGO_LDFLAGS="-L${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH} -luv -lraft -ldqlite -llz4 -lsqlite3" \
+		CGO_LDFLAGS="-L${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH} -luv -ldqlite -lraft -llz4 -lsqlite3" \
 		CGO_LDFLAGS_ALLOW="(-Wl,-wrap,pthread_create)|(-Wl,-z,now)" \
 		LD_LIBRARY_PATH="${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH}" \
 		CGO_ENABLED=1 \
@@ -454,7 +454,7 @@ go-test-alias: musl-install-if-missing dqlite-install-if-missing
 	@echo alias jt=\'PATH=\"${MUSL_BIN_PATH}:$$${PPATH}\" \
 		CC=\"musl-gcc\" \
 		CGO_CFLAGS=\"-I${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH}/include\" \
-		CGO_LDFLAGS=\"-L${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH} -luv -lraft -ldqlite -llz4 -lsqlite3\" \
+		CGO_LDFLAGS=\"-L${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH} -luv -ldqlite -lraft -llz4 -lsqlite3\" \
 		CGO_LDFLAGS_ALLOW=\""(-Wl,-wrap,pthread_create)|(-Wl,-z,now)"\" \
 		LD_LIBRARY_PATH=\"${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH}\" \
 		CGO_ENABLED=\"1\" \

--- a/Makefile
+++ b/Makefile
@@ -240,7 +240,7 @@ define run_cgo_build
 	@env PATH="${MUSL_BIN_PATH}:${PATH}" \
 		CC="musl-gcc" \
 		CGO_CFLAGS="-I${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH}/include" \
-		CGO_LDFLAGS="-L${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH} -luv -ldqlite -lraft -llz4 -lsqlite3" \
+		CGO_LDFLAGS="-L${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH} -luv -ldqlite -lraft -llz4 -lsqlite3 -Wl,-z,stack-size=1048576" \
 		CGO_LDFLAGS_ALLOW="(-Wl,-wrap,pthread_create)|(-Wl,-z,now)" \
 		LD_LIBRARY_PATH="${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH}" \
 		CGO_ENABLED=1 \
@@ -270,7 +270,7 @@ define run_cgo_install
 	@env PATH="${MUSL_BIN_PATH}:${PATH}" \
 		CC="musl-gcc" \
 		CGO_CFLAGS="-I${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH}/include" \
-		CGO_LDFLAGS="-L${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH} -luv -ldqlite -lraft -llz4 -lsqlite3" \
+		CGO_LDFLAGS="-L${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH} -luv -ldqlite -lraft -llz4 -lsqlite3 -Wl,-z,stack-size=1048576" \
 		CGO_LDFLAGS_ALLOW="(-Wl,-wrap,pthread_create)|(-Wl,-z,now)" \
 		LD_LIBRARY_PATH="${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH}" \
 		CGO_ENABLED=1 \
@@ -424,7 +424,7 @@ run-tests: musl-install-if-missing dqlite-install-if-missing
 		PATH="${MUSL_BIN_PATH}:${PATH}" \
 		CC="musl-gcc" \
 		CGO_CFLAGS="-I${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH}/include" \
-		CGO_LDFLAGS="-L${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH} -luv -ldqlite -lraft -llz4 -lsqlite3" \
+		CGO_LDFLAGS="-L${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH} -luv -ldqlite -lraft -llz4 -lsqlite3 -Wl,-z,stack-size=1048576" \
 		CGO_LDFLAGS_ALLOW="(-Wl,-wrap,pthread_create)|(-Wl,-z,now)" \
 		LD_LIBRARY_PATH="${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH}" \
 		CGO_ENABLED=1 \
@@ -442,7 +442,7 @@ run-go-tests: musl-install-if-missing dqlite-install-if-missing
 	@PATH="${MUSL_BIN_PATH}:${PATH}" \
 		CC="musl-gcc" \
 		CGO_CFLAGS="-I${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH}/include" \
-		CGO_LDFLAGS="-L${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH} -luv -ldqlite -lraft -llz4 -lsqlite3" \
+		CGO_LDFLAGS="-L${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH} -luv -ldqlite -lraft -llz4 -lsqlite3 -Wl,-z,stack-size=1048576" \
 		CGO_LDFLAGS_ALLOW="(-Wl,-wrap,pthread_create)|(-Wl,-z,now)" \
 		LD_LIBRARY_PATH="${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH}" \
 		CGO_ENABLED=1 \
@@ -454,7 +454,7 @@ go-test-alias: musl-install-if-missing dqlite-install-if-missing
 	@echo alias jt=\'PATH=\"${MUSL_BIN_PATH}:$$${PPATH}\" \
 		CC=\"musl-gcc\" \
 		CGO_CFLAGS=\"-I${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH}/include\" \
-		CGO_LDFLAGS=\"-L${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH} -luv -ldqlite -lraft -llz4 -lsqlite3\" \
+		CGO_LDFLAGS=\"-L${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH} -luv -ldqlite -lraft -llz4 -lsqlite3 -Wl,-z,stack-size=1048576\" \
 		CGO_LDFLAGS_ALLOW=\""(-Wl,-wrap,pthread_create)|(-Wl,-z,now)"\" \
 		LD_LIBRARY_PATH=\"${DQLITE_EXTRACTED_DEPS_ARCHIVE_PATH}\" \
 		CGO_ENABLED=\"1\" \

--- a/scripts/dqlite/scripts/env.sh
+++ b/scripts/dqlite/scripts/env.sh
@@ -64,9 +64,8 @@ TAG_LIBTIRPC=upstream/1.3.3
 TAG_LIBNSL=v2.0.0
 TAG_LIBUV=v1.46.0
 TAG_LIBLZ4=v1.9.4
-TAG_RAFT=v0.18.0
-TAG_SQLITE=version-3.43.1
-TAG_DQLITE=v1.16.0
+TAG_SQLITE=version-3.46.0
+TAG_DQLITE=v1.16.6
 
 S3_BUCKET=s3://dqlite-static-libs
 S3_ARCHIVE_NAME=$(date -u +"%Y-%m-%d")-dqlite-deps-${BUILD_ARCH}.tar.bz2

--- a/scripts/dqlite/scripts/env.sh
+++ b/scripts/dqlite/scripts/env.sh
@@ -65,7 +65,7 @@ TAG_LIBNSL=v2.0.0
 TAG_LIBUV=v1.46.0
 TAG_LIBLZ4=v1.9.4
 TAG_SQLITE=version-3.46.0
-TAG_DQLITE=v1.16.6
+TAG_DQLITE=v1.16.7
 
 S3_BUCKET=s3://dqlite-static-libs
 S3_ARCHIVE_NAME=$(date -u +"%Y-%m-%d")-dqlite-deps-${BUILD_ARCH}.tar.bz2

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -363,7 +363,7 @@ parts:
     go-cgo-enabled: "1"
     go-cgo-cc: "musl-gcc"
     go-cgo-cflags: "-I/usr/local/musl/include"
-    go-cgo-ldflags: "-luv -ldqlite -llz4 -lsqlite3"
+    go-cgo-ldflags: "-luv -ldqlite -llz4 -lsqlite3 -Wl,-z,stack-size=1048576"
     go-cgo-ldflags-allow: "(-Wl,-wrap,pthread_create)|(-Wl,-z,now)"
 
   juju:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -73,7 +73,7 @@ parts:
     source: snap/local
 
   musl:
-    source: https://musl.libc.org/releases/musl-1.2.3.tar.gz
+    source: https://musl.libc.org/releases/musl-1.2.5.tar.gz
     source-type: tar
     plugin: autotools
     build-packages:
@@ -105,7 +105,7 @@ parts:
     override-build: |
       set -ex
 
-      ln -s $(pwd)/include/sys/queue.h /usr/local/musl/include/sys/queue.h
+      ln -s $(pwd)/include/sys/queue.h /usr/local/musl/include/sys/queue.h || true
 
   libtirpc:
     after:
@@ -224,7 +224,7 @@ parts:
       - musl
       - musl-compat
     source: https://github.com/sqlite/sqlite.git
-    source-tag: version-3.40.0
+    source-tag: version-3.46.0
     source-type: git
     source-depth: 1
     plugin: autotools
@@ -291,58 +291,14 @@ parts:
     stage:
     - -*.*
 
-  libraft:
-    after:
-      - libuv
-      - liblz4
-    source: https://github.com/canonical/raft.git
-    source-tag: v0.17.1
-    source-type: git
-    source-depth: 1
-    plugin: autotools
-    build-packages:
-      - automake
-      - make
-    override-build: |
-      set -ex
-
-      export PATH=/usr/local/musl/bin:$PATH
-      export CC=musl-gcc
-
-      CUSTOM_CFLAGS=""
-      if [ "$(uname -m)" = "ppc64le" ]; then
-        CUSTOM_CFLAGS="-mlong-double-64"
-      fi
-
-      autoreconf -i
-      CFLAGS="-I${SNAPCRAFT_STAGE}/libuv/include -I${SNAPCRAFT_STAGE}/liblz4/lib ${CUSTOM_CFLAGS}" \
-            LDFLAGS="-L${SNAPCRAFT_STAGE}/libuv/.libs -L${SNAPCRAFT_STAGE}/liblz4/lib" \
-            UV_CFLAGS="-I${SNAPCRAFT_STAGE}/libuv/include" \
-            UV_LIBS="-L${SNAPCRAFT_STAGE}/libuv/.libs" \
-            LZ4_CFLAGS="-I${SNAPCRAFT_STAGE}/liblz4/lib" \
-            LZ4_LIBS="-L${SNAPCRAFT_STAGE}/liblz4/lib" \
-            ./configure --disable-shared
-      make
-
-      mkdir -p $SNAPCRAFT_PART_INSTALL/libraft
-      cp -r $SNAPCRAFT_PART_BUILD/include $SNAPCRAFT_PART_INSTALL/libraft/include
-      cp -r $SNAPCRAFT_PART_BUILD/.libs $SNAPCRAFT_PART_INSTALL/libraft/.libs
-
-      mkdir -p $SNAPCRAFT_PART_INSTALL/libs
-      cp -r $SNAPCRAFT_PART_BUILD/.libs/*.a $SNAPCRAFT_PART_INSTALL/libs
-
-      mkdir -p $SNAPCRAFT_PART_INSTALL/libs/include
-      cp -r $SNAPCRAFT_PART_BUILD/include/* $SNAPCRAFT_PART_INSTALL/libs/include
-    stage:
-    - -*.*
-
   libdqlite:
     after:
       - libnsl
-      - libraft
+      - liblz4
+      - libuv
       - libsqlite3
     source: https://github.com/canonical/dqlite.git
-    source-tag: v1.14.0
+    source-tag: v1.16.7
     source-type: git
     source-depth: 1
     plugin: autotools
@@ -368,14 +324,14 @@ parts:
       fi
 
       autoreconf -i
-      CFLAGS="-I${SNAPCRAFT_STAGE}/libraft/include -I${SNAPCRAFT_STAGE}/libsqlite3 -I${SNAPCRAFT_STAGE}/libuv/include -I${SNAPCRAFT_STAGE}/liblz4/lib -I/usr/local/musl/include -Werror=implicit-function-declaration ${CUSTOM_CFLAGS}" \
-            LDFLAGS="-L${SNAPCRAFT_STAGE}/libraft/.libs -L${SNAPCRAFT_STAGE}/libuv/.libs -L${SNAPCRAFT_STAGE}/liblz4/lib -L${SNAPCRAFT_STAGE}/libnsl/src" \
-            RAFT_CFLAGS="-I${SNAPCRAFT_STAGE}/libraft/include" \
-            RAFT_LIBS="-L${SNAPCRAFT_STAGE}/libraft/.libs" \
+      CFLAGS="-I${SNAPCRAFT_STAGE}/libsqlite3 -I${SNAPCRAFT_STAGE}/libuv/include -I${SNAPCRAFT_STAGE}/liblz4/lib -I/usr/local/musl/include -Werror=implicit-function-declaration ${CUSTOM_CFLAGS}" \
+            LDFLAGS="-L${SNAPCRAFT_STAGE}/libuv/.libs -L${SNAPCRAFT_STAGE}/liblz4/lib -L${SNAPCRAFT_STAGE}/libnsl/src" \
             UV_CFLAGS="-I${SNAPCRAFT_STAGE}/libuv/include" \
             UV_LIBS="-L${SNAPCRAFT_STAGE}/libuv/.libs" \
+            LZ4_CFLAGS="-I${SNAPCRAFT_STAGE}/liblz4/lib" \
+            LZ4_LIBS="-L${SNAPCRAFT_STAGE}/liblz4/lib" \
             SQLITE_CFLAGS="-I${SNAPCRAFT_STAGE}/libsqlite3" \
-            ./configure --disable-shared --enable-debug
+            ./configure --disable-shared --enable-debug --enable-build-raft
       make
 
       mkdir -p $SNAPCRAFT_PART_INSTALL/libdqlite
@@ -407,7 +363,7 @@ parts:
     go-cgo-enabled: "1"
     go-cgo-cc: "musl-gcc"
     go-cgo-cflags: "-I/usr/local/musl/include"
-    go-cgo-ldflags: "-luv -lraft -ldqlite -llz4 -lsqlite3"
+    go-cgo-ldflags: "-luv -ldqlite -llz4 -lsqlite3"
     go-cgo-ldflags-allow: "(-Wl,-wrap,pthread_create)|(-Wl,-z,now)"
 
   juju:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -73,7 +73,7 @@ parts:
     source: snap/local
 
   musl:
-    source: https://musl.libc.org/releases/musl-1.2.5.tar.gz
+    source: https://musl.libc.org/releases/musl-1.2.3.tar.gz
     source-type: tar
     plugin: autotools
     build-packages:
@@ -224,7 +224,7 @@ parts:
       - musl
       - musl-compat
     source: https://github.com/sqlite/sqlite.git
-    source-tag: version-3.46.0
+    source-tag: version-3.40.0
     source-type: git
     source-depth: 1
     plugin: autotools


### PR DESCRIPTION
This updates to the latest dqlite release. This includes removing the building of raft as an explicit dependency. Dqlite lib directly builds the dependency.

This is stage 1 of the update. Stage 2 of the release is to land this, and run the jenkins job to produce the artefacts and land the hashes into the 3.6 branch.

<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://docs.google.com/document/d/1SYUo9G7qZ_jdoVXpUVamS5VCgHmtZ0QA-wZxKoMS-C0 
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc

## QA steps

Ensure we can build the dev artefacts (this will be used by Jenkins builder):

```sh
$ make dqlite-build-lxd
```

Then ensure that we can build snaps:

```sh
$ snapcraft --use-lxd
```

## Links

**Jira card:** [JUJU-6474](https://warthogs.atlassian.net/browse/JUJU-6474)



[JUJU-6474]: https://warthogs.atlassian.net/browse/JUJU-6474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ