### PR TITLE
fix(login): use nil instead of empty user tag for NewLegacyLoginProvider

### DIFF
--- a/cmd/juju/user/login.go
+++ b/cmd/juju/user/login.go
@@ -397,7 +397,7 @@ func (c *loginCommand) publicControllerLogin(
 				})
 			},
 		),
-		api.NewLegacyLoginProvider(names.UserTag{}, "", "", nil, bclient, cookieURL),
+		api.NewLegacyLoginProvider(nil, "", "", nil, bclient, cookieURL),
 	)
 
 	// Keep track of existing interactors as the dial callback will create


### PR DESCRIPTION
Fixes an issue when trying to log to public controller. juju login failed with below error: ERROR cannot log into "x.x.x.x:17070": "user-" is not a valid user tag

See https://bugs.launchpad.net/juju/+bug/2084043

It was due by the fact that user tag is tested against nil and if not nil, authtag is replaced by "user-<field name>".

- Before this commit, names.UserTag{} was passed to NewLegacyLoginProvider, which could lead to potential issues with incorrect or unwanted user tagging.
- After this commit, passing nil ensures proper handling and safeguards against potential tagging errors, resulting in more robust and predictable behavior.

<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://docs.google.com/document/d/1SYUo9G7qZ_jdoVXpUVamS5VCgHmtZ0QA-wZxKoMS-C0 
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

<!-- Describe steps to verify that the change works. -->

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/

**Jira card:** JUJU-

