### PR TITLE
chore: remove MongoModelWatcher from apiserver/common

### DIFF
--- a/apiserver/common/modelwatcher.go
+++ b/apiserver/common/modelwatcher.go
@@ -13,8 +13,6 @@ import (
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/rpc/params"
-	"github.com/juju/juju/state"
-	statewatcher "github.com/juju/juju/state/watcher"
 )
 
 // ModelConfigService is an interface that provides access to the
@@ -70,57 +68,6 @@ func (m *ModelWatcher) WatchForModelConfigChanges(ctx context.Context) (params.N
 func (m *ModelWatcher) ModelConfig(ctx context.Context) (params.ModelConfigResult, error) {
 	result := params.ModelConfigResult{}
 	config, err := m.modelConfigService.ModelConfig(ctx)
-	if err != nil {
-		return result, err
-	}
-	result.Config = config.AllAttrs()
-	return result, nil
-}
-
-// MongoModelWatcher implements two common methods for use by various
-// facades - WatchForModelConfigChanges and ModelConfig.
-type MongoModelWatcher struct {
-	st        state.ModelAccessor
-	resources facade.Resources
-}
-
-// NewMongoModelWatcher returns a new MongoModelWatcher. Active watchers
-// will be stored in the provided Resources. The two GetAuthFunc
-// callbacks will be used on each invocation of the methods to
-// determine current permissions.
-// Right now, model tags are not used, so both created AuthFuncs
-// are called with "" for tag, which means "the current model".
-func NewMongoModelWatcher(st state.ModelAccessor, resources facade.Resources) *MongoModelWatcher {
-	return &MongoModelWatcher{
-		st:        st,
-		resources: resources,
-	}
-}
-
-// WatchForModelConfigChanges returns a NotifyWatcher that observes
-// changes to the model configuration.
-// Note that although the NotifyWatchResult contains an Error field,
-// it's not used because we are only returning a single watcher,
-// so we use the regular error return.
-func (m *MongoModelWatcher) WatchForModelConfigChanges(ctx context.Context) (params.NotifyWatchResult, error) {
-	result := params.NotifyWatchResult{}
-	watch := m.st.WatchForModelConfigChanges()
-	// Consume the initial event. Technically, API
-	// calls to Watch 'transmit' the initial event
-	// in the Watch response. But NotifyWatchers
-	// have no state to transmit.
-	if _, ok := <-watch.Changes(); ok {
-		result.NotifyWatcherId = m.resources.Register(watch)
-	} else {
-		return result, statewatcher.EnsureErr(watch)
-	}
-	return result, nil
-}
-
-// ModelConfig returns the current model's configuration.
-func (m *MongoModelWatcher) ModelConfig(ctx context.Context) (params.ModelConfigResult, error) {
-	result := params.ModelConfigResult{}
-	config, err := m.st.ModelConfig(ctx)
 	if err != nil {
 		return result, err
 	}

--- a/apiserver/common/modelwatcher_test.go
+++ b/apiserver/common/modelwatcher_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/common/mocks"
 	facademocks "github.com/juju/juju/apiserver/facade/mocks"
-	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/core/watcher/watchertest"
 	"github.com/juju/juju/environs/bootstrap"
@@ -26,7 +25,6 @@ import (
 	"github.com/juju/juju/internal/testing"
 	"github.com/juju/juju/jujuclient"
 	"github.com/juju/juju/rpc/params"
-	"github.com/juju/juju/state"
 )
 
 type modelWatcherSuite struct {
@@ -125,65 +123,6 @@ func (s *modelWatcherSuite) TestModelConfigFetchError(c *gc.C) {
 	result, err := facade.ModelConfig(context.Background())
 	c.Assert(err, gc.ErrorMatches, "nope")
 	c.Check(result.Config, gc.IsNil)
-}
-
-type mongoModelWatcherSuite struct {
-	testing.BaseSuite
-}
-
-var _ = gc.Suite(&mongoModelWatcherSuite{})
-
-type fakeModelAccessor struct {
-	modelConfig      *config.Config
-	modelConfigError error
-}
-
-func (*fakeModelAccessor) WatchForModelConfigChanges() state.NotifyWatcher {
-	return apiservertesting.NewFakeNotifyWatcher()
-}
-
-func (f *fakeModelAccessor) ModelConfig(ctx context.Context) (*config.Config, error) {
-	if f.modelConfigError != nil {
-		return nil, f.modelConfigError
-	}
-	return f.modelConfig, nil
-}
-
-func (s *mongoModelWatcherSuite) TestWatchSuccess(c *gc.C) {
-	resources := common.NewResources()
-	s.AddCleanup(func(_ *gc.C) { resources.StopAll() })
-	e := common.NewMongoModelWatcher(
-		&fakeModelAccessor{},
-		resources,
-	)
-	result, err := e.WatchForModelConfigChanges(context.Background())
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(result, gc.DeepEquals, params.NotifyWatchResult{NotifyWatcherId: "1", Error: nil})
-	c.Assert(resources.Count(), gc.Equals, 1)
-}
-
-func (*mongoModelWatcherSuite) TestModelConfigSuccess(c *gc.C) {
-	testingModelConfig := testingEnvConfig(c)
-	e := common.NewMongoModelWatcher(
-		&fakeModelAccessor{modelConfig: testingModelConfig},
-		nil,
-	)
-	result, err := e.ModelConfig(context.Background())
-	c.Assert(err, jc.ErrorIsNil)
-	// Make sure we can read the secret attribute (i.e. it's not masked).
-	c.Check(result.Config["secret"], gc.Equals, "pork")
-	c.Check(map[string]any(result.Config), jc.DeepEquals, testingModelConfig.AllAttrs())
-}
-
-func (*mongoModelWatcherSuite) TestModelConfigFetchError(c *gc.C) {
-	e := common.NewMongoModelWatcher(
-		&fakeModelAccessor{
-			modelConfigError: fmt.Errorf("pow"),
-		},
-		nil,
-	)
-	_, err := e.ModelConfig(context.Background())
-	c.Assert(err, gc.ErrorMatches, "pow")
 }
 
 func testingEnvConfig(c *gc.C) *config.Config {

--- a/state/interface.go
+++ b/state/interface.go
@@ -4,7 +4,6 @@
 package state
 
 import (
-	"context"
 	"time"
 
 	"github.com/juju/names/v5"
@@ -13,7 +12,6 @@ import (
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/core/status"
-	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/internal/tools"
 )
 
@@ -69,13 +67,6 @@ type Authenticator interface {
 // can be watched.
 type NotifyWatcherFactory interface {
 	Watch() NotifyWatcher
-}
-
-// ModelAccessor defines the methods needed to watch for model
-// config changes, and read the model config.
-type ModelAccessor interface {
-	WatchForModelConfigChanges() NotifyWatcher
-	ModelConfig(context.Context) (*config.Config, error)
 }
 
 // UnitsWatcher defines the methods needed to retrieve an entity (a

--- a/state/interface_test.go
+++ b/state/interface_test.go
@@ -34,9 +34,8 @@ var (
 	_ NotifyWatcherFactory = (*Application)(nil)
 	_ NotifyWatcherFactory = (*Model)(nil)
 
-	_ ModelAccessor = (*Model)(nil)
-	_ UnitsWatcher  = (*Machine)(nil)
-	_ UnitsWatcher  = (*Application)(nil)
+	_ UnitsWatcher = (*Machine)(nil)
+	_ UnitsWatcher = (*Application)(nil)
 
 	_ ModelMachinesWatcher = (*State)(nil)
 


### PR DESCRIPTION
Through a series of recent PRs (#18056, #18064, #18075, #18076, #18087), the `MongoModelWatcher` in `apiserver/common` has been entirely replaced with the (Dqlite-based) `ModelWatcher`. Hence we can now remove the `MongoModelWatcher`.

We can also delete the `ModelAccessor` interface in state, as this was the last usage.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- ~[ ] Code style: imports ordered, good names, simple structure, etc~
- ~[ ] Comments saying why design decisions were made~
- ~[ ] Go unit tests, with comments saying what you're testing~
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

N/A - this is a removal of unused code. Check Juju builds, linting passes and all unit tests pass.

## Links

**Jira card:** JUJU-6680