### PR TITLE
chore(gating-ci): update percona-cluster to use specific channel

### DIFF
--- a/acceptancetests/repository/basic-openstack-lxd.yaml
+++ b/acceptancetests/repository/basic-openstack-lxd.yaml
@@ -69,6 +69,7 @@ applications:
       gui-x: '0'
       gui-y: '250'
     charm: cs:percona-cluster
+    channel: 5.7/edge
     num_units: 1
     options:
       max-connections: 20000


### PR DESCRIPTION
- Before this commit, the percona-cluster charm used the default channel.
- After this commit, the percona-cluster charm will use the 5.7/edge channel.

This commit ensures the percona-cluster charm uses a specific channel, since latest stable doesn't accept focal series. We selected to 5.7/edge which accepts this series.

It is required to fix ci-gating-tests for release 3.1.10


<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://docs.google.com/document/d/1SYUo9G7qZ_jdoVXpUVamS5VCgHmtZ0QA-wZxKoMS-C0 
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

~- [ ] Code style: imports ordered, good names, simple structure, etc~
~- [ ] Comments saying why design decisions were made~
~- [ ] Go unit tests, with comments saying what you're testing~
~- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
~- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

None
<!-- Describe steps to verify that the change works. -->

## Documentation changes

None
<!-- How it affects user workflow (CLI or API). -->

## Links

None