### PR TITLE
fix: model machine info checks controller model machines

### DIFF
--- a/apiserver/facades/client/modelmanager/mocks/service_mock.go
+++ b/apiserver/facades/client/modelmanager/mocks/service_mock.go
@@ -1464,6 +1464,44 @@ func (c *MockModelDomainServicesConfigCall) DoAndReturn(f func() modelmanager.Mo
 	return c
 }
 
+// Machine mocks base method.
+func (m *MockModelDomainServices) Machine() modelmanager.MachineService {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Machine")
+	ret0, _ := ret[0].(modelmanager.MachineService)
+	return ret0
+}
+
+// Machine indicates an expected call of Machine.
+func (mr *MockModelDomainServicesMockRecorder) Machine() *MockModelDomainServicesMachineCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Machine", reflect.TypeOf((*MockModelDomainServices)(nil).Machine))
+	return &MockModelDomainServicesMachineCall{Call: call}
+}
+
+// MockModelDomainServicesMachineCall wrap *gomock.Call
+type MockModelDomainServicesMachineCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockModelDomainServicesMachineCall) Return(arg0 modelmanager.MachineService) *MockModelDomainServicesMachineCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockModelDomainServicesMachineCall) Do(f func() modelmanager.MachineService) *MockModelDomainServicesMachineCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockModelDomainServicesMachineCall) DoAndReturn(f func() modelmanager.MachineService) *MockModelDomainServicesMachineCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // ModelInfo mocks base method.
 func (m *MockModelDomainServices) ModelInfo() modelmanager.ModelInfoService {
 	m.ctrl.T.Helper()

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -1192,7 +1192,7 @@ func (m *ModelManagerAPI) getModelInfo(ctx context.Context, tag names.ModelTag, 
 		}
 	}
 	if canSeeMachinesAndSecrets {
-		if info.Machines, err = common.ModelMachineInfo(ctx, st, m.machineService); shouldErr(err) {
+		if info.Machines, err = common.ModelMachineInfo(ctx, st, modelDomainServices.Machine()); shouldErr(err) {
 			return params.ModelInfo{}, err
 		}
 	}

--- a/apiserver/facades/client/modelmanager/modelmanager_test.go
+++ b/apiserver/facades/client/modelmanager/modelmanager_test.go
@@ -378,12 +378,15 @@ func (s *modelManagerSuite) expectCreateModelOnModelDB(
 	// Expect calls to get various model services.
 	modelInfoService := mocks.NewMockModelInfoService(ctrl)
 	networkService := mocks.NewMockNetworkService(ctrl)
+	machineService := mocks.NewMockMachineService(ctrl)
+
 	s.modelConfigService = mocks.NewMockModelConfigService(ctrl)
 	modelAgentService := mocks.NewMockModelAgentService(ctrl)
 	modelDomainServices.EXPECT().ModelInfo().Return(modelInfoService).AnyTimes()
 	modelDomainServices.EXPECT().Network().Return(networkService)
 	modelDomainServices.EXPECT().Config().Return(s.modelConfigService).AnyTimes()
 	modelDomainServices.EXPECT().Agent().Return(modelAgentService).AnyTimes()
+	modelDomainServices.EXPECT().Machine().Return(machineService)
 
 	// Expect calls to functions of the model services.
 	modelInfoService.EXPECT().CreateModel(gomock.Any(), s.controllerUUID)
@@ -1130,11 +1133,13 @@ func (s *modelManagerStateSuite) expectCreateModelStateSuite(
 	modelConfigService := mocks.NewMockModelConfigService(ctrl)
 	modelInfoService := mocks.NewMockModelInfoService(ctrl)
 	networkService := mocks.NewMockNetworkService(ctrl)
+	machineService := mocks.NewMockMachineService(ctrl)
 
 	modelDomainServices.EXPECT().Agent().Return(modelAgentService).AnyTimes()
 	modelDomainServices.EXPECT().Config().Return(modelConfigService).AnyTimes()
 	modelDomainServices.EXPECT().ModelInfo().Return(modelInfoService).AnyTimes()
 	modelDomainServices.EXPECT().Network().Return(networkService)
+	modelDomainServices.EXPECT().Machine().Return(machineService)
 
 	blockCommandService := mocks.NewMockBlockCommandService(ctrl)
 	modelDomainServices.EXPECT().BlockCommand().Return(blockCommandService).AnyTimes()

--- a/apiserver/facades/client/modelmanager/services.go
+++ b/apiserver/facades/client/modelmanager/services.go
@@ -51,6 +51,9 @@ type ModelDomainServices interface {
 	// Network returns the space service.
 	Network() NetworkService
 	BlockCommand() BlockCommandService
+
+	// Machine returns the machine service.
+	Machine() MachineService
 }
 
 // DomainServicesGetter is a factory for creating model services.
@@ -318,6 +321,10 @@ func (s domainServices) ModelInfo() ModelInfoService { return s.domainServices.M
 
 func (s domainServices) Network() NetworkService {
 	return s.domainServices.Network()
+}
+
+func (s domainServices) Machine() MachineService {
+	return s.domainServices.Machine()
 }
 
 func (s domainServices) BlockCommand() BlockCommandService {


### PR DESCRIPTION
Before this patch, any calls to MachineModelInfo() (located in apiserver/common) would have actually be returning info from the controller model machines.
This was clearly reproducible if you had a model with 2 machines (and a no-ha controller), then a call to `juju show-model` would return with an error stating that machine "1" wasn't found. Another way of reproducing was to migrate that model.

The fix is to inject the correct MachineService on the modelmanager facade.

<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://github.com/juju/juju/blob/main/doc/conventional-commits.md
-->

<!-- Why this change is needed and what it does. -->


## QA steps

Calls to `show-model` and `migrate` should work fine:

```
$ juju bootstrap lxd dst
$ juju bootstrap lxd src
$ juju add-model m
$ juju add-machine
$ juju add-machine
$ juju show-model
m:
  name: admin/m
  short-name: m
  model-uuid: 8d208308-f412-451e-8605-5899d621d8ed
  model-type: iaas
  controller-uuid: b3867b85-1284-4524-8ca4-13c50e9de91f
  controller-name: src
  is-controller: false
  owner: admin
  cloud: localhost
  region: localhost
  type: lxd
  life: alive
  status:
    current: available
    since: 6 seconds ago
  users:
    admin:
      display-name: admin
      access: admin
      last-connection: 11 seconds ago
  machines:
    "0":
      cores: 0
    "1":
      cores: 0
  secret-backends:
    internal:
      num-secrets: 0
      status: active
  agent-version: 4.0-beta5.1
  credential:
    name: localhost
    owner: admin
    cloud: localhost
    validity-check: valid
  supported-features:
  - name: juju
    description: the version of Juju used by the model
    version: 4.0-beta5.1
$ juju migrate m dst
$ juju switch dst:m
$ juju show-model
m:
  name: admin/m
  short-name: m
  model-uuid: 8d208308-f412-451e-8605-5899d621d8ed
  model-type: iaas
  controller-uuid: b3867b85-1284-4524-8ca4-13c50e9de91f
  controller-name: dst
  is-controller: false
  owner: admin
  cloud: localhost
  region: localhost
  type: lxd
  life: alive
  status:
    current: available
    since: 6 seconds ago
  users:
    admin:
      display-name: admin
      access: admin
      last-connection: 11 seconds ago
  machines:
    "0":
      cores: 0
    "1":
      cores: 0
  secret-backends:
    internal:
      num-secrets: 0
      status: active
  agent-version: 4.0-beta5.1
  credential:
    name: localhost
    owner: admin
    cloud: localhost
    validity-check: valid
  supported-features:
  - name: juju
    description: the version of Juju used by the model
    version: 4.0-beta5.1
```
## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/

**Jira card:** JUJU-

