### PR TITLE
3.6 main

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -551,10 +551,13 @@ rebuild-schema:
 	@echo "Generating facade schema..."
 # GOOS and GOARCH environment variables are cleared in case the user is trying to cross architecture compilation.
 ifdef SCHEMA_PATH
-	@env GOOS= GOARCH= CGO_ENABLED=1 go run -tags="libsqlite3" $(COMPILE_FLAGS) $(PROJECT)/generate/schemagen -admin-facades -facade-group=client "$(SCHEMA_PATH)"
+	@env GOOS= GOARCH= CGO_ENABLED=1 go run -tags="libsqlite3" $(COMPILE_FLAGS) $(PROJECT)/generate/schemagen -admin-facades -facade-group=client "$(SCHEMA_PATH)/schema.json"
+	@env GOOS= GOARCH= CGO_ENABLED=1 go run -tags="libsqlite3" $(COMPILE_FLAGS) $(PROJECT)/generate/schemagen -admin-facades -facade-group=agent "$(SCHEMA_PATH)/agent-schema.json"
 else
 	@env GOOS= GOARCH= CGO_ENABLED=1 go run -tags="libsqlite3" $(COMPILE_FLAGS) $(PROJECT)/generate/schemagen -admin-facades -facade-group=client \
 		./apiserver/facades/schema.json
+	@env GOOS= GOARCH= CGO_ENABLED=1 go run -tags="libsqlite3" $(COMPILE_FLAGS) $(PROJECT)/generate/schemagen -admin-facades -facade-group=agent \
+		./apiserver/facades/agent-schema.json
 endif
 
 .PHONY: rebuild-triggers

--- a/apiserver/facades/agent-schema.json
+++ b/apiserver/facades/agent-schema.json
@@ -1,0 +1,14468 @@
+[
+    {
+        "Name": "Admin",
+        "Description": "",
+        "Version": 3,
+        "AvailableTo": [
+            "controller-machine-agent",
+            "machine-agent",
+            "unit-agent",
+            "controller-user",
+            "model-user"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "Login": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/LoginRequest"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/LoginResult"
+                        }
+                    }
+                },
+                "RedirectInfo": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/RedirectInfoResult"
+                        }
+                    }
+                }
+            },
+            "definitions": {
+                "Address": {
+                    "type": "object",
+                    "properties": {
+                        "cidr": {
+                            "type": "string"
+                        },
+                        "config-type": {
+                            "type": "string"
+                        },
+                        "is-secondary": {
+                            "type": "boolean"
+                        },
+                        "scope": {
+                            "type": "string"
+                        },
+                        "space-id": {
+                            "type": "string"
+                        },
+                        "space-name": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "type": "string"
+                        },
+                        "value": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "value",
+                        "type",
+                        "scope"
+                    ]
+                },
+                "AuthUserInfo": {
+                    "type": "object",
+                    "properties": {
+                        "controller-access": {
+                            "type": "string"
+                        },
+                        "credentials": {
+                            "type": "string"
+                        },
+                        "display-name": {
+                            "type": "string"
+                        },
+                        "identity": {
+                            "type": "string"
+                        },
+                        "last-connection": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "model-access": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "display-name",
+                        "identity",
+                        "controller-access",
+                        "model-access"
+                    ]
+                },
+                "FacadeVersions": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "versions": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "name",
+                        "versions"
+                    ]
+                },
+                "HostPort": {
+                    "type": "object",
+                    "properties": {
+                        "Address": {
+                            "$ref": "#/definitions/Address"
+                        },
+                        "cidr": {
+                            "type": "string"
+                        },
+                        "config-type": {
+                            "type": "string"
+                        },
+                        "is-secondary": {
+                            "type": "boolean"
+                        },
+                        "port": {
+                            "type": "integer"
+                        },
+                        "scope": {
+                            "type": "string"
+                        },
+                        "space-id": {
+                            "type": "string"
+                        },
+                        "space-name": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "type": "string"
+                        },
+                        "value": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "value",
+                        "type",
+                        "scope",
+                        "Address",
+                        "port"
+                    ]
+                },
+                "LoginRequest": {
+                    "type": "object",
+                    "properties": {
+                        "auth-tag": {
+                            "type": "string"
+                        },
+                        "bakery-version": {
+                            "type": "integer"
+                        },
+                        "cli-args": {
+                            "type": "string"
+                        },
+                        "client-version": {
+                            "type": "string"
+                        },
+                        "credentials": {
+                            "type": "string"
+                        },
+                        "macaroons": {
+                            "type": "array",
+                            "items": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/definitions/Macaroon"
+                                }
+                            }
+                        },
+                        "nonce": {
+                            "type": "string"
+                        },
+                        "token": {
+                            "type": "string"
+                        },
+                        "user-data": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "auth-tag",
+                        "credentials",
+                        "nonce",
+                        "macaroons",
+                        "user-data"
+                    ]
+                },
+                "LoginResult": {
+                    "type": "object",
+                    "properties": {
+                        "bakery-discharge-required": {
+                            "$ref": "#/definitions/Macaroon"
+                        },
+                        "controller-tag": {
+                            "type": "string"
+                        },
+                        "discharge-required": {
+                            "$ref": "#/definitions/Macaroon"
+                        },
+                        "discharge-required-error": {
+                            "type": "string"
+                        },
+                        "facades": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/FacadeVersions"
+                            }
+                        },
+                        "model-tag": {
+                            "type": "string"
+                        },
+                        "public-dns-name": {
+                            "type": "string"
+                        },
+                        "server-version": {
+                            "type": "string"
+                        },
+                        "servers": {
+                            "type": "array",
+                            "items": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/definitions/HostPort"
+                                }
+                            }
+                        },
+                        "user-info": {
+                            "$ref": "#/definitions/AuthUserInfo"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "Macaroon": {
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "RedirectInfoResult": {
+                    "type": "object",
+                    "properties": {
+                        "ca-cert": {
+                            "type": "string"
+                        },
+                        "servers": {
+                            "type": "array",
+                            "items": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/definitions/HostPort"
+                                }
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "servers",
+                        "ca-cert"
+                    ]
+                }
+            }
+        }
+    },
+    {
+        "Name": "Agent",
+        "Description": "",
+        "Version": 3,
+        "AvailableTo": [
+            "controller-machine-agent",
+            "machine-agent",
+            "unit-agent"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "ClearReboot": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "CloudSpec": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/CloudSpecResults"
+                        }
+                    }
+                },
+                "ControllerAPIInfoForModels": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ControllerAPIInfoResults"
+                        }
+                    }
+                },
+                "ControllerConfig": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/ControllerConfigResult"
+                        }
+                    }
+                },
+                "GetCloudSpec": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/ModelTag"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/CloudSpecResult"
+                        }
+                    }
+                },
+                "GetEntities": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/AgentGetEntitiesResults"
+                        }
+                    }
+                },
+                "IsMaster": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/IsMasterResult"
+                        }
+                    }
+                },
+                "ModelConfig": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/ModelConfigResult"
+                        }
+                    }
+                },
+                "SetPasswords": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/EntityPasswords"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "StateServingInfo": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/StateServingInfo"
+                        }
+                    }
+                },
+                "WatchCloudSpecsChanges": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/NotifyWatchResults"
+                        }
+                    }
+                },
+                "WatchCredentials": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/NotifyWatchResults"
+                        }
+                    }
+                },
+                "WatchForModelConfigChanges": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/NotifyWatchResult"
+                        }
+                    }
+                }
+            },
+            "definitions": {
+                "AgentGetEntitiesResult": {
+                    "type": "object",
+                    "properties": {
+                        "container-type": {
+                            "type": "string"
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "jobs": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "life": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "life",
+                        "jobs",
+                        "container-type"
+                    ]
+                },
+                "AgentGetEntitiesResults": {
+                    "type": "object",
+                    "properties": {
+                        "entities": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/AgentGetEntitiesResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "entities"
+                    ]
+                },
+                "CloudCredential": {
+                    "type": "object",
+                    "properties": {
+                        "attrs": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "auth-type": {
+                            "type": "string"
+                        },
+                        "redacted": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "auth-type"
+                    ]
+                },
+                "CloudSpec": {
+                    "type": "object",
+                    "properties": {
+                        "cacertificates": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "credential": {
+                            "$ref": "#/definitions/CloudCredential"
+                        },
+                        "endpoint": {
+                            "type": "string"
+                        },
+                        "identity-endpoint": {
+                            "type": "string"
+                        },
+                        "is-controller-cloud": {
+                            "type": "boolean"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "region": {
+                            "type": "string"
+                        },
+                        "skip-tls-verify": {
+                            "type": "boolean"
+                        },
+                        "storage-endpoint": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "type",
+                        "name"
+                    ]
+                },
+                "CloudSpecResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "$ref": "#/definitions/CloudSpec"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "CloudSpecResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/CloudSpecResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ControllerAPIInfoResult": {
+                    "type": "object",
+                    "properties": {
+                        "addresses": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "cacert": {
+                            "type": "string"
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "addresses",
+                        "cacert"
+                    ]
+                },
+                "ControllerAPIInfoResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ControllerAPIInfoResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "ControllerConfigResult": {
+                    "type": "object",
+                    "properties": {
+                        "config": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "config"
+                    ]
+                },
+                "Entities": {
+                    "type": "object",
+                    "properties": {
+                        "entities": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Entity"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "entities"
+                    ]
+                },
+                "Entity": {
+                    "type": "object",
+                    "properties": {
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag"
+                    ]
+                },
+                "EntityPassword": {
+                    "type": "object",
+                    "properties": {
+                        "password": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag",
+                        "password"
+                    ]
+                },
+                "EntityPasswords": {
+                    "type": "object",
+                    "properties": {
+                        "changes": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/EntityPassword"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "changes"
+                    ]
+                },
+                "Error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "message",
+                        "code"
+                    ]
+                },
+                "ErrorResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ErrorResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ErrorResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "IsMasterResult": {
+                    "type": "object",
+                    "properties": {
+                        "master": {
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "master"
+                    ]
+                },
+                "ModelConfigResult": {
+                    "type": "object",
+                    "properties": {
+                        "config": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "config"
+                    ]
+                },
+                "ModelTag": {
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "NotifyWatchResult": {
+                    "type": "object",
+                    "properties": {
+                        "NotifyWatcherId": {
+                            "type": "string"
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "NotifyWatcherId"
+                    ]
+                },
+                "NotifyWatchResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/NotifyWatchResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "StateServingInfo": {
+                    "type": "object",
+                    "properties": {
+                        "api-port": {
+                            "type": "integer"
+                        },
+                        "ca-private-key": {
+                            "type": "string"
+                        },
+                        "cert": {
+                            "type": "string"
+                        },
+                        "controller-api-port": {
+                            "type": "integer"
+                        },
+                        "private-key": {
+                            "type": "string"
+                        },
+                        "shared-secret": {
+                            "type": "string"
+                        },
+                        "state-port": {
+                            "type": "integer"
+                        },
+                        "system-identity": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "api-port",
+                        "state-port",
+                        "cert",
+                        "private-key",
+                        "ca-private-key",
+                        "shared-secret",
+                        "system-identity"
+                    ]
+                }
+            }
+        }
+    },
+    {
+        "Name": "AgentLifeFlag",
+        "Description": "",
+        "Version": 1,
+        "AvailableTo": [
+            "controller-machine-agent",
+            "machine-agent",
+            "unit-agent",
+            "model-user"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "Life": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/LifeResults"
+                        }
+                    }
+                },
+                "Watch": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/NotifyWatchResults"
+                        }
+                    }
+                }
+            },
+            "definitions": {
+                "Entities": {
+                    "type": "object",
+                    "properties": {
+                        "entities": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Entity"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "entities"
+                    ]
+                },
+                "Entity": {
+                    "type": "object",
+                    "properties": {
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag"
+                    ]
+                },
+                "Error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "message",
+                        "code"
+                    ]
+                },
+                "LifeResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "life": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "life"
+                    ]
+                },
+                "LifeResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/LifeResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "NotifyWatchResult": {
+                    "type": "object",
+                    "properties": {
+                        "NotifyWatcherId": {
+                            "type": "string"
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "NotifyWatcherId"
+                    ]
+                },
+                "NotifyWatchResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/NotifyWatchResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                }
+            }
+        }
+    },
+    {
+        "Name": "CAASAdmission",
+        "Description": "",
+        "Version": 1,
+        "AvailableTo": [
+            "controller-machine-agent",
+            "machine-agent"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "ControllerAPIInfoForModels": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ControllerAPIInfoResults"
+                        }
+                    }
+                },
+                "ControllerConfig": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/ControllerConfigResult"
+                        }
+                    }
+                }
+            },
+            "definitions": {
+                "ControllerAPIInfoResult": {
+                    "type": "object",
+                    "properties": {
+                        "addresses": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "cacert": {
+                            "type": "string"
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "addresses",
+                        "cacert"
+                    ]
+                },
+                "ControllerAPIInfoResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ControllerAPIInfoResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "ControllerConfigResult": {
+                    "type": "object",
+                    "properties": {
+                        "config": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "config"
+                    ]
+                },
+                "Entities": {
+                    "type": "object",
+                    "properties": {
+                        "entities": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Entity"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "entities"
+                    ]
+                },
+                "Entity": {
+                    "type": "object",
+                    "properties": {
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag"
+                    ]
+                },
+                "Error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "message",
+                        "code"
+                    ]
+                }
+            }
+        }
+    },
+    {
+        "Name": "CAASAgent",
+        "Description": "",
+        "Version": 2,
+        "AvailableTo": [
+            "controller-machine-agent",
+            "machine-agent",
+            "unit-agent",
+            "model-user"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "CloudSpec": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/CloudSpecResults"
+                        }
+                    }
+                },
+                "ControllerAPIInfoForModels": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ControllerAPIInfoResults"
+                        }
+                    }
+                },
+                "ControllerConfig": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/ControllerConfigResult"
+                        }
+                    }
+                },
+                "GetCloudSpec": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/ModelTag"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/CloudSpecResult"
+                        }
+                    }
+                },
+                "ModelConfig": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/ModelConfigResult"
+                        }
+                    }
+                },
+                "WatchCloudSpecsChanges": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/NotifyWatchResults"
+                        }
+                    }
+                },
+                "WatchForModelConfigChanges": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/NotifyWatchResult"
+                        }
+                    }
+                }
+            },
+            "definitions": {
+                "CloudCredential": {
+                    "type": "object",
+                    "properties": {
+                        "attrs": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "auth-type": {
+                            "type": "string"
+                        },
+                        "redacted": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "auth-type"
+                    ]
+                },
+                "CloudSpec": {
+                    "type": "object",
+                    "properties": {
+                        "cacertificates": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "credential": {
+                            "$ref": "#/definitions/CloudCredential"
+                        },
+                        "endpoint": {
+                            "type": "string"
+                        },
+                        "identity-endpoint": {
+                            "type": "string"
+                        },
+                        "is-controller-cloud": {
+                            "type": "boolean"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "region": {
+                            "type": "string"
+                        },
+                        "skip-tls-verify": {
+                            "type": "boolean"
+                        },
+                        "storage-endpoint": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "type",
+                        "name"
+                    ]
+                },
+                "CloudSpecResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "$ref": "#/definitions/CloudSpec"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "CloudSpecResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/CloudSpecResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ControllerAPIInfoResult": {
+                    "type": "object",
+                    "properties": {
+                        "addresses": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "cacert": {
+                            "type": "string"
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "addresses",
+                        "cacert"
+                    ]
+                },
+                "ControllerAPIInfoResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ControllerAPIInfoResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "ControllerConfigResult": {
+                    "type": "object",
+                    "properties": {
+                        "config": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "config"
+                    ]
+                },
+                "Entities": {
+                    "type": "object",
+                    "properties": {
+                        "entities": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Entity"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "entities"
+                    ]
+                },
+                "Entity": {
+                    "type": "object",
+                    "properties": {
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag"
+                    ]
+                },
+                "Error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "message",
+                        "code"
+                    ]
+                },
+                "ModelConfigResult": {
+                    "type": "object",
+                    "properties": {
+                        "config": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "config"
+                    ]
+                },
+                "ModelTag": {
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "NotifyWatchResult": {
+                    "type": "object",
+                    "properties": {
+                        "NotifyWatcherId": {
+                            "type": "string"
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "NotifyWatcherId"
+                    ]
+                },
+                "NotifyWatchResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/NotifyWatchResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                }
+            }
+        }
+    },
+    {
+        "Name": "CAASApplication",
+        "Description": "",
+        "Version": 1,
+        "AvailableTo": [
+            "controller-machine-agent",
+            "machine-agent",
+            "unit-agent",
+            "model-user"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "UnitIntroduction": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/CAASUnitIntroductionArgs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/CAASUnitIntroductionResult"
+                        }
+                    }
+                },
+                "UnitTerminating": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entity"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/CAASUnitTerminationResult"
+                        }
+                    }
+                }
+            },
+            "definitions": {
+                "CAASUnitIntroduction": {
+                    "type": "object",
+                    "properties": {
+                        "agent-conf": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            }
+                        },
+                        "unit-name": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "unit-name",
+                        "agent-conf"
+                    ]
+                },
+                "CAASUnitIntroductionArgs": {
+                    "type": "object",
+                    "properties": {
+                        "pod-name": {
+                            "type": "string"
+                        },
+                        "pod-uuid": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "pod-name",
+                        "pod-uuid"
+                    ]
+                },
+                "CAASUnitIntroductionResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "$ref": "#/definitions/CAASUnitIntroduction"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "CAASUnitTerminationResult": {
+                    "type": "object",
+                    "properties": {
+                        "Error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "WillRestart": {
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "WillRestart",
+                        "Error"
+                    ]
+                },
+                "Entity": {
+                    "type": "object",
+                    "properties": {
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag"
+                    ]
+                },
+                "Error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "message",
+                        "code"
+                    ]
+                }
+            }
+        }
+    },
+    {
+        "Name": "CredentialValidator",
+        "Description": "",
+        "Version": 2,
+        "AvailableTo": [
+            "controller-machine-agent",
+            "machine-agent",
+            "unit-agent",
+            "model-user"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "InvalidateModelCredential": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/InvalidateCredentialArg"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResult"
+                        }
+                    }
+                },
+                "ModelCredential": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/ModelCredential"
+                        }
+                    }
+                },
+                "WatchCredential": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entity"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/NotifyWatchResult"
+                        }
+                    }
+                },
+                "WatchModelCredential": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/NotifyWatchResult"
+                        }
+                    }
+                }
+            },
+            "definitions": {
+                "Entity": {
+                    "type": "object",
+                    "properties": {
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag"
+                    ]
+                },
+                "Error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "message",
+                        "code"
+                    ]
+                },
+                "ErrorResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "InvalidateCredentialArg": {
+                    "type": "object",
+                    "properties": {
+                        "reason": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ModelCredential": {
+                    "type": "object",
+                    "properties": {
+                        "credential-tag": {
+                            "type": "string"
+                        },
+                        "exists": {
+                            "type": "boolean"
+                        },
+                        "model-tag": {
+                            "type": "string"
+                        },
+                        "valid": {
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "model-tag",
+                        "credential-tag"
+                    ]
+                },
+                "NotifyWatchResult": {
+                    "type": "object",
+                    "properties": {
+                        "NotifyWatcherId": {
+                            "type": "string"
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "NotifyWatcherId"
+                    ]
+                }
+            }
+        }
+    },
+    {
+        "Name": "Deployer",
+        "Description": "",
+        "Version": 1,
+        "AvailableTo": [
+            "controller-machine-agent",
+            "machine-agent"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "APIAddresses": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/StringsResult"
+                        }
+                    }
+                },
+                "APIHostPorts": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/APIHostPortsResult"
+                        }
+                    }
+                },
+                "ConnectionInfo": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/DeployerConnectionValues"
+                        }
+                    }
+                },
+                "Life": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/LifeResults"
+                        }
+                    }
+                },
+                "ModelUUID": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/StringResult"
+                        }
+                    }
+                },
+                "Remove": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "SetPasswords": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/EntityPasswords"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "SetStatus": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/SetStatus"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "WatchAPIHostPorts": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/NotifyWatchResult"
+                        }
+                    }
+                },
+                "WatchUnits": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/StringsWatchResults"
+                        }
+                    }
+                }
+            },
+            "definitions": {
+                "APIHostPortsResult": {
+                    "type": "object",
+                    "properties": {
+                        "servers": {
+                            "type": "array",
+                            "items": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/definitions/HostPort"
+                                }
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "servers"
+                    ]
+                },
+                "Address": {
+                    "type": "object",
+                    "properties": {
+                        "cidr": {
+                            "type": "string"
+                        },
+                        "config-type": {
+                            "type": "string"
+                        },
+                        "is-secondary": {
+                            "type": "boolean"
+                        },
+                        "scope": {
+                            "type": "string"
+                        },
+                        "space-id": {
+                            "type": "string"
+                        },
+                        "space-name": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "type": "string"
+                        },
+                        "value": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "value",
+                        "type",
+                        "scope"
+                    ]
+                },
+                "DeployerConnectionValues": {
+                    "type": "object",
+                    "properties": {
+                        "api-addresses": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "api-addresses"
+                    ]
+                },
+                "Entities": {
+                    "type": "object",
+                    "properties": {
+                        "entities": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Entity"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "entities"
+                    ]
+                },
+                "Entity": {
+                    "type": "object",
+                    "properties": {
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag"
+                    ]
+                },
+                "EntityPassword": {
+                    "type": "object",
+                    "properties": {
+                        "password": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag",
+                        "password"
+                    ]
+                },
+                "EntityPasswords": {
+                    "type": "object",
+                    "properties": {
+                        "changes": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/EntityPassword"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "changes"
+                    ]
+                },
+                "EntityStatusArgs": {
+                    "type": "object",
+                    "properties": {
+                        "data": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "info": {
+                            "type": "string"
+                        },
+                        "status": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag",
+                        "status",
+                        "info",
+                        "data"
+                    ]
+                },
+                "Error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "message",
+                        "code"
+                    ]
+                },
+                "ErrorResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ErrorResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ErrorResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "HostPort": {
+                    "type": "object",
+                    "properties": {
+                        "Address": {
+                            "$ref": "#/definitions/Address"
+                        },
+                        "cidr": {
+                            "type": "string"
+                        },
+                        "config-type": {
+                            "type": "string"
+                        },
+                        "is-secondary": {
+                            "type": "boolean"
+                        },
+                        "port": {
+                            "type": "integer"
+                        },
+                        "scope": {
+                            "type": "string"
+                        },
+                        "space-id": {
+                            "type": "string"
+                        },
+                        "space-name": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "type": "string"
+                        },
+                        "value": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "value",
+                        "type",
+                        "scope",
+                        "Address",
+                        "port"
+                    ]
+                },
+                "LifeResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "life": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "life"
+                    ]
+                },
+                "LifeResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/LifeResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "NotifyWatchResult": {
+                    "type": "object",
+                    "properties": {
+                        "NotifyWatcherId": {
+                            "type": "string"
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "NotifyWatcherId"
+                    ]
+                },
+                "SetStatus": {
+                    "type": "object",
+                    "properties": {
+                        "entities": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/EntityStatusArgs"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "entities"
+                    ]
+                },
+                "StringResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "result"
+                    ]
+                },
+                "StringsResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "StringsWatchResult": {
+                    "type": "object",
+                    "properties": {
+                        "changes": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "watcher-id": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "watcher-id"
+                    ]
+                },
+                "StringsWatchResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/StringsWatchResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                }
+            }
+        }
+    },
+    {
+        "Name": "DiskManager",
+        "Description": "",
+        "Version": 2,
+        "AvailableTo": [
+            "controller-machine-agent",
+            "machine-agent"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "SetMachineBlockDevices": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/SetMachineBlockDevices"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                }
+            },
+            "definitions": {
+                "BlockDevice": {
+                    "type": "object",
+                    "properties": {
+                        "BusAddress": {
+                            "type": "string"
+                        },
+                        "DeviceLinks": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "DeviceName": {
+                            "type": "string"
+                        },
+                        "FilesystemType": {
+                            "type": "string"
+                        },
+                        "HardwareId": {
+                            "type": "string"
+                        },
+                        "InUse": {
+                            "type": "boolean"
+                        },
+                        "Label": {
+                            "type": "string"
+                        },
+                        "MountPoint": {
+                            "type": "string"
+                        },
+                        "SerialId": {
+                            "type": "string"
+                        },
+                        "Size": {
+                            "type": "integer"
+                        },
+                        "UUID": {
+                            "type": "string"
+                        },
+                        "WWN": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "DeviceName",
+                        "DeviceLinks",
+                        "Label",
+                        "UUID",
+                        "HardwareId",
+                        "WWN",
+                        "BusAddress",
+                        "Size",
+                        "FilesystemType",
+                        "InUse",
+                        "MountPoint",
+                        "SerialId"
+                    ]
+                },
+                "Error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "message",
+                        "code"
+                    ]
+                },
+                "ErrorResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ErrorResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ErrorResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "MachineBlockDevices": {
+                    "type": "object",
+                    "properties": {
+                        "block-devices": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/BlockDevice"
+                            }
+                        },
+                        "machine": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "machine"
+                    ]
+                },
+                "SetMachineBlockDevices": {
+                    "type": "object",
+                    "properties": {
+                        "machine-block-devices": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/MachineBlockDevices"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "machine-block-devices"
+                    ]
+                }
+            }
+        }
+    },
+    {
+        "Name": "HostKeyReporter",
+        "Description": "",
+        "Version": 1,
+        "AvailableTo": [
+            "controller-machine-agent",
+            "machine-agent",
+            "unit-agent",
+            "model-user"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "ReportKeys": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/SSHHostKeySet"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                }
+            },
+            "definitions": {
+                "Error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "message",
+                        "code"
+                    ]
+                },
+                "ErrorResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ErrorResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ErrorResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "SSHHostKeySet": {
+                    "type": "object",
+                    "properties": {
+                        "entity-keys": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/SSHHostKeys"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "entity-keys"
+                    ]
+                },
+                "SSHHostKeys": {
+                    "type": "object",
+                    "properties": {
+                        "public-keys": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag",
+                        "public-keys"
+                    ]
+                }
+            }
+        }
+    },
+    {
+        "Name": "InstanceMutater",
+        "Description": "",
+        "Version": 3,
+        "AvailableTo": [
+            "controller-machine-agent",
+            "machine-agent",
+            "unit-agent",
+            "model-user"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "CharmProfilingInfo": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entity"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/CharmProfilingInfoResult"
+                        }
+                    }
+                },
+                "ContainerType": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entity"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ContainerTypeResult"
+                        }
+                    }
+                },
+                "Life": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/LifeResults"
+                        }
+                    }
+                },
+                "SetCharmProfiles": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/SetProfileArgs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "SetModificationStatus": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/SetStatus"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "WatchContainers": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entity"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/StringsWatchResult"
+                        }
+                    }
+                },
+                "WatchLXDProfileVerificationNeeded": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/NotifyWatchResults"
+                        }
+                    }
+                },
+                "WatchMachines": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/StringsWatchResult"
+                        }
+                    }
+                },
+                "WatchModelMachines": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/StringsWatchResult"
+                        }
+                    }
+                }
+            },
+            "definitions": {
+                "CharmLXDProfile": {
+                    "type": "object",
+                    "properties": {
+                        "config": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": {
+                            "type": "string"
+                        },
+                        "devices": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "patternProperties": {
+                                        ".*": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "config",
+                        "description",
+                        "devices"
+                    ]
+                },
+                "CharmProfilingInfoResult": {
+                    "type": "object",
+                    "properties": {
+                        "current-profiles": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "instance-id": {
+                            "type": "string"
+                        },
+                        "model-name": {
+                            "type": "string"
+                        },
+                        "profile-changes": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ProfileInfoResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "instance-id",
+                        "model-name",
+                        "profile-changes",
+                        "current-profiles",
+                        "error"
+                    ]
+                },
+                "ContainerTypeResult": {
+                    "type": "object",
+                    "properties": {
+                        "container-type": {
+                            "type": "string"
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "container-type",
+                        "error"
+                    ]
+                },
+                "Entities": {
+                    "type": "object",
+                    "properties": {
+                        "entities": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Entity"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "entities"
+                    ]
+                },
+                "Entity": {
+                    "type": "object",
+                    "properties": {
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag"
+                    ]
+                },
+                "EntityStatusArgs": {
+                    "type": "object",
+                    "properties": {
+                        "data": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "info": {
+                            "type": "string"
+                        },
+                        "status": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag",
+                        "status",
+                        "info",
+                        "data"
+                    ]
+                },
+                "Error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "message",
+                        "code"
+                    ]
+                },
+                "ErrorResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ErrorResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ErrorResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "LifeResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "life": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "life"
+                    ]
+                },
+                "LifeResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/LifeResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "NotifyWatchResult": {
+                    "type": "object",
+                    "properties": {
+                        "NotifyWatcherId": {
+                            "type": "string"
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "NotifyWatcherId"
+                    ]
+                },
+                "NotifyWatchResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/NotifyWatchResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "ProfileInfoResult": {
+                    "type": "object",
+                    "properties": {
+                        "application-name": {
+                            "type": "string"
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "profile": {
+                            "$ref": "#/definitions/CharmLXDProfile"
+                        },
+                        "revision": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "SetProfileArg": {
+                    "type": "object",
+                    "properties": {
+                        "entity": {
+                            "$ref": "#/definitions/Entity"
+                        },
+                        "profiles": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "entity",
+                        "profiles"
+                    ]
+                },
+                "SetProfileArgs": {
+                    "type": "object",
+                    "properties": {
+                        "args": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/SetProfileArg"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "args"
+                    ]
+                },
+                "SetStatus": {
+                    "type": "object",
+                    "properties": {
+                        "entities": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/EntityStatusArgs"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "entities"
+                    ]
+                },
+                "StringsWatchResult": {
+                    "type": "object",
+                    "properties": {
+                        "changes": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "watcher-id": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "watcher-id"
+                    ]
+                }
+            }
+        }
+    },
+    {
+        "Name": "KeyUpdater",
+        "Description": "",
+        "Version": 1,
+        "AvailableTo": [
+            "controller-machine-agent",
+            "machine-agent",
+            "unit-agent",
+            "model-user"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "AuthorisedKeys": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/StringsResults"
+                        }
+                    }
+                },
+                "WatchAuthorisedKeys": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/NotifyWatchResults"
+                        }
+                    }
+                }
+            },
+            "definitions": {
+                "Entities": {
+                    "type": "object",
+                    "properties": {
+                        "entities": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Entity"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "entities"
+                    ]
+                },
+                "Entity": {
+                    "type": "object",
+                    "properties": {
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag"
+                    ]
+                },
+                "Error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "message",
+                        "code"
+                    ]
+                },
+                "NotifyWatchResult": {
+                    "type": "object",
+                    "properties": {
+                        "NotifyWatcherId": {
+                            "type": "string"
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "NotifyWatcherId"
+                    ]
+                },
+                "NotifyWatchResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/NotifyWatchResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "StringsResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "StringsResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/StringsResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                }
+            }
+        }
+    },
+    {
+        "Name": "LeadershipService",
+        "Description": "",
+        "Version": 2,
+        "AvailableTo": [
+            "controller-machine-agent",
+            "machine-agent",
+            "unit-agent",
+            "model-user"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "BlockUntilLeadershipReleased": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/ApplicationTag"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResult"
+                        }
+                    }
+                },
+                "ClaimLeadership": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/ClaimLeadershipBulkParams"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ClaimLeadershipBulkResults"
+                        }
+                    }
+                }
+            },
+            "definitions": {
+                "ApplicationTag": {
+                    "type": "object",
+                    "properties": {
+                        "Name": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "Name"
+                    ]
+                },
+                "ClaimLeadershipBulkParams": {
+                    "type": "object",
+                    "properties": {
+                        "params": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ClaimLeadershipParams"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "params"
+                    ]
+                },
+                "ClaimLeadershipBulkResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ErrorResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "ClaimLeadershipParams": {
+                    "type": "object",
+                    "properties": {
+                        "application-tag": {
+                            "type": "string"
+                        },
+                        "duration": {
+                            "type": "number"
+                        },
+                        "unit-tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "application-tag",
+                        "unit-tag",
+                        "duration"
+                    ]
+                },
+                "Error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "message",
+                        "code"
+                    ]
+                },
+                "ErrorResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            }
+        }
+    },
+    {
+        "Name": "Logger",
+        "Description": "",
+        "Version": 1,
+        "AvailableTo": [
+            "controller-machine-agent",
+            "machine-agent",
+            "unit-agent",
+            "model-user"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "LoggingConfig": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/StringResults"
+                        }
+                    }
+                },
+                "WatchLoggingConfig": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/NotifyWatchResults"
+                        }
+                    }
+                }
+            },
+            "definitions": {
+                "Entities": {
+                    "type": "object",
+                    "properties": {
+                        "entities": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Entity"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "entities"
+                    ]
+                },
+                "Entity": {
+                    "type": "object",
+                    "properties": {
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag"
+                    ]
+                },
+                "Error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "message",
+                        "code"
+                    ]
+                },
+                "NotifyWatchResult": {
+                    "type": "object",
+                    "properties": {
+                        "NotifyWatcherId": {
+                            "type": "string"
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "NotifyWatcherId"
+                    ]
+                },
+                "NotifyWatchResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/NotifyWatchResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "StringResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "result"
+                    ]
+                },
+                "StringResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/StringResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                }
+            }
+        }
+    },
+    {
+        "Name": "MachineActions",
+        "Description": "",
+        "Version": 1,
+        "AvailableTo": [
+            "controller-machine-agent",
+            "machine-agent"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "Actions": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ActionResults"
+                        }
+                    }
+                },
+                "BeginActions": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "FinishActions": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/ActionExecutionResults"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "RunningActions": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ActionsByReceivers"
+                        }
+                    }
+                },
+                "WatchActionNotifications": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/StringsWatchResults"
+                        }
+                    }
+                }
+            },
+            "definitions": {
+                "Action": {
+                    "type": "object",
+                    "properties": {
+                        "execution-group": {
+                            "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "parallel": {
+                            "type": "boolean"
+                        },
+                        "parameters": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "receiver": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag",
+                        "receiver",
+                        "name"
+                    ]
+                },
+                "ActionExecutionResult": {
+                    "type": "object",
+                    "properties": {
+                        "action-tag": {
+                            "type": "string"
+                        },
+                        "message": {
+                            "type": "string"
+                        },
+                        "results": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "status": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "action-tag",
+                        "status"
+                    ]
+                },
+                "ActionExecutionResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ActionExecutionResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ActionMessage": {
+                    "type": "object",
+                    "properties": {
+                        "message": {
+                            "type": "string"
+                        },
+                        "timestamp": {
+                            "type": "string",
+                            "format": "date-time"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "timestamp",
+                        "message"
+                    ]
+                },
+                "ActionResult": {
+                    "type": "object",
+                    "properties": {
+                        "action": {
+                            "$ref": "#/definitions/Action"
+                        },
+                        "completed": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "enqueued": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "log": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ActionMessage"
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        },
+                        "output": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "started": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "status": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ActionResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ActionResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ActionsByReceiver": {
+                    "type": "object",
+                    "properties": {
+                        "actions": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ActionResult"
+                            }
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "receiver": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ActionsByReceivers": {
+                    "type": "object",
+                    "properties": {
+                        "actions": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ActionsByReceiver"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "Entities": {
+                    "type": "object",
+                    "properties": {
+                        "entities": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Entity"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "entities"
+                    ]
+                },
+                "Entity": {
+                    "type": "object",
+                    "properties": {
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag"
+                    ]
+                },
+                "Error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "message",
+                        "code"
+                    ]
+                },
+                "ErrorResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ErrorResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ErrorResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "StringsWatchResult": {
+                    "type": "object",
+                    "properties": {
+                        "changes": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "watcher-id": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "watcher-id"
+                    ]
+                },
+                "StringsWatchResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/StringsWatchResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                }
+            }
+        }
+    },
+    {
+        "Name": "Machiner",
+        "Description": "",
+        "Version": 6,
+        "AvailableTo": [
+            "controller-machine-agent",
+            "machine-agent",
+            "unit-agent",
+            "model-user"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "APIAddresses": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/StringsResult"
+                        }
+                    }
+                },
+                "APIHostPorts": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/APIHostPortsResult"
+                        }
+                    }
+                },
+                "EnsureDead": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "IsController": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/IsControllerResults"
+                        }
+                    }
+                },
+                "Life": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/LifeResults"
+                        }
+                    }
+                },
+                "RecordAgentStartInformation": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/RecordAgentStartInformationArgs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "RecordAgentStartTime": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "SetMachineAddresses": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/SetMachinesAddresses"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "SetObservedNetworkConfig": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/SetMachineNetworkConfig"
+                        }
+                    }
+                },
+                "SetStatus": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/SetStatus"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "Watch": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/NotifyWatchResults"
+                        }
+                    }
+                },
+                "WatchAPIHostPorts": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/NotifyWatchResult"
+                        }
+                    }
+                }
+            },
+            "definitions": {
+                "APIHostPortsResult": {
+                    "type": "object",
+                    "properties": {
+                        "servers": {
+                            "type": "array",
+                            "items": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/definitions/HostPort"
+                                }
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "servers"
+                    ]
+                },
+                "Address": {
+                    "type": "object",
+                    "properties": {
+                        "cidr": {
+                            "type": "string"
+                        },
+                        "config-type": {
+                            "type": "string"
+                        },
+                        "is-secondary": {
+                            "type": "boolean"
+                        },
+                        "scope": {
+                            "type": "string"
+                        },
+                        "space-id": {
+                            "type": "string"
+                        },
+                        "space-name": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "type": "string"
+                        },
+                        "value": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "value",
+                        "type",
+                        "scope"
+                    ]
+                },
+                "Entities": {
+                    "type": "object",
+                    "properties": {
+                        "entities": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Entity"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "entities"
+                    ]
+                },
+                "Entity": {
+                    "type": "object",
+                    "properties": {
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag"
+                    ]
+                },
+                "EntityStatusArgs": {
+                    "type": "object",
+                    "properties": {
+                        "data": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "info": {
+                            "type": "string"
+                        },
+                        "status": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag",
+                        "status",
+                        "info",
+                        "data"
+                    ]
+                },
+                "Error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "message",
+                        "code"
+                    ]
+                },
+                "ErrorResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ErrorResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ErrorResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "HostPort": {
+                    "type": "object",
+                    "properties": {
+                        "Address": {
+                            "$ref": "#/definitions/Address"
+                        },
+                        "cidr": {
+                            "type": "string"
+                        },
+                        "config-type": {
+                            "type": "string"
+                        },
+                        "is-secondary": {
+                            "type": "boolean"
+                        },
+                        "port": {
+                            "type": "integer"
+                        },
+                        "scope": {
+                            "type": "string"
+                        },
+                        "space-id": {
+                            "type": "string"
+                        },
+                        "space-name": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "type": "string"
+                        },
+                        "value": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "value",
+                        "type",
+                        "scope",
+                        "Address",
+                        "port"
+                    ]
+                },
+                "IsControllerResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "is-controller": {
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "is-controller"
+                    ]
+                },
+                "IsControllerResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/IsControllerResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "LifeResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "life": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "life"
+                    ]
+                },
+                "LifeResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/LifeResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "MachineAddresses": {
+                    "type": "object",
+                    "properties": {
+                        "addresses": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Address"
+                            }
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag",
+                        "addresses"
+                    ]
+                },
+                "NetworkConfig": {
+                    "type": "object",
+                    "properties": {
+                        "address": {
+                            "type": "string"
+                        },
+                        "addresses": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Address"
+                            }
+                        },
+                        "cidr": {
+                            "type": "string"
+                        },
+                        "config-type": {
+                            "type": "string"
+                        },
+                        "device-index": {
+                            "type": "integer"
+                        },
+                        "disabled": {
+                            "type": "boolean"
+                        },
+                        "dns-search-domains": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "dns-servers": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "gateway-address": {
+                            "type": "string"
+                        },
+                        "interface-name": {
+                            "type": "string"
+                        },
+                        "interface-type": {
+                            "type": "string"
+                        },
+                        "is-default-gateway": {
+                            "type": "boolean"
+                        },
+                        "mac-address": {
+                            "type": "string"
+                        },
+                        "mtu": {
+                            "type": "integer"
+                        },
+                        "no-auto-start": {
+                            "type": "boolean"
+                        },
+                        "origin": {
+                            "type": "string"
+                        },
+                        "parent-interface-name": {
+                            "type": "string"
+                        },
+                        "provider-address-id": {
+                            "type": "string"
+                        },
+                        "provider-id": {
+                            "type": "string"
+                        },
+                        "provider-network-id": {
+                            "type": "string"
+                        },
+                        "provider-space-id": {
+                            "type": "string"
+                        },
+                        "provider-subnet-id": {
+                            "type": "string"
+                        },
+                        "provider-vlan-id": {
+                            "type": "string"
+                        },
+                        "routes": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/NetworkRoute"
+                            }
+                        },
+                        "shadow-addresses": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Address"
+                            }
+                        },
+                        "virtual-port-type": {
+                            "type": "string"
+                        },
+                        "vlan-tag": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "device-index",
+                        "mac-address",
+                        "cidr",
+                        "mtu",
+                        "provider-id",
+                        "provider-network-id",
+                        "provider-subnet-id",
+                        "provider-space-id",
+                        "provider-address-id",
+                        "provider-vlan-id",
+                        "vlan-tag",
+                        "interface-name",
+                        "parent-interface-name",
+                        "interface-type",
+                        "disabled"
+                    ]
+                },
+                "NetworkRoute": {
+                    "type": "object",
+                    "properties": {
+                        "destination-cidr": {
+                            "type": "string"
+                        },
+                        "gateway-ip": {
+                            "type": "string"
+                        },
+                        "metric": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "destination-cidr",
+                        "gateway-ip",
+                        "metric"
+                    ]
+                },
+                "NotifyWatchResult": {
+                    "type": "object",
+                    "properties": {
+                        "NotifyWatcherId": {
+                            "type": "string"
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "NotifyWatcherId"
+                    ]
+                },
+                "NotifyWatchResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/NotifyWatchResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "RecordAgentStartInformationArg": {
+                    "type": "object",
+                    "properties": {
+                        "hostname": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag"
+                    ]
+                },
+                "RecordAgentStartInformationArgs": {
+                    "type": "object",
+                    "properties": {
+                        "args": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/RecordAgentStartInformationArg"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "args"
+                    ]
+                },
+                "SetMachineNetworkConfig": {
+                    "type": "object",
+                    "properties": {
+                        "config": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/NetworkConfig"
+                            }
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag",
+                        "config"
+                    ]
+                },
+                "SetMachinesAddresses": {
+                    "type": "object",
+                    "properties": {
+                        "machine-addresses": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/MachineAddresses"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "machine-addresses"
+                    ]
+                },
+                "SetStatus": {
+                    "type": "object",
+                    "properties": {
+                        "entities": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/EntityStatusArgs"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "entities"
+                    ]
+                },
+                "StringsResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            }
+        }
+    },
+    {
+        "Name": "MigrationFlag",
+        "Description": "",
+        "Version": 1,
+        "AvailableTo": [
+            "controller-machine-agent",
+            "machine-agent",
+            "unit-agent",
+            "model-user"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "Phase": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/PhaseResults"
+                        }
+                    }
+                },
+                "Watch": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/NotifyWatchResults"
+                        }
+                    }
+                }
+            },
+            "definitions": {
+                "Entities": {
+                    "type": "object",
+                    "properties": {
+                        "entities": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Entity"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "entities"
+                    ]
+                },
+                "Entity": {
+                    "type": "object",
+                    "properties": {
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag"
+                    ]
+                },
+                "Error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "message",
+                        "code"
+                    ]
+                },
+                "NotifyWatchResult": {
+                    "type": "object",
+                    "properties": {
+                        "NotifyWatcherId": {
+                            "type": "string"
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "NotifyWatcherId"
+                    ]
+                },
+                "NotifyWatchResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/NotifyWatchResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "PhaseResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "phase": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "PhaseResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/PhaseResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                }
+            }
+        }
+    },
+    {
+        "Name": "MigrationMinion",
+        "Description": "",
+        "Version": 1,
+        "AvailableTo": [
+            "controller-machine-agent",
+            "machine-agent",
+            "unit-agent",
+            "model-user"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "Report": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/MinionReport"
+                        }
+                    }
+                },
+                "Watch": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/NotifyWatchResult"
+                        }
+                    }
+                }
+            },
+            "definitions": {
+                "Error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "message",
+                        "code"
+                    ]
+                },
+                "MinionReport": {
+                    "type": "object",
+                    "properties": {
+                        "migration-id": {
+                            "type": "string"
+                        },
+                        "phase": {
+                            "type": "string"
+                        },
+                        "success": {
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "migration-id",
+                        "phase",
+                        "success"
+                    ]
+                },
+                "NotifyWatchResult": {
+                    "type": "object",
+                    "properties": {
+                        "NotifyWatcherId": {
+                            "type": "string"
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "NotifyWatcherId"
+                    ]
+                }
+            }
+        }
+    },
+    {
+        "Name": "PayloadsHookContext",
+        "Description": "",
+        "Version": 1,
+        "AvailableTo": [
+            "controller-machine-agent",
+            "machine-agent",
+            "unit-agent",
+            "model-user"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "List": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/PayloadResults"
+                        }
+                    }
+                },
+                "LookUp": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/LookUpPayloadArgs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/PayloadResults"
+                        }
+                    }
+                },
+                "SetStatus": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/SetPayloadStatusArgs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/PayloadResults"
+                        }
+                    }
+                },
+                "Track": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/TrackPayloadArgs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/PayloadResults"
+                        }
+                    }
+                },
+                "Untrack": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/PayloadResults"
+                        }
+                    }
+                }
+            },
+            "definitions": {
+                "Entities": {
+                    "type": "object",
+                    "properties": {
+                        "entities": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Entity"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "entities"
+                    ]
+                },
+                "Entity": {
+                    "type": "object",
+                    "properties": {
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag"
+                    ]
+                },
+                "Error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "message",
+                        "code"
+                    ]
+                },
+                "LookUpPayloadArg": {
+                    "type": "object",
+                    "properties": {
+                        "id": {
+                            "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "name",
+                        "id"
+                    ]
+                },
+                "LookUpPayloadArgs": {
+                    "type": "object",
+                    "properties": {
+                        "args": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/LookUpPayloadArg"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "args"
+                    ]
+                },
+                "Payload": {
+                    "type": "object",
+                    "properties": {
+                        "class": {
+                            "type": "string"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "labels": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "machine": {
+                            "type": "string"
+                        },
+                        "status": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "type": "string"
+                        },
+                        "unit": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "class",
+                        "type",
+                        "id",
+                        "status",
+                        "labels",
+                        "unit",
+                        "machine"
+                    ]
+                },
+                "PayloadResult": {
+                    "type": "object",
+                    "properties": {
+                        "Entity": {
+                            "$ref": "#/definitions/Entity"
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "not-found": {
+                            "type": "boolean"
+                        },
+                        "payload": {
+                            "$ref": "#/definitions/Payload"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag",
+                        "Entity",
+                        "payload",
+                        "not-found"
+                    ]
+                },
+                "PayloadResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/PayloadResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "SetPayloadStatusArg": {
+                    "type": "object",
+                    "properties": {
+                        "Entity": {
+                            "$ref": "#/definitions/Entity"
+                        },
+                        "status": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag",
+                        "Entity",
+                        "status"
+                    ]
+                },
+                "SetPayloadStatusArgs": {
+                    "type": "object",
+                    "properties": {
+                        "args": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/SetPayloadStatusArg"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "args"
+                    ]
+                },
+                "TrackPayloadArgs": {
+                    "type": "object",
+                    "properties": {
+                        "payloads": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Payload"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "payloads"
+                    ]
+                }
+            }
+        }
+    },
+    {
+        "Name": "Pinger",
+        "Description": "",
+        "Version": 1,
+        "AvailableTo": [
+            "controller-machine-agent",
+            "machine-agent",
+            "unit-agent",
+            "controller-user",
+            "model-user"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "Ping": {
+                    "type": "object"
+                },
+                "Stop": {
+                    "type": "object"
+                }
+            }
+        }
+    },
+    {
+        "Name": "Provisioner",
+        "Description": "",
+        "Version": 11,
+        "AvailableTo": [
+            "controller-machine-agent",
+            "machine-agent"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "APIAddresses": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/StringsResult"
+                        }
+                    }
+                },
+                "APIHostPorts": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/APIHostPortsResult"
+                        }
+                    }
+                },
+                "AvailabilityZone": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/StringResults"
+                        }
+                    }
+                },
+                "CACert": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/BytesResult"
+                        }
+                    }
+                },
+                "Constraints": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ConstraintsResults"
+                        }
+                    }
+                },
+                "ContainerConfig": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/ContainerConfig"
+                        }
+                    }
+                },
+                "ContainerManagerConfig": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/ContainerManagerConfigParams"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ContainerManagerConfig"
+                        }
+                    }
+                },
+                "ControllerAPIInfoForModels": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ControllerAPIInfoResults"
+                        }
+                    }
+                },
+                "ControllerConfig": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/ControllerConfigResult"
+                        }
+                    }
+                },
+                "DistributionGroup": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/DistributionGroupResults"
+                        }
+                    }
+                },
+                "DistributionGroupByMachineId": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/StringsResults"
+                        }
+                    }
+                },
+                "EnsureDead": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "FindTools": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/FindToolsParams"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/FindToolsResult"
+                        }
+                    }
+                },
+                "GetContainerInterfaceInfo": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/MachineNetworkConfigResults"
+                        }
+                    }
+                },
+                "GetContainerProfileInfo": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ContainerProfileResults"
+                        }
+                    }
+                },
+                "HostChangesForContainers": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/HostNetworkChangeResults"
+                        }
+                    }
+                },
+                "InstanceId": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/StringResults"
+                        }
+                    }
+                },
+                "InstanceStatus": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/StatusResults"
+                        }
+                    }
+                },
+                "KeepInstance": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/BoolResults"
+                        }
+                    }
+                },
+                "Life": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/LifeResults"
+                        }
+                    }
+                },
+                "MachinesWithTransientErrors": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/StatusResults"
+                        }
+                    }
+                },
+                "MarkMachinesForRemoval": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "ModelConfig": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/ModelConfigResult"
+                        }
+                    }
+                },
+                "ModelUUID": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/StringResult"
+                        }
+                    }
+                },
+                "PrepareContainerInterfaceInfo": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/MachineNetworkConfigResults"
+                        }
+                    }
+                },
+                "ProvisioningInfo": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ProvisioningInfoResults"
+                        }
+                    }
+                },
+                "ReleaseContainerAddresses": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "Remove": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "SetCharmProfiles": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/SetProfileArgs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "SetHostMachineNetworkConfig": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/SetMachineNetworkConfig"
+                        }
+                    }
+                },
+                "SetInstanceInfo": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/InstancesInfo"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "SetInstanceStatus": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/SetStatus"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "SetModificationStatus": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/SetStatus"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "SetObservedNetworkConfig": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/SetMachineNetworkConfig"
+                        }
+                    }
+                },
+                "SetPasswords": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/EntityPasswords"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "SetStatus": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/SetStatus"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "SetSupportedContainers": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/MachineContainersParams"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "Status": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/StatusResults"
+                        }
+                    }
+                },
+                "SupportedContainers": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/MachineContainerResults"
+                        }
+                    }
+                },
+                "Tools": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ToolsResults"
+                        }
+                    }
+                },
+                "WatchAPIHostPorts": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/NotifyWatchResult"
+                        }
+                    }
+                },
+                "WatchAllContainers": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/WatchContainers"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/StringsWatchResults"
+                        }
+                    }
+                },
+                "WatchContainers": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/WatchContainers"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/StringsWatchResults"
+                        }
+                    }
+                },
+                "WatchForModelConfigChanges": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/NotifyWatchResult"
+                        }
+                    }
+                },
+                "WatchMachineErrorRetry": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/NotifyWatchResult"
+                        }
+                    }
+                },
+                "WatchModelMachineStartTimes": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/StringsWatchResult"
+                        }
+                    }
+                },
+                "WatchModelMachines": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/StringsWatchResult"
+                        }
+                    }
+                }
+            },
+            "definitions": {
+                "APIHostPortsResult": {
+                    "type": "object",
+                    "properties": {
+                        "servers": {
+                            "type": "array",
+                            "items": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/definitions/HostPort"
+                                }
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "servers"
+                    ]
+                },
+                "Address": {
+                    "type": "object",
+                    "properties": {
+                        "cidr": {
+                            "type": "string"
+                        },
+                        "config-type": {
+                            "type": "string"
+                        },
+                        "is-secondary": {
+                            "type": "boolean"
+                        },
+                        "scope": {
+                            "type": "string"
+                        },
+                        "space-id": {
+                            "type": "string"
+                        },
+                        "space-name": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "type": "string"
+                        },
+                        "value": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "value",
+                        "type",
+                        "scope"
+                    ]
+                },
+                "Base": {
+                    "type": "object",
+                    "properties": {
+                        "channel": {
+                            "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "name",
+                        "channel"
+                    ]
+                },
+                "Binary": {
+                    "type": "object",
+                    "properties": {
+                        "Arch": {
+                            "type": "string"
+                        },
+                        "Build": {
+                            "type": "integer"
+                        },
+                        "Major": {
+                            "type": "integer"
+                        },
+                        "Minor": {
+                            "type": "integer"
+                        },
+                        "Number": {
+                            "$ref": "#/definitions/Number"
+                        },
+                        "Patch": {
+                            "type": "integer"
+                        },
+                        "Release": {
+                            "type": "string"
+                        },
+                        "Tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "Major",
+                        "Minor",
+                        "Tag",
+                        "Patch",
+                        "Build",
+                        "Number",
+                        "Release",
+                        "Arch"
+                    ]
+                },
+                "BoolResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "result"
+                    ]
+                },
+                "BoolResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/BoolResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "BytesResult": {
+                    "type": "object",
+                    "properties": {
+                        "result": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "result"
+                    ]
+                },
+                "CharmLXDProfile": {
+                    "type": "object",
+                    "properties": {
+                        "config": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": {
+                            "type": "string"
+                        },
+                        "devices": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "patternProperties": {
+                                        ".*": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "config",
+                        "description",
+                        "devices"
+                    ]
+                },
+                "CloudImageMetadata": {
+                    "type": "object",
+                    "properties": {
+                        "arch": {
+                            "type": "string"
+                        },
+                        "image-id": {
+                            "type": "string"
+                        },
+                        "priority": {
+                            "type": "integer"
+                        },
+                        "region": {
+                            "type": "string"
+                        },
+                        "root-storage-size": {
+                            "type": "integer"
+                        },
+                        "root-storage-type": {
+                            "type": "string"
+                        },
+                        "source": {
+                            "type": "string"
+                        },
+                        "stream": {
+                            "type": "string"
+                        },
+                        "version": {
+                            "type": "string"
+                        },
+                        "virt-type": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "image-id",
+                        "region",
+                        "version",
+                        "arch",
+                        "source",
+                        "priority"
+                    ]
+                },
+                "ConstraintsResult": {
+                    "type": "object",
+                    "properties": {
+                        "constraints": {
+                            "$ref": "#/definitions/Value"
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "constraints"
+                    ]
+                },
+                "ConstraintsResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ConstraintsResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "ContainerConfig": {
+                    "type": "object",
+                    "properties": {
+                        "UpdateBehavior": {
+                            "$ref": "#/definitions/UpdateBehavior"
+                        },
+                        "apt-mirror": {
+                            "type": "string"
+                        },
+                        "apt-proxy": {
+                            "$ref": "#/definitions/Settings"
+                        },
+                        "authorized-keys": {
+                            "type": "string"
+                        },
+                        "cloudinit-userdata": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "container-inherit-properties": {
+                            "type": "string"
+                        },
+                        "juju-proxy": {
+                            "$ref": "#/definitions/Settings"
+                        },
+                        "legacy-proxy": {
+                            "$ref": "#/definitions/Settings"
+                        },
+                        "provider-type": {
+                            "type": "string"
+                        },
+                        "snap-proxy": {
+                            "$ref": "#/definitions/Settings"
+                        },
+                        "snap-store-assertions": {
+                            "type": "string"
+                        },
+                        "snap-store-proxy-id": {
+                            "type": "string"
+                        },
+                        "snap-store-proxy-url": {
+                            "type": "string"
+                        },
+                        "ssl-hostname-verification": {
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "provider-type",
+                        "authorized-keys",
+                        "ssl-hostname-verification",
+                        "legacy-proxy",
+                        "juju-proxy",
+                        "apt-proxy",
+                        "snap-proxy",
+                        "snap-store-assertions",
+                        "snap-store-proxy-id",
+                        "snap-store-proxy-url",
+                        "UpdateBehavior"
+                    ]
+                },
+                "ContainerLXDProfile": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "profile": {
+                            "$ref": "#/definitions/CharmLXDProfile"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "profile",
+                        "name"
+                    ]
+                },
+                "ContainerManagerConfig": {
+                    "type": "object",
+                    "properties": {
+                        "config": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "config"
+                    ]
+                },
+                "ContainerManagerConfigParams": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "type"
+                    ]
+                },
+                "ContainerProfileResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "lxd-profiles": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ContainerLXDProfile"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ContainerProfileResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ContainerProfileResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "ControllerAPIInfoResult": {
+                    "type": "object",
+                    "properties": {
+                        "addresses": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "cacert": {
+                            "type": "string"
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "addresses",
+                        "cacert"
+                    ]
+                },
+                "ControllerAPIInfoResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ControllerAPIInfoResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "ControllerConfigResult": {
+                    "type": "object",
+                    "properties": {
+                        "config": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "config"
+                    ]
+                },
+                "DeviceBridgeInfo": {
+                    "type": "object",
+                    "properties": {
+                        "bridge-name": {
+                            "type": "string"
+                        },
+                        "host-device-name": {
+                            "type": "string"
+                        },
+                        "mac-address": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "host-device-name",
+                        "bridge-name",
+                        "mac-address"
+                    ]
+                },
+                "DistributionGroupResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "result"
+                    ]
+                },
+                "DistributionGroupResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/DistributionGroupResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "Entities": {
+                    "type": "object",
+                    "properties": {
+                        "entities": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Entity"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "entities"
+                    ]
+                },
+                "Entity": {
+                    "type": "object",
+                    "properties": {
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag"
+                    ]
+                },
+                "EntityPassword": {
+                    "type": "object",
+                    "properties": {
+                        "password": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag",
+                        "password"
+                    ]
+                },
+                "EntityPasswords": {
+                    "type": "object",
+                    "properties": {
+                        "changes": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/EntityPassword"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "changes"
+                    ]
+                },
+                "EntityStatusArgs": {
+                    "type": "object",
+                    "properties": {
+                        "data": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "info": {
+                            "type": "string"
+                        },
+                        "status": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag",
+                        "status",
+                        "info",
+                        "data"
+                    ]
+                },
+                "Error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "message",
+                        "code"
+                    ]
+                },
+                "ErrorResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ErrorResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ErrorResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "FindToolsParams": {
+                    "type": "object",
+                    "properties": {
+                        "agentstream": {
+                            "type": "string"
+                        },
+                        "arch": {
+                            "type": "string"
+                        },
+                        "major": {
+                            "type": "integer"
+                        },
+                        "number": {
+                            "$ref": "#/definitions/Number"
+                        },
+                        "os-type": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "number",
+                        "major",
+                        "arch",
+                        "os-type",
+                        "agentstream"
+                    ]
+                },
+                "FindToolsResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "list": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Tools"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "list"
+                    ]
+                },
+                "HardwareCharacteristics": {
+                    "type": "object",
+                    "properties": {
+                        "arch": {
+                            "type": "string"
+                        },
+                        "availability-zone": {
+                            "type": "string"
+                        },
+                        "cpu-cores": {
+                            "type": "integer"
+                        },
+                        "cpu-power": {
+                            "type": "integer"
+                        },
+                        "mem": {
+                            "type": "integer"
+                        },
+                        "root-disk": {
+                            "type": "integer"
+                        },
+                        "root-disk-source": {
+                            "type": "string"
+                        },
+                        "tags": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "virt-type": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "HostNetworkChange": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "new-bridges": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/DeviceBridgeInfo"
+                            }
+                        },
+                        "reconfigure-delay": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "new-bridges",
+                        "reconfigure-delay"
+                    ]
+                },
+                "HostNetworkChangeResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/HostNetworkChange"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "HostPort": {
+                    "type": "object",
+                    "properties": {
+                        "Address": {
+                            "$ref": "#/definitions/Address"
+                        },
+                        "cidr": {
+                            "type": "string"
+                        },
+                        "config-type": {
+                            "type": "string"
+                        },
+                        "is-secondary": {
+                            "type": "boolean"
+                        },
+                        "port": {
+                            "type": "integer"
+                        },
+                        "scope": {
+                            "type": "string"
+                        },
+                        "space-id": {
+                            "type": "string"
+                        },
+                        "space-name": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "type": "string"
+                        },
+                        "value": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "value",
+                        "type",
+                        "scope",
+                        "Address",
+                        "port"
+                    ]
+                },
+                "InstanceInfo": {
+                    "type": "object",
+                    "properties": {
+                        "characteristics": {
+                            "$ref": "#/definitions/HardwareCharacteristics"
+                        },
+                        "charm-profiles": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "display-name": {
+                            "type": "string"
+                        },
+                        "instance-id": {
+                            "type": "string"
+                        },
+                        "network-config": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/NetworkConfig"
+                            }
+                        },
+                        "nonce": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        },
+                        "volume-attachments": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "$ref": "#/definitions/VolumeAttachmentInfo"
+                                }
+                            }
+                        },
+                        "volumes": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Volume"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag",
+                        "instance-id",
+                        "display-name",
+                        "nonce",
+                        "characteristics",
+                        "volumes",
+                        "volume-attachments",
+                        "network-config",
+                        "charm-profiles"
+                    ]
+                },
+                "InstancesInfo": {
+                    "type": "object",
+                    "properties": {
+                        "machines": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/InstanceInfo"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "machines"
+                    ]
+                },
+                "LifeResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "life": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "life"
+                    ]
+                },
+                "LifeResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/LifeResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "MachineContainerResult": {
+                    "type": "object",
+                    "properties": {
+                        "container-types": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "determined": {
+                            "type": "boolean"
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "container-types",
+                        "determined"
+                    ]
+                },
+                "MachineContainerResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/MachineContainerResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "MachineContainers": {
+                    "type": "object",
+                    "properties": {
+                        "container-types": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "machine-tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "machine-tag",
+                        "container-types"
+                    ]
+                },
+                "MachineContainersParams": {
+                    "type": "object",
+                    "properties": {
+                        "params": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/MachineContainers"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "params"
+                    ]
+                },
+                "MachineNetworkConfigResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "info": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/NetworkConfig"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "info"
+                    ]
+                },
+                "MachineNetworkConfigResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/MachineNetworkConfigResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "ModelConfigResult": {
+                    "type": "object",
+                    "properties": {
+                        "config": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "config"
+                    ]
+                },
+                "NetworkConfig": {
+                    "type": "object",
+                    "properties": {
+                        "address": {
+                            "type": "string"
+                        },
+                        "addresses": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Address"
+                            }
+                        },
+                        "cidr": {
+                            "type": "string"
+                        },
+                        "config-type": {
+                            "type": "string"
+                        },
+                        "device-index": {
+                            "type": "integer"
+                        },
+                        "disabled": {
+                            "type": "boolean"
+                        },
+                        "dns-search-domains": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "dns-servers": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "gateway-address": {
+                            "type": "string"
+                        },
+                        "interface-name": {
+                            "type": "string"
+                        },
+                        "interface-type": {
+                            "type": "string"
+                        },
+                        "is-default-gateway": {
+                            "type": "boolean"
+                        },
+                        "mac-address": {
+                            "type": "string"
+                        },
+                        "mtu": {
+                            "type": "integer"
+                        },
+                        "no-auto-start": {
+                            "type": "boolean"
+                        },
+                        "origin": {
+                            "type": "string"
+                        },
+                        "parent-interface-name": {
+                            "type": "string"
+                        },
+                        "provider-address-id": {
+                            "type": "string"
+                        },
+                        "provider-id": {
+                            "type": "string"
+                        },
+                        "provider-network-id": {
+                            "type": "string"
+                        },
+                        "provider-space-id": {
+                            "type": "string"
+                        },
+                        "provider-subnet-id": {
+                            "type": "string"
+                        },
+                        "provider-vlan-id": {
+                            "type": "string"
+                        },
+                        "routes": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/NetworkRoute"
+                            }
+                        },
+                        "shadow-addresses": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Address"
+                            }
+                        },
+                        "virtual-port-type": {
+                            "type": "string"
+                        },
+                        "vlan-tag": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "device-index",
+                        "mac-address",
+                        "cidr",
+                        "mtu",
+                        "provider-id",
+                        "provider-network-id",
+                        "provider-subnet-id",
+                        "provider-space-id",
+                        "provider-address-id",
+                        "provider-vlan-id",
+                        "vlan-tag",
+                        "interface-name",
+                        "parent-interface-name",
+                        "interface-type",
+                        "disabled"
+                    ]
+                },
+                "NetworkRoute": {
+                    "type": "object",
+                    "properties": {
+                        "destination-cidr": {
+                            "type": "string"
+                        },
+                        "gateway-ip": {
+                            "type": "string"
+                        },
+                        "metric": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "destination-cidr",
+                        "gateway-ip",
+                        "metric"
+                    ]
+                },
+                "NotifyWatchResult": {
+                    "type": "object",
+                    "properties": {
+                        "NotifyWatcherId": {
+                            "type": "string"
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "NotifyWatcherId"
+                    ]
+                },
+                "Number": {
+                    "type": "object",
+                    "properties": {
+                        "Build": {
+                            "type": "integer"
+                        },
+                        "Major": {
+                            "type": "integer"
+                        },
+                        "Minor": {
+                            "type": "integer"
+                        },
+                        "Patch": {
+                            "type": "integer"
+                        },
+                        "Tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "Major",
+                        "Minor",
+                        "Tag",
+                        "Patch",
+                        "Build"
+                    ]
+                },
+                "ProvisioningInfo": {
+                    "type": "object",
+                    "properties": {
+                        "ProvisioningNetworkTopology": {
+                            "$ref": "#/definitions/ProvisioningNetworkTopology"
+                        },
+                        "base": {
+                            "$ref": "#/definitions/Base"
+                        },
+                        "charm-lxd-profiles": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "cloudinit-userdata": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "constraints": {
+                            "$ref": "#/definitions/Value"
+                        },
+                        "controller-config": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "endpoint-bindings": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "image-metadata": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/CloudImageMetadata"
+                            }
+                        },
+                        "jobs": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "placement": {
+                            "type": "string"
+                        },
+                        "root-disk": {
+                            "$ref": "#/definitions/VolumeParams"
+                        },
+                        "space-subnets": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "subnet-zones": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "tags": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "volume-attachments": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/VolumeAttachmentParams"
+                            }
+                        },
+                        "volumes": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/VolumeParams"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "constraints",
+                        "base",
+                        "placement",
+                        "jobs",
+                        "subnet-zones",
+                        "space-subnets",
+                        "ProvisioningNetworkTopology"
+                    ]
+                },
+                "ProvisioningInfoResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "$ref": "#/definitions/ProvisioningInfo"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "result"
+                    ]
+                },
+                "ProvisioningInfoResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ProvisioningInfoResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "ProvisioningNetworkTopology": {
+                    "type": "object",
+                    "properties": {
+                        "space-subnets": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "subnet-zones": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "subnet-zones",
+                        "space-subnets"
+                    ]
+                },
+                "SetMachineNetworkConfig": {
+                    "type": "object",
+                    "properties": {
+                        "config": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/NetworkConfig"
+                            }
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag",
+                        "config"
+                    ]
+                },
+                "SetProfileArg": {
+                    "type": "object",
+                    "properties": {
+                        "entity": {
+                            "$ref": "#/definitions/Entity"
+                        },
+                        "profiles": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "entity",
+                        "profiles"
+                    ]
+                },
+                "SetProfileArgs": {
+                    "type": "object",
+                    "properties": {
+                        "args": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/SetProfileArg"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "args"
+                    ]
+                },
+                "SetStatus": {
+                    "type": "object",
+                    "properties": {
+                        "entities": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/EntityStatusArgs"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "entities"
+                    ]
+                },
+                "Settings": {
+                    "type": "object",
+                    "properties": {
+                        "AutoNoProxy": {
+                            "type": "string"
+                        },
+                        "Ftp": {
+                            "type": "string"
+                        },
+                        "Http": {
+                            "type": "string"
+                        },
+                        "Https": {
+                            "type": "string"
+                        },
+                        "NoProxy": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "Http",
+                        "Https",
+                        "Ftp",
+                        "NoProxy",
+                        "AutoNoProxy"
+                    ]
+                },
+                "StatusResult": {
+                    "type": "object",
+                    "properties": {
+                        "data": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "string"
+                        },
+                        "life": {
+                            "type": "string"
+                        },
+                        "since": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "status": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "id",
+                        "life",
+                        "status",
+                        "info",
+                        "data",
+                        "since"
+                    ]
+                },
+                "StatusResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/StatusResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "StringResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "result"
+                    ]
+                },
+                "StringResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/StringResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "StringsResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "StringsResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/StringsResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "StringsWatchResult": {
+                    "type": "object",
+                    "properties": {
+                        "changes": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "watcher-id": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "watcher-id"
+                    ]
+                },
+                "StringsWatchResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/StringsWatchResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "Tools": {
+                    "type": "object",
+                    "properties": {
+                        "sha256": {
+                            "type": "string"
+                        },
+                        "size": {
+                            "type": "integer"
+                        },
+                        "url": {
+                            "type": "string"
+                        },
+                        "version": {
+                            "$ref": "#/definitions/Binary"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "version",
+                        "url",
+                        "size"
+                    ]
+                },
+                "ToolsResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "tools": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Tools"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tools"
+                    ]
+                },
+                "ToolsResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ToolsResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "UpdateBehavior": {
+                    "type": "object",
+                    "properties": {
+                        "enable-os-refresh-update": {
+                            "type": "boolean"
+                        },
+                        "enable-os-upgrade": {
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "enable-os-refresh-update",
+                        "enable-os-upgrade"
+                    ]
+                },
+                "Value": {
+                    "type": "object",
+                    "properties": {
+                        "allocate-public-ip": {
+                            "type": "boolean"
+                        },
+                        "arch": {
+                            "type": "string"
+                        },
+                        "container": {
+                            "type": "string"
+                        },
+                        "cores": {
+                            "type": "integer"
+                        },
+                        "cpu-power": {
+                            "type": "integer"
+                        },
+                        "image-id": {
+                            "type": "string"
+                        },
+                        "instance-role": {
+                            "type": "string"
+                        },
+                        "instance-type": {
+                            "type": "string"
+                        },
+                        "mem": {
+                            "type": "integer"
+                        },
+                        "root-disk": {
+                            "type": "integer"
+                        },
+                        "root-disk-source": {
+                            "type": "string"
+                        },
+                        "spaces": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "tags": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "virt-type": {
+                            "type": "string"
+                        },
+                        "zones": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "Volume": {
+                    "type": "object",
+                    "properties": {
+                        "info": {
+                            "$ref": "#/definitions/VolumeInfo"
+                        },
+                        "volume-tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "volume-tag",
+                        "info"
+                    ]
+                },
+                "VolumeAttachmentInfo": {
+                    "type": "object",
+                    "properties": {
+                        "bus-address": {
+                            "type": "string"
+                        },
+                        "device-link": {
+                            "type": "string"
+                        },
+                        "device-name": {
+                            "type": "string"
+                        },
+                        "plan-info": {
+                            "$ref": "#/definitions/VolumeAttachmentPlanInfo"
+                        },
+                        "read-only": {
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "VolumeAttachmentParams": {
+                    "type": "object",
+                    "properties": {
+                        "instance-id": {
+                            "type": "string"
+                        },
+                        "machine-tag": {
+                            "type": "string"
+                        },
+                        "provider": {
+                            "type": "string"
+                        },
+                        "read-only": {
+                            "type": "boolean"
+                        },
+                        "volume-id": {
+                            "type": "string"
+                        },
+                        "volume-tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "volume-tag",
+                        "machine-tag",
+                        "provider"
+                    ]
+                },
+                "VolumeAttachmentPlanInfo": {
+                    "type": "object",
+                    "properties": {
+                        "device-attributes": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "device-type": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "VolumeInfo": {
+                    "type": "object",
+                    "properties": {
+                        "hardware-id": {
+                            "type": "string"
+                        },
+                        "persistent": {
+                            "type": "boolean"
+                        },
+                        "pool": {
+                            "type": "string"
+                        },
+                        "size": {
+                            "type": "integer"
+                        },
+                        "volume-id": {
+                            "type": "string"
+                        },
+                        "wwn": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "volume-id",
+                        "size",
+                        "persistent"
+                    ]
+                },
+                "VolumeParams": {
+                    "type": "object",
+                    "properties": {
+                        "attachment": {
+                            "$ref": "#/definitions/VolumeAttachmentParams"
+                        },
+                        "attributes": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "provider": {
+                            "type": "string"
+                        },
+                        "size": {
+                            "type": "integer"
+                        },
+                        "tags": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "volume-tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "volume-tag",
+                        "size",
+                        "provider"
+                    ]
+                },
+                "WatchContainer": {
+                    "type": "object",
+                    "properties": {
+                        "container-type": {
+                            "type": "string"
+                        },
+                        "machine-tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "machine-tag",
+                        "container-type"
+                    ]
+                },
+                "WatchContainers": {
+                    "type": "object",
+                    "properties": {
+                        "params": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/WatchContainer"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "params"
+                    ]
+                }
+            }
+        }
+    },
+    {
+        "Name": "ProxyUpdater",
+        "Description": "",
+        "Version": 2,
+        "AvailableTo": [
+            "controller-machine-agent",
+            "machine-agent",
+            "unit-agent",
+            "model-user"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "ProxyConfig": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ProxyConfigResults"
+                        }
+                    }
+                },
+                "WatchForProxyConfigAndAPIHostPortChanges": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/NotifyWatchResults"
+                        }
+                    }
+                }
+            },
+            "definitions": {
+                "Entities": {
+                    "type": "object",
+                    "properties": {
+                        "entities": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Entity"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "entities"
+                    ]
+                },
+                "Entity": {
+                    "type": "object",
+                    "properties": {
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag"
+                    ]
+                },
+                "Error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "message",
+                        "code"
+                    ]
+                },
+                "NotifyWatchResult": {
+                    "type": "object",
+                    "properties": {
+                        "NotifyWatcherId": {
+                            "type": "string"
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "NotifyWatcherId"
+                    ]
+                },
+                "NotifyWatchResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/NotifyWatchResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "ProxyConfig": {
+                    "type": "object",
+                    "properties": {
+                        "ftp": {
+                            "type": "string"
+                        },
+                        "http": {
+                            "type": "string"
+                        },
+                        "https": {
+                            "type": "string"
+                        },
+                        "no-proxy": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "http",
+                        "https",
+                        "ftp",
+                        "no-proxy"
+                    ]
+                },
+                "ProxyConfigResult": {
+                    "type": "object",
+                    "properties": {
+                        "apt-mirror": {
+                            "type": "string"
+                        },
+                        "apt-proxy-settings": {
+                            "$ref": "#/definitions/ProxyConfig"
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "juju-proxy-settings": {
+                            "$ref": "#/definitions/ProxyConfig"
+                        },
+                        "legacy-proxy-settings": {
+                            "$ref": "#/definitions/ProxyConfig"
+                        },
+                        "snap-proxy-settings": {
+                            "$ref": "#/definitions/ProxyConfig"
+                        },
+                        "snap-store-assertions": {
+                            "type": "string"
+                        },
+                        "snap-store-id": {
+                            "type": "string"
+                        },
+                        "snap-store-proxy-url": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "legacy-proxy-settings",
+                        "juju-proxy-settings"
+                    ]
+                },
+                "ProxyConfigResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ProxyConfigResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                }
+            }
+        }
+    },
+    {
+        "Name": "Reboot",
+        "Description": "",
+        "Version": 2,
+        "AvailableTo": [
+            "controller-machine-agent",
+            "machine-agent"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "ClearReboot": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "GetRebootAction": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/RebootActionResults"
+                        }
+                    }
+                },
+                "RequestReboot": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "WatchForRebootEvent": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/NotifyWatchResult"
+                        }
+                    }
+                }
+            },
+            "definitions": {
+                "Entities": {
+                    "type": "object",
+                    "properties": {
+                        "entities": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Entity"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "entities"
+                    ]
+                },
+                "Entity": {
+                    "type": "object",
+                    "properties": {
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag"
+                    ]
+                },
+                "Error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "message",
+                        "code"
+                    ]
+                },
+                "ErrorResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ErrorResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ErrorResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "NotifyWatchResult": {
+                    "type": "object",
+                    "properties": {
+                        "NotifyWatcherId": {
+                            "type": "string"
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "NotifyWatcherId"
+                    ]
+                },
+                "RebootActionResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "RebootActionResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/RebootActionResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            }
+        }
+    },
+    {
+        "Name": "ResourcesHookContext",
+        "Description": "",
+        "Version": 1,
+        "AvailableTo": [
+            "controller-machine-agent",
+            "machine-agent",
+            "unit-agent",
+            "model-user"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "GetResourceInfo": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/ListUnitResourcesArgs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/UnitResourcesResult"
+                        }
+                    }
+                }
+            },
+            "definitions": {
+                "CharmResource": {
+                    "type": "object",
+                    "properties": {
+                        "description": {
+                            "type": "string"
+                        },
+                        "fingerprint": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            }
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "origin": {
+                            "type": "string"
+                        },
+                        "path": {
+                            "type": "string"
+                        },
+                        "revision": {
+                            "type": "integer"
+                        },
+                        "size": {
+                            "type": "integer"
+                        },
+                        "type": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "name",
+                        "type",
+                        "path",
+                        "origin",
+                        "revision",
+                        "fingerprint",
+                        "size"
+                    ]
+                },
+                "Error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "message",
+                        "code"
+                    ]
+                },
+                "ErrorResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ListUnitResourcesArgs": {
+                    "type": "object",
+                    "properties": {
+                        "resource-names": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "resource-names"
+                    ]
+                },
+                "Resource": {
+                    "type": "object",
+                    "properties": {
+                        "CharmResource": {
+                            "$ref": "#/definitions/CharmResource"
+                        },
+                        "application": {
+                            "type": "string"
+                        },
+                        "description": {
+                            "type": "string"
+                        },
+                        "fingerprint": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            }
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "origin": {
+                            "type": "string"
+                        },
+                        "path": {
+                            "type": "string"
+                        },
+                        "pending-id": {
+                            "type": "string"
+                        },
+                        "revision": {
+                            "type": "integer"
+                        },
+                        "size": {
+                            "type": "integer"
+                        },
+                        "timestamp": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "type": {
+                            "type": "string"
+                        },
+                        "username": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "name",
+                        "type",
+                        "path",
+                        "origin",
+                        "revision",
+                        "fingerprint",
+                        "size",
+                        "CharmResource",
+                        "id",
+                        "pending-id",
+                        "application",
+                        "username",
+                        "timestamp"
+                    ]
+                },
+                "UnitResourceResult": {
+                    "type": "object",
+                    "properties": {
+                        "ErrorResult": {
+                            "$ref": "#/definitions/ErrorResult"
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "resource": {
+                            "$ref": "#/definitions/Resource"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "ErrorResult",
+                        "resource"
+                    ]
+                },
+                "UnitResourcesResult": {
+                    "type": "object",
+                    "properties": {
+                        "ErrorResult": {
+                            "$ref": "#/definitions/ErrorResult"
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "resources": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/UnitResourceResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "ErrorResult",
+                        "resources"
+                    ]
+                }
+            }
+        }
+    },
+    {
+        "Name": "RetryStrategy",
+        "Description": "",
+        "Version": 1,
+        "AvailableTo": [
+            "controller-machine-agent",
+            "machine-agent",
+            "unit-agent",
+            "model-user"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "RetryStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/RetryStrategyResults"
+                        }
+                    }
+                },
+                "WatchRetryStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/NotifyWatchResults"
+                        }
+                    }
+                }
+            },
+            "definitions": {
+                "Entities": {
+                    "type": "object",
+                    "properties": {
+                        "entities": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Entity"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "entities"
+                    ]
+                },
+                "Entity": {
+                    "type": "object",
+                    "properties": {
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag"
+                    ]
+                },
+                "Error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "message",
+                        "code"
+                    ]
+                },
+                "NotifyWatchResult": {
+                    "type": "object",
+                    "properties": {
+                        "NotifyWatcherId": {
+                            "type": "string"
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "NotifyWatcherId"
+                    ]
+                },
+                "NotifyWatchResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/NotifyWatchResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "RetryStrategy": {
+                    "type": "object",
+                    "properties": {
+                        "jitter-retry-time": {
+                            "type": "boolean"
+                        },
+                        "max-retry-time": {
+                            "type": "integer"
+                        },
+                        "min-retry-time": {
+                            "type": "integer"
+                        },
+                        "retry-time-factor": {
+                            "type": "integer"
+                        },
+                        "should-retry": {
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "should-retry",
+                        "min-retry-time",
+                        "max-retry-time",
+                        "jitter-retry-time",
+                        "retry-time-factor"
+                    ]
+                },
+                "RetryStrategyResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "$ref": "#/definitions/RetryStrategy"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "RetryStrategyResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/RetryStrategyResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                }
+            }
+        }
+    },
+    {
+        "Name": "SecretsManager",
+        "Description": "",
+        "Version": 2,
+        "AvailableTo": [
+            "unit-agent"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "CreateSecretURIs": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/CreateSecretURIsArg"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/StringResults"
+                        }
+                    }
+                },
+                "GetConsumerSecretsRevisionInfo": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/GetSecretConsumerInfoArgs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/SecretConsumerInfoResults"
+                        }
+                    }
+                },
+                "GetSecretBackendConfigs": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/SecretBackendArgs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/SecretBackendConfigResults"
+                        }
+                    }
+                },
+                "GetSecretContentInfo": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/GetSecretContentArgs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/SecretContentResults"
+                        }
+                    }
+                },
+                "GetSecretMetadata": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/ListSecretResults"
+                        }
+                    }
+                },
+                "GetSecretRevisionContentInfo": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/SecretRevisionArg"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/SecretContentResults"
+                        }
+                    }
+                },
+                "SecretsRotated": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/SecretRotatedArgs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "WatchConsumedSecretsChanges": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/StringsWatchResults"
+                        }
+                    }
+                },
+                "WatchObsolete": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/StringsWatchResult"
+                        }
+                    }
+                },
+                "WatchSecretRevisionsExpiryChanges": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/SecretTriggerWatchResult"
+                        }
+                    }
+                },
+                "WatchSecretsRotationChanges": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/SecretTriggerWatchResult"
+                        }
+                    }
+                }
+            },
+            "definitions": {
+                "AccessInfo": {
+                    "type": "object",
+                    "properties": {
+                        "role": {
+                            "type": "string"
+                        },
+                        "scope-tag": {
+                            "type": "string"
+                        },
+                        "target-tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "target-tag",
+                        "scope-tag",
+                        "role"
+                    ]
+                },
+                "CreateSecretURIsArg": {
+                    "type": "object",
+                    "properties": {
+                        "count": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "count"
+                    ]
+                },
+                "Entities": {
+                    "type": "object",
+                    "properties": {
+                        "entities": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Entity"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "entities"
+                    ]
+                },
+                "Entity": {
+                    "type": "object",
+                    "properties": {
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag"
+                    ]
+                },
+                "Error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "message",
+                        "code"
+                    ]
+                },
+                "ErrorResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ErrorResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ErrorResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "GetSecretConsumerInfoArgs": {
+                    "type": "object",
+                    "properties": {
+                        "consumer-tag": {
+                            "type": "string"
+                        },
+                        "uris": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "consumer-tag",
+                        "uris"
+                    ]
+                },
+                "GetSecretContentArg": {
+                    "type": "object",
+                    "properties": {
+                        "label": {
+                            "type": "string"
+                        },
+                        "peek": {
+                            "type": "boolean"
+                        },
+                        "refresh": {
+                            "type": "boolean"
+                        },
+                        "uri": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "uri"
+                    ]
+                },
+                "GetSecretContentArgs": {
+                    "type": "object",
+                    "properties": {
+                        "args": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/GetSecretContentArg"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "args"
+                    ]
+                },
+                "ListSecretResult": {
+                    "type": "object",
+                    "properties": {
+                        "access": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/AccessInfo"
+                            }
+                        },
+                        "create-time": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "description": {
+                            "type": "string"
+                        },
+                        "label": {
+                            "type": "string"
+                        },
+                        "latest-expire-time": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "latest-revision": {
+                            "type": "integer"
+                        },
+                        "latest-revision-checksum": {
+                            "type": "string"
+                        },
+                        "next-rotate-time": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "owner-tag": {
+                            "type": "string"
+                        },
+                        "revisions": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/SecretRevision"
+                            }
+                        },
+                        "rotate-policy": {
+                            "type": "string"
+                        },
+                        "update-time": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "uri": {
+                            "type": "string"
+                        },
+                        "value": {
+                            "$ref": "#/definitions/SecretValueResult"
+                        },
+                        "version": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "uri",
+                        "version",
+                        "owner-tag",
+                        "latest-revision",
+                        "latest-revision-checksum",
+                        "create-time",
+                        "update-time",
+                        "revisions"
+                    ]
+                },
+                "ListSecretResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ListSecretResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "SecretBackendArgs": {
+                    "type": "object",
+                    "properties": {
+                        "backend-ids": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "for-drain": {
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "for-drain",
+                        "backend-ids"
+                    ]
+                },
+                "SecretBackendConfig": {
+                    "type": "object",
+                    "properties": {
+                        "params": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "type": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "type"
+                    ]
+                },
+                "SecretBackendConfigResult": {
+                    "type": "object",
+                    "properties": {
+                        "config": {
+                            "$ref": "#/definitions/SecretBackendConfig"
+                        },
+                        "draining": {
+                            "type": "boolean"
+                        },
+                        "model-controller": {
+                            "type": "string"
+                        },
+                        "model-name": {
+                            "type": "string"
+                        },
+                        "model-uuid": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "model-controller",
+                        "model-uuid",
+                        "model-name",
+                        "draining"
+                    ]
+                },
+                "SecretBackendConfigResults": {
+                    "type": "object",
+                    "properties": {
+                        "active-id": {
+                            "type": "string"
+                        },
+                        "results": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "$ref": "#/definitions/SecretBackendConfigResult"
+                                }
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "active-id"
+                    ]
+                },
+                "SecretConsumerInfoResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "label": {
+                            "type": "string"
+                        },
+                        "revision": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "revision",
+                        "label"
+                    ]
+                },
+                "SecretConsumerInfoResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/SecretConsumerInfoResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "SecretContentParams": {
+                    "type": "object",
+                    "properties": {
+                        "checksum": {
+                            "type": "string"
+                        },
+                        "data": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "value-ref": {
+                            "$ref": "#/definitions/SecretValueRef"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "SecretContentResult": {
+                    "type": "object",
+                    "properties": {
+                        "backend-config": {
+                            "$ref": "#/definitions/SecretBackendConfigResult"
+                        },
+                        "content": {
+                            "$ref": "#/definitions/SecretContentParams"
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "latest-revision": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "content"
+                    ]
+                },
+                "SecretContentResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/SecretContentResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "SecretRevision": {
+                    "type": "object",
+                    "properties": {
+                        "backend-name": {
+                            "type": "string"
+                        },
+                        "create-time": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "expire-time": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "revision": {
+                            "type": "integer"
+                        },
+                        "update-time": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "value-ref": {
+                            "$ref": "#/definitions/SecretValueRef"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "revision"
+                    ]
+                },
+                "SecretRevisionArg": {
+                    "type": "object",
+                    "properties": {
+                        "pending-delete": {
+                            "type": "boolean"
+                        },
+                        "revisions": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            }
+                        },
+                        "uri": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "uri",
+                        "revisions",
+                        "pending-delete"
+                    ]
+                },
+                "SecretRotatedArg": {
+                    "type": "object",
+                    "properties": {
+                        "original-revision": {
+                            "type": "integer"
+                        },
+                        "skip": {
+                            "type": "boolean"
+                        },
+                        "uri": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "uri",
+                        "original-revision",
+                        "skip"
+                    ]
+                },
+                "SecretRotatedArgs": {
+                    "type": "object",
+                    "properties": {
+                        "args": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/SecretRotatedArg"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "args"
+                    ]
+                },
+                "SecretTriggerChange": {
+                    "type": "object",
+                    "properties": {
+                        "next-trigger-time": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "revision": {
+                            "type": "integer"
+                        },
+                        "uri": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "uri",
+                        "next-trigger-time"
+                    ]
+                },
+                "SecretTriggerWatchResult": {
+                    "type": "object",
+                    "properties": {
+                        "changes": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/SecretTriggerChange"
+                            }
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "watcher-id": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "watcher-id",
+                        "changes"
+                    ]
+                },
+                "SecretValueRef": {
+                    "type": "object",
+                    "properties": {
+                        "backend-id": {
+                            "type": "string"
+                        },
+                        "revision-id": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "backend-id",
+                        "revision-id"
+                    ]
+                },
+                "SecretValueResult": {
+                    "type": "object",
+                    "properties": {
+                        "data": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "StringResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "result"
+                    ]
+                },
+                "StringResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/StringResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "StringsWatchResult": {
+                    "type": "object",
+                    "properties": {
+                        "changes": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "watcher-id": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "watcher-id"
+                    ]
+                },
+                "StringsWatchResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/StringsWatchResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                }
+            }
+        }
+    },
+    {
+        "Name": "StorageProvisioner",
+        "Description": "",
+        "Version": 4,
+        "AvailableTo": [
+            "controller-machine-agent",
+            "machine-agent",
+            "unit-agent",
+            "model-user"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "AttachmentLife": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/MachineStorageIds"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/LifeResults"
+                        }
+                    }
+                },
+                "CreateVolumeAttachmentPlans": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/VolumeAttachmentPlans"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "EnsureDead": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "FilesystemAttachmentParams": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/MachineStorageIds"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/FilesystemAttachmentParamsResults"
+                        }
+                    }
+                },
+                "FilesystemAttachments": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/MachineStorageIds"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/FilesystemAttachmentResults"
+                        }
+                    }
+                },
+                "FilesystemParams": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/FilesystemParamsResults"
+                        }
+                    }
+                },
+                "Filesystems": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/FilesystemResults"
+                        }
+                    }
+                },
+                "InstanceId": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/StringResults"
+                        }
+                    }
+                },
+                "Life": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/LifeResults"
+                        }
+                    }
+                },
+                "Remove": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "RemoveAttachment": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/MachineStorageIds"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "RemoveFilesystemParams": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/RemoveFilesystemParamsResults"
+                        }
+                    }
+                },
+                "RemoveVolumeAttachmentPlan": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/MachineStorageIds"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "RemoveVolumeParams": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/RemoveVolumeParamsResults"
+                        }
+                    }
+                },
+                "SetFilesystemAttachmentInfo": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/FilesystemAttachments"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "SetFilesystemInfo": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Filesystems"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "SetStatus": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/SetStatus"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "SetVolumeAttachmentInfo": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/VolumeAttachments"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "SetVolumeAttachmentPlanBlockInfo": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/VolumeAttachmentPlans"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "SetVolumeInfo": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Volumes"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "VolumeAttachmentParams": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/MachineStorageIds"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/VolumeAttachmentParamsResults"
+                        }
+                    }
+                },
+                "VolumeAttachmentPlans": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/MachineStorageIds"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/VolumeAttachmentPlanResults"
+                        }
+                    }
+                },
+                "VolumeAttachments": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/MachineStorageIds"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/VolumeAttachmentResults"
+                        }
+                    }
+                },
+                "VolumeBlockDevices": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/MachineStorageIds"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/BlockDeviceResults"
+                        }
+                    }
+                },
+                "VolumeParams": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/VolumeParamsResults"
+                        }
+                    }
+                },
+                "Volumes": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/VolumeResults"
+                        }
+                    }
+                },
+                "WatchApplications": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/StringsWatchResult"
+                        }
+                    }
+                },
+                "WatchBlockDevices": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/NotifyWatchResults"
+                        }
+                    }
+                },
+                "WatchFilesystemAttachments": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/MachineStorageIdsWatchResults"
+                        }
+                    }
+                },
+                "WatchFilesystems": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/StringsWatchResults"
+                        }
+                    }
+                },
+                "WatchMachines": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/NotifyWatchResults"
+                        }
+                    }
+                },
+                "WatchVolumeAttachmentPlans": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/MachineStorageIdsWatchResults"
+                        }
+                    }
+                },
+                "WatchVolumeAttachments": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/MachineStorageIdsWatchResults"
+                        }
+                    }
+                },
+                "WatchVolumes": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/StringsWatchResults"
+                        }
+                    }
+                }
+            },
+            "definitions": {
+                "BlockDevice": {
+                    "type": "object",
+                    "properties": {
+                        "BusAddress": {
+                            "type": "string"
+                        },
+                        "DeviceLinks": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "DeviceName": {
+                            "type": "string"
+                        },
+                        "FilesystemType": {
+                            "type": "string"
+                        },
+                        "HardwareId": {
+                            "type": "string"
+                        },
+                        "InUse": {
+                            "type": "boolean"
+                        },
+                        "Label": {
+                            "type": "string"
+                        },
+                        "MountPoint": {
+                            "type": "string"
+                        },
+                        "SerialId": {
+                            "type": "string"
+                        },
+                        "Size": {
+                            "type": "integer"
+                        },
+                        "UUID": {
+                            "type": "string"
+                        },
+                        "WWN": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "DeviceName",
+                        "DeviceLinks",
+                        "Label",
+                        "UUID",
+                        "HardwareId",
+                        "WWN",
+                        "BusAddress",
+                        "Size",
+                        "FilesystemType",
+                        "InUse",
+                        "MountPoint",
+                        "SerialId"
+                    ]
+                },
+                "BlockDeviceResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "$ref": "#/definitions/BlockDevice"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "result"
+                    ]
+                },
+                "BlockDeviceResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/BlockDeviceResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "Entities": {
+                    "type": "object",
+                    "properties": {
+                        "entities": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Entity"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "entities"
+                    ]
+                },
+                "Entity": {
+                    "type": "object",
+                    "properties": {
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag"
+                    ]
+                },
+                "EntityStatusArgs": {
+                    "type": "object",
+                    "properties": {
+                        "data": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "info": {
+                            "type": "string"
+                        },
+                        "status": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag",
+                        "status",
+                        "info",
+                        "data"
+                    ]
+                },
+                "Error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "message",
+                        "code"
+                    ]
+                },
+                "ErrorResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ErrorResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ErrorResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "Filesystem": {
+                    "type": "object",
+                    "properties": {
+                        "filesystem-tag": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "$ref": "#/definitions/FilesystemInfo"
+                        },
+                        "volume-tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "filesystem-tag",
+                        "info"
+                    ]
+                },
+                "FilesystemAttachment": {
+                    "type": "object",
+                    "properties": {
+                        "filesystem-tag": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "$ref": "#/definitions/FilesystemAttachmentInfo"
+                        },
+                        "machine-tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "filesystem-tag",
+                        "machine-tag",
+                        "info"
+                    ]
+                },
+                "FilesystemAttachmentInfo": {
+                    "type": "object",
+                    "properties": {
+                        "mount-point": {
+                            "type": "string"
+                        },
+                        "read-only": {
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "FilesystemAttachmentParams": {
+                    "type": "object",
+                    "properties": {
+                        "filesystem-id": {
+                            "type": "string"
+                        },
+                        "filesystem-tag": {
+                            "type": "string"
+                        },
+                        "instance-id": {
+                            "type": "string"
+                        },
+                        "machine-tag": {
+                            "type": "string"
+                        },
+                        "mount-point": {
+                            "type": "string"
+                        },
+                        "provider": {
+                            "type": "string"
+                        },
+                        "read-only": {
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "filesystem-tag",
+                        "machine-tag",
+                        "provider"
+                    ]
+                },
+                "FilesystemAttachmentParamsResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "$ref": "#/definitions/FilesystemAttachmentParams"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "result"
+                    ]
+                },
+                "FilesystemAttachmentParamsResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/FilesystemAttachmentParamsResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "FilesystemAttachmentResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "$ref": "#/definitions/FilesystemAttachment"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "result"
+                    ]
+                },
+                "FilesystemAttachmentResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/FilesystemAttachmentResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "FilesystemAttachments": {
+                    "type": "object",
+                    "properties": {
+                        "filesystem-attachments": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/FilesystemAttachment"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "filesystem-attachments"
+                    ]
+                },
+                "FilesystemInfo": {
+                    "type": "object",
+                    "properties": {
+                        "filesystem-id": {
+                            "type": "string"
+                        },
+                        "pool": {
+                            "type": "string"
+                        },
+                        "size": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "filesystem-id",
+                        "pool",
+                        "size"
+                    ]
+                },
+                "FilesystemParams": {
+                    "type": "object",
+                    "properties": {
+                        "attachment": {
+                            "$ref": "#/definitions/FilesystemAttachmentParams"
+                        },
+                        "attributes": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "filesystem-tag": {
+                            "type": "string"
+                        },
+                        "provider": {
+                            "type": "string"
+                        },
+                        "size": {
+                            "type": "integer"
+                        },
+                        "tags": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "volume-tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "filesystem-tag",
+                        "size",
+                        "provider"
+                    ]
+                },
+                "FilesystemParamsResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "$ref": "#/definitions/FilesystemParams"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "result"
+                    ]
+                },
+                "FilesystemParamsResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/FilesystemParamsResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "FilesystemResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "$ref": "#/definitions/Filesystem"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "result"
+                    ]
+                },
+                "FilesystemResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/FilesystemResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "Filesystems": {
+                    "type": "object",
+                    "properties": {
+                        "filesystems": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Filesystem"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "filesystems"
+                    ]
+                },
+                "LifeResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "life": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "life"
+                    ]
+                },
+                "LifeResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/LifeResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "MachineStorageId": {
+                    "type": "object",
+                    "properties": {
+                        "attachment-tag": {
+                            "type": "string"
+                        },
+                        "machine-tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "machine-tag",
+                        "attachment-tag"
+                    ]
+                },
+                "MachineStorageIds": {
+                    "type": "object",
+                    "properties": {
+                        "ids": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/MachineStorageId"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "ids"
+                    ]
+                },
+                "MachineStorageIdsWatchResult": {
+                    "type": "object",
+                    "properties": {
+                        "changes": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/MachineStorageId"
+                            }
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "watcher-id": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "watcher-id",
+                        "changes"
+                    ]
+                },
+                "MachineStorageIdsWatchResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/MachineStorageIdsWatchResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "NotifyWatchResult": {
+                    "type": "object",
+                    "properties": {
+                        "NotifyWatcherId": {
+                            "type": "string"
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "NotifyWatcherId"
+                    ]
+                },
+                "NotifyWatchResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/NotifyWatchResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "RemoveFilesystemParams": {
+                    "type": "object",
+                    "properties": {
+                        "destroy": {
+                            "type": "boolean"
+                        },
+                        "filesystem-id": {
+                            "type": "string"
+                        },
+                        "provider": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "provider",
+                        "filesystem-id"
+                    ]
+                },
+                "RemoveFilesystemParamsResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "$ref": "#/definitions/RemoveFilesystemParams"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "result"
+                    ]
+                },
+                "RemoveFilesystemParamsResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/RemoveFilesystemParamsResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "RemoveVolumeParams": {
+                    "type": "object",
+                    "properties": {
+                        "destroy": {
+                            "type": "boolean"
+                        },
+                        "provider": {
+                            "type": "string"
+                        },
+                        "volume-id": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "provider",
+                        "volume-id"
+                    ]
+                },
+                "RemoveVolumeParamsResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "$ref": "#/definitions/RemoveVolumeParams"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "result"
+                    ]
+                },
+                "RemoveVolumeParamsResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/RemoveVolumeParamsResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "SetStatus": {
+                    "type": "object",
+                    "properties": {
+                        "entities": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/EntityStatusArgs"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "entities"
+                    ]
+                },
+                "StringResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "result"
+                    ]
+                },
+                "StringResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/StringResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "StringsWatchResult": {
+                    "type": "object",
+                    "properties": {
+                        "changes": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "watcher-id": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "watcher-id"
+                    ]
+                },
+                "StringsWatchResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/StringsWatchResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "Volume": {
+                    "type": "object",
+                    "properties": {
+                        "info": {
+                            "$ref": "#/definitions/VolumeInfo"
+                        },
+                        "volume-tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "volume-tag",
+                        "info"
+                    ]
+                },
+                "VolumeAttachment": {
+                    "type": "object",
+                    "properties": {
+                        "info": {
+                            "$ref": "#/definitions/VolumeAttachmentInfo"
+                        },
+                        "machine-tag": {
+                            "type": "string"
+                        },
+                        "volume-tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "volume-tag",
+                        "machine-tag",
+                        "info"
+                    ]
+                },
+                "VolumeAttachmentInfo": {
+                    "type": "object",
+                    "properties": {
+                        "bus-address": {
+                            "type": "string"
+                        },
+                        "device-link": {
+                            "type": "string"
+                        },
+                        "device-name": {
+                            "type": "string"
+                        },
+                        "plan-info": {
+                            "$ref": "#/definitions/VolumeAttachmentPlanInfo"
+                        },
+                        "read-only": {
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "VolumeAttachmentParams": {
+                    "type": "object",
+                    "properties": {
+                        "instance-id": {
+                            "type": "string"
+                        },
+                        "machine-tag": {
+                            "type": "string"
+                        },
+                        "provider": {
+                            "type": "string"
+                        },
+                        "read-only": {
+                            "type": "boolean"
+                        },
+                        "volume-id": {
+                            "type": "string"
+                        },
+                        "volume-tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "volume-tag",
+                        "machine-tag",
+                        "provider"
+                    ]
+                },
+                "VolumeAttachmentParamsResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "$ref": "#/definitions/VolumeAttachmentParams"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "result"
+                    ]
+                },
+                "VolumeAttachmentParamsResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/VolumeAttachmentParamsResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "VolumeAttachmentPlan": {
+                    "type": "object",
+                    "properties": {
+                        "block-device": {
+                            "$ref": "#/definitions/BlockDevice"
+                        },
+                        "life": {
+                            "type": "string"
+                        },
+                        "machine-tag": {
+                            "type": "string"
+                        },
+                        "plan-info": {
+                            "$ref": "#/definitions/VolumeAttachmentPlanInfo"
+                        },
+                        "volume-tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "volume-tag",
+                        "machine-tag",
+                        "plan-info"
+                    ]
+                },
+                "VolumeAttachmentPlanInfo": {
+                    "type": "object",
+                    "properties": {
+                        "device-attributes": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "device-type": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "VolumeAttachmentPlanResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "$ref": "#/definitions/VolumeAttachmentPlan"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "result"
+                    ]
+                },
+                "VolumeAttachmentPlanResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/VolumeAttachmentPlanResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "VolumeAttachmentPlans": {
+                    "type": "object",
+                    "properties": {
+                        "volume-plans": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/VolumeAttachmentPlan"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "volume-plans"
+                    ]
+                },
+                "VolumeAttachmentResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "$ref": "#/definitions/VolumeAttachment"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "result"
+                    ]
+                },
+                "VolumeAttachmentResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/VolumeAttachmentResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "VolumeAttachments": {
+                    "type": "object",
+                    "properties": {
+                        "volume-attachments": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/VolumeAttachment"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "volume-attachments"
+                    ]
+                },
+                "VolumeInfo": {
+                    "type": "object",
+                    "properties": {
+                        "hardware-id": {
+                            "type": "string"
+                        },
+                        "persistent": {
+                            "type": "boolean"
+                        },
+                        "pool": {
+                            "type": "string"
+                        },
+                        "size": {
+                            "type": "integer"
+                        },
+                        "volume-id": {
+                            "type": "string"
+                        },
+                        "wwn": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "volume-id",
+                        "size",
+                        "persistent"
+                    ]
+                },
+                "VolumeParams": {
+                    "type": "object",
+                    "properties": {
+                        "attachment": {
+                            "$ref": "#/definitions/VolumeAttachmentParams"
+                        },
+                        "attributes": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "provider": {
+                            "type": "string"
+                        },
+                        "size": {
+                            "type": "integer"
+                        },
+                        "tags": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "volume-tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "volume-tag",
+                        "size",
+                        "provider"
+                    ]
+                },
+                "VolumeParamsResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "$ref": "#/definitions/VolumeParams"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "result"
+                    ]
+                },
+                "VolumeParamsResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/VolumeParamsResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "VolumeResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "$ref": "#/definitions/Volume"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "result"
+                    ]
+                },
+                "VolumeResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/VolumeResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "Volumes": {
+                    "type": "object",
+                    "properties": {
+                        "volumes": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Volume"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "volumes"
+                    ]
+                }
+            }
+        }
+    },
+    {
+        "Name": "UnitAssigner",
+        "Description": "",
+        "Version": 1,
+        "AvailableTo": [
+            "controller-machine-agent",
+            "machine-agent",
+            "unit-agent",
+            "model-user"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "AssignUnits": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "SetAgentStatus": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/SetStatus"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "WatchUnitAssignments": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/StringsWatchResult"
+                        }
+                    }
+                }
+            },
+            "definitions": {
+                "Entities": {
+                    "type": "object",
+                    "properties": {
+                        "entities": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Entity"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "entities"
+                    ]
+                },
+                "Entity": {
+                    "type": "object",
+                    "properties": {
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag"
+                    ]
+                },
+                "EntityStatusArgs": {
+                    "type": "object",
+                    "properties": {
+                        "data": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "info": {
+                            "type": "string"
+                        },
+                        "status": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag",
+                        "status",
+                        "info",
+                        "data"
+                    ]
+                },
+                "Error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "message",
+                        "code"
+                    ]
+                },
+                "ErrorResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ErrorResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ErrorResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "SetStatus": {
+                    "type": "object",
+                    "properties": {
+                        "entities": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/EntityStatusArgs"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "entities"
+                    ]
+                },
+                "StringsWatchResult": {
+                    "type": "object",
+                    "properties": {
+                        "changes": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "watcher-id": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "watcher-id"
+                    ]
+                }
+            }
+        }
+    },
+    {
+        "Name": "Uniter",
+        "Description": "",
+        "Version": 19,
+        "AvailableTo": [
+            "controller-machine-agent",
+            "machine-agent",
+            "unit-agent",
+            "model-user"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "APIAddresses": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/StringsResult"
+                        }
+                    }
+                },
+                "APIHostPorts": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/APIHostPortsResult"
+                        }
+                    }
+                },
+                "ActionStatus": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/StringResults"
+                        }
+                    }
+                },
+                "Actions": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ActionResults"
+                        }
+                    }
+                },
+                "ApplicationStatus": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ApplicationStatusResults"
+                        }
+                    }
+                },
+                "AssignedMachine": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/StringResults"
+                        }
+                    }
+                },
+                "AvailabilityZone": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/StringResults"
+                        }
+                    }
+                },
+                "BeginActions": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "CanApplyLXDProfile": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/BoolResults"
+                        }
+                    }
+                },
+                "CharmArchiveSha256": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/CharmURLs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/StringResults"
+                        }
+                    }
+                },
+                "CharmModifiedVersion": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/IntResults"
+                        }
+                    }
+                },
+                "CharmURL": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/StringBoolResults"
+                        }
+                    }
+                },
+                "ClearResolved": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "CloudAPIVersion": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/StringResult"
+                        }
+                    }
+                },
+                "CloudSpec": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/CloudSpecResult"
+                        }
+                    }
+                },
+                "CommitHookChanges": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/CommitHookChangesArgs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "ConfigSettings": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ConfigSettingsResults"
+                        }
+                    }
+                },
+                "CurrentModel": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/ModelResult"
+                        }
+                    }
+                },
+                "Destroy": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "DestroyAllSubordinates": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "DestroyUnitStorageAttachments": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "EnsureDead": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "EnterScope": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/RelationUnits"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "FinishActions": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/ActionExecutionResults"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "GetPrincipal": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/StringBoolResults"
+                        }
+                    }
+                },
+                "GoalStates": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/GoalStateResults"
+                        }
+                    }
+                },
+                "HasSubordinates": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/BoolResults"
+                        }
+                    }
+                },
+                "LXDProfileName": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/StringResults"
+                        }
+                    }
+                },
+                "LXDProfileRequired": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/CharmURLs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/BoolResults"
+                        }
+                    }
+                },
+                "LeaveScope": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/RelationUnits"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "Life": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/LifeResults"
+                        }
+                    }
+                },
+                "LogActionsMessages": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/ActionMessageParams"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "Merge": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/MergeLeadershipSettingsBulkParams"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "ModelConfig": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/ModelConfigResult"
+                        }
+                    }
+                },
+                "NetworkInfo": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/NetworkInfoParams"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/NetworkInfoResults"
+                        }
+                    }
+                },
+                "OpenedMachinePortRangesByEndpoint": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/OpenPortRangesByEndpointResults"
+                        }
+                    }
+                },
+                "OpenedPortRangesByEndpoint": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/OpenPortRangesByEndpointResults"
+                        }
+                    }
+                },
+                "PrivateAddress": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/StringResults"
+                        }
+                    }
+                },
+                "ProviderType": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/StringResult"
+                        }
+                    }
+                },
+                "PublicAddress": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/StringResults"
+                        }
+                    }
+                },
+                "Read": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/GetLeadershipSettingsBulkResults"
+                        }
+                    }
+                },
+                "ReadLocalApplicationSettings": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/RelationUnit"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/SettingsResult"
+                        }
+                    }
+                },
+                "ReadRemoteSettings": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/RelationUnitPairs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/SettingsResults"
+                        }
+                    }
+                },
+                "ReadSettings": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/RelationUnits"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/SettingsResults"
+                        }
+                    }
+                },
+                "Refresh": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/UnitRefreshResults"
+                        }
+                    }
+                },
+                "Relation": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/RelationUnits"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/RelationResults"
+                        }
+                    }
+                },
+                "RelationById": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/RelationIds"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/RelationResults"
+                        }
+                    }
+                },
+                "RelationsStatus": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/RelationUnitStatusResults"
+                        }
+                    }
+                },
+                "RemoveStorageAttachments": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/StorageAttachmentIds"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "RequestReboot": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "Resolved": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ResolvedModeResults"
+                        }
+                    }
+                },
+                "SetAgentStatus": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/SetStatus"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "SetApplicationStatus": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/SetStatus"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "SetCharmURL": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/EntitiesCharmURL"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "SetRelationStatus": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/RelationStatusArgs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "SetState": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/SetUnitStateArgs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "SetStatus": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/SetStatus"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "SetUnitStatus": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/SetStatus"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "SetWorkloadVersion": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/EntityWorkloadVersions"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "State": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/UnitStateResults"
+                        }
+                    }
+                },
+                "StorageAttachmentLife": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/StorageAttachmentIds"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/LifeResults"
+                        }
+                    }
+                },
+                "StorageAttachments": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/StorageAttachmentIds"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/StorageAttachmentResults"
+                        }
+                    }
+                },
+                "UnitStatus": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/StatusResults"
+                        }
+                    }
+                },
+                "UnitStorageAttachments": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/StorageAttachmentIdsResults"
+                        }
+                    }
+                },
+                "UpdateNetworkInfo": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "Watch": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/NotifyWatchResults"
+                        }
+                    }
+                },
+                "WatchAPIHostPorts": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/NotifyWatchResult"
+                        }
+                    }
+                },
+                "WatchActionNotifications": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/StringsWatchResults"
+                        }
+                    }
+                },
+                "WatchConfigSettingsHash": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/StringsWatchResults"
+                        }
+                    }
+                },
+                "WatchForModelConfigChanges": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/NotifyWatchResult"
+                        }
+                    }
+                },
+                "WatchInstanceData": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/NotifyWatchResults"
+                        }
+                    }
+                },
+                "WatchLeadershipSettings": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/NotifyWatchResults"
+                        }
+                    }
+                },
+                "WatchRelationUnits": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/RelationUnits"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/RelationUnitsWatchResults"
+                        }
+                    }
+                },
+                "WatchStorageAttachments": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/StorageAttachmentIds"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/NotifyWatchResults"
+                        }
+                    }
+                },
+                "WatchTrustConfigSettingsHash": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/StringsWatchResults"
+                        }
+                    }
+                },
+                "WatchUnitAddressesHash": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/StringsWatchResults"
+                        }
+                    }
+                },
+                "WatchUnitRelations": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/StringsWatchResults"
+                        }
+                    }
+                },
+                "WatchUnitStorageAttachments": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/StringsWatchResults"
+                        }
+                    }
+                },
+                "WorkloadVersion": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/StringResults"
+                        }
+                    }
+                }
+            },
+            "definitions": {
+                "APIHostPortsResult": {
+                    "type": "object",
+                    "properties": {
+                        "servers": {
+                            "type": "array",
+                            "items": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/definitions/HostPort"
+                                }
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "servers"
+                    ]
+                },
+                "Action": {
+                    "type": "object",
+                    "properties": {
+                        "execution-group": {
+                            "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "parallel": {
+                            "type": "boolean"
+                        },
+                        "parameters": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "receiver": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag",
+                        "receiver",
+                        "name"
+                    ]
+                },
+                "ActionExecutionResult": {
+                    "type": "object",
+                    "properties": {
+                        "action-tag": {
+                            "type": "string"
+                        },
+                        "message": {
+                            "type": "string"
+                        },
+                        "results": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "status": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "action-tag",
+                        "status"
+                    ]
+                },
+                "ActionExecutionResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ActionExecutionResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ActionMessage": {
+                    "type": "object",
+                    "properties": {
+                        "message": {
+                            "type": "string"
+                        },
+                        "timestamp": {
+                            "type": "string",
+                            "format": "date-time"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "timestamp",
+                        "message"
+                    ]
+                },
+                "ActionMessageParams": {
+                    "type": "object",
+                    "properties": {
+                        "messages": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/EntityString"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "messages"
+                    ]
+                },
+                "ActionResult": {
+                    "type": "object",
+                    "properties": {
+                        "action": {
+                            "$ref": "#/definitions/Action"
+                        },
+                        "completed": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "enqueued": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "log": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ActionMessage"
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        },
+                        "output": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "started": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "status": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ActionResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ActionResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "Address": {
+                    "type": "object",
+                    "properties": {
+                        "cidr": {
+                            "type": "string"
+                        },
+                        "config-type": {
+                            "type": "string"
+                        },
+                        "is-secondary": {
+                            "type": "boolean"
+                        },
+                        "scope": {
+                            "type": "string"
+                        },
+                        "space-id": {
+                            "type": "string"
+                        },
+                        "space-name": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "type": "string"
+                        },
+                        "value": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "value",
+                        "type",
+                        "scope"
+                    ]
+                },
+                "ApplicationStatusResult": {
+                    "type": "object",
+                    "properties": {
+                        "application": {
+                            "$ref": "#/definitions/StatusResult"
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "units": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "$ref": "#/definitions/StatusResult"
+                                }
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "application",
+                        "units"
+                    ]
+                },
+                "ApplicationStatusResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ApplicationStatusResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "BoolResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "result"
+                    ]
+                },
+                "BoolResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/BoolResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "CharmRelation": {
+                    "type": "object",
+                    "properties": {
+                        "interface": {
+                            "type": "string"
+                        },
+                        "limit": {
+                            "type": "integer"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "optional": {
+                            "type": "boolean"
+                        },
+                        "role": {
+                            "type": "string"
+                        },
+                        "scope": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "name",
+                        "role",
+                        "interface",
+                        "optional",
+                        "limit",
+                        "scope"
+                    ]
+                },
+                "CharmURL": {
+                    "type": "object",
+                    "properties": {
+                        "url": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "url"
+                    ]
+                },
+                "CharmURLs": {
+                    "type": "object",
+                    "properties": {
+                        "urls": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/CharmURL"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "urls"
+                    ]
+                },
+                "CloudCredential": {
+                    "type": "object",
+                    "properties": {
+                        "attrs": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "auth-type": {
+                            "type": "string"
+                        },
+                        "redacted": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "auth-type"
+                    ]
+                },
+                "CloudSpec": {
+                    "type": "object",
+                    "properties": {
+                        "cacertificates": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "credential": {
+                            "$ref": "#/definitions/CloudCredential"
+                        },
+                        "endpoint": {
+                            "type": "string"
+                        },
+                        "identity-endpoint": {
+                            "type": "string"
+                        },
+                        "is-controller-cloud": {
+                            "type": "boolean"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "region": {
+                            "type": "string"
+                        },
+                        "skip-tls-verify": {
+                            "type": "boolean"
+                        },
+                        "storage-endpoint": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "type",
+                        "name"
+                    ]
+                },
+                "CloudSpecResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "$ref": "#/definitions/CloudSpec"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "CommitHookChangesArg": {
+                    "type": "object",
+                    "properties": {
+                        "add-storage": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/StorageAddParams"
+                            }
+                        },
+                        "close-ports": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/EntityPortRange"
+                            }
+                        },
+                        "open-ports": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/EntityPortRange"
+                            }
+                        },
+                        "relation-unit-settings": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/RelationUnitSettings"
+                            }
+                        },
+                        "secret-creates": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/CreateSecretArg"
+                            }
+                        },
+                        "secret-deletes": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/DeleteSecretArg"
+                            }
+                        },
+                        "secret-grants": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/GrantRevokeSecretArg"
+                            }
+                        },
+                        "secret-revokes": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/GrantRevokeSecretArg"
+                            }
+                        },
+                        "secret-track-latest": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "secret-updates": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/UpdateSecretArg"
+                            }
+                        },
+                        "tag": {
+                            "type": "string"
+                        },
+                        "unit-state": {
+                            "$ref": "#/definitions/SetUnitStateArg"
+                        },
+                        "update-network-info": {
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag",
+                        "update-network-info"
+                    ]
+                },
+                "CommitHookChangesArgs": {
+                    "type": "object",
+                    "properties": {
+                        "args": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/CommitHookChangesArg"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "args"
+                    ]
+                },
+                "ConfigSettingsResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "settings": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "settings"
+                    ]
+                },
+                "ConfigSettingsResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ConfigSettingsResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "CreateSecretArg": {
+                    "type": "object",
+                    "properties": {
+                        "UpsertSecretArg": {
+                            "$ref": "#/definitions/UpsertSecretArg"
+                        },
+                        "content": {
+                            "$ref": "#/definitions/SecretContentParams"
+                        },
+                        "description": {
+                            "type": "string"
+                        },
+                        "expire-time": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "label": {
+                            "type": "string"
+                        },
+                        "owner-tag": {
+                            "type": "string"
+                        },
+                        "params": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "rotate-policy": {
+                            "type": "string"
+                        },
+                        "uri": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "UpsertSecretArg",
+                        "owner-tag"
+                    ]
+                },
+                "DeleteSecretArg": {
+                    "type": "object",
+                    "properties": {
+                        "label": {
+                            "type": "string"
+                        },
+                        "revisions": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            }
+                        },
+                        "uri": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "uri",
+                        "label"
+                    ]
+                },
+                "Endpoint": {
+                    "type": "object",
+                    "properties": {
+                        "application-name": {
+                            "type": "string"
+                        },
+                        "relation": {
+                            "$ref": "#/definitions/CharmRelation"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "application-name",
+                        "relation"
+                    ]
+                },
+                "Entities": {
+                    "type": "object",
+                    "properties": {
+                        "entities": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Entity"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "entities"
+                    ]
+                },
+                "EntitiesCharmURL": {
+                    "type": "object",
+                    "properties": {
+                        "entities": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/EntityCharmURL"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "entities"
+                    ]
+                },
+                "Entity": {
+                    "type": "object",
+                    "properties": {
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag"
+                    ]
+                },
+                "EntityCharmURL": {
+                    "type": "object",
+                    "properties": {
+                        "charm-url": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag",
+                        "charm-url"
+                    ]
+                },
+                "EntityPortRange": {
+                    "type": "object",
+                    "properties": {
+                        "endpoint": {
+                            "type": "string"
+                        },
+                        "from-port": {
+                            "type": "integer"
+                        },
+                        "protocol": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        },
+                        "to-port": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag",
+                        "protocol",
+                        "from-port",
+                        "to-port",
+                        "endpoint"
+                    ]
+                },
+                "EntityStatusArgs": {
+                    "type": "object",
+                    "properties": {
+                        "data": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "info": {
+                            "type": "string"
+                        },
+                        "status": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag",
+                        "status",
+                        "info",
+                        "data"
+                    ]
+                },
+                "EntityString": {
+                    "type": "object",
+                    "properties": {
+                        "tag": {
+                            "type": "string"
+                        },
+                        "value": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag",
+                        "value"
+                    ]
+                },
+                "EntityWorkloadVersion": {
+                    "type": "object",
+                    "properties": {
+                        "tag": {
+                            "type": "string"
+                        },
+                        "workload-version": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag",
+                        "workload-version"
+                    ]
+                },
+                "EntityWorkloadVersions": {
+                    "type": "object",
+                    "properties": {
+                        "entities": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/EntityWorkloadVersion"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "entities"
+                    ]
+                },
+                "Error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "message",
+                        "code"
+                    ]
+                },
+                "ErrorResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ErrorResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ErrorResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "GetLeadershipSettingsBulkResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/GetLeadershipSettingsResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "GetLeadershipSettingsResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "settings": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "settings"
+                    ]
+                },
+                "GoalState": {
+                    "type": "object",
+                    "properties": {
+                        "relations": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "patternProperties": {
+                                        ".*": {
+                                            "$ref": "#/definitions/GoalStateStatus"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "units": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "$ref": "#/definitions/GoalStateStatus"
+                                }
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "units",
+                        "relations"
+                    ]
+                },
+                "GoalStateResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "$ref": "#/definitions/GoalState"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "result",
+                        "error"
+                    ]
+                },
+                "GoalStateResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/GoalStateResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "GoalStateStatus": {
+                    "type": "object",
+                    "properties": {
+                        "since": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "status": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "status",
+                        "since"
+                    ]
+                },
+                "GrantRevokeSecretArg": {
+                    "type": "object",
+                    "properties": {
+                        "role": {
+                            "type": "string"
+                        },
+                        "scope-tag": {
+                            "type": "string"
+                        },
+                        "subject-tags": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "uri": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "uri",
+                        "scope-tag",
+                        "subject-tags",
+                        "role"
+                    ]
+                },
+                "HostPort": {
+                    "type": "object",
+                    "properties": {
+                        "Address": {
+                            "$ref": "#/definitions/Address"
+                        },
+                        "cidr": {
+                            "type": "string"
+                        },
+                        "config-type": {
+                            "type": "string"
+                        },
+                        "is-secondary": {
+                            "type": "boolean"
+                        },
+                        "port": {
+                            "type": "integer"
+                        },
+                        "scope": {
+                            "type": "string"
+                        },
+                        "space-id": {
+                            "type": "string"
+                        },
+                        "space-name": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "type": "string"
+                        },
+                        "value": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "value",
+                        "type",
+                        "scope",
+                        "Address",
+                        "port"
+                    ]
+                },
+                "IntResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "result"
+                    ]
+                },
+                "IntResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/IntResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "InterfaceAddress": {
+                    "type": "object",
+                    "properties": {
+                        "cidr": {
+                            "type": "string"
+                        },
+                        "hostname": {
+                            "type": "string"
+                        },
+                        "value": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "hostname",
+                        "value",
+                        "cidr"
+                    ]
+                },
+                "LifeResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "life": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "life"
+                    ]
+                },
+                "LifeResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/LifeResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "MergeLeadershipSettingsBulkParams": {
+                    "type": "object",
+                    "properties": {
+                        "params": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/MergeLeadershipSettingsParam"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "params"
+                    ]
+                },
+                "MergeLeadershipSettingsParam": {
+                    "type": "object",
+                    "properties": {
+                        "application-tag": {
+                            "type": "string"
+                        },
+                        "settings": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "unit-tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "settings"
+                    ]
+                },
+                "ModelConfigResult": {
+                    "type": "object",
+                    "properties": {
+                        "config": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "config"
+                    ]
+                },
+                "ModelResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "type": "string"
+                        },
+                        "uuid": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "name",
+                        "uuid",
+                        "type"
+                    ]
+                },
+                "NetworkInfo": {
+                    "type": "object",
+                    "properties": {
+                        "addresses": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/InterfaceAddress"
+                            }
+                        },
+                        "interface-name": {
+                            "type": "string"
+                        },
+                        "mac-address": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "mac-address",
+                        "interface-name",
+                        "addresses"
+                    ]
+                },
+                "NetworkInfoParams": {
+                    "type": "object",
+                    "properties": {
+                        "bindings": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "relation-id": {
+                            "type": "integer"
+                        },
+                        "unit": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "unit",
+                        "bindings"
+                    ]
+                },
+                "NetworkInfoResult": {
+                    "type": "object",
+                    "properties": {
+                        "bind-addresses": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/NetworkInfo"
+                            }
+                        },
+                        "egress-subnets": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "ingress-addresses": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "NetworkInfoResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "$ref": "#/definitions/NetworkInfoResult"
+                                }
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "NotifyWatchResult": {
+                    "type": "object",
+                    "properties": {
+                        "NotifyWatcherId": {
+                            "type": "string"
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "NotifyWatcherId"
+                    ]
+                },
+                "NotifyWatchResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/NotifyWatchResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "OpenPortRangesByEndpointResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "unit-port-ranges": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/definitions/OpenUnitPortRangesByEndpoint"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "unit-port-ranges"
+                    ]
+                },
+                "OpenPortRangesByEndpointResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/OpenPortRangesByEndpointResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "OpenUnitPortRangesByEndpoint": {
+                    "type": "object",
+                    "properties": {
+                        "endpoint": {
+                            "type": "string"
+                        },
+                        "port-ranges": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/PortRange"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "endpoint",
+                        "port-ranges"
+                    ]
+                },
+                "PortRange": {
+                    "type": "object",
+                    "properties": {
+                        "from-port": {
+                            "type": "integer"
+                        },
+                        "protocol": {
+                            "type": "string"
+                        },
+                        "to-port": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "from-port",
+                        "to-port",
+                        "protocol"
+                    ]
+                },
+                "RelationIds": {
+                    "type": "object",
+                    "properties": {
+                        "relation-ids": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "relation-ids"
+                    ]
+                },
+                "RelationResult": {
+                    "type": "object",
+                    "properties": {
+                        "bool": {
+                            "type": "boolean"
+                        },
+                        "endpoint": {
+                            "$ref": "#/definitions/Endpoint"
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "id": {
+                            "type": "integer"
+                        },
+                        "key": {
+                            "type": "string"
+                        },
+                        "life": {
+                            "type": "string"
+                        },
+                        "other-application": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "life",
+                        "id",
+                        "key",
+                        "endpoint"
+                    ]
+                },
+                "RelationResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/RelationResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "RelationStatusArg": {
+                    "type": "object",
+                    "properties": {
+                        "message": {
+                            "type": "string"
+                        },
+                        "relation-id": {
+                            "type": "integer"
+                        },
+                        "status": {
+                            "type": "string"
+                        },
+                        "unit-tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "unit-tag",
+                        "relation-id",
+                        "status",
+                        "message"
+                    ]
+                },
+                "RelationStatusArgs": {
+                    "type": "object",
+                    "properties": {
+                        "args": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/RelationStatusArg"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "args"
+                    ]
+                },
+                "RelationUnit": {
+                    "type": "object",
+                    "properties": {
+                        "relation": {
+                            "type": "string"
+                        },
+                        "unit": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "relation",
+                        "unit"
+                    ]
+                },
+                "RelationUnitPair": {
+                    "type": "object",
+                    "properties": {
+                        "local-unit": {
+                            "type": "string"
+                        },
+                        "relation": {
+                            "type": "string"
+                        },
+                        "remote-unit": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "relation",
+                        "local-unit",
+                        "remote-unit"
+                    ]
+                },
+                "RelationUnitPairs": {
+                    "type": "object",
+                    "properties": {
+                        "relation-unit-pairs": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/RelationUnitPair"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "relation-unit-pairs"
+                    ]
+                },
+                "RelationUnitSettings": {
+                    "type": "object",
+                    "properties": {
+                        "application-settings": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "relation": {
+                            "type": "string"
+                        },
+                        "settings": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "unit": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "relation",
+                        "unit",
+                        "settings",
+                        "application-settings"
+                    ]
+                },
+                "RelationUnitStatus": {
+                    "type": "object",
+                    "properties": {
+                        "in-scope": {
+                            "type": "boolean"
+                        },
+                        "relation-tag": {
+                            "type": "string"
+                        },
+                        "suspended": {
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "relation-tag",
+                        "in-scope",
+                        "suspended"
+                    ]
+                },
+                "RelationUnitStatusResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/RelationUnitStatus"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "RelationUnitStatusResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/RelationUnitStatusResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "RelationUnits": {
+                    "type": "object",
+                    "properties": {
+                        "relation-units": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/RelationUnit"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "relation-units"
+                    ]
+                },
+                "RelationUnitsChange": {
+                    "type": "object",
+                    "properties": {
+                        "app-changed": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "integer"
+                                }
+                            }
+                        },
+                        "changed": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "$ref": "#/definitions/UnitSettings"
+                                }
+                            }
+                        },
+                        "departed": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "changed"
+                    ]
+                },
+                "RelationUnitsWatchResult": {
+                    "type": "object",
+                    "properties": {
+                        "changes": {
+                            "$ref": "#/definitions/RelationUnitsChange"
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "watcher-id": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "watcher-id",
+                        "changes"
+                    ]
+                },
+                "RelationUnitsWatchResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/RelationUnitsWatchResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "ResolvedModeResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "mode": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "mode"
+                    ]
+                },
+                "ResolvedModeResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ResolvedModeResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "SecretContentParams": {
+                    "type": "object",
+                    "properties": {
+                        "checksum": {
+                            "type": "string"
+                        },
+                        "data": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "value-ref": {
+                            "$ref": "#/definitions/SecretValueRef"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "SecretValueRef": {
+                    "type": "object",
+                    "properties": {
+                        "backend-id": {
+                            "type": "string"
+                        },
+                        "revision-id": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "backend-id",
+                        "revision-id"
+                    ]
+                },
+                "SetStatus": {
+                    "type": "object",
+                    "properties": {
+                        "entities": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/EntityStatusArgs"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "entities"
+                    ]
+                },
+                "SetUnitStateArg": {
+                    "type": "object",
+                    "properties": {
+                        "charm-state": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "relation-state": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "secret-state": {
+                            "type": "string"
+                        },
+                        "storage-state": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        },
+                        "uniter-state": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag"
+                    ]
+                },
+                "SetUnitStateArgs": {
+                    "type": "object",
+                    "properties": {
+                        "args": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/SetUnitStateArg"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "args"
+                    ]
+                },
+                "SettingsResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "settings": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "settings"
+                    ]
+                },
+                "SettingsResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/SettingsResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "StatusResult": {
+                    "type": "object",
+                    "properties": {
+                        "data": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "string"
+                        },
+                        "life": {
+                            "type": "string"
+                        },
+                        "since": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "status": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "id",
+                        "life",
+                        "status",
+                        "info",
+                        "data",
+                        "since"
+                    ]
+                },
+                "StatusResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/StatusResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "StorageAddParams": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "storage": {
+                            "$ref": "#/definitions/StorageDirectives"
+                        },
+                        "unit": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "unit",
+                        "name",
+                        "storage"
+                    ]
+                },
+                "StorageAttachment": {
+                    "type": "object",
+                    "properties": {
+                        "kind": {
+                            "type": "integer"
+                        },
+                        "life": {
+                            "type": "string"
+                        },
+                        "location": {
+                            "type": "string"
+                        },
+                        "owner-tag": {
+                            "type": "string"
+                        },
+                        "storage-tag": {
+                            "type": "string"
+                        },
+                        "unit-tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "storage-tag",
+                        "owner-tag",
+                        "unit-tag",
+                        "kind",
+                        "location",
+                        "life"
+                    ]
+                },
+                "StorageAttachmentId": {
+                    "type": "object",
+                    "properties": {
+                        "storage-tag": {
+                            "type": "string"
+                        },
+                        "unit-tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "storage-tag",
+                        "unit-tag"
+                    ]
+                },
+                "StorageAttachmentIds": {
+                    "type": "object",
+                    "properties": {
+                        "ids": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/StorageAttachmentId"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "ids"
+                    ]
+                },
+                "StorageAttachmentIdsResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "$ref": "#/definitions/StorageAttachmentIds"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "result"
+                    ]
+                },
+                "StorageAttachmentIdsResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/StorageAttachmentIdsResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "StorageAttachmentResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "$ref": "#/definitions/StorageAttachment"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "result"
+                    ]
+                },
+                "StorageAttachmentResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/StorageAttachmentResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "StorageDirectives": {
+                    "type": "object",
+                    "properties": {
+                        "count": {
+                            "type": "integer"
+                        },
+                        "pool": {
+                            "type": "string"
+                        },
+                        "size": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "StringBoolResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "ok": {
+                            "type": "boolean"
+                        },
+                        "result": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "result",
+                        "ok"
+                    ]
+                },
+                "StringBoolResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/StringBoolResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "StringResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "result"
+                    ]
+                },
+                "StringResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/StringResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "StringsResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "StringsWatchResult": {
+                    "type": "object",
+                    "properties": {
+                        "changes": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "watcher-id": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "watcher-id"
+                    ]
+                },
+                "StringsWatchResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/StringsWatchResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "UnitRefreshResult": {
+                    "type": "object",
+                    "properties": {
+                        "Error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "Life": {
+                            "type": "string"
+                        },
+                        "Resolved": {
+                            "type": "string"
+                        },
+                        "provider-id": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "Life",
+                        "Resolved",
+                        "Error"
+                    ]
+                },
+                "UnitRefreshResults": {
+                    "type": "object",
+                    "properties": {
+                        "Results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/UnitRefreshResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "Results"
+                    ]
+                },
+                "UnitSettings": {
+                    "type": "object",
+                    "properties": {
+                        "version": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "version"
+                    ]
+                },
+                "UnitStateResult": {
+                    "type": "object",
+                    "properties": {
+                        "charm-state": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "relation-state": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "secret-state": {
+                            "type": "string"
+                        },
+                        "storage-state": {
+                            "type": "string"
+                        },
+                        "uniter-state": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "UnitStateResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/UnitStateResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "UpdateSecretArg": {
+                    "type": "object",
+                    "properties": {
+                        "UpsertSecretArg": {
+                            "$ref": "#/definitions/UpsertSecretArg"
+                        },
+                        "content": {
+                            "$ref": "#/definitions/SecretContentParams"
+                        },
+                        "description": {
+                            "type": "string"
+                        },
+                        "expire-time": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "label": {
+                            "type": "string"
+                        },
+                        "params": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "rotate-policy": {
+                            "type": "string"
+                        },
+                        "uri": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "UpsertSecretArg",
+                        "uri"
+                    ]
+                },
+                "UpsertSecretArg": {
+                    "type": "object",
+                    "properties": {
+                        "content": {
+                            "$ref": "#/definitions/SecretContentParams"
+                        },
+                        "description": {
+                            "type": "string"
+                        },
+                        "expire-time": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "label": {
+                            "type": "string"
+                        },
+                        "params": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "rotate-policy": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            }
+        }
+    },
+    {
+        "Name": "UpgradeSteps",
+        "Description": "",
+        "Version": 3,
+        "AvailableTo": [
+            "controller-machine-agent",
+            "machine-agent",
+            "unit-agent",
+            "model-user"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "WriteAgentState": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/SetUnitStateArgs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                }
+            },
+            "definitions": {
+                "Error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "message",
+                        "code"
+                    ]
+                },
+                "ErrorResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ErrorResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ErrorResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "SetUnitStateArg": {
+                    "type": "object",
+                    "properties": {
+                        "charm-state": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "relation-state": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "secret-state": {
+                            "type": "string"
+                        },
+                        "storage-state": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        },
+                        "uniter-state": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag"
+                    ]
+                },
+                "SetUnitStateArgs": {
+                    "type": "object",
+                    "properties": {
+                        "args": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/SetUnitStateArg"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "args"
+                    ]
+                }
+            }
+        }
+    },
+    {
+        "Name": "Upgrader",
+        "Description": "",
+        "Version": 1,
+        "AvailableTo": [
+            "controller-machine-agent",
+            "machine-agent",
+            "unit-agent",
+            "model-user"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "DesiredVersion": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/VersionResults"
+                        }
+                    }
+                },
+                "SetTools": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/EntitiesVersion"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    }
+                },
+                "Tools": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ToolsResults"
+                        }
+                    }
+                },
+                "WatchAPIVersion": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/NotifyWatchResults"
+                        }
+                    }
+                }
+            },
+            "definitions": {
+                "Binary": {
+                    "type": "object",
+                    "properties": {
+                        "Arch": {
+                            "type": "string"
+                        },
+                        "Build": {
+                            "type": "integer"
+                        },
+                        "Major": {
+                            "type": "integer"
+                        },
+                        "Minor": {
+                            "type": "integer"
+                        },
+                        "Number": {
+                            "$ref": "#/definitions/Number"
+                        },
+                        "Patch": {
+                            "type": "integer"
+                        },
+                        "Release": {
+                            "type": "string"
+                        },
+                        "Tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "Major",
+                        "Minor",
+                        "Tag",
+                        "Patch",
+                        "Build",
+                        "Number",
+                        "Release",
+                        "Arch"
+                    ]
+                },
+                "Entities": {
+                    "type": "object",
+                    "properties": {
+                        "entities": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Entity"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "entities"
+                    ]
+                },
+                "EntitiesVersion": {
+                    "type": "object",
+                    "properties": {
+                        "agent-tools": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/EntityVersion"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "agent-tools"
+                    ]
+                },
+                "Entity": {
+                    "type": "object",
+                    "properties": {
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag"
+                    ]
+                },
+                "EntityVersion": {
+                    "type": "object",
+                    "properties": {
+                        "tag": {
+                            "type": "string"
+                        },
+                        "tools": {
+                            "$ref": "#/definitions/Version"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag",
+                        "tools"
+                    ]
+                },
+                "Error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "message",
+                        "code"
+                    ]
+                },
+                "ErrorResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ErrorResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ErrorResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "NotifyWatchResult": {
+                    "type": "object",
+                    "properties": {
+                        "NotifyWatcherId": {
+                            "type": "string"
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "NotifyWatcherId"
+                    ]
+                },
+                "NotifyWatchResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/NotifyWatchResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "Number": {
+                    "type": "object",
+                    "properties": {
+                        "Build": {
+                            "type": "integer"
+                        },
+                        "Major": {
+                            "type": "integer"
+                        },
+                        "Minor": {
+                            "type": "integer"
+                        },
+                        "Patch": {
+                            "type": "integer"
+                        },
+                        "Tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "Major",
+                        "Minor",
+                        "Tag",
+                        "Patch",
+                        "Build"
+                    ]
+                },
+                "Tools": {
+                    "type": "object",
+                    "properties": {
+                        "sha256": {
+                            "type": "string"
+                        },
+                        "size": {
+                            "type": "integer"
+                        },
+                        "url": {
+                            "type": "string"
+                        },
+                        "version": {
+                            "$ref": "#/definitions/Binary"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "version",
+                        "url",
+                        "size"
+                    ]
+                },
+                "ToolsResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "tools": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Tools"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tools"
+                    ]
+                },
+                "ToolsResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ToolsResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "Version": {
+                    "type": "object",
+                    "properties": {
+                        "version": {
+                            "$ref": "#/definitions/Binary"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "version"
+                    ]
+                },
+                "VersionResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "version": {
+                            "$ref": "#/definitions/Number"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "VersionResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/VersionResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                }
+            }
+        }
+    }
+]

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -1,7 +1,7 @@
 [
     {
         "Name": "Action",
-        "Description": "APIv7 provides the Action API facade for version 7.",
+        "Description": "",
         "Version": 7,
         "AvailableTo": [
             "model-user"
@@ -18,8 +18,7 @@
                         "Result": {
                             "$ref": "#/definitions/ActionResults"
                         }
-                    },
-                    "description": "Actions takes a list of ActionTags, and returns the full Action for\neach ID."
+                    }
                 },
                 "ApplicationsCharmsActions": {
                     "type": "object",
@@ -30,8 +29,7 @@
                         "Result": {
                             "$ref": "#/definitions/ApplicationsCharmActionsResults"
                         }
-                    },
-                    "description": "ApplicationsCharmsActions returns a slice of charm Actions for a slice of\nservices."
+                    }
                 },
                 "Cancel": {
                     "type": "object",
@@ -42,8 +40,7 @@
                         "Result": {
                             "$ref": "#/definitions/ActionResults"
                         }
-                    },
-                    "description": "Cancel attempts to cancel enqueued Actions from running."
+                    }
                 },
                 "EnqueueOperation": {
                     "type": "object",
@@ -54,8 +51,7 @@
                         "Result": {
                             "$ref": "#/definitions/EnqueuedActions"
                         }
-                    },
-                    "description": "EnqueueOperation takes a list of Actions and queues them up to be executed as\nan operation, each action running as a task on the designated ActionReceiver.\nWe return the ID of the overall operation and each individual task."
+                    }
                 },
                 "ListOperations": {
                     "type": "object",
@@ -66,8 +62,7 @@
                         "Result": {
                             "$ref": "#/definitions/OperationResults"
                         }
-                    },
-                    "description": "ListOperations fetches the called actions for specified apps/units."
+                    }
                 },
                 "Operations": {
                     "type": "object",
@@ -78,8 +73,7 @@
                         "Result": {
                             "$ref": "#/definitions/OperationResults"
                         }
-                    },
-                    "description": "Operations fetches the specified operation ids."
+                    }
                 },
                 "Run": {
                     "type": "object",
@@ -90,8 +84,7 @@
                         "Result": {
                             "$ref": "#/definitions/EnqueuedActions"
                         }
-                    },
-                    "description": "Run the commands specified on the machines identified through the\nlist of machines, units and services."
+                    }
                 },
                 "RunOnAllMachines": {
                     "type": "object",
@@ -102,8 +95,7 @@
                         "Result": {
                             "$ref": "#/definitions/EnqueuedActions"
                         }
-                    },
-                    "description": "RunOnAllMachines attempts to run the specified command on all the machines."
+                    }
                 },
                 "WatchActionsProgress": {
                     "type": "object",
@@ -114,8 +106,7 @@
                         "Result": {
                             "$ref": "#/definitions/StringsWatchResults"
                         }
-                    },
-                    "description": "WatchActionsProgress creates a watcher that reports on action log messages."
+                    }
                 }
             },
             "definitions": {
@@ -548,7 +539,7 @@
     },
     {
         "Name": "Admin",
-        "Description": "admin is the only object that unlogged-in clients can access. It holds any\nmethods that are needed to log in.",
+        "Description": "",
         "Version": 3,
         "AvailableTo": [
             "controller-machine-agent",
@@ -569,8 +560,7 @@
                         "Result": {
                             "$ref": "#/definitions/LoginResult"
                         }
-                    },
-                    "description": "Login logs in with the provided credentials.  All subsequent requests on the\nconnection will act as the authenticated user."
+                    }
                 },
                 "RedirectInfo": {
                     "type": "object",
@@ -578,8 +568,7 @@
                         "Result": {
                             "$ref": "#/definitions/RedirectInfoResult"
                         }
-                    },
-                    "description": "RedirectInfo returns redirected host information for the model.\nIn Juju it always returns an error because the Juju controller\ndoes not multiplex controllers."
+                    }
                 }
             },
             "definitions": {
@@ -833,7 +822,7 @@
     },
     {
         "Name": "Annotations",
-        "Description": "API implements the service interface and is the concrete\nimplementation of the api end point.",
+        "Description": "",
         "Version": 2,
         "AvailableTo": [
             "model-user"
@@ -850,8 +839,7 @@
                         "Result": {
                             "$ref": "#/definitions/AnnotationsGetResults"
                         }
-                    },
-                    "description": "Get returns annotations for given entities.\nIf annotations cannot be retrieved for a given entity, an error is returned.\nEach entity is treated independently and, hence, will fail or succeed independently."
+                    }
                 },
                 "Set": {
                     "type": "object",
@@ -862,8 +850,7 @@
                         "Result": {
                             "$ref": "#/definitions/ErrorResults"
                         }
-                    },
-                    "description": "Set stores annotations for given entities"
+                    }
                 }
             },
             "definitions": {
@@ -1023,7 +1010,7 @@
     },
     {
         "Name": "Application",
-        "Description": "APIv20 provides the Application API facade for version 20.",
+        "Description": "",
         "Version": 20,
         "AvailableTo": [
             "controller-machine-agent",
@@ -1043,8 +1030,7 @@
                         "Result": {
                             "$ref": "#/definitions/AddRelationResults"
                         }
-                    },
-                    "description": "AddRelation adds a relation between the specified endpoints and returns the relation info."
+                    }
                 },
                 "AddUnits": {
                     "type": "object",
@@ -1055,8 +1041,7 @@
                         "Result": {
                             "$ref": "#/definitions/AddApplicationUnitsResults"
                         }
-                    },
-                    "description": "AddUnits adds a given number of units to an application."
+                    }
                 },
                 "ApplicationsInfo": {
                     "type": "object",
@@ -1067,8 +1052,7 @@
                         "Result": {
                             "$ref": "#/definitions/ApplicationInfoResults"
                         }
-                    },
-                    "description": "ApplicationsInfo returns applications information."
+                    }
                 },
                 "CharmConfig": {
                     "type": "object",
@@ -1079,8 +1063,7 @@
                         "Result": {
                             "$ref": "#/definitions/ApplicationGetConfigResults"
                         }
-                    },
-                    "description": "CharmConfig returns charm config for the input list of applications."
+                    }
                 },
                 "CharmRelations": {
                     "type": "object",
@@ -1091,8 +1074,7 @@
                         "Result": {
                             "$ref": "#/definitions/ApplicationCharmRelationsResults"
                         }
-                    },
-                    "description": "CharmRelations implements the server side of Application.CharmRelations."
+                    }
                 },
                 "Consume": {
                     "type": "object",
@@ -1103,8 +1085,7 @@
                         "Result": {
                             "$ref": "#/definitions/ErrorResults"
                         }
-                    },
-                    "description": "Consume adds remote applications to the model without creating any\nrelations."
+                    }
                 },
                 "Deploy": {
                     "type": "object",
@@ -1115,8 +1096,7 @@
                         "Result": {
                             "$ref": "#/definitions/ErrorResults"
                         }
-                    },
-                    "description": "Deploy fetches the charms from the charm store and deploys them\nusing the specified placement directives."
+                    }
                 },
                 "DeployFromRepository": {
                     "type": "object",
@@ -1127,8 +1107,7 @@
                         "Result": {
                             "$ref": "#/definitions/DeployFromRepositoryResults"
                         }
-                    },
-                    "description": "DeployFromRepository is a one-stop deployment method for repository\ncharms. Only a charm name is required to deploy. If argument validation\nfails, a list of all errors found in validation will be returned. If a\nlocal resource is provided, details required for uploading the validated\nresource will be returned."
+                    }
                 },
                 "DestroyApplication": {
                     "type": "object",
@@ -1139,8 +1118,7 @@
                         "Result": {
                             "$ref": "#/definitions/DestroyApplicationResults"
                         }
-                    },
-                    "description": "DestroyApplication removes a given set of applications."
+                    }
                 },
                 "DestroyConsumedApplications": {
                     "type": "object",
@@ -1151,8 +1129,7 @@
                         "Result": {
                             "$ref": "#/definitions/ErrorResults"
                         }
-                    },
-                    "description": "DestroyConsumedApplications removes a given set of consumed (remote) applications."
+                    }
                 },
                 "DestroyRelation": {
                     "type": "object",
@@ -1160,8 +1137,7 @@
                         "Params": {
                             "$ref": "#/definitions/DestroyRelation"
                         }
-                    },
-                    "description": "DestroyRelation removes the relation between the\nspecified endpoints or an id."
+                    }
                 },
                 "DestroyUnit": {
                     "type": "object",
@@ -1172,8 +1148,7 @@
                         "Result": {
                             "$ref": "#/definitions/DestroyUnitResults"
                         }
-                    },
-                    "description": "DestroyUnit removes a given set of application units."
+                    }
                 },
                 "Expose": {
                     "type": "object",
@@ -1181,8 +1156,7 @@
                         "Params": {
                             "$ref": "#/definitions/ApplicationExpose"
                         }
-                    },
-                    "description": "Expose changes the juju-managed firewall to expose any ports that\nwere also explicitly marked by units as open."
+                    }
                 },
                 "Get": {
                     "type": "object",
@@ -1193,8 +1167,7 @@
                         "Result": {
                             "$ref": "#/definitions/ApplicationGetResults"
                         }
-                    },
-                    "description": "Get returns the charm configuration for an application."
+                    }
                 },
                 "GetCharmURLOrigin": {
                     "type": "object",
@@ -1205,8 +1178,7 @@
                         "Result": {
                             "$ref": "#/definitions/CharmURLOriginResult"
                         }
-                    },
-                    "description": "GetCharmURLOrigin returns the charm URL and charm origin the given\napplication is running at present."
+                    }
                 },
                 "GetConfig": {
                     "type": "object",
@@ -1217,8 +1189,7 @@
                         "Result": {
                             "$ref": "#/definitions/ApplicationGetConfigResults"
                         }
-                    },
-                    "description": "GetConfig returns the charm config for each of the input applications."
+                    }
                 },
                 "GetConstraints": {
                     "type": "object",
@@ -1229,8 +1200,7 @@
                         "Result": {
                             "$ref": "#/definitions/ApplicationGetConstraintsResults"
                         }
-                    },
-                    "description": "GetConstraints returns the constraints for a given application."
+                    }
                 },
                 "Leader": {
                     "type": "object",
@@ -1241,8 +1211,7 @@
                         "Result": {
                             "$ref": "#/definitions/StringResult"
                         }
-                    },
-                    "description": "Leader returns the unit name of the leader for the given application."
+                    }
                 },
                 "MergeBindings": {
                     "type": "object",
@@ -1253,8 +1222,7 @@
                         "Result": {
                             "$ref": "#/definitions/ErrorResults"
                         }
-                    },
-                    "description": "MergeBindings merges operator-defined bindings with the current bindings for\none or more applications."
+                    }
                 },
                 "ResolveUnitErrors": {
                     "type": "object",
@@ -1265,8 +1233,7 @@
                         "Result": {
                             "$ref": "#/definitions/ErrorResults"
                         }
-                    },
-                    "description": "ResolveUnitErrors marks errors on the specified units as resolved."
+                    }
                 },
                 "ScaleApplications": {
                     "type": "object",
@@ -1277,8 +1244,7 @@
                         "Result": {
                             "$ref": "#/definitions/ScaleApplicationResults"
                         }
-                    },
-                    "description": "ScaleApplications scales the specified application to the requested number of units."
+                    }
                 },
                 "SetCharm": {
                     "type": "object",
@@ -1286,8 +1252,7 @@
                         "Params": {
                             "$ref": "#/definitions/ApplicationSetCharmV2"
                         }
-                    },
-                    "description": "SetCharm sets the charm for a given for the application."
+                    }
                 },
                 "SetConfigs": {
                     "type": "object",
@@ -1298,8 +1263,7 @@
                         "Result": {
                             "$ref": "#/definitions/ErrorResults"
                         }
-                    },
-                    "description": "SetConfigs implements the server side of Application.SetConfig.  Both\napplication and charm config are set. It does not unset values in\nConfig map that are set to an empty string. Unset should be used for that."
+                    }
                 },
                 "SetConstraints": {
                     "type": "object",
@@ -1307,8 +1271,7 @@
                         "Params": {
                             "$ref": "#/definitions/SetConstraints"
                         }
-                    },
-                    "description": "SetConstraints sets the constraints for a given application."
+                    }
                 },
                 "SetRelationsSuspended": {
                     "type": "object",
@@ -1319,8 +1282,7 @@
                         "Result": {
                             "$ref": "#/definitions/ErrorResults"
                         }
-                    },
-                    "description": "SetRelationsSuspended sets the suspended status of the specified relations."
+                    }
                 },
                 "Unexpose": {
                     "type": "object",
@@ -1328,8 +1290,7 @@
                         "Params": {
                             "$ref": "#/definitions/ApplicationUnexpose"
                         }
-                    },
-                    "description": "Unexpose changes the juju-managed firewall to unexpose any ports that\nwere also explicitly marked by units as open."
+                    }
                 },
                 "UnitsInfo": {
                     "type": "object",
@@ -1340,8 +1301,7 @@
                         "Result": {
                             "$ref": "#/definitions/UnitInfoResults"
                         }
-                    },
-                    "description": "UnitsInfo returns unit information for the given entities (units or\napplications)."
+                    }
                 },
                 "UnsetApplicationsConfig": {
                     "type": "object",
@@ -1352,8 +1312,7 @@
                         "Result": {
                             "$ref": "#/definitions/ErrorResults"
                         }
-                    },
-                    "description": "UnsetApplicationsConfig implements the server side of Application.UnsetApplicationsConfig."
+                    }
                 }
             },
             "definitions": {
@@ -3299,7 +3258,7 @@
     },
     {
         "Name": "ApplicationOffers",
-        "Description": "OffersAPIv5 implements the cross model interface and is the concrete\nimplementation of the api end point.",
+        "Description": "",
         "Version": 5,
         "AvailableTo": [
             "controller-machine-agent",
@@ -3319,8 +3278,7 @@
                         "Result": {
                             "$ref": "#/definitions/ApplicationOffersResults"
                         }
-                    },
-                    "description": "ApplicationOffers gets details about remote applications that match given URLs."
+                    }
                 },
                 "DestroyOffers": {
                     "type": "object",
@@ -3331,8 +3289,7 @@
                         "Result": {
                             "$ref": "#/definitions/ErrorResults"
                         }
-                    },
-                    "description": "DestroyOffers removes the offers specified by the given URLs, forcing if necessary."
+                    }
                 },
                 "FindApplicationOffers": {
                     "type": "object",
@@ -3343,8 +3300,7 @@
                         "Result": {
                             "$ref": "#/definitions/QueryApplicationOffersResultsV5"
                         }
-                    },
-                    "description": "FindApplicationOffers gets details about remote applications that match given filter."
+                    }
                 },
                 "GetConsumeDetails": {
                     "type": "object",
@@ -3355,8 +3311,7 @@
                         "Result": {
                             "$ref": "#/definitions/ConsumeOfferDetailsResults"
                         }
-                    },
-                    "description": "GetConsumeDetails returns the details necessary to pass to another model\nto allow the specified args user to consume the offers represented by the args URLs."
+                    }
                 },
                 "ListApplicationOffers": {
                     "type": "object",
@@ -3367,8 +3322,7 @@
                         "Result": {
                             "$ref": "#/definitions/QueryApplicationOffersResultsV5"
                         }
-                    },
-                    "description": "ListApplicationOffers gets deployed details about application offers that match given filter.\nThe results contain details about the deployed applications such as connection count."
+                    }
                 },
                 "ModifyOfferAccess": {
                     "type": "object",
@@ -3379,8 +3333,7 @@
                         "Result": {
                             "$ref": "#/definitions/ErrorResults"
                         }
-                    },
-                    "description": "ModifyOfferAccess changes the application offer access granted to users."
+                    }
                 },
                 "Offer": {
                     "type": "object",
@@ -3391,8 +3344,7 @@
                         "Result": {
                             "$ref": "#/definitions/ErrorResults"
                         }
-                    },
-                    "description": "Offer makes application endpoints available for consumption at a specified URL."
+                    }
                 },
                 "RemoteApplicationInfo": {
                     "type": "object",
@@ -3403,8 +3355,7 @@
                         "Result": {
                             "$ref": "#/definitions/RemoteApplicationInfoResults"
                         }
-                    },
-                    "description": "RemoteApplicationInfo returns information about the requested remote application.\nThis call currently has no client side API, only there for the Dashboard at this stage."
+                    }
                 }
             },
             "definitions": {
@@ -4081,7 +4032,7 @@
     },
     {
         "Name": "Backups",
-        "Description": "API provides backup-specific API methods.",
+        "Description": "",
         "Version": 3,
         "AvailableTo": [
             "controller-machine-agent",
@@ -4101,8 +4052,7 @@
                         "Result": {
                             "$ref": "#/definitions/BackupsMetadataResult"
                         }
-                    },
-                    "description": "Create is the API method that requests juju to create a new backup\nof its state."
+                    }
                 }
             },
             "definitions": {
@@ -4242,7 +4192,7 @@
     },
     {
         "Name": "Block",
-        "Description": "API implements Block interface and is the concrete\nimplementation of the api end point.",
+        "Description": "",
         "Version": 2,
         "AvailableTo": [
             "model-user"
@@ -4256,8 +4206,7 @@
                         "Result": {
                             "$ref": "#/definitions/BlockResults"
                         }
-                    },
-                    "description": "List implements Block.List()."
+                    }
                 },
                 "SwitchBlockOff": {
                     "type": "object",
@@ -4268,8 +4217,7 @@
                         "Result": {
                             "$ref": "#/definitions/ErrorResult"
                         }
-                    },
-                    "description": "SwitchBlockOff implements Block.SwitchBlockOff()."
+                    }
                 },
                 "SwitchBlockOn": {
                     "type": "object",
@@ -4280,8 +4228,7 @@
                         "Result": {
                             "$ref": "#/definitions/ErrorResult"
                         }
-                    },
-                    "description": "SwitchBlockOn implements Block.SwitchBlockOn()."
+                    }
                 }
             },
             "definitions": {
@@ -4389,7 +4336,7 @@
     },
     {
         "Name": "Bundle",
-        "Description": "APIv8 provides the Bundle API facade for version 8. It drops IncludeSeries\nfrom ExportBundle params, and drops series entirely from ExportBundle output",
+        "Description": "",
         "Version": 8,
         "AvailableTo": [
             "controller-machine-agent",
@@ -4410,8 +4357,7 @@
                         "Result": {
                             "$ref": "#/definitions/StringResult"
                         }
-                    },
-                    "description": "ExportBundle exports the current model configuration as bundle."
+                    }
                 },
                 "GetChangesMapArgs": {
                     "type": "object",
@@ -4422,8 +4368,7 @@
                         "Result": {
                             "$ref": "#/definitions/BundleChangesMapArgsResults"
                         }
-                    },
-                    "description": "GetChangesMapArgs returns the list of changes required to deploy the given\nbundle data. The changes are sorted by requirements, so that they can be\napplied in order.\nV4 GetChangesMapArgs is not supported on anything less than v4"
+                    }
                 }
             },
             "definitions": {
@@ -4548,7 +4493,7 @@
     },
     {
         "Name": "Charms",
-        "Description": "APIv7 provides the Charms API facade for version 7.",
+        "Description": "",
         "Version": 7,
         "AvailableTo": [
             "model-user"
@@ -4565,8 +4510,7 @@
                         "Result": {
                             "$ref": "#/definitions/CharmOriginResult"
                         }
-                    },
-                    "description": "AddCharm adds the given charm URL (which must include revision) to the\nenvironment, if it does not exist yet. Local charms are not supported,\nonly charm store and charm hub URLs. See also AddLocalCharm()."
+                    }
                 },
                 "CharmInfo": {
                     "type": "object",
@@ -4577,8 +4521,7 @@
                         "Result": {
                             "$ref": "#/definitions/Charm"
                         }
-                    },
-                    "description": "CharmInfo returns information about the requested charm."
+                    }
                 },
                 "CheckCharmPlacement": {
                     "type": "object",
@@ -4589,8 +4532,7 @@
                         "Result": {
                             "$ref": "#/definitions/ErrorResults"
                         }
-                    },
-                    "description": "CheckCharmPlacement checks if a charm is allowed to be placed with in a\ngiven application."
+                    }
                 },
                 "GetDownloadInfos": {
                     "type": "object",
@@ -4601,8 +4543,7 @@
                         "Result": {
                             "$ref": "#/definitions/DownloadInfoResults"
                         }
-                    },
-                    "description": "GetDownloadInfos attempts to get the bundle corresponding to the charm url\nand origin."
+                    }
                 },
                 "List": {
                     "type": "object",
@@ -4613,8 +4554,7 @@
                         "Result": {
                             "$ref": "#/definitions/CharmsListResult"
                         }
-                    },
-                    "description": "List returns a list of charm URLs currently in the state. If supplied\nparameter contains any names, the result will be filtered to return only the\ncharms with supplied names. The order of the charms is not guaranteed to be\nthe same as the order of the names passed in."
+                    }
                 },
                 "ListCharmResources": {
                     "type": "object",
@@ -4625,8 +4565,7 @@
                         "Result": {
                             "$ref": "#/definitions/CharmResourcesResults"
                         }
-                    },
-                    "description": "ListCharmResources returns a series of resources for a given charm."
+                    }
                 },
                 "ResolveCharms": {
                     "type": "object",
@@ -4637,8 +4576,7 @@
                         "Result": {
                             "$ref": "#/definitions/ResolveCharmWithChannelResults"
                         }
-                    },
-                    "description": "ResolveCharms resolves the given charm URLs with an optionally specified\npreferred channel.  Channel provided via CharmOrigin."
+                    }
                 }
             },
             "definitions": {
@@ -5605,7 +5543,7 @@
     },
     {
         "Name": "Client",
-        "Description": "Client serves client-specific API methods.",
+        "Description": "",
         "Version": 8,
         "AvailableTo": [
             "model-user"
@@ -5622,8 +5560,7 @@
                         "Result": {
                             "$ref": "#/definitions/FullStatus"
                         }
-                    },
-                    "description": "FullStatus gives the information needed for juju status over the api"
+                    }
                 },
                 "StatusHistory": {
                     "type": "object",
@@ -5634,8 +5571,7 @@
                         "Result": {
                             "$ref": "#/definitions/StatusHistoryResults"
                         }
-                    },
-                    "description": "StatusHistory returns a slice of past statuses for several entities."
+                    }
                 },
                 "WatchAll": {
                     "type": "object",
@@ -5643,8 +5579,7 @@
                         "Result": {
                             "$ref": "#/definitions/AllWatcherId"
                         }
-                    },
-                    "description": "WatchAll initiates a watcher for entities in the connected model."
+                    }
                 }
             },
             "definitions": {
@@ -6889,7 +6824,7 @@
     },
     {
         "Name": "Cloud",
-        "Description": "CloudAPI implements the cloud interface and is the concrete implementation\nof the api end point.",
+        "Description": "",
         "Version": 7,
         "AvailableTo": [
             "controller-machine-agent",
@@ -6906,8 +6841,7 @@
                         "Params": {
                             "$ref": "#/definitions/AddCloudArgs"
                         }
-                    },
-                    "description": "AddCloud adds a new cloud, different from the one managed by the controller."
+                    }
                 },
                 "AddCredentials": {
                     "type": "object",
@@ -6918,8 +6852,7 @@
                         "Result": {
                             "$ref": "#/definitions/ErrorResults"
                         }
-                    },
-                    "description": "AddCredentials adds new credentials.\nIn contrast to UpdateCredentials() below, the new credentials can be\nfor a cloud that the controller does not manage (this is required\nfor CAAS models)"
+                    }
                 },
                 "Cloud": {
                     "type": "object",
@@ -6930,8 +6863,7 @@
                         "Result": {
                             "$ref": "#/definitions/CloudResults"
                         }
-                    },
-                    "description": "Cloud returns the cloud definitions for the specified clouds."
+                    }
                 },
                 "CloudInfo": {
                     "type": "object",
@@ -6942,8 +6874,7 @@
                         "Result": {
                             "$ref": "#/definitions/CloudInfoResults"
                         }
-                    },
-                    "description": "CloudInfo returns information about the specified clouds."
+                    }
                 },
                 "Clouds": {
                     "type": "object",
@@ -6951,8 +6882,7 @@
                         "Result": {
                             "$ref": "#/definitions/CloudsResult"
                         }
-                    },
-                    "description": "Clouds returns the definitions of all clouds supported by the controller\nthat the logged in user can see."
+                    }
                 },
                 "Credential": {
                     "type": "object",
@@ -6963,8 +6893,7 @@
                         "Result": {
                             "$ref": "#/definitions/CloudCredentialResults"
                         }
-                    },
-                    "description": "Credential returns the specified cloud credential for each tag, minus secrets."
+                    }
                 },
                 "CredentialContents": {
                     "type": "object",
@@ -6975,8 +6904,7 @@
                         "Result": {
                             "$ref": "#/definitions/CredentialContentResults"
                         }
-                    },
-                    "description": "CredentialContents returns the specified cloud credentials,\nincluding the secrets if requested.\nIf no specific credential name/cloud was passed in, all credentials for this user\nare returned.\nOnly credential owner can see its contents as well as what models use it.\nController admin has no special superpowers here and is treated the same as all other users."
+                    }
                 },
                 "ListCloudInfo": {
                     "type": "object",
@@ -6987,8 +6915,7 @@
                         "Result": {
                             "$ref": "#/definitions/ListCloudInfoResults"
                         }
-                    },
-                    "description": "ListCloudInfo returns clouds that the specified user has access to.\nController admins (superuser) can list clouds for any user.\nOther users can only ask about their own clouds."
+                    }
                 },
                 "ModifyCloudAccess": {
                     "type": "object",
@@ -6999,8 +6926,7 @@
                         "Result": {
                             "$ref": "#/definitions/ErrorResults"
                         }
-                    },
-                    "description": "ModifyCloudAccess changes the model access granted to users."
+                    }
                 },
                 "RemoveClouds": {
                     "type": "object",
@@ -7011,8 +6937,7 @@
                         "Result": {
                             "$ref": "#/definitions/ErrorResults"
                         }
-                    },
-                    "description": "RemoveClouds removes the specified clouds from the controller.\nIf a cloud is in use (has models deployed to it), the removal will fail."
+                    }
                 },
                 "RevokeCredentialsCheckModels": {
                     "type": "object",
@@ -7023,8 +6948,7 @@
                         "Result": {
                             "$ref": "#/definitions/ErrorResults"
                         }
-                    },
-                    "description": "RevokeCredentialsCheckModels revokes a set of cloud credentials.\nIf the credentials are used by any of the models, the credential deletion will be aborted.\nIf credential-in-use needs to be revoked nonetheless, this method allows the use of force."
+                    }
                 },
                 "UpdateCloud": {
                     "type": "object",
@@ -7035,8 +6959,7 @@
                         "Result": {
                             "$ref": "#/definitions/ErrorResults"
                         }
-                    },
-                    "description": "UpdateCloud updates an existing cloud that the controller knows about."
+                    }
                 },
                 "UpdateCredentialsCheckModels": {
                     "type": "object",
@@ -7047,8 +6970,7 @@
                         "Result": {
                             "$ref": "#/definitions/UpdateCredentialResults"
                         }
-                    },
-                    "description": "UpdateCredentialsCheckModels updates a set of cloud credentials' content.\nIf there are any models that are using a credential and these models\nare not going to be visible with updated credential content,\nthere will be detailed validation errors per model.  Such model errors are returned\nseparately and do not contribute to the overall method error status.\nController admins can 'force' an update of the credential\nregardless of whether it is deemed valid or not."
+                    }
                 },
                 "UserCredentials": {
                     "type": "object",
@@ -7059,8 +6981,7 @@
                         "Result": {
                             "$ref": "#/definitions/StringsResults"
                         }
-                    },
-                    "description": "UserCredentials returns the cloud credentials for a set of users."
+                    }
                 }
             },
             "definitions": {
@@ -7862,7 +7783,7 @@
     },
     {
         "Name": "Controller",
-        "Description": "ControllerAPI provides the Controller API.",
+        "Description": "",
         "Version": 12,
         "AvailableTo": [
             "controller-machine-agent",
@@ -7879,8 +7800,7 @@
                         "Result": {
                             "$ref": "#/definitions/UserModelList"
                         }
-                    },
-                    "description": "AllModels allows controller administrators to get the list of all the\nmodels in the controller."
+                    }
                 },
                 "CloudSpec": {
                     "type": "object",
@@ -7891,8 +7811,7 @@
                         "Result": {
                             "$ref": "#/definitions/CloudSpecResults"
                         }
-                    },
-                    "description": "CloudSpec returns the model's cloud spec."
+                    }
                 },
                 "ConfigSet": {
                     "type": "object",
@@ -7900,8 +7819,7 @@
                         "Params": {
                             "$ref": "#/definitions/ControllerConfigSet"
                         }
-                    },
-                    "description": "ConfigSet changes the value of specified controller configuration\nsettings. Only some settings can be changed after bootstrap.\nSettings that aren't specified in the params are left unchanged."
+                    }
                 },
                 "ControllerAPIInfoForModels": {
                     "type": "object",
@@ -7912,8 +7830,7 @@
                         "Result": {
                             "$ref": "#/definitions/ControllerAPIInfoResults"
                         }
-                    },
-                    "description": "ControllerAPIInfoForModels returns the controller api connection details for the specified models."
+                    }
                 },
                 "ControllerConfig": {
                     "type": "object",
@@ -7921,8 +7838,7 @@
                         "Result": {
                             "$ref": "#/definitions/ControllerConfigResult"
                         }
-                    },
-                    "description": "ControllerConfig returns the controller's configuration."
+                    }
                 },
                 "ControllerVersion": {
                     "type": "object",
@@ -7930,8 +7846,7 @@
                         "Result": {
                             "$ref": "#/definitions/ControllerVersionResults"
                         }
-                    },
-                    "description": "ControllerVersion returns the version information associated with this\ncontroller binary.\n\nNOTE: the implementation intentionally does not check for SuperuserAccess\nas the Version is known even to users with login access."
+                    }
                 },
                 "DashboardConnectionInfo": {
                     "type": "object",
@@ -7939,8 +7854,7 @@
                         "Result": {
                             "$ref": "#/definitions/DashboardConnectionInfo"
                         }
-                    },
-                    "description": "DashboardConnectionInfo returns the connection information for a client to\nconnect to the Juju Dashboard including any proxying information."
+                    }
                 },
                 "DestroyController": {
                     "type": "object",
@@ -7948,8 +7862,7 @@
                         "Params": {
                             "$ref": "#/definitions/DestroyControllerArgs"
                         }
-                    },
-                    "description": "DestroyController destroys the controller.\n\nIf the args specify the destruction of the models, this method will\nattempt to do so. Otherwise, if the controller has any non-empty,\nnon-Dead hosted models, then an error with the code\nparams.CodeHasHostedModels will be transmitted."
+                    }
                 },
                 "GetCloudSpec": {
                     "type": "object",
@@ -7960,8 +7873,7 @@
                         "Result": {
                             "$ref": "#/definitions/CloudSpecResult"
                         }
-                    },
-                    "description": "GetCloudSpec constructs the CloudSpec for a validated and authorized model."
+                    }
                 },
                 "GetControllerAccess": {
                     "type": "object",
@@ -7972,8 +7884,7 @@
                         "Result": {
                             "$ref": "#/definitions/UserAccessResults"
                         }
-                    },
-                    "description": "GetControllerAccess returns the level of access the specified users\nhave on the controller."
+                    }
                 },
                 "HostedModelConfigs": {
                     "type": "object",
@@ -7981,8 +7892,7 @@
                         "Result": {
                             "$ref": "#/definitions/HostedModelConfigsResults"
                         }
-                    },
-                    "description": "HostedModelConfigs returns all the information that the client needs in\norder to connect directly with the host model's provider and destroy it\ndirectly."
+                    }
                 },
                 "IdentityProviderURL": {
                     "type": "object",
@@ -7990,8 +7900,7 @@
                         "Result": {
                             "$ref": "#/definitions/StringResult"
                         }
-                    },
-                    "description": "IdentityProviderURL returns the URL of the configured external identity\nprovider for this controller or an empty string if no external identity\nprovider has been configured when the controller was bootstrapped.\n\nNOTE: the implementation intentionally does not check for SuperuserAccess\nas the URL is known even to users with login access."
+                    }
                 },
                 "InitiateMigration": {
                     "type": "object",
@@ -8002,8 +7911,7 @@
                         "Result": {
                             "$ref": "#/definitions/InitiateMigrationResults"
                         }
-                    },
-                    "description": "InitiateMigration attempts to begin the migration of one or\nmore models to other controllers."
+                    }
                 },
                 "ListBlockedModels": {
                     "type": "object",
@@ -8011,8 +7919,7 @@
                         "Result": {
                             "$ref": "#/definitions/ModelBlockInfoList"
                         }
-                    },
-                    "description": "ListBlockedModels returns a list of all models on the controller\nwhich have a block in place.  The resulting slice is sorted by model\nname, then owner. Callers must be controller administrators to retrieve the\nlist."
+                    }
                 },
                 "ModelStatus": {
                     "type": "object",
@@ -8023,8 +7930,7 @@
                         "Result": {
                             "$ref": "#/definitions/ModelStatusResults"
                         }
-                    },
-                    "description": "ModelStatus returns a summary of the model."
+                    }
                 },
                 "ModifyControllerAccess": {
                     "type": "object",
@@ -8035,8 +7941,7 @@
                         "Result": {
                             "$ref": "#/definitions/ErrorResults"
                         }
-                    },
-                    "description": "ModifyControllerAccess changes the model access granted to users."
+                    }
                 },
                 "MongoVersion": {
                     "type": "object",
@@ -8044,8 +7949,7 @@
                         "Result": {
                             "$ref": "#/definitions/StringResult"
                         }
-                    },
-                    "description": "MongoVersion allows the introspection of the mongo version per controller"
+                    }
                 },
                 "RemoveBlocks": {
                     "type": "object",
@@ -8053,8 +7957,7 @@
                         "Params": {
                             "$ref": "#/definitions/RemoveBlocksArgs"
                         }
-                    },
-                    "description": "RemoveBlocks removes all the blocks in the controller."
+                    }
                 },
                 "WatchAllModelSummaries": {
                     "type": "object",
@@ -8062,8 +7965,7 @@
                         "Result": {
                             "$ref": "#/definitions/SummaryWatcherID"
                         }
-                    },
-                    "description": "WatchAllModelSummaries starts watching the summary updates from the cache.\nThis method is superuser access only, and watches all models in the\ncontroller."
+                    }
                 },
                 "WatchAllModels": {
                     "type": "object",
@@ -8071,8 +7973,7 @@
                         "Result": {
                             "$ref": "#/definitions/AllWatcherId"
                         }
-                    },
-                    "description": "WatchAllModels starts watching events for all models in the\ncontroller. The returned AllWatcherId should be used with Next on the\nAllModelWatcher endpoint to receive deltas."
+                    }
                 },
                 "WatchCloudSpecsChanges": {
                     "type": "object",
@@ -8083,8 +7984,7 @@
                         "Result": {
                             "$ref": "#/definitions/NotifyWatchResults"
                         }
-                    },
-                    "description": "WatchCloudSpecsChanges returns a watcher for cloud spec changes."
+                    }
                 },
                 "WatchModelSummaries": {
                     "type": "object",
@@ -8092,8 +7992,7 @@
                         "Result": {
                             "$ref": "#/definitions/SummaryWatcherID"
                         }
-                    },
-                    "description": "WatchModelSummaries starts watching the summary updates from the cache.\nOnly models that the user has access to are returned."
+                    }
                 }
             },
             "definitions": {
@@ -9073,8 +8972,7 @@
                         "Result": {
                             "$ref": "#/definitions/ErrorResult"
                         }
-                    },
-                    "description": "InvalidateModelCredential marks the cloud credential for this model as invalid."
+                    }
                 }
             },
             "definitions": {
@@ -9126,7 +9024,7 @@
     },
     {
         "Name": "HighAvailability",
-        "Description": "HighAvailabilityAPI implements the HighAvailability interface and is the concrete\nimplementation of the api end point.",
+        "Description": "",
         "Version": 3,
         "AvailableTo": [
             "controller-user",
@@ -9141,8 +9039,7 @@
                         "Result": {
                             "$ref": "#/definitions/ControllerDetailsResults"
                         }
-                    },
-                    "description": "ControllerDetails returns details about each controller node."
+                    }
                 },
                 "EnableHA": {
                     "type": "object",
@@ -9153,8 +9050,7 @@
                         "Result": {
                             "$ref": "#/definitions/ControllersChangeResults"
                         }
-                    },
-                    "description": "EnableHA adds controller machines as necessary to ensure the\ncontroller has the number of machines specified."
+                    }
                 }
             },
             "definitions": {
@@ -9381,7 +9277,7 @@
     },
     {
         "Name": "ImageMetadataManager",
-        "Description": "API is the concrete implementation of the API endpoint for cloud image\nmetadata manipulations.",
+        "Description": "",
         "Version": 1,
         "AvailableTo": [
             "controller-machine-agent",
@@ -9401,8 +9297,7 @@
                         "Result": {
                             "$ref": "#/definitions/ErrorResults"
                         }
-                    },
-                    "description": "Delete deletes cloud image metadata for given image ids.\nIt supports bulk calls."
+                    }
                 },
                 "List": {
                     "type": "object",
@@ -9413,8 +9308,7 @@
                         "Result": {
                             "$ref": "#/definitions/ListCloudImageMetadataResult"
                         }
-                    },
-                    "description": "List returns all found cloud image metadata that satisfy\ngiven filter.\nReturned list contains metadata ordered by priority."
+                    }
                 },
                 "Save": {
                     "type": "object",
@@ -9425,8 +9319,7 @@
                         "Result": {
                             "$ref": "#/definitions/ErrorResults"
                         }
-                    },
-                    "description": "Save stores given cloud image metadata.\nIt supports bulk calls."
+                    }
                 }
             },
             "definitions": {
@@ -9612,7 +9505,7 @@
     },
     {
         "Name": "KeyManager",
-        "Description": "KeyManagerAPI provides api endpoints for manipulating ssh keys",
+        "Description": "",
         "Version": 1,
         "AvailableTo": [
             "controller-machine-agent",
@@ -9632,8 +9525,7 @@
                         "Result": {
                             "$ref": "#/definitions/ErrorResults"
                         }
-                    },
-                    "description": "AddKeys adds new authorised ssh keys for the specified user."
+                    }
                 },
                 "DeleteKeys": {
                     "type": "object",
@@ -9644,8 +9536,7 @@
                         "Result": {
                             "$ref": "#/definitions/ErrorResults"
                         }
-                    },
-                    "description": "DeleteKeys deletes the authorised ssh keys for the specified user."
+                    }
                 },
                 "ImportKeys": {
                     "type": "object",
@@ -9656,8 +9547,7 @@
                         "Result": {
                             "$ref": "#/definitions/ErrorResults"
                         }
-                    },
-                    "description": "ImportKeys imports new authorised ssh keys from the specified key ids for the\nspecified user."
+                    }
                 },
                 "ListKeys": {
                     "type": "object",
@@ -9668,8 +9558,7 @@
                         "Result": {
                             "$ref": "#/definitions/StringsResults"
                         }
-                    },
-                    "description": "ListKeys returns the authorised ssh keys for the specified users."
+                    }
                 }
             },
             "definitions": {
@@ -9819,7 +9708,7 @@
     },
     {
         "Name": "MachineManager",
-        "Description": "MachineManagerAPI provides access to the MachineManager API facade.",
+        "Description": "",
         "Version": 11,
         "AvailableTo": [
             "controller-machine-agent",
@@ -9839,8 +9728,7 @@
                         "Result": {
                             "$ref": "#/definitions/AddMachinesResults"
                         }
-                    },
-                    "description": "AddMachines adds new machines with the supplied parameters.\nThe args will contain Base info."
+                    }
                 },
                 "DestroyMachineWithParams": {
                     "type": "object",
@@ -9851,8 +9739,7 @@
                         "Result": {
                             "$ref": "#/definitions/DestroyMachineResults"
                         }
-                    },
-                    "description": "DestroyMachineWithParams removes a set of machines from the model."
+                    }
                 },
                 "InstanceTypes": {
                     "type": "object",
@@ -9863,8 +9750,7 @@
                         "Result": {
                             "$ref": "#/definitions/InstanceTypesResults"
                         }
-                    },
-                    "description": "InstanceTypes returns instance type information for the cloud and region\nin which the current model is deployed."
+                    }
                 },
                 "ProvisioningScript": {
                     "type": "object",
@@ -9875,8 +9761,7 @@
                         "Result": {
                             "$ref": "#/definitions/ProvisioningScriptResult"
                         }
-                    },
-                    "description": "ProvisioningScript returns a shell script that, when run,\nprovisions a machine agent on the machine executing the script."
+                    }
                 },
                 "RetryProvisioning": {
                     "type": "object",
@@ -9887,8 +9772,7 @@
                         "Result": {
                             "$ref": "#/definitions/ErrorResults"
                         }
-                    },
-                    "description": "RetryProvisioning marks a provisioning error as transient on the machines."
+                    }
                 }
             },
             "definitions": {
@@ -10483,7 +10367,7 @@
     },
     {
         "Name": "ModelConfig",
-        "Description": "ModelConfigAPI provides the base implementation of the methods.",
+        "Description": "",
         "Version": 4,
         "AvailableTo": [
             "controller-machine-agent",
@@ -10501,8 +10385,7 @@
                         "Result": {
                             "$ref": "#/definitions/GetConstraintsResults"
                         }
-                    },
-                    "description": "GetModelConstraints returns the constraints for the model."
+                    }
                 },
                 "GetModelSecretBackend": {
                     "type": "object",
@@ -10510,8 +10393,7 @@
                         "Result": {
                             "$ref": "#/definitions/StringResult"
                         }
-                    },
-                    "description": "GetModelSecretBackend returns the secret backend for the model,\nreturning an error satisfying [authentication.ErrorEntityMissingPermission] if the user does not have read access to the model,\nreturning [params.CodeModelNotFound] if the model does not exist."
+                    }
                 },
                 "ModelGet": {
                     "type": "object",
@@ -10519,8 +10401,7 @@
                         "Result": {
                             "$ref": "#/definitions/ModelConfigResults"
                         }
-                    },
-                    "description": "ModelGet implements the server-side part of the\nmodel-config CLI command."
+                    }
                 },
                 "ModelSet": {
                     "type": "object",
@@ -10528,8 +10409,7 @@
                         "Params": {
                             "$ref": "#/definitions/ModelSet"
                         }
-                    },
-                    "description": "ModelSet implements the server-side part of the\nset-model-config CLI command."
+                    }
                 },
                 "ModelUnset": {
                     "type": "object",
@@ -10537,8 +10417,7 @@
                         "Params": {
                             "$ref": "#/definitions/ModelUnset"
                         }
-                    },
-                    "description": "ModelUnset implements the server-side part of the set-model-config CLI command."
+                    }
                 },
                 "Sequences": {
                     "type": "object",
@@ -10546,8 +10425,7 @@
                         "Result": {
                             "$ref": "#/definitions/ModelSequencesResult"
                         }
-                    },
-                    "description": "Sequences returns the model's sequence names and next values."
+                    }
                 },
                 "SetModelConstraints": {
                     "type": "object",
@@ -10555,8 +10433,7 @@
                         "Params": {
                             "$ref": "#/definitions/SetConstraints"
                         }
-                    },
-                    "description": "SetModelConstraints sets the constraints for the model."
+                    }
                 },
                 "SetModelSecretBackend": {
                     "type": "object",
@@ -10567,8 +10444,7 @@
                         "Result": {
                             "$ref": "#/definitions/ErrorResult"
                         }
-                    },
-                    "description": "SetModelSecretBackend sets the secret backend for the model,\nreturning an error satisfying [authentication.ErrorEntityMissingPermission] if the user does not have write access to the model,\nreturning [params.CodeModelNotFound] if the model does not exist,\nreturning [params.CodeSecretBackendNotFound] if the secret backend does not exist,\nreturning [params.CodeSecretBackendNotValid] if the secret backend name is not valid."
+                    }
                 }
             },
             "definitions": {
@@ -10810,7 +10686,7 @@
     },
     {
         "Name": "ModelManager",
-        "Description": "ModelManagerAPI implements the model manager interface and is\nthe concrete implementation of the api end point.",
+        "Description": "",
         "Version": 10,
         "AvailableTo": [
             "controller-machine-agent",
@@ -10830,8 +10706,7 @@
                         "Result": {
                             "$ref": "#/definitions/ErrorResults"
                         }
-                    },
-                    "description": "ChangeModelCredential changes cloud credential reference for models.\nThese new cloud credentials must already exist on the controller."
+                    }
                 },
                 "CreateModel": {
                     "type": "object",
@@ -10842,8 +10717,7 @@
                         "Result": {
                             "$ref": "#/definitions/ModelInfo"
                         }
-                    },
-                    "description": "CreateModel creates a new model using the account and\nmodel config specified in the args."
+                    }
                 },
                 "DestroyModels": {
                     "type": "object",
@@ -10854,8 +10728,7 @@
                         "Result": {
                             "$ref": "#/definitions/ErrorResults"
                         }
-                    },
-                    "description": "DestroyModels will try to destroy the specified models.\nIf there is a block on destruction, this method will return an error.\nFrom ModelManager v7 onwards, DestroyModels gains 'force' and 'max-wait' parameters."
+                    }
                 },
                 "DumpModels": {
                     "type": "object",
@@ -10866,8 +10739,7 @@
                         "Result": {
                             "$ref": "#/definitions/StringResults"
                         }
-                    },
-                    "description": "DumpModels will export the models into the database agnostic\nrepresentation. The user needs to either be a controller admin, or have\nadmin privileges on the model itself."
+                    }
                 },
                 "DumpModelsDB": {
                     "type": "object",
@@ -10878,8 +10750,7 @@
                         "Result": {
                             "$ref": "#/definitions/MapResults"
                         }
-                    },
-                    "description": "DumpModelsDB will gather all documents from all model collections\nfor the specified model. The map result contains a map of collection\nnames to lists of documents represented as maps."
+                    }
                 },
                 "ListModelSummaries": {
                     "type": "object",
@@ -10890,8 +10761,7 @@
                         "Result": {
                             "$ref": "#/definitions/ModelSummaryResults"
                         }
-                    },
-                    "description": "ListModelSummaries returns models that the specified user\nhas access to in the current server.  Controller admins (superuser)\ncan list models for any user.  Other users\ncan only ask about their own models."
+                    }
                 },
                 "ListModels": {
                     "type": "object",
@@ -10902,8 +10772,7 @@
                         "Result": {
                             "$ref": "#/definitions/UserModelList"
                         }
-                    },
-                    "description": "ListModels returns the models that the specified user\nhas access to in the current server.  Controller admins (superuser)\ncan list models for any user.  Other users\ncan only ask about their own models."
+                    }
                 },
                 "ModelDefaultsForClouds": {
                     "type": "object",
@@ -10914,8 +10783,7 @@
                         "Result": {
                             "$ref": "#/definitions/ModelDefaultsResults"
                         }
-                    },
-                    "description": "ModelDefaultsForClouds returns the default config values for the specified\nclouds."
+                    }
                 },
                 "ModelInfo": {
                     "type": "object",
@@ -10926,8 +10794,7 @@
                         "Result": {
                             "$ref": "#/definitions/ModelInfoResults"
                         }
-                    },
-                    "description": "ModelInfo returns information about the specified models."
+                    }
                 },
                 "ModelStatus": {
                     "type": "object",
@@ -10938,8 +10805,7 @@
                         "Result": {
                             "$ref": "#/definitions/ModelStatusResults"
                         }
-                    },
-                    "description": "ModelStatus returns a summary of the model."
+                    }
                 },
                 "ModifyModelAccess": {
                     "type": "object",
@@ -10950,8 +10816,7 @@
                         "Result": {
                             "$ref": "#/definitions/ErrorResults"
                         }
-                    },
-                    "description": "ModifyModelAccess changes the model access granted to users."
+                    }
                 },
                 "SetModelDefaults": {
                     "type": "object",
@@ -10962,8 +10827,7 @@
                         "Result": {
                             "$ref": "#/definitions/ErrorResults"
                         }
-                    },
-                    "description": "SetModelDefaults writes new values for the specified default model settings."
+                    }
                 },
                 "UnsetModelDefaults": {
                     "type": "object",
@@ -10974,8 +10838,7 @@
                         "Result": {
                             "$ref": "#/definitions/ErrorResults"
                         }
-                    },
-                    "description": "UnsetModelDefaults removes the specified default model settings."
+                    }
                 }
             },
             "definitions": {
@@ -12133,7 +11996,7 @@
     },
     {
         "Name": "ModelUpgrader",
-        "Description": "ModelUpgraderAPI implements the model upgrader interface and is\nthe concrete implementation of the api end point.",
+        "Description": "",
         "Version": 1,
         "AvailableTo": [
             "controller-user"
@@ -12147,8 +12010,7 @@
                         "Params": {
                             "$ref": "#/definitions/ModelParam"
                         }
-                    },
-                    "description": "AbortModelUpgrade returns not supported, as it's not possible to move\nback to a prior version."
+                    }
                 },
                 "UpgradeModel": {
                     "type": "object",
@@ -12159,8 +12021,7 @@
                         "Result": {
                             "$ref": "#/definitions/UpgradeModelResult"
                         }
-                    },
-                    "description": "UpgradeModel upgrades a model."
+                    }
                 }
             },
             "definitions": {
@@ -12274,7 +12135,7 @@
     },
     {
         "Name": "Payloads",
-        "Description": "API serves payload-specific API methods.",
+        "Description": "",
         "Version": 1,
         "AvailableTo": [
             "model-user"
@@ -12291,8 +12152,7 @@
                         "Result": {
                             "$ref": "#/definitions/PayloadListResults"
                         }
-                    },
-                    "description": "List builds the list of payloads being tracked for\nthe given unit and IDs. If no IDs are provided then all tracked\npayloads for the unit are returned."
+                    }
                 }
             },
             "definitions": {
@@ -12370,7 +12230,7 @@
     },
     {
         "Name": "Pinger",
-        "Description": "API serves pinger-specific API methods.",
+        "Description": "",
         "Version": 1,
         "AvailableTo": [
             "controller-machine-agent",
@@ -12383,19 +12243,17 @@
             "type": "object",
             "properties": {
                 "Ping": {
-                    "type": "object",
-                    "description": "Ping is used by the client heartbeat monitor and resets."
+                    "type": "object"
                 },
                 "Stop": {
-                    "type": "object",
-                    "description": "Stop stops the pinger."
+                    "type": "object"
                 }
             }
         }
     },
     {
         "Name": "Resources",
-        "Description": "API is the public API facade for resources.",
+        "Description": "",
         "Version": 3,
         "AvailableTo": [
             "model-user"
@@ -12412,8 +12270,7 @@
                         "Result": {
                             "$ref": "#/definitions/AddPendingResourcesResult"
                         }
-                    },
-                    "description": "AddPendingResources adds the provided resources (info) to the Juju\nmodel in a pending state, meaning they are not available until\nresolved. Handles CharmHub and Local charms."
+                    }
                 },
                 "ListResources": {
                     "type": "object",
@@ -12424,8 +12281,7 @@
                         "Result": {
                             "$ref": "#/definitions/ResourcesResults"
                         }
-                    },
-                    "description": "ListResources returns the list of resources for the given application."
+                    }
                 }
             },
             "definitions": {
@@ -12808,7 +12664,7 @@
     },
     {
         "Name": "SSHClient",
-        "Description": "Facade implements the API required by the sshclient worker.",
+        "Description": "",
         "Version": 4,
         "AvailableTo": [
             "controller-machine-agent",
@@ -12828,8 +12684,7 @@
                         "Result": {
                             "$ref": "#/definitions/SSHAddressesResults"
                         }
-                    },
-                    "description": "AllAddresses reports all addresses that might have SSH listening for each\nentity in args. The result is sorted with public addresses first.\nMachines and units are supported as entity types."
+                    }
                 },
                 "ModelCredentialForSSH": {
                     "type": "object",
@@ -12837,8 +12692,7 @@
                         "Result": {
                             "$ref": "#/definitions/CloudSpecResult"
                         }
-                    },
-                    "description": "ModelCredentialForSSH returns a cloud spec for ssh purpose.\nThis facade call is only used for k8s model."
+                    }
                 },
                 "PrivateAddress": {
                     "type": "object",
@@ -12849,8 +12703,7 @@
                         "Result": {
                             "$ref": "#/definitions/SSHAddressResults"
                         }
-                    },
-                    "description": "PrivateAddress reports the preferred private network address for one or\nmore entities. Machines and units are supported."
+                    }
                 },
                 "Proxy": {
                     "type": "object",
@@ -12858,8 +12711,7 @@
                         "Result": {
                             "$ref": "#/definitions/SSHProxyResult"
                         }
-                    },
-                    "description": "Proxy returns whether SSH connections should be proxied through the\ncontroller hosts for the model associated with the API connection."
+                    }
                 },
                 "PublicAddress": {
                     "type": "object",
@@ -12870,8 +12722,7 @@
                         "Result": {
                             "$ref": "#/definitions/SSHAddressResults"
                         }
-                    },
-                    "description": "PublicAddress reports the preferred public network address for one\nor more entities. Machines and units are supported."
+                    }
                 },
                 "PublicKeys": {
                     "type": "object",
@@ -12882,8 +12733,7 @@
                         "Result": {
                             "$ref": "#/definitions/SSHPublicKeysResults"
                         }
-                    },
-                    "description": "PublicKeys returns the public SSH hosts for one or more\nentities. Machines and units are supported."
+                    }
                 }
             },
             "definitions": {
@@ -13127,7 +12977,7 @@
     },
     {
         "Name": "SecretBackends",
-        "Description": "SecretBackendsAPI is the server implementation for the SecretBackends facade.",
+        "Description": "",
         "Version": 1,
         "AvailableTo": [
             "controller-user"
@@ -13144,8 +12994,7 @@
                         "Result": {
                             "$ref": "#/definitions/ErrorResults"
                         }
-                    },
-                    "description": "AddSecretBackends adds new secret backends."
+                    }
                 },
                 "ListSecretBackends": {
                     "type": "object",
@@ -13156,8 +13005,7 @@
                         "Result": {
                             "$ref": "#/definitions/ListSecretBackendsResults"
                         }
-                    },
-                    "description": "ListSecretBackends lists available secret backends."
+                    }
                 },
                 "RemoveSecretBackends": {
                     "type": "object",
@@ -13168,8 +13016,7 @@
                         "Result": {
                             "$ref": "#/definitions/ErrorResults"
                         }
-                    },
-                    "description": "RemoveSecretBackends removes secret backends."
+                    }
                 },
                 "UpdateSecretBackends": {
                     "type": "object",
@@ -13180,8 +13027,7 @@
                         "Result": {
                             "$ref": "#/definitions/ErrorResults"
                         }
-                    },
-                    "description": "UpdateSecretBackends updates secret backends."
+                    }
                 }
             },
             "definitions": {
@@ -13467,7 +13313,7 @@
     },
     {
         "Name": "Secrets",
-        "Description": "SecretsAPI is the backend for the Secrets facade.",
+        "Description": "",
         "Version": 2,
         "AvailableTo": [
             "model-user"
@@ -13484,8 +13330,7 @@
                         "Result": {
                             "$ref": "#/definitions/StringResults"
                         }
-                    },
-                    "description": "CreateSecrets creates new secrets."
+                    }
                 },
                 "GrantSecret": {
                     "type": "object",
@@ -13496,8 +13341,7 @@
                         "Result": {
                             "$ref": "#/definitions/ErrorResults"
                         }
-                    },
-                    "description": "GrantSecret grants access to a user secret."
+                    }
                 },
                 "ListSecrets": {
                     "type": "object",
@@ -13508,8 +13352,7 @@
                         "Result": {
                             "$ref": "#/definitions/ListSecretResults"
                         }
-                    },
-                    "description": "ListSecrets lists available secrets.\nIf args specifies secret owners, then only charm secrets are queried because user secret don't have owners as such.\nIf no owners are specified, we use the more generic list method when returns all types of secret."
+                    }
                 },
                 "RemoveSecrets": {
                     "type": "object",
@@ -13520,8 +13363,7 @@
                         "Result": {
                             "$ref": "#/definitions/ErrorResults"
                         }
-                    },
-                    "description": "RemoveSecrets remove user secret."
+                    }
                 },
                 "RevokeSecret": {
                     "type": "object",
@@ -13532,8 +13374,7 @@
                         "Result": {
                             "$ref": "#/definitions/ErrorResults"
                         }
-                    },
-                    "description": "RevokeSecret revokes access to a user secret."
+                    }
                 },
                 "UpdateSecrets": {
                     "type": "object",
@@ -13544,8 +13385,7 @@
                         "Result": {
                             "$ref": "#/definitions/ErrorResults"
                         }
-                    },
-                    "description": "UpdateSecrets updates user secrets."
+                    }
                 }
             },
             "definitions": {
@@ -14069,7 +13909,7 @@
     },
     {
         "Name": "Spaces",
-        "Description": "API provides the spaces API facade for version 6.",
+        "Description": "",
         "Version": 6,
         "AvailableTo": [
             "model-user"
@@ -14086,8 +13926,7 @@
                         "Result": {
                             "$ref": "#/definitions/ErrorResults"
                         }
-                    },
-                    "description": "CreateSpaces creates a new Juju network space, associating the\nspecified subnets with it (optional; can be empty)."
+                    }
                 },
                 "ListSpaces": {
                     "type": "object",
@@ -14095,8 +13934,7 @@
                         "Result": {
                             "$ref": "#/definitions/ListSpacesResults"
                         }
-                    },
-                    "description": "ListSpaces lists all the available spaces and their associated subnets."
+                    }
                 },
                 "MoveSubnets": {
                     "type": "object",
@@ -14107,12 +13945,10 @@
                         "Result": {
                             "$ref": "#/definitions/MoveSubnetsResults"
                         }
-                    },
-                    "description": "MoveSubnets ensures that the input subnets are in the input space."
+                    }
                 },
                 "ReloadSpaces": {
-                    "type": "object",
-                    "description": "ReloadSpaces refreshes spaces from substrate"
+                    "type": "object"
                 },
                 "RemoveSpace": {
                     "type": "object",
@@ -14123,8 +13959,7 @@
                         "Result": {
                             "$ref": "#/definitions/RemoveSpaceResults"
                         }
-                    },
-                    "description": "RemoveSpace removes a space.\nReturns SpaceResults if entities/settings are found which makes the deletion not possible."
+                    }
                 },
                 "RenameSpace": {
                     "type": "object",
@@ -14135,8 +13970,7 @@
                         "Result": {
                             "$ref": "#/definitions/ErrorResults"
                         }
-                    },
-                    "description": "RenameSpace renames a space."
+                    }
                 },
                 "ShowSpace": {
                     "type": "object",
@@ -14147,8 +13981,7 @@
                         "Result": {
                             "$ref": "#/definitions/ShowSpaceResults"
                         }
-                    },
-                    "description": "ShowSpace shows the spaces for a set of given entities."
+                    }
                 }
             },
             "definitions": {
@@ -14599,7 +14432,7 @@
     },
     {
         "Name": "Storage",
-        "Description": "StorageAPI implements the latest version (v6) of the Storage API.",
+        "Description": "",
         "Version": 6,
         "AvailableTo": [
             "controller-machine-agent",
@@ -14619,8 +14452,7 @@
                         "Result": {
                             "$ref": "#/definitions/AddStorageResults"
                         }
-                    },
-                    "description": "AddToUnit validates and creates additional storage instances for units.\nA \"CHANGE\" block can block this operation."
+                    }
                 },
                 "Attach": {
                     "type": "object",
@@ -14631,8 +14463,7 @@
                         "Result": {
                             "$ref": "#/definitions/ErrorResults"
                         }
-                    },
-                    "description": "Attach attaches existing storage instances to units.\nA \"CHANGE\" block can block this operation."
+                    }
                 },
                 "CreatePool": {
                     "type": "object",
@@ -14643,8 +14474,7 @@
                         "Result": {
                             "$ref": "#/definitions/ErrorResults"
                         }
-                    },
-                    "description": "CreatePool creates a new pool with specified parameters."
+                    }
                 },
                 "DetachStorage": {
                     "type": "object",
@@ -14655,8 +14485,7 @@
                         "Result": {
                             "$ref": "#/definitions/ErrorResults"
                         }
-                    },
-                    "description": "DetachStorage sets the specified storage attachments to Dying, unless they are\nalready Dying or Dead. Any associated, persistent storage will remain\nalive. This call can be forced."
+                    }
                 },
                 "Import": {
                     "type": "object",
@@ -14667,8 +14496,7 @@
                         "Result": {
                             "$ref": "#/definitions/ImportStorageResults"
                         }
-                    },
-                    "description": "Import imports existing storage into the model.\nA \"CHANGE\" block can block this operation."
+                    }
                 },
                 "ListFilesystems": {
                     "type": "object",
@@ -14679,8 +14507,7 @@
                         "Result": {
                             "$ref": "#/definitions/FilesystemDetailsListResults"
                         }
-                    },
-                    "description": "ListFilesystems returns a list of filesystems in the environment matching\nthe provided filter. Each result describes a filesystem in detail, including\nthe filesystem's attachments."
+                    }
                 },
                 "ListPools": {
                     "type": "object",
@@ -14691,8 +14518,7 @@
                         "Result": {
                             "$ref": "#/definitions/StoragePoolsResults"
                         }
-                    },
-                    "description": "ListPools returns a list of pools.\nIf filter is provided, returned list only contains pools that match\nthe filter.\nPools can be filtered on names and provider types.\nIf both names and types are provided as filter,\npools that match either are returned.\nThis method lists union of pools and environment provider types.\nIf no filter is provided, all pools are returned."
+                    }
                 },
                 "ListStorageDetails": {
                     "type": "object",
@@ -14703,8 +14529,7 @@
                         "Result": {
                             "$ref": "#/definitions/StorageDetailsListResults"
                         }
-                    },
-                    "description": "ListStorageDetails returns storage matching a filter."
+                    }
                 },
                 "ListVolumes": {
                     "type": "object",
@@ -14715,8 +14540,7 @@
                         "Result": {
                             "$ref": "#/definitions/VolumeDetailsListResults"
                         }
-                    },
-                    "description": "ListVolumes lists volumes with the given filters. Each filter produces\nan independent list of volumes, or an error if the filter is invalid\nor the volumes could not be listed."
+                    }
                 },
                 "Remove": {
                     "type": "object",
@@ -14727,8 +14551,7 @@
                         "Result": {
                             "$ref": "#/definitions/ErrorResults"
                         }
-                    },
-                    "description": "Remove sets the specified storage entities to Dying, unless they are\nalready Dying or Dead, such that the storage will eventually be removed\nfrom the model. If the arguments specify that the storage should be\ndestroyed, then the associated cloud storage will be destroyed first;\notherwise it will only be released from Juju's control."
+                    }
                 },
                 "RemovePool": {
                     "type": "object",
@@ -14739,8 +14562,7 @@
                         "Result": {
                             "$ref": "#/definitions/ErrorResults"
                         }
-                    },
-                    "description": "RemovePool deletes the named pool"
+                    }
                 },
                 "StorageDetails": {
                     "type": "object",
@@ -14751,8 +14573,7 @@
                         "Result": {
                             "$ref": "#/definitions/StorageDetailsResults"
                         }
-                    },
-                    "description": "StorageDetails retrieves and returns detailed information about desired\nstorage identified by supplied tags. If specified storage cannot be\nretrieved, individual error is returned instead of storage information."
+                    }
                 },
                 "UpdatePool": {
                     "type": "object",
@@ -14763,8 +14584,7 @@
                         "Result": {
                             "$ref": "#/definitions/ErrorResults"
                         }
-                    },
-                    "description": "UpdatePool deletes the named pool"
+                    }
                 }
             },
             "definitions": {
@@ -15733,7 +15553,7 @@
     },
     {
         "Name": "Subnets",
-        "Description": "API provides the subnets API facade for version 5.",
+        "Description": "",
         "Version": 5,
         "AvailableTo": [
             "controller-machine-agent",
@@ -15750,8 +15570,7 @@
                         "Result": {
                             "$ref": "#/definitions/ZoneResults"
                         }
-                    },
-                    "description": "AllZones returns all availability zones known to Juju. If a\nzone is unusable, unavailable, or deprecated the Available\nfield will be false."
+                    }
                 },
                 "ListSubnets": {
                     "type": "object",
@@ -15762,8 +15581,7 @@
                         "Result": {
                             "$ref": "#/definitions/ListSubnetsResults"
                         }
-                    },
-                    "description": "ListSubnets returns the matching subnets after applying\noptional filters."
+                    }
                 },
                 "SubnetsByCIDR": {
                     "type": "object",
@@ -15774,8 +15592,7 @@
                         "Result": {
                             "$ref": "#/definitions/SubnetsResults"
                         }
-                    },
-                    "description": "SubnetsByCIDR returns the collection of subnets matching each CIDR in the input."
+                    }
                 }
             },
             "definitions": {
@@ -16008,7 +15825,7 @@
     },
     {
         "Name": "UserManager",
-        "Description": "UserManagerAPI implements the user manager interface and is the concrete\nimplementation of the api end point.",
+        "Description": "",
         "Version": 3,
         "AvailableTo": [
             "controller-user"
@@ -16025,8 +15842,7 @@
                         "Result": {
                             "$ref": "#/definitions/AddUserResults"
                         }
-                    },
-                    "description": "AddUser adds a user with a username, and either a password or\na randomly generated secret key which will be returned."
+                    }
                 },
                 "DisableUser": {
                     "type": "object",
@@ -16037,8 +15853,7 @@
                         "Result": {
                             "$ref": "#/definitions/ErrorResults"
                         }
-                    },
-                    "description": "DisableUser disables one or more users.  If the user is already disabled,\nthe action is considered a success."
+                    }
                 },
                 "EnableUser": {
                     "type": "object",
@@ -16049,8 +15864,7 @@
                         "Result": {
                             "$ref": "#/definitions/ErrorResults"
                         }
-                    },
-                    "description": "EnableUser enables one or more users.  If the user is already enabled,\nthe action is considered a success."
+                    }
                 },
                 "ModelUserInfo": {
                     "type": "object",
@@ -16061,8 +15875,7 @@
                         "Result": {
                             "$ref": "#/definitions/ModelUserInfoResults"
                         }
-                    },
-                    "description": "ModelUserInfo returns information on all users in the model."
+                    }
                 },
                 "RemoveUser": {
                     "type": "object",
@@ -16073,8 +15886,7 @@
                         "Result": {
                             "$ref": "#/definitions/ErrorResults"
                         }
-                    },
-                    "description": "RemoveUser permanently removes a user from the current controller for each\nentity provided. While the user is permanently removed we keep it's\ninformation around for auditing purposes.\nTODO(redir): Add information about getting deleted user information when we\nadd that capability."
+                    }
                 },
                 "ResetPassword": {
                     "type": "object",
@@ -16085,8 +15897,7 @@
                         "Result": {
                             "$ref": "#/definitions/AddUserResults"
                         }
-                    },
-                    "description": "ResetPassword resets password for supplied users by\ninvalidating current passwords (if any) and generating\nnew random secret keys which will be returned.\nUsers cannot reset their own password."
+                    }
                 },
                 "SetPassword": {
                     "type": "object",
@@ -16097,8 +15908,7 @@
                         "Result": {
                             "$ref": "#/definitions/ErrorResults"
                         }
-                    },
-                    "description": "SetPassword changes the stored password for the specified users."
+                    }
                 },
                 "UserInfo": {
                     "type": "object",
@@ -16109,8 +15919,7 @@
                         "Result": {
                             "$ref": "#/definitions/UserInfoResults"
                         }
-                    },
-                    "description": "UserInfo returns information on a user."
+                    }
                 }
             },
             "definitions": {

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -18,7 +18,7 @@ import (
 
 const yesNoMsg = "\nContinue [y/N]? "
 
-var nameVerificationMsg = "\nTo continue, enter the name of the %s to be destroyed: "
+var nameVerificationMsg = "\nTo continue, enter the name of the %s to be unregistered: "
 
 type userAbortedError string
 

--- a/cmd/juju/controller/unregister.go
+++ b/cmd/juju/controller/unregister.go
@@ -92,8 +92,8 @@ func (c *unregisterCommand) Init(args []string) error {
 
 var unregisterMsg = `
 This command will remove connection information for controller %q.
-Doing so will prevent you from accessing this controller until
-you register it again.
+The controller will not be destroyed but you must register it again
+if you want to access it.
 `[1:]
 
 func (c *unregisterCommand) Run(ctx *cmd.Context) error {

--- a/cmd/juju/controller/unregister_test.go
+++ b/cmd/juju/controller/unregister_test.go
@@ -84,10 +84,10 @@ func (s *UnregisterSuite) TestUnregisterController(c *gc.C) {
 
 var unregisterMsg = `
 This command will remove connection information for controller "fake1".
-Doing so will prevent you from accessing this controller until
-you register it again.
+The controller will not be destroyed but you must register it again
+if you want to access it.
 
-To continue, enter the name of the controller to be destroyed: `[1:]
+To continue, enter the name of the controller to be unregistered: `[1:]
 
 func (s *UnregisterSuite) unregisterCommandAborts(c *gc.C, answer string) {
 	var stdin, stderr bytes.Buffer

--- a/generate/schemagen/gen/package_test.go
+++ b/generate/schemagen/gen/package_test.go
@@ -4,13 +4,13 @@
 package gen_test
 
 import (
-	stdtesting "testing"
+	"testing"
 
 	gc "gopkg.in/check.v1"
 )
 
 //go:generate go run go.uber.org/mock/mockgen -typed -package gen -destination describeapi_mock.go -write_package_comment=false github.com/juju/juju/generate/schemagen/gen APIServer,Registry,PackageRegistry,Linker
 
-func TestPackage(t *stdtesting.T) {
+func TestPackage(t *testing.T) {
 	gc.TestingT(t)
 }

--- a/scripts/schema.bash
+++ b/scripts/schema.bash
@@ -2,11 +2,18 @@
 # Copyright 2019 Canonical Ltd.
 # Licensed under the AGPLv3, see LICENCE file for details.
 current_schema_sha=$(git show HEAD:apiserver/facades/schema.json | shasum -a 1 | awk '{ print $1 }')
-tmpfile=$(mktemp /tmp/schema-XXXXX)
+current_agentschema_sha=$(git show HEAD:apiserver/facades/agent-schema.json | shasum -a 1 | awk '{ print $1 }')
+tmpfile=$(mktemp -d /tmp/schema-XXXXX)
 make SCHEMA_PATH=$tmpfile rebuild-schema
-new_schema_sha=$(cat $tmpfile | shasum -a 1 | awk '{ print $1 }')
+new_schema_sha=$(cat $tmpfile/schema.json | shasum -a 1 | awk '{ print $1 }')
+new_agentschema_sha=$(cat $tmpfile/agent-schema.json | shasum -a 1 | awk '{ print $1 }')
 
 if [ $current_schema_sha != $new_schema_sha ]; then
-    (>&2 echo "Error: facades schema is not in sync. Run 'make rebuild-schema' and commit source.")
+    (>&2 echo "Error: client facades schema is not in sync. Run 'make rebuild-schema' and commit source.")
+    exit 1
+fi
+
+if [ $current_agentschema_sha != $new_agentschema_sha ]; then
+    (>&2 echo "Error: agent facades schema is not in sync. Run 'make rebuild-schema' and commit source.")
     exit 1
 fi

--- a/tests/suites/static_analysis/schema.sh
+++ b/tests/suites/static_analysis/schema.sh
@@ -1,8 +1,10 @@
 run_schema() {
-	TMP_ORIG=$(mktemp /tmp/schema-XXXXX)
-	git show "HEAD:apiserver/facades/schema.json" >"${TMP_ORIG}"
-	CUR_SHA=$(cat "${TMP_ORIG}" | shasum -a 1 | awk '{ print $1 }')
-	TMP=$(mktemp /tmp/schema-XXXXX)
+	TMP_ORIG=$(mktemp -d /tmp/schema-XXXXX)
+	git show "HEAD:apiserver/facades/schema.json" >"${TMP_ORIG}/schema.json"
+	CUR_SHA=$(cat "${TMP_ORIG}/schema.json" | shasum -a 1 | awk '{ print $1 }')
+	git show "HEAD:apiserver/facades/agent-schema.json" >"${TMP_ORIG}/agent-schema.json"
+	CUR_AGENT_SHA=$(cat "${TMP_ORIG}/agent-schema.json" | shasum -a 1 | awk '{ print $1 }')
+	TMP=$(mktemp -d /tmp/schema-XXXXX)
 	OUT=$(make --no-print-directory SCHEMA_PATH="${TMP}" rebuild-schema 2>&1)
 	OUT_CODE=$?
 	if [ $OUT_CODE -ne 0 ]; then
@@ -12,11 +14,18 @@ run_schema() {
 		exit 1
 	fi
 	# shellcheck disable=SC2002
-	NEW_SHA=$(cat "${TMP}" | shasum -a 1 | awk '{ print $1 }')
+	NEW_SHA=$(cat "${TMP}/schema.json" | shasum -a 1 | awk '{ print $1 }')
+	# shellcheck disable=SC2002
+	NEW_AGENT_SHA=$(cat "${TMP}/agent-schema.json" | shasum -a 1 | awk '{ print $1 }')
 
 	if [ "${CUR_SHA}" != "${NEW_SHA}" ]; then
-		(echo >&2 "\\nError: facades schema is not in sync. Run 'make rebuild-schema' and commit source.")
-		(>&2 diff "${TMP_ORIG}" "${TMP}")
+		(echo >&2 "\\nError: client facades schema is not in sync. Run 'make rebuild-schema' and commit source.")
+		(>&2 diff "${TMP_ORIG}/schema.json" "${TMP}/schema.json")
+		exit 1
+	fi
+	if [ "${CUR_AGENT_SHA}" != "${NEW_AGENT_SHA}" ]; then
+		(echo >&2 "\\nError: agent facades schema is not in sync. Run 'make rebuild-schema' and commit source.")
+		(>&2 diff "${TMP_ORIG}/agent-schema.json" "${TMP}/agent-schema.json")
 		exit 1
 	fi
 }


### PR DESCRIPTION
Merge up from 3.6 to main:
Contains: 
- #18408 from hpidcock
  - Conflicts:
  - CONFLICT (content): Merge conflict in Makefile
    - Added CGO and libsqlite3 options to go run
  - CONFLICT (content): Merge conflict in apiserver/facades/schema.json
    - regenerated after merge
  - CONFLICT (content): Merge conflict in generate/schemagen/gen/package_test.go
    - kept 3.6 simplification
  - CONFLICT (content): Merge conflict in generate/schemagen/schemagen.go
    - kept generation of agent-schema
  - CONFLICT (content): Merge conflict in tests/suites/static_analysis/schema.sh
    - switched to provide diff on failure for agent-schema as well
- #18376 from CodingCookieRookie

