### PR TITLE
fix: wrong utils package used

### DIFF
--- a/internal/ssh/authorizedkeys.go
+++ b/internal/ssh/authorizedkeys.go
@@ -14,7 +14,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/juju/utils/v3"
+	"github.com/juju/utils/v4"
 	"golang.org/x/crypto/ssh"
 )
 


### PR DESCRIPTION
The wrong utils package; v3 intead of v4 was brought in. This is a super quick fix. The go mod change should have picked this up but is currently disabled because of gomock issues.


