### PR TITLE
test: watcher harness kills watcher

### DIFF
--- a/core/watcher/watchertest/harness.go
+++ b/core/watcher/watchertest/harness.go
@@ -102,6 +102,10 @@ func (h *Harness[T]) Run(c *gc.C, initial ...T) {
 
 	h.watcher.AssertNoChange()
 	h.idler.AssertChangeStreamIdle(c)
+
+	// Now ensure that the watcher is also killed cleanly.
+
+	h.watcher.AssertKilled()
 }
 
 type harnessTest[T any] struct {


### PR DESCRIPTION
Upon completion of the run command, the watcher should be killed cleanly. If this isn't the case, we'll see some unexpected results at the API server level.

The code enforces this strategy when testing watchers.


## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

All the watcher tests should pass.

