### PR TITLE
fix: set git details in CLI tests

### DIFF
--- a/tests/suites/cli/local_charms.sh
+++ b/tests/suites/cli/local_charms.sh
@@ -14,8 +14,8 @@ run_deploy_local_charm_revision() {
 	cd "${TMP}/ubuntu-plus" || exit 1
 
 	# Initialise a git repo to check the commit SHA is used as the charm version.
-	git init
-	git add . && git commit -m "commit everything"
+
+	create_local_git_folder
 	SHA_OF_UBUNTU_PLUS=\"$(git describe --dirty --always)\"
 
 	# Deploy from directory.


### PR DESCRIPTION
deploy_local_charm_revision did not set the git user and email like the other tests did. Not sure how this was not caught in 3.6 tests.

## QA steps

```
./main.sh -v cli deploy_local_charm_revision
```
