### PR TITLE
refactor(ports): refactor port service state

### DIFF
--- a/core/network/portrange.go
+++ b/core/network/portrange.go
@@ -96,7 +96,7 @@ func (grp GroupedPortRanges) UniquePortRanges() []PortRange {
 // Clone returns a copy of this port range grouping.
 func (grp GroupedPortRanges) Clone() GroupedPortRanges {
 	if len(grp) == 0 {
-		return nil
+		return GroupedPortRanges{}
 	}
 
 	grpCopy := make(GroupedPortRanges, len(grp))

--- a/domain/port/service/package_mock_test.go
+++ b/domain/port/service/package_mock_test.go
@@ -13,7 +13,9 @@ import (
 	context "context"
 	reflect "reflect"
 
+	application "github.com/juju/juju/core/application"
 	network "github.com/juju/juju/core/network"
+	unit "github.com/juju/juju/core/unit"
 	domain "github.com/juju/juju/domain"
 	port "github.com/juju/juju/domain/port"
 	gomock "go.uber.org/mock/gomock"
@@ -43,7 +45,7 @@ func (m *MockState) EXPECT() *MockStateMockRecorder {
 }
 
 // AddEndpoints mocks base method.
-func (m *MockState) AddEndpoints(arg0 domain.AtomicContext, arg1 string, arg2 []string) ([]port.Endpoint, error) {
+func (m *MockState) AddEndpoints(arg0 domain.AtomicContext, arg1 unit.UUID, arg2 []string) ([]port.Endpoint, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddEndpoints", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]port.Endpoint)
@@ -70,19 +72,19 @@ func (c *MockStateAddEndpointsCall) Return(arg0 []port.Endpoint, arg1 error) *Mo
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateAddEndpointsCall) Do(f func(domain.AtomicContext, string, []string) ([]port.Endpoint, error)) *MockStateAddEndpointsCall {
+func (c *MockStateAddEndpointsCall) Do(f func(domain.AtomicContext, unit.UUID, []string) ([]port.Endpoint, error)) *MockStateAddEndpointsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateAddEndpointsCall) DoAndReturn(f func(domain.AtomicContext, string, []string) ([]port.Endpoint, error)) *MockStateAddEndpointsCall {
+func (c *MockStateAddEndpointsCall) DoAndReturn(f func(domain.AtomicContext, unit.UUID, []string) ([]port.Endpoint, error)) *MockStateAddEndpointsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // AddOpenedPorts mocks base method.
-func (m *MockState) AddOpenedPorts(arg0 domain.AtomicContext, arg1 network.GroupedPortRanges) error {
+func (m *MockState) AddOpenedPorts(arg0 domain.AtomicContext, arg1 map[port.UUID][]network.PortRange) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddOpenedPorts", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -108,19 +110,19 @@ func (c *MockStateAddOpenedPortsCall) Return(arg0 error) *MockStateAddOpenedPort
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateAddOpenedPortsCall) Do(f func(domain.AtomicContext, network.GroupedPortRanges) error) *MockStateAddOpenedPortsCall {
+func (c *MockStateAddOpenedPortsCall) Do(f func(domain.AtomicContext, map[port.UUID][]network.PortRange) error) *MockStateAddOpenedPortsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateAddOpenedPortsCall) DoAndReturn(f func(domain.AtomicContext, network.GroupedPortRanges) error) *MockStateAddOpenedPortsCall {
+func (c *MockStateAddOpenedPortsCall) DoAndReturn(f func(domain.AtomicContext, map[port.UUID][]network.PortRange) error) *MockStateAddOpenedPortsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetApplicationOpenedPorts mocks base method.
-func (m *MockState) GetApplicationOpenedPorts(arg0 context.Context, arg1 string) (port.UnitEndpointPortRanges, error) {
+func (m *MockState) GetApplicationOpenedPorts(arg0 context.Context, arg1 application.ID) (port.UnitEndpointPortRanges, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetApplicationOpenedPorts", arg0, arg1)
 	ret0, _ := ret[0].(port.UnitEndpointPortRanges)
@@ -147,19 +149,19 @@ func (c *MockStateGetApplicationOpenedPortsCall) Return(arg0 port.UnitEndpointPo
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetApplicationOpenedPortsCall) Do(f func(context.Context, string) (port.UnitEndpointPortRanges, error)) *MockStateGetApplicationOpenedPortsCall {
+func (c *MockStateGetApplicationOpenedPortsCall) Do(f func(context.Context, application.ID) (port.UnitEndpointPortRanges, error)) *MockStateGetApplicationOpenedPortsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetApplicationOpenedPortsCall) DoAndReturn(f func(context.Context, string) (port.UnitEndpointPortRanges, error)) *MockStateGetApplicationOpenedPortsCall {
+func (c *MockStateGetApplicationOpenedPortsCall) DoAndReturn(f func(context.Context, application.ID) (port.UnitEndpointPortRanges, error)) *MockStateGetApplicationOpenedPortsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetColocatedOpenedPorts mocks base method.
-func (m *MockState) GetColocatedOpenedPorts(arg0 domain.AtomicContext, arg1 string) ([]network.PortRange, error) {
+func (m *MockState) GetColocatedOpenedPorts(arg0 domain.AtomicContext, arg1 unit.UUID) ([]network.PortRange, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetColocatedOpenedPorts", arg0, arg1)
 	ret0, _ := ret[0].([]network.PortRange)
@@ -186,19 +188,19 @@ func (c *MockStateGetColocatedOpenedPortsCall) Return(arg0 []network.PortRange, 
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetColocatedOpenedPortsCall) Do(f func(domain.AtomicContext, string) ([]network.PortRange, error)) *MockStateGetColocatedOpenedPortsCall {
+func (c *MockStateGetColocatedOpenedPortsCall) Do(f func(domain.AtomicContext, unit.UUID) ([]network.PortRange, error)) *MockStateGetColocatedOpenedPortsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetColocatedOpenedPortsCall) DoAndReturn(f func(domain.AtomicContext, string) ([]network.PortRange, error)) *MockStateGetColocatedOpenedPortsCall {
+func (c *MockStateGetColocatedOpenedPortsCall) DoAndReturn(f func(domain.AtomicContext, unit.UUID) ([]network.PortRange, error)) *MockStateGetColocatedOpenedPortsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetEndpoints mocks base method.
-func (m *MockState) GetEndpoints(arg0 domain.AtomicContext, arg1 string) ([]port.Endpoint, error) {
+func (m *MockState) GetEndpoints(arg0 domain.AtomicContext, arg1 unit.UUID) ([]port.Endpoint, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetEndpoints", arg0, arg1)
 	ret0, _ := ret[0].([]port.Endpoint)
@@ -225,22 +227,22 @@ func (c *MockStateGetEndpointsCall) Return(arg0 []port.Endpoint, arg1 error) *Mo
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetEndpointsCall) Do(f func(domain.AtomicContext, string) ([]port.Endpoint, error)) *MockStateGetEndpointsCall {
+func (c *MockStateGetEndpointsCall) Do(f func(domain.AtomicContext, unit.UUID) ([]port.Endpoint, error)) *MockStateGetEndpointsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetEndpointsCall) DoAndReturn(f func(domain.AtomicContext, string) ([]port.Endpoint, error)) *MockStateGetEndpointsCall {
+func (c *MockStateGetEndpointsCall) DoAndReturn(f func(domain.AtomicContext, unit.UUID) ([]port.Endpoint, error)) *MockStateGetEndpointsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetMachineOpenedPorts mocks base method.
-func (m *MockState) GetMachineOpenedPorts(arg0 context.Context, arg1 string) (map[string]network.GroupedPortRanges, error) {
+func (m *MockState) GetMachineOpenedPorts(arg0 context.Context, arg1 string) (map[unit.UUID]network.GroupedPortRanges, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMachineOpenedPorts", arg0, arg1)
-	ret0, _ := ret[0].(map[string]network.GroupedPortRanges)
+	ret0, _ := ret[0].(map[unit.UUID]network.GroupedPortRanges)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -258,25 +260,25 @@ type MockStateGetMachineOpenedPortsCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockStateGetMachineOpenedPortsCall) Return(arg0 map[string]network.GroupedPortRanges, arg1 error) *MockStateGetMachineOpenedPortsCall {
+func (c *MockStateGetMachineOpenedPortsCall) Return(arg0 map[unit.UUID]network.GroupedPortRanges, arg1 error) *MockStateGetMachineOpenedPortsCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetMachineOpenedPortsCall) Do(f func(context.Context, string) (map[string]network.GroupedPortRanges, error)) *MockStateGetMachineOpenedPortsCall {
+func (c *MockStateGetMachineOpenedPortsCall) Do(f func(context.Context, string) (map[unit.UUID]network.GroupedPortRanges, error)) *MockStateGetMachineOpenedPortsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetMachineOpenedPortsCall) DoAndReturn(f func(context.Context, string) (map[string]network.GroupedPortRanges, error)) *MockStateGetMachineOpenedPortsCall {
+func (c *MockStateGetMachineOpenedPortsCall) DoAndReturn(f func(context.Context, string) (map[unit.UUID]network.GroupedPortRanges, error)) *MockStateGetMachineOpenedPortsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetUnitOpenedPorts mocks base method.
-func (m *MockState) GetUnitOpenedPorts(arg0 context.Context, arg1 string) (network.GroupedPortRanges, error) {
+func (m *MockState) GetUnitOpenedPorts(arg0 context.Context, arg1 unit.UUID) (network.GroupedPortRanges, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetUnitOpenedPorts", arg0, arg1)
 	ret0, _ := ret[0].(network.GroupedPortRanges)
@@ -303,58 +305,58 @@ func (c *MockStateGetUnitOpenedPortsCall) Return(arg0 network.GroupedPortRanges,
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetUnitOpenedPortsCall) Do(f func(context.Context, string) (network.GroupedPortRanges, error)) *MockStateGetUnitOpenedPortsCall {
+func (c *MockStateGetUnitOpenedPortsCall) Do(f func(context.Context, unit.UUID) (network.GroupedPortRanges, error)) *MockStateGetUnitOpenedPortsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetUnitOpenedPortsCall) DoAndReturn(f func(context.Context, string) (network.GroupedPortRanges, error)) *MockStateGetUnitOpenedPortsCall {
+func (c *MockStateGetUnitOpenedPortsCall) DoAndReturn(f func(context.Context, unit.UUID) (network.GroupedPortRanges, error)) *MockStateGetUnitOpenedPortsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
-// GetUnitOpenedPortsUUID mocks base method.
-func (m *MockState) GetUnitOpenedPortsUUID(arg0 domain.AtomicContext, arg1 string) (map[string][]port.PortRangeUUID, error) {
+// GetUnitOpenedPortsWithUUIDs mocks base method.
+func (m *MockState) GetUnitOpenedPortsWithUUIDs(arg0 domain.AtomicContext, arg1 unit.UUID) (map[string][]port.PortRangeWithUUID, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetUnitOpenedPortsUUID", arg0, arg1)
-	ret0, _ := ret[0].(map[string][]port.PortRangeUUID)
+	ret := m.ctrl.Call(m, "GetUnitOpenedPortsWithUUIDs", arg0, arg1)
+	ret0, _ := ret[0].(map[string][]port.PortRangeWithUUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetUnitOpenedPortsUUID indicates an expected call of GetUnitOpenedPortsUUID.
-func (mr *MockStateMockRecorder) GetUnitOpenedPortsUUID(arg0, arg1 any) *MockStateGetUnitOpenedPortsUUIDCall {
+// GetUnitOpenedPortsWithUUIDs indicates an expected call of GetUnitOpenedPortsWithUUIDs.
+func (mr *MockStateMockRecorder) GetUnitOpenedPortsWithUUIDs(arg0, arg1 any) *MockStateGetUnitOpenedPortsWithUUIDsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnitOpenedPortsUUID", reflect.TypeOf((*MockState)(nil).GetUnitOpenedPortsUUID), arg0, arg1)
-	return &MockStateGetUnitOpenedPortsUUIDCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnitOpenedPortsWithUUIDs", reflect.TypeOf((*MockState)(nil).GetUnitOpenedPortsWithUUIDs), arg0, arg1)
+	return &MockStateGetUnitOpenedPortsWithUUIDsCall{Call: call}
 }
 
-// MockStateGetUnitOpenedPortsUUIDCall wrap *gomock.Call
-type MockStateGetUnitOpenedPortsUUIDCall struct {
+// MockStateGetUnitOpenedPortsWithUUIDsCall wrap *gomock.Call
+type MockStateGetUnitOpenedPortsWithUUIDsCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockStateGetUnitOpenedPortsUUIDCall) Return(arg0 map[string][]port.PortRangeUUID, arg1 error) *MockStateGetUnitOpenedPortsUUIDCall {
+func (c *MockStateGetUnitOpenedPortsWithUUIDsCall) Return(arg0 map[string][]port.PortRangeWithUUID, arg1 error) *MockStateGetUnitOpenedPortsWithUUIDsCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetUnitOpenedPortsUUIDCall) Do(f func(domain.AtomicContext, string) (map[string][]port.PortRangeUUID, error)) *MockStateGetUnitOpenedPortsUUIDCall {
+func (c *MockStateGetUnitOpenedPortsWithUUIDsCall) Do(f func(domain.AtomicContext, unit.UUID) (map[string][]port.PortRangeWithUUID, error)) *MockStateGetUnitOpenedPortsWithUUIDsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetUnitOpenedPortsUUIDCall) DoAndReturn(f func(domain.AtomicContext, string) (map[string][]port.PortRangeUUID, error)) *MockStateGetUnitOpenedPortsUUIDCall {
+func (c *MockStateGetUnitOpenedPortsWithUUIDsCall) DoAndReturn(f func(domain.AtomicContext, unit.UUID) (map[string][]port.PortRangeWithUUID, error)) *MockStateGetUnitOpenedPortsWithUUIDsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // RemoveOpenedPorts mocks base method.
-func (m *MockState) RemoveOpenedPorts(arg0 domain.AtomicContext, arg1 []string) error {
+func (m *MockState) RemoveOpenedPorts(arg0 domain.AtomicContext, arg1 []port.UUID) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveOpenedPorts", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -380,13 +382,13 @@ func (c *MockStateRemoveOpenedPortsCall) Return(arg0 error) *MockStateRemoveOpen
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateRemoveOpenedPortsCall) Do(f func(domain.AtomicContext, []string) error) *MockStateRemoveOpenedPortsCall {
+func (c *MockStateRemoveOpenedPortsCall) Do(f func(domain.AtomicContext, []port.UUID) error) *MockStateRemoveOpenedPortsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateRemoveOpenedPortsCall) DoAndReturn(f func(domain.AtomicContext, []string) error) *MockStateRemoveOpenedPortsCall {
+func (c *MockStateRemoveOpenedPortsCall) DoAndReturn(f func(domain.AtomicContext, []port.UUID) error) *MockStateRemoveOpenedPortsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/port/service/package_mock_test.go
+++ b/domain/port/service/package_mock_test.go
@@ -42,6 +42,83 @@ func (m *MockState) EXPECT() *MockStateMockRecorder {
 	return m.recorder
 }
 
+// AddEndpoints mocks base method.
+func (m *MockState) AddEndpoints(arg0 domain.AtomicContext, arg1 string, arg2 []string) ([]port.Endpoint, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddEndpoints", arg0, arg1, arg2)
+	ret0, _ := ret[0].([]port.Endpoint)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AddEndpoints indicates an expected call of AddEndpoints.
+func (mr *MockStateMockRecorder) AddEndpoints(arg0, arg1, arg2 any) *MockStateAddEndpointsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddEndpoints", reflect.TypeOf((*MockState)(nil).AddEndpoints), arg0, arg1, arg2)
+	return &MockStateAddEndpointsCall{Call: call}
+}
+
+// MockStateAddEndpointsCall wrap *gomock.Call
+type MockStateAddEndpointsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateAddEndpointsCall) Return(arg0 []port.Endpoint, arg1 error) *MockStateAddEndpointsCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateAddEndpointsCall) Do(f func(domain.AtomicContext, string, []string) ([]port.Endpoint, error)) *MockStateAddEndpointsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateAddEndpointsCall) DoAndReturn(f func(domain.AtomicContext, string, []string) ([]port.Endpoint, error)) *MockStateAddEndpointsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// AddOpenedPorts mocks base method.
+func (m *MockState) AddOpenedPorts(arg0 domain.AtomicContext, arg1 network.GroupedPortRanges) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddOpenedPorts", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AddOpenedPorts indicates an expected call of AddOpenedPorts.
+func (mr *MockStateMockRecorder) AddOpenedPorts(arg0, arg1 any) *MockStateAddOpenedPortsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddOpenedPorts", reflect.TypeOf((*MockState)(nil).AddOpenedPorts), arg0, arg1)
+	return &MockStateAddOpenedPortsCall{Call: call}
+}
+
+// MockStateAddOpenedPortsCall wrap *gomock.Call
+type MockStateAddOpenedPortsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateAddOpenedPortsCall) Return(arg0 error) *MockStateAddOpenedPortsCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateAddOpenedPortsCall) Do(f func(domain.AtomicContext, network.GroupedPortRanges) error) *MockStateAddOpenedPortsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateAddOpenedPortsCall) DoAndReturn(f func(domain.AtomicContext, network.GroupedPortRanges) error) *MockStateAddOpenedPortsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetApplicationOpenedPorts mocks base method.
 func (m *MockState) GetApplicationOpenedPorts(arg0 context.Context, arg1 string) (port.UnitEndpointPortRanges, error) {
 	m.ctrl.T.Helper()
@@ -121,10 +198,10 @@ func (c *MockStateGetColocatedOpenedPortsCall) DoAndReturn(f func(domain.AtomicC
 }
 
 // GetEndpoints mocks base method.
-func (m *MockState) GetEndpoints(arg0 domain.AtomicContext, arg1 string) ([]string, error) {
+func (m *MockState) GetEndpoints(arg0 domain.AtomicContext, arg1 string) ([]port.Endpoint, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetEndpoints", arg0, arg1)
-	ret0, _ := ret[0].([]string)
+	ret0, _ := ret[0].([]port.Endpoint)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -142,19 +219,19 @@ type MockStateGetEndpointsCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockStateGetEndpointsCall) Return(arg0 []string, arg1 error) *MockStateGetEndpointsCall {
+func (c *MockStateGetEndpointsCall) Return(arg0 []port.Endpoint, arg1 error) *MockStateGetEndpointsCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetEndpointsCall) Do(f func(domain.AtomicContext, string) ([]string, error)) *MockStateGetEndpointsCall {
+func (c *MockStateGetEndpointsCall) Do(f func(domain.AtomicContext, string) ([]port.Endpoint, error)) *MockStateGetEndpointsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetEndpointsCall) DoAndReturn(f func(domain.AtomicContext, string) ([]string, error)) *MockStateGetEndpointsCall {
+func (c *MockStateGetEndpointsCall) DoAndReturn(f func(domain.AtomicContext, string) ([]port.Endpoint, error)) *MockStateGetEndpointsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -198,45 +275,6 @@ func (c *MockStateGetMachineOpenedPortsCall) DoAndReturn(f func(context.Context,
 	return c
 }
 
-// GetOpenedEndpointPorts mocks base method.
-func (m *MockState) GetOpenedEndpointPorts(arg0 domain.AtomicContext, arg1, arg2 string) ([]network.PortRange, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetOpenedEndpointPorts", arg0, arg1, arg2)
-	ret0, _ := ret[0].([]network.PortRange)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetOpenedEndpointPorts indicates an expected call of GetOpenedEndpointPorts.
-func (mr *MockStateMockRecorder) GetOpenedEndpointPorts(arg0, arg1, arg2 any) *MockStateGetOpenedEndpointPortsCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOpenedEndpointPorts", reflect.TypeOf((*MockState)(nil).GetOpenedEndpointPorts), arg0, arg1, arg2)
-	return &MockStateGetOpenedEndpointPortsCall{Call: call}
-}
-
-// MockStateGetOpenedEndpointPortsCall wrap *gomock.Call
-type MockStateGetOpenedEndpointPortsCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockStateGetOpenedEndpointPortsCall) Return(arg0 []network.PortRange, arg1 error) *MockStateGetOpenedEndpointPortsCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockStateGetOpenedEndpointPortsCall) Do(f func(domain.AtomicContext, string, string) ([]network.PortRange, error)) *MockStateGetOpenedEndpointPortsCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetOpenedEndpointPortsCall) DoAndReturn(f func(domain.AtomicContext, string, string) ([]network.PortRange, error)) *MockStateGetOpenedEndpointPortsCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // GetUnitOpenedPorts mocks base method.
 func (m *MockState) GetUnitOpenedPorts(arg0 context.Context, arg1 string) (network.GroupedPortRanges, error) {
 	m.ctrl.T.Helper()
@@ -276,6 +314,83 @@ func (c *MockStateGetUnitOpenedPortsCall) DoAndReturn(f func(context.Context, st
 	return c
 }
 
+// GetUnitOpenedPortsUUID mocks base method.
+func (m *MockState) GetUnitOpenedPortsUUID(arg0 domain.AtomicContext, arg1 string) (map[string][]port.PortRangeUUID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUnitOpenedPortsUUID", arg0, arg1)
+	ret0, _ := ret[0].(map[string][]port.PortRangeUUID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUnitOpenedPortsUUID indicates an expected call of GetUnitOpenedPortsUUID.
+func (mr *MockStateMockRecorder) GetUnitOpenedPortsUUID(arg0, arg1 any) *MockStateGetUnitOpenedPortsUUIDCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnitOpenedPortsUUID", reflect.TypeOf((*MockState)(nil).GetUnitOpenedPortsUUID), arg0, arg1)
+	return &MockStateGetUnitOpenedPortsUUIDCall{Call: call}
+}
+
+// MockStateGetUnitOpenedPortsUUIDCall wrap *gomock.Call
+type MockStateGetUnitOpenedPortsUUIDCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateGetUnitOpenedPortsUUIDCall) Return(arg0 map[string][]port.PortRangeUUID, arg1 error) *MockStateGetUnitOpenedPortsUUIDCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateGetUnitOpenedPortsUUIDCall) Do(f func(domain.AtomicContext, string) (map[string][]port.PortRangeUUID, error)) *MockStateGetUnitOpenedPortsUUIDCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateGetUnitOpenedPortsUUIDCall) DoAndReturn(f func(domain.AtomicContext, string) (map[string][]port.PortRangeUUID, error)) *MockStateGetUnitOpenedPortsUUIDCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// RemoveOpenedPorts mocks base method.
+func (m *MockState) RemoveOpenedPorts(arg0 domain.AtomicContext, arg1 []string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveOpenedPorts", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RemoveOpenedPorts indicates an expected call of RemoveOpenedPorts.
+func (mr *MockStateMockRecorder) RemoveOpenedPorts(arg0, arg1 any) *MockStateRemoveOpenedPortsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveOpenedPorts", reflect.TypeOf((*MockState)(nil).RemoveOpenedPorts), arg0, arg1)
+	return &MockStateRemoveOpenedPortsCall{Call: call}
+}
+
+// MockStateRemoveOpenedPortsCall wrap *gomock.Call
+type MockStateRemoveOpenedPortsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateRemoveOpenedPortsCall) Return(arg0 error) *MockStateRemoveOpenedPortsCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateRemoveOpenedPortsCall) Do(f func(domain.AtomicContext, []string) error) *MockStateRemoveOpenedPortsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateRemoveOpenedPortsCall) DoAndReturn(f func(domain.AtomicContext, []string) error) *MockStateRemoveOpenedPortsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // RunAtomic mocks base method.
 func (m *MockState) RunAtomic(arg0 context.Context, arg1 func(domain.AtomicContext) error) error {
 	m.ctrl.T.Helper()
@@ -310,44 +425,6 @@ func (c *MockStateRunAtomicCall) Do(f func(context.Context, func(domain.AtomicCo
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockStateRunAtomicCall) DoAndReturn(f func(context.Context, func(domain.AtomicContext) error) error) *MockStateRunAtomicCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// UpdateUnitPorts mocks base method.
-func (m *MockState) UpdateUnitPorts(arg0 domain.AtomicContext, arg1 string, arg2, arg3 network.GroupedPortRanges) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateUnitPorts", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// UpdateUnitPorts indicates an expected call of UpdateUnitPorts.
-func (mr *MockStateMockRecorder) UpdateUnitPorts(arg0, arg1, arg2, arg3 any) *MockStateUpdateUnitPortsCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateUnitPorts", reflect.TypeOf((*MockState)(nil).UpdateUnitPorts), arg0, arg1, arg2, arg3)
-	return &MockStateUpdateUnitPortsCall{Call: call}
-}
-
-// MockStateUpdateUnitPortsCall wrap *gomock.Call
-type MockStateUpdateUnitPortsCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockStateUpdateUnitPortsCall) Return(arg0 error) *MockStateUpdateUnitPortsCall {
-	c.Call = c.Call.Return(arg0)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockStateUpdateUnitPortsCall) Do(f func(domain.AtomicContext, string, network.GroupedPortRanges, network.GroupedPortRanges) error) *MockStateUpdateUnitPortsCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateUpdateUnitPortsCall) DoAndReturn(f func(domain.AtomicContext, string, network.GroupedPortRanges, network.GroupedPortRanges) error) *MockStateUpdateUnitPortsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/port/service/package_test.go
+++ b/domain/port/service/package_test.go
@@ -7,9 +7,13 @@ import (
 	"testing"
 
 	gc "gopkg.in/check.v1"
+
+	portstate "github.com/juju/juju/domain/port/state"
 )
 
 //go:generate go run go.uber.org/mock/mockgen -typed -package service -destination package_mock_test.go github.com/juju/juju/domain/port/service State
+
+var _ State = (*portstate.State)(nil)
 
 func TestPackage(t *testing.T) {
 	gc.TestingT(t)

--- a/domain/port/service/types.go
+++ b/domain/port/service/types.go
@@ -10,15 +10,15 @@ import (
 
 // portRangeUUIDIndex is a map targeting the uuids of existing port ranges for a unit.
 // These UUIDS are indexed, first by the endpoint, then by the port range itself.
-type portRangeUUIDIndex map[string]map[network.PortRange]string
+type portRangeUUIDIndex map[string]map[network.PortRange]port.UUID
 
 // indexPortRanges indexes the given port ranges by endpoint and port range.
-func indexPortRanges(groupedPortRanges map[string][]port.PortRangeUUID) portRangeUUIDIndex {
+func indexPortRanges(groupedPortRanges map[string][]port.PortRangeWithUUID) portRangeUUIDIndex {
 	index := make(portRangeUUIDIndex)
 	for endpoint, portRanges := range groupedPortRanges {
 		for _, portRange := range portRanges {
 			if _, ok := index[endpoint]; !ok {
-				index[endpoint] = make(map[network.PortRange]string)
+				index[endpoint] = make(map[network.PortRange]port.UUID)
 			}
 			index[endpoint][portRange.PortRange] = portRange.UUID
 		}

--- a/domain/port/service/types.go
+++ b/domain/port/service/types.go
@@ -1,0 +1,27 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package service
+
+import (
+	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/domain/port"
+)
+
+// portRangeUUIDIndex is a map targeting the uuids of existing port ranges for a unit.
+// These UUIDS are indexed, first by the endpoint, then by the port range itself.
+type portRangeUUIDIndex map[string]map[network.PortRange]string
+
+// indexPortRanges indexes the given port ranges by endpoint and port range.
+func indexPortRanges(groupedPortRanges map[string][]port.PortRangeUUID) portRangeUUIDIndex {
+	index := make(portRangeUUIDIndex)
+	for endpoint, portRanges := range groupedPortRanges {
+		for _, portRange := range portRanges {
+			if _, ok := index[endpoint]; !ok {
+				index[endpoint] = make(map[network.PortRange]string)
+			}
+			index[endpoint][portRange.PortRange] = portRange.UUID
+		}
+	}
+	return index
+}

--- a/domain/port/state/errors.go
+++ b/domain/port/state/errors.go
@@ -1,0 +1,8 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import "github.com/juju/juju/internal/errors"
+
+const ErrUnitEndpointConflict = errors.ConstError("unit endpoint conflict")

--- a/domain/port/state/state.go
+++ b/domain/port/state/state.go
@@ -10,13 +10,14 @@ import (
 	"github.com/juju/collections/transform"
 	jujuerrors "github.com/juju/errors"
 
+	"github.com/juju/juju/core/application"
 	coredatabase "github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/core/unit"
 	"github.com/juju/juju/domain"
 	"github.com/juju/juju/domain/port"
 	"github.com/juju/juju/internal/database"
 	"github.com/juju/juju/internal/errors"
-	"github.com/juju/juju/internal/uuid"
 )
 
 // State represents the persistence layer for opened ports.
@@ -33,13 +34,13 @@ func NewState(factory coredatabase.TxnRunnerFactory) *State {
 
 // GetUnitOpenedPorts returns the opened ports for a given unit uuid,
 // grouped by endpoint.
-func (st *State) GetUnitOpenedPorts(ctx context.Context, unit string) (network.GroupedPortRanges, error) {
+func (st *State) GetUnitOpenedPorts(ctx context.Context, unit unit.UUID) (network.GroupedPortRanges, error) {
 	db, err := st.DB()
 	if err != nil {
 		return nil, jujuerrors.Trace(err)
 	}
 
-	unitUUID := unitUUID{UUID: unit}
+	unitUUID := unitUUID{UUID: unit.String()}
 
 	query, err := st.Prepare(`
 SELECT &endpointPortRange.*
@@ -80,10 +81,10 @@ WHERE unit_endpoint.unit_uuid = $unitUUID.unit_uuid
 	return groupedPortRanges, nil
 }
 
-// GetUnitOpenedPortsUUID returns the opened ports for the given unit with the
+// GetUnitOpenedPortsWithUUIDs returns the opened ports for the given unit with the
 // UUID of the port range. The opened ports are grouped by endpoint.
-func (st *State) GetUnitOpenedPortsUUID(ctx domain.AtomicContext, unit string) (map[string][]port.PortRangeUUID, error) {
-	unitUUID := unitUUID{UUID: unit}
+func (st *State) GetUnitOpenedPortsWithUUIDs(ctx domain.AtomicContext, unit unit.UUID) (map[string][]port.PortRangeWithUUID, error) {
+	unitUUID := unitUUID{UUID: unit.String()}
 	getOpenedPorts, err := st.Prepare(`
 SELECT 
 	port_range.uuid AS &endpointPortRangeUUID.uuid,
@@ -112,13 +113,13 @@ WHERE unit_endpoint.unit_uuid = $unitUUID.unit_uuid
 		return nil, jujuerrors.Trace(err)
 	}
 
-	ret := map[string][]port.PortRangeUUID{}
+	ret := map[string][]port.PortRangeWithUUID{}
 	for _, openedPort := range openedPorts {
 		if _, ok := ret[openedPort.Endpoint]; !ok {
-			ret[openedPort.Endpoint] = []port.PortRangeUUID{}
+			ret[openedPort.Endpoint] = []port.PortRangeWithUUID{}
 		}
-		ret[openedPort.Endpoint] = append(ret[openedPort.Endpoint], port.PortRangeUUID{
-			UUID:      openedPort.UUID,
+		ret[openedPort.Endpoint] = append(ret[openedPort.Endpoint], port.PortRangeWithUUID{
+			UUID:      port.UUID(openedPort.UUID),
 			PortRange: openedPort.decode(),
 		})
 	}
@@ -130,7 +131,7 @@ WHERE unit_endpoint.unit_uuid = $unitUUID.unit_uuid
 //
 // NOTE: In the ddl machines and units both share 1-to-1 relations with net_nodes.
 // So to join units to machines we go via their net_nodes.
-func (st *State) GetMachineOpenedPorts(ctx context.Context, machine string) (map[string]network.GroupedPortRanges, error) {
+func (st *State) GetMachineOpenedPorts(ctx context.Context, machine string) (map[unit.UUID]network.GroupedPortRanges, error) {
 	db, err := st.DB()
 	if err != nil {
 		return nil, jujuerrors.Trace(err)
@@ -172,13 +173,13 @@ WHERE machine.uuid = $machineUUID.machine_uuid
 // GetApplicationOpenedPorts returns the opened ports for all the units of the
 // given application. We return opened ports paired with the unit UUIDs, grouped
 // by endpoint. This is because some consumers do not care about the unit.
-func (st *State) GetApplicationOpenedPorts(ctx context.Context, application string) (port.UnitEndpointPortRanges, error) {
+func (st *State) GetApplicationOpenedPorts(ctx context.Context, application application.ID) (port.UnitEndpointPortRanges, error) {
 	db, err := st.DB()
 	if err != nil {
 		return nil, jujuerrors.Trace(err)
 	}
 
-	applicationUUID := applicationUUID{UUID: application}
+	applicationUUID := applicationUUID{UUID: application.String()}
 
 	query, err := st.Prepare(`
 SELECT &unitEndpointPortRange.*
@@ -214,8 +215,8 @@ WHERE unit.application_uuid = $applicationUUID.application_uuid
 // GetColocatedOpenedPorts returns all the open ports for all units co-located with
 // the given unit. Units are considered co-located if they share the same net-node.
 // Port ranges are NOT grouped
-func (st *State) GetColocatedOpenedPorts(ctx domain.AtomicContext, unit string) ([]network.PortRange, error) {
-	unitUUID := unitUUID{UUID: unit}
+func (st *State) GetColocatedOpenedPorts(ctx domain.AtomicContext, unit unit.UUID) ([]network.PortRange, error) {
+	unitUUID := unitUUID{UUID: unit.String()}
 
 	getOpenedPorts, err := st.Prepare(`
 SELECT DISTINCT &portRange.*
@@ -249,7 +250,7 @@ WHERE u2.uuid = $unitUUID.unit_uuid
 
 // AddOpenedPorts adds the given port ranges to the database. Port ranges must
 // be grouped by endpoint UUID.
-func (st *State) AddOpenedPorts(ctx domain.AtomicContext, portRangesByEndpointUUID network.GroupedPortRanges) error {
+func (st *State) AddOpenedPorts(ctx domain.AtomicContext, portRangesByEndpointUUID map[port.UUID][]network.PortRange) error {
 	insertPortRange, err := st.Prepare("INSERT INTO port_range (*) VALUES ($unitPortRange.*)", unitPortRange{})
 	if err != nil {
 		return errors.Errorf("preparing insert port range statement: %w", err)
@@ -265,16 +266,16 @@ func (st *State) AddOpenedPorts(ctx domain.AtomicContext, portRangesByEndpointUU
 
 	for endpointUUID, portRanges := range portRangesByEndpointUUID {
 		for _, portRange := range portRanges {
-			uuid, err := uuid.NewUUID()
+			portRangeUUID, err := port.NewUUID()
 			if err != nil {
 				return errors.Errorf("generating UUID for port range: %w", err)
 			}
 			openPortRanges = append(openPortRanges, unitPortRange{
-				UUID:             uuid.String(),
+				UUID:             portRangeUUID.String(),
 				ProtocolID:       protocolMap[portRange.Protocol],
 				FromPort:         portRange.FromPort,
 				ToPort:           portRange.ToPort,
-				UnitEndpointUUID: endpointUUID,
+				UnitEndpointUUID: endpointUUID.String(),
 			})
 		}
 	}
@@ -313,8 +314,8 @@ func (st *State) getProtocolMap(ctx domain.AtomicContext) (map[string]int, error
 }
 
 // RemoveOpenedPorts removes the given port ranges from the database by uuid.
-func (st *State) RemoveOpenedPorts(ctx domain.AtomicContext, uuids []string) error {
-	portRangeUUIDs := portRangeUUIDs(uuids)
+func (st *State) RemoveOpenedPorts(ctx domain.AtomicContext, uuids []port.UUID) error {
+	portRangeUUIDs := portRangeUUIDs(transform.Slice(uuids, func(u port.UUID) string { return u.String() }))
 
 	closePortRanges, err := st.Prepare(`
 DELETE FROM port_range
@@ -338,8 +339,8 @@ WHERE uuid IN ($portRangeUUIDs[:])
 //
 // Once it has been implemented, we should check the charm_relation table to get a
 // complete list of endpoints instead.
-func (st *State) GetEndpoints(ctx domain.AtomicContext, unit string) ([]port.Endpoint, error) {
-	unitUUID := unitUUID{UUID: unit}
+func (st *State) GetEndpoints(ctx domain.AtomicContext, unit unit.UUID) ([]port.Endpoint, error) {
+	unitUUID := unitUUID{UUID: unit.String()}
 
 	getEndpoints, err := st.Prepare(`
 SELECT &endpoint.*
@@ -367,12 +368,12 @@ WHERE unit_endpoint.unit_uuid = $unitUUID.unit_uuid
 
 // AddEndpoints adds the endpoints to a given unit. Return the added endpoints
 // with their corresponding UUIDs.
-func (st *State) AddEndpoints(ctx domain.AtomicContext, unit string, endpoints []string) ([]port.Endpoint, error) {
+func (st *State) AddEndpoints(ctx domain.AtomicContext, unit unit.UUID, endpoints []string) ([]port.Endpoint, error) {
 	if len(endpoints) == 0 {
 		return nil, nil
 	}
 
-	unitUUID := unitUUID{UUID: unit}
+	unitUUID := unitUUID{UUID: unit.String()}
 
 	insertUnitEndpoint, err := st.Prepare("INSERT INTO unit_endpoint (*) VALUES ($unitEndpoint.*)", unitEndpoint{})
 	if err != nil {
@@ -381,7 +382,7 @@ func (st *State) AddEndpoints(ctx domain.AtomicContext, unit string, endpoints [
 
 	newEndpoints := make([]unitEndpoint, len(endpoints))
 	for i, endpoint := range endpoints {
-		uuid, err := uuid.NewUUID()
+		uuid, err := port.NewUUID()
 		if err != nil {
 			return nil, errors.Errorf("generating UUID for unit endpoint: %w", err)
 		}

--- a/domain/port/state/state.go
+++ b/domain/port/state/state.go
@@ -7,14 +7,14 @@ import (
 	"context"
 
 	"github.com/canonical/sqlair"
-	"github.com/juju/collections/set"
 	"github.com/juju/collections/transform"
 	jujuerrors "github.com/juju/errors"
 
-	"github.com/juju/juju/core/database"
+	coredatabase "github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/domain"
 	"github.com/juju/juju/domain/port"
+	"github.com/juju/juju/internal/database"
 	"github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/internal/uuid"
 )
@@ -25,7 +25,7 @@ type State struct {
 }
 
 // NewState returns a new state reference.
-func NewState(factory database.TxnRunnerFactory) *State {
+func NewState(factory coredatabase.TxnRunnerFactory) *State {
 	return &State{
 		StateBase: domain.NewStateBase(factory),
 	}
@@ -80,6 +80,51 @@ WHERE unit_endpoint.unit_uuid = $unitUUID.unit_uuid
 	return groupedPortRanges, nil
 }
 
+// GetUnitOpenedPortsUUID returns the opened ports for the given unit with the
+// UUID of the port range. The opened ports are grouped by endpoint.
+func (st *State) GetUnitOpenedPortsUUID(ctx domain.AtomicContext, unit string) (map[string][]port.PortRangeUUID, error) {
+	unitUUID := unitUUID{UUID: unit}
+	getOpenedPorts, err := st.Prepare(`
+SELECT 
+	port_range.uuid AS &endpointPortRangeUUID.uuid,
+	protocol.protocol AS &endpointPortRangeUUID.protocol,
+	port_range.from_port AS &endpointPortRangeUUID.from_port,
+	port_range.to_port AS &endpointPortRangeUUID.to_port,
+	unit_endpoint.endpoint AS &endpointPortRangeUUID.endpoint
+FROM port_range
+JOIN protocol ON port_range.protocol_id = protocol.id
+JOIN unit_endpoint ON port_range.unit_endpoint_uuid = unit_endpoint.uuid
+WHERE unit_endpoint.unit_uuid = $unitUUID.unit_uuid
+`, endpointPortRangeUUID{}, unitUUID)
+	if err != nil {
+		return nil, errors.Errorf("preparing get opened ports statement: %w", err)
+	}
+
+	openedPorts := []endpointPortRangeUUID{}
+	err = domain.Run(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		err := tx.Query(ctx, getOpenedPorts, unitUUID).GetAll(&openedPorts)
+		if errors.Is(err, sqlair.ErrNoRows) {
+			return nil
+		}
+		return err
+	})
+	if err != nil {
+		return nil, jujuerrors.Trace(err)
+	}
+
+	ret := map[string][]port.PortRangeUUID{}
+	for _, openedPort := range openedPorts {
+		if _, ok := ret[openedPort.Endpoint]; !ok {
+			ret[openedPort.Endpoint] = []port.PortRangeUUID{}
+		}
+		ret[openedPort.Endpoint] = append(ret[openedPort.Endpoint], port.PortRangeUUID{
+			UUID:      openedPort.UUID,
+			PortRange: openedPort.decode(),
+		})
+	}
+	return ret, nil
+}
+
 // GetMachineOpenedPorts returns the opened ports for all the units on the given
 // machine. Opened ports are grouped first by unit and then by endpoint.
 //
@@ -118,7 +163,10 @@ WHERE machine.uuid = $machineUUID.machine_uuid
 		return nil, errors.Errorf("getting opened ports for machine %q: %w", machine, err)
 	}
 
-	return groupPortRangesByUnitByEndpoint(results), nil
+	decoded := port.UnitEndpointPortRanges(transform.Slice(results, func(p unitEndpointPortRange) port.UnitEndpointPortRange {
+		return p.decodeToUnitEndpointPortRange()
+	}))
+	return decoded.ByUnitByEndpoint(), nil
 }
 
 // GetApplicationOpenedPorts returns the opened ports for all the units of the
@@ -163,36 +211,14 @@ WHERE unit.application_uuid = $applicationUUID.application_uuid
 	return ret, nil
 }
 
-func groupPortRangesByUnitByEndpoint(portRanges []unitEndpointPortRange) map[string]network.GroupedPortRanges {
-	groupedPortRanges := map[string]network.GroupedPortRanges{}
-	for _, portRange := range portRanges {
-		unitUUID := portRange.UnitUUID
-		endpoint := portRange.Endpoint
-		if _, ok := groupedPortRanges[unitUUID]; !ok {
-			groupedPortRanges[unitUUID] = network.GroupedPortRanges{}
-		}
-		if _, ok := groupedPortRanges[unitUUID][endpoint]; !ok {
-			groupedPortRanges[unitUUID][endpoint] = []network.PortRange{}
-		}
-		groupedPortRanges[unitUUID][endpoint] = append(groupedPortRanges[unitUUID][endpoint], portRange.decodeToPortRange())
-	}
-
-	for _, grp := range groupedPortRanges {
-		for _, portRanges := range grp {
-			network.SortPortRanges(portRanges)
-		}
-	}
-
-	return groupedPortRanges
-}
-
 // GetColocatedOpenedPorts returns all the open ports for all units co-located with
 // the given unit. Units are considered co-located if they share the same net-node.
+// Port ranges are NOT grouped
 func (st *State) GetColocatedOpenedPorts(ctx domain.AtomicContext, unit string) ([]network.PortRange, error) {
 	unitUUID := unitUUID{UUID: unit}
 
 	getOpenedPorts, err := st.Prepare(`
-SELECT &portRange.*
+SELECT DISTINCT &portRange.*
 FROM port_range AS pr
 JOIN protocol AS p ON pr.protocol_id = p.id
 JOIN unit_endpoint AS ep ON pr.unit_endpoint_uuid = ep.uuid
@@ -221,220 +247,24 @@ WHERE u2.uuid = $unitUUID.unit_uuid
 	return ret, nil
 }
 
-// GetEndpointOpenedPorts returns the opened ports for a given endpoint of a
-// given unit.
-func (st *State) GetEndpointOpenedPorts(ctx domain.AtomicContext, unit string, endpoint string) ([]network.PortRange, error) {
-	unitUUID := unitUUID{UUID: unit}
-	endpointName := endpointName{Endpoint: endpoint}
-
-	query, err := st.Prepare(`
-SELECT &portRange.*
-FROM port_range
-JOIN protocol ON port_range.protocol_id = protocol.id
-JOIN unit_endpoint ON port_range.unit_endpoint_uuid = unit_endpoint.uuid
-WHERE unit_endpoint.unit_uuid = $unitUUID.unit_uuid
-AND unit_endpoint.endpoint = $endpointName.endpoint
-`, portRange{}, unitUUID, endpointName)
-	if err != nil {
-		return nil, errors.Errorf("preparing get endpoint opened ports statement: %w", err)
-	}
-
-	var portRanges []portRange
-	err = domain.Run(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		err := tx.Query(ctx, query, unitUUID, endpointName).GetAll(&portRanges)
-		if errors.Is(err, sqlair.ErrNoRows) {
-			return nil
-		}
-		return jujuerrors.Trace(err)
-	})
-	if err != nil {
-		return nil, errors.Errorf("getting opened ports for endpoint %q of unit %q: %w", endpoint, unit, err)
-	}
-
-	decodedPortRanges := make([]network.PortRange, len(portRanges))
-	for i, pr := range portRanges {
-		decodedPortRanges[i] = pr.decode()
-	}
-	network.SortPortRanges(decodedPortRanges)
-	return decodedPortRanges, nil
-}
-
-// UpdateUnitPorts opens and closes ports for the endpoints of a given unit.
-// The service layer must ensure that opened and closed ports for the same
-// endpoints must not conflict.
-func (st *State) UpdateUnitPorts(
-	ctx domain.AtomicContext, unit string, openPorts, closePorts network.GroupedPortRanges,
-) error {
-	endpointsUnderActionSet := set.NewStrings()
-	for endpoint := range openPorts {
-		endpointsUnderActionSet.Add(endpoint)
-	}
-	for endpoint := range closePorts {
-		endpointsUnderActionSet.Add(endpoint)
-	}
-	endpointsUnderAction := endpoints(endpointsUnderActionSet.Values())
-
-	unitUUID := unitUUID{UUID: unit}
-
-	return domain.Run(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		endpoints, err := st.ensureEndpoints(ctx, tx, unitUUID, endpointsUnderAction)
-		if err != nil {
-			return errors.Errorf("ensuring endpoints exist for unit %q: %w", unit, err)
-		}
-
-		currentUnitOpenedPorts, err := st.getUnitOpenedPorts(ctx, tx, unitUUID)
-		if err != nil {
-			return errors.Errorf("getting opened ports for unit %q: %w", unit, err)
-		}
-
-		err = st.openPorts(ctx, tx, openPorts, currentUnitOpenedPorts, endpoints)
-		if err != nil {
-			return errors.Errorf("opening ports for unit %q: %w", unit, err)
-		}
-
-		err = st.closePorts(ctx, tx, closePorts, currentUnitOpenedPorts)
-		if err != nil {
-			return errors.Errorf("closing ports for unit %q: %w", unit, err)
-		}
-
-		return nil
-	})
-}
-
-// ensureEndpoints ensures that the given endpoints are present in the database.
-// Return all endpoints under action with their corresponding UUIDs.
-//
-// TODO(jack-w-shaw): Once it has been implemented, we should verify new endpoints
-// are valid by checking the charm_relation table.
-func (st *State) ensureEndpoints(
-	ctx context.Context, tx *sqlair.TX, unitUUID unitUUID, endpointsUnderAction endpoints,
-) ([]endpoint, error) {
-	getUnitEndpoints, err := st.Prepare(`
-SELECT &endpoint.*
-FROM unit_endpoint
-WHERE unit_uuid = $unitUUID.unit_uuid
-AND endpoint IN ($endpoints[:])
-`, endpoint{}, unitUUID, endpointsUnderAction)
-	if err != nil {
-		return nil, errors.Errorf("preparing get unit endpoints statement: %w", err)
-	}
-
-	insertUnitEndpoint, err := st.Prepare("INSERT INTO unit_endpoint (*) VALUES ($unitEndpoint.*)", unitEndpoint{})
-	if err != nil {
-		return nil, errors.Errorf("preparing insert unit endpoint statement: %w", err)
-	}
-
-	var endpoints []endpoint
-	err = tx.Query(ctx, getUnitEndpoints, unitUUID, endpointsUnderAction).GetAll(&endpoints)
-	if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-		return nil, jujuerrors.Trace(err)
-	}
-
-	foundEndpoints := set.NewStrings()
-	for _, ep := range endpoints {
-		foundEndpoints.Add(ep.Endpoint)
-	}
-
-	// Insert any new endpoints that are required.
-	requiredEndpoints := set.NewStrings(endpointsUnderAction...).Difference(foundEndpoints)
-	newUnitEndpoints := make([]unitEndpoint, requiredEndpoints.Size())
-	for i, requiredEndpoint := range requiredEndpoints.Values() {
-		uuid, err := uuid.NewUUID()
-		if err != nil {
-			return nil, errors.Errorf("generating UUID for unit endpoint: %w", err)
-		}
-		newUnitEndpoints[i] = unitEndpoint{
-			UUID:     uuid.String(),
-			UnitUUID: unitUUID.UUID,
-			Endpoint: requiredEndpoint,
-		}
-		endpoints = append(endpoints, endpoint{
-			Endpoint: requiredEndpoint,
-			UUID:     uuid.String(),
-		})
-	}
-
-	if len(newUnitEndpoints) > 0 {
-		err = tx.Query(ctx, insertUnitEndpoint, newUnitEndpoints).Run()
-		if err != nil {
-			return nil, jujuerrors.Trace(err)
-		}
-	}
-
-	return endpoints, nil
-}
-
-// getUnitOpenedPorts returns the opened ports for the given unit.
-//
-// NOTE: This differs from GetUnitOpenedPorts in that it returns port ranges with
-// their UUIDs, which are not needed by GetUnitOpenedPorts.
-func (st *State) getUnitOpenedPorts(ctx context.Context, tx *sqlair.TX, unitUUID unitUUID) ([]endpointPortRangeUUID, error) {
-	getOpenedPorts, err := st.Prepare(`
-SELECT 
-	port_range.uuid AS &endpointPortRangeUUID.uuid,
-	protocol.protocol AS &endpointPortRangeUUID.protocol,
-	port_range.from_port AS &endpointPortRangeUUID.from_port,
-	port_range.to_port AS &endpointPortRangeUUID.to_port,
-	unit_endpoint.endpoint AS &endpointPortRangeUUID.endpoint
-FROM port_range
-JOIN protocol ON port_range.protocol_id = protocol.id
-JOIN unit_endpoint ON port_range.unit_endpoint_uuid = unit_endpoint.uuid
-WHERE unit_endpoint.unit_uuid = $unitUUID.unit_uuid
-`, endpointPortRangeUUID{}, unitUUID)
-	if err != nil {
-		return nil, errors.Errorf("preparing get opened ports statement: %w", err)
-	}
-
-	var openedPorts []endpointPortRangeUUID
-	err = tx.Query(ctx, getOpenedPorts, unitUUID).GetAll(&openedPorts)
-	if errors.Is(err, sqlair.ErrNoRows) {
-		return []endpointPortRangeUUID{}, nil
-	}
-	if err != nil {
-		return nil, jujuerrors.Trace(err)
-	}
-	return openedPorts, nil
-}
-
-// openPorts inserts the given port ranges into the database, unless they're already open.
-func (st *State) openPorts(
-	ctx context.Context, tx *sqlair.TX,
-	openPorts network.GroupedPortRanges, currentOpenedPorts []endpointPortRangeUUID, endpoints []endpoint,
-) error {
+// AddOpenedPorts adds the given port ranges to the database. Port ranges must
+// be grouped by endpoint UUID.
+func (st *State) AddOpenedPorts(ctx domain.AtomicContext, portRangesByEndpointUUID network.GroupedPortRanges) error {
 	insertPortRange, err := st.Prepare("INSERT INTO port_range (*) VALUES ($unitPortRange.*)", unitPortRange{})
 	if err != nil {
 		return errors.Errorf("preparing insert port range statement: %w", err)
 	}
 
-	protocolMap, err := st.getProtocolMap(ctx, tx)
+	protocolMap, err := st.getProtocolMap(ctx)
 	if err != nil {
 		return errors.Errorf("getting protocol map: %w", err)
-	}
-
-	// index the current opened ports by endpoint and port range
-	currentOpenedPortRangeExistenceIndex := make(map[string]map[network.PortRange]bool)
-	for _, openedPortRange := range currentOpenedPorts {
-		if _, ok := currentOpenedPortRangeExistenceIndex[openedPortRange.Endpoint]; !ok {
-			currentOpenedPortRangeExistenceIndex[openedPortRange.Endpoint] = make(map[network.PortRange]bool)
-		}
-		currentOpenedPortRangeExistenceIndex[openedPortRange.Endpoint][openedPortRange.decode()] = true
 	}
 
 	// Construct the new port ranges to open
 	var openPortRanges []unitPortRange
 
-	for _, ep := range endpoints {
-		ports, ok := openPorts[ep.Endpoint]
-		if !ok {
-			continue
-		}
-
-		for _, portRange := range ports {
-			// skip port range if it's already open on this endpoint
-			if _, ok := currentOpenedPortRangeExistenceIndex[ep.Endpoint][portRange]; ok {
-				continue
-			}
-
+	for endpointUUID, portRanges := range portRangesByEndpointUUID {
+		for _, portRange := range portRanges {
 			uuid, err := uuid.NewUUID()
 			if err != nil {
 				return errors.Errorf("generating UUID for port range: %w", err)
@@ -444,29 +274,32 @@ func (st *State) openPorts(
 				ProtocolID:       protocolMap[portRange.Protocol],
 				FromPort:         portRange.FromPort,
 				ToPort:           portRange.ToPort,
-				UnitEndpointUUID: ep.UUID,
+				UnitEndpointUUID: endpointUUID,
 			})
 		}
 	}
 
-	if len(openPortRanges) > 0 {
-		err = tx.Query(ctx, insertPortRange, openPortRanges).Run()
-		if err != nil {
-			return jujuerrors.Trace(err)
-		}
+	err = domain.Run(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		return tx.Query(ctx, insertPortRange, openPortRanges).Run()
+	})
+	if err != nil {
+		return jujuerrors.Trace(err)
 	}
+
 	return nil
 }
 
 // getProtocolMap returns a map of protocol names to their IDs in DQLite.
-func (st *State) getProtocolMap(ctx context.Context, tx *sqlair.TX) (map[string]int, error) {
+func (st *State) getProtocolMap(ctx domain.AtomicContext) (map[string]int, error) {
 	getProtocols, err := st.Prepare("SELECT &protocol.* FROM protocol", protocol{})
 	if err != nil {
 		return nil, errors.Errorf("preparing get protocol ID statement: %w", err)
 	}
 
 	protocols := []protocol{}
-	err = tx.Query(ctx, getProtocols).GetAll(&protocols)
+	err = domain.Run(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		return tx.Query(ctx, getProtocols).GetAll(&protocols)
+	})
 	if err != nil {
 		return nil, jujuerrors.Trace(err)
 	}
@@ -479,51 +312,22 @@ func (st *State) getProtocolMap(ctx context.Context, tx *sqlair.TX) (map[string]
 	return protocolMap, nil
 }
 
-// closePorts removes the given port ranges from the database, if they exist.
-func (st *State) closePorts(
-	ctx context.Context, tx *sqlair.TX, closePorts network.GroupedPortRanges, currentOpenedPorts []endpointPortRangeUUID,
-) error {
+// RemoveOpenedPorts removes the given port ranges from the database by uuid.
+func (st *State) RemoveOpenedPorts(ctx domain.AtomicContext, uuids []string) error {
+	portRangeUUIDs := portRangeUUIDs(uuids)
+
 	closePortRanges, err := st.Prepare(`
 DELETE FROM port_range
 WHERE uuid IN ($portRangeUUIDs[:])
-`, portRangeUUIDs{})
+`, portRangeUUIDs)
 	if err != nil {
-		return errors.Errorf("preparing close port range statement: %w", err)
+		return errors.Errorf("preparing remove opened ports statement: %w", err)
 	}
 
-	// index the uuids of current opened ports by endpoint and port range
-	openedPortRangeUUIDIndex := make(map[string]map[network.PortRange]string)
-	for _, openedPortRange := range currentOpenedPorts {
-		if _, ok := openedPortRangeUUIDIndex[openedPortRange.Endpoint]; !ok {
-			openedPortRangeUUIDIndex[openedPortRange.Endpoint] = make(map[network.PortRange]string)
-		}
-		openedPortRangeUUIDIndex[openedPortRange.Endpoint][openedPortRange.decode()] = openedPortRange.UUID
-	}
-
-	// Find the uuids of port ranges to close
-	var closePortRangeUUIDs portRangeUUIDs
-	for endpoint, portRanges := range closePorts {
-		index, ok := openedPortRangeUUIDIndex[endpoint]
-		if !ok {
-			continue
-		}
-
-		for _, closePortRange := range portRanges {
-			openedRangeUUID, ok := index[closePortRange]
-			if !ok {
-				continue
-			}
-			closePortRangeUUIDs = append(closePortRangeUUIDs, openedRangeUUID)
-		}
-	}
-
-	if len(closePortRangeUUIDs) > 0 {
-		err = tx.Query(ctx, closePortRanges, closePortRangeUUIDs).Run()
-		if err != nil {
-			return jujuerrors.Trace(err)
-		}
-	}
-	return nil
+	err = domain.Run(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		return tx.Query(ctx, closePortRanges, portRangeUUIDs).Run()
+	})
+	return jujuerrors.Trace(err)
 }
 
 // GetEndpoints returns all the endpoints for the given unit
@@ -534,21 +338,21 @@ WHERE uuid IN ($portRangeUUIDs[:])
 //
 // Once it has been implemented, we should check the charm_relation table to get a
 // complete list of endpoints instead.
-func (st *State) GetEndpoints(ctx domain.AtomicContext, unit string) ([]string, error) {
+func (st *State) GetEndpoints(ctx domain.AtomicContext, unit string) ([]port.Endpoint, error) {
 	unitUUID := unitUUID{UUID: unit}
 
 	getEndpoints, err := st.Prepare(`
-SELECT &endpointName.*
+SELECT &endpoint.*
 FROM unit_endpoint
 WHERE unit_endpoint.unit_uuid = $unitUUID.unit_uuid
-`, endpointName{}, unitUUID)
+`, endpoint{}, unitUUID)
 	if err != nil {
 		return nil, errors.Errorf("preparing get endpoints statement: %w", err)
 	}
 
-	var endpointNames []endpointName
+	var endpoints []endpoint
 	err = domain.Run(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		err := tx.Query(ctx, getEndpoints, unitUUID).GetAll(&endpointNames)
+		err := tx.Query(ctx, getEndpoints, unitUUID).GetAll(&endpoints)
 		if errors.Is(err, sqlair.ErrNoRows) {
 			return nil
 		}
@@ -558,9 +362,46 @@ WHERE unit_endpoint.unit_uuid = $unitUUID.unit_uuid
 		return nil, errors.Errorf("getting endpoints for unit %q: %w", unit, err)
 	}
 
-	endpoints := make([]string, len(endpointNames))
-	for i, ep := range endpointNames {
-		endpoints[i] = ep.Endpoint
+	return transform.Slice(endpoints, func(e endpoint) port.Endpoint { return e.decode() }), nil
+}
+
+// AddEndpoints adds the endpoints to a given unit. Return the added endpoints
+// with their corresponding UUIDs.
+func (st *State) AddEndpoints(ctx domain.AtomicContext, unit string, endpoints []string) ([]port.Endpoint, error) {
+	if len(endpoints) == 0 {
+		return nil, nil
 	}
-	return endpoints, nil
+
+	unitUUID := unitUUID{UUID: unit}
+
+	insertUnitEndpoint, err := st.Prepare("INSERT INTO unit_endpoint (*) VALUES ($unitEndpoint.*)", unitEndpoint{})
+	if err != nil {
+		return nil, errors.Errorf("preparing insert unit endpoint statement: %w", err)
+	}
+
+	newEndpoints := make([]unitEndpoint, len(endpoints))
+	for i, endpoint := range endpoints {
+		uuid, err := uuid.NewUUID()
+		if err != nil {
+			return nil, errors.Errorf("generating UUID for unit endpoint: %w", err)
+		}
+		newEndpoints[i] = unitEndpoint{
+			UUID:     uuid.String(),
+			UnitUUID: unitUUID.UUID,
+			Endpoint: endpoint,
+		}
+	}
+
+	err = domain.Run(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		err := tx.Query(ctx, insertUnitEndpoint, newEndpoints).Run()
+		if database.IsErrConstraintUnique(err) {
+			return ErrUnitEndpointConflict
+		}
+		return err
+	})
+	if err != nil {
+		return nil, errors.Errorf("adding endpoints to unit %q: %w", unit, err)
+	}
+
+	return transform.Slice(newEndpoints, func(e unitEndpoint) port.Endpoint { return e.decode() }), nil
 }

--- a/domain/port/state/types.go
+++ b/domain/port/state/types.go
@@ -109,19 +109,25 @@ type endpoint struct {
 	Endpoint string `db:"endpoint"`
 }
 
-// endpointName represents a network endpoint's name.
-type endpointName struct {
-	Endpoint string `db:"endpoint"`
+func (e endpoint) decode() port.Endpoint {
+	return port.Endpoint{
+		UUID:     e.UUID,
+		Endpoint: e.Endpoint,
+	}
 }
-
-// endpoints represents a list of network endpoints.
-type endpoints []string
 
 // unitEndpoint represents a unit's endpoint and its UUID.
 type unitEndpoint struct {
 	UUID     string `db:"uuid"`
 	Endpoint string `db:"endpoint"`
 	UnitUUID string `db:"unit_uuid"`
+}
+
+func (u unitEndpoint) decode() port.Endpoint {
+	return port.Endpoint{
+		UUID:     u.UUID,
+		Endpoint: u.Endpoint,
+	}
 }
 
 // unitUUID represents a unit's UUID.

--- a/domain/port/state/types.go
+++ b/domain/port/state/types.go
@@ -5,6 +5,7 @@ package state
 
 import (
 	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/core/unit"
 	"github.com/juju/juju/domain/port"
 )
 
@@ -77,7 +78,7 @@ type unitEndpointPortRange struct {
 
 func (p unitEndpointPortRange) decodeToUnitEndpointPortRange() port.UnitEndpointPortRange {
 	return port.UnitEndpointPortRange{
-		UnitUUID:  p.UnitUUID,
+		UnitUUID:  unit.UUID(p.UnitUUID),
 		Endpoint:  p.Endpoint,
 		PortRange: p.decodeToPortRange(),
 	}
@@ -111,7 +112,7 @@ type endpoint struct {
 
 func (e endpoint) decode() port.Endpoint {
 	return port.Endpoint{
-		UUID:     e.UUID,
+		UUID:     port.UUID(e.UUID),
 		Endpoint: e.Endpoint,
 	}
 }
@@ -125,7 +126,7 @@ type unitEndpoint struct {
 
 func (u unitEndpoint) decode() port.Endpoint {
 	return port.Endpoint{
-		UUID:     u.UUID,
+		UUID:     port.UUID(u.UUID),
 		Endpoint: u.Endpoint,
 	}
 }

--- a/domain/port/types.go
+++ b/domain/port/types.go
@@ -9,6 +9,17 @@ import (
 	"github.com/juju/juju/core/network"
 )
 
+// Endpoint represents a unit's network endpoint.
+type Endpoint struct {
+	UUID     string
+	Endpoint string
+}
+
+type PortRangeUUID struct {
+	UUID      string
+	PortRange network.PortRange
+}
+
 // UnitPortRange represents a range of ports for a given protocol for a
 // given unit.
 type UnitEndpointPortRange struct {
@@ -44,6 +55,11 @@ func (prs UnitEndpointPortRanges) ByUnitByEndpoint() map[string]network.GroupedP
 			byUnitByEndpoint[unitUUID] = network.GroupedPortRanges{}
 		}
 		byUnitByEndpoint[unitUUID][endpoint] = append(byUnitByEndpoint[unitUUID][endpoint], unitEnpointPortRange.PortRange)
+	}
+	for _, grp := range byUnitByEndpoint {
+		for _, portRanges := range grp {
+			network.SortPortRanges(portRanges)
+		}
 	}
 	return byUnitByEndpoint
 }


### PR DESCRIPTION
The initial implementation of the ports domain included far too much business logic in the state layer. This was made particularly bad given the usage of RunAtomic.

Hoist all of this business logic out of the state layer and into the service layer. Do this by re-writing the domain

This PR essentially represents an entire re-write of the domain. It might be easiest for you to just clone the branch and review it from scratch

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

Unit tests pass