### PR TITLE
test: fix local_charm git issue

### DIFF
--- a/tests/suites/cli/local_charms.sh
+++ b/tests/suites/cli/local_charms.sh
@@ -14,8 +14,7 @@ run_deploy_local_charm_revision() {
 	cd "${TMP}/ubuntu-plus" || exit 1
 
 	# Initialise a git repo to check the commit SHA is used as the charm version.
-	git init
-	git add . && git commit -m "commit everything"
+	create_local_git_and_commit_all
 	SHA_OF_UBUNTU_PLUS=\"$(git describe --dirty --always)\"
 
 	# Deploy from directory.
@@ -100,8 +99,7 @@ run_deploy_local_charm_revision_relative_path() {
 	cd "${TMP}/ubuntu-plus" || exit 1
 
 	# Initialise a git repo and commit everything so that commit SHA is used as the charm version.
-	git init
-	git add . && git commit -m "commit everything"
+	create_local_git_and_commit_all
 	SHA_OF_UBUNTU_PLUS=\"$(git describe --dirty --always)\"
 
 	# Create git directory outside the charm directory
@@ -149,8 +147,7 @@ run_deploy_local_charm_revision_invalid_git() {
 	cd "${TMP_CHARM_GIT}/ubuntu-plus" || exit 1
 
 	# Initialise a git repo and commit everything so that commit SHA is used as the charm version.
-	git init
-	git add . && git commit -m "commit everything"
+	create_local_git_and_commit_all
 	SHA_OF_UBUNTU_PLUS=\"$(git describe --dirty --always)\"
 
 	WANTED_CHARM_SHA=\"$(git describe --dirty --always)\"
@@ -181,6 +178,15 @@ create_local_git_folder() {
 	touch rand_file
 	git add rand_file
 	git commit -am "rand_file"
+}
+
+create_local_git_and_commit_all() {
+	git init .
+	if [ -z "$(git config --global user.email)" ]; then
+		git config --global user.email "john@doe.com"
+		git config --global user.name "John Doe"
+	fi
+	git add . && git commit -m "commit everything"
 }
 
 test_local_charms() {


### PR DESCRIPTION
Backport https://github.com/juju/juju/pull/18216 from 3.6.

Git needed to have a user to commit, set the user.

<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://docs.google.com/document/d/1SYUo9G7qZ_jdoVXpUVamS5VCgHmtZ0QA-wZxKoMS-C0 
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

<!-- Describe steps to verify that the change works. -->

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/

**Jira card:** JUJU-

