### PR TITLE
refactor(domain): introduce infra for atomic testing

### DIFF
--- a/domain/port/service/service_test.go
+++ b/domain/port/service/service_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/network"
 	domain "github.com/juju/juju/domain"
+	domaintesting "github.com/juju/juju/domain/testing"
 )
 
 type serviceSuite struct {
@@ -28,7 +29,7 @@ func (s *serviceSuite) setupMocks(c *gc.C) *gomock.Controller {
 
 	s.st = NewMockState(ctrl)
 	s.st.EXPECT().RunAtomic(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, fn func(ctx domain.AtomicContext) error) error {
-		return fn(nil)
+		return fn(domaintesting.NewAtomicContext(ctx))
 	}).AnyTimes()
 
 	return ctrl
@@ -74,8 +75,8 @@ func (s *serviceSuite) TestUpdateUnitPorts(c *gc.C) {
 		},
 	}
 
-	s.st.EXPECT().GetOpenedEndpointPorts(gomock.Any(), unitUUID, WildcardEndpoint).Return([]network.PortRange{}, nil)
-	s.st.EXPECT().UpdateUnitPorts(gomock.Any(), unitUUID, openPorts, closePorts).Return(nil)
+	s.st.EXPECT().GetOpenedEndpointPorts(domaintesting.IsAtomicContextChecker, unitUUID, WildcardEndpoint).Return([]network.PortRange{}, nil)
+	s.st.EXPECT().UpdateUnitPorts(domaintesting.IsAtomicContextChecker, unitUUID, openPorts, closePorts).Return(nil)
 
 	srv := NewService(s.st)
 	err := srv.UpdateUnitPorts(context.Background(), unitUUID, openPorts, closePorts)
@@ -105,8 +106,8 @@ func (s *serviceSuite) TestUpdateUnitPortsSameRangeAcrossEndpoints(c *gc.C) {
 	}
 	closePorts := network.GroupedPortRanges{}
 
-	s.st.EXPECT().GetOpenedEndpointPorts(gomock.Any(), unitUUID, WildcardEndpoint).Return([]network.PortRange{}, nil)
-	s.st.EXPECT().UpdateUnitPorts(gomock.Any(), unitUUID, openPorts, closePorts).Return(nil)
+	s.st.EXPECT().GetOpenedEndpointPorts(domaintesting.IsAtomicContextChecker, unitUUID, WildcardEndpoint).Return([]network.PortRange{}, nil)
+	s.st.EXPECT().UpdateUnitPorts(domaintesting.IsAtomicContextChecker, unitUUID, openPorts, closePorts).Return(nil)
 
 	srv := NewService(s.st)
 	err := srv.UpdateUnitPorts(context.Background(), unitUUID, openPorts, closePorts)
@@ -156,9 +157,9 @@ func (s *serviceSuite) TestUpdateUnitPortsOpenWildcard(c *gc.C) {
 	}
 	closePorts := network.GroupedPortRanges{}
 
-	s.st.EXPECT().GetOpenedEndpointPorts(gomock.Any(), unitUUID, WildcardEndpoint).Return([]network.PortRange{}, nil)
+	s.st.EXPECT().GetOpenedEndpointPorts(domaintesting.IsAtomicContextChecker, unitUUID, WildcardEndpoint).Return([]network.PortRange{}, nil)
 	s.st.EXPECT().GetEndpoints(gomock.Any(), unitUUID).Return([]string{WildcardEndpoint, "ep1", "ep2", "ep3"}, nil)
-	s.st.EXPECT().UpdateUnitPorts(gomock.Any(), unitUUID, openPorts, network.GroupedPortRanges{
+	s.st.EXPECT().UpdateUnitPorts(domaintesting.IsAtomicContextChecker, unitUUID, openPorts, network.GroupedPortRanges{
 		"ep1": {
 			network.MustParsePortRange("100-200/tcp"),
 		},
@@ -185,10 +186,10 @@ func (s *serviceSuite) TestUpdateUnitPortsOpenPortRangeOpenOnWildcard(c *gc.C) {
 	}
 	closePorts := network.GroupedPortRanges{}
 
-	s.st.EXPECT().GetOpenedEndpointPorts(gomock.Any(), unitUUID, WildcardEndpoint).Return([]network.PortRange{
+	s.st.EXPECT().GetOpenedEndpointPorts(domaintesting.IsAtomicContextChecker, unitUUID, WildcardEndpoint).Return([]network.PortRange{
 		network.MustParsePortRange("100-200/tcp"),
 	}, nil)
-	s.st.EXPECT().UpdateUnitPorts(gomock.Any(), unitUUID, openPorts, network.GroupedPortRanges{}).Return(nil)
+	s.st.EXPECT().UpdateUnitPorts(domaintesting.IsAtomicContextChecker, unitUUID, openPorts, network.GroupedPortRanges{}).Return(nil)
 
 	srv := NewService(s.st)
 	err := srv.UpdateUnitPorts(context.Background(), unitUUID, openPorts, closePorts)
@@ -205,9 +206,9 @@ func (s *serviceSuite) TestUpdateUnitPortsCloseWildcard(c *gc.C) {
 		},
 	}
 
-	s.st.EXPECT().GetOpenedEndpointPorts(gomock.Any(), unitUUID, WildcardEndpoint).Return([]network.PortRange{}, nil)
+	s.st.EXPECT().GetOpenedEndpointPorts(domaintesting.IsAtomicContextChecker, unitUUID, WildcardEndpoint).Return([]network.PortRange{}, nil)
 	s.st.EXPECT().GetEndpoints(gomock.Any(), unitUUID).Return([]string{WildcardEndpoint, "ep1", "ep2", "ep3"}, nil)
-	s.st.EXPECT().UpdateUnitPorts(gomock.Any(), unitUUID, openPorts, network.GroupedPortRanges{
+	s.st.EXPECT().UpdateUnitPorts(domaintesting.IsAtomicContextChecker, unitUUID, openPorts, network.GroupedPortRanges{
 		WildcardEndpoint: {
 			network.MustParsePortRange("100-200/tcp"),
 		},
@@ -237,11 +238,11 @@ func (s *serviceSuite) TestUpdateUnitPortsClosePortRangeOpenOnWildcard(c *gc.C) 
 		},
 	}
 
-	s.st.EXPECT().GetOpenedEndpointPorts(gomock.Any(), unitUUID, WildcardEndpoint).Return([]network.PortRange{
+	s.st.EXPECT().GetOpenedEndpointPorts(domaintesting.IsAtomicContextChecker, unitUUID, WildcardEndpoint).Return([]network.PortRange{
 		network.MustParsePortRange("100-200/tcp"),
 	}, nil)
 	s.st.EXPECT().GetEndpoints(gomock.Any(), unitUUID).Return([]string{WildcardEndpoint, "ep1", "ep2", "ep3"}, nil)
-	s.st.EXPECT().UpdateUnitPorts(gomock.Any(), unitUUID, network.GroupedPortRanges{
+	s.st.EXPECT().UpdateUnitPorts(domaintesting.IsAtomicContextChecker, unitUUID, network.GroupedPortRanges{
 		"ep2": {
 			network.MustParsePortRange("100-200/tcp"),
 		},

--- a/domain/testing/atomic.go
+++ b/domain/testing/atomic.go
@@ -1,0 +1,32 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package testing
+
+import (
+	"context"
+
+	"go.uber.org/mock/gomock"
+
+	"github.com/juju/juju/domain"
+)
+
+type testingAtomicContext struct {
+	ctx context.Context
+}
+
+// NewAtomicContext returns a stub implementation of domain.AtomicContext.
+// Used for testing.
+func NewAtomicContext(ctx context.Context) *testingAtomicContext {
+	return &testingAtomicContext{
+		ctx: ctx,
+	}
+}
+
+func (t *testingAtomicContext) Context() context.Context {
+	return t.ctx
+}
+
+// IsAtomicContextChecker is a gomock.Matcher that checks if the argument is an
+// AtomicContext.
+var IsAtomicContextChecker = gomock.AssignableToTypeOf(domain.AtomicContext(&testingAtomicContext{}))

--- a/domain/testing/notest.go
+++ b/domain/testing/notest.go
@@ -1,0 +1,22 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+//go:build notest
+
+package testing
+
+import (
+	_ "unsafe"
+)
+
+// Dear Reader,
+// You have found your way here because you imported github.com/juju/juju/domain/testing
+// into code that found its way into a non-test binary.
+// This is bad. Please don't use test code inside a juju binary.
+
+//go:linkname do_not_import_test_code_into_juju
+func do_not_import_test_code_into_juju()
+
+func init() {
+	do_not_import_test_code_into_juju()
+}


### PR DESCRIPTION
We recently added methods to state + services to allow us to run multiple state methods within an atomic transaction in our services (RunAtomic method on state), which takes a closure

Usage of this method is a little difficult to test, since one step of it's implementation wraps the context in an atomicContext, which is then passed back up to the user

Add and use some testing infrastructure to construct a stub atomic context out of a context.

As a flyby, ban linking of our testing package in production

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

unit tests pass