### PR TITLE
fix: ensure forced removal of offers succeeds

### DIFF
--- a/state/address.go
+++ b/state/address.go
@@ -277,7 +277,7 @@ func (st *State) isCAASController() (bool, error) {
 
 func (st *State) apiHostPortsForCAAS(public bool) (addresses []network.SpaceHostPorts, err error) {
 	defer func() {
-		logger.Debugf("getting api hostports for CAAS: public %t, addresses %v", public, addresses)
+		logger.Tracef("getting api hostports for CAAS: public %t, addresses %v", public, addresses)
 	}()
 
 	if st.ModelUUID() != st.controllerModelTag.Id() {

--- a/state/applicationoffers.go
+++ b/state/applicationoffers.go
@@ -271,6 +271,8 @@ func (op *RemoveOfferOperation) Build(attempt int) (ops []txn.Op, err error) {
 		}
 		ops = append(ops, proxyOps...)
 	}
+
+	sortRemoveOpsLast(ops)
 	return ops, nil
 }
 

--- a/state/modeloperation.go
+++ b/state/modeloperation.go
@@ -4,6 +4,8 @@
 package state
 
 import (
+	"sort"
+	
 	"github.com/juju/errors"
 	"github.com/juju/mgo/v3/txn"
 	jujutxn "github.com/juju/txn/v3"
@@ -73,7 +75,7 @@ func ComposeModelOperations(modelOps ...ModelOperation) ModelOperation {
 			return ops, nil
 		},
 		doneFn: func(err error) error {
-			// Unfortunately, we cannot detect the extact
+			// Unfortunately, we cannot detect the exact
 			// ModelOperation that caused the error. For now, just
 			// pass the error to each done method and ignore the
 			// return value. Then, return the original error back
@@ -103,4 +105,20 @@ func ComposeModelOperations(modelOps ...ModelOperation) ModelOperation {
 func (st *State) ApplyOperation(op ModelOperation) error {
 	err := st.db().Run(op.Build)
 	return op.Done(err)
+}
+
+// sortRemoveOpsLast re-orders a slice of transaction operations so that any
+// document removals occur at the end of the slice.
+// This is important for server-side transactions because of two execution
+// characteristics:
+// 1. All assertions are verified first.
+// 2. We can read our own writes inside the transaction.
+// This means it is possible for a removal and a subsequent update operation
+// on the same document to pass the assertions, then fail with "not found" upon
+// actual processing.
+// Legacy client-side transactions do not exhibit this behaviour.
+func sortRemoveOpsLast(ops []txn.Op) {
+	sort.Slice(ops, func(i, j int) bool {
+		return !ops[i].Remove && ops[j].Remove
+	})
 }

--- a/state/package_test.go
+++ b/state/package_test.go
@@ -11,6 +11,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/secrets"
 	coretesting "github.com/juju/juju/testing"
@@ -122,4 +123,18 @@ func (st *State) IsSecretRevisionObsolete(c *gc.C, uri *secrets.URI, rev int) bo
 	err := col.FindId(secretRevisionKey(uri, rev)).One(&doc)
 	c.Assert(err, jc.ErrorIsNil)
 	return doc.Obsolete
+}
+
+// ApplicationOffersExposingOps extends the crossmodel.ApplicationOffers
+// interface so that external test packages can interrogate the generated
+// model operation for removal.
+type ApplicationOffersExposingOps interface {
+	crossmodel.ApplicationOffers
+	RemoveOfferOperation(offerName string, force bool) (*RemoveOfferOperation, error)
+}
+
+// NewApplicationOffersExposingOps returns an extended indirection for
+// a new reference to the package-private applicationOffers type.
+func NewApplicationOffersExposingOps(st *State) ApplicationOffersExposingOps {
+	return &applicationOffers{st: st}
 }

--- a/state/relation.go
+++ b/state/relation.go
@@ -375,7 +375,10 @@ func (op *DestroyRelationOperation) internalDestroy() (ops []txn.Op, err error) 
 	} else if op.FatalError(err) {
 		return nil, err
 	}
-	return append(ops, destroyOps...), nil
+
+	ops = append(ops, destroyOps...)
+	sortRemoveOpsLast(ops)
+	return ops, nil
 }
 
 // destroyOps returns the operations necessary to destroy the relation, and


### PR DESCRIPTION
The linked LP bug describes an issues where, despite the application of the `--force` flag, removal of a particular cross-model relation (CMR) cannot be achieved.

I happened to replicate this issue for both a CMR and its offer when testing a scenario where cos-lite was related to a controller.

The model operations for removals associated with relations (including CMRs and their offers) are very convoluted. This is an example of the transaction operations generated for an offer removal:
```
txn.Op{C:"applications", Id:"prometheus", Assert:bson.D{bson.DocElem{Name:"relationcount", Value:11}}, Insert:interface {}(nil), Update:interface {}(nil), Remove:false}
txn.Op{C:"relationscopes", Id:"r#28#provider#remote-97037b2dc1d342788f13a7ee41a0c573/0", Assert:"d+", Insert:interface {}(nil), Update:interface {}(nil), Remove:true}
txn.Op{C:"relations", Id:"e67c68b9-4b99-49b1-8c13-9a492f11bd63:prometheus:metrics-endpoint remote-97037b2dc1d342788f13a7ee41a0c573:metrics-endpoint", Assert:bson.D{bson.DocElem{Name:"life", Value:1}, bson.DocElem{Name:"unitcount", Value:1}}, Insert:interface {}(nil), Update:interface {}(nil), Remove:true}
txn.Op{C:"applications", Id:"e67c68b9-4b99-49b1-8c13-9a492f11bd63:prometheus", Assert:bson.D{bson.DocElem{Name:"relationcount", Value:bson.D{bson.DocElem{Name:"$gt", Value:0}}}}, Insert:interface {}(nil), Update:bson.D{bson.DocElem{Name:"$inc", Value:bson.D{bson.DocElem{Name:"relationcount", Value:-1}}}}, Remove:false}
txn.Op{C:"remoteApplications", Id:"e67c68b9-4b99-49b1-8c13-9a492f11bd63:remote-97037b2dc1d342788f13a7ee41a0c573", Assert:bson.D{bson.DocElem{Name:"relationcount", Value:1}}, Insert:interface {}(nil), Update:interface {}(nil), Remove:true}
txn.Op{C:"statuses", Id:"e67c68b9-4b99-49b1-8c13-9a492f11bd63:c#remote-97037b2dc1d342788f13a7ee41a0c573", Assert:interface {}(nil), Insert:interface {}(nil), Update:interface {}(nil), Remove:true}
txn.Op{C:"remoteEntities", Id:"application-remote-97037b2dc1d342788f13a7ee41a0c573", Assert:interface {}(nil), Insert:interface {}(nil), Update:interface {}(nil), Remove:true}
txn.Op{C:"statuses", Id:"e67c68b9-4b99-49b1-8c13-9a492f11bd63:r#28", Assert:interface {}(nil), Insert:interface {}(nil), Update:interface {}(nil), Remove:true}
txn.op{c:"relationnetworks", id:"e67c68b9-4b99-49b1-8c13-9a492f11bd63:prometheus:metrics-endpoint remote-97037b2dc1d342788f13a7ee41a0c573:metrics-endpoint:ingress:override", Assert:interface {}(nil), Insert:interface {}(nil), Update:interface {}(nil), Remove:true}
txn.Op{C:"relationNetworks", Id:"e67c68b9-4b99-49b1-8c13-9a492f11bd63:prometheus:metrics-endpoint remote-97037b2dc1d342788f13a7ee41a0c573:metrics-endpoint:ingress:default", Assert:interface {}(nil), Insert:interface {}(nil), Update:interface {}(nil), Remove:true}
txn.Op{C:"relationNetworks", Id:"e67c68b9-4b99-49b1-8c13-9a492f11bd63:prometheus:metrics-endpoint remote-97037b2dc1d342788f13a7ee41a0c573:metrics-endpoint:egress:override", Assert:interface {}(nil), Insert:interface {}(nil), Update:interface {}(nil), Remove:true}
txn.Op{C:"relationNetworks", Id:"e67c68b9-4b99-49b1-8c13-9a492f11bd63:prometheus:metrics-endpoint remote-97037b2dc1d342788f13a7ee41a0c573:metrics-endpoint:egress:default", Assert:interface {}(nil), Insert:interface {}(nil), Update:interface {}(nil), Remove:true}
txn.Op{C:"remoteEntities", Id:"relation-prometheus.metrics-endpoint#remote-97037b2dc1d342788f13a7ee41a0c573.metrics-endpoint", Assert:interface {}(nil), Insert:interface {}(nil), Update:interface {}(nil), Remove:true}
txn.Op{C:"applicationOfferConnections", Id:"28", Assert:interface {}(nil), Insert:interface {}(nil), Update:interface {}(nil), Remove:true}
txn.Op{C:"cleanups", Id:"66fff51ffe5c050033764afd", Assert:interface {}(nil), Insert:(*state.cleanupDoc)(0xc0048fa420), Update:interface {}(nil), Remove:false}
txn.Op{C:"cleanups", Id:"66fff51ffe5c050033764afe", Assert:interface {}(nil), Insert:(*state.cleanupDoc)(0xc0048fa4e0), Update:interface {}(nil), Remove:false}
txn.Op{C:"relations", Id:"e67c68b9-4b99-49b1-8c13-9a492f11bd63:prometheus:metrics-endpoint remote-97037b2dc1d342788f13a7ee41a0c573:metrics-endpoint", Assert:bson.D{bson.DocElem{Name:"unitcount", Value:bson.D{bson.DocElem{Name:"$gt", Value:0}}}, bson.DocElem{Name:"life", Value:1}}, Insert:interface {}(nil), Update:bson.D{bson.DocElem{Name:"$set", Value:bson.D{bson.DocElem{Name:"life", Value:1}}}}, Remove:false}
txn.Op{C:"applicationOffers", Id:"prometheus", Assert:"d+", Insert:interface {}(nil), Update:interface {}(nil), Remove:true}
txn.Op{C:"refcounts", Id:"offer#prometheus", Assert:bson.D{bson.DocElem{Name:"refcount", Value:1}}, Insert:interface {}(nil), Update:interface {}(nil), Remove:true}
txn.Op{C:"remoteEntities", Id:"application-prometheus", Assert:interface {}(nil), Insert:interface {}(nil), Update:interface {}(nil), Remove:true}
txn.Op{C:"cleanups", Id:"66fff51ffe5c050033764aff", Assert:interface {}(nil), Insert:(*state.cleanupDoc)(0xc0048fae40), Update:interface {}(nil), Remove:false}
txn.Op{C:"relations", Id:"e67c68b9-4b99-49b1-8c13-9a492f11bd63:prometheus:metrics-endpoint remote-97037b2dc1d342788f13a7ee41a0c573:metrics-endpoint", Assert:bson.D{bson.DocElem{Name:"unitcount", Value:bson.D{bson.DocElem{Name:"$gt", Value:0}}}, bson.DocElem{Name:"life", Value:1}}, Insert:interface {}(nil), Update:bson.D{bson.DocElem{Name:"$set", Value:bson.D{bson.DocElem{Name:"life", Value:1}}}}, Remove:false}
txn.Op{C:"remoteApplications", Id:"e67c68b9-4b99-49b1-8c13-9a492f11bd63:remote-97037b2dc1d342788f13a7ee41a0c573", Assert:bson.D(nil), Insert:interface {}(nil), Update:interface {}(nil), Remove:true}
txn.Op{C:"statuses", Id:"e67c68b9-4b99-49b1-8c13-9a492f11bd63:c#remote-97037b2dc1d342788f13a7ee41a0c573", Assert:interface {}(nil), Insert:interface {}(nil), Update:interface {}(nil), Remove:true}
txn.Op{C:"remoteEntities", Id:"application-remote-97037b2dc1d342788f13a7ee41a0c573", Assert:interface {}(nil), Insert:interface {}(nil), Update:interface {}(nil), Remove:true}
```
This resulted in an undecorated `not found` error when run against Mongo.


## QA steps

TBC

## Documentation changes

None.

## Links

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2081126

**Jira card:** [JUJU-6899](https://warthogs.atlassian.net/browse/JUJU-6899)

