### PR TITLE
refactor(apiserver): wire provider factory through apiserver

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -49,6 +49,7 @@ import (
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/core/presence"
+	"github.com/juju/juju/core/providertracker"
 	"github.com/juju/juju/core/resources"
 	coretrace "github.com/juju/juju/core/trace"
 	internallogger "github.com/juju/juju/internal/logger"
@@ -236,6 +237,10 @@ type ServerConfig struct {
 	// ObjectStoreGetter returns an object store for the given namespace.
 	// This is used for retrieving blobs for charms and agents.
 	ObjectStoreGetter objectstore.ObjectStoreGetter
+
+	// ProviderFactory returns a provider for a given model. This should be
+	// used sparingly in facade code.
+	ProviderFactory providertracker.ProviderFactory
 }
 
 // Validate validates the API server configuration.
@@ -299,6 +304,9 @@ func (c ServerConfig) Validate() error {
 	if c.ObjectStoreGetter == nil {
 		return errors.NotValidf("missing ObjectStoreGetter")
 	}
+	if c.ProviderFactory == nil {
+		return errors.NotValidf("missing ProviderFactory")
+	}
 	if c.SSHImporterHTTPClient == nil {
 		return errors.NotValidf("missing SSHImporterHTTPClient")
 	}
@@ -361,6 +369,7 @@ func newServer(ctx context.Context, cfg ServerConfig) (_ *Server, err error) {
 		dbGetter:              cfg.DBGetter,
 		dbDeleter:             cfg.DBDeleter,
 		serviceFactoryGetter:  cfg.ServiceFactoryGetter,
+		providerFactory:       cfg.ProviderFactory,
 		tracerGetter:          cfg.TracerGetter,
 		objectStoreGetter:     cfg.ObjectStoreGetter,
 		machineTag:            cfg.Tag,
@@ -1162,6 +1171,7 @@ func (srv *Server) serveConn(
 	}
 
 	serviceFactory := srv.shared.serviceFactoryGetter.FactoryForModel(resolvedModelID)
+	modelProviderFactory := facade.NewModelProviderFactory(resolvedModelID, srv.shared.providerFactory)
 
 	var handler *apiHandler
 	st, err := srv.shared.statePool.Get(resolvedModelID.String())
@@ -1174,6 +1184,7 @@ func (srv *Server) serveConn(
 			conn,
 			serviceFactory,
 			srv.shared.serviceFactoryGetter,
+			modelProviderFactory,
 			tracer,
 			objectStore,
 			srv.shared.objectStoreGetter,

--- a/apiserver/export_test.go
+++ b/apiserver/export_test.go
@@ -86,6 +86,10 @@ func (testingAPIRootHandler) Authorizer() facade.Authorizer {
 	return nil
 }
 
+func (testingAPIRootHandler) ProviderFactory() facade.ModelProviderFactory {
+	return nil
+}
+
 // Deprecated: Resources are deprecated. Use WatcherRegistry instead.
 func (testingAPIRootHandler) Resources() *common.Resources {
 	return common.NewResources()
@@ -141,7 +145,22 @@ func TestingAPIHandler(c *gc.C, pool *state.StatePool, st *state.State, sf servi
 		},
 		tag: names.NewMachineTag("0"),
 	}
-	h, err := newAPIHandler(context.Background(), srv, st, nil, sf, nil, coretrace.NoopTracer{}, nil, nil, nil, model.UUID(st.ModelUUID()), 6543, "testing.invalid:1234")
+	h, err := newAPIHandler(
+		context.Background(),
+		srv,
+		st,
+		nil,
+		sf,
+		nil,
+		nil,
+		coretrace.NoopTracer{},
+		nil,
+		nil,
+		nil,
+		model.UUID(st.ModelUUID()),
+		6543,
+		"testing.invalid:1234",
+	)
 	c.Assert(err, jc.ErrorIsNil)
 
 	return h, h.Resources()

--- a/apiserver/facade/facadetest/context.go
+++ b/apiserver/facade/facadetest/context.go
@@ -4,6 +4,7 @@
 package facadetest
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/juju/errors"
@@ -14,6 +15,7 @@ import (
 	"github.com/juju/juju/core/lease"
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/objectstore"
+	"github.com/juju/juju/core/providertracker"
 	"github.com/juju/juju/internal/servicefactory"
 	"github.com/juju/juju/state"
 )
@@ -41,6 +43,7 @@ type ModelContext struct {
 	SSHImporterHTTPClient_ facade.HTTPClient
 	ServiceFactory_        servicefactory.ServiceFactory
 	ServiceFactoryGetter_  servicefactory.ServiceFactoryGetter
+	Provider_              providertracker.Provider
 	ModelExporter_         facade.ModelExporter
 	ModelImporter_         facade.ModelImporter
 	ObjectStore_           objectstore.ObjectStore
@@ -196,6 +199,11 @@ func (c ModelContext) HTTPClient(purpose facade.HTTPClientPurpose) (facade.HTTPC
 // ServiceFactory implements facade.ModelContext.
 func (c ModelContext) ServiceFactory() servicefactory.ServiceFactory {
 	return c.ServiceFactory_
+}
+
+// GetProvider implements facade.ModelContext.
+func (c ModelContext) GetProvider(context.Context) (providertracker.Provider, error) {
+	return c.Provider_, nil
 }
 
 // ModelExporter returns a model exporter for the current model.

--- a/apiserver/facade/interface.go
+++ b/apiserver/facade/interface.go
@@ -5,11 +5,13 @@ package facade
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/url"
 	"time"
 
 	"github.com/juju/description/v8"
+	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 
 	"github.com/juju/juju/core/leadership"
@@ -19,6 +21,7 @@ import (
 	"github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/core/presence"
+	"github.com/juju/juju/core/providertracker"
 	"github.com/juju/juju/internal/servicefactory"
 	"github.com/juju/juju/state"
 )
@@ -85,6 +88,15 @@ type ModelContext interface {
 	ServiceFactory
 	ObjectStoreFactory
 	Logger
+
+	// ModelProviderFactory returns a provider for the current model. This
+	// should be used very sparingly in facades. The recommended usage is to
+	// define a provider interface with the methods you need, and pass the
+	// context into the top-level ProviderRunner function to get a provider of
+	// the correct type:
+	//
+	//     providerGetter := facade.ProviderRunner[myProviderType](ctx)
+	ModelProviderFactory
 
 	// Auth represents information about the connected client. You
 	// should always be checking individual requests against Auth:
@@ -319,3 +331,42 @@ const (
 	// established for use in the keymanager facade.
 	HTTPClientPurposeUserSSHImport HTTPClientPurpose = "ssh-key-import"
 )
+
+// ModelProviderFactory returns the provider for the current model.
+type ModelProviderFactory interface {
+	GetProvider(context.Context) (providertracker.Provider, error)
+}
+
+// ModelProviderFactoryFunc is a simple implementation of ModelProviderFactory.
+type ModelProviderFactoryFunc func(context.Context) (providertracker.Provider, error)
+
+// GetProvider implements ModelProviderFactory.
+func (f ModelProviderFactoryFunc) GetProvider(ctx context.Context) (providertracker.Provider, error) {
+	return f(ctx)
+}
+
+// NewModelProviderFactory returns a new ModelProviderFactory given a
+// providertracker.ProviderFactory and a given model ID.
+func NewModelProviderFactory(
+	modelID model.UUID,
+	providerFactory providertracker.ProviderFactory,
+) ModelProviderFactoryFunc {
+	return func(ctx context.Context) (providertracker.Provider, error) {
+		return providerFactory.ProviderForModel(ctx, modelID.String())
+	}
+}
+
+// ProviderRunner allows getting a provider satisfying a given interface.
+func ProviderRunner[T any](providerFactory ModelProviderFactory) func(context.Context) (T, error) {
+	var zero T
+	return func(ctx context.Context) (T, error) {
+		p, err := providerFactory.GetProvider(ctx)
+		if err != nil {
+			return zero, fmt.Errorf("getting provider for model: %w", err)
+		}
+		if v, ok := p.(T); ok {
+			return v, nil
+		}
+		return zero, errors.NotSupportedf("provider type %T", zero)
+	}
+}

--- a/apiserver/facades/agent/keyupdater/facade_mock_test.go
+++ b/apiserver/facades/agent/keyupdater/facade_mock_test.go
@@ -10,6 +10,7 @@
 package keyupdater
 
 import (
+	context "context"
 	reflect "reflect"
 
 	facade "github.com/juju/juju/apiserver/facade"
@@ -17,6 +18,7 @@ import (
 	lease "github.com/juju/juju/core/lease"
 	logger "github.com/juju/juju/core/logger"
 	objectstore "github.com/juju/juju/core/objectstore"
+	providertracker "github.com/juju/juju/core/providertracker"
 	servicefactory "github.com/juju/juju/internal/servicefactory"
 	state "github.com/juju/juju/state"
 	names "github.com/juju/names/v5"
@@ -230,6 +232,45 @@ func (c *MockModelContextDisposeCall) Do(f func()) *MockModelContextDisposeCall 
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockModelContextDisposeCall) DoAndReturn(f func()) *MockModelContextDisposeCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetProvider mocks base method.
+func (m *MockModelContext) GetProvider(arg0 context.Context) (providertracker.Provider, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetProvider", arg0)
+	ret0, _ := ret[0].(providertracker.Provider)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetProvider indicates an expected call of GetProvider.
+func (mr *MockModelContextMockRecorder) GetProvider(arg0 any) *MockModelContextGetProviderCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProvider", reflect.TypeOf((*MockModelContext)(nil).GetProvider), arg0)
+	return &MockModelContextGetProviderCall{Call: call}
+}
+
+// MockModelContextGetProviderCall wrap *gomock.Call
+type MockModelContextGetProviderCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockModelContextGetProviderCall) Return(arg0 providertracker.Provider, arg1 error) *MockModelContextGetProviderCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockModelContextGetProviderCall) Do(f func(context.Context) (providertracker.Provider, error)) *MockModelContextGetProviderCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockModelContextGetProviderCall) DoAndReturn(f func(context.Context) (providertracker.Provider, error)) *MockModelContextGetProviderCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/shared.go
+++ b/apiserver/shared.go
@@ -20,6 +20,7 @@ import (
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/core/presence"
+	"github.com/juju/juju/core/providertracker"
 	"github.com/juju/juju/internal/pubsub/controller"
 	"github.com/juju/juju/internal/servicefactory"
 	"github.com/juju/juju/internal/worker/trace"
@@ -64,6 +65,10 @@ type sharedServerContext struct {
 	// ServiceFactoryGetter is used to get the service factory for controllers
 	// and models.
 	serviceFactoryGetter servicefactory.ServiceFactoryGetter
+
+	// providerFactory returns a provider for a given model. This should be
+	// used sparingly in facade code.
+	providerFactory providertracker.ProviderFactory
 
 	// TraceGetter is used to get the tracer for the API server.
 	tracerGetter trace.TracerGetter
@@ -112,6 +117,10 @@ type sharedServerConfig struct {
 	machineTag           names.Tag
 	dataDir              string
 	logDir               string
+
+	// providerFactory returns a provider for a given model. This should be
+	// used sparingly in facades.
+	providerFactory providertracker.ProviderFactory
 }
 
 func (c *sharedServerConfig) validate() error {
@@ -141,6 +150,9 @@ func (c *sharedServerConfig) validate() error {
 	}
 	if c.serviceFactoryGetter == nil {
 		return errors.NotValidf("nil serviceFactoryGetter")
+	}
+	if c.providerFactory == nil {
+		return errors.NotValidf("nil providerFactory")
 	}
 	if c.tracerGetter == nil {
 		return errors.NotValidf("nil tracerGetter")
@@ -175,6 +187,7 @@ func newSharedServerContext(config sharedServerConfig) (*sharedServerContext, er
 		dbGetter:              config.dbGetter,
 		dbDeleter:             config.dbDeleter,
 		serviceFactoryGetter:  config.serviceFactoryGetter,
+		providerFactory:       config.providerFactory,
 		tracerGetter:          config.tracerGetter,
 		objectStoreGetter:     config.objectStoreGetter,
 		machineTag:            config.machineTag,

--- a/apiserver/shared_test.go
+++ b/apiserver/shared_test.go
@@ -4,6 +4,7 @@
 package apiserver
 
 import (
+	"context"
 	"net/http"
 	"time"
 
@@ -17,6 +18,7 @@ import (
 	corecontroller "github.com/juju/juju/controller"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/presence"
+	"github.com/juju/juju/core/providertracker"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 	"github.com/juju/juju/internal/pubsub/controller"
 	"github.com/juju/juju/internal/testing"
@@ -50,6 +52,7 @@ func (s *sharedServerContextSuite) SetUpTest(c *gc.C) {
 		dbGetter:              StubDBGetter{},
 		dbDeleter:             StubDBDeleter{},
 		serviceFactoryGetter:  &StubServiceFactoryGetter{},
+		providerFactory:       &fakeProviderFactory{},
 		tracerGetter:          &StubTracerGetter{},
 		objectStoreGetter:     &StubObjectStoreGetter{},
 		machineTag:            names.NewMachineTag("0"),
@@ -154,4 +157,10 @@ func (s *sharedServerContextSuite) TestControllerConfigChanged(c *gc.C) {
 	c.Check(ctx.featureEnabled("bar"), jc.IsTrue)
 	c.Check(ctx.featureEnabled("baz"), jc.IsFalse)
 	c.Check(stub.published, gc.HasLen, 0)
+}
+
+type fakeProviderFactory struct{}
+
+func (*fakeProviderFactory) ProviderForModel(context.Context, string) (providertracker.Provider, error) {
+	return nil, nil
 }

--- a/cmd/jujud-controller/agent/machine/manifolds.go
+++ b/cmd/jujud-controller/agent/machine/manifolds.go
@@ -661,6 +661,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			SSHImporterHTTPClientName: sshImporterHTTPClientName,
 			TraceName:                 traceName,
 			ObjectStoreName:           objectStoreName,
+			ProviderFactoryName:       providerTrackerName,
 
 			// Note that although there is a transient dependency on dbaccessor
 			// via changestream, the direct dependency supplies the capability

--- a/internal/worker/apiserver/manifold.go
+++ b/internal/worker/apiserver/manifold.go
@@ -5,6 +5,7 @@ package apiserver
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -29,6 +30,7 @@ import (
 	corelogger "github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/core/presence"
+	"github.com/juju/juju/core/providertracker"
 	"github.com/juju/juju/internal/servicefactory"
 	"github.com/juju/juju/internal/worker/common"
 	"github.com/juju/juju/internal/worker/gate"
@@ -83,6 +85,11 @@ type ManifoldConfig struct {
 	ServiceFactoryName        string
 	TraceName                 string
 	ObjectStoreName           string
+
+	// ProviderFactoryName is the name of the manifold dependency for the
+	// provider tracker, which returns a provider for a given model. This
+	// should be used sparingly in API facades.
+	ProviderFactoryName string
 
 	PrometheusRegisterer              prometheus.Registerer
 	RegisterIntrospectionHTTPHandlers func(func(path string, _ http.Handler))
@@ -151,6 +158,9 @@ func (config ManifoldConfig) Validate() error {
 	if config.ObjectStoreName == "" {
 		return errors.NotValidf("empty ObjectStoreName")
 	}
+	if config.ProviderFactoryName == "" {
+		return errors.NotValidf("empty ProviderFactoryName")
+	}
 	if config.Hub == nil {
 		return errors.NotValidf("nil Hub")
 	}
@@ -193,6 +203,7 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 			config.ServiceFactoryName,
 			config.TraceName,
 			config.ObjectStoreName,
+			config.ProviderFactoryName,
 			config.LogSinkName,
 		},
 		Start: config.start,
@@ -285,6 +296,11 @@ func (config ManifoldConfig) start(ctx context.Context, getter dependency.Getter
 		return nil, errors.Trace(err)
 	}
 
+	var providerFactory providertracker.ProviderFactory
+	if err := getter.Get(config.ProviderFactoryName, &providerFactory); err != nil {
+		return nil, fmt.Errorf("getting provider factory: %w", err)
+	}
+
 	controllerConfigService, err := config.GetControllerConfigService(getter, config.ServiceFactoryName)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -336,6 +352,7 @@ func (config ManifoldConfig) start(ctx context.Context, getter dependency.Getter
 		ServiceFactoryGetter:              serviceFactoryGetter,
 		TracerGetter:                      tracerGetter,
 		ObjectStoreGetter:                 objectStoreGetter,
+		ProviderFactory:                   providerFactory,
 		ControllerConfigService:           controllerConfigService,
 		ModelService:                      modelService,
 	})

--- a/internal/worker/apiserver/worker.go
+++ b/internal/worker/apiserver/worker.go
@@ -26,6 +26,7 @@ import (
 	corelogger "github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/core/presence"
+	"github.com/juju/juju/core/providertracker"
 	"github.com/juju/juju/internal/servicefactory"
 	"github.com/juju/juju/internal/worker/trace"
 	"github.com/juju/juju/state"
@@ -62,6 +63,9 @@ type Config struct {
 	ObjectStoreGetter       objectstore.ObjectStoreGetter
 	ControllerConfigService ControllerConfigService
 	ModelService            ModelService
+
+	// ProviderFactory returns a provider for a given model.
+	ProviderFactory providertracker.ProviderFactory
 }
 
 type HTTPClient interface {
@@ -133,6 +137,9 @@ func (config Config) Validate() error {
 	}
 	if config.ObjectStoreGetter == nil {
 		return errors.NotValidf("nil ObjectStoreGetter")
+	}
+	if config.ProviderFactory == nil {
+		return errors.NotValidf("nil ProviderFactory")
 	}
 	if config.ControllerConfigService == nil {
 		return errors.NotValidf("nil ControllerConfigService")
@@ -209,6 +216,7 @@ func NewWorker(ctx context.Context, config Config) (worker.Worker, error) {
 		ServiceFactoryGetter:          config.ServiceFactoryGetter,
 		TracerGetter:                  config.TracerGetter,
 		ObjectStoreGetter:             config.ObjectStoreGetter,
+		ProviderFactory:               config.ProviderFactory,
 		SSHImporterHTTPClient:         config.SSHImporterHTTPClient,
 	}
 	return config.NewServer(ctx, serverConfig)

--- a/internal/worker/apiserver/worker_state_test.go
+++ b/internal/worker/apiserver/worker_state_test.go
@@ -147,6 +147,7 @@ func (s *WorkerStateSuite) TestStart(c *gc.C) {
 		ServiceFactoryGetter:       s.serviceFactoryGetter,
 		TracerGetter:               s.tracerGetter,
 		ObjectStoreGetter:          s.objectStoreGetter,
+		ProviderFactory:            s.providerFactory,
 		ControllerUUID:             s.controllerUUID,
 		ControllerModelID:          s.controllerModelID,
 	})

--- a/internal/worker/apiserver/worker_test.go
+++ b/internal/worker/apiserver/worker_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/juju/juju/core/model"
 	modeltesting "github.com/juju/juju/core/model/testing"
 	"github.com/juju/juju/core/presence"
+	"github.com/juju/juju/core/providertracker"
 	"github.com/juju/juju/internal/servicefactory"
 	coretesting "github.com/juju/juju/internal/testing"
 	"github.com/juju/juju/internal/worker/apiserver"
@@ -52,6 +53,7 @@ type workerFixture struct {
 	controllerConfigService *MockControllerConfigService
 	modelService            *MockModelService
 	serviceFactoryGetter    servicefactory.ServiceFactoryGetter
+	providerFactory         *fakeProviderFactory
 	controllerUUID          string
 	controllerModelID       model.UUID
 }
@@ -75,6 +77,7 @@ func (s *workerFixture) SetUpTest(c *gc.C) {
 	s.charmhubHTTPClient = &http.Client{}
 	s.sshimporterHTTPClient = &http.Client{}
 	s.serviceFactoryGetter = &stubServiceFactoryGetter{}
+	s.providerFactory = &fakeProviderFactory{}
 	s.controllerUUID = coretesting.ControllerTag.Id()
 	s.controllerModelID = modeltesting.GenModelUUID(c)
 	s.stub.ResetCalls()
@@ -102,6 +105,7 @@ func (s *workerFixture) SetUpTest(c *gc.C) {
 		ServiceFactoryGetter:              s.serviceFactoryGetter,
 		TracerGetter:                      s.tracerGetter,
 		ObjectStoreGetter:                 s.objectStoreGetter,
+		ProviderFactory:                   s.providerFactory,
 	}
 }
 
@@ -175,6 +179,9 @@ func (s *WorkerValidationSuite) TestValidateErrors(c *gc.C) {
 		func(cfg *apiserver.Config) { cfg.ObjectStoreGetter = nil },
 		"nil ObjectStoreGetter not valid",
 	}, {
+		func(cfg *apiserver.Config) { cfg.ProviderFactory = nil },
+		"nil ProviderFactory not valid",
+	}, {
 		func(cfg *apiserver.Config) { cfg.ControllerConfigService = nil },
 		"nil ControllerConfigService not valid",
 	}, {
@@ -208,4 +215,10 @@ func (s *WorkerValidationSuite) testValidateLogSinkConfig(c *gc.C, key, value, e
 	s.agentConfig.values = map[string]string{key: value}
 	_, err := apiserver.NewWorker(context.Background(), s.config)
 	c.Check(err, gc.ErrorMatches, "getting log sink config: "+expect)
+}
+
+type fakeProviderFactory struct{}
+
+func (*fakeProviderFactory) ProviderForModel(ctx context.Context, namespace string) (providertracker.Provider, error) {
+	return nil, nil
 }

--- a/juju/testing/apiserver.go
+++ b/juju/testing/apiserver.go
@@ -45,6 +45,7 @@ import (
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/core/presence"
+	"github.com/juju/juju/core/providertracker"
 	"github.com/juju/juju/core/trace"
 	coreuser "github.com/juju/juju/core/user"
 	cloudstate "github.com/juju/juju/domain/cloud/state"
@@ -351,6 +352,8 @@ func (s *ApiServerSuite) setupApiServer(c *gc.C, controllerCfg controller.Config
 		serviceFactoryGetter: cfg.ServiceFactoryGetter,
 	}
 	s.ObjectStoreGetter = cfg.ObjectStoreGetter
+
+	cfg.ProviderFactory = &fakeProviderFactory{}
 
 	// Set up auth handler.
 	factory := s.ControllerServiceFactory(c)
@@ -793,4 +796,10 @@ func (f *fakePresence) AgentStatus(agent string) (presence.Status, error) {
 		return status, nil
 	}
 	return presence.Alive, nil
+}
+
+type fakeProviderFactory struct{}
+
+func (*fakeProviderFactory) ProviderForModel(ctx context.Context, namespace string) (providertracker.Provider, error) {
+	return nil, nil
 }


### PR DESCRIPTION
This PR adds a provider factory dependency to the apiserver. This will allow us to remove usages of `EnvironConfigGetter` in the facades and replace them with a provider factory. Eventually, most of the facade logic that needs providers should be pushed into the service layer. It is possible that some facades may still need to use providers/environs though.

See #17881 and #17882 for examples of how this will affect logic in the spaces and client facades.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

<!-- Describe steps to verify that the change works. -->

Run unit tests. Check that Juju can bootstrap.

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Jira card:** JUJU-6332