### PR TITLE
fix: prevent uniter bouncing

### DIFF
--- a/apiserver/facades/agent/uniter/service.go
+++ b/apiserver/facades/agent/uniter/service.go
@@ -9,7 +9,6 @@ import (
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/credential"
-	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/leadership"
 	"github.com/juju/juju/core/life"
 	coremachine "github.com/juju/juju/core/machine"
@@ -114,7 +113,7 @@ type MachineService interface {
 	// the changes in the machine_cloud_instance table in the model.
 	WatchLXDProfiles(ctx context.Context, machineUUID string) (watcher.NotifyWatcher, error)
 
-	// HardwareCharacteristics returns the hardware characteristics of the
+	// AvailabilityZone returns the hardware characteristics of the
 	// specified machine.
-	HardwareCharacteristics(ctx context.Context, machineUUID string) (*instance.HardwareCharacteristics, error)
+	AvailabilityZone(ctx context.Context, machineUUID string) (string, error)
 }

--- a/apiserver/facades/agent/uniter/service_mock_test.go
+++ b/apiserver/facades/agent/uniter/service_mock_test.go
@@ -13,7 +13,6 @@ import (
 	context "context"
 	reflect "reflect"
 
-	instance "github.com/juju/juju/core/instance"
 	machine "github.com/juju/juju/core/machine"
 	model "github.com/juju/juju/core/model"
 	network "github.com/juju/juju/core/network"
@@ -204,6 +203,21 @@ func (mr *MockMachineServiceMockRecorder) AppliedLXDProfileNames(arg0, arg1 any)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppliedLXDProfileNames", reflect.TypeOf((*MockMachineService)(nil).AppliedLXDProfileNames), arg0, arg1)
 }
 
+// AvailabilityZone mocks base method.
+func (m *MockMachineService) AvailabilityZone(arg0 context.Context, arg1 string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AvailabilityZone", arg0, arg1)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AvailabilityZone indicates an expected call of AvailabilityZone.
+func (mr *MockMachineServiceMockRecorder) AvailabilityZone(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AvailabilityZone", reflect.TypeOf((*MockMachineService)(nil).AvailabilityZone), arg0, arg1)
+}
+
 // ClearMachineReboot mocks base method.
 func (m *MockMachineService) ClearMachineReboot(arg0 context.Context, arg1 string) error {
 	m.ctrl.T.Helper()
@@ -231,21 +245,6 @@ func (m *MockMachineService) GetMachineUUID(arg0 context.Context, arg1 machine.N
 func (mr *MockMachineServiceMockRecorder) GetMachineUUID(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMachineUUID", reflect.TypeOf((*MockMachineService)(nil).GetMachineUUID), arg0, arg1)
-}
-
-// HardwareCharacteristics mocks base method.
-func (m *MockMachineService) HardwareCharacteristics(arg0 context.Context, arg1 string) (*instance.HardwareCharacteristics, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HardwareCharacteristics", arg0, arg1)
-	ret0, _ := ret[0].(*instance.HardwareCharacteristics)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// HardwareCharacteristics indicates an expected call of HardwareCharacteristics.
-func (mr *MockMachineServiceMockRecorder) HardwareCharacteristics(arg0, arg1 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HardwareCharacteristics", reflect.TypeOf((*MockMachineService)(nil).HardwareCharacteristics), arg0, arg1)
 }
 
 // IsMachineRebootRequired mocks base method.

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -349,14 +349,11 @@ var getZone = func(ctx context.Context, st *state.State, machineService MachineS
 	if err != nil {
 		return "", errors.Trace(err)
 	}
-	hc, err := machineService.HardwareCharacteristics(ctx, machineUUID)
+	az, err := machineService.AvailabilityZone(ctx, machineUUID)
 	if err != nil {
 		return "", errors.Trace(err)
 	}
-	if hc.AvailabilityZone == nil {
-		return "", nil
-	}
-	return *hc.AvailabilityZone, errors.Trace(err)
+	return az, errors.Trace(err)
 }
 
 // AvailabilityZone returns the availability zone for each given unit, if applicable.

--- a/domain/machine/service/machine_cloud_instance.go
+++ b/domain/machine/service/machine_cloud_instance.go
@@ -34,6 +34,15 @@ func (s *Service) InstanceIDAndName(ctx context.Context, machineUUID string) (st
 	return instanceID, instanceName, nil
 }
 
+// AvailabilityZone returns the availability zone for the specified machine.
+func (s *Service) AvailabilityZone(ctx context.Context, machineUUID string) (string, error) {
+	az, err := s.st.AvailabilityZone(ctx, machineUUID)
+	if errors.Is(err, errors.NotFound) {
+		return "", errors.NotProvisionedf("machine %q is not provisioned", machineUUID)
+	}
+	return az, errors.Annotatef(err, "retrieving availability zone for machine %q", machineUUID)
+}
+
 // HardwareCharacteristics returns the hardware characteristics of the
 // of the specified machine.
 func (s *Service) HardwareCharacteristics(ctx context.Context, machineUUID string) (*instance.HardwareCharacteristics, error) {

--- a/domain/machine/service/machine_cloud_instance_test.go
+++ b/domain/machine/service/machine_cloud_instance_test.go
@@ -42,6 +42,17 @@ func (s *serviceSuite) TestRetrieveHardwareCharacteristicsFails(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "retrieving hardware characteristics for machine \"42\": boom")
 }
 
+func (s *serviceSuite) TestRetrieveAvailabilityZone(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.state.EXPECT().AvailabilityZone(gomock.Any(), "42").
+		Return("foo", nil)
+
+	hc, err := NewService(s.state).AvailabilityZone(context.Background(), "42")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(hc, gc.DeepEquals, "foo")
+}
+
 func (s *serviceSuite) TestSetMachineCloudInstance(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 

--- a/domain/machine/service/package_mock_test.go
+++ b/domain/machine/service/package_mock_test.go
@@ -121,6 +121,45 @@ func (c *MockStateAppliedLXDProfileNamesCall) DoAndReturn(f func(context.Context
 	return c
 }
 
+// AvailabilityZone mocks base method.
+func (m *MockState) AvailabilityZone(arg0 context.Context, arg1 string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AvailabilityZone", arg0, arg1)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AvailabilityZone indicates an expected call of AvailabilityZone.
+func (mr *MockStateMockRecorder) AvailabilityZone(arg0, arg1 any) *MockStateAvailabilityZoneCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AvailabilityZone", reflect.TypeOf((*MockState)(nil).AvailabilityZone), arg0, arg1)
+	return &MockStateAvailabilityZoneCall{Call: call}
+}
+
+// MockStateAvailabilityZoneCall wrap *gomock.Call
+type MockStateAvailabilityZoneCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateAvailabilityZoneCall) Return(arg0 string, arg1 error) *MockStateAvailabilityZoneCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateAvailabilityZoneCall) Do(f func(context.Context, string) (string, error)) *MockStateAvailabilityZoneCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateAvailabilityZoneCall) DoAndReturn(f func(context.Context, string) (string, error)) *MockStateAvailabilityZoneCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // ClearMachineReboot mocks base method.
 func (m *MockState) ClearMachineReboot(arg0 context.Context, arg1 string) error {
 	m.ctrl.T.Helper()

--- a/domain/machine/service/service.go
+++ b/domain/machine/service/service.go
@@ -88,6 +88,9 @@ type State interface {
 	// data retrieved from the machine cloud instance table.
 	HardwareCharacteristics(context.Context, string) (*instance.HardwareCharacteristics, error)
 
+	// AvailabilityZone returns the availability zone for the specified machine.
+	AvailabilityZone(context.Context, string) (string, error)
+
 	// SetMachineCloudInstance sets an entry in the machine cloud instance table
 	// along with the instance tags and the link to a lxd profile if any.
 	SetMachineCloudInstance(context.Context, string, instance.Id, string, *instance.HardwareCharacteristics) error

--- a/domain/machine/state/machine_cloud_instance_test.go
+++ b/domain/machine/state/machine_cloud_instance_test.go
@@ -79,6 +79,22 @@ func (s *stateSuite) TestGetHardwareCharacteristicsWithoutAvailabilityZone(c *gc
 	c.Check(*hc.VirtType, gc.Equals, "virtual-machine")
 }
 
+func (s *stateSuite) TestAvailabilityZoneWithNoMachine(c *gc.C) {
+	machineUUID, err := uuid.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = s.state.AvailabilityZone(context.Background(), machineUUID.String())
+	c.Assert(err, jc.ErrorIs, errors.NotFound)
+}
+
+func (s *stateSuite) TestAvailabilityZone(c *gc.C) {
+	machineUUID := s.ensureInstance(c, "42")
+
+	az, err := s.state.AvailabilityZone(context.Background(), machineUUID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(az, gc.Equals, "az-1")
+}
+
 func (s *stateSuite) TestSetInstanceData(c *gc.C) {
 	db := s.DB()
 


### PR DESCRIPTION
The controller uniter is bouncing because it's trying to get hold of the az, but it can't be found, which isn't the error that the uniter is expecting. It is expecting a not-provisioned error.

This code is not correct, because we've not got the correct errors in place for the machine domain.

For now, this allows us to continue with progress.

<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://docs.google.com/document/d/1SYUo9G7qZ_jdoVXpUVamS5VCgHmtZ0QA-wZxKoMS-C0 
-->

<!-- Why this change is needed and what it does. -->


## QA steps

```sh
$ juju bootstrap lxd test
$ watch juju status -m controller
```

Ensure that the agent runs.
