### PR TITLE
refactor: use model config service instead of state

### DIFF
--- a/apiserver/facades/client/resources/base_test.go
+++ b/apiserver/facades/client/resources/base_test.go
@@ -4,6 +4,7 @@
 package resources_test
 
 import (
+	"context"
 	"time"
 
 	"github.com/juju/testing"
@@ -39,7 +40,7 @@ func (s *BaseSuite) setUpTest(c *gc.C) *gomock.Controller {
 }
 
 func (s *BaseSuite) newFacade(c *gc.C) *resources.API {
-	factoryFunc := func(_ *charm.URL) (resources.NewCharmRepository, error) {
+	factoryFunc := func(context.Context, *charm.URL) (resources.NewCharmRepository, error) {
 		return s.factory, nil
 	}
 	facade, err := resources.NewResourcesAPI(s.backend, factoryFunc, loggertesting.WrapCheckLog(c))

--- a/apiserver/facades/client/resources/server_test.go
+++ b/apiserver/facades/client/resources/server_test.go
@@ -4,6 +4,8 @@
 package resources_test
 
 import (
+	"context"
+
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -20,13 +22,13 @@ type FacadeSuite struct {
 
 func (s *FacadeSuite) TestNewFacadeOkay(c *gc.C) {
 	defer s.setUpTest(c).Finish()
-	_, err := resources.NewResourcesAPI(s.backend, func(*charm.URL) (resources.NewCharmRepository, error) { return s.factory, nil }, loggertesting.WrapCheckLog(c))
+	_, err := resources.NewResourcesAPI(s.backend, func(context.Context, *charm.URL) (resources.NewCharmRepository, error) { return s.factory, nil }, loggertesting.WrapCheckLog(c))
 	c.Check(err, jc.ErrorIsNil)
 }
 
 func (s *FacadeSuite) TestNewFacadeMissingDataStore(c *gc.C) {
 	defer s.setUpTest(c).Finish()
-	_, err := resources.NewResourcesAPI(nil, func(*charm.URL) (resources.NewCharmRepository, error) { return s.factory, nil }, loggertesting.WrapCheckLog(c))
+	_, err := resources.NewResourcesAPI(nil, func(context.Context, *charm.URL) (resources.NewCharmRepository, error) { return s.factory, nil }, loggertesting.WrapCheckLog(c))
 	c.Check(err, gc.ErrorMatches, `missing data backend`)
 }
 


### PR DESCRIPTION

Swap model config from state for the model config service. 

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [ ] ~Go unit tests, with comments saying what you're testing~
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```
$ juju bootstrap lxd testing
$ juju add-model five
$ juju deploy juju-qa-test
# Wait for active/idle status

# Trigger the resource use and validate
$ juju config juju-qa-test foo-file=true
$ juju status
...
App           Version  Status  Scale  Charm         Channel        Rev  Exposed  Message
juju-qa-test           active      1  juju-qa-test  latest/stable   25  no       resource line one: testing two.
...
```


## Links

**Jira card:** JUJU-6467

