### PR TITLE
fix: poor error message validating constraints

### DIFF
--- a/api/package_test.go
+++ b/api/package_test.go
@@ -55,6 +55,7 @@ func (*ImportSuite) TestImports(c *gc.C) {
 		"storage",
 		"tools",
 		"utils/proxy",
+		"utils/stringcompare",
 		"version",
 	})
 }

--- a/cmd/containeragent/initialize/package_test.go
+++ b/cmd/containeragent/initialize/package_test.go
@@ -108,6 +108,7 @@ func (*importSuite) TestImports(c *gc.C) {
 		"worker/apicaller",
 		"worker/introspection",
 		"worker/introspection/pprof",
+		"utils/stringcompare",
 	)
 
 	unexpected := found.Difference(expected)

--- a/cmd/juju/waitfor/errors.go
+++ b/cmd/juju/waitfor/errors.go
@@ -13,6 +13,7 @@ import (
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/cmd/juju/waitfor/query"
+	"github.com/juju/juju/utils/stringcompare"
 )
 
 func HelpDisplay(err error, input string, idents []string) error {
@@ -195,7 +196,7 @@ func orderPotentialMatches(name string, possible []string) (string, []string, bo
 	for _, ident := range possible {
 		matches = append(matches, Indexed{
 			Name:  ident,
-			Value: levenshteinDistance(name, ident),
+			Value: stringcompare.LevenshteinDistance(name, ident),
 		})
 	}
 	// Find the smallest levenshtein distance. If two values are the same,
@@ -283,41 +284,4 @@ func runtimeSyntaxErrDisplay(err error, input string) error {
 	}
 
 	return fmt.Errorf(builder.String())
-}
-
-// levenshteinDistance
-// from https://groups.google.com/forum/#!topic/golang-nuts/YyH1f_qCZVc
-// (no min, compute lengths once, 2 rows array)
-// fastest profiled
-func levenshteinDistance(a, b string) int {
-	la := len(a)
-	lb := len(b)
-	d := make([]int, la+1)
-	var lastdiag, olddiag, temp int
-
-	for i := 1; i <= la; i++ {
-		d[i] = i
-	}
-	for i := 1; i <= lb; i++ {
-		d[0] = i
-		lastdiag = i - 1
-		for j := 1; j <= la; j++ {
-			olddiag = d[j]
-			min := d[j] + 1
-			if (d[j-1] + 1) < min {
-				min = d[j-1] + 1
-			}
-			if a[j-1] == b[i-1] {
-				temp = 0
-			} else {
-				temp = 1
-			}
-			if (lastdiag + temp) < min {
-				min = lastdiag + temp
-			}
-			d[j] = min
-			lastdiag = olddiag
-		}
-	}
-	return d[la]
 }

--- a/core/cache/package_test.go
+++ b/core/cache/package_test.go
@@ -195,6 +195,7 @@ func (*ImportSuite) TestImports(c *gc.C) {
 		"core/permission",
 		"core/settings",
 		"core/status",
+		"utils/stringcompare",
 	})
 }
 

--- a/core/constraints/package_test.go
+++ b/core/constraints/package_test.go
@@ -23,11 +23,12 @@ var _ = gc.Suite(&ImportTest{})
 func (*ImportTest) TestImports(c *gc.C) {
 	found := coretesting.FindJujuCoreImports(c, "github.com/juju/juju/core/constraints")
 
-	// This package should only depend on other core packages.
+	// This package should only depend on the core packages and the utils/stringcompare package.
 	// If this test fails with a non-core package, please check the dependencies.
 	c.Assert(found, jc.SameContents, []string{
 		"core/arch",
 		"core/instance",
 		"core/status",
+		"utils/stringcompare",
 	})
 }

--- a/core/multiwatcher/package_test.go
+++ b/core/multiwatcher/package_test.go
@@ -34,5 +34,6 @@ func (*ImportTest) TestImports(c *gc.C) {
 		"core/network",
 		"core/permission",
 		"core/status",
+		"utils/stringcompare",
 	})
 }

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -1882,11 +1882,11 @@ func (s *environSuite) TestConstraintsValidatorVocabulary(c *gc.C) {
 	validator := s.constraintsValidator(c)
 	_, err := validator.Validate(constraints.MustParse("arch=s390x"))
 	c.Assert(err, gc.ErrorMatches,
-		"invalid constraint value: arch=s390x\nvalid values are: \\[amd64\\]",
+		"invalid constraint value: arch=s390x\nvalid values are: amd64",
 	)
 	_, err = validator.Validate(constraints.MustParse("instance-type=t1.micro"))
 	c.Assert(err, gc.ErrorMatches,
-		"invalid constraint value: instance-type=t1.micro\nvalid values are: \\[A1 D1 D2 Standard_A1 Standard_D1 Standard_D2\\]",
+		"invalid constraint value: instance-type=t1.micro\nvalid values are: A1 D1 D2 Standard_A1 Standard_D1 Standard_D2",
 	)
 }
 

--- a/provider/lxd/environ_policy_test.go
+++ b/provider/lxd/environ_policy_test.go
@@ -219,7 +219,7 @@ func (s *environPolicySuite) TestConstraintsValidatorVocabArchUnknown(c *gc.C) {
 	cons := constraints.MustParse("arch=ppc64el")
 	_, err = validator.Validate(cons)
 
-	c.Check(err, gc.ErrorMatches, "invalid constraint value: arch=ppc64el\nvalid values are: \\[amd64\\]")
+	c.Check(err, gc.ErrorMatches, "invalid constraint value: arch=ppc64el\nvalid values are: amd64")
 }
 
 func (s *environPolicySuite) TestConstraintsValidatorVocabContainerUnknown(c *gc.C) {

--- a/provider/maas/maas_environ_whitebox_test.go
+++ b/provider/maas/maas_environ_whitebox_test.go
@@ -2654,7 +2654,7 @@ func (suite *maasEnvironSuite) TestConstraintsValidatorVocab(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	cons := constraints.MustParse("arch=ppc64el")
 	_, err = validator.Validate(cons)
-	c.Assert(err, gc.ErrorMatches, "invalid constraint value: arch=ppc64el\nvalid values are: \\[amd64 arm64\\]")
+	c.Assert(err, gc.ErrorMatches, "invalid constraint value: arch=ppc64el\nvalid values are: amd64 arm64")
 }
 
 func (suite *maasEnvironSuite) TestReleaseContainerAddresses(c *gc.C) {

--- a/provider/openstack/local_test.go
+++ b/provider/openstack/local_test.go
@@ -1610,7 +1610,7 @@ func (s *localServerSuite) TestConstraintsValidatorVocab(c *gc.C) {
 
 	cons = constraints.MustParse("virt-type=foo")
 	_, err = validator.Validate(cons)
-	c.Assert(err, gc.ErrorMatches, regexp.QuoteMeta("invalid constraint value: virt-type=foo\nvalid values are: [kvm lxd]"))
+	c.Assert(err, gc.ErrorMatches, regexp.QuoteMeta("invalid constraint value: virt-type=foo\nvalid values are: kvm lxd"))
 }
 
 func (s *localServerSuite) TestConstraintsMerge(c *gc.C) {

--- a/state/constraintsvalidation_test.go
+++ b/state/constraintsvalidation_test.go
@@ -293,7 +293,7 @@ func (s *applicationConstraintsSuite) TestAddApplicationInvalidConstraints(c *gc
 		Charm:       s.testCharm,
 		Constraints: cons,
 	})
-	c.Assert(errors.Cause(err), gc.ErrorMatches, regexp.QuoteMeta("invalid constraint value: virt-type=blah\nvalid values are: [kvm]"))
+	c.Assert(errors.Cause(err), gc.ErrorMatches, regexp.QuoteMeta("invalid constraint value: virt-type=blah\nvalid values are: kvm"))
 }
 
 func (s *applicationConstraintsSuite) TestAddApplicationValidConstraints(c *gc.C) {

--- a/utils/stringcompare/package_test.go
+++ b/utils/stringcompare/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package stringcompare
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/utils/stringcompare/stringcomparator.go
+++ b/utils/stringcompare/stringcomparator.go
@@ -1,0 +1,46 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package stringcompare
+
+// LevenshteinDistance calculates the Levenshtein distance between strings a and b.
+//
+// The Levenshtein distance is a measure of the minimum number of
+// single-character edits (insertions, deletions, or substitutions)
+// required to transform one string into the other.
+//
+// Adapted from a Golang implementation shared on https://groups.google.com/forum/#!topic/golang-nuts/YyH1f_qCZVc
+//
+// Returns the computed Levenshtein distance as an integer.
+func LevenshteinDistance(a, b string) int {
+	la := len(a)
+	lb := len(b)
+	d := make([]int, la+1)
+	var lastdiag, olddiag, temp int
+
+	for i := 1; i <= la; i++ {
+		d[i] = i
+	}
+	for i := 1; i <= lb; i++ {
+		d[0] = i
+		lastdiag = i - 1
+		for j := 1; j <= la; j++ {
+			olddiag = d[j]
+			min := d[j] + 1
+			if (d[j-1] + 1) < min {
+				min = d[j-1] + 1
+			}
+			if a[j-1] == b[i-1] {
+				temp = 0
+			} else {
+				temp = 1
+			}
+			if (lastdiag + temp) < min {
+				min = lastdiag + temp
+			}
+			d[j] = min
+			lastdiag = olddiag
+		}
+	}
+	return d[la]
+}

--- a/utils/stringcompare/stringcomparator_test.go
+++ b/utils/stringcompare/stringcomparator_test.go
@@ -1,0 +1,39 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package stringcompare_test
+
+import (
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/utils/stringcompare"
+)
+
+type StringComparatorSuite struct{}
+
+var _ = gc.Suite(&StringComparatorSuite{})
+
+func (*StringComparatorSuite) TestLevenshteinDistance(c *gc.C) {
+	testCases := []struct {
+		input1, input2 string
+		expectedResult int
+		desc           string
+	}{
+		{"", "", 0, "both strings are empty"},
+		{"", "abc", 3, "first string is empty"},
+		{"abc", "", 3, "second string is empty"},
+		{"abc", "abc", 0, "both strings are identical"},
+		{"abc", "def", 3, "completely different strings"},
+		{"fly", "cry", 2, "simple case with substitutions"},
+		{"playing", "sharing", 3, "normal case with substitutions and insertions"},
+		{"distance", "editing", 5, "more complex strings with multiple edits"},
+		{"aaaaaaaaaaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbbbbbbbbbb", 24, "long strings"},
+		{"à", "à", 0, "similar unicode strings"},
+	}
+
+	for _, tc := range testCases {
+		c.Check(stringcompare.LevenshteinDistance(tc.input1, tc.input2), gc.Equals, tc.expectedResult,
+			gc.Commentf("Description: %s | Inputs: '%s', '%s'", tc.desc, tc.input1, tc.input2),
+		)
+	}
+}


### PR DESCRIPTION
The error message for validating 'instance-type' currently contains numerous duplicates, is highly verbose, and lacks sorting. This update will address these issues by sorting the values, removing duplicates, and providing the closest match when the list of valid constraint values exceeds 10.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
~~- [ ] Comments saying why design decisions were made~~
- [x] Go unit tests, with comments saying what you're testing
~~- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~~
~~- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~~

## QA steps

 1. Bootstrap a 3.5 controller and deploy a charm with an invalid constraint.
```sh
$ juju bootstrap aws test
$ juju add-model test
$ deploy postgresql --constraints instance-type=t2.tiny
```

## Links

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/1926351

**Jira card:** https://warthogs.atlassian.net/browse/JUJU-7217
