### PR TITLE
feat: export charm actions, config and lxd profile

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/juju/clock v1.1.1
 	github.com/juju/cmd/v3 v3.0.15
 	github.com/juju/collections v1.0.4
-	github.com/juju/description/v7 v7.0.0
+	github.com/juju/description/v7 v7.0.2
 	github.com/juju/errors v1.0.0
 	github.com/juju/featureflag v1.0.0
 	github.com/juju/gnuflag v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -487,8 +487,8 @@ github.com/juju/collections v0.0.0-20220203020748-febd7cad8a7a/go.mod h1:JWeZdyt
 github.com/juju/collections v1.0.0/go.mod h1:JWeZdyttIEbkR51z2S13+J+aCuHVe0F6meRy+P0YGDo=
 github.com/juju/collections v1.0.4 h1:GjL+aN512m2rVDqhPII7P6qB0e+iYFubz8sqBhZaZtk=
 github.com/juju/collections v1.0.4/go.mod h1:hVrdB0Zwq9wIU1Fl6ItD2+UETeNeOEs+nGvJufVe+0c=
-github.com/juju/description/v7 v7.0.0 h1:8uKaUWdPLEj/JJjqZ8E7erWHxDcdGbKpxcvHzY0/qoc=
-github.com/juju/description/v7 v7.0.0/go.mod h1:lEwq+EiDmUgJ5V4UIDLppWx3sYc/5o1GW32MXb8Ko+k=
+github.com/juju/description/v7 v7.0.2 h1:v44ZkjMeuIwvQQ/abFNS/W2SUQaN6zWfJz0dhuEAtZ0=
+github.com/juju/description/v7 v7.0.2/go.mod h1:lEwq+EiDmUgJ5V4UIDLppWx3sYc/5o1GW32MXb8Ko+k=
 github.com/juju/errors v0.0.0-20150916125642-1b5e39b83d18/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
 github.com/juju/errors v0.0.0-20200330140219-3fe23663418f/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
 github.com/juju/errors v0.0.0-20210818161939-5560c4c073ff/go.mod h1:i1eL7XREII6aHpQ2gApI/v6FkVUDEBremNkcBCKYAcY=

--- a/state/migration_export_test.go
+++ b/state/migration_export_test.go
@@ -664,6 +664,7 @@ func (s *MigrationExportSuite) assertMigrateApplications(c *gc.C, isSidecar bool
 	c.Check(exportedPeers, jc.DeepEquals, expectedPeers)
 
 	// Check that we're exporting the manifest.
+
 	exportedCharmManifest := exported.CharmManifest()
 	c.Assert(exportedCharmManifest, gc.NotNil)
 
@@ -684,6 +685,69 @@ func (s *MigrationExportSuite) assertMigrateApplications(c *gc.C, isSidecar bool
 		))
 	}
 	c.Check(exportedManifestBases, jc.DeepEquals, expectedManifestBases)
+
+	// Check that we're exporting the actions.
+
+	exportedCharmActions := exported.CharmActions()
+	c.Assert(exportedCharmActions, gc.NotNil)
+
+	type actionSpec struct {
+		Description    string
+		Parallel       bool
+		Params         map[string]interface{}
+		ExecutionGroup string
+	}
+
+	expectedActions := make(map[string]actionSpec)
+	for name, action := range ch.Actions().ActionSpecs {
+		expectedActions[name] = actionSpec{
+			Description:    action.Description,
+			Parallel:       action.Parallel,
+			Params:         action.Params,
+			ExecutionGroup: action.ExecutionGroup,
+		}
+	}
+
+	exportedActions := make(map[string]actionSpec)
+	for name, action := range exportedCharmActions.Actions() {
+		exportedActions[name] = actionSpec{
+			Description:    action.Description(),
+			Parallel:       action.Parallel(),
+			Params:         action.Parameters(),
+			ExecutionGroup: action.ExecutionGroup(),
+		}
+	}
+	c.Check(exportedActions, jc.DeepEquals, expectedActions)
+
+	// Check that we're exporting the config.
+
+	exportedCharmConfig := exported.CharmConfigs()
+	c.Assert(exportedCharmConfig, gc.NotNil)
+
+	type configSpec struct {
+		Type        string
+		Description string
+		Default     interface{}
+	}
+
+	expectedConfigs := make(map[string]configSpec)
+	for name, config := range ch.Config().Options {
+		expectedConfigs[name] = configSpec{
+			Type:        config.Type,
+			Description: config.Description,
+			Default:     config.Default,
+		}
+	}
+
+	exportedConfigs := make(map[string]configSpec)
+	for name, config := range exportedCharmConfig.Configs() {
+		exportedConfigs[name] = configSpec{
+			Type:        config.Type(),
+			Description: config.Description(),
+			Default:     config.Default(),
+		}
+	}
+	c.Check(exportedConfigs, jc.DeepEquals, expectedConfigs)
 }
 
 func (s *MigrationExportSuite) TestMalformedApplications(c *gc.C) {

--- a/state/mocks/description_mock.go
+++ b/state/mocks/description_mock.go
@@ -136,6 +136,20 @@ func (mr *MockApplicationMockRecorder) Channel() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Channel", reflect.TypeOf((*MockApplication)(nil).Channel))
 }
 
+// CharmActions mocks base method.
+func (m *MockApplication) CharmActions() description.CharmActions {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CharmActions")
+	ret0, _ := ret[0].(description.CharmActions)
+	return ret0
+}
+
+// CharmActions indicates an expected call of CharmActions.
+func (mr *MockApplicationMockRecorder) CharmActions() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CharmActions", reflect.TypeOf((*MockApplication)(nil).CharmActions))
+}
+
 // CharmConfig mocks base method.
 func (m *MockApplication) CharmConfig() map[string]any {
 	m.ctrl.T.Helper()
@@ -148,6 +162,20 @@ func (m *MockApplication) CharmConfig() map[string]any {
 func (mr *MockApplicationMockRecorder) CharmConfig() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CharmConfig", reflect.TypeOf((*MockApplication)(nil).CharmConfig))
+}
+
+// CharmConfigs mocks base method.
+func (m *MockApplication) CharmConfigs() description.CharmConfigs {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CharmConfigs")
+	ret0, _ := ret[0].(description.CharmConfigs)
+	return ret0
+}
+
+// CharmConfigs indicates an expected call of CharmConfigs.
+func (mr *MockApplicationMockRecorder) CharmConfigs() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CharmConfigs", reflect.TypeOf((*MockApplication)(nil).CharmConfigs))
 }
 
 // CharmManifest mocks base method.
@@ -524,6 +552,30 @@ func (m *MockApplication) SetAnnotations(arg0 map[string]string) {
 func (mr *MockApplicationMockRecorder) SetAnnotations(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetAnnotations", reflect.TypeOf((*MockApplication)(nil).SetAnnotations), arg0)
+}
+
+// SetCharmActions mocks base method.
+func (m *MockApplication) SetCharmActions(arg0 description.CharmActionsArgs) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetCharmActions", arg0)
+}
+
+// SetCharmActions indicates an expected call of SetCharmActions.
+func (mr *MockApplicationMockRecorder) SetCharmActions(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCharmActions", reflect.TypeOf((*MockApplication)(nil).SetCharmActions), arg0)
+}
+
+// SetCharmConfigs mocks base method.
+func (m *MockApplication) SetCharmConfigs(arg0 description.CharmConfigsArgs) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetCharmConfigs", arg0)
+}
+
+// SetCharmConfigs indicates an expected call of SetCharmConfigs.
+func (mr *MockApplicationMockRecorder) SetCharmConfigs(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCharmConfigs", reflect.TypeOf((*MockApplication)(nil).SetCharmConfigs), arg0)
 }
 
 // SetCharmManifest mocks base method.


### PR DESCRIPTION
This follows on from PR[1], which already exported the manifest and metadata for a charm. This continues on with the work and exports the charm actions and config.

Doing this allows us to construct a full charm upon importing a model from another controller. Thus we don't need to update any additional information when importing the charm blob. The data already exists.

Again, 3.6 never cares about importing charm metadata, manifest, actions and config, so this can be elided.

 1. https://github.com/juju/juju/pull/17820

<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://docs.google.com/document/d/1SYUo9G7qZ_jdoVXpUVamS5VCgHmtZ0QA-wZxKoMS-C0 
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps


Checkout this PR.

```sh
$ juju bootstrap lxd src36
$ juju add-model default
$ juju deploy ubuntu
```

Checkout the main branch and apply this patch.

```sh
diff --git a/domain/application/modelmigration/import.go b/domain/application/modelmigration/import.go
index 7ca6313e26..b3eca33212 100644
--- a/domain/application/modelmigration/import.go
+++ b/domain/application/modelmigration/import.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/juju/description/v8"
+	"github.com/juju/loggo"
 
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/modelmigration"
@@ -62,6 +63,8 @@ func (i *importOperation) Setup(scope modelmigration.Scope) error {
 
 func (i *importOperation) Execute(ctx context.Context, model description.Model) error {
 	for _, app := range model.Applications() {
+		loggo.GetLogger("****").Criticalf("importing application %q %q", app.CharmActions(), app.CharmConfigs())
+
 		unitArgs := make([]service.AddUnitParams, 0, len(app.Units()))
 		for _, unit := range app.Units() {
 			name := unit.Name()
```

Bootstrap the patched main

```sh
$ juju bootstrap lxd src40
```

Switch back to src36

```sh
$ juju migrate src36:default src40
```

Ensure the log is filled with the correct Metadata.


## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/

**Jira card:** [JUJU-6411](https://warthogs.atlassian.net/browse/JUJU-6411)



[JUJU-6411]: https://warthogs.atlassian.net/browse/JUJU-6411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ