### PR TITLE
feat: allow a precheck per transaction

### DIFF
--- a/core/changestream/database_mock_test.go
+++ b/core/changestream/database_mock_test.go
@@ -116,3 +116,41 @@ func (c *MockTxnRunnerTxnCall) DoAndReturn(f func(context.Context, func(context.
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
+
+// TxnWithPrecheck mocks base method.
+func (m *MockTxnRunner) TxnWithPrecheck(arg0 context.Context, arg1 func(context.Context) error, arg2 func(context.Context, *sqlair.TX) error) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TxnWithPrecheck", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// TxnWithPrecheck indicates an expected call of TxnWithPrecheck.
+func (mr *MockTxnRunnerMockRecorder) TxnWithPrecheck(arg0, arg1, arg2 any) *MockTxnRunnerTxnWithPrecheckCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TxnWithPrecheck", reflect.TypeOf((*MockTxnRunner)(nil).TxnWithPrecheck), arg0, arg1, arg2)
+	return &MockTxnRunnerTxnWithPrecheckCall{Call: call}
+}
+
+// MockTxnRunnerTxnWithPrecheckCall wrap *gomock.Call
+type MockTxnRunnerTxnWithPrecheckCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockTxnRunnerTxnWithPrecheckCall) Return(arg0 error) *MockTxnRunnerTxnWithPrecheckCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockTxnRunnerTxnWithPrecheckCall) Do(f func(context.Context, func(context.Context) error, func(context.Context, *sqlair.TX) error) error) *MockTxnRunnerTxnWithPrecheckCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockTxnRunnerTxnWithPrecheckCall) DoAndReturn(f func(context.Context, func(context.Context) error, func(context.Context, *sqlair.TX) error) error) *MockTxnRunnerTxnWithPrecheckCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}

--- a/core/database/runner.go
+++ b/core/database/runner.go
@@ -18,6 +18,11 @@ type TxnRunner interface {
 	// The input context can be used by the caller to cancel this process.
 	Txn(context.Context, func(context.Context, *sqlair.TX) error) error
 
+	// TxnWithPrecheck runs a transaction with a precheck function that is
+	// executed before the transaction is started. If the precheck function
+	// returns an error, the transaction is not started.
+	TxnWithPrecheck(context.Context, func(context.Context) error, func(context.Context, *sqlair.TX) error) error
+
 	// StdTxn manages the application of a standard library transaction within
 	// which the input function is executed.
 	// The input context can be used by the caller to cancel this process.

--- a/domain/application/service/package_mock_test.go
+++ b/domain/application/service/package_mock_test.go
@@ -656,6 +656,44 @@ func (c *MockApplicationStateRunAtomicCall) DoAndReturn(f func(context.Context, 
 	return c
 }
 
+// RunAtomicWithPrecheck mocks base method.
+func (m *MockApplicationState) RunAtomicWithPrecheck(arg0 context.Context, arg1 func(context.Context) error, arg2 func(domain.AtomicContext) error) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RunAtomicWithPrecheck", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RunAtomicWithPrecheck indicates an expected call of RunAtomicWithPrecheck.
+func (mr *MockApplicationStateMockRecorder) RunAtomicWithPrecheck(arg0, arg1, arg2 any) *MockApplicationStateRunAtomicWithPrecheckCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunAtomicWithPrecheck", reflect.TypeOf((*MockApplicationState)(nil).RunAtomicWithPrecheck), arg0, arg1, arg2)
+	return &MockApplicationStateRunAtomicWithPrecheckCall{Call: call}
+}
+
+// MockApplicationStateRunAtomicWithPrecheckCall wrap *gomock.Call
+type MockApplicationStateRunAtomicWithPrecheckCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockApplicationStateRunAtomicWithPrecheckCall) Return(arg0 error) *MockApplicationStateRunAtomicWithPrecheckCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockApplicationStateRunAtomicWithPrecheckCall) Do(f func(context.Context, func(context.Context) error, func(domain.AtomicContext) error) error) *MockApplicationStateRunAtomicWithPrecheckCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockApplicationStateRunAtomicWithPrecheckCall) DoAndReturn(f func(context.Context, func(context.Context) error, func(domain.AtomicContext) error) error) *MockApplicationStateRunAtomicWithPrecheckCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // SetApplicationLife mocks base method.
 func (m *MockApplicationState) SetApplicationLife(arg0 domain.AtomicContext, arg1 application.ID, arg2 life.Life) error {
 	m.ctrl.T.Helper()

--- a/domain/port/service/package_mock_test.go
+++ b/domain/port/service/package_mock_test.go
@@ -314,6 +314,44 @@ func (c *MockStateRunAtomicCall) DoAndReturn(f func(context.Context, func(domain
 	return c
 }
 
+// RunAtomicWithPrecheck mocks base method.
+func (m *MockState) RunAtomicWithPrecheck(arg0 context.Context, arg1 func(context.Context) error, arg2 func(domain.AtomicContext) error) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RunAtomicWithPrecheck", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RunAtomicWithPrecheck indicates an expected call of RunAtomicWithPrecheck.
+func (mr *MockStateMockRecorder) RunAtomicWithPrecheck(arg0, arg1, arg2 any) *MockStateRunAtomicWithPrecheckCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunAtomicWithPrecheck", reflect.TypeOf((*MockState)(nil).RunAtomicWithPrecheck), arg0, arg1, arg2)
+	return &MockStateRunAtomicWithPrecheckCall{Call: call}
+}
+
+// MockStateRunAtomicWithPrecheckCall wrap *gomock.Call
+type MockStateRunAtomicWithPrecheckCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateRunAtomicWithPrecheckCall) Return(arg0 error) *MockStateRunAtomicWithPrecheckCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateRunAtomicWithPrecheckCall) Do(f func(context.Context, func(context.Context) error, func(domain.AtomicContext) error) error) *MockStateRunAtomicWithPrecheckCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateRunAtomicWithPrecheckCall) DoAndReturn(f func(context.Context, func(context.Context) error, func(domain.AtomicContext) error) error) *MockStateRunAtomicWithPrecheckCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // UpdateUnitPorts mocks base method.
 func (m *MockState) UpdateUnitPorts(arg0 domain.AtomicContext, arg1 string, arg2, arg3 network.GroupedPortRanges) error {
 	m.ctrl.T.Helper()

--- a/domain/secret/service/state_mock_test.go
+++ b/domain/secret/service/state_mock_test.go
@@ -1911,6 +1911,44 @@ func (c *MockStateRunAtomicCall) DoAndReturn(f func(context.Context, func(domain
 	return c
 }
 
+// RunAtomicWithPrecheck mocks base method.
+func (m *MockState) RunAtomicWithPrecheck(arg0 context.Context, arg1 func(context.Context) error, arg2 func(domain.AtomicContext) error) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RunAtomicWithPrecheck", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RunAtomicWithPrecheck indicates an expected call of RunAtomicWithPrecheck.
+func (mr *MockStateMockRecorder) RunAtomicWithPrecheck(arg0, arg1, arg2 any) *MockStateRunAtomicWithPrecheckCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunAtomicWithPrecheck", reflect.TypeOf((*MockState)(nil).RunAtomicWithPrecheck), arg0, arg1, arg2)
+	return &MockStateRunAtomicWithPrecheckCall{Call: call}
+}
+
+// MockStateRunAtomicWithPrecheckCall wrap *gomock.Call
+type MockStateRunAtomicWithPrecheckCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateRunAtomicWithPrecheckCall) Return(arg0 error) *MockStateRunAtomicWithPrecheckCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateRunAtomicWithPrecheckCall) Do(f func(context.Context, func(context.Context) error, func(domain.AtomicContext) error) error) *MockStateRunAtomicWithPrecheckCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateRunAtomicWithPrecheckCall) DoAndReturn(f func(context.Context, func(context.Context) error, func(domain.AtomicContext) error) error) *MockStateRunAtomicWithPrecheckCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // SaveSecretConsumer mocks base method.
 func (m *MockState) SaveSecretConsumer(arg0 context.Context, arg1 *secrets.URI, arg2 string, arg3 *secrets.SecretConsumerMetadata) error {
 	m.ctrl.T.Helper()

--- a/domain/testing/controllerconfigsuite.go
+++ b/domain/testing/controllerconfigsuite.go
@@ -39,6 +39,10 @@ func (noopTxnRunner) Txn(context.Context, func(context.Context, *sqlair.TX) erro
 	return errors.NotImplemented
 }
 
+func (noopTxnRunner) TxnWithPrecheck(context.Context, func(context.Context) error, func(context.Context, *sqlair.TX) error) error {
+	return errors.NotImplemented
+}
+
 func (noopTxnRunner) StdTxn(context.Context, func(context.Context, *sql.Tx) error) error {
 	return errors.NotImplemented
 }

--- a/domain/unitstate/service/state_mock_test.go
+++ b/domain/unitstate/service/state_mock_test.go
@@ -155,6 +155,44 @@ func (c *MockStateRunAtomicCall) DoAndReturn(f func(context.Context, func(domain
 	return c
 }
 
+// RunAtomicWithPrecheck mocks base method.
+func (m *MockState) RunAtomicWithPrecheck(arg0 context.Context, arg1 func(context.Context) error, arg2 func(domain.AtomicContext) error) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RunAtomicWithPrecheck", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RunAtomicWithPrecheck indicates an expected call of RunAtomicWithPrecheck.
+func (mr *MockStateMockRecorder) RunAtomicWithPrecheck(arg0, arg1, arg2 any) *MockStateRunAtomicWithPrecheckCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunAtomicWithPrecheck", reflect.TypeOf((*MockState)(nil).RunAtomicWithPrecheck), arg0, arg1, arg2)
+	return &MockStateRunAtomicWithPrecheckCall{Call: call}
+}
+
+// MockStateRunAtomicWithPrecheckCall wrap *gomock.Call
+type MockStateRunAtomicWithPrecheckCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateRunAtomicWithPrecheckCall) Return(arg0 error) *MockStateRunAtomicWithPrecheckCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateRunAtomicWithPrecheckCall) Do(f func(context.Context, func(context.Context) error, func(domain.AtomicContext) error) error) *MockStateRunAtomicWithPrecheckCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateRunAtomicWithPrecheckCall) DoAndReturn(f func(context.Context, func(context.Context) error, func(domain.AtomicContext) error) error) *MockStateRunAtomicWithPrecheckCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // SetUnitStateCharm mocks base method.
 func (m *MockState) SetUnitStateCharm(arg0 domain.AtomicContext, arg1 string, arg2 map[string]string) error {
 	m.ctrl.T.Helper()

--- a/generate/triggergen/main.go
+++ b/generate/triggergen/main.go
@@ -354,6 +354,10 @@ func (r *txnRunner) Txn(ctx context.Context, f func(context.Context, *sqlair.TX)
 	return errors.Trace(Txn(ctx, sqlair.NewDB(r.db), f))
 }
 
+func (r *txnRunner) TxnWithPrecheck(ctx context.Context, precheck func(context.Context) error, f func(context.Context, *sqlair.TX) error) error {
+	return errors.Trace(TxnWithPrecheck(ctx, sqlair.NewDB(r.db), precheck, f))
+}
+
 func (r *txnRunner) StdTxn(ctx context.Context, f func(context.Context, *sql.Tx) error) error {
 	return errors.Trace(StdTxn(ctx, r.db, f))
 }
@@ -373,6 +377,20 @@ var (
 // handle transactions.
 func Txn(ctx context.Context, db *sqlair.DB, fn func(context.Context, *sqlair.TX) error) error {
 	return defaultTransactionRunner.Txn(ctx, db, fn)
+}
+
+// TxnWithPrecheck runs a transaction with a precheck function that is
+// executed before the transaction is started. If the precheck function
+// returns an error, the transaction is not started.
+//
+// Txn executes the input function against the tracked database, using
+// the sqlair package. The sqlair package provides a mapping library for
+// SQL queries and statements.
+// Retry semantics are applied automatically based on transient failures.
+// This is the function that almost all downstream database consumers
+// should use.
+func TxnWithPrecheck(ctx context.Context, db *sqlair.DB, precheck func(context.Context) error, fn func(context.Context, *sqlair.TX) error) error {
+	return defaultTransactionRunner.TxnWithPrecheck(ctx, db, precheck, fn)
 }
 
 // StdTxn defines a generic txn function for applying transactions on a given

--- a/internal/changestream/testing/changestream.go
+++ b/internal/changestream/testing/changestream.go
@@ -90,6 +90,13 @@ func (w *TestWatchableDB) Txn(ctx context.Context, fn func(context.Context, *sql
 	return w.db.Txn(ctx, fn)
 }
 
+// TxnWithPrecheck runs a transaction with a precheck function that is
+// executed before the transaction is started. If the precheck function
+// returns an error, the transaction is not started.
+func (w *TestWatchableDB) TxnWithPrecheck(ctx context.Context, precheck func(context.Context) error, fn func(context.Context, *sqlair.TX) error) error {
+	return w.db.TxnWithPrecheck(ctx, precheck, fn)
+}
+
 // StdTxn manages the application of a standard library transaction within
 // which the input function is executed.
 // The input context can be used by the caller to cancel this process.

--- a/internal/database/bootstrap.go
+++ b/internal/database/bootstrap.go
@@ -190,6 +190,10 @@ func (r *txnRunner) Txn(ctx context.Context, f func(context.Context, *sqlair.TX)
 	return errors.Trace(Txn(ctx, sqlair.NewDB(r.db), f))
 }
 
+func (r *txnRunner) TxnWithPrecheck(ctx context.Context, precheck func(context.Context) error, f func(context.Context, *sqlair.TX) error) error {
+	return errors.Trace(TxnWithPrecheck(ctx, sqlair.NewDB(r.db), precheck, f))
+}
+
 func (r *txnRunner) StdTxn(ctx context.Context, f func(context.Context, *sql.Tx) error) error {
 	return errors.Trace(StdTxn(ctx, r.db, f))
 }

--- a/internal/database/pragma/pragma.go
+++ b/internal/database/pragma/pragma.go
@@ -45,7 +45,7 @@ var (
 // SetPragma sets the given pragma to the given value.
 func SetPragma[T any](ctx context.Context, db *sql.DB, pragma Pragma, value T) error {
 	query := fmt.Sprintf("PRAGMA %s = %v", pragma, value)
-	err := runner.Retry(ctx, func() error {
+	err := runner.Retry(ctx, func(context.Context) error {
 		_, err := db.ExecContext(ctx, query)
 		return errors.Trace(err)
 	})

--- a/internal/database/testing/dqlitesuite.go
+++ b/internal/database/testing/dqlitesuite.go
@@ -258,6 +258,13 @@ func (noopTxnRunner) Txn(context.Context, func(context.Context, *sqlair.TX) erro
 	return errors.NotImplemented
 }
 
+// TxnWithPrecheck runs a transaction with a precheck function that is
+// executed before the transaction is started. If the precheck function
+// returns an error, the transaction is not started.
+func (noopTxnRunner) TxnWithPrecheck(context.Context, func(context.Context) error, func(context.Context, *sqlair.TX) error) error {
+	return errors.NotImplemented
+}
+
 // StdTxn manages the application of a standard library transaction within
 // which the input function is executed.
 // The input context can be used by the caller to cancel this process.

--- a/internal/database/txn.go
+++ b/internal/database/txn.go
@@ -29,6 +29,23 @@ func Txn(ctx context.Context, db *sqlair.DB, fn func(context.Context, *sqlair.TX
 	return defaultTransactionRunner.Txn(ctx, db, fn)
 }
 
+// TxnWithPrecheck runs a transaction with a precheck function that is
+// executed before the transaction is started. If the precheck function
+// returns an error, the transaction is not started.
+//
+// Txn executes the input function against the tracked database, using
+// the sqlair package. The sqlair package provides a mapping library for
+// SQL queries and statements.
+// Retry semantics are applied automatically based on transient failures.
+// This is the function that almost all downstream database consumers
+// should use.
+//
+// This should not be used directly, instead the TxnRunner should be used to
+// handle transactions.
+func TxnWithPrecheck(ctx context.Context, db *sqlair.DB, precheck func(context.Context) error, fn func(context.Context, *sqlair.TX) error) error {
+	return defaultTransactionRunner.TxnWithPrecheck(ctx, db, precheck, fn)
+}
+
 // StdTxn defines a generic txn function for applying transactions on a given
 // database. It expects that no individual transaction function should take
 // longer than the default timeout.
@@ -46,6 +63,6 @@ func StdTxn(ctx context.Context, db *sql.DB, fn func(context.Context, *sql.Tx) e
 //
 // This should not be used directly, instead the TxnRunner should be used to
 // handle transactions.
-func Retry(ctx context.Context, fn func() error) error {
+func Retry(ctx context.Context, fn func(context.Context) error) error {
 	return defaultTransactionRunner.Retry(ctx, fn)
 }

--- a/internal/database/txn/errors_test.go
+++ b/internal/database/txn/errors_test.go
@@ -31,6 +31,11 @@ func (s *isErrRetryableSuite) TestIsErrRetryable(c *gc.C) {
 			expected: false,
 		},
 		{
+			name:     "precheck failure",
+			err:      txn.ErrPrecheckFailure,
+			expected: false,
+		},
+		{
 			name:     "driver error busy error",
 			err:      &driver.Error{Code: driver.ErrBusy},
 			expected: true,

--- a/internal/database/txn/transaction_test.go
+++ b/internal/database/txn/transaction_test.go
@@ -219,7 +219,7 @@ func (s *transactionRunnerSuite) TestRetryForNonRetryableError(c *gc.C) {
 	runner := txn.NewRetryingTxnRunner()
 
 	var count int
-	err := runner.Retry(context.Background(), func() error {
+	err := runner.Retry(context.Background(), func(context.Context) error {
 		count++
 		return errors.Errorf("fail")
 	})
@@ -233,7 +233,7 @@ func (s *transactionRunnerSuite) TestRetryWithACancelledContext(c *gc.C) {
 	runner := txn.NewRetryingTxnRunner()
 
 	var count int
-	err := runner.Retry(ctx, func() error {
+	err := runner.Retry(ctx, func(context.Context) error {
 		defer cancel()
 
 		count++
@@ -247,7 +247,7 @@ func (s *transactionRunnerSuite) TestRetryForRetryableError(c *gc.C) {
 	runner := txn.NewRetryingTxnRunner()
 
 	var count int
-	err := runner.Retry(context.Background(), func() error {
+	err := runner.Retry(context.Background(), func(context.Context) error {
 		count++
 		return sqlite3.ErrBusy
 	})

--- a/internal/worker/changestream/stream_mock_test.go
+++ b/internal/worker/changestream/stream_mock_test.go
@@ -260,6 +260,44 @@ func (c *MockWatchableDBWorkerTxnCall) DoAndReturn(f func(context.Context, func(
 	return c
 }
 
+// TxnWithPrecheck mocks base method.
+func (m *MockWatchableDBWorker) TxnWithPrecheck(arg0 context.Context, arg1 func(context.Context) error, arg2 func(context.Context, *sqlair.TX) error) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TxnWithPrecheck", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// TxnWithPrecheck indicates an expected call of TxnWithPrecheck.
+func (mr *MockWatchableDBWorkerMockRecorder) TxnWithPrecheck(arg0, arg1, arg2 any) *MockWatchableDBWorkerTxnWithPrecheckCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TxnWithPrecheck", reflect.TypeOf((*MockWatchableDBWorker)(nil).TxnWithPrecheck), arg0, arg1, arg2)
+	return &MockWatchableDBWorkerTxnWithPrecheckCall{Call: call}
+}
+
+// MockWatchableDBWorkerTxnWithPrecheckCall wrap *gomock.Call
+type MockWatchableDBWorkerTxnWithPrecheckCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockWatchableDBWorkerTxnWithPrecheckCall) Return(arg0 error) *MockWatchableDBWorkerTxnWithPrecheckCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockWatchableDBWorkerTxnWithPrecheckCall) Do(f func(context.Context, func(context.Context) error, func(context.Context, *sqlair.TX) error) error) *MockWatchableDBWorkerTxnWithPrecheckCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockWatchableDBWorkerTxnWithPrecheckCall) DoAndReturn(f func(context.Context, func(context.Context) error, func(context.Context, *sqlair.TX) error) error) *MockWatchableDBWorkerTxnWithPrecheckCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // Wait mocks base method.
 func (m *MockWatchableDBWorker) Wait() error {
 	m.ctrl.T.Helper()

--- a/internal/worker/changestream/watchabledb.go
+++ b/internal/worker/changestream/watchabledb.go
@@ -88,6 +88,13 @@ func (w *WatchableDB) Txn(ctx context.Context, fn func(context.Context, *sqlair.
 	return w.db.Txn(ctx, fn)
 }
 
+// TxnWithPrecheck runs a transaction with a precheck function that is
+// executed before the transaction is started. If the precheck function
+// returns an error, the transaction is not started.
+func (w *WatchableDB) TxnWithPrecheck(ctx context.Context, precheck func(context.Context) error, fn func(context.Context, *sqlair.TX) error) error {
+	return w.db.TxnWithPrecheck(ctx, precheck, fn)
+}
+
 // StdTxn manages the application of a standard library transaction within
 // which the input function is executed.
 // The input context can be used by the caller to cancel this process.

--- a/internal/worker/dbaccessor/metrics.go
+++ b/internal/worker/dbaccessor/metrics.go
@@ -16,7 +16,6 @@ const (
 
 // Collector defines a prometheus collector for the dbaccessor.
 type Collector struct {
-	DBRequests  *prometheus.GaugeVec
 	DBDuration  *prometheus.HistogramVec
 	DBErrors    *prometheus.CounterVec
 	DBSuccess   *prometheus.CounterVec
@@ -27,12 +26,6 @@ type Collector struct {
 // NewMetricsCollector returns a new Collector.
 func NewMetricsCollector() *Collector {
 	return &Collector{
-		DBRequests: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Namespace: dbaccessorMetricsNamespace,
-			Subsystem: dbaccessorSubsystemNamespace,
-			Name:      "requests_total",
-			Help:      "Number of active db requests.",
-		}, []string{"namespace"}),
 		DBDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: dbaccessorMetricsNamespace,
 			Subsystem: dbaccessorSubsystemNamespace,
@@ -55,7 +48,7 @@ func NewMetricsCollector() *Collector {
 			Namespace: dbaccessorMetricsNamespace,
 			Subsystem: dbaccessorSubsystemNamespace,
 			Name:      "txn_requests_total",
-			Help:      "Total number of txn requests including retries.",
+			Help:      "Total number of txn requests.",
 		}, []string{"namespace"}),
 		TxnRetries: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: dbaccessorMetricsNamespace,
@@ -68,7 +61,6 @@ func NewMetricsCollector() *Collector {
 
 // Describe is part of the prometheus.Collector interface.
 func (c *Collector) Describe(ch chan<- *prometheus.Desc) {
-	c.DBRequests.Describe(ch)
 	c.DBDuration.Describe(ch)
 	c.DBErrors.Describe(ch)
 	c.DBSuccess.Describe(ch)
@@ -78,7 +70,6 @@ func (c *Collector) Describe(ch chan<- *prometheus.Desc) {
 
 // Collect is part of the prometheus.Collector interface.
 func (c *Collector) Collect(ch chan<- prometheus.Metric) {
-	c.DBRequests.Collect(ch)
 	c.DBDuration.Collect(ch)
 	c.DBErrors.Collect(ch)
 	c.DBSuccess.Collect(ch)

--- a/internal/worker/dbaccessor/metrics_test.go
+++ b/internal/worker/dbaccessor/metrics_test.go
@@ -27,7 +27,6 @@ func (s *metricsSuite) TestMetricsAreCollected(c *gc.C) {
 	go func() {
 		defer close(done)
 		collector.DBDuration.WithLabelValues("foo", "success").Observe(0.1)
-		collector.DBRequests.WithLabelValues("foo").Inc()
 		collector.DBErrors.WithLabelValues("foo", "bar").Inc()
 		collector.DBSuccess.WithLabelValues("foo").Inc()
 		collector.TxnRequests.WithLabelValues("foo").Inc()
@@ -60,13 +59,10 @@ juju_db_duration_seconds_count{namespace="foo",result="success"} 1
 # HELP juju_db_errors_total Total number of db errors.
 # TYPE juju_db_errors_total counter
 juju_db_errors_total{error="bar",namespace="foo"} 1
-# HELP juju_db_requests_total Number of active db requests.
-# TYPE juju_db_requests_total gauge
-juju_db_requests_total{namespace="foo"} 1
 # HELP juju_db_success_total Total number of successful db operations.
 # TYPE juju_db_success_total counter
 juju_db_success_total{namespace="foo"} 1
-# HELP juju_db_txn_requests_total Total number of txn requests including retries.
+# HELP juju_db_txn_requests_total Total number of txn requests.
 # TYPE juju_db_txn_requests_total counter
 juju_db_txn_requests_total{namespace="foo"} 1
 # HELP juju_db_txn_retries_total Total number of txn retries.
@@ -76,7 +72,6 @@ juju_db_txn_retries_total{namespace="foo"} 1
 
 	err := testutil.CollectAndCompare(
 		collector, expected,
-		"juju_db_requests_total",
 		"juju_db_duration_seconds",
 		"juju_db_errors_total",
 		"juju_db_success_total",

--- a/internal/worker/dbaccessor/package_mock_test.go
+++ b/internal/worker/dbaccessor/package_mock_test.go
@@ -968,6 +968,44 @@ func (c *MockTrackedDBTxnCall) DoAndReturn(f func(context.Context, func(context.
 	return c
 }
 
+// TxnWithPrecheck mocks base method.
+func (m *MockTrackedDB) TxnWithPrecheck(arg0 context.Context, arg1 func(context.Context) error, arg2 func(context.Context, *sqlair.TX) error) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TxnWithPrecheck", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// TxnWithPrecheck indicates an expected call of TxnWithPrecheck.
+func (mr *MockTrackedDBMockRecorder) TxnWithPrecheck(arg0, arg1, arg2 any) *MockTrackedDBTxnWithPrecheckCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TxnWithPrecheck", reflect.TypeOf((*MockTrackedDB)(nil).TxnWithPrecheck), arg0, arg1, arg2)
+	return &MockTrackedDBTxnWithPrecheckCall{Call: call}
+}
+
+// MockTrackedDBTxnWithPrecheckCall wrap *gomock.Call
+type MockTrackedDBTxnWithPrecheckCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockTrackedDBTxnWithPrecheckCall) Return(arg0 error) *MockTrackedDBTxnWithPrecheckCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockTrackedDBTxnWithPrecheckCall) Do(f func(context.Context, func(context.Context) error, func(context.Context, *sqlair.TX) error) error) *MockTrackedDBTxnWithPrecheckCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockTrackedDBTxnWithPrecheckCall) DoAndReturn(f func(context.Context, func(context.Context) error, func(context.Context, *sqlair.TX) error) error) *MockTrackedDBTxnWithPrecheckCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // Wait mocks base method.
 func (m *MockTrackedDB) Wait() error {
 	m.ctrl.T.Helper()

--- a/internal/worker/dbaccessor/testing/trackeddb.go
+++ b/internal/worker/dbaccessor/testing/trackeddb.go
@@ -50,6 +50,14 @@ func (t *testTrackedDB) Txn(ctx context.Context, fn func(context.Context, *sqlai
 	return db.Txn(ctx, fn)
 }
 
+func (t *testTrackedDB) TxnWithPrecheck(ctx context.Context, precheck func(context.Context) error, fn func(context.Context, *sqlair.TX) error) error {
+	db, err := t.txnRunnerFactory()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return db.TxnWithPrecheck(ctx, precheck, fn)
+}
+
 func (t *testTrackedDB) StdTxn(ctx context.Context, fn func(context.Context, *sql.Tx) error) error {
 	db, err := t.txnRunnerFactory()
 	if err != nil {

--- a/internal/worker/dbaccessor/worker.go
+++ b/internal/worker/dbaccessor/worker.go
@@ -736,7 +736,7 @@ func (w *dbWorker) deleteDatabase(namespace string) error {
 
 	// Now attempt to delete the database and all of it's contents.
 	// This can be replaced with DROP DB once it's supported by dqlite.
-	if err := internaldatabase.Retry(ctx, func() error {
+	if err := internaldatabase.Retry(ctx, func(ctx context.Context) error {
 		return internaldatabase.StdTxn(ctx, db, func(ctx context.Context, tx *sql.Tx) error {
 			return deleteDBContents(ctx, tx, w.cfg.Logger)
 		})

--- a/internal/worker/dbaccessor/worker_integration_test.go
+++ b/internal/worker/dbaccessor/worker_integration_test.go
@@ -296,6 +296,10 @@ func (r *txnRunner) Txn(ctx context.Context, f func(context.Context, *sqlair.TX)
 	return errors.Trace(database.Txn(ctx, sqlair.NewDB(r.db), f))
 }
 
+func (r *txnRunner) TxnWithPrecheck(ctx context.Context, precheck func(context.Context) error, f func(context.Context, *sqlair.TX) error) error {
+	return errors.Trace(database.TxnWithPrecheck(ctx, sqlair.NewDB(r.db), precheck, f))
+}
+
 func (r *txnRunner) StdTxn(ctx context.Context, f func(context.Context, *sql.Tx) error) error {
 	return errors.Trace(database.StdTxn(ctx, r.db, f))
 }

--- a/internal/worker/dbaccessor/worker_namespace_test.go
+++ b/internal/worker/dbaccessor/worker_namespace_test.go
@@ -418,6 +418,10 @@ func (w *workerTrackedDB) Txn(ctx context.Context, fn func(context.Context, *sql
 	return w.db.Txn(ctx, fn)
 }
 
+func (w *workerTrackedDB) TxnWithPrecheck(ctx context.Context, precheck func(context.Context) error, fn func(context.Context, *sqlair.TX) error) error {
+	return w.db.TxnWithPrecheck(ctx, precheck, fn)
+}
+
 func (w *workerTrackedDB) StdTxn(ctx context.Context, fn func(context.Context, *sql.Tx) error) error {
 	return w.db.StdTxn(ctx, fn)
 }

--- a/scripts/dqlite-bench/main.go
+++ b/scripts/dqlite-bench/main.go
@@ -170,8 +170,8 @@ func SlotPerDBBasedTransactionRunner(slots int) func(*sql.DB) TxRunner {
 		return TxRunner(func(c context.Context, fn func(context.Context, *sql.Tx) error) error {
 			slotCh <- nil
 			defer func() { <-slotCh }()
-			err := txnRunner.Retry(c, func() error {
-				return txnRunner.StdTxn(c, db, fn)
+			err := txnRunner.Retry(c, func(ctx context.Context) error {
+				return txnRunner.StdTxn(ctx, db, fn)
 			})
 			return err
 		})
@@ -187,8 +187,8 @@ func SlotAllDBBasedTransactionRunner(slots int) func(*sql.DB) TxRunner {
 		return TxRunner(func(c context.Context, fn func(context.Context, *sql.Tx) error) error {
 			slotCh <- nil
 			defer func() { <-slotCh }()
-			err := txnRunner.Retry(c, func() error {
-				return txnRunner.StdTxn(c, db, fn)
+			err := txnRunner.Retry(c, func(ctx context.Context) error {
+				return txnRunner.StdTxn(ctx, db, fn)
 			})
 			return err
 		})
@@ -216,8 +216,8 @@ func RetryableTransactionRunner(db *sql.DB) TxRunner {
 	txnRunner := txn.NewRetryingTxnRunner()
 
 	return TxRunner(func(c context.Context, fn func(context.Context, *sql.Tx) error) error {
-		return txnRunner.Retry(c, func() error {
-			return txnRunner.StdTxn(c, db, fn)
+		return txnRunner.Retry(c, func(ctx context.Context) error {
+			return txnRunner.StdTxn(ctx, db, fn)
 		})
 	})
 }

--- a/scripts/dqlite/cmd/main.go
+++ b/scripts/dqlite/cmd/main.go
@@ -234,6 +234,10 @@ func (r *txnRunner) Txn(ctx context.Context, f func(context.Context, *sqlair.TX)
 	return errors.Trace(Txn(ctx, sqlair.NewDB(r.db), f))
 }
 
+func (r *txnRunner) TxnWithPrecheck(ctx context.Context, precheck func(context.Context) error, f func(context.Context, *sqlair.TX) error) error {
+	return errors.Trace(TxnWithPrecheck(ctx, sqlair.NewDB(r.db), precheck, f))
+}
+
 func (r *txnRunner) StdTxn(ctx context.Context, f func(context.Context, *sql.Tx) error) error {
 	return errors.Trace(StdTxn(ctx, r.db, f))
 }
@@ -253,6 +257,23 @@ var (
 // handle transactions.
 func Txn(ctx context.Context, db *sqlair.DB, fn func(context.Context, *sqlair.TX) error) error {
 	return defaultTransactionRunner.Txn(ctx, db, fn)
+}
+
+// TxnWithPrecheck runs a transaction with a precheck function that is
+// executed before the transaction is started. If the precheck function
+// returns an error, the transaction is not started.
+//
+// Txn executes the input function against the tracked database, using
+// the sqlair package. The sqlair package provides a mapping library for
+// SQL queries and statements.
+// Retry semantics are applied automatically based on transient failures.
+// This is the function that almost all downstream database consumers
+// should use.
+//
+// This should not be used directly, instead the TxnRunner should be used to
+// handle transactions.
+func TxnWithPrecheck(ctx context.Context, db *sqlair.DB, precheck func(context.Context) error, fn func(context.Context, *sqlair.TX) error) error {
+	return defaultTransactionRunner.TxnWithPrecheck(ctx, db, precheck, fn)
 }
 
 // StdTxn defines a generic txn function for applying transactions on a given


### PR DESCRIPTION
The precheck concept is to run a function for every retry to ensure
that something is as close to being true, without being run in a
transaction. This might be something like; ensuring a lease exists
for a given unit, or running another query from another database,
without running it within the same transaction. Nested transactions
are undefined behaviour and we should do our best not to allow that.

Originally we wanted the code to be specific, so we should potentially
look at changing the signature in the state base of the TxnRunner.
Otherwise, this PR is very much a generic prechecker.

Also, the prechecker will be run just before the transaction `BEGIN`,
which is after the semaphore. All precheckers will be rate-limited.
Any slow prechecker will also slow down any transactions in the
queue behind. With this in mind, the prechecker ~~should~~ must 
NOT be used for external calls (providers or similar).

In theory, we could run it before the semaphore, but there is
no guarantee it will execute in a timely manor. It can be up to
30 seconds between precheck and the actual transaction begin,
in the worst case.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing


## QA steps

All the tests pass.


## Links

**Jira card:** JUJU-

