### PR TITLE
chore(provisioner): move provisionertask to own package in internal

### DIFF
--- a/internal/provisionertask/export_test.go
+++ b/internal/provisionertask/export_test.go
@@ -1,0 +1,49 @@
+// Copyright 2012, 2013 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provisionertask
+
+import (
+	"context"
+	"sort"
+
+	"github.com/juju/version/v2"
+
+	apiprovisioner "github.com/juju/juju/api/agent/provisioner"
+	"github.com/juju/juju/environs"
+	"github.com/juju/juju/rpc/params"
+)
+
+var ClassifyMachine = classifyMachine
+
+// GetCopyAvailabilityZoneMachines returns a copy of p.(*provisionerTask).availabilityZoneMachines
+func GetCopyAvailabilityZoneMachines(p ProvisionerTask) []AvailabilityZoneMachine {
+	task := p.(*provisionerTask)
+	task.machinesMutex.RLock()
+	defer task.machinesMutex.RUnlock()
+	// Sort to make comparisons in the tests easier.
+	zoneMachines := task.availabilityZoneMachines
+	sort.Slice(task.availabilityZoneMachines, func(i, j int) bool {
+		switch {
+		case zoneMachines[i].MachineIds.Size() < zoneMachines[j].MachineIds.Size():
+			return true
+		case zoneMachines[i].MachineIds.Size() == zoneMachines[j].MachineIds.Size():
+			return zoneMachines[i].ZoneName < zoneMachines[j].ZoneName
+		}
+		return false
+	})
+	retvalues := make([]AvailabilityZoneMachine, len(zoneMachines))
+	for i := range zoneMachines {
+		retvalues[i] = *zoneMachines[i]
+	}
+	return retvalues
+}
+
+func SetupToStartMachine(
+	p ProvisionerTask,
+	machine apiprovisioner.MachineProvisioner,
+	version *version.Number,
+	pInfoResult params.ProvisioningInfoResult,
+) (environs.StartInstanceParams, error) {
+	return p.(*provisionerTask).setupToStartMachine(context.Background(), machine, version, pInfoResult)
+}

--- a/internal/provisionertask/package_test.go
+++ b/internal/provisionertask/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package provisionertask_test
+
+import (
+	stdtesting "testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *stdtesting.T) {
+	gc.TestingT(t)
+}

--- a/internal/worker/provisioner/container_initialisation.go
+++ b/internal/worker/provisioner/container_initialisation.go
@@ -25,6 +25,12 @@ import (
 	"github.com/juju/juju/rpc/params"
 )
 
+// ContainerProvisionerAPI describes methods for provisioning a container.
+type ContainerProvisionerAPI interface {
+	ContainerManagerConfigGetter
+	broker.APICalls
+}
+
 // ContainerSetup sets up the machine to be able to create containers
 // and start a suitable provisioner. Work is triggered by the
 // ContainerSetupAndProvisioner.

--- a/internal/worker/provisioner/containerprovisioner_test.go
+++ b/internal/worker/provisioner/containerprovisioner_test.go
@@ -62,11 +62,10 @@ func (s *lxdProvisionerSuite) newLXDProvisioner(c *gc.C, ctrl *gomock.Controller
 		Machine: m0,
 	}}, nil)
 
-	toolsFinder := &mockToolsFinder{}
 	w, err := provisioner.NewContainerProvisioner(
 		instance.LXD, s.controllerAPI, s.machinesAPI, loggertesting.WrapCheckLog(c),
 		cfg, s.broker,
-		toolsFinder, &mockDistributionGroupFinder{}, &credentialAPIForTest{})
+		&mockToolsFinder{}, &mockDistributionGroupFinder{}, &credentialAPIForTest{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.waitForProvisioner(c)

--- a/internal/worker/provisioner/export_test.go
+++ b/internal/worker/provisioner/export_test.go
@@ -5,16 +5,11 @@ package provisioner
 
 import (
 	"context"
-	"sort"
 
 	"github.com/juju/names/v5"
-	"github.com/juju/version/v2"
 
-	apiprovisioner "github.com/juju/juju/api/agent/provisioner"
 	"github.com/juju/juju/core/watcher"
-	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
-	"github.com/juju/juju/rpc/params"
 )
 
 func SetObserver(p Provisioner, observer chan<- *config.Config) {
@@ -39,40 +34,6 @@ func GetRetryWatcher(p Provisioner) (watcher.NotifyWatcher, error) {
 var (
 	GetContainerInitialiser = &getContainerInitialiser
 )
-
-var ClassifyMachine = classifyMachine
-
-// GetCopyAvailabilityZoneMachines returns a copy of p.(*provisionerTask).availabilityZoneMachines
-func GetCopyAvailabilityZoneMachines(p ProvisionerTask) []AvailabilityZoneMachine {
-	task := p.(*provisionerTask)
-	task.machinesMutex.RLock()
-	defer task.machinesMutex.RUnlock()
-	// Sort to make comparisons in the tests easier.
-	zoneMachines := task.availabilityZoneMachines
-	sort.Slice(task.availabilityZoneMachines, func(i, j int) bool {
-		switch {
-		case zoneMachines[i].MachineIds.Size() < zoneMachines[j].MachineIds.Size():
-			return true
-		case zoneMachines[i].MachineIds.Size() == zoneMachines[j].MachineIds.Size():
-			return zoneMachines[i].ZoneName < zoneMachines[j].ZoneName
-		}
-		return false
-	})
-	retvalues := make([]AvailabilityZoneMachine, len(zoneMachines))
-	for i := range zoneMachines {
-		retvalues[i] = *zoneMachines[i]
-	}
-	return retvalues
-}
-
-func SetupToStartMachine(
-	p ProvisionerTask,
-	machine apiprovisioner.MachineProvisioner,
-	version *version.Number,
-	pInfoResult params.ProvisioningInfoResult,
-) (environs.StartInstanceParams, error) {
-	return p.(*provisionerTask).setupToStartMachine(context.Background(), machine, version, pInfoResult)
-}
 
 func MachineSupportsContainers(
 	cfg ContainerManifoldConfig, pr ContainerMachineGetter, mTag names.MachineTag,

--- a/internal/worker/provisioner/provisioner_test.go
+++ b/internal/worker/provisioner/provisioner_test.go
@@ -6,6 +6,8 @@ package provisioner_test
 import (
 	"context"
 	"fmt"
+	"reflect"
+	"sync"
 	"time"
 
 	"github.com/juju/errors"
@@ -14,27 +16,32 @@ import (
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/version/v2"
 	"github.com/juju/worker/v4/workertest"
+	"github.com/kr/pretty"
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/agent"
+	"github.com/juju/juju/api"
 	apiprovisioner "github.com/juju/juju/api/agent/provisioner"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/arch"
+	corebase "github.com/juju/juju/core/base"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/status"
 	jujuversion "github.com/juju/juju/core/version"
+	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/core/watcher/watchertest"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/envcontext"
 	"github.com/juju/juju/environs/instances"
 	environmocks "github.com/juju/juju/environs/testing"
+	"github.com/juju/juju/internal/cloudconfig/instancecfg"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 	coretesting "github.com/juju/juju/internal/testing"
-	coretools "github.com/juju/juju/internal/tools"
+	"github.com/juju/juju/internal/tools"
 	"github.com/juju/juju/internal/worker/provisioner"
 	"github.com/juju/juju/internal/worker/provisioner/mocks"
 	"github.com/juju/juju/rpc/params"
@@ -257,6 +264,50 @@ func (s *CommonProvisionerSuite) newEnvironProvisioner(c *gc.C) provisioner.Prov
 	return w
 }
 
+type mockDistributionGroupFinder struct {
+	groups map[names.MachineTag][]string
+}
+
+func (mock *mockDistributionGroupFinder) DistributionGroupByMachineId(
+	ctx context.Context,
+	tags ...names.MachineTag,
+) ([]apiprovisioner.DistributionGroupResult, error) {
+	result := make([]apiprovisioner.DistributionGroupResult, len(tags))
+	if len(mock.groups) == 0 {
+		for i := range tags {
+			result[i] = apiprovisioner.DistributionGroupResult{MachineIds: []string{}}
+		}
+	} else {
+		for i, tag := range tags {
+			if dg, ok := mock.groups[tag]; ok {
+				result[i] = apiprovisioner.DistributionGroupResult{MachineIds: dg}
+			} else {
+				result[i] = apiprovisioner.DistributionGroupResult{
+					MachineIds: []string{}, Err: &params.Error{Code: params.CodeNotFound, Message: "Fail"}}
+			}
+		}
+	}
+	return result, nil
+}
+
+type mockToolsFinder struct {
+}
+
+func (f mockToolsFinder) FindTools(ctx context.Context, number version.Number, os string, a string) (tools.List, error) {
+	if number.Compare(version.MustParse("6.6.6")) == 0 {
+		return nil, tools.ErrNoMatches
+	}
+	v, err := version.ParseBinary(fmt.Sprintf("%s-%s-%s", number, os, arch.HostArch()))
+	if err != nil {
+		return nil, err
+	}
+	if a == "" {
+		return nil, errors.New("missing arch")
+	}
+	v.Arch = a
+	return tools.List{&tools.Tools{Version: v}}, nil
+}
+
 type ProvisionerSuite struct {
 	CommonProvisionerSuite
 }
@@ -342,103 +393,300 @@ func (s *ProvisionerSuite) TestEnvironProvisionerObservesConfigChangesWorkerCoun
 	s.assertProvisionerObservesConfigChangesWorkerCount(c, p, false)
 }
 
-type MachineClassifySuite struct {
+var (
+	startInstanceArgTemplate = environs.StartInstanceParams{
+		ControllerUUID: coretesting.ControllerTag.Id(),
+		Tools:          tools.List{{Version: version.MustParseBinary("2.99.0-ubuntu-amd64")}},
+	}
+	instanceConfigTemplate = instancecfg.InstanceConfig{
+		ControllerTag:    coretesting.ControllerTag,
+		ControllerConfig: coretesting.FakeControllerConfig(),
+		Jobs:             []model.MachineJob{model.JobHostUnits},
+		APIInfo: &api.Info{
+			ModelTag: coretesting.ModelTag,
+			Addrs:    []string{"10.0.0.1"},
+			CACert:   coretesting.CACert,
+		},
+		Base:               corebase.MustParseBaseFromString("ubuntu@22.04"),
+		TransientDataDir:   "/var/run/juju",
+		DataDir:            "/var/lib/juju",
+		LogDir:             "/var/log/juju",
+		MetricsSpoolDir:    "/var/lib/juju/metricspool",
+		CloudInitOutputLog: "/var/log/cloud-init-output.log",
+		ImageStream:        "released",
+	}
+)
+
+func machineStartInstanceArg(id string) *environs.StartInstanceParams {
+	result := startInstanceArgTemplate
+	instCfg := instanceConfigTemplate
+	result.InstanceConfig = &instCfg
+	tag := names.NewMachineTag(id)
+	result.InstanceConfig.APIInfo.Tag = tag
+	result.InstanceConfig.MachineId = id
+	result.InstanceConfig.MachineAgentServiceName = fmt.Sprintf("jujud-%s", tag)
+	return &result
 }
 
-var _ = gc.Suite(&MachineClassifySuite{})
+func newDefaultStartInstanceParamsMatcher(c *gc.C, want *environs.StartInstanceParams) *startInstanceParamsMatcher {
+	match := func(p environs.StartInstanceParams) bool {
+		p.Abort = nil
+		p.StatusCallback = nil
+		p.CleanupCallback = nil
+		if p.InstanceConfig != nil {
+			cfgCopy := *p.InstanceConfig
+			// The api password and machine nonce are generated to random values.
+			// Just ensure they are not empty and tweak it so that the compare succeeds.
+			if cfgCopy.APIInfo != nil {
+				if cfgCopy.APIInfo.Password == "" {
+					return false
+				}
+				cfgCopy.APIInfo.Password = want.InstanceConfig.APIInfo.Password
+			}
+			if cfgCopy.MachineNonce == "" {
+				return false
+			}
+			cfgCopy.MachineNonce = ""
+			p.InstanceConfig = &cfgCopy
+		}
+		if len(p.EndpointBindings) == 0 {
+			p.EndpointBindings = nil
+		}
+		if len(p.Volumes) == 0 {
+			p.Volumes = nil
+		}
+		if len(p.VolumeAttachments) == 0 {
+			p.VolumeAttachments = nil
+		}
+		if len(p.ImageMetadata) == 0 {
+			p.ImageMetadata = nil
+		}
+		match := reflect.DeepEqual(p, *want)
+		if !match {
+			c.Logf("got: %s\n", pretty.Sprint(p))
+		}
+		return match
+	}
+	m := newStartInstanceParamsMatcher(map[string]func(environs.StartInstanceParams) bool{
+		fmt.Sprintf("core start params: %s\n", pretty.Sprint(*want)): match,
+	})
+	return m
+}
 
-type machineClassificationTest struct {
-	description    string
+func newStartInstanceParamsMatcher(
+	matchers map[string]func(environs.StartInstanceParams) bool,
+) *startInstanceParamsMatcher {
+	if matchers == nil {
+		matchers = make(map[string]func(environs.StartInstanceParams) bool)
+	}
+	return &startInstanceParamsMatcher{matchers: matchers}
+}
+
+// startInstanceParamsMatcher is a GoMock matcher that applies a collection of
+// conditions to an environs.StartInstanceParams.
+// All conditions must be true in order for a positive match.
+type startInstanceParamsMatcher struct {
+	matchers map[string]func(environs.StartInstanceParams) bool
+	failMsg  string
+}
+
+func (m *startInstanceParamsMatcher) Matches(params interface{}) bool {
+	siParams := params.(environs.StartInstanceParams)
+	for msg, match := range m.matchers {
+		if !match(siParams) {
+			m.failMsg = msg
+			return false
+		}
+	}
+	return true
+}
+
+func (m *startInstanceParamsMatcher) String() string {
+	return m.failMsg
+}
+
+type testInstance struct {
+	instances.Instance
+	id string
+}
+
+func (i *testInstance) Id() instance.Id {
+	return instance.Id(i.id)
+}
+
+type testMachine struct {
+	*apiprovisioner.Machine
+
+	mu sync.Mutex
+
+	id             string
 	life           life.Value
-	status         status.Status
-	idErr          string
-	ensureDeadErr  string
-	expectErrCode  string
-	expectErrFmt   string
-	statusErr      string
-	classification provisioner.MachineClassification
+	agentVersion   version.Number
+	instance       *testInstance
+	keepInstance   bool
+	markForRemoval bool
+	machineStatus  status.Status
+	instStatus     status.Status
+	instStatusMsg  string
+	modStatusMsg   string
+	password       string
+
+	containersCh chan []string
 }
 
-var machineClassificationTestsNoMaintenance = machineClassificationTest{
-	description:    "Machine doesn't need maintaining",
-	life:           life.Alive,
-	status:         status.Started,
-	classification: provisioner.None,
+func (m *testMachine) Id() string {
+	return m.id
 }
 
-func (s *MachineClassifySuite) TestMachineClassification(c *gc.C) {
-	test := func(t machineClassificationTest, id string) {
-		// Run a sub-test from the test table
-		s2e := func(s string) error {
-			// Little helper to turn a non-empty string into a useful error for "ErrorMatches"
-			if s != "" {
-				return &params.Error{Code: s}
-			}
-			return nil
-		}
+func (m *testMachine) String() string {
+	return m.Id()
+}
 
-		c.Logf("%s: %s", id, t.description)
-		machine := testMachine{
-			life:          t.life,
-			instStatus:    t.status,
-			machineStatus: t.status,
-			id:            id,
-			idErr:         s2e(t.idErr),
-			ensureDeadErr: s2e(t.ensureDeadErr),
-			statusErr:     s2e(t.statusErr),
-		}
-		classification, err := provisioner.ClassifyMachine(context.Background(), loggertesting.WrapCheckLog(c), &machine)
-		if err != nil {
-			c.Assert(err, gc.ErrorMatches, fmt.Sprintf(t.expectErrFmt, machine.Id()))
-		} else {
-			c.Assert(err, gc.Equals, s2e(t.expectErrCode))
-		}
-		c.Assert(classification, gc.Equals, t.classification)
+func (m *testMachine) Life() life.Value {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.life
+}
+
+func (m *testMachine) SetLife(life life.Value) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.life = life
+}
+
+func (m *testMachine) WatchContainers(_ context.Context, cType instance.ContainerType) (watcher.StringsWatcher, error) {
+	if m.containersCh == nil {
+		return nil, errors.Errorf("unexpected call to watch %q containers on %q", cType, m.id)
 	}
-
-	test(machineClassificationTestsNoMaintenance, "0")
+	w := watchertest.NewMockStringsWatcher(m.containersCh)
+	return w, nil
 }
 
-type mockDistributionGroupFinder struct {
-	groups map[names.MachineTag][]string
+func (m *testMachine) InstanceId(context.Context) (instance.Id, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.instance == nil {
+		return "", params.Error{Code: "not provisioned"}
+	}
+	return m.instance.Id(), nil
 }
 
-func (mock *mockDistributionGroupFinder) DistributionGroupByMachineId(
-	ctx context.Context,
-	tags ...names.MachineTag,
-) ([]apiprovisioner.DistributionGroupResult, error) {
-	result := make([]apiprovisioner.DistributionGroupResult, len(tags))
-	if len(mock.groups) == 0 {
-		for i := range tags {
-			result[i] = apiprovisioner.DistributionGroupResult{MachineIds: []string{}}
-		}
-	} else {
-		for i, tag := range tags {
-			if dg, ok := mock.groups[tag]; ok {
-				result[i] = apiprovisioner.DistributionGroupResult{MachineIds: dg}
-			} else {
-				result[i] = apiprovisioner.DistributionGroupResult{
-					MachineIds: []string{}, Err: &params.Error{Code: params.CodeNotFound, Message: "Fail"}}
-			}
-		}
-	}
-	return result, nil
+func (m *testMachine) InstanceNames() (instance.Id, string, error) {
+	instId, err := m.InstanceId(context.Background())
+	return instId, "", err
 }
 
-type mockToolsFinder struct {
+func (m *testMachine) KeepInstance(context.Context) (bool, error) {
+	return m.keepInstance, nil
 }
 
-func (f mockToolsFinder) FindTools(ctx context.Context, number version.Number, os string, a string) (coretools.List, error) {
-	if number.Compare(version.MustParse("6.6.6")) == 0 {
-		return nil, coretools.ErrNoMatches
+func (m *testMachine) MarkForRemoval(context.Context) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.markForRemoval = true
+	return nil
+}
+
+func (m *testMachine) GetMarkForRemoval() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.markForRemoval
+}
+
+func (m *testMachine) Tag() names.Tag {
+	return m.MachineTag()
+}
+
+func (m *testMachine) MachineTag() names.MachineTag {
+	return names.NewMachineTag(m.id)
+}
+
+func (m *testMachine) SetInstanceStatus(ctx context.Context, status status.Status, message string, _ map[string]interface{}) error {
+	m.mu.Lock()
+	m.instStatus = status
+	m.instStatusMsg = message
+	m.mu.Unlock()
+	return nil
+}
+
+func (m *testMachine) InstanceStatus(context.Context) (status.Status, string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.instStatus == "" {
+		return "pending", "", nil
 	}
-	v, err := version.ParseBinary(fmt.Sprintf("%s-%s-%s", number, os, arch.HostArch()))
-	if err != nil {
-		return nil, err
+	return m.instStatus, m.instStatusMsg, nil
+}
+
+func (m *testMachine) SetModificationStatus(_ context.Context, _ status.Status, message string, _ map[string]interface{}) error {
+	m.mu.Lock()
+	m.modStatusMsg = message
+	m.mu.Unlock()
+	return nil
+}
+
+func (m *testMachine) ModificationStatus() (status.Status, string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return "", m.modStatusMsg, nil
+}
+
+func (m *testMachine) SetStatus(_ context.Context, status status.Status, _ string, _ map[string]interface{}) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.machineStatus = status
+	return nil
+}
+
+func (m *testMachine) Status(context.Context) (status.Status, string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.machineStatus == "" {
+		return "pending", "", nil
 	}
-	if a == "" {
-		return nil, errors.New("missing arch")
+	return m.machineStatus, "", nil
+}
+
+func (m *testMachine) ModelAgentVersion(context.Context) (*version.Number, error) {
+	if m.agentVersion == version.Zero {
+		return &coretesting.FakeVersionNumber, nil
 	}
-	v.Arch = a
-	return coretools.List{&coretools.Tools{Version: v}}, nil
+	return &m.agentVersion, nil
+}
+
+func (m *testMachine) SetUnprovisioned() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.instance = nil
+}
+
+func (m *testMachine) SetInstanceInfo(
+	_ context.Context,
+	instId instance.Id, _ string, _ string, _ *instance.HardwareCharacteristics, _ []params.NetworkConfig, _ []params.Volume,
+	_ map[string]params.VolumeAttachmentInfo, _ []string,
+) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.instance = &testInstance{id: string(instId)}
+	return nil
+}
+
+func (m *testMachine) SetPassword(_ context.Context, password string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.password = password
+	return nil
+}
+
+func (m *testMachine) GetPassword() string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.password
+}
+
+func (m *testMachine) EnsureDead(context.Context) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.markForRemoval = true
+	return nil
 }


### PR DESCRIPTION
We had the provisioner task inside the provisioner worker package, and this is in part problematic because the provisioner worker has become somewhat overly complicated and changes on it are difficult.

This patch addresses this partly by moving the provisioner task, which is basically the logic for building the tasks, to its own package, leaving the worker for environ and container provisioner mainly focused on the dispatch and orchestration instead of the logic.


## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Test adding machines and containers on aws:
```
juju bootstrap aws c
juju add-model m
juju deploy ubuntu
juju add-machine lxd
juju status
Model  Controller  Cloud/Region   Version      Timestamp
m      c           aws/eu-west-3  4.0-beta5.1  13:47:56+02:00

App     Version  Status  Scale  Charm   Channel        Rev  Exposed  Message
ubuntu  22.04    active      1  ubuntu  latest/stable   24  no

Unit       Workload  Agent  Machine  Public address  Ports  Message
ubuntu/0*  active    idle   0        35.180.113.97

Machine  State    Address         Inst id              Base          AZ          Message
0        started  35.180.113.97   i-0ded69d0e65b46f68  ubuntu@22.04  eu-west-3c  running
1        started  35.180.207.12   i-0c1baf01a1a0afe82  ubuntu@22.04  eu-west-3b  running
1/lxd/0  started  10.222.112.162  juju-2bb804-1-lxd-0  ubuntu@22.04  eu-west-3b  Container started
```
There shouldn't be any errors.
