### PR TITLE
feat(lxdprofiles): add DDL and state layer for adding and retrieving LXD profiles

### DIFF
--- a/domain/machine/state/state_test.go
+++ b/domain/machine/state/state_test.go
@@ -788,8 +788,7 @@ func (s *stateSuite) TestSetLXDProfiles(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 		profiles = append(profiles, profile)
 	}
-	c.Check(profiles, gc.HasLen, 2)
-	c.Check(profiles, jc.SameContents, []string{"profile1", "profile2"})
+	c.Check(profiles, gc.DeepEquals, []string{"profile1", "profile2"})
 }
 
 func (s *stateSuite) TestSetLXDProfilesPartial(c *gc.C) {
@@ -799,7 +798,7 @@ func (s *stateSuite) TestSetLXDProfilesPartial(c *gc.C) {
 	// Insert a single lxd profile.
 	db := s.DB()
 	_, err = db.Exec(`INSERT INTO machine_lxd_profile VALUES
-("deadbeef", "profile1")`)
+("deadbeef", "profile1", 0)`)
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = s.state.SetLXDProfiles(context.Background(), "deadbeef", []string{"profile1", "profile2"})
@@ -817,8 +816,45 @@ func (s *stateSuite) TestSetLXDProfilesPartial(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 		profiles = append(profiles, profile)
 	}
-	c.Check(profiles, gc.HasLen, 2)
-	c.Check(profiles, jc.SameContents, []string{"profile1", "profile2"})
+	c.Check(profiles, gc.DeepEquals, []string{"profile1", "profile2"})
+}
+
+func (s *stateSuite) TestSetLXDProfilesOverwriteAll(c *gc.C) {
+	err := s.state.CreateMachine(context.Background(), "666", "", "deadbeef")
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Insert 3 lxd profiles.
+	db := s.DB()
+	_, err = db.Exec(`INSERT INTO machine_lxd_profile VALUES
+("deadbeef", "profile1", 0), ("deadbeef", "profile2", 1), ("deadbeef", "profile3", 2)`)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.state.SetLXDProfiles(context.Background(), "deadbeef", []string{"profile1", "profile4"})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Check that the profile names are in the machine_lxd_profile table.
+	rows, err := db.Query("SELECT name FROM machine_lxd_profile WHERE machine_uuid = 'deadbeef'")
+	defer rows.Close()
+	c.Assert(err, jc.ErrorIsNil)
+	var profiles []string
+	for rows.Next() {
+		var profile string
+		err := rows.Scan(&profile)
+		c.Assert(err, jc.ErrorIsNil)
+		profiles = append(profiles, profile)
+	}
+	c.Check(profiles, gc.DeepEquals, []string{"profile1", "profile4"})
+}
+
+func (s *stateSuite) TestSetLXDProfilesSameOrder(c *gc.C) {
+	err := s.state.CreateMachine(context.Background(), "666", "", "deadbeef")
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.state.SetLXDProfiles(context.Background(), "deadbeef", []string{"profile3", "profile1", "profile2"})
+	c.Assert(err, jc.ErrorIsNil)
+
+	profiles, err := s.state.LXDProfiles(context.Background(), "deadbeef")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(profiles, gc.DeepEquals, []string{"profile3", "profile1", "profile2"})
 }
 
 func (s *stateSuite) TestSetLXDProfilesNotFound(c *gc.C) {
@@ -844,16 +880,12 @@ func (s *stateSuite) TestLXDProfiles(c *gc.C) {
 	// Insert 2 lxd profiles.
 	db := s.DB()
 	_, err = db.Exec(`INSERT INTO machine_lxd_profile VALUES
-("deadbeef", "profile1")`)
-	c.Assert(err, jc.ErrorIsNil)
-	_, err = db.Exec(`INSERT INTO machine_lxd_profile VALUES
-("deadbeef", "profile2")`)
+("deadbeef", "profile1", 0), ("deadbeef", "profile2", 1)`)
 	c.Assert(err, jc.ErrorIsNil)
 
 	profiles, err := s.state.LXDProfiles(context.Background(), "deadbeef")
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(profiles, gc.HasLen, 2)
-	c.Check(profiles, jc.SameContents, []string{"profile1", "profile2"})
+	c.Check(profiles, gc.DeepEquals, []string{"profile1", "profile2"})
 }
 
 func (s *stateSuite) TestLXDProfilesNoErrorEmpty(c *gc.C) {

--- a/domain/machine/state/state_test.go
+++ b/domain/machine/state/state_test.go
@@ -776,8 +776,48 @@ func (s *stateSuite) TestSetLXDProfiles(c *gc.C) {
 	err = s.state.SetLXDProfiles(context.Background(), "deadbeef", []string{"profile1", "profile2"})
 	c.Assert(err, jc.ErrorIsNil)
 
-	profiles, err := s.state.LXDProfiles(context.Background(), "deadbeef")
+	// Check that the profile names are in the machine_lxd_profile table.
+	db := s.DB()
+	rows, err := db.Query("SELECT name FROM machine_lxd_profile WHERE machine_uuid = 'deadbeef'")
+	defer rows.Close()
 	c.Assert(err, jc.ErrorIsNil)
+	var profiles []string
+	for rows.Next() {
+		var profile string
+		err := rows.Scan(&profile)
+		c.Assert(err, jc.ErrorIsNil)
+		profiles = append(profiles, profile)
+	}
+	c.Check(profiles, gc.HasLen, 2)
+	c.Check(profiles, jc.SameContents, []string{"profile1", "profile2"})
+}
+
+func (s *stateSuite) TestSetLXDProfilesPartial(c *gc.C) {
+	err := s.state.CreateMachine(context.Background(), "666", "", "deadbeef")
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Insert a single lxd profile.
+	db := s.DB()
+	_, err = db.Exec(`INSERT INTO machine_lxd_profile VALUES
+("deadbeef", "profile1")`)
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.state.SetLXDProfiles(context.Background(), "deadbeef", []string{"profile1", "profile2"})
+	// This shouldn't fail, but add the missing profile to the table.
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Check that the profile names are in the machine_lxd_profile table.
+	rows, err := db.Query("SELECT name FROM machine_lxd_profile WHERE machine_uuid = 'deadbeef'")
+	defer rows.Close()
+	c.Assert(err, jc.ErrorIsNil)
+	var profiles []string
+	for rows.Next() {
+		var profile string
+		err := rows.Scan(&profile)
+		c.Assert(err, jc.ErrorIsNil)
+		profiles = append(profiles, profile)
+	}
+	c.Check(profiles, gc.HasLen, 2)
 	c.Check(profiles, jc.SameContents, []string{"profile1", "profile2"})
 }
 
@@ -792,6 +832,31 @@ func (s *stateSuite) TestSetLXDProfilesEmpty(c *gc.C) {
 	err = s.state.SetLXDProfiles(context.Background(), "deadbeef", []string{})
 	c.Assert(err, jc.ErrorIsNil)
 
+	profiles, err := s.state.LXDProfiles(context.Background(), "deadbeef")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(profiles, gc.HasLen, 0)
+}
+
+func (s *stateSuite) TestLXDProfiles(c *gc.C) {
+	err := s.state.CreateMachine(context.Background(), "666", "", "deadbeef")
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Insert 2 lxd profiles.
+	db := s.DB()
+	_, err = db.Exec(`INSERT INTO machine_lxd_profile VALUES
+("deadbeef", "profile1")`)
+	c.Assert(err, jc.ErrorIsNil)
+	_, err = db.Exec(`INSERT INTO machine_lxd_profile VALUES
+("deadbeef", "profile2")`)
+	c.Assert(err, jc.ErrorIsNil)
+
+	profiles, err := s.state.LXDProfiles(context.Background(), "deadbeef")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(profiles, gc.HasLen, 2)
+	c.Check(profiles, jc.SameContents, []string{"profile1", "profile2"})
+}
+
+func (s *stateSuite) TestLXDProfilesNoErrorEmpty(c *gc.C) {
 	profiles, err := s.state.LXDProfiles(context.Background(), "deadbeef")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(profiles, gc.HasLen, 0)

--- a/domain/machine/state/types.go
+++ b/domain/machine/state/types.go
@@ -242,9 +242,3 @@ type lxdProfile struct {
 	MachineUUID string `db:"machine_uuid"`
 	Name        string `db:"name"`
 }
-
-// machineExists is used to record if a row in the machine table exists by
-// selecting true into it.
-type machineExists struct {
-	Exists bool `db:"exists"`
-}

--- a/domain/machine/state/types.go
+++ b/domain/machine/state/types.go
@@ -235,3 +235,16 @@ type createMachineArgs struct {
 	netNodeUUID string
 	parentName  machine.Name
 }
+
+// lxdProfile represents the struct to be used for the sqlair statements on the
+// lxd_profile table.
+type lxdProfile struct {
+	MachineUUID string `db:"machine_uuid"`
+	Name        string `db:"name"`
+}
+
+// machineExists is used to record if a row in the machine table exists by
+// selecting true into it.
+type machineExists struct {
+	Exists bool `db:"exists"`
+}

--- a/domain/machine/state/types.go
+++ b/domain/machine/state/types.go
@@ -241,4 +241,5 @@ type createMachineArgs struct {
 type lxdProfile struct {
 	MachineUUID string `db:"machine_uuid"`
 	Name        string `db:"name"`
+	Index       int    `db:"array_index"`
 }

--- a/domain/schema/model/sql/0016-machine-cloud-instance.sql
+++ b/domain/schema/model/sql/0016-machine-cloud-instance.sql
@@ -26,18 +26,6 @@ CREATE TABLE instance_tag (
     REFERENCES machine (uuid)
 );
 
-CREATE TABLE machine_lxd_profile (
-    machine_uuid TEXT NOT NULL,
-    lxd_profile_uuid TEXT NOT NULL,
-    -- TODO(nvinuesa): lxd_profile_uuid should be a foreign key to the 
-    -- charm_lxd_profile uuid and therefore the CONSTRAINT should be added when 
-    -- that table is implemented.
-    PRIMARY KEY (machine_uuid, lxd_profile_uuid),
-    CONSTRAINT fk_machine_machine_uuid
-    FOREIGN KEY (machine_uuid)
-    REFERENCES machine (uuid)
-);
-
 CREATE TABLE machine_cloud_instance_status_value (
     id INT PRIMARY KEY,
     status TEXT NOT NULL

--- a/domain/schema/model/sql/0017-machine.sql
+++ b/domain/schema/model/sql/0017-machine.sql
@@ -154,3 +154,14 @@ CREATE TABLE machine_removals (
     FOREIGN KEY (machine_uuid)
     REFERENCES machine (uuid)
 );
+
+-- lxd_profile table keeps track of the lxd profiles (previously charm-profiles)
+-- for a machine.
+CREATE TABLE lxd_profile (
+    machine_uuid TEXT NOT NULL,
+    name TEXT NOT NULL,
+    PRIMARY KEY (machine_uuid, name),
+    CONSTRAINT fk_lxd_profile_machine
+    FOREIGN KEY (machine_uuid)
+    REFERENCES machine (uuid)
+);

--- a/domain/schema/model/sql/0017-machine.sql
+++ b/domain/schema/model/sql/0017-machine.sql
@@ -160,6 +160,7 @@ CREATE TABLE machine_removals (
 CREATE TABLE machine_lxd_profile (
     machine_uuid TEXT NOT NULL,
     name TEXT NOT NULL,
+    array_index INT NOT NULL,
     PRIMARY KEY (machine_uuid, name),
     CONSTRAINT fk_lxd_profile_machine
     FOREIGN KEY (machine_uuid)

--- a/domain/schema/model/sql/0017-machine.sql
+++ b/domain/schema/model/sql/0017-machine.sql
@@ -155,9 +155,9 @@ CREATE TABLE machine_removals (
     REFERENCES machine (uuid)
 );
 
--- lxd_profile table keeps track of the lxd profiles (previously charm-profiles)
+-- machine_lxd_profile table keeps track of the lxd profiles (previously charm-profiles)
 -- for a machine.
-CREATE TABLE lxd_profile (
+CREATE TABLE machine_lxd_profile (
     machine_uuid TEXT NOT NULL,
     name TEXT NOT NULL,
     PRIMARY KEY (machine_uuid, name),

--- a/domain/schema/schema_test.go
+++ b/domain/schema/schema_test.go
@@ -701,7 +701,7 @@ func (s *schemaSuite) TestModelTriggers(c *gc.C) {
 func (s *schemaSuite) assertChangeLogCount(c *gc.C, editType int, namespaceID tableNamespaceID, expectedCount int) {
 	_ = s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		rows, err := tx.QueryContext(ctx, `
-SELECT COUNT(*) FROM change_log 
+SELECT COUNT(*) FROM change_log
 WHERE edit_type_id = ? AND namespace_id = ?;`[1:], editType, namespaceID)
 
 		c.Assert(err, jc.ErrorIsNil)
@@ -846,14 +846,14 @@ func (s *schemaSuite) TestModelChangeLogTriggersForSecretTables(c *gc.C) {
 
 	appUUID := utils.MustNewUUID().String()
 	s.assertExecSQL(c, `
-INSERT INTO application (uuid, charm_uuid, name, life_id, password_hash_algorithm_id, password_hash) 
+INSERT INTO application (uuid, charm_uuid, name, life_id, password_hash_algorithm_id, password_hash)
 VALUES (?, ?, 'mysql', 0, 0, 'K68fQBBdlQH+MZqOxGP99DJaKl30Ra3z9XL2JiU2eMk=');`, appUUID, charmUUID)
 
 	netNodeUUID := utils.MustNewUUID().String()
 	s.assertExecSQL(c, `INSERT INTO net_node (uuid) VALUES (?);`, netNodeUUID)
 	unitUUID := utils.MustNewUUID().String()
 	s.assertExecSQL(c, `
-INSERT INTO unit (uuid, life_id, name, application_uuid, net_node_uuid, charm_uuid, resolve_kind_id) 
+INSERT INTO unit (uuid, life_id, name, application_uuid, net_node_uuid, charm_uuid, resolve_kind_id)
 VALUES (?, 0, 0, ?, ?, ?, 0);`,
 		unitUUID, appUUID, netNodeUUID, charmUUID)
 }


### PR DESCRIPTION
This small patch adds the DDL (creation of the new lxd_profile table) and the state layer to add and retrieve all lxd profiles for a given machine.

_Note: the new methods use the internal/errors new convention but I haven't updated the rest of the methods, this will be done little by little or on a following PR since the machines domain will continue to evolve._

<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://docs.google.com/document/d/1SYUo9G7qZ_jdoVXpUVamS5VCgHmtZ0QA-wZxKoMS-C0 
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Only state layer changed, so unit tests must pass.

## Links

**Jira card:** JUJU-6808

