### PR TITLE
test: perf worker

### DIFF
--- a/agent/engine/metrics.go
+++ b/agent/engine/metrics.go
@@ -12,6 +12,7 @@ import (
 const (
 	dependencyMetricsNamespace   = "juju"
 	dependencySubsystemNamespace = "dependency_engine"
+	perfSubsystemNamespace       = "perf"
 )
 
 const (
@@ -37,6 +38,7 @@ var metricsModelWorkerStartNames = []string{
 type Collector struct {
 	workerStarts      *prometheus.GaugeVec
 	modelWorkerStarts *prometheus.GaugeVec
+	perfWorkerSteps   *prometheus.CounterVec
 }
 
 // NewMetrics creates a new collector for a model.
@@ -54,6 +56,12 @@ func NewMetrics() *Collector {
 			Name:      "worker_starts_for_model",
 			Help:      "Current number of worker starts in the dependency engine by model",
 		}, metricsModelWorkerStartNames),
+		perfWorkerSteps: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: dependencyMetricsNamespace,
+			Subsystem: perfSubsystemNamespace,
+			Name:      "iteration_count",
+			Help:      "Current number of iterations of the perf worker steps",
+		}, metricsModelWorkerStartNames),
 	}
 }
 
@@ -61,6 +69,7 @@ func NewMetrics() *Collector {
 // ensures that we correctly tidy up after the removal of a model.
 type MetricSink interface {
 	dependency.Metrics
+	RecordPerfStep()
 	Unregister() bool
 }
 
@@ -76,12 +85,14 @@ func (c *Collector) ForModel(model names.ModelTag) MetricSink {
 func (c *Collector) Describe(ch chan<- *prometheus.Desc) {
 	c.workerStarts.Describe(ch)
 	c.modelWorkerStarts.Describe(ch)
+	c.perfWorkerSteps.Describe(ch)
 }
 
 // Collect is part of the prometheus.Collector interface.
 func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 	c.workerStarts.Collect(ch)
 	c.modelWorkerStarts.Collect(ch)
+	c.perfWorkerSteps.Collect(ch)
 }
 
 type modelCollector struct {
@@ -94,6 +105,11 @@ type modelCollector struct {
 func (c *modelCollector) RecordStart(worker string) {
 	c.collector.workerStarts.WithLabelValues(worker).Inc()
 	c.collector.modelWorkerStarts.WithLabelValues(c.modelUUID).Inc()
+}
+
+// RecordPerfStep tracks that a perf worker has ticked over another step in its process
+func (c *modelCollector) RecordPerfStep() {
+	c.collector.perfWorkerSteps.WithLabelValues(c.modelUUID).Inc()
 }
 
 // Unregister removes any associated model worker starts from the sink if

--- a/cmd/jujud-controller/agent/machine.go
+++ b/cmd/jujud-controller/agent/machine.go
@@ -1011,7 +1011,7 @@ func (a *MachineAgent) startModelWorkers(cfg modelworkermanager.NewModelConfig) 
 		NewMigrationMaster:           migrationmaster.NewWorker,
 		ServiceFactory:               cfg.ServiceFactory,
 		ProviderServiceFactoryGetter: cfg.ProviderServiceFactoryGetter,
-		PrometheusRegisterer:         cfg.PrometheusRegisterer,
+		ModelMetricSink:              cfg.ModelMetrics,
 	}
 	if wrench.IsActive("charmrevision", "shortinterval") {
 		interval := 10 * time.Second

--- a/cmd/jujud-controller/agent/machine.go
+++ b/cmd/jujud-controller/agent/machine.go
@@ -1011,6 +1011,7 @@ func (a *MachineAgent) startModelWorkers(cfg modelworkermanager.NewModelConfig) 
 		NewMigrationMaster:           migrationmaster.NewWorker,
 		ServiceFactory:               cfg.ServiceFactory,
 		ProviderServiceFactoryGetter: cfg.ProviderServiceFactoryGetter,
+		PrometheusRegisterer:         cfg.PrometheusRegisterer,
 	}
 	if wrench.IsActive("charmrevision", "shortinterval") {
 		interval := 10 * time.Second

--- a/cmd/jujud-controller/agent/machine/manifolds.go
+++ b/cmd/jujud-controller/agent/machine/manifolds.go
@@ -714,6 +714,7 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			Logger:                          internallogger.GetLogger("juju.workers.modelworkermanager"),
 			GetProviderServiceFactoryGetter: modelworkermanager.GetProviderServiceFactoryGetter,
 			GetControllerConfig:             modelworkermanager.GetControllerConfig,
+			PrometheusRegisterer:            config.PrometheusRegisterer,
 		})),
 
 		peergrouperName: ifFullyUpgraded(peergrouper.Manifold(peergrouper.ManifoldConfig{

--- a/cmd/jujud-controller/agent/model/manifolds.go
+++ b/cmd/jujud-controller/agent/model/manifolds.go
@@ -52,6 +52,7 @@ import (
 	"github.com/juju/juju/internal/worker/migrationflag"
 	"github.com/juju/juju/internal/worker/migrationmaster"
 	"github.com/juju/juju/internal/worker/modelworkermanager"
+	"github.com/juju/juju/internal/worker/perf"
 	"github.com/juju/juju/internal/worker/providertracker"
 	"github.com/juju/juju/internal/worker/pruner"
 	"github.com/juju/juju/internal/worker/remoterelations"
@@ -153,6 +154,13 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			NewConnection: apicaller.OnlyConnect,
 			Filter:        apiConnectFilter,
 			Logger:        config.LoggingContext.GetLogger("juju.worker.apicaller"),
+		}),
+
+		perfWorkerName: perf.Manifold(perf.ManifoldConfig{
+			AgentName:          agentName,
+			Clock:              config.Clock,
+			Logger:             config.LoggingContext.GetLogger("juju.worker.perf"),
+			ServiceFactoryName: serviceFactoryName,
 		}),
 
 		// The provider service factory is used to access the provider service.
@@ -716,4 +724,6 @@ const (
 	userSecretsDrainWorker = "user-secrets-drain-worker"
 
 	validCredentialFlagName = "valid-credential-flag"
+
+	perfWorkerName = "perf-worker"
 )

--- a/cmd/jujud-controller/agent/model/manifolds.go
+++ b/cmd/jujud-controller/agent/model/manifolds.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/utils/v4/voyeur"
 	"github.com/juju/worker/v4"
 	"github.com/juju/worker/v4/dependency"
+	"github.com/prometheus/client_golang/prometheus"
 
 	coreagent "github.com/juju/juju/agent"
 	"github.com/juju/juju/agent/engine"
@@ -127,6 +128,10 @@ type ManifoldsConfig struct {
 
 	// ServiceFactory is used to access the service factory.
 	ServiceFactory servicefactory.ServiceFactory
+
+	// PrometheusRegisterer is a prometheus.Registerer that may be used
+	// by workers to register Prometheus metric collectors.
+	PrometheusRegisterer prometheus.Registerer
 }
 
 // commonManifolds returns a set of interdependent dependency manifolds that will
@@ -157,10 +162,11 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		}),
 
 		perfWorkerName: perf.Manifold(perf.ManifoldConfig{
-			AgentName:          agentName,
-			Clock:              config.Clock,
-			Logger:             config.LoggingContext.GetLogger("juju.worker.perf"),
-			ServiceFactoryName: serviceFactoryName,
+			AgentName:            agentName,
+			Clock:                config.Clock,
+			Logger:               config.LoggingContext.GetLogger("juju.worker.perf"),
+			ServiceFactoryName:   serviceFactoryName,
+			PrometheusRegisterer: config.PrometheusRegisterer,
 		}),
 
 		// The provider service factory is used to access the provider service.

--- a/cmd/jujud-controller/agent/model/manifolds.go
+++ b/cmd/jujud-controller/agent/model/manifolds.go
@@ -11,7 +11,6 @@ import (
 	"github.com/juju/utils/v4/voyeur"
 	"github.com/juju/worker/v4"
 	"github.com/juju/worker/v4/dependency"
-	"github.com/prometheus/client_golang/prometheus"
 
 	coreagent "github.com/juju/juju/agent"
 	"github.com/juju/juju/agent/engine"
@@ -129,9 +128,8 @@ type ManifoldsConfig struct {
 	// ServiceFactory is used to access the service factory.
 	ServiceFactory servicefactory.ServiceFactory
 
-	// PrometheusRegisterer is a prometheus.Registerer that may be used
-	// by workers to register Prometheus metric collectors.
-	PrometheusRegisterer prometheus.Registerer
+	// ModelMetricSink is a per-model tracker of metrics in a model
+	ModelMetricSink engine.MetricSink
 }
 
 // commonManifolds returns a set of interdependent dependency manifolds that will
@@ -162,11 +160,11 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 		}),
 
 		perfWorkerName: perf.Manifold(perf.ManifoldConfig{
-			AgentName:            agentName,
-			Clock:                config.Clock,
-			Logger:               config.LoggingContext.GetLogger("juju.worker.perf"),
-			ServiceFactoryName:   serviceFactoryName,
-			PrometheusRegisterer: config.PrometheusRegisterer,
+			AgentName:          agentName,
+			Clock:              config.Clock,
+			Logger:             config.LoggingContext.GetLogger("juju.worker.perf"),
+			ServiceFactoryName: serviceFactoryName,
+			MetricsStepper:     config.ModelMetricSink,
 		}),
 
 		// The provider service factory is used to access the provider service.

--- a/internal/worker/modelworkermanager/manifold.go
+++ b/internal/worker/modelworkermanager/manifold.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/worker/v4"
 	"github.com/juju/worker/v4/dependency"
+	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/controller"
@@ -64,6 +65,9 @@ type ManifoldConfig struct {
 	ModelMetrics ModelMetrics
 	// Logger is the logger for the worker.
 	Logger logger.Logger
+	// PrometheusRegisterer is a prometheus.Registerer that may be used
+	// by workers to register Prometheus metric collectors.
+	PrometheusRegisterer prometheus.Registerer
 }
 
 // Validate validates the manifold configuration.
@@ -97,6 +101,9 @@ func (config ManifoldConfig) Validate() error {
 	}
 	if config.Logger == nil {
 		return errors.NotValidf("nil Logger")
+	}
+	if config.PrometheusRegisterer == nil {
+		return errors.NotValidf("nil PrometheusRegisterer")
 	}
 	if config.GetProviderServiceFactoryGetter == nil {
 		return errors.NotValidf("nil GetProviderServiceFactoryGetter")
@@ -178,6 +185,7 @@ func (config ManifoldConfig) start(context context.Context, getter dependency.Ge
 		ServiceFactoryGetter:         serviceFactoryGetter,
 		ProviderServiceFactoryGetter: providerServiceFactoryGetter,
 		GetControllerConfig:          config.GetControllerConfig,
+		PrometheusRegisterer:         config.PrometheusRegisterer,
 	})
 	if err != nil {
 		_ = stTracker.Done()

--- a/internal/worker/modelworkermanager/modelworkermanager_test.go
+++ b/internal/worker/modelworkermanager/modelworkermanager_test.go
@@ -209,6 +209,7 @@ func (s *suite) runKillTest(c *gc.C, kill killFunc, test testFunc) {
 		GetControllerConfig: func(ctx context.Context, controllerConfigService modelworkermanager.ControllerConfigService) (controller.Config, error) {
 			return coretesting.FakeControllerConfig(), nil
 		},
+		PrometheusRegisterer: nil,
 	}
 	w, err := modelworkermanager.New(config)
 	c.Assert(err, jc.ErrorIsNil)

--- a/internal/worker/perf/manifold.go
+++ b/internal/worker/perf/manifold.go
@@ -1,0 +1,78 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package perf
+
+import (
+	"context"
+
+	"github.com/juju/clock"
+	"github.com/juju/errors"
+	"github.com/juju/worker/v4"
+	"github.com/juju/worker/v4/dependency"
+
+	"github.com/juju/juju/agent"
+	"github.com/juju/juju/core/logger"
+	"github.com/juju/juju/core/model"
+	"github.com/juju/juju/internal/servicefactory"
+)
+
+// ManifoldConfig holds the information necessary to run a performance test
+// plan.
+type ManifoldConfig struct {
+	AgentName          string
+	ServiceFactoryName string
+
+	Clock  clock.Clock
+	Logger logger.Logger
+}
+
+// Validate validates the manifold configuration.
+func (config ManifoldConfig) Validate() error {
+	if config.AgentName == "" {
+		return errors.NotValidf("empty AgentName")
+	}
+	if config.ServiceFactoryName == "" {
+		return errors.NotValidf("empty ServiceFactoryName")
+	}
+	if config.Clock == nil {
+		return errors.NotValidf("nil Clock")
+	}
+	if config.Logger == nil {
+		return errors.NotValidf("nil Logger")
+	}
+	return nil
+}
+
+// Manifold returns a dependency.Manifold that will run an HTTP server
+// worker.
+func Manifold(config ManifoldConfig) dependency.Manifold {
+	return dependency.Manifold{
+		Inputs: []string{
+			config.AgentName,
+			config.ServiceFactoryName,
+		},
+		Start: config.start,
+	}
+}
+
+// start is a method on ManifoldConfig because it's more readable than a closure.
+func (config ManifoldConfig) start(ctx context.Context, getter dependency.Getter) (worker.Worker, error) {
+	if err := config.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var agent agent.Agent
+	if err := getter.Get(config.AgentName, &agent); err != nil {
+		return nil, err
+	}
+
+	currentModelUUID := model.UUID(agent.CurrentConfig().Model().Id())
+
+	var serviceFactory servicefactory.ServiceFactory
+	if err := getter.Get(config.ServiceFactoryName, &serviceFactory); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	return newPerfWorker(currentModelUUID, serviceFactory, config.Clock, config.Logger)
+}

--- a/internal/worker/perf/metrics.go
+++ b/internal/worker/perf/metrics.go
@@ -13,19 +13,19 @@ const (
 )
 
 type Collector struct {
-	iterationCount prometheus.Counter
+	iterationCount *prometheus.CounterVec
 }
 
 func NewMetricsCollector() *Collector {
 	// TODO (jam): we could use a CounterVec and do something like counts per model, but for now, we just
 	//  want to know the total count
 	return &Collector{
-		iterationCount: prometheus.NewCounter(prometheus.CounterOpts{
+		iterationCount: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: metricsNamespace,
 			Subsystem: subsystemNamespace,
 			Name:      "iteration_count",
 			Help:      "Count the number of iterations that this perf worker has completed",
-		}),
+		}, []string{"model_uuid"}),
 	}
 }
 

--- a/internal/worker/perf/metrics.go
+++ b/internal/worker/perf/metrics.go
@@ -1,0 +1,40 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package perf
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	metricsNamespace   = "juju"
+	subsystemNamespace = "perf"
+)
+
+type Collector struct {
+	iterationCount prometheus.Counter
+}
+
+func NewMetricsCollector() *Collector {
+	// TODO (jam): we could use a CounterVec and do something like counts per model, but for now, we just
+	//  want to know the total count
+	return &Collector{
+		iterationCount: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Subsystem: subsystemNamespace,
+			Name:      "iteration_count",
+			Help:      "Count the number of iterations that this perf worker has completed",
+		}),
+	}
+}
+
+// Describe is part of the prometheus.Collector interface.
+func (c *Collector) Describe(ch chan<- *prometheus.Desc) {
+	c.iterationCount.Describe(ch)
+}
+
+// Collect is part of the prometheus.Collector interface.
+func (c *Collector) Collect(ch chan<- prometheus.Metric) {
+	c.iterationCount.Collect(ch)
+}

--- a/internal/worker/perf/worker.go
+++ b/internal/worker/perf/worker.go
@@ -1,0 +1,224 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package perf
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/juju/clock"
+	"github.com/juju/worker/v4"
+	"github.com/juju/worker/v4/catacomb"
+	"gopkg.in/tomb.v2"
+
+	"github.com/juju/juju/core/logger"
+	"github.com/juju/juju/core/model"
+	"github.com/juju/juju/internal/servicefactory"
+)
+
+type perfWorker struct {
+	catacomb catacomb.Catacomb
+	runner   *worker.Runner
+	clock    clock.Clock
+	logger   logger.Logger
+
+	id int64
+
+	modelUUID model.UUID
+	service   servicefactory.ServiceFactory
+}
+
+func newPerfWorker(modelUUID model.UUID, service servicefactory.ServiceFactory, clock clock.Clock, logger logger.Logger) (*perfWorker, error) {
+	w := &perfWorker{
+		modelUUID: modelUUID,
+		clock:     clock,
+		logger:    logger,
+		service:   service,
+		runner: worker.NewRunner(worker.RunnerParams{
+			Clock: clock,
+			IsFatal: func(err error) bool {
+				return false
+			},
+			ShouldRestart: func(err error) bool {
+				return true
+			},
+			RestartDelay: time.Second * 10,
+			Logger:       logger,
+		}),
+	}
+
+	if err := catacomb.Invoke(catacomb.Plan{
+		Work: w.run,
+		Site: &w.catacomb,
+		Init: []worker.Worker{
+			w.runner,
+		},
+	}); err != nil {
+		return nil, err
+	}
+
+	return w, nil
+}
+
+// Wait blocks until the worker has finished.
+func (w *perfWorker) Wait() error {
+	return w.catacomb.Wait()
+}
+
+// Kill stops the worker.
+func (w *perfWorker) Kill() {
+	w.catacomb.Kill(nil)
+}
+
+func (w *perfWorker) run() error {
+	ctx, cancel := context.WithCancel(w.catacomb.Context(context.Background()))
+	defer cancel()
+
+	controllerModelUUID, err := w.service.Controller().ControllerModelUUID(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Don't run the performance test on the controller model.
+	if controllerModelUUID == w.modelUUID {
+		w.logger.Infof("%s: Controller model, not running performance test", w.modelUUID)
+		return nil
+	}
+
+	w.logger.Debugf("%s: Starting performance test", w.modelUUID)
+
+	// Every 30 seconds, create a new step worker.
+	timer := w.clock.NewTimer(time.Second * 30)
+	for {
+		select {
+		case <-w.catacomb.Dying():
+			w.logger.Debugf("%s: Catacomb is dying", w.modelUUID)
+			timer.Stop()
+			return nil
+
+		case <-timer.Chan():
+			w.id++
+			name := fmt.Sprintf("step-%d", w.id)
+
+			w.logger.Infof("%s: Creating worker step %s", w.modelUUID, name)
+
+			if err := w.runner.StartWorker(name, func() (worker.Worker, error) {
+				return newStepWorker(w.modelUUID, w.id, w.clock, w.logger, w.runStep), nil
+			}); err != nil {
+				return err
+			}
+
+			// Stop the timer if we've reached 10 step workers.
+			if w.id >= 10 {
+				timer.Stop()
+			} else {
+				timer.Reset(time.Second * 30)
+			}
+		}
+	}
+}
+
+func (w *perfWorker) runStep(ctx context.Context, step int) error {
+	switch step % 6 {
+	case 1:
+		// Controller access.
+		access := w.service.Access()
+		_, err := access.GetAllUsers(ctx, true)
+		return err
+	case 2:
+		// Controller access.
+		modelDefaults := w.service.ModelDefaults()
+		_, err := modelDefaults.ModelDefaults(ctx, w.modelUUID)
+		return err
+	case 3:
+		// Controller access.
+		model := w.service.Model()
+		_, err := model.Model(ctx, w.modelUUID)
+		return err
+	case 4:
+		// Model access.
+		agent := w.service.Agent()
+		_, err := agent.GetModelAgentVersion(ctx)
+		return err
+	case 5:
+		// Model access.
+		modelInfo := w.service.ModelInfo()
+		_, err := modelInfo.GetModelInfo(ctx)
+		return err
+	case 6:
+		// Model access.
+		machine := w.service.Machine()
+		_, err := machine.AllMachineNames(ctx)
+		return err
+	default:
+		// Controller access.
+		controllerConfig := w.service.ControllerConfig()
+		_, err := controllerConfig.ControllerConfig(ctx)
+		return err
+	}
+}
+
+type stepWorker struct {
+	tomb tomb.Tomb
+
+	modelUUID model.UUID
+
+	id     int64
+	clock  clock.Clock
+	logger logger.Logger
+
+	step func(context.Context, int) error
+}
+
+func newStepWorker(modelUUID model.UUID, id int64, clock clock.Clock, logger logger.Logger, fn func(context.Context, int) error) *stepWorker {
+	w := &stepWorker{
+		modelUUID: modelUUID,
+		id:        id,
+		clock:     clock,
+		logger:    logger,
+		step:      fn,
+	}
+	w.tomb.Go(w.run)
+	return w
+}
+
+// Wait blocks until the worker has finished.
+func (w *stepWorker) Wait() error {
+	return w.tomb.Wait()
+}
+
+// Kill stops the worker.
+func (w *stepWorker) Kill() {
+	w.tomb.Kill(nil)
+}
+
+func (w *stepWorker) run() error {
+	ctx, cancel := context.WithCancel(w.tomb.Context(context.Background()))
+	defer cancel()
+
+	timer := w.clock.NewTimer(time.Second)
+	for {
+		select {
+		case <-w.tomb.Dying():
+			w.logger.Debugf("%s: Tomb is dying %d", w.modelUUID, w.id)
+			timer.Stop()
+			return nil
+
+		case <-timer.Chan():
+			w.logger.Debugf("%s: Step %d: starting", w.modelUUID, w.id)
+
+			for i := 0; i < 20; i++ {
+				if err := w.step(ctx, i); err != nil {
+					w.logger.Errorf("Failed to run step %d: %v", w.id, err)
+					continue
+				}
+			}
+
+			w.logger.Debugf("%s: Step %d: finished", w.modelUUID, w.id)
+
+			timer.Reset(time.Second)
+		}
+	}
+}

--- a/internal/worker/perf/worker.go
+++ b/internal/worker/perf/worker.go
@@ -126,7 +126,7 @@ func (w *perfWorker) runStep(ctx context.Context, step int) error {
 	// TODO (jam): we could add metrics for the time for each of these calls to complete,
 	//  it might be interesting if one of them is particularly more expensive/slow than the others
 	w.metrics.RecordPerfStep()
-	switch step % 6 {
+	switch step % 7 {
 	case 1:
 		// Controller access.
 		access := w.service.Access()
@@ -214,7 +214,7 @@ func (w *stepWorker) run() error {
 		case <-timer.Chan():
 			w.logger.Debugf("%s: Step %d: starting", w.modelUUID, w.id)
 
-			for i := 0; i < 20; i++ {
+			for i := 0; i < 21; i++ {
 				if err := w.step(ctx, i); err != nil {
 					w.logger.Errorf("Failed to run step %d: %v", w.id, err)
 					continue

--- a/internal/worker/perf/worker.go
+++ b/internal/worker/perf/worker.go
@@ -125,7 +125,7 @@ func (w *perfWorker) run() error {
 func (w *perfWorker) runStep(ctx context.Context, step int) error {
 	// TODO (jam): we could add metrics for the time for each of these calls to complete,
 	//  it might be interesting if one of them is particularly more expensive/slow than the others
-	w.metrics.iterationCount.Inc()
+	w.metrics.iterationCount.WithLabelValues(string(w.modelUUID)).Inc()
 	switch step % 6 {
 	case 1:
 		// Controller access.

--- a/internal/worker/perf/worker.go
+++ b/internal/worker/perf/worker.go
@@ -23,7 +23,7 @@ type perfWorker struct {
 	runner   *worker.Runner
 	clock    clock.Clock
 	logger   logger.Logger
-	metrics  *Collector
+	metrics  MetricStep
 
 	id int64
 
@@ -31,7 +31,7 @@ type perfWorker struct {
 	service   servicefactory.ServiceFactory
 }
 
-func newPerfWorker(modelUUID model.UUID, service servicefactory.ServiceFactory, clock clock.Clock, logger logger.Logger, metrics *Collector) (*perfWorker, error) {
+func newPerfWorker(modelUUID model.UUID, service servicefactory.ServiceFactory, clock clock.Clock, logger logger.Logger, metrics MetricStep) (*perfWorker, error) {
 	w := &perfWorker{
 		modelUUID: modelUUID,
 		clock:     clock,
@@ -125,7 +125,7 @@ func (w *perfWorker) run() error {
 func (w *perfWorker) runStep(ctx context.Context, step int) error {
 	// TODO (jam): we could add metrics for the time for each of these calls to complete,
 	//  it might be interesting if one of them is particularly more expensive/slow than the others
-	w.metrics.iterationCount.WithLabelValues(string(w.modelUUID)).Inc()
+	w.metrics.RecordPerfStep()
 	switch step % 6 {
 	case 1:
 		// Controller access.

--- a/internal/worker/perf/worker.go
+++ b/internal/worker/perf/worker.go
@@ -23,6 +23,7 @@ type perfWorker struct {
 	runner   *worker.Runner
 	clock    clock.Clock
 	logger   logger.Logger
+	metrics  *Collector
 
 	id int64
 
@@ -30,11 +31,12 @@ type perfWorker struct {
 	service   servicefactory.ServiceFactory
 }
 
-func newPerfWorker(modelUUID model.UUID, service servicefactory.ServiceFactory, clock clock.Clock, logger logger.Logger) (*perfWorker, error) {
+func newPerfWorker(modelUUID model.UUID, service servicefactory.ServiceFactory, clock clock.Clock, logger logger.Logger, metrics *Collector) (*perfWorker, error) {
 	w := &perfWorker{
 		modelUUID: modelUUID,
 		clock:     clock,
 		logger:    logger,
+		metrics:   metrics,
 		service:   service,
 		runner: worker.NewRunner(worker.RunnerParams{
 			Clock: clock,
@@ -121,6 +123,9 @@ func (w *perfWorker) run() error {
 }
 
 func (w *perfWorker) runStep(ctx context.Context, step int) error {
+	// TODO (jam): we could add metrics for the time for each of these calls to complete,
+	//  it might be interesting if one of them is particularly more expensive/slow than the others
+	w.metrics.iterationCount.Inc()
 	switch step % 6 {
 	case 1:
 		// Controller access.


### PR DESCRIPTION
How hard can we actually hit dqlite from inside of juju. Let's find out!

---- 

The premise is simple, can we afford to run multiple read transactions with wild abandon?

Before this change a spike was done to test the premise, but from the outside of Juju, going via the CLI and the apiserver. The problem we hit pretty quickly was that we required a fmutex to access the local yaml files found in `~/.local/share/juju`. Hacking that out of the way allowed us to reach 800/tps (transactions per second). After doing the spike, the thought was to remove the overhead from the CLI, WebSockets, and API server/facades to get a true figure.

This proposal introduces a model worker. The model worker can acquire the service factory for that given model and then run several read-only queries. This then removes the potential of accidental writes into the database whilst testing this setup.

-----

The perf worker creates a new step worker every 30 seconds. The step worker will then run a series (currently 20 iterations), every second. This will then build up over time, currently no upper limit (this will likely change).

The step function will then call a series of calls against the controller and model database. 

To add more work and transactions, add more models.



<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://docs.google.com/document/d/1SYUo9G7qZ_jdoVXpUVamS5VCgHmtZ0QA-wZxKoMS-C0 
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

Download the bundle and overlay https://gist.github.com/SimonRichardson/0283807cdc026c4ecfe557891958f5b6
Alternatively, deploy the COS stack to then monitor the controller.

```
$ juju bootstrap lxd test --build-agent --bootstrap-base=ubuntu@20.04
$ juju add-user prometheus
$ juju grant prometheus read controller
$ juju change-user-password prometheus
$ juju switch controller
$ juju deploy ./bundle.yaml --overlay ./overlay.yaml --map-machines=existing
 ```

## Links


**Jira card:** https://warthogs.atlassian.net/browse/JUJU-6625

