### PR TITLE
feat: restricted LXD servers

### DIFF
--- a/provider/lxd/credentials.go
+++ b/provider/lxd/credentials.go
@@ -172,6 +172,7 @@ func (p environProviderCredentials) DetectCredentials(cloudName string) (*cloud.
 // detectLocalCredentials will use the local server to read and finalize the
 // cloud credentials.
 func (p environProviderCredentials) detectLocalCredentials(certPEM, keyPEM []byte) (*cloud.Credential, error) {
+	// TODO: pass in project or use restricted server
 	svr, err := p.serverFactory.LocalServer()
 	if err != nil {
 		return nil, errors.NewNotFound(err, "failed to connect to local LXD")
@@ -361,6 +362,7 @@ func (p environProviderCredentials) finalizeCredential(
 	// and we can start a local server to finalise the credential
 	// over the LXD Unix docket.
 	if args.CloudEndpoint == "" {
+		// TODO: pass in project or use restricted server
 		svr, err := p.serverFactory.LocalServer()
 		if err != nil {
 			return nil, errors.Trace(err)
@@ -405,6 +407,7 @@ func (p environProviderCredentials) finalizeRemoteCredential(
 	}
 
 	insecureCreds := cloud.NewCredential(cloud.CertificateAuthType, credAttrs)
+	// TODO: pass in LXD project or use restricted client
 	server, err := p.serverFactory.InsecureRemoteServer(CloudSpec{
 		CloudSpec: environscloudspec.CloudSpec{
 			Endpoint:   endpoint,
@@ -461,6 +464,7 @@ func (p environProviderCredentials) finalizeRemoteCredential(
 	attributes[credAttrServerCert] = lxdServerCert
 
 	secureCreds := cloud.NewCredential(cloud.CertificateAuthType, attributes)
+	// TODO: add project or use restricted client
 	server, err = p.serverFactory.RemoteServer(CloudSpec{
 		CloudSpec: environscloudspec.CloudSpec{
 			Endpoint:   endpoint,

--- a/provider/lxd/provider.go
+++ b/provider/lxd/provider.go
@@ -315,7 +315,7 @@ func (p *environProvider) FinalizeCloud(
 }
 
 func getLocalHostAddress(ctx environs.FinalizeCloudContext, serverFactory ServerFactory) (string, error) {
-	svr, err := serverFactory.LocalServer()
+	svr, err := serverFactory.LocalRestrictedServer()
 	if err != nil {
 		return "", errors.Trace(err)
 	}

--- a/provider/lxd/restricted.go
+++ b/provider/lxd/restricted.go
@@ -1,0 +1,14 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package lxd
+
+// A RestrictedServer is a LXD client which can only perform a restricted
+// subset of operations, such as getting information about the LXD cluster as a
+// whole. These operations do not require one to specify the LXD project.
+type RestrictedServer interface {
+	// ServerVersion returns the version of the LXD server.
+	ServerVersion() string
+	// LocalBridgeName returns the name of the local LXD network bridge.
+	LocalBridgeName() string
+}

--- a/upgrades/upgradevalidation/validation.go
+++ b/upgrades/upgradevalidation/validation.go
@@ -351,7 +351,7 @@ func getCheckForLXDVersion(cloudspec environscloudspec.CloudSpec) Validator {
 			return jujuhttp.NewClient(
 				jujuhttp.WithLogger(logger.ChildWithLabels("http", corelogger.HTTP)),
 			).Client()
-		})).RemoteServer(lxd.CloudSpec{CloudSpec: cloudspec})
+		})).RemoteRestrictedServer(lxd.CloudSpec{CloudSpec: cloudspec})
 		if err != nil {
 			return nil, errors.Trace(err)
 		}


### PR DESCRIPTION
## Background

A bug [LP2075510](https://bugs.launchpad.net/juju/+bug/2075510) was reported in which a Juju controller bootstrapped into a restricted LXD project cannot be upgraded. Restricted means the user can access a custom LXD project, but they do not have permission to access the default project.

The issue is that even if the controller is bootstrapped to a specific (non-default) LXD project, certain LXD API calls are not specifying the project parameter. Hence they are being redirected to the default project, and if the user does not have access to the default project, this predictably fails. The specific API call in question came from the initialisation code for the `lxd.Server`, this contains a default check for the `default` profile.

It was agreed things should be changed so that we always have to specify the project when doing any non-trivial operations with LXD. However, there is a very small set of operations that should be okay to do without specifying a project. These include getting basic information about the cluster such as the LXD server version. (In the LXD API world, this is saying calls to `/1.0` are OK without specifying a project). This motivates the introduction of a "restricted" client which can perform a restricted set of operations that don't require specifying the LXD project.

## Changes

Changes to the LXD server factory. The normal `LocalServer`, `RemoteServer`, `InsecureRemoteServer` functions now require the LXD project to be specified. They will validate the project and return an error if it is not specified.

For other use cases, such as checking the LXD version or getting the LXD server address, we have created a `RestrictedServer` type and new functions `LocalRestrictedServer`, `RemoteRestrictedServer` on the server factory. These operations are considered OK to do without specifying a project, in circumstances where the LXD project may not be readily available.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

<!-- Describe steps to verify that the change works. -->

TODO

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2075510

**Jira card:** [JUJU-6583](https://warthogs.atlassian.net/browse/JUJU-6583)

[JUJU-6583]: https://warthogs.atlassian.net/browse/JUJU-6583?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ