### PR TITLE
refactor(ports): use static UUID/ID types in domain

### DIFF
--- a/domain/port/service/package_mock_test.go
+++ b/domain/port/service/package_mock_test.go
@@ -14,7 +14,9 @@ import (
 	reflect "reflect"
 
 	set "github.com/juju/collections/set"
+	application "github.com/juju/juju/core/application"
 	network "github.com/juju/juju/core/network"
+	unit "github.com/juju/juju/core/unit"
 	domain "github.com/juju/juju/domain"
 	port "github.com/juju/juju/domain/port"
 	gomock "go.uber.org/mock/gomock"
@@ -44,7 +46,7 @@ func (m *MockState) EXPECT() *MockStateMockRecorder {
 }
 
 // FilterEndpointsForApplication mocks base method.
-func (m *MockState) FilterEndpointsForApplication(arg0 context.Context, arg1 string, arg2 []string) (set.Strings, error) {
+func (m *MockState) FilterEndpointsForApplication(arg0 context.Context, arg1 application.ID, arg2 []string) (set.Strings, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FilterEndpointsForApplication", arg0, arg1, arg2)
 	ret0, _ := ret[0].(set.Strings)
@@ -71,19 +73,19 @@ func (c *MockStateFilterEndpointsForApplicationCall) Return(arg0 set.Strings, ar
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateFilterEndpointsForApplicationCall) Do(f func(context.Context, string, []string) (set.Strings, error)) *MockStateFilterEndpointsForApplicationCall {
+func (c *MockStateFilterEndpointsForApplicationCall) Do(f func(context.Context, application.ID, []string) (set.Strings, error)) *MockStateFilterEndpointsForApplicationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateFilterEndpointsForApplicationCall) DoAndReturn(f func(context.Context, string, []string) (set.Strings, error)) *MockStateFilterEndpointsForApplicationCall {
+func (c *MockStateFilterEndpointsForApplicationCall) DoAndReturn(f func(context.Context, application.ID, []string) (set.Strings, error)) *MockStateFilterEndpointsForApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetApplicationOpenedPorts mocks base method.
-func (m *MockState) GetApplicationOpenedPorts(arg0 context.Context, arg1 string) (port.UnitEndpointPortRanges, error) {
+func (m *MockState) GetApplicationOpenedPorts(arg0 context.Context, arg1 application.ID) (port.UnitEndpointPortRanges, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetApplicationOpenedPorts", arg0, arg1)
 	ret0, _ := ret[0].(port.UnitEndpointPortRanges)
@@ -110,19 +112,19 @@ func (c *MockStateGetApplicationOpenedPortsCall) Return(arg0 port.UnitEndpointPo
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetApplicationOpenedPortsCall) Do(f func(context.Context, string) (port.UnitEndpointPortRanges, error)) *MockStateGetApplicationOpenedPortsCall {
+func (c *MockStateGetApplicationOpenedPortsCall) Do(f func(context.Context, application.ID) (port.UnitEndpointPortRanges, error)) *MockStateGetApplicationOpenedPortsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetApplicationOpenedPortsCall) DoAndReturn(f func(context.Context, string) (port.UnitEndpointPortRanges, error)) *MockStateGetApplicationOpenedPortsCall {
+func (c *MockStateGetApplicationOpenedPortsCall) DoAndReturn(f func(context.Context, application.ID) (port.UnitEndpointPortRanges, error)) *MockStateGetApplicationOpenedPortsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetColocatedOpenedPorts mocks base method.
-func (m *MockState) GetColocatedOpenedPorts(arg0 domain.AtomicContext, arg1 string) ([]network.PortRange, error) {
+func (m *MockState) GetColocatedOpenedPorts(arg0 domain.AtomicContext, arg1 unit.UUID) ([]network.PortRange, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetColocatedOpenedPorts", arg0, arg1)
 	ret0, _ := ret[0].([]network.PortRange)
@@ -149,19 +151,19 @@ func (c *MockStateGetColocatedOpenedPortsCall) Return(arg0 []network.PortRange, 
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetColocatedOpenedPortsCall) Do(f func(domain.AtomicContext, string) ([]network.PortRange, error)) *MockStateGetColocatedOpenedPortsCall {
+func (c *MockStateGetColocatedOpenedPortsCall) Do(f func(domain.AtomicContext, unit.UUID) ([]network.PortRange, error)) *MockStateGetColocatedOpenedPortsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetColocatedOpenedPortsCall) DoAndReturn(f func(domain.AtomicContext, string) ([]network.PortRange, error)) *MockStateGetColocatedOpenedPortsCall {
+func (c *MockStateGetColocatedOpenedPortsCall) DoAndReturn(f func(domain.AtomicContext, unit.UUID) ([]network.PortRange, error)) *MockStateGetColocatedOpenedPortsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetEndpointOpenedPorts mocks base method.
-func (m *MockState) GetEndpointOpenedPorts(arg0 domain.AtomicContext, arg1, arg2 string) ([]network.PortRange, error) {
+func (m *MockState) GetEndpointOpenedPorts(arg0 domain.AtomicContext, arg1 unit.UUID, arg2 string) ([]network.PortRange, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetEndpointOpenedPorts", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]network.PortRange)
@@ -188,19 +190,19 @@ func (c *MockStateGetEndpointOpenedPortsCall) Return(arg0 []network.PortRange, a
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetEndpointOpenedPortsCall) Do(f func(domain.AtomicContext, string, string) ([]network.PortRange, error)) *MockStateGetEndpointOpenedPortsCall {
+func (c *MockStateGetEndpointOpenedPortsCall) Do(f func(domain.AtomicContext, unit.UUID, string) ([]network.PortRange, error)) *MockStateGetEndpointOpenedPortsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetEndpointOpenedPortsCall) DoAndReturn(f func(domain.AtomicContext, string, string) ([]network.PortRange, error)) *MockStateGetEndpointOpenedPortsCall {
+func (c *MockStateGetEndpointOpenedPortsCall) DoAndReturn(f func(domain.AtomicContext, unit.UUID, string) ([]network.PortRange, error)) *MockStateGetEndpointOpenedPortsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetEndpoints mocks base method.
-func (m *MockState) GetEndpoints(arg0 domain.AtomicContext, arg1 string) ([]string, error) {
+func (m *MockState) GetEndpoints(arg0 domain.AtomicContext, arg1 unit.UUID) ([]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetEndpoints", arg0, arg1)
 	ret0, _ := ret[0].([]string)
@@ -227,22 +229,22 @@ func (c *MockStateGetEndpointsCall) Return(arg0 []string, arg1 error) *MockState
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetEndpointsCall) Do(f func(domain.AtomicContext, string) ([]string, error)) *MockStateGetEndpointsCall {
+func (c *MockStateGetEndpointsCall) Do(f func(domain.AtomicContext, unit.UUID) ([]string, error)) *MockStateGetEndpointsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetEndpointsCall) DoAndReturn(f func(domain.AtomicContext, string) ([]string, error)) *MockStateGetEndpointsCall {
+func (c *MockStateGetEndpointsCall) DoAndReturn(f func(domain.AtomicContext, unit.UUID) ([]string, error)) *MockStateGetEndpointsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetMachineOpenedPorts mocks base method.
-func (m *MockState) GetMachineOpenedPorts(arg0 context.Context, arg1 string) (map[string]network.GroupedPortRanges, error) {
+func (m *MockState) GetMachineOpenedPorts(arg0 context.Context, arg1 string) (map[unit.UUID]network.GroupedPortRanges, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMachineOpenedPorts", arg0, arg1)
-	ret0, _ := ret[0].(map[string]network.GroupedPortRanges)
+	ret0, _ := ret[0].(map[unit.UUID]network.GroupedPortRanges)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -260,19 +262,19 @@ type MockStateGetMachineOpenedPortsCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockStateGetMachineOpenedPortsCall) Return(arg0 map[string]network.GroupedPortRanges, arg1 error) *MockStateGetMachineOpenedPortsCall {
+func (c *MockStateGetMachineOpenedPortsCall) Return(arg0 map[unit.UUID]network.GroupedPortRanges, arg1 error) *MockStateGetMachineOpenedPortsCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetMachineOpenedPortsCall) Do(f func(context.Context, string) (map[string]network.GroupedPortRanges, error)) *MockStateGetMachineOpenedPortsCall {
+func (c *MockStateGetMachineOpenedPortsCall) Do(f func(context.Context, string) (map[unit.UUID]network.GroupedPortRanges, error)) *MockStateGetMachineOpenedPortsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetMachineOpenedPortsCall) DoAndReturn(f func(context.Context, string) (map[string]network.GroupedPortRanges, error)) *MockStateGetMachineOpenedPortsCall {
+func (c *MockStateGetMachineOpenedPortsCall) DoAndReturn(f func(context.Context, string) (map[unit.UUID]network.GroupedPortRanges, error)) *MockStateGetMachineOpenedPortsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -317,7 +319,7 @@ func (c *MockStateGetMachinesForEndpointsCall) DoAndReturn(f func(context.Contex
 }
 
 // GetUnitOpenedPorts mocks base method.
-func (m *MockState) GetUnitOpenedPorts(arg0 context.Context, arg1 string) (network.GroupedPortRanges, error) {
+func (m *MockState) GetUnitOpenedPorts(arg0 context.Context, arg1 unit.UUID) (network.GroupedPortRanges, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetUnitOpenedPorts", arg0, arg1)
 	ret0, _ := ret[0].(network.GroupedPortRanges)
@@ -344,13 +346,13 @@ func (c *MockStateGetUnitOpenedPortsCall) Return(arg0 network.GroupedPortRanges,
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetUnitOpenedPortsCall) Do(f func(context.Context, string) (network.GroupedPortRanges, error)) *MockStateGetUnitOpenedPortsCall {
+func (c *MockStateGetUnitOpenedPortsCall) Do(f func(context.Context, unit.UUID) (network.GroupedPortRanges, error)) *MockStateGetUnitOpenedPortsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetUnitOpenedPortsCall) DoAndReturn(f func(context.Context, string) (network.GroupedPortRanges, error)) *MockStateGetUnitOpenedPortsCall {
+func (c *MockStateGetUnitOpenedPortsCall) DoAndReturn(f func(context.Context, unit.UUID) (network.GroupedPortRanges, error)) *MockStateGetUnitOpenedPortsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -432,7 +434,7 @@ func (c *MockStateRunAtomicCall) DoAndReturn(f func(context.Context, func(domain
 }
 
 // UpdateUnitPorts mocks base method.
-func (m *MockState) UpdateUnitPorts(arg0 domain.AtomicContext, arg1 string, arg2, arg3 network.GroupedPortRanges) error {
+func (m *MockState) UpdateUnitPorts(arg0 domain.AtomicContext, arg1 unit.UUID, arg2, arg3 network.GroupedPortRanges) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateUnitPorts", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
@@ -458,13 +460,13 @@ func (c *MockStateUpdateUnitPortsCall) Return(arg0 error) *MockStateUpdateUnitPo
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateUpdateUnitPortsCall) Do(f func(domain.AtomicContext, string, network.GroupedPortRanges, network.GroupedPortRanges) error) *MockStateUpdateUnitPortsCall {
+func (c *MockStateUpdateUnitPortsCall) Do(f func(domain.AtomicContext, unit.UUID, network.GroupedPortRanges, network.GroupedPortRanges) error) *MockStateUpdateUnitPortsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateUpdateUnitPortsCall) DoAndReturn(f func(domain.AtomicContext, string, network.GroupedPortRanges, network.GroupedPortRanges) error) *MockStateUpdateUnitPortsCall {
+func (c *MockStateUpdateUnitPortsCall) DoAndReturn(f func(domain.AtomicContext, unit.UUID, network.GroupedPortRanges, network.GroupedPortRanges) error) *MockStateUpdateUnitPortsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/port/service/service_test.go
+++ b/domain/port/service/service_test.go
@@ -10,7 +10,9 @@ import (
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
+	coreapplication "github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/network"
+	coreunit "github.com/juju/juju/core/unit"
 	domain "github.com/juju/juju/domain"
 	"github.com/juju/juju/domain/port"
 	domaintesting "github.com/juju/juju/domain/testing"
@@ -24,9 +26,9 @@ type serviceSuite struct {
 var _ = gc.Suite(&serviceSuite{})
 
 const (
-	unitUUID    = "unit-uuid"
-	machineUUID = "machine-uuid"
-	appUUID     = "app-uuid"
+	unitUUID    coreunit.UUID      = "unit-uuid"
+	machineUUID string             = "machine-uuid"
+	appUUID     coreapplication.ID = "app-uuid"
 )
 
 func (s *serviceSuite) setupMocks(c *gc.C) *gomock.Controller {
@@ -65,7 +67,7 @@ func (s *serviceSuite) TestGetUnitOpenedPorts(c *gc.C) {
 func (s *serviceSuite) TestGetMachineOpenedPorts(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	grp := map[string]network.GroupedPortRanges{
+	grp := map[coreunit.UUID]network.GroupedPortRanges{
 		"unit-uuid-1": {
 			"ep1": {
 				network.MustParsePortRange("80/tcp"),
@@ -99,7 +101,7 @@ func (s *serviceSuite) TestGetApplicationOpenedPorts(c *gc.C) {
 		{Endpoint: "ep3", UnitUUID: "unit-uuid-2", PortRange: network.MustParsePortRange("8080/tcp")},
 	}
 
-	expected := map[string]network.GroupedPortRanges{
+	expected := map[coreunit.UUID]network.GroupedPortRanges{
 		"unit-uuid-1": {
 			"ep1": {
 				network.MustParsePortRange("80/tcp"),

--- a/domain/port/service/watcher.go
+++ b/domain/port/service/watcher.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/collections/set"
 	"github.com/juju/collections/transform"
 
+	coreapplication "github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/changestream"
 	"github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/watcher"
@@ -64,7 +65,7 @@ type WatcherState interface {
 
 	// FilterEndpointsForApplication returns the subset of provided endpoint uuids
 	// that are associated with the provided application.
-	FilterEndpointsForApplication(ctx context.Context, app string, eps []string) (set.Strings, error)
+	FilterEndpointsForApplication(ctx context.Context, app coreapplication.ID, eps []string) (set.Strings, error)
 }
 
 // WatchOpenedPorts returns a strings watcher for opened ports. This watcher
@@ -82,7 +83,7 @@ func (s *WatchableService) WatchOpenedPorts(ctx context.Context) (watcher.String
 // WatchOpenedPortsForApplication returns a notify watcher for opened ports. This
 // watcher emits events for changes to the opened ports table that are associated
 // with the given application
-func (s *WatchableService) WatchOpenedPortsForApplication(ctx context.Context, applicationUUID string) (watcher.NotifyWatcher, error) {
+func (s *WatchableService) WatchOpenedPortsForApplication(ctx context.Context, applicationUUID coreapplication.ID) (watcher.NotifyWatcher, error) {
 	return s.watcherFactory.NewNamespaceNotifyMapperWatcher(
 		s.st.WatchOpenedPortsTable(),
 		changestream.Create|changestream.Delete,
@@ -122,7 +123,7 @@ func (s *WatchableService) endpointToMachineMapper(
 // filterForApplication returns an eventsource.Mapper that filters events emitted
 // by port range changes to only include events for port range changes corresponding
 // to the given application
-func (s *WatchableService) filterForApplication(applicationUUID string) eventsource.Mapper {
+func (s *WatchableService) filterForApplication(applicationUUID coreapplication.ID) eventsource.Mapper {
 	return func(
 		ctx context.Context, db database.TxnRunner, events []changestream.ChangeEvent,
 	) ([]changestream.ChangeEvent, error) {

--- a/domain/port/state/state_test.go
+++ b/domain/port/state/state_test.go
@@ -11,7 +11,9 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	coreapplication "github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/network"
+	coreunit "github.com/juju/juju/core/unit"
 	"github.com/juju/juju/domain"
 	"github.com/juju/juju/domain/application"
 	"github.com/juju/juju/domain/application/charm"
@@ -32,9 +34,9 @@ type baseSuite struct {
 type stateSuite struct {
 	baseSuite
 
-	unitUUID string
+	unitUUID coreunit.UUID
 
-	appUUID string
+	appUUID coreapplication.ID
 }
 
 var _ = gc.Suite(&stateSuite{})
@@ -57,7 +59,7 @@ func (s *stateSuite) SetUpTest(c *gc.C) {
 
 // createUnit creates a new unit in state and returns its UUID. The unit is assigned
 // to the net node with uuid `netNodeUUID`.
-func (s *baseSuite) createUnit(c *gc.C, netNodeUUID, appName string) (string, string) {
+func (s *baseSuite) createUnit(c *gc.C, netNodeUUID, appName string) (coreunit.UUID, coreapplication.ID) {
 	applicationSt := applicationstate.NewApplicationState(s.TxnRunnerFactory(), logger.GetLogger("juju.test.application"))
 	_, err := applicationSt.CreateApplication(context.Background(), appName, application.AddApplicationArg{
 		Charm: charm.Charm{
@@ -74,8 +76,8 @@ func (s *baseSuite) createUnit(c *gc.C, netNodeUUID, appName string) (string, st
 	s.unitCount++
 
 	var (
-		unitUUID string
-		appUUID  string
+		unitUUID coreunit.UUID
+		appUUID  coreapplication.ID
 	)
 	err = s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		err := tx.QueryRowContext(ctx, "SELECT uuid FROM unit WHERE name = ?", unitName).Scan(&unitUUID)

--- a/domain/port/state/types.go
+++ b/domain/port/state/types.go
@@ -5,6 +5,7 @@ package state
 
 import (
 	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/core/unit"
 	"github.com/juju/juju/domain/port"
 )
 
@@ -77,7 +78,7 @@ type unitEndpointPortRange struct {
 
 func (p unitEndpointPortRange) decodeToUnitEndpointPortRange() port.UnitEndpointPortRange {
 	return port.UnitEndpointPortRange{
-		UnitUUID:  p.UnitUUID,
+		UnitUUID:  unit.UUID(p.UnitUUID),
 		Endpoint:  p.Endpoint,
 		PortRange: p.decodeToPortRange(),
 	}

--- a/domain/port/state/watcher.go
+++ b/domain/port/state/watcher.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/collections/transform"
 	jujuerrors "github.com/juju/errors"
 
+	coreapplication "github.com/juju/juju/core/application"
 	"github.com/juju/juju/internal/errors"
 )
 
@@ -62,13 +63,13 @@ WHERE unit_endpoint.uuid IN ($endpoints[:])
 
 // FilterEndpointsForApplication returns the subset of provided endpoint uuids
 // that are associated with the provided application.
-func (st *State) FilterEndpointsForApplication(ctx context.Context, app string, eps []string) (set.Strings, error) {
+func (st *State) FilterEndpointsForApplication(ctx context.Context, app coreapplication.ID, eps []string) (set.Strings, error) {
 	db, err := st.DB()
 	if err != nil {
 		return nil, jujuerrors.Trace(err)
 	}
 
-	applicationUUID := applicationUUID{UUID: app}
+	applicationUUID := applicationUUID{UUID: app.String()}
 	endpointUUIDs := endpoints(eps)
 
 	query, err := st.Prepare(`

--- a/domain/port/state/watcher_test.go
+++ b/domain/port/state/watcher_test.go
@@ -11,7 +11,9 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	coreapplication "github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/network"
+	coreunit "github.com/juju/juju/core/unit"
 	"github.com/juju/juju/domain"
 	machinestate "github.com/juju/juju/domain/machine/state"
 	"github.com/juju/juju/internal/logger"
@@ -20,9 +22,9 @@ import (
 type watcherSuite struct {
 	baseSuite
 
-	unitUUIDs [3]string
+	unitUUIDs [3]coreunit.UUID
 
-	appUUIDs [2]string
+	appUUIDs [2]coreapplication.ID
 }
 
 var _ = gc.Suite(&watcherSuite{})

--- a/domain/port/types.go
+++ b/domain/port/types.go
@@ -7,12 +7,13 @@ import (
 	"sort"
 
 	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/core/unit"
 )
 
 // UnitPortRange represents a range of ports for a given protocol for a
 // given unit.
 type UnitEndpointPortRange struct {
-	UnitUUID  string
+	UnitUUID  unit.UUID
 	Endpoint  string
 	PortRange network.PortRange
 }
@@ -35,8 +36,8 @@ func SortUnitEndpointPortRanges(portRanges UnitEndpointPortRanges) {
 
 type UnitEndpointPortRanges []UnitEndpointPortRange
 
-func (prs UnitEndpointPortRanges) ByUnitByEndpoint() map[string]network.GroupedPortRanges {
-	byUnitByEndpoint := make(map[string]network.GroupedPortRanges)
+func (prs UnitEndpointPortRanges) ByUnitByEndpoint() map[unit.UUID]network.GroupedPortRanges {
+	byUnitByEndpoint := make(map[unit.UUID]network.GroupedPortRanges)
 	for _, unitEnpointPortRange := range prs {
 		unitUUID := unitEnpointPortRange.UnitUUID
 		endpoint := unitEnpointPortRange.Endpoint

--- a/domain/port/watcher_test.go
+++ b/domain/port/watcher_test.go
@@ -11,9 +11,11 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	coreapplication "github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/changestream"
 	"github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/network"
+	coreunit "github.com/juju/juju/core/unit"
 	"github.com/juju/juju/core/watcher/watchertest"
 	"github.com/juju/juju/domain"
 	"github.com/juju/juju/domain/application"
@@ -36,9 +38,9 @@ type watcherSuite struct {
 
 	unitCount int
 
-	unitUUIDs [3]string
+	unitUUIDs [3]coreunit.UUID
 
-	appUUIDs [2]string
+	appUUIDs [2]coreapplication.ID
 }
 
 var _ = gc.Suite(&watcherSuite{})
@@ -82,7 +84,7 @@ func (s *watcherSuite) SetUpTest(c *gc.C) {
 
 // createUnit creates a new unit in state and returns its UUID. The unit is assigned
 // to the net node with uuid `netNodeUUID`.
-func (s *watcherSuite) createUnit(c *gc.C, netNodeUUID, appName string) (string, string) {
+func (s *watcherSuite) createUnit(c *gc.C, netNodeUUID, appName string) (coreunit.UUID, coreapplication.ID) {
 	applicationSt := applicationstate.NewApplicationState(s.TxnRunnerFactory(), logger.GetLogger("juju.test.application"))
 	_, err := applicationSt.CreateApplication(context.Background(), appName, application.AddApplicationArg{
 		Charm: charm.Charm{
@@ -99,8 +101,8 @@ func (s *watcherSuite) createUnit(c *gc.C, netNodeUUID, appName string) (string,
 	s.unitCount++
 
 	var (
-		unitUUID string
-		appUUID  string
+		unitUUID coreunit.UUID
+		appUUID  coreapplication.ID
 	)
 	err = s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		err := tx.QueryRowContext(ctx, "SELECT uuid FROM unit WHERE name = ?", unitName).Scan(&unitUUID)


### PR DESCRIPTION
We have been transitioning to using static UUID/ID types from core to represent resource IDs for lookup.

Make use of these in the ports domain.

This increases readability of our domain

As a flyby, remove some duplicated code

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

unit tests pass