### PR TITLE
WIP feat(resource): add SetResource method

### DIFF
--- a/domain/application/errors/errors.go
+++ b/domain/application/errors/errors.go
@@ -140,6 +140,10 @@ const (
 	// container image metadata is not found.
 	ContainerImageMetadataNotFound = errors.ConstError("container image metadata not found")
 
+	// CharmResourceNotFound describes an error that occurs when a resource is
+	// not found in a charm description.
+	CharmResourceNotFound = errors.ConstError("charm resource not found")
+
 	// UnknownResourceType describes an error where the resource type is
 	// not oci-image or file.
 	UnknownResourceType = errors.ConstError("unknown resource type")
@@ -147,6 +151,14 @@ const (
 	// UnknownRetrievedByType describes an error where the retrieved by type is
 	// neither user, unit nor application.
 	UnknownRetrievedByType = errors.ConstError("unknown retrieved by type")
+
+	// UnknownResourceRetrievedByType describes an error where the added by type is
+	// neither user, unit nor application.
+	UnknownResourceRetrievedByType = errors.ConstError("unknown resource retrieved by type")
+
+	// UnknownResourceOriginType describes an error where the origin type is
+	// neither upload nor store.
+	UnknownResourceOriginType = errors.ConstError("unknown resource origin type")
 
 	// ResourceNameNotValid describes an error where the resource name is not
 	// valid, usually because it's empty.

--- a/domain/application/resource/types.go
+++ b/domain/application/resource/types.go
@@ -10,7 +10,7 @@ import (
 	"github.com/juju/juju/core/application"
 	coreresource "github.com/juju/juju/core/resource"
 	"github.com/juju/juju/core/unit"
-	"github.com/juju/juju/internal/charm/resource"
+	charmresource "github.com/juju/juju/internal/charm/resource"
 )
 
 // IncrementCharmModifiedVersionType is the argument type for incrementing
@@ -45,7 +45,7 @@ type ApplicationResources struct {
 	// was polled. Each entry here corresponds to the same indexed entry
 	// in the Resources field. An entry may be empty if data has not
 	// yet been retrieve from the repository.
-	RepositoryResources []resource.Resource
+	RepositoryResources []charmresource.Resource
 
 	// UnitResources reports the currently-in-use version of file type
 	// resources for each unit.
@@ -70,7 +70,7 @@ type ApplicationResources struct {
 //
 //	Fingerprint, Size
 type Resource struct {
-	resource.Resource
+	charmresource.Resource
 
 	// UUID uniquely identifies a resource within the model.
 	UUID coreresource.UUID
@@ -124,7 +124,7 @@ type SetResourceArgs struct {
 	ApplicationID  application.ID
 	SuppliedBy     string
 	SuppliedByType RetrievedByType
-	Resource       resource.Resource
+	Resource       charmresource.Resource
 	Reader         io.Reader
 	Increment      IncrementCharmModifiedVersionType
 }
@@ -151,7 +151,7 @@ type SetRepositoryResourcesArgs struct {
 	// ApplicationID is the id of the application having these resources.
 	ApplicationID application.ID
 	// Info is a slice of resource data received from the repository.
-	Info []resource.Resource
+	Info []charmresource.Resource
 	// LastPolled indicates when the resource data was last polled.
 	LastPolled time.Time
 }

--- a/domain/application/state/types.go
+++ b/domain/application/state/types.go
@@ -4,6 +4,7 @@
 package state
 
 import (
+	"database/sql"
 	"time"
 
 	coreapplication "github.com/juju/juju/core/application"
@@ -679,4 +680,37 @@ type containerImageMetadata struct {
 	RegistryPath string `db:"registry_path"`
 	UserName     string `db:"username"`
 	Password     string `db:"password"`
+}
+
+type setResource struct {
+	// UUID is resources unique identifier.
+	UUID string `db:"uuid"`
+	// CharmUUD is the UUID of the charm this resource is defined in.
+	CharmUUID string `db:"charm_uuid"`
+	// CharmResourceName is the name of the resource in the charm definition.
+	CharmResourceName string `db:"charm_resource_name"`
+	// Revision is the resource revision.
+	Revision sql.Null[int64] `db:"revision"`
+	// OriginTypeID is the ID of the origin of the stored resource.
+	OriginTypeID int `db:"origin_type_id"`
+	// Created at is the time the row is inserted into the resource table.
+	CreatedAt time.Time `db:"created_at"`
+	// StateID is the state ID of the resource
+	StateID int `db:"state_id"`
+}
+
+type resourceOriginType struct {
+	Name string `db:"name"`
+	ID   int    `db:"id"`
+}
+
+type resourceRetrievedByType struct {
+	Name string `db:"name"`
+	ID   int    `db:"id"`
+}
+
+type resourceRetrievedBy struct {
+	ResourceUUID      string `db:"resource_uuid"`
+	RetrievedByTypeID int    `db:"retrieved_by_type_id"`
+	Name              string `db:"name"`
 }

--- a/domain/schema/model/sql/0022-resource.sql
+++ b/domain/schema/model/sql/0022-resource.sql
@@ -7,7 +7,7 @@ CREATE UNIQUE INDEX idx_resource_origin_name
 ON resource_origin_type (name);
 
 INSERT INTO resource_origin_type VALUES
-(0, 'uploaded'),
+(0, 'upload'),
 (1, 'store');
 
 CREATE TABLE resource_state (


### PR DESCRIPTION
Add the SetResource method to the application domain.

<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://github.com/juju/juju/blob/main/doc/conventional-commits.md
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Unit tests pass
<!-- 

Describe steps to verify that the change works. 

If you're changing any of the facades, you need to ensure that you've tested
a model migration from 3.6 to 4.0 and from 4.0 to 4.0.

The following steps are a good starting point:

 1. Bootstrap a 3.6 controller and deploy a charm.

```sh
$ juju bootstrap lxd src36
$ juju add-model moveme1
$ juju deploy juju-qa-test
```

 2. Bootstrap a 4.0 controller with the changes and migrate the model.

```sh
$ juju bootstrap lxd dst40
$ juju migrate src36:moveme1 dst40
$ juju add-unit juju-qa-test
```

 3. Verify no errors exist in the model logs for the agents. If there are
    errors, this is a bug and should be fixed before merging. The fix can
    either be applied to the 4.0 branch (preferable) or the 3.6 branch, though
    that needs to be discussed with the team.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme1
```

    4. We also need to test a model migration from 4.0 to 4.0.

```sh
$ juju bootstrap lxd src40
$ juju add-model moveme2
$ juju deploy juju-qa-test
```

```sh
$ juju migrate src40:moveme2 dst40
$ juju add-unit juju-qa-test
```

    5. Verify that there are no errors in the controller or model logs.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme2
```

-->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Jira card:** [JUJU-6397](https://warthogs.atlassian.net/browse/JUJU-6397)



[JUJU-6397]: https://warthogs.atlassian.net/browse/JUJU-6397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ