### PR TITLE
fix: add info message when controller does not support backup download

### DIFF
--- a/api/client/backups/download.go
+++ b/api/client/backups/download.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/errors"
 	"gopkg.in/httprequest.v1"
 
+	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/rpc/params"
 )
 
@@ -36,7 +37,7 @@ func (c *Client) Download(filename string) (io.ReadCloser, error) {
 		&resp,
 	)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Trace(apiservererrors.RestoreError(err))
 	}
 	return resp.Body, nil
 }


### PR DESCRIPTION
Rather than a 404 message, print a nice error message if attempting to download a backup archive from a 4.0 controller, or any other which does not support the action.

## Checklist

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

If it hasn't been merged into main yet, use #17928 to bootstrap juju.

```
# Bootstrap juju from #17928 unless it's already merged. In that case use juju 4.0.
$ juju bootstrap lxd no-backup-download

# using the juju client built from this PR
$ juju download-backup -m controller /tmp/testme
Download of backup archive files is not supported by this controller.
```

## Links

**Jira card:** JUJU-6470

