### PR TITLE
refactor: replace MongoModelWatcher in caasagent facade

### DIFF
--- a/apiserver/facades/agent/caasagent/caasagent.go
+++ b/apiserver/facades/agent/caasagent/caasagent.go
@@ -11,6 +11,6 @@ import (
 // FacadeV2 is the V2 facade of the caas agent
 type FacadeV2 struct {
 	cloudspec.CloudSpecer
-	*common.MongoModelWatcher
+	*common.ModelWatcher
 	*common.ControllerConfigAPI
 }

--- a/apiserver/facades/agent/caasagent/register.go
+++ b/apiserver/facades/agent/caasagent/register.go
@@ -47,8 +47,8 @@ func newStateFacadeV2(ctx facade.ModelContext) (*FacadeV2, error) {
 		common.AuthFuncForTag(model.ModelTag()),
 	)
 	return &FacadeV2{
-		CloudSpecer:       cloudSpecAPI,
-		MongoModelWatcher: common.NewMongoModelWatcher(model, resources),
+		CloudSpecer:  cloudSpecAPI,
+		ModelWatcher: common.NewModelWatcher(serviceFactory.Config(), ctx.WatcherRegistry()),
 		ControllerConfigAPI: common.NewControllerConfigAPI(
 			ctx.State(),
 			serviceFactory.ControllerConfig(),


### PR DESCRIPTION
The MongoModelWatcher sources the model config from Mongo. As part of our effort to move model config off Mongo, we replace this with *common.ModelWatcher, which uses dqlite services.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- ~[ ] Comments saying why design decisions were made~
- ~[ ] Go unit tests, with comments saying what you're testing~
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Check that the CAAS broker picks up model config changes.

```
make microk8s-operator-update
juju bootstrap microk8s c --config logging-config='juju.worker.caas=DEBUG'
juju switch controller
juju model-config [any-key]=[any-value]
```

Check the debug log for the following line:
```console
$ juju debug-log --replay --include-module juju.worker.caas
model-ddc35d77-d62c-4fd9-807d-477b0a4bd478: 10:14:52 DEBUG juju.worker.caas reloading model config
```

## Links

**Jira card:** [JUJU-6685](https://warthogs.atlassian.net/browse/JUJU-6685)

[JUJU-6685]: https://warthogs.atlassian.net/browse/JUJU-6685?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ