### PR TITLE
ci: fix errors around unknown term for tput

### DIFF
--- a/tests/includes/colors.sh
+++ b/tests/includes/colors.sh
@@ -1,5 +1,5 @@
 supports_colors() {
-	if [[ -z ${TERM} ]] || [[ ${TERM} == "" ]] || [[ ${TERM} == "dumb" ]]; then
+	if [[ -z ${TERM} ]] || [[ ${TERM} == "" ]] || [[ ${TERM} == "dumb" ]] || [[ ${TERM} == "unknown" ]]; then
 		echo "NO"
 		return
 	fi


### PR DESCRIPTION
Don't try to use tput when TERM is `unknown`.

## QA steps

Should be no `tput: unknown terminal "unknown"` lines in the shell test output.