### PR TITLE
test: fix teardown race

### DIFF
--- a/internal/worker/caasfirewaller/package_test.go
+++ b/internal/worker/caasfirewaller/package_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/worker/v4"
 	"github.com/juju/worker/v4/catacomb"
+	"go.uber.org/goleak"
 	gc "gopkg.in/check.v1"
 )
 
@@ -20,6 +21,8 @@ import (
 //go:generate go run go.uber.org/mock/mockgen -typed -package mocks -destination mocks/services_mocks.go github.com/juju/juju/internal/services ModelDomainServices
 
 func TestAll(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
 	gc.TestingT(t)
 }
 

--- a/internal/worker/caasfirewaller/worker.go
+++ b/internal/worker/caasfirewaller/worker.go
@@ -125,6 +125,7 @@ func (p *firewaller) loop() error {
 		select {
 		case <-p.catacomb.Dying():
 			return p.catacomb.ErrDying()
+
 		case apps, ok := <-w.Changes():
 			if !ok {
 				return errors.New("watcher closed channel")


### PR DESCRIPTION
The watcher wasn't correctly cleaned up on teardown, which leaked the goroutine. This meant that the next time it came around it would cause a race in the teardown logic.

I've reworked all the tests to sequence the tests to ensure that no goroutines are leaked.

----

This pull request includes several changes to improve the `caasfirewaller` worker tests and add leak detection. The most important changes include adding the `goleak` package for leak detection, refactoring the `workerSuite` setup and teardown methods, and improving the reliability of tests by adding timeouts and synchronization channels.

### Leak Detection:
* [`internal/worker/caasfirewaller/package_test.go`](diffhunk://#diff-8b4229dfffd1182bc69aeb76e021fe406fc398ad6433f1cfc8f61effeee9970aR12): Added the `goleak` package to detect goroutine leaks and included `goleak.VerifyNone(t)` in the `TestAll` function. [[1]](diffhunk://#diff-8b4229dfffd1182bc69aeb76e021fe406fc398ad6433f1cfc8f61effeee9970aR12) [[2]](diffhunk://#diff-8b4229dfffd1182bc69aeb76e021fe406fc398ad6433f1cfc8f61effeee9970aR24-R25)

### Test Refactoring:
* [`internal/worker/caasfirewaller/worker_test.go`](diffhunk://#diff-40143fdd31e12cccb15f6d891e5977d76d83bf850f25d3f3918aa6b7dd185dbdL40-R49): Refactored the `workerSuite` setup and teardown methods by removing `SetUpTest` and `TearDownTest`, and consolidating the mock setup into a new `setupMocks` method. [[1]](diffhunk://#diff-40143fdd31e12cccb15f6d891e5977d76d83bf850f25d3f3918aa6b7dd185dbdL40-R49) [[2]](diffhunk://#diff-40143fdd31e12cccb15f6d891e5977d76d83bf850f25d3f3918aa6b7dd185dbdL124-R101)

### Test Reliability:
* [`internal/worker/caasfirewaller/worker_test.go`](diffhunk://#diff-40143fdd31e12cccb15f6d891e5977d76d83bf850f25d3f3918aa6b7dd185dbdR126-R127): Improved the reliability of tests by adding timeouts and synchronization channels to ensure tests do not hang indefinitely. [[1]](diffhunk://#diff-40143fdd31e12cccb15f6d891e5977d76d83bf850f25d3f3918aa6b7dd185dbdR126-R127) [[2]](diffhunk://#diff-40143fdd31e12cccb15f6d891e5977d76d83bf850f25d3f3918aa6b7dd185dbdL186-R297)

### Minor Code Cleanup:
* [`internal/worker/caasfirewaller/worker.go`](diffhunk://#diff-eac26f49000c6abf7cf74f802698895bfba91e83df3224d4bc996b6abb9a689aR128): Added a missing newline in the `loop` function for better readability.

## QA steps

This is just a test composition change.
