### PR TITLE
fix: fix slice init length

### DIFF
--- a/apiserver/common/crossmodel/crossmodel.go
+++ b/apiserver/common/crossmodel/crossmodel.go
@@ -626,7 +626,7 @@ func getDerivedUnitsStatus(app Application) (status.StatusInfo, error) {
 		return status.StatusInfo{}, errors.Trace(err)
 	}
 
-	statuses := make([]status.StatusInfo, len(units))
+	statuses := make([]status.StatusInfo, 0, len(units))
 	for _, unit := range units {
 		st, err := unit.Status()
 		if err != nil {


### PR DESCRIPTION
<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://docs.google.com/document/d/1SYUo9G7qZ_jdoVXpUVamS5VCgHmtZ0QA-wZxKoMS-C0 
-->

<!-- Why this change is needed and what it does. -->

The intention here should be to initialize a slice with a capacity of length rather than initializing the  `len(units)`  of this slice. 

The online demo: https://go.dev/play/p/q1BcVCmvidW



## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

<!-- Describe steps to verify that the change works. -->

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/

**Jira card:** JUJU-

