### PR TITLE
fix(charmhub): add charm hash to origin

### DIFF
--- a/internal/charm/repository/charmhub.go
+++ b/internal/charm/repository/charmhub.go
@@ -72,12 +72,13 @@ func (c *CharmHubRepository) ResolveForDeploy(ctx context.Context, arg corecharm
 	if err != nil {
 		return corecharm.ResolvedDataForDeploy{}, errors.Trace(err)
 	}
-	essMeta.ResolvedOrigin = resolvedOrigin
 
 	// Get ID and Hash for the origin. Needed in the case where this
 	// charm has been downloaded before.
 	resolvedOrigin.ID = resp.Entity.ID
 	resolvedOrigin.Hash = resp.Entity.Download.HashSHA256
+
+	essMeta.ResolvedOrigin = resolvedOrigin
 
 	// Resources are best attempt here. If we were able to resolve the charm
 	// via a channel, the resource data will be here. If using a revision,

--- a/internal/charm/repository/charmhub_test.go
+++ b/internal/charm/repository/charmhub_test.go
@@ -218,7 +218,21 @@ func (s *charmHubRepositorySuite) TestResolveForDeployWithRevisionSuccess(c *gc.
 
 	curl.Revision = revision
 
-	expectedOrigin := origin
+	expectedOrigin := corecharm.Origin{
+		Source: "charm-hub",
+		Platform: corecharm.Platform{
+			Architecture: arch.DefaultArchitecture,
+			OS:           "ubuntu",
+			Channel:      "20.04",
+		},
+		Revision: &revision,
+		Channel: &charm.Channel{
+			Track: "latest",
+			Risk:  "stable",
+		},
+		ID:   "charmCHARMcharmCHARMcharmCHARM01",
+		Hash: "SHA256 hash",
+	}
 	expectedOrigin.Type = "charm"
 	expectedOrigin.Revision = &revision
 
@@ -251,7 +265,18 @@ func (s *charmHubRepositorySuite) TestResolveForDeploySuccessChooseBase(c *gc.C)
 
 	curl.Revision = 16
 
-	expectedOrigin := origin
+	expectedOrigin := corecharm.Origin{
+		Source: "charm-hub",
+		Platform: corecharm.Platform{
+			Architecture: arch.DefaultArchitecture,
+		},
+		Channel: &charm.Channel{
+			Track: "latest",
+			Risk:  "stable",
+		},
+		ID:   "charmCHARMcharmCHARMcharmCHARM01",
+		Hash: "SHA256 hash",
+	}
 	expectedOrigin.Type = "charm"
 	expectedOrigin.Revision = &curl.Revision
 	expectedOrigin.Platform.OS = "ubuntu"


### PR DESCRIPTION
Before this patch, the resolved origin of a charmhub charm did not include the charm hash. It's simply because the returned struct was not being filled correctly.
This commit therefore fixes the returnd origin on `ResolveForDeploy()` method of charm repository.

<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://docs.google.com/document/d/1SYUo9G7qZ_jdoVXpUVamS5VCgHmtZ0QA-wZxKoMS-C0 
-->

<!-- Why this change is needed and what it does. -->

## QA steps

This patch should not affect deploying  (local charms are not on the same codepath) a charmhub charm:
```
juju bootstrap lxd c --build-agent
juju add-model m
juju deploy ubuntu
```


## Links


**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/

**Jira card:** JUJU-

