### PR TITLE
chore: merge 3.5 into 3.6

### DIFF
--- a/network/netplan/netplan.go
+++ b/network/netplan/netplan.go
@@ -52,6 +52,16 @@ type Interface struct {
 	// specified, this instructs netplan not to bring any ipv4/ipv6 address
 	// up.
 	LinkLocal *[]string `yaml:"link-local,omitempty"`
+
+	// According to the netplan examples, this section typically includes
+	// some OVS-specific configuration bits. However, MAAS may just
+	// include an empty block to indicate the presence of an OVS-managed
+	// bridge (LP1942328). As a workaround, we make this an optional map
+	// so we can tell whether it is present (but empty) vs not being
+	// present.
+	//
+	// See: https://github.com/canonical/netplan/blob/main/examples/openvswitch.yaml
+	OVSParameters *map[string]interface{} `yaml:"openvswitch,omitempty"`
 }
 
 // Ethernet defines fields for just Ethernet devices
@@ -61,11 +71,13 @@ type Ethernet struct {
 	SetName   string            `yaml:"set-name,omitempty"`
 	Interface `yaml:",inline"`
 }
+
 type AccessPoint struct {
 	Password string `yaml:"password,omitempty"`
 	Mode     string `yaml:"mode,omitempty"`
 	Channel  int    `yaml:"channel,omitempty"`
 }
+
 type Wifi struct {
 	Match        map[string]string      `yaml:"match,omitempty"`
 	SetName      string                 `yaml:"set-name,omitempty"`
@@ -76,7 +88,7 @@ type Wifi struct {
 
 type BridgeParameters struct {
 	AgeingTime   *int           `yaml:"ageing-time,omitempty"`
-	ForwardDelay *int           `yaml:"forward-delay,omitempty"`
+	ForwardDelay IntString      `yaml:"forward-delay,omitempty"`
 	HelloTime    *int           `yaml:"hello-time,omitempty"`
 	MaxAge       *int           `yaml:"max-age,omitempty"`
 	PathCost     map[string]int `yaml:"path-cost,omitempty"`
@@ -89,16 +101,6 @@ type Bridge struct {
 	Interfaces []string `yaml:"interfaces,omitempty,flow"`
 	Interface  `yaml:",inline"`
 	Parameters BridgeParameters `yaml:"parameters,omitempty"`
-
-	// According to the netplan examples, this section typically includes
-	// some OVS-specific configuration bits. However, MAAS may just
-	// include an empty block to indicate the presence of an OVS-managed
-	// bridge (LP1942328). As a workaround, we make this an optional map
-	// so we can tell whether it is present (but empty) vs not being
-	// present.
-	//
-	// See: https://github.com/canonical/netplan/blob/main/examples/openvswitch.yaml
-	OVSParameters *map[string]interface{} `yaml:"openvswitch,omitempty"`
 }
 
 type Route struct {
@@ -194,7 +196,7 @@ func (i IntString) MarshalYAML() (interface{}, error) {
 type BondParameters struct {
 	Mode               IntString `yaml:"mode,omitempty"`
 	LACPRate           IntString `yaml:"lacp-rate,omitempty"`
-	MIIMonitorInterval *int      `yaml:"mii-monitor-interval,omitempty"`
+	MIIMonitorInterval IntString `yaml:"mii-monitor-interval,omitempty"`
 	MinLinks           *int      `yaml:"min-links,omitempty"`
 	TransmitHashPolicy string    `yaml:"transmit-hash-policy,omitempty"`
 	ADSelect           IntString `yaml:"ad-select,omitempty"`
@@ -203,8 +205,8 @@ type BondParameters struct {
 	ARPIPTargets       []string  `yaml:"arp-ip-targets,omitempty"`
 	ARPValidate        IntString `yaml:"arp-validate,omitempty"`
 	ARPAllTargets      IntString `yaml:"arp-all-targets,omitempty"`
-	UpDelay            *int      `yaml:"up-delay,omitempty"`
-	DownDelay          *int      `yaml:"down-delay,omitempty"`
+	UpDelay            IntString `yaml:"up-delay,omitempty"`
+	DownDelay          IntString `yaml:"down-delay,omitempty"`
 	FailOverMACPolicy  IntString `yaml:"fail-over-mac-policy,omitempty"`
 	// Netplan misspelled this as 'gratuitious-arp', not sure if it works with that name.
 	// We may need custom handling of both spellings.

--- a/network/netplan/netplan_test.go
+++ b/network/netplan/netplan_test.go
@@ -141,6 +141,179 @@ network:
 `)
 }
 
+func (s *NetplanSuite) TestDecodeBondsWithOVS(c *gc.C) {
+	_ = MustNetplanFromYaml(c, `
+network:
+  version: 2
+  ethernets:
+    ens13f0:
+      match:
+        macaddress: "d4:04:e6:80:6e:62"
+      set-name: "ens13f0"
+      mtu: 1500
+    ens13f1:
+      match:
+        macaddress: "d4:04:e6:80:6e:63"
+      set-name: "ens13f1"
+      mtu: 1500
+    ens13f2:
+      match:
+        macaddress: "d4:04:e6:80:6e:64"
+      optional: true
+      set-name: "ens13f2"
+      mtu: 1500
+    ens13f3:
+      match:
+        macaddress: "d4:04:e6:80:6e:65"
+      optional: true
+      set-name: "ens13f3"
+      mtu: 1500
+    ens4f0np0:
+      match:
+        macaddress: "a0:88:c2:a1:a6:26"
+      set-name: "ens4f0np0"
+      mtu: 9000
+    ens4f1np1:
+      match:
+        macaddress: "a0:88:c2:a1:a6:27"
+      set-name: "ens4f1np1"
+      mtu: 9000
+  bridges:
+    br-data:
+      macaddress: "a0:88:c2:a1:a6:26"
+      mtu: 9000
+      interfaces:
+      - bond1
+      parameters:
+        forward-delay: "15"
+        stp: false
+      openvswitch: {}
+  bonds:
+    bond1:
+      macaddress: "a0:88:c2:a1:a6:26"
+      mtu: 9000
+      interfaces:
+      - ens4f0np0
+      - ens4f1np1
+      parameters:
+        mode: "802.3ad"
+        mii-monitor-interval: "100"
+        up-delay: "0"
+        down-delay: "0"
+        lacp-rate: "fast"
+        transmit-hash-policy: "layer3+4"
+    bondm:
+      addresses:
+      - "10.150.11.23/24"
+      nameservers:
+        addresses:
+        - 10.150.11.10
+        search:
+        - ps7.canonical.com
+        - maas
+      gateway4: 10.150.11.1
+      macaddress: "d4:04:e6:80:6e:62"
+      mtu: 1500
+      interfaces:
+      - ens13f0
+      - ens13f1
+      parameters:
+        mode: "802.3ad"
+        mii-monitor-interval: "100"
+        up-delay: "0"
+        down-delay: "0"
+        lacp-rate: "fast"
+        transmit-hash-policy: "layer3+4"
+      routes:
+      - metric: 0
+        to: "10.150.12.0/24"
+        via: "10.150.11.1"
+      - metric: 0
+        to: "10.150.13.0/24"
+        via: "10.150.11.1"
+  vlans:
+    bondm.3216:
+      addresses:
+      - "10.150.50.54/23"
+      nameservers:
+        addresses:
+        - 10.150.50.11
+        - 10.150.11.10
+        - 10.150.50.12
+        - 10.150.50.32
+        - 10.150.50.10
+        search:
+        - ps7.canonical.com
+        - maas
+      mtu: 1500
+      id: 3216
+      link: "bondm"
+    br-data.3207:
+      addresses:
+      - "10.150.21.15/24"
+      mtu: 9000
+      routes:
+      - metric: 0
+        to: "10.150.22.0/24"
+        via: "10.150.21.1"
+      - metric: 0
+        to: "10.150.23.0/24"
+        via: "10.150.21.1"
+      id: 3207
+      link: "br-data"
+      openvswitch: {}
+    br-data.3210:
+      addresses:
+      - "10.150.31.15/24"
+      mtu: 9000
+      routes:
+      - metric: 0
+        to: "10.150.32.0/24"
+        via: "10.150.31.1"
+      - metric: 0
+        to: "10.150.33.0/24"
+        via: "10.150.31.1"
+      id: 3210
+      link: "br-data"
+      openvswitch: {}
+    br-data.3213:
+      addresses:
+      - "10.150.41.15/24"
+      mtu: 9000
+      routes:
+      - metric: 0
+        to: "10.150.42.0/24"
+        via: "10.150.41.1"
+      - metric: 0
+        to: "10.150.43.0/24"
+        via: "10.150.41.1"
+      id: 3213
+      link: "br-data"
+      openvswitch: {}
+    br-data.3217:
+      addresses:
+      - "10.150.52.42/23"
+      mtu: 9000
+      id: 3217
+      link: "br-data"
+      openvswitch: {}
+    br-data.3218:
+      addresses:
+      - "10.150.54.42/23"
+      mtu: 9000
+      id: 3218
+      link: "br-data"
+      openvswitch: {}
+    br-data.3219:
+      addresses:
+      - "10.150.56.27/22"
+      mtu: 9000
+      id: 3219
+      link: "br-data"
+      openvswitch: {}  
+  `)
+}
+
 func (s *NetplanSuite) TestSerializationOfEthernetDevicesWithLinkLocalFields(c *gc.C) {
 	np := MustNetplanFromYaml(c, `
 network:
@@ -199,7 +372,7 @@ network:
         lacp-rate: fast
         mii-monitor-interval: 100
         transmit-hash-policy: layer2
-        up-delay: 0
+        up-delay: "0"
         down-delay: 0
 `)
 }
@@ -231,7 +404,7 @@ network:
         mii-monitor-interval: 100
         transmit-hash-policy: layer2
         up-delay: 0
-        down-delay: 0
+        down-delay: "0"
 `)
 }
 
@@ -355,7 +528,7 @@ network:
       parameters:
         mode: 802.3ad
         lacp-rate: fast
-        mii-monitor-interval: 100
+        mii-monitor-interval: "100"
         min-links: 0
         transmit-hash-policy: layer2
         ad-select: 1


### PR DESCRIPTION
Brings forward a single patch from 3.5:
- #18249 from manadart/3.5-netplan-parse

