### PR TITLE
chore: remove charm post request

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -774,10 +774,9 @@ func (srv *Server) endpoints() ([]apihttp.Endpoint, error) {
 		logger:            logger.Child("charms-handler"),
 	}
 	modelCharmsHTTPHandler := &charmsHTTPHandler{
-		postHandler: modelCharmsHandler.ServePost,
-		getHandler:  modelCharmsHandler.ServeGet,
+		getHandler: modelCharmsHandler.ServeGet,
 	}
-	modelCharmsUploadAuthorizer := tagKindAuthorizer{names.UserTagKind}
+	charmsObjectsAuthorizer := tagKindAuthorizer{names.UserTagKind}
 
 	modelObjectsCharmsHTTPHandler := &objectsCharmHTTPHandler{
 		ctxt:              httpCtxt,
@@ -865,8 +864,7 @@ func (srv *Server) endpoints() ([]apihttp.Endpoint, error) {
 		logger:            logger.Child("charms-handler"),
 	}
 	migrateCharmsHTTPHandler := &charmsHTTPHandler{
-		postHandler: migrateCharmsHandler.ServePost,
-		getHandler:  migrateCharmsHandler.ServeUnsupported,
+		getHandler: migrateCharmsHandler.ServeUnsupported,
 	}
 	migrateObjectsCharmsHTTPHandler := &objectsCharmHTTPHandler{
 		ctxt:              httpCtxt,
@@ -926,11 +924,6 @@ func (srv *Server) endpoints() ([]apihttp.Endpoint, error) {
 		pattern: modelRoutePrefix + "/charms",
 		methods: []string{"GET"},
 		handler: modelCharmsHTTPHandler,
-	}, {
-		pattern:    modelRoutePrefix + "/charms",
-		methods:    []string{"POST"},
-		handler:    modelCharmsHTTPHandler,
-		authorizer: modelCharmsUploadAuthorizer,
 	}, {
 		pattern:    modelRoutePrefix + "/tools",
 		handler:    modelToolsUploadHandler,
@@ -1020,7 +1013,7 @@ func (srv *Server) endpoints() ([]apihttp.Endpoint, error) {
 		pattern:    charmsObjectsRoutePrefix,
 		methods:    []string{"PUT"},
 		handler:    modelObjectsCharmsHTTPHandler,
-		authorizer: modelCharmsUploadAuthorizer,
+		authorizer: charmsObjectsAuthorizer,
 	}}
 	if srv.registerIntrospectionHandlers != nil {
 		add := func(subpath string, h http.Handler) {

--- a/apiserver/charms.go
+++ b/apiserver/charms.go
@@ -4,24 +4,19 @@
 package apiserver
 
 import (
-	"archive/zip"
 	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
-	"fmt"
 	"io"
 	"mime"
 	"net/http"
 	"os"
 	"path"
 	"path/filepath"
-	"sort"
 	"strconv"
-	"strings"
 
 	"github.com/juju/errors"
-	ziputil "github.com/juju/utils/v4/zip"
 
 	"github.com/juju/juju/apiserver/common"
 	apiservererrors "github.com/juju/juju/apiserver/errors"
@@ -61,15 +56,12 @@ import (
 // 3.3 and before for both local charm upload and model migration. When we
 // no longer support model migrations from 3.3 we should drop this handler
 type charmsHTTPHandler struct {
-	postHandler endpointMethodHandlerFunc
-	getHandler  endpointMethodHandlerFunc
+	getHandler endpointMethodHandlerFunc
 }
 
 func (h *charmsHTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var err error
 	switch r.Method {
-	case "POST":
-		err = errors.Annotate(h.postHandler(w, r), "cannot upload charm")
 	case "GET":
 		err = errors.Annotate(h.getHandler(w, r), "cannot retrieve charm")
 	default:
@@ -100,42 +92,13 @@ func (h *charmsHandler) ServeUnsupported(w http.ResponseWriter, r *http.Request)
 	return errors.Trace(emitUnsupportedMethodErr(r.Method))
 }
 
-func (h *charmsHandler) ServePost(w http.ResponseWriter, r *http.Request) error {
-	if h.logger.IsLevelEnabled(corelogger.TRACE) {
-		h.logger.Tracef("ServePost(%s)", r.URL)
-	}
-
-	if r.Method != "POST" {
-		return errors.Trace(emitUnsupportedMethodErr(r.Method))
-	}
-
-	// Make sure the content type is zip.
-	contentType := r.Header.Get("Content-Type")
-	if contentType != "application/zip" {
-		return errors.BadRequestf("expected Content-Type: application/zip, got: %v", contentType)
-	}
-
-	st, err := h.stateAuthFunc(r)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	defer st.Release()
-
-	// Add a charm to the store provider.
-	charmURL, err := h.processPost(r, st.State)
-	if err != nil {
-		return errors.NewBadRequest(err, "")
-	}
-	return errors.Trace(sendStatusAndHeadersAndJSON(w, http.StatusOK, map[string]string{"Juju-Curl": charmURL}, &params.CharmsResponse{CharmURL: charmURL}))
-}
-
 func (h *charmsHandler) ServeGet(w http.ResponseWriter, r *http.Request) error {
-	if h.logger.IsLevelEnabled(corelogger.TRACE) {
-		h.logger.Tracef("ServeGet(%s)", r.URL)
-	}
-
 	if r.Method != "GET" {
 		return errors.Trace(emitUnsupportedMethodErr(r.Method))
+	}
+
+	if h.logger.IsLevelEnabled(corelogger.TRACE) {
+		h.logger.Tracef("ServeGet(%s)", r.URL)
 	}
 
 	st, _, err := h.ctxt.stateForRequestAuthenticated(r)
@@ -149,7 +112,7 @@ func (h *charmsHandler) ServeGet(w http.ResponseWriter, r *http.Request) error {
 	// charm file) to be included in the query. Optionally also receives an
 	// "icon" query for returning the charm icon or a default one in case the
 	// charm has no icon.
-	charmArchivePath, fileArg, serveIcon, err := h.processGet(r, st.State)
+	charmArchivePath, fileArg, err := h.processGet(r, st.State)
 	if err != nil {
 		// An error occurred retrieving the charm bundle.
 		if errors.Is(err, errors.NotFound) || errors.Is(err, errors.NotYetAvailable) {
@@ -170,7 +133,7 @@ func (h *charmsHandler) ServeGet(w http.ResponseWriter, r *http.Request) error {
 		sender = h.archiveSender
 	default:
 		// The client requested a specific file.
-		sender = h.archiveEntrySender(fileArg, serveIcon)
+		sender = h.archiveEntrySender(fileArg)
 	}
 
 	return errors.Trace(sendBundleContent(w, r, charmArchivePath, sender))
@@ -193,9 +156,9 @@ func (h *charmsHandler) manifestSender(w http.ResponseWriter, r *http.Request, b
 // filePath does not identify a file or a symlink, a 403 forbidden error is
 // returned. If serveIcon is true, then the charm icon.svg file is sent, or a
 // default icon if that file is not included in the charm.
-func (h *charmsHandler) archiveEntrySender(filePath string, serveIcon bool) bundleContentSenderFunc {
+func (h *charmsHandler) archiveEntrySender(filePath string) bundleContentSenderFunc {
 	return func(w http.ResponseWriter, r *http.Request, bundle *charm.CharmArchive) error {
-		contents, err := common.CharmArchiveEntry(bundle.Path, filePath, serveIcon)
+		contents, err := common.CharmArchiveEntry(bundle.Path, filePath)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -227,211 +190,6 @@ func (h *charmsHandler) archiveSender(w http.ResponseWriter, r *http.Request, bu
 	http.ServeFile(w, r, bundle.Path)
 	return nil
 }
-
-// processPost handles a charm upload POST request after authentication.
-func (h *charmsHandler) processPost(r *http.Request, st *state.State) (string, error) {
-	query := r.URL.Query()
-	schema := query.Get("schema")
-	if schema == "" {
-		schema = "local"
-	}
-	if schema != "local" {
-		// charmhub charms may only be uploaded into models
-		// which are being imported during model migrations.
-		// There's currently no other time where it makes sense
-		// to accept repository charms through this endpoint.
-		if isImporting, err := modelIsImporting(st); err != nil {
-			return "", errors.Trace(err)
-		} else if !isImporting {
-			return "", errors.New("charms may only be uploaded during model migration import")
-		}
-	}
-
-	// Attempt to get the object store early, so we're not unnecessarily
-	// creating a parsing/reading if we can't get the object store.
-	objectStore, err := h.objectStoreGetter.GetObjectStore(r.Context(), st.ModelUUID())
-	if err != nil {
-		return "", errors.Trace(err)
-	}
-
-	charmFileName, err := writeCharmToTempFile(r.Body)
-	if err != nil {
-		return "", errors.Trace(err)
-	}
-	defer os.Remove(charmFileName)
-
-	err = h.processUploadedArchive(charmFileName)
-	if err != nil {
-		return "", err
-	}
-	archive, err := charm.ReadCharmArchive(charmFileName)
-	if err != nil {
-		return "", errors.BadRequestf("invalid charm archive: %v", err)
-	}
-
-	// Use the name from the query string. If we're dealing with an older client
-	// then this won't be sent, instead fallback to the archive metadata name.
-	name := query.Get("name")
-	if name == "" {
-		name = archive.Meta().Name
-	}
-	if err := charm.ValidateName(name); err != nil {
-		return "", errors.NewBadRequest(err, "")
-	}
-
-	var revision int
-	if revisionStr := query.Get("revision"); revisionStr != "" {
-		revision, err = strconv.Atoi(revisionStr)
-		if err != nil {
-			return "", errors.NewBadRequest(errors.NewNotValid(err, "revision"), "")
-		}
-	} else {
-		revision = archive.Revision()
-	}
-
-	// We got it, now let's reserve a charm URL for it in state.
-	curlStr := curlString(schema, query.Get("arch"), name, query.Get("series"), revision)
-
-	switch charm.Schema(schema) {
-	case charm.Local:
-		curl, err := st.PrepareLocalCharmUpload(curlStr)
-		if err != nil {
-			return "", errors.Trace(err)
-		}
-		curlStr = curl.String()
-
-	case charm.CharmHub:
-		if _, err := st.PrepareCharmUpload(curlStr); err != nil {
-			return "", errors.Trace(err)
-		}
-
-	default:
-		return "", errors.Errorf("unsupported schema %q", schema)
-	}
-
-	err = RepackageAndUploadCharm(r.Context(), objectStore, storageStateShim{State: st}, archive, curlStr, revision)
-	if err != nil {
-		return "", errors.Trace(err)
-	}
-	return curlStr, nil
-}
-
-// curlString takes the constituent parts of a charm url and renders the url as a string.
-// This is required since, to support migrations from legacy controllers, we need to support
-// charm urls with series since controllers do not allow migrations to mutate charm urls during
-// migration.
-//
-// This is the only place in Juju 4 where series in a charm url needs to be processed. As such,
-// instead of dragging support for series with us into 4.0, in this one place we string-hack the
-// url
-func curlString(schema, arch, name, series string, revision int) string {
-	if series == "" {
-		curl := &charm.URL{
-			Schema:       schema,
-			Architecture: arch,
-			Name:         name,
-			Revision:     revision,
-		}
-		return curl.String()
-	}
-	var curl string
-	if arch == "" {
-		curl = fmt.Sprintf("%s:%s/%s", schema, series, name)
-	} else {
-		curl = fmt.Sprintf("%s:%s/%s/%s", schema, arch, series, name)
-	}
-	if revision != -1 {
-		curl = fmt.Sprintf("%s-%d", curl, revision)
-	}
-	return curl
-}
-
-// processUploadedArchive opens the given charm archive from path,
-// inspects it to see if it has all files at the root of the archive
-// or it has subdirs. It repackages the archive so it has all the
-// files at the root dir, if necessary, replacing the original archive
-// at path.
-func (h *charmsHandler) processUploadedArchive(path string) error {
-	// Open the archive as a zip.
-	f, err := os.OpenFile(path, os.O_RDWR, 0644)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-	fi, err := f.Stat()
-	if err != nil {
-		return err
-	}
-	zipr, err := zip.NewReader(f, fi.Size())
-	if err != nil {
-		return errors.Annotate(err, "cannot open charm archive")
-	}
-
-	// Find out the root dir prefix from the archive.
-	rootDir, err := h.findArchiveRootDir(zipr)
-	if err != nil {
-		return errors.Annotate(err, "cannot read charm archive")
-	}
-	if rootDir == "." {
-		// Normal charm, just use charm.ReadCharmArchive).
-		return nil
-	}
-
-	// There is one or more subdirs, so we need extract it to a temp
-	// dir and then read it as a charm dir.
-	tempDir, err := os.MkdirTemp("", "charm-extract")
-	if err != nil {
-		return errors.Annotate(err, "cannot create temp directory")
-	}
-	defer os.RemoveAll(tempDir)
-	if err := ziputil.Extract(zipr, tempDir, rootDir); err != nil {
-		return errors.Annotate(err, "cannot extract charm archive")
-	}
-	dir, err := charm.ReadCharmDir(tempDir)
-	if err != nil {
-		return errors.Annotate(err, "cannot read extracted archive")
-	}
-
-	// Now repackage the dir as a bundle at the original path.
-	if err := f.Truncate(0); err != nil {
-		return err
-	}
-	if err := dir.ArchiveTo(f); err != nil {
-		return err
-	}
-	return nil
-}
-
-// findArchiveRootDir scans a zip archive and returns the rootDir of
-// the archive, the one containing metadata.yaml, config.yaml and
-// revision files, or an error if the archive appears invalid.
-func (h *charmsHandler) findArchiveRootDir(zipr *zip.Reader) (string, error) {
-	paths, err := ziputil.Find(zipr, "metadata.yaml")
-	if err != nil {
-		return "", err
-	}
-	switch len(paths) {
-	case 0:
-		return "", errors.Errorf("invalid charm archive: missing metadata.yaml")
-	case 1:
-	default:
-		sort.Sort(byDepth(paths))
-		if depth(paths[0]) == depth(paths[1]) {
-			return "", errors.Errorf("invalid charm archive: ambiguous root directory")
-		}
-	}
-	return filepath.Dir(paths[0]), nil
-}
-
-func depth(path string) int {
-	return strings.Count(path, "/")
-}
-
-type byDepth []string
-
-func (d byDepth) Len() int           { return len(d) }
-func (d byDepth) Swap(i, j int)      { d[i], d[j] = d[j], d[i] }
-func (d byDepth) Less(i, j int) bool { return depth(d[i]) < depth(d[j]) }
 
 // CharmUploader is an interface that is used to update the charm in
 // state and upload it to the object store.
@@ -525,11 +283,10 @@ func (s storageStateShim) PrepareCharmUpload(curl string) (services.UploadedChar
 func (h *charmsHandler) processGet(r *http.Request, st *state.State) (
 	archivePath string,
 	fileArg string,
-	serveIcon bool,
 	err error,
 ) {
-	errRet := func(err error) (string, string, bool, error) {
-		return "", "", false, err
+	errRet := func(err error) (string, string, error) {
+		return "", "", err
 	}
 
 	query := r.URL.Query()
@@ -542,9 +299,6 @@ func (h *charmsHandler) processGet(r *http.Request, st *state.State) (
 	fileArg = query.Get("file")
 	if fileArg != "" {
 		fileArg = path.Clean(fileArg)
-	} else if query.Get("icon") == "1" {
-		serveIcon = true
-		fileArg = "icon.svg"
 	}
 
 	// Use the storage to retrieve and save the charm archive.
@@ -569,7 +323,7 @@ func (h *charmsHandler) processGet(r *http.Request, st *state.State) (
 	if err != nil {
 		return errRet(errors.Annotatef(err, "cannot read charm %q from storage", curl))
 	}
-	return archivePath, fileArg, serveIcon, nil
+	return archivePath, fileArg, nil
 }
 
 // sendJSONError sends a JSON-encoded error response.  Note the

--- a/apiserver/charms_test.go
+++ b/apiserver/charms_test.go
@@ -5,30 +5,17 @@ package apiserver_test
 
 import (
 	"bytes"
-	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
-	"mime"
 	"net/http"
 	"net/url"
 	"os"
-	"path/filepath"
 
-	"github.com/juju/names/v5"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/v4"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/apiserver"
-	"github.com/juju/juju/apiserver/common"
 	apitesting "github.com/juju/juju/apiserver/testing"
-	"github.com/juju/juju/core/permission"
-	"github.com/juju/juju/core/user"
-	"github.com/juju/juju/domain/access/service"
-	"github.com/juju/juju/internal/auth"
 	"github.com/juju/juju/internal/charm"
 	"github.com/juju/juju/internal/testing/factory"
 	jujutesting "github.com/juju/juju/juju/testing"
@@ -56,19 +43,24 @@ func (s *charmsSuite) charmsURI(query string) string {
 	return s.charmsURL(query).String()
 }
 
-func (s *charmsSuite) uploadRequest(c *gc.C, url, contentType string, content io.Reader) *http.Response {
+func (s *charmsSuite) uploadRequest(c *gc.C, url string, curl string, content io.Reader) *http.Response {
 	return sendHTTPRequest(c, apitesting.HTTPRequestParams{
-		Method:      "POST",
+		Method:      "PUT",
 		URL:         url,
-		ContentType: contentType,
+		ContentType: "application/zip",
 		Body:        content,
+		ExtraHeaders: map[string]string{
+			"Juju-Curl": curl,
+		},
 	})
 }
 
-func (s *charmsSuite) assertUploadResponse(c *gc.C, resp *http.Response, expCharmURL string) {
-	charmResponse := s.assertResponse(c, resp, http.StatusOK)
-	c.Check(charmResponse.Error, gc.Equals, "")
-	c.Check(charmResponse.CharmURL, gc.Equals, expCharmURL)
+func (s *charmsSuite) objectsCharmsURL(charmRef string) *url.URL {
+	return s.URL(fmt.Sprintf("/model-%s/charms/%s", s.ControllerModelUUID(), charmRef), nil)
+}
+
+func (s *charmsSuite) objectsCharmsURI(charmRef string) string {
+	return s.objectsCharmsURL(charmRef).String()
 }
 
 func (s *charmsSuite) assertGetFileResponse(c *gc.C, resp *http.Response, expBody, expContentType string) {
@@ -95,13 +87,6 @@ func (s *charmsSuite) assertResponse(c *gc.C, resp *http.Response, expStatus int
 	return charmResponse
 }
 
-func (s *charmsSuite) setModelImporting(c *gc.C) {
-	model, err := s.ControllerModel(c).State().Model()
-	c.Assert(err, jc.ErrorIsNil)
-	err = model.SetMigrationMode(state.MigrationModeImporting)
-	c.Assert(err, jc.ErrorIsNil)
-}
-
 func (s *charmsSuite) TestCharmsServedSecurely(c *gc.C) {
 	url := s.charmsURL("")
 	url.Scheme = "http"
@@ -112,452 +97,16 @@ func (s *charmsSuite) TestCharmsServedSecurely(c *gc.C) {
 	})
 }
 
-func (s *charmsSuite) TestPOSTRequiresAuth(c *gc.C) {
-	resp := apitesting.SendHTTPRequest(c, apitesting.HTTPRequestParams{Method: "POST", URL: s.charmsURI("")})
-	body := apitesting.AssertResponse(c, resp, http.StatusUnauthorized, "text/plain; charset=utf-8")
-	c.Assert(string(body), gc.Equals, "authentication failed: no credentials provided\n")
-}
-
 func (s *charmsSuite) TestGETRequiresAuth(c *gc.C) {
 	resp := apitesting.SendHTTPRequest(c, apitesting.HTTPRequestParams{Method: "GET", URL: s.charmsURI("")})
 	body := apitesting.AssertResponse(c, resp, http.StatusUnauthorized, "text/plain; charset=utf-8")
 	c.Assert(string(body), gc.Equals, "authentication failed: no credentials provided\n")
 }
 
-func (s *charmsSuite) TestRequiresPOSTorGET(c *gc.C) {
+func (s *charmsSuite) TestRequiresGET(c *gc.C) {
 	resp := sendHTTPRequest(c, apitesting.HTTPRequestParams{Method: "PUT", URL: s.charmsURI("")})
 	body := apitesting.AssertResponse(c, resp, http.StatusMethodNotAllowed, "text/plain; charset=utf-8")
 	c.Assert(string(body), gc.Equals, "Method Not Allowed\n")
-}
-
-func (s *charmsSuite) TestPOSTRequiresUserAuth(c *gc.C) {
-	// Add a machine and try to login.
-	f, release := s.NewFactory(c, s.ControllerModelUUID())
-	defer release()
-	machine, password := f.MakeMachineReturningPassword(c, &factory.MachineParams{
-		Nonce: "noncy",
-	})
-	resp := apitesting.SendHTTPRequest(c, apitesting.HTTPRequestParams{
-		Tag:         machine.Tag().String(),
-		Password:    password,
-		Method:      "POST",
-		URL:         s.charmsURI(""),
-		Nonce:       "noncy",
-		ContentType: "foo/bar",
-	})
-	body := apitesting.AssertResponse(c, resp, http.StatusForbidden, "text/plain; charset=utf-8")
-	c.Assert(string(body), gc.Equals, "authorization failed: tag kind machine not valid\n")
-
-	// Now try a user login.
-	resp = sendHTTPRequest(c, apitesting.HTTPRequestParams{Method: "POST", URL: s.charmsURI("")})
-	s.assertErrorResponse(c, resp, http.StatusBadRequest, ".*expected Content-Type: application/zip.+")
-}
-
-func (s *charmsSuite) TestUploadFailsWithInvalidZip(c *gc.C) {
-	var empty bytes.Buffer
-
-	// Pretend we upload a zip by setting the Content-Type, so we can
-	// check the error at extraction time later.
-	resp := s.uploadRequest(c, s.charmsURI("?series=quantal"), "application/zip", &empty)
-	s.assertErrorResponse(c, resp, http.StatusBadRequest, ".*cannot open charm archive: zip: not a valid zip file$")
-
-	// Now try with the default Content-Type.
-	resp = s.uploadRequest(c, s.charmsURI("?series=quantal"), "application/octet-stream", &empty)
-	s.assertErrorResponse(c, resp, http.StatusBadRequest, ".*expected Content-Type: application/zip, got: application/octet-stream$")
-}
-
-func (s *charmsSuite) TestUploadBumpsRevision(c *gc.C) {
-	// Add the dummy charm with revision 1.
-	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
-	curl := fmt.Sprintf("local:quantal/%s-%d", ch.Meta().Name, ch.Revision())
-	info := state.CharmInfo{
-		Charm:       ch,
-		ID:          curl,
-		StoragePath: "dummy-storage-path",
-		SHA256:      "dummy-1-sha256",
-	}
-	_, err := s.ControllerModel(c).State().AddCharm(info)
-	c.Assert(err, jc.ErrorIsNil)
-
-	// Now try uploading the same revision and verify it gets bumped,
-	// and the BundleSha256 is calculated.
-	f, err := os.Open(ch.Path)
-	c.Assert(err, jc.ErrorIsNil)
-	defer f.Close()
-	resp := s.uploadRequest(c, s.charmsURI("?series=quantal"), "application/zip", f)
-	expectedURL := "local:quantal/dummy-2"
-	s.assertUploadResponse(c, resp, expectedURL)
-	sch, err := s.ControllerModel(c).State().Charm(expectedURL)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(sch.URL(), gc.Equals, expectedURL)
-	c.Assert(sch.Revision(), gc.Equals, 2)
-	c.Assert(sch.IsUploaded(), jc.IsTrue)
-	// No more checks for the hash here, because it is
-	// verified in TestUploadRespectsLocalRevision.
-	c.Assert(sch.BundleSha256(), gc.Not(gc.Equals), "")
-}
-
-func (s *charmsSuite) TestUploadVersion(c *gc.C) {
-	expectedVersion := "dummy-146-g725cfd3-dirty"
-
-	// Add the dummy charm with version "juju-2.4-beta3-146-g725cfd3-dirty".
-	pathToArchive := testcharms.Repo.CharmArchivePath(c.MkDir(), "dummy")
-	err := testcharms.InjectFilesToCharmArchive(pathToArchive, map[string]string{
-		"version": expectedVersion,
-	})
-	c.Assert(err, gc.IsNil)
-	ch, err := charm.ReadCharmArchive(pathToArchive)
-	c.Assert(err, gc.IsNil)
-
-	f, err := os.Open(ch.Path)
-	c.Assert(err, jc.ErrorIsNil)
-	defer f.Close()
-	resp := s.uploadRequest(c, s.charmsURI("?series=quantal"), "application/zip", f)
-
-	inputURL := "local:quantal/dummy-1"
-	s.assertUploadResponse(c, resp, inputURL)
-	sch, err := s.ControllerModel(c).State().Charm(inputURL)
-	c.Assert(err, jc.ErrorIsNil)
-
-	version := sch.Version()
-	c.Assert(version, gc.Equals, expectedVersion)
-}
-
-func (s *charmsSuite) TestUploadRespectsLocalRevision(c *gc.C) {
-	// Make a dummy charm dir with revision 123.
-	dir := testcharms.Repo.ClonedDir(c.MkDir(), "dummy")
-	dir.SetDiskRevision(123)
-	// Now bundle the dir.
-	var buf bytes.Buffer
-	err := dir.ArchiveTo(&buf)
-	c.Assert(err, jc.ErrorIsNil)
-	hash := sha256.New()
-	hash.Write(buf.Bytes())
-	expectedSHA256 := hex.EncodeToString(hash.Sum(nil))
-
-	// Now try uploading it and ensure the revision persists.
-	resp := s.uploadRequest(c, s.charmsURI("?series=quantal"), "application/zip", &buf)
-	expectedURL := "local:quantal/dummy-123"
-	s.assertUploadResponse(c, resp, expectedURL)
-	sch, err := s.ControllerModel(c).State().Charm(expectedURL)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(sch.URL(), gc.Equals, expectedURL)
-	c.Assert(sch.Revision(), gc.Equals, 123)
-	c.Assert(sch.IsUploaded(), jc.IsTrue)
-	c.Assert(sch.BundleSha256(), gc.Equals, expectedSHA256)
-
-	store := s.ObjectStore(c, s.ControllerModelUUID())
-	reader, _, err := store.Get(context.Background(), sch.StoragePath())
-	c.Assert(err, jc.ErrorIsNil)
-	defer reader.Close()
-	downloadedSHA256, _, err := utils.ReadSHA256(reader)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(downloadedSHA256, gc.Equals, expectedSHA256)
-}
-
-func (s *charmsSuite) TestUploadWithMultiSeriesCharm(c *gc.C) {
-	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
-	resp := s.uploadRequest(c, s.charmsURL("").String(), "application/zip", &fileReader{path: ch.Path})
-	expectedURL := "local:dummy-1"
-	s.assertUploadResponse(c, resp, expectedURL)
-}
-
-func (s *charmsSuite) TestUploadAllowsModelUUIDPath(c *gc.C) {
-	// Check that we can upload charms to https://host:port/ModelUUID/charms
-	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
-	url := s.charmsURL("series=quantal")
-	resp := s.uploadRequest(c, url.String(), "application/zip", &fileReader{path: ch.Path})
-	expectedURL := "local:quantal/dummy-1"
-	s.assertUploadResponse(c, resp, expectedURL)
-}
-
-func (s *charmsSuite) TestUploadAllowsOtherModelUUIDPath(c *gc.C) {
-	f, release := s.NewFactory(c, s.ControllerModelUUID())
-	defer release()
-	newSt := f.MakeModel(c, nil)
-	defer newSt.Close()
-
-	// Check that we can upload charms to https://host:port/ModelUUID/charms
-	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
-	url := s.charmsURL("series=quantal")
-	url.Path = fmt.Sprintf("/model/%s/charms", newSt.ModelUUID())
-	resp := s.uploadRequest(c, url.String(), "application/zip", &fileReader{path: ch.Path})
-	expectedURL := "local:quantal/dummy-1"
-	s.assertUploadResponse(c, resp, expectedURL)
-}
-
-func (s *charmsSuite) TestUploadRepackagesNestedArchives(c *gc.C) {
-	// Make a clone of the dummy charm in a nested directory.
-	rootDir := c.MkDir()
-	dirPath := filepath.Join(rootDir, "subdir1", "subdir2")
-	err := os.MkdirAll(dirPath, 0755)
-	c.Assert(err, jc.ErrorIsNil)
-	dir := testcharms.Repo.ClonedDir(dirPath, "dummy")
-	// Now tweak the path the dir thinks it is in and bundle it.
-	dir.Path = rootDir
-	var buf bytes.Buffer
-	err = dir.ArchiveTo(&buf)
-	c.Assert(err, jc.ErrorIsNil)
-
-	// Try reading it as a bundle - should fail due to nested dirs.
-	_, err = charm.ReadCharmArchiveBytes(buf.Bytes())
-	c.Assert(err, gc.ErrorMatches, `archive file "metadata.yaml" not found`)
-
-	// Now try uploading it - should succeed and be repackaged.
-	resp := s.uploadRequest(c, s.charmsURI("?series=quantal"), "application/zip", &buf)
-	expectedURL := "local:quantal/dummy-1"
-	s.assertUploadResponse(c, resp, expectedURL)
-	sch, err := s.ControllerModel(c).State().Charm(expectedURL)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(sch.URL(), gc.Equals, expectedURL)
-	c.Assert(sch.Revision(), gc.Equals, 1)
-	c.Assert(sch.IsUploaded(), jc.IsTrue)
-
-	// Get it from the storage and try to read it as a bundle - it
-	// should succeed, because it was repackaged during upload to
-	// strip nested dirs.
-	store := s.ObjectStore(c, s.ControllerModelUUID())
-	reader, _, err := store.Get(context.Background(), sch.StoragePath())
-	c.Assert(err, jc.ErrorIsNil)
-	defer reader.Close()
-
-	data, err := io.ReadAll(reader)
-	c.Assert(err, jc.ErrorIsNil)
-	downloadedFile, err := os.CreateTemp(c.MkDir(), "downloaded")
-	c.Assert(err, jc.ErrorIsNil)
-	defer downloadedFile.Close()
-	defer os.Remove(downloadedFile.Name())
-	err = os.WriteFile(downloadedFile.Name(), data, 0644)
-	c.Assert(err, jc.ErrorIsNil)
-
-	bundle, err := charm.ReadCharmArchive(downloadedFile.Name())
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(bundle.Revision(), jc.DeepEquals, sch.Revision())
-	c.Assert(bundle.Meta(), jc.DeepEquals, sch.Meta())
-	c.Assert(bundle.Config(), jc.DeepEquals, sch.Config())
-}
-
-func (s *charmsSuite) TestNonLocalCharmUploadFailsIfNotMigrating(c *gc.C) {
-	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
-	curl := fmt.Sprintf("ch:quantal/%s-%d", ch.Meta().Name, ch.Revision())
-	info := state.CharmInfo{
-		Charm:       ch,
-		ID:          curl,
-		StoragePath: "dummy-storage-path",
-		SHA256:      "dummy-1-sha256",
-	}
-	_, err := s.ControllerModel(c).State().AddCharm(info)
-	c.Assert(err, jc.ErrorIsNil)
-
-	resp := s.uploadRequest(c, s.charmsURI("?schema=ch&series=quantal"), "application/zip", &fileReader{path: ch.Path})
-	s.assertErrorResponse(c, resp, 400, ".*charms may only be uploaded during model migration import$")
-}
-
-func (s *charmsSuite) TestNonLocalCharmUpload(c *gc.C) {
-	// Check that upload of charms with the "ch:" schema works (for
-	// model migrations).
-	s.setModelImporting(c)
-	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
-
-	resp := s.uploadRequest(c, s.charmsURI("?schema=ch&series=quantal"), "application/zip", &fileReader{path: ch.Path})
-
-	expectedURL := "ch:quantal/dummy-1"
-	s.assertUploadResponse(c, resp, expectedURL)
-	sch, err := s.ControllerModel(c).State().Charm(expectedURL)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(sch.URL(), gc.DeepEquals, expectedURL)
-	c.Assert(sch.Revision(), gc.Equals, 1)
-	c.Assert(sch.IsUploaded(), jc.IsTrue)
-}
-
-func (s *charmsSuite) TestCharmHubCharmUpload(c *gc.C) {
-	// Check that upload of charms with the "ch:" schema works (for
-	// model migrations).
-	s.setModelImporting(c)
-	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
-	expectedURL := "ch:s390x/bionic/dummy-15"
-	info := state.CharmInfo{
-		Charm:       ch,
-		ID:          expectedURL,
-		StoragePath: "dummy-storage-path",
-		SHA256:      "dummy-1-sha256",
-	}
-	_, err := s.ControllerModel(c).State().AddCharm(info)
-	c.Assert(err, jc.ErrorIsNil)
-
-	resp := s.uploadRequest(c, s.charmsURI("?arch=s390x&revision=15&schema=ch&series=bionic"), "application/zip", &fileReader{path: ch.Path})
-
-	s.assertUploadResponse(c, resp, expectedURL)
-	sch, err := s.ControllerModel(c).State().Charm(expectedURL)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(sch.URL(), gc.DeepEquals, expectedURL)
-	c.Assert(sch.Revision(), gc.Equals, 15)
-	c.Assert(sch.IsUploaded(), jc.IsTrue)
-}
-
-func (s *charmsSuite) TestUnsupportedSchema(c *gc.C) {
-	s.setModelImporting(c)
-	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
-
-	resp := s.uploadRequest(c, s.charmsURI("?schema=zz"), "application/zip", &fileReader{path: ch.Path})
-	s.assertErrorResponse(
-		c, resp, http.StatusBadRequest,
-		`cannot upload charm: unsupported schema "zz"`,
-	)
-}
-
-func (s *charmsSuite) TestCharmUploadWithUserOverride(c *gc.C) {
-	s.setModelImporting(c)
-	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
-
-	resp := s.uploadRequest(c, s.charmsURI("?schema=ch"), "application/zip", &fileReader{path: ch.Path})
-
-	expectedURL := "ch:dummy-1"
-	s.assertUploadResponse(c, resp, expectedURL)
-	sch, err := s.ControllerModel(c).State().Charm(expectedURL)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(sch.URL(), gc.DeepEquals, expectedURL)
-	c.Assert(sch.IsUploaded(), jc.IsTrue)
-}
-
-func (s *charmsSuite) TestNonLocalCharmUploadWithRevisionOverride(c *gc.C) {
-	s.setModelImporting(c)
-	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
-
-	resp := s.uploadRequest(c, s.charmsURI("?schema=ch&&revision=99"), "application/zip", &fileReader{path: ch.Path})
-
-	expectedURL := "ch:dummy-99"
-	s.assertUploadResponse(c, resp, expectedURL)
-	sch, err := s.ControllerModel(c).State().Charm(expectedURL)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(sch.URL(), gc.DeepEquals, expectedURL)
-	c.Assert(sch.Revision(), gc.Equals, 99)
-	c.Assert(sch.IsUploaded(), jc.IsTrue)
-}
-
-func (s *charmsSuite) TestMigrateCharm(c *gc.C) {
-	f, release := s.NewFactory(c, s.ControllerModelUUID())
-	defer release()
-	newSt := f.MakeModel(c, nil)
-	defer newSt.Close()
-	importedModel, err := newSt.Model()
-	c.Assert(err, jc.ErrorIsNil)
-	err = importedModel.SetMigrationMode(state.MigrationModeImporting)
-	c.Assert(err, jc.ErrorIsNil)
-
-	// The default user is just a normal user, not a controller admin
-	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
-	url := s.charmsURL("series=quantal")
-	url.Path = "/migrate/charms"
-	resp := sendHTTPRequest(c, apitesting.HTTPRequestParams{
-		Method:      "POST",
-		URL:         url.String(),
-		ContentType: "application/zip",
-		Body:        &fileReader{path: ch.Path},
-		ExtraHeaders: map[string]string{
-			params.MigrationModelHTTPHeader: importedModel.UUID(),
-		},
-	})
-	expectedURL := "local:quantal/dummy-1"
-	s.assertUploadResponse(c, resp, expectedURL)
-
-	// The charm was added to the migrated model.
-	_, err = newSt.Charm(expectedURL)
-	c.Assert(err, jc.ErrorIsNil)
-}
-
-func (s *charmsSuite) TestMigrateCharmName(c *gc.C) {
-	f, release := s.NewFactory(c, s.ControllerModelUUID())
-	defer release()
-	newSt := f.MakeModel(c, nil)
-	defer newSt.Close()
-	importedModel, err := newSt.Model()
-	c.Assert(err, jc.ErrorIsNil)
-	err = importedModel.SetMigrationMode(state.MigrationModeImporting)
-	c.Assert(err, jc.ErrorIsNil)
-
-	// The default user is just a normal user, not a controller admin
-	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
-	url := s.charmsURL("series=quantal&name=meshuggah")
-	url.Path = "/migrate/charms"
-	resp := sendHTTPRequest(c, apitesting.HTTPRequestParams{
-		Method:      "POST",
-		URL:         url.String(),
-		ContentType: "application/zip",
-		Body:        &fileReader{path: ch.Path},
-		ExtraHeaders: map[string]string{
-			params.MigrationModelHTTPHeader: importedModel.UUID(),
-		},
-	})
-	expectedURL := "local:quantal/meshuggah-1"
-	s.assertUploadResponse(c, resp, expectedURL)
-
-	// The charm was added to the migrated model.
-	_, err = newSt.Charm(expectedURL)
-	c.Assert(err, jc.ErrorIsNil)
-}
-
-func (s *charmsSuite) TestMigrateCharmNotMigrating(c *gc.C) {
-	f, release := s.NewFactory(c, s.ControllerModelUUID())
-	defer release()
-	migratedModel := f.MakeModel(c, nil)
-	defer migratedModel.Close()
-
-	// The default user is just a normal user, not a controller admin
-	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
-	url := s.charmsURL("series=quantal")
-	url.Path = "/migrate/charms"
-	resp := sendHTTPRequest(c, apitesting.HTTPRequestParams{
-		Method:      "POST",
-		URL:         url.String(),
-		ContentType: "application/zip",
-		Body:        &fileReader{path: ch.Path},
-		ExtraHeaders: map[string]string{
-			params.MigrationModelHTTPHeader: migratedModel.ModelUUID(),
-		},
-	})
-	s.assertErrorResponse(
-		c, resp, http.StatusBadRequest,
-		`cannot upload charm: model migration mode is "" instead of "importing"`,
-	)
-}
-
-func (s *charmsSuite) TestMigrateCharmUnauthorized(c *gc.C) {
-	userService := s.ControllerServiceFactory(c).Access()
-	userTag := names.NewUserTag("bobbrown")
-	_, _, err := userService.AddUser(context.Background(), service.AddUserArg{
-		Name:        user.NameFromTag(userTag),
-		DisplayName: "Bob Brown",
-		CreatorUUID: s.AdminUserUUID,
-		Password:    ptr(auth.NewPassword("hunter2")),
-		Permission: permission.AccessSpec{
-			Access: permission.LoginAccess,
-			Target: permission.ID{
-				ObjectType: permission.Controller,
-				Key:        s.ControllerUUID,
-			},
-		},
-	})
-	c.Assert(err, jc.ErrorIsNil)
-
-	// TODO (stickupkid): Permissions: This is only required to insert admin
-	// permissions into the state, remove when permissions are written to state.
-	f, release := s.NewFactory(c, s.ControllerModelUUID())
-	defer release()
-	f.MakeUser(c, &factory.UserParams{
-		Name: userTag.Name(),
-	})
-
-	url := s.charmsURL("series=quantal")
-	url.Path = "/migrate/charms"
-	resp := apitesting.SendHTTPRequest(c, apitesting.HTTPRequestParams{
-		Method:   "POST",
-		URL:      url.String(),
-		Tag:      userTag.String(),
-		Password: "hunter2",
-	})
-	body := apitesting.AssertResponse(c, resp, http.StatusForbidden, "text/plain; charset=utf-8")
-	c.Assert(string(body), gc.Matches, "authorization failed: user .* not a controller admin\n")
 }
 
 func (s *charmsSuite) TestGetRequiresCharmURL(c *gc.C) {
@@ -614,18 +163,25 @@ func (s *charmsSuite) TestGetReturnsNotYetAvailableForPendingCharms(c *gc.C) {
 
 func (s *charmsSuite) TestGetReturnsForbiddenWithDirectory(c *gc.C) {
 	// Add the dummy charm.
-	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
-	s.uploadRequest(c, s.charmsURI("?series=quantal"), "application/zip", &fileReader{path: ch.Path})
+	chArchive := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
+	f, err := os.Open(chArchive.Path)
+	defer func() { _ = f.Close() }()
+	c.Assert(err, jc.ErrorIsNil)
+	s.uploadRequest(c, s.objectsCharmsURI("testcharm-"+getCharmHash(c, f)), "local:quantal/testcharm-1", &fileReader{path: chArchive.Path})
 
 	// Ensure a 403 is returned if the requested file is a directory.
-	uri := s.charmsURI("?url=local:quantal/dummy-1&file=hooks")
+	uri := s.charmsURI("?url=local:quantal/testcharm-1&file=hooks")
 	resp := sendHTTPRequest(c, apitesting.HTTPRequestParams{Method: "GET", URL: uri})
 	c.Assert(resp.StatusCode, gc.Equals, http.StatusForbidden)
 }
 
 func (s *charmsSuite) TestGetReturnsFileContents(c *gc.C) {
-	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
-	s.uploadRequest(c, s.charmsURI("?series=quantal"), "application/zip", &fileReader{path: ch.Path})
+	// Add the dummy charm.
+	chArchive := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
+	f, err := os.Open(chArchive.Path)
+	defer func() { _ = f.Close() }()
+	c.Assert(err, jc.ErrorIsNil)
+	s.uploadRequest(c, s.objectsCharmsURI("testcharm-"+getCharmHash(c, f)), "local:quantal/testcharm-1", &fileReader{path: chArchive.Path})
 
 	// Ensure the file contents are properly returned.
 	for i, t := range []struct {
@@ -647,63 +203,9 @@ func (s *charmsSuite) TestGetReturnsFileContents(c *gc.C) {
 	},
 	} {
 		c.Logf("test %d: %s", i, t.summary)
-		uri := s.charmsURI("?url=local:quantal/dummy-1&file=" + t.file)
+		uri := s.charmsURI("?url=local:quantal/testcharm-1&file=" + t.file)
 		resp := sendHTTPRequest(c, apitesting.HTTPRequestParams{Method: "GET", URL: uri})
 		s.assertGetFileResponse(c, resp, t.response, "text/plain; charset=utf-8")
-	}
-}
-
-func (s *charmsSuite) TestGetCharmIcon(c *gc.C) {
-	// Upload the local charms.
-	ch := testcharms.Repo.CharmArchive(c.MkDir(), "mysql")
-	s.uploadRequest(c, s.charmsURI("?series=quantal"), "application/zip", &fileReader{path: ch.Path})
-	ch = testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
-	s.uploadRequest(c, s.charmsURI("?series=quantal"), "application/zip", &fileReader{path: ch.Path})
-
-	// Prepare the tests.
-	svgMimeType := mime.TypeByExtension(".svg")
-	iconPath := filepath.Join(testcharms.Repo.CharmDirPath("mysql"), "icon.svg")
-	icon, err := os.ReadFile(iconPath)
-	c.Assert(err, jc.ErrorIsNil)
-	tests := []struct {
-		about      string
-		query      string
-		expectType string
-		expectBody string
-	}{{
-		about:      "icon found",
-		query:      "?url=local:quantal/mysql-1&file=icon.svg",
-		expectBody: string(icon),
-	}, {
-		about: "icon not found",
-		query: "?url=local:quantal/dummy-1&file=icon.svg",
-	}, {
-		about:      "default icon requested: icon found",
-		query:      "?url=local:quantal/mysql-1&icon=1",
-		expectBody: string(icon),
-	}, {
-		about:      "default icon requested: icon not found",
-		query:      "?url=local:quantal/dummy-1&icon=1",
-		expectBody: common.DefaultCharmIcon,
-	}, {
-		about:      "default icon request ignored",
-		query:      "?url=local:quantal/mysql-1&file=revision&icon=1",
-		expectType: "text/plain; charset=utf-8",
-		expectBody: "1",
-	}}
-
-	for i, test := range tests {
-		c.Logf("\ntest %d: %s", i, test.about)
-		uri := s.charmsURI(test.query)
-		resp := sendHTTPRequest(c, apitesting.HTTPRequestParams{Method: "GET", URL: uri})
-		if test.expectBody == "" {
-			s.assertErrorResponse(c, resp, http.StatusNotFound, ".*charm file not found$")
-			continue
-		}
-		if test.expectType == "" {
-			test.expectType = svgMimeType
-		}
-		s.assertGetFileResponse(c, resp, test.expectBody, test.expectType)
 	}
 }
 
@@ -754,20 +256,29 @@ func (s *charmsSuite) TestGetStarReturnsArchiveBytes(c *gc.C) {
 	defer os.Remove(tempFile.Name())
 	err = ch.ArchiveTo(tempFile)
 	c.Assert(err, jc.ErrorIsNil)
-	s.uploadRequest(c, s.charmsURI("?series=quantal"), "application/zip", &fileReader{path: tempFile.Name()})
+	// Add the dummy charm.
+	f, err := os.Open(tempFile.Name())
+	defer func() { _ = f.Close() }()
+	c.Assert(err, jc.ErrorIsNil)
+	s.uploadRequest(c, s.objectsCharmsURI("testcharm-"+getCharmHash(c, f)), "local:quantal/testcharm-1", &fileReader{path: tempFile.Name()})
 
 	data, err := os.ReadFile(tempFile.Name())
 	c.Assert(err, jc.ErrorIsNil)
 
-	uri := s.charmsURI("?url=local:quantal/dummy-1&file=*")
+	uri := s.charmsURI("?url=local:quantal/testcharm-1&file=*")
 	resp := sendHTTPRequest(c, apitesting.HTTPRequestParams{Method: "GET", URL: uri})
 	s.assertGetFileResponse(c, resp, string(data), "application/zip")
 }
 
 func (s *charmsSuite) TestGetAllowsModelUUIDPath(c *gc.C) {
-	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
-	s.uploadRequest(c, s.charmsURI("?series=quantal"), "application/zip", &fileReader{path: ch.Path})
-	url := s.charmsURL("url=local:quantal/dummy-1&file=revision")
+	// Add the dummy charm.
+	chArchive := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
+	f, err := os.Open(chArchive.Path)
+	defer func() { _ = f.Close() }()
+	c.Assert(err, jc.ErrorIsNil)
+	s.uploadRequest(c, s.objectsCharmsURI("testcharm-"+getCharmHash(c, f)), "local:quantal/testcharm-1", &fileReader{path: chArchive.Path})
+
+	url := s.charmsURL("url=local:quantal/testcharm-1&file=revision")
 	resp := sendHTTPRequest(c, apitesting.HTTPRequestParams{Method: "GET", URL: url.String()})
 	s.assertGetFileResponse(c, resp, "1", "text/plain; charset=utf-8")
 }
@@ -791,34 +302,21 @@ func (s *charmsSuite) TestGetAllowsOtherEnvironment(c *gc.C) {
 
 func (s *charmsSuite) TestGetReturnsManifest(c *gc.C) {
 	// Add the dummy charm.
-	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
-	s.uploadRequest(c, s.charmsURI("?series=quantal"), "application/zip", &fileReader{path: ch.Path})
+	chArchive := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
+	f, err := os.Open(chArchive.Path)
+	defer func() { _ = f.Close() }()
+	c.Assert(err, jc.ErrorIsNil)
+	s.uploadRequest(c, s.objectsCharmsURI("testcharm-"+getCharmHash(c, f)), "local:quantal/testcharm-1", &fileReader{path: chArchive.Path})
 
 	// Ensure charm files are properly listed.
-	uri := s.charmsURI("?url=local:quantal/dummy-1")
+	uri := s.charmsURI("?url=local:quantal/testcharm-1")
 	resp := sendHTTPRequest(c, apitesting.HTTPRequestParams{Method: "GET", URL: uri})
-	manifest, err := ch.ArchiveMembers()
+	manifest, err := chArchive.ArchiveMembers()
 	c.Assert(err, jc.ErrorIsNil)
 	expectedFiles := manifest.SortedValues()
 	s.assertGetFileListResponse(c, resp, expectedFiles)
 	ctype := resp.Header.Get("content-type")
 	c.Assert(ctype, gc.Equals, params.ContentTypeJSON)
-}
-
-func (s *charmsSuite) TestNoTempFilesLeftBehind(c *gc.C) {
-	// Add the dummy charm.
-	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
-	s.uploadRequest(c, s.charmsURI("?series=quantal"), "application/zip", &fileReader{path: ch.Path})
-
-	// Download it.
-	uri := s.charmsURI("?url=local:quantal/dummy-1&file=*")
-	resp := sendHTTPRequest(c, apitesting.HTTPRequestParams{Method: "GET", URL: uri})
-	apitesting.AssertResponse(c, resp, http.StatusOK, "application/zip")
-
-	// Ensure the tmp directory exists but nothing is in it.
-	files, err := os.ReadDir(filepath.Join(apiserver.DataDir(s.Server), "charm-get-tmp"))
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(files, gc.HasLen, 0)
 }
 
 type fileReader struct {

--- a/apiserver/common/charms.go
+++ b/apiserver/common/charms.go
@@ -57,7 +57,7 @@ func ReadCharmFromStorage(ctx context.Context, objectStore ReadObjectStore, data
 }
 
 // CharmArchiveEntry retrieves the specified entry from the zip archive.
-func CharmArchiveEntry(charmPath, entryPath string, wantIcon bool) ([]byte, error) {
+func CharmArchiveEntry(charmPath, entryPath string) ([]byte, error) {
 	// TODO(fwereade) 2014-01-27 bug #1285685
 	// This doesn't handle symlinks helpfully, and should be talking in
 	// terms of bundles rather than zip readers; but this demands thought
@@ -84,11 +84,6 @@ func CharmArchiveEntry(charmPath, entryPath string, wantIcon bool) ([]byte, erro
 		}
 		defer contents.Close()
 		return io.ReadAll(contents)
-	}
-	if wantIcon {
-		// An icon was requested but none was found in the archive so
-		// return the default icon instead.
-		return []byte(DefaultCharmIcon), nil
 	}
 	return nil, errors.NotFoundf("charm file")
 }

--- a/apiserver/objects_test.go
+++ b/apiserver/objects_test.go
@@ -164,7 +164,7 @@ func (s *getCharmObjectSuite) TestGetReturnsNotYetAvailableForPendingCharms(c *g
 func (s *getCharmObjectSuite) TestGetReturnsMatchingContents(c *gc.C) {
 	chArchive := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
 	f, err := os.Open(chArchive.Path)
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	c.Assert(err, jc.ErrorIsNil)
 	_ = s.uploadRequest(c, s.objectsCharmsURI("testcharm-"+getCharmHash(c, f)), "application/zip", "local:testcharm", f)
 
@@ -200,7 +200,7 @@ func (s *getCharmObjectSuite) TestGetWorksForControllerMachines(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	f, err := os.Open(ch.Path)
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Controller machine should be able to download the charm from
@@ -235,7 +235,7 @@ func (s *getCharmObjectSuite) TestGetAllowsOtherEnvironments(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	f, err := os.Open(ch.Path)
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	c.Assert(err, jc.ErrorIsNil)
 
 	uri := s.URL(fmt.Sprintf("/model-%s/charms/%s", newSt.ModelUUID(), "testcharm-"+getCharmHash(c, f)), nil).String()
@@ -323,7 +323,7 @@ func (s *putCharmObjectSuite) TestUploadBumpsRevision(c *gc.C) {
 	// and the BundleSha256 is calculated.
 	f, err := os.Open(ch.Path)
 	c.Assert(err, jc.ErrorIsNil)
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	resp := s.uploadRequest(c, s.objectsCharmsURI("testcharm-"+getCharmHash(c, f)), "application/zip", "local:testcharm", f)
 	expectedURL := "local:testcharm-2"
 	s.assertUploadResponse(c, resp, expectedURL)
@@ -351,7 +351,7 @@ func (s *putCharmObjectSuite) TestUploadVersion(c *gc.C) {
 
 	f, err := os.Open(ch.Path)
 	c.Assert(err, jc.ErrorIsNil)
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	resp := s.uploadRequest(c, s.objectsCharmsURI("testcharm-"+getCharmHash(c, f)), "application/zip", "local:testcharm", f)
 
 	expectedURL := "local:testcharm-1"
@@ -401,7 +401,7 @@ func (s *putCharmObjectSuite) TestNonLocalCharmUploadFailsIfNotMigrating(c *gc.C
 	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
 	f, err := os.Open(ch.Path)
 	c.Assert(err, jc.ErrorIsNil)
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	hash := getCharmHash(c, f)
 
 	curl := fmt.Sprintf("ch:%s-%d", ch.Meta().Name, ch.Revision())
@@ -425,7 +425,7 @@ func (s *putCharmObjectSuite) TestNonLocalCharmUpload(c *gc.C) {
 	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
 	f, err := os.Open(ch.Path)
 	c.Assert(err, jc.ErrorIsNil)
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	hash := getCharmHash(c, f)
 
 	curl := fmt.Sprintf("ch:%s-%d", ch.Meta().Name, ch.Revision())
@@ -454,7 +454,7 @@ func (s *putCharmObjectSuite) TestUnsupportedSchema(c *gc.C) {
 	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
 	f, err := os.Open(ch.Path)
 	c.Assert(err, jc.ErrorIsNil)
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	resp := s.uploadRequest(c, s.objectsCharmsURI("testcharm-"+getCharmHash(c, f)), "application/zip", "zz:testcharm", f)
 	s.assertErrorResponse(
@@ -468,7 +468,7 @@ func (s *putCharmObjectSuite) TestNonLocalCharmUploadWithRevisionOverride(c *gc.
 	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
 	f, err := os.Open(ch.Path)
 	c.Assert(err, jc.ErrorIsNil)
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	resp := s.uploadRequest(c, s.objectsCharmsURI("testcharm-"+getCharmHash(c, f)), "application/zip", "ch:testcharm-99", f)
 
@@ -487,7 +487,7 @@ func (s *putCharmObjectSuite) TestMigrateCharm(c *gc.C) {
 	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
 	f, err := os.Open(ch.Path)
 	c.Assert(err, jc.ErrorIsNil)
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	// The default user is just a normal user, not a controller admin
 	url := s.migrateObjectsCharmsURI("testcharm-" + getCharmHash(c, f))
@@ -515,7 +515,7 @@ func (s *putCharmObjectSuite) TestMigrateCharmName(c *gc.C) {
 	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
 	f, err := os.Open(ch.Path)
 	c.Assert(err, jc.ErrorIsNil)
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	// The default user is just a normal user, not a controller admin
 	url := s.migrateObjectsCharmsURI("meshuggah-" + getCharmHash(c, f))
@@ -541,7 +541,7 @@ func (s *putCharmObjectSuite) TestMigrateCharmNotMigrating(c *gc.C) {
 	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
 	f, err := os.Open(ch.Path)
 	c.Assert(err, jc.ErrorIsNil)
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	// The default user is just a normal user, not a controller admin
 	url := s.migrateObjectsCharmsURI("testcharm-" + getCharmHash(c, f))
@@ -593,7 +593,7 @@ func (s *putCharmObjectSuite) TestMigrateCharmUnauthorized(c *gc.C) {
 	ch := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
 	f, err := os.Open(ch.Path)
 	c.Assert(err, jc.ErrorIsNil)
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	// The default user is just a normal user, not a controller admin
 	url := s.migrateObjectsCharmsURI("testcharm-" + getCharmHash(c, f))
@@ -613,11 +613,11 @@ func (s *putCharmObjectSuite) TestMigrateCharmUnauthorized(c *gc.C) {
 }
 
 func getCharmHash(c *gc.C, stream io.ReadSeeker) string {
-	_, err := stream.Seek(0, os.SEEK_SET)
+	_, err := stream.Seek(0, io.SeekStart)
 	c.Assert(err, jc.ErrorIsNil)
 	hash, _, err := utils.ReadSHA256(stream)
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = stream.Seek(0, os.SEEK_SET)
+	_, err = stream.Seek(0, io.SeekStart)
 	c.Assert(err, jc.ErrorIsNil)
 	return hash[0:7]
 }


### PR DESCRIPTION
The charm upload request using POST was deprecated in 3.3, but we wanted to wait until 4.0 to remove. The new method to upload charms was via PUT (/model-:modeluuid/charms/:object).

I've still kept the GET request around for now, until I'm confident that we don't need to service this request. Not only is the GET request problematic from a Juju perspective, it's overly complicated. The charm is opened in memory to read portions of the charm archive, which can potentially lead to OOM errors or undexpected memory pressures whith large charms. Fortunately the end point isn't well documented, so many of the features don't seem well used. We're moving towards if you want information about a charm, you can download that charm and extract the information yourself.

This PR also removes the ability to fetch the charm icon. I've checked with the dashboard team, and they no longer use this functionality and source all images from charmhub. The correct approach to this would be to add additional meta information whilst uploading (similar to annotations), that could contain the icon if required.

<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://docs.google.com/document/d/1SYUo9G7qZ_jdoVXpUVamS5VCgHmtZ0QA-wZxKoMS-C0 
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

### Deploy local charms

download a charm from charmhub
```
$ juju download ubuntu
Fetching charm "ubuntu" revision 24 using "stable" channel and base "amd64/ubuntu/22.04"
Install the "ubuntu" charm with:
    juju deploy ./ubuntu_r24.charm
```

Deploy several local charms
```
$ juju add-model local
$ juju deploy ./ubuntu_r24.charm ubu-arch
Located local charm "ubuntu", revision 0
Deploying "ubu-arch" from local charm "ubuntu", revision 0 on ubuntu@22.04/stable

$ juju deploy ./ubuntu_r24.charm ubu-focal --base ubuntu@20.04
Located local charm "ubuntu", revision 0
Deploying "ubu-focal" from local charm "ubuntu", revision 0 on ubuntu@20.04/stable


$ juju deploy ./testcharms/charms/ubuntu-plus/ ubu-dir
Located local charm "ubuntu-plus", revision 0
Deploying "ubu-dir" from local charm "ubuntu-plus", revision 0 on ubuntu@22.04/stable

$ juju status
Model  Controller  Cloud/Region         Version      Timestamp
m      lxd-src     localhost/localhost  4.0-beta5.1  14:12:50+01:00

App        Version  Status   Scale  Charm        Channel  Rev  Exposed  Message
ubu-arch   22.04    active       1  ubuntu                  0  no       
ubu-dir             waiting      1  ubuntu-plus             0  no       Hello from install, it is Thu Apr  4 13:12:36 UTC 2024.
ubu-focal  20.04    active       1  ubuntu                  0  no       

Unit          Workload  Agent  Machine  Public address  Ports  Message
ubu-arch/0*   active    idle   0        10.219.211.73          
ubu-dir/0*    waiting   idle   2        10.219.211.65          Hello from install, it is Thu Apr  4 13:12:36 UTC 2024.
ubu-focal/0*  active    idle   1        10.219.211.227         

Machine  State    Address         Inst id        Base          AZ  Message
0        started  10.219.211.73   juju-99dc44-0  ubuntu@22.04      Running
1        started  10.219.211.227  juju-99dc44-1  ubuntu@20.04      Running
2        started  10.219.211.65   juju-99dc44-2  ubuntu@22.04      Running
```

### Model migrations

Repeat the following steps bootstrapping controllers:
1) `lxd-src` from this PR; `lxd-dst` from this PR
2) `lxd-src` from 3.6; `lxd-dst` from this PR

```
$ juju add-model m
$ juju deploy ./ubuntu_r24.charm ubu-local
$ juju deploy ubuntu ubu-ch
$ juju status
 Model  Controller  Cloud/Region         Version      Timestamp
m      lxd-src     localhost/localhost  4.0-beta5.1  15:08:57+01:00

App        Version  Status  Scale  Charm   Channel  Rev  Exposed  Message
ubu-ch     22.04    active      1  ubuntu  stable    24  no       
ubu-local  22.04    active      1  ubuntu             0  no       

Unit          Workload  Agent  Machine  Public address  Ports  Message
ubu-ch/0*     active    idle   0        10.219.211.127         
ubu-local/0*  active    idle   1        10.219.211.111         

Machine  State    Address         Inst id        Base          AZ  Message
0        started  10.219.211.127  juju-975167-0  ubuntu@22.04      Running
1        started  10.219.211.111  juju-975167-1  ubuntu@22.04      Running

$ juju migrate m lxd-dst
Migration started with ID "355633ec-fc28-47a0-8a86-ae3dcd975167:0"

$ juju status
ERROR Model "admin/m" has been migrated to controller "lxd-dst".
To access it run 'juju switch lxd-dst:admin/m'.

$ juju switch lxd-dst:m
$ juju status
Model  Controller  Cloud/Region         Version      Timestamp
m      lxd-dst     localhost/localhost  4.0-beta5.1  15:10:10+01:00

App        Version  Status  Scale  Charm   Channel        Rev  Exposed  Message
ubu-ch     22.04    active      1  ubuntu  latest/stable   24  no       
ubu-local  22.04    active      1  ubuntu                   0  no       

Unit          Workload  Agent  Machine  Public address  Ports  Message
ubu-ch/0*     active    idle   0        10.219.211.127         
ubu-local/0*  active    idle   1        10.219.211.111         

Machine  State    Address         Inst id        Base          AZ  Message
0        started  10.219.211.127  juju-975167-0  ubuntu@22.04      Running
1        started  10.219.211.111  juju-975167-1  ubuntu@22.04      Running

$ juju add-unit ubu-local
$ juju add-unit ubu-ch
$ juju status
Model  Controller  Cloud/Region         Version      Timestamp
m      lxd-dst     localhost/localhost  4.0-beta5.1  15:34:30+01:00

App        Version  Status  Scale  Charm   Channel        Rev  Exposed  Message
ubu-ch              active      2  ubuntu  latest/stable   24  no       
ubu-local           active      2  ubuntu                   0  no       

Unit          Workload  Agent  Machine  Public address  Ports  Message
ubu-ch/0*     active    idle   0        10.219.211.127         
ubu-ch/1      active    idle   2        10.219.211.3           
ubu-local/0*  active    idle   1        10.219.211.111         
ubu-local/1   active    idle   3        10.219.211.40          

Machine  State    Address         Inst id        Base          AZ  Message
0        started  10.219.211.127  juju-975167-0  ubuntu@22.04      Running
1        started  10.219.211.111  juju-975167-1  ubuntu@22.04      Running
2        started  10.219.211.3    juju-975167-2  ubuntu@22.04      Running
3        started  10.219.211.40   juju-975167-3  ubuntu@22.04      Running
```

## Links


**Jira card:** [JUJU-6624](https://warthogs.atlassian.net/browse/JUJU-6624)

