### PR TITLE
fix(ec2): add storage tag for 23.10+ aws cloud images

### DIFF
--- a/provider/ec2/environ.go
+++ b/provider/ec2/environ.go
@@ -530,8 +530,9 @@ func (e *environ) Region() (simplestreams.CloudSpec, error) {
 }
 
 const (
-	ebsStorage = "ebs"
-	ssdStorage = "ssd"
+	ebsStorage    = "ebs"
+	ssdGP3Storage = "ssd-gp3"
+	ssdStorage    = "ssd"
 )
 
 // DistributeInstances implements the state.InstanceDistributor policy.
@@ -639,7 +640,7 @@ func (e *environ) StartInstance(
 			Base:        args.InstanceConfig.Base,
 			Arch:        arch,
 			Constraints: args.Constraints,
-			Storage:     []string{ssdStorage, ebsStorage},
+			Storage:     []string{ssdStorage, ebsStorage, ssdGP3Storage},
 		},
 	)
 	if err != nil {

--- a/provider/ec2/image_test.go
+++ b/provider/ec2/image_test.go
@@ -220,7 +220,7 @@ func (s *specSuite) TestFindInstanceSpec(c *gc.C) {
 			test.storage)
 		stor := test.storage
 		if len(stor) == 0 {
-			stor = []string{ssdStorage, ebsStorage}
+			stor = []string{ssdStorage, ebsStorage, ssdGP3Storage}
 		}
 		// We need to filter the image metadata to the test's
 		// arches and series; the provisioner and bootstrap


### PR DESCRIPTION
After 23.10, cloud images have changed their volume type on AWS (https://documentation.ubuntu.com/aws/en/latest/aws-how-to/instances/find-ubuntu-images).

This patch adds the new storage tag (`ssd-gp3` on simplestreams) to the image filtering method on ec2 provider, thus fixing the bug preventing deploying noble images on aws.

## Checklist


- [X] Code style: imports ordered, good names, simple structure, etc
- [ ] ~Comments saying why design decisions were made~
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

We need to make sure 23.10+ ubuntu images work:

```
juju bootstrap aws c
juju add-model m
# deploy noble
juju add-machine --base ubuntu@24.04
# deploy mantic
juju add-machine --base ubuntu@23.10
```
everything should be OK on the logs and status:
```
juju status
Model  Controller  Cloud/Region   Version  SLA          Timestamp
m      c           aws/eu-west-3  3.4.6.1  unsupported  15:15:08+02:00

Machine  State    Address       Inst id              Base          AZ          Message
0        started  13.38.5.203   i-018568d4188d90527  ubuntu@24.04  eu-west-3b  running
1        started  35.180.39.44  i-02d664446b6c5fd6c  ubuntu@23.10  eu-west-3c  running
```

## Links

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2077160

**Jira card:** JUJU-6566

