### PR TITLE
fix: azure panic

### DIFF
--- a/provider/azure/internal/azureauth/discovery.go
+++ b/provider/azure/internal/azureauth/discovery.go
@@ -29,7 +29,9 @@ type recordAuthHeaderPolicy struct {
 
 func (p *recordAuthHeaderPolicy) Do(req *policy.Request) (*http.Response, error) {
 	resp, err := req.Next()
-	p.authHeader = resp.Header.Get(authenticateHeaderKey)
+	if resp.Header != nil {
+		p.authHeader = resp.Header.Get(authenticateHeaderKey)
+	}
 	return resp, err
 }
 


### PR DESCRIPTION
Sometimes when a request fails, we do not return any headers.

This can lead to a panic as we assume they are there.

However, even if we return an error, we sometimes still want to set the authHeader. This is why we don't just exit early on error

## QA steps

```
juju bootstrap azure azure
```
