### PR TITLE
fix: merge secret-set in hook context;

### DIFF
--- a/worker/uniter/runner/context/context_test.go
+++ b/worker/uniter/runner/context/context_test.go
@@ -1581,20 +1581,31 @@ func (s *mockHookContextSuite) TestSecretUpdate(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	uri := coresecrets.NewURI()
-	data := map[string]string{"foo": "bar"}
-	value := coresecrets.NewSecretValue(data)
-	expiry := time.Now()
-	s.mockLeadership.EXPECT().IsLeader().Return(true, nil)
+	s.mockLeadership.EXPECT().IsLeader().Return(true, nil).Times(2)
 	hookContext := context.NewMockUnitHookContext(s.mockUnit, model.IAAS, s.mockLeadership)
 	context.SetEnvironmentHookContextSecret(hookContext, uri.String(), map[string]jujuc.SecretMetadata{
 		uri.ID: {Description: "a secret", LatestRevision: 666, Owner: names.NewApplicationTag("mariadb")},
 	}, nil, nil)
+
+	data := map[string]string{"foo": "bar"}
+	value := coresecrets.NewSecretValue(data)
 	err := hookContext.UpdateSecret(uri, &jujuc.SecretUpdateArgs{
-		Value:        value,
-		RotatePolicy: ptr(coresecrets.RotateDaily),
-		ExpireTime:   ptr(expiry),
-		Description:  ptr("my secret"),
-		Label:        ptr("foo"),
+		Value:        value,                        // will be overwritten by the new value.
+		RotatePolicy: ptr(coresecrets.RotateDaily), // will be kept.
+		Description:  ptr("my secret"),             // will be overwritten by the new value.
+		Label:        ptr("label1"),                // will be overwritten by the new value.
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// update again, nerge with existing.
+	newData := map[string]string{"bar": "baz"}
+	newValue := coresecrets.NewSecretValue(newData)
+	expiry := time.Now()
+	err = hookContext.UpdateSecret(uri, &jujuc.SecretUpdateArgs{
+		ExpireTime:  ptr(expiry),          // will be merged.
+		Value:       newValue,             // will be the new value.
+		Description: ptr("my new secret"), // will be the new value.
+		Label:       ptr("label2"),        // will be the new value.
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(hookContext.PendingSecretUpdates(), jc.DeepEquals, map[string]uniter.SecretUpdateArg{
@@ -1602,11 +1613,11 @@ func (s *mockHookContextSuite) TestSecretUpdate(c *gc.C) {
 			CurrentRevision: 666,
 			SecretUpsertArg: uniter.SecretUpsertArg{
 				URI:          uri,
-				Value:        value,
+				Value:        newValue,
 				RotatePolicy: ptr(coresecrets.RotateDaily),
 				ExpireTime:   ptr(expiry),
-				Description:  ptr("my secret"),
-				Label:        ptr("foo"),
+				Description:  ptr("my new secret"),
+				Label:        ptr("label2"),
 			},
 		}})
 }

--- a/worker/uniter/runner/context/secrets.go
+++ b/worker/uniter/runner/context/secrets.go
@@ -78,7 +78,27 @@ func (s *secretsChangeRecorder) update(arg uniter.SecretUpdateArg) {
 		s.pendingCreates[arg.URI.ID] = c
 		return
 	}
-	s.pendingUpdates[arg.URI.ID] = arg
+	previous, ok := s.pendingUpdates[arg.URI.ID]
+	if !ok {
+		s.pendingUpdates[arg.URI.ID] = arg
+		return
+	}
+	if arg.Label != nil {
+		previous.Label = arg.Label
+	}
+	if arg.Description != nil {
+		previous.Description = arg.Description
+	}
+	if arg.Value != nil && !arg.Value.IsEmpty() {
+		previous.Value = arg.Value
+	}
+	if arg.RotatePolicy != nil {
+		previous.RotatePolicy = arg.RotatePolicy
+	}
+	if arg.ExpireTime != nil {
+		previous.ExpireTime = arg.ExpireTime
+	}
+	s.pendingUpdates[arg.URI.ID] = previous
 }
 
 func (s *secretsChangeRecorder) remove(uri *secrets.URI, revision *int) {


### PR DESCRIPTION
On the uniter side, all relation-set calls are merged if they are made within the same context. However, secret-set currently overwrites previous calls. This PR updates secret-set to follow the same merging logic as relation-set.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps




## Documentation changes

No

## Links

**Launchpad bug:** https://bugs.launchpad.net/bugs/2081034

**Jira card:** [JUJU-6804](https://warthogs.atlassian.net/browse/JUJU-6804)

