### PR TITLE
fix: prevent controllerTracker status race

### DIFF
--- a/worker/peergrouper/controllertracker.go
+++ b/worker/peergrouper/controllertracker.go
@@ -239,6 +239,9 @@ func (c *controllerTracker) hasNodeChanged() (bool, error) {
 }
 
 func (c *controllerTracker) hostPendingProvisioning() (bool, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	status, err := c.host.Status()
 	if err != nil {
 		return false, errors.Trace(err)


### PR DESCRIPTION
This fixes a race added under https://github.com/juju/juju/pull/17816. It was detected in CI by the race suite.

We already had lock protection around the write site (`Refresh`), but we added a new read of `Status` without such protection. This adds it.

## QA steps

```
TEST_PACKAGES="./worker/peergrouper -count=100 -timeout=10m -race" TEST_FILTER="Suite" GOTRACEBACK=all make run-go-tests
```
should do it.

## Documentation changes

None

## Links

**Jira card:** [JUJU-6598](https://warthogs.atlassian.net/browse/JUJU-6598)

