### PR TITLE
chore(instancedata): full cleanup of instance data on legacy state

### DIFF
--- a/apiserver/facades/agent/provisioner/provisioner_integration_test.go
+++ b/apiserver/facades/agent/provisioner/provisioner_integration_test.go
@@ -1350,8 +1350,15 @@ func (s *withoutControllerSuite) TestSetInstanceInfo(c *gc.C) {
 	}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
+	machineService := domainServicesGetter.ServicesForModel(model.UUID(st.ModelUUID())).Machine()
 	// Provision machine 0 first.
 	hwChars := instance.MustParseHardware("arch=arm64", "mem=4G")
+	machine0UUID, err := machineService.GetMachineUUID(context.Background(), coremachine.Name(s.machines[0].Id()))
+	c.Assert(err, jc.ErrorIsNil)
+	err = machineService.SetMachineCloudInstance(context.Background(), machine0UUID, instance.Id("i-am"), "", &hwChars)
+	c.Assert(err, jc.ErrorIsNil)
+
+	// We keep this SetInstanceInfo only for the nonce.
 	err = s.machines[0].SetInstanceInfo("i-am", "", "fake_nonce", &hwChars, nil, nil, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -1363,7 +1370,6 @@ func (s *withoutControllerSuite) TestSetInstanceInfo(c *gc.C) {
 		}},
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	machineService := domainServicesGetter.ServicesForModel(model.UUID(st.ModelUUID())).Machine()
 	_, err = machineService.CreateMachine(context.Background(), coremachine.Name(volumesMachine.Id()))
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -637,7 +637,6 @@ type statusContext struct {
 	// allMachines: machine id -> machine
 	// The machine in this map is the same machine in the machines map.
 	allMachines    map[string]*state.Machine
-	allInstances   *state.ModelInstanceData
 	allConstraints *state.ModelConstraints
 
 	// controllerNodes: node id -> controller node
@@ -709,10 +708,6 @@ func (context *statusContext) fetchMachines(st Backend) error {
 		}
 	}
 
-	context.allInstances, err = context.model.AllInstanceData()
-	if err != nil {
-		return err
-	}
 	context.allConstraints, err = context.model.AllConstraints()
 	if err != nil {
 		return err

--- a/domain/machine/modelmigration/export.go
+++ b/domain/machine/modelmigration/export.go
@@ -78,6 +78,13 @@ func (e *exportOperation) Execute(ctx context.Context, model description.Model) 
 		}
 		instanceID, err := e.service.InstanceID(ctx, machineUUID)
 		if errors.Is(err, machineerrors.NotProvisioned) {
+			// TODO(nvinuesa): Here we should remove the machine from the
+			// exported model because we should not migrate non-provisioned
+			// machines. This used to be checked in model.Description, but was
+			// removed in https://github.com/juju/description/pull/157.
+			// We should revisit this once we finish migrating machines over to
+			// dqlite (by not adding the machine to the exported model to begin
+			// with if it's not provisioned).
 			continue
 		}
 		if err != nil {

--- a/state/addmachine.go
+++ b/state/addmachine.go
@@ -296,29 +296,6 @@ func (st *State) addMachineOps(
 
 	prereqOps = append(prereqOps, assertModelActiveOp(st.ModelUUID()))
 	prereqOps = append(prereqOps, insertNewContainerRefOp(st, mdoc.Id))
-	if template.InstanceId != "" {
-		prereqOps = append(prereqOps, txn.Op{
-			C:      instanceDataC,
-			Id:     mdoc.DocID,
-			Assert: txn.DocMissing,
-			Insert: &instanceData{
-				DocID:          mdoc.DocID,
-				MachineId:      mdoc.Id,
-				InstanceId:     template.InstanceId,
-				DisplayName:    template.DisplayName,
-				ModelUUID:      mdoc.ModelUUID,
-				Arch:           template.HardwareCharacteristics.Arch,
-				Mem:            template.HardwareCharacteristics.Mem,
-				RootDisk:       template.HardwareCharacteristics.RootDisk,
-				RootDiskSource: template.HardwareCharacteristics.RootDiskSource,
-				CpuCores:       template.HardwareCharacteristics.CpuCores,
-				CpuPower:       template.HardwareCharacteristics.CpuPower,
-				Tags:           template.HardwareCharacteristics.Tags,
-				AvailZone:      template.HardwareCharacteristics.AvailabilityZone,
-				VirtType:       template.HardwareCharacteristics.VirtType,
-			},
-		})
-	}
 	if isController(mdoc) {
 		prereqOps = append(prereqOps, addControllerNodeOp(st, mdoc.Id, false))
 	}

--- a/state/allcollections.go
+++ b/state/allcollections.go
@@ -228,13 +228,6 @@ func allCollections() CollectionSchema {
 				Key: []string{"model-uuid"},
 			}},
 		},
-		instanceDataC: {
-			indexes: []mgo.Index{{
-				Key: []string{"model-uuid", "machineid"},
-			}, {
-				Key: []string{"model-uuid", "instanceid"},
-			}},
-		},
 		machinesC: {
 			indexes: []mgo.Index{{
 				Key: []string{"model-uuid", "machineid"},
@@ -496,7 +489,6 @@ const (
 	globalClockC           = "globalclock"
 	globalRefcountsC       = "globalRefcounts"
 	globalSettingsC        = "globalSettings"
-	instanceDataC          = "instanceData"
 	machinesC              = "machines"
 	machineRemovalsC       = "machineremovals"
 	minUnitsC              = "minunits"

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -355,9 +355,6 @@ func (i *importer) machine(m description.Machine, arch string) error {
 		cons,
 	)
 
-	// 3. create op for adding in instance data
-	prereqOps = append(prereqOps, i.machineInstanceOp(mdoc, instance, arch))
-
 	if parentId := container.ParentId(mdoc.Id); parentId != "" {
 		prereqOps = append(prereqOps,
 			// Update containers record for host machine.
@@ -460,60 +457,6 @@ func (i *importer) applicationPortsOp(a description.Application) txn.Op {
 		Id:     docID,
 		Assert: txn.DocMissing,
 		Insert: portRangeDoc,
-	}
-}
-
-// machineInstanceOp creates for txn operation for inserting a doc into
-// instance data collection. The parentArch is included to fix data from
-// older versions of juju where the architecture of a container was left
-// empty.
-func (i *importer) machineInstanceOp(mdoc *machineDoc, inst description.CloudInstance, parentArch string) txn.Op {
-	doc := &instanceData{
-		DocID:       mdoc.DocID,
-		MachineId:   mdoc.Id,
-		InstanceId:  instance.Id(inst.InstanceId()),
-		DisplayName: inst.DisplayName(),
-		ModelUUID:   mdoc.ModelUUID,
-	}
-
-	if arch := inst.Architecture(); arch != "" {
-		doc.Arch = &arch
-	} else if parentArch != "" {
-		doc.Arch = &parentArch
-	}
-	if mem := inst.Memory(); mem != 0 {
-		doc.Mem = &mem
-	}
-	if rootDisk := inst.RootDisk(); rootDisk != 0 {
-		doc.RootDisk = &rootDisk
-	}
-	if rootDiskSource := inst.RootDiskSource(); rootDiskSource != "" {
-		doc.RootDiskSource = &rootDiskSource
-	}
-	if cores := inst.CpuCores(); cores != 0 {
-		doc.CpuCores = &cores
-	}
-	if power := inst.CpuPower(); power != 0 {
-		doc.CpuPower = &power
-	}
-	if tags := inst.Tags(); len(tags) > 0 {
-		doc.Tags = &tags
-	}
-	if az := inst.AvailabilityZone(); az != "" {
-		doc.AvailZone = &az
-	}
-	if vt := inst.VirtType(); vt != "" {
-		doc.VirtType = &vt
-	}
-	if profiles := inst.CharmProfiles(); len(profiles) > 0 {
-		doc.CharmProfiles = profiles
-	}
-
-	return txn.Op{
-		C:      instanceDataC,
-		Id:     mdoc.DocID,
-		Assert: txn.DocMissing,
-		Insert: doc,
 	}
 }
 


### PR DESCRIPTION
This patch removes the last pieces of instance data from the legacy
state (the collection, and some bits of the methods `SetInstanceInfo` 
and `SetProvisioned`). 

The only non-removal code is a fix in the
provisioner_integration_test.go, where one test was still calling
SetProvisioned from the legacy state. This was easily replaced by the
service method.
<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://docs.google.com/document/d/1SYUo9G7qZ_jdoVXpUVamS5VCgHmtZ0QA-wZxKoMS-C0 
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

This is the last patch for the instance data domain, so everything should work and no errors observed:

### Aws
```
juju bootstrap aws c
juju add-model m
juju add-machine
# check status and wait until machine State is ACTIVE
juju deploy ubuntu
```
Check outputs:
```
juju status
Model  Controller  Cloud/Region   Version      Timestamp
m      c2          aws/eu-west-3  4.0-beta5.1  16:01:09+02:00

App     Version  Status  Scale  Charm   Channel        Rev  Exposed  Message
ubuntu  22.04    active      1  ubuntu  latest/stable   25  no

Unit       Workload  Agent  Machine  Public address  Ports  Message
ubuntu/0*  active    idle   1        13.39.13.64

Machine  State    Address         Inst id              Base          AZ          Message
0        started  35.180.130.173  i-011143154353bcec3  ubuntu@22.04  eu-west-3b  running
1        started  13.39.13.64     i-0e8d2642f8198cff4  ubuntu@22.04  eu-west-3c  running

juju status --format yaml
model:
  name: m
  type: iaas
  controller: c2
  cloud: aws
  region: eu-west-3
  version: 4.0-beta5.1
  model-status:
    current: available
    since: 11 Oct 2024 15:59:48+02:00
machines:
  "0":
    juju-status:
      current: started
      since: 11 Oct 2024 16:00:50+02:00
      version: 4.0-beta5.1
    hostname: ip-172-31-28-136
    dns-name: 35.180.130.173
    ip-addresses:
    - 35.180.130.173
    - 172.31.28.136
    instance-id: i-011143154353bcec3
    machine-status:
      current: running
      message: running
      since: 11 Oct 2024 16:00:05+02:00
    modification-status:
      current: idle
      since: 11 Oct 2024 15:59:51+02:00
    base:
      name: ubuntu
      channel: "22.04"
    network-interfaces:
      enp39s0:
        ip-addresses:
        - 172.31.28.136
        mac-address: 0a:00:90:7c:8b:f1
        gateway: 172.31.16.1
        space: alpha
        is-up: true
    hardware: arch=amd64 cores=2 cpu-power=895 mem=8192M root-disk=8192M availability-zone=eu-west-3b
  "1":
    juju-status:
      current: started
      since: 11 Oct 2024 16:00:50+02:00
      version: 4.0-beta5.1
    hostname: ip-172-31-36-6
    dns-name: 13.39.13.64
    ip-addresses:
    - 13.39.13.64
    - 172.31.36.6
    instance-id: i-0e8d2642f8198cff4
    machine-status:
      current: running
      message: running
      since: 11 Oct 2024 16:00:01+02:00
    modification-status:
      current: idle
      since: 11 Oct 2024 15:59:54+02:00
    base:
      name: ubuntu
      channel: "22.04"
    network-interfaces:
      enp39s0:
        ip-addresses:
        - 172.31.36.6
        mac-address: 0e:73:fe:56:2a:23
        gateway: 172.31.32.1
        space: alpha
        is-up: true
    constraints: arch=amd64
    hardware: arch=amd64 cores=2 cpu-power=895 mem=8192M root-disk=8192M availability-zone=eu-west-3c
applications:
  ubuntu:
    charm: ubuntu
    base:
      name: ubuntu
      channel: "22.04"
    charm-origin: charmhub
    charm-name: ubuntu
    charm-rev: 25
    charm-channel: latest/stable
    exposed: false
    application-status:
      current: active
      since: 11 Oct 2024 16:00:54+02:00
    units:
      ubuntu/0:
        workload-status:
          current: active
          since: 11 Oct 2024 16:00:54+02:00
        juju-status:
          current: idle
          since: 11 Oct 2024 16:00:56+02:00
          version: 4.0-beta5.1
        leader: true
        machine: "1"
        public-address: 13.39.13.64
    version: "22.04"
storage: {}
controller:
  timestamp: 16:01:30+02:00
```

### LXD
```
juju bootstrap localhost c
juju add-model m
juju add-machine
# check status and wait until machine State is ACTIVE
juju deploy ubuntu
```
Check outputs:
```
juju status
Model  Controller  Cloud/Region         Version      Timestamp
m      c           localhost/localhost  4.0-beta5.1  15:59:17+02:00

App     Version  Status  Scale  Charm   Channel        Rev  Exposed  Message
ubuntu  22.04    active      1  ubuntu  latest/stable   25  no

Unit       Workload  Agent  Machine  Public address  Ports  Message
ubuntu/0*  active    idle   1        10.165.241.210

Machine  State    Address         Inst id        Base          AZ  Message
0        started  10.165.241.126  juju-735fb3-0  ubuntu@22.04      Running
1        started  10.165.241.210  juju-735fb3-1  ubuntu@22.04      Running

juju status --format yaml
model:
  name: m
  type: iaas
  controller: c
  cloud: localhost
  region: localhost
  version: 4.0-beta5.1
  model-status:
    current: available
    since: 11 Oct 2024 15:58:11+02:00
machines:
  "0":
    juju-status:
      current: started
      since: 11 Oct 2024 15:58:58+02:00
      version: 4.0-beta5.1
    hostname: juju-735fb3-0
    dns-name: 10.165.241.126
    ip-addresses:
    - 10.165.241.126
    instance-id: juju-735fb3-0
    machine-status:
      current: running
      message: Running
      since: 11 Oct 2024 15:58:23+02:00
    modification-status:
      current: idle
      since: 11 Oct 2024 15:58:17+02:00
    base:
      name: ubuntu
      channel: "22.04"
    network-interfaces:
      eth0:
        ip-addresses:
        - 10.165.241.126
        mac-address: 00:16:3e:d2:55:8c
        gateway: 10.165.241.1
        space: alpha
        is-up: true
    hardware: arch=amd64 cores=0 mem=0M virt-type=container
  "1":
    juju-status:
      current: started
      since: 11 Oct 2024 15:58:58+02:00
      version: 4.0-beta5.1
    hostname: juju-735fb3-1
    dns-name: 10.165.241.210
    ip-addresses:
    - 10.165.241.210
    instance-id: juju-735fb3-1
    machine-status:
      current: running
      message: Running
      since: 11 Oct 2024 15:58:27+02:00
    modification-status:
      current: idle
      since: 11 Oct 2024 15:58:22+02:00
    base:
      name: ubuntu
      channel: "22.04"
    network-interfaces:
      eth0:
        ip-addresses:
        - 10.165.241.210
        mac-address: 00:16:3e:97:46:2e
        gateway: 10.165.241.1
        space: alpha
        is-up: true
    constraints: arch=amd64
    hardware: arch=amd64 cores=0 mem=0M virt-type=container
applications:
  ubuntu:
    charm: ubuntu
    base:
      name: ubuntu
      channel: "22.04"
    charm-origin: charmhub
    charm-name: ubuntu
    charm-rev: 25
    charm-channel: latest/stable
    exposed: false
    application-status:
      current: active
      since: 11 Oct 2024 15:59:02+02:00
    units:
      ubuntu/0:
        workload-status:
          current: active
          since: 11 Oct 2024 15:59:02+02:00
        juju-status:
          current: idle
          since: 11 Oct 2024 15:59:04+02:00
          version: 4.0-beta5.1
        leader: true
        machine: "1"
        public-address: 10.165.241.210
    version: "22.04"
storage: {}
controller:
  timestamp: 15:59:33+02:00
```
make sure to have correct values on the machines' `instance-id` and `hardware`.

### Migration

Set up two controllers and one model. Migrate that model to the target controller:

```
juju bootstrap localhost tgt
juju bootstrap localhost src
juju add-model m
juju deploy ubuntu
# Wait until ACTIVE
juju migrate m tgt
```
Make sure the status shows everything OK on the target controller and no errors in the logs.

## Links


**Jira card:** JUJU-6703

