### PR TITLE
docs: add package docs for the compute and container provisioners

### DIFF
--- a/internal/worker/computeprovisioner/doc.go
+++ b/internal/worker/computeprovisioner/doc.go
@@ -1,0 +1,10 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package computeprovisioner defines the compute provisioner worker. This
+// worker is responsible for provisioning new compute (machine) instances in
+// the cloud provider when a new machine is added to the model.
+//
+// This worker, the same as the containerprovisioner, will retrieve the
+// machines from the database and simply do the provisioning.
+package computeprovisioner

--- a/internal/worker/containerprovisioner/doc.go
+++ b/internal/worker/containerprovisioner/doc.go
@@ -1,0 +1,10 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package containerprovisioner defines the container provisioner worker. This
+// worker is responsible for provisioning new containers on the underlying
+// machine.
+//
+// This worker, the same as the computeprovisioner, will retrieve the
+// containers from the database and simply do the provisioning.
+package containerprovisioner


### PR DESCRIPTION
This PR adds new package documentation to the `containerprovisioner` and the `computeprovisioner` workers, as well as rewording and reformatting the already existing `doc/provisioning.md`, which was very comprehensive and detailed.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] ~Code style: imports ordered, good names, simple structure, etc~
- [ ] ~Comments saying why design decisions were made~
- [ ] ~Go unit tests, with comments saying what you're testing~
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [X] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

N/A

## Documentation changes

- Adds `internal/worker/computeprovisioner/doc.go`.
- Adds `internal/worker/containerprovisioner/doc.go`
- Rewords/reformats `doc/provisioning.md`

## Links

**Jira card:** JUJU-5004

