### PR TITLE
fix: return resource_oci_image_metadata_store to status quo

### DIFF
--- a/domain/schema/model/sql/0022-resource.sql
+++ b/domain/schema/model/sql/0022-resource.sql
@@ -139,8 +139,7 @@ CREATE TABLE resource_oci_image_metadata_store (
     resource_uuid TEXT NOT NULL,
     registry_path TEXT NOT NULL,
     username TEXT,
-    password_hash TEXT,
-    password_salt TEXT,
+    password TEXT,
     CONSTRAINT fk_resource_uuid
     FOREIGN KEY (resource_uuid)
     REFERENCES resource (uuid)


### PR DESCRIPTION
For the time being, resource_oci_image_metadata_store will mimic the old dockerMetadataDoc data with username and password as plain text. A new epic to handle sensative data, like passwords, which must be persisted is being created. This password is not the sole place where this is a concern.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [ ] ~Go unit tests, with comments saying what you're testing~
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

N/A

## Links

**Jira card:** JUJU-6962

