### PR TITLE
fix: ignore not implemented error

### DIFF
--- a/worker/upgradeseries/worker.go
+++ b/worker/upgradeseries/worker.go
@@ -126,8 +126,14 @@ func NewWorker(config Config) (worker.Worker, error) {
 }
 
 func (w *upgradeSeriesWorker) loop() error {
+	// From 4.0 onwards, the upgrade-series worker is not supported, the
+	// upgrade-series facade has been removed from the API server. Thus we
+	// need to trap the error and return out. Nothing in the worker will work
+	// as expected.
 	uw, err := w.WatchUpgradeSeriesNotifications()
-	if err != nil {
+	if errors.Is(err, errors.NotImplemented) {
+		return nil
+	} else if err != nil {
 		return errors.Trace(err)
 	}
 	err = w.catacomb.Add(uw)


### PR DESCRIPTION
Upgrade series is no longer supported in the 4.0, so it will return a not implemented error. As the worker is no longer required in the 4.0 land, we can return cleanly and the worker will be removed. This is safe to do, as the migration checks that the upgrade is not in progress.

We'll have to be careful what is removed from 4.0 once 3.6 is removed as we won't have the privilege of providing constant hot fixes.

<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://docs.google.com/document/d/1SYUo9G7qZ_jdoVXpUVamS5VCgHmtZ0QA-wZxKoMS-C0 
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

<!-- Describe steps to verify that the change works. -->
Bootstrap 4.0 as the destination controller.

```sh
$ juju bootstrap lxd dst40
```

Bootstrap 3.6 as that's the model we want to move.

```sh
$ juju bootstrap lxd src36
$ juju add-model movme
$ juju deploy ubuntu
$ juju migrate src36:moveme dst40
$ juju debug-log -m dst40:movme
```

There should be no errors about the upgrade series worker not being implemented.


## Links

**Jira card:** [JUJU-6411](https://warthogs.atlassian.net/browse/JUJU-6411)


[JUJU-6411]: https://warthogs.atlassian.net/browse/JUJU-6411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ