### PR TITLE
fix: errors from GOOS=darwin make go-install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,6 @@ define INSTALL_TARGETS
 	juju \
 	jujuc \
 	jujud \
-	jujud-controller \
 	containeragent \
 	juju-metadata
 endef
@@ -162,6 +161,7 @@ endif
 
 # We only add pebble to the list of install targets if we are building for linux
 ifeq ($(GOOS), linux)
+	INSTALL_TARGETS += jujud-controller
 	INSTALL_TARGETS += pebble
 endif
 

--- a/internal/container/lxd/initialisation.go
+++ b/internal/container/lxd/initialisation.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/os/v2/series"
 	"github.com/juju/proxy"
 
+	"github.com/juju/juju/core/containermanager"
 	"github.com/juju/juju/internal/container"
 )
 
@@ -20,7 +21,7 @@ type containerInitialiser struct {
 var _ container.Initialiser = (*containerInitialiser)(nil)
 
 // NewContainerInitialiser  - on anything but Linux this is a NOP
-func NewContainerInitialiser(string, string) container.Initialiser {
+func NewContainerInitialiser(string, containermanager.NetworkingMethod) container.Initialiser {
 	return &containerInitialiser{}
 }
 

--- a/internal/worker/diskmanager/diskmanager_unsupported.go
+++ b/internal/worker/diskmanager/diskmanager_unsupported.go
@@ -8,14 +8,14 @@ package diskmanager
 import (
 	"runtime"
 
-	"github.com/juju/juju/internal/storage"
+	"github.com/juju/juju/core/blockdevice"
 )
 
-var blockDeviceInUse = func(storage.BlockDevice) (bool, error) {
+var blockDeviceInUse = func(blockdevice.BlockDevice) (bool, error) {
 	panic("not supported")
 }
 
-func listBlockDevices() ([]storage.BlockDevice, error) {
+func listBlockDevices() ([]blockdevice.BlockDevice, error) {
 	// Return an empty list each time.
 	return nil, nil
 }


### PR DESCRIPTION

Fixing errors found running `make go-install` on Darwin:
\# github.com/juju/juju/internal/worker/diskmanager
internal/worker/diskmanager/diskmanager_unsupported.go:14:37: undefined: storage.BlockDevice
internal/worker/diskmanager/diskmanager_unsupported.go:18:36: undefined: storage.BlockDevice
\# github.com/juju/juju/internal/worker/provisioner
internal/worker/provisioner/container_initialisation.go:161:58: cannot use containerNetworkingMethod (variable of type containermanager.NetworkingMethod) as string value in argument to lxd.NewContainerInitialiser

Running `make go-build` does not find the errors, thus they were not caught by our Build GitHub action.  `jujud-controller` is only supported for Ubuntu, update the `go-install` make target for darwin to not install it. 

Thanks to @SimonRichardson for the Makefile change to allow for `GOOS=darwin make go-install` to be happy and allow for updated GitHub actions on non ubuntu operating systems. 

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [ ] ~Comments saying why design decisions were made~
- [ ] ~Go unit tests, with comments saying what you're testing~
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```
`GOOS=darwin make go-install`
```

