### PR TITLE
feat(build): add rebuild-client-schema target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -505,7 +505,7 @@ endif
 
 .PHONY: rebuild-client-schema
 rebuild-client-schema:
-## rebuild-client-schema: Rebuild the schema for clients with the latest facades
+## rebuild-client-schema: Rebuild the schema with the client facade-group only. Output used by python-libjuju.
 	@echo "Generating client facade schema..."
 # GOOS and GOARCH environment variables are cleared in case the user is trying to cross architecture compilation.
 ifdef SCHEMA_PATH

--- a/Makefile
+++ b/Makefile
@@ -367,7 +367,7 @@ simplestreams: juju juju-metadata ${SIMPLESTREAMS_TARGETS}
 	@echo "\nRun export JUJU_METADATA_SOURCE=\"${JUJU_METADATA_SOURCE}\" if not defined in your env"
 
 .PHONY: build
-build: rebuild-schema go-build
+build: rebuild-schema rebuild-client-schema go-build
 ## build: builds all the targets including rebuilding a new schema.
 
 .PHONY: go-agent-build
@@ -501,6 +501,18 @@ ifdef SCHEMA_PATH
 else
 	@env GOOS= GOARCH= go run $(COMPILE_FLAGS) $(PROJECT)/generate/schemagen -admin-facades \
 		./apiserver/facades/schema.json
+endif
+
+.PHONY: rebuild-client-schema
+rebuild-client-schema:
+## rebuild-client-schema: Rebuild the schema for clients with the latest facades
+	@echo "Generating client facade schema..."
+# GOOS and GOARCH environment variables are cleared in case the user is trying to cross architecture compilation.
+ifdef SCHEMA_PATH
+	@env GOOS= GOARCH= go run $(COMPILE_FLAGS) $(PROJECT)/generate/schemagen -admin-facades -facade-group=client "$(SCHEMA_PATH)"
+else
+	@env GOOS= GOARCH= go run $(COMPILE_FLAGS) $(PROJECT)/generate/schemagen -admin-facades -facade-group=client \
+		./apiserver/facades/client-schema.json
 endif
 
 .PHONY: install-snap-dependencies


### PR DESCRIPTION
In support of `python-libjuju` only needing the client schema (see [#1099](https://github.com/juju/python-libjuju/issues/1099)), add a new target to the Makefile (`rebuild-client-schema`), which generates a `client-schema.json` file containing only the client schema, and add `rebuild-client-schema` to the `build` target.

The `schema.json` generated by `rebuild-schema` is currently used by `python-libjuju` for generating facade code. This involves copying the `schema.json` generated by a juju build for a given release to the `python-libjuju` repo. However, the `schema.json` generated by `rebuild-schema` contains all controller, agent and client schema, while `python-libjuju` only needs the client schema. Using only the client schema reduces the generated code in `python-libjuju`, which will simplify enhancements and maintenance for generated code in `python-libjuju` going forward.

`rebuild-client-schema` is added to the `build` target, so that the client only schema is generated when juju is built. The rationale is that it is more appropriate for `python-libjuju` to continue to use a build artifact from `juju`'s release process for corresponding `python-libjuju` releases rather than to manually run `make rebuild-client-schema` in `juju` when releasing `python-libjuju`.

`client-schema.json` will need to be checked in alongside `schema.json` whenever a new `schema.json` would be committed. If the new `schema.json` was generated via `make rebuild-schema` rather than `make build` then `make rebuild-client-schema` would also need to be run before checking in `client-schema.json`.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] ~Code style: imports ordered, good names, simple structure, etc~
- [x] ~Comments saying why design decisions were made~
- [x] ~Go unit tests, with comments saying what you're testing~
- [x] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [x] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

* Run `make rebuild-client-schema` and verify that a `client-schema.json` file has been generated.
* Run `make build` and verify that the same contents are generated for `client-schema.json`.
* Verify that `client-schema.json` contains a subset of the contents of `schema.json`.

## Documentation changes

I'd be happy to add documentation for this wherever needed, please let me know where it would be appropriate to add this information.

Please let me know if juju currently uses any automated processes that could be updated to support this, for example checking that if a PR modifies `schema.json` then `client-schema.json` should also be modified.

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**python-libjuju issue:** https://github.com/juju/python-libjuju/issues/1099