### PR TITLE
fix: authorized keys not working

### DIFF
--- a/apiserver/facades/agent/keyupdater/authorisedkeys.go
+++ b/apiserver/facades/agent/keyupdater/authorisedkeys.go
@@ -114,13 +114,6 @@ func (api *KeyUpdaterAPI) WatchAuthorisedKeys(ctx context.Context, arg params.En
 			)
 		}
 
-		if err != nil {
-			return params.NotifyWatchResults{}, fmt.Errorf(
-				"converting machine %q authorised keys watcher to notify watcher: %w",
-				machineId, err,
-			)
-		}
-
 		results[i].NotifyWatcherId, _, err = internal.EnsureRegisterWatcher[struct{}](
 			ctx, api.watcherRegistry, keysWatcher,
 		)

--- a/domain/keymanager/state/state.go
+++ b/domain/keymanager/state/state.go
@@ -465,7 +465,7 @@ func (s *State) GetPublicKeysForUser(
 	stmt, err := s.Prepare(`
 SELECT &publicKey.*
 FROM user_public_ssh_key AS upsk
-JOIN model_authorized_keys AS m ON upsk.user_public_ssh_key_id = m.user_public_ssh_key_id
+JOIN model_authorized_keys AS m ON upsk.id = m.user_public_ssh_key_id
 WHERE user_uuid = $userUUIDValue.user_uuid
 AND model_uuid = $modelUUIDValue.model_uuid
 `, userUUIDVal, publicKey{}, modelUUIDVal)

--- a/domain/services/model.go
+++ b/domain/services/model.go
@@ -159,7 +159,7 @@ func (s *ModelFactory) KeyManagerWithImporter(
 	return keymanagerservice.NewImporterService(
 		s.modelUUID,
 		importer,
-		keymanagerstate.NewState(changestream.NewTxnRunnerFactory(s.modelDB)),
+		keymanagerstate.NewState(changestream.NewTxnRunnerFactory(s.controllerDB)),
 	)
 }
 
@@ -175,7 +175,7 @@ func (s *ModelFactory) KeyUpdater() *keyupdaterservice.WatchableService {
 		),
 		controllerState,
 		keyupdaterstate.NewState(changestream.NewTxnRunnerFactory(s.modelDB)),
-		domain.NewWatcherFactory(s.modelDB, s.logger.Child("keyupdater")),
+		domain.NewWatcherFactory(s.controllerDB, s.logger.Child("keyupdater")),
 	)
 }
 

--- a/tests/suites/authorized_keys/machine.sh
+++ b/tests/suites/authorized_keys/machine.sh
@@ -16,11 +16,11 @@ run_machine_ssh() {
 
 	# Watch the debug log for the agent to assert that a key has been added to
 	# the machine.
-	timeout 5m juju debug-log --tail | grep -m 1 'adding ssh keys to authorized keys' || true
+	timeout 1m juju debug-log --tail | grep -m 1 'adding ssh keys to authorized keys' || true
 
 	# Check that the test can ssh to the machine with the new keypair and run a
 	# command.
-	check_contains "$(juju ssh 0 -i \"${ssh_key_file}\" echo foobar)" "foobar"
+	check_contains "$(juju ssh 0 -i ${ssh_key_file} echo foobar)" "foobar"
 }
 
 # test_machine_ssh is responsible for testing that adding authorized keys to a


### PR DESCRIPTION
This fixes an issue with the latest changes to authorized keys where the wrong database was being wired up in several places causing the domain logic to fail because of missing or bad DDL.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- ~[ ] Comments saying why design decisions were made~
- ~[ ] Go unit tests, with comments saying what you're testing~
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

There is a set of bash suites to prove this out. `cd tests; ./main.sh authorized-keys`

## Documentation changes

N/A

## Links

**Jira card:** JUJU-6824

