### PR TITLE
fix: change revoke model permission from AddModel to Admin

### DIFF
--- a/core/permission/access.go
+++ b/core/permission/access.go
@@ -332,7 +332,7 @@ func (a Access) GreaterOfferAccessThan(access Access) bool {
 // * Read gets you NoAccess
 func modelRevoke(a Access) Access {
 	switch a {
-	case AddModelAccess:
+	case AdminAccess:
 		return WriteAccess
 	case WriteAccess:
 		return ReadAccess

--- a/core/permission/user_test.go
+++ b/core/permission/user_test.go
@@ -18,7 +18,7 @@ var validateRevokeAccessTest = []struct {
 	expected permission.Access
 }{
 	{
-		spec:     permission.AccessSpec{Target: permission.ID{ObjectType: permission.Model}, Access: permission.AddModelAccess},
+		spec:     permission.AccessSpec{Target: permission.ID{ObjectType: permission.Model}, Access: permission.AdminAccess},
 		expected: permission.WriteAccess,
 	}, {
 		spec:     permission.AccessSpec{Target: permission.ID{ObjectType: permission.Model}, Access: permission.WriteAccess},


### PR DESCRIPTION
The highest level model permission is Admin not AddModel which is for clouds.

This was causing the user integration tests to fail.
<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://docs.google.com/document/d/1SYUo9G7qZ_jdoVXpUVamS5VCgHmtZ0QA-wZxKoMS-C0 
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps
Run user integration tests
```
cd tests
./main.sh -v user
```


