### PR TITLE
docs: add better migration steps

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -19,7 +19,62 @@ https://docs.google.com/document/d/1SYUo9G7qZ_jdoVXpUVamS5VCgHmtZ0QA-wZxKoMS-C0
 
 ## QA steps
 
-<!-- Describe steps to verify that the change works. -->
+<!-- 
+
+Describe steps to verify that the change works. 
+
+If you're changing any of the facades, you need to ensure that you've tested
+a model migration from 3.6 to 4.0 and from 4.0 to 4.0.
+
+The following steps are a good starting point:
+
+ 1. Bootstrap a 3.6 controller and deploy a charm.
+
+```sh
+$ juju bootstrap lxd src36
+$ juju add-model moveme1
+$ juju deploy juju-qa-test
+```
+
+ 2. Bootstrap a 4.0 controller with the changes and migrate the model.
+
+```sh
+$ juju bootstrap lxd dst40
+$ juju migrate src36:moveme1 dst40
+$ juju add-unit juju-qa-test
+```
+
+ 3. Verify no errors exist in the model logs for the agents. If there are
+    errors, this is a bug and should be fixed before merging. The fix can
+    either be applied to the 4.0 branch (preferable) or the 3.6 branch, though
+    that needs to be discussed with the team.
+
+```sh
+$ juju debug-log -m dst40:controller
+$ juju debug-log -m dst40:moveme1
+```
+
+    4. We also need to test a model migration from 4.0 to 4.0.
+
+```sh
+$ juju bootstrap lxd src40
+$ juju add-model moveme2
+$ juju deploy juju-qa-test
+```
+
+```sh
+$ juju migrate src40:moveme2 dst40
+$ juju add-unit juju-qa-test
+```
+
+    5. Verify that there are no errors in the controller or model logs.
+
+```sh
+$ juju debug-log -m dst40:controller
+$ juju debug-log -m dst40:moveme2
+```
+
+-->
 
 ## Documentation changes
 


### PR DESCRIPTION
To make people aware of potential breakages between 3.6 and 4.0, QA steps have been added as a subtle reminder to test the migration workflow.

This is an interim solution until we improve the github tests to ensure that we don't get any errors that are non-transitive between a model migration.


