### PR TITLE
feat: model logger

### DIFF
--- a/cmd/internal/agent/agentconf/agentconf.go
+++ b/cmd/internal/agent/agentconf/agentconf.go
@@ -64,7 +64,7 @@ func SetupAgentLogging(context corelogger.LoggerContext, config agent.Config) {
 	if loggingOverride := config.Value(agent.LoggingOverride); loggingOverride != "" {
 		logger.Infof("logging override set for this agent: %q", loggingOverride)
 		context.ResetLoggerLevels()
-		err := context.ConfigureLoggers(loggingOverride)
+		err := context.ConfigureLoggers(loggingOverride, config.Model().Id())
 		if err != nil {
 			logger.Errorf("setting logging override %v", err)
 		}
@@ -73,7 +73,7 @@ func SetupAgentLogging(context corelogger.LoggerContext, config agent.Config) {
 		// There should only be valid logging configuration strings saved
 		// in the logging config section in the agent.conf file.
 		context.ResetLoggerLevels()
-		err := context.ConfigureLoggers(loggingConfig)
+		err := context.ConfigureLoggers(loggingConfig, config.Model().Id())
 		if err != nil {
 			logger.Errorf("problem setting logging config %v", err)
 		}

--- a/cmd/jujud-controller/agent/agent_test.go
+++ b/cmd/jujud-controller/agent/agent_test.go
@@ -74,7 +74,7 @@ var _ = gc.Suite(&agentLoggingSuite{})
 
 func (*agentLoggingSuite) TestNoLoggingConfig(c *gc.C) {
 	f := &fakeLoggingConfig{}
-	context := internallogger.LoggerContext(corelogger.WARNING)
+	context := internallogger.LoggerContext(corelogger.WARNING, "")
 	initial := context.Config().String()
 
 	agentconf.SetupAgentLogging(context, f)
@@ -86,7 +86,7 @@ func (*agentLoggingSuite) TestLoggingOverride(c *gc.C) {
 	f := &fakeLoggingConfig{
 		loggingOverride: "test=INFO",
 	}
-	context := internallogger.LoggerContext(corelogger.WARNING)
+	context := internallogger.LoggerContext(corelogger.WARNING, "")
 
 	agentconf.SetupAgentLogging(context, f)
 
@@ -97,7 +97,7 @@ func (*agentLoggingSuite) TestLoggingConfig(c *gc.C) {
 	f := &fakeLoggingConfig{
 		loggingConfig: "test=INFO",
 	}
-	context := internallogger.LoggerContext(corelogger.WARNING)
+	context := internallogger.LoggerContext(corelogger.WARNING, "")
 
 	agentconf.SetupAgentLogging(context, f)
 

--- a/cmd/jujud-controller/agent/machine.go
+++ b/cmd/jujud-controller/agent/machine.go
@@ -991,7 +991,7 @@ func (a *MachineAgent) startModelWorkers(cfg modelworkermanager.NewModelConfig) 
 		return nil, errors.Trace(err)
 	}
 
-	loggingContext := internallogger.LoggerContext(corelogger.INFO)
+	loggingContext := internallogger.LoggerContext(corelogger.INFO, cfg.ModelUUID)
 	if err := loggingContext.AddWriter("logsink", cfg.ModelLogger); err != nil {
 		logger.Errorf("unable to configure logging for model: %v", err)
 	}

--- a/cmd/jujud/agent/agent_test.go
+++ b/cmd/jujud/agent/agent_test.go
@@ -83,7 +83,7 @@ var _ = gc.Suite(&agentLoggingSuite{})
 
 func (*agentLoggingSuite) TestNoLoggingConfig(c *gc.C) {
 	f := &fakeLoggingConfig{}
-	context := internallogger.LoggerContext(corelogger.WARNING)
+	context := internallogger.LoggerContext(corelogger.WARNING, "")
 	initial := context.Config().String()
 
 	agentconf.SetupAgentLogging(context, f)
@@ -95,7 +95,7 @@ func (*agentLoggingSuite) TestLoggingOverride(c *gc.C) {
 	f := &fakeLoggingConfig{
 		loggingOverride: "test=INFO",
 	}
-	context := internallogger.LoggerContext(corelogger.WARNING)
+	context := internallogger.LoggerContext(corelogger.WARNING, "")
 
 	agentconf.SetupAgentLogging(context, f)
 
@@ -106,7 +106,7 @@ func (*agentLoggingSuite) TestLoggingConfig(c *gc.C) {
 	f := &fakeLoggingConfig{
 		loggingConfig: "test=INFO",
 	}
-	context := internallogger.LoggerContext(corelogger.WARNING)
+	context := internallogger.LoggerContext(corelogger.WARNING, "")
 
 	agentconf.SetupAgentLogging(context, f)
 

--- a/core/logger/interface.go
+++ b/core/logger/interface.go
@@ -166,7 +166,7 @@ type LoggerContext interface {
 	// does not have a label that matches the provided labels, then the logger
 	// will not be configured. No labels will configure all loggers in the
 	// specification.
-	ConfigureLoggers(specification string) error
+	ConfigureLoggers(specification string, modelUUID string) error
 
 	// ResetLoggerLevels iterates through the known logging modules and sets the
 	// levels of all to UNSPECIFIED, except for <root> which is set to WARNING.

--- a/go.mod
+++ b/go.mod
@@ -314,3 +314,5 @@ require (
 )
 
 replace gopkg.in/yaml.v2 => github.com/juju/yaml/v2 v2.0.0
+
+replace github.com/juju/loggo/v2 => /home/simon/go/src/github.com/juju/loggo

--- a/internal/logger/default.go
+++ b/internal/logger/default.go
@@ -17,8 +17,10 @@ func GetLogger(name string, tags ...string) logger.Logger {
 
 // LoggerContext returns a logger factory that creates loggers.
 // Currently this is backed with loggo.
-func LoggerContext(level logger.Level) logger.LoggerContext {
-	return WrapLoggoContext(loggo.NewContext(loggo.Level(level)))
+func LoggerContext(level logger.Level, modelUUID string) logger.LoggerContext {
+	return WrapLoggoContext(loggo.NewContext(loggo.Level(level), map[string]string{
+		"model-uuid": modelUUID,
+	}))
 }
 
 // DefaultContext returns a logger factory that creates loggers.

--- a/internal/logger/loggo.go
+++ b/internal/logger/loggo.go
@@ -116,8 +116,10 @@ func (c loggoLoggerContext) ResetLoggerLevels() {
 // does not have a label that matches the provided labels, then the logger
 // will not be configured. No labels will configure all loggers in the
 // specification.
-func (c loggoLoggerContext) ConfigureLoggers(specification string) error {
-	return c.context.ConfigureLoggers(specification)
+func (c loggoLoggerContext) ConfigureLoggers(specification string, modelUUID string) error {
+	return c.context.ConfigureLoggers(specification, map[string]string{
+		"model-uuid": modelUUID,
+	})
 }
 
 // Config returns the current configuration of the Loggers. Loggers

--- a/internal/worker/deployer/unit_manifolds_test.go
+++ b/internal/worker/deployer/unit_manifolds_test.go
@@ -30,7 +30,7 @@ func (s *ManifoldsSuite) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
 	s.config = deployer.UnitManifoldsConfig{
 		Agent:         struct{ agent.Agent }{},
-		LoggerContext: internallogger.LoggerContext(logger.DEBUG),
+		LoggerContext: internallogger.LoggerContext(logger.DEBUG, ""),
 	}
 }
 

--- a/internal/worker/logger/logger_test.go
+++ b/internal/worker/logger/logger_test.go
@@ -115,7 +115,7 @@ func (s *LoggerSuite) TestInitialState(c *gc.C) {
 	c.Assert(expected, gc.Not(gc.Equals), initial)
 
 	s.context.ResetLoggerLevels()
-	err := s.context.ConfigureLoggers(initial)
+	err := s.context.ConfigureLoggers(initial, "")
 	c.Assert(err, jc.ErrorIsNil)
 
 	loggingWorker := s.makeLogger(c)
@@ -132,7 +132,7 @@ func (s *LoggerSuite) TestConfigOverride(c *gc.C) {
 	s.config.Override = "test=TRACE"
 
 	s.context.ResetLoggerLevels()
-	err := s.context.ConfigureLoggers("<root>=DEBUG;wibble=ERROR")
+	err := s.context.ConfigureLoggers("<root>=DEBUG;wibble=ERROR", "")
 	c.Assert(err, jc.ErrorIsNil)
 
 	loggingWorker := s.makeLogger(c)

--- a/internal/worker/logger/manifold.go
+++ b/internal/worker/logger/manifold.go
@@ -47,15 +47,15 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 			}
 
 			loggerFacade := logger.NewClient(apiCaller)
-			workerConfig := WorkerConfig{
+			return NewLogger(WorkerConfig{
 				Context:  config.LoggerContext,
 				API:      loggerFacade,
 				Tag:      currentConfig.Tag(),
+				ModelTag: currentConfig.Model(),
 				Logger:   config.Logger,
 				Override: loggingOverride,
 				Callback: config.UpdateAgentFunc,
-			}
-			return NewLogger(workerConfig)
+			})
 		},
 	}
 }


### PR DESCRIPTION
The idea of this PR is to explore if it's possible to just have one logger throughout the controller agent and partition the information on the writing of the data. Thus removing the need for the model logger. We can then use this concept to then drive status history.

Ensuring the correct model uuid is the biggest foot gun. If this can be correctly handled without the onus on the person adding the logs (clean API) then this is considered "workable".

<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://docs.google.com/document/d/1SYUo9G7qZ_jdoVXpUVamS5VCgHmtZ0QA-wZxKoMS-C0 
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

<!-- Describe steps to verify that the change works. -->

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/

**Jira card:** JUJU-

