### PR TITLE
refactor: remove EnvironConfigGetter in apiserver registration

### DIFF
--- a/apiserver/registration.go
+++ b/apiserver/registration.go
@@ -15,14 +15,14 @@ import (
 	"github.com/juju/names/v5"
 	"gopkg.in/macaroon.v2"
 
-	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/core/model"
+	"github.com/juju/juju/core/providertracker"
 	usererrors "github.com/juju/juju/domain/access/errors"
 	"github.com/juju/juju/environs"
 	internalmacaroon "github.com/juju/juju/internal/macaroon"
 	"github.com/juju/juju/internal/servicefactory"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
-	"github.com/juju/juju/state/stateenvirons"
 )
 
 // registerUserHandler is an http.Handler for the "/register" endpoint. This is
@@ -59,8 +59,6 @@ func (h *registerUserHandler) ServeHTTP(w http.ResponseWriter, req *http.Request
 		st.State,
 		serviceFactory.ControllerConfig(),
 		serviceFactory.Access(),
-		serviceFactory.Cloud(),
-		serviceFactory.Credential(),
 	)
 	if err != nil {
 		if err := sendError(w, err); err != nil {
@@ -115,7 +113,6 @@ func (h *registerUserHandler) processPost(
 	st *state.State,
 	controllerConfigService ControllerConfigService,
 	userService UserService,
-	cloudService common.CloudService, credentialService common.CredentialService,
 ) (
 	names.UserTag, *params.SecretKeyLoginResponse, error,
 ) {
@@ -148,7 +145,7 @@ func (h *registerUserHandler) processPost(
 
 	// Respond with the CA-cert and password, encrypted again with the
 	// activation key.
-	responsePayload, err := h.getSecretKeyLoginResponsePayload(req.Context(), st, controllerConfigService, cloudService, credentialService)
+	responsePayload, err := h.getSecretKeyLoginResponsePayload(req.Context(), st, controllerConfigService)
 	if err != nil {
 		return names.UserTag{}, nil, errors.Trace(err)
 	}
@@ -172,17 +169,18 @@ func (h *registerUserHandler) processPost(
 	return userTag, response, nil
 }
 
-func getConnectorInfoer(ctx context.Context, model stateenvirons.Model, cloudService common.CloudService, credentialService common.CredentialService) (environs.ConnectorInfo, error) {
-	configGetter := stateenvirons.EnvironConfigGetter{
-		Model: model, CloudService: cloudService, CredentialService: credentialService}
-	environ, err := common.EnvironFuncForModel(model, cloudService, credentialService, configGetter)(ctx)
-	if err != nil {
-		return nil, errors.Trace(err)
+func getConnectorInfoer(
+	ctx context.Context,
+	providerFactory providertracker.ProviderFactory,
+	controllerModelID model.UUID,
+) (environs.ConnectorInfo, error) {
+
+	type connectableProvider interface {
+		environs.BootstrapEnviron
+		environs.ConnectorInfo
 	}
-	if connInfo, ok := environ.(environs.ConnectorInfo); ok {
-		return connInfo, nil
-	}
-	return nil, errors.NotSupportedf("environ %q", environ.Config().Type())
+	return providertracker.ProviderRunner[connectableProvider](
+		providerFactory, controllerModelID.String())(ctx)
 }
 
 // For testing.
@@ -194,8 +192,6 @@ func (h *registerUserHandler) getSecretKeyLoginResponsePayload(
 	ctx context.Context,
 	st *state.State,
 	controllerConfigService ControllerConfigService,
-	cloudService common.CloudService,
-	credentialService common.CredentialService,
 ) (*params.SecretKeyLoginResponsePayload, error) {
 	if !st.IsController() {
 		return nil, errors.New("state is not for a controller")
@@ -210,11 +206,10 @@ func (h *registerUserHandler) getSecretKeyLoginResponsePayload(
 		ControllerUUID: controllerConfig.ControllerUUID(),
 	}
 
-	model, err := st.Model()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	connInfo, err := GetConnectorInfoer(ctx, model, cloudService, credentialService)
+	connInfo, err := GetConnectorInfoer(ctx,
+		h.ctxt.srv.shared.providerFactory,
+		h.ctxt.srv.shared.controllerModelID,
+	)
 	if errors.Is(err, errors.NotSupported) { // Not all providers support this.
 		return &payload, nil
 	}

--- a/apiserver/registration_test.go
+++ b/apiserver/registration_test.go
@@ -21,8 +21,9 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver"
-	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/permission"
+	"github.com/juju/juju/core/providertracker"
 	"github.com/juju/juju/core/user"
 	usererrors "github.com/juju/juju/domain/access/errors"
 	"github.com/juju/juju/domain/access/service"
@@ -33,7 +34,6 @@ import (
 	"github.com/juju/juju/internal/testing/factory"
 	jujutesting "github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/rpc/params"
-	"github.com/juju/juju/state/stateenvirons"
 )
 
 type registrationSuite struct {
@@ -92,7 +92,11 @@ func (s *registrationSuite) assertRegisterNoProxy(c *gc.C, hasProxy bool) {
 	}
 	environ := NewMockConnectorInfo(ctrl)
 	proxier := NewMockProxier(ctrl)
-	s.PatchValue(&apiserver.GetConnectorInfoer, func(context.Context, stateenvirons.Model, common.CloudService, common.CredentialService) (environs.ConnectorInfo, error) {
+	s.PatchValue(&apiserver.GetConnectorInfoer, func(
+		ctx context.Context,
+		providerFactory providertracker.ProviderFactory,
+		controllerModelID model.UUID,
+	) (environs.ConnectorInfo, error) {
 		if hasProxy {
 			return environ, nil
 		}


### PR DESCRIPTION
This PR continues our work to remove the EnvironConfigGetter.

In the apiserver registration, there is a provider access to determine whether the environment supports proxying. Previously it was using EnvironConfigGetter, but now we can replace it with the provider factory introduced in #17859.

This also allows us to remove some services that were being passed through, and are no longer needed.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

<!-- Describe steps to verify that the change works. -->

TODO

## Links

**Jira card:** JUJU-6487