### PR TITLE
chore(secrets): add unit tests and fix state method

### DIFF
--- a/domain/secret/service/access_test.go
+++ b/domain/secret/service/access_test.go
@@ -15,12 +15,11 @@ import (
 )
 
 func (s *serviceSuite) TestCanManageOwnerUnit(c *gc.C) {
-	ctrl := gomock.NewController(c)
+	ctrl := s.setupMocks(c)
 	defer ctrl.Finish()
 
 	uri := coresecrets.NewURI()
 
-	s.state = NewMockState(ctrl)
 	s.state.EXPECT().GetSecretAccess(gomock.Any(), uri, domainsecret.AccessParams{
 		SubjectTypeID: domainsecret.SubjectUnit,
 		SubjectID:     "mariadb/0",
@@ -36,12 +35,11 @@ func (s *serviceSuite) TestCanManageOwnerUnit(c *gc.C) {
 }
 
 func (s *serviceSuite) TestCanManageLeaderUnitAppSecret(c *gc.C) {
-	ctrl := gomock.NewController(c)
+	ctrl := s.setupMocks(c)
 	defer ctrl.Finish()
 
 	uri := coresecrets.NewURI()
 
-	s.state = NewMockState(ctrl)
 	s.state.EXPECT().GetSecretAccess(gomock.Any(), uri, domainsecret.AccessParams{
 		SubjectTypeID: domainsecret.SubjectUnit,
 		SubjectID:     "mariadb/0",
@@ -62,12 +60,11 @@ func (s *serviceSuite) TestCanManageLeaderUnitAppSecret(c *gc.C) {
 }
 
 func (s *serviceSuite) TestCanManageUserSecrets(c *gc.C) {
-	ctrl := gomock.NewController(c)
+	ctrl := s.setupMocks(c)
 	defer ctrl.Finish()
 
 	uri := coresecrets.NewURI()
 
-	s.state = NewMockState(ctrl)
 	s.state.EXPECT().GetSecretAccess(gomock.Any(), uri, domainsecret.AccessParams{
 		SubjectTypeID: domainsecret.SubjectModel,
 		SubjectID:     "model-uuid",
@@ -83,12 +80,11 @@ func (s *serviceSuite) TestCanManageUserSecrets(c *gc.C) {
 }
 
 func (s *serviceSuite) TestCanReadAppSecret(c *gc.C) {
-	ctrl := gomock.NewController(c)
+	ctrl := s.setupMocks(c)
 	defer ctrl.Finish()
 
 	uri := coresecrets.NewURI()
 
-	s.state = NewMockState(ctrl)
 	s.state.EXPECT().GetSecretAccess(gomock.Any(), uri, domainsecret.AccessParams{
 		SubjectTypeID: domainsecret.SubjectUnit,
 		SubjectID:     "mariadb/0",

--- a/domain/secret/service/consume.go
+++ b/domain/secret/service/consume.go
@@ -67,7 +67,6 @@ func (s *SecretService) GetURIByConsumerLabel(ctx context.Context, label string,
 
 // GetConsumedRevision returns the secret revision number for the specified consumer, possibly updating
 // the label associated with the secret for the consumer.
-// TODO(secrets) - test
 func (s *SecretService) GetConsumedRevision(ctx context.Context, uri *secrets.URI, unitName string, refresh, peek bool, labelToUpdate *string) (int, error) {
 	consumerInfo, latestRevision, err := s.GetSecretConsumerAndLatest(ctx, uri, unitName)
 	if err != nil && !errors.Is(err, secreterrors.SecretConsumerNotFound) {

--- a/domain/secret/service/state_mock_test.go
+++ b/domain/secret/service/state_mock_test.go
@@ -515,6 +515,45 @@ func (c *MockStateGetConsumedSecretURIsWithChangesCall) DoAndReturn(f func(conte
 	return c
 }
 
+// GetLatestRevision mocks base method.
+func (m *MockState) GetLatestRevision(arg0 context.Context, arg1 *secrets.URI) (int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetLatestRevision", arg0, arg1)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetLatestRevision indicates an expected call of GetLatestRevision.
+func (mr *MockStateMockRecorder) GetLatestRevision(arg0, arg1 any) *MockStateGetLatestRevisionCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLatestRevision", reflect.TypeOf((*MockState)(nil).GetLatestRevision), arg0, arg1)
+	return &MockStateGetLatestRevisionCall{Call: call}
+}
+
+// MockStateGetLatestRevisionCall wrap *gomock.Call
+type MockStateGetLatestRevisionCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateGetLatestRevisionCall) Return(arg0 int, arg1 error) *MockStateGetLatestRevisionCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateGetLatestRevisionCall) Do(f func(context.Context, *secrets.URI) (int, error)) *MockStateGetLatestRevisionCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateGetLatestRevisionCall) DoAndReturn(f func(context.Context, *secrets.URI) (int, error)) *MockStateGetLatestRevisionCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetModelUUID mocks base method.
 func (m *MockState) GetModelUUID(arg0 context.Context) (string, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Clean up some secret TODOs.

The main change was to add missing service unit tests, including some small cleanup to avoid patching a global func for tests.
Some test bugs were found and fixed - not all tests properly set up the mock state. So a setupMocks method is added.

Also add a state GetLatestRevision method so that GetSecret doesn't have to be called where it's not needed.

## QA steps

`./main.sh secrets_iaas`

## Links

**Jira card:** [JUJU-6112](https://warthogs.atlassian.net/browse/JUJU-6112)



[JUJU-6112]: https://warthogs.atlassian.net/browse/JUJU-6112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ