### PR TITLE
chore: remove lease introspection commands

### DIFF
--- a/worker/introspection/script.go
+++ b/worker/introspection/script.go
@@ -192,66 +192,6 @@ juju_start_unit () {
   juju_agent --post units action=start $args
 }
 
-juju_leases () {
-  # This requires some arguments.
-  local query
-  local model
-  if [ "$1" = "-m" ]; then
-    if [ "$#" -lt 2 ]; then
-      echo "usage: juju_leases [-m <partial-model-uuid>] [<partial-app-name>...]"
-      return 1
-    fi
-    shift
-    model=$1
-    shift
-    query="&model=$model"
-  fi
-  for i in "$@"; do
-    query="$query&app=$i"
-  done
-  if [ -z "$query" ]; then
-    juju_agent leases
-  else
-    juju_agent "leases?q=y&$query"
-  fi
-}
-
-juju_revoke_lease () {
-  # This requires some arguments.
-  local model
-  local lease
-  local ns
-
-  while [[ $# -gt 0 ]]
-  do
-    key="$1"
-
-    case $key in
-      -m|--model)
-        model="$2"; shift; shift
-      ;;
-      -n|--ns)
-        ns="$2"; shift; shift
-      ;;
-      -l|--lease)
-        lease="$2"; shift; shift
-      ;;
-      *)
-        echo "usage: juju_revoke_lease -m <model-uuid> -l <lease> [-n <namespace>]"
-        return 1
-      ;;
-    esac
-  done
-
-  if [ -z "$model" ] | [ -z "$lease" ]; then
-    echo "usage: juju_revoke_lease -m <model-uuid> -l <lease> [-n <namespace>]"
-    return 1
-  fi  
-
-  juju_agent --post leases/revoke model="$model" lease="$lease" ns="$ns"
-}
-
-
 # This asks for the command of the current pid.
 # Can't use $0 nor $SHELL due to this being wrong in various situations.
 shell=$(ps -p "$$" -o comm --no-headers)
@@ -274,7 +214,5 @@ if [ "$shell" = "bash" ]; then
   export -f juju_unit_status
   export -f juju_start_unit
   export -f juju_stop_unit
-  export -f juju_leases
-  export -f juju_revoke_lease
 fi
 `


### PR DESCRIPTION
The lease introspection API handler was removed when we moved to dqlite-backed leases. To list leases, it is expected to look at the controller database lease table. It's possible to then revoke a lease by manipulating the database, even though it's not advised.

This was spotted in an introspection demo.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing


## QA steps

```sh
$ juju bootstrap lxd test
$ juju ssh -m controller 0
```

