### PR TITLE
fix(charm): local charm deploy fails due to bad source

### DIFF
--- a/apiserver/facades/client/application/application_get.go
+++ b/apiserver/facades/client/application/application_get.go
@@ -126,13 +126,20 @@ func (api *APIBase) getCharmID(ctx context.Context, charmURL string) (corecharm.
 		return "", errors.Annotate(err, "parsing charm URL")
 	}
 
+	charmSource, err := applicationcharm.ParseCharmSchema(charm.Schema(curl.Schema))
+	if err != nil {
+		return "", errors.Trace(err)
+	}
 	charmID, err := api.applicationService.GetCharmID(ctx, applicationcharm.GetCharmArgs{
 		Name:     curl.Name,
 		Revision: ptr(curl.Revision),
+		Source:   charmSource,
 	})
 	if errors.Is(err, applicationerrors.CharmNotFound) {
 		return "", errors.NotFoundf("charm %q", charmURL)
 	} else if errors.Is(err, applicationerrors.CharmNameNotValid) {
+		return "", errors.NotValidf("charm %q", charmURL)
+	} else if errors.Is(err, applicationerrors.CharmSourceNotValid) {
 		return "", errors.NotValidf("charm %q", charmURL)
 	} else if err != nil {
 		return "", errors.Annotate(err, "getting charm id")

--- a/apiserver/facades/client/application/package_test.go
+++ b/apiserver/facades/client/application/package_test.go
@@ -137,6 +137,7 @@ func (s *baseSuite) newAPI(c *gc.C, modelType model.ModelType) {
 		UUID: s.modelUUID,
 		Type: modelType,
 	}
+	s.deployApplication = DeployApplication
 
 	var err error
 	s.api, err = NewAPIBase(


### PR DESCRIPTION
At https://github.com/juju/juju/pull/18413 we introduced the Source when retrieving a charm ID, which was in turn needed to deploy. 
This small patch fixes the deploy of a local charm because the Source was not being injected on that code path.

<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://github.com/juju/juju/blob/main/doc/conventional-commits.md
-->

<!-- Why this change is needed and what it does. -->

## QA steps

Deploy a local charm:

```
$ juju download ubuntu
$ juju deploy ./ubuntu_r25.charm
$ juju status
Model  Controller  Cloud/Region         Version      Timestamp
m      c           localhost/localhost  4.0-beta5.1  15:22:38+01:00

App     Version  Status  Scale  Charm   Channel  Rev  Exposed  Message
ubuntu  24.04    active      1  ubuntu             0  no

Unit       Workload  Agent  Machine  Public address  Ports  Message
ubuntu/0*  active    idle   0        10.165.241.21

Machine  State    Address        Inst id        Base          AZ  Message
0        started  10.165.241.21  juju-bc520e-0  ubuntu@24.04      Running
```


## Links

**Jira card:** JUJU-6842

