### PR TITLE
refactor(test): remove assert from txn

### DIFF
--- a/domain/port/watcher_test.go
+++ b/domain/port/watcher_test.go
@@ -128,7 +128,9 @@ func (s *watcherSuite) createUnit(c *gc.C, netNodeUUID, appName string) (coreuni
 		}
 
 		_, err = tx.ExecContext(ctx, "INSERT INTO net_node VALUES (?) ON CONFLICT DO NOTHING", netNodeUUID)
-		c.Assert(err, jc.ErrorIsNil)
+		if err != nil {
+			return err
+		}
 
 		_, err = tx.ExecContext(ctx, "UPDATE unit SET net_node_uuid = ? WHERE name = ?", netNodeUUID, unitName)
 		if err != nil {


### PR DESCRIPTION
There was a single c.Assert left behind inside a transaction for the ports domain tests. Remove this assertion by returning the error instead

The reason we should avoid asserts in a txn is because if an assertion fails, it runs a panic. This messes with the rollback and retry logic that wraps our transactions 

## QA steps

Unit tests pass