### PR TITLE
feat: hash 256 and 512-384 in the objectstore

### DIFF
--- a/core/objectstore/metadata.go
+++ b/core/objectstore/metadata.go
@@ -19,8 +19,10 @@ const (
 
 // Metadata represents the metadata for an object.
 type Metadata struct {
-	// Hash is the hash of the object.
-	Hash string
+	// Hash256 is the 256 hash of the object.
+	Hash256 string
+	// Hash512_384 is the 512_384 hash of the object.
+	Hash512_384 string
 	// Path is the path to the object.
 	Path string
 	// Size is the size of the object.

--- a/domain/objectstore/errors/errors.go
+++ b/domain/objectstore/errors/errors.go
@@ -17,4 +17,7 @@ const (
 	// ErrPathAlreadyExistsDifferentHash is returned when a path already exists
 	// with a different hash.
 	ErrPathAlreadyExistsDifferentHash = errors.ConstError("path already exists with different hash")
+
+	// ErrMissingHash is returned when a hash is missing.
+	ErrMissingHash = errors.ConstError("missing hash")
 )

--- a/domain/objectstore/service/service_test.go
+++ b/domain/objectstore/service/service_test.go
@@ -14,9 +14,9 @@ import (
 
 	"github.com/juju/juju/core/changestream"
 	"github.com/juju/juju/core/objectstore"
-	coreobjectstore "github.com/juju/juju/core/objectstore"
 	objectstoretesting "github.com/juju/juju/core/objectstore/testing"
 	"github.com/juju/juju/core/watcher/watchertest"
+	objectstoreerrors "github.com/juju/juju/domain/objectstore/errors"
 	"github.com/juju/juju/internal/uuid"
 )
 
@@ -34,16 +34,18 @@ func (s *serviceSuite) TestGetMetadata(c *gc.C) {
 
 	path := uuid.MustNewUUID().String()
 
-	metadata := coreobjectstore.Metadata{
-		Path: path,
-		Hash: uuid.MustNewUUID().String(),
-		Size: 666,
+	metadata := objectstore.Metadata{
+		Path:        path,
+		Hash256:     uuid.MustNewUUID().String(),
+		Hash512_384: uuid.MustNewUUID().String(),
+		Size:        666,
 	}
 
-	s.state.EXPECT().GetMetadata(gomock.Any(), path).Return(coreobjectstore.Metadata{
-		Path: metadata.Path,
-		Size: metadata.Size,
-		Hash: metadata.Hash,
+	s.state.EXPECT().GetMetadata(gomock.Any(), path).Return(objectstore.Metadata{
+		Path:        metadata.Path,
+		Size:        metadata.Size,
+		Hash256:     metadata.Hash256,
+		Hash512_384: metadata.Hash512_384,
 	}, nil)
 
 	p, err := NewService(s.state).GetMetadata(context.Background(), path)
@@ -56,24 +58,27 @@ func (s *serviceSuite) TestListMetadata(c *gc.C) {
 
 	path := uuid.MustNewUUID().String()
 
-	metadata := coreobjectstore.Metadata{
-		Path: path,
-		Hash: uuid.MustNewUUID().String(),
-		Size: 666,
+	metadata := objectstore.Metadata{
+		Path:        path,
+		Hash256:     uuid.MustNewUUID().String(),
+		Hash512_384: uuid.MustNewUUID().String(),
+		Size:        666,
 	}
 
-	s.state.EXPECT().ListMetadata(gomock.Any()).Return([]coreobjectstore.Metadata{{
-		Path: metadata.Path,
-		Hash: metadata.Hash,
-		Size: metadata.Size,
+	s.state.EXPECT().ListMetadata(gomock.Any()).Return([]objectstore.Metadata{{
+		Path:        metadata.Path,
+		Hash256:     metadata.Hash256,
+		Hash512_384: metadata.Hash512_384,
+		Size:        metadata.Size,
 	}}, nil)
 
 	p, err := NewService(s.state).ListMetadata(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(p, gc.DeepEquals, []coreobjectstore.Metadata{{
-		Path: metadata.Path,
-		Size: metadata.Size,
-		Hash: metadata.Hash,
+	c.Assert(p, gc.DeepEquals, []objectstore.Metadata{{
+		Path:        metadata.Path,
+		Size:        metadata.Size,
+		Hash256:     metadata.Hash256,
+		Hash512_384: metadata.Hash512_384,
 	}})
 }
 
@@ -81,23 +86,53 @@ func (s *serviceSuite) TestPutMetadata(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	path := uuid.MustNewUUID().String()
-	metadata := coreobjectstore.Metadata{
-		Path: path,
-		Hash: uuid.MustNewUUID().String(),
-		Size: 666,
+	metadata := objectstore.Metadata{
+		Path:        path,
+		Hash256:     uuid.MustNewUUID().String(),
+		Hash512_384: uuid.MustNewUUID().String(),
+		Size:        666,
 	}
 
 	uuid := objectstoretesting.GenObjectStoreUUID(c)
-	s.state.EXPECT().PutMetadata(gomock.Any(), gomock.AssignableToTypeOf(coreobjectstore.Metadata{})).DoAndReturn(func(ctx context.Context, data coreobjectstore.Metadata) (objectstore.UUID, error) {
+	s.state.EXPECT().PutMetadata(gomock.Any(), gomock.AssignableToTypeOf(objectstore.Metadata{})).DoAndReturn(func(ctx context.Context, data objectstore.Metadata) (objectstore.UUID, error) {
 		c.Check(data.Path, gc.Equals, metadata.Path)
 		c.Check(data.Size, gc.Equals, metadata.Size)
-		c.Check(data.Hash, gc.Equals, metadata.Hash)
+		c.Check(data.Hash256, gc.Equals, metadata.Hash256)
+		c.Check(data.Hash512_384, gc.Equals, metadata.Hash512_384)
 		return uuid, nil
 	})
 
 	result, err := NewService(s.state).PutMetadata(context.Background(), metadata)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(result, gc.Equals, uuid)
+}
+
+func (s *serviceSuite) TestPutMetadataMissingHash512_384(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	path := uuid.MustNewUUID().String()
+	metadata := objectstore.Metadata{
+		Path:    path,
+		Hash256: uuid.MustNewUUID().String(),
+		Size:    666,
+	}
+
+	_, err := NewService(s.state).PutMetadata(context.Background(), metadata)
+	c.Assert(err, jc.ErrorIs, objectstoreerrors.ErrMissingHash)
+}
+
+func (s *serviceSuite) TestPutMetadataMissingHash256(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	path := uuid.MustNewUUID().String()
+	metadata := objectstore.Metadata{
+		Path:        path,
+		Hash512_384: uuid.MustNewUUID().String(),
+		Size:        666,
+	}
+
+	_, err := NewService(s.state).PutMetadata(context.Background(), metadata)
+	c.Assert(err, jc.ErrorIs, objectstoreerrors.ErrMissingHash)
 }
 
 func (s *serviceSuite) TestRemoveMetadata(c *gc.C) {

--- a/domain/objectstore/state/state.go
+++ b/domain/objectstore/state/state.go
@@ -40,7 +40,7 @@ func (s *State) GetMetadata(ctx context.Context, path string) (coreobjectstore.M
 	metadata := dbMetadata{Path: path}
 
 	stmt, err := s.Prepare(`
-SELECT (p.path, m.uuid, m.size, m.hash) AS (&dbMetadata.*)
+SELECT &dbMetadata.*
 FROM object_store_metadata_path p
 LEFT JOIN object_store_metadata m ON p.metadata_uuid = m.uuid
 WHERE path = $dbMetadata.path`, metadata)
@@ -72,7 +72,7 @@ func (s *State) ListMetadata(ctx context.Context) ([]coreobjectstore.Metadata, e
 	}
 
 	stmt, err := s.Prepare(`
-SELECT (p.path, m.uuid, m.size, m.hash) AS (&dbMetadata.*)
+SELECT &dbMetadata.*
 FROM object_store_metadata_path p
 LEFT JOIN object_store_metadata m ON p.metadata_uuid = m.uuid`, dbMetadata{})
 	if err != nil {
@@ -106,10 +106,10 @@ func (s *State) PutMetadata(ctx context.Context, metadata coreobjectstore.Metada
 	}
 
 	dbMetadata := dbMetadata{
-		UUID:       uuid.String(),
-		Hash:       metadata.Hash,
-		HashTypeID: 1,
-		Size:       metadata.Size,
+		UUID:        uuid.String(),
+		Hash256:     metadata.Hash256,
+		Hash512_384: metadata.Hash512_384,
+		Size:        metadata.Size,
 	}
 
 	dbMetadataPath := dbMetadataPath{
@@ -118,8 +118,10 @@ func (s *State) PutMetadata(ctx context.Context, metadata coreobjectstore.Metada
 	}
 
 	metadataStmt, err := s.Prepare(`
-INSERT INTO object_store_metadata (uuid, hash_type_id, hash, size)
-VALUES ($dbMetadata.*) ON CONFLICT (hash) DO NOTHING`, dbMetadata)
+INSERT INTO object_store_metadata (uuid, hash_256, hash_512_384, size)
+VALUES ($dbMetadata.*) 
+ON CONFLICT (hash_256) DO NOTHING
+ON CONFLICT (hash_512_384) DO NOTHING`, dbMetadata)
 	if err != nil {
 		return "", errors.Annotate(err, "preparing insert metadata statement")
 	}
@@ -134,7 +136,10 @@ VALUES ($dbMetadataPath.*)`, dbMetadataPath)
 	metadataLookupStmt, err := s.Prepare(`
 SELECT uuid AS &dbMetadataPath.metadata_uuid
 FROM   object_store_metadata 
-WHERE  hash = $dbMetadata.hash 
+WHERE  (
+	hash_512_384 = $dbMetadata.hash_512_384 OR
+	hash_256 = $dbMetadata.hash_256
+)
 AND    size = $dbMetadata.size`, dbMetadata, dbMetadataPath)
 	if err != nil {
 		return "", errors.Annotate(err, "preparing select metadata statement")

--- a/domain/objectstore/state/state_test.go
+++ b/domain/objectstore/state/state_test.go
@@ -33,9 +33,10 @@ func (s *stateSuite) TestGetMetadataFound(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory())
 
 	metadata := coreobjectstore.Metadata{
-		Hash: "hash",
-		Path: "blah-foo",
-		Size: 666,
+		Hash256:     "hash256",
+		Hash512_384: "hash512_384",
+		Path:        "blah-foo",
+		Size:        666,
 	}
 
 	_, err := st.PutMetadata(context.Background(), metadata)
@@ -50,9 +51,10 @@ func (s *stateSuite) TestListMetadataFound(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory())
 
 	metadata := coreobjectstore.Metadata{
-		Hash: "hash",
-		Path: "blah-foo",
-		Size: 666,
+		Hash256:     "hash256",
+		Hash512_384: "hash512_384",
+		Path:        "blah-foo",
+		Size:        666,
 	}
 
 	_, err := st.PutMetadata(context.Background(), metadata)
@@ -67,9 +69,10 @@ func (s *stateSuite) TestPutMetadata(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory())
 
 	metadata := coreobjectstore.Metadata{
-		Hash: "hash",
-		Path: "blah-foo",
-		Size: 666,
+		Hash256:     "hash256",
+		Hash512_384: "hash512_384",
+		Path:        "blah-foo",
+		Size:        666,
 	}
 
 	uuid, err := st.PutMetadata(context.Background(), metadata)
@@ -81,8 +84,8 @@ func (s *stateSuite) TestPutMetadata(c *gc.C) {
 	var received coreobjectstore.Metadata
 	err = runner.StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		row := tx.QueryRowContext(ctx, `
-SELECT path, size, hash FROM v_object_store_metadata WHERE uuid = ?`, uuid)
-		return row.Scan(&received.Path, &received.Size, &received.Hash)
+SELECT path, size, hash_256, hash_512_384 FROM v_object_store_metadata WHERE uuid = ?`, uuid)
+		return row.Scan(&received.Path, &received.Size, &received.Hash256, &received.Hash512_384)
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(received, gc.DeepEquals, metadata)
@@ -92,9 +95,10 @@ func (s *stateSuite) TestPutMetadataConflict(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory())
 
 	metadata := coreobjectstore.Metadata{
-		Hash: "hash",
-		Path: "blah-foo",
-		Size: 666,
+		Hash256:     "hash256",
+		Hash512_384: "hash512_384",
+		Path:        "blah-foo",
+		Size:        666,
 	}
 
 	_, err := st.PutMetadata(context.Background(), metadata)
@@ -105,18 +109,66 @@ func (s *stateSuite) TestPutMetadataConflict(c *gc.C) {
 	c.Check(err, jc.ErrorIs, objectstoreerrors.ErrPathAlreadyExistsDifferentHash)
 }
 
-func (s *stateSuite) TestPutMetadataWithSameHashAndSize(c *gc.C) {
+func (s *stateSuite) TestPutMetadataWithSameHashesAndSize(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory())
 
 	metadata1 := coreobjectstore.Metadata{
-		Hash: "hash",
-		Path: "blah-foo-1",
-		Size: 666,
+		Hash256:     "hash256",
+		Hash512_384: "hash512_384",
+		Path:        "blah-foo-1",
+		Size:        666,
 	}
 	metadata2 := coreobjectstore.Metadata{
-		Hash: "hash",
-		Path: "blah-foo-2",
-		Size: 666,
+		Hash256:     "hash256",
+		Hash512_384: "hash512_384",
+		Path:        "blah-foo-2",
+		Size:        666,
+	}
+
+	_, err := st.PutMetadata(context.Background(), metadata1)
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = st.PutMetadata(context.Background(), metadata2)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *stateSuite) TestPutMetadataWithSameHash256AndSize(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	metadata1 := coreobjectstore.Metadata{
+		Hash256:     "hash256",
+		Hash512_384: "foo",
+		Path:        "blah-foo-1",
+		Size:        666,
+	}
+	metadata2 := coreobjectstore.Metadata{
+		Hash256:     "hash256",
+		Hash512_384: "bar",
+		Path:        "blah-foo-2",
+		Size:        666,
+	}
+
+	_, err := st.PutMetadata(context.Background(), metadata1)
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = st.PutMetadata(context.Background(), metadata2)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *stateSuite) TestPutMetadataWithSameHash512_384AndSize(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory())
+
+	metadata1 := coreobjectstore.Metadata{
+		Hash256:     "foo",
+		Hash512_384: "hash512_384",
+		Path:        "blah-foo-1",
+		Size:        666,
+	}
+	metadata2 := coreobjectstore.Metadata{
+		Hash256:     "bar",
+		Hash512_384: "hash512_384",
+		Path:        "blah-foo-2",
+		Size:        666,
 	}
 
 	_, err := st.PutMetadata(context.Background(), metadata1)
@@ -134,14 +186,16 @@ func (s *stateSuite) TestPutMetadataWithSameHashDifferentSize(c *gc.C) {
 	// There is a broken hash function somewhere.
 
 	metadata1 := coreobjectstore.Metadata{
-		Hash: "hash",
-		Path: "blah-foo-1",
-		Size: 666,
+		Hash256:     "hash256",
+		Hash512_384: "hash512_384",
+		Path:        "blah-foo-1",
+		Size:        666,
 	}
 	metadata2 := coreobjectstore.Metadata{
-		Hash: "hash",
-		Path: "blah-foo-2",
-		Size: 42,
+		Hash256:     "hash256",
+		Hash512_384: "hash512_384",
+		Path:        "blah-foo-2",
+		Size:        42,
 	}
 
 	_, err := st.PutMetadata(context.Background(), metadata1)
@@ -159,9 +213,10 @@ func (s *stateSuite) TestPutMetadataMultipleTimes(c *gc.C) {
 
 	for i := 0; i < 10; i++ {
 		metadatas[i] = coreobjectstore.Metadata{
-			Hash: fmt.Sprintf("hash-%d", i),
-			Path: fmt.Sprintf("blah-foo-%d", i),
-			Size: 666,
+			Hash256:     fmt.Sprintf("hash-256-%d", i),
+			Hash512_384: fmt.Sprintf("hash-512_384-%d", i),
+			Path:        fmt.Sprintf("blah-foo-%d", i),
+			Size:        666,
 		}
 
 		_, err := st.PutMetadata(context.Background(), metadatas[i])
@@ -186,14 +241,16 @@ func (s *stateSuite) TestRemoveMetadataDoesNotRemoveMetadataIfReferenced(c *gc.C
 	st := NewState(s.TxnRunnerFactory())
 
 	metadata1 := coreobjectstore.Metadata{
-		Hash: "hash",
-		Path: "blah-foo-1",
-		Size: 666,
+		Hash256:     "hash256",
+		Hash512_384: "hash512_384",
+		Path:        "blah-foo-1",
+		Size:        666,
 	}
 	metadata2 := coreobjectstore.Metadata{
-		Hash: "hash",
-		Path: "blah-foo-2",
-		Size: 666,
+		Hash256:     "hash256",
+		Hash512_384: "hash512_384",
+		Path:        "blah-foo-2",
+		Size:        666,
 	}
 
 	_, err := st.PutMetadata(context.Background(), metadata1)
@@ -214,14 +271,16 @@ func (s *stateSuite) TestRemoveMetadataCleansUpEverything(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory())
 
 	metadata1 := coreobjectstore.Metadata{
-		Hash: "hash",
-		Path: "blah-foo-1",
-		Size: 666,
+		Hash256:     "hash256",
+		Hash512_384: "hash512_384",
+		Path:        "blah-foo-1",
+		Size:        666,
 	}
 	metadata2 := coreobjectstore.Metadata{
-		Hash: "hash",
-		Path: "blah-foo-2",
-		Size: 666,
+		Hash256:     "hash256",
+		Hash512_384: "hash512_384",
+		Path:        "blah-foo-2",
+		Size:        666,
 	}
 
 	// Add both metadata.
@@ -244,9 +303,10 @@ func (s *stateSuite) TestRemoveMetadataCleansUpEverything(c *gc.C) {
 
 	// Add a new metadata with the same hash and size.
 	metadata3 := coreobjectstore.Metadata{
-		Hash: "hash",
-		Path: "blah-foo-3",
-		Size: 666,
+		Hash256:     "hash256",
+		Hash512_384: "hash512_384",
+		Path:        "blah-foo-3",
+		Size:        666,
 	}
 	_, err = st.PutMetadata(context.Background(), metadata3)
 	c.Assert(err, jc.ErrorIsNil)
@@ -263,9 +323,10 @@ func (s *stateSuite) TestRemoveMetadataThenAddAgain(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory())
 
 	metadata := coreobjectstore.Metadata{
-		Hash: "hash",
-		Path: "blah-foo-1",
-		Size: 666,
+		Hash256:     "hash256",
+		Hash512_384: "hash512_384",
+		Path:        "blah-foo-1",
+		Size:        666,
 	}
 
 	_, err := st.PutMetadata(context.Background(), metadata)
@@ -286,9 +347,10 @@ func (s *stateSuite) TestListMetadata(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory())
 
 	metadata := coreobjectstore.Metadata{
-		Hash: "hash",
-		Path: "blah-foo-1",
-		Size: 666,
+		Hash256:     "hash256",
+		Hash512_384: "hash512_384",
+		Path:        "blah-foo-1",
+		Size:        666,
 	}
 
 	_, err := st.PutMetadata(context.Background(), metadata)

--- a/domain/objectstore/state/types.go
+++ b/domain/objectstore/state/types.go
@@ -9,11 +9,10 @@ import coreobjectstore "github.com/juju/juju/core/objectstore"
 type dbMetadata struct {
 	// UUID is the uuid for the metadata.
 	UUID string `db:"uuid"`
-	// Hash is the hash of the object.
-	Hash string `db:"hash"`
-	// HashTypeID is the id of the type of hash used to generate the hash. It
-	// can be looked up in object_store_metadata_hash_type.
-	HashTypeID uint `db:"hash_type_id"`
+	// Hash256 is the 256 hash of the object.
+	Hash256 string `db:"hash_256"`
+	// Hash512_384 is the 512_384 hash of the object.
+	Hash512_384 string `db:"hash_512_384"`
 	// Path is the path to the object.
 	Path string `db:"path"`
 	// Size is the size of the object.
@@ -33,8 +32,9 @@ type dbMetadataPath struct {
 // object metadata.
 func (m dbMetadata) ToCoreObjectStoreMetadata() coreobjectstore.Metadata {
 	return coreobjectstore.Metadata{
-		Hash: m.Hash,
-		Path: m.Path,
-		Size: m.Size,
+		Hash256:     m.Hash256,
+		Hash512_384: m.Hash512_384,
+		Path:        m.Path,
+		Size:        m.Size,
 	}
 }

--- a/domain/objectstore/watcher_test.go
+++ b/domain/objectstore/watcher_test.go
@@ -48,9 +48,10 @@ func (s *watcherSuite) TestWatchWithAdd(c *gc.C) {
 
 	// Add a new object.
 	metadata := objectstore.Metadata{
-		Path: "foo",
-		Hash: "hash",
-		Size: 666,
+		Path:        "foo",
+		Hash256:     "hash256",
+		Hash512_384: "hash512_384",
+		Size:        666,
 	}
 	_, err = svc.PutMetadata(context.Background(), metadata)
 	c.Assert(err, jc.ErrorIsNil)
@@ -84,9 +85,10 @@ func (s *watcherSuite) TestWatchWithDelete(c *gc.C) {
 
 	// Add a new object.
 	metadata := objectstore.Metadata{
-		Path: "foo",
-		Hash: "hash",
-		Size: 666,
+		Path:        "foo",
+		Hash256:     "hash256",
+		Hash512_384: "hash512_384",
+		Size:        666,
 	}
 	_, err = svc.PutMetadata(context.Background(), metadata)
 	c.Assert(err, jc.ErrorIsNil)

--- a/domain/schema/controller/sql/0014-objectstore-metadata.sql
+++ b/domain/schema/controller/sql/0014-objectstore-metadata.sql
@@ -1,26 +1,15 @@
-CREATE TABLE object_store_metadata_hash_type (
-    id INT PRIMARY KEY,
-    hash_type TEXT NOT NULL
-);
-
-CREATE UNIQUE INDEX idx_object_store_metadata_hash_type_name
-ON object_store_metadata_hash_type (hash_type);
-
-INSERT INTO object_store_metadata_hash_type VALUES
-(0, 'none'),
-(1, 'sha512-384');
-
 CREATE TABLE object_store_metadata (
     uuid TEXT NOT NULL PRIMARY KEY,
-    hash_type_id INT NOT NULL,
-    hash TEXT NOT NULL,
-    size INT NOT NULL,
-    CONSTRAINT fk_object_store_metadata_hash_type
-    FOREIGN KEY (hash_type_id)
-    REFERENCES object_store_metadata_hash_type (id)
+    hash_256 TEXT NOT NULL,
+    hash_512_384 TEXT NOT NULL,
+    size INT NOT NULL
 );
 
-CREATE UNIQUE INDEX idx_object_store_metadata_hash ON object_store_metadata (hash);
+-- Add a unique index for each hash and a composite unique index for both hashes
+-- to ensure that the same hash is not stored multiple times.
+CREATE UNIQUE INDEX idx_object_store_metadata_hash_256 ON object_store_metadata (hash_256);
+CREATE UNIQUE INDEX idx_object_store_metadata_hash_512_384 ON object_store_metadata (hash_512_384);
+CREATE UNIQUE INDEX idx_object_store_metadata_hash ON object_store_metadata (hash_256, hash_512_384);
 
 CREATE TABLE object_store_metadata_path (
     path TEXT NOT NULL PRIMARY KEY,
@@ -33,11 +22,10 @@ CREATE TABLE object_store_metadata_path (
 CREATE VIEW v_object_store_metadata AS
 SELECT
     osm.uuid,
-    osm.hash,
+    osm.hash_256,
+    osm.hash_512_384,
     osm.size,
     osmp.path
 FROM object_store_metadata AS osm
-LEFT JOIN object_store_metadata_hash_type AS osmht
-    ON osm.hash_type_id = osmht.id
 LEFT JOIN object_store_metadata_path AS osmp
     ON osm.uuid = osmp.metadata_uuid;

--- a/domain/schema/model/sql/0006-objectstore-metadata.sql
+++ b/domain/schema/model/sql/0006-objectstore-metadata.sql
@@ -1,26 +1,15 @@
-CREATE TABLE object_store_metadata_hash_type (
-    id INT PRIMARY KEY,
-    hash_type TEXT NOT NULL
-);
-
-CREATE UNIQUE INDEX idx_object_store_metadata_hash_type_name
-ON object_store_metadata_hash_type (hash_type);
-
-INSERT INTO object_store_metadata_hash_type VALUES
-(0, 'none'),
-(1, 'sha512-384');
-
 CREATE TABLE object_store_metadata (
     uuid TEXT NOT NULL PRIMARY KEY,
-    hash_type_id INT NOT NULL,
-    hash TEXT NOT NULL,
-    size INT NOT NULL,
-    CONSTRAINT fk_object_store_metadata_hash_type
-    FOREIGN KEY (hash_type_id)
-    REFERENCES object_store_metadata_hash_type (id)
+    hash_256 TEXT NOT NULL,
+    hash_512_384 TEXT NOT NULL,
+    size INT NOT NULL
 );
 
-CREATE UNIQUE INDEX idx_object_store_metadata_hash ON object_store_metadata (hash);
+-- Add a unique index for each hash and a composite unique index for both hashes
+-- to ensure that the same hash is not stored multiple times.
+CREATE UNIQUE INDEX idx_object_store_metadata_hash_256 ON object_store_metadata (hash_256);
+CREATE UNIQUE INDEX idx_object_store_metadata_hash_512_384 ON object_store_metadata (hash_512_384);
+CREATE UNIQUE INDEX idx_object_store_metadata_hash ON object_store_metadata (hash_256, hash_512_384);
 
 CREATE TABLE object_store_metadata_path (
     path TEXT NOT NULL PRIMARY KEY,
@@ -33,11 +22,10 @@ CREATE TABLE object_store_metadata_path (
 CREATE VIEW v_object_store_metadata AS
 SELECT
     osm.uuid,
-    osm.hash,
+    osm.hash_256,
+    osm.hash_512_384,
     osm.size,
     osmp.path
 FROM object_store_metadata AS osm
-LEFT JOIN object_store_metadata_hash_type AS osmht
-    ON osm.hash_type_id = osmht.id
 LEFT JOIN object_store_metadata_path AS osmp
     ON osm.uuid = osmp.metadata_uuid;

--- a/domain/services/objectstore.go
+++ b/domain/services/objectstore.go
@@ -26,7 +26,7 @@ func NewObjectStoreServices(
 	logger logger.Logger,
 ) *ObjectStoreServices {
 	return &ObjectStoreServices{
-		modelServiceFactoryBase{
+		modelServiceFactoryBase: modelServiceFactoryBase{
 			serviceFactoryBase: serviceFactoryBase{
 				controllerDB: controllerDB,
 				logger:       logger,

--- a/internal/objectstore/base.go
+++ b/internal/objectstore/base.go
@@ -274,7 +274,7 @@ func (w *baseObjectStore) prune(ctx context.Context, list pruneListFunc, delete 
 	// database.
 	hashes := make(map[string]struct{})
 	for _, m := range metadata {
-		hashes[m.Hash] = struct{}{}
+		hashes[selectHash(m)] = struct{}{}
 	}
 
 	// Remove any objects that we don't know about.
@@ -299,6 +299,10 @@ func (w *baseObjectStore) prune(ctx context.Context, list pruneListFunc, delete 
 	}
 
 	return nil
+}
+
+func selectHash(m objectstore.Metadata) string {
+	return m.Hash512_384
 }
 
 type hashValidator func(string) (string, bool)

--- a/internal/objectstore/base_test.go
+++ b/internal/objectstore/base_test.go
@@ -261,7 +261,7 @@ func (s *baseObjectStoreSuite) TestPruneWithJustMetadata(c *gc.C) {
 
 	list := func(ctx context.Context) ([]objectstore.Metadata, []string, error) {
 		return []objectstore.Metadata{{
-			Hash: "hash",
+			Hash512_384: "hash",
 		}}, nil, nil
 	}
 	delete := func(ctx context.Context, hash string) error {
@@ -316,7 +316,7 @@ func (s *baseObjectStoreSuite) TestPruneWithMatches(c *gc.C) {
 
 	list := func(ctx context.Context) ([]objectstore.Metadata, []string, error) {
 		return []objectstore.Metadata{{
-			Hash: "bar",
+			Hash512_384: "bar",
 		}}, []string{"bar", "foo"}, nil
 	}
 	delete := func(ctx context.Context, hash string) error {

--- a/internal/objectstore/fileobjectstore.go
+++ b/internal/objectstore/fileobjectstore.go
@@ -5,6 +5,7 @@ package objectstore
 
 import (
 	"context"
+	"crypto/sha256"
 	"crypto/sha512"
 	"encoding/hex"
 	"fmt"
@@ -294,16 +295,18 @@ func (t *fileObjectStore) get(ctx context.Context, path string) (io.ReadCloser, 
 		return nil, -1, fmt.Errorf("get metadata: %w", err)
 	}
 
-	file, err := t.fs.Open(metadata.Hash)
+	hash := selectHash(metadata)
+
+	file, err := t.fs.Open(hash)
 	if err != nil {
-		return nil, -1, fmt.Errorf("opening file %q encoded as %q: %w", path, metadata.Hash, err)
+		return nil, -1, fmt.Errorf("opening file %q encoded as %q: %w", path, hash, err)
 	}
 
 	// Verify that the size of the file matches the expected size.
 	// This is a sanity check, that the underlying file hasn't changed.
 	stat, err := file.Stat()
 	if err != nil {
-		return nil, -1, fmt.Errorf("retrieving size: file %q encoded as %q: %w", path, metadata.Hash, err)
+		return nil, -1, fmt.Errorf("retrieving size: file %q encoded as %q: %w", path, hash, err)
 	}
 
 	size := stat.Size()
@@ -323,9 +326,17 @@ func (t *fileObjectStore) put(ctx context.Context, path string, r io.Reader, siz
 	// I can only assume 384 was chosen over 256 and others, is because it's
 	// not susceptible to length extension attacks? In any case, we'll
 	// keep using it for now.
-	hasher := sha512.New384()
+	hash512_384 := sha512.New384()
 
-	tmpFileName, tmpFileCleanup, err := t.writeToTmpFile(t.path, io.TeeReader(r, hasher), size)
+	// We need two hash sets here, because juju wants to use SHA384, but s3
+	// and http handlers want to use SHA256. We can't change the hash used by
+	// default to SHA256. Luckily, we can piggyback on the writing to a tmp
+	// file and create TeeReader with a MultiWriter.
+	hash256 := sha256.New()
+
+	// We need to write this to a temp file, because if the client retries
+	// then we need seek back to the beginning of the file.
+	tmpFileName, tmpFileCleanup, err := t.writeToTmpFile(t.path, io.TeeReader(r, io.MultiWriter(hash512_384, hash256)), size)
 	if err != nil {
 		return "", errors.Trace(err)
 	}
@@ -333,22 +344,21 @@ func (t *fileObjectStore) put(ctx context.Context, path string, r io.Reader, siz
 	// Ensure that we remove the temporary file if we fail to persist it.
 	defer func() { _ = tmpFileCleanup() }()
 
-	// Encode the hash as a hex string. This is what the rest of the juju
-	// codebase expects. Although we should probably use base64.StdEncoding
-	// instead.
-	hash := hex.EncodeToString(hasher.Sum(nil))
+	// Encode the hashes as strings, so we can use them for file and http lookups.
+	encoded512_384 := hex.EncodeToString(hash512_384.Sum(nil))
+	encoded256 := hex.EncodeToString(hash256.Sum(nil))
 
 	// Ensure that the hash of the file matches the expected hash.
-	if expected, ok := validator(hash); !ok {
-		return "", fmt.Errorf("hash mismatch for %q: expected %q, got %q: %w", path, expected, hash, objectstore.ErrHashMismatch)
+	if expected, ok := validator(encoded512_384); !ok {
+		return "", fmt.Errorf("hash mismatch for %q: expected %q, got %q: %w", path, expected, encoded512_384, objectstore.ErrHashMismatch)
 	}
 
 	// Lock the file with the given hash, so that we can't remove the file
 	// while we're writing it.
 	var uuid objectstore.UUID
-	if err := t.withLock(ctx, hash, func(ctx context.Context) error {
+	if err := t.withLock(ctx, encoded512_384, func(ctx context.Context) error {
 		// Persist the temporary file to the final location.
-		if err := t.persistTmpFile(ctx, tmpFileName, hash, size); err != nil {
+		if err := t.persistTmpFile(ctx, tmpFileName, encoded512_384, size); err != nil {
 			return errors.Trace(err)
 		}
 
@@ -357,9 +367,10 @@ func (t *fileObjectStore) put(ctx context.Context, path string, r io.Reader, siz
 		// race where the watch event is emitted before the file is written.
 		var err error
 		if uuid, err = t.metadataService.PutMetadata(ctx, objectstore.Metadata{
-			Path: path,
-			Hash: hash,
-			Size: size,
+			Path:        path,
+			Hash256:     encoded256,
+			Hash512_384: encoded512_384,
+			Size:        size,
 		}); err != nil {
 			return errors.Trace(err)
 		}
@@ -403,7 +414,7 @@ func (t *fileObjectStore) remove(ctx context.Context, path string) error {
 		return fmt.Errorf("get metadata: %w", err)
 	}
 
-	hash := metadata.Hash
+	hash := selectHash(metadata)
 	return t.withLock(ctx, hash, func(ctx context.Context) error {
 		if err := t.metadataService.RemoveMetadata(ctx, path); err != nil {
 			return fmt.Errorf("remove metadata: %w", err)

--- a/internal/objectstore/fileobjectstore_test.go
+++ b/internal/objectstore/fileobjectstore_test.go
@@ -50,9 +50,10 @@ func (s *fileObjectStoreSuite) TestGetMetadataFoundNoFile(c *gc.C) {
 	defer workertest.DirtyKill(c, store)
 
 	s.service.EXPECT().GetMetadata(gomock.Any(), "foo").Return(objectstore.Metadata{
-		Hash: "blah",
-		Path: "foo",
-		Size: 666,
+		Hash512_384: "blah",
+		Hash256:     "blah",
+		Path:        "foo",
+		Size:        666,
 	}, nil).Times(2)
 
 	_, _, err := store.Get(context.Background(), "foo")
@@ -66,15 +67,16 @@ func (s *fileObjectStoreSuite) TestGetMetadataAndFileFound(c *gc.C) {
 
 	namespace := "inferi"
 	fileName := "foo"
-	size, hash := s.createFile(c, s.filePath(path, namespace), fileName, "some content")
+	size, hash512_384, hash256 := s.createFile(c, s.filePath(path, namespace), fileName, "some content")
 
 	store := s.newFileObjectStore(c, path)
 	defer workertest.DirtyKill(c, store)
 
 	s.service.EXPECT().GetMetadata(gomock.Any(), fileName).Return(objectstore.Metadata{
-		Hash: hash,
-		Path: fileName,
-		Size: size,
+		Hash512_384: hash512_384,
+		Hash256:     hash256,
+		Path:        fileName,
+		Size:        size,
 	}, nil)
 
 	file, fileSize, err := store.Get(context.Background(), fileName)
@@ -93,20 +95,22 @@ func (s *fileObjectStoreSuite) TestGetMetadataAndFileNotFoundThenFound(c *gc.C) 
 
 	namespace := "inferi"
 	fileName := "foo"
-	size, hash := s.createFile(c, s.filePath(path, namespace), fileName, "some content")
+	size, hash512_384, hash256 := s.createFile(c, s.filePath(path, namespace), fileName, "some content")
 
 	store := s.newFileObjectStore(c, path)
 	defer workertest.DirtyKill(c, store)
 
 	s.service.EXPECT().GetMetadata(gomock.Any(), fileName).Return(objectstore.Metadata{
-		Hash: hash,
-		Path: fileName,
-		Size: size,
+		Hash512_384: hash512_384,
+		Hash256:     hash256,
+		Path:        fileName,
+		Size:        size,
 	}, errors.NotFoundf("not found"))
 	s.service.EXPECT().GetMetadata(gomock.Any(), fileName).Return(objectstore.Metadata{
-		Hash: hash,
-		Path: fileName,
-		Size: size,
+		Hash512_384: hash512_384,
+		Hash256:     hash256,
+		Path:        fileName,
+		Size:        size,
 	}, nil)
 
 	file, fileSize, err := store.Get(context.Background(), fileName)
@@ -122,15 +126,16 @@ func (s *fileObjectStoreSuite) TestGetMetadataAndFileFoundWithIncorrectSize(c *g
 
 	namespace := "inferi"
 	fileName := "foo"
-	size, hash := s.createFile(c, s.filePath(path, namespace), fileName, "some content")
+	size, hash512_384, hash256 := s.createFile(c, s.filePath(path, namespace), fileName, "some content")
 
 	store := s.newFileObjectStore(c, path)
 	defer workertest.DirtyKill(c, store)
 
 	s.service.EXPECT().GetMetadata(gomock.Any(), fileName).Return(objectstore.Metadata{
-		Hash: hash,
-		Path: fileName,
-		Size: size + 1,
+		Hash512_384: hash512_384,
+		Hash256:     hash256,
+		Path:        fileName,
+		Size:        size + 1,
 	}, nil).Times(2)
 
 	_, _, err := store.Get(context.Background(), fileName)
@@ -140,9 +145,11 @@ func (s *fileObjectStoreSuite) TestGetMetadataAndFileFoundWithIncorrectSize(c *g
 func (s *fileObjectStoreSuite) TestPut(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	hash := s.calculateHexHash(c, "some content")
-	s.expectClaim(hash, 1)
-	s.expectRelease(hash, 1)
+	hash512_384 := s.calculateHexHash512_384(c, "some content")
+	hash256 := s.calculateHexHash256(c, "some content")
+
+	s.expectClaim(hash512_384, 1)
+	s.expectRelease(hash512_384, 1)
 
 	path := c.MkDir()
 
@@ -152,9 +159,10 @@ func (s *fileObjectStoreSuite) TestPut(c *gc.C) {
 	uuid := objectstoretesting.GenObjectStoreUUID(c)
 
 	s.service.EXPECT().PutMetadata(gomock.Any(), objectstore.Metadata{
-		Hash: hash,
-		Path: "foo",
-		Size: 12,
+		Hash512_384: hash512_384,
+		Hash256:     hash256,
+		Path:        "foo",
+		Size:        12,
 	}).Return(uuid, nil)
 
 	received, err := store.Put(context.Background(), "foo", strings.NewReader("some content"), 12)
@@ -166,9 +174,11 @@ func (s *fileObjectStoreSuite) TestPut(c *gc.C) {
 func (s *fileObjectStoreSuite) TestPutFileAlreadyExists(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	hash := s.calculateHexHash(c, "some content")
-	s.expectClaim(hash, 2)
-	s.expectRelease(hash, 2)
+	hash512_384 := s.calculateHexHash512_384(c, "some content")
+	hash256 := s.calculateHexHash256(c, "some content")
+
+	s.expectClaim(hash512_384, 2)
+	s.expectRelease(hash512_384, 2)
 
 	path := c.MkDir()
 
@@ -178,9 +188,10 @@ func (s *fileObjectStoreSuite) TestPutFileAlreadyExists(c *gc.C) {
 	uuid := objectstoretesting.GenObjectStoreUUID(c)
 
 	s.service.EXPECT().PutMetadata(gomock.Any(), objectstore.Metadata{
-		Hash: hash,
-		Path: "foo",
-		Size: 12,
+		Hash512_384: hash512_384,
+		Hash256:     hash256,
+		Path:        "foo",
+		Size:        12,
 	}).Return(uuid, nil).Times(2)
 
 	uuid0, err := store.Put(context.Background(), "foo", strings.NewReader("some content"), 12)
@@ -200,9 +211,11 @@ func (s *fileObjectStoreSuite) TestPutCleansUpFileOnMetadataFailure(c *gc.C) {
 	// If the file is not referenced by another metadata entry, then the file
 	// should be left to be cleaned by the object store later on.
 
-	hash := s.calculateHexHash(c, "some content")
-	s.expectClaim(hash, 1)
-	s.expectRelease(hash, 1)
+	hash512_384 := s.calculateHexHash512_384(c, "some content")
+	hash256 := s.calculateHexHash256(c, "some content")
+
+	s.expectClaim(hash512_384, 1)
+	s.expectRelease(hash512_384, 1)
 
 	path := c.MkDir()
 
@@ -212,15 +225,16 @@ func (s *fileObjectStoreSuite) TestPutCleansUpFileOnMetadataFailure(c *gc.C) {
 	uuid := objectstoretesting.GenObjectStoreUUID(c)
 
 	s.service.EXPECT().PutMetadata(gomock.Any(), objectstore.Metadata{
-		Hash: hash,
-		Path: "foo",
-		Size: 12,
+		Hash512_384: hash512_384,
+		Hash256:     hash256,
+		Path:        "foo",
+		Size:        12,
 	}).Return(uuid, errors.Errorf("boom"))
 
 	_, err := store.Put(context.Background(), "foo", strings.NewReader("some content"), 12)
 	c.Assert(err, gc.ErrorMatches, `.*boom`)
 
-	s.expectFileDoesExist(c, path, hash)
+	s.expectFileDoesExist(c, path, hash512_384)
 }
 
 func (s *fileObjectStoreSuite) TestPutDoesNotCleansUpFileOnMetadataFailure(c *gc.C) {
@@ -230,9 +244,11 @@ func (s *fileObjectStoreSuite) TestPutDoesNotCleansUpFileOnMetadataFailure(c *gc
 	// metadata entry. In this case we need to ensure that the file is not
 	// cleaned up if the metadata service returns an error.
 
-	hash := s.calculateHexHash(c, "some content")
-	s.expectClaim(hash, 2)
-	s.expectRelease(hash, 2)
+	hash512_384 := s.calculateHexHash512_384(c, "some content")
+	hash256 := s.calculateHexHash256(c, "some content")
+
+	s.expectClaim(hash512_384, 2)
+	s.expectRelease(hash512_384, 2)
 
 	path := c.MkDir()
 
@@ -242,32 +258,36 @@ func (s *fileObjectStoreSuite) TestPutDoesNotCleansUpFileOnMetadataFailure(c *gc
 	uuid := objectstoretesting.GenObjectStoreUUID(c)
 
 	s.service.EXPECT().PutMetadata(gomock.Any(), objectstore.Metadata{
-		Hash: hash,
-		Path: "foo",
-		Size: 12,
+		Hash512_384: hash512_384,
+		Hash256:     hash256,
+		Path:        "foo",
+		Size:        12,
 	}).Return(uuid, nil)
 
 	_, err := store.Put(context.Background(), "foo", strings.NewReader("some content"), 12)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.service.EXPECT().PutMetadata(gomock.Any(), objectstore.Metadata{
-		Hash: hash,
-		Path: "foo",
-		Size: 12,
+		Hash512_384: hash512_384,
+		Hash256:     hash256,
+		Path:        "foo",
+		Size:        12,
 	}).Return(uuid, errors.Errorf("boom"))
 
 	_, err = store.Put(context.Background(), "foo", strings.NewReader("some content"), 12)
 	c.Assert(err, gc.ErrorMatches, `.*boom`)
 
-	s.expectFileDoesExist(c, path, hash)
+	s.expectFileDoesExist(c, path, hash512_384)
 }
 
 func (s *fileObjectStoreSuite) TestPutAndCheckHash(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	hash := s.calculateHexHash(c, "some content")
-	s.expectClaim(hash, 1)
-	s.expectRelease(hash, 1)
+	hash512_384 := s.calculateHexHash512_384(c, "some content")
+	hash256 := s.calculateHexHash256(c, "some content")
+
+	s.expectClaim(hash512_384, 1)
+	s.expectRelease(hash512_384, 1)
 
 	path := c.MkDir()
 
@@ -277,12 +297,13 @@ func (s *fileObjectStoreSuite) TestPutAndCheckHash(c *gc.C) {
 	uuid := objectstoretesting.GenObjectStoreUUID(c)
 
 	s.service.EXPECT().PutMetadata(gomock.Any(), objectstore.Metadata{
-		Hash: hash,
-		Path: "foo",
-		Size: 12,
+		Hash512_384: hash512_384,
+		Hash256:     hash256,
+		Path:        "foo",
+		Size:        12,
 	}).Return(uuid, nil)
 
-	uuid, err := store.PutAndCheckHash(context.Background(), "foo", strings.NewReader("some content"), 12, hash)
+	uuid, err := store.PutAndCheckHash(context.Background(), "foo", strings.NewReader("some content"), 12, hash512_384)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(uuid.Validate(), jc.ErrorIsNil)
 }
@@ -290,8 +311,9 @@ func (s *fileObjectStoreSuite) TestPutAndCheckHash(c *gc.C) {
 func (s *fileObjectStoreSuite) TestPutAndCheckHashWithInvalidHash(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	hash := s.calculateHexHash(c, "some content")
-	fakeHash := fmt.Sprintf("%s0", hash)
+	hash512_384 := s.calculateHexHash512_384(c, "some content")
+
+	fakeHash := fmt.Sprintf("%s0", hash512_384)
 
 	path := c.MkDir()
 
@@ -305,9 +327,11 @@ func (s *fileObjectStoreSuite) TestPutAndCheckHashWithInvalidHash(c *gc.C) {
 func (s *fileObjectStoreSuite) TestPutAndCheckHashFileAlreadyExists(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	hash := s.calculateHexHash(c, "some content")
-	s.expectClaim(hash, 2)
-	s.expectRelease(hash, 2)
+	hash512_384 := s.calculateHexHash512_384(c, "some content")
+	hash256 := s.calculateHexHash256(c, "some content")
+
+	s.expectClaim(hash512_384, 2)
+	s.expectRelease(hash512_384, 2)
 
 	path := c.MkDir()
 
@@ -317,16 +341,17 @@ func (s *fileObjectStoreSuite) TestPutAndCheckHashFileAlreadyExists(c *gc.C) {
 	uuid := objectstoretesting.GenObjectStoreUUID(c)
 
 	s.service.EXPECT().PutMetadata(gomock.Any(), objectstore.Metadata{
-		Hash: hash,
-		Path: "foo",
-		Size: 12,
+		Hash512_384: hash512_384,
+		Hash256:     hash256,
+		Path:        "foo",
+		Size:        12,
 	}).Return(uuid, nil).Times(2)
 
-	uuid0, err := store.PutAndCheckHash(context.Background(), "foo", strings.NewReader("some content"), 12, hash)
+	uuid0, err := store.PutAndCheckHash(context.Background(), "foo", strings.NewReader("some content"), 12, hash512_384)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(uuid0.Validate(), jc.ErrorIsNil)
 
-	uuid1, err := store.PutAndCheckHash(context.Background(), "foo", strings.NewReader("some content"), 12, hash)
+	uuid1, err := store.PutAndCheckHash(context.Background(), "foo", strings.NewReader("some content"), 12, hash512_384)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(uuid1.Validate(), jc.ErrorIsNil)
 
@@ -339,9 +364,11 @@ func (s *fileObjectStoreSuite) TestPutAndCheckHashCleansUpFileOnMetadataFailure(
 	// If the file is not referenced by another metadata entry, then the file
 	// should be left to cleaned up by the object store later on.
 
-	hash := s.calculateHexHash(c, "some content")
-	s.expectClaim(hash, 1)
-	s.expectRelease(hash, 1)
+	hash512_384 := s.calculateHexHash512_384(c, "some content")
+	hash256 := s.calculateHexHash256(c, "some content")
+
+	s.expectClaim(hash512_384, 1)
+	s.expectRelease(hash512_384, 1)
 
 	path := c.MkDir()
 
@@ -349,15 +376,16 @@ func (s *fileObjectStoreSuite) TestPutAndCheckHashCleansUpFileOnMetadataFailure(
 	defer workertest.DirtyKill(c, store)
 
 	s.service.EXPECT().PutMetadata(gomock.Any(), objectstore.Metadata{
-		Hash: hash,
-		Path: "foo",
-		Size: 12,
+		Hash512_384: hash512_384,
+		Hash256:     hash256,
+		Path:        "foo",
+		Size:        12,
 	}).Return("", errors.Errorf("boom"))
 
-	_, err := store.PutAndCheckHash(context.Background(), "foo", strings.NewReader("some content"), 12, hash)
+	_, err := store.PutAndCheckHash(context.Background(), "foo", strings.NewReader("some content"), 12, hash512_384)
 	c.Assert(err, gc.ErrorMatches, `.*boom`)
 
-	s.expectFileDoesExist(c, path, hash)
+	s.expectFileDoesExist(c, path, hash512_384)
 }
 
 func (s *fileObjectStoreSuite) TestPutAndCheckHashDoesNotCleansUpFileOnMetadataFailure(c *gc.C) {
@@ -367,9 +395,11 @@ func (s *fileObjectStoreSuite) TestPutAndCheckHashDoesNotCleansUpFileOnMetadataF
 	// metadata entry. In this case we need to ensure that the file is not
 	// cleaned up if the metadata service returns an error.
 
-	hash := s.calculateHexHash(c, "some content")
-	s.expectClaim(hash, 2)
-	s.expectRelease(hash, 2)
+	hash512_384 := s.calculateHexHash512_384(c, "some content")
+	hash256 := s.calculateHexHash256(c, "some content")
+
+	s.expectClaim(hash512_384, 2)
+	s.expectRelease(hash512_384, 2)
 
 	path := c.MkDir()
 
@@ -377,24 +407,26 @@ func (s *fileObjectStoreSuite) TestPutAndCheckHashDoesNotCleansUpFileOnMetadataF
 	defer workertest.DirtyKill(c, store)
 
 	s.service.EXPECT().PutMetadata(gomock.Any(), objectstore.Metadata{
-		Hash: s.calculateHexHash(c, "some content"),
-		Path: "foo",
-		Size: 12,
+		Hash512_384: hash512_384,
+		Hash256:     hash256,
+		Path:        "foo",
+		Size:        12,
 	}).Return("", nil)
 
-	_, err := store.PutAndCheckHash(context.Background(), "foo", strings.NewReader("some content"), 12, hash)
+	_, err := store.PutAndCheckHash(context.Background(), "foo", strings.NewReader("some content"), 12, hash512_384)
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.service.EXPECT().PutMetadata(gomock.Any(), objectstore.Metadata{
-		Hash: hash,
-		Path: "foo",
-		Size: 12,
+		Hash512_384: hash512_384,
+		Hash256:     hash256,
+		Path:        "foo",
+		Size:        12,
 	}).Return("", errors.Errorf("boom"))
 
-	_, err = store.PutAndCheckHash(context.Background(), "foo", strings.NewReader("some content"), 12, hash)
+	_, err = store.PutAndCheckHash(context.Background(), "foo", strings.NewReader("some content"), 12, hash512_384)
 	c.Assert(err, gc.ErrorMatches, `.*boom`)
 
-	s.expectFileDoesExist(c, path, hash)
+	s.expectFileDoesExist(c, path, hash512_384)
 }
 
 func (s *fileObjectStoreSuite) TestRemoveFileNotFound(c *gc.C) {
@@ -415,9 +447,10 @@ func (s *fileObjectStoreSuite) TestRemoveFileNotFound(c *gc.C) {
 	defer workertest.DirtyKill(c, store)
 
 	s.service.EXPECT().GetMetadata(gomock.Any(), fileName).Return(objectstore.Metadata{
-		Hash: "blah",
-		Path: fileName,
-		Size: 666,
+		Hash512_384: "blah",
+		Hash256:     "blah",
+		Path:        fileName,
+		Size:        666,
 	}, nil)
 
 	s.service.EXPECT().RemoveMetadata(gomock.Any(), "foo").Return(nil)
@@ -429,9 +462,11 @@ func (s *fileObjectStoreSuite) TestRemoveFileNotFound(c *gc.C) {
 func (s *fileObjectStoreSuite) TestRemove(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	hash := s.calculateHexHash(c, "some content")
-	s.expectClaim(hash, 2)
-	s.expectRelease(hash, 2)
+	hash512_384 := s.calculateHexHash512_384(c, "some content")
+	hash256 := s.calculateHexHash256(c, "some content")
+
+	s.expectClaim(hash512_384, 2)
+	s.expectRelease(hash512_384, 2)
 
 	path := c.MkDir()
 
@@ -439,20 +474,22 @@ func (s *fileObjectStoreSuite) TestRemove(c *gc.C) {
 	defer workertest.DirtyKill(c, store)
 
 	s.service.EXPECT().PutMetadata(gomock.Any(), objectstore.Metadata{
-		Hash: hash,
-		Path: "foo",
-		Size: 12,
+		Hash512_384: hash512_384,
+		Hash256:     hash256,
+		Path:        "foo",
+		Size:        12,
 	}).Return("", nil)
 
 	_, err := store.Put(context.Background(), "foo", strings.NewReader("some content"), 12)
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.expectFileDoesExist(c, path, hash)
+	s.expectFileDoesExist(c, path, hash512_384)
 
 	s.service.EXPECT().GetMetadata(gomock.Any(), "foo").Return(objectstore.Metadata{
-		Hash: hash,
-		Path: "foo",
-		Size: 12,
+		Hash512_384: hash512_384,
+		Hash256:     hash256,
+		Path:        "foo",
+		Size:        12,
 	}, nil)
 
 	s.service.EXPECT().RemoveMetadata(gomock.Any(), "foo").Return(nil)
@@ -460,7 +497,7 @@ func (s *fileObjectStoreSuite) TestRemove(c *gc.C) {
 	err = store.Remove(context.Background(), "foo")
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.expectFileDoesNotExist(c, path, hash)
+	s.expectFileDoesNotExist(c, path, hash512_384)
 }
 
 func (s *fileObjectStoreSuite) TestList(c *gc.C) {
@@ -470,7 +507,7 @@ func (s *fileObjectStoreSuite) TestList(c *gc.C) {
 
 	namespace := "inferi"
 	fileName := "foo"
-	size, hash := s.createFile(c, s.filePath(path, namespace), fileName, "some content")
+	size, hash512_384, hash256 := s.createFile(c, s.filePath(path, namespace), fileName, "some content")
 
 	s.createDirectory(c, s.filePath(path, namespace), "other")
 
@@ -478,19 +515,21 @@ func (s *fileObjectStoreSuite) TestList(c *gc.C) {
 	defer workertest.DirtyKill(c, store)
 
 	s.service.EXPECT().ListMetadata(gomock.Any()).Return([]objectstore.Metadata{{
-		Hash: hash,
-		Path: fileName,
-		Size: size,
+		Hash512_384: hash512_384,
+		Hash256:     hash256,
+		Path:        fileName,
+		Size:        size,
 	}}, nil)
 
 	metadata, files, err := store.list(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(metadata, gc.DeepEquals, []objectstore.Metadata{{
-		Hash: hash,
-		Path: fileName,
-		Size: size,
+		Hash512_384: hash512_384,
+		Hash256:     hash256,
+		Path:        fileName,
+		Size:        size,
 	}})
-	c.Check(files, gc.DeepEquals, []string{hash})
+	c.Check(files, gc.DeepEquals, []string{hash512_384})
 }
 
 func (s *fileObjectStoreSuite) expectFileDoesNotExist(c *gc.C, path, hash string) {

--- a/internal/objectstore/s3objectstore_test.go
+++ b/internal/objectstore/s3objectstore_test.go
@@ -61,15 +61,17 @@ func (s *s3ObjectStoreSuite) TestGetMetadataNotFound(c *gc.C) {
 func (s *s3ObjectStoreSuite) TestGetMetadataFoundNoFile(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	hash := "blah"
+	hash256 := "blah-256"
+	hash512_384 := "blah-512-384"
 
 	s.session.EXPECT().CreateBucket(gomock.Any(), defaultBucketName).Return(nil)
 	s.service.EXPECT().GetMetadata(gomock.Any(), "foo").Return(objectstore.Metadata{
-		Hash: hash,
-		Path: "foo",
-		Size: 666,
+		Hash256:     hash256,
+		Hash512_384: hash512_384,
+		Path:        "foo",
+		Size:        666,
 	}, nil).Times(2)
-	s.session.EXPECT().GetObject(gomock.Any(), defaultBucketName, filePath(hash)).Return(nil, int64(0), "", errors.NotFoundf("not found")).Times(2)
+	s.session.EXPECT().GetObject(gomock.Any(), defaultBucketName, filePath(hash512_384)).Return(nil, int64(0), "", errors.NotFoundf("not found")).Times(2)
 
 	store := s.newS3ObjectStore(c)
 	defer workertest.DirtyKill(c, store)
@@ -88,7 +90,8 @@ func (s *s3ObjectStoreSuite) TestGetMetadataAndFileNotFoundThenFound(c *gc.C) {
 	// Then attempt to read the file after it exists. This should succeed.
 
 	fileName := "foo"
-	hash := "blah"
+	hash256 := "blah-256"
+	hash512_384 := "blah-512-384"
 	size := int64(666)
 	reader := io.NopCloser(bytes.NewBufferString("hello"))
 
@@ -100,11 +103,12 @@ func (s *s3ObjectStoreSuite) TestGetMetadataAndFileNotFoundThenFound(c *gc.C) {
 
 	s.expectFailure(fileName, errors.NotFoundf("not found"))
 	s.service.EXPECT().GetMetadata(gomock.Any(), fileName).Return(objectstore.Metadata{
-		Hash: hash,
-		Path: fileName,
-		Size: size,
+		Hash256:     hash256,
+		Hash512_384: hash512_384,
+		Path:        fileName,
+		Size:        size,
 	}, nil)
-	s.session.EXPECT().GetObject(gomock.Any(), defaultBucketName, filePath(hash)).Return(reader, size, hash, nil)
+	s.session.EXPECT().GetObject(gomock.Any(), defaultBucketName, filePath(hash512_384)).Return(reader, size, hash512_384, nil)
 
 	store := s.newS3ObjectStore(c)
 	defer workertest.DirtyKill(c, store)
@@ -122,7 +126,8 @@ func (s *s3ObjectStoreSuite) TestGetMetadataAndFileFoundWithIncorrectSize(c *gc.
 	defer s.setupMocks(c).Finish()
 
 	fileName := "foo"
-	hash := "blah"
+	hash256 := "blah-256"
+	hash512_384 := "blah-512-384"
 	size := int64(666)
 	reader := io.NopCloser(bytes.NewBufferString("hello"))
 
@@ -136,11 +141,12 @@ func (s *s3ObjectStoreSuite) TestGetMetadataAndFileFoundWithIncorrectSize(c *gc.
 
 	s.expectFailure(fileName, errors.NotFoundf("not found"))
 	s.service.EXPECT().GetMetadata(gomock.Any(), fileName).Return(objectstore.Metadata{
-		Hash: hash,
-		Path: fileName,
-		Size: size + 1,
+		Hash256:     hash256,
+		Hash512_384: hash512_384,
+		Path:        fileName,
+		Size:        size + 1,
 	}, nil)
-	s.session.EXPECT().GetObject(gomock.Any(), defaultBucketName, filePath(hash)).Return(reader, size, hash, nil)
+	s.session.EXPECT().GetObject(gomock.Any(), defaultBucketName, filePath(hash512_384)).Return(reader, size, hash512_384, nil)
 
 	store := s.newS3ObjectStore(c)
 	defer workertest.DirtyKill(c, store)
@@ -156,22 +162,24 @@ func (s *s3ObjectStoreSuite) TestPut(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	content := "some content"
-	hexHash := s.calculateHexHash(c, content)
-	base64Hash := s.calculateBase64Hash(c, content)
-	s.expectClaim(hexHash, 1)
-	s.expectRelease(hexHash, 1)
+	hexHash512_384 := s.calculateHexHash512_384(c, content)
+	hexHash256 := s.calculateHexHash256(c, content)
+	base64Hash256 := s.calculateBase64Hash256(c, content)
+	s.expectClaim(hexHash512_384, 1)
+	s.expectRelease(hexHash512_384, 1)
 
 	uuid := objectstoretesting.GenObjectStoreUUID(c)
 
 	s.session.EXPECT().CreateBucket(gomock.Any(), defaultBucketName).Return(nil)
 	s.service.EXPECT().PutMetadata(gomock.Any(), objectstore.Metadata{
-		Hash: hexHash,
-		Path: "foo",
-		Size: 12,
+		Hash512_384: hexHash512_384,
+		Hash256:     hexHash256,
+		Path:        "foo",
+		Size:        12,
 	}).Return(uuid, nil)
 
 	var receivedContent string
-	s.session.EXPECT().PutObject(gomock.Any(), defaultBucketName, filePath(hexHash), gomock.Any(), base64Hash).DoAndReturn(func(ctx context.Context, bucketName, objectName string, body io.Reader, hash string) error {
+	s.session.EXPECT().PutObject(gomock.Any(), defaultBucketName, filePath(hexHash512_384), gomock.Any(), base64Hash256).DoAndReturn(func(ctx context.Context, bucketName, objectName string, body io.Reader, hash string) error {
 		receivedContent = s.readFile(c, io.NopCloser(body))
 		return nil
 	})
@@ -194,22 +202,24 @@ func (s *s3ObjectStoreSuite) TestPutAndCheckHash(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	content := "some content"
-	hexHash := s.calculateHexHash(c, content)
-	base64Hash := s.calculateBase64Hash(c, content)
-	s.expectClaim(hexHash, 1)
-	s.expectRelease(hexHash, 1)
+	hexHash512_384 := s.calculateHexHash512_384(c, content)
+	hexHash256 := s.calculateHexHash256(c, content)
+	base64Hash256 := s.calculateBase64Hash256(c, content)
+	s.expectClaim(hexHash512_384, 1)
+	s.expectRelease(hexHash512_384, 1)
 
 	uuid := objectstoretesting.GenObjectStoreUUID(c)
 
 	s.session.EXPECT().CreateBucket(gomock.Any(), defaultBucketName).Return(nil)
 	s.service.EXPECT().PutMetadata(gomock.Any(), objectstore.Metadata{
-		Hash: hexHash,
-		Path: "foo",
-		Size: 12,
+		Hash512_384: hexHash512_384,
+		Hash256:     hexHash256,
+		Path:        "foo",
+		Size:        12,
 	}).Return(uuid, nil)
 
 	var receivedContent string
-	s.session.EXPECT().PutObject(gomock.Any(), defaultBucketName, filePath(hexHash), gomock.Any(), base64Hash).DoAndReturn(func(ctx context.Context, bucketName, objectName string, body io.Reader, hash string) error {
+	s.session.EXPECT().PutObject(gomock.Any(), defaultBucketName, filePath(hexHash512_384), gomock.Any(), base64Hash256).DoAndReturn(func(ctx context.Context, bucketName, objectName string, body io.Reader, hash string) error {
 		receivedContent = s.readFile(c, io.NopCloser(body))
 		return nil
 	})
@@ -220,7 +230,7 @@ func (s *s3ObjectStoreSuite) TestPutAndCheckHash(c *gc.C) {
 	// Ensure we've started up before we start the test.
 	s.expectStartup(c)
 
-	uuid, err := store.PutAndCheckHash(context.Background(), "foo", strings.NewReader(content), 12, hexHash)
+	uuid, err := store.PutAndCheckHash(context.Background(), "foo", strings.NewReader(content), 12, hexHash512_384)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(uuid.Validate(), jc.ErrorIsNil)
 
@@ -231,8 +241,8 @@ func (s *s3ObjectStoreSuite) TestPutAndCheckHashWithInvalidHash(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	content := "some content"
-	hexHash := s.calculateHexHash(c, content)
-	fakeHash := fmt.Sprintf("%s0", hexHash)
+	hexHash512_384 := s.calculateHexHash512_384(c, content)
+	fakeHash := fmt.Sprintf("%s0", hexHash512_384)
 
 	s.session.EXPECT().CreateBucket(gomock.Any(), defaultBucketName).Return(nil)
 
@@ -250,26 +260,28 @@ func (s *s3ObjectStoreSuite) TestPutAndCheckHashFileAlreadyExists(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	content := "some content"
-	hexHash := s.calculateHexHash(c, content)
-	base64Hash := s.calculateBase64Hash(c, content)
-	s.expectClaim(hexHash, 2)
-	s.expectRelease(hexHash, 2)
+	hexHash512_384 := s.calculateHexHash512_384(c, content)
+	hexHash256 := s.calculateHexHash256(c, content)
+	base64Hash256 := s.calculateBase64Hash256(c, content)
+	s.expectClaim(hexHash512_384, 2)
+	s.expectRelease(hexHash512_384, 2)
 
 	uuid := objectstoretesting.GenObjectStoreUUID(c)
 
 	s.session.EXPECT().CreateBucket(gomock.Any(), defaultBucketName).Return(nil)
 	s.service.EXPECT().PutMetadata(gomock.Any(), objectstore.Metadata{
-		Hash: hexHash,
-		Path: "foo",
-		Size: 12,
+		Hash512_384: hexHash512_384,
+		Hash256:     hexHash256,
+		Path:        "foo",
+		Size:        12,
 	}).Return(uuid, nil).Times(2)
 
 	var receivedContent string
-	s.session.EXPECT().PutObject(gomock.Any(), defaultBucketName, filePath(hexHash), gomock.Any(), base64Hash).DoAndReturn(func(ctx context.Context, bucketName, objectName string, body io.Reader, hash string) error {
+	s.session.EXPECT().PutObject(gomock.Any(), defaultBucketName, filePath(hexHash512_384), gomock.Any(), base64Hash256).DoAndReturn(func(ctx context.Context, bucketName, objectName string, body io.Reader, hash string) error {
 		receivedContent = s.readFile(c, io.NopCloser(body))
 		return nil
 	})
-	s.session.EXPECT().PutObject(gomock.Any(), defaultBucketName, filePath(hexHash), gomock.Any(), base64Hash).Return(errors.AlreadyExistsf("already exists"))
+	s.session.EXPECT().PutObject(gomock.Any(), defaultBucketName, filePath(hexHash512_384), gomock.Any(), base64Hash256).Return(errors.AlreadyExistsf("already exists"))
 
 	store := s.newS3ObjectStore(c)
 	defer workertest.DirtyKill(c, store)
@@ -277,11 +289,11 @@ func (s *s3ObjectStoreSuite) TestPutAndCheckHashFileAlreadyExists(c *gc.C) {
 	// Ensure we've started up before we start the test.
 	s.expectStartup(c)
 
-	uuid0, err := store.PutAndCheckHash(context.Background(), "foo", strings.NewReader(content), 12, hexHash)
+	uuid0, err := store.PutAndCheckHash(context.Background(), "foo", strings.NewReader(content), 12, hexHash512_384)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(uuid0.Validate(), jc.ErrorIsNil)
 
-	uuid1, err := store.PutAndCheckHash(context.Background(), "foo", strings.NewReader(content), 12, hexHash)
+	uuid1, err := store.PutAndCheckHash(context.Background(), "foo", strings.NewReader(content), 12, hexHash512_384)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(uuid1.Validate(), jc.ErrorIsNil)
 
@@ -297,20 +309,22 @@ func (s *s3ObjectStoreSuite) TestPutFileOnMetadataFailure(c *gc.C) {
 	// should be left to cleaned up by the object store later on.
 
 	content := "some content"
-	hexHash := s.calculateHexHash(c, content)
-	base64Hash := s.calculateBase64Hash(c, content)
-	s.expectClaim(hexHash, 1)
-	s.expectRelease(hexHash, 1)
+	hexHash512_384 := s.calculateHexHash512_384(c, content)
+	hexHash256 := s.calculateHexHash256(c, content)
+	base64Hash256 := s.calculateBase64Hash256(c, content)
+	s.expectClaim(hexHash512_384, 1)
+	s.expectRelease(hexHash512_384, 1)
 
 	uuid := objectstoretesting.GenObjectStoreUUID(c)
 
 	s.session.EXPECT().CreateBucket(gomock.Any(), defaultBucketName).Return(nil)
 	s.service.EXPECT().PutMetadata(gomock.Any(), objectstore.Metadata{
-		Hash: hexHash,
-		Path: "foo",
-		Size: 12,
+		Hash512_384: hexHash512_384,
+		Hash256:     hexHash256,
+		Path:        "foo",
+		Size:        12,
 	}).Return(uuid, errors.Errorf("boom"))
-	s.session.EXPECT().PutObject(gomock.Any(), defaultBucketName, filePath(hexHash), gomock.Any(), base64Hash).Return(nil)
+	s.session.EXPECT().PutObject(gomock.Any(), defaultBucketName, filePath(hexHash512_384), gomock.Any(), base64Hash256).Return(nil)
 
 	store := s.newS3ObjectStore(c)
 	defer workertest.DirtyKill(c, store)
@@ -318,7 +332,7 @@ func (s *s3ObjectStoreSuite) TestPutFileOnMetadataFailure(c *gc.C) {
 	// Ensure we've started up before we start the test.
 	s.expectStartup(c)
 
-	_, err := store.PutAndCheckHash(context.Background(), "foo", strings.NewReader(content), 12, hexHash)
+	_, err := store.PutAndCheckHash(context.Background(), "foo", strings.NewReader(content), 12, hexHash512_384)
 	c.Assert(err, gc.ErrorMatches, `.*boom`)
 }
 
@@ -330,22 +344,24 @@ func (s *s3ObjectStoreSuite) TestRemoveFileNotFound(c *gc.C) {
 	// is removed.
 
 	content := "some content"
-	hexHash := s.calculateHexHash(c, content)
+	hexHash512_384 := s.calculateHexHash512_384(c, content)
+	hexHash256 := s.calculateHexHash256(c, content)
 
-	s.expectClaim(hexHash, 1)
-	s.expectRelease(hexHash, 1)
+	s.expectClaim(hexHash512_384, 1)
+	s.expectRelease(hexHash512_384, 1)
 
 	fileName := "foo"
 
 	s.session.EXPECT().CreateBucket(gomock.Any(), defaultBucketName).Return(nil)
 	s.service.EXPECT().GetMetadata(gomock.Any(), fileName).Return(objectstore.Metadata{
-		Hash: hexHash,
-		Path: fileName,
-		Size: 666,
+		Hash512_384: hexHash512_384,
+		Hash256:     hexHash256,
+		Path:        fileName,
+		Size:        666,
 	}, nil)
 
 	s.service.EXPECT().RemoveMetadata(gomock.Any(), "foo").Return(nil)
-	s.session.EXPECT().DeleteObject(gomock.Any(), defaultBucketName, filePath(hexHash)).Return(errors.NotFoundf("foo"))
+	s.session.EXPECT().DeleteObject(gomock.Any(), defaultBucketName, filePath(hexHash512_384)).Return(errors.NotFoundf("foo"))
 
 	store := s.newS3ObjectStore(c)
 	defer workertest.DirtyKill(c, store)
@@ -361,20 +377,22 @@ func (s *s3ObjectStoreSuite) TestRemove(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	content := "some content"
-	hexHash := s.calculateHexHash(c, content)
+	hexHash512_384 := s.calculateHexHash512_384(c, content)
+	hexHash256 := s.calculateHexHash256(c, content)
 
-	s.expectClaim(hexHash, 1)
-	s.expectRelease(hexHash, 1)
+	s.expectClaim(hexHash512_384, 1)
+	s.expectRelease(hexHash512_384, 1)
 
 	s.session.EXPECT().CreateBucket(gomock.Any(), defaultBucketName).Return(nil)
 	s.service.EXPECT().GetMetadata(gomock.Any(), "foo").Return(objectstore.Metadata{
-		Hash: hexHash,
-		Path: "foo",
-		Size: 12,
+		Hash512_384: hexHash512_384,
+		Hash256:     hexHash256,
+		Path:        "foo",
+		Size:        12,
 	}, nil)
 
 	s.service.EXPECT().RemoveMetadata(gomock.Any(), "foo").Return(nil)
-	s.session.EXPECT().DeleteObject(gomock.Any(), defaultBucketName, filePath(hexHash)).Return(nil)
+	s.session.EXPECT().DeleteObject(gomock.Any(), defaultBucketName, filePath(hexHash512_384)).Return(nil)
 
 	store := s.newS3ObjectStore(c)
 	defer workertest.DirtyKill(c, store)
@@ -390,17 +408,20 @@ func (s *s3ObjectStoreSuite) TestList(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	content := "some content"
-	hexHash := s.calculateHexHash(c, content)
+	hexHash512_384 := s.calculateHexHash512_384(c, content)
+	hexHash256 := s.calculateHexHash256(c, content)
+
 	fileName := "foo"
 	size := int64(666)
 
 	s.session.EXPECT().CreateBucket(gomock.Any(), defaultBucketName).Return(nil)
 	s.service.EXPECT().ListMetadata(gomock.Any()).Return([]objectstore.Metadata{{
-		Hash: hexHash,
-		Path: fileName,
-		Size: size,
+		Hash512_384: hexHash512_384,
+		Hash256:     hexHash256,
+		Path:        fileName,
+		Size:        size,
 	}}, nil)
-	s.session.EXPECT().ListObjects(gomock.Any(), defaultBucketName).Return([]string{hexHash}, nil)
+	s.session.EXPECT().ListObjects(gomock.Any(), defaultBucketName).Return([]string{hexHash512_384}, nil)
 
 	store := s.newS3ObjectStore(c).(*s3ObjectStore)
 	defer workertest.DirtyKill(c, store)
@@ -411,11 +432,12 @@ func (s *s3ObjectStoreSuite) TestList(c *gc.C) {
 	metadata, files, err := store.list(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(metadata, gc.DeepEquals, []objectstore.Metadata{{
-		Hash: hexHash,
-		Path: fileName,
-		Size: size,
+		Hash512_384: hexHash512_384,
+		Hash256:     hexHash256,
+		Path:        fileName,
+		Size:        size,
 	}})
-	c.Check(files, gc.DeepEquals, []string{hexHash})
+	c.Check(files, gc.DeepEquals, []string{hexHash512_384})
 }
 
 func (s *s3ObjectStoreSuite) TestDrainFilesWithNoFiles(c *gc.C) {
@@ -443,9 +465,10 @@ func (s *s3ObjectStoreSuite) TestDrainFiles(c *gc.C) {
 	s.session.EXPECT().CreateBucket(gomock.Any(), defaultBucketName).Return(nil)
 
 	s.expectListMetadata([]objectstore.Metadata{{
-		Hash: "foo",
-		Path: "foo",
-		Size: 12,
+		Hash512_384: "foo",
+		Hash256:     "foo",
+		Path:        "foo",
+		Size:        12,
 	}})
 	s.expectHashToExistError("foo", errors.NotFound)
 
@@ -468,9 +491,10 @@ func (s *s3ObjectStoreSuite) TestDrainFilesWithError(c *gc.C) {
 
 	s.session.EXPECT().CreateBucket(gomock.Any(), defaultBucketName).Return(nil)
 	s.expectListMetadata([]objectstore.Metadata{{
-		Hash: "foo",
-		Path: "foo",
-		Size: 12,
+		Hash512_384: "foo",
+		Hash256:     "foo",
+		Path:        "foo",
+		Size:        12,
 	}})
 	done := s.expectHashToExistError("foo", errors.Errorf("boom"))
 
@@ -671,7 +695,7 @@ func (s *s3ObjectStoreSuite) TestComputeS3Hash(c *gc.C) {
 	// the reader to the start of the file.
 
 	content := "some content"
-	expectedHash := s.calculateBase64Hash(c, content)
+	expectedHash := s.calculateBase64Hash256(c, content)
 
 	store := &s3ObjectStore{}
 
@@ -692,7 +716,7 @@ func (s *s3ObjectStoreSuite) TestComputeS3HashNoSeekerReader(c *gc.C) {
 	// we require that the reader is rewound to the start of the file.
 
 	content := "some content"
-	expectedHash := s.calculateBase64Hash(c, content)
+	expectedHash := s.calculateBase64Hash256(c, content)
 
 	store := &s3ObjectStore{}
 
@@ -709,8 +733,8 @@ func (s *s3ObjectStoreSuite) TestPersistTmpFile(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	content := "some content"
-	hexHash := s.calculateHexHash(c, content)
-	base64Hash := s.calculateBase64Hash(c, content)
+	hexHash := s.calculateHexHash512_384(c, content)
+	base64Hash := s.calculateBase64Hash256(c, content)
 
 	s.session.EXPECT().CreateBucket(gomock.Any(), defaultBucketName).Return(nil)
 

--- a/scripts/dqlite/Makefile
+++ b/scripts/dqlite/Makefile
@@ -41,3 +41,9 @@ repl-install:
 
 repl:
 	+@./scripts/dqlite/scripts/repl/repl.sh
+
+repl-list-models:
+	+@./scripts/dqlite/scripts/repl/repl-list-models.sh
+
+repl-model:
+	+@./scripts/dqlite/scripts/repl/repl-model.sh

--- a/scripts/dqlite/scripts/repl/repl-list-models.sh
+++ b/scripts/dqlite/scripts/repl/repl-list-models.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+
+MACHINE=${MACHINE:-0}
+
+CMDS=$(cat << EOF
+sudo awk '/controllercert/ {in_cert_block=1; next}
+/:/ {in_cert_block=0}
+in_cert_block { print }' /var/lib/juju/agents/machine-$MACHINE/agent.conf | sed 's/  //' > dqlite.cert
+sudo awk '/controllerkey/ {in_cert_block=1; next}
+/:/ {in_cert_block=0}
+in_cert_block { print }' /var/lib/juju/agents/machine-$MACHINE/agent.conf | sed 's/  //' > dqlite.key
+sudo dqlite -s file:///var/lib/juju/dqlite/cluster.yaml -c ./dqlite.cert -k ./dqlite.key controller "SELECT uuid, name FROM model"
+EOF
+)
+
+juju ssh --pty=false -m controller ${MACHINE} "${CMDS}"

--- a/scripts/dqlite/scripts/repl/repl.sh
+++ b/scripts/dqlite/scripts/repl/repl.sh
@@ -7,7 +7,7 @@ DB_NAME=${DB_NAME:-controller}
 
 echo "-------------------------------------------------------------------------"
 echo ""
-echo "DQLITE REPL Mode:"
+echo "DQLITE REPL Mode: ${DB_NAME}"
 echo ""
 echo "-------------------------------------------------------------------------"
 echo ""


### PR DESCRIPTION
The object store currently stores all hashes as 512_384, which is an issue when searching for files based on the hash. The API objects are expected to be searched via 256. This is because the http handlers are moving towards s3 compatability. Unfortunately, the backend of juju uses 512_348. There isn't anything we can do about that right now, but we can store both to make our lives easier for now and in the future. This means if we did want to drop either, it should be doable now.


-----

This pull request includes significant changes to the `objectstore` package, focusing on enhancing the metadata structure and improving error handling. The most important changes include renaming and expanding hash fields in the `Metadata` struct, adding new error handling for missing hashes, and updating related tests and database interactions.

### Metadata Structure Enhancements:
* [`core/objectstore/metadata.go`](diffhunk://#diff-74121d42b45bae39af87391e4a84a59878baed310c2385680ff3e49a8d0eb274L22-R25): Renamed `Hash` to `Hash256` and added a new field `Hash512_384` to the `Metadata` struct.

### Error Handling Improvements:
* [`domain/objectstore/errors/errors.go`](diffhunk://#diff-d7e7b1efae793960e9d6e5598952bd588d3fe1ac142e019fa5133d01b9622137R20-R22): Introduced a new error `ErrMissingHash` for cases where a hash is missing.
* [`domain/objectstore/service/service.go`](diffhunk://#diff-4adf2f712065e640b54bed210bc3e8684b2fa886ea775697e4b3a79968096c55L54-R106): Updated `PutMetadata` to handle cases where either `Hash256` or `Hash512_384` is missing, returning `ErrMissingHash` accordingly.

### Codebase Refactoring:
* [`domain/objectstore/service/service.go`](diffhunk://#diff-4adf2f712065e640b54bed210bc3e8684b2fa886ea775697e4b3a79968096c55L14-R26): Replaced references to `coreobjectstore` with `objectstore` and updated method implementations to use the new hash fields. [[1]](diffhunk://#diff-4adf2f712065e640b54bed210bc3e8684b2fa886ea775697e4b3a79968096c55L14-R26) [[2]](diffhunk://#diff-4adf2f712065e640b54bed210bc3e8684b2fa886ea775697e4b3a79968096c55L41-R41) [[3]](diffhunk://#diff-4adf2f712065e640b54bed210bc3e8684b2fa886ea775697e4b3a79968096c55L54-R106)
* [`domain/objectstore/state/state.go`](diffhunk://#diff-c42f783bb3188aca5482018e5a76e81124933a13439c2bcefd4b70071fdfa626L43-R43): Modified database queries and insertions to handle the new hash fields. [[1]](diffhunk://#diff-c42f783bb3188aca5482018e5a76e81124933a13439c2bcefd4b70071fdfa626L43-R43) [[2]](diffhunk://#diff-c42f783bb3188aca5482018e5a76e81124933a13439c2bcefd4b70071fdfa626L75-R75) [[3]](diffhunk://#diff-c42f783bb3188aca5482018e5a76e81124933a13439c2bcefd4b70071fdfa626L110-R111) [[4]](diffhunk://#diff-c42f783bb3188aca5482018e5a76e81124933a13439c2bcefd4b70071fdfa626L121-R124) [[5]](diffhunk://#diff-c42f783bb3188aca5482018e5a76e81124933a13439c2bcefd4b70071fdfa626L137-R142)

### Test Updates:
* [`domain/objectstore/service/service_test.go`](diffhunk://#diff-6f8f83c98867fea330c448d9b9032118b4bb202ad7483ffdf5d2fe49fc960db3L17-R19): Updated tests to reflect changes in the `Metadata` struct and added new tests for missing hash scenarios. [[1]](diffhunk://#diff-6f8f83c98867fea330c448d9b9032118b4bb202ad7483ffdf5d2fe49fc960db3L17-R19) [[2]](diffhunk://#diff-6f8f83c98867fea330c448d9b9032118b4bb202ad7483ffdf5d2fe49fc960db3L37-R48) [[3]](diffhunk://#diff-6f8f83c98867fea330c448d9b9032118b4bb202ad7483ffdf5d2fe49fc960db3L59-R101) [[4]](diffhunk://#diff-6f8f83c98867fea330c448d9b9032118b4bb202ad7483ffdf5d2fe49fc960db3R110-R137)
* [`domain/objectstore/state/state_test.go`](diffhunk://#diff-2a8a15d54edc97d16fc46b82fa407963a270e655409462930c8b941f7988014bL36-R37): Adjusted tests to accommodate the new hash fields and added new test cases for hash conflict scenarios. [[1]](diffhunk://#diff-2a8a15d54edc97d16fc46b82fa407963a270e655409462930c8b941f7988014bL36-R37) [[2]](diffhunk://#diff-2a8a15d54edc97d16fc46b82fa407963a270e655409462930c8b941f7988014bL53-R55) [[3]](diffhunk://#diff-2a8a15d54edc97d16fc46b82fa407963a270e655409462930c8b941f7988014bL70-R73) [[4]](diffhunk://#diff-2a8a15d54edc97d16fc46b82fa407963a270e655409462930c8b941f7988014bL84-R88) [[5]](diffhunk://#diff-2a8a15d54edc97d16fc46b82fa407963a270e655409462930c8b941f7988014bL95-R99) [[6]](diffhunk://#diff-2a8a15d54edc97d16fc46b82fa407963a270e655409462930c8b941f7988014bL108-R169) [[7]](diffhunk://#diff-2a8a15d54edc97d16fc46b82fa407963a270e655409462930c8b941f7988014bL137-R196) [[8]](diffhunk://#diff-2a8a15d54edc97d16fc46b82fa407963a270e655409462930c8b941f7988014bL162-R217) [[9]](diffhunk://#diff-2a8a15d54edc97d16fc46b82fa407963a270e655409462930c8b941f7988014bL189-R251)


## QA Steps

```sh
$ juju bootstrap lxd test
$ juju add-model default
$ juju deploy ubuntu
$ make repl-install
$ make repl DB_NAME="<locate one>"
dqlite> SELECT * FROM object_store_metadata
```

## Links


**Jira card:** JUJU-

