### PR TITLE
fix(dqlite): force watcher kill to be done before DB teardown

### DIFF
--- a/apiserver/facades/agent/reboot/reboot_test.go
+++ b/apiserver/facades/agent/reboot/reboot_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/juju/clock"
 	"github.com/juju/names/v5"
+	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v4/workertest"
 	gc "gopkg.in/check.v1"
@@ -50,6 +51,7 @@ var (
 )
 
 type rebootSuite struct {
+	testing.CleanupSuite
 	jujutesting.ApiServerSuite
 	changestreamtesting.ModelSuite
 
@@ -115,18 +117,22 @@ func (s *rebootSuite) setupMachine(c *gc.C, tag names.MachineTag, err error, uui
 }
 
 func (s *rebootSuite) SetUpSuite(c *gc.C) {
+	s.CleanupSuite.SetUpSuite(c)
 	s.ModelSuite.SetUpSuite(c)
 	s.ApiServerSuite.SetUpSuite(c)
 }
 
 func (s *rebootSuite) SetUpTest(c *gc.C) {
+	s.CleanupSuite.SetUpTest(c)
 	s.ModelSuite.SetUpTest(c)
 	s.ApiServerSuite.SetUpTest(c)
 
 	var err error
 	s.watcherRegistry, err = registry.NewRegistry(clock.WallClock)
 	c.Assert(err, jc.ErrorIsNil)
-	s.AddCleanup(func(c *gc.C) { workertest.DirtyKill(c, s.watcherRegistry) })
+	s.AddCleanup(func(c *gc.C) {
+		workertest.DirtyKill(c, s.watcherRegistry)
+	})
 
 	factory := changestream.NewWatchableDBFactoryForNamespace(s.GetWatchableDB, "machine")
 	s.machineService = service.NewWatchableService(
@@ -140,11 +146,14 @@ func (s *rebootSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *rebootSuite) TearDownTest(c *gc.C) {
+
+	s.CleanupSuite.TearDownTest(c)
 	s.ApiServerSuite.TearDownTest(c)
 	s.ModelSuite.TearDownTest(c)
 }
 
 func (s *rebootSuite) TearDownSuite(c *gc.C) {
+	s.CleanupSuite.TearDownSuite(c)
 	s.ApiServerSuite.TearDownSuite(c)
 	s.ModelSuite.TearDownSuite(c)
 }


### PR DESCRIPTION
- Before this commit, killing machine watchers was done using Cleanup function from CleanupTestSuite embedded into ModelTestSuit. It causes issues because those function are called after the DB teardown, which may cause a datarace between both cleanup.
- After this commit, killing machine watchers is done before any teardown, adding a local CleanupSuite where we control the order of deletion.

This is an alternative version of this PR : https://github.com/juju/juju/pull/18059

