### PR TITLE
feat: new CloudSpec method on cloud service

### DIFF
--- a/apiserver/facades/agent/uniter/service.go
+++ b/apiserver/facades/agent/uniter/service.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/watcher"
+	"github.com/juju/juju/environs/cloudspec"
 	"github.com/juju/juju/environs/config"
 )
 
@@ -39,6 +40,8 @@ type ModelInfoService interface {
 type CloudService interface {
 	Cloud(ctx context.Context, name string) (*cloud.Cloud, error)
 	WatchCloud(ctx context.Context, name string) (watcher.NotifyWatcher, error)
+	// CloudSpec returns a cloudspec.CloudSpec for the model with the given ID.
+	CloudSpec(ctx context.Context, modelID model.UUID) (cloudspec.CloudSpec, error)
 }
 
 // CredentialService provides access to credentials.

--- a/domain/cloud/service/service.go
+++ b/domain/cloud/service/service.go
@@ -10,8 +10,10 @@ import (
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/core/changestream"
+	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/user"
 	"github.com/juju/juju/core/watcher"
+	"github.com/juju/juju/environs/cloudspec"
 	"github.com/juju/juju/internal/uuid"
 )
 
@@ -38,6 +40,9 @@ type State interface {
 
 	// ListClouds returns the clouds matching the optional filter.
 	ListClouds(context.Context) ([]cloud.Cloud, error)
+
+	// CloudSpec returns a cloudspec.CloudSpec for the model with the given ID.
+	CloudSpec(ctx context.Context, modelID model.UUID) (cloudspec.CloudSpec, error)
 }
 
 // Service provides the API for working with clouds.
@@ -85,6 +90,11 @@ func (s *Service) ListAll(ctx context.Context) ([]cloud.Cloud, error) {
 func (s *Service) Cloud(ctx context.Context, name string) (*cloud.Cloud, error) {
 	cloud, err := s.st.Cloud(ctx, name)
 	return cloud, errors.Trace(err)
+}
+
+// CloudSpec returns a cloudspec.CloudSpec for the model with the given ID.
+func (s *Service) CloudSpec(ctx context.Context, modelID model.UUID) (cloudspec.CloudSpec, error) {
+	return s.st.CloudSpec(ctx, modelID)
 }
 
 // WatchableService defines a service for interacting with the underlying state

--- a/domain/cloud/state/state_test.go
+++ b/domain/cloud/state/state_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/juju/juju/domain/model"
 	modelstate "github.com/juju/juju/domain/model/state"
 	modelstatetesting "github.com/juju/juju/domain/model/state/testing"
+	"github.com/juju/juju/environs/cloudspec"
 	"github.com/juju/juju/internal/changestream/testing"
 	jujudb "github.com/juju/juju/internal/database"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
@@ -995,4 +996,25 @@ func (s *stateSuite) TestGetCloudForID(c *gc.C) {
 	cloud, err := st.GetCloudForID(context.Background(), id)
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(cloud, jc.DeepEquals, testCloud)
+}
+
+func (s *stateSuite) TestCloudSpec(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+	modelID := modelstatetesting.CreateTestModel(c, s.TxnRunnerFactory(), "test")
+
+	expectedCred := cloud.NewNamedCredential(
+		"foobar",
+		"access-key",
+		map[string]string{"": ""},
+		false,
+	)
+
+	cloudSpec, err := st.CloudSpec(context.Background(), modelID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(cloudSpec, jc.DeepEquals, cloudspec.CloudSpec{
+		Type:          "ec2",
+		Name:          "test",
+		SkipTLSVerify: true,
+		Credential:    &expectedCred,
+	})
 }

--- a/domain/cloud/state/types.go
+++ b/domain/cloud/state/types.go
@@ -3,6 +3,8 @@
 
 package state
 
+import "github.com/juju/juju/core/credential"
+
 // These structs represent the persistent cloud entity schema in the database.
 
 // cloudType represents a single row from the cloud_type table.
@@ -208,4 +210,10 @@ type dbAddUserPermission struct {
 	// ObjectType is the type of the object for this user for the
 	// GrantOn value.
 	ObjectType string `db:"object_type"`
+}
+
+type cloudSpecInfo struct {
+	CloudName    string        `db:"cloud_name"`
+	RegionName   string        `db:"cloud_region_name"`
+	CredentialID credential.ID `db:"cloud_credential_uuid"`
 }

--- a/domain/schema/controller/sql/0005-cloud.sql
+++ b/domain/schema/controller/sql/0005-cloud.sql
@@ -259,6 +259,6 @@ SELECT
     cca."key" AS attribute_key,
     cca.value AS attribute_value
 FROM v_cloud_credential AS cc
-INNER JOIN
+LEFT JOIN
     cloud_credential_attributes AS cca
     ON cc.uuid = cca.cloud_credential_uuid;


### PR DESCRIPTION
The logic inside the `apiserver/common/cloudspec` package is used by many facades to generate cloudspecs. This logic relies extensively on state model methods, including model config. Hence, we have to replace it using domain services.

This PR defines a new `CloudSpec` method on the cloud service, which returns the cloudspec for a given model. It also shows how this method could be used in the uniter facade.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

<!-- Describe steps to verify that the change works. -->

TODO

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Jira card:** JUJU-6489