### PR TITLE
fix: ensure correct error

### DIFF
--- a/domain/machine/state/machine_cloud_instance.go
+++ b/domain/machine/state/machine_cloud_instance.go
@@ -45,12 +45,13 @@ WHERE     v.machine_uuid = $instanceDataResult.machine_uuid`
 
 	var row instanceDataResult
 	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		return errors.Trace(tx.Query(ctx, retrieveHardwareCharacteristicsStmt, machineUUIDQuery).Get(&row))
-	}); err != nil {
+		err := tx.Query(ctx, retrieveHardwareCharacteristicsStmt, machineUUIDQuery).Get(&row)
 		if errors.Is(err, sql.ErrNoRows) {
-			return nil, errors.Annotatef(errors.NotFound, "machine cloud instance for machine %q", machineUUID)
+			return errors.Annotatef(errors.NotFound, "machine cloud instance for machine %q", machineUUID)
 		}
-		return nil, errors.Annotatef(err, "querying machine cloud instance for machine %q", machineUUID)
+		return errors.Annotatef(err, "querying machine cloud instance for machine %q", machineUUID)
+	}); err != nil {
+		return nil, errors.Trace(err)
 	}
 	return row.toHardwareCharacteristics(), nil
 }

--- a/domain/machine/state/machine_cloud_instance_test.go
+++ b/domain/machine/state/machine_cloud_instance_test.go
@@ -5,9 +5,7 @@ package state
 
 import (
 	"context"
-	"fmt"
 
-	"github.com/google/uuid"
 	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -16,12 +14,20 @@ import (
 	"github.com/juju/juju/core/machine"
 	"github.com/juju/juju/core/status"
 	machineerrors "github.com/juju/juju/domain/machine/errors"
+	"github.com/juju/juju/internal/uuid"
 )
+
+func (s *stateSuite) TestGetHardwareCharacteristicsWithNoData(c *gc.C) {
+	machineUUID, err := uuid.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = s.state.HardwareCharacteristics(context.Background(), machineUUID.String())
+	c.Assert(err, jc.ErrorIs, errors.NotFound)
+}
 
 func (s *stateSuite) TestGetHardwareCharacteristics(c *gc.C) {
 	machineUUID := s.ensureInstance(c, "42")
 
-	fmt.Printf("machineUUID: %s\n", machineUUID)
 	hc, err := s.state.HardwareCharacteristics(context.Background(), machineUUID)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(*hc.Arch, gc.Equals, "arm64")
@@ -372,7 +378,7 @@ func (s *stateSuite) TestInstanceStatusValues(c *gc.C) {
 	// Check that the status values in the machine_cloud_instance_status_value table match
 	// the instance status values in core status.
 	rows, err := db.QueryContext(context.Background(), "SELECT id, status FROM machine_cloud_instance_status_value")
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 	c.Assert(err, jc.ErrorIsNil)
 	var statusValues []struct {
 		ID   int
@@ -402,7 +408,7 @@ func (s *stateSuite) ensureInstance(c *gc.C, mName machine.Name) string {
 	db := s.DB()
 
 	// Create a reference machine.
-	uuid, err := uuid.NewV7()
+	uuid, err := uuid.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
 	machineUUID := uuid.String()
 	err = s.state.CreateMachine(context.Background(), mName, "", machineUUID)


### PR DESCRIPTION
The following ensures that the correct error is returned with no hardware characteristics. The error was correctly trapped and replaced.

This was missing a vital test.

Note: we should be using a machine error to signify that there was no HardwareCharacteristics, but that can be done later.


## QA steps

```
$ juju bootstrap lxd test
$ juju debug-log -m controller
```

Ensure that there are no errors.


