### PR TITLE
WIP fix: add annotation to error and split validators

### DIFF
--- a/apiserver/facades/client/modelupgrader/upgrader.go
+++ b/apiserver/facades/client/modelupgrader/upgrader.go
@@ -338,7 +338,7 @@ func (m *ModelUpgraderAPI) validateModelUpgrade(
 
 	checker := upgradevalidation.NewModelUpgradeCheck(
 		modelTag.Id(), m.statePool, st, model,
-		upgradevalidation.ValidatorsForControllerUpgrade(true, targetVersion, cloudspec)...,
+		upgradevalidation.ValidatorsForControllerUpgrade(targetVersion, cloudspec)...,
 	)
 	blockers, err = checker.Validate()
 	if err != nil {
@@ -374,12 +374,12 @@ func (m *ModelUpgraderAPI) validateModelUpgrade(
 		if err != nil {
 			return errors.Trace(err)
 		}
-		validators := upgradevalidation.ValidatorsForControllerUpgrade(false, targetVersion, cloudspec)
+		validators := upgradevalidation.ModelValidatorsForControllerUpgrade(targetVersion, cloudspec)
 
 		checker := upgradevalidation.NewModelUpgradeCheck(modelUUID, m.statePool, st, model, validators...)
 		blockersForModel, err := checker.Validate()
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Annotatef(err, "validating model %s", model.Name())
 		}
 		if blockersForModel == nil {
 			// all good.

--- a/upgrades/upgradevalidation/upgrade.go
+++ b/upgrades/upgradevalidation/upgrade.go
@@ -9,27 +9,32 @@ import (
 	environscloudspec "github.com/juju/juju/environs/cloudspec"
 )
 
-// ValidatorsForControllerUpgrade returns a list of validators for controller
-// upgrade.
+// ValidatorsForControllerUpgrade returns a list of validators for the
+// controller model in a controller upgrade.
 // Note: the target version can never be lower than the current version.
 func ValidatorsForControllerUpgrade(
-	isControllerModel bool, targetVersion version.Number, cloudspec environscloudspec.CloudSpec,
+	targetVersion version.Number, cloudspec environscloudspec.CloudSpec,
 ) []Validator {
-	if isControllerModel {
-		validators := []Validator{
-			getCheckTargetVersionForControllerModel(targetVersion),
-			checkMongoStatusForControllerUpgrade,
-			checkMongoVersionForControllerModel,
-			checkNoWinMachinesForModel,
-			checkForDeprecatedUbuntuSeriesForModel,
-			getCheckForLXDVersion(cloudspec),
-		}
-		if targetVersion.Major == 3 && targetVersion.Minor >= 1 {
-			validators = append(validators, checkForCharmStoreCharms)
-		}
-		return validators
+	validators := []Validator{
+		getCheckTargetVersionForControllerModel(targetVersion),
+		checkMongoStatusForControllerUpgrade,
+		checkMongoVersionForControllerModel,
+		checkNoWinMachinesForModel,
+		checkForDeprecatedUbuntuSeriesForModel,
+		getCheckForLXDVersion(cloudspec),
 	}
+	if targetVersion.Major == 3 && targetVersion.Minor >= 1 {
+		validators = append(validators, checkForCharmStoreCharms)
+	}
+	return validators
+}
 
+// ModelValidatorsForControllerUpgrade returns a list of validators for
+// non-controller models in a controller upgrade.
+// Note: the target version can never be lower than the current version.
+func ModelValidatorsForControllerUpgrade(
+	targetVersion version.Number, cloudspec environscloudspec.CloudSpec,
+) []Validator {
 	validators := []Validator{
 		getCheckTargetVersionForModel(targetVersion, UpgradeControllerAllowed),
 		checkModelMigrationModeForControllerUpgrade,


### PR DESCRIPTION
The controller upgrade validators function was effectively two functions with a boolean flag as input to determine what was returned. Split it into actual separate functions.

Also annotate error coming back from checks so that it is clear which check is failing to run if controller upgrade is blocked.

<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://docs.google.com/document/d/1SYUo9G7qZ_jdoVXpUVamS5VCgHmtZ0QA-wZxKoMS-C0 
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps
Add a new cloud to ~/.local/share/juju/clouds.yaml that is the same as the Lxd one but with a different name:
```
  lxd-test-broken:
    type: lxd
    auth-types: [certificate]
    endpoint: 172.17.0.1:8443
    regions:
      default:
        endpoint: 172.17.0.1:8443
```
Add a credential to ~/.local/share/juju/credentails.yaml for the new cloud (the credential below has the same name as the cloud)
```
  lxd-test-broken:
    default-credential: lxd-test-broken
    lxd-test-broken:
      auth-type: certificate
      client-cert: |
        -----BEGIN CERTIFICATE-----
...
        -----END CERTIFICATE-----
      client-key: |
        -----BEGIN EC PRIVATE KEY-----
...
        -----END EC PRIVATE KEY-----
      server-cert: |
        -----BEGIN CERTIFICATE-----
...
        -----END CERTIFICATE-----

```
Try upgrading controller that has a model in a cloud with a dodgy cert. This should cause one of the validators to file to run (note that this is different from it blocking).
```
$ juju bootstrap lxd upgrade-controller-check
$ juju add-cloud lxd-test-broken
This operation can be applied to both a copy on this client and to the one on a controller.
Do you want to add cloud to:
    1. client only (--client)
    2. controller "upgrade-controller-check" only (--controller upgrade-controller-check)
    3. both (--client --controller upgrade-controller-check)
Enter your choice, or type Q|q to quit: 
# Press 2
$ juju clouds --controller upgrade-controller-check
Clouds available on the controller:
Cloud            Regions  Default  Type
lxd              1        default  lxd  
lxd-test-broken  1        default  lxd  
$ juju add-model broken-lxd lxd-test-broken
$ juju deploy ubuntu
$ juju db
$ mongo> db.cloudCredentials.find()
{ "_id" : "lxd-test-broken#admin#lxd-test-broken", "owner" : "admin", "cloud" : "lxd-test-broken", "name" : "lxd-test-...
$ mongo> db.cloudCredentials.remove({"cloud": "lxd-test-broken"})
WriteResult({ "nRemoved" : 1 })
$ mongo> db.cloudCredentials.find()
# Now gone from the collection
# Mess around with the certs, delete a few chars
$ mongo> db.cloudCredentials.insert({ "_id" : "lxd-test-broken#admin#lxd-test-broken", "owner" : "admin", "cloud" : "lxd-test-broken", "name" : "lxd-test-...)
# Exit mongo
$ juju upgrade-controller --build-agent
# ERROR validating model "broken-lxd" for controller upgrade: tls: failed to find any PEM data in certificate input
Note that error now includes the name of the model for which the validation failed.
```


<!-- Describe steps to verify that the change works. -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2075304

**Jira card:** [JUJU-6582](https://warthogs.atlassian.net/browse/JUJU-6582)

