### PR TITLE
fix: remove debug flag

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -331,7 +331,7 @@ parts:
             LZ4_CFLAGS="-I${SNAPCRAFT_STAGE}/liblz4/lib" \
             LZ4_LIBS="-L${SNAPCRAFT_STAGE}/liblz4/lib" \
             SQLITE_CFLAGS="-I${SNAPCRAFT_STAGE}/libsqlite3" \
-            ./configure --disable-shared --enable-debug --enable-build-raft
+            ./configure --disable-shared --enable-build-raft
       make
 
       mkdir -p $SNAPCRAFT_PART_INSTALL/libdqlite


### PR DESCRIPTION
Whilst testing the segfault issue on arm64 with dqlite, we enabled debug mode, to display better backtraces and stack unwinding.

<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://docs.google.com/document/d/1SYUo9G7qZ_jdoVXpUVamS5VCgHmtZ0QA-wZxKoMS-C0 
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
$ juju bootstrap lxd test
```



