### PR TITLE
fix: include series in result charm URL for ResolveCharm v6

### DIFF
--- a/apiserver/facades/client/charms/client_test.go
+++ b/apiserver/facades/client/charms/client_test.go
@@ -173,19 +173,27 @@ func (s *charmsMockSuite) TestResolveCharms(c *gc.C) {
 	api := s.api(c)
 
 	curl := "ch:testme"
-	seriesCurl := "ch:amd64/focal/testme"
+	archCurl := "ch:amd64/testme"
 
 	edgeOrigin := params.CharmOrigin{
 		Source:       corecharm.CharmHub.String(),
 		Type:         "charm",
 		Risk:         "edge",
 		Architecture: "amd64",
+		Base: params.Base{
+			Name:    "ubuntu",
+			Channel: "20.04/stable",
+		},
 	}
 	stableOrigin := params.CharmOrigin{
 		Source:       corecharm.CharmHub.String(),
 		Type:         "charm",
 		Risk:         "stable",
 		Architecture: "amd64",
+		Base: params.Base{
+			Name:    "ubuntu",
+			Channel: "20.04/stable",
+		},
 	}
 
 	args := params.ResolveCharmsWithChannel{
@@ -195,13 +203,13 @@ func (s *charmsMockSuite) TestResolveCharms(c *gc.C) {
 				Architecture: "amd64",
 			}},
 			{Reference: curl, Origin: stableOrigin},
-			{Reference: seriesCurl, Origin: edgeOrigin},
+			{Reference: curl, Origin: edgeOrigin},
 		},
 	}
 
 	expected := []params.ResolveCharmWithChannelResult{
 		{
-			URL:    seriesCurl,
+			URL:    archCurl,
 			Origin: stableOrigin,
 			SupportedBases: []params.Base{
 				{Name: "ubuntu", Channel: "18.04"},
@@ -209,7 +217,7 @@ func (s *charmsMockSuite) TestResolveCharms(c *gc.C) {
 				{Name: "ubuntu", Channel: "16.04"},
 			},
 		}, {
-			URL:    seriesCurl,
+			URL:    archCurl,
 			Origin: stableOrigin,
 			SupportedBases: []params.Base{
 				{Name: "ubuntu", Channel: "18.04"},
@@ -218,7 +226,7 @@ func (s *charmsMockSuite) TestResolveCharms(c *gc.C) {
 			},
 		},
 		{
-			URL:    seriesCurl,
+			URL:    archCurl,
 			Origin: edgeOrigin,
 			SupportedBases: []params.Base{
 				{Name: "ubuntu", Channel: "18.04"},
@@ -266,12 +274,20 @@ func (s *charmsMockSuite) TestResolveCharmV6(c *gc.C) {
 		Type:         "charm",
 		Risk:         "edge",
 		Architecture: "amd64",
+		Base: params.Base{
+			Name:    "ubuntu",
+			Channel: "20.04/stable",
+		},
 	}
 	stableOrigin := params.CharmOrigin{
 		Source:       corecharm.CharmHub.String(),
 		Type:         "charm",
 		Risk:         "stable",
 		Architecture: "amd64",
+		Base: params.Base{
+			Name:    "ubuntu",
+			Channel: "20.04/stable",
+		},
 	}
 
 	args := params.ResolveCharmsWithChannel{
@@ -660,6 +676,11 @@ func (s *charmsMockSuite) expectResolveWithPreferredChannel(times int, err error
 		func(name string, requestedOrigin corecharm.Origin) (*charm.URL, corecharm.Origin, []corecharm.Platform, error) {
 			resolvedOrigin := requestedOrigin
 			resolvedOrigin.Type = "charm"
+			resolvedOrigin.Platform = corecharm.Platform{
+				Architecture: "amd64",
+				OS:           "ubuntu",
+				Channel:      "20.04",
+			}
 
 			if requestedOrigin.Channel == nil || requestedOrigin.Channel.Risk == "" {
 				if requestedOrigin.Channel == nil {
@@ -677,7 +698,6 @@ func (s *charmsMockSuite) expectResolveWithPreferredChannel(times int, err error
 			curl := &charm.URL{
 				Schema:       "ch",
 				Name:         name,
-				Series:       "focal",
 				Architecture: "amd64",
 				Revision:     -1,
 			}

--- a/rpc/params/params.go
+++ b/rpc/params/params.go
@@ -686,7 +686,7 @@ type ResolveCharmWithChannelResults struct {
 	Results []ResolveCharmWithChannelResult
 }
 
-// ResolveCharmWithChannelResult is the result of a single charm resolution.
+// ResolveCharmWithChannelResultV6 is the result of a single charm resolution.
 type ResolveCharmWithChannelResultV6 struct {
 	URL             string      `json:"url"`
 	Origin          CharmOrigin `json:"charm-origin"`
@@ -694,7 +694,7 @@ type ResolveCharmWithChannelResultV6 struct {
 	Error           *Error      `json:"error,omitempty"`
 }
 
-// ResolveCharmWithChannelResults holds the results of ResolveCharmsWithChannel.
+// ResolveCharmWithChannelResultsV6 holds the results of ResolveCharmsWithChannel.
 type ResolveCharmWithChannelResultsV6 struct {
 	Results []ResolveCharmWithChannelResultV6
 }


### PR DESCRIPTION
The v6 client charms facade was accidentally changed to exclude series from the result charm URL. It happened when the v7 facade was added.
This breaks compatibility with libjuju clients.

This PR ensure that the v6 facade call includes series in the charm URL.

## QA steps

bootstrap and add a model
start a libjuju REPL

```
>>> from juju.model import Model
>>> model = Model()
>>> await model.connect()
>>> app = await model.deploy("ubuntu")
>>> print(app)
<Application entity_id="ubuntu">
```

## Links

https://bugs.launchpad.net/juju/+bug/2084767

**Jira card:** [JUJU-7090](https://warthogs.atlassian.net/browse/JUJU-7090)

