### PR TITLE
feat: add integration test for external users permission

### DIFF
--- a/tests/suites/user/manage.sh
+++ b/tests/suites/user/manage.sh
@@ -40,6 +40,65 @@ run_user_grant_revoke() {
 	destroy_model "user-grant-revoke"
 }
 
+# Granting and revoking read/write/admins rights for external users including
+# the special everyone@external user.
+run_user_grant_revoke_external() {
+	# Echo out to ensure nice output to the test suite.
+	echo
+
+	# The following ensures that a bootstrap juju exists.
+	file="${TEST_DIR}/test-user-grant-revoke-external.log"
+	ensure "user-grant-revoke-external" "${file}"
+
+	echo "Check that current user is admin"
+	juju whoami --format=json | jq -r '."user"' | check "admin"
+
+	echo "Check that the everyone@external user has been created on bootstrap"
+	juju show-user everyone@external --format=json | jq -r '."user-name"' | check "everyone@external"
+	echo "Check that the everyone@external user has no permissions"
+	juju users --format=json | jq -r '.[] | select(."user-name"=="everyone@external") | ."access"' | check ""
+
+	echo "Add an external user with no permission"
+	# Grant the user login permissions and immediately revoke them. Granting an
+	# external user permissions is the only way to add the user.
+	juju grant nopermuser@external login
+	juju revoke nopermuser@external login
+	echo "Add an external user with login permissions"
+	juju grant loginuser@external login
+	echo "Add an external user with superuser permissions"
+	juju grant superuser@external superuser
+
+	echo "Check rights for added users"
+	juju users --format=json | jq -r '.[] | select(."user-name"=="nopermuser@external") | ."access"' | check ""
+	juju users --format=json | jq -r '.[] | select(."user-name"=="loginuser@external") | ."access"' | check "login"
+	juju users --format=json | jq -r '.[] | select(."user-name"=="superuser@external") | ."access"' | check "superuser"
+
+	echo "Grant everyone@external login permissions"
+	juju grant everyone@external "login"
+
+	echo "Check that external users inherit the permissions"
+	juju users --format=json | jq -r '.[] | select(."user-name"=="everyone@external") | ."access"' | check "login"
+	juju users --format=json | jq -r '.[] | select(."user-name"=="nopermuser@external") | ."access"' | check "login"
+	juju users --format=json | jq -r '.[] | select(."user-name"=="loginuser@external") | ."access"' | check "login"
+	juju users --format=json | jq -r '.[] | select(."user-name"=="superuser@external") | ."access"' | check "superuser"
+
+	echo "Revoke login permission of everyone@external"
+	juju revoke everyone@external login
+
+	echo "Check that external users have their original permissions"
+	juju users --format=json | jq -r '.[] | select(."user-name"=="everyone@external") | ."access"' | check ""
+	juju users --format=json | jq -r '.[] | select(."user-name"=="nopermuser@external") | ."access"' | check ""
+	juju users --format=json | jq -r '.[] | select(."user-name"=="loginuser@external") | ."access"' | check "login"
+	juju users --format=json | jq -r '.[] | select(."user-name"=="superuser@external") | ."access"' | check "superuser"
+
+	echo "Remove added users"
+	juju remove-user -y nopermuser@external
+	juju remove-user -y loginuser@external
+	juju remove-user -y superuser@external
+
+	destroy_model "user-grant-revoke-external"
+}
+
 # Disabling and enabling users.
 run_user_disable_enable() {
 	# Echo out to ensure nice output to the test suite.
@@ -144,6 +203,7 @@ test_user_manage() {
 		cd .. || exit
 
 		run "run_user_grant_revoke"
+		run "run_user_grant_revoke_external"
 		run "run_user_disable_enable"
 		run "run_user_controller_access"
 		run "run_user_remove"


### PR DESCRIPTION
This integration test checks that external users inherit permissions from everyone@external. This was previously untested behvaiour.

Note that these tests are only added to 4.0 because of subtitles in the way external users are handled. In 4.0 granting permissions to an external user creates the user on the controller. In 3.x this was not the case. The permission was added with corresponding user in the users collection. In 4.0 there is referential integrity (foreign keys) which mean we have to add these users when permissions are granted to them.
<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://docs.google.com/document/d/1SYUo9G7qZ_jdoVXpUVamS5VCgHmtZ0QA-wZxKoMS-C0 
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps
```
cd tests
./main.sh -v user run_user_grant_revoke_external
```

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Jira card:** [JUJU-6712](https://warthogs.atlassian.net/browse/JUJU-6712)

