### PR TITLE
fix: allow some netplan values to be string or int

### DIFF
--- a/network/netplan/netplan.go
+++ b/network/netplan/netplan.go
@@ -194,7 +194,7 @@ func (i IntString) MarshalYAML() (interface{}, error) {
 type BondParameters struct {
 	Mode               IntString `yaml:"mode,omitempty"`
 	LACPRate           IntString `yaml:"lacp-rate,omitempty"`
-	MIIMonitorInterval *int      `yaml:"mii-monitor-interval,omitempty"`
+	MIIMonitorInterval IntString `yaml:"mii-monitor-interval,omitempty"`
 	MinLinks           *int      `yaml:"min-links,omitempty"`
 	TransmitHashPolicy string    `yaml:"transmit-hash-policy,omitempty"`
 	ADSelect           IntString `yaml:"ad-select,omitempty"`
@@ -203,8 +203,8 @@ type BondParameters struct {
 	ARPIPTargets       []string  `yaml:"arp-ip-targets,omitempty"`
 	ARPValidate        IntString `yaml:"arp-validate,omitempty"`
 	ARPAllTargets      IntString `yaml:"arp-all-targets,omitempty"`
-	UpDelay            *int      `yaml:"up-delay,omitempty"`
-	DownDelay          *int      `yaml:"down-delay,omitempty"`
+	UpDelay            IntString `yaml:"up-delay,omitempty"`
+	DownDelay          IntString `yaml:"down-delay,omitempty"`
 	FailOverMACPolicy  IntString `yaml:"fail-over-mac-policy,omitempty"`
 	// Netplan misspelled this as 'gratuitious-arp', not sure if it works with that name.
 	// We may need custom handling of both spellings.

--- a/network/netplan/netplan_test.go
+++ b/network/netplan/netplan_test.go
@@ -199,7 +199,7 @@ network:
         lacp-rate: fast
         mii-monitor-interval: 100
         transmit-hash-policy: layer2
-        up-delay: 0
+        up-delay: "0"
         down-delay: 0
 `)
 }
@@ -231,7 +231,7 @@ network:
         mii-monitor-interval: 100
         transmit-hash-policy: layer2
         up-delay: 0
-        down-delay: 0
+        down-delay: "0"
 `)
 }
 
@@ -355,7 +355,7 @@ network:
       parameters:
         mode: 802.3ad
         lacp-rate: fast
-        mii-monitor-interval: 100
+        mii-monitor-interval: "100"
         min-links: 0
         transmit-hash-policy: layer2
         ad-select: 1


### PR DESCRIPTION
Netplan 0.107 introduced changes whereby some values that we parsed as integers, are now explicitly rendered as strings.

We already had a type, `IntString` to handle values that could be `int` or `string`, so recruiting this is a convenient fix, that maintains backward compatibility.

## QA steps

TBC

## Documentation changes

None.

## Links

**Launchpad bug:** https://bugs.launchpad.net/netplan/+bug/2084444

**Jira card:** JUJU-TBC

