### PR TITLE
fix: fix bootstrap issue on k8s snap

### DIFF
--- a/cmd/juju/common/controller.go
+++ b/cmd/juju/common/controller.go
@@ -133,6 +133,7 @@ func WaitForAgentInitialisation(
 			switch {
 			case cause == io.EOF,
 				strings.HasSuffix(errorMessage, "no such host"), // wait for dns getting resolvable, aws elb for example.
+				strings.HasSuffix(errorMessage, "operation not permitted"),
 				strings.HasSuffix(errorMessage, "connection refused"),
 				strings.HasSuffix(errorMessage, "target machine actively refused it."), // Winsock message for connection refused
 				strings.HasSuffix(errorMessage, "connection is shut down"),


### PR DESCRIPTION
When bootstrapping on k8s, the Juju CLI polls the controller API until it is ready. Sadly, we need to do string matching to account for expected errors which should be retried. This PR adds 'operation not permitted' to list of errors to match.

## QA steps

See bug.

Install k8s snap from 1.30-classic channel and bootstrap to it.

juju bootstrap --config controller-service-type=loadbalancer ck8s

## Links

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2088256

**Jira card:** [JUJU-7168](https://warthogs.atlassian.net/browse/JUJU-7168)

