### PR TITLE
chore: bump version to 3.6.1

### DIFF
--- a/scripts/win-installer/setup.iss
+++ b/scripts/win-installer/setup.iss
@@ -4,7 +4,7 @@
 #if GetEnv('JUJU_VERSION') != ""
 #define MyAppVersion=GetEnv('JUJU_VERSION')
 #else
-#define MyAppVersion="3.6-rc3"
+#define MyAppVersion="3.6.1"
 #endif
 
 #define MyAppName "Juju"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: juju
-version: 3.6-rc3
+version: 3.6.1
 summary: Juju - a model-driven operator lifecycle manager for K8s and machines
 license: AGPL-3.0
 description: |

--- a/version/version.go
+++ b/version/version.go
@@ -18,7 +18,7 @@ import (
 // The presence and format of this constant is very important.
 // The debian/rules build recipe uses this value for the version
 // number of the release package.
-const version = "3.6-rc3"
+const version = "3.6.1"
 
 // UserAgentVersion defines a user agent version used for communication for
 // outside resources.


### PR DESCRIPTION
With 3.6.0 being released, the in tree version is bumped to 3.6.1.
