### PR TITLE
fix(test): intermittent failure in serviceSuite.TestListAllModelSummaries

### DIFF
--- a/domain/model/service/service_test.go
+++ b/domain/model/service/service_test.go
@@ -875,7 +875,7 @@ func (s *serviceSuite) TestListAllModelSummaries(c *gc.C) {
 	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder(), loggertesting.WrapCheckLog(c))
 	models, err := svc.ListAllModelSummaries(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(models, gc.DeepEquals, []coremodel.ModelSummary{{
+	c.Check(models, jc.SameContents, []coremodel.ModelSummary{{
 		Name:           "my-awesome-model",
 		AgentVersion:   jujuversion.Current,
 		UUID:           uuid1,


### PR DESCRIPTION
Lists of 2 items being compared for the test are not always in the same order due to one starting in a map. Use SameContents to compare instead of DeepEquals which requires the same order.

## QA steps

Allow the [stress test from wiki](https://github.com/juju/juju/wiki/Stress-Test) to run 100 times and see no error

```
$ (cd domain/model/service ; ~/stress.bash)
```



