### PR TITLE
ci: increase build runners size to xxlarge

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   build:
     name: Build
-    runs-on: [self-hosted, linux, "${{ matrix.platform.host_arch }}", aws, large]
+    runs-on: [self-hosted, linux, "${{ matrix.platform.host_arch }}", aws, xxlarge]
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Builds on main are taking 18-19 minutes these days, more than the 15 minute target. This can slow down developer/PR velocity. Increase the size of the runner to hopefully speed up the build.

## QA steps

'Build' GitHub job below should finish in less than 15 minutes.