### PR TITLE
refactor: remove state model tag from model config

### DIFF
--- a/apiserver/facades/client/modelconfig/backend.go
+++ b/apiserver/facades/client/modelconfig/backend.go
@@ -14,7 +14,6 @@ import (
 // allowing stubs to be created for testing.
 type Backend interface {
 	ControllerTag() names.ControllerTag
-	ModelTag() names.ModelTag
 	Sequences() (map[string]int, error)
 	SetModelConstraints(value constraints.Value) error
 	ModelConstraints() (constraints.Value, error)
@@ -23,15 +22,6 @@ type Backend interface {
 type stateShim struct {
 	*state.State
 	model *state.Model
-}
-
-func (st stateShim) ModelTag() names.ModelTag {
-	m, err := st.State.Model()
-	if err != nil {
-		return names.NewModelTag(st.State.ModelUUID())
-	}
-
-	return m.ModelTag()
 }
 
 // NewStateBackend creates a backend for the facade to use.


### PR DESCRIPTION
Removes the usage of state based model tag from model config.

This is just a quick cleanup PR as we button up model config. Noticed this while planning next cycle.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Bootstrap a new controller with a model and set a few model config items while also retrieving the model config.

## Documentation changes

N/A
