### PR TITLE
feat(model): move model summaries to model domain

### DIFF
--- a/apiserver/common/modeluser.go
+++ b/apiserver/common/modeluser.go
@@ -40,7 +40,7 @@ func ModelUserInfo(ctx context.Context, service accessService, apiUser names.Use
 			lmi := mi.LastModelLogin
 			lastModelLogin = &lmi
 		}
-		accessType, err := StateToParamsUserAccessPermission(mi.Access)
+		accessType, err := EncodeAccess(mi.Access)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -54,8 +54,8 @@ func ModelUserInfo(ctx context.Context, service accessService, apiUser names.Use
 	return modelUserInfo, nil
 }
 
-// StateToParamsUserAccessPermission converts permission.Access to params.AccessPermission.
-func StateToParamsUserAccessPermission(descriptionAccess permission.Access) (params.UserAccessPermission, error) {
+// EncodeAccess converts permission.Access to params.AccessPermission.
+func EncodeAccess(descriptionAccess permission.Access) (params.UserAccessPermission, error) {
 	switch descriptionAccess {
 	case permission.ReadAccess:
 		return params.ModelReadAccess, nil

--- a/apiserver/facades/client/modelmanager/mocks/service_mock.go
+++ b/apiserver/facades/client/modelmanager/mocks/service_mock.go
@@ -449,6 +449,45 @@ func (c *MockModelServiceDeleteModelCall) DoAndReturn(f func(context.Context, mo
 	return c
 }
 
+// ListAllModelSummaries mocks base method.
+func (m *MockModelService) ListAllModelSummaries(arg0 context.Context) ([]model.ModelSummary, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListAllModelSummaries", arg0)
+	ret0, _ := ret[0].([]model.ModelSummary)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListAllModelSummaries indicates an expected call of ListAllModelSummaries.
+func (mr *MockModelServiceMockRecorder) ListAllModelSummaries(arg0 any) *MockModelServiceListAllModelSummariesCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAllModelSummaries", reflect.TypeOf((*MockModelService)(nil).ListAllModelSummaries), arg0)
+	return &MockModelServiceListAllModelSummariesCall{Call: call}
+}
+
+// MockModelServiceListAllModelSummariesCall wrap *gomock.Call
+type MockModelServiceListAllModelSummariesCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockModelServiceListAllModelSummariesCall) Return(arg0 []model.ModelSummary, arg1 error) *MockModelServiceListAllModelSummariesCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockModelServiceListAllModelSummariesCall) Do(f func(context.Context) ([]model.ModelSummary, error)) *MockModelServiceListAllModelSummariesCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockModelServiceListAllModelSummariesCall) DoAndReturn(f func(context.Context) ([]model.ModelSummary, error)) *MockModelServiceListAllModelSummariesCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // ListAllModels mocks base method.
 func (m *MockModelService) ListAllModels(arg0 context.Context) ([]model.Model, error) {
 	m.ctrl.T.Helper()
@@ -484,6 +523,45 @@ func (c *MockModelServiceListAllModelsCall) Do(f func(context.Context) ([]model.
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockModelServiceListAllModelsCall) DoAndReturn(f func(context.Context) ([]model.Model, error)) *MockModelServiceListAllModelsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// ListModelSummariesForUser mocks base method.
+func (m *MockModelService) ListModelSummariesForUser(arg0 context.Context, arg1 string) ([]model.UserModelSummary, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListModelSummariesForUser", arg0, arg1)
+	ret0, _ := ret[0].([]model.UserModelSummary)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListModelSummariesForUser indicates an expected call of ListModelSummariesForUser.
+func (mr *MockModelServiceMockRecorder) ListModelSummariesForUser(arg0, arg1 any) *MockModelServiceListModelSummariesForUserCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListModelSummariesForUser", reflect.TypeOf((*MockModelService)(nil).ListModelSummariesForUser), arg0, arg1)
+	return &MockModelServiceListModelSummariesForUserCall{Call: call}
+}
+
+// MockModelServiceListModelSummariesForUserCall wrap *gomock.Call
+type MockModelServiceListModelSummariesForUserCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockModelServiceListModelSummariesForUserCall) Return(arg0 []model.UserModelSummary, arg1 error) *MockModelServiceListModelSummariesForUserCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockModelServiceListModelSummariesForUserCall) Do(f func(context.Context, string) ([]model.UserModelSummary, error)) *MockModelServiceListModelSummariesForUserCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockModelServiceListModelSummariesForUserCall) DoAndReturn(f func(context.Context, string) ([]model.UserModelSummary, error)) *MockModelServiceListModelSummariesForUserCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/client/modelmanager/services.go
+++ b/apiserver/facades/client/modelmanager/services.go
@@ -67,6 +67,14 @@ type ModelService interface {
 
 	// ListAllModels returns a list of all models.
 	ListAllModels(context.Context) ([]coremodel.Model, error)
+
+	// ListModelSummariesForUser returns a slice of model summaries for a given
+	// user. If no models are found an empty slice is returned.
+	ListModelSummariesForUser(ctx context.Context, userName string) ([]coremodel.UserModelSummary, error)
+
+	// ListAllModelSummaries returns a slice of model summaries for all models
+	// known to the controller.
+	ListAllModelSummaries(ctx context.Context) ([]coremodel.ModelSummary, error)
 }
 
 // ModelDefaultsService defines a interface for interacting with the model

--- a/core/credential/credential.go
+++ b/core/credential/credential.go
@@ -21,7 +21,7 @@ type Key struct {
 	// Owner is the owner of the credential. Key is valid when this value is set.
 	Owner string
 
-	// Name is the name of the credential. Is is valid when this value is set.
+	// Name is the name of the credential. It is valid when this value is set.
 	Name string
 }
 

--- a/core/model/modelsummary.go
+++ b/core/model/modelsummary.go
@@ -1,0 +1,89 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package model
+
+import (
+	"time"
+
+	"github.com/juju/version/v2"
+
+	"github.com/juju/juju/core/credential"
+	"github.com/juju/juju/core/life"
+	"github.com/juju/juju/core/permission"
+	"github.com/juju/juju/core/status"
+)
+
+// UserModelSummary holds information about a model and a users access on it.
+type UserModelSummary struct {
+	// UserAccess is model access level for the  current user.
+	UserAccess permission.Access
+
+	// UserLastConnection contains the time when current user logged in
+	// into the model last.
+	UserLastConnection *time.Time
+
+	// ModelSummary embeds the remaining model summary fields.
+	ModelSummary
+}
+
+// ModelSummary holds summary about a Juju model.
+type ModelSummary struct {
+	// Name is the model name.
+	Name string
+
+	// UUID is the model unique identifier.
+	UUID UUID
+
+	// ModelType is the model type (e.g. IAAS or CAAS).
+	ModelType ModelType
+
+	// CloudName is the name of the model cloud.
+	CloudName string
+
+	// CloudType is the models cloud type.
+	CloudType string
+
+	// CloudRegion is the region of the model cloud.
+	CloudRegion string
+
+	// CloudCredentialName is the name of the cloud credential.
+	CloudCredentialKey credential.Key
+
+	// ControllerUUID is the unique identifier of the controller.
+	ControllerUUID string
+
+	// IsController indicates if the model is a controller.
+	IsController bool
+
+	// OwnerName is the tag of the user that owns the model.
+	OwnerName string
+
+	// Life is the current lifecycle state of the model.
+	Life life.Value
+
+	// AgentVersion is the agent version for this model.
+	AgentVersion version.Number
+
+	// Status is the current status of the model.
+	Status status.StatusInfo
+
+	// MachineCount is the number of machines this model contains.
+	MachineCount int64
+	// CoreCount is the number of CPU cores used by this model.
+	CoreCount int64
+	// UnitCount is the number of application units in this model.
+	UnitCount int64
+
+	// Migration contains information about the latest failed or
+	// currently-running migration. It'll be nil if there isn't one.
+	Migration *ModelMigrationStatus
+}
+
+// ModelMigrationStatus holds information about the progress of a (possibly
+// failed) migration.
+type ModelMigrationStatus struct {
+	Status string     `json:"status"`
+	Start  *time.Time `json:"start"`
+	End    *time.Time `json:"end,omitempty"`
+}


### PR DESCRIPTION
Model summaries return information about all the models a user or controller has access to. This was done in state, now it is done in domain.

Not all the information contained in the model summaries is currently in domain, todos are put in to represent this work. Jira tasks have also been added to the models epic.

<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://docs.google.com/document/d/1SYUo9G7qZ_jdoVXpUVamS5VCgHmtZ0QA-wZxKoMS-C0 
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
~- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps
```
$ juju bootstrap lxd test-modelsummaries
$ juju add-model default
$ juju add-model other
$ juju models
Controller: test-modelsummaries

Model       Cloud/Region  Type  Status  Access  Last connection
controller  lxd/default   lxd   -       admin   just now
default*    lxd/default   lxd   -       admin   never connected
other       lxd/default   lxd   -       admin   never connected

$ juju models --format=json | jq
{
  "models": [
    {
      "name": "admin/controller",
      "short-name": "controller",
      "model-uuid": "5aea63f3-db13-4c0f-8585-80374c13c271",
      "model-type": "iaas",
      "controller-uuid": "fd310e03-d5c8-4155-8c47-f52e98dd272f",
      "controller-name": "test-modelsummaries",
      "is-controller": true,
      "owner": "admin",
      "cloud": "lxd",
      "region": "default",
      "credential": {
        "name": "lxd",
        "owner": "admin",
        "cloud": "lxd"
      },
      "type": "lxd",
      "life": "alive",
      "status": {},
      "access": "admin",
      "last-connection": "just now",
      "agent-version": "4.0-beta4.1"
    },
    {
      "name": "admin/default",
      "short-name": "default",
      "model-uuid": "e61792c1-1cd6-4eaf-8978-aea8ab564ec5",
      "model-type": "iaas",
      "controller-uuid": "fd310e03-d5c8-4155-8c47-f52e98dd272f",
      "controller-name": "test-modelsummaries",
      "is-controller": false,
      "owner": "admin",
      "cloud": "lxd",
      "region": "default",
      "credential": {
        "name": "lxd",
        "owner": "admin",
        "cloud": "lxd"
      },
      "type": "lxd",
      "life": "alive",
      "status": {},
      "access": "admin",
      "last-connection": "never connected",
      "agent-version": "4.0-beta4.1"
    },
    {
      "name": "admin/other",
      "short-name": "other",
      "model-uuid": "e2de2e00-52f0-4fb7-8bbc-755389542f4b",
      "model-type": "iaas",
      "controller-uuid": "fd310e03-d5c8-4155-8c47-f52e98dd272f",
      "controller-name": "test-modelsummaries",
      "is-controller": false,
      "owner": "admin",
      "cloud": "lxd",
      "region": "default",
      "credential": {
        "name": "lxd",
        "owner": "admin",
        "cloud": "lxd"
      },
      "type": "lxd",
      "life": "alive",
      "status": {},
      "access": "admin",
      "last-connection": "never connected",
      "agent-version": "4.0-beta4.1"
    }
  ],
  "current-model": "default"
}
```
Test with a different user (`fred`). Give him write on the model, but also superuser on the controller. He should only the model he can write when he does `juju models` but should be able to see all with `juju models --all`.

Notice that when he does `--all` access is blank, this is because when you do ask for all models we do not include the users info.
```
$ juju add-user fred
$ juju grant fred write default 
$ juju change-user-password fred
$ juju change-user-password admin
$ juju logout 
$ juju login fred
$ juju models
Controller: test-modelsummaries

Model           Cloud/Region  Type  Status  Access  Last connection
admin/default*  lxd/default   lxd   -       write   never connected
$ juju models --format=json | jq
{
  "models": [
    {
      "name": "admin/default",
      "short-name": "default",
      "model-uuid": "e61792c1-1cd6-4eaf-8978-aea8ab564ec5",
      "model-type": "iaas",
      "controller-uuid": "fd310e03-d5c8-4155-8c47-f52e98dd272f",
      "controller-name": "test-modelsummaries",
      "is-controller": false,
      "owner": "admin",
      "cloud": "lxd",
      "region": "default",
      "credential": {
        "name": "lxd",
        "owner": "admin",
        "cloud": "lxd"
      },
      "type": "lxd",
      "life": "alive",
      "status": {},
      "access": "write",
      "last-connection": "never connected",
      "agent-version": "4.0-beta4.1"
    }
  ],
  "current-model": "admin/default"
}

$ juju models --all
Controller: test-modelsummaries

Model             Cloud/Region  Type  Status  Access  Last connection
admin/controller  lxd/default   lxd   -       -       never connected
admin/default*    lxd/default   lxd   -       -       never connected
admin/other       lxd/default   lxd   -       -       never connected
$ juju models --all --format=json | jq
{
  "models": [
    {
      "name": "admin/controller",
      "short-name": "controller",
      "model-uuid": "5aea63f3-db13-4c0f-8585-80374c13c271",
      "model-type": "iaas",
      "controller-uuid": "fd310e03-d5c8-4155-8c47-f52e98dd272f",
      "controller-name": "test-modelsummaries",
      "is-controller": true,
      "owner": "admin",
      "cloud": "lxd",
      "region": "default",
      "credential": {
        "name": "lxd",
        "owner": "admin",
        "cloud": "lxd"
      },
      "type": "lxd",
      "life": "alive",
      "status": {},
      "access": "",
      "last-connection": "never connected",
      "agent-version": "4.0-beta4.1"
    },
    {
      "name": "admin/default",
      "short-name": "default",
      "model-uuid": "e61792c1-1cd6-4eaf-8978-aea8ab564ec5",
      "model-type": "iaas",
      "controller-uuid": "fd310e03-d5c8-4155-8c47-f52e98dd272f",
      "controller-name": "test-modelsummaries",
      "is-controller": false,
      "owner": "admin",
      "cloud": "lxd",
      "region": "default",
      "credential": {
        "name": "lxd",
        "owner": "admin",
        "cloud": "lxd"
      },
      "type": "lxd",
      "life": "alive",
      "status": {},
      "access": "",
      "last-connection": "never connected",
      "agent-version": "4.0-beta4.1"
    },
    {
      "name": "admin/other",
      "short-name": "other",
      "model-uuid": "e2de2e00-52f0-4fb7-8bbc-755389542f4b",
      "model-type": "iaas",
      "controller-uuid": "fd310e03-d5c8-4155-8c47-f52e98dd272f",
      "controller-name": "test-modelsummaries",
      "is-controller": false,
      "owner": "admin",
      "cloud": "lxd",
      "region": "default",
      "credential": {
        "name": "lxd",
        "owner": "admin",
        "cloud": "lxd"
      },
      "type": "lxd",
      "life": "alive",
      "status": {},
      "access": "",
      "last-connection": "never connected",
      "agent-version": "4.0-beta4.1"
    }
  ],
  "current-model": "admin/default"
}
```
Test migration
```
$ juju bootstrap lxd test36
$ juju add-model moveme1
$ juju deploy juju-qa-test
$ juju switch modelsummaries
$ juju migrate test36:moveme1 modelsummaries
Migration started with ID "2dd867df-37c4-460a-8774-2984e978b93c:0"
$ juju models
Controller: test-modelsummaries

Model           Cloud/Region  Type  Status  Access  Last connection
controller*     lxd/default   lxd   -       admin   just now
default         lxd/default   lxd   -       admin   16 minutes ago
other           lxd/default   lxd   -       admin   never connected
migration-test  lxd/default   lxd   -       admin   14 minutes ago
$ juju switch moveme1
$ juju debug-log
$ juju add-unit juju-qa-test
$ juju debug-log -m modelsummaries:controller
$ juju debug-log -m modelsummaries:moveme1
$ juju bootstrap lxd dst40
$ juju switch modelsummaries
$ juju add-model moveme2
$ juju deploy juju-qa-test
$ juju migrate modelsummaries:moveme2 dst40
$ juju switch dst40
$ juju add-unit juju-qa-test
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme2
$ juju models
Controller: dst40

Model       Cloud/Region  Type  Status  Access  Last connection
controller  lxd/default   lxd   -       admin   just now
moveme2*    lxd/default   lxd   -       admin   2 minutes ago

```

-->
```
The controller version number doesn't seem to be upgrading to 4.0-beta4.2, not sure why that is.
<!-- Describe steps to verify that the change works. -->



## Links

**Jira card:** [JUJU-6446](https://warthogs.atlassian.net/browse/JUJU-6446)


[JUJU-6446]: https://warthogs.atlassian.net/browse/JUJU-6446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ