### PR TITLE
fix: watcher typo.

### DIFF
--- a/core/watcher/watchertest/watcher.go
+++ b/core/watcher/watchertest/watcher.go
@@ -22,7 +22,7 @@ type WatcherAssert[T any] func(c *gc.C, changes []T) bool
 func SliceAssert[T any](expect ...T) WatcherAssert[T] {
 	return func(c *gc.C, changes []T) bool {
 		if len(changes) >= len(expect) {
-			c.Assert(expect, jc.SameContents, expect)
+			c.Assert(changes, jc.SameContents, expect)
 			return true
 		}
 		return false

--- a/domain/application/watcher_test.go
+++ b/domain/application/watcher_test.go
@@ -90,7 +90,7 @@ func (s *watcherSuite) TestWatchCharm(c *gc.C) {
 		)
 	})
 
-	harness.Run(c)
+	harness.Run(c, []string(nil))
 }
 
 func (s *watcherSuite) createApplication(c *gc.C, svc *service.Service, name string, units ...service.AddUnitArg) coreapplication.ID {
@@ -294,7 +294,7 @@ func (s *watcherSuite) TestWatchUnitLife(c *gc.C) {
 	}, func(w watchertest.WatcherC[[]string]) {
 		w.AssertNoChange()
 	})
-	harness.Run(c)
+	harness.Run(c, []string{})
 }
 
 func (s *watcherSuite) TestWatchUnitLifeInitial(c *gc.C) {
@@ -341,7 +341,7 @@ func (s *watcherSuite) TestWatchUnitLifeInitial(c *gc.C) {
 		)
 	})
 
-	harness.Run(c)
+	harness.Run(c, []string{})
 }
 
 func (s *watcherSuite) TestWatchApplicationScale(c *gc.C) {
@@ -386,7 +386,7 @@ func (s *watcherSuite) TestWatchApplicationScale(c *gc.C) {
 		w.AssertNoChange()
 	})
 
-	harness.Run(c)
+	harness.Run(c, struct{}{})
 }
 
 func (s *watcherSuite) setupService(c *gc.C, factory domain.WatchableDBFactory) *service.WatchableService {

--- a/domain/controllerconfig/watcher_test.go
+++ b/domain/controllerconfig/watcher_test.go
@@ -91,5 +91,5 @@ func (s *watcherSuite) TestWatchControllerConfig(c *gc.C) {
 		w.AssertNoChange()
 	})
 
-	harness.Run(c)
+	harness.Run(c, []string(nil))
 }

--- a/domain/machine/watcher_test.go
+++ b/domain/machine/watcher_test.go
@@ -172,7 +172,7 @@ func (s *watcherSuite) TestWatchLXDProfiles(c *gc.C) {
 		w.AssertNoChange()
 	})
 
-	harness.Run(c)
+	harness.Run(c, struct{}{})
 }
 
 // TestWatchMachineForReboot tests the functionality of watching machines for reboot.
@@ -245,7 +245,7 @@ func (s *watcherSuite) TestWatchMachineForReboot(c *gc.C) {
 		w.Check(watchertest.SliceAssert(struct{}{}))
 	})
 
-	harness.Run(c)
+	harness.Run(c, struct{}{})
 }
 
 func uintptr(u uint64) *uint64 {

--- a/domain/port/watcher_test.go
+++ b/domain/port/watcher_test.go
@@ -336,5 +336,5 @@ func (s *watcherSuite) TestWatchOpenedPortsForApplication(c *gc.C) {
 		w.AssertNoChange()
 	})
 
-	harness.Run(c)
+	harness.Run(c, struct{}{})
 }


### PR DESCRIPTION
This pull request includes multiple changes to the test functions in various files to ensure they pass the correct arguments to the `harness.Run` function. Additionally, there is a fix in the `SliceAssert` function to correctly compare the changes with the expected values.

### Key changes:

#### Argument updates in test functions:
* Updated the `harness.Run` calls in `domain/application/watcher_test.go` to pass an empty slice or nil slice where appropriate. [[1]](diffhunk://#diff-1f3b2be7b706a322c3a8d0810ffbd92ae5d936cea0d6b76f8055fa7163408e1bL93-R93) [[2]](diffhunk://#diff-1f3b2be7b706a322c3a8d0810ffbd92ae5d936cea0d6b76f8055fa7163408e1bL297-R297) [[3]](diffhunk://#diff-1f3b2be7b706a322c3a8d0810ffbd92ae5d936cea0d6b76f8055fa7163408e1bL344-R344) [[4]](diffhunk://#diff-1f3b2be7b706a322c3a8d0810ffbd92ae5d936cea0d6b76f8055fa7163408e1bL389-R389)
* Updated the `harness.Run` calls in `domain/controllerconfig/watcher_test.go` to pass a nil slice.
* Updated the `harness.Run` calls in `domain/machine/watcher_test.go` to pass an empty struct where appropriate. [[1]](diffhunk://#diff-62a057f1a0a662825d70f7ece1277da7e1cd569c6ab804b41058f2d7c3ad3679L175-R175) [[2]](diffhunk://#diff-62a057f1a0a662825d70f7ece1277da7e1cd569c6ab804b41058f2d7c3ad3679L248-R248)
* Updated the `harness.Run` call in `domain/port/watcher_test.go` to pass an empty struct.

#### Bug fix in `SliceAssert` function:
* Corrected the assertion in the `SliceAssert` function in `core/watcher/watchertest/watcher.go` to compare `changes` with `expect` instead of comparing `expect` with itself.


### QA steps

All tests should pass.