### PR TITLE
feat(charm): add source selector when retrieving charmID

### DIFF
--- a/apiserver/common/charms/charminfo_test.go
+++ b/apiserver/common/charms/charminfo_test.go
@@ -40,6 +40,7 @@ func (s *charmInfoSuite) TestCharmInfo(c *gc.C) {
 	s.charmService.EXPECT().GetCharmID(gomock.Any(), charm.GetCharmArgs{
 		Name:     "foo",
 		Revision: ptr(1),
+		Source:   charm.CharmHubSource,
 	}).Return(corecharm.ID("deadbeef"), nil)
 
 	metadata := &internalcharm.Meta{Name: "foo"}
@@ -81,6 +82,7 @@ func (s *charmInfoSuite) TestCharmInfoMinimal(c *gc.C) {
 	s.charmService.EXPECT().GetCharmID(gomock.Any(), charm.GetCharmArgs{
 		Name:     "foo",
 		Revision: ptr(1),
+		Source:   charm.CharmHubSource,
 	}).Return(corecharm.ID("deadbeef"), nil)
 
 	metadata := &internalcharm.Meta{Name: "foo"}

--- a/apiserver/common/charms/common.go
+++ b/apiserver/common/charms/common.go
@@ -68,10 +68,14 @@ func (a *CharmInfoAPI) CharmInfo(ctx context.Context, args params.CharmURL) (par
 
 	// Get the charm ID, the charm ID is the unique UUID for the charm. All
 	// operations on the charm are done using the charm ID.
+	charmSource, err := applicationcharm.ParseCharmSchema(charm.Schema(url.Schema))
+	if err != nil {
+		return params.Charm{}, errors.Trace(err)
+	}
 	id, err := a.service.GetCharmID(ctx, applicationcharm.GetCharmArgs{
 		Name:     url.Name,
 		Revision: ptr(url.Revision),
-		Source:   applicationcharm.FromLegacySchema(url.Schema),
+		Source:   charmSource,
 	})
 	if errors.Is(err, applicationerrors.CharmNotFound) {
 		return params.Charm{}, errors.NotFoundf("charm %q", args.URL)

--- a/apiserver/common/charms/common.go
+++ b/apiserver/common/charms/common.go
@@ -71,6 +71,7 @@ func (a *CharmInfoAPI) CharmInfo(ctx context.Context, args params.CharmURL) (par
 	id, err := a.service.GetCharmID(ctx, applicationcharm.GetCharmArgs{
 		Name:     url.Name,
 		Revision: ptr(url.Revision),
+		Source:   applicationcharm.FromLegacySchema(url.Schema),
 	})
 	if errors.Is(err, applicationerrors.CharmNotFound) {
 		return params.Charm{}, errors.NotFoundf("charm %q", args.URL)

--- a/domain/application/charm/types.go
+++ b/domain/application/charm/types.go
@@ -6,7 +6,9 @@ package charm
 import (
 	"github.com/juju/version/v2"
 
+	applicationerrors "github.com/juju/juju/domain/application/errors"
 	internalcharm "github.com/juju/juju/internal/charm"
+	"github.com/juju/juju/internal/errors"
 )
 
 // GetCharmArgs holds the arguments for the GetCharmID method.
@@ -35,14 +37,17 @@ const (
 	CharmHubSource CharmSource = "charmhub"
 )
 
-func FromLegacySchema(s string) CharmSource {
-	switch s {
-	case "local":
-		return LocalSource
-	case "ch":
-		return CharmHubSource
+// ParseCharmSchema creates a CharmSource from a  string.
+// It will map the string "ch" (representing the CharmHub URL scheme) to
+// CharmHubSource and "local" to LocalSource.
+func ParseCharmSchema(source internalcharm.Schema) (CharmSource, error) {
+	switch source {
+	case internalcharm.Local:
+		return LocalSource, nil
+	case internalcharm.CharmHub:
+		return CharmHubSource, nil
 	default:
-		return CharmHubSource
+		return "", errors.Errorf("%w: %v", applicationerrors.CharmSourceNotValid, source)
 	}
 }
 

--- a/domain/application/charm/types.go
+++ b/domain/application/charm/types.go
@@ -20,6 +20,9 @@ type GetCharmArgs struct {
 	// Revision allows the selection of a specific revision of the charm.
 	// Otherwise, the latest revision is returned.
 	Revision *int
+
+	// Source is the source of the charm.
+	Source CharmSource
 }
 
 // CharmSource represents the source of a charm.
@@ -31,6 +34,17 @@ const (
 	// CharmHubSource represents a charmhub charm source.
 	CharmHubSource CharmSource = "charmhub"
 )
+
+func FromLegacySchema(s string) CharmSource {
+	switch s {
+	case "local":
+		return LocalSource
+	case "ch":
+		return CharmHubSource
+	default:
+		return CharmHubSource
+	}
+}
 
 // SetCharmArgs holds the arguments for the SetCharm method.
 type SetCharmArgs struct {

--- a/domain/application/service/charm.go
+++ b/domain/application/service/charm.go
@@ -43,10 +43,10 @@ type WatcherFactory interface {
 
 // CharmState describes retrieval and persistence methods for charms.
 type CharmState interface {
-	// GetCharmIDByRevision returns the charm ID by the natural key, for a
-	// specific revision. If the charm does not exist, a
+	// GetCharmID returns the charm ID by the natural key, for a
+	// specific revision and source. If the charm does not exist, a
 	// [applicationerrors.CharmNotFound] error is returned.
-	GetCharmIDByRevision(ctx context.Context, name string, revision int) (corecharm.ID, error)
+	GetCharmID(ctx context.Context, name string, revision int, source charm.CharmSource) (corecharm.ID, error)
 
 	// IsControllerCharm returns whether the charm is a controller charm. If the
 	// charm does not exist, a [applicationerrors.CharmNotFound] error is
@@ -163,8 +163,8 @@ func (s *CharmService) GetCharmID(ctx context.Context, args charm.GetCharmArgs) 
 		return "", applicationerrors.CharmNameNotValid
 	}
 
-	if rev := args.Revision; rev != nil && *rev >= 0 {
-		return s.st.GetCharmIDByRevision(ctx, args.Name, *rev)
+	if rev := args.Revision; rev != nil && *rev >= 0 && args.Source != "" {
+		return s.st.GetCharmID(ctx, args.Name, *rev, args.Source)
 	}
 
 	return "", applicationerrors.CharmNotFound

--- a/domain/application/service/charm_test.go
+++ b/domain/application/service/charm_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/juju/juju/core/changestream"
 	charmtesting "github.com/juju/juju/core/charm/testing"
+	"github.com/juju/juju/domain/application/charm"
 	domaincharm "github.com/juju/juju/domain/application/charm"
 	applicationerrors "github.com/juju/juju/domain/application/errors"
 	internalcharm "github.com/juju/juju/internal/charm"
@@ -37,7 +38,8 @@ func (s *charmServiceSuite) TestGetCharmIDWithoutRevision(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	_, err := s.service.GetCharmID(context.Background(), domaincharm.GetCharmArgs{
-		Name: "foo",
+		Name:   "foo",
+		Source: charm.CharmHubSource,
 	})
 	c.Assert(err, jc.ErrorIs, applicationerrors.CharmNotFound)
 }
@@ -49,8 +51,9 @@ func (s *charmServiceSuite) TestGetCharmIDWithoutSource(c *gc.C) {
 		Name:     "foo",
 		Revision: ptr(42),
 	})
-	c.Assert(err, jc.ErrorIs, applicationerrors.CharmNotFound)
+	c.Assert(err, jc.ErrorIs, applicationerrors.CharmSourceNotValid)
 }
+
 func (s *charmServiceSuite) TestGetCharmIDInvalidName(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
@@ -58,6 +61,17 @@ func (s *charmServiceSuite) TestGetCharmIDInvalidName(c *gc.C) {
 		Name: "Foo",
 	})
 	c.Assert(err, jc.ErrorIs, applicationerrors.CharmNameNotValid)
+}
+
+func (s *charmServiceSuite) TestGetCharmIDInvalidSource(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	_, err := s.service.GetCharmID(context.Background(), domaincharm.GetCharmArgs{
+		Name:     "foo",
+		Revision: ptr(42),
+		Source:   "wrong-source",
+	})
+	c.Assert(err, jc.ErrorIs, applicationerrors.CharmSourceNotValid)
 }
 
 func (s *charmServiceSuite) TestGetCharmID(c *gc.C) {

--- a/domain/application/service/package_mock_test.go
+++ b/domain/application/service/package_mock_test.go
@@ -1601,41 +1601,41 @@ func (c *MockCharmStateGetCharmConfigCall) DoAndReturn(f func(context.Context, c
 	return c
 }
 
-// GetCharmIDByRevision mocks base method.
-func (m *MockCharmState) GetCharmIDByRevision(arg0 context.Context, arg1 string, arg2 int) (charm.ID, error) {
+// GetCharmID mocks base method.
+func (m *MockCharmState) GetCharmID(arg0 context.Context, arg1 string, arg2 int, arg3 charm0.CharmSource) (charm.ID, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCharmIDByRevision", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "GetCharmID", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(charm.ID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetCharmIDByRevision indicates an expected call of GetCharmIDByRevision.
-func (mr *MockCharmStateMockRecorder) GetCharmIDByRevision(arg0, arg1, arg2 any) *MockCharmStateGetCharmIDByRevisionCall {
+// GetCharmID indicates an expected call of GetCharmID.
+func (mr *MockCharmStateMockRecorder) GetCharmID(arg0, arg1, arg2, arg3 any) *MockCharmStateGetCharmIDCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCharmIDByRevision", reflect.TypeOf((*MockCharmState)(nil).GetCharmIDByRevision), arg0, arg1, arg2)
-	return &MockCharmStateGetCharmIDByRevisionCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCharmID", reflect.TypeOf((*MockCharmState)(nil).GetCharmID), arg0, arg1, arg2, arg3)
+	return &MockCharmStateGetCharmIDCall{Call: call}
 }
 
-// MockCharmStateGetCharmIDByRevisionCall wrap *gomock.Call
-type MockCharmStateGetCharmIDByRevisionCall struct {
+// MockCharmStateGetCharmIDCall wrap *gomock.Call
+type MockCharmStateGetCharmIDCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockCharmStateGetCharmIDByRevisionCall) Return(arg0 charm.ID, arg1 error) *MockCharmStateGetCharmIDByRevisionCall {
+func (c *MockCharmStateGetCharmIDCall) Return(arg0 charm.ID, arg1 error) *MockCharmStateGetCharmIDCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockCharmStateGetCharmIDByRevisionCall) Do(f func(context.Context, string, int) (charm.ID, error)) *MockCharmStateGetCharmIDByRevisionCall {
+func (c *MockCharmStateGetCharmIDCall) Do(f func(context.Context, string, int, charm0.CharmSource) (charm.ID, error)) *MockCharmStateGetCharmIDCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockCharmStateGetCharmIDByRevisionCall) DoAndReturn(f func(context.Context, string, int) (charm.ID, error)) *MockCharmStateGetCharmIDByRevisionCall {
+func (c *MockCharmStateGetCharmIDCall) DoAndReturn(f func(context.Context, string, int, charm0.CharmSource) (charm.ID, error)) *MockCharmStateGetCharmIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/application/state/charm.go
+++ b/domain/application/state/charm.go
@@ -49,23 +49,19 @@ func (s *CharmState) GetCharmID(ctx context.Context, name string, revision int, 
 		return "", internalerrors.Capture(err)
 	}
 
-	var ident charmID
-	charmRef := charmReferenceNameRevision{
+	var ident charmUUID
+	charmRef := charmReferenceNameRevisionSource{
 		ReferenceName: name,
 		Revision:      revision,
 		Source:        string(source),
 	}
 
 	query := `
-SELECT &charmID.*
-FROM charm
-INNER JOIN charm_origin AS co
-ON charm.uuid = co.charm_uuid
-INNER JOIN charm_source AS cs
-ON cs.id = co.source_id
-WHERE co.reference_name = $charmReferenceNameRevision.reference_name
-AND co.revision = $charmReferenceNameRevision.revision
-AND cs.name = $charmReferenceNameRevision.source;
+SELECT &charmUUID.*
+FROM v_charm_origin
+WHERE reference_name = $charmReferenceNameRevisionSource.reference_name
+AND revision = $charmReferenceNameRevisionSource.revision
+AND source = $charmReferenceNameRevisionSource.source;
 `
 	stmt, err := s.Prepare(query, ident, charmRef)
 	if err != nil {

--- a/domain/application/state/charm_test.go
+++ b/domain/application/state/charm_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical Ltd
+// Copyright 2024 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package state

--- a/domain/application/state/state.go
+++ b/domain/application/state/state.go
@@ -61,10 +61,10 @@ SELECT &charmID.*
 FROM charm
 LEFT JOIN charm_origin
 WHERE charm.uuid = charm_origin.charm_uuid
-AND charm_origin.reference_name = $charmReferenceNameRevision.reference_name 
-AND charm_origin.revision = $charmReferenceNameRevision.revision
+AND charm_origin.reference_name = $charmReferenceNameRevisionSource.reference_name 
+AND charm_origin.revision = $charmReferenceNameRevisionSource.revision
 	`
-	ref := charmReferenceNameRevision{
+	ref := charmReferenceNameRevisionSource{
 		ReferenceName: referenceName,
 		Revision:      revision,
 	}

--- a/domain/application/state/types.go
+++ b/domain/application/state/types.go
@@ -196,9 +196,9 @@ type charmName struct {
 	Name string `db:"name"`
 }
 
-// charmReferenceNameRevision is used to pass the reference name and revision to
-// the query.
-type charmReferenceNameRevision struct {
+// charmReferenceNameRevisionSource is used to pass the reference name,
+// revision and source to the query.
+type charmReferenceNameRevisionSource struct {
 	ReferenceName string `db:"reference_name"`
 	Revision      int    `db:"revision"`
 	Source        string `db:"source"`

--- a/domain/application/state/types.go
+++ b/domain/application/state/types.go
@@ -201,6 +201,7 @@ type charmName struct {
 type charmReferenceNameRevision struct {
 	ReferenceName string `db:"reference_name"`
 	Revision      int    `db:"revision"`
+	Source        string `db:"source"`
 }
 
 // charmAvailable is used to get the available status of a charm.


### PR DESCRIPTION
Before this patch the charm source (local or charmhub) was not part of the query when retrieving a charm ID by name (plus revision). Now we also have to provide the charm source.

This work is needed because in a following patch we are going to be retrieving charms by URL (as URLs are the natural key on the legacy state) and the charm source (URL schema) was the last missing part preventing us doing so.

<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://docs.google.com/document/d/1SYUo9G7qZ_jdoVXpUVamS5VCgHmtZ0QA-wZxKoMS-C0 
-->

<!-- Why this change is needed and what it does. -->

## QA steps

Deploying any charm should test the modified path (deployer calls `CharmInfo()` so everything should be OK):

```
juju bootstrap lxd c
juju add-model m
juju deploy ubuntu
```

## Links

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/

**Jira card:** JUJU-6846

