### PR TITLE
fix: wrong error return type for agent version

### DIFF
--- a/domain/modelagent/service/service.go
+++ b/domain/modelagent/service/service.go
@@ -270,7 +270,8 @@ func (s *ModelService) WatchModelTargetAgentVersion(
 // WatchUnitTargetAgentVersion is responsible for watching the target agent
 // version for unit and reporting when there has been a change via a
 // [watcher.NotifyWatcher]. The following errors can be expected:
-// - [applicationerrors.NotFound] - When no unit exists for the provided name.
+// - [applicationerrors.UnitNotFound] - When no unit exists for the provided
+// name.
 // - [modelerrors.NotFound] - When the model of the unit no longer exists.
 func (s *ModelService) WatchUnitTargetAgentVersion(
 	ctx context.Context,
@@ -280,7 +281,7 @@ func (s *ModelService) WatchUnitTargetAgentVersion(
 	if errors.Is(err, applicationerrors.UnitNotFound) {
 		return nil, errors.Errorf(
 			"unit %q does not exist", unitName,
-		).Add(machineerrors.MachineNotFound)
+		).Add(applicationerrors.UnitNotFound)
 	} else if err != nil {
 		return nil, errors.Errorf(
 			"checking if unit %q exists when watching target agent version: %w",

--- a/domain/modelagent/service/service_test.go
+++ b/domain/modelagent/service/service_test.go
@@ -150,3 +150,18 @@ func (s *suite) TestGetUnitTargetAgentVersionNotFound(c *gc.C) {
 	)
 	c.Check(err, jc.ErrorIs, applicationerrors.UnitNotFound)
 }
+
+// TestWatchUnitTargetAgentVersion is testing that the service returns a
+func (s *suite) TestWatchUnitTargetAgentVersion(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.modelState.EXPECT().CheckUnitExists(gomock.Any(), "foo-0").Return(
+		applicationerrors.UnitNotFound,
+	)
+
+	_, err := NewModelService(s.modelState, s.state, nil).WatchUnitTargetAgentVersion(
+		context.Background(),
+		"foo-0",
+	)
+	c.Check(err, jc.ErrorIs, applicationerrors.UnitNotFound)
+}


### PR DESCRIPTION
Fixes the model agent service to return the correct error when a unit is not found.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Unit tests have been added to cover the regression.

## Documentation changes

N/A

## Links

Needed for #18282

