### PR TITLE
refactor: redefine function signature for RequestModelUUID and others

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -809,22 +809,22 @@ func (srv *Server) endpoints() ([]apihttp.Endpoint, error) {
 				return nil, nil, nil, errors.Trace(err)
 			}
 
-			store, err := httpCtxt.objectStoreForRequest(req)
+			store, err := httpCtxt.objectStoreForRequest(req.Context())
 			if err != nil {
 				return nil, nil, nil, errors.Trace(err)
 			}
 			rst := st.Resources(store)
 			return rst, st, entity.Tag(), nil
 		},
-		ChangeAllowedFunc: func(req *http.Request) error {
-			st, err := httpCtxt.stateForRequestUnauthenticated(req)
+		ChangeAllowedFunc: func(ctx context.Context) error {
+			st, err := httpCtxt.stateForRequestUnauthenticated(ctx)
 			if err != nil {
 				return errors.Trace(err)
 			}
 			defer st.Release()
 
 			blockChecker := common.NewBlockChecker(st)
-			if err := blockChecker.ChangeAllowed(req.Context()); err != nil {
+			if err := blockChecker.ChangeAllowed(ctx); err != nil {
 				return errors.Trace(err)
 			}
 			return nil
@@ -836,7 +836,7 @@ func (srv *Server) endpoints() ([]apihttp.Endpoint, error) {
 			if err != nil {
 				return nil, nil, errors.Trace(err)
 			}
-			store, err := httpCtxt.objectStoreForRequest(req)
+			store, err := httpCtxt.objectStoreForRequest(req.Context())
 			if err != nil {
 				return nil, nil, errors.Trace(err)
 			}
@@ -846,7 +846,7 @@ func (srv *Server) endpoints() ([]apihttp.Endpoint, error) {
 			if err != nil {
 				return nil, nil, errors.Trace(err)
 			}
-			serviceFactory, err := httpCtxt.serviceFactoryForRequest(req)
+			serviceFactory, err := httpCtxt.serviceFactoryForRequest(req.Context())
 			if err != nil {
 				return nil, nil, errors.Trace(errors.Annotate(err, "cannot get service factory for unit resource request"))
 			}
@@ -1112,7 +1112,7 @@ func (srv *Server) apiHandler(w http.ResponseWriter, req *http.Request) {
 	defer apiObserver.Leave()
 
 	websocket.Serve(w, req, func(conn *websocket.Conn) {
-		modelUUID, modelOnlyLogin := httpcontext.RequestModelUUID(req)
+		modelUUID, modelOnlyLogin := httpcontext.RequestModelUUID(req.Context())
 
 		// If the modelUUID wasn't present in the request, then this is
 		// considered a controller-only login.

--- a/apiserver/debuglog.go
+++ b/apiserver/debuglog.go
@@ -110,7 +110,7 @@ func (h *debugLogHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			return
 		}
 
-		st, err := h.ctxt.stateForRequestUnauthenticated(req)
+		st, err := h.ctxt.stateForRequestUnauthenticated(req.Context())
 		if err != nil {
 			socket.sendError(err)
 			return

--- a/apiserver/embeddedcli.go
+++ b/apiserver/embeddedcli.go
@@ -70,7 +70,7 @@ func (h *embeddedCLIHandler) ServeHTTP(w http.ResponseWriter, req *http.Request)
 		ticker := time.NewTicker(websocket.PingPeriod)
 		defer ticker.Stop()
 
-		modelUUID, valid := httpcontext.RequestModelUUID(req)
+		modelUUID, valid := httpcontext.RequestModelUUID(req.Context())
 		if !valid {
 			h.logger.Errorf("invalid model UUID")
 			return

--- a/apiserver/httpcontext/model.go
+++ b/apiserver/httpcontext/model.go
@@ -79,8 +79,11 @@ type modelKey struct{}
 // attempt is made to validate the model UUID; QueryModelHandler and
 // BucketModelHandler does this, and ControllerModelHandler should always be
 // supplied with a valid UUID.
-func RequestModelUUID(req *http.Request) (string, bool) {
-	if value := req.Context().Value(modelKey{}); value != nil {
+func RequestModelUUID(ctx context.Context) (string, bool) {
+	if ctx == nil {
+		return "", false
+	}
+	if value := ctx.Value(modelKey{}); value != nil {
 		return value.(string), true
 	}
 	return "", false

--- a/apiserver/httpcontext/model_test.go
+++ b/apiserver/httpcontext/model_test.go
@@ -32,7 +32,7 @@ var _ = gc.Suite(&ModelHandlersSuite{})
 func (s *ModelHandlersSuite) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		modelUUID, _ := httpcontext.RequestModelUUID(r)
+		modelUUID, _ := httpcontext.RequestModelUUID(r.Context())
 		io.WriteString(w, modelUUID)
 	})
 	s.controllerModelHandler = &httpcontext.ControllerModelHandler{
@@ -55,7 +55,8 @@ func (s *ModelHandlersSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *ModelHandlersSuite) TestRequestModelUUIDNoContext(c *gc.C) {
-	uuid, valid := httpcontext.RequestModelUUID(&http.Request{})
+	r := &http.Request{}
+	uuid, valid := httpcontext.RequestModelUUID(r.Context())
 	c.Assert(uuid, gc.Equals, "")
 	c.Assert(valid, jc.IsFalse)
 }

--- a/apiserver/logsink/logsink.go
+++ b/apiserver/logsink/logsink.go
@@ -178,7 +178,7 @@ func (h *logSinkHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	// If the modelUUID from the request is empty, fallback to the one in
 	// the logsink handler (controller UUID)
 	resolvedModelUUID := h.modelUUID
-	if modelUUID, valid := httpcontext.RequestModelUUID(req); valid {
+	if modelUUID, valid := httpcontext.RequestModelUUID(req.Context()); valid {
 		resolvedModelUUID = modelUUID
 	}
 

--- a/apiserver/registration.go
+++ b/apiserver/registration.go
@@ -41,7 +41,7 @@ func (h *registerUserHandler) ServeHTTP(w http.ResponseWriter, req *http.Request
 		}
 		return
 	}
-	st, err := h.ctxt.stateForRequestUnauthenticated(req)
+	st, err := h.ctxt.stateForRequestUnauthenticated(req.Context())
 	if err != nil {
 		if err := sendError(w, err); err != nil {
 			logger.Errorf("%v", err)

--- a/apiserver/resources.go
+++ b/apiserver/resources.go
@@ -4,6 +4,7 @@
 package apiserver
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"mime"
@@ -44,7 +45,7 @@ type ResourcesBackend interface {
 // uploads of resources.
 type ResourcesHandler struct {
 	StateAuthFunc     func(*http.Request, ...string) (ResourcesBackend, state.PoolHelper, names.Tag, error)
-	ChangeAllowedFunc func(*http.Request) error
+	ChangeAllowedFunc func(context.Context) error
 }
 
 // ServeHTTP implements http.Handler.
@@ -76,7 +77,7 @@ func (h *ResourcesHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request
 			logger.Errorf("resource download failed: %v", err)
 		}
 	case "PUT":
-		if err := h.ChangeAllowedFunc(req); err != nil {
+		if err := h.ChangeAllowedFunc(req.Context()); err != nil {
 			if err := sendError(resp, err); err != nil {
 				logger.Errorf("%v", err)
 			}

--- a/apiserver/resources_mig.go
+++ b/apiserver/resources_mig.go
@@ -4,6 +4,7 @@
 package apiserver
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/url"
@@ -22,7 +23,7 @@ import (
 type resourcesMigrationUploadHandler struct {
 	ctxt          httpContext
 	stateAuthFunc func(*http.Request) (*state.PooledState, error)
-	objectStore   func(*http.Request) (objectstore.ObjectStore, error)
+	objectStore   func(context.Context) (objectstore.ObjectStore, error)
 }
 
 func (h *resourcesMigrationUploadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -37,7 +38,7 @@ func (h *resourcesMigrationUploadHandler) ServeHTTP(w http.ResponseWriter, r *ht
 	}
 	defer st.Release()
 
-	store, err := h.objectStore(r)
+	store, err := h.objectStore(r.Context())
 	if err != nil {
 		if err := sendError(w, err); err != nil {
 			logger.Errorf("%v", err)

--- a/apiserver/resources_test.go
+++ b/apiserver/resources_test.go
@@ -4,6 +4,7 @@
 package apiserver_test
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -60,7 +61,7 @@ func (s *ResourcesHandlerSuite) SetUpTest(c *gc.C) {
 	s.recorder = httptest.NewRecorder()
 	s.handler = &apiserver.ResourcesHandler{
 		StateAuthFunc:     s.authState,
-		ChangeAllowedFunc: func(*http.Request) error { return nil },
+		ChangeAllowedFunc: func(context.Context) error { return nil },
 	}
 }
 
@@ -142,7 +143,7 @@ func (s *ResourcesHandlerSuite) TestPutChangeBlocked(c *gc.C) {
 	s.backend.ReturnSetResource = res
 
 	expectedError := apiservererrors.OperationBlockedError("test block")
-	s.handler.ChangeAllowedFunc = func(*http.Request) error {
+	s.handler.ChangeAllowedFunc = func(context.Context) error {
 		return expectedError
 	}
 

--- a/apiserver/stateauthenticator/auth.go
+++ b/apiserver/stateauthenticator/auth.go
@@ -127,7 +127,7 @@ func (a *Authenticator) AddHandlers(mux *apiserverhttp.Mux) error {
 
 // Authenticate is part of the httpcontext.Authenticator interface.
 func (a *Authenticator) Authenticate(req *http.Request) (authentication.AuthInfo, error) {
-	modelUUID, valid := httpcontext.RequestModelUUID(req)
+	modelUUID, valid := httpcontext.RequestModelUUID(req.Context())
 	if !valid {
 		return authentication.AuthInfo{}, errors.New("model UUID not found")
 	}

--- a/apiserver/tools.go
+++ b/apiserver/tools.go
@@ -77,7 +77,7 @@ func newToolsDownloadHandler(httpCtxt httpContext) *toolsDownloadHandler {
 }
 
 func (h *toolsDownloadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	st, err := h.ctxt.stateForRequestUnauthenticated(r)
+	st, err := h.ctxt.stateForRequestUnauthenticated(r.Context())
 	if err != nil {
 		if err := sendError(w, err); err != nil {
 			logger.Errorf("%v", err)
@@ -151,7 +151,7 @@ func (h *toolsDownloadHandler) getToolsForRequest(r *http.Request, st *state.Sta
 	}
 	logger.Debugf("request for agent binaries: %s", vers)
 
-	store, err := h.ctxt.controllerObjectStoreForRequest(r)
+	store, err := h.ctxt.controllerObjectStoreForRequest(r.Context())
 	if err != nil {
 		return nil, 0, errors.Trace(err)
 	}
@@ -328,7 +328,7 @@ func (h *toolsUploadHandler) processPost(r *http.Request, st *state.State) (*too
 		return nil, errors.Trace(err)
 	}
 
-	store, err := h.ctxt.controllerObjectStoreForRequest(r)
+	store, err := h.ctxt.controllerObjectStoreForRequest(r.Context())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -337,7 +337,7 @@ func (h *toolsUploadHandler) processPost(r *http.Request, st *state.State) (*too
 }
 
 func (h *toolsUploadHandler) getServerRoot(r *http.Request, query url.Values, st *state.State) (string, error) {
-	modelUUID, valid := httpcontext.RequestModelUUID(r)
+	modelUUID, valid := httpcontext.RequestModelUUID(r.Context())
 	if !valid {
 		return "", errors.BadRequestf("invalid model UUID")
 	}


### PR DESCRIPTION
Follow on to #17949 

RequestModelUUID does not need an http.Request, it only needs a context. Supply what is needed not more.

Other methods for an httpContext only need a context as well: stateForRequestUnauthenticated, objectStoreForRequest, and serviceFactoryForRequest.

Some methods of httpContext look like they only required a context as well, however they must share a method signture with a different method as they are supplied to structures used twice with different methods. E.G. methods which must satisfy the stateAuthFunc definition for the toolsHandler structure.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```
$ juju bootstrap lxd testing
$ juju add-model five
$ juju deploy juju-qa-test
# Wait for active/idle status

# Trigger the resource use and validate
$ juju config juju-qa-test foo-file=true
$ juju status
...
App           Version  Status  Scale  Charm         Channel        Rev  Exposed  Message
juju-qa-test           active      1  juju-qa-test  latest/stable   25  no       resource line one: testing two.
...
```

## Links

Related to **Jira card:** JUJU-6468

