### PR TITLE
fix(azure): fix azure provider panic

### DIFF
--- a/provider/azure/internal/azureauth/discovery.go
+++ b/provider/azure/internal/azureauth/discovery.go
@@ -29,7 +29,7 @@ type recordAuthHeaderPolicy struct {
 
 func (p *recordAuthHeaderPolicy) Do(req *policy.Request) (*http.Response, error) {
 	resp, err := req.Next()
-	if resp.Header != nil {
+	if resp != nil {
 		p.authHeader = resp.Header.Get(authenticateHeaderKey)
 	}
 	return resp, err


### PR DESCRIPTION
We previosuly noticed a panic in the azure provider. The initial fix for this, however, was incorrect.

We believed that recordAuthHeaderPolicy response included a nil header, which paniced when .Get was called.

However, .Get is safe to call on nil headers. The problem was that is you don't have network connctivity resp itself was nil, causing a panic when dereferencing to lookup Headers.

Fix our condition to reflect this

## QA steps

Connected to network
```
$ juju bootstrap azure az
Creating Juju controller "az" on azure/centralus
Looking for packaged Juju agent version 3.5.5 for amd64
No packaged binary found, preparing local Juju agent binary
Launching controller instance(s) on azure/centralus...
 - juju-5d5a1d-0 (arch=amd64 mem=3.5G cores=1)
Installing Juju agent on bootstrap instance
Waiting for address
Attempting to connect to 192.168.16.4:22
Attempting to connect to 48.214.170.67:22
Connected to 48.214.170.67
Running machine configuration script...
Bootstrap agent now started
Contacting Juju controller at 192.168.16.4 to verify accessibility...

Bootstrap complete, controller "az" is now available
Controller machines are in the "controller" model

Now you can run
	juju add-model <model-name>
to create a new model to deploy workloads.
```

Disconnected from network
```
$ juju bootstrap azure az1
ERROR getting tenant ID: expected unauthorized error response, got 0: Get "https://management.azure.com/subscriptions/2eebf55a-1e02-45d8-a299-02aed8aea00b?api-version=2022-12-01": dial tcp: lookup management.azure.com on 127.0.0.53:53: server misbehaving
```
^ this would panic prior to this patch