### PR TITLE
WIP chore(portranges): use PortRanges constructor/methods

### DIFF
--- a/api/agent/uniter/uniter.go
+++ b/api/agent/uniter/uniter.go
@@ -415,9 +415,9 @@ func processOpenPortRangesByEndpointResults(results params.OpenPortRangesByEndpo
 		}
 		portRangeMap[unitTag] = make(network.GroupedPortRanges)
 		for _, group := range unitPortRanges {
-			portRangeMap[unitTag][group.Endpoint] = transform.Slice(group.PortRanges, func(pr params.PortRange) network.PortRange {
+			portRangeMap[unitTag][group.Endpoint] = network.NewPortRanges(transform.Slice(group.PortRanges, func(pr params.PortRange) network.PortRange {
 				return pr.NetworkPortRange()
-			})
+			})...)
 		}
 	}
 	return portRangeMap, nil

--- a/api/agent/uniter/uniter_test.go
+++ b/api/agent/uniter/uniter_test.go
@@ -80,11 +80,11 @@ func (s *uniterSuite) TestOpenedMachinePortRangesByEndpoint(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(portRangesMap, jc.DeepEquals, map[names.UnitTag]network.GroupedPortRanges{
 		names.NewUnitTag("mysql/0"): {
-			"":       []network.PortRange{network.MustParsePortRange("100-200/tcp")},
-			"server": []network.PortRange{network.MustParsePortRange("3306/tcp")},
+			"":       network.NewPortRanges(network.MustParsePortRange("100-200/tcp")),
+			"server": network.NewPortRanges(network.MustParsePortRange("3306/tcp")),
 		},
 		names.NewUnitTag("wordpress/0"): {
-			"monitoring-port": []network.PortRange{network.MustParsePortRange("1337/udp")},
+			"monitoring-port": network.NewPortRanges(network.MustParsePortRange("1337/udp")),
 		},
 	})
 }
@@ -128,11 +128,11 @@ func (s *uniterSuite) TestOpenedPortRangesByEndpoint(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, map[names.UnitTag]network.GroupedPortRanges{
 		names.NewUnitTag("mysql/0"): {
-			"":       []network.PortRange{network.MustParsePortRange("100-200/tcp")},
-			"server": []network.PortRange{network.MustParsePortRange("3306/tcp")},
+			"":       network.NewPortRanges(network.MustParsePortRange("100-200/tcp")),
+			"server": network.NewPortRanges(network.MustParsePortRange("3306/tcp")),
 		},
 		names.NewUnitTag("wordpress/0"): {
-			"monitoring-port": []network.PortRange{network.MustParsePortRange("1337/udp")},
+			"monitoring-port": network.NewPortRanges(network.MustParsePortRange("1337/udp")),
 		},
 	})
 }

--- a/api/controller/caasfirewaller/client.go
+++ b/api/controller/caasfirewaller/client.go
@@ -6,6 +6,7 @@ package caasfirewaller
 import (
 	"context"
 
+	"github.com/juju/collections/transform"
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 
@@ -94,9 +95,9 @@ func (c *Client) GetOpenedPorts(ctx context.Context, appName string) (network.Gr
 	}
 	out := make(network.GroupedPortRanges)
 	for _, pgs := range res.ApplicationPortRanges {
-		for _, pg := range pgs.PortRanges {
-			out[pgs.Endpoint] = append(out[pgs.Endpoint], pg.NetworkPortRange())
-		}
+		out[pgs.Endpoint] = network.NewPortRanges(transform.Slice(pgs.PortRanges, func(pr params.PortRange) network.PortRange {
+			return pr.NetworkPortRange()
+		})...)
 	}
 	return out, nil
 }

--- a/api/controller/caasfirewaller/client_test.go
+++ b/api/controller/caasfirewaller/client_test.go
@@ -100,13 +100,11 @@ func (s *firewallerSuite) TestGetOpenedPorts(c *gc.C) {
 	result, err := client.GetOpenedPorts(context.Background(), "gitlab")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, network.GroupedPortRanges{
-		"": []network.PortRange{
-			{
-				FromPort: 80,
-				ToPort:   8080,
-				Protocol: "tcp",
-			},
-		},
+		"": network.NewPortRanges(network.PortRange{
+			FromPort: 80,
+			ToPort:   8080,
+			Protocol: "tcp",
+		}),
 	})
 }
 

--- a/api/controller/firewaller/machine.go
+++ b/api/controller/firewaller/machine.go
@@ -137,9 +137,9 @@ func (m *Machine) OpenedMachinePortRanges(ctx context.Context) (byUnitAndCIDR ma
 				portList[i] = pr.NetworkPortRange()
 			}
 
-			byUnitAndEndpoint[unitTag][unitPortRanges.Endpoint] = append(byUnitAndEndpoint[unitTag][unitPortRanges.Endpoint], portList...)
+			byUnitAndEndpoint[unitTag][unitPortRanges.Endpoint] = append(byUnitAndEndpoint[unitTag][unitPortRanges.Endpoint], portList...).Normalise()
 			for _, cidr := range unitPortRanges.SubnetCIDRs {
-				byUnitAndCIDR[unitTag][cidr] = append(byUnitAndCIDR[unitTag][cidr], portList...)
+				byUnitAndCIDR[unitTag][cidr] = append(byUnitAndCIDR[unitTag][cidr], portList...).Normalise()
 			}
 		}
 	}

--- a/api/controller/firewaller/machine_test.go
+++ b/api/controller/firewaller/machine_test.go
@@ -224,44 +224,44 @@ func (s *machineSuite) TestOpenedPortRanges(c *gc.C) {
 
 	c.Assert(byUnitAndCIDR, jc.DeepEquals, map[names.UnitTag]network.GroupedPortRanges{
 		names.NewUnitTag("mysql/0"): {
-			"192.168.0.0/24": []network.PortRange{
+			"192.168.0.0/24": network.NewPortRanges(
 				network.MustParsePortRange("3306/tcp"),
-			},
-			"192.168.1.0/24": []network.PortRange{
+			),
+			"192.168.1.0/24": network.NewPortRanges(
 				network.MustParsePortRange("3306/tcp"),
-			},
+			),
 		},
 		names.NewUnitTag("wordpress/0"): {
-			"10.0.0.0/24": []network.PortRange{
+			"10.0.0.0/24": network.NewPortRanges(
 				network.MustParsePortRange("1337/tcp"),
-			},
-			"10.0.1.0/24": []network.PortRange{
+			),
+			"10.0.1.0/24": network.NewPortRanges(
 				network.MustParsePortRange("1337/tcp"),
-			},
-			"192.168.0.0/24": []network.PortRange{
+			),
+			"192.168.0.0/24": network.NewPortRanges(
 				network.MustParsePortRange("80/tcp"),
 				network.MustParsePortRange("1337/tcp"),
-			},
-			"192.168.1.0/24": []network.PortRange{
+			),
+			"192.168.1.0/24": network.NewPortRanges(
 				network.MustParsePortRange("80/tcp"),
 				network.MustParsePortRange("1337/tcp"),
-			},
+			),
 		},
 	})
 
 	c.Assert(byUnitAndEndpoint, jc.DeepEquals, map[names.UnitTag]network.GroupedPortRanges{
 		names.NewUnitTag("mysql/0"): {
-			"server": []network.PortRange{
+			"server": network.NewPortRanges(
 				network.MustParsePortRange("3306/tcp"),
-			},
+			),
 		},
 		names.NewUnitTag("wordpress/0"): {
-			"website": []network.PortRange{
+			"website": network.NewPortRanges(
 				network.MustParsePortRange("80/tcp"),
-			},
-			"metrics": []network.PortRange{
+			),
+			"metrics": network.NewPortRanges(
 				network.MustParsePortRange("1337/tcp"),
-			},
+			),
 		},
 	})
 	c.Assert(calls, gc.Equals, 2)

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -3595,7 +3595,7 @@ func (s *uniterSuite) TestCommitHookChangesWithPortsSidecarApplication(c *gc.C) 
 
 	c.Assert(portRanges.UniquePortRanges(), jc.DeepEquals, []network.PortRange{{Protocol: "tcp", FromPort: 80, ToPort: 80}})
 	c.Assert(portRanges.ByEndpoint(), jc.DeepEquals, network.GroupedPortRanges{
-		"db": []network.PortRange{network.MustParsePortRange("80/tcp")},
+		"db": network.NewPortRanges(network.MustParsePortRange("80/tcp")),
 	})
 }
 

--- a/apiserver/facades/client/application/mocks/state_mock.go
+++ b/apiserver/facades/client/application/mocks/state_mock.go
@@ -754,10 +754,10 @@ func (c *MockUnitPortRangesOpenCall) DoAndReturn(f func(string, network.PortRang
 }
 
 // UniquePortRanges mocks base method.
-func (m *MockUnitPortRanges) UniquePortRanges() []network.PortRange {
+func (m *MockUnitPortRanges) UniquePortRanges() network.PortRanges {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UniquePortRanges")
-	ret0, _ := ret[0].([]network.PortRange)
+	ret0, _ := ret[0].(network.PortRanges)
 	return ret0
 }
 
@@ -774,19 +774,19 @@ type MockUnitPortRangesUniquePortRangesCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockUnitPortRangesUniquePortRangesCall) Return(arg0 []network.PortRange) *MockUnitPortRangesUniquePortRangesCall {
+func (c *MockUnitPortRangesUniquePortRangesCall) Return(arg0 network.PortRanges) *MockUnitPortRangesUniquePortRangesCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockUnitPortRangesUniquePortRangesCall) Do(f func() []network.PortRange) *MockUnitPortRangesUniquePortRangesCall {
+func (c *MockUnitPortRangesUniquePortRangesCall) Do(f func() network.PortRanges) *MockUnitPortRangesUniquePortRangesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockUnitPortRangesUniquePortRangesCall) DoAndReturn(f func() []network.PortRange) *MockUnitPortRangesUniquePortRangesCall {
+func (c *MockUnitPortRangesUniquePortRangesCall) DoAndReturn(f func() network.PortRanges) *MockUnitPortRangesUniquePortRangesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/controller/caasfirewaller/firewaller_test.go
+++ b/apiserver/facades/controller/caasfirewaller/firewaller_test.go
@@ -129,20 +129,16 @@ func (s *firewallerSuite) TestWatchOpenedPorts(c *gc.C) {
 
 func (s *firewallerSuite) TestGetApplicationOpenedPorts(c *gc.C) {
 	s.st.application.appPortRanges = network.GroupedPortRanges{
-		"": []network.PortRange{
-			{
-				FromPort: 80,
-				ToPort:   80,
-				Protocol: "tcp",
-			},
-		},
-		"endport-1": []network.PortRange{
-			{
-				FromPort: 8888,
-				ToPort:   8888,
-				Protocol: "tcp",
-			},
-		},
+		"": network.NewPortRanges(network.PortRange{
+			FromPort: 80,
+			ToPort:   80,
+			Protocol: "tcp",
+		}),
+		"endport-1": network.NewPortRanges(network.PortRange{
+			FromPort: 8888,
+			ToPort:   8888,
+			Protocol: "tcp",
+		}),
 	}
 
 	results, err := s.facade.GetOpenedPorts(context.Background(), params.Entity{

--- a/apiserver/facades/controller/firewaller/firewaller_internal_test.go
+++ b/apiserver/facades/controller/firewaller/firewaller_internal_test.go
@@ -19,17 +19,17 @@ type UnitToCIDRMappingSuite struct {
 
 func (s *UnitToCIDRMappingSuite) TestBindingMapping(c *gc.C) {
 	portRangesByEndpoint := network.GroupedPortRanges{
-		"foo": []network.PortRange{
+		"foo": network.NewPortRanges(
 			network.MustParsePortRange("123/tcp"),
 			network.MustParsePortRange("456/tcp"),
-		},
-		"bar": []network.PortRange{
+		),
+		"bar": network.NewPortRanges(
 			// The descending ordering here is intentional so that
 			// we can verify that the output list entries do get
 			// sorted.
 			network.MustParsePortRange("777/tcp"),
 			network.MustParsePortRange("123/tcp"),
-		},
+		),
 	}
 	endpointBindings := map[string]string{
 		"": network.AlphaSpaceId,
@@ -74,15 +74,15 @@ func (s *UnitToCIDRMappingSuite) TestBindingMapping(c *gc.C) {
 
 func (s *UnitToCIDRMappingSuite) TestWildcardExpansion(c *gc.C) {
 	portRangesByEndpoint := network.GroupedPortRanges{
-		"": []network.PortRange{
+		"": network.NewPortRanges(
 			// These ranges should be added to the CIDRs of each
 			// bound endpoint (so, both alpha and "42").
 			network.MustParsePortRange("123/tcp"),
 			network.MustParsePortRange("456/tcp"),
-		},
-		"bar": []network.PortRange{
+		),
+		"bar": network.NewPortRanges(
 			network.MustParsePortRange("999/tcp"),
-		},
+		),
 	}
 	endpointBindings := map[string]string{
 		"":    network.AlphaSpaceId,

--- a/apiserver/facades/controller/firewaller/firewaller_unit_test.go
+++ b/apiserver/facades/controller/firewaller/firewaller_unit_test.go
@@ -308,17 +308,17 @@ func (s *FirewallerSuite) TestOpenedMachinePortRanges(c *gc.C) {
 		newMockUnitPortRanges(
 			"wordpress/0",
 			network.GroupedPortRanges{
-				"": []network.PortRange{
+				"": network.NewPortRanges(
 					network.MustParsePortRange("80/tcp"),
-				},
+				),
 			},
 		),
 		newMockUnitPortRanges(
 			"mysql/0",
 			network.GroupedPortRanges{
-				"foo": []network.PortRange{
+				"foo": network.NewPortRanges(
 					network.MustParsePortRange("3306/tcp"),
-				},
+				),
 			},
 		),
 	)

--- a/core/network/portrange.go
+++ b/core/network/portrange.go
@@ -45,14 +45,12 @@ func (grp GroupedPortRanges) MergePendingClosePortRanges(pendingCloseRanges Grou
 }
 
 // UniquePortRanges returns the unique set of PortRanges in this group.
-func (grp GroupedPortRanges) UniquePortRanges() []PortRange {
-	var allPorts []PortRange
+func (grp GroupedPortRanges) UniquePortRanges() PortRanges {
+	var res []PortRange
 	for _, portRanges := range grp {
-		allPorts = append(allPorts, portRanges...)
+		res = append(res, portRanges...)
 	}
-	uniquePortRanges := UniquePortRanges(allPorts)
-	SortPortRanges(uniquePortRanges)
-	return uniquePortRanges
+	return NewPortRanges(res...)
 }
 
 // Clone returns a copy of this port range grouping.

--- a/core/network/portrange_test.go
+++ b/core/network/portrange_test.go
@@ -416,10 +416,10 @@ func (p *PortRangeSuite) TestUniquePortRangesInGroup(c *gc.C) {
 		),
 	}
 
-	exp := []network.PortRange{
+	exp := network.NewPortRanges(
 		network.MustParsePortRange("123/tcp"),
 		network.MustParsePortRange("456/tcp"),
-	}
+	)
 
 	got := in.UniquePortRanges()
 	c.Assert(got, gc.DeepEquals, exp, gc.Commentf("expected duplicate port ranges to be removed"))

--- a/core/network/portrange_test.go
+++ b/core/network/portrange_test.go
@@ -406,14 +406,14 @@ func (p *PortRangeSuite) TestUniquePortRanges(c *gc.C) {
 
 func (p *PortRangeSuite) TestUniquePortRangesInGroup(c *gc.C) {
 	in := network.GroupedPortRanges{
-		"foxtrot": []network.PortRange{
+		"foxtrot": network.NewPortRanges(
 			network.MustParsePortRange("123/tcp"),
 			network.MustParsePortRange("123/tcp"),
-		},
-		"unicorn": []network.PortRange{
+		),
+		"unicorn": network.NewPortRanges(
 			network.MustParsePortRange("123/tcp"),
 			network.MustParsePortRange("456/tcp"),
-		},
+		),
 	}
 
 	exp := []network.PortRange{
@@ -434,52 +434,52 @@ func (p *PortRangeSuite) TestGroupedPortRangesEquality(c *gc.C) {
 		{
 			descr: "equal port ranges in random order",
 			a: network.GroupedPortRanges{
-				"foo": []network.PortRange{
+				"foo": network.NewPortRanges(
 					network.MustParsePortRange("123/tcp"),
 					network.MustParsePortRange("456/tcp"),
-				},
-				"bar": []network.PortRange{
+				),
+				"bar": network.NewPortRanges(
 					network.MustParsePortRange("123/tcp"),
-				},
+				),
 			},
 			b: network.GroupedPortRanges{
-				"foo": []network.PortRange{
+				"foo": network.NewPortRanges(
 					network.MustParsePortRange("456/tcp"),
 					network.MustParsePortRange("123/tcp"),
-				},
-				"bar": []network.PortRange{
+				),
+				"bar": network.NewPortRanges(
 					network.MustParsePortRange("123/tcp"),
-				},
+				),
 			},
 			expEqual: true,
 		},
 		{
 			descr: "groups with different lengths",
 			a: network.GroupedPortRanges{
-				"foo": []network.PortRange{
+				"foo": network.NewPortRanges(
 					network.MustParsePortRange("123/tcp"),
 					network.MustParsePortRange("456/tcp"),
-				},
+				),
 			},
 			b: network.GroupedPortRanges{
-				"foo": []network.PortRange{
+				"foo": network.NewPortRanges(
 					network.MustParsePortRange("123/tcp"),
-				},
+				),
 			},
 			expEqual: false,
 		},
 		{
 			descr: "groups with same length but different keys",
 			a: network.GroupedPortRanges{
-				"foo": []network.PortRange{
+				"foo": network.NewPortRanges(
 					network.MustParsePortRange("123/tcp"),
 					network.MustParsePortRange("456/tcp"),
-				},
+				),
 			},
 			b: network.GroupedPortRanges{
-				"bar": []network.PortRange{
+				"bar": network.NewPortRanges(
 					network.MustParsePortRange("123/tcp"),
-				},
+				),
 			},
 			expEqual: false,
 		},

--- a/internal/worker/caasfirewaller/applicationworker.go
+++ b/internal/worker/caasfirewaller/applicationworker.go
@@ -158,7 +158,6 @@ func (w *applicationWorker) loop() (err error) {
 
 func toServicePorts(in network.GroupedPortRanges) []caas.ServicePort {
 	ports := in.UniquePortRanges()
-	network.SortPortRanges(ports)
 	out := make([]caas.ServicePort, len(ports))
 	for i, p := range ports {
 		out[i] = caas.ServicePort{

--- a/internal/worker/caasfirewaller/applicationworker_test.go
+++ b/internal/worker/caasfirewaller/applicationworker_test.go
@@ -98,18 +98,18 @@ func (s *appWorkerSuite) TestWorker(c *gc.C) {
 	}()
 
 	gpr1 := network.GroupedPortRanges{
-		"": []network.PortRange{
+		"": network.NewPortRanges(
 			network.MustParsePortRange("1000/tcp"),
-		},
+		),
 	}
 
 	gpr2 := network.GroupedPortRanges{
-		"": []network.PortRange{
+		"": network.NewPortRanges(
 			network.MustParsePortRange("1000/tcp"),
-		},
-		"monitoring-port": []network.PortRange{
+		),
+		"monitoring-port": network.NewPortRanges(
 			network.MustParsePortRange("2000/udp"),
-		},
+		),
 	}
 
 	gomock.InOrder(
@@ -120,7 +120,7 @@ func (s *appWorkerSuite) TestWorker(c *gc.C) {
 		// initial fetch.
 		s.firewallerAPI.EXPECT().GetOpenedPorts(gomock.Any(), s.appName).Return(network.GroupedPortRanges{}, nil),
 
-		// 1st triggerred by port change event.
+		// 1st triggered by port change event.
 		s.firewallerAPI.EXPECT().GetOpenedPorts(gomock.Any(), s.appName).Return(gpr1, nil),
 		s.brokerApp.EXPECT().UpdatePorts([]caas.ServicePort{
 			{
@@ -131,10 +131,10 @@ func (s *appWorkerSuite) TestWorker(c *gc.C) {
 			},
 		}, false).Return(nil),
 
-		// 2nd triggerred by port change event, no UpdatePorts because no diff on the portchanges.
+		// 2nd triggered by port change event, no UpdatePorts because no diff on the portchanges.
 		s.firewallerAPI.EXPECT().GetOpenedPorts(gomock.Any(), s.appName).Return(gpr1, nil),
 
-		// 1rd triggerred by port change event.
+		// 1rd triggered by port change event.
 		s.firewallerAPI.EXPECT().GetOpenedPorts(gomock.Any(), s.appName).Return(gpr2, nil),
 		s.brokerApp.EXPECT().UpdatePorts([]caas.ServicePort{
 			{

--- a/internal/worker/uniter/runner/context/context_test.go
+++ b/internal/worker/uniter/runner/context/context_test.go
@@ -993,20 +993,20 @@ func (s *HookContextSuite) TestOpenedPortRanges(c *gc.C) {
 	// OpenedPortRanges() should return the pending requests, see
 	// https://bugs.launchpad.net/juju/+bug/2008035
 	openedPorts := hookContext.OpenedPortRanges()
-	expectedOpenPorts := []network.PortRange{
+	expectedOpenPorts := network.NewPortRanges(
 		// Already present range from NewMockUnitHookContext()
-		{
+		network.PortRange{
 			FromPort: 666,
 			ToPort:   888,
 			Protocol: "tcp",
 		},
 		// Newly added but not yet flushed range
-		{
+		network.PortRange{
 			FromPort: 8080,
 			ToPort:   8080,
 			Protocol: "tcp",
 		},
-	}
+	)
 	c.Assert(openedPorts.UniquePortRanges(), gc.DeepEquals, expectedOpenPorts)
 
 	err = hookContext.Flush(stdcontext.Background(), "success", nil)

--- a/internal/worker/uniter/runner/context/export_test.go
+++ b/internal/worker/uniter/runner/context/export_test.go
@@ -120,7 +120,7 @@ func NewMockUnitHookContext(c *gc.C, mockUnit *api.MockUnit, modelType model.Mod
 		portRangeChanges: newPortRangeChangeRecorder(logger, mockUnit.Tag(), modelType, nil,
 			map[names.UnitTag]network.GroupedPortRanges{
 				mockUnit.Tag(): {
-					"": []network.PortRange{network.MustParsePortRange("666-888/tcp")},
+					"": network.NewPortRanges(network.MustParsePortRange("666-888/tcp")),
 				},
 			},
 		),

--- a/internal/worker/uniter/runner/context/flush_test.go
+++ b/internal/worker/uniter/runner/context/flush_test.go
@@ -204,10 +204,10 @@ func (s *FlushContextSuite) TestRunHookOpensAndClosesPendingPorts(c *gc.C) {
 	// Open some ports on this unit and another one.
 	s.machinePortRanges = map[names.UnitTag]network.GroupedPortRanges{
 		s.unit.Tag(): {
-			allEndpoints: []network.PortRange{network.MustParsePortRange("100-200/tcp")},
+			allEndpoints: network.NewPortRanges(network.MustParsePortRange("100-200/tcp")),
 		},
 		names.NewUnitTag("u/1"): {
-			allEndpoints: []network.PortRange{network.MustParsePortRange("200-300/udp")},
+			allEndpoints: network.NewPortRanges(network.MustParsePortRange("200-300/udp")),
 		},
 	}
 

--- a/internal/worker/uniter/runner/context/ports.go
+++ b/internal/worker/uniter/runner/context/ports.go
@@ -96,7 +96,11 @@ func (r *portRangeChangeRecorder) OpenPortRange(endpointName string, portRange n
 	if r.pendingOpenRanges == nil {
 		r.pendingOpenRanges = make(network.GroupedPortRanges)
 	}
-	r.pendingOpenRanges[endpointName] = append(r.pendingOpenRanges[endpointName], portRange)
+	if r.pendingOpenRanges[endpointName] == nil {
+		r.pendingOpenRanges[endpointName] = network.NewPortRanges(portRange)
+	} else {
+		r.pendingOpenRanges[endpointName] = r.pendingOpenRanges[endpointName].Add(portRange)
+	}
 	return nil
 }
 
@@ -174,7 +178,11 @@ func (r *portRangeChangeRecorder) ClosePortRange(endpointName string, portRange 
 	if r.pendingCloseRanges == nil {
 		r.pendingCloseRanges = make(network.GroupedPortRanges)
 	}
-	r.pendingCloseRanges[endpointName] = append(r.pendingCloseRanges[endpointName], portRange)
+	if r.pendingCloseRanges[endpointName] == nil {
+		r.pendingCloseRanges[endpointName] = network.NewPortRanges(portRange)
+	} else {
+		r.pendingCloseRanges[endpointName] = r.pendingCloseRanges[endpointName].Add(portRange)
+	}
 	return nil
 }
 
@@ -239,10 +247,7 @@ func (r *portRangeChangeRecorder) PendingChanges() (network.GroupedPortRanges, n
 // pending open and close changes.
 func (r *portRangeChangeRecorder) mergeWithPendingChanges(portRanges network.GroupedPortRanges) network.GroupedPortRanges {
 
-	resultingChanges := make(network.GroupedPortRanges)
-	for group, ranges := range portRanges {
-		resultingChanges[group] = append(resultingChanges[group], ranges...)
-	}
+	resultingChanges := portRanges.Clone()
 
 	// Add the pending open changes
 	resultingChanges.MergePendingOpenPortRanges(r.pendingOpenRanges)

--- a/internal/worker/uniter/runner/context/ports_test.go
+++ b/internal/worker/uniter/runner/context/ports_test.go
@@ -45,7 +45,7 @@ func (s *PortRangeChangeRecorderSuite) TestOpenPortRange(c *gc.C) {
 			targetEndpoint:  "",
 			targetPortRange: network.MustParsePortRange("10-20/tcp"),
 			expectPendingOpen: network.GroupedPortRanges{
-				"": []network.PortRange{network.MustParsePortRange("10-20/tcp")},
+				"": network.NewPortRanges(network.MustParsePortRange("10-20/tcp")),
 			},
 		},
 		{
@@ -54,7 +54,7 @@ func (s *PortRangeChangeRecorderSuite) TestOpenPortRange(c *gc.C) {
 			targetPortRange: network.MustParsePortRange("10-20/tcp"),
 			machinePortRanges: map[names.UnitTag]network.GroupedPortRanges{
 				names.NewUnitTag("u/0"): {
-					"": []network.PortRange{network.MustParsePortRange("10-20/tcp")},
+					"": network.NewPortRanges(network.MustParsePortRange("10-20/tcp")),
 				},
 			},
 		},
@@ -64,11 +64,11 @@ func (s *PortRangeChangeRecorderSuite) TestOpenPortRange(c *gc.C) {
 			targetPortRange: network.MustParsePortRange("10-20/tcp"),
 			machinePortRanges: map[names.UnitTag]network.GroupedPortRanges{
 				names.NewUnitTag("u/0"): {
-					"": []network.PortRange{network.MustParsePortRange("10-20/tcp")},
+					"": network.NewPortRanges(network.MustParsePortRange("10-20/tcp")),
 				},
 			},
 			expectPendingOpen: network.GroupedPortRanges{
-				"foo": []network.PortRange{network.MustParsePortRange("10-20/tcp")},
+				"foo": network.NewPortRanges(network.MustParsePortRange("10-20/tcp")),
 			},
 		},
 		{
@@ -76,15 +76,15 @@ func (s *PortRangeChangeRecorderSuite) TestOpenPortRange(c *gc.C) {
 			targetEndpoint:  "foo",
 			targetPortRange: network.MustParsePortRange("10-20/tcp"),
 			pendingCloseRanges: network.GroupedPortRanges{
-				"foo": []network.PortRange{network.MustParsePortRange("10-20/tcp")},
+				"foo": network.NewPortRanges(network.MustParsePortRange("10-20/tcp")),
 			},
 			machinePortRanges: map[names.UnitTag]network.GroupedPortRanges{
 				names.NewUnitTag("u/0"): {
-					"foo": []network.PortRange{network.MustParsePortRange("10-20/tcp")},
+					"foo": network.NewPortRanges(network.MustParsePortRange("10-20/tcp")),
 				},
 			},
 			expectPendingClose: network.GroupedPortRanges{
-				"foo": []network.PortRange{},
+				"foo": network.NewPortRanges(),
 			},
 		},
 		{
@@ -93,7 +93,7 @@ func (s *PortRangeChangeRecorderSuite) TestOpenPortRange(c *gc.C) {
 			targetPortRange: network.MustParsePortRange("10-20/tcp"),
 			applicationPortRanges: map[names.UnitTag]network.GroupedPortRanges{
 				names.NewUnitTag("u/0"): {
-					"": []network.PortRange{network.MustParsePortRange("10-20/tcp")},
+					"": network.NewPortRanges(network.MustParsePortRange("10-20/tcp")),
 				},
 			},
 		},
@@ -103,11 +103,11 @@ func (s *PortRangeChangeRecorderSuite) TestOpenPortRange(c *gc.C) {
 			targetPortRange: network.MustParsePortRange("10-20/tcp"),
 			applicationPortRanges: map[names.UnitTag]network.GroupedPortRanges{
 				names.NewUnitTag("u/0"): {
-					"": []network.PortRange{network.MustParsePortRange("10-20/tcp")},
+					"": network.NewPortRanges(network.MustParsePortRange("10-20/tcp")),
 				},
 			},
 			expectPendingOpen: network.GroupedPortRanges{
-				"foo": []network.PortRange{network.MustParsePortRange("10-20/tcp")},
+				"foo": network.NewPortRanges(network.MustParsePortRange("10-20/tcp")),
 			},
 		},
 		{
@@ -115,15 +115,15 @@ func (s *PortRangeChangeRecorderSuite) TestOpenPortRange(c *gc.C) {
 			targetEndpoint:  "foo",
 			targetPortRange: network.MustParsePortRange("10-20/tcp"),
 			pendingCloseRanges: network.GroupedPortRanges{
-				"foo": []network.PortRange{network.MustParsePortRange("10-20/tcp")},
+				"foo": network.NewPortRanges(network.MustParsePortRange("10-20/tcp")),
 			},
 			applicationPortRanges: map[names.UnitTag]network.GroupedPortRanges{
 				names.NewUnitTag("u/0"): {
-					"foo": []network.PortRange{network.MustParsePortRange("10-20/tcp")},
+					"foo": network.NewPortRanges(network.MustParsePortRange("10-20/tcp")),
 				},
 			},
 			expectPendingClose: network.GroupedPortRanges{
-				"foo": []network.PortRange{},
+				"foo": network.NewPortRanges(),
 			},
 		},
 		{
@@ -131,13 +131,13 @@ func (s *PortRangeChangeRecorderSuite) TestOpenPortRange(c *gc.C) {
 			targetEndpoint:  "",
 			targetPortRange: network.MustParsePortRange("10-20/tcp"),
 			pendingCloseRanges: network.GroupedPortRanges{
-				"": []network.PortRange{network.MustParsePortRange("10-20/tcp")},
+				"": network.NewPortRanges(network.MustParsePortRange("10-20/tcp")),
 			},
 			expectPendingOpen: network.GroupedPortRanges{
-				"": []network.PortRange{network.MustParsePortRange("10-20/tcp")},
+				"": network.NewPortRanges(network.MustParsePortRange("10-20/tcp")),
 			},
 			expectPendingClose: network.GroupedPortRanges{
-				"": []network.PortRange{},
+				"": network.NewPortRanges(),
 			},
 		},
 		{
@@ -145,10 +145,10 @@ func (s *PortRangeChangeRecorderSuite) TestOpenPortRange(c *gc.C) {
 			targetEndpoint:  "",
 			targetPortRange: network.MustParsePortRange("10-20/tcp"),
 			pendingOpenRanges: network.GroupedPortRanges{
-				"": []network.PortRange{network.MustParsePortRange("10-20/tcp")},
+				"": network.NewPortRanges(network.MustParsePortRange("10-20/tcp")),
 			},
 			expectPendingOpen: network.GroupedPortRanges{
-				"": []network.PortRange{network.MustParsePortRange("10-20/tcp")},
+				"": network.NewPortRanges(network.MustParsePortRange("10-20/tcp")),
 			},
 		},
 		{
@@ -157,7 +157,7 @@ func (s *PortRangeChangeRecorderSuite) TestOpenPortRange(c *gc.C) {
 			targetPortRange: network.MustParsePortRange("10-20/tcp"),
 			machinePortRanges: map[names.UnitTag]network.GroupedPortRanges{
 				names.NewUnitTag("other/0"): {
-					"": []network.PortRange{network.MustParsePortRange("10-20/tcp")},
+					"": network.NewPortRanges(network.MustParsePortRange("10-20/tcp")),
 				},
 			},
 			expectErr: `cannot open 10-20/tcp \(unit "u/0"\): port range conflicts with 10-20/tcp \(unit "other/0"\)`,
@@ -168,7 +168,7 @@ func (s *PortRangeChangeRecorderSuite) TestOpenPortRange(c *gc.C) {
 			targetPortRange: network.MustParsePortRange("1-200/tcp"),
 			machinePortRanges: map[names.UnitTag]network.GroupedPortRanges{
 				names.NewUnitTag("u/0"): {
-					"": []network.PortRange{network.MustParsePortRange("10-20/tcp")},
+					"": network.NewPortRanges(network.MustParsePortRange("10-20/tcp")),
 				},
 			},
 			expectErr: `cannot open 1-200/tcp \(unit "u/0"\): port range conflicts with 10-20/tcp \(unit "u/0"\)`,
@@ -178,7 +178,7 @@ func (s *PortRangeChangeRecorderSuite) TestOpenPortRange(c *gc.C) {
 			targetEndpoint:  "",
 			targetPortRange: network.MustParsePortRange("1-200/tcp"),
 			pendingOpenRanges: network.GroupedPortRanges{
-				"": []network.PortRange{network.MustParsePortRange("10-20/tcp")},
+				"": network.NewPortRanges(network.MustParsePortRange("10-20/tcp")),
 			},
 			expectErr: `cannot open 1-200/tcp \(unit "u/0"\): port range conflicts with 10-20/tcp \(unit "u/0"\) requested earlier`,
 		},
@@ -195,7 +195,7 @@ func (s *PortRangeChangeRecorderSuite) TestOpenPortRange(c *gc.C) {
 			isCAAS:          true,
 			targetPortRange: network.MustParsePortRange("80/tcp"),
 			expectPendingOpen: network.GroupedPortRanges{
-				"": []network.PortRange{network.MustParsePortRange("80/tcp")},
+				"": network.NewPortRanges(network.MustParsePortRange("80/tcp")),
 			},
 		},
 	}
@@ -239,11 +239,11 @@ func (s *PortRangeChangeRecorderSuite) TestClosePortRange(c *gc.C) {
 			targetPortRange: network.MustParsePortRange("10-20/tcp"),
 			machinePortRanges: map[names.UnitTag]network.GroupedPortRanges{
 				names.NewUnitTag("u/0"): {
-					"": []network.PortRange{network.MustParsePortRange("10-20/tcp")},
+					"": network.NewPortRanges(network.MustParsePortRange("10-20/tcp")),
 				},
 			},
 			expectPendingClose: network.GroupedPortRanges{
-				"": []network.PortRange{network.MustParsePortRange("10-20/tcp")},
+				"": network.NewPortRanges(network.MustParsePortRange("10-20/tcp")),
 			},
 		},
 		{
@@ -252,11 +252,11 @@ func (s *PortRangeChangeRecorderSuite) TestClosePortRange(c *gc.C) {
 			targetPortRange: network.MustParsePortRange("10-20/tcp"),
 			machinePortRanges: map[names.UnitTag]network.GroupedPortRanges{
 				names.NewUnitTag("u/0"): {
-					"": []network.PortRange{network.MustParsePortRange("10-20/tcp")},
+					"": network.NewPortRanges(network.MustParsePortRange("10-20/tcp")),
 				},
 			},
 			expectPendingClose: network.GroupedPortRanges{
-				"foo": []network.PortRange{network.MustParsePortRange("10-20/tcp")},
+				"foo": network.NewPortRanges(network.MustParsePortRange("10-20/tcp")),
 			},
 		},
 		{
@@ -265,11 +265,11 @@ func (s *PortRangeChangeRecorderSuite) TestClosePortRange(c *gc.C) {
 			targetPortRange: network.MustParsePortRange("10-20/tcp"),
 			applicationPortRanges: map[names.UnitTag]network.GroupedPortRanges{
 				names.NewUnitTag("u/0"): {
-					"": []network.PortRange{network.MustParsePortRange("10-20/tcp")},
+					"": network.NewPortRanges(network.MustParsePortRange("10-20/tcp")),
 				},
 			},
 			expectPendingClose: network.GroupedPortRanges{
-				"": []network.PortRange{network.MustParsePortRange("10-20/tcp")},
+				"": network.NewPortRanges(network.MustParsePortRange("10-20/tcp")),
 			},
 		},
 		{
@@ -278,11 +278,11 @@ func (s *PortRangeChangeRecorderSuite) TestClosePortRange(c *gc.C) {
 			targetPortRange: network.MustParsePortRange("10-20/tcp"),
 			applicationPortRanges: map[names.UnitTag]network.GroupedPortRanges{
 				names.NewUnitTag("u/0"): {
-					"": []network.PortRange{network.MustParsePortRange("10-20/tcp")},
+					"": network.NewPortRanges(network.MustParsePortRange("10-20/tcp")),
 				},
 			},
 			expectPendingClose: network.GroupedPortRanges{
-				"foo": []network.PortRange{network.MustParsePortRange("10-20/tcp")},
+				"foo": network.NewPortRanges(network.MustParsePortRange("10-20/tcp")),
 			},
 		},
 		{
@@ -290,10 +290,10 @@ func (s *PortRangeChangeRecorderSuite) TestClosePortRange(c *gc.C) {
 			targetEndpoint:  "foo",
 			targetPortRange: network.MustParsePortRange("10-20/tcp"),
 			pendingOpenRanges: network.GroupedPortRanges{
-				"foo": []network.PortRange{network.MustParsePortRange("10-20/tcp")},
+				"foo": network.NewPortRanges(network.MustParsePortRange("10-20/tcp")),
 			},
 			expectPendingOpen: network.GroupedPortRanges{
-				"foo": []network.PortRange{},
+				"foo": network.NewPortRanges(),
 			},
 		},
 		{
@@ -302,17 +302,17 @@ func (s *PortRangeChangeRecorderSuite) TestClosePortRange(c *gc.C) {
 			targetPortRange: network.MustParsePortRange("10-20/tcp"),
 			machinePortRanges: map[names.UnitTag]network.GroupedPortRanges{
 				names.NewUnitTag("u/0"): {
-					"": []network.PortRange{network.MustParsePortRange("10-20/tcp")},
+					"": network.NewPortRanges(network.MustParsePortRange("10-20/tcp")),
 				},
 			},
 			pendingOpenRanges: network.GroupedPortRanges{
-				"": []network.PortRange{network.MustParsePortRange("10-20/tcp")},
+				"": network.NewPortRanges(network.MustParsePortRange("10-20/tcp")),
 			},
 			expectPendingOpen: network.GroupedPortRanges{
-				"": []network.PortRange{},
+				"": network.NewPortRanges(),
 			},
 			expectPendingClose: network.GroupedPortRanges{
-				"": []network.PortRange{network.MustParsePortRange("10-20/tcp")},
+				"": network.NewPortRanges(network.MustParsePortRange("10-20/tcp")),
 			},
 		},
 		{
@@ -321,14 +321,14 @@ func (s *PortRangeChangeRecorderSuite) TestClosePortRange(c *gc.C) {
 			targetPortRange: network.MustParsePortRange("10-20/tcp"),
 			machinePortRanges: map[names.UnitTag]network.GroupedPortRanges{
 				names.NewUnitTag("u/0"): {
-					"": []network.PortRange{network.MustParsePortRange("10-20/tcp")},
+					"": network.NewPortRanges(network.MustParsePortRange("10-20/tcp")),
 				},
 			},
 			pendingCloseRanges: network.GroupedPortRanges{
-				"": []network.PortRange{network.MustParsePortRange("10-20/tcp")},
+				"": network.NewPortRanges(network.MustParsePortRange("10-20/tcp")),
 			},
 			expectPendingClose: network.GroupedPortRanges{
-				"": []network.PortRange{network.MustParsePortRange("10-20/tcp")},
+				"": network.NewPortRanges(network.MustParsePortRange("10-20/tcp")),
 			},
 		},
 		{
@@ -337,17 +337,17 @@ func (s *PortRangeChangeRecorderSuite) TestClosePortRange(c *gc.C) {
 			targetPortRange: network.MustParsePortRange("10-20/tcp"),
 			applicationPortRanges: map[names.UnitTag]network.GroupedPortRanges{
 				names.NewUnitTag("u/0"): {
-					"": []network.PortRange{network.MustParsePortRange("10-20/tcp")},
+					"": network.NewPortRanges(network.MustParsePortRange("10-20/tcp")),
 				},
 			},
 			pendingOpenRanges: network.GroupedPortRanges{
-				"": []network.PortRange{network.MustParsePortRange("10-20/tcp")},
+				"": network.NewPortRanges(network.MustParsePortRange("10-20/tcp")),
 			},
 			expectPendingOpen: network.GroupedPortRanges{
-				"": []network.PortRange{},
+				"": network.NewPortRanges(),
 			},
 			expectPendingClose: network.GroupedPortRanges{
-				"": []network.PortRange{network.MustParsePortRange("10-20/tcp")},
+				"": network.NewPortRanges(network.MustParsePortRange("10-20/tcp")),
 			},
 		},
 		{
@@ -356,14 +356,14 @@ func (s *PortRangeChangeRecorderSuite) TestClosePortRange(c *gc.C) {
 			targetPortRange: network.MustParsePortRange("10-20/tcp"),
 			applicationPortRanges: map[names.UnitTag]network.GroupedPortRanges{
 				names.NewUnitTag("u/0"): {
-					"": []network.PortRange{network.MustParsePortRange("10-20/tcp")},
+					"": network.NewPortRanges(network.MustParsePortRange("10-20/tcp")),
 				},
 			},
 			pendingCloseRanges: network.GroupedPortRanges{
-				"": []network.PortRange{network.MustParsePortRange("10-20/tcp")},
+				"": network.NewPortRanges(network.MustParsePortRange("10-20/tcp")),
 			},
 			expectPendingClose: network.GroupedPortRanges{
-				"": []network.PortRange{network.MustParsePortRange("10-20/tcp")},
+				"": network.NewPortRanges(network.MustParsePortRange("10-20/tcp")),
 			},
 		},
 		{
@@ -372,7 +372,7 @@ func (s *PortRangeChangeRecorderSuite) TestClosePortRange(c *gc.C) {
 			targetPortRange: network.MustParsePortRange("10-20/tcp"),
 			machinePortRanges: map[names.UnitTag]network.GroupedPortRanges{
 				names.NewUnitTag("other/0"): {
-					"": []network.PortRange{network.MustParsePortRange("10-20/tcp")},
+					"": network.NewPortRanges(network.MustParsePortRange("10-20/tcp")),
 				},
 			},
 			expectErr: `cannot close 10-20/tcp \(unit "u/0"\): port range conflicts with 10-20/tcp \(unit "other/0"\)`,
@@ -383,7 +383,7 @@ func (s *PortRangeChangeRecorderSuite) TestClosePortRange(c *gc.C) {
 			targetPortRange: network.MustParsePortRange("1-200/tcp"),
 			machinePortRanges: map[names.UnitTag]network.GroupedPortRanges{
 				names.NewUnitTag("u/0"): {
-					"": []network.PortRange{network.MustParsePortRange("10-20/tcp")},
+					"": network.NewPortRanges(network.MustParsePortRange("10-20/tcp")),
 				},
 			},
 			expectErr: `cannot close 1-200/tcp \(unit "u/0"\): port range conflicts with 10-20/tcp \(unit "u/0"\)`,
@@ -394,11 +394,11 @@ func (s *PortRangeChangeRecorderSuite) TestClosePortRange(c *gc.C) {
 			targetPortRange: network.MustParsePortRange("1-200/tcp"),
 			machinePortRanges: map[names.UnitTag]network.GroupedPortRanges{
 				names.NewUnitTag("u/0"): {
-					"": []network.PortRange{network.MustParsePortRange("10-20/tcp")},
+					"": network.NewPortRanges(network.MustParsePortRange("10-20/tcp")),
 				},
 			},
 			pendingCloseRanges: network.GroupedPortRanges{
-				"": []network.PortRange{network.MustParsePortRange("10-20/tcp")},
+				"": network.NewPortRanges(network.MustParsePortRange("10-20/tcp")),
 			},
 			expectErr: `cannot close 1-200/tcp \(unit "u/0"\): port range conflicts with 10-20/tcp \(unit "u/0"\) requested earlier`,
 		},

--- a/internal/worker/uniter/runner/jujuc/jujuctesting/networking.go
+++ b/internal/worker/uniter/runner/jujuc/jujuctesting/networking.go
@@ -32,23 +32,20 @@ func (ni *NetworkInterface) AddPortRange(endpoint string, portRange network.Port
 	if ni.PortRangesByEndpoint == nil {
 		ni.PortRangesByEndpoint = make(network.GroupedPortRanges)
 	}
-	ni.PortRangesByEndpoint[endpoint] = append(ni.PortRangesByEndpoint[endpoint], portRange)
-	network.SortPortRanges(ni.PortRangesByEndpoint[endpoint])
+	if ni.PortRangesByEndpoint[endpoint] == nil {
+		ni.PortRangesByEndpoint[endpoint] = network.NewPortRanges(portRange)
+	} else {
+		ni.PortRangesByEndpoint[endpoint] = ni.PortRangesByEndpoint[endpoint].Add(portRange)
+	}
 }
 
 // RemovePortRange removes the specified port range.
 func (ni *NetworkInterface) RemovePortRange(endpoint string, portRange network.PortRange) {
-	if ni.PortRangesByEndpoint == nil {
+	if ni.PortRangesByEndpoint == nil || ni.PortRangesByEndpoint[endpoint] == nil {
 		return
 	}
 
-	for i, existingPortRange := range ni.PortRangesByEndpoint[endpoint] {
-		if existingPortRange == portRange {
-			ni.PortRangesByEndpoint[endpoint] = append(ni.PortRangesByEndpoint[endpoint][:i], ni.PortRangesByEndpoint[endpoint][i+1:]...)
-			break
-		}
-	}
-	network.SortPortRanges(ni.PortRangesByEndpoint[endpoint])
+	ni.PortRangesByEndpoint[endpoint] = ni.PortRangesByEndpoint[endpoint].Remove(portRange)
 }
 
 // ContextNetworking is a test double for jujuc.ContextNetworking.

--- a/internal/worker/uniter/runner/jujuc/ports_test.go
+++ b/internal/worker/uniter/runner/jujuc/ports_test.go
@@ -7,6 +7,7 @@ package jujuc_test
 import (
 	"github.com/juju/cmd/v4"
 	"github.com/juju/cmd/v4/cmdtesting"
+	"github.com/juju/collections/transform"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -26,46 +27,41 @@ var portsTests = []struct {
 }{
 	{[]string{"open-port", "80"}, makeAllEndpointsRanges("80/tcp")},
 	{[]string{"open-port", "99/tcp"}, makeAllEndpointsRanges("80/tcp", "99/tcp")},
-	{[]string{"open-port", "100-200"}, makeAllEndpointsRanges("80/tcp", "99/tcp", "100-200/tcp")},
-	{[]string{"open-port", "443/udp"}, makeAllEndpointsRanges("80/tcp", "99/tcp", "100-200/tcp", "443/udp")},
-	{[]string{"close-port", "80/TCP"}, makeAllEndpointsRanges("99/tcp", "100-200/tcp", "443/udp")},
+	{[]string{"open-port", "100-200"}, makeAllEndpointsRanges("80/tcp", "99-200/tcp")},
+	{[]string{"open-port", "443/udp"}, makeAllEndpointsRanges("80/tcp", "99-200/tcp", "443/udp")},
+	{[]string{"close-port", "80/TCP"}, makeAllEndpointsRanges("99-200/tcp", "443/udp")},
 	{[]string{"close-port", "100-200/tcP"}, makeAllEndpointsRanges("99/tcp", "443/udp")},
 	{[]string{"close-port", "443"}, makeAllEndpointsRanges("99/tcp", "443/udp")},
 	{[]string{"close-port", "443/udp"}, makeAllEndpointsRanges("99/tcp")},
 	{[]string{"open-port", "123/udp"}, makeAllEndpointsRanges("99/tcp", "123/udp")},
-	{[]string{"close-port", "9999/UDP"}, makeAllEndpointsRanges("99/tcp", "123/udp")},
-	{[]string{"open-port", "icmp"}, makeAllEndpointsRanges("icmp", "99/tcp", "123/udp")},
+	{[]string{"open-port", "124/udp"}, makeAllEndpointsRanges("99/tcp", "123-124/udp")},
+	{[]string{"close-port", "9999/UDP"}, makeAllEndpointsRanges("99/tcp", "123-124/udp")},
+	{[]string{"open-port", "icmp"}, makeAllEndpointsRanges("icmp", "99/tcp", "123-124/udp")},
 	// Tests with --endpoints.
 	{[]string{"open-port", "--endpoints", "foo,bar", "1337/tcp"}, network.GroupedPortRanges{
 		// Pre-existing ports from previous tests
-		"": []network.PortRange{
+		"": network.NewPortRanges(
 			network.MustParsePortRange("icmp"),
 			network.MustParsePortRange("99/tcp"),
-			network.MustParsePortRange("123/udp"),
-		},
+			network.MustParsePortRange("123-124/udp"),
+		),
 		// Endpoint-specific ports
-		"foo": []network.PortRange{network.MustParsePortRange("1337/tcp")},
-		"bar": []network.PortRange{network.MustParsePortRange("1337/tcp")},
+		"foo": network.NewPortRanges(network.MustParsePortRange("1337/tcp")),
+		"bar": network.NewPortRanges(network.MustParsePortRange("1337/tcp")),
 	}},
 	{[]string{"close-port", "--endpoints", "foo", "1337/tcp"}, network.GroupedPortRanges{
-		"": []network.PortRange{
+		"": network.NewPortRanges(
 			network.MustParsePortRange("icmp"),
 			network.MustParsePortRange("99/tcp"),
-			network.MustParsePortRange("123/udp"),
-		},
-		"foo": []network.PortRange{
-			// Removed
-		},
-		"bar": []network.PortRange{network.MustParsePortRange("1337/tcp")},
+			network.MustParsePortRange("123-124/udp"),
+		),
+		"foo": network.NewPortRanges(), // Removed
+		"bar": network.NewPortRanges(network.MustParsePortRange("1337/tcp")),
 	}},
 }
 
 func makeAllEndpointsRanges(stringRanges ...string) network.GroupedPortRanges {
-	var results []network.PortRange
-	for _, s := range stringRanges {
-		results = append(results, network.MustParsePortRange(s))
-	}
-	network.SortPortRanges(results)
+	results := network.NewPortRanges(transform.Slice(stringRanges, network.MustParsePortRange)...)
 	return network.GroupedPortRanges{
 		"": results,
 	}
@@ -73,7 +69,8 @@ func makeAllEndpointsRanges(stringRanges ...string) network.GroupedPortRanges {
 
 func (s *PortsSuite) TestOpenClose(c *gc.C) {
 	hctx := s.GetHookContext(c, -1, "")
-	for _, t := range portsTests {
+	for i, t := range portsTests {
+		c.Logf("test %d: %v", i, t.cmd)
 		com, err := jujuc.NewCommand(hctx, t.cmd[0])
 		c.Assert(err, jc.ErrorIsNil)
 		ctx := cmdtesting.Context(c)

--- a/state/application_ports.go
+++ b/state/application_ports.go
@@ -194,9 +194,8 @@ func (p *unitPortRanges) Changes() ModelOperation {
 }
 
 // UniquePortRanges returns a slice of unique open PortRanges for the unit.
-func (p *unitPortRanges) UniquePortRanges() []network.PortRange {
+func (p *unitPortRanges) UniquePortRanges() network.PortRanges {
 	allRanges := p.apg.doc.UnitRanges[p.unitName].UniquePortRanges()
-	network.SortPortRanges(allRanges)
 	return allRanges
 }
 

--- a/state/unit_machine_ports.go
+++ b/state/unit_machine_ports.go
@@ -41,9 +41,8 @@ func (p *unitPortRangesForMachine) ByEndpoint() network.GroupedPortRanges {
 
 // UniquePortRanges returns a slice of unique open PortRanges across all
 // endpoints.
-func (p *unitPortRangesForMachine) UniquePortRanges() []network.PortRange {
+func (p *unitPortRangesForMachine) UniquePortRanges() network.PortRanges {
 	uniquePortRanges := p.machinePortRanges.doc.UnitRanges[p.unitName].UniquePortRanges()
-	network.SortPortRanges(uniquePortRanges)
 	return uniquePortRanges
 }
 

--- a/state/unit_ports.go
+++ b/state/unit_ports.go
@@ -28,7 +28,7 @@ type UnitPortRanges interface {
 
 	// UniquePortRanges returns a slice of unique open PortRanges across
 	// all endpoints.
-	UniquePortRanges() []network.PortRange
+	UniquePortRanges() network.PortRanges
 
 	// Changes returns a ModelOperation for applying any changes that were
 	// made to the port ranges for this unit.

--- a/tests/suites/firewall/expose_app.sh
+++ b/tests/suites/firewall/expose_app.sh
@@ -6,7 +6,7 @@ run_expose_app_ec2() {
 	ensure "expose-app" "${file}"
 
 	# Deploy test charm
-	juju deploy jameinel-ubuntu-lite
+	juju deploy ubuntu-lite
 	wait_for "ubuntu-lite" "$(idle_condition "ubuntu-lite")"
 
 	# Open ports and verify hook tool behavior


### PR DESCRIPTION
Recently we replace the value type for the maptype aliased to GroupedPortRanges from []PortRange to PortRanges

However, PortRanges was intended to be manipulated only via it's constructor + methods, since we make certain assumptions about it's structure.

This means constructing a PortRanges via append and the like, as we did for values of GroupedPortRanges, could lead to bugs.

Uses these methods + constructors whenever we manipulate a GroupedPortRanges.

## Checklist

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

<!-- Describe steps to verify that the change works. -->

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/

**Jira card:** JUJU-

