### PR TITLE
refactor(tests): test against DQLite state

### DIFF
--- a/apiserver/facades/agent/uniter/uniter_network_test.go
+++ b/apiserver/facades/agent/uniter/uniter_network_test.go
@@ -768,11 +768,6 @@ func (s *uniterNetworkInfoSuite) TestCommitHookChanges(c *gc.C) {
 	}
 	c.Assert(relSettings.Map(), jc.DeepEquals, expRelSettings, gc.Commentf("composed model operations did not yield expected result for unit relation settings"))
 
-	unitPortRanges, err := s.wordpressUnit.OpenedPortRanges()
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(unitPortRanges.UniquePortRanges(), jc.DeepEquals, []network.PortRange{{Protocol: "tcp", FromPort: 80, ToPort: 81}})
-	c.Assert(unitPortRanges.ByEndpoint()["monitoring-port"], jc.DeepEquals, []network.PortRange{{Protocol: "tcp", FromPort: 80, ToPort: 81}}, gc.Commentf("unit ports where not opened for the requested endpoint"))
-
 	unitUUID, err := s.domainServices.Application(service.ApplicationServiceParams{}).GetUnitUUID(context.Background(), s.wordpressUnit.Tag().Id())
 	c.Assert(err, jc.ErrorIsNil)
 	grp, err := s.domainServices.Port().GetUnitOpenedPorts(context.Background(), unitUUID)

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -3573,7 +3573,9 @@ func (s *uniterSuite) TestCommitHookChangesWithStorage(c *gc.C) {
 	})
 
 	// Verify state
-	unitPortRanges, err := unit.OpenedPortRanges()
+	unitUUID, err := s.applicationService.GetUnitUUID(context.Background(), unit.Tag().Id())
+	c.Assert(err, jc.ErrorIsNil)
+	unitPortRanges, err := s.portService.GetUnitOpenedPorts(context.Background(), unitUUID)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(unitPortRanges.UniquePortRanges(), jc.DeepEquals, []network.PortRange{{Protocol: "tcp", FromPort: 80, ToPort: 81}})
 
@@ -3620,11 +3622,12 @@ func (s *uniterSuite) TestCommitHookChangesWithPortsSidecarApplication(c *gc.C) 
 		},
 	})
 
-	portRanges, err := unit.OpenedPortRanges()
+	unitUUID, err := s.applicationService.GetUnitUUID(context.Background(), unit.Tag().Id())
+	c.Assert(err, jc.ErrorIsNil)
+	portRanges, err := s.portService.GetUnitOpenedPorts(context.Background(), unitUUID)
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Assert(portRanges.UniquePortRanges(), jc.DeepEquals, []network.PortRange{{Protocol: "tcp", FromPort: 80, ToPort: 80}})
-	c.Assert(portRanges.ByEndpoint(), jc.DeepEquals, network.GroupedPortRanges{
+	c.Assert(portRanges, jc.DeepEquals, network.GroupedPortRanges{
 		"db": []network.PortRange{network.MustParsePortRange("80/tcp")},
 	})
 }


### PR DESCRIPTION
Drop tests which make assertions against Mongo state. Instead these tests should make assertions against DQLite state

## QA steps

Unit tests pass