### PR TITLE
feat: ddl for cloud container addresses

### DIFF
--- a/domain/schema/model/sql/0020-network.sql
+++ b/domain/schema/model/sql/0020-network.sql
@@ -23,3 +23,163 @@ CREATE TABLE cloud_container (
     FOREIGN KEY (net_node_uuid)
     REFERENCES net_node (uuid)
 );
+
+CREATE TABLE cloud_container_ip_address (
+    net_node_uuid TEXT NOT NULL,
+    ip_address_uuid TEXT NOT NULL,
+    CONSTRAINT fk_cloud_container_ip_address_net_node_uuid
+    FOREIGN KEY (net_node_uuid)
+    REFERENCES cloud_container (net_node_uuid),
+    CONSTRAINT fk_cloud_container_ip_address_ip_address_uuid
+    FOREIGN KEY (ip_address_uuid)
+    REFERENCES ip_address (uuid),
+    PRIMARY KEY (net_node_uuid, ip_address_uuid)
+);
+
+CREATE TABLE cloud_container_port (
+    net_node_uuid TEXT NOT NULL,
+    port TEXT NOT NULL,
+    CONSTRAINT fk_cloud_container_port_net_node_uuid
+    FOREIGN KEY (net_node_uuid)
+    REFERENCES cloud_container (net_node_uuid),
+    PRIMARY KEY (net_node_uuid, port)
+);
+
+-- ip_address_type represents the possible ways of specifying
+-- an address, either a hostname resolvable by dns lookup,
+-- or IPv4 or IPv6 address.
+CREATE TABLE ip_address_type (
+    id INT PRIMARY KEY,
+    name TEXT NOT NULL
+);
+
+CREATE UNIQUE INDEX idx_ip_address_type_name
+ON ip_address_type (name);
+
+INSERT INTO ip_address_type VALUES
+(0, 'hostname'),
+(1, 'ipv4'),
+(2, 'ipv6');
+
+-- ip_address_origin represents the authoritative source of
+-- an ip address.
+CREATE TABLE ip_address_origin (
+    id INT PRIMARY KEY,
+    name TEXT NOT NULL
+);
+
+CREATE UNIQUE INDEX idx_ip_address_origin_name
+ON ip_address_origin (name);
+
+INSERT INTO ip_address_origin VALUES
+(0, 'unknown'),
+(1, 'machine'),
+(2, 'provider');
+
+-- ip_address_scope denotes the context an address may apply to.
+-- If a name or address can be reached from the wider internet,
+-- it is considered public. A private network address is either
+-- specific to the cloud or cloud subnet a machine belongs to,
+-- or to the machine itself for containers.
+CREATE TABLE ip_address_scope (
+    id INT PRIMARY KEY,
+    name TEXT NOT NULL
+);
+
+CREATE UNIQUE INDEX idx_ip_address_scope_name
+ON ip_address_scope (name);
+
+INSERT INTO ip_address_scope VALUES
+(0, 'unknown'),
+(1, 'public'),
+(2, 'local-cloud'),
+(3, 'local-machine'),
+(4, 'link-local');
+
+-- ip_address_config_type defines valid network
+-- link configuration types.
+CREATE TABLE ip_address_config_type (
+    id INT PRIMARY KEY,
+    name TEXT NOT NULL
+);
+
+CREATE UNIQUE INDEX idx_ip_address_config_type_name
+ON ip_address_config_type (name);
+
+INSERT INTO ip_address_config_type VALUES
+(0, 'unknown'),
+(1, 'dhcp'),
+(2, 'static'),
+(3, 'manual'),
+(4, 'loopback');
+
+CREATE TABLE ip_address (
+    uuid TEXT NOT NULL PRIMARY KEY,
+    -- The value of the configured IP address.
+    -- e.g. 192.168.1.2 or 2001:db8::/64.
+    address_value TEXT NOT NULL,
+    type_id INT NOT NULL,
+    origin_id INT NOT NULL,
+    config_type_id INT NOT NULL,
+    scope_id INT NOT NULL,
+
+    CONSTRAINT fk_ip_address_type
+    FOREIGN KEY (type_id)
+    REFERENCES ip_address_type (id),
+    CONSTRAINT fk_ip_address_origin
+    FOREIGN KEY (origin_id)
+    REFERENCES ip_address_origin (id),
+    CONSTRAINT fk_ip_address_scope
+    FOREIGN KEY (scope_id)
+    REFERENCES ip_address_scope (id),
+    CONSTRAINT fk_ip_address_config_type
+    FOREIGN KEY (config_type_id)
+    REFERENCES ip_address_config_type (id)
+);
+
+CREATE TABLE ip_address_provider (
+    -- a provider-specific ID of the IP address.
+    provider_id TEXT NOT NULL PRIMARY KEY,
+    ip_address_uuid TEXT NOT NULL,
+    CONSTRAINT fk_provider_ip_address_ip_address_uuid
+    FOREIGN KEY (ip_address_uuid)
+    REFERENCES ip_address (uuid)
+);
+
+CREATE TABLE ip_address_space (
+    space_uuid TEXT NOT NULL,
+    ip_address_uuid TEXT NOT NULL,
+    CONSTRAINT fk_ip_address_space_space_uuid
+    FOREIGN KEY (space_uuid)
+    REFERENCES space (uuid),
+    CONSTRAINT fk_ip_address_space_ip_address_uuid
+    FOREIGN KEY (ip_address_uuid)
+    REFERENCES ip_address (uuid),
+    PRIMARY KEY (space_uuid, ip_address_uuid)
+);
+
+CREATE TABLE ip_address_subnet (
+    subnet_uuid TEXT NOT NULL,
+    ip_address_uuid TEXT NOT NULL,
+    CONSTRAINT fk_ip_address_subnet_subnet_uuid
+    FOREIGN KEY (subnet_uuid)
+    REFERENCES subnet (uuid),
+    CONSTRAINT fk_ip_address_subnet_ip_address_uuid
+    FOREIGN KEY (ip_address_uuid)
+    REFERENCES ip_address (uuid),
+    PRIMARY KEY (subnet_uuid, ip_address_uuid)
+);
+
+CREATE TABLE ip_address_gateway (
+    ip_address_uuid TEXT NOT NULL,
+    -- The IP address of the gateway this IP address's
+    -- device uses.
+    gateway_address TEXT NOT NULL,
+    -- True if that device/subnet is the default gateway
+    -- of the node.
+    is_default_gateway BOOLEAN DEFAULT FALSE,
+    CONSTRAINT fk_ip_address_subnet_ip_address_uuid
+    FOREIGN KEY (ip_address_uuid)
+    REFERENCES ip_address (uuid),
+    PRIMARY KEY (ip_address_uuid, gateway_address)
+);

--- a/domain/schema/model/sql/0020-network.sql
+++ b/domain/schema/model/sql/0020-network.sql
@@ -116,7 +116,7 @@ INSERT INTO ip_address_config_type VALUES
 CREATE TABLE ip_address (
     uuid TEXT NOT NULL PRIMARY KEY,
     -- The value of the configured IP address.
-    -- e.g. 192.168.1.2 or 2001:db8::/64.
+    -- e.g. 192.168.1.2 or 2001:db8::1.
     address_value TEXT NOT NULL,
     type_id INT NOT NULL,
     origin_id INT NOT NULL,
@@ -168,18 +168,4 @@ CREATE TABLE ip_address_subnet (
     FOREIGN KEY (ip_address_uuid)
     REFERENCES ip_address (uuid),
     PRIMARY KEY (subnet_uuid, ip_address_uuid)
-);
-
-CREATE TABLE ip_address_gateway (
-    ip_address_uuid TEXT NOT NULL,
-    -- The IP address of the gateway this IP address's
-    -- device uses.
-    gateway_address TEXT NOT NULL,
-    -- True if that device/subnet is the default gateway
-    -- of the node.
-    is_default_gateway BOOLEAN DEFAULT FALSE,
-    CONSTRAINT fk_ip_address_subnet_ip_address_uuid
-    FOREIGN KEY (ip_address_uuid)
-    REFERENCES ip_address (uuid),
-    PRIMARY KEY (ip_address_uuid, gateway_address)
 );

--- a/domain/schema/schema_test.go
+++ b/domain/schema/schema_test.go
@@ -307,7 +307,6 @@ func (s *schemaSuite) TestModelTables(c *gc.C) {
 		"ip_address_provider",
 		"ip_address_space",
 		"ip_address_subnet",
-		"ip_address_gateway",
 
 		// Unit
 		"unit",

--- a/domain/schema/schema_test.go
+++ b/domain/schema/schema_test.go
@@ -299,11 +299,13 @@ func (s *schemaSuite) TestModelTables(c *gc.C) {
 		"instance_tag",
 
 		// IP address
+		"network_address",
+		"ip_address",
+		"fqdn_address",
 		"ip_address_type",
 		"ip_address_origin",
 		"ip_address_scope",
 		"ip_address_config_type",
-		"ip_address",
 		"ip_address_provider",
 		"ip_address_space",
 		"ip_address_subnet",
@@ -473,6 +475,7 @@ func (s *schemaSuite) TestModelViews(c *gc.C) {
 		"v_charm_url",
 		"v_secret_permission",
 		"v_space_subnet",
+		"v_address",
 	)
 	c.Assert(readEntityNames(c, s.DB(), "view"), jc.SameContents, expected.SortedValues())
 }

--- a/domain/schema/schema_test.go
+++ b/domain/schema/schema_test.go
@@ -290,11 +290,24 @@ func (s *schemaSuite) TestModelTables(c *gc.C) {
 		"net_node",
 		"cloud_service",
 		"cloud_container",
+		"cloud_container_port",
+		"cloud_container_ip_address",
 		"machine_cloud_instance",
 		"machine_cloud_instance_status",
 		"machine_cloud_instance_status_data",
 		"machine_lxd_profile",
 		"instance_tag",
+
+		// IP address
+		"ip_address_type",
+		"ip_address_origin",
+		"ip_address_scope",
+		"ip_address_config_type",
+		"ip_address",
+		"ip_address_provider",
+		"ip_address_space",
+		"ip_address_subnet",
+		"ip_address_gateway",
 
 		// Unit
 		"unit",


### PR DESCRIPTION
Add DDl for cloud container ports, addresses.

Includes the DDL for the address tables themselves, which will also be used for link layer devices etc when that's done later.

This will allow cloud container info from a k8s cluster to be recorded in dqlite.

## QA steps

schema unit tests

## Links

**Jira card:** [JUJU-6572](https://warthogs.atlassian.net/browse/JUJU-6572)



[JUJU-6572]: https://warthogs.atlassian.net/browse/JUJU-6572?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ