### PR TITLE
feat(port): add domain methods for app ports

### DIFF
--- a/domain/port/service/package_mock_test.go
+++ b/domain/port/service/package_mock_test.go
@@ -41,6 +41,45 @@ func (m *MockState) EXPECT() *MockStateMockRecorder {
 	return m.recorder
 }
 
+// GetApplicationOpenedPorts mocks base method.
+func (m *MockState) GetApplicationOpenedPorts(arg0 context.Context, arg1 string) (map[string]network.GroupedPortRanges, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetApplicationOpenedPorts", arg0, arg1)
+	ret0, _ := ret[0].(map[string]network.GroupedPortRanges)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetApplicationOpenedPorts indicates an expected call of GetApplicationOpenedPorts.
+func (mr *MockStateMockRecorder) GetApplicationOpenedPorts(arg0, arg1 any) *MockStateGetApplicationOpenedPortsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetApplicationOpenedPorts", reflect.TypeOf((*MockState)(nil).GetApplicationOpenedPorts), arg0, arg1)
+	return &MockStateGetApplicationOpenedPortsCall{Call: call}
+}
+
+// MockStateGetApplicationOpenedPortsCall wrap *gomock.Call
+type MockStateGetApplicationOpenedPortsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateGetApplicationOpenedPortsCall) Return(arg0 map[string]network.GroupedPortRanges, arg1 error) *MockStateGetApplicationOpenedPortsCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateGetApplicationOpenedPortsCall) Do(f func(context.Context, string) (map[string]network.GroupedPortRanges, error)) *MockStateGetApplicationOpenedPortsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateGetApplicationOpenedPortsCall) DoAndReturn(f func(context.Context, string) (map[string]network.GroupedPortRanges, error)) *MockStateGetApplicationOpenedPortsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetColocatedOpenedPorts mocks base method.
 func (m *MockState) GetColocatedOpenedPorts(arg0 domain.AtomicContext, arg1 string) ([]network.PortRange, error) {
 	m.ctrl.T.Helper()

--- a/domain/port/service/service.go
+++ b/domain/port/service/service.go
@@ -48,8 +48,13 @@ type State interface {
 	GetUnitOpenedPorts(ctx context.Context, unitUUID string) (network.GroupedPortRanges, error)
 
 	// GetMachineOpenedPorts returns the opened ports for all the units on the
-	// machine. Opened ports are grouped first by unit and then by endpoint.
+	// given machine. Opened ports are grouped first by unit and then by endpoint.
 	GetMachineOpenedPorts(ctx context.Context, machineUUID string) (map[string]network.GroupedPortRanges, error)
+
+	// GetApplicationOpenedPorts returns the opened ports for all the units of
+	// the given application. Opened ports are grouped first by unit and then by
+	// endpoint.
+	GetApplicationOpenedPorts(ctx context.Context, applicationUUID string) (map[string]network.GroupedPortRanges, error)
 }
 
 // Service provides the API for managing the opened ports for units.
@@ -65,7 +70,8 @@ func NewService(st State) *Service {
 	}
 }
 
-// GetUnitOpenedPorts returns the opened ports for a given unit uuid, grouped by endpoint.
+// GetUnitOpenedPorts returns the opened ports for a given unit uuid, grouped by
+// endpoint.
 func (s *Service) GetUnitOpenedPorts(ctx context.Context, unitUUID string) (network.GroupedPortRanges, error) {
 	return s.st.GetUnitOpenedPorts(ctx, unitUUID)
 }
@@ -74,6 +80,57 @@ func (s *Service) GetUnitOpenedPorts(ctx context.Context, unitUUID string) (netw
 // Opened ports are grouped first by unit and then by endpoint.
 func (s *Service) GetMachineOpenedPorts(ctx context.Context, machineUUID string) (map[string]network.GroupedPortRanges, error) {
 	return s.st.GetMachineOpenedPorts(ctx, machineUUID)
+}
+
+// GetApplicationOpenedPorts returns the opened ports for all the units of the
+// application. Opened ports are grouped first by unit and then by endpoint.
+func (s *Service) GetApplicationOpenedPorts(ctx context.Context, applicationUUID string) (map[string]network.GroupedPortRanges, error) {
+	return s.st.GetApplicationOpenedPorts(ctx, applicationUUID)
+}
+
+// GetApplicationOpenedPortsByEndpoint returns all the opened ports for the given
+// application, across all units, grouped by endpoint.
+//
+// NOTE: The returned port ranges are atomised, meaning that each port range
+// we guarantee that each port range is of unit length. This is useful for
+// down-stream consumers such as k8s, which can only reason with unit-length
+// port ranges.
+func (s *Service) GetApplicationOpenedPortsByEndpoint(ctx context.Context, applicationUUID string) (network.GroupedPortRanges, error) {
+	openedPorts, err := s.st.GetApplicationOpenedPorts(ctx, applicationUUID)
+	if err != nil {
+		return nil, err
+	}
+	ret := network.GroupedPortRanges{}
+
+	// combine port ranges across all units & atomise the port ranges
+	for _, grp := range openedPorts {
+		for endpoint, portRanges := range grp {
+			for _, portRange := range portRanges {
+				ret[endpoint] = append(ret[endpoint], atomisePortRange(portRange)...)
+			}
+		}
+	}
+
+	// de-dupe our port ranges
+	for endpoint, portRanges := range ret {
+		ret[endpoint] = network.UniquePortRanges(portRanges)
+	}
+
+	return ret, nil
+}
+
+// atomisePortRange breaks down the input port range into a slice of unit-length
+// port ranges.
+func atomisePortRange(portRange network.PortRange) []network.PortRange {
+	ret := make([]network.PortRange, portRange.Length())
+	for i := 0; i < portRange.Length(); i++ {
+		ret[i] = network.PortRange{
+			Protocol: portRange.Protocol,
+			FromPort: portRange.FromPort + i,
+			ToPort:   portRange.FromPort + i,
+		}
+	}
+	return ret
 }
 
 // UpdateUnitPorts opens and closes ports for the endpoints of a given unit.

--- a/domain/port/service/service_test.go
+++ b/domain/port/service/service_test.go
@@ -25,6 +25,7 @@ var _ = gc.Suite(&serviceSuite{})
 const (
 	unitUUID    = "unit-uuid"
 	machineUUID = "machine-uuid"
+	appUUID     = "app-uuid"
 )
 
 func (s *serviceSuite) setupMocks(c *gc.C) *gomock.Controller {
@@ -55,7 +56,7 @@ func (s *serviceSuite) TestGetUnitOpenedPorts(c *gc.C) {
 
 	srv := NewService(s.st)
 	res, err := srv.GetUnitOpenedPorts(context.Background(), unitUUID)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(res, gc.DeepEquals, grp)
 }
 
@@ -83,8 +84,118 @@ func (s *serviceSuite) TestGetMachineOpenedPorts(c *gc.C) {
 
 	srv := NewService(s.st)
 	res, err := srv.GetMachineOpenedPorts(context.Background(), machineUUID)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(res, gc.DeepEquals, grp)
+}
+
+func (s *serviceSuite) TestGetApplicationOpenedPorts(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	grp := map[string]network.GroupedPortRanges{
+		"unit-uuid-1": {
+			"ep1": {
+				network.MustParsePortRange("80/tcp"),
+				network.MustParsePortRange("443/tcp"),
+			},
+			"ep2": {
+				network.MustParsePortRange("8000-9000/udp"),
+			},
+		},
+		"unit-uuid-2": {
+			"ep3": {
+				network.MustParsePortRange("8080/tcp"),
+			},
+		},
+	}
+
+	s.st.EXPECT().GetApplicationOpenedPorts(gomock.Any(), appUUID).Return(grp, nil)
+
+	srv := NewService(s.st)
+	res, err := srv.GetApplicationOpenedPorts(context.Background(), appUUID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(res, gc.DeepEquals, grp)
+}
+
+func (s *serviceSuite) TestGetApplicationOpenedPortsByEndpoint(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	grp := map[string]network.GroupedPortRanges{
+		"unit-uuid-1": {
+			"ep1": {
+				network.MustParsePortRange("80/tcp"),
+				network.MustParsePortRange("443/tcp"),
+			},
+			"ep2": {
+				network.MustParsePortRange("8000-8005/udp"),
+			},
+		},
+		"unit-uuid-2": {
+			"ep1": {
+				network.MustParsePortRange("8080/tcp"),
+			},
+		},
+	}
+
+	s.st.EXPECT().GetApplicationOpenedPorts(gomock.Any(), appUUID).Return(grp, nil)
+
+	expected := network.GroupedPortRanges{
+		"ep1": {
+			network.MustParsePortRange("80/tcp"),
+			network.MustParsePortRange("443/tcp"),
+			network.MustParsePortRange("8080/tcp"),
+		},
+		"ep2": {
+			network.MustParsePortRange("8000/udp"),
+			network.MustParsePortRange("8001/udp"),
+			network.MustParsePortRange("8002/udp"),
+			network.MustParsePortRange("8003/udp"),
+			network.MustParsePortRange("8004/udp"),
+			network.MustParsePortRange("8005/udp"),
+		},
+	}
+
+	srv := NewService(s.st)
+	res, err := srv.GetApplicationOpenedPortsByEndpoint(context.Background(), appUUID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(res, gc.DeepEquals, expected)
+}
+
+func (s serviceSuite) TestGetApplicationOpenedPortsByEndpointOverlap(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	grp := map[string]network.GroupedPortRanges{
+		"unit-uuid-1": {
+			"ep1": {
+				network.MustParsePortRange("80-85/tcp"),
+			},
+		},
+		"unit-uuid-2": {
+			"ep1": {
+				network.MustParsePortRange("83-88/tcp"),
+			},
+		},
+	}
+
+	s.st.EXPECT().GetApplicationOpenedPorts(gomock.Any(), appUUID).Return(grp, nil)
+
+	expected := network.GroupedPortRanges{
+		"ep1": {
+			network.MustParsePortRange("80/tcp"),
+			network.MustParsePortRange("81/tcp"),
+			network.MustParsePortRange("82/tcp"),
+			network.MustParsePortRange("83/tcp"),
+			network.MustParsePortRange("84/tcp"),
+			network.MustParsePortRange("85/tcp"),
+			network.MustParsePortRange("86/tcp"),
+			network.MustParsePortRange("87/tcp"),
+			network.MustParsePortRange("88/tcp"),
+		},
+	}
+
+	srv := NewService(s.st)
+	res, err := srv.GetApplicationOpenedPortsByEndpoint(context.Background(), appUUID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(res, gc.DeepEquals, expected)
 }
 
 func (s *serviceSuite) TestUpdateUnitPorts(c *gc.C) {
@@ -112,7 +223,7 @@ func (s *serviceSuite) TestUpdateUnitPorts(c *gc.C) {
 
 	srv := NewService(s.st)
 	err := srv.UpdateUnitPorts(context.Background(), unitUUID, openPorts, closePorts)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *serviceSuite) TestUpdateUnitPortsNoChanges(c *gc.C) {

--- a/domain/port/state/state_test.go
+++ b/domain/port/state/state_test.go
@@ -28,6 +28,8 @@ type stateSuite struct {
 
 	unitUUID  string
 	unitCount int
+
+	appUUID string
 }
 
 var _ = gc.Suite(&stateSuite{})
@@ -35,6 +37,7 @@ var _ = gc.Suite(&stateSuite{})
 const (
 	mUUID       = "machine-uuid"
 	netNodeUUID = "net-node-uuid"
+	appName     = "app-name"
 )
 
 func (s *stateSuite) SetUpTest(c *gc.C) {
@@ -44,30 +47,38 @@ func (s *stateSuite) SetUpTest(c *gc.C) {
 	err := machineSt.CreateMachine(context.Background(), "m", netNodeUUID, mUUID)
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.unitUUID = s.createUnit(c, netNodeUUID)
+	s.unitUUID, s.appUUID = s.createUnit(c, netNodeUUID, appName)
 }
 
 // createUnit creates a new unit in state and returns its UUID. The unit is assigned
 // to the net node with uuid `netNodeUUID`.
-func (s *stateSuite) createUnit(c *gc.C, netNodeUUID string) string {
+func (s *stateSuite) createUnit(c *gc.C, netNodeUUID, appName string) (string, string) {
 	applicationSt := applicationstate.NewApplicationState(s.TxnRunnerFactory(), logger.GetLogger("juju.test.application"))
-	_, err := applicationSt.CreateApplication(context.Background(), "app", application.AddApplicationArg{
+	_, err := applicationSt.CreateApplication(context.Background(), appName, application.AddApplicationArg{
 		Charm: charm.Charm{
 			Metadata: charm.Metadata{
-				Name: "app",
+				Name: appName,
 			},
 		},
 	})
 	c.Assert(err == nil || errors.Is(err, applicationerrors.ApplicationAlreadyExists), jc.IsTrue)
 
-	unitName := fmt.Sprintf("app/%d", s.unitCount)
-	err = applicationSt.AddUnits(context.Background(), "app", application.UpsertUnitArg{UnitName: &unitName})
+	unitName := fmt.Sprintf("%s/%d", appName, s.unitCount)
+	err = applicationSt.AddUnits(context.Background(), appName, application.UpsertUnitArg{UnitName: &unitName})
 	c.Assert(err, jc.ErrorIsNil)
 	s.unitCount++
 
-	var unitUUID string
+	var (
+		unitUUID string
+		appUUID  string
+	)
 	err = s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		err := tx.QueryRowContext(ctx, "SELECT uuid FROM unit WHERE name = ?", unitName).Scan(&unitUUID)
+		if err != nil {
+			return err
+		}
+
+		err = tx.QueryRowContext(ctx, "SELECT uuid FROM application WHERE name = ?", appName).Scan(&appUUID)
 		if err != nil {
 			return err
 		}
@@ -83,7 +94,7 @@ func (s *stateSuite) createUnit(c *gc.C, netNodeUUID string) string {
 		return nil
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	return unitUUID
+	return unitUUID, appUUID
 }
 
 func (s *stateSuite) initialiseOpenPort(c *gc.C, st *State) {
@@ -156,6 +167,7 @@ func (s *stateSuite) TestGetMachineOpenedPorts(c *gc.C) {
 
 	unit0PortRanges, ok := machineGroupedPortRanges[s.unitUUID]
 	c.Assert(ok, jc.IsTrue)
+	c.Check(unit0PortRanges, gc.HasLen, 2)
 
 	c.Check(unit0PortRanges["endpoint"], gc.HasLen, 2)
 	c.Check(unit0PortRanges["endpoint"][0], jc.DeepEquals, network.PortRange{Protocol: "tcp", FromPort: 80, ToPort: 80})
@@ -170,7 +182,7 @@ func (s *stateSuite) TestGetMachineOpenedPortsAcrossTwoUnits(c *gc.C) {
 	ctx := context.Background()
 	s.initialiseOpenPort(c, st)
 
-	unit1UUID := s.createUnit(c, netNodeUUID)
+	unit1UUID, _ := s.createUnit(c, netNodeUUID, appName)
 	err := st.RunAtomic(ctx, func(ctx domain.AtomicContext) error {
 		return st.UpdateUnitPorts(ctx, unit1UUID, network.GroupedPortRanges{
 			"endpoint": {
@@ -187,6 +199,7 @@ func (s *stateSuite) TestGetMachineOpenedPortsAcrossTwoUnits(c *gc.C) {
 
 	unit0PortRanges, ok := machineGroupedPortRanges[s.unitUUID]
 	c.Assert(ok, jc.IsTrue)
+	c.Check(unit0PortRanges, gc.HasLen, 2)
 
 	c.Check(unit0PortRanges["endpoint"], gc.HasLen, 2)
 	c.Check(unit0PortRanges["endpoint"][0], jc.DeepEquals, network.PortRange{Protocol: "tcp", FromPort: 80, ToPort: 80})
@@ -197,6 +210,169 @@ func (s *stateSuite) TestGetMachineOpenedPortsAcrossTwoUnits(c *gc.C) {
 
 	unit1PortRanges, ok := machineGroupedPortRanges[unit1UUID]
 	c.Assert(ok, jc.IsTrue)
+	c.Check(unit1PortRanges, gc.HasLen, 1)
+
+	c.Check(unit1PortRanges["endpoint"], gc.HasLen, 2)
+	c.Check(unit1PortRanges["endpoint"][0], jc.DeepEquals, network.PortRange{Protocol: "tcp", FromPort: 443, ToPort: 443})
+	c.Check(unit1PortRanges["endpoint"][1], jc.DeepEquals, network.PortRange{Protocol: "udp", FromPort: 2000, ToPort: 2500})
+}
+
+func (s *stateSuite) TestGetMachineOpenedPortsAcrossTwoUnitsDifferentMachines(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+	ctx := context.Background()
+	s.initialiseOpenPort(c, st)
+
+	machineSt := machinestate.NewState(s.TxnRunnerFactory(), logger.GetLogger("juju.test.machine"))
+	err := machineSt.CreateMachine(context.Background(), "m2", "net-node-uuid-2", "machine-uuid-2")
+	c.Assert(err, jc.ErrorIsNil)
+
+	unit1UUID, _ := s.createUnit(c, "net-node-uuid-2", appName)
+	err = st.RunAtomic(ctx, func(ctx domain.AtomicContext) error {
+		return st.UpdateUnitPorts(ctx, unit1UUID, network.GroupedPortRanges{
+			"endpoint": {
+				{Protocol: "tcp", FromPort: 443, ToPort: 443},
+				{Protocol: "udp", FromPort: 2000, ToPort: 2500},
+			},
+		}, network.GroupedPortRanges{})
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	machineGroupedPortRanges, err := st.GetMachineOpenedPorts(ctx, mUUID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(machineGroupedPortRanges, gc.HasLen, 1)
+
+	unit0PortRanges, ok := machineGroupedPortRanges[s.unitUUID]
+	c.Assert(ok, jc.IsTrue)
+	c.Check(unit0PortRanges, gc.HasLen, 2)
+
+	c.Check(unit0PortRanges["endpoint"], gc.HasLen, 2)
+	c.Check(unit0PortRanges["endpoint"][0], jc.DeepEquals, network.PortRange{Protocol: "tcp", FromPort: 80, ToPort: 80})
+	c.Check(unit0PortRanges["endpoint"][1], jc.DeepEquals, network.PortRange{Protocol: "udp", FromPort: 1000, ToPort: 1500})
+
+	c.Check(unit0PortRanges["misc"], gc.HasLen, 1)
+	c.Check(unit0PortRanges["misc"][0], jc.DeepEquals, network.PortRange{Protocol: "tcp", FromPort: 8080, ToPort: 8080})
+
+	machineGroupedPortRanges, err = st.GetMachineOpenedPorts(ctx, "machine-uuid-2")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(machineGroupedPortRanges, gc.HasLen, 1)
+
+	unit1PortRanges, ok := machineGroupedPortRanges[unit1UUID]
+	c.Assert(ok, jc.IsTrue)
+	c.Check(unit1PortRanges, gc.HasLen, 1)
+
+	c.Check(unit1PortRanges["endpoint"], gc.HasLen, 2)
+	c.Check(unit1PortRanges["endpoint"][0], jc.DeepEquals, network.PortRange{Protocol: "tcp", FromPort: 443, ToPort: 443})
+	c.Check(unit1PortRanges["endpoint"][1], jc.DeepEquals, network.PortRange{Protocol: "udp", FromPort: 2000, ToPort: 2500})
+}
+
+func (s *stateSuite) TestGetApplicationOpenedPortsBlankDB(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+	ctx := context.Background()
+
+	applicationGroupedPortRanges, err := st.GetApplicationOpenedPorts(ctx, "non-existent")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(applicationGroupedPortRanges, gc.HasLen, 0)
+}
+
+func (s *stateSuite) TestGetApplicationOpenedPorts(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+	ctx := context.Background()
+	s.initialiseOpenPort(c, st)
+
+	applicationGroupedPortRanges, err := st.GetApplicationOpenedPorts(ctx, s.appUUID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(applicationGroupedPortRanges, gc.HasLen, 1)
+
+	unit0PortRanges, ok := applicationGroupedPortRanges[s.unitUUID]
+	c.Assert(ok, jc.IsTrue)
+	c.Check(unit0PortRanges, gc.HasLen, 2)
+
+	c.Check(unit0PortRanges["endpoint"], gc.HasLen, 2)
+	c.Check(unit0PortRanges["endpoint"][0], jc.DeepEquals, network.PortRange{Protocol: "tcp", FromPort: 80, ToPort: 80})
+	c.Check(unit0PortRanges["endpoint"][1], jc.DeepEquals, network.PortRange{Protocol: "udp", FromPort: 1000, ToPort: 1500})
+
+	c.Check(unit0PortRanges["misc"], gc.HasLen, 1)
+	c.Check(unit0PortRanges["misc"][0], jc.DeepEquals, network.PortRange{Protocol: "tcp", FromPort: 8080, ToPort: 8080})
+}
+
+func (s *stateSuite) TestGetApplicationOpenedPortsAcrossTwoUnits(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+	ctx := context.Background()
+	s.initialiseOpenPort(c, st)
+
+	unit1UUID, _ := s.createUnit(c, "net-node-uuid-2", appName)
+	err := st.RunAtomic(ctx, func(ctx domain.AtomicContext) error {
+		return st.UpdateUnitPorts(ctx, unit1UUID, network.GroupedPortRanges{
+			"endpoint": {
+				{Protocol: "tcp", FromPort: 443, ToPort: 443},
+				{Protocol: "udp", FromPort: 2000, ToPort: 2500},
+			},
+		}, network.GroupedPortRanges{})
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	applicationGroupedPortRanges, err := st.GetApplicationOpenedPorts(ctx, s.appUUID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(applicationGroupedPortRanges, gc.HasLen, 2)
+
+	unit0PortRanges, ok := applicationGroupedPortRanges[s.unitUUID]
+	c.Assert(ok, jc.IsTrue)
+	c.Check(unit0PortRanges, gc.HasLen, 2)
+
+	c.Check(unit0PortRanges["endpoint"], gc.HasLen, 2)
+	c.Check(unit0PortRanges["endpoint"][0], jc.DeepEquals, network.PortRange{Protocol: "tcp", FromPort: 80, ToPort: 80})
+	c.Check(unit0PortRanges["endpoint"][1], jc.DeepEquals, network.PortRange{Protocol: "udp", FromPort: 1000, ToPort: 1500})
+
+	c.Check(unit0PortRanges["misc"], gc.HasLen, 1)
+	c.Check(unit0PortRanges["misc"][0], jc.DeepEquals, network.PortRange{Protocol: "tcp", FromPort: 8080, ToPort: 8080})
+
+	unit1PortRanges, ok := applicationGroupedPortRanges[unit1UUID]
+	c.Assert(ok, jc.IsTrue)
+	c.Check(unit1PortRanges, gc.HasLen, 1)
+
+	c.Check(unit1PortRanges["endpoint"], gc.HasLen, 2)
+	c.Check(unit1PortRanges["endpoint"][0], jc.DeepEquals, network.PortRange{Protocol: "tcp", FromPort: 443, ToPort: 443})
+	c.Check(unit1PortRanges["endpoint"][1], jc.DeepEquals, network.PortRange{Protocol: "udp", FromPort: 2000, ToPort: 2500})
+}
+
+func (s *stateSuite) TestGetApplicationOpenedPortsAcrossTwoUnitsDifferentApplications(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+	ctx := context.Background()
+	s.initialiseOpenPort(c, st)
+
+	unit1UUID, app2UUID := s.createUnit(c, "net-node-uuid-2", "app-name-2")
+	err := st.RunAtomic(ctx, func(ctx domain.AtomicContext) error {
+		return st.UpdateUnitPorts(ctx, unit1UUID, network.GroupedPortRanges{
+			"endpoint": {
+				{Protocol: "tcp", FromPort: 443, ToPort: 443},
+				{Protocol: "udp", FromPort: 2000, ToPort: 2500},
+			},
+		}, network.GroupedPortRanges{})
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	applicationGroupedPortRanges, err := st.GetApplicationOpenedPorts(ctx, s.appUUID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(applicationGroupedPortRanges, gc.HasLen, 1)
+
+	unit0PortRanges, ok := applicationGroupedPortRanges[s.unitUUID]
+	c.Assert(ok, jc.IsTrue)
+	c.Check(unit0PortRanges, gc.HasLen, 2)
+
+	c.Check(unit0PortRanges["endpoint"], gc.HasLen, 2)
+	c.Check(unit0PortRanges["endpoint"][0], jc.DeepEquals, network.PortRange{Protocol: "tcp", FromPort: 80, ToPort: 80})
+	c.Check(unit0PortRanges["endpoint"][1], jc.DeepEquals, network.PortRange{Protocol: "udp", FromPort: 1000, ToPort: 1500})
+
+	c.Check(unit0PortRanges["misc"], gc.HasLen, 1)
+	c.Check(unit0PortRanges["misc"][0], jc.DeepEquals, network.PortRange{Protocol: "tcp", FromPort: 8080, ToPort: 8080})
+
+	applicationGroupedPortRanges, err = st.GetApplicationOpenedPorts(ctx, app2UUID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(applicationGroupedPortRanges, gc.HasLen, 1)
+
+	unit1PortRanges, ok := applicationGroupedPortRanges[unit1UUID]
+	c.Assert(ok, jc.IsTrue)
+	c.Check(unit1PortRanges, gc.HasLen, 1)
 
 	c.Check(unit1PortRanges["endpoint"], gc.HasLen, 2)
 	c.Check(unit1PortRanges["endpoint"][0], jc.DeepEquals, network.PortRange{Protocol: "tcp", FromPort: 443, ToPort: 443})
@@ -226,7 +402,7 @@ func (s *stateSuite) TestGetColocatedOpenedPortsMultipleUnits(c *gc.C) {
 	ctx := context.Background()
 	s.initialiseOpenPort(c, st)
 
-	unit1UUID := s.createUnit(c, netNodeUUID)
+	unit1UUID, _ := s.createUnit(c, netNodeUUID, appName)
 	err := st.RunAtomic(ctx, func(ctx domain.AtomicContext) error {
 		return st.UpdateUnitPorts(ctx, unit1UUID, network.GroupedPortRanges{
 			"endpoint": {
@@ -257,7 +433,7 @@ func (s *stateSuite) TestGetColocatedOpenedPortsMultipleUnitsOnNetNodes(c *gc.C)
 	ctx := context.Background()
 	s.initialiseOpenPort(c, st)
 
-	unit1UUID := s.createUnit(c, "net-node-uuid-2")
+	unit1UUID, _ := s.createUnit(c, "net-node-uuid-2", appName)
 	err := st.RunAtomic(ctx, func(ctx domain.AtomicContext) error {
 		return st.UpdateUnitPorts(ctx, unit1UUID, network.GroupedPortRanges{
 			"endpoint": {
@@ -540,7 +716,7 @@ func (s *stateSuite) TestUpdateUnitPortRangesOpenAlreadyOpenAcrossUnits(c *gc.C)
 	st := NewState(s.TxnRunnerFactory())
 	ctx := context.Background()
 	s.initialiseOpenPort(c, st)
-	unit1UUID := s.createUnit(c, netNodeUUID)
+	unit1UUID, _ := s.createUnit(c, netNodeUUID, appName)
 
 	err := st.RunAtomic(ctx, func(ctx domain.AtomicContext) error {
 		return st.UpdateUnitPorts(ctx, s.unitUUID, network.GroupedPortRanges{"endpoint": {{Protocol: "udp", FromPort: 1000, ToPort: 1500}}}, network.GroupedPortRanges{})
@@ -564,6 +740,8 @@ func (s *stateSuite) TestUpdateUnitPortRangesOpenAlreadyOpenAcrossUnits(c *gc.C)
 
 	unit1PortRanges, ok := machineGroupedPortRanges[unit1UUID]
 	c.Assert(ok, jc.IsTrue)
+	c.Check(unit1PortRanges, gc.HasLen, 1)
+
 	c.Check(unit1PortRanges["endpoint"], gc.HasLen, 1)
 	c.Check(unit1PortRanges["endpoint"][0], jc.DeepEquals, network.PortRange{Protocol: "udp", FromPort: 1000, ToPort: 1500})
 }

--- a/domain/port/state/types.go
+++ b/domain/port/state/types.go
@@ -123,3 +123,8 @@ type unitUUID struct {
 type machineUUID struct {
 	UUID string `db:"machine_uuid"`
 }
+
+// applicationUUID represents an application's UUID.
+type applicationUUID struct {
+	UUID string `db:"application_uuid"`
+}


### PR DESCRIPTION
We need two methods. One which simply returns opened ports by unit, by endpoint for an application. This will be used for model migration

And another, which will be used by the caasfirewaller api, which groups all opened port ranges on an application by endpoint only, and atomises the port ranges.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Unit tests pass