### PR TITLE
Refactor charm state

### DIFF
--- a/domain/application/errors/errors.go
+++ b/domain/application/errors/errors.go
@@ -81,6 +81,10 @@ const (
 	// CharmNotFound describes an error that occurs when a charm cannot be found.
 	CharmNotFound = errors.ConstError("charm not found")
 
+	// LXDProfileNotFound describes an error that occurs when an LXD profile
+	// cannot be found.
+	LXDProfileNotFound = errors.ConstError("LXD profile not found")
+
 	// CharmAlreadyExists describes an error that occurs when a charm already
 	// exists for the given natural key.
 	CharmAlreadyExists = errors.ConstError("charm already exists")

--- a/domain/application/state/application.go
+++ b/domain/application/state/application.go
@@ -106,7 +106,7 @@ func (st *ApplicationState) CreateApplication(ctx context.Context, name string, 
 	)
 
 	originInfo := setCharmOrigin{
-		CharmID: charmID.String(),
+		CharmUUID: charmID.String(),
 		// Set the Name on charm origin to the application name. This is
 		// because the charm metadata.yaml can differ from the charm name
 		// that was used to create the application.
@@ -124,7 +124,7 @@ func (st *ApplicationState) CreateApplication(ctx context.Context, name string, 
 	}
 
 	charmPlatformInfo := charmPlatform{
-		CharmID:        charmID.String(),
+		CharmUUID:      charmID.String(),
 		OSTypeID:       int(app.Platform.OSType),
 		Channel:        app.Platform.Channel,
 		ArchitectureID: int(app.Platform.Architecture),

--- a/domain/application/state/charm_test.go
+++ b/domain/application/state/charm_test.go
@@ -32,11 +32,20 @@ func (s *charmStateSuite) TestGetCharmIDByRevision(c *gc.C) {
 	id := charmtesting.GenCharmID(c)
 
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
-		_, err := tx.ExecContext(ctx, `INSERT INTO charm (uuid, name) VALUES (?, 'foo')`, id.String())
-		c.Assert(err, jc.ErrorIsNil)
+		_, err := tx.ExecContext(ctx, `INSERT INTO charm (uuid) VALUES (?)`, id.String())
+		if err != nil {
+			return errors.Trace(err)
+		}
+
+		_, err = tx.ExecContext(ctx, `INSERT INTO charm_metadata (charm_uuid, name) VALUES (?, 'foo')`, id.String())
+		if err != nil {
+			return errors.Trace(err)
+		}
 
 		_, err = tx.ExecContext(ctx, `INSERT INTO charm_origin (reference_name, charm_uuid, revision) VALUES (?, ?, 1)`, "foo", id.String())
-		c.Assert(err, jc.ErrorIsNil)
+		if err != nil {
+			return errors.Trace(err)
+		}
 
 		return nil
 	})
@@ -92,8 +101,15 @@ func (s *charmStateSuite) TestIsControllerCharmWithControllerCharm(c *gc.C) {
 	id := charmtesting.GenCharmID(c)
 
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
-		_, err := tx.ExecContext(ctx, `INSERT INTO charm (uuid, name) VALUES (?, 'juju-controller')`, id.String())
-		c.Assert(err, jc.ErrorIsNil)
+		_, err := tx.ExecContext(ctx, `INSERT INTO charm (uuid) VALUES (?)`, id.String())
+		if err != nil {
+			return errors.Trace(err)
+		}
+
+		_, err = tx.ExecContext(ctx, `INSERT INTO charm_metadata (charm_uuid, name) VALUES (?, 'juju-controller')`, id.String())
+		if err != nil {
+			return errors.Trace(err)
+		}
 		return nil
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -109,8 +125,15 @@ func (s *charmStateSuite) TestIsControllerCharmWithNoControllerCharm(c *gc.C) {
 	id := charmtesting.GenCharmID(c)
 
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
-		_, err := tx.ExecContext(ctx, `INSERT INTO charm (uuid, name) VALUES (?, 'ubuntu')`, id.String())
-		c.Assert(err, jc.ErrorIsNil)
+		_, err := tx.ExecContext(ctx, `INSERT INTO charm (uuid) VALUES (?)`, id.String())
+		if err != nil {
+			return errors.Trace(err)
+		}
+
+		_, err = tx.ExecContext(ctx, `INSERT INTO charm_metadata (charm_uuid, name) VALUES (?, 'ubuntu')`, id.String())
+		if err != nil {
+			return errors.Trace(err)
+		}
 		return nil
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -135,8 +158,15 @@ func (s *charmStateSuite) TestIsSubordinateCharmWithSubordinateCharm(c *gc.C) {
 	id := charmtesting.GenCharmID(c)
 
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
-		_, err := tx.ExecContext(ctx, `INSERT INTO charm (uuid, name, subordinate) VALUES (?, 'ubuntu', true)`, id.String())
-		c.Assert(err, jc.ErrorIsNil)
+		_, err := tx.ExecContext(ctx, `INSERT INTO charm (uuid) VALUES (?)`, id.String())
+		if err != nil {
+			return errors.Trace(err)
+		}
+
+		_, err = tx.ExecContext(ctx, `INSERT INTO charm_metadata (charm_uuid, name, subordinate) VALUES (?, 'ubuntu', true)`, id.String())
+		if err != nil {
+			return errors.Trace(err)
+		}
 		return nil
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -152,8 +182,16 @@ func (s *charmStateSuite) TestIsSubordinateCharmWithNoSubordinateCharm(c *gc.C) 
 	id := charmtesting.GenCharmID(c)
 
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
-		_, err := tx.ExecContext(ctx, `INSERT INTO charm (uuid, name, subordinate) VALUES (?, 'ubuntu', false)`, id.String())
-		c.Assert(err, jc.ErrorIsNil)
+		_, err := tx.ExecContext(ctx, `INSERT INTO charm (uuid) VALUES (?)`, id.String())
+		if err != nil {
+			return errors.Trace(err)
+		}
+
+		_, err = tx.ExecContext(ctx, `INSERT INTO charm_metadata (charm_uuid, name, subordinate) VALUES (?, 'ubuntu', false)`, id.String())
+		if err != nil {
+			return errors.Trace(err)
+		}
+
 		return nil
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -178,14 +216,25 @@ func (s *charmStateSuite) TestSupportsContainersWithContainers(c *gc.C) {
 	id := charmtesting.GenCharmID(c)
 
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
-		_, err := tx.ExecContext(ctx, `INSERT INTO charm (uuid, name) VALUES (?, 'ubuntu')`, id.String())
-		c.Assert(err, jc.ErrorIsNil)
+		_, err := tx.ExecContext(ctx, `INSERT INTO charm (uuid) VALUES (?)`, id.String())
+		if err != nil {
+			return errors.Trace(err)
+		}
+
+		_, err = tx.ExecContext(ctx, `INSERT INTO charm_metadata (charm_uuid, name) VALUES (?, 'ubuntu')`, id.String())
+		if err != nil {
+			return errors.Trace(err)
+		}
 
 		_, err = tx.ExecContext(ctx, `INSERT INTO charm_container (charm_uuid, "key") VALUES (?, 'ubuntu@22.04')`, id.String())
-		c.Assert(err, jc.ErrorIsNil)
+		if err != nil {
+			return errors.Trace(err)
+		}
 
 		_, err = tx.ExecContext(ctx, `INSERT INTO charm_container (charm_uuid, "key") VALUES (?, 'ubuntu@20.04')`, id.String())
-		c.Assert(err, jc.ErrorIsNil)
+		if err != nil {
+			return errors.Trace(err)
+		}
 		return nil
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -201,8 +250,15 @@ func (s *charmStateSuite) TestSupportsContainersWithNoContainers(c *gc.C) {
 	id := charmtesting.GenCharmID(c)
 
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
-		_, err := tx.ExecContext(ctx, `INSERT INTO charm (uuid, name, subordinate) VALUES (?, 'ubuntu', false)`, id.String())
-		c.Assert(err, jc.ErrorIsNil)
+		_, err := tx.ExecContext(ctx, `INSERT INTO charm (uuid) VALUES (?)`, id.String())
+		if err != nil {
+			return errors.Trace(err)
+		}
+
+		_, err = tx.ExecContext(ctx, `INSERT INTO charm_metadata (charm_uuid, name, subordinate) VALUES (?, 'ubuntu', false)`, id.String())
+		if err != nil {
+			return errors.Trace(err)
+		}
 		return nil
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -227,11 +283,15 @@ func (s *charmStateSuite) TestIsCharmAvailableWithAvailable(c *gc.C) {
 	id := charmtesting.GenCharmID(c)
 
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
-		_, err := tx.ExecContext(ctx, `INSERT INTO charm (uuid, name) VALUES (?, 'ubuntu')`, id.String())
-		c.Assert(err, jc.ErrorIsNil)
+		_, err := tx.ExecContext(ctx, `INSERT INTO charm (uuid, available) VALUES (?, true)`, id.String())
+		if err != nil {
+			return errors.Trace(err)
+		}
 
-		_, err = tx.ExecContext(ctx, `INSERT INTO charm_state (charm_uuid, available) VALUES (?, true)`, id.String())
-		c.Assert(err, jc.ErrorIsNil)
+		_, err = tx.ExecContext(ctx, `INSERT INTO charm_metadata (charm_uuid, name) VALUES (?, 'ubuntu')`, id.String())
+		if err != nil {
+			return errors.Trace(err)
+		}
 		return nil
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -247,11 +307,15 @@ func (s *charmStateSuite) TestIsCharmAvailableWithNotAvailable(c *gc.C) {
 	id := charmtesting.GenCharmID(c)
 
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
-		_, err := tx.ExecContext(ctx, `INSERT INTO charm (uuid, name) VALUES (?, 'ubuntu')`, id.String())
-		c.Assert(err, jc.ErrorIsNil)
+		_, err := tx.ExecContext(ctx, `INSERT INTO charm (uuid, available) VALUES (?, false)`, id.String())
+		if err != nil {
+			return errors.Trace(err)
+		}
 
-		_, err = tx.ExecContext(ctx, `INSERT INTO charm_state (charm_uuid, available) VALUES (?, false)`, id.String())
-		c.Assert(err, jc.ErrorIsNil)
+		_, err = tx.ExecContext(ctx, `INSERT INTO charm_metadata (charm_uuid, name) VALUES (?, 'ubuntu')`, id.String())
+		if err != nil {
+			return errors.Trace(err)
+		}
 		return nil
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -276,11 +340,15 @@ func (s *charmStateSuite) TestSetCharmAvailable(c *gc.C) {
 	id := charmtesting.GenCharmID(c)
 
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
-		_, err := tx.ExecContext(ctx, `INSERT INTO charm (uuid, name) VALUES (?, 'ubuntu')`, id.String())
-		c.Assert(err, jc.ErrorIsNil)
+		_, err := tx.ExecContext(ctx, `INSERT INTO charm (uuid, available) VALUES (?, false)`, id.String())
+		if err != nil {
+			return errors.Trace(err)
+		}
 
-		_, err = tx.ExecContext(ctx, `INSERT INTO charm_state (charm_uuid, available) VALUES (?, false)`, id.String())
-		c.Assert(err, jc.ErrorIsNil)
+		_, err = tx.ExecContext(ctx, `INSERT INTO charm_metadata (charm_uuid, name) VALUES (?, 'ubuntu')`, id.String())
+		if err != nil {
+			return errors.Trace(err)
+		}
 		return nil
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -312,11 +380,20 @@ func (s *charmStateSuite) TestReserveCharmRevision(c *gc.C) {
 	id := charmtesting.GenCharmID(c)
 
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
-		_, err := tx.ExecContext(ctx, `INSERT INTO charm (uuid, name, run_as_id) VALUES (?, 'ubuntu', 0)`, id.String())
-		c.Assert(err, jc.ErrorIsNil)
+		_, err := tx.ExecContext(ctx, `INSERT INTO charm (uuid, available) VALUES (?, false)`, id.String())
+		if err != nil {
+			return errors.Trace(err)
+		}
 
-		_, err = tx.ExecContext(ctx, `INSERT INTO charm_state (charm_uuid, available) VALUES (?, false)`, id.String())
-		c.Assert(err, jc.ErrorIsNil)
+		_, err = tx.ExecContext(ctx, `INSERT INTO charm_metadata (charm_uuid, name, run_as_id) VALUES (?, 'ubuntu', 0)`, id.String())
+		if err != nil {
+			return errors.Trace(err)
+		}
+
+		_, err = tx.ExecContext(ctx, `INSERT INTO charm_origin (charm_uuid, reference_name) VALUES (?, 'ubuntu')`, id.String())
+		if err != nil {
+			return errors.Trace(err)
+		}
 		return nil
 	})
 	c.Assert(err, jc.ErrorIsNil)
@@ -1908,9 +1985,9 @@ func (s *charmStateSuite) TestGetCharmLXDProfile(c *gc.C) {
 		}
 
 		_, err := tx.ExecContext(ctx, `
-UPDATE charm 
+UPDATE charm_metadata 
 SET lxd_profile = ?
-WHERE uuid = ?
+WHERE charm_uuid = ?
 `, `{"profile": []}`, uuid)
 		if err != nil {
 			return errors.Trace(err)
@@ -1936,6 +2013,25 @@ func (s *charmStateSuite) TestGetCharmLXDProfileCharmNotFound(c *gc.C) {
 
 	_, err := st.GetCharmLXDProfile(context.Background(), id)
 	c.Assert(err, jc.ErrorIs, applicationerrors.CharmNotFound)
+}
+
+func (s *charmStateSuite) TestGetCharmLXDProfileLXDProfileNotFound(c *gc.C) {
+	st := NewCharmState(s.TxnRunnerFactory())
+
+	id := charmtesting.GenCharmID(c)
+	uuid := id.String()
+
+	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `INSERT INTO charm (uuid, available) VALUES (?, false)`, uuid)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		return nil
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = st.GetCharmLXDProfile(context.Background(), id)
+	c.Assert(err, jc.ErrorIs, applicationerrors.LXDProfileNotFound)
 }
 
 func (s *charmStateSuite) TestGetCharmConfig(c *gc.C) {
@@ -2239,14 +2335,14 @@ func (s *charmStateSuite) TestGetCharmArchivePathCharmNotFound(c *gc.C) {
 }
 
 func insertCharmState(ctx context.Context, c *gc.C, tx *sql.Tx, uuid string) error {
-	_, err := tx.ExecContext(ctx, `
-INSERT INTO charm (uuid, name, description, summary, subordinate, min_juju_version, run_as_id, assumes) 
-VALUES (?, 'ubuntu', 'description', 'summary', true, '4.0.0', 1, 'null')`, uuid)
+	_, err := tx.ExecContext(ctx, `INSERT INTO charm (uuid, available) VALUES (?, false)`, uuid)
 	if err != nil {
 		return errors.Trace(err)
 	}
 
-	_, err = tx.ExecContext(ctx, `INSERT INTO charm_state (charm_uuid, available) VALUES (?, false)`, uuid)
+	_, err = tx.ExecContext(ctx, `
+INSERT INTO charm_metadata (charm_uuid, name, description, summary, subordinate, min_juju_version, run_as_id, assumes) 
+VALUES (?, 'ubuntu', 'description', 'summary', true, '4.0.0', 1, 'null')`, uuid)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/domain/application/state/metadata.go
+++ b/domain/application/state/metadata.go
@@ -393,14 +393,14 @@ func decodeContainers(containers []charmContainer) (map[string]charm.Container, 
 	return result, nil
 }
 
-func encodeMetadata(id corecharm.ID, metadata charm.Metadata, lxdProfile []byte, archivePath string) (setCharmMetadata, error) {
+func encodeMetadata(id corecharm.ID, metadata charm.Metadata, lxdProfile []byte) (setCharmMetadata, error) {
 	runAs, err := encodeRunAs(metadata.RunAs)
 	if err != nil {
 		return setCharmMetadata{}, fmt.Errorf("cannot encode run as %q: %w", metadata.RunAs, err)
 	}
 
 	return setCharmMetadata{
-		UUID:           id.String(),
+		CharmUUID:      id.String(),
 		Name:           metadata.Name,
 		Summary:        metadata.Summary,
 		Description:    metadata.Description,
@@ -409,7 +409,6 @@ func encodeMetadata(id corecharm.ID, metadata charm.Metadata, lxdProfile []byte,
 		RunAsID:        runAs,
 		Assumes:        metadata.Assumes,
 		LXDProfile:     lxdProfile,
-		ArchivePath:    archivePath,
 	}, nil
 }
 

--- a/domain/application/state/metadata_test.go
+++ b/domain/application/state/metadata_test.go
@@ -474,10 +474,10 @@ func (s *metadataSuite) TestEncodeMetadata(c *gc.C) {
 		RunAs:          "root",
 		Subordinate:    true,
 		Assumes:        []byte("null"),
-	}, []byte("{}"), "archive-path")
+	}, []byte("{}"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(result, gc.DeepEquals, setCharmMetadata{
-		UUID:           id.String(),
+		CharmUUID:      id.String(),
 		Name:           "foo",
 		Summary:        "summary",
 		Description:    "description",
@@ -486,7 +486,6 @@ func (s *metadataSuite) TestEncodeMetadata(c *gc.C) {
 		Subordinate:    true,
 		Assumes:        []byte("null"),
 		LXDProfile:     []byte("{}"),
-		ArchivePath:    "archive-path",
 	})
 
 }

--- a/domain/application/state/types.go
+++ b/domain/application/state/types.go
@@ -145,6 +145,12 @@ type setCharmHash struct {
 	Hash       string `db:"hash"`
 }
 
+// setCharm is used to set the charm.
+type setCharm struct {
+	UUID        string `db:"uuid"`
+	ArchivePath string `db:"archive_path"`
+}
+
 // setInitialCharmOrigin is used to set the reference_name, source, revision
 // and version of a charm.
 type setInitialCharmOrigin struct {
@@ -169,7 +175,7 @@ type charmMetadata struct {
 // setCharmMetadata is used to set the metadata of a charm.
 // This includes the setting of the LXD profile.
 type setCharmMetadata struct {
-	UUID           string `db:"uuid"`
+	CharmUUID      string `db:"charm_uuid"`
 	Name           string `db:"name"`
 	Summary        string `db:"summary"`
 	Description    string `db:"description"`
@@ -178,7 +184,6 @@ type setCharmMetadata struct {
 	Assumes        []byte `db:"assumes"`
 	RunAsID        int    `db:"run_as_id"`
 	LXDProfile     []byte `db:"lxd_profile"`
-	ArchivePath    string `db:"archive_path"`
 }
 
 // charmTag is used to get the tags of a charm.
@@ -481,7 +486,7 @@ type charmArchivePath struct {
 
 // charmOrigin is used to get the origin of a charm.
 type charmOrigin struct {
-	CharmID       string `db:"charm_uuid"`
+	CharmUUID     string `db:"charm_uuid"`
 	ReferenceName string `db:"reference_name"`
 	Source        string `db:"source"`
 	Revision      int    `db:"revision"`
@@ -489,7 +494,7 @@ type charmOrigin struct {
 
 // setCharmOrigin is used to set the origin of a charm.
 type setCharmOrigin struct {
-	CharmID       string `db:"charm_uuid"`
+	CharmUUID     string `db:"charm_uuid"`
 	ReferenceName string `db:"reference_name"`
 	SourceID      int    `db:"source_id"`
 	Revision      int    `db:"revision"`
@@ -500,8 +505,14 @@ type countResult struct {
 }
 
 type charmPlatform struct {
-	CharmID        string `db:"charm_uuid"`
+	CharmUUID      string `db:"charm_uuid"`
 	OSTypeID       int    `db:"os_id"`
 	Channel        string `db:"channel"`
 	ArchitectureID int    `db:"architecture_id"`
+}
+
+type reserveCharm struct {
+	UUID          string `db:"uuid"`
+	Name          string `db:"name"`
+	ReferenceName string `db:"reference_name"`
 }

--- a/domain/schema/model/sql/0015-charm.sql
+++ b/domain/schema/model/sql/0015-charm.sql
@@ -12,8 +12,21 @@ INSERT INTO charm_run_as_kind VALUES
 (2, 'sudoer'),
 (3, 'non-root');
 
+-- The charm table exists as the nexus to all charm data. 
+--
+-- The fact that the charm is in the database indicates that it's a placeholder.
+-- Updating the available flag to true indicates that the charm is now available
+-- for deployment.
 CREATE TABLE charm (
     uuid TEXT NOT NULL PRIMARY KEY,
+    -- Archive path is the path to the charm archive on disk. This is used to
+    -- determine the source of the charm.
+    archive_path TEXT,
+    available BOOLEAN DEFAULT FALSE
+);
+
+CREATE TABLE charm_metadata (
+    charm_uuid TEXT NOT NULL,
     -- name represents the original name of the charm. This is what is stored
     -- in the charm metadata.yaml file.
     name TEXT NOT NULL,
@@ -28,43 +41,28 @@ CREATE TABLE charm (
     -- blob without constraining the expression to a specific set of rules.
     assumes TEXT,
     lxd_profile TEXT,
-    -- Archive path is the path to the charm archive on disk. This is used to
-    -- determine the source of the charm.
-    archive_path TEXT,
     CONSTRAINT fk_charm_run_as_kind_charm
     FOREIGN KEY (run_as_id)
-    REFERENCES charm_run_as_kind (id)
-);
-
-CREATE VIEW v_charm AS
-SELECT
-    c.uuid,
-    c.name,
-    c.description,
-    c.summary,
-    c.subordinate,
-    c.min_juju_version,
-    crak.name AS run_as,
-    c.assumes
-FROM charm AS c
-LEFT JOIN charm_run_as_kind AS crak ON c.run_as_id = crak.id;
-
--- The charm_state table exists to store the availability of a charm. The
--- fact that the charm is in the database indicates that it's a placeholder.
--- Updating the available flag to true indicates that the charm is now
--- available for deployment.
--- This is exists as a separate table as the charm table models the charm
--- metadata and the goal state of the charm. The charm_state table models the
--- internal state of the charm.
-CREATE TABLE charm_state (
-    charm_uuid TEXT NOT NULL,
-    -- Available is a flag that indicates whether the charm is available for
-    -- deployment.
-    available BOOLEAN,
-    CONSTRAINT fk_charm_state_charm
+    REFERENCES charm_run_as_kind (id),
+    CONSTRAINT fk_charm_metadata_charm
     FOREIGN KEY (charm_uuid)
     REFERENCES charm (uuid)
 );
+
+CREATE VIEW v_charm_metadata AS
+SELECT
+    c.uuid,
+    cm.name,
+    cm.description,
+    cm.summary,
+    cm.subordinate,
+    cm.min_juju_version,
+    crak.name AS run_as,
+    cm.assumes,
+    c.available
+FROM charm AS c
+JOIN charm_metadata AS cm ON c.uuid = cm.charm_uuid
+LEFT JOIN charm_run_as_kind AS crak ON cm.run_as_id = crak.id;
 
 CREATE TABLE charm_source (
     id INT PRIMARY KEY,

--- a/domain/schema/model/sql/0015-charm.sql
+++ b/domain/schema/model/sql/0015-charm.sql
@@ -488,7 +488,7 @@ ON charm_container_mount (charm_uuid);
 CREATE VIEW v_charm_url AS
 SELECT
     c.uuid,
-    cs.name || ':' || c.name || '-' || COALESCE(co.revision, 0) AS url
+    cs.name || ':' || co.reference_name || '-' || COALESCE(co.revision, 0) AS url
 FROM charm AS c
 INNER JOIN charm_origin AS co ON c.uuid = co.charm_uuid
 LEFT JOIN charm_source AS cs ON co.source_id = cs.id;

--- a/domain/schema/model/triggers/charm.gen.go
+++ b/domain/schema/model/triggers/charm.gen.go
@@ -26,15 +26,8 @@ END;
 CREATE TRIGGER trg_log_charm_update
 AFTER UPDATE ON charm FOR EACH ROW
 WHEN 
-	NEW.name != OLD.name OR
-	(NEW.description != OLD.description OR (NEW.description IS NOT NULL AND OLD.description IS NULL) OR (NEW.description IS NULL AND OLD.description IS NOT NULL)) OR
-	(NEW.summary != OLD.summary OR (NEW.summary IS NOT NULL AND OLD.summary IS NULL) OR (NEW.summary IS NULL AND OLD.summary IS NOT NULL)) OR
-	(NEW.subordinate != OLD.subordinate OR (NEW.subordinate IS NOT NULL AND OLD.subordinate IS NULL) OR (NEW.subordinate IS NULL AND OLD.subordinate IS NOT NULL)) OR
-	(NEW.min_juju_version != OLD.min_juju_version OR (NEW.min_juju_version IS NOT NULL AND OLD.min_juju_version IS NULL) OR (NEW.min_juju_version IS NULL AND OLD.min_juju_version IS NOT NULL)) OR
-	(NEW.run_as_id != OLD.run_as_id OR (NEW.run_as_id IS NOT NULL AND OLD.run_as_id IS NULL) OR (NEW.run_as_id IS NULL AND OLD.run_as_id IS NOT NULL)) OR
-	(NEW.assumes != OLD.assumes OR (NEW.assumes IS NOT NULL AND OLD.assumes IS NULL) OR (NEW.assumes IS NULL AND OLD.assumes IS NOT NULL)) OR
-	(NEW.lxd_profile != OLD.lxd_profile OR (NEW.lxd_profile IS NOT NULL AND OLD.lxd_profile IS NULL) OR (NEW.lxd_profile IS NULL AND OLD.lxd_profile IS NOT NULL)) OR
-	(NEW.archive_path != OLD.archive_path OR (NEW.archive_path IS NOT NULL AND OLD.archive_path IS NULL) OR (NEW.archive_path IS NULL AND OLD.archive_path IS NOT NULL)) 
+	(NEW.archive_path != OLD.archive_path OR (NEW.archive_path IS NOT NULL AND OLD.archive_path IS NULL) OR (NEW.archive_path IS NULL AND OLD.archive_path IS NOT NULL)) OR
+	(NEW.available != OLD.available OR (NEW.available IS NOT NULL AND OLD.available IS NULL) OR (NEW.available IS NULL AND OLD.available IS NOT NULL)) 
 BEGIN
     INSERT INTO change_log (edit_type_id, namespace_id, changed, created_at)
     VALUES (2, %[2]d, OLD.%[1]s, DATETIME('now'));

--- a/domain/secret/watcher_test.go
+++ b/domain/secret/watcher_test.go
@@ -44,8 +44,8 @@ func (s *watcherSuite) SetUpTest(c *gc.C) {
 
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		_, err := tx.ExecContext(ctx, `
-			INSERT INTO model (uuid, controller_uuid, target_agent_version, name, type, cloud, cloud_type)
-			VALUES (?, ?, ?, "test", "iaas", "fluffy", "ec2")
+INSERT INTO model (uuid, controller_uuid, target_agent_version, name, type, cloud, cloud_type)
+VALUES (?, ?, ?, "test", "iaas", "fluffy", "ec2")
 		`, s.ModelUUID(), coretesting.ControllerTag.Id(), jujuversion.Current.String())
 		return err
 	})


### PR DESCRIPTION
Refactor the charm state to place the charm state as the core
concept and then move everything of that table into a charm_metadata
table. The charms "metadata" (metadata, actions, config, lxdprofile)
should be immutable. There are times where we want to register
a charm placeholder, but we don't have the charm. In these situations
we just want to add a row. This covers the case nicely. You either
have a charm row or not. That charm row can become available or not.

The only lingering thought is that the the charm reference_name, the
name part of the charm URL should also be on the charm table and
not on the charm_origin. I'm currently split on this, we can leave
it where it is and move it later. Most of the time it resides behind
a view anyway.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing


## QA steps

The tests should pass.

```sh
$ juju bootstrap lxd test
$ juju add-model default
$ juju deploy ubuntu
```

## Links

**Jira card:** [JUJU-6624](https://warthogs.atlassian.net/browse/JUJU-6624)

