### PR TITLE
fix: ignore ModelNotFound in LastestMigration if Done

### DIFF
--- a/state/modelmigration.go
+++ b/state/modelmigration.go
@@ -849,10 +849,10 @@ func (st *State) LatestMigration() (ModelMigration, error) {
 	// away from a model and then migrated back.
 	if phase == migration.DONE {
 		model, err := st.Model()
-		if err != nil {
+		if err != nil && !errors.Is(err, errors.NotFound) {
 			return nil, errors.Trace(err)
 		}
-		if model.MigrationMode() == MigrationModeNone {
+		if model != nil && model.MigrationMode() == MigrationModeNone {
 			return nil, errors.NotFoundf("migration")
 		}
 	}

--- a/state/modelmigration_test.go
+++ b/state/modelmigration_test.go
@@ -259,10 +259,10 @@ func (s *MigrationSuite) TestLatestMigration(c *gc.C) {
 	c.Assert(mig1.Id(), gc.Equals, mig2.Id())
 }
 
-func (s *MigrationSuite) TestLatestMigrationNotExist(c *gc.C) {
+func (s *MigrationSuite) TestLatestMigrationIgnoresModelNotFound(c *gc.C) {
 	mig, err := s.State.LatestMigration()
 	c.Check(mig, gc.IsNil)
-	c.Check(errors.IsNotFound(err), jc.IsTrue)
+	c.Check(err, jc.ErrorIsNil)
 }
 
 func (s *MigrationSuite) TestGetsLatestAttempt(c *gc.C) {
@@ -298,6 +298,8 @@ func (s *MigrationSuite) TestLatestMigrationWithPrevious(c *gc.C) {
 		migration.LOGTRANSFER,
 		migration.REAP,
 		migration.DONE,
+		// Check that it is idempotent on DONE.
+		migration.DONE,
 	}
 	for i := 0; i < 10; i++ {
 		mig, err := s.State2.CreateMigration(s.stdSpec)
@@ -311,6 +313,7 @@ func (s *MigrationSuite) TestLatestMigrationWithPrevious(c *gc.C) {
 	// Previous migration shouldn't be reported.
 	_, err := s.State2.LatestMigration()
 	c.Check(errors.IsNotFound(err), jc.IsTrue)
+	c.Check(err, gc.ErrorMatches, "migration not found")
 
 	// Start a new migration attempt, which should be reported.
 	migNext, err := s.State2.CreateMigration(s.stdSpec)


### PR DESCRIPTION
LatestMigration is called by SetPhase. There is a bug where if the phase is done then the "if" block will be triggered and the deleted model not found, causing LatestMigration to return an error.

This was stopping post-migration steps such as setting up offer redirects from happening.

This appears to have been an issue even back in 2.9. I tried the following code:
```
juju bootstrap lxd migration-source-29
juju bootstrap lxd migration-target-29
juju switch migration-source-29
juju add-model test-mig
juju deploy ubuntu
juju migrate test-mig migration-target-29
juju debug-log -m controller
```
And this is in the debug log:
```
machine-0: 10:35:42 INFO juju.worker.migrationmaster.6716e6 setting
migration phase to DONE machine-0: 10:35:42 DEBUG juju.worker.dependency
"migration-master" manifold worker stopped: failed to set phase: could
not get migration: model "6716e6b5-20a1-408a-8c5c-19f34ae15d54" not
found (not found) stack trace: could not get migration: model
"6716e6b5-20a1-408a-8c5c-19f34ae15d54" not found (not found)
github.com/juju/juju/rpc.(*Conn).Call:178:
github.com/juju/juju/worker/migrationmaster.(*Worker).run:266: failed to
set phase machine-0: 10:35:42 ERROR juju.worker.dependency
"migration-master" manifold worker returned unexpected error: failed to
set phase: could not get migration: model
"6716e6b5-20a1-408a-8c5c-19f34ae15d54" not found (not found)
```

This same error appears in 3.6 and other 3.x versions (see bug report).

From my investigations, the issue is that if you are migrating from the old controller, you set the phase to done twice. Once at the end of reap, [here](
https://github.com/juju/juju/tree/main/apiserver/facades/controller/migrationmaster/facade.go#L305 ),
and again from the migration master worker
[here](https://github.com/juju/juju/tree/main/worker/migrationmaster/worker.go#L265). In REAP, we delete the model, then as part of  `SetPhase` when setting it to done, we call `LatestMigration` . If the phase is Done then it checks to see if the model has in fact been migrated back and can be found, in which case it does not returns an error for the latest migration. The problem is, it also returns an error if the model cannot be found at all. The model cannot be found at all when the Phase is already done because it has been deleted in the reap phase.

Inspired by @hpidcock's fix here: https://github.com/juju/juju/pull/16858/files

<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://docs.google.com/document/d/1SYUo9G7qZ_jdoVXpUVamS5VCgHmtZ0QA-wZxKoMS-C0 
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

```
cd tests
./main.sh -v model test_model_migration_saas_external
```
TODO check that migrating a model back that was migrated away still works
<!-- Describe steps to verify that the change works. -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** **Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2078672


