### PR TITLE
docs: link to juju specific conventional commits info

### DIFF
--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -6,7 +6,7 @@ great.
   not GitHub. Please check that your bug has not already been reported.
 - When opening a pull request:
   - Check that all your [commits are signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
-  - Use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit messages.
+  - Use [Conventional Commits](#conventional-commits) for commit messages.
   - Check that your patch is [targeting the correct branch](#branches) -
     if not, please rebase it.
   - Please [sign the CLA](#contributor-licence-agreement) if you haven't already.
@@ -22,6 +22,7 @@ Contents
 - [Dependency management](#dependency-management)
 - [Code formatting](#code-formatting)
 - [Workflow](#workflow)
+   - [Conventional commits](#conventional-commits)
    - [Contributor licence agreement](#contributor-licence-agreement)
 - [Community](#community)
 
@@ -305,7 +306,9 @@ Conventional commits
 --------------------
 
 Once you have written some code and have tested the changes, the next step is to
-`git commit` it. For commit messages Juju follows [conventional commits guidelines](conventional-commits.md).
+`git commit` it. For commit messages Juju follows
+[conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) -- see our
+[conventional commits guidelines](doc/conventional-commits.md) for our commit types.
 In short the commits should be of the following form:
 ```
 <type>(optional <scope>): <description>


### PR DESCRIPTION
Currently the initial link only goes to the conventional commits website, which leaves the type field of conventional commits underspeficied. The types used in this project are linked to later in the document.

This PR changes the initial link go to this later section, which can explicitly link to both the general conventional commits information and the juju project specific guidelines.

## Checklist

- [x] ~Code style: imports ordered, good names, simple structure, etc~
- [x] ~Comments saying why design decisions were made~
- [x] ~Go unit tests, with comments saying what you're testing~
- [x] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [x] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## Documentation changes

Small improvement in docs experience for new contributors. I personally got tripped up by this a bit at first when working on python-libjuju.

## Links

I notice that CONTRIBUTING.md links to:
https://github.com/juju/juju/blob/main/doc/conventional-commits.md

While the PR template links to:
https://docs.google.com/document/d/1SYUo9G7qZ_jdoVXpUVamS5VCgHmtZ0QA-wZxKoMS-C0

Not sure which should be preferred.