### PR TITLE
fix: also check tenant when searching for azure role definition

### DIFF
--- a/provider/azure/internal/azureauth/serviceprincipal.go
+++ b/provider/azure/internal/azureauth/serviceprincipal.go
@@ -185,32 +185,42 @@ func (c *ServicePrincipalCreator) Create(sdkCtx context.Context, params ServiceP
 	return applicationId, servicePrincipalObjectId, password, nil
 }
 
-func (c *ServicePrincipalCreator) ensureRoleDefinition(
-	ctx context.Context, clientFactory *armauthorization.ClientFactory, subscriptionId, roleName string,
-) (string, error) {
-	roleScope := path.Join("subscriptions", subscriptionId)
-
-	// Find any existing role definition with the name params.RoleDefinitionName.
-	roleDefinitionClient := clientFactory.NewRoleDefinitionsClient()
-	pager := roleDefinitionClient.NewListPager(roleScope, &armauthorization.RoleDefinitionsClientListOptions{
-		Filter: to.Ptr(fmt.Sprintf("roleName eq '%s'", roleName)),
+func (c *ServicePrincipalCreator) getExistingRoleDefinition(ctx context.Context, client *armauthorization.RoleDefinitionsClient, roleScope, roleName string) (string, error) {
+	pager := client.NewListPager(roleScope, &armauthorization.RoleDefinitionsClientListOptions{
+		Filter: to.Ptr("type eq 'CustomRole'"),
 	})
-	var roleDefinitionId string
-done:
 	for pager.More() {
 		next, err := pager.NextPage(ctx)
 		if err != nil {
 			return "", errors.Annotate(err, "fetching role definitions")
 		}
 		for _, r := range next.Value {
-			roleDefinitionId = toValue(r.ID)
-			break done
+			if r.Properties != nil && toValue(r.Properties.RoleName) == roleName {
+				roleDefinitionId := toValue(r.ID)
+				return roleDefinitionId, nil
+			}
 		}
 	}
+	return "", errors.NotFoundf("role definition %q", roleName)
+}
 
-	if roleDefinitionId != "" {
+func (c *ServicePrincipalCreator) ensureRoleDefinition(
+	ctx context.Context, clientFactory *armauthorization.ClientFactory, subscriptionId, roleName string,
+) (string, error) {
+	roleScope := path.Join("subscriptions", subscriptionId)
+
+	// Find any existing role definition with the name params.RoleDefinitionName.
+	// Try subscription scope first, then tenant scope.
+	roleDefinitionClient := clientFactory.NewRoleDefinitionsClient()
+	roleDefinitionId, err := c.getExistingRoleDefinition(ctx, roleDefinitionClient, roleScope, roleName)
+	if err != nil && errors.Is(err, errors.NotFound) {
+		roleDefinitionId, err = c.getExistingRoleDefinition(ctx, roleDefinitionClient, "", roleName)
+	}
+	if err == nil {
 		logger.Debugf("found existing role definition %q", roleDefinitionId)
 		return roleDefinitionId, nil
+	} else if !errors.Is(err, errors.NotFound) {
+		return "", errors.Annotate(err, "finding existing tenant scoped role definition")
 	}
 
 	roleDefinitionUUID, err := c.newUUID()

--- a/provider/azure/internal/azureauth/serviceprincipal_test.go
+++ b/provider/azure/internal/azureauth/serviceprincipal_test.go
@@ -83,10 +83,13 @@ var _ = gc.Suite(&InteractiveSuite{})
 
 const fakeTenantId = "11111111-1111-1111-1111-111111111111"
 
-func roleDefinitionListSender() *azuretesting.MockSender {
+func roleDefinitionListSender(name string) *azuretesting.MockSender {
 	roleDefinitions := []*armauthorization.RoleDefinition{{
 		ID:   to.Ptr("owner-role-id"),
-		Name: to.Ptr("Owner"),
+		Name: to.Ptr("name-id"),
+		Properties: &armauthorization.RoleDefinitionProperties{
+			RoleName: to.Ptr(name),
+		},
 	}}
 	return azuretesting.NewSenderWithValue(armauthorization.RoleDefinitionListResult{
 		Value: roleDefinitions,
@@ -160,7 +163,8 @@ func (s *InteractiveSuite) TestInteractive(c *gc.C) {
 	}}
 
 	authSenders := &azuretesting.Senders{
-		roleDefinitionListSender(),
+		roleDefinitionListSender("Some other role"),
+		roleDefinitionListSender("Juju Application Role Definition"),
 		roleAssignmentSender(),
 	}
 	spc := azureauth.ServicePrincipalCreator{
@@ -220,7 +224,7 @@ func (s *InteractiveSuite) TestInteractiveRoleAssignmentAlreadyExists(c *gc.C) {
 	}}
 
 	authSenders := &azuretesting.Senders{
-		roleDefinitionListSender(),
+		roleDefinitionListSender("Juju Application Role Definition"),
 		roleAssignmentAlreadyExistsSender(),
 	}
 	spc := azureauth.ServicePrincipalCreator{
@@ -293,7 +297,7 @@ func (s *InteractiveSuite) TestInteractiveServicePrincipalNotFound(c *gc.C) {
 	}}
 
 	authSenders := &azuretesting.Senders{
-		roleDefinitionListSender(),
+		roleDefinitionListSender("Juju Application Role Definition"),
 		roleAssignmentSender(),
 	}
 	spc := azureauth.ServicePrincipalCreator{
@@ -355,7 +359,7 @@ func (s *InteractiveSuite) TestInteractiveServicePrincipalNotFoundRace(c *gc.C) 
 	}}
 
 	authSenders := &azuretesting.Senders{
-		roleDefinitionListSender(),
+		roleDefinitionListSender("Juju Application Role Definition"),
 		roleAssignmentSender(),
 	}
 	spc := azureauth.ServicePrincipalCreator{
@@ -410,7 +414,7 @@ func (s *InteractiveSuite) TestInteractiveRetriesRoleAssignment(c *gc.C) {
 	}}
 
 	authSenders := &azuretesting.Senders{
-		roleDefinitionListSender(),
+		roleDefinitionListSender("Juju Application Role Definition"),
 		roleAssignmentPrincipalNotExistSender(),
 		roleAssignmentSender(),
 	}


### PR DESCRIPTION
When creating an azure credential, we look for an existing custom role definition, usually "Juju Application Role Definition".

The search filter was not working as expected, so manually check for the role in the tenant if it's not found in the subscription. If we don't check the tenant, we can get a 409 already exists error when creating the role.

## QA steps

`juju add-credential azure`

Accept defaults for all prompts.
bootstrap with credential.

## Links

https://bugs.launchpad.net/juju/+bug/2084858

**Jira card:** [JUJU-6906](https://warthogs.atlassian.net/browse/JUJU-6906)

