### PR TITLE
chore: remove unused environ code from applicationoffers facade

### DIFF
--- a/apiserver/facades/client/applicationoffers/access_test.go
+++ b/apiserver/facades/client/applicationoffers/access_test.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/juju/juju/apiserver/common/crossmodel"
 	"github.com/juju/juju/apiserver/facades/client/applicationoffers"
-	apiservertesting "github.com/juju/juju/apiserver/testing"
 	jujucrossmodel "github.com/juju/juju/core/crossmodel"
 	modeltesting "github.com/juju/juju/core/model/testing"
 	"github.com/juju/juju/core/permission"
@@ -54,10 +53,10 @@ func (s *offerAccessSuite) setupAPI(c *gc.C) {
 		return &stubApplicationOffers{}
 	}
 	api, err := applicationoffers.CreateOffersAPI(
-		getApplicationOffers, nil, getFakeControllerInfo,
+		getApplicationOffers, getFakeControllerInfo,
 		s.mockState, s.mockStatePool,
 		s.mockModelService,
-		s.authorizer, s.authContext, apiservertesting.NoopModelCredentialInvalidatorGetter,
+		s.authorizer, s.authContext,
 		c.MkDir(), loggertesting.WrapCheckLog(c),
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/client/applicationoffers/applicationoffers.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers.go
@@ -20,7 +20,6 @@ import (
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/environs"
-	envcontext "github.com/juju/juju/environs/envcontext"
 	"github.com/juju/juju/rpc/params"
 )
 
@@ -37,14 +36,12 @@ type OffersAPIv5 struct {
 // createAPI returns a new application offers OffersAPI facade.
 func createOffersAPI(
 	getApplicationOffers func(interface{}) jujucrossmodel.ApplicationOffers,
-	getEnviron environFromModelFunc,
 	getControllerInfo func(context.Context) ([]string, string, error),
 	backend Backend,
 	statePool StatePool,
 	modelService ModelService,
 	authorizer facade.Authorizer,
 	authContext *commoncrossmodel.AuthContext,
-	credentialInvalidatorGetter envcontext.ModelCredentialInvalidatorGetter,
 	dataDir string,
 	logger corelogger.Logger,
 ) (*OffersAPIv5, error) {
@@ -56,15 +53,13 @@ func createOffersAPI(
 		dataDir:     dataDir,
 		authContext: authContext,
 		BaseAPI: BaseAPI{
-			Authorizer:                  authorizer,
-			GetApplicationOffers:        getApplicationOffers,
-			ControllerModel:             backend,
-			modelService:                modelService,
-			credentialInvalidatorGetter: credentialInvalidatorGetter,
-			StatePool:                   statePool,
-			getEnviron:                  getEnviron,
-			getControllerInfo:           getControllerInfo,
-			logger:                      logger,
+			Authorizer:           authorizer,
+			GetApplicationOffers: getApplicationOffers,
+			ControllerModel:      backend,
+			modelService:         modelService,
+			StatePool:            statePool,
+			getControllerInfo:    getControllerInfo,
+			logger:               logger,
 		},
 	}
 	return api, nil

--- a/apiserver/facades/client/applicationoffers/applicationoffers_test.go
+++ b/apiserver/facades/client/applicationoffers/applicationoffers_test.go
@@ -66,13 +66,10 @@ func (s *applicationOffersSuite) setupAPI(c *gc.C) {
 	getApplicationOffers := func(interface{}) jujucrossmodel.ApplicationOffers {
 		return s.applicationOffers
 	}
-	getEnviron := func(ctx context.Context, modelUUID string) (environs.Environ, error) {
-		return s.env, nil
-	}
 	api, err := applicationoffers.CreateOffersAPI(
-		getApplicationOffers, getEnviron, getFakeControllerInfo,
+		getApplicationOffers, getFakeControllerInfo,
 		s.mockState, s.mockStatePool, s.mockModelService,
-		s.authorizer, s.authContext, apiservertesting.NoopModelCredentialInvalidatorGetter,
+		s.authorizer, s.authContext,
 		c.MkDir(), loggertesting.WrapCheckLog(c),
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1183,14 +1180,11 @@ func (s *consumeSuite) setupAPI(c *gc.C) {
 	getApplicationOffers := func(st interface{}) jujucrossmodel.ApplicationOffers {
 		return &mockApplicationOffers{st: st.(*mockState)}
 	}
-	getEnviron := func(ctx context.Context, modelUUID string) (environs.Environ, error) {
-		return s.env, nil
-	}
 	api, err := applicationoffers.CreateOffersAPI(
-		getApplicationOffers, getEnviron, getFakeControllerInfo,
+		getApplicationOffers, getFakeControllerInfo,
 		s.mockState, s.mockStatePool, s.mockModelService,
 		s.authorizer, s.authContext,
-		apiservertesting.NoopModelCredentialInvalidatorGetter, c.MkDir(),
+		c.MkDir(),
 		loggertesting.WrapCheckLog(c),
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/client/applicationoffers/base.go
+++ b/apiserver/facades/client/applicationoffers/base.go
@@ -18,21 +18,18 @@ import (
 	corelogger "github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/permission"
-	envcontext "github.com/juju/juju/environs/envcontext"
 	"github.com/juju/juju/rpc/params"
 )
 
 // BaseAPI provides various boilerplate methods used by the facade business logic.
 type BaseAPI struct {
-	Authorizer                  facade.Authorizer
-	GetApplicationOffers        func(interface{}) jujucrossmodel.ApplicationOffers
-	ControllerModel             Backend
-	StatePool                   StatePool
-	modelService                ModelService
-	getEnviron                  environFromModelFunc
-	getControllerInfo           func(context.Context) (apiAddrs []string, caCert string, _ error)
-	credentialInvalidatorGetter envcontext.ModelCredentialInvalidatorGetter
-	logger                      corelogger.Logger
+	Authorizer           facade.Authorizer
+	GetApplicationOffers func(interface{}) jujucrossmodel.ApplicationOffers
+	ControllerModel      Backend
+	StatePool            StatePool
+	modelService         ModelService
+	getControllerInfo    func(context.Context) (apiAddrs []string, caCert string, _ error)
+	logger               corelogger.Logger
 }
 
 // checkAdmin ensures that the specified in user is a model or controller admin.


### PR DESCRIPTION
The following fields on `applicationoffers.BaseAPI` were unused: `getEnviron`, `credentialInvalidatorGetter`. Remove them and remove the dependence on `EnvironConfigGetter`.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- ~[ ] Comments saying why design decisions were made~
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Run unit tests.

Basic QA of the applicationoffers facade: TODO

## Links

**Jira card:** JUJU-6495