### PR TITLE
fix(charm relation): fix charm relation DDL

### DIFF
--- a/domain/application/errors/errors.go
+++ b/domain/application/errors/errors.go
@@ -114,6 +114,10 @@ const (
 	// base name is not supported.
 	CharmBaseNameNotSupported = errors.ConstError("charm base name not supported")
 
+	// CharmRelationKeyConflict describes an error that occurs when the charm
+	// has multiple relations with the same name
+	CharmRelationNameConflict = errors.ConstError("charm relation name conflict")
+
 	// ResourceNotFound describes an error that occurs when a resource is
 	// not found.
 	ResourceNotFound = errors.ConstError("resource not found")

--- a/domain/application/state/types.go
+++ b/domain/application/state/types.go
@@ -304,6 +304,7 @@ type charmRelation struct {
 
 // setCharmRelation is used to set the relations of a charm.
 type setCharmRelation struct {
+	UUID      string `db:"uuid"`
 	CharmUUID string `db:"charm_uuid"`
 	KindID    int    `db:"kind_id"`
 	Key       string `db:"key"`

--- a/domain/schema/model/sql/0015-charm.sql
+++ b/domain/schema/model/sql/0015-charm.sql
@@ -194,6 +194,7 @@ INSERT INTO charm_relation_scope VALUES
 (1, 'container');
 
 CREATE TABLE charm_relation (
+    uuid TEXT NOT NULL PRIMARY KEY,
     charm_uuid TEXT NOT NULL,
     kind_id TEXT NOT NULL,
     "key" TEXT NOT NULL,
@@ -214,9 +215,11 @@ CREATE TABLE charm_relation (
     REFERENCES charm_relation_role (id),
     CONSTRAINT fk_charm_relation_scope
     FOREIGN KEY (scope_id)
-    REFERENCES charm_relation_scope (id),
-    PRIMARY KEY (charm_uuid, kind_id, "key")
+    REFERENCES charm_relation_scope (id)
 );
+
+CREATE UNIQUE INDEX idx_charm_relation_charm_key
+ON charm_relation (charm_uuid, "key");
 
 CREATE VIEW v_charm_relation AS
 SELECT


### PR DESCRIPTION
Relations on charms have unique names, even if they are of different kinds. However, our uniqueness constraint (i.e. the primary key) included the kind. Drop the kind.

Uniqueness of relation names has been enforced for a very long time: https://github.com/juju/charm/blob/6b348d6033da7feecfc7272c6eb752b2e8df2e1e/meta.go#L786-L788

Also, as a flyby, add a uuid primary key to the charm relation table. It will soon be the target of a foriegn key relation.

This meant replacing the old multi-entry primary key mentioned above with a unique index. This required some changes to the service code.

Verify charm relation in the application service. This was added in the encoding code path. I tried extracting verification into separate methods, but this turned out to be a poor abstraction as encoding and verifying are just too tied up with eachother 

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

Build a charm with duplicate relation names
```
$ charmcraft init
[edit charmcraft.yaml such that]
$ cat charmcraft.yaml
...
provides:
  foo:
    interface: foo
requires:
  foo:
    interface: foo
...

$ charmcraft pack
Packed init_ubuntu-22.04-amd64.charm
```

```
$ juju bootstrap lxd lxd
$ juju add-model m
$ juju deploy ubuntu
(success)
$ juju deploy ./init_ubuntu-22.04-amd64.charm
ERROR attempting to deploy "./init_ubuntu-22.04-amd64.charm": charm "init" using a duplicated relation name: "foo"
```
