### PR TITLE
chore: skip terraform tests while they are not reliably passing

### DIFF
--- a/.github/workflows/context-tests.yml
+++ b/.github/workflows/context-tests.yml
@@ -104,7 +104,8 @@ jobs:
   terraform:
     needs: [changed-files]
     name: Terraform Smoke
-    if: github.event.pull_request.draft == false && github.base_ref != 'main' && needs.changed-files.outputs.check-terraform == 'true'
+    # TODO - always skip terraform tests until they are made reliable on 3.x branches.
+    if: false && github.event.pull_request.draft == false && github.base_ref != 'main' && needs.changed-files.outputs.check-terraform == 'true'
     uses: ./.github/workflows/terraform-smoke.yml
 
   migrate:


### PR DESCRIPTION
The Terraform smoke tests mostly fail on 3.x branches. The issues are upstream and are known but will take some time to fix. Until then, running the tests takes time and doesn't add any value since we end up with a red cross anyway.

This PR skips them for now until upstream is fixed.