### PR TITLE
feat(units): make progress on dual wrting units

### DIFF
--- a/apiserver/facades/agent/caasapplication/application.go
+++ b/apiserver/facades/agent/caasapplication/application.go
@@ -178,7 +178,16 @@ func (f *Facade) UnitIntroduction(ctx context.Context, args params.CAASUnitIntro
 	if err != nil {
 		return errResp(err)
 	}
-	if err := f.applicationService.UpsertCAASUnit(ctx, application.Name(), applicationservice.UpsertCAASUnitParams{UnitName: upsert.UnitName}); err != nil {
+	// Dual write CAAS unit to dqlite.
+	if err := f.applicationService.UpsertCAASUnit(ctx, application.Name(), applicationservice.UpsertCAASUnitParams{
+		UnitName:     *upsert.UnitName,
+		ProviderId:   upsert.ProviderId,
+		Address:      upsert.Address,
+		Ports:        upsert.Ports,
+		PasswordHash: upsert.PasswordHash,
+		OrderedScale: upsert.OrderedScale,
+		OrderedId:    upsert.OrderedId,
+	}); err != nil {
 		return errResp(err)
 	}
 

--- a/apiserver/facades/agent/caasapplication/application_test.go
+++ b/apiserver/facades/agent/caasapplication/application_test.go
@@ -55,10 +55,8 @@ func (s *CAASApplicationSuite) SetUpTest(c *gc.C) {
 	// Seed the model with an application, this will be used to allow the
 	// upserting of units.
 	serviceFactory := s.DefaultModelServiceFactory(c)
-	serviceFactory.Application(nil).CreateApplication(context.Background(), "gitlab", service.AddApplicationArgs{
-		Charm:  &stubCharm{},
-		Origin: corecharm.Origin{},
-	})
+	_, err := serviceFactory.Application(nil).CreateApplication(context.Background(), "gitlab", &stubCharm{}, corecharm.Origin{}, service.AddApplicationArgs{})
+	c.Assert(err, jc.ErrorIsNil)
 
 	s.st = newMockState()
 	s.broker = &mockBroker{}

--- a/apiserver/facades/agent/caasapplication/application_test.go
+++ b/apiserver/facades/agent/caasapplication/application_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/juju/apiserver/facades/agent/caasapplication"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/caas"
+	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/domain/application/service"
 	"github.com/juju/juju/domain/servicefactory/testing"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
@@ -54,7 +55,10 @@ func (s *CAASApplicationSuite) SetUpTest(c *gc.C) {
 	// Seed the model with an application, this will be used to allow the
 	// upserting of units.
 	serviceFactory := s.DefaultModelServiceFactory(c)
-	serviceFactory.Application(nil).CreateApplication(context.Background(), "gitlab", &stubCharm{}, service.AddApplicationArgs{})
+	serviceFactory.Application(nil).CreateApplication(context.Background(), "gitlab", service.AddApplicationArgs{
+		Charm:  &stubCharm{},
+		Origin: corecharm.Origin{},
+	})
 
 	s.st = newMockState()
 	s.broker = &mockBroker{}

--- a/apiserver/facades/client/application/application_unit_test.go
+++ b/apiserver/facades/client/application/application_unit_test.go
@@ -1414,9 +1414,9 @@ func createCharmOriginFromURL(url string) *params.CharmOrigin {
 	curl := charm.MustParseURL(url)
 	switch curl.Schema {
 	case "local":
-		return &params.CharmOrigin{Source: "local", Base: params.Base{Name: "ubuntu", Channel: "22.04/stable"}}
+		return &params.CharmOrigin{Source: "local", Base: params.Base{Name: "ubuntu", Channel: "22.04/stable"}, Architecture: "amd64"}
 	default:
-		return &params.CharmOrigin{Source: "charm-hub", Base: params.Base{Name: "ubuntu", Channel: "22.04/stable"}}
+		return &params.CharmOrigin{Source: "charm-hub", Base: params.Base{Name: "ubuntu", Channel: "22.04/stable"}, Architecture: "amd64"}
 	}
 }
 
@@ -1424,9 +1424,9 @@ func createStateCharmOriginFromURL(url string) *state.CharmOrigin {
 	curl := charm.MustParseURL(url)
 	switch curl.Schema {
 	case "local":
-		return &state.CharmOrigin{Source: "local", Platform: &state.Platform{OS: "ubuntu", Channel: "22.04"}}
+		return &state.CharmOrigin{Source: "local", Platform: &state.Platform{OS: "ubuntu", Channel: "22.04", Architecture: "amd64"}}
 	default:
-		return &state.CharmOrigin{Source: "charm-hub", Platform: &state.Platform{OS: "ubuntu", Channel: "22.04"}}
+		return &state.CharmOrigin{Source: "charm-hub", Platform: &state.Platform{OS: "ubuntu", Channel: "22.04", Architecture: "amd64"}}
 	}
 }
 

--- a/apiserver/facades/client/application/deploy.go
+++ b/apiserver/facades/client/application/deploy.go
@@ -156,8 +156,7 @@ func DeployApplication(
 
 	// Dual write storage directives to dqlite.
 	if err == nil {
-		_, err = applicationService.CreateApplication(ctx, args.ApplicationName, applicationservice.AddApplicationArgs{
-			Charm:   args.Charm,
+		_, err = applicationService.CreateApplication(ctx, args.ApplicationName, args.Charm, args.CharmOrigin, applicationservice.AddApplicationArgs{
 			Storage: args.Storage,
 		}, unitArgs...)
 	}

--- a/apiserver/facades/client/application/deploy.go
+++ b/apiserver/facades/client/application/deploy.go
@@ -156,7 +156,8 @@ func DeployApplication(
 
 	// Dual write storage directives to dqlite.
 	if err == nil {
-		_, err = applicationService.CreateApplication(ctx, args.ApplicationName, args.Charm, applicationservice.AddApplicationArgs{
+		_, err = applicationService.CreateApplication(ctx, args.ApplicationName, applicationservice.AddApplicationArgs{
+			Charm:   args.Charm,
 			Storage: args.Storage,
 		}, unitArgs...)
 	}

--- a/apiserver/facades/client/application/deployrepository.go
+++ b/apiserver/facades/client/application/deployrepository.go
@@ -164,9 +164,7 @@ func (api *DeployFromRepositoryAPI) DeployFromRepository(ctx context.Context, ar
 			n := fmt.Sprintf("%s/%d", dt.applicationName, nextUnitNum+i)
 			unitArgs[i].UnitName = &n
 		}
-		_, addApplicationErr = api.applicationService.CreateApplication(ctx, dt.applicationName, applicationservice.AddApplicationArgs{
-			Charm:   ch,
-			Origin:  dt.origin,
+		_, addApplicationErr = api.applicationService.CreateApplication(ctx, dt.applicationName, ch, dt.origin, applicationservice.AddApplicationArgs{
 			Storage: dt.storage,
 		}, unitArgs...)
 	}

--- a/apiserver/facades/client/application/deployrepository.go
+++ b/apiserver/facades/client/application/deployrepository.go
@@ -164,7 +164,9 @@ func (api *DeployFromRepositoryAPI) DeployFromRepository(ctx context.Context, ar
 			n := fmt.Sprintf("%s/%d", dt.applicationName, nextUnitNum+i)
 			unitArgs[i].UnitName = &n
 		}
-		_, addApplicationErr = api.applicationService.CreateApplication(ctx, dt.applicationName, ch, applicationservice.AddApplicationArgs{
+		_, addApplicationErr = api.applicationService.CreateApplication(ctx, dt.applicationName, applicationservice.AddApplicationArgs{
+			Charm:   ch,
+			Origin:  dt.origin,
 			Storage: dt.storage,
 		}, unitArgs...)
 	}

--- a/apiserver/facades/client/application/deployrepository_test.go
+++ b/apiserver/facades/client/application/deployrepository_test.go
@@ -1181,20 +1181,18 @@ func (s *deployRepositorySuite) TestDeployFromRepositoryAPI(c *gc.C) {
 	}
 	s.state.EXPECT().ReadSequence("metadata-name").Return(0, nil)
 	s.state.EXPECT().AddApplication(addApplicationArgsMatcher{c: c, expectedArgs: addAppArgs}, gomock.Any()).Return(s.application, nil)
-	s.applicationService.EXPECT().CreateApplication(gomock.Any(), "metadata-name", applicationservice.AddApplicationArgs{
-		Charm: s.charm,
-		Origin: corecharm.Origin{
-			Source:   "charm-hub",
-			Revision: intptr(5),
-			Channel: &charm.Channel{
-				Risk: "stable",
-			},
-			Platform: corecharm.Platform{
-				Architecture: "amd64",
-				OS:           "ubuntu",
-				Channel:      "22.04",
-			},
+	s.applicationService.EXPECT().CreateApplication(gomock.Any(), "metadata-name", s.charm, corecharm.Origin{
+		Source:   "charm-hub",
+		Revision: intptr(5),
+		Channel: &charm.Channel{
+			Risk: "stable",
 		},
+		Platform: corecharm.Platform{
+			Architecture: "amd64",
+			OS:           "ubuntu",
+			Channel:      "22.04",
+		},
+	}, applicationservice.AddApplicationArgs{
 		Storage: nil,
 	}, applicationservice.AddUnitArg{UnitName: ptr("metadata-name/0")})
 	deployFromRepositoryAPI := s.getDeployFromRepositoryAPI(c)
@@ -1326,20 +1324,18 @@ func (s *deployRepositorySuite) TestAddPendingResourcesForDeployFromRepositoryAP
 	}
 	s.state.EXPECT().ReadSequence("metadata-name").Return(0, nil)
 	s.state.EXPECT().AddApplication(addApplicationArgsMatcher{c: c, expectedArgs: addAppArgs}, gomock.Any()).Return(s.application, nil)
-	s.applicationService.EXPECT().CreateApplication(gomock.Any(), "metadata-name", applicationservice.AddApplicationArgs{
-		Charm: s.charm,
-		Origin: corecharm.Origin{
-			Source:   "charm-hub",
-			Revision: intptr(5),
-			Channel: &charm.Channel{
-				Risk: "stable",
-			},
-			Platform: corecharm.Platform{
-				Architecture: "amd64",
-				OS:           "ubuntu",
-				Channel:      "22.04",
-			},
+	s.applicationService.EXPECT().CreateApplication(gomock.Any(), "metadata-name", s.charm, corecharm.Origin{
+		Source:   "charm-hub",
+		Revision: intptr(5),
+		Channel: &charm.Channel{
+			Risk: "stable",
 		},
+		Platform: corecharm.Platform{
+			Architecture: "amd64",
+			OS:           "ubuntu",
+			Channel:      "22.04",
+		},
+	}, applicationservice.AddApplicationArgs{
 		Storage: nil,
 	}, applicationservice.AddUnitArg{UnitName: ptr("metadata-name/0")})
 

--- a/apiserver/facades/client/application/deployrepository_test.go
+++ b/apiserver/facades/client/application/deployrepository_test.go
@@ -1181,7 +1181,20 @@ func (s *deployRepositorySuite) TestDeployFromRepositoryAPI(c *gc.C) {
 	}
 	s.state.EXPECT().ReadSequence("metadata-name").Return(0, nil)
 	s.state.EXPECT().AddApplication(addApplicationArgsMatcher{c: c, expectedArgs: addAppArgs}, gomock.Any()).Return(s.application, nil)
-	s.applicationService.EXPECT().CreateApplication(gomock.Any(), "metadata-name", s.charm, applicationservice.AddApplicationArgs{
+	s.applicationService.EXPECT().CreateApplication(gomock.Any(), "metadata-name", applicationservice.AddApplicationArgs{
+		Charm: s.charm,
+		Origin: corecharm.Origin{
+			Source:   "charm-hub",
+			Revision: intptr(5),
+			Channel: &charm.Channel{
+				Risk: "stable",
+			},
+			Platform: corecharm.Platform{
+				Architecture: "amd64",
+				OS:           "ubuntu",
+				Channel:      "22.04",
+			},
+		},
 		Storage: nil,
 	}, applicationservice.AddUnitArg{UnitName: ptr("metadata-name/0")})
 	deployFromRepositoryAPI := s.getDeployFromRepositoryAPI(c)
@@ -1313,7 +1326,20 @@ func (s *deployRepositorySuite) TestAddPendingResourcesForDeployFromRepositoryAP
 	}
 	s.state.EXPECT().ReadSequence("metadata-name").Return(0, nil)
 	s.state.EXPECT().AddApplication(addApplicationArgsMatcher{c: c, expectedArgs: addAppArgs}, gomock.Any()).Return(s.application, nil)
-	s.applicationService.EXPECT().CreateApplication(gomock.Any(), "metadata-name", s.charm, applicationservice.AddApplicationArgs{
+	s.applicationService.EXPECT().CreateApplication(gomock.Any(), "metadata-name", applicationservice.AddApplicationArgs{
+		Charm: s.charm,
+		Origin: corecharm.Origin{
+			Source:   "charm-hub",
+			Revision: intptr(5),
+			Channel: &charm.Channel{
+				Risk: "stable",
+			},
+			Platform: corecharm.Platform{
+				Architecture: "amd64",
+				OS:           "ubuntu",
+				Channel:      "22.04",
+			},
+		},
 		Storage: nil,
 	}, applicationservice.AddUnitArg{UnitName: ptr("metadata-name/0")})
 

--- a/apiserver/facades/client/application/get_test.go
+++ b/apiserver/facades/client/application/get_test.go
@@ -150,7 +150,7 @@ func (s *getSuite) TestClientApplicationGetCAASModelSmokeTest(c *gc.C) {
 	ch := f2.MakeCharm(c, &factory.CharmParams{Name: "dashboard4miner", Series: "focal"})
 	app := f2.MakeApplication(c, &factory.ApplicationParams{
 		Name: "dashboard4miner", Charm: ch,
-		CharmOrigin: &state.CharmOrigin{Platform: &state.Platform{OS: "ubuntu", Channel: "22.04/stable"}},
+		CharmOrigin: &state.CharmOrigin{Platform: &state.Platform{OS: "ubuntu", Channel: "22.04/stable", Architecture: "amd64"}},
 	})
 
 	schemaFields, defaults, err := application.ConfigSchema()
@@ -285,7 +285,7 @@ var getTests = []struct {
 	},
 	origin: &state.CharmOrigin{
 		Source:   "charm-hub",
-		Platform: &state.Platform{OS: "ubuntu", Channel: "22.04/stable"},
+		Platform: &state.Platform{OS: "ubuntu", Channel: "22.04/stable", Architecture: "amd64"},
 	},
 	expect: params.ApplicationGetResults{
 		CharmConfig: map[string]interface{}{
@@ -344,7 +344,7 @@ var getTests = []struct {
 	},
 	origin: &state.CharmOrigin{
 		Source:   "charm-hub",
-		Platform: &state.Platform{OS: "ubuntu", Channel: "22.04/stable"},
+		Platform: &state.Platform{OS: "ubuntu", Channel: "22.04/stable", Architecture: "amd64"},
 	},
 	expect: params.ApplicationGetResults{
 		CharmConfig: map[string]interface{}{
@@ -399,7 +399,7 @@ var getTests = []struct {
 	charm: "logging",
 	origin: &state.CharmOrigin{
 		Source:   "charm-hub",
-		Platform: &state.Platform{OS: "ubuntu", Channel: "22.04/stable"},
+		Platform: &state.Platform{OS: "ubuntu", Channel: "22.04/stable", Architecture: "amd64"},
 	},
 	expect: params.ApplicationGetResults{
 		CharmConfig: map[string]interface{}{},
@@ -429,7 +429,7 @@ var getTests = []struct {
 			Risk:   "stable",
 			Branch: "foo",
 		},
-		Platform: &state.Platform{OS: "ubuntu", Channel: "22.04/stable"},
+		Platform: &state.Platform{OS: "ubuntu", Channel: "22.04/stable", Architecture: "amd64"},
 	},
 	expect: params.ApplicationGetResults{
 		CharmConfig: map[string]interface{}{},

--- a/apiserver/facades/client/application/service.go
+++ b/apiserver/facades/client/application/service.go
@@ -9,11 +9,13 @@ import (
 	"github.com/juju/version/v2"
 
 	coreapplication "github.com/juju/juju/core/application"
+	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/machine"
 	"github.com/juju/juju/core/network"
 	applicationservice "github.com/juju/juju/domain/application/service"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/internal/charm"
 	"github.com/juju/juju/internal/storage"
 )
 
@@ -49,7 +51,7 @@ type MachineService interface {
 // ApplicationService instances save an application to dqlite state.
 type ApplicationService interface {
 	// CreateApplication creates the specified application and units if required.
-	CreateApplication(ctx context.Context, name string, params applicationservice.AddApplicationArgs, units ...applicationservice.AddUnitArg) (coreapplication.ID, error)
+	CreateApplication(ctx context.Context, name string, charm charm.Charm, origin corecharm.Origin, params applicationservice.AddApplicationArgs, units ...applicationservice.AddUnitArg) (coreapplication.ID, error)
 	// AddUnits adds units to the application.
 	AddUnits(ctx context.Context, name string, units ...applicationservice.AddUnitArg) error
 	// UpdateApplicationCharm sets a new charm for the application, validating that aspects such

--- a/apiserver/facades/client/application/service.go
+++ b/apiserver/facades/client/application/service.go
@@ -14,7 +14,6 @@ import (
 	"github.com/juju/juju/core/network"
 	applicationservice "github.com/juju/juju/domain/application/service"
 	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/internal/charm"
 	"github.com/juju/juju/internal/storage"
 )
 
@@ -50,7 +49,7 @@ type MachineService interface {
 // ApplicationService instances save an application to dqlite state.
 type ApplicationService interface {
 	// CreateApplication creates the specified application and units if required.
-	CreateApplication(ctx context.Context, name string, charm charm.Charm, params applicationservice.AddApplicationArgs, units ...applicationservice.AddUnitArg) (coreapplication.ID, error)
+	CreateApplication(ctx context.Context, name string, params applicationservice.AddApplicationArgs, units ...applicationservice.AddUnitArg) (coreapplication.ID, error)
 	// AddUnits adds units to the application.
 	AddUnits(ctx context.Context, name string, units ...applicationservice.AddUnitArg) error
 	// UpdateApplicationCharm sets a new charm for the application, validating that aspects such

--- a/apiserver/facades/client/application/service_mock_test.go
+++ b/apiserver/facades/client/application/service_mock_test.go
@@ -19,7 +19,6 @@ import (
 	network "github.com/juju/juju/core/network"
 	service "github.com/juju/juju/domain/application/service"
 	config "github.com/juju/juju/environs/config"
-	charm "github.com/juju/juju/internal/charm"
 	storage "github.com/juju/juju/internal/storage"
 	version "github.com/juju/version/v2"
 	gomock "go.uber.org/mock/gomock"
@@ -154,10 +153,10 @@ func (c *MockApplicationServiceAddUnitsCall) DoAndReturn(f func(context.Context,
 }
 
 // CreateApplication mocks base method.
-func (m *MockApplicationService) CreateApplication(arg0 context.Context, arg1 string, arg2 charm.Charm, arg3 service.AddApplicationArgs, arg4 ...service.AddUnitArg) (application.ID, error) {
+func (m *MockApplicationService) CreateApplication(arg0 context.Context, arg1 string, arg2 service.AddApplicationArgs, arg3 ...service.AddUnitArg) (application.ID, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1, arg2, arg3}
-	for _, a := range arg4 {
+	varargs := []any{arg0, arg1, arg2}
+	for _, a := range arg3 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "CreateApplication", varargs...)
@@ -167,9 +166,9 @@ func (m *MockApplicationService) CreateApplication(arg0 context.Context, arg1 st
 }
 
 // CreateApplication indicates an expected call of CreateApplication.
-func (mr *MockApplicationServiceMockRecorder) CreateApplication(arg0, arg1, arg2, arg3 any, arg4 ...any) *MockApplicationServiceCreateApplicationCall {
+func (mr *MockApplicationServiceMockRecorder) CreateApplication(arg0, arg1, arg2 any, arg3 ...any) *MockApplicationServiceCreateApplicationCall {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1, arg2, arg3}, arg4...)
+	varargs := append([]any{arg0, arg1, arg2}, arg3...)
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateApplication", reflect.TypeOf((*MockApplicationService)(nil).CreateApplication), varargs...)
 	return &MockApplicationServiceCreateApplicationCall{Call: call}
 }
@@ -186,13 +185,13 @@ func (c *MockApplicationServiceCreateApplicationCall) Return(arg0 application.ID
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceCreateApplicationCall) Do(f func(context.Context, string, charm.Charm, service.AddApplicationArgs, ...service.AddUnitArg) (application.ID, error)) *MockApplicationServiceCreateApplicationCall {
+func (c *MockApplicationServiceCreateApplicationCall) Do(f func(context.Context, string, service.AddApplicationArgs, ...service.AddUnitArg) (application.ID, error)) *MockApplicationServiceCreateApplicationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceCreateApplicationCall) DoAndReturn(f func(context.Context, string, charm.Charm, service.AddApplicationArgs, ...service.AddUnitArg) (application.ID, error)) *MockApplicationServiceCreateApplicationCall {
+func (c *MockApplicationServiceCreateApplicationCall) DoAndReturn(f func(context.Context, string, service.AddApplicationArgs, ...service.AddUnitArg) (application.ID, error)) *MockApplicationServiceCreateApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/client/application/service_mock_test.go
+++ b/apiserver/facades/client/application/service_mock_test.go
@@ -14,11 +14,13 @@ import (
 	reflect "reflect"
 
 	application "github.com/juju/juju/core/application"
+	charm "github.com/juju/juju/core/charm"
 	crossmodel "github.com/juju/juju/core/crossmodel"
 	machine "github.com/juju/juju/core/machine"
 	network "github.com/juju/juju/core/network"
 	service "github.com/juju/juju/domain/application/service"
 	config "github.com/juju/juju/environs/config"
+	charm0 "github.com/juju/juju/internal/charm"
 	storage "github.com/juju/juju/internal/storage"
 	version "github.com/juju/version/v2"
 	gomock "go.uber.org/mock/gomock"
@@ -153,10 +155,10 @@ func (c *MockApplicationServiceAddUnitsCall) DoAndReturn(f func(context.Context,
 }
 
 // CreateApplication mocks base method.
-func (m *MockApplicationService) CreateApplication(arg0 context.Context, arg1 string, arg2 service.AddApplicationArgs, arg3 ...service.AddUnitArg) (application.ID, error) {
+func (m *MockApplicationService) CreateApplication(arg0 context.Context, arg1 string, arg2 charm0.Charm, arg3 charm.Origin, arg4 service.AddApplicationArgs, arg5 ...service.AddUnitArg) (application.ID, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1, arg2}
-	for _, a := range arg3 {
+	varargs := []any{arg0, arg1, arg2, arg3, arg4}
+	for _, a := range arg5 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "CreateApplication", varargs...)
@@ -166,9 +168,9 @@ func (m *MockApplicationService) CreateApplication(arg0 context.Context, arg1 st
 }
 
 // CreateApplication indicates an expected call of CreateApplication.
-func (mr *MockApplicationServiceMockRecorder) CreateApplication(arg0, arg1, arg2 any, arg3 ...any) *MockApplicationServiceCreateApplicationCall {
+func (mr *MockApplicationServiceMockRecorder) CreateApplication(arg0, arg1, arg2, arg3, arg4 any, arg5 ...any) *MockApplicationServiceCreateApplicationCall {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1, arg2}, arg3...)
+	varargs := append([]any{arg0, arg1, arg2, arg3, arg4}, arg5...)
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateApplication", reflect.TypeOf((*MockApplicationService)(nil).CreateApplication), varargs...)
 	return &MockApplicationServiceCreateApplicationCall{Call: call}
 }
@@ -185,13 +187,13 @@ func (c *MockApplicationServiceCreateApplicationCall) Return(arg0 application.ID
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceCreateApplicationCall) Do(f func(context.Context, string, service.AddApplicationArgs, ...service.AddUnitArg) (application.ID, error)) *MockApplicationServiceCreateApplicationCall {
+func (c *MockApplicationServiceCreateApplicationCall) Do(f func(context.Context, string, charm0.Charm, charm.Origin, service.AddApplicationArgs, ...service.AddUnitArg) (application.ID, error)) *MockApplicationServiceCreateApplicationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceCreateApplicationCall) DoAndReturn(f func(context.Context, string, service.AddApplicationArgs, ...service.AddUnitArg) (application.ID, error)) *MockApplicationServiceCreateApplicationCall {
+func (c *MockApplicationServiceCreateApplicationCall) DoAndReturn(f func(context.Context, string, charm0.Charm, charm.Origin, service.AddApplicationArgs, ...service.AddUnitArg) (application.ID, error)) *MockApplicationServiceCreateApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/client/charms/client.go
+++ b/apiserver/facades/client/charms/client.go
@@ -417,11 +417,7 @@ func validateOrigin(origin corecharm.Origin, curl *charm.URL, switchCharm bool) 
 			return errors.NotValidf("origin source %q with schema", origin.Source)
 		}
 	}
-
-	if corecharm.CharmHub.Matches(origin.Source.String()) && origin.Platform.Architecture == "" {
-		return errors.NotValidf("empty architecture")
-	}
-	return nil
+	return origin.Validate()
 }
 
 func (a *API) getCharmRepository(ctx context.Context, src corecharm.Source) (corecharm.Repository, error) {

--- a/core/charm/origin.go
+++ b/core/charm/origin.go
@@ -55,6 +55,14 @@ type Origin struct {
 	InstanceKey string
 }
 
+// Validate returns an error if the origin is invalid.
+func (o Origin) Validate() error {
+	if CharmHub.Matches(o.Source.String()) && o.Platform.Architecture == "" {
+		return errors.NotValidf("empty architecture")
+	}
+	return nil
+}
+
 // Platform describes the platform used to install the charm with.
 type Platform struct {
 	Architecture string

--- a/domain/application/errors/errors.go
+++ b/domain/application/errors/errors.go
@@ -31,6 +31,9 @@ const (
 	// CharmNotValid describes an error that occurs when the charm is not valid.
 	CharmNotValid = errors.ConstError("charm not valid")
 
+	// CharmOriginNotValid describes an error that occurs when the charm origin is not valid.
+	CharmOriginNotValid = errors.ConstError("charm origin not valid")
+
 	// CharmNameNotValid describes an error that occurs when attempting to get
 	// a charm using an invalid name.
 	CharmNameNotValid = errors.ConstError("charm name not valid")

--- a/domain/application/modelmigration/import.go
+++ b/domain/application/modelmigration/import.go
@@ -51,7 +51,7 @@ type importOperation struct {
 // from another controller model to this controller.
 type ImportService interface {
 	// CreateApplication registers the existence of an application in the model.
-	CreateApplication(context.Context, string, service.AddApplicationArgs, ...service.AddUnitArg) (coreapplication.ID, error)
+	CreateApplication(context.Context, string, internalcharm.Charm, corecharm.Origin, service.AddApplicationArgs, ...service.AddUnitArg) (coreapplication.ID, error)
 }
 
 // Name returns the name of this operation.
@@ -109,13 +109,10 @@ func (i *importOperation) Execute(ctx context.Context, model description.Model) 
 		}
 
 		_, err = i.service.CreateApplication(
-			ctx, app.Name(), service.AddApplicationArgs{
-				Charm: &stubCharm{
-					name:     url.Name,
-					revision: url.Revision,
-				},
-				Origin: *origin,
-			}, unitArgs...,
+			ctx, app.Name(), &stubCharm{
+				name:     url.Name,
+				revision: url.Revision,
+			}, *origin, service.AddApplicationArgs{}, unitArgs...,
 		)
 		if err != nil {
 			return fmt.Errorf(

--- a/domain/application/modelmigration/import_test.go
+++ b/domain/application/modelmigration/import_test.go
@@ -9,10 +9,14 @@ import (
 	"github.com/juju/description/v8"
 	"github.com/juju/names/v5"
 	jc "github.com/juju/testing/checkers"
-	gomock "go.uber.org/mock/gomock"
+	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
+	corecharm "github.com/juju/juju/core/charm"
+	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/domain/application/service"
+	"github.com/juju/juju/internal/charm"
+	"github.com/juju/juju/internal/logger/testing"
 )
 
 type importSuite struct {
@@ -34,30 +38,84 @@ func (i *importSuite) TestApplicationSave(c *gc.C) {
 		Tag:      names.NewApplicationTag("prometheus"),
 		CharmURL: "ch:prometheus-1",
 	}
-	model.AddApplication(appArgs).AddUnit(description.UnitArgs{
-		Tag: names.NewUnitTag("prometheus/0"),
+	app := model.AddApplication(appArgs)
+	app.AddUnit(description.UnitArgs{
+		Tag:          names.NewUnitTag("prometheus/0"),
+		PasswordHash: "passwordhash",
+		CloudContainer: &description.CloudContainerArgs{
+			ProviderId: "provider-id",
+			Address: description.AddressArgs{
+				Value:   "10.6.6.6",
+				Type:    "ipv4",
+				Scope:   "local-machine",
+				Origin:  "provider",
+				SpaceID: "666",
+			},
+			Ports: []string{"6666"},
+		},
+	})
+	app.SetCharmOrigin(description.CharmOriginArgs{
+		Source:   "charm-hub",
+		ID:       "1234",
+		Hash:     "deadbeef",
+		Revision: 1,
+		Channel:  "666/stable",
+		Platform: "arm64/ubuntu/24.04",
 	})
 
 	defer i.setupMocks(c).Finish()
 
+	rev := 1
 	i.importService.EXPECT().CreateApplication(
 		gomock.Any(),
 		"prometheus",
-		gomock.Any(),
-		gomock.Any(),
+		service.AddApplicationArgs{
+			Charm: &stubCharm{
+				name:     "prometheus",
+				revision: 1,
+			},
+			Origin: corecharm.Origin{
+				Source:   "charm-hub",
+				Type:     "charm",
+				ID:       "1234",
+				Hash:     "deadbeef",
+				Revision: &rev,
+				Channel: &charm.Channel{
+					Track: "666",
+					Risk:  "stable",
+				},
+				Platform: corecharm.Platform{
+					Architecture: "arm64",
+					OS:           "ubuntu",
+					Channel:      "24.04",
+				},
+			},
+		},
 		[]service.AddUnitArg{{
-			UnitName: ptrString("prometheus/0"),
+			UnitName:     ptr("prometheus/0"),
+			PasswordHash: ptr("passwordhash"),
+			CloudContainer: ptr(service.CloudContainerParams{
+				ProviderId: ptr("provider-id"),
+				Address: ptr(network.SpaceAddress{
+					MachineAddress: network.MachineAddress{
+						Value: "10.6.6.6",
+						Type:  "ipv4",
+						Scope: "local-machine",
+					},
+					SpaceID: "666",
+				}),
+				AddressOrigin: ptr(network.OriginProvider),
+				Ports:         ptr([]string{"6666"}),
+			}),
 		}},
 	).Return("", nil)
 
 	importOp := importOperation{
-		service: i.importService,
+		service:      i.importService,
+		logger:       testing.WrapCheckLog(c),
+		charmOrigins: make(map[string]*corecharm.Origin),
 	}
 
 	err := importOp.Execute(context.Background(), model)
 	c.Assert(err, jc.ErrorIsNil)
-}
-
-func ptrString(s string) *string {
-	return &s
 }

--- a/domain/application/modelmigration/import_test.go
+++ b/domain/application/modelmigration/import_test.go
@@ -69,28 +69,27 @@ func (i *importSuite) TestApplicationSave(c *gc.C) {
 	i.importService.EXPECT().CreateApplication(
 		gomock.Any(),
 		"prometheus",
-		service.AddApplicationArgs{
-			Charm: &stubCharm{
-				name:     "prometheus",
-				revision: 1,
+		&stubCharm{
+			name:     "prometheus",
+			revision: 1,
+		},
+		corecharm.Origin{
+			Source:   "charm-hub",
+			Type:     "charm",
+			ID:       "1234",
+			Hash:     "deadbeef",
+			Revision: &rev,
+			Channel: &charm.Channel{
+				Track: "666",
+				Risk:  "stable",
 			},
-			Origin: corecharm.Origin{
-				Source:   "charm-hub",
-				Type:     "charm",
-				ID:       "1234",
-				Hash:     "deadbeef",
-				Revision: &rev,
-				Channel: &charm.Channel{
-					Track: "666",
-					Risk:  "stable",
-				},
-				Platform: corecharm.Platform{
-					Architecture: "arm64",
-					OS:           "ubuntu",
-					Channel:      "24.04",
-				},
+			Platform: corecharm.Platform{
+				Architecture: "arm64",
+				OS:           "ubuntu",
+				Channel:      "24.04",
 			},
 		},
+		service.AddApplicationArgs{},
 		[]service.AddUnitArg{{
 			UnitName:     ptr("prometheus/0"),
 			PasswordHash: ptr("passwordhash"),

--- a/domain/application/modelmigration/migrations_mock_test.go
+++ b/domain/application/modelmigration/migrations_mock_test.go
@@ -15,7 +15,6 @@ import (
 
 	application "github.com/juju/juju/core/application"
 	service "github.com/juju/juju/domain/application/service"
-	charm "github.com/juju/juju/internal/charm"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -43,10 +42,10 @@ func (m *MockImportService) EXPECT() *MockImportServiceMockRecorder {
 }
 
 // CreateApplication mocks base method.
-func (m *MockImportService) CreateApplication(arg0 context.Context, arg1 string, arg2 charm.Charm, arg3 service.AddApplicationArgs, arg4 ...service.AddUnitArg) (application.ID, error) {
+func (m *MockImportService) CreateApplication(arg0 context.Context, arg1 string, arg2 service.AddApplicationArgs, arg3 ...service.AddUnitArg) (application.ID, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1, arg2, arg3}
-	for _, a := range arg4 {
+	varargs := []any{arg0, arg1, arg2}
+	for _, a := range arg3 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "CreateApplication", varargs...)
@@ -56,9 +55,9 @@ func (m *MockImportService) CreateApplication(arg0 context.Context, arg1 string,
 }
 
 // CreateApplication indicates an expected call of CreateApplication.
-func (mr *MockImportServiceMockRecorder) CreateApplication(arg0, arg1, arg2, arg3 any, arg4 ...any) *MockImportServiceCreateApplicationCall {
+func (mr *MockImportServiceMockRecorder) CreateApplication(arg0, arg1, arg2 any, arg3 ...any) *MockImportServiceCreateApplicationCall {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1, arg2, arg3}, arg4...)
+	varargs := append([]any{arg0, arg1, arg2}, arg3...)
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateApplication", reflect.TypeOf((*MockImportService)(nil).CreateApplication), varargs...)
 	return &MockImportServiceCreateApplicationCall{Call: call}
 }
@@ -75,13 +74,13 @@ func (c *MockImportServiceCreateApplicationCall) Return(arg0 application.ID, arg
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockImportServiceCreateApplicationCall) Do(f func(context.Context, string, charm.Charm, service.AddApplicationArgs, ...service.AddUnitArg) (application.ID, error)) *MockImportServiceCreateApplicationCall {
+func (c *MockImportServiceCreateApplicationCall) Do(f func(context.Context, string, service.AddApplicationArgs, ...service.AddUnitArg) (application.ID, error)) *MockImportServiceCreateApplicationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockImportServiceCreateApplicationCall) DoAndReturn(f func(context.Context, string, charm.Charm, service.AddApplicationArgs, ...service.AddUnitArg) (application.ID, error)) *MockImportServiceCreateApplicationCall {
+func (c *MockImportServiceCreateApplicationCall) DoAndReturn(f func(context.Context, string, service.AddApplicationArgs, ...service.AddUnitArg) (application.ID, error)) *MockImportServiceCreateApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/application/modelmigration/migrations_mock_test.go
+++ b/domain/application/modelmigration/migrations_mock_test.go
@@ -14,7 +14,9 @@ import (
 	reflect "reflect"
 
 	application "github.com/juju/juju/core/application"
+	charm "github.com/juju/juju/core/charm"
 	service "github.com/juju/juju/domain/application/service"
+	charm0 "github.com/juju/juju/internal/charm"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -42,10 +44,10 @@ func (m *MockImportService) EXPECT() *MockImportServiceMockRecorder {
 }
 
 // CreateApplication mocks base method.
-func (m *MockImportService) CreateApplication(arg0 context.Context, arg1 string, arg2 service.AddApplicationArgs, arg3 ...service.AddUnitArg) (application.ID, error) {
+func (m *MockImportService) CreateApplication(arg0 context.Context, arg1 string, arg2 charm0.Charm, arg3 charm.Origin, arg4 service.AddApplicationArgs, arg5 ...service.AddUnitArg) (application.ID, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1, arg2}
-	for _, a := range arg3 {
+	varargs := []any{arg0, arg1, arg2, arg3, arg4}
+	for _, a := range arg5 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "CreateApplication", varargs...)
@@ -55,9 +57,9 @@ func (m *MockImportService) CreateApplication(arg0 context.Context, arg1 string,
 }
 
 // CreateApplication indicates an expected call of CreateApplication.
-func (mr *MockImportServiceMockRecorder) CreateApplication(arg0, arg1, arg2 any, arg3 ...any) *MockImportServiceCreateApplicationCall {
+func (mr *MockImportServiceMockRecorder) CreateApplication(arg0, arg1, arg2, arg3, arg4 any, arg5 ...any) *MockImportServiceCreateApplicationCall {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1, arg2}, arg3...)
+	varargs := append([]any{arg0, arg1, arg2, arg3, arg4}, arg5...)
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateApplication", reflect.TypeOf((*MockImportService)(nil).CreateApplication), varargs...)
 	return &MockImportServiceCreateApplicationCall{Call: call}
 }
@@ -74,13 +76,13 @@ func (c *MockImportServiceCreateApplicationCall) Return(arg0 application.ID, arg
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockImportServiceCreateApplicationCall) Do(f func(context.Context, string, service.AddApplicationArgs, ...service.AddUnitArg) (application.ID, error)) *MockImportServiceCreateApplicationCall {
+func (c *MockImportServiceCreateApplicationCall) Do(f func(context.Context, string, charm0.Charm, charm.Origin, service.AddApplicationArgs, ...service.AddUnitArg) (application.ID, error)) *MockImportServiceCreateApplicationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockImportServiceCreateApplicationCall) DoAndReturn(f func(context.Context, string, service.AddApplicationArgs, ...service.AddUnitArg) (application.ID, error)) *MockImportServiceCreateApplicationCall {
+func (c *MockImportServiceCreateApplicationCall) DoAndReturn(f func(context.Context, string, charm0.Charm, charm.Origin, service.AddApplicationArgs, ...service.AddUnitArg) (application.ID, error)) *MockImportServiceCreateApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/application/platform.go
+++ b/domain/application/platform.go
@@ -1,0 +1,56 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package application
+
+import (
+	"github.com/juju/juju/core/arch"
+	"github.com/juju/juju/core/os/ostype"
+)
+
+// OSType represents the type of an application's OS.
+type OSType int
+
+const (
+	Ubuntu OSType = iota
+)
+
+// MarshallOSType converts an os type to a db os type id.
+func MarshallOSType(os ostype.OSType) OSType {
+	switch os {
+	case ostype.Ubuntu:
+		return Ubuntu
+	default:
+		// Ubuntu is all we support.
+		return Ubuntu
+	}
+}
+
+// Architecture represents an application's architecture.
+type Architecture int
+
+const (
+	AMD64 Architecture = iota
+	ARM64
+	PPC64EL
+	S390X
+	RISV64
+)
+
+// MarshallArchitecture converts an architecture to a db architecture id.
+func MarshallArchitecture(a arch.Arch) Architecture {
+	switch a {
+	case arch.AMD64:
+		return AMD64
+	case arch.ARM64:
+		return ARM64
+	case arch.PPC64EL:
+		return PPC64EL
+	case arch.S390X:
+		return S390X
+	case arch.RISCV64:
+		return RISV64
+	default:
+		return AMD64
+	}
+}

--- a/domain/application/platform_test.go
+++ b/domain/application/platform_test.go
@@ -1,0 +1,83 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package application
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/arch"
+	"github.com/juju/juju/core/os/ostype"
+	schematesting "github.com/juju/juju/domain/schema/testing"
+)
+
+type ostypeSuite struct {
+	schematesting.ModelSuite
+}
+
+var _ = gc.Suite(&ostypeSuite{})
+
+// TestOsTypeDBValues ensures there's no skew between what's in the
+// database table for os type and the typed consts used in the state packages.
+func (s *ostypeSuite) TestOsTypeDBValues(c *gc.C) {
+	db := s.DB()
+	rows, err := db.Query("SELECT id, name FROM os")
+	c.Assert(err, jc.ErrorIsNil)
+	defer rows.Close()
+
+	dbValues := make(map[OSType]string)
+	for rows.Next() {
+		var (
+			id   int
+			name string
+		)
+		err := rows.Scan(&id, &name)
+		c.Assert(err, jc.ErrorIsNil)
+		dbValues[OSType(id)] = name
+	}
+	c.Assert(dbValues, jc.DeepEquals, map[OSType]string{
+		Ubuntu: "ubuntu",
+	})
+	// Also check the core os type enums match.
+	for _, os := range dbValues {
+		c.Assert(ostype.IsValidOSTypeName(os), jc.IsTrue)
+	}
+}
+
+type architectureSuite struct {
+	schematesting.ModelSuite
+}
+
+var _ = gc.Suite(&architectureSuite{})
+
+// TestArchitectureDBValues ensures there's no skew between what's in the
+// database table for architecture and the typed consts used in the state packages.
+func (s *architectureSuite) TestArchitectureDBValues(c *gc.C) {
+	db := s.DB()
+	rows, err := db.Query("SELECT id, name FROM architecture")
+	c.Assert(err, jc.ErrorIsNil)
+	defer rows.Close()
+
+	dbValues := make(map[Architecture]string)
+	for rows.Next() {
+		var (
+			id   int
+			name string
+		)
+		err := rows.Scan(&id, &name)
+		c.Assert(err, jc.ErrorIsNil)
+		dbValues[Architecture(id)] = name
+	}
+	c.Assert(dbValues, jc.DeepEquals, map[Architecture]string{
+		AMD64:   "amd64",
+		ARM64:   "arm64",
+		PPC64EL: "ppc64el",
+		S390X:   "s390x",
+		RISV64:  "riscv64",
+	})
+	// Also check the core arch enums match.
+	for _, a := range dbValues {
+		c.Assert(arch.IsSupportedArch(a), jc.IsTrue)
+	}
+}

--- a/domain/application/service/application_test.go
+++ b/domain/application/service/application_test.go
@@ -13,6 +13,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	applicationtesting "github.com/juju/juju/core/application/testing"
+	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/domain/application"
 	domaincharm "github.com/juju/juju/domain/application/charm"
 	applicationerrors "github.com/juju/juju/domain/application/errors"
@@ -66,8 +67,17 @@ func (s *applicationServiceSuite) TestCreateApplication(c *gc.C) {
 			RunAs: "default",
 		},
 	}
+	platform := application.Platform{
+		Channel:        "24.04",
+		OSTypeID:       application.Ubuntu,
+		ArchitectureID: application.ARM64,
+	}
+	app := application.AddApplicationArg{
+		Charm:    ch,
+		Platform: platform,
+	}
 	s.state.EXPECT().StorageDefaults(gomock.Any()).Return(domainstorage.StorageDefaults{}, nil)
-	s.state.EXPECT().CreateApplication(gomock.Any(), "666", ch, u).Return(id, nil)
+	s.state.EXPECT().CreateApplication(gomock.Any(), "666", app, u).Return(id, nil)
 	s.charm.EXPECT().Manifest().Return(&charm.Manifest{})
 	s.charm.EXPECT().Actions().Return(&charm.Actions{})
 	s.charm.EXPECT().Config().Return(&charm.Config{})
@@ -78,7 +88,11 @@ func (s *applicationServiceSuite) TestCreateApplication(c *gc.C) {
 	a := AddUnitArg{
 		UnitName: ptr("foo/666"),
 	}
-	_, err := s.service.CreateApplication(context.Background(), "666", s.charm, AddApplicationArgs{}, a)
+	_, err := s.service.CreateApplication(context.Background(), "666", AddApplicationArgs{
+		Origin: corecharm.Origin{
+			Platform: corecharm.MustParsePlatform("arm64/ubuntu/24.04"),
+		},
+		Charm: s.charm}, a)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -106,8 +120,17 @@ func (s *applicationServiceSuite) TestCreateWithStorageBlock(c *gc.C) {
 			},
 		},
 	}
+	platform := application.Platform{
+		Channel:        "24.04",
+		OSTypeID:       application.Ubuntu,
+		ArchitectureID: application.ARM64,
+	}
+	app := application.AddApplicationArg{
+		Charm:    ch,
+		Platform: platform,
+	}
 	s.state.EXPECT().StorageDefaults(gomock.Any()).Return(domainstorage.StorageDefaults{}, nil)
-	s.state.EXPECT().CreateApplication(gomock.Any(), "666", ch, u).Return(id, nil)
+	s.state.EXPECT().CreateApplication(gomock.Any(), "666", app, u).Return(id, nil)
 	s.charm.EXPECT().Manifest().Return(&charm.Manifest{})
 	s.charm.EXPECT().Actions().Return(&charm.Actions{})
 	s.charm.EXPECT().Config().Return(&charm.Config{})
@@ -130,7 +153,11 @@ func (s *applicationServiceSuite) TestCreateWithStorageBlock(c *gc.C) {
 	a := AddUnitArg{
 		UnitName: ptr("foo/666"),
 	}
-	_, err := s.service.CreateApplication(context.Background(), "666", s.charm, AddApplicationArgs{}, a)
+	_, err := s.service.CreateApplication(context.Background(), "666", AddApplicationArgs{
+		Origin: corecharm.Origin{
+			Platform: corecharm.MustParsePlatform("arm64/ubuntu/24.04"),
+		},
+		Charm: s.charm}, a)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -158,8 +185,17 @@ func (s *applicationServiceSuite) TestCreateWithStorageBlockDefaultSource(c *gc.
 			},
 		},
 	}
+	platform := application.Platform{
+		Channel:        "24.04",
+		OSTypeID:       application.Ubuntu,
+		ArchitectureID: application.ARM64,
+	}
+	app := application.AddApplicationArg{
+		Charm:    ch,
+		Platform: platform,
+	}
 	s.state.EXPECT().StorageDefaults(gomock.Any()).Return(domainstorage.StorageDefaults{DefaultBlockSource: ptr("fast")}, nil)
-	s.state.EXPECT().CreateApplication(gomock.Any(), "666", ch, u).Return(id, nil)
+	s.state.EXPECT().CreateApplication(gomock.Any(), "666", app, u).Return(id, nil)
 	s.charm.EXPECT().Manifest().Return(&charm.Manifest{})
 	s.charm.EXPECT().Actions().Return(&charm.Actions{})
 	s.charm.EXPECT().Config().Return(&charm.Config{})
@@ -182,7 +218,11 @@ func (s *applicationServiceSuite) TestCreateWithStorageBlockDefaultSource(c *gc.
 	a := AddUnitArg{
 		UnitName: ptr("foo/666"),
 	}
-	_, err := s.service.CreateApplication(context.Background(), "666", s.charm, AddApplicationArgs{
+	_, err := s.service.CreateApplication(context.Background(), "666", AddApplicationArgs{
+		Origin: corecharm.Origin{
+			Platform: corecharm.MustParsePlatform("arm64/ubuntu/24.04"),
+		},
+		Charm: s.charm,
 		Storage: map[string]storage.Directive{
 			"data": {Count: 2},
 		},
@@ -214,8 +254,17 @@ func (s *applicationServiceSuite) TestCreateWithStorageFilesystem(c *gc.C) {
 			},
 		},
 	}
+	platform := application.Platform{
+		Channel:        "24.04",
+		OSTypeID:       application.Ubuntu,
+		ArchitectureID: application.ARM64,
+	}
+	app := application.AddApplicationArg{
+		Charm:    ch,
+		Platform: platform,
+	}
 	s.state.EXPECT().StorageDefaults(gomock.Any()).Return(domainstorage.StorageDefaults{}, nil)
-	s.state.EXPECT().CreateApplication(gomock.Any(), "666", ch, u).Return(id, nil)
+	s.state.EXPECT().CreateApplication(gomock.Any(), "666", app, u).Return(id, nil)
 	s.charm.EXPECT().Manifest().Return(&charm.Manifest{})
 	s.charm.EXPECT().Actions().Return(&charm.Actions{})
 	s.charm.EXPECT().Config().Return(&charm.Config{})
@@ -238,7 +287,11 @@ func (s *applicationServiceSuite) TestCreateWithStorageFilesystem(c *gc.C) {
 	a := AddUnitArg{
 		UnitName: ptr("foo/666"),
 	}
-	_, err := s.service.CreateApplication(context.Background(), "666", s.charm, AddApplicationArgs{}, a)
+	_, err := s.service.CreateApplication(context.Background(), "666", AddApplicationArgs{
+		Origin: corecharm.Origin{
+			Platform: corecharm.MustParsePlatform("arm64/ubuntu/24.04"),
+		},
+		Charm: s.charm}, a)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -266,8 +319,17 @@ func (s *applicationServiceSuite) TestCreateWithStorageFilesystemDefaultSource(c
 			},
 		},
 	}
+	platform := application.Platform{
+		Channel:        "24.04",
+		OSTypeID:       application.Ubuntu,
+		ArchitectureID: application.ARM64,
+	}
+	app := application.AddApplicationArg{
+		Charm:    ch,
+		Platform: platform,
+	}
 	s.state.EXPECT().StorageDefaults(gomock.Any()).Return(domainstorage.StorageDefaults{DefaultFilesystemSource: ptr("fast")}, nil)
-	s.state.EXPECT().CreateApplication(gomock.Any(), "666", ch, u).Return(id, nil)
+	s.state.EXPECT().CreateApplication(gomock.Any(), "666", app, u).Return(id, nil)
 	s.charm.EXPECT().Manifest().Return(&charm.Manifest{})
 	s.charm.EXPECT().Actions().Return(&charm.Actions{})
 	s.charm.EXPECT().Config().Return(&charm.Config{})
@@ -290,7 +352,11 @@ func (s *applicationServiceSuite) TestCreateWithStorageFilesystemDefaultSource(c
 	a := AddUnitArg{
 		UnitName: ptr("foo/666"),
 	}
-	_, err := s.service.CreateApplication(context.Background(), "666", s.charm, AddApplicationArgs{
+	_, err := s.service.CreateApplication(context.Background(), "666", AddApplicationArgs{
+		Origin: corecharm.Origin{
+			Platform: corecharm.MustParsePlatform("arm64/ubuntu/24.04"),
+		},
+		Charm: s.charm,
 		Storage: map[string]storage.Directive{
 			"data": {Count: 2},
 		},
@@ -316,7 +382,9 @@ func (s *applicationServiceSuite) TestCreateWithSharedStorageMissingDirectives(c
 	a := AddUnitArg{
 		UnitName: ptr("foo/666"),
 	}
-	_, err := s.service.CreateApplication(context.Background(), "666", s.charm, AddApplicationArgs{}, a)
+	_, err := s.service.CreateApplication(context.Background(), "666", AddApplicationArgs{
+		Charm: s.charm,
+	}, a)
 	c.Assert(err, jc.ErrorIs, storageerrors.MissingSharedStorageDirectiveError)
 	c.Assert(err, gc.ErrorMatches, `adding default storage directives: no storage directive specified for shared charm storage "data"`)
 }
@@ -340,8 +408,11 @@ func (s *applicationServiceSuite) TestCreateWithStorageValidates(c *gc.C) {
 	a := AddUnitArg{
 		UnitName: ptr("foo/666"),
 	}
-	_, err := s.service.CreateApplication(context.Background(), "666", s.charm, AddApplicationArgs{
-
+	_, err := s.service.CreateApplication(context.Background(), "666", AddApplicationArgs{
+		Origin: corecharm.Origin{
+			Platform: corecharm.MustParsePlatform("arm64/ubuntu/24.04"),
+		},
+		Charm: s.charm,
 		Storage: map[string]storage.Directive{
 			"logs": {Count: 2},
 		},
@@ -354,7 +425,9 @@ func (s *applicationServiceSuite) TestCreateApplicationWithNoCharmName(c *gc.C) 
 
 	s.charm.EXPECT().Meta().Return(&charm.Meta{}).AnyTimes()
 
-	_, err := s.service.CreateApplication(context.Background(), "666", s.charm, AddApplicationArgs{})
+	_, err := s.service.CreateApplication(context.Background(), "666", AddApplicationArgs{
+		Charm: s.charm,
+	})
 	c.Assert(err, jc.ErrorIs, applicationerrors.CharmNameNotValid)
 }
 
@@ -363,7 +436,9 @@ func (s *applicationServiceSuite) TestCreateApplicationWithNoApplicationOrCharmN
 
 	s.charm.EXPECT().Meta().Return(&charm.Meta{}).AnyTimes()
 
-	_, err := s.service.CreateApplication(context.Background(), "", s.charm, AddApplicationArgs{})
+	_, err := s.service.CreateApplication(context.Background(), "", AddApplicationArgs{
+		Charm: s.charm,
+	})
 	c.Assert(err, jc.ErrorIs, applicationerrors.ApplicationNameNotValid)
 }
 
@@ -372,7 +447,9 @@ func (s *applicationServiceSuite) TestCreateApplicationWithNoMeta(c *gc.C) {
 
 	s.charm.EXPECT().Meta().Return(nil).AnyTimes()
 
-	_, err := s.service.CreateApplication(context.Background(), "", s.charm, AddApplicationArgs{})
+	_, err := s.service.CreateApplication(context.Background(), "", AddApplicationArgs{
+		Charm: s.charm,
+	})
 	c.Assert(err, jc.ErrorIs, applicationerrors.CharmMetadataNotValid)
 }
 
@@ -391,7 +468,9 @@ func (s *applicationServiceSuite) TestCreateApplicationError(c *gc.C) {
 		Name: "foo",
 	}).AnyTimes()
 
-	_, err := s.service.CreateApplication(context.Background(), "666", s.charm, AddApplicationArgs{})
+	_, err := s.service.CreateApplication(context.Background(), "666", AddApplicationArgs{
+		Charm: s.charm,
+	})
 	c.Check(err, jc.ErrorIs, rErr)
 	c.Assert(err, gc.ErrorMatches, `creating application "666": boom`)
 }
@@ -435,12 +514,43 @@ func (s *applicationServiceSuite) TestAddUpsertCAASUnit(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	u := application.AddUnitArg{
-		UnitName: ptr("foo/666"),
+		UnitName:     ptr("foo/666"),
+		PasswordHash: ptr("passwordhash"),
+		CloudContainer: &application.CloudContainer{
+			ProviderId: ptr("provider-id"),
+			Address: ptr(application.Address{
+				Value:       "10.6.6.6",
+				AddressType: "ipv4",
+				Scope:       "local-machine",
+				Origin:      "provider",
+				SpaceID:     "0",
+			}),
+			Ports: ptr([]string{"6666"}),
+		},
 	}
-	s.state.EXPECT().UpsertApplication(gomock.Any(), "foo", u).Return(nil)
+	s.state.EXPECT().UpsertApplicationUnit(gomock.Any(), "foo", u).Return(nil)
 
 	p := UpsertCAASUnitParams{
+		UnitName:     "foo/666",
+		PasswordHash: ptr("passwordhash"),
+		ProviderId:   ptr("provider-id"),
+		Address:      ptr("10.6.6.6"),
+		Ports:        ptr([]string{"6666"}),
+	}
+	err := s.service.UpsertCAASUnit(context.Background(), "foo", p)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *applicationServiceSuite) TestAddUpsertCAASUnitMinimal(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	u := application.AddUnitArg{
 		UnitName: ptr("foo/666"),
+	}
+	s.state.EXPECT().UpsertApplicationUnit(gomock.Any(), "foo", u).Return(nil)
+
+	p := UpsertCAASUnitParams{
+		UnitName: "foo/666",
 	}
 	err := s.service.UpsertCAASUnit(context.Background(), "foo", p)
 	c.Assert(err, jc.ErrorIsNil)

--- a/domain/application/service/application_test.go
+++ b/domain/application/service/application_test.go
@@ -88,11 +88,9 @@ func (s *applicationServiceSuite) TestCreateApplication(c *gc.C) {
 	a := AddUnitArg{
 		UnitName: ptr("foo/666"),
 	}
-	_, err := s.service.CreateApplication(context.Background(), "666", AddApplicationArgs{
-		Origin: corecharm.Origin{
-			Platform: corecharm.MustParsePlatform("arm64/ubuntu/24.04"),
-		},
-		Charm: s.charm}, a)
+	_, err := s.service.CreateApplication(context.Background(), "666", s.charm, corecharm.Origin{
+		Platform: corecharm.MustParsePlatform("arm64/ubuntu/24.04"),
+	}, AddApplicationArgs{}, a)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -153,11 +151,9 @@ func (s *applicationServiceSuite) TestCreateWithStorageBlock(c *gc.C) {
 	a := AddUnitArg{
 		UnitName: ptr("foo/666"),
 	}
-	_, err := s.service.CreateApplication(context.Background(), "666", AddApplicationArgs{
-		Origin: corecharm.Origin{
-			Platform: corecharm.MustParsePlatform("arm64/ubuntu/24.04"),
-		},
-		Charm: s.charm}, a)
+	_, err := s.service.CreateApplication(context.Background(), "666", s.charm, corecharm.Origin{
+		Platform: corecharm.MustParsePlatform("arm64/ubuntu/24.04"),
+	}, AddApplicationArgs{}, a)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -218,11 +214,9 @@ func (s *applicationServiceSuite) TestCreateWithStorageBlockDefaultSource(c *gc.
 	a := AddUnitArg{
 		UnitName: ptr("foo/666"),
 	}
-	_, err := s.service.CreateApplication(context.Background(), "666", AddApplicationArgs{
-		Origin: corecharm.Origin{
-			Platform: corecharm.MustParsePlatform("arm64/ubuntu/24.04"),
-		},
-		Charm: s.charm,
+	_, err := s.service.CreateApplication(context.Background(), "666", s.charm, corecharm.Origin{
+		Platform: corecharm.MustParsePlatform("arm64/ubuntu/24.04"),
+	}, AddApplicationArgs{
 		Storage: map[string]storage.Directive{
 			"data": {Count: 2},
 		},
@@ -287,11 +281,9 @@ func (s *applicationServiceSuite) TestCreateWithStorageFilesystem(c *gc.C) {
 	a := AddUnitArg{
 		UnitName: ptr("foo/666"),
 	}
-	_, err := s.service.CreateApplication(context.Background(), "666", AddApplicationArgs{
-		Origin: corecharm.Origin{
-			Platform: corecharm.MustParsePlatform("arm64/ubuntu/24.04"),
-		},
-		Charm: s.charm}, a)
+	_, err := s.service.CreateApplication(context.Background(), "666", s.charm, corecharm.Origin{
+		Platform: corecharm.MustParsePlatform("arm64/ubuntu/24.04"),
+	}, AddApplicationArgs{}, a)
 	c.Assert(err, jc.ErrorIsNil)
 }
 
@@ -352,11 +344,9 @@ func (s *applicationServiceSuite) TestCreateWithStorageFilesystemDefaultSource(c
 	a := AddUnitArg{
 		UnitName: ptr("foo/666"),
 	}
-	_, err := s.service.CreateApplication(context.Background(), "666", AddApplicationArgs{
-		Origin: corecharm.Origin{
-			Platform: corecharm.MustParsePlatform("arm64/ubuntu/24.04"),
-		},
-		Charm: s.charm,
+	_, err := s.service.CreateApplication(context.Background(), "666", s.charm, corecharm.Origin{
+		Platform: corecharm.MustParsePlatform("arm64/ubuntu/24.04"),
+	}, AddApplicationArgs{
 		Storage: map[string]storage.Directive{
 			"data": {Count: 2},
 		},
@@ -382,9 +372,9 @@ func (s *applicationServiceSuite) TestCreateWithSharedStorageMissingDirectives(c
 	a := AddUnitArg{
 		UnitName: ptr("foo/666"),
 	}
-	_, err := s.service.CreateApplication(context.Background(), "666", AddApplicationArgs{
-		Charm: s.charm,
-	}, a)
+	_, err := s.service.CreateApplication(context.Background(), "666", s.charm, corecharm.Origin{
+		Platform: corecharm.MustParsePlatform("arm64/ubuntu/24.04"),
+	}, AddApplicationArgs{}, a)
 	c.Assert(err, jc.ErrorIs, storageerrors.MissingSharedStorageDirectiveError)
 	c.Assert(err, gc.ErrorMatches, `adding default storage directives: no storage directive specified for shared charm storage "data"`)
 }
@@ -408,11 +398,9 @@ func (s *applicationServiceSuite) TestCreateWithStorageValidates(c *gc.C) {
 	a := AddUnitArg{
 		UnitName: ptr("foo/666"),
 	}
-	_, err := s.service.CreateApplication(context.Background(), "666", AddApplicationArgs{
-		Origin: corecharm.Origin{
-			Platform: corecharm.MustParsePlatform("arm64/ubuntu/24.04"),
-		},
-		Charm: s.charm,
+	_, err := s.service.CreateApplication(context.Background(), "666", s.charm, corecharm.Origin{
+		Platform: corecharm.MustParsePlatform("arm64/ubuntu/24.04"),
+	}, AddApplicationArgs{
 		Storage: map[string]storage.Directive{
 			"logs": {Count: 2},
 		},
@@ -425,9 +413,9 @@ func (s *applicationServiceSuite) TestCreateApplicationWithNoCharmName(c *gc.C) 
 
 	s.charm.EXPECT().Meta().Return(&charm.Meta{}).AnyTimes()
 
-	_, err := s.service.CreateApplication(context.Background(), "666", AddApplicationArgs{
-		Charm: s.charm,
-	})
+	_, err := s.service.CreateApplication(context.Background(), "666", s.charm, corecharm.Origin{
+		Platform: corecharm.MustParsePlatform("arm64/ubuntu/24.04"),
+	}, AddApplicationArgs{})
 	c.Assert(err, jc.ErrorIs, applicationerrors.CharmNameNotValid)
 }
 
@@ -436,9 +424,9 @@ func (s *applicationServiceSuite) TestCreateApplicationWithNoApplicationOrCharmN
 
 	s.charm.EXPECT().Meta().Return(&charm.Meta{}).AnyTimes()
 
-	_, err := s.service.CreateApplication(context.Background(), "", AddApplicationArgs{
-		Charm: s.charm,
-	})
+	_, err := s.service.CreateApplication(context.Background(), "", s.charm, corecharm.Origin{
+		Platform: corecharm.MustParsePlatform("arm64/ubuntu/24.04"),
+	}, AddApplicationArgs{})
 	c.Assert(err, jc.ErrorIs, applicationerrors.ApplicationNameNotValid)
 }
 
@@ -447,10 +435,22 @@ func (s *applicationServiceSuite) TestCreateApplicationWithNoMeta(c *gc.C) {
 
 	s.charm.EXPECT().Meta().Return(nil).AnyTimes()
 
-	_, err := s.service.CreateApplication(context.Background(), "", AddApplicationArgs{
-		Charm: s.charm,
-	})
+	_, err := s.service.CreateApplication(context.Background(), "666", s.charm, corecharm.Origin{
+		Platform: corecharm.MustParsePlatform("arm64/ubuntu/24.04"),
+	}, AddApplicationArgs{})
 	c.Assert(err, jc.ErrorIs, applicationerrors.CharmMetadataNotValid)
+}
+
+func (s *applicationServiceSuite) TestCreateApplicationWithNoArchitecture(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.charm.EXPECT().Meta().Return(&charm.Meta{Name: "foo"}).AnyTimes()
+
+	_, err := s.service.CreateApplication(context.Background(), "666", s.charm, corecharm.Origin{
+		Source:   corecharm.CharmHub,
+		Platform: corecharm.Platform{Channel: "24.04", OS: "ubuntu"},
+	}, AddApplicationArgs{})
+	c.Assert(err, jc.ErrorIs, applicationerrors.CharmOriginNotValid)
 }
 
 func (s *applicationServiceSuite) TestCreateApplicationError(c *gc.C) {
@@ -468,9 +468,9 @@ func (s *applicationServiceSuite) TestCreateApplicationError(c *gc.C) {
 		Name: "foo",
 	}).AnyTimes()
 
-	_, err := s.service.CreateApplication(context.Background(), "666", AddApplicationArgs{
-		Charm: s.charm,
-	})
+	_, err := s.service.CreateApplication(context.Background(), "666", s.charm, corecharm.Origin{
+		Platform: corecharm.MustParsePlatform("arm64/ubuntu/24.04"),
+	}, AddApplicationArgs{})
 	c.Check(err, jc.ErrorIs, rErr)
 	c.Assert(err, gc.ErrorMatches, `creating application "666": boom`)
 }

--- a/domain/application/service/package_mock_test.go
+++ b/domain/application/service/package_mock_test.go
@@ -90,7 +90,7 @@ func (c *MockApplicationStateAddUnitsCall) DoAndReturn(f func(context.Context, s
 }
 
 // CreateApplication mocks base method.
-func (m *MockApplicationState) CreateApplication(arg0 context.Context, arg1 string, arg2 charm0.Charm, arg3 ...application0.AddUnitArg) (application.ID, error) {
+func (m *MockApplicationState) CreateApplication(arg0 context.Context, arg1 string, arg2 application0.AddApplicationArg, arg3 ...application0.AddUnitArg) (application.ID, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1, arg2}
 	for _, a := range arg3 {
@@ -122,13 +122,13 @@ func (c *MockApplicationStateCreateApplicationCall) Return(arg0 application.ID, 
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationStateCreateApplicationCall) Do(f func(context.Context, string, charm0.Charm, ...application0.AddUnitArg) (application.ID, error)) *MockApplicationStateCreateApplicationCall {
+func (c *MockApplicationStateCreateApplicationCall) Do(f func(context.Context, string, application0.AddApplicationArg, ...application0.AddUnitArg) (application.ID, error)) *MockApplicationStateCreateApplicationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationStateCreateApplicationCall) DoAndReturn(f func(context.Context, string, charm0.Charm, ...application0.AddUnitArg) (application.ID, error)) *MockApplicationStateCreateApplicationCall {
+func (c *MockApplicationStateCreateApplicationCall) DoAndReturn(f func(context.Context, string, application0.AddApplicationArg, ...application0.AddUnitArg) (application.ID, error)) *MockApplicationStateCreateApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -249,45 +249,40 @@ func (c *MockApplicationStateStorageDefaultsCall) DoAndReturn(f func(context.Con
 	return c
 }
 
-// UpsertApplication mocks base method.
-func (m *MockApplicationState) UpsertApplication(arg0 context.Context, arg1 string, arg2 ...application0.AddUnitArg) error {
+// UpsertApplicationUnit mocks base method.
+func (m *MockApplicationState) UpsertApplicationUnit(arg0 context.Context, arg1 string, arg2 application0.AddUnitArg) error {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1}
-	for _, a := range arg2 {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "UpsertApplication", varargs...)
+	ret := m.ctrl.Call(m, "UpsertApplicationUnit", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// UpsertApplication indicates an expected call of UpsertApplication.
-func (mr *MockApplicationStateMockRecorder) UpsertApplication(arg0, arg1 any, arg2 ...any) *MockApplicationStateUpsertApplicationCall {
+// UpsertApplicationUnit indicates an expected call of UpsertApplicationUnit.
+func (mr *MockApplicationStateMockRecorder) UpsertApplicationUnit(arg0, arg1, arg2 any) *MockApplicationStateUpsertApplicationUnitCall {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1}, arg2...)
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertApplication", reflect.TypeOf((*MockApplicationState)(nil).UpsertApplication), varargs...)
-	return &MockApplicationStateUpsertApplicationCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertApplicationUnit", reflect.TypeOf((*MockApplicationState)(nil).UpsertApplicationUnit), arg0, arg1, arg2)
+	return &MockApplicationStateUpsertApplicationUnitCall{Call: call}
 }
 
-// MockApplicationStateUpsertApplicationCall wrap *gomock.Call
-type MockApplicationStateUpsertApplicationCall struct {
+// MockApplicationStateUpsertApplicationUnitCall wrap *gomock.Call
+type MockApplicationStateUpsertApplicationUnitCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockApplicationStateUpsertApplicationCall) Return(arg0 error) *MockApplicationStateUpsertApplicationCall {
+func (c *MockApplicationStateUpsertApplicationUnitCall) Return(arg0 error) *MockApplicationStateUpsertApplicationUnitCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationStateUpsertApplicationCall) Do(f func(context.Context, string, ...application0.AddUnitArg) error) *MockApplicationStateUpsertApplicationCall {
+func (c *MockApplicationStateUpsertApplicationUnitCall) Do(f func(context.Context, string, application0.AddUnitArg) error) *MockApplicationStateUpsertApplicationUnitCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationStateUpsertApplicationCall) DoAndReturn(f func(context.Context, string, ...application0.AddUnitArg) error) *MockApplicationStateUpsertApplicationCall {
+func (c *MockApplicationStateUpsertApplicationUnitCall) DoAndReturn(f func(context.Context, string, application0.AddUnitArg) error) *MockApplicationStateUpsertApplicationUnitCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/application/service/params.go
+++ b/domain/application/service/params.go
@@ -4,20 +4,44 @@
 package service
 
 import (
+	corecharm "github.com/juju/juju/core/charm"
+	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/internal/charm"
 	"github.com/juju/juju/internal/storage"
 )
 
-// AddApplicationArgs contain arguments for adding an application to the model.
+// AddApplicationArgs contains arguments for adding an application to the model.
 type AddApplicationArgs struct {
+	// Charm is the application's charm.
+	Charm charm.Charm
+	// Origin is the origin of the charm.
+	Origin corecharm.Origin
 	// Storage contains the application's storage directives.
 	Storage map[string]storage.Directive
 }
 
-// AddUnitArgs contains parameters for adding a unit to the model.
+// CloudContainerParams contains parameters for a unit cloud container.
+type CloudContainerParams struct {
+	ProviderId    *string
+	Address       *network.SpaceAddress
+	AddressOrigin *network.Origin
+	Ports         *[]string
+}
+
+// AddressParams contains parameters for a unit/cloud container address.
+type AddressParams struct {
+	Value       string
+	AddressType string
+	Scope       string
+	Origin      string
+	SpaceID     string
+}
+
+// AddUnitArg contains parameters for adding a unit to the model.
 type AddUnitArg struct {
-	// UnitName is for migration, adding named units.
-	UnitName *string
+	UnitName       *string
+	PasswordHash   *string
+	CloudContainer *CloudContainerParams
 
 	// Storage params go here.
 }
@@ -25,8 +49,13 @@ type AddUnitArg struct {
 // UpsertCAASUnitParams contain parameters for introducing
 // a k8s unit representing a new pod to the model.
 type UpsertCAASUnitParams struct {
-	// UnitName is for CAAS models when creating stateful units.
-	UnitName *string
+	UnitName     string
+	PasswordHash *string
+	ProviderId   *string
+	Address      *string
+	Ports        *[]string
+	OrderedScale bool
+	OrderedId    int
 }
 
 // UpdateCharmParams contains the parameters for updating

--- a/domain/application/service/params.go
+++ b/domain/application/service/params.go
@@ -4,7 +4,6 @@
 package service
 
 import (
-	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/internal/charm"
 	"github.com/juju/juju/internal/storage"
@@ -12,10 +11,6 @@ import (
 
 // AddApplicationArgs contains arguments for adding an application to the model.
 type AddApplicationArgs struct {
-	// Charm is the application's charm.
-	Charm charm.Charm
-	// Origin is the origin of the charm.
-	Origin corecharm.Origin
 	// Storage contains the application's storage directives.
 	Storage map[string]storage.Directive
 }

--- a/domain/application/state/application.go
+++ b/domain/application/state/application.go
@@ -71,7 +71,7 @@ INSERT INTO application (*) VALUES ($applicationDetails.*)
 
 	platformInfo := applicationPlatform{
 		ApplicationID:  appID.String(),
-		OsID:           app.Platform.OSTypeID,
+		OSTypeID:       app.Platform.OSTypeID,
 		Channel:        app.Platform.Channel,
 		ArchitectureID: app.Platform.ArchitectureID,
 	}

--- a/domain/application/state/types.go
+++ b/domain/application/state/types.go
@@ -3,6 +3,11 @@
 
 package state
 
+import (
+	"github.com/juju/juju/domain/application"
+	"github.com/juju/juju/domain/life"
+)
+
 // These structs represent the persistent block device entity schema in the database.
 
 type KeyValue struct {
@@ -18,6 +23,37 @@ type applicationID struct {
 // applicationName is used to get the name of an application.
 type applicationName struct {
 	Name string `db:"name"`
+}
+
+type applicationDetails struct {
+	ApplicationID string    `db:"uuid"`
+	Name          string    `db:"name"`
+	CharmID       string    `db:"charm_uuid"`
+	LifeID        life.Life `db:"life_id"`
+}
+
+type applicationPlatform struct {
+	ApplicationID  string                   `db:"application_uuid"`
+	OsID           application.OSType       `db:"os_id"`
+	Channel        string                   `db:"channel"`
+	ArchitectureID application.Architecture `db:"architecture_id"`
+}
+
+type applicationChannel struct {
+	ApplicationID string `db:"application_uuid"`
+	Track         string `db:"track"`
+	Risk          string `db:"risk"`
+	Branch        string `db:"branch"`
+}
+
+type unitDetails struct {
+	UnitID                  string    `db:"uuid"`
+	NetNodeID               string    `db:"net_node_uuid"`
+	Name                    string    `db:"name"`
+	ApplicationID           string    `db:"application_uuid"`
+	LifeID                  life.Life `db:"life_id"`
+	PasswordHash            string    `db:"password_hash"`
+	PasswordHashAlgorithmID int       `db:"password_hash_algorithm_id"`
 }
 
 // These structs represent the persistent charm schema in the database.

--- a/domain/application/state/types.go
+++ b/domain/application/state/types.go
@@ -34,7 +34,7 @@ type applicationDetails struct {
 
 type applicationPlatform struct {
 	ApplicationID  string                   `db:"application_uuid"`
-	OsID           application.OSType       `db:"os_id"`
+	OSTypeID       application.OSType       `db:"os_id"`
 	Channel        string                   `db:"channel"`
 	ArchitectureID application.Architecture `db:"architecture_id"`
 }

--- a/domain/application/types.go
+++ b/domain/application/types.go
@@ -3,8 +3,41 @@
 
 package application
 
+import (
+	domaincharm "github.com/juju/juju/domain/application/charm"
+)
+
+// AddApplicationArg contains parameters for saving an application to state.
+type AddApplicationArg struct {
+	Charm    domaincharm.Charm
+	Channel  *domaincharm.Channel
+	Platform Platform
+}
+
+// Platform contains parameters for an application's platform.
+type Platform struct {
+	Channel        string
+	OSTypeID       OSType
+	ArchitectureID Architecture
+}
+
+type CloudContainer struct {
+	ProviderId *string
+	Address    *Address
+	Ports      *[]string
+}
+
+type Address struct {
+	Value       string
+	AddressType string
+	Scope       string
+	Origin      string
+	SpaceID     string
+}
+
 // AddUnitArg contains parameters for saving a unit to state.
 type AddUnitArg struct {
-	// UnitName is for CAAS models when creating stateful units.
-	UnitName *string
+	UnitName       *string
+	PasswordHash   *string
+	CloudContainer *CloudContainer
 }

--- a/domain/application/types.go
+++ b/domain/application/types.go
@@ -21,12 +21,14 @@ type Platform struct {
 	ArchitectureID Architecture
 }
 
+// CloudContainer contains parameters for a unit's cloud container.
 type CloudContainer struct {
 	ProviderId *string
 	Address    *Address
 	Ports      *[]string
 }
 
+// Address contains parameters for a cloud container address.
 type Address struct {
 	Value       string
 	AddressType string

--- a/domain/schema/model/sql/0017-machine.sql
+++ b/domain/schema/model/sql/0017-machine.sql
@@ -51,16 +51,20 @@ CREATE TABLE machine_constraint (
     REFERENCES "constraint" (uuid)
 );
 
-CREATE TABLE machine_tool (
+CREATE TABLE machine_agent (
     machine_uuid TEXT NOT NULL,
-    tool_url TEXT NOT NULL,
-    tool_version TEXT NOT NULL,
-    tool_sha256 TEXT NOT NULL,
-    tool_size INT NOT NULL,
+    url TEXT NOT NULL,
+    version_major INT NOT NULL,
+    version_minor INT NOT NULL,
+    version_tag TEXT,
+    version_patch INT NOT NULL,
+    version_build INT,
+    sha256 TEXT NOT NULL,
+    binary_size INT NOT NULL,
     CONSTRAINT fk_machine_principal_machine
     FOREIGN KEY (machine_uuid)
     REFERENCES machine (uuid),
-    PRIMARY KEY (machine_uuid, tool_url)
+    PRIMARY KEY (machine_uuid, url)
 );
 
 CREATE TABLE machine_volume (

--- a/domain/schema/model/sql/0017-machine.sql
+++ b/domain/schema/model/sql/0017-machine.sql
@@ -59,11 +59,15 @@ CREATE TABLE machine_agent (
     version_tag TEXT,
     version_patch INT NOT NULL,
     version_build INT,
-    sha256 TEXT NOT NULL,
+    hash TEXT NOT NULL,
+    hash_kind_id INT NOT NULL DEFAULT 0,
     binary_size INT NOT NULL,
     CONSTRAINT fk_machine_principal_machine
     FOREIGN KEY (machine_uuid)
     REFERENCES machine (uuid),
+    CONSTRAINT fk_machine_agent_hash_kind
+    FOREIGN KEY (hash_kind_id)
+    REFERENCES hash_kind (id),
     PRIMARY KEY (machine_uuid, url)
 );
 

--- a/domain/schema/model/sql/0018-application.sql
+++ b/domain/schema/model/sql/0018-application.sql
@@ -37,7 +37,7 @@ CREATE TABLE application_channel (
 CREATE TABLE application_scale (
     application_uuid TEXT NOT NULL PRIMARY KEY,
     scale INT,
-    scale_target TEXT,
+    scale_target INT,
     scaling BOOLEAN DEFAULT FALSE,
     CONSTRAINT fk_application_endpoint_space_application
     FOREIGN KEY (application_uuid)
@@ -46,9 +46,9 @@ CREATE TABLE application_scale (
 
 CREATE TABLE application_platform (
     application_uuid TEXT NOT NULL PRIMARY KEY,
-    os_id TEXT,
-    channel TEXT,
-    architecture_id TEXT,
+    os_id TEXT NOT NULL,
+    channel TEXT NOT NULL,
+    architecture_id TEXT NOT NULL,
     CONSTRAINT fk_application_platform_application
     FOREIGN KEY (application_uuid)
     REFERENCES application (uuid),

--- a/domain/schema/model/sql/0019-unit.sql
+++ b/domain/schema/model/sql/0019-unit.sql
@@ -73,11 +73,15 @@ CREATE TABLE unit_agent (
     version_tag TEXT,
     version_patch INT NOT NULL,
     version_build INT,
-    sha256 TEXT NOT NULL,
+    hash TEXT NOT NULL,
+    hash_kind_id INT NOT NULL DEFAULT 0,
     binary_size INT NOT NULL,
     CONSTRAINT fk_unit_agent_unit
     FOREIGN KEY (unit_uuid)
     REFERENCES unit (uuid),
+    CONSTRAINT fk_unit_agent_hash_kind
+    FOREIGN KEY (hash_kind_id)
+    REFERENCES hash_kind (id),
     CONSTRAINT fk_object_store_metadata_path_unit
     FOREIGN KEY (url)
     REFERENCES object_store_metadata_path (path),

--- a/domain/schema/model/sql/0019-unit.sql
+++ b/domain/schema/model/sql/0019-unit.sql
@@ -17,9 +17,9 @@ CREATE TABLE unit (
     life_id INT NOT NULL,
     application_uuid TEXT NOT NULL,
     net_node_uuid TEXT NOT NULL,
-    -- charm_uuid should not be nullable, but we need to allow it for now
-    -- whilst we're wiring up the model.
+    -- Freshly created units will not have a charm URL set.
     charm_uuid TEXT,
+    -- Resolve Kind starts out as None, is only set when a hook errors.
     resolve_kind_id INT NOT NULL DEFAULT 0,
     password_hash_algorithm_id TEXT,
     password_hash TEXT,
@@ -52,23 +52,20 @@ ON unit (application_uuid);
 CREATE INDEX idx_unit_net_node
 ON unit (net_node_uuid);
 
-CREATE TABLE unit_platform (
+-- unit_principal table is a table which is used to store the.
+-- principal units for subordinate units.
+CREATE TABLE unit_principal (
     unit_uuid TEXT NOT NULL PRIMARY KEY,
-    os_id TEXT,
-    channel TEXT,
-    architecture_id TEXT,
-    CONSTRAINT fk_unit_platform_unit
+    principal_uuid TEXT NOT NULL,
+    CONSTRAINT fk_unit_principal_unit
     FOREIGN KEY (unit_uuid)
     REFERENCES unit (uuid),
-    CONSTRAINT fk_unit_platform_os
-    FOREIGN KEY (os_id)
-    REFERENCES os (id),
-    CONSTRAINT fk_unit_platform_architecture
-    FOREIGN KEY (architecture_id)
-    REFERENCES architecture (id)
+    CONSTRAINT fk_unit_principal_principal
+    FOREIGN KEY (principal_uuid)
+    REFERENCES unit (uuid)
 );
 
-CREATE TABLE unit_tool (
+CREATE TABLE unit_agent (
     unit_uuid TEXT NOT NULL,
     url TEXT NOT NULL,
     version_major INT NOT NULL,
@@ -76,7 +73,9 @@ CREATE TABLE unit_tool (
     version_tag TEXT,
     version_patch INT NOT NULL,
     version_build INT,
-    CONSTRAINT fk_unit_tool_unit
+    sha256 TEXT NOT NULL,
+    binary_size INT NOT NULL,
+    CONSTRAINT fk_unit_agent_unit
     FOREIGN KEY (unit_uuid)
     REFERENCES unit (uuid),
     CONSTRAINT fk_object_store_metadata_path_unit

--- a/domain/schema/schema_test.go
+++ b/domain/schema/schema_test.go
@@ -298,12 +298,12 @@ func (s *schemaSuite) TestModelTables(c *gc.C) {
 
 		// Unit
 		"unit",
-		"unit_platform",
 		"unit_resolve_kind",
 		"unit_state_charm",
 		"unit_state_relation",
 		"unit_state",
-		"unit_tool",
+		"unit_agent",
+		"unit_principal",
 
 		// Constraint
 		"constraint",
@@ -315,7 +315,7 @@ func (s *schemaSuite) TestModelTables(c *gc.C) {
 		"machine",
 		"machine_parent",
 		"machine_constraint",
-		"machine_tool",
+		"machine_agent",
 		"machine_volume",
 		"machine_filesystem",
 		"machine_requires_reboot",

--- a/domain/secret/watcher_test.go
+++ b/domain/secret/watcher_test.go
@@ -58,8 +58,9 @@ func (s *watcherSuite) setupUnits(c *gc.C, appName string) {
 	unitName := fmt.Sprintf("%s/0", appName)
 	_, err := svc.CreateApplication(context.Background(),
 		appName,
-		&stubCharm{},
-		applicationservice.AddApplicationArgs{},
+		applicationservice.AddApplicationArgs{
+			Charm: &stubCharm{},
+		},
 		applicationservice.AddUnitArg{UnitName: &unitName},
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/domain/secret/watcher_test.go
+++ b/domain/secret/watcher_test.go
@@ -14,6 +14,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/changestream"
+	corecharm "github.com/juju/juju/core/charm"
 	coresecrets "github.com/juju/juju/core/secrets"
 	jujuversion "github.com/juju/juju/core/version"
 	corewatcher "github.com/juju/juju/core/watcher"
@@ -58,9 +59,9 @@ func (s *watcherSuite) setupUnits(c *gc.C, appName string) {
 	unitName := fmt.Sprintf("%s/0", appName)
 	_, err := svc.CreateApplication(context.Background(),
 		appName,
-		applicationservice.AddApplicationArgs{
-			Charm: &stubCharm{},
-		},
+		&stubCharm{},
+		corecharm.Origin{},
+		applicationservice.AddApplicationArgs{},
 		applicationservice.AddUnitArg{UnitName: &unitName},
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/internal/bootstrap/bootstrap_mock_test.go
+++ b/internal/bootstrap/bootstrap_mock_test.go
@@ -2142,10 +2142,10 @@ func (m *MockApplicationService) EXPECT() *MockApplicationServiceMockRecorder {
 }
 
 // CreateApplication mocks base method.
-func (m *MockApplicationService) CreateApplication(arg0 context.Context, arg1 string, arg2 service.AddApplicationArgs, arg3 ...service.AddUnitArg) (application.ID, error) {
+func (m *MockApplicationService) CreateApplication(arg0 context.Context, arg1 string, arg2 charm0.Charm, arg3 charm.Origin, arg4 service.AddApplicationArgs, arg5 ...service.AddUnitArg) (application.ID, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1, arg2}
-	for _, a := range arg3 {
+	varargs := []any{arg0, arg1, arg2, arg3, arg4}
+	for _, a := range arg5 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "CreateApplication", varargs...)
@@ -2155,9 +2155,9 @@ func (m *MockApplicationService) CreateApplication(arg0 context.Context, arg1 st
 }
 
 // CreateApplication indicates an expected call of CreateApplication.
-func (mr *MockApplicationServiceMockRecorder) CreateApplication(arg0, arg1, arg2 any, arg3 ...any) *MockApplicationServiceCreateApplicationCall {
+func (mr *MockApplicationServiceMockRecorder) CreateApplication(arg0, arg1, arg2, arg3, arg4 any, arg5 ...any) *MockApplicationServiceCreateApplicationCall {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1, arg2}, arg3...)
+	varargs := append([]any{arg0, arg1, arg2, arg3, arg4}, arg5...)
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateApplication", reflect.TypeOf((*MockApplicationService)(nil).CreateApplication), varargs...)
 	return &MockApplicationServiceCreateApplicationCall{Call: call}
 }
@@ -2174,13 +2174,13 @@ func (c *MockApplicationServiceCreateApplicationCall) Return(arg0 application.ID
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceCreateApplicationCall) Do(f func(context.Context, string, service.AddApplicationArgs, ...service.AddUnitArg) (application.ID, error)) *MockApplicationServiceCreateApplicationCall {
+func (c *MockApplicationServiceCreateApplicationCall) Do(f func(context.Context, string, charm0.Charm, charm.Origin, service.AddApplicationArgs, ...service.AddUnitArg) (application.ID, error)) *MockApplicationServiceCreateApplicationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceCreateApplicationCall) DoAndReturn(f func(context.Context, string, service.AddApplicationArgs, ...service.AddUnitArg) (application.ID, error)) *MockApplicationServiceCreateApplicationCall {
+func (c *MockApplicationServiceCreateApplicationCall) DoAndReturn(f func(context.Context, string, charm0.Charm, charm.Origin, service.AddApplicationArgs, ...service.AddUnitArg) (application.ID, error)) *MockApplicationServiceCreateApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/bootstrap/bootstrap_mock_test.go
+++ b/internal/bootstrap/bootstrap_mock_test.go
@@ -2142,10 +2142,10 @@ func (m *MockApplicationService) EXPECT() *MockApplicationServiceMockRecorder {
 }
 
 // CreateApplication mocks base method.
-func (m *MockApplicationService) CreateApplication(arg0 context.Context, arg1 string, arg2 charm0.Charm, arg3 service.AddApplicationArgs, arg4 ...service.AddUnitArg) (application.ID, error) {
+func (m *MockApplicationService) CreateApplication(arg0 context.Context, arg1 string, arg2 service.AddApplicationArgs, arg3 ...service.AddUnitArg) (application.ID, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1, arg2, arg3}
-	for _, a := range arg4 {
+	varargs := []any{arg0, arg1, arg2}
+	for _, a := range arg3 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "CreateApplication", varargs...)
@@ -2155,9 +2155,9 @@ func (m *MockApplicationService) CreateApplication(arg0 context.Context, arg1 st
 }
 
 // CreateApplication indicates an expected call of CreateApplication.
-func (mr *MockApplicationServiceMockRecorder) CreateApplication(arg0, arg1, arg2, arg3 any, arg4 ...any) *MockApplicationServiceCreateApplicationCall {
+func (mr *MockApplicationServiceMockRecorder) CreateApplication(arg0, arg1, arg2 any, arg3 ...any) *MockApplicationServiceCreateApplicationCall {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1, arg2, arg3}, arg4...)
+	varargs := append([]any{arg0, arg1, arg2}, arg3...)
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateApplication", reflect.TypeOf((*MockApplicationService)(nil).CreateApplication), varargs...)
 	return &MockApplicationServiceCreateApplicationCall{Call: call}
 }
@@ -2174,13 +2174,13 @@ func (c *MockApplicationServiceCreateApplicationCall) Return(arg0 application.ID
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceCreateApplicationCall) Do(f func(context.Context, string, charm0.Charm, service.AddApplicationArgs, ...service.AddUnitArg) (application.ID, error)) *MockApplicationServiceCreateApplicationCall {
+func (c *MockApplicationServiceCreateApplicationCall) Do(f func(context.Context, string, service.AddApplicationArgs, ...service.AddUnitArg) (application.ID, error)) *MockApplicationServiceCreateApplicationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceCreateApplicationCall) DoAndReturn(f func(context.Context, string, charm0.Charm, service.AddApplicationArgs, ...service.AddUnitArg) (application.ID, error)) *MockApplicationServiceCreateApplicationCall {
+func (c *MockApplicationServiceCreateApplicationCall) DoAndReturn(f func(context.Context, string, service.AddApplicationArgs, ...service.AddUnitArg) (application.ID, error)) *MockApplicationServiceCreateApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/bootstrap/deployer.go
+++ b/internal/bootstrap/deployer.go
@@ -401,8 +401,10 @@ func (b *baseDeployer) AddControllerApplication(ctx context.Context, curl string
 	unitName := bootstrap.ControllerApplicationName + "/0"
 	_, err = b.applicationService.CreateApplication(ctx,
 		bootstrap.ControllerApplicationName,
-		ch,
-		applicationservice.AddApplicationArgs{},
+		applicationservice.AddApplicationArgs{
+			Charm:  ch,
+			Origin: origin,
+		},
 		applicationservice.AddUnitArg{UnitName: &unitName},
 	)
 	if err != nil {

--- a/internal/bootstrap/deployer.go
+++ b/internal/bootstrap/deployer.go
@@ -401,10 +401,8 @@ func (b *baseDeployer) AddControllerApplication(ctx context.Context, curl string
 	unitName := bootstrap.ControllerApplicationName + "/0"
 	_, err = b.applicationService.CreateApplication(ctx,
 		bootstrap.ControllerApplicationName,
-		applicationservice.AddApplicationArgs{
-			Charm:  ch,
-			Origin: origin,
-		},
+		ch, origin,
+		applicationservice.AddApplicationArgs{},
 		applicationservice.AddUnitArg{UnitName: &unitName},
 	)
 	if err != nil {

--- a/internal/bootstrap/deployer_test.go
+++ b/internal/bootstrap/deployer_test.go
@@ -263,8 +263,20 @@ func (s *deployerSuite) TestAddControllerApplication(c *gc.C) {
 	s.stateBackend.EXPECT().Unit(unitName).Return(s.unit, nil)
 	s.applicationService.EXPECT().CreateApplication(
 		gomock.Any(),
-		bootstrap.ControllerApplicationName, s.charm,
-		applicationservice.AddApplicationArgs{}, applicationservice.AddUnitArg{UnitName: &unitName},
+		bootstrap.ControllerApplicationName,
+		applicationservice.AddApplicationArgs{
+			Charm: s.charm,
+			Origin: corecharm.Origin{
+				Source:  "charm-hub",
+				Type:    "charm",
+				Channel: &charm.Channel{},
+				Platform: corecharm.Platform{
+					Architecture: "arm64",
+					OS:           "ubuntu",
+					Channel:      "22.04",
+				},
+			},
+		}, applicationservice.AddUnitArg{UnitName: &unitName},
 	)
 
 	deployer := s.newBaseDeployer(c, cfg)

--- a/internal/bootstrap/deployer_test.go
+++ b/internal/bootstrap/deployer_test.go
@@ -264,19 +264,19 @@ func (s *deployerSuite) TestAddControllerApplication(c *gc.C) {
 	s.applicationService.EXPECT().CreateApplication(
 		gomock.Any(),
 		bootstrap.ControllerApplicationName,
-		applicationservice.AddApplicationArgs{
-			Charm: s.charm,
-			Origin: corecharm.Origin{
-				Source:  "charm-hub",
-				Type:    "charm",
-				Channel: &charm.Channel{},
-				Platform: corecharm.Platform{
-					Architecture: "arm64",
-					OS:           "ubuntu",
-					Channel:      "22.04",
-				},
+		s.charm,
+		corecharm.Origin{
+			Source:  "charm-hub",
+			Type:    "charm",
+			Channel: &charm.Channel{},
+			Platform: corecharm.Platform{
+				Architecture: "arm64",
+				OS:           "ubuntu",
+				Channel:      "22.04",
 			},
-		}, applicationservice.AddUnitArg{UnitName: &unitName},
+		},
+		applicationservice.AddApplicationArgs{},
+		applicationservice.AddUnitArg{UnitName: &unitName},
 	)
 
 	deployer := s.newBaseDeployer(c, cfg)

--- a/internal/bootstrap/service.go
+++ b/internal/bootstrap/service.go
@@ -7,13 +7,15 @@ import (
 	"context"
 
 	coreapplication "github.com/juju/juju/core/application"
+	corecharm "github.com/juju/juju/core/charm"
 	applicationservice "github.com/juju/juju/domain/application/service"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/internal/charm"
 )
 
 // ApplicationService instances create an application.
 type ApplicationService interface {
-	CreateApplication(context.Context, string, applicationservice.AddApplicationArgs, ...applicationservice.AddUnitArg) (coreapplication.ID, error)
+	CreateApplication(context.Context, string, charm.Charm, corecharm.Origin, applicationservice.AddApplicationArgs, ...applicationservice.AddUnitArg) (coreapplication.ID, error)
 }
 
 // ModelConfigService provides access to the model configuration.

--- a/internal/bootstrap/service.go
+++ b/internal/bootstrap/service.go
@@ -9,12 +9,11 @@ import (
 	coreapplication "github.com/juju/juju/core/application"
 	applicationservice "github.com/juju/juju/domain/application/service"
 	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/internal/charm"
 )
 
 // ApplicationService instances create an application.
 type ApplicationService interface {
-	CreateApplication(context.Context, string, charm.Charm, applicationservice.AddApplicationArgs, ...applicationservice.AddUnitArg) (coreapplication.ID, error)
+	CreateApplication(context.Context, string, applicationservice.AddApplicationArgs, ...applicationservice.AddUnitArg) (coreapplication.ID, error)
 }
 
 // ModelConfigService provides access to the model configuration.

--- a/internal/testing/factory/factory.go
+++ b/internal/testing/factory/factory.go
@@ -596,25 +596,23 @@ func (factory *Factory) MakeApplicationReturningPassword(c *gc.C, params *Applic
 				Branch: params.CharmOrigin.Channel.Branch,
 			}
 		}
-		_, err = factory.applicationService.CreateApplication(context.Background(), params.Name, applicationservice.AddApplicationArgs{
-			Charm: params.Charm,
-			Origin: corecharm.Origin{
-				Source:   corecharm.Source(params.CharmOrigin.Source),
-				Type:     params.CharmOrigin.Type,
-				ID:       params.CharmOrigin.ID,
-				Hash:     params.CharmOrigin.Hash,
-				Revision: params.CharmOrigin.Revision,
-				Channel:  channel,
-				Platform: corecharm.Platform{
-					Architecture: params.CharmOrigin.Platform.Architecture,
-					OS:           params.CharmOrigin.Platform.OS,
-					Channel:      params.CharmOrigin.Platform.Channel,
-				},
+		_, err = factory.applicationService.CreateApplication(context.Background(), params.Name, params.Charm, corecharm.Origin{
+			Source:   corecharm.Source(params.CharmOrigin.Source),
+			Type:     params.CharmOrigin.Type,
+			ID:       params.CharmOrigin.ID,
+			Hash:     params.CharmOrigin.Hash,
+			Revision: params.CharmOrigin.Revision,
+			Channel:  channel,
+			Platform: corecharm.Platform{
+				Architecture: params.CharmOrigin.Platform.Architecture,
+				OS:           params.CharmOrigin.Platform.OS,
+				Channel:      params.CharmOrigin.Platform.Channel,
 			},
+		}, applicationservice.AddApplicationArgs{
 			Storage: directives,
 		})
-		c.Assert(err, jc.ErrorIsNil)
 	}
+	c.Assert(err, jc.ErrorIsNil)
 
 	model, err := factory.st.Model()
 	c.Assert(err, jc.ErrorIsNil)

--- a/internal/testing/factory/factory.go
+++ b/internal/testing/factory/factory.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/arch"
+	corecharm "github.com/juju/juju/core/charm"
 	coreconfig "github.com/juju/juju/core/config"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
@@ -587,7 +588,29 @@ func (factory *Factory) MakeApplicationReturningPassword(c *gc.C, params *Applic
 				Count: sc.Count,
 			}
 		}
-		_, err = factory.applicationService.CreateApplication(context.Background(), params.Name, params.Charm, applicationservice.AddApplicationArgs{
+		var channel *charm.Channel
+		if params.CharmOrigin.Channel != nil {
+			channel = &charm.Channel{
+				Track:  params.CharmOrigin.Channel.Track,
+				Risk:   charm.Risk(params.CharmOrigin.Channel.Risk),
+				Branch: params.CharmOrigin.Channel.Branch,
+			}
+		}
+		_, err = factory.applicationService.CreateApplication(context.Background(), params.Name, applicationservice.AddApplicationArgs{
+			Charm: params.Charm,
+			Origin: corecharm.Origin{
+				Source:   corecharm.Source(params.CharmOrigin.Source),
+				Type:     params.CharmOrigin.Type,
+				ID:       params.CharmOrigin.ID,
+				Hash:     params.CharmOrigin.Hash,
+				Revision: params.CharmOrigin.Revision,
+				Channel:  channel,
+				Platform: corecharm.Platform{
+					Architecture: params.CharmOrigin.Platform.Architecture,
+					OS:           params.CharmOrigin.Platform.OS,
+					Channel:      params.CharmOrigin.Platform.Channel,
+				},
+			},
 			Storage: directives,
 		})
 		c.Assert(err, jc.ErrorIsNil)

--- a/internal/worker/bootstrap/bootstrap_mock_test.go
+++ b/internal/worker/bootstrap/bootstrap_mock_test.go
@@ -17,6 +17,7 @@ import (
 	cloud "github.com/juju/juju/cloud"
 	controller "github.com/juju/juju/controller"
 	application "github.com/juju/juju/core/application"
+	charm "github.com/juju/juju/core/charm"
 	network "github.com/juju/juju/core/network"
 	objectstore "github.com/juju/juju/core/objectstore"
 	user "github.com/juju/juju/core/user"
@@ -25,7 +26,7 @@ import (
 	service1 "github.com/juju/juju/domain/storage/service"
 	config "github.com/juju/juju/environs/config"
 	bootstrap "github.com/juju/juju/internal/bootstrap"
-	charm "github.com/juju/juju/internal/charm"
+	charm0 "github.com/juju/juju/internal/charm"
 	services "github.com/juju/juju/internal/charm/services"
 	storage "github.com/juju/juju/internal/storage"
 	state "github.com/juju/juju/state"
@@ -514,10 +515,10 @@ func (c *MockSystemStatePrepareCharmUploadCall) DoAndReturn(f func(string) (serv
 }
 
 // PrepareLocalCharmUpload mocks base method.
-func (m *MockSystemState) PrepareLocalCharmUpload(arg0 string) (*charm.URL, error) {
+func (m *MockSystemState) PrepareLocalCharmUpload(arg0 string) (*charm0.URL, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PrepareLocalCharmUpload", arg0)
-	ret0, _ := ret[0].(*charm.URL)
+	ret0, _ := ret[0].(*charm0.URL)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -535,19 +536,19 @@ type MockSystemStatePrepareLocalCharmUploadCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockSystemStatePrepareLocalCharmUploadCall) Return(arg0 *charm.URL, arg1 error) *MockSystemStatePrepareLocalCharmUploadCall {
+func (c *MockSystemStatePrepareLocalCharmUploadCall) Return(arg0 *charm0.URL, arg1 error) *MockSystemStatePrepareLocalCharmUploadCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSystemStatePrepareLocalCharmUploadCall) Do(f func(string) (*charm.URL, error)) *MockSystemStatePrepareLocalCharmUploadCall {
+func (c *MockSystemStatePrepareLocalCharmUploadCall) Do(f func(string) (*charm0.URL, error)) *MockSystemStatePrepareLocalCharmUploadCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSystemStatePrepareLocalCharmUploadCall) DoAndReturn(f func(string) (*charm.URL, error)) *MockSystemStatePrepareLocalCharmUploadCall {
+func (c *MockSystemStatePrepareLocalCharmUploadCall) DoAndReturn(f func(string) (*charm0.URL, error)) *MockSystemStatePrepareLocalCharmUploadCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -955,10 +956,10 @@ func (m *MockApplicationService) EXPECT() *MockApplicationServiceMockRecorder {
 }
 
 // CreateApplication mocks base method.
-func (m *MockApplicationService) CreateApplication(arg0 context.Context, arg1 string, arg2 service0.AddApplicationArgs, arg3 ...service0.AddUnitArg) (application.ID, error) {
+func (m *MockApplicationService) CreateApplication(arg0 context.Context, arg1 string, arg2 charm0.Charm, arg3 charm.Origin, arg4 service0.AddApplicationArgs, arg5 ...service0.AddUnitArg) (application.ID, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1, arg2}
-	for _, a := range arg3 {
+	varargs := []any{arg0, arg1, arg2, arg3, arg4}
+	for _, a := range arg5 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "CreateApplication", varargs...)
@@ -968,9 +969,9 @@ func (m *MockApplicationService) CreateApplication(arg0 context.Context, arg1 st
 }
 
 // CreateApplication indicates an expected call of CreateApplication.
-func (mr *MockApplicationServiceMockRecorder) CreateApplication(arg0, arg1, arg2 any, arg3 ...any) *MockApplicationServiceCreateApplicationCall {
+func (mr *MockApplicationServiceMockRecorder) CreateApplication(arg0, arg1, arg2, arg3, arg4 any, arg5 ...any) *MockApplicationServiceCreateApplicationCall {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1, arg2}, arg3...)
+	varargs := append([]any{arg0, arg1, arg2, arg3, arg4}, arg5...)
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateApplication", reflect.TypeOf((*MockApplicationService)(nil).CreateApplication), varargs...)
 	return &MockApplicationServiceCreateApplicationCall{Call: call}
 }
@@ -987,13 +988,13 @@ func (c *MockApplicationServiceCreateApplicationCall) Return(arg0 application.ID
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceCreateApplicationCall) Do(f func(context.Context, string, service0.AddApplicationArgs, ...service0.AddUnitArg) (application.ID, error)) *MockApplicationServiceCreateApplicationCall {
+func (c *MockApplicationServiceCreateApplicationCall) Do(f func(context.Context, string, charm0.Charm, charm.Origin, service0.AddApplicationArgs, ...service0.AddUnitArg) (application.ID, error)) *MockApplicationServiceCreateApplicationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceCreateApplicationCall) DoAndReturn(f func(context.Context, string, service0.AddApplicationArgs, ...service0.AddUnitArg) (application.ID, error)) *MockApplicationServiceCreateApplicationCall {
+func (c *MockApplicationServiceCreateApplicationCall) DoAndReturn(f func(context.Context, string, charm0.Charm, charm.Origin, service0.AddApplicationArgs, ...service0.AddUnitArg) (application.ID, error)) *MockApplicationServiceCreateApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/bootstrap/bootstrap_mock_test.go
+++ b/internal/worker/bootstrap/bootstrap_mock_test.go
@@ -955,10 +955,10 @@ func (m *MockApplicationService) EXPECT() *MockApplicationServiceMockRecorder {
 }
 
 // CreateApplication mocks base method.
-func (m *MockApplicationService) CreateApplication(arg0 context.Context, arg1 string, arg2 charm.Charm, arg3 service0.AddApplicationArgs, arg4 ...service0.AddUnitArg) (application.ID, error) {
+func (m *MockApplicationService) CreateApplication(arg0 context.Context, arg1 string, arg2 service0.AddApplicationArgs, arg3 ...service0.AddUnitArg) (application.ID, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1, arg2, arg3}
-	for _, a := range arg4 {
+	varargs := []any{arg0, arg1, arg2}
+	for _, a := range arg3 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "CreateApplication", varargs...)
@@ -968,9 +968,9 @@ func (m *MockApplicationService) CreateApplication(arg0 context.Context, arg1 st
 }
 
 // CreateApplication indicates an expected call of CreateApplication.
-func (mr *MockApplicationServiceMockRecorder) CreateApplication(arg0, arg1, arg2, arg3 any, arg4 ...any) *MockApplicationServiceCreateApplicationCall {
+func (mr *MockApplicationServiceMockRecorder) CreateApplication(arg0, arg1, arg2 any, arg3 ...any) *MockApplicationServiceCreateApplicationCall {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1, arg2, arg3}, arg4...)
+	varargs := append([]any{arg0, arg1, arg2}, arg3...)
 	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateApplication", reflect.TypeOf((*MockApplicationService)(nil).CreateApplication), varargs...)
 	return &MockApplicationServiceCreateApplicationCall{Call: call}
 }
@@ -987,13 +987,13 @@ func (c *MockApplicationServiceCreateApplicationCall) Return(arg0 application.ID
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceCreateApplicationCall) Do(f func(context.Context, string, charm.Charm, service0.AddApplicationArgs, ...service0.AddUnitArg) (application.ID, error)) *MockApplicationServiceCreateApplicationCall {
+func (c *MockApplicationServiceCreateApplicationCall) Do(f func(context.Context, string, service0.AddApplicationArgs, ...service0.AddUnitArg) (application.ID, error)) *MockApplicationServiceCreateApplicationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceCreateApplicationCall) DoAndReturn(f func(context.Context, string, charm.Charm, service0.AddApplicationArgs, ...service0.AddUnitArg) (application.ID, error)) *MockApplicationServiceCreateApplicationCall {
+func (c *MockApplicationServiceCreateApplicationCall) DoAndReturn(f func(context.Context, string, service0.AddApplicationArgs, ...service0.AddUnitArg) (application.ID, error)) *MockApplicationServiceCreateApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/bootstrap/service.go
+++ b/internal/worker/bootstrap/service.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/controller"
 	coreapplication "github.com/juju/juju/core/application"
+	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/user"
@@ -16,12 +17,13 @@ import (
 	applicationservice "github.com/juju/juju/domain/application/service"
 	storageservice "github.com/juju/juju/domain/storage/service"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/internal/charm"
 	"github.com/juju/juju/internal/storage"
 )
 
 // ApplicationService instances save an application to dqlite state.
 type ApplicationService interface {
-	CreateApplication(ctx context.Context, name string, params applicationservice.AddApplicationArgs, units ...applicationservice.AddUnitArg) (coreapplication.ID, error)
+	CreateApplication(ctx context.Context, name string, charm charm.Charm, origin corecharm.Origin, params applicationservice.AddApplicationArgs, units ...applicationservice.AddUnitArg) (coreapplication.ID, error)
 }
 
 // BakeryConfigService describes the service used to initialise the

--- a/internal/worker/bootstrap/service.go
+++ b/internal/worker/bootstrap/service.go
@@ -16,13 +16,12 @@ import (
 	applicationservice "github.com/juju/juju/domain/application/service"
 	storageservice "github.com/juju/juju/domain/storage/service"
 	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/internal/charm"
 	"github.com/juju/juju/internal/storage"
 )
 
 // ApplicationService instances save an application to dqlite state.
 type ApplicationService interface {
-	CreateApplication(ctx context.Context, name string, charm charm.Charm, params applicationservice.AddApplicationArgs, units ...applicationservice.AddUnitArg) (coreapplication.ID, error)
+	CreateApplication(ctx context.Context, name string, params applicationservice.AddApplicationArgs, units ...applicationservice.AddUnitArg) (coreapplication.ID, error)
 }
 
 // BakeryConfigService describes the service used to initialise the

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -4,7 +4,6 @@
 package state
 
 import (
-	"context"
 	"encoding/hex"
 	"fmt"
 	"reflect"
@@ -29,7 +28,6 @@ import (
 	"github.com/juju/juju/core/payloads"
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/core/status"
-	applicationservice "github.com/juju/juju/domain/application/service"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/internal/charm"
 	internallogger "github.com/juju/juju/internal/logger"
@@ -38,16 +36,6 @@ import (
 	"github.com/juju/juju/internal/tools"
 	"github.com/juju/juju/state/cloudimagemetadata"
 )
-
-// MachineService instances save a machine to dqlite state.
-type MachineService interface {
-	CreateMachine(context.Context, string) error
-}
-
-// ApplicationService instances save an application to dqlite state.
-type ApplicationService interface {
-	CreateApplication(ctx context.Context, name string, charm charm.Charm, params applicationservice.AddApplicationArgs, units ...applicationservice.AddUnitArg) error
-}
 
 // Import the database agnostic model representation into the database.
 func (ctrl *Controller) Import(


### PR DESCRIPTION
This PR adds to the skeleton app and unit creation in dqlite to wire up additional attributes for app and unit creation:
- platform
- channel
- password hash
- cloud container

The first 3 are wired all the way through to the db. The cloud container is not yet implemented in state because there's no DDL yet for recording address information.
Also added as params but not yet used in the service layer are the scale attributes for upserting caas units.

The CreateApplication method was tweaked so that the charm param is moved to the args struct - it sits beside the charm origin. The key param "name" is left separate and moving forward we can add the additional params to the arg struct.

The import code to deal with charm origin was based on the old mongo code, minus the no longer needed compatibility bollocks. Plus charm url is now treated as opaque and attributes are source exclusively from the origin not the url.

In the state layer, cleanup was done to stop using all the sqlair.M{} structs and instead use bespoke structs with attributes.

Some clean up of the DDL was done - there was a table for unit platform but this isn't needed - all units use the same platform as for the parent app. We were also missing a join table to record principal unit for subordinates, so this was added.
As a driveby, machine_tools is renamed to machine_agent since we long ago stopped using "tools". Same with unit tools.

## QA steps

bootstrap 3.6 controller, add a model with a local and ch charm
migrate to a 4.0 controller 
deploy another charm 

## Links

**Jira card:** [JUJU-6510](https://warthogs.atlassian.net/browse/JUJU-6510)



[JUJU-6510]: https://warthogs.atlassian.net/browse/JUJU-6510?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ