### PR TITLE
refactor: change retrived_by to added_by

### DIFF
--- a/domain/application/errors/errors.go
+++ b/domain/application/errors/errors.go
@@ -144,9 +144,9 @@ const (
 	// not oci-image or file.
 	UnknownResourceType = errors.ConstError("unknown resource type")
 
-	// UnknownRetrievedByType describes an error where the retrieved by type is
+	// UnknownAddedByByType describes an error where the added by type is
 	// neither user, unit nor application.
-	UnknownRetrievedByType = errors.ConstError("unknown retrieved by type")
+	UnknownAddedByByType = errors.ConstError("unknown added by type")
 
 	// ResourceNameNotValid describes an error where the resource name is not
 	// valid, usually because it's empty.

--- a/domain/application/resource/types.go
+++ b/domain/application/resource/types.go
@@ -63,7 +63,7 @@ type ApplicationResources struct {
 // populated before an upload (whether local or from the charm store).
 // In that case the following fields are not set:
 //
-//	Timestamp, RetrievedBy, RetrievedByType
+//	Timestamp, AddedBy, AddedByType
 //
 // For "upload" placeholders, the following additional fields are
 // not set:
@@ -78,29 +78,29 @@ type Resource struct {
 	// ApplicationID identifies the application for the resource.
 	ApplicationID application.ID
 
-	// RetrievedBy is the name of who added the resource to the controller.
+	// AddedBy is the name of who added the resource to the controller.
 	// The name is a username if the resource is uploaded from the cli
 	// by a specific user. If the resource is downloaded from a repository,
 	// the ID of the unit which triggered the download is used.
-	RetrievedBy string
+	AddedBy string
 
-	// RetrievedByType indicates what type of value the RetrievedBy name is:
+	// AddedByType indicates what type of value the AddedBy name is:
 	// application, username or unit.
-	RetrievedByType RetrievedByType
+	AddedByType AddedByType
 
 	// Timestamp indicates when this resource was added to the model in
 	// the case of applications or when this resource was loaded by a unit.
 	Timestamp time.Time
 }
 
-// RetrievedByType indicates what the RetrievedBy name represents.
-type RetrievedByType string
+// AddedByType indicates what the AddedBy name represents.
+type AddedByType string
 
 const (
-	Unknown     RetrievedByType = "unknown"
-	Application RetrievedByType = "application"
-	Unit        RetrievedByType = "unit"
-	User        RetrievedByType = "user"
+	Unknown     AddedByType = "unknown"
+	Application AddedByType = "application"
+	Unit        AddedByType = "unit"
+	User        AddedByType = "user"
 )
 
 // UnitResources contains the list of resources used by a unit.
@@ -121,20 +121,20 @@ type GetApplicationResourceIDArgs struct {
 
 // SetResourceArgs holds the arguments for the SetResource method.
 type SetResourceArgs struct {
-	ApplicationID  application.ID
-	SuppliedBy     string
-	SuppliedByType RetrievedByType
-	Resource       resource.Resource
-	Reader         io.Reader
-	Increment      IncrementCharmModifiedVersionType
+	ApplicationID application.ID
+	AddedBy       string
+	AddedByType   AddedByType
+	Resource      resource.Resource
+	Reader        io.Reader
+	Increment     IncrementCharmModifiedVersionType
 }
 
 // SetUnitResourceArgs holds the arguments for the SetUnitResource method.
 type SetUnitResourceArgs struct {
-	ResourceUUID    coreresource.UUID
-	RetrievedBy     string
-	RetrievedByType RetrievedByType
-	UnitUUID        unit.UUID
+	ResourceUUID coreresource.UUID
+	AddedBy      string
+	AddedByType  AddedByType
+	UnitUUID     unit.UUID
 }
 
 // SetUnitResourceResult is the result data from setting a unit's resource.

--- a/domain/application/service/resource.go
+++ b/domain/application/service/resource.go
@@ -148,8 +148,8 @@ func (s *Service) GetResource(
 // The following error types can be expected to be returned:
 //   - errors.NotValid is returned if the application ID is not valid.
 //   - errors.NotValid is returned if the resource is not valid.
-//   - errors.NotValid is returned if the RetrievedByType is unknown while
-//     RetrievedBy has a value.
+//   - errors.NotValid is returned if the AddedByType is unknown while
+//     AddedBy has a value.
 //   - application.ApplicationNotFound if the specified application does
 //     not exist.
 func (s *Service) SetResource(
@@ -159,9 +159,9 @@ func (s *Service) SetResource(
 	if err := args.ApplicationID.Validate(); err != nil {
 		return resource.Resource{}, fmt.Errorf("application id: %w", err)
 	}
-	if args.SuppliedBy != "" && args.SuppliedByType == resource.Unknown {
+	if args.AddedBy != "" && args.AddedByType == resource.Unknown {
 		return resource.Resource{},
-			fmt.Errorf("%w RetrievedByType cannot be unknown if RetrievedBy set", errors.NotValid)
+			fmt.Errorf("%w AddedByType cannot be unknown if AddedBy set", errors.NotValid)
 	}
 	if err := args.Resource.Validate(); err != nil {
 		return resource.Resource{}, fmt.Errorf("resource: %w", err)
@@ -174,8 +174,8 @@ func (s *Service) SetResource(
 // The following error types can be expected to be returned:
 //   - [errors.NotValid] is returned if the unit UUID is not valid.
 //   - [errors.NotValid] is returned if the resource UUID is not valid.
-//   - [errors.NotValid] is returned if the RetrievedByType is unknown while
-//     RetrievedBy has a value.
+//   - [errors.NotValid] is returned if the AddedByType is unknown while
+//     AddedBy has a value.
 //   - [applicationerrors.ResourceNotFound] if the specified resource doesn't exist
 //   - [applicationerrors.UnitNotFound] if the specified unit doesn't exist
 func (s *Service) SetUnitResource(
@@ -188,9 +188,9 @@ func (s *Service) SetUnitResource(
 	if err := args.ResourceUUID.Validate(); err != nil {
 		return resource.SetUnitResourceResult{}, fmt.Errorf("resource id: %w", err)
 	}
-	if args.RetrievedBy != "" && args.RetrievedByType == resource.Unknown {
+	if args.AddedBy != "" && args.AddedByType == resource.Unknown {
 		return resource.SetUnitResourceResult{},
-			fmt.Errorf("%w RetrievedByType cannot be unknown if RetrievedBy set", errors.NotValid)
+			fmt.Errorf("%w AddedByType cannot be unknown if AddedBy set", errors.NotValid)
 	}
 	return s.st.SetUnitResource(ctx, args)
 }

--- a/domain/application/service/resource_test.go
+++ b/domain/application/service/resource_test.go
@@ -69,8 +69,8 @@ func (s *resourceServiceSuite) TestListResources(c *gc.C) {
 	id := applicationtesting.GenApplicationUUID(c)
 	expectedList := resource.ApplicationResources{
 		Resources: []resource.Resource{{
-			RetrievedBy:     "admin",
-			RetrievedByType: resource.Application,
+			AddedBy:     "admin",
+			AddedByType: resource.Application,
 		}},
 	}
 	s.state.EXPECT().ListResources(gomock.Any(), id).Return(expectedList, nil)
@@ -91,8 +91,8 @@ func (s *resourceServiceSuite) TestGetResource(c *gc.C) {
 
 	id := resourcestesting.GenResourceUUID(c)
 	expectedRes := resource.Resource{
-		RetrievedBy:     "admin",
-		RetrievedByType: resource.Application,
+		AddedBy:     "admin",
+		AddedByType: resource.Application,
 	}
 	s.state.EXPECT().GetResource(gomock.Any(), id).Return(expectedRes, nil)
 
@@ -115,9 +115,9 @@ func (s *resourceServiceSuite) TestSetResource(c *gc.C) {
 	fp, err := charmresource.NewFingerprint(fingerprint)
 	c.Assert(err, jc.ErrorIsNil)
 	args := resource.SetResourceArgs{
-		ApplicationID:  applicationtesting.GenApplicationUUID(c),
-		SuppliedBy:     "admin",
-		SuppliedByType: resource.User,
+		ApplicationID: applicationtesting.GenApplicationUUID(c),
+		AddedBy:       "admin",
+		AddedByType:   resource.User,
 		Resource: charmresource.Resource{
 			Meta: charmresource.Meta{
 				Name:        "my-resource",
@@ -134,8 +134,8 @@ func (s *resourceServiceSuite) TestSetResource(c *gc.C) {
 		Increment: false,
 	}
 	expectedRes := resource.Resource{
-		RetrievedBy:     "admin",
-		RetrievedByType: resource.User,
+		AddedBy:     "admin",
+		AddedByType: resource.User,
 	}
 	s.state.EXPECT().SetResource(gomock.Any(), args).Return(expectedRes, nil)
 
@@ -154,12 +154,12 @@ func (s *resourceServiceSuite) TestSetResourceBadID(c *gc.C) {
 	c.Assert(err, jc.ErrorIs, errors.NotValid)
 }
 
-func (s *resourceServiceSuite) TestSetResourceBadSuppliedBy(c *gc.C) {
+func (s *resourceServiceSuite) TestSetResourceBadAddedBy(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	args := resource.SetResourceArgs{
-		ApplicationID:  applicationtesting.GenApplicationUUID(c),
-		SuppliedByType: resource.Application,
+		ApplicationID: applicationtesting.GenApplicationUUID(c),
+		AddedByType:   resource.Application,
 	}
 	_, err := s.service.SetResource(context.Background(), args)
 	c.Assert(err, jc.ErrorIs, errors.NotValid)
@@ -187,10 +187,10 @@ func (s *resourceServiceSuite) TestSetUnitResource(c *gc.C) {
 
 	resID := resourcestesting.GenResourceUUID(c)
 	args := resource.SetUnitResourceArgs{
-		ResourceUUID:    resID,
-		RetrievedBy:     "admin",
-		RetrievedByType: resource.User,
-		UnitUUID:        unittesting.GenUnitUUID(c),
+		ResourceUUID: resID,
+		AddedBy:      "admin",
+		AddedByType:  resource.User,
+		UnitUUID:     unittesting.GenUnitUUID(c),
 	}
 	expectedRet := resource.SetUnitResourceResult{
 		UUID: resourcestesting.GenResourceUUID(c),

--- a/domain/application/state/types.go
+++ b/domain/application/state/types.go
@@ -627,8 +627,8 @@ type resourceView struct {
 	CreatedAt       time.Time `db:"created_at"`
 	Revision        int       `db:"revision"`
 	OriginTypeId    int       `db:"origin_type_id"`
-	RetrievedBy     string    `db:"retrieved_by"`
-	RetrievedByType string    `db:"retrieved_by_type"`
+	AddedBy         string    `db:"added_by"`
+	AddedByType     string    `db:"added_by_type"`
 	Path            string    `db:"path"`
 	Description     string    `db:"description"`
 	KindId          int       `db:"kind_id"`
@@ -654,12 +654,12 @@ func (rv resourceView) toCharmResource() charmresource.Resource {
 // toResource converts a resourceView object to a resource.Resource object including metadata and timestamps.
 func (rv resourceView) toResource() resource.Resource {
 	return resource.Resource{
-		Resource:        rv.toCharmResource(),
-		UUID:            coreresource.UUID(rv.UUID),
-		ApplicationID:   coreapplication.ID(rv.ApplicationUUID),
-		RetrievedBy:     rv.RetrievedBy,
-		RetrievedByType: resource.RetrievedByType(rv.RetrievedByType),
-		Timestamp:       rv.CreatedAt,
+		Resource:      rv.toCharmResource(),
+		UUID:          coreresource.UUID(rv.UUID),
+		ApplicationID: coreapplication.ID(rv.ApplicationUUID),
+		AddedBy:       rv.AddedBy,
+		AddedByType:   resource.AddedByType(rv.AddedByType),
+		Timestamp:     rv.CreatedAt,
 	}
 }
 

--- a/domain/schema/model/sql/0022-resource.sql
+++ b/domain/schema/model/sql/0022-resource.sql
@@ -66,22 +66,22 @@ CREATE TABLE application_resource (
     REFERENCES resource (uuid)
 );
 
-CREATE TABLE resource_retrieved_by_type (
+CREATE TABLE resource_added_by_type (
     id INT PRIMARY KEY,
     name TEXT NOT NULL
 );
 
-CREATE UNIQUE INDEX idx_resource_retrieved_by_type
-ON resource_retrieved_by_type (name);
+CREATE UNIQUE INDEX idx_resource_added_by_type
+ON resource_added_by_type (name);
 
-INSERT INTO resource_retrieved_by_type VALUES
+INSERT INTO resource_added_by_type VALUES
 (0, 'user'),
 (1, 'unit'),
 (2, 'application');
 
-CREATE TABLE resource_retrieved_by (
+CREATE TABLE resource_added_by (
     resource_uuid TEXT NOT NULL PRIMARY KEY,
-    retrieved_by_type_id INT NOT NULL,
+    added_by_type_id INT NOT NULL,
     -- Name is the entity who retrieved the resource blob:
     --   The name of the user who uploaded the resource.
     --   Unit or application name of which triggered the download
@@ -90,9 +90,9 @@ CREATE TABLE resource_retrieved_by (
     CONSTRAINT fk_resource
     FOREIGN KEY (resource_uuid)
     REFERENCES resource (uuid),
-    CONSTRAINT fk_resource_retrieved_by_type
-    FOREIGN KEY (retrieved_by_type_id)
-    REFERENCES resource_retrieved_by_type (id)
+    CONSTRAINT fk_resource_added_by_type
+    FOREIGN KEY (added_by_type_id)
+    REFERENCES resource_added_by_type (id)
 );
 
 -- This is an container image resource used by a kubernetes application.
@@ -170,13 +170,13 @@ SELECT
     r.created_at,
     r.revision,
     r.origin_type_id,
-    rrb.name AS retrieved_by,
-    rrbt.name AS retrieved_by_type,
+    rrb.name AS added_by,
+    rabt.name AS added_by_type,
     cr.path,
     cr.description,
     cr.kind_id
 FROM resource AS r
 INNER JOIN application_resource AS ar ON r.uuid = ar.resource_uuid
 INNER JOIN charm_resource AS cr ON r.charm_uuid = cr.charm_uuid AND r.charm_resource_name = cr.name
-LEFT JOIN resource_retrieved_by AS rrb ON r.uuid = rrb.resource_uuid
-LEFT JOIN resource_retrieved_by_type AS rrbt ON rrb.retrieved_by_type_id = rrbt.id;
+LEFT JOIN resource_added_by AS rrb ON r.uuid = rrb.resource_uuid
+LEFT JOIN resource_added_by_type AS rabt ON rrb.added_by_type_id = rabt.id;

--- a/domain/schema/schema_test.go
+++ b/domain/schema/schema_test.go
@@ -414,8 +414,8 @@ func (s *schemaSuite) TestModelTables(c *gc.C) {
 		"resource_file_store",
 		"resource_image_store",
 		"resource_origin_type",
-		"resource_retrieved_by",
-		"resource_retrieved_by_type",
+		"resource_added_by",
+		"resource_added_by_type",
 		"resource_state",
 		"unit_resource",
 


### PR DESCRIPTION
The field captures the id of the entity that added the resource to state. If it is a charmhub resource, this will be the app or the unit, but if it is a user added resource this will be the user name. retrieved_by didn't quite make sense in the context of the user, added_by does more so.

<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://github.com/juju/juju/blob/main/doc/conventional-commits.md
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps
Unit tests pass
<!-- 

Describe steps to verify that the change works. 

If you're changing any of the facades, you need to ensure that you've tested
a model migration from 3.6 to 4.0 and from 4.0 to 4.0.

The following steps are a good starting point:

 1. Bootstrap a 3.6 controller and deploy a charm.

```sh
$ juju bootstrap lxd src36
$ juju add-model moveme1
$ juju deploy juju-qa-test
```

 2. Bootstrap a 4.0 controller with the changes and migrate the model.

```sh
$ juju bootstrap lxd dst40
$ juju migrate src36:moveme1 dst40
$ juju add-unit juju-qa-test
```

 3. Verify no errors exist in the model logs for the agents. If there are
    errors, this is a bug and should be fixed before merging. The fix can
    either be applied to the 4.0 branch (preferable) or the 3.6 branch, though
    that needs to be discussed with the team.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme1
```

    4. We also need to test a model migration from 4.0 to 4.0.

```sh
$ juju bootstrap lxd src40
$ juju add-model moveme2
$ juju deploy juju-qa-test
```

```sh
$ juju migrate src40:moveme2 dst40
$ juju add-unit juju-qa-test
```

    5. Verify that there are no errors in the controller or model logs.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme2
```

-->
