### PR TITLE
feat: remove orphaned secret revisions

### DIFF
--- a/scripts/secrets/README.md
+++ b/scripts/secrets/README.md
@@ -1,0 +1,15 @@
+## Remove old secret revision
+
+If a revision has been orphaned by a new revision and we didn't remove it, this
+can lead to leak of the resource. There is no collector running in the
+background to clean up the orphaned resources. So, it is important to remove the
+old revision once a new revision is created.
+
+### Run the ./remove-old-secret-revisions.sh
+
+The script will prompt you to ensure that you want to remove the old revision.
+If there is an old revision it will be removed.
+
+```bash
+./remove-old-secret-revisions.sh
+```

--- a/scripts/secrets/remove-old-secret-revisions.sh
+++ b/scripts/secrets/remove-old-secret-revisions.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -eu
+
+secrets=$(juju secrets --format=json | jq -r "to_entries | .[] | select( .value | .revision > 1) | .key" | sort -u)
+for secret in $secrets; do
+    owner=$(juju show-secret $secret --format=json | jq -r ".[] | .owner")
+    revision=$(juju show-secret $secret --format=json | jq -r ".[] | .revision")
+    new_revision=$((revision-1))
+    echo "$owner Secret: $secret at $revision"
+
+    remove=0
+    read -p "Do you wish to remove revision from 1 to $new_revision? " yn
+    case $yn in
+        [Yy]* ) remove=1;;
+        [Nn]* ) ;;
+        * ) echo "Please answer yes or no.";;
+    esac
+
+    if [ $remove = 0 ]; then
+        continue
+    fi
+
+    for i in $(seq 1 $new_revision); do
+        echo " - Removing $secret at revision $i"
+        juju exec -u $owner/leader -- secret-remove "secret:$secret" --revision $i 2>&1 | sed "s/^/   > /" || true
+    done
+done


### PR DESCRIPTION
If secret revisions have been orphaned, it's important to clean them up, otherwise we can end up with lots of revisions. This can in turn create a lot of pressure on the database.

The script provided cleans up older revisions, and will attempt to remove older ones. If there is an error or the revision is not found it will move on to the next one.

<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://docs.google.com/document/d/1SYUo9G7qZ_jdoVXpUVamS5VCgHmtZ0QA-wZxKoMS-C0 
-->

<!-- Why this change is needed and what it does. -->


## QA steps

```sh
$ juju bootstrap lxd test
$ juju add-model foo
$ juju deploy ubuntu
```

Let's create some secrets with some revisions

```sh
$ juju exec -u ubuntu/0 -- secret-add foo=bar
$ juju exec -u ubuntu/0 -- secret-set $SECRET_ID foo=bar
$ juju exec -u ubuntu/0 -- secret-set $SECRET_ID foo=bar
$ juju exec -u ubuntu/0 -- secret-set $SECRET_ID foo=bar
```

Do this a couple of times.

```sh
$ ./scripts/secrets/remove-old-secret-revisions.sh
```

You'll be prompted to remove them, similar to:

```
$ ./scripts/secrets/remove-old-secret-revisions.sh
ubuntu Secret: csb5fe4n9r7jss5f799g at 2
Do you wish to remove revision from 1 to 1? y
 - Removing csb5fe4n9r7jss5f799g at revision 1
ubuntu Secret: csb5mf4n9r7jss5f79ag at 3
Do you wish to remove revision from 1 to 2? y
 - Removing csb5mf4n9r7jss5f79ag at revision 1
 - Removing csb5mf4n9r7jss5f79ag at revision 2
```


## Links



**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2069238


