### PR TITLE
ci: increase prometheus controller test retries

### DIFF
--- a/tests/suites/controllercharm/prometheus.sh
+++ b/tests/suites/controllercharm/prometheus.sh
@@ -10,11 +10,11 @@ run_prometheus() {
 	juju deploy prometheus-k8s --trust
 	juju relate prometheus-k8s controller.controller
 	wait_for "prometheus-k8s" "$(active_idle_condition "prometheus-k8s" 0 0)"
-	retry 'check_prometheus_targets prometheus-k8s 0' 15
+	retry 'check_prometheus_targets prometheus-k8s 0' 30
 
 	juju remove-relation prometheus-k8s controller
 	# Check Juju controller is removed from Prometheus targets
-	retry 'check_prometheus_no_target prometheus-k8s 0' 5
+	retry 'check_prometheus_no_target prometheus-k8s 0' 30
 	# Check no errors in controller charm or Prometheus
 	juju status -m controller --format json | jq -r "$(active_condition "controller")" | check "controller"
 	juju status --format json | jq -r "$(active_condition "prometheus-k8s")" | check "prometheus-k8s"
@@ -37,16 +37,16 @@ run_prometheus_multiple_units() {
 	juju deploy prometheus-k8s p1 --trust
 	juju relate p1 controller.controller
 	wait_for "p1" "$(active_idle_condition "p1" 0 0)"
-	retry 'check_prometheus_targets p1 0' 15
+	retry 'check_prometheus_targets p1 0' 30
 
 	juju deploy prometheus-k8s p2 --trust
 	juju relate p2 controller.controller
 	wait_for "p2" "$(active_idle_condition "p2" 1 0)"
-	retry 'check_prometheus_targets p2 0' 15
+	retry 'check_prometheus_targets p2 0' 30
 
 	juju add-unit p1
 	wait_for "p1" "$(active_idle_condition "p1" 0 1)"
-	retry 'check_prometheus_targets p1 1' 15
+	retry 'check_prometheus_targets p1 1' 30
 
 	juju remove-unit p1 --num-units 1
 	# Wait until the application p1 settles before health checks
@@ -61,7 +61,7 @@ run_prometheus_multiple_units() {
 	wait_for "p2" "$(active_condition "p2" 1)"
 
 	# Check Juju controller is removed from Prometheus targets
-	retry 'check_prometheus_no_target p2 0' 5
+	retry 'check_prometheus_no_target p2 0' 30
 	# Check no errors in controller charm or Prometheus
 	juju status -m controller --format json | jq -r "$(active_condition "controller")" | check "controller"
 	juju status --format json | jq -r "$(active_condition "p2" 1)" | check "p2"
@@ -69,7 +69,7 @@ run_prometheus_multiple_units() {
 	juju remove-relation p1 controller
 
 	# Check Juju controller is removed from Prometheus targets
-	retry 'check_prometheus_no_target p1 0' 5
+	retry 'check_prometheus_no_target p1 0' 30
 	# Check no errors in controller charm or Prometheus
 	juju status -m controller --format json | jq -r "$(active_condition "controller")" | check "controller"
 	# Ensure p1 is still healty
@@ -102,11 +102,11 @@ run_prometheus_cross_controller() {
 	juju deploy prometheus-k8s --trust
 	juju relate prometheus-k8s "${CONTROLLER_NAME}:controller.controller"
 	wait_for "prometheus-k8s" "$(active_idle_condition "prometheus-k8s" 0 0)"
-	retry 'check_prometheus_targets prometheus-k8s 0' 15
+	retry 'check_prometheus_targets prometheus-k8s 0' 30
 
 	juju remove-relation prometheus-k8s controller
 	# Check Juju controller is removed from Prometheus targets
-	retry 'check_prometheus_no_target prometheus-k8s 0' 5
+	retry 'check_prometheus_no_target prometheus-k8s 0' 30
 	# Check no errors in controller charm or Prometheus
 	juju status -m controller --format json | jq -r "$(active_condition "controller")" | check "controller"
 	juju status --format json | jq -r "$(active_condition "prometheus-k8s")" | check "prometheus-k8s"


### PR DESCRIPTION
This increases the retries on the prometheus/juju controller tests, 15 was not enough locally to complete the suite successfully.