### PR TITLE
fix: unset the bootstrap additional args after bootstrap

### DIFF
--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -327,6 +327,9 @@ post_bootstrap() {
 	controller=${1}
 	model=${2}
 
+	# Unset the bootstrap args to reset them for subsequent tests.
+	unset BOOTSTRAP_ADDITIONAL_ARGS
+
 	# Setup up log tailing on the controller.
 	# shellcheck disable=SC2069
 	juju debug-log -m "${controller}:controller" --replay --tail 2>&1 >"${TEST_DIR}/${controller}-controller-debug.log" &

--- a/tests/suites/controllercharm/prometheus.sh
+++ b/tests/suites/controllercharm/prometheus.sh
@@ -95,7 +95,6 @@ run_prometheus_cross_controller() {
 	K8S_CLOUD=${K8S_CLOUD:-microk8s}
 	PROMETHEUS_MODEL_NAME="test-prometheus-cmr-prom"
 	file="${TEST_DIR}/${PROMETHEUS_MODEL_NAME}.log"
-	export BOOTSTRAP_ADDITIONAL_ARGS='' # TODO: remove
 	BOOTSTRAP_PROVIDER='k8s' BOOTSTRAP_CLOUD="${K8S_CLOUD}" bootstrap "${PROMETHEUS_MODEL_NAME}" "${file}"
 
 	juju offer -c "${CONTROLLER_NAME}" controller.controller:metrics-endpoint


### PR DESCRIPTION
The bootstrap additional args were getting double written in suties tests that bootstrapped a new controller for each test. By unsetting them at post bootstrap we ensure that they are not double written.


<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing

## QA steps
Run integration tests
<!-- Describe steps to verify that the change works. -->
