### PR TITLE
refactor: remove validator cloud facade

### DIFF
--- a/apiserver/facades/client/cloud/register.go
+++ b/apiserver/facades/client/cloud/register.go
@@ -9,10 +9,7 @@ import (
 
 	"github.com/juju/errors"
 
-	"github.com/juju/juju/apiserver/common/credentialcommon"
 	"github.com/juju/juju/apiserver/facade"
-	coremodel "github.com/juju/juju/core/model"
-	"github.com/juju/juju/domain/credential/service"
 )
 
 // Register is called to expose a package of facades onto a given registry.
@@ -32,39 +29,6 @@ func newFacadeV7(stdCtx stdcontext.Context, context facade.ModelContext) (*Cloud
 	credentialService := serviceFactory.Credential().
 		WithLegacyUpdater(systemState.CloudCredentialUpdated).
 		WithLegacyRemover(systemState.RemoveModelsCredential)
-
-	credentialCallContextGetter := func(ctx stdcontext.Context, modelUUID coremodel.UUID) (service.CredentialValidationContext, error) {
-		modelState, err := context.StatePool().Get(modelUUID.String())
-		if err != nil {
-			return service.CredentialValidationContext{}, err
-		}
-		defer modelState.Release()
-
-		m, err := modelState.Model()
-		if err != nil {
-			return service.CredentialValidationContext{}, err
-		}
-		cfg, err := m.Config()
-		if err != nil {
-			return service.CredentialValidationContext{}, err
-		}
-
-		cld, err := context.ServiceFactory().Cloud().Cloud(ctx, m.CloudName())
-		if err != nil {
-			return service.CredentialValidationContext{}, err
-		}
-
-		return service.CredentialValidationContext{
-			ControllerUUID: context.ControllerUUID(),
-			Config:         cfg,
-			MachineService: credentialcommon.NewMachineService(modelState.State),
-			ModelType:      coremodel.ModelType(m.Type()),
-			Cloud:          *cld,
-			Region:         m.CloudRegion(),
-		}, nil
-	}
-
-	credentialService = credentialService.WithValidationContextGetter(credentialCallContextGetter)
 
 	controllerInfo, err := systemState.ControllerInfo()
 	if err != nil {


### PR DESCRIPTION
This PR removes the credential validation logic from both the cloud facade and the credential service. We have decided to do this as a temporary measure to get DQlite work though the system. This needs to be redesigned with more rigger. I have documented the work that needs to be done in both the risk register and in JUJU-6670

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

1. Bootstrap a controller.
2. Add a model and deploy a workload.
3. Update the cloud credential for the created model.
4. Confirm that you can still add a new machine.
5. Confirm that `juju status` doesn't report any problems.

## Documentation changes

N/A

## Links

**Jira card:** JUJU-6421

