### PR TITLE
refactor: delete unused ConfigValidator method from state

### DIFF
--- a/apiserver/common/modelstatus_test.go
+++ b/apiserver/common/modelstatus_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/life"
 	storageerrors "github.com/juju/juju/domain/storage/errors"
-	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/envcontext"
 	"github.com/juju/juju/internal/storage"
 	"github.com/juju/juju/internal/storage/provider"
@@ -311,10 +310,6 @@ func (noopStoragePoolGetter) GetStoragePoolByName(_ context.Context, name string
 }
 
 type statePolicy struct{}
-
-func (statePolicy) ConfigValidator() (config.Validator, error) {
-	return nil, errors.NotImplementedf("ConfigValidator")
-}
 
 func (statePolicy) ConstraintsValidator(envcontext.ProviderCallContext) (constraints.Validator, error) {
 	return nil, errors.NotImplementedf("ConstraintsValidator")

--- a/state/internal_test.go
+++ b/state/internal_test.go
@@ -93,10 +93,6 @@ func (s *internalStateSuite) TearDownTest(c *gc.C) {
 
 type internalStatePolicy struct{}
 
-func (internalStatePolicy) ConfigValidator() (config.Validator, error) {
-	return nil, errors.NotImplementedf("ConfigValidator")
-}
-
 func (internalStatePolicy) ConstraintsValidator(envcontext.ProviderCallContext) (constraints.Validator, error) {
 	return nil, errors.NotImplementedf("ConstraintsValidator")
 }

--- a/state/stateenvirons/policy.go
+++ b/state/stateenvirons/policy.go
@@ -4,7 +4,6 @@
 package stateenvirons
 
 import (
-	stdcontext "context"
 	"sync"
 
 	"github.com/juju/errors"
@@ -13,7 +12,6 @@ import (
 	"github.com/juju/juju/core/constraints"
 	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/environs"
-	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/envcontext"
 	"github.com/juju/juju/internal/storage"
 	"github.com/juju/juju/internal/storage/provider"
@@ -96,19 +94,6 @@ func (p *environStatePolicy) getDeployChecker() (deployChecker, error) {
 	return p.checker, err
 }
 
-// ConfigValidator implements state.Policy.
-func (p *environStatePolicy) ConfigValidator() (config.Validator, error) {
-	model, err := p.st.Model()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	cloud, err := p.cloudService.Cloud(stdcontext.Background(), model.CloudName())
-	if err != nil {
-		return nil, errors.Annotate(err, "getting cloud")
-	}
-	return environProvider(cloud.Type)
-}
-
 // ConstraintsValidator implements state.Policy.
 func (p *environStatePolicy) ConstraintsValidator(ctx envcontext.ProviderCallContext) (constraints.Validator, error) {
 	checker, err := p.getDeployChecker()
@@ -174,8 +159,4 @@ func NewStorageProviderRegistryForModel(
 // the provided registry with the common storage providers.
 func NewStorageProviderRegistry(reg storage.ProviderRegistry) storage.ProviderRegistry {
 	return storage.ChainedProviderRegistry{reg, provider.CommonStorageProviders()}
-}
-
-func environProvider(cloudType string) (environs.EnvironProvider, error) {
-	return environs.Provider(cloudType)
 }

--- a/state/testing/policy.go
+++ b/state/testing/policy.go
@@ -24,18 +24,10 @@ import (
 )
 
 type MockPolicy struct {
-	GetConfigValidator         func() (config.Validator, error)
 	GetConstraintsValidator    func() (constraints.Validator, error)
 	GetStorageProviderRegistry func() (storage.ProviderRegistry, error)
 
 	Providers map[string]domainstorage.StoragePoolDetails
-}
-
-func (p *MockPolicy) ConfigValidator() (config.Validator, error) {
-	if p.GetConfigValidator != nil {
-		return p.GetConfigValidator()
-	}
-	return nil, errors.NotImplementedf("ConfigValidator")
 }
 
 func (p *MockPolicy) ConstraintsValidator(ctx envcontext.ProviderCallContext) (constraints.Validator, error) {


### PR DESCRIPTION
Model config is validated in the domain and by providers. This method is no longer used.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc~
- ~[ ] Comments saying why design decisions were made~
- ~[ ] Go unit tests, with comments saying what you're testing~
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```
$ juju bootstrap lxd testing
$ juju add-model testme
$ juju deploy ubuntu -n 2
$ juju model-config update-status-hook-interval=3m

# check controller and testme model logs - no errors related to missing config validator. No panics.
```

## Links

**Jira card:** JUJU-6688

