### PR TITLE
feat(logforwarder): add Close method to LogStream interface

### DIFF
--- a/worker/logforwarder/logforwarder_test.go
+++ b/worker/logforwarder/logforwarder_test.go
@@ -285,6 +285,14 @@ func (s *stubStream) Next() ([]logfwd.Record, error) {
 	return []logfwd.Record{<-s.nextRecs}, nil
 }
 
+func (s *stubStream) Close() error {
+	s.stub.AddCall("Close")
+	if err := s.stub.NextErr(); err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
 type stubSender struct {
 	stub     *testing.Stub
 	activity chan string


### PR DESCRIPTION
- introduce Close method on LogStream to ensure proper resource de-allocation

(splitted from initial PR: https://github.com/juju/juju/pull/18275)

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
~- [ ] Go unit tests, with comments saying what you're testing~
~- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
~- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Nothing to do. Just read carefully.

## Documentation changes

*None*

## Links

It try to fix a resource leak discussed at various places

* https://matrix.to/#/!wJiiHsLipVywuWOyNi:ubuntu.com/$0wuvr9XZ3eLwCR0juY06mWfZhvSWuouMqY0lvp0WnC0?via=ubuntu.com&via=matrix.org
* https://chat.canonical.com/canonical/pl/cwai9mfaqfge7jkwrmau5e1q9a

JIRA: [6989](https://warthogs.atlassian.net/browse/JUJU-6989)
