### PR TITLE
refactor: remove EnvironConfigGetter from spaces facade

### DIFF
--- a/apiserver/facades/client/spaces/interface.go
+++ b/apiserver/facades/client/spaces/interface.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/network"
-	"github.com/juju/juju/environs"
 	"github.com/juju/juju/state"
 )
 
@@ -58,8 +57,6 @@ type Bindings interface {
 
 // Backing describes the state methods used in this package.
 type Backing interface {
-	environs.EnvironConfigGetter
-
 	// ModelTag returns the tag of this model.
 	ModelTag() names.ModelTag
 

--- a/apiserver/facades/client/spaces/package_mock_test.go
+++ b/apiserver/facades/client/spaces/package_mock_test.go
@@ -17,8 +17,6 @@ import (
 	controller "github.com/juju/juju/controller"
 	constraints "github.com/juju/juju/core/constraints"
 	network "github.com/juju/juju/core/network"
-	cloudspec "github.com/juju/juju/environs/cloudspec"
-	config "github.com/juju/juju/environs/config"
 	state "github.com/juju/juju/state"
 	txn "github.com/juju/mgo/v3/txn"
 	names "github.com/juju/names/v5"
@@ -203,45 +201,6 @@ func (c *MockBackingApplyOperationCall) DoAndReturn(f func(state.ModelOperation)
 	return c
 }
 
-// CloudSpec mocks base method.
-func (m *MockBacking) CloudSpec(arg0 context.Context) (cloudspec.CloudSpec, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CloudSpec", arg0)
-	ret0, _ := ret[0].(cloudspec.CloudSpec)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CloudSpec indicates an expected call of CloudSpec.
-func (mr *MockBackingMockRecorder) CloudSpec(arg0 any) *MockBackingCloudSpecCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloudSpec", reflect.TypeOf((*MockBacking)(nil).CloudSpec), arg0)
-	return &MockBackingCloudSpecCall{Call: call}
-}
-
-// MockBackingCloudSpecCall wrap *gomock.Call
-type MockBackingCloudSpecCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockBackingCloudSpecCall) Return(arg0 cloudspec.CloudSpec, arg1 error) *MockBackingCloudSpecCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockBackingCloudSpecCall) Do(f func(context.Context) (cloudspec.CloudSpec, error)) *MockBackingCloudSpecCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockBackingCloudSpecCall) DoAndReturn(f func(context.Context) (cloudspec.CloudSpec, error)) *MockBackingCloudSpecCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // ConstraintsBySpaceName mocks base method.
 func (m *MockBacking) ConstraintsBySpaceName(arg0 string) ([]Constraints, error) {
 	m.ctrl.T.Helper()
@@ -315,45 +274,6 @@ func (c *MockBackingIsControllerCall) Do(f func() bool) *MockBackingIsController
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockBackingIsControllerCall) DoAndReturn(f func() bool) *MockBackingIsControllerCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// ModelConfig mocks base method.
-func (m *MockBacking) ModelConfig(arg0 context.Context) (*config.Config, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ModelConfig", arg0)
-	ret0, _ := ret[0].(*config.Config)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ModelConfig indicates an expected call of ModelConfig.
-func (mr *MockBackingMockRecorder) ModelConfig(arg0 any) *MockBackingModelConfigCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModelConfig", reflect.TypeOf((*MockBacking)(nil).ModelConfig), arg0)
-	return &MockBackingModelConfigCall{Call: call}
-}
-
-// MockBackingModelConfigCall wrap *gomock.Call
-type MockBackingModelConfigCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockBackingModelConfigCall) Return(arg0 *config.Config, arg1 error) *MockBackingModelConfigCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockBackingModelConfigCall) Do(f func(context.Context) (*config.Config, error)) *MockBackingModelConfigCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockBackingModelConfigCall) DoAndReturn(f func(context.Context) (*config.Config, error)) *MockBackingModelConfigCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/client/spaces/register.go
+++ b/apiserver/facades/client/spaces/register.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/common/credentialcommon"
 	"github.com/juju/juju/apiserver/facade"
+	"github.com/juju/juju/environs"
 )
 
 // Register is called to expose a package of facades onto a given registry.
@@ -37,11 +38,15 @@ func newAPI(ctx facade.ModelContext) (*API, error) {
 	credentialInvalidatorGetter := credentialcommon.CredentialInvalidatorGetter(ctx)
 	check := common.NewBlockChecker(st)
 	auth := ctx.Auth()
+
+	providerGetter := facade.ProviderRunner[environs.NetworkingEnviron](ctx)
+
 	return newAPIWithBacking(apiConfig{
 		NetworkService:              ctx.ServiceFactory().Network(),
 		Backing:                     stateShim,
 		Check:                       check,
 		CredentialInvalidatorGetter: credentialInvalidatorGetter,
+		ProviderGetter:              providerGetter,
 		Resources:                   ctx.Resources(),
 		Authorizer:                  auth,
 		logger:                      ctx.Logger().Child("spaces"),

--- a/apiserver/facades/client/spaces/rename.go
+++ b/apiserver/facades/client/spaces/rename.go
@@ -11,6 +11,7 @@ import (
 
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/core/network"
+	networkerrors "github.com/juju/juju/domain/network/errors"
 	"github.com/juju/juju/rpc/params"
 )
 
@@ -40,7 +41,7 @@ func (api *API) RenameSpace(ctx context.Context, args params.RenameSpacesParams)
 			continue
 		}
 		toSpace, err := api.networkService.SpaceByName(ctx, toTag.Id())
-		if err != nil && !errors.Is(err, errors.NotFound) {
+		if err != nil && !errors.Is(err, networkerrors.SpaceNotFound) {
 			newErr := errors.Annotatef(err, "retrieving space %q", toTag.Id())
 			result.Results[i].Error = apiservererrors.ServerError(errors.Trace(newErr))
 			continue

--- a/apiserver/facades/client/spaces/spaces_internal_test.go
+++ b/apiserver/facades/client/spaces/spaces_internal_test.go
@@ -1,0 +1,102 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package spaces
+
+import (
+	"context"
+
+	"github.com/juju/errors"
+	jc "github.com/juju/testing/checkers"
+	"go.uber.org/mock/gomock"
+	gc "gopkg.in/check.v1"
+
+	apiservertesting "github.com/juju/juju/apiserver/testing"
+	"github.com/juju/juju/environs"
+	environmocks "github.com/juju/juju/environs/testing"
+)
+
+// mockSuite is a test suite that uses mocked services and dependencies for the
+// spaces API. As we move this facade over to dqlite, we should gradually port
+// tests over here.
+type mockSuite struct {
+	environ *environmocks.MockNetworkingEnviron
+}
+
+var _ = gc.Suite(&mockSuite{})
+
+func (s *mockSuite) setupMocks(c *gc.C) *gomock.Controller {
+	ctrl := gomock.NewController(c)
+	s.environ = environmocks.NewMockNetworkingEnviron(ctrl)
+	return ctrl
+}
+
+// TestSupportsSpaces checks that API.checkSupportsSpaces returns nil if spaces
+// are supported by the environ.
+func (s *mockSuite) TestSupportsSpaces(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.environ.EXPECT().SupportsSpaces(gomock.Any()).Return(true, nil)
+
+	api := &API{
+		providerGetter: func(context.Context) (environs.NetworkingEnviron, error) {
+			return s.environ, nil
+		},
+		credentialInvalidatorGetter: apiservertesting.NoopModelCredentialInvalidatorGetter,
+	}
+
+	err := api.checkSupportsSpaces(context.Background())
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+// TestSupportsSpacesFalse checks that API.checkSupportsSpaces returns the
+// correct error if spaces are not supported by the environ.
+func (s *mockSuite) TestSupportsSpacesFalse(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.environ.EXPECT().SupportsSpaces(gomock.Any()).Return(false, nil)
+
+	api := &API{
+		providerGetter: func(context.Context) (environs.NetworkingEnviron, error) {
+			return s.environ, nil
+		},
+		credentialInvalidatorGetter: apiservertesting.NoopModelCredentialInvalidatorGetter,
+	}
+
+	err := api.checkSupportsSpaces(context.Background())
+	c.Assert(err, jc.ErrorIs, errors.NotSupported)
+}
+
+// TestSupportsSpacesError checks that API.checkSupportsSpaces returns the
+// correct error if spaces are not supported by the environ.
+func (s *mockSuite) TestSupportsSpacesError(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.environ.EXPECT().SupportsSpaces(gomock.Any()).Return(false, errors.NotSupportedf("spaces"))
+
+	api := &API{
+		providerGetter: func(context.Context) (environs.NetworkingEnviron, error) {
+			return s.environ, nil
+		},
+		credentialInvalidatorGetter: apiservertesting.NoopModelCredentialInvalidatorGetter,
+	}
+
+	err := api.checkSupportsSpaces(context.Background())
+	c.Assert(err, jc.ErrorIs, errors.NotSupported)
+}
+
+// TestSupportsSpacesError checks that API.checkSupportsSpaces returns the
+// correct error if the environ does not support networking.
+func (s *mockSuite) TestSupportsSpacesNetworkingNotSupported(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	api := &API{
+		providerGetter: func(context.Context) (environs.NetworkingEnviron, error) {
+			return nil, errors.NotSupportedf("networking")
+		},
+		credentialInvalidatorGetter: apiservertesting.NoopModelCredentialInvalidatorGetter,
+	}
+
+	err := api.checkSupportsSpaces(context.Background())
+	c.Assert(err, jc.ErrorIs, errors.NotSupported)
+}

--- a/domain/network/service/interface.go
+++ b/domain/network/service/interface.go
@@ -38,15 +38,23 @@ type State interface {
 type SpaceState interface {
 	// AddSpace creates a space.
 	AddSpace(ctx context.Context, uuid string, name string, providerID network.Id, subnetIDs []string) error
-	// GetSpace returns the space by UUID.
+	// GetSpace returns the space by UUID. If the space is not found, an error
+	// is returned matching
+	// [github.com/juju/juju/domain/network/errors.SpaceNotFound].
 	GetSpace(ctx context.Context, uuid string) (*network.SpaceInfo, error)
-	// GetSpaceByName returns the space by name.
+	// GetSpaceByName returns the space by name. If the space is not found, an
+	// error is returned matching
+	// [github.com/juju/juju/domain/network/errors.SpaceNotFound].
 	GetSpaceByName(ctx context.Context, name string) (*network.SpaceInfo, error)
 	// GetAllSpaces returns all spaces for the model.
 	GetAllSpaces(ctx context.Context) (network.SpaceInfos, error)
-	// UpdateSpace updates the space identified by the passed uuid.
+	// UpdateSpace updates the space identified by the passed uuid. If the
+	// space is not found, an error is returned matching
+	// [github.com/juju/juju/domain/network/errors.SpaceNotFound].
 	UpdateSpace(ctx context.Context, uuid string, name string) error
-	// DeleteSpace deletes the space identified by the passed uuid.
+	// DeleteSpace deletes the space identified by the passed uuid. If the
+	// space is not found, an error is returned matching
+	// [github.com/juju/juju/domain/network/errors.SpaceNotFound].
 	DeleteSpace(ctx context.Context, uuid string) error
 }
 

--- a/domain/network/service/space.go
+++ b/domain/network/service/space.go
@@ -62,14 +62,16 @@ func (s *Service) AddSpace(ctx context.Context, space network.SpaceInfo) (networ
 	return network.Id(spaceID), nil
 }
 
-// UpdateSpace updates the space name identified by the passed uuid.
+// UpdateSpace updates the space name identified by the passed uuid. If the
+// space is not found, an error is returned matching
+// [github.com/juju/juju/domain/network/errors.SpaceNotFound].
 func (s *Service) UpdateSpace(ctx context.Context, uuid string, name string) error {
 	return errors.Trace(s.st.UpdateSpace(ctx, uuid, name))
 }
 
-// Space returns a space from state that matches the input ID.
-// An error is returned if the space does not exist or if there was a problem
-// accessing its information.
+// Space returns a space from state that matches the input ID. If the space is
+// not found, an error is returned matching
+// [github.com/juju/juju/domain/network/errors.SpaceNotFound].
 func (s *Service) Space(ctx context.Context, uuid string) (*network.SpaceInfo, error) {
 	sp, err := s.st.GetSpace(ctx, uuid)
 	if err != nil {
@@ -78,9 +80,9 @@ func (s *Service) Space(ctx context.Context, uuid string) (*network.SpaceInfo, e
 	return sp, nil
 }
 
-// SpaceByName returns a space from state that matches the input name.
-// An error is returned that satisfied errors.NotFound if the space was not found
-// or an error static any problems fetching the given space.
+// SpaceByName returns a space from state that matches the input name. If the
+// space is not found, an error is returned matching
+// [github.com/juju/juju/domain/network/errors.SpaceNotFound].
 func (s *Service) SpaceByName(ctx context.Context, name string) (*network.SpaceInfo, error) {
 	sp, err := s.st.GetSpaceByName(ctx, name)
 	if err != nil {
@@ -98,7 +100,9 @@ func (s *Service) GetAllSpaces(ctx context.Context) (network.SpaceInfos, error) 
 	return spaces, nil
 }
 
-// RemoveSpace deletes a space identified by its uuid.
+// RemoveSpace deletes a space identified by its uuid. If the space is not
+// found, an error is returned matching
+// [github.com/juju/juju/domain/network/errors.SpaceNotFound].
 func (s *Service) RemoveSpace(ctx context.Context, uuid string) error {
 	return errors.Trace(s.st.DeleteSpace(ctx, uuid))
 }

--- a/domain/network/state/space.go
+++ b/domain/network/state/space.go
@@ -91,7 +91,8 @@ VALUES ($ProviderSpace.*)`, providerSpace)
 	return errors.Trace(err)
 }
 
-// GetSpace returns the space by UUID.
+// GetSpace returns the space by UUID. If the space is not found, an error is
+// returned matching [networkerrors.SpaceNotFound].
 func (st *State) GetSpace(
 	ctx context.Context,
 	uuid string,
@@ -127,7 +128,8 @@ WHERE  uuid = $Space.uuid;`, SpaceSubnetRow{}, space)
 	return &spaceRows.ToSpaceInfos()[0], nil
 }
 
-// GetSpaceByName returns the space by name.
+// GetSpaceByName returns the space by name. If the space is not found, an
+// error is returned matching [networkerrors.SpaceNotFound].
 func (st *State) GetSpaceByName(
 	ctx context.Context,
 	name string,
@@ -202,7 +204,8 @@ FROM   v_space_subnet
 	return rows.ToSpaceInfos(), nil
 }
 
-// UpdateSpace updates the space identified by the passed uuid.
+// UpdateSpace updates the space identified by the passed uuid. If the space is
+// not found, an error is returned matching [networkerrors.SpaceNotFound].
 func (st *State) UpdateSpace(
 	ctx context.Context,
 	uuid string,
@@ -242,7 +245,8 @@ WHERE  uuid = $Space.uuid;`, space)
 	return err
 }
 
-// DeleteSpace deletes the space identified by the passed uuid.
+// DeleteSpace deletes the space identified by the passed uuid. If the space is
+// not found, an error is returned matching [networkerrors.SpaceNotFound].
 func (st *State) DeleteSpace(
 	ctx context.Context,
 	uuid string,

--- a/domain/network/state/space_test.go
+++ b/domain/network/state/space_test.go
@@ -235,6 +235,9 @@ func (s *stateSuite) TestRetrieveSpaceByUUID(c *gc.C) {
 	c.Check(sp.Subnets, jc.SameContents, expected)
 }
 
+// TestRetrieveSpaceByUUIDNotFound tests that if we try to call State.GetSpace
+// with a non-existent space, it will return an error matching
+// [networkerrors.SpaceNotFound].
 func (s *stateSuite) TestRetrieveSpaceByUUIDNotFound(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
@@ -264,6 +267,9 @@ func (s *stateSuite) TestRetrieveSpaceByName(c *gc.C) {
 	c.Check(sp1.Name, gc.Equals, network.SpaceName("space1"))
 }
 
+// TestRetrieveSpaceByNameNotFound tests that if we try to call
+// State.GetSpaceByName with a non-existent space, it will return an error
+// matching [networkerrors.SpaceNotFound].
 func (s *stateSuite) TestRetrieveSpaceByNameNotFound(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
@@ -374,6 +380,9 @@ func (s *stateSuite) TestUpdateSpace(c *gc.C) {
 	c.Check(sp.Name, gc.Equals, network.SpaceName("newSpaceName0"))
 }
 
+// TestUpdateSpaceFailNotFound tests that if we try to call State.UpdateSpace
+// with a non-existent space, it will return an error matching
+// [networkerrors.SpaceNotFound].
 func (s *stateSuite) TestUpdateSpaceFailNotFound(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
@@ -429,4 +438,16 @@ func (s *stateSuite) TestDeleteSpace(c *gc.C) {
 	subnet, err = st.GetSubnet(ctx.Background(), subnetUUID0.String())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(subnet.SpaceID, gc.Equals, network.AlphaSpaceId)
+}
+
+// TestDeleteSpaceNotFound tests that if we try to call State.DeleteSpace with
+// a non-existent space, it will return an error matching
+// [networkerrors.SpaceNotFound].
+func (s *stateSuite) TestDeleteSpaceNotFound(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+
+	spUUID, err := uuid.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.DeleteSpace(ctx.Background(), spUUID.String())
+	c.Assert(err, jc.ErrorIs, networkerrors.SpaceNotFound)
 }

--- a/environs/networking.go
+++ b/environs/networking.go
@@ -130,14 +130,9 @@ func supportsNetworking(environ BootstrapEnviron) (NetworkingEnviron, bool) {
 	return ne, ok
 }
 
-// SupportsSpaces checks if the environment implements NetworkingEnviron
-// and also if it supports spaces.
-func SupportsSpaces(ctx envcontext.ProviderCallContext, env BootstrapEnviron) bool {
-	netEnv, ok := supportsNetworking(env)
-	if !ok {
-		return false
-	}
-	ok, err := netEnv.SupportsSpaces(ctx)
+// SupportsSpaces checks if the environment supports spaces.
+func SupportsSpaces(ctx envcontext.ProviderCallContext, env NetworkingEnviron) bool {
+	ok, err := env.SupportsSpaces(ctx)
 	if err != nil {
 		if !errors.Is(err, errors.NotSupported) {
 			logger.Errorf("checking model spaces support failed with: %v", err)


### PR DESCRIPTION
This PR refactors the spaces facade to replace EnvironConfigGetter with the new provider factory provided by the facade model context (see #17859).

Tests are modified accordingly. The `SupportsSpaces` tests have been ported over to a new `mockSuite`, as it was too much effort to fix them.

A subtle bug was found where the `RenameSpace` code was expecting `errors.NotFound` instead of `networkerrors.NotFound`, resulting in the following:
```
$ juju rename-space foo bar
ERROR cannot rename space "foo": retrieving space "bar": space not found with bar: space not found
```
The `RenameSpace` method has been fixed accordingly, and the network service interface clarified to make clear that it returns `networkerrors.NotFound` instead of `errors.NotFound`.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

<!-- Describe steps to verify that the change works. -->

Basic QA of the spaces facade to check that it can correctly determine the supported features of the provider.

For example, on ec2, spaces are supported but space discovery is not, so you should be able to modify spaces.

```console
$ juju bootstrap aws aws
$ juju add-model m

# this should work because spaces are supported
$ juju spaces
Name   Space ID  Subnets       
alpha  0         172.31.0.0/20 
                 172.31.16.0/20
                 172.31.32.0/20
                               
$ juju add-space foo
added space "foo" with no subnets

# this should also work because spaces are mutable on ec2
$ juju rename-space foo bar
renamed space "foo" to "bar"
$ juju remove-space bar
removed space "bar"
```

## Links

**Jira card:** JUJU-6501