### PR TITLE
feat: define ddl for model status;

### DIFF
--- a/domain/schema/model/sql/0025-model-status.sql
+++ b/domain/schema/model/sql/0025-model-status.sql
@@ -1,0 +1,26 @@
+CREATE TABLE model_status_value (
+    id INT PRIMARY KEY,
+    status TEXT NOT NULL
+);
+
+-- Status values for the model.
+INSERT INTO model_status_value VALUES
+(0, 'error'),
+(1, 'available'),
+-- We set the model status to busy when the model is being upgrading.
+(2, 'busy'),
+-- We set the model status to suspended when the model has invlid cloud credentials.
+(3, 'suspended');
+
+CREATE TABLE model_status (
+    model_uuid TEXT NOT NULL PRIMARY KEY,
+    status_id INT NOT NULL,
+    message TEXT,
+    updated_at DATETIME,
+    CONSTRAINT fk_model_status_model
+    FOREIGN KEY (model_uuid)
+    REFERENCES model (uuid),
+    CONSTRAINT fk_model_status_status
+    FOREIGN KEY (status_id)
+    REFERENCES model_status_value (id)
+);

--- a/domain/schema/schema_test.go
+++ b/domain/schema/schema_test.go
@@ -293,6 +293,10 @@ func (s *schemaSuite) TestModelTables(c *gc.C) {
 		// Model config
 		"model_config",
 
+		// Model status
+		"model_status",
+		"model_status_value",
+
 		// Object store metadata
 		"object_store_metadata",
 		"object_store_metadata_path",


### PR DESCRIPTION
This PR defines two new tables for recording model status information:

- `model_status_value` table stores the model status values.
- `model_status` table records the models' status information.

We also define four possible values for the model status:
- error
- available
- busy
- suspended

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Unit tests.

## Documentation changes

No

## Links

**Jira card:** [JUJU-7067](https://warthogs.atlassian.net/browse/JUJU-7067)

