### PR TITLE
fix: model migration

### DIFF
--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -478,14 +478,6 @@ func (b *AgentBootstrap) initBootstrapMachine(
 
 	// TODO: move this call to the bootstrap worker
 	m, err := st.AddOneMachine(
-		// By design, we do not have access here to the Dqlite database. Hence
-		// the model config we pass here is not guaranteed to be equal to the
-		// "real" model config. This has potential to cause issues, but at this
-		// stage we are only using this to read the default storage pools, and
-		// furthermore, this call is not creating a machine, it's just
-		// recording the existing machine in state. Long-term, this should be
-		// removed once we move machines over to Dqlite.
-		&modelConfigShim{cfg: stateParams.ControllerModelConfig},
 		state.MachineTemplate{
 			Base:                    state.Base{OS: base.OS, Channel: base.Channel.String()},
 			Nonce:                   agent.BootstrapNonce,
@@ -582,15 +574,4 @@ func machineJobFromParams(job model.MachineJob) (state.MachineJob, error) {
 	default:
 		return -1, errors.Errorf("invalid machine job %q", job)
 	}
-}
-
-// modelConfigShim implements state.ModelConfigService using a constant model
-// config (namely, the controller model config sourced from the state
-// initialization params).
-type modelConfigShim struct {
-	cfg *config.Config
-}
-
-func (m *modelConfigShim) ModelConfig(stdcontext.Context) (*config.Config, error) {
-	return m.cfg, nil
 }

--- a/apiserver/authentication/agent_test.go
+++ b/apiserver/authentication/agent_test.go
@@ -57,14 +57,12 @@ func (s *agentAuthenticatorSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.user = authentication.TaggedUser(user, names.NewUserTag("bobbrown"))
 
-	modelConfigService := s.ControllerDomainServices(c).Config()
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
-	f = f.WithModelConfigService(modelConfigService)
 
 	// add machine for testing machine agent authentication
 	st := s.ControllerModel(c).State()
-	machine, err := st.AddMachine(modelConfigService, state.UbuntuBase("12.10"), state.JobHostUnits)
+	machine, err := st.AddMachine(state.UbuntuBase("12.10"), state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 	nonce, err := internalpassword.RandomPassword()
 	c.Assert(err, jc.ErrorIsNil)
@@ -83,7 +81,7 @@ func (s *agentAuthenticatorSuite) SetUpTest(c *gc.C) {
 		Name:  "wordpress",
 		Charm: f.MakeCharm(c, &factory.CharmParams{Name: "wordpress"}),
 	})
-	unit, err := wordpress.AddUnit(modelConfigService, state.AddUnitParams{})
+	unit, err := wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	s.unit = unit
 	password, err = internalpassword.RandomPassword()

--- a/apiserver/authentication/user_test.go
+++ b/apiserver/authentication/user_test.go
@@ -40,7 +40,7 @@ var _ = gc.Suite(&userAuthenticatorSuite{})
 
 func (s *userAuthenticatorSuite) TestMachineLoginFails(c *gc.C) {
 	// add machine for testing machine agent authentication
-	machine, err := s.ControllerModel(c).State().AddMachine(s.ControllerDomainServices(c).Config(), state.UbuntuBase("12.10"), state.JobHostUnits)
+	machine, err := s.ControllerModel(c).State().AddMachine(state.UbuntuBase("12.10"), state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 	nonce, err := password.RandomPassword()
 	c.Assert(err, jc.ErrorIsNil)
@@ -65,14 +65,13 @@ func (s *userAuthenticatorSuite) TestMachineLoginFails(c *gc.C) {
 func (s *userAuthenticatorSuite) TestUnitLoginFails(c *gc.C) {
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.ControllerDomainServices(c).Config())
 
 	// add a unit for testing unit agent authentication
 	wordpress := f.MakeApplication(c, &factory.ApplicationParams{
 		Name:  "wordpress",
 		Charm: f.MakeCharm(c, &factory.CharmParams{Name: "wordpress"}),
 	})
-	unit, err := wordpress.AddUnit(s.ControllerDomainServices(c).Config(), state.AddUnitParams{})
+	unit, err := wordpress.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	password, err := password.RandomPassword()
 	c.Assert(err, jc.ErrorIsNil)
@@ -369,7 +368,6 @@ func (s *userAuthenticatorSuite) TestRemovedMacaroonUserLogin(c *gc.C) {
 func (s *userAuthenticatorSuite) TestInvalidRelationLogin(c *gc.C) {
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.ControllerDomainServices(c).Config())
 
 	// add relation
 	wordpress := f.MakeApplication(c, &factory.ApplicationParams{

--- a/apiserver/common/crossmodel/crossmodel.go
+++ b/apiserver/common/crossmodel/crossmodel.go
@@ -36,7 +36,6 @@ func PublishRelationChange(
 	ctx context.Context,
 	auth authoriser,
 	backend Backend,
-	modelConfigService ModelConfigService,
 	modelID model.UUID,
 	relationTag,
 	applicationTag names.Tag,
@@ -113,7 +112,7 @@ func PublishRelationChange(
 		return errors.Trace(err)
 	}
 
-	return errors.Trace(handleChangedUnits(modelConfigService, change, applicationTag, rel))
+	return errors.Trace(handleChangedUnits(change, applicationTag, rel))
 }
 
 type authoriser interface {
@@ -211,7 +210,6 @@ func handleDepartedUnits(change params.RemoteRelationChangeEvent, applicationTag
 }
 
 func handleChangedUnits(
-	modelConfigService ModelConfigService,
 	change params.RemoteRelationChangeEvent,
 	applicationTag names.Tag,
 	rel Relation,
@@ -233,7 +231,7 @@ func handleChangedUnits(
 		}
 		if !inScope {
 			logger.Debugf("%s entering scope (%v)", unitTag.Id(), settings)
-			err = ru.EnterScope(modelConfigService, settings)
+			err = ru.EnterScope(settings)
 		} else {
 			logger.Debugf("%s updated settings (%v)", unitTag.Id(), settings)
 			err = ru.ReplaceSettings(settings)

--- a/apiserver/common/crossmodel/interface.go
+++ b/apiserver/common/crossmodel/interface.go
@@ -175,7 +175,7 @@ type RelationUnit interface {
 	// EnterScope ensures that the unit has entered its scope in the
 	// relation. When the unit has already entered its scope, EnterScope
 	// will report success but make no changes to state.
-	EnterScope(modelConfigService state.ModelConfigService, settings map[string]interface{}) error
+	EnterScope(settings map[string]interface{}) error
 
 	// InScope returns whether the relation unit has entered scope and
 	// not left it.

--- a/apiserver/common/modelstatus_test.go
+++ b/apiserver/common/modelstatus_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/machine"
 	storageerrors "github.com/juju/juju/domain/storage/errors"
-	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/envcontext"
 	"github.com/juju/juju/internal/storage"
 	"github.com/juju/juju/internal/storage/provider"
@@ -174,8 +173,7 @@ func (s *modelStatusSuite) TestModelStatus(c *gc.C) {
 		s.authorizer.GetAuthTag().(names.UserTag),
 	)
 
-	otherFactory := factory.NewFactory(otherSt, s.StatePool, testing.FakeControllerConfig()).
-		WithModelConfigService(&stubModelConfigService{cfg: testing.ModelConfig(c)})
+	otherFactory := factory.NewFactory(otherSt, s.StatePool, testing.FakeControllerConfig())
 	otherFactory.MakeMachine(c, &factory.MachineParams{InstanceId: "id-8"})
 	otherFactory.MakeMachine(c, &factory.MachineParams{InstanceId: "id-9"})
 	otherFactory.MakeApplication(c, &factory.ApplicationParams{
@@ -268,8 +266,7 @@ func (s *modelStatusSuite) TestModelStatusCAAS(c *gc.C) {
 	})
 	defer otherSt.Close()
 
-	otherFactory := factory.NewFactory(otherSt, s.StatePool, testing.FakeControllerConfig()).
-		WithModelConfigService(&stubModelConfigService{cfg: testing.ModelConfig(c)})
+	otherFactory := factory.NewFactory(otherSt, s.StatePool, testing.FakeControllerConfig())
 	app := otherFactory.MakeApplication(c, &factory.ApplicationParams{
 		Charm: otherFactory.MakeCharm(c, &factory.CharmParams{Name: "gitlab-k8s", Series: "focal"}),
 	})
@@ -369,12 +366,4 @@ func (statePolicy) StorageServices() (state.StoragePoolGetter, storage.ProviderR
 		dummystorage.StorageProviders(),
 		provider.CommonStorageProviders(),
 	}, nil
-}
-
-type stubModelConfigService struct {
-	cfg *config.Config
-}
-
-func (s *stubModelConfigService) ModelConfig(ctx context.Context) (*config.Config, error) {
-	return s.cfg, nil
 }

--- a/apiserver/facades/agent/agent/agent_test.go
+++ b/apiserver/facades/agent/agent/agent_test.go
@@ -51,19 +51,18 @@ func (s *agentSuite) SetUpTest(c *gc.C) {
 	s.ApiServerSuite.SetUpTest(c)
 
 	st := s.ControllerModel(c).State()
-	modelConfigService := s.ControllerDomainServices(c).Config()
 	var err error
-	s.machine0, err = st.AddMachine(modelConfigService, state.UbuntuBase("12.10"), state.JobManageModel)
+	s.machine0, err = st.AddMachine(state.UbuntuBase("12.10"), state.JobManageModel)
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.machine1, err = st.AddMachine(modelConfigService, state.UbuntuBase("12.10"), state.JobHostUnits)
+	s.machine1, err = st.AddMachine(state.UbuntuBase("12.10"), state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 
 	template := state.MachineTemplate{
 		Base: state.UbuntuBase("12.10"),
 		Jobs: []state.MachineJob{state.JobHostUnits},
 	}
-	s.container, err = st.AddMachineInsideMachine(modelConfigService, template, s.machine1.Id(), instance.LXD)
+	s.container, err = st.AddMachineInsideMachine(template, s.machine1.Id(), instance.LXD)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.resources = common.NewResources()

--- a/apiserver/facades/agent/caasapplication/application.go
+++ b/apiserver/facades/agent/caasapplication/application.go
@@ -218,7 +218,7 @@ func (f *Facade) UnitIntroduction(ctx context.Context, args params.CAASUnitIntro
 	if err != nil {
 		return errResp(err)
 	}
-	_, err = application.UpsertCAASUnit(f.modelConfigService, upsert)
+	_, err = application.UpsertCAASUnit(upsert)
 	if err != nil {
 		return errResp(err)
 	}

--- a/apiserver/facades/agent/caasapplication/application_test.go
+++ b/apiserver/facades/agent/caasapplication/application_test.go
@@ -140,7 +140,7 @@ func (s *CAASApplicationSuite) TestAddUnit(c *gc.C) {
 
 	mc := jc.NewMultiChecker()
 	mc.AddExpr("_.AddUnitParams.PasswordHash", gc.Not(gc.IsNil))
-	c.Assert(s.st.app.Calls()[0].Args[1], mc, state.UpsertCAASUnitParams{
+	c.Assert(s.st.app.Calls()[0].Args[0], mc, state.UpsertCAASUnitParams{
 		AddUnitParams: state.AddUnitParams{
 			ProviderId: strPtr("gitlab-0"),
 			UnitName:   strPtr("gitlab/0"),
@@ -211,7 +211,7 @@ func (s *CAASApplicationSuite) TestReuseUnitByName(c *gc.C) {
 
 	mc := jc.NewMultiChecker()
 	mc.AddExpr("_.AddUnitParams.PasswordHash", gc.Not(gc.IsNil))
-	c.Assert(s.st.app.Calls()[0].Args[1], mc, state.UpsertCAASUnitParams{
+	c.Assert(s.st.app.Calls()[0].Args[0], mc, state.UpsertCAASUnitParams{
 		AddUnitParams: state.AddUnitParams{
 			ProviderId: strPtr("gitlab-0"),
 			UnitName:   strPtr("gitlab/0"),

--- a/apiserver/facades/agent/caasapplication/mock_test.go
+++ b/apiserver/facades/agent/caasapplication/mock_test.go
@@ -122,10 +122,9 @@ type mockApplication struct {
 }
 
 func (a *mockApplication) UpsertCAASUnit(
-	modelConfigService common.ModelConfigService,
 	args state.UpsertCAASUnitParams,
 ) (caasapplication.Unit, error) {
-	a.MethodCall(a, "UpsertCAASUnit", modelConfigService, args)
+	a.MethodCall(a, "UpsertCAASUnit", args)
 	return a.unit, a.NextErr()
 }
 

--- a/apiserver/facades/agent/caasapplication/state.go
+++ b/apiserver/facades/agent/caasapplication/state.go
@@ -6,7 +6,6 @@ package caasapplication
 import (
 	"github.com/juju/names/v5"
 
-	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/network"
@@ -38,7 +37,7 @@ type Model interface {
 // Application provides the subset of application state
 // required by the CAAS application facade.
 type Application interface {
-	UpsertCAASUnit(modelConfigService common.ModelConfigService, args state.UpsertCAASUnitParams) (Unit, error)
+	UpsertCAASUnit(args state.UpsertCAASUnitParams) (Unit, error)
 }
 
 // Charm provides the subset of charm state required by the
@@ -92,10 +91,9 @@ func (a applicationShim) AllUnits() ([]Unit, error) {
 }
 
 func (a applicationShim) UpsertCAASUnit(
-	modelConfigService common.ModelConfigService,
 	args state.UpsertCAASUnitParams,
 ) (Unit, error) {
-	u, err := a.Application.UpsertCAASUnit(modelConfigService, args)
+	u, err := a.Application.UpsertCAASUnit(args)
 	if err != nil {
 		return nil, err
 	}

--- a/apiserver/facades/agent/deployer/deployer_test.go
+++ b/apiserver/facades/agent/deployer/deployer_test.go
@@ -99,22 +99,21 @@ func (s *deployerSuite) SetUpTest(c *gc.C) {
 	s.ApiServerSuite.SetUpTest(c)
 
 	st := s.ControllerModel(c).State()
-	modelConfigService := s.ControllerDomainServices(c).Config()
 	var err error
 
 	// The two known machines now contain the following units:
 	// machine 0 (not authorized): mysql/1 (principal1)
 	// machine 1 (authorized): mysql/0 (principal0), logging/0 (subordinate0)
 
-	s.machine0, err = st.AddMachine(modelConfigService, state.UbuntuBase("12.10"), state.JobManageModel, state.JobHostUnits)
+	s.machine0, err = st.AddMachine(state.UbuntuBase("12.10"), state.JobManageModel, state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.machine1, err = st.AddMachine(modelConfigService, state.UbuntuBase("12.10"), state.JobHostUnits)
+	s.machine1, err = st.AddMachine(state.UbuntuBase("12.10"), state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
-	f = f.WithModelConfigService(modelConfigService)
+
 	s.service0 = f.MakeApplication(c, nil)
 
 	f.MakeApplication(c, &factory.ApplicationParams{
@@ -126,19 +125,19 @@ func (s *deployerSuite) SetUpTest(c *gc.C) {
 	rel, err := st.AddRelation(eps...)
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.principal0, err = s.service0.AddUnit(modelConfigService, state.AddUnitParams{})
+	s.principal0, err = s.service0.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.principal0.AssignToMachine(modelConfigService, s.machine1)
+	err = s.principal0.AssignToMachine(s.machine1)
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.principal1, err = s.service0.AddUnit(modelConfigService, state.AddUnitParams{})
+	s.principal1, err = s.service0.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.principal1.AssignToMachine(modelConfigService, s.machine0)
+	err = s.principal1.AssignToMachine(s.machine0)
 	c.Assert(err, jc.ErrorIsNil)
 
 	relUnit0, err := rel.Unit(s.principal0)
 	c.Assert(err, jc.ErrorIsNil)
-	err = relUnit0.EnterScope(modelConfigService, nil)
+	err = relUnit0.EnterScope(nil)
 	c.Assert(err, jc.ErrorIsNil)
 	s.subordinate0, err = st.Unit("logging/0")
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/agent/machine/package_test.go
+++ b/apiserver/facades/agent/machine/package_test.go
@@ -34,12 +34,12 @@ func (s *commonSuite) SetUpTest(c *gc.C) {
 	s.ApiServerSuite.SetUpTest(c)
 
 	st := s.ControllerModel(c).State()
-	modelConfigService := s.ControllerDomainServices(c).Config()
+
 	var err error
-	s.machine0, err = st.AddMachine(modelConfigService, state.UbuntuBase("12.10"), state.JobManageModel)
+	s.machine0, err = st.AddMachine(state.UbuntuBase("12.10"), state.JobManageModel)
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.machine1, err = st.AddMachine(modelConfigService, state.UbuntuBase("12.10"), state.JobHostUnits)
+	s.machine1, err = st.AddMachine(state.UbuntuBase("12.10"), state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Create a FakeAuthorizer so we can check permissions,

--- a/apiserver/facades/agent/provisioner/container_test.go
+++ b/apiserver/facades/agent/provisioner/container_test.go
@@ -32,7 +32,6 @@ func (s *containerProvisionerSuite) SetUpTest(c *gc.C) {
 func addContainerToMachine(
 	c *gc.C,
 	st *state.State,
-	modelConfigService provisioner.ModelConfigService,
 	machine *state.Machine,
 ) *state.Machine {
 	// Add a container machine with machine as its host.
@@ -40,7 +39,7 @@ func addContainerToMachine(
 		Base: state.UbuntuBase("12.10"),
 		Jobs: []state.MachineJob{state.JobHostUnits},
 	}
-	container, err := st.AddMachineInsideMachine(modelConfigService, containerTemplate, machine.Id(), instance.LXD)
+	container, err := st.AddMachineInsideMachine(containerTemplate, machine.Id(), instance.LXD)
 	c.Assert(err, jc.ErrorIsNil)
 	return container
 }
@@ -50,10 +49,9 @@ func (s *containerProvisionerSuite) TestPrepareContainerInterfaceInfoPermission(
 
 	// Login as a machine agent for machine 1, which has a container put on it
 	st := s.ControllerModel(c).State()
-	modelConfigService := s.ControllerDomainServices(c).Config()
-	addContainerToMachine(c, st, modelConfigService, s.machines[1])
-	addContainerToMachine(c, st, modelConfigService, s.machines[1])
-	addContainerToMachine(c, st, modelConfigService, s.machines[2])
+	addContainerToMachine(c, st, s.machines[1])
+	addContainerToMachine(c, st, s.machines[1])
+	addContainerToMachine(c, st, s.machines[2])
 
 	anAuthorizer := s.authorizer
 	anAuthorizer.Controller = false
@@ -108,10 +106,9 @@ func (s *containerProvisionerSuite) TestHostChangesForContainersPermission(c *gc
 
 	// Login as a machine agent for machine 1, which has a container put on it
 	st := s.ControllerModel(c).State()
-	modelConfigService := s.ControllerDomainServices(c).Config()
-	addContainerToMachine(c, st, modelConfigService, s.machines[1])
-	addContainerToMachine(c, st, modelConfigService, s.machines[1])
-	addContainerToMachine(c, st, modelConfigService, s.machines[2])
+	addContainerToMachine(c, st, s.machines[1])
+	addContainerToMachine(c, st, s.machines[1])
+	addContainerToMachine(c, st, s.machines[2])
 
 	anAuthorizer := s.authorizer
 	anAuthorizer.Controller = false

--- a/apiserver/facades/agent/provisioner/provisioner_integration_test.go
+++ b/apiserver/facades/agent/provisioner/provisioner_integration_test.go
@@ -89,13 +89,13 @@ func (s *provisionerSuite) setUpTest(c *gc.C, withController bool) {
 		controllerConfig, err := controllerConfigService.ControllerConfig(context.Background())
 		c.Assert(err, jc.ErrorIsNil)
 
-		s.machines = append(s.machines, testing.AddControllerMachine(c, st, controllerModelConfigService, controllerConfig))
+		s.machines = append(s.machines, testing.AddControllerMachine(c, st, controllerConfig))
 	}
 
 	s.domainServices = s.ControllerDomainServices(c)
 
 	for i := 0; i < 5; i++ {
-		m, err := st.AddMachine(controllerModelConfigService, state.UbuntuBase("12.10"), state.JobHostUnits)
+		m, err := st.AddMachine(state.UbuntuBase("12.10"), state.JobHostUnits)
 		c.Check(err, jc.ErrorIsNil)
 		_, err = s.domainServices.Machine().CreateMachine(context.Background(), coremachine.Name(m.Id()))
 		c.Assert(err, jc.ErrorIsNil)
@@ -131,12 +131,6 @@ type withoutControllerSuite struct {
 }
 
 var _ = gc.Suite(&withoutControllerSuite{})
-
-// modelConfigService is a convenience function to get the controller model's
-// model config service inside a test.
-func (s *withoutControllerSuite) modelConfigService(c *gc.C) provisioner.ModelConfigService {
-	return s.ControllerDomainServices(c).Config()
-}
 
 func (s *withoutControllerSuite) SetUpTest(c *gc.C) {
 	s.setUpTest(c, false)
@@ -261,7 +255,7 @@ func (s *withoutControllerSuite) TestLifeAsMachineAgent(c *gc.C) {
 	}
 	var containers []*state.Machine
 	for i := 0; i < 3; i++ {
-		container, err := st.AddMachineInsideMachine(s.modelConfigService(c), template, s.machines[0].Id(), instance.LXD)
+		container, err := st.AddMachineInsideMachine(template, s.machines[0].Id(), instance.LXD)
 		c.Check(err, jc.ErrorIsNil)
 		containers = append(containers, container)
 	}
@@ -1018,7 +1012,6 @@ func (s *withoutControllerSuite) TestKeepInstance(c *gc.C) {
 func (s *withoutControllerSuite) TestDistributionGroup(c *gc.C) {
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService(c))
 
 	st := s.ControllerModel(c).State()
 	domainServicesGetter := s.DomainServicesGetter(c, s.NoopObjectStore(c))
@@ -1030,9 +1023,9 @@ func (s *withoutControllerSuite) TestDistributionGroup(c *gc.C) {
 			Charm: f.MakeCharm(c, &factory.CharmParams{Name: name}),
 		})
 		for _, m := range machines {
-			unit, err := app.AddUnit(s.modelConfigService(c), state.AddUnitParams{})
+			unit, err := app.AddUnit(state.AddUnitParams{})
 			c.Assert(err, jc.ErrorIsNil)
-			err = unit.AssignToMachine(s.modelConfigService(c), m)
+			err = unit.AssignToMachine(m)
 			c.Assert(err, jc.ErrorIsNil)
 			units = append(units, unit)
 		}
@@ -1064,7 +1057,7 @@ func (s *withoutControllerSuite) TestDistributionGroup(c *gc.C) {
 	setProvisioned("3")
 
 	// Add a few controllers, provision two of them.
-	_, _, err = st.EnableHA(s.modelConfigService(c), 3, constraints.Value{}, state.UbuntuBase("12.10"), nil)
+	_, _, err = st.EnableHA(3, constraints.Value{}, state.UbuntuBase("12.10"), nil)
 	c.Assert(err, jc.ErrorIsNil)
 	// Manually add the controller machines on the domain:
 	_, err = machineService.CreateMachine(context.Background(), coremachine.Name("5"))
@@ -1087,7 +1080,7 @@ func (s *withoutControllerSuite) TestDistributionGroup(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	ru, err := rel.Unit(mysqlUnit)
 	c.Assert(err, jc.ErrorIsNil)
-	err = ru.EnterScope(s.modelConfigService(c), nil)
+	err = ru.EnterScope(nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	args := params.Entities{Entities: []params.Entity{
@@ -1175,7 +1168,6 @@ func (s *withoutControllerSuite) TestDistributionGroupMachineAgentAuth(c *gc.C) 
 func (s *withoutControllerSuite) TestDistributionGroupByMachineId(c *gc.C) {
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService(c))
 
 	addUnits := func(name string, machines ...*state.Machine) (units []*state.Unit) {
 		app := f.MakeApplication(c, &factory.ApplicationParams{
@@ -1183,9 +1175,9 @@ func (s *withoutControllerSuite) TestDistributionGroupByMachineId(c *gc.C) {
 			Charm: f.MakeCharm(c, &factory.CharmParams{Name: name}),
 		})
 		for _, m := range machines {
-			unit, err := app.AddUnit(s.modelConfigService(c), state.AddUnitParams{})
+			unit, err := app.AddUnit(state.AddUnitParams{})
 			c.Assert(err, jc.ErrorIsNil)
-			err = unit.AssignToMachine(s.modelConfigService(c), m)
+			err = unit.AssignToMachine(m)
 			c.Assert(err, jc.ErrorIsNil)
 			units = append(units, unit)
 		}
@@ -1213,7 +1205,7 @@ func (s *withoutControllerSuite) TestDistributionGroupByMachineId(c *gc.C) {
 	setProvisioned("3")
 
 	// Add a few controllers, provision two of them.
-	_, _, err = s.ControllerModel(c).State().EnableHA(s.modelConfigService(c), 3, constraints.Value{}, state.UbuntuBase("12.10"), nil)
+	_, _, err = s.ControllerModel(c).State().EnableHA(3, constraints.Value{}, state.UbuntuBase("12.10"), nil)
 	c.Assert(err, jc.ErrorIsNil)
 	setProvisioned("5")
 	setProvisioned("7")
@@ -1308,7 +1300,7 @@ func (s *withoutControllerSuite) TestConstraints(c *gc.C) {
 		Jobs:        []state.MachineJob{state.JobHostUnits},
 		Constraints: cons,
 	}
-	consMachine, err := s.ControllerModel(c).State().AddOneMachine(s.modelConfigService(c), template)
+	consMachine, err := s.ControllerModel(c).State().AddOneMachine(template)
 	c.Assert(err, jc.ErrorIsNil)
 
 	machine0Constraints, err := s.machines[0].Constraints()
@@ -1362,7 +1354,7 @@ func (s *withoutControllerSuite) TestSetInstanceInfo(c *gc.C) {
 	err = s.machines[0].SetInstanceInfo("i-am", "", "fake_nonce", &hwChars, nil, nil, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
-	volumesMachine, err := st.AddOneMachine(s.modelConfigService(c), state.MachineTemplate{
+	volumesMachine, err := st.AddOneMachine(state.MachineTemplate{
 		Base: state.UbuntuBase("12.10"),
 		Jobs: []state.MachineJob{state.JobHostUnits},
 		Volumes: []state.HostVolumeParams{{
@@ -1417,7 +1409,10 @@ func (s *withoutControllerSuite) TestSetInstanceInfo(c *gc.C) {
 			}},
 			{Error: nil},
 			{Error: nil},
-			{Error: nil},
+			{Error: &params.Error{
+				Message: `cannot record provisioning info for "i-am-also": cannot set info for volume "0": volume "0" not found`,
+				Code:    params.CodeNotFound,
+			}},
 			{Error: apiservertesting.NotFoundError("machine 42")},
 			{Error: apiservertesting.ErrUnauthorized},
 			{Error: apiservertesting.ErrUnauthorized},
@@ -1443,14 +1438,19 @@ func (s *withoutControllerSuite) TestSetInstanceInfo(c *gc.C) {
 	volumeAttachments, err := sb.MachineVolumeAttachments(volumesMachine.MachineTag())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(volumeAttachments, gc.HasLen, 1)
+
+	// Note (stickupkid): This is all incorrect, because we are no longer
+	// using model-config for fallback storage pools. This should be fixed
+	// once that's implemented in the new storage code.
+	// See: https://warthogs.atlassian.net/browse/JUJU-6933
 	volumeAttachmentInfo, err := volumeAttachments[0].Info()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(volumeAttachmentInfo, gc.Equals, state.VolumeAttachmentInfo{DeviceName: "sda"})
+	c.Assert(err, jc.ErrorIs, errors.NotProvisioned)
+	c.Assert(volumeAttachmentInfo, gc.Equals, state.VolumeAttachmentInfo{})
 	volume, err := sb.Volume(volumeAttachments[0].Volume())
 	c.Assert(err, jc.ErrorIsNil)
 	volumeInfo, err := volume.Info()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(volumeInfo, gc.Equals, state.VolumeInfo{VolumeId: "vol-0", Pool: "static-pool", Size: 1234})
+	c.Assert(err, jc.ErrorIs, errors.NotProvisioned)
+	c.Assert(volumeInfo, gc.Equals, state.VolumeInfo{})
 
 	// Verify the machine without requested volumes still has no volume
 	// attachments recorded in state.

--- a/apiserver/facades/agent/provisioner/provisioninginfo_test.go
+++ b/apiserver/facades/agent/provisioner/provisioninginfo_test.go
@@ -51,7 +51,7 @@ func (s *withoutControllerSuite) TestProvisioningInfoWithStorage(c *gc.C) {
 			{Volume: state.VolumeParams{Size: 2000, Pool: "static-pool"}},
 		},
 	}
-	placementMachine, err := st.AddOneMachine(s.modelConfigService(c), template)
+	placementMachine, err := st.AddOneMachine(template)
 	c.Assert(err, jc.ErrorIsNil)
 
 	args := params.Entities{Entities: []params.Entity{
@@ -148,7 +148,7 @@ func (s *withoutControllerSuite) TestProvisioningInfoRootDiskVolume(c *gc.C) {
 		Constraints: constraints.MustParse("root-disk-source=static-pool"),
 		Jobs:        []state.MachineJob{state.JobHostUnits},
 	}
-	machine, err := st.AddOneMachine(s.modelConfigService(c), template)
+	machine, err := st.AddOneMachine(template)
 	c.Assert(err, jc.ErrorIsNil)
 
 	args := params.Entities{Entities: []params.Entity{
@@ -176,7 +176,7 @@ func (s *withoutControllerSuite) TestProvisioningInfoWithMultiplePositiveSpaceCo
 		Constraints: cons,
 		Placement:   "valid",
 	}
-	placementMachine, err := st.AddOneMachine(s.modelConfigService(c), template)
+	placementMachine, err := st.AddOneMachine(template)
 	c.Assert(err, jc.ErrorIsNil)
 
 	args := params.Entities{Entities: []params.Entity{
@@ -241,7 +241,6 @@ func (s *withoutControllerSuite) TestProvisioningInfoWithEndpointBindings(c *gc.
 
 	st := s.ControllerModel(c).State()
 	wordpressMachine, err := st.AddOneMachine(
-		s.modelConfigService(c),
 		state.MachineTemplate{
 			Base: state.UbuntuBase("12.10"),
 			Jobs: []state.MachineJob{state.JobHostUnits},
@@ -251,7 +250,6 @@ func (s *withoutControllerSuite) TestProvisioningInfoWithEndpointBindings(c *gc.
 
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService(c))
 
 	// Simulates running `juju deploy --bind "..."`.
 	bindings := map[string]string{
@@ -263,9 +261,9 @@ func (s *withoutControllerSuite) TestProvisioningInfoWithEndpointBindings(c *gc.
 		EndpointBindings: bindings,
 	})
 
-	wordpressUnit, err := wordpressService.AddUnit(s.modelConfigService(c), state.AddUnitParams{})
+	wordpressUnit, err := wordpressService.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
-	err = wordpressUnit.AssignToMachine(s.modelConfigService(c), wordpressMachine)
+	err = wordpressUnit.AssignToMachine(wordpressMachine)
 	c.Assert(err, jc.ErrorIsNil)
 
 	args := params.Entities{Entities: []params.Entity{
@@ -329,7 +327,6 @@ func (s *withoutControllerSuite) TestProvisioningInfoWithEndpointBindingsAndNoAl
 
 	st := s.ControllerModel(c).State()
 	wordpressMachine, err := st.AddOneMachine(
-		s.modelConfigService(c),
 		state.MachineTemplate{
 			Base: state.UbuntuBase("12.10"),
 			Jobs: []state.MachineJob{state.JobHostUnits},
@@ -339,7 +336,6 @@ func (s *withoutControllerSuite) TestProvisioningInfoWithEndpointBindingsAndNoAl
 
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService(c))
 
 	// Simulates running `juju deploy --bind "..."`.
 	bindings := map[string]string{
@@ -351,9 +347,9 @@ func (s *withoutControllerSuite) TestProvisioningInfoWithEndpointBindingsAndNoAl
 		EndpointBindings: bindings,
 	})
 
-	wordpressUnit, err := wordpressService.AddUnit(s.modelConfigService(c), state.AddUnitParams{})
+	wordpressUnit, err := wordpressService.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
-	err = wordpressUnit.AssignToMachine(s.modelConfigService(c), wordpressMachine)
+	err = wordpressUnit.AssignToMachine(wordpressMachine)
 	c.Assert(err, jc.ErrorIsNil)
 
 	args := params.Entities{Entities: []params.Entity{
@@ -386,7 +382,6 @@ func (s *withoutControllerSuite) TestConflictingNegativeConstraintWithBindingErr
 	st := s.ControllerModel(c).State()
 	cons := constraints.MustParse("spaces=^space1")
 	wordpressMachine, err := st.AddOneMachine(
-		s.modelConfigService(c),
 		state.MachineTemplate{
 			Base:        state.UbuntuBase("12.10"),
 			Jobs:        []state.MachineJob{state.JobHostUnits},
@@ -397,7 +392,6 @@ func (s *withoutControllerSuite) TestConflictingNegativeConstraintWithBindingErr
 
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService(c))
 
 	// Simulates running `juju deploy --bind "..."`.
 	bindings := map[string]string{
@@ -408,9 +402,9 @@ func (s *withoutControllerSuite) TestConflictingNegativeConstraintWithBindingErr
 		Charm:            f.MakeCharm(c, &factory.CharmParams{Name: "wordpress"}),
 		EndpointBindings: bindings,
 	})
-	wordpressUnit, err := wordpressService.AddUnit(s.modelConfigService(c), state.AddUnitParams{})
+	wordpressUnit, err := wordpressService.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
-	err = wordpressUnit.AssignToMachine(s.modelConfigService(c), wordpressMachine)
+	err = wordpressUnit.AssignToMachine(wordpressMachine)
 	c.Assert(err, jc.ErrorIsNil)
 
 	args := params.Entities{Entities: []params.Entity{
@@ -431,7 +425,7 @@ func (s *withoutControllerSuite) TestConflictingNegativeConstraintWithBindingErr
 func (s *withoutControllerSuite) TestNoSpaceConstraintsProvidedSpaceTopologyEmpty(c *gc.C) {
 	st := s.ControllerModel(c).State()
 	wordpressMachine, err := st.AddOneMachine(
-		s.modelConfigService(c),
+
 		state.MachineTemplate{
 			Base: state.UbuntuBase("12.10"),
 			Jobs: []state.MachineJob{state.JobHostUnits},
@@ -441,7 +435,6 @@ func (s *withoutControllerSuite) TestNoSpaceConstraintsProvidedSpaceTopologyEmpt
 
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService(c))
 
 	// Simulates running `juju deploy --bind "..."`.
 	bindings := map[string]string{
@@ -452,9 +445,9 @@ func (s *withoutControllerSuite) TestNoSpaceConstraintsProvidedSpaceTopologyEmpt
 		Charm:            f.MakeCharm(c, &factory.CharmParams{Name: "wordpress"}),
 		EndpointBindings: bindings,
 	})
-	wordpressUnit, err := wordpressService.AddUnit(s.modelConfigService(c), state.AddUnitParams{})
+	wordpressUnit, err := wordpressService.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
-	err = wordpressUnit.AssignToMachine(s.modelConfigService(c), wordpressMachine)
+	err = wordpressUnit.AssignToMachine(wordpressMachine)
 	c.Assert(err, jc.ErrorIsNil)
 
 	args := params.Entities{Entities: []params.Entity{
@@ -484,7 +477,7 @@ func (s *withoutControllerSuite) TestAlphaSpaceConstraintsProvidedExplicitly(c *
 
 	cons := constraints.MustParse("spaces=alpha")
 	wordpressMachine, err := st.AddOneMachine(
-		s.modelConfigService(c),
+
 		state.MachineTemplate{
 			Base:        state.UbuntuBase("12.10"),
 			Jobs:        []state.MachineJob{state.JobHostUnits},
@@ -495,7 +488,6 @@ func (s *withoutControllerSuite) TestAlphaSpaceConstraintsProvidedExplicitly(c *
 
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService(c))
 
 	// Simulates running `juju deploy --bind "..."`.
 	bindings := map[string]string{
@@ -506,9 +498,9 @@ func (s *withoutControllerSuite) TestAlphaSpaceConstraintsProvidedExplicitly(c *
 		Charm:            f.MakeCharm(c, &factory.CharmParams{Name: "wordpress"}),
 		EndpointBindings: bindings,
 	})
-	wordpressUnit, err := wordpressService.AddUnit(s.modelConfigService(c), state.AddUnitParams{})
+	wordpressUnit, err := wordpressService.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
-	err = wordpressUnit.AssignToMachine(s.modelConfigService(c), wordpressMachine)
+	err = wordpressUnit.AssignToMachine(wordpressMachine)
 	c.Assert(err, jc.ErrorIsNil)
 
 	args := params.Entities{Entities: []params.Entity{
@@ -625,7 +617,7 @@ func (s *withoutControllerSuite) TestProvisioningInfoWithUnsuitableSpacesConstra
 		Constraints: consMissingSpace,
 		Placement:   "valid",
 	}}
-	placementMachines, err := st.AddMachines(s.modelConfigService(c), templates...)
+	placementMachines, err := st.AddMachines(templates...)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(placementMachines, gc.HasLen, 2)
 
@@ -650,7 +642,7 @@ func (s *withoutControllerSuite) TestProvisioningInfoWithUnsuitableSpacesConstra
 func (s *withoutControllerSuite) TestProvisioningInfoWithLXDProfile(c *gc.C) {
 	st := s.ControllerModel(c).State()
 	profileMachine, err := st.AddOneMachine(
-		s.modelConfigService(c),
+
 		state.MachineTemplate{
 			Base: state.UbuntuBase("12.10"),
 			Jobs: []state.MachineJob{state.JobHostUnits},
@@ -660,15 +652,15 @@ func (s *withoutControllerSuite) TestProvisioningInfoWithLXDProfile(c *gc.C) {
 
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService(c))
+
 	ch := f.MakeCharm(c, &factory.CharmParams{Name: "lxd-profile"})
 	profileService := f.MakeApplication(c, &factory.ApplicationParams{
 		Name:  "lxd-profile",
 		Charm: ch,
 	})
-	profileUnit, err := profileService.AddUnit(s.modelConfigService(c), state.AddUnitParams{})
+	profileUnit, err := profileService.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
-	err = profileUnit.AssignToMachine(s.modelConfigService(c), profileMachine)
+	err = profileUnit.AssignToMachine(profileMachine)
 	c.Assert(err, jc.ErrorIsNil)
 
 	args := params.Entities{Entities: []params.Entity{
@@ -719,7 +711,7 @@ func (s *withoutControllerSuite) TestStorageProviderFallbackToType(c *gc.C) {
 		},
 	}
 	st := s.ControllerModel(c).State()
-	placementMachine, err := st.AddOneMachine(s.modelConfigService(c), template)
+	placementMachine, err := st.AddOneMachine(template)
 	c.Assert(err, jc.ErrorIsNil)
 
 	args := params.Entities{Entities: []params.Entity{
@@ -778,7 +770,7 @@ func (s *withoutControllerSuite) TestStorageProviderVolumes(c *gc.C) {
 			{Volume: state.VolumeParams{Size: 1000, Pool: "modelscoped"}},
 		},
 	}
-	machine, err := st.AddOneMachine(s.modelConfigService(c), template)
+	machine, err := st.AddOneMachine(template)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Provision just one of the volumes, but neither of the attachments.
@@ -834,7 +826,7 @@ func (s *withoutControllerSuite) TestProviderInfoCloudInitUserData(c *gc.C) {
 		Jobs: []state.MachineJob{state.JobHostUnits},
 	}
 	st := s.ControllerModel(c).State()
-	m, err := st.AddOneMachine(s.modelConfigService(c), template)
+	m, err := st.AddOneMachine(template)
 	c.Assert(err, jc.ErrorIsNil)
 
 	args := params.Entities{Entities: []params.Entity{

--- a/apiserver/facades/agent/storageprovisioner/storageprovisioner_caas_test.go
+++ b/apiserver/facades/agent/storageprovisioner/storageprovisioner_caas_test.go
@@ -100,7 +100,6 @@ func (s *caasProvisionerSuite) SetUpTest(c *gc.C) {
 func (s *caasProvisionerSuite) setupFilesystems(c *gc.C) {
 	f, release := s.NewFactory(c, s.st.ModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService(c))
 
 	ch := f.MakeCharm(c, &factory.CharmParams{
 		Name:   "storage-filesystem",
@@ -160,7 +159,6 @@ func (s *caasProvisionerSuite) setupFilesystems(c *gc.C) {
 func (s *caasProvisionerSuite) TestWatchApplications(c *gc.C) {
 	f, release := s.NewFactory(c, s.st.ModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService(c))
 
 	ch := f.MakeCharm(c, &factory.CharmParams{
 		Name:   "storage-filesystem",

--- a/apiserver/facades/agent/storageprovisioner/storageprovisioner_iaas_test.go
+++ b/apiserver/facades/agent/storageprovisioner/storageprovisioner_iaas_test.go
@@ -104,7 +104,6 @@ func (s *iaasProvisionerSuite) newApi(c *gc.C, blockDeviceService storageprovisi
 func (s *iaasProvisionerSuite) setupVolumes(c *gc.C) {
 	f, release := s.NewFactory(c, s.st.ModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService(c))
 
 	machineService := s.ControllerDomainServices(c).Machine()
 	machine0UUID, err := machineService.CreateMachine(context.Background(), machine.Name("0"))
@@ -152,7 +151,6 @@ func (s *iaasProvisionerSuite) setupVolumes(c *gc.C) {
 	// TODO(axw) extend testing/factory to allow creating unprovisioned
 	// machines.
 	_, err = s.st.AddOneMachine(
-		s.modelConfigService(c),
 		state.MachineTemplate{
 			Base: state.UbuntuBase("12.10"),
 			Jobs: []state.MachineJob{state.JobHostUnits},
@@ -169,7 +167,6 @@ func (s *iaasProvisionerSuite) setupVolumes(c *gc.C) {
 func (s *iaasProvisionerSuite) setupFilesystems(c *gc.C) {
 	f, release := s.NewFactory(c, s.st.ModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService(c))
 
 	machineService := s.ControllerDomainServices(c).Machine()
 	machine0UUID, err := machineService.CreateMachine(context.Background(), machine.Name("0"))
@@ -214,7 +211,6 @@ func (s *iaasProvisionerSuite) setupFilesystems(c *gc.C) {
 	// TODO(axw) extend testing/factory to allow creating unprovisioned
 	// machines.
 	_, err = s.st.AddOneMachine(
-		s.modelConfigService(c),
 		state.MachineTemplate{
 			Base: state.UbuntuBase("12.10"),
 			Jobs: []state.MachineJob{state.JobHostUnits},
@@ -491,7 +487,6 @@ func (s *iaasProvisionerSuite) TestRemoveVolumeParams(c *gc.C) {
 
 	f, release := s.NewFactory(c, s.st.ModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService(c))
 
 	// Deploy an application that will create a storage instance,
 	// so we can release the storage and show the effects on the
@@ -631,7 +626,6 @@ func (s *iaasProvisionerSuite) TestRemoveFilesystemParams(c *gc.C) {
 
 	f, release := s.NewFactory(c, s.st.ModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService(c))
 
 	// Deploy an application that will create a storage instance,
 	// so we can release the storage and show the effects on the
@@ -962,7 +956,6 @@ func (s *iaasProvisionerSuite) TestWatchVolumes(c *gc.C) {
 
 	f, release := s.NewFactory(c, s.st.ModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService(c))
 
 	f.MakeMachine(c, nil)
 	c.Assert(s.resources.Count(), gc.Equals, 0)
@@ -1008,7 +1001,6 @@ func (s *iaasProvisionerSuite) TestWatchVolumeAttachments(c *gc.C) {
 
 	f, release := s.NewFactory(c, s.st.ModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService(c))
 
 	f.MakeMachine(c, nil)
 	c.Assert(s.resources.Count(), gc.Equals, 0)
@@ -1176,7 +1168,6 @@ func (s *iaasProvisionerSuite) TestWatchFilesystemAttachments(c *gc.C) {
 func (s *iaasProvisionerSuite) TestWatchBlockDevices(c *gc.C) {
 	f, release := s.NewFactory(c, s.st.ModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService(c))
 
 	f.MakeMachine(c, nil)
 	c.Assert(s.resources.Count(), gc.Equals, 0)
@@ -1223,7 +1214,6 @@ func (s *iaasProvisionerSuite) TestVolumeBlockDevices(c *gc.C) {
 
 	f, release := s.NewFactory(c, s.st.ModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService(c))
 
 	f.MakeMachine(c, nil)
 
@@ -1278,7 +1268,6 @@ func (s *iaasProvisionerSuite) TestVolumeBlockDevicesPlanBlockInfoSet(c *gc.C) {
 
 	f, release := s.NewFactory(c, s.st.ModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService(c))
 
 	f.MakeMachine(c, nil)
 

--- a/apiserver/facades/agent/storageprovisioner/storageprovisioner_test.go
+++ b/apiserver/facades/agent/storageprovisioner/storageprovisioner_test.go
@@ -32,12 +32,6 @@ type provisionerSuite struct {
 	storageBackend storageprovisioner.StorageBackend
 }
 
-// modelConfigService is a convenience function to get the controller model's
-// model config service inside a test.
-func (s *provisionerSuite) modelConfigService(c *gc.C) storageprovisioner.ModelConfigService {
-	return s.ControllerDomainServices(c).Config()
-}
-
 func (s *provisionerSuite) SetUpTest(c *gc.C) {
 	s.ApiServerSuite.SetUpTest(c)
 }

--- a/apiserver/facades/agent/unitassigner/register.go
+++ b/apiserver/facades/agent/unitassigner/register.go
@@ -26,7 +26,7 @@ func newFacade(ctx facade.ModelContext) (*API, error) {
 
 	setter := common.NewStatusSetter(&common.UnitAgentFinder{EntityFinder: st}, common.AuthAlways())
 	return &API{
-		st:             stateShim{State: st, modelConfigService: domainServices.Config()},
+		st:             stateShim{State: st},
 		machineService: domainServices.Machine(),
 		networkService: domainServices.Network(),
 		stubService:    domainServices.Stub(),

--- a/apiserver/facades/agent/unitassigner/state.go
+++ b/apiserver/facades/agent/unitassigner/state.go
@@ -6,18 +6,16 @@ package unitassigner
 import (
 	"github.com/juju/errors"
 
-	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/state"
 )
 
 type stateShim struct {
 	*state.State
-	modelConfigService common.ModelConfigService
 }
 
 func (s stateShim) AssignStagedUnits(allSpaces network.SpaceInfos, ids []string) ([]state.UnitAssignmentResult, error) {
-	return s.State.AssignStagedUnits(s.modelConfigService, allSpaces, ids)
+	return s.State.AssignStagedUnits(allSpaces, ids)
 }
 
 func (s stateShim) AssignedMachineId(unit string) (string, error) {

--- a/apiserver/facades/agent/uniter/export_test.go
+++ b/apiserver/facades/agent/uniter/export_test.go
@@ -71,7 +71,7 @@ type patcher interface {
 }
 
 func PatchGetStorageStateError(patcher patcher, err error) {
-	patcher.PatchValue(&getStorageState, func(*state.State, ModelConfigService) (storageAccess, error) { return nil, err })
+	patcher.PatchValue(&getStorageState, func(*state.State) (storageAccess, error) { return nil, err })
 }
 
 func (n *NetworkInfoIAAS) MachineNetworkInfos() (map[string][]NetInfoAddress, error) {

--- a/apiserver/facades/agent/uniter/goal-state_test.go
+++ b/apiserver/facades/agent/uniter/goal-state_test.go
@@ -42,7 +42,6 @@ func (s *uniterGoalStateSuite) SetUpTest(c *gc.C) {
 
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService(c))
 
 	s.machine2 = f.MakeMachine(c, &factory.MachineParams{
 		Base: state.UbuntuBase("12.10"),
@@ -121,7 +120,6 @@ func (s *uniterGoalStateSuite) TestPeerUnitsNoRelation(c *gc.C) {
 
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService(c))
 
 	f.MakeUnit(c, &factory.UnitParams{
 		Application: s.mysql,
@@ -181,7 +179,6 @@ func (s *uniterGoalStateSuite) TestGoalStatesDeadUnitsExcluded(c *gc.C) {
 
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService(c))
 
 	newMysqlUnit := f.MakeUnit(c, &factory.UnitParams{
 		Application: s.mysql,
@@ -235,14 +232,13 @@ func (s *uniterGoalStateSuite) TestGoalStatesDeadUnitsExcluded(c *gc.C) {
 // remove change caused many of these to fail.
 func preventUnitDestroyRemove(
 	c *gc.C,
-	modelConfigService uniter.ModelConfigService,
 	u *state.Unit,
 ) {
 	// To have a non-allocating status, a unit needs to
 	// be assigned to a machine.
 	_, err := u.AssignedMachineId()
 	if errors.Is(err, errors.NotAssigned) {
-		err = u.AssignToNewMachine(modelConfigService)
+		err = u.AssignToNewMachine()
 	}
 	c.Assert(err, jc.ErrorIsNil)
 	now := time.Now()
@@ -259,7 +255,6 @@ func preventUnitDestroyRemove(
 func (s *uniterGoalStateSuite) TestGoalStatesSingleRelationDyingUnits(c *gc.C) {
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService(c))
 
 	mysqlUnit := f.MakeUnit(c, &factory.UnitParams{
 		Application: s.mysql,
@@ -287,7 +282,7 @@ func (s *uniterGoalStateSuite) TestGoalStatesSingleRelationDyingUnits(c *gc.C) {
 			},
 		},
 	})
-	preventUnitDestroyRemove(c, s.modelConfigService(c), mysqlUnit)
+	preventUnitDestroyRemove(c, mysqlUnit)
 	err = mysqlUnit.Destroy(s.store)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -381,7 +376,6 @@ func (s *uniterGoalStateSuite) TestGoalStatesMultipleRelations(c *gc.C) {
 
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService(c))
 
 	// Add another wordpress unit on machine 1.
 	f.MakeUnit(c, &factory.UnitParams{
@@ -464,7 +458,7 @@ func (s *uniterGoalStateSuite) addRelationEnterScope(c *gc.C, unit1 *state.Unit,
 	relationUnit, err := relation.Unit(unit1)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = relationUnit.EnterScope(s.modelConfigService(c), nil)
+	err = relationUnit.EnterScope(nil)
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertInScope(c, relationUnit, true)
 	return err

--- a/apiserver/facades/agent/uniter/networkinfo_test.go
+++ b/apiserver/facades/agent/uniter/networkinfo_test.go
@@ -58,12 +58,6 @@ type networkInfoSuite struct {
 	networkService NetworkService
 }
 
-// modelConfigService is a convenience function to get the controller model's
-// model config service inside a test.
-func (s *networkInfoSuite) modelConfigService(c *gc.C) uniter.ModelConfigService {
-	return s.ControllerDomainServices(c).Config()
-}
-
 var _ = gc.Suite(&networkInfoSuite{})
 
 func (s *networkInfoSuite) SetUpTest(c *gc.C) {
@@ -78,7 +72,7 @@ func (s *networkInfoSuite) TestNetworksForRelation(c *gc.C) {
 	st := s.ControllerModel(c).State()
 
 	prr := s.newProReqRelation(c, charm.ScopeGlobal)
-	err := prr.pu0.AssignToNewMachine(s.modelConfigService(c))
+	err := prr.pu0.AssignToNewMachine()
 	c.Assert(err, jc.ErrorIsNil)
 	id, err := prr.pu0.AssignedMachineId()
 	c.Assert(err, jc.ErrorIsNil)
@@ -138,7 +132,6 @@ func (s *networkInfoSuite) TestProcessAPIRequestForBinding(c *gc.C) {
 
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService(c))
 
 	bindings := map[string]string{
 		"":             network.AlphaSpaceId,
@@ -166,9 +159,9 @@ func (s *networkInfoSuite) TestProcessAPIRequestForBinding(c *gc.C) {
 		})
 	c.Assert(err, jc.ErrorIsNil)
 
-	unit, err := app.AddUnit(s.modelConfigService(c), state.AddUnitParams{})
+	unit, err := app.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(unit.AssignToNewMachine(s.modelConfigService(c)), jc.ErrorIsNil)
+	c.Assert(unit.AssignToNewMachine(), jc.ErrorIsNil)
 
 	id, err := unit.AssignedMachineId()
 	c.Assert(err, jc.ErrorIsNil)
@@ -223,7 +216,6 @@ func (s *networkInfoSuite) TestProcessAPIRequestBridgeWithSameIPOverNIC(c *gc.C)
 
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService(c))
 
 	bindings := map[string]string{
 		"":             network.AlphaSpaceId,
@@ -233,9 +225,9 @@ func (s *networkInfoSuite) TestProcessAPIRequestBridgeWithSameIPOverNIC(c *gc.C)
 		EndpointBindings: bindings,
 	})
 
-	unit, err := app.AddUnit(s.modelConfigService(c), state.AddUnitParams{})
+	unit, err := app.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(unit.AssignToNewMachine(s.modelConfigService(c)), jc.ErrorIsNil)
+	c.Assert(unit.AssignToNewMachine(), jc.ErrorIsNil)
 
 	id, err := unit.AssignedMachineId()
 	c.Assert(err, jc.ErrorIsNil)
@@ -288,7 +280,7 @@ func (s *networkInfoSuite) TestProcessAPIRequestBridgeWithSameIPOverNIC(c *gc.C)
 
 func (s *networkInfoSuite) TestAPIRequestForRelationIAASHostNameIngressNoEgress(c *gc.C) {
 	prr := s.newProReqRelation(c, charm.ScopeGlobal)
-	err := prr.pu0.AssignToNewMachine(s.modelConfigService(c))
+	err := prr.pu0.AssignToNewMachine()
 	c.Assert(err, jc.ErrorIsNil)
 	id, err := prr.pu0.AssignedMachineId()
 	c.Assert(err, jc.ErrorIsNil)
@@ -348,7 +340,6 @@ func (s *networkInfoSuite) TestAPIRequestForRelationCAASHostNameNoIngress(c *gc.
 
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService(c))
 
 	// For the test to run properly with part of the model in mongo and
 	// part in a service domain, a model with the same uuid is required
@@ -361,7 +352,6 @@ func (s *networkInfoSuite) TestAPIRequestForRelationCAASHostNameNoIngress(c *gc.
 
 	f2, release := s.NewFactory(c, st.ModelUUID())
 	defer release()
-	f2 = f2.WithModelConfigService(s.modelConfigService(c))
 
 	ch := f2.MakeCharm(c, &factory.CharmParams{Name: "mysql-k8s", Series: "focal"})
 	app := f2.MakeApplication(c, &factory.ApplicationParams{Name: "mysql", Charm: ch})
@@ -423,7 +413,7 @@ func (s *networkInfoSuite) TestNetworksForRelationWithSpaces(c *gc.C) {
 	st := s.ControllerModel(c).State()
 
 	prr := s.newProReqRelationWithBindings(c, charm.ScopeGlobal, bindings, nil)
-	err := prr.pu0.AssignToNewMachine(s.modelConfigService(c))
+	err := prr.pu0.AssignToNewMachine()
 	c.Assert(err, jc.ErrorIsNil)
 	id, err := prr.pu0.AssignedMachineId()
 	c.Assert(err, jc.ErrorIsNil)
@@ -467,7 +457,7 @@ func (s *networkInfoSuite) TestNetworksForRelationWithSpaces(c *gc.C) {
 func (s *networkInfoSuite) TestNetworksForRelationRemoteRelation(c *gc.C) {
 	st := s.ControllerModel(c).State()
 	prr := s.newRemoteProReqRelation(c)
-	err := prr.ru0.AssignToNewMachine(s.modelConfigService(c))
+	err := prr.ru0.AssignToNewMachine()
 	c.Assert(err, jc.ErrorIsNil)
 	id, err := prr.ru0.AssignedMachineId()
 	c.Assert(err, jc.ErrorIsNil)
@@ -501,7 +491,7 @@ func (s *networkInfoSuite) TestNetworksForRelationRemoteRelationNoPublicAddr(c *
 	st := s.ControllerModel(c).State()
 
 	prr := s.newRemoteProReqRelation(c)
-	err := prr.ru0.AssignToNewMachine(s.modelConfigService(c))
+	err := prr.ru0.AssignToNewMachine()
 	c.Assert(err, jc.ErrorIsNil)
 	id, err := prr.ru0.AssignedMachineId()
 	c.Assert(err, jc.ErrorIsNil)
@@ -534,7 +524,7 @@ func (s *networkInfoSuite) TestNetworksForRelationRemoteRelationDelayedPublicAdd
 	st := s.ControllerModel(c).State()
 
 	prr := s.newRemoteProReqRelation(c)
-	err := prr.ru0.AssignToNewMachine(s.modelConfigService(c))
+	err := prr.ru0.AssignToNewMachine()
 	c.Assert(err, jc.ErrorIsNil)
 	id, err := prr.ru0.AssignedMachineId()
 	c.Assert(err, jc.ErrorIsNil)
@@ -579,7 +569,7 @@ func (s *networkInfoSuite) TestNetworksForRelationRemoteRelationDelayedPrivateAd
 	st := s.ControllerModel(c).State()
 
 	prr := s.newRemoteProReqRelation(c)
-	err := prr.ru0.AssignToNewMachine(s.modelConfigService(c))
+	err := prr.ru0.AssignToNewMachine()
 	c.Assert(err, jc.ErrorIsNil)
 	id, err := prr.ru0.AssignedMachineId()
 	c.Assert(err, jc.ErrorIsNil)
@@ -639,7 +629,6 @@ func (s *networkInfoSuite) TestNetworksForRelationCAASModel(c *gc.C) {
 
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService(c))
 
 	// For the test to run properly with part of the model in mongo and
 	// part in a service domain, a model with the same uuid is required
@@ -652,14 +641,13 @@ func (s *networkInfoSuite) TestNetworksForRelationCAASModel(c *gc.C) {
 
 	f2, release := s.NewFactory(c, st.ModelUUID())
 	defer release()
-	f2 = f2.WithModelConfigService(s.modelConfigService(c))
 
 	gitlabch := f2.MakeCharm(c, &factory.CharmParams{Name: "gitlab-k8s", Series: "focal"})
 	mysqlch := f2.MakeCharm(c, &factory.CharmParams{Name: "mysql-k8s", Series: "focal"})
 	gitlab := f2.MakeApplication(c, &factory.ApplicationParams{Name: "gitlab", Charm: gitlabch})
 	mysql := f2.MakeApplication(c, &factory.ApplicationParams{Name: "mysql", Charm: mysqlch})
 
-	prr := newProReqRelationForApps(c, st, s.modelConfigService(c), mysql, gitlab)
+	prr := newProReqRelationForApps(c, st, mysql, gitlab)
 
 	modelConfigService := s.ControllerDomainServices(c).Config()
 	// We need to instantiate this with the new CAAS model state.
@@ -700,7 +688,6 @@ func (s *networkInfoSuite) TestNetworksForRelationCAASModelInvalidBinding(c *gc.
 
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService(c))
 
 	// For the test to run properly with part of the model in mongo and
 	// part in a service domain, a model with the same uuid is required
@@ -713,14 +700,13 @@ func (s *networkInfoSuite) TestNetworksForRelationCAASModelInvalidBinding(c *gc.
 
 	f2, release := s.NewFactory(c, st.ModelUUID())
 	defer release()
-	f2 = f2.WithModelConfigService(s.modelConfigService(c))
 
 	gitLabCh := f2.MakeCharm(c, &factory.CharmParams{Name: "gitlab-k8s", Series: "focal"})
 	mySqlCh := f2.MakeCharm(c, &factory.CharmParams{Name: "mysql-k8s", Series: "focal"})
 	gitLab := f2.MakeApplication(c, &factory.ApplicationParams{Name: "gitlab", Charm: gitLabCh})
 	mySql := f2.MakeApplication(c, &factory.ApplicationParams{Name: "mysql", Charm: mySqlCh})
 
-	prr := newProReqRelationForApps(c, st, s.modelConfigService(c), mySql, gitLab)
+	prr := newProReqRelationForApps(c, st, mySql, gitLab)
 
 	modelConfigService := s.ControllerDomainServices(c).Config()
 	// We need to instantiate this with the new CAAS model state.
@@ -737,7 +723,6 @@ func (s *networkInfoSuite) TestNetworksForRelationCAASModelCrossModelNoPrivate(c
 
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService(c))
 
 	// For the test to run properly with part of the model in mongo and
 	// part in a service domain, a model with the same uuid is required
@@ -750,7 +735,6 @@ func (s *networkInfoSuite) TestNetworksForRelationCAASModelCrossModelNoPrivate(c
 
 	f2, release := s.NewFactory(c, st.ModelUUID())
 	defer release()
-	f2 = f2.WithModelConfigService(s.modelConfigService(c))
 
 	gitLabCh := f2.MakeCharm(c, &factory.CharmParams{Name: "gitlab-k8s", Series: "focal"})
 	gitLab := f2.MakeApplication(c, &factory.ApplicationParams{Name: "gitlab", Charm: gitLabCh})
@@ -784,8 +768,8 @@ func (s *networkInfoSuite) TestNetworksForRelationCAASModelCrossModelNoPrivate(c
 	prr := &RemoteProReqRelation{rel: rel, papp: papp, rapp: gitLab}
 	prr.pru0 = addRemoteRU(c, rel, "mysql/0")
 	prr.pru1 = addRemoteRU(c, rel, "mysql/1")
-	prr.ru0, prr.rru0 = addRU(c, s.modelConfigService(c), gitLab, rel, nil)
-	prr.ru1, prr.rru1 = addRU(c, s.modelConfigService(c), gitLab, rel, nil)
+	prr.ru0, prr.rru0 = addRU(c, gitLab, rel, nil)
+	prr.ru1, prr.rru1 = addRU(c, gitLab, rel, nil)
 
 	// Add a container address.
 	// These are scoped as local-machine and are fallen back to for CAAS by
@@ -844,7 +828,6 @@ func (s *networkInfoSuite) TestMachineNetworkInfos(c *gc.C) {
 
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService(c))
 
 	bindings := map[string]string{
 		"":             spaceDefault.ID,
@@ -854,12 +837,12 @@ func (s *networkInfoSuite) TestMachineNetworkInfos(c *gc.C) {
 		EndpointBindings: bindings,
 	})
 
-	unit, err := app.AddUnit(s.modelConfigService(c), state.AddUnitParams{})
+	unit, err := app.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	st := s.ControllerModel(c).State()
 	machine, err := st.AddOneMachine(
-		s.modelConfigService(c),
+
 		state.MachineTemplate{
 			Base: state.UbuntuBase("12.10"),
 			Jobs: []state.MachineJob{state.JobHostUnits},
@@ -867,7 +850,7 @@ func (s *networkInfoSuite) TestMachineNetworkInfos(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = unit.AssignToMachine(s.modelConfigService(c), machine)
+	err = unit.AssignToMachine(machine)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.createNICAndBridgeWithIP(c, machine, "eth0", "br-eth0", "10.0.0.20/24")
@@ -925,19 +908,18 @@ func (s *networkInfoSuite) TestMachineNetworkInfos(c *gc.C) {
 func (s *networkInfoSuite) TestMachineNetworkInfosAlphaNoSubnets(c *gc.C) {
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService(c))
 
 	app := f.MakeApplication(c, &factory.ApplicationParams{
 		Name:  "wordpress",
 		Charm: f.MakeCharm(c, &factory.CharmParams{Name: "wordpress"}),
 	})
 
-	unit, err := app.AddUnit(s.modelConfigService(c), state.AddUnitParams{})
+	unit, err := app.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	st := s.ControllerModel(c).State()
 	machine, err := st.AddOneMachine(
-		s.modelConfigService(c),
+
 		state.MachineTemplate{
 			Base: state.UbuntuBase("12.10"),
 			Jobs: []state.MachineJob{state.JobHostUnits},
@@ -945,7 +927,7 @@ func (s *networkInfoSuite) TestMachineNetworkInfosAlphaNoSubnets(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = unit.AssignToMachine(s.modelConfigService(c), machine)
+	err = unit.AssignToMachine(machine)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.createNICAndBridgeWithIP(c, machine, "eth0", "br-eth0", "10.0.0.20/24")
@@ -1069,7 +1051,6 @@ func (s *networkInfoSuite) newProReqRelationWithBindings(
 ) *ProReqRelation {
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService(c))
 
 	papp := f.MakeApplication(c, &factory.ApplicationParams{
 		EndpointBindings: pBindings,
@@ -1088,13 +1069,12 @@ func (s *networkInfoSuite) newProReqRelationWithBindings(
 			EndpointBindings: rBindings,
 		})
 	}
-	return newProReqRelationForApps(c, s.ControllerModel(c).State(), s.modelConfigService(c), papp, rapp)
+	return newProReqRelationForApps(c, s.ControllerModel(c).State(), papp, rapp)
 }
 
 func (s *networkInfoSuite) newProReqRelation(c *gc.C, scope charm.RelationScope) *ProReqRelation {
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService(c))
 
 	pApp := f.MakeApplication(c, nil)
 
@@ -1111,7 +1091,7 @@ func (s *networkInfoSuite) newProReqRelation(c *gc.C, scope charm.RelationScope)
 		})
 	}
 
-	return newProReqRelationForApps(c, s.ControllerModel(c).State(), s.modelConfigService(c), pApp, rApp)
+	return newProReqRelationForApps(c, s.ControllerModel(c).State(), pApp, rApp)
 }
 
 func (s *networkInfoSuite) newRemoteProReqRelation(c *gc.C) *RemoteProReqRelation {
@@ -1129,7 +1109,6 @@ func (s *networkInfoSuite) newRemoteProReqRelation(c *gc.C) *RemoteProReqRelatio
 
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService(c))
 
 	rapp := f.MakeApplication(c, &factory.ApplicationParams{
 		Name:  "wordpress",
@@ -1144,15 +1123,14 @@ func (s *networkInfoSuite) newRemoteProReqRelation(c *gc.C) *RemoteProReqRelatio
 	prr := &RemoteProReqRelation{rel: rel, papp: papp, rapp: rapp}
 	prr.pru0 = addRemoteRU(c, rel, "mysql/0")
 	prr.pru1 = addRemoteRU(c, rel, "mysql/1")
-	prr.ru0, prr.rru0 = addRU(c, s.modelConfigService(c), rapp, rel, nil)
-	prr.ru1, prr.rru1 = addRU(c, s.modelConfigService(c), rapp, rel, nil)
+	prr.ru0, prr.rru0 = addRU(c, rapp, rel, nil)
+	prr.ru1, prr.rru1 = addRU(c, rapp, rel, nil)
 	return prr
 }
 
 func newProReqRelationForApps(
 	c *gc.C,
 	st *state.State,
-	modelConfigService uniter.ModelConfigService,
 	proApp, reqApp *state.Application,
 ) *ProReqRelation {
 	eps, err := st.InferEndpoints(proApp.Name(), reqApp.Name())
@@ -1160,21 +1138,20 @@ func newProReqRelationForApps(
 	rel, err := st.AddRelation(eps...)
 	c.Assert(err, jc.ErrorIsNil)
 	prr := &ProReqRelation{rel: rel, papp: proApp, rapp: reqApp}
-	prr.pu0, prr.pru0 = addRU(c, modelConfigService, proApp, rel, nil)
-	prr.pu1, prr.pru1 = addRU(c, modelConfigService, proApp, rel, nil)
+	prr.pu0, prr.pru0 = addRU(c, proApp, rel, nil)
+	prr.pu1, prr.pru1 = addRU(c, proApp, rel, nil)
 	if eps[0].Scope == charm.ScopeGlobal {
-		prr.ru0, prr.rru0 = addRU(c, modelConfigService, reqApp, rel, nil)
-		prr.ru1, prr.rru1 = addRU(c, modelConfigService, reqApp, rel, nil)
+		prr.ru0, prr.rru0 = addRU(c, reqApp, rel, nil)
+		prr.ru1, prr.rru1 = addRU(c, reqApp, rel, nil)
 	} else {
-		prr.ru0, prr.rru0 = addRU(c, modelConfigService, reqApp, rel, prr.pu0)
-		prr.ru1, prr.rru1 = addRU(c, modelConfigService, reqApp, rel, prr.pu1)
+		prr.ru0, prr.rru0 = addRU(c, reqApp, rel, prr.pu0)
+		prr.ru1, prr.rru1 = addRU(c, reqApp, rel, prr.pu1)
 	}
 	return prr
 }
 
 func addRU(
 	c *gc.C,
-	modelConfigService uniter.ModelConfigService,
 	app *state.Application,
 	rel *state.Relation,
 	principal *state.Unit,
@@ -1185,7 +1162,7 @@ func addRU(
 	// relation's scope as the principal.
 	var u *state.Unit
 	if principal == nil {
-		unit, err := app.AddUnit(modelConfigService, state.AddUnitParams{})
+		unit, err := app.AddUnit(state.AddUnitParams{})
 		c.Assert(err, jc.ErrorIsNil)
 		u = unit
 	} else {
@@ -1193,7 +1170,7 @@ func addRU(
 		c.Assert(err, jc.ErrorIsNil)
 		pru, err := rel.Unit(principal)
 		c.Assert(err, jc.ErrorIsNil)
-		err = pru.EnterScope(modelConfigService, nil) // to create the subordinate
+		err = pru.EnterScope(nil) // to create the subordinate
 		c.Assert(err, jc.ErrorIsNil)
 		err = pru.LeaveScope() // to reset to initial expected state
 		c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/agent/uniter/package_test.go
+++ b/apiserver/facades/agent/uniter/package_test.go
@@ -102,7 +102,6 @@ func (s *uniterSuiteBase) SetUpTest(c *gc.C) {
 func (s *uniterSuiteBase) setupState(c *gc.C) {
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService(c))
 
 	s.machine0 = f.MakeMachine(c, &factory.MachineParams{
 		Base: state.UbuntuBase("12.10"),
@@ -184,7 +183,6 @@ func (s *uniterSuiteBase) assertInScope(c *gc.C, relUnit *state.RelationUnit, in
 func (s *uniterSuiteBase) setupCAASModel(c *gc.C) (*apiuniter.Client, *state.CAASModel, *state.Application, *state.Unit) {
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService(c))
 
 	// For the test to run properly with part of the model in mongo and
 	// part in a service domain, a model with the same uuid is required
@@ -203,7 +201,6 @@ func (s *uniterSuiteBase) setupCAASModel(c *gc.C) (*apiuniter.Client, *state.CAA
 
 	f2, release := s.NewFactory(c, m.UUID())
 	defer release()
-	f2 = f2.WithModelConfigService(s.modelConfigService(c))
 
 	app := f2.MakeApplication(
 		c, &factory.ApplicationParams{
@@ -227,12 +224,6 @@ func (s *uniterSuiteBase) setupCAASModel(c *gc.C) (*apiuniter.Client, *state.CAA
 	u, err := apiuniter.NewFromConnection(api)
 	c.Assert(err, jc.ErrorIsNil)
 	return u, cm, app, unit
-}
-
-// modelConfigService is a convenience function to get the controller model's
-// model config service inside a test.
-func (s *uniterSuiteBase) modelConfigService(c *gc.C) uniter.ModelConfigService {
-	return s.ControllerDomainServices(c).Config()
 }
 
 type fakeBroker struct {

--- a/apiserver/facades/agent/uniter/register.go
+++ b/apiserver/facades/agent/uniter/register.go
@@ -108,7 +108,7 @@ func newUniterAPIWithServices(
 		return nil, errors.Trace(err)
 	}
 
-	storageAccessor, err := getStorageState(st, modelConfigService)
+	storageAccessor, err := getStorageState(st)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/apiserver/facades/agent/uniter/state.go
+++ b/apiserver/facades/agent/uniter/state.go
@@ -51,13 +51,12 @@ type storageFilesystemInterface interface {
 
 var getStorageState = func(
 	st *state.State,
-	modelConfigService ModelConfigService,
 ) (storageAccess, error) {
 	m, err := st.Model()
 	if err != nil {
 		return nil, err
 	}
-	sb, err := state.NewStorageConfigBackend(st, modelConfigService)
+	sb, err := state.NewStorageConfigBackend(st)
 	if err != nil {
 		return nil, err
 	}

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -1281,7 +1281,7 @@ func (u *UniterAPI) EnterScope(ctx context.Context, args params.RelationUnits) (
 		if len(egressSubnets) > 0 {
 			settings["egress-subnets"] = strings.Join(egressSubnets, ",")
 		}
-		return relUnit.EnterScope(u.modelConfigService, settings)
+		return relUnit.EnterScope(settings)
 	}
 	for i, arg := range args.RelationUnits {
 		tag, err := names.ParseUnitTag(arg.Unit)

--- a/apiserver/facades/agent/uniter/uniter_network_test.go
+++ b/apiserver/facades/agent/uniter/uniter_network_test.go
@@ -137,7 +137,6 @@ func (s *uniterNetworkInfoSuite) SetUpTest(c *gc.C) {
 
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService(c))
 
 	s.wpCharm = f.MakeCharm(c, &factory.CharmParams{
 		Name: "wordpress-extra-bindings",
@@ -193,7 +192,7 @@ func (s *uniterNetworkInfoSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *uniterNetworkInfoSuite) addProvisionedMachineWithDevicesAndAddresses(c *gc.C, addrSuffix int) *state.Machine {
-	machine, err := s.st.AddMachine(s.modelConfigService(c), state.UbuntuBase("12.10"), state.JobHostUnits)
+	machine, err := s.st.AddMachine(state.UbuntuBase("12.10"), state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 	err = machine.SetInstanceInfo("i-am", "", "fake_nonce", nil, nil, nil, nil, nil, nil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -307,7 +306,7 @@ func (s *uniterNetworkInfoSuite) addRelationAndAssertInScope(c *gc.C) {
 	rel := s.addRelation(c, "wordpress", "mysql")
 	wpRelUnit, err := rel.Unit(s.wordpressUnit)
 	c.Assert(err, jc.ErrorIsNil)
-	err = wpRelUnit.EnterScope(s.modelConfigService(c), nil)
+	err = wpRelUnit.EnterScope(nil)
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertInScope(c, wpRelUnit, true)
 }
@@ -492,7 +491,7 @@ func (s *uniterNetworkInfoSuite) TestNetworkInfoForImplicitlyBoundEndpoint(c *gc
 	rel := s.addRelation(c, "mysql", "wordpress")
 	mysqlRelUnit, err := rel.Unit(s.mysqlUnit)
 	c.Assert(err, jc.ErrorIsNil)
-	err = mysqlRelUnit.EnterScope(s.modelConfigService(c), nil)
+	err = mysqlRelUnit.EnterScope(nil)
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertInScope(c, mysqlRelUnit, true)
 
@@ -538,7 +537,7 @@ func (s *uniterNetworkInfoSuite) TestNetworkInfoUsesRelationAddressNonDefaultBin
 	rel := s.addRelation(c, "mysql", "wordpress-remote")
 	mysqlRelUnit, err := rel.Unit(s.mysqlUnit)
 	c.Assert(err, jc.ErrorIsNil)
-	err = mysqlRelUnit.EnterScope(s.modelConfigService(c), nil)
+	err = mysqlRelUnit.EnterScope(nil)
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertInScope(c, mysqlRelUnit, true)
 
@@ -592,7 +591,6 @@ func (s *uniterNetworkInfoSuite) TestNetworkInfoUsesRelationAddressDefaultBindin
 
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService(c))
 
 	// Recreate mysql app without endpoint binding.
 	s.mysql = f.MakeApplication(c, &factory.ApplicationParams{
@@ -608,7 +606,7 @@ func (s *uniterNetworkInfoSuite) TestNetworkInfoUsesRelationAddressDefaultBindin
 	rel := s.addRelation(c, "mysql-default", "wordpress-remote")
 	mysqlRelUnit, err := rel.Unit(s.mysqlUnit)
 	c.Assert(err, jc.ErrorIsNil)
-	err = mysqlRelUnit.EnterScope(s.modelConfigService(c), nil)
+	err = mysqlRelUnit.EnterScope(nil)
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertInScope(c, mysqlRelUnit, true)
 

--- a/apiserver/facades/agent/upgrader/unitupgrader_test.go
+++ b/apiserver/facades/agent/upgrader/unitupgrader_test.go
@@ -49,8 +49,7 @@ func (s *unitUpgraderSuite) SetUpTest(c *gc.C) {
 
 	// Create a machine and unit to work with
 	st := s.ControllerModel(c).State()
-	modelConfigService := s.ControllerDomainServices(c).Config()
-	machine, err := st.AddMachine(modelConfigService, state.UbuntuBase("12.10"), state.JobHostUnits)
+	machine, err := st.AddMachine(state.UbuntuBase("12.10"), state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 
 	arch := arch.DefaultArchitecture
@@ -63,15 +62,14 @@ func (s *unitUpgraderSuite) SetUpTest(c *gc.C) {
 
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
-	f = f.WithModelConfigService(modelConfigService)
 	app := f.MakeApplication(c, &factory.ApplicationParams{
 		Name:  "wordpress",
 		Charm: f.MakeCharm(c, &factory.CharmParams{Name: "wordpress"}),
 	})
-	s.rawUnit, err = app.AddUnit(modelConfigService, state.AddUnitParams{})
+	s.rawUnit, err = app.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
 	// Assign the unit to the machine.
-	err = s.rawUnit.AssignToNewMachine(modelConfigService)
+	err = s.rawUnit.AssignToNewMachine()
 	c.Assert(err, jc.ErrorIsNil)
 	id, err := s.rawUnit.AssignedMachineId()
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/agent/upgrader/upgrader_test.go
+++ b/apiserver/facades/agent/upgrader/upgrader_test.go
@@ -62,16 +62,15 @@ func (s *upgraderSuite) SetUpTest(c *gc.C) {
 	// For now, test with the controller model, but
 	// we may add a different hosted model later.
 	s.hosted = s.ControllerModel(c).State()
-	modelConfigService := s.ControllerDomainServices(c).Config()
 
 	// Create a machine to work with
 	var err error
 	// The first machine created is the only one allowed to
 	// JobManageModel
-	s.apiMachine, err = s.hosted.AddMachine(modelConfigService, state.UbuntuBase("12.10"), state.JobHostUnits,
+	s.apiMachine, err = s.hosted.AddMachine(state.UbuntuBase("12.10"), state.JobHostUnits,
 		state.JobManageModel)
 	c.Assert(err, jc.ErrorIsNil)
-	s.rawMachine, err = s.hosted.AddMachine(modelConfigService, state.UbuntuBase("12.10"), state.JobHostUnits)
+	s.rawMachine, err = s.hosted.AddMachine(state.UbuntuBase("12.10"), state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// The default auth is as the machine agent
@@ -145,10 +144,8 @@ func (s *upgraderSuite) TestWatchAPIVersion(c *gc.C) {
 func (s *upgraderSuite) TestWatchAPIVersionApplication(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	modelConfigService := s.ControllerDomainServices(c).Config()
 	f, release := s.NewFactory(c, s.hosted.ModelUUID())
 	defer release()
-	f = f.WithModelConfigService(modelConfigService)
 
 	app := f.MakeApplication(c, nil)
 	authorizer := apiservertesting.FakeAuthorizer{
@@ -194,14 +191,12 @@ func (s *upgraderSuite) TestWatchAPIVersionApplication(c *gc.C) {
 func (s *upgraderSuite) TestWatchAPIVersionUnit(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	modelConfigService := s.ControllerDomainServices(c).Config()
 	f, release := s.NewFactory(c, s.hosted.ModelUUID())
 	defer release()
-	f = f.WithModelConfigService(modelConfigService)
 
 	app := f.MakeApplication(c, nil)
 	providerId := "provider-id1"
-	unit, err := app.AddUnit(modelConfigService, state.AddUnitParams{ProviderId: &providerId})
+	unit, err := app.AddUnit(state.AddUnitParams{ProviderId: &providerId})
 	c.Assert(err, jc.ErrorIsNil)
 	authorizer := apiservertesting.FakeAuthorizer{
 		Tag: unit.Tag(),

--- a/apiserver/facades/client/action/action_test.go
+++ b/apiserver/facades/client/action/action_test.go
@@ -380,7 +380,7 @@ func (s *baseSuite) setupMocks(c *gc.C) *gomock.Controller {
 
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.ControllerDomainServices(c).Config())
+
 	s.charm = f.MakeCharm(c, &factory.CharmParams{
 		Name: "wordpress",
 	})

--- a/apiserver/facades/client/action/run_test.go
+++ b/apiserver/facades/client/action/run_test.go
@@ -92,7 +92,7 @@ func (s *runSuite) TestRunMachineAndApplication(c *gc.C) {
 	defer release()
 	charm := f.MakeCharm(c, &factory.CharmParams{Name: "dummy"})
 	magic, err := st.AddApplication(
-		s.modelConfigService(c),
+
 		state.AddApplicationArgs{
 			Name: "magic", Charm: charm,
 			CharmOrigin: &state.CharmOrigin{Platform: &state.Platform{OS: "ubuntu", Channel: "20.04/stable"}},
@@ -156,7 +156,7 @@ func (s *runSuite) TestRunApplicationWorkload(c *gc.C) {
 	defer release()
 	charm := f.MakeCharm(c, &factory.CharmParams{Name: "dummy"})
 	magic, err := st.AddApplication(
-		s.modelConfigService(c),
+
 		state.AddApplicationArgs{
 			Name: "magic", Charm: charm,
 			CharmOrigin: &state.CharmOrigin{Platform: &state.Platform{OS: "ubuntu", Channel: "20.04/stable"}},
@@ -289,12 +289,6 @@ func (s *runSuite) TestRunOnAllMachinesRequiresAdmin(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-// modelConfigService is a convenience function to get the controller model's
-// model config service inside a test.
-func (s *runSuite) modelConfigService(c *gc.C) state.ModelConfigService {
-	return s.ControllerDomainServices(c).Config()
-}
-
 func (s *runSuite) setupMocks(c *gc.C) *gomock.Controller {
 	ctrl := gomock.NewController(c)
 
@@ -312,15 +306,15 @@ func (s *runSuite) setupMocks(c *gc.C) *gomock.Controller {
 
 func (s *runSuite) addMachine(c *gc.C) *state.Machine {
 	st := s.ControllerModel(c).State()
-	machine, err := st.AddMachine(s.modelConfigService(c), state.UbuntuBase("12.10"), state.JobHostUnits)
+	machine, err := st.AddMachine(state.UbuntuBase("12.10"), state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 	return machine
 }
 
 func (s *runSuite) addUnit(c *gc.C, application *state.Application) *state.Unit {
-	unit, err := application.AddUnit(s.modelConfigService(c), state.AddUnitParams{})
+	unit, err := application.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
-	err = unit.AssignToNewMachine(s.modelConfigService(c))
+	err = unit.AssignToNewMachine()
 	c.Assert(err, jc.ErrorIsNil)
 	return unit
 }

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -158,8 +158,7 @@ func newFacadeBase(stdCtx context.Context, ctx facade.ModelContext) (*APIBase, e
 	}
 
 	state := &stateShim{
-		State:              ctx.State(),
-		modelConfigService: domainServices.Config(),
+		State: ctx.State(),
 	}
 
 	charmhubHTTPClient, err := ctx.HTTPClient(facade.CharmhubHTTPClient)

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -75,7 +75,7 @@ func (s *applicationSuite) SetUpTest(c *gc.C) {
 
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.ControllerDomainServices(c).Config())
+
 	s.application = f.MakeApplication(c, nil)
 
 	s.authorizer = &apiservertesting.FakeAuthorizer{
@@ -113,7 +113,7 @@ func (s *applicationSuite) makeAPI(c *gc.C) {
 	})
 
 	api, err := application.NewAPIBase(
-		application.GetState(st, s.modelConfigService),
+		application.GetState(st),
 		nil,
 		s.networkService,
 		storageAccess,
@@ -295,7 +295,7 @@ func (s *applicationSuite) TestApplicationDeployToMachine(c *gc.C) {
 	curl, ch := s.addCharmToState(c, "ch:jammy/dummy-0", "dummy")
 
 	st := s.ControllerModel(c).State()
-	machine, err := st.AddMachine(s.modelConfigService, state.UbuntuBase("22.04"), state.JobHostUnits)
+	machine, err := st.AddMachine(state.UbuntuBase("22.04"), state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 
 	arch := arch.DefaultArchitecture
@@ -348,7 +348,7 @@ func (s *applicationSuite) TestApplicationDeployToMachineWithLXDProfile(c *gc.C)
 	curl, ch := s.addCharmToState(c, "ch:jammy/lxd-profile-0", "lxd-profile")
 
 	st := s.ControllerModel(c).State()
-	machine, err := st.AddMachine(s.modelConfigService, state.UbuntuBase("22.04"), state.JobHostUnits)
+	machine, err := st.AddMachine(state.UbuntuBase("22.04"), state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 
 	arch := arch.DefaultArchitecture
@@ -407,7 +407,7 @@ func (s *applicationSuite) TestApplicationDeployToMachineWithInvalidLXDProfileAn
 	curl, ch := s.addCharmToState(c, "ch:jammy/lxd-profile-fail-0", "lxd-profile-fail")
 
 	st := s.ControllerModel(c).State()
-	machine, err := st.AddMachine(s.modelConfigService, state.UbuntuBase("22.04"), state.JobHostUnits)
+	machine, err := st.AddMachine(state.UbuntuBase("22.04"), state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 
 	arch := arch.DefaultArchitecture
@@ -531,7 +531,7 @@ func (s *applicationSuite) TestClientAddApplicationUnits(c *gc.C) {
 
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService)
+
 	f.MakeApplication(c, &factory.ApplicationParams{
 		Name:  "dummy",
 		Charm: f.MakeCharm(c, &factory.CharmParams{Name: "dummy"}),
@@ -571,13 +571,13 @@ func (s *applicationSuite) TestAddApplicationUnitsToNewContainer(c *gc.C) {
 
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService)
+
 	app := f.MakeApplication(c, &factory.ApplicationParams{
 		Name:  "dummy",
 		Charm: f.MakeCharm(c, &factory.CharmParams{Name: "dummy"}),
 	})
 	st := s.ControllerModel(c).State()
-	machine, err := st.AddMachine(s.modelConfigService, state.UbuntuBase("22.04"), state.JobHostUnits)
+	machine, err := st.AddMachine(state.UbuntuBase("22.04"), state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, err = s.applicationAPI.AddUnits(context.Background(), params.AddApplicationUnits{
@@ -616,7 +616,7 @@ func (s *applicationSuite) TestApplicationCharmRelations(c *gc.C) {
 
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService)
+
 	f.MakeApplication(c, &factory.ApplicationParams{
 		Name:  "wordpress",
 		Charm: f.MakeCharm(c, &factory.CharmParams{Name: "wordpress"}),
@@ -656,7 +656,7 @@ func (s *applicationSuite) TestBlockDestroyAddApplicationUnits(c *gc.C) {
 
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService)
+
 	f.MakeApplication(c, &factory.ApplicationParams{
 		Name:  "dummy",
 		Charm: f.MakeCharm(c, &factory.CharmParams{Name: "dummy"}),
@@ -671,7 +671,7 @@ func (s *applicationSuite) TestBlockRemoveAddApplicationUnits(c *gc.C) {
 
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService)
+
 	f.MakeApplication(c, &factory.ApplicationParams{
 		Name:  "dummy",
 		Charm: f.MakeCharm(c, &factory.CharmParams{Name: "dummy"}),
@@ -686,7 +686,7 @@ func (s *applicationSuite) TestBlockChangeAddApplicationUnits(c *gc.C) {
 
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService)
+
 	f.MakeApplication(c, &factory.ApplicationParams{
 		Name:  "dummy",
 		Charm: f.MakeCharm(c, &factory.CharmParams{Name: "dummy"}),
@@ -701,7 +701,7 @@ func (s *applicationSuite) TestAddUnitToMachineNotFound(c *gc.C) {
 
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService)
+
 	f.MakeApplication(c, &factory.ApplicationParams{
 		Name:  "dummy",
 		Charm: f.MakeCharm(c, &factory.CharmParams{Name: "dummy"}),
@@ -720,7 +720,7 @@ func (s *applicationSuite) TestApplicationExpose(c *gc.C) {
 
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService)
+
 	charm := f.MakeCharm(c, &factory.CharmParams{Name: "dummy"})
 	applicationNames := []string{"dummy-application", "exposed-application"}
 	apps := make([]*state.Application, len(applicationNames))
@@ -745,7 +745,7 @@ func (s *applicationSuite) TestApplicationExposeEndpoints(c *gc.C) {
 
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService)
+
 	app := f.MakeApplication(c, &factory.ApplicationParams{
 		Name:  "wordpress",
 		Charm: f.MakeCharm(c, &factory.CharmParams{Name: "wordpress"}),
@@ -778,7 +778,7 @@ func (s *applicationSuite) TestApplicationExposeEndpointsWithPre29Client(c *gc.C
 
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService)
+
 	app := f.MakeApplication(c, &factory.ApplicationParams{
 		Name:  "wordpress",
 		Charm: f.MakeCharm(c, &factory.CharmParams{Name: "wordpress"}),
@@ -806,7 +806,7 @@ func (s *applicationSuite) TestApplicationExposeEndpointsWithPre29Client(c *gc.C
 func (s *applicationSuite) setupApplicationExpose(c *gc.C) {
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService)
+
 	charm := f.MakeCharm(c, &factory.CharmParams{Name: "dummy"})
 	applicationNames := []string{"dummy-application", "exposed-application"}
 	apps := make([]*state.Application, len(applicationNames))
@@ -1015,7 +1015,7 @@ func (s *applicationSuite) TestApplicationUnexpose(c *gc.C) {
 
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService)
+
 	charm := f.MakeCharm(c, nil)
 	for i, t := range applicationUnexposeTests {
 		c.Logf("test %d. %s", i, t.about)
@@ -1048,7 +1048,7 @@ func (s *applicationSuite) TestApplicationUnexpose(c *gc.C) {
 func (s *applicationSuite) setupApplicationUnexpose(c *gc.C) *state.Application {
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService)
+
 	app := f.MakeApplication(c, &factory.ApplicationParams{
 		Name:  "dummy-application",
 		Charm: f.MakeCharm(c, &factory.CharmParams{Name: "dummy"}),
@@ -1108,7 +1108,7 @@ func (s *applicationSuite) TestClientSetApplicationConstraints(c *gc.C) {
 
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService)
+
 	app := f.MakeApplication(c, &factory.ApplicationParams{
 		Name:  "dummy",
 		Charm: f.MakeCharm(c, &factory.CharmParams{Name: "dummy"}),
@@ -1129,7 +1129,7 @@ func (s *applicationSuite) TestClientSetApplicationConstraints(c *gc.C) {
 func (s *applicationSuite) setupSetApplicationConstraints(c *gc.C) (*state.Application, constraints.Value) {
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService)
+
 	app := f.MakeApplication(c, &factory.ApplicationParams{
 		Name:  "dummy",
 		Charm: f.MakeCharm(c, &factory.CharmParams{Name: "dummy"}),
@@ -1187,7 +1187,7 @@ func (s *applicationSuite) TestClientGetApplicationConstraints(c *gc.C) {
 
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService)
+
 	fooConstraints := constraints.MustParse("arch=amd64", "mem=4G")
 	f.MakeApplication(c, &factory.ApplicationParams{
 		Name:        "foo",
@@ -1249,7 +1249,7 @@ func (s *applicationSuite) checkEndpoints(c *gc.C, mysqlAppName string, endpoint
 func (s *applicationSuite) setupRelationScenario(c *gc.C) {
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService)
+
 	f.MakeApplication(c, &factory.ApplicationParams{
 		Name:  "wordpress",
 		Charm: f.MakeCharm(c, &factory.CharmParams{Name: "wordpress"}),
@@ -1333,7 +1333,7 @@ func (s *applicationSuite) TestBlockChangesAddRelation(c *gc.C) {
 
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService)
+
 	f.MakeApplication(c, &factory.ApplicationParams{
 		Name:  "wordpress",
 		Charm: f.MakeCharm(c, &factory.CharmParams{Name: "wordpress"}),
@@ -1360,7 +1360,7 @@ func (s *applicationSuite) TestCallWithOnlyOneEndpoint(c *gc.C) {
 
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService)
+
 	f.MakeApplication(c, &factory.ApplicationParams{
 		Name:  "wordpress",
 		Charm: f.MakeCharm(c, &factory.CharmParams{Name: "wordpress"}),
@@ -1376,7 +1376,7 @@ func (s *applicationSuite) TestCallWithOneEndpointTooMany(c *gc.C) {
 
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService)
+
 	f.MakeApplication(c, &factory.ApplicationParams{
 		Name:  "wordpress",
 		Charm: f.MakeCharm(c, &factory.CharmParams{Name: "wordpress"}),
@@ -1396,7 +1396,7 @@ func (s *applicationSuite) TestAddAlreadyAddedRelation(c *gc.C) {
 
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService)
+
 	f.MakeApplication(c, &factory.ApplicationParams{
 		Name:  "wordpress",
 		Charm: f.MakeCharm(c, &factory.CharmParams{Name: "wordpress"}),
@@ -1494,7 +1494,7 @@ func (s *applicationSuite) TestRemoteRelationInvalidEndpoint(c *gc.C) {
 	s.setupRemoteApplication(c)
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService)
+
 	f.MakeApplication(c, &factory.ApplicationParams{
 		Name:  "wordpress",
 		Charm: f.MakeCharm(c, &factory.CharmParams{Name: "wordpress"}),
@@ -1526,7 +1526,7 @@ func (s *applicationSuite) TestRemoteRelationNoMatchingEndpoint(c *gc.C) {
 
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService)
+
 	f.MakeApplication(c, &factory.ApplicationParams{
 		Name:  "wordpress",
 		Charm: f.MakeCharm(c, &factory.CharmParams{Name: "wordpress"}),
@@ -1542,7 +1542,7 @@ func (s *applicationSuite) TestRemoteRelationApplicationNotFound(c *gc.C) {
 
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService)
+
 	f.MakeApplication(c, &factory.ApplicationParams{
 		Name:  "wordpress",
 		Charm: f.MakeCharm(c, &factory.CharmParams{Name: "wordpress"}),

--- a/apiserver/facades/client/application/deploy_test.go
+++ b/apiserver/facades/client/application/deploy_test.go
@@ -43,12 +43,6 @@ type DeployLocalSuite struct {
 
 var _ = gc.Suite(&DeployLocalSuite{})
 
-// modelConfigService is a convenience function to get the controller model's
-// model config service inside a test.
-func (s *DeployLocalSuite) modelConfigService(c *gc.C) application.ModelConfigService {
-	return s.ControllerDomainServices(c).Config()
-}
-
 func (s *DeployLocalSuite) SetUpSuite(c *gc.C) {
 	s.ApiServerSuite.SetUpSuite(c)
 }
@@ -76,7 +70,7 @@ func (s *DeployLocalSuite) TestDeployControllerNotAllowed(c *gc.C) {
 	ch := f.MakeCharm(c, &factory.CharmParams{Name: "juju-controller"})
 	_, err := application.DeployApplication(
 		context.Background(),
-		stateDeployer{State: s.ControllerModel(c).State(), modelConfigService: s.modelConfigService(c)},
+		stateDeployer{State: s.ControllerModel(c).State()},
 		s.ControllerModel(c),
 		model.ReadOnlyModel{},
 		applicationService,
@@ -103,7 +97,7 @@ func (s *DeployLocalSuite) TestDeployMinimal(c *gc.C) {
 
 	app, err := application.DeployApplication(
 		context.Background(),
-		stateDeployer{State: s.ControllerModel(c).State(), modelConfigService: s.modelConfigService(c)},
+		stateDeployer{State: s.ControllerModel(c).State()},
 		s.ControllerModel(c),
 		model.ReadOnlyModel{},
 		applicationService,
@@ -171,7 +165,7 @@ func (s *DeployLocalSuite) TestDeployWithImplicitBindings(c *gc.C) {
 
 	app, err := application.DeployApplication(
 		context.Background(),
-		stateDeployer{State: s.ControllerModel(c).State(), modelConfigService: s.modelConfigService(c)},
+		stateDeployer{State: s.ControllerModel(c).State()},
 		s.ControllerModel(c),
 		model.ReadOnlyModel{},
 		applicationService,
@@ -251,7 +245,7 @@ func (s *DeployLocalSuite) TestDeployWithSomeSpecifiedBindings(c *gc.C) {
 
 	app, err := application.DeployApplication(
 		context.Background(),
-		stateDeployer{State: st, modelConfigService: s.modelConfigService(c)},
+		stateDeployer{State: st},
 		m,
 		model.ReadOnlyModel{},
 		applicationService,
@@ -312,7 +306,7 @@ func (s *DeployLocalSuite) TestDeployWithBoundRelationNamesAndExtraBindingsNames
 
 	app, err := application.DeployApplication(
 		context.Background(),
-		stateDeployer{State: st, modelConfigService: s.modelConfigService(c)},
+		stateDeployer{State: st},
 		m,
 		model.ReadOnlyModel{},
 		applicationService,
@@ -395,7 +389,7 @@ func (s *DeployLocalSuite) TestDeploySettings(c *gc.C) {
 
 	app, err := application.DeployApplication(
 		context.Background(),
-		stateDeployer{State: s.ControllerModel(c).State(), modelConfigService: s.modelConfigService(c)},
+		stateDeployer{State: s.ControllerModel(c).State()},
 		s.ControllerModel(c),
 		model.ReadOnlyModel{},
 		applicationService,
@@ -431,7 +425,7 @@ func (s *DeployLocalSuite) TestDeploySettingsError(c *gc.C) {
 	st := s.ControllerModel(c).State()
 	_, err := application.DeployApplication(
 		context.Background(),
-		stateDeployer{State: st, modelConfigService: s.modelConfigService(c)},
+		stateDeployer{State: st},
 		s.ControllerModel(c),
 		model.ReadOnlyModel{},
 		applicationService,
@@ -479,7 +473,7 @@ func (s *DeployLocalSuite) TestDeployWithApplicationConfig(c *gc.C) {
 
 	app, err := application.DeployApplication(
 		context.Background(),
-		stateDeployer{State: s.ControllerModel(c).State(), modelConfigService: s.modelConfigService(c)},
+		stateDeployer{State: s.ControllerModel(c).State()},
 		s.ControllerModel(c),
 		model.ReadOnlyModel{},
 		applicationService,
@@ -516,7 +510,7 @@ func (s *DeployLocalSuite) TestDeployConstraints(c *gc.C) {
 
 	app, err := application.DeployApplication(
 		context.Background(),
-		stateDeployer{State: st, modelConfigService: s.modelConfigService(c)},
+		stateDeployer{State: st},
 		s.ControllerModel(c),
 		model.ReadOnlyModel{},
 		applicationService,
@@ -859,7 +853,7 @@ func (s *DeployLocalSuite) assertMachines(c *gc.C, app application.Application, 
 	st := s.ControllerModel(c).State()
 	for _, unit := range units {
 		id := unit.UnitTag().Id()
-		res, err := st.AssignStagedUnits(s.modelConfigService(c), nil, []string{id})
+		res, err := st.AssignStagedUnits(nil, []string{id})
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(res[0].Error, jc.ErrorIsNil)
 		c.Assert(res[0].Unit, gc.Equals, id)
@@ -885,7 +879,6 @@ func (s *DeployLocalSuite) assertMachines(c *gc.C, app application.Application, 
 
 type stateDeployer struct {
 	*state.State
-	modelConfigService application.ModelConfigService
 }
 
 func (d stateDeployer) ReadSequence(name string) (int, error) {
@@ -893,11 +886,11 @@ func (d stateDeployer) ReadSequence(name string) (int, error) {
 }
 
 func (d stateDeployer) AddApplication(args state.AddApplicationArgs, store objectstore.ObjectStore) (application.Application, error) {
-	app, err := d.State.AddApplication(d.modelConfigService, args, store)
+	app, err := d.State.AddApplication(args, store)
 	if err != nil {
 		return nil, err
 	}
-	return application.NewStateApplication(d.State, d.modelConfigService, app), nil
+	return application.NewStateApplication(d.State, app), nil
 }
 
 type fakeDeployer struct {

--- a/apiserver/facades/client/application/export_test.go
+++ b/apiserver/facades/client/application/export_test.go
@@ -13,8 +13,8 @@ var (
 	ValidateSecretConfig    = validateSecretConfig
 )
 
-func GetState(st *state.State, modelConfigService ModelConfigService) Backend {
-	return stateShim{State: st, modelConfigService: modelConfigService}
+func GetState(st *state.State) Backend {
+	return stateShim{State: st}
 }
 
 func GetModel(m *state.Model) Model {

--- a/apiserver/facades/client/application/get_test.go
+++ b/apiserver/facades/client/application/get_test.go
@@ -42,12 +42,6 @@ type getSuite struct {
 
 var _ = gc.Suite(&getSuite{})
 
-// modelConfigService is a convenience function to get the controller model's
-// model config service inside a test.
-func (s *getSuite) modelConfigService(c *gc.C) application.ModelConfigService {
-	return s.ControllerDomainServices(c).Config()
-}
-
 func (s *getSuite) SetUpTest(c *gc.C) {
 	s.ApiServerSuite.SetUpTest(c)
 	s.ApiServerSuite.SeedCAASCloud(c)
@@ -75,7 +69,7 @@ func (s *getSuite) SetUpTest(c *gc.C) {
 	})
 
 	api, err := application.NewAPIBase(
-		application.GetState(st, s.modelConfigService(c)),
+		application.GetState(st),
 		nil,
 		domainServices.Network(),
 		storageAccess,
@@ -108,7 +102,7 @@ func (s *getSuite) SetUpTest(c *gc.C) {
 func (s *getSuite) TestClientApplicationGetIAASModelSmokeTest(c *gc.C) {
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService(c))
+
 	f.MakeApplication(c, &factory.ApplicationParams{
 		Name:  "wordpress",
 		Charm: f.MakeCharm(c, &factory.CharmParams{Name: "wordpress"}),
@@ -162,7 +156,7 @@ func (s *getSuite) TestClientApplicationGetCAASModelSmokeTest(c *gc.C) {
 	defer st.Close()
 	f2, release := s.NewFactory(c, st.ModelUUID())
 	defer release()
-	f2 = f2.WithModelConfigService(s.modelConfigService(c))
+
 	ch := f2.MakeCharm(c, &factory.CharmParams{Name: "dashboard4miner", Series: "focal"})
 	app := f2.MakeApplication(c, &factory.ApplicationParams{
 		Name: "dashboard4miner", Charm: ch,
@@ -234,7 +228,7 @@ func (s *getSuite) TestClientApplicationGetCAASModelSmokeTest(c *gc.C) {
 	})
 
 	api, err := application.NewAPIBase(
-		application.GetState(st, s.modelConfigService(c)),
+		application.GetState(st),
 		nil,
 		domainServices.Network(),
 		storageAccess,
@@ -484,7 +478,6 @@ var getTests = []struct {
 func (s *getSuite) TestApplicationGet(c *gc.C) {
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService(c))
 
 	for i, t := range getTests {
 		c.Logf("test %d. %s", i, t.about)
@@ -528,7 +521,7 @@ func (s *getSuite) TestGetMaxResolutionInt(c *gc.C) {
 
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
-	f = f.WithModelConfigService(s.modelConfigService(c))
+
 	app := f.MakeApplication(c, &factory.ApplicationParams{
 		Name:  "test-application",
 		Charm: f.MakeCharm(c, &factory.CharmParams{Name: "dummy"}),

--- a/apiserver/facades/client/client/filtering_test.go
+++ b/apiserver/facades/client/client/filtering_test.go
@@ -28,7 +28,6 @@ var _ = gc.Suite(&filteringStatusSuite{})
 func (s *filteringStatusSuite) TestRelationFiltered(c *gc.C) {
 	factory, release := s.NewFactory(c, s.ControllerModelUUID())
 	release()
-	factory = factory.WithModelConfigService(s.modelConfigService(c))
 	// make application 1 with endpoint 1
 	a1 := factory.MakeApplication(c, &testfactory.ApplicationParams{
 		Name: "abc",
@@ -97,7 +96,6 @@ func (s *filteringStatusSuite) TestRelationFiltered(c *gc.C) {
 func (s *filteringStatusSuite) TestApplicationFilterIndependentOfAlphabeticUnitOrdering(c *gc.C) {
 	factory, release := s.NewFactory(c, s.ControllerModelUUID())
 	release()
-	factory = factory.WithModelConfigService(s.modelConfigService(c))
 	// Application A has no touch points with application C
 	// but will have a unit on the same machine is a unit of an application B.
 	applicationA := factory.MakeApplication(c, &testfactory.ApplicationParams{
@@ -159,7 +157,6 @@ func (s *filteringStatusSuite) TestApplicationFilterIndependentOfAlphabeticUnitO
 func (s *filteringStatusSuite) TestFilterOutRelationsForRelatedApplicationsThatDoNotMatchCriteriaDirectly(c *gc.C) {
 	factory, release := s.NewFactory(c, s.ControllerModelUUID())
 	release()
-	factory = factory.WithModelConfigService(s.modelConfigService(c))
 	// Application A has no touch points with application C
 	// but will have a unit on the same machine is a unit of an application B.
 	applicationA := factory.MakeApplication(c, &testfactory.ApplicationParams{
@@ -223,7 +220,6 @@ func (s *filteringStatusSuite) TestFilterOutRelationsForRelatedApplicationsThatD
 func (s *filteringStatusSuite) TestFilterByPortRange(c *gc.C) {
 	factory, release := s.NewFactory(c, s.ControllerModelUUID())
 	release()
-	factory = factory.WithModelConfigService(s.modelConfigService(c))
 
 	app := factory.MakeApplication(c, &testfactory.ApplicationParams{
 		Charm: factory.MakeCharm(c, &testfactory.CharmParams{

--- a/apiserver/facades/client/client/status_caas_test.go
+++ b/apiserver/facades/client/client/status_caas_test.go
@@ -51,7 +51,6 @@ func (s *CAASStatusSuite) SetUpTest(c *gc.C) {
 	s.CleanupSuite.AddCleanup(func(*gc.C) { st.Close() })
 	f2, release := s.NewFactory(c, st.ModelUUID())
 	defer release()
-	f2 = f2.WithModelConfigService(s.modelConfigService(c))
 	m, err := st.Model()
 	c.Assert(err, jc.ErrorIsNil)
 	s.model = m

--- a/apiserver/facades/client/controller/destroy_test.go
+++ b/apiserver/facades/client/controller/destroy_test.go
@@ -209,8 +209,7 @@ func (s *destroyControllerSuite) TestDestroyControllerDestroyStorageNotSpecified
 	})
 	s.AddCleanup(func(c *gc.C) { _ = modelState.Close() })
 
-	f2 := factory.NewFactory(modelState, s.StatePool(), controllerConfig).
-		WithModelConfigService(s.ControllerDomainServices(c).Config())
+	f2 := factory.NewFactory(modelState, s.StatePool(), controllerConfig)
 	f2.MakeUnit(c, &factory.UnitParams{
 		Application: f2.MakeApplication(c, &factory.ApplicationParams{
 			Charm: f2.MakeCharm(c, &factory.CharmParams{
@@ -254,8 +253,7 @@ func (s *destroyControllerSuite) TestDestroyControllerDestroyStorageSpecified(c 
 	})
 	s.AddCleanup(func(c *gc.C) { _ = modelState.Close() })
 
-	f2 := factory.NewFactory(modelState, s.StatePool(), controllerConfig).
-		WithModelConfigService(s.ControllerDomainServices(c).Config())
+	f2 := factory.NewFactory(modelState, s.StatePool(), controllerConfig)
 	f2.MakeUnit(c, &factory.UnitParams{
 		Application: f2.MakeApplication(c, &factory.ApplicationParams{
 			Charm: f2.MakeCharm(c, &factory.CharmParams{

--- a/apiserver/facades/client/highavailability/highavailability.go
+++ b/apiserver/facades/client/highavailability/highavailability.go
@@ -161,7 +161,7 @@ func (api *HighAvailabilityAPI) enableHASingle(ctx context.Context, spec params.
 	}
 
 	// Might be nicer to pass the spec itself to this method.
-	changes, addedUnits, err := st.EnableHA(api.modelConfigService, spec.NumControllers, spec.Constraints, referenceMachine.Base(), spec.Placement)
+	changes, addedUnits, err := st.EnableHA(spec.NumControllers, spec.Constraints, referenceMachine.Base(), spec.Placement)
 	if err != nil {
 		return params.ControllersChanges{}, err
 	}

--- a/apiserver/facades/client/highavailability/highavailability_test.go
+++ b/apiserver/facades/client/highavailability/highavailability_test.go
@@ -11,7 +11,6 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facade/facadetest"
 	"github.com/juju/juju/apiserver/facades/client/highavailability"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
@@ -44,12 +43,6 @@ var (
 	controllerCons = constraints.MustParse("mem=16G cores=16")
 )
 
-// modelConfigService is a convenience function to get the controller model's
-// model config service inside a test.
-func (s *clientSuite) modelConfigService(c *gc.C) common.ModelConfigService {
-	return s.ControllerDomainServices(c).Config()
-}
-
 func (s *clientSuite) SetUpTest(c *gc.C) {
 	s.ApiServerSuite.SetUpTest(c)
 
@@ -70,7 +63,6 @@ func (s *clientSuite) SetUpTest(c *gc.C) {
 	// We have to ensure the agents are alive, or EnableHA will create more to
 	// replace them.
 	_, err = st.AddMachines(
-		s.modelConfigService(c),
 		state.MachineTemplate{
 			Base:        state.UbuntuBase("12.10"),
 			Jobs:        []state.MachineJob{state.JobManageModel},
@@ -381,7 +373,6 @@ func (s *clientSuite) TestEnableHAPlacementTo(c *gc.C) {
 	st := s.ControllerModel(c).State()
 	machine1Cons := constraints.MustParse("mem=8G")
 	_, err := st.AddMachines(
-		s.modelConfigService(c),
 		state.MachineTemplate{
 			Base:        state.UbuntuBase("12.10"),
 			Jobs:        []state.MachineJob{state.JobHostUnits},
@@ -390,7 +381,7 @@ func (s *clientSuite) TestEnableHAPlacementTo(c *gc.C) {
 	)
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = st.AddMachine(s.modelConfigService(c), state.UbuntuBase("12.10"), state.JobHostUnits)
+	_, err = st.AddMachine(state.UbuntuBase("12.10"), state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 
 	placement := []string{"1", "2"}

--- a/apiserver/facades/client/machinemanager/register.go
+++ b/apiserver/facades/client/machinemanager/register.go
@@ -40,8 +40,7 @@ func makeFacadeV11(stdCtx context.Context, ctx facade.ModelContext) (*MachineMan
 	domainServices := ctx.DomainServices()
 
 	backend := &stateShim{
-		State:              st,
-		modelConfigService: domainServices.Config(),
+		State: st,
 	}
 	storageAccess, err := getStorageState(st)
 	if err != nil {

--- a/apiserver/facades/client/machinemanager/state.go
+++ b/apiserver/facades/client/machinemanager/state.go
@@ -75,7 +75,6 @@ type Charm interface {
 
 type stateShim struct {
 	*state.State
-	modelConfigService ModelConfigService
 }
 
 func (s stateShim) Application(name string) (Application, error) {
@@ -99,17 +98,17 @@ func (s stateShim) Machine(name string) (Machine, error) {
 }
 
 func (s stateShim) AddOneMachine(template state.MachineTemplate) (Machine, error) {
-	m, err := s.State.AddOneMachine(s.modelConfigService, template)
+	m, err := s.State.AddOneMachine(template)
 	return machineShim{Machine: m}, err
 }
 
 func (s stateShim) AddMachineInsideNewMachine(template, parentTemplate state.MachineTemplate, containerType instance.ContainerType) (Machine, error) {
-	m, err := s.State.AddMachineInsideNewMachine(s.modelConfigService, template, parentTemplate, containerType)
+	m, err := s.State.AddMachineInsideNewMachine(template, parentTemplate, containerType)
 	return machineShim{Machine: m}, err
 }
 
 func (s stateShim) AddMachineInsideMachine(template state.MachineTemplate, parentId string, containerType instance.ContainerType) (Machine, error) {
-	m, err := s.State.AddMachineInsideMachine(s.modelConfigService, template, parentId, containerType)
+	m, err := s.State.AddMachineInsideMachine(template, parentId, containerType)
 	return machineShim{Machine: m}, err
 }
 

--- a/apiserver/facades/client/storage/register.go
+++ b/apiserver/facades/client/storage/register.go
@@ -48,7 +48,7 @@ func newStorageAPI(ctx facade.ModelContext) (*StorageAPI, error) {
 	}
 
 	domainServices := ctx.DomainServices()
-	storageAccessor, err := getStorageAccessor(st, domainServices.Config())
+	storageAccessor, err := getStorageAccessor(st)
 	if err != nil {
 		return nil, errors.Annotate(err, "getting backend")
 	}

--- a/apiserver/facades/client/storage/shim.go
+++ b/apiserver/facades/client/storage/shim.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/juju/names/v5"
 
-	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/common/storagecommon"
 	"github.com/juju/juju/core/blockdevice"
 	"github.com/juju/juju/state"
@@ -100,9 +99,8 @@ type storageFile interface {
 
 var getStorageAccessor = func(
 	st *state.State,
-	modelConfigService common.ModelConfigService,
 ) (storageAccess, error) {
-	sb, err := state.NewStorageConfigBackend(st, modelConfigService)
+	sb, err := state.NewStorageConfigBackend(st)
 	if err != nil {
 		return nil, err
 	}

--- a/apiserver/facades/controller/applicationscaler/shim.go
+++ b/apiserver/facades/controller/applicationscaler/shim.go
@@ -6,7 +6,6 @@ package applicationscaler
 import (
 	"github.com/juju/errors"
 
-	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/state"
 )
@@ -20,8 +19,7 @@ import (
 func newAPI(ctx facade.ModelContext) (*Facade, error) {
 	st := ctx.State()
 	return NewFacade(backendShim{
-		st:                 st,
-		modelConfigService: ctx.DomainServices().Config(),
+		st: st,
 	}, ctx.Resources(), ctx.Auth())
 }
 
@@ -33,8 +31,7 @@ func newAPI(ctx facade.ModelContext) (*Facade, error) {
 // ...so long as it stays simple, and the full functionality remains tested
 // elsewhere.
 type backendShim struct {
-	st                 *state.State
-	modelConfigService common.ModelConfigService
+	st *state.State
 }
 
 // WatchScaledServices is part of the Backend interface.
@@ -48,5 +45,5 @@ func (shim backendShim) RescaleService(name string) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	return service.EnsureMinUnits(shim.modelConfigService)
+	return service.EnsureMinUnits()
 }

--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations.go
@@ -167,7 +167,7 @@ func (api *CrossModelRelationsAPIv3) PublishRelationChanges(
 				continue
 			}
 		}
-		if err := commoncrossmodel.PublishRelationChange(ctx, api.authorizer, api.st, api.modelConfigService, api.modelID, relationTag, applicationTag, change); err != nil {
+		if err := commoncrossmodel.PublishRelationChange(ctx, api.authorizer, api.st, api.modelID, relationTag, applicationTag, change); err != nil {
 			results.Results[i].Error = apiservererrors.ServerError(err)
 			continue
 		}

--- a/apiserver/facades/controller/crossmodelrelations/crossmodelrelations_test.go
+++ b/apiserver/facades/controller/crossmodelrelations/crossmodelrelations_test.go
@@ -224,7 +224,7 @@ func (s *crossmodelRelationsSuite) assertPublishRelationsChanges(c *gc.C, lifeVa
 	} else {
 		ru1.CheckCalls(c, []testing.StubCall{
 			{"InScope", []interface{}{}},
-			{"EnterScope", []interface{}{s.modelConfigService, map[string]interface{}{"foo": "bar"}}},
+			{"EnterScope", []interface{}{map[string]interface{}{"foo": "bar"}}},
 		})
 		if lifeValue == life.Alive {
 			rel.CheckCalls(c, []testing.StubCall{
@@ -764,7 +764,7 @@ func (s *crossmodelRelationsSuite) TestPublishChangesWithApplicationSettingsRemo
 	s.st.CheckCalls(c, expected)
 	ru1.CheckCalls(c, []testing.StubCall{
 		{"InScope", []interface{}{}},
-		{"EnterScope", []interface{}{s.modelConfigService, map[string]interface{}{"foo": "bar"}}},
+		{"EnterScope", []interface{}{map[string]interface{}{"foo": "bar"}}},
 	})
 	ru2.CheckCalls(c, []testing.StubCall{
 		{"LeaveScope", []interface{}{}},
@@ -836,7 +836,7 @@ func (s *crossmodelRelationsSuite) TestPublishChangesWithApplicationSettingsRemo
 	s.st.CheckCalls(c, expected)
 	ru1.CheckCalls(c, []testing.StubCall{
 		{"InScope", []interface{}{}},
-		{"EnterScope", []interface{}{s.modelConfigService, map[string]interface{}{"foo": "bar"}}},
+		{"EnterScope", []interface{}{map[string]interface{}{"foo": "bar"}}},
 	})
 	ru2.CheckCalls(c, []testing.StubCall{
 		{"LeaveScope", []interface{}{}},

--- a/apiserver/facades/controller/crossmodelrelations/mock_test.go
+++ b/apiserver/facades/controller/crossmodelrelations/mock_test.go
@@ -610,8 +610,8 @@ func (u *mockRelationUnit) LeaveScope() error {
 	return nil
 }
 
-func (u *mockRelationUnit) EnterScope(modelConfigService state.ModelConfigService, settings map[string]interface{}) error {
-	u.MethodCall(u, "EnterScope", modelConfigService, settings)
+func (u *mockRelationUnit) EnterScope(settings map[string]interface{}) error {
+	u.MethodCall(u, "EnterScope", settings)
 	if err := u.NextErr(); err != nil {
 		return err
 	}

--- a/apiserver/facades/controller/firewaller/firewaller_base_test.go
+++ b/apiserver/facades/controller/firewaller/firewaller_base_test.go
@@ -51,16 +51,14 @@ func (s *firewallerBaseSuite) SetUpTest(c *gc.C) {
 	// Note that the specific machine ids allocated are assumed
 	// to be numerically consecutive from zero.
 	st := s.ControllerModel(c).State()
-	modelConfigService := s.ControllerDomainServices(c).Config()
 	for i := 0; i <= 2; i++ {
-		machine, err := st.AddMachine(modelConfigService, state.UbuntuBase("12.10"), state.JobHostUnits)
+		machine, err := st.AddMachine(state.UbuntuBase("12.10"), state.JobHostUnits)
 		c.Check(err, jc.ErrorIsNil)
 		s.machines = append(s.machines, machine)
 	}
 	// Create an application and three units for these machines.
 	f, release := s.NewFactory(c, s.ControllerModelUUID())
 	defer release()
-	f = f.WithModelConfigService(modelConfigService)
 
 	s.charm = f.MakeCharm(c, &factory.CharmParams{Name: "wordpress"})
 	s.application = f.MakeApplication(c, &factory.ApplicationParams{
@@ -69,9 +67,9 @@ func (s *firewallerBaseSuite) SetUpTest(c *gc.C) {
 	})
 	// Add the rest of the units and assign them.
 	for i := 0; i <= 2; i++ {
-		unit, err := s.application.AddUnit(modelConfigService, state.AddUnitParams{})
+		unit, err := s.application.AddUnit(state.AddUnitParams{})
 		c.Check(err, jc.ErrorIsNil)
-		err = unit.AssignToMachine(modelConfigService, s.machines[i])
+		err = unit.AssignToMachine(s.machines[i])
 		c.Check(err, jc.ErrorIsNil)
 		s.units = append(s.units, unit)
 	}
@@ -382,7 +380,7 @@ func (s *firewallerBaseSuite) testGetAssignedMachine(
 	})
 
 	// Now reset assign unit 2 again and check.
-	err = s.units[2].AssignToMachine(s.ControllerDomainServices(c).Config(), s.machines[0])
+	err = s.units[2].AssignToMachine(s.machines[0])
 	c.Assert(err, jc.ErrorIsNil)
 
 	args = params.Entities{Entities: []params.Entity{

--- a/apiserver/facades/controller/firewaller/firewaller_test.go
+++ b/apiserver/facades/controller/firewaller/firewaller_test.go
@@ -225,7 +225,6 @@ func (s *firewallerSuite) TestAreManuallyProvisioned(c *gc.C) {
 
 	st := s.ControllerModel(c).State()
 	m, err := st.AddOneMachine(
-		s.modelConfigService,
 		state.MachineTemplate{
 			Base:       state.UbuntuBase("12.10"),
 			Jobs:       []state.MachineJob{state.JobHostUnits},

--- a/apiserver/facades/controller/remoterelations/mock_test.go
+++ b/apiserver/facades/controller/remoterelations/mock_test.go
@@ -338,8 +338,8 @@ func (u *mockRelationUnit) LeaveScope() error {
 	return nil
 }
 
-func (u *mockRelationUnit) EnterScope(modelConfigService state.ModelConfigService, settings map[string]interface{}) error {
-	u.MethodCall(u, "EnterScope", modelConfigService, settings)
+func (u *mockRelationUnit) EnterScope(settings map[string]interface{}) error {
+	u.MethodCall(u, "EnterScope", settings)
 	if err := u.NextErr(); err != nil {
 		return err
 	}

--- a/apiserver/facades/controller/remoterelations/remoterelations.go
+++ b/apiserver/facades/controller/remoterelations/remoterelations.go
@@ -391,7 +391,7 @@ func (api *API) ConsumeRemoteRelationChanges(ctx context.Context, changes params
 			continue
 		}
 		api.logger.Debugf("ConsumeRemoteRelationChanges: rel tag %v; app tag: %v", relationTag, applicationTag)
-		if err := commoncrossmodel.PublishRelationChange(ctx, api.authorizer, api.st, api.modelConfigService, api.modelID, relationTag, applicationTag, change); err != nil {
+		if err := commoncrossmodel.PublishRelationChange(ctx, api.authorizer, api.st, api.modelID, relationTag, applicationTag, change); err != nil {
 			results.Results[i].Error = apiservererrors.ServerError(err)
 			continue
 		}

--- a/apiserver/resources_mig_test.go
+++ b/apiserver/resources_mig_test.go
@@ -60,7 +60,7 @@ func (s *resourcesUploadSuite) SetUpTest(c *gc.C) {
 
 	newFactory, release := s.NewFactory(c, s.importingModel.UUID())
 	defer release()
-	newFactory = newFactory.WithModelConfigService(s.ControllerDomainServices(c).Config())
+
 	app := newFactory.MakeApplication(c, nil)
 	s.appName = app.Name()
 

--- a/apiserver/server_test.go
+++ b/apiserver/server_test.go
@@ -184,7 +184,7 @@ func (s *serverSuite) TestOpenAsMachineErrors(c *gc.C) {
 
 	// Now add another machine, intentionally unprovisioned.
 	st1 := s.ControllerModel(c).State()
-	stm1, err := st1.AddMachine(s.ControllerDomainServices(c).Config(), state.UbuntuBase("12.10"), state.JobHostUnits)
+	stm1, err := st1.AddMachine(state.UbuntuBase("12.10"), state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 	err = stm1.SetPassword(password)
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/tools_test.go
+++ b/apiserver/tools_test.go
@@ -198,7 +198,7 @@ func (s *toolsSuite) TestRequiresPOST(c *gc.C) {
 func (s *toolsSuite) TestAuthRequiresUser(c *gc.C) {
 	// Add a machine and try to login.
 	st := s.ControllerModel(c).State()
-	machine, err := st.AddMachine(s.ControllerDomainServices(c).Config(), state.UbuntuBase("12.10"), state.JobHostUnits)
+	machine, err := st.AddMachine(state.UbuntuBase("12.10"), state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 	err = machine.SetProvisioned("foo", "", "fake_nonce", nil)
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/jujud-controller/agent/machine_legacy_test.go
+++ b/cmd/jujud-controller/agent/machine_legacy_test.go
@@ -567,7 +567,7 @@ func (s *MachineLegacySuite) TestManageModelRunsCleaner(c *gc.C) {
 			Name:  "wordpress",
 			Charm: f.MakeCharm(c, &factory.CharmParams{Name: "wordpress"}),
 		})
-		unit, err := app.AddUnit(s.modelConfigService(c), state.AddUnitParams{})
+		unit, err := app.AddUnit(state.AddUnitParams{})
 		c.Assert(err, jc.ErrorIsNil)
 		err = app.Destroy(testing.NewObjectStore(c, s.ControllerModelUUID()))
 		c.Assert(err, jc.ErrorIsNil)
@@ -725,9 +725,9 @@ func (s *MachineLegacySuite) TestManageModelRunsInstancePoller(c *gc.C) {
 			}},
 		Constraints: constraints.MustParse("arch=" + arch),
 	})
-	unit, err := app.AddUnit(s.modelConfigService(c), state.AddUnitParams{})
+	unit, err := app.AddUnit(state.AddUnitParams{})
 	c.Assert(err, jc.ErrorIsNil)
-	err = s.ControllerModel(c).State().AssignUnit(s.modelConfigService(c), unit, state.AssignNew)
+	err = s.ControllerModel(c).State().AssignUnit(unit, state.AssignNew)
 	c.Assert(err, jc.ErrorIsNil)
 
 	m, instId := s.waitProvisioned(c, unit)

--- a/cmd/jujud-controller/agent/machine_test.go
+++ b/cmd/jujud-controller/agent/machine_test.go
@@ -538,10 +538,9 @@ func (s *MachineSuite) TestMachineAgentIgnoreAddressesContainer(c *gc.C) {
 	ignoreAddressCh := s.setupIgnoreAddresses(c, true)
 
 	st := s.ControllerModel(c).State()
-	parent, err := st.AddMachine(s.modelConfigService(c), state.UbuntuBase("20.04"), state.JobHostUnits)
+	parent, err := st.AddMachine(state.UbuntuBase("20.04"), state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 	m, err := st.AddMachineInsideMachine(
-		s.modelConfigService(c),
 		state.MachineTemplate{
 			Base: state.UbuntuBase("22.04"),
 			Jobs: []state.MachineJob{state.JobHostUnits},

--- a/cmd/jujud-controller/agent/util_test.go
+++ b/cmd/jujud-controller/agent/util_test.go
@@ -80,12 +80,6 @@ type commonMachineSuite struct {
 	cmdRunner *mocks.MockCommandRunner
 }
 
-// modelConfigService is a convenience function to get the controller model's
-// model config service inside a test.
-func (s *commonMachineSuite) modelConfigService(c *gc.C) state.ModelConfigService {
-	return s.ControllerDomainServices(c).Config()
-}
-
 func (s *commonMachineSuite) SetUpSuite(c *gc.C) {
 	s.AgentSuite.SetUpSuite(c)
 	// Set up FakeJujuXDGDataHomeSuite after AgentSuite since
@@ -194,7 +188,7 @@ func (s *commonMachineSuite) primeAgent(c *gc.C, jobs ...state.MachineJob) (
 // primeAgentVersion is similar to primeAgent, but permits the
 // caller to specify the version.Binary to prime with.
 func (s *commonMachineSuite) primeAgentVersion(c *gc.C, vers version.Binary, jobs ...state.MachineJob) (m *state.Machine, agentConfig agent.ConfigSetterWriter, tools *tools.Tools) {
-	m, err := s.ControllerModel(c).State().AddMachine(s.modelConfigService(c), state.UbuntuBase("12.10"), jobs...)
+	m, err := s.ControllerModel(c).State().AddMachine(state.UbuntuBase("12.10"), jobs...)
 	c.Assert(err, jc.ErrorIsNil)
 	// TODO(wallyworld) - we need the dqlite model database to be available.
 	// s.createMachine(c, m.Id())

--- a/cmd/jujud/agent/machine_test.go
+++ b/cmd/jujud/agent/machine_test.go
@@ -429,10 +429,9 @@ func (s *MachineSuite) TestMachineAgentIgnoreAddressesContainer(c *gc.C) {
 	ignoreAddressCh := s.setupIgnoreAddresses(c, true)
 
 	st := s.ControllerModel(c).State()
-	parent, err := st.AddMachine(s.modelConfigService(c), state.UbuntuBase("20.04"), state.JobHostUnits)
+	parent, err := st.AddMachine(state.UbuntuBase("20.04"), state.JobHostUnits)
 	c.Assert(err, jc.ErrorIsNil)
 	m, err := st.AddMachineInsideMachine(
-		s.modelConfigService(c),
 		state.MachineTemplate{
 			Base: state.UbuntuBase("22.04"),
 			Jobs: []state.MachineJob{state.JobHostUnits},

--- a/cmd/jujud/agent/util_test.go
+++ b/cmd/jujud/agent/util_test.go
@@ -66,12 +66,6 @@ type commonMachineSuite struct {
 	cmdRunner *mocks.MockCommandRunner
 }
 
-// modelConfigService is a convenience function to get the controller model's
-// model config service inside a test.
-func (s *commonMachineSuite) modelConfigService(c *gc.C) state.ModelConfigService {
-	return s.ControllerDomainServices(c).Config()
-}
-
 func (s *commonMachineSuite) SetUpSuite(c *gc.C) {
 	s.AgentSuite.SetUpSuite(c)
 	// Set up FakeJujuXDGDataHomeSuite after AgentSuite since
@@ -150,7 +144,7 @@ func (s *commonMachineSuite) primeAgent(c *gc.C, jobs ...state.MachineJob) (m *s
 // primeAgentVersion is similar to primeAgent, but permits the
 // caller to specify the version.Binary to prime with.
 func (s *commonMachineSuite) primeAgentVersion(c *gc.C, vers version.Binary, jobs ...state.MachineJob) (m *state.Machine, agentConfig agent.ConfigSetterWriter, tools *tools.Tools) {
-	m, err := s.ControllerModel(c).State().AddMachine(s.modelConfigService(c), state.UbuntuBase("12.10"), jobs...)
+	m, err := s.ControllerModel(c).State().AddMachine(state.UbuntuBase("12.10"), jobs...)
 	c.Assert(err, jc.ErrorIsNil)
 	// TODO(wallyworld) - we need the dqlite model database to be available.
 	// s.createMachine(c, m.Id())

--- a/internal/worker/bootstrap/deployer.go
+++ b/internal/worker/bootstrap/deployer.go
@@ -202,7 +202,6 @@ func (c charmUploader) ModelUUID() string {
 
 type stateShim struct {
 	*state.State
-	modelConfigService ModelConfigService
 }
 
 func (s *stateShim) PrepareCharmUpload(curl string) (services.UploadedCharm, error) {
@@ -214,7 +213,7 @@ func (s *stateShim) UpdateUploadedCharm(info state.CharmInfo) (services.Uploaded
 }
 
 func (s *stateShim) AddApplication(args state.AddApplicationArgs, objectStore objectstore.ObjectStore) (bootstrap.Application, error) {
-	a, err := s.State.AddApplication(s.modelConfigService, args, objectStore)
+	a, err := s.State.AddApplication(args, objectStore)
 	if err != nil {
 		return nil, err
 	}
@@ -234,7 +233,7 @@ func (s *stateShim) Unit(tag string) (bootstrap.Unit, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &unitShim{Unit: u, modelConfigService: s.modelConfigService}, nil
+	return &unitShim{Unit: u}, nil
 }
 
 func (s *stateShim) Machine(name string) (bootstrap.Machine, error) {
@@ -263,11 +262,10 @@ type charmShim struct {
 
 type unitShim struct {
 	*state.Unit
-	modelConfigService ModelConfigService
 }
 
 func (u *unitShim) AssignToMachineRef(ref state.MachineRef) error {
-	return u.Unit.AssignToMachineRef(u.modelConfigService, ref)
+	return u.Unit.AssignToMachineRef(ref)
 }
 
 type machineShim struct {

--- a/internal/worker/bootstrap/manifold.go
+++ b/internal/worker/bootstrap/manifold.go
@@ -266,8 +266,7 @@ func Manifold(config ManifoldConfig) dependency.Manifold {
 				NetworkService:          controllerModelDomainServices.Network(),
 				BakeryConfigService:     controllerDomainServices.Macaroon(),
 				SystemState: &stateShim{
-					State:              systemState,
-					modelConfigService: controllerModelDomainServices.Config(),
+					State: systemState,
 				},
 				BootstrapUnlocker:       bootstrapUnlocker,
 				AgentBinaryUploader:     config.AgentBinaryUploader,

--- a/juju/testing/apiserver.go
+++ b/juju/testing/apiserver.go
@@ -517,7 +517,7 @@ func (s *ApiServerSuite) OpenAPIAsNewMachine(c *gc.C, jobs ...state.MachineJob) 
 	}
 
 	st := s.ControllerModel(c).State()
-	machine, err := st.AddMachine(s.ControllerDomainServices(c).Config(), state.UbuntuBase("12.10"), jobs...)
+	machine, err := st.AddMachine(state.UbuntuBase("12.10"), jobs...)
 	c.Assert(err, jc.ErrorIsNil)
 	password, err := password.RandomPassword()
 	c.Assert(err, jc.ErrorIsNil)

--- a/juju/testing/utils.go
+++ b/juju/testing/utils.go
@@ -150,10 +150,9 @@ func (p lxdCharmProfiler) LXDProfile() lxdprofile.LXDProfile {
 func AddControllerMachine(
 	c *gc.C,
 	st *state.State,
-	modelConfigService state.ModelConfigService,
 	controllerConfig controller.Config,
 ) *state.Machine {
-	machine, err := st.AddMachine(modelConfigService, state.UbuntuBase("12.10"), state.JobManageModel)
+	machine, err := st.AddMachine(state.UbuntuBase("12.10"), state.JobManageModel)
 	c.Assert(err, jc.ErrorIsNil)
 	err = machine.SetProviderAddresses(controllerConfig, network.NewSpaceAddress("0.1.2.3"))
 	c.Assert(err, jc.ErrorIsNil)

--- a/state/enableha.go
+++ b/state/enableha.go
@@ -90,7 +90,6 @@ func (st *State) maintainControllersOps(newIds []string, bootstrapOnly bool) ([]
 // exhausted; thereafter any new machines are started according to the constraints and series.
 // MachineID is the id of the machine where the apiserver is running.
 func (st *State) EnableHA(
-	modelConfigService ModelConfigService,
 	numControllers int, cons constraints.Value, base Base, placement []string,
 ) (ControllersChanges, []string, error) {
 
@@ -149,7 +148,7 @@ func (st *State) EnableHA(
 		logger.Infof("%d new machines; converting %v", intent.newCount, intent.convert)
 
 		var ops []txn.Op
-		ops, change, addedUnits, err = st.enableHAIntentionOps(modelConfigService, intent, cons, base)
+		ops, change, addedUnits, err = st.enableHAIntentionOps(intent, cons, base)
 		return ops, err
 	}
 	if err := st.db().Run(buildTxn); err != nil {
@@ -169,7 +168,6 @@ type ControllersChanges struct {
 
 // enableHAIntentionOps returns operations to fulfil the desired intent.
 func (st *State) enableHAIntentionOps(
-	modelConfigService ModelConfigService,
 	intent *enableHAIntent,
 	cons constraints.Value,
 	base Base,
@@ -191,7 +189,7 @@ func (st *State) enableHAIntentionOps(
 		change.Converted = append(change.Converted, m.Id())
 		// Add a controller charm unit to the promoted machine.
 		if controllerApp != nil {
-			unitName, unitOps, err := controllerApp.addUnitOps(modelConfigService, "", AddUnitParams{machineID: m.Id()}, nil)
+			unitName, unitOps, err := controllerApp.addUnitOps("", AddUnitParams{machineID: m.Id()}, nil)
 			if err != nil {
 				return nil, ControllersChanges{}, nil, errors.Trace(err)
 			}
@@ -243,7 +241,7 @@ func (st *State) enableHAIntentionOps(
 			template.Dirty = true
 			template.principals = []string{controllerUnitName}
 		}
-		mdoc, addOps, err := st.addMachineOps(modelConfigService, template)
+		mdoc, addOps, err := st.addMachineOps(template)
 		if err != nil {
 			return nil, ControllersChanges{}, nil, errors.Trace(err)
 		}
@@ -253,7 +251,7 @@ func (st *State) enableHAIntentionOps(
 		ops = append(ops, addOps...)
 		change.Added = append(change.Added, mdoc.Id)
 		if controllerApp != nil {
-			_, unitOps, err := controllerApp.addUnitOps(modelConfigService, "", AddUnitParams{
+			_, unitOps, err := controllerApp.addUnitOps("", AddUnitParams{
 				UnitName:  &controllerUnitName,
 				machineID: mdoc.Id,
 			}, nil)

--- a/state/filesystem.go
+++ b/state/filesystem.go
@@ -4,7 +4,6 @@
 package state
 
 import (
-	"context"
 	"fmt"
 	"path"
 	"regexp"
@@ -1168,16 +1167,12 @@ func (sb *storageBackend) newFilesystemOps(doc filesystemDoc, status statusDoc) 
 
 func (sb *storageConfigBackend) filesystemParamsWithDefaults(params FilesystemParams) (FilesystemParams, error) {
 	if params.Pool == "" {
-		modelConfig, err := sb.modelConfigService.ModelConfig(context.Background())
-		if err != nil {
-			return FilesystemParams{}, errors.Trace(err)
-		}
 		cons := StorageConstraints{
 			Pool:  params.Pool,
 			Size:  params.Size,
 			Count: 1,
 		}
-		poolName, err := defaultStoragePool(sb.modelType, modelConfig, storage.StorageKindFilesystem, cons)
+		poolName, err := defaultStoragePool(sb.modelType, storage.StorageKindFilesystem, cons)
 		if err != nil {
 			return FilesystemParams{}, errors.Annotate(err, "getting default filesystem storage pool")
 		}

--- a/state/minimumunits.go
+++ b/state/minimumunits.go
@@ -146,9 +146,7 @@ func (a *Application) MinUnits() int {
 
 // EnsureMinUnits adds new units if the application's MinUnits value is greater
 // than the number of alive units.
-func (a *Application) EnsureMinUnits(
-	modelConfigService ModelConfigService,
-) (err error) {
+func (a *Application) EnsureMinUnits() (err error) {
 	defer errors.DeferredAnnotatef(&err, "cannot ensure minimum units for application %q", a)
 	app := &Application{st: a.st, doc: a.doc}
 	for {
@@ -170,7 +168,7 @@ func (a *Application) EnsureMinUnits(
 		if missing <= 0 {
 			return nil
 		}
-		name, ops, err := ensureMinUnitsOps(modelConfigService, app)
+		name, ops, err := ensureMinUnitsOps(app)
 		if err != nil {
 			return err
 		}
@@ -182,7 +180,7 @@ func (a *Application) EnsureMinUnits(
 			if err != nil {
 				return err
 			}
-			if err := app.st.AssignUnit(modelConfigService, unit, AssignNew); err != nil {
+			if err := app.st.AssignUnit(unit, AssignNew); err != nil {
 				return err
 			}
 			// No need to proceed and refresh the application if this was the
@@ -213,10 +211,7 @@ func aliveUnitsCount(app *Application) (int, error) {
 // ensureMinUnitsOps returns the operations required to add a unit for the
 // application in MongoDB and the name for the new unit. The resulting transaction
 // will be aborted if the application document changes when running the operations.
-func ensureMinUnitsOps(
-	modelConfigService ModelConfigService,
-	app *Application,
-) (string, []txn.Op, error) {
+func ensureMinUnitsOps(app *Application) (string, []txn.Op, error) {
 	asserts := bson.D{{"txn-revno", app.doc.TxnRevno}}
-	return app.addUnitOps(modelConfigService, "", AddUnitParams{}, asserts)
+	return app.addUnitOps("", AddUnitParams{}, asserts)
 }

--- a/state/relationunit.go
+++ b/state/relationunit.go
@@ -73,7 +73,6 @@ func (ru *RelationUnit) UnitName() string {
 // intervention; the relation will not be able to become Dead until all units
 // have departed its scopes.
 func (ru *RelationUnit) EnterScope(
-	modelConfigService ModelConfigService,
 	settings map[string]interface{},
 ) error {
 	db, dbCloser := ru.st.newDB()
@@ -201,7 +200,7 @@ func (ru *RelationUnit) EnterScope(
 		})
 
 		// * If the unit should have a subordinate, and does not, create it.
-		if subOps, subName, err := ru.subordinateOps(modelConfigService); err != nil {
+		if subOps, subName, err := ru.subordinateOps(); err != nil {
 			return nil, errors.Trace(err)
 		} else {
 			existingSubName = subName
@@ -241,7 +240,7 @@ func (ru *RelationUnit) counterpartApplicationSettingsKeys() []string {
 // subordinate state when entering scope. If a required subordinate unit
 // exists and is Alive, its name will be returned as well; if one exists
 // but is not Alive, ErrCannotEnterScopeYet is returned.
-func (ru *RelationUnit) subordinateOps(modelConfigService ModelConfigService) ([]txn.Op, string, error) {
+func (ru *RelationUnit) subordinateOps() ([]txn.Op, string, error) {
 	units, closer := ru.st.db().GetCollection(unitsC)
 	defer closer()
 
@@ -281,7 +280,7 @@ func (ru *RelationUnit) subordinateOps(modelConfigService ModelConfigService) ([
 		if err != nil {
 			return nil, "", err
 		}
-		_, ops, err := application.addUnitOps(modelConfigService, unitName, AddUnitParams{
+		_, ops, err := application.addUnitOps(unitName, AddUnitParams{
 			machineID: principalMachineID,
 		}, nil)
 		return ops, "", err

--- a/state/state.go
+++ b/state/state.go
@@ -1057,7 +1057,6 @@ type AddApplicationArgs struct {
 // supplied name (which must be unique). If the charm defines peer relations,
 // they will be created automatically.
 func (st *State) AddApplication(
-	modelConfigService ModelConfigService,
 	args AddApplicationArgs,
 	store objectstore.ObjectStore,
 ) (_ *Application, err error) {
@@ -1128,7 +1127,7 @@ func (st *State) AddApplication(
 	if args.Storage == nil {
 		args.Storage = make(map[string]StorageConstraints)
 	}
-	sb, err := NewStorageConfigBackend(st, modelConfigService)
+	sb, err := NewStorageConfigBackend(st)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -1333,7 +1332,6 @@ func (st *State) AddApplication(
 		// Collect unit-adding operations.
 		for x := 0; x < args.NumUnits; x++ {
 			unitName, unitOps, err := app.addUnitOpsWithCons(
-				modelConfigService,
 				applicationAddUnitOpsArgs{
 					cons:          args.Constraints,
 					storageCons:   args.Storage,
@@ -1512,7 +1510,6 @@ func assignUnitOps(unitName string, placement instance.Placement) []txn.Op {
 // AssignStagedUnits gets called by the UnitAssigner worker, and runs the given
 // assignments.
 func (st *State) AssignStagedUnits(
-	modelConfigService ModelConfigService,
 	allSpaces network.SpaceInfos,
 	ids []string,
 ) ([]UnitAssignmentResult, error) {
@@ -1523,7 +1520,7 @@ func (st *State) AssignStagedUnits(
 	}
 	results := make([]UnitAssignmentResult, len(unitAssignments))
 	for i, a := range unitAssignments {
-		err := st.assignStagedUnit(modelConfigService, a, allSpaces)
+		err := st.assignStagedUnit(a, allSpaces)
 		results[i].Unit = a.Unit
 		results[i].Error = err
 	}
@@ -1563,7 +1560,6 @@ func removeStagedAssignmentOp(id string) txn.Op {
 }
 
 func (st *State) assignStagedUnit(
-	modelConfigService ModelConfigService,
 	a UnitAssignment,
 	allSpaces network.SpaceInfos,
 ) error {
@@ -1572,18 +1568,17 @@ func (st *State) assignStagedUnit(
 		return errors.Trace(err)
 	}
 	if a.Scope == "" && a.Directive == "" {
-		return errors.Trace(st.AssignUnit(modelConfigService, u, AssignNew))
+		return errors.Trace(st.AssignUnit(u, AssignNew))
 	}
 
 	placement := &instance.Placement{Scope: a.Scope, Directive: a.Directive}
 
-	return errors.Trace(st.AssignUnitWithPlacement(modelConfigService, u, placement, allSpaces))
+	return errors.Trace(st.AssignUnitWithPlacement(u, placement, allSpaces))
 }
 
 // AssignUnitWithPlacement chooses a machine using the given placement directive
 // and then assigns the unit to it.
 func (st *State) AssignUnitWithPlacement(
-	modelConfigService ModelConfigService,
 	unit *Unit,
 	placement *instance.Placement,
 	allSpaces network.SpaceInfos,
@@ -1596,14 +1591,14 @@ func (st *State) AssignUnitWithPlacement(
 		return errors.Trace(err)
 	}
 	if data.placementType() == directivePlacement {
-		return unit.assignToNewMachine(modelConfigService, data.directive)
+		return unit.assignToNewMachine(data.directive)
 	}
 
-	m, err := st.addMachineWithPlacement(modelConfigService, unit, data, allSpaces)
+	m, err := st.addMachineWithPlacement(unit, data, allSpaces)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	return unit.AssignToMachine(modelConfigService, m)
+	return unit.AssignToMachine(m)
 }
 
 // placementData is a helper type that encodes some of the logic behind how an
@@ -1655,7 +1650,6 @@ func (st *State) parsePlacement(placement *instance.Placement) (*placementData, 
 // addMachineWithPlacement finds a machine that matches the given
 // placement directive for the given unit.
 func (st *State) addMachineWithPlacement(
-	modelConfigService ModelConfigService,
 	unit *Unit,
 	data *placementData,
 	lookup network.SpaceInfos,
@@ -1740,9 +1734,9 @@ func (st *State) addMachineWithPlacement(
 			Constraints: cons,
 		}
 		if mId != "" {
-			return st.AddMachineInsideMachine(modelConfigService, template, mId, data.containerType)
+			return st.AddMachineInsideMachine(template, mId, data.containerType)
 		}
-		return st.AddMachineInsideNewMachine(modelConfigService, template, template, data.containerType)
+		return st.AddMachineInsideNewMachine(template, template, data.containerType)
 	case directivePlacement:
 		return nil, errors.NotSupportedf(
 			"programming error: directly adding a machine for %s with a non-machine placement directive", unit.Name())
@@ -2367,7 +2361,6 @@ func (st *State) UnitsInError() ([]*Unit, error) {
 // state of the model, this may lead to new instances being launched
 // within the model.
 func (st *State) AssignUnit(
-	modelConfigService ModelConfigService,
 	u *Unit,
 	policy AssignmentPolicy,
 ) (err error) {
@@ -2382,9 +2375,9 @@ func (st *State) AssignUnit(
 		if err != nil {
 			return errors.Trace(err)
 		}
-		return u.AssignToMachine(modelConfigService, m)
+		return u.AssignToMachine(m)
 	case AssignNew:
-		return errors.Trace(u.AssignToNewMachine(modelConfigService))
+		return errors.Trace(u.AssignToNewMachine())
 	}
 	return errors.Errorf("unknown unit assignment policy: %q", policy)
 }

--- a/state/testing/suite.go
+++ b/state/testing/suite.go
@@ -4,7 +4,6 @@
 package testing
 
 import (
-	"context"
 	"sync"
 	"time"
 
@@ -99,8 +98,7 @@ func (s *StateSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.Model = model
 
-	s.Factory = factory.NewFactory(s.State, s.StatePool, s.ControllerConfig).
-		WithModelConfigService(&stubModelConfigService{cfg: testing.ModelConfig(c)})
+	s.Factory = factory.NewFactory(s.State, s.StatePool, s.ControllerConfig)
 
 	s.ConfigSchemaSourceGetter = func(c *gc.C) config.ConfigSchemaSourceGetter {
 		return state.NoopConfigSchemaSource
@@ -173,12 +171,4 @@ func (s *StateSuite) WaitForModelWatchersIdle(c *gc.C, modelUUID string) {
 			c.Fatal("no sync event sent, is the watcher dead?")
 		}
 	}
-}
-
-type stubModelConfigService struct {
-	cfg *config.Config
-}
-
-func (s *stubModelConfigService) ModelConfig(context.Context) (*config.Config, error) {
-	return s.cfg, nil
 }

--- a/state/testing/suite_wallclock.go
+++ b/state/testing/suite_wallclock.go
@@ -63,8 +63,7 @@ func (s *StateWithWallClockSuite) SetUpTest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.Model = model
 
-	s.Factory = factory.NewFactory(s.State, s.StatePool, s.ControllerInheritedConfig).
-		WithModelConfigService(&stubModelConfigService{cfg: coretesting.ModelConfig(c)})
+	s.Factory = factory.NewFactory(s.State, s.StatePool, s.ControllerInheritedConfig)
 }
 
 func (s *StateWithWallClockSuite) TearDownTest(c *gc.C) {

--- a/state/volume.go
+++ b/state/volume.go
@@ -4,7 +4,6 @@
 package state
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
@@ -1131,16 +1130,12 @@ func (sb *storageBackend) newVolumeOps(doc volumeDoc, status statusDoc) []txn.Op
 
 func (sb *storageConfigBackend) volumeParamsWithDefaults(params VolumeParams) (VolumeParams, error) {
 	if params.Pool == "" {
-		modelConfig, err := sb.modelConfigService.ModelConfig(context.Background())
-		if err != nil {
-			return VolumeParams{}, errors.Trace(err)
-		}
 		cons := StorageConstraints{
 			Pool:  params.Pool,
 			Size:  params.Size,
 			Count: 1,
 		}
-		poolName, err := defaultStoragePool(sb.modelType, modelConfig, storage.StorageKindBlock, cons)
+		poolName, err := defaultStoragePool(sb.modelType, storage.StorageKindBlock, cons)
 		if err != nil {
 			return VolumeParams{}, errors.Annotate(err, "getting default block storage pool")
 		}


### PR DESCRIPTION
Removes model config from storage backend. This means that we use the fallback storage pool for all requests. This fixes the issue where state was imported before dqlite for k8s. We can't attempt to use dqlite before or during state importing. We could invert it to import dqlite before state, but we also run into this as well.

In the end, this is dead code, just remove it.

See Jira task to put it back: https://warthogs.atlassian.net/browse/JUJU-6933

<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://docs.google.com/document/d/1SYUo9G7qZ_jdoVXpUVamS5VCgHmtZ0QA-wZxKoMS-C0 
-->

<!-- Why this change is needed and what it does. -->


## QA steps

Using the tip of 3.6.

```sh
$ make microk8s-operator-update
$ juju bootstrap microk8s src
$ juju add-model moveme
$ juju deploy prometheus-k8s --trust
```

Switch to this branch

```sh
$ make microk8s-operator-update
$ juju bootstrap microk8s dst
$ juju migrate src:moveme dst
```

