### PR TITLE
fix: always include peer relations in relation-ids

### DIFF
--- a/worker/uniter/runner/context/contextfactory.go
+++ b/worker/uniter/runner/context/contextfactory.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"fmt"
 
+	"github.com/juju/charm/v12"
 	"github.com/juju/charm/v12/hooks"
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
@@ -374,7 +375,8 @@ func (f *contextFactory) getContextRelations() map[int]*ContextRelation {
 		// If there are no members and the relation is dying or suspended, a relation is broken.
 		rel := info.RelationUnit.Relation()
 		relationInactive := rel.Life() != life.Alive || rel.Suspended()
-		broken := relationInactive && len(memberNames) == 0
+		isPeer := info.RelationUnit.Endpoint().Role == charm.RolePeer
+		broken := !isPeer && relationInactive && len(memberNames) == 0
 		contextRelations[id] = NewContextRelation(relationUnit, cache, broken)
 	}
 	f.relationCaches = relationCaches

--- a/worker/uniter/runner/context/contextfactory_test.go
+++ b/worker/uniter/runner/context/contextfactory_test.go
@@ -247,6 +247,48 @@ func (s *ContextFactorySuite) TestRelationBrokenHookContext(c *gc.C) {
 	c.Assert(context.RelationBroken(ctx, 1), jc.IsTrue)
 }
 
+func (s *ContextFactorySuite) TestRelationIsPeerHookContext(c *gc.C) {
+	relCh := s.AddTestingCharm(c, "riak")
+	app := s.AddTestingApplication(c, "riak", relCh)
+	u, err := app.AddUnit(state.AddUnitParams{})
+	c.Assert(err, jc.ErrorIsNil)
+	password, err := utils.RandomPassword()
+	c.Assert(err, jc.ErrorIsNil)
+	err = u.SetPassword(password)
+	c.Assert(err, jc.ErrorIsNil)
+	st := s.OpenAPIAs(c, u.Tag(), password)
+	uniterAPI, err := uniter.NewFromConnection(st)
+	c.Assert(err, jc.ErrorIsNil)
+
+	rels, err := app.Relations()
+	c.Assert(err, jc.ErrorIsNil)
+	var rel *state.Relation
+	for _, r := range rels {
+		if len(r.Endpoints()) == 1 {
+			rel = r
+			break
+		}
+	}
+	c.Assert(rel, gc.NotNil)
+	ru, err := rel.Unit(u)
+	c.Assert(err, jc.ErrorIsNil)
+	err = ru.EnterScope(map[string]interface{}{"relation-name": "riak"})
+	c.Assert(err, jc.ErrorIsNil)
+	apiRel, err := uniterAPI.Relation(rel.Tag().(names.RelationTag))
+	c.Assert(err, jc.ErrorIsNil)
+	apiRelUnit, err := apiRel.Unit(u.UnitTag())
+	c.Assert(err, jc.ErrorIsNil)
+	s.apiRelunits[rel.Id()] = apiRelUnit
+
+	hi := hook.Info{
+		Kind:       hooks.RelationBroken,
+		RelationId: rel.Id(),
+	}
+	ctx, err := s.factory.HookContext(hi)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(context.RelationBroken(ctx, rel.Id()), jc.IsFalse)
+}
+
 func (s *ContextFactorySuite) TestWorkloadHookContext(c *gc.C) {
 	hi := hook.Info{
 		Kind:         hooks.PebbleReady,


### PR DESCRIPTION
When excluding broken relations from the output of `relation-ids`, peer relations should not have been excluded as they never have any members recorded and are always needed.

## QA steps

add debug to a relation broken hook to log the output of `relation-ids`
deploy and remove an application and see the peer relation ids are included in the log

## Links

https://bugs.launchpad.net/juju/+bug/2076599

**Jira card:** [JUJU-6805](https://warthogs.atlassian.net/browse/JUJU-6805)

