### PR TITLE
test: manually add ssh keys

### DIFF
--- a/tests/suites/appdata/appdata.sh
+++ b/tests/suites/appdata/appdata.sh
@@ -4,6 +4,7 @@ run_appdata_basic() {
 	file="${TEST_DIR}/appdata-basic.log"
 
 	ensure "appdata-basic" "${file}"
+	juju add-ssh-key "$(cat ~/.ssh/id_rsa.pub)"
 
 	juju deploy juju-qa-appdata-source
 	juju deploy -n 2 juju-qa-appdata-sink

--- a/tests/suites/backup/backup.sh
+++ b/tests/suites/backup/backup.sh
@@ -29,6 +29,7 @@ run_basic_backup_restore() {
 	file="${TEST_DIR}/test-basic-backup-restore.log"
 
 	ensure "test-basic-backup-restore" "${file}"
+	juju add-ssh-key "$(cat ~/.ssh/id_rsa.pub)"
 
 	echo "Deploy a workload (1 machine)"
 	juju deploy jameinel-ubuntu-lite

--- a/tests/suites/hooks/reboot.sh
+++ b/tests/suites/hooks/reboot.sh
@@ -5,6 +5,7 @@ run_start_hook_fires_after_reboot() {
 	file="${TEST_DIR}/${model_name}.log"
 
 	ensure "${model_name}" "${file}"
+	juju add-ssh-key "$(cat ~/.ssh/id_rsa.pub)"
 
 	# the log messages the test looks for do not appear if root
 	# log level is WARNING.
@@ -81,6 +82,7 @@ run_reboot_monitor_state_cleanup() {
 	file="${TEST_DIR}/${model_name}.log"
 
 	ensure "${model_name}" "${file}"
+	juju add-ssh-key "$(cat ~/.ssh/id_rsa.pub)"
 
 	juju deploy juju-qa-test --base ubuntu@22.04
 	juju deploy juju-qa-dummy-subordinate

--- a/tests/suites/machine/machine.sh
+++ b/tests/suites/machine/machine.sh
@@ -5,6 +5,7 @@ test_log_permissions() {
 	# The following ensures that a bootstrap juju exists
 	file="${TEST_DIR}/test_log_permissions.log"
 	ensure "correct-log" "${file}"
+	juju add-ssh-key "$(cat ~/.ssh/id_rsa.pub)"
 
 	juju deploy juju-qa-test source --base ubuntu@20.04
 

--- a/tests/suites/spaces_ec2/juju_bind.sh
+++ b/tests/suites/spaces_ec2/juju_bind.sh
@@ -4,6 +4,7 @@ run_juju_bind() {
 	file="${TEST_DIR}/test-juju-bind.log"
 
 	ensure "spaces-juju-bind" "${file}"
+	juju add-ssh-key "$(cat ~/.ssh/id_rsa.pub)"
 
 	## Setup spaces
 	juju reload-spaces

--- a/tests/suites/spaces_ec2/machines_in_spaces.sh
+++ b/tests/suites/spaces_ec2/machines_in_spaces.sh
@@ -6,6 +6,7 @@ run_machines_in_spaces() {
 	file="${TEST_DIR}/test-machines-in-spaces.log"
 
 	ensure "machines-in-spaces" "${file}"
+	juju add-ssh-key "$(cat ~/.ssh/id_rsa.pub)"
 
 	echo "Setup spaces"
 	juju reload-spaces

--- a/tests/suites/spaces_ec2/upgrade_charm_with_bind.sh
+++ b/tests/suites/spaces_ec2/upgrade_charm_with_bind.sh
@@ -4,6 +4,7 @@ run_upgrade_charm_with_bind() {
 	file="${TEST_DIR}/test-upgrade-charm-with-bind-ec2.log"
 
 	ensure "spaces-upgrade-charm-with-bind-ec2" "${file}"
+	juju add-ssh-key "$(cat ~/.ssh/id_rsa.pub)"
 
 	## Setup spaces
 	juju reload-spaces


### PR DESCRIPTION
In 4.0, ssh keys are no longer automatically added to new models. A few Bash tests use `juju ssh`, hence we have to manually add the ssh keys here to ensure the test works.

The following gating tests are affected:
test-spaces_ec2-test-upgrade-charm-with-bind-aws
test-spaces_ec2-test-juju-bind-aws
test-spaces_ec2-test-machines-in-spaces-aws
test-machine-test-logs-lxd
test-hooks-test-start-hook-fires-after-reboot-lxd
test-appdata-test-appdata-int-lxd

## QA steps

Run the following test suites:
- `spaces_ec2` (bind tests failing due to unrelated issue with NICs)
- `machine`
- `appdata` (failing due to unrelated issue in relation state tracker)
- `hooks` subtest `test_start_hook_fires_after_reboot` (failing due to unrelated issue with charm lacking manifest)

## Links

**Jira card:** JUJU-6878