### PR TITLE
feat: collect coverage profiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,11 @@ EXTRA_BUILD_TAGS += libsqlite3
 EXTRA_BUILD_TAGS += dqlite
 endif
 
+# Enable coverage collection.
+ifneq ($(COVERAGE_COLLECT_URL),)
+EXTRA_BUILD_TAGS += cover
+endif
+
 # FINAL_BUILD_TAGS is the final list of build tags.
 FINAL_BUILD_TAGS=$(shell echo "$(BUILD_TAGS) $(EXTRA_BUILD_TAGS)" | awk '{$$1=$$1};1' | tr ' ' ',')
 
@@ -181,17 +186,26 @@ define link_flags_version
 -X $(PROJECT)/version.GitCommit=$(GIT_COMMIT) \
 -X $(PROJECT)/version.GitTreeState=$(GIT_TREE_STATE) \
 -X $(PROJECT)/version.build=$(JUJU_BUILD_NUMBER) \
--X $(PROJECT)/version.GoBuildTags=$(FINAL_BUILD_TAGS)
+-X $(PROJECT)/version.GoBuildTags=$(FINAL_BUILD_TAGS) \
+-X $(PROJECT)/internal/debug/coveruploader.putURL=$(COVERAGE_COLLECT_URL)
 endef
+
+# Enable coverage collection.
+ifneq ($(COVERAGE_COLLECT_URL),)
+	COVER_COMPILE_FLAGS = -cover -covermode=atomic
+	COVER_LINK_FLAGS = -checklinkname=0
+	COVER_CGO_LINK_FLAGS = -checklinkname=0
+endif
 
 # Compile with debug flags if requested.
 ifeq ($(DEBUG_JUJU), 1)
-    COMPILE_FLAGS = -gcflags "all=-N -l"
-    LINK_FLAGS =  "$(link_flags_version)"
-	CGO_LINK_FLAGS = "-linkmode 'external' -extldflags '-static' $(link_flags_version)"
+    COMPILE_FLAGS = $(COVER_COMPILE_FLAGS) -gcflags "all=-N -l"
+    LINK_FLAGS = "$(COVER_LINK_FLAGS) $(link_flags_version)"
+	CGO_LINK_FLAGS = "$(COVER_CGO_LINK_FLAGS) -linkmode 'external' -extldflags '-static' $(link_flags_version)"
 else
-    LINK_FLAGS = "-s -w -extldflags '-static' $(link_flags_version)"
-	CGO_LINK_FLAGS = "-s -w -linkmode 'external' -extldflags '-static' $(link_flags_version)"
+	COMPILE_FLAGS = $(COVER_COMPILE_FLAGS)
+    LINK_FLAGS = "$(COVER_LINK_FLAGS) -s -w -extldflags '-static' $(link_flags_version)"
+	CGO_LINK_FLAGS = "$(COVER_CGO_LINK_FLAGS) -s -w -linkmode 'external' -extldflags '-static' $(link_flags_version)"
 endif
 
 define DEPENDENCIES
@@ -497,9 +511,9 @@ rebuild-schema:
 	@echo "Generating facade schema..."
 # GOOS and GOARCH environment variables are cleared in case the user is trying to cross architecture compilation.
 ifdef SCHEMA_PATH
-	@env GOOS= GOARCH= go run $(COMPILE_FLAGS) $(PROJECT)/generate/schemagen -admin-facades "$(SCHEMA_PATH)"
+	@env GOOS= GOARCH= go run $(PROJECT)/generate/schemagen -admin-facades "$(SCHEMA_PATH)"
 else
-	@env GOOS= GOARCH= go run $(COMPILE_FLAGS) $(PROJECT)/generate/schemagen -admin-facades \
+	@env GOOS= GOARCH= go run $(PROJECT)/generate/schemagen -admin-facades \
 		./apiserver/facades/schema.json
 endif
 

--- a/cmd/juju/main.go
+++ b/cmd/juju/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/cmd/v3"
 	"github.com/juju/loggo"
 
+	"github.com/juju/juju/internal/debug/coveruploader"
 	"github.com/juju/juju/cmd/juju/commands"
 	_ "github.com/juju/juju/provider/all" // Import the providers.
 )
@@ -20,6 +21,7 @@ func init() {
 }
 
 func main() {
+	coveruploader.Enable()
 	_, err := loggo.ReplaceDefaultWriter(cmd.NewWarningWriter(os.Stderr))
 	if err != nil {
 		panic(err)

--- a/cmd/jujuc/main.go
+++ b/cmd/jujuc/main.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/juju/juju/juju/osenv"
 	"github.com/juju/juju/juju/sockets"
+	"github.com/juju/juju/internal/debug/coveruploader"
 )
 
 var logger = loggo.GetLogger("juju.cmd.jujud")
@@ -169,6 +170,7 @@ func hookToolMain(commandName string, ctx *cmd.Context, args []string) (code int
 }
 
 func main() {
+	coveruploader.Enable()
 	os.Exit(Main(os.Args))
 }
 

--- a/cmd/jujud/main.go
+++ b/cmd/jujud/main.go
@@ -48,6 +48,7 @@ import (
 	jujuversion "github.com/juju/juju/version"
 	"github.com/juju/juju/worker/logsender"
 	"github.com/juju/juju/worker/uniter/runner/jujuc"
+	"github.com/juju/juju/internal/debug/coveruploader"
 )
 
 var logger = loggo.GetLogger("juju.cmd.jujud")
@@ -292,6 +293,7 @@ func MainWrapper(args []string) {
 }
 
 func main() {
+	coveruploader.Enable()
 	MainWrapper(os.Args)
 }
 

--- a/internal/debug/coveruploader/cover_cover.go
+++ b/internal/debug/coveruploader/cover_cover.go
@@ -1,0 +1,139 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+//go:build cover
+
+package coveruploader
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"runtime/coverage"
+	"time"
+	_ "unsafe"
+)
+
+// putURL is injected by build scripts as the target for the
+// uploaded coverage profile.
+var putURL string
+
+func Enable() {
+	if putURL == "" {
+		return
+	}
+	ticker := time.NewTicker(10 * time.Second)
+	f := func() {
+		ticker.Stop()
+		upload()
+	}
+	go func() {
+		for {
+			_, ok := <-ticker.C
+			if !ok {
+				return
+			}
+			upload()
+		}
+	}()
+	addExitHook(hook{
+		F:            f,
+		RunOnFailure: true,
+	})
+}
+
+func upload() {
+	cm := &bytes.Buffer{}
+	err := coverage.WriteMeta(cm)
+	if err != nil {
+		log.Printf("cover: cannot write coverage meta: %v\n", err)
+		return
+	}
+	cc := &bytes.Buffer{}
+	err = coverage.WriteCounters(cc)
+	if err != nil {
+		log.Printf("cover: cannot write coverage counters: %v\n", err)
+		return
+	}
+
+	var randName [16]byte
+	_, _ = rand.Read(randName[:])
+	name := hex.EncodeToString(randName[:])
+
+	tb := &bytes.Buffer{}
+	gw := gzip.NewWriter(tb)
+	tw := tar.NewWriter(gw)
+	err = tw.WriteHeader(&tar.Header{
+		Name:     fmt.Sprintf("covmeta.%s", name),
+		Size:     int64(cm.Len()),
+		Mode:     0644,
+		Typeflag: tar.TypeReg,
+	})
+	if err != nil {
+		log.Printf("cover: cannot write coverage meta tar header: %v\n", err)
+		return
+	}
+	_, err = io.Copy(tw, cm)
+	if err != nil {
+		log.Printf("cover: cannot write coverage meta body: %v\n", err)
+		return
+	}
+	err = tw.WriteHeader(&tar.Header{
+		Name:     fmt.Sprintf("covcounters.%s.0.%d", name, time.Now().UnixNano()),
+		Size:     int64(cc.Len()),
+		Mode:     0644,
+		Typeflag: tar.TypeReg,
+	})
+	if err != nil {
+		log.Printf("cover: cannot write coverage counters tar header: %v\n", err)
+		return
+	}
+	_, err = io.Copy(tw, cc)
+	if err != nil {
+		log.Printf("cover: cannot write coverage counters body: %v\n", err)
+		return
+	}
+	_ = tw.Close()
+	_ = gw.Close()
+
+	req, err := http.NewRequest("PUT", putURL, tb)
+	if err != nil {
+		log.Printf("cover: cannot upload cover profile to %q: %v\n", putURL, err)
+		return
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		log.Printf("cover: cannot upload cover profile to %q: %v\n", putURL, err)
+		return
+	}
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Printf("cover: cannot upload cover profile to %q: %v\n", putURL, err)
+		return
+	}
+	if resp.StatusCode >= 400 {
+		log.Printf("cover: failed to upload cover profile to %q with %d:\n%s",
+			putURL, resp.StatusCode, respBody)
+		return
+	}
+}
+
+// Exit hooks from go src/internal/runtime/exithook/hooks.go
+
+//go:linkname addExitHook internal/runtime/exithook.Add
+func addExitHook(h hook)
+
+// Copyright 2024 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+type hook struct {
+	F            func() // func to run
+	RunOnFailure bool   // whether to run on non-zero exit code
+}

--- a/internal/debug/coveruploader/cover_nocover.go
+++ b/internal/debug/coveruploader/cover_nocover.go
@@ -1,0 +1,8 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+//go:build !cover
+
+package coveruploader
+
+func Enable() {}


### PR DESCRIPTION
To collect coverage profiles from integration tests it is
required to ship these coverage profiles to a central place.

This change allows agents running in many places to
profile coverage then on shutdown/every-10-seconds upload
coverage profiles to an S3 bucket or other endpoint via
a HTTP PUT request.

These coverage profiles can then be consumed and merged
with `go tool covdata merge`.

## QA steps

With a presigned url to an s3 bucket (with object versioning 
enabled). Set `COVERAGE_COLLECT_URL` to that URL.
Then `make install` and bootstrap a controller and destroy
the controller. Download all the version of the s3 object then
untar them via `ls | xargs -L 1 tar -xvf`. You can then combine
these coverage profiles with:
`go tool covdata merge -i . -pcombine -o=out`.

Once you have a combined coverage profile in the `out`
directory, you can convert the coverage to a text profile that
is normally produced by `go test -coverprofile` by using
`go tool covdata textfmt -i out -o=coverprofile.txt`.

With a textual coverage profile you can then generate a
html report using `go tool cover -html coverprofile.txt`.

## Links

**Jira card:** JUJU-7006