### PR TITLE
feat: provider for credential

### DIFF
--- a/core/providertracker/provider_mock_test.go
+++ b/core/providertracker/provider_mock_test.go
@@ -13,6 +13,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	cloud "github.com/juju/juju/cloud"
 	constraints "github.com/juju/juju/core/constraints"
 	environs "github.com/juju/juju/environs"
 	config "github.com/juju/juju/environs/config"
@@ -371,6 +372,45 @@ func (c *MockProviderDestroyControllerCall) Do(f func(envcontext.ProviderCallCon
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockProviderDestroyControllerCall) DoAndReturn(f func(envcontext.ProviderCallContext, string) error) *MockProviderDestroyControllerCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// ForCredential mocks base method.
+func (m *MockProvider) ForCredential(arg0 context.Context, arg1 cloud.Credential) (Provider, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ForCredential", arg0, arg1)
+	ret0, _ := ret[0].(Provider)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ForCredential indicates an expected call of ForCredential.
+func (mr *MockProviderMockRecorder) ForCredential(arg0, arg1 any) *MockProviderForCredentialCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForCredential", reflect.TypeOf((*MockProvider)(nil).ForCredential), arg0, arg1)
+	return &MockProviderForCredentialCall{Call: call}
+}
+
+// MockProviderForCredentialCall wrap *gomock.Call
+type MockProviderForCredentialCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockProviderForCredentialCall) Return(arg0 Provider, arg1 error) *MockProviderForCredentialCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockProviderForCredentialCall) Do(f func(context.Context, cloud.Credential) (Provider, error)) *MockProviderForCredentialCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockProviderForCredentialCall) DoAndReturn(f func(context.Context, cloud.Credential) (Provider, error)) *MockProviderForCredentialCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/providertracker/provider.go
+++ b/internal/worker/providertracker/provider.go
@@ -1,0 +1,154 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package providertracker
+
+import (
+	"context"
+
+	"github.com/juju/juju/caas"
+	jujucloud "github.com/juju/juju/cloud"
+	"github.com/juju/juju/core/providertracker"
+	"github.com/juju/juju/environs"
+	environscloudspec "github.com/juju/juju/environs/cloudspec"
+	"github.com/juju/juju/internal/errors"
+	"github.com/juju/juju/internal/uuid"
+)
+
+// Provider is an interface that represents a provider, this can either be
+// a CAAS broker or IAAS provider.
+type Provider = providertracker.Provider
+
+// ProviderConfigGetter is an interface that extends
+// environs.EnvironConfigGetter to include the ControllerUUID method.
+type ProviderConfigGetter interface {
+	environs.EnvironConfigGetter
+
+	// ControllerUUID returns the UUID of the controller.
+	ControllerUUID() uuid.UUID
+
+	// ForCredential returns a new cloned provider with the given
+	// credential.
+	ForCredential(jujucloud.Credential) ProviderConfigGetter
+}
+
+// IAASGetProvider creates a new provider from the given args.
+func IAASGetProvider(newProvider IAASProviderFunc) func(ctx context.Context, getter ProviderConfigGetter) (Provider, environscloudspec.CloudSpec, error) {
+	return func(ctx context.Context, getter ProviderConfigGetter) (Provider, environscloudspec.CloudSpec, error) {
+		// We can't use newProvider directly, as type invariance prevents us
+		// from using it with the environs.GetEnvironAndCloud function.
+		// Just wrap it in a closure to work around this.
+		provider, spec, err := environs.GetEnvironAndCloud(ctx, getter, func(ctx context.Context, op environs.OpenParams) (environs.Environ, error) {
+			return newProvider(ctx, op)
+		})
+		if err != nil {
+			return nil, environscloudspec.CloudSpec{}, err
+		}
+		return newForkableIAASProvider(provider, newProvider, getter), *spec, nil
+	}
+}
+
+// CAASGetProvider creates a new provider from the given args.
+func CAASGetProvider(newProvider CAASProviderFunc) func(ctx context.Context, getter ProviderConfigGetter) (Provider, environscloudspec.CloudSpec, error) {
+	return func(ctx context.Context, getter ProviderConfigGetter) (Provider, environscloudspec.CloudSpec, error) {
+		cloudSpec, err := getter.CloudSpec(ctx)
+		if err != nil {
+			return nil, environscloudspec.CloudSpec{}, errors.Errorf("cannot get cloud information: %w", err)
+		}
+
+		cfg, err := getter.ModelConfig(ctx)
+		if err != nil {
+			return nil, environscloudspec.CloudSpec{}, err
+		}
+
+		broker, err := newProvider(ctx, environs.OpenParams{
+			ControllerUUID: getter.ControllerUUID().String(),
+			Cloud:          cloudSpec,
+			Config:         cfg,
+		})
+		if err != nil {
+			return nil, environscloudspec.CloudSpec{}, errors.Errorf("cannot create caas broker: %w", err)
+		}
+		return newForkableCAASProvider(broker, newProvider, getter), cloudSpec, nil
+	}
+}
+
+type forkableIAASProvider struct {
+	environs.Environ
+	newProvider  IAASProviderFunc
+	configGetter ProviderConfigGetter
+}
+
+func newForkableIAASProvider(environ environs.Environ, newProvider IAASProviderFunc, getter ProviderConfigGetter) *forkableIAASProvider {
+	return &forkableIAASProvider{
+		Environ:      environ,
+		newProvider:  newProvider,
+		configGetter: getter,
+	}
+}
+
+// ForCredential returns a new cloned forked provider with the given
+// credential.
+func (p *forkableIAASProvider) ForCredential(ctx context.Context, cred jujucloud.Credential) (Provider, error) {
+	provider, _, err := environs.GetEnvironAndCloud(ctx, p.configGetter.ForCredential(cred), func(ctx context.Context, op environs.OpenParams) (environs.Environ, error) {
+		return p.newProvider(ctx, op)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return newForkableIAASProvider(provider, p.newProvider, p.configGetter), nil
+}
+
+// EnvironProvider returns the underlying provider.
+func (p *forkableIAASProvider) EnvironProvider() providertracker.EnvironProvider {
+	return p.Environ
+}
+
+type forkableCAASProvider struct {
+	caas.Broker
+	newProvider  CAASProviderFunc
+	configGetter ProviderConfigGetter
+}
+
+func newForkableCAASProvider(broker caas.Broker, newProvider CAASProviderFunc, getter ProviderConfigGetter) *forkableCAASProvider {
+	return &forkableCAASProvider{
+		Broker:       broker,
+		newProvider:  newProvider,
+		configGetter: getter,
+	}
+}
+
+// ForCredential returns a new cloned forked provider with the given
+// credential.
+func (p *forkableCAASProvider) ForCredential(ctx context.Context, cred jujucloud.Credential) (Provider, error) {
+	cloudSpec, err := p.configGetter.CloudSpec(ctx)
+	if err != nil {
+		return nil, errors.Errorf("cannot get cloud information: %w", err)
+	}
+
+	cfg, err := p.configGetter.ModelConfig(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	broker, err := p.newProvider(ctx, environs.OpenParams{
+		ControllerUUID: p.configGetter.ControllerUUID().String(),
+		Cloud:          cloudSpec,
+		Config:         cfg,
+	})
+	if err != nil {
+		return nil, errors.Errorf("cannot create caas broker: %w", err)
+	}
+	return newForkableCAASProvider(broker, p.newProvider, p.configGetter), nil
+}
+
+// EnvironProvider returns the underlying provider.
+func (p *forkableCAASProvider) EnvironProvider() providertracker.EnvironProvider {
+	return p.Broker
+}
+
+// environProvider returns the underlying provider.
+type environProvider interface {
+	// EnvironProvider returns the underlying provider.
+	EnvironProvider() providertracker.EnvironProvider
+}


### PR DESCRIPTION
To work on a provider with a temporary credential, we need to be able to fork the current provider to allow only working and validate on a credential. The provider will then be thrown away after the credential has been verified.

It's possible to just call this out of band, but we then loose the ability to just have one location for the environs.

There are some limitations with doing this, like the onus is on the use to correctly handle the provider and to relinquish the it once it's done.

<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://docs.google.com/document/d/1SYUo9G7qZ_jdoVXpUVamS5VCgHmtZ0QA-wZxKoMS-C0 
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

<!-- Describe steps to verify that the change works. -->

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/

**Jira card:** JUJU-

