### PR TITLE
fix: set param LastConnection to nil if IsZero

### DIFF
--- a/apiserver/facades/client/usermanager/usermanager.go
+++ b/apiserver/facades/client/usermanager/usermanager.go
@@ -6,6 +6,7 @@ package usermanager
 import (
 	"context"
 	"strings"
+	"time"
 
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
@@ -348,13 +349,17 @@ func (api *UserManagerAPI) UserInfo(ctx context.Context, request params.UserInfo
 // information needed but not contained in the core user from the access
 // service.
 func (api *UserManagerAPI) infoForUser(ctx context.Context, tag names.UserTag, user coreuser.User) params.UserInfoResult {
+	var lastLogin *time.Time
+	if !user.LastLogin.IsZero() {
+		lastLogin = &user.LastLogin
+	}
 	result := params.UserInfoResult{
 		Result: &params.UserInfo{
 			Username:       user.Name,
 			DisplayName:    user.DisplayName,
 			CreatedBy:      user.CreatorName,
 			DateCreated:    user.CreatedAt,
-			LastConnection: &user.LastLogin,
+			LastConnection: lastLogin,
 			Disabled:       user.Disabled,
 		},
 	}

--- a/apiserver/facades/client/usermanager/usermanager_test.go
+++ b/apiserver/facades/client/usermanager/usermanager_test.go
@@ -412,7 +412,7 @@ func (s *userManagerSuite) TestUserInfoAll(c *gc.C) {
 				Username:       "fred",
 				Disabled:       false,
 				Access:         "login",
-				LastConnection: &time.Time{},
+				LastConnection: nil,
 			},
 		}}}
 	expectedIncDisabled := params.UserInfoResults{
@@ -421,7 +421,7 @@ func (s *userManagerSuite) TestUserInfoAll(c *gc.C) {
 				Username:       "nancy",
 				Disabled:       true,
 				Access:         "",
-				LastConnection: &time.Time{},
+				LastConnection: nil,
 			},
 		}),
 	}


### PR DESCRIPTION
When you did `juju users` or `juju show-user` if a user never connected it would show their login time as `01-01-0001`, which was annoying. This fixes it by changing it to show never connected.



<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://docs.google.com/document/d/1SYUo9G7qZ_jdoVXpUVamS5VCgHmtZ0QA-wZxKoMS-C0 
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps
```
juju bootstrap test
juju add-model m
juju add-user jim

juju users
Controller: test-fix-lastlogin

Name          Display name  Access     Date created   Last connection
admin*        admin         superuser  1 minute ago   just now
juju-metrics  Juju Metrics  login      1 minute ago   never connected
jim                         login      2 seconds ago  never connected

juju show-user jim
user-name: jim
access: login
date-created: 7 seconds ago
last-connection: never connected
```

