### PR TITLE
feat(machine): implement keep instance on new machine domain

### DIFF
--- a/apiserver/facades/agent/provisioner/provisioner.go
+++ b/apiserver/facades/agent/provisioner/provisioner.go
@@ -506,7 +506,7 @@ func (api *ProvisionerAPI) KeepInstance(ctx context.Context, args params.Entitie
 			result.Results[i].Error = apiservererrors.ServerError(apiservererrors.ErrPerm)
 			continue
 		}
-		keep, err := api.machineService.KeepInstance(ctx, machine.Name(tag.Id()))
+		keep, err := api.machineService.ShouldKeepInstance(ctx, machine.Name(tag.Id()))
 		result.Results[i].Result = keep
 		result.Results[i].Error = apiservererrors.ServerError(err)
 	}

--- a/apiserver/facades/agent/provisioner/provisioner_integration_test.go
+++ b/apiserver/facades/agent/provisioner/provisioner_integration_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/machine"
+	coremachine "github.com/juju/juju/core/machine"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/status"
@@ -958,7 +959,7 @@ func (s *withoutControllerSuite) TestKeepInstance(c *gc.C) {
 
 	// Add a machine with keep-instance = true.
 	foobarMachine := f.MakeMachine(c, &factory.MachineParams{InstanceId: "1234"})
-	err := foobarMachine.SetKeepInstance(true)
+	err := s.serviceFactory.Machine().SetKeepInstance(context.Background(), coremachine.Name(foobarMachine.Tag().String()), true)
 	c.Assert(err, jc.ErrorIsNil)
 
 	args := params.Entities{Entities: []params.Entity{

--- a/apiserver/facades/agent/provisioner/provisioner_integration_test.go
+++ b/apiserver/facades/agent/provisioner/provisioner_integration_test.go
@@ -959,7 +959,9 @@ func (s *withoutControllerSuite) TestKeepInstance(c *gc.C) {
 
 	// Add a machine with keep-instance = true.
 	foobarMachine := f.MakeMachine(c, &factory.MachineParams{InstanceId: "1234"})
-	err := s.serviceFactory.Machine().SetKeepInstance(context.Background(), coremachine.Name(foobarMachine.Tag().String()), true)
+	_, err := s.serviceFactory.Machine().CreateMachine(context.Background(), coremachine.Name(foobarMachine.Tag().Id()))
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.serviceFactory.Machine().SetKeepInstance(context.Background(), coremachine.Name(foobarMachine.Tag().Id()), true)
 	c.Assert(err, jc.ErrorIsNil)
 
 	args := params.Entities{Entities: []params.Entity{
@@ -968,7 +970,6 @@ func (s *withoutControllerSuite) TestKeepInstance(c *gc.C) {
 		{Tag: s.machines[2].Tag().String()},
 		{Tag: "machine-42"},
 		{Tag: "unit-foo-0"},
-		{Tag: "application-bar"},
 	}}
 	result, err := s.provisioner.KeepInstance(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
@@ -977,8 +978,7 @@ func (s *withoutControllerSuite) TestKeepInstance(c *gc.C) {
 			{Result: false},
 			{Result: true},
 			{Result: false},
-			{Error: apiservertesting.NotFoundError("machine 42")},
-			{Error: apiservertesting.ErrUnauthorized},
+			{Error: apiservertesting.ServerError("check for machine \"42\" keep instance: machine not found")},
 			{Error: apiservertesting.ErrUnauthorized},
 		},
 	})

--- a/apiserver/facades/agent/provisioner/service.go
+++ b/apiserver/facades/agent/provisioner/service.go
@@ -10,6 +10,7 @@ import (
 	"github.com/juju/juju/core/container"
 	"github.com/juju/juju/core/containermanager"
 	"github.com/juju/juju/core/instance"
+	coremachine "github.com/juju/juju/core/machine"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/environs/config"
@@ -48,6 +49,20 @@ type ModelInfoService interface {
 	// GetModelInfo returns the readonly model information for the model in
 	// question.
 	GetModelInfo(context.Context) (model.ReadOnlyModel, error)
+}
+
+// MachineService defines the methods that the facade assumes from the Machine
+// service.
+type MachineService interface {
+	// KeepInstance reports whether a machine, when removed from Juju, should cause
+	// the corresponding cloud instance to be stopped.
+	// It returns a NotFound if the given machine doesn't exist.
+	KeepInstance(ctx context.Context, machineName coremachine.Name) (bool, error)
+	// SetKeepInstance sets whether the machine cloud instance will be retained
+	// when the machine is removed from Juju. This is only relevant if an instance
+	// exists.
+	// It returns a NotFound if the given machine doesn't exist.
+	SetKeepInstance(ctx context.Context, machineName coremachine.Name, keep bool) error
 }
 
 // StoragePoolGetter instances get a storage pool by name.

--- a/apiserver/facades/agent/provisioner/service.go
+++ b/apiserver/facades/agent/provisioner/service.go
@@ -54,10 +54,10 @@ type ModelInfoService interface {
 // MachineService defines the methods that the facade assumes from the Machine
 // service.
 type MachineService interface {
-	// KeepInstance reports whether a machine, when removed from Juju, should cause
+	// ShouldKeepInstance reports whether a machine, when removed from Juju, should cause
 	// the corresponding cloud instance to be stopped.
 	// It returns a NotFound if the given machine doesn't exist.
-	KeepInstance(ctx context.Context, machineName coremachine.Name) (bool, error)
+	ShouldKeepInstance(ctx context.Context, machineName coremachine.Name) (bool, error)
 	// SetKeepInstance sets whether the machine cloud instance will be retained
 	// when the machine is removed from Juju. This is only relevant if an instance
 	// exists.

--- a/apiserver/facades/client/machinemanager/machinemanager.go
+++ b/apiserver/facades/client/machinemanager/machinemanager.go
@@ -96,10 +96,10 @@ type MachineService interface {
 	GetBootstrapEnviron(context.Context) (environs.BootstrapEnviron, error)
 	// GetInstanceTypesFetcher returns the instance types fetcher.
 	GetInstanceTypesFetcher(context.Context) (environs.InstanceTypesFetcher, error)
-	// KeepInstance reports whether a machine, when removed from Juju, should cause
+	// ShouldKeepInstance reports whether a machine, when removed from Juju, should cause
 	// the corresponding cloud instance to be stopped.
 	// It returns a NotFound if the given machine doesn't exist.
-	KeepInstance(ctx context.Context, machineName coremachine.Name) (bool, error)
+	ShouldKeepInstance(ctx context.Context, machineName coremachine.Name) (bool, error)
 	// SetKeepInstance sets whether the machine cloud instance will be retained
 	// when the machine is removed from Juju. This is only relevant if an instance
 	// exists.

--- a/apiserver/facades/client/machinemanager/machinemanager_test.go
+++ b/apiserver/facades/client/machinemanager/machinemanager_test.go
@@ -22,6 +22,7 @@ import (
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/machine"
+	coremachine "github.com/juju/juju/core/machine"
 	"github.com/juju/juju/core/model"
 	modeltesting "github.com/juju/juju/core/model/testing"
 	"github.com/juju/juju/core/network"
@@ -270,9 +271,6 @@ func (s *DestroyMachineManagerSuite) expectUnpinAppLeaders(id string) {
 
 func (s *DestroyMachineManagerSuite) expectDestroyMachine(ctrl *gomock.Controller, units []Unit, containers []string, attemptDestroy, keep, force bool) *MockMachine {
 	machine := NewMockMachine(ctrl)
-	if keep {
-		machine.EXPECT().SetKeepInstance(true).Return(nil)
-	}
 
 	machine.EXPECT().Containers().Return(containers, nil)
 
@@ -554,6 +552,7 @@ func (s *DestroyMachineManagerSuite) TestDestroyMachineWithParamsNoWait(c *gc.C)
 	s.expectUnpinAppLeaders("0")
 
 	machine0 := s.expectDestroyMachine(ctrl, nil, nil, true, true, true)
+	s.machineService.EXPECT().SetKeepInstance(gomock.Any(), coremachine.Name("0"), true)
 	s.st.EXPECT().Machine("0").Return(machine0, nil)
 
 	noWait := 0 * time.Second
@@ -591,6 +590,7 @@ func (s *DestroyMachineManagerSuite) TestDestroyMachineWithParamsNilWait(c *gc.C
 	s.expectUnpinAppLeaders("0")
 
 	machine0 := s.expectDestroyMachine(ctrl, nil, nil, true, true, true)
+	s.machineService.EXPECT().SetKeepInstance(gomock.Any(), coremachine.Name("0"), true)
 	s.st.EXPECT().Machine("0").Return(machine0, nil)
 
 	results, err := s.api.DestroyMachineWithParams(context.Background(), params.DestroyMachinesParams{

--- a/apiserver/facades/client/machinemanager/package_mock_test.go
+++ b/apiserver/facades/client/machinemanager/package_mock_test.go
@@ -1531,44 +1531,6 @@ func (c *MockMachineSetInstanceStatusCall) DoAndReturn(f func(status.StatusInfo)
 	return c
 }
 
-// SetKeepInstance mocks base method.
-func (m *MockMachine) SetKeepInstance(arg0 bool) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetKeepInstance", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// SetKeepInstance indicates an expected call of SetKeepInstance.
-func (mr *MockMachineMockRecorder) SetKeepInstance(arg0 any) *MockMachineSetKeepInstanceCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetKeepInstance", reflect.TypeOf((*MockMachine)(nil).SetKeepInstance), arg0)
-	return &MockMachineSetKeepInstanceCall{Call: call}
-}
-
-// MockMachineSetKeepInstanceCall wrap *gomock.Call
-type MockMachineSetKeepInstanceCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockMachineSetKeepInstanceCall) Return(arg0 error) *MockMachineSetKeepInstanceCall {
-	c.Call = c.Call.Return(arg0)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockMachineSetKeepInstanceCall) Do(f func(bool) error) *MockMachineSetKeepInstanceCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineSetKeepInstanceCall) DoAndReturn(f func(bool) error) *MockMachineSetKeepInstanceCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // SetPassword mocks base method.
 func (m *MockMachine) SetPassword(arg0 string) error {
 	m.ctrl.T.Helper()
@@ -2401,45 +2363,6 @@ func (c *MockMachineServiceGetInstanceTypesFetcherCall) DoAndReturn(f func(conte
 	return c
 }
 
-// KeepInstance mocks base method.
-func (m *MockMachineService) KeepInstance(arg0 context.Context, arg1 machine.Name) (bool, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "KeepInstance", arg0, arg1)
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// KeepInstance indicates an expected call of KeepInstance.
-func (mr *MockMachineServiceMockRecorder) KeepInstance(arg0, arg1 any) *MockMachineServiceKeepInstanceCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "KeepInstance", reflect.TypeOf((*MockMachineService)(nil).KeepInstance), arg0, arg1)
-	return &MockMachineServiceKeepInstanceCall{Call: call}
-}
-
-// MockMachineServiceKeepInstanceCall wrap *gomock.Call
-type MockMachineServiceKeepInstanceCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockMachineServiceKeepInstanceCall) Return(arg0 bool, arg1 error) *MockMachineServiceKeepInstanceCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockMachineServiceKeepInstanceCall) Do(f func(context.Context, machine.Name) (bool, error)) *MockMachineServiceKeepInstanceCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineServiceKeepInstanceCall) DoAndReturn(f func(context.Context, machine.Name) (bool, error)) *MockMachineServiceKeepInstanceCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // SetKeepInstance mocks base method.
 func (m *MockMachineService) SetKeepInstance(arg0 context.Context, arg1 machine.Name, arg2 bool) error {
 	m.ctrl.T.Helper()
@@ -2474,6 +2397,45 @@ func (c *MockMachineServiceSetKeepInstanceCall) Do(f func(context.Context, machi
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockMachineServiceSetKeepInstanceCall) DoAndReturn(f func(context.Context, machine.Name, bool) error) *MockMachineServiceSetKeepInstanceCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// ShouldKeepInstance mocks base method.
+func (m *MockMachineService) ShouldKeepInstance(arg0 context.Context, arg1 machine.Name) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ShouldKeepInstance", arg0, arg1)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ShouldKeepInstance indicates an expected call of ShouldKeepInstance.
+func (mr *MockMachineServiceMockRecorder) ShouldKeepInstance(arg0, arg1 any) *MockMachineServiceShouldKeepInstanceCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ShouldKeepInstance", reflect.TypeOf((*MockMachineService)(nil).ShouldKeepInstance), arg0, arg1)
+	return &MockMachineServiceShouldKeepInstanceCall{Call: call}
+}
+
+// MockMachineServiceShouldKeepInstanceCall wrap *gomock.Call
+type MockMachineServiceShouldKeepInstanceCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockMachineServiceShouldKeepInstanceCall) Return(arg0 bool, arg1 error) *MockMachineServiceShouldKeepInstanceCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockMachineServiceShouldKeepInstanceCall) Do(f func(context.Context, machine.Name) (bool, error)) *MockMachineServiceShouldKeepInstanceCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockMachineServiceShouldKeepInstanceCall) DoAndReturn(f func(context.Context, machine.Name) (bool, error)) *MockMachineServiceShouldKeepInstanceCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/client/machinemanager/package_mock_test.go
+++ b/apiserver/facades/client/machinemanager/package_mock_test.go
@@ -2401,6 +2401,83 @@ func (c *MockMachineServiceGetInstanceTypesFetcherCall) DoAndReturn(f func(conte
 	return c
 }
 
+// KeepInstance mocks base method.
+func (m *MockMachineService) KeepInstance(arg0 context.Context, arg1 machine.Name) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "KeepInstance", arg0, arg1)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// KeepInstance indicates an expected call of KeepInstance.
+func (mr *MockMachineServiceMockRecorder) KeepInstance(arg0, arg1 any) *MockMachineServiceKeepInstanceCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "KeepInstance", reflect.TypeOf((*MockMachineService)(nil).KeepInstance), arg0, arg1)
+	return &MockMachineServiceKeepInstanceCall{Call: call}
+}
+
+// MockMachineServiceKeepInstanceCall wrap *gomock.Call
+type MockMachineServiceKeepInstanceCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockMachineServiceKeepInstanceCall) Return(arg0 bool, arg1 error) *MockMachineServiceKeepInstanceCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockMachineServiceKeepInstanceCall) Do(f func(context.Context, machine.Name) (bool, error)) *MockMachineServiceKeepInstanceCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockMachineServiceKeepInstanceCall) DoAndReturn(f func(context.Context, machine.Name) (bool, error)) *MockMachineServiceKeepInstanceCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// SetKeepInstance mocks base method.
+func (m *MockMachineService) SetKeepInstance(arg0 context.Context, arg1 machine.Name, arg2 bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetKeepInstance", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetKeepInstance indicates an expected call of SetKeepInstance.
+func (mr *MockMachineServiceMockRecorder) SetKeepInstance(arg0, arg1, arg2 any) *MockMachineServiceSetKeepInstanceCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetKeepInstance", reflect.TypeOf((*MockMachineService)(nil).SetKeepInstance), arg0, arg1, arg2)
+	return &MockMachineServiceSetKeepInstanceCall{Call: call}
+}
+
+// MockMachineServiceSetKeepInstanceCall wrap *gomock.Call
+type MockMachineServiceSetKeepInstanceCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockMachineServiceSetKeepInstanceCall) Return(arg0 error) *MockMachineServiceSetKeepInstanceCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockMachineServiceSetKeepInstanceCall) Do(f func(context.Context, machine.Name, bool) error) *MockMachineServiceSetKeepInstanceCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockMachineServiceSetKeepInstanceCall) DoAndReturn(f func(context.Context, machine.Name, bool) error) *MockMachineServiceSetKeepInstanceCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // MockNetworkService is a mock of NetworkService interface.
 type MockNetworkService struct {
 	ctrl     *gomock.Controller

--- a/apiserver/facades/client/machinemanager/state.go
+++ b/apiserver/facades/client/machinemanager/state.go
@@ -66,7 +66,6 @@ type Machine interface {
 	Base() state.Base
 	Containers() ([]string, error)
 	Units() ([]Unit, error)
-	SetKeepInstance(keepInstance bool) error
 	Principals() []string
 	IsManager() bool
 	ApplicationNames() ([]string, error)

--- a/domain/machine/service/package_mock_test.go
+++ b/domain/machine/service/package_mock_test.go
@@ -779,6 +779,45 @@ func (c *MockStateIsMachineRebootRequiredCall) DoAndReturn(f func(context.Contex
 	return c
 }
 
+// KeepInstance mocks base method.
+func (m *MockState) KeepInstance(arg0 context.Context, arg1 machine.Name) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "KeepInstance", arg0, arg1)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// KeepInstance indicates an expected call of KeepInstance.
+func (mr *MockStateMockRecorder) KeepInstance(arg0, arg1 any) *MockStateKeepInstanceCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "KeepInstance", reflect.TypeOf((*MockState)(nil).KeepInstance), arg0, arg1)
+	return &MockStateKeepInstanceCall{Call: call}
+}
+
+// MockStateKeepInstanceCall wrap *gomock.Call
+type MockStateKeepInstanceCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateKeepInstanceCall) Return(arg0 bool, arg1 error) *MockStateKeepInstanceCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateKeepInstanceCall) Do(f func(context.Context, machine.Name) (bool, error)) *MockStateKeepInstanceCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateKeepInstanceCall) DoAndReturn(f func(context.Context, machine.Name) (bool, error)) *MockStateKeepInstanceCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // MarkMachineForRemoval mocks base method.
 func (m *MockState) MarkMachineForRemoval(arg0 context.Context, arg1 machine.Name) error {
 	m.ctrl.T.Helper()
@@ -889,6 +928,44 @@ func (c *MockStateSetInstanceStatusCall) Do(f func(context.Context, machine.Name
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockStateSetInstanceStatusCall) DoAndReturn(f func(context.Context, machine.Name, status.StatusInfo) error) *MockStateSetInstanceStatusCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// SetKeepInstance mocks base method.
+func (m *MockState) SetKeepInstance(arg0 context.Context, arg1 machine.Name, arg2 bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetKeepInstance", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetKeepInstance indicates an expected call of SetKeepInstance.
+func (mr *MockStateMockRecorder) SetKeepInstance(arg0, arg1, arg2 any) *MockStateSetKeepInstanceCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetKeepInstance", reflect.TypeOf((*MockState)(nil).SetKeepInstance), arg0, arg1, arg2)
+	return &MockStateSetKeepInstanceCall{Call: call}
+}
+
+// MockStateSetKeepInstanceCall wrap *gomock.Call
+type MockStateSetKeepInstanceCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateSetKeepInstanceCall) Return(arg0 error) *MockStateSetKeepInstanceCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateSetKeepInstanceCall) Do(f func(context.Context, machine.Name, bool) error) *MockStateSetKeepInstanceCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateSetKeepInstanceCall) DoAndReturn(f func(context.Context, machine.Name, bool) error) *MockStateSetKeepInstanceCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/machine/service/package_mock_test.go
+++ b/domain/machine/service/package_mock_test.go
@@ -779,45 +779,6 @@ func (c *MockStateIsMachineRebootRequiredCall) DoAndReturn(f func(context.Contex
 	return c
 }
 
-// KeepInstance mocks base method.
-func (m *MockState) KeepInstance(arg0 context.Context, arg1 machine.Name) (bool, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "KeepInstance", arg0, arg1)
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// KeepInstance indicates an expected call of KeepInstance.
-func (mr *MockStateMockRecorder) KeepInstance(arg0, arg1 any) *MockStateKeepInstanceCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "KeepInstance", reflect.TypeOf((*MockState)(nil).KeepInstance), arg0, arg1)
-	return &MockStateKeepInstanceCall{Call: call}
-}
-
-// MockStateKeepInstanceCall wrap *gomock.Call
-type MockStateKeepInstanceCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockStateKeepInstanceCall) Return(arg0 bool, arg1 error) *MockStateKeepInstanceCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockStateKeepInstanceCall) Do(f func(context.Context, machine.Name) (bool, error)) *MockStateKeepInstanceCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateKeepInstanceCall) DoAndReturn(f func(context.Context, machine.Name) (bool, error)) *MockStateKeepInstanceCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // MarkMachineForRemoval mocks base method.
 func (m *MockState) MarkMachineForRemoval(arg0 context.Context, arg1 machine.Name) error {
 	m.ctrl.T.Helper()
@@ -1080,6 +1041,45 @@ func (c *MockStateSetMachineStatusCall) Do(f func(context.Context, machine.Name,
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockStateSetMachineStatusCall) DoAndReturn(f func(context.Context, machine.Name, status.StatusInfo) error) *MockStateSetMachineStatusCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// ShouldKeepInstance mocks base method.
+func (m *MockState) ShouldKeepInstance(arg0 context.Context, arg1 machine.Name) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ShouldKeepInstance", arg0, arg1)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ShouldKeepInstance indicates an expected call of ShouldKeepInstance.
+func (mr *MockStateMockRecorder) ShouldKeepInstance(arg0, arg1 any) *MockStateShouldKeepInstanceCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ShouldKeepInstance", reflect.TypeOf((*MockState)(nil).ShouldKeepInstance), arg0, arg1)
+	return &MockStateShouldKeepInstanceCall{Call: call}
+}
+
+// MockStateShouldKeepInstanceCall wrap *gomock.Call
+type MockStateShouldKeepInstanceCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateShouldKeepInstanceCall) Return(arg0 bool, arg1 error) *MockStateShouldKeepInstanceCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateShouldKeepInstanceCall) Do(f func(context.Context, machine.Name) (bool, error)) *MockStateShouldKeepInstanceCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateShouldKeepInstanceCall) DoAndReturn(f func(context.Context, machine.Name) (bool, error)) *MockStateShouldKeepInstanceCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/machine/service/service.go
+++ b/domain/machine/service/service.go
@@ -101,9 +101,9 @@ type State interface {
 	// It returns a NotFound if the given machine doesn't exist.
 	IsMachineController(context.Context, coremachine.Name) (bool, error)
 
-	// KeepInstance reports whether a machine, when removed from Juju, should cause
+	// ShouldKeepInstance reports whether a machine, when removed from Juju, should cause
 	// the corresponding cloud instance to be stopped.
-	KeepInstance(ctx context.Context, mName machine.Name) (bool, error)
+	ShouldKeepInstance(ctx context.Context, mName machine.Name) (bool, error)
 
 	// SetKeepInstance sets whether the machine cloud instance will be retained
 	// when the machine is removed from Juju. This is only relevant if an instance
@@ -317,11 +317,11 @@ func (s *Service) IsMachineController(ctx context.Context, machineName coremachi
 	return isController, nil
 }
 
-// KeepInstance reports whether a machine, when removed from Juju, should cause
+// ShouldKeepInstance reports whether a machine, when removed from Juju, should cause
 // the corresponding cloud instance to be stopped.
 // It returns a NotFound if the given machine doesn't exist.
-func (s *Service) KeepInstance(ctx context.Context, machineName coremachine.Name) (bool, error) {
-	keepInstance, err := s.st.KeepInstance(ctx, machineName)
+func (s *Service) ShouldKeepInstance(ctx context.Context, machineName coremachine.Name) (bool, error) {
+	keepInstance, err := s.st.ShouldKeepInstance(ctx, machineName)
 	if err != nil {
 		return false, errors.Trace(err)
 	}

--- a/domain/machine/service/service.go
+++ b/domain/machine/service/service.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/core/machine"
 	coremachine "github.com/juju/juju/core/machine"
 	"github.com/juju/juju/core/providertracker"
 	"github.com/juju/juju/core/status"
@@ -99,6 +100,15 @@ type State interface {
 	// IsMachineController returns whether the machine is a controller machine.
 	// It returns a NotFound if the given machine doesn't exist.
 	IsMachineController(context.Context, coremachine.Name) (bool, error)
+
+	// KeepInstance reports whether a machine, when removed from Juju, should cause
+	// the corresponding cloud instance to be stopped.
+	KeepInstance(ctx context.Context, mName machine.Name) (bool, error)
+
+	// SetKeepInstance sets whether the machine cloud instance will be retained
+	// when the machine is removed from Juju. This is only relevant if an instance
+	// exists.
+	SetKeepInstance(ctx context.Context, mName machine.Name, keep bool) error
 
 	// RequireMachineReboot sets the machine referenced by its UUID as requiring a reboot.
 	RequireMachineReboot(ctx context.Context, uuid string) error
@@ -305,6 +315,25 @@ func (s *Service) IsMachineController(ctx context.Context, machineName coremachi
 		return false, errors.Annotatef(err, "checking if machine %q is a controller", machineName)
 	}
 	return isController, nil
+}
+
+// KeepInstance reports whether a machine, when removed from Juju, should cause
+// the corresponding cloud instance to be stopped.
+// It returns a NotFound if the given machine doesn't exist.
+func (s *Service) KeepInstance(ctx context.Context, machineName coremachine.Name) (bool, error) {
+	keepInstance, err := s.st.KeepInstance(ctx, machineName)
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+	return keepInstance, nil
+}
+
+// SetKeepInstance sets whether the machine cloud instance will be retained
+// when the machine is removed from Juju. This is only relevant if an instance
+// exists.
+// It returns a NotFound if the given machine doesn't exist.
+func (s *Service) SetKeepInstance(ctx context.Context, machineName coremachine.Name, keep bool) error {
+	return errors.Trace(s.st.SetKeepInstance(ctx, machineName, keep))
 }
 
 // RequireMachineReboot sets the machine referenced by its UUID as requiring a reboot.

--- a/domain/machine/state/state.go
+++ b/domain/machine/state/state.go
@@ -808,7 +808,7 @@ WHERE  name = $machineName.name`
 		return nil
 	})
 	if err != nil {
-		return false, fmt.Errorf("check for machine %q keep instane: %w", mName, err)
+		return false, fmt.Errorf("check for machine %q keep instance: %w", mName, err)
 	}
 
 	return result.KeepInstance, nil

--- a/domain/machine/state/state_test.go
+++ b/domain/machine/state/state_test.go
@@ -716,3 +716,56 @@ func (s *stateSuite) TestGetMachineUUID(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(name, gc.Equals, "123")
 }
+
+func (s *stateSuite) TestKeepInstance(c *gc.C) {
+	err := s.state.CreateMachine(context.Background(), "666", "", "")
+	c.Assert(err, jc.ErrorIsNil)
+
+	isController, err := s.state.KeepInstance(context.Background(), "666")
+	c.Check(err, jc.ErrorIsNil)
+	c.Assert(isController, gc.Equals, false)
+
+	db := s.DB()
+
+	updateIsController := `
+UPDATE machine
+SET    keep_instance = TRUE
+WHERE  name = $1`
+	_, err = db.ExecContext(context.Background(), updateIsController, "666")
+	c.Assert(err, jc.ErrorIsNil)
+	isController, err = s.state.KeepInstance(context.Background(), "666")
+	c.Check(err, jc.ErrorIsNil)
+	c.Assert(isController, gc.Equals, true)
+}
+
+// TestIsControllerNotFound asserts that a NotFound error is returned when the
+// machine is not found.
+func (s *stateSuite) TestKeepInstanceNotFound(c *gc.C) {
+	_, err := s.state.KeepInstance(context.Background(), "666")
+	c.Assert(err, jc.ErrorIs, machineerrors.MachineNotFound)
+}
+
+func (s *stateSuite) TestSetKeepInstance(c *gc.C) {
+	err := s.state.CreateMachine(context.Background(), "666", "", "")
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.state.SetKeepInstance(context.Background(), "666", true)
+	c.Assert(err, jc.ErrorIsNil)
+
+	db := s.DB()
+	query := `
+SELECT keep_instance
+FROM   machine
+WHERE  name = $1`
+	row := db.QueryRowContext(context.Background(), query, "666")
+	c.Assert(row.Err(), jc.ErrorIsNil)
+
+	var keep bool
+	c.Assert(row.Scan(&keep), jc.ErrorIsNil)
+	c.Check(keep, jc.IsTrue)
+
+}
+
+func (s *stateSuite) TestSetKeepInstanceNotFound(c *gc.C) {
+	err := s.state.SetKeepInstance(context.Background(), "666", true)
+	c.Assert(err, jc.ErrorIs, machineerrors.MachineNotFound)
+}

--- a/domain/machine/state/state_test.go
+++ b/domain/machine/state/state_test.go
@@ -721,7 +721,7 @@ func (s *stateSuite) TestKeepInstance(c *gc.C) {
 	err := s.state.CreateMachine(context.Background(), "666", "", "")
 	c.Assert(err, jc.ErrorIsNil)
 
-	isController, err := s.state.KeepInstance(context.Background(), "666")
+	isController, err := s.state.ShouldKeepInstance(context.Background(), "666")
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(isController, gc.Equals, false)
 
@@ -733,7 +733,7 @@ SET    keep_instance = TRUE
 WHERE  name = $1`
 	_, err = db.ExecContext(context.Background(), updateIsController, "666")
 	c.Assert(err, jc.ErrorIsNil)
-	isController, err = s.state.KeepInstance(context.Background(), "666")
+	isController, err = s.state.ShouldKeepInstance(context.Background(), "666")
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(isController, gc.Equals, true)
 }
@@ -741,7 +741,7 @@ WHERE  name = $1`
 // TestIsControllerNotFound asserts that a NotFound error is returned when the
 // machine is not found.
 func (s *stateSuite) TestKeepInstanceNotFound(c *gc.C) {
-	_, err := s.state.KeepInstance(context.Background(), "666")
+	_, err := s.state.ShouldKeepInstance(context.Background(), "666")
 	c.Assert(err, jc.ErrorIs, machineerrors.MachineNotFound)
 }
 

--- a/domain/machine/state/types.go
+++ b/domain/machine/state/types.go
@@ -110,6 +110,12 @@ type machineIsController struct {
 	IsController bool `db:"is_controller"`
 }
 
+// keepInstance represents the struct to be used for the keep_instance column
+// within the sqlair statements in the machine domain.
+type keepInstance struct {
+	KeepInstance bool `db:"keep_instance"`
+}
+
 // machineParent represents the struct to be used for the columns of the
 // machine_parent table within the sqlair statements in the machine domain.
 type machineParent struct {

--- a/domain/schema/model/sql/0017-machine.sql
+++ b/domain/schema/model/sql/0017-machine.sql
@@ -13,6 +13,7 @@ CREATE TABLE machine (
     agent_started_at DATETIME,
     hostname TEXT,
     is_controller BOOLEAN,
+    keep_instance BOOLEAN,
     CONSTRAINT fk_machine_net_node
     FOREIGN KEY (net_node_uuid)
     REFERENCES net_node (uuid),

--- a/domain/schema/model/triggers/machine-triggers.gen.go
+++ b/domain/schema/model/triggers/machine-triggers.gen.go
@@ -38,7 +38,8 @@ WHEN
 	(NEW.placement != OLD.placement OR (NEW.placement IS NOT NULL AND OLD.placement IS NULL) OR (NEW.placement IS NULL AND OLD.placement IS NOT NULL)) OR
 	(NEW.agent_started_at != OLD.agent_started_at OR (NEW.agent_started_at IS NOT NULL AND OLD.agent_started_at IS NULL) OR (NEW.agent_started_at IS NULL AND OLD.agent_started_at IS NOT NULL)) OR
 	(NEW.hostname != OLD.hostname OR (NEW.hostname IS NOT NULL AND OLD.hostname IS NULL) OR (NEW.hostname IS NULL AND OLD.hostname IS NOT NULL)) OR
-	(NEW.is_controller != OLD.is_controller OR (NEW.is_controller IS NOT NULL AND OLD.is_controller IS NULL) OR (NEW.is_controller IS NULL AND OLD.is_controller IS NOT NULL)) 
+	(NEW.is_controller != OLD.is_controller OR (NEW.is_controller IS NOT NULL AND OLD.is_controller IS NULL) OR (NEW.is_controller IS NULL AND OLD.is_controller IS NOT NULL)) OR
+	(NEW.keep_instance != OLD.keep_instance OR (NEW.keep_instance IS NOT NULL AND OLD.keep_instance IS NULL) OR (NEW.keep_instance IS NULL AND OLD.keep_instance IS NOT NULL)) 
 BEGIN
     INSERT INTO change_log (edit_type_id, namespace_id, changed, created_at)
     VALUES (2, %[2]d, OLD.%[1]s, DATETIME('now'));

--- a/state/machine.go
+++ b/state/machine.go
@@ -417,34 +417,6 @@ func (m *Machine) Jobs() []MachineJob {
 	return m.doc.Jobs
 }
 
-// SetKeepInstance sets whether the cloud machine instance
-// will be retained when the machine is removed from Juju.
-// This is only relevant if an instance exists.
-func (m *Machine) SetKeepInstance(keepInstance bool) error {
-	ops := []txn.Op{{
-		C:      instanceDataC,
-		Id:     m.doc.DocID,
-		Assert: txn.DocExists,
-		Update: bson.D{{"$set", bson.D{{"keep-instance", keepInstance}}}},
-	}}
-	if err := m.st.db().RunTransaction(ops); err != nil {
-		// If instance doc doesn't exist, that's ok; there's nothing to keep,
-		// but that's not an error we care about.
-		return errors.Annotatef(onAbort(err, nil), "cannot set KeepInstance on machine %v", m)
-	}
-	return nil
-}
-
-// KeepInstance reports whether a machine, when removed from
-// Juju, will cause the corresponding cloud instance to be stopped.
-func (m *Machine) KeepInstance() (bool, error) {
-	instData, err := getInstanceData(m.st, m.Id())
-	if err != nil {
-		return false, err
-	}
-	return instData.KeepInstance, nil
-}
-
 // CharmProfiles returns the names of any LXD profiles used by the machine,
 // which were defined in the charm deployed to that machine.
 func (m *Machine) CharmProfiles() ([]string, error) {

--- a/state/machine_test.go
+++ b/state/machine_test.go
@@ -85,19 +85,6 @@ func (s *MachineSuite) TestRecordAgentStartInformation(c *gc.C) {
 	c.Assert(s.machine.Hostname(), gc.Equals, "thundering-herds", gc.Commentf("expected the host name not be changed"))
 }
 
-func (s *MachineSuite) TestSetKeepInstance(c *gc.C) {
-	err := s.machine.SetProvisioned("1234", "", "nonce", nil)
-	c.Assert(err, jc.ErrorIsNil)
-	err = s.machine.SetKeepInstance(true)
-	c.Assert(err, jc.ErrorIsNil)
-
-	m, err := s.State.Machine(s.machine.Id())
-	c.Assert(err, jc.ErrorIsNil)
-	keep, err := m.KeepInstance()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(keep, jc.IsTrue)
-}
-
 func (s *MachineSuite) TestAddMachineInsideMachineModelDying(c *gc.C) {
 	model, err := s.State.Model()
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
This patch adds the functionality of keep-instance to the new machine domain.

Since the two methods `SetKeepInstance()` and `KeepInstance()` were only used in two facades, the call to the legacy state has been already deleted and therefore the entire functionality lives in Dqlite without the need for double writing.

_Note: Since this feature is so simple and self-contained, the whole functionality (from ddl changes to facades wiring) has been implemented in this only patch, without the need for any temporary double writes._

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

The keep-instance functionality must continue working as usual, no change expected even though the full functionality lives in dqlite now.

Example on lxd:

```
juju bootstrap localhost c
juju add-model m
juju add-machine
lxc ls
+---------------+---------+-----------------------+------+-----------+-----------+
|     NAME      |  STATE  |         IPV4          | IPV6 |   TYPE    | SNAPSHOTS |
+---------------+---------+-----------------------+------+-----------+-----------+
| juju-365cdd-0 | RUNNING | 10.170.236.168 (eth0) |      | CONTAINER | 0         |
+---------------+---------+-----------------------+------+-----------+-----------+
| juju-616657-0 | RUNNING | 10.170.236.132 (eth0) |      | CONTAINER | 0         |
+---------------+---------+-----------------------+------+-----------+-----------+

juju remove-machine 0 --keep-instance
WARNING This command will perform the following actions:
will remove machine 0 (but retaining cloud instance)

Continue [y/N]? y
lxc ls
+---------------+---------+-----------------------+------+-----------+-----------+
|     NAME      |  STATE  |         IPV4          | IPV6 |   TYPE    | SNAPSHOTS |
+---------------+---------+-----------------------+------+-----------+-----------+
| juju-365cdd-0 | RUNNING | 10.170.236.168 (eth0) |      | CONTAINER | 0         |
+---------------+---------+-----------------------+------+-----------+-----------+
| juju-616657-0 | RUNNING | 10.170.236.132 (eth0) |      | CONTAINER | 0         |
+---------------+---------+-----------------------+------+-----------+-----------+
```
Then we add another machine and when we delete it without --keep-instance, we expect it to be removed from lxd.
```
juju add-machine
lxc ls
+---------------+---------+-----------------------+------+-----------+-----------+
|     NAME      |  STATE  |         IPV4          | IPV6 |   TYPE    | SNAPSHOTS |
+---------------+---------+-----------------------+------+-----------+-----------+
| juju-365cdd-0 | RUNNING | 10.170.236.168 (eth0) |      | CONTAINER | 0         |
+---------------+---------+-----------------------+------+-----------+-----------+
| juju-616657-0 | RUNNING | 10.170.236.132 (eth0) |      | CONTAINER | 0         |
+---------------+---------+-----------------------+------+-----------+-----------+
| juju-616657-1 | RUNNING | 10.170.236.27 (eth0)  |      | CONTAINER | 0         |
+---------------+---------+-----------------------+------+-----------+-----------+
juju remove-machine 1
WARNING This command will perform the following actions:
will remove machine 1

Continue [y/N]? y
lxc ls
+---------------+---------+-----------------------+------+-----------+-----------+
|     NAME      |  STATE  |         IPV4          | IPV6 |   TYPE    | SNAPSHOTS |
+---------------+---------+-----------------------+------+-----------+-----------+
| juju-365cdd-0 | RUNNING | 10.170.236.168 (eth0) |      | CONTAINER | 0         |
+---------------+---------+-----------------------+------+-----------+-----------+
| juju-616657-0 | RUNNING | 10.170.236.132 (eth0) |      | CONTAINER | 0         |
+---------------+---------+-----------------------+------+-----------+-----------+
```

## Links


**Jira card:** JUJU-6702

