### PR TITLE
feat(instancedata): cleanup charmprofiles and watch instance data

### DIFF
--- a/apiserver/facades/agent/instancemutater/instancemutater.go
+++ b/apiserver/facades/agent/instancemutater/instancemutater.go
@@ -40,15 +40,15 @@ type MachineService interface {
 	GetMachineUUID(ctx context.Context, name coremachine.Name) (string, error)
 
 	// InstanceID returns the cloud specific instance id for this machine.
-	InstanceID(ctx context.Context, mUUID string) (string, error)
+	InstanceID(ctx context.Context, machineUUID string) (string, error)
 
 	// AppliedLXDProfileNames returns the names of the LXD profiles on the machine.
-	AppliedLXDProfileNames(ctx context.Context, mUUID string) ([]string, error)
+	AppliedLXDProfileNames(ctx context.Context, machineUUID string) ([]string, error)
 
 	// SetAppliedLXDProfileNames sets the list of LXD profile names to the
 	// lxd_profile table for the given machine. This method will overwrite the list
 	// of profiles for the given machine without any checks.
-	SetAppliedLXDProfileNames(ctx context.Context, mUUID string, profileNames []string) error
+	SetAppliedLXDProfileNames(ctx context.Context, machineUUID string, profileNames []string) error
 
 	// WatchLXDProfiles returns a NotifyWatcher that is subscribed to the changes in
 	// the machine_cloud_instance table in the model, for the given machine UUID.

--- a/apiserver/facades/agent/instancemutater/instancemutater_test.go
+++ b/apiserver/facades/agent/instancemutater/instancemutater_test.go
@@ -466,8 +466,6 @@ func (s *InstanceMutaterAPISetCharmProfilesSuite) TestSetCharmProfiles(c *gc.C) 
 
 	s.expectAuthMachineAgent()
 	s.expectLife(s.machineTag)
-	s.expectMachine(s.machineTag, s.machine)
-	s.expectSetProfiles(profiles, nil)
 	facade := s.facadeAPIForScenario(c)
 
 	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("0")).Return("uuid0", nil)
@@ -493,8 +491,6 @@ func (s *InstanceMutaterAPISetCharmProfilesSuite) TestSetCharmProfilesWithError(
 
 	s.expectAuthMachineAgent()
 	s.expectLife(s.machineTag)
-	s.expectMachine(s.machineTag, s.machine)
-	s.expectSetProfiles(profiles, nil)
 	facade := s.facadeAPIForScenario(c)
 
 	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("0")).Return("uuid0", nil).Times(2)
@@ -523,10 +519,6 @@ func (s *InstanceMutaterAPISetCharmProfilesSuite) TestSetCharmProfilesWithError(
 			},
 		},
 	})
-}
-
-func (s *InstanceMutaterAPISetCharmProfilesSuite) expectSetProfiles(profiles []string, err error) {
-	s.machine.EXPECT().SetCharmProfiles(profiles).Return(err)
 }
 
 type InstanceMutaterAPISetModificationStatusSuite struct {

--- a/apiserver/facades/agent/instancemutater/instancemutater_test.go
+++ b/apiserver/facades/agent/instancemutater/instancemutater_test.go
@@ -376,7 +376,7 @@ func (s *InstanceMutaterAPICharmProfilingInfoSuite) TestCharmProfilingInfoWithMa
 
 	results, err := facade.CharmProfilingInfo(context.Background(), params.Entity{Tag: "machine-0"})
 	c.Assert(err, gc.IsNil)
-	c.Assert(results.Error, gc.ErrorMatches, "machine-0: attempting to get instanceId: machine not provisioned")
+	c.Assert(results.Error, gc.ErrorMatches, ".* not provisioned")
 	c.Assert(results.InstanceId, gc.Equals, instance.Id(""))
 	c.Assert(results.ModelName, gc.Equals, "")
 	c.Assert(results.ProfileChanges, gc.HasLen, 0)

--- a/apiserver/facades/agent/instancemutater/interface.go
+++ b/apiserver/facades/agent/instancemutater/interface.go
@@ -35,11 +35,9 @@ type Machine interface {
 	Id() string
 	ContainerType() instance.ContainerType
 	IsManual() (bool, error)
-	SetCharmProfiles([]string) error
 	SetModificationStatus(status.StatusInfo) error
 	Units() ([]Unit, error)
 	WatchContainers(instance.ContainerType) state.StringsWatcher
-	WatchInstanceData() state.NotifyWatcher
 }
 
 // Unit represents a point of use methods from the state Unit object.

--- a/apiserver/facades/agent/instancemutater/lxdprofilewatcher.go
+++ b/apiserver/facades/agent/instancemutater/lxdprofilewatcher.go
@@ -152,7 +152,14 @@ func (w *machineLXDProfileWatcher) loop() error {
 	if err := w.catacomb.Add(unitWatcher); err != nil {
 		return errors.Trace(err)
 	}
-	instanceWatcher := w.machine.WatchInstanceData()
+	machineUUID, err := w.machineService.GetMachineUUID(context.TODO(), coremachine.Name(w.machine.Id()))
+	if err != nil {
+		return errors.Trace(err)
+	}
+	instanceWatcher, err := w.machineService.WatchLXDProfiles(context.TODO(), machineUUID)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	if err := w.catacomb.Add(instanceWatcher); err != nil {
 		return errors.Trace(err)
 	}

--- a/apiserver/facades/agent/instancemutater/lxdprofilewatcher_test.go
+++ b/apiserver/facades/agent/instancemutater/lxdprofilewatcher_test.go
@@ -399,7 +399,9 @@ func (s *lxdProfileWatcherSuite) setupWatchers(c *gc.C) {
 	s.state.EXPECT().WatchCharms().Return(s.charmsWatcher)
 	s.state.EXPECT().WatchApplicationCharms().Return(s.appWatcher)
 	s.state.EXPECT().WatchUnits().Return(s.unitsWatcher)
-	s.machine0.EXPECT().WatchInstanceData().Return(s.instanceWatcher)
+
+	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name("0")).Return("uuid0", nil)
+	s.machineService.EXPECT().WatchLXDProfiles(gomock.Any(), "uuid0").Return(s.instanceWatcher, nil)
 
 	s.charmsWatcher.EXPECT().Changes().AnyTimes().Return(s.charmChanges)
 	s.charmsWatcher.EXPECT().Wait().Return(nil)

--- a/apiserver/facades/agent/instancemutater/mocks/instancemutater_mock.go
+++ b/apiserver/facades/agent/instancemutater/mocks/instancemutater_mock.go
@@ -20,6 +20,7 @@ import (
 	lxdprofile "github.com/juju/juju/core/lxdprofile"
 	machine "github.com/juju/juju/core/machine"
 	status "github.com/juju/juju/core/status"
+	watcher "github.com/juju/juju/core/watcher"
 	state "github.com/juju/juju/state"
 	names "github.com/juju/names/v5"
 	gomock "go.uber.org/mock/gomock"
@@ -711,44 +712,6 @@ func (c *MockMachineIsManualCall) DoAndReturn(f func() (bool, error)) *MockMachi
 	return c
 }
 
-// SetCharmProfiles mocks base method.
-func (m *MockMachine) SetCharmProfiles(arg0 []string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetCharmProfiles", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// SetCharmProfiles indicates an expected call of SetCharmProfiles.
-func (mr *MockMachineMockRecorder) SetCharmProfiles(arg0 any) *MockMachineSetCharmProfilesCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCharmProfiles", reflect.TypeOf((*MockMachine)(nil).SetCharmProfiles), arg0)
-	return &MockMachineSetCharmProfilesCall{Call: call}
-}
-
-// MockMachineSetCharmProfilesCall wrap *gomock.Call
-type MockMachineSetCharmProfilesCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockMachineSetCharmProfilesCall) Return(arg0 error) *MockMachineSetCharmProfilesCall {
-	c.Call = c.Call.Return(arg0)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockMachineSetCharmProfilesCall) Do(f func([]string) error) *MockMachineSetCharmProfilesCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineSetCharmProfilesCall) DoAndReturn(f func([]string) error) *MockMachineSetCharmProfilesCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // SetModificationStatus mocks base method.
 func (m *MockMachine) SetModificationStatus(arg0 status.StatusInfo) error {
 	m.ctrl.T.Helper()
@@ -860,44 +823,6 @@ func (c *MockMachineWatchContainersCall) Do(f func(instance.ContainerType) state
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockMachineWatchContainersCall) DoAndReturn(f func(instance.ContainerType) state.StringsWatcher) *MockMachineWatchContainersCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// WatchInstanceData mocks base method.
-func (m *MockMachine) WatchInstanceData() state.NotifyWatcher {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchInstanceData")
-	ret0, _ := ret[0].(state.NotifyWatcher)
-	return ret0
-}
-
-// WatchInstanceData indicates an expected call of WatchInstanceData.
-func (mr *MockMachineMockRecorder) WatchInstanceData() *MockMachineWatchInstanceDataCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchInstanceData", reflect.TypeOf((*MockMachine)(nil).WatchInstanceData))
-	return &MockMachineWatchInstanceDataCall{Call: call}
-}
-
-// MockMachineWatchInstanceDataCall wrap *gomock.Call
-type MockMachineWatchInstanceDataCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockMachineWatchInstanceDataCall) Return(arg0 state.NotifyWatcher) *MockMachineWatchInstanceDataCall {
-	c.Call = c.Call.Return(arg0)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockMachineWatchInstanceDataCall) Do(f func() state.NotifyWatcher) *MockMachineWatchInstanceDataCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockMachineWatchInstanceDataCall) DoAndReturn(f func() state.NotifyWatcher) *MockMachineWatchInstanceDataCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1528,6 +1453,45 @@ func (c *MockMachineServiceSetAppliedLXDProfileNamesCall) Do(f func(context.Cont
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockMachineServiceSetAppliedLXDProfileNamesCall) DoAndReturn(f func(context.Context, string, []string) error) *MockMachineServiceSetAppliedLXDProfileNamesCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// WatchLXDProfiles mocks base method.
+func (m *MockMachineService) WatchLXDProfiles(arg0 context.Context, arg1 string) (watcher.Watcher[struct{}], error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WatchLXDProfiles", arg0, arg1)
+	ret0, _ := ret[0].(watcher.Watcher[struct{}])
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WatchLXDProfiles indicates an expected call of WatchLXDProfiles.
+func (mr *MockMachineServiceMockRecorder) WatchLXDProfiles(arg0, arg1 any) *MockMachineServiceWatchLXDProfilesCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchLXDProfiles", reflect.TypeOf((*MockMachineService)(nil).WatchLXDProfiles), arg0, arg1)
+	return &MockMachineServiceWatchLXDProfilesCall{Call: call}
+}
+
+// MockMachineServiceWatchLXDProfilesCall wrap *gomock.Call
+type MockMachineServiceWatchLXDProfilesCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockMachineServiceWatchLXDProfilesCall) Return(arg0 watcher.Watcher[struct{}], arg1 error) *MockMachineServiceWatchLXDProfilesCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockMachineServiceWatchLXDProfilesCall) Do(f func(context.Context, string) (watcher.Watcher[struct{}], error)) *MockMachineServiceWatchLXDProfilesCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockMachineServiceWatchLXDProfilesCall) DoAndReturn(f func(context.Context, string) (watcher.Watcher[struct{}], error)) *MockMachineServiceWatchLXDProfilesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/agent/provisioner/provisioner.go
+++ b/apiserver/facades/agent/provisioner/provisioner.go
@@ -1470,18 +1470,14 @@ func (api *ProvisionerAPI) setOneMachineCharmProfiles(ctx context.Context, machi
 	if err != nil {
 		return errors.Trace(err)
 	}
+	if !canAccess(mTag) {
+		return apiservererrors.ErrPerm
+	}
 	machineUUID, err := api.machineService.GetMachineUUID(ctx, coremachine.Name(mTag.Id()))
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if err := api.machineService.SetAppliedLXDProfileNames(ctx, machineUUID, profiles); err != nil {
-		return errors.Trace(err)
-	}
-	machine, err := api.getMachine(canAccess, mTag)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	return machine.SetCharmProfiles(profiles)
+	return errors.Trace(api.machineService.SetAppliedLXDProfileNames(ctx, machineUUID, profiles))
 }
 
 // ModelUUID returns the model UUID that the current connection is for.

--- a/apiserver/facades/agent/uniter/newlxdprofile.go
+++ b/apiserver/facades/agent/uniter/newlxdprofile.go
@@ -31,10 +31,8 @@ type LXDProfileBackendV2 interface {
 // LXDProfileMachineV2 describes machine-receiver state methods
 // for executing a lxd profile upgrade.
 type LXDProfileMachineV2 interface {
-	CharmProfiles() ([]string, error)
 	ContainerType() instance.ContainerType
 	IsManual() (bool, error)
-	WatchInstanceData() state.NotifyWatcher
 }
 
 // LXDProfileUnitV2 describes unit-receiver state methods

--- a/apiserver/facades/agent/uniter/newlxdprofile.go
+++ b/apiserver/facades/agent/uniter/newlxdprofile.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/juju/core/lxdprofile"
 	coremachine "github.com/juju/juju/core/machine"
 	"github.com/juju/juju/core/model"
+	machineerrors "github.com/juju/juju/domain/machine/errors"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
 )
@@ -245,7 +246,9 @@ func (u *LXDProfileAPIv2) LXDProfileName(ctx context.Context, args params.Entiti
 			continue
 		}
 		name, err := u.getOneLXDProfileName(ctx, unit, machineUUID)
-		if err != nil {
+		if errors.Is(err, machineerrors.NotProvisioned) {
+			result.Results[i].Error = apiservererrors.ServerError(errors.NotProvisionedf("machine %q", machineTagID))
+		} else if err != nil {
 			result.Results[i].Error = apiservererrors.ServerError(err)
 			continue
 		}

--- a/apiserver/facades/agent/uniter/package_mocks_test.go
+++ b/apiserver/facades/agent/uniter/package_mocks_test.go
@@ -523,45 +523,6 @@ func (m *MockLXDProfileMachineV2) EXPECT() *MockLXDProfileMachineV2MockRecorder 
 	return m.recorder
 }
 
-// CharmProfiles mocks base method.
-func (m *MockLXDProfileMachineV2) CharmProfiles() ([]string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CharmProfiles")
-	ret0, _ := ret[0].([]string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CharmProfiles indicates an expected call of CharmProfiles.
-func (mr *MockLXDProfileMachineV2MockRecorder) CharmProfiles() *MockLXDProfileMachineV2CharmProfilesCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CharmProfiles", reflect.TypeOf((*MockLXDProfileMachineV2)(nil).CharmProfiles))
-	return &MockLXDProfileMachineV2CharmProfilesCall{Call: call}
-}
-
-// MockLXDProfileMachineV2CharmProfilesCall wrap *gomock.Call
-type MockLXDProfileMachineV2CharmProfilesCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockLXDProfileMachineV2CharmProfilesCall) Return(arg0 []string, arg1 error) *MockLXDProfileMachineV2CharmProfilesCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockLXDProfileMachineV2CharmProfilesCall) Do(f func() ([]string, error)) *MockLXDProfileMachineV2CharmProfilesCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockLXDProfileMachineV2CharmProfilesCall) DoAndReturn(f func() ([]string, error)) *MockLXDProfileMachineV2CharmProfilesCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // ContainerType mocks base method.
 func (m *MockLXDProfileMachineV2) ContainerType() instance.ContainerType {
 	m.ctrl.T.Helper()
@@ -635,44 +596,6 @@ func (c *MockLXDProfileMachineV2IsManualCall) Do(f func() (bool, error)) *MockLX
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockLXDProfileMachineV2IsManualCall) DoAndReturn(f func() (bool, error)) *MockLXDProfileMachineV2IsManualCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// WatchInstanceData mocks base method.
-func (m *MockLXDProfileMachineV2) WatchInstanceData() state.NotifyWatcher {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WatchInstanceData")
-	ret0, _ := ret[0].(state.NotifyWatcher)
-	return ret0
-}
-
-// WatchInstanceData indicates an expected call of WatchInstanceData.
-func (mr *MockLXDProfileMachineV2MockRecorder) WatchInstanceData() *MockLXDProfileMachineV2WatchInstanceDataCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchInstanceData", reflect.TypeOf((*MockLXDProfileMachineV2)(nil).WatchInstanceData))
-	return &MockLXDProfileMachineV2WatchInstanceDataCall{Call: call}
-}
-
-// MockLXDProfileMachineV2WatchInstanceDataCall wrap *gomock.Call
-type MockLXDProfileMachineV2WatchInstanceDataCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockLXDProfileMachineV2WatchInstanceDataCall) Return(arg0 state.NotifyWatcher) *MockLXDProfileMachineV2WatchInstanceDataCall {
-	c.Call = c.Call.Return(arg0)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockLXDProfileMachineV2WatchInstanceDataCall) Do(f func() state.NotifyWatcher) *MockLXDProfileMachineV2WatchInstanceDataCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockLXDProfileMachineV2WatchInstanceDataCall) DoAndReturn(f func() state.NotifyWatcher) *MockLXDProfileMachineV2WatchInstanceDataCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/client/client/service.go
+++ b/apiserver/facades/client/client/service.go
@@ -46,4 +46,6 @@ type MachineService interface {
 	// HardwareCharacteristics returns the hardware characteristics of the
 	// specified machine.
 	HardwareCharacteristics(ctx context.Context, machineUUID string) (*instance.HardwareCharacteristics, error)
+	// LXDProfiles returns the names of the LXD profiles on the machine.
+	AppliedLXDProfileNames(ctx context.Context, mUUID string) ([]string, error)
 }

--- a/apiserver/facades/client/client/service.go
+++ b/apiserver/facades/client/client/service.go
@@ -39,13 +39,13 @@ type MachineService interface {
 	// GetMachineUUID returns the UUID of a machine identified by its name.
 	GetMachineUUID(ctx context.Context, name machine.Name) (string, error)
 	// InstanceID returns the cloud specific instance id for this machine.
-	InstanceID(ctx context.Context, mUUID string) (string, error)
+	InstanceID(ctx context.Context, machineUUID string) (string, error)
 	// InstanceIDAndName returns the cloud specific instance ID and display name for
 	// this machine.
 	InstanceIDAndName(ctx context.Context, machineUUID string) (string, string, error)
 	// HardwareCharacteristics returns the hardware characteristics of the
 	// specified machine.
 	HardwareCharacteristics(ctx context.Context, machineUUID string) (*instance.HardwareCharacteristics, error)
-	// LXDProfiles returns the names of the LXD profiles on the machine.
-	AppliedLXDProfileNames(ctx context.Context, mUUID string) ([]string, error)
+	// AppliedLXDProfiles returns the names of the LXD profiles on the machine.
+	AppliedLXDProfileNames(ctx context.Context, machineUUID string) ([]string, error)
 }

--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -1203,6 +1203,9 @@ func (c *statusContext) makeMachineStatus(
 
 	lxdProfiles := make(map[string]params.LXDProfile)
 	charmProfiles, err := machineService.AppliedLXDProfileNames(ctx, machineUUID)
+	if errors.Is(err, machineerrors.NotProvisioned) {
+		logger.Debugf("can't retrieve lxd profiles for machine %q: not provisioned", machineUUID)
+	}
 	if err != nil {
 		logger.Debugf("error fetching lxd profiles: %w", err)
 	}

--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -1202,7 +1202,10 @@ func (c *statusContext) makeMachineStatus(
 	status.Containers = make(map[string]params.MachineStatus)
 
 	lxdProfiles := make(map[string]params.LXDProfile)
-	charmProfiles := c.allInstances.CharmProfiles(machineID)
+	charmProfiles, err := machineService.AppliedLXDProfileNames(ctx, machineUUID)
+	if err != nil {
+		logger.Debugf("error fetching lxd profiles: %w", err)
+	}
 	if charmProfiles != nil {
 		for _, v := range charmProfiles {
 			if profile, ok := appStatusInfo.lxdProfiles[v]; ok {

--- a/domain/machine/watcher_test.go
+++ b/domain/machine/watcher_test.go
@@ -136,7 +136,11 @@ func (s *watcherSuite) TestMachineCloudInstanceWatchWithDelete(c *gc.C) {
 func (s *watcherSuite) TestWatchLXDProfiles(c *gc.C) {
 	machineUUIDm0, err := s.svc.CreateMachine(context.Background(), "machine-1")
 	c.Assert(err, jc.ErrorIsNil)
+	err = s.svc.SetMachineCloudInstance(context.Background(), machineUUIDm0, instance.Id("123"), "", nil)
+	c.Assert(err, jc.ErrorIsNil)
 	machineUUIDm1, err := s.svc.CreateMachine(context.Background(), "machine-2")
+	c.Assert(err, jc.ErrorIsNil)
+	err = s.svc.SetMachineCloudInstance(context.Background(), machineUUIDm1, instance.Id("456"), "", nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	watcher, err := s.svc.WatchLXDProfiles(context.Background(), machineUUIDm0)

--- a/state/machine.go
+++ b/state/machine.go
@@ -283,21 +283,6 @@ type instanceData struct {
 	CharmProfiles []string `bson:"charm-profiles,omitempty"`
 }
 
-func getInstanceData(st *State, id string) (instanceData, error) {
-	instanceDataCollection, closer := st.db().GetCollection(instanceDataC)
-	defer closer()
-
-	var instData instanceData
-	err := instanceDataCollection.FindId(id).One(&instData)
-	if err == mgo.ErrNotFound {
-		return instanceData{}, errors.NotFoundf("instance data for machine %v", id)
-	}
-	if err != nil {
-		return instanceData{}, fmt.Errorf("cannot get instance data for machine %v: %v", id, err)
-	}
-	return instData, nil
-}
-
 // removeInstanceDataOp returns the operation needed to remove the
 // instance data document associated with the given globalKey.
 func removeInstanceDataOp(globalKey string) txn.Op {

--- a/state/machine.go
+++ b/state/machine.go
@@ -374,58 +374,6 @@ func (m *Machine) Jobs() []MachineJob {
 	return m.doc.Jobs
 }
 
-// CharmProfiles returns the names of any LXD profiles used by the machine,
-// which were defined in the charm deployed to that machine.
-func (m *Machine) CharmProfiles() ([]string, error) {
-	instData, err := getInstanceData(m.st, m.Id())
-	if errors.Is(err, errors.NotFound) {
-		err = errors.NotProvisionedf("machine %v", m.Id())
-	}
-	if err != nil {
-		return nil, err
-	}
-	return instData.CharmProfiles, nil
-}
-
-// SetCharmProfiles sets the names of the charm profiles used on a machine
-// in its instanceData.
-func (m *Machine) SetCharmProfiles(profiles []string) error {
-	buildTxn := func(attempt int) ([]txn.Op, error) {
-		if attempt > 0 {
-			if err := m.Refresh(); err != nil {
-				return nil, errors.Trace(err)
-			}
-		}
-
-		// Exit early if the Machine profiles doesn't need to change.
-		currentProfiles, err := m.CharmProfiles()
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		currentProfileSet := set.NewStrings(currentProfiles...)
-		newProfileSet := set.NewStrings(profiles...)
-		if currentProfileSet.Size() == newProfileSet.Size() &&
-			currentProfileSet.Intersection(newProfileSet).Size() == currentProfileSet.Size() {
-			return nil, jujutxn.ErrNoOperations
-		}
-
-		assertion := bson.M{"charm-profiles": currentProfiles}
-		if currentProfiles == nil {
-			assertion = bson.M{"charm-profiles": bson.D{{"$exists", false}}}
-		}
-		ops := []txn.Op{{
-			C:      instanceDataC,
-			Id:     m.doc.DocID,
-			Assert: assertion,
-			Update: bson.D{{"$set", bson.D{{"charm-profiles", profiles}}}},
-		}}
-
-		return ops, nil
-	}
-	err := m.st.db().Run(buildTxn)
-	return errors.Annotatef(err, "cannot update profiles for %q to %s", m, strings.Join(profiles, ", "))
-}
-
 // IsManager returns true if the machine has JobManageModel.
 func (m *Machine) IsManager() bool {
 	return isController(&m.doc)
@@ -1361,10 +1309,7 @@ func (m *Machine) SetInstanceInfo(
 		}
 	}
 
-	if err := m.SetProvisioned(id, displayName, nonce, characteristics); err != nil {
-		return errors.Trace(err)
-	}
-	return m.SetCharmProfiles(charmProfiles)
+	return errors.Trace(m.SetProvisioned(id, displayName, nonce, characteristics))
 }
 
 // Addresses returns any hostnames and ips associated with a machine,

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -1956,11 +1956,6 @@ func (w *unitsWatcher) loop(coll, id string) error {
 	}
 }
 
-// WatchInstanceData returns a watcher for observing changes to a machine's instance data.
-func (m *Machine) WatchInstanceData() NotifyWatcher {
-	return newEntityWatcher(m.st, instanceDataC, m.doc.DocID)
-}
-
 // WatchControllerInfo returns a StringsWatcher for the controllers collection
 func (st *State) WatchControllerInfo() StringsWatcher {
 	return newCollectionWatcher(st, colWCfg{col: controllerNodesC})


### PR DESCRIPTION
After this patch there will be no more used methods on machine related
to instance data on the legacy state.

This patch cleans up and wires CharmProfiles() (now called
`AppliedLXDProfiles()` on the new domain) on the missing call sites.
Also, the InstanceDataWatcher was cleaned up.

<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://docs.google.com/document/d/1SYUo9G7qZ_jdoVXpUVamS5VCgHmtZ0QA-wZxKoMS-C0 
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

LXD profiles are currently broken on main (until the migration for units and apps is finished) so we cannot QA using the CI tests deploy-lxd-profiles.
_Note: I haven't spent a huge amount of time trying to fix it (it's out of scope because it touches other domains) but I think it fails because the instance mutater is not triggering the call to write the profiles, maybe due to some of the other watchers (units/apps?) not being fully wired._
Bootstrap and deploy should work with no errors though:
```
juju bootstrap lxd c
juju add-model m
juju deploy ubuntu
```
Check status and logs for any unexpected error.

## Links


**Jira card:** JUJU-6703

