### PR TITLE
refactor: use model config service in storage backend

### DIFF
--- a/apiserver/common/modelmanagerinterface.go
+++ b/apiserver/common/modelmanagerinterface.go
@@ -57,8 +57,8 @@ type ModelManagerBackend interface {
 	ModelTag() names.ModelTag
 	AllMachines() (machines []Machine, err error)
 	AllApplications() (applications []Application, err error)
-	AllFilesystems() ([]state.Filesystem, error)
-	AllVolumes() ([]state.Volume, error)
+	AllFilesystems(ModelConfigService) ([]state.Filesystem, error)
+	AllVolumes(ModelConfigService) ([]state.Volume, error)
 	ControllerTag() names.ControllerTag
 	Export(leaders map[string]string, store objectstore.ObjectStore) (description.Model, error)
 	ExportPartial(state.ExportConfig, objectstore.ObjectStore) (description.Model, error)
@@ -307,16 +307,16 @@ func (st modelManagerStateShim) AllApplications() ([]Application, error) {
 	return all, nil
 }
 
-func (st modelManagerStateShim) AllFilesystems() ([]state.Filesystem, error) {
-	sb, err := state.NewStorageBackend(st.State)
+func (st modelManagerStateShim) AllFilesystems(modelConfigService ModelConfigService) ([]state.Filesystem, error) {
+	sb, err := state.NewStorageBackendFromServices(st.State, modelConfigService)
 	if err != nil {
 		return nil, err
 	}
 	return sb.AllFilesystems()
 }
 
-func (st modelManagerStateShim) AllVolumes() ([]state.Volume, error) {
-	sb, err := state.NewStorageBackend(st.State)
+func (st modelManagerStateShim) AllVolumes(modelConfigService ModelConfigService) ([]state.Volume, error) {
+	sb, err := state.NewStorageBackendFromServices(st.State, modelConfigService)
 	if err != nil {
 		return nil, err
 	}

--- a/apiserver/common/modelstatus_test.go
+++ b/apiserver/common/modelstatus_test.go
@@ -14,12 +14,14 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/apiserver/common"
+	"github.com/juju/juju/apiserver/common/mocks"
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/core/arch"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/life"
+	"github.com/juju/juju/core/model"
 	storageerrors "github.com/juju/juju/domain/storage/errors"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/envcontext"
@@ -65,6 +67,11 @@ func (s *modelStatusSuite) SetUpTest(c *gc.C) {
 		common.NewModelManagerBackend(state.NoopConfigSchemaSource, s.Model, s.StatePool),
 		s.authorizer,
 		s.authorizer.GetAuthTag().(names.UserTag),
+		func(uuid model.UUID) common.ModelConfigService {
+			// For these tests, we just need something of the right type. It
+			// doesn't actually have to do anything (yet).
+			return mocks.NewMockModelConfigService(nil)
+		},
 	)
 
 	loggo.GetLogger("juju.apiserver.controller").SetLogLevel(loggo.TRACE)
@@ -81,6 +88,7 @@ func (s *modelStatusSuite) TestModelStatusNonAuth(c *gc.C) {
 		common.NewModelManagerBackend(state.NoopConfigSchemaSource, s.Model, s.StatePool),
 		anAuthoriser,
 		anAuthoriser.GetAuthTag().(names.UserTag),
+		nil,
 	)
 	controllerModelTag := s.Model.ModelTag().String()
 
@@ -104,6 +112,7 @@ func (s *modelStatusSuite) TestModelStatusOwnerAllowed(c *gc.C) {
 		common.NewModelManagerBackend(state.NoopConfigSchemaSource, s.Model, s.StatePool),
 		anAuthoriser,
 		anAuthoriser.GetAuthTag().(names.UserTag),
+		nil,
 	)
 
 	model, err := st.Model()

--- a/apiserver/facades/agent/storageprovisioner/register.go
+++ b/apiserver/facades/agent/storageprovisioner/register.go
@@ -45,7 +45,7 @@ func newFacadeV4(stdCtx context.Context, ctx facade.ModelContext) (*StorageProvi
 		return nil, errors.Trace(err)
 	}
 
-	backend, storageBackend, err := NewStateBackends(st)
+	backend, storageBackend, err := NewStateBackends(st, serviceFactory.Config())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/apiserver/facades/agent/storageprovisioner/shim.go
+++ b/apiserver/facades/agent/storageprovisioner/shim.go
@@ -84,12 +84,12 @@ type stateShim struct {
 }
 
 // NewStateBackends creates a Backend from the given *state.State.
-func NewStateBackends(st *state.State) (Backend, StorageBackend, error) {
+func NewStateBackends(st *state.State, modelConfigService ModelConfigService) (Backend, StorageBackend, error) {
 	m, err := st.Model()
 	if err != nil {
 		return nil, nil, err
 	}
-	sb, err := state.NewStorageBackend(st)
+	sb, err := state.NewStorageBackendFromServices(st, modelConfigService)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/apiserver/facades/agent/storageprovisioner/storageprovisioner_caas_test.go
+++ b/apiserver/facades/agent/storageprovisioner/storageprovisioner_caas_test.go
@@ -68,7 +68,7 @@ func (s *caasProvisionerSuite) SetUpTest(c *gc.C) {
 		Tag:        names.NewMachineTag("0"),
 		Controller: true,
 	}
-	backend, storageBackend, err := storageprovisioner.NewStateBackends(s.st)
+	backend, storageBackend, err := storageprovisioner.NewStateBackends(s.st, serviceFactory.Config())
 	c.Assert(err, jc.ErrorIsNil)
 	s.storageBackend = storageBackend
 	s.api, err = storageprovisioner.NewStorageProvisionerAPIv4(

--- a/apiserver/facades/agent/storageprovisioner/storageprovisioner_iaas_test.go
+++ b/apiserver/facades/agent/storageprovisioner/storageprovisioner_iaas_test.go
@@ -77,7 +77,7 @@ func (s *iaasProvisionerSuite) newApi(c *gc.C, blockDeviceService storageprovisi
 		Tag:        names.NewMachineTag("0"),
 		Controller: true,
 	}
-	backend, storageBackend, err := storageprovisioner.NewStateBackends(s.st)
+	backend, storageBackend, err := storageprovisioner.NewStateBackends(s.st, serviceFactory.Config())
 	c.Assert(err, jc.ErrorIsNil)
 	s.storageBackend = storageBackend
 	api, err := storageprovisioner.NewStorageProvisionerAPIv4(

--- a/apiserver/facades/agent/storageprovisioner/storageprovisioner_test.go
+++ b/apiserver/facades/agent/storageprovisioner/storageprovisioner_test.go
@@ -39,7 +39,7 @@ func (s *provisionerSuite) SetUpTest(c *gc.C) {
 func (s *provisionerSuite) TestNewStorageProvisionerAPINonMachine(c *gc.C) {
 	tag := names.NewUnitTag("mysql/0")
 	authorizer := &apiservertesting.FakeAuthorizer{Tag: tag}
-	backend, storageBackend, err := storageprovisioner.NewStateBackends(s.st)
+	backend, storageBackend, err := storageprovisioner.NewStateBackends(s.st, s.ControllerServiceFactory(c).Config())
 	c.Assert(err, jc.ErrorIsNil)
 
 	modelInfo, err := s.ControllerServiceFactory(c).ModelInfo().GetModelInfo(context.Background())

--- a/apiserver/facades/client/controller/controller.go
+++ b/apiserver/facades/client/controller/controller.go
@@ -41,7 +41,6 @@ import (
 	modelerrors "github.com/juju/juju/domain/model/errors"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/bootstrap"
-	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/internal/docker"
 	"github.com/juju/juju/internal/migration"
 	"github.com/juju/juju/internal/proxy"
@@ -92,12 +91,6 @@ type ApplicationService interface {
 	GetApplicationLife(ctx context.Context, name string) (life.Value, error)
 }
 
-// ModelConfigService provides access to the model configuration.
-type ModelConfigService interface {
-	// ModelConfig returns the current config for the model.
-	ModelConfig(context.Context) (*config.Config, error)
-}
-
 // ProxyService provides access to the proxy service.
 type ProxyService interface {
 	// GetProxyToApplication returns the proxy information for the application
@@ -134,7 +127,7 @@ type ControllerAPI struct {
 	accessService            ControllerAccessService
 	modelService             ModelService
 	applicationServiceGetter func(coremodel.UUID) ApplicationService
-	modelConfigServiceGetter func(coremodel.UUID) ModelConfigService
+	modelConfigServiceGetter func(coremodel.UUID) common.ModelConfigService
 	proxyService             ProxyService
 	modelExporter            func(coremodel.UUID, facade.LegacyStateExporter) ModelExporter
 	store                    objectstore.ObjectStore
@@ -168,7 +161,7 @@ func NewControllerAPI(
 	accessService ControllerAccessService,
 	modelService ModelService,
 	applicationServiceGetter func(coremodel.UUID) ApplicationService,
-	modelConfigServiceGetter func(coremodel.UUID) ModelConfigService,
+	modelConfigServiceGetter func(coremodel.UUID) common.ModelConfigService,
 	proxyService ProxyService,
 	modelExporter func(coremodel.UUID, facade.LegacyStateExporter) ModelExporter,
 	store objectstore.ObjectStore,
@@ -196,6 +189,7 @@ func NewControllerAPI(
 			common.NewModelManagerBackend(environs.ProviderConfigSchemaSource(cloudService), model, pool),
 			authorizer,
 			apiUser,
+			modelConfigServiceGetter,
 		),
 		CloudSpecer: cloudspec.NewCloudSpecV2(
 			resources,

--- a/apiserver/facades/client/controller/register.go
+++ b/apiserver/facades/client/controller/register.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/juju/errors"
 
+	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/domain/application/service"
@@ -44,7 +45,7 @@ func makeControllerAPI(stdCtx context.Context, ctx facade.MultiModelContext) (*C
 		return nil, errors.Trace(err)
 	}
 
-	modelConfigServiceGetter := func(modelID model.UUID) ModelConfigService {
+	modelConfigServiceGetter := func(modelID model.UUID) common.ModelConfigService {
 		return ctx.ServiceFactoryForModel(modelID).Config()
 	}
 	applicationServiceGetter := func(modelID model.UUID) ApplicationService {

--- a/apiserver/facades/client/modelmanager/modelinfo_test.go
+++ b/apiserver/facades/client/modelmanager/modelinfo_test.go
@@ -887,12 +887,12 @@ func (st *mockState) AllApplications() ([]common.Application, error) {
 	return nil, st.NextErr()
 }
 
-func (st *mockState) AllVolumes() ([]state.Volume, error) {
+func (st *mockState) AllVolumes(common.ModelConfigService) ([]state.Volume, error) {
 	st.MethodCall(st, "AllVolumes")
 	return nil, st.NextErr()
 }
 
-func (st *mockState) AllFilesystems() ([]state.Filesystem, error) {
+func (st *mockState) AllFilesystems(common.ModelConfigService) ([]state.Filesystem, error) {
 	st.MethodCall(st, "AllFilesystems")
 	return nil, st.NextErr()
 }

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -125,7 +125,12 @@ func NewModelManagerAPI(
 	isAdmin := err == nil
 
 	return &ModelManagerAPI{
-		ModelStatusAPI:       common.NewModelStatusAPI(st, authorizer, apiUser),
+		ModelStatusAPI: common.NewModelStatusAPI(
+			st, authorizer, apiUser,
+			func(modelID coremodel.UUID) common.ModelConfigService {
+				return services.ServiceFactoryGetter.ServiceFactoryForModel(modelID).Config()
+			},
+		),
 		state:                st,
 		serviceFactoryGetter: services.ServiceFactoryGetter,
 		modelExporter:        modelExporter,

--- a/apiserver/facades/client/modelmanager/services.go
+++ b/apiserver/facades/client/modelmanager/services.go
@@ -18,10 +18,12 @@ import (
 	"github.com/juju/juju/core/objectstore"
 	corepermission "github.com/juju/juju/core/permission"
 	coreuser "github.com/juju/juju/core/user"
+	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/domain/access"
 	"github.com/juju/juju/domain/model"
 	modeldefaultsservice "github.com/juju/juju/domain/modeldefaults/service"
 	secretbackendservice "github.com/juju/juju/domain/secretbackend/service"
+	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/internal/servicefactory"
 	"github.com/juju/juju/internal/uuid"
 	"github.com/juju/juju/state"
@@ -46,6 +48,11 @@ type ModelConfigServiceGetter func(coremodel.UUID) (ModelConfigService, error)
 // ModelConfigService describes the set of functions needed for working with a
 // model's config.
 type ModelConfigService interface {
+	// ModelConfig returns the current config for the model.
+	ModelConfig(context.Context) (*config.Config, error)
+	// Watch returns a watcher that returns keys for any changes to model
+	// config.
+	Watch() (watcher.StringsWatcher, error)
 	// SetModelConfig sets the models config.
 	SetModelConfig(context.Context, map[string]any) error
 }

--- a/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
@@ -125,7 +125,7 @@ func NewStateCAASApplicationProvisionerAPI(ctx facade.ModelContext) (*APIGroup, 
 		),
 	})
 
-	sb, err := state.NewStorageBackend(ctx.State())
+	sb, err := state.NewStorageBackendFromServices(ctx.State(), modelConfigService)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}


### PR DESCRIPTION
## Background

There is a "storage backend" in state which uses Mongo model config. As part of the model config epic, we need to deal with this.

Unfortunately the storage backend is used *everywhere* in state (even inside Mongo operations), and it's impossible to wire a model config service through all of this. Nor is this really necessary: model config is only used to get the default storage pool, and only two keys are read: `storage-default-block-source` and `storage-default-filesystem-source`. There is already logic to choose a default if these model config keys are not defined (namely, block storage defaults to `loop` and fs storage defaults to `rootfs`).

Hence, for now, it is fine to just disable the model config access in the storage backend and fallback to the default values. Effectively, this will mean that `storage-default-block-source` and `storage-default-filesystem-source` are ignored sometimes. Considering they are just default values, we are not losing any functionality here but only some convenience, so it's not too egregious IMO. I will add an item to the risk register about this, and when storage is re-implemented in Dqlite, we can make sure that these keys are re-enabled.

## Changes

This PR:
- Modifies the `NewStorageBackend` method so that it uses a fake/fixed/default model config instead of reading the real one from Mongo. Furthermore, this method has been deprecated.
- Adds a new method `NewStorageBackendFromServices`, which creates a storage backend using a model config service.
- Refactor facade code to use `NewStorageBackendFromServices` instead of `NewStorageBackend`.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

TODO

## Links

**Jira card:** JUJU-6679