### PR TITLE
feat(units): state methods for unit agent/workload/container status

### DIFF
--- a/domain/application/state/types.go
+++ b/domain/application/state/types.go
@@ -4,6 +4,8 @@
 package state
 
 import (
+	"time"
+
 	"github.com/juju/juju/domain/application"
 	"github.com/juju/juju/domain/life"
 )
@@ -83,6 +85,19 @@ type unitCount struct {
 	UnitLifeID        life.Life `db:"unit_life_id"`
 	ApplicationLifeID life.Life `db:"app_life_id"`
 	Count             int       `db:"count"`
+}
+
+type unitStatusInfo struct {
+	UnitUUID  string    `db:"unit_uuid"`
+	StatusID  int       `db:"status_id"`
+	Message   string    `db:"message"`
+	UpdatedAt time.Time `db:"updated_at"`
+}
+
+type unitStatusData struct {
+	UnitUUID string `db:"unit_uuid"`
+	Key      string `db:"key"`
+	Data     string `db:"data"`
 }
 
 type cloudContainer struct {

--- a/domain/application/status.go
+++ b/domain/application/status.go
@@ -1,0 +1,101 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package application
+
+import (
+	corestatus "github.com/juju/juju/core/status"
+)
+
+// CloudContainerStatusType represents the status of a cloud container
+// as recorded in the cloud_container_status_value lookup table.
+type CloudContainerStatusType int
+
+const (
+	CloudContainerStatusWaiting CloudContainerStatusType = iota
+	CloudContainerStatusBlocked
+	CloudContainerStatusRunning
+)
+
+// MarshallCloudContainerStatus converts a core status to a db cloud container status id.
+func MarshallCloudContainerStatus(status corestatus.Status) CloudContainerStatusType {
+	switch status {
+	case corestatus.Waiting:
+		return CloudContainerStatusWaiting
+	case corestatus.Blocked:
+		return CloudContainerStatusBlocked
+	case corestatus.Running:
+		return CloudContainerStatusRunning
+	}
+	return CloudContainerStatusWaiting
+}
+
+// UnitAgentStatusType represents the status of a unit agent
+// as recorded in the unit_agent_status_value lookup table.
+type UnitAgentStatusType int
+
+const (
+	UnitAgentStatusAllocating UnitAgentStatusType = iota
+	UnitAgentStatusExecuting
+	UnitAgentStatusIdle
+	UnitAgentStatusError
+	UnitAgentStatusFailed
+	UnitAgentStatusLost
+	UnitAgentStatusRebooting
+)
+
+// MarshallUnitAgentStatus converts a core status to a db cunit agent status id.
+func MarshallUnitAgentStatus(status corestatus.Status) UnitAgentStatusType {
+	switch status {
+	case corestatus.Allocating:
+		return UnitAgentStatusAllocating
+	case corestatus.Executing:
+		return UnitAgentStatusExecuting
+	case corestatus.Idle:
+		return UnitAgentStatusIdle
+	case corestatus.Error:
+		return UnitAgentStatusError
+	case corestatus.Failed:
+		return UnitAgentStatusFailed
+	case corestatus.Lost:
+		return UnitAgentStatusLost
+	case corestatus.Rebooting:
+		return UnitAgentStatusRebooting
+	}
+	return UnitAgentStatusAllocating
+}
+
+// UnitWorkloadStatusType represents the status of a unit workload
+// as recorded in the unit_workload_status_value lookup table.
+type UnitWorkloadStatusType int
+
+const (
+	UnitWorkloadStatusUnset UnitWorkloadStatusType = iota
+	UnitWorkloadStatusUnknown
+	UnitWorkloadStatusMaintenance
+	UnitWorkloadStatusWaiting
+	UnitWorkloadStatusBlocked
+	UnitWorkloadStatusActive
+	UnitWorkloadStatusTerminated
+)
+
+// MarshallUnitWorkloadStatus converts a core status to a db unit workload status id.
+func MarshallUnitWorkloadStatus(status corestatus.Status) UnitWorkloadStatusType {
+	switch status {
+	case corestatus.Unset:
+		return UnitWorkloadStatusUnset
+	case corestatus.Unknown:
+		return UnitWorkloadStatusUnknown
+	case corestatus.Maintenance:
+		return UnitWorkloadStatusMaintenance
+	case corestatus.Waiting:
+		return UnitWorkloadStatusWaiting
+	case corestatus.Blocked:
+		return UnitWorkloadStatusBlocked
+	case corestatus.Active:
+		return UnitWorkloadStatusActive
+	case corestatus.Terminated:
+		return UnitWorkloadStatusTerminated
+	}
+	return UnitWorkloadStatusUnset
+}

--- a/domain/application/status_test.go
+++ b/domain/application/status_test.go
@@ -1,0 +1,103 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package application
+
+import (
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	schematesting "github.com/juju/juju/domain/schema/testing"
+)
+
+type statusSuite struct {
+	schematesting.ModelSuite
+}
+
+var _ = gc.Suite(&statusSuite{})
+
+// TestCloudContainerStatusDBValues ensures there's no skew between what's in the
+// database table for cloud container status and the typed consts used in the
+// state packages.
+func (s *statusSuite) TestCloudContainerStatusDBValues(c *gc.C) {
+	db := s.DB()
+	rows, err := db.Query("SELECT id, status FROM cloud_container_status_value")
+	c.Assert(err, jc.ErrorIsNil)
+	defer rows.Close()
+
+	dbValues := make(map[CloudContainerStatusType]string)
+	for rows.Next() {
+		var (
+			id   int
+			name string
+		)
+		err := rows.Scan(&id, &name)
+		c.Assert(err, jc.ErrorIsNil)
+		dbValues[CloudContainerStatusType(id)] = name
+	}
+	c.Assert(dbValues, jc.DeepEquals, map[CloudContainerStatusType]string{
+		CloudContainerStatusWaiting: "waiting",
+		CloudContainerStatusBlocked: "blocked",
+		CloudContainerStatusRunning: "running",
+	})
+}
+
+// TestUnitAgentStatusDBValues ensures there's no skew between what's in the
+// database table for unit agent status and the typed consts used in the
+// state packages.
+func (s *statusSuite) TestUnitAgentStatusDBValues(c *gc.C) {
+	db := s.DB()
+	rows, err := db.Query("SELECT id, status FROM unit_agent_status_value")
+	c.Assert(err, jc.ErrorIsNil)
+	defer rows.Close()
+
+	dbValues := make(map[UnitAgentStatusType]string)
+	for rows.Next() {
+		var (
+			id   int
+			name string
+		)
+		err := rows.Scan(&id, &name)
+		c.Assert(err, jc.ErrorIsNil)
+		dbValues[UnitAgentStatusType(id)] = name
+	}
+	c.Assert(dbValues, jc.DeepEquals, map[UnitAgentStatusType]string{
+		UnitAgentStatusAllocating: "allocating",
+		UnitAgentStatusExecuting:  "executing",
+		UnitAgentStatusIdle:       "idle",
+		UnitAgentStatusError:      "error",
+		UnitAgentStatusFailed:     "failed",
+		UnitAgentStatusLost:       "lost",
+		UnitAgentStatusRebooting:  "rebooting",
+	})
+}
+
+// TestUnitWorkloadStatusDBValues ensures there's no skew between what's in the
+// database table for unit workload status and the typed consts used in the
+// state packages.
+func (s *statusSuite) TestUnitWorkloadStatusDBValues(c *gc.C) {
+	db := s.DB()
+	rows, err := db.Query("SELECT id, status FROM unit_workload_status_value")
+	c.Assert(err, jc.ErrorIsNil)
+	defer rows.Close()
+
+	dbValues := make(map[UnitWorkloadStatusType]string)
+	for rows.Next() {
+		var (
+			id   int
+			name string
+		)
+		err := rows.Scan(&id, &name)
+		c.Assert(err, jc.ErrorIsNil)
+		dbValues[UnitWorkloadStatusType(id)] = name
+	}
+	c.Assert(dbValues, jc.DeepEquals, map[UnitWorkloadStatusType]string{
+		UnitWorkloadStatusUnset:       "unset",
+		UnitWorkloadStatusUnknown:     "unknown",
+		UnitWorkloadStatusMaintenance: "maintenance",
+		UnitWorkloadStatusWaiting:     "waiting",
+		UnitWorkloadStatusBlocked:     "blocked",
+		UnitWorkloadStatusActive:      "active",
+		UnitWorkloadStatusTerminated:  "terminated",
+	})
+}

--- a/domain/application/types.go
+++ b/domain/application/types.go
@@ -4,6 +4,8 @@
 package application
 
 import (
+	"time"
+
 	domaincharm "github.com/juju/juju/domain/application/charm"
 	"github.com/juju/juju/domain/ipaddress"
 	"github.com/juju/juju/domain/linklayerdevice"
@@ -107,4 +109,31 @@ type UpsertUnitArg struct {
 	UnitName       string
 	PasswordHash   *string
 	CloudContainer *CloudContainer
+}
+
+// CloudContainerStatusStatusInfo holds a cloud container status
+// and associated information.
+type CloudContainerStatusStatusInfo struct {
+	StatusID CloudContainerStatusType
+	Message  string
+	Data     map[string]string
+	Since    time.Time
+}
+
+// UnitAgentStatusInfo holds a unit agent status
+// and associated information.
+type UnitAgentStatusInfo struct {
+	StatusID UnitAgentStatusType
+	Message  string
+	Data     map[string]string
+	Since    time.Time
+}
+
+// UnitWorkloadStatusInfo holds a unit workload status
+// and associated information.
+type UnitWorkloadStatusInfo struct {
+	StatusID UnitWorkloadStatusType
+	Message  string
+	Data     map[string]string
+	Since    time.Time
 }

--- a/domain/schema/model/sql/0019-unit.sql
+++ b/domain/schema/model/sql/0019-unit.sql
@@ -152,9 +152,10 @@ INSERT INTO unit_agent_status_value VALUES
 (0, 'allocating'),
 (1, 'executing'),
 (2, 'idle'),
-(3, 'failed'),
-(4, 'lost'),
-(5, 'rebooting');
+(3, 'error'),
+(4, 'failed'),
+(5, 'lost'),
+(6, 'rebooting');
 
 -- Status values for unit workloads.
 CREATE TABLE unit_workload_status_value (


### PR DESCRIPTION
Adds state methods for saving and deleting status for:
- unit agents
- unit workloads
- unit cloud container

Due to the transition towards using UUID, the status methods take a unit UUID to work with. So a GetUnitUUID method is added to lookup UUID from the unit name - this will be used when the service logic is implemented.

Also adds a missing unit agent status enum for error.

## QA steps

Just unit tests

## Links

**Jira card:** [JUJU-6777](https://warthogs.atlassian.net/browse/JUJU-6777)
**Jira card:** [JUJU-6803](https://warthogs.atlassian.net/browse/JUJU-6803)

