### PR TITLE
fix: check errors outside of txn.

### DIFF
--- a/domain/modeldefaults/bootstrap/bootstrap.go
+++ b/domain/modeldefaults/bootstrap/bootstrap.go
@@ -95,7 +95,7 @@ func SetCloudDefaults(
 	cloudName string,
 	defaults map[string]any,
 ) internaldatabase.BootstrapOpt {
-	return func(ctx context.Context, controller, model database.TxnRunner) error {
+	return func(ctx context.Context, controller, _ database.TxnRunner) error {
 		strDefaults, err := modelconfigservice.CoerceConfigForStorage(defaults)
 		if err != nil {
 			return fmt.Errorf("coercing cloud %q default values for storage: %w", cloudName, err)

--- a/domain/modeldefaults/bootstrap/bootstrap.go
+++ b/domain/modeldefaults/bootstrap/bootstrap.go
@@ -88,7 +88,7 @@ func ModelDefaultsProvider(
 
 // SetCloudDefaults is responsible for setting a previously inserted cloud's
 // default config values that will be used as part of the default values
-// supplied to a models config. If no cloud exists for the specified name an
+// supplied to a model's config. If no cloud exists for the specified name an
 // error satisfying [github.com/juju/juju/domain/cloud/errors.NotFound] will be
 // returned.
 func SetCloudDefaults(

--- a/domain/modeldefaults/service/service.go
+++ b/domain/modeldefaults/service/service.go
@@ -57,8 +57,8 @@ type State interface {
 	// is returned.
 	UpdateCloudDefaults(ctx context.Context, cloudUID cloud.UUID, attrs map[string]string) error
 
-	// DeleteCloudDefaults will delete the specified default keys from the cloud
-	// if they exist. If the cloud does not exist an error satisfying
+	// DeleteCloudDefaults will delete the specified default config keys from
+	// the cloud if they exist. If the cloud does not exist an error satisfying
 	// [clouderrors.NotFound] will be returned.
 	DeleteCloudDefaults(ctx context.Context, cloudUID cloud.UUID, attrs []string) error
 
@@ -583,6 +583,15 @@ func coerceDefaultsToSchema(
 	providerFieldMap := schema.FieldMap(nil, nil)
 	if configProvider != nil {
 		providerSchema := configProvider.ConfigSchema()
+
+		// We are building a set of defaults here for each key that exists in
+		// the provider's schema set to [schema.Omit]. The reason for this is
+		// that [schema.FieldMap.Coerce] will try and apply defaults for key's
+		// that don't exist in the input.
+		//
+		// We don't want this to happen here. The purpose of this function is to
+		// fundamentally coerce the type we store the value in at a state level
+		// to that of the schema only if and when the key exists in the input.
 		omitDefaults := make(schema.Defaults, len(providerSchema))
 		for k := range providerSchema {
 			omitDefaults[k] = schema.Omit

--- a/domain/modeldefaults/state/state.go
+++ b/domain/modeldefaults/state/state.go
@@ -19,7 +19,6 @@ import (
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/internal/database"
 	"github.com/juju/juju/internal/errors"
-	interrors "github.com/juju/juju/internal/errors"
 )
 
 // State represents a type for interacting with the underlying model defaults
@@ -616,19 +615,19 @@ ON CONFLICT(region_uuid, key) DO UPDATE
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err := tx.Query(ctx, selectStmt, cld, region).Get(&region)
 		if errors.Is(err, sqlair.ErrNoRows) {
-			return interrors.Errorf(
+			return errors.Errorf(
 				"cloud %q region %q does not exist",
 				cloudUUID, regionName,
 			).Add(clouderrors.NotFound)
 		} else if err != nil {
-			return interrors.Errorf("fetching cloud %q region %q: %w", cloudUUID, regionName, err)
+			return errors.Errorf("fetching cloud %q region %q: %w", cloudUUID, regionName, err)
 		}
 
 		for k, v := range updateAttrs {
 			err := tx.Query(ctx, upsertStmt, cloudRegionDefaultValue{UUID: region.UUID, Key: k, Value: v}).Run()
 			// The cloud UUID has previously been checked. This allows us to avoid having to use RunAtomic.
 			if database.IsErrConstraintForeignKey(err) {
-				return interrors.Errorf("cloud %q not found", cloudUUID).Add(clouderrors.NotFound)
+				return errors.Errorf("cloud %q not found", cloudUUID).Add(clouderrors.NotFound)
 			} else if err != nil {
 				return errors.Capture(err)
 			}
@@ -636,7 +635,7 @@ ON CONFLICT(region_uuid, key) DO UPDATE
 		return nil
 	})
 	if err != nil {
-		return interrors.Errorf(
+		return errors.Errorf(
 			"updating cloud %q region %q default keys: %w",
 			cloudUUID,
 			regionName,


### PR DESCRIPTION
This commit is a followup to PR feedback for moving error handling for a state layer concern outside of the txn so that all error's can realistically be captured and annotated.

In response to #18367

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Unit tests are enough to validate this doesn't break contracts.

## Documentation changes
N/A

## Links

**Jira card:** JUJU-7145

