### PR TITLE
feat: adds Capture() to errors library

### DIFF
--- a/internal/errors/traced.go
+++ b/internal/errors/traced.go
@@ -35,6 +35,22 @@ type frameTracer struct {
 	pc uintptr
 }
 
+// Capture is responsible for recording the location where this function was
+// called from in the error supplied. This allows errors that are being passed
+// up through a stack to have extra information attached to them at call sites.
+//
+// Captured errors should only be used in scenario's where adding extra context
+// to an error is not necessary or can't be done.
+//
+// [ErrorStack] can be used to gather all of the capture sites about an error.
+func Capture(err error) Traced {
+	if err == nil {
+		return nil
+	}
+
+	return newFrameTracer(err, 1)
+}
+
 // ErrorStack recursively unwinds an error chain by repeatedly calling
 // [stderrors.Unwrap] until no new errors are returned. A new line is outputted
 // to the resultant string for each error in the chain. If an error in the chain

--- a/internal/errors/traced_test.go
+++ b/internal/errors/traced_test.go
@@ -132,4 +132,42 @@ func TestErrorStack(t *testing.T) {
 			t.Errorf("test call to ErrorStack() returned %#v expected %#v", stack, expected)
 		}
 	})
+
+	t.Run("CapturedError", func(t *testing.T) {
+		err := Capture(errors.New("test"))
+
+		stack := ErrorStack(err)
+		expected := strings.Join([]string{
+			"github.com/juju/juju/internal/errors.TestErrorStack.func8:137: test",
+			"test",
+		}, "\n")
+		if !reflect.DeepEqual(stack, expected) {
+			t.Errorf("test call to ErrorStack() returned %#v expected %#v", stack, expected)
+		}
+	})
+}
+
+// TestErrorCapture is asserting the schematics around [Capture].
+func TestErrorCapture(t *testing.T) {
+	t.Run("CaptureNil", func(t *testing.T) {
+		if Capture(nil) != nil {
+			t.Error("expected passing nil to Capture() will result in a nil Traced error")
+		}
+	})
+
+	t.Run("Capture", func(t *testing.T) {
+		traced := Capture(errors.New("test"))
+		funcName, line := traced.Location()
+
+		if funcName != "github.com/juju/juju/internal/errors.TestErrorCapture.func2" {
+			t.Errorf(
+				"Capture() returned %q for function name, expected %q",
+				funcName,
+				"github.com/juju/juju/internal/errors.TestErrorCapture.func2",
+			)
+		}
+		if line != 159 {
+			t.Errorf("Capture() returned %d for line number, expected %d", line, 159)
+		}
+	})
 }


### PR DESCRIPTION
Based on usage and feedback we have decided to look at adding a method similar to the old juju/errors.Trace to this library. This will be similar in semantics and offer a means for capturing the call site where the func was called from.

This commit has deliberately avoided calling this new method Trace so that we can identify what is using old techniques v new techniques.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Unit tests are adequate here.

## Documentation changes

N/A

