### PR TITLE
feat(instancedata): remove AvailabilityZones from state/machine

### DIFF
--- a/apiserver/facades/agent/provisioner/service.go
+++ b/apiserver/facades/agent/provisioner/service.go
@@ -77,6 +77,10 @@ type MachineService interface {
 	// lxd_profile table for the given machine. This method will overwrite the list
 	// of profiles for the given machine without any checks.
 	SetAppliedLXDProfileNames(ctx context.Context, mUUID string, profileNames []string) error
+
+	// HardwareCharacteristics returns the hardware characteristics of the
+	// of the specified machine.
+	HardwareCharacteristics(ctx context.Context, machineUUID string) (*instance.HardwareCharacteristics, error)
 }
 
 // StoragePoolGetter instances get a storage pool by name.

--- a/apiserver/facades/agent/uniter/register.go
+++ b/apiserver/facades/agent/uniter/register.go
@@ -152,6 +152,7 @@ func newUniterAPIWithServices(
 		controllerConfigService: controllerConfigService,
 		modelConfigService:      modelConfigService,
 		modelInfoService:        modelInfoService,
+		machineService:          machineService,
 		secretService:           secretService,
 		networkService:          networkService,
 		cloudService:            cloudService,

--- a/apiserver/facades/agent/uniter/service.go
+++ b/apiserver/facades/agent/uniter/service.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/credential"
+	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/leadership"
 	"github.com/juju/juju/core/life"
 	coremachine "github.com/juju/juju/core/machine"
@@ -105,4 +106,8 @@ type MachineService interface {
 	// WatchMachineCloudInstances returns a StringsWatcher that is subscribed to
 	// the changes in the machine_cloud_instance table in the model.
 	WatchLXDProfiles(ctx context.Context, machineUUID string) (watcher.NotifyWatcher, error)
+
+	// HardwareCharacteristics returns the hardware characteristics of the
+	// specified machine.
+	HardwareCharacteristics(ctx context.Context, machineUUID string) (*instance.HardwareCharacteristics, error)
 }

--- a/apiserver/facades/agent/uniter/service_mock_test.go
+++ b/apiserver/facades/agent/uniter/service_mock_test.go
@@ -13,6 +13,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	instance "github.com/juju/juju/core/instance"
 	machine "github.com/juju/juju/core/machine"
 	model "github.com/juju/juju/core/model"
 	network "github.com/juju/juju/core/network"
@@ -230,6 +231,21 @@ func (m *MockMachineService) GetMachineUUID(arg0 context.Context, arg1 machine.N
 func (mr *MockMachineServiceMockRecorder) GetMachineUUID(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMachineUUID", reflect.TypeOf((*MockMachineService)(nil).GetMachineUUID), arg0, arg1)
+}
+
+// HardwareCharacteristics mocks base method.
+func (m *MockMachineService) HardwareCharacteristics(arg0 context.Context, arg1 string) (*instance.HardwareCharacteristics, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HardwareCharacteristics", arg0, arg1)
+	ret0, _ := ret[0].(*instance.HardwareCharacteristics)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// HardwareCharacteristics indicates an expected call of HardwareCharacteristics.
+func (mr *MockMachineServiceMockRecorder) HardwareCharacteristics(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HardwareCharacteristics", reflect.TypeOf((*MockMachineService)(nil).HardwareCharacteristics), arg0, arg1)
 }
 
 // IsMachineRebootRequired mocks base method.

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -352,7 +352,7 @@ var getZone = func(ctx context.Context, st *state.State, machineService MachineS
 		return "", errors.Trace(err)
 	}
 	if hc.AvailabilityZone == nil {
-		return "", errors.Trace(err)
+		return "", nil
 	}
 	return *hc.AvailabilityZone, errors.Trace(err)
 }

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -514,7 +514,7 @@ func (s *uniterSuite) TestNetworkInfoSpaceless(c *gc.C) {
 }
 
 func (s *uniterSuite) TestAvailabilityZone(c *gc.C) {
-	s.PatchValue(uniter.GetZone, func(st *state.State, tag names.Tag) (string, error) {
+	s.PatchValue(uniter.GetZone, func(ctx context.Context, st *state.State, machineService uniter.MachineService, tag names.Tag) (string, error) {
 		return "a_zone", nil
 	})
 

--- a/domain/machine/state/machine_cloud_instance.go
+++ b/domain/machine/state/machine_cloud_instance.go
@@ -32,10 +32,21 @@ func (st *State) HardwareCharacteristics(
 		return nil, errors.Trace(err)
 	}
 	retrieveHardwareCharacteristics := `
-SELECT &instanceData.*
-FROM   machine_cloud_instance
-WHERE  machine_uuid = $instanceData.machine_uuid`
-	machineUUIDQuery := instanceData{
+SELECT    (machine_cloud_instance.machine_uuid,
+           machine_cloud_instance.instance_id,
+           machine_cloud_instance.arch,
+           machine_cloud_instance.mem,
+           machine_cloud_instance.root_disk,
+           machine_cloud_instance.root_disk_source,
+           machine_cloud_instance.cpu_cores,
+           machine_cloud_instance.cpu_power,
+           machine_cloud_instance.virt_type) AS (&instanceDataResult.*),
+           availability_zone.name AS &instanceDataResult.availability_zone
+FROM      machine_cloud_instance
+LEFT JOIN availability_zone
+ON        machine_cloud_instance.availability_zone_uuid = availability_zone.uuid
+WHERE     machine_uuid = $instanceDataResult.machine_uuid`
+	machineUUIDQuery := instanceDataResult{
 		MachineUUID: machineUUID,
 	}
 	retrieveHardwareCharacteristicsStmt, err := st.Prepare(retrieveHardwareCharacteristics, machineUUIDQuery)
@@ -43,7 +54,7 @@ WHERE  machine_uuid = $instanceData.machine_uuid`
 		return nil, errors.Annotate(err, "preparing retrieve hardware characteristics statement")
 	}
 
-	var row instanceData
+	var row instanceDataResult
 	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		return errors.Trace(tx.Query(ctx, retrieveHardwareCharacteristicsStmt, machineUUIDQuery).Get(&row))
 	}); err != nil {
@@ -114,7 +125,7 @@ WHERE  availability_zone.name = $availabilityZoneName.name
 			instanceData.CPUCores = hardwareCharacteristics.CpuCores
 			instanceData.CPUPower = hardwareCharacteristics.CpuPower
 			instanceData.VirtType = hardwareCharacteristics.VirtType
-			if hardwareCharacteristics.AvailabilityZone != nil {
+			if hardwareCharacteristics.AvailabilityZone != nil && *hardwareCharacteristics.AvailabilityZone != "" {
 				azUUID := availabilityZoneName{}
 				if err := tx.Query(ctx, retrieveAZUUIDStmt, azName).Get(&azUUID); err != nil {
 					if errors.Is(err, sql.ErrNoRows) {

--- a/domain/machine/state/machine_cloud_instance.go
+++ b/domain/machine/state/machine_cloud_instance.go
@@ -32,20 +32,9 @@ func (st *State) HardwareCharacteristics(
 		return nil, errors.Trace(err)
 	}
 	retrieveHardwareCharacteristics := `
-SELECT    (machine_cloud_instance.machine_uuid,
-           machine_cloud_instance.instance_id,
-           machine_cloud_instance.arch,
-           machine_cloud_instance.mem,
-           machine_cloud_instance.root_disk,
-           machine_cloud_instance.root_disk_source,
-           machine_cloud_instance.cpu_cores,
-           machine_cloud_instance.cpu_power,
-           machine_cloud_instance.virt_type) AS (&instanceDataResult.*),
-           availability_zone.name AS &instanceDataResult.availability_zone
-FROM      machine_cloud_instance
-LEFT JOIN availability_zone
-ON        machine_cloud_instance.availability_zone_uuid = availability_zone.uuid
-WHERE     machine_uuid = $instanceDataResult.machine_uuid`
+SELECT    &instanceDataResult.*
+FROM      v_hardware_characteristics AS v
+WHERE     v.machine_uuid = $instanceDataResult.machine_uuid`
 	machineUUIDQuery := instanceDataResult{
 		MachineUUID: machineUUID,
 	}

--- a/domain/machine/state/machine_cloud_instance_test.go
+++ b/domain/machine/state/machine_cloud_instance_test.go
@@ -5,7 +5,9 @@ package state
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/google/uuid"
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -19,6 +21,7 @@ import (
 func (s *stateSuite) TestGetHardwareCharacteristics(c *gc.C) {
 	machineUUID := s.ensureInstance(c, "42")
 
+	fmt.Printf("machineUUID: %s\n", machineUUID)
 	hc, err := s.state.HardwareCharacteristics(context.Background(), machineUUID)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(*hc.Arch, gc.Equals, "arm64")
@@ -399,12 +402,10 @@ func (s *stateSuite) ensureInstance(c *gc.C, mName machine.Name) string {
 	db := s.DB()
 
 	// Create a reference machine.
-	err := s.state.CreateMachine(context.Background(), mName, "", "")
+	uuid, err := uuid.NewV7()
 	c.Assert(err, jc.ErrorIsNil)
-	var machineUUID string
-	row := db.QueryRowContext(context.Background(), "SELECT uuid FROM machine WHERE name='"+string(mName)+"'")
-	c.Assert(row.Err(), jc.ErrorIsNil)
-	err = row.Scan(&machineUUID)
+	machineUUID := uuid.String()
+	err = s.state.CreateMachine(context.Background(), mName, "", machineUUID)
 	c.Assert(err, jc.ErrorIsNil)
 	// Add a reference AZ.
 	_, err = db.ExecContext(context.Background(), "INSERT INTO availability_zone VALUES('deadbeef-0bad-400d-8000-4b1d0d06f00d', 'az-1')")

--- a/domain/machine/state/types.go
+++ b/domain/machine/state/types.go
@@ -38,7 +38,7 @@ type instanceDataResult struct {
 	RootDiskSource   *string `db:"root_disk_source"`
 	CPUCores         *uint64 `db:"cpu_cores"`
 	CPUPower         *uint64 `db:"cpu_power"`
-	AvailabilityZone *string `db:"availability_zone"`
+	AvailabilityZone *string `db:"availability_zone_name"`
 	VirtType         *string `db:"virt_type"`
 }
 

--- a/domain/machine/state/types.go
+++ b/domain/machine/state/types.go
@@ -27,6 +27,21 @@ type instanceData struct {
 	VirtType             *string `db:"virt_type"`
 }
 
+// instanceDataResult represents the struct used to retrieve rows when joining
+// the machine_cloud_instance table with the availability_zone table.
+type instanceDataResult struct {
+	MachineUUID      string  `db:"machine_uuid"`
+	InstanceID       string  `db:"instance_id"`
+	Arch             *string `db:"arch"`
+	Mem              *uint64 `db:"mem"`
+	RootDisk         *uint64 `db:"root_disk"`
+	RootDiskSource   *string `db:"root_disk_source"`
+	CPUCores         *uint64 `db:"cpu_cores"`
+	CPUPower         *uint64 `db:"cpu_power"`
+	AvailabilityZone *string `db:"availability_zone"`
+	VirtType         *string `db:"virt_type"`
+}
+
 // instanceTag represents the struct to be inserted into the instance_tag
 // table.
 type instanceTag struct {
@@ -48,7 +63,7 @@ func tagsFromHardwareCharacteristics(machineUUID string, hc *instance.HardwareCh
 	return res
 }
 
-func (d *instanceData) toHardwareCharacteristics() *instance.HardwareCharacteristics {
+func (d *instanceDataResult) toHardwareCharacteristics() *instance.HardwareCharacteristics {
 	return &instance.HardwareCharacteristics{
 		Arch:             d.Arch,
 		Mem:              d.Mem,
@@ -56,7 +71,7 @@ func (d *instanceData) toHardwareCharacteristics() *instance.HardwareCharacteris
 		RootDiskSource:   d.RootDiskSource,
 		CpuCores:         d.CPUCores,
 		CpuPower:         d.CPUPower,
-		AvailabilityZone: d.AvailabilityZoneUUID,
+		AvailabilityZone: d.AvailabilityZone,
 		VirtType:         d.VirtType,
 	}
 }

--- a/domain/network/state/subnet.go
+++ b/domain/network/state/subnet.go
@@ -23,7 +23,7 @@ import (
 func (st *State) AllSubnetsQuery(ctx context.Context, db database.TxnRunner) ([]string, error) {
 	var subnets []Subnet
 	stmt, err := st.Prepare(`
-SELECT &Subnet.uuid 
+SELECT &Subnet.uuid
 FROM   subnet`, Subnet{})
 	if err != nil {
 		return nil, errors.Annotate(err, "preparing select subnet statement")
@@ -103,7 +103,7 @@ func (st *State) addSubnet(ctx context.Context, tx *sqlair.TX, subnetInfo networ
 	}
 
 	insertSubnetStmt, err := st.Prepare(`
-INSERT INTO subnet (*) 
+INSERT INTO subnet (*)
 VALUES ($Subnet.*)`, subnet)
 	if err != nil {
 		return errors.Trace(err)
@@ -444,8 +444,8 @@ DELETE FROM subnet WHERE uuid = $Subnet.uuid;`, subnet)
 		return errors.Annotate(err, "preparing delete subnet statement")
 	}
 	selectProviderNetworkStmt, err := st.Prepare(`
-SELECT &ProviderNetworkSubnet.provider_network_uuid 
-FROM   provider_network_subnet 
+SELECT &ProviderNetworkSubnet.provider_network_uuid
+FROM   provider_network_subnet
 WHERE  subnet_uuid = $Subnet.uuid;`, subnet, providerNetworkSubnet)
 	if err != nil {
 		return errors.Annotate(err, "preparing select provider network statement")

--- a/domain/schema/model/sql/0016-machine-cloud-instance.sql
+++ b/domain/schema/model/sql/0016-machine-cloud-instance.sql
@@ -17,6 +17,22 @@ CREATE TABLE machine_cloud_instance (
     REFERENCES availability_zone (uuid)
 );
 
+CREATE VIEW v_hardware_characteristics AS
+SELECT
+    m.machine_uuid,
+    m.instance_id,
+    m.arch,
+    m.mem,
+    m.root_disk,
+    m.root_disk_source,
+    m.cpu_cores,
+    m.cpu_power,
+    m.virt_type,
+    az.name AS availability_zone_name,
+    az.uuid AS availability_zone_uuid
+FROM machine_cloud_instance AS m
+LEFT JOIN availability_zone AS az ON m.availability_zone_uuid = az.uuid;
+
 CREATE TABLE instance_tag (
     machine_uuid TEXT NOT NULL,
     tag TEXT NOT NULL,

--- a/domain/schema/schema_test.go
+++ b/domain/schema/schema_test.go
@@ -497,6 +497,7 @@ func (s *schemaSuite) TestModelViews(c *gc.C) {
 		"v_charm_resource",
 		"v_charm_storage",
 		"v_charm_url",
+		"v_hardware_characteristics",
 		"v_secret_permission",
 		"v_space_subnet",
 	)

--- a/state/machine.go
+++ b/state/machine.go
@@ -1261,23 +1261,6 @@ func (m *Machine) SetModificationStatus(sInfo status.StatusInfo) (err error) {
 	})
 }
 
-// AvailabilityZone returns the provider-specific instance availability
-// zone in which the machine was provisioned.
-func (m *Machine) AvailabilityZone() (string, error) {
-	instData, err := getInstanceData(m.st, m.Id())
-	if errors.Is(err, errors.NotFound) {
-		return "", errors.Trace(errors.NotProvisionedf("machine %v", m.Id()))
-	}
-	if err != nil {
-		return "", errors.Trace(err)
-	}
-	var zone string
-	if instData.AvailZone != nil {
-		zone = *instData.AvailZone
-	}
-	return zone, nil
-}
-
 // ApplicationNames returns the names of applications
 // represented by units running on the machine.
 func (m *Machine) ApplicationNames() ([]string, error) {

--- a/state/unit.go
+++ b/state/unit.go
@@ -1350,16 +1350,6 @@ func (u *Unit) scopedAddress(scope string) (network.SpaceAddress, error) {
 	return addr, nil
 }
 
-// AvailabilityZone returns the name of the availability zone into which
-// the unit's machine instance was provisioned.
-func (u *Unit) AvailabilityZone() (string, error) {
-	m, err := u.machine()
-	if err != nil {
-		return "", errors.Trace(err)
-	}
-	return m.AvailabilityZone()
-}
-
 // Refresh refreshes the contents of the Unit from the underlying
 // state. It an error that satisfies errors.IsNotFound if the unit has
 // been removed.


### PR DESCRIPTION
This patch removes the AvailabilityZones methods from state/machine and state/unit. This was only used on the uniter (for the `AvailabilityZones()` method) and was replaced by the call to `HardwareCharacteristics` on the machine domain. 
Also, `HardwareCharacteristics` call was replaced on the provisioner for the `AvailabilityZones()` method.

<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://docs.google.com/document/d/1SYUo9G7qZ_jdoVXpUVamS5VCgHmtZ0QA-wZxKoMS-C0 
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Bootstrap and deploy machine+container should test both work paths:
```
juju bootstrap aws c
juju add-model m
juju deploy ubuntu
juju deploy ubuntu --to lxd
```

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links
**Jira card:** JUJU-6703

