### PR TITLE
feat: is one of for errors library

### DIFF
--- a/internal/errors/std.go
+++ b/internal/errors/std.go
@@ -108,6 +108,23 @@ func Is(err, target error) bool {
 	return stderrors.Is(err, target)
 }
 
+// IsOneOf reports whether any error in err's tree matches one of the target
+// errors. This check works on a first match effort in that the first target
+// error discovered reports back true with no further errors.
+//
+// If targets is empty then this func will always return false.
+//
+// IsOneOf is the same as writing Is(err, type1) || Is(err, type2) || Is(err, type3)
+func IsOneOf(err error, targets ...error) bool {
+	for _, target := range targets {
+		if stderrors.Is(err, target) {
+			return true
+		}
+	}
+
+	return false
+}
+
 // Join returns an error that wraps the given errors.
 // Any nil error values are discarded.
 // Join returns nil if every value in errs is nil.

--- a/internal/errors/std_test.go
+++ b/internal/errors/std_test.go
@@ -312,3 +312,35 @@ func TestNew(t *testing.T) {
 func TestUnwrap(t *testing.T) {
 	t.SkipNow()
 }
+
+// TestIsOneOf is testing [IsOneOf] and the various combinations of errors and
+// targets we are likely to expect.
+func TestIsOneOf(t *testing.T) {
+	t.Run("ReturnsFalseForEmptyTargets", func(t *testing.T) {
+		err := New("test error")
+		if IsOneOf(err) {
+			t.Error("IsOf with empty target list should return false")
+		}
+	})
+
+	t.Run("ReturnsFalseForNilError", func(t *testing.T) {
+		err := New("test error")
+		if IsOneOf(nil, err) {
+			t.Error("IsOneOf with nil error should return false")
+		}
+
+		if IsOneOf(nil) {
+			t.Error("IsOneOf with nil error with empty target list should return false")
+		}
+	})
+
+	t.Run("IsOneOfMultiple", func(t *testing.T) {
+		type1 := New("type 1")
+		type2 := New("type 2")
+		err := Errorf("%w", type1)
+
+		if !IsOneOf(err, type2, type1) {
+			t.Error("IsOf expected to find type1 in error chain")
+		}
+	})
+}


### PR DESCRIPTION
Adds a new helper func to the errors library for checking if a single error is one of the errors in a target list. This is useful when transforming multiple errors onto one return type for api usage.

This work was originally proposed in #18209 and has been broken out.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Run unit tests in `internal/errors`

## Documentation changes

N/A

## Links

**Jira card:** JUJU-6094

