### PR TITLE
fix(ddl): ensure text primary keys are NOT NULL

### DIFF
--- a/core/watcher/eventsource/namespace_test.go
+++ b/core/watcher/eventsource/namespace_test.go
@@ -59,7 +59,7 @@ func (s *namespaceSuite) TestInitialStateSent(c *gc.C) {
 	// The EventQueue is mocked, but we use a real Sqlite DB from which the
 	// initial state is read. Insert some data to verify.
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
-		if _, err := tx.ExecContext(ctx, "CREATE TABLE random_namespace (key_name TEXT PRIMARY KEY)"); err != nil {
+		if _, err := tx.ExecContext(ctx, "CREATE TABLE random_namespace (key_name TEXT NOT NULL PRIMARY KEY)"); err != nil {
 			return err
 		}
 
@@ -109,7 +109,7 @@ func (s *namespaceSuite) TestInitialStateSentByMapper(c *gc.C) {
 	// The EventQueue is mocked, but we use a real Sqlite DB from which the
 	// initial state is read. Insert some data to verify.
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
-		if _, err := tx.ExecContext(ctx, "CREATE TABLE random_namespace (key_name TEXT PRIMARY KEY)"); err != nil {
+		if _, err := tx.ExecContext(ctx, "CREATE TABLE random_namespace (key_name TEXT NOT NULL PRIMARY KEY)"); err != nil {
 			return err
 		}
 
@@ -389,7 +389,7 @@ func (schemaDDLApplier) Apply(c *gc.C, ctx context.Context, runner database.TxnR
 	schema := schema.New(
 		schema.MakePatch(`
 CREATE TABLE external_controller (
-	uuid            TEXT PRIMARY KEY,
+	uuid            TEXT NOT NULL PRIMARY KEY,
 	alias           TEXT,
 	ca_cert         TEXT NOT NULL
 );

--- a/domain/schema/controller/sql/0020-macaroon.sql
+++ b/domain/schema/controller/sql/0020-macaroon.sql
@@ -14,7 +14,7 @@ CREATE TABLE bakery_config (
 CREATE UNIQUE INDEX idx_singleton_bakery_config ON bakery_config ((1));
 
 CREATE TABLE macaroon_root_key (
-    id TEXT PRIMARY KEY,
+    id TEXT NOT NULL PRIMARY KEY,
     created_at TIMESTAMP NOT NULL,
     expires_at TIMESTAMP NOT NULL,
     root_key TEXT NOT NULL

--- a/domain/schema/controller/sql/0024-cloudimagemetadata.sql
+++ b/domain/schema/controller/sql/0024-cloudimagemetadata.sql
@@ -1,5 +1,5 @@
 CREATE TABLE cloud_image_metadata (
-    uuid TEXT PRIMARY KEY,
+    uuid TEXT NOT NULL PRIMARY KEY,
     created_at DATETIME NOT NULL,
     source TEXT NOT NULL,
     stream TEXT NOT NULL,

--- a/domain/schema/model/sql/0012-secret.sql
+++ b/domain/schema/model/sql/0012-secret.sql
@@ -19,7 +19,7 @@ INSERT INTO secret_rotate_policy VALUES
 (6, 'yearly');
 
 CREATE TABLE secret (
-    id TEXT PRIMARY KEY
+    id TEXT NOT NULL PRIMARY KEY
 );
 
 -- secret_reference stores details about

--- a/domain/schema/model/sql/0020-network.sql
+++ b/domain/schema/model/sql/0020-network.sql
@@ -1,5 +1,5 @@
 CREATE TABLE net_node (
-    uuid TEXT PRIMARY KEY
+    uuid TEXT NOT NULL PRIMARY KEY
 );
 
 CREATE TABLE link_layer_device_type (

--- a/domain/schema/model/sql/0021-port-ranges.sql
+++ b/domain/schema/model/sql/0021-port-ranges.sql
@@ -9,7 +9,7 @@ INSERT INTO protocol VALUES
 (2, 'udp');
 
 CREATE TABLE port_range (
-    uuid TEXT PRIMARY KEY,
+    uuid TEXT NOT NULL PRIMARY KEY,
     unit_endpoint_uuid TEXT NOT NULL,
     protocol_id INT NOT NULL,
     from_port INT,
@@ -29,7 +29,7 @@ CREATE TABLE port_range (
 CREATE UNIQUE INDEX idx_port_range_endpoint_port_range ON port_range (unit_endpoint_uuid, protocol_id, from_port);
 
 CREATE TABLE unit_endpoint (
-    uuid TEXT PRIMARY KEY,
+    uuid TEXT NOT NULL PRIMARY KEY,
     endpoint TEXT NOT NULL,
     unit_uuid TEXT NOT NULL,
     CONSTRAINT fk_endpoint_unit

--- a/domain/schema/model/sql/0024-command-block.sql
+++ b/domain/schema/model/sql/0024-command-block.sql
@@ -12,7 +12,7 @@ INSERT INTO block_command_type VALUES
 (2, 'change');
 
 CREATE TABLE block_command (
-    uuid TEXT PRIMARY KEY,
+    uuid TEXT NOT NULL PRIMARY KEY,
     block_command_type_id INT NOT NULL,
     message TEXT,
     CONSTRAINT fk_block_command_type

--- a/domain/watcher_test.go
+++ b/domain/watcher_test.go
@@ -69,7 +69,7 @@ func (s *watcherSuite) TestNewNamespaceWatcherSuccess(c *gc.C) {
 	s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		_, err := tx.ExecContext(ctx, `
 			CREATE TABLE some_namespace (
-				uuid TEXT PRIMARY KEY
+				uuid TEXT NOT NULL PRIMARY KEY
 			);
 		`)
 		return err
@@ -104,7 +104,7 @@ func (s *watcherSuite) TestNewNamespaceMapperWatcherSuccess(c *gc.C) {
 	s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		_, err := tx.ExecContext(ctx, `
 			CREATE TABLE some_namespace (
-				uuid TEXT PRIMARY KEY
+				uuid TEXT NOT NULL PRIMARY KEY
 			);
 		`)
 		return err

--- a/internal/database/migration_test.go
+++ b/internal/database/migration_test.go
@@ -23,7 +23,7 @@ var _ = gc.Suite(&migrationSuite{})
 func (s *migrationSuite) TestMigrationSuccess(c *gc.C) {
 	patches := schema.New()
 	patches.Add(
-		schema.MakePatch("CREATE TABLE band(name TEXT PRIMARY KEY);"),
+		schema.MakePatch("CREATE TABLE band(name TEXT NOT NULL PRIMARY KEY);"),
 		schema.MakePatch("INSERT INTO band VALUES (?);", "Blood Incantation"),
 	)
 

--- a/scripts/dqlite-bench/main.go
+++ b/scripts/dqlite-bench/main.go
@@ -58,7 +58,7 @@ const (
 const (
 	schema = `
 CREATE TABLE agent (
-    uuid TEXT PRIMARY KEY,
+    uuid TEXT NOT NULL PRIMARY KEY,
     model_name TEXT NOT NULL,
     status TEXT NOT NULL
 );


### PR DESCRIPTION
As a result of a bug in early SQLite, a design was made to allow null text priamry. This is non-obvious, so in many places we accidentally allow null text primary keys in our tables.

Go through our tables, ensuring text primary keys have a NOT NULL constraint.

## QA steps

Unit tests pass