### PR TITLE
feat: add migration check for charms without manifest

### DIFF
--- a/apiserver/facades/client/modelupgrader/mocks/state_mock.go
+++ b/apiserver/facades/client/modelupgrader/mocks/state_mock.go
@@ -156,6 +156,21 @@ func (mr *MockStateMockRecorder) AllModelUUIDs() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllModelUUIDs", reflect.TypeOf((*MockState)(nil).AllModelUUIDs))
 }
 
+// Charm mocks base method.
+func (m *MockState) Charm(arg0 string) (*state.Charm, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Charm", arg0)
+	ret0, _ := ret[0].(*state.Charm)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Charm indicates an expected call of Charm.
+func (mr *MockStateMockRecorder) Charm(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Charm", reflect.TypeOf((*MockState)(nil).Charm), arg0)
+}
+
 // ControllerConfig mocks base method.
 func (m *MockState) ControllerConfig() (controller.Config, error) {
 	m.ctrl.T.Helper()

--- a/apiserver/facades/client/modelupgrader/shims.go
+++ b/apiserver/facades/client/modelupgrader/shims.go
@@ -34,6 +34,7 @@ type State interface {
 	AbortCurrentUpgrade() error
 	ControllerConfig() (controller.Config, error)
 	AllCharmURLs() ([]*string, error)
+	Charm(curl string) (*state.Charm, error)
 }
 
 type SystemState interface {

--- a/apiserver/facades/controller/migrationmaster/mocks/precheckbackend.go
+++ b/apiserver/facades/controller/migrationmaster/mocks/precheckbackend.go
@@ -133,6 +133,21 @@ func (mr *MockPrecheckBackendMockRecorder) AllRelations() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllRelations", reflect.TypeOf((*MockPrecheckBackend)(nil).AllRelations))
 }
 
+// Charm mocks base method.
+func (m *MockPrecheckBackend) Charm(arg0 string) (*state.Charm, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Charm", arg0)
+	ret0, _ := ret[0].(*state.Charm)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Charm indicates an expected call of Charm.
+func (mr *MockPrecheckBackendMockRecorder) Charm(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Charm", reflect.TypeOf((*MockPrecheckBackend)(nil).Charm), arg0)
+}
+
 // CloudCredential mocks base method.
 func (m *MockPrecheckBackend) CloudCredential(arg0 names.CloudCredentialTag) (state.Credential, error) {
 	m.ctrl.T.Helper()

--- a/migration/interface.go
+++ b/migration/interface.go
@@ -28,6 +28,7 @@ type PrecheckBackend interface {
 	AllApplications() ([]PrecheckApplication, error)
 	AllRelations() ([]PrecheckRelation, error)
 	AllCharmURLs() ([]*string, error)
+	Charm(curl string) (*state.Charm, error)
 	ControllerBackend() (PrecheckBackend, error)
 	CloudCredential(tag names.CloudCredentialTag) (state.Credential, error)
 	HasUpgradeSeriesLocks() (bool, error)

--- a/migration/precheck_test.go
+++ b/migration/precheck_test.go
@@ -936,6 +936,10 @@ func (b *fakeBackend) AllCharmURLs() ([]*string, error) {
 	return nil, errors.NotFoundf("charms")
 }
 
+func (b *fakeBackend) Charm(string) (*state.Charm, error) {
+	return nil, errors.NotFoundf("charms")
+}
+
 type fakePool struct {
 	models []migration.PrecheckModel
 }

--- a/upgrades/upgradevalidation/interfaces.go
+++ b/upgrades/upgradevalidation/interfaces.go
@@ -20,6 +20,7 @@ type StatePool interface {
 // State represents a point of use interface for modelling a current model.
 type State interface {
 	AllCharmURLs() ([]*string, error)
+	Charm(curl string) (*state.Charm, error)
 	HasUpgradeSeriesLocks() (bool, error)
 	MachineCountForBase(base ...state.Base) (map[string]int, error)
 	MongoCurrentStatus() (*replicaset.Status, error)

--- a/upgrades/upgradevalidation/migrate.go
+++ b/upgrades/upgradevalidation/migrate.go
@@ -19,5 +19,6 @@ func ValidatorsForModelMigrationSource(
 		checkForDeprecatedUbuntuSeriesForModel,
 		getCheckForLXDVersion(cloudspec),
 		checkForCharmStoreCharms,
+		checkForCharmsWithNoManifest,
 	}
 }

--- a/upgrades/upgradevalidation/migrate_test.go
+++ b/upgrades/upgradevalidation/migrate_test.go
@@ -120,7 +120,7 @@ func (s *migrateSuite) setupMocks(c *gc.C) (*gomock.Controller, environscloudspe
 	s.st.EXPECT().MachineCountForBase(makeBases("windows", winVersions)).Return(nil, nil)
 	s.st.EXPECT().MachineCountForBase(makeBases("ubuntu", unsupportedUbuntuVersions)).Return(nil, nil)
 	// - check no charm store charms
-	s.st.EXPECT().AllCharmURLs().Return([]*string{}, errors.NotFoundf("charm urls"))
+	s.st.EXPECT().AllCharmURLs().Return([]*string{}, errors.NotFoundf("charm urls")).Times(2)
 
 	return ctrl, cloudSpec.CloudSpec
 }

--- a/upgrades/upgradevalidation/mocks/state_mock.go
+++ b/upgrades/upgradevalidation/mocks/state_mock.go
@@ -95,6 +95,21 @@ func (mr *MockStateMockRecorder) AllCharmURLs() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllCharmURLs", reflect.TypeOf((*MockState)(nil).AllCharmURLs))
 }
 
+// Charm mocks base method.
+func (m *MockState) Charm(arg0 string) (*state.Charm, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Charm", arg0)
+	ret0, _ := ret[0].(*state.Charm)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Charm indicates an expected call of Charm.
+func (mr *MockStateMockRecorder) Charm(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Charm", reflect.TypeOf((*MockState)(nil).Charm), arg0)
+}
+
 // HasUpgradeSeriesLocks mocks base method.
 func (m *MockState) HasUpgradeSeriesLocks() (bool, error) {
 	m.ctrl.T.Helper()

--- a/upgrades/upgradevalidation/package_test.go
+++ b/upgrades/upgradevalidation/package_test.go
@@ -26,4 +26,5 @@ var (
 	CheckMongoVersionForControllerModel         = checkMongoVersionForControllerModel
 	GetCheckForLXDVersion                       = getCheckForLXDVersion
 	CheckForCharmStoreCharms                    = checkForCharmStoreCharms
+	CheckForCharmsWithNoManifest                = checkForCharmsWithNoManifest
 )

--- a/upgrades/upgradevalidation/validation_test.go
+++ b/upgrades/upgradevalidation/validation_test.go
@@ -424,3 +424,26 @@ func (s *upgradeValidationSuite) TestCheckForCharmStoreCharmsError(c *gc.C) {
 	_, err := upgradevalidation.CheckForCharmStoreCharms("", nil, st, nil)
 	c.Assert(errors.Is(err, errors.BadRequest), jc.IsTrue)
 }
+
+func (s *upgradeValidationSuite) TestCheckForCharmsWithNoManifestNotFound(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	st := mocks.NewMockState(ctrl)
+	st.EXPECT().AllCharmURLs().Return([]*string{}, errors.NotFoundf("charm urls"))
+
+	blocker, err := upgradevalidation.CheckForCharmsWithNoManifest("", nil, st, nil)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(blocker, gc.IsNil)
+}
+
+func (s *upgradeValidationSuite) TestCheckForCharmsWithNoManifestError(c *gc.C) {
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	st := mocks.NewMockState(ctrl)
+	st.EXPECT().AllCharmURLs().Return([]*string{}, errors.BadRequestf("charm urls"))
+
+	_, err := upgradevalidation.CheckForCharmsWithNoManifest("", nil, st, nil)
+	c.Assert(errors.Is(err, errors.BadRequest), jc.IsTrue)
+}


### PR DESCRIPTION
Charms without a manifest.yaml are not supported in 4.0. This check blocks migration of models that contain such charms.

The unit tests for this new functionality are very limited. This is because I couldn't find a reasonable way to do the unit tests aside from the error checks, and this is how the other charm related migration prechecker is tested (i.e. its not really).

<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://docs.google.com/document/d/1SYUo9G7qZ_jdoVXpUVamS5VCgHmtZ0QA-wZxKoMS-C0 
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing

## QA steps
Test 3.6 - 3.6 blocked
```
$ juju bootstrap lxd no-manifest-blocker
$ juju bootstrap lxd target
$ juju switch no-manifest-blocker
$ juju add-model test-mig
$ juju deploy ./testcharms/charms/ubuntu-plus
$ juju migrate test-mig target
ERROR source prechecks failed: cannot migrate to controller due to issues:
"admin/test-mig":
- All charms now require a manifest.yaml file. This model hosts charm(s) with no manifest.yaml file: ubuntu-plus
```
Test successful migration.
```
$ juju add-model test-successful
$ juju deploy ubuntu
$ juju migrate test-successful target
Migration started with ID "ec416470-3b8e-4594-8bdf-aa000a548e94:0"
$ juju models     
Controller: no-manifest-blocker

Model             Cloud/Region  Type  Status     Machines  Units  Access  Last connection
controller        lxd/default   lxd   available         1      1  admin   just now
test-mig          lxd/default   lxd   available         1      1  admin   18 minutes ago
test-successful*  lxd/default   lxd   busy              1      1  admin   15 seconds ago
$ juju status
ERROR Model "admin/test-successful" has been migrated to controller "target".
To access it run 'juju switch target:admin/test-successful'.
$ juju switch target:test-successful
no-manifest-blocker:admin/test-successful -> target:admin/test-successful
$ juju status
Model            Controller  Cloud/Region  Version      SLA          Timestamp
test-successful  target      lxd/default   3.6-beta3.1  unsupported  11:02:41+01:00

App     Version  Status  Scale  Charm   Channel        Rev  Exposed  Message
ubuntu  22.04    active      1  ubuntu  latest/stable   24  no       

Unit       Workload  Agent  Machine  Public address  Ports  Message
ubuntu/1*  active    idle   1        10.101.18.201          

Machine  State    Address        Inst id        Base          AZ  Message
1        started  10.101.18.201  juju-548e94-1  ubuntu@22.04      Running
```
Test 3.6 to 4.0
``` 
# build 4.0
$ juju bootstrap lxd mig40
$ juju switch no-manifest-blocker
$ juju add-model test-to-4
# Check that it handles multiple charms and multiple applications ok.
$ juju deploy ./testcharms/charms/ubuntu-plus
$ juju deploy ./testcharms/charms/ubuntu-plus second-ubuntu-plus
$ juju deploy ./testcharms/charms/space-defender
$ juju status
Model      Controller           Cloud/Region  Version      SLA          Timestamp
test-to-4  no-manifest-blocker  lxd/default   3.6-beta3.1  unsupported  11:23:28+01:00

App                 Version  Status   Scale  Charm           Channel  Rev  Exposed  Message
second-ubuntu-plus           active       1  ubuntu-plus                1  no       Hello from update-status, load: 8.03, 10.18, 8.33
space-defender               unknown      1  space-defender             0  no       
ubuntu-plus                  active       1  ubuntu-plus                0  no       Hello from update-status, load: 8.03, 10.18, 8.33

Unit                   Workload  Agent  Machine  Public address  Ports  Message
second-ubuntu-plus/0*  active    idle   1        10.101.18.57           Hello from update-status, load: 8.03, 10.18, 8.33
space-defender/0*      unknown   idle   2        10.101.18.128          
ubuntu-plus/0*         active    idle   0        10.101.18.33           Hello from update-status, load: 8.03, 10.18, 8.33

Machine  State    Address        Inst id        Base          AZ  Message
0        started  10.101.18.33   juju-18a887-0  ubuntu@22.04      Running
1        started  10.101.18.57   juju-18a887-1  ubuntu@22.04      Running
2        started  10.101.18.128  juju-18a887-2  ubuntu@22.04      Running
$ juju migrate test-to-4 mig40
ERROR source prechecks failed: cannot migrate to controller due to issues:
"admin/test-to-4":
- All charms now require a manifest.yaml file. This model hosts charm(s) with no manifest.yaml file: space-defender, ubuntu-plus
```

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2080359

**Jira card:** [JUJU-6727](https://warthogs.atlassian.net/browse/JUJU-6727)


[JUJU-6727]: https://warthogs.atlassian.net/browse/JUJU-6727?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ