### PR TITLE
fix: multiwatcher misses events

### DIFF
--- a/core/watcher/eventsource/multiwatcher_test.go
+++ b/core/watcher/eventsource/multiwatcher_test.go
@@ -38,9 +38,8 @@ func (*multiWatcherSuite) TestNotifyMultiWatcher(c *gc.C) {
 	wc.AssertOneChange()
 
 	ch0 <- struct{}{}
-	wc.AssertOneChange()
 	ch1 <- struct{}{}
-	wc.AssertOneChange()
+	wc.AssertNChanges(2)
 
 	ch0 <- struct{}{}
 	ch1 <- struct{}{}


### PR DESCRIPTION
The MultiWatcher only has a single variable to store incoming event values. If a second event arrives too quickly before the previous one is sent, the first unsent event will be discarded. This fix ensures that no events are missed in the main fan-in channel, particularly preventing events from being missed when coming from different source watchers. 

However, there’s still a possibility of missing events that arrive too quickly from the same source watcher.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```
go test -race -v ./core/watcher/eventsource/... -test.timeout=600s -check.v -count=100 -check.f=multiWatcherSuite.TestNotifyMultiWatcher
```

## Documentation changes

No

## Links

**Jira card:** [JUJU-6910](https://warthogs.atlassian.net/browse/JUJU-6910)

