### PR TITLE
ci: make docs build job periodic

### DIFF
--- a/.github/workflows/docs-sphinx-python-dependency-build-checks.yml
+++ b/.github/workflows/docs-sphinx-python-dependency-build-checks.yml
@@ -11,9 +11,9 @@
 # succeed.
 name: Check and document build requirements for Sphinx venv
 on:
-  - push
-  - pull_request
-  - workflow_dispatch
+  schedule:
+    - cron: "0 2 * * 0,3" # Runs at 02:00 AM on every Sunday and Wednesday.
+
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
This job was running on every push to every pull request. Make it periodic as its quite expensive.

<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://docs.google.com/document/d/1SYUo9G7qZ_jdoVXpUVamS5VCgHmtZ0QA-wZxKoMS-C0 
-->

<!-- Why this change is needed and what it does. -->

## QA steps

Check workflow when it runs. 
<!-- Describe steps to verify that the change works. -->
