### PR TITLE
fix: firewaller panic

### DIFF
--- a/internal/worker/firewaller/shim.go
+++ b/internal/worker/firewaller/shim.go
@@ -42,7 +42,10 @@ func (s *firewallerShim) Machine(ctx context.Context, tag names.MachineTag) (Mac
 
 func (s *firewallerShim) Unit(ctx context.Context, tag names.UnitTag) (Unit, error) {
 	u, err := s.Client.Unit(ctx, tag)
-	return &unitShim{Unit: u}, err
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &unitShim{Unit: u}, nil
 }
 
 type unitShim struct {


### PR DESCRIPTION
We should return a nil Unit and nil unitShim on any error. The firewaller code expects the unit to be nil if there is any error. Failure here causes the a panic, because of a nil tag.


## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing


## QA steps

```
$ juju bootstrap lxd test
$ juju add-model default
$ juju deploy postgresql -n 2
$ juju deploy postgresql pgsink
$ juju relate postgresql:replication-offer pgsink
```


