### PR TITLE
refactor: rewrite secret watcher tests using harness

### DIFF
--- a/core/watcher/watchertest/watcher.go
+++ b/core/watcher/watchertest/watcher.go
@@ -46,6 +46,25 @@ func StringSliceAssert[T string](expect ...T) WatcherAssert[[]T] {
 	}
 }
 
+// SecretTriggerSliceAssert returns a WatcherAssert that checks that the watcher has
+// received at least the given []watcher.SecretTriggerChange changes. The changes are
+// concatenated before the assertion, order doesn't matter during assertion.
+func SecretTriggerSliceAssert[T watcher.SecretTriggerChange](expect ...T) WatcherAssert[[]T] {
+	return func(c *gc.C, changes [][]T) bool {
+		var received []T
+		for _, change := range changes {
+			received = append(received, change...)
+		}
+		if len(received) >= len(expect) {
+			mc := jc.NewMultiChecker()
+			mc.AddExpr(`_[_].NextTriggerTime`, jc.Almost, jc.ExpectedValue)
+			c.Assert(received, mc, expect)
+			return true
+		}
+		return false
+	}
+}
+
 // WatcherC embeds a gocheck.C and adds methods to help
 // verify the behaviour of generic watchers.
 type WatcherC[T any] struct {


### PR DESCRIPTION
This PR rewrites the secret watcher tests using the harness test helper.
It also added a new assert helper SecretTriggerSliceAssert to check the SecretTriggerChange.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

unit tests

## Documentation changes

No

## Links

No
