### PR TITLE
feat(security): add SECURITY.md for reporting security issues

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,3 @@
+To report a security issue, file a [Private Security Report](https://github.com/juju/juju/security/advisories/new) with a description of the issue, the steps you took to create the issue, affected versions, and, if known, mitigations for the issue.
+
+The [Ubuntu Security disclosure and embargo policy](https://ubuntu.com/security/disclosure-policy) contains more information about what you can expect when you contact us and what we expect from you.


### PR DESCRIPTION
- Added a `SECURITY.md` file to provide guidelines for reporting security issues.
- Included a link to file a Private Security Report on GitHub.
- Referenced the Ubuntu Security disclosure and embargo policy for more information.

This change helps in standardizing the process for reporting and handling security vulnerabilities.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

```
# All checks are passed
```

## Links

**Jira card:** JUJU-

