### PR TITLE
fix: remove username and password from resource_oci_image_metadata_store

### DIFF
--- a/domain/schema/model/sql/0022-resource.sql
+++ b/domain/schema/model/sql/0022-resource.sql
@@ -138,9 +138,6 @@ CREATE TABLE unit_resource (
 CREATE TABLE resource_oci_image_metadata_store (
     resource_uuid TEXT NOT NULL,
     registry_path TEXT NOT NULL,
-    username TEXT,
-    password_hash TEXT,
-    password_salt TEXT,
     CONSTRAINT fk_resource_uuid
     FOREIGN KEY (resource_uuid)
     REFERENCES resource (uuid)


### PR DESCRIPTION
Removing the username and password related columns from the resource_oci_image_metadata_store while how to securely handle the data is decided.

Based on conversations related to #18322, remove while working to find an appropriate secure approach. This will allow for public registry paths to be provided for oci-image resources, however registry paths requiring username and password will not work until this is resolved.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- ~[ ] Go unit tests, with comments saying what you're testing~
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

