### PR TITLE
fix(tests): unregister tests checks for empty controllers.yaml

### DIFF
--- a/tests/suites/cli/unregister.sh
+++ b/tests/suites/cli/unregister.sh
@@ -32,7 +32,13 @@ EOF
 	JUJU_DATA="${TEST_DIR}/juju" juju unregister --no-prompt "unregister-test"
 
 	echo "Check that temporary controllers.yaml has no controllers' data"
-	EXPECTED="controllers: {}"
+	EXPECTED=$(
+		cat <<'EOF'
+controllers: {}
+has-controller-changed-on-previous-switch: false
+EOF
+	)
+
 	OUT=$(cat "${TEST_DIR}/juju/controllers.yaml")
 	if [ "${OUT}" != "${EXPECTED}" ]; then
 		echo "expected ${EXPECTED}, got ${OUT}"


### PR DESCRIPTION
In https://github.com/juju/juju/pull/17516 we added the ability to switch controllers, and this adds fields on the controllers.yaml file for the juju client.

Since our unregister test checks for that file to have no controllers, and it's a textual comparison, we need to also add the line
```
has-controller-changed-on-previous-switch: false
```
which will always be on controllers.yaml

<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://docs.google.com/document/d/1SYUo9G7qZ_jdoVXpUVamS5VCgHmtZ0QA-wZxKoMS-C0 
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] ~Code style: imports ordered, good names, simple structure, etc~
- [ ] ~Comments saying why design decisions were made~
- [ ] ~Go unit tests, with comments saying what you're testing~
- [X] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps


```
cd tests && ./main.sh -v cli test_unregister 
```


## Links

**Jira card:** JUJU-6887

