### PR TITLE
fix: remove requirement for yq from repl script

### DIFF
--- a/scripts/dqlite/scripts/repl/repl.sh
+++ b/scripts/dqlite/scripts/repl/repl.sh
@@ -21,8 +21,12 @@ echo "--------------------------------------------------------------------------
 echo ""
 
 CMDS=$(cat << EOF
-sudo cat /var/lib/juju/agents/machine-$MACHINE/agent.conf | yq '.controllercert' | xargs -I% echo % > dqlite.cert
-sudo cat /var/lib/juju/agents/machine-$MACHINE/agent.conf | yq '.controllerkey' | xargs -I% echo % > dqlite.key
+sudo awk '/controllercert/ {in_cert_block=1; next}
+/:/ {in_cert_block=0}
+in_cert_block { print }' /var/lib/juju/agents/machine-$MACHINE/agent.conf | sed 's/  //' > dqlite.cert
+sudo awk '/controllerkey/ {in_cert_block=1; next}
+/:/ {in_cert_block=0}
+in_cert_block { print }' /var/lib/juju/agents/machine-$MACHINE/agent.conf | sed 's/  //' > dqlite.key
 sudo dqlite -s file:///var/lib/juju/dqlite/cluster.yaml -c ./dqlite.cert -k ./dqlite.key $DB_NAME
 EOF
 )


### PR DESCRIPTION
The repl script needed yq which is not installed by default on controller machines

<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://docs.google.com/document/d/1SYUo9G7qZ_jdoVXpUVamS5VCgHmtZ0QA-wZxKoMS-C0 
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc

## QA steps
```
juju bootstrap lxd test
make repl-install
make repl
```
<!-- Describe steps to verify that the change works. -->


