### PR TITLE
docs(state): add deprecation warnings to state methods

### DIFF
--- a/state/model.go
+++ b/state/model.go
@@ -459,32 +459,50 @@ func (m *Model) ControllerTag() names.ControllerTag {
 }
 
 // UUID returns the universally unique identifier of the model.
+//
+// Deprecated: please use the UUID field from
+// [github.com/juju/juju/domain/model/service.ModelService.GetModelInfo] instead.
 func (m *Model) UUID() string {
 	return m.doc.UUID
 }
 
 // ControllerUUID returns the universally unique identifier of the controller
 // in which the model is running.
+//
+// Deprecated: please use the ControllerUUID field from
+// [github.com/juju/juju/domain/model/service.ModelService.GetModelInfo] instead.
 func (m *Model) ControllerUUID() string {
 	return m.doc.ControllerUUID
 }
 
 // Name returns the human friendly name of the model.
+//
+// Deprecated: please use the Name field from
+// [github.com/juju/juju/domain/model/service.ModelService.GetModelInfo] instead.
 func (m *Model) Name() string {
 	return m.doc.Name
 }
 
 // Type returns the type of the model.
+//
+// Deprecated: please use the Type field from
+// [github.com/juju/juju/domain/model/service.ModelService.GetModelInfo] instead.
 func (m *Model) Type() ModelType {
 	return m.doc.Type
 }
 
 // CloudName returns the name of the cloud to which the model is deployed.
+//
+// Deprecated: please use the Cloud field from
+// [github.com/juju/juju/domain/model/service.ModelService.GetModelInfo] instead.
 func (m *Model) CloudName() string {
 	return m.doc.Cloud
 }
 
 // CloudRegion returns the name of the cloud region to which the model is deployed.
+//
+// Deprecated: please use the CloudRegion field from
+// [github.com/juju/juju/domain/model/service.ModelService.GetModelInfo] instead.
 func (m *Model) CloudRegion() string {
 	return m.doc.CloudRegion
 }
@@ -608,6 +626,9 @@ func (m *Model) StatusHistory(filter status.StatusHistoryFilter) ([]status.Statu
 }
 
 // Config returns the config for the model.
+//
+// Deprecated: please use
+// [github.com/juju/juju/domain/modelconfig/service.Service.ModelConfig] instead.
 func (m *Model) Config() (*config.Config, error) {
 	return getModelConfig(m.st.db(), m.UUID())
 }
@@ -821,6 +842,9 @@ func (m *Model) AllEndpointBindings() (map[string]*Bindings, error) {
 }
 
 // Users returns a slice of all users for this model.
+//
+// Deprecated: please use
+// [github.com/juju/juju/domain/access/service.Service.GetModelUsers] instead.
 func (m *Model) Users() ([]permission.UserAccess, error) {
 	coll, closer := m.st.db().GetCollection(modelUsersC)
 	defer closer()

--- a/state/modelconfig.go
+++ b/state/modelconfig.go
@@ -23,12 +23,19 @@ var disallowedModelConfigAttrs = [...]string{
 }
 
 // ModelConfig returns the complete config for the model
+//
+// Deprecated: please use
+// [github.com/juju/juju/domain/modelconfig/service.Service.ModelConfig] instead.
 func (m *Model) ModelConfig(context.Context) (*config.Config, error) {
 	return getModelConfig(m.st.db(), m.UUID())
 }
 
 // AgentVersion returns the agent version for the model config.
 // If no agent version is found, it returns NotFound error.
+//
+// Deprecated: please use
+// [github.com/juju/juju/domain/modelagent/service.ModelService.GetModelAgentVersion]
+// instead.
 func (m *Model) AgentVersion() (version.Number, error) {
 	cfg, err := m.ModelConfig(context.Background())
 	if err != nil {


### PR DESCRIPTION
We are currently in the process of replacing the old Mongo-based `state` package with new services in the `domain` package. This is a coordinated effort involving essentially the entire team. This PR deals with the issue of cross-team communication and coordination.

There are hundreds if not thousands of state methods. As we define new service methods to replace them, it becomes harder and harder to keep track of which service and method should replace a given state method. Thus, we should have a way to document this.

My suggestion is to use standard Go deprecation warnings. The state methods are already deprecated under any reasonable interpretation of that word. As soon as there is a service method equivalent for a certain state method, we should add a deprecation warning to that state method directing people to use the new service method.

Obviously it's not always as easy as find and replace, but I think we can trust team members to use their best judgement here. Having a starting point would at least be helpful.

As an example, @Aflynn50 recently merged a PR #17810 which introduced a `GetModelUsers` method on the access service to replace the state `Model.Users` method. If you missed that PR, then you may not know that there is a service method to replace `Model.Users`. This could result in slower refactoring or in the worst case, duplication of work.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- ~[ ] Code style: imports ordered, good names, simple structure, etc~
- [x] Comments saying why design decisions were made
- ~[ ] Go unit tests, with comments saying what you're testing~
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

N/A - this is a doc change

## Documentation changes

Certain state methods will carry deprecation warnings.

## Links

**Jira card:** JUJU-XXXX