### PR TITLE
chore(dependency): fix http-server-args dependency

### DIFF
--- a/cmd/jujud-controller/agent/machine/manifolds.go
+++ b/cmd/jujud-controller/agent/machine/manifolds.go
@@ -614,7 +614,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			Kind:            coretrace.KindController,
 		}),
 
-		httpServerArgsName: ifDatabaseUpgradeComplete(httpserverargs.Manifold(httpserverargs.ManifoldConfig{
+		httpServerArgsName: ifBootstrapComplete(httpserverargs.Manifold(httpserverargs.ManifoldConfig{
 			ClockName:             clockName,
 			StateName:             stateName,
 			ServiceFactoryName:    serviceFactoryName,
@@ -647,7 +647,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			NewWorker:          logsink.NewWorker,
 		})),
 
-		apiServerName: ifBootstrapComplete(apiserver.Manifold(apiserver.ManifoldConfig{
+		apiServerName: apiserver.Manifold(apiserver.ManifoldConfig{
 			AgentName:                 agentName,
 			AuthenticatorName:         httpServerArgsName,
 			ClockName:                 clockName,
@@ -677,7 +677,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			GetModelService:                   apiserver.GetModelService,
 			NewWorker:                         apiserver.NewWorker,
 			NewMetricsCollector:               apiserver.NewMetricsCollector,
-		})),
+		}),
 
 		charmhubHTTPClientName: dependency.Manifold{
 			Start: func(_ context.Context, _ dependency.Getter) (worker.Worker, error) {

--- a/cmd/jujud-controller/agent/machine/manifolds_test.go
+++ b/cmd/jujud-controller/agent/machine/manifolds_test.go
@@ -352,7 +352,6 @@ func (*ManifoldsSuite) TestSingularGuardsUsed(c *gc.C) {
 		"audit-config-updater",
 		"bootstrap",
 		"control-socket",
-		"http-server-args",
 		"log-sink",
 		"object-store",
 		"object-store-s3-caller",
@@ -361,7 +360,7 @@ func (*ManifoldsSuite) TestSingularGuardsUsed(c *gc.C) {
 
 	// bootstrapWorkers are workers that are run directly run after bootstrap.
 	bootstrapWorkers := set.NewStrings(
-		"api-server",
+		"http-server-args",
 	)
 
 	for name, manifold := range manifolds {
@@ -782,9 +781,11 @@ var expectedMachineManifoldsWithDependenciesIAAS = map[string][]string{
 		"controller-agent-config",
 		"db-accessor",
 		"file-notify-watcher",
-		"provider-tracker",
+		"is-bootstrap-flag",
+		"is-bootstrap-gate",
 		"is-controller-flag",
 		"provider-service-factory",
+		"provider-tracker",
 		"query-logger",
 		"service-factory",
 		"state",
@@ -1524,9 +1525,11 @@ var expectedMachineManifoldsWithDependenciesCAAS = map[string][]string{
 		"controller-agent-config",
 		"db-accessor",
 		"file-notify-watcher",
-		"provider-tracker",
+		"is-bootstrap-flag",
+		"is-bootstrap-gate",
 		"is-controller-flag",
 		"provider-service-factory",
+		"provider-tracker",
 		"query-logger",
 		"service-factory",
 		"state",


### PR DESCRIPTION
We incorrectly did not gate http-server-args on bootstrap. This lead to the worker bouncing when querying DQLite for bakery config keys, which had not yet been initialised.

Ensure http-server-args is gated on bootstrap completion.

## QA steps

Bootstrap juju and verify in debug-logs that `http-server-args` starts successfully

```
$ juju bootstrap lxd lxd
$ juju debug-log -m controller --replay | grep http-server-args
machine-0: 12:31:06 DEBUG juju.worker.dependency "http-server-args" manifold worker started at 2024-08-02 11:31:06.277636961 +0000 UTC
$
```

Repeat 3 times