### PR TITLE
feat: add controller model uuid to db and update ControllerModel

### DIFF
--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -257,7 +257,7 @@ func (b *AgentBootstrap) Initialize(ctx stdcontext.Context) (_ *state.Controller
 	databaseBootstrapOptions := []database.BootstrapOpt{
 		// The controller config needs to be inserted before the admin users
 		// because the admin users permissions require the controller UUID.
-		ccbootstrap.InsertInitialControllerConfig(stateParams.ControllerConfig),
+		ccbootstrap.InsertInitialControllerConfig(stateParams.ControllerConfig, controllerModelUUID),
 		// The admin user needs to be added before everything else that
 		// requires being owned by a Juju user.
 		addAdminUser,

--- a/domain/controllerconfig/bootstrap/bootstrap_test.go
+++ b/domain/controllerconfig/bootstrap/bootstrap_test.go
@@ -6,10 +6,12 @@ package bootstrap
 import (
 	"context"
 
+	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/controller"
+	coremodel "github.com/juju/juju/core/model"
 	schematesting "github.com/juju/juju/domain/schema/testing"
 	"github.com/juju/juju/internal/testing"
 )
@@ -21,8 +23,13 @@ type bootstrapSuite struct {
 var _ = gc.Suite(&bootstrapSuite{})
 
 func (s *bootstrapSuite) TestInsertInitialControllerConfig(c *gc.C) {
-	cfg := controller.Config{controller.CACertKey: testing.CACert}
-	err := InsertInitialControllerConfig(cfg)(context.Background(), s.TxnRunner(), s.NoopTxnRunner())
+	cfg := controller.Config{
+		controller.CACertKey:         testing.CACert,
+		controller.ControllerUUIDKey: testing.ControllerTag.Id(),
+	}
+	modelUUID, err := coremodel.NewUUID()
+	c.Assert(err, gc.IsNil)
+	err = InsertInitialControllerConfig(cfg, modelUUID)(context.Background(), s.TxnRunner(), s.NoopTxnRunner())
 	c.Assert(err, jc.ErrorIsNil)
 
 	var cert string
@@ -30,10 +37,25 @@ func (s *bootstrapSuite) TestInsertInitialControllerConfig(c *gc.C) {
 	c.Assert(row.Scan(&cert), jc.ErrorIsNil)
 
 	c.Check(cert, gc.Equals, testing.CACert)
+
+	var dbUUID, dbModelUUID string
+	row = s.DB().QueryRow("SELECT uuid, model_uuid FROM controller")
+	c.Assert(row.Scan(&dbUUID, &dbModelUUID), jc.ErrorIsNil)
+
+	c.Check(dbModelUUID, gc.Equals, modelUUID.String())
+	c.Check(dbUUID, gc.Equals, testing.ControllerTag.Id())
+}
+
+func (s *bootstrapSuite) TestValidModelUUID(c *gc.C) {
+	cfg := controller.Config{controller.CACertKey: testing.CACert}
+	err := InsertInitialControllerConfig(cfg, coremodel.UUID("bad-uuid"))(context.Background(), s.TxnRunner(), s.NoopTxnRunner())
+	c.Assert(err, jc.ErrorIs, errors.NotValid)
 }
 
 func (s *bootstrapSuite) TestInsertMinimalControllerConfig(c *gc.C) {
 	cfg := controller.Config{}
-	err := InsertInitialControllerConfig(cfg)(context.Background(), s.TxnRunner(), s.NoopTxnRunner())
+	modelUUID, err := coremodel.NewUUID()
+	c.Assert(err, gc.IsNil)
+	err = InsertInitialControllerConfig(cfg, modelUUID)(context.Background(), s.TxnRunner(), s.NoopTxnRunner())
 	c.Assert(err, gc.ErrorMatches, "no controller config values to insert at bootstrap")
 }

--- a/domain/controllerconfig/controllerconfig_test.go
+++ b/domain/controllerconfig/controllerconfig_test.go
@@ -12,6 +12,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/controller"
+	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/domain/controllerconfig/bootstrap"
 	"github.com/juju/juju/domain/controllerconfig/service"
 	domainstate "github.com/juju/juju/domain/controllerconfig/state"
@@ -47,7 +48,9 @@ func (s *controllerconfigSuite) TestControllerConfigRoundTrips(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = bootstrap.InsertInitialControllerConfig(cfgIn)(ctx.Background(), s.TxnRunner(), s.NoopTxnRunner())
+	controllerModelUUID := coremodel.UUID(jujutesting.ModelTag.Id())
+
+	err = bootstrap.InsertInitialControllerConfig(cfgIn, controllerModelUUID)(ctx.Background(), s.TxnRunner(), s.NoopTxnRunner())
 	c.Assert(err, jc.ErrorIsNil)
 
 	cfgOut, err := srv.ControllerConfig(ctx.Background())

--- a/domain/controllerconfig/state/state_test.go
+++ b/domain/controllerconfig/state/state_test.go
@@ -11,6 +11,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/controller"
+	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/domain/controllerconfig/bootstrap"
 	schematesting "github.com/juju/juju/domain/schema/testing"
 	jujutesting "github.com/juju/juju/internal/testing"
@@ -29,7 +30,8 @@ func (s *stateSuite) SetUpTest(c *gc.C) {
 		controller.ControllerUUIDKey: jujutesting.ControllerTag.Id(),
 		controller.CACertKey:         jujutesting.CACert,
 	}
-	err := bootstrap.InsertInitialControllerConfig(cfg)(ctx.Background(), s.TxnRunner(), s.NoopTxnRunner())
+	controllerModelUUID := coremodel.UUID(jujutesting.ModelTag.Id())
+	err := bootstrap.InsertInitialControllerConfig(cfg, controllerModelUUID)(ctx.Background(), s.TxnRunner(), s.NoopTxnRunner())
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/domain/model/bootstrap/bootstrap.go
+++ b/domain/model/bootstrap/bootstrap.go
@@ -8,6 +8,7 @@ import (
 	"database/sql"
 	"fmt"
 
+	"github.com/canonical/sqlair"
 	"github.com/juju/version/v2"
 
 	"github.com/juju/juju/core/database"
@@ -127,7 +128,7 @@ func CreateReadOnlyModel(
 		}
 
 		var m coremodel.Model
-		err := controllerDB.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		err := controllerDB.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 			var err error
 			m, err = state.GetModel(ctx, tx, id)
 			return err

--- a/domain/model/doc.go
+++ b/domain/model/doc.go
@@ -1,0 +1,8 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package model contains the controller model service. The controller stores
+// information about all the models it manages. This service exposes methods to
+// perform management operations such as creating, destroying and gathering
+// information about models the controller manages.
+package model

--- a/domain/model/service/service.go
+++ b/domain/model/service/service.go
@@ -65,6 +65,9 @@ type State interface {
 	// GetModelType returns the model type for a model with the provided uuid.
 	GetModelType(context.Context, coremodel.UUID) (coremodel.ModelType, error)
 
+	// GetControllerModel returns the model the controller is running in.
+	GetControllerModel(ctx context.Context) (coremodel.Model, error)
+
 	// Delete removes a model and all of it's associated data from Juju.
 	Delete(context.Context, coremodel.UUID) error
 
@@ -349,7 +352,7 @@ func (s *Service) ImportModel(
 // Should no model exist for the controller an error of [modelerrors.NotFound]
 // will be returned.
 func (s *Service) ControllerModel(ctx context.Context) (coremodel.Model, error) {
-	return s.st.GetModelByName(ctx, coremodel.ControllerModelOwnerUsername, coremodel.ControllerModelName)
+	return s.st.GetControllerModel(ctx)
 }
 
 // Model returns the model associated with the provided uuid.

--- a/domain/model/service/service_test.go
+++ b/domain/model/service/service_test.go
@@ -824,6 +824,7 @@ func (s *serviceSuite) TestControllerModel(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(activator(context.Background()), jc.ErrorIsNil)
+	s.state.controllerModelUUID = modelID
 
 	model, err := svc.ControllerModel(context.Background())
 	c.Check(err, jc.ErrorIsNil)

--- a/domain/model/service/state_test.go
+++ b/domain/model/service/state_test.go
@@ -27,11 +27,12 @@ type dummyStateCloud struct {
 }
 
 type dummyState struct {
-	clouds             map[string]dummyStateCloud
-	models             map[coremodel.UUID]coremodel.Model
-	nonActivatedModels map[coremodel.UUID]coremodel.Model
-	users              map[user.UUID]string
-	secretBackends     []string
+	clouds              map[string]dummyStateCloud
+	models              map[coremodel.UUID]coremodel.Model
+	nonActivatedModels  map[coremodel.UUID]coremodel.Model
+	users               map[user.UUID]string
+	secretBackends      []string
+	controllerModelUUID coremodel.UUID
 }
 
 type dummyDeleter struct {
@@ -146,6 +147,16 @@ func (d *dummyState) GetModel(
 	info, exists := d.models[uuid]
 	if !exists {
 		return coremodel.Model{}, fmt.Errorf("%w %q", modelerrors.NotFound, uuid)
+	}
+	return info, nil
+}
+
+func (d *dummyState) GetControllerModel(
+	_ context.Context,
+) (coremodel.Model, error) {
+	info, exists := d.models[d.controllerModelUUID]
+	if !exists {
+		return coremodel.Model{}, modelerrors.NotFound
 	}
 	return info, nil
 }

--- a/domain/model/state/state_test.go
+++ b/domain/model/state/state_test.go
@@ -61,7 +61,8 @@ func (m *stateSuite) SetUpTest(c *gc.C) {
 	m.userUUID = userUUID
 	m.userName = "test-user"
 	c.Assert(err, jc.ErrorIsNil)
-	m.controllerUUID = m.SeedControllerUUID(c)
+	m.uuid = modeltesting.GenModelUUID(c)
+	m.controllerUUID = m.SeedControllerTable(c, m.uuid)
 	userState := accessstate.NewState(m.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 	err = userState.AddUser(
 		context.Background(),
@@ -142,7 +143,6 @@ func (m *stateSuite) SetUpTest(c *gc.C) {
 	err = bootstrap.CreateDefaultBackends(coremodel.IAAS)(context.Background(), m.ControllerTxnRunner(), m.TxnRunner())
 	c.Assert(err, jc.ErrorIsNil)
 
-	m.uuid = modeltesting.GenModelUUID(c)
 	modelSt := NewState(m.TxnRunnerFactory())
 	err = modelSt.Create(
 		context.Background(),
@@ -1173,4 +1173,31 @@ func (m *stateSuite) TestCleanupBrokenModel(c *gc.C) {
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
+}
+
+// TestGetControllerModel is asserting the happy path of
+// [State.GetControllerModel] and checking that we can retrieve the controller
+// model established in SetUpTest.
+func (m *stateSuite) TestGetControllerModel(c *gc.C) {
+	modelSt := NewState(m.TxnRunnerFactory())
+	// The controller model uuid was set in SetUpTest.
+	model, err := modelSt.GetControllerModel(context.Background())
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(model, gc.DeepEquals, coremodel.Model{
+		Name:         "my-test-model",
+		Life:         life.Alive,
+		UUID:         m.uuid,
+		ModelType:    coremodel.IAAS,
+		AgentVersion: version.Current,
+		Cloud:        "my-cloud",
+		CloudType:    "ec2",
+		CloudRegion:  "my-region",
+		Credential: corecredential.Key{
+			Cloud: "my-cloud",
+			Owner: "test-user",
+			Name:  "foobar",
+		},
+		Owner:     m.userUUID,
+		OwnerName: m.userName,
+	})
 }

--- a/domain/model/state/types.go
+++ b/domain/model/state/types.go
@@ -1,0 +1,89 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"fmt"
+
+	"github.com/juju/version/v2"
+
+	"github.com/juju/juju/core/credential"
+	"github.com/juju/juju/core/life"
+	coremodel "github.com/juju/juju/core/model"
+	"github.com/juju/juju/core/user"
+)
+
+// dbModel represents the state of a model.
+type dbModel struct {
+	// Name is the human friendly name of the model.
+	Name string `db:"name"`
+
+	// Life is the current state of the model.
+	// Options are alive, dying, dead. Every model starts as alive, only
+	// during the destruction of the model it transitions to dying and then
+	// dead.
+	Life string `db:"life"`
+
+	// UUID is the universally unique identifier of the model.
+	UUID string `db:"uuid"`
+
+	// ModelType is the type of model.
+	ModelType string `db:"model_type"`
+
+	// AgentVersion is the target version for agents running under this model.
+	AgentVersion string `db:"target_version"`
+
+	// CloudName is the name of the cloud to associate with the model.
+	CloudName string `db:"cloud_name"`
+
+	// CloudType is the type of the underlying cloud (e.g. lxd, azure, ...)
+	CloudType string `db:"cloud_type"`
+
+	// CloudRegion is the region that the model will use in the cloud.
+	CloudRegion string `db:"cloud_region_name"`
+
+	// CredentialName is the name of the model cloud credential.
+	CredentialName string `db:"cloud_credential_name"`
+
+	// CredentialCloudName is the cloud name that the model cloud credential applies to.
+	CredentialCloudName string `db:"cloud_credential_cloud_name"`
+
+	// CredentialOwnerName is the owner of the model cloud credential.
+	CredentialOwnerName string `db:"cloud_credential_owner_name"`
+
+	// OwnerUUID is the uuid of the user that owns this model in the Juju controller.
+	OwnerUUID string `db:"owner_uuid"`
+
+	// OwnerName is the name of the model owner in the Juju controller.
+	OwnerName string `db:"owner_name"`
+}
+
+func (m *dbModel) toCoreModel() (coremodel.Model, error) {
+	agentVersion, err := version.Parse(m.AgentVersion)
+	if err != nil {
+		return coremodel.Model{}, fmt.Errorf("parsing model %q agent version %q: %w", m.UUID, agentVersion, err)
+	}
+	return coremodel.Model{
+		Name:         m.Name,
+		Life:         life.Value(m.Life),
+		UUID:         coremodel.UUID(m.UUID),
+		ModelType:    coremodel.ModelType(m.ModelType),
+		AgentVersion: agentVersion,
+		Cloud:        m.CloudName,
+		CloudType:    m.CloudType,
+		CloudRegion:  m.CloudRegion,
+		Credential: credential.Key{
+			Name:  m.CredentialName,
+			Cloud: m.CredentialCloudName,
+			Owner: m.CredentialOwnerName,
+		},
+		Owner:     user.UUID(m.OwnerUUID),
+		OwnerName: m.OwnerName,
+	}, nil
+}
+
+// dbModelUUID represents the controller model uuid from the controller table.
+type dbModelUUID struct {
+	ModelUUID string `db:"model_uuid"`
+}

--- a/domain/modelconfig/bootstrap/bootstrap.go
+++ b/domain/modelconfig/bootstrap/bootstrap.go
@@ -5,7 +5,6 @@ package bootstrap
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 
 	"github.com/canonical/sqlair"
@@ -43,7 +42,7 @@ func SetModelConfig(
 		}
 
 		var m coremodel.Model
-		err = controller.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		err = controller.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 			var err error
 			m, err = modelstate.GetModel(ctx, tx, modelID)
 			return err

--- a/domain/schema/controller/sql/0009-controller-config.sql
+++ b/domain/schema/controller/sql/0009-controller-config.sql
@@ -4,7 +4,8 @@ CREATE TABLE controller_config (
 );
 
 CREATE TABLE controller (
-    uuid TEXT NOT NULL PRIMARY KEY
+    uuid TEXT NOT NULL PRIMARY KEY,
+    model_uuid TEXT NOT NULL
 );
 
 -- A unique constraint over a constant index ensures only 1 entry matching the 

--- a/domain/servicefactory/testing/suite.go
+++ b/domain/servicefactory/testing/suite.go
@@ -94,6 +94,7 @@ func (s *ServiceFactorySuite) DefaultModelServiceFactory(c *gc.C) servicefactory
 func (s *ServiceFactorySuite) SeedControllerConfig(c *gc.C) {
 	fn := controllerconfigbootstrap.InsertInitialControllerConfig(
 		s.ControllerConfig,
+		s.ControllerModelUUID,
 	)
 	err := fn(context.Background(), s.ControllerTxnRunner(), s.NoopTxnRunner())
 	c.Assert(err, jc.ErrorIsNil)

--- a/domain/testing/controllerconfigsuite.go
+++ b/domain/testing/controllerconfigsuite.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/juju/juju/controller"
 	coredatabase "github.com/juju/juju/core/database"
+	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/domain/controllerconfig/bootstrap"
 )
 
@@ -24,9 +25,10 @@ type ControllerTxnProvider interface {
 func SeedControllerConfig(
 	c *gc.C,
 	config controller.Config,
+	controllerModelUUID coremodel.UUID,
 	provider ControllerTxnProvider,
 ) controller.Config {
-	err := bootstrap.InsertInitialControllerConfig(config)(context.Background(), provider.ControllerTxnRunner(), noopTxnRunner{})
+	err := bootstrap.InsertInitialControllerConfig(config, controllerModelUUID)(context.Background(), provider.ControllerTxnRunner(), noopTxnRunner{})
 	c.Assert(err, jc.ErrorIsNil)
 	return config
 }

--- a/internal/testing/environ.go
+++ b/internal/testing/environ.go
@@ -54,6 +54,10 @@ var ModelTag = names.NewModelTag("deadbeef-0bad-400d-8000-4b1d0d06f00d")
 // ControllerTag is a defined known valid UUID that can be used in testing.
 var ControllerTag = names.NewControllerTag("deadbeef-1bad-500d-9000-4b1d0d06f00d")
 
+// ControllerModelTag is a defined known valid UUID that can be used in testing
+// for the model the controller is running on.
+var ControllerModelTag = names.NewControllerTag("deadbeef-2bad-500d-9000-4b1d0d06f00d")
+
 // FakeControllerConfig returns an environment configuration
 // that is expected to be found in state for a fake controller.
 func FakeControllerConfig() controller.Config {


### PR DESCRIPTION
The controller model UUID was not stored anywhere in the dqlite db. The naturual place for this to go is the controller table, alongside the ControllerUUID.

The method on model, ControllerModel, got the controller model by looking for the model with the name "controller". A new method on the model state has now been added to get the controller model by looking up its uuid in the controller table.

<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://docs.google.com/document/d/1SYUo9G7qZ_jdoVXpUVamS5VCgHmtZ0QA-wZxKoMS-C0 
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps
Test model migration because this uses the `ControllerModel` method on the controller service.
```
juju bootstrap lxd test-controller-uuid
juju add-model test
juju bootstrap lxd migration-target
juju switch test-controller-uuid
juju migrate test migration-target
juju switch migration-target
juju models
Controller: migration-target

Model       Cloud/Region  Type  Status     Machines  Units  Access  Last connection
controller  lxd/default   lxd   available         1      1  admin   just now
test        lxd/default   lxd   available         0      -  admin   never connected

```
<!-- Describe steps to verify that the change works. -->

## Documentation changes

Added doc.go to model domain

## Links


**Jira card:** [JUJU-6476](https://warthogs.atlassian.net/browse/JUJU-6476)



[JUJU-6476]: https://warthogs.atlassian.net/browse/JUJU-6476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ