### PR TITLE
test: lengthen timeouts on controllercharm tests

### DIFF
--- a/tests/suites/controllercharm/prometheus.sh
+++ b/tests/suites/controllercharm/prometheus.sh
@@ -10,11 +10,11 @@ run_prometheus() {
 	juju deploy prometheus-k8s --trust
 	juju relate prometheus-k8s controller.controller
 	wait_for "prometheus-k8s" "$(active_idle_condition "prometheus-k8s" 0 0)"
-	retry 'check_prometheus_targets prometheus-k8s 0' 15
+	retry 'check_prometheus_targets prometheus-k8s 0' 30
 
 	juju remove-relation prometheus-k8s controller
 	# Check Juju controller is removed from Prometheus targets
-	retry 'check_prometheus_no_target prometheus-k8s 0' 5
+	retry 'check_prometheus_no_target prometheus-k8s 0' 30
 	# Check no errors in controller charm or Prometheus
 	juju status -m controller --format json | jq -r "$(active_condition "controller")" | check "controller"
 	juju status --format json | jq -r "$(active_condition "prometheus-k8s")" | check "prometheus-k8s"
@@ -37,16 +37,16 @@ run_prometheus_multiple_units() {
 	juju deploy prometheus-k8s p1 --trust
 	juju relate p1 controller.controller
 	wait_for "p1" "$(active_idle_condition "p1" 0 0)"
-	retry 'check_prometheus_targets p1 0' 15
+	retry 'check_prometheus_targets p1 0' 30
 
 	juju deploy prometheus-k8s p2 --trust
 	juju relate p2 controller.controller
 	wait_for "p2" "$(active_idle_condition "p2" 1 0)"
-	retry 'check_prometheus_targets p2 0' 15
+	retry 'check_prometheus_targets p2 0' 30
 
 	juju add-unit p1
 	wait_for "p1" "$(active_idle_condition "p1" 0 1)"
-	retry 'check_prometheus_targets p1 1' 15
+	retry 'check_prometheus_targets p1 1' 30
 
 	juju remove-unit p1 --num-units 1
 	# Wait until the application p1 settles before health checks
@@ -61,7 +61,7 @@ run_prometheus_multiple_units() {
 	wait_for "p2" "$(active_condition "p2" 1)"
 
 	# Check Juju controller is removed from Prometheus targets
-	retry 'check_prometheus_no_target p2 0' 5
+	retry 'check_prometheus_no_target p2 0' 30
 	# Check no errors in controller charm or Prometheus
 	juju status -m controller --format json | jq -r "$(active_condition "controller")" | check "controller"
 	juju status --format json | jq -r "$(active_condition "p2" 1)" | check "p2"
@@ -69,16 +69,16 @@ run_prometheus_multiple_units() {
 	juju remove-relation p1 controller
 
 	# Check Juju controller is removed from Prometheus targets
-	retry 'check_prometheus_no_target p1 0' 5
+	retry 'check_prometheus_no_target p1 0' 30
 	# Check no errors in controller charm or Prometheus
 	juju status -m controller --format json | jq -r "$(active_condition "controller")" | check "controller"
 	# Ensure p1 is still healty
 	wait_for "p1" "$(active_condition "p1" 0)"
 
 	juju remove-application p1 --destroy-storage \
-		--force --no-wait # TODO: remove these flags once storage bug is fixed
+		--force --no-wait --no-prompt # TODO: remove these flags once storage bug is fixed
 	juju remove-application p2 --destroy-storage \
-		--force --no-wait # TODO: remove these flags once storage bug is fixed
+		--force --no-wait --no-prompt # TODO: remove these flags once storage bug is fixed
 	destroy_controller "${MODEL_NAME}"
 }
 
@@ -102,17 +102,17 @@ run_prometheus_cross_controller() {
 	juju deploy prometheus-k8s --trust
 	juju relate prometheus-k8s "${CONTROLLER_NAME}:controller.controller"
 	wait_for "prometheus-k8s" "$(active_idle_condition "prometheus-k8s" 0 0)"
-	retry 'check_prometheus_targets prometheus-k8s 0' 15
+	retry 'check_prometheus_targets prometheus-k8s 0' 30
 
 	juju remove-relation prometheus-k8s controller
 	# Check Juju controller is removed from Prometheus targets
-	retry 'check_prometheus_no_target prometheus-k8s 0' 5
+	retry 'check_prometheus_no_target prometheus-k8s 0' 30
 	# Check no errors in controller charm or Prometheus
 	juju status -m controller --format json | jq -r "$(active_condition "controller")" | check "controller"
 	juju status --format json | jq -r "$(active_condition "prometheus-k8s")" | check "prometheus-k8s"
 
 	juju remove-application prometheus-k8s --destroy-storage \
-		--force --no-wait # TODO: remove these flags once storage bug is fixed
+		--force --no-wait --no-prompt # TODO: remove these flags once storage bug is fixed
 	destroy_controller "${PROMETHEUS_MODEL_NAME}"
 }
 


### PR DESCRIPTION
This 3.6 integration test keeps failing because of timeouts but it worked on my machine, looks like they just need lengthening. Also added `--no-prompt` to the remove-application calls at the end.


## QA steps
```
./main.sh -l test -v controllercharm run_prometheus_multiple_units
```
<!-- Describe steps to verify that the change works. -->



