### PR TITLE
feat(lxdprofiles): add lxd profiles watcher

### DIFF
--- a/apiserver/facades/agent/uniter/register.go
+++ b/apiserver/facades/agent/uniter/register.go
@@ -142,7 +142,7 @@ func newUniterAPIWithServices(
 		RebootRequester:            common.NewRebootRequester(machineService, accessMachine),
 		UnitStateAPI:               common.NewExternalUnitStateAPI(controllerConfigService, unitStateService, st, resources, authorizer, accessUnit, logger),
 		LeadershipSettingsAccessor: leadershipSettingsAccessorFactory(st, leadershipChecker, resources, authorizer),
-		lxdProfileAPI:              NewExternalLXDProfileAPIv2(st, machineService, resources, authorizer, accessUnit, logger, modelInfoService),
+		lxdProfileAPI:              NewExternalLXDProfileAPIv2(st, machineService, context.WatcherRegistry(), authorizer, accessUnit, logger, modelInfoService),
 		// TODO(fwereade): so *every* unit should be allowed to get/set its
 		// own status *and* its application's? This is not a pleasing arrangement.
 		StatusAPI: NewStatusAPI(m, accessUnitOrApplication, leadershipChecker),

--- a/apiserver/facades/agent/uniter/service.go
+++ b/apiserver/facades/agent/uniter/service.go
@@ -101,4 +101,8 @@ type MachineService interface {
 
 	// AppliedLXDProfileNames returns the names of the LXD profiles on the machine.
 	AppliedLXDProfileNames(ctx context.Context, mUUID string) ([]string, error)
+
+	// WatchMachineCloudInstances returns a StringsWatcher that is subscribed to
+	// the changes in the machine_cloud_instance table in the model.
+	WatchLXDProfiles(ctx context.Context, machineUUID string) (watcher.NotifyWatcher, error)
 }

--- a/apiserver/facades/agent/uniter/service_mock_test.go
+++ b/apiserver/facades/agent/uniter/service_mock_test.go
@@ -275,3 +275,18 @@ func (mr *MockMachineServiceMockRecorder) ShouldRebootOrShutdown(arg0, arg1 any)
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ShouldRebootOrShutdown", reflect.TypeOf((*MockMachineService)(nil).ShouldRebootOrShutdown), arg0, arg1)
 }
+
+// WatchLXDProfiles mocks base method.
+func (m *MockMachineService) WatchLXDProfiles(arg0 context.Context, arg1 string) (watcher.Watcher[struct{}], error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WatchLXDProfiles", arg0, arg1)
+	ret0, _ := ret[0].(watcher.Watcher[struct{}])
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WatchLXDProfiles indicates an expected call of WatchLXDProfiles.
+func (mr *MockMachineServiceMockRecorder) WatchLXDProfiles(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchLXDProfiles", reflect.TypeOf((*MockMachineService)(nil).WatchLXDProfiles), arg0, arg1)
+}

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -2746,7 +2746,7 @@ func (u *UniterAPI) commitHookChangesForOneUnit(ctx context.Context, unitTag nam
 
 // WatchInstanceData is a shim to call the LXDProfileAPIv2 version of this method.
 func (u *UniterAPI) WatchInstanceData(ctx context.Context, args params.Entities) (params.NotifyWatchResults, error) {
-	return u.lxdProfileAPI.WatchInstanceData(args)
+	return u.lxdProfileAPI.WatchInstanceData(ctx, args)
 }
 
 // LXDProfileName is a shim to call the LXDProfileAPIv2 version of this method.

--- a/domain/machine/service/package_mock_test.go
+++ b/domain/machine/service/package_mock_test.go
@@ -584,45 +584,6 @@ func (c *MockStateHardwareCharacteristicsCall) DoAndReturn(f func(context.Contex
 	return c
 }
 
-// InitialWatchInstanceStatement mocks base method.
-func (m *MockState) InitialWatchInstanceStatement() (string, string) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InitialWatchInstanceStatement")
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(string)
-	return ret0, ret1
-}
-
-// InitialWatchInstanceStatement indicates an expected call of InitialWatchInstanceStatement.
-func (mr *MockStateMockRecorder) InitialWatchInstanceStatement() *MockStateInitialWatchInstanceStatementCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitialWatchInstanceStatement", reflect.TypeOf((*MockState)(nil).InitialWatchInstanceStatement))
-	return &MockStateInitialWatchInstanceStatementCall{Call: call}
-}
-
-// MockStateInitialWatchInstanceStatementCall wrap *gomock.Call
-type MockStateInitialWatchInstanceStatementCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockStateInitialWatchInstanceStatementCall) Return(arg0, arg1 string) *MockStateInitialWatchInstanceStatementCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockStateInitialWatchInstanceStatementCall) Do(f func() (string, string)) *MockStateInitialWatchInstanceStatementCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateInitialWatchInstanceStatementCall) DoAndReturn(f func() (string, string)) *MockStateInitialWatchInstanceStatementCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // InitialWatchModelMachinesStatement mocks base method.
 func (m *MockState) InitialWatchModelMachinesStatement() (string, string) {
 	m.ctrl.T.Helper()

--- a/domain/machine/service/service.go
+++ b/domain/machine/service/service.go
@@ -57,10 +57,6 @@ type State interface {
 	// If there's no machine, it returns an empty slice.
 	AllMachineNames(context.Context) ([]coremachine.Name, error)
 
-	// InitialWatchInstanceStatement returns the table and the initial watch statement
-	// for the machine cloud instances.
-	InitialWatchInstanceStatement() (string, string)
-
 	// InstanceID returns the cloud specific instance id for this machine.
 	// If the machine is not provisioned, it returns a
 	// [machineerrors.NotProvisionedError]

--- a/domain/machine/state/machine_cloud_instance.go
+++ b/domain/machine/state/machine_cloud_instance.go
@@ -414,9 +414,3 @@ VALUES ($machineUUID.uuid, $machineStatusWithData.key, $machineStatusWithData.da
 		return nil
 	})
 }
-
-// InitialWatchInstanceStatement returns the table and the initial watch statement
-// for the machine cloud instances.
-func (st *State) InitialWatchInstanceStatement() (string, string) {
-	return "machine_cloud_instance", "SELECT machine_uuid FROM machine_cloud_instance"
-}

--- a/domain/schema/model.go
+++ b/domain/schema/model.go
@@ -17,7 +17,7 @@ import (
 //go:generate go run ./../../generate/triggergen -db=model -destination=./model/triggers/objectstore-triggers.gen.go -package=triggers -tables=object_store_metadata_path
 //go:generate go run ./../../generate/triggergen -db=model -destination=./model/triggers/secret-triggers.gen.go -package=triggers -tables=secret_metadata,secret_rotation,secret_revision,secret_revision_expire,secret_revision_obsolete,secret_revision,secret_reference
 //go:generate go run ./../../generate/triggergen -db=model -destination=./model/triggers/network-triggers.gen.go -package=triggers -tables=subnet
-//go:generate go run ./../../generate/triggergen -db=model -destination=./model/triggers/machine-triggers.gen.go -package=triggers -tables=machine
+//go:generate go run ./../../generate/triggergen -db=model -destination=./model/triggers/machine-triggers.gen.go -package=triggers -tables=machine,machine_lxd_profile
 //go:generate go run ./../../generate/triggergen -db=model -destination=./model/triggers/machine-cloud-instance-triggers.gen.go -package=triggers -tables=machine_cloud_instance
 //go:generate go run ./../../generate/triggergen -db=model -destination=./model/triggers/machine-requires-reboot-triggers.gen.go -package=triggers -tables=machine_requires_reboot
 //go:generate go run ./../../generate/triggergen -db=model -destination=./model/triggers/charm.gen.go -package=triggers -tables=charm
@@ -45,6 +45,7 @@ const (
 	tableSecretReference
 	tableSubnet
 	tableMachine
+	tableMachineLxdProfile
 	tableMachineCloudInstance
 	tableMachineRequireReboot
 	tableCharm
@@ -102,6 +103,7 @@ func ModelDDL() *schema.Schema {
 		triggers.ChangeLogTriggersForSecretReference("secret_id", tableSecretReference),
 		triggers.ChangeLogTriggersForSubnet("uuid", tableSubnet),
 		triggers.ChangeLogTriggersForMachine("uuid", tableMachine),
+		triggers.ChangeLogTriggersForMachineLxdProfile("machine_uuid", tableMachineLxdProfile),
 		triggers.ChangeLogTriggersForMachineCloudInstance("machine_uuid", tableMachineCloudInstance),
 		triggers.ChangeLogTriggersForMachineRequiresReboot("machine_uuid", tableMachineRequireReboot),
 		triggers.ChangeLogTriggersForCharm("uuid", tableCharm),

--- a/domain/schema/schema_test.go
+++ b/domain/schema/schema_test.go
@@ -663,6 +663,10 @@ func (s *schemaSuite) TestModelTriggers(c *gc.C) {
 		"trg_log_machine_update",
 		"trg_log_machine_delete",
 
+		"trg_log_machine_lxd_profile_insert",
+		"trg_log_machine_lxd_profile_update",
+		"trg_log_machine_lxd_profile_delete",
+
 		"trg_log_machine_cloud_instance_insert",
 		"trg_log_machine_cloud_instance_update",
 		"trg_log_machine_cloud_instance_delete",


### PR DESCRIPTION
Before this patch, the lxd watcher on the uniter facades used the
instance data watcher underneath. This was suboptimal because a lot of
unrelated changes were triggered.

With the migration to dqlite, we now add a new lxd profiles watcher
which replaces the legacy instance data watcher on the uniter.

Bonus: The machine cloud instance watcher is now transformed into a
notify watcher and taking a machine UUID as argument, to match what's
needed on the call site.

Bonus 2: Small fix to use the FilterEvents method on the machine reboots
watcher.
<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://docs.google.com/document/d/1SYUo9G7qZ_jdoVXpUVamS5VCgHmtZ0QA-wZxKoMS-C0 
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

We can't QA lxd profiles since the instance mutator is currently broken on main. All unit tests should pass though.

## Links


**Jira card:** JUJU-6816

