### PR TITLE
fix: ignore ModelNotFound in LastestMigration if Done

### DIFF
--- a/state/modelmigration.go
+++ b/state/modelmigration.go
@@ -849,10 +849,10 @@ func (st *State) LatestMigration() (ModelMigration, error) {
 	// away from a model and then migrated back.
 	if phase == migration.DONE {
 		model, err := st.Model()
-		if err != nil {
+		if err != nil && !errors.Is(err, errors.NotFound) {
 			return nil, errors.Trace(err)
 		}
-		if model.MigrationMode() == MigrationModeNone {
+		if model != nil && model.MigrationMode() == MigrationModeNone {
 			return nil, errors.NotFoundf("migration")
 		}
 	}

--- a/state/modelmigration_test.go
+++ b/state/modelmigration_test.go
@@ -259,10 +259,10 @@ func (s *MigrationSuite) TestLatestMigration(c *gc.C) {
 	c.Assert(mig1.Id(), gc.Equals, mig2.Id())
 }
 
-func (s *MigrationSuite) TestLatestMigrationNotExist(c *gc.C) {
+func (s *MigrationSuite) TestLatestMigrationIgnoresModelNotFound(c *gc.C) {
 	mig, err := s.State.LatestMigration()
 	c.Check(mig, gc.IsNil)
-	c.Check(errors.IsNotFound(err), jc.IsTrue)
+	c.Check(err, jc.ErrorIsNil)
 }
 
 func (s *MigrationSuite) TestGetsLatestAttempt(c *gc.C) {


### PR DESCRIPTION
LatestMigration is called by SetPhase. There is a bug where if the phase is done then the "if" block will be triggered and the deleted model not found, causing LatestMigration to return an error.

This was stopping post-migration steps such as setting up offer redirects from happening.

Change this to be idempotent by ignoring the NotFound error and making the code more.

Inspired by @hpidcock's fix here: https://github.com/juju/juju/pull/16858/files
<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://docs.google.com/document/d/1SYUo9G7qZ_jdoVXpUVamS5VCgHmtZ0QA-wZxKoMS-C0 
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps
TESTED MANUALLY BUT STILL NEED TO RUN THIS
```
cd tests
./main.sh -v model test_model_migration_saas_external
```
<!-- Describe steps to verify that the change works. -->


## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2078672

