### PR TITLE
feat: pass model uuid through the context

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -1139,6 +1139,8 @@ func (srv *Server) serveConn(
 		resolvedModelID = srv.shared.controllerModelID
 	}
 
+	ctx = model.WithContextModelUUID(ctx, resolvedModelID)
+
 	tracer, err := srv.shared.tracerGetter.GetTracer(
 		ctx,
 		coretrace.Namespace("apiserver", resolvedModelID.String()),

--- a/core/model/context.go
+++ b/core/model/context.go
@@ -1,0 +1,25 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package model
+
+import "context"
+
+type contextKey string
+
+const (
+	// ContextKeyModelUUID is the key used to store the model UUID in the
+	// context.
+	ContextKeyModelUUID contextKey = "model-uuid"
+)
+
+// WitContextModelUUID returns a new context with the model UUID set.
+func WithContextModelUUID(ctx context.Context, modelUUID UUID) context.Context {
+	return context.WithValue(ctx, ContextKeyModelUUID, modelUUID)
+}
+
+// ModelUUIDFromContext returns the model UUID from the context.
+func ModelUUIDFromContext(ctx context.Context) (UUID, bool) {
+	modelUUID, ok := ctx.Value(ContextKeyModelUUID).(UUID)
+	return modelUUID, ok
+}

--- a/core/model/context_test.go
+++ b/core/model/context_test.go
@@ -1,0 +1,21 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package model
+
+import (
+	"context"
+
+	gc "gopkg.in/check.v1"
+)
+
+type contextSuite struct{}
+
+var _ = gc.Suite(&contextSuite{})
+
+func (s *contextSuite) TestContextModelUUIDIsPassed(c *gc.C) {
+	ctx := WithContextModelUUID(context.Background(), UUID("model-uuid"))
+	modelUUID, ok := ModelUUIDFromContext(ctx)
+	c.Assert(ok, gc.Equals, true)
+	c.Check(modelUUID, gc.Equals, UUID("model-uuid"))
+}


### PR DESCRIPTION
To start the work on supporting model level logging filtering we need the model uuid to passed via the context for every request.

Do this should allow every request against a facade method call to be assigned the right model uuid. The next change would be to ensure that the logging package consumed a context and added the model uuid to the associated log request. The work already exists in the loggo package, it's just a case of wiring it up.

<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://docs.google.com/document/d/1SYUo9G7qZ_jdoVXpUVamS5VCgHmtZ0QA-wZxKoMS-C0 
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

<!-- Describe steps to verify that the change works. -->
```
$ juju bootstrap lxd test
$ juju add-model default
$ juju deploy ubuntu
```


