### PR TITLE
docs(contributing): correct relative links in doc/CONTRIBUTING.md

### DIFF
--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -33,7 +33,7 @@ Issue tracker: https://bugs.launchpad.net/juju/+bugs
 
 Documentation:
 * https://juju.is/docs
-* [source tree docs](doc/)
+* [source tree docs](./)
 
 Community:
 * https://chat.charmhub.io
@@ -308,7 +308,7 @@ Conventional commits
 Once you have written some code and have tested the changes, the next step is to
 `git commit` it. For commit messages Juju follows
 [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) -- see our
-[conventional commits guidelines](doc/conventional-commits.md) for our commit types.
+[conventional commits guidelines](conventional-commits.md) for our commit types.
 In short the commits should be of the following form:
 ```
 <type>(optional <scope>): <description>


### PR DESCRIPTION
Currently some of the links in `CONTRIBUTING.md` link to `doc/$target` which resolves to `doc/doc/$target` since `CONTRIBUTING.md` is in the `doc` directory. This PR fixes those links.

## Checklist

~- [ x] Code style: imports ordered, good names, simple structure, etc~
~- [ x] Comments saying why design decisions were made~
~- [ x] Go unit tests, with comments saying what you're testing~
~- [ x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
~- [ x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Verify that the 'conventional commits guidelines' link [here](https://github.com/james-garner-canonical/juju/blob/2024-11/docs/correct-conventional-commits-link/doc/CONTRIBUTING.md#conventional-commits) correctly resolves to the `conventional-commits.md` file.