### PR TITLE
feat: client facade v8

### DIFF
--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -51,7 +51,7 @@ var facadeVersions = facades.FacadeVersions{
 	"CharmRevisionUpdater":         {2},
 	"Charms":                       {5, 6, 7},
 	"Cleaner":                      {2},
-	"Client":                       {6, 7},
+	"Client":                       {6, 7, 8},
 	"Cloud":                        {7},
 	"Controller":                   {11, 12},
 	"CredentialManager":            {1},

--- a/apiserver/facades/client/client/backend.go
+++ b/apiserver/facades/client/client/backend.go
@@ -103,12 +103,6 @@ type Model interface {
 	Status() (status.StatusInfo, error)
 }
 
-// Pool contains the StatePool functionality used in this package.
-type Pool interface {
-	GetModel(string) (*state.Model, func(), error)
-	SystemState() (*state.State, error)
-}
-
 // Application represents a state.Application.
 type Application interface {
 	StatusHistory(status.StatusHistoryFilter) ([]status.StatusInfo, error)
@@ -165,22 +159,6 @@ func (s *stateShim) Unit(name string) (Unit, error) {
 func (s *stateShim) AllApplicationOffers() ([]*crossmodel.ApplicationOffer, error) {
 	offers := state.NewApplicationOffers(s.State)
 	return offers.AllApplicationOffers()
-}
-
-type poolShim struct {
-	pool *state.StatePool
-}
-
-func (p *poolShim) SystemState() (*state.State, error) {
-	return p.pool.SystemState()
-}
-
-func (p *poolShim) GetModel(uuid string) (*state.Model, func(), error) {
-	model, ph, err := p.pool.GetModel(uuid)
-	if err != nil {
-		return nil, nil, errors.Trace(err)
-	}
-	return model, func() { ph.Release() }, nil
 }
 
 func (s stateShim) ModelConfig() (*config.Config, error) {

--- a/apiserver/facades/client/client/client.go
+++ b/apiserver/facades/client/client/client.go
@@ -24,7 +24,6 @@ import (
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/docker"
 	"github.com/juju/juju/docker/registry"
-	"github.com/juju/juju/environs/context"
 	envtools "github.com/juju/juju/environs/tools"
 	"github.com/juju/juju/feature"
 	"github.com/juju/juju/rpc/params"
@@ -35,45 +34,41 @@ import (
 
 var logger = loggo.GetLogger("juju.apiserver.client")
 
-type API struct {
+// Client serves client-specific API methods.
+type Client struct {
 	stateAccessor   Backend
-	pool            Pool
 	storageAccessor StorageInterface
 	auth            facade.Authorizer
-	resources       facade.Resources
 	presence        facade.Presence
 
-	multiwatcherFactory multiwatcher.Factory
-
-	toolsFinder      common.ToolsFinder
 	leadershipReader leadership.Reader
 	modelCache       *cache.Model
+}
+
+// ClientV7 serves the (v7) client-specific API methods.
+type ClientV7 struct {
+	*Client
+	registryAPIFunc     func(repoDetails docker.ImageRepoDetails) (registry.Registry, error)
+	resources           facade.Resources
+	multiwatcherFactory multiwatcher.Factory
+	toolsFinder         common.ToolsFinder
+}
+
+// ClientV6 serves the (v6) client-specific API methods.
+type ClientV6 struct {
+	*ClientV7
 }
 
 // TODO(wallyworld) - remove this method
 // state returns a state.State instance for this API.
 // Until all code is refactored to use interfaces, we
 // need this helper to keep older code happy.
-func (api *API) state() *state.State {
-	return api.stateAccessor.(*stateShim).State
-}
-
-// Client serves client-specific API methods.
-type Client struct {
-	api             *API
-	newEnviron      common.NewEnvironFunc
-	check           *common.BlockChecker
-	callContext     context.ProviderCallContext
-	registryAPIFunc func(repoDetails docker.ImageRepoDetails) (registry.Registry, error)
-}
-
-// ClientV6 serves the (v6) client-specific API methods.
-type ClientV6 struct {
-	*Client
+func (c *Client) state() *state.State {
+	return c.stateAccessor.(*stateShim).State
 }
 
 func (c *Client) checkCanRead() error {
-	err := c.api.auth.HasPermission(permission.SuperuserAccess, c.api.stateAccessor.ControllerTag())
+	err := c.auth.HasPermission(permission.SuperuserAccess, c.stateAccessor.ControllerTag())
 	if err != nil && !errors.Is(err, authentication.ErrorEntityMissingPermission) {
 		return errors.Trace(err)
 	}
@@ -82,11 +77,11 @@ func (c *Client) checkCanRead() error {
 		return nil
 	}
 
-	return c.api.auth.HasPermission(permission.ReadAccess, c.api.stateAccessor.ModelTag())
+	return c.auth.HasPermission(permission.ReadAccess, c.stateAccessor.ModelTag())
 }
 
 func (c *Client) checkCanWrite() error {
-	err := c.api.auth.HasPermission(permission.SuperuserAccess, c.api.stateAccessor.ControllerTag())
+	err := c.auth.HasPermission(permission.SuperuserAccess, c.stateAccessor.ControllerTag())
 	if err != nil && !errors.Is(err, authentication.ErrorEntityMissingPermission) {
 		return errors.Trace(err)
 	}
@@ -95,11 +90,11 @@ func (c *Client) checkCanWrite() error {
 		return nil
 	}
 
-	return c.api.auth.HasPermission(permission.WriteAccess, c.api.stateAccessor.ModelTag())
+	return c.auth.HasPermission(permission.WriteAccess, c.stateAccessor.ModelTag())
 }
 
 func (c *Client) checkIsAdmin() error {
-	err := c.api.auth.HasPermission(permission.SuperuserAccess, c.api.stateAccessor.ControllerTag())
+	err := c.auth.HasPermission(permission.SuperuserAccess, c.stateAccessor.ControllerTag())
 	if err != nil && !errors.Is(err, authentication.ErrorEntityMissingPermission) {
 		return errors.Trace(err)
 	}
@@ -108,13 +103,13 @@ func (c *Client) checkIsAdmin() error {
 		return nil
 	}
 
-	return c.api.auth.HasPermission(permission.AdminAccess, c.api.stateAccessor.ModelTag())
+	return c.auth.HasPermission(permission.AdminAccess, c.stateAccessor.ModelTag())
 }
 
-// NewFacade creates a Client facade to handle API requests.
+// NewFacadeV7 creates a ClientV7 facade to handle API requests.
 // Changes:
 // - FindTools deals with CAAS models now;
-func NewFacade(ctx facade.Context) (*Client, error) {
+func NewFacadeV7(ctx facade.Context) (*ClientV7, error) {
 	st := ctx.State()
 	resources := ctx.Resources()
 	authorizer := ctx.Auth()
@@ -136,7 +131,6 @@ func NewFacade(ctx facade.Context) (*Client, error) {
 	}
 	urlGetter := common.NewToolsURLGetter(modelUUID, systemState)
 	toolsFinder := common.NewToolsFinder(configGetter, st, urlGetter, newEnviron)
-	blockChecker := common.NewBlockChecker(st)
 	leadershipReader, err := ctx.LeadershipReader(modelUUID)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -152,17 +146,13 @@ func NewFacade(ctx facade.Context) (*Client, error) {
 		return nil, errors.Trace(err)
 	}
 
-	return NewClient(
+	return NewClientV7(
 		&stateShim{st, model, nil},
-		&poolShim{ctx.StatePool()},
 		storageAccessor,
 		resources,
 		authorizer,
 		presence,
 		toolsFinder,
-		newEnviron,
-		blockChecker,
-		context.CallContext(st),
 		leadershipReader,
 		modelCache,
 		factory,
@@ -170,63 +160,55 @@ func NewFacade(ctx facade.Context) (*Client, error) {
 	)
 }
 
-// NewClient creates a new instance of the Client Facade.
-func NewClient(
+// NewClientV7 creates a new instance of the ClientV7 Facade.
+func NewClientV7(
 	backend Backend,
-	pool Pool,
 	storageAccessor StorageInterface,
 	resources facade.Resources,
 	authorizer facade.Authorizer,
 	presence facade.Presence,
 	toolsFinder common.ToolsFinder,
-	newEnviron common.NewEnvironFunc,
-	blockChecker *common.BlockChecker,
-	callCtx context.ProviderCallContext,
 	leadershipReader leadership.Reader,
 	modelCache *cache.Model,
 	factory multiwatcher.Factory,
 	registryAPIFunc func(docker.ImageRepoDetails) (registry.Registry, error),
-) (*Client, error) {
+) (*ClientV7, error) {
 	if !authorizer.AuthClient() {
 		return nil, apiservererrors.ErrPerm
 	}
-	client := &Client{
-		api: &API{
-			stateAccessor:       backend,
-			pool:                pool,
-			storageAccessor:     storageAccessor,
-			auth:                authorizer,
-			resources:           resources,
-			presence:            presence,
-			toolsFinder:         toolsFinder,
-			leadershipReader:    leadershipReader,
-			modelCache:          modelCache,
-			multiwatcherFactory: factory,
+
+	return &ClientV7{
+		Client: &Client{
+			stateAccessor:    backend,
+			storageAccessor:  storageAccessor,
+			auth:             authorizer,
+			presence:         presence,
+			leadershipReader: leadershipReader,
+			modelCache:       modelCache,
 		},
-		newEnviron:      newEnviron,
-		check:           blockChecker,
-		callContext:     callCtx,
-		registryAPIFunc: registryAPIFunc,
-	}
-	return client, nil
+		registryAPIFunc:     registryAPIFunc,
+		resources:           resources,
+		multiwatcherFactory: factory,
+		toolsFinder:         toolsFinder,
+	}, nil
 }
 
 // WatchAll initiates a watcher for entities in the connected model.
-func (c *Client) WatchAll() (params.AllWatcherId, error) {
+func (c *ClientV7) WatchAll() (params.AllWatcherId, error) {
 	if err := c.checkCanRead(); err != nil {
 		return params.AllWatcherId{}, err
 	}
-	isAdmin, err := common.HasModelAdmin(c.api.auth, c.api.stateAccessor.ControllerTag(), names.NewModelTag(c.api.state().ModelUUID()))
+	isAdmin, err := common.HasModelAdmin(c.auth, c.stateAccessor.ControllerTag(), names.NewModelTag(c.state().ModelUUID()))
 	if err != nil {
 		return params.AllWatcherId{}, errors.Trace(err)
 	}
-	modelUUID := c.api.stateAccessor.ModelUUID()
-	w := c.api.multiwatcherFactory.WatchModel(modelUUID)
+	modelUUID := c.stateAccessor.ModelUUID()
+	w := c.multiwatcherFactory.WatchModel(modelUUID)
 	if !isAdmin {
 		w = &stripApplicationOffers{w}
 	}
 	return params.AllWatcherId{
-		AllWatcherId: c.api.resources.Register(w),
+		AllWatcherId: c.resources.Register(w),
 	}, nil
 }
 
@@ -258,16 +240,16 @@ func (s *stripApplicationOffers) Next() ([]multiwatcher.Delta, error) {
 
 // FindTools returns a List containing all tools matching the given parameters.
 // TODO(juju 3.1) - remove, used by 2.9 client only
-func (c *Client) FindTools(args params.FindToolsParams) (params.FindToolsResult, error) {
+func (c *ClientV7) FindTools(args params.FindToolsParams) (params.FindToolsResult, error) {
 	if err := c.checkCanWrite(); err != nil {
 		return params.FindToolsResult{}, err
 	}
-	model, err := c.api.stateAccessor.Model()
+	model, err := c.stateAccessor.Model()
 	if err != nil {
 		return params.FindToolsResult{}, errors.Trace(err)
 	}
 
-	list, err := c.api.toolsFinder.FindAgents(common.FindAgentsParams{
+	list, err := c.toolsFinder.FindAgents(common.FindAgentsParams{
 		Number:       args.Number,
 		MajorVersion: args.MajorVersion,
 		Arch:         args.Arch,
@@ -302,9 +284,9 @@ func (c *Client) FindTools(args params.FindToolsParams) (params.FindToolsResult,
 	return c.toolVersionsForCAAS(args, streamsVersions, currentVersion)
 }
 
-func (c *Client) toolVersionsForCAAS(args params.FindToolsParams, streamsVersions set.Strings, current version.Number) (params.FindToolsResult, error) {
+func (c *ClientV7) toolVersionsForCAAS(args params.FindToolsParams, streamsVersions set.Strings, current version.Number) (params.FindToolsResult, error) {
 	result := params.FindToolsResult{}
-	controllerCfg, err := c.api.stateAccessor.ControllerConfig()
+	controllerCfg, err := c.stateAccessor.ControllerConfig()
 	if err != nil {
 		return result, errors.Trace(err)
 	}

--- a/apiserver/facades/client/client/client.go
+++ b/apiserver/facades/client/client/client.go
@@ -41,17 +41,17 @@ type Client struct {
 	auth            facade.Authorizer
 	presence        facade.Presence
 
-	leadershipReader leadership.Reader
-	modelCache       *cache.Model
+	leadershipReader    leadership.Reader
+	modelCache          *cache.Model
+	multiwatcherFactory multiwatcher.Factory
+	resources           facade.Resources
 }
 
 // ClientV7 serves the (v7) client-specific API methods.
 type ClientV7 struct {
 	*Client
-	registryAPIFunc     func(repoDetails docker.ImageRepoDetails) (registry.Registry, error)
-	resources           facade.Resources
-	multiwatcherFactory multiwatcher.Factory
-	toolsFinder         common.ToolsFinder
+	registryAPIFunc func(repoDetails docker.ImageRepoDetails) (registry.Registry, error)
+	toolsFinder     common.ToolsFinder
 }
 
 // ClientV6 serves the (v6) client-specific API methods.
@@ -179,22 +179,22 @@ func NewClientV7(
 
 	return &ClientV7{
 		Client: &Client{
-			stateAccessor:    backend,
-			storageAccessor:  storageAccessor,
-			auth:             authorizer,
-			presence:         presence,
-			leadershipReader: leadershipReader,
-			modelCache:       modelCache,
+			stateAccessor:       backend,
+			storageAccessor:     storageAccessor,
+			auth:                authorizer,
+			presence:            presence,
+			leadershipReader:    leadershipReader,
+			modelCache:          modelCache,
+			resources:           resources,
+			multiwatcherFactory: factory,
 		},
-		registryAPIFunc:     registryAPIFunc,
-		resources:           resources,
-		multiwatcherFactory: factory,
-		toolsFinder:         toolsFinder,
+		registryAPIFunc: registryAPIFunc,
+		toolsFinder:     toolsFinder,
 	}, nil
 }
 
 // WatchAll initiates a watcher for entities in the connected model.
-func (c *ClientV7) WatchAll() (params.AllWatcherId, error) {
+func (c *Client) WatchAll() (params.AllWatcherId, error) {
 	if err := c.checkCanRead(); err != nil {
 		return params.AllWatcherId{}, err
 	}

--- a/apiserver/facades/client/client/client_test.go
+++ b/apiserver/facades/client/client/client_test.go
@@ -82,9 +82,6 @@ func (s *serverSuite) authClientForState(c *gc.C, st *state.State, auth facade.A
 	s.newEnviron = func() (environs.BootstrapEnviron, error) {
 		return environs.GetEnviron(stateenvirons.EnvironConfigGetter{Model: m}, environs.New)
 	}
-	client.SetNewEnviron(apiserverClient, func() (environs.BootstrapEnviron, error) {
-		return s.newEnviron()
-	})
 	return apiserverClient
 }
 
@@ -463,11 +460,16 @@ func (s *findToolsSuite) TestFindToolsIAAS(c *gc.C) {
 		model.EXPECT().Type().Return(state.ModelTypeIAAS),
 	)
 
-	api, err := client.NewClient(
-		backend, nil,
-		nil, nil,
-		authorizer, nil, toolsFinder,
-		nil, nil, nil, nil, nil, nil,
+	api, err := client.NewClientV7(
+		backend,
+		nil,
+		nil,
+		authorizer,
+		nil,
+		toolsFinder,
+		nil,
+		nil,
+		nil,
 		func(docker.ImageRepoDetails) (registry.Registry, error) {
 			return registryProvider, nil
 		},
@@ -553,11 +555,16 @@ func (s *findToolsSuite) assertFindToolsCAASReleased(c *gc.C, wantArch, expectAr
 		registryProvider.EXPECT().Close().Return(nil),
 	)
 
-	api, err := client.NewClient(
-		backend, nil,
-		nil, nil,
-		authorizer, nil, toolsFinder,
-		nil, nil, nil, nil, nil, nil,
+	api, err := client.NewClientV7(
+		backend,
+		nil,
+		nil,
+		authorizer,
+		nil,
+		toolsFinder,
+		nil,
+		nil,
+		nil,
 		func(repo docker.ImageRepoDetails) (registry.Registry, error) {
 			c.Assert(repo, gc.DeepEquals, docker.ImageRepoDetails{
 				Repository:    "test-account",
@@ -637,11 +644,16 @@ func (s *findToolsSuite) TestFindToolsCAASNonReleased(c *gc.C) {
 		registryProvider.EXPECT().Close().Return(nil),
 	)
 
-	api, err := client.NewClient(
-		backend, nil,
-		nil, nil,
-		authorizer, nil, toolsFinder,
-		nil, nil, nil, nil, nil, nil,
+	api, err := client.NewClientV7(
+		backend,
+		nil,
+		nil,
+		authorizer,
+		nil,
+		toolsFinder,
+		nil,
+		nil,
+		nil,
 		func(repo docker.ImageRepoDetails) (registry.Registry, error) {
 			c.Assert(repo, gc.DeepEquals, docker.ImageRepoDetails{
 				Repository:    "test-account",

--- a/apiserver/facades/client/client/export_test.go
+++ b/apiserver/facades/client/client/export_test.go
@@ -3,16 +3,9 @@
 
 package client
 
-import (
-	"github.com/juju/juju/environs"
-)
-
 // Filtering exports
 var (
 	MatchPortRanges = matchPortRanges
 	MatchSubnet     = matchSubnet
+	NewFacade       = newFacadeV8
 )
-
-func SetNewEnviron(c *Client, newEnviron func() (environs.BootstrapEnviron, error)) {
-	c.newEnviron = newEnviron
-}

--- a/apiserver/facades/client/client/register.go
+++ b/apiserver/facades/client/client/register.go
@@ -47,7 +47,9 @@ func newFacadeV8(ctx facade.Context) (*Client, error) {
 	}
 
 	st := ctx.State()
+	resources := ctx.Resources()
 	presence := ctx.Presence()
+	factory := ctx.MultiwatcherFactory()
 
 	model, err := st.Model()
 	if err != nil {
@@ -71,11 +73,13 @@ func newFacadeV8(ctx facade.Context) (*Client, error) {
 	}
 
 	return &Client{
-		stateAccessor:    &stateShim{st, model, nil},
-		storageAccessor:  storageAccessor,
-		auth:             authorizer,
-		presence:         presence,
-		leadershipReader: leadershipReader,
-		modelCache:       modelCache,
+		stateAccessor:       &stateShim{st, model, nil},
+		storageAccessor:     storageAccessor,
+		auth:                authorizer,
+		presence:            presence,
+		leadershipReader:    leadershipReader,
+		modelCache:          modelCache,
+		resources:           resources,
+		multiwatcherFactory: factory,
 	}, nil
 }

--- a/apiserver/facades/client/client/register.go
+++ b/apiserver/facades/client/client/register.go
@@ -6,6 +6,9 @@ package client
 import (
 	"reflect"
 
+	"github.com/juju/errors"
+
+	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facade"
 )
 
@@ -16,9 +19,13 @@ func Register(registry facade.FacadeRegistry) {
 	}, reflect.TypeOf((*ClientV6)(nil)))
 	registry.MustRegister("Client", 7, func(ctx facade.Context) (facade.Facade, error) {
 		return newFacadeV7(ctx)
+	}, reflect.TypeOf((*ClientV7)(nil)))
+	registry.MustRegister("Client", 8, func(ctx facade.Context) (facade.Facade, error) {
+		return newFacadeV8(ctx)
 	}, reflect.TypeOf((*Client)(nil)))
 }
 
+// newFacadeV6 returns a new ClientV6 facade.
 func newFacadeV6(ctx facade.Context) (*ClientV6, error) {
 	client, err := newFacadeV7(ctx)
 	if err != nil {
@@ -27,6 +34,48 @@ func newFacadeV6(ctx facade.Context) (*ClientV6, error) {
 	return &ClientV6{client}, nil
 }
 
-func newFacadeV7(ctx facade.Context) (*Client, error) {
-	return NewFacade(ctx)
+// newFacadeV7 returns a new ClientV7 facade.
+func newFacadeV7(ctx facade.Context) (*ClientV7, error) {
+	return NewFacadeV7(ctx)
+}
+
+// newFacadeV8 returns a new Client facade (v8).
+func newFacadeV8(ctx facade.Context) (*Client, error) {
+	authorizer := ctx.Auth()
+	if !authorizer.AuthClient() {
+		return nil, apiservererrors.ErrPerm
+	}
+
+	st := ctx.State()
+	presence := ctx.Presence()
+
+	model, err := st.Model()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	modelUUID := model.UUID()
+
+	leadershipReader, err := ctx.LeadershipReader(modelUUID)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	modelCache, err := ctx.CachedModel(modelUUID)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	storageAccessor, err := getStorageState(st)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	return &Client{
+		stateAccessor:    &stateShim{st, model, nil},
+		storageAccessor:  storageAccessor,
+		auth:             authorizer,
+		presence:         presence,
+		leadershipReader: leadershipReader,
+		modelCache:       modelCache,
+	}, nil
 }

--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -65,9 +65,9 @@ func (c *Client) applicationStatusHistory(appTag names.ApplicationTag, filter st
 		err error
 	)
 	if kind == status.KindApplication {
-		app, err = c.api.stateAccessor.Application(appTag.Name)
+		app, err = c.stateAccessor.Application(appTag.Name)
 	} else {
-		app, err = c.api.stateAccessor.RemoteApplication(appTag.Name)
+		app, err = c.stateAccessor.RemoteApplication(appTag.Name)
 	}
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -82,7 +82,7 @@ func (c *Client) applicationStatusHistory(appTag names.ApplicationTag, filter st
 // unitStatusHistory returns a list of status history entries for unit agents or workloads.
 func (c *Client) unitStatusHistory(unitTag names.UnitTag, filter status.StatusHistoryFilter,
 	kind status.HistoryKind) ([]params.DetailedStatus, error) {
-	unit, err := c.api.stateAccessor.Unit(unitTag.Id())
+	unit, err := c.stateAccessor.Unit(unitTag.Id())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -116,7 +116,7 @@ func (c *Client) unitStatusHistory(unitTag names.UnitTag, filter status.StatusHi
 // machineStatusHistory returns status history for the given machine.
 func (c *Client) machineStatusHistory(machineTag names.MachineTag, filter status.StatusHistoryFilter,
 	kind status.HistoryKind) ([]params.DetailedStatus, error) {
-	machine, err := c.api.stateAccessor.Machine(machineTag.Id())
+	machine, err := c.stateAccessor.Machine(machineTag.Id())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -134,7 +134,7 @@ func (c *Client) machineStatusHistory(machineTag names.MachineTag, filter status
 
 // modelStatusHistory returns status history for the current model.
 func (c *Client) modelStatusHistory(filter status.StatusHistoryFilter) ([]params.DetailedStatus, error) {
-	m, err := c.api.stateAccessor.Model()
+	m, err := c.stateAccessor.Model()
 	if err != nil {
 		return nil, errors.Annotate(err, "cannot get model")
 	}
@@ -228,54 +228,54 @@ func (c *Client) FullStatus(args params.StatusParams) (params.FullStatus, error)
 
 	var noStatus params.FullStatus
 	var context statusContext
-	context.cachedModel = c.api.modelCache
+	context.cachedModel = c.modelCache
 
-	m, err := c.api.stateAccessor.Model()
+	m, err := c.stateAccessor.Model()
 	if err != nil {
 		return noStatus, errors.Annotate(err, "cannot get model")
 	}
-	context.presence.Presence = c.api.presence.ModelPresence(m.UUID())
+	context.presence.Presence = c.presence.ModelPresence(m.UUID())
 	cfg, err := m.Config()
 	if err != nil {
 		return noStatus, errors.Annotate(err, "cannot obtain current model config")
 	}
 	context.providerType = cfg.Type()
 
-	if context.spaceInfos, err = c.api.stateAccessor.AllSpaceInfos(); err != nil {
+	if context.spaceInfos, err = c.stateAccessor.AllSpaceInfos(); err != nil {
 		return noStatus, errors.Annotate(err, "cannot obtain space information")
 	}
-	if context.model, err = c.api.state().Model(); err != nil {
+	if context.model, err = c.state().Model(); err != nil {
 		return noStatus, errors.Annotate(err, "could not fetch model")
 	}
 	if context.status, err = context.model.LoadModelStatus(); err != nil {
 		return noStatus, errors.Annotate(err, "could not load model status values")
 	}
 	if context.allAppsUnitsCharmBindings, err =
-		fetchAllApplicationsAndUnits(c.api.stateAccessor, context.model, context.spaceInfos); err != nil {
+		fetchAllApplicationsAndUnits(c.stateAccessor, context.model, context.spaceInfos); err != nil {
 		return noStatus, errors.Annotate(err, "could not fetch applications and units")
 	}
 	if context.consumerRemoteApplications, err =
-		fetchConsumerRemoteApplications(c.api.stateAccessor); err != nil {
+		fetchConsumerRemoteApplications(c.stateAccessor); err != nil {
 		return noStatus, errors.Annotate(err, "could not fetch remote applications")
 	}
 	// Only admins can see offer details.
 	if err := c.checkIsAdmin(); err == nil {
 		if context.offers, err =
-			fetchOffers(c.api.stateAccessor, context.allAppsUnitsCharmBindings.applications); err != nil {
+			fetchOffers(c.stateAccessor, context.allAppsUnitsCharmBindings.applications); err != nil {
 			return noStatus, errors.Annotate(err, "could not fetch application offers")
 		}
 	}
-	if err = context.fetchMachines(c.api.stateAccessor); err != nil {
+	if err = context.fetchMachines(c.stateAccessor); err != nil {
 		return noStatus, errors.Annotate(err, "could not fetch machines")
 	}
-	if err = context.fetchOpenPortRangesForAllMachines(c.api.stateAccessor); err != nil {
+	if err = context.fetchOpenPortRangesForAllMachines(c.stateAccessor); err != nil {
 		return noStatus, errors.Annotate(err, "could not fetch open port ranges")
 	}
-	if context.controllerNodes, err = fetchControllerNodes(c.api.stateAccessor); err != nil {
+	if context.controllerNodes, err = fetchControllerNodes(c.stateAccessor); err != nil {
 		return noStatus, errors.Annotate(err, "could not fetch controller nodes")
 	}
 	if len(context.controllerNodes) > 1 {
-		if primaryHAMachine, err := c.api.stateAccessor.HAPrimaryMachine(); err != nil {
+		if primaryHAMachine, err := c.stateAccessor.HAPrimaryMachine(); err != nil {
 			// We do not want to return any errors here as they are all
 			// non-fatal for this call since we can still
 			// get FullStatus including machine info even if we could not get HA Primary determined.
@@ -288,14 +288,14 @@ func (c *Client) FullStatus(args params.StatusParams) (params.FullStatus, error)
 	}
 	// These may be empty when machines have not finished deployment.
 	if context.ipAddresses, context.spaces, context.linkLayerDevices, err =
-		fetchNetworkInterfaces(c.api.stateAccessor, context.spaceInfos); err != nil {
+		fetchNetworkInterfaces(c.stateAccessor, context.spaceInfos); err != nil {
 		return noStatus, errors.Annotate(err, "could not fetch IP addresses and link layer devices")
 	}
-	if context.relations, context.relationsById, err = fetchRelations(c.api.stateAccessor); err != nil {
+	if context.relations, context.relationsById, err = fetchRelations(c.stateAccessor); err != nil {
 		return noStatus, errors.Annotate(err, "could not fetch relations")
 	}
 	if len(context.allAppsUnitsCharmBindings.applications) > 0 {
-		if context.leaders, err = c.api.leadershipReader.Leaders(); err != nil {
+		if context.leaders, err = c.leadershipReader.Leaders(); err != nil {
 			// Leader information is additive for status.
 			// Given that it comes from Dqlite, which may be subject to
 			// reconfiguration when mutating the control plane, we would
@@ -304,21 +304,21 @@ func (c *Client) FullStatus(args params.StatusParams) (params.FullStatus, error)
 			context.leaders = make(map[string]string)
 		}
 	}
-	if context.controllerTimestamp, err = c.api.stateAccessor.ControllerTimestamp(); err != nil {
+	if context.controllerTimestamp, err = c.stateAccessor.ControllerTimestamp(); err != nil {
 		return noStatus, errors.Annotate(err, "could not fetch controller timestamp")
 	}
-	context.branches = fetchBranches(c.api.modelCache)
+	context.branches = fetchBranches(c.modelCache)
 
 	if args.IncludeStorage {
-		context.storageInstances, err = c.api.storageAccessor.AllStorageInstances()
+		context.storageInstances, err = c.storageAccessor.AllStorageInstances()
 		if err != nil {
 			return noStatus, errors.Annotate(err, "cannot list all storage instances")
 		}
-		context.filesystems, err = c.api.storageAccessor.AllFilesystems()
+		context.filesystems, err = c.storageAccessor.AllFilesystems()
 		if err != nil {
 			return noStatus, errors.Annotate(err, "cannot list all filesystems")
 		}
-		context.volumes, err = c.api.storageAccessor.AllVolumes()
+		context.volumes, err = c.storageAccessor.AllVolumes()
 		if err != nil {
 			return noStatus, errors.Annotate(err, "cannot list all volumes")
 		}
@@ -528,15 +528,15 @@ func (c *Client) FullStatus(args params.StatusParams) (params.FullStatus, error)
 	var filesystemDetails []params.FilesystemDetails
 	var volumeDetails []params.VolumeDetails
 	if args.IncludeStorage {
-		storageDetails, err = context.processStorage(c.api.storageAccessor)
+		storageDetails, err = context.processStorage(c.storageAccessor)
 		if err != nil {
 			return noStatus, errors.Annotate(err, "cannot process storage instances")
 		}
-		filesystemDetails, err = context.processFilesystems(c.api.storageAccessor)
+		filesystemDetails, err = context.processFilesystems(c.storageAccessor)
 		if err != nil {
 			return noStatus, errors.Annotate(err, "cannot process filesystems")
 		}
-		volumeDetails, err = context.processVolumes(c.api.storageAccessor)
+		volumeDetails, err = context.processVolumes(c.storageAccessor)
 		if err != nil {
 			return noStatus, errors.Annotate(err, "cannot process volumes")
 		}
@@ -615,7 +615,7 @@ func filterBranches(ctxBranches map[string]cache.Branch,
 func (c *Client) modelStatus() (params.ModelStatusInfo, error) {
 	var info params.ModelStatusInfo
 
-	m, err := c.api.stateAccessor.Model()
+	m, err := c.stateAccessor.Model()
 	if err != nil {
 		return info, errors.Annotate(err, "cannot get model")
 	}

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -16111,28 +16111,13 @@
     {
         "Name": "Client",
         "Description": "Client serves client-specific API methods.",
-        "Version": 7,
+        "Version": 8,
         "AvailableTo": [
-            "controller-machine-agent",
-            "machine-agent",
-            "unit-agent",
             "model-user"
         ],
         "Schema": {
             "type": "object",
             "properties": {
-                "FindTools": {
-                    "type": "object",
-                    "properties": {
-                        "Params": {
-                            "$ref": "#/definitions/FindToolsParams"
-                        },
-                        "Result": {
-                            "$ref": "#/definitions/FindToolsResult"
-                        }
-                    },
-                    "description": "FindTools returns a List containing all tools matching the given parameters.\nTODO(juju 3.1) - remove, used by 2.9 client only"
-                },
                 "FullStatus": {
                     "type": "object",
                     "properties": {
@@ -16156,30 +16141,9 @@
                         }
                     },
                     "description": "StatusHistory returns a slice of past statuses for several entities."
-                },
-                "WatchAll": {
-                    "type": "object",
-                    "properties": {
-                        "Result": {
-                            "$ref": "#/definitions/AllWatcherId"
-                        }
-                    },
-                    "description": "WatchAll initiates a watcher for entities in the connected model."
                 }
             },
             "definitions": {
-                "AllWatcherId": {
-                    "type": "object",
-                    "properties": {
-                        "watcher-id": {
-                            "type": "string"
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "watcher-id"
-                    ]
-                },
                 "ApplicationOfferStatus": {
                     "type": "object",
                     "properties": {
@@ -16348,46 +16312,6 @@
                     "required": [
                         "name",
                         "channel"
-                    ]
-                },
-                "Binary": {
-                    "type": "object",
-                    "properties": {
-                        "Arch": {
-                            "type": "string"
-                        },
-                        "Build": {
-                            "type": "integer"
-                        },
-                        "Major": {
-                            "type": "integer"
-                        },
-                        "Minor": {
-                            "type": "integer"
-                        },
-                        "Number": {
-                            "$ref": "#/definitions/Number"
-                        },
-                        "Patch": {
-                            "type": "integer"
-                        },
-                        "Release": {
-                            "type": "string"
-                        },
-                        "Tag": {
-                            "type": "string"
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "Major",
-                        "Minor",
-                        "Tag",
-                        "Patch",
-                        "Build",
-                        "Number",
-                        "Release",
-                        "Arch"
                     ]
                 },
                 "BranchStatus": {
@@ -16657,52 +16581,6 @@
                         "filesystem-id",
                         "pool",
                         "size"
-                    ]
-                },
-                "FindToolsParams": {
-                    "type": "object",
-                    "properties": {
-                        "agentstream": {
-                            "type": "string"
-                        },
-                        "arch": {
-                            "type": "string"
-                        },
-                        "major": {
-                            "type": "integer"
-                        },
-                        "number": {
-                            "$ref": "#/definitions/Number"
-                        },
-                        "os-type": {
-                            "type": "string"
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "number",
-                        "major",
-                        "arch",
-                        "os-type",
-                        "agentstream"
-                    ]
-                },
-                "FindToolsResult": {
-                    "type": "object",
-                    "properties": {
-                        "error": {
-                            "$ref": "#/definitions/Error"
-                        },
-                        "list": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/Tools"
-                            }
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "list"
                     ]
                 },
                 "FullStatus": {
@@ -17039,34 +16917,6 @@
                         "is-up"
                     ]
                 },
-                "Number": {
-                    "type": "object",
-                    "properties": {
-                        "Build": {
-                            "type": "integer"
-                        },
-                        "Major": {
-                            "type": "integer"
-                        },
-                        "Minor": {
-                            "type": "integer"
-                        },
-                        "Patch": {
-                            "type": "integer"
-                        },
-                        "Tag": {
-                            "type": "string"
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "Major",
-                        "Minor",
-                        "Tag",
-                        "Patch",
-                        "Build"
-                    ]
-                },
                 "RelationStatus": {
                     "type": "object",
                     "properties": {
@@ -17350,29 +17200,6 @@
                         "kind",
                         "status",
                         "persistent"
-                    ]
-                },
-                "Tools": {
-                    "type": "object",
-                    "properties": {
-                        "sha256": {
-                            "type": "string"
-                        },
-                        "size": {
-                            "type": "integer"
-                        },
-                        "url": {
-                            "type": "string"
-                        },
-                        "version": {
-                            "$ref": "#/definitions/Binary"
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "version",
-                        "url",
-                        "size"
                     ]
                 },
                 "UnitStatus": {


### PR DESCRIPTION
This PR adds a version 8 of the Client facade, which removes the `FindTools` method. This method has not been used by the client since 2.9. In 4.0, versions 6 and 7 of the Client facade will be removed, so only v8 is supported.

A lot of unused code was removed, including unused interfaces (Pool) and fields on the client.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

<!-- Describe steps to verify that the change works. -->

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/

**Jira card:** JUJU-

