### PR TITLE
feat(modelmigration): check provider and model machines instances match

### DIFF
--- a/domain/modelmigration/service/service.go
+++ b/domain/modelmigration/service/service.go
@@ -148,13 +148,13 @@ func (s *Service) CheckMachines(
 			err,
 		)
 	}
-	var providerInstanceIDs []string
-	for _, instance := range providerInstances {
-		providerInstanceIDs = append(providerInstanceIDs, string(instance.Id()))
-	}
 
 	// Build the sets of provider instance IDs and model machine instance IDs.
-	providerInstanceIDsSet := set.NewStrings(providerInstanceIDs...)
+	providerInstanceIDsSet := make(set.Strings, len(providerInstances))
+	for _, instance := range providerInstances {
+		providerInstanceIDsSet.Add(string(instance.Id()))
+	}
+
 	instanceIDsSet, err := s.st.GetAllInstanceIDs(ctx)
 	if err != nil {
 		return nil, errors.Errorf("cannot get all instance IDs for model when checking machines: %w", err)

--- a/domain/modelmigration/service/service_mock_test.go
+++ b/domain/modelmigration/service/service_mock_test.go
@@ -13,6 +13,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	set "github.com/juju/collections/set"
 	envcontext "github.com/juju/juju/environs/envcontext"
 	instances "github.com/juju/juju/environs/instances"
 	version "github.com/juju/version/v2"
@@ -163,6 +164,45 @@ func NewMockState(ctrl *gomock.Controller) *MockState {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockState) EXPECT() *MockStateMockRecorder {
 	return m.recorder
+}
+
+// GetAllInstanceIDs mocks base method.
+func (m *MockState) GetAllInstanceIDs(arg0 context.Context) (set.Strings, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAllInstanceIDs", arg0)
+	ret0, _ := ret[0].(set.Strings)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAllInstanceIDs indicates an expected call of GetAllInstanceIDs.
+func (mr *MockStateMockRecorder) GetAllInstanceIDs(arg0 any) *MockStateGetAllInstanceIDsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllInstanceIDs", reflect.TypeOf((*MockState)(nil).GetAllInstanceIDs), arg0)
+	return &MockStateGetAllInstanceIDsCall{Call: call}
+}
+
+// MockStateGetAllInstanceIDsCall wrap *gomock.Call
+type MockStateGetAllInstanceIDsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateGetAllInstanceIDsCall) Return(arg0 set.Strings, arg1 error) *MockStateGetAllInstanceIDsCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateGetAllInstanceIDsCall) Do(f func(context.Context) (set.Strings, error)) *MockStateGetAllInstanceIDsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateGetAllInstanceIDsCall) DoAndReturn(f func(context.Context) (set.Strings, error)) *MockStateGetAllInstanceIDsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
 }
 
 // GetControllerUUID mocks base method.

--- a/domain/modelmigration/state/state_test.go
+++ b/domain/modelmigration/state/state_test.go
@@ -9,10 +9,12 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/core/instance"
 	coremodel "github.com/juju/juju/core/model"
 	modeltesting "github.com/juju/juju/core/model/testing"
 	usertesting "github.com/juju/juju/core/user/testing"
 	jujuversion "github.com/juju/juju/core/version"
+	machinestate "github.com/juju/juju/domain/machine/state"
 	"github.com/juju/juju/domain/model"
 	modelstate "github.com/juju/juju/domain/model/state"
 	schematesting "github.com/juju/juju/domain/schema/testing"
@@ -58,4 +60,44 @@ func (s *migrationSuite) TestGetControllerUUID(c *gc.C) {
 	controllerId, err := New(s.TxnRunnerFactory()).GetControllerUUID(context.Background())
 	c.Check(err, jc.ErrorIsNil)
 	c.Check(controllerId, gc.Equals, s.controllerUUID.String())
+}
+
+// TestGetAllInstanceIDs is asserting the happy path of getting all instance
+// IDs for the model.
+func (s *migrationSuite) TestGetAllInstanceIDs(c *gc.C) {
+	// Add two different instances.
+	db := s.DB()
+	machineState := machinestate.NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+
+	err := machineState.CreateMachine(context.Background(), "666", "0", "deadbeef")
+	c.Assert(err, jc.ErrorIsNil)
+	// Add a reference AZ.
+	_, err = db.ExecContext(context.Background(), "INSERT INTO availability_zone VALUES('deadbeef', 'az-1')")
+	c.Assert(err, jc.ErrorIsNil)
+	arch := "arm64"
+	err = machineState.SetMachineCloudInstance(
+		context.Background(),
+		"deadbeef",
+		instance.Id("instance-0"),
+		&instance.HardwareCharacteristics{
+			Arch: &arch,
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	err = machineState.CreateMachine(context.Background(), "667", "1", "deadbeef-2")
+	c.Assert(err, jc.ErrorIsNil)
+	err = machineState.SetMachineCloudInstance(
+		context.Background(),
+		"deadbeef-2",
+		instance.Id("instance-1"),
+		&instance.HardwareCharacteristics{
+			Arch: &arch,
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+
+	instanceIDs, err := New(s.TxnRunnerFactory()).GetAllInstanceIDs(context.Background())
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(instanceIDs, gc.HasLen, 2)
+	c.Check(instanceIDs.Values(), jc.SameContents, []string{"instance-0", "instance-1"})
 }

--- a/domain/modelmigration/state/state_test.go
+++ b/domain/modelmigration/state/state_test.go
@@ -58,7 +58,7 @@ func (s *migrationSuite) SetUpTest(c *gc.C) {
 // uuid from the database.
 func (s *migrationSuite) TestGetControllerUUID(c *gc.C) {
 	controllerId, err := New(s.TxnRunnerFactory()).GetControllerUUID(context.Background())
-	c.Check(err, jc.ErrorIsNil)
+	c.Assert(err, jc.ErrorIsNil)
 	c.Check(controllerId, gc.Equals, s.controllerUUID.String())
 }
 
@@ -97,7 +97,15 @@ func (s *migrationSuite) TestGetAllInstanceIDs(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	instanceIDs, err := New(s.TxnRunnerFactory()).GetAllInstanceIDs(context.Background())
-	c.Check(err, jc.ErrorIsNil)
+	c.Assert(err, jc.ErrorIsNil)
 	c.Check(instanceIDs, gc.HasLen, 2)
 	c.Check(instanceIDs.Values(), jc.SameContents, []string{"instance-0", "instance-1"})
+}
+
+// TestEmptyInstanceIDs tests that no error is returned when there are no
+// instances in the model.
+func (s *migrationSuite) TestEmptyInstanceIDs(c *gc.C) {
+	instanceIDs, err := New(s.TxnRunnerFactory()).GetAllInstanceIDs(context.Background())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(instanceIDs, gc.HasLen, 0)
 }

--- a/domain/modelmigration/state/types.go
+++ b/domain/modelmigration/state/types.go
@@ -9,3 +9,9 @@ type ModelInfo struct {
 	// ControllerUUID is the controllers unique id.
 	ControllerUUID string `db:"controller_uuid"`
 }
+
+// instanceID represents the struct to be used for the instance_id column within
+// the sqlair statements in the machine domain.
+type instanceID struct {
+	ID string `db:"instance_id"`
+}


### PR DESCRIPTION
This patch implements a missing step on the checks when migrating a model, left as a TODO by @tlm.

Basically the check makes sure that the list of instance IDs retrieved from the provider and the ones retrieved from the DB (model machines) are exactly the same, any discrepancy results in a precheck error.


## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

This QA tests the happy path of model migration. Unit tests validate discrepancies from the provider (which are difficult to test manually):

```
juju bootstrap lxd src
juju add-model m
juju deploy ubuntu
juju bootstrap lxd tgt
juju switch src:admin/m
juju migrate tgt
```
At this point, make sure the model was correctly migrated (including the ubuntu unit).

## Links

**Jira card:** JUJU-6618

