### PR TITLE
fix: use ed25519 ssh keys when juju sshing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -78,7 +78,7 @@ require (
 	github.com/juju/terms-client/v2 v2.0.0
 	github.com/juju/testing v1.1.0
 	github.com/juju/txn/v3 v3.0.2
-	github.com/juju/utils/v3 v3.1.1
+	github.com/juju/utils/v3 v3.2.0
 	github.com/juju/version/v2 v2.0.1
 	github.com/juju/viddy v0.0.0-beta5
 	github.com/juju/webbrowser v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -598,8 +598,8 @@ github.com/juju/utils/v3 v3.0.0-20220130232349-cd7ecef0e94a/go.mod h1:LzwbbEN7bu
 github.com/juju/utils/v3 v3.0.0-20220202114721-338bb0530e89/go.mod h1:wf5w+8jyTh2IYnSX0sHnMJo4ZPwwuiBWn+xN3DkQg4k=
 github.com/juju/utils/v3 v3.0.0-20220203023959-c3fbc78a33b0/go.mod h1:8csUcj1VRkfjNIRzBFWzLFCMLwLqsRWvkmhfVAUwbC4=
 github.com/juju/utils/v3 v3.0.0/go.mod h1:8csUcj1VRkfjNIRzBFWzLFCMLwLqsRWvkmhfVAUwbC4=
-github.com/juju/utils/v3 v3.1.1 h1:shEMr/4Wkw0YCOPz5IFOYkLv1ec50pzRi59TRl0qQ/0=
-github.com/juju/utils/v3 v3.1.1/go.mod h1:nAj3sHtdYfAkvnkqttTy3Xzm2HzkD9Hfgnc+upOW2Z8=
+github.com/juju/utils/v3 v3.2.0 h1:RkEgTHbrPoOqTuOSaob52B1gLkpeMLd5fZj/4kFzb1k=
+github.com/juju/utils/v3 v3.2.0/go.mod h1:nAj3sHtdYfAkvnkqttTy3Xzm2HzkD9Hfgnc+upOW2Z8=
 github.com/juju/version v0.0.0-20161031051906-1f41e27e54f2/go.mod h1:kE8gK5X0CImdr7qpSKl3xB2PmpySSmfj7zVbkZFs81U=
 github.com/juju/version v0.0.0-20180108022336-b64dbd566305/go.mod h1:kE8gK5X0CImdr7qpSKl3xB2PmpySSmfj7zVbkZFs81U=
 github.com/juju/version v0.0.0-20191219164919-81c1be00b9a6/go.mod h1:kE8gK5X0CImdr7qpSKl3xB2PmpySSmfj7zVbkZFs81U=


### PR DESCRIPTION
OpenSSH shim in juju/utils was only finding rsa, dsa and ecdsa private keys. This PR updates juju/utils/v3 to v3.2.0 with changes to also find ed25519 keys.

See https://github.com/juju/utils/pull/338

## QA steps

1. Generate a new ed25519 ssh key pair `ssh-keygen -t ed25519`
2. Bootstrap a new controller with this key `juju bootstrap --config "authorized-keys=$(cat ~/.ssh/id_[ed25519.pub](http://ed25519.pub/))" [localhost](http://localhost/)
3. juju switch controller
4. juju ssh 0
If you can ssh to the controller machine then this has been fixed. Can also confirm the ed25519 key is the only one in the model with `juju ssh-keys --full`

## Documentation changes

N/A

## Links

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2012208

**Jira card:** JUJU-6515

