### PR TITLE
docs: generate documentation for hook tools

### DIFF
--- a/scripts/md-gen/hook-tools/main.go
+++ b/scripts/md-gen/hook-tools/main.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/juju/charm/v12"
+	"github.com/juju/cmd/v3"
+	"github.com/juju/errors"
+	"github.com/juju/gnuflag"
+
+	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/storage"
+	"github.com/juju/juju/worker/uniter/runner/jujuc"
+)
+
+// This script generates Markdown documentation for the hook tools.
+// We want to use the same `juju documentation` command to generate docs for
+// the hook tools, to ensure the hook tool docs are consistent with the command
+// docs. However, there is no super-command for the hook tools like there is
+// with juju commands. Hence, this script creates such a super-command, and
+// runs the embedded 'documentation' command to generate the docs.
+func main() {
+	baseDocsDir := mustEnv("DOCS_DIR")
+	hookToolDocsDir := filepath.Join(baseDocsDir, "hook-tools")
+
+	jujucSuperCmd := cmd.NewSuperCommand(cmd.SuperCommandParams{})
+	for _, name := range jujuc.CommandNames() {
+		hookTool, err := jujuc.NewCommand(dummyHookContext{}, name)
+		check(err)
+		jujucSuperCmd.Register(hookTool)
+	}
+
+	jujucSuperCmd.SetFlags(&gnuflag.FlagSet{})
+	err := jujucSuperCmd.Init([]string{"documentation", "--split", "--out", hookToolDocsDir})
+	check(err)
+	err = jujucSuperCmd.Run(&cmd.Context{})
+	check(err)
+
+	// Delete the default help.md and documentation.md files that are generated
+	// automatically. They are contrived here and don't have any meaning.
+	err = os.Remove(filepath.Join(hookToolDocsDir, "documentation.md"))
+	check(err)
+	err = os.Remove(filepath.Join(hookToolDocsDir, "help.md"))
+	check(err)
+}
+
+// dummyHookContext implements hooks.Context, as expected by hooks.NewCommand.
+// Copied from cmd/juju/commands/helptool.go
+type dummyHookContext struct{ jujuc.Context }
+
+func (dummyHookContext) AddMetrics(_, _ string, _ time.Time) error {
+	return nil
+}
+func (dummyHookContext) UnitName() string {
+	return ""
+}
+func (dummyHookContext) SetPodSpec(specYaml string) error {
+	return nil
+}
+func (dummyHookContext) GetPodSpec() (string, error) {
+	return "", nil
+}
+func (dummyHookContext) SetRawK8sSpec(specYaml string) error {
+	return nil
+}
+func (dummyHookContext) GetRawK8sSpec() (string, error) {
+	return "", nil
+}
+func (dummyHookContext) PublicAddress() (string, error) {
+	return "", errors.NotFoundf("PublicAddress")
+}
+func (dummyHookContext) PrivateAddress() (string, error) {
+	return "", errors.NotFoundf("PrivateAddress")
+}
+func (dummyHookContext) AvailabilityZone() (string, error) {
+	return "", errors.NotFoundf("AvailabilityZone")
+}
+func (dummyHookContext) OpenPort(protocol string, port int) error {
+	return nil
+}
+func (dummyHookContext) ClosePort(protocol string, port int) error {
+	return nil
+}
+func (dummyHookContext) OpenedPorts() []network.PortRange {
+	return nil
+}
+func (dummyHookContext) ConfigSettings() (charm.Settings, error) {
+	return charm.NewConfig().DefaultSettings(), nil
+}
+func (dummyHookContext) HookRelation() (jujuc.ContextRelation, error) {
+	return nil, errors.NotFoundf("HookRelation")
+}
+func (dummyHookContext) RemoteUnitName() (string, error) {
+	return "", errors.NotFoundf("RemoteUnitName")
+}
+func (dummyHookContext) RemoteApplicationName() (string, error) {
+	return "", errors.NotFoundf("RemoteApplicationName")
+}
+func (dummyHookContext) Relation(id int) (jujuc.ContextRelation, error) {
+	return nil, errors.NotFoundf("Relation")
+}
+func (dummyHookContext) RelationIds() ([]int, error) {
+	return []int{}, errors.NotFoundf("RelationIds")
+}
+func (dummyHookContext) RequestReboot(prio jujuc.RebootPriority) error {
+	return nil
+}
+func (dummyHookContext) HookStorageInstance() (*storage.StorageInstance, error) {
+	return nil, errors.NotFoundf("HookStorageInstance")
+}
+func (dummyHookContext) HookStorage() (jujuc.ContextStorageAttachment, error) {
+	return nil, errors.NotFoundf("HookStorage")
+}
+func (dummyHookContext) StorageInstance(id string) (*storage.StorageInstance, error) {
+	return nil, errors.NotFoundf("StorageInstance")
+}
+func (dummyHookContext) UnitStatus() (*jujuc.StatusInfo, error) {
+	return &jujuc.StatusInfo{}, nil
+}
+func (dummyHookContext) SetStatus(jujuc.StatusInfo) error {
+	return nil
+}
+
+// UTILITY FUNCTIONS
+
+// check panics if the provided error is not nil.
+func check(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+
+// Returns the value of the given environment variable, panicking if the var
+// is not set.
+func mustEnv(key string) string {
+	val, ok := os.LookupEnv(key)
+	if !ok {
+		panic(fmt.Sprintf("env var %q not set", key))
+	}
+	return val
+}


### PR DESCRIPTION
The [hook tool documentation](https://juju.is/docs/juju/hook-tool) is out of date. This was originally copied from the output of `juju help-tool`. Instead, we should autogenerate this documentation like we do for the [Juju CLI reference docs](https://juju.is/docs/juju/juju-cli-commands).

To ensure consistency with the CLI reference docs, we should generate this documentation using the same method (i.e. running the `documentation` subcommand). Unfortunately, there is no super-command for all the hook tools like there is for the Juju commands.

So I've added a script `scripts/md-gen/hook-tools` to generate this documentation. It creates a "fake" super-command and registers all the hook tools as subcommands. It then runs the embedded `documentation` command to generate the hook tool documentation.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

<!-- Describe steps to verify that the change works. -->

Generate the hook tool docs:
```
export DOCS_DIR=./docs
go run ./scripts/md-gen/hook-tools
```
You should see the Markdown docs in the directory `docs/hook-tools`.

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

Hook tool reference documentation will be autogenerated

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Jira card:** JUJU-6241