### PR TITLE
fix(simpleconnector): fix connect() method of simple connector to handle DialOptions

### DIFF
--- a/api/connector/clientstoreconnector.go
+++ b/api/connector/clientstoreconnector.go
@@ -66,7 +66,7 @@ func NewClientStore(config ClientStoreConfig, dialOptions ...api.DialOption) (*C
 
 // Connect returns an api.Connection to the controller / model specified in c's
 // config, or an error if there was a problem opening the connection.
-func (c *ClientStoreConnector) Connect(dialOptions ...api.DialOption) (api.Connection, error) {
+func (c *ClientStoreConnector) Connect(openFunc api.OpenFunc, dialOptions ...api.DialOption) (api.Connection, error) {
 	opts := c.defaultDialOpts
 	for _, f := range dialOptions {
 		f(&opts)
@@ -87,7 +87,7 @@ func (c *ClientStoreConnector) Connect(dialOptions ...api.DialOption) (api.Conne
 	return juju.NewAPIConnection(juju.NewAPIConnectionParams{
 		ControllerName: c.config.ControllerName,
 		Store:          c.config.ClientStore,
-		OpenAPI:        api.Open,
+		OpenAPI:        openFunc,
 		DialOpts:       opts,
 		AccountDetails: c.config.AccountDetails,
 		ModelUUID:      c.config.ModelUUID,

--- a/api/connector/connector.go
+++ b/api/connector/connector.go
@@ -10,5 +10,5 @@ import (
 // A Connector is able to provide a Connection.  This connection can be used to
 // make API calls via the various packages in github.com/juju/juju/api.
 type Connector interface {
-	Connect(...api.DialOption) (api.Connection, error)
+	Connect(api.OpenFunc, ...api.DialOption) (api.Connection, error)
 }

--- a/api/connector/simpleconnector.go
+++ b/api/connector/simpleconnector.go
@@ -94,10 +94,10 @@ func NewSimple(opts SimpleConfig, dialOptions ...api.DialOption) (*SimpleConnect
 }
 
 // Connect returns a Connection according to c's configuration.
-func (c *SimpleConnector) Connect(dialOptions ...api.DialOption) (api.Connection, error) {
+func (c *SimpleConnector) Connect(openFunc api.OpenFunc, dialOptions ...api.DialOption) (api.Connection, error) {
 	opts := c.defaultDialOpts
 	for _, f := range dialOptions {
 		f(&opts)
 	}
-	return api.Open(&c.info, c.defaultDialOpts)
+	return openFunc(&c.info, opts)
 }


### PR DESCRIPTION



<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://docs.google.com/document/d/1SYUo9G7qZ_jdoVXpUVamS5VCgHmtZ0QA-wZxKoMS-C0 
-->

<!-- Why this change is needed and what it does. -->
The dial options within the simple connector were not being applied as we were copying the defaultDialOpts to opts, running the configuration function over a pointer to the copy but passing the defaultDialOpts. We now just pass the opts. As a driveby, we now allow any api.OpewnFunc to be passed to Connect.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

<!-- Describe steps to verify that the change works. -->

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/

**Jira card:** JUJU-

