### PR TITLE
refactor: rename service factories

### DIFF
--- a/domain/services/provider.go
+++ b/domain/services/provider.go
@@ -16,19 +16,19 @@ import (
 	modelconfigstate "github.com/juju/juju/domain/modelconfig/state"
 )
 
-// ProviderFactory provides access to the services required by the apiserver.
-type ProviderFactory struct {
+// ProviderServices provides access to the services required by the apiserver.
+type ProviderServices struct {
 	modelServiceFactoryBase
 }
 
-// NewProviderFactory returns a new registry which uses the provided db
+// NewProviderServices returns a new registry which uses the provided db
 // function to obtain a model database.
-func NewProviderFactory(
+func NewProviderServices(
 	controllerDB changestream.WatchableDBFactory,
 	modelDB changestream.WatchableDBFactory,
 	logger logger.Logger,
-) *ProviderFactory {
-	return &ProviderFactory{
+) *ProviderServices {
+	return &ProviderServices{
 		modelServiceFactoryBase{
 			serviceFactoryBase: serviceFactoryBase{
 				controllerDB: controllerDB,
@@ -40,7 +40,7 @@ func NewProviderFactory(
 }
 
 // Model returns the provider model service.
-func (s *ProviderFactory) Model() *modelservice.ProviderService {
+func (s *ProviderServices) Model() *modelservice.ProviderService {
 	return modelservice.NewProviderService(
 		modelstate.NewModelState(
 			changestream.NewTxnRunnerFactory(s.modelDB),
@@ -50,7 +50,7 @@ func (s *ProviderFactory) Model() *modelservice.ProviderService {
 }
 
 // Cloud returns the provider cloud service.
-func (s *ProviderFactory) Cloud() *cloudservice.WatchableProviderService {
+func (s *ProviderServices) Cloud() *cloudservice.WatchableProviderService {
 	return cloudservice.NewWatchableProviderService(
 		cloudstate.NewState(changestream.NewTxnRunnerFactory(s.controllerDB)),
 		s.controllerWatcherFactory("cloud"),
@@ -58,7 +58,7 @@ func (s *ProviderFactory) Cloud() *cloudservice.WatchableProviderService {
 }
 
 // Credential returns the provider credential service.
-func (s *ProviderFactory) Credential() *credentialservice.WatchableProviderService {
+func (s *ProviderServices) Credential() *credentialservice.WatchableProviderService {
 	return credentialservice.NewWatchableProviderService(
 		credentialstate.NewState(changestream.NewTxnRunnerFactory(s.controllerDB)),
 		s.controllerWatcherFactory("credential"),
@@ -66,7 +66,7 @@ func (s *ProviderFactory) Credential() *credentialservice.WatchableProviderServi
 }
 
 // Config returns the provider model config service.
-func (s *ProviderFactory) Config() *modelconfigservice.WatchableProviderService {
+func (s *ProviderServices) Config() *modelconfigservice.WatchableProviderService {
 	return modelconfigservice.NewWatchableProviderService(
 		modelconfigstate.NewState(changestream.NewTxnRunnerFactory(s.modelDB)),
 		s.modelWatcherFactory("modelconfig"),

--- a/domain/services/service.go
+++ b/domain/services/service.go
@@ -19,7 +19,7 @@ import (
 // DomainServices provides access to the services required by the apiserver.
 type DomainServices struct {
 	*ControllerServices
-	*ModelFactory
+	*ModelServices
 }
 
 // NewDomainServices returns a new domain services which can be used to
@@ -40,7 +40,7 @@ func NewDomainServices(
 	controllerServices := NewControllerServices(controllerDB, deleterDB, clock, logger)
 	return &DomainServices{
 		ControllerServices: controllerServices,
-		ModelFactory: NewModelFactory(
+		ModelServices: NewModelServices(
 			modelUUID,
 			controllerDB,
 			modelDB,

--- a/internal/worker/domainservices/manifold.go
+++ b/internal/worker/domainservices/manifold.go
@@ -254,7 +254,7 @@ func NewProviderTrackerModelDomainServices(
 	clock clock.Clock,
 	logger logger.Logger,
 ) services.ModelDomainServices {
-	return domainservices.NewModelFactory(
+	return domainservices.NewModelServices(
 		modelUUID,
 		changestream.NewWatchableDBFactoryForNamespace(dbGetter.GetWatchableDB, coredatabase.ControllerNS),
 		changestream.NewWatchableDBFactoryForNamespace(dbGetter.GetWatchableDB, modelUUID.String()),

--- a/internal/worker/domainservices/package_test.go
+++ b/internal/worker/domainservices/package_test.go
@@ -117,7 +117,7 @@ func NewModelDomainServices(
 	clock clock.Clock,
 	logger logger.Logger,
 ) services.ModelDomainServices {
-	return domainservices.NewModelFactory(
+	return domainservices.NewModelServices(
 		modelUUID,
 		changestream.NewWatchableDBFactoryForNamespace(dbGetter.GetWatchableDB, coredatabase.ControllerNS),
 		changestream.NewWatchableDBFactoryForNamespace(dbGetter.GetWatchableDB, modelUUID.String()),

--- a/internal/worker/domainservices/worker.go
+++ b/internal/worker/domainservices/worker.go
@@ -68,7 +68,7 @@ func (config Config) Validate() error {
 		return errors.NotValidf("nil DBGetter")
 	}
 	if config.ProviderFactory == nil {
-		return errors.NotValidf("nil ProviderFactory")
+		return errors.NotValidf("nil ProviderServices")
 	}
 	if config.ObjectStoreGetter == nil {
 		return errors.NotValidf("nil ObjectStoreGetter")

--- a/internal/worker/providerservicefactory/manifold.go
+++ b/internal/worker/providerservicefactory/manifold.go
@@ -137,7 +137,7 @@ func NewProviderServices(
 	dbGetter changestream.WatchableDBGetter,
 	logger logger.Logger,
 ) services.ProviderServices {
-	return domainservicefactory.NewProviderFactory(
+	return domainservicefactory.NewProviderServices(
 		changestream.NewWatchableDBFactoryForNamespace(dbGetter.GetWatchableDB, coredatabase.ControllerNS),
 		changestream.NewWatchableDBFactoryForNamespace(dbGetter.GetWatchableDB, modelUUID.String()),
 		logger,


### PR DESCRIPTION
This is a trivial patch to make nomenclature around service factories uniform.

`ModelFactory` and `ProviderFactory` are renamed to `ModelServices` and `ProviderServices` respectively. This brings them in line with controller and object store services, and finishes a renaming that was started with the renaming of `DomainServices`.