### PR TITLE
feat(application): Resource DDL schema

### DIFF
--- a/domain/schema/model/sql/0022-resource.sql
+++ b/domain/schema/model/sql/0022-resource.sql
@@ -1,0 +1,135 @@
+CREATE TABLE resource_origin_type (
+    id INT PRIMARY KEY,
+    name TEXT NOT NULL
+);
+
+CREATE UNIQUE INDEX idx_resource_origin_name
+ON resource_origin_type (name);
+
+INSERT INTO resource_origin_type VALUES
+(0, 'uploaded'),
+(1, 'store');
+
+CREATE TABLE resource_state (
+    id INT PRIMARY KEY,
+    name TEXT NOT NULL
+);
+
+CREATE UNIQUE INDEX idx_resource_state
+ON resource_state (name);
+
+-- Resource state values:
+-- Available is the application resource which will be used by any units
+-- at this point in time.
+-- Potential indicates there is a different revision of the resource available
+-- in a repository. Used to let users know a resource can be upgraded.
+INSERT INTO resource_state VALUES
+(0, 'available'),
+(1, 'potential');
+
+CREATE TABLE resource (
+    uuid TEXT NOT NULL PRIMARY KEY,
+    application_uuid TEXT NOT NULL,
+    name TEXT NOT NULL,
+    origin_type_id INT NOT NULL,
+    state_id INT NOT NULL,
+    size INT,
+    hash TEXT,
+    hash_type_id TEXT,
+    created_at TIMESTAMP NOT NULL,
+    CONSTRAINT fk_resource_application_uuid
+    FOREIGN KEY (application_uuid)
+    REFERENCES application (uuid),
+    CONSTRAINT fk_resource_name
+    FOREIGN KEY (name)
+    REFERENCES resource_meta (name),
+    CONSTRAINT fk_resource_origin_type_id
+    FOREIGN KEY (origin_type_id)
+    REFERENCES resource_origin_type (id),
+    CONSTRAINT fk_resource_state_id
+    FOREIGN KEY (state_id)
+    REFERENCES resource_state (id),
+    CONSTRAINT fk_resource_hash_type_id
+    FOREIGN KEY (hash_type_id)
+    REFERENCES object_store_metadata_hash_type (id)
+);
+
+CREATE UNIQUE INDEX idx_resource ON resource (application_uuid, name, state_id);
+
+CREATE TABLE resource_meta (
+    application_uuid TEXT NOT NULL,
+    name TEXT NOT NULL,
+    type_id INT NOT NULL,
+    path TEXT,
+    description TEXT,
+    CONSTRAINT fk_resource_type_id
+    FOREIGN KEY (type_id)
+    REFERENCES charm_resource_kind (id),
+    PRIMARY KEY (application_uuid, name)
+);
+
+CREATE UNIQUE INDEX idx_resource_meta ON resource_meta (application_uuid, name);
+
+CREATE TABLE resource_supplied_by_type (
+    id INT PRIMARY KEY,
+    name TEXT NOT NULL
+);
+
+CREATE UNIQUE INDEX idx_resource_supplied_by_type
+ON resource_supplied_by_type (name);
+
+INSERT INTO resource_supplied_by_type VALUES
+(0, 'user'),
+(1, 'unit'),
+(2, 'application');
+
+CREATE TABLE resource_supplied_by (
+    uuid TEXT NOT NULL PRIMARY KEY,
+    supplied_by_type_id INT NOT NULL,
+    -- Name is the entity who supplied the resource blob:
+    --   The name of the user who uploaded the resource.
+    --   Unit or application name of which triggered the download
+    --     from a repository.
+    name TEXT NOT NULL,
+    CONSTRAINT fk_resource_supplied_by_type
+    FOREIGN KEY (supplied_by_type_id)
+    REFERENCES resource_supplied_by_type (id)
+);
+
+CREATE UNIQUE INDEX idx_resource_supplied_by
+ON resource_supplied_by (name);
+
+CREATE TABLE application_resource (
+    resource_uuid TEXT NOT NULL PRIMARY KEY,
+    supplied_by_uuid TEXT,
+    storage_path TEXT,
+    CONSTRAINT fk_resource_uuid
+    FOREIGN KEY (resource_uuid)
+    REFERENCES resource (uuid),
+    CONSTRAINT fk_resource_supplied_by_uuid
+    FOREIGN KEY (supplied_by_uuid)
+    REFERENCES resource_supplied_by (uuid)
+);
+
+-- Polled resource values from the repository.
+CREATE TABLE repository_resource (
+    resource_uuid TEXT NOT NULL PRIMARY KEY,
+    last_polled TIMESTAMP NOT NULL,
+    CONSTRAINT fk_resource_uuid
+    FOREIGN KEY (resource_uuid)
+    REFERENCES resource (uuid)
+);
+
+CREATE TABLE unit_resource (
+    resource_uuid TEXT NOT NULL,
+    unit_uuid TEXT NOT NULL,
+    -- Download progress between the controller and the unit.
+    download_progress INT,
+    CONSTRAINT fk_resource_uuid
+    FOREIGN KEY (resource_uuid)
+    REFERENCES resource (uuid),
+    CONSTRAINT fk_resource_unit_uuid
+    FOREIGN KEY (unit_uuid)
+    REFERENCES unit (uuid),
+    PRIMARY KEY (resource_uuid, unit_uuid)
+);

--- a/domain/schema/schema_test.go
+++ b/domain/schema/schema_test.go
@@ -357,6 +357,17 @@ func (s *schemaSuite) TestModelTables(c *gc.C) {
 		"hash_kind",
 		"os",
 
+		// Resources
+		"application_resource",
+		"repository_resource",
+		"resource",
+		"resource_meta",
+		"resource_origin_type",
+		"resource_state",
+		"resource_supplied_by",
+		"resource_supplied_by_type",
+		"unit_resource",
+
 		// Space
 		"space",
 		"provider_space",


### PR DESCRIPTION
Adds the charm resource DDL schema to replace the resources mongo collection. The collection actually contained three types of elements with some overlapping data: an application resource (application-name/resource-name), a unit resource (application-name/resource-name#unit) and a charm store resource ((application-name/resource-name#charmstore). No single type utilized all details of the resourceDoc. The DDL splits out the detail. The idea of a pending ID is no longer necessary as we will be able to add the application resource in the same transaction as adding the application or setting a charm.

A resource describes a charm resource that can be used by the deployed application.

A resource_meta is the application id and resource metadata necessary to use a resource. Taken from the charm metadata, however once deployed, the resource is not longer linked directly to a charm and may act independently.

A application_resource is the resource that units of an application should use.

A unit_resource is the resource that the given unit is currently using.

The repository_resource is a resource found by the charm revision updater worker with the intention letting users know that a new resource revision is available if they wish to refresh.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [ ] ~Go unit tests, with comments saying what you're testing~
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Code is not in used yet, all current unit tests should continue to pass.

## Links

**Jira card:** JUJU-6395

