### PR TITLE
fix: fallback to env config when no base set

### DIFF
--- a/cmd/plugins/juju-metadata/imagemetadata.go
+++ b/cmd/plugins/juju-metadata/imagemetadata.go
@@ -161,11 +161,15 @@ func (c *imageMetadataCommand) setParams(context *cmd.Context, base corebase.Bas
 					c.Endpoint = cloudSpec.Endpoint
 				}
 			}
-			cfg := environ.Config()
 
-			// If we have a base, overwrite that from the environment.
-			if b := config.PreferredBase(cfg); !b.Empty() {
-				base = b
+			// If we don't have a base set, then look up the one from the
+			// environment configuration.
+			if c.Base == "" {
+				cfg := environ.Config()
+
+				if b := config.PreferredBase(cfg); !b.Empty() {
+					base = b
+				}
 			}
 		} else {
 			logger.Warningf("bootstrap parameters could not be opened: %v", err)

--- a/cmd/plugins/juju-metadata/imagemetadata_test.go
+++ b/cmd/plugins/juju-metadata/imagemetadata_test.go
@@ -185,6 +185,23 @@ func (s *ImageMetadataSuite) TestImageMetadataFilesUsingEnv(c *gc.C) {
 	s.assertCommandOutput(c, expected, out, defaultIndexFileName, defaultImageFileName)
 }
 
+func (s *ImageMetadataSuite) TestImageMetadataFilesUsingEnvWithoutUsingBase(c *gc.C) {
+	ctx, err := runImageMetadata(c, s.store,
+		"-d", s.dir, "-c", "ec2-controller", "-i", "1234", "--virt-type=pv", "--storage=root", "--base=ubuntu@20.04",
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	out := cmdtesting.Stdout(ctx)
+	expected := expectedMetadata{
+		version:  "20.04",
+		arch:     "amd64",
+		region:   "us-east-1",
+		endpoint: "https://ec2.us-east-1.amazonaws.com",
+		virtType: "pv",
+		storage:  "root",
+	}
+	s.assertCommandOutput(c, expected, out, defaultIndexFileName, defaultImageFileName)
+}
+
 func (s *ImageMetadataSuite) TestImageMetadataFilesUsingEnvWithRegionOverride(c *gc.C) {
 	ctx, err := runImageMetadata(c, s.store,
 		"-d", s.dir, "-c", "ec2-controller", "-r", "us-west-1", "-u", "https://ec2.us-west-1.amazonaws.com", "-i", "1234",


### PR DESCRIPTION
We only want to fallback to the env config when no base is set. Otherwise, if a user specifies a base, it will be ignored. There was no test to ensure this behaviour, so we added one to lock it in.


## QA steps

Set up microkstack or similar OpenStack.

 - https://microstack.run/docs/juju-workloads

> [!TIP]
> You might want to set the default base on the model to a base and make sure it's not 24.04, otherwise this will work by accident.

```
$ mkdir simplestreams
$ juju metadata generate-image -d ~/ss -i $IMAGE_ID --base ubuntu@24.04 -r RegionOne -u $OS_AUTH_URL
$ cat simplestreams/images/streams/v1/com.ubuntu.cloud-released-imagemetadata.json
```

The output should include 24.04 as specified.


## Links


**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2084362

