### PR TITLE
fix(test): remove unnecessary clean kill assertions

### DIFF
--- a/apiserver/facades/agent/reboot/reboot_test.go
+++ b/apiserver/facades/agent/reboot/reboot_test.go
@@ -101,7 +101,6 @@ func (s *rebootSuite) setupMachine(c *gc.C, tag names.MachineTag, err error, uui
 	wc.AssertNoChange()
 
 	s.AddCleanup(func(c *gc.C) {
-		watchertest.DirtyKill(c, w)
 		wc.AssertKilled()
 	})
 

--- a/core/watcher/eventsource/multiwatcher_test.go
+++ b/core/watcher/eventsource/multiwatcher_test.go
@@ -107,7 +107,6 @@ func (*multiWatcherSuite) TestMultiWatcherStop(c *gc.C) {
 	defer workertest.DirtyKill(c, w)
 	wc.AssertOneChange()
 
-	workertest.CleanKill(c, w)
 	wc.AssertKilled()
 
 	// Ensure that the underlying watchers are also stopped.


### PR DESCRIPTION
- Before this commit, some watcher in test were unnecessary killed twice, causing possible data race into watcher tear down, resulting in random test failures.
- After this commit, watcher are killed once and shouldn't trigger this random test failure anymore.

<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://docs.google.com/document/d/1SYUo9G7qZ_jdoVXpUVamS5VCgHmtZ0QA-wZxKoMS-C0 
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
~- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
~- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

<!-- Describe steps to verify that the change works. -->
None 

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->
None 

## Links

None 
