### PR TITLE
feat(network): store ip address values as msb, lsb

### DIFF
--- a/api/package_test.go
+++ b/api/package_test.go
@@ -60,6 +60,7 @@ func (*ImportSuite) TestImports(c *gc.C) {
 		"internal/charm/assumes",
 		"internal/charm/hooks",
 		"internal/charm/resource",
+		"internal/errors",
 		"internal/featureflag",
 		"internal/http",
 		"internal/logger",

--- a/cmd/containeragent/initialize/package_test.go
+++ b/cmd/containeragent/initialize/package_test.go
@@ -92,6 +92,7 @@ func (*importSuite) TestImports(c *gc.C) {
 		"internal/charmhub",
 		"internal/charmhub/path",
 		"internal/charmhub/transport",
+		"internal/errors",
 		"internal/featureflag",
 		"internal/http",
 		"internal/logger",

--- a/core/migration/package_test.go
+++ b/core/migration/package_test.go
@@ -31,6 +31,7 @@ func (*ImportTest) TestImports(c *gc.C) {
 		"core/network",
 		"core/resources",
 		"internal/charm/resource",
+		"internal/errors",
 		"internal/logger",
 		"internal/uuid",
 	})

--- a/core/network/address.go
+++ b/core/network/address.go
@@ -805,42 +805,6 @@ func MergedAddresses(machineAddresses, providerAddresses []SpaceAddress) []Space
 	return merged
 }
 
-// CIDRAddressType returns back an AddressType to indicate whether the supplied
-// CIDR corresponds to an IPV4 or IPV6 range. An error will be returned if a
-// non-valid CIDR is provided.
-//
-// Caveat: if the provided CIDR corresponds to an IPV6 range with a 4in6
-// prefix, the function will classify it as an IPV4 address. This is a known
-// limitation of the go stdlib IP parsing code but it's not something that we
-// are likely to encounter in the wild so there is no need to add extra logic
-// to work around it.
-func CIDRAddressType(cidr string) (AddressType, error) {
-	_, netIP, err := net.ParseCIDR(cidr)
-	if err != nil {
-		return "", err
-	}
-
-	if netIP.IP.To4() != nil {
-		return IPv4Address, nil
-	}
-
-	return IPv6Address, nil
-}
-
-// NetworkCIDRFromIPAndMask constructs a CIDR for a network by applying the
-// provided netmask to the specified address (can be either a host or network
-// address) and formatting the result as a CIDR.
-//
-// For example, passing 10.0.0.4 and a /24 mask yields 10.0.0.0/24.
-func NetworkCIDRFromIPAndMask(ip net.IP, netmask net.IPMask) string {
-	if ip == nil || netmask == nil {
-		return ""
-	}
-
-	hostBits, _ := netmask.Size()
-	return fmt.Sprintf("%s/%d", ip.Mask(netmask), hostBits)
-}
-
 // SpaceAddressCandidate describes property methods required
 // for conversion to sortable space addresses.
 type SpaceAddressCandidate interface {

--- a/core/network/address_test.go
+++ b/core/network/address_test.go
@@ -975,92 +975,11 @@ func (s *AddressSuite) TestAddressValueForCIDR(c *gc.C) {
 	c.Check(val, gc.Equals, "172.31.37.53/20")
 }
 
-func (s *AddressSuite) TestCIDRAddressType(c *gc.C) {
-	tests := []struct {
-		descr  string
-		CIDR   string
-		exp    network.AddressType
-		expErr string
-	}{
-		{
-			descr: "IPV4 CIDR",
-			CIDR:  "10.0.0.0/24",
-			exp:   network.IPv4Address,
-		},
-		{
-			descr: "IPV6 CIDR",
-			CIDR:  "2002::1234:abcd:ffff:c0a8:101/64",
-			exp:   network.IPv6Address,
-		},
-		{
-			descr: "IPV6 with 4in6 prefix",
-			CIDR:  "0:0:0:0:0:ffff:c0a8:2a00/120",
-			// The Go stdlib interprets this as an IPV4
-			exp: network.IPv4Address,
-		},
-		{
-			descr:  "bogus CIDR",
-			CIDR:   "catastrophe",
-			expErr: ".*invalid CIDR address.*",
-		},
-	}
-
-	for i, t := range tests {
-		c.Logf("test %d: %s", i, t.descr)
-		got, err := network.CIDRAddressType(t.CIDR)
-		if t.expErr != "" {
-			c.Check(got, gc.Equals, network.AddressType(""))
-			c.Check(err, gc.ErrorMatches, t.expErr)
-		} else {
-			c.Check(err, jc.ErrorIsNil)
-			c.Check(got, gc.Equals, t.exp)
-		}
-	}
-}
-
 func (s *AddressSuite) TestNoAddressError(c *gc.C) {
 	err := network.NoAddressError("fake")
 	c.Assert(err, gc.ErrorMatches, `no fake address\(es\)`)
 	c.Assert(network.IsNoAddressError(err), jc.IsTrue)
 	c.Assert(network.IsNoAddressError(errors.New("address found")), jc.IsFalse)
-}
-
-func (s *AddressSuite) TestNetworkCIDRFromIPAndMask(c *gc.C) {
-	specs := []struct {
-		descr   string
-		ip      net.IP
-		mask    net.IPMask
-		expCIDR string
-	}{
-		{
-			descr:   "nil ip",
-			mask:    net.IPv4Mask(0, 0, 0, 255),
-			expCIDR: "",
-		},
-		{
-			descr:   "nil mask",
-			ip:      net.ParseIP("10.1.2.42"),
-			expCIDR: "",
-		},
-		{
-			descr:   "network IP",
-			ip:      net.ParseIP("10.1.0.0"),
-			mask:    net.IPv4Mask(255, 255, 0, 0),
-			expCIDR: "10.1.0.0/16",
-		},
-		{
-			descr:   "host IP",
-			ip:      net.ParseIP("10.1.2.42"),
-			mask:    net.IPv4Mask(255, 255, 255, 0),
-			expCIDR: "10.1.2.0/24",
-		},
-	}
-
-	for i, spec := range specs {
-		c.Logf("%d: %s", i, spec.descr)
-		gotCIDR := network.NetworkCIDRFromIPAndMask(spec.ip, spec.mask)
-		c.Assert(gotCIDR, gc.Equals, spec.expCIDR)
-	}
 }
 
 func (s *AddressSuite) TestIsValidAddressConfigTypeWithValidValues(c *gc.C) {

--- a/core/network/cidr.go
+++ b/core/network/cidr.go
@@ -54,7 +54,8 @@ func ParseCIDR(cidr string) (*CIDR, error) {
 		return nil, errors.Errorf("parsing CIDR %q: %w", cidr, err)
 	}
 	if prefix.Masked().Addr() != prefix.Addr() {
-		return nil, errors.Errorf("CIDR %q is not valid", cidr)
+		return nil, errors.Errorf(
+			"CIDR %q is not valid: %q is not the start address (%s) of the range", cidr, prefix.Addr(), prefix.Masked().Addr())
 	}
 	return &CIDR{Prefix: prefix}, nil
 }

--- a/core/network/cidr.go
+++ b/core/network/cidr.go
@@ -1,0 +1,74 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package network
+
+import (
+	"fmt"
+	"net"
+	"net/netip"
+
+	"github.com/juju/juju/internal/errors"
+)
+
+// CIDRAddressType returns back an AddressType to indicate whether the supplied
+// CIDR corresponds to an IPV4 or IPV6 range. An error will be returned if a
+// non-valid CIDR is provided.
+func CIDRAddressType(cidrStr string) (AddressType, error) {
+	cidr, err := ParseCIDR(cidrStr)
+	if err != nil {
+		return "", err
+	}
+
+	if cidr.Addr().Is4() {
+		return IPv4Address, nil
+	}
+
+	return IPv6Address, nil
+}
+
+// NetworkCIDRFromIPAndMask constructs a CIDR for a network by applying the
+// provided netmask to the specified address (can be either a host or network
+// address) and formatting the result as a CIDR.
+//
+// For example, passing 10.0.0.4 and a /24 mask yields 10.0.0.0/24.
+func NetworkCIDRFromIPAndMask(ip net.IP, netmask net.IPMask) string {
+	if ip == nil || netmask == nil {
+		return ""
+	}
+
+	hostBits, _ := netmask.Size()
+	return fmt.Sprintf("%s/%d", ip.Mask(netmask), hostBits)
+}
+
+// CIDR wraps a [netip.Prefix] instance and provides a
+// method to return the start and end address range.
+type CIDR struct {
+	netip.Prefix
+}
+
+// ParseCIDR parses the specified cidr string.
+func ParseCIDR(cidr string) (*CIDR, error) {
+	prefix, err := netip.ParsePrefix(cidr)
+	if err != nil {
+		return nil, errors.Errorf("parsing CIDR %q: %w", cidr, err)
+	}
+	if prefix.Masked().Addr() != prefix.Addr() {
+		return nil, errors.Errorf("CIDR %q is not valid", cidr)
+	}
+	return &CIDR{Prefix: prefix}, nil
+}
+
+// AddressRange returns the start and end address for the cidr.
+func (c CIDR) AddressRange() (start, end IPAddress) {
+	start = IPAddress{c.Masked().Addr()}
+
+	m := net.CIDRMask(c.Bits(), c.Addr().BitLen())
+	endSlice := c.Addr().AsSlice()
+	for i := 0; i < len(endSlice); i++ {
+		endSlice[i] = endSlice[i] | ^m[i]
+	}
+	endAddr, _ := netip.AddrFromSlice(endSlice)
+	end = IPAddress{endAddr}
+	return start, end
+}

--- a/core/network/cidr_test.go
+++ b/core/network/cidr_test.go
@@ -1,0 +1,166 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package network_test
+
+import (
+	"net"
+	"regexp"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/internal/testing"
+)
+
+type CIDRSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&CIDRSuite{})
+
+func (s *CIDRSuite) TestCIDRAddressType(c *gc.C) {
+	tests := []struct {
+		descr  string
+		CIDR   string
+		exp    network.AddressType
+		expErr string
+	}{
+		{
+			descr: "IPV4 CIDR",
+			CIDR:  "10.0.0.0/24",
+			exp:   network.IPv4Address,
+		},
+		{
+			descr: "IPV6 CIDR",
+			CIDR:  "2001:0DB8::/32",
+			exp:   network.IPv6Address,
+		},
+		{
+			descr: "IPV6 with 4in6 prefix",
+			CIDR:  "0:0:0:0:0:ffff:c0a8:2a00/120",
+			exp:   network.IPv6Address,
+		},
+		{
+			descr:  "bogus CIDR",
+			CIDR:   "catastrophe",
+			expErr: regexp.QuoteMeta(`parsing CIDR "catastrophe"`) + ".*",
+		},
+	}
+
+	for i, t := range tests {
+		c.Logf("test %d: %s", i, t.descr)
+		got, err := network.CIDRAddressType(t.CIDR)
+		if t.expErr != "" {
+			c.Check(got, gc.Equals, network.AddressType(""))
+			c.Check(err, gc.ErrorMatches, t.expErr)
+		} else {
+			c.Check(err, jc.ErrorIsNil)
+			c.Check(got, gc.Equals, t.exp)
+		}
+	}
+}
+
+func (s *CIDRSuite) TestNetworkCIDRFromIPAndMask(c *gc.C) {
+	specs := []struct {
+		descr   string
+		ip      net.IP
+		mask    net.IPMask
+		expCIDR string
+	}{
+		{
+			descr:   "nil ip",
+			mask:    net.IPv4Mask(0, 0, 0, 255),
+			expCIDR: "",
+		},
+		{
+			descr:   "nil mask",
+			ip:      net.ParseIP("10.1.2.42"),
+			expCIDR: "",
+		},
+		{
+			descr:   "network IP",
+			ip:      net.ParseIP("10.1.0.0"),
+			mask:    net.IPv4Mask(255, 255, 0, 0),
+			expCIDR: "10.1.0.0/16",
+		},
+		{
+			descr:   "host IP",
+			ip:      net.ParseIP("10.1.2.42"),
+			mask:    net.IPv4Mask(255, 255, 255, 0),
+			expCIDR: "10.1.2.0/24",
+		},
+	}
+
+	for i, spec := range specs {
+		c.Logf("%d: %s", i, spec.descr)
+		gotCIDR := network.NetworkCIDRFromIPAndMask(spec.ip, spec.mask)
+		c.Assert(gotCIDR, gc.Equals, spec.expCIDR)
+	}
+}
+
+func (s *CIDRSuite) TestParseCIDRError(c *gc.C) {
+	_, err := network.ParseCIDR("192.168.0.0/12")
+	c.Assert(err, gc.ErrorMatches, `CIDR "192.168.0.0/12" is not valid`)
+}
+
+func (s *CIDRSuite) TestParseCIDR(c *gc.C) {
+	for _, cidrStr := range []string{
+		"10.1.2.0/24",
+		"2001:db8::/32",
+	} {
+		got, err := network.ParseCIDR(cidrStr)
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(got.String(), gc.Equals, cidrStr)
+	}
+}
+
+func (*CIDRSuite) TestAddressRangeForCIDR(c *gc.C) {
+	specs := []struct {
+		cidr     string
+		expFirst string
+		expLast  string
+	}{
+		{
+			cidr:     "10.20.30.0/24",
+			expFirst: "10.20.30.0",
+			expLast:  "10.20.30.255",
+		},
+		{
+			cidr:     "10.20.28.0/22",
+			expFirst: "10.20.28.0",
+			expLast:  "10.20.31.255",
+		},
+		{
+			cidr:     "192.168.0.0/13",
+			expFirst: "192.168.0.0",
+			expLast:  "192.175.255.255",
+		},
+		{
+			cidr:     "10.1.2.42/32",
+			expFirst: "10.1.2.42",
+			expLast:  "10.1.2.42",
+		},
+		{
+			cidr:     "2001:db8::/32",
+			expFirst: "2001:db8::",
+			expLast:  "2001:db8:ffff:ffff:ffff:ffff:ffff:ffff",
+		},
+		{
+			cidr:     "2001:db8:85a3::8a2e:370:7334/128",
+			expFirst: "2001:db8:85a3::8a2e:370:7334",
+			expLast:  "2001:db8:85a3::8a2e:370:7334",
+		},
+	}
+
+	for i, spec := range specs {
+		c.Logf("%d. check that range for %q is [%s, %s]", i, spec.cidr, spec.expFirst, spec.expLast)
+		cidr, err := network.ParseCIDR(spec.cidr)
+		c.Assert(err, jc.ErrorIsNil)
+		gotFirst, gotLast := cidr.AddressRange()
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(gotFirst.String(), gc.Equals, spec.expFirst)
+		c.Assert(gotLast.String(), gc.Equals, spec.expLast)
+	}
+}

--- a/core/network/firewall/rule_test.go
+++ b/core/network/firewall/rule_test.go
@@ -264,7 +264,7 @@ func (IngressRuleSuite) TestRemoveCIDRsMatchingAddressType(c *gc.C) {
 		NewIngressRule(network.MustParsePortRange("80/tcp"), "35.187.158.35/32"),
 		// We expect these rules to be de-dupped once the IPV6 CIDRs get removed
 		NewIngressRule(network.MustParsePortRange("81/tcp"), "35.187.1.35/32", "::/0"),
-		NewIngressRule(network.MustParsePortRange("81/tcp"), "35.187.1.35/32", "2002::1234:abcd:ffff:c0a8:101/64"),
+		NewIngressRule(network.MustParsePortRange("81/tcp"), "35.187.1.35/32", "2001:0DB8::/32"),
 	}
 
 	out := in.RemoveCIDRsMatchingAddressType(network.IPv6Address)

--- a/core/network/import_test.go
+++ b/core/network/import_test.go
@@ -18,6 +18,7 @@ var _ = gc.Suite(&ImportSuite{})
 var allowedCoreImports = set.NewStrings(
 	"core/life",
 	"core/logger",
+	"internal/errors",
 	"internal/logger",
 )
 

--- a/core/network/ipaddress.go
+++ b/core/network/ipaddress.go
@@ -1,0 +1,27 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package network
+
+import (
+	"encoding/binary"
+	"net/netip"
+)
+
+// IPAddress wraps a [netip.Addr] instance and provides a
+// method to decompose the address into msb, lsb uint64 values.
+type IPAddress struct {
+	netip.Addr
+}
+
+// AsInts returns the MSB and LSB uint64 values for the specified address.
+func (a IPAddress) AsInts() (msb uint64, lsb uint64) {
+	addrB := a.AsSlice()
+	if a.Is4() {
+		lsb = uint64(binary.BigEndian.Uint32(addrB[:4]))
+	} else {
+		msb = binary.BigEndian.Uint64(addrB[:8])
+		lsb = binary.BigEndian.Uint64(addrB[8:])
+	}
+	return msb, lsb
+}

--- a/core/network/ipaddress.go
+++ b/core/network/ipaddress.go
@@ -5,6 +5,7 @@ package network
 
 import (
 	"encoding/binary"
+	"net"
 	"net/netip"
 )
 
@@ -17,8 +18,8 @@ type IPAddress struct {
 // AsInts returns the MSB and LSB uint64 values for the specified address.
 func (a IPAddress) AsInts() (msb uint64, lsb uint64) {
 	addrB := a.AsSlice()
-	if a.Is4() {
-		lsb = uint64(binary.BigEndian.Uint32(addrB[:4]))
+	if len(addrB) == net.IPv4len {
+		lsb = uint64(binary.BigEndian.Uint32(addrB[:net.IPv4len]))
 	} else {
 		msb = binary.BigEndian.Uint64(addrB[:8])
 		lsb = binary.BigEndian.Uint64(addrB[8:])

--- a/core/network/ipaddress_test.go
+++ b/core/network/ipaddress_test.go
@@ -1,0 +1,33 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package network_test
+
+import (
+	"net/netip"
+
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/internal/testing"
+)
+
+type IPAddressSuite struct {
+	testing.BaseSuite
+}
+
+var _ = gc.Suite(&IPAddressSuite{})
+
+func (s *IPAddressSuite) TestIPv4AddressSplit(c *gc.C) {
+	addr := network.IPAddress{netip.MustParseAddr("192.168.0.0")}
+	msb, lsb := addr.AsInts()
+	c.Assert(msb, gc.Equals, uint64(0))
+	c.Assert(lsb, gc.Equals, uint64(0xc0a80000))
+}
+
+func (s *IPAddressSuite) TestIPv6AddressSplit(c *gc.C) {
+	addr := network.IPAddress{netip.MustParseAddr("fd7a:115c:a1e0:ab12:4843:cd96:626b:430b")}
+	msb, lsb := addr.AsInts()
+	c.Assert(msb, gc.Equals, uint64(0xfd7a115ca1e0ab12))
+	c.Assert(lsb, gc.Equals, uint64(0x4843cd96626b430b))
+}

--- a/core/network/ipaddress_test.go
+++ b/core/network/ipaddress_test.go
@@ -19,15 +19,15 @@ type IPAddressSuite struct {
 var _ = gc.Suite(&IPAddressSuite{})
 
 func (s *IPAddressSuite) TestIPv4AddressSplit(c *gc.C) {
-	addr := network.IPAddress{netip.MustParseAddr("192.168.0.0")}
+	addr := network.IPAddress{netip.MustParseAddr("192.168.1.1")}
 	msb, lsb := addr.AsInts()
 	c.Assert(msb, gc.Equals, uint64(0))
-	c.Assert(lsb, gc.Equals, uint64(0xc0a80000))
+	c.Assert(lsb, gc.Equals, uint64(0xc0a80101))
 }
 
 func (s *IPAddressSuite) TestIPv6AddressSplit(c *gc.C) {
-	addr := network.IPAddress{netip.MustParseAddr("fd7a:115c:a1e0:ab12:4843:cd96:626b:430b")}
+	addr := network.IPAddress{netip.MustParseAddr("2001:0db8:85a3:0000:0000:8a2e:0370:7666")}
 	msb, lsb := addr.AsInts()
-	c.Assert(msb, gc.Equals, uint64(0xfd7a115ca1e0ab12))
-	c.Assert(lsb, gc.Equals, uint64(0x4843cd96626b430b))
+	c.Assert(msb, gc.Equals, uint64(0x20010db885a30000))
+	c.Assert(lsb, gc.Equals, uint64(0x8a2e03707666))
 }

--- a/core/watcher/eventsource/package_test.go
+++ b/core/watcher/eventsource/package_test.go
@@ -45,6 +45,7 @@ func (*ImportTest) TestImports(c *gc.C) {
 		"core/status",
 		"core/watcher",
 		"internal/charm/resource",
+		"internal/errors",
 		"internal/logger",
 		"internal/uuid",
 	})

--- a/core/watcher/package_test.go
+++ b/core/watcher/package_test.go
@@ -33,6 +33,7 @@ func (s *ImportTest) TestImports(c *gc.C) {
 		"core/secrets",
 		"core/status",
 		"internal/charm/resource",
+		"internal/errors",
 		"internal/logger",
 		"internal/uuid",
 	})

--- a/domain/network/modelmigration/import_test.go
+++ b/domain/network/modelmigration/import_test.go
@@ -49,7 +49,7 @@ func (s *importSuite) TestImportSubnetWithoutSpaces(c *gc.C) {
 		ProviderNetworkId: "subnet-provider-network-id",
 		VLANTag:           42,
 		AvailabilityZones: []string{"az1", "az2"},
-		FanLocalUnderlay:  "192.168.0.0/12",
+		FanLocalUnderlay:  "192.160.0.0/12",
 		FanOverlay:        "10.0.0.0/8",
 	})
 	s.importService.EXPECT().AddSubnet(gomock.Any(), network.SubnetInfo{

--- a/domain/network/service/interface.go
+++ b/domain/network/service/interface.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/core/watcher/eventsource"
+	domainnetwork "github.com/juju/juju/domain/network"
 	"github.com/juju/juju/environs"
 )
 
@@ -61,7 +62,7 @@ type SpaceState interface {
 // SubnetState describes persistence layer methods for the subnet (sub-) domain.
 type SubnetState interface {
 	// AddSubnet creates a subnet.
-	AddSubnet(ctx context.Context, subnet network.SubnetInfo) error
+	AddSubnet(ctx context.Context, subnet domainnetwork.SubnetArg) error
 	// GetAllSubnets returns all known subnets in the model.
 	GetAllSubnets(ctx context.Context) (network.SubnetInfos, error)
 	// GetSubnet returns the subnet by UUID.
@@ -76,7 +77,7 @@ type SubnetState interface {
 	DeleteSubnet(ctx context.Context, uuid string) error
 	// UpsertSubnets updates or adds each one of the provided subnets in one
 	// transaction.
-	UpsertSubnets(ctx context.Context, subnets []network.SubnetInfo) error
+	UpsertSubnets(ctx context.Context, subnets []domainnetwork.SubnetArg) error
 	// AllSubnetsQuery returns the SQL query that finds all subnet UUIDs from the
 	// subnet table, needed for the subnets watcher.
 	AllSubnetsQuery(ctx context.Context, db database.TxnRunner) ([]string, error)

--- a/domain/network/service/package_mock_test.go
+++ b/domain/network/service/package_mock_test.go
@@ -16,6 +16,7 @@ import (
 	database "github.com/juju/juju/core/database"
 	instance "github.com/juju/juju/core/instance"
 	network "github.com/juju/juju/core/network"
+	network0 "github.com/juju/juju/domain/network"
 	environs "github.com/juju/juju/environs"
 	envcontext "github.com/juju/juju/environs/envcontext"
 	names "github.com/juju/names/v5"
@@ -84,7 +85,7 @@ func (c *MockStateAddSpaceCall) DoAndReturn(f func(context.Context, string, stri
 }
 
 // AddSubnet mocks base method.
-func (m *MockState) AddSubnet(arg0 context.Context, arg1 network.SubnetInfo) error {
+func (m *MockState) AddSubnet(arg0 context.Context, arg1 network0.SubnetArg) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddSubnet", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -110,13 +111,13 @@ func (c *MockStateAddSubnetCall) Return(arg0 error) *MockStateAddSubnetCall {
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateAddSubnetCall) Do(f func(context.Context, network.SubnetInfo) error) *MockStateAddSubnetCall {
+func (c *MockStateAddSubnetCall) Do(f func(context.Context, network0.SubnetArg) error) *MockStateAddSubnetCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateAddSubnetCall) DoAndReturn(f func(context.Context, network.SubnetInfo) error) *MockStateAddSubnetCall {
+func (c *MockStateAddSubnetCall) DoAndReturn(f func(context.Context, network0.SubnetArg) error) *MockStateAddSubnetCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -552,7 +553,7 @@ func (c *MockStateUpdateSubnetCall) DoAndReturn(f func(context.Context, string, 
 }
 
 // UpsertSubnets mocks base method.
-func (m *MockState) UpsertSubnets(arg0 context.Context, arg1 []network.SubnetInfo) error {
+func (m *MockState) UpsertSubnets(arg0 context.Context, arg1 []network0.SubnetArg) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpsertSubnets", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -578,13 +579,13 @@ func (c *MockStateUpsertSubnetsCall) Return(arg0 error) *MockStateUpsertSubnetsC
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateUpsertSubnetsCall) Do(f func(context.Context, []network.SubnetInfo) error) *MockStateUpsertSubnetsCall {
+func (c *MockStateUpsertSubnetsCall) Do(f func(context.Context, []network0.SubnetArg) error) *MockStateUpsertSubnetsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateUpsertSubnetsCall) DoAndReturn(f func(context.Context, []network.SubnetInfo) error) *MockStateUpsertSubnetsCall {
+func (c *MockStateUpsertSubnetsCall) DoAndReturn(f func(context.Context, []network0.SubnetArg) error) *MockStateUpsertSubnetsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/network/service/subnet_test.go
+++ b/domain/network/service/subnet_test.go
@@ -9,10 +9,11 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
-	gomock "go.uber.org/mock/gomock"
+	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/network"
+	domainnetwork "github.com/juju/juju/domain/network"
 )
 
 type subnetSuite struct {
@@ -46,9 +47,10 @@ func (s *subnetSuite) TestFailAddSubnet(c *gc.C) {
 		DoAndReturn(
 			func(
 				ctx context.Context,
-				subnet network.SubnetInfo,
+				subnet domainnetwork.SubnetArg,
 			) error {
 				c.Assert(subnet.CIDR, gc.Equals, subnetInfo.CIDR)
+				c.Assert(subnet.CIDRAddressRange, jc.DeepEquals, domainnetwork.MustCIDRAddressRangeFromString(subnetInfo.CIDR))
 				c.Assert(subnet.ProviderId, gc.Equals, subnetInfo.ProviderId)
 				c.Assert(subnet.ProviderNetworkId, gc.Equals, subnetInfo.ProviderNetworkId)
 				c.Assert(subnet.AvailabilityZones, jc.SameContents, subnetInfo.AvailabilityZones)
@@ -75,9 +77,10 @@ func (s *subnetSuite) TestAddSubnet(c *gc.C) {
 		Do(
 			func(
 				ctx context.Context,
-				subnet network.SubnetInfo,
+				subnet domainnetwork.SubnetArg,
 			) error {
 				c.Assert(subnet.CIDR, gc.Equals, subnetInfo.CIDR)
+				c.Assert(subnet.CIDRAddressRange, jc.DeepEquals, domainnetwork.MustCIDRAddressRangeFromString(subnetInfo.CIDR))
 				c.Assert(subnet.ProviderId, gc.Equals, subnetInfo.ProviderId)
 				c.Assert(subnet.ProviderNetworkId, gc.Equals, subnetInfo.ProviderNetworkId)
 				c.Assert(subnet.AvailabilityZones, jc.SameContents, subnetInfo.AvailabilityZones)

--- a/domain/network/state/space_test.go
+++ b/domain/network/state/space_test.go
@@ -10,6 +10,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/network"
+	domainnetwork "github.com/juju/juju/domain/network"
 	networkerrors "github.com/juju/juju/domain/network/errors"
 	schematesting "github.com/juju/juju/domain/schema/testing"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
@@ -34,14 +35,17 @@ func (s *stateSuite) TestAddSpace(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.AddSubnet(
 		ctx.Background(),
-		network.SubnetInfo{
-			ID:                network.Id(subnetUUID.String()),
-			CIDR:              "192.168.0.0/12",
-			ProviderId:        "provider-id-0",
-			ProviderNetworkId: "provider-network-id-0",
-			VLANTag:           0,
-			AvailabilityZones: []string{"az0", "az1"},
-			SpaceID:           "",
+		domainnetwork.SubnetArg{
+			SubnetInfo: network.SubnetInfo{
+				ID:                network.Id(subnetUUID.String()),
+				CIDR:              "192.168.0.0/13",
+				ProviderId:        "provider-id-0",
+				ProviderNetworkId: "provider-network-id-0",
+				VLANTag:           0,
+				AvailabilityZones: []string{"az0", "az1"},
+				SpaceID:           "",
+			},
+			CIDRAddressRange: domainnetwork.MustCIDRAddressRangeFromString("192.168.0.0/13"),
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -91,14 +95,17 @@ func (s *stateSuite) TestAddSpaceFailDuplicateName(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.AddSubnet(
 		ctx.Background(),
-		network.SubnetInfo{
-			ID:                network.Id(subnetUUID.String()),
-			CIDR:              "192.168.0.0/12",
-			ProviderId:        "provider-id-0",
-			ProviderNetworkId: "provider-network-id-0",
-			VLANTag:           0,
-			AvailabilityZones: []string{"az0", "az1"},
-			SpaceID:           "",
+		domainnetwork.SubnetArg{
+			SubnetInfo: network.SubnetInfo{
+				ID:                network.Id(subnetUUID.String()),
+				CIDR:              "192.168.0.0/13",
+				ProviderId:        "provider-id-0",
+				ProviderNetworkId: "provider-network-id-0",
+				VLANTag:           0,
+				AvailabilityZones: []string{"az0", "az1"},
+				SpaceID:           "",
+			},
+			CIDRAddressRange: domainnetwork.MustCIDRAddressRangeFromString("192.168.0.0/13"),
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -131,14 +138,17 @@ func (s *stateSuite) TestAddSpaceEmptyProviderID(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.AddSubnet(
 		ctx.Background(),
-		network.SubnetInfo{
-			ID:                network.Id(subnetUUID.String()),
-			CIDR:              "192.168.0.0/12",
-			ProviderId:        "",
-			ProviderNetworkId: "provider-network-id-0",
-			VLANTag:           0,
-			AvailabilityZones: []string{"az0", "az1"},
-			SpaceID:           "",
+		domainnetwork.SubnetArg{
+			SubnetInfo: network.SubnetInfo{
+				ID:                network.Id(subnetUUID.String()),
+				CIDR:              "192.168.0.0/13",
+				ProviderId:        "",
+				ProviderNetworkId: "provider-network-id-0",
+				VLANTag:           0,
+				AvailabilityZones: []string{"az0", "az1"},
+				SpaceID:           "",
+			},
+			CIDRAddressRange: domainnetwork.MustCIDRAddressRangeFromString("192.168.0.0/13"),
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -167,14 +177,17 @@ func (s *stateSuite) TestRetrieveSpaceByUUID(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.AddSubnet(
 		ctx.Background(),
-		network.SubnetInfo{
-			ID:                network.Id(subnetUUID0.String()),
-			CIDR:              "192.168.0.0/12",
-			ProviderId:        "provider-id-0",
-			ProviderNetworkId: "provider-network-id-0",
-			VLANTag:           0,
-			AvailabilityZones: []string{"az0"},
-			SpaceID:           "",
+		domainnetwork.SubnetArg{
+			SubnetInfo: network.SubnetInfo{
+				ID:                network.Id(subnetUUID0.String()),
+				CIDR:              "192.168.0.0/13",
+				ProviderId:        "provider-id-0",
+				ProviderNetworkId: "provider-network-id-0",
+				VLANTag:           0,
+				AvailabilityZones: []string{"az0"},
+				SpaceID:           "",
+			},
+			CIDRAddressRange: domainnetwork.MustCIDRAddressRangeFromString("192.168.0.0/13"),
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -183,14 +196,17 @@ func (s *stateSuite) TestRetrieveSpaceByUUID(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.AddSubnet(
 		ctx.Background(),
-		network.SubnetInfo{
-			ID:                network.Id(subnetUUID1.String()),
-			CIDR:              "192.176.0.0/12",
-			ProviderId:        "provider-id-2",
-			ProviderNetworkId: "provider-network-id-2",
-			VLANTag:           0,
-			AvailabilityZones: []string{"az1"},
-			SpaceID:           "",
+		domainnetwork.SubnetArg{
+			SubnetInfo: network.SubnetInfo{
+				ID:                network.Id(subnetUUID1.String()),
+				CIDR:              "192.176.0.0/12",
+				ProviderId:        "provider-id-2",
+				ProviderNetworkId: "provider-network-id-2",
+				VLANTag:           0,
+				AvailabilityZones: []string{"az1"},
+				SpaceID:           "",
+			},
+			CIDRAddressRange: domainnetwork.MustCIDRAddressRangeFromString("192.176.0.0/12"),
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -209,7 +225,7 @@ func (s *stateSuite) TestRetrieveSpaceByUUID(c *gc.C) {
 	expected := network.SubnetInfos{
 		{
 			ID:                network.Id(subnetUUID0.String()),
-			CIDR:              "192.168.0.0/12",
+			CIDR:              "192.168.0.0/13",
 			ProviderId:        "provider-id-0",
 			ProviderSpaceId:   "foo",
 			ProviderNetworkId: "provider-network-id-0",
@@ -300,14 +316,17 @@ func (s *stateSuite) TestRetrieveAllSpaces(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.AddSubnet(
 		ctx.Background(),
-		network.SubnetInfo{
-			ID:                network.Id(subnetUUID0.String()),
-			CIDR:              "192.168.0.0/24",
-			ProviderId:        "provider-id-0",
-			ProviderNetworkId: "provider-network-id-0",
-			VLANTag:           0,
-			AvailabilityZones: []string{"az0", "az1"},
-			SpaceID:           "",
+		domainnetwork.SubnetArg{
+			SubnetInfo: network.SubnetInfo{
+				ID:                network.Id(subnetUUID0.String()),
+				CIDR:              "192.168.0.0/24",
+				ProviderId:        "provider-id-0",
+				ProviderNetworkId: "provider-network-id-0",
+				VLANTag:           0,
+				AvailabilityZones: []string{"az0", "az1"},
+				SpaceID:           "",
+			},
+			CIDRAddressRange: domainnetwork.MustCIDRAddressRangeFromString("192.168.0.0/24"),
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -315,14 +334,17 @@ func (s *stateSuite) TestRetrieveAllSpaces(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.AddSubnet(
 		ctx.Background(),
-		network.SubnetInfo{
-			ID:                network.Id(subnetUUID1.String()),
-			CIDR:              "192.168.1.0/24",
-			ProviderId:        "provider-id-1",
-			ProviderNetworkId: "provider-network-id-1",
-			VLANTag:           0,
-			AvailabilityZones: []string{"az0", "az1"},
-			SpaceID:           "",
+		domainnetwork.SubnetArg{
+			SubnetInfo: network.SubnetInfo{
+				ID:                network.Id(subnetUUID1.String()),
+				CIDR:              "192.168.1.0/24",
+				ProviderId:        "provider-id-1",
+				ProviderNetworkId: "provider-network-id-1",
+				VLANTag:           0,
+				AvailabilityZones: []string{"az0", "az1"},
+				SpaceID:           "",
+			},
+			CIDRAddressRange: domainnetwork.MustCIDRAddressRangeFromString("192.168.1.0/24"),
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -330,14 +352,17 @@ func (s *stateSuite) TestRetrieveAllSpaces(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.AddSubnet(
 		ctx.Background(),
-		network.SubnetInfo{
-			ID:                network.Id(subnetUUID2.String()),
-			CIDR:              "192.168.2.0/24",
-			ProviderId:        "provider-id-2",
-			ProviderNetworkId: "provider-network-id-2",
-			VLANTag:           0,
-			AvailabilityZones: []string{"az2", "az3"},
-			SpaceID:           "",
+		domainnetwork.SubnetArg{
+			SubnetInfo: network.SubnetInfo{
+				ID:                network.Id(subnetUUID2.String()),
+				CIDR:              "192.168.2.0/24",
+				ProviderId:        "provider-id-2",
+				ProviderNetworkId: "provider-network-id-2",
+				VLANTag:           0,
+				AvailabilityZones: []string{"az2", "az3"},
+				SpaceID:           "",
+			},
+			CIDRAddressRange: domainnetwork.MustCIDRAddressRangeFromString("192.168.2.0/24"),
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -399,14 +424,17 @@ func (s *stateSuite) TestDeleteSpace(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.AddSubnet(
 		ctx.Background(),
-		network.SubnetInfo{
-			ID:                network.Id(subnetUUID0.String()),
-			CIDR:              "192.168.0.0/20",
-			ProviderId:        "provider-id-0",
-			ProviderNetworkId: "provider-network-id-0",
-			VLANTag:           0,
-			AvailabilityZones: []string{"az0", "az1"},
-			SpaceID:           "",
+		domainnetwork.SubnetArg{
+			SubnetInfo: network.SubnetInfo{
+				ID:                network.Id(subnetUUID0.String()),
+				CIDR:              "192.168.0.0/20",
+				ProviderId:        "provider-id-0",
+				ProviderNetworkId: "provider-network-id-0",
+				VLANTag:           0,
+				AvailabilityZones: []string{"az0", "az1"},
+				SpaceID:           "",
+			},
+			CIDRAddressRange: domainnetwork.MustCIDRAddressRangeFromString("192.168.0.0/20"),
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)

--- a/domain/network/state/types.go
+++ b/domain/network/state/types.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 
 	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/internal/database"
 )
 
 // Subnet represents a single row from the subnet table.
@@ -15,6 +16,11 @@ type Subnet struct {
 	UUID string `db:"uuid"`
 	// CIDR of the network, in 123.45.67.89/24 format.
 	CIDR string `db:"cidr"`
+	// CIDR of the network, in 123.45.67.89/24 format.
+	StartAddressMSB database.Uint64 `db:"start_address_msb"`
+	StartAddressLSB database.Uint64 `db:"start_address_lsb"`
+	EndAddressMSB   database.Uint64 `db:"end_address_msb"`
+	EndAddressLSB   database.Uint64 `db:"end_address_lsb"`
 	// VLANtag is the subnet's vlan tag.
 	VLANtag int `db:"vlan_tag"`
 	// SpaceUUID is the space UUID.

--- a/domain/network/types.go
+++ b/domain/network/types.go
@@ -1,0 +1,60 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package network
+
+import (
+	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/internal/database"
+	"github.com/juju/juju/internal/errors"
+)
+
+// SubnetArg represents a subnet to be persisted.
+type SubnetArg struct {
+	network.SubnetInfo
+	CIDRAddressRange
+}
+
+// IPAddressBytes represents an IP address as
+// unsigned int64 values for msb, lsb.
+type IPAddressBytes struct {
+	MSB database.Uint64
+	LSB database.Uint64
+}
+
+// CIDRAddressRange represents a CIDR address range.
+type CIDRAddressRange struct {
+	Start IPAddressBytes
+	End   IPAddressBytes
+}
+
+// CIDRAddressRangeFromString parses CIDR string into a CIDRAddressRange.
+func CIDRAddressRangeFromString(cidrStr string) (CIDRAddressRange, error) {
+	var result CIDRAddressRange
+	cidr, err := network.ParseCIDR(cidrStr)
+	if err != nil {
+		return result, errors.Errorf("invalid subnet CIDR: %w", err)
+	}
+	start, end := cidr.AddressRange()
+	startMSB, startLSB := start.AsInts()
+	endMSB, endLSB := end.AsInts()
+	result.Start = IPAddressBytes{
+		MSB: database.NewUint64(startMSB),
+		LSB: database.NewUint64(startLSB),
+	}
+	result.End = IPAddressBytes{
+		MSB: database.NewUint64(endMSB),
+		LSB: database.NewUint64(endLSB),
+	}
+	return result, nil
+}
+
+// MustCIDRAddressRangeFromString parses CIDR string into a CIDRAddressRange
+// and panics on error.
+func MustCIDRAddressRangeFromString(cidrStr string) CIDRAddressRange {
+	result, err := CIDRAddressRangeFromString(cidrStr)
+	if err != nil {
+		panic(err)
+	}
+	return result
+}

--- a/domain/network/types_test.go
+++ b/domain/network/types_test.go
@@ -1,0 +1,47 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package network_test
+
+import (
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/domain/network"
+	"github.com/juju/juju/internal/database"
+)
+
+type typesSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&typesSuite{})
+
+func (s *typesSuite) TestCIDRAddressRangeFromString(c *gc.C) {
+	// This is just a sanity check.
+	// Extensive parsing tests are in the core network package.
+
+	result, err := network.CIDRAddressRangeFromString("2001:0DB8::/32")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Start, jc.DeepEquals, network.IPAddressBytes{
+		MSB: database.Uint64{
+			UnsignedValue: 0x20010db800000000,
+			Valid:         true,
+		},
+		LSB: database.Uint64{
+			UnsignedValue: 0,
+			Valid:         true,
+		},
+	})
+	c.Assert(result.End, jc.DeepEquals, network.IPAddressBytes{
+		MSB: database.Uint64{
+			UnsignedValue: 0x20010db8ffffffff,
+			Valid:         true,
+		},
+		LSB: database.Uint64{
+			UnsignedValue: 0xffffffffffffffff,
+			Valid:         true,
+		},
+	})
+}

--- a/domain/schema/model/sql/0009-subnet.sql
+++ b/domain/schema/model/sql/0009-subnet.sql
@@ -3,13 +3,13 @@ CREATE TABLE subnet (
     cidr TEXT NOT NULL,
     -- the most significant 64 bits of the cidr
     -- start ip address.
-    start_address_msb UNSIGNED BIG INT,
+    start_address_msb UNSIGNED BIG INT NOT NULL DEFAULT 0,
     -- the least significant 64 bits of the cidr
     -- start ip address.
     start_address_lsb UNSIGNED BIG INT NOT NULL,
     -- the most significant 64 bits of the cidr
     -- end ip address.
-    end_address_msb UNSIGNED BIG INT,
+    end_address_msb UNSIGNED BIG INT NOT NULL DEFAULT 0,
     -- the least significant 64 bits of the cidr
     -- end ip address.
     end_address_lsb UNSIGNED BIG INT NOT NULL,

--- a/domain/schema/model/sql/0009-subnet.sql
+++ b/domain/schema/model/sql/0009-subnet.sql
@@ -1,6 +1,19 @@
 CREATE TABLE subnet (
     uuid TEXT NOT NULL PRIMARY KEY,
     cidr TEXT NOT NULL,
+    -- the most significant 64 bits of the cidr
+    -- start ip address.
+    start_address_msb UNSIGNED BIG INT,
+    -- the least significant 64 bits of the cidr
+    -- start ip address.
+    start_address_lsb UNSIGNED BIG INT NOT NULL,
+    -- the most significant 64 bits of the cidr
+    -- end ip address.
+    end_address_msb UNSIGNED BIG INT,
+    -- the least significant 64 bits of the cidr
+    -- end ip address.
+    end_address_lsb UNSIGNED BIG INT NOT NULL,
+
     vlan_tag INT,
     space_uuid TEXT,
     CONSTRAINT fk_subnets_spaces

--- a/domain/schema/model/sql/0020-network.sql
+++ b/domain/schema/model/sql/0020-network.sql
@@ -170,7 +170,7 @@ CREATE TABLE ip_address (
     -- e.g. 192.168.1.2 or 2001:db8:0000:0000:0000:0000:0000:00001.
     address_value TEXT NOT NULL,
     -- the most significant 64 bits of the address.
-    address_msb UNSIGNED BIG INT,
+    address_msb UNSIGNED BIG INT NOT NULL DEFAULT 0,
     -- the least significant 64 bits of the address.
     address_lsb UNSIGNED BIG INT NOT NULL,
     -- one of ipv4, ipv6 etc.

--- a/domain/schema/model/sql/0020-network.sql
+++ b/domain/schema/model/sql/0020-network.sql
@@ -169,6 +169,10 @@ CREATE TABLE ip_address (
     -- The value of the configured IP address.
     -- e.g. 192.168.1.2 or 2001:db8:0000:0000:0000:0000:0000:00001.
     address_value TEXT NOT NULL,
+    -- the most significant 64 bits of the address.
+    address_msb UNSIGNED BIG INT,
+    -- the least significant 64 bits of the address.
+    address_lsb UNSIGNED BIG INT NOT NULL,
     -- one of ipv4, ipv6 etc.
     type_id INT NOT NULL,
     -- one of dhcp, static, manual, loopback etc.

--- a/domain/schema/model/triggers/network-triggers.gen.go
+++ b/domain/schema/model/triggers/network-triggers.gen.go
@@ -27,9 +27,9 @@ CREATE TRIGGER trg_log_subnet_update
 AFTER UPDATE ON subnet FOR EACH ROW
 WHEN 
 	NEW.cidr != OLD.cidr OR
-	(NEW.start_address_msb != OLD.start_address_msb OR (NEW.start_address_msb IS NOT NULL AND OLD.start_address_msb IS NULL) OR (NEW.start_address_msb IS NULL AND OLD.start_address_msb IS NOT NULL)) OR
+	NEW.start_address_msb != OLD.start_address_msb OR
 	NEW.start_address_lsb != OLD.start_address_lsb OR
-	(NEW.end_address_msb != OLD.end_address_msb OR (NEW.end_address_msb IS NOT NULL AND OLD.end_address_msb IS NULL) OR (NEW.end_address_msb IS NULL AND OLD.end_address_msb IS NOT NULL)) OR
+	NEW.end_address_msb != OLD.end_address_msb OR
 	NEW.end_address_lsb != OLD.end_address_lsb OR
 	(NEW.vlan_tag != OLD.vlan_tag OR (NEW.vlan_tag IS NOT NULL AND OLD.vlan_tag IS NULL) OR (NEW.vlan_tag IS NULL AND OLD.vlan_tag IS NOT NULL)) OR
 	(NEW.space_uuid != OLD.space_uuid OR (NEW.space_uuid IS NOT NULL AND OLD.space_uuid IS NULL) OR (NEW.space_uuid IS NULL AND OLD.space_uuid IS NOT NULL)) 

--- a/domain/schema/model/triggers/network-triggers.gen.go
+++ b/domain/schema/model/triggers/network-triggers.gen.go
@@ -27,6 +27,10 @@ CREATE TRIGGER trg_log_subnet_update
 AFTER UPDATE ON subnet FOR EACH ROW
 WHEN 
 	NEW.cidr != OLD.cidr OR
+	(NEW.start_address_msb != OLD.start_address_msb OR (NEW.start_address_msb IS NOT NULL AND OLD.start_address_msb IS NULL) OR (NEW.start_address_msb IS NULL AND OLD.start_address_msb IS NOT NULL)) OR
+	NEW.start_address_lsb != OLD.start_address_lsb OR
+	(NEW.end_address_msb != OLD.end_address_msb OR (NEW.end_address_msb IS NOT NULL AND OLD.end_address_msb IS NULL) OR (NEW.end_address_msb IS NULL AND OLD.end_address_msb IS NOT NULL)) OR
+	NEW.end_address_lsb != OLD.end_address_lsb OR
 	(NEW.vlan_tag != OLD.vlan_tag OR (NEW.vlan_tag IS NOT NULL AND OLD.vlan_tag IS NULL) OR (NEW.vlan_tag IS NULL AND OLD.vlan_tag IS NOT NULL)) OR
 	(NEW.space_uuid != OLD.space_uuid OR (NEW.space_uuid IS NOT NULL AND OLD.space_uuid IS NULL) OR (NEW.space_uuid IS NULL AND OLD.space_uuid IS NOT NULL)) 
 BEGIN

--- a/internal/database/types.go
+++ b/internal/database/types.go
@@ -5,6 +5,7 @@ package database
 
 import (
 	"database/sql/driver"
+	"encoding/binary"
 	"fmt"
 	"time"
 )
@@ -42,4 +43,43 @@ func (nd NullDuration) Value() (driver.Value, error) {
 		return nil, nil
 	}
 	return int64(nd.Duration), nil
+}
+
+// Uint64 represents a uint64 value.
+// The sql driver only handles signed ints.
+type Uint64 struct {
+	UnsignedValue uint64
+	Valid         bool
+}
+
+// NewUint64 returns a Uint64 with the given value.
+func NewUint64(v uint64) Uint64 {
+	return Uint64{UnsignedValue: v, Valid: true}
+}
+
+// Scan implements the sql.Scanner interface.
+func (ui *Uint64) Scan(value interface{}) error {
+	if value == nil {
+		ui.UnsignedValue, ui.Valid = 0, false
+		return nil
+	}
+
+	switch v := value.(type) {
+	case []byte:
+		ui.UnsignedValue = binary.NativeEndian.Uint64(v)
+		ui.Valid = len(v) == 8
+	default:
+		return fmt.Errorf("cannot scan type %T into uint64", value)
+	}
+	return nil
+}
+
+// Value implements the driver.Valuer interface.
+func (ui Uint64) Value() (driver.Value, error) {
+	if !ui.Valid {
+		return nil, nil
+	}
+	v := make([]byte, 8)
+	binary.NativeEndian.PutUint64(v, ui.UnsignedValue)
+	return v, nil
 }

--- a/internal/database/types_test.go
+++ b/internal/database/types_test.go
@@ -4,6 +4,7 @@
 package database
 
 import (
+	"encoding/binary"
 	"time"
 
 	"github.com/juju/testing"
@@ -41,4 +42,32 @@ func (s *typesSuite) TestNullDuration(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(nd.Duration, gc.Equals, 20*time.Second)
 	c.Assert(nd.Valid, jc.IsTrue)
+}
+
+func (s *typesSuite) TestUint64(c *gc.C) {
+	uiv := Uint64{UnsignedValue: uint64(1844674407370955161), Valid: true}
+	v, err := uiv.Value()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(v, jc.DeepEquals, []byte{0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x99, 0x19})
+
+	uiv = Uint64{Valid: true}
+	v, err = uiv.Value()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(v, jc.DeepEquals, []byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0})
+
+	uiv = Uint64{Valid: false}
+	v, err = uiv.Value()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(v, gc.IsNil)
+
+	err = uiv.Scan("value")
+	c.Assert(err, gc.ErrorMatches, `cannot scan type string into uint64`)
+	c.Assert(uiv.Valid, jc.IsFalse)
+
+	b := make([]byte, 8)
+	binary.NativeEndian.PutUint64(b, uint64(1844674407370955161))
+	err = uiv.Scan(b)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(uiv.UnsignedValue, gc.Equals, uint64(1844674407370955161))
+	c.Assert(uiv.Valid, jc.IsTrue)
 }

--- a/internal/provider/openstack/provider_test.go
+++ b/internal/provider/openstack/provider_test.go
@@ -315,7 +315,7 @@ func (*localTests) TestPortsToRuleInfo(c *gc.C) {
 		}},
 	}, {
 		about: "IPV4 and IPV6 CIDRs",
-		rules: firewall.IngressRules{firewall.NewIngressRule(network.MustParsePortRange("80-100/tcp"), "192.168.1.0/24", "2002::1234:abcd:ffff:c0a8:101/64")},
+		rules: firewall.IngressRules{firewall.NewIngressRule(network.MustParsePortRange("80-100/tcp"), "192.168.1.0/24", "2002:0:0:1234::/64")},
 		expected: []neutron.RuleInfoV2{{
 			Direction:      "ingress",
 			IPProtocol:     "tcp",
@@ -329,7 +329,7 @@ func (*localTests) TestPortsToRuleInfo(c *gc.C) {
 			IPProtocol:     "tcp",
 			PortRangeMin:   80,
 			PortRangeMax:   100,
-			RemoteIPPrefix: "2002::1234:abcd:ffff:c0a8:101/64",
+			RemoteIPPrefix: "2002:0:0:1234::/64",
 			ParentGroupId:  groupId,
 			EthernetType:   "IPv6",
 		}},

--- a/internal/worker/firewaller/firewaller_test.go
+++ b/internal/worker/firewaller/firewaller_test.go
@@ -1950,7 +1950,7 @@ func (s *InstanceModeSuite) TestExposeToIPV6CIDRsOnIPV4OnlyProvider(c *gc.C) {
 
 	// Expose app to space-1.
 	app.EXPECT().ExposeInfo(gomock.Any()).Return(true, map[string]params.ExposedEndpoint{
-		allEndpoints: {ExposeToCIDRs: []string{"10.0.0.0/24", "2002::1234:abcd:ffff:c0a8:101/64"}},
+		allEndpoints: {ExposeToCIDRs: []string{"10.0.0.0/24", "2002:0:0:1234::/64"}},
 	}, nil)
 
 	s.applicationsCh <- struct{}{}
@@ -2253,7 +2253,7 @@ func (s *GlobalModeSuite) TestExposeToIPV6CIDRsOnIPV4OnlyProvider(c *gc.C) {
 
 	// Expose app to space-1.
 	app.EXPECT().ExposeInfo(gomock.Any()).Return(true, map[string]params.ExposedEndpoint{
-		allEndpoints: {ExposeToCIDRs: []string{"10.0.0.0/24", "2002::1234:abcd:ffff:c0a8:101/64"}},
+		allEndpoints: {ExposeToCIDRs: []string{"10.0.0.0/24", "2002:0:0:1234::/64"}},
 	}, nil)
 
 	s.applicationsCh <- struct{}{}


### PR DESCRIPTION
We are storing ip address values as the string. This included subnet CIDRs.
We now decompose the address values into 2 64bit numbers, for msb and lsb and store these as well as the string value. For CIDR values, we store the start and end ip address from the range.

The affected tables are ip_address and subnet.
The domain state layer uses new helpers added to the core network package. 

The address.go file in core network contained some cidr related methods - these are moved to cidr.go and the new methods from this PR added there also.

A flaw was exposed in existing test code. The tests used invalid cidrs, eg `192.168.0.0/12` which should have been `192.168.0.0/13`. There were other places too. The new code in cidr.go which parses cidr strings makes sure to return an error if the cidr string is not a proper cidr, even though it may be syntactically correct.

There is an existing method `CIDRAddressType` which also suffers from the above problem. It is changed to use the new cidr parsing code which checks errors, and so existing tests needed updating.

## QA steps

Run the domain network unit tests
As a regression test, bootstrap to aws
```
juju subnets
subnets:
  172.31.0.0/20:
    type: ipv4
    provider-id: subnet-ab0bebce
    provider-network-id: vpc-3bc7de59
    space: alpha
    zones:
    - ap-southeast-2a
  172.31.16.0/20:
    type: ipv4
    provider-id: subnet-69efe31d
    provider-network-id: vpc-3bc7de59
    space: alpha
    zones:
    - ap-southeast-2b
  172.31.32.0/20:
    type: ipv4
    provider-id: subnet-60510a26
    provider-network-id: vpc-3bc7de59
    space: alpha
    zones:
    - ap-southeast-2c
  172.31.48.0/20:
    type: ipv4
    provider-id: subnet-06167dc609aaea9c9
    provider-network-id: vpc-3bc7de59
    space: alpha
    zones:
    - ap-southeast-2b
```

bootstrap to lxd
```
juju subnets
subnets:
  10.54.85.0/24:
    type: ipv4
    provider-id: subnet-lxdbr0-10.54.85.0/24
    provider-network-id: net-lxdbr0
    space: alpha
    zones:
    - wallyworld
  10.128.112.0/24:
    type: ipv4
    provider-id: subnet-mpqemubr0-10.128.112.0/24
    provider-network-id: net-mpqemubr0
    space: alpha
    zones:
    - wallyworld
  fd42:a3a8:97a1:627::/64:
    type: ipv6
    provider-id: subnet-lxdbr0-fd42:a3a8:97a1:627::/64
    provider-network-id: net-lxdbr0
    space: alpha
    zones:
    - wallyworld

```

## Links

**Jira card:** [JUJU-6690](https://warthogs.atlassian.net/browse/JUJU-6690)



[JUJU-6690]: https://warthogs.atlassian.net/browse/JUJU-6690?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ