### PR TITLE
feat(machine): support machine cloud instance model migration 

### DIFF
--- a/domain/machine/modelmigration/export.go
+++ b/domain/machine/modelmigration/export.go
@@ -8,11 +8,13 @@ import (
 
 	"github.com/juju/description/v8"
 
+	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/logger"
 	coremachine "github.com/juju/juju/core/machine"
 	"github.com/juju/juju/core/modelmigration"
 	"github.com/juju/juju/domain/machine/service"
 	"github.com/juju/juju/domain/machine/state"
+	"github.com/juju/juju/internal/errors"
 )
 
 // RegisterExport registers the export operations with the given coordinator.
@@ -22,19 +24,29 @@ func RegisterExport(coordinator Coordinator, logger logger.Logger) {
 	})
 }
 
-// ExportService provides a subset of the machine domain
-// service methods needed for machine export.
+// ExportService defines the machine service used to export machines to
+// another controller model to this controller.
 type ExportService interface {
+	// AllMachineNames returns the names of all machines in the model.
 	AllMachineNames(ctx context.Context) ([]coremachine.Name, error)
+	// InstanceID returns the cloud specific instance id for this machine.
+	// If the machine is not provisioned, it returns a NotProvisionedError.
+	InstanceID(ctx context.Context, machineUUID string) (string, error)
+	// HardwareCharacteristics returns the hardware characteristics of the
+	// of the specified machine.
+	HardwareCharacteristics(ctx context.Context, machineUUID string) (*instance.HardwareCharacteristics, error)
+	// GetMachineUUID returns the UUID of a machine identified by its name.
+	// It returns a MachineNotFound if the machine does not exist.
+	GetMachineUUID(ctx context.Context, name coremachine.Name) (string, error)
 }
 
 // exportOperation describes a way to execute a migration for
-// exporting machines.
+// exporting external controllers.
 type exportOperation struct {
 	modelmigration.BaseOperation
 
-	logger  logger.Logger
 	service ExportService
+	logger  logger.Logger
 }
 
 // Name returns the name of this operation.
@@ -42,14 +54,67 @@ func (e *exportOperation) Name() string {
 	return "export machines"
 }
 
-// Setup implements Operation.
 func (e *exportOperation) Setup(scope modelmigration.Scope) error {
-	e.service = service.NewService(
-		state.NewState(scope.ModelDB(), e.logger))
+	e.service = service.NewService(state.NewState(scope.ModelDB(), e.logger))
 	return nil
 }
 
-// Execute the export, adding the machine to the model.
 func (e *exportOperation) Execute(ctx context.Context, model description.Model) error {
+
+	for _, machine := range model.Machines() {
+		// TODO(nvinuesa): We must check if the machine cloud instance is already
+		// set and in that case don't ovewrite anything. This check can be removed
+		// once we fully move machines over to dqlite.
+		if instance := machine.Instance(); instance != nil {
+			continue
+		}
+
+		machineName := coremachine.Name(machine.Id())
+		machineUUID, err := e.service.GetMachineUUID(ctx, machineName)
+		if err != nil {
+			return errors.Errorf("retrieving instance ID for machine %q: %w", machineName, err)
+		}
+		instanceID, err := e.service.InstanceID(ctx, machineUUID)
+		if err != nil {
+			return errors.Errorf("retrieving instance ID for machine %q: %w", machineName, err)
+		}
+		instanceArgs := description.CloudInstanceArgs{
+			InstanceId: instanceID,
+		}
+		hardwareCharacteristics, err := e.service.HardwareCharacteristics(ctx, machineUUID)
+		if err != nil {
+			return errors.Errorf("retrieving hardware characteristics for machine %q: %w", machineName, err)
+		}
+		if hardwareCharacteristics.Arch != nil {
+			instanceArgs.Architecture = *hardwareCharacteristics.Arch
+		}
+		if hardwareCharacteristics.Mem != nil {
+			instanceArgs.Memory = *hardwareCharacteristics.Mem
+		}
+		if hardwareCharacteristics.RootDisk != nil {
+			instanceArgs.RootDisk = *hardwareCharacteristics.RootDisk
+		}
+		if hardwareCharacteristics.RootDiskSource != nil {
+			instanceArgs.RootDiskSource = *hardwareCharacteristics.RootDiskSource
+		}
+		if hardwareCharacteristics.CpuCores != nil {
+			instanceArgs.CpuCores = *hardwareCharacteristics.CpuCores
+		}
+		if hardwareCharacteristics.CpuPower != nil {
+			instanceArgs.CpuPower = *hardwareCharacteristics.CpuPower
+		}
+		if hardwareCharacteristics.Tags != nil {
+			instanceArgs.Tags = *hardwareCharacteristics.Tags
+		}
+		if hardwareCharacteristics.AvailabilityZone != nil {
+			instanceArgs.AvailabilityZone = *hardwareCharacteristics.AvailabilityZone
+		}
+		if hardwareCharacteristics.VirtType != nil {
+			instanceArgs.VirtType = *hardwareCharacteristics.VirtType
+		}
+		machine.SetInstance(instanceArgs)
+		instance := machine.Instance()
+		instance.SetStatus(description.StatusArgs{})
+	}
 	return nil
 }

--- a/domain/machine/modelmigration/export.go
+++ b/domain/machine/modelmigration/export.go
@@ -33,10 +33,11 @@ type ExportService interface {
 	// If the machine is not provisioned, it returns a NotProvisionedError.
 	InstanceID(ctx context.Context, machineUUID string) (string, error)
 	// HardwareCharacteristics returns the hardware characteristics of the
-	// of the specified machine.
+	// specified machine.
 	HardwareCharacteristics(ctx context.Context, machineUUID string) (*instance.HardwareCharacteristics, error)
 	// GetMachineUUID returns the UUID of a machine identified by its name.
-	// It returns a MachineNotFound if the machine does not exist.
+	// It returns a [github.com/juju/juju/domain/machine/errors.MachineNotFound]
+	// if the machine does not exist.
 	GetMachineUUID(ctx context.Context, name coremachine.Name) (string, error)
 }
 
@@ -63,7 +64,7 @@ func (e *exportOperation) Execute(ctx context.Context, model description.Model) 
 
 	for _, machine := range model.Machines() {
 		// TODO(nvinuesa): We must check if the machine cloud instance is already
-		// set and in that case don't ovewrite anything. This check can be removed
+		// set and in that case don't overwrite anything. This check can be removed
 		// once we fully move machines over to dqlite.
 		if instance := machine.Instance(); instance != nil {
 			continue

--- a/domain/machine/modelmigration/export_test.go
+++ b/domain/machine/modelmigration/export_test.go
@@ -99,15 +99,15 @@ func (s *exportSuite) TestExport(c *gc.C) {
 		Return(machineUUIDs[0], nil)
 	tags := []string{"tag0", "tag1"}
 	hc := instance.HardwareCharacteristics{
-		Arch:             strPtr("amd64"),
-		Mem:              uintptr(1024),
-		RootDisk:         uintptr(2048),
-		RootDiskSource:   strPtr("/"),
-		CpuCores:         uintptr(4),
-		CpuPower:         uintptr(16),
+		Arch:             ptr("amd64"),
+		Mem:              ptr(uint64(1024)),
+		RootDisk:         ptr(uint64(2048)),
+		RootDiskSource:   ptr("/"),
+		CpuCores:         ptr(uint64(4)),
+		CpuPower:         ptr(uint64(16)),
 		Tags:             &tags,
-		AvailabilityZone: strPtr("az-1"),
-		VirtType:         strPtr("vm"),
+		AvailabilityZone: ptr("az-1"),
+		VirtType:         ptr("vm"),
 	}
 	s.service.EXPECT().HardwareCharacteristics(gomock.Any(), machineUUIDs[0]).
 		Return(&hc, nil)
@@ -132,10 +132,6 @@ func (s *exportSuite) TestExport(c *gc.C) {
 	c.Check(cloudInstance.VirtType(), gc.Equals, "vm")
 }
 
-func strPtr(s string) *string {
-	return &s
-}
-
-func uintptr(u uint64) *uint64 {
+func ptr[T any](u T) *T {
 	return &u
 }

--- a/domain/machine/modelmigration/export_test.go
+++ b/domain/machine/modelmigration/export_test.go
@@ -5,11 +5,17 @@ package modelmigration
 
 import (
 	"context"
+	"errors"
 
 	"github.com/juju/description/v8"
+	"github.com/juju/names/v5"
 	jc "github.com/juju/testing/checkers"
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/instance"
+	coremachine "github.com/juju/juju/core/machine"
+	loggertesting "github.com/juju/juju/internal/logger/testing"
 )
 
 type exportSuite struct {
@@ -28,21 +34,108 @@ func (s *exportSuite) setupMocks(c *gc.C) *gomock.Controller {
 	return ctrl
 }
 
-func (s *exportSuite) newExportOperation() *exportOperation {
+func (s *exportSuite) newExportOperation(c *gc.C) *exportOperation {
 	return &exportOperation{
 		service: s.service,
+		logger:  loggertesting.WrapCheckLog(c),
 	}
+}
+
+func (s *exportSuite) TestFailGetInstanceIDForExport(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	dst := description.NewModel(description.ModelArgs{})
+	machineNames := []coremachine.Name{"deadbeef"}
+	dst.AddMachine(description.MachineArgs{
+		Id: names.NewMachineTag(string(machineNames[0])),
+	})
+
+	machineUUIDs := []string{"deadbeef-0bad-400d-8000-4b1d0d06f00d"}
+	s.service.EXPECT().GetMachineUUID(gomock.Any(), machineNames[0]).
+		Return(machineUUIDs[0], nil)
+	s.service.EXPECT().InstanceID(gomock.Any(), machineUUIDs[0]).
+		Return("", errors.New("boom"))
+
+	op := s.newExportOperation(c)
+	err := op.Execute(context.Background(), dst)
+	c.Assert(err, gc.ErrorMatches, "retrieving instance ID for machine \"deadbeef\": boom")
+}
+
+func (s *exportSuite) TestFailGetHardwareCharacteristicsForExport(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	dst := description.NewModel(description.ModelArgs{})
+	machineNames := []coremachine.Name{"deadbeef"}
+	dst.AddMachine(description.MachineArgs{
+		Id: names.NewMachineTag(string(machineNames[0])),
+	})
+
+	machineUUIDs := []string{"deadbeef-0bad-400d-8000-4b1d0d06f00d"}
+	s.service.EXPECT().GetMachineUUID(gomock.Any(), machineNames[0]).
+		Return(machineUUIDs[0], nil)
+	s.service.EXPECT().InstanceID(gomock.Any(), machineUUIDs[0]).
+		Return("inst-0", nil)
+	s.service.EXPECT().HardwareCharacteristics(gomock.Any(), machineUUIDs[0]).
+		Return(nil, errors.New("boom"))
+
+	op := s.newExportOperation(c)
+	err := op.Execute(context.Background(), dst)
+	c.Assert(err, gc.ErrorMatches, "retrieving hardware characteristics for machine \"deadbeef\": boom")
 }
 
 func (s *exportSuite) TestExport(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	dst := description.NewModel(description.ModelArgs{})
+	machineNames := []coremachine.Name{"deadbeef"}
+	dst.AddMachine(description.MachineArgs{
+		Id: names.NewMachineTag(string(machineNames[0])),
+	})
 
-	op := s.newExportOperation()
+	machineUUIDs := []string{"deadbeef-0bad-400d-8000-4b1d0d06f00d"}
+	s.service.EXPECT().InstanceID(gomock.Any(), machineUUIDs[0]).
+		Return("inst-0", nil)
+	s.service.EXPECT().GetMachineUUID(gomock.Any(), machineNames[0]).
+		Return(machineUUIDs[0], nil)
+	tags := []string{"tag0", "tag1"}
+	hc := instance.HardwareCharacteristics{
+		Arch:             strPtr("amd64"),
+		Mem:              uintptr(1024),
+		RootDisk:         uintptr(2048),
+		RootDiskSource:   strPtr("/"),
+		CpuCores:         uintptr(4),
+		CpuPower:         uintptr(16),
+		Tags:             &tags,
+		AvailabilityZone: strPtr("az-1"),
+		VirtType:         strPtr("vm"),
+	}
+	s.service.EXPECT().HardwareCharacteristics(gomock.Any(), machineUUIDs[0]).
+		Return(&hc, nil)
+
+	op := s.newExportOperation(c)
 	err := op.Execute(context.Background(), dst)
 	c.Assert(err, jc.ErrorIsNil)
 
-	m := dst.Machines()
-	c.Assert(m, gc.HasLen, 0)
+	actualMachines := dst.Machines()
+	c.Check(len(actualMachines), gc.Equals, 1)
+	c.Check(actualMachines[0].Id(), gc.Equals, machineNames[0].String())
+
+	cloudInstance := actualMachines[0].Instance()
+	c.Check(cloudInstance.Architecture(), gc.Equals, "amd64")
+	c.Check(cloudInstance.Memory(), gc.Equals, uint64(1024))
+	c.Check(cloudInstance.RootDisk(), gc.Equals, uint64(2048))
+	c.Check(cloudInstance.RootDiskSource(), gc.Equals, "/")
+	c.Check(cloudInstance.CpuCores(), gc.Equals, uint64(4))
+	c.Check(cloudInstance.CpuPower(), gc.Equals, uint64(16))
+	c.Check(cloudInstance.Tags(), jc.SameContents, tags)
+	c.Check(cloudInstance.AvailabilityZone(), gc.Equals, "az-1")
+	c.Check(cloudInstance.VirtType(), gc.Equals, "vm")
+}
+
+func strPtr(s string) *string {
+	return &s
+}
+
+func uintptr(u uint64) *uint64 {
+	return &u
 }

--- a/domain/machine/modelmigration/import.go
+++ b/domain/machine/modelmigration/import.go
@@ -68,29 +68,18 @@ func (i *importOperation) Execute(ctx context.Context, model description.Model) 
 		// Import the machine's cloud instance.
 		cloudInstance := m.Instance()
 		if cloudInstance != nil {
-			arch := cloudInstance.Architecture()
-			mem := cloudInstance.Memory()
-			rootDisk := cloudInstance.RootDisk()
-			rootDiskSource := cloudInstance.RootDiskSource()
-			cpuCores := cloudInstance.CpuCores()
-			cpuPower := cloudInstance.CpuPower()
-			tags := cloudInstance.Tags()
-			virtType := cloudInstance.VirtType()
 			hardwareCharacteristics := &instance.HardwareCharacteristics{
-				Arch:           &arch,
-				Mem:            &mem,
-				RootDisk:       &rootDisk,
-				RootDiskSource: &rootDiskSource,
-				CpuCores:       &cpuCores,
-				CpuPower:       &cpuPower,
-				Tags:           &tags,
-				VirtType:       &virtType,
+				Arch:             nilZeroPtr(cloudInstance.Architecture()),
+				Mem:              nilZeroPtr(cloudInstance.Memory()),
+				RootDisk:         nilZeroPtr(cloudInstance.RootDisk()),
+				RootDiskSource:   nilZeroPtr(cloudInstance.RootDiskSource()),
+				CpuCores:         nilZeroPtr(cloudInstance.CpuCores()),
+				CpuPower:         nilZeroPtr(cloudInstance.CpuPower()),
+				AvailabilityZone: nilZeroPtr(cloudInstance.AvailabilityZone()),
+				VirtType:         nilZeroPtr(cloudInstance.VirtType()),
 			}
-			// Only add the availability zone if it is not empty. It can be empty
-			// because we are deserializing from a description.Model and we
-			// lose the pointer reference since it returns a string.
-			if availabilityZone := cloudInstance.AvailabilityZone(); availabilityZone != "" {
-				hardwareCharacteristics.AvailabilityZone = &availabilityZone
+			if tags := cloudInstance.Tags(); len(tags) != 0 {
+				hardwareCharacteristics.Tags = &tags
 			}
 			if err := i.service.SetMachineCloudInstance(
 				ctx,
@@ -103,4 +92,12 @@ func (i *importOperation) Execute(ctx context.Context, model description.Model) 
 		}
 	}
 	return nil
+}
+
+func nilZeroPtr[T comparable](v T) *T {
+	var zero T
+	if v == zero {
+		return nil
+	}
+	return &v
 }

--- a/domain/machine/modelmigration/migrations_mock_test.go
+++ b/domain/machine/modelmigration/migrations_mock_test.go
@@ -13,6 +13,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	instance "github.com/juju/juju/core/instance"
 	machine "github.com/juju/juju/core/machine"
 	modelmigration "github.com/juju/juju/core/modelmigration"
 	gomock "go.uber.org/mock/gomock"
@@ -139,6 +140,44 @@ func (c *MockImportServiceCreateMachineCall) DoAndReturn(f func(context.Context,
 	return c
 }
 
+// SetMachineCloudInstance mocks base method.
+func (m *MockImportService) SetMachineCloudInstance(arg0 context.Context, arg1 string, arg2 instance.Id, arg3 *instance.HardwareCharacteristics) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetMachineCloudInstance", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetMachineCloudInstance indicates an expected call of SetMachineCloudInstance.
+func (mr *MockImportServiceMockRecorder) SetMachineCloudInstance(arg0, arg1, arg2, arg3 any) *MockImportServiceSetMachineCloudInstanceCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMachineCloudInstance", reflect.TypeOf((*MockImportService)(nil).SetMachineCloudInstance), arg0, arg1, arg2, arg3)
+	return &MockImportServiceSetMachineCloudInstanceCall{Call: call}
+}
+
+// MockImportServiceSetMachineCloudInstanceCall wrap *gomock.Call
+type MockImportServiceSetMachineCloudInstanceCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockImportServiceSetMachineCloudInstanceCall) Return(arg0 error) *MockImportServiceSetMachineCloudInstanceCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockImportServiceSetMachineCloudInstanceCall) Do(f func(context.Context, string, instance.Id, *instance.HardwareCharacteristics) error) *MockImportServiceSetMachineCloudInstanceCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockImportServiceSetMachineCloudInstanceCall) DoAndReturn(f func(context.Context, string, instance.Id, *instance.HardwareCharacteristics) error) *MockImportServiceSetMachineCloudInstanceCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // MockExportService is a mock of ExportService interface.
 type MockExportService struct {
 	ctrl     *gomock.Controller
@@ -197,6 +236,123 @@ func (c *MockExportServiceAllMachineNamesCall) Do(f func(context.Context) ([]mac
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockExportServiceAllMachineNamesCall) DoAndReturn(f func(context.Context) ([]machine.Name, error)) *MockExportServiceAllMachineNamesCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetMachineUUID mocks base method.
+func (m *MockExportService) GetMachineUUID(arg0 context.Context, arg1 machine.Name) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMachineUUID", arg0, arg1)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetMachineUUID indicates an expected call of GetMachineUUID.
+func (mr *MockExportServiceMockRecorder) GetMachineUUID(arg0, arg1 any) *MockExportServiceGetMachineUUIDCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMachineUUID", reflect.TypeOf((*MockExportService)(nil).GetMachineUUID), arg0, arg1)
+	return &MockExportServiceGetMachineUUIDCall{Call: call}
+}
+
+// MockExportServiceGetMachineUUIDCall wrap *gomock.Call
+type MockExportServiceGetMachineUUIDCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockExportServiceGetMachineUUIDCall) Return(arg0 string, arg1 error) *MockExportServiceGetMachineUUIDCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockExportServiceGetMachineUUIDCall) Do(f func(context.Context, machine.Name) (string, error)) *MockExportServiceGetMachineUUIDCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockExportServiceGetMachineUUIDCall) DoAndReturn(f func(context.Context, machine.Name) (string, error)) *MockExportServiceGetMachineUUIDCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// HardwareCharacteristics mocks base method.
+func (m *MockExportService) HardwareCharacteristics(arg0 context.Context, arg1 string) (*instance.HardwareCharacteristics, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HardwareCharacteristics", arg0, arg1)
+	ret0, _ := ret[0].(*instance.HardwareCharacteristics)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// HardwareCharacteristics indicates an expected call of HardwareCharacteristics.
+func (mr *MockExportServiceMockRecorder) HardwareCharacteristics(arg0, arg1 any) *MockExportServiceHardwareCharacteristicsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HardwareCharacteristics", reflect.TypeOf((*MockExportService)(nil).HardwareCharacteristics), arg0, arg1)
+	return &MockExportServiceHardwareCharacteristicsCall{Call: call}
+}
+
+// MockExportServiceHardwareCharacteristicsCall wrap *gomock.Call
+type MockExportServiceHardwareCharacteristicsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockExportServiceHardwareCharacteristicsCall) Return(arg0 *instance.HardwareCharacteristics, arg1 error) *MockExportServiceHardwareCharacteristicsCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockExportServiceHardwareCharacteristicsCall) Do(f func(context.Context, string) (*instance.HardwareCharacteristics, error)) *MockExportServiceHardwareCharacteristicsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockExportServiceHardwareCharacteristicsCall) DoAndReturn(f func(context.Context, string) (*instance.HardwareCharacteristics, error)) *MockExportServiceHardwareCharacteristicsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// InstanceID mocks base method.
+func (m *MockExportService) InstanceID(arg0 context.Context, arg1 string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InstanceID", arg0, arg1)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// InstanceID indicates an expected call of InstanceID.
+func (mr *MockExportServiceMockRecorder) InstanceID(arg0, arg1 any) *MockExportServiceInstanceIDCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstanceID", reflect.TypeOf((*MockExportService)(nil).InstanceID), arg0, arg1)
+	return &MockExportServiceInstanceIDCall{Call: call}
+}
+
+// MockExportServiceInstanceIDCall wrap *gomock.Call
+type MockExportServiceInstanceIDCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockExportServiceInstanceIDCall) Return(arg0 string, arg1 error) *MockExportServiceInstanceIDCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockExportServiceInstanceIDCall) Do(f func(context.Context, string) (string, error)) *MockExportServiceInstanceIDCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockExportServiceInstanceIDCall) DoAndReturn(f func(context.Context, string) (string, error)) *MockExportServiceInstanceIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/machine/modelmigration/package_test.go
+++ b/domain/machine/modelmigration/package_test.go
@@ -10,7 +10,6 @@ import (
 )
 
 //go:generate go run go.uber.org/mock/mockgen -typed -package modelmigration -destination migrations_mock_test.go github.com/juju/juju/domain/machine/modelmigration Coordinator,ImportService,ExportService
-
 func TestPackage(t *testing.T) {
 	gc.TestingT(t)
 }

--- a/domain/machine/service/package_mock_test.go
+++ b/domain/machine/service/package_mock_test.go
@@ -662,41 +662,41 @@ func (c *MockStateInitialWatchStatementCall) DoAndReturn(f func() (string, strin
 	return c
 }
 
-// InstanceId mocks base method.
-func (m *MockState) InstanceId(arg0 context.Context, arg1 machine.Name) (string, error) {
+// InstanceID mocks base method.
+func (m *MockState) InstanceID(arg0 context.Context, arg1 string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InstanceId", arg0, arg1)
+	ret := m.ctrl.Call(m, "InstanceID", arg0, arg1)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// InstanceId indicates an expected call of InstanceId.
-func (mr *MockStateMockRecorder) InstanceId(arg0, arg1 any) *MockStateInstanceIdCall {
+// InstanceID indicates an expected call of InstanceID.
+func (mr *MockStateMockRecorder) InstanceID(arg0, arg1 any) *MockStateInstanceIDCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstanceId", reflect.TypeOf((*MockState)(nil).InstanceId), arg0, arg1)
-	return &MockStateInstanceIdCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstanceID", reflect.TypeOf((*MockState)(nil).InstanceID), arg0, arg1)
+	return &MockStateInstanceIDCall{Call: call}
 }
 
-// MockStateInstanceIdCall wrap *gomock.Call
-type MockStateInstanceIdCall struct {
+// MockStateInstanceIDCall wrap *gomock.Call
+type MockStateInstanceIDCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockStateInstanceIdCall) Return(arg0 string, arg1 error) *MockStateInstanceIdCall {
+func (c *MockStateInstanceIDCall) Return(arg0 string, arg1 error) *MockStateInstanceIDCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateInstanceIdCall) Do(f func(context.Context, machine.Name) (string, error)) *MockStateInstanceIdCall {
+func (c *MockStateInstanceIDCall) Do(f func(context.Context, string) (string, error)) *MockStateInstanceIDCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateInstanceIdCall) DoAndReturn(f func(context.Context, machine.Name) (string, error)) *MockStateInstanceIdCall {
+func (c *MockStateInstanceIDCall) DoAndReturn(f func(context.Context, string) (string, error)) *MockStateInstanceIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/machine/service/service.go
+++ b/domain/machine/service/service.go
@@ -62,7 +62,8 @@ type State interface {
 	InitialWatchInstanceStatement() (string, string)
 
 	// InstanceID returns the cloud specific instance id for this machine.
-	// If the machine is not provisioned, it returns a NotProvisionedError.
+	// If the machine is not provisioned, it returns a
+	// [machineerrors.NotProvisionedError]
 	InstanceID(context.Context, string) (string, error)
 
 	// GetInstanceStatus returns the cloud specific instance status for this
@@ -244,7 +245,8 @@ func (s *Service) AllMachineNames(ctx context.Context) ([]coremachine.Name, erro
 }
 
 // InstanceID returns the cloud specific instance id for this machine.
-// If the machine is not provisioned, it returns a NotProvisionedError.
+// If the machine is not provisioned, it returns a
+// [machineerrors.NotProvisionedError]
 func (s *Service) InstanceID(ctx context.Context, machineUUID string) (string, error) {
 	instanceId, err := s.st.InstanceID(ctx, machineUUID)
 	if err != nil {

--- a/domain/machine/service/service.go
+++ b/domain/machine/service/service.go
@@ -61,9 +61,9 @@ type State interface {
 	// for the machine cloud instances.
 	InitialWatchInstanceStatement() (string, string)
 
-	// InstanceId returns the cloud specific instance id for this machine.
+	// InstanceID returns the cloud specific instance id for this machine.
 	// If the machine is not provisioned, it returns a NotProvisionedError.
-	InstanceId(context.Context, coremachine.Name) (string, error)
+	InstanceID(context.Context, string) (string, error)
 
 	// GetInstanceStatus returns the cloud specific instance status for this
 	// machine.
@@ -243,12 +243,12 @@ func (s *Service) AllMachineNames(ctx context.Context) ([]coremachine.Name, erro
 	return machines, nil
 }
 
-// InstanceId returns the cloud specific instance id for this machine.
+// InstanceID returns the cloud specific instance id for this machine.
 // If the machine is not provisioned, it returns a NotProvisionedError.
-func (s *Service) InstanceId(ctx context.Context, machineName coremachine.Name) (string, error) {
-	instanceId, err := s.st.InstanceId(ctx, machineName)
+func (s *Service) InstanceID(ctx context.Context, machineUUID string) (string, error) {
+	instanceId, err := s.st.InstanceID(ctx, machineUUID)
 	if err != nil {
-		return "", errors.Annotatef(err, "retrieving cloud instance id for machine %q", machineName)
+		return "", errors.Annotatef(err, "retrieving cloud instance id for machine %q", machineUUID)
 	}
 	return instanceId, nil
 }

--- a/domain/machine/service/service_test.go
+++ b/domain/machine/service/service_test.go
@@ -264,9 +264,9 @@ func (s *serviceSuite) TestListAllMachinesError(c *gc.C) {
 func (s *serviceSuite) TestInstanceIdSuccess(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().InstanceId(gomock.Any(), cmachine.Name("666")).Return("123", nil)
+	s.state.EXPECT().InstanceID(gomock.Any(), "deadbeef-0bad-400d-8000-4b1d0d06f00d").Return("123", nil)
 
-	instanceId, err := NewService(s.state).InstanceId(context.Background(), "666")
+	instanceId, err := NewService(s.state).InstanceID(context.Background(), "deadbeef-0bad-400d-8000-4b1d0d06f00d")
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(instanceId, gc.Equals, "123")
 }
@@ -277,9 +277,9 @@ func (s *serviceSuite) TestInstanceIdError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	rErr := errors.New("boom")
-	s.state.EXPECT().InstanceId(gomock.Any(), cmachine.Name("666")).Return("", rErr)
+	s.state.EXPECT().InstanceID(gomock.Any(), "deadbeef-0bad-400d-8000-4b1d0d06f00d").Return("", rErr)
 
-	instanceId, err := NewService(s.state).InstanceId(context.Background(), "666")
+	instanceId, err := NewService(s.state).InstanceID(context.Background(), "deadbeef-0bad-400d-8000-4b1d0d06f00d")
 	c.Check(err, jc.ErrorIs, rErr)
 	c.Check(instanceId, gc.Equals, "")
 }
@@ -291,9 +291,9 @@ func (s *serviceSuite) TestInstanceIdError(c *gc.C) {
 func (s *serviceSuite) TestInstanceIdNotProvisionedError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().InstanceId(gomock.Any(), cmachine.Name("666")).Return("", errors.NotProvisioned)
+	s.state.EXPECT().InstanceID(gomock.Any(), "deadbeef-0bad-400d-8000-4b1d0d06f00d").Return("", errors.NotProvisioned)
 
-	instanceId, err := NewService(s.state).InstanceId(context.Background(), "666")
+	instanceId, err := NewService(s.state).InstanceID(context.Background(), "deadbeef-0bad-400d-8000-4b1d0d06f00d")
 	c.Check(err, jc.ErrorIs, errors.NotProvisioned)
 	c.Check(instanceId, gc.Equals, "")
 }

--- a/domain/machine/state/machine_cloud_instance.go
+++ b/domain/machine/state/machine_cloud_instance.go
@@ -215,22 +215,20 @@ WHERE machine_uuid=$machineUUID.uuid
 	})
 }
 
-// InstanceId returns the cloud specific instance id for this machine.
+// InstanceID returns the cloud specific instance id for this machine.
 // If the machine is not provisioned, it returns a NotProvisionedError.
-func (st *State) InstanceId(ctx context.Context, mName machine.Name) (string, error) {
+func (st *State) InstanceID(ctx context.Context, mUUID string) (string, error) {
 	db, err := st.DB()
 	if err != nil {
 		return "", errors.Trace(err)
 	}
 
-	machineIDParam := machineName{Name: mName}
+	mUUIDParam := machineUUID{UUID: mUUID}
 	query := `
-SELECT instance_id AS &instanceID.*
-FROM machine AS m
-    JOIN machine_cloud_instance AS mci ON m.uuid = mci.machine_uuid
-WHERE m.name = $machineName.name;
-`
-	queryStmt, err := st.Prepare(query, machineIDParam, instanceID{})
+SELECT &instanceID.instance_id
+FROM   machine_cloud_instance
+WHERE  machine_uuid = $machineUUID.uuid;`
+	queryStmt, err := st.Prepare(query, mUUIDParam, instanceID{})
 	if err != nil {
 		return "", errors.Trace(err)
 	}
@@ -238,12 +236,12 @@ WHERE m.name = $machineName.name;
 	var instanceId string
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		var result instanceID
-		err := tx.Query(ctx, queryStmt, machineIDParam).Get(&result)
+		err := tx.Query(ctx, queryStmt, mUUIDParam).Get(&result)
 		if err != nil {
 			if errors.Is(err, sqlair.ErrNoRows) {
-				return errors.Annotatef(machineerrors.NotProvisioned, "machine: %q", mName)
+				return errors.Annotatef(machineerrors.NotProvisioned, "machine: %q", mUUID)
 			}
-			return errors.Annotatef(err, "querying instance for machine %q", mName)
+			return errors.Annotatef(err, "querying instance for machine %q", mUUID)
 		}
 
 		instanceId = result.ID

--- a/domain/machine/state/machine_cloud_instance.go
+++ b/domain/machine/state/machine_cloud_instance.go
@@ -216,7 +216,8 @@ WHERE machine_uuid=$machineUUID.uuid
 }
 
 // InstanceID returns the cloud specific instance id for this machine.
-// If the machine is not provisioned, it returns a NotProvisionedError.
+// If the machine is not provisioned, it returns a
+// [machineerrors.NotProvisionedError].
 func (st *State) InstanceID(ctx context.Context, mUUID string) (string, error) {
 	db, err := st.DB()
 	if err != nil {

--- a/domain/machine/state/machine_cloud_instance_test.go
+++ b/domain/machine/state/machine_cloud_instance_test.go
@@ -203,9 +203,9 @@ func strsliceptr(s []string) *[]string {
 }
 
 func (s *stateSuite) TestInstanceIdSuccess(c *gc.C) {
-	s.ensureInstance(c, "666")
+	machineUUID := s.ensureInstance(c, "666")
 
-	instanceId, err := s.state.InstanceId(context.Background(), "666")
+	instanceId, err := s.state.InstanceID(context.Background(), machineUUID)
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(instanceId, gc.Equals, "123")
 }
@@ -214,7 +214,7 @@ func (s *stateSuite) TestInstanceIdError(c *gc.C) {
 	err := s.state.CreateMachine(context.Background(), "666", "", "")
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = s.state.InstanceId(context.Background(), "666")
+	_, err = s.state.InstanceID(context.Background(), "666")
 	c.Check(err, jc.ErrorIs, machineerrors.NotProvisioned)
 }
 


### PR DESCRIPTION
This commit adds support for machine cloud instances model migration operations for the machine domain.

As a bonus: machine's method InstanceId is renamed to InstanceID so it adheres to idiomatic golang.

<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://docs.google.com/document/d/1SYUo9G7qZ_jdoVXpUVamS5VCgHmtZ0QA-wZxKoMS-C0 
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Model migration should work (3.6->4.0 and 4.0->4.0, please test and try to break it), and in the target model the machine cloud instance should be correctly inserted in dqlite:
```
juju bootstrap localhost tgt
juju bootstrap localhost src
juju add-model m
juju deploy ubuntu 
juju migrate src:admin/m tgt
```
At this point we can switch to tgt and check everything is OK:
```
juju switch tgt:admin/m
# make sure you are PWDd at juju root dir
make repl-install
make repl
# retrieve the model db UUID: select * from model
DB_NAME={modeldbUUID} make repl
dqlite> select * from machine_cloud_instance
machine_uuid                            instance_id     arch    mem     root_disk       root_disk_source        cpu_cores       cpu_power       availability_zone_uuid  virt_type
37db5c6b-3872-4d92-8065-96a004219c78    juju-44d1ae-0   amd64   0       0        
```

## Links

**Jira card:** JUJU-6359

