### PR TITLE
fix: fix test_deploy_charms

### DIFF
--- a/tests/suites/deploy/deploy_charms.sh
+++ b/tests/suites/deploy/deploy_charms.sh
@@ -75,7 +75,7 @@ run_deploy_specific_series() {
 	charm_name="juju-qa-refresher"
 	# Have to check against default base, to avoid false positives.
 	# These two bases should be different.
-	default_base="ubuntu@24.04"
+	default_base="ubuntu@20.04"
 	expected_base="ubuntu@22.04"
 
 	juju deploy "$charm_name" app1


### PR DESCRIPTION
Our test deploy_specific_series had previously been fixed incorrectly.

juju-qa-refresher, the charm we deploy, deploys to ubuntu@20.04 by default. Amend this fix

## QA steps

```
./main.sh -v deploy test_deploy_charms
```