### PR TITLE
feat: add support for TopologySpreadConstraints

### DIFF
--- a/caas/kubernetes/provider/constraints.go
+++ b/caas/kubernetes/provider/constraints.go
@@ -4,6 +4,10 @@
 package provider
 
 import (
+	"errors"
+	"strings"
+
+	caasApplication "github.com/juju/juju/caas/kubernetes/provider/application"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/environs/envcontext"
 )
@@ -23,5 +27,81 @@ var unsupportedConstraints = []string{
 func (k *kubernetesClient) ConstraintsValidator(ctx envcontext.ProviderCallContext) (constraints.Validator, error) {
 	validator := constraints.NewValidator()
 	validator.RegisterUnsupported(unsupportedConstraints)
-	return validator, nil
+	return &constraintsValidator{Validator: validator}, nil
+}
+
+type constraintsValidator struct {
+	constraints.Validator
+}
+
+// Validate returns an error if the given constraints are not valid, and also
+// any unsupported attributes.
+func (v *constraintsValidator) Validate(cons constraints.Value) ([]string, error) {
+	if cons.Tags != nil {
+
+		var validateTopologyKeyTagFunc = func(key string, topologySpreadKey string, array []string) error {
+			var topologySpreadValue, otherValue *string = nil, nil
+			// Search for the topologySpreadValue for topologyKeyTag
+			for tag := range array {
+				if strings.HasPrefix(array[tag], topologySpreadKey) {
+					trimmedValue := strings.TrimPrefix(array[tag], topologySpreadKey+"=")
+					topologySpreadValue = &trimmedValue
+					break
+				}
+			}
+			if topologySpreadValue == nil {
+				// Nothing to do, continue to the next check
+				return nil
+			}
+
+			for tag := range array {
+				if strings.HasPrefix(array[tag], key) {
+					trimmedValue := strings.TrimPrefix(array[tag], key+"=")
+					otherValue = &trimmedValue
+					break
+				}
+			}
+
+			if otherValue != nil && *topologySpreadValue == *otherValue {
+				return errors.New("podAffinity/antiPodAffinity's topology-key and topologySpread's cannot have the same value")
+			}
+			return nil
+		}
+
+		positives, negatives := parseDelimitedValues(*cons.Tags)
+		elements := append(positives, negatives...)
+
+		topologySpreadKey := caasApplication.TopologySpreadPrefix + caasApplication.TopologyKeyTag
+		podKey := caasApplication.PodPrefix + caasApplication.TopologyKeyTag
+		if err := validateTopologyKeyTagFunc(podKey, topologySpreadKey, elements); err != nil {
+			return nil, err
+		}
+
+		antiPodKey := caasApplication.AntiPodPrefix + caasApplication.TopologyKeyTag
+		if err := validateTopologyKeyTagFunc(antiPodKey, topologySpreadKey, elements); err != nil {
+			return nil, err
+		}
+	}
+
+	return v.Validator.Validate(cons)
+}
+
+// parseDelimitedValues parses a slice of raw values coming from constraints
+// (Tags or Spaces). The result is split into two slices - positives and
+// negatives (prefixed with "^"). Empty values are ignored.
+func parseDelimitedValues(rawValues []string) (positives, negatives []string) {
+	for _, value := range rawValues {
+		if value == "" || value == "^" {
+			// Neither of these cases should happen in practise, as constraints
+			// are validated before setting them and empty names for spaces or
+			// tags are not allowed.
+			continue
+		}
+		if strings.HasPrefix(value, "^") {
+			negatives = append(negatives, strings.TrimPrefix(value, "^"))
+		} else {
+			positives = append(positives, value)
+		}
+	}
+	return positives, negatives
 }

--- a/core/constraints/constraints.go
+++ b/core/constraints/constraints.go
@@ -433,6 +433,7 @@ func Merge(values ...Value) (Value, error) {
 // as Parse, but panics on failure.
 func MustParse(args ...string) Value {
 	v, err := Parse(args...)
+
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
This change fixes [LP#2039316](https://bugs.launchpad.net/juju/+bug/2039316). This PR is a follow-up to main branch from: https://github.com/juju/juju/pull/18158 

Currently, the only mechanisms available to set topology in k8s are the tag constraints anti-pod|node|pod. That enables to have certain configurations, such as enforce that all replicas of a given database land in different nodes or availability zones.

However, during the lifecycle of our application, these pods may migrate between nodes and end up in a configuration that does not respect anymore the original placement constraints, e.g. all database replicas landing in the same AZ now.

This PR extends existing k8s constraints and adds support for [TopologySpreadConstraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/). It brings two benefits: (1) the [TopologySpreadConstraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) is k8s official response to the problem of controlling topology and placement over the lifecycle of applications; and (2) we do not need to manually tweak the statefulset that Juju manages, post original deployment.

The current proposal adds the following tags to CAAS constraints:

* maxSkew: we accept 1 or more pods to co-exist and not respecting the topology constraint at a time
* minDomains: how many domains do we expect the deployment to have (e.g. number of AZs): it allows an extra validation that the environment has the needed domain count
* nodeTaintsPolicy: allows the user to follow with taints besides the topology spread rules
* matchLabel: custom-defined labels, following the same pattern as the anti-pod|pod|node tags
This PR also enforces nodeAffinityPolicy to Honor and forbids further scheduling if the topology constraints are not satisfied (i.e. WhenUnsatisfiable == DoNotSchedule).

Closes: LP#2039316