### PR TITLE
fix: fix managed identity on azure

### DIFF
--- a/domain/schema/controller/sql/0005-cloud.sql
+++ b/domain/schema/controller/sql/0005-cloud.sql
@@ -47,7 +47,8 @@ INSERT INTO auth_type VALUES
 (9, 'empty'),
 (10, 'certificate'),
 (11, 'oauth2withcert'),
-(12, 'service-principal-secret');
+(12, 'service-principal-secret'),
+(13, 'managed-identity');
 
 CREATE TABLE cloud (
     uuid TEXT NOT NULL PRIMARY KEY,


### PR DESCRIPTION
The cloud auth type lookup table was missing an entry for "managed-identity".

## QA steps

`juju bootstrap azure --constraints="instance-role=auto"`

## Links

**Jira card:** [JUJU-6511](https://warthogs.atlassian.net/browse/JUJU-6511)



[JUJU-6511]: https://warthogs.atlassian.net/browse/JUJU-6511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ