### PR TITLE
fix: juju dashboard cmd when resolving ipv6 host

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -512,7 +512,7 @@ func dialAPI(ctx context.Context, info *Info, opts0 DialOpts) (*dialResult, erro
 		case jujuproxy.TunnelProxier:
 			logger.Debugf("tunnel proxy in use at %s on port %s", p.Host(), p.Port())
 			addrs = []string{
-				fmt.Sprintf("%s:%s", p.Host(), p.Port()),
+				net.JoinHostPort(p.Host(), p.Port()),
 			}
 		default:
 			info.Proxier.Stop()

--- a/cmd/juju/dashboard/dashboard.go
+++ b/cmd/juju/dashboard/dashboard.go
@@ -6,9 +6,11 @@ package dashboard
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/url"
 	"os"
 	"os/signal"
+	"strconv"
 	"sync"
 
 	"github.com/juju/cmd/v3"
@@ -223,7 +225,7 @@ func tunnelSSHRunner(
 		args = append(args, "-m", tunnel.Model, tunnel.Entity)
 	}
 	args = append(args, "-N", "-L",
-		fmt.Sprintf("%d:%s:%s", localPort, tunnel.Host, tunnel.Port))
+		fmt.Sprintf("%d:%s", localPort, net.JoinHostPort(tunnel.Host, tunnel.Port)))
 
 	return func(ctx context.Context, callBack urlCallBack) error {
 		f := &gnuflag.FlagSet{}
@@ -237,7 +239,11 @@ func tunnelSSHRunner(
 			return errors.Trace(err)
 		}
 
-		callBack(fmt.Sprintf("http://localhost:%d", localPort))
+		u := url.URL{
+			Scheme: "http",
+			Host:   net.JoinHostPort("localhost", strconv.Itoa(localPort)),
+		}
+		callBack(u.String())
 
 		// TODO(wallyworld) - extract the core ssh machinery and use directly.
 		defCtx, err := cmd.DefaultContext()
@@ -256,7 +262,11 @@ func tunnelProxyRunner(p proxy.TunnelProxier) connectionRunner {
 		}
 		defer p.Stop()
 
-		callBack(fmt.Sprintf("http://%s:%s", p.Host(), p.Port()))
+		u := url.URL{
+			Scheme: "http",
+			Host:   net.JoinHostPort(p.Host(), p.Port()),
+		}
+		callBack(u.String())
 		select {
 		case <-ctx.Done():
 		}


### PR DESCRIPTION
`juju dashboard` command should be able to use an ipv6 address in ssh proxy.

```
| Dashboard for controller "ctrl-b2caas32" is enabled at:
    |   http://localhost:31666/
    | Your login credential is:
    |   username: admin
    |   password: eeb257ecb030a74e288e3af2afe74cae
    | Bad local forwarding specification '31666:fd42:507a:f3b9:e2a2:216:3eff:fec6:ac86:8080'
    | ERROR running connection runner: subprocess encountered error code 255
```

## QA steps

Check you can still:
- bootstrap
- deploy `juju-dashboard`
- relate to the controller
- use `juju dashboard` command

It might be difficult to reliably get a v6 address.

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links

https://jenkins.juju.canonical.com/job/test-dashboard-test-dashboard-deploy-lxd/1770/consoleText

