### PR TITLE
chore: replace juju/errors with machine/errors in machine domain

### DIFF
--- a/apiserver/facades/agent/provisioner/provisioner.go
+++ b/apiserver/facades/agent/provisioner/provisioner.go
@@ -503,12 +503,12 @@ func (api *ProvisionerAPI) AvailabilityZone(ctx context.Context, args params.Ent
 		}
 		machineUUID, err := api.machineService.GetMachineUUID(ctx, coremachine.Name(tag.Id()))
 		if err != nil {
-			result.Results[i].Error = apiservererrors.ServerError(machineerrors.MachineNotFound)
+			result.Results[i].Error = apiservererrors.ServerError(fmt.Errorf("%w: %w", err, errors.NotFound))
 			continue
 		}
 		hc, err := api.machineService.HardwareCharacteristics(ctx, machineUUID)
 		if errors.Is(err, machineerrors.NotProvisioned) {
-			result.Results[i].Error = apiservererrors.ServerError(errors.NotProvisioned)
+			result.Results[i].Error = apiservererrors.ServerError(errors.NotFound)
 			continue
 		}
 		if err != nil {

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -30,6 +30,7 @@ import (
 	"github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/core/status"
 	applicationerrors "github.com/juju/juju/domain/application/errors"
+	machineerrors "github.com/juju/juju/domain/machine/errors"
 	"github.com/juju/juju/domain/unitstate"
 	"github.com/juju/juju/internal/charm"
 	internalerrors "github.com/juju/juju/internal/errors"
@@ -350,6 +351,9 @@ var getZone = func(ctx context.Context, st *state.State, machineService MachineS
 		return "", errors.Trace(err)
 	}
 	az, err := machineService.AvailabilityZone(ctx, machineUUID)
+	if errors.Is(err, machineerrors.AvailabilityZoneNotFound) {
+		return "", errors.NotProvisioned
+	}
 	if err != nil {
 		return "", errors.Trace(err)
 	}

--- a/domain/machine/errors/errors.go
+++ b/domain/machine/errors/errors.go
@@ -12,6 +12,10 @@ const (
 	// operated on does not exist.
 	MachineNotFound = errors.ConstError("machine not found")
 
+	// AvailabilityZoneNotFound describes an error that occurs when the required
+	// availability zone does not exist.
+	AvailabilityZoneNotFound = errors.ConstError("availability zone not found")
+
 	// NotProvisioned describes an error that occurs when the machine being
 	// operated on is not provisioned yet.
 	NotProvisioned = errors.ConstError("machine not provisioned")

--- a/domain/machine/service/machine_cloud_instance.go
+++ b/domain/machine/service/machine_cloud_instance.go
@@ -37,9 +37,6 @@ func (s *Service) InstanceIDAndName(ctx context.Context, machineUUID string) (st
 // AvailabilityZone returns the availability zone for the specified machine.
 func (s *Service) AvailabilityZone(ctx context.Context, machineUUID string) (string, error) {
 	az, err := s.st.AvailabilityZone(ctx, machineUUID)
-	if errors.Is(err, errors.NotFound) {
-		return "", errors.NotProvisionedf("machine %q is not provisioned", machineUUID)
-	}
 	return az, errors.Annotatef(err, "retrieving availability zone for machine %q", machineUUID)
 }
 

--- a/domain/machine/state/machine_cloud_instance_test.go
+++ b/domain/machine/state/machine_cloud_instance_test.go
@@ -6,7 +6,6 @@ package state
 import (
 	"context"
 
-	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -84,7 +83,7 @@ func (s *stateSuite) TestAvailabilityZoneWithNoMachine(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, err = s.state.AvailabilityZone(context.Background(), machineUUID.String())
-	c.Assert(err, jc.ErrorIs, errors.NotFound)
+	c.Assert(err, jc.ErrorIs, machineerrors.AvailabilityZoneNotFound)
 }
 
 func (s *stateSuite) TestAvailabilityZone(c *gc.C) {
@@ -353,7 +352,7 @@ func (s *stateSuite) TestGetInstanceStatusSuccessWithData(c *gc.C) {
 // NotFound error when the given machine cannot be found.
 func (s *stateSuite) TestGetInstanceStatusNotFoundError(c *gc.C) {
 	_, err := s.state.GetInstanceStatus(context.Background(), "666")
-	c.Assert(err, jc.ErrorIs, errors.NotFound)
+	c.Assert(err, jc.ErrorIs, machineerrors.MachineNotFound)
 }
 
 // TestGetInstanceStatusStatusNotSetError asserts that GetInstanceStatus returns
@@ -403,7 +402,7 @@ func (s *stateSuite) TestSetInstanceStatusSuccessWithData(c *gc.C) {
 // error when the given machine cannot be found.
 func (s *stateSuite) TestSetInstanceStatusError(c *gc.C) {
 	err := s.state.SetInstanceStatus(context.Background(), "666", status.StatusInfo{})
-	c.Check(err, jc.ErrorIs, errors.NotFound)
+	c.Check(err, jc.ErrorIs, machineerrors.MachineNotFound)
 }
 
 // TestInstanceStatusValues asserts the keys and values in the


### PR DESCRIPTION
Some old behavior was still present on the machine domain, where we returned errors.NotFound instead of machineerrors.MachineNotFound for example.

This patch addresses this and only returns domain errors.

_Note: also fixes one domain error that was returned over the wire with a `ServerErr(..)`._

<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://docs.google.com/document/d/1SYUo9G7qZ_jdoVXpUVamS5VCgHmtZ0QA-wZxKoMS-C0 
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Unit tests should pass.

Bootstrapping and deploying on aws (for instance) should work as usual:

```
juju bootstrap aws c
juju add-model m
juju deploy ubunut
```

Status and debug-log should not return or log any errors.

## Links

**Jira card:** JUJU-6902

