### PR TITLE
fix(bootstrap): fix create model version compare

### DIFF
--- a/domain/model/bootstrap/bootstrap.go
+++ b/domain/model/bootstrap/bootstrap.go
@@ -74,7 +74,7 @@ func CreateModel(
 			agentVersion = jujuversion.Current
 		}
 
-		if agentVersion.Compare(jujuversion.Current) != 0 {
+		if agentVersion.Major != jujuversion.Current.Major || agentVersion.Minor != jujuversion.Current.Minor {
 			return fmt.Errorf("%w %q during bootstrap", modelerrors.AgentVersionNotSupported, agentVersion)
 		}
 		args.AgentVersion = agentVersion

--- a/domain/model/bootstrap/bootstrap_test.go
+++ b/domain/model/bootstrap/bootstrap_test.go
@@ -145,3 +145,25 @@ func (s *modelBootstrapSuite) TestCreateReadOnlyModel(c *gc.C) {
 	err = fn(context.Background(), s.ControllerTxnRunner(), s.ModelTxnRunner())
 	c.Assert(err, jc.ErrorIsNil)
 }
+
+func (s *modelBootstrapSuite) TestCreateModelWithDifferingBuildNumber(c *gc.C) {
+	v := jujuversion.Current
+	v.Build++
+
+	args := model.ModelCreationArgs{
+		AgentVersion: v,
+		Cloud:        s.cloudName,
+		Credential: credential.Key{
+			Cloud: s.cloudName,
+			Name:  s.credentialName,
+			Owner: coreuser.AdminUserName,
+		},
+		Name:  "test",
+		Owner: s.adminUserUUID,
+	}
+
+	// Create a model and then create a read-only model from it.
+	fn := CreateModel(modeltesting.GenModelUUID(c), args)
+	err := fn(context.Background(), s.ControllerTxnRunner(), s.ModelTxnRunner())
+	c.Assert(err, jc.ErrorIsNil)
+}


### PR DESCRIPTION
Originally, when bootstrapping we would verify that the agent version matches exactly the controller version.

This check was causing failures in our integration tests, as the build numbers didn't match.
e.g. https://jenkins.juju.canonical.com/job/test-actions-test-actions-params-lxd/508/console

This check is actually way to strict. Really, we only care that the major and the minor versions match. Amend the check.

This fundamentally results from our misuse of semantic versioning. The `juju/version` does not follow the semantic versioning spec for (at least) two reasons:
- We separate build number with a `.`, not a `+`
- We order our versions by build number. Semver does not take build metadata into account

https://semver.org/

## QA steps

```
juju bootstrap lxd lxd
```
```
juju bootstrap lxd lxd --agent-version 4.0-beta3
```
```
juju bootstrap lxd lxd --build-agent
```