### PR TITLE
fix: return the real error;

### DIFF
--- a/cmd/juju/model/destroy.go
+++ b/cmd/juju/model/destroy.go
@@ -576,13 +576,13 @@ func getModelStatus(modelTag names.ModelTag, api DestroyModelAPI) (*base.ModelSt
 		return nil, errors.Errorf("error finding model status: expected one result, got %d", l)
 	}
 	modelStatus := modelStatuses[0]
+	if errors.Is(modelStatus.Error, errors.NotFound) {
+		// This most likely occurred because a model was
+		// destroyed half-way through the call.
+		return nil, errors.Errorf("model not found, it may have been destroyed during this operation")
+	}
 	if modelStatus.Error != nil {
-		if errors.IsNotFound(modelStatus.Error) {
-			// This most likely occurred because a model was
-			// destroyed half-way through the call.
-			return nil, errors.Errorf("model not found, it may have been destroyed during this operation")
-		}
-		return nil, errors.Annotate(err, "getting model status")
+		return nil, errors.Annotate(modelStatus.Error, "getting model status")
 	}
 	return &modelStatus, nil
 }


### PR DESCRIPTION
This PR fixes a panic if the fetching status call returns a non not found error.

```
====> Destroying juju model model-secrets-juju
18:54:13     | 
18:54:13     | Found some issues
18:54:13     | panic: runtime error: invalid memory address or nil pointer dereference
18:54:13     | [signal SIGSEGV: segmentation violation code=0x1 addr=0x98 pc=0x1ddd8f3]
18:54:13     | 
18:54:13     | goroutine 1 [running]:
18:54:13     | github.com/juju/juju/cmd/juju/model.countDetachableStorage(...)
18:54:13     | 	/home/jenkins/workspace/build-juju/go-path/src/github.com/juju/juju/cmd/juju/model/destroy.go:607
18:54:13     | github.com/juju/juju/cmd/juju/model.(*destroyCommand).Run(0xc0001f3900, 0xc00078dce0)
18:54:13     | 	/home/jenkins/workspace/build-juju/go-path/src/github.com/juju/juju/cmd/juju/model/destroy.go:282 +0x233
18:54:13     | github.com/juju/juju/cmd/modelcmd.(*modelCommandWrapper).Run(0xc000940270, 0xc00078dce0)
18:54:13     | 	/home/jenkins/workspace/build-juju/go-path/src/github.com/juju/juju/cmd/modelcmd/modelcommand.go:620 +0x11f
18:54:13     | github.com/juju/juju/cmd/modelcmd.(*baseCommandWrapper).Run(0xc000379110, 0xc00078dce0)
18:54:13     | 	/home/jenkins/workspace/build-juju/go-path/src/github.com/juju/juju/cmd/modelcmd/base.go:567 +0x95
18:54:13     | github.com/juju/cmd/v4.(*SuperCommand).Run(0xc0008da160, 0xc00078dce0)
18:54:13     | 	/home/jenkins/workspace/build-juju/go-path/src/github.com/juju/juju/vendor/github.com/juju/cmd/v4/supercommand.go:536 +0x3a9
18:54:13     | github.com/juju/cmd/v4.Main({0x66c6f58, 0xc0008da160}, 0xc00078dce0, {0xc0008b3940, 0x4, 0x4})
18:54:13     | 	/home/jenkins/workspace/build-juju/go-path/src/github.com/juju/juju/vendor/github.com/juju/cmd/v4/cmd.go:444 +0x232
18:54:13     | github.com/juju/juju/cmd/juju/commands.jujuMain.Run({0xc000099f40?}, {0xc0000720a0, 0x5, 0x5})
18:54:13     | 	/home/jenkins/workspace/build-juju/go-path/src/github.com/juju/juju/cmd/juju/commands/main.go:197 +0x8da
18:54:13     | github.com/juju/juju/cmd/juju/commands.Main(...)
18:54:13     | 	/home/jenkins/workspace/build-juju/go-path/src/github.com/juju/juju/cmd/juju/commands/main.go:121
18:54:13     | main.main()
18:54:13     | 	/home/jenkins/workspace/build-juju/go-path/src/github.com/juju/juju/cmd/juju/main.go:27 +0x6c
```


## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

This only happens if the getting status call returns a non not found error which is not easy to reproduce.

## Documentation changes

No


