### PR TITLE
fix: add apt update to dependency install for docs workflow

### DIFF
--- a/.github/workflows/docs-sphinx-python-dependency-build-checks.yml
+++ b/.github/workflows/docs-sphinx-python-dependency-build-checks.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Install dependencies
         run: |
           set -ex
+          sudo apt -y update
           sudo apt -y install \
             cargo \
             libpython3-dev \


### PR DESCRIPTION
This workflow was taken from the documentation starter pack. The lack of an apt update meant that it could fail packages are updated in the archive as suggested by @hpidcock here https://github.com/juju/juju/pull/18313#discussion_r1855566903.

Add in an apt update to the workflow.

<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://docs.google.com/document/d/1SYUo9G7qZ_jdoVXpUVamS5VCgHmtZ0QA-wZxKoMS-C0 
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

## QA steps

Documentation workflows passes.

