### PR TITLE
fix(refresh): add retry mechanism for charm URL origin fetching

### DIFF
--- a/cmd/juju/application/export_test.go
+++ b/cmd/juju/application/export_test.go
@@ -5,6 +5,7 @@ package application
 
 import (
 	"context"
+	"time"
 
 	"github.com/juju/cmd/v4"
 
@@ -43,6 +44,8 @@ func NewRefreshCommandForTest(
 		NewRefresherFactory:   refresher.NewRefresherFactory,
 		ModelConfigClient:     newModelConfigClient,
 		NewCharmHubClient:     newCharmHubClient,
+		RetryGetCharmCount:    1,
+		RetryGetCharmDelay:    1 * time.Millisecond,
 	}
 	cmd.SetClientStore(store)
 	cmd.SetAPIOpen(apiOpen)

--- a/tests/suites/refresh/refresh.sh
+++ b/tests/suites/refresh/refresh.sh
@@ -134,6 +134,11 @@ run_refresh_revision() {
 	# shellcheck disable=SC2059
 	printf "${OUT}\n"
 
+	if echo "${OUT}" | head -n 1 | grep -vq "Added"; then
+		printf "refresh failed, cannot extract the revision number"
+		exit 5
+	fi
+
 	# format: Added charm-store charm "ubuntu", revision 21 in channel stable, to the model
 	revision=$(echo "${OUT}" | awk 'BEGIN{FS=","} {print $2}' | awk 'BEGIN{FS=" "} {print $2}')
 


### PR DESCRIPTION
- Before this commit, the charm refresh process would fail if the charm URL origin was not immediately available.
- After this commit, the refresh process will retry several times before failing

This is motivated by the fact that the migration to dqlite tends to degrade enough the performance to make refresh integration test consistently failing. This change will make the refresh command a bit more resilient (resilient enough to make the CI succeed) through hidden retry.

It is the follow up of https://github.com/juju/juju/pull/18221 after @SimonRichardson comment: https://github.com/juju/juju/pull/18221#issuecomment-2407354929

> Note: I didn't make change in previous juju version because I didn't reproduce the issue in older version.

## QA steps

```sh
cd tests
./main.sh -v refresh run_refresh_revision  
```

## Links

**Jira card:** [JUJU-6891](https://warthogs.atlassian.net/browse/JUJU-6891)



[JUJU-6891]: https://warthogs.atlassian.net/browse/JUJU-6891?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ