### PR TITLE
fix: destroy-model defaults to waiting 2s

### DIFF
--- a/cmd/juju/model/destroy.go
+++ b/cmd/juju/model/destroy.go
@@ -340,8 +340,10 @@ func waitForModelDestroyed(
 		erroredStatuses.PrettyPrint(ctx.Stdout)
 	}
 
-	// no wait for 1st time.
-	intervalSeconds := 0 * time.Second
+	// wait a little bit for the model to be destroyed, backoff
+	// exponentially, but no longer than 2s
+	intervalSeconds := 10 * time.Millisecond
+	const maxIntervalSeconds = 2 * time.Second
 	reported := ""
 	lineLength := 0
 	const perLineLength = 80
@@ -373,7 +375,10 @@ func waitForModelDestroyed(
 				reported = msg
 				lineLength = len(msg) + 3
 			}
-			intervalSeconds = 2 * time.Second
+			intervalSeconds *= 2
+			if intervalSeconds > maxIntervalSeconds {
+				intervalSeconds = maxIntervalSeconds
+			}
 		}
 	}
 }


### PR DESCRIPTION
When creating a lot of models and then destroying them, it turns out that we just had a direct 'always wait 2s'. Occasionally when destroying 20 models the model would be cleaned up by the time we looked, but most of the time it takes a short time to actually cleanup.
This shouldn't impact most people, as waiting for real machines to tear down, it will quickly ramp up to waiting 2s again.
However, when doing testing, this allows me to teardown 20 models in 7s instead of taking 40s.

## Checklist

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

I used these loops in my own testing:
```sh
$ time (for i in `seq -w 0 19`; do juju add-model model-$i --no-switch; done)
$ time (for i in `seq -w 0 19`; do juju destroy-model model-$i --no-prompt; done)
```

## Documentation changes

None

## Links

None

