### PR TITLE
fix: close the tmp file

### DIFF
--- a/internal/objectstore/fileobjectstore.go
+++ b/internal/objectstore/fileobjectstore.go
@@ -373,7 +373,7 @@ func (t *fileObjectStore) persistTmpFile(ctx context.Context, tmpFileName, hash 
 			return errors.AlreadyExistsf("encoded as %q", filePath)
 		}
 		return nil
-	} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+	} else if !errors.Is(err, os.ErrNotExist) {
 		// There is an error attempting to stat the file, and it's not because
 		// the file doesn't exist.
 		return errors.Trace(err)

--- a/internal/objectstore/s3objectstore.go
+++ b/internal/objectstore/s3objectstore.go
@@ -513,6 +513,13 @@ func (t *s3ObjectStore) persistTmpFile(ctx context.Context, tmpFileName, fileEnc
 	if err != nil {
 		return errors.Trace(err)
 	}
+	defer file.Close()
+
+	if stat, err := file.Stat(); err != nil {
+		return errors.Trace(err)
+	} else if stat.Size() != size {
+		return fmt.Errorf("size mismatch for %q: expected %d, got %d", tmpFileName, size, stat.Size())
+	}
 
 	if err := t.client.Session(ctx, func(ctx context.Context, s objectstore.Session) error {
 		// Seek back to the beginning of the file, so that we can read it again.


### PR DESCRIPTION
The s3 tmp file isn't being closed after use. I spotted this whilst looking to encrypt the s3 data into a bucket.

## QA steps


#### S3 based

We're going to use local s3 setup, but this works just as well with AWS S3.

Install docker or podman (I'll demonstrate using docker).

```sh
docker run -d \
   -p 9000:9000 \
   -p 9001:9001 \
   --user $(id -u):$(id -g) \
   --name minio1 \
   -e "MINIO_ROOT_USER=ROOTUSER" \
   -e "MINIO_ROOT_PASSWORD=CHANGEME123" \
   -v ${HOME}/.local/minio/data:/data \
   quay.io/minio/minio server /data --console-address ":9001"
```

Go to http://localhost:9001/access-keys and add an access key, keeping note of the key and secret.

Locate the IP for minio, we'll use that later.

```sh
$ juju bootstrap lxd test --build-agent --config="object-store-type=s3" --config="object-store-s3-endpoint=http://${IP_ADDRESS}:9000" --config="object-store-s3-static-key=${S3_KEY}" --config="object-store-s3-static-secret=${S3_SECRET}"
```
