### PR TITLE
refactor: remove juju/errors

### DIFF
--- a/api/package_test.go
+++ b/api/package_test.go
@@ -60,6 +60,7 @@ func (*ImportSuite) TestImports(c *gc.C) {
 		"internal/charm/assumes",
 		"internal/charm/hooks",
 		"internal/charm/resource",
+		"internal/errors",
 		"internal/featureflag",
 		"internal/http",
 		"internal/logger",

--- a/domain/access/bootstrap/bootstrap.go
+++ b/domain/access/bootstrap/bootstrap.go
@@ -5,10 +5,8 @@ package bootstrap
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/canonical/sqlair"
-	"github.com/juju/errors"
 
 	"github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/permission"
@@ -17,6 +15,7 @@ import (
 	"github.com/juju/juju/domain/access/state"
 	"github.com/juju/juju/internal/auth"
 	internaldatabase "github.com/juju/juju/internal/database"
+	"github.com/juju/juju/internal/errors"
 )
 
 // AddUserWithPassword is responsible for adding a new user in the system at
@@ -29,32 +28,32 @@ func AddUserWithPassword(name user.Name, password auth.Password, access permissi
 	defer password.Destroy()
 
 	if name.IsZero() {
-		return "", bootstrapErr(errors.Annotatef(usererrors.UserNameNotValid, "%q", name))
+		return "", bootstrapErr(errors.Errorf("%q %w", name, usererrors.UserNameNotValid))
 	}
 
 	uuid, err := user.NewUUID()
 	if err != nil {
-		return "", bootstrapErr(fmt.Errorf(
+		return "", bootstrapErr(errors.Errorf(
 			"generating uuid for bootstrap add user %q with password: %w",
 			name, err))
 	}
 
 	salt, err := auth.NewSalt()
 	if err != nil {
-		return "", bootstrapErr(fmt.Errorf(
+		return "", bootstrapErr(errors.Errorf(
 			"generating salt for bootstrap add user %q with password: %w",
 			name, err))
 	}
 
 	pwHash, err := auth.HashPassword(password, salt)
 	if err != nil {
-		return "", bootstrapErr(fmt.Errorf(
+		return "", bootstrapErr(errors.Errorf(
 			"generating password hash for bootstrap add user %q with password: %w",
 			name, err))
 	}
 
 	return uuid, func(ctx context.Context, controller, model database.TxnRunner) error {
-		return errors.Trace(controller.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		return errors.Capture(controller.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 			if err = state.AddUserWithPassword(
 				ctx, tx,
 				uuid,
@@ -63,12 +62,13 @@ func AddUserWithPassword(name user.Name, password auth.Password, access permissi
 				access,
 				pwHash, salt,
 			); err != nil {
-				return fmt.Errorf("adding bootstrap user %q with password: %w",
-					name, err,
-				)
+				return errors.Errorf("adding bootstrap user %q with password: %w",
+					name, err)
+
 			}
 			return nil
 		}))
+
 	}
 }
 

--- a/domain/access/errors/errors.go
+++ b/domain/access/errors/errors.go
@@ -3,9 +3,7 @@
 
 package errors
 
-import (
-	"github.com/juju/errors"
-)
+import "github.com/juju/juju/internal/errors"
 
 const (
 	// UserNotFound describes an error that occurs when the user being requested does

--- a/domain/access/modelmigration/export.go
+++ b/domain/access/modelmigration/export.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/juju/description/v8"
-	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 
 	"github.com/juju/juju/core/logger"
@@ -19,6 +18,7 @@ import (
 	accesserrors "github.com/juju/juju/domain/access/errors"
 	"github.com/juju/juju/domain/access/service"
 	"github.com/juju/juju/domain/access/state"
+	"github.com/juju/juju/internal/errors"
 )
 
 // RegisterExport registers the export operations with the given coordinator.
@@ -78,12 +78,12 @@ func (e *exportOperation) Execute(ctx context.Context, model description.Model) 
 		Key:        modelUUID,
 	})
 	if err != nil {
-		return errors.Annotatef(err, "getting user access on model")
+		return errors.Errorf("getting user access on model %w", err)
 	}
 	for _, userAccess := range userAccesses {
 		lastModelLogin, err := e.service.LastModelLogin(ctx, userAccess.UserName, coremodel.UUID(modelUUID))
 		if err != nil && !errors.Is(err, accesserrors.UserNeverAccessedModel) {
-			return errors.Annotatef(err, "getting user last login on model")
+			return errors.Errorf("getting user last login on model %w", err)
 		}
 		userName := names.NewUserTag(userAccess.UserName.Name())
 		var createdBy names.UserTag

--- a/domain/access/modelmigration/import.go
+++ b/domain/access/modelmigration/import.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/juju/description/v8"
-	"github.com/juju/errors"
 
 	"github.com/juju/juju/core/logger"
 	coremodel "github.com/juju/juju/core/model"
@@ -18,6 +17,7 @@ import (
 	accesserrors "github.com/juju/juju/domain/access/errors"
 	"github.com/juju/juju/domain/access/service"
 	"github.com/juju/juju/domain/access/state"
+	"github.com/juju/juju/internal/errors"
 )
 
 // Coordinator is the interface that is used to add operations to a migration.
@@ -78,7 +78,7 @@ func (i *importOperation) Execute(ctx context.Context, model description.Model) 
 		name := user.NameFromTag(u.Name())
 		access := corepermission.Access(u.Access())
 		if err := access.Validate(); err != nil {
-			return errors.Annotatef(err, "importing access for user %q", name)
+			return errors.Errorf("importing access for user %q %w", name, err)
 		}
 		_, err := i.service.CreatePermission(ctx, corepermission.UserAccessSpec{
 			AccessSpec: corepermission.AccessSpec{
@@ -93,14 +93,14 @@ func (i *importOperation) Execute(ctx context.Context, model description.Model) 
 		if err != nil && !errors.Is(err, accesserrors.PermissionAlreadyExists) {
 			// If the permission already exists then it must be the model owner
 			// who is granted admin access when the model is created.
-			return errors.Annotatef(err, "creating permission for user %q", name)
+			return errors.Errorf("creating permission for user %q %w", name, err)
 		}
 
 		lastLogin := u.LastConnection()
 		if !lastLogin.IsZero() {
 			err := i.service.SetLastModelLogin(ctx, name, coremodel.UUID(modelUUID), lastLogin)
 			if err != nil {
-				return errors.Annotatef(err, "setting model last login for user %q", name)
+				return errors.Errorf("setting model last login for user %q %w", name, err)
 			}
 		}
 

--- a/domain/access/service/permission.go
+++ b/domain/access/service/permission.go
@@ -6,13 +6,13 @@ package service
 import (
 	"context"
 
-	"github.com/juju/errors"
-
 	"github.com/juju/juju/core/credential"
+	coreerrors "github.com/juju/juju/core/errors"
 	corepermission "github.com/juju/juju/core/permission"
 	"github.com/juju/juju/core/user"
 	"github.com/juju/juju/domain/access"
 	accesserrors "github.com/juju/juju/domain/access/errors"
+	"github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/internal/uuid"
 )
 
@@ -33,14 +33,14 @@ func NewPermissionService(st PermissionState) *PermissionService {
 // are passed through from the spec validation and state layer.
 func (s *PermissionService) CreatePermission(ctx context.Context, spec corepermission.UserAccessSpec) (corepermission.UserAccess, error) {
 	if err := spec.Validate(); err != nil {
-		return corepermission.UserAccess{}, errors.Trace(err)
+		return corepermission.UserAccess{}, errors.Capture(err)
 	}
 	newUUID, err := uuid.NewUUID()
 	if err != nil {
-		return corepermission.UserAccess{}, errors.Trace(err)
+		return corepermission.UserAccess{}, errors.Capture(err)
 	}
 	userAccess, err := s.st.CreatePermission(ctx, newUUID, spec)
-	return userAccess, errors.Trace(err)
+	return userAccess, errors.Capture(err)
 }
 
 // DeletePermission removes the given user's access to the given target.
@@ -48,12 +48,12 @@ func (s *PermissionService) CreatePermission(ctx context.Context, spec corepermi
 // the target is not valid. Any errors from the state layer are passed through.
 func (s *PermissionService) DeletePermission(ctx context.Context, subject user.Name, target corepermission.ID) error {
 	if subject.IsZero() {
-		return errors.Trace(errors.NotValidf("empty subject"))
+		return errors.Capture(errors.Errorf("empty subject %w", coreerrors.NotValid))
 	}
 	if err := target.Validate(); err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
-	return errors.Trace(s.st.DeletePermission(ctx, subject, target))
+	return errors.Capture(s.st.DeletePermission(ctx, subject, target))
 }
 
 // ReadUserAccessForTarget returns the user access for the given user on
@@ -62,13 +62,13 @@ func (s *PermissionService) DeletePermission(ctx context.Context, subject user.N
 // layer are passed through.
 func (s *PermissionService) ReadUserAccessForTarget(ctx context.Context, subject user.Name, target corepermission.ID) (corepermission.UserAccess, error) {
 	if subject.IsZero() {
-		return corepermission.UserAccess{}, errors.Trace(errors.NotValidf("empty subject"))
+		return corepermission.UserAccess{}, errors.Capture(errors.Errorf("empty subject %w", coreerrors.NotValid))
 	}
 	if err := target.Validate(); err != nil {
-		return corepermission.UserAccess{}, errors.Trace(err)
+		return corepermission.UserAccess{}, errors.Capture(err)
 	}
 	userAccess, err := s.st.ReadUserAccessForTarget(ctx, subject, target)
-	return userAccess, errors.Trace(err)
+	return userAccess, errors.Capture(err)
 }
 
 // EnsureExternalUserIfAuthorized checks if an external user is missing from the
@@ -77,16 +77,16 @@ func (s *PermissionService) ReadUserAccessForTarget(ctx context.Context, subject
 // inherited their permissions from everyone@external.
 func (s *PermissionService) EnsureExternalUserIfAuthorized(ctx context.Context, subject user.Name, target corepermission.ID) error {
 	if subject.IsZero() {
-		return errors.Trace(errors.NotValidf("empty subject"))
+		return errors.Capture(errors.Errorf("empty subject %w", coreerrors.NotValid))
 	}
 	if err := target.Validate(); err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	err := s.st.EnsureExternalUserIfAuthorized(ctx, subject, target)
 	if errors.Is(err, accesserrors.UserNotFound) {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
-	return errors.Trace(err)
+	return errors.Capture(err)
 }
 
 // ReadUserAccessLevelForTarget returns the user access level for the
@@ -97,13 +97,13 @@ func (s *PermissionService) EnsureExternalUserIfAuthorized(ctx context.Context, 
 // [accesserrors.AccessNotFound] is returned.
 func (s *PermissionService) ReadUserAccessLevelForTarget(ctx context.Context, subject user.Name, target corepermission.ID) (corepermission.Access, error) {
 	if subject.IsZero() {
-		return "", errors.Trace(errors.NotValidf("empty subject"))
+		return "", errors.Capture(errors.Errorf("empty subject %w", coreerrors.NotValid))
 	}
 	if err := target.Validate(); err != nil {
-		return "", errors.Trace(err)
+		return "", errors.Capture(err)
 	}
 	access, err := s.st.ReadUserAccessLevelForTarget(ctx, subject, target)
-	return access, errors.Trace(err)
+	return access, errors.Capture(err)
 }
 
 // ReadAllUserAccessForTarget return a slice of user access for all users
@@ -111,10 +111,10 @@ func (s *PermissionService) ReadUserAccessLevelForTarget(ctx context.Context, su
 // target is not valid. Any errors from the state layer are passed through.
 func (s *PermissionService) ReadAllUserAccessForTarget(ctx context.Context, target corepermission.ID) ([]corepermission.UserAccess, error) {
 	if err := target.Validate(); err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	userAccess, err := s.st.ReadAllUserAccessForTarget(ctx, target)
-	return userAccess, errors.Trace(err)
+	return userAccess, errors.Capture(err)
 }
 
 // ReadAllUserAccessForUser returns a slice of the user access the given
@@ -123,10 +123,10 @@ func (s *PermissionService) ReadAllUserAccessForTarget(ctx context.Context, targ
 // passed through.
 func (s *PermissionService) ReadAllUserAccessForUser(ctx context.Context, subject user.Name) ([]corepermission.UserAccess, error) {
 	if subject.IsZero() {
-		return nil, errors.Trace(errors.NotValidf("empty subject"))
+		return nil, errors.Capture(errors.Errorf("empty subject %w", coreerrors.NotValid))
 	}
 	userAccess, err := s.st.ReadAllUserAccessForUser(ctx, subject)
-	return userAccess, errors.Trace(err)
+	return userAccess, errors.Capture(err)
 }
 
 // ReadAllAccessForUserAndObjectType returns a slice of user access for the
@@ -136,13 +136,13 @@ func (s *PermissionService) ReadAllUserAccessForUser(ctx context.Context, subjec
 // E.G. All clouds the user has access to.
 func (s *PermissionService) ReadAllAccessForUserAndObjectType(ctx context.Context, subject user.Name, objectType corepermission.ObjectType) ([]corepermission.UserAccess, error) {
 	if subject.IsZero() {
-		return nil, errors.Trace(errors.NotValidf("empty subject"))
+		return nil, errors.Capture(errors.Errorf("empty subject %w", coreerrors.NotValid))
 	}
 	if err := objectType.Validate(); err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	userAccess, err := s.st.ReadAllAccessForUserAndObjectType(ctx, subject, objectType)
-	return userAccess, errors.Trace(err)
+	return userAccess, errors.Capture(err)
 }
 
 // UpdatePermission updates the permission on the target for the given subject
@@ -155,14 +155,14 @@ func (s *PermissionService) ReadAllAccessForUserAndObjectType(ctx context.Contex
 // granted an access level greater or equal to what they already have.
 func (s *PermissionService) UpdatePermission(ctx context.Context, args access.UpdatePermissionArgs) error {
 	if err := args.Validate(); err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
-	return errors.Trace(s.st.UpdatePermission(ctx, args))
+	return errors.Capture(s.st.UpdatePermission(ctx, args))
 }
 
 // AllModelAccessForCloudCredential for a given (cloud) credential key, return all
 // model name and model access level combinations.
 func (s *PermissionService) AllModelAccessForCloudCredential(ctx context.Context, key credential.Key) ([]access.CredentialOwnerModelAccess, error) {
 	results, err := s.st.AllModelAccessForCloudCredential(ctx, key)
-	return results, errors.Trace(err)
+	return results, errors.Capture(err)
 }

--- a/domain/access/service/permission_test.go
+++ b/domain/access/service/permission_test.go
@@ -6,16 +6,17 @@ package service
 import (
 	"context"
 
-	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/credential"
+	coreerrors "github.com/juju/juju/core/errors"
 	corepermission "github.com/juju/juju/core/permission"
 	usertesting "github.com/juju/juju/core/user/testing"
 	"github.com/juju/juju/domain/access"
+	"github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/internal/uuid"
 )
 
@@ -65,7 +66,7 @@ func (s *serviceSuite) TestCreatePermissionError(c *gc.C) {
 		},
 	}
 	_, err := NewService(s.state).CreatePermission(context.Background(), spec)
-	c.Assert(err, jc.ErrorIs, errors.NotValid)
+	c.Assert(err, jc.ErrorIs, coreerrors.NotValid)
 }
 
 func (s *serviceSuite) TestDeletePermission(c *gc.C) {
@@ -85,7 +86,7 @@ func (s *serviceSuite) TestDeletePermissionError(c *gc.C) {
 		ObjectType: "faileme",
 		Key:        "aws",
 	})
-	c.Assert(err, jc.ErrorIs, errors.NotValid, gc.Commentf("%+v", err))
+	c.Assert(err, jc.ErrorIs, coreerrors.NotValid, gc.Commentf("%+v", err))
 }
 
 func (s *serviceSuite) TestUpsertPermission(c *gc.C) {
@@ -133,7 +134,7 @@ func (s *serviceSuite) TestReadUserAccessForTargetError(c *gc.C) {
 			ObjectType: "faileme",
 			Key:        "aws",
 		})
-	c.Assert(errors.Is(err, errors.NotValid), jc.IsTrue, gc.Commentf("%+v", err))
+	c.Assert(errors.Is(err, coreerrors.NotValid), jc.IsTrue, gc.Commentf("%+v", err))
 }
 
 func (s *serviceSuite) TestReadUserAccessLevelForTarget(c *gc.C) {
@@ -160,7 +161,7 @@ func (s *serviceSuite) TestReadUserAccessLevelForTargetError(c *gc.C) {
 			ObjectType: "faileme",
 			Key:        "aws",
 		})
-	c.Assert(err, jc.ErrorIs, errors.NotValid, gc.Commentf("%+v", err))
+	c.Assert(err, jc.ErrorIs, coreerrors.NotValid, gc.Commentf("%+v", err))
 }
 
 func (s *serviceSuite) TestReadAllUserAccessForTarget(c *gc.C) {
@@ -185,7 +186,7 @@ func (s *serviceSuite) TestReadAllUserAccessForTargetError(c *gc.C) {
 			ObjectType: "faileme",
 			Key:        "aws",
 		})
-	c.Assert(err, jc.ErrorIs, errors.NotValid, gc.Commentf("%+v", err))
+	c.Assert(err, jc.ErrorIs, coreerrors.NotValid, gc.Commentf("%+v", err))
 }
 
 func (s *serviceSuite) TestReadAllUserAccessForUser(c *gc.C) {
@@ -216,7 +217,7 @@ func (s *serviceSuite) TestReadAllAccessForUserAndObjectTypeError(c *gc.C) {
 		context.Background(),
 		usertesting.GenNewName(c, "testme"),
 		"failme")
-	c.Assert(err, jc.ErrorIs, errors.NotValid, gc.Commentf("%+v", err))
+	c.Assert(err, jc.ErrorIs, coreerrors.NotValid, gc.Commentf("%+v", err))
 }
 
 func (s *serviceSuite) TestAllModelAccessForCloudCredential(c *gc.C) {

--- a/domain/access/service/user.go
+++ b/domain/access/service/user.go
@@ -7,16 +7,16 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/json"
-	"fmt"
 	"time"
 
-	"github.com/juju/errors"
 	"golang.org/x/crypto/nacl/secretbox"
 
+	coreerrors "github.com/juju/juju/core/errors"
 	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/user"
 	accesserrors "github.com/juju/juju/domain/access/errors"
 	"github.com/juju/juju/internal/auth"
+	"github.com/juju/juju/internal/errors"
 )
 
 // UserService provides the API for working with users.
@@ -38,7 +38,7 @@ func NewUserService(st UserState) *UserService {
 func (s *UserService) GetAllUsers(ctx context.Context, includeDisabled bool) ([]user.User, error) {
 	usrs, err := s.st.GetAllUsers(ctx, includeDisabled)
 	if err != nil {
-		return nil, errors.Annotate(err, "getting all users with auth info")
+		return nil, errors.Errorf("getting all users with auth info %w", err)
 	}
 	return usrs, nil
 }
@@ -51,12 +51,12 @@ func (s *UserService) GetUser(
 	uuid user.UUID,
 ) (user.User, error) {
 	if err := uuid.Validate(); err != nil {
-		return user.User{}, errors.Annotatef(accesserrors.UserUUIDNotValid, "validating uuid %q", uuid)
+		return user.User{}, errors.Errorf("validating uuid %q %w", uuid, accesserrors.UserUUIDNotValid)
 	}
 
 	usr, err := s.st.GetUser(ctx, uuid)
 	if err != nil {
-		return user.User{}, errors.Annotatef(err, "getting user for uuid %q", uuid)
+		return user.User{}, errors.Errorf("getting user for uuid %q %w", uuid, err)
 	}
 
 	return usr, nil
@@ -73,12 +73,12 @@ func (s *UserService) GetUserByName(
 	name user.Name,
 ) (user.User, error) {
 	if name.IsZero() {
-		return user.User{}, errors.Annotatef(accesserrors.UserNameNotValid, "empty username")
+		return user.User{}, errors.Errorf("empty username %w", accesserrors.UserNameNotValid)
 	}
 
 	usr, err := s.st.GetUserByName(ctx, name)
 	if err != nil {
-		return user.User{}, errors.Annotatef(err, "getting user %q", name)
+		return user.User{}, errors.Errorf("getting user %q %w", name, err)
 	}
 
 	return usr, nil
@@ -95,11 +95,11 @@ func (s *UserService) GetUserByAuth(
 	password auth.Password,
 ) (user.User, error) {
 	if name.IsZero() {
-		return user.User{}, errors.Annotatef(accesserrors.UserNameNotValid, "empty username")
+		return user.User{}, errors.Errorf("empty username %w", accesserrors.UserNameNotValid)
 	}
 
 	if err := password.Validate(); err != nil {
-		return user.User{}, errors.Trace(err)
+		return user.User{}, errors.Capture(err)
 	}
 
 	usr, err := s.st.GetUserByAuth(ctx, name, password)
@@ -108,7 +108,7 @@ func (s *UserService) GetUserByAuth(
 		// The happy path hashes the password in state,
 		// and in so doing destroys it.
 		password.Destroy()
-		return user.User{}, errors.Annotatef(err, "getting user %q", name)
+		return user.User{}, errors.Errorf("getting user %q %w", name, err)
 	}
 
 	return usr, nil
@@ -125,26 +125,26 @@ func (s *UserService) GetUserByAuth(
 //   - auth.ErrPasswordNotValid: If the password supplied is not valid.
 func (s *UserService) AddUser(ctx context.Context, arg AddUserArg) (user.UUID, []byte, error) {
 	if arg.Name.IsZero() {
-		return "", nil, errors.Annotatef(accesserrors.UserNameNotValid, "empty username")
+		return "", nil, errors.Errorf("empty username %w", accesserrors.UserNameNotValid)
 	}
 	if !arg.Name.IsLocal() {
-		return "", nil, errors.Annotatef(accesserrors.UserNameNotValid, "cannot add external user %q", arg.Name)
+		return "", nil, errors.Errorf("cannot add external user %q %w", arg.Name, accesserrors.UserNameNotValid)
 	}
 	if err := arg.CreatorUUID.Validate(); err != nil {
-		return "", nil, errors.Annotatef(err, "validating creator UUID %q", arg.CreatorUUID)
+		return "", nil, errors.Errorf("validating creator UUID %q %w", arg.CreatorUUID, err)
 	}
 
 	if err := arg.Permission.Validate(); err != nil {
-		return "", nil, fmt.Errorf("validating permission %q: %w: %w", arg.Permission, err, accesserrors.PermissionNotValid)
+		return "", nil, errors.Errorf("validating permission %q: %w: %w", arg.Permission, err, accesserrors.PermissionNotValid)
 	}
 
 	if arg.UUID.String() == "" {
 		var err error
 		if arg.UUID, err = user.NewUUID(); err != nil {
-			return "", nil, errors.Annotatef(err, "generating UUID for user %q", arg.Name)
+			return "", nil, errors.Errorf("generating UUID for user %q %w", arg.Name, err)
 		}
 	} else if err := arg.UUID.Validate(); err != nil {
-		return "", nil, errors.Annotatef(err, "validating user UUID %q", arg.UUID)
+		return "", nil, errors.Errorf("validating user UUID %q %w", arg.UUID, err)
 	}
 
 	var key []byte
@@ -155,7 +155,7 @@ func (s *UserService) AddUser(ctx context.Context, arg AddUserArg) (user.UUID, [
 		key, err = s.addUserWithActivationKey(ctx, arg)
 	}
 	if err != nil {
-		return "", nil, errors.Trace(err)
+		return "", nil, errors.Capture(err)
 	}
 
 	return arg.UUID, key, nil
@@ -163,31 +163,31 @@ func (s *UserService) AddUser(ctx context.Context, arg AddUserArg) (user.UUID, [
 
 func (s *UserService) addUserWithPassword(ctx context.Context, arg AddUserArg) error {
 	if err := arg.Password.Validate(); err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	salt, err := auth.NewSalt()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	hash, err := auth.HashPassword(*arg.Password, salt)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	err = s.st.AddUserWithPasswordHash(ctx, arg.UUID, arg.Name, arg.DisplayName, arg.CreatorUUID, arg.Permission, hash, salt)
-	return errors.Trace(err)
+	return errors.Capture(err)
 }
 
 func (s *UserService) addUserWithActivationKey(ctx context.Context, arg AddUserArg) ([]byte, error) {
 	key, err := generateActivationKey()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	if err = s.st.AddUserWithActivationKey(ctx, arg.UUID, arg.Name, arg.DisplayName, arg.CreatorUUID, arg.Permission, key); err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	return key, nil
 }
@@ -201,12 +201,12 @@ func (s *UserService) addUserWithActivationKey(ctx context.Context, arg AddUserA
 //     does not exist.
 func (s *UserService) AddExternalUser(ctx context.Context, name user.Name, displayName string, creatorUUID user.UUID) error {
 	if name.IsLocal() {
-		return errors.Annotatef(accesserrors.UserNameNotValid, "cannot use add external user method to add local user")
+		return errors.Errorf("cannot use add external user method to add local user %w", accesserrors.UserNameNotValid)
 	}
 
 	uuid, err := user.NewUUID()
 	if err != nil {
-		return errors.Annotate(err, "generating user UUID")
+		return errors.Errorf("generating user UUID %w", err)
 	}
 	err = s.st.AddUser(ctx, uuid, name, displayName, true, creatorUUID)
 	return err
@@ -220,10 +220,10 @@ func (s *UserService) AddExternalUser(ctx context.Context, name user.Name, displ
 // - accesserrors.NotFound: If no user by the given UUID exists.
 func (s *UserService) RemoveUser(ctx context.Context, name user.Name) error {
 	if name.IsZero() {
-		return errors.Annotatef(accesserrors.UserNameNotValid, "empty username")
+		return errors.Errorf("empty username %w", accesserrors.UserNameNotValid)
 	}
 	if err := s.st.RemoveUser(ctx, name); err != nil {
-		return errors.Annotatef(err, "removing user for %q", name)
+		return errors.Errorf("removing user for %q %w", name, err)
 	}
 	return nil
 }
@@ -236,15 +236,15 @@ func (s *UserService) RemoveUser(ctx context.Context, name user.Name) error {
 //   - internal/auth.ErrPasswordNotValid: If the password supplied is not valid.
 func (s *UserService) SetPassword(ctx context.Context, name user.Name, pass auth.Password) error {
 	if name.IsZero() {
-		return errors.Annotatef(accesserrors.UserNameNotValid, "empty username")
+		return errors.Errorf("empty username %w", accesserrors.UserNameNotValid)
 	}
 
 	if err := pass.Validate(); err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	err := s.setPassword(ctx, name, pass)
-	return errors.Trace(err)
+	return errors.Capture(err)
 }
 
 // ResetPassword will remove any active passwords for a user and generate a new
@@ -254,16 +254,16 @@ func (s *UserService) SetPassword(ctx context.Context, name user.Name, pass auth
 // - accesserrors.NotFound: If no user by the given UUID exists.
 func (s *UserService) ResetPassword(ctx context.Context, name user.Name) ([]byte, error) {
 	if name.IsZero() {
-		return nil, errors.Annotatef(accesserrors.UserNameNotValid, "empty username")
+		return nil, errors.Errorf("empty username %w", accesserrors.UserNameNotValid)
 	}
 
 	activationKey, err := generateActivationKey()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	if err = s.st.SetActivationKey(ctx, name, activationKey); err != nil {
-		return nil, errors.Annotatef(err, "setting activation key for user %q", name)
+		return nil, errors.Errorf("setting activation key for user %q %w", name, err)
 	}
 	return activationKey, nil
 }
@@ -274,11 +274,11 @@ func (s *UserService) ResetPassword(ctx context.Context, name user.Name) ([]byte
 // - accesserrors.NotFound: If no user by the given UUID exists.
 func (s *UserService) EnableUserAuthentication(ctx context.Context, name user.Name) error {
 	if name.IsZero() {
-		return errors.Annotatef(accesserrors.UserNameNotValid, "empty username")
+		return errors.Errorf("empty username %w", accesserrors.UserNameNotValid)
 	}
 
 	if err := s.st.EnableUserAuthentication(ctx, name); err != nil {
-		return errors.Annotatef(err, "enabling user with uuid %q", name)
+		return errors.Errorf("enabling user with uuid %q %w", name, err)
 	}
 	return nil
 }
@@ -289,11 +289,11 @@ func (s *UserService) EnableUserAuthentication(ctx context.Context, name user.Na
 // - accesserrors.NotFound: If no user by the given UUID exists.
 func (s *UserService) DisableUserAuthentication(ctx context.Context, name user.Name) error {
 	if name.IsZero() {
-		return errors.Annotatef(accesserrors.UserNameNotValid, "empty username")
+		return errors.Errorf("empty username %w", accesserrors.UserNameNotValid)
 	}
 
 	if err := s.st.DisableUserAuthentication(ctx, name); err != nil {
-		return errors.Annotatef(err, "disabling user %q", name)
+		return errors.Errorf("disabling user %q %w", name, err)
 	}
 	return nil
 }
@@ -305,11 +305,11 @@ func (s *UserService) DisableUserAuthentication(ctx context.Context, name user.N
 // - [modelerrors.NotFound] if no model by the given modelUUID exists.
 func (s *UserService) UpdateLastModelLogin(ctx context.Context, name user.Name, modelUUID coremodel.UUID) error {
 	if name.IsZero() {
-		return errors.Annotatef(accesserrors.UserNameNotValid, "empty username")
+		return errors.Errorf("empty username %w", accesserrors.UserNameNotValid)
 	}
 
 	if err := s.st.UpdateLastModelLogin(ctx, name, modelUUID, time.Now()); err != nil {
-		return errors.Annotatef(err, "updating last login for user %q", name)
+		return errors.Errorf("updating last login for user %q %w", name, err)
 	}
 	return nil
 }
@@ -321,11 +321,11 @@ func (s *UserService) UpdateLastModelLogin(ctx context.Context, name user.Name, 
 // [modelerrors.NotFound] if no model by the given modelUUID exists.
 func (s *UserService) SetLastModelLogin(ctx context.Context, name user.Name, modelUUID coremodel.UUID, lastLogin time.Time) error {
 	if name.IsZero() {
-		return errors.Annotatef(accesserrors.UserNameNotValid, "empty username")
+		return errors.Errorf("empty username %w", accesserrors.UserNameNotValid)
 	}
 
 	if err := s.st.UpdateLastModelLogin(ctx, name, modelUUID, lastLogin); err != nil {
-		return errors.Annotatef(err, "setting last login for user %q", name)
+		return errors.Errorf("setting last login for user %q %w", name, err)
 	}
 	return nil
 }
@@ -339,16 +339,16 @@ func (s *UserService) SetLastModelLogin(ctx context.Context, name user.Name, mod
 // accessing the model.
 func (s *UserService) LastModelLogin(ctx context.Context, name user.Name, modelUUID coremodel.UUID) (time.Time, error) {
 	if name.IsZero() {
-		return time.Time{}, errors.Annotatef(accesserrors.UserNameNotValid, "empty username")
+		return time.Time{}, errors.Errorf("empty username %w", accesserrors.UserNameNotValid)
 	}
 
 	if err := modelUUID.Validate(); err != nil {
-		return time.Time{}, errors.Annotatef(err, "getting last model connection for %q: bad uuid", name)
+		return time.Time{}, errors.Errorf("getting last model connection for %q: bad uuid %w", name, err)
 	}
 
 	lastConnection, err := s.st.LastModelLogin(ctx, name, modelUUID)
 	if err != nil {
-		return time.Time{}, errors.Trace(err)
+		return time.Time{}, errors.Capture(err)
 	}
 	return lastConnection, nil
 }
@@ -361,7 +361,7 @@ const activationKeyLength = 32
 func generateActivationKey() ([]byte, error) {
 	var activationKey [activationKeyLength]byte
 	if _, err := rand.Read(activationKey[:]); err != nil {
-		return nil, errors.Annotate(err, "generating activation key")
+		return nil, errors.Errorf("generating activation key %w", err)
 	}
 	return activationKey[:], nil
 }
@@ -389,17 +389,17 @@ type Sealer interface {
 // a Sealer will be returned that can be used to seal the response payload.
 func (s *UserService) SetPasswordWithActivationKey(ctx context.Context, name user.Name, nonce, box []byte) (Sealer, error) {
 	if name.IsZero() {
-		return nil, errors.Annotatef(accesserrors.UserNameNotValid, "empty username")
+		return nil, errors.Errorf("empty username %w", accesserrors.UserNameNotValid)
 	}
 
 	if len(nonce) != activationBoxNonceLength {
-		return nil, errors.NotValidf("nonce")
+		return nil, errors.Errorf("nonce %w", coreerrors.NotValid)
 	}
 
 	// Get the activation key for the user.
 	key, err := s.st.GetActivationKey(ctx, name)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	// Copy the nonce and the key to arrays which can be used for the secretbox.
@@ -421,11 +421,11 @@ func (s *UserService) SetPasswordWithActivationKey(ctx context.Context, name use
 		Password string `json:"password"`
 	}
 	if err := json.Unmarshal(boxPayloadBytes, &payload); err != nil {
-		return nil, errors.Annotate(err, "cannot unmarshal payload")
+		return nil, errors.Errorf("cannot unmarshal payload %w", err)
 	}
 
 	if err := s.setPassword(ctx, name, auth.NewPassword(payload.Password)); err != nil {
-		return nil, errors.Annotate(err, "setting new password")
+		return nil, errors.Errorf("setting new password %w", err)
 	}
 
 	return boxSealer{
@@ -436,16 +436,16 @@ func (s *UserService) SetPasswordWithActivationKey(ctx context.Context, name use
 func (s *UserService) setPassword(ctx context.Context, name user.Name, pass auth.Password) error {
 	salt, err := auth.NewSalt()
 	if err != nil {
-		return errors.Annotatef(err, "generating password salt for user %q", name)
+		return errors.Errorf("generating password salt for user %q %w", name, err)
 	}
 
 	pwHash, err := auth.HashPassword(pass, salt)
 	if err != nil {
-		return errors.Annotatef(err, "hashing password for user %q", name)
+		return errors.Errorf("hashing password for user %q %w", name, err)
 	}
 
 	if err = s.st.SetPasswordHash(ctx, name, pwHash, salt); err != nil {
-		return errors.Annotatef(err, "setting password for user %q", name)
+		return errors.Errorf("setting password for user %q %w", name, err)
 	}
 
 	return nil
@@ -458,7 +458,7 @@ type boxSealer struct {
 
 func (s boxSealer) Seal(nonce, payload []byte) ([]byte, error) {
 	if len(nonce) != activationBoxNonceLength {
-		return nil, errors.NotValidf("nonce")
+		return nil, errors.Errorf("nonce %w", coreerrors.NotValid)
 	}
 
 	var sbNonce [activationBoxNonceLength]byte

--- a/domain/access/service/user_test.go
+++ b/domain/access/service/user_test.go
@@ -12,12 +12,12 @@ import (
 	"testing"
 	"time"
 
-	jujuerrors "github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"go.uber.org/mock/gomock"
 	"golang.org/x/crypto/nacl/secretbox"
 	gc "gopkg.in/check.v1"
 
+	coreerrors "github.com/juju/juju/core/errors"
 	modeltesting "github.com/juju/juju/core/model/testing"
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/core/user"
@@ -606,7 +606,7 @@ func (s *userServiceSuite) TestLastModelLogin(c *gc.C) {
 func (s *userServiceSuite) TestLastModelLoginBadUUID(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	_, err := s.service().LastModelLogin(context.Background(), coreusertesting.GenNewName(c, "name"), "bad-uuid")
-	c.Assert(err, jc.ErrorIs, jujuerrors.NotValid)
+	c.Assert(err, jc.ErrorIs, coreerrors.NotValid)
 }
 
 // TestLastModelLoginBadUsername tests a bad username for LastModelLogin.

--- a/domain/access/state/permission.go
+++ b/domain/access/state/permission.go
@@ -9,10 +9,10 @@ import (
 
 	"github.com/canonical/sqlair"
 	"github.com/juju/collections/set"
-	"github.com/juju/errors"
 
 	"github.com/juju/juju/core/credential"
 	coredatabase "github.com/juju/juju/core/database"
+	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/logger"
 	corepermission "github.com/juju/juju/core/permission"
 	"github.com/juju/juju/core/user"
@@ -20,6 +20,7 @@ import (
 	"github.com/juju/juju/domain/access"
 	accesserrors "github.com/juju/juju/domain/access/errors"
 	internaldatabase "github.com/juju/juju/internal/database"
+	"github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/internal/uuid"
 )
 
@@ -51,17 +52,17 @@ func (st *PermissionState) CreatePermission(ctx context.Context, newPermissionUU
 
 	db, err := st.DB()
 	if err != nil {
-		return userAccess, errors.Trace(err)
+		return userAccess, errors.Capture(err)
 	}
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		user, err := st.findUserByName(ctx, tx, spec.User)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		if user.Disabled {
-			return fmt.Errorf("%w: %q", accesserrors.UserAuthenticationDisabled, user.Name)
+			return errors.Errorf("%w: %q", accesserrors.UserAuthenticationDisabled, user.Name)
 		}
 
 		if err := AddUserPermission(ctx, tx, AddUserPermissionArgs{
@@ -70,14 +71,14 @@ func (st *PermissionState) CreatePermission(ctx context.Context, newPermissionUU
 			Access:         spec.Access,
 			Target:         spec.Target,
 		}); err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		userAccess, err = user.toCoreUserAccess()
-		return errors.Trace(err)
+		return errors.Capture(err)
 	})
 	if err != nil {
-		return corepermission.UserAccess{}, errors.Trace(err)
+		return corepermission.UserAccess{}, errors.Capture(err)
 	}
 
 	userAccess.Access = spec.Access
@@ -100,11 +101,11 @@ type AddUserPermissionArgs struct {
 func AddUserPermission(ctx context.Context, tx *sqlair.TX, spec AddUserPermissionArgs) error {
 	// Validate the access is appropriate for the target.
 	if err := spec.Target.ValidateAccess(spec.Access); err != nil {
-		return fmt.Errorf("%q for %q %w ", spec.Access, spec.Target.Key, accesserrors.PermissionAccessInvalid)
+		return errors.Errorf("%q for %q %w ", spec.Access, spec.Target.Key, accesserrors.PermissionAccessInvalid)
 	}
 	// Validate the target exists.
 	if err := targetExists(ctx, tx, spec.Target); err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	perm := dbPermission{
@@ -116,7 +117,7 @@ func AddUserPermission(ctx context.Context, tx *sqlair.TX, spec AddUserPermissio
 	}
 	err := insertPermission(ctx, tx, perm)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	return nil
 }
@@ -129,14 +130,14 @@ func AddUserPermission(ctx context.Context, tx *sqlair.TX, spec AddUserPermissio
 func (st *PermissionState) DeletePermission(ctx context.Context, subject user.Name, target corepermission.ID) error {
 	db, err := st.DB()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err := st.deletePermission(ctx, tx, subject, target)
-		return errors.Annotatef(err, "delete permission")
+		return errors.Errorf("delete permission %w", err)
 	})
-	return errors.Trace(err)
+	return errors.Capture(err)
 }
 
 // UpdatePermission updates the permission on the target for the given subject
@@ -150,7 +151,7 @@ func (st *PermissionState) DeletePermission(ctx context.Context, subject user.Na
 func (st *PermissionState) UpdatePermission(ctx context.Context, args access.UpdatePermissionArgs) error {
 	db, err := st.DB()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
@@ -159,20 +160,20 @@ func (st *PermissionState) UpdatePermission(ctx context.Context, args access.Upd
 			subjectUUID, err = st.addExternalUser(ctx, tx, args.Subject)
 		}
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		switch args.Change {
 		case corepermission.Grant:
-			return errors.Trace(st.grantPermission(ctx, tx, subjectUUID, args))
+			return errors.Capture(st.grantPermission(ctx, tx, subjectUUID, args))
 		case corepermission.Revoke:
-			return errors.Trace(st.revokePermission(ctx, tx, args))
+			return errors.Capture(st.revokePermission(ctx, tx, args))
 		default:
-			return errors.Trace(errors.NotValidf("change type %q", args.Change))
+			return errors.Capture(errors.Errorf("change type %q %w", args.Change, coreerrors.NotValid))
 		}
 	})
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	return nil
 }
@@ -184,7 +185,7 @@ func (st *PermissionState) UpdatePermission(ctx context.Context, args access.Upd
 func (st *PermissionState) ReadUserAccessForTarget(ctx context.Context, subject user.Name, target corepermission.ID) (corepermission.UserAccess, error) {
 	db, err := st.DB()
 	if err != nil {
-		return corepermission.UserAccess{}, errors.Trace(err)
+		return corepermission.UserAccess{}, errors.Capture(err)
 	}
 
 	user := dbPermissionUser{
@@ -208,7 +209,7 @@ AND     u.removed = false
 
 	readStmt, err := st.Prepare(readQuery, user, perm)
 	if err != nil {
-		return corepermission.UserAccess{}, errors.Trace(err)
+		return corepermission.UserAccess{}, errors.Capture(err)
 	}
 
 	var baseExternalPerms dbPermission
@@ -216,27 +217,27 @@ AND     u.removed = false
 
 		err = tx.Query(ctx, readStmt, user, perm).Get(&perm, &user)
 		if errors.Is(err, sqlair.ErrNoRows) {
-			return errors.Annotatef(accesserrors.UserNotFound, "looking for permissions for %q on %q", subject, target.Key)
+			return errors.Errorf("looking for permissions for %q on %q %w", subject, target.Key, accesserrors.UserNotFound)
 		} else if err != nil {
-			return errors.Annotatef(err, "getting permission for %q on %q", subject.Name(), target.Key)
+			return errors.Errorf("getting permission for %q on %q %w", subject.Name(), target.Key, err)
 		}
 
 		if user.External {
 			baseExternalPerms, err = st.baseExternalAccessForTarget(ctx, tx, target)
 			if err != nil {
-				return errors.Trace(err)
+				return errors.Capture(err)
 			}
 		}
 
 		return nil
 	})
 	if err != nil {
-		return corepermission.UserAccess{}, errors.Trace(err)
+		return corepermission.UserAccess{}, errors.Capture(err)
 	}
 
 	userAccess, err := st.generateUserAccess(user, perm, baseExternalPerms)
 	if err != nil {
-		return corepermission.UserAccess{}, errors.Annotatef(err, "for %q on %s %q", subject, target.ObjectType, target.Key)
+		return corepermission.UserAccess{}, errors.Errorf("for %q on %s %q %w", subject, target.ObjectType, target.Key, err)
 	}
 
 	return userAccess, err
@@ -250,7 +251,7 @@ func (st *PermissionState) ReadUserAccessLevelForTarget(ctx context.Context, sub
 	userAccess := corepermission.NoAccess
 	db, err := st.DB()
 	if err != nil {
-		return userAccess, errors.Trace(err)
+		return userAccess, errors.Capture(err)
 	}
 
 	user := dbPermissionUser{
@@ -272,28 +273,28 @@ AND     u.removed = false
 
 	readStmt, err := st.Prepare(readQuery, user, perm)
 	if err != nil {
-		return userAccess, errors.Annotatef(err, "preparing select user access level for target statement")
+		return userAccess, errors.Errorf("preparing select user access level for target statement %w", err)
 	}
 
 	var baseExternalPerms dbPermission
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err = tx.Query(ctx, readStmt, user, perm).Get(&user, &perm)
 		if errors.Is(err, sqlair.ErrNoRows) {
-			return fmt.Errorf("%w for %q on %q", accesserrors.AccessNotFound, subject, target.Key)
+			return errors.Errorf("%w for %q on %q", accesserrors.AccessNotFound, subject, target.Key)
 		} else if err != nil {
-			return errors.Annotatef(err, "reading user access level for target")
+			return errors.Errorf("reading user access level for target %w", err)
 		}
 
 		if user.External {
 			baseExternalPerms, err = st.baseExternalAccessForTarget(ctx, tx, target)
 			if err != nil {
-				return errors.Trace(err)
+				return errors.Capture(err)
 			}
 		}
 		return err
 	})
 	if err != nil {
-		return userAccess, errors.Trace(err)
+		return userAccess, errors.Capture(err)
 	}
 
 	userAccess = corepermission.Access(perm.AccessType)
@@ -303,7 +304,7 @@ AND     u.removed = false
 	if perm.AccessType != string(corepermission.NoAccess) {
 		return userAccess, nil
 	}
-	return corepermission.NoAccess, fmt.Errorf("%w for %q on %q", accesserrors.AccessNotFound, subject, target.Key)
+	return corepermission.NoAccess, errors.Errorf("%w for %q on %q", accesserrors.AccessNotFound, subject, target.Key)
 }
 
 // EnsureExternalUserIfAuthorized checks if an external user is missing from the
@@ -321,7 +322,7 @@ func (st *PermissionState) EnsureExternalUserIfAuthorized(
 
 	db, err := st.DB()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
@@ -329,25 +330,25 @@ func (st *PermissionState) EnsureExternalUserIfAuthorized(
 		if err == nil {
 			return nil
 		} else if !errors.Is(err, accesserrors.UserNotFound) {
-			return fmt.Errorf("getting user %q", subject)
+			return errors.Errorf("getting user %q", subject)
 		}
 		// We have a UserNotFound error. Check if everyone@external has permissions
 		// on the target.
 		baseExternalPerms, err := st.baseExternalAccessForTarget(ctx, tx, target)
 		if err != nil {
-			return errors.Annotatef(err, "getting everyone@external access")
+			return errors.Errorf("getting everyone@external access %w", err)
 		}
 		if corepermission.Access(baseExternalPerms.AccessType) == corepermission.NoAccess {
 			return nil
 		}
 		_, err = st.addExternalUser(ctx, tx, subject)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		return nil
 	})
 	if err != nil {
-		return errors.Annotatef(err, "adding external user %q if missing", subject)
+		return errors.Errorf("adding external user %q if missing %w", subject, err)
 	}
 	return nil
 }
@@ -358,15 +359,15 @@ func (st *PermissionState) addExternalUser(ctx context.Context, tx *sqlair.TX, s
 	// Get the UUID of everyone@external to use as the creator.
 	everyoneExternal, err := st.findUserByName(ctx, tx, corepermission.EveryoneUserName)
 	if errors.Is(err, accesserrors.UserNotFound) || errors.Is(err, accesserrors.UserAuthenticationDisabled) {
-		return "", errors.Annotatef(accesserrors.UserNotFound, "%q (should be added on bootstrap)", corepermission.EveryoneUserName)
+		return "", errors.Errorf("%q (should be added on bootstrap) %w", corepermission.EveryoneUserName, accesserrors.UserNotFound)
 	}
 	userUUID, err := user.NewUUID()
 	if err != nil {
-		return "", errors.Annotate(err, "generating user UUID")
+		return "", errors.Errorf("generating user UUID %w", err)
 	}
 	err = AddUser(ctx, tx, userUUID, subject, subject.Name(), true, user.UUID(everyoneExternal.UUID))
 	if err != nil {
-		return "", errors.Annotatef(err, "adding exteranl user %q", subject)
+		return "", errors.Errorf("adding exteranl user %q %w", subject, err)
 	}
 	return userUUID, nil
 }
@@ -376,7 +377,7 @@ func (st *PermissionState) addExternalUser(ctx context.Context, tx *sqlair.TX, s
 func (st *PermissionState) ReadAllUserAccessForUser(ctx context.Context, subject user.Name) ([]corepermission.UserAccess, error) {
 	db, err := st.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	var (
 		users       []dbPermissionUser
@@ -397,37 +398,37 @@ WHERE  u.removed = false
 
 	queryStmt, err := st.Prepare(query, uName, dbPermissionUser{}, dbPermission{})
 	if err != nil {
-		return nil, errors.Annotate(err, "preparing select all access for user query")
+		return nil, errors.Errorf("preparing select all access for user query %w", err)
 	}
 
 	var externalPerms []dbPermission
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err = tx.Query(ctx, queryStmt, uName).GetAll(&users, &permissions)
 		if errors.Is(err, sqlair.ErrNoRows) || len(users) == 0 {
-			return errors.Annotatef(accesserrors.UserNotFound, "%q", subject)
+			return errors.Errorf("%q %w", subject, accesserrors.UserNotFound)
 		} else if err != nil {
-			return errors.Annotatef(err, "getting user with name %q", subject)
+			return errors.Errorf("getting user with name %q %w", subject, err)
 		}
 
 		if users[0].External {
 			externalPerms, err = st.baseExternalAccess(ctx, tx)
 			if err != nil {
-				return errors.Trace(err)
+				return errors.Capture(err)
 			}
 		}
 		return nil
 	})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	if users[0].Disabled {
-		return nil, errors.Annotatef(accesserrors.UserAuthenticationDisabled, "%q", subject)
+		return nil, errors.Errorf("%q %w", subject, accesserrors.UserAuthenticationDisabled)
 	}
 
 	userAccess, err := st.generateAllUserAccess(users[0], permissions, externalPerms)
 	if err != nil {
-		return nil, errors.Annotatef(err, "getting permissions for user %q", subject)
+		return nil, errors.Errorf("getting permissions for user %q %w", subject, err)
 	}
 
 	if len(userAccess) == 0 {
@@ -444,7 +445,7 @@ WHERE  u.removed = false
 func (st *PermissionState) ReadAllUserAccessForTarget(ctx context.Context, target corepermission.ID) ([]corepermission.UserAccess, error) {
 	db, err := st.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	grantOn := dbPermission{GrantOn: target.Key}
 
@@ -463,7 +464,7 @@ AND     (p.uuid IS NOT NULL) OR (u.external AND ee.uuid IS NOT NULL)
 `
 	stmt, err := st.Prepare(query, grantOn, dbPermissionUser{}, dbEveryoneExternal{})
 	if err != nil {
-		return nil, errors.Annotatef(err, "preparing select all user access for target statement")
+		return nil, errors.Errorf("preparing select all user access for target statement %w", err)
 	}
 	var (
 		users             []dbPermissionUser
@@ -473,22 +474,22 @@ AND     (p.uuid IS NOT NULL) OR (u.external AND ee.uuid IS NOT NULL)
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err = tx.Query(ctx, stmt, grantOn).GetAll(&users, &permissions, &everyoneExternals)
 		if errors.Is(err, sqlair.ErrNoRows) {
-			return errors.Annotatef(accesserrors.PermissionNotFound, "for %s %q", target.ObjectType, target.Key)
+			return errors.Errorf("for %s %q %w", target.ObjectType, target.Key, accesserrors.PermissionNotFound)
 		} else if err != nil {
-			return errors.Annotatef(err, "collecting permissions on %s %q", target.ObjectType, target.Key)
+			return errors.Errorf("collecting permissions on %s %q %w", target.ObjectType, target.Key, err)
 		}
 
 		return nil
 	})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	if len(users) != len(permissions) {
-		return nil, fmt.Errorf(
+		return nil, errors.Errorf(
 			"interal error: users slice (%d) length does not match permissions slice (%d)",
-			len(users), len(permissions),
-		)
+			len(users), len(permissions))
+
 	}
 	var userAccess []corepermission.UserAccess
 	for i, user := range users {
@@ -497,7 +498,7 @@ AND     (p.uuid IS NOT NULL) OR (u.external AND ee.uuid IS NOT NULL)
 		}
 		ua, err := st.generateUserAccess(user, permissions[i], dbPermission(everyoneExternals[i]))
 		if err != nil {
-			return nil, errors.Annotatef(err, "for %q on %s %q", user.Name, target.ObjectType, target.Key)
+			return nil, errors.Errorf("for %q on %s %q %w", user.Name, target.ObjectType, target.Key, err)
 		}
 		userAccess = append(userAccess, ua)
 	}
@@ -513,7 +514,7 @@ func (st *PermissionState) ReadAllAccessForUserAndObjectType(
 ) ([]corepermission.UserAccess, error) {
 	db, err := st.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	var (
 		permissions []dbPermission
@@ -530,7 +531,7 @@ func (st *PermissionState) ReadAllAccessForUserAndObjectType(
 	case corepermission.Offer:
 		view = "v_permission_offer"
 	default:
-		return nil, errors.NotValidf("object type %q", objectType)
+		return nil, errors.Errorf("object type %q %w", objectType, coreerrors.NotValid)
 	}
 	readQuery := fmt.Sprintf(`
 SELECT (p.*) AS (&dbPermission.*),
@@ -548,28 +549,28 @@ AND    u.removed = false
 
 	readStmt, err := st.Prepare(readQuery, uName, dbPermission{}, dbPermissionUser{})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	var externalPerms []dbPermission
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err = tx.Query(ctx, readStmt, uName).GetAll(&permissions, &users)
 		if errors.Is(err, sqlair.ErrNoRows) || len(users) == 0 {
-			return errors.Annotatef(accesserrors.PermissionNotFound, "for %q on %q", subject.Name(), objectType)
+			return errors.Errorf("for %q on %q %w", subject.Name(), objectType, accesserrors.PermissionNotFound)
 		} else if err != nil {
-			return errors.Annotatef(err, "getting permissions for %q on %q", subject.Name(), objectType)
+			return errors.Errorf("getting permissions for %q on %q %w", subject.Name(), objectType, err)
 		}
 
 		if users[0].External {
 			externalPerms, err = st.baseExternalAccess(ctx, tx)
 			if err != nil {
-				return errors.Trace(err)
+				return errors.Capture(err)
 			}
 		}
 		return nil
 	})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	var externalPermsOnObject []dbPermission
@@ -580,7 +581,7 @@ AND    u.removed = false
 	}
 	userAccess, err := st.generateAllUserAccess(users[0], permissions, externalPermsOnObject)
 	if err != nil {
-		return nil, errors.Annotatef(err, "getting permissions for %q on %q", subject.Name(), objectType)
+		return nil, errors.Errorf("getting permissions for %q on %q %w", subject.Name(), objectType, err)
 	}
 
 	if len(userAccess) == 0 {
@@ -595,7 +596,7 @@ AND    u.removed = false
 func (st *PermissionState) AllModelAccessForCloudCredential(ctx context.Context, key credential.Key) ([]access.CredentialOwnerModelAccess, error) {
 	db, err := st.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	type input struct {
@@ -615,7 +616,7 @@ AND    m.cloud_credential_name = $input.cred_name
 `
 	readStmt, err := st.Prepare(query, input{}, access.CredentialOwnerModelAccess{})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	in := input{
@@ -627,14 +628,14 @@ AND    m.cloud_credential_name = $input.cred_name
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err = tx.Query(ctx, readStmt, in).GetAll(&results)
 		if errors.Is(err, sqlair.ErrNoRows) {
-			return errors.Annotatef(accesserrors.PermissionNotFound, "for %q on %q", key.Owner, key.Cloud)
+			return errors.Errorf("for %q on %q %w", key.Owner, key.Cloud, accesserrors.PermissionNotFound)
 		} else if err != nil {
-			return errors.Annotatef(err, "getting permissions for %q on %q", key.Owner, key.Cloud)
+			return errors.Errorf("getting permissions for %q on %q %w", key.Owner, key.Cloud, err)
 		}
 		return nil
 	})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	return results, nil
@@ -657,16 +658,16 @@ WHERE  u.removed = false
 
 	selectUserStmt, err := st.Prepare(getUserQuery, dbPermissionUser{}, uName)
 	if err != nil {
-		return result, errors.Annotate(err, "preparing select getUser query")
+		return result, errors.Errorf("preparing select getUser query %w", err)
 	}
 	err = tx.Query(ctx, selectUserStmt, uName).Get(&result)
 	if errors.Is(err, sqlair.ErrNoRows) {
-		return result, errors.Annotatef(accesserrors.UserNotFound, "%q", name)
+		return result, errors.Errorf("%q %w", name, accesserrors.UserNotFound)
 	} else if err != nil {
-		return result, errors.Annotatef(err, "getting user with name %q", name)
+		return result, errors.Errorf("getting user with name %q %w", name, err)
 	}
 	if result.Disabled {
-		return result, errors.Annotatef(accesserrors.UserAuthenticationDisabled, "%q", name)
+		return result, errors.Errorf("%q %w", name, accesserrors.UserAuthenticationDisabled)
 	}
 	return result, nil
 }
@@ -697,20 +698,20 @@ WHERE   name = $M.grant_on
 	case corepermission.Offer:
 		return nil
 	default:
-		return errors.NotValidf("object type %q", target.ObjectType)
+		return errors.Errorf("object type %q %w", target.ObjectType, coreerrors.NotValid)
 	}
 
 	targetExistsStmt, err := sqlair.Prepare(targetExists, sqlair.M{})
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	m := sqlair.M{}
 	err = tx.Query(ctx, targetExistsStmt, sqlair.M{"grant_on": target.Key}).Get(&m)
 	if errors.Is(err, sqlair.ErrNoRows) {
-		return fmt.Errorf("%q %w", target, accesserrors.PermissionTargetInvalid)
+		return errors.Errorf("%q %w", target, accesserrors.PermissionTargetInvalid)
 	} else if err != nil {
-		return errors.Annotatef(err, "verifying %q target exists", target)
+		return errors.Errorf("verifying %q target exists %w", target, err)
 	}
 	return nil
 }
@@ -734,15 +735,15 @@ AND     u.removed = false
 `, inputOut{})
 
 	if err != nil {
-		return "", errors.Annotate(err, "preparing user exist statement")
+		return "", errors.Errorf("preparing user exist statement %w", err)
 	}
 	inOut := inputOut{Name: name.Name()}
 
 	err = tx.Query(ctx, stmt, inOut).Get(&inOut)
 	if errors.Is(err, sqlair.ErrNoRows) {
-		return "", errors.Annotatef(accesserrors.UserNotFound, "active user %q", name)
+		return "", errors.Errorf("active user %q %w", name, accesserrors.UserNotFound)
 	} else if err != nil {
-		return "", errors.Annotatef(err, "getting user %q", name)
+		return "", errors.Errorf("getting user %q %w", name, err)
 	}
 	return user.UUID(inOut.UUID), nil
 }
@@ -764,7 +765,7 @@ AND     p.grant_on = $permInOut.grant_on
 `
 	readStmt, err := st.Prepare(readQuery, inOut)
 	if err != nil {
-		return errors.Annotatef(err, "preparing select existsing user access statement")
+		return errors.Errorf("preparing select existsing user access statement %w", err)
 	}
 
 	// Check the access level only if it exists, it may not for grant.
@@ -772,7 +773,7 @@ AND     p.grant_on = $permInOut.grant_on
 	if errors.Is(err, sqlair.ErrNoRows) {
 		newUUID, err := uuid.NewUUID()
 		if err != nil {
-			return errors.Annotate(err, "generating new UUID")
+			return errors.Errorf("generating new UUID %w", err)
 		}
 		spec := args.AccessSpec
 		perm := dbPermission{
@@ -783,9 +784,9 @@ AND     p.grant_on = $permInOut.grant_on
 			ObjectType: string(spec.Target.ObjectType),
 		}
 		err = insertPermission(ctx, tx, perm)
-		return errors.Trace(err)
+		return errors.Capture(err)
 	} else if err != nil {
-		return errors.Annotatef(err, "getting current access for grant")
+		return errors.Errorf("getting current access for grant %w", err)
 	}
 
 	aSpec := corepermission.AccessSpec{
@@ -795,10 +796,10 @@ AND     p.grant_on = $permInOut.grant_on
 
 	grantAccess := args.AccessSpec.Access
 	if aSpec.EqualOrGreaterThan(grantAccess) {
-		return fmt.Errorf("user %q already has %q %w", args.Subject, grantAccess, accesserrors.PermissionAccessGreater)
+		return errors.Errorf("user %q already has %q %w", args.Subject, grantAccess, accesserrors.PermissionAccessGreater)
 	}
 	if err := st.updatePermission(ctx, tx, args.Subject.Name(), args.AccessSpec.Target.Key, grantAccess.String()); err != nil {
-		return errors.Annotatef(err, "updating current access during grant")
+		return errors.Errorf("updating current access during grant %w", err)
 	}
 	return nil
 }
@@ -807,10 +808,10 @@ func (st *PermissionState) revokePermission(ctx context.Context, tx *sqlair.TX, 
 	newAccess := args.AccessSpec.RevokeAccess()
 	if newAccess == corepermission.NoAccess {
 		err := st.deletePermission(ctx, tx, args.Subject, args.AccessSpec.Target)
-		return errors.Annotatef(err, "revoking %q", args.AccessSpec.Access)
+		return errors.Errorf("revoking %q %w", args.AccessSpec.Access, err)
 	}
 	if err := st.updatePermission(ctx, tx, args.Subject.Name(), args.AccessSpec.Target.Key, newAccess.String()); err != nil {
-		return errors.Annotatef(err, "updating current access during revoke")
+		return errors.Errorf("updating current access during revoke %w", err)
 	}
 	return nil
 }
@@ -830,7 +831,7 @@ AND    grant_to IN (
 `
 	deletePermissionStmt, err := sqlair.Prepare(deletePermission, permInOut{})
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	in := permInOut{
@@ -839,7 +840,7 @@ AND    grant_to IN (
 	}
 	err = tx.Query(ctx, deletePermissionStmt, in).Run()
 	if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-		return errors.Annotatef(err, "deleting permission of %q on %q", subject.Name(), target.Key)
+		return errors.Errorf("deleting permission of %q on %q %w", subject.Name(), target.Key, err)
 	}
 	return nil
 }
@@ -863,7 +864,7 @@ AND    grant_to IN (
 `
 	updateQueryStmt, err := st.Prepare(updateQuery, permInOut{})
 	if err != nil {
-		return errors.Annotate(err, "preparing updatePermission query")
+		return errors.Errorf("preparing updatePermission query %w", err)
 	}
 
 	in := permInOut{
@@ -872,7 +873,7 @@ AND    grant_to IN (
 		Access:  access,
 	}
 	if err := tx.Query(ctx, updateQueryStmt, in).Run(); err != nil {
-		return errors.Annotatef(err, "updating access on %q for %q to %q", grantOn, subjectName, access)
+		return errors.Errorf("updating access on %q for %q to %q %w", grantOn, subjectName, access, err)
 	}
 	return nil
 }
@@ -894,11 +895,11 @@ AND     u.removed = false
 	`
 	readStmt, err := st.Prepare(readQuery, user, perm)
 	if err != nil {
-		return dbPermission{}, errors.Trace(err)
+		return dbPermission{}, errors.Capture(err)
 	}
 	err = tx.Query(ctx, readStmt, user, perm).Get(&perm)
 	if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-		return dbPermission{}, errors.Annotatef(err, "getting external user permission on %q", target.Key)
+		return dbPermission{}, errors.Errorf("getting external user permission on %q %w", target.Key, err)
 	}
 	return perm, nil
 }
@@ -919,11 +920,11 @@ AND     u.removed = false
 	`
 	readStmt, err := st.Prepare(readQuery, user, dbPermission{})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	err = tx.Query(ctx, readStmt, user).GetAll(&perms)
 	if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-		return nil, errors.Annotate(err, "getting external user permission")
+		return nil, errors.Errorf("getting external user permission %w", err)
 	}
 	return perms, nil
 }
@@ -984,7 +985,7 @@ func (st *PermissionState) generateAllUserAccess(user dbPermissionUser, userPerm
 			externalPerm := targetToExternalPerm[target]
 			userAccess[i], err = st.generateUserAccess(user, userPerm, externalPerm)
 			if err != nil {
-				return nil, errors.Trace(err)
+				return nil, errors.Capture(err)
 			}
 		}
 	} else {
@@ -992,7 +993,7 @@ func (st *PermissionState) generateAllUserAccess(user dbPermissionUser, userPerm
 			if p.AccessType != string(corepermission.NoAccess) {
 				ua, err := p.toUserAccess(user)
 				if err != nil {
-					return nil, errors.Trace(err)
+					return nil, errors.Capture(err)
 				}
 				userAccess = append(userAccess, ua)
 			}
@@ -1026,16 +1027,16 @@ AND    ot.type = $dbPermission.object_type
 
 	insertPermissionStmt, err := sqlair.Prepare(newPermission, dbPermission{})
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	// No IsErrConstraintForeignKey should be seen as both foreign keys
 	// have been checked.
 	err = tx.Query(ctx, insertPermissionStmt, perm).Run()
 	if internaldatabase.IsErrConstraintUnique(err) {
-		return errors.Annotatef(accesserrors.PermissionAlreadyExists, "%q on %q", perm.GrantTo, perm.GrantOn)
+		return errors.Errorf("%q on %q %w", perm.GrantTo, perm.GrantOn, accesserrors.PermissionAlreadyExists)
 	} else if err != nil {
-		return errors.Annotatef(err, "adding permission %q for %q on %q", perm.AccessType, perm.GrantTo, perm.GrantOn)
+		return errors.Errorf("adding permission %q for %q on %q %w", perm.AccessType, perm.GrantTo, perm.GrantOn, err)
 	}
 	return nil
 }

--- a/domain/access/state/types.go
+++ b/domain/access/state/types.go
@@ -6,10 +6,9 @@ package state
 import (
 	"time"
 
-	"github.com/juju/errors"
-
 	corepermission "github.com/juju/juju/core/permission"
 	coreuser "github.com/juju/juju/core/user"
+	"github.com/juju/juju/internal/errors"
 )
 
 // user represents a user in the state layer with the associated fields in the
@@ -56,13 +55,13 @@ type dbUser struct {
 func (u dbUser) toCoreUser() (coreuser.User, error) {
 	name, err := coreuser.NewName(u.Name)
 	if err != nil {
-		return coreuser.User{}, errors.Annotate(err, "user name from db")
+		return coreuser.User{}, errors.Errorf("user name from db %w", err)
 	}
 	var creatorName coreuser.Name
 	if u.CreatorName != "" {
 		creatorName, err = coreuser.NewName(u.CreatorName)
 		if err != nil {
-			return coreuser.User{}, errors.Annotate(err, "creator name from db")
+			return coreuser.User{}, errors.Errorf("creator name from db %w", err)
 		}
 	}
 	return coreuser.User{
@@ -114,13 +113,13 @@ type dbPermissionUser struct {
 func (u dbPermissionUser) toCoreUserAccess() (corepermission.UserAccess, error) {
 	name, err := coreuser.NewName(u.Name)
 	if err != nil {
-		return corepermission.UserAccess{}, errors.Trace(err)
+		return corepermission.UserAccess{}, errors.Capture(err)
 	}
 	var creatorName coreuser.Name
 	if u.CreatorName != "" {
 		creatorName, err = coreuser.NewName(u.CreatorName)
 		if err != nil {
-			return corepermission.UserAccess{}, errors.Trace(err)
+			return corepermission.UserAccess{}, errors.Capture(err)
 		}
 	}
 
@@ -158,7 +157,7 @@ type dbPermission struct {
 func (r dbPermission) toUserAccess(u dbPermissionUser) (corepermission.UserAccess, error) {
 	userAccess, err := u.toCoreUserAccess()
 	if err != nil {
-		return corepermission.UserAccess{}, errors.Trace(err)
+		return corepermission.UserAccess{}, errors.Capture(err)
 	}
 
 	userAccess.PermissionID = r.UUID

--- a/domain/access/state/user.go
+++ b/domain/access/state/user.go
@@ -6,13 +6,12 @@ package state
 import (
 	"context"
 	"database/sql"
-	"fmt"
 	"time"
 
 	"github.com/canonical/sqlair"
-	"github.com/juju/errors"
 
 	"github.com/juju/juju/core/database"
+	coreerrors "github.com/juju/juju/core/errors"
 	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/core/user"
@@ -21,6 +20,7 @@ import (
 	modelerrors "github.com/juju/juju/domain/model/errors"
 	"github.com/juju/juju/internal/auth"
 	internaldatabase "github.com/juju/juju/internal/database"
+	"github.com/juju/juju/internal/errors"
 	internaluuid "github.com/juju/juju/internal/uuid"
 )
 
@@ -51,10 +51,10 @@ func (st *UserState) AddUser(
 ) error {
 	db, err := st.DB()
 	if err != nil {
-		return errors.Annotate(err, "getting DB access")
+		return errors.Errorf("getting DB access %w", err)
 	}
 	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		return errors.Trace(AddUser(ctx, tx, uuid, name, displayName, external, creatorUUID))
+		return errors.Capture(AddUser(ctx, tx, uuid, name, displayName, external, creatorUUID))
 	})
 }
 
@@ -74,11 +74,11 @@ func (st *UserState) AddUserWithPermission(
 ) error {
 	db, err := st.DB()
 	if err != nil {
-		return errors.Annotate(err, "getting DB access")
+		return errors.Errorf("getting DB access %w", err)
 	}
 
 	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		return errors.Trace(AddUserWithPermission(ctx, tx, uuid, name, displayName, external, creatorUUID, permission))
+		return errors.Capture(AddUserWithPermission(ctx, tx, uuid, name, displayName, external, creatorUUID, permission))
 	})
 }
 
@@ -98,11 +98,11 @@ func (st *UserState) AddUserWithPasswordHash(
 ) error {
 	db, err := st.DB()
 	if err != nil {
-		return errors.Annotate(err, "getting DB access")
+		return errors.Errorf("getting DB access %w", err)
 	}
 
 	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		return errors.Trace(AddUserWithPassword(ctx, tx, uuid, name, displayName, creatorUUID, permission, passwordHash, salt))
+		return errors.Capture(AddUserWithPassword(ctx, tx, uuid, name, displayName, creatorUUID, permission, passwordHash, salt))
 	})
 }
 
@@ -122,15 +122,15 @@ func (st *UserState) AddUserWithActivationKey(
 ) error {
 	db, err := st.DB()
 	if err != nil {
-		return errors.Annotate(err, "getting DB access")
+		return errors.Errorf("getting DB access %w", err)
 	}
 
 	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err = AddUserWithPermission(ctx, tx, uuid, name, displayName, false, creatorUUID, permission)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
-		return errors.Trace(setActivationKey(ctx, tx, name, activationKey))
+		return errors.Capture(setActivationKey(ctx, tx, name, activationKey))
 	})
 }
 
@@ -140,7 +140,7 @@ func (st *UserState) AddUserWithActivationKey(
 func (st *UserState) GetAllUsers(ctx context.Context, includeDisabled bool) ([]user.User, error) {
 	db, err := st.DB()
 	if err != nil {
-		return nil, errors.Annotate(err, "getting DB access")
+		return nil, errors.Errorf("getting DB access %w", err)
 	}
 
 	selectGetAllUsersStmt, err := st.Prepare(`
@@ -154,19 +154,19 @@ FROM   v_user_auth u
 WHERE  u.removed = false 
 `, dbUser{})
 	if err != nil {
-		return nil, errors.Annotate(err, "preparing select getAllUsers query")
+		return nil, errors.Errorf("preparing select getAllUsers query %w", err)
 	}
 
 	var results []dbUser
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err = tx.Query(ctx, selectGetAllUsersStmt).GetAll(&results)
 		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-			return errors.Annotate(err, "getting query results")
+			return errors.Errorf("getting query results %w", err)
 		}
 		return nil
 	})
 	if err != nil {
-		return nil, errors.Annotate(err, "getting all users")
+		return nil, errors.Errorf("getting all users %w", err)
 	}
 
 	var usrs []user.User
@@ -174,7 +174,7 @@ WHERE  u.removed = false
 		if !result.Disabled || includeDisabled {
 			coreUser, err := result.toCoreUser()
 			if err != nil {
-				return nil, errors.Trace(err)
+				return nil, errors.Capture(err)
 			}
 			usrs = append(usrs, coreUser)
 		}
@@ -189,7 +189,7 @@ WHERE  u.removed = false
 func (st *UserState) GetUser(ctx context.Context, uuid user.UUID) (user.User, error) {
 	db, err := st.DB()
 	if err != nil {
-		return user.User{}, errors.Annotate(err, "getting DB access")
+		return user.User{}, errors.Errorf("getting DB access %w", err)
 	}
 
 	var usr user.User
@@ -210,22 +210,22 @@ WHERE  u.uuid = $M.uuid`
 
 		selectGetUserStmt, err := st.Prepare(getUserQuery, dbUser{}, sqlair.M{})
 		if err != nil {
-			return errors.Annotate(err, "preparing select getUser query")
+			return errors.Errorf("preparing select getUser query %w", err)
 		}
 
 		var result dbUser
 		err = tx.Query(ctx, selectGetUserStmt, sqlair.M{"uuid": uuid.String()}).Get(&result)
 		if errors.Is(err, sql.ErrNoRows) {
-			return errors.Annotatef(accesserrors.UserNotFound, "%q", uuid)
+			return errors.Errorf("%q %w", uuid, accesserrors.UserNotFound)
 		} else if err != nil {
-			return errors.Annotatef(err, "getting user with uuid %q", uuid)
+			return errors.Errorf("getting user with uuid %q %w", uuid, err)
 		}
 
 		usr, err = result.toCoreUser()
-		return errors.Trace(err)
+		return errors.Capture(err)
 	})
 	if err != nil {
-		return user.User{}, errors.Annotatef(err, "getting user with uuid %q", uuid)
+		return user.User{}, errors.Errorf("getting user with uuid %q %w", uuid, err)
 	}
 
 	return usr, nil
@@ -246,19 +246,19 @@ AND user.removed = false`
 
 	selectUserUUIDStmt, err := sqlair.Prepare(stmt, sqlair.M{}, uName)
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", errors.Capture(err)
 	}
 
 	result := sqlair.M{}
 	err = tx.Query(ctx, selectUserUUIDStmt, uName).Get(&result)
 	if errors.Is(err, sql.ErrNoRows) {
-		return "", fmt.Errorf("%w when finding user uuid for name %q", accesserrors.UserNotFound, name)
+		return "", errors.Errorf("%w when finding user uuid for name %q", accesserrors.UserNotFound, name)
 	} else if err != nil {
-		return "", fmt.Errorf("looking up user uuid for name %q: %w", name, err)
+		return "", errors.Errorf("looking up user uuid for name %q: %w", name, err)
 	}
 
 	if result["userUUID"] == nil {
-		return "", fmt.Errorf("retrieving user uuid for user name %q, no result provided", name)
+		return "", errors.Errorf("retrieving user uuid for user name %q, no result provided", name)
 	}
 
 	return user.UUID(result["userUUID"].(string)), nil
@@ -270,7 +270,7 @@ AND user.removed = false`
 func (st *UserState) GetUserByName(ctx context.Context, name user.Name) (user.User, error) {
 	db, err := st.DB()
 	if err != nil {
-		return user.User{}, errors.Annotate(err, "getting DB access")
+		return user.User{}, errors.Errorf("getting DB access %w", err)
 	}
 
 	uName := userName{Name: name.Name()}
@@ -294,22 +294,22 @@ AND    u.removed = false`
 
 		selectGetUserByNameStmt, err := st.Prepare(getUserByNameQuery, dbUser{}, uName)
 		if err != nil {
-			return errors.Annotate(err, "preparing select getUserByName query")
+			return errors.Errorf("preparing select getUserByName query %w", err)
 		}
 
 		var result dbUser
 		err = tx.Query(ctx, selectGetUserByNameStmt, uName).Get(&result)
 		if errors.Is(err, sql.ErrNoRows) {
-			return errors.Annotatef(accesserrors.UserNotFound, "%q", name)
+			return errors.Errorf("%q %w", name, accesserrors.UserNotFound)
 		} else if err != nil {
-			return errors.Annotatef(err, "getting user with name %q", name)
+			return errors.Errorf("getting user with name %q %w", name, err)
 		}
 
 		usr, err = result.toCoreUser()
-		return errors.Trace(err)
+		return errors.Capture(err)
 	})
 	if err != nil {
-		return user.User{}, errors.Annotatef(err, "getting user with name %q", name)
+		return user.User{}, errors.Errorf("getting user with name %q %w", name, err)
 	}
 
 	return usr, nil
@@ -322,7 +322,7 @@ AND    u.removed = false`
 func (st *UserState) GetUserByAuth(ctx context.Context, name user.Name, password auth.Password) (user.User, error) {
 	db, err := st.DB()
 	if err != nil {
-		return user.User{}, errors.Annotate(err, "getting DB access")
+		return user.User{}, errors.Errorf("getting DB access %w", err)
 	}
 
 	uName := userName{Name: name.Name()}
@@ -343,37 +343,37 @@ AND    user.removed = false
 
 	selectGetUserByAuthStmt, err := st.Prepare(getUserWithAuthQuery, dbUser{}, uName)
 	if err != nil {
-		return user.User{}, errors.Annotate(err, "preparing select getUserWithAuth query")
+		return user.User{}, errors.Errorf("preparing select getUserWithAuth query %w", err)
 	}
 
 	var result dbUser
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err = tx.Query(ctx, selectGetUserByAuthStmt, uName).Get(&result)
 		if errors.Is(err, sql.ErrNoRows) {
-			return errors.Annotatef(accesserrors.UserNotFound, "%q", name)
+			return errors.Errorf("%q %w", name, accesserrors.UserNotFound)
 		} else if err != nil {
-			return errors.Annotatef(err, "getting user with name %q", name)
+			return errors.Errorf("getting user with name %q %w", name, err)
 		}
 
 		return nil
 	})
 	if err != nil {
-		return user.User{}, errors.Annotatef(err, "getting user with name %q", name)
+		return user.User{}, errors.Errorf("getting user with name %q %w", name, err)
 	}
 
 	passwordHash, err := auth.HashPassword(password, result.PasswordSalt)
-	if errors.Is(err, errors.NotValid) {
+	if errors.Is(err, coreerrors.NotValid) {
 		// If the user has no salt, then they don't have a password correctly
 		// set. In this case, we should return an unauthorized error.
-		return user.User{}, errors.Annotatef(accesserrors.UserUnauthorized, "%q", name)
+		return user.User{}, errors.Errorf("%q %w", name, accesserrors.UserUnauthorized)
 	} else if err != nil {
-		return user.User{}, errors.Annotatef(err, "hashing password for user with name %q", name)
+		return user.User{}, errors.Errorf("hashing password for user with name %q %w", name, err)
 	} else if passwordHash != result.PasswordHash {
-		return user.User{}, errors.Annotatef(accesserrors.UserUnauthorized, "%q", name)
+		return user.User{}, errors.Errorf("%q %w", name, accesserrors.UserUnauthorized)
 	}
 
 	coreUser, err := result.toCoreUser()
-	return coreUser, errors.Trace(err)
+	return coreUser, errors.Capture(err)
 }
 
 // RemoveUser marks the user as removed. This obviates the ability of a user
@@ -384,12 +384,12 @@ AND    user.removed = false
 func (st *UserState) RemoveUser(ctx context.Context, name user.Name) error {
 	db, err := st.DB()
 	if err != nil {
-		return errors.Annotate(err, "getting DB access")
+		return errors.Errorf("getting DB access %w", err)
 	}
 
 	uuidStmt, err := st.getActiveUUIDStmt()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	m := make(sqlair.M, 1)
@@ -401,62 +401,62 @@ WHERE user_public_ssh_key_id IN (SELECT id
 								 WHERE upsk.user_uuid = $M.uuid)
 	`, m)
 	if err != nil {
-		return errors.Annotate(err, "preparing delete model authorized keys query for user")
+		return errors.Errorf("preparing delete model authorized keys query for user %w", err)
 	}
 
 	deleteUserPublicSSHKeysStmt, err := st.Prepare(
 		"DELETE FROM user_public_ssh_key WHERE user_uuid = $M.uuid", m,
 	)
 	if err != nil {
-		return errors.Annotate(err, "preparing delete user public ssh keys")
+		return errors.Errorf("preparing delete user public ssh keys %w", err)
 	}
 
 	deletePassStmt, err := st.Prepare("DELETE FROM user_password WHERE user_uuid = $M.uuid", m)
 	if err != nil {
-		return errors.Annotate(err, "preparing password deletion query")
+		return errors.Errorf("preparing password deletion query %w", err)
 	}
 
 	deleteKeyStmt, err := st.Prepare("DELETE FROM user_activation_key WHERE user_uuid = $M.uuid", m)
 	if err != nil {
-		return errors.Annotate(err, "preparing activation key deletion query")
+		return errors.Errorf("preparing activation key deletion query %w", err)
 	}
 
 	setRemovedStmt, err := st.Prepare("UPDATE user SET removed = true WHERE uuid = $M.uuid", m)
 	if err != nil {
-		return errors.Annotate(err, "preparing password deletion query")
+		return errors.Errorf("preparing password deletion query %w", err)
 	}
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		uuid, err := st.uuidForName(ctx, tx, uuidStmt, name)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		m["uuid"] = uuid
 
 		if err := tx.Query(ctx, deleteModelAuthorizedKeysStmt, m).Run(); err != nil {
-			return errors.Annotatef(err, "deleting model authorized keys for %q", name)
+			return errors.Errorf("deleting model authorized keys for %q %w", name, err)
 		}
 
 		if err := tx.Query(ctx, deleteUserPublicSSHKeysStmt, m).Run(); err != nil {
-			return errors.Annotatef(err, "deleting user publish ssh keys for %q", name)
+			return errors.Errorf("deleting user publish ssh keys for %q %w", name, err)
 		}
 
 		if err := tx.Query(ctx, deletePassStmt, m).Run(); err != nil {
-			return errors.Annotatef(err, "deleting password for %q", name)
+			return errors.Errorf("deleting password for %q %w", name, err)
 		}
 
 		if err := tx.Query(ctx, deleteKeyStmt, m).Run(); err != nil {
-			return errors.Annotatef(err, "deleting key for %q", name)
+			return errors.Errorf("deleting key for %q %w", name, err)
 		}
 
 		if err := tx.Query(ctx, setRemovedStmt, m).Run(); err != nil {
-			return errors.Annotatef(err, "marking %q removed", name)
+			return errors.Errorf("marking %q removed %w", name, err)
 		}
 
 		return nil
 	})
 
-	return errors.Annotatef(err, "removing user %q", name)
+	return errors.Errorf("removing user %q %w", name, err)
 }
 
 // SetActivationKey removes any active passwords for the user and sets the
@@ -465,32 +465,32 @@ WHERE user_public_ssh_key_id IN (SELECT id
 func (st *UserState) SetActivationKey(ctx context.Context, name user.Name, activationKey []byte) error {
 	db, err := st.DB()
 	if err != nil {
-		return errors.Annotate(err, "getting DB access")
+		return errors.Errorf("getting DB access %w", err)
 	}
 
 	uuidStmt, err := st.getActiveUUIDStmt()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	m := make(sqlair.M, 1)
 
 	deletePassStmt, err := st.Prepare("DELETE FROM user_password WHERE user_uuid = $M.uuid", m)
 	if err != nil {
-		return errors.Annotate(err, "preparing password deletion query")
+		return errors.Errorf("preparing password deletion query %w", err)
 	}
 
 	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		uuid, err := st.uuidForName(ctx, tx, uuidStmt, name)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		if err := tx.Query(ctx, deletePassStmt, sqlair.M{"uuid": uuid}).Run(); err != nil {
-			return errors.Annotatef(err, "deleting password for %q", name)
+			return errors.Errorf("deleting password for %q %w", name, err)
 		}
 
-		return errors.Trace(setActivationKey(ctx, tx, name, activationKey))
+		return errors.Capture(setActivationKey(ctx, tx, name, activationKey))
 	})
 }
 
@@ -500,12 +500,12 @@ func (st *UserState) SetActivationKey(ctx context.Context, name user.Name, activ
 func (st *UserState) GetActivationKey(ctx context.Context, name user.Name) ([]byte, error) {
 	db, err := st.DB()
 	if err != nil {
-		return nil, errors.Annotate(err, "getting DB access")
+		return nil, errors.Errorf("getting DB access %w", err)
 	}
 
 	uuidStmt, err := st.getActiveUUIDStmt()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	m := make(sqlair.M, 1)
@@ -514,29 +514,29 @@ func (st *UserState) GetActivationKey(ctx context.Context, name user.Name) ([]by
 SELECT (*) AS (&dbActivationKey.*) FROM user_activation_key WHERE user_uuid = $M.uuid
 `, m, dbActivationKey{})
 	if err != nil {
-		return nil, errors.Annotate(err, "preparing activation get query")
+		return nil, errors.Errorf("preparing activation get query %w", err)
 	}
 
 	var key dbActivationKey
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		uuid, err := st.uuidForName(ctx, tx, uuidStmt, name)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		if err := tx.Query(ctx, selectKeyStmt, sqlair.M{"uuid": uuid}).Get(&key); err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
-				return errors.Annotatef(accesserrors.ActivationKeyNotFound, "activation key for %q", name)
+				return errors.Errorf("activation key for %q %w", name, accesserrors.ActivationKeyNotFound)
 			}
-			return errors.Annotatef(err, "selecting activation key for %q", name)
+			return errors.Errorf("selecting activation key for %q %w", name, err)
 		}
-		return errors.Trace(err)
+		return errors.Capture(err)
 	})
 	if err != nil {
-		return nil, errors.Annotatef(err, "getting activation key for %q", name)
+		return nil, errors.Errorf("getting activation key for %q %w", name, err)
 	}
 	if len(key.ActivationKey) == 0 {
-		return nil, errors.Annotatef(accesserrors.ActivationKeyNotValid, "activation key for %q", name)
+		return nil, errors.Errorf("activation key for %q %w", name, accesserrors.ActivationKeyNotValid)
 	}
 	return []byte(key.ActivationKey), nil
 }
@@ -547,33 +547,33 @@ SELECT (*) AS (&dbActivationKey.*) FROM user_activation_key WHERE user_uuid = $M
 func (st *UserState) SetPasswordHash(ctx context.Context, name user.Name, passwordHash string, salt []byte) error {
 	db, err := st.DB()
 	if err != nil {
-		return errors.Annotate(err, "getting DB access")
+		return errors.Errorf("getting DB access %w", err)
 	}
 
 	uuidStmt, err := st.getActiveUUIDStmt()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	m := make(sqlair.M, 1)
 
 	deleteKeyStmt, err := st.Prepare("DELETE FROM user_activation_key WHERE user_uuid = $M.uuid", m)
 	if err != nil {
-		return errors.Annotate(err, "preparing password deletion query")
+		return errors.Errorf("preparing password deletion query %w", err)
 	}
 
 	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		uuid, err := st.uuidForName(ctx, tx, uuidStmt, name)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		m["uuid"] = uuid
 
 		if err := tx.Query(ctx, deleteKeyStmt, m).Run(); err != nil {
-			return errors.Annotatef(err, "deleting key for %q", name)
+			return errors.Errorf("deleting key for %q %w", name, err)
 		}
 
-		return errors.Trace(setPasswordHash(ctx, tx, name, passwordHash, salt))
+		return errors.Capture(setPasswordHash(ctx, tx, name, passwordHash, salt))
 	})
 }
 
@@ -583,12 +583,12 @@ func (st *UserState) SetPasswordHash(ctx context.Context, name user.Name, passwo
 func (st *UserState) EnableUserAuthentication(ctx context.Context, name user.Name) error {
 	db, err := st.DB()
 	if err != nil {
-		return errors.Annotate(err, "getting DB access")
+		return errors.Errorf("getting DB access %w", err)
 	}
 
 	uuidStmt, err := st.getActiveUUIDStmt()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	m := make(sqlair.M, 1)
@@ -601,18 +601,18 @@ UPDATE SET disabled = false`
 
 	enableUserStmt, err := st.Prepare(q, m)
 	if err != nil {
-		return errors.Annotate(err, "preparing enable user query")
+		return errors.Errorf("preparing enable user query %w", err)
 	}
 
 	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		uuid, err := st.uuidForName(ctx, tx, uuidStmt, name)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		m["uuid"] = uuid
 
 		if err := tx.Query(ctx, enableUserStmt, m).Run(); err != nil {
-			return errors.Annotatef(err, "enabling user %q", name)
+			return errors.Errorf("enabling user %q %w", name, err)
 		}
 
 		return nil
@@ -624,12 +624,12 @@ UPDATE SET disabled = false`
 func (st *UserState) DisableUserAuthentication(ctx context.Context, name user.Name) error {
 	db, err := st.DB()
 	if err != nil {
-		return errors.Annotate(err, "getting DB access")
+		return errors.Errorf("getting DB access %w", err)
 	}
 
 	uuidStmt, err := st.getActiveUUIDStmt()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	m := make(sqlair.M, 1)
@@ -642,22 +642,23 @@ UPDATE SET disabled = true`
 
 	disableUserStmt, err := st.Prepare(q, m)
 	if err != nil {
-		return errors.Annotate(err, "preparing disable user query")
+		return errors.Errorf("preparing disable user query %w", err)
 	}
 
-	return errors.Trace(db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+	return errors.Capture(db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		uuid, err := st.uuidForName(ctx, tx, uuidStmt, name)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		m["uuid"] = uuid
 
 		if err := tx.Query(ctx, disableUserStmt, m).Run(); err != nil {
-			return errors.Annotatef(err, "disabling user %q", name)
+			return errors.Errorf("disabling user %q %w", name, err)
 		}
 
 		return nil
 	}))
+
 }
 
 // AddUserWithPassword adds a new user to the database with the
@@ -678,10 +679,10 @@ func AddUserWithPassword(
 ) error {
 	err := AddUserWithPermission(ctx, tx, uuid, name, displayName, false, creatorUUID, permission)
 	if err != nil {
-		return errors.Annotatef(err, "adding user with uuid %q", uuid)
+		return errors.Errorf("adding user with uuid %q %w", uuid, err)
 	}
 
-	return errors.Trace(setPasswordHash(ctx, tx, name, passwordHash, salt))
+	return errors.Capture(setPasswordHash(ctx, tx, name, passwordHash, salt))
 }
 
 // AddUser adds a new user to the database and enables the user.
@@ -713,16 +714,16 @@ VALUES           ($dbUser.*)`
 
 	insertAddUserStmt, err := sqlair.Prepare(addUserQuery, user)
 	if err != nil {
-		return errors.Annotate(err, "preparing add user query")
+		return errors.Errorf("preparing add user query %w", err)
 	}
 
 	err = tx.Query(ctx, insertAddUserStmt, user).Run()
 	if internaldatabase.IsErrConstraintUnique(err) {
-		return errors.Annotatef(accesserrors.UserAlreadyExists, "adding user %q", name)
+		return errors.Errorf("adding user %q %w", name, accesserrors.UserAlreadyExists)
 	} else if internaldatabase.IsErrConstraintForeignKey(err) {
-		return errors.Annotatef(accesserrors.UserCreatorUUIDNotFound, "adding user %q", name)
+		return errors.Errorf("adding user %q %w", name, accesserrors.UserCreatorUUIDNotFound)
 	} else if err != nil {
-		return errors.Annotatef(err, "adding user %q", name)
+		return errors.Errorf("adding user %q %w", name, err)
 	}
 
 	enableUserQuery := `
@@ -732,11 +733,11 @@ VALUES ($dbUser.uuid, false)
 
 	enableUserStmt, err := sqlair.Prepare(enableUserQuery, user)
 	if err != nil {
-		return errors.Annotate(err, "preparing enable user query")
+		return errors.Errorf("preparing enable user query %w", err)
 	}
 
 	if err := tx.Query(ctx, enableUserStmt, user).Run(); err != nil {
-		return errors.Annotatef(err, "enabling user %q", name)
+		return errors.Errorf("enabling user %q %w", name, err)
 	}
 
 	return nil
@@ -760,12 +761,12 @@ func AddUserWithPermission(
 ) error {
 	err := AddUser(ctx, tx, uuid, name, displayName, external, creatorUuid)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	permissionUUID, err := internaluuid.NewUUID()
 	if err != nil {
-		return errors.Annotate(err, "generating permission UUID")
+		return errors.Errorf("generating permission UUID %w", err)
 	}
 	err = AddUserPermission(ctx, tx, AddUserPermissionArgs{
 		PermissionUUID: permissionUUID.String(),
@@ -774,7 +775,7 @@ func AddUserWithPermission(
 		Target:         access.Target,
 	})
 	if err != nil {
-		return errors.Annotatef(err, "adding permission for user %q", name)
+		return errors.Errorf("adding permission for user %q %w", name, err)
 	}
 
 	return nil
@@ -789,12 +790,12 @@ func AddUserWithPermission(
 func (st *UserState) UpdateLastModelLogin(ctx context.Context, name user.Name, modelUUID coremodel.UUID, lastLogin time.Time) error {
 	db, err := st.DB()
 	if err != nil {
-		return errors.Annotate(err, "getting DB access")
+		return errors.Errorf("getting DB access %w", err)
 	}
 
 	uuidStmt, err := st.getActiveUUIDStmt()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	insertModelLoginStmt, err := st.Prepare(`
@@ -803,13 +804,13 @@ VALUES ($dbModelLastLogin.*)
 ON CONFLICT(model_uuid, user_uuid) DO UPDATE SET 
 	time = excluded.time`, dbModelLastLogin{})
 	if err != nil {
-		return errors.Annotate(err, "preparing insert model login query")
+		return errors.Errorf("preparing insert model login query %w", err)
 	}
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		userUUID, err := st.uuidForName(ctx, tx, uuidStmt, name)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		mll := dbModelLastLogin{
@@ -825,12 +826,12 @@ ON CONFLICT(model_uuid, user_uuid) DO UPDATE SET
 				// uuidForName query would have failed, so it must be the model.
 				return modelerrors.NotFound
 			}
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		return nil
 	})
 	if err != nil {
-		return errors.Annotatef(err, "inserting last login for user %q for model %q", name, modelUUID)
+		return errors.Errorf("inserting last login for user %q for model %q %w", name, modelUUID, err)
 	}
 	return nil
 }
@@ -845,12 +846,12 @@ ON CONFLICT(model_uuid, user_uuid) DO UPDATE SET
 func (st *UserState) LastModelLogin(ctx context.Context, name user.Name, modelUUID coremodel.UUID) (time.Time, error) {
 	db, err := st.DB()
 	if err != nil {
-		return time.Time{}, errors.Annotate(err, "getting DB access")
+		return time.Time{}, errors.Errorf("getting DB access %w", err)
 	}
 
 	uuidStmt, err := st.getActiveUUIDStmt()
 	if err != nil {
-		return time.Time{}, errors.Trace(err)
+		return time.Time{}, errors.Capture(err)
 	}
 
 	getLastModelLoginTime := `
@@ -862,14 +863,14 @@ ORDER BY time DESC LIMIT 1;
 	`
 	getLastModelLoginTimeStmt, err := st.Prepare(getLastModelLoginTime, dbModelLastLogin{})
 	if err != nil {
-		return time.Time{}, errors.Annotate(err, "preparing select getLastModelLoginTime query")
+		return time.Time{}, errors.Errorf("preparing select getLastModelLoginTime query %w", err)
 	}
 
 	var lastConnection time.Time
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		userUUID, err := st.uuidForName(ctx, tx, uuidStmt, name)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		mll := dbModelLastLogin{
@@ -879,24 +880,24 @@ ORDER BY time DESC LIMIT 1;
 		err = tx.Query(ctx, getLastModelLoginTimeStmt, mll).Get(&mll)
 		if errors.Is(err, sql.ErrNoRows) {
 			if exists, err := st.checkModelExists(ctx, tx, modelUUID); err != nil {
-				return errors.Annotate(err, "checking model exists")
+				return errors.Errorf("checking model exists %w", err)
 			} else if !exists {
 				return modelerrors.NotFound
 			}
 			return accesserrors.UserNeverAccessedModel
 		} else if err != nil {
-			return errors.Annotatef(err, "running query getLastModelLoginTime")
+			return errors.Errorf("running query getLastModelLoginTime %w", err)
 		}
 
 		lastConnection = mll.Time
 		if err != nil {
-			return errors.Annotate(err, "parsing time")
+			return errors.Errorf("parsing time %w", err)
 		}
 
 		return nil
 	})
 	if err != nil {
-		return time.Time{}, errors.Trace(err)
+		return time.Time{}, errors.Capture(err)
 	}
 	return lastConnection.UTC(), nil
 }
@@ -923,24 +924,24 @@ WHERE      disabled = false`
 
 	insertDefineUserAuthenticationStmt, err := sqlair.Prepare(defineUserAuthenticationQuery, sqlair.M{})
 	if err != nil {
-		return errors.Annotate(err, "preparing insert defineUserAuthentication query")
+		return errors.Errorf("preparing insert defineUserAuthentication query %w", err)
 	}
 
 	var outcome sqlair.Outcome
 	err = tx.Query(ctx, insertDefineUserAuthenticationStmt, sqlair.M{"name": name.Name(), "disabled": false}).Get(&outcome)
 	if internaldatabase.IsErrConstraintForeignKey(err) {
-		return errors.Annotatef(accesserrors.UserNotFound, "%q", name)
+		return errors.Errorf("%q %w", name, accesserrors.UserNotFound)
 	} else if err != nil {
-		return errors.Annotatef(err, "setting authentication for user %q", name)
+		return errors.Errorf("setting authentication for user %q %w", name, err)
 	}
 
 	affected, err := outcome.Result().RowsAffected()
 	if err != nil {
-		return errors.Annotatef(err, "determining results of setting authentication for user %q", name)
+		return errors.Errorf("determining results of setting authentication for user %q %w", name, err)
 	}
 
 	if affected == 0 {
-		return errors.Annotatef(accesserrors.UserAuthenticationDisabled, "%q", name)
+		return errors.Errorf("%q %w", name, accesserrors.UserAuthenticationDisabled)
 	}
 	return nil
 }
@@ -953,7 +954,7 @@ WHERE      disabled = false`
 func setPasswordHash(ctx context.Context, tx *sqlair.TX, name user.Name, passwordHash string, salt []byte) error {
 	err := ensureUserAuthentication(ctx, tx, name)
 	if err != nil {
-		return errors.Annotatef(err, "setting password hash for user %q", name)
+		return errors.Errorf("setting password hash for user %q %w", name, err)
 	}
 
 	setPasswordHashQuery := `
@@ -966,7 +967,7 @@ ON CONFLICT(user_uuid) DO UPDATE SET password_hash = excluded.password_hash, pas
 
 	insertSetPasswordHashStmt, err := sqlair.Prepare(setPasswordHashQuery, sqlair.M{})
 	if err != nil {
-		return errors.Annotate(err, "preparing insert setPasswordHash query")
+		return errors.Errorf("preparing insert setPasswordHash query %w", err)
 	}
 
 	err = tx.Query(ctx, insertSetPasswordHashStmt, sqlair.M{
@@ -975,7 +976,7 @@ ON CONFLICT(user_uuid) DO UPDATE SET password_hash = excluded.password_hash, pas
 		"password_salt": salt},
 	).Run()
 	if err != nil {
-		return errors.Annotatef(err, "setting password hash for user %q", name)
+		return errors.Errorf("setting password hash for user %q %w", name, err)
 	}
 
 	return nil
@@ -988,7 +989,7 @@ ON CONFLICT(user_uuid) DO UPDATE SET password_hash = excluded.password_hash, pas
 func setActivationKey(ctx context.Context, tx *sqlair.TX, name user.Name, activationKey []byte) error {
 	err := ensureUserAuthentication(ctx, tx, name)
 	if err != nil {
-		return errors.Annotatef(err, "setting activation key for user %q", name)
+		return errors.Errorf("setting activation key for user %q %w", name, err)
 	}
 
 	setActivationKeyQuery := `
@@ -1001,12 +1002,12 @@ ON CONFLICT(user_uuid) DO UPDATE SET activation_key = excluded.activation_key`
 
 	insertSetActivationKeyStmt, err := sqlair.Prepare(setActivationKeyQuery, sqlair.M{})
 	if err != nil {
-		return errors.Annotate(err, "preparing insert setActivationKey query")
+		return errors.Errorf("preparing insert setActivationKey query %w", err)
 	}
 
 	err = tx.Query(ctx, insertSetActivationKeyStmt, sqlair.M{"name": name.Name(), "activation_key": activationKey}).Run()
 	if err != nil {
-		return errors.Annotatef(err, "setting activation key for user %q", name)
+		return errors.Errorf("setting activation key for user %q %w", name, err)
 	}
 
 	return nil
@@ -1019,14 +1020,14 @@ func (st *UserState) uuidForName(
 	err := tx.Query(ctx, stmt, userName{Name: name.Name()}).Get(&dbUUID)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return "", errors.Annotatef(accesserrors.UserNotFound, "active user %q", name)
+			return "", errors.Errorf("active user %q %w", name, accesserrors.UserNotFound)
 		}
-		return "", errors.Annotatef(err, "getting user %q", name)
+		return "", errors.Errorf("getting user %q %w", name, err)
 	}
 
 	uuid := user.UUID(dbUUID.UUID)
 	if err := uuid.Validate(); err != nil {
-		return "", errors.Annotatef(accesserrors.UserNotFound, "invalid UUID for %q", name)
+		return "", errors.Errorf("invalid UUID for %q %w", name, accesserrors.UserNotFound)
 	}
 	return uuid, nil
 }
@@ -1046,14 +1047,14 @@ SELECT true AS &dbModelExists.exists
 FROM model 
 WHERE model.uuid = $dbModelUUID.uuid`, dbModelUUID{}, dbModelExists{})
 	if err != nil {
-		return false, errors.Annotatef(err, "preparing select checkModelExists")
+		return false, errors.Errorf("preparing select checkModelExists %w", err)
 	}
 	var exists dbModelExists
 	err = tx.Query(ctx, stmt, dbModelUUID{UUID: modelUUID.String()}).Get(&exists)
 	if errors.Is(err, sqlair.ErrNoRows) {
 		return false, nil
 	} else if err != nil {
-		return false, errors.Trace(err)
+		return false, errors.Capture(err)
 	}
 	return true, nil
 }

--- a/domain/access/state/user.go
+++ b/domain/access/state/user.go
@@ -456,7 +456,10 @@ WHERE user_public_ssh_key_id IN (SELECT id
 		return nil
 	})
 
-	return errors.Errorf("removing user %q %w", name, err)
+	if err != nil {
+		return errors.Errorf("removing user %q %w", name, err)
+	}
+	return nil
 }
 
 // SetActivationKey removes any active passwords for the user and sets the

--- a/domain/access/state/user_test.go
+++ b/domain/access/state/user_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/canonical/sqlair"
-	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"golang.org/x/net/context"
 	gc "gopkg.in/check.v1"
@@ -26,6 +25,7 @@ import (
 	schematesting "github.com/juju/juju/domain/schema/testing"
 	"github.com/juju/juju/internal/auth"
 	"github.com/juju/juju/internal/database"
+	"github.com/juju/juju/internal/errors"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 )
 
@@ -107,7 +107,7 @@ func (s *userStateSuite) TestSingletonActiveUser(c *gc.C) {
 func generateActivationKey() ([]byte, error) {
 	var activationKey [32]byte
 	if _, err := rand.Read(activationKey[:]); err != nil {
-		return nil, errors.Annotate(err, "generating activation key")
+		return nil, errors.Errorf("generating activation key %w", err)
 	}
 	return activationKey[:], nil
 }

--- a/domain/access/types.go
+++ b/domain/access/types.go
@@ -4,10 +4,10 @@
 package access
 
 import (
-	"github.com/juju/errors"
-
+	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/core/user"
+	"github.com/juju/juju/internal/errors"
 )
 
 // UpdatePermissionArgs are necessary arguments to run
@@ -25,13 +25,13 @@ type UpdatePermissionArgs struct {
 
 func (args UpdatePermissionArgs) Validate() error {
 	if args.Subject.IsZero() {
-		return errors.Trace(errors.NotValidf("empty subject"))
+		return errors.Capture(errors.Errorf("empty subject %w", coreerrors.NotValid))
 	}
 	if err := args.AccessSpec.Validate(); err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	if args.Change != permission.Grant && args.Change != permission.Revoke {
-		return errors.Trace(errors.NotValidf("change %q", args.Change))
+		return errors.Capture(errors.Errorf("change %q %w", args.Change, coreerrors.NotValid))
 	}
 	return nil
 }

--- a/domain/access/types_test.go
+++ b/domain/access/types_test.go
@@ -4,10 +4,10 @@
 package access
 
 import (
-	"github.com/juju/errors"
 	"github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/permission"
 	usertesting "github.com/juju/juju/core/user/testing"
 )
@@ -43,6 +43,6 @@ func (s *typesSuite) TestUpsertPermissionArgsValidationFail(c *gc.C) {
 		}}
 	for i, args := range argsToTest {
 		c.Logf("Test %d", i)
-		c.Check(args.Validate(), checkers.ErrorIs, errors.NotValid)
+		c.Check(args.Validate(), checkers.ErrorIs, coreerrors.NotValid)
 	}
 }

--- a/domain/agentprovisioner/service/service.go
+++ b/domain/agentprovisioner/service/service.go
@@ -5,22 +5,22 @@ package service
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 	"strings"
 
-	"github.com/juju/errors"
 	"github.com/juju/proxy"
 	"gopkg.in/yaml.v2"
 
 	"github.com/juju/juju/core/container"
 	"github.com/juju/juju/core/containermanager"
+	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/modelconfig"
 	"github.com/juju/juju/core/providertracker"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/environs/envcontext"
+	"github.com/juju/juju/internal/errors"
 )
 
 // keysForContainerConfig lists the model config keys that we need to determine
@@ -97,7 +97,7 @@ func (s *Service) ContainerManagerConfigForType(
 
 	modelID, err := s.st.ModelID(ctx)
 	if err != nil {
-		return rval, fmt.Errorf("getting ID for current model: %w", err)
+		return rval, errors.Errorf("getting ID for current model: %w", err)
 	}
 
 	cfg, err := s.st.GetModelConfigKeyValues(ctx,
@@ -107,10 +107,10 @@ func (s *Service) ContainerManagerConfigForType(
 		config.ContainerImageStreamKey,
 	)
 	if err != nil {
-		return rval, fmt.Errorf(
+		return rval, errors.Errorf(
 			"cannot get model config keys when calculating container manager config: %w",
-			err,
-		)
+			err)
+
 	}
 
 	rval.ModelID = modelID
@@ -130,7 +130,7 @@ func (s *Service) ContainerManagerConfigForType(
 func (s *Service) ContainerNetworkingMethod(ctx context.Context) (containermanager.NetworkingMethod, error) {
 	cfg, err := s.st.GetModelConfigKeyValues(ctx, config.ContainerNetworkingMethodKey)
 	if err != nil {
-		return "", fmt.Errorf("getting container networking method from model config: %w", err)
+		return "", errors.Errorf("getting container networking method from model config: %w", err)
 	}
 
 	method := modelconfig.ContainerNetworkingMethod(cfg[config.ContainerNetworkingMethodKey])
@@ -142,28 +142,28 @@ func (s *Service) ContainerNetworkingMethod(ctx context.Context) (containermanag
 	case modelconfig.ContainerNetworkingMethodAuto:
 		// Auto-configure container networking method below
 	default:
-		return "", fmt.Errorf("unable to deduce container networking method %q from model config", method)
+		return "", errors.Errorf("unable to deduce container networking method %q from model config", method)
 	}
 
 	provider, err := s.providerGetter(ctx)
-	if errors.Is(err, errors.NotSupported) {
+	if errors.Is(err, coreerrors.NotSupported) {
 		// Provider doesn't have the SupportsContainerAddresses method
 		return containermanager.NetworkingMethodLocal, nil
 	} else if err != nil {
-		return "", fmt.Errorf(
+		return "", errors.Errorf(
 			"cannot get networking provider for model: %w",
-			err,
-		)
+			err)
+
 	}
 
 	supports, err := provider.SupportsContainerAddresses(envcontext.WithoutCredentialInvalidator(ctx))
-	if errors.Is(err, errors.NotSupported) {
+	if errors.Is(err, coreerrors.NotSupported) {
 		return containermanager.NetworkingMethodLocal, nil
 	} else if err != nil {
-		return "", fmt.Errorf(
+		return "", errors.Errorf(
 			"cannot determine if provider supports container addresses: %w",
-			err,
-		)
+			err)
+
 	}
 	if supports {
 		return containermanager.NetworkingMethodProvider, nil
@@ -177,10 +177,10 @@ func (s *Service) ContainerConfig(ctx context.Context) (container.Config, error)
 
 	modelConfig, err := s.st.GetModelConfigKeyValues(ctx, keysForContainerConfig...)
 	if err != nil {
-		return result, fmt.Errorf(
+		return result, errors.Errorf(
 			"cannot get model config keys when calculating container config: %w",
-			err,
-		)
+			err)
+
 	}
 
 	result.EnableOSRefreshUpdate, _ = strconv.ParseBool(modelConfig[config.EnableOSRefreshUpdateKey])

--- a/domain/agentprovisioner/service/service_test.go
+++ b/domain/agentprovisioner/service/service_test.go
@@ -6,7 +6,6 @@ package service
 import (
 	"context"
 
-	"github.com/juju/errors"
 	"github.com/juju/proxy"
 	jc "github.com/juju/testing/checkers"
 	"go.uber.org/mock/gomock"
@@ -14,9 +13,11 @@ import (
 
 	"github.com/juju/juju/core/container"
 	"github.com/juju/juju/core/containermanager"
+	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/instance"
 	modeltesting "github.com/juju/juju/core/model/testing"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/internal/errors"
 )
 
 type suite struct {
@@ -92,7 +93,7 @@ func (s *suite) TestDetermineNetworkingMethodProviderNotSupported(c *gc.C) {
 		config.ContainerNetworkingMethodKey: "", // auto-configure
 	}, nil)
 	providerGetter := func(ctx context.Context) (Provider, error) {
-		return nil, errors.NotSupportedf("provider type %T", Provider(nil))
+		return nil, errors.Errorf("provider type %T %w", Provider(nil), coreerrors.NotSupported)
 	}
 
 	service := NewService(s.state, providerGetter)
@@ -144,7 +145,7 @@ func (s *suite) TestDetermineNetworkingMethodProviderReturnsNotSupported(c *gc.C
 	s.state.EXPECT().GetModelConfigKeyValues(gomock.Any(), gomock.Any()).Return(map[string]string{
 		config.ContainerNetworkingMethodKey: "", // auto-configure
 	}, nil)
-	s.provider.EXPECT().SupportsContainerAddresses(gomock.Any()).Return(false, errors.NotSupportedf("container addresses"))
+	s.provider.EXPECT().SupportsContainerAddresses(gomock.Any()).Return(false, errors.Errorf("container addresses %w", coreerrors.NotSupported))
 
 	service := NewService(s.state, s.providerGetter)
 	method, err := service.ContainerNetworkingMethod(context.Background())

--- a/domain/agentprovisioner/state/state.go
+++ b/domain/agentprovisioner/state/state.go
@@ -5,15 +5,14 @@ package state
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/canonical/sqlair"
-	"github.com/juju/errors"
 
 	"github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/domain"
 	modelerrors "github.com/juju/juju/domain/model/errors"
+	"github.com/juju/juju/internal/errors"
 )
 
 // State is responsible for accessing the controller/model DB to retrieve the
@@ -43,7 +42,7 @@ func (s *State) GetModelConfigKeyValues(
 
 	db, err := s.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	input := make(sqlair.S, 0, len(keys))
@@ -58,9 +57,9 @@ WHERE key in ($S[:])
 `, input, modelConfigRow{})
 
 	if err != nil {
-		return nil, fmt.Errorf(
-			"preparing get model config key values: %w", domain.CoerceError(err),
-		)
+		return nil, errors.Errorf(
+			"preparing get model config key values: %w", domain.CoerceError(err))
+
 	}
 
 	result := make([]modelConfigRow, 0, len(keys))
@@ -69,10 +68,10 @@ WHERE key in ($S[:])
 		if errors.Is(err, sqlair.ErrNoRows) {
 			return nil
 		} else if err != nil {
-			return fmt.Errorf(
+			return errors.Errorf(
 				"getting model config key values: %w",
-				domain.CoerceError(err),
-			)
+				domain.CoerceError(err))
+
 		}
 		return nil
 	})
@@ -93,7 +92,7 @@ WHERE key in ($S[:])
 func (s *State) ModelID(ctx context.Context) (model.UUID, error) {
 	db, err := s.DB()
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", errors.Capture(err)
 	}
 
 	stmt, err := s.Prepare(`
@@ -102,9 +101,9 @@ FROM model
 `, modelInfo{})
 
 	if err != nil {
-		return "", fmt.Errorf(
-			"preparing get model statement: %w", domain.CoerceError(err),
-		)
+		return "", errors.Errorf(
+			"preparing get model statement: %w", domain.CoerceError(err))
+
 	}
 
 	result := make([]modelInfo, 0, 1)

--- a/domain/annotation/errors/errors.go
+++ b/domain/annotation/errors/errors.go
@@ -3,9 +3,7 @@
 
 package errors
 
-import (
-	"github.com/juju/errors"
-)
+import "github.com/juju/juju/internal/errors"
 
 const (
 	// UnknownKind is raised when the Kind of an ID provided to the annotations

--- a/domain/annotation/state/query.go
+++ b/domain/annotation/state/query.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 
 	"github.com/canonical/sqlair"
-	"github.com/juju/errors"
 
 	"github.com/juju/juju/core/annotations"
 	annotationerrors "github.com/juju/juju/domain/annotation/errors"
+	"github.com/juju/juju/internal/errors"
 )
 
 // getAnnotationQueryForID provides a query for the given id, based on
@@ -24,7 +24,7 @@ func getAnnotationQueryForID(id annotations.ID) (string, error) {
 
 	kindName, err := kindNameFromID(id)
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", errors.Capture(err)
 	}
 	return fmt.Sprintf(`
 SELECT (key, value) AS (&Annotation.*)
@@ -46,7 +46,7 @@ VALUES ($Annotation.*)
 
 	kindName, err := kindNameFromID(id)
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", errors.Capture(err)
 	}
 	return fmt.Sprintf(`
 INSERT INTO annotation_%s (uuid, key, value)
@@ -62,7 +62,7 @@ func deleteAnnotationsQueryForID(id annotations.ID) (string, error) {
 	} else {
 		kindName, err := kindNameFromID(id)
 		if err != nil {
-			return "", errors.Trace(err)
+			return "", errors.Capture(err)
 		}
 		return fmt.Sprintf(`
 DELETE FROM annotation_%s
@@ -82,7 +82,7 @@ WHERE uuid = $annotationUUID.uuid`, kindName), nil
 func uuidQueryForID(id annotations.ID) (string, sqlair.M, error) {
 	kindName, err := kindNameFromID(id)
 	if err != nil {
-		return "", sqlair.M{}, errors.Trace(err)
+		return "", sqlair.M{}, errors.Capture(err)
 	}
 
 	var selector string
@@ -118,7 +118,7 @@ func kindNameFromID(id annotations.ID) (string, error) {
 	case annotations.KindModel:
 		kindName = "model"
 	default:
-		return "", errors.Annotatef(annotationerrors.UnknownKind, "%q", id.Kind)
+		return "", errors.Errorf("%q %w", id.Kind, annotationerrors.UnknownKind)
 	}
 	return kindName, nil
 }

--- a/domain/annotation/types.go
+++ b/domain/annotation/types.go
@@ -3,7 +3,10 @@
 
 package annotation
 
-import "github.com/juju/errors"
+import (
+	coreerrors "github.com/juju/juju/core/errors"
+	"github.com/juju/juju/internal/errors"
+)
 
 // GetCharmArgs holds the arguments for the GetCharm method.
 type GetCharmArgs struct {
@@ -15,13 +18,13 @@ type GetCharmArgs struct {
 // Validate checks if the GetCharmArgs are valid or not.
 func (a GetCharmArgs) Validate() error {
 	if a.Source == "" {
-		return errors.NotValidf("source")
+		return errors.Errorf("source %w", coreerrors.NotValid)
 	}
 	if a.Name == "" {
-		return errors.NotValidf("name")
+		return errors.Errorf("name %w", coreerrors.NotValid)
 	}
 	if a.Revision < 0 {
-		return errors.NotValidf("negative revision")
+		return errors.Errorf("negative revision %w", coreerrors.NotValid)
 	}
 	return nil
 }

--- a/domain/application/errors/errors.go
+++ b/domain/application/errors/errors.go
@@ -3,9 +3,7 @@
 
 package errors
 
-import (
-	"github.com/juju/errors"
-)
+import "github.com/juju/juju/internal/errors"
 
 const (
 	// ApplicationNotFound describes an error that occurs when the application

--- a/domain/application/modelmigration/export.go
+++ b/domain/application/modelmigration/export.go
@@ -6,11 +6,9 @@ package modelmigration
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 
 	"github.com/juju/clock"
 	"github.com/juju/description/v8"
-	"github.com/juju/errors"
 
 	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/core/logger"
@@ -21,6 +19,7 @@ import (
 	"github.com/juju/juju/domain/application/state"
 	internalcharm "github.com/juju/juju/internal/charm"
 	"github.com/juju/juju/internal/charm/resource"
+	"github.com/juju/juju/internal/errors"
 )
 
 // RegisterExport registers the export operations with the given coordinator.
@@ -105,7 +104,7 @@ func (e *exportOperation) Execute(ctx context.Context, model description.Model) 
 
 		curl, err := internalcharm.ParseURL(app.CharmURL())
 		if err != nil {
-			return fmt.Errorf("cannot parse charm URL %q: %v", app.CharmURL(), err)
+			return errors.Errorf("cannot parse charm URL %q: %v", app.CharmURL(), err)
 		}
 
 		charmID, err := e.service.GetCharmID(ctx, charm.GetCharmArgs{
@@ -113,16 +112,16 @@ func (e *exportOperation) Execute(ctx context.Context, model description.Model) 
 			Revision: &curl.Revision,
 		})
 		if err != nil {
-			return fmt.Errorf("cannot get charm ID for %q: %v", app.CharmURL(), err)
+			return errors.Errorf("cannot get charm ID for %q: %v", app.CharmURL(), err)
 		}
 
 		charm, _, err := e.service.GetCharm(ctx, charmID)
 		if err != nil {
-			return fmt.Errorf("cannot get charm %q: %v", charmID, err)
+			return errors.Errorf("cannot get charm %q: %v", charmID, err)
 		}
 
 		if err := e.exportCharm(ctx, app, charm); err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 	}
 	return nil
@@ -133,28 +132,28 @@ func (e *exportOperation) exportCharm(ctx context.Context, app description.Appli
 	if profiler, ok := charm.(internalcharm.LXDProfiler); ok {
 		var err error
 		if lxdProfile, err = e.exportLXDProfile(profiler.LXDProfile()); err != nil {
-			return fmt.Errorf("cannot export LXD profile: %v", err)
+			return errors.Errorf("cannot export LXD profile: %v", err)
 		}
 	}
 
 	metadata, err := e.exportCharmMetadata(charm.Meta(), lxdProfile)
 	if err != nil {
-		return fmt.Errorf("cannot export charm metadata: %v", err)
+		return errors.Errorf("cannot export charm metadata: %v", err)
 	}
 
 	manifest, err := e.exportCharmManifest(charm.Manifest())
 	if err != nil {
-		return fmt.Errorf("cannot export charm manifest: %v", err)
+		return errors.Errorf("cannot export charm manifest: %v", err)
 	}
 
 	config, err := e.exportCharmConfig(charm.Config())
 	if err != nil {
-		return fmt.Errorf("cannot export charm config: %v", err)
+		return errors.Errorf("cannot export charm config: %v", err)
 	}
 
 	actions, err := e.exportCharmActions(charm.Actions())
 	if err != nil {
-		return fmt.Errorf("cannot export charm actions: %v", err)
+		return errors.Errorf("cannot export charm actions: %v", err)
 	}
 
 	app.SetCharmMetadata(metadata)
@@ -177,58 +176,58 @@ func (e *exportOperation) exportCharmMetadata(metadata *internalcharm.Meta, lxdP
 		var err error
 		assumesBytes, err = json.Marshal(expr)
 		if err != nil {
-			return description.CharmMetadataArgs{}, fmt.Errorf("cannot marshal assumes: %v", err)
+			return description.CharmMetadataArgs{}, errors.Errorf("cannot marshal assumes: %v", err)
 		}
 	}
 
 	runAs, err := exportCharmUser(metadata.CharmUser)
 	if err != nil {
-		return description.CharmMetadataArgs{}, errors.Trace(err)
+		return description.CharmMetadataArgs{}, errors.Capture(err)
 	}
 
 	provides, err := exportRelations(metadata.Provides)
 	if err != nil {
-		return description.CharmMetadataArgs{}, errors.Trace(err)
+		return description.CharmMetadataArgs{}, errors.Capture(err)
 	}
 
 	requires, err := exportRelations(metadata.Requires)
 	if err != nil {
-		return description.CharmMetadataArgs{}, errors.Trace(err)
+		return description.CharmMetadataArgs{}, errors.Capture(err)
 	}
 
 	peers, err := exportRelations(metadata.Peers)
 	if err != nil {
-		return description.CharmMetadataArgs{}, errors.Trace(err)
+		return description.CharmMetadataArgs{}, errors.Capture(err)
 	}
 
 	extraBindings := exportExtraBindings(metadata.ExtraBindings)
 	if err != nil {
-		return description.CharmMetadataArgs{}, errors.Trace(err)
+		return description.CharmMetadataArgs{}, errors.Capture(err)
 	}
 
 	storage, err := exportStorage(metadata.Storage)
 	if err != nil {
-		return description.CharmMetadataArgs{}, errors.Trace(err)
+		return description.CharmMetadataArgs{}, errors.Capture(err)
 	}
 
 	devices, err := exportDevices(metadata.Devices)
 	if err != nil {
-		return description.CharmMetadataArgs{}, errors.Trace(err)
+		return description.CharmMetadataArgs{}, errors.Capture(err)
 	}
 
 	payloads, err := exportPayloads(metadata.PayloadClasses)
 	if err != nil {
-		return description.CharmMetadataArgs{}, errors.Trace(err)
+		return description.CharmMetadataArgs{}, errors.Capture(err)
 	}
 
 	containers, err := exportContainers(metadata.Containers)
 	if err != nil {
-		return description.CharmMetadataArgs{}, errors.Trace(err)
+		return description.CharmMetadataArgs{}, errors.Capture(err)
 	}
 
 	resources, err := exportResources(metadata.Resources)
 	if err != nil {
-		return description.CharmMetadataArgs{}, errors.Trace(err)
+		return description.CharmMetadataArgs{}, errors.Capture(err)
 	}
 
 	return description.CharmMetadataArgs{
@@ -265,7 +264,7 @@ func (e *exportOperation) exportLXDProfile(profile *internalcharm.LXDProfile) (s
 	// YAML.
 	data, err := json.Marshal(profile)
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", errors.Capture(err)
 	}
 
 	return string(data), nil
@@ -278,7 +277,7 @@ func (e *exportOperation) exportCharmManifest(manifest *internalcharm.Manifest) 
 
 	bases, err := exportManifestBases(manifest.Bases)
 	if err != nil {
-		return description.CharmManifestArgs{}, errors.Trace(err)
+		return description.CharmManifestArgs{}, errors.Capture(err)
 	}
 
 	return description.CharmManifestArgs{
@@ -357,7 +356,7 @@ func exportRelations(relations map[string]internalcharm.Relation) (map[string]de
 	for name, relation := range relations {
 		args, err := exportRelation(relation)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, errors.Capture(err)
 		}
 		result[name] = args
 	}
@@ -367,12 +366,12 @@ func exportRelations(relations map[string]internalcharm.Relation) (map[string]de
 func exportRelation(relation internalcharm.Relation) (description.CharmMetadataRelation, error) {
 	role, err := exportCharmRole(relation.Role)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	scope, err := exportCharmScope(relation.Scope)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	return relationType{
@@ -443,7 +442,7 @@ func exportStorage(storage map[string]internalcharm.Storage) (map[string]descrip
 	for name, storage := range storage {
 		typ, err := exportStorageType(storage)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, errors.Capture(err)
 		}
 
 		result[name] = storageType{
@@ -539,7 +538,7 @@ func exportResources(resources map[string]resource.Meta) (map[string]description
 	for name, resource := range resources {
 		typ, err := exportResourceType(resource.Type)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, errors.Capture(err)
 		}
 
 		result[name] = resourceType{

--- a/domain/application/modelmigration/import_test.go
+++ b/domain/application/modelmigration/import_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/juju/description/v8"
-	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -17,6 +16,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	corecharm "github.com/juju/juju/core/charm"
+	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/domain/application/charm"
 	"github.com/juju/juju/domain/application/service"
@@ -190,7 +190,7 @@ func (s *importSuite) TestImportCharmMetadataEmpty(c *gc.C) {
 	}
 
 	_, err := importOp.importCharmMetadata(nil)
-	c.Assert(err, jc.ErrorIs, errors.NotValid)
+	c.Assert(err, jc.ErrorIs, coreerrors.NotValid)
 }
 
 func (s *importSuite) TestImportCharmMetadataInvalidUser(c *gc.C) {
@@ -204,7 +204,7 @@ func (s *importSuite) TestImportCharmMetadataInvalidUser(c *gc.C) {
 	}
 
 	_, err := importOp.importCharmMetadata(s.charmMetadata)
-	c.Assert(err, jc.ErrorIs, errors.NotValid)
+	c.Assert(err, jc.ErrorIs, coreerrors.NotValid)
 }
 
 func (s *importSuite) TestImportCharmMetadataInvalidAssumes(c *gc.C) {
@@ -219,7 +219,7 @@ func (s *importSuite) TestImportCharmMetadataInvalidAssumes(c *gc.C) {
 	}
 
 	_, err := importOp.importCharmMetadata(s.charmMetadata)
-	c.Assert(err, jc.ErrorIs, errors.NotValid)
+	c.Assert(err, jc.ErrorIs, coreerrors.NotValid)
 }
 
 func (s *importSuite) TestImportCharmMetadataInvalidMinJujuVersion(c *gc.C) {
@@ -235,7 +235,7 @@ func (s *importSuite) TestImportCharmMetadataInvalidMinJujuVersion(c *gc.C) {
 	}
 
 	_, err := importOp.importCharmMetadata(s.charmMetadata)
-	c.Assert(err, jc.ErrorIs, errors.NotValid)
+	c.Assert(err, jc.ErrorIs, coreerrors.NotValid)
 }
 
 func (s *importSuite) TestImportCharmMetadataInvalidRelationRole(c *gc.C) {
@@ -258,7 +258,7 @@ func (s *importSuite) TestImportCharmMetadataInvalidRelationRole(c *gc.C) {
 	}
 
 	_, err := importOp.importCharmMetadata(s.charmMetadata)
-	c.Assert(err, jc.ErrorIs, errors.NotValid)
+	c.Assert(err, jc.ErrorIs, coreerrors.NotValid)
 }
 
 func (s *importSuite) TestImportCharmMetadataInvalidRelationScope(c *gc.C) {
@@ -282,7 +282,7 @@ func (s *importSuite) TestImportCharmMetadataInvalidRelationScope(c *gc.C) {
 	}
 
 	_, err := importOp.importCharmMetadata(s.charmMetadata)
-	c.Assert(err, jc.ErrorIs, errors.NotValid)
+	c.Assert(err, jc.ErrorIs, coreerrors.NotValid)
 }
 
 func (s *importSuite) TestImportCharmMetadataInvalidStorage(c *gc.C) {
@@ -318,7 +318,7 @@ func (s *importSuite) TestImportCharmMetadataInvalidStorage(c *gc.C) {
 	}
 
 	_, err := importOp.importCharmMetadata(s.charmMetadata)
-	c.Assert(err, jc.ErrorIs, errors.NotValid)
+	c.Assert(err, jc.ErrorIs, coreerrors.NotValid)
 }
 
 func (s *importSuite) TestImportCharmMetadataInvalidResource(c *gc.C) {
@@ -370,7 +370,7 @@ func (s *importSuite) TestImportCharmMetadataInvalidResource(c *gc.C) {
 	}
 
 	_, err := importOp.importCharmMetadata(s.charmMetadata)
-	c.Assert(err, jc.ErrorIs, errors.NotValid)
+	c.Assert(err, jc.ErrorIs, coreerrors.NotValid)
 }
 
 func (s *importSuite) TestImportCharmMetadata(c *gc.C) {
@@ -592,7 +592,7 @@ func (s *importSuite) TestImportCharmManifestWithInvalidBase(c *gc.C) {
 	}
 
 	_, err := importOp.importCharmManifest(s.charmManifest)
-	c.Assert(err, jc.ErrorIs, errors.NotValid)
+	c.Assert(err, jc.ErrorIs, coreerrors.NotValid)
 }
 
 func (s *importSuite) TestImportEmptyCharmLXDProfile(c *gc.C) {

--- a/domain/application/resource/resourcestore_test.go
+++ b/domain/application/resource/resourcestore_test.go
@@ -6,13 +6,13 @@ package resource
 import (
 	"context"
 
-	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
 	applicationerrors "github.com/juju/juju/domain/application/errors"
 	charmresource "github.com/juju/juju/internal/charm/resource"
+	"github.com/juju/juju/internal/errors"
 )
 
 type resourceStoreSuite struct {

--- a/domain/application/service/actions.go
+++ b/domain/application/service/actions.go
@@ -5,10 +5,10 @@ package service
 
 import (
 	"encoding/json"
-	"fmt"
 
 	"github.com/juju/juju/domain/application/charm"
 	internalcharm "github.com/juju/juju/internal/charm"
+	"github.com/juju/juju/internal/errors"
 )
 
 func decodeActions(actions charm.Actions) (internalcharm.Actions, error) {
@@ -20,7 +20,7 @@ func decodeActions(actions charm.Actions) (internalcharm.Actions, error) {
 	for name, action := range actions.Actions {
 		params, err := decodeActionParams(action.Params)
 		if err != nil {
-			return internalcharm.Actions{}, fmt.Errorf("decode action params: %w", err)
+			return internalcharm.Actions{}, errors.Errorf("decode action params: %w", err)
 		}
 
 		result[name] = internalcharm.ActionSpec{
@@ -42,7 +42,7 @@ func decodeActionParams(params []byte) (map[string]any, error) {
 
 	var result map[string]any
 	if err := json.Unmarshal(params, &result); err != nil {
-		return nil, fmt.Errorf("unmarshal: %w", err)
+		return nil, errors.Errorf("unmarshal: %w", err)
 	}
 	return result, nil
 }
@@ -56,7 +56,7 @@ func encodeActions(actions *internalcharm.Actions) (charm.Actions, error) {
 	for name, action := range actions.ActionSpecs {
 		params, err := encodeActionParams(action.Params)
 		if err != nil {
-			return charm.Actions{}, fmt.Errorf("encode action params: %w", err)
+			return charm.Actions{}, errors.Errorf("encode action params: %w", err)
 		}
 
 		result[name] = charm.Action{
@@ -78,7 +78,7 @@ func encodeActionParams(params map[string]any) ([]byte, error) {
 
 	result, err := json.Marshal(params)
 	if err != nil {
-		return nil, fmt.Errorf("marshal: %w", err)
+		return nil, errors.Errorf("marshal: %w", err)
 	}
 
 	return result, nil

--- a/domain/application/service/application.go
+++ b/domain/application/service/application.go
@@ -441,7 +441,10 @@ func (s *Service) AddUnits(ctx context.Context, name string, units ...AddUnitArg
 		}
 		return s.st.AddUnits(ctx, appID, args...)
 	})
-	return errors.Errorf("adding units to application %q %w", name, err)
+	if err != nil {
+		return errors.Errorf("adding units to application %q %w", name, err)
+	}
+	return nil
 }
 
 // GetApplicationIDByUnitName returns the application ID for the named unit,
@@ -727,7 +730,10 @@ func (s *Service) RegisterCAASUnit(ctx context.Context, appName string, args Reg
 			HashAlgorithm: application.HashAlgorithmSHA256,
 		})
 	})
-	return errors.Errorf("saving caas unit %q %w", args.UnitName, err)
+	if err != nil {
+		return errors.Errorf("saving caas unit %q %w", args.UnitName, err)
+	}
+	return nil
 }
 
 func (s *Service) insertCAASUnit(
@@ -833,7 +839,11 @@ func (s *Service) UpdateCAASUnit(ctx context.Context, unitName coreunit.Name, pa
 		}
 		return nil
 	})
-	return errors.Errorf("updating caas unit %q %w", unitName, err)
+
+	if err != nil {
+		return errors.Errorf("updating caas unit %q %w", unitName, err)
+	}
+	return nil
 }
 
 // SetUnitPassword updates the password for the specified unit, returning an error

--- a/domain/application/service/application_test.go
+++ b/domain/application/service/application_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/juju/clock/testclock"
-	jujuerrors "github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/version/v2"
@@ -22,6 +21,7 @@ import (
 	"github.com/juju/juju/core/changestream"
 	corecharm "github.com/juju/juju/core/charm"
 	charmtesting "github.com/juju/juju/core/charm/testing"
+	coreerrors "github.com/juju/juju/core/errors"
 	modeltesting "github.com/juju/juju/core/model/testing"
 	corestorage "github.com/juju/juju/core/storage"
 	coreunit "github.com/juju/juju/core/unit"
@@ -1216,7 +1216,7 @@ func (s *applicationWatcherServiceSuite) TestWatchApplicationsWithPendingCharmMa
 	}}
 
 	_, err := s.service.watchApplicationsWithPendingCharmsMapper(context.Background(), changes)
-	c.Assert(err, jc.ErrorIs, jujuerrors.NotValid)
+	c.Assert(err, jc.ErrorIs, coreerrors.NotValid)
 }
 
 func (s *applicationWatcherServiceSuite) TestWatchApplicationsWithPendingCharmMapperOrder(c *gc.C) {
@@ -1420,7 +1420,7 @@ func (s *providerServiceSuite) TestGetSupportedFeatures(c *gc.C) {
 
 func (s *providerServiceSuite) TestGetSupportedFeaturesNotSupported(c *gc.C) {
 	ctrl := s.setupMocksWithProvider(c, func(ctx context.Context) (Provider, error) {
-		return s.provider, jujuerrors.NotSupported
+		return s.provider, coreerrors.NotSupported
 	})
 	defer ctrl.Finish()
 

--- a/domain/application/service/charm.go
+++ b/domain/application/service/charm.go
@@ -5,11 +5,8 @@ package service
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"regexp"
-
-	"github.com/juju/errors"
 
 	"github.com/juju/juju/core/changestream"
 	corecharm "github.com/juju/juju/core/charm"
@@ -18,7 +15,7 @@ import (
 	"github.com/juju/juju/domain/application/charm"
 	applicationerrors "github.com/juju/juju/domain/application/errors"
 	internalcharm "github.com/juju/juju/internal/charm"
-	internalerrors "github.com/juju/juju/internal/errors"
+	"github.com/juju/juju/internal/errors"
 )
 
 var (
@@ -178,11 +175,11 @@ func (s *Service) GetCharmID(ctx context.Context, args charm.GetCharmArgs) (core
 // charm does not exist, a [applicationerrors.CharmNotFound] error is returned.
 func (s *Service) IsControllerCharm(ctx context.Context, id corecharm.ID) (bool, error) {
 	if err := id.Validate(); err != nil {
-		return false, fmt.Errorf("charm id: %w", err)
+		return false, errors.Errorf("charm id: %w", err)
 	}
 	b, err := s.st.IsControllerCharm(ctx, id)
 	if err != nil {
-		return false, errors.Trace(err)
+		return false, errors.Capture(err)
 	}
 	return b, nil
 }
@@ -195,11 +192,11 @@ func (s *Service) IsControllerCharm(ctx context.Context, id corecharm.ID) (bool,
 // returned.
 func (s *Service) SupportsContainers(ctx context.Context, id corecharm.ID) (bool, error) {
 	if err := id.Validate(); err != nil {
-		return false, fmt.Errorf("charm id: %w", err)
+		return false, errors.Errorf("charm id: %w", err)
 	}
 	b, err := s.st.SupportsContainers(ctx, id)
 	if err != nil {
-		return false, errors.Trace(err)
+		return false, errors.Capture(err)
 	}
 	return b, nil
 }
@@ -212,11 +209,11 @@ func (s *Service) SupportsContainers(ctx context.Context, id corecharm.ID) (bool
 // returned.
 func (s *Service) IsSubordinateCharm(ctx context.Context, id corecharm.ID) (bool, error) {
 	if err := id.Validate(); err != nil {
-		return false, fmt.Errorf("charm id: %w", err)
+		return false, errors.Errorf("charm id: %w", err)
 	}
 	b, err := s.st.IsSubordinateCharm(ctx, id)
 	if err != nil {
-		return false, errors.Trace(err)
+		return false, errors.Capture(err)
 	}
 	return b, nil
 }
@@ -232,39 +229,39 @@ func (s *Service) IsSubordinateCharm(ctx context.Context, id corecharm.ID) (bool
 // returned.
 func (s *Service) GetCharm(ctx context.Context, id corecharm.ID) (internalcharm.Charm, charm.CharmLocator, error) {
 	if err := id.Validate(); err != nil {
-		return nil, charm.CharmLocator{}, fmt.Errorf("charm id: %w", err)
+		return nil, charm.CharmLocator{}, errors.Errorf("charm id: %w", err)
 	}
 
 	ch, _, err := s.st.GetCharm(ctx, id)
 	if err != nil {
-		return nil, charm.CharmLocator{}, errors.Trace(err)
+		return nil, charm.CharmLocator{}, errors.Capture(err)
 	}
 
 	// The charm needs to be decoded into the internalcharm.Charm type.
 
 	metadata, err := decodeMetadata(ch.Metadata)
 	if err != nil {
-		return nil, charm.CharmLocator{}, errors.Trace(err)
+		return nil, charm.CharmLocator{}, errors.Capture(err)
 	}
 
 	manifest, err := decodeManifest(ch.Manifest)
 	if err != nil {
-		return nil, charm.CharmLocator{}, errors.Trace(err)
+		return nil, charm.CharmLocator{}, errors.Capture(err)
 	}
 
 	actions, err := decodeActions(ch.Actions)
 	if err != nil {
-		return nil, charm.CharmLocator{}, errors.Trace(err)
+		return nil, charm.CharmLocator{}, errors.Capture(err)
 	}
 
 	config, err := decodeConfig(ch.Config)
 	if err != nil {
-		return nil, charm.CharmLocator{}, errors.Trace(err)
+		return nil, charm.CharmLocator{}, errors.Capture(err)
 	}
 
 	lxdProfile, err := decodeLXDProfile(ch.LXDProfile)
 	if err != nil {
-		return nil, charm.CharmLocator{}, errors.Trace(err)
+		return nil, charm.CharmLocator{}, errors.Capture(err)
 	}
 
 	locator := charm.CharmLocator{
@@ -289,17 +286,17 @@ func (s *Service) GetCharm(ctx context.Context, id corecharm.ID) (internalcharm.
 // returned.
 func (s *Service) GetCharmMetadata(ctx context.Context, id corecharm.ID) (internalcharm.Meta, error) {
 	if err := id.Validate(); err != nil {
-		return internalcharm.Meta{}, fmt.Errorf("charm id: %w", err)
+		return internalcharm.Meta{}, errors.Errorf("charm id: %w", err)
 	}
 
 	metadata, err := s.st.GetCharmMetadata(ctx, id)
 	if err != nil {
-		return internalcharm.Meta{}, errors.Trace(err)
+		return internalcharm.Meta{}, errors.Capture(err)
 	}
 
 	decoded, err := decodeMetadata(metadata)
 	if err != nil {
-		return internalcharm.Meta{}, errors.Trace(err)
+		return internalcharm.Meta{}, errors.Capture(err)
 	}
 	return decoded, nil
 }
@@ -311,12 +308,12 @@ func (s *Service) GetCharmMetadata(ctx context.Context, id corecharm.ID) (intern
 // returned.
 func (s *Service) GetCharmMetadataName(ctx context.Context, id corecharm.ID) (string, error) {
 	if err := id.Validate(); err != nil {
-		return "", fmt.Errorf("charm id: %w", err)
+		return "", errors.Errorf("charm id: %w", err)
 	}
 
 	name, err := s.st.GetCharmMetadataName(ctx, id)
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", errors.Capture(err)
 	}
 	return name, nil
 }
@@ -328,12 +325,12 @@ func (s *Service) GetCharmMetadataName(ctx context.Context, id corecharm.ID) (st
 // returned.
 func (s *Service) GetCharmMetadataDescription(ctx context.Context, id corecharm.ID) (string, error) {
 	if err := id.Validate(); err != nil {
-		return "", fmt.Errorf("charm id: %w", err)
+		return "", errors.Errorf("charm id: %w", err)
 	}
 
 	description, err := s.st.GetCharmMetadataDescription(ctx, id)
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", errors.Capture(err)
 	}
 	return description, nil
 }
@@ -344,17 +341,17 @@ func (s *Service) GetCharmMetadataDescription(ctx context.Context, id corecharm.
 // returned.
 func (s *Service) GetCharmManifest(ctx context.Context, id corecharm.ID) (internalcharm.Manifest, error) {
 	if err := id.Validate(); err != nil {
-		return internalcharm.Manifest{}, fmt.Errorf("charm id: %w", err)
+		return internalcharm.Manifest{}, errors.Errorf("charm id: %w", err)
 	}
 
 	manifest, err := s.st.GetCharmManifest(ctx, id)
 	if err != nil {
-		return internalcharm.Manifest{}, errors.Trace(err)
+		return internalcharm.Manifest{}, errors.Capture(err)
 	}
 
 	decoded, err := decodeManifest(manifest)
 	if err != nil {
-		return internalcharm.Manifest{}, errors.Trace(err)
+		return internalcharm.Manifest{}, errors.Capture(err)
 	}
 	return decoded, nil
 }
@@ -365,17 +362,17 @@ func (s *Service) GetCharmManifest(ctx context.Context, id corecharm.ID) (intern
 // returned.
 func (s *Service) GetCharmActions(ctx context.Context, id corecharm.ID) (internalcharm.Actions, error) {
 	if err := id.Validate(); err != nil {
-		return internalcharm.Actions{}, fmt.Errorf("charm id: %w", err)
+		return internalcharm.Actions{}, errors.Errorf("charm id: %w", err)
 	}
 
 	actions, err := s.st.GetCharmActions(ctx, id)
 	if err != nil {
-		return internalcharm.Actions{}, errors.Trace(err)
+		return internalcharm.Actions{}, errors.Capture(err)
 	}
 
 	decoded, err := decodeActions(actions)
 	if err != nil {
-		return internalcharm.Actions{}, errors.Trace(err)
+		return internalcharm.Actions{}, errors.Capture(err)
 	}
 	return decoded, nil
 }
@@ -386,17 +383,17 @@ func (s *Service) GetCharmActions(ctx context.Context, id corecharm.ID) (interna
 // returned.
 func (s *Service) GetCharmConfig(ctx context.Context, id corecharm.ID) (internalcharm.Config, error) {
 	if err := id.Validate(); err != nil {
-		return internalcharm.Config{}, fmt.Errorf("charm id: %w", err)
+		return internalcharm.Config{}, errors.Errorf("charm id: %w", err)
 	}
 
 	config, err := s.st.GetCharmConfig(ctx, id)
 	if err != nil {
-		return internalcharm.Config{}, errors.Trace(err)
+		return internalcharm.Config{}, errors.Capture(err)
 	}
 
 	decoded, err := decodeConfig(config)
 	if err != nil {
-		return internalcharm.Config{}, errors.Trace(err)
+		return internalcharm.Config{}, errors.Capture(err)
 	}
 	return decoded, nil
 }
@@ -408,17 +405,17 @@ func (s *Service) GetCharmConfig(ctx context.Context, id corecharm.ID) (internal
 // returned.
 func (s *Service) GetCharmLXDProfile(ctx context.Context, id corecharm.ID) (internalcharm.LXDProfile, charm.Revision, error) {
 	if err := id.Validate(); err != nil {
-		return internalcharm.LXDProfile{}, -1, fmt.Errorf("charm id: %w", err)
+		return internalcharm.LXDProfile{}, -1, errors.Errorf("charm id: %w", err)
 	}
 
 	profile, revision, err := s.st.GetCharmLXDProfile(ctx, id)
 	if err != nil {
-		return internalcharm.LXDProfile{}, -1, errors.Trace(err)
+		return internalcharm.LXDProfile{}, -1, errors.Capture(err)
 	}
 
 	decoded, err := decodeLXDProfile(profile)
 	if err != nil {
-		return internalcharm.LXDProfile{}, -1, errors.Trace(err)
+		return internalcharm.LXDProfile{}, -1, errors.Capture(err)
 	}
 	return decoded, revision, nil
 }
@@ -430,12 +427,12 @@ func (s *Service) GetCharmLXDProfile(ctx context.Context, id corecharm.ID) (inte
 // returned.
 func (s *Service) GetCharmArchivePath(ctx context.Context, id corecharm.ID) (string, error) {
 	if err := id.Validate(); err != nil {
-		return "", internalerrors.Errorf("charm id: %w", err)
+		return "", errors.Errorf("charm id: %w", err)
 	}
 
 	path, err := s.st.GetCharmArchivePath(ctx, id)
 	if err != nil {
-		return "", internalerrors.Errorf("getting charm archive path: %w", err)
+		return "", errors.Errorf("getting charm archive path: %w", err)
 	}
 	return path, nil
 }
@@ -448,17 +445,17 @@ func (s *Service) GetCharmArchivePath(ctx context.Context, id corecharm.ID) (str
 // returned.
 func (s *Service) GetCharmArchive(ctx context.Context, id corecharm.ID) (io.ReadCloser, string, error) {
 	if err := id.Validate(); err != nil {
-		return nil, "", internalerrors.Errorf("charm id: %w", err)
+		return nil, "", errors.Errorf("charm id: %w", err)
 	}
 
 	archivePath, hash, err := s.st.GetCharmArchiveMetadata(ctx, id)
 	if err != nil {
-		return nil, "", internalerrors.Errorf("getting charm archive metadata: %w", err)
+		return nil, "", errors.Errorf("getting charm archive metadata: %w", err)
 	}
 
 	reader, err := s.charmStore.Get(ctx, archivePath)
 	if err != nil {
-		return nil, "", internalerrors.Errorf("getting charm archive: %w", err)
+		return nil, "", errors.Errorf("getting charm archive: %w", err)
 	}
 
 	return reader, hash, nil
@@ -472,11 +469,11 @@ func (s *Service) GetCharmArchive(ctx context.Context, id corecharm.ID) (io.Read
 // returned.
 func (s *Service) IsCharmAvailable(ctx context.Context, id corecharm.ID) (bool, error) {
 	if err := id.Validate(); err != nil {
-		return false, fmt.Errorf("charm id: %w", err)
+		return false, errors.Errorf("charm id: %w", err)
 	}
 	b, err := s.st.IsCharmAvailable(ctx, id)
 	if err != nil {
-		return false, errors.Trace(err)
+		return false, errors.Capture(err)
 	}
 	return b, nil
 }
@@ -487,10 +484,10 @@ func (s *Service) IsCharmAvailable(ctx context.Context, id corecharm.ID) (bool, 
 // returned.
 func (s *Service) SetCharmAvailable(ctx context.Context, id corecharm.ID) error {
 	if err := id.Validate(); err != nil {
-		return fmt.Errorf("charm id: %w", err)
+		return errors.Errorf("charm id: %w", err)
 	}
 
-	return errors.Trace(s.st.SetCharmAvailable(ctx, id))
+	return errors.Capture(s.st.SetCharmAvailable(ctx, id))
 }
 
 // SetCharm persists the charm metadata, actions, config and manifest to
@@ -514,7 +511,7 @@ func (s *Service) SetCharm(ctx context.Context, args charm.SetCharmArgs) (corech
 
 	// If the reference name is provided, it must be valid.
 	if !isValidReferenceName(args.ReferenceName) {
-		return "", nil, fmt.Errorf("reference name: %w", applicationerrors.CharmNameNotValid)
+		return "", nil, errors.Errorf("reference name: %w", applicationerrors.CharmNameNotValid)
 	}
 
 	// If the origin is from charmhub, then we require the download info.
@@ -523,19 +520,19 @@ func (s *Service) SetCharm(ctx context.Context, args charm.SetCharmArgs) (corech
 			return "", nil, applicationerrors.CharmDownloadInfoNotFound
 		}
 		if err := args.DownloadInfo.Validate(); err != nil {
-			return "", nil, fmt.Errorf("download info: %w", err)
+			return "", nil, errors.Errorf("download info: %w", err)
 		}
 	}
 
 	source, err := encodeCharmSource(args.Source)
 	if err != nil {
-		return "", nil, fmt.Errorf("encoding charm source: %w", err)
+		return "", nil, errors.Errorf("encoding charm source: %w", err)
 	}
 
 	architecture := encodeArchitecture(args.Architecture)
 	ch, warnings, err := encodeCharm(args.Charm)
 	if err != nil {
-		return "", warnings, fmt.Errorf("encoding charm: %w", err)
+		return "", warnings, errors.Errorf("encoding charm: %w", err)
 	}
 
 	ch.Source = source
@@ -548,7 +545,7 @@ func (s *Service) SetCharm(ctx context.Context, args charm.SetCharmArgs) (corech
 
 	charmID, err := s.st.SetCharm(ctx, ch, args.DownloadInfo)
 	if err != nil {
-		return "", warnings, errors.Trace(err)
+		return "", warnings, errors.Capture(err)
 	}
 
 	return charmID, warnings, nil
@@ -558,7 +555,7 @@ func (s *Service) SetCharm(ctx context.Context, args charm.SetCharmArgs) (corech
 // Returns an error if the charm does not exist.
 func (s *Service) DeleteCharm(ctx context.Context, id corecharm.ID) error {
 	if err := id.Validate(); err != nil {
-		return fmt.Errorf("charm id: %w", err)
+		return errors.Errorf("charm id: %w", err)
 	}
 	return s.st.DeleteCharm(ctx, id)
 }
@@ -578,7 +575,7 @@ func (s *Service) ListCharmLocators(ctx context.Context, names ...string) ([]cha
 // charm ID.
 func (s *Service) GetCharmDownloadInfo(ctx context.Context, id corecharm.ID) (*charm.DownloadInfo, error) {
 	if err := id.Validate(); err != nil {
-		return nil, fmt.Errorf("charm id: %w", err)
+		return nil, errors.Errorf("charm id: %w", err)
 	}
 	return s.st.GetCharmDownloadInfo(ctx, id)
 }
@@ -600,29 +597,29 @@ func encodeCharm(ch internalcharm.Charm) (charm.Charm, []string, error) {
 
 	metadata, err := encodeMetadata(ch.Meta())
 	if err != nil {
-		return charm.Charm{}, nil, fmt.Errorf("encoding metadata: %w", err)
+		return charm.Charm{}, nil, errors.Errorf("encoding metadata: %w", err)
 	}
 
 	manifest, warnings, err := encodeManifest(ch.Manifest())
 	if err != nil {
-		return charm.Charm{}, warnings, fmt.Errorf("encoding manifest: %w", err)
+		return charm.Charm{}, warnings, errors.Errorf("encoding manifest: %w", err)
 	}
 
 	actions, err := encodeActions(ch.Actions())
 	if err != nil {
-		return charm.Charm{}, warnings, fmt.Errorf("encoding actions: %w", err)
+		return charm.Charm{}, warnings, errors.Errorf("encoding actions: %w", err)
 	}
 
 	config, err := encodeConfig(ch.Config())
 	if err != nil {
-		return charm.Charm{}, warnings, fmt.Errorf("encoding config: %w", err)
+		return charm.Charm{}, warnings, errors.Errorf("encoding config: %w", err)
 	}
 
 	var profile []byte
 	if lxdProfile, ok := ch.(internalcharm.LXDProfiler); ok && lxdProfile != nil {
 		profile, err = encodeLXDProfile(lxdProfile.LXDProfile())
 		if err != nil {
-			return charm.Charm{}, warnings, fmt.Errorf("encoding lxd profile: %w", err)
+			return charm.Charm{}, warnings, errors.Errorf("encoding lxd profile: %w", err)
 		}
 	}
 

--- a/domain/application/service/charm_test.go
+++ b/domain/application/service/charm_test.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"strings"
 
-	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v4/workertest"
 	"go.uber.org/mock/gomock"
@@ -18,6 +17,7 @@ import (
 	"github.com/juju/juju/core/changestream"
 	corecharm "github.com/juju/juju/core/charm"
 	charmtesting "github.com/juju/juju/core/charm/testing"
+	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/domain/application/architecture"
 	"github.com/juju/juju/domain/application/charm"
 	applicationerrors "github.com/juju/juju/domain/application/errors"
@@ -116,7 +116,7 @@ func (s *charmServiceSuite) TestIsControllerCharmInvalidUUID(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	_, err := s.service.IsControllerCharm(context.Background(), "")
-	c.Assert(err, jc.ErrorIs, errors.NotValid)
+	c.Assert(err, jc.ErrorIs, coreerrors.NotValid)
 }
 
 func (s *charmServiceSuite) TestIsCharmAvailable(c *gc.C) {
@@ -146,7 +146,7 @@ func (s *charmServiceSuite) TestIsCharmAvailableInvalidUUID(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	_, err := s.service.IsCharmAvailable(context.Background(), "")
-	c.Assert(err, jc.ErrorIs, errors.NotValid)
+	c.Assert(err, jc.ErrorIs, coreerrors.NotValid)
 }
 
 func (s *charmServiceSuite) TestSupportsContainers(c *gc.C) {
@@ -176,7 +176,7 @@ func (s *charmServiceSuite) TestSupportsContainersInvalidUUID(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	_, err := s.service.SupportsContainers(context.Background(), "")
-	c.Assert(err, jc.ErrorIs, errors.NotValid)
+	c.Assert(err, jc.ErrorIs, coreerrors.NotValid)
 }
 
 func (s *charmServiceSuite) TestGetCharm(c *gc.C) {
@@ -226,7 +226,7 @@ func (s *charmServiceSuite) TestGetCharmInvalidUUID(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	_, _, err := s.service.GetCharm(context.Background(), "")
-	c.Assert(err, jc.ErrorIs, errors.NotValid)
+	c.Assert(err, jc.ErrorIs, coreerrors.NotValid)
 }
 
 func (s *charmServiceSuite) TestGetCharmMetadata(c *gc.C) {
@@ -268,7 +268,7 @@ func (s *charmServiceSuite) TestGetCharmMetadataInvalidUUID(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	_, err := s.service.GetCharmMetadata(context.Background(), "")
-	c.Assert(err, jc.ErrorIs, errors.NotValid)
+	c.Assert(err, jc.ErrorIs, coreerrors.NotValid)
 }
 
 func (s *charmServiceSuite) TestGetCharmLXDProfile(c *gc.C) {
@@ -309,7 +309,7 @@ func (s *charmServiceSuite) TestGetCharmLXDProfileInvalidUUID(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	_, _, err := s.service.GetCharmLXDProfile(context.Background(), "")
-	c.Assert(err, jc.ErrorIs, errors.NotValid)
+	c.Assert(err, jc.ErrorIs, coreerrors.NotValid)
 }
 
 func (s *charmServiceSuite) TestGetCharmMetadataName(c *gc.C) {
@@ -339,7 +339,7 @@ func (s *charmServiceSuite) TestGetCharmMetadataNameInvalidUUID(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	_, err := s.service.GetCharmMetadataName(context.Background(), "")
-	c.Assert(err, jc.ErrorIs, errors.NotValid)
+	c.Assert(err, jc.ErrorIs, coreerrors.NotValid)
 }
 
 func (s *charmServiceSuite) TestGetCharmMetadataDescription(c *gc.C) {
@@ -369,7 +369,7 @@ func (s *charmServiceSuite) TestGetCharmMetadataDescriptionInvalidUUID(c *gc.C) 
 	defer s.setupMocks(c).Finish()
 
 	_, err := s.service.GetCharmMetadataDescription(context.Background(), "")
-	c.Assert(err, jc.ErrorIs, errors.NotValid)
+	c.Assert(err, jc.ErrorIs, coreerrors.NotValid)
 }
 
 func (s *charmServiceSuite) TestGetCharmArchivePath(c *gc.C) {
@@ -399,7 +399,7 @@ func (s *charmServiceSuite) TestGetCharmArchivePathInvalidUUID(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	_, err := s.service.GetCharmArchivePath(context.Background(), "")
-	c.Assert(err, jc.ErrorIs, errors.NotValid)
+	c.Assert(err, jc.ErrorIs, coreerrors.NotValid)
 }
 
 func (s *charmServiceSuite) TestGetCharmArchive(c *gc.C) {
@@ -446,7 +446,7 @@ func (s *charmServiceSuite) TestSetCharmAvailableInvalidUUID(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	err := s.service.SetCharmAvailable(context.Background(), "")
-	c.Assert(err, jc.ErrorIs, errors.NotValid)
+	c.Assert(err, jc.ErrorIs, coreerrors.NotValid)
 }
 
 func (s *charmServiceSuite) TestSetCharm(c *gc.C) {

--- a/domain/application/service/config.go
+++ b/domain/application/service/config.go
@@ -4,10 +4,9 @@
 package service
 
 import (
-	"fmt"
-
 	"github.com/juju/juju/domain/application/charm"
 	internalcharm "github.com/juju/juju/internal/charm"
+	"github.com/juju/juju/internal/errors"
 )
 
 func decodeConfig(options charm.Config) (internalcharm.Config, error) {
@@ -19,7 +18,7 @@ func decodeConfig(options charm.Config) (internalcharm.Config, error) {
 	for name, option := range options.Options {
 		opt, err := decodeConfigOption(option)
 		if err != nil {
-			return internalcharm.Config{}, fmt.Errorf("decode config option: %w", err)
+			return internalcharm.Config{}, errors.Errorf("decode config option: %w", err)
 		}
 
 		result[name] = opt
@@ -32,7 +31,7 @@ func decodeConfig(options charm.Config) (internalcharm.Config, error) {
 func decodeConfigOption(option charm.Option) (internalcharm.Option, error) {
 	t, err := decodeOptionType(option.Type)
 	if err != nil {
-		return internalcharm.Option{}, fmt.Errorf("decode option type: %w", err)
+		return internalcharm.Option{}, errors.Errorf("decode option type: %w", err)
 	}
 
 	return internalcharm.Option{
@@ -55,7 +54,7 @@ func decodeOptionType(t charm.OptionType) (string, error) {
 	case charm.OptionSecret:
 		return "secret", nil
 	default:
-		return "", fmt.Errorf("unknown option type %q", t)
+		return "", errors.Errorf("unknown option type %q", t)
 	}
 }
 
@@ -68,7 +67,7 @@ func encodeConfig(config *internalcharm.Config) (charm.Config, error) {
 	for name, option := range config.Options {
 		opt, err := encodeConfigOption(option)
 		if err != nil {
-			return charm.Config{}, fmt.Errorf("encode config option: %w", err)
+			return charm.Config{}, errors.Errorf("encode config option: %w", err)
 		}
 
 		result[name] = opt
@@ -81,7 +80,7 @@ func encodeConfig(config *internalcharm.Config) (charm.Config, error) {
 func encodeConfigOption(option internalcharm.Option) (charm.Option, error) {
 	t, err := encodeOptionType(option.Type)
 	if err != nil {
-		return charm.Option{}, fmt.Errorf("encode option type: %w", err)
+		return charm.Option{}, errors.Errorf("encode option type: %w", err)
 	}
 
 	return charm.Option{
@@ -104,6 +103,6 @@ func encodeOptionType(t string) (charm.OptionType, error) {
 	case "secret":
 		return charm.OptionSecret, nil
 	default:
-		return "", fmt.Errorf("unknown option type %q", t)
+		return "", errors.Errorf("unknown option type %q", t)
 	}
 }

--- a/domain/application/service/lxdprofile.go
+++ b/domain/application/service/lxdprofile.go
@@ -5,9 +5,9 @@ package service
 
 import (
 	"encoding/json"
-	"fmt"
 
 	internalcharm "github.com/juju/juju/internal/charm"
+	"github.com/juju/juju/internal/errors"
 )
 
 func decodeLXDProfile(profile []byte) (internalcharm.LXDProfile, error) {
@@ -17,7 +17,7 @@ func decodeLXDProfile(profile []byte) (internalcharm.LXDProfile, error) {
 
 	var result lxdProfile
 	if err := json.Unmarshal(profile, &result); err != nil {
-		return internalcharm.LXDProfile{}, fmt.Errorf("unmarshal lxd profile: %w", err)
+		return internalcharm.LXDProfile{}, errors.Errorf("unmarshal lxd profile: %w", err)
 	}
 
 	return internalcharm.LXDProfile{
@@ -38,7 +38,7 @@ func encodeLXDProfile(profile *internalcharm.LXDProfile) ([]byte, error) {
 		Devices:     profile.Devices,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("marshal lxd profile: %w", err)
+		return nil, errors.Errorf("marshal lxd profile: %w", err)
 	}
 
 	return result, nil

--- a/domain/application/service/manifest.go
+++ b/domain/application/service/manifest.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/domain/application/charm"
 	applicationerrors "github.com/juju/juju/domain/application/errors"
 	internalcharm "github.com/juju/juju/internal/charm"
+	"github.com/juju/juju/internal/errors"
 )
 
 // Conversion code is used to decode charm.Manifest code to non-domain
@@ -24,7 +25,7 @@ import (
 func decodeManifest(manifest charm.Manifest) (internalcharm.Manifest, error) {
 	bases, err := decodeManifestBases(manifest.Bases)
 	if err != nil {
-		return internalcharm.Manifest{}, fmt.Errorf("decode bases: %w", err)
+		return internalcharm.Manifest{}, errors.Errorf("decode bases: %w", err)
 	}
 
 	return internalcharm.Manifest{
@@ -37,7 +38,7 @@ func decodeManifestBases(bases []charm.Base) ([]internalcharm.Base, error) {
 	for _, base := range bases {
 		decodedBase, err := decodeManifestBase(base)
 		if err != nil {
-			return nil, fmt.Errorf("decode base: %w", err)
+			return nil, errors.Errorf("decode base: %w", err)
 		}
 		decoded = append(decoded, decodedBase)
 	}
@@ -47,7 +48,7 @@ func decodeManifestBases(bases []charm.Base) ([]internalcharm.Base, error) {
 func decodeManifestBase(base charm.Base) (internalcharm.Base, error) {
 	channel, err := decodeManifestChannel(base.Channel)
 	if err != nil {
-		return internalcharm.Base{}, fmt.Errorf("decode channel: %w", err)
+		return internalcharm.Base{}, errors.Errorf("decode channel: %w", err)
 	}
 
 	return internalcharm.Base{
@@ -60,7 +61,7 @@ func decodeManifestBase(base charm.Base) (internalcharm.Base, error) {
 func decodeManifestChannel(channel charm.Channel) (internalcharm.Channel, error) {
 	risk, err := decodeManifestRisk(channel.Risk)
 	if err != nil {
-		return internalcharm.Channel{}, fmt.Errorf("decode risk: %w", err)
+		return internalcharm.Channel{}, errors.Errorf("decode risk: %w", err)
 	}
 
 	return internalcharm.Channel{
@@ -81,7 +82,7 @@ func decodeManifestRisk(risk charm.ChannelRisk) (internalcharm.Risk, error) {
 	case charm.RiskEdge:
 		return internalcharm.Edge, nil
 	default:
-		return "", fmt.Errorf("unknown risk: %q", risk)
+		return "", errors.Errorf("unknown risk: %q", risk)
 	}
 }
 
@@ -92,7 +93,7 @@ func encodeManifest(manifest *internalcharm.Manifest) (charm.Manifest, []string,
 
 	bases, warnings, err := encodeManifestBases(manifest.Bases)
 	if err != nil {
-		return charm.Manifest{}, warnings, fmt.Errorf("encode bases: %w", err)
+		return charm.Manifest{}, warnings, errors.Errorf("encode bases: %w", err)
 	}
 
 	return charm.Manifest{
@@ -106,7 +107,7 @@ func encodeManifestBases(bases []internalcharm.Base) ([]charm.Base, []string, er
 	for _, base := range bases {
 		encodedBase, unsupported, err := encodeManifestBase(base)
 		if err != nil {
-			return nil, unsupportedArches, fmt.Errorf("encode base: %w", err)
+			return nil, unsupportedArches, errors.Errorf("encode base: %w", err)
 		}
 		encoded = append(encoded, encodedBase)
 		unsupportedArches = append(unsupportedArches, unsupported...)
@@ -121,14 +122,14 @@ func encodeManifestBase(base internalcharm.Base) (charm.Base, []string, error) {
 	// Juju only supports Ubuntu bases.
 	baseType, err := ostype.ParseOSType(base.Name)
 	if err != nil {
-		return charm.Base{}, nil, fmt.Errorf("parse base name: %w", err)
+		return charm.Base{}, nil, errors.Errorf("parse base name: %w", err)
 	} else if baseType != ostype.Ubuntu {
 		return charm.Base{}, nil, applicationerrors.CharmBaseNameNotSupported
 	}
 
 	channel, err := encodeManifestChannel(base.Channel)
 	if err != nil {
-		return charm.Base{}, nil, fmt.Errorf("encode channel: %w", err)
+		return charm.Base{}, nil, errors.Errorf("encode channel: %w", err)
 	}
 
 	arches := set.NewStrings()
@@ -169,7 +170,7 @@ func encodeManifestBase(base internalcharm.Base) (charm.Base, []string, error) {
 func encodeManifestChannel(channel internalcharm.Channel) (charm.Channel, error) {
 	risk, err := encodeManifestRisk(channel.Risk)
 	if err != nil {
-		return charm.Channel{}, fmt.Errorf("encode risk: %w", err)
+		return charm.Channel{}, errors.Errorf("encode risk: %w", err)
 	}
 
 	return charm.Channel{
@@ -190,6 +191,6 @@ func encodeManifestRisk(risk internalcharm.Risk) (charm.ChannelRisk, error) {
 	case internalcharm.Edge:
 		return charm.RiskEdge, nil
 	default:
-		return "", fmt.Errorf("unknown risk: %q", risk)
+		return "", errors.Errorf("unknown risk: %q", risk)
 	}
 }

--- a/domain/application/service/metadata.go
+++ b/domain/application/service/metadata.go
@@ -5,7 +5,6 @@ package service
 
 import (
 	"encoding/json"
-	"fmt"
 	"strings"
 
 	"github.com/juju/collections/set"
@@ -26,52 +25,52 @@ import (
 func decodeMetadata(metadata charm.Metadata) (internalcharm.Meta, error) {
 	provides, err := decodeMetadataRelation(metadata.Provides)
 	if err != nil {
-		return internalcharm.Meta{}, fmt.Errorf("decode provides relation: %w", err)
+		return internalcharm.Meta{}, errors.Errorf("decode provides relation: %w", err)
 	}
 
 	requires, err := decodeMetadataRelation(metadata.Requires)
 	if err != nil {
-		return internalcharm.Meta{}, fmt.Errorf("decode requires relation: %w", err)
+		return internalcharm.Meta{}, errors.Errorf("decode requires relation: %w", err)
 	}
 
 	peers, err := decodeMetadataRelation(metadata.Peers)
 	if err != nil {
-		return internalcharm.Meta{}, fmt.Errorf("decode peers relation: %w", err)
+		return internalcharm.Meta{}, errors.Errorf("decode peers relation: %w", err)
 	}
 
 	storage, err := decodeMetadataStorage(metadata.Storage)
 	if err != nil {
-		return internalcharm.Meta{}, fmt.Errorf("decode storage: %w", err)
+		return internalcharm.Meta{}, errors.Errorf("decode storage: %w", err)
 	}
 
 	devices, err := decodeMetadataDevices(metadata.Devices)
 	if err != nil {
-		return internalcharm.Meta{}, fmt.Errorf("decode devices: %w", err)
+		return internalcharm.Meta{}, errors.Errorf("decode devices: %w", err)
 	}
 
 	payloadClasses, err := decodeMetadataPayloadClasses(metadata.PayloadClasses)
 	if err != nil {
-		return internalcharm.Meta{}, fmt.Errorf("decode payload classes: %w", err)
+		return internalcharm.Meta{}, errors.Errorf("decode payload classes: %w", err)
 	}
 
 	resources, err := decodeMetadataResources(metadata.Resources)
 	if err != nil {
-		return internalcharm.Meta{}, fmt.Errorf("decode resources: %w", err)
+		return internalcharm.Meta{}, errors.Errorf("decode resources: %w", err)
 	}
 
 	containers, err := decodeMetadataContainers(metadata.Containers)
 	if err != nil {
-		return internalcharm.Meta{}, fmt.Errorf("decode containers: %w", err)
+		return internalcharm.Meta{}, errors.Errorf("decode containers: %w", err)
 	}
 
 	assumes, err := decodeMetadataAssumes(metadata.Assumes)
 	if err != nil {
-		return internalcharm.Meta{}, fmt.Errorf("parse assumes: %w", err)
+		return internalcharm.Meta{}, errors.Errorf("parse assumes: %w", err)
 	}
 
 	charmUser, err := decodeMetadataRunAs(metadata.RunAs)
 	if err != nil {
-		return internalcharm.Meta{}, fmt.Errorf("decode charm user: %w", err)
+		return internalcharm.Meta{}, errors.Errorf("decode charm user: %w", err)
 	}
 
 	return internalcharm.Meta{
@@ -106,12 +105,12 @@ func decodeMetadataRelation(relations map[string]charm.Relation) (map[string]int
 	for k, v := range relations {
 		role, err := decodeMetadataRole(v.Role)
 		if err != nil {
-			return nil, fmt.Errorf("decode role: %w", err)
+			return nil, errors.Errorf("decode role: %w", err)
 		}
 
 		scope, err := decodeMetadataScope(v.Scope)
 		if err != nil {
-			return nil, fmt.Errorf("decode scope: %w", err)
+			return nil, errors.Errorf("decode scope: %w", err)
 		}
 
 		result[k] = internalcharm.Relation{
@@ -173,7 +172,7 @@ func decodeMetadataStorage(storage map[string]charm.Storage) (map[string]interna
 	for k, v := range storage {
 		storeType, err := decodeMetadataStorageType(v.Type)
 		if err != nil {
-			return nil, fmt.Errorf("decode storage type: %w", err)
+			return nil, errors.Errorf("decode storage type: %w", err)
 		}
 
 		result[k] = internalcharm.Storage{
@@ -245,7 +244,7 @@ func decodeMetadataResources(resources map[string]charm.Resource) (map[string]re
 	for k, v := range resources {
 		resourceType, err := decodeMetadataResourceType(v.Type)
 		if err != nil {
-			return nil, fmt.Errorf("decode resource type: %w", err)
+			return nil, errors.Errorf("decode resource type: %w", err)
 		}
 
 		result[k] = resource.Meta{
@@ -280,7 +279,7 @@ func decodeMetadataContainers(containers map[string]charm.Container) (map[string
 	for k, v := range containers {
 		mounts, err := decodeMetadataMounts(v.Mounts)
 		if err != nil {
-			return nil, fmt.Errorf("decode mounts: %w", err)
+			return nil, errors.Errorf("decode mounts: %w", err)
 		}
 
 		result[k] = internalcharm.Container{
@@ -349,57 +348,57 @@ func encodeMetadata(metadata *internalcharm.Meta) (charm.Metadata, error) {
 
 	provides, err := encodeMetadataRelation(metadata.Provides)
 	if err != nil {
-		return charm.Metadata{}, fmt.Errorf("encode provides relation: %w", err)
+		return charm.Metadata{}, errors.Errorf("encode provides relation: %w", err)
 	}
 
 	requires, err := encodeMetadataRelation(metadata.Requires)
 	if err != nil {
-		return charm.Metadata{}, fmt.Errorf("encode requires relation: %w", err)
+		return charm.Metadata{}, errors.Errorf("encode requires relation: %w", err)
 	}
 
 	peers, err := encodeMetadataRelation(metadata.Peers)
 	if err != nil {
-		return charm.Metadata{}, fmt.Errorf("encode peers relation: %w", err)
+		return charm.Metadata{}, errors.Errorf("encode peers relation: %w", err)
 	}
 
 	err = verifyRelations(metadata, provides, requires, peers)
 	if err != nil {
-		return charm.Metadata{}, fmt.Errorf("verifying charm relations: %w", err)
+		return charm.Metadata{}, errors.Errorf("verifying charm relations: %w", err)
 	}
 
 	storage, err := encodeMetadataStorage(metadata.Storage)
 	if err != nil {
-		return charm.Metadata{}, fmt.Errorf("encode storage: %w", err)
+		return charm.Metadata{}, errors.Errorf("encode storage: %w", err)
 	}
 
 	devices, err := encodeMetadataDevices(metadata.Devices)
 	if err != nil {
-		return charm.Metadata{}, fmt.Errorf("encode devices: %w", err)
+		return charm.Metadata{}, errors.Errorf("encode devices: %w", err)
 	}
 
 	payloadClasses, err := encodeMetadataPayloadClasses(metadata.PayloadClasses)
 	if err != nil {
-		return charm.Metadata{}, fmt.Errorf("encode payload classes: %w", err)
+		return charm.Metadata{}, errors.Errorf("encode payload classes: %w", err)
 	}
 
 	resources, err := encodeMetadataResources(metadata.Resources)
 	if err != nil {
-		return charm.Metadata{}, fmt.Errorf("encode resources: %w", err)
+		return charm.Metadata{}, errors.Errorf("encode resources: %w", err)
 	}
 
 	containers, err := encodeMetadataContainers(metadata.Containers)
 	if err != nil {
-		return charm.Metadata{}, fmt.Errorf("encode containers: %w", err)
+		return charm.Metadata{}, errors.Errorf("encode containers: %w", err)
 	}
 
 	assumes, err := encodeMetadataAssumes(metadata.Assumes)
 	if err != nil {
-		return charm.Metadata{}, fmt.Errorf("encode assumes: %w", err)
+		return charm.Metadata{}, errors.Errorf("encode assumes: %w", err)
 	}
 
 	charmUser, err := encodeMetadataRunAs(metadata.CharmUser)
 	if err != nil {
-		return charm.Metadata{}, fmt.Errorf("encode charm user: %w", err)
+		return charm.Metadata{}, errors.Errorf("encode charm user: %w", err)
 	}
 
 	return charm.Metadata{
@@ -438,12 +437,12 @@ func encodeMetadataRelation(relations map[string]internalcharm.Relation) (map[st
 
 		role, err := encodeMetadataRole(v.Role)
 		if err != nil {
-			return nil, fmt.Errorf("encode role: %w", err)
+			return nil, errors.Errorf("encode role: %w", err)
 		}
 
 		scope, err := encodeMetadataScope(v.Scope)
 		if err != nil {
-			return nil, fmt.Errorf("encode scope: %w", err)
+			return nil, errors.Errorf("encode scope: %w", err)
 		}
 
 		result[name] = charm.Relation{
@@ -605,7 +604,7 @@ func encodeMetadataStorage(storage map[string]internalcharm.Storage) (map[string
 	for k, v := range storage {
 		storeType, err := encodeMetadataStorageType(v.Type)
 		if err != nil {
-			return nil, fmt.Errorf("encode storage type: %w", err)
+			return nil, errors.Errorf("encode storage type: %w", err)
 		}
 
 		result[k] = charm.Storage{
@@ -677,7 +676,7 @@ func encodeMetadataResources(resources map[string]resource.Meta) (map[string]cha
 	for k, v := range resources {
 		resourceType, err := encodeMetadataResourceType(v.Type)
 		if err != nil {
-			return nil, fmt.Errorf("encode resource type: %w", err)
+			return nil, errors.Errorf("encode resource type: %w", err)
 		}
 
 		result[k] = charm.Resource{
@@ -711,7 +710,7 @@ func encodeMetadataContainers(containers map[string]internalcharm.Container) (ma
 	for k, v := range containers {
 		mounts, err := encodeMetadataMounts(v.Mounts)
 		if err != nil {
-			return nil, fmt.Errorf("encode mounts: %w", err)
+			return nil, errors.Errorf("encode mounts: %w", err)
 		}
 
 		result[k] = charm.Container{

--- a/domain/application/service/package_test.go
+++ b/domain/application/service/package_test.go
@@ -9,12 +9,12 @@ import (
 	"time"
 
 	"github.com/juju/clock/testclock"
-	"github.com/juju/errors"
 	jujutesting "github.com/juju/testing"
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/changestream"
+	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/model"
 	modeltesting "github.com/juju/juju/core/model/testing"
 	corestorage "github.com/juju/juju/core/storage"
@@ -22,6 +22,7 @@ import (
 	"github.com/juju/juju/domain/application/charm"
 	domaintesting "github.com/juju/juju/domain/testing"
 	"github.com/juju/juju/internal/charm/resource"
+	"github.com/juju/juju/internal/errors"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 	"github.com/juju/juju/internal/storage"
 	"github.com/juju/juju/internal/storage/provider"
@@ -56,7 +57,7 @@ type baseSuite struct {
 
 func (s *baseSuite) setupMocks(c *gc.C) *gomock.Controller {
 	return s.setupMocksWithAtomic(c, func(ctx domain.AtomicContext) error {
-		return errors.NotImplementedf("not implemented")
+		return errors.Errorf("not implemented %w", coreerrors.NotImplemented)
 	})
 }
 

--- a/domain/application/service/resource.go
+++ b/domain/application/service/resource.go
@@ -5,18 +5,17 @@ package service
 
 import (
 	"context"
-	"fmt"
 	"io"
 
-	"github.com/juju/errors"
-
 	coreapplication "github.com/juju/juju/core/application"
+	coreerrors "github.com/juju/juju/core/errors"
 	coreresource "github.com/juju/juju/core/resource"
 	coreunit "github.com/juju/juju/core/unit"
 	"github.com/juju/juju/domain/application"
 	applicationerrors "github.com/juju/juju/domain/application/errors"
 	"github.com/juju/juju/domain/application/resource"
 	charmresource "github.com/juju/juju/internal/charm/resource"
+	"github.com/juju/juju/internal/errors"
 )
 
 // ResourceState describes retrieval and persistence methods for resource.
@@ -97,7 +96,7 @@ func (s *Service) GetApplicationResourceID(
 	args resource.GetApplicationResourceIDArgs,
 ) (coreresource.UUID, error) {
 	if err := args.ApplicationID.Validate(); err != nil {
-		return "", fmt.Errorf("application id: %w", err)
+		return "", errors.Errorf("application id: %w", err)
 	}
 	if args.Name == "" {
 		return "", applicationerrors.ResourceNameNotValid
@@ -121,7 +120,7 @@ func (s *Service) ListResources(
 	applicationID coreapplication.ID,
 ) (resource.ApplicationResources, error) {
 	if err := applicationID.Validate(); err != nil {
-		return resource.ApplicationResources{}, fmt.Errorf("application id: %w", err)
+		return resource.ApplicationResources{}, errors.Errorf("application id: %w", err)
 	}
 	return s.st.ListResources(ctx, applicationID)
 }
@@ -138,7 +137,7 @@ func (s *Service) GetResource(
 	resourceUUID coreresource.UUID,
 ) (resource.Resource, error) {
 	if err := resourceUUID.Validate(); err != nil {
-		return resource.Resource{}, fmt.Errorf("application id: %w", err)
+		return resource.Resource{}, errors.Errorf("application id: %w", err)
 	}
 	return s.st.GetResource(ctx, resourceUUID)
 }
@@ -157,14 +156,14 @@ func (s *Service) SetResource(
 	args resource.SetResourceArgs,
 ) (resource.Resource, error) {
 	if err := args.ApplicationID.Validate(); err != nil {
-		return resource.Resource{}, fmt.Errorf("application id: %w", err)
+		return resource.Resource{}, errors.Errorf("application id: %w", err)
 	}
 	if args.SuppliedBy != "" && args.SuppliedByType == resource.Unknown {
 		return resource.Resource{},
-			fmt.Errorf("%w RetrievedByType cannot be unknown if RetrievedBy set", errors.NotValid)
+			errors.Errorf("%w RetrievedByType cannot be unknown if RetrievedBy set", coreerrors.NotValid)
 	}
 	if err := args.Resource.Validate(); err != nil {
-		return resource.Resource{}, fmt.Errorf("resource: %w", err)
+		return resource.Resource{}, errors.Errorf("resource: %w", err)
 	}
 	return s.st.SetResource(ctx, args)
 }
@@ -183,14 +182,14 @@ func (s *Service) SetUnitResource(
 	args resource.SetUnitResourceArgs,
 ) (resource.SetUnitResourceResult, error) {
 	if err := args.UnitUUID.Validate(); err != nil {
-		return resource.SetUnitResourceResult{}, fmt.Errorf("unit id: %w", err)
+		return resource.SetUnitResourceResult{}, errors.Errorf("unit id: %w", err)
 	}
 	if err := args.ResourceUUID.Validate(); err != nil {
-		return resource.SetUnitResourceResult{}, fmt.Errorf("resource id: %w", err)
+		return resource.SetUnitResourceResult{}, errors.Errorf("resource id: %w", err)
 	}
 	if args.RetrievedBy != "" && args.RetrievedByType == resource.Unknown {
 		return resource.SetUnitResourceResult{},
-			fmt.Errorf("%w RetrievedByType cannot be unknown if RetrievedBy set", errors.NotValid)
+			errors.Errorf("%w RetrievedByType cannot be unknown if RetrievedBy set", coreerrors.NotValid)
 	}
 	return s.st.SetUnitResource(ctx, args)
 }
@@ -206,7 +205,7 @@ func (s *Service) OpenApplicationResource(
 	resourceUUID coreresource.UUID,
 ) (resource.Resource, io.ReadCloser, error) {
 	if err := resourceUUID.Validate(); err != nil {
-		return resource.Resource{}, nil, fmt.Errorf("resource id: %w", err)
+		return resource.Resource{}, nil, errors.Errorf("resource id: %w", err)
 	}
 	res, err := s.st.OpenApplicationResource(ctx, resourceUUID)
 	return res, &noopReadCloser{}, err
@@ -230,10 +229,10 @@ func (s *Service) OpenUnitResource(
 	unitID coreunit.UUID,
 ) (resource.Resource, io.ReadCloser, error) {
 	if err := unitID.Validate(); err != nil {
-		return resource.Resource{}, nil, fmt.Errorf("unit id: %w", err)
+		return resource.Resource{}, nil, errors.Errorf("unit id: %w", err)
 	}
 	if err := resourceUUID.Validate(); err != nil {
-		return resource.Resource{}, nil, fmt.Errorf("resource id: %w", err)
+		return resource.Resource{}, nil, errors.Errorf("resource id: %w", err)
 	}
 	res, err := s.st.OpenUnitResource(ctx, resourceUUID, unitID)
 	return res, &noopReadCloser{}, err
@@ -254,18 +253,18 @@ func (s *Service) SetRepositoryResources(
 	args resource.SetRepositoryResourcesArgs,
 ) error {
 	if err := args.ApplicationID.Validate(); err != nil {
-		return fmt.Errorf("application id: %w", err)
+		return errors.Errorf("application id: %w", err)
 	}
 	if len(args.Info) == 0 {
-		return fmt.Errorf("empty Info %w", errors.NotValid)
+		return errors.Errorf("empty Info %w", coreerrors.NotValid)
 	}
 	for _, info := range args.Info {
 		if err := info.Validate(); err != nil {
-			return fmt.Errorf("resource: %w", err)
+			return errors.Errorf("resource: %w", err)
 		}
 	}
 	if args.LastPolled.IsZero() {
-		return fmt.Errorf("zero LastPolled %w", errors.NotValid)
+		return errors.Errorf("zero LastPolled %w", coreerrors.NotValid)
 	}
 	return s.st.SetRepositoryResources(ctx, args)
 }

--- a/domain/application/service/resource_test.go
+++ b/domain/application/service/resource_test.go
@@ -7,12 +7,12 @@ import (
 	"context"
 	"time"
 
-	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
 	applicationtesting "github.com/juju/juju/core/application/testing"
+	coreerrors "github.com/juju/juju/core/errors"
 	resourcestesting "github.com/juju/juju/core/resource/testing"
 	unittesting "github.com/juju/juju/core/unit/testing"
 	applicationerrors "github.com/juju/juju/domain/application/errors"
@@ -49,7 +49,7 @@ func (s *resourceServiceSuite) TestGetApplicationResourceIDBadID(c *gc.C) {
 		Name:          "test-resource",
 	}
 	_, err := s.service.GetApplicationResourceID(context.Background(), args)
-	c.Assert(err, jc.ErrorIs, errors.NotValid)
+	c.Assert(err, jc.ErrorIs, coreerrors.NotValid)
 }
 
 func (s *resourceServiceSuite) TestGetApplicationResourceIDBadName(c *gc.C) {
@@ -83,7 +83,7 @@ func (s *resourceServiceSuite) TestListResources(c *gc.C) {
 func (s *resourceServiceSuite) TestListResourcesBadID(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	_, err := s.service.ListResources(context.Background(), "")
-	c.Assert(err, jc.ErrorIs, errors.NotValid)
+	c.Assert(err, jc.ErrorIs, coreerrors.NotValid)
 }
 
 func (s *resourceServiceSuite) TestGetResource(c *gc.C) {
@@ -104,7 +104,7 @@ func (s *resourceServiceSuite) TestGetResource(c *gc.C) {
 func (s *resourceServiceSuite) TestGetResourceBadID(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	_, err := s.service.GetResource(context.Background(), "")
-	c.Assert(err, jc.ErrorIs, errors.NotValid)
+	c.Assert(err, jc.ErrorIs, coreerrors.NotValid)
 }
 
 var fingerprint = []byte("123456789012345678901234567890123456789012345678")
@@ -151,7 +151,7 @@ func (s *resourceServiceSuite) TestSetResourceBadID(c *gc.C) {
 		ApplicationID: applicationtesting.GenApplicationUUID(c),
 	}
 	_, err := s.service.SetResource(context.Background(), args)
-	c.Assert(err, jc.ErrorIs, errors.NotValid)
+	c.Assert(err, jc.ErrorIs, coreerrors.NotValid)
 }
 
 func (s *resourceServiceSuite) TestSetResourceBadSuppliedBy(c *gc.C) {
@@ -162,7 +162,7 @@ func (s *resourceServiceSuite) TestSetResourceBadSuppliedBy(c *gc.C) {
 		SuppliedByType: resource.Application,
 	}
 	_, err := s.service.SetResource(context.Background(), args)
-	c.Assert(err, jc.ErrorIs, errors.NotValid)
+	c.Assert(err, jc.ErrorIs, coreerrors.NotValid)
 }
 
 func (s *resourceServiceSuite) TestSetResourceBadResource(c *gc.C) {
@@ -179,7 +179,7 @@ func (s *resourceServiceSuite) TestSetResourceBadResource(c *gc.C) {
 	}
 
 	_, err := s.service.SetResource(context.Background(), args)
-	c.Assert(err, jc.ErrorIs, errors.NotValid)
+	c.Assert(err, jc.ErrorIs, coreerrors.NotValid)
 }
 
 func (s *resourceServiceSuite) TestSetUnitResource(c *gc.C) {
@@ -220,7 +220,7 @@ func (s *resourceServiceSuite) TestOpenApplicationResourceBadID(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	_, _, err := s.service.OpenApplicationResource(context.Background(), "id")
-	c.Assert(err, jc.ErrorIs, errors.NotValid)
+	c.Assert(err, jc.ErrorIs, coreerrors.NotValid)
 }
 
 func (s *resourceServiceSuite) TestOpenUnitResource(c *gc.C) {
@@ -244,14 +244,14 @@ func (s *resourceServiceSuite) TestOpenUnitResourceBadUnitID(c *gc.C) {
 	resourceID := resourcestesting.GenResourceUUID(c)
 
 	_, _, err := s.service.OpenUnitResource(context.Background(), resourceID, "")
-	c.Assert(err, jc.ErrorIs, errors.NotValid)
+	c.Assert(err, jc.ErrorIs, coreerrors.NotValid)
 }
 
 func (s *resourceServiceSuite) TestOpenUnitResourceBadResourceID(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	_, _, err := s.service.OpenUnitResource(context.Background(), "", "")
-	c.Assert(err, jc.ErrorIs, errors.NotValid)
+	c.Assert(err, jc.ErrorIs, coreerrors.NotValid)
 }
 
 func (s *resourceServiceSuite) TestSetRepositoryResources(c *gc.C) {

--- a/domain/application/service/service.go
+++ b/domain/application/service/service.go
@@ -608,12 +608,12 @@ func validateStorageDirectives(
 func encodeChannelAndPlatform(origin corecharm.Origin) (*application.Channel, application.Platform, error) {
 	channel, err := encodeChannel(origin.Channel)
 	if err != nil {
-		return nil, application.Platform{}, errors.Trace(err)
+		return nil, application.Platform{}, errors.Capture(err)
 	}
 
 	platform, err := encodePlatform(origin.Platform)
 	if err != nil {
-		return nil, application.Platform{}, errors.Trace(err)
+		return nil, application.Platform{}, errors.Capture(err)
 	}
 
 	return channel, platform, nil
@@ -627,7 +627,7 @@ func encodeCharmSource(source corecharm.Source) (charm.CharmSource, error) {
 	case corecharm.CharmHub:
 		return charm.CharmHubSource, nil
 	default:
-		return "", internalerrors.Errorf("unknown source %q, expected local or charmhub: %w", source, applicationerrors.CharmSourceNotValid)
+		return "", errors.Errorf("unknown source %q, expected local or charmhub: %w", source, applicationerrors.CharmSourceNotValid)
 	}
 }
 
@@ -645,7 +645,7 @@ func encodeChannel(ch *internalcharm.Channel) (*application.Channel, error) {
 
 	risk, err := encodeChannelRisk(normalize.Risk)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	return &application.Channel{
@@ -673,12 +673,12 @@ func encodeChannelRisk(risk internalcharm.Risk) (application.ChannelRisk, error)
 func encodePlatform(platform corecharm.Platform) (application.Platform, error) {
 	ostype, err := encodeOSType(platform.OS)
 	if err != nil {
-		return application.Platform{}, errors.Trace(err)
+		return application.Platform{}, errors.Capture(err)
 	}
 
 	arch := encodeArchitecture(platform.Architecture)
 	if err != nil {
-		return application.Platform{}, errors.Trace(err)
+		return application.Platform{}, errors.Capture(err)
 	}
 
 	return application.Platform{

--- a/domain/application/state/application.go
+++ b/domain/application/state/application.go
@@ -174,7 +174,11 @@ func (st *State) CreateApplication(ctx domain.AtomicContext, name string, app ap
 		}
 		return nil
 	})
-	return appID, errors.Errorf("creating application %q %w", name, err)
+
+	if err != nil {
+		return "", errors.Errorf("creating application %q %w", name, err)
+	}
+	return appID, nil
 }
 
 func (st *State) checkApplicationExists(ctx context.Context, tx *sqlair.TX, name string) error {

--- a/domain/application/state/charm.go
+++ b/domain/application/state/charm.go
@@ -28,7 +28,7 @@ func (s *State) GetCharmID(ctx context.Context, name string, revision int, sourc
 
 	sourceID, err := encodeCharmSource(source)
 	if err != nil {
-		return "", internalerrors.Errorf("failed to encode charm source: %w", err)
+		return "", errors.Errorf("failed to encode charm source: %w", err)
 	}
 
 	var ident charmID
@@ -681,7 +681,7 @@ WHERE name IN ($nameSelector[:]);
 func (s *State) GetCharmDownloadInfo(ctx context.Context, id corecharm.ID) (*charm.DownloadInfo, error) {
 	db, err := s.DB()
 	if err != nil {
-		return nil, internalerrors.Capture(err)
+		return nil, errors.Capture(err)
 	}
 
 	ident := charmID{UUID: id.String()}
@@ -692,13 +692,13 @@ func (s *State) GetCharmDownloadInfo(ctx context.Context, id corecharm.ID) (*cha
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil
 		} else if err != nil {
-			return internalerrors.Capture(err)
+			return errors.Capture(err)
 		}
 		downloadInfo = &info
 
 		return nil
 	}); err != nil {
-		return nil, internalerrors.Errorf("getting charm download info: %w", err)
+		return nil, errors.Errorf("getting charm download info: %w", err)
 	}
 
 	return downloadInfo, nil

--- a/domain/application/state/charm_test.go
+++ b/domain/application/state/charm_test.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 
 	"github.com/juju/clock"
-	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/version/v2"
 	gc "gopkg.in/check.v1"
@@ -20,6 +19,7 @@ import (
 	"github.com/juju/juju/domain/application/architecture"
 	"github.com/juju/juju/domain/application/charm"
 	applicationerrors "github.com/juju/juju/domain/application/errors"
+	"github.com/juju/juju/internal/errors"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 	"github.com/juju/juju/internal/uuid"
 )
@@ -40,7 +40,7 @@ func (s *charmStateSuite) TestGetCharmIDCharmhubCharm(c *gc.C) {
 INSERT INTO charm (uuid, reference_name, architecture_id, revision) 
 VALUES (?, 'foo', 0, 1)`, id.String())
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		_, err = tx.ExecContext(ctx, `
@@ -48,7 +48,7 @@ INSERT INTO charm_metadata (charm_uuid, name)
 VALUES (?, 'foo')
 `, id.String())
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		return nil
@@ -70,14 +70,14 @@ func (s *charmStateSuite) TestGetCharmIDLocalCharm(c *gc.C) {
 INSERT INTO charm (uuid, reference_name, architecture_id, revision, source_id) 
 VALUES (?, 'foo', 0, 1, 0)`, id.String())
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		_, err = tx.ExecContext(ctx, `
 INSERT INTO charm_metadata (charm_uuid, name) 
 VALUES (?, 'foo')`, id.String())
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		return nil
@@ -182,12 +182,12 @@ func (s *charmStateSuite) TestIsControllerCharmWithControllerCharm(c *gc.C) {
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		_, err := tx.ExecContext(ctx, `INSERT INTO charm (uuid, reference_name, architecture_id) VALUES (?, 'ubuntu', 0)`, id.String())
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		_, err = tx.ExecContext(ctx, `INSERT INTO charm_metadata (charm_uuid, name) VALUES (?, 'juju-controller')`, id.String())
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		return nil
 	})
@@ -206,12 +206,12 @@ func (s *charmStateSuite) TestIsControllerCharmWithNoControllerCharm(c *gc.C) {
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		_, err := tx.ExecContext(ctx, `INSERT INTO charm (uuid, reference_name, architecture_id) VALUES (?, 'ubuntu', 0)`, id.String())
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		_, err = tx.ExecContext(ctx, `INSERT INTO charm_metadata (charm_uuid, name) VALUES (?, 'ubuntu')`, id.String())
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		return nil
 	})
@@ -239,12 +239,12 @@ func (s *charmStateSuite) TestIsSubordinateCharmWithSubordinateCharm(c *gc.C) {
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		_, err := tx.ExecContext(ctx, `INSERT INTO charm (uuid, reference_name, architecture_id) VALUES (?, 'ubuntu', 0)`, id.String())
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		_, err = tx.ExecContext(ctx, `INSERT INTO charm_metadata (charm_uuid, name, subordinate) VALUES (?, 'ubuntu', true)`, id.String())
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		return nil
 	})
@@ -263,12 +263,12 @@ func (s *charmStateSuite) TestIsSubordinateCharmWithNoSubordinateCharm(c *gc.C) 
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		_, err := tx.ExecContext(ctx, `INSERT INTO charm (uuid, reference_name, architecture_id) VALUES (?, 'ubuntu', 0)`, id.String())
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		_, err = tx.ExecContext(ctx, `INSERT INTO charm_metadata (charm_uuid, name, subordinate) VALUES (?, 'ubuntu', false)`, id.String())
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		return nil
@@ -297,22 +297,22 @@ func (s *charmStateSuite) TestSupportsContainersWithContainers(c *gc.C) {
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		_, err := tx.ExecContext(ctx, `INSERT INTO charm (uuid, reference_name, architecture_id) VALUES (?, 'ubuntu', 0)`, id.String())
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		_, err = tx.ExecContext(ctx, `INSERT INTO charm_metadata (charm_uuid, name) VALUES (?, 'ubuntu')`, id.String())
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		_, err = tx.ExecContext(ctx, `INSERT INTO charm_container (charm_uuid, "key") VALUES (?, 'ubuntu@22.04')`, id.String())
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		_, err = tx.ExecContext(ctx, `INSERT INTO charm_container (charm_uuid, "key") VALUES (?, 'ubuntu@20.04')`, id.String())
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		return nil
 	})
@@ -331,12 +331,12 @@ func (s *charmStateSuite) TestSupportsContainersWithNoContainers(c *gc.C) {
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		_, err := tx.ExecContext(ctx, `INSERT INTO charm (uuid, reference_name, architecture_id) VALUES (?, 'ubuntu', 0)`, id.String())
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		_, err = tx.ExecContext(ctx, `INSERT INTO charm_metadata (charm_uuid, name, subordinate) VALUES (?, 'ubuntu', false)`, id.String())
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		return nil
 	})
@@ -364,12 +364,12 @@ func (s *charmStateSuite) TestIsCharmAvailableWithAvailable(c *gc.C) {
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		_, err := tx.ExecContext(ctx, `INSERT INTO charm (uuid, reference_name, architecture_id, available) VALUES (?, 'ubuntu', 0, true)`, id.String())
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		_, err = tx.ExecContext(ctx, `INSERT INTO charm_metadata (charm_uuid, name) VALUES (?, 'ubuntu')`, id.String())
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		return nil
 	})
@@ -388,12 +388,12 @@ func (s *charmStateSuite) TestIsCharmAvailableWithNotAvailable(c *gc.C) {
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		_, err := tx.ExecContext(ctx, `INSERT INTO charm (uuid, reference_name, architecture_id, available) VALUES (?, 'ubuntu', 0, false)`, id.String())
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		_, err = tx.ExecContext(ctx, `INSERT INTO charm_metadata (charm_uuid, name) VALUES (?, 'ubuntu')`, id.String())
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		return nil
 	})
@@ -421,12 +421,12 @@ func (s *charmStateSuite) TestSetCharmAvailable(c *gc.C) {
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		_, err := tx.ExecContext(ctx, `INSERT INTO charm (uuid, available, reference_name, architecture_id) VALUES (?, false, 'ubuntu', 0)`, id.String())
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		_, err = tx.ExecContext(ctx, `INSERT INTO charm_metadata (charm_uuid, name) VALUES (?, 'ubuntu')`, id.String())
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		return nil
 	})
@@ -546,7 +546,7 @@ func (s *charmStateSuite) TestGetCharmMetadataWithTagsAndCategories(c *gc.C) {
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		var err error
 		if expected, err = insertCharmMetadata(ctx, c, tx, uuid); err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		_, err = tx.ExecContext(ctx, `
@@ -554,7 +554,7 @@ INSERT INTO charm_category (charm_uuid, array_index, value)
 VALUES (?, 0, 'data'), (?, 1, 'kubernetes'), (?, 2, 'kubernetes')
 `, uuid, uuid, uuid)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		_, err = tx.ExecContext(ctx, `
@@ -562,7 +562,7 @@ INSERT INTO charm_tag (charm_uuid, array_index, value)
 VALUES (?, 0, 'foo'), (?, 1, 'foo'), (?, 2,'bar')
 `, uuid, uuid, uuid)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		return nil
@@ -591,7 +591,7 @@ func (s *charmStateSuite) TestGetCharmMetadataWithTerms(c *gc.C) {
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		var err error
 		if expected, err = insertCharmMetadata(ctx, c, tx, uuid); err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		_, err = tx.ExecContext(ctx, `
@@ -599,7 +599,7 @@ INSERT INTO charm_term (charm_uuid, array_index, value)
 VALUES (?, 0, 'alpha'), (?, 1, 'beta'), (?, 2, 'beta')
 `, uuid, uuid, uuid)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		return nil
@@ -627,7 +627,7 @@ func (s *charmStateSuite) TestGetCharmMetadataWithRelation(c *gc.C) {
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		var err error
 		if expected, err = insertCharmMetadata(ctx, c, tx, charmUUID); err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		_, err = tx.ExecContext(ctx, `
@@ -643,7 +643,7 @@ VALUES
 			uuid.MustNewUUID().String(), charmUUID,
 		)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		return nil
@@ -698,7 +698,7 @@ func (s *charmStateSuite) TestGetCharmMetadataWithExtraBindings(c *gc.C) {
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		var err error
 		if expected, err = insertCharmMetadata(ctx, c, tx, uuid); err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		_, err = tx.ExecContext(ctx, `
@@ -708,7 +708,7 @@ VALUES
     (?, 'fred', 'baz');`,
 			uuid, uuid)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		return nil
@@ -743,7 +743,7 @@ func (s *charmStateSuite) TestGetCharmMetadataWithStorageWithNoProperties(c *gc.
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		var err error
 		if expected, err = insertCharmMetadata(ctx, c, tx, uuid); err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		_, err = tx.ExecContext(ctx, `
@@ -764,7 +764,7 @@ INSERT INTO charm_storage (
     (?, 'fred', 'baz', 'description 2', 0, false, false, 4, 5, 6, '/var/mount');`,
 			uuid, uuid)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		return nil
@@ -815,7 +815,7 @@ func (s *charmStateSuite) TestGetCharmMetadataWithStorageWithProperties(c *gc.C)
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		var err error
 		if expected, err = insertCharmMetadata(ctx, c, tx, uuid); err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		_, err = tx.ExecContext(ctx, `
@@ -836,7 +836,7 @@ INSERT INTO charm_storage (
     (?, 'fred', 'baz', 'description 2', 0, false, false, 4, 5, 6, '/var/mount');`,
 			uuid, uuid)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		_, err = tx.ExecContext(ctx, `
@@ -851,7 +851,7 @@ INSERT INTO charm_storage_property (
     (?, 'foo', 2, 'beta');`,
 			uuid, uuid, uuid)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		return nil
@@ -901,7 +901,7 @@ func (s *charmStateSuite) TestGetCharmMetadataWithDevices(c *gc.C) {
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		var err error
 		if expected, err = insertCharmMetadata(ctx, c, tx, uuid); err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		_, err = tx.ExecContext(ctx, `
@@ -918,7 +918,7 @@ INSERT INTO charm_device (
     (?, 'fred', 'baz', 'description 2', 'tpu', 3, 4);`,
 			uuid, uuid)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		return nil
@@ -959,7 +959,7 @@ func (s *charmStateSuite) TestGetCharmMetadataWithPayloadClasses(c *gc.C) {
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		var err error
 		if expected, err = insertCharmMetadata(ctx, c, tx, uuid); err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		_, err = tx.ExecContext(ctx, `
@@ -973,7 +973,7 @@ INSERT INTO charm_payload (
     (?, 'fred', 'baz', 'kvm');`,
 			uuid, uuid)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		return nil
@@ -1008,7 +1008,7 @@ func (s *charmStateSuite) TestGetCharmMetadataWithResources(c *gc.C) {
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		var err error
 		if expected, err = insertCharmMetadata(ctx, c, tx, uuid); err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		_, err = tx.ExecContext(ctx, `
@@ -1023,7 +1023,7 @@ INSERT INTO charm_resource (
     (?, 'bar', 1, 'hub.docker.io/jujusolutions', 'description 2');`,
 			uuid, uuid)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		return nil
@@ -1062,7 +1062,7 @@ func (s *charmStateSuite) TestGetCharmMetadataWithContainersWithNoMounts(c *gc.C
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		var err error
 		if expected, err = insertCharmMetadata(ctx, c, tx, uuid); err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		_, err = tx.ExecContext(ctx, `
@@ -1077,7 +1077,7 @@ INSERT INTO charm_container (
     (?, 'fred', 'ubuntu@20.04', -1, -1);`,
 			uuid, uuid)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		return nil
@@ -1112,7 +1112,7 @@ func (s *charmStateSuite) TestGetCharmMetadataWithContainersWithMounts(c *gc.C) 
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		var err error
 		if expected, err = insertCharmMetadata(ctx, c, tx, uuid); err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		_, err = tx.ExecContext(ctx, `
@@ -1127,7 +1127,7 @@ INSERT INTO charm_container (
     (?, 'fred', 'ubuntu@20.04', -1, -1);`,
 			uuid, uuid)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		_, err = tx.ExecContext(ctx, `
@@ -1143,7 +1143,7 @@ INSERT INTO charm_container_mount (
     (?, 0, 'fred', 'file', '/var/log');`,
 			uuid, uuid, uuid)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		return nil
 	})
@@ -2219,7 +2219,7 @@ func (s *charmStateSuite) TestGetCharmManifest(c *gc.C) {
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		var err error
 		if expected, err = insertCharmManifest(ctx, c, tx, uuid); err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		_, err = tx.ExecContext(ctx, `
@@ -2239,7 +2239,7 @@ INSERT INTO charm_manifest_base (
     (?, 2, 0, 0, '4.0', 'beta', 'baz', 2);`,
 			uuid, uuid, uuid, uuid)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		return nil
 	})
@@ -2358,7 +2358,7 @@ func (s *charmStateSuite) TestGetCharmLXDProfile(c *gc.C) {
 
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		if err := insertCharmState(ctx, c, tx, uuid); err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		_, err := tx.ExecContext(ctx, `
@@ -2367,7 +2367,7 @@ SET lxd_profile = ?
 WHERE charm_uuid = ?
 `, `{"profile": []}`, uuid)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		return nil
 	})
@@ -2404,7 +2404,7 @@ func (s *charmStateSuite) TestGetCharmLXDProfileLXDProfileNotFound(c *gc.C) {
 INSERT INTO charm (uuid, available, reference_name, architecture_id) 
 VALUES (?, false, 'ubuntu', 0)`, uuid)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		return nil
 	})
@@ -2422,7 +2422,7 @@ func (s *charmStateSuite) TestGetCharmConfig(c *gc.C) {
 
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		if err := insertCharmState(ctx, c, tx, uuid); err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		_, err := tx.ExecContext(ctx, `
@@ -2441,7 +2441,7 @@ INSERT INTO charm_config (
 	(?, 'shh', 4, 'secret', 'this is a secret');`,
 			uuid, uuid, uuid, uuid, uuid, uuid)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		return nil
 	})
@@ -2566,7 +2566,7 @@ func (s *charmStateSuite) TestGetCharmConfigEmpty(c *gc.C) {
 
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		if err := insertCharmState(ctx, c, tx, uuid); err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		return nil
 	})
@@ -2587,7 +2587,7 @@ func (s *charmStateSuite) TestGetCharmActions(c *gc.C) {
 
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		if err := insertCharmState(ctx, c, tx, uuid); err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		_, err := tx.ExecContext(ctx, `
@@ -2603,7 +2603,7 @@ INSERT INTO charm_action (
     (?, 'bar', 'description2', false, 'group2', null);`,
 			uuid, uuid)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		return nil
 	})
@@ -2691,7 +2691,7 @@ func (s *charmStateSuite) TestGetCharmActionsEmpty(c *gc.C) {
 
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		if err := insertCharmState(ctx, c, tx, uuid); err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		return nil
 	})
@@ -3056,14 +3056,14 @@ INSERT INTO charm (uuid, archive_path, available, reference_name, revision, vers
 VALUES (?, 'archive', false, 'ubuntu', 42, 'deadbeef', 0)
 `, uuid)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	_, err = tx.ExecContext(ctx, `
 INSERT INTO charm_metadata (charm_uuid, name, description, summary, subordinate, min_juju_version, run_as_id, assumes)
 VALUES (?, 'ubuntu', 'description', 'summary', true, '4.0.0', 1, 'null')`, uuid)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	return nil
@@ -3071,7 +3071,7 @@ VALUES (?, 'ubuntu', 'description', 'summary', true, '4.0.0', 1, 'null')`, uuid)
 
 func insertCharmMetadata(ctx context.Context, c *gc.C, tx *sql.Tx, uuid string) (charm.Metadata, error) {
 	if err := insertCharmState(ctx, c, tx, uuid); err != nil {
-		return charm.Metadata{}, errors.Trace(err)
+		return charm.Metadata{}, errors.Capture(err)
 	}
 
 	return charm.Metadata{
@@ -3087,7 +3087,7 @@ func insertCharmMetadata(ctx context.Context, c *gc.C, tx *sql.Tx, uuid string) 
 
 func insertCharmManifest(ctx context.Context, c *gc.C, tx *sql.Tx, uuid string) (charm.Manifest, error) {
 	if err := insertCharmState(ctx, c, tx, uuid); err != nil {
-		return charm.Manifest{}, errors.Trace(err)
+		return charm.Manifest{}, errors.Capture(err)
 	}
 
 	return charm.Manifest{}, nil
@@ -3122,7 +3122,7 @@ func assertTableEmpty(c *gc.C, runner coredatabase.TxnRunner, table string) {
 	err := runner.StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		err := tx.QueryRowContext(ctx, fmt.Sprintf("SELECT COUNT(*) FROM %s", table)).Scan(&count)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		return nil

--- a/domain/application/state/config.go
+++ b/domain/application/state/config.go
@@ -4,11 +4,11 @@
 package state
 
 import (
-	"fmt"
 	"strconv"
 
 	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/domain/application/charm"
+	"github.com/juju/juju/internal/errors"
 )
 
 func decodeConfig(configs []charmConfig) (charm.Config, error) {
@@ -18,12 +18,12 @@ func decodeConfig(configs []charmConfig) (charm.Config, error) {
 	for _, config := range configs {
 		optionType, err := decodeConfigType(config.Type)
 		if err != nil {
-			return charm.Config{}, fmt.Errorf("cannot decode config type %q: %w", config.Type, err)
+			return charm.Config{}, errors.Errorf("cannot decode config type %q: %w", config.Type, err)
 		}
 
 		defaultValue, err := decodeConfigDefaultValue(optionType, config.DefaultValue)
 		if err != nil {
-			return charm.Config{}, fmt.Errorf("cannot decode config default value %v: %w", config.DefaultValue, err)
+			return charm.Config{}, errors.Errorf("cannot decode config default value %v: %w", config.DefaultValue, err)
 		}
 
 		result.Options[config.Key] = charm.Option{
@@ -48,7 +48,7 @@ func decodeConfigType(t string) (charm.OptionType, error) {
 	case "secret":
 		return charm.OptionSecret, nil
 	default:
-		return "", fmt.Errorf("unknown config type %q", t)
+		return "", errors.Errorf("unknown config type %q", t)
 	}
 }
 
@@ -67,7 +67,7 @@ func decodeConfigDefaultValue(t charm.OptionType, value *string) (any, error) {
 	case charm.OptionBool:
 		return strconv.ParseBool(*value)
 	default:
-		return nil, fmt.Errorf("unknown config type %q", t)
+		return nil, errors.Errorf("unknown config type %q", t)
 	}
 }
 
@@ -76,12 +76,12 @@ func encodeConfig(id corecharm.ID, config charm.Config) ([]setCharmConfig, error
 	for key, option := range config.Options {
 		encodedType, err := encodeConfigType(option.Type)
 		if err != nil {
-			return nil, fmt.Errorf("cannot encode config type %q: %w", option.Type, err)
+			return nil, errors.Errorf("cannot encode config type %q: %w", option.Type, err)
 		}
 
 		encodedDefaultValue, err := encodeConfigDefaultValue(option.Default)
 		if err != nil {
-			return nil, fmt.Errorf("cannot encode config default value %q: %w", option.Default, err)
+			return nil, errors.Errorf("cannot encode config default value %q: %w", option.Default, err)
 		}
 
 		result = append(result, setCharmConfig{
@@ -108,7 +108,7 @@ func encodeConfigType(t charm.OptionType) (int, error) {
 	case charm.OptionSecret:
 		return 4, nil
 	default:
-		return -1, fmt.Errorf("unknown config type %q", t)
+		return -1, errors.Errorf("unknown config type %q", t)
 	}
 }
 
@@ -127,7 +127,7 @@ func encodeConfigDefaultValue(value any) (*string, error) {
 	case nil:
 		return nil, nil
 	default:
-		return nil, fmt.Errorf("unknown config default value type %T", value)
+		return nil, errors.Errorf("unknown config default value type %T", value)
 	}
 }
 

--- a/domain/application/state/manifest.go
+++ b/domain/application/state/manifest.go
@@ -4,10 +4,9 @@
 package state
 
 import (
-	"fmt"
-
 	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/domain/application/charm"
+	"github.com/juju/juju/internal/errors"
 )
 
 const (
@@ -26,7 +25,7 @@ func decodeManifest(manifests []charmManifest) (charm.Manifest, error) {
 	for _, base := range manifests {
 		channel, err := decodeManifestChannel(base)
 		if err != nil {
-			return charm.Manifest{}, fmt.Errorf("cannot decode channel: %w", err)
+			return charm.Manifest{}, errors.Errorf("cannot decode channel: %w", err)
 		}
 
 		if b, ok := bases[base.Index]; ok {
@@ -73,7 +72,7 @@ func decodeManifest(manifests []charmManifest) (charm.Manifest, error) {
 func decodeManifestChannel(base charmManifest) (charm.Channel, error) {
 	risk, err := decodeManifestChannelRisk(base.Risk)
 	if err != nil {
-		return charm.Channel{}, fmt.Errorf("cannot decode risk: %w", err)
+		return charm.Channel{}, errors.Errorf("cannot decode risk: %w", err)
 	}
 
 	return charm.Channel{
@@ -95,7 +94,7 @@ func decodeManifestChannelRisk(risk string) (charm.ChannelRisk, error) {
 	case "edge":
 		return charm.RiskEdge, nil
 	default:
-		return "", fmt.Errorf("unknown risk %q", risk)
+		return "", errors.Errorf("unknown risk %q", risk)
 	}
 }
 
@@ -104,12 +103,12 @@ func encodeManifest(id corecharm.ID, manifest charm.Manifest) ([]setCharmManifes
 	for index, base := range manifest.Bases {
 		encodedRisk, err := encodeManifestChannelRisk(base.Channel.Risk)
 		if err != nil {
-			return nil, fmt.Errorf("cannot encode risk: %w", err)
+			return nil, errors.Errorf("cannot encode risk: %w", err)
 		}
 
 		encodedOS, err := encodeManifestOS(base.Name)
 		if err != nil {
-			return nil, fmt.Errorf("cannot encode OS: %w", err)
+			return nil, errors.Errorf("cannot encode OS: %w", err)
 		}
 
 		// No architectures specified, use the default.
@@ -130,7 +129,7 @@ func encodeManifest(id corecharm.ID, manifest charm.Manifest) ([]setCharmManifes
 		for i, architecture := range base.Architectures {
 			encodedArch, err := encodeManifestArchitecture(architecture)
 			if err != nil {
-				return nil, fmt.Errorf("cannot encode architecture: %w", err)
+				return nil, errors.Errorf("cannot encode architecture: %w", err)
 			}
 			result = append(result, setCharmManifest{
 				CharmUUID:      id.String(),
@@ -158,7 +157,7 @@ func encodeManifestChannelRisk(risk charm.ChannelRisk) (string, error) {
 	case charm.RiskEdge:
 		return "edge", nil
 	default:
-		return "", fmt.Errorf("unknown risk %q", risk)
+		return "", errors.Errorf("unknown risk %q", risk)
 	}
 }
 
@@ -167,7 +166,7 @@ func encodeManifestOS(os string) (int, error) {
 	case "ubuntu":
 		return 0, nil
 	default:
-		return -1, fmt.Errorf("unknown OS %q", os)
+		return -1, errors.Errorf("unknown OS %q", os)
 	}
 }
 
@@ -184,6 +183,6 @@ func encodeManifestArchitecture(architecture string) (int, error) {
 	case "riscv64":
 		return 4, nil
 	default:
-		return -1, fmt.Errorf("unknown architecture %q", architecture)
+		return -1, errors.Errorf("unknown architecture %q", architecture)
 	}
 }

--- a/domain/application/state/metadata.go
+++ b/domain/application/state/metadata.go
@@ -4,8 +4,6 @@
 package state
 
 import (
-	"fmt"
-
 	"github.com/juju/version/v2"
 
 	corecharm "github.com/juju/juju/core/charm"
@@ -43,33 +41,33 @@ func decodeMetadata(metadata charmMetadata, args decodeMetadataArgs) (charm.Meta
 	if metadata.MinJujuVersion != "" {
 		minVersion, err = version.Parse(metadata.MinJujuVersion)
 		if err != nil {
-			return charm.Metadata{}, fmt.Errorf("cannot parse min juju version %q: %w", metadata.MinJujuVersion, err)
+			return charm.Metadata{}, errors.Errorf("cannot parse min juju version %q: %w", metadata.MinJujuVersion, err)
 		}
 	}
 
 	runAs, err := decodeRunAs(metadata.RunAs)
 	if err != nil {
-		return charm.Metadata{}, fmt.Errorf("cannot decode run as %q: %w", metadata.RunAs, err)
+		return charm.Metadata{}, errors.Errorf("cannot decode run as %q: %w", metadata.RunAs, err)
 	}
 
 	provides, requires, peer, err := decodeRelations(args.relations)
 	if err != nil {
-		return charm.Metadata{}, fmt.Errorf("cannot decode relations: %w", err)
+		return charm.Metadata{}, errors.Errorf("cannot decode relations: %w", err)
 	}
 
 	storage, err := decodeStorage(args.storage)
 	if err != nil {
-		return charm.Metadata{}, fmt.Errorf("cannot decode storage: %w", err)
+		return charm.Metadata{}, errors.Errorf("cannot decode storage: %w", err)
 	}
 
 	resources, err := decodeResources(args.resources)
 	if err != nil {
-		return charm.Metadata{}, fmt.Errorf("cannot decode resources: %w", err)
+		return charm.Metadata{}, errors.Errorf("cannot decode resources: %w", err)
 	}
 
 	containers, err := decodeContainers(args.containers)
 	if err != nil {
-		return charm.Metadata{}, fmt.Errorf("cannot decode containers: %w", err)
+		return charm.Metadata{}, errors.Errorf("cannot decode containers: %w", err)
 	}
 
 	return charm.Metadata{
@@ -106,7 +104,7 @@ func decodeRunAs(runAs string) (charm.RunAs, error) {
 	case "user":
 		return charm.RunAsNonRoot, nil
 	default:
-		return "", fmt.Errorf("unknown run as value %q", runAs)
+		return "", errors.Errorf("unknown run as value %q", runAs)
 	}
 }
 
@@ -138,12 +136,12 @@ func decodeRelations(relations []charmRelation) (map[string]charm.Relation, map[
 	makeRelation := func(relation charmRelation) (charm.Relation, error) {
 		role, err := decodeRelationRole(relation.Role)
 		if err != nil {
-			return charm.Relation{}, fmt.Errorf("cannot decode relation role %q: %w", relation.Role, err)
+			return charm.Relation{}, errors.Errorf("cannot decode relation role %q: %w", relation.Role, err)
 		}
 
 		scope, err := decodeRelationScope(relation.Scope)
 		if err != nil {
-			return charm.Relation{}, fmt.Errorf("cannot decode relation scope %q: %w", relation.Scope, err)
+			return charm.Relation{}, errors.Errorf("cannot decode relation scope %q: %w", relation.Scope, err)
 		}
 
 		return charm.Relation{
@@ -161,7 +159,7 @@ func decodeRelations(relations []charmRelation) (map[string]charm.Relation, map[
 	for _, relation := range relations {
 		rel, err := makeRelation(relation)
 		if err != nil {
-			return nil, nil, nil, fmt.Errorf("cannot make relation: %w", err)
+			return nil, nil, nil, errors.Errorf("cannot make relation: %w", err)
 		}
 
 		switch relation.Kind {
@@ -181,7 +179,7 @@ func decodeRelations(relations []charmRelation) (map[string]charm.Relation, map[
 			}
 			peers[relation.Key] = rel
 		default:
-			return nil, nil, nil, fmt.Errorf("unknown relation role %q", relation.Kind)
+			return nil, nil, nil, errors.Errorf("unknown relation role %q", relation.Kind)
 		}
 	}
 
@@ -197,7 +195,7 @@ func decodeRelationRole(role string) (charm.RelationRole, error) {
 	case "peer":
 		return charm.RolePeer, nil
 	default:
-		return "", fmt.Errorf("unknown relation role %q", role)
+		return "", errors.Errorf("unknown relation role %q", role)
 	}
 }
 
@@ -208,7 +206,7 @@ func decodeRelationScope(scope string) (charm.RelationScope, error) {
 	case "container":
 		return charm.ScopeContainer, nil
 	default:
-		return "", fmt.Errorf("unknown relation scope %q", scope)
+		return "", errors.Errorf("unknown relation scope %q", scope)
 	}
 }
 
@@ -245,7 +243,7 @@ func decodeStorage(storages []charmStorage) (map[string]charm.Storage, error) {
 
 		kind, err := decodeStorageType(storage.Kind)
 		if err != nil {
-			return nil, fmt.Errorf("cannot decode storage type %q: %w", storage.Kind, err)
+			return nil, errors.Errorf("cannot decode storage type %q: %w", storage.Kind, err)
 		}
 
 		// If we've got a property that isn't an empty string, then we need to
@@ -278,7 +276,7 @@ func decodeStorageType(kind string) (charm.StorageType, error) {
 	case "filesystem":
 		return charm.StorageFilesystem, nil
 	default:
-		return "", fmt.Errorf("unknown storage kind %q", kind)
+		return "", errors.Errorf("unknown storage kind %q", kind)
 	}
 }
 
@@ -324,7 +322,7 @@ func decodeResources(resources []charmResource) (map[string]charm.Resource, erro
 	for _, resource := range resources {
 		kind, err := decodeResourceType(resource.Kind)
 		if err != nil {
-			return nil, fmt.Errorf("cannot parse resource type %q: %w", resource.Kind, err)
+			return nil, errors.Errorf("cannot parse resource type %q: %w", resource.Kind, err)
 		}
 
 		result[resource.Name] = charm.Resource{
@@ -344,7 +342,7 @@ func decodeResourceType(kind string) (charm.ResourceType, error) {
 	case "oci-image":
 		return charm.ResourceTypeContainerImage, nil
 	default:
-		return "", fmt.Errorf("unknown resource kind %q", kind)
+		return "", errors.Errorf("unknown resource kind %q", kind)
 	}
 }
 
@@ -398,7 +396,7 @@ func decodeContainers(containers []charmContainer) (map[string]charm.Container, 
 func encodeMetadata(id corecharm.ID, metadata charm.Metadata, lxdProfile []byte) (setCharmMetadata, error) {
 	runAs, err := encodeRunAs(metadata.RunAs)
 	if err != nil {
-		return setCharmMetadata{}, fmt.Errorf("cannot encode run as %q: %w", metadata.RunAs, err)
+		return setCharmMetadata{}, errors.Errorf("cannot encode run as %q: %w", metadata.RunAs, err)
 	}
 
 	return setCharmMetadata{
@@ -425,7 +423,7 @@ func encodeRunAs(runAs charm.RunAs) (int, error) {
 	case charm.RunAsNonRoot:
 		return 3, nil
 	default:
-		return -1, fmt.Errorf("unknown run as value %q", runAs)
+		return -1, errors.Errorf("unknown run as value %q", runAs)
 	}
 }
 
@@ -540,7 +538,7 @@ func encodeRelationKind(kind string) (int, error) {
 	case relationKindPeers:
 		return 2, nil
 	default:
-		return -1, fmt.Errorf("unknown relation kind %q", kind)
+		return -1, errors.Errorf("unknown relation kind %q", kind)
 	}
 }
 
@@ -555,7 +553,7 @@ func encodeRelationRole(role charm.RelationRole) (int, error) {
 	case charm.RolePeer:
 		return 2, nil
 	default:
-		return -1, fmt.Errorf("unknown relation role %q", role)
+		return -1, errors.Errorf("unknown relation role %q", role)
 	}
 }
 
@@ -568,7 +566,7 @@ func encodeRelationScope(scope charm.RelationScope) (int, error) {
 	case charm.ScopeContainer:
 		return 1, nil
 	default:
-		return -1, fmt.Errorf("unknown relation scope %q", scope)
+		return -1, errors.Errorf("unknown relation scope %q", scope)
 	}
 }
 
@@ -592,7 +590,7 @@ func encodeStorage(id corecharm.ID, storage map[string]charm.Storage) ([]setChar
 	for key, storage := range storage {
 		kind, err := encodeStorageType(storage.Type)
 		if err != nil {
-			return nil, nil, fmt.Errorf("cannot encode storage type %q: %w", storage.Type, err)
+			return nil, nil, errors.Errorf("cannot encode storage type %q: %w", storage.Type, err)
 		}
 
 		storages = append(storages, setCharmStorage{
@@ -630,7 +628,7 @@ func encodeStorageType(kind charm.StorageType) (int, error) {
 	case charm.StorageFilesystem:
 		return 1, nil
 	default:
-		return -1, fmt.Errorf("unknown storage kind %q", kind)
+		return -1, errors.Errorf("unknown storage kind %q", kind)
 	}
 }
 
@@ -671,7 +669,7 @@ func encodeResources(id corecharm.ID, resources map[string]charm.Resource) ([]se
 	for _, resource := range resources {
 		kind, err := encodeResourceType(resource.Type)
 		if err != nil {
-			return nil, fmt.Errorf("cannot encode resource type %q: %w", resource.Type, err)
+			return nil, errors.Errorf("cannot encode resource type %q: %w", resource.Type, err)
 		}
 
 		result = append(result, setCharmResource{
@@ -695,7 +693,7 @@ func encodeResourceType(kind charm.ResourceType) (int, error) {
 	case charm.ResourceTypeContainerImage:
 		return 1, nil
 	default:
-		return -1, fmt.Errorf("unknown resource kind %q", kind)
+		return -1, errors.Errorf("unknown resource kind %q", kind)
 	}
 }
 

--- a/domain/application/state/state.go
+++ b/domain/application/state/state.go
@@ -1345,7 +1345,7 @@ func encodeArchitecture(a architecture.Architecture) (int, error) {
 	case architecture.RISV64:
 		return 4, nil
 	default:
-		return 0, internalerrors.Errorf("unsupported architecture: %d", a)
+		return 0, errors.Errorf("unsupported architecture: %d", a)
 	}
 }
 
@@ -1356,7 +1356,7 @@ func encodeCharmSource(source charm.CharmSource) (int, error) {
 	case charm.CharmHubSource:
 		return 1, nil
 	default:
-		return 0, internalerrors.Errorf("unsupported source type: %s", source)
+		return 0, errors.Errorf("unsupported source type: %s", source)
 	}
 }
 
@@ -1371,7 +1371,7 @@ func encodeProvenance(provenance charm.Provenance) (int, error) {
 	case charm.ProvenanceBootstrap:
 		return 3, nil
 	default:
-		return 0, internalerrors.Errorf("unsupported provenance type: %s", provenance)
+		return 0, errors.Errorf("unsupported provenance type: %s", provenance)
 	}
 }
 

--- a/domain/application/state/state.go
+++ b/domain/application/state/state.go
@@ -6,11 +6,9 @@ package state
 import (
 	"context"
 	"database/sql"
-	"fmt"
 
 	"github.com/canonical/sqlair"
 	"github.com/juju/clock"
-	"github.com/juju/errors"
 
 	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/core/database"
@@ -21,7 +19,7 @@ import (
 	"github.com/juju/juju/domain/application/charm"
 	applicationerrors "github.com/juju/juju/domain/application/errors"
 	internaldatabase "github.com/juju/juju/internal/database"
-	internalerrors "github.com/juju/juju/internal/errors"
+	"github.com/juju/juju/internal/errors"
 )
 
 type State struct {
@@ -49,17 +47,17 @@ WHERE uuid = $charmID.uuid;
 	result := charmID{UUID: id.UUID}
 	selectStmt, err := s.Prepare(selectQuery, result)
 	if err != nil {
-		return internalerrors.Errorf("preparing query: %w", err)
+		return errors.Errorf("preparing query: %w", err)
 	}
 	if err := tx.Query(ctx, selectStmt, result).Get(&result); err != nil {
 		if errors.Is(err, sqlair.ErrNoRows) {
 			return applicationerrors.CharmNotFound
 		}
-		return internalerrors.Errorf("failed to check charm exists: %w", err)
+		return errors.Errorf("failed to check charm exists: %w", err)
 	}
 
 	if _, err := corecharm.ParseID(result.UUID); err != nil {
-		return internalerrors.Errorf("failed to parse charm ID: %w", err)
+		return errors.Errorf("failed to parse charm ID: %w", err)
 	}
 
 	return nil
@@ -80,18 +78,18 @@ AND revision = $charmReferenceNameRevisionSource.revision
 	var result charmID
 	selectStmt, err := s.Prepare(selectQuery, result, ref)
 	if err != nil {
-		return "", fmt.Errorf("preparing query: %w", err)
+		return "", errors.Errorf("preparing query: %w", err)
 	}
 	if err := tx.Query(ctx, selectStmt, ref).Get(&result); err != nil {
 		if errors.Is(err, sqlair.ErrNoRows) {
 			return "", nil
 		}
-		return "", fmt.Errorf("failed to check charm exists: %w", err)
+		return "", errors.Errorf("failed to check charm exists: %w", err)
 	}
 
 	id, err := corecharm.ParseID(result.UUID)
 	if err != nil {
-		return "", fmt.Errorf("failed to parse charm ID: %w", err)
+		return "", errors.Errorf("failed to parse charm ID: %w", err)
 	}
 
 	return id, applicationerrors.CharmAlreadyExists
@@ -99,69 +97,69 @@ AND revision = $charmReferenceNameRevisionSource.revision
 
 func (s *State) setCharm(ctx context.Context, tx *sqlair.TX, uuid corecharm.ID, ch charm.Charm, downloadInfo *charm.DownloadInfo) error {
 	if err := s.setCharmState(ctx, tx, uuid, ch); err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	if err := s.setCharmMetadata(ctx, tx, uuid, ch.Metadata, ch.LXDProfile); err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	if err := s.setCharmTags(ctx, tx, uuid, ch.Metadata.Tags); err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	if err := s.setCharmCategories(ctx, tx, uuid, ch.Metadata.Categories); err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	if err := s.setCharmTerms(ctx, tx, uuid, ch.Metadata.Terms); err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	if err := s.setCharmRelations(ctx, tx, uuid, ch.Metadata); err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	if err := s.setCharmExtraBindings(ctx, tx, uuid, ch.Metadata.ExtraBindings); err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	if err := s.setCharmStorage(ctx, tx, uuid, ch.Metadata.Storage); err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	if err := s.setCharmDevices(ctx, tx, uuid, ch.Metadata.Devices); err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	if err := s.setCharmPayloads(ctx, tx, uuid, ch.Metadata.PayloadClasses); err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	if err := s.setCharmResources(ctx, tx, uuid, ch.Metadata.Resources); err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	if err := s.setCharmContainers(ctx, tx, uuid, ch.Metadata.Containers); err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	if err := s.setCharmActions(ctx, tx, uuid, ch.Actions); err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	if err := s.setCharmConfig(ctx, tx, uuid, ch.Config); err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	if err := s.setCharmManifest(ctx, tx, uuid, ch.Manifest); err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	// Insert the download info if the charm is from CharmHub.
 	if ch.Source == charm.CharmHubSource {
 		if err := s.setCharmDownloadInfo(ctx, tx, uuid, downloadInfo); err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 	}
 
@@ -176,12 +174,12 @@ func (s *State) setCharmState(
 ) error {
 	sourceID, err := encodeCharmSource(ch.Source)
 	if err != nil {
-		return fmt.Errorf("encoding charm source: %w", err)
+		return errors.Errorf("encoding charm source: %w", err)
 	}
 
 	architectureID, err := encodeArchitecture(ch.Architecture)
 	if err != nil {
-		return fmt.Errorf("encoding charm architecture: %w", err)
+		return errors.Errorf("encoding charm architecture: %w", err)
 	}
 
 	nullableArchitectureID := sql.NullInt64{}
@@ -206,7 +204,7 @@ func (s *State) setCharmState(
 	charmQuery := `INSERT INTO charm (*) VALUES ($setCharmState.*);`
 	charmStmt, err := s.Prepare(charmQuery, chState)
 	if err != nil {
-		return fmt.Errorf("preparing query: %w", err)
+		return errors.Errorf("preparing query: %w", err)
 	}
 
 	hash := setCharmHash{
@@ -218,15 +216,15 @@ func (s *State) setCharmState(
 	hashQuery := `INSERT INTO charm_hash (*) VALUES ($setCharmHash.*);`
 	hashStmt, err := s.Prepare(hashQuery, hash)
 	if err != nil {
-		return fmt.Errorf("preparing query: %w", err)
+		return errors.Errorf("preparing query: %w", err)
 	}
 
 	if err := tx.Query(ctx, charmStmt, chState).Run(); err != nil {
-		return fmt.Errorf("inserting charm state: %w", err)
+		return errors.Errorf("inserting charm state: %w", err)
 	}
 
 	if err := tx.Query(ctx, hashStmt, hash).Run(); err != nil {
-		return fmt.Errorf("inserting charm hash: %w", err)
+		return errors.Errorf("inserting charm hash: %w", err)
 	}
 
 	return nil
@@ -239,7 +237,7 @@ func (s *State) setCharmDownloadInfo(ctx context.Context, tx *sqlair.TX, id core
 
 	provenance, err := encodeProvenance(downloadInfo.Provenance)
 	if err != nil {
-		return fmt.Errorf("encoding charm provenance: %w", err)
+		return errors.Errorf("encoding charm provenance: %w", err)
 	}
 
 	downloadInfoState := setCharmDownloadInfo{
@@ -253,11 +251,11 @@ func (s *State) setCharmDownloadInfo(ctx context.Context, tx *sqlair.TX, id core
 	query := `INSERT INTO charm_download_info (*) VALUES ($setCharmDownloadInfo.*);`
 	stmt, err := s.Prepare(query, downloadInfoState)
 	if err != nil {
-		return fmt.Errorf("preparing query: %w", err)
+		return errors.Errorf("preparing query: %w", err)
 	}
 
 	if err := tx.Query(ctx, stmt, downloadInfoState).Run(); err != nil {
-		return fmt.Errorf("inserting charm download info: %w", err)
+		return errors.Errorf("inserting charm download info: %w", err)
 	}
 
 	return nil
@@ -272,17 +270,17 @@ func (s *State) setCharmMetadata(
 ) error {
 	encodedMetadata, err := encodeMetadata(id, metadata, lxdProfile)
 	if err != nil {
-		return fmt.Errorf("encoding charm metadata: %w", err)
+		return errors.Errorf("encoding charm metadata: %w", err)
 	}
 
 	query := `INSERT INTO charm_metadata (*) VALUES ($setCharmMetadata.*);`
 	stmt, err := s.Prepare(query, encodedMetadata)
 	if err != nil {
-		return fmt.Errorf("preparing query: %w", err)
+		return errors.Errorf("preparing query: %w", err)
 	}
 
 	if err := tx.Query(ctx, stmt, encodedMetadata).Run(); err != nil {
-		return fmt.Errorf("inserting charm metadata: %w", err)
+		return errors.Errorf("inserting charm metadata: %w", err)
 	}
 
 	return nil
@@ -297,11 +295,11 @@ func (s *State) setCharmTags(ctx context.Context, tx *sqlair.TX, id corecharm.ID
 	query := `INSERT INTO charm_tag (*) VALUES ($setCharmTag.*);`
 	stmt, err := s.Prepare(query, setCharmTag{})
 	if err != nil {
-		return fmt.Errorf("preparing query: %w", err)
+		return errors.Errorf("preparing query: %w", err)
 	}
 
 	if err := tx.Query(ctx, stmt, encodeTags(id, tags)).Run(); err != nil {
-		return fmt.Errorf("inserting charm tag: %w", err)
+		return errors.Errorf("inserting charm tag: %w", err)
 	}
 
 	return nil
@@ -316,11 +314,11 @@ func (s *State) setCharmCategories(ctx context.Context, tx *sqlair.TX, id corech
 	query := `INSERT INTO charm_category (*) VALUES ($setCharmCategory.*);`
 	stmt, err := s.Prepare(query, setCharmCategory{})
 	if err != nil {
-		return fmt.Errorf("preparing query: %w", err)
+		return errors.Errorf("preparing query: %w", err)
 	}
 
 	if err := tx.Query(ctx, stmt, encodeCategories(id, categories)).Run(); err != nil {
-		return fmt.Errorf("inserting charm categories: %w", err)
+		return errors.Errorf("inserting charm categories: %w", err)
 	}
 
 	return nil
@@ -335,11 +333,11 @@ func (s *State) setCharmTerms(ctx context.Context, tx *sqlair.TX, id corecharm.I
 	query := `INSERT INTO charm_term (*) VALUES ($setCharmTerm.*);`
 	stmt, err := s.Prepare(query, setCharmTerm{})
 	if err != nil {
-		return fmt.Errorf("preparing query: %w", err)
+		return errors.Errorf("preparing query: %w", err)
 	}
 
 	if err := tx.Query(ctx, stmt, encodeTerms(id, terms)).Run(); err != nil {
-		return fmt.Errorf("inserting charm terms: %w", err)
+		return errors.Errorf("inserting charm terms: %w", err)
 	}
 
 	return nil
@@ -348,7 +346,7 @@ func (s *State) setCharmTerms(ctx context.Context, tx *sqlair.TX, id corecharm.I
 func (s *State) setCharmRelations(ctx context.Context, tx *sqlair.TX, id corecharm.ID, metadata charm.Metadata) error {
 	encodedRelations, err := encodeRelations(id, metadata)
 	if err != nil {
-		return fmt.Errorf("encoding charm relations: %w", err)
+		return errors.Errorf("encoding charm relations: %w", err)
 	}
 
 	// If there are no relations, we don't need to do anything.
@@ -359,13 +357,13 @@ func (s *State) setCharmRelations(ctx context.Context, tx *sqlair.TX, id corecha
 	query := `INSERT INTO charm_relation (*) VALUES ($setCharmRelation.*);`
 	stmt, err := s.Prepare(query, setCharmRelation{})
 	if err != nil {
-		return fmt.Errorf("preparing query: %w", err)
+		return errors.Errorf("preparing query: %w", err)
 	}
 
 	if err := tx.Query(ctx, stmt, encodedRelations).Run(); internaldatabase.IsErrConstraintUnique(err) {
 		return applicationerrors.CharmRelationNameConflict
 	} else if err != nil {
-		return fmt.Errorf("inserting charm relations: %w", err)
+		return errors.Errorf("inserting charm relations: %w", err)
 	}
 
 	return nil
@@ -380,11 +378,11 @@ func (s *State) setCharmExtraBindings(ctx context.Context, tx *sqlair.TX, id cor
 	query := `INSERT INTO charm_extra_binding (*) VALUES ($setCharmExtraBinding.*);`
 	stmt, err := s.Prepare(query, setCharmExtraBinding{})
 	if err != nil {
-		return fmt.Errorf("preparing query: %w", err)
+		return errors.Errorf("preparing query: %w", err)
 	}
 
 	if err := tx.Query(ctx, stmt, encodeExtraBindings(id, extraBindings)).Run(); err != nil {
-		return fmt.Errorf("inserting charm extra bindings: %w", err)
+		return errors.Errorf("inserting charm extra bindings: %w", err)
 	}
 
 	return nil
@@ -398,17 +396,17 @@ func (s *State) setCharmStorage(ctx context.Context, tx *sqlair.TX, id corecharm
 
 	encodedStorage, encodedProperties, err := encodeStorage(id, storage)
 	if err != nil {
-		return fmt.Errorf("encoding charm storage: %w", err)
+		return errors.Errorf("encoding charm storage: %w", err)
 	}
 
 	storageQuery := `INSERT INTO charm_storage (*) VALUES ($setCharmStorage.*);`
 	storageStmt, err := s.Prepare(storageQuery, setCharmStorage{})
 	if err != nil {
-		return fmt.Errorf("preparing query: %w", err)
+		return errors.Errorf("preparing query: %w", err)
 	}
 
 	if err := tx.Query(ctx, storageStmt, encodedStorage).Run(); err != nil {
-		return fmt.Errorf("inserting charm storage: %w", err)
+		return errors.Errorf("inserting charm storage: %w", err)
 	}
 
 	// Only insert properties if there are any.
@@ -416,11 +414,11 @@ func (s *State) setCharmStorage(ctx context.Context, tx *sqlair.TX, id corecharm
 		propertiesQuery := `INSERT INTO charm_storage_property (*) VALUES ($setCharmStorageProperty.*);`
 		propertiesStmt, err := s.Prepare(propertiesQuery, setCharmStorageProperty{})
 		if err != nil {
-			return fmt.Errorf("preparing query: %w", err)
+			return errors.Errorf("preparing query: %w", err)
 		}
 
 		if err := tx.Query(ctx, propertiesStmt, encodedProperties).Run(); err != nil {
-			return fmt.Errorf("inserting charm storage properties: %w", err)
+			return errors.Errorf("inserting charm storage properties: %w", err)
 		}
 	}
 	return nil
@@ -435,11 +433,11 @@ func (s *State) setCharmDevices(ctx context.Context, tx *sqlair.TX, id corecharm
 	query := `INSERT INTO charm_device (*) VALUES ($setCharmDevice.*);`
 	stmt, err := s.Prepare(query, setCharmDevice{})
 	if err != nil {
-		return fmt.Errorf("preparing query: %w", err)
+		return errors.Errorf("preparing query: %w", err)
 	}
 
 	if err := tx.Query(ctx, stmt, encodeDevices(id, devices)).Run(); err != nil {
-		return fmt.Errorf("inserting charm devices: %w", err)
+		return errors.Errorf("inserting charm devices: %w", err)
 	}
 
 	return nil
@@ -454,11 +452,11 @@ func (s *State) setCharmPayloads(ctx context.Context, tx *sqlair.TX, id corechar
 	query := `INSERT INTO charm_payload (*) VALUES ($setCharmPayload.*);`
 	stmt, err := s.Prepare(query, setCharmPayload{})
 	if err != nil {
-		return fmt.Errorf("preparing query: %w", err)
+		return errors.Errorf("preparing query: %w", err)
 	}
 
 	if err := tx.Query(ctx, stmt, encodePayloads(id, payloads)).Run(); err != nil {
-		return fmt.Errorf("inserting charm payloads: %w", err)
+		return errors.Errorf("inserting charm payloads: %w", err)
 	}
 
 	return nil
@@ -472,17 +470,17 @@ func (s *State) setCharmResources(ctx context.Context, tx *sqlair.TX, id corecha
 
 	encodedResources, err := encodeResources(id, resources)
 	if err != nil {
-		return fmt.Errorf("encoding charm resources: %w", err)
+		return errors.Errorf("encoding charm resources: %w", err)
 	}
 
 	query := `INSERT INTO charm_resource (*) VALUES ($setCharmResource.*);`
 	stmt, err := s.Prepare(query, setCharmResource{})
 	if err != nil {
-		return fmt.Errorf("preparing query: %w", err)
+		return errors.Errorf("preparing query: %w", err)
 	}
 
 	if err := tx.Query(ctx, stmt, encodedResources).Run(); err != nil {
-		return fmt.Errorf("inserting charm resources: %w", err)
+		return errors.Errorf("inserting charm resources: %w", err)
 	}
 
 	return nil
@@ -496,17 +494,17 @@ func (s *State) setCharmContainers(ctx context.Context, tx *sqlair.TX, id corech
 
 	encodedContainers, encodedMounts, err := encodeContainers(id, containers)
 	if err != nil {
-		return fmt.Errorf("encoding charm containers: %w", err)
+		return errors.Errorf("encoding charm containers: %w", err)
 	}
 
 	containerQuery := `INSERT INTO charm_container (*) VALUES ($setCharmContainer.*);`
 	containerStmt, err := s.Prepare(containerQuery, setCharmContainer{})
 	if err != nil {
-		return fmt.Errorf("preparing query: %w", err)
+		return errors.Errorf("preparing query: %w", err)
 	}
 
 	if err := tx.Query(ctx, containerStmt, encodedContainers).Run(); err != nil {
-		return fmt.Errorf("inserting charm containers: %w", err)
+		return errors.Errorf("inserting charm containers: %w", err)
 	}
 
 	// Only insert mounts if there are any.
@@ -514,11 +512,11 @@ func (s *State) setCharmContainers(ctx context.Context, tx *sqlair.TX, id corech
 		mountQuery := `INSERT INTO charm_container_mount (*) VALUES ($setCharmMount.*);`
 		mountStmt, err := s.Prepare(mountQuery, setCharmMount{})
 		if err != nil {
-			return fmt.Errorf("preparing query: %w", err)
+			return errors.Errorf("preparing query: %w", err)
 		}
 
 		if err := tx.Query(ctx, mountStmt, encodedMounts).Run(); err != nil {
-			return fmt.Errorf("inserting charm container mounts: %w", err)
+			return errors.Errorf("inserting charm container mounts: %w", err)
 		}
 	}
 
@@ -534,11 +532,11 @@ func (s *State) setCharmActions(ctx context.Context, tx *sqlair.TX, id corecharm
 	query := `INSERT INTO charm_action (*) VALUES ($setCharmAction.*);`
 	stmt, err := s.Prepare(query, setCharmAction{})
 	if err != nil {
-		return fmt.Errorf("preparing query: %w", err)
+		return errors.Errorf("preparing query: %w", err)
 	}
 
 	if err := tx.Query(ctx, stmt, encodeActions(id, actions)).Run(); err != nil {
-		return fmt.Errorf("inserting charm actions: %w", err)
+		return errors.Errorf("inserting charm actions: %w", err)
 	}
 
 	return nil
@@ -552,17 +550,17 @@ func (s *State) setCharmConfig(ctx context.Context, tx *sqlair.TX, id corecharm.
 
 	encodedConfig, err := encodeConfig(id, config)
 	if err != nil {
-		return fmt.Errorf("encoding charm config: %w", err)
+		return errors.Errorf("encoding charm config: %w", err)
 	}
 
 	query := `INSERT INTO charm_config (*) VALUES ($setCharmConfig.*);`
 	stmt, err := s.Prepare(query, setCharmConfig{})
 	if err != nil {
-		return fmt.Errorf("preparing query: %w", err)
+		return errors.Errorf("preparing query: %w", err)
 	}
 
 	if err := tx.Query(ctx, stmt, encodedConfig).Run(); err != nil {
-		return fmt.Errorf("inserting charm config: %w", err)
+		return errors.Errorf("inserting charm config: %w", err)
 	}
 
 	return nil
@@ -575,17 +573,17 @@ func (s *State) setCharmManifest(ctx context.Context, tx *sqlair.TX, id corechar
 
 	encodedManifest, err := encodeManifest(id, manifest)
 	if err != nil {
-		return fmt.Errorf("encoding charm manifest: %w", err)
+		return errors.Errorf("encoding charm manifest: %w", err)
 	}
 
 	query := `INSERT INTO charm_manifest_base (*) VALUES ($setCharmManifest.*);`
 	stmt, err := s.Prepare(query, setCharmManifest{})
 	if err != nil {
-		return fmt.Errorf("preparing query: %w", err)
+		return errors.Errorf("preparing query: %w", err)
 	}
 
 	if err := tx.Query(ctx, stmt, encodedManifest).Run(); err != nil {
-		return fmt.Errorf("inserting charm manifest: %w", err)
+		return errors.Errorf("inserting charm manifest: %w", err)
 	}
 
 	return nil
@@ -597,34 +595,34 @@ func (s *State) setCharmManifest(ctx context.Context, tx *sqlair.TX, id corechar
 func (s *State) getCharm(ctx context.Context, tx *sqlair.TX, ident charmID) (charm.Charm, *charm.DownloadInfo, error) {
 	ch, err := s.getCharmState(ctx, tx, ident)
 	if err != nil {
-		return ch, nil, errors.Trace(err)
+		return ch, nil, errors.Capture(err)
 	}
 
 	if ch.Metadata, err = s.getMetadata(ctx, tx, ident); err != nil {
-		return ch, nil, errors.Trace(err)
+		return ch, nil, errors.Capture(err)
 	}
 
 	if ch.Config, err = s.getCharmConfig(ctx, tx, ident); err != nil {
-		return ch, nil, errors.Trace(err)
+		return ch, nil, errors.Capture(err)
 	}
 
 	if ch.Manifest, err = s.getCharmManifest(ctx, tx, ident); err != nil {
-		return ch, nil, errors.Trace(err)
+		return ch, nil, errors.Capture(err)
 	}
 
 	if ch.Actions, err = s.getCharmActions(ctx, tx, ident); err != nil {
-		return ch, nil, errors.Trace(err)
+		return ch, nil, errors.Capture(err)
 	}
 
 	if ch.LXDProfile, _, err = s.getCharmLXDProfile(ctx, tx, ident); err != nil {
-		return ch, nil, errors.Trace(err)
+		return ch, nil, errors.Capture(err)
 	}
 
 	// Download information should only be recorded for charmhub charms.
 	// If it's not present, ensure we report it as not found.
 	var downloadInfo *charm.DownloadInfo
 	if info, err := s.getCharmDownloadInfo(ctx, tx, ident); err != nil && !errors.Is(err, sql.ErrNoRows) {
-		return ch, nil, errors.Trace(err)
+		return ch, nil, errors.Capture(err)
 	} else if err == nil {
 		downloadInfo = &info
 	} else if ch.Source == charm.CharmHubSource {
@@ -642,7 +640,7 @@ WHERE uuid = $charmID.uuid;
 
 	charmStmt, err := s.Prepare(charmQuery, charmState{}, ident)
 	if err != nil {
-		return charm.Charm{}, fmt.Errorf("preparing query: %w", err)
+		return charm.Charm{}, errors.Errorf("preparing query: %w", err)
 	}
 
 	hashQuery := `
@@ -652,7 +650,7 @@ WHERE charm_uuid = $charmID.uuid;
 `
 	hashStmt, err := s.Prepare(hashQuery, charmHash{}, ident)
 	if err != nil {
-		return charm.Charm{}, fmt.Errorf("preparing hash query: %w", err)
+		return charm.Charm{}, errors.Errorf("preparing hash query: %w", err)
 	}
 
 	var charmState charmState
@@ -660,7 +658,7 @@ WHERE charm_uuid = $charmID.uuid;
 		if errors.Is(err, sqlair.ErrNoRows) {
 			return charm.Charm{}, applicationerrors.CharmNotFound
 		}
-		return charm.Charm{}, fmt.Errorf("getting charm state: %w", err)
+		return charm.Charm{}, errors.Errorf("getting charm state: %w", err)
 	}
 
 	var hash charmHash
@@ -668,12 +666,12 @@ WHERE charm_uuid = $charmID.uuid;
 		if errors.Is(err, sqlair.ErrNoRows) {
 			return charm.Charm{}, applicationerrors.CharmNotFound
 		}
-		return charm.Charm{}, fmt.Errorf("getting charm hash: %w", err)
+		return charm.Charm{}, errors.Errorf("getting charm hash: %w", err)
 	}
 
 	result, err := decodeCharmState(charmState)
 	if err != nil {
-		return charm.Charm{}, fmt.Errorf("decoding charm state: %w", err)
+		return charm.Charm{}, errors.Errorf("decoding charm state: %w", err)
 	}
 
 	result.Hash = hash.Hash
@@ -693,17 +691,17 @@ AND c.source_id = 1;
 
 	stmt, err := s.Prepare(query, charmDownloadInfo{}, ident)
 	if err != nil {
-		return charm.DownloadInfo{}, fmt.Errorf("preparing query: %w", err)
+		return charm.DownloadInfo{}, errors.Errorf("preparing query: %w", err)
 	}
 
 	var downloadInfo charmDownloadInfo
 	if err := tx.Query(ctx, stmt, ident).Get(&downloadInfo); err != nil {
-		return charm.DownloadInfo{}, fmt.Errorf("getting charm download info: %w", err)
+		return charm.DownloadInfo{}, errors.Errorf("getting charm download info: %w", err)
 	}
 
 	provenance, err := decodeProvenance(downloadInfo.Provenance)
 	if err != nil {
-		return charm.DownloadInfo{}, fmt.Errorf("decoding charm provenance: %w", err)
+		return charm.DownloadInfo{}, errors.Errorf("decoding charm provenance: %w", err)
 	}
 
 	return charm.DownloadInfo{
@@ -745,47 +743,47 @@ func (s *State) getMetadata(ctx context.Context, tx *sqlair.TX, ident charmID) (
 
 	var err error
 	if metadata, err = s.getCharmMetadata(ctx, tx, ident); err != nil {
-		return charm.Metadata{}, errors.Trace(err)
+		return charm.Metadata{}, errors.Capture(err)
 	}
 
 	if tags, err = s.getCharmTags(ctx, tx, ident); err != nil {
-		return charm.Metadata{}, errors.Trace(err)
+		return charm.Metadata{}, errors.Capture(err)
 	}
 
 	if categories, err = s.getCharmCategories(ctx, tx, ident); err != nil {
-		return charm.Metadata{}, errors.Trace(err)
+		return charm.Metadata{}, errors.Capture(err)
 	}
 
 	if terms, err = s.getCharmTerms(ctx, tx, ident); err != nil {
-		return charm.Metadata{}, errors.Trace(err)
+		return charm.Metadata{}, errors.Capture(err)
 	}
 
 	if relations, err = s.getCharmRelations(ctx, tx, ident); err != nil {
-		return charm.Metadata{}, errors.Trace(err)
+		return charm.Metadata{}, errors.Capture(err)
 	}
 
 	if extraBindings, err = s.getCharmExtraBindings(ctx, tx, ident); err != nil {
-		return charm.Metadata{}, errors.Trace(err)
+		return charm.Metadata{}, errors.Capture(err)
 	}
 
 	if storage, err = s.getCharmStorage(ctx, tx, ident); err != nil {
-		return charm.Metadata{}, errors.Trace(err)
+		return charm.Metadata{}, errors.Capture(err)
 	}
 
 	if devices, err = s.getCharmDevices(ctx, tx, ident); err != nil {
-		return charm.Metadata{}, errors.Trace(err)
+		return charm.Metadata{}, errors.Capture(err)
 	}
 
 	if payloads, err = s.getCharmPayloads(ctx, tx, ident); err != nil {
-		return charm.Metadata{}, errors.Trace(err)
+		return charm.Metadata{}, errors.Capture(err)
 	}
 
 	if resources, err = s.getCharmResources(ctx, tx, ident); err != nil {
-		return charm.Metadata{}, errors.Trace(err)
+		return charm.Metadata{}, errors.Capture(err)
 	}
 
 	if containers, err = s.getCharmContainers(ctx, tx, ident); err != nil {
-		return charm.Metadata{}, errors.Trace(err)
+		return charm.Metadata{}, errors.Capture(err)
 	}
 
 	return decodeMetadata(metadata, decodeMetadataArgs{
@@ -817,7 +815,7 @@ ORDER BY array_index ASC, nested_array_index ASC;
 
 	stmt, err := s.Prepare(query, charmManifest{}, ident)
 	if err != nil {
-		return charm.Manifest{}, fmt.Errorf("preparing query: %w", err)
+		return charm.Manifest{}, errors.Errorf("preparing query: %w", err)
 	}
 
 	var manifests []charmManifest
@@ -825,7 +823,7 @@ ORDER BY array_index ASC, nested_array_index ASC;
 		if errors.Is(err, sqlair.ErrNoRows) {
 			return charm.Manifest{}, applicationerrors.CharmNotFound
 		}
-		return charm.Manifest{}, fmt.Errorf("getting charm manifest: %w", err)
+		return charm.Manifest{}, errors.Errorf("failed to get charm manifest: %w", err)
 	}
 
 	return decodeManifest(manifests)
@@ -853,26 +851,26 @@ WHERE uuid = $charmID.uuid;
 
 	charmStmt, err := s.Prepare(charmQuery, ident)
 	if err != nil {
-		return nil, -1, fmt.Errorf("preparing charm query: %w", err)
+		return nil, -1, errors.Errorf("failed to prepare charm query: %w", err)
 	}
 	var profile charmLXDProfile
 	lxdProfileStmt, err := s.Prepare(lxdProfileQuery, profile, ident)
 	if err != nil {
-		return nil, -1, fmt.Errorf("preparing lxd profile query: %w", err)
+		return nil, -1, errors.Errorf("preparing lxd profile query: %w", err)
 	}
 
 	if err := tx.Query(ctx, charmStmt, ident).Get(&ident); err != nil {
 		if errors.Is(err, sqlair.ErrNoRows) {
 			return nil, -1, applicationerrors.CharmNotFound
 		}
-		return nil, -1, fmt.Errorf("getting charm: %w", err)
+		return nil, -1, errors.Errorf("getting charm: %w", err)
 	}
 
 	if err := tx.Query(ctx, lxdProfileStmt, ident).Get(&profile); err != nil {
 		if errors.Is(err, sqlair.ErrNoRows) {
 			return nil, -1, applicationerrors.LXDProfileNotFound
 		}
-		return nil, -1, fmt.Errorf("getting charm lxd profile: %w", err)
+		return nil, -1, errors.Errorf("getting charm lxd profile: %w", err)
 	}
 
 	// TODO - figure out why this is happening
@@ -903,18 +901,18 @@ WHERE charm_uuid = $charmID.uuid;
 
 	charmStmt, err := s.Prepare(charmQuery, ident)
 	if err != nil {
-		return charm.Config{}, fmt.Errorf("preparing charm query: %w", err)
+		return charm.Config{}, errors.Errorf("preparing charm query: %w", err)
 	}
 	configStmt, err := s.Prepare(configQuery, charmConfig{}, ident)
 	if err != nil {
-		return charm.Config{}, fmt.Errorf("preparing config query: %w", err)
+		return charm.Config{}, errors.Errorf("preparing config query: %w", err)
 	}
 
 	if err := tx.Query(ctx, charmStmt, ident).Get(&ident); err != nil {
 		if errors.Is(err, sqlair.ErrNoRows) {
 			return charm.Config{}, applicationerrors.CharmNotFound
 		}
-		return charm.Config{}, fmt.Errorf("getting charm: %w", err)
+		return charm.Config{}, errors.Errorf("getting charm: %w", err)
 	}
 
 	var configs []charmConfig
@@ -922,7 +920,7 @@ WHERE charm_uuid = $charmID.uuid;
 		if errors.Is(err, sqlair.ErrNoRows) {
 			return charm.Config{}, nil
 		}
-		return charm.Config{}, fmt.Errorf("getting charm config: %w", err)
+		return charm.Config{}, errors.Errorf("getting charm config: %w", err)
 	}
 
 	return decodeConfig(configs)
@@ -947,18 +945,18 @@ WHERE charm_uuid = $charmID.uuid;
 
 	charmStmt, err := s.Prepare(charmQuery, ident)
 	if err != nil {
-		return charm.Actions{}, fmt.Errorf("preparing charm query: %w", err)
+		return charm.Actions{}, errors.Errorf("preparing charm query: %w", err)
 	}
 	actionsStmt, err := s.Prepare(actionQuery, charmAction{}, ident)
 	if err != nil {
-		return charm.Actions{}, fmt.Errorf("preparing action query: %w", err)
+		return charm.Actions{}, errors.Errorf("preparing action query: %w", err)
 	}
 
 	if err := tx.Query(ctx, charmStmt, ident).Get(&ident); err != nil {
 		if errors.Is(err, sqlair.ErrNoRows) {
 			return charm.Actions{}, applicationerrors.CharmNotFound
 		}
-		return charm.Actions{}, fmt.Errorf("getting charm: %w", err)
+		return charm.Actions{}, errors.Errorf("getting charm: %w", err)
 	}
 
 	var actions []charmAction
@@ -966,7 +964,7 @@ WHERE charm_uuid = $charmID.uuid;
 		if errors.Is(err, sqlair.ErrNoRows) {
 			return charm.Actions{}, nil
 		}
-		return charm.Actions{}, fmt.Errorf("getting charm actions: %w", err)
+		return charm.Actions{}, errors.Errorf("getting charm actions: %w", err)
 	}
 
 	return decodeActions(actions), nil
@@ -983,14 +981,14 @@ WHERE uuid = $charmID.uuid;
 	var metadata charmMetadata
 	stmt, err := s.Prepare(query, metadata, ident)
 	if err != nil {
-		return metadata, fmt.Errorf("preparing query: %w", err)
+		return metadata, errors.Errorf("preparing query: %w", err)
 	}
 
 	if err := tx.Query(ctx, stmt, ident).Get(&metadata); err != nil {
 		if errors.Is(err, sqlair.ErrNoRows) {
 			return metadata, applicationerrors.CharmNotFound
 		}
-		return metadata, fmt.Errorf("failed to select charm metadata: %w", err)
+		return metadata, errors.Errorf("failed to select charm metadata: %w", err)
 	}
 
 	return metadata, nil
@@ -1012,7 +1010,7 @@ ORDER BY array_index ASC;
 `
 	stmt, err := s.Prepare(query, charmTag{}, ident)
 	if err != nil {
-		return nil, fmt.Errorf("preparing query: %w", err)
+		return nil, errors.Errorf("preparing query: %w", err)
 	}
 
 	var result []charmTag
@@ -1020,7 +1018,7 @@ ORDER BY array_index ASC;
 		if errors.Is(err, sqlair.ErrNoRows) {
 			return result, nil
 		}
-		return nil, fmt.Errorf("failed to select charm tags: %w", err)
+		return nil, errors.Errorf("failed to select charm tags: %w", err)
 	}
 
 	return result, nil
@@ -1042,7 +1040,7 @@ ORDER BY array_index ASC;
 `
 	stmt, err := s.Prepare(query, charmCategory{}, ident)
 	if err != nil {
-		return nil, fmt.Errorf("preparing query: %w", err)
+		return nil, errors.Errorf("preparing query: %w", err)
 	}
 
 	var result []charmCategory
@@ -1050,7 +1048,7 @@ ORDER BY array_index ASC;
 		if errors.Is(err, sqlair.ErrNoRows) {
 			return result, nil
 		}
-		return nil, fmt.Errorf("failed to select charm categories: %w", err)
+		return nil, errors.Errorf("failed to select charm categories: %w", err)
 	}
 
 	return result, nil
@@ -1072,7 +1070,7 @@ ORDER BY array_index ASC;
 `
 	stmt, err := s.Prepare(query, charmTerm{}, ident)
 	if err != nil {
-		return nil, fmt.Errorf("preparing query: %w", err)
+		return nil, errors.Errorf("preparing query: %w", err)
 	}
 
 	var result []charmTerm
@@ -1080,7 +1078,7 @@ ORDER BY array_index ASC;
 		if errors.Is(err, sqlair.ErrNoRows) {
 			return result, nil
 		}
-		return nil, fmt.Errorf("failed to select charm terms: %w", err)
+		return nil, errors.Errorf("failed to select charm terms: %w", err)
 	}
 
 	return result, nil
@@ -1099,7 +1097,7 @@ WHERE charm_uuid = $charmID.uuid;
 	`
 	stmt, err := s.Prepare(query, charmRelation{}, ident)
 	if err != nil {
-		return nil, fmt.Errorf("preparing query: %w", err)
+		return nil, errors.Errorf("preparing query: %w", err)
 	}
 
 	var result []charmRelation
@@ -1107,7 +1105,7 @@ WHERE charm_uuid = $charmID.uuid;
 		if errors.Is(err, sqlair.ErrNoRows) {
 			return result, nil
 		}
-		return nil, fmt.Errorf("failed to select charm relations: %w", err)
+		return nil, errors.Errorf("failed to select charm relations: %w", err)
 	}
 
 	return result, nil
@@ -1128,7 +1126,7 @@ WHERE charm_uuid = $charmID.uuid;
 
 	stmt, err := s.Prepare(query, charmExtraBinding{}, ident)
 	if err != nil {
-		return nil, fmt.Errorf("preparing query: %w", err)
+		return nil, errors.Errorf("preparing query: %w", err)
 	}
 
 	var result []charmExtraBinding
@@ -1136,7 +1134,7 @@ WHERE charm_uuid = $charmID.uuid;
 		if errors.Is(err, sqlair.ErrNoRows) {
 			return result, nil
 		}
-		return nil, fmt.Errorf("failed to select charm extra bindings: %w", err)
+		return nil, errors.Errorf("failed to select charm extra bindings: %w", err)
 	}
 
 	return result, nil
@@ -1156,7 +1154,7 @@ ORDER BY property_index ASC;
 
 	stmt, err := s.Prepare(query, charmStorage{}, ident)
 	if err != nil {
-		return nil, fmt.Errorf("preparing query: %w", err)
+		return nil, errors.Errorf("preparing query: %w", err)
 	}
 
 	var result []charmStorage
@@ -1164,7 +1162,7 @@ ORDER BY property_index ASC;
 		if errors.Is(err, sqlair.ErrNoRows) {
 			return result, nil
 		}
-		return nil, fmt.Errorf("failed to select charm storage: %w", err)
+		return nil, errors.Errorf("failed to select charm storage: %w", err)
 	}
 
 	return result, nil
@@ -1182,7 +1180,7 @@ WHERE charm_uuid = $charmID.uuid;
 
 	stmt, err := s.Prepare(query, charmDevice{}, ident)
 	if err != nil {
-		return nil, fmt.Errorf("preparing query: %w", err)
+		return nil, errors.Errorf("preparing query: %w", err)
 	}
 
 	var result []charmDevice
@@ -1190,7 +1188,7 @@ WHERE charm_uuid = $charmID.uuid;
 		if errors.Is(err, sqlair.ErrNoRows) {
 			return result, nil
 		}
-		return nil, fmt.Errorf("failed to select charm device: %w", err)
+		return nil, errors.Errorf("failed to select charm device: %w", err)
 	}
 
 	return result, nil
@@ -1208,7 +1206,7 @@ WHERE charm_uuid = $charmID.uuid;
 
 	stmt, err := s.Prepare(query, charmPayload{}, ident)
 	if err != nil {
-		return nil, fmt.Errorf("preparing query: %w", err)
+		return nil, errors.Errorf("preparing query: %w", err)
 	}
 
 	var result []charmPayload
@@ -1216,7 +1214,7 @@ WHERE charm_uuid = $charmID.uuid;
 		if errors.Is(err, sqlair.ErrNoRows) {
 			return result, nil
 		}
-		return nil, fmt.Errorf("failed to select charm payload: %w", err)
+		return nil, errors.Errorf("failed to select charm payload: %w", err)
 	}
 
 	return result, nil
@@ -1234,7 +1232,7 @@ WHERE charm_uuid = $charmID.uuid;
 
 	stmt, err := s.Prepare(query, charmResource{}, ident)
 	if err != nil {
-		return nil, fmt.Errorf("preparing query: %w", err)
+		return nil, errors.Errorf("preparing query: %w", err)
 	}
 
 	var result []charmResource
@@ -1242,7 +1240,7 @@ WHERE charm_uuid = $charmID.uuid;
 		if errors.Is(err, sqlair.ErrNoRows) {
 			return result, nil
 		}
-		return nil, fmt.Errorf("failed to select charm payload: %w", err)
+		return nil, errors.Errorf("failed to select charm payload: %w", err)
 	}
 
 	return result, nil
@@ -1261,7 +1259,7 @@ ORDER BY array_index ASC;
 
 	stmt, err := s.Prepare(query, charmContainer{}, ident)
 	if err != nil {
-		return nil, fmt.Errorf("preparing query: %w", err)
+		return nil, errors.Errorf("preparing query: %w", err)
 	}
 
 	var result []charmContainer
@@ -1269,7 +1267,7 @@ ORDER BY array_index ASC;
 		if errors.Is(err, sqlair.ErrNoRows) {
 			return result, nil
 		}
-		return nil, fmt.Errorf("failed to select charm container: %w", err)
+		return nil, errors.Errorf("failed to select charm container: %w", err)
 	}
 
 	return result, nil
@@ -1315,7 +1313,7 @@ func decodeArchitecture(arch sql.NullInt64) (application.Architecture, error) {
 	case 4:
 		return architecture.RISV64, nil
 	default:
-		return -1, fmt.Errorf("unsupported architecture: %d", arch.Int64)
+		return -1, errors.Errorf("unsupported architecture: %d", arch.Int64)
 	}
 }
 
@@ -1326,7 +1324,7 @@ func decodeCharmSource(source int) (charm.CharmSource, error) {
 	case 0:
 		return charm.LocalSource, nil
 	default:
-		return "", fmt.Errorf("unsupported charm source: %d", source)
+		return "", errors.Errorf("unsupported charm source: %d", source)
 	}
 }
 
@@ -1388,6 +1386,6 @@ func decodeProvenance(provenance string) (charm.Provenance, error) {
 	case "bootstrap":
 		return charm.ProvenanceBootstrap, nil
 	default:
-		return "", fmt.Errorf("unknown provenance: %s", provenance)
+		return "", errors.Errorf("unknown provenance: %s", provenance)
 	}
 }

--- a/domain/application/watcher_test.go
+++ b/domain/application/watcher_test.go
@@ -8,7 +8,6 @@ import (
 	"database/sql"
 
 	"github.com/juju/clock"
-	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -28,6 +27,7 @@ import (
 	secretstate "github.com/juju/juju/domain/secret/state"
 	changestreamtesting "github.com/juju/juju/internal/changestream/testing"
 	internalcharm "github.com/juju/juju/internal/charm"
+	"github.com/juju/juju/internal/errors"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 	"github.com/juju/juju/internal/storage"
 	"github.com/juju/juju/internal/storage/provider"
@@ -134,13 +134,13 @@ func (s *watcherSuite) TestWatchUnitLife(c *gc.C) {
 
 		err = s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 			if err := tx.QueryRowContext(ctx, "SELECT uuid FROM unit WHERE name=?", "foo/666").Scan(&unitID1); err != nil {
-				return errors.Trace(err)
+				return errors.Capture(err)
 			}
 			if err := tx.QueryRowContext(ctx, "SELECT uuid FROM unit WHERE name=?", "foo/667").Scan(&unitID2); err != nil {
-				return errors.Trace(err)
+				return errors.Capture(err)
 			}
 			if err := tx.QueryRowContext(ctx, "SELECT uuid FROM unit WHERE name=?", "bar/667").Scan(&unitID3); err != nil {
-				return errors.Trace(err)
+				return errors.Capture(err)
 			}
 			return nil
 		})
@@ -156,7 +156,7 @@ func (s *watcherSuite) TestWatchUnitLife(c *gc.C) {
 		// Update non app unit first up.
 		err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 			if _, err := tx.ExecContext(ctx, "UPDATE unit SET life_id = 1 WHERE name=?", "bar/668"); err != nil {
-				return errors.Trace(err)
+				return errors.Capture(err)
 			}
 			return nil
 		})
@@ -170,7 +170,7 @@ func (s *watcherSuite) TestWatchUnitLife(c *gc.C) {
 	harness.AddTest(func(c *gc.C) {
 		err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 			if _, err := tx.ExecContext(ctx, "UPDATE unit SET life_id = 1 WHERE name=?", "foo/666"); err != nil {
-				return errors.Trace(err)
+				return errors.Capture(err)
 			}
 			return nil
 		})
@@ -183,7 +183,7 @@ func (s *watcherSuite) TestWatchUnitLife(c *gc.C) {
 	harness.AddTest(func(c *gc.C) {
 		err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 			if _, err := tx.ExecContext(ctx, "UPDATE unit SET life_id = 2 WHERE name=?", "foo/666"); err != nil {
-				return errors.Trace(err)
+				return errors.Capture(err)
 			}
 			return nil
 		})
@@ -197,13 +197,13 @@ func (s *watcherSuite) TestWatchUnitLife(c *gc.C) {
 		// Removing dead unit, no change.
 		err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 			if _, err := tx.ExecContext(ctx, "DELETE FROM unit_agent_status WHERE unit_uuid=?", unitID1); err != nil {
-				return errors.Trace(err)
+				return errors.Capture(err)
 			}
 			if _, err := tx.ExecContext(ctx, "DELETE FROM unit_workload_status WHERE unit_uuid=?", unitID1); err != nil {
-				return errors.Trace(err)
+				return errors.Capture(err)
 			}
 			if _, err := tx.ExecContext(ctx, "DELETE FROM unit WHERE name=?", "foo/666"); err != nil {
-				return errors.Trace(err)
+				return errors.Capture(err)
 			}
 			return nil
 		})
@@ -215,7 +215,7 @@ func (s *watcherSuite) TestWatchUnitLife(c *gc.C) {
 		// Updating different app unit with > 0 app units remaining - no change.
 		err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 			if _, err := tx.ExecContext(ctx, "UPDATE unit SET life_id = 1 WHERE name=?", "bar/667"); err != nil {
-				return errors.Trace(err)
+				return errors.Capture(err)
 			}
 			return nil
 		})
@@ -227,7 +227,7 @@ func (s *watcherSuite) TestWatchUnitLife(c *gc.C) {
 		// Removing non app unit - no change.
 		err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 			if _, err := tx.ExecContext(ctx, "UPDATE unit SET life_id = 1 WHERE name=?", "bar/666"); err != nil {
-				return errors.Trace(err)
+				return errors.Capture(err)
 			}
 			return nil
 		})
@@ -239,13 +239,13 @@ func (s *watcherSuite) TestWatchUnitLife(c *gc.C) {
 		// Removing non dead unit - change.
 		err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 			if _, err := tx.ExecContext(ctx, "DELETE FROM unit_agent_status WHERE unit_uuid=?", unitID2); err != nil {
-				return errors.Trace(err)
+				return errors.Capture(err)
 			}
 			if _, err := tx.ExecContext(ctx, "DELETE FROM unit_workload_status WHERE unit_uuid=?", unitID2); err != nil {
-				return errors.Trace(err)
+				return errors.Capture(err)
 			}
 			if _, err := tx.ExecContext(ctx, "DELETE FROM unit WHERE name=?", "foo/667"); err != nil {
-				return errors.Trace(err)
+				return errors.Capture(err)
 			}
 			return nil
 		})
@@ -259,7 +259,7 @@ func (s *watcherSuite) TestWatchUnitLife(c *gc.C) {
 		// Updating different app unit with no app units remaining - no change.
 		err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 			if _, err := tx.ExecContext(ctx, "UPDATE unit SET life_id = 1 WHERE name=?", "bar/667"); err != nil {
-				return errors.Trace(err)
+				return errors.Capture(err)
 			}
 			return nil
 		})
@@ -271,13 +271,13 @@ func (s *watcherSuite) TestWatchUnitLife(c *gc.C) {
 		// Deleting different app unit with no app units remaining - no change.
 		err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 			if _, err := tx.ExecContext(ctx, "DELETE FROM unit_agent_status WHERE unit_uuid=?", unitID3); err != nil {
-				return errors.Trace(err)
+				return errors.Capture(err)
 			}
 			if _, err := tx.ExecContext(ctx, "DELETE FROM unit_workload_status WHERE unit_uuid=?", unitID3); err != nil {
-				return errors.Trace(err)
+				return errors.Capture(err)
 			}
 			if _, err := tx.ExecContext(ctx, "DELETE FROM unit WHERE name=?", "bar/667"); err != nil {
-				return errors.Trace(err)
+				return errors.Capture(err)
 			}
 			return nil
 		})
@@ -309,10 +309,10 @@ func (s *watcherSuite) TestWatchUnitLifeInitial(c *gc.C) {
 
 		err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 			if err := tx.QueryRowContext(ctx, "SELECT uuid FROM unit WHERE name=?", "foo/666").Scan(&unitID1); err != nil {
-				return errors.Trace(err)
+				return errors.Capture(err)
 			}
 			if err := tx.QueryRowContext(ctx, "SELECT uuid FROM unit WHERE name=?", "foo/667").Scan(&unitID2); err != nil {
-				return errors.Trace(err)
+				return errors.Capture(err)
 			}
 			return nil
 		})

--- a/domain/autocert/errors/errors.go
+++ b/domain/autocert/errors/errors.go
@@ -3,9 +3,7 @@
 
 package errors
 
-import (
-	"github.com/juju/errors"
-)
+import "github.com/juju/juju/internal/errors"
 
 const (
 	// NotFound describes an error that occurs when a cert cannot be found.

--- a/domain/autocert/service/service.go
+++ b/domain/autocert/service/service.go
@@ -6,10 +6,11 @@ package service
 import (
 	"context"
 
-	"github.com/juju/errors"
 	"golang.org/x/crypto/acme/autocert"
 
+	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/logger"
+	"github.com/juju/juju/internal/errors"
 )
 
 // State describes retrieval and persistence methods for storage.
@@ -49,7 +50,7 @@ func (s *Service) Put(ctx context.Context, name string, data []byte) error {
 func (s *Service) Get(ctx context.Context, name string) ([]byte, error) {
 	s.logger.Tracef("retrieving autocert %s from the autocert cache", name)
 	cert, err := s.st.Get(ctx, name)
-	if errors.Is(err, errors.NotFound) {
+	if errors.Is(err, coreerrors.NotFound) {
 		return nil, autocert.ErrCacheMiss
 	}
 	return cert, err

--- a/domain/autocert/service/service_test.go
+++ b/domain/autocert/service/service_test.go
@@ -6,13 +6,14 @@ package service
 import (
 	"context"
 
-	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gomock "go.uber.org/mock/gomock"
 	"golang.org/x/crypto/acme/autocert"
 	gc "gopkg.in/check.v1"
 
+	coreerrors "github.com/juju/juju/core/errors"
+	"github.com/juju/juju/internal/errors"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 )
 
@@ -36,7 +37,7 @@ func (s *serviceSuite) TestCheckCacheMiss(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	certName := "test-cert-name"
-	s.state.EXPECT().Get(gomock.Any(), certName).Return(nil, errors.Annotatef(errors.NotFound, "autocert %s", certName))
+	s.state.EXPECT().Get(gomock.Any(), certName).Return(nil, errors.Errorf("autocert %s %w", certName, coreerrors.NotFound))
 
 	svc := NewService(s.state, loggertesting.WrapCheckLog(c))
 

--- a/domain/autocert/state/state.go
+++ b/domain/autocert/state/state.go
@@ -8,11 +8,11 @@ import (
 	"database/sql"
 
 	"github.com/canonical/sqlair"
-	"github.com/juju/errors"
 
 	coreDB "github.com/juju/juju/core/database"
 	"github.com/juju/juju/domain"
 	autocerterrors "github.com/juju/juju/domain/autocert/errors"
+	"github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/internal/uuid"
 )
 
@@ -32,12 +32,12 @@ func NewState(factory coreDB.TxnRunnerFactory) *State {
 func (st *State) Put(ctx context.Context, name string, data []byte) error {
 	db, err := st.DB()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	uuid, err := uuid.NewUUID()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	autocert := dbAutocert{
@@ -52,23 +52,23 @@ INSERT INTO autocert_cache (*)
 VALUES ($dbAutocert.*)
   ON CONFLICT(name) DO UPDATE SET data=excluded.data`, autocert)
 	if err != nil {
-		return errors.Annotatef(err, "preparing insert autocert into cache")
+		return errors.Errorf("preparing insert autocert into cache %w", err)
 	}
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		if err := tx.Query(ctx, q, autocert).Run(); err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		return nil
 	})
-	return errors.Trace(err)
+	return errors.Capture(err)
 }
 
 // Get implements autocert.Cache.Get.
 func (st *State) Get(ctx context.Context, name string) ([]byte, error) {
 	db, err := st.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	autocert := dbAutocert{Name: name}
@@ -79,18 +79,18 @@ FROM   autocert_cache
 WHERE  name = $dbAutocert.name`
 	s, err := st.Prepare(q, autocert)
 	if err != nil {
-		return nil, errors.Annotatef(err, "preparing autocert select statement")
+		return nil, errors.Errorf("preparing autocert select statement %w", err)
 	}
 
 	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err := tx.Query(ctx, s, autocert).Get(&autocert)
 		if errors.Is(err, sql.ErrNoRows) {
-			return errors.Annotatef(autocerterrors.NotFound, "autocert %s", name)
+			return errors.Errorf("autocert %s %w", name, autocerterrors.NotFound)
 		}
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}); err != nil {
 
-		return nil, errors.Annotate(err, "querying autocert cache")
+		return nil, errors.Errorf("querying autocert cache %w", err)
 	}
 
 	return []byte(autocert.Data), nil
@@ -100,7 +100,7 @@ WHERE  name = $dbAutocert.name`
 func (st *State) Delete(ctx context.Context, name string) error {
 	db, err := st.DB()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	autocert := dbAutocert{Name: name}
@@ -111,28 +111,28 @@ FROM   autocert_cache
 WHERE  name = $dbAutocert.name`
 	s, err := st.Prepare(q, autocert)
 	if err != nil {
-		return errors.Annotatef(err, "preparing autocert select statement")
+		return errors.Errorf("preparing autocert select statement %w", err)
 	}
 
 	stmt, err := st.Prepare(`DELETE FROM autocert_cache WHERE name = $dbAutocert.name`, autocert)
 	if err != nil {
-		return errors.Annotatef(err, "preparing autocert cache delete statement")
+		return errors.Errorf("preparing autocert cache delete statement %w", err)
 	}
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		// First check if the autocert exists.
 		err := tx.Query(ctx, s, autocert).Get(&autocert)
 		if errors.Is(err, sqlair.ErrNoRows) {
-			return errors.Annotatef(autocerterrors.NotFound, "autocert %s", name)
+			return errors.Errorf("autocert %s %w", name, autocerterrors.NotFound)
 		} else if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		if err := tx.Query(ctx, stmt, autocert).Run(); err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		return nil
 	})
 
-	return errors.Trace(err)
+	return errors.Capture(err)
 }

--- a/domain/blockcommand/errors/errors.go
+++ b/domain/blockcommand/errors/errors.go
@@ -3,9 +3,7 @@
 
 package errors
 
-import (
-	"github.com/juju/juju/internal/errors"
-)
+import "github.com/juju/juju/internal/errors"
 
 const (
 	// NotFound describes an error that occurs when the block being operated on

--- a/domain/blockcommand/modelmigration/export.go
+++ b/domain/blockcommand/modelmigration/export.go
@@ -7,13 +7,13 @@ import (
 	"context"
 
 	"github.com/juju/description/v8"
-	"github.com/juju/errors"
 
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/modelmigration"
 	"github.com/juju/juju/domain/blockcommand"
 	"github.com/juju/juju/domain/blockcommand/service"
 	"github.com/juju/juju/domain/blockcommand/state"
+	"github.com/juju/juju/internal/errors"
 )
 
 // RegisterExport registers the export operations with the given coordinator.
@@ -56,7 +56,7 @@ func (e *exportOperation) Setup(scope modelmigration.Scope) error {
 func (e *exportOperation) Execute(ctx context.Context, model description.Model) error {
 	blocks, err := e.service.GetBlocks(ctx)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	migration := make(map[string]string)

--- a/domain/blockcommand/modelmigration/import.go
+++ b/domain/blockcommand/modelmigration/import.go
@@ -7,13 +7,13 @@ import (
 	"context"
 
 	"github.com/juju/description/v8"
-	"github.com/juju/errors"
 
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/modelmigration"
 	"github.com/juju/juju/domain/blockcommand"
 	"github.com/juju/juju/domain/blockcommand/service"
 	"github.com/juju/juju/domain/blockcommand/state"
+	"github.com/juju/juju/internal/errors"
 )
 
 // Coordinator is the interface that is used to add operations to a migration.
@@ -63,11 +63,11 @@ func (i *importOperation) Execute(ctx context.Context, model description.Model) 
 	for k, msg := range blocks {
 		t, err := importMigrationValue(k)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		if err := i.service.SwitchBlockOn(ctx, t, msg); err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 	}
 	return nil

--- a/domain/blockcommand/service/service.go
+++ b/domain/blockcommand/service/service.go
@@ -9,7 +9,7 @@ import (
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/domain/blockcommand"
 	blockcommanderrors "github.com/juju/juju/domain/blockcommand/errors"
-	internalerrors "github.com/juju/juju/internal/errors"
+	"github.com/juju/juju/internal/errors"
 )
 
 // State defines an interface for interacting with the underlying state.
@@ -64,10 +64,10 @@ func (s *Service) SwitchBlockOn(ctx context.Context, t blockcommand.BlockType, m
 	}
 
 	if len(message) > blockcommand.DefaultMaxMessageLength {
-		return internalerrors.Errorf("message length exceeds maximum allowed length of %d", blockcommand.DefaultMaxMessageLength)
+		return errors.Errorf("message length exceeds maximum allowed length of %d", blockcommand.DefaultMaxMessageLength)
 	}
 
-	if err := s.st.SetBlock(ctx, t, message); internalerrors.Is(err, blockcommanderrors.AlreadyExists) {
+	if err := s.st.SetBlock(ctx, t, message); errors.Is(err, blockcommanderrors.AlreadyExists) {
 		s.logger.Debugf("block already exists for type %q", t)
 		return nil
 	} else if err != nil {

--- a/domain/blockdevice/modelmigration/export.go
+++ b/domain/blockdevice/modelmigration/export.go
@@ -7,13 +7,13 @@ import (
 	"context"
 
 	"github.com/juju/description/v8"
-	"github.com/juju/errors"
 
 	"github.com/juju/juju/core/blockdevice"
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/modelmigration"
 	"github.com/juju/juju/domain/blockdevice/service"
 	"github.com/juju/juju/domain/blockdevice/state"
+	"github.com/juju/juju/internal/errors"
 )
 
 // RegisterExport registers the export operations with the given coordinator.
@@ -56,7 +56,7 @@ func (e *exportOperation) Setup(scope modelmigration.Scope) error {
 func (e *exportOperation) Execute(ctx context.Context, model description.Model) error {
 	blockDevices, err := e.service.AllBlockDevices(ctx)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	for machineId, bd := range blockDevices {
 		err := model.AddBlockDevice(machineId, description.BlockDeviceArgs{
@@ -74,7 +74,7 @@ func (e *exportOperation) Execute(ctx context.Context, model description.Model) 
 			MountPoint:     bd.MountPoint,
 		})
 		if err != nil {
-			return errors.Annotatef(err, "adding block device for machine %q", machineId)
+			return errors.Errorf("adding block device for machine %q %w", machineId, err)
 		}
 	}
 	return nil

--- a/domain/blockdevice/modelmigration/export_test.go
+++ b/domain/blockdevice/modelmigration/export_test.go
@@ -7,13 +7,13 @@ import (
 	"context"
 
 	"github.com/juju/description/v8"
-	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 	jc "github.com/juju/testing/checkers"
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/blockdevice"
+	coreerrors "github.com/juju/juju/core/errors"
 )
 
 type exportSuite struct {
@@ -103,5 +103,5 @@ func (s *exportSuite) TestExportMachineNotFound(c *gc.C) {
 
 	op := s.newExportOperation()
 	err := op.Execute(context.Background(), dst)
-	c.Assert(err, jc.ErrorIs, errors.NotFound)
+	c.Assert(err, jc.ErrorIs, coreerrors.NotFound)
 }

--- a/domain/blockdevice/modelmigration/import.go
+++ b/domain/blockdevice/modelmigration/import.go
@@ -7,13 +7,13 @@ import (
 	"context"
 
 	"github.com/juju/description/v8"
-	"github.com/juju/errors"
 
 	"github.com/juju/juju/core/blockdevice"
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/modelmigration"
 	"github.com/juju/juju/domain/blockdevice/service"
 	"github.com/juju/juju/domain/blockdevice/state"
+	"github.com/juju/juju/internal/errors"
 )
 
 // Coordinator is the interface that is used to add operations to a migration.
@@ -83,7 +83,7 @@ func (i *importOperation) Execute(ctx context.Context, model description.Model) 
 			}
 		}
 		if err := i.service.UpdateBlockDevices(ctx, m.Id(), machineBlockDevices...); err != nil {
-			return errors.Annotatef(err, "importing block devices for machine %q", m.Id())
+			return errors.Errorf("importing block devices for machine %q %w", m.Id(), err)
 		}
 	}
 	return nil

--- a/domain/blockdevice/service/service.go
+++ b/domain/blockdevice/service/service.go
@@ -6,14 +6,13 @@ package service
 import (
 	"context"
 
-	"github.com/juju/errors"
-
 	"github.com/juju/juju/core/blockdevice"
 	"github.com/juju/juju/core/changestream"
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/core/watcher/eventsource"
 	"github.com/juju/juju/domain/filesystem"
+	"github.com/juju/juju/internal/errors"
 )
 
 type getWatcherFunc = func(
@@ -81,7 +80,7 @@ func (s *Service) UpdateBlockDevices(ctx context.Context, machineId string, devi
 func (s *Service) AllBlockDevices(ctx context.Context) (map[string]blockdevice.BlockDevice, error) {
 	machineDevices, err := s.st.MachineBlockDevices(ctx)
 	if err != nil {
-		return nil, errors.Annotate(err, "loading all block devices")
+		return nil, errors.Errorf("loading all block devices %w", err)
 	}
 	result := make(map[string]blockdevice.BlockDevice)
 	for _, md := range machineDevices {

--- a/domain/blockdevice/state/state.go
+++ b/domain/blockdevice/state/state.go
@@ -5,20 +5,20 @@ package state
 
 import (
 	"context"
-	"fmt"
 	"reflect"
 
 	"github.com/canonical/sqlair"
-	"github.com/juju/errors"
 
 	"github.com/juju/juju/core/blockdevice"
 	"github.com/juju/juju/core/changestream"
 	coredatabase "github.com/juju/juju/core/database"
+	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/core/watcher/eventsource"
 	"github.com/juju/juju/domain"
 	"github.com/juju/juju/domain/life"
 	machineerrors "github.com/juju/juju/domain/machine/errors"
+	"github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/internal/uuid"
 )
 
@@ -40,16 +40,16 @@ func NewState(factory coredatabase.TxnRunnerFactory) *State {
 func (st *State) BlockDevices(ctx context.Context, machineId string) ([]blockdevice.BlockDevice, error) {
 	db, err := st.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	var result []blockdevice.BlockDevice
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		var err error
 		result, err = st.loadBlockDevices(ctx, tx, machineId)
-		return errors.Trace(err)
+		return errors.Capture(err)
 	})
-	return result, errors.Trace(err)
+	return result, errors.Capture(err)
 }
 
 func (st *State) loadBlockDevices(ctx context.Context, tx *sqlair.TX, machineId string) ([]blockdevice.BlockDevice, error) {
@@ -73,7 +73,7 @@ WHERE  machine.name = $M.name
 
 	stmt, err := st.Prepare(query, types...)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	var (
@@ -86,10 +86,10 @@ WHERE  machine.name = $M.name
 	if errors.Is(err, sqlair.ErrNoRows) {
 		return nil, nil
 	} else if err != nil {
-		return nil, errors.Annotatef(err, "loading block devices for machine %q", machineId)
+		return nil, errors.Errorf("loading block devices for machine %q %w", machineId, err)
 	}
 	result, _, err := dbRows.toBlockDevicesAndMachines(dbDeviceLinks, dbFilesystemTypes, nil)
-	return result, errors.Trace(err)
+	return result, errors.Capture(err)
 }
 
 func (st *State) getMachineInfo(ctx context.Context, tx *sqlair.TX, machineId string) (string, life.Life, error) {
@@ -100,16 +100,16 @@ WHERE  machine.name = $M.name
 `
 	stmt, err := st.Prepare(q, sqlair.M{})
 	if err != nil {
-		return "", 0, errors.Trace(err)
+		return "", 0, errors.Capture(err)
 	}
 
 	result := sqlair.M{}
 	err = tx.Query(ctx, stmt, sqlair.M{"name": machineId}).Get(result)
 	if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-		return "", 0, errors.Annotatef(err, "looking up UUID for machine %q", machineId)
+		return "", 0, errors.Errorf("looking up UUID for machine %q %w", machineId, err)
 	}
 	if len(result) == 0 {
-		return "", 0, fmt.Errorf("machine %q not found%w", machineId, errors.Hide(machineerrors.MachineNotFound))
+		return "", 0, errors.Errorf("machine %q not found", machineId).Add(machineerrors.MachineNotFound)
 	}
 	machineLife, ok := result["life_id"].(int64)
 	if !ok {
@@ -125,37 +125,37 @@ WHERE  machine.name = $M.name
 func (st *State) SetMachineBlockDevices(ctx context.Context, machineId string, devices ...blockdevice.BlockDevice) error {
 	db, err := st.DB()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		machineUUID, machineLife, err := st.getMachineInfo(ctx, tx, machineId)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		if machineLife == life.Dead {
 			return errors.Errorf("cannot update block devices on dead machine %q", machineId)
 		}
 		existing, err := st.loadBlockDevices(ctx, tx, machineId)
 		if err != nil {
-			return errors.Annotatef(err, "loading block devices for machine %q", machineId)
+			return errors.Errorf("loading block devices for machine %q %w", machineId, err)
 		}
 		if !blockDevicesChanged(existing, devices) {
 			return nil
 		}
 
 		if err := st.updateBlockDevices(ctx, tx, machineUUID, devices...); err != nil {
-			return errors.Annotatef(err, "updating block devices on machine %q (%s)", machineId, machineUUID)
+			return errors.Errorf("updating block devices on machine %q (%s) %w", machineId, machineUUID, err)
 		}
 		return nil
 	})
 
-	return errors.Trace(err)
+	return errors.Capture(err)
 }
 
 func (st *State) updateBlockDevices(ctx context.Context, tx *sqlair.TX, machineUUID string, devices ...blockdevice.BlockDevice) error {
 	if err := RemoveMachineBlockDevices(ctx, tx, machineUUID); err != nil {
-		return errors.Annotatef(err, "removing existing block devices for machine %q", machineUUID)
+		return errors.Errorf("removing existing block devices for machine %q %w", machineUUID, err)
 	}
 
 	if len(devices) == 0 {
@@ -165,11 +165,11 @@ func (st *State) updateBlockDevices(ctx context.Context, tx *sqlair.TX, machineU
 	fsTypeQuery := `SELECT * AS &FilesystemType.* FROM filesystem_type`
 	fsTypeStmt, err := st.Prepare(fsTypeQuery, FilesystemType{})
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	var fsTypes []FilesystemType
 	if err := tx.Query(ctx, fsTypeStmt).GetAll(&fsTypes); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	fsTypeByName := make(map[string]int)
 	for _, fsType := range fsTypes {
@@ -179,7 +179,7 @@ func (st *State) updateBlockDevices(ctx context.Context, tx *sqlair.TX, machineU
 	insertQuery := `INSERT INTO block_device (*) VALUES ($BlockDevice.*)`
 	insertStmt, err := st.Prepare(insertQuery, BlockDevice{})
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	insertLinkQuery := `
@@ -191,17 +191,17 @@ VALUES (
 `
 	insertLinkStmt, err := st.Prepare(insertLinkQuery, DeviceLink{})
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	for _, bd := range devices {
 		fsTypeID, ok := fsTypeByName[bd.FilesystemType]
 		if !ok {
-			return errors.NotValidf("filesystem type %q for block device %q", bd.FilesystemType, bd.DeviceName)
+			return errors.Errorf("filesystem type %q for block device %q %w", bd.FilesystemType, bd.DeviceName, coreerrors.NotValid)
 		}
 		id, err := uuid.NewUUID()
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		dbBlockDevice := BlockDevice{
 			ID:             id.String(),
@@ -219,7 +219,7 @@ VALUES (
 			InUse:          bd.InUse,
 		}
 		if err := tx.Query(ctx, insertStmt, dbBlockDevice).Run(); err != nil {
-			return errors.Annotate(err, "inserting block devices")
+			return errors.Errorf("inserting block devices %w", err)
 		}
 
 		for _, link := range bd.DeviceLinks {
@@ -228,7 +228,7 @@ VALUES (
 				Name:       link,
 			}
 			if err := tx.Query(ctx, insertLinkStmt, dbDeviceLink).Run(); err != nil {
-				return errors.Annotate(err, "inserting block device links")
+				return errors.Errorf("inserting block device links %w", err)
 			}
 		}
 	}
@@ -259,7 +259,7 @@ func blockDevicesChanged(oldDevices, newDevices []blockdevice.BlockDevice) bool 
 func (st *State) MachineBlockDevices(ctx context.Context) ([]blockdevice.MachineBlockDevice, error) {
 	db, err := st.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	query := `
@@ -282,7 +282,7 @@ FROM   block_device bd
 
 	stmt, err := st.Prepare(query, types...)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	var (
@@ -297,13 +297,13 @@ FROM   block_device bd
 			dbMachines        []BlockDeviceMachine
 		)
 		if err := tx.Query(ctx, stmt).GetAll(&dbRows, &dbDeviceLinks, &dbFilesystemTypes, &dbMachines); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-			return errors.Annotate(err, "loading block devices")
+			return errors.Errorf("loading block devices %w", err)
 		}
 		blockDevices, machines, err = dbRows.toBlockDevicesAndMachines(dbDeviceLinks, dbFilesystemTypes, dbMachines)
-		return errors.Trace(err)
+		return errors.Capture(err)
 	})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	result := make([]blockdevice.MachineBlockDevice, len(blockDevices))
 	for i, bd := range blockDevices {
@@ -339,10 +339,10 @@ WHERE block_device_uuid IN (
 
 	deleteStmt, err := sqlair.Prepare(linkDeleteQuery, sqlair.M{})
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	if err := tx.Query(ctx, deleteStmt, machineUUIDParam).Run(); err != nil {
-		return errors.Annotate(err, "deleting block device link devices")
+		return errors.Errorf("deleting block device link devices %w", err)
 	}
 
 	deleteQuery := `
@@ -353,10 +353,10 @@ WHERE machine_uuid = $M.machine_uuid
 
 	deleteStmt, err = sqlair.Prepare(deleteQuery, sqlair.M{})
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	if err := tx.Query(ctx, deleteStmt, machineUUIDParam).Run(); err != nil {
-		return errors.Annotate(err, "deleting block devices")
+		return errors.Errorf("deleting block devices %w", err)
 	}
 	return nil
 }
@@ -374,7 +374,7 @@ func (st *State) WatchBlockDevices(
 ) (watcher.NotifyWatcher, error) {
 	db, err := st.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	var (
@@ -383,11 +383,11 @@ func (st *State) WatchBlockDevices(
 	)
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		machineUUID, machineLife, err = st.getMachineInfo(ctx, tx, machineId)
-		return errors.Trace(err)
+		return errors.Capture(err)
 	})
 
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	if machineLife == life.Dead {
 		return nil, errors.Errorf("cannot watch block devices on dead machine %q", machineId)
@@ -397,7 +397,7 @@ func (st *State) WatchBlockDevices(
 		return ce.Changed() == machineUUID
 	}))
 	if err != nil {
-		return nil, errors.Annotatef(err, "watching machine %q block devices", machineId)
+		return nil, errors.Errorf("watching machine %q block devices %w", machineId, err)
 	}
 	return baseWatcher, nil
 }

--- a/domain/blockdevice/state/state_test.go
+++ b/domain/blockdevice/state/state_test.go
@@ -11,6 +11,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/blockdevice"
+	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/domain/life"
 	schematesting "github.com/juju/juju/domain/schema/testing"
 	"github.com/juju/juju/internal/uuid"
@@ -240,7 +241,7 @@ func (s *stateSuite) TestSetMachineBlockDevicesBadFilesystemType(c *gc.C) {
 	}
 
 	err := NewState(s.TxnRunnerFactory()).SetMachineBlockDevices(context.Background(), "666", bd)
-	c.Assert(err, gc.ErrorMatches, `updating block devices on machine "666".*: filesystem type "foo" for block device "name-666" not valid`)
+	c.Check(err, jc.ErrorIs, coreerrors.NotValid)
 }
 
 func (s *stateSuite) TestSetMachineBlockDevices(c *gc.C) {

--- a/domain/blockdevice/state/types.go
+++ b/domain/blockdevice/state/types.go
@@ -4,9 +4,8 @@
 package state
 
 import (
-	"github.com/juju/errors"
-
 	"github.com/juju/juju/core/blockdevice"
+	"github.com/juju/juju/internal/errors"
 )
 
 // These structs represent the persistent block device entity schema in the database.

--- a/domain/blockdevice/watcher_test.go
+++ b/domain/blockdevice/watcher_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"database/sql"
 
-	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v4/workertest"
 	gc "gopkg.in/check.v1"
@@ -19,6 +18,7 @@ import (
 	"github.com/juju/juju/domain/blockdevice/service"
 	"github.com/juju/juju/domain/blockdevice/state"
 	"github.com/juju/juju/internal/changestream/testing"
+	"github.com/juju/juju/internal/errors"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 	"github.com/juju/juju/internal/uuid"
 )
@@ -45,11 +45,11 @@ VALUES (?, ?, ?, ?)
 
 	err := db.StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		if _, err := tx.ExecContext(ctx, queryNetNode, netNodeUUID); err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		if _, err := tx.ExecContext(ctx, queryMachine, machineUUID, 0, name, netNodeUUID); err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		return nil
 	})

--- a/domain/cloud/bootstrap/bootstrap.go
+++ b/domain/cloud/bootstrap/bootstrap.go
@@ -7,13 +7,13 @@ import (
 	"context"
 
 	"github.com/canonical/sqlair"
-	"github.com/juju/errors"
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/user"
 	"github.com/juju/juju/domain/cloud/state"
 	internaldatabase "github.com/juju/juju/internal/database"
+	"github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/internal/uuid"
 )
 
@@ -22,13 +22,14 @@ func InsertCloud(ownerName user.Name, cloud cloud.Cloud) internaldatabase.Bootst
 	return func(ctx context.Context, controller, model database.TxnRunner) error {
 		cloudUUID, err := uuid.NewUUID()
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
-		return errors.Trace(controller.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		return errors.Capture(controller.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 			if err := state.CreateCloud(ctx, tx, ownerName, cloudUUID.String(), cloud); err != nil {
-				return errors.Annotate(err, "creating bootstrap cloud")
+				return errors.Errorf("creating bootstrap cloud %w", err)
 			}
 			return nil
 		}))
+
 	}
 }

--- a/domain/cloud/errors/errors.go
+++ b/domain/cloud/errors/errors.go
@@ -3,9 +3,7 @@
 
 package errors
 
-import (
-	"github.com/juju/errors"
-)
+import "github.com/juju/juju/internal/errors"
 
 const (
 	// NotFound describes an error that occurs when the cloud being operated on

--- a/domain/cloud/service/providerservice.go
+++ b/domain/cloud/service/providerservice.go
@@ -6,11 +6,10 @@ package service
 import (
 	"context"
 
-	"github.com/juju/errors"
-
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/core/changestream"
 	"github.com/juju/juju/core/watcher"
+	"github.com/juju/juju/internal/errors"
 )
 
 type ProviderState interface {
@@ -44,7 +43,7 @@ func NewProviderService(st ProviderState) *ProviderService {
 // Cloud returns the named cloud.
 func (s *ProviderService) Cloud(ctx context.Context, name string) (*cloud.Cloud, error) {
 	cloud, err := s.st.Cloud(ctx, name)
-	return cloud, errors.Trace(err)
+	return cloud, errors.Capture(err)
 }
 
 // WatchableProviderService returns a new provider service reference wrapping

--- a/domain/cloud/service/providerservice_test.go
+++ b/domain/cloud/service/providerservice_test.go
@@ -6,13 +6,14 @@ package service
 import (
 	"context"
 
-	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cloud"
+	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/watcher/watchertest"
+	"github.com/juju/juju/internal/errors"
 )
 
 type providerServiceSuite struct {
@@ -37,11 +38,11 @@ func (s *providerServiceSuite) TestCloud(c *gc.C) {
 func (s *providerServiceSuite) TestCloudNotFound(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().Cloud(gomock.Any(), "fluffy").Return(nil, errors.NotFoundf(`cloud "fluffy"`))
+	s.state.EXPECT().Cloud(gomock.Any(), "fluffy").Return(nil, errors.Errorf(`cloud "fluffy"`+" %w", coreerrors.NotFound))
 
 	result, err := NewWatchableProviderService(s.state, s.watcherFactory).Cloud(context.Background(), "fluffy")
 	c.Assert(err, gc.ErrorMatches, `cloud "fluffy" not found`)
-	c.Check(err, jc.ErrorIs, errors.NotFound)
+	c.Check(err, jc.ErrorIs, coreerrors.NotFound)
 	c.Check(result, gc.IsNil)
 }
 

--- a/domain/cloud/service/service.go
+++ b/domain/cloud/service/service.go
@@ -6,12 +6,11 @@ package service
 import (
 	"context"
 
-	"github.com/juju/errors"
-
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/core/changestream"
 	"github.com/juju/juju/core/user"
 	"github.com/juju/juju/core/watcher"
+	"github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/internal/uuid"
 )
 
@@ -50,34 +49,34 @@ type Service struct {
 func (s *Service) CreateCloud(ctx context.Context, owner user.Name, cloud cloud.Cloud) error {
 	credUUID, err := uuid.NewUUID()
 	if err != nil {
-		return errors.Annotatef(err, "creating uuid for cloud %q", cloud.Name)
+		return errors.Errorf("creating uuid for cloud %q %w", cloud.Name, err)
 	}
 	err = s.st.CreateCloud(ctx, owner, credUUID.String(), cloud)
-	return errors.Annotatef(err, "creating cloud %q", cloud.Name)
+	return errors.Errorf("creating cloud %q %w", cloud.Name, err)
 }
 
 // UpdateCloud updates the specified cloud.
 func (s *Service) UpdateCloud(ctx context.Context, cloud cloud.Cloud) error {
 	err := s.st.UpdateCloud(ctx, cloud)
-	return errors.Annotatef(err, "updating cloud %q", cloud.Name)
+	return errors.Errorf("updating cloud %q %w", cloud.Name, err)
 }
 
 // DeleteCloud removes the specified cloud.
 func (s *Service) DeleteCloud(ctx context.Context, name string) error {
 	err := s.st.DeleteCloud(ctx, name)
-	return errors.Annotatef(err, "deleting cloud %q", name)
+	return errors.Errorf("deleting cloud %q %w", name, err)
 }
 
 // ListAll returns all the clouds.
 func (s *Service) ListAll(ctx context.Context) ([]cloud.Cloud, error) {
 	all, err := s.st.ListClouds(ctx)
-	return all, errors.Trace(err)
+	return all, errors.Capture(err)
 }
 
 // Cloud returns the named cloud.
 func (s *Service) Cloud(ctx context.Context, name string) (*cloud.Cloud, error) {
 	cloud, err := s.st.Cloud(ctx, name)
-	return cloud, errors.Trace(err)
+	return cloud, errors.Capture(err)
 }
 
 // WatchableService defines a service for interacting with the underlying state

--- a/domain/cloud/service/service.go
+++ b/domain/cloud/service/service.go
@@ -51,32 +51,44 @@ func (s *Service) CreateCloud(ctx context.Context, owner user.Name, cloud cloud.
 	if err != nil {
 		return errors.Errorf("creating uuid for cloud %q %w", cloud.Name, err)
 	}
-	err = s.st.CreateCloud(ctx, owner, credUUID.String(), cloud)
-	return errors.Errorf("creating cloud %q %w", cloud.Name, err)
+	if err = s.st.CreateCloud(ctx, owner, credUUID.String(), cloud); err != nil {
+		return errors.Errorf("creating cloud %q: %w", cloud.Name, err)
+	}
+	return nil
 }
 
 // UpdateCloud updates the specified cloud.
 func (s *Service) UpdateCloud(ctx context.Context, cloud cloud.Cloud) error {
-	err := s.st.UpdateCloud(ctx, cloud)
-	return errors.Errorf("updating cloud %q %w", cloud.Name, err)
+	if err := s.st.UpdateCloud(ctx, cloud); err != nil {
+		return errors.Errorf("updating cloud %q: %w", cloud.Name, err)
+	}
+	return nil
 }
 
 // DeleteCloud removes the specified cloud.
 func (s *Service) DeleteCloud(ctx context.Context, name string) error {
-	err := s.st.DeleteCloud(ctx, name)
-	return errors.Errorf("deleting cloud %q %w", name, err)
+	if err := s.st.DeleteCloud(ctx, name); err != nil {
+		return errors.Errorf("deleting cloud %q %w", name, err)
+	}
+	return nil
 }
 
 // ListAll returns all the clouds.
 func (s *Service) ListAll(ctx context.Context) ([]cloud.Cloud, error) {
 	all, err := s.st.ListClouds(ctx)
-	return all, errors.Capture(err)
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+	return all, nil
 }
 
 // Cloud returns the named cloud.
 func (s *Service) Cloud(ctx context.Context, name string) (*cloud.Cloud, error) {
 	cloud, err := s.st.Cloud(ctx, name)
-	return cloud, errors.Capture(err)
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+	return cloud, nil
 }
 
 // WatchableService defines a service for interacting with the underlying state

--- a/domain/cloud/service/service_test.go
+++ b/domain/cloud/service/service_test.go
@@ -6,14 +6,15 @@ package service
 import (
 	"context"
 
-	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cloud"
+	coreerrors "github.com/juju/juju/core/errors"
 	usertesting "github.com/juju/juju/core/user/testing"
 	"github.com/juju/juju/core/watcher/watchertest"
+	"github.com/juju/juju/internal/errors"
 )
 
 type serviceSuite struct {
@@ -108,11 +109,11 @@ func (s *serviceSuite) TestCloud(c *gc.C) {
 func (s *serviceSuite) TestCloudNotFound(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().Cloud(gomock.Any(), "fluffy").Return(nil, errors.NotFoundf(`cloud "fluffy"`))
+	s.state.EXPECT().Cloud(gomock.Any(), "fluffy").Return(nil, errors.Errorf(`cloud "fluffy"`+" %w", coreerrors.NotFound))
 
 	result, err := NewWatchableService(s.state, s.watcherFactory).Cloud(context.Background(), "fluffy")
 	c.Assert(err, gc.ErrorMatches, `cloud "fluffy" not found`)
-	c.Check(err, jc.ErrorIs, errors.NotFound)
+	c.Check(err, jc.ErrorIs, coreerrors.NotFound)
 	c.Check(result, gc.IsNil)
 }
 

--- a/domain/cloud/state/state.go
+++ b/domain/cloud/state/state.go
@@ -855,5 +855,8 @@ WHERE name = $cloudID.name`, cloud)
 		return nil, errors.Capture(err)
 	}
 	result, err := getWatcher("cloud", cloud.UUID, changestream.All)
-	return result, errors.Errorf("watching cloud %w", err)
+	if err != nil {
+		return nil, errors.Errorf("watching cloud: %w", err)
+	}
+	return result, nil
 }

--- a/domain/cloud/state/state_test.go
+++ b/domain/cloud/state/state_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/canonical/sqlair"
 	"github.com/juju/collections/set"
-	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/utils/v4"
 	"github.com/juju/worker/v4/workertest"
@@ -20,6 +19,7 @@ import (
 	"github.com/juju/juju/core/changestream"
 	corecloud "github.com/juju/juju/core/cloud"
 	cloudtesting "github.com/juju/juju/core/cloud/testing"
+	coreerrors "github.com/juju/juju/core/errors"
 	coremodel "github.com/juju/juju/core/model"
 	modeltesting "github.com/juju/juju/core/model/testing"
 	"github.com/juju/juju/core/permission"
@@ -295,7 +295,7 @@ func (s *stateSuite) TestCloudWithEmptyNameFails(c *gc.C) {
 
 	st := NewState(s.TxnRunnerFactory())
 	err := st.CreateCloud(context.Background(), usertesting.GenNewName(c, "admin"), uuid.MustNewUUID().String(), cld)
-	c.Assert(err, jc.ErrorIs, errors.NotValid)
+	c.Assert(err, jc.ErrorIs, coreerrors.NotValid)
 }
 
 func (s *stateSuite) TestCreateCloudInvalidAuthType(c *gc.C) {
@@ -473,7 +473,7 @@ func (s *stateSuite) TestWatchCloudNotFound(c *gc.C) {
 
 	ctx := context.Background()
 	_, err := st.WatchCloud(ctx, s.watcherFunc(c, ""), "fluffy")
-	c.Assert(err, jc.ErrorIs, errors.NotFound)
+	c.Assert(err, jc.ErrorIs, coreerrors.NotFound)
 }
 
 func (s *stateSuite) TestWatchCloud(c *gc.C) {

--- a/domain/cloudimagemetadata/bootstrap/bootstrap_test.go
+++ b/domain/cloudimagemetadata/bootstrap/bootstrap_test.go
@@ -8,7 +8,6 @@ import (
 	"database/sql"
 
 	"github.com/juju/clock"
-	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -16,6 +15,7 @@ import (
 	schematesting "github.com/juju/juju/domain/schema/testing"
 	"github.com/juju/juju/environs/imagemetadata"
 	"github.com/juju/juju/environs/simplestreams"
+	"github.com/juju/juju/internal/errors"
 )
 
 type bootstrapSuite struct {
@@ -142,7 +142,7 @@ image_id
  FROM cloud_image_metadata
  JOIN architecture arch on cloud_image_metadata.architecture_id = arch.id`)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		defer func() { _ = rows.Close() }()
 		for rows.Next() {
@@ -158,10 +158,10 @@ image_id
 				&dbMetadata.Arch,
 				&dbMetadata.ImageID,
 			); err != nil {
-				return errors.Trace(err)
+				return errors.Capture(err)
 			}
 			metadata = append(metadata, dbMetadata)
 		}
-		return errors.Trace(rows.Err())
+		return errors.Capture(rows.Err())
 	})
 }

--- a/domain/cloudimagemetadata/modelmigration/import_test.go
+++ b/domain/cloudimagemetadata/modelmigration/import_test.go
@@ -15,6 +15,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/domain/cloudimagemetadata"
+	"github.com/juju/juju/internal/errors"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 )
 
@@ -140,7 +141,7 @@ func (s *importSuite) TestImportFailureWhenSaveMetadata(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	// Arrange
-	expectedError := fmt.Errorf("error")
+	expectedError := errors.Errorf("error")
 	dst := description.NewModel(description.ModelArgs{})
 	// few args to trigger a save, value non-important
 	for range 3 {

--- a/domain/cloudimagemetadata/service/service.go
+++ b/domain/cloudimagemetadata/service/service.go
@@ -1,4 +1,4 @@
-t // Copyright 2024 Canonical Ltd.
+// Copyright 2024 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package service
@@ -63,7 +63,7 @@ func (s Service) SaveMetadata(ctx context.Context, metadata []cloudimagemetadata
 // It returns a [errors.EmptyImageID] if the provided imageID is empty.
 func (s Service) DeleteMetadataWithImageID(ctx context.Context, imageID string) error {
 	if imageID == "" {
-		return errors.EmptyImageID
+		return cloudimageerrors.EmptyImageID
 	}
 
 	return s.st.DeleteMetadataWithImageID(ctx, imageID)

--- a/domain/cloudimagemetadata/service/service.go
+++ b/domain/cloudimagemetadata/service/service.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Canonical Ltd.
+t // Copyright 2024 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
 package service
@@ -9,8 +9,8 @@ import (
 	"github.com/juju/collections/set"
 
 	"github.com/juju/juju/domain/cloudimagemetadata"
-	"github.com/juju/juju/domain/cloudimagemetadata/errors"
-	jujuerrors "github.com/juju/juju/internal/errors"
+	cloudimageerrors "github.com/juju/juju/domain/cloudimagemetadata/errors"
+	"github.com/juju/juju/internal/errors"
 )
 
 // State is an interface of the persistence layer for managing cloud image metadata
@@ -94,13 +94,13 @@ func (s Service) validateAllMetadata(ctx context.Context, metadata []cloudimagem
 	for _, m := range metadata {
 		errs = append(errs, s.validateMetadata(ctx, m))
 	}
-	return jujuerrors.Join(errs...)
+	return errors.Join(errs...)
 }
 
 // validateMetadata validates a single cloud image metadata entry.
 func (s Service) validateMetadata(ctx context.Context, m cloudimagemetadata.Metadata) error {
 	if m.ImageID == "" {
-		return jujuerrors.Errorf("%w: %w", errors.EmptyImageID, errors.NotValid)
+		return errors.Errorf("%w: %w", cloudimageerrors.EmptyImageID, cloudimageerrors.NotValid)
 	}
 
 	var missing []string
@@ -121,12 +121,12 @@ func (s Service) validateMetadata(ctx context.Context, m cloudimagemetadata.Meta
 	}
 
 	if len(missing) > 0 {
-		return errors.NotValidMissingFields(m.ImageID, missing)
+		return cloudimageerrors.NotValidMissingFields(m.ImageID, missing)
 	}
 
 	supportedArchitectures := s.st.SupportedArchitectures(ctx)
 	if !supportedArchitectures.Contains(m.Arch) {
-		return jujuerrors.Errorf("unsupported architecture %s (should be any of %s): %w", m.Arch, supportedArchitectures.Values(), errors.NotValid)
+		return errors.Errorf("unsupported architecture %s (should be any of %s): %w", m.Arch, supportedArchitectures.Values(), cloudimageerrors.NotValid)
 	}
 
 	return nil

--- a/domain/cloudimagemetadata/service/service_test.go
+++ b/domain/cloudimagemetadata/service/service_test.go
@@ -13,8 +13,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/domain/cloudimagemetadata"
-	"github.com/juju/juju/domain/cloudimagemetadata/errors"
-	jujuerrors "github.com/juju/juju/internal/errors"
+	"github.com/juju/juju/internal/errors"
 )
 
 type serviceSuite struct {
@@ -125,7 +124,7 @@ func (s *serviceSuite) TestSaveMetadataInvalidArchitectureName(c *gc.C) { // Arr
 func (s *serviceSuite) TestSaveMetadataError(c *gc.C) { // Arrange
 	// Arrange
 	defer s.setupMocks(c).Finish()
-	errExpected := jujuerrors.New("oh no!!")
+	errExpected := errors.New("oh no!!")
 	validMetadata := []cloudimagemetadata.Metadata{{ImageID: "dead-beaf",
 		MetadataAttributes: cloudimagemetadata.MetadataAttributes{
 			Version: "1.2.3",
@@ -173,7 +172,7 @@ func (s *serviceSuite) TestDeleteMetadataEmptyImageID(c *gc.C) {
 func (s *serviceSuite) TestDeleteMetadataError(c *gc.C) {
 	// Arrange
 	defer s.setupMocks(c).Finish()
-	errExpected := jujuerrors.New("oh no!!")
+	errExpected := errors.New("oh no!!")
 	s.state.EXPECT().DeleteMetadataWithImageID(gomock.Any(), "dead-beaf").Return(errExpected)
 
 	// Act
@@ -281,7 +280,7 @@ func (s *serviceSuite) TestFindMetadataError(c *gc.C) {
 	// Arrange
 	defer s.setupMocks(c).Finish()
 
-	errExpected := jujuerrors.New("oh no!!")
+	errExpected := errors.New("oh no!!")
 	criteria := cloudimagemetadata.MetadataFilter{Region: "whatever"}
 
 	s.state.EXPECT().FindMetadata(gomock.Any(), criteria).Return(nil, errExpected)
@@ -323,7 +322,7 @@ func (s *serviceSuite) TestAllCloudImageMetadataError(c *gc.C) {
 	// Arrange
 	defer s.setupMocks(c).Finish()
 
-	errExpected := jujuerrors.New("oh no!!")
+	errExpected := errors.New("oh no!!")
 
 	s.state.EXPECT().AllCloudImageMetadata(gomock.Any()).Return(nil, errExpected)
 

--- a/domain/cloudimagemetadata/service/service_test.go
+++ b/domain/cloudimagemetadata/service/service_test.go
@@ -63,8 +63,8 @@ func (s *serviceSuite) TestSaveMetadataEmptyImageID(c *gc.C) {
 	err := NewService(s.state).SaveMetadata(context.Background(), []cloudimagemetadata.Metadata{{ImageID: ""}})
 
 	// Assert
-	c.Assert(err, jc.ErrorIs, errors.NotValid)
-	c.Assert(err, jc.ErrorIs, errors.EmptyImageID)
+	c.Assert(err, jc.ErrorIs, cloudimageerrors.NotValid)
+	c.Assert(err, jc.ErrorIs, cloudimageerrors.EmptyImageID)
 	c.Assert(err, gc.ErrorMatches, "image id is empty: invalid metadata")
 }
 
@@ -78,7 +78,7 @@ func (s *serviceSuite) TestSaveMetadataInvalidFields(c *gc.C) {
 	err := NewService(s.state).SaveMetadata(context.Background(), []cloudimagemetadata.Metadata{{ImageID: "dead-beaf" /* some field are required */}})
 
 	// Assert
-	c.Assert(err, jc.ErrorIs, errors.NotValid)
+	c.Assert(err, jc.ErrorIs, cloudimageerrors.NotValid)
 	c.Assert(err, gc.ErrorMatches, "missing version, stream, source, arch, region: invalid metadata for image dead-beaf")
 }
 
@@ -115,7 +115,7 @@ func (s *serviceSuite) TestSaveMetadataInvalidArchitectureName(c *gc.C) { // Arr
 	)
 
 	// Assert
-	c.Assert(err, jc.ErrorIs, errors.NotValid)
+	c.Assert(err, jc.ErrorIs, cloudimageerrors.NotValid)
 	c.Assert(err, gc.ErrorMatches, "unsupported architecture risc \\(should be any of \\[(amd64 arm64|arm64 amd64)\\]\\): invalid metadata")
 }
 
@@ -165,7 +165,7 @@ func (s *serviceSuite) TestDeleteMetadataEmptyImageID(c *gc.C) {
 	err := NewService(s.state).DeleteMetadataWithImageID(context.Background(), "")
 
 	// Assert
-	c.Assert(err, jc.ErrorIs, errors.EmptyImageID)
+	c.Assert(err, jc.ErrorIs, cloudimageerrors.EmptyImageID)
 }
 
 // TestDeleteMetadataError verifies that the DeleteMetadataWithImageID method returns the underlying error when deletion fails.
@@ -265,13 +265,13 @@ func (s *serviceSuite) TestFindMetadataNotFound(c *gc.C) {
 
 	criteria := cloudimagemetadata.MetadataFilter{Region: "whatever"}
 
-	s.state.EXPECT().FindMetadata(gomock.Any(), criteria).Return(nil, errors.NotFound)
+	s.state.EXPECT().FindMetadata(gomock.Any(), criteria).Return(nil, cloudimageerrors.NotFound)
 
 	// Act
 	_, err := NewService(s.state).FindMetadata(context.Background(), criteria)
 
 	// Assert
-	c.Assert(err, jc.ErrorIs, errors.NotFound)
+	c.Assert(err, jc.ErrorIs, cloudimageerrors.NotFound)
 }
 
 // TestFindMetadataError tests the behavior of the service's FindMetadata method when an error is returned by the state.

--- a/domain/cloudimagemetadata/service/service_test.go
+++ b/domain/cloudimagemetadata/service/service_test.go
@@ -13,6 +13,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/domain/cloudimagemetadata"
+	cloudimageerrors "github.com/juju/juju/domain/cloudimagemetadata/errors"
 	"github.com/juju/juju/internal/errors"
 )
 

--- a/domain/cloudimagemetadata/state/helpers_test.go
+++ b/domain/cloudimagemetadata/state/helpers_test.go
@@ -8,9 +8,9 @@ import (
 	"database/sql"
 
 	"github.com/canonical/sqlair"
-	"github.com/juju/errors"
 
 	"github.com/juju/juju/domain/cloudimagemetadata"
+	"github.com/juju/juju/internal/errors"
 )
 
 // retrieveMetadataFromDB retrieves all metadata from the cloud_image_metadata database table.
@@ -36,7 +36,7 @@ image_id
  FROM cloud_image_metadata
  JOIN architecture arch on cloud_image_metadata.architecture_id = arch.id`)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		defer func() { _ = rows.Close() }()
 		for rows.Next() {
@@ -54,11 +54,11 @@ image_id
 				&dbMetadata.Arch,
 				&dbMetadata.ImageID,
 			); err != nil {
-				return errors.Trace(err)
+				return errors.Capture(err)
 			}
 			metadata = append(metadata, dbMetadata)
 		}
-		return errors.Trace(err)
+		return errors.Capture(err)
 	})
 }
 

--- a/domain/cloudimagemetadata/state/state.go
+++ b/domain/cloudimagemetadata/state/state.go
@@ -14,7 +14,6 @@ import (
 	"github.com/canonical/sqlair"
 	"github.com/juju/clock"
 	"github.com/juju/collections/set"
-	"github.com/juju/errors"
 
 	"github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/logger"
@@ -22,6 +21,7 @@ import (
 	"github.com/juju/juju/domain/cloudimagemetadata"
 	cloudmetadataerrors "github.com/juju/juju/domain/cloudimagemetadata/errors"
 	dberrors "github.com/juju/juju/internal/database"
+	"github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/internal/uuid"
 )
 
@@ -105,7 +105,7 @@ func (s *State) SaveMetadata(ctx context.Context, metadata []cloudimagemetadata.
 
 	db, err := s.DB()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	return InsertMetadata(ctx, db, metadata, s.clock.Now())
@@ -131,7 +131,7 @@ func InsertMetadata(ctx context.Context, db domain.TxnRunner, metadata []cloudim
 
 		mUUID, err := uuid.NewUUID()
 		if err != nil {
-			return errors.Annotatef(err, "failed to generate metadata uuid")
+			return errors.Errorf("failed to generate metadata uuid %w", err)
 		}
 		values = append(values, inputMetadata{
 			UUID:            mUUID.String(),
@@ -161,7 +161,7 @@ AND root_storage_type = $inputMetadata.root_storage_type
 AND source = $inputMetadata.source
 `, metadataUUID{}, inputMetadata{})
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	// Prepare a statement to update only the image from a specific UUID
@@ -170,7 +170,7 @@ UPDATE cloud_image_metadata
 SET image_id = $inputMetadata.image_id
 WHERE cloud_image_metadata.uuid = $inputMetadata.uuid;`, inputMetadata{})
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	// Prepare statement to insert a batch of image in db. In case of conflict on unique constraint,
@@ -179,10 +179,10 @@ WHERE cloud_image_metadata.uuid = $inputMetadata.uuid;`, inputMetadata{})
 INSERT INTO cloud_image_metadata (*)
 VALUES ($inputMetadata.*)`, inputMetadata{})
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
-	return errors.Trace(db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+	return errors.Capture(db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		toInsert := make([]inputMetadata, 0, len(values))
 		for _, m := range values {
 			var out metadataUUID
@@ -195,10 +195,10 @@ VALUES ($inputMetadata.*)`, inputMetadata{})
 				m.UUID = out.UUID
 				err = tx.Query(ctx, updateMetadataStmt, m).Run()
 				if err != nil {
-					return errors.Trace(err)
+					return errors.Capture(err)
 				}
 			} else {
-				return errors.Trace(err)
+				return errors.Capture(err)
 			}
 		}
 
@@ -209,30 +209,32 @@ VALUES ($inputMetadata.*)`, inputMetadata{})
 		if err := tx.Query(ctx, insertMetadataStmt, toInsert).Run(); dberrors.IsErrConstraintUnique(err) {
 			return cloudmetadataerrors.ImageMetadataAlreadyExists
 		} else if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		return nil
 	}))
+
 }
 
 // DeleteMetadataWithImageID deletes all metadata associated with the given image ID from the database.
 func (s *State) DeleteMetadataWithImageID(ctx context.Context, imageID string) error {
 	db, err := s.DB()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	deleteMetadataStmt, err := sqlair.Prepare(`
 DELETE FROM cloud_image_metadata 
 WHERE image_id = $metadataImageID.image_id`, metadataImageID{})
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
-	return errors.Trace(db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+	return errors.Capture(db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err := tx.Query(ctx, deleteMetadataStmt, metadataImageID{imageID}).Run()
 		return err
 	}))
+
 }
 
 // FindMetadata retrieves cloud image metadata from the database based on specified filter criteria.
@@ -241,7 +243,7 @@ WHERE image_id = $metadataImageID.image_id`, metadataImageID{})
 func (s *State) FindMetadata(ctx context.Context, criteria cloudimagemetadata.MetadataFilter) ([]cloudimagemetadata.Metadata, error) {
 	db, err := s.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	filter := metadataFilter{
@@ -307,7 +309,7 @@ WHERE %s;`, strings.Join(clauses, ` AND `))
 
 	findMetadataStmt, err := sqlair.Prepare(findMetadataQuery, append([]any{outputMetadata{}}, inputArgs...)...)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	var metadata []outputMetadata
@@ -319,7 +321,7 @@ WHERE %s;`, strings.Join(clauses, ` AND `))
 		return err
 	})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	result := make([]cloudimagemetadata.Metadata, len(metadata))
@@ -350,7 +352,7 @@ func (s *State) AllCloudImageMetadata(ctx context.Context) ([]cloudimagemetadata
 	if errors.Is(err, cloudmetadataerrors.NotFound) {
 		return nil, nil
 	}
-	return result, errors.Trace(err)
+	return result, errors.Capture(err)
 }
 
 // tryCleanUpExpiredMetadata removes metadata records from the cloud_image_metadata table that are older than [ExpirationDelay].
@@ -359,7 +361,7 @@ func (s *State) AllCloudImageMetadata(ctx context.Context) ([]cloudimagemetadata
 func (s *State) tryCleanUpExpiredMetadata(ctx context.Context) error {
 	db, err := s.DB()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	// Injection of the expiration time
@@ -375,11 +377,12 @@ DELETE FROM cloud_image_metadata
 WHERE source != $inputMetadata.source AND  
 created_at < $ttl.expires_at;`, expirationTime, customSource)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
-	return errors.Trace(db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+	return errors.Capture(db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err := tx.Query(ctx, deleteMetadataStmt, expirationTime, customSource).Run()
 		return err
 	}))
+
 }

--- a/domain/controller/state/state.go
+++ b/domain/controller/state/state.go
@@ -5,14 +5,13 @@ package state
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/canonical/sqlair"
-	"github.com/juju/errors"
 
 	"github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/domain"
+	"github.com/juju/juju/internal/errors"
 )
 
 // State represents a type for interacting with the underlying state.
@@ -31,7 +30,7 @@ func NewState(factory database.TxnRunnerFactory) *State {
 func (st *State) ControllerModelUUID(ctx context.Context) (model.UUID, error) {
 	db, err := st.DB()
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", errors.Capture(err)
 	}
 
 	var uuid controllerModelUUID
@@ -40,18 +39,18 @@ SELECT &controllerModelUUID.model_uuid
 FROM   controller
 `, uuid)
 	if err != nil {
-		return "", errors.Annotate(err, "preparing select controller model uuid statement")
+		return "", errors.Errorf("preparing select controller model uuid statement %w", err)
 	}
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err := tx.Query(ctx, stmt).Get(&uuid)
 		if errors.Is(err, sqlair.ErrNoRows) {
 			// This should never reasonably happen.
-			return fmt.Errorf("internal error: controller model uuid not found")
+			return errors.Errorf("internal error: controller model uuid not found")
 		}
 		return err
 	})
 	if err != nil {
-		return "", errors.Annotate(err, "getting controller model uuid")
+		return "", errors.Errorf("getting controller model uuid %w", err)
 	}
 
 	return model.UUID(uuid.UUID), nil

--- a/domain/controllerconfig/bootstrap/bootstrap.go
+++ b/domain/controllerconfig/bootstrap/bootstrap.go
@@ -5,15 +5,14 @@ package bootstrap
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/canonical/sqlair"
-	"github.com/juju/errors"
 
 	jujucontroller "github.com/juju/juju/controller"
 	"github.com/juju/juju/core/database"
 	coremodel "github.com/juju/juju/core/model"
 	internaldatabase "github.com/juju/juju/internal/database"
+	"github.com/juju/juju/internal/errors"
 )
 
 // InsertInitialControllerConfig inserts the initial controller configuration
@@ -22,30 +21,30 @@ func InsertInitialControllerConfig(cfg jujucontroller.Config, controllerModelUUI
 	return func(ctx context.Context, controller, model database.TxnRunner) error {
 		values, err := jujucontroller.EncodeToString(cfg)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		if err = controllerModelUUID.Validate(); err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		fields, _, err := jujucontroller.ConfigSchema.ValidationSchema()
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		for k := range values {
 			if field, ok := fields[k]; ok {
 				_, err := field.Coerce(values[k], []string{k})
 				if err != nil {
-					return errors.Annotatef(err, "unable to coerce controller config key %q", k)
+					return errors.Errorf("unable to coerce controller config key %q %w", k, err)
 				}
 			}
 		}
 
 		insertStmt, err := sqlair.Prepare(`INSERT INTO controller_config (key, value) VALUES ($dbKeyValue.*)`, dbKeyValue{})
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		controllerData := dbController{
@@ -54,7 +53,7 @@ func InsertInitialControllerConfig(cfg jujucontroller.Config, controllerModelUUI
 		}
 		controllerStmt, err := sqlair.Prepare(`INSERT INTO controller (uuid, model_uuid) VALUES ($dbController.*)`, controllerData)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		updateKeyValues := make([]dbKeyValue, 0)
@@ -68,23 +67,24 @@ func InsertInitialControllerConfig(cfg jujucontroller.Config, controllerModelUUI
 			})
 		}
 
-		return errors.Trace(controller.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		return errors.Capture(controller.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 			// Insert the controller data.
 			if err := tx.Query(ctx, controllerStmt, controllerData).Run(); err != nil {
-				return errors.Trace(err)
+				return errors.Capture(err)
 			}
 
 			// Update the attributes.
 			if len(updateKeyValues) > 0 {
 				if err := tx.Query(ctx, insertStmt, updateKeyValues).Run(); err != nil {
-					return errors.Trace(err)
+					return errors.Capture(err)
 				}
 			} else {
-				return fmt.Errorf("no controller config values to insert at bootstrap")
+				return errors.Errorf("no controller config values to insert at bootstrap")
 			}
 
 			return nil
 		}))
+
 	}
 }
 

--- a/domain/controllerconfig/bootstrap/bootstrap_test.go
+++ b/domain/controllerconfig/bootstrap/bootstrap_test.go
@@ -6,11 +6,11 @@ package bootstrap
 import (
 	"context"
 
-	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/controller"
+	coreerrors "github.com/juju/juju/core/errors"
 	coremodel "github.com/juju/juju/core/model"
 	schematesting "github.com/juju/juju/domain/schema/testing"
 	"github.com/juju/juju/internal/testing"
@@ -49,7 +49,7 @@ func (s *bootstrapSuite) TestInsertInitialControllerConfig(c *gc.C) {
 func (s *bootstrapSuite) TestValidModelUUID(c *gc.C) {
 	cfg := controller.Config{controller.CACertKey: testing.CACert}
 	err := InsertInitialControllerConfig(cfg, coremodel.UUID("bad-uuid"))(context.Background(), s.TxnRunner(), s.NoopTxnRunner())
-	c.Assert(err, jc.ErrorIs, errors.NotValid)
+	c.Assert(err, jc.ErrorIs, coreerrors.NotValid)
 }
 
 func (s *bootstrapSuite) TestInsertMinimalControllerConfig(c *gc.C) {

--- a/domain/controllerconfig/service/service.go
+++ b/domain/controllerconfig/service/service.go
@@ -6,13 +6,13 @@ package service
 import (
 	"context"
 
-	"github.com/juju/errors"
-
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/changestream"
+	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/core/watcher/eventsource"
+	"github.com/juju/juju/internal/errors"
 )
 
 // ModificationValidatorFunc is a function that validates a modification
@@ -52,11 +52,11 @@ func NewService(st State) *Service {
 func (s *Service) ControllerConfig(ctx context.Context) (controller.Config, error) {
 	ctrlConfigMap, err := s.st.ControllerConfig(ctx)
 	if err != nil {
-		return nil, errors.Annotatef(err, "unable to get controller config")
+		return nil, errors.Errorf("unable to get controller config %w", err)
 	}
 	coerced, err := deserializeMap(ctrlConfigMap)
 	if err != nil {
-		return nil, errors.Annotatef(err, "unable to coerce controller config")
+		return nil, errors.Errorf("unable to coerce controller config %w", err)
 	}
 
 	// Get the controller UUID and CA cert from the config, so we can generate
@@ -66,30 +66,30 @@ func (s *Service) ControllerConfig(ctx context.Context) (controller.Config, erro
 		ok               bool
 	)
 	if ctrlUUID, ok = coerced[controller.ControllerUUIDKey].(string); !ok {
-		return nil, errors.NotFoundf("controller UUID")
+		return nil, errors.Errorf("controller UUID %w", coreerrors.NotFound)
 	}
 	if caCert, ok = coerced[controller.CACertKey].(string); !ok {
-		return nil, errors.NotFoundf("controller CACert")
+		return nil, errors.Errorf("controller CACert %w", coreerrors.NotFound)
 	}
 
 	// Make a new controller config based on the coerced controller config map
 	// returned from state.
 	ctrlConfig, err := controller.NewConfig(ctrlUUID, caCert, coerced)
 	if err != nil {
-		return nil, errors.Annotatef(err, "unable to create controller config")
+		return nil, errors.Errorf("unable to create controller config %w", err)
 	}
-	return ctrlConfig, errors.Annotate(err, "getting controller config state")
+	return ctrlConfig, errors.Errorf("getting controller config state %w", err)
 }
 
 // UpdateControllerConfig updates the controller config.
 func (s *Service) UpdateControllerConfig(ctx context.Context, updateAttrs controller.Config, removeAttrs []string) error {
 	coerced, err := controller.EncodeToString(updateAttrs)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	err = validateConfig(coerced, removeAttrs)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	// Drop controller UUID, as we don't need to set it and it will be validated
@@ -104,35 +104,35 @@ func (s *Service) UpdateControllerConfig(ctx context.Context, updateAttrs contro
 		// For example, is it possible to move from filestorage to s3storage.
 		// But it is not possible to move from s3storage to filestorage.
 		if err := validObjectStoreProgression(current, updateAttrs, removeAttrs); err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		return nil
 	})
-	return errors.Annotate(err, "updating controller config state")
+	return errors.Errorf("updating controller config state %w", err)
 }
 
 // validateConfig validates the given updateAttrs and removeAttrs.
 func validateConfig(updateAttrs map[string]string, removeAttrs []string) error {
 	fields, _, err := controller.ConfigSchema.ValidationSchema()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	for k := range updateAttrs {
 		if err := validateConfigField(k); err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		if field, ok := fields[k]; ok {
 			_, err := field.Coerce(updateAttrs[k], []string{k})
 			if err != nil {
-				return errors.Annotatef(err, "unable to coerce controller config key %q", k)
+				return errors.Errorf("unable to coerce controller config key %q %w", k, err)
 			}
 		}
 	}
 	for _, r := range removeAttrs {
 		if err := validateConfigField(r); err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 	}
 	return nil
@@ -154,7 +154,7 @@ func validateConfigField(name string) error {
 func deserializeMap(m map[string]string) (map[string]any, error) {
 	fields, _, err := controller.ConfigSchema.ValidationSchema()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	result := make(map[string]any, len(m))
@@ -162,7 +162,7 @@ func deserializeMap(m map[string]string) (map[string]any, error) {
 		if field, ok := fields[key]; ok {
 			v, err := field.Coerce(m[key], []string{key})
 			if err != nil {
-				return nil, errors.Annotatef(err, "unable to coerce controller config key %q", key)
+				return nil, errors.Errorf("unable to coerce controller config key %q %w", key, err)
 			}
 			result[key] = v
 			continue
@@ -201,7 +201,7 @@ func validObjectStoreProgression(current map[string]string, updateAttrs controll
 		// This is rather expensive, but it's the only way to be sure that we
 		// can change from filestorage to s3storage.
 		if err := updateCompletesS3Config(current, updateAttrs); err != nil {
-			return errors.Annotatef(err, "can not change %q from %q to %q without complete s3 config", controller.ObjectStoreType, cur, upd)
+			return errors.Errorf("can not change %q from %q to %q without complete s3 config %w", controller.ObjectStoreType, cur, upd, err)
 		}
 		return nil
 	}

--- a/domain/controllerconfig/service/service.go
+++ b/domain/controllerconfig/service/service.go
@@ -78,7 +78,7 @@ func (s *Service) ControllerConfig(ctx context.Context) (controller.Config, erro
 	if err != nil {
 		return nil, errors.Errorf("unable to create controller config %w", err)
 	}
-	return ctrlConfig, errors.Errorf("getting controller config state %w", err)
+	return ctrlConfig, nil
 }
 
 // UpdateControllerConfig updates the controller config.
@@ -109,7 +109,11 @@ func (s *Service) UpdateControllerConfig(ctx context.Context, updateAttrs contro
 
 		return nil
 	})
-	return errors.Errorf("updating controller config state %w", err)
+
+	if err != nil {
+		return errors.Errorf("updating controller config state %w", err)
+	}
+	return nil
 }
 
 // validateConfig validates the given updateAttrs and removeAttrs.

--- a/domain/controllerconfig/state/state.go
+++ b/domain/controllerconfig/state/state.go
@@ -8,11 +8,11 @@ import (
 	"database/sql"
 
 	"github.com/canonical/sqlair"
-	"github.com/juju/errors"
 
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/database"
 	"github.com/juju/juju/domain"
+	"github.com/juju/juju/internal/errors"
 )
 
 // State represents a type for interacting with the underlying state.
@@ -31,12 +31,12 @@ func NewState(factory database.TxnRunnerFactory) *State {
 func (st *State) ControllerConfig(ctx context.Context) (map[string]string, error) {
 	db, err := st.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	stmt, err := st.Prepare("SELECT &KeyValue.* FROM v_controller_config", KeyValue{})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	result := make(map[string]string)
@@ -46,7 +46,7 @@ func (st *State) ControllerConfig(ctx context.Context) (map[string]string, error
 			if errors.Is(err, sql.ErrNoRows) {
 				return nil
 			}
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		for _, kv := range keyValues {
@@ -73,17 +73,17 @@ func (st *State) UpdateControllerConfig(
 ) error {
 	db, err := st.DB()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	selectStmt, err := st.Prepare("SELECT &KeyValue.* FROM v_controller_config", KeyValue{})
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	deleteStmt, err := st.Prepare("DELETE FROM controller_config WHERE key IN ($StringSlice[:])", StringSlice{})
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	updateStmt, err := st.Prepare(`
@@ -91,7 +91,7 @@ INSERT INTO controller_config (key, value)
 VALUES ($KeyValue.*)
   ON CONFLICT(key) DO UPDATE SET value=excluded.value`, KeyValue{})
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	updateKeyValues := make([]KeyValue, 0)
 	for k, v := range updateAttrs {
@@ -112,7 +112,7 @@ VALUES ($KeyValue.*)
 		var keyValues []KeyValue
 		if err := tx.Query(ctx, selectStmt).GetAll(&keyValues); err != nil {
 			if !errors.Is(err, sql.ErrNoRows) {
-				return errors.Trace(err)
+				return errors.Capture(err)
 			}
 		}
 
@@ -121,25 +121,25 @@ VALUES ($KeyValue.*)
 			current[kv.Key] = kv.Value
 		}
 		if err := validateModification(current); err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		// Update the attributes.
 		if err := tx.Query(ctx, updateStmt, updateKeyValues).Run(); err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		// Remove the attributes
 		if len(removeAttrs) > 0 {
 			if err := tx.Query(ctx, deleteStmt, StringSlice(removeAttrs)).Run(); err != nil {
-				return errors.Trace(err)
+				return errors.Capture(err)
 			}
 		}
 
 		return nil
 	})
 
-	return errors.Trace(err)
+	return errors.Capture(err)
 }
 
 // AllKeysQuery returns a SQL statement that will return

--- a/domain/controllerconfig/state/state_test.go
+++ b/domain/controllerconfig/state/state_test.go
@@ -6,7 +6,6 @@ package state
 import (
 	ctx "context"
 
-	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -14,6 +13,7 @@ import (
 	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/domain/controllerconfig/bootstrap"
 	schematesting "github.com/juju/juju/domain/schema/testing"
+	"github.com/juju/juju/internal/errors"
 	jujutesting "github.com/juju/juju/internal/testing"
 )
 

--- a/domain/controllernode/errors/errors.go
+++ b/domain/controllernode/errors/errors.go
@@ -3,9 +3,7 @@
 
 package errors
 
-import (
-	"github.com/juju/errors"
-)
+import "github.com/juju/juju/internal/errors"
 
 const (
 	// NotFound describes an error that occurs when a controller cannot be

--- a/domain/controllernode/service/service.go
+++ b/domain/controllernode/service/service.go
@@ -5,11 +5,10 @@ package service
 
 import (
 	"context"
-	"fmt"
 
-	"github.com/juju/errors"
-
+	coreerrors "github.com/juju/juju/core/errors"
 	controllernodeerrors "github.com/juju/juju/domain/controllernode/errors"
+	"github.com/juju/juju/internal/errors"
 )
 
 // State describes retrieval and persistence
@@ -34,14 +33,14 @@ func NewService(st State) *Service {
 // controller node records according to the input slices.
 func (s *Service) CurateNodes(ctx context.Context, toAdd, toRemove []string) error {
 	err := s.st.CurateNodes(ctx, toAdd, toRemove)
-	return errors.Annotatef(err, "curating controller codes; adding %v, removing %v", toAdd, toRemove)
+	return errors.Errorf("curating controller codes; adding %v, removing %v %w", toAdd, toRemove, err)
 }
 
 // UpdateDqliteNode sets the Dqlite node ID and bind address for the input
 // controller ID.
 func (s *Service) UpdateDqliteNode(ctx context.Context, controllerID string, nodeID uint64, addr string) error {
 	err := s.st.UpdateDqliteNode(ctx, controllerID, nodeID, addr)
-	return errors.Annotatef(err, "updating Dqlite node details for %q", controllerID)
+	return errors.Errorf("updating Dqlite node details for %q %w", controllerID, err)
 }
 
 // IsKnownDatabaseNamespace reports if the namespace is known to the controller.
@@ -49,13 +48,13 @@ func (s *Service) UpdateDqliteNode(ctx context.Context, controllerID string, nod
 // returned.
 func (s *Service) IsKnownDatabaseNamespace(ctx context.Context, namespace string) (bool, error) {
 	if namespace == "" {
-		return false, fmt.Errorf("namespace %q is %w, cannot be empty", namespace, errors.NotValid)
+		return false, errors.Errorf("namespace %q is %w, cannot be empty", namespace, coreerrors.NotValid)
 	}
 
 	ns, err := s.st.SelectDatabaseNamespace(ctx, namespace)
 	if err != nil {
 		if !errors.Is(err, controllernodeerrors.NotFound) {
-			return false, errors.Annotatef(err, "determining namespace existence")
+			return false, errors.Errorf("determining namespace existence %w", err)
 		}
 	}
 

--- a/domain/controllernode/service/service.go
+++ b/domain/controllernode/service/service.go
@@ -32,15 +32,19 @@ func NewService(st State) *Service {
 // CurateNodes modifies the known control plane by adding and removing
 // controller node records according to the input slices.
 func (s *Service) CurateNodes(ctx context.Context, toAdd, toRemove []string) error {
-	err := s.st.CurateNodes(ctx, toAdd, toRemove)
-	return errors.Errorf("curating controller codes; adding %v, removing %v %w", toAdd, toRemove, err)
+	if err := s.st.CurateNodes(ctx, toAdd, toRemove); err != nil {
+		return errors.Errorf("curating controller codes; adding %v, removing %v %w", toAdd, toRemove, err)
+	}
+	return nil
 }
 
 // UpdateDqliteNode sets the Dqlite node ID and bind address for the input
 // controller ID.
 func (s *Service) UpdateDqliteNode(ctx context.Context, controllerID string, nodeID uint64, addr string) error {
-	err := s.st.UpdateDqliteNode(ctx, controllerID, nodeID, addr)
-	return errors.Errorf("updating Dqlite node details for %q %w", controllerID, err)
+	if err := s.st.UpdateDqliteNode(ctx, controllerID, nodeID, addr); err != nil {
+		return errors.Errorf("updating Dqlite node details for %q %w", controllerID, err)
+	}
+	return nil
 }
 
 // IsKnownDatabaseNamespace reports if the namespace is known to the controller.

--- a/domain/controllernode/state/state.go
+++ b/domain/controllernode/state/state.go
@@ -5,15 +5,14 @@ package state
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 
 	"github.com/canonical/sqlair"
-	"github.com/juju/errors"
 
 	"github.com/juju/juju/core/database"
 	"github.com/juju/juju/domain"
 	controllernodeerrors "github.com/juju/juju/domain/controllernode/errors"
+	"github.com/juju/juju/internal/errors"
 )
 
 // State represents database interactions dealing with controller nodes.
@@ -34,7 +33,7 @@ func NewState(factory database.TxnRunnerFactory) *State {
 func (st *State) CurateNodes(ctx context.Context, insert, delete []string) error {
 	db, err := st.DB()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	// Single dbControllerNode object created here and reused.
@@ -45,34 +44,34 @@ func (st *State) CurateNodes(ctx context.Context, insert, delete []string) error
 INSERT INTO controller_node (controller_id)
 VALUES      ($dbControllerNode.*)`, controllerNode)
 	if err != nil {
-		return errors.Annotate(err, "preparing insert controller node statement")
+		return errors.Errorf("preparing insert controller node statement %w", err)
 	}
 	deleteStmt, err := st.Prepare(`
 DELETE FROM controller_node 
 WHERE       controller_id = $dbControllerNode.controller_id`, controllerNode)
 	if err != nil {
-		return errors.Annotate(err, "preparing delete controller node statement")
+		return errors.Errorf("preparing delete controller node statement %w", err)
 	}
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		for _, cID := range insert {
 			controllerNode.ControllerID = cID
 			if err := tx.Query(ctx, insertStmt, controllerNode).Run(); err != nil {
-				return errors.Annotatef(err, "inserting controller node %q", cID)
+				return errors.Errorf("inserting controller node %q %w", cID, err)
 			}
 		}
 
 		for _, cID := range delete {
 			controllerNode.ControllerID = cID
 			if err := tx.Query(ctx, deleteStmt, controllerNode).Run(); err != nil {
-				return errors.Annotatef(err, "deleting controller node %q", cID)
+				return errors.Errorf("deleting controller node %q %w", cID, err)
 			}
 		}
 
 		return nil
 	})
 
-	return errors.Annotate(err, "curating controller nodes")
+	return errors.Errorf("curating controller nodes %w", err)
 }
 
 // UpdateDqliteNode sets the Dqlite node ID and bind address for the input
@@ -80,7 +79,7 @@ WHERE       controller_id = $dbControllerNode.controller_id`, controllerNode)
 func (st *State) UpdateDqliteNode(ctx context.Context, controllerID string, nodeID uint64, addr string) error {
 	db, err := st.DB()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	// uint64 values with the high bit set cause the driver to throw an error,
@@ -102,13 +101,14 @@ WHERE  controller_id = $dbControllerNode.controller_id
 AND    (dqlite_node_id != $dbControllerNode.dqlite_node_id OR bind_address != $dbControllerNode.bind_address)`
 	stmt, err := st.Prepare(q, controllerNode)
 	if err != nil {
-		return errors.Annotate(err, "preparing update controller node statement")
+		return errors.Errorf("preparing update controller node statement %w", err)
 	}
 
-	return errors.Trace(db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+	return errors.Capture(db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err := tx.Query(ctx, stmt, controllerNode).Run()
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}))
+
 }
 
 // SelectDatabaseNamespace is responsible for selecting and returning the
@@ -117,7 +117,7 @@ AND    (dqlite_node_id != $dbControllerNode.dqlite_node_id OR bind_address != $d
 func (st *State) SelectDatabaseNamespace(ctx context.Context, namespace string) (string, error) {
 	db, err := st.DB()
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", errors.Capture(err)
 	}
 
 	dbNamespace := dbNamespace{Namespace: namespace}
@@ -126,20 +126,20 @@ func (st *State) SelectDatabaseNamespace(ctx context.Context, namespace string) 
 SELECT &dbNamespace.* from namespace_list 
 WHERE  namespace = $dbNamespace.namespace`, dbNamespace)
 	if err != nil {
-		return "", fmt.Errorf("preparing select namespace statement")
+		return "", errors.Errorf("preparing select namespace statement")
 	}
 
 	err = db.Txn(ctx, func(ctx context.Context, db *sqlair.TX) error {
 		err := db.Query(ctx, stmt, dbNamespace).Get(&dbNamespace)
 		if errors.Is(err, sqlair.ErrNoRows) {
-			return fmt.Errorf("namespace %q %w", namespace, controllernodeerrors.NotFound)
+			return errors.Errorf("namespace %q %w", namespace, controllernodeerrors.NotFound)
 		} else if err != nil {
-			return fmt.Errorf("selecting namespace %q: %w", namespace, err)
+			return errors.Errorf("selecting namespace %q: %w", namespace, err)
 		}
 		return nil
 	})
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", errors.Capture(err)
 	}
 
 	return namespace, nil

--- a/domain/credential/bootstrap/bootstrap.go
+++ b/domain/credential/bootstrap/bootstrap.go
@@ -7,7 +7,6 @@ import (
 	"context"
 
 	"github.com/canonical/sqlair"
-	"github.com/juju/errors"
 
 	"github.com/juju/juju/cloud"
 	corecredential "github.com/juju/juju/core/credential"
@@ -15,6 +14,7 @@ import (
 	"github.com/juju/juju/domain/credential"
 	"github.com/juju/juju/domain/credential/state"
 	internaldatabase "github.com/juju/juju/internal/database"
+	"github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/internal/uuid"
 )
 
@@ -27,9 +27,9 @@ func InsertCredential(key corecredential.Key, cred cloud.Credential) internaldat
 
 		credentialUUID, err := uuid.NewUUID()
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
-		return errors.Trace(controller.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		return errors.Capture(controller.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 			if err := state.CreateCredential(ctx, tx, credentialUUID.String(), key, credential.CloudCredentialInfo{
 				AuthType:      string(cred.AuthType()),
 				Attributes:    cred.Attributes(),
@@ -38,9 +38,10 @@ func InsertCredential(key corecredential.Key, cred cloud.Credential) internaldat
 				Invalid:       cred.Invalid,
 				InvalidReason: cred.InvalidReason,
 			}); err != nil {
-				return errors.Annotate(err, "creating bootstrap credential")
+				return errors.Errorf("creating bootstrap credential %w", err)
 			}
 			return nil
 		}))
+
 	}
 }

--- a/domain/credential/errors/errors.go
+++ b/domain/credential/errors/errors.go
@@ -3,9 +3,7 @@
 
 package errors
 
-import (
-	"github.com/juju/errors"
-)
+import "github.com/juju/juju/internal/errors"
 
 const (
 	// CredentialModelValidation describes an error that occurs when a credential

--- a/domain/credential/modelmigration/export.go
+++ b/domain/credential/modelmigration/export.go
@@ -7,7 +7,6 @@ import (
 	"context"
 
 	"github.com/juju/description/v8"
-	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 
 	"github.com/juju/juju/cloud"
@@ -17,6 +16,7 @@ import (
 	"github.com/juju/juju/core/user"
 	"github.com/juju/juju/domain/credential/service"
 	"github.com/juju/juju/domain/credential/state"
+	"github.com/juju/juju/internal/errors"
 )
 
 // RegisterExport registers the export operations with the given coordinator.
@@ -67,7 +67,7 @@ func (e *exportOperation) Execute(ctx context.Context, model description.Model) 
 	}
 	name, err := user.NewName(credInfo.Owner())
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	key := credential.Key{
 		Cloud: credInfo.Cloud(),
@@ -76,7 +76,7 @@ func (e *exportOperation) Execute(ctx context.Context, model description.Model) 
 	}
 	cred, err := e.service.CloudCredential(ctx, key)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	model.SetCloudCredential(description.CloudCredentialArgs{
 		Owner:      names.NewUserTag(key.Owner.Name()),

--- a/domain/credential/modelmigration/export_test.go
+++ b/domain/credential/modelmigration/export_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 
 	"github.com/juju/description/v8"
-	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 	jc "github.com/juju/testing/checkers"
 	"go.uber.org/mock/gomock"
@@ -15,6 +14,7 @@ import (
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/core/credential"
+	coreerrors "github.com/juju/juju/core/errors"
 	usertesting "github.com/juju/juju/core/user/testing"
 )
 
@@ -77,7 +77,7 @@ func (s *exportSuite) TestExportNotFound(c *gc.C) {
 	key := credential.Key{Cloud: "cirrus", Owner: usertesting.GenNewName(c, "fred"), Name: "foo"}
 	s.service.EXPECT().CloudCredential(gomock.Any(), key).
 		Times(1).
-		Return(cloud.Credential{}, errors.NotFound)
+		Return(cloud.Credential{}, coreerrors.NotFound)
 
 	op := s.newExportOperation()
 	err := op.Execute(context.Background(), dst)

--- a/domain/credential/modelmigration/import.go
+++ b/domain/credential/modelmigration/import.go
@@ -8,15 +8,16 @@ import (
 	"reflect"
 
 	"github.com/juju/description/v8"
-	"github.com/juju/errors"
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/core/credential"
+	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/modelmigration"
 	"github.com/juju/juju/core/user"
 	"github.com/juju/juju/domain/credential/service"
 	"github.com/juju/juju/domain/credential/state"
+	"github.com/juju/juju/internal/errors"
 )
 
 // Coordinator is the interface that is used to add operations to a migration.
@@ -69,7 +70,7 @@ func (i *importOperation) Execute(ctx context.Context, model description.Model) 
 
 	name, err := user.NewName(cred.Owner())
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	// Need to add credential or make sure an existing credential
 	// matches.
@@ -79,18 +80,18 @@ func (i *importOperation) Execute(ctx context.Context, model description.Model) 
 		Name:  cred.Name(),
 	}
 	if err := key.Validate(); err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	existing, err := i.service.CloudCredential(ctx, key)
 
-	if errors.Is(err, errors.NotFound) {
+	if errors.Is(err, coreerrors.NotFound) {
 		credential := cloud.NewCredential(
 			cloud.AuthType(cred.AuthType()),
 			cred.Attributes())
-		return errors.Trace(i.service.UpdateCloudCredential(ctx, key, credential))
+		return errors.Capture(i.service.UpdateCloudCredential(ctx, key, credential))
 	} else if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	// ensure existing cred matches.
 	if existing.AuthType() != cloud.AuthType(cred.AuthType()) {

--- a/domain/credential/modelmigration/import_test.go
+++ b/domain/credential/modelmigration/import_test.go
@@ -8,7 +8,6 @@ import (
 	"regexp"
 
 	"github.com/juju/description/v8"
-	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 	jc "github.com/juju/testing/checkers"
 	"go.uber.org/mock/gomock"
@@ -16,6 +15,7 @@ import (
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/core/credential"
+	coreerrors "github.com/juju/juju/core/errors"
 	usertesting "github.com/juju/juju/core/user/testing"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 )
@@ -79,7 +79,7 @@ func (s *importSuite) TestImport(c *gc.C) {
 	)
 	cred := cloud.NewCredential(cloud.UserPassAuthType, map[string]string{"hello": "world"})
 	key := credential.Key{Cloud: "cirrus", Owner: usertesting.GenNewName(c, "fred"), Name: "foo"}
-	s.service.EXPECT().CloudCredential(gomock.All(), key).Times(1).Return(cloud.Credential{}, errors.NotFound)
+	s.service.EXPECT().CloudCredential(gomock.All(), key).Times(1).Return(cloud.Credential{}, coreerrors.NotFound)
 	s.service.EXPECT().UpdateCloudCredential(gomock.Any(), key, cred).Times(1)
 
 	op := s.newImportOperation()

--- a/domain/credential/service/modelcredential.go
+++ b/domain/credential/service/modelcredential.go
@@ -176,7 +176,7 @@ func checkMachineInstances(ctx stdcontext.Context, machineState MachineState, ma
 			// to know about it.
 			continue
 		} else if err != nil {
-			results = append(results, errors.Errorf("getting instance id for machine %s %w", machine.Id(), err))
+			results = append(results, errors.Errorf("getting instance id for machine %s: %w", machine.Id(), err))
 			continue
 		}
 		machinesByInstance[instanceId] = machine.Id()

--- a/domain/credential/service/modelcredential_test.go
+++ b/domain/credential/service/modelcredential_test.go
@@ -6,7 +6,6 @@ package service
 import (
 	"context"
 
-	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"go.uber.org/mock/gomock"
@@ -15,6 +14,7 @@ import (
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/cloud"
 	corecredential "github.com/juju/juju/core/credential"
+	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/machine"
 	usertesting "github.com/juju/juju/core/user/testing"
@@ -22,6 +22,7 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/envcontext"
 	"github.com/juju/juju/environs/instances"
+	"github.com/juju/juju/internal/errors"
 	jujutesting "github.com/juju/juju/internal/testing"
 )
 
@@ -262,7 +263,7 @@ func (s *CheckMachinesSuite) TestCheckMachinesNotProvisionedError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	machine1 := createTestMachine("2", "")
-	machine1.instanceIdFunc = func() (instance.Id, error) { return "", errors.NotProvisionedf("machine 2") }
+	machine1.instanceIdFunc = func() (instance.Id, error) { return "", errors.Errorf("machine 2 %w", coreerrors.NotProvisioned) }
 	s.machineState.EXPECT().AllMachines().Return([]Machine{s.machine, machine1}, nil)
 	s.machineService.EXPECT().GetMachineUUID(gomock.Any(), machine.Name(s.machine.Id())).Return("deadbeef", nil)
 	s.machineService.EXPECT().InstanceID(gomock.Any(), "deadbeef").Return("wind-up", nil)

--- a/domain/credential/service/providerservice.go
+++ b/domain/credential/service/providerservice.go
@@ -6,13 +6,12 @@ package service
 import (
 	"context"
 
-	"github.com/juju/errors"
-
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/core/changestream"
 	corecredential "github.com/juju/juju/core/credential"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/domain/credential"
+	"github.com/juju/juju/internal/errors"
 )
 
 // ProviderState describes retrieval and persistence methods for storage.
@@ -47,11 +46,11 @@ func NewProviderService(st ProviderState) *ProviderService {
 // CloudCredential returns the cloud credential for the given tag.
 func (s *ProviderService) CloudCredential(ctx context.Context, key corecredential.Key) (cloud.Credential, error) {
 	if err := key.Validate(); err != nil {
-		return cloud.Credential{}, errors.Annotate(err, "invalid id getting cloud credential")
+		return cloud.Credential{}, errors.Errorf("invalid id getting cloud credential %w", err)
 	}
 	credInfo, err := s.st.CloudCredential(ctx, key)
 	if err != nil {
-		return cloud.Credential{}, errors.Trace(err)
+		return cloud.Credential{}, errors.Capture(err)
 	}
 	cred := cloud.NewNamedCredential(credInfo.Label, cloud.AuthType(credInfo.AuthType), credInfo.Attributes, credInfo.Revoked)
 	cred.Invalid = credInfo.Invalid
@@ -81,7 +80,7 @@ func NewWatchableProviderService(st ProviderState, watcherFactory WatcherFactory
 // credential.
 func (s *WatchableProviderService) WatchCredential(ctx context.Context, key corecredential.Key) (watcher.NotifyWatcher, error) {
 	if err := key.Validate(); err != nil {
-		return nil, errors.Annotatef(err, "invalid id watching cloud credential")
+		return nil, errors.Errorf("invalid id watching cloud credential %w", err)
 	}
 	return s.st.WatchCredential(ctx, s.watcherFactory.NewValueWatcher, key)
 }

--- a/domain/credential/service/service.go
+++ b/domain/credential/service/service.go
@@ -9,18 +9,19 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/core/changestream"
 	corecredential "github.com/juju/juju/core/credential"
+	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/logger"
 	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/user"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/domain/credential"
 	credentialerrors "github.com/juju/juju/domain/credential/errors"
+	"github.com/juju/juju/internal/errors"
 )
 
 // WatcherFactory instances return a watcher for a specified credential UUID,
@@ -96,11 +97,11 @@ func (s *Service) WithLegacyRemover(remover func(tag names.CloudCredentialTag) e
 // CloudCredential returns the cloud credential for the given tag.
 func (s *Service) CloudCredential(ctx context.Context, key corecredential.Key) (cloud.Credential, error) {
 	if err := key.Validate(); err != nil {
-		return cloud.Credential{}, errors.Annotate(err, "invalid id getting cloud credential")
+		return cloud.Credential{}, errors.Errorf("invalid id getting cloud credential %w", err)
 	}
 	credInfo, err := s.st.CloudCredential(ctx, key)
 	if err != nil {
-		return cloud.Credential{}, errors.Trace(err)
+		return cloud.Credential{}, errors.Capture(err)
 	}
 	cred := cloud.NewNamedCredential(credInfo.Label, cloud.AuthType(credInfo.AuthType), credInfo.Attributes, credInfo.Revoked)
 	cred.Invalid = credInfo.Invalid
@@ -113,7 +114,7 @@ func (s *Service) CloudCredential(ctx context.Context, key corecredential.Key) (
 func (s *Service) AllCloudCredentialsForOwner(ctx context.Context, owner user.Name) (map[corecredential.Key]cloud.Credential, error) {
 	creds, err := s.st.AllCloudCredentialsForOwner(ctx, owner)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	result := make(map[corecredential.Key]cloud.Credential)
 	for id, c := range creds {
@@ -127,7 +128,7 @@ func (s *Service) AllCloudCredentialsForOwner(ctx context.Context, owner user.Na
 func (s *Service) CloudCredentialsForOwner(ctx context.Context, owner user.Name, cloudName string) (map[string]cloud.Credential, error) {
 	creds, err := s.st.CloudCredentialsForOwner(ctx, owner, cloudName)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	result := make(map[string]cloud.Credential)
 	for name, credInfoResult := range creds {
@@ -139,7 +140,7 @@ func (s *Service) CloudCredentialsForOwner(ctx context.Context, owner user.Name,
 // UpdateCloudCredential adds or updates a cloud credential with the given tag.
 func (s *Service) UpdateCloudCredential(ctx context.Context, key corecredential.Key, cred cloud.Credential) error {
 	if err := key.Validate(); err != nil {
-		return errors.Annotatef(err, "invalid id updating cloud credential")
+		return errors.Errorf("invalid id updating cloud credential %w", err)
 	}
 	_, err := s.st.UpsertCloudCredential(ctx, key, credentialInfoFromCloudCredential(cred))
 	return err
@@ -148,7 +149,7 @@ func (s *Service) UpdateCloudCredential(ctx context.Context, key corecredential.
 // RemoveCloudCredential removes a cloud credential with the given tag.
 func (s *Service) RemoveCloudCredential(ctx context.Context, key corecredential.Key) error {
 	if err := key.Validate(); err != nil {
-		return errors.Annotatef(err, "invalid id removing cloud credential")
+		return errors.Errorf("invalid id removing cloud credential %w", err)
 	}
 	return s.st.RemoveCloudCredential(ctx, key)
 }
@@ -156,15 +157,15 @@ func (s *Service) RemoveCloudCredential(ctx context.Context, key corecredential.
 // InvalidateCredential marks the cloud credential for the given name, cloud, owner as invalid.
 func (s *Service) InvalidateCredential(ctx context.Context, key corecredential.Key, reason string) error {
 	if err := key.Validate(); err != nil {
-		return errors.Annotatef(err, "invalid id invalidating cloud credential")
+		return errors.Errorf("invalid id invalidating cloud credential %w", err)
 	}
 	return s.st.InvalidateCloudCredential(ctx, key, reason)
 }
 
 func (s *Service) modelsUsingCredential(ctx context.Context, key corecredential.Key) (map[coremodel.UUID]string, error) {
 	models, err := s.st.ModelsUsingCloudCredential(ctx, key)
-	if err != nil && !errors.Is(err, errors.NotFound) {
-		return nil, errors.Trace(err)
+	if err != nil && !errors.Is(err, coreerrors.NotFound) {
+		return nil, errors.Capture(err)
 	}
 	return models, nil
 }
@@ -179,12 +180,12 @@ func (s *Service) modelsUsingCredential(ctx context.Context, key corecredential.
 // but before validation can complete.
 func (s *Service) CheckAndUpdateCredential(ctx context.Context, key corecredential.Key, cred cloud.Credential, force bool) ([]UpdateCredentialModelResult, error) {
 	if err := key.Validate(); err != nil {
-		return nil, errors.Annotatef(err, "invalid id updating cloud credential")
+		return nil, errors.Errorf("invalid id updating cloud credential %w", err)
 	}
 
 	models, err := s.modelsUsingCredential(ctx, key)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	var (
@@ -213,10 +214,10 @@ func (s *Service) CheckAndUpdateCredential(ctx context.Context, key corecredenti
 
 	existingInvalid, err := s.st.UpsertCloudCredential(ctx, key, credentialInfoFromCloudCredential(cred))
 	if err != nil {
-		if errors.Is(err, errors.NotFound) {
-			err = fmt.Errorf("%w %q for credential %q", credentialerrors.UnknownCloud, key.Name, key.Cloud)
+		if errors.Is(err, coreerrors.NotFound) {
+			err = errors.Errorf("%w %q for credential %q", credentialerrors.UnknownCloud, key.Name, key.Cloud)
 		}
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	if s.legacyUpdater == nil || cred.Invalid {
 		return modelsResult, nil
@@ -231,10 +232,10 @@ func (s *Service) CheckAndUpdateCredential(ctx context.Context, key corecredenti
 	if existingInvalid != nil && *existingInvalid {
 		tag, err := key.Tag()
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, errors.Capture(err)
 		}
 		if err := s.legacyUpdater(tag); err != nil {
-			return nil, errors.Trace(err)
+			return nil, errors.Capture(err)
 		}
 	}
 	return modelsResult, nil
@@ -247,12 +248,12 @@ func (s *Service) CheckAndUpdateCredential(ctx context.Context, key corecredenti
 // but before validation can complete.
 func (s *Service) CheckAndRevokeCredential(ctx context.Context, key corecredential.Key, force bool) error {
 	if err := key.Validate(); err != nil {
-		return errors.Annotatef(err, "invalid id revoking cloud credential")
+		return errors.Errorf("invalid id revoking cloud credential %w", err)
 	}
 
 	models, err := s.modelsUsingCredential(ctx, key)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	if len(models) != 0 {
 		opMessage := "cannot be deleted as"
@@ -271,15 +272,15 @@ func (s *Service) CheckAndRevokeCredential(ctx context.Context, key corecredenti
 	}
 	err = s.st.RemoveCloudCredential(ctx, key)
 	if err != nil || s.legacyRemover == nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	} else {
 		// If credential was successfully removed, we also want to clear all references to it from the models.
 		tag, err := key.Tag()
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		if err := s.legacyRemover(tag); err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 	}
 	return nil
@@ -307,7 +308,7 @@ func NewWatchableService(st State, watcherFactory WatcherFactory, logger logger.
 // credential.
 func (s *WatchableService) WatchCredential(ctx context.Context, key corecredential.Key) (watcher.NotifyWatcher, error) {
 	if err := key.Validate(); err != nil {
-		return nil, errors.Annotatef(err, "invalid id watching cloud credential")
+		return nil, errors.Errorf("invalid id watching cloud credential %w", err)
 	}
 	return s.st.WatchCredential(ctx, s.watcherFactory.NewValueWatcher, key)
 }

--- a/domain/credential/service/service_test.go
+++ b/domain/credential/service/service_test.go
@@ -6,7 +6,6 @@ package service
 import (
 	"context"
 
-	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 	jc "github.com/juju/testing/checkers"
 	"go.uber.org/mock/gomock"
@@ -14,10 +13,12 @@ import (
 
 	"github.com/juju/juju/cloud"
 	corecredential "github.com/juju/juju/core/credential"
+	coreerrors "github.com/juju/juju/core/errors"
 	coremodel "github.com/juju/juju/core/model"
 	usertesting "github.com/juju/juju/core/user/testing"
 	"github.com/juju/juju/core/watcher/watchertest"
 	"github.com/juju/juju/domain/credential"
+	"github.com/juju/juju/internal/errors"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 	jujutesting "github.com/juju/juju/internal/testing"
 )
@@ -209,7 +210,7 @@ func (s *serviceSuite) TestCheckAndUpdateCredentialsNoModelsFound(c *gc.C) {
 		Name:  "foobar",
 	}
 
-	s.state.EXPECT().ModelsUsingCloudCredential(gomock.Any(), key).Return(nil, errors.NotFound)
+	s.state.EXPECT().ModelsUsingCloudCredential(gomock.Any(), key).Return(nil, coreerrors.NotFound)
 
 	var invalid = true
 	s.state.EXPECT().UpsertCloudCredential(gomock.Any(), key, cred).Return(&invalid, nil)
@@ -251,7 +252,7 @@ func (s *serviceSuite) TestUpdateCredentialsModelsError(c *gc.C) {
 	var legacyUpdated bool
 	service := s.service(c).
 		WithLegacyUpdater(func(tag names.CloudCredentialTag) error {
-			return errors.NotImplemented
+			return coreerrors.NotImplemented
 		})
 
 	results, err := service.CheckAndUpdateCredential(context.Background(), key, cred, false)
@@ -340,7 +341,7 @@ func (s *serviceSuite) TestRevokeCredentialsModelsError(c *gc.C) {
 	var legacyUpdated bool
 	service := s.service(c).
 		WithLegacyRemover(func(tag names.CloudCredentialTag) error {
-			return errors.NotImplemented
+			return coreerrors.NotImplemented
 		})
 
 	err := service.CheckAndRevokeCredential(context.Background(), key, false)

--- a/domain/credential/state/state.go
+++ b/domain/credential/state/state.go
@@ -9,11 +9,11 @@ import (
 	"fmt"
 
 	"github.com/canonical/sqlair"
-	"github.com/juju/errors"
 
 	"github.com/juju/juju/core/changestream"
 	corecredential "github.com/juju/juju/core/credential"
 	coredatabase "github.com/juju/juju/core/database"
+	coreerrors "github.com/juju/juju/core/errors"
 	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/user"
 	"github.com/juju/juju/core/watcher"
@@ -22,6 +22,7 @@ import (
 	"github.com/juju/juju/domain/credential"
 	credentialerrors "github.com/juju/juju/domain/credential/errors"
 	"github.com/juju/juju/internal/database"
+	"github.com/juju/juju/internal/errors"
 )
 
 // State is used to access the database.
@@ -50,7 +51,7 @@ func credentialKeyMap(key corecredential.Key) sqlair.M {
 func (st *State) CredentialUUIDForKey(ctx context.Context, key corecredential.Key) (corecredential.UUID, error) {
 	db, err := st.DB()
 	if err != nil {
-		return corecredential.UUID(""), errors.Trace(err)
+		return corecredential.UUID(""), errors.Capture(err)
 	}
 
 	var rval corecredential.UUID
@@ -78,22 +79,22 @@ AND cloud_name = $M.cloud_name
 `
 	selectStmt, err := st.Prepare(selectQ, sqlair.M{})
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", errors.Capture(err)
 	}
 	uuid := sqlair.M{}
 	err = tx.Query(ctx, selectStmt, credentialKeyMap(key)).Get(&uuid)
 	if errors.Is(err, sql.ErrNoRows) {
-		return "", fmt.Errorf("cloud credential %q %w", key, credentialerrors.NotFound)
+		return "", errors.Errorf("cloud credential %q %w", key, credentialerrors.NotFound)
 	} else if err != nil {
-		return "", fmt.Errorf("fetching cloud credential %q: %w", key, err)
+		return "", errors.Errorf("fetching cloud credential %q: %w", key, err)
 	}
 
 	uuidStr, exists := uuid["uuid"]
 	if !exists {
-		return "", fmt.Errorf(
+		return "", errors.Errorf(
 			"%w expected cloud credential uuid for credential %q, got no returned value",
-			credentialerrors.NotFound, key,
-		)
+			credentialerrors.NotFound, key)
+
 	}
 
 	return corecredential.UUID(uuidStr.(string)), nil
@@ -108,7 +109,7 @@ AND cloud_name = $M.cloud_name
 func (st *State) UpsertCloudCredential(ctx context.Context, key corecredential.Key, credential credential.CloudCredentialInfo) (*bool, error) {
 	db, err := st.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	q := `
@@ -121,7 +122,7 @@ AND owner_name = $M.owner
 `
 	stmt, err := st.Prepare(q, sqlair.M{})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	var existingInvalid *bool
@@ -132,7 +133,7 @@ AND owner_name = $M.owner
 		result := sqlair.M{}
 		err = tx.Query(ctx, stmt, credentialKeyMap(key)).Get(result)
 		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		invalid, ok := result["invalid"].(bool)
 		if ok {
@@ -141,21 +142,21 @@ AND owner_name = $M.owner
 		credentialUUID, ok := result["uuid"].(string)
 		if !ok {
 			if credential.Invalid || credential.InvalidReason != "" {
-				return fmt.Errorf("adding invalid credential %w", errors.NotSupported)
+				return errors.Errorf("adding invalid credential %w", coreerrors.NotSupported)
 			}
 			id, err := corecredential.NewUUID()
 			if err != nil {
-				return fmt.Errorf("generating new credential uuid: %w", err)
+				return errors.Errorf("generating new credential uuid: %w", err)
 			}
 			credentialUUID = id.String()
 		}
 
 		if err := upsertCredential(ctx, tx, credentialUUID, key, credential); err != nil {
-			return fmt.Errorf("updating credential: %w", err)
+			return errors.Errorf("updating credential: %w", err)
 		}
 
 		if err := updateCredentialAttributes(ctx, tx, credentialUUID, credential.Attributes); err != nil {
-			return fmt.Errorf("updating credential %q attributes: %w", key.Name, err)
+			return errors.Errorf("updating credential %q attributes: %w", key.Name, err)
 		}
 
 		// TODO(wallyworld) - update model status (suspended etc)
@@ -163,17 +164,17 @@ AND owner_name = $M.owner
 		return nil
 	})
 
-	return existingInvalid, errors.Trace(err)
+	return existingInvalid, errors.Capture(err)
 }
 
 // CreateCredential saves the specified credential.
 // Exported for use in the related credential bootstrap package.
 func CreateCredential(ctx context.Context, tx *sqlair.TX, credentialUUID string, key corecredential.Key, credential credential.CloudCredentialInfo) error {
 	if err := upsertCredential(ctx, tx, credentialUUID, key, credential); err != nil {
-		return errors.Annotatef(err, "creating credential %s", credentialUUID)
+		return errors.Errorf("creating credential %s %w", credentialUUID, err)
 	}
 	if err := updateCredentialAttributes(ctx, tx, credentialUUID, credential.Attributes); err != nil {
-		return errors.Annotatef(err, "creating credential %s attributes", credentialUUID)
+		return errors.Errorf("creating credential %s attributes %w", credentialUUID, err)
 	}
 	return nil
 }
@@ -181,7 +182,7 @@ func CreateCredential(ctx context.Context, tx *sqlair.TX, credentialUUID string,
 func upsertCredential(ctx context.Context, tx *sqlair.TX, credentialUUID string, key corecredential.Key, credential credential.CloudCredentialInfo) error {
 	dbCredential, err := dbCredentialFromCredential(ctx, tx, credentialUUID, key, credential)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	insertQuery := `
@@ -207,14 +208,14 @@ ON CONFLICT(uuid) DO UPDATE SET name=excluded.name,
 
 	insertStmt, err := sqlair.Prepare(insertQuery, Credential{})
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	err = tx.Query(ctx, insertStmt, dbCredential).Run()
 	if database.IsErrConstraintCheck(err) {
-		return fmt.Errorf("credential name cannot be empty%w%w", errors.Hide(errors.NotValid), errors.Hide(err))
+		return errors.Errorf("credential name cannot be empty", errors.Hide(coreerrors.NotValid), errors.Hide(err))
 	} else if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	return nil
 }
@@ -230,10 +231,10 @@ WHERE        cloud_credential_uuid = $M.uuid
 
 	deleteStmt, err := sqlair.Prepare(deleteQuery, sqlair.M{})
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	if err := tx.Query(ctx, deleteStmt, sqlair.M{"uuid": credentialUUID}).Run(); err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	insertQuery := `
@@ -248,7 +249,7 @@ ON CONFLICT(cloud_credential_uuid, key) DO UPDATE SET key=excluded.key,
 `
 	insertStmt, err := sqlair.Prepare(insertQuery, CredentialAttribute{})
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	for key, value := range attr {
@@ -257,7 +258,7 @@ ON CONFLICT(cloud_credential_uuid, key) DO UPDATE SET key=excluded.key,
 			Key:            key,
 			Value:          value,
 		}).Run(); err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 	}
 	return nil
@@ -280,30 +281,30 @@ func dbCredentialFromCredential(ctx context.Context, tx *sqlair.TX, credentialUU
 
 	userUUID, err := userstate.GetUserUUIDByName(ctx, tx, key.Owner)
 	if err != nil {
-		return nil, fmt.Errorf("getting user uuid for credential owner %q: %w", key.Owner, err)
+		return nil, errors.Errorf("getting user uuid for credential owner %q: %w", key.Owner, err)
 	}
 	cred.OwnerUUID = userUUID.String()
 
 	q := "SELECT uuid AS &Credential.cloud_uuid FROM cloud WHERE name = $dbCloudName.name"
 	stmt, err := sqlair.Prepare(q, Credential{}, dbCloudName{})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	err = tx.Query(ctx, stmt, dbCloudName{Name: key.Cloud}).Get(cred)
 	if err != nil {
 		if errors.Is(err, sqlair.ErrNoRows) {
-			return nil, fmt.Errorf("cloud %q for credential %w", key.Cloud, errors.NotFound)
+			return nil, errors.Errorf("cloud %q for credential %w", key.Cloud, coreerrors.NotFound)
 		}
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	validAuthTypes, err := validAuthTypesForCloud(ctx, tx, key.Cloud)
 	if err != nil {
-		return nil, errors.Annotate(err, "loading cloud auth types")
+		return nil, errors.Errorf("loading cloud auth types %w", err)
 	}
 	if errors.Is(err, sqlair.ErrNoRows) {
-		return nil, errors.Annotate(err, "no valid cloud auth types")
+		return nil, errors.Errorf("no valid cloud auth types %w", err)
 	}
 	var validAuthTypeNames []string
 	for _, at := range validAuthTypes {
@@ -313,9 +314,10 @@ func dbCredentialFromCredential(ctx context.Context, tx *sqlair.TX, credentialUU
 		validAuthTypeNames = append(validAuthTypeNames, at.Type)
 	}
 	if cred.AuthTypeID == -1 {
-		return nil, fmt.Errorf(
+		return nil, errors.Errorf(
 			"validating credential %q owned by %q for cloud %q: supported auth-types %q, %q %w",
-			key.Name, key.Owner, key.Cloud, validAuthTypeNames, credential.AuthType, errors.NotSupported)
+			key.Name, key.Owner, key.Cloud, validAuthTypeNames, credential.AuthType, coreerrors.NotSupported)
+
 	}
 	return cred, nil
 }
@@ -331,19 +333,19 @@ WHERE  cloud.name = $dbCloudName.name
 	cloud := dbCloudName{Name: cloudName}
 	stmt, err := sqlair.Prepare(authTypeQuery, authType{}, cloud)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	var result authTypes
 	err = tx.Query(ctx, stmt, cloud).GetAll(&result)
-	return result, errors.Trace(err)
+	return result, errors.Capture(err)
 }
 
 // InvalidateCloudCredential marks a cloud credential with the given name, cloud and owner. as invalid.
 func (st *State) InvalidateCloudCredential(ctx context.Context, key corecredential.Key, reason string) error {
 	db, err := st.DB()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	q := `
@@ -363,7 +365,7 @@ AND    cloud_credential.cloud_uuid = (
 )`
 	stmt, err := st.Prepare(q, sqlair.M{})
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
@@ -372,18 +374,18 @@ AND    cloud_credential.cloud_uuid = (
 		terms["invalid_reason"] = reason
 		err = tx.Query(ctx, stmt, terms).Get(&outcome)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		n, err := outcome.Result().RowsAffected()
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		if n < 1 {
-			return fmt.Errorf("credential %q for cloud %q owned by %q %w", key.Name, key.Cloud, key.Owner, errors.NotFound)
+			return errors.Errorf("credential %q for cloud %q owned by %q %w", key.Name, key.Cloud, key.Owner, coreerrors.NotFound)
 		}
 		return nil
 	})
-	return errors.Trace(err)
+	return errors.Capture(err)
 }
 
 // CloudCredentialsForOwner returns the owner's cloud credentials for a given
@@ -391,7 +393,7 @@ AND    cloud_credential.cloud_uuid = (
 func (st *State) CloudCredentialsForOwner(ctx context.Context, owner user.Name, cloudName string) (map[string]credential.CloudCredentialResult, error) {
 	db, err := st.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	var (
@@ -425,22 +427,22 @@ AND    cloud.name = $ownerAndCloudName.cloud_name
 			CredentialAttribute{},
 		)
 		if err != nil {
-			return errors.Annotatef(err, "preparing select credentials for owner statement")
+			return errors.Errorf("preparing select credentials for owner statement %w", err)
 		}
 
 		err = tx.Query(ctx, credStmt, names).GetAll(&dbRows, &dbAuthTypes, &keyValues)
 		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-			return errors.Annotate(err, "loading cloud credentials")
+			return errors.Errorf("loading cloud credentials %w", err)
 		}
 		return nil
 	})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	creds, err := dbRows.ToCloudCredentials(cloudName, dbAuthTypes, keyValues)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	result := make(map[string]credential.CloudCredentialResult)
 	for _, cred := range creds {
@@ -453,7 +455,7 @@ AND    cloud.name = $ownerAndCloudName.cloud_name
 func (st *State) CloudCredential(ctx context.Context, key corecredential.Key) (credential.CloudCredentialResult, error) {
 	db, err := st.DB()
 	if err != nil {
-		return credential.CloudCredentialResult{}, errors.Trace(err)
+		return credential.CloudCredentialResult{}, errors.Capture(err)
 	}
 
 	var (
@@ -489,32 +491,32 @@ AND    cc.name = $credentialKey.name
 			CredentialAttribute{},
 		)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		err = tx.Query(ctx, credStmt, credKey).GetAll(&dbRows, &dbAuthTypes, &keyValues)
 		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-			return errors.Annotate(err, "loading cloud credentials")
+			return errors.Errorf("loading cloud credentials %w", err)
 		}
 		return nil
 	})
 	if err != nil {
-		return credential.CloudCredentialResult{}, errors.Trace(err)
+		return credential.CloudCredentialResult{}, errors.Capture(err)
 	}
 	if len(dbRows) == 0 {
-		return credential.CloudCredentialResult{}, fmt.Errorf(
+		return credential.CloudCredentialResult{}, errors.Errorf(
 			"%w: credential %q for cloud %q owned by %q",
-			credentialerrors.CredentialNotFound, key.Name, key.Cloud, key.Owner,
-		)
+			credentialerrors.CredentialNotFound, key.Name, key.Cloud, key.Owner)
+
 	}
 	creds, err := dbRows.ToCloudCredentials(key.Cloud, dbAuthTypes, keyValues)
 	if err != nil {
-		return credential.CloudCredentialResult{}, errors.Trace(err)
+		return credential.CloudCredentialResult{}, errors.Capture(err)
 	}
 	if len(creds) > 1 {
 		return credential.CloudCredentialResult{}, errors.Errorf("expected 1 credential, got %d", len(creds))
 	}
-	return creds[0], errors.Trace(err)
+	return creds[0], errors.Capture(err)
 }
 
 // GetCloudCredential is responsible for returning a cloud credential identified
@@ -526,7 +528,7 @@ func (st *State) GetCloudCredential(
 ) (credential.CloudCredentialResult, error) {
 	db, err := st.DB()
 	if err != nil {
-		return credential.CloudCredentialResult{}, errors.Trace(err)
+		return credential.CloudCredentialResult{}, errors.Capture(err)
 	}
 
 	var rval credential.CloudCredentialResult
@@ -563,7 +565,7 @@ WHERE uuid = $M.id
 
 	stmt, err := st.Prepare(q, credentialWithAttribute{}, sqlair.M{})
 	if err != nil {
-		return credential.CloudCredentialResult{}, errors.Trace(err)
+		return credential.CloudCredentialResult{}, errors.Capture(err)
 	}
 
 	args := sqlair.M{
@@ -573,9 +575,9 @@ WHERE uuid = $M.id
 
 	err = tx.Query(ctx, stmt, args).GetAll(&rows)
 	if errors.Is(err, sql.ErrNoRows) {
-		return credential.CloudCredentialResult{}, fmt.Errorf("%w for id %q", credentialerrors.NotFound, id)
+		return credential.CloudCredentialResult{}, errors.Errorf("%w for id %q", credentialerrors.NotFound, id)
 	} else if err != nil {
-		return credential.CloudCredentialResult{}, fmt.Errorf("getting cloud credential for id %q: %w", id, err)
+		return credential.CloudCredentialResult{}, errors.Errorf("getting cloud credential for id %q: %w", id, err)
 	}
 
 	rval := credential.CloudCredentialResult{
@@ -600,7 +602,7 @@ WHERE uuid = $M.id
 func (st *State) AllCloudCredentialsForOwner(ctx context.Context, owner user.Name) (map[corecredential.Key]credential.CloudCredentialResult, error) {
 	db, err := st.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	var (
@@ -635,23 +637,23 @@ AND    user.name = $ownerName.name
 			CredentialAttribute{},
 		)
 		if err != nil {
-			return errors.Annotatef(err, "preparing select all credentials for owner statement")
+			return errors.Errorf("preparing select all credentials for owner statement %w", err)
 		}
 
 		err = tx.Query(ctx, credStmt, ownerName).GetAll(&dbRows, &dbCloudNames, &dbAuthTypes, &keyValues)
 		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-			return errors.Annotate(err, "loading cloud credentials")
+			return errors.Errorf("loading cloud credentials %w", err)
 		}
 		return nil
 	})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	result := make(map[corecredential.Key]credential.CloudCredentialResult)
 	for _, cloudName := range dbCloudNames {
 		infos, err := dbRows.ToCloudCredentials(cloudName.Name, dbAuthTypes, keyValues)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, errors.Capture(err)
 		}
 		for _, info := range infos {
 			result[corecredential.Key{
@@ -662,16 +664,16 @@ AND    user.name = $ownerName.name
 		}
 	}
 	if len(result) == 0 {
-		return nil, fmt.Errorf("cloud credentials for %q %w", owner, errors.NotFound)
+		return nil, errors.Errorf("cloud credentials for %q %w", owner, coreerrors.NotFound)
 	}
-	return result, errors.Trace(err)
+	return result, errors.Capture(err)
 }
 
 // RemoveCloudCredential removes a cloud credential with the given name, cloud and owner..
 func (st *State) RemoveCloudCredential(ctx context.Context, key corecredential.Key) error {
 	db, err := st.DB()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	credAttrDeleteQ := `
@@ -686,24 +688,24 @@ WHERE  cloud_credential.uuid = $M.uuid
 
 	credAttrDeleteStmt, err := st.Prepare(credAttrDeleteQ, sqlair.M{})
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	credDeleteStmt, err := st.Prepare(credDeleteQ, sqlair.M{})
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		id, err := st.credentialUUIDForKey(ctx, tx, key)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		uuidMap := sqlair.M{"uuid": id.String()}
 		if err := tx.Query(ctx, credAttrDeleteStmt, uuidMap).Run(); err != nil {
-			return errors.Annotate(err, "deleting credential attributes")
+			return errors.Errorf("deleting credential attributes %w", err)
 		}
 		err = tx.Query(ctx, credDeleteStmt, uuidMap).Run()
-		return errors.Annotate(err, "deleting credential")
+		return errors.Errorf("deleting credential %w", err)
 	})
 }
 
@@ -715,27 +717,27 @@ func (st *State) WatchCredential(
 ) (watcher.NotifyWatcher, error) {
 	db, err := st.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	var id corecredential.UUID
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		var err error
 		id, err = st.credentialUUIDForKey(ctx, tx, key)
-		return errors.Trace(err)
+		return errors.Capture(err)
 	})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	result, err := getWatcher("cloud_credential", id.String(), changestream.All)
-	return result, errors.Annotatef(err, "watching credential")
+	return result, errors.Errorf("watching credential %w", err)
 }
 
 // ModelsUsingCloudCredential returns a map of uuid->name for models which use the credential.
 func (st *State) ModelsUsingCloudCredential(ctx context.Context, key corecredential.Key) (map[coremodel.UUID]string, error) {
 	db, err := st.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	credKey := credentialKey{
@@ -753,7 +755,7 @@ AND    m.owner_name = $credentialKey.owner_name
 `
 	stmt, err := st.Prepare(query, credKey, modelNameAndUUID{})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	result := make(map[coremodel.UUID]string)
@@ -766,7 +768,7 @@ AND    m.owner_name = $credentialKey.owner_name
 		return nil
 	})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	for _, m := range modelNameAndUUIDs {
 		result[coremodel.UUID(m.UUID)] = m.Name

--- a/domain/credential/state/state.go
+++ b/domain/credential/state/state.go
@@ -704,8 +704,10 @@ WHERE  cloud_credential.uuid = $M.uuid
 		if err := tx.Query(ctx, credAttrDeleteStmt, uuidMap).Run(); err != nil {
 			return errors.Errorf("deleting credential attributes %w", err)
 		}
-		err = tx.Query(ctx, credDeleteStmt, uuidMap).Run()
-		return errors.Errorf("deleting credential %w", err)
+		if err = tx.Query(ctx, credDeleteStmt, uuidMap).Run(); err != nil {
+			return errors.Errorf("deleting credential %w", err)
+		}
+		return nil
 	})
 }
 

--- a/domain/credential/state/state.go
+++ b/domain/credential/state/state.go
@@ -213,7 +213,7 @@ ON CONFLICT(uuid) DO UPDATE SET name=excluded.name,
 
 	err = tx.Query(ctx, insertStmt, dbCredential).Run()
 	if database.IsErrConstraintCheck(err) {
-		return errors.Errorf("credential name cannot be empty", errors.Hide(coreerrors.NotValid), errors.Hide(err))
+		return errors.New("credential name cannot be empty").Add(coreerrors.NotValid)
 	} else if err != nil {
 		return errors.Capture(err)
 	}

--- a/domain/credential/state/state_test.go
+++ b/domain/credential/state/state_test.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/canonical/sqlair"
-	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v4/workertest"
 	gc "gopkg.in/check.v1"
@@ -19,6 +18,7 @@ import (
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/core/changestream"
 	corecredential "github.com/juju/juju/core/credential"
+	coreerrors "github.com/juju/juju/core/errors"
 	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/core/user"
@@ -32,6 +32,7 @@ import (
 	"github.com/juju/juju/domain/credential"
 	credentialerrors "github.com/juju/juju/domain/credential/errors"
 	changestreamtesting "github.com/juju/juju/internal/changestream/testing"
+	"github.com/juju/juju/internal/errors"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 	"github.com/juju/juju/internal/uuid"
 )
@@ -160,7 +161,7 @@ func (s *credentialSuite) TestUpdateCloudCredentialMissingName(c *gc.C) {
 	}
 	ctx := context.Background()
 	_, err := st.UpsertCloudCredential(ctx, corecredential.Key{Cloud: "stratus", Owner: s.userName}, credInfo)
-	c.Assert(errors.Is(err, errors.NotValid), jc.IsTrue)
+	c.Assert(errors.Is(err, coreerrors.NotValid), jc.IsTrue)
 }
 
 func (s *credentialSuite) TestCreateInvalidCredential(c *gc.C) {
@@ -489,7 +490,7 @@ func (s *credentialSuite) TestInvalidateCloudCredentialNotFound(c *gc.C) {
 	key := corecredential.Key{Cloud: "stratus", Owner: s.userName, Name: "foobar"}
 	ctx := context.Background()
 	err := st.InvalidateCloudCredential(ctx, key, "reason")
-	c.Assert(err, jc.ErrorIs, errors.NotFound)
+	c.Assert(err, jc.ErrorIs, coreerrors.NotFound)
 }
 
 type watcherFunc func(namespace, changeValue string, changeMask changestream.ChangeType) (watcher.NotifyWatcher, error)

--- a/domain/credential/state/types.go
+++ b/domain/credential/state/types.go
@@ -4,9 +4,8 @@
 package state
 
 import (
-	"github.com/juju/errors"
-
 	"github.com/juju/juju/domain/credential"
+	"github.com/juju/juju/internal/errors"
 )
 
 // These structs represent the persistent cloud credential entity schema in the database.

--- a/domain/errors.go
+++ b/domain/errors.go
@@ -6,9 +6,8 @@ package domain
 import (
 	"database/sql"
 
-	"github.com/juju/errors"
-
 	"github.com/juju/juju/internal/database"
+	"github.com/juju/juju/internal/errors"
 )
 
 // CoerceError converts all sql, sqlite and dqlite errors into an error that
@@ -24,7 +23,7 @@ func CoerceError(err error) error {
 	// If the error is a sql error, a dqlite error or a database error, we mask
 	// the error to prevent it from being unwrapped.
 	if isDatabaseError(err) {
-		return errors.Trace(maskError{error: err})
+		return errors.Capture(maskError{error: err})
 	}
 
 	return err

--- a/domain/errors_test.go
+++ b/domain/errors_test.go
@@ -5,13 +5,13 @@ package domain
 
 import (
 	"database/sql"
-	"fmt"
 
 	dqlite "github.com/canonical/go-dqlite/driver"
-	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"github.com/mattn/go-sqlite3"
 	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/internal/errors"
 )
 
 type asError struct {
@@ -70,7 +70,7 @@ func (e *errorsSuite) TestMaskErrorIsHidesSqlErrors(c *gc.C) {
 	}
 
 	for _, test := range tests {
-		err := maskError{fmt.Errorf("%q %w", test.Name, test.Error)}
+		err := maskError{errors.Errorf("%q %w", test.Name, test.Error)}
 		c.Check(errors.Is(err, test.Error), jc.IsFalse, gc.Commentf(test.Name))
 	}
 }
@@ -81,15 +81,15 @@ func (e *errorsSuite) TestErrorMessagePreserved(c *gc.C) {
 		Expected string
 	}{
 		{
-			Error:    fmt.Errorf("wrap orig error: %w", sql.ErrNoRows),
+			Error:    errors.Errorf("wrap orig error: %w", sql.ErrNoRows),
 			Expected: "wrap orig error: sql: no rows in result set",
 		},
 		{
-			Error:    fmt.Errorf("wrap orig error: %w%w", sql.ErrNoRows, dqlite.Error{Code: dqlite.ErrBusy}),
+			Error:    errors.Errorf("wrap orig error: %w", sql.ErrNoRows, dqlite.Error{Code: dqlite.ErrBusy}),
 			Expected: "wrap orig error: sql: no rows in result set",
 		},
 		{
-			Error:    fmt.Errorf("wrap orig error: %w - %w", sql.ErrNoRows, fmt.Errorf("nested error")),
+			Error:    errors.Errorf("wrap orig error: %w - %w", sql.ErrNoRows, errors.Errorf("nested error")),
 			Expected: "wrap orig error: sql: no rows in result set - nested error",
 		},
 	}
@@ -103,7 +103,7 @@ func (e *errorsSuite) TestErrorMessagePreserved(c *gc.C) {
 // errors within its chain that it doesn't attempt to hide their existence.
 func (e *errorsSuite) TestMaskErrorIsNoHide(c *gc.C) {
 	origError := errors.New("test error")
-	err := fmt.Errorf("wrap orig error: %w", origError)
+	err := errors.Errorf("wrap orig error: %w", origError)
 	maskErr := maskError{err}
 	c.Check(errors.Is(maskErr, origError), jc.IsTrue)
 
@@ -112,7 +112,7 @@ func (e *errorsSuite) TestMaskErrorIsNoHide(c *gc.C) {
 		ExtendedCode: sqlite3.ErrBusyRecovery,
 	}
 
-	err = fmt.Errorf("double wrap %w %w", sqlErr, origError)
+	err = errors.Errorf("double wrap %w %w", sqlErr, origError)
 	maskErr = maskError{err}
 	c.Check(errors.Is(maskErr, origError), jc.IsTrue)
 }
@@ -121,7 +121,7 @@ func (e *errorsSuite) TestMaskErrorIsNoHide(c *gc.C) {
 // errors within its chain that it doesn't attempt to hide their existence.
 func (e *errorsSuite) TestMaskErrorAsNoHide(c *gc.C) {
 	origError := asError{"ipv6 rocks"}
-	err := fmt.Errorf("wrap orig error: %w", origError)
+	err := errors.Errorf("wrap orig error: %w", origError)
 	maskErr := maskError{err}
 
 	var rval asError
@@ -132,7 +132,7 @@ func (e *errorsSuite) TestMaskErrorAsNoHide(c *gc.C) {
 		ExtendedCode: sqlite3.ErrBusyRecovery,
 	}
 
-	err = fmt.Errorf("double wrap %w %w", sqlErr, origError)
+	err = errors.Errorf("double wrap %w %w", sqlErr, origError)
 	maskErr = maskError{err}
 	c.Check(errors.As(maskErr, &rval), jc.IsTrue)
 }

--- a/domain/externalcontroller/modelmigration/export.go
+++ b/domain/externalcontroller/modelmigration/export.go
@@ -7,12 +7,12 @@ import (
 	"context"
 
 	"github.com/juju/description/v8"
-	"github.com/juju/errors"
 
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/modelmigration"
 	"github.com/juju/juju/domain/externalcontroller/service"
 	"github.com/juju/juju/domain/externalcontroller/state"
+	"github.com/juju/juju/internal/errors"
 )
 
 // RegisterExport registers the export operations with the given coordinator.
@@ -79,7 +79,7 @@ func (e *exportOperation) Execute(ctx context.Context, model description.Model) 
 
 	controllers, err := e.service.ControllersForModels(ctx, sourceModelUUIDs...)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	for _, controller := range controllers {

--- a/domain/externalcontroller/modelmigration/export_test.go
+++ b/domain/externalcontroller/modelmigration/export_test.go
@@ -7,13 +7,14 @@ import (
 	"context"
 
 	"github.com/juju/description/v8"
-	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 	jc "github.com/juju/testing/checkers"
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/crossmodel"
+	coreerrors "github.com/juju/juju/core/errors"
+	"github.com/juju/juju/internal/errors"
 )
 
 type exportSuite struct {
@@ -176,7 +177,7 @@ func (s *exportSuite) TestExportExternalControllerWithNoControllerNotFound(c *gc
 
 	s.service.EXPECT().ControllersForModels(gomock.Any(), []string{modelUUID}).
 		Times(1).
-		Return(nil, errors.NotFoundf("test-external-controller"))
+		Return(nil, errors.Errorf("test-external-controller %w", coreerrors.NotFound))
 
 	op := s.newExportOperation()
 	err := op.Execute(context.Background(), dst)

--- a/domain/externalcontroller/modelmigration/import.go
+++ b/domain/externalcontroller/modelmigration/import.go
@@ -69,6 +69,8 @@ func (i *importOperation) Execute(ctx context.Context, model description.Model) 
 		})
 	}
 
-	err := i.service.ImportExternalControllers(ctx, controllers)
-	return errors.Errorf("cannot import external controllers %w", err)
+	if err := i.service.ImportExternalControllers(ctx, controllers); err != nil {
+		return errors.Errorf("cannot import external controllers %w", err)
+	}
+	return nil
 }

--- a/domain/externalcontroller/modelmigration/import.go
+++ b/domain/externalcontroller/modelmigration/import.go
@@ -7,12 +7,12 @@ import (
 	"context"
 
 	"github.com/juju/description/v8"
-	"github.com/juju/errors"
 
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/modelmigration"
 	"github.com/juju/juju/domain/externalcontroller/service"
 	"github.com/juju/juju/domain/externalcontroller/state"
+	"github.com/juju/juju/internal/errors"
 )
 
 // Coordinator is the interface that is used to add operations to a migration.
@@ -70,5 +70,5 @@ func (i *importOperation) Execute(ctx context.Context, model description.Model) 
 	}
 
 	err := i.service.ImportExternalControllers(ctx, controllers)
-	return errors.Annotatef(err, "cannot import external controllers")
+	return errors.Errorf("cannot import external controllers %w", err)
 }

--- a/domain/externalcontroller/service/service.go
+++ b/domain/externalcontroller/service/service.go
@@ -62,7 +62,10 @@ func (s *Service) Controller(
 	controllerUUID string,
 ) (*crossmodel.ControllerInfo, error) {
 	controllerInfo, err := s.st.Controller(ctx, controllerUUID)
-	return controllerInfo, errors.Errorf("retrieving external controller %s %w", controllerUUID, err)
+	if err != nil {
+		return nil, errors.Errorf("retrieving external controller %s %w", controllerUUID, err)
+	}
+	return controllerInfo, nil
 }
 
 // ControllerForModel returns the controller record that's associated
@@ -89,8 +92,10 @@ func (s *Service) ControllerForModel(
 func (s *Service) UpdateExternalController(
 	ctx context.Context, ec crossmodel.ControllerInfo,
 ) error {
-	err := s.st.UpdateExternalController(ctx, ec)
-	return errors.Errorf("updating external controller state %w", err)
+	if err := s.st.UpdateExternalController(ctx, ec); err != nil {
+		return errors.Errorf("updating external controller state %w", err)
+	}
+	return nil
 }
 
 // ImportExternalControllers imports the list of MigrationControllerInfo

--- a/domain/externalcontroller/service/service.go
+++ b/domain/externalcontroller/service/service.go
@@ -6,11 +6,11 @@ package service
 import (
 	"context"
 
-	"github.com/juju/errors"
-
 	"github.com/juju/juju/core/changestream"
 	"github.com/juju/juju/core/crossmodel"
+	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/watcher"
+	"github.com/juju/juju/internal/errors"
 )
 
 // State describes retrieval and persistence methods for storage.
@@ -62,7 +62,7 @@ func (s *Service) Controller(
 	controllerUUID string,
 ) (*crossmodel.ControllerInfo, error) {
 	controllerInfo, err := s.st.Controller(ctx, controllerUUID)
-	return controllerInfo, errors.Annotatef(err, "retrieving external controller %s", controllerUUID)
+	return controllerInfo, errors.Errorf("retrieving external controller %s %w", controllerUUID, err)
 }
 
 // ControllerForModel returns the controller record that's associated
@@ -74,11 +74,11 @@ func (s *Service) ControllerForModel(
 	controllers, err := s.st.ControllersForModels(ctx, modelUUID)
 
 	if err != nil {
-		return nil, errors.Annotatef(err, "retrieving external controller for model %s", modelUUID)
+		return nil, errors.Errorf("retrieving external controller for model %s %w", modelUUID, err)
 	}
 
 	if len(controllers) == 0 {
-		return nil, errors.NotFoundf("external controller for model %q", modelUUID)
+		return nil, errors.Errorf("external controller for model %q %w", modelUUID, coreerrors.NotFound)
 	}
 
 	return &controllers[0], nil
@@ -90,7 +90,7 @@ func (s *Service) UpdateExternalController(
 	ctx context.Context, ec crossmodel.ControllerInfo,
 ) error {
 	err := s.st.UpdateExternalController(ctx, ec)
-	return errors.Annotate(err, "updating external controller state")
+	return errors.Errorf("updating external controller state %w", err)
 }
 
 // ImportExternalControllers imports the list of MigrationControllerInfo
@@ -109,7 +109,7 @@ func (s *Service) ModelsForController(
 	controllerUUID string,
 ) ([]string, error) {
 	models, err := s.st.ModelsForController(ctx, controllerUUID)
-	return models, errors.Annotatef(err, "retrieving model UUIDs for controller %s", controllerUUID)
+	return models, errors.Errorf("retrieving model UUIDs for controller %s %w", controllerUUID, err)
 }
 
 // ControllersForModels returns the list of controllers which
@@ -148,5 +148,5 @@ func (s *WatchableService) Watch() (watcher.StringsWatcher, error) {
 			changestream.Create|changestream.Update,
 		)
 	}
-	return nil, errors.NotYetAvailablef("external controller watcher")
+	return nil, errors.Errorf("external controller watcher %w", coreerrors.NotYetAvailable)
 }

--- a/domain/externalcontroller/state/state.go
+++ b/domain/externalcontroller/state/state.go
@@ -9,11 +9,12 @@ import (
 
 	"github.com/canonical/sqlair"
 	"github.com/juju/collections/transform"
-	"github.com/juju/errors"
 
 	"github.com/juju/juju/core/crossmodel"
 	coredatabase "github.com/juju/juju/core/database"
+	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/domain"
+	"github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/internal/uuid"
 )
 
@@ -36,7 +37,7 @@ func (st *State) Controller(
 ) (*crossmodel.ControllerInfo, error) {
 	db, err := st.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	controller := Controller{ID: controllerUUID}
@@ -55,16 +56,16 @@ FROM   external_controller AS ctrl
 WHERE  ctrl.uuid = $Controller.uuid`
 	s, err := st.Prepare(q, controller)
 	if err != nil {
-		return nil, errors.Annotatef(err, "preparing %q", q)
+		return nil, errors.Errorf("preparing %q %w", q, err)
 	}
 
 	var rows Controllers
 	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		return errors.Trace(tx.Query(ctx, s, controller).GetAll(&rows))
+		return errors.Capture(tx.Query(ctx, s, controller).GetAll(&rows))
 	}); errors.Is(err, sqlair.ErrNoRows) || len(rows) == 0 {
-		return nil, errors.NotFoundf("external controller %q", controllerUUID)
+		return nil, errors.Errorf("external controller %q %w", controllerUUID, coreerrors.NotFound)
 	} else if err != nil {
-		return nil, errors.Annotate(err, "querying external controller")
+		return nil, errors.Errorf("querying external controller %w", err)
 	}
 
 	return &rows.ToControllerInfo()[0], nil
@@ -75,7 +76,7 @@ WHERE  ctrl.uuid = $Controller.uuid`
 func (st *State) ControllersForModels(ctx context.Context, modelUUIDs ...string) ([]crossmodel.ControllerInfo, error) {
 	db, err := st.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	dbModelUUIDs := ModelUUIDs(modelUUIDs)
@@ -98,18 +99,18 @@ WHERE  ctrl.uuid IN (
 
 	stmt, err := st.Prepare(q, Controller{}, dbModelUUIDs)
 	if err != nil {
-		return nil, errors.Annotatef(err, "preparing %q", q)
+		return nil, errors.Errorf("preparing %q %w", q, err)
 	}
 
 	var resultControllerInfos Controllers
 	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err := tx.Query(ctx, stmt, dbModelUUIDs).GetAll(&resultControllerInfos)
 		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		return nil
 	}); err != nil {
-		return nil, errors.Annotate(err, "querying external controller")
+		return nil, errors.Errorf("querying external controller %w", err)
 	}
 
 	return resultControllerInfos.ToControllerInfo(), nil
@@ -122,14 +123,14 @@ func (st *State) UpdateExternalController(
 ) error {
 	db, err := st.DB()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		return st.updateExternalControllerTx(ctx, tx, ci)
 	})
 
-	return errors.Trace(err)
+	return errors.Capture(err)
 }
 
 // ImportExternalControllers imports the list of ControllerInfo
@@ -137,7 +138,7 @@ func (st *State) UpdateExternalController(
 func (st *State) ImportExternalControllers(ctx context.Context, infos []crossmodel.ControllerInfo) error {
 	db, err := st.DB()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
@@ -148,13 +149,13 @@ func (st *State) ImportExternalControllers(ctx context.Context, infos []crossmod
 				ci,
 			)
 			if err != nil {
-				return errors.Trace(err)
+				return errors.Capture(err)
 			}
 		}
 		return nil
 	})
 
-	return errors.Trace(err)
+	return errors.Capture(err)
 }
 
 func (st *State) updateExternalControllerTx(
@@ -176,11 +177,11 @@ VALUES ($Controller.*)
 `
 	upsertControllerStmt, err := st.Prepare(upsertControllerQuery, externalController)
 	if err != nil {
-		return errors.Annotatef(err, "preparing %q:", upsertControllerQuery)
+		return errors.Errorf("preparing %q: %w", upsertControllerQuery, err)
 	}
 
 	if err := tx.Query(ctx, upsertControllerStmt, externalController).Run(); err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	cIDs := ControllerUUIDs(ci.Addrs)
@@ -192,11 +193,11 @@ AND    address NOT IN ($ControllerUUIDs[:])
 `
 	deleteUnusedAddressesStmt, err := st.Prepare(deleteUnusedAddressesQuery, externalController, cIDs)
 	if err != nil {
-		return errors.Annotatef(err, "preparing %q:", deleteUnusedAddressesQuery)
+		return errors.Errorf("preparing %q: %w", deleteUnusedAddressesQuery, err)
 	}
 
 	if err := tx.Query(ctx, deleteUnusedAddressesStmt, externalController, cIDs).Run(); err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	if len(ci.Addrs) > 0 {
@@ -204,7 +205,7 @@ AND    address NOT IN ($ControllerUUIDs[:])
 		for _, addr := range ci.Addrs {
 			uuid, err := uuid.NewUUID()
 			if err != nil {
-				return errors.Trace(err)
+				return errors.Capture(err)
 			}
 			externContAddrs = append(externContAddrs, Address{
 				ID:             uuid.String(),
@@ -220,11 +221,11 @@ VALUES ($Address.*)
 `
 		insertNewAddressesStmt, err := st.Prepare(insertNewAddressesQuery, Address{})
 		if err != nil {
-			return errors.Annotatef(err, "preparing %q:", insertNewAddressesQuery)
+			return errors.Errorf("preparing %q: %w", insertNewAddressesQuery, err)
 		}
 
 		if err := tx.Query(ctx, insertNewAddressesStmt, externContAddrs).Run(); err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 	}
 
@@ -247,11 +248,11 @@ VALUES ($Model.*)
 `
 		upsertModelStmt, err := st.Prepare(upsertModelQuery, Model{})
 		if err != nil {
-			return errors.Annotatef(err, "preparing %q:", upsertModelQuery)
+			return errors.Errorf("preparing %q: %w", upsertModelQuery, err)
 		}
 
 		if err := tx.Query(ctx, upsertModelStmt, externModels).Run(); err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 	}
 
@@ -266,7 +267,7 @@ func (st *State) ModelsForController(
 ) ([]string, error) {
 	db, err := st.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	controller := Controller{
@@ -278,14 +279,14 @@ SELECT &Model.uuid
 FROM   external_model 
 WHERE  controller_uuid = $Controller.uuid`, controller, Model{})
 	if err != nil {
-		return nil, errors.Annotate(err, "preparing select models for controller")
+		return nil, errors.Errorf("preparing select models for controller %w", err)
 	}
 
 	var models []Model
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err := tx.Query(ctx, stmt, controller).GetAll(&models)
 		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		return nil

--- a/domain/flag/service/service.go
+++ b/domain/flag/service/service.go
@@ -6,7 +6,8 @@ package service
 import (
 	"context"
 
-	"github.com/juju/errors"
+	coreerrors "github.com/juju/juju/core/errors"
+	"github.com/juju/juju/internal/errors"
 )
 
 // State describes retrieval and persistence methods for storage.
@@ -36,7 +37,7 @@ func (s *Service) SetFlag(ctx context.Context, flag string, value bool, descript
 // GetFlag returns the value of a flag.
 func (s *Service) GetFlag(ctx context.Context, flag string) (bool, error) {
 	value, err := s.st.GetFlag(ctx, flag)
-	if err != nil && !errors.Is(err, errors.NotFound) {
+	if err != nil && !errors.Is(err, coreerrors.NotFound) {
 		return false, err
 	}
 	return value, nil

--- a/domain/flag/service/service_test.go
+++ b/domain/flag/service/service_test.go
@@ -6,11 +6,13 @@ package service
 import (
 	"context"
 
-	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gomock "go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
+
+	coreerrors "github.com/juju/juju/core/errors"
+	"github.com/juju/juju/internal/errors"
 )
 
 type serviceSuite struct {
@@ -45,7 +47,7 @@ func (s *serviceSuite) TestGetFlag(c *gc.C) {
 func (s *serviceSuite) TestGetFlagNotFound(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().GetFlag(gomock.Any(), "foo").Return(false, errors.NotFoundf("flag"))
+	s.state.EXPECT().GetFlag(gomock.Any(), "foo").Return(false, errors.Errorf("flag %w", coreerrors.NotFound))
 
 	service := NewService(s.state)
 	value, err := service.GetFlag(context.Background(), "foo")

--- a/domain/flag/state/state.go
+++ b/domain/flag/state/state.go
@@ -7,11 +7,12 @@ import (
 	"context"
 
 	"github.com/canonical/sqlair"
-	"github.com/juju/errors"
 
 	coredb "github.com/juju/juju/core/database"
+	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/domain"
+	"github.com/juju/juju/internal/errors"
 )
 
 // State describes retrieval and persistence methods for storage.
@@ -33,7 +34,7 @@ func NewState(factory coredb.TxnRunnerFactory, logger logger.Logger) *State {
 func (s *State) SetFlag(ctx context.Context, flagName string, value bool, description string) error {
 	db, err := s.DB()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	flag := dbFlag{Name: flagName, Value: value, Description: description}
@@ -45,24 +46,24 @@ ON CONFLICT (name) DO UPDATE SET value = excluded.value,
                                  description = excluded.description;
 `, flag)
 	if err != nil {
-		return errors.Annotate(err, "preparing set flag stmt")
+		return errors.Errorf("preparing set flag stmt %w", err)
 	}
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		var outcome sqlair.Outcome
 		err := tx.Query(ctx, stmt, flag).Get(&outcome)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		if affected, err := outcome.Result().RowsAffected(); err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		} else if affected != 1 {
 			return errors.Errorf("unexpected number of rows affected: %d (should be 1)", affected)
 		}
 		return nil
 	})
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	s.logger.Debugf("set flag %q to %v", flagName, value)
@@ -74,7 +75,7 @@ ON CONFLICT (name) DO UPDATE SET value = excluded.value,
 func (s *State) GetFlag(ctx context.Context, flagName string) (bool, error) {
 	db, err := s.DB()
 	if err != nil {
-		return false, errors.Trace(err)
+		return false, errors.Capture(err)
 	}
 
 	flag := dbFlag{Name: flagName}
@@ -85,18 +86,18 @@ FROM   flag
 WHERE  name = $dbFlag.name;
 	`, flag)
 	if err != nil {
-		return false, errors.Annotate(err, "preparing select flag stmt")
+		return false, errors.Errorf("preparing select flag stmt %w", err)
 	}
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err := tx.Query(ctx, stmt, flag).Get(&flag)
 		if errors.Is(err, sqlair.ErrNoRows) {
-			return errors.NotFoundf("flag %q", flagName)
+			return errors.Errorf("flag %q %w", flagName, coreerrors.NotFound)
 		}
-		return errors.Trace(err)
+		return errors.Capture(err)
 	})
 	if err != nil {
-		return false, errors.Trace(err)
+		return false, errors.Capture(err)
 	}
 	return flag.Value, nil
 }

--- a/domain/flag/state/state_test.go
+++ b/domain/flag/state/state_test.go
@@ -7,11 +7,12 @@ import (
 	"context"
 
 	"github.com/canonical/sqlair"
-	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	coreerrors "github.com/juju/juju/core/errors"
 	schematesting "github.com/juju/juju/domain/schema/testing"
+	"github.com/juju/juju/internal/errors"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 )
 
@@ -31,7 +32,7 @@ func (s *stateSuite) SetUpTest(c *gc.C) {
 
 func (s *stateSuite) TestGetFlagNotFound(c *gc.C) {
 	value, err := s.state.GetFlag(context.Background(), "foo")
-	c.Assert(err, jc.ErrorIs, errors.NotFound)
+	c.Assert(err, jc.ErrorIs, coreerrors.NotFound)
 	c.Assert(value, jc.IsFalse)
 }
 
@@ -55,11 +56,11 @@ SELECT (value, description) AS (&dbFlag.*)
 FROM   flag 
 WHERE  name = 'foo'`, flag)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		err = tx.Query(ctx, stmt).Get(&flag)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		if !flag.Value {
 			return errors.Errorf("unexpected value: %v", flag.Value)

--- a/domain/keymanager/errors/errors.go
+++ b/domain/keymanager/errors/errors.go
@@ -3,9 +3,7 @@
 
 package errors
 
-import (
-	"github.com/juju/errors"
-)
+import "github.com/juju/juju/internal/errors"
 
 const (
 	// PublicKeyAlreadyExists indicates that the authorised key already

--- a/domain/keymanager/service/service_test.go
+++ b/domain/keymanager/service/service_test.go
@@ -7,12 +7,12 @@ import (
 	"context"
 	"net/url"
 
-	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gomock "go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
+	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/model"
 	modeltesting "github.com/juju/juju/core/model/testing"
 	coressh "github.com/juju/juju/core/ssh"
@@ -86,7 +86,7 @@ func (s *serviceSuite) TestAddKeysForInvalidUser(c *gc.C) {
 
 	err := NewService(s.modelUUID, s.state).
 		AddPublicKeysForUser(context.Background(), user.UUID("notvalid"), "key")
-	c.Check(err, jc.ErrorIs, errors.NotValid)
+	c.Check(err, jc.ErrorIs, coreerrors.NotValid)
 }
 
 // TestAddKeysForNonExistentUser is testing that if a user id doesn't exist that
@@ -289,7 +289,7 @@ func (s *serviceSuite) TestListKeysForInvalidUserId(c *gc.C) {
 	svc := NewService(s.modelUUID, s.state)
 
 	_, err := svc.ListPublicKeysForUser(context.Background(), user.UUID("not-valid"))
-	c.Check(err, jc.ErrorIs, errors.NotValid)
+	c.Check(err, jc.ErrorIs, coreerrors.NotValid)
 }
 
 // TestListKeysForNonExistentUser is testing that if we ask for the keys for a
@@ -335,7 +335,7 @@ func (s *serviceSuite) TestDeleteKeysForInvalidUser(c *gc.C) {
 
 	err := NewService(s.modelUUID, s.state).
 		DeleteKeysForUser(context.Background(), user.UUID("notvalid"), "key")
-	c.Check(err, jc.ErrorIs, errors.NotValid)
+	c.Check(err, jc.ErrorIs, coreerrors.NotValid)
 }
 
 // TestDeleteKeysForUserNotFound is asserting that if the state layer

--- a/domain/keyupdater/service/controllerkey.go
+++ b/domain/keyupdater/service/controllerkey.go
@@ -5,9 +5,9 @@ package service
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/juju/juju/controller"
+	"github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/internal/ssh"
 )
 
@@ -38,15 +38,15 @@ func (s *ControllerKeyService) ControllerAuthorisedKeys(
 ) ([]string, error) {
 	ctrlConfig, err := s.st.GetControllerConfigKeys(ctx, []string{controller.SystemSSHKeys})
 	if err != nil {
-		return nil, fmt.Errorf("cannot get juju controller public ssh keys: %w", err)
+		return nil, errors.Errorf("cannot get juju controller public ssh keys: %w", err)
 	}
 
 	keys, err := ssh.SplitAuthorizedKeys(ctrlConfig[controller.SystemSSHKeys])
 	if err != nil {
-		return nil, fmt.Errorf(
+		return nil, errors.Errorf(
 			"cannot split authorized keys from controller config system ssh keys: %w",
-			err,
-		)
+			err)
+
 	}
 
 	return keys, nil

--- a/domain/keyupdater/service/service.go
+++ b/domain/keyupdater/service/service.go
@@ -113,7 +113,7 @@ func NewWatchableService(
 
 // GetAuthorisedKeysForMachine is responsible for fetching the authorised keys
 // that should be available on a machine. The following errors can be expected:
-// - [github.com/juju/errors.NotValid] if the machine id is not valid.
+// - [github.com/juju/juju/core/errors.NotValid] if the machine id is not valid.
 // - [github.com/juju/juju/domain/machine/errors.NotFound] if the machine does
 // not exist.
 func (s *Service) GetAuthorisedKeysForMachine(
@@ -168,7 +168,7 @@ func (s *Service) GetAuthorisedKeysForMachine(
 
 // WatchAuthorisedKeysForMachine will watch for authorised key changes for a
 // give machine name. The following errors can be expected:
-// - [github.com/juju/errors.NotValid] if the machine id is not valid.
+// - [github.com/juju/juju/core/errors.NotValid] if the machine id is not valid.
 // - [machineerrors.MachineNotFound] if no machine exists for the provided name.
 func (s *WatchableService) WatchAuthorisedKeysForMachine(
 	ctx context.Context,

--- a/domain/keyupdater/service/service_test.go
+++ b/domain/keyupdater/service/service_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"slices"
 
-	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
@@ -16,6 +15,7 @@ import (
 	"github.com/juju/juju/core/model"
 	modeltesting "github.com/juju/juju/core/model/testing"
 	machineerrors "github.com/juju/juju/domain/machine/errors"
+	"github.com/juju/juju/internal/errors"
 )
 
 type serviceSuite struct {

--- a/domain/lease/modelmigration/import.go
+++ b/domain/lease/modelmigration/import.go
@@ -8,13 +8,13 @@ import (
 	"time"
 
 	"github.com/juju/description/v8"
-	"github.com/juju/errors"
 
 	"github.com/juju/juju/core/lease"
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/modelmigration"
 	"github.com/juju/juju/domain/lease/service"
 	"github.com/juju/juju/domain/lease/state"
+	"github.com/juju/juju/internal/errors"
 )
 
 const (
@@ -75,7 +75,7 @@ func (o *importOperation) Execute(ctx context.Context, model description.Model) 
 			Duration: LeadershipGuarantee,
 		}
 		if err := o.service.ClaimLease(ctx, key, req); err != nil {
-			return errors.Annotatef(err, "claiming lease for %q", key)
+			return errors.Errorf("claiming lease for %q %w", key, err)
 		}
 	}
 

--- a/domain/lease/modelmigration/import.go
+++ b/domain/lease/modelmigration/import.go
@@ -75,7 +75,7 @@ func (o *importOperation) Execute(ctx context.Context, model description.Model) 
 			Duration: LeadershipGuarantee,
 		}
 		if err := o.service.ClaimLease(ctx, key, req); err != nil {
-			return errors.Errorf("claiming lease for %q %w", key, err)
+			return errors.Errorf("claiming lease for %q: %w", key, err)
 		}
 	}
 

--- a/domain/lease/service/service.go
+++ b/domain/lease/service/service.go
@@ -6,9 +6,9 @@ package service
 import (
 	"context"
 
-	"github.com/juju/errors"
-
+	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/lease"
+	"github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/internal/uuid"
 )
 
@@ -46,7 +46,7 @@ func (s *Service) Leases(ctx context.Context, keys ...lease.Key) (map[lease.Key]
 	// As it is, there are no upstream usages for more than one key,
 	// so we just lock in that behaviour.
 	if len(keys) > 1 {
-		return nil, errors.NotSupportedf("filtering with more than one lease key")
+		return nil, errors.Errorf("filtering with more than one lease key %w", coreerrors.NotSupported)
 	}
 
 	return s.st.Leases(ctx, keys...)
@@ -57,11 +57,11 @@ func (s *Service) Leases(ctx context.Context, keys ...lease.Key) (map[lease.Key]
 // The lease must not already be held, otherwise an error is returned.
 func (s *Service) ClaimLease(ctx context.Context, key lease.Key, req lease.Request) error {
 	if err := req.Validate(); err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	uuid, err := uuid.NewUUID()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	return s.st.ClaimLease(ctx, uuid, key, req)
 }
@@ -71,7 +71,7 @@ func (s *Service) ClaimLease(ctx context.Context, key lease.Key, req lease.Reque
 // If the input holder does not currently hold the lease, an error is returned.
 func (s *Service) ExtendLease(ctx context.Context, key lease.Key, req lease.Request) error {
 	if err := req.Validate(); err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	return s.st.ExtendLease(ctx, key, req)

--- a/domain/leaseservice_test.go
+++ b/domain/leaseservice_test.go
@@ -5,7 +5,6 @@ package domain
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/juju/testing"
@@ -68,7 +67,7 @@ func (s *leaseServiceSuite) TestWithLeaderWaitReturnsError(c *gc.C) {
 
 	s.leaseChecker.EXPECT().WaitUntilExpired(gomock.Any(), "leaseName", gomock.Any()).DoAndReturn(
 		func(ctx context.Context, leaseName string, start chan<- struct{}) error {
-			return fmt.Errorf("not holding lease")
+			return errors.Errorf("not holding lease")
 		},
 	)
 
@@ -103,7 +102,7 @@ func (s *leaseServiceSuite) TestWithLeaderWaitHasLeaseChange(c *gc.C) {
 
 			close(done)
 
-			return fmt.Errorf("not holding lease")
+			return errors.Errorf("not holding lease")
 		},
 	)
 

--- a/domain/lifewatcher.go
+++ b/domain/lifewatcher.go
@@ -7,13 +7,13 @@ import (
 	"context"
 
 	"github.com/juju/collections/set"
-	"github.com/juju/errors"
 
 	"github.com/juju/juju/core/changestream"
 	coredatabase "github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/watcher/eventsource"
 	"github.com/juju/juju/domain/life"
+	"github.com/juju/juju/internal/errors"
 )
 
 // LifeGetter is a function which looks up life values of the entities with the specified IDs.
@@ -59,7 +59,7 @@ func LifeStringsWatcherMapperFunc(logger logger.Logger, lifeGetter LifeGetter) e
 		// Gather the latest life values of the ids.
 		currentValues, err := lifeGetter(ctx, db, ids.Values())
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, errors.Capture(err)
 		}
 
 		// We queried the ids that were not removed. The result contains

--- a/domain/macaroon/errors/errors.go
+++ b/domain/macaroon/errors/errors.go
@@ -3,7 +3,7 @@
 
 package errors
 
-import "github.com/juju/errors"
+import "github.com/juju/juju/internal/errors"
 
 const (
 	// NotInitialised describes an error that occurs when a requested

--- a/domain/macaroon/service/config.go
+++ b/domain/macaroon/service/config.go
@@ -70,7 +70,10 @@ func (s *BakeryConfigService) InitialiseBakeryConfig(ctx context.Context) error 
 		externalUsersThirdPartyKey,
 		offersThirdPartyKey,
 	)
-	return errors.Errorf("initialising bakery config %w", err)
+	if err != nil {
+		return errors.Errorf("initialising bakery config %w", err)
+	}
+	return nil
 }
 
 // GetLocalUsersKey returns the key pair used with the local users bakery.

--- a/domain/macaroon/service/config.go
+++ b/domain/macaroon/service/config.go
@@ -7,7 +7,8 @@ import (
 	"context"
 
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
-	"github.com/juju/errors"
+
+	"github.com/juju/juju/internal/errors"
 )
 
 // BakeryConfigState describes persistence layer methods for bakery config
@@ -44,22 +45,22 @@ func NewBakeryConfigService(st BakeryConfigState) *BakeryConfigService {
 func (s *BakeryConfigService) InitialiseBakeryConfig(ctx context.Context) error {
 	localUsersKey, err := bakery.GenerateKey()
 	if err != nil {
-		return errors.Annotate(err, "generating local users keypair")
+		return errors.Errorf("generating local users keypair %w", err)
 	}
 
 	localUsersThirdPartyKey, err := bakery.GenerateKey()
 	if err != nil {
-		return errors.Annotate(err, "generating local users third party keypair")
+		return errors.Errorf("generating local users third party keypair %w", err)
 	}
 
 	externalUsersThirdPartyKey, err := bakery.GenerateKey()
 	if err != nil {
-		return errors.Annotate(err, "generating external users third party keypair")
+		return errors.Errorf("generating external users third party keypair %w", err)
 	}
 
 	offersThirdPartyKey, err := bakery.GenerateKey()
 	if err != nil {
-		return errors.Annotate(err, "generating offers third party keypair")
+		return errors.Errorf("generating offers third party keypair %w", err)
 	}
 
 	err = s.st.InitialiseBakeryConfig(
@@ -69,14 +70,14 @@ func (s *BakeryConfigService) InitialiseBakeryConfig(ctx context.Context) error 
 		externalUsersThirdPartyKey,
 		offersThirdPartyKey,
 	)
-	return errors.Annotate(err, "initialising bakery config")
+	return errors.Errorf("initialising bakery config %w", err)
 }
 
 // GetLocalUsersKey returns the key pair used with the local users bakery.
 func (s *BakeryConfigService) GetLocalUsersKey(ctx context.Context) (*bakery.KeyPair, error) {
 	keyPair, err := s.st.GetLocalUsersKey(ctx)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	return keyPair, nil
 }
@@ -85,7 +86,7 @@ func (s *BakeryConfigService) GetLocalUsersKey(ctx context.Context) (*bakery.Key
 func (s *BakeryConfigService) GetLocalUsersThirdPartyKey(ctx context.Context) (*bakery.KeyPair, error) {
 	keyPair, err := s.st.GetLocalUsersThirdPartyKey(ctx)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	return keyPair, nil
 }
@@ -94,7 +95,7 @@ func (s *BakeryConfigService) GetLocalUsersThirdPartyKey(ctx context.Context) (*
 func (s *BakeryConfigService) GetExternalUsersThirdPartyKey(ctx context.Context) (*bakery.KeyPair, error) {
 	keyPair, err := s.st.GetExternalUsersThirdPartyKey(ctx)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	return keyPair, nil
 }
@@ -103,7 +104,7 @@ func (s *BakeryConfigService) GetExternalUsersThirdPartyKey(ctx context.Context)
 func (s *BakeryConfigService) GetOffersThirdPartyKey(ctx context.Context) (*bakery.KeyPair, error) {
 	keyPair, err := s.st.GetOffersThirdPartyKey(ctx)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	return keyPair, nil
 }

--- a/domain/macaroon/service/rootkeys.go
+++ b/domain/macaroon/service/rootkeys.go
@@ -9,10 +9,10 @@ import (
 
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/dbrootkeystore"
-	"github.com/juju/errors"
 
 	"github.com/juju/juju/domain/macaroon"
 	macaroonerrors "github.com/juju/juju/domain/macaroon/errors"
+	"github.com/juju/juju/internal/errors"
 )
 
 // RootKeyState describes the persistence layer for

--- a/domain/macaroon/service/rootkeys_test.go
+++ b/domain/macaroon/service/rootkeys_test.go
@@ -9,13 +9,13 @@ import (
 
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery/dbrootkeystore"
-	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/domain/macaroon"
 	macaroonerrors "github.com/juju/juju/domain/macaroon/errors"
+	"github.com/juju/juju/internal/errors"
 )
 
 var _ dbrootkeystore.ContextBacking = &RootKeyService{}

--- a/domain/macaroon/state/config.go
+++ b/domain/macaroon/state/config.go
@@ -9,12 +9,12 @@ import (
 
 	"github.com/canonical/sqlair"
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
-	"github.com/juju/errors"
 
 	coredatabase "github.com/juju/juju/core/database"
 	"github.com/juju/juju/domain"
 	macroonerrors "github.com/juju/juju/domain/macaroon/errors"
 	internaldatabase "github.com/juju/juju/internal/database"
+	"github.com/juju/juju/internal/errors"
 )
 
 // BakeryConfigState describes the persistence layer for
@@ -40,7 +40,7 @@ func (st *BakeryConfigState) InitialiseBakeryConfig(
 ) error {
 	db, err := st.DB()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	cfg := FullConfig{
@@ -56,7 +56,7 @@ func (st *BakeryConfigState) InitialiseBakeryConfig(
 
 	initialiseConfigStmt, err := st.Prepare("INSERT INTO bakery_config (*) VALUES ($FullConfig.*)", FullConfig{})
 	if err != nil {
-		return errors.Annotate(err, "preparing initialise bakery config statement")
+		return errors.Errorf("preparing initialise bakery config statement %w", err)
 	}
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err := tx.Query(ctx, initialiseConfigStmt, cfg).Run()
@@ -65,19 +65,19 @@ func (st *BakeryConfigState) InitialiseBakeryConfig(
 		}
 		return err
 	})
-	return errors.Trace(err)
+	return errors.Capture(err)
 }
 
 // GetLocalUsersKey returns the key pair used with the local users bakery.
 func (st *BakeryConfigState) GetLocalUsersKey(ctx context.Context) (*bakery.KeyPair, error) {
 	db, err := st.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	loadKeyStmt, err := st.Prepare("SELECT &LocalUsersKeyPair.* FROM bakery_config", LocalUsersKeyPair{})
 	if err != nil {
-		return nil, errors.Annotatef(err, "preparing local users key statement")
+		return nil, errors.Errorf("preparing local users key statement %w", err)
 	}
 
 	var keyPair LocalUsersKeyPair
@@ -89,7 +89,7 @@ func (st *BakeryConfigState) GetLocalUsersKey(ctx context.Context) (*bakery.KeyP
 		return err
 	})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	return &bakery.KeyPair{
@@ -102,12 +102,12 @@ func (st *BakeryConfigState) GetLocalUsersKey(ctx context.Context) (*bakery.KeyP
 func (st *BakeryConfigState) GetLocalUsersThirdPartyKey(ctx context.Context) (*bakery.KeyPair, error) {
 	db, err := st.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	loadKeyStmt, err := st.Prepare("SELECT &LocalUsersThirdPartyKeyPair.* FROM bakery_config", LocalUsersThirdPartyKeyPair{})
 	if err != nil {
-		return nil, errors.Annotatef(err, "preparing local users third party key statement")
+		return nil, errors.Errorf("preparing local users third party key statement %w", err)
 	}
 
 	var keyPair LocalUsersThirdPartyKeyPair
@@ -120,7 +120,7 @@ func (st *BakeryConfigState) GetLocalUsersThirdPartyKey(ctx context.Context) (*b
 	})
 
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	return &bakery.KeyPair{
@@ -133,12 +133,12 @@ func (st *BakeryConfigState) GetLocalUsersThirdPartyKey(ctx context.Context) (*b
 func (st *BakeryConfigState) GetExternalUsersThirdPartyKey(ctx context.Context) (*bakery.KeyPair, error) {
 	db, err := st.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	loadKeyStmt, err := st.Prepare("SELECT &ExternalUsersThirdPartyKeyPair.* FROM bakery_config", ExternalUsersThirdPartyKeyPair{})
 	if err != nil {
-		return nil, errors.Annotatef(err, "preparing external users third party key statement")
+		return nil, errors.Errorf("preparing external users third party key statement %w", err)
 	}
 
 	var keyPair ExternalUsersThirdPartyKeyPair
@@ -151,7 +151,7 @@ func (st *BakeryConfigState) GetExternalUsersThirdPartyKey(ctx context.Context) 
 	})
 
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	return &bakery.KeyPair{
@@ -164,12 +164,12 @@ func (st *BakeryConfigState) GetExternalUsersThirdPartyKey(ctx context.Context) 
 func (st *BakeryConfigState) GetOffersThirdPartyKey(ctx context.Context) (*bakery.KeyPair, error) {
 	db, err := st.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	loadKeyStmt, err := st.Prepare("SELECT &OffersThirdPartyKeyPair.* FROM bakery_config", OffersThirdPartyKeyPair{})
 	if err != nil {
-		return nil, errors.Annotatef(err, "preparing offers third party key statement")
+		return nil, errors.Errorf("preparing offers third party key statement %w", err)
 	}
 
 	var keyPair OffersThirdPartyKeyPair
@@ -181,7 +181,7 @@ func (st *BakeryConfigState) GetOffersThirdPartyKey(ctx context.Context) (*baker
 		return err
 	})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	return &bakery.KeyPair{

--- a/domain/macaroon/state/rootkeys.go
+++ b/domain/macaroon/state/rootkeys.go
@@ -8,13 +8,13 @@ import (
 	"time"
 
 	"github.com/canonical/sqlair"
-	"github.com/juju/errors"
 
 	coredatabase "github.com/juju/juju/core/database"
 	"github.com/juju/juju/domain"
 	"github.com/juju/juju/domain/macaroon"
 	macaroonerrors "github.com/juju/juju/domain/macaroon/errors"
 	"github.com/juju/juju/internal/database"
+	"github.com/juju/juju/internal/errors"
 )
 
 // RootKeyState describes the persistence layer for
@@ -35,12 +35,12 @@ func NewRootKeyState(factory coredatabase.TxnRunnerFactory) *RootKeyState {
 func (st *RootKeyState) GetKey(ctx context.Context, id []byte, now time.Time) (macaroon.RootKey, error) {
 	db, err := st.DB()
 	if err != nil {
-		return macaroon.RootKey{}, errors.Trace(err)
+		return macaroon.RootKey{}, errors.Capture(err)
 	}
 	key := rootKeyID{ID: id}
 	getKeyStmt, err := st.Prepare("SELECT &rootKey.* FROM macaroon_root_key WHERE id = $rootKeyID.id", rootKey{}, key)
 	if err != nil {
-		return macaroon.RootKey{}, errors.Annotate(err, "preparing get root key statement")
+		return macaroon.RootKey{}, errors.Errorf("preparing get root key statement %w", err)
 	}
 
 	var result rootKey
@@ -51,7 +51,7 @@ func (st *RootKeyState) GetKey(ctx context.Context, id []byte, now time.Time) (m
 		}
 		err = tx.Query(ctx, getKeyStmt, key).Get(&result)
 		if database.IsErrNotFound(err) {
-			return errors.Annotatef(macaroonerrors.KeyNotFound, "key with id %s", string(id))
+			return errors.Errorf("key with id %s %w", string(id), macaroonerrors.KeyNotFound)
 		}
 		return err
 	})
@@ -60,7 +60,7 @@ func (st *RootKeyState) GetKey(ctx context.Context, id []byte, now time.Time) (m
 		Created: result.Created,
 		Expires: result.Expires,
 		RootKey: result.RootKey,
-	}, errors.Trace(err)
+	}, errors.Capture(err)
 }
 
 // FindLatestKey returns the most recently created root key k following all
@@ -74,7 +74,7 @@ func (st *RootKeyState) GetKey(ctx context.Context, id []byte, now time.Time) (m
 func (st *RootKeyState) FindLatestKey(ctx context.Context, createdAfter, expiresAfter, expiresBefore, now time.Time) (macaroon.RootKey, error) {
 	db, err := st.DB()
 	if err != nil {
-		return macaroon.RootKey{}, errors.Trace(err)
+		return macaroon.RootKey{}, errors.Capture(err)
 	}
 
 	m := sqlair.M{
@@ -93,7 +93,7 @@ ORDER BY created_at DESC
 `
 	stmt, err := st.Prepare(q, rootKey{}, m)
 	if err != nil {
-		return macaroon.RootKey{}, errors.Annotatef(err, "preparing get latest key statement")
+		return macaroon.RootKey{}, errors.Errorf("preparing get latest key statement %w", err)
 	}
 
 	var result rootKey
@@ -109,7 +109,7 @@ ORDER BY created_at DESC
 		return err
 	})
 	if err != nil {
-		return macaroon.RootKey{}, errors.Trace(err)
+		return macaroon.RootKey{}, errors.Capture(err)
 	}
 	return macaroon.RootKey{
 		ID:      result.ID,
@@ -124,7 +124,7 @@ ORDER BY created_at DESC
 func (st *RootKeyState) InsertKey(ctx context.Context, key macaroon.RootKey) error {
 	db, err := st.DB()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	row := rootKey{
@@ -135,16 +135,16 @@ func (st *RootKeyState) InsertKey(ctx context.Context, key macaroon.RootKey) err
 	}
 	insertKeyStmt, err := st.Prepare("INSERT INTO macaroon_root_key (*) VALUES ($rootKey.*)", row)
 	if err != nil {
-		return errors.Annotate(err, "preparing insert root key statement")
+		return errors.Errorf("preparing insert root key statement %w", err)
 	}
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err := tx.Query(ctx, insertKeyStmt, row).Run()
 		if database.IsErrConstraintPrimaryKey(err) {
-			return errors.Annotatef(macaroonerrors.KeyAlreadyExists, "key with id %s", string(key.ID))
+			return errors.Errorf("key with id %s %w", string(key.ID), macaroonerrors.KeyAlreadyExists)
 		}
 		return err
 	})
-	return errors.Trace(err)
+	return errors.Capture(err)
 }
 
 // removeKeysExpiredBefore removes all root keys from state with an expiry
@@ -156,7 +156,7 @@ func (st *RootKeyState) removeKeysExpiredBefore(ctx context.Context, tx *sqlair.
 
 	removeExpiredStmt, err := st.Prepare("DELETE FROM macaroon_root_key WHERE expires_at < $M.cutoff", m)
 	if err != nil {
-		return errors.Annotatef(err, "preparing remove expired root key statement")
+		return errors.Errorf("preparing remove expired root key statement %w", err)
 	}
 	return tx.Query(ctx, removeExpiredStmt, m).Run()
 }

--- a/domain/macaroon/state/types.go
+++ b/domain/macaroon/state/types.go
@@ -8,7 +8,8 @@ import (
 	"time"
 
 	"github.com/go-macaroon-bakery/macaroon-bakery/v3/bakery"
-	"github.com/juju/errors"
+
+	"github.com/juju/juju/internal/errors"
 )
 
 // FullConfig holds the full macaroon bakery config data

--- a/domain/machine/bootstrap/bootstrap.go
+++ b/domain/machine/bootstrap/bootstrap.go
@@ -7,11 +7,11 @@ import (
 	"context"
 
 	"github.com/canonical/sqlair"
-	"github.com/juju/errors"
 
 	"github.com/juju/juju/core/database"
 	"github.com/juju/juju/domain/life"
 	internaldatabase "github.com/juju/juju/internal/database"
+	"github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/internal/uuid"
 )
 
@@ -26,25 +26,25 @@ VALUES ($M.machine_uuid, $M.net_node_uuid, $M.name, $M.life_id)
 `
 		createMachineStmt, err := sqlair.Prepare(createMachine, sqlair.M{})
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		createNode := `INSERT INTO net_node (uuid) VALUES ($M.net_node_uuid)`
 		createNodeStmt, err := sqlair.Prepare(createNode, sqlair.M{})
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		nodeUUID, err := uuid.NewUUID()
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		machineUUID, err := uuid.NewUUID()
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
-		return errors.Trace(model.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		return errors.Capture(model.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 			createParams := sqlair.M{
 				"machine_uuid":  machineUUID.String(),
 				"net_node_uuid": nodeUUID.String(),
@@ -52,12 +52,13 @@ VALUES ($M.machine_uuid, $M.net_node_uuid, $M.name, $M.life_id)
 				"life_id":       life.Alive,
 			}
 			if err := tx.Query(ctx, createNodeStmt, createParams).Run(); err != nil {
-				return errors.Annotatef(err, "creating net node row for bootstrap machine %q", machineId)
+				return errors.Errorf("creating net node row for bootstrap machine %q %w", machineId, err)
 			}
 			if err := tx.Query(ctx, createMachineStmt, createParams).Run(); err != nil {
-				return errors.Annotatef(err, "creating machine row for bootstrap machine %q", machineId)
+				return errors.Errorf("creating machine row for bootstrap machine %q %w", machineId, err)
 			}
 			return nil
 		}))
+
 	}
 }

--- a/domain/machine/errors/errors.go
+++ b/domain/machine/errors/errors.go
@@ -3,9 +3,7 @@
 
 package errors
 
-import (
-	"github.com/juju/errors"
-)
+import "github.com/juju/juju/internal/errors"
 
 const (
 	// MachineNotFound describes an error that occurs when the machine being

--- a/domain/machine/modelmigration/import.go
+++ b/domain/machine/modelmigration/import.go
@@ -7,7 +7,6 @@ import (
 	"context"
 
 	"github.com/juju/description/v8"
-	"github.com/juju/errors"
 
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/logger"
@@ -15,6 +14,7 @@ import (
 	"github.com/juju/juju/core/modelmigration"
 	"github.com/juju/juju/domain/machine/service"
 	"github.com/juju/juju/domain/machine/state"
+	"github.com/juju/juju/internal/errors"
 )
 
 // Coordinator is the interface that is used to add operations to a migration.
@@ -62,7 +62,7 @@ func (i *importOperation) Execute(ctx context.Context, model description.Model) 
 		// We need skeleton machines in dqlite.
 		machineUUID, err := i.service.CreateMachine(ctx, machine.Name(m.Id()))
 		if err != nil {
-			return errors.Annotatef(err, "importing machine %q", m.Id())
+			return errors.Errorf("importing machine %q %w", m.Id(), err)
 		}
 
 		// Import the machine's cloud instance.
@@ -88,7 +88,7 @@ func (i *importOperation) Execute(ctx context.Context, model description.Model) 
 				cloudInstance.DisplayName(),
 				hardwareCharacteristics,
 			); err != nil {
-				return errors.Annotatef(err, "importing machine cloud instance %q", m.Id())
+				return errors.Errorf("importing machine cloud instance %q %w", m.Id(), err)
 			}
 		}
 	}

--- a/domain/machine/service/machine_cloud_instance.go
+++ b/domain/machine/service/machine_cloud_instance.go
@@ -36,14 +36,20 @@ func (s *Service) InstanceIDAndName(ctx context.Context, machineUUID string) (in
 // AvailabilityZone returns the availability zone for the specified machine.
 func (s *Service) AvailabilityZone(ctx context.Context, machineUUID string) (string, error) {
 	az, err := s.st.AvailabilityZone(ctx, machineUUID)
-	return az, errors.Errorf("retrieving availability zone for machine %q %w", machineUUID, err)
+	if err != nil {
+		return "", errors.Errorf("retrieving availability zone for machine %q %w", machineUUID, err)
+	}
+	return az, nil
 }
 
 // HardwareCharacteristics returns the hardware characteristics of the
 // of the specified machine.
 func (s *Service) HardwareCharacteristics(ctx context.Context, machineUUID string) (*instance.HardwareCharacteristics, error) {
 	hc, err := s.st.HardwareCharacteristics(ctx, machineUUID)
-	return hc, errors.Errorf("retrieving hardware characteristics for machine %q %w", machineUUID, err)
+	if err != nil {
+		return nil, errors.Errorf("retrieving hardware characteristics for machine %q %w", machineUUID, err)
+	}
+	return hc, nil
 }
 
 // SetMachineCloudInstance sets an entry in the machine cloud instance table
@@ -64,7 +70,7 @@ func (s *Service) SetMachineCloudInstance(
 // table along with the instance tags and the link to a lxd profile if any, as
 // well as any associated status data.
 func (s *Service) DeleteMachineCloudInstance(ctx context.Context, machineUUID string) error {
-	return errors.Errorf("deleting machine cloud instance for machine %q %w", machineUUID,
+	return errors.Errorf("deleting machine cloud instance for machine %q: %w", machineUUID,
 		s.st.DeleteMachineCloudInstance(ctx, machineUUID))
 
 }

--- a/domain/machine/service/machine_cloud_instance.go
+++ b/domain/machine/service/machine_cloud_instance.go
@@ -6,9 +6,8 @@ package service
 import (
 	"context"
 
-	"github.com/juju/errors"
-
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/internal/errors"
 )
 
 // InstanceID returns the cloud specific instance id for this machine.
@@ -17,7 +16,7 @@ import (
 func (s *Service) InstanceID(ctx context.Context, machineUUID string) (instance.Id, error) {
 	instanceId, err := s.st.InstanceID(ctx, machineUUID)
 	if err != nil {
-		return "", errors.Annotatef(err, "retrieving cloud instance id for machine %q", machineUUID)
+		return "", errors.Errorf("retrieving cloud instance id for machine %q %w", machineUUID, err)
 	}
 	return instance.Id(instanceId), nil
 }
@@ -29,7 +28,7 @@ func (s *Service) InstanceID(ctx context.Context, machineUUID string) (instance.
 func (s *Service) InstanceIDAndName(ctx context.Context, machineUUID string) (instance.Id, string, error) {
 	instanceID, instanceName, err := s.st.InstanceIDAndName(ctx, machineUUID)
 	if err != nil {
-		return "", "", errors.Annotatef(err, "retrieving cloud instance name for machine %q", machineUUID)
+		return "", "", errors.Errorf("retrieving cloud instance name for machine %q %w", machineUUID, err)
 	}
 	return instance.Id(instanceID), instanceName, nil
 }
@@ -37,14 +36,14 @@ func (s *Service) InstanceIDAndName(ctx context.Context, machineUUID string) (in
 // AvailabilityZone returns the availability zone for the specified machine.
 func (s *Service) AvailabilityZone(ctx context.Context, machineUUID string) (string, error) {
 	az, err := s.st.AvailabilityZone(ctx, machineUUID)
-	return az, errors.Annotatef(err, "retrieving availability zone for machine %q", machineUUID)
+	return az, errors.Errorf("retrieving availability zone for machine %q %w", machineUUID, err)
 }
 
 // HardwareCharacteristics returns the hardware characteristics of the
 // of the specified machine.
 func (s *Service) HardwareCharacteristics(ctx context.Context, machineUUID string) (*instance.HardwareCharacteristics, error) {
 	hc, err := s.st.HardwareCharacteristics(ctx, machineUUID)
-	return hc, errors.Annotatef(err, "retrieving hardware characteristics for machine %q", machineUUID)
+	return hc, errors.Errorf("retrieving hardware characteristics for machine %q %w", machineUUID, err)
 }
 
 // SetMachineCloudInstance sets an entry in the machine cloud instance table
@@ -56,19 +55,16 @@ func (s *Service) SetMachineCloudInstance(
 	displayName string,
 	hardwareCharacteristics *instance.HardwareCharacteristics,
 ) error {
-	return errors.Annotatef(
-		s.st.SetMachineCloudInstance(ctx, machineUUID, instanceID, displayName, hardwareCharacteristics),
-		"setting machine cloud instance for machine %q", machineUUID,
-	)
+	return errors.Errorf("setting machine cloud instance for machine %q %w", machineUUID,
+		s.st.SetMachineCloudInstance(ctx, machineUUID, instanceID, displayName, hardwareCharacteristics))
+
 }
 
 // DeleteMachineCloudInstance removes an entry in the machine cloud instance
 // table along with the instance tags and the link to a lxd profile if any, as
 // well as any associated status data.
 func (s *Service) DeleteMachineCloudInstance(ctx context.Context, machineUUID string) error {
-	return errors.Annotatef(
-		s.st.DeleteMachineCloudInstance(ctx, machineUUID),
-		"deleting machine cloud instance for machine %q", machineUUID,
-	)
+	return errors.Errorf("deleting machine cloud instance for machine %q %w", machineUUID,
+		s.st.DeleteMachineCloudInstance(ctx, machineUUID))
 
 }

--- a/domain/machine/service/machine_cloud_instance_test.go
+++ b/domain/machine/service/machine_cloud_instance_test.go
@@ -6,12 +6,12 @@ package service
 import (
 	"context"
 
-	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gomock "go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/instance"
+	"github.com/juju/juju/internal/errors"
 )
 
 func (s *serviceSuite) TestRetrieveHardwareCharacteristics(c *gc.C) {

--- a/domain/machine/service/service.go
+++ b/domain/machine/service/service.go
@@ -6,8 +6,6 @@ package service
 import (
 	"context"
 
-	"github.com/juju/errors"
-
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/machine"
 	coremachine "github.com/juju/juju/core/machine"
@@ -16,6 +14,7 @@ import (
 	"github.com/juju/juju/domain/life"
 	machineerrors "github.com/juju/juju/domain/machine/errors"
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/internal/uuid"
 )
 
@@ -176,12 +175,12 @@ func (s *Service) CreateMachine(ctx context.Context, machineName coremachine.Nam
 	// the state layer we don't keep regenerating.
 	nodeUUID, machineUUID, err := createUUIDs()
 	if err != nil {
-		return "", errors.Annotatef(err, "creating machine %q", machineName)
+		return "", errors.Errorf("creating machine %q %w", machineName, err)
 	}
 
 	err = s.st.CreateMachine(ctx, machineName, nodeUUID, machineUUID)
 
-	return machineUUID, errors.Annotatef(err, "creating machine %q", machineName)
+	return machineUUID, errors.Errorf("creating machine %q %w", machineName, err)
 }
 
 // CreateMachineWirhParent creates the specified machine with the specified
@@ -195,23 +194,23 @@ func (s *Service) CreateMachineWithParent(ctx context.Context, machineName, pare
 	// the state layer we don't keep regenerating.
 	nodeUUID, machineUUID, err := createUUIDs()
 	if err != nil {
-		return "", errors.Annotatef(err, "creating machine %q with parent %q", machineName, parentName)
+		return "", errors.Errorf("creating machine %q with parent %q %w", machineName, parentName, err)
 	}
 
 	err = s.st.CreateMachineWithParent(ctx, machineName, parentName, nodeUUID, machineUUID)
 
-	return machineUUID, errors.Annotatef(err, "creating machine %q with parent %q", machineName, parentName)
+	return machineUUID, errors.Errorf("creating machine %q with parent %q %w", machineName, parentName, err)
 }
 
 // createUUIDs generates a new UUID for the machine and the net-node.
 func createUUIDs() (string, string, error) {
 	nodeUUID, err := uuid.NewUUID()
 	if err != nil {
-		return "", "", errors.Annotate(err, "generating net-node UUID")
+		return "", "", errors.Errorf("generating net-node UUID %w", err)
 	}
 	machineUUID, err := uuid.NewUUID()
 	if err != nil {
-		return "", "", errors.Annotate(err, "generating machine UUID")
+		return "", "", errors.Errorf("generating machine UUID %w", err)
 	}
 	return nodeUUID.String(), machineUUID.String(), nil
 }
@@ -219,21 +218,21 @@ func createUUIDs() (string, string, error) {
 // DeleteMachine deletes the specified machine.
 func (s *Service) DeleteMachine(ctx context.Context, machineName coremachine.Name) error {
 	err := s.st.DeleteMachine(ctx, machineName)
-	return errors.Annotatef(err, "deleting machine %q", machineName)
+	return errors.Errorf("deleting machine %q %w", machineName, err)
 }
 
 // GetMachineLife returns the GetMachineLife status of the specified machine.
 // It returns a NotFound if the given machine doesn't exist.
 func (s *Service) GetMachineLife(ctx context.Context, machineName coremachine.Name) (*life.Life, error) {
 	life, err := s.st.GetMachineLife(ctx, machineName)
-	return life, errors.Annotatef(err, "getting life status for machine %q", machineName)
+	return life, errors.Errorf("getting life status for machine %q %w", machineName, err)
 }
 
 // SetMachineLife sets the life status of the specified machine.
 // It returns a MachineNotFound if the provided machine doesn't exist.
 func (s *Service) SetMachineLife(ctx context.Context, machineName coremachine.Name, life life.Life) error {
 	err := s.st.SetMachineLife(ctx, machineName, life)
-	return errors.Annotatef(err, "setting life status for machine %q", machineName)
+	return errors.Errorf("setting life status for machine %q %w", machineName, err)
 }
 
 // EnsureDeadMachine sets the provided machine's life status to Dead.
@@ -247,7 +246,7 @@ func (s *Service) EnsureDeadMachine(ctx context.Context, machineName coremachine
 func (s *Service) AllMachineNames(ctx context.Context) ([]coremachine.Name, error) {
 	machines, err := s.st.AllMachineNames(ctx)
 	if err != nil {
-		return nil, errors.Annotate(err, "retrieving all machines")
+		return nil, errors.Errorf("retrieving all machines %w", err)
 	}
 	return machines, nil
 }
@@ -260,7 +259,7 @@ func (s *Service) AllMachineNames(ctx context.Context) ([]coremachine.Name, erro
 func (s *Service) GetInstanceStatus(ctx context.Context, machineName coremachine.Name) (status.StatusInfo, error) {
 	instanceStatus, err := s.st.GetInstanceStatus(ctx, machineName)
 	if err != nil {
-		return status.StatusInfo{}, errors.Annotatef(err, "retrieving cloud instance status for machine %q", machineName)
+		return status.StatusInfo{}, errors.Errorf("retrieving cloud instance status for machine %q %w", machineName, err)
 	}
 	return instanceStatus, nil
 }
@@ -275,7 +274,7 @@ func (s *Service) SetInstanceStatus(ctx context.Context, machineName coremachine
 	}
 	err := s.st.SetInstanceStatus(ctx, machineName, status)
 	if err != nil {
-		return errors.Annotatef(err, "setting cloud instance status for machine %q", machineName)
+		return errors.Errorf("setting cloud instance status for machine %q %w", machineName, err)
 	}
 	return nil
 }
@@ -287,7 +286,7 @@ func (s *Service) SetInstanceStatus(ctx context.Context, machineName coremachine
 func (s *Service) GetMachineStatus(ctx context.Context, machineName coremachine.Name) (status.StatusInfo, error) {
 	machineStatus, err := s.st.GetMachineStatus(ctx, machineName)
 	if err != nil {
-		return status.StatusInfo{}, errors.Annotatef(err, "retrieving machine status for machine %q", machineName)
+		return status.StatusInfo{}, errors.Errorf("retrieving machine status for machine %q %w", machineName, err)
 	}
 	return machineStatus, nil
 }
@@ -301,7 +300,7 @@ func (s *Service) SetMachineStatus(ctx context.Context, machineName coremachine.
 	}
 	err := s.st.SetMachineStatus(ctx, machineName, status)
 	if err != nil {
-		return errors.Annotatef(err, "setting machine status for machine %q", machineName)
+		return errors.Errorf("setting machine status for machine %q %w", machineName, err)
 	}
 	return nil
 }
@@ -311,7 +310,7 @@ func (s *Service) SetMachineStatus(ctx context.Context, machineName coremachine.
 func (s *Service) IsMachineController(ctx context.Context, machineName coremachine.Name) (bool, error) {
 	isController, err := s.st.IsMachineController(ctx, machineName)
 	if err != nil {
-		return false, errors.Annotatef(err, "checking if machine %q is a controller", machineName)
+		return false, errors.Errorf("checking if machine %q is a controller %w", machineName, err)
 	}
 	return isController, nil
 }
@@ -322,7 +321,7 @@ func (s *Service) IsMachineController(ctx context.Context, machineName coremachi
 func (s *Service) ShouldKeepInstance(ctx context.Context, machineName coremachine.Name) (bool, error) {
 	keepInstance, err := s.st.ShouldKeepInstance(ctx, machineName)
 	if err != nil {
-		return false, errors.Trace(err)
+		return false, errors.Capture(err)
 	}
 	return keepInstance, nil
 }
@@ -332,23 +331,23 @@ func (s *Service) ShouldKeepInstance(ctx context.Context, machineName coremachin
 // exists.
 // It returns a NotFound if the given machine doesn't exist.
 func (s *Service) SetKeepInstance(ctx context.Context, machineName coremachine.Name, keep bool) error {
-	return errors.Trace(s.st.SetKeepInstance(ctx, machineName, keep))
+	return errors.Capture(s.st.SetKeepInstance(ctx, machineName, keep))
 }
 
 // RequireMachineReboot sets the machine referenced by its UUID as requiring a reboot.
 func (s *Service) RequireMachineReboot(ctx context.Context, uuid string) error {
-	return errors.Annotatef(s.st.RequireMachineReboot(ctx, uuid), "requiring a machine reboot for machine with uuid %q", uuid)
+	return errors.Errorf("requiring a machine reboot for machine with uuid %q %w", uuid, s.st.RequireMachineReboot(ctx, uuid))
 }
 
 // ClearMachineReboot removes the reboot flag of the machine referenced by its UUID if a reboot has previously been required.
 func (s *Service) ClearMachineReboot(ctx context.Context, uuid string) error {
-	return errors.Annotatef(s.st.ClearMachineReboot(ctx, uuid), "clear machine reboot flag for machine with uuid %q", uuid)
+	return errors.Errorf("clear machine reboot flag for machine with uuid %q %w", uuid, s.st.ClearMachineReboot(ctx, uuid))
 }
 
 // IsMachineRebootRequired checks if the machine referenced by its UUID requires a reboot.
 func (s *Service) IsMachineRebootRequired(ctx context.Context, uuid string) (bool, error) {
 	rebootRequired, err := s.st.IsMachineRebootRequired(ctx, uuid)
-	return rebootRequired, errors.Annotatef(err, "checking if machine with uuid %q is requiring a reboot", uuid)
+	return rebootRequired, errors.Errorf("checking if machine with uuid %q is requiring a reboot %w", uuid, err)
 }
 
 // GetMachineParentUUID returns the parent UUID of the specified machine.
@@ -358,7 +357,7 @@ func (s *Service) IsMachineRebootRequired(ctx context.Context, uuid string) (boo
 func (s *Service) GetMachineParentUUID(ctx context.Context, machineUUID string) (string, error) {
 	parentUUID, err := s.st.GetMachineParentUUID(ctx, machineUUID)
 	if err != nil {
-		return "", errors.Annotatef(err, "retrieving parent UUID for machine %q", machineUUID)
+		return "", errors.Errorf("retrieving parent UUID for machine %q %w", machineUUID, err)
 	}
 	return parentUUID, nil
 }
@@ -366,13 +365,13 @@ func (s *Service) GetMachineParentUUID(ctx context.Context, machineUUID string) 
 // ShouldRebootOrShutdown determines whether a machine should reboot or shutdown
 func (s *Service) ShouldRebootOrShutdown(ctx context.Context, uuid string) (coremachine.RebootAction, error) {
 	rebootRequired, err := s.st.ShouldRebootOrShutdown(ctx, uuid)
-	return rebootRequired, errors.Annotatef(err, "getting if the machine with uuid %q need to reboot or shutdown", uuid)
+	return rebootRequired, errors.Errorf("getting if the machine with uuid %q need to reboot or shutdown %w", uuid, err)
 }
 
 // MarkMachineForRemoval marks the given machine for removal.
 // It returns a MachineNotFound error if the machine does not exist.
 func (s *Service) MarkMachineForRemoval(ctx context.Context, machineName coremachine.Name) error {
-	return errors.Annotatef(s.st.MarkMachineForRemoval(ctx, machineName), "marking machine %q for removal", machineName)
+	return errors.Errorf("marking machine %q for removal %w", machineName, s.st.MarkMachineForRemoval(ctx, machineName))
 }
 
 // GetAllMachineRemovals returns the UUIDs of all of the machines that need to
@@ -380,7 +379,7 @@ func (s *Service) MarkMachineForRemoval(ctx context.Context, machineName coremac
 func (s *Service) GetAllMachineRemovals(ctx context.Context) ([]string, error) {
 	removals, err := s.st.GetAllMachineRemovals(ctx)
 	if err != nil {
-		return nil, errors.Annotate(err, "retrieving all machines marked to be removed")
+		return nil, errors.Errorf("retrieving all machines marked to be removed %w", err)
 	}
 	return removals, nil
 }
@@ -395,7 +394,7 @@ func (s *Service) GetMachineUUID(ctx context.Context, name coremachine.Name) (st
 func (s *Service) AppliedLXDProfileNames(ctx context.Context, mUUID string) ([]string, error) {
 	profiles, err := s.st.AppliedLXDProfileNames(ctx, mUUID)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	return profiles, nil
 }
@@ -406,7 +405,7 @@ func (s *Service) AppliedLXDProfileNames(ctx context.Context, mUUID string) ([]s
 // [machineerrors.MachineNotFound] will be returned if the machine does not
 // exist.
 func (s *Service) SetAppliedLXDProfileNames(ctx context.Context, mUUID string, profileNames []string) error {
-	return errors.Trace(s.st.SetAppliedLXDProfileNames(ctx, mUUID, profileNames))
+	return errors.Capture(s.st.SetAppliedLXDProfileNames(ctx, mUUID, profileNames))
 }
 
 // ProviderService provides the API for working with machines using the
@@ -421,7 +420,7 @@ type ProviderService struct {
 func (s *ProviderService) GetBootstrapEnviron(ctx context.Context) (environs.BootstrapEnviron, error) {
 	provider, err := s.providerGetter(ctx)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	return provider, nil
 }
@@ -430,7 +429,7 @@ func (s *ProviderService) GetBootstrapEnviron(ctx context.Context) (environs.Boo
 func (s *ProviderService) GetInstanceTypesFetcher(ctx context.Context) (environs.InstanceTypesFetcher, error) {
 	provider, err := s.providerGetter(ctx)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	return provider, nil
 }

--- a/domain/machine/service/service_test.go
+++ b/domain/machine/service/service_test.go
@@ -6,17 +6,18 @@ package service
 import (
 	"context"
 
-	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
+	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/instance"
 	cmachine "github.com/juju/juju/core/machine"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/domain/life"
 	machineerrors "github.com/juju/juju/domain/machine/errors"
+	"github.com/juju/juju/internal/errors"
 )
 
 type serviceSuite struct {
@@ -99,10 +100,10 @@ func (s *serviceSuite) TestCreateMachineWithParentError(c *gc.C) {
 func (s *serviceSuite) TestCreateMachineWithParentParentNotFound(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().CreateMachineWithParent(gomock.Any(), cmachine.Name("666"), cmachine.Name("parent"), gomock.Any(), gomock.Any()).Return(errors.NotFound)
+	s.state.EXPECT().CreateMachineWithParent(gomock.Any(), cmachine.Name("666"), cmachine.Name("parent"), gomock.Any(), gomock.Any()).Return(coreerrors.NotFound)
 
 	_, err := NewService(s.state).CreateMachineWithParent(context.Background(), cmachine.Name("666"), cmachine.Name("parent"))
-	c.Check(err, jc.ErrorIs, errors.NotFound)
+	c.Check(err, jc.ErrorIs, coreerrors.NotFound)
 }
 
 // TestCreateMachineWithParentMachineAlreadyExists asserts that the state layer
@@ -173,11 +174,11 @@ func (s *serviceSuite) TestGetLifeError(c *gc.C) {
 func (s *serviceSuite) TestGetLifeNotFoundError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().GetMachineLife(gomock.Any(), cmachine.Name("666")).Return(nil, errors.NotFound)
+	s.state.EXPECT().GetMachineLife(gomock.Any(), cmachine.Name("666")).Return(nil, coreerrors.NotFound)
 
 	l, err := NewService(s.state).GetMachineLife(context.Background(), "666")
 	c.Check(l, gc.IsNil)
-	c.Check(err, jc.ErrorIs, errors.NotFound)
+	c.Check(err, jc.ErrorIs, coreerrors.NotFound)
 }
 
 // TestSetMachineLifeSuccess asserts the happy path of the SetMachineLife
@@ -210,10 +211,10 @@ func (s *serviceSuite) TestSetMachineLifeError(c *gc.C) {
 func (s *serviceSuite) TestSetMachineLifeMachineDontExist(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().SetMachineLife(gomock.Any(), cmachine.Name("nonexistent"), life.Alive).Return(errors.NotFound)
+	s.state.EXPECT().SetMachineLife(gomock.Any(), cmachine.Name("nonexistent"), life.Alive).Return(coreerrors.NotFound)
 
 	err := NewService(s.state).SetMachineLife(context.Background(), "nonexistent", life.Alive)
-	c.Assert(err, jc.ErrorIs, errors.NotFound)
+	c.Assert(err, jc.ErrorIs, coreerrors.NotFound)
 }
 
 // TestEnsureDeadMachineSuccess asserts the happy path of the EnsureDeadMachine
@@ -442,10 +443,10 @@ func (s *serviceSuite) TestIsControllerError(c *gc.C) {
 func (s *serviceSuite) TestIsControllerNotFound(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().IsMachineController(gomock.Any(), cmachine.Name("666")).Return(false, errors.NotFound)
+	s.state.EXPECT().IsMachineController(gomock.Any(), cmachine.Name("666")).Return(false, coreerrors.NotFound)
 
 	isController, err := NewService(s.state).IsMachineController(context.Background(), cmachine.Name("666"))
-	c.Check(err, jc.ErrorIs, errors.NotFound)
+	c.Check(err, jc.ErrorIs, coreerrors.NotFound)
 	c.Check(isController, jc.IsFalse)
 }
 
@@ -556,10 +557,10 @@ func (s *serviceSuite) TestGetMachineParentUUIDError(c *gc.C) {
 func (s *serviceSuite) TestGetMachineParentUUIDNotFound(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().GetMachineParentUUID(gomock.Any(), "666").Return("", errors.NotFound)
+	s.state.EXPECT().GetMachineParentUUID(gomock.Any(), "666").Return("", coreerrors.NotFound)
 
 	parentUUID, err := NewService(s.state).GetMachineParentUUID(context.Background(), "666")
-	c.Check(err, jc.ErrorIs, errors.NotFound)
+	c.Check(err, jc.ErrorIs, coreerrors.NotFound)
 	c.Check(parentUUID, gc.Equals, "")
 }
 
@@ -705,10 +706,10 @@ func (s *serviceSuite) TestGetMachineUUIDSuccess(c *gc.C) {
 func (s *serviceSuite) TestGetMachineUUIDNotFound(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().GetMachineUUID(gomock.Any(), cmachine.Name("666")).Return("", errors.NotFound)
+	s.state.EXPECT().GetMachineUUID(gomock.Any(), cmachine.Name("666")).Return("", coreerrors.NotFound)
 
 	uuid, err := NewService(s.state).GetMachineUUID(context.Background(), "666")
-	c.Check(err, jc.ErrorIs, errors.NotFound)
+	c.Check(err, jc.ErrorIs, coreerrors.NotFound)
 	c.Check(uuid, gc.Equals, "")
 }
 

--- a/domain/machine/service/watcher.go
+++ b/domain/machine/service/watcher.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/juju/collections/set"
 	"github.com/juju/collections/transform"
-	"github.com/juju/errors"
 
 	"github.com/juju/juju/core/changestream"
 	"github.com/juju/juju/core/database"
@@ -20,6 +19,7 @@ import (
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/core/watcher/eventsource"
 	machineerrors "github.com/juju/juju/domain/machine/errors"
+	"github.com/juju/juju/internal/errors"
 )
 
 type WatchableService struct {
@@ -115,7 +115,7 @@ func (s *WatchableService) WatchLXDProfiles(ctx context.Context, machineUUID str
 func (s *WatchableService) WatchMachineReboot(ctx context.Context, uuid string) (watcher.NotifyWatcher, error) {
 	uuids, err := s.machineToCareForReboot(ctx, uuid)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	machines := set.NewStrings(uuids...)
 	return s.watcherFactory.NewNamespaceNotifyMapperWatcher(
@@ -130,7 +130,7 @@ func (s *WatchableService) WatchMachineReboot(ctx context.Context, uuid string) 
 func (s *WatchableService) machineToCareForReboot(ctx context.Context, uuid string) ([]string, error) {
 	parentUUID, err := s.st.GetMachineParentUUID(ctx, uuid)
 	if err != nil && !errors.Is(err, machineerrors.MachineHasNoParent) {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	if errors.Is(err, machineerrors.MachineHasNoParent) {
 		return []string{uuid}, nil

--- a/domain/machine/state/machine_cloud_instance.go
+++ b/domain/machine/state/machine_cloud_instance.go
@@ -246,7 +246,7 @@ WHERE machine_uuid=$machineUUID.uuid
 
 		// Delete the machine cloud instance.
 		if err := tx.Query(ctx, deleteInstanceStmt, machineUUIDParam).Run(); err != nil {
-			return errors.Errorf("deleting machine cloud instance for machine %q %w", mUUID, domain.CoerceError(err))
+			return errors.Errorf("deleting machine cloud instance for machine %q: %w", mUUID, domain.CoerceError(err))
 		}
 
 		// Delete the machine cloud instance tags.

--- a/domain/machine/state/reboot.go
+++ b/domain/machine/state/reboot.go
@@ -7,11 +7,11 @@ import (
 	"context"
 
 	"github.com/canonical/sqlair"
-	"github.com/juju/errors"
 
 	coremachine "github.com/juju/juju/core/machine"
 	machineerrors "github.com/juju/juju/domain/machine/errors"
 	"github.com/juju/juju/internal/database"
+	"github.com/juju/juju/internal/errors"
 )
 
 // RequireMachineReboot sets the machine referenced by its UUID as requiring a
@@ -23,13 +23,13 @@ import (
 func (st *State) RequireMachineReboot(ctx context.Context, uuid string) error {
 	db, err := st.DB()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	machineUUIDParam := machineUUID{uuid}
 	setRebootFlag := `INSERT INTO machine_requires_reboot (machine_uuid) VALUES ($machineUUID.uuid)`
 	setRebootFlagStmt, err := sqlair.Prepare(setRebootFlag, machineUUIDParam)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err := tx.Query(ctx, setRebootFlagStmt, machineUUIDParam).Run()
@@ -37,12 +37,12 @@ func (st *State) RequireMachineReboot(ctx context.Context, uuid string) error {
 			// if the same uuid is added twice, do nothing (idempotency)
 			return nil
 		} else if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		return nil
 	})
 
-	return errors.Annotatef(err, "requiring reboot of machine %q", uuid)
+	return errors.Errorf("requiring reboot of machine %q %w", uuid, err)
 }
 
 // ClearMachineReboot removes the reboot flag of the machine referenced by its UUID if a reboot
@@ -53,18 +53,18 @@ func (st *State) RequireMachineReboot(ctx context.Context, uuid string) error {
 func (st *State) ClearMachineReboot(ctx context.Context, uuid string) error {
 	db, err := st.DB()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	machineUUIDParam := machineUUID{uuid}
 	unsetRebootFlag := `DELETE FROM machine_requires_reboot WHERE machine_uuid = $machineUUID.uuid`
 	unsetRebootFlagStmt, err := sqlair.Prepare(unsetRebootFlag, machineUUIDParam)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		return tx.Query(ctx, unsetRebootFlagStmt, machineUUIDParam).Run()
 	})
-	return errors.Annotatef(err, "cancelling reboot of machine %q", uuid)
+	return errors.Errorf("cancelling reboot of machine %q %w", uuid, err)
 }
 
 // IsMachineRebootRequired checks if the specified machine requires a reboot.
@@ -75,7 +75,7 @@ func (st *State) ClearMachineReboot(ctx context.Context, uuid string) error {
 func (st *State) IsMachineRebootRequired(ctx context.Context, uuid string) (bool, error) {
 	db, err := st.DB()
 	if err != nil {
-		return false, errors.Trace(err)
+		return false, errors.Capture(err)
 	}
 
 	var isRebootRequired bool
@@ -83,18 +83,18 @@ func (st *State) IsMachineRebootRequired(ctx context.Context, uuid string) (bool
 	isRebootFlag := `SELECT machine_uuid as &machineUUID.uuid  FROM machine_requires_reboot WHERE machine_uuid = $machineUUID.uuid`
 	isRebootFlagStmt, err := sqlair.Prepare(isRebootFlag, machineUUIDParam)
 	if err != nil {
-		return false, errors.Trace(err)
+		return false, errors.Capture(err)
 	}
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err := tx.Query(ctx, isRebootFlagStmt, machineUUIDParam).Get(&machineUUIDParam)
 		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		isRebootRequired = !errors.Is(err, sqlair.ErrNoRows)
 		return nil
 	})
 
-	return isRebootRequired, errors.Annotatef(err, "requiring reboot of machine %q", uuid)
+	return isRebootRequired, errors.Errorf("requiring reboot of machine %q %w", uuid, err)
 }
 
 // ShouldRebootOrShutdown determines if a machine should reboot or shutdown
@@ -117,7 +117,7 @@ func (st *State) IsMachineRebootRequired(ctx context.Context, uuid string) (bool
 func (st *State) ShouldRebootOrShutdown(ctx context.Context, uuid string) (coremachine.RebootAction, error) {
 	db, err := st.DB()
 	if err != nil {
-		return coremachine.ShouldDoNothing, errors.Trace(err)
+		return coremachine.ShouldDoNothing, errors.Capture(err)
 	}
 
 	// Prepare query to get parent UUID
@@ -125,14 +125,14 @@ func (st *State) ShouldRebootOrShutdown(ctx context.Context, uuid string) (corem
 	getParentQuery := `SELECT machine_parent.parent_uuid as &machineUUID.uuid  FROM machine_parent WHERE machine_uuid = $machineUUID.uuid`
 	getParentStmt, err := sqlair.Prepare(getParentQuery, machineUUIDParam)
 	if err != nil {
-		return coremachine.ShouldDoNothing, errors.Annotatef(err, "requiring reboot action for machine %q", uuid)
+		return coremachine.ShouldDoNothing, errors.Errorf("requiring reboot action for machine %q %w", uuid, err)
 	}
 
 	// Prepare query to check if a machine requires reboot
 	isRebootFlag := `SELECT machine_uuid as &machineUUID.uuid  FROM machine_requires_reboot WHERE machine_uuid = $machineUUID.uuid`
 	isRebootFlagStmt, err := sqlair.Prepare(isRebootFlag, machineUUIDParam)
 	if err != nil {
-		return coremachine.ShouldDoNothing, errors.Annotatef(err, "requiring reboot action for machine %q", uuid)
+		return coremachine.ShouldDoNothing, errors.Errorf("requiring reboot action for machine %q %w", uuid, err)
 	}
 
 	var parentShouldReboot, machineShouldReboot bool
@@ -141,13 +141,13 @@ func (st *State) ShouldRebootOrShutdown(ctx context.Context, uuid string) (corem
 		var machine, parentMachine, grandParentMachine machineUUID
 		err := tx.Query(ctx, getParentStmt, machineUUIDParam).Get(&parentMachine)
 		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		// Check that there is no grandparent (it is not supported)
 		err = tx.Query(ctx, getParentStmt, parentMachine).Get(&grandParentMachine)
 		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		if err == nil {
 			// Grandparent are not supported. If you get there, possible cause are:
@@ -159,14 +159,14 @@ func (st *State) ShouldRebootOrShutdown(ctx context.Context, uuid string) (corem
 			// loophole: if we accept grandparent in the actual representation in DQLite, we may
 			// have cycle.
 			// Moreover, reboot watcher statement and implementation may need to be updated.
-			return errors.Annotatef(machineerrors.GrandParentNotSupported, "found  %q parent of %q parent of %q", grandParentMachine.UUID, parentMachine.UUID, uuid)
+			return errors.Errorf("found  %q parent of %q parent of %q %w", grandParentMachine.UUID, parentMachine.UUID, uuid, machineerrors.GrandParentNotSupported)
 		}
 
 		// Check parent reboot status
 		if parentMachine.UUID != "" {
 			err := tx.Query(ctx, isRebootFlagStmt, parentMachine).Get(&machine)
 			if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-				return errors.Trace(err)
+				return errors.Capture(err)
 			}
 			parentShouldReboot = !errors.Is(err, sqlair.ErrNoRows)
 			if parentShouldReboot {
@@ -177,13 +177,13 @@ func (st *State) ShouldRebootOrShutdown(ctx context.Context, uuid string) (corem
 		// Check machine reboot status
 		err = tx.Query(ctx, isRebootFlagStmt, machineUUIDParam).Get(&machine)
 		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		machineShouldReboot = !errors.Is(err, sqlair.ErrNoRows)
 		return nil
 	})
 	if err != nil {
-		return coremachine.ShouldDoNothing, errors.Annotatef(err, "requiring reboot action for machine %q", uuid)
+		return coremachine.ShouldDoNothing, errors.Errorf("requiring reboot action for machine %q %w", uuid, err)
 	}
 
 	// Parent need reboot

--- a/domain/machine/state/reboot_test.go
+++ b/domain/machine/state/reboot_test.go
@@ -6,12 +6,12 @@ package state
 import (
 	"context"
 
-	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	coremachine "github.com/juju/juju/core/machine"
 	machineerrors "github.com/juju/juju/domain/machine/errors"
+	"github.com/juju/juju/internal/errors"
 )
 
 func (s *stateSuite) TestIsMachineRebootRequiredNoMachine(c *gc.C) {

--- a/domain/machine/state/state.go
+++ b/domain/machine/state/state.go
@@ -198,7 +198,11 @@ WHERE  machine_uuid = $machineUUID.uuid`
 
 		return nil
 	})
-	return errors.Errorf("inserting machine %q %w", mName, err)
+
+	if err != nil {
+		return errors.Errorf("inserting machine %q %w", mName, err)
+	}
+	return nil
 }
 
 // DeleteMachine deletes the specified machine and any dependent child records.
@@ -276,7 +280,7 @@ DELETE FROM net_node WHERE uuid IN
 
 		// Remove the machine.
 		if err := tx.Query(ctx, deleteMachineStmt, machineNameParam).Run(); err != nil {
-			return errors.Errorf("deleting machine %q %w", mName, err)
+			return errors.Errorf("deleting machine %q: %w", mName, err)
 		}
 
 		// Remove the net node for the machine.
@@ -286,7 +290,10 @@ DELETE FROM net_node WHERE uuid IN
 
 		return nil
 	})
-	return errors.Errorf("deleting machine %q %w", mName, err)
+	if err != nil {
+		return errors.Errorf("deleting machine %q: %w", mName, err)
+	}
+	return nil
 }
 
 // InitialWatchModelMachinesStatement returns the table and the initial watch

--- a/domain/machine/state/state.go
+++ b/domain/machine/state/state.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/canonical/sqlair"
 	"github.com/juju/collections/transform"
-	"github.com/juju/errors"
 
 	coredb "github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/logger"
@@ -19,7 +18,7 @@ import (
 	blockdevice "github.com/juju/juju/domain/blockdevice/state"
 	"github.com/juju/juju/domain/life"
 	machineerrors "github.com/juju/juju/domain/machine/errors"
-	internalerrors "github.com/juju/juju/internal/errors"
+	"github.com/juju/juju/internal/errors"
 )
 
 // State describes retrieval and persistence methods for storage.
@@ -72,7 +71,7 @@ func (st *State) CreateMachineWithParent(ctx context.Context, machineName, paren
 func (st *State) createMachine(ctx context.Context, args createMachineArgs) error {
 	db, err := st.DB()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	mName := args.name
@@ -83,7 +82,7 @@ func (st *State) createMachine(ctx context.Context, args createMachineArgs) erro
 	machineUUIDQuery := `SELECT &machineUUID.uuid FROM machine WHERE name = $machineName.name`
 	machineUUIDStmt, err := st.Prepare(machineUUIDQuery, machineNameParam, machineUUIDout)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	// Prepare query for creating machine row.
@@ -99,14 +98,14 @@ VALUES ($M.machine_uuid, $M.net_node_uuid, $M.name, $M.life_id)
 `
 	createMachineStmt, err := st.Prepare(createMachineQuery, createParams)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	// Prepare query for creating net node row.
 	createNodeQuery := `INSERT INTO net_node (uuid) VALUES ($M.net_node_uuid)`
 	createNodeStmt, err := st.Prepare(createNodeQuery, createParams)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	// Prepare query for associating/verifying parent machine.
@@ -123,7 +122,7 @@ VALUES ($machineParent.machine_uuid, $machineParent.parent_uuid)
 `
 		associateParentStmt, err = st.Prepare(associateParentQuery, associateParentParam)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		// Prepare query for verifying there's no grandparent.
@@ -135,7 +134,7 @@ FROM   machine_parent
 WHERE  machine_uuid = $machineUUID.uuid`
 		parentQueryStmt, err = st.Prepare(parentQuery, outputMachineParent, inputParentMachineUUID)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 	}
 
@@ -145,22 +144,22 @@ WHERE  machine_uuid = $machineUUID.uuid`
 		err := tx.Query(ctx, machineUUIDStmt, machineNameParam).Get(&machineUUIDout)
 		// No error means we found the machine with the given name.
 		if err == nil {
-			return errors.Annotatef(machineerrors.MachineAlreadyExists, "machine %q", mName)
+			return errors.Errorf("machine %q %w", mName, machineerrors.MachineAlreadyExists)
 		}
 		if !errors.Is(err, sqlair.ErrNoRows) {
 			// Return error if the query failed for any reason other than not
 			// found.
-			return errors.Annotatef(err, "querying machine %q", mName)
+			return errors.Errorf("querying machine %q %w", mName, err)
 		}
 
 		// Run query to create net node row.
 		if err := tx.Query(ctx, createNodeStmt, createParams).Run(); err != nil {
-			return errors.Annotatef(err, "creating net node row for machine %q", mName)
+			return errors.Errorf("creating net node row for machine %q %w", mName, err)
 		}
 
 		// Run query to create machine row.
 		if err := tx.Query(ctx, createMachineStmt, createParams).Run(); err != nil {
-			return errors.Annotatef(err, "creating machine row for machine %q", mName)
+			return errors.Errorf("creating machine row for machine %q %w", mName, err)
 		}
 
 		// Associate a parent machine if parentName is provided.
@@ -169,10 +168,10 @@ WHERE  machine_uuid = $machineUUID.uuid`
 			// Reusing the machineUUIDout variable for the parent.
 			err := tx.Query(ctx, machineUUIDStmt, parentNameParam).Get(&machineUUIDout)
 			if errors.Is(err, sqlair.ErrNoRows) {
-				return errors.Annotatef(machineerrors.MachineNotFound, "parent machine %q for %q", args.parentName, mName)
+				return errors.Errorf("parent machine %q for %q %w", args.parentName, mName, machineerrors.MachineNotFound)
 			}
 			if err != nil {
-				return errors.Annotatef(err, "querying parent machine %q for machine %q", args.parentName, mName)
+				return errors.Errorf("querying parent machine %q for machine %q %w", args.parentName, mName, err)
 			}
 
 			// Protect against a grandparent
@@ -182,24 +181,24 @@ WHERE  machine_uuid = $machineUUID.uuid`
 			err = tx.Query(ctx, parentQueryStmt, machineParentUUID).Get(&machineParent)
 			// No error means we found a grandparent.
 			if err == nil {
-				return errors.Annotatef(machineerrors.GrandParentNotSupported, "machine %q", mName)
+				return errors.Errorf("machine %q %w", mName, machineerrors.GrandParentNotSupported)
 			}
 			if !errors.Is(err, sqlair.ErrNoRows) {
 				// Return error if the query failed for any reason other than not
 				// found.
-				return errors.Annotatef(err, "querying for grandparent UUID for machine %q", mName)
+				return errors.Errorf("querying for grandparent UUID for machine %q %w", mName, err)
 			}
 
 			// Run query to associate parent machine.
 			associateParentParam.ParentUUID = machineUUIDout.UUID
 			if err := tx.Query(ctx, associateParentStmt, associateParentParam).Run(); err != nil {
-				return errors.Annotatef(err, "associating parent machine %q for machine %q", args.parentName, mName)
+				return errors.Errorf("associating parent machine %q for machine %q %w", args.parentName, mName, err)
 			}
 		}
 
 		return nil
 	})
-	return errors.Annotatef(err, "inserting machine %q", mName)
+	return errors.Errorf("inserting machine %q %w", mName, err)
 }
 
 // DeleteMachine deletes the specified machine and any dependent child records.
@@ -207,7 +206,7 @@ WHERE  machine_uuid = $machineUUID.uuid`
 func (st *State) DeleteMachine(ctx context.Context, mName machine.Name) error {
 	db, err := st.DB()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	// Prepare query for machine uuid.
@@ -216,14 +215,14 @@ func (st *State) DeleteMachine(ctx context.Context, mName machine.Name) error {
 	queryMachine := `SELECT uuid AS &machineUUID.* FROM machine WHERE name = $machineName.name`
 	queryMachineStmt, err := st.Prepare(queryMachine, machineNameParam, machineUUIDParam)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	// Prepare query for deleting machine row.
 	deleteMachine := `DELETE FROM machine WHERE name = $machineName.name`
 	deleteMachineStmt, err := st.Prepare(deleteMachine, machineNameParam)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	// Prepare query for deleting net node row.
@@ -233,20 +232,20 @@ DELETE FROM net_node WHERE uuid IN
 `
 	deleteNodeStmt, err := st.Prepare(deleteNode, machineNameParam)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	// Prepare query for deleting status and status data for the machine.
 	deleteStatus := `DELETE FROM machine_status WHERE machine_uuid = $machineUUID.uuid`
 	deleteStatusStmt, err := st.Prepare(deleteStatus, machineUUIDParam)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	deleteStatusData := `DELETE FROM machine_status_data WHERE machine_uuid = $machineUUID.uuid`
 	deleteStatusDataStmt, err := st.Prepare(deleteStatusData, machineUUIDParam)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
@@ -255,39 +254,39 @@ DELETE FROM net_node WHERE uuid IN
 			return machineerrors.MachineNotFound
 		}
 		if err != nil {
-			return errors.Annotatef(err, "looking up UUID for machine %q", mName)
+			return errors.Errorf("looking up UUID for machine %q %w", mName, err)
 		}
 
 		// Remove block devices for the machine.
 		if err := blockdevice.RemoveMachineBlockDevices(ctx, tx, machineUUIDParam.UUID); err != nil {
-			return errors.Annotatef(err, "deleting block devices for machine %q", mName)
+			return errors.Errorf("deleting block devices for machine %q %w", mName, err)
 		}
 
 		// Remove the status data for the machine. No need to return error if no
 		// status data is set for the machine.
 		if err := tx.Query(ctx, deleteStatusDataStmt, machineUUIDParam).Run(); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-			return errors.Annotatef(err, "deleting status data for machine %q", mName)
+			return errors.Errorf("deleting status data for machine %q %w", mName, err)
 		}
 
 		// Remove the status for the machine. No need to return error if no
 		// status is set for the machine while deleting.
 		if err := tx.Query(ctx, deleteStatusStmt, machineUUIDParam).Run(); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-			return errors.Annotatef(err, "deleting status for machine %q", mName)
+			return errors.Errorf("deleting status for machine %q %w", mName, err)
 		}
 
 		// Remove the machine.
 		if err := tx.Query(ctx, deleteMachineStmt, machineNameParam).Run(); err != nil {
-			return errors.Annotatef(err, "deleting machine %q", mName)
+			return errors.Errorf("deleting machine %q %w", mName, err)
 		}
 
 		// Remove the net node for the machine.
 		if err := tx.Query(ctx, deleteNodeStmt, machineNameParam).Run(); err != nil {
-			return errors.Annotatef(err, "deleting net node for machine  %q", mName)
+			return errors.Errorf("deleting net node for machine  %q %w", mName, err)
 		}
 
 		return nil
 	})
-	return errors.Annotatef(err, "deleting machine %q", mName)
+	return errors.Errorf("deleting machine %q %w", mName, err)
 }
 
 // InitialWatchModelMachinesStatement returns the table and the initial watch
@@ -307,14 +306,14 @@ func (st *State) InitialWatchStatement() (string, string) {
 func (st *State) GetMachineLife(ctx context.Context, mName machine.Name) (*life.Life, error) {
 	db, err := st.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	machineNameParam := machineName{Name: mName}
 	queryForLife := `SELECT life_id as &machineLife.life_id FROM machine WHERE name = $machineName.name`
 	lifeStmt, err := st.Prepare(queryForLife, machineNameParam, machineLife{})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	var lifeResult life.Life
@@ -325,7 +324,7 @@ func (st *State) GetMachineLife(ctx context.Context, mName machine.Name) (*life.
 			return machineerrors.MachineNotFound
 		}
 		if err != nil {
-			return errors.Annotatef(err, "looking up life for machine %q", mName)
+			return errors.Errorf("looking up life for machine %q %w", mName, err)
 		}
 
 		lifeResult = result.LifeID
@@ -333,7 +332,7 @@ func (st *State) GetMachineLife(ctx context.Context, mName machine.Name) (*life.
 		return nil
 	})
 	if err != nil {
-		return nil, errors.Annotatef(err, "getting life status for machine %q", mName)
+		return nil, errors.Errorf("getting life status for machine %q %w", mName, err)
 	}
 	return &lifeResult, nil
 }
@@ -345,7 +344,7 @@ func (st *State) GetMachineLife(ctx context.Context, mName machine.Name) (*life.
 func (st *State) GetMachineStatus(ctx context.Context, mName machine.Name) (status.StatusInfo, error) {
 	db, err := st.DB()
 	if err != nil {
-		return status.StatusInfo{}, errors.Trace(err)
+		return status.StatusInfo{}, errors.Capture(err)
 	}
 
 	// Prepare query for machine uuid (to be used in machine status and status
@@ -355,7 +354,7 @@ func (st *State) GetMachineStatus(ctx context.Context, mName machine.Name) (stat
 	uuidQuery := `SELECT uuid AS &machineUUID.uuid FROM machine WHERE name = $machineName.name`
 	uuidQueryStmt, err := st.Prepare(uuidQuery, machineNameParam, machineUUIDout)
 	if err != nil {
-		return status.StatusInfo{}, errors.Trace(err)
+		return status.StatusInfo{}, errors.Capture(err)
 	}
 
 	// Prepare query for combined machine status and the status data (to get
@@ -369,7 +368,7 @@ ON st.machine_uuid = st_data.machine_uuid
 WHERE st.machine_uuid = $machineUUID.uuid`
 	statusCombinedQueryStmt, err := st.Prepare(statusCombinedQuery, machineUUIDout, machineStatusDataParam)
 	if err != nil {
-		return status.StatusInfo{}, errors.Trace(err)
+		return status.StatusInfo{}, errors.Capture(err)
 	}
 
 	var machineStatusWithAllData machineStatusData
@@ -378,25 +377,25 @@ WHERE st.machine_uuid = $machineUUID.uuid`
 		err := tx.Query(ctx, uuidQueryStmt, machineNameParam).Get(&machineUUIDout)
 		if err != nil {
 			if errors.Is(err, sqlair.ErrNoRows) {
-				return errors.Annotatef(machineerrors.MachineNotFound, "machine %q", mName)
+				return errors.Errorf("machine %q %w", mName, machineerrors.MachineNotFound)
 			}
-			return errors.Annotatef(err, "querying uuid for machine %q", mName)
+			return errors.Errorf("querying uuid for machine %q %w", mName, err)
 		}
 
 		// Query for the machine cloud instance status and status data combined
 		err = tx.Query(ctx, statusCombinedQueryStmt, machineUUIDout).GetAll(&machineStatusWithAllData)
 		if errors.Is(err, sqlair.ErrNoRows) {
-			return errors.Annotatef(machineerrors.StatusNotSet, "machine: %q", mName)
+			return errors.Errorf("machine: %q %w", mName, machineerrors.StatusNotSet)
 		}
 		if err != nil {
-			return errors.Annotatef(err, "querying machine status for machine %q", mName)
+			return errors.Errorf("querying machine status for machine %q %w", mName, err)
 		}
 
 		return nil
 	})
 
 	if err != nil {
-		return status.StatusInfo{}, errors.Trace(err)
+		return status.StatusInfo{}, errors.Capture(err)
 	}
 
 	// Transform the status data slice into a status.Data map.
@@ -420,7 +419,7 @@ WHERE st.machine_uuid = $machineUUID.uuid`
 func (st *State) SetMachineStatus(ctx context.Context, mName machine.Name, newStatus status.StatusInfo) error {
 	db, err := st.DB()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	// Prepare the new status to be set.
@@ -437,7 +436,7 @@ func (st *State) SetMachineStatus(ctx context.Context, mName machine.Name, newSt
 	queryMachine := `SELECT uuid AS &machineUUID.* FROM machine WHERE name = $machineName.name`
 	queryMachineStmt, err := st.Prepare(queryMachine, machineNameParam, mUUID)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	// Prepare query for setting machine status
@@ -449,7 +448,7 @@ VALUES ($machineUUID.uuid, $machineStatusWithData.status_id, $machineStatusWithD
 `
 	statusQueryStmt, err := st.Prepare(statusQuery, mUUID, machineStatus)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	// Prepare query for setting machine status data
@@ -460,23 +459,23 @@ VALUES ($machineUUID.uuid, $machineStatusWithData.key, $machineStatusWithData.da
 `
 	statusDataQueryStmt, err := st.Prepare(statusDataQuery, mUUID, machineStatus)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		// Query for the machine uuid.
 		err := tx.Query(ctx, queryMachineStmt, machineNameParam).Get(&mUUID)
 		if errors.Is(err, sqlair.ErrNoRows) {
-			return errors.Annotatef(machineerrors.MachineNotFound, "machine %q", mName)
+			return errors.Errorf("machine %q %w", mName, machineerrors.MachineNotFound)
 		}
 		if err != nil {
-			return errors.Annotatef(err, "querying uuid for machine %q", mName)
+			return errors.Errorf("querying uuid for machine %q %w", mName, err)
 		}
 
 		// Query for setting the machine status.
 		err = tx.Query(ctx, statusQueryStmt, mUUID, machineStatus).Run()
 		if err != nil {
-			return errors.Annotatef(err, "setting machine status for machine %q", mName)
+			return errors.Errorf("setting machine status for machine %q %w", mName, err)
 		}
 
 		// Query for setting the machine status data if machineStatusData is not
@@ -484,7 +483,7 @@ VALUES ($machineUUID.uuid, $machineStatusWithData.key, $machineStatusWithData.da
 		if len(machineStatusData) > 0 {
 			err = tx.Query(ctx, statusDataQueryStmt, mUUID, machineStatusData).Run()
 			if err != nil {
-				return errors.Annotatef(err, "setting machine status data for machine %q", mName)
+				return errors.Errorf("setting machine status data for machine %q %w", mName, err)
 			}
 		}
 
@@ -497,7 +496,7 @@ VALUES ($machineUUID.uuid, $machineStatusWithData.key, $machineStatusWithData.da
 func (st *State) SetMachineLife(ctx context.Context, mName machine.Name, life life.Life) error {
 	db, err := st.DB()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	// Prepare query for machine UUID.
@@ -506,7 +505,7 @@ func (st *State) SetMachineLife(ctx context.Context, mName machine.Name, life li
 	uuidQuery := `SELECT &machineUUID.uuid FROM machine WHERE name = $machineName.name`
 	uuidQueryStmt, err := st.Prepare(uuidQuery, machineNameParam, machineUUIDoutput)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	// Prepare query for updating machine life.
@@ -514,7 +513,7 @@ func (st *State) SetMachineLife(ctx context.Context, mName machine.Name, life li
 	query := `UPDATE machine SET life_id = $machineLife.life_id WHERE uuid = $machineLife.uuid`
 	queryStmt, err := st.Prepare(query, machineLifeParam)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
@@ -524,14 +523,14 @@ func (st *State) SetMachineLife(ctx context.Context, mName machine.Name, life li
 			return machineerrors.MachineNotFound
 		}
 		if err != nil {
-			return errors.Annotatef(err, "querying UUID for machine %q", mName)
+			return errors.Errorf("querying UUID for machine %q %w", mName, err)
 		}
 
 		// Update machine life status.
 		machineLifeParam.UUID = machineUUIDoutput.UUID
 		err = tx.Query(ctx, queryStmt, machineLifeParam).Run()
 		if err != nil {
-			return errors.Annotatef(err, "setting life for machine %q", mName)
+			return errors.Errorf("setting life for machine %q %w", mName, err)
 		}
 		return nil
 	})
@@ -542,7 +541,7 @@ func (st *State) SetMachineLife(ctx context.Context, mName machine.Name, life li
 func (st *State) IsMachineController(ctx context.Context, mName machine.Name) (bool, error) {
 	db, err := st.DB()
 	if err != nil {
-		return false, errors.Trace(err)
+		return false, errors.Capture(err)
 	}
 
 	machineNameParam := machineName{Name: mName}
@@ -550,7 +549,7 @@ func (st *State) IsMachineController(ctx context.Context, mName machine.Name) (b
 	query := `SELECT &machineIsController.is_controller FROM machine WHERE name = $machineName.name`
 	queryStmt, err := st.Prepare(query, machineNameParam, result)
 	if err != nil {
-		return false, errors.Trace(err)
+		return false, errors.Capture(err)
 	}
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
@@ -559,12 +558,12 @@ func (st *State) IsMachineController(ctx context.Context, mName machine.Name) (b
 			return machineerrors.MachineNotFound
 		}
 		if err != nil {
-			return errors.Annotatef(err, "querying if machine %q is a controller", mName)
+			return errors.Errorf("querying if machine %q is a controller %w", mName, err)
 		}
 		return nil
 	})
 	if err != nil {
-		return false, errors.Annotatef(err, "checking if machine %q is a controller", mName)
+		return false, errors.Errorf("checking if machine %q is a controller %w", mName, err)
 	}
 
 	return result.IsController, nil
@@ -574,13 +573,13 @@ func (st *State) IsMachineController(ctx context.Context, mName machine.Name) (b
 func (st *State) AllMachineNames(ctx context.Context) ([]machine.Name, error) {
 	db, err := st.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	query := `SELECT name AS &machineName.* FROM machine`
 	queryStmt, err := st.Prepare(query, machineName{})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	var results []machineName
@@ -590,12 +589,12 @@ func (st *State) AllMachineNames(ctx context.Context) ([]machine.Name, error) {
 			return nil
 		}
 		if err != nil {
-			return errors.Annotate(err, "querying all machines")
+			return errors.Errorf("querying all machines %w", err)
 		}
 		return nil
 	})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	// Transform the results ([]machineName) into a slice of machine.Name.
@@ -610,7 +609,7 @@ func (st *State) AllMachineNames(ctx context.Context) ([]machine.Name, error) {
 func (st *State) GetMachineParentUUID(ctx context.Context, uuid string) (string, error) {
 	db, err := st.DB()
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", errors.Capture(err)
 	}
 
 	// Prepare query for checking that the machine exists.
@@ -618,7 +617,7 @@ func (st *State) GetMachineParentUUID(ctx context.Context, uuid string) (string,
 	query := `SELECT uuid AS &machineUUID.uuid FROM machine WHERE uuid = $machineUUID.uuid`
 	queryStmt, err := st.Prepare(query, currentMachineUUID)
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", errors.Capture(err)
 	}
 
 	// Prepare query for parent UUID.
@@ -629,7 +628,7 @@ SELECT parent_uuid AS &machineParent.parent_uuid
 FROM machine_parent WHERE machine_uuid = $machineUUID.uuid`
 	parentQueryStmt, err := st.Prepare(parentQuery, currentMachineUUID, parentUUIDParam)
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", errors.Capture(err)
 	}
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
@@ -637,26 +636,26 @@ FROM machine_parent WHERE machine_uuid = $machineUUID.uuid`
 		outUUID := machineUUID{} // This value doesn't really matter, it is just a way to check existence
 		err := tx.Query(ctx, queryStmt, currentMachineUUID).Get(&outUUID)
 		if errors.Is(err, sqlair.ErrNoRows) {
-			return errors.Annotatef(machineerrors.MachineNotFound, "machine %q", uuid)
+			return errors.Errorf("machine %q %w", uuid, machineerrors.MachineNotFound)
 		}
 		if err != nil {
-			return errors.Annotatef(err, "checking existence of machine %q", uuid)
+			return errors.Errorf("checking existence of machine %q %w", uuid, err)
 		}
 
 		// Query for the parent UUID.
 		err = tx.Query(ctx, parentQueryStmt, currentMachineUUID).Get(&parentUUIDParam)
 		if errors.Is(err, sqlair.ErrNoRows) {
-			return errors.Annotatef(machineerrors.MachineHasNoParent, "machine %q", uuid)
+			return errors.Errorf("machine %q %w", uuid, machineerrors.MachineHasNoParent)
 		}
 		if err != nil {
-			return errors.Annotatef(err, "querying parent UUID for machine %q", uuid)
+			return errors.Errorf("querying parent UUID for machine %q %w", uuid, err)
 		}
 
 		parentUUID = parentUUIDParam.ParentUUID
 
 		return nil
 	})
-	return parentUUID, errors.Annotatef(err, "getting parent UUID for machine %q", uuid)
+	return parentUUID, errors.Errorf("getting parent UUID for machine %q %w", uuid, err)
 }
 
 // MarkMachineForRemoval marks the specified machine for removal.
@@ -667,7 +666,7 @@ FROM machine_parent WHERE machine_uuid = $machineUUID.uuid`
 func (st *State) MarkMachineForRemoval(ctx context.Context, mName machine.Name) error {
 	db, err := st.DB()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	// Prepare query for getting the machine UUID.
@@ -676,7 +675,7 @@ func (st *State) MarkMachineForRemoval(ctx context.Context, mName machine.Name) 
 	machineUUIDQuery := `SELECT uuid AS &machineMarkForRemoval.machine_uuid FROM machine WHERE name = $machineName.name`
 	machineUUIDStmt, err := st.Prepare(machineUUIDQuery, machineNameParam, markForRemovalUUID)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	// Prepare query for adding the machine to the machine_removals table.
@@ -685,24 +684,24 @@ INSERT OR IGNORE INTO machine_removals (machine_uuid)
 VALUES ($machineMarkForRemoval.machine_uuid)`
 	markForRemovalStmt, err := st.Prepare(markForRemovalUpdateQuery, markForRemovalUUID)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		// Query for the machine UUID.
 		err := tx.Query(ctx, machineUUIDStmt, machineNameParam).Get(&markForRemovalUUID)
 		if errors.Is(err, sqlair.ErrNoRows) {
-			return errors.Annotatef(machineerrors.MachineNotFound, "machine %q", mName)
+			return errors.Errorf("machine %q %w", mName, machineerrors.MachineNotFound)
 		}
 		if err != nil {
-			return errors.Annotatef(err, "querying UUID for machine %q", mName)
+			return errors.Errorf("querying UUID for machine %q %w", mName, err)
 		}
 
 		// Run query for adding the machine to the removals table.
 		return tx.Query(ctx, markForRemovalStmt, markForRemovalUUID).Run()
 	})
 
-	return errors.Annotatef(err, "marking machine %q for removal", mName)
+	return errors.Errorf("marking machine %q for removal %w", mName, err)
 }
 
 // GetAllMachineRemovals returns the UUIDs of all of the machines that need to
@@ -710,7 +709,7 @@ VALUES ($machineMarkForRemoval.machine_uuid)`
 func (st *State) GetAllMachineRemovals(ctx context.Context) ([]string, error) {
 	db, err := st.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	// Prepare query for uuids of all machines marked for removal.
@@ -718,7 +717,7 @@ func (st *State) GetAllMachineRemovals(ctx context.Context) ([]string, error) {
 	machinesMarkedForRemovalQuery := `SELECT &machineMarkForRemoval.machine_uuid FROM machine_removals`
 	machinesMarkedForRemovalStmt, err := st.Prepare(machinesMarkedForRemovalQuery, markForRemovalParam)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	var results []machineMarkForRemoval
@@ -733,7 +732,7 @@ func (st *State) GetAllMachineRemovals(ctx context.Context) ([]string, error) {
 	})
 
 	if err != nil {
-		return nil, errors.Annotate(err, "querying all machines marked for removal")
+		return nil, errors.Errorf("querying all machines marked for removal %w", err)
 	}
 
 	// Transform the results ([]machineUUID) into a slice of machine UUIDs.
@@ -750,7 +749,7 @@ func (st *State) GetAllMachineRemovals(ctx context.Context) ([]string, error) {
 func (st *State) GetMachineUUID(ctx context.Context, name machine.Name) (string, error) {
 	db, err := st.DB()
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", errors.Capture(err)
 	}
 
 	var uuid machineUUID
@@ -758,21 +757,21 @@ func (st *State) GetMachineUUID(ctx context.Context, name machine.Name) (string,
 	query := `SELECT uuid AS &machineUUID.uuid FROM machine WHERE name = $machineName.name`
 	queryStmt, err := st.Prepare(query, uuid, currentMachineName)
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", errors.Capture(err)
 	}
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		// Query for the machine UUID.
 		err := tx.Query(ctx, queryStmt, currentMachineName).Get(&uuid)
 		if errors.Is(err, sqlair.ErrNoRows) {
-			return errors.Annotatef(machineerrors.MachineNotFound, "machine %q", name)
+			return errors.Errorf("machine %q %w", name, machineerrors.MachineNotFound)
 		}
 		if err != nil {
-			return errors.Annotatef(err, "querying uuid for machine %q", name)
+			return errors.Errorf("querying uuid for machine %q %w", name, err)
 		}
 		return nil
 	})
-	return uuid.UUID, errors.Annotatef(err, "getting UUID for machine %q", name)
+	return uuid.UUID, errors.Errorf("getting UUID for machine %q %w", name, err)
 }
 
 // ShouldKeepInstance reports whether a machine, when removed from Juju, should cause
@@ -780,7 +779,7 @@ func (st *State) GetMachineUUID(ctx context.Context, name machine.Name) (string,
 func (st *State) ShouldKeepInstance(ctx context.Context, mName machine.Name) (bool, error) {
 	db, err := st.DB()
 	if err != nil {
-		return false, errors.Trace(err)
+		return false, errors.Capture(err)
 	}
 
 	machineNameParam := machineName{Name: mName}
@@ -791,7 +790,7 @@ FROM   machine
 WHERE  name = $machineName.name`
 	queryStmt, err := st.Prepare(query, machineNameParam, result)
 	if err != nil {
-		return false, errors.Trace(err)
+		return false, errors.Capture(err)
 	}
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
@@ -800,12 +799,12 @@ WHERE  name = $machineName.name`
 			return machineerrors.MachineNotFound
 		}
 		if err != nil {
-			return fmt.Errorf("querying machine %q keep instance: %w", mName, err)
+			return errors.Errorf("querying machine %q keep instance: %w", mName, err)
 		}
 		return nil
 	})
 	if err != nil {
-		return false, fmt.Errorf("check for machine %q keep instance: %w", mName, err)
+		return false, errors.Errorf("check for machine %q keep instance: %w", mName, err)
 	}
 
 	return result.KeepInstance, nil
@@ -817,7 +816,7 @@ WHERE  name = $machineName.name`
 func (st *State) SetKeepInstance(ctx context.Context, mName machine.Name, keep bool) error {
 	db, err := st.DB()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	// Prepare query for machine uuid.
@@ -829,7 +828,7 @@ FROM   machine
 WHERE  name = $machineName.name`
 	machineExistsStmt, err := st.Prepare(machineExistsQuery, machineUUID, machineNameParam)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	// Prepare query for updating machine keep instance.
@@ -840,7 +839,7 @@ SET    keep_instance = $keepInstance.keep_instance
 WHERE  name = $machineName.name`
 	keepInstanceStmt, err := st.Prepare(keepInstanceQuery, keepInstanceParam, machineNameParam)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
@@ -853,7 +852,7 @@ WHERE  name = $machineName.name`
 		// Update machine keep instance.
 		err = tx.Query(ctx, keepInstanceStmt, keepInstanceParam, machineNameParam).Run()
 		if err != nil {
-			return fmt.Errorf("setting keep instance for machine %q: %w", mName, err)
+			return errors.Errorf("setting keep instance for machine %q: %w", mName, err)
 		}
 		return nil
 	})
@@ -863,7 +862,7 @@ WHERE  name = $machineName.name`
 func (st *State) AppliedLXDProfileNames(ctx context.Context, mUUID string) ([]string, error) {
 	db, err := st.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	instanceDataQuery := instanceData{MachineUUID: mUUID}
@@ -872,7 +871,7 @@ SELECT   &instanceData.instance_id
 FROM     machine_cloud_instance
 WHERE    machine_uuid = $instanceData.machine_uuid`, instanceDataQuery)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	lxdProfileQuery := lxdProfile{MachineUUID: mUUID}
@@ -882,7 +881,7 @@ FROM     machine_lxd_profile
 WHERE    machine_uuid = $lxdProfile.machine_uuid
 ORDER BY array_index ASC`, lxdProfileQuery)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	var result []lxdProfile
@@ -890,14 +889,14 @@ ORDER BY array_index ASC`, lxdProfileQuery)
 		var instanceData instanceData
 		err := tx.Query(ctx, isProvisionedStmt, instanceDataQuery).Get(&instanceData)
 		if errors.Is(err, sqlair.ErrNoRows) {
-			return internalerrors.Errorf("machine %q: %w", mUUID, machineerrors.NotProvisioned)
+			return errors.Errorf("machine %q: %w", mUUID, machineerrors.NotProvisioned)
 		}
 		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-			return internalerrors.Errorf("checking machine cloud instance for machine %q: %w", mUUID, err)
+			return errors.Errorf("checking machine cloud instance for machine %q: %w", mUUID, err)
 		}
 		err = tx.Query(ctx, queryStmt, lxdProfileQuery).GetAll(&result)
 		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-			return internalerrors.Errorf("retrieving lxd profiles for machine %q: %w", mUUID, err)
+			return errors.Errorf("retrieving lxd profiles for machine %q: %w", mUUID, err)
 		}
 		return nil
 	}); err != nil {
@@ -923,7 +922,7 @@ func (st *State) SetAppliedLXDProfileNames(ctx context.Context, mUUID string, pr
 
 	db, err := st.DB()
 	if err != nil {
-		return internalerrors.Errorf("cannot get database to set lxd profiles %v for machine %q: %w", profileNames, mUUID, err)
+		return errors.Errorf("cannot get database to set lxd profiles %v for machine %q: %w", profileNames, mUUID, err)
 	}
 
 	queryMachineUUID := machineUUID{UUID: mUUID}
@@ -932,7 +931,7 @@ SELECT uuid AS &machineUUID.uuid
 FROM   machine
 WHERE  machine.uuid = $machineUUID.uuid`, queryMachineUUID)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	instanceDataQuery := instanceData{MachineUUID: mUUID}
@@ -941,7 +940,7 @@ SELECT   &instanceData.instance_id
 FROM     machine_cloud_instance
 WHERE    machine_uuid = $instanceData.machine_uuid`, instanceDataQuery)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	queryLXDProfile := lxdProfile{MachineUUID: mUUID}
@@ -951,7 +950,7 @@ FROM     machine_lxd_profile
 WHERE    machine_uuid = $lxdProfile.machine_uuid
 ORDER BY array_index ASC`, queryLXDProfile)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	removePreviousProfilesStmt, err := st.Prepare(
@@ -959,14 +958,14 @@ ORDER BY array_index ASC`, queryLXDProfile)
 		machineUUID{},
 	)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	setLXDProfileStmt, err := st.Prepare(`
 INSERT INTO machine_lxd_profile (*)
 VALUES      ($lxdProfile.*)`, lxdProfile{})
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
@@ -975,24 +974,24 @@ VALUES      ($lxdProfile.*)`, lxdProfile{})
 		if errors.Is(err, sqlair.ErrNoRows) {
 			return machineerrors.MachineNotFound
 		} else if err != nil {
-			return internalerrors.Errorf("checking if machine %q exists: %w", mUUID, err)
+			return errors.Errorf("checking if machine %q exists: %w", mUUID, err)
 		}
 
 		// Check if the machine is provisioned
 		var instanceData instanceData
 		err = tx.Query(ctx, isProvisionedStmt, instanceDataQuery).Get(&instanceData)
 		if errors.Is(err, sqlair.ErrNoRows) {
-			return internalerrors.Errorf("machine %q: %w", mUUID, machineerrors.NotProvisioned)
+			return errors.Errorf("machine %q: %w", mUUID, machineerrors.NotProvisioned)
 		}
 		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-			return internalerrors.Errorf("checking machine cloud instance for machine %q: %w", mUUID, err)
+			return errors.Errorf("checking machine cloud instance for machine %q: %w", mUUID, err)
 		}
 		// Retrieve the existing profiles to check if the input is the exactly
 		// the same as the existing ones and in that case no insert is needed.
 		var existingProfiles []lxdProfile
 		err = tx.Query(ctx, retrievePreviousProfilesStmt, queryLXDProfile).GetAll(&existingProfiles)
 		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-			return internalerrors.Errorf("retrieving previous profiles for machine %q: %w", mUUID, err)
+			return errors.Errorf("retrieving previous profiles for machine %q: %w", mUUID, err)
 		}
 		// Compare the input with the existing profiles.
 		somethingToInsert := len(existingProfiles) != len(profileNames)
@@ -1015,7 +1014,7 @@ VALUES      ($lxdProfile.*)`, lxdProfile{})
 
 		// Make sure to clean up any existing profiles on the given machine.
 		if err := tx.Query(ctx, removePreviousProfilesStmt, queryMachineUUID).Run(); err != nil {
-			return internalerrors.Errorf("remove previous profiles for machine %q: %w", mUUID, err)
+			return errors.Errorf("remove previous profiles for machine %q: %w", mUUID, err)
 		}
 
 		profilesToInsert := make([]lxdProfile, 0, len(profileNames))
@@ -1030,7 +1029,7 @@ VALUES      ($lxdProfile.*)`, lxdProfile{})
 			)
 		}
 		if err := tx.Query(ctx, setLXDProfileStmt, profilesToInsert).Run(); err != nil {
-			return internalerrors.Errorf("setting lxd profiles %v for machine %q: %w", profileNames, mUUID, err)
+			return errors.Errorf("setting lxd profiles %v for machine %q: %w", profileNames, mUUID, err)
 		}
 		return nil
 	})

--- a/domain/machine/state/state_test.go
+++ b/domain/machine/state/state_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/canonical/sqlair"
 	"github.com/juju/collections/transform"
-	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -21,6 +20,7 @@ import (
 	"github.com/juju/juju/domain/life"
 	machineerrors "github.com/juju/juju/domain/machine/errors"
 	schematesting "github.com/juju/juju/domain/schema/testing"
+	"github.com/juju/juju/internal/errors"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 	"github.com/juju/juju/internal/uuid"
 )
@@ -67,7 +67,7 @@ func (s *stateSuite) TestCreateMachine(c *gc.C) {
 	err = s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		err := tx.QueryRowContext(ctx, "SELECT name FROM machine").Scan(&machineName)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		return nil
 	})
@@ -110,7 +110,7 @@ WHERE   parent.parent_uuid = 1
 	err = s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		err := tx.QueryRowContext(ctx, parentStmt).Scan(&machineName)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		return nil
 	})
@@ -180,7 +180,7 @@ func (s *stateSuite) TestDeleteMachine(c *gc.C) {
 	err = s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		err := tx.QueryRowContext(ctx, "SELECT count(*) FROM machine WHERE name=?", "666").Scan(&machineCount)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		return nil
 	})
@@ -220,11 +220,11 @@ func (s *stateSuite) TestDeleteMachineStatus(c *gc.C) {
 	err = s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		err := tx.QueryRowContext(ctx, "SELECT count(*) FROM machine_status WHERE machine_uuid=?", "123").Scan(&status)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		err = tx.QueryRowContext(ctx, "SELECT count(*) FROM machine_status_data WHERE machine_uuid=?", "123").Scan(&statusData)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		return nil
 	})

--- a/domain/model/errors/errors.go
+++ b/domain/model/errors/errors.go
@@ -3,9 +3,7 @@
 
 package errors
 
-import (
-	"github.com/juju/errors"
-)
+import "github.com/juju/juju/internal/errors"
 
 const (
 	// AgentVersionNotSupported describes an error that occurs when then agent

--- a/domain/model/modelmigration/import_test.go
+++ b/domain/model/modelmigration/import_test.go
@@ -7,13 +7,13 @@ import (
 	"context"
 
 	"github.com/juju/description/v8"
-	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 	jc "github.com/juju/testing/checkers"
 	gomock "go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/credential"
+	coreerrors "github.com/juju/juju/core/errors"
 	coremodel "github.com/juju/juju/core/model"
 	modeltesting "github.com/juju/juju/core/model/testing"
 	"github.com/juju/juju/core/modelmigration"
@@ -25,6 +25,7 @@ import (
 	"github.com/juju/juju/domain/model"
 	modelerrors "github.com/juju/juju/domain/model/errors"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/internal/errors"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 	"github.com/juju/juju/internal/testing"
 	"github.com/juju/juju/internal/uuid"
@@ -63,7 +64,7 @@ func (i *importSuite) TestModelMetadataInvalid(c *gc.C) {
 		},
 	})
 	err := importOp.Execute(context.Background(), model)
-	c.Assert(err, jc.ErrorIs, errors.NotValid)
+	c.Assert(err, jc.ErrorIs, coreerrors.NotValid)
 
 	// model name of wrong type
 	model = description.NewModel(description.ModelArgs{
@@ -73,7 +74,7 @@ func (i *importSuite) TestModelMetadataInvalid(c *gc.C) {
 		},
 	})
 	err = importOp.Execute(context.Background(), model)
-	c.Assert(err, jc.ErrorIs, errors.NotValid)
+	c.Assert(err, jc.ErrorIs, coreerrors.NotValid)
 
 	// uuid not defined
 	model = description.NewModel(description.ModelArgs{
@@ -82,7 +83,7 @@ func (i *importSuite) TestModelMetadataInvalid(c *gc.C) {
 		},
 	})
 	err = importOp.Execute(context.Background(), model)
-	c.Assert(err, jc.ErrorIs, errors.NotValid)
+	c.Assert(err, jc.ErrorIs, coreerrors.NotValid)
 
 	// uuid of wrong type
 	model = description.NewModel(description.ModelArgs{
@@ -92,7 +93,7 @@ func (i *importSuite) TestModelMetadataInvalid(c *gc.C) {
 		},
 	})
 	err = importOp.Execute(context.Background(), model)
-	c.Assert(err, jc.ErrorIs, errors.NotValid)
+	c.Assert(err, jc.ErrorIs, coreerrors.NotValid)
 }
 
 // TestModelOwnerNoExist is asserting that if we try and import a model where

--- a/domain/model/service/service_test.go
+++ b/domain/model/service/service_test.go
@@ -9,13 +9,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/version/v2"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/credential"
+	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/life"
 	coremodel "github.com/juju/juju/core/model"
 	modeltesting "github.com/juju/juju/core/model/testing"
@@ -89,7 +89,7 @@ func (s *serviceSuite) TestControllerModelOwnerUsername(c *gc.C) {
 func (s *serviceSuite) TestCreateModelInvalidArgs(c *gc.C) {
 	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder(), loggertesting.WrapCheckLog(c))
 	_, _, err := svc.CreateModel(context.Background(), model.ModelCreationArgs{})
-	c.Assert(err, jc.ErrorIs, errors.NotValid)
+	c.Assert(err, jc.ErrorIs, coreerrors.NotValid)
 }
 
 func (s *serviceSuite) TestModelCreation(c *gc.C) {
@@ -169,7 +169,7 @@ func (s *serviceSuite) TestModelCreationInvalidCloud(c *gc.C) {
 		Name:        "my-awesome-model",
 	})
 
-	c.Assert(err, jc.ErrorIs, errors.NotFound)
+	c.Assert(err, jc.ErrorIs, coreerrors.NotFound)
 }
 
 func (s *serviceSuite) TestModelCreationNoCloudRegion(c *gc.C) {
@@ -185,7 +185,7 @@ func (s *serviceSuite) TestModelCreationNoCloudRegion(c *gc.C) {
 		Name:        "my-awesome-model",
 	})
 
-	c.Assert(err, jc.ErrorIs, errors.NotFound)
+	c.Assert(err, jc.ErrorIs, coreerrors.NotFound)
 }
 
 // TestModelCreationOwnerNotFound is testing that if we make a model with an
@@ -229,7 +229,7 @@ func (s *serviceSuite) TestModelCreationNoCloudCredential(c *gc.C) {
 		Name:  "my-awesome-model",
 	})
 
-	c.Assert(err, jc.ErrorIs, errors.NotFound)
+	c.Assert(err, jc.ErrorIs, coreerrors.NotFound)
 }
 
 func (s *serviceSuite) TestModelCreationNameOwnerConflict(c *gc.C) {
@@ -358,7 +358,7 @@ func (s *serviceSuite) TestUpdateModelCredentialZeroValue(c *gc.C) {
 	c.Assert(activator(context.Background()), jc.ErrorIsNil)
 
 	err = svc.UpdateCredential(context.Background(), id, credential.Key{})
-	c.Assert(err, jc.ErrorIs, errors.NotValid)
+	c.Assert(err, jc.ErrorIs, coreerrors.NotValid)
 }
 
 func (s *serviceSuite) TestUpdateModelCredentialDifferentCloud(c *gc.C) {
@@ -398,7 +398,7 @@ func (s *serviceSuite) TestUpdateModelCredentialDifferentCloud(c *gc.C) {
 	c.Assert(activator(context.Background()), jc.ErrorIsNil)
 
 	err = svc.UpdateCredential(context.Background(), id, cred2)
-	c.Assert(err, jc.ErrorIs, errors.NotValid)
+	c.Assert(err, jc.ErrorIs, coreerrors.NotValid)
 }
 
 func (s *serviceSuite) TestUpdateModelCredentialNotFound(c *gc.C) {
@@ -432,7 +432,7 @@ func (s *serviceSuite) TestUpdateModelCredentialNotFound(c *gc.C) {
 	c.Assert(activator(context.Background()), jc.ErrorIsNil)
 
 	err = svc.UpdateCredential(context.Background(), id, cred2)
-	c.Assert(err, jc.ErrorIs, errors.NotFound)
+	c.Assert(err, jc.ErrorIs, coreerrors.NotFound)
 }
 
 func (s *serviceSuite) TestDeleteModel(c *gc.C) {
@@ -880,7 +880,7 @@ func (s *serviceSuite) TestGetModelUsers(c *gc.C) {
 func (s *serviceSuite) TestGetModelUsersBadUUID(c *gc.C) {
 	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder(), loggertesting.WrapCheckLog(c))
 	_, err := svc.GetModelUsers(context.Background(), "bad-uuid)")
-	c.Assert(err, jc.ErrorIs, errors.NotValid)
+	c.Assert(err, jc.ErrorIs, coreerrors.NotValid)
 }
 
 func (s *serviceSuite) TestGetModelUser(c *gc.C) {
@@ -907,7 +907,7 @@ func (s *serviceSuite) TestGetModelUser(c *gc.C) {
 func (s *serviceSuite) TestGetModelUserBadUUID(c *gc.C) {
 	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder(), loggertesting.WrapCheckLog(c))
 	_, err := svc.GetModelUser(context.Background(), "bad-uuid", usertesting.GenNewName(c, "bob"))
-	c.Assert(err, jc.ErrorIs, errors.NotValid)
+	c.Assert(err, jc.ErrorIs, coreerrors.NotValid)
 }
 
 func (s *serviceSuite) TestGetModelUserZeroUserName(c *gc.C) {
@@ -975,7 +975,7 @@ func (s *serviceSuite) TestListAllModelSummaries(c *gc.C) {
 func (s *serviceSuite) TestListModelsForUserBadName(c *gc.C) {
 	svc := NewService(s.state, s.deleter, DefaultAgentBinaryFinder(), loggertesting.WrapCheckLog(c))
 	_, err := svc.ListModelsForUser(context.Background(), "((*)(")
-	c.Check(err, jc.ErrorIs, errors.NotValid)
+	c.Check(err, jc.ErrorIs, coreerrors.NotValid)
 }
 
 func (s *serviceSuite) TestListModelSummariesForUser(c *gc.C) {

--- a/domain/model/service/state_test.go
+++ b/domain/model/service/state_test.go
@@ -5,12 +5,10 @@ package service
 
 import (
 	"context"
-	"fmt"
 	"time"
 
-	"github.com/juju/errors"
-
 	"github.com/juju/juju/core/credential"
+	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/life"
 	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/permission"
@@ -22,6 +20,7 @@ import (
 	"github.com/juju/juju/domain/model"
 	modelerrors "github.com/juju/juju/domain/model/errors"
 	secretbackenderrors "github.com/juju/juju/domain/secretbackend/errors"
+	"github.com/juju/juju/internal/errors"
 	jujutesting "github.com/juju/juju/internal/testing"
 )
 
@@ -67,23 +66,23 @@ func (d *dummyState) Create(
 	args model.ModelCreationArgs,
 ) error {
 	if _, exists := d.models[modelID]; exists {
-		return fmt.Errorf("%w %q", modelerrors.AlreadyExists, modelID)
+		return errors.Errorf("%w %q", modelerrors.AlreadyExists, modelID)
 	}
 
 	for _, v := range d.models {
 		if v.Name == args.Name && v.Owner == args.Owner {
-			return fmt.Errorf("%w for name %q and owner %q", modelerrors.AlreadyExists, v.Name, v.Owner)
+			return errors.Errorf("%w for name %q and owner %q", modelerrors.AlreadyExists, v.Name, v.Owner)
 		}
 	}
 
 	cloud, exists := d.clouds[args.Cloud]
 	if !exists {
-		return fmt.Errorf("%w cloud %q", errors.NotFound, args.Cloud)
+		return errors.Errorf("%w cloud %q", coreerrors.NotFound, args.Cloud)
 	}
 
 	userName, exists := d.users[user.UUID(args.Owner.String())]
 	if !exists {
-		return fmt.Errorf("%w for owner %q", usererrors.UserNotFound, args.Owner)
+		return errors.Errorf("%w for owner %q", usererrors.UserNotFound, args.Owner)
 	}
 
 	hasRegion := false
@@ -93,12 +92,12 @@ func (d *dummyState) Create(
 		}
 	}
 	if !hasRegion {
-		return fmt.Errorf("%w cloud %q region %q", errors.NotFound, args.Cloud, args.CloudRegion)
+		return errors.Errorf("%w cloud %q region %q", coreerrors.NotFound, args.Cloud, args.CloudRegion)
 	}
 
 	if !args.Credential.IsZero() {
 		if _, exists := cloud.Credentials[args.Credential.String()]; !exists {
-			return fmt.Errorf("%w credential %q", errors.NotFound, args.Credential.String())
+			return errors.Errorf("%w credential %q", coreerrors.NotFound, args.Credential.String())
 		}
 	}
 
@@ -150,7 +149,7 @@ func (d *dummyState) GetModel(
 ) (coremodel.Model, error) {
 	info, exists := d.models[uuid]
 	if !exists {
-		return coremodel.Model{}, fmt.Errorf("%w %q", modelerrors.NotFound, uuid)
+		return coremodel.Model{}, errors.Errorf("%w %q", modelerrors.NotFound, uuid)
 	}
 	return info, nil
 }
@@ -184,7 +183,7 @@ func (d *dummyState) GetModelType(
 ) (coremodel.ModelType, error) {
 	info, exists := d.models[uuid]
 	if !exists {
-		return "", fmt.Errorf("%w %q", modelerrors.NotFound, uuid)
+		return "", errors.Errorf("%w %q", modelerrors.NotFound, uuid)
 	}
 	return info.ModelType, nil
 }
@@ -194,7 +193,7 @@ func (d *dummyState) Delete(
 	uuid coremodel.UUID,
 ) error {
 	if _, exists := d.models[uuid]; !exists {
-		return fmt.Errorf("%w %q", modelerrors.NotFound, uuid)
+		return errors.Errorf("%w %q", modelerrors.NotFound, uuid)
 	}
 	delete(d.models, uuid)
 	return nil
@@ -263,20 +262,20 @@ func (d *dummyState) UpdateCredential(
 ) error {
 	info, exists := d.models[uuid]
 	if !exists {
-		return fmt.Errorf("%w %q", modelerrors.NotFound, uuid)
+		return errors.Errorf("%w %q", modelerrors.NotFound, uuid)
 	}
 
 	cloud, exists := d.clouds[credentialKey.Cloud]
 	if !exists {
-		return fmt.Errorf("%w cloud %q", errors.NotFound, credentialKey.Cloud)
+		return errors.Errorf("%w cloud %q", coreerrors.NotFound, credentialKey.Cloud)
 	}
 
 	if _, exists := cloud.Credentials[credentialKey.String()]; !exists {
-		return fmt.Errorf("%w credential %q", errors.NotFound, credentialKey.String())
+		return errors.Errorf("%w credential %q", coreerrors.NotFound, credentialKey.String())
 	}
 
 	if info.Cloud != credentialKey.Cloud {
-		return fmt.Errorf("%w credential cloud is different to that of the model", errors.NotValid)
+		return errors.Errorf("%w credential cloud is different to that of the model", coreerrors.NotValid)
 	}
 
 	return nil

--- a/domain/model/state/controllerstate.go
+++ b/domain/model/state/controllerstate.go
@@ -6,14 +6,13 @@ package state
 import (
 	"context"
 	"database/sql"
-	"fmt"
 
 	"github.com/canonical/sqlair"
-	"github.com/juju/errors"
 	"github.com/juju/version/v2"
 
 	"github.com/juju/juju/core/credential"
 	"github.com/juju/juju/core/database"
+	coreerrors "github.com/juju/juju/core/errors"
 	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/core/user"
@@ -25,7 +24,7 @@ import (
 	modelerrors "github.com/juju/juju/domain/model/errors"
 	secretbackenderrors "github.com/juju/juju/domain/secretbackend/errors"
 	jujudb "github.com/juju/juju/internal/database"
-	internalerrors "github.com/juju/juju/internal/errors"
+	"github.com/juju/juju/internal/errors"
 	internaluuid "github.com/juju/juju/internal/uuid"
 )
 
@@ -52,7 +51,7 @@ func (s *State) CloudType(
 ) (string, error) {
 	db, err := s.DB()
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", errors.Capture(err)
 	}
 
 	ctFunc := CloudType()
@@ -80,15 +79,15 @@ ON c.cloud_type_id = ct.id
 WHERE c.name = $dbName.name
 		`, dbCloudType{}, n)
 		if err != nil {
-			return "", errors.Annotate(err, "preparing select cloud type statement")
+			return "", errors.Errorf("preparing select cloud type statement %w", err)
 		}
 
 		var cloudType dbCloudType
 
 		if err := tx.Query(ctx, stmt, n).Get(&cloudType); errors.Is(err, sqlair.ErrNoRows) {
-			return "", fmt.Errorf("%w for name %q", clouderrors.NotFound, name)
+			return "", errors.Errorf("%w for name %q", clouderrors.NotFound, name)
 		} else if err != nil {
-			return "", fmt.Errorf("determining type for cloud %q: %w", name, err)
+			return "", errors.Errorf("determining type for cloud %q: %w", name, err)
 		}
 		return cloudType.Type, nil
 	}
@@ -113,7 +112,7 @@ func (s *State) Create(
 ) error {
 	db, err := s.DB()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
@@ -145,44 +144,44 @@ func Create(
 
 	// Create the initial model and associated metadata.
 	if err := createModel(ctx, preparer, tx, modelID, modelType, input); err != nil {
-		return fmt.Errorf(
+		return errors.Errorf(
 			"creating initial model %q with id %q: %w",
-			input.Name, modelID, err,
-		)
+			input.Name, modelID, err)
+
 	}
 
 	// Add permissions for the model owner to be an admin of the newly created
 	// model.
 	if err := addAdminPermissions(ctx, preparer, tx, modelID, input.Owner); err != nil {
-		return fmt.Errorf(
+		return errors.Errorf(
 			"adding admin permissions to model %q with id %q for owner %q: %w",
-			input.Name, modelID, input.Owner, err,
-		)
+			input.Name, modelID, input.Owner, err)
+
 	}
 
 	// Creates a record for the newly created model and register the target
 	// agent version.
 	if err := createModelAgent(ctx, preparer, tx, modelID, input.AgentVersion); err != nil {
-		return fmt.Errorf(
+		return errors.Errorf(
 			"creating model %q with id %q agent: %w",
-			input.Name, modelID, err,
-		)
+			input.Name, modelID, err)
+
 	}
 
 	// Sets the secret backend to be used for the newly created model.
 	if err := setModelSecretBackend(ctx, preparer, tx, modelID, input.SecretBackend); err != nil {
-		return fmt.Errorf(
+		return errors.Errorf(
 			"setting model %q with id %q secret backend: %w",
-			input.Name, modelID, err,
-		)
+			input.Name, modelID, err)
+
 	}
 
 	// Register a DQlite namespace for the model.
 	if _, err := registerModelNamespace(ctx, preparer, tx, modelID); err != nil {
-		return fmt.Errorf(
+		return errors.Errorf(
 			"registering model %q with id %q database namespace: %w",
-			input.Name, modelID, err,
-		)
+			input.Name, modelID, err)
+
 	}
 	return nil
 }
@@ -193,7 +192,7 @@ func Create(
 func (s *State) GetModel(ctx context.Context, uuid coremodel.UUID) (coremodel.Model, error) {
 	db, err := s.DB()
 	if err != nil {
-		return coremodel.Model{}, errors.Trace(err)
+		return coremodel.Model{}, errors.Capture(err)
 	}
 
 	var model coremodel.Model
@@ -214,7 +213,7 @@ func (s *State) GetModelByName(
 ) (coremodel.Model, error) {
 	db, err := s.DB()
 	if err != nil {
-		return coremodel.Model{}, errors.Trace(err)
+		return coremodel.Model{}, errors.Capture(err)
 	}
 
 	dbNames := dbNames{
@@ -230,29 +229,29 @@ WHERE name = $dbNames.name
 AND owner_name = $dbNames.owner_name
 `, model, dbNames)
 	if err != nil {
-		return coremodel.Model{}, errors.Annotate(err, "preparing select model statement")
+		return coremodel.Model{}, errors.Errorf("preparing select model statement %w", err)
 	}
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		if err := tx.Query(ctx, stmt, dbNames).Get(&model); errors.Is(err, sqlair.ErrNoRows) {
-			return fmt.Errorf(
+			return errors.Errorf(
 				"%w for user %q and name %q",
 				modelerrors.NotFound,
 				username,
-				modelName,
-			)
+				modelName)
+
 		} else if err != nil {
-			return fmt.Errorf(
+			return errors.Errorf(
 				"cannot find model for user %q and name %q: %w",
 				username,
 				modelName,
-				err,
-			)
+				err)
+
 		}
 		return nil
 	})
 	if err != nil {
-		return coremodel.Model{}, errors.Trace(err)
+		return coremodel.Model{}, errors.Capture(err)
 	}
 
 	return model.toCoreModel()
@@ -265,7 +264,7 @@ AND owner_name = $dbNames.owner_name
 func (s *State) GetModelState(ctx context.Context, uuid coremodel.UUID) (model.ModelState, error) {
 	db, err := s.DB()
 	if err != nil {
-		return model.ModelState{}, errors.Trace(err)
+		return model.ModelState{}, errors.Capture(err)
 	}
 
 	modelUUIDVal := dbModelUUID{UUID: uuid.String()}
@@ -275,19 +274,19 @@ func (s *State) GetModelState(ctx context.Context, uuid coremodel.UUID) (model.M
 SELECT &dbModelState.* FROM v_model_state WHERE uuid = $dbModelUUID.uuid
 `, modelUUIDVal, modelState)
 	if err != nil {
-		return model.ModelState{}, internalerrors.Capture(err)
+		return model.ModelState{}, errors.Capture(err)
 	}
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err := tx.Query(ctx, stmt, modelUUIDVal).Get(&modelState)
-		if internalerrors.Is(err, sqlair.ErrNoRows) {
-			return internalerrors.New("model does not exist").Add(modelerrors.NotFound)
+		if errors.Is(err, sqlair.ErrNoRows) {
+			return errors.New("model does not exist").Add(modelerrors.NotFound)
 		}
 		return err
 	})
 
 	if err != nil {
-		return model.ModelState{}, internalerrors.Errorf(
+		return model.ModelState{}, errors.Errorf(
 			"getting model %q state: %w", uuid, err,
 		)
 	}
@@ -306,7 +305,7 @@ SELECT &dbModelState.* FROM v_model_state WHERE uuid = $dbModelUUID.uuid
 func (s *State) GetModelType(ctx context.Context, uuid coremodel.UUID) (coremodel.ModelType, error) {
 	db, err := s.DB()
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", errors.Capture(err)
 	}
 
 	var modelType coremodel.ModelType
@@ -316,7 +315,7 @@ func (s *State) GetModelType(ctx context.Context, uuid coremodel.UUID) (coremode
 		return err
 	})
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", errors.Capture(err)
 	}
 	return modelType, nil
 }
@@ -325,7 +324,7 @@ func (s *State) GetModelType(ctx context.Context, uuid coremodel.UUID) (coremode
 func (s *State) GetControllerModel(ctx context.Context) (coremodel.Model, error) {
 	db, err := s.DB()
 	if err != nil {
-		return coremodel.Model{}, errors.Trace(err)
+		return coremodel.Model{}, errors.Capture(err)
 	}
 
 	controllerModelUUID := dbModelUUIDRef{}
@@ -334,7 +333,7 @@ SELECT &dbModelUUIDRef.model_uuid
 FROM   controller
 `, controllerModelUUID)
 	if err != nil {
-		return coremodel.Model{}, errors.Annotate(err, "preparing get controller model UUID statement")
+		return coremodel.Model{}, errors.Errorf("preparing get controller model UUID statement %w", err)
 	}
 
 	var model coremodel.Model
@@ -345,15 +344,15 @@ FROM   controller
 			// wrong. There is no point making this a modelerrors.NotFound type
 			// as that implies the error is catchable and something can be done
 			// about it, this is not the case.
-			return fmt.Errorf("controller model not found")
+			return errors.Errorf("controller model not found")
 		} else if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		model, err = GetModel(ctx, tx, coremodel.UUID(controllerModelUUID.ModelUUID))
-		return errors.Trace(err)
+		return errors.Capture(err)
 	})
 	if err != nil {
-		return coremodel.Model{}, errors.Annotatef(err, "getting controller model")
+		return coremodel.Model{}, errors.Errorf("getting controller model %w", err)
 	}
 	return model, nil
 }
@@ -375,14 +374,14 @@ FROM v_model AS m
 WHERE uuid = $dbUUID.uuid
 `, dbModelType{}, mUUID)
 	if err != nil {
-		return "", errors.Annotate(err, "preparing select model type statement")
+		return "", errors.Errorf("preparing select model type statement %w", err)
 	}
 
 	var modelType dbModelType
 	if err := tx.Query(ctx, stmt, mUUID).Get(&modelType); errors.Is(err, sqlair.ErrNoRows) {
-		return "", fmt.Errorf("%w for uuid %q", modelerrors.NotFound, uuid)
+		return "", errors.Errorf("%w for uuid %q", modelerrors.NotFound, uuid)
 	} else if err != nil {
-		return "", fmt.Errorf("getting model type for uuid %q: %w", uuid, err)
+		return "", errors.Errorf("getting model type for uuid %q: %w", uuid, err)
 	}
 	return coremodel.ModelType(modelType.Type), nil
 }
@@ -403,19 +402,19 @@ WHERE uuid = $dbModel.uuid
 	model := dbModel{UUID: uuid.String()}
 	stmt, err := sqlair.Prepare(q, model)
 	if err != nil {
-		return coremodel.Model{}, errors.Annotate(err, "preparing select model statement")
+		return coremodel.Model{}, errors.Errorf("preparing select model statement %w", err)
 	}
 
 	err = tx.Query(ctx, stmt, model).Get(&model)
 	if errors.Is(err, sqlair.ErrNoRows) {
-		return coremodel.Model{}, fmt.Errorf("%w for uuid %q", modelerrors.NotFound, uuid)
+		return coremodel.Model{}, errors.Errorf("%w for uuid %q", modelerrors.NotFound, uuid)
 	} else if err != nil {
-		return coremodel.Model{}, fmt.Errorf("getting model %q: %w", uuid, err)
+		return coremodel.Model{}, errors.Errorf("getting model %q: %w", uuid, err)
 	}
 
 	coreModel, err := model.toCoreModel()
 	if err != nil {
-		return coremodel.Model{}, errors.Trace(err)
+		return coremodel.Model{}, errors.Capture(err)
 	}
 	return coreModel, nil
 }
@@ -441,30 +440,30 @@ func createModelAgent(
 INSERT INTO model_agent (*) VALUES ($dbModelAgent.*)
 `, modelAgent)
 	if err != nil {
-		return errors.Annotatef(err, "preparing insert model agent statement")
+		return errors.Errorf("preparing insert model agent statement %w", err)
 	}
 
 	var outcome sqlair.Outcome
 	err = tx.Query(ctx, stmt, modelAgent).Get(&outcome)
 	if jujudb.IsErrConstraintPrimaryKey(err) {
-		return fmt.Errorf(
+		return errors.Errorf(
 			"%w for uuid %q while setting model agent version",
-			modelerrors.AlreadyExists, modelUUID,
-		)
+			modelerrors.AlreadyExists, modelUUID)
+
 	} else if jujudb.IsErrConstraintForeignKey(err) {
-		return fmt.Errorf(
+		return errors.Errorf(
 			"%w for uuid %q while setting model agent version",
 			modelerrors.NotFound,
-			modelUUID,
-		)
+			modelUUID)
+
 	} else if err != nil {
-		return fmt.Errorf("creating model %q agent information: %w", modelUUID, err)
+		return errors.Errorf("creating model %q agent information: %w", modelUUID, err)
 	}
 
 	if num, err := outcome.Result().RowsAffected(); err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	} else if num != 1 {
-		return fmt.Errorf("creating model agent record, expected 1 row to be inserted got %d", num)
+		return errors.Errorf("creating model agent record, expected 1 row to be inserted got %d", num)
 	}
 
 	return nil
@@ -488,20 +487,20 @@ func setModelSecretBackend(
 SELECT &dbUUID.uuid from secret_backend WHERE name = $dbName.name
 `, backendName, backendUUID)
 	if err != nil {
-		return errors.Annotatef(err, "preparing select backend statement")
+		return errors.Errorf("preparing select backend statement %w", err)
 	}
 
 	err = tx.Query(ctx, backendFindStmt, backendName).Get(&backendUUID)
 	if errors.Is(err, sqlair.ErrNoRows) {
-		return fmt.Errorf(
+		return errors.Errorf(
 			"setting model %q secret backend to %q: %w",
-			modelID, backend, secretbackenderrors.NotFound,
-		)
+			modelID, backend, secretbackenderrors.NotFound)
+
 	} else if err != nil {
-		return fmt.Errorf(
+		return errors.Errorf(
 			"setting model %q secret backend to %q: %w",
-			modelID, backend, err,
-		)
+			modelID, backend, err)
+
 	}
 
 	modelSecretBackend := dbModelSecretBackend{
@@ -513,33 +512,33 @@ SELECT &dbUUID.uuid from secret_backend WHERE name = $dbName.name
 INSERT INTO model_secret_backend (*) VALUES ($dbModelSecretBackend.*) 
 `, modelSecretBackend)
 	if err != nil {
-		return errors.Annotatef(err, "preparing insert model secret backend statement")
+		return errors.Errorf("preparing insert model secret backend statement %w", err)
 	}
 
 	var outcome sqlair.Outcome
 	err = tx.Query(ctx, stmt, modelSecretBackend).Get(&outcome)
 	if jujudb.IsErrConstraintPrimaryKey(err) {
-		return fmt.Errorf(
-			"model for id %q %w", modelID, modelerrors.SecretBackendAlreadySet,
-		)
+		return errors.Errorf(
+			"model for id %q %w", modelID, modelerrors.SecretBackendAlreadySet)
+
 	} else if jujudb.IsErrConstraintForeignKey(err) {
-		return fmt.Errorf(
+		return errors.Errorf(
 			"%w for id %q while setting model secret backend to %q",
 			modelerrors.NotFound,
 			modelID,
-			backend,
-		)
+			backend)
+
 	} else if err != nil {
-		return fmt.Errorf(
+		return errors.Errorf(
 			"setting model for id %q secret backend %q: %w",
-			modelID, backend, err,
-		)
+			modelID, backend, err)
+
 	}
 
 	if num, err := outcome.Result().RowsAffected(); err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	} else if num != 1 {
-		return fmt.Errorf("creating model secret backend record, expected 1 row to be inserted got %d", num)
+		return errors.Errorf("creating model secret backend record, expected 1 row to be inserted got %d", num)
 	}
 
 	return nil
@@ -572,14 +571,14 @@ func createModel(
 
 	cloudStmt, err := preparer.Prepare(`SELECT &dbUUID.* FROM cloud WHERE name = $dbName.name`, dbUUID{}, cloudName)
 	if err != nil {
-		return errors.Annotate(err, "preparing select cloud statement")
+		return errors.Errorf("preparing select cloud statement %w", err)
 	}
 
 	var cloudUUID dbUUID
 	if err := tx.Query(ctx, cloudStmt, cloudName).Get(&cloudUUID); errors.Is(err, sqlair.ErrNoRows) {
-		return fmt.Errorf("%w: %q", clouderrors.NotFound, input.Cloud)
+		return errors.Errorf("%w: %q", clouderrors.NotFound, input.Cloud)
 	} else if err != nil {
-		return fmt.Errorf("getting cloud %q uuid: %w", input.Cloud, err)
+		return errors.Errorf("getting cloud %q uuid: %w", input.Cloud, err)
 	}
 
 	ownerUUID := dbUserUUID{UUID: input.Owner.String()}
@@ -590,19 +589,19 @@ func createModel(
 		AND removed = false
 	`, ownerUUID)
 	if err != nil {
-		return errors.Annotatef(err, "preparing check user exists statement")
+		return errors.Errorf("preparing check user exists statement %w", err)
 	}
 	err = tx.Query(ctx, userStmt, ownerUUID).Get(&ownerUUID)
 	if errors.Is(err, sqlair.ErrNoRows) {
-		return fmt.Errorf("%w for model owner %q", accesserrors.UserNotFound, input.Owner)
+		return errors.Errorf("%w for model owner %q", accesserrors.UserNotFound, input.Owner)
 	} else if err != nil {
-		return fmt.Errorf("getting user uuid for setting model %q owner: %w", input.Name, err)
+		return errors.Errorf("getting user uuid for setting model %q owner: %w", input.Name, err)
 	}
 
 	// If a model with this name/owner was previously created, clean it up
 	// before creating the new model.
 	if err := cleanupBrokenModel(ctx, preparer, tx, input.Name, input.Owner); err != nil {
-		return fmt.Errorf("deleting broken model with name %q and owner %q: %w", input.Name, input.Owner, err)
+		return errors.Errorf("deleting broken model with name %q and owner %q: %w", input.Name, input.Owner, err)
 	}
 
 	model := dbInitialModel{
@@ -631,33 +630,33 @@ func createModel(
 		WHERE model_type.type = $dbInitialModel.model_type
 		`, model)
 	if err != nil {
-		return errors.Annotatef(err, "preparing insert initial model statement")
+		return errors.Errorf("preparing insert initial model statement %w", err)
 	}
 
 	var outcome sqlair.Outcome
 	err = tx.Query(ctx, stmt, model).Get(&outcome)
 	if jujudb.IsErrConstraintPrimaryKey(err) {
-		return fmt.Errorf("%w for id %q", modelerrors.AlreadyExists, modelUUID)
+		return errors.Errorf("%w for id %q", modelerrors.AlreadyExists, modelUUID)
 	} else if jujudb.IsErrConstraintUnique(err) {
-		return fmt.Errorf("%w for name %q and owner %q", modelerrors.AlreadyExists, input.Name, input.Owner)
+		return errors.Errorf("%w for name %q and owner %q", modelerrors.AlreadyExists, input.Name, input.Owner)
 	} else if err != nil {
-		return fmt.Errorf("setting model %q information: %w", modelUUID, err)
+		return errors.Errorf("setting model %q information: %w", modelUUID, err)
 	}
 
 	if num, err := outcome.Result().RowsAffected(); err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	} else if num != 1 {
-		return fmt.Errorf("creating model metadata, expected 1 row to be inserted, got %d", num)
+		return errors.Errorf("creating model metadata, expected 1 row to be inserted, got %d", num)
 	}
 
 	if err := setCloudRegion(ctx, preparer, tx, modelUUID, input.Cloud, input.CloudRegion); err != nil {
-		return fmt.Errorf("setting cloud region for model %q: %w", modelUUID, err)
+		return errors.Errorf("setting cloud region for model %q: %w", modelUUID, err)
 	}
 
 	if !input.Credential.IsZero() {
 		err := updateCredential(ctx, preparer, tx, modelUUID, input.Credential)
 		if err != nil {
-			return fmt.Errorf("setting cloud credential for model %q: %w", modelUUID, err)
+			return errors.Errorf("setting cloud credential for model %q: %w", modelUUID, err)
 		}
 	}
 
@@ -680,7 +679,7 @@ func (s *State) Delete(
 ) error {
 	db, err := s.DB()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	mUUID := dbUUID{UUID: uuid.String()}
@@ -698,7 +697,7 @@ func (s *State) Delete(
 	for _, query := range queries {
 		stmt, err := s.Prepare(query, mUUID)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		stmts = append(stmts, stmt)
 	}
@@ -706,33 +705,33 @@ func (s *State) Delete(
 	// The model statement is required, and the output needs to be checked.
 	mStmt, err := s.Prepare(`DELETE FROM model WHERE uuid = $dbUUID.uuid`, mUUID)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		if err := unregisterModelNamespace(ctx, s, tx, uuid); err != nil {
-			return fmt.Errorf("un-registering model %q database namespaces: %w", uuid, err)
+			return errors.Errorf("un-registering model %q database namespaces: %w", uuid, err)
 		}
 
 		for _, stmt := range stmts {
 			if err := tx.Query(ctx, stmt, mUUID).Run(); errors.Is(err, sqlair.ErrNoRows) {
 				continue
 			} else if err != nil {
-				return errors.Trace(err)
+				return errors.Capture(err)
 			}
 		}
 
 		var outcome sqlair.Outcome
 		if err := tx.Query(ctx, mStmt, mUUID).Get(&outcome); errors.Is(err, sqlair.ErrNoRows) {
-			return fmt.Errorf("%w for uuid %q", modelerrors.NotFound, uuid)
+			return errors.Errorf("%w for uuid %q", modelerrors.NotFound, uuid)
 		} else if err != nil {
-			return fmt.Errorf("deleting model %q: %w", uuid, err)
+			return errors.Errorf("deleting model %q: %w", uuid, err)
 		}
 
 		if affected, err := outcome.Result().RowsAffected(); err != nil {
-			return fmt.Errorf("deleting model %q: %w", uuid, err)
+			return errors.Errorf("deleting model %q: %w", uuid, err)
 		} else if affected == 0 {
-			return fmt.Errorf("%w for uuid %q", modelerrors.NotFound, uuid)
+			return errors.Errorf("%w for uuid %q", modelerrors.NotFound, uuid)
 		}
 
 		return nil
@@ -750,7 +749,7 @@ func (s *State) Delete(
 func (s *State) Activate(ctx context.Context, uuid coremodel.UUID) error {
 	db, err := s.DB()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	activator := GetActivator()
@@ -782,7 +781,7 @@ FROM model
 WHERE uuid = $dbUUID.uuid
 		`, dbModelActivated{}, mUUID)
 		if err != nil {
-			return errors.Annotate(err, "preparing select model activated statement")
+			return errors.Errorf("preparing select model activated statement %w", err)
 		}
 
 		stmt, err := preparer.Prepare(`
@@ -791,28 +790,28 @@ SET activated = TRUE
 WHERE uuid = $dbUUID.uuid
 		`, mUUID)
 		if err != nil {
-			return errors.Annotate(err, "preparing update model activated statement")
+			return errors.Errorf("preparing update model activated statement %w", err)
 		}
 
 		var activated dbModelActivated
 		if err := tx.Query(ctx, existsStmt, mUUID).Get(&activated); errors.Is(err, sqlair.ErrNoRows) {
-			return fmt.Errorf("%w for id %q", modelerrors.NotFound, uuid)
+			return errors.Errorf("%w for id %q", modelerrors.NotFound, uuid)
 		} else if err != nil {
-			return fmt.Errorf("determining activated status for model with id %q: %w", uuid, err)
+			return errors.Errorf("determining activated status for model with id %q: %w", uuid, err)
 		}
 
 		if activated.Activated {
-			return fmt.Errorf("%w for id %q", modelerrors.AlreadyActivated, uuid)
+			return errors.Errorf("%w for id %q", modelerrors.AlreadyActivated, uuid)
 		}
 
 		var outcome sqlair.Outcome
 		if err := tx.Query(ctx, stmt, mUUID).Get(&outcome); err != nil {
-			return fmt.Errorf("activating model with id %q: %w", uuid, err)
+			return errors.Errorf("activating model with id %q: %w", uuid, err)
 		}
 		if affected, err := outcome.Result().RowsAffected(); err != nil {
-			return fmt.Errorf("activating model with id %q: %w", uuid, err)
+			return errors.Errorf("activating model with id %q: %w", uuid, err)
 		} else if affected == 0 {
-			return fmt.Errorf("model not activated")
+			return errors.Errorf("model not activated")
 		}
 		return nil
 	}
@@ -824,13 +823,13 @@ func (s *State) GetModelTypes(ctx context.Context) ([]coremodel.ModelType, error
 
 	db, err := s.DB()
 	if err != nil {
-		return rval, errors.Trace(err)
+		return rval, errors.Capture(err)
 	}
 
 	stmt, err := s.Prepare(`SELECT &dbModelType.* FROM model_type;
 `, dbModelType{})
 	if err != nil {
-		return rval, errors.Annotate(err, "preparing select model type statement")
+		return rval, errors.Errorf("preparing select model type statement %w", err)
 	}
 
 	return rval, db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
@@ -838,13 +837,13 @@ func (s *State) GetModelTypes(ctx context.Context) ([]coremodel.ModelType, error
 		if err := tx.Query(ctx, stmt).GetAll(&result); errors.Is(err, sqlair.ErrNoRows) {
 			return nil
 		} else if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		for _, r := range result {
 			mt := coremodel.ModelType(r.Type)
 			if !mt.IsValid() {
-				return fmt.Errorf("invalid model type %q", r.Type)
+				return errors.Errorf("invalid model type %q", r.Type)
 			}
 			rval = append(rval, mt)
 		}
@@ -857,12 +856,12 @@ func (s *State) GetModelTypes(ctx context.Context) ([]coremodel.ModelType, error
 func (s *State) ListAllModels(ctx context.Context) ([]coremodel.Model, error) {
 	db, err := s.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	modelStmt, err := s.Prepare(`SELECT &dbModel.* FROM v_model`, dbModel{})
 	if err != nil {
-		return nil, errors.Annotate(err, "preparing select model statement")
+		return nil, errors.Errorf("preparing select model statement %w", err)
 	}
 
 	rval := []coremodel.Model{}
@@ -871,13 +870,13 @@ func (s *State) ListAllModels(ctx context.Context) ([]coremodel.Model, error) {
 		if err := tx.Query(ctx, modelStmt).GetAll(&result); errors.Is(err, sqlair.ErrNoRows) {
 			return nil
 		} else if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		for _, r := range result {
 			model, err := r.toCoreModel()
 			if err != nil {
-				return errors.Trace(err)
+				return errors.Capture(err)
 			}
 
 			rval = append(rval, model)
@@ -887,7 +886,7 @@ func (s *State) ListAllModels(ctx context.Context) ([]coremodel.Model, error) {
 	})
 
 	if err != nil {
-		return nil, fmt.Errorf("getting all models: %w", err)
+		return nil, errors.Errorf("getting all models: %w", err)
 	}
 
 	return rval, nil
@@ -898,12 +897,12 @@ func (s *State) ListAllModels(ctx context.Context) ([]coremodel.Model, error) {
 func (s *State) ListModelIDs(ctx context.Context) ([]coremodel.UUID, error) {
 	db, err := s.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	stmt, err := s.Prepare(`SELECT &dbUUID.uuid FROM v_model;`, dbUUID{})
 	if err != nil {
-		return nil, errors.Annotate(err, "preparing select model UUID statement")
+		return nil, errors.Errorf("preparing select model UUID statement %w", err)
 	}
 
 	var models []coremodel.UUID
@@ -912,7 +911,7 @@ func (s *State) ListModelIDs(ctx context.Context) ([]coremodel.UUID, error) {
 		if err := tx.Query(ctx, stmt).GetAll(&result); errors.Is(err, sqlair.ErrNoRows) {
 			return nil
 		} else if err != nil {
-			return fmt.Errorf("getting all model UUIDs: %w", err)
+			return errors.Errorf("getting all model UUIDs: %w", err)
 		}
 
 		for _, r := range result {
@@ -920,7 +919,7 @@ func (s *State) ListModelIDs(ctx context.Context) ([]coremodel.UUID, error) {
 		}
 		return nil
 	})
-	return models, errors.Trace(err)
+	return models, errors.Capture(err)
 }
 
 // ListModelsForUser returns a slice of models owned or accessible by the user
@@ -932,7 +931,7 @@ func (s *State) ListModelsForUser(
 ) ([]coremodel.Model, error) {
 	db, err := s.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	uUUID := dbUUID{UUID: userID.String()}
@@ -947,7 +946,7 @@ OR uuid IN (SELECT grant_on
             AND access_type_id IN (0, 1, 3))
 `, dbModel{}, uUUID)
 	if err != nil {
-		return nil, errors.Annotatef(err, "preparing select model statement")
+		return nil, errors.Errorf("preparing select model statement %w", err)
 	}
 
 	rval := []coremodel.Model{}
@@ -956,13 +955,13 @@ OR uuid IN (SELECT grant_on
 		if err := tx.Query(ctx, modelStmt, uUUID).GetAll(&result); errors.Is(err, sqlair.ErrNoRows) {
 			return nil
 		} else if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		for _, r := range result {
 			model, err := r.toCoreModel()
 			if err != nil {
-				return errors.Trace(err)
+				return errors.Capture(err)
 			}
 
 			rval = append(rval, model)
@@ -972,7 +971,7 @@ OR uuid IN (SELECT grant_on
 	})
 
 	if err != nil {
-		return nil, fmt.Errorf("getting models owned by user %q: %w", userID, err)
+		return nil, errors.Errorf("getting models owned by user %q: %w", userID, err)
 	}
 
 	return rval, nil
@@ -984,7 +983,7 @@ OR uuid IN (SELECT grant_on
 func (st *State) GetModelUsers(ctx context.Context, modelUUID coremodel.UUID) ([]coremodel.ModelUserInfo, error) {
 	db, err := st.DB()
 	if err != nil {
-		return nil, errors.Annotate(err, "getting DB access")
+		return nil, errors.Errorf("getting DB access %w", err)
 	}
 	q := `
 SELECT    (u.name, u.display_name, mll.time, p.access_type) AS (&dbModelUserInfo.*)
@@ -998,7 +997,7 @@ AND       u.removed = false
 	uuid := dbModelUUIDRef{ModelUUID: modelUUID.String()}
 	stmt, err := st.Prepare(q, dbModelUserInfo{}, uuid)
 	if err != nil {
-		return nil, errors.Annotatef(err, "preparing select model user info statement")
+		return nil, errors.Errorf("preparing select model user info statement %w", err)
 	}
 
 	var modelUsers []dbModelUserInfo
@@ -1006,23 +1005,23 @@ AND       u.removed = false
 		err = tx.Query(ctx, stmt, uuid).GetAll(&modelUsers)
 		if errors.Is(err, sqlair.ErrNoRows) {
 			if _, err := GetModel(ctx, tx, modelUUID); err != nil {
-				return errors.Trace(err)
+				return errors.Capture(err)
 			}
-			return fmt.Errorf("no users found on model")
+			return errors.Errorf("no users found on model")
 		} else if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		return nil
 	})
 	if err != nil {
-		return nil, errors.Annotatef(err, "getting model users from database")
+		return nil, errors.Errorf("getting model users from database %w", err)
 	}
 
 	var userInfo []coremodel.ModelUserInfo
 	for _, modelUser := range modelUsers {
 		mui, err := modelUser.toModelUserInfo()
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, errors.Capture(err)
 		}
 		userInfo = append(userInfo, mui)
 	}
@@ -1039,7 +1038,7 @@ AND       u.removed = false
 func (s *State) ListModelSummariesForUser(ctx context.Context, userName user.Name) ([]coremodel.UserModelSummary, error) {
 	db, err := s.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	q := `
@@ -1057,7 +1056,7 @@ AND       u.name = $dbUserName.name
 	name := dbUserName{Name: userName.Name()}
 	modelStmt, err := s.Prepare(q, name, dbModelSummary{})
 	if err != nil {
-		return nil, errors.Annotatef(err, "preparing get model summary for user statement")
+		return nil, errors.Errorf("preparing get model summary for user statement %w", err)
 	}
 
 	controllerInfo := dbController{}
@@ -1066,7 +1065,7 @@ SELECT &dbController.*
 FROM controller
 `, controllerInfo)
 	if err != nil {
-		return nil, errors.Annotatef(err, "preparing get controller uuid statement")
+		return nil, errors.Errorf("preparing get controller uuid statement %w", err)
 	}
 
 	var models []dbModelSummary
@@ -1075,7 +1074,7 @@ FROM controller
 		if errors.Is(err, sqlair.ErrNoRows) {
 			return nil
 		} else if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		err = tx.Query(ctx, controllerUUIDstmt).Get(&controllerInfo)
@@ -1083,19 +1082,19 @@ FROM controller
 			// If this happens something is very wrong.
 			return errors.New("controller uuid not found")
 		} else if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		return nil
 	})
 	if err != nil {
-		return nil, errors.Annotate(err, "getting model summaries for user")
+		return nil, errors.Errorf("getting model summaries for user %w", err)
 	}
 
 	modelSummaries := make([]coremodel.UserModelSummary, len(models))
 	for i, m := range models {
 		modelSummaries[i], err = m.decodeUserModelSummary(controllerInfo)
 		if err != nil {
-			return nil, errors.Annotate(err, "getting model summaries for user")
+			return nil, errors.Errorf("getting model summaries for user %w", err)
 		}
 	}
 
@@ -1112,7 +1111,7 @@ FROM controller
 func (s *State) ListAllModelSummaries(ctx context.Context) ([]coremodel.ModelSummary, error) {
 	db, err := s.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	modelStmt, err := s.Prepare(`
@@ -1123,7 +1122,7 @@ SELECT    (m.uuid, m.name, m.cloud_name, m.cloud_region_name,
 FROM      v_model m 
 `, dbModelSummary{})
 	if err != nil {
-		return nil, errors.Annotatef(err, "preparing get model statement")
+		return nil, errors.Errorf("preparing get model statement %w", err)
 	}
 
 	controllerInfo := dbController{}
@@ -1132,7 +1131,7 @@ SELECT &dbController.*
 FROM controller
 `, controllerInfo)
 	if err != nil {
-		return nil, errors.Annotatef(err, "preparing get controller uuid statement")
+		return nil, errors.Errorf("preparing get controller uuid statement %w", err)
 	}
 
 	var models []dbModelSummary
@@ -1141,7 +1140,7 @@ FROM controller
 		if errors.Is(err, sqlair.ErrNoRows) {
 			return modelerrors.NotFound
 		} else if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		err = tx.Query(ctx, controllerUUIDstmt).Get(&controllerInfo)
@@ -1149,19 +1148,19 @@ FROM controller
 			// If this happens something is very wrong.
 			return errors.New("controller uuid not found")
 		} else if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		return nil
 	})
 	if err != nil {
-		return nil, errors.Annotatef(err, "getting all model summaries")
+		return nil, errors.Errorf("getting all model summaries %w", err)
 	}
 
 	modelSummaries := make([]coremodel.ModelSummary, len(models))
 	for i, m := range models {
 		modelSummaries[i], err = m.decodeModelSummary(controllerInfo)
 		if err != nil {
-			return nil, errors.Annotatef(err, "getting all model summaries")
+			return nil, errors.Errorf("getting all model summaries %w", err)
 		}
 	}
 
@@ -1178,7 +1177,7 @@ func (s *State) ModelCloudNameAndCredential(
 ) (string, credential.Key, error) {
 	db, err := s.DB()
 	if err != nil {
-		return "", credential.Key{}, errors.Trace(err)
+		return "", credential.Key{}, errors.Capture(err)
 	}
 
 	args := dbCloudOwner{
@@ -1193,7 +1192,7 @@ WHERE name = $dbCloudOwner.name
 AND owner_name = $dbCloudOwner.owner_name
 `, dbCloudCredential{}, args)
 	if err != nil {
-		return "", credential.Key{}, errors.Annotate(err, "preparing select model cloud name and credential statement")
+		return "", credential.Key{}, errors.Errorf("preparing select model cloud name and credential statement %w", err)
 	}
 
 	var (
@@ -1204,9 +1203,9 @@ AND owner_name = $dbCloudOwner.owner_name
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		var result dbCloudCredential
 		if err := tx.Query(ctx, stmt, args).Get(&result); errors.Is(err, sqlair.ErrNoRows) {
-			return fmt.Errorf("%w for name %q and owner %q", modelerrors.NotFound, modelName, modelOwnerName)
+			return errors.Errorf("%w for name %q and owner %q", modelerrors.NotFound, modelName, modelOwnerName)
 		} else if err != nil {
-			return fmt.Errorf("getting cloud name and credential for model %q with owner %q: %w", modelName, modelOwnerName, err)
+			return errors.Errorf("getting cloud name and credential for model %q with owner %q: %w", modelName, modelOwnerName, err)
 		}
 
 		cloudName = result.Name
@@ -1219,13 +1218,13 @@ AND owner_name = $dbCloudOwner.owner_name
 		return nil
 	})
 	if err != nil {
-		return "", credential.Key{}, errors.Trace(err)
+		return "", credential.Key{}, errors.Capture(err)
 	}
 
 	if credentialOwner.Valid && credentialOwner.String != "" {
 		ownerName, err := user.NewName(credentialOwner.String)
 		if err != nil {
-			return "", credential.Key{}, errors.Annotate(err, "credential owner")
+			return "", credential.Key{}, errors.Errorf("credential owner %w", err)
 		}
 		credentialKey.Owner = ownerName
 	}
@@ -1240,7 +1239,7 @@ AND owner_name = $dbCloudOwner.owner_name
 func (s *State) NamespaceForModel(ctx context.Context, id coremodel.UUID) (string, error) {
 	db, err := s.DB()
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", errors.Capture(err)
 	}
 
 	mUUID := dbUUID{UUID: id.String()}
@@ -1253,30 +1252,30 @@ LEFT JOIN model_namespace mn ON m.uuid = mn.model_uuid
 WHERE m.uuid = $dbUUID.uuid
 `, dbModelNamespace{}, mUUID)
 	if err != nil {
-		return "", errors.Annotate(err, "preparing select model namespace statement")
+		return "", errors.Errorf("preparing select model namespace statement %w", err)
 	}
 
 	var namespace sql.NullString
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		var result dbModelNamespace
 		if err := tx.Query(ctx, stmt, mUUID).Get(&result); errors.Is(err, sqlair.ErrNoRows) {
-			return fmt.Errorf("%w for id %q", modelerrors.NotFound, id)
+			return errors.Errorf("%w for id %q", modelerrors.NotFound, id)
 		} else if err != nil {
-			return fmt.Errorf("getting database namespace for model %q: %w", id, err)
+			return errors.Errorf("getting database namespace for model %q: %w", id, err)
 		}
 		namespace = result.Namespace
 		return nil
 	})
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", errors.Capture(err)
 	}
 
 	if !namespace.Valid {
-		return "", fmt.Errorf(
+		return "", errors.Errorf(
 			"%w for id %q",
 			modelerrors.ModelNamespaceNotFound,
-			id,
-		)
+			id)
+
 	}
 
 	return namespace.String, nil
@@ -1302,30 +1301,30 @@ func registerModelNamespace(
 INSERT INTO namespace_list (namespace) VALUES ($dbModelNamespace.namespace)
 	`, modelNamespace)
 	if err != nil {
-		return "", errors.Annotatef(err, "preparing insert namespace statement")
+		return "", errors.Errorf("preparing insert namespace statement %w", err)
 	}
 
 	err = tx.Query(ctx, insertNamespaceStmt, modelNamespace).Run()
 	if jujudb.IsErrConstraintPrimaryKey(err) {
-		return "", fmt.Errorf("database namespace already registered for model %q", uuid)
+		return "", errors.Errorf("database namespace already registered for model %q", uuid)
 	} else if err != nil {
-		return "", fmt.Errorf("registering database namespace for model %q: %w", uuid, err)
+		return "", errors.Errorf("registering database namespace for model %q: %w", uuid, err)
 	}
 
 	insertModelNamespaceStmt, err := preparer.Prepare(`
 INSERT INTO model_namespace (*) VALUES ($dbModelNamespace.*)
 	`, modelNamespace)
 	if err != nil {
-		return "", errors.Annotatef(err, "preparing insert model namespace statement")
+		return "", errors.Errorf("preparing insert model namespace statement %w", err)
 	}
 
 	err = tx.Query(ctx, insertModelNamespaceStmt, modelNamespace).Run()
 	if jujudb.IsErrConstraintUnique(err) {
-		return "", fmt.Errorf("model %q already has a database namespace registered", uuid)
+		return "", errors.Errorf("model %q already has a database namespace registered", uuid)
 	} else if jujudb.IsErrConstraintForeignKey(err) {
-		return "", fmt.Errorf("%w for uuid %q", modelerrors.NotFound, uuid)
+		return "", errors.Errorf("%w for uuid %q", modelerrors.NotFound, uuid)
 	} else if err != nil {
-		return "", fmt.Errorf("associating database namespace with model %q, %w", uuid, err)
+		return "", errors.Errorf("associating database namespace with model %q, %w", uuid, err)
 	}
 
 	return uuid.String(), nil
@@ -1354,7 +1353,7 @@ AND owner_uuid = $dbModelNameAndOwner.owner_uuid
 AND activated = false
 `, uuid, nameAndOwner)
 	if err != nil {
-		return errors.Annotatef(err, "preparing select model uuid statement")
+		return errors.Errorf("preparing select model uuid statement %w", err)
 	}
 
 	err = tx.Query(ctx, findBrokenModelStmt, nameAndOwner).Get(&uuid)
@@ -1363,9 +1362,9 @@ AND activated = false
 		return nil
 	}
 	if err != nil {
-		return fmt.Errorf("finding broken model for name %q and owner %q: %w",
-			modelName, modelOwner, err,
-		)
+		return errors.Errorf("finding broken model for name %q and owner %q: %w",
+			modelName, modelOwner, err)
+
 	}
 
 	// Delete model namespace
@@ -1374,13 +1373,13 @@ DELETE FROM model_namespace
 WHERE model_uuid = $dbUUID.uuid
 `, uuid)
 	if err != nil {
-		return errors.Annotatef(err, "preparing delete model namespace statement")
+		return errors.Errorf("preparing delete model namespace statement %w", err)
 	}
 	err = tx.Query(ctx, deleteBadStateModelNamespace, uuid).Run()
 	if err != nil {
-		return fmt.Errorf("cleaning up bad model namespace for model with UUID %q: %w",
-			uuid.UUID, err,
-		)
+		return errors.Errorf("cleaning up bad model namespace for model with UUID %q: %w",
+			uuid.UUID, err)
+
 	}
 
 	// Delete model agent entry
@@ -1389,13 +1388,13 @@ DELETE FROM model_agent
 WHERE model_uuid = $dbUUID.uuid
 `, uuid)
 	if err != nil {
-		return errors.Annotatef(err, "preparing delete model agent statement")
+		return errors.Errorf("preparing delete model agent statement %w", err)
 	}
 	err = tx.Query(ctx, deleteBrokenModelAgent, uuid).Run()
 	if err != nil {
-		return fmt.Errorf("cleaning up model agent entry for model with UUID %q: %w",
-			uuid.UUID, err,
-		)
+		return errors.Errorf("cleaning up model agent entry for model with UUID %q: %w",
+			uuid.UUID, err)
+
 	}
 
 	// Delete model secret backend
@@ -1404,13 +1403,13 @@ DELETE FROM model_secret_backend
 WHERE model_uuid = $dbUUID.uuid
 `, uuid)
 	if err != nil {
-		return errors.Annotatef(err, "preparing delete secret backend statement")
+		return errors.Errorf("preparing delete secret backend statement %w", err)
 	}
 	err = tx.Query(ctx, deleteBrokenModelSecretBackend, uuid).Run()
 	if err != nil {
-		return fmt.Errorf("cleaning up model secret backend for model with UUID %q: %w",
-			uuid.UUID, err,
-		)
+		return errors.Errorf("cleaning up model secret backend for model with UUID %q: %w",
+			uuid.UUID, err)
+
 	}
 
 	// Delete model last login
@@ -1419,13 +1418,13 @@ DELETE FROM model_last_login
 WHERE model_uuid = $dbUUID.uuid
 `, uuid)
 	if err != nil {
-		return errors.Annotatef(err, "preparing delete model last login statement")
+		return errors.Errorf("preparing delete model last login statement %w", err)
 	}
 	err = tx.Query(ctx, deleteBrokenModelLastLogin, uuid).Run()
 	if err != nil {
-		return fmt.Errorf("cleaning up model last login for model with UUID %q: %w",
-			uuid.UUID, err,
-		)
+		return errors.Errorf("cleaning up model last login for model with UUID %q: %w",
+			uuid.UUID, err)
+
 	}
 
 	// Finally, delete the model from the model table.
@@ -1434,13 +1433,13 @@ DELETE FROM model
 WHERE uuid = $dbUUID.uuid
 `, uuid)
 	if err != nil {
-		return errors.Annotatef(err, "preparing model statement")
+		return errors.Errorf("preparing model statement %w", err)
 	}
 	err = tx.Query(ctx, deleteBadStateModel, uuid).Run()
 	if err != nil {
-		return fmt.Errorf("cleaning up bad model state for model with UUID %q: %w",
-			uuid.UUID, err,
-		)
+		return errors.Errorf("cleaning up bad model state for model with UUID %q: %w",
+			uuid.UUID, err)
+
 	}
 
 	return nil
@@ -1477,13 +1476,13 @@ WHERE  m.name = 'controller'
 AND    c.name = $dbName.name
 `, cloudName, cloudRegionUUID)
 		if err != nil {
-			return errors.Annotatef(err, "preparing select controller cloud region statement")
+			return errors.Errorf("preparing select controller cloud region statement %w", err)
 		}
 
 		if err := tx.Query(ctx, stmt, cloudName).Get(&cloudRegionUUID); errors.Is(err, sqlair.ErrNoRows) {
 			return nil
 		} else if err != nil {
-			return fmt.Errorf("getting controller cloud region uuid: %w", err)
+			return errors.Errorf("getting controller cloud region uuid: %w", err)
 		}
 
 		// If the region is empty, we will not set a cloud region for the model
@@ -1506,13 +1505,13 @@ WHERE m.uuid = $dbUUID.uuid
 AND cr.name = $dbName.name
 `, cloudRegionName, modelUUID, cloudRegionUUID)
 		if err != nil {
-			return errors.Annotatef(err, "preparing select cloud region statement")
+			return errors.Errorf("preparing select cloud region statement %w", err)
 		}
 
 		if err := tx.Query(ctx, stmt, modelUUID, cloudRegionName).Get(&cloudRegionUUID); errors.Is(err, sqlair.ErrNoRows) {
-			return fmt.Errorf("%w cloud region %q for model uuid %q", errors.NotFound, region, uuid)
+			return errors.Errorf("%w cloud region %q for model uuid %q", coreerrors.NotFound, region, uuid)
 		} else if err != nil {
-			return fmt.Errorf("getting cloud region %q uuid for model %q: %w", region, uuid, err)
+			return errors.Errorf("getting cloud region %q uuid for model %q: %w", region, uuid, err)
 		}
 	}
 
@@ -1523,27 +1522,26 @@ WHERE uuid = $dbUUID.uuid
 AND cloud_region_uuid IS NULL
 `, modelUUID, cloudRegionUUID)
 	if err != nil {
-		return errors.Annotatef(err, "preparing update cloud region statement")
+		return errors.Errorf("preparing update cloud region statement %w", err)
 	}
 
 	var outcome sqlair.Outcome
 	err = tx.Query(ctx, modelMetadataStmt, cloudRegionUUID, modelUUID).Get(&outcome)
 	if err != nil {
-		return fmt.Errorf(
+		return errors.Errorf(
 			"setting cloud region uuid %q for model uuid %q: %w",
 			cloudRegionUUID.CloudRegionUUID,
 			uuid,
-			err,
-		)
+			err)
+
 	}
 	if num, err := outcome.Result().RowsAffected(); err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	} else if num != 1 {
-		return fmt.Errorf(
-			"model %q already has a cloud region set%w",
-			uuid,
-			errors.Hide(errors.AlreadyExists),
-		)
+		return errors.Errorf(
+			"model %q already has a cloud region set",
+			uuid).Add(coreerrors.AlreadyExists)
+
 	}
 	return nil
 }
@@ -1561,11 +1559,11 @@ func unregisterModelNamespace(
 
 	stmt, err := preparer.Prepare("DELETE from model_namespace WHERE model_uuid = $dbUUID.uuid", mUUID)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	if err := tx.Query(ctx, stmt, mUUID).Run(); err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	return nil
@@ -1583,7 +1581,7 @@ func (s *State) UpdateCredential(
 ) error {
 	db, err := s.DB()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
@@ -1623,21 +1621,21 @@ AND u.removed = false
 AND cc.name = $dbCredKey.cloud_credential_name
 `, selectArgs, dbUpdateCredentialResult{})
 	if err != nil {
-		return internalerrors.Errorf("preparing select cloud credential statement: %w", err)
+		return errors.Errorf("preparing select cloud credential statement: %w", err)
 	}
 
 	var result dbUpdateCredentialResult
 	err = tx.Query(ctx, cloudCredUUIDStmt, selectArgs).Get(&result)
 	if errors.Is(err, sqlair.ErrNoRows) {
-		return fmt.Errorf(
-			"%w cloud credential %q%w",
-			errors.NotFound, key, errors.Hide(err),
-		)
+		return errors.Errorf(
+			"%w cloud credential %q",
+			coreerrors.NotFound, key).Add(err)
+
 	} else if err != nil {
-		return fmt.Errorf(
+		return errors.Errorf(
 			"getting cloud credential uuid for %q: %w",
-			key, err,
-		)
+			key, err)
+
 	}
 
 	updateArgs := dbUpdateCredential{
@@ -1653,21 +1651,23 @@ WHERE uuid= $dbUpdateCredential.uuid
 AND cloud_uuid = $dbUpdateCredential.cloud_uuid
 `, updateArgs)
 	if err != nil {
-		return internalerrors.Errorf("preparing update model cloud credential statement: %w", err)
+		return errors.Errorf("preparing update model cloud credential statement: %w", err)
 	}
 
 	var outcome sqlair.Outcome
 	if err := tx.Query(ctx, updateCloudCredStmt, updateArgs).Get(&outcome); err != nil {
-		return fmt.Errorf(
+		return errors.Errorf(
 			"setting cloud credential %q for model %q: %w",
 			key, uuid, err)
+
 	}
 	if num, err := outcome.Result().RowsAffected(); err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	} else if num != 1 {
-		return fmt.Errorf(
+		return errors.Errorf(
 			"%w model %q has different cloud to credential %q",
-			errors.NotValid, uuid, key)
+			coreerrors.NotValid, uuid, key)
+
 	}
 	return nil
 }
@@ -1704,21 +1704,21 @@ WHERE  at.type = $dbPermission.access_type
 AND    ot.type = $dbPermission.object_type
 `, adminPermission)
 	if err != nil {
-		return errors.Annotatef(err, "preparing add admin permission statement")
+		return errors.Errorf("preparing add admin permission statement %w", err)
 	}
 
 	var outcome sqlair.Outcome
 	err = tx.Query(ctx, permStmt, adminPermission).Get(&outcome)
 	if jujudb.IsErrConstraintUnique(err) {
-		return fmt.Errorf("%w for model %q and owner %q", accesserrors.PermissionAlreadyExists, modelUUID, ownerUUID)
+		return errors.Errorf("%w for model %q and owner %q", accesserrors.PermissionAlreadyExists, modelUUID, ownerUUID)
 	} else if err != nil {
-		return fmt.Errorf("setting permission for model %q: %w", modelUUID, err)
+		return errors.Errorf("setting permission for model %q: %w", modelUUID, err)
 	}
 
 	if num, err := outcome.Result().RowsAffected(); err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	} else if num != 1 {
-		return fmt.Errorf("creating model permission metadata, expected 1 row to be inserted, got %d", num)
+		return errors.Errorf("creating model permission metadata, expected 1 row to be inserted, got %d", num)
 	}
 	return nil
 }

--- a/domain/model/state/controllerstate_test.go
+++ b/domain/model/state/controllerstate_test.go
@@ -12,12 +12,12 @@ import (
 
 	"github.com/canonical/sqlair"
 	"github.com/juju/collections/set"
-	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cloud"
 	corecredential "github.com/juju/juju/core/credential"
+	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/life"
 	coremodel "github.com/juju/juju/core/model"
 	modeltesting "github.com/juju/juju/core/model/testing"
@@ -379,7 +379,7 @@ func (m *stateSuite) TestCreateModelWithInvalidCloudRegion(c *gc.C) {
 			SecretBackend: juju.BackendName,
 		},
 	)
-	c.Assert(err, jc.ErrorIs, errors.NotFound)
+	c.Assert(err, jc.ErrorIs, coreerrors.NotFound)
 }
 
 func (m *stateSuite) TestCreateWithEmptyRegion(c *gc.C) {
@@ -666,7 +666,7 @@ func (m *stateSuite) TestUpdateCredentialForDifferentCloud(c *gc.C) {
 			Name:  "foobar1",
 		},
 	)
-	c.Assert(err, jc.ErrorIs, errors.NotValid)
+	c.Assert(err, jc.ErrorIs, coreerrors.NotValid)
 }
 
 // We are trying to test here that we can set a cloud credential on the model

--- a/domain/model/state/modelstate.go
+++ b/domain/model/state/modelstate.go
@@ -6,7 +6,6 @@ package state
 import (
 	"context"
 	"database/sql"
-	"fmt"
 
 	"github.com/canonical/sqlair"
 	"github.com/juju/version/v2"
@@ -82,7 +81,7 @@ func (s *ModelState) Delete(ctx context.Context, uuid coremodel.UUID) error {
 		if errors.Is(err, sqlair.ErrNoRows) {
 			return errors.New("model does not exist").Add(modelerrors.NotFound)
 		} else if err != nil && !internaldatabase.IsErrError(err) {
-			return fmt.Errorf("deleting model trigger %w", err)
+			return errors.Errorf("deleting model trigger %w", err)
 		}
 
 		var outcome sqlair.Outcome

--- a/domain/model/state/types.go
+++ b/domain/model/state/types.go
@@ -5,10 +5,8 @@ package state
 
 import (
 	"database/sql"
-	"fmt"
 	"time"
 
-	"github.com/juju/errors"
 	"github.com/juju/version/v2"
 
 	"github.com/juju/juju/core/credential"
@@ -16,6 +14,7 @@ import (
 	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/core/user"
+	"github.com/juju/juju/internal/errors"
 )
 
 // dbModel represents the state of a model.
@@ -66,17 +65,17 @@ type dbModel struct {
 func (m *dbModel) toCoreModel() (coremodel.Model, error) {
 	agentVersion, err := version.Parse(m.AgentVersion)
 	if err != nil {
-		return coremodel.Model{}, fmt.Errorf("parsing model %q agent version %q: %w", m.UUID, agentVersion, err)
+		return coremodel.Model{}, errors.Errorf("parsing model %q agent version %q: %w", m.UUID, agentVersion, err)
 	}
 	ownerName, err := user.NewName(m.OwnerName)
 	if err != nil {
-		return coremodel.Model{}, errors.Trace(err)
+		return coremodel.Model{}, errors.Capture(err)
 	}
 	var credOwnerName user.Name
 	if m.CredentialOwnerName != "" {
 		credOwnerName, err = user.NewName(m.CredentialOwnerName)
 		if err != nil {
-			return coremodel.Model{}, errors.Trace(err)
+			return coremodel.Model{}, errors.Capture(err)
 		}
 	}
 
@@ -209,7 +208,7 @@ type dbModelSummary struct {
 func (m dbModelSummary) decodeUserModelSummary(controllerInfo dbController) (coremodel.UserModelSummary, error) {
 	ms, err := m.decodeModelSummary(controllerInfo)
 	if err != nil {
-		return coremodel.UserModelSummary{}, errors.Trace(err)
+		return coremodel.UserModelSummary{}, errors.Capture(err)
 	}
 	return coremodel.UserModelSummary{
 		ModelSummary:       ms,
@@ -225,20 +224,20 @@ func (m dbModelSummary) decodeModelSummary(controllerInfo dbController) (coremod
 		var err error
 		agentVersion, err = version.Parse(m.AgentVersion)
 		if err != nil {
-			return coremodel.ModelSummary{}, errors.Annotatef(
-				err, "parsing model %q agent version %q", m.Name, agentVersion,
-			)
+			return coremodel.ModelSummary{}, errors.Errorf("parsing model %q agent version %q %w", m.Name, agentVersion,
+				err)
+
 		}
 	}
 	ownerName, err := user.NewName(m.OwnerName)
 	if err != nil {
-		return coremodel.ModelSummary{}, errors.Trace(err)
+		return coremodel.ModelSummary{}, errors.Capture(err)
 	}
 	var credOwnerName user.Name
 	if m.CloudCredentialOwnerName != "" {
 		credOwnerName, err = user.NewName(m.CloudCredentialOwnerName)
 		if err != nil {
-			return coremodel.ModelSummary{}, errors.Trace(err)
+			return coremodel.ModelSummary{}, errors.Capture(err)
 		}
 	}
 	return coremodel.ModelSummary{
@@ -297,7 +296,7 @@ type dbModelUserInfo struct {
 func (info *dbModelUserInfo) toModelUserInfo() (coremodel.ModelUserInfo, error) {
 	name, err := user.NewName(info.Name)
 	if err != nil {
-		return coremodel.ModelUserInfo{}, errors.Trace(err)
+		return coremodel.ModelUserInfo{}, errors.Capture(err)
 	}
 
 	return coremodel.ModelUserInfo{

--- a/domain/model/types.go
+++ b/domain/model/types.go
@@ -4,16 +4,16 @@
 package model
 
 import (
-	"fmt"
 	"time"
 
-	"github.com/juju/errors"
 	"github.com/juju/version/v2"
 
 	"github.com/juju/juju/core/credential"
+	coreerrors "github.com/juju/juju/core/errors"
 	coremodel "github.com/juju/juju/core/model"
 	corestatus "github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/user"
+	"github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/internal/uuid"
 )
 
@@ -54,17 +54,17 @@ type ModelCreationArgs struct {
 // error satisfying [errors.NotValid] is returned.
 func (m ModelCreationArgs) Validate() error {
 	if m.Cloud == "" {
-		return fmt.Errorf("%w cloud cannot be empty", errors.NotValid)
+		return errors.Errorf("%w cloud cannot be empty", coreerrors.NotValid)
 	}
 	if m.Name == "" {
-		return fmt.Errorf("%w name cannot be empty", errors.NotValid)
+		return errors.Errorf("%w name cannot be empty", coreerrors.NotValid)
 	}
 	if err := m.Owner.Validate(); err != nil {
-		return fmt.Errorf("%w owner: %w", errors.NotValid, err)
+		return errors.Errorf("%w owner: %w", coreerrors.NotValid, err)
 	}
 	if !m.Credential.IsZero() {
 		if err := m.Credential.Validate(); err != nil {
-			return fmt.Errorf("credential: %w", err)
+			return errors.Errorf("credential: %w", err)
 		}
 	}
 	return nil
@@ -86,11 +86,11 @@ type ModelImportArgs struct {
 // satisfying [errors.NotValid] is returned.
 func (m ModelImportArgs) Validate() error {
 	if err := m.ModelCreationArgs.Validate(); err != nil {
-		return fmt.Errorf("ModelCreationArgs %w", err)
+		return errors.Errorf("ModelCreationArgs %w", err)
 	}
 
 	if err := m.ID.Validate(); err != nil {
-		return fmt.Errorf("validating model import args id: %w", err)
+		return errors.Errorf("validating model import args id: %w", err)
 	}
 
 	return nil

--- a/domain/model/types_test.go
+++ b/domain/model/types_test.go
@@ -4,12 +4,12 @@
 package model
 
 import (
-	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/credential"
+	coreerrors "github.com/juju/juju/core/errors"
 	modeltesting "github.com/juju/juju/core/model/testing"
 	usertesting "github.com/juju/juju/core/user/testing"
 )
@@ -38,7 +38,7 @@ func (*typesSuite) TestModelCreationArgsValidation(c *gc.C) {
 				Name:        "",
 				Owner:       userUUID,
 			},
-			ErrTest: errors.NotValid,
+			ErrTest: coreerrors.NotValid,
 		},
 		{
 			Name: "Test invalid owner",
@@ -48,7 +48,7 @@ func (*typesSuite) TestModelCreationArgsValidation(c *gc.C) {
 				Name:        "my-awesome-model",
 				Owner:       "",
 			},
-			ErrTest: errors.NotValid,
+			ErrTest: coreerrors.NotValid,
 		},
 		{
 			Name: "Test invalid cloud",
@@ -58,7 +58,7 @@ func (*typesSuite) TestModelCreationArgsValidation(c *gc.C) {
 				Name:        "my-awesome-model",
 				Owner:       userUUID,
 			},
-			ErrTest: errors.NotValid,
+			ErrTest: coreerrors.NotValid,
 		},
 		{
 			Name: "Test invalid cloud region",
@@ -81,7 +81,7 @@ func (*typesSuite) TestModelCreationArgsValidation(c *gc.C) {
 				Name:  "my-awesome-model",
 				Owner: userUUID,
 			},
-			ErrTest: errors.NotValid,
+			ErrTest: coreerrors.NotValid,
 		},
 		{
 			Name: "Test happy path without credential key",
@@ -165,7 +165,7 @@ func (*typesSuite) TestModelImportArgsValidation(c *gc.C) {
 				},
 				ID: "not valid",
 			},
-			ErrTest: errors.NotValid,
+			ErrTest: coreerrors.NotValid,
 		},
 	}
 

--- a/domain/modelagent/service/service.go
+++ b/domain/modelagent/service/service.go
@@ -5,7 +5,6 @@ package service
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/juju/version/v2"
 
@@ -197,10 +196,10 @@ func (s *ModelService) WatchMachineTargetAgentVersion(
 
 	w, err := s.WatchModelTargetAgentVersion(ctx)
 	if err != nil {
-		return nil, fmt.Errorf(
+		return nil, errors.Errorf(
 			"getting watcher for machine %q model target agent version: %w",
-			machineName, err,
-		)
+			machineName, err)
+
 	}
 	return w, nil
 }
@@ -254,10 +253,10 @@ func (s *ModelService) WatchUnitTargetAgentVersion(
 
 	w, err := s.WatchModelTargetAgentVersion(ctx)
 	if err != nil {
-		return nil, fmt.Errorf(
+		return nil, errors.Errorf(
 			"getting watcher for unit %q model target agent version: %w",
-			unitName, err,
-		)
+			unitName, err)
+
 	}
 	return w, nil
 }

--- a/domain/modelagent/service/service_test.go
+++ b/domain/modelagent/service/service_test.go
@@ -5,20 +5,20 @@ package service
 
 import (
 	"context"
-	"fmt"
 
-	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/version/v2"
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
+	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/machine"
 	"github.com/juju/juju/core/model"
 	modeltesting "github.com/juju/juju/core/model/testing"
 	applicationerrors "github.com/juju/juju/domain/application/errors"
 	machineerrors "github.com/juju/juju/domain/machine/errors"
 	modelerrors "github.com/juju/juju/domain/model/errors"
+	"github.com/juju/juju/internal/errors"
 )
 
 type suite struct {
@@ -59,7 +59,7 @@ func (s *suite) TestGetModelAgentVersionInvalidModelID(c *gc.C) {
 
 	svc := NewService(s.state)
 	_, err := svc.GetModelTargetAgentVersion(context.Background(), "invalid")
-	c.Check(err, jc.ErrorIs, errors.NotValid)
+	c.Check(err, jc.ErrorIs, coreerrors.NotValid)
 }
 
 // TestGetModelAgentVersionModelNotFound tests that Service.GetModelAgentVersion
@@ -68,7 +68,7 @@ func (s *suite) TestGetModelAgentVersionModelNotFound(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	modelID := modeltesting.GenModelUUID(c)
-	modelNotFoundErr := fmt.Errorf("%w for id %q", modelerrors.NotFound, modelID)
+	modelNotFoundErr := errors.Errorf("%w for id %q", modelerrors.NotFound, modelID)
 	s.state.EXPECT().GetModelTargetAgentVersion(gomock.Any(), modelID).
 		Return(version.Zero, modelNotFoundErr)
 
@@ -192,7 +192,7 @@ func (s *suite) TestWatchModelTargetAgentVersionNotFound(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	modelID := modeltesting.GenModelUUID(c)
-	modelNotFoundErr := fmt.Errorf("%w for id %q", modelerrors.NotFound, modelID)
+	modelNotFoundErr := errors.Errorf("%w for id %q", modelerrors.NotFound, modelID)
 	s.modelState.EXPECT().GetModelUUID(context.Background()).Return(model.UUID(""), modelNotFoundErr)
 
 	_, err := NewModelService(s.modelState, s.state, nil).WatchModelTargetAgentVersion(

--- a/domain/modelconfig/modelmigration/export.go
+++ b/domain/modelconfig/modelmigration/export.go
@@ -7,13 +7,14 @@ import (
 	"context"
 
 	"github.com/juju/description/v8"
-	"github.com/juju/errors"
 
+	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/modelmigration"
 	"github.com/juju/juju/domain/modelconfig/service"
 	"github.com/juju/juju/domain/modelconfig/state"
 	"github.com/juju/juju/domain/modeldefaults"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/internal/errors"
 )
 
 // RegisterExport registers the export operations with the given coordinator.
@@ -57,14 +58,14 @@ func (e *exportOperation) Setup(scope modelmigration.Scope) error {
 func (e *exportOperation) Execute(ctx context.Context, model description.Model) error {
 	config, err := e.service.ModelConfig(ctx)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	// If the config is empty we don't want to export it, mark it as an error.
 	// If we do export with an empty model config, then the import will fail,
 	// which will put us in a worse state than when we started.
 	if config == nil || len(config.AllAttrs()) == 0 {
-		return errors.NotValidf("empty model config")
+		return errors.Errorf("empty model config %w", coreerrors.NotValid)
 	}
 
 	model.UpdateConfig(config.AllAttrs())
@@ -77,5 +78,5 @@ type noopModelDefaultsProvider struct{}
 // ModelDefaults will return the default config values to be used for a model
 // and its config.
 func (noopModelDefaultsProvider) ModelDefaults(context.Context) (modeldefaults.Defaults, error) {
-	return modeldefaults.Defaults{}, errors.NotSupportedf("model defaults")
+	return modeldefaults.Defaults{}, errors.Errorf("model defaults %w", coreerrors.NotSupported)
 }

--- a/domain/modelconfig/modelmigration/export_test.go
+++ b/domain/modelconfig/modelmigration/export_test.go
@@ -7,11 +7,11 @@ import (
 	"context"
 
 	"github.com/juju/description/v8"
-	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
+	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/environs/config"
 )
 
@@ -54,7 +54,7 @@ func (s *exportSuite) TestNilModelConfig(c *gc.C) {
 
 	op := s.newExportOperation()
 	err := op.Execute(context.Background(), model)
-	c.Assert(err, jc.ErrorIs, errors.NotValid)
+	c.Assert(err, jc.ErrorIs, coreerrors.NotValid)
 }
 
 func (s *exportSuite) TestEmptyModelConfig(c *gc.C) {
@@ -68,7 +68,7 @@ func (s *exportSuite) TestEmptyModelConfig(c *gc.C) {
 
 	op := s.newExportOperation()
 	err := op.Execute(context.Background(), model)
-	c.Assert(err, jc.ErrorIs, errors.NotValid)
+	c.Assert(err, jc.ErrorIs, coreerrors.NotValid)
 }
 
 func (s *exportSuite) TestModelConfig(c *gc.C) {

--- a/domain/modelconfig/modelmigration/import.go
+++ b/domain/modelconfig/modelmigration/import.go
@@ -7,12 +7,13 @@ import (
 	"context"
 
 	"github.com/juju/description/v8"
-	"github.com/juju/errors"
 
+	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/modelmigration"
 	"github.com/juju/juju/domain/modelconfig/service"
 	"github.com/juju/juju/domain/modelconfig/state"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/internal/errors"
 )
 
 // Coordinator is the interface that is used to add operations to a migration.
@@ -70,11 +71,11 @@ func (i *importOperation) Execute(ctx context.Context, model description.Model) 
 	// If we don't have any model config, then there is something seriously
 	// wrong. In this case, we should return an error.
 	if len(attrs) == 0 {
-		return errors.NotValidf("model config")
+		return errors.Errorf("model config %w", coreerrors.NotValid)
 	}
 
 	if err := i.service.SetModelConfig(ctx, attrs); err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	return nil
 }

--- a/domain/modelconfig/modelmigration/import_test.go
+++ b/domain/modelconfig/modelmigration/import_test.go
@@ -7,11 +7,11 @@ import (
 	"context"
 
 	"github.com/juju/description/v8"
-	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
+	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/environs/config"
 )
 
@@ -49,7 +49,7 @@ func (s *importSuite) TestEmptyModelConfig(c *gc.C) {
 
 	op := s.newImportOperation()
 	err := op.Execute(context.Background(), model)
-	c.Assert(err, jc.ErrorIs, errors.NotValid)
+	c.Assert(err, jc.ErrorIs, coreerrors.NotValid)
 }
 
 func (s *importSuite) TestModelConfig(c *gc.C) {

--- a/domain/modelconfig/service/providerservice.go
+++ b/domain/modelconfig/service/providerservice.go
@@ -5,7 +5,6 @@ package service
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/juju/collections/transform"
 
@@ -13,6 +12,7 @@ import (
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/core/watcher/eventsource"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/internal/errors"
 )
 
 // ProviderState defines the state methods required by the ProviderService.
@@ -46,7 +46,7 @@ func NewProviderService(
 func (s *ProviderService) ModelConfig(ctx context.Context) (*config.Config, error) {
 	stConfig, err := s.st.ModelConfig(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("getting model config from state: %w", err)
+		return nil, errors.Errorf("getting model config from state: %w", err)
 	}
 
 	altConfig := transform.Map(stConfig, func(k, v string) (string, any) { return k, v })

--- a/domain/modelconfig/service/service.go
+++ b/domain/modelconfig/service/service.go
@@ -5,10 +5,8 @@ package service
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/juju/collections/transform"
-	"github.com/juju/errors"
 
 	"github.com/juju/juju/core/changestream"
 	"github.com/juju/juju/core/watcher"
@@ -16,6 +14,7 @@ import (
 	"github.com/juju/juju/domain/modelconfig/validators"
 	"github.com/juju/juju/domain/modeldefaults"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/internal/errors"
 )
 
 // ModelDefaultsProvider is responsible for providing the default config values
@@ -89,12 +88,12 @@ func NewService(
 func (s *Service) ModelConfig(ctx context.Context) (*config.Config, error) {
 	stConfig, err := s.st.ModelConfig(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("getting model config from state: %w", err)
+		return nil, errors.Errorf("getting model config from state: %w", err)
 	}
 
 	agentVersion, err := s.st.AgentVersion(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("getting model agent version for model config: %w", err)
+		return nil, errors.Errorf("getting model agent version for model config: %w", err)
 	}
 
 	altConfig := transform.Map(stConfig, func(k, v string) (string, any) { return k, v })
@@ -118,7 +117,7 @@ func (s *Service) ModelConfigValues(
 
 	defaults, err := s.defaultsProvider.ModelDefaults(ctx)
 	if err != nil {
-		return config.ConfigValues{}, fmt.Errorf("getting model defaults: %w", err)
+		return config.ConfigValues{}, errors.Errorf("getting model defaults: %w", err)
 	}
 
 	allAttrs := cfg.AllAttrs()
@@ -159,12 +158,12 @@ func (s *Service) buildUpdatedModelConfig(
 
 	newConf, err := current.Remove(removeAttrs)
 	if err != nil {
-		return newConf, current, fmt.Errorf("building new model config with removed attributes: %w", err)
+		return newConf, current, errors.Errorf("building new model config with removed attributes: %w", err)
 	}
 
 	newConf, err = newConf.Apply(updates)
 	if err != nil {
-		return newConf, current, fmt.Errorf("building new model config with removed attributes: %w", err)
+		return newConf, current, errors.Errorf("building new model config with removed attributes: %w", err)
 	}
 
 	return newConf, current, nil
@@ -184,12 +183,12 @@ func (s *Service) reconcileRemovedAttributes(
 	updates := map[string]any{}
 	hasAttrs, err := s.st.ModelConfigHasAttributes(ctx, removeAttrs)
 	if err != nil {
-		return updates, fmt.Errorf("determining model config has attributes: %w", err)
+		return updates, errors.Errorf("determining model config has attributes: %w", err)
 	}
 
 	defaults, err := s.defaultsProvider.ModelDefaults(ctx)
 	if err != nil {
-		return updates, fmt.Errorf("getting model defaults for config attribute removal: %w", err)
+		return updates, errors.Errorf("getting model defaults for config attribute removal: %w", err)
 	}
 
 	for _, attr := range hasAttrs {
@@ -210,7 +209,7 @@ func (s *Service) SetModelConfig(
 ) error {
 	defaults, err := s.defaultsProvider.ModelDefaults(ctx)
 	if err != nil {
-		return fmt.Errorf("getting model defaults: %w", err)
+		return errors.Errorf("getting model defaults: %w", err)
 	}
 
 	// We want to make a copy of cfg so that we don't modify the users input.
@@ -228,17 +227,17 @@ func (s *Service) SetModelConfig(
 
 	setCfg, err := config.New(config.NoDefaults, cfgCopy)
 	if err != nil {
-		return fmt.Errorf("constructing new model config with model defaults: %w", err)
+		return errors.Errorf("constructing new model config with model defaults: %w", err)
 	}
 
 	_, err = s.validatorForSetModelConfig().Validate(ctx, setCfg, nil)
 	if err != nil {
-		return fmt.Errorf("validating model config to set for model: %w", err)
+		return errors.Errorf("validating model config to set for model: %w", err)
 	}
 
 	rawCfg, err := CoerceConfigForStorage(setCfg.AllAttrs())
 	if err != nil {
-		return fmt.Errorf("coercing model config for storage: %w", err)
+		return errors.Errorf("coercing model config for storage: %w", err)
 	}
 
 	return s.st.SetModelConfig(ctx, rawCfg)
@@ -272,7 +271,7 @@ func (s *Service) UpdateModelConfig(
 
 	updates, err := s.reconcileRemovedAttributes(ctx, removeAttrs)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	// It's important here that we apply the user updates over the top of the
@@ -284,22 +283,22 @@ func (s *Service) UpdateModelConfig(
 
 	newCfg, currCfg, err := s.buildUpdatedModelConfig(ctx, updates, removeAttrs)
 	if err != nil {
-		return fmt.Errorf("making updated model configuration: %w", err)
+		return errors.Errorf("making updated model configuration: %w", err)
 	}
 
 	_, err = s.validatorForUpdateModelConfig().Validate(ctx, newCfg, currCfg)
 	if err != nil {
-		return fmt.Errorf("validating updated model configuration: %w", err)
+		return errors.Errorf("validating updated model configuration: %w", err)
 	}
 
 	rawCfg, err := CoerceConfigForStorage(updateAttrs)
 	if err != nil {
-		return fmt.Errorf("coercing new configuration for persistence: %w", err)
+		return errors.Errorf("coercing new configuration for persistence: %w", err)
 	}
 
 	err = s.st.UpdateModelConfig(ctx, rawCfg, removeAttrs)
 	if err != nil {
-		return fmt.Errorf("updating model config: %w", err)
+		return errors.Errorf("updating model config: %w", err)
 	}
 	return nil
 }

--- a/domain/modelconfig/service/testing/state.go
+++ b/domain/modelconfig/service/testing/state.go
@@ -5,11 +5,11 @@ package testing
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/juju/juju/core/changestream"
 	jujuversion "github.com/juju/juju/core/version"
 	"github.com/juju/juju/domain/testing"
+	"github.com/juju/juju/internal/errors"
 )
 
 // MemoryState implements an in memory representation of the state required for
@@ -37,7 +37,7 @@ func (s *MemoryState) AllKeysQuery() string {
 // then an error is returned.
 func (s *MemoryState) KeysQuery(query string) ([]string, error) {
 	if query != allKeysQuery {
-		return []string{}, fmt.Errorf("unexpected all keys query %q", query)
+		return []string{}, errors.Errorf("unexpected all keys query %q", query)
 	}
 
 	keys := make([]string, 0, len(s.Config))
@@ -94,7 +94,7 @@ func (s *MemoryState) SetModelConfig(
 
 	changes, err := s.KeysQuery(allKeysQuery)
 	if err != nil {
-		return fmt.Errorf("getting model config keys")
+		return errors.Errorf("getting model config keys")
 	}
 	return s.FeedChange(ctx, "model_config", changestream.Create, changes)
 }
@@ -121,7 +121,7 @@ func (s *MemoryState) UpdateModelConfig(
 	// update changes. For now this will do.
 	changes, err := s.KeysQuery(allKeysQuery)
 	if err != nil {
-		return fmt.Errorf("getting model config keys")
+		return errors.Errorf("getting model config keys")
 	}
 	changes = append(changes, remove...)
 	return s.FeedChange(ctx, "model_config", changestream.Update, changes)

--- a/domain/modelconfig/state/state.go
+++ b/domain/modelconfig/state/state.go
@@ -6,13 +6,13 @@ package state
 import (
 	"context"
 	"database/sql"
-	"fmt"
 
 	"github.com/canonical/sqlair"
-	"github.com/juju/errors"
 
 	coredatabase "github.com/juju/juju/core/database"
+	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/domain"
+	"github.com/juju/juju/internal/errors"
 )
 
 // State is a reference to the underlying data accessor for ModelConfig data.
@@ -32,7 +32,7 @@ func NewState(factory coredatabase.TxnRunnerFactory) *State {
 func (st *State) AgentVersion(ctx context.Context) (string, error) {
 	db, err := st.DB()
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", errors.Capture(err)
 	}
 
 	q := `SELECT &dbAgentVersion.target_agent_version FROM model`
@@ -41,20 +41,20 @@ func (st *State) AgentVersion(ctx context.Context) (string, error) {
 
 	stmt, err := st.Prepare(q, rval)
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", errors.Capture(err)
 	}
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err := tx.Query(ctx, stmt).Get(&rval)
 		if errors.Is(err, sql.ErrNoRows) {
-			return fmt.Errorf("agent version %w", errors.NotFound)
+			return errors.Errorf("agent version %w", coreerrors.NotFound)
 		} else if err != nil {
-			return fmt.Errorf("retrieving current agent version: %w", err)
+			return errors.Errorf("retrieving current agent version: %w", err)
 		}
 		return nil
 	})
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", errors.Capture(err)
 	}
 
 	return rval.TargetAgentVersion, nil
@@ -73,21 +73,21 @@ func (st *State) ModelConfigHasAttributes(
 
 	db, err := st.DB()
 	if err != nil {
-		return rval, errors.Trace(err)
+		return rval, errors.Capture(err)
 	}
 
 	stmt, err := st.Prepare(`
 SELECT &dbKey.key FROM model_config WHERE key IN ($dbKeys[:])
 `, dbKeys{}, dbKey{})
 	if err != nil {
-		return rval, errors.Trace(err)
+		return rval, errors.Capture(err)
 	}
 
 	return rval, db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		var keys []dbKey
 		err := tx.Query(ctx, stmt, dbKeys(attrs)).GetAll(&keys)
 		if err != nil {
-			return fmt.Errorf("getting model config attrs set: %w", err)
+			return errors.Errorf("getting model config attrs set: %w", err)
 		}
 
 		rval = make([]string, len(keys))
@@ -104,18 +104,18 @@ func (st *State) ModelConfig(ctx context.Context) (map[string]string, error) {
 
 	db, err := st.DB()
 	if err != nil {
-		return config, errors.Trace(err)
+		return config, errors.Capture(err)
 	}
 
 	stmt, err := st.Prepare(`SELECT &dbKeyValue.* FROM model_config`, dbKeyValue{})
 	if err != nil {
-		return config, errors.Trace(err)
+		return config, errors.Capture(err)
 	}
 
 	return config, db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		var result []dbKeyValue
 		if err := tx.Query(ctx, stmt).GetAll(&result); err != nil && !errors.Is(err, sql.ErrNoRows) {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		for _, kv := range result {
@@ -134,38 +134,38 @@ func (st *State) SetModelConfig(
 ) error {
 	db, err := st.DB()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	selectQuery := `SELECT &dbKeyValue.* FROM model_config`
 	selectStmt, err := st.Prepare(selectQuery, dbKeyValue{})
 	if err != nil {
-		return fmt.Errorf("preparing select query: %w", err)
+		return errors.Errorf("preparing select query: %w", err)
 	}
 
 	insertQuery := `INSERT INTO model_config (*) VALUES ($dbKeyValue.*)`
 	insertStmt, err := st.Prepare(insertQuery, dbKeyValue{})
 	if err != nil {
-		return fmt.Errorf("preparing insert query: %w", err)
+		return errors.Errorf("preparing insert query: %w", err)
 	}
 
 	updateQuery := `UPDATE model_config SET value = $dbKeyValue.value WHERE key = $dbKeyValue.key`
 	updateStmt, err := st.Prepare(updateQuery, dbKeyValue{})
 	if err != nil {
-		return fmt.Errorf("preparing update query: %w", err)
+		return errors.Errorf("preparing update query: %w", err)
 	}
 
 	deleteQuery := `DELETE FROM model_config WHERE key IN ($dbKeys[:])`
 	deleteStmt, err := st.Prepare(deleteQuery, dbKeys{})
 	if err != nil {
-		return fmt.Errorf("preparing delete query: %w", err)
+		return errors.Errorf("preparing delete query: %w", err)
 	}
 
 	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		var keyValues []dbKeyValue
 		if err := tx.Query(ctx, selectStmt).GetAll(&keyValues); err != nil {
 			if !errors.Is(err, sql.ErrNoRows) {
-				return fmt.Errorf("getting model config values: %w", err)
+				return errors.Errorf("getting model config values: %w", err)
 			}
 		}
 
@@ -215,14 +215,14 @@ func (st *State) SetModelConfig(
 				insertKV = append(insertKV, dbKeyValue{Key: k, Value: v})
 			}
 			if err := tx.Query(ctx, insertStmt, insertKV).Run(); err != nil {
-				return fmt.Errorf("inserting model config values: %w", err)
+				return errors.Errorf("inserting model config values: %w", err)
 			}
 		}
 
 		// Update any keys that have changed.
 		for k, v := range update {
 			if err := tx.Query(ctx, updateStmt, dbKeyValue{Key: k, Value: v}).Run(); err != nil {
-				return fmt.Errorf("updating model config key %q: %w", k, err)
+				return errors.Errorf("updating model config key %q: %w", k, err)
 			}
 		}
 
@@ -233,7 +233,7 @@ func (st *State) SetModelConfig(
 				deleteKeys = append(deleteKeys, k)
 			}
 			if err := tx.Query(ctx, deleteStmt, deleteKeys).Run(); err != nil {
-				return fmt.Errorf("deleting model config keys: %w", err)
+				return errors.Errorf("deleting model config keys: %w", err)
 			}
 		}
 
@@ -251,12 +251,12 @@ func (st *State) UpdateModelConfig(
 ) error {
 	db, err := st.DB()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	deleteStmt, err := st.Prepare(`DELETE FROM model_config WHERE key IN ($dbKeys[:])`, dbKeys{})
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	upsertStmt, err := st.Prepare(`
@@ -266,19 +266,19 @@ SET value = excluded.value
 WHERE key = excluded.key
 `[1:], dbKeyValue{})
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		if len(removeAttrs) != 0 {
 			if err := tx.Query(ctx, deleteStmt, dbKeys(removeAttrs)).Run(); err != nil {
-				return fmt.Errorf("removing model config keys: %w", err)
+				return errors.Errorf("removing model config keys: %w", err)
 			}
 		}
 
 		for k, v := range updateAttrs {
 			if err := tx.Query(ctx, upsertStmt, dbKeyValue{Key: k, Value: v}).Run(); err != nil {
-				return errors.Trace(err)
+				return errors.Capture(err)
 			}
 		}
 		return nil
@@ -289,12 +289,12 @@ WHERE key = excluded.key
 func (st *State) SpaceExists(ctx context.Context, spaceName string) (bool, error) {
 	db, err := st.DB()
 	if err != nil {
-		return false, errors.Trace(err)
+		return false, errors.Capture(err)
 	}
 
 	stmt, err := st.Prepare(`SELECT &dbSpace.* FROM space WHERE name = $dbSpace.name`, dbSpace{})
 	if err != nil {
-		return false, errors.Trace(err)
+		return false, errors.Capture(err)
 	}
 
 	var exists bool
@@ -302,7 +302,7 @@ func (st *State) SpaceExists(ctx context.Context, spaceName string) (bool, error
 		if err := tx.Query(ctx, stmt, dbSpace{Space: spaceName}).Get(&dbSpace{}); errors.Is(err, sql.ErrNoRows) {
 			return nil
 		} else if err != nil {
-			return errors.Annotatef(err, "checking space %q exists", spaceName)
+			return errors.Errorf("checking space %q exists %w", spaceName, err)
 		}
 		exists = true
 		return nil

--- a/domain/modelconfig/state/state_test.go
+++ b/domain/modelconfig/state/state_test.go
@@ -7,10 +7,10 @@ import (
 	"context"
 	"database/sql"
 
-	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/domain/modelconfig/state"
 	schematesting "github.com/juju/juju/domain/schema/testing"
 )
@@ -147,7 +147,7 @@ func (s *stateSuite) TestSetModelConfig(c *gc.C) {
 func (s *stateSuite) TestAgentVersionNotFound(c *gc.C) {
 	st := state.NewState(s.TxnRunnerFactory())
 	version, err := st.AgentVersion(context.Background())
-	c.Check(err, jc.ErrorIs, errors.NotFound)
+	c.Check(err, jc.ErrorIs, coreerrors.NotFound)
 	c.Check(version, gc.Equals, "")
 }
 

--- a/domain/modelconfig/validators/validators.go
+++ b/domain/modelconfig/validators/validators.go
@@ -7,10 +7,10 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/juju/errors"
 	"github.com/juju/loggo/v2"
 
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/internal/errors"
 )
 
 // CharmhubURLChange returns a config validator that will check to make sure
@@ -55,7 +55,7 @@ func AgentVersionChange() config.ValidatorFunc {
 
 		cfg, err := cfg.Remove([]string{config.AgentVersionKey})
 		if err != nil {
-			return cfg, fmt.Errorf("removing agent version key from model config: %w", err)
+			return cfg, errors.Errorf("removing agent version key from model config: %w", err)
 		}
 		return cfg, nil
 	}
@@ -112,7 +112,7 @@ func SpaceChecker(provider SpaceProvider) config.ValidatorFunc {
 
 		has, err := provider.HasSpace(ctx, spaceName)
 		if err != nil {
-			return cfg, fmt.Errorf("checking for space %q existence to validate model config: %w", spaceName, err)
+			return cfg, errors.Errorf("checking for space %q existence to validate model config: %w", spaceName, err)
 		}
 
 		if !has {
@@ -166,13 +166,13 @@ func LoggingTracePermissionChecker(canTrace bool) config.ValidatorFunc {
 		}
 
 		if !canTrace && haveTrace {
-			return cfg, fmt.Errorf(
+			return cfg, errors.Errorf(
 				"%w %w",
 				ErrorLogTracingPermission,
 				&config.ValidationError{
 					InvalidAttrs: []string{config.LoggingConfigKey},
-				},
-			)
+				})
+
 		}
 
 		return cfg, nil

--- a/domain/modelconfig/validators/validators_test.go
+++ b/domain/modelconfig/validators/validators_test.go
@@ -6,11 +6,11 @@ package validators
 import (
 	"context"
 
-	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/internal/testing"
 )
 

--- a/domain/modeldefaults/bootstrap/bootstrap.go
+++ b/domain/modeldefaults/bootstrap/bootstrap.go
@@ -5,7 +5,6 @@ package bootstrap
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/canonical/sqlair"
 
@@ -98,7 +97,7 @@ func SetCloudDefaults(
 	return func(ctx context.Context, controller, _ database.TxnRunner) error {
 		strDefaults, err := modelconfigservice.CoerceConfigForStorage(defaults)
 		if err != nil {
-			return fmt.Errorf("coercing cloud %q default values for storage: %w", cloudName, err)
+			return errors.Errorf("coercing cloud %q default values for storage: %w", cloudName, err)
 		}
 
 		err = controller.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
@@ -106,7 +105,7 @@ func SetCloudDefaults(
 		})
 
 		if err != nil {
-			return fmt.Errorf("setting cloud %q bootstrap defaults: %w", cloudName, err)
+			return errors.Errorf("setting cloud %q bootstrap defaults: %w", cloudName, err)
 		}
 		return nil
 	}

--- a/domain/network/errors/errors.go
+++ b/domain/network/errors/errors.go
@@ -3,9 +3,7 @@
 
 package errors
 
-import (
-	"github.com/juju/errors"
-)
+import "github.com/juju/juju/internal/errors"
 
 const (
 	// SpaceAlreadyExists is returned when a space already exists.

--- a/domain/network/modelmigration/export.go
+++ b/domain/network/modelmigration/export.go
@@ -7,13 +7,13 @@ import (
 	"context"
 
 	"github.com/juju/description/v8"
-	"github.com/juju/errors"
 
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/modelmigration"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/domain/network/service"
 	"github.com/juju/juju/domain/network/state"
+	"github.com/juju/juju/internal/errors"
 )
 
 // RegisterExport registers the export operations with the given coordinator.
@@ -57,7 +57,7 @@ func (e *exportOperation) Setup(scope modelmigration.Scope) error {
 func (e *exportOperation) Execute(ctx context.Context, model description.Model) error {
 	spaces, err := e.exportService.GetAllSpaces(ctx)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	for _, space := range spaces {
 		// We do not export the alpha space because it is created by default
@@ -77,7 +77,7 @@ func (e *exportOperation) Execute(ctx context.Context, model description.Model) 
 	// Export subnets.
 	subnets, err := e.exportService.GetAllSubnets(ctx)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	for _, subnet := range subnets {
 		args := description.SubnetArgs{

--- a/domain/network/modelmigration/export_test.go
+++ b/domain/network/modelmigration/export_test.go
@@ -7,11 +7,11 @@ import (
 	"context"
 
 	"github.com/juju/description/v8"
-	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
+	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/network"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 )
@@ -95,7 +95,7 @@ func (s *exportSuite) TestExportSpacesNotFound(c *gc.C) {
 	dst := description.NewModel(description.ModelArgs{})
 
 	s.exportService.EXPECT().GetAllSpaces(gomock.Any()).
-		Return(nil, errors.NotFound)
+		Return(nil, coreerrors.NotFound)
 
 	op := s.newExportOperation(c)
 	err := op.Execute(context.Background(), dst)
@@ -110,7 +110,7 @@ func (s *exportSuite) TestExportSubnetsNotFound(c *gc.C) {
 	s.exportService.EXPECT().GetAllSpaces(gomock.Any()).
 		Return(nil, nil)
 	s.exportService.EXPECT().GetAllSubnets(gomock.Any()).
-		Return(nil, errors.NotFound)
+		Return(nil, coreerrors.NotFound)
 
 	op := s.newExportOperation(c)
 	err := op.Execute(context.Background(), dst)

--- a/domain/network/modelmigration/import.go
+++ b/domain/network/modelmigration/import.go
@@ -7,13 +7,13 @@ import (
 	"context"
 
 	"github.com/juju/description/v8"
-	"github.com/juju/errors"
 
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/modelmigration"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/domain/network/service"
 	"github.com/juju/juju/domain/network/state"
+	"github.com/juju/juju/internal/errors"
 )
 
 // Coordinator is the interface that is used to add operations to a migration.
@@ -73,7 +73,7 @@ func (i *importOperation) Execute(ctx context.Context, model description.Model) 
 		}
 		spaceID, err := i.importService.AddSpace(ctx, spaceInfo)
 		if err != nil {
-			return errors.Annotatef(err, "creating space %s", space.Name())
+			return errors.Errorf("creating space %s %w", space.Name(), err)
 		}
 		// Update the space IDs mapping, which we need for subnets
 		// import. We do this for the pre-4.0 migrations, where
@@ -101,7 +101,7 @@ func (i *importOperation) Execute(ctx context.Context, model description.Model) 
 		if ok {
 			space, err := i.importService.Space(ctx, importedSpaceID)
 			if err != nil {
-				return errors.Annotatef(err, "retrieving space with ID %s to import subnet %s", importedSpaceID, subnet.ID())
+				return errors.Errorf("retrieving space with ID %s to import subnet %s %w", importedSpaceID, subnet.ID(), err)
 			}
 			subnetInfo.SpaceID = importedSpaceID
 			subnetInfo.SpaceName = string(space.Name)
@@ -110,7 +110,7 @@ func (i *importOperation) Execute(ctx context.Context, model description.Model) 
 
 		_, err := i.importService.AddSubnet(ctx, subnetInfo)
 		if err != nil {
-			return errors.Annotatef(err, "creating subnet %s", subnet.CIDR())
+			return errors.Errorf("creating subnet %s %w", subnet.CIDR(), err)
 		}
 	}
 

--- a/domain/network/service/space.go
+++ b/domain/network/service/space.go
@@ -10,15 +10,16 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/juju/collections/set"
-	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 
+	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/providertracker"
 	networkerrors "github.com/juju/juju/domain/network/errors"
 	"github.com/juju/juju/environs/envcontext"
+	"github.com/juju/juju/internal/errors"
 )
 
 // Service provides the API for working with spaces.
@@ -40,14 +41,14 @@ func NewService(st State, logger logger.Logger) *Service {
 // AddSpace creates and returns a new space.
 func (s *Service) AddSpace(ctx context.Context, space network.SpaceInfo) (network.Id, error) {
 	if !names.IsValidSpace(string(space.Name)) {
-		return "", errors.NotValidf("space name %q%w", space.Name, errors.Hide(networkerrors.SpaceNameNotValid))
+		return "", errors.Errorf("space name %q%w %w", space.Name, errors.Hide(networkerrors.SpaceNameNotValid), coreerrors.NotValid)
 	}
 
 	spaceID := space.ID
 	if spaceID == "" {
 		uuid, err := uuid.NewV7()
 		if err != nil {
-			return "", errors.Annotatef(err, "creating uuid for new space %q", space.Name)
+			return "", errors.Errorf("creating uuid for new space %q %w", space.Name, err)
 		}
 		spaceID = uuid.String()
 	}
@@ -57,7 +58,7 @@ func (s *Service) AddSpace(ctx context.Context, space network.SpaceInfo) (networ
 		subnetIDs[i] = subnet.ID.String()
 	}
 	if err := s.st.AddSpace(ctx, spaceID, string(space.Name), space.ProviderId, subnetIDs); err != nil {
-		return "", errors.Trace(err)
+		return "", errors.Capture(err)
 	}
 	return network.Id(spaceID), nil
 }
@@ -66,7 +67,7 @@ func (s *Service) AddSpace(ctx context.Context, space network.SpaceInfo) (networ
 // space is not found, an error is returned matching
 // [github.com/juju/juju/domain/network/errors.SpaceNotFound].
 func (s *Service) UpdateSpace(ctx context.Context, uuid string, name string) error {
-	return errors.Trace(s.st.UpdateSpace(ctx, uuid, name))
+	return errors.Capture(s.st.UpdateSpace(ctx, uuid, name))
 }
 
 // Space returns a space from state that matches the input ID. If the space is
@@ -75,7 +76,7 @@ func (s *Service) UpdateSpace(ctx context.Context, uuid string, name string) err
 func (s *Service) Space(ctx context.Context, uuid string) (*network.SpaceInfo, error) {
 	sp, err := s.st.GetSpace(ctx, uuid)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	return sp, nil
 }
@@ -86,7 +87,7 @@ func (s *Service) Space(ctx context.Context, uuid string) (*network.SpaceInfo, e
 func (s *Service) SpaceByName(ctx context.Context, name string) (*network.SpaceInfo, error) {
 	sp, err := s.st.GetSpaceByName(ctx, name)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	return sp, nil
 }
@@ -95,7 +96,7 @@ func (s *Service) SpaceByName(ctx context.Context, name string) (*network.SpaceI
 func (s *Service) GetAllSpaces(ctx context.Context) (network.SpaceInfos, error) {
 	spaces, err := s.st.GetAllSpaces(ctx)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	return spaces, nil
 }
@@ -104,7 +105,7 @@ func (s *Service) GetAllSpaces(ctx context.Context) (network.SpaceInfos, error) 
 // found, an error is returned matching
 // [github.com/juju/juju/domain/network/errors.SpaceNotFound].
 func (s *Service) RemoveSpace(ctx context.Context, uuid string) error {
-	return errors.Trace(s.st.DeleteSpace(ctx, uuid))
+	return errors.Capture(s.st.DeleteSpace(ctx, uuid))
 }
 
 // ProviderService provides the API for working with network spaces.
@@ -133,33 +134,33 @@ func (s *ProviderService) ReloadSpaces(ctx context.Context) error {
 	callContext := envcontext.WithoutCredentialInvalidator(ctx)
 
 	networkProvider, err := s.provider(ctx)
-	if errors.Is(err, errors.NotSupported) {
-		return errors.NotSupportedf("spaces discovery in a non-networking environ")
+	if errors.Is(err, coreerrors.NotSupported) {
+		return errors.Errorf("spaces discovery in a non-networking environ %w", coreerrors.NotSupported)
 	}
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	canDiscoverSpaces, err := networkProvider.SupportsSpaceDiscovery()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	if canDiscoverSpaces {
 		spaces, err := networkProvider.Spaces(callContext)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		s.Service.logger.Infof("discovered spaces: %s", spaces.String())
 
 		providerSpaces := NewProviderSpaces(s, s.logger)
 		if err := providerSpaces.saveSpaces(ctx, spaces); err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		warnings, err := providerSpaces.deleteSpaces(ctx)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		for _, warning := range warnings {
 			s.Service.logger.Tracef(warning)
@@ -170,11 +171,11 @@ func (s *ProviderService) ReloadSpaces(ctx context.Context) error {
 	s.Service.logger.Debugf("environ does not support space discovery, falling back to subnet discovery")
 	subnets, err := networkProvider.Subnets(callContext, instance.UnknownId, nil)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	// TODO(nvinuesa): Here, the alpha space is scaffolding, it should be
 	// replaced with the model's default space.
-	return errors.Trace(s.saveProviderSubnets(ctx, subnets, network.AlphaSpaceId))
+	return errors.Capture(s.saveProviderSubnets(ctx, subnets, network.AlphaSpaceId))
 }
 
 // SaveProviderSubnets loads subnets into state.
@@ -190,7 +191,7 @@ func (s *ProviderService) saveProviderSubnets(
 	for _, subnet := range subnets {
 		ip, _, err := net.ParseCIDR(subnet.CIDR)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		if ip.IsInterfaceLocalMulticast() || ip.IsLinkLocalMulticast() || ip.IsLinkLocalUnicast() {
 			continue
@@ -203,7 +204,7 @@ func (s *ProviderService) saveProviderSubnets(
 	}
 
 	if len(subnetsToUpsert) > 0 {
-		return errors.Trace(s.upsertProviderSubnets(ctx, subnetsToUpsert))
+		return errors.Capture(s.upsertProviderSubnets(ctx, subnetsToUpsert))
 	}
 
 	return nil
@@ -217,14 +218,14 @@ func (s *ProviderService) upsertProviderSubnets(ctx context.Context, subnetsToUp
 		if sn.ID.String() == "" {
 			uuid, err := uuid.NewV7()
 			if err != nil {
-				return errors.Trace(err)
+				return errors.Capture(err)
 			}
 			subnetsToUpsert[i].ID = network.Id(uuid.String())
 		}
 
 	}
-	if err := s.st.UpsertSubnets(ctx, subnetsToUpsert); err != nil && !errors.Is(err, errors.AlreadyExists) {
-		return errors.Trace(err)
+	if err := s.st.UpsertSubnets(ctx, subnetsToUpsert); err != nil && !errors.Is(err, coreerrors.AlreadyExists) {
+		return errors.Capture(err)
 	}
 	return nil
 }
@@ -232,10 +233,10 @@ func (s *ProviderService) upsertProviderSubnets(ctx context.Context, subnetsToUp
 // SupportsSpaces returns whether the provider supports spaces.
 func (s *ProviderService) SupportsSpaces(ctx context.Context) (bool, error) {
 	networkProvider, err := s.provider(ctx)
-	if errors.Is(err, errors.NotSupported) {
+	if errors.Is(err, coreerrors.NotSupported) {
 		return false, nil
 	} else if err != nil {
-		return false, errors.Trace(err)
+		return false, errors.Capture(err)
 	}
 	return networkProvider.SupportsSpaces()
 }
@@ -244,10 +245,10 @@ func (s *ProviderService) SupportsSpaces(ctx context.Context) (bool, error) {
 // spaces from the provider.
 func (s *ProviderService) SupportsSpaceDiscovery(ctx context.Context) (bool, error) {
 	networkProvider, err := s.provider(ctx)
-	if errors.Is(err, errors.NotSupported) {
+	if errors.Is(err, coreerrors.NotSupported) {
 		return false, nil
 	} else if err != nil {
-		return false, errors.Trace(err)
+		return false, errors.Capture(err)
 	}
 	return networkProvider.SupportsSpaceDiscovery()
 }
@@ -279,7 +280,7 @@ func NewProviderSpaces(spaceService *ProviderService, logger logger.Logger) *Pro
 func (s *ProviderSpaces) saveSpaces(ctx context.Context, providerSpaces []network.SpaceInfo) error {
 	stateSpaces, err := s.spaceService.GetAllSpaces(ctx)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	spaceNames := set.NewStrings()
 	for _, space := range stateSpaces {
@@ -308,7 +309,7 @@ func (s *ProviderSpaces) saveSpaces(ctx context.Context, providerSpaces []networ
 				},
 			)
 			if err != nil {
-				return errors.Trace(err)
+				return errors.Capture(err)
 			}
 
 			spaceNames.Add(spaceName)
@@ -325,7 +326,7 @@ func (s *ProviderSpaces) saveSpaces(ctx context.Context, providerSpaces []networ
 
 		err = s.spaceService.saveProviderSubnets(ctx, spaceInfo.Subnets, spaceID)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		s.updatedSpaces.Add(spaceInfo.ProviderId)
@@ -397,7 +398,7 @@ func (s *ProviderSpaces) deleteSpaces(ctx context.Context) ([]string, error) {
 		// ignore them for now.
 
 		if err := s.spaceService.RemoveSpace(ctx, space.ID); err != nil {
-			return warnings, errors.Trace(err)
+			return warnings, errors.Capture(err)
 		}
 	}
 

--- a/domain/network/service/space.go
+++ b/domain/network/service/space.go
@@ -41,7 +41,7 @@ func NewService(st State, logger logger.Logger) *Service {
 // AddSpace creates and returns a new space.
 func (s *Service) AddSpace(ctx context.Context, space network.SpaceInfo) (network.Id, error) {
 	if !names.IsValidSpace(string(space.Name)) {
-		return "", errors.Errorf("space name %q%w %w", space.Name, errors.Hide(networkerrors.SpaceNameNotValid), coreerrors.NotValid)
+		return "", errors.Errorf("space name %q not valid", space.Name).Add(networkerrors.SpaceNameNotValid)
 	}
 
 	spaceID := space.ID

--- a/domain/network/service/subnet.go
+++ b/domain/network/service/subnet.go
@@ -7,9 +7,10 @@ import (
 	"context"
 
 	"github.com/google/uuid"
-	"github.com/juju/errors"
 
+	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/internal/errors"
 )
 
 // AddSubnet creates and returns a new subnet.
@@ -17,13 +18,13 @@ func (s *Service) AddSubnet(ctx context.Context, args network.SubnetInfo) (netwo
 	if args.ID == "" {
 		uuid, err := uuid.NewV7()
 		if err != nil {
-			return "", errors.Annotatef(err, "creating uuid for new subnet with CIDR %q", args.CIDR)
+			return "", errors.Errorf("creating uuid for new subnet with CIDR %q %w", args.CIDR, err)
 		}
 		args.ID = network.Id(uuid.String())
 	}
 
-	if err := s.st.AddSubnet(ctx, args); err != nil && !errors.Is(err, errors.AlreadyExists) {
-		return "", errors.Trace(err)
+	if err := s.st.AddSubnet(ctx, args); err != nil && !errors.Is(err, coreerrors.AlreadyExists) {
+		return "", errors.Capture(err)
 	}
 
 	return args.ID, nil
@@ -32,29 +33,29 @@ func (s *Service) AddSubnet(ctx context.Context, args network.SubnetInfo) (netwo
 // GetAllSubnets returns all the subnets for the model.
 func (s *Service) GetAllSubnets(ctx context.Context) (network.SubnetInfos, error) {
 	allSubnets, err := s.st.GetAllSubnets(ctx)
-	return allSubnets, errors.Trace(err)
+	return allSubnets, errors.Capture(err)
 }
 
 // Subnet returns the subnet identified by the input UUID,
 // or an error if it is not found.
 func (s *Service) Subnet(ctx context.Context, uuid string) (*network.SubnetInfo, error) {
 	subnet, err := s.st.GetSubnet(ctx, uuid)
-	return subnet, errors.Trace(err)
+	return subnet, errors.Capture(err)
 }
 
 // SubnetsByCIDR returns the subnets matching the input CIDRs.
 func (s *Service) SubnetsByCIDR(ctx context.Context, cidrs ...string) ([]network.SubnetInfo, error) {
 	subnets, err := s.st.GetSubnetsByCIDR(ctx, cidrs...)
-	return subnets, errors.Trace(err)
+	return subnets, errors.Capture(err)
 }
 
 // UpdateSubnet updates the spaceUUID of the subnet identified by the input
 // UUID.
 func (s *Service) UpdateSubnet(ctx context.Context, uuid, spaceUUID string) error {
-	return errors.Trace(s.st.UpdateSubnet(ctx, uuid, spaceUUID))
+	return errors.Capture(s.st.UpdateSubnet(ctx, uuid, spaceUUID))
 }
 
 // Remove deletes a subnet identified by its uuid.
 func (s *Service) RemoveSubnet(ctx context.Context, uuid string) error {
-	return errors.Trace(s.st.DeleteSubnet(ctx, uuid))
+	return errors.Capture(s.st.DeleteSubnet(ctx, uuid))
 }

--- a/domain/network/service/subnet_test.go
+++ b/domain/network/service/subnet_test.go
@@ -6,13 +6,14 @@ package service
 import (
 	"context"
 
-	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gomock "go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
+	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/network"
+	"github.com/juju/juju/internal/errors"
 )
 
 type subnetSuite struct {
@@ -120,7 +121,7 @@ func (s *subnetSuite) TestFailRetrieveSubnetByID(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	s.st.EXPECT().GetSubnet(gomock.Any(), "unknown-subnet").
-		Return(nil, errors.NotFoundf("subnet %q", "unknown-subnet"))
+		Return(nil, errors.Errorf("subnet %q %w", "unknown-subnet", coreerrors.NotFound))
 	_, err := NewService(s.st, nil).Subnet(context.Background(), "unknown-subnet")
 	c.Assert(err, gc.ErrorMatches, "subnet \"unknown-subnet\" not found")
 }
@@ -154,7 +155,7 @@ func (s *subnetSuite) TestFailUpdateSubnet(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	s.st.EXPECT().UpdateSubnet(gomock.Any(), "unknown-subnet", "space0").
-		Return(errors.NotFoundf("subnet %q", "unknown-subnet"))
+		Return(errors.Errorf("subnet %q %w", "unknown-subnet", coreerrors.NotFound))
 	err := NewService(s.st, nil).UpdateSubnet(context.Background(), "unknown-subnet", "space0")
 	c.Assert(err, gc.ErrorMatches, "subnet \"unknown-subnet\" not found")
 }
@@ -171,7 +172,7 @@ func (s *subnetSuite) TestFailRemoveSubnet(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	s.st.EXPECT().DeleteSubnet(gomock.Any(), "unknown-subnet").
-		Return(errors.NotFoundf("subnet %q", "unknown-subnet"))
+		Return(errors.Errorf("subnet %q %w", "unknown-subnet", coreerrors.NotFound))
 	err := NewService(s.st, nil).RemoveSubnet(context.Background(), "unknown-subnet")
 	c.Assert(err, gc.ErrorMatches, "subnet \"unknown-subnet\" not found")
 }

--- a/domain/network/state/space.go
+++ b/domain/network/state/space.go
@@ -5,10 +5,8 @@ package state
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/canonical/sqlair"
-	"github.com/juju/errors"
 
 	coreDB "github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/logger"
@@ -16,6 +14,7 @@ import (
 	"github.com/juju/juju/domain"
 	networkerrors "github.com/juju/juju/domain/network/errors"
 	"github.com/juju/juju/internal/database"
+	"github.com/juju/juju/internal/errors"
 )
 
 // State represents a type for interacting with the underlying state.
@@ -42,14 +41,14 @@ func (st *State) AddSpace(
 ) error {
 	db, err := st.DB()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	space := Space{UUID: uuid, Name: name}
 	insertSpaceStmt, err := st.Prepare(`
 INSERT INTO space (uuid, name) 
 VALUES ($Space.*)`, space)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	providerSpace := ProviderSpace{ProviderID: providerID, SpaceUUID: uuid}
@@ -57,19 +56,19 @@ VALUES ($Space.*)`, space)
 INSERT INTO provider_space (provider_id, space_uuid)
 VALUES ($ProviderSpace.*)`, providerSpace)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		if err := tx.Query(ctx, insertSpaceStmt, space).Run(); err != nil {
 			if database.IsErrConstraintUnique(err) {
-				return fmt.Errorf("inserting space uuid %q into space table: %w with err: %w", uuid, networkerrors.SpaceAlreadyExists, err)
+				return errors.Errorf("inserting space uuid %q into space table: %w with err: %w", uuid, networkerrors.SpaceAlreadyExists, err)
 			}
-			return errors.Annotatef(err, "inserting space uuid %q into space table", uuid)
+			return errors.Errorf("inserting space uuid %q into space table %w", uuid, err)
 		}
 		if providerID != "" {
 			if err := tx.Query(ctx, insertProviderStmt, providerSpace).Run(); err != nil {
-				return errors.Annotatef(err, "inserting provider id %q into provider_space table", providerID)
+				return errors.Errorf("inserting provider id %q into provider_space table %w", providerID, err)
 			}
 		}
 
@@ -83,12 +82,12 @@ VALUES ($ProviderSpace.*)`, providerSpace)
 					UUID:      subnetID,
 					SpaceUUID: uuid,
 				}); err != nil {
-				return errors.Annotatef(err, "updating subnet %q using space uuid %q", subnetID, uuid)
+				return errors.Errorf("updating subnet %q using space uuid %q %w", subnetID, uuid, err)
 			}
 		}
 		return nil
 	})
-	return errors.Trace(err)
+	return errors.Capture(err)
 }
 
 // GetSpace returns the space by UUID. If the space is not found, an error is
@@ -99,7 +98,7 @@ func (st *State) GetSpace(
 ) (*network.SpaceInfo, error) {
 	db, err := st.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	space := Space{UUID: uuid}
@@ -108,7 +107,7 @@ SELECT &SpaceSubnetRow.*
 FROM   v_space_subnet
 WHERE  uuid = $Space.uuid;`, SpaceSubnetRow{}, space)
 	if err != nil {
-		return nil, errors.Annotate(err, "preparing select space statement")
+		return nil, errors.Errorf("preparing select space statement %w", err)
 	}
 
 	var spaceRows SpaceSubnetRows
@@ -116,13 +115,13 @@ WHERE  uuid = $Space.uuid;`, SpaceSubnetRow{}, space)
 		err := tx.Query(ctx, spacesStmt, space).GetAll(&spaceRows)
 		if err != nil {
 			if errors.Is(err, sqlair.ErrNoRows) {
-				return fmt.Errorf("space not found with %s: %w", uuid, networkerrors.SpaceNotFound)
+				return errors.Errorf("space not found with %s: %w", uuid, networkerrors.SpaceNotFound)
 			}
-			return errors.Annotatef(err, "retrieving space %q", uuid)
+			return errors.Errorf("retrieving space %q %w", uuid, err)
 		}
 		return err
 	}); err != nil {
-		return nil, errors.Annotate(err, "querying spaces")
+		return nil, errors.Errorf("querying spaces %w", err)
 	}
 
 	return &spaceRows.ToSpaceInfos()[0], nil
@@ -136,7 +135,7 @@ func (st *State) GetSpaceByName(
 ) (*network.SpaceInfo, error) {
 	db, err := st.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	space := Space{
 		Name: name,
@@ -150,21 +149,21 @@ WHERE  name = $Space.name;`
 
 	s, err := st.Prepare(q, SpaceSubnetRow{}, space)
 	if err != nil {
-		return nil, errors.Annotatef(err, "preparing %q", q)
+		return nil, errors.Errorf("preparing %q %w", q, err)
 	}
 
 	var rows SpaceSubnetRows
 	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		err := errors.Trace(tx.Query(ctx, s, space).GetAll(&rows))
+		err := errors.Capture(tx.Query(ctx, s, space).GetAll(&rows))
 		if err != nil {
 			if errors.Is(err, sqlair.ErrNoRows) {
-				return fmt.Errorf("space not found with %s: %w", name, networkerrors.SpaceNotFound)
+				return errors.Errorf("space not found with %s: %w", name, networkerrors.SpaceNotFound)
 			}
-			return errors.Annotate(err, "querying spaces by name")
+			return errors.Errorf("querying spaces by name %w", err)
 		}
 		return nil
 	}); err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	return &rows.ToSpaceInfos()[0], nil
@@ -177,7 +176,7 @@ func (st *State) GetAllSpaces(
 
 	db, err := st.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	s, err := st.Prepare(`
@@ -185,7 +184,7 @@ SELECT &SpaceSubnetRow.*
 FROM   v_space_subnet
 `, SpaceSubnetRow{})
 	if err != nil {
-		return nil, errors.Annotatef(err, "preparing select all spaces statement")
+		return nil, errors.Errorf("preparing select all spaces statement %w", err)
 	}
 
 	var rows SpaceSubnetRows
@@ -194,11 +193,11 @@ FROM   v_space_subnet
 			if errors.Is(err, sqlair.ErrNoRows) {
 				return nil
 			}
-			return errors.Annotate(err, "querying all spaces")
+			return errors.Errorf("querying all spaces %w", err)
 		}
 		return nil
 	}); err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	return rows.ToSpaceInfos(), nil
@@ -213,7 +212,7 @@ func (st *State) UpdateSpace(
 ) error {
 	db, err := st.DB()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	space := Space{
@@ -225,20 +224,20 @@ UPDATE space
 SET    name = $Space.name
 WHERE  uuid = $Space.uuid;`, space)
 	if err != nil {
-		return errors.Annotate(err, "preparing update space statement")
+		return errors.Errorf("preparing update space statement %w", err)
 	}
 	var outcome sqlair.Outcome
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err := tx.Query(ctx, stmt, space).Get(&outcome)
 		if err != nil {
-			return errors.Annotatef(err, "updating space %q with name %q", uuid, name)
+			return errors.Errorf("updating space %q with name %q %w", uuid, name, err)
 		}
 		affected, err := outcome.Result().RowsAffected()
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		if affected == 0 {
-			return fmt.Errorf("space not found with %s: %w", uuid, networkerrors.SpaceNotFound)
+			return errors.Errorf("space not found with %s: %w", uuid, networkerrors.SpaceNotFound)
 		}
 		return nil
 	})
@@ -253,7 +252,7 @@ func (st *State) DeleteSpace(
 ) error {
 	db, err := st.DB()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	space := Space{UUID: uuid}
@@ -262,39 +261,39 @@ func (st *State) DeleteSpace(
 DELETE FROM space 
 WHERE       uuid = $Space.uuid;`, space)
 	if err != nil {
-		return errors.Annotate(err, "preparing delete space statement")
+		return errors.Errorf("preparing delete space statement %w", err)
 	}
 	deleteProviderSpaceStmt, err := st.Prepare(`
 DELETE FROM provider_space 
 WHERE       space_uuid = $Space.uuid;`, space)
 	if err != nil {
-		return errors.Annotate(err, "preparing delete provider space statement")
+		return errors.Errorf("preparing delete provider space statement %w", err)
 	}
 	updateSubnetSpaceUUIDStmt, err := st.Prepare(`
 UPDATE subnet 
 SET    space_uuid = (SELECT uuid FROM space WHERE name = 'alpha') 
 WHERE  space_uuid = $Space.uuid;`, space)
 	if err != nil {
-		return errors.Annotate(err, "preparing update subnet statement")
+		return errors.Errorf("preparing update subnet statement %w", err)
 	}
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		if err := tx.Query(ctx, deleteProviderSpaceStmt, space).Run(); err != nil {
-			return errors.Annotatef(err, "removing space %q from the provider_space table", uuid)
+			return errors.Errorf("removing space %q from the provider_space table %w", uuid, err)
 		}
 
 		if err := tx.Query(ctx, updateSubnetSpaceUUIDStmt, space).Run(); err != nil {
-			return errors.Annotatef(err, "updating subnet table by removing the space %q", uuid)
+			return errors.Errorf("updating subnet table by removing the space %q %w", uuid, err)
 		}
 
 		var outcome sqlair.Outcome
 		err := tx.Query(ctx, deleteSpaceStmt, space).Get(&outcome)
 		if err != nil {
-			return errors.Annotatef(err, "removing space %q", uuid)
+			return errors.Errorf("removing space %q %w", uuid, err)
 		}
 		delSpaceAffected, err := outcome.Result().RowsAffected()
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		if delSpaceAffected != 1 {
 			return networkerrors.SpaceNotFound

--- a/domain/network/state/subnet.go
+++ b/domain/network/state/subnet.go
@@ -5,17 +5,17 @@ package state
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/canonical/sqlair"
 	"github.com/google/uuid"
 	"github.com/juju/collections/transform"
-	"github.com/juju/errors"
 
 	"github.com/juju/juju/core/database"
+	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/network"
 	networkerrors "github.com/juju/juju/domain/network/errors"
 	internaldatabase "github.com/juju/juju/internal/database"
+	"github.com/juju/juju/internal/errors"
 )
 
 // AllSubnetsQuery returns the SQL query that finds all subnet UUIDs from the
@@ -26,7 +26,7 @@ func (st *State) AllSubnetsQuery(ctx context.Context, db database.TxnRunner) ([]
 SELECT &Subnet.uuid
 FROM   subnet`, Subnet{})
 	if err != nil {
-		return nil, errors.Annotate(err, "preparing select subnet statement")
+		return nil, errors.Errorf("preparing select subnet statement %w", err)
 	}
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
@@ -34,10 +34,10 @@ FROM   subnet`, Subnet{})
 		if errors.Is(err, sqlair.ErrNoRows) {
 			return nil
 		}
-		return errors.Trace(err)
+		return errors.Capture(err)
 	})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	return transform.Slice(subnets, func(s Subnet) string { return s.UUID }), nil
 }
@@ -47,7 +47,7 @@ FROM   subnet`, Subnet{})
 func (st *State) UpsertSubnets(ctx context.Context, subnets []network.SubnetInfo) error {
 	db, err := st.DB()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
@@ -60,17 +60,17 @@ func (st *State) UpsertSubnets(ctx context.Context, subnets []network.SubnetInfo
 					SpaceUUID: subnet.SpaceID,
 				},
 			)
-			if err != nil && !errors.Is(err, errors.NotFound) {
-				return errors.Trace(err)
+			if err != nil && !errors.Is(err, coreerrors.NotFound) {
+				return errors.Capture(err)
 			}
 			// If the subnet does not yet exist then we need to create it.
-			if errors.Is(err, errors.NotFound) {
+			if errors.Is(err, coreerrors.NotFound) {
 				if err := st.addSubnet(
 					ctx,
 					tx,
 					subnet,
 				); err != nil {
-					return errors.Trace(err)
+					return errors.Capture(err)
 				}
 			}
 		}
@@ -106,59 +106,59 @@ func (st *State) addSubnet(ctx context.Context, tx *sqlair.TX, subnetInfo networ
 INSERT INTO subnet (*)
 VALUES ($Subnet.*)`, subnet)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	insertSubnetProviderIDStmt, err := st.Prepare(`
 INSERT INTO provider_subnet (*)
 VALUES ($ProviderSubnet.*)`, providerSubnet)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	retrieveProviderNetworkUUIDStmt, err := st.Prepare(`
 SELECT uuid AS &ProviderNetworkSubnet.provider_network_uuid
 FROM   provider_network
 WHERE  provider_network_id = $ProviderNetwork.provider_network_id`, providerNetwork, providerNetworkSubnet)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	insertSubnetProviderNetworkIDStmt, err := st.Prepare(`
 INSERT INTO provider_network (*)
 VALUES ($ProviderNetwork.*)`, providerNetwork)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	insertSubnetProviderNetworkSubnetStmt, err := st.Prepare(`
 INSERT INTO provider_network_subnet (*)
 VALUES ($ProviderNetworkSubnet.*)`, providerNetworkSubnet)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	// Add the subnet entity.
 	if err := tx.Query(ctx, insertSubnetStmt, subnet).Run(); err != nil {
 		st.logger.Errorf("inserting subnet %q, %v", subnetInfo.CIDR, err)
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	// Add the subnet uuid to the provider ids table.
 	if err := tx.Query(ctx, insertSubnetProviderIDStmt, providerSubnet).Run(); err != nil {
 		if internaldatabase.IsErrConstraintPrimaryKey(err) || internaldatabase.IsErrConstraintUnique(err) {
 			st.logger.Debugf("inserting provider id %q for subnet %q, %v", subnetInfo.ProviderId, subnetUUID, err)
-			return errors.AlreadyExistsf("provider id %q for subnet %q", subnetInfo.ProviderId, subnetUUID)
+			return errors.Errorf("provider id %q for subnet %q %w", subnetInfo.ProviderId, subnetUUID, coreerrors.AlreadyExists)
 		}
 		st.logger.Errorf("inserting provider id %q for subnet %q, %v", subnetInfo.ProviderId, subnetUUID, err)
-		return errors.Annotatef(err, "inserting provider id %q for subnet %q", subnetInfo.ProviderId, subnetUUID)
+		return errors.Errorf("inserting provider id %q for subnet %q %w", subnetInfo.ProviderId, subnetUUID, err)
 	}
 
 	var pnUUIDStr string
 	err = tx.Query(ctx, retrieveProviderNetworkUUIDStmt, providerNetwork).Get(&providerNetworkSubnet)
 	if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 		st.logger.Errorf("retrieving provider network ID %q for subnet %q, %v", subnetInfo.ProviderNetworkId, subnetUUID, err)
-		return errors.Annotatef(err, "retrieving provider network ID %q for subnet %q", subnetInfo.ProviderNetworkId, subnetUUID)
+		return errors.Errorf("retrieving provider network ID %q for subnet %q %w", subnetInfo.ProviderNetworkId, subnetUUID, err)
 	} else if errors.Is(err, sqlair.ErrNoRows) {
 		// If the provider network doesn't exist, insert it.
 		pnUUID, err := uuid.NewV7()
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		// Record the new UUID in provider network and the provider network
@@ -170,7 +170,7 @@ VALUES ($ProviderNetworkSubnet.*)`, providerNetworkSubnet)
 		// provider_network table.
 		if err := tx.Query(ctx, insertSubnetProviderNetworkIDStmt, providerNetwork).Run(); err != nil {
 			st.logger.Errorf("inserting provider network id %q for subnet %q, %v", subnetInfo.ProviderNetworkId, subnetUUID, err)
-			return errors.Annotatef(err, "inserting provider network id %q for subnet %q", subnetInfo.ProviderNetworkId, subnetUUID)
+			return errors.Errorf("inserting provider network id %q for subnet %q %w", subnetInfo.ProviderNetworkId, subnetUUID, err)
 		}
 	}
 
@@ -178,7 +178,7 @@ VALUES ($ProviderNetworkSubnet.*)`, providerNetworkSubnet)
 	// subnets mapping table.
 	if err := tx.Query(ctx, insertSubnetProviderNetworkSubnetStmt, providerNetworkSubnet).Run(); err != nil {
 		st.logger.Errorf("inserting association between provider network id %q and subnet %q, %v", subnetInfo.ProviderNetworkId, subnetUUID, err)
-		return errors.Annotatef(err, "inserting association between provider network id (%q) %q and subnet %q", pnUUIDStr, subnetInfo.ProviderNetworkId, subnetUUID)
+		return errors.Errorf("inserting association between provider network id (%q) %q and subnet %q %w", pnUUIDStr, subnetInfo.ProviderNetworkId, subnetUUID, err)
 	}
 
 	return st.addAvailabilityZones(ctx, tx, subnetUUID, subnetInfo)
@@ -196,19 +196,19 @@ SELECT &AvailabilityZone.uuid
 FROM   availability_zone
 WHERE  name = $AvailabilityZone.name`, availabilityZone)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	insertAvailabilityZoneStmt, err := st.Prepare(`
 INSERT INTO availability_zone (*)
 VALUES ($AvailabilityZone.*)`, availabilityZone)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	insertAvailabilityZoneSubnetStmt, err := st.Prepare(`
 INSERT INTO availability_zone_subnet (*)
 VALUES ($AvailabilityZoneSubnet.*)`, availabilityZoneSubnet)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	for _, az := range subnet.AvailabilityZones {
@@ -218,19 +218,19 @@ VALUES ($AvailabilityZoneSubnet.*)`, availabilityZoneSubnet)
 		err := tx.Query(ctx, retrieveAvailabilityZoneStmt, availabilityZone).Get(&availabilityZone)
 		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
 			st.logger.Errorf("retrieving availability zone %q for subnet %q, %v", az, subnetUUID, err)
-			return errors.Annotatef(err, "retrieving availability zone %q for subnet %q", az, subnetUUID)
+			return errors.Errorf("retrieving availability zone %q for subnet %q %w", az, subnetUUID, err)
 		}
 
 		// If it doesn't exist, add the availability zone.
 		if errors.Is(err, sqlair.ErrNoRows) {
 			azUUID, err := uuid.NewV7()
 			if err != nil {
-				return errors.Annotatef(err, "generating UUID for availability zone %q for subnet %q", az, subnetUUID)
+				return errors.Errorf("generating UUID for availability zone %q for subnet %q %w", az, subnetUUID, err)
 			}
 			availabilityZone.UUID = azUUID.String()
 			if err := tx.Query(ctx, insertAvailabilityZoneStmt, availabilityZone).Run(); err != nil {
 				st.logger.Errorf("inserting availability zone %q for subnet %q, %v", az, subnetUUID, err)
-				return errors.Annotatef(err, "inserting availability zone %q for subnet %q", az, subnetUUID)
+				return errors.Errorf("inserting availability zone %q for subnet %q %w", az, subnetUUID, err)
 			}
 		}
 		availabilityZoneSubnet.AZUUID = availabilityZone.UUID
@@ -238,7 +238,7 @@ VALUES ($AvailabilityZoneSubnet.*)`, availabilityZoneSubnet)
 		// availability_zone_subnet mapping table.
 		if err := tx.Query(ctx, insertAvailabilityZoneSubnetStmt, availabilityZoneSubnet).Run(); err != nil {
 			st.logger.Errorf("inserting availability zone %q association with subnet %q, %v", az, subnetUUID, err)
-			return errors.Annotatef(err, "inserting availability zone %q association with subnet %q", az, subnetUUID)
+			return errors.Errorf("inserting availability zone %q association with subnet %q %w", az, subnetUUID, err)
 		}
 	}
 	return nil
@@ -251,14 +251,14 @@ func (st *State) AddSubnet(
 ) error {
 	db, err := st.DB()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
-	return errors.Trace(
+	return errors.Capture(
 		db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 			return st.addSubnet(ctx, tx, subnet)
-		}),
-	)
+		}))
+
 }
 
 // GetAllSubnets returns all known subnets in the model.
@@ -267,7 +267,7 @@ func (st *State) GetAllSubnets(
 ) (network.SubnetInfos, error) {
 	db, err := st.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	// Append the space uuid condition to the query only if it's passed to the function.
@@ -278,17 +278,17 @@ FROM   v_space_subnet
 
 	s, err := st.Prepare(q, SubnetRow{})
 	if err != nil {
-		return nil, errors.Annotatef(err, "preparing %q", q)
+		return nil, errors.Errorf("preparing %q %w", q, err)
 	}
 
 	var rows SubnetRows
 	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		return errors.Trace(tx.Query(ctx, s).GetAll(&rows))
+		return errors.Capture(tx.Query(ctx, s).GetAll(&rows))
 	}); errors.Is(err, sqlair.ErrNoRows) {
 		return nil, nil
 	} else if err != nil {
 		st.logger.Errorf("querying subnets, %v", err)
-		return nil, errors.Annotate(err, "querying subnets")
+		return nil, errors.Errorf("querying subnets %w", err)
 	}
 
 	return rows.ToSubnetInfos(), nil
@@ -301,7 +301,7 @@ func (st *State) GetSubnet(
 ) (*network.SubnetInfo, error) {
 	db, err := st.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	// Append the space uuid condition to the query only if it's passed to the function.
@@ -312,7 +312,7 @@ WHERE  subnet_uuid = $M.id;`
 
 	stmt, err := st.Prepare(q, SubnetRow{}, sqlair.M{})
 	if err != nil {
-		return nil, errors.Annotatef(err, "preparing %q", q)
+		return nil, errors.Errorf("preparing %q %w", q, err)
 	}
 
 	var rows SubnetRows
@@ -322,11 +322,11 @@ WHERE  subnet_uuid = $M.id;`
 			if errors.Is(err, sqlair.ErrNoRows) {
 				return networkerrors.SubnetNotFound
 			}
-			return errors.Annotatef(err, "retrieving subnet %q", uuid)
+			return errors.Errorf("retrieving subnet %q %w", uuid, err)
 		}
 		return nil
 	}); err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	return &rows.ToSubnetInfos()[0], nil
@@ -341,7 +341,7 @@ func (st *State) GetSubnetsByCIDR(
 ) (network.SubnetInfos, error) {
 	db, err := st.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	// Append the where clause to the query.
@@ -352,7 +352,7 @@ WHERE  subnet_cidr = $M.cidr`
 
 	s, err := st.Prepare(q, SubnetRow{}, sqlair.M{})
 	if err != nil {
-		return nil, errors.Annotatef(err, "preparing %q", q)
+		return nil, errors.Errorf("preparing %q %w", q, err)
 	}
 
 	var resultSubnets SubnetRows
@@ -363,13 +363,13 @@ WHERE  subnet_cidr = $M.cidr`
 				if errors.Is(err, sqlair.ErrNoRows) {
 					continue
 				}
-				return errors.Annotatef(err, "retrieving subnets by CIDR %v", cidr)
+				return errors.Errorf("retrieving subnets by CIDR %v %w", cidr, err)
 			}
 			resultSubnets = append(resultSubnets, rows...)
 		}
 		return nil
 	}); err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	return resultSubnets.ToSubnetInfos(), nil
@@ -388,21 +388,21 @@ UPDATE subnet
 SET    space_uuid = $Subnet.space_uuid
 WHERE  uuid = $Subnet.uuid;`, subnet)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	var outcome sqlair.Outcome
 
 	if err = tx.Query(ctx, updateSubnetSpaceIDStmt, subnet).Get(&outcome); err != nil {
 		st.logger.Errorf("updating subnet %q space ID %v, %v", subnet.UUID, subnet.SpaceUUID, err)
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	affected, err := outcome.Result().RowsAffected()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	if affected != 1 {
-		return errors.NotFoundf("subnet %q", subnet.UUID)
+		return errors.Errorf("subnet %q %w", subnet.UUID, coreerrors.NotFound)
 	}
 
 	return nil
@@ -416,7 +416,7 @@ func (st *State) UpdateSubnet(
 ) error {
 	db, err := st.DB()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	subnet := Subnet{SpaceUUID: spaceID, UUID: uuid}
 
@@ -432,7 +432,7 @@ func (st *State) DeleteSubnet(
 ) error {
 	db, err := st.DB()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	subnet := Subnet{UUID: uuid}
@@ -441,91 +441,91 @@ func (st *State) DeleteSubnet(
 	deleteSubnetStmt, err := st.Prepare(`
 DELETE FROM subnet WHERE uuid = $Subnet.uuid;`, subnet)
 	if err != nil {
-		return errors.Annotate(err, "preparing delete subnet statement")
+		return errors.Errorf("preparing delete subnet statement %w", err)
 	}
 	selectProviderNetworkStmt, err := st.Prepare(`
 SELECT &ProviderNetworkSubnet.provider_network_uuid
 FROM   provider_network_subnet
 WHERE  subnet_uuid = $Subnet.uuid;`, subnet, providerNetworkSubnet)
 	if err != nil {
-		return errors.Annotate(err, "preparing select provider network statement")
+		return errors.Errorf("preparing select provider network statement %w", err)
 	}
 	deleteProviderNetworkStmt, err := st.Prepare(`
 DELETE FROM provider_network WHERE uuid = $ProviderNetworkSubnet.provider_network_uuid;`, providerNetworkSubnet)
 	if err != nil {
-		return errors.Annotate(err, "preparing delete provider network statement")
+		return errors.Errorf("preparing delete provider network statement %w", err)
 	}
 	deleteProviderNetworkSubnetStmt, err := st.Prepare(`
 DELETE FROM provider_network_subnet WHERE subnet_uuid = $Subnet.uuid;`, subnet)
 	if err != nil {
-		return errors.Annotate(err, "preparing delete provider network subnet statement")
+		return errors.Errorf("preparing delete provider network subnet statement %w", err)
 	}
 	deleteProviderSubnetStmt, err := st.Prepare(`
 DELETE FROM provider_subnet WHERE subnet_uuid = $Subnet.uuid;`, subnet)
 	if err != nil {
-		return errors.Annotate(err, "preparing delete provider subnet statement")
+		return errors.Errorf("preparing delete provider subnet statement %w", err)
 	}
 	deleteAvailabilityZoneSubnetStmt, err := st.Prepare(`
 DELETE FROM availability_zone_subnet WHERE subnet_uuid = $Subnet.uuid;`, subnet)
 	if err != nil {
-		return errors.Annotate(err, "preparing delete availability zone subnet statement")
+		return errors.Errorf("preparing delete availability zone subnet statement %w", err)
 	}
 
 	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err := tx.Query(ctx, selectProviderNetworkStmt, subnet).Get(&providerNetworkSubnet)
 		if err != nil {
 			st.logger.Errorf("retrieving provider network corresponding to subnet %q, %v", uuid, err)
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		var outcome sqlair.Outcome
 		err = tx.Query(ctx, deleteProviderNetworkSubnetStmt, subnet).Get(&outcome)
 		if err != nil {
 			st.logger.Errorf("removing the provider network entry for subnet %q, %v", uuid, err)
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		if delProviderNetworkSubnetAffected, err := outcome.Result().RowsAffected(); err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		} else if delProviderNetworkSubnetAffected != 1 {
-			return fmt.Errorf("provider network subnets for subnet %s not found", uuid)
+			return errors.Errorf("provider network subnets for subnet %s not found", uuid)
 		}
 
 		err = tx.Query(ctx, deleteProviderNetworkStmt, providerNetworkSubnet).Get(&outcome)
 		if err != nil {
 			st.logger.Errorf("removing the provider network entry %q, %v", providerNetworkSubnet.ProviderNetworkUUID, err)
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		if delProviderNetworkAffected, err := outcome.Result().RowsAffected(); err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		} else if delProviderNetworkAffected != 1 {
-			return fmt.Errorf("provider network for subnet %s not found", uuid)
+			return errors.Errorf("provider network for subnet %s not found", uuid)
 		}
 
 		if err := tx.Query(ctx, deleteAvailabilityZoneSubnetStmt, subnet).Run(); err != nil {
 			st.logger.Errorf("removing the availability zone entry for subnet %q, %v", uuid, err)
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		err = tx.Query(ctx, deleteProviderSubnetStmt, subnet).Get(&outcome)
 		st.logger.Errorf("removing the provider subnet entry for subnet %q, %v", uuid, err)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		if delProviderSubnetAffected, err := outcome.Result().RowsAffected(); err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		} else if delProviderSubnetAffected != 1 {
-			return fmt.Errorf("provider subnet for subnet %s not found", uuid)
+			return errors.Errorf("provider subnet for subnet %s not found", uuid)
 		}
 
 		err = tx.Query(ctx, deleteSubnetStmt, subnet).Get(&outcome)
 		if err != nil {
 			st.logger.Errorf("removing subnet %q, %v", uuid, err)
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		if delSubnetAffected, err := outcome.Result().RowsAffected(); err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		} else if delSubnetAffected != 1 {
-			return fmt.Errorf("subnet %s not found", uuid)
+			return errors.Errorf("subnet %s not found", uuid)
 		}
 
 		return nil

--- a/domain/objectstore/state/state.go
+++ b/domain/objectstore/state/state.go
@@ -5,17 +5,16 @@ package state
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/canonical/sqlair"
 	"github.com/juju/collections/transform"
-	"github.com/juju/errors"
 
 	coredatabase "github.com/juju/juju/core/database"
 	coreobjectstore "github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/domain"
 	objectstoreerrors "github.com/juju/juju/domain/objectstore/errors"
 	"github.com/juju/juju/internal/database"
+	"github.com/juju/juju/internal/errors"
 )
 
 // State implements the domain objectstore state.
@@ -34,7 +33,7 @@ func NewState(factory coredatabase.TxnRunnerFactory) *State {
 func (s *State) GetMetadata(ctx context.Context, path string) (coreobjectstore.Metadata, error) {
 	db, err := s.DB()
 	if err != nil {
-		return coreobjectstore.Metadata{}, errors.Trace(err)
+		return coreobjectstore.Metadata{}, errors.Capture(err)
 	}
 
 	metadata := dbMetadata{Path: path}
@@ -44,7 +43,7 @@ SELECT &dbMetadata.*
 FROM v_object_store_metadata
 WHERE path = $dbMetadata.path`, metadata)
 	if err != nil {
-		return coreobjectstore.Metadata{}, errors.Annotate(err, "preparing select metadata statement")
+		return coreobjectstore.Metadata{}, errors.Errorf("preparing select metadata statement %w", err)
 	}
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
@@ -53,12 +52,12 @@ WHERE path = $dbMetadata.path`, metadata)
 			if errors.Is(err, sqlair.ErrNoRows) {
 				return objectstoreerrors.ErrNotFound
 			}
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		return nil
 	})
 	if err != nil {
-		return coreobjectstore.Metadata{}, errors.Annotatef(err, "retrieving metadata %s", path)
+		return coreobjectstore.Metadata{}, errors.Errorf("retrieving metadata %s %w", path, err)
 	}
 	return decodeDbMetadata(metadata), nil
 }
@@ -110,19 +109,19 @@ func (s *State) ListMetadata(ctx context.Context) ([]coreobjectstore.Metadata, e
 SELECT &dbMetadata.*
 FROM v_object_store_metadata`, dbMetadata{})
 	if err != nil {
-		return nil, errors.Annotate(err, "preparing select metadata statement")
+		return nil, errors.Errorf("preparing select metadata statement %w", err)
 	}
 
 	var metadata []dbMetadata
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err := tx.Query(ctx, stmt).GetAll(&metadata)
 		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-			return errors.Annotate(err, "retrieving metadata")
+			return errors.Errorf("retrieving metadata %w", err)
 		}
 		return nil
 	})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	return transform.Slice(metadata, decodeDbMetadata), nil
 }
@@ -131,7 +130,7 @@ FROM v_object_store_metadata`, dbMetadata{})
 func (s *State) PutMetadata(ctx context.Context, metadata coreobjectstore.Metadata) (coreobjectstore.UUID, error) {
 	db, err := s.DB()
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", errors.Capture(err)
 	}
 
 	uuid, err := coreobjectstore.NewUUID()
@@ -157,14 +156,14 @@ VALUES ($dbMetadata.*)
 ON CONFLICT (sha_256) DO NOTHING
 ON CONFLICT (sha_384) DO NOTHING`, dbMetadata)
 	if err != nil {
-		return "", errors.Annotate(err, "preparing insert metadata statement")
+		return "", errors.Errorf("preparing insert metadata statement %w", err)
 	}
 
 	pathStmt, err := s.Prepare(`
 INSERT INTO object_store_metadata_path (path, metadata_uuid)
 VALUES ($dbMetadataPath.*)`, dbMetadataPath)
 	if err != nil {
-		return "", errors.Annotate(err, "preparing insert metadata path statement")
+		return "", errors.Errorf("preparing insert metadata path statement %w", err)
 	}
 
 	metadataLookupStmt, err := s.Prepare(`
@@ -176,18 +175,18 @@ WHERE  (
 )
 AND    size = $dbMetadata.size`, dbMetadata, dbMetadataPath)
 	if err != nil {
-		return "", errors.Annotate(err, "preparing select metadata statement")
+		return "", errors.Errorf("preparing select metadata statement %w", err)
 	}
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		var outcome sqlair.Outcome
 		err := tx.Query(ctx, metadataStmt, dbMetadata).Get(&outcome)
 		if err != nil {
-			return errors.Annotatef(err, "inserting metadata")
+			return errors.Errorf("inserting metadata %w", err)
 		}
 
 		if rows, err := outcome.Result().RowsAffected(); err != nil {
-			return errors.Annotatef(err, "inserting metadata")
+			return errors.Errorf("inserting metadata %w", err)
 		} else if rows != 1 {
 			// If the rows affected is 0, then the metadata already exists.
 			// We need to get the uuid for the metadata, so that we can insert
@@ -196,7 +195,7 @@ AND    size = $dbMetadata.size`, dbMetadata, dbMetadataPath)
 			if errors.Is(err, sqlair.ErrNoRows) {
 				return objectstoreerrors.ErrHashAndSizeAlreadyExists
 			} else if err != nil {
-				return errors.Annotatef(err, "inserting metadata")
+				return errors.Errorf("inserting metadata %w", err)
 			}
 		}
 
@@ -204,17 +203,17 @@ AND    size = $dbMetadata.size`, dbMetadata, dbMetadataPath)
 		if database.IsErrConstraintPrimaryKey(err) {
 			return objectstoreerrors.ErrPathAlreadyExistsDifferentHash
 		} else if err != nil {
-			return errors.Annotatef(err, "inserting metadata path")
+			return errors.Errorf("inserting metadata path %w", err)
 		}
 		if rows, err := outcome.Result().RowsAffected(); err != nil {
-			return errors.Annotatef(err, "inserting metadata path")
+			return errors.Errorf("inserting metadata path %w", err)
 		} else if rows != 1 {
-			return fmt.Errorf("metadata path not inserted")
+			return errors.Errorf("metadata path not inserted")
 		}
 		return nil
 	})
 	if err != nil {
-		return "", errors.Annotatef(err, "adding path %s", metadata.Path)
+		return "", errors.Errorf("adding path %s %w", metadata.Path, err)
 	}
 	return uuid, nil
 }
@@ -223,7 +222,7 @@ AND    size = $dbMetadata.size`, dbMetadata, dbMetadataPath)
 func (s *State) RemoveMetadata(ctx context.Context, path string) error {
 	db, err := s.DB()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	dbMetadataPath := dbMetadataPath{
@@ -235,13 +234,13 @@ SELECT &dbMetadataPath.metadata_uuid
 FROM object_store_metadata_path 
 WHERE path = $dbMetadataPath.path`, dbMetadataPath)
 	if err != nil {
-		return errors.Annotate(err, "preparing select metadata statement")
+		return errors.Errorf("preparing select metadata statement %w", err)
 	}
 	pathStmt, err := s.Prepare(`
 DELETE FROM object_store_metadata_path 
 WHERE path = $dbMetadataPath.path`, dbMetadataPath)
 	if err != nil {
-		return errors.Annotate(err, "preparing delete metadata path statement")
+		return errors.Errorf("preparing delete metadata path statement %w", err)
 	}
 
 	metadataStmt, err := s.Prepare(`
@@ -253,7 +252,7 @@ AND NOT EXISTS (
   WHERE  metadata_uuid = object_store_metadata.uuid
 )`, dbMetadataPath)
 	if err != nil {
-		return errors.Annotate(err, "preparing delete metadata statement")
+		return errors.Errorf("preparing delete metadata statement %w", err)
 	}
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
@@ -263,21 +262,21 @@ AND NOT EXISTS (
 		if errors.Is(err, sqlair.ErrNoRows) {
 			return objectstoreerrors.ErrNotFound
 		} else if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		if err := tx.Query(ctx, pathStmt, dbMetadataPath).Run(); err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		if err := tx.Query(ctx, metadataStmt, dbMetadataPath).Run(); err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		return nil
 	})
 	if err != nil {
-		return errors.Annotatef(err, "removing path %s", path)
+		return errors.Errorf("removing path %s %w", path, err)
 	}
 	return nil
 }

--- a/domain/port/errors/errors.go
+++ b/domain/port/errors/errors.go
@@ -3,9 +3,7 @@
 
 package errors
 
-import (
-	"github.com/juju/juju/internal/errors"
-)
+import "github.com/juju/juju/internal/errors"
 
 const (
 	// UnitNotFound describes an error that occurs when the unit

--- a/domain/port/state/state.go
+++ b/domain/port/state/state.go
@@ -5,7 +5,6 @@ package state
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/canonical/sqlair"
 	"github.com/juju/collections/set"
@@ -571,7 +570,7 @@ WHERE name=$unitName.name`, u)
 	}
 	err = tx.Query(ctx, selectUnitUUIDStmt, u).Get(&u)
 	if errors.Is(err, sqlair.ErrNoRows) {
-		return "", fmt.Errorf("%s %w", name, porterrors.UnitNotFound)
+		return "", errors.Errorf("%s %w", name, porterrors.UnitNotFound)
 	}
 	if err != nil {
 		return "", errors.Errorf("looking up unit UUID for %q: %w", name, err)

--- a/domain/port/state/watcher.go
+++ b/domain/port/state/watcher.go
@@ -9,7 +9,6 @@ import (
 	"github.com/canonical/sqlair"
 	"github.com/juju/collections/set"
 	"github.com/juju/collections/transform"
-	jujuerrors "github.com/juju/errors"
 
 	coreapplication "github.com/juju/juju/core/application"
 	coremachine "github.com/juju/juju/core/machine"
@@ -32,7 +31,7 @@ func (st *State) InitialWatchMachineOpenedPortsStatement() string {
 func (st *State) GetMachineNamesForUnits(ctx context.Context, units []unit.UUID) ([]coremachine.Name, error) {
 	db, err := st.DB()
 	if err != nil {
-		return nil, jujuerrors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	unitUUIDs := unitUUIDs(units)
@@ -53,7 +52,7 @@ WHERE unit.uuid IN ($unitUUIDs[:])
 		if errors.Is(err, sqlair.ErrNoRows) {
 			return nil
 		}
-		return jujuerrors.Trace(err)
+		return errors.Capture(err)
 	})
 	if err != nil {
 		return nil, errors.Errorf("failed to get machines for units: %w", err)
@@ -65,7 +64,7 @@ WHERE unit.uuid IN ($unitUUIDs[:])
 func (st *State) FilterUnitUUIDsForApplication(ctx context.Context, units []unit.UUID, app coreapplication.ID) (set.Strings, error) {
 	db, err := st.DB()
 	if err != nil {
-		return nil, jujuerrors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	applicationUUID := applicationUUID{UUID: app}
@@ -87,7 +86,7 @@ AND unit.application_uuid = $applicationUUID.application_uuid
 		if errors.Is(err, sqlair.ErrNoRows) {
 			return nil
 		}
-		return jujuerrors.Trace(err)
+		return errors.Capture(err)
 	})
 	if err != nil {
 		return nil, errors.Errorf("failed to get applications for units: %w", err)

--- a/domain/proxy/errors/errors.go
+++ b/domain/proxy/errors/errors.go
@@ -3,9 +3,7 @@
 
 package errors
 
-import (
-	"github.com/juju/errors"
-)
+import "github.com/juju/juju/internal/errors"
 
 const (
 	// ProxyInfoNotSupported describes an error that occurs when the underlying

--- a/domain/proxy/service/service.go
+++ b/domain/proxy/service/service.go
@@ -6,11 +6,11 @@ package service
 import (
 	"context"
 
-	"github.com/juju/errors"
-
+	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/providertracker"
 	proxyerrors "github.com/juju/juju/domain/proxy/errors"
 	"github.com/juju/juju/environs"
+	"github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/internal/proxy"
 )
 
@@ -41,17 +41,17 @@ func NewService(providerGetter providertracker.ProviderGetter[Provider]) *Servic
 // it will return [errors.ProxyNotFound].
 func (s *Service) GetConnectionProxyInfo(ctx context.Context) (proxy.Proxier, error) {
 	provider, err := s.providerGetter(ctx)
-	if errors.Is(err, errors.NotSupported) {
+	if errors.Is(err, coreerrors.NotSupported) {
 		return nil, proxyerrors.ProxyInfoNotSupported
 	} else if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	proxier, err := provider.ConnectionProxyInfo(ctx)
-	if errors.Is(err, errors.NotFound) {
+	if errors.Is(err, coreerrors.NotFound) {
 		return nil, proxyerrors.ProxyInfoNotFound
 	} else if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	return proxier, nil
@@ -61,10 +61,10 @@ func (s *Service) GetConnectionProxyInfo(ctx context.Context) (proxy.Proxier, er
 // with the given port.
 func (s *Service) GetProxyToApplication(ctx context.Context, appName, remotePort string) (proxy.Proxier, error) {
 	provider, err := s.providerGetter(ctx)
-	if errors.Is(err, errors.NotSupported) {
+	if errors.Is(err, coreerrors.NotSupported) {
 		return nil, proxyerrors.ProxyNotSupported
 	} else if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	return provider.ProxyToApplication(ctx, appName, remotePort)

--- a/domain/proxy/service/service_test.go
+++ b/domain/proxy/service/service_test.go
@@ -6,12 +6,12 @@ package service
 import (
 	"context"
 
-	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
+	coreerrors "github.com/juju/juju/core/errors"
 	proxyerrors "github.com/juju/juju/domain/proxy/errors"
 )
 
@@ -50,7 +50,7 @@ func (s *serviceSuite) TestGetConnectionProxyInfoNotSupported(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	service := NewService(func(ctx context.Context) (Provider, error) {
-		return s.provider, errors.NotSupported
+		return s.provider, coreerrors.NotSupported
 	})
 	_, err := service.GetConnectionProxyInfo(context.Background())
 	c.Assert(err, jc.ErrorIs, proxyerrors.ProxyInfoNotSupported)
@@ -59,7 +59,7 @@ func (s *serviceSuite) TestGetConnectionProxyInfoNotSupported(c *gc.C) {
 func (s *serviceSuite) TestGetConnectionProxyInfoNotFound(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.provider.EXPECT().ConnectionProxyInfo(gomock.Any()).Return(s.proxier, errors.NotFound)
+	s.provider.EXPECT().ConnectionProxyInfo(gomock.Any()).Return(s.proxier, coreerrors.NotFound)
 
 	service := NewService(func(ctx context.Context) (Provider, error) {
 		return s.provider, nil
@@ -85,7 +85,7 @@ func (s *serviceSuite) TestGetProxyToApplicationNotSupported(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	service := NewService(func(ctx context.Context) (Provider, error) {
-		return s.provider, errors.NotSupported
+		return s.provider, coreerrors.NotSupported
 	})
 	_, err := service.GetProxyToApplication(context.Background(), "foo", "8080")
 	c.Assert(err, jc.ErrorIs, proxyerrors.ProxyNotSupported)

--- a/domain/schema/controller/triggers/cloud-triggers.gen.go
+++ b/domain/schema/controller/triggers/cloud-triggers.gen.go
@@ -8,7 +8,6 @@ import (
 	"github.com/juju/juju/core/database/schema"
 )
 
-
 // ChangeLogTriggersForCloud generates the triggers for the
 // cloud table.
 func ChangeLogTriggersForCloud(columnName string, namespaceID int) func() schema.Patch {
@@ -128,4 +127,3 @@ BEGIN
 END;`, columnName, namespaceID))
 	}
 }
-

--- a/domain/schema/controller/triggers/cloud-triggers.gen.go
+++ b/domain/schema/controller/triggers/cloud-triggers.gen.go
@@ -8,6 +8,7 @@ import (
 	"github.com/juju/juju/core/database/schema"
 )
 
+
 // ChangeLogTriggersForCloud generates the triggers for the
 // cloud table.
 func ChangeLogTriggersForCloud(columnName string, namespaceID int) func() schema.Patch {
@@ -127,3 +128,4 @@ BEGIN
 END;`, columnName, namespaceID))
 	}
 }
+

--- a/domain/schema/controller/triggers/controller-triggers.gen.go
+++ b/domain/schema/controller/triggers/controller-triggers.gen.go
@@ -8,7 +8,6 @@ import (
 	"github.com/juju/juju/core/database/schema"
 )
 
-
 // ChangeLogTriggersForControllerConfig generates the triggers for the
 // controller_config table.
 func ChangeLogTriggersForControllerConfig(columnName string, namespaceID int) func() schema.Patch {
@@ -81,4 +80,3 @@ BEGIN
 END;`, columnName, namespaceID))
 	}
 }
-

--- a/domain/schema/controller/triggers/controller-triggers.gen.go
+++ b/domain/schema/controller/triggers/controller-triggers.gen.go
@@ -8,6 +8,7 @@ import (
 	"github.com/juju/juju/core/database/schema"
 )
 
+
 // ChangeLogTriggersForControllerConfig generates the triggers for the
 // controller_config table.
 func ChangeLogTriggersForControllerConfig(columnName string, namespaceID int) func() schema.Patch {
@@ -80,3 +81,4 @@ BEGIN
 END;`, columnName, namespaceID))
 	}
 }
+

--- a/domain/schema/controller/triggers/migration-triggers.gen.go
+++ b/domain/schema/controller/triggers/migration-triggers.gen.go
@@ -8,6 +8,7 @@ import (
 	"github.com/juju/juju/core/database/schema"
 )
 
+
 // ChangeLogTriggersForModelMigrationMinionSync generates the triggers for the
 // model_migration_minion_sync table.
 func ChangeLogTriggersForModelMigrationMinionSync(columnName string, namespaceID int) func() schema.Patch {
@@ -88,3 +89,4 @@ BEGIN
 END;`, columnName, namespaceID))
 	}
 }
+

--- a/domain/schema/controller/triggers/migration-triggers.gen.go
+++ b/domain/schema/controller/triggers/migration-triggers.gen.go
@@ -8,7 +8,6 @@ import (
 	"github.com/juju/juju/core/database/schema"
 )
 
-
 // ChangeLogTriggersForModelMigrationMinionSync generates the triggers for the
 // model_migration_minion_sync table.
 func ChangeLogTriggersForModelMigrationMinionSync(columnName string, namespaceID int) func() schema.Patch {
@@ -89,4 +88,3 @@ BEGIN
 END;`, columnName, namespaceID))
 	}
 }
-

--- a/domain/schema/controller/triggers/model-agent-triggers.gen.go
+++ b/domain/schema/controller/triggers/model-agent-triggers.gen.go
@@ -8,7 +8,6 @@ import (
 	"github.com/juju/juju/core/database/schema"
 )
 
-
 // ChangeLogTriggersForModelAgent generates the triggers for the
 // model_agent table.
 func ChangeLogTriggersForModelAgent(columnName string, namespaceID int) func() schema.Patch {
@@ -45,4 +44,3 @@ BEGIN
 END;`, columnName, namespaceID))
 	}
 }
-

--- a/domain/schema/controller/triggers/model-agent-triggers.gen.go
+++ b/domain/schema/controller/triggers/model-agent-triggers.gen.go
@@ -8,6 +8,7 @@ import (
 	"github.com/juju/juju/core/database/schema"
 )
 
+
 // ChangeLogTriggersForModelAgent generates the triggers for the
 // model_agent table.
 func ChangeLogTriggersForModelAgent(columnName string, namespaceID int) func() schema.Patch {
@@ -44,3 +45,4 @@ BEGIN
 END;`, columnName, namespaceID))
 	}
 }
+

--- a/domain/schema/controller/triggers/model-authorized-keys-triggers.gen.go
+++ b/domain/schema/controller/triggers/model-authorized-keys-triggers.gen.go
@@ -8,6 +8,7 @@ import (
 	"github.com/juju/juju/core/database/schema"
 )
 
+
 // ChangeLogTriggersForModelAuthorizedKeys generates the triggers for the
 // model_authorized_keys table.
 func ChangeLogTriggersForModelAuthorizedKeys(columnName string, namespaceID int) func() schema.Patch {
@@ -43,3 +44,4 @@ BEGIN
 END;`, columnName, namespaceID))
 	}
 }
+

--- a/domain/schema/controller/triggers/model-authorized-keys-triggers.gen.go
+++ b/domain/schema/controller/triggers/model-authorized-keys-triggers.gen.go
@@ -8,7 +8,6 @@ import (
 	"github.com/juju/juju/core/database/schema"
 )
 
-
 // ChangeLogTriggersForModelAuthorizedKeys generates the triggers for the
 // model_authorized_keys table.
 func ChangeLogTriggersForModelAuthorizedKeys(columnName string, namespaceID int) func() schema.Patch {
@@ -44,4 +43,3 @@ BEGIN
 END;`, columnName, namespaceID))
 	}
 }
-

--- a/domain/schema/controller/triggers/model-triggers.gen.go
+++ b/domain/schema/controller/triggers/model-triggers.gen.go
@@ -8,7 +8,6 @@ import (
 	"github.com/juju/juju/core/database/schema"
 )
 
-
 // ChangeLogTriggersForModel generates the triggers for the
 // model table.
 func ChangeLogTriggersForModel(columnName string, namespaceID int) func() schema.Patch {
@@ -51,4 +50,3 @@ BEGIN
 END;`, columnName, namespaceID))
 	}
 }
-

--- a/domain/schema/controller/triggers/model-triggers.gen.go
+++ b/domain/schema/controller/triggers/model-triggers.gen.go
@@ -8,6 +8,7 @@ import (
 	"github.com/juju/juju/core/database/schema"
 )
 
+
 // ChangeLogTriggersForModel generates the triggers for the
 // model table.
 func ChangeLogTriggersForModel(columnName string, namespaceID int) func() schema.Patch {
@@ -50,3 +51,4 @@ BEGIN
 END;`, columnName, namespaceID))
 	}
 }
+

--- a/domain/schema/controller/triggers/objectstore-triggers.gen.go
+++ b/domain/schema/controller/triggers/objectstore-triggers.gen.go
@@ -8,7 +8,6 @@ import (
 	"github.com/juju/juju/core/database/schema"
 )
 
-
 // ChangeLogTriggersForObjectStoreMetadataPath generates the triggers for the
 // object_store_metadata_path table.
 func ChangeLogTriggersForObjectStoreMetadataPath(columnName string, namespaceID int) func() schema.Patch {
@@ -44,4 +43,3 @@ BEGIN
 END;`, columnName, namespaceID))
 	}
 }
-

--- a/domain/schema/controller/triggers/objectstore-triggers.gen.go
+++ b/domain/schema/controller/triggers/objectstore-triggers.gen.go
@@ -8,6 +8,7 @@ import (
 	"github.com/juju/juju/core/database/schema"
 )
 
+
 // ChangeLogTriggersForObjectStoreMetadataPath generates the triggers for the
 // object_store_metadata_path table.
 func ChangeLogTriggersForObjectStoreMetadataPath(columnName string, namespaceID int) func() schema.Patch {
@@ -43,3 +44,4 @@ BEGIN
 END;`, columnName, namespaceID))
 	}
 }
+

--- a/domain/schema/controller/triggers/secret-triggers.gen.go
+++ b/domain/schema/controller/triggers/secret-triggers.gen.go
@@ -8,6 +8,7 @@ import (
 	"github.com/juju/juju/core/database/schema"
 )
 
+
 // ChangeLogTriggersForModelSecretBackend generates the triggers for the
 // model_secret_backend table.
 func ChangeLogTriggersForModelSecretBackend(columnName string, namespaceID int) func() schema.Patch {
@@ -79,3 +80,4 @@ BEGIN
 END;`, columnName, namespaceID))
 	}
 }
+

--- a/domain/schema/controller/triggers/secret-triggers.gen.go
+++ b/domain/schema/controller/triggers/secret-triggers.gen.go
@@ -8,7 +8,6 @@ import (
 	"github.com/juju/juju/core/database/schema"
 )
 
-
 // ChangeLogTriggersForModelSecretBackend generates the triggers for the
 // model_secret_backend table.
 func ChangeLogTriggersForModelSecretBackend(columnName string, namespaceID int) func() schema.Patch {
@@ -80,4 +79,3 @@ BEGIN
 END;`, columnName, namespaceID))
 	}
 }
-

--- a/domain/schema/controller/triggers/upgrade-triggers.gen.go
+++ b/domain/schema/controller/triggers/upgrade-triggers.gen.go
@@ -8,6 +8,7 @@ import (
 	"github.com/juju/juju/core/database/schema"
 )
 
+
 // ChangeLogTriggersForUpgradeInfo generates the triggers for the
 // upgrade_info table.
 func ChangeLogTriggersForUpgradeInfo(columnName string, namespaceID int) func() schema.Patch {
@@ -83,3 +84,4 @@ BEGIN
 END;`, columnName, namespaceID))
 	}
 }
+

--- a/domain/schema/controller/triggers/upgrade-triggers.gen.go
+++ b/domain/schema/controller/triggers/upgrade-triggers.gen.go
@@ -8,7 +8,6 @@ import (
 	"github.com/juju/juju/core/database/schema"
 )
 
-
 // ChangeLogTriggersForUpgradeInfo generates the triggers for the
 // upgrade_info table.
 func ChangeLogTriggersForUpgradeInfo(columnName string, namespaceID int) func() schema.Patch {
@@ -84,4 +83,3 @@ BEGIN
 END;`, columnName, namespaceID))
 	}
 }
-

--- a/domain/schema/controller/triggers/user-authentication-triggers.gen.go
+++ b/domain/schema/controller/triggers/user-authentication-triggers.gen.go
@@ -8,6 +8,7 @@ import (
 	"github.com/juju/juju/core/database/schema"
 )
 
+
 // ChangeLogTriggersForUserAuthentication generates the triggers for the
 // user_authentication table.
 func ChangeLogTriggersForUserAuthentication(columnName string, namespaceID int) func() schema.Patch {
@@ -43,3 +44,4 @@ BEGIN
 END;`, columnName, namespaceID))
 	}
 }
+

--- a/domain/schema/controller/triggers/user-authentication-triggers.gen.go
+++ b/domain/schema/controller/triggers/user-authentication-triggers.gen.go
@@ -8,7 +8,6 @@ import (
 	"github.com/juju/juju/core/database/schema"
 )
 
-
 // ChangeLogTriggersForUserAuthentication generates the triggers for the
 // user_authentication table.
 func ChangeLogTriggersForUserAuthentication(columnName string, namespaceID int) func() schema.Patch {
@@ -44,4 +43,3 @@ BEGIN
 END;`, columnName, namespaceID))
 	}
 }
-

--- a/domain/schema/model/triggers/application-triggers.gen.go
+++ b/domain/schema/model/triggers/application-triggers.gen.go
@@ -8,7 +8,6 @@ import (
 	"github.com/juju/juju/core/database/schema"
 )
 
-
 // ChangeLogTriggersForApplication generates the triggers for the
 // application table.
 func ChangeLogTriggersForApplication(columnName string, namespaceID int) func() schema.Patch {
@@ -215,4 +214,3 @@ BEGIN
 END;`, columnName, namespaceID))
 	}
 }
-

--- a/domain/schema/model/triggers/application-triggers.gen.go
+++ b/domain/schema/model/triggers/application-triggers.gen.go
@@ -8,6 +8,7 @@ import (
 	"github.com/juju/juju/core/database/schema"
 )
 
+
 // ChangeLogTriggersForApplication generates the triggers for the
 // application table.
 func ChangeLogTriggersForApplication(columnName string, namespaceID int) func() schema.Patch {
@@ -214,3 +215,4 @@ BEGIN
 END;`, columnName, namespaceID))
 	}
 }
+

--- a/domain/schema/model/triggers/machine-cloud-instance-triggers.gen.go
+++ b/domain/schema/model/triggers/machine-cloud-instance-triggers.gen.go
@@ -8,6 +8,7 @@ import (
 	"github.com/juju/juju/core/database/schema"
 )
 
+
 // ChangeLogTriggersForMachineCloudInstance generates the triggers for the
 // machine_cloud_instance table.
 func ChangeLogTriggersForMachineCloudInstance(columnName string, namespaceID int) func() schema.Patch {
@@ -52,3 +53,4 @@ BEGIN
 END;`, columnName, namespaceID))
 	}
 }
+

--- a/domain/schema/model/triggers/machine-cloud-instance-triggers.gen.go
+++ b/domain/schema/model/triggers/machine-cloud-instance-triggers.gen.go
@@ -8,7 +8,6 @@ import (
 	"github.com/juju/juju/core/database/schema"
 )
 
-
 // ChangeLogTriggersForMachineCloudInstance generates the triggers for the
 // machine_cloud_instance table.
 func ChangeLogTriggersForMachineCloudInstance(columnName string, namespaceID int) func() schema.Patch {
@@ -53,4 +52,3 @@ BEGIN
 END;`, columnName, namespaceID))
 	}
 }
-

--- a/domain/schema/model/triggers/machine-requires-reboot-triggers.gen.go
+++ b/domain/schema/model/triggers/machine-requires-reboot-triggers.gen.go
@@ -8,6 +8,7 @@ import (
 	"github.com/juju/juju/core/database/schema"
 )
 
+
 // ChangeLogTriggersForMachineRequiresReboot generates the triggers for the
 // machine_requires_reboot table.
 func ChangeLogTriggersForMachineRequiresReboot(columnName string, namespaceID int) func() schema.Patch {
@@ -43,3 +44,4 @@ BEGIN
 END;`, columnName, namespaceID))
 	}
 }
+

--- a/domain/schema/model/triggers/machine-requires-reboot-triggers.gen.go
+++ b/domain/schema/model/triggers/machine-requires-reboot-triggers.gen.go
@@ -8,7 +8,6 @@ import (
 	"github.com/juju/juju/core/database/schema"
 )
 
-
 // ChangeLogTriggersForMachineRequiresReboot generates the triggers for the
 // machine_requires_reboot table.
 func ChangeLogTriggersForMachineRequiresReboot(columnName string, namespaceID int) func() schema.Patch {
@@ -44,4 +43,3 @@ BEGIN
 END;`, columnName, namespaceID))
 	}
 }
-

--- a/domain/schema/model/triggers/machine-triggers.gen.go
+++ b/domain/schema/model/triggers/machine-triggers.gen.go
@@ -8,6 +8,7 @@ import (
 	"github.com/juju/juju/core/database/schema"
 )
 
+
 // ChangeLogTriggersForMachine generates the triggers for the
 // machine table.
 func ChangeLogTriggersForMachine(columnName string, namespaceID int) func() schema.Patch {
@@ -93,3 +94,4 @@ BEGIN
 END;`, columnName, namespaceID))
 	}
 }
+

--- a/domain/schema/model/triggers/machine-triggers.gen.go
+++ b/domain/schema/model/triggers/machine-triggers.gen.go
@@ -8,7 +8,6 @@ import (
 	"github.com/juju/juju/core/database/schema"
 )
 
-
 // ChangeLogTriggersForMachine generates the triggers for the
 // machine table.
 func ChangeLogTriggersForMachine(columnName string, namespaceID int) func() schema.Patch {
@@ -94,4 +93,3 @@ BEGIN
 END;`, columnName, namespaceID))
 	}
 }
-

--- a/domain/schema/model/triggers/model-triggers.gen.go
+++ b/domain/schema/model/triggers/model-triggers.gen.go
@@ -8,6 +8,7 @@ import (
 	"github.com/juju/juju/core/database/schema"
 )
 
+
 // ChangeLogTriggersForModelConfig generates the triggers for the
 // model_config table.
 func ChangeLogTriggersForModelConfig(columnName string, namespaceID int) func() schema.Patch {
@@ -43,3 +44,4 @@ BEGIN
 END;`, columnName, namespaceID))
 	}
 }
+

--- a/domain/schema/model/triggers/model-triggers.gen.go
+++ b/domain/schema/model/triggers/model-triggers.gen.go
@@ -8,7 +8,6 @@ import (
 	"github.com/juju/juju/core/database/schema"
 )
 
-
 // ChangeLogTriggersForModelConfig generates the triggers for the
 // model_config table.
 func ChangeLogTriggersForModelConfig(columnName string, namespaceID int) func() schema.Patch {
@@ -44,4 +43,3 @@ BEGIN
 END;`, columnName, namespaceID))
 	}
 }
-

--- a/domain/schema/model/triggers/network-triggers.gen.go
+++ b/domain/schema/model/triggers/network-triggers.gen.go
@@ -8,7 +8,6 @@ import (
 	"github.com/juju/juju/core/database/schema"
 )
 
-
 // ChangeLogTriggersForSubnet generates the triggers for the
 // subnet table.
 func ChangeLogTriggersForSubnet(columnName string, namespaceID int) func() schema.Patch {
@@ -46,4 +45,3 @@ BEGIN
 END;`, columnName, namespaceID))
 	}
 }
-

--- a/domain/schema/model/triggers/network-triggers.gen.go
+++ b/domain/schema/model/triggers/network-triggers.gen.go
@@ -8,6 +8,7 @@ import (
 	"github.com/juju/juju/core/database/schema"
 )
 
+
 // ChangeLogTriggersForSubnet generates the triggers for the
 // subnet table.
 func ChangeLogTriggersForSubnet(columnName string, namespaceID int) func() schema.Patch {
@@ -45,3 +46,4 @@ BEGIN
 END;`, columnName, namespaceID))
 	}
 }
+

--- a/domain/schema/model/triggers/objectstore-triggers.gen.go
+++ b/domain/schema/model/triggers/objectstore-triggers.gen.go
@@ -8,7 +8,6 @@ import (
 	"github.com/juju/juju/core/database/schema"
 )
 
-
 // ChangeLogTriggersForObjectStoreMetadataPath generates the triggers for the
 // object_store_metadata_path table.
 func ChangeLogTriggersForObjectStoreMetadataPath(columnName string, namespaceID int) func() schema.Patch {
@@ -44,4 +43,3 @@ BEGIN
 END;`, columnName, namespaceID))
 	}
 }
-

--- a/domain/schema/model/triggers/objectstore-triggers.gen.go
+++ b/domain/schema/model/triggers/objectstore-triggers.gen.go
@@ -8,6 +8,7 @@ import (
 	"github.com/juju/juju/core/database/schema"
 )
 
+
 // ChangeLogTriggersForObjectStoreMetadataPath generates the triggers for the
 // object_store_metadata_path table.
 func ChangeLogTriggersForObjectStoreMetadataPath(columnName string, namespaceID int) func() schema.Patch {
@@ -43,3 +44,4 @@ BEGIN
 END;`, columnName, namespaceID))
 	}
 }
+

--- a/domain/schema/model/triggers/secret-triggers.gen.go
+++ b/domain/schema/model/triggers/secret-triggers.gen.go
@@ -8,6 +8,7 @@ import (
 	"github.com/juju/juju/core/database/schema"
 )
 
+
 // ChangeLogTriggersForSecretDeletedValueRef generates the triggers for the
 // secret_deleted_value_ref table.
 func ChangeLogTriggersForSecretDeletedValueRef(columnName string, namespaceID int) func() schema.Patch {
@@ -269,3 +270,4 @@ BEGIN
 END;`, columnName, namespaceID))
 	}
 }
+

--- a/domain/schema/model/triggers/secret-triggers.gen.go
+++ b/domain/schema/model/triggers/secret-triggers.gen.go
@@ -8,7 +8,6 @@ import (
 	"github.com/juju/juju/core/database/schema"
 )
 
-
 // ChangeLogTriggersForSecretDeletedValueRef generates the triggers for the
 // secret_deleted_value_ref table.
 func ChangeLogTriggersForSecretDeletedValueRef(columnName string, namespaceID int) func() schema.Patch {
@@ -270,4 +269,3 @@ BEGIN
 END;`, columnName, namespaceID))
 	}
 }
-

--- a/domain/schema/model/triggers/storage-triggers.gen.go
+++ b/domain/schema/model/triggers/storage-triggers.gen.go
@@ -8,7 +8,6 @@ import (
 	"github.com/juju/juju/core/database/schema"
 )
 
-
 // ChangeLogTriggersForBlockDevice generates the triggers for the
 // block_device table.
 func ChangeLogTriggersForBlockDevice(columnName string, namespaceID int) func() schema.Patch {
@@ -299,4 +298,3 @@ BEGIN
 END;`, columnName, namespaceID))
 	}
 }
-

--- a/domain/schema/model/triggers/storage-triggers.gen.go
+++ b/domain/schema/model/triggers/storage-triggers.gen.go
@@ -8,6 +8,7 @@ import (
 	"github.com/juju/juju/core/database/schema"
 )
 
+
 // ChangeLogTriggersForBlockDevice generates the triggers for the
 // block_device table.
 func ChangeLogTriggersForBlockDevice(columnName string, namespaceID int) func() schema.Patch {
@@ -298,3 +299,4 @@ BEGIN
 END;`, columnName, namespaceID))
 	}
 }
+

--- a/domain/schema/model/triggers/user-public-ssh-key.gen.go
+++ b/domain/schema/model/triggers/user-public-ssh-key.gen.go
@@ -8,7 +8,6 @@ import (
 	"github.com/juju/juju/core/database/schema"
 )
 
-
 // ChangeLogTriggersForUserPublicSshKey generates the triggers for the
 // user_public_ssh_key table.
 func ChangeLogTriggersForUserPublicSshKey(columnName string, namespaceID int) func() schema.Patch {
@@ -48,4 +47,3 @@ BEGIN
 END;`, columnName, namespaceID))
 	}
 }
-

--- a/domain/schema/schema_test.go
+++ b/domain/schema/schema_test.go
@@ -19,6 +19,7 @@ import (
 	coresecrets "github.com/juju/juju/core/secrets"
 	jujuversion "github.com/juju/juju/core/version"
 	databasetesting "github.com/juju/juju/internal/database/testing"
+	"github.com/juju/juju/internal/errors"
 )
 
 type schemaSuite struct {
@@ -749,7 +750,7 @@ WHERE edit_type_id = ? AND namespace_id = ?;`[1:], editType, namespaceID)
 		defer func() { _ = rows.Close() }()
 
 		if !rows.Next() {
-			return fmt.Errorf("no rows returned")
+			return errors.Errorf("no rows returned")
 		}
 		return rows.Scan(&count)
 	})

--- a/domain/secret/errors/errors.go
+++ b/domain/secret/errors/errors.go
@@ -3,9 +3,7 @@
 
 package errors
 
-import (
-	"github.com/juju/errors"
-)
+import "github.com/juju/juju/internal/errors"
 
 const (
 	// PermissionDenied describes an error that occurs when the secret being operated on

--- a/domain/secret/modelmigration/export.go
+++ b/domain/secret/modelmigration/export.go
@@ -5,18 +5,18 @@ package modelmigration
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/juju/description/v8"
-	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 
+	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/modelmigration"
 	"github.com/juju/juju/core/secrets"
 	"github.com/juju/juju/domain/secret/service"
 	"github.com/juju/juju/domain/secret/state"
 	secretbackendstate "github.com/juju/juju/domain/secretbackend/state"
+	"github.com/juju/juju/internal/errors"
 )
 
 // RegisterExport registers the export operations with the given coordinator.
@@ -69,7 +69,7 @@ func ownerTagFromOwner(owner secrets.Owner) (names.Tag, error) {
 	case secrets.ModelOwner:
 		return names.NewModelTag(owner.ID), nil
 	}
-	return nil, errors.NotValidf("owner kind %q", owner.Kind)
+	return nil, errors.Errorf("owner kind %q %w", owner.Kind, coreerrors.NotValid)
 }
 
 func scopeTagFromAccessScope(scope service.SecretAccessScope) (names.Tag, error) {
@@ -83,7 +83,7 @@ func scopeTagFromAccessScope(scope service.SecretAccessScope) (names.Tag, error)
 	case service.ModelAccessScope:
 		return names.NewModelTag(scope.ID), nil
 	}
-	return nil, errors.NotValidf("scope kind %q", scope.Kind)
+	return nil, errors.Errorf("scope kind %q %w", scope.Kind, coreerrors.NotValid)
 }
 
 func accessorTagFromAccessor(subject service.SecretAccessor) (names.Tag, error) {
@@ -97,36 +97,36 @@ func accessorTagFromAccessor(subject service.SecretAccessor) (names.Tag, error) 
 	case service.RemoteApplicationAccessor:
 		return names.NewApplicationTag(subject.ID), nil
 	}
-	return nil, errors.NotValidf("subject kind %q", subject.Kind)
+	return nil, errors.Errorf("subject kind %q %w", subject.Kind, coreerrors.NotValid)
 }
 
 // Execute exports any secrets to the specified model.
 func (e *exportOperation) Execute(ctx context.Context, model description.Model) error {
 	allSecrets, err := e.service.GetSecretsForExport(ctx)
 	if err != nil {
-		return errors.Annotate(err, "failed to list secrets for export")
+		return errors.Errorf("failed to list secrets for export %w", err)
 	}
 
 	accessArgsByID, err := e.collateAccess(allSecrets.Access)
 	if err != nil {
-		return errors.Annotatef(err, "collating secret access args")
+		return errors.Errorf("collating secret access args %w", err)
 	}
 
 	consumersByID, err := e.collateConsumers(allSecrets.Consumers)
 	if err != nil {
-		return errors.Annotatef(err, "collating secret consumer args")
+		return errors.Errorf("collating secret consumer args %w", err)
 	}
 
 	remoteConsumersByID, err := e.collateRemoteConsumers(allSecrets.RemoteConsumers)
 	if err != nil {
-		return errors.Annotatef(err, "collating secret remote consumer args")
+		return errors.Errorf("collating secret remote consumer args %w", err)
 	}
 
 	for _, md := range allSecrets.Secrets {
 		ownerTag, err := ownerTagFromOwner(md.Owner)
 		if err != nil {
 			// Should never happen.
-			return errors.Annotatef(err, "invalid secret owner %q", md.Owner.ID)
+			return errors.Errorf("invalid secret owner %q %w", md.Owner.ID, err)
 		}
 
 		revisionArgsByID := make(map[string][]description.SecretRevisionArgs)
@@ -147,7 +147,7 @@ func (e *exportOperation) Execute(ctx context.Context, model description.Model) 
 					RevisionID: rev.ValueRef.RevisionID,
 				}
 			} else {
-				return fmt.Errorf("missing secret content to export for secret %q", md.URI.ID)
+				return errors.Errorf("missing secret content to export for secret %q", md.URI.ID)
 			}
 			revisionArgsByID[md.URI.ID] = append(revisionArgsByID[md.URI.ID], revArg)
 		}
@@ -176,7 +176,7 @@ func (e *exportOperation) Execute(ctx context.Context, model description.Model) 
 		consumerTag, err := accessorTagFromAccessor(rs.Accessor)
 		if err != nil {
 			// Should never happen.
-			return errors.Annotatef(err, "invalid remote secret accessor %q", rs.Accessor.ID)
+			return errors.Errorf("invalid remote secret accessor %q %w", rs.Accessor.ID, err)
 		}
 		arg := description.RemoteSecretArgs{
 			ID:              rs.URI.ID,
@@ -198,7 +198,7 @@ func (e *exportOperation) collateConsumers(consumers map[string][]service.Consum
 			consumerTag, err := accessorTagFromAccessor(info.Accessor)
 			if err != nil {
 				// Should never happen.
-				return nil, errors.Annotatef(err, "invalid secret consumer %q", info.Accessor.ID)
+				return nil, errors.Errorf("invalid secret consumer %q %w", info.Accessor.ID, err)
 			}
 			consumerArg := description.SecretConsumerArgs{
 				Consumer:        consumerTag,
@@ -218,7 +218,7 @@ func (e *exportOperation) collateRemoteConsumers(consumers map[string][]service.
 			consumerTag, err := accessorTagFromAccessor(info.Accessor)
 			if err != nil {
 				// Should never happen.
-				return nil, errors.Annotatef(err, "invalid remote secret consumer %q", info.Accessor.ID)
+				return nil, errors.Errorf("invalid remote secret consumer %q %w", info.Accessor.ID, err)
 			}
 			consumerArg := description.SecretRemoteConsumerArgs{
 				Consumer:        consumerTag,
@@ -237,7 +237,7 @@ func (e *exportOperation) collateAccess(access map[string][]service.SecretAccess
 			scopeTag, err := scopeTagFromAccessScope(perm.Scope)
 			if err != nil {
 				// Should never happen.
-				return nil, errors.Annotatef(err, "invalid secret access scope %q", perm.Scope.ID)
+				return nil, errors.Errorf("invalid secret access scope %q %w", perm.Scope.ID, err)
 			}
 			accessArg := description.SecretAccessArgs{
 				Scope: scopeTag.String(),
@@ -251,7 +251,7 @@ func (e *exportOperation) collateAccess(access map[string][]service.SecretAccess
 			accessorTag, err := accessorTagFromAccessor(perm.Subject)
 			if err != nil {
 				// Should never happen.
-				return nil, errors.Annotatef(err, "invalid secret accessor %q", perm.Subject.ID)
+				return nil, errors.Errorf("invalid secret accessor %q %w", perm.Subject.ID, err)
 			}
 			access[accessorTag.String()] = accessArg
 		}

--- a/domain/secret/service/access.go
+++ b/domain/secret/service/access.go
@@ -5,16 +5,15 @@ package service
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
-	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 
 	"github.com/juju/juju/core/leadership"
 	"github.com/juju/juju/core/secrets"
 	domainsecret "github.com/juju/juju/domain/secret"
 	secreterrors "github.com/juju/juju/domain/secret/errors"
+	"github.com/juju/juju/internal/errors"
 )
 
 // GetSecretGrants returns the subjects which have the specified access to the secret.
@@ -22,7 +21,7 @@ import (
 func (s *SecretService) GetSecretGrants(ctx context.Context, uri *secrets.URI, role secrets.SecretRole) ([]SecretAccess, error) {
 	accessors, err := s.secretState.GetSecretGrants(ctx, uri, role)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	result := make([]SecretAccess, len(accessors))
 	for i, accessor := range accessors {
@@ -78,7 +77,7 @@ func (s *SecretService) GetSecretAccessScope(ctx context.Context, uri *secrets.U
 	}
 	accessScope, err := s.secretState.GetSecretAccessScope(ctx, uri, ap)
 	if err != nil {
-		return SecretAccessScope{}, errors.Trace(err)
+		return SecretAccessScope{}, errors.Capture(err)
 	}
 	result := SecretAccessScope{
 		ID: accessScope.ScopeID,
@@ -114,7 +113,7 @@ func (s *SecretService) getSecretAccess(ctx context.Context, uri *secrets.URI, a
 	}
 	role, err := s.secretState.GetSecretAccess(ctx, uri, ap)
 	if err != nil {
-		return secrets.RoleNone, errors.Trace(err)
+		return secrets.RoleNone, errors.Capture(err)
 	}
 	// "none" is db value, secret enum is "".
 	if role == "none" {
@@ -131,7 +130,7 @@ func (s *SecretService) getSecretAccess(ctx context.Context, uri *secrets.URI, a
 func (s *SecretService) GrantSecretAccess(ctx context.Context, uri *secrets.URI, params SecretAccessParams) error {
 	withCaveat, err := s.getManagementCaveat(ctx, uri, params.Accessor, params.LeaderToken)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	return withCaveat(ctx, func(innerCtx context.Context) error {
@@ -174,7 +173,7 @@ func grantParams(in SecretAccessParams) domainsecret.GrantParams {
 func (s *SecretService) RevokeSecretAccess(ctx context.Context, uri *secrets.URI, params SecretAccessParams) error {
 	withCaveat, err := s.getManagementCaveat(ctx, uri, params.Accessor, params.LeaderToken)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	p := domainsecret.AccessParams{
@@ -212,7 +211,7 @@ func (s *SecretService) getManagementCaveat(
 	hasRole, err := s.getSecretAccess(ctx, uri, assessor)
 	if err != nil {
 		// Typically not found error.
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	if hasRole.Allowed(secrets.RoleManage) {
 		return func(ctx context.Context, fn func(context.Context) error) error {
@@ -235,7 +234,7 @@ func (s *SecretService) getManagementCaveat(
 			})
 			if err != nil {
 				// Typically not found error.
-				return nil, errors.Trace(err)
+				return nil, errors.Capture(err)
 			}
 			if hasRole.Allowed(secrets.RoleManage) {
 				return func(ctx context.Context, fn func(context.Context) error) error {
@@ -244,8 +243,7 @@ func (s *SecretService) getManagementCaveat(
 			}
 		}
 	}
-	return nil, fmt.Errorf(
-		"%q is not allowed to manage this secret %w", assessor.ID, errors.Hide(secreterrors.PermissionDenied))
+	return nil, errors.Errorf("%q is not allowed to manage this secret", assessor.ID).Add(secreterrors.PermissionDenied)
 }
 
 // canRead checks that the accessor can read the secret.
@@ -254,13 +252,13 @@ func (s *SecretService) canRead(ctx context.Context, uri *secrets.URI, accessor 
 	hasRole, err := s.getSecretAccess(ctx, uri, accessor)
 	if err != nil {
 		// Typically not found error.
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	if hasRole.Allowed(secrets.RoleView) {
 		return nil
 	}
 
-	notAllowedErr := fmt.Errorf("%q is not allowed to read this secret%w", accessor.ID, errors.Hide(secreterrors.PermissionDenied))
+	notAllowedErr := errors.Errorf("%q is not allowed to read this secret", accessor.ID).Add(secreterrors.PermissionDenied)
 
 	if accessor.Kind != UnitAccessor {
 		return notAllowedErr
@@ -279,7 +277,7 @@ func (s *SecretService) canRead(ctx context.Context, uri *secrets.URI, accessor 
 	})
 	if err != nil {
 		// Typically not found error.
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	if hasRole.Allowed(secrets.RoleView) {
 		return nil

--- a/domain/secret/service/service.go
+++ b/domain/secret/service/service.go
@@ -498,10 +498,6 @@ func (s *SecretService) UpdateCharmSecret(ctx context.Context, uri *secrets.URI,
 		}
 		return nil
 	})
-	if err != nil {
-		return errors.Errorf("cannot update charm secret %q %w", uri.ID, err)
-	}
-	return nil
 }
 
 func (s *SecretService) createSecret(

--- a/domain/secret/service/service_test.go
+++ b/domain/secret/service/service_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/juju/clock/testclock"
-	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v4/workertest"
@@ -18,6 +17,7 @@ import (
 	coreapplication "github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/changestream"
 	"github.com/juju/juju/core/database"
+	coreerrors "github.com/juju/juju/core/errors"
 	coremodel "github.com/juju/juju/core/model"
 	modeltesting "github.com/juju/juju/core/model/testing"
 	coresecrets "github.com/juju/juju/core/secrets"
@@ -29,6 +29,7 @@ import (
 	domainsecret "github.com/juju/juju/domain/secret"
 	secreterrors "github.com/juju/juju/domain/secret/errors"
 	domaintesting "github.com/juju/juju/domain/testing"
+	"github.com/juju/juju/internal/errors"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 	"github.com/juju/juju/internal/secrets/provider"
 	coretesting "github.com/juju/juju/internal/testing"
@@ -181,7 +182,7 @@ func (s *serviceSuite) assertCreateUserSecret(c *gc.C, isInternal, finalStepFail
 	)
 	if isInternal {
 		s.secretsBackend.EXPECT().SaveContent(gomock.Any(), uri, 1, coresecrets.NewSecretValue(map[string]string{"foo": "bar"})).
-			Return("", errors.NotSupportedf("not supported"))
+			Return("", errors.Errorf("not supported %w", coreerrors.NotSupported))
 
 	} else {
 		s.secretsBackend.EXPECT().SaveContent(gomock.Any(), uri, 1, coresecrets.NewSecretValue(map[string]string{"foo": "bar"})).
@@ -249,7 +250,7 @@ func (s *serviceSuite) assertUpdateUserSecret(c *gc.C, isInternal, finalStepFail
 	uri := coresecrets.NewURI()
 	if isInternal {
 		s.secretsBackend.EXPECT().SaveContent(gomock.Any(), uri, 3, coresecrets.NewSecretValue(map[string]string{"foo": "bar"})).
-			Return("", errors.NotSupportedf("not supported"))
+			Return("", errors.Errorf("not supported %w", coreerrors.NotSupported))
 	} else {
 		s.secretsBackend.EXPECT().SaveContent(gomock.Any(), uri, 3, coresecrets.NewSecretValue(map[string]string{"foo": "bar"})).
 			Return("rev-id", nil)

--- a/domain/secret/service/watcher.go
+++ b/domain/secret/service/watcher.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 
 	"github.com/juju/collections/set"
-	"github.com/juju/errors"
 	"github.com/juju/worker/v4"
 	"github.com/juju/worker/v4/catacomb"
 
@@ -17,6 +16,7 @@ import (
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/core/watcher/eventsource"
+	"github.com/juju/juju/internal/errors"
 )
 
 // WatchableService provides the API for working with the secret service.
@@ -47,14 +47,14 @@ func (s *WatchableService) WatchConsumedSecretsChanges(ctx context.Context, unit
 		tableLocal, changestream.Create, queryLocal,
 	)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	processLocalChanges := func(ctx context.Context, revisionUUIDs ...string) ([]string, error) {
 		return s.secretState.GetConsumedSecretURIsWithChanges(ctx, unitName, revisionUUIDs...)
 	}
 	sWLocal, err := newSecretStringWatcher(wLocal, s.logger, processLocalChanges)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	tableRemote, queryRemote := s.secretState.InitialWatchStatementForConsumedRemoteSecretsChange(unitName)
@@ -63,14 +63,14 @@ func (s *WatchableService) WatchConsumedSecretsChanges(ctx context.Context, unit
 		tableRemote, changestream.All, queryRemote,
 	)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	processRemoteChanges := func(ctx context.Context, secretIDs ...string) ([]string, error) {
 		return s.secretState.GetConsumedRemoteSecretURIsWithChanges(ctx, unitName, secretIDs...)
 	}
 	sWRemote, err := newSecretStringWatcher(wRemote, s.logger, processRemoteChanges)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	return eventsource.NewMultiStringsWatcher(ctx, sWLocal, sWRemote)
 }
@@ -84,7 +84,7 @@ func (s *WatchableService) WatchRemoteConsumedSecretsChanges(_ context.Context, 
 		table, changestream.All, query,
 	)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	processChanges := func(ctx context.Context, secretIDs ...string) ([]string, error) {
 		return s.secretState.GetRemoteConsumedSecretURIsWithChangesFromOfferingSide(ctx, appName, secretIDs...)
@@ -110,7 +110,7 @@ func (s *WatchableService) WatchObsolete(_ context.Context, owners ...CharmSecre
 		table, changestream.Create, query,
 	)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	processChanges := func(ctx context.Context, revisionUUIDs ...string) ([]string, error) {
 		return s.secretState.GetRevisionIDsForObsolete(ctx, appOwners, unitOwners, revisionUUIDs...)
@@ -130,12 +130,12 @@ func (s *WatchableService) WatchSecretRevisionsExpiryChanges(_ context.Context, 
 		table, changestream.All, query,
 	)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	processChanges := func(ctx context.Context, revisionUUIDs ...string) ([]watcher.SecretTriggerChange, error) {
 		result, err := s.secretState.GetSecretsRevisionExpiryChanges(ctx, appOwners, unitOwners, revisionUUIDs...)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, errors.Capture(err)
 		}
 		changes := make([]watcher.SecretTriggerChange, len(result))
 		for i, r := range result {
@@ -162,12 +162,12 @@ func (s *WatchableService) WatchSecretsRotationChanges(_ context.Context, owners
 		table, changestream.All, query,
 	)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	processChanges := func(ctx context.Context, secretIDs ...string) ([]watcher.SecretTriggerChange, error) {
 		result, err := s.secretState.GetSecretsRotationChanges(ctx, appOwners, unitOwners, secretIDs...)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, errors.Capture(err)
 		}
 		changes := make([]watcher.SecretTriggerChange, len(result))
 		for i, r := range result {
@@ -190,7 +190,7 @@ func (s *WatchableService) WatchObsoleteUserSecretsToPrune(ctx context.Context) 
 		}
 		obsoleteRevs, err := s.secretState.GetObsoleteUserSecretRevisionsReadyToPrune(ctx)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, errors.Capture(err)
 		}
 		if len(obsoleteRevs) == 0 {
 			return nil, nil
@@ -204,14 +204,14 @@ func (s *WatchableService) WatchObsoleteUserSecretsToPrune(ctx context.Context) 
 		"secret_revision_obsolete", changestream.Create, mapper,
 	)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	wAutoPrune, err := s.watcherFactory.NewNamespaceNotifyMapperWatcher(
 		"secret_metadata", changestream.Update, mapper,
 	)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	return eventsource.NewMultiNotifyWatcher(ctx, wObsolete, wAutoPrune)
 }
@@ -242,7 +242,7 @@ func newSecretStringWatcher[T any](
 		Work: w.loop,
 		Init: []worker.Worker{sourceWatcher},
 	})
-	return w, errors.Trace(err)
+	return w, errors.Capture(err)
 }
 
 func (w *secretWatcher[T]) scopedContext() (context.Context, context.CancelFunc) {
@@ -266,7 +266,7 @@ func (w *secretWatcher[T]) loop() error {
 		processed, err := w.processChanges(ctx, events.Values()...)
 		cancel()
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		if len(processed) == 0 {
 			return nil
@@ -297,7 +297,7 @@ func (w *secretWatcher[T]) loop() error {
 				return errors.Errorf("event watcher closed")
 			}
 			if err := addChanges(set.NewStrings(events...)); err != nil {
-				return errors.Trace(err)
+				return errors.Capture(err)
 			}
 		case out <- changes:
 			changes = nil

--- a/domain/secret/state/state.go
+++ b/domain/secret/state/state.go
@@ -11,10 +11,10 @@ import (
 	"time"
 
 	"github.com/canonical/sqlair"
-	"github.com/juju/errors"
 
 	coreapplication "github.com/juju/juju/core/application"
 	coredatabase "github.com/juju/juju/core/database"
+	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/logger"
 	coresecrets "github.com/juju/juju/core/secrets"
 	coreunit "github.com/juju/juju/core/unit"
@@ -24,6 +24,7 @@ import (
 	modelerrors "github.com/juju/juju/domain/model/errors"
 	domainsecret "github.com/juju/juju/domain/secret"
 	secreterrors "github.com/juju/juju/domain/secret/errors"
+	"github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/internal/uuid"
 )
 
@@ -47,7 +48,7 @@ func NewState(factory coredatabase.TxnRunnerFactory, logger logger.Logger) *Stat
 func (st State) GetModelUUID(ctx context.Context) (string, error) {
 	db, err := st.DB()
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", errors.Capture(err)
 	}
 
 	var modelUUID string
@@ -56,7 +57,7 @@ func (st State) GetModelUUID(ctx context.Context) (string, error) {
 		modelUUID, err = st.getModelUUID(ctx, tx)
 		return err
 	})
-	return modelUUID, errors.Trace(err)
+	return modelUUID, errors.Capture(err)
 }
 
 func (st State) getModelUUID(ctx context.Context, tx *sqlair.TX) (string, error) {
@@ -65,7 +66,7 @@ func (st State) getModelUUID(ctx context.Context, tx *sqlair.TX) (string, error)
 	getModelUUIDSQL := "SELECT &M.uuid FROM model"
 	getModelUUIDStmt, err := st.Prepare(getModelUUIDSQL, result)
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", errors.Capture(err)
 	}
 
 	err = tx.Query(ctx, getModelUUIDStmt).Get(&result)
@@ -73,7 +74,7 @@ func (st State) getModelUUID(ctx context.Context, tx *sqlair.TX) (string, error)
 		if errors.Is(err, sqlair.ErrNoRows) {
 			return "", modelerrors.NotFound
 		} else {
-			return "", errors.Annotatef(err, "looking up model UUID")
+			return "", errors.Errorf("looking up model UUID %w", err)
 		}
 	}
 	return result["uuid"].(string), nil
@@ -89,20 +90,20 @@ SELECT &application.uuid
 FROM application
 WHERE name=$application.name`, app)
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", errors.Capture(err)
 	}
 
 	err = domain.Run(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err = tx.Query(ctx, selectApplicationUUIDStmt, app).Get(&app)
 		if errors.Is(err, sqlair.ErrNoRows) {
-			return fmt.Errorf("application %q not found%w", appName, errors.Hide(applicationerrors.ApplicationNotFound))
+			return errors.Errorf("application %q not found", appName).Add(applicationerrors.ApplicationNotFound)
 		}
 		if err != nil {
-			return errors.Annotatef(err, "looking up application UUID for %q", appName)
+			return errors.Errorf("looking up application UUID for %q %w", appName, err)
 		}
 		return nil
 	})
-	return app.UUID, errors.Trace(err)
+	return app.UUID, errors.Capture(err)
 }
 
 // GetUnitUUID returns the UUID of the unit with the given name, returning an error satisfying
@@ -112,9 +113,9 @@ func (st State) GetUnitUUID(ctx domain.AtomicContext, unitName string) (coreunit
 	err := domain.Run(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		var err error
 		unitUUID, err = st.getUnitUUID(ctx, tx, unitName)
-		return errors.Trace(err)
+		return errors.Capture(err)
 	})
-	return unitUUID, errors.Trace(err)
+	return unitUUID, errors.Capture(err)
 }
 
 func (st State) getUnitUUID(ctx context.Context, tx *sqlair.TX, unitName string) (coreunit.UUID, error) {
@@ -125,16 +126,16 @@ SELECT &unit.uuid
 FROM unit
 WHERE name=$unit.name`, u)
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", errors.Capture(err)
 	}
 	err = tx.Query(ctx, selectUnitUUIDStmt, u).Get(&u)
 	if errors.Is(err, sqlair.ErrNoRows) {
-		return "", fmt.Errorf("unit %q not found%w", unitName, errors.Hide(applicationerrors.UnitNotFound))
+		return "", errors.Errorf("unit %q not found", unitName).Add(applicationerrors.UnitNotFound)
 	}
 	if err != nil {
-		return "", errors.Annotatef(err, "looking up unit UUID for %q", unitName)
+		return "", errors.Errorf("looking up unit UUID for %q %w", unitName, err)
 	}
-	return u.UUID, errors.Trace(err)
+	return u.UUID, errors.Capture(err)
 }
 
 // CheckApplicationSecretLabelExists checks if a charm application secret with the given label already exists.
@@ -163,15 +164,15 @@ FROM (
 
 	checkExistsStmt, err := st.Prepare(checkLabelExistsSQL, input, count)
 	if err != nil {
-		return false, errors.Trace(err)
+		return false, errors.Capture(err)
 	}
 
 	err = domain.Run(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err := tx.Query(ctx, checkExistsStmt, input).Get(&count)
-		return errors.Trace(err)
+		return errors.Capture(err)
 	})
 	if err != nil {
-		return false, fmt.Errorf("checking if secret owned by application %q with label %q exists: %w", appUUID, label, err)
+		return false, errors.Errorf("checking if secret owned by application %q with label %q exists: %w", appUUID, label, err)
 	}
 	return count.Num > 0, nil
 }
@@ -204,16 +205,17 @@ FROM (
 
 	checkExistsStmt, err := st.Prepare(checkLabelExistsSQL, input, count)
 	if err != nil {
-		return false, errors.Trace(err)
+		return false, errors.Capture(err)
 	}
 
 	err = domain.Run(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err := tx.Query(ctx, checkExistsStmt, input).Get(&count)
-		return errors.Trace(err)
+		return errors.Capture(err)
 	})
 	if err != nil {
-		return false, fmt.Errorf(
+		return false, errors.Errorf(
 			"checking if secret owned by unit %q with label %q exists: %w", unitUUID, label, err)
+
 	}
 	return count.Num > 0, nil
 
@@ -233,14 +235,14 @@ WHERE  label = $secretOwner.label`
 
 	checkExistsStmt, err := st.Prepare(checkLabelExistsSQL, input, count)
 	if err != nil {
-		return false, errors.Trace(err)
+		return false, errors.Capture(err)
 	}
 	err = domain.Run(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err := tx.Query(ctx, checkExistsStmt, input).Get(&count)
-		return errors.Trace(err)
+		return errors.Capture(err)
 	})
 	if err != nil {
-		return false, fmt.Errorf("checking if user secret with label %q exists: %w", label, err)
+		return false, errors.Errorf("checking if user secret with label %q exists: %w", label, err)
 	}
 	return count.Num > 0, nil
 }
@@ -253,7 +255,7 @@ func (st State) CreateUserSecret(
 ) error {
 	err := domain.Run(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		if err := st.createSecret(ctx, tx, version, uri, secret); err != nil {
-			return errors.Annotatef(err, "inserting secret records for secret %q", uri)
+			return errors.Errorf("inserting secret records for secret %q %w", uri, err)
 		}
 
 		label := ""
@@ -262,20 +264,20 @@ func (st State) CreateUserSecret(
 		}
 		dbSecretOwner := secretModelOwner{SecretID: uri.ID, Label: label}
 		if err := st.upsertSecretModelOwner(ctx, tx, dbSecretOwner); err != nil {
-			return errors.Annotatef(err, "inserting user secret record for secret %q", uri)
+			return errors.Errorf("inserting user secret record for secret %q %w", uri, err)
 		}
 
 		modelUUID, err := st.getModelUUID(ctx, tx)
 		if err != nil {
-			return errors.Annotatef(err, "cannot get current model UUID for secret %q", uri)
+			return errors.Errorf("cannot get current model UUID for secret %q %w", uri, err)
 		}
 
 		if err := st.grantSecretOwnerManage(ctx, tx, uri, modelUUID, domainsecret.SubjectModel); err != nil {
-			return errors.Annotatef(err, "granting owner manage access for secret %q", uri)
+			return errors.Errorf("granting owner manage access for secret %q %w", uri, err)
 		}
 		return nil
 	})
-	return errors.Trace(err)
+	return errors.Capture(err)
 }
 
 // CreateCharmApplicationSecret creates a secret onwed by the specified
@@ -302,21 +304,21 @@ func (st State) CreateCharmApplicationSecret(
 		}
 
 		if err := st.createSecret(ctx, tx, version, uri, secret); err != nil {
-			return errors.Annotatef(err, "inserting secret records for secret %q", uri)
+			return errors.Errorf("inserting secret records for secret %q %w", uri, err)
 		}
 
 		if err := st.upsertSecretApplicationOwner(ctx, tx, dbSecretOwner); err != nil {
-			return errors.Annotatef(err, "inserting application secret record for secret %q", uri)
+			return errors.Errorf("inserting application secret record for secret %q %w", uri, err)
 		}
 
 		if err := st.grantSecretOwnerManage(
 			ctx, tx, uri, dbSecretOwner.ApplicationUUID, domainsecret.SubjectApplication,
 		); err != nil {
-			return errors.Annotatef(err, "granting owner manage access for secret %q", uri)
+			return errors.Errorf("granting owner manage access for secret %q %w", uri, err)
 		}
 		return nil
 	})
-	return errors.Trace(err)
+	return errors.Capture(err)
 }
 
 // CreateCharmUnitSecret creates a secret onwed by the specified unit,
@@ -342,19 +344,19 @@ func (st State) CreateCharmUnitSecret(
 			UnitUUID: unitUUID.String(),
 		}
 		if err := st.createSecret(ctx, tx, version, uri, secret); err != nil {
-			return errors.Annotatef(err, "inserting secret records for secret %q", uri)
+			return errors.Errorf("inserting secret records for secret %q %w", uri, err)
 		}
 
 		if err := st.upsertSecretUnitOwner(ctx, tx, dbSecretOwner); err != nil {
-			return errors.Annotatef(err, "inserting unit secret record for secret %q", uri)
+			return errors.Errorf("inserting unit secret record for secret %q %w", uri, err)
 		}
 
 		if err := st.grantSecretOwnerManage(ctx, tx, uri, dbSecretOwner.UnitUUID, domainsecret.SubjectUnit); err != nil {
-			return errors.Annotatef(err, "granting owner manage access for secret %q", uri)
+			return errors.Errorf("granting owner manage access for secret %q %w", uri, err)
 		}
 		return nil
 	})
-	return errors.Trace(err)
+	return errors.Capture(err)
 }
 
 // UpdateSecret creates a secret with the specified parameters, returning an
@@ -371,11 +373,11 @@ func (st State) UpdateSecret(
 	err := domain.Run(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err := st.updateSecret(ctx, tx, uri, secret)
 		if err != nil {
-			return errors.Annotatef(err, "updating secret records for secret %q", uri)
+			return errors.Errorf("updating secret records for secret %q %w", uri, err)
 		}
 		return nil
 	})
-	return errors.Trace(err)
+	return errors.Capture(err)
 }
 
 // createSecret creates the records needed to store secret data,
@@ -397,12 +399,12 @@ VALUES ($secretID.id)`
 
 	insertStmt, err := st.Prepare(insertQuery, secretID{})
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	err = tx.Query(ctx, insertStmt, secretID{ID: uri.ID}).Run()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	now := time.Now().UTC()
@@ -414,7 +416,7 @@ VALUES ($secretID.id)`
 	}
 	updateSecretMetadataFromParams(secret, &dbSecret)
 	if err := st.upsertSecret(ctx, tx, dbSecret); err != nil {
-		return errors.Annotatef(err, "creating user secret %q", uri)
+		return errors.Errorf("creating user secret %q %w", uri, err)
 	}
 
 	dbRevision := &secretRevision{
@@ -425,30 +427,30 @@ VALUES ($secretID.id)`
 	}
 
 	if err := st.upsertSecretRevision(ctx, tx, dbRevision); err != nil {
-		return errors.Annotatef(err, "inserting revision for secret %q", uri)
+		return errors.Errorf("inserting revision for secret %q %w", uri, err)
 	}
 
 	if secret.ExpireTime != nil {
 		if err := st.upsertSecretRevisionExpiry(ctx, tx, dbRevision.ID, secret.ExpireTime); err != nil {
-			return errors.Annotatef(err, "inserting revision expiry for secret %q", uri)
+			return errors.Errorf("inserting revision expiry for secret %q %w", uri, err)
 		}
 	}
 
 	if secret.NextRotateTime != nil {
 		if err := st.upsertSecretNextRotateTime(ctx, tx, uri, *secret.NextRotateTime); err != nil {
-			return errors.Annotatef(err, "inserting next rotate time for secret %q", uri)
+			return errors.Errorf("inserting next rotate time for secret %q %w", uri, err)
 		}
 	}
 
 	if len(secret.Data) > 0 {
 		if err := st.updateSecretContent(ctx, tx, dbRevision.ID, secret.Data); err != nil {
-			return errors.Annotatef(err, "updating content for secret %q", uri)
+			return errors.Errorf("updating content for secret %q %w", uri, err)
 		}
 	}
 
 	if secret.ValueRef != nil {
 		if err := st.upsertSecretValueRef(ctx, tx, dbRevision.ID, secret.ValueRef); err != nil {
-			return errors.Annotatef(err, "updating backend value reference for secret %q", uri)
+			return errors.Errorf("updating backend value reference for secret %q %w", uri, err)
 		}
 	}
 	return nil
@@ -480,19 +482,19 @@ LEFT JOIN (
 WHERE  sm.secret_id = $secretID.id
 `, input, secretOwner{}, ownerKindParam)
 	if err != nil {
-		return domainsecret.Owner{}, errors.Trace(err)
+		return domainsecret.Owner{}, errors.Capture(err)
 	}
 
 	var result []secretOwner
 	err = domain.Run(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err := tx.Query(ctx, stmt, input, ownerKindParam).GetAll(&result)
 		if errors.Is(err, sqlair.ErrNoRows) || len(result) == 0 {
-			return fmt.Errorf("secret %q not found%w", uri, errors.Hide(secreterrors.SecretNotFound))
+			return errors.Errorf("secret %q not found", uri).Add(secreterrors.SecretNotFound)
 		}
-		return errors.Trace(err)
+		return errors.Capture(err)
 	})
 	if err != nil {
-		return domainsecret.Owner{}, errors.Trace(err)
+		return domainsecret.Owner{}, errors.Capture(err)
 	}
 	owner := result[0]
 	return domainsecret.Owner{
@@ -544,7 +546,7 @@ GROUP BY sm.secret_id`
 
 	existingSecretStmt, err := st.Prepare(existingSecretQuery, secretID{}, secretInfo{}, secretOwner{}, ownerKindParam)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	var (
@@ -554,15 +556,15 @@ GROUP BY sm.secret_id`
 	secretIDParam := secretID{ID: uri.ID}
 	err = tx.Query(ctx, existingSecretStmt, secretIDParam, ownerKindParam).GetAll(&dbSecrets, &dbsecretOwners)
 	if errors.Is(err, sqlair.ErrNoRows) {
-		return fmt.Errorf("secret %q not found%w", uri, errors.Hide(secreterrors.SecretNotFound))
+		return errors.Errorf("secret %q not found", uri).Add(secreterrors.SecretNotFound)
 	}
 	if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	existingResult, err := dbSecrets.toSecretMetadata(dbsecretOwners)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	existing := existingResult[0]
 	latestRevisionUUID := dbSecrets[0].LatestRevisionUUID
@@ -579,12 +581,12 @@ GROUP BY sm.secret_id`
 	dbSecret.UpdateTime = now
 	updateSecretMetadataFromParams(secret, &dbSecret)
 	if err := st.upsertSecret(ctx, tx, dbSecret); err != nil {
-		return errors.Annotatef(err, "updating secret %q", uri)
+		return errors.Errorf("updating secret %q %w", uri, err)
 	}
 
 	if secret.Label != nil {
 		if err := st.upsertSecretLabel(ctx, tx, existing.URI, *secret.Label, existing.Owner); err != nil {
-			return errors.Annotatef(err, "updating label for secret %q", uri)
+			return errors.Errorf("updating label for secret %q %w", uri, err)
 		}
 	}
 
@@ -593,16 +595,16 @@ GROUP BY sm.secret_id`
 		deleteNextRotate := "DELETE FROM secret_rotation WHERE secret_id=$secretID.id"
 		deleteNextRotateStmt, err := st.Prepare(deleteNextRotate, secretID{})
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		err = tx.Query(ctx, deleteNextRotateStmt, secretIDParam).Run()
 		if err != nil {
-			return errors.Annotatef(err, "deleting next rotate record for secret %q", uri)
+			return errors.Errorf("deleting next rotate record for secret %q %w", uri, err)
 		}
 	}
 	if secret.NextRotateTime != nil {
 		if err := st.upsertSecretNextRotateTime(ctx, tx, uri, *secret.NextRotateTime); err != nil {
-			return errors.Annotatef(err, "updating next rotate time for secret %q", uri)
+			return errors.Errorf("updating next rotate time for secret %q %w", uri, err)
 		}
 	}
 
@@ -625,30 +627,30 @@ GROUP BY sm.secret_id`
 	}
 	if dbRevision != nil {
 		if err := st.upsertSecretRevision(ctx, tx, dbRevision); err != nil {
-			return errors.Annotatef(err, "inserting revision for secret %q", uri)
+			return errors.Errorf("inserting revision for secret %q %w", uri, err)
 		}
 	}
 	if secret.ExpireTime != nil {
 		if err := st.upsertSecretRevisionExpiry(ctx, tx, latestRevisionUUID, secret.ExpireTime); err != nil {
-			return errors.Annotatef(err, "inserting revision expiry for secret %q", uri)
+			return errors.Errorf("inserting revision expiry for secret %q %w", uri, err)
 		}
 
 	}
 
 	if len(secret.Data) > 0 && shouldCreateNewRevision {
 		if err := st.updateSecretContent(ctx, tx, dbRevision.ID, secret.Data); err != nil {
-			return errors.Annotatef(err, "updating content for secret %q", uri)
+			return errors.Errorf("updating content for secret %q %w", uri, err)
 		}
 	}
 
 	if secret.ValueRef != nil && shouldCreateNewRevision {
 		if err := st.upsertSecretValueRef(ctx, tx, dbRevision.ID, secret.ValueRef); err != nil {
-			return errors.Annotatef(err, "updating backend value reference for secret %q", uri)
+			return errors.Errorf("updating backend value reference for secret %q %w", uri, err)
 		}
 	}
 
 	if err := st.markObsoleteRevisions(ctx, tx, uri); err != nil {
-		return errors.Annotatef(err, "marking obsolete revisions for secret %q", uri)
+		return errors.Errorf("marking obsolete revisions for secret %q %w", uri, err)
 	}
 	return nil
 }
@@ -678,7 +680,7 @@ WHERE sr.secret_id = $secretRef.secret_id
 AND (in_use.revision IS NULL OR in_use.revision = 0);
 `, secretRef{}, secretRevision{})
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	stmt, err := st.Prepare(`
@@ -688,7 +690,7 @@ ON CONFLICT(revision_uuid) DO UPDATE SET
     obsolete=excluded.obsolete,
     pending_delete=excluded.pending_delete`, secretRevisionObsolete{})
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	var revisionUUIIDs secretRevisions
@@ -698,7 +700,7 @@ ON CONFLICT(revision_uuid) DO UPDATE SET
 		return nil
 	}
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	for _, revisionUUID := range revisionUUIIDs {
@@ -710,7 +712,7 @@ ON CONFLICT(revision_uuid) DO UPDATE SET
 		}
 		err = tx.Query(ctx, stmt, obsolete).Run()
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 	}
 	return nil
@@ -726,7 +728,7 @@ func (st State) upsertSecretLabel(
 			Label:    label,
 		}
 		if err := st.upsertSecretModelOwner(ctx, tx, dbSecretOwner); err != nil {
-			return errors.Annotatef(err, "updating model secret record for secret %q", uri)
+			return errors.Errorf("updating model secret record for secret %q %w", uri, err)
 		}
 	case coresecrets.ApplicationOwner:
 		dbSecretOwner := secretApplicationOwner{
@@ -736,7 +738,7 @@ func (st State) upsertSecretLabel(
 			Label:           label,
 		}
 		if err := st.upsertSecretApplicationOwner(ctx, tx, dbSecretOwner); err != nil {
-			return errors.Annotatef(err, "updating application secret record for secret %q", uri)
+			return errors.Errorf("updating application secret record for secret %q %w", uri, err)
 		}
 	case coresecrets.UnitOwner:
 		dbSecretOwner := secretUnitOwner{
@@ -746,7 +748,7 @@ func (st State) upsertSecretLabel(
 			Label:    label,
 		}
 		if err := st.upsertSecretUnitOwner(ctx, tx, dbSecretOwner); err != nil {
-			return errors.Annotatef(err, "updating unit secret record for secret %q", uri)
+			return errors.Errorf("updating unit secret record for secret %q %w", uri, err)
 		}
 	}
 	return nil
@@ -780,12 +782,12 @@ ON CONFLICT(secret_id) DO UPDATE SET
 
 	insertMetadataStmt, err := st.Prepare(insertMetadataQuery, secretMetadata{})
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	err = tx.Query(ctx, insertMetadataStmt, dbSecret).Run()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	return nil
 }
@@ -819,12 +821,12 @@ ON CONFLICT(secret_id) DO UPDATE SET label=excluded.label`
 
 	insertStmt, err := st.Prepare(insertQuery, secretModelOwner{})
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	err = tx.Query(ctx, insertStmt, owner).Run()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	return nil
 }
@@ -837,12 +839,12 @@ ON CONFLICT(secret_id, application_uuid) DO UPDATE SET label=excluded.label`
 
 	insertStmt, err := st.Prepare(insertQuery, secretApplicationOwner{})
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	err = tx.Query(ctx, insertStmt, owner).Run()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	return nil
 }
@@ -855,12 +857,12 @@ ON CONFLICT(secret_id, unit_uuid) DO UPDATE SET label=excluded.label`
 
 	insertStmt, err := st.Prepare(insertQuery, secretUnitOwner{})
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	err = tx.Query(ctx, insertStmt, owner).Run()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	return nil
 }
@@ -877,12 +879,12 @@ ON CONFLICT(secret_id) DO UPDATE SET
 	rotate := secretRotate{SecretID: uri.ID, NextRotateTime: next.UTC()}
 	insertStmt, err := st.Prepare(insertQuery, rotate)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	err = tx.Query(ctx, insertStmt, rotate).Run()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	return nil
 }
@@ -896,12 +898,12 @@ VALUES ($secretRevision.*)`
 
 	insertStmt, err := st.Prepare(insertQuery, secretRevision{})
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	err = tx.Query(ctx, insertStmt, dbRevision).Run()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	return nil
@@ -923,12 +925,12 @@ ON CONFLICT(revision_uuid) DO UPDATE SET
 	expire := secretRevisionExpire{RevisionUUID: revisionUUID, ExpireTime: expireTime.UTC()}
 	insertExpireTimeStmt, err := st.Prepare(insertExpireTimeQuery, expire)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	err = tx.Query(ctx, insertExpireTimeStmt, expire).Run()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	return nil
@@ -946,7 +948,7 @@ ON CONFLICT(revision_uuid) DO UPDATE SET
 
 	upsertStmt, err := st.Prepare(upsertQuery, secretValueRef{})
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	err = tx.Query(ctx, upsertStmt, secretValueRef{
@@ -955,7 +957,7 @@ ON CONFLICT(revision_uuid) DO UPDATE SET
 		RevisionID:   valueRef.RevisionID,
 	}).Run()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	return nil
 }
@@ -973,7 +975,7 @@ AND    name NOT IN ($keysToKeep[:])`
 
 	deleteStmt, err := st.Prepare(deleteQuery, revisionUUID{}, keysToKeep{})
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	insertQuery := `
@@ -989,7 +991,7 @@ ON CONFLICT(revision_uuid, name) DO UPDATE SET
 
 	insertStmt, err := st.Prepare(insertQuery, secretContent{})
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	var keys keysToKeep
@@ -997,7 +999,7 @@ ON CONFLICT(revision_uuid, name) DO UPDATE SET
 		keys = append(keys, k)
 	}
 	if err := tx.Query(ctx, deleteStmt, revisionUUID{UUID: revUUID}, keys).Run(); err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	for key, value := range content {
 		if err := tx.Query(ctx, insertStmt, secretContent{
@@ -1005,7 +1007,7 @@ ON CONFLICT(revision_uuid, name) DO UPDATE SET
 			Name:         key,
 			Content:      value,
 		}).Run(); err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 	}
 	return nil
@@ -1040,7 +1042,7 @@ AND
 
 	queryStmt, err := st.Prepare(query, queryTypes...)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	var (
@@ -1050,12 +1052,12 @@ AND
 	if err := domain.Run(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err = tx.Query(ctx, queryStmt, appOwners, unitOwners).GetAll(&dbSecrets)
 		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		uris, err = dbSecrets.toSecretURIs()
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}); err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	return uris, nil
 }
@@ -1069,13 +1071,13 @@ func (st State) ListSecrets(ctx context.Context, uri *coresecrets.URI,
 ) ([]*coresecrets.SecretMetadata, [][]*coresecrets.SecretRevisionMetadata, error) {
 	db, err := st.DB()
 	if err != nil {
-		return nil, nil, errors.Trace(err)
+		return nil, nil, errors.Capture(err)
 	}
 
 	var revisionNotFoundErr error
 	if revision != nil {
-		revisionNotFoundErr = fmt.Errorf(
-			"secret revision %d for %s not found%w", *revision, uri, errors.Hide(secreterrors.SecretRevisionNotFound))
+		revisionNotFoundErr = errors.Errorf(
+			"secret revision %d for %s not found", *revision, uri).Add(secreterrors.SecretRevisionNotFound)
 	}
 
 	var (
@@ -1086,13 +1088,13 @@ func (st State) ListSecrets(ctx context.Context, uri *coresecrets.URI,
 		var err error
 		secrets, err = st.listSecretsAnyOwner(ctx, tx, uri)
 		if err != nil {
-			return errors.Annotate(err, "querying secrets")
+			return errors.Errorf("querying secrets %w", err)
 		}
 		revisionResult = make([][]*coresecrets.SecretRevisionMetadata, len(secrets))
 		for i, secret := range secrets {
 			secretRevisions, err := st.listSecretRevisions(ctx, tx, secret.URI, revision)
 			if err != nil {
-				return errors.Annotatef(err, "querying secret revisions for %q", secret.URI.ID)
+				return errors.Errorf("querying secret revisions for %q %w", secret.URI.ID, err)
 			}
 			revisionResult[i] = secretRevisions
 			if revision != nil && len(secretRevisions) == 0 {
@@ -1101,7 +1103,7 @@ func (st State) ListSecrets(ctx context.Context, uri *coresecrets.URI,
 		}
 		return nil
 	}); err != nil {
-		return nil, nil, errors.Trace(err)
+		return nil, nil, errors.Capture(err)
 	}
 	if revision != nil && len(secrets) == 0 {
 		return nil, nil, revisionNotFoundErr
@@ -1115,20 +1117,20 @@ func (st State) ListSecrets(ctx context.Context, uri *coresecrets.URI,
 func (st State) GetSecret(ctx context.Context, uri *coresecrets.URI) (*coresecrets.SecretMetadata, error) {
 	db, err := st.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	var secrets []*coresecrets.SecretMetadata
 	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		var err error
 		secrets, err = st.listSecretsAnyOwner(ctx, tx, uri)
-		return errors.Annotatef(err, "querying secret for %q", uri.ID)
+		return errors.Errorf("querying secret for %q %w", uri.ID, err)
 	}); err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	if len(secrets) == 0 {
-		return nil, fmt.Errorf("secret %q not found%w", uri, errors.Hide(secreterrors.SecretNotFound))
+		return nil, errors.Errorf("secret %q not found", uri).Add(secreterrors.SecretNotFound)
 	}
 	return secrets[0], nil
 }
@@ -1138,7 +1140,7 @@ func (st State) GetSecret(ctx context.Context, uri *coresecrets.URI) (*coresecre
 func (st State) GetLatestRevision(ctx context.Context, uri *coresecrets.URI) (int, error) {
 	db, err := st.DB()
 	if err != nil {
-		return 0, errors.Trace(err)
+		return 0, errors.Capture(err)
 	}
 	query := `
 SELECT MAX(sr.revision) AS &secretInfo.latest_revision
@@ -1150,19 +1152,19 @@ WHERE  sr.secret_id = $secretInfo.secret_id
 	}
 	stmt, err := st.Prepare(query, info)
 	if err != nil {
-		return 0, errors.Trace(err)
+		return 0, errors.Capture(err)
 	}
 	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err := tx.Query(ctx, stmt, info).Get(&info)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		if info.LatestRevision == 0 {
-			return fmt.Errorf("secret %q not found%w", uri, errors.Hide(secreterrors.SecretNotFound))
+			return errors.Errorf("secret %q not found", uri).Add(secreterrors.SecretNotFound)
 		}
 		return nil
 	}); err != nil {
-		return 0, errors.Trace(err)
+		return 0, errors.Capture(err)
 	}
 	return info.LatestRevision, nil
 }
@@ -1171,7 +1173,7 @@ WHERE  sr.secret_id = $secretInfo.secret_id
 func (st State) GetRotationExpiryInfo(ctx context.Context, uri *coresecrets.URI) (*domainsecret.RotationExpiryInfo, error) {
 	db, err := st.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	input := secretID{ID: uri.ID}
 	result := secretInfo{}
@@ -1189,17 +1191,17 @@ WHERE    sm.secret_id = $secretID.id
 GROUP BY sr.secret_id`, input, result)
 
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err := tx.Query(ctx, stmt, input).Get(&result)
 		if errors.Is(err, sqlair.ErrNoRows) {
-			return fmt.Errorf("secret %q not found%w", uri, errors.Hide(secreterrors.SecretNotFound))
+			return errors.Errorf("secret %q not found", uri).Add(secreterrors.SecretNotFound)
 		}
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}); err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	info := &domainsecret.RotationExpiryInfo{
 		RotatePolicy:   coresecrets.RotatePolicy(result.RotatePolicy),
@@ -1218,7 +1220,7 @@ GROUP BY sr.secret_id`, input, result)
 func (st State) GetRotatePolicy(ctx context.Context, uri *coresecrets.URI) (coresecrets.RotatePolicy, error) {
 	db, err := st.DB()
 	if err != nil {
-		return coresecrets.RotateNever, errors.Trace(err)
+		return coresecrets.RotateNever, errors.Capture(err)
 	}
 	stmt, err := st.Prepare(`
 SELECT srp.policy AS &secretInfo.policy
@@ -1226,18 +1228,18 @@ FROM   secret_metadata sm
        JOIN secret_rotate_policy srp ON srp.id = sm.rotate_policy_id
 WHERE  sm.secret_id = $secretID.id`, secretID{}, secretInfo{})
 	if err != nil {
-		return coresecrets.RotateNever, errors.Trace(err)
+		return coresecrets.RotateNever, errors.Capture(err)
 	}
 
 	var info secretInfo
 	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err := tx.Query(ctx, stmt, secretID{ID: uri.ID}).Get(&info)
 		if errors.Is(err, sqlair.ErrNoRows) {
-			return fmt.Errorf("rotate policy for %q not found%w", uri, errors.Hide(secreterrors.SecretNotFound))
+			return errors.Errorf("rotate policy for %q not found", uri).Add(secreterrors.SecretNotFound)
 		}
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}); err != nil {
-		return coresecrets.RotateNever, errors.Trace(err)
+		return coresecrets.RotateNever, errors.Capture(err)
 	}
 	return coresecrets.RotatePolicy(info.RotatePolicy), nil
 }
@@ -1296,7 +1298,7 @@ FROM   secret_metadata sm
 	queryStmt, err := st.Prepare(query, queryTypes...)
 	if err != nil {
 		st.logger.Tracef("failed to prepare err: %v, query: \n%s", err, query)
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	var (
@@ -1305,7 +1307,7 @@ FROM   secret_metadata sm
 	)
 	err = tx.Query(ctx, queryStmt, queryParams...).GetAll(&dbSecrets, &dbsecretOwners)
 	if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	return dbSecrets.toSecretMetadata(dbsecretOwners)
 }
@@ -1317,7 +1319,7 @@ func (st State) ListCharmSecrets(ctx context.Context,
 ) ([]*coresecrets.SecretMetadata, [][]*coresecrets.SecretRevisionMetadata, error) {
 	db, err := st.DB()
 	if err != nil {
-		return nil, nil, errors.Trace(err)
+		return nil, nil, errors.Capture(err)
 	}
 
 	var (
@@ -1328,19 +1330,19 @@ func (st State) ListCharmSecrets(ctx context.Context,
 		var err error
 		secrets, err = st.listCharmSecrets(ctx, tx, appOwners, unitOwners)
 		if err != nil {
-			return errors.Annotate(err, "querying charm secrets")
+			return errors.Errorf("querying charm secrets %w", err)
 		}
 		revisionResult = make([][]*coresecrets.SecretRevisionMetadata, len(secrets))
 		for i, secret := range secrets {
 			secretRevisions, err := st.listSecretRevisions(ctx, tx, secret.URI, nil)
 			if err != nil {
-				return errors.Annotatef(err, "querying secret revisions for %q", secret.URI.ID)
+				return errors.Errorf("querying secret revisions for %q %w", secret.URI.ID, err)
 			}
 			revisionResult[i] = secretRevisions
 		}
 		return nil
 	}); err != nil {
-		return nil, nil, errors.Trace(err)
+		return nil, nil, errors.Capture(err)
 	}
 
 	return secrets, revisionResult, nil
@@ -1430,7 +1432,7 @@ FROM   secret_metadata sm
 	queryParts = append(queryParts, ownerJoin, `GROUP BY sm.secret_id`)
 	queryStmt, err := st.Prepare(strings.Join(queryParts, "\n"), queryTypes...)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	var (
@@ -1439,7 +1441,7 @@ FROM   secret_metadata sm
 	)
 	err = tx.Query(ctx, queryStmt, queryParams...).GetAll(&dbSecrets, &dbsecretOwners)
 	if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	return dbSecrets.toSecretMetadata(dbsecretOwners)
 }
@@ -1448,7 +1450,7 @@ FROM   secret_metadata sm
 func (st State) ListUserSecretsToDrain(ctx context.Context) ([]*coresecrets.SecretMetadataForDrain, error) {
 	db, err := st.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	query := `
@@ -1463,7 +1465,7 @@ FROM   secret_metadata sm
 
 	queryStmt, err := st.Prepare(query, secretID{}, secretExternalRevision{})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	var (
@@ -1474,11 +1476,11 @@ FROM   secret_metadata sm
 	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err = tx.Query(ctx, queryStmt).GetAll(&dbSecrets, &dbsecretRevs)
 		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		return nil
 	}); err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	return dbSecrets.toSecretMetadataForDrain(dbsecretRevs)
@@ -1496,7 +1498,7 @@ func (st State) ListCharmSecretsToDrain(
 
 	db, err := st.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	appOwnedSelect := `
@@ -1556,7 +1558,7 @@ JOIN (
 
 	queryStmt, err := st.Prepare("WITH "+strings.Join(queryParts, "\n"), append(queryTypes, queryParams...)...)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	var (
@@ -1567,11 +1569,11 @@ JOIN (
 	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err = tx.Query(ctx, queryStmt, queryParams...).GetAll(&dbSecrets, &dbsecretRevs)
 		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		return nil
 	}); err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	return dbSecrets.toSecretMetadataForDrain(dbsecretRevs)
@@ -1581,12 +1583,12 @@ JOIN (
 // or an error satisfying [secreterrors.SecretNotFound] if there's no corresponding URI.
 func (st State) GetUserSecretURIByLabel(ctx context.Context, label string) (*coresecrets.URI, error) {
 	if label == "" {
-		return nil, errors.NotValidf("empty secret label")
+		return nil, errors.Errorf("empty secret label %w", coreerrors.NotValid)
 	}
 
 	db, err := st.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	query := `
@@ -1599,22 +1601,22 @@ WHERE  mso.label = $M.label
 
 	queryStmt, err := st.Prepare(query, secretInfo{}, arg)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	var dbSecrets secretInfos
 	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err := tx.Query(ctx, queryStmt, arg).GetAll(&dbSecrets)
 		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-			return errors.Annotatef(err, "querying secret URI for label %q", label)
+			return errors.Errorf("querying secret URI for label %q %w", label, err)
 		}
 		return nil
 	}); err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	if len(dbSecrets) == 0 {
-		return nil, fmt.Errorf("secret with label %q not found%w", label, errors.Hide(secreterrors.SecretNotFound))
+		return nil, errors.Errorf("secret with label %q not found", label).Add(secreterrors.SecretNotFound)
 	}
 	return coresecrets.ParseURI(dbSecrets[0].ID)
 }
@@ -1626,12 +1628,12 @@ WHERE  mso.label = $M.label
 // is returned.
 func (st State) GetURIByConsumerLabel(ctx context.Context, label string, unitName string) (*coresecrets.URI, error) {
 	if label == "" {
-		return nil, errors.NotValidf("empty secret label")
+		return nil, errors.Errorf("empty secret label %w", coreerrors.NotValid)
 	}
 
 	db, err := st.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	query := `
@@ -1644,7 +1646,7 @@ AND    suc.unit_uuid = $secretUnitConsumer.unit_uuid
 
 	queryStmt, err := st.Prepare(query, secretUnitConsumer{})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	var dbConsumers []secretUnitConsumer
@@ -1652,25 +1654,25 @@ AND    suc.unit_uuid = $secretUnitConsumer.unit_uuid
 		suc := secretUnitConsumer{Label: label}
 		suc.UnitUUID, err = st.getUnitUUID(ctx, tx, unitName)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		err := tx.Query(ctx, queryStmt, suc).GetAll(&dbConsumers)
 		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-			return errors.Annotatef(err, "querying secret URI for label %q", label)
+			return errors.Errorf("querying secret URI for label %q %w", label, err)
 		}
 		return nil
 	}); err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	if len(dbConsumers) == 0 {
-		return nil, fmt.Errorf(
-			"secret with label %q for unit %q not found%w", label, unitName, errors.Hide(secreterrors.SecretNotFound))
+		return nil, errors.Errorf(
+			"secret with label %q for unit %q not found", label, unitName).Add(secreterrors.SecretNotFound)
 	}
 	uri, err := coresecrets.ParseURI(dbConsumers[0].SecretID)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	return uri.WithSource(dbConsumers[0].SourceModelUUID), nil
 }
@@ -1695,7 +1697,7 @@ WHERE  secret_id = $secretRevision.secret_id
 
 	queryStmt, err := st.Prepare(query, secretRevision{}, secretRevisionExpire{}, secretValueRef{})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	var (
@@ -1705,7 +1707,7 @@ WHERE  secret_id = $secretRevision.secret_id
 	)
 	err = tx.Query(ctx, queryStmt, want).GetAll(&dbSecretRevisions, &dbSecretValueRefs, &dbSecretRevisionsExpire)
 	if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-		return nil, errors.Annotatef(err, "retrieving secret revisions for %q", uri)
+		return nil, errors.Errorf("retrieving secret revisions for %q %w", uri, err)
 	}
 
 	return dbSecretRevisions.toSecretRevisions(dbSecretValueRefs, dbSecretRevisionsExpire)
@@ -1719,7 +1721,7 @@ func (st State) GetSecretValue(
 ) {
 	db, err := st.DB()
 	if err != nil {
-		return nil, nil, errors.Trace(err)
+		return nil, nil, errors.Capture(err)
 	}
 
 	// We look for either content or a value reference, which ever is present.
@@ -1732,7 +1734,7 @@ AND    rev.revision = $secretRevision.revision`
 
 	contentQueryStmt, err := st.Prepare(contentQuery, secretContent{}, secretRevision{})
 	if err != nil {
-		return nil, nil, errors.Trace(err)
+		return nil, nil, errors.Capture(err)
 	}
 
 	valueRefQuery := `
@@ -1744,7 +1746,7 @@ AND    rev.revision = $secretRevision.revision`
 
 	valueRefQueryStmt, err := st.Prepare(valueRefQuery, secretValueRef{}, secretRevision{})
 	if err != nil {
-		return nil, nil, errors.Trace(err)
+		return nil, nil, errors.Capture(err)
 	}
 
 	want := secretRevision{SecretID: uri.ID, Revision: revision}
@@ -1756,7 +1758,7 @@ AND    rev.revision = $secretRevision.revision`
 	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err := tx.Query(ctx, contentQueryStmt, want).GetAll(&dbSecretValues)
 		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-			return errors.Annotatef(err, "retrieving secret value for %q revision %d", uri, revision)
+			return errors.Errorf("retrieving secret value for %q revision %d %w", uri, revision, err)
 		}
 		// Do we have content from the db?
 		if len(dbSecretValues) > 0 {
@@ -1768,9 +1770,9 @@ AND    rev.revision = $secretRevision.revision`
 		if errors.Is(err, sqlair.ErrNoRows) {
 			return nil
 		}
-		return errors.Annotatef(err, "retrieving secret value ref for %q revision %d", uri, revision)
+		return errors.Errorf("retrieving secret value ref for %q revision %d %w", uri, revision, err)
 	}); err != nil {
-		return nil, nil, errors.Annotate(err, "querying secret value")
+		return nil, nil, errors.Errorf("querying secret value %w", err)
 	}
 
 	// Compose and return any secret content from the db.
@@ -1781,12 +1783,13 @@ AND    rev.revision = $secretRevision.revision`
 
 	// Process any value reference.
 	if len(dbSecretValueRefs) == 0 {
-		return nil, nil, fmt.Errorf(
-			"secret value ref for %q revision %d not found%w", uri, revision, errors.Hide(secreterrors.SecretRevisionNotFound))
+		return nil, nil, errors.Errorf(
+			"secret value ref for %q revision %d not found", uri, revision).Add(secreterrors.SecretRevisionNotFound)
 	}
 	if len(dbSecretValueRefs) != 1 {
-		return nil, nil, fmt.Errorf(
+		return nil, nil, errors.Errorf(
 			"unexpected secret value refs for %q revision %d: got %d values", uri, revision, len(dbSecretValues))
+
 	}
 	return nil, &coresecrets.ValueRef{
 		BackendID:  dbSecretValueRefs[0].BackendUUID,
@@ -1817,7 +1820,7 @@ FROM (SELECT * FROM local UNION SELECT * FROM remote)`
 	ref := secretRef{ID: uri.ID, SourceUUID: uri.SourceUUID}
 	queryStmt, err := st.Prepare(query, ref, result)
 	if err != nil {
-		return false, errors.Trace(err)
+		return false, errors.Capture(err)
 	}
 	err = tx.Query(ctx, queryStmt, ref).Get(&result)
 	if err == nil {
@@ -1827,7 +1830,7 @@ FROM (SELECT * FROM local UNION SELECT * FROM remote)`
 	if errors.Is(err, sqlair.ErrNoRows) {
 		return false, secreterrors.SecretNotFound
 	}
-	return false, errors.Annotatef(err, "looking up secret URI %q", uri)
+	return false, errors.Errorf("looking up secret URI %q %w", uri, err)
 }
 
 // GetSecretConsumer returns the secret consumer info for the specified unit
@@ -1843,7 +1846,7 @@ func (st State) GetSecretConsumer(
 ) (*coresecrets.SecretConsumerMetadata, int, error) {
 	db, err := st.DB()
 	if err != nil {
-		return nil, 0, errors.Trace(err)
+		return nil, 0, errors.Capture(err)
 	}
 
 	consumer := secretUnitConsumer{
@@ -1859,7 +1862,7 @@ AND    suc.unit_uuid = $secretUnitConsumer.unit_uuid`
 
 	queryStmt, err := st.Prepare(query, secretUnitConsumer{})
 	if err != nil {
-		return nil, 0, errors.Trace(err)
+		return nil, 0, errors.Capture(err)
 	}
 
 	selectLatestLocalRevision := `
@@ -1868,7 +1871,7 @@ FROM   secret_revision rev
 WHERE  rev.secret_id = $secretRef.secret_id`
 	selectLatestLocalRevisionStmt, err := st.Prepare(selectLatestLocalRevision, secretRef{})
 	if err != nil {
-		return nil, 0, errors.Trace(err)
+		return nil, 0, errors.Capture(err)
 	}
 
 	selectLatestRemoteRevision := `
@@ -1877,7 +1880,7 @@ FROM   secret_reference ref
 WHERE  ref.secret_id = $secretRef.secret_id`
 	selectLatestRemoteRevisionStmt, err := st.Prepare(selectLatestRemoteRevision, secretRef{})
 	if err != nil {
-		return nil, 0, errors.Trace(err)
+		return nil, 0, errors.Capture(err)
 	}
 
 	var (
@@ -1887,16 +1890,16 @@ WHERE  ref.secret_id = $secretRef.secret_id`
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		isLocal, err := st.checkExistsIfLocal(ctx, tx, uri)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		consumer.UnitUUID, err = st.getUnitUUID(ctx, tx, unitName)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		err = tx.Query(ctx, queryStmt, consumer).GetAll(&dbSecretConsumers)
 		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-			return errors.Annotate(err, "querying secret consumers")
+			return errors.Errorf("querying secret consumers %w", err)
 		}
 
 		latest := secretRef{}
@@ -1913,7 +1916,7 @@ WHERE  ref.secret_id = $secretRef.secret_id`
 					return secreterrors.SecretNotFound
 				}
 			} else {
-				return errors.Annotatef(err, "looking up latest revision for %q", uri.ID)
+				return errors.Errorf("looking up latest revision for %q %w", uri.ID, err)
 			}
 		}
 		latestRevision = latest.Revision
@@ -1921,10 +1924,10 @@ WHERE  ref.secret_id = $secretRef.secret_id`
 		return nil
 	})
 	if err != nil {
-		return nil, 0, errors.Trace(err)
+		return nil, 0, errors.Capture(err)
 	}
 	if len(dbSecretConsumers) == 0 {
-		return nil, latestRevision, fmt.Errorf("secret consumer for %q and unit %q%w", uri.ID, unitName, secreterrors.SecretConsumerNotFound)
+		return nil, latestRevision, errors.Errorf("secret consumer for %q and unit %q", uri.ID, unitName, secreterrors.SecretConsumerNotFound)
 	}
 	consumers := dbSecretConsumers.toSecretConsumers()
 	return consumers[0], latestRevision, nil
@@ -1938,7 +1941,7 @@ func (st State) SaveSecretConsumer(
 ) error {
 	db, err := st.DB()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	insertQuery := `
@@ -1950,7 +1953,7 @@ ON CONFLICT(secret_id, unit_uuid) DO UPDATE SET
 
 	insertStmt, err := st.Prepare(insertQuery, secretUnitConsumer{})
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	// We might be saving a tracked revision for a remote secret
@@ -1964,7 +1967,7 @@ ON CONFLICT DO NOTHING`
 
 	insertRemoteSecretStmt, err := st.Prepare(insertRemoteSecretQuery, secretRef)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	remoteRef := remoteSecret{SecretID: uri.ID, LatestRevision: md.CurrentRevision}
@@ -1975,7 +1978,7 @@ ON CONFLICT DO NOTHING`
 
 	insertRemoteSecretReferenceStmt, err := st.Prepare(insertRemoteSecretReferenceQuery, remoteRef)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	consumer := secretUnitConsumer{
@@ -1987,7 +1990,7 @@ ON CONFLICT DO NOTHING`
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		isLocal, err := st.checkExistsIfLocal(ctx, tx, uri)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		if !isLocal {
@@ -1995,36 +1998,36 @@ ON CONFLICT DO NOTHING`
 			// This will normally be done by the watcher but it may not have fired yet.
 			err = tx.Query(ctx, insertRemoteSecretStmt, secretRef).Run()
 			if err != nil {
-				return errors.Annotatef(err, "inserting remote secret reference for %q", uri)
+				return errors.Errorf("inserting remote secret reference for %q %w", uri, err)
 			}
 			err = tx.Query(ctx, insertRemoteSecretReferenceStmt, remoteRef).Run()
 			if err != nil {
-				return errors.Annotatef(err, "inserting remote secret revision for %q", uri)
+				return errors.Errorf("inserting remote secret revision for %q %w", uri, err)
 			}
 		}
 		consumer.UnitUUID, err = st.getUnitUUID(ctx, tx, unitName)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		if err := tx.Query(ctx, insertStmt, consumer).Run(); err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		if err := st.markObsoleteRevisions(ctx, tx, uri); err != nil {
-			return errors.Annotatef(err, "marking obsolete revisions for secret %q", uri)
+			return errors.Errorf("marking obsolete revisions for secret %q %w", uri, err)
 		}
 
 		return nil
 	})
-	return errors.Trace(err)
+	return errors.Capture(err)
 }
 
 // AllSecretConsumers loads all local secret consumers keyed by secret id.
 func (st State) AllSecretConsumers(ctx context.Context) (map[string][]domainsecret.ConsumerInfo, error) {
 	db, err := st.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	query := `
@@ -2039,19 +2042,19 @@ FROM   secret_unit_consumer suc
 
 	queryStmt, err := st.Prepare(query, secretUnitConsumerInfo{})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	var dbSecretConsumers secretUnitConsumerInfos
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err = tx.Query(ctx, queryStmt).GetAll(&dbSecretConsumers)
 		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-			return errors.Annotate(err, "querying secret consumers")
+			return errors.Errorf("querying secret consumers %w", err)
 		}
 		return nil
 	})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	consumers := dbSecretConsumers.toSecretConsumersBySecret()
 	return consumers, nil
@@ -2067,7 +2070,7 @@ func (st State) GetSecretRemoteConsumer(
 ) (*coresecrets.SecretConsumerMetadata, int, error) {
 	db, err := st.DB()
 	if err != nil {
-		return nil, 0, errors.Trace(err)
+		return nil, 0, errors.Capture(err)
 	}
 
 	consumer := secretRemoteUnitConsumer{
@@ -2083,7 +2086,7 @@ AND    suc.unit_name = $secretRemoteUnitConsumer.unit_name`
 
 	queryStmt, err := st.Prepare(query, secretRemoteUnitConsumer{})
 	if err != nil {
-		return nil, 0, errors.Trace(err)
+		return nil, 0, errors.Capture(err)
 	}
 
 	selectLatestRevision := `
@@ -2092,7 +2095,7 @@ FROM   secret_revision rev
 WHERE  rev.secret_id = $secretInfo.secret_id`
 	selectLatestRevisionStmt, err := st.Prepare(selectLatestRevision, secretInfo{})
 	if err != nil {
-		return nil, 0, errors.Trace(err)
+		return nil, 0, errors.Capture(err)
 	}
 
 	var (
@@ -2101,7 +2104,7 @@ WHERE  rev.secret_id = $secretInfo.secret_id`
 	)
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		if isLocal, err := st.checkExistsIfLocal(ctx, tx, uri); err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		} else if !isLocal {
 			// Should never happen.
 			return secreterrors.SecretIsNotLocal
@@ -2109,7 +2112,7 @@ WHERE  rev.secret_id = $secretInfo.secret_id`
 
 		err = tx.Query(ctx, queryStmt, consumer).GetAll(&dbSecretConsumers)
 		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-			return errors.Annotatef(err, "querying secret consumer info for secret %q and unit %q", uri, unitName)
+			return errors.Errorf("querying secret consumer info for secret %q and unit %q %w", uri, unitName, err)
 		}
 
 		result := secretInfo{ID: uri.ID}
@@ -2118,7 +2121,7 @@ WHERE  rev.secret_id = $secretInfo.secret_id`
 			if errors.Is(err, sqlair.ErrNoRows) {
 				return secreterrors.SecretNotFound
 			} else {
-				return errors.Annotatef(err, "looking up latest revision for %q", uri.ID)
+				return errors.Errorf("looking up latest revision for %q %w", uri.ID, err)
 			}
 		}
 		latestRevision = result.LatestRevision
@@ -2126,11 +2129,12 @@ WHERE  rev.secret_id = $secretInfo.secret_id`
 		return nil
 	})
 	if err != nil {
-		return nil, 0, errors.Trace(err)
+		return nil, 0, errors.Capture(err)
 	}
 	if len(dbSecretConsumers) == 0 {
-		return nil, latestRevision, fmt.Errorf(
-			"secret consumer for %q and unit %q%w", uri.ID, unitName, secreterrors.SecretConsumerNotFound)
+		return nil, latestRevision, errors.Errorf(
+			"secret consumer for %q and unit %q", uri.ID, unitName, secreterrors.SecretConsumerNotFound)
+
 	}
 	consumers := dbSecretConsumers.toSecretConsumers()
 	return consumers[0], latestRevision, nil
@@ -2143,7 +2147,7 @@ func (st State) SaveSecretRemoteConsumer(
 ) error {
 	db, err := st.DB()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	insertQuery := `
@@ -2154,7 +2158,7 @@ ON CONFLICT(secret_id, unit_name) DO UPDATE SET
 
 	insertStmt, err := st.Prepare(insertQuery, secretRemoteUnitConsumer{})
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	consumer := secretRemoteUnitConsumer{
@@ -2164,29 +2168,29 @@ ON CONFLICT(secret_id, unit_name) DO UPDATE SET
 	}
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		if isLocal, err := st.checkExistsIfLocal(ctx, tx, uri); err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		} else if !isLocal {
 			// Should never happen.
 			return secreterrors.SecretIsNotLocal
 		}
 		if err := tx.Query(ctx, insertStmt, consumer).Run(); err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		if err := st.markObsoleteRevisions(ctx, tx, uri); err != nil {
-			return errors.Annotatef(err, "marking obsolete revisions for secret %q", uri)
+			return errors.Errorf("marking obsolete revisions for secret %q %w", uri, err)
 		}
 
 		return nil
 	})
-	return errors.Trace(err)
+	return errors.Capture(err)
 }
 
 // AllSecretRemoteConsumers loads all secret remote consumers keyed by secret id.
 func (st State) AllSecretRemoteConsumers(ctx context.Context) (map[string][]domainsecret.ConsumerInfo, error) {
 	db, err := st.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	query := `
@@ -2198,19 +2202,19 @@ FROM   secret_remote_unit_consumer suc
 
 	queryStmt, err := st.Prepare(query, secretUnitConsumerInfo{})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	var dbSecretConsumers secretUnitConsumerInfos
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err = tx.Query(ctx, queryStmt).GetAll(&dbSecretConsumers)
 		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-			return errors.Annotate(err, "querying secret remote consumers")
+			return errors.Errorf("querying secret remote consumers %w", err)
 		}
 		return nil
 	})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	consumers := dbSecretConsumers.toSecretConsumersBySecret()
 	return consumers, nil
@@ -2221,7 +2225,7 @@ FROM   secret_remote_unit_consumer suc
 func (st State) UpdateRemoteSecretRevision(ctx context.Context, uri *coresecrets.URI, latestRevision int) error {
 	db, err := st.DB()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	insertQuery := `
@@ -2231,7 +2235,7 @@ ON CONFLICT(id) DO NOTHING`
 
 	insertStmt, err := st.Prepare(insertQuery, secretID{})
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	insertLatestQuery := `
@@ -2242,7 +2246,7 @@ ON CONFLICT(secret_id) DO UPDATE SET
 
 	insertLatestStmt, err := st.Prepare(insertLatestQuery, remoteSecret{})
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	secret := remoteSecret{
@@ -2252,17 +2256,17 @@ ON CONFLICT(secret_id) DO UPDATE SET
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err = tx.Query(ctx, insertStmt, secretID{ID: uri.ID}).Run()
 		if err != nil {
-			return errors.Annotatef(err, "inserting URI record for cross model secret %q", uri)
+			return errors.Errorf("inserting URI record for cross model secret %q %w", uri, err)
 		}
 		if err := tx.Query(ctx, insertLatestStmt, secret).Run(); err != nil {
-			return errors.Annotatef(err, "updating latest revision %d for cross model secret %q", latestRevision, uri)
+			return errors.Errorf("updating latest revision %d for cross model secret %q %w", latestRevision, uri, err)
 		}
 		if err := st.markObsoleteRevisions(ctx, tx, uri); err != nil {
-			return errors.Annotatef(err, "marking obsolete revisions for secret %q", uri)
+			return errors.Errorf("marking obsolete revisions for secret %q %w", uri, err)
 		}
 		return nil
 	})
-	return errors.Trace(err)
+	return errors.Capture(err)
 }
 
 // AllRemoteSecrets returns consumer info for secrets stored in
@@ -2270,7 +2274,7 @@ ON CONFLICT(secret_id) DO UPDATE SET
 func (st State) AllRemoteSecrets(ctx context.Context) ([]domainsecret.RemoteSecretInfo, error) {
 	db, err := st.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	q := `
@@ -2287,7 +2291,7 @@ FROM   secret_unit_consumer suc
 
 	stmt, err := st.Prepare(q, secretUnitConsumerInfo{})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	var dbSecretConsumers secretUnitConsumerInfos
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
@@ -2296,10 +2300,10 @@ FROM   secret_unit_consumer suc
 			// No secrets found.
 			return nil
 		}
-		return errors.Trace(err)
+		return errors.Capture(err)
 	})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	secrets := dbSecretConsumers.toRemoteSecrets()
@@ -2313,7 +2317,7 @@ FROM   secret_unit_consumer suc
 func (st State) GrantAccess(ctx context.Context, uri *coresecrets.URI, params domainsecret.GrantParams) error {
 	db, err := st.DB()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	checkInvariantQuery := `
@@ -2327,7 +2331,7 @@ AND    (sp.subject_type_id <> $secretPermission.subject_type_id
 
 	checkInvariantStmt, err := st.Prepare(checkInvariantQuery, secretPermission{}, secretID{})
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
@@ -2336,7 +2340,7 @@ AND    (sp.subject_type_id <> $secretPermission.subject_type_id
 			RoleID:   params.RoleID,
 		}
 		if isLocal, err := st.checkExistsIfLocal(ctx, tx, uri); err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		} else if !isLocal {
 			// Should never happen.
 			return secreterrors.SecretIsNotLocal
@@ -2346,14 +2350,14 @@ AND    (sp.subject_type_id <> $secretPermission.subject_type_id
 		perm.SubjectTypeID = params.SubjectTypeID
 		perm.SubjectUUID, err = st.lookupSubjectUUID(ctx, tx, params.SubjectID, params.SubjectTypeID)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		// Look up the UUID of the access scope entity.
 		perm.ScopeTypeID = params.ScopeTypeID
 		perm.ScopeUUID, err = st.lookupScopeUUID(ctx, tx, params.ScopeID, params.ScopeTypeID)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		// Check that the access scope or subject type is not changing.
@@ -2363,12 +2367,12 @@ AND    (sp.subject_type_id <> $secretPermission.subject_type_id
 			// Should never happen.
 			return secreterrors.InvalidSecretPermissionChange
 		} else if !errors.Is(err, sqlair.ErrNoRows) {
-			return errors.Annotatef(err, "checking duplicate permission record for secret %q", uri)
+			return errors.Errorf("checking duplicate permission record for secret %q %w", uri, err)
 		}
 
 		return st.grantAccess(ctx, tx, perm)
 	})
-	return errors.Trace(err)
+	return errors.Capture(err)
 }
 
 const (
@@ -2404,19 +2408,19 @@ func (st State) lookupSubjectUUID(
 	}
 	selectSubjectUUIDStmt, err := st.Prepare(selectSubjectUUID, selectSubjectQueryParams...)
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", errors.Capture(err)
 	}
 	result := entityRef{}
 	err = tx.Query(ctx, selectSubjectUUIDStmt, selectSubjectQueryParams...).Get(&result)
 	if err != nil {
 		if errors.Is(err, sqlair.ErrNoRows) {
-			return "", fmt.Errorf("%s %q not found%w", subjectTypeID, subjectID, errors.Hide(subjectNotFoundError))
+			return "", errors.Errorf("%s %q not found", subjectTypeID, subjectID).Add(subjectNotFoundError)
 		} else {
 			subject := subjectID
 			if subjectTypeID == domainsecret.SubjectModel {
 				subject = "model"
 			}
-			return "", errors.Annotatef(err, "looking up secret grant subject UUID for %q", subject)
+			return "", errors.Errorf("looking up secret grant subject UUID for %q %w", subject, err)
 		}
 	}
 	return result.UUID, nil
@@ -2448,20 +2452,20 @@ func (st State) lookupScopeUUID(
 	}
 	selectScopeUUIDStmt, err := st.Prepare(selectScopeUUID, selectScopeQueryParams...)
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", errors.Capture(err)
 	}
 
 	result := entityRef{}
 	err = tx.Query(ctx, selectScopeUUIDStmt, selectScopeQueryParams...).Get(&result)
 	if err != nil {
 		if errors.Is(err, sqlair.ErrNoRows) {
-			return "", fmt.Errorf("%s %q not found%w", scopeTypeID, scopeID, errors.Hide(scopeNotFoundError))
+			return "", errors.Errorf("%s %q not found", scopeTypeID, scopeID).Add(scopeNotFoundError)
 		} else {
 			scope := scopeID
 			if scopeTypeID == domainsecret.ScopeModel {
 				scope = "model"
 			}
-			return "", errors.Annotatef(err, "looking up secret grant scope UUID for %q", scope)
+			return "", errors.Errorf("looking up secret grant scope UUID for %q %w", scope, err)
 		}
 	}
 	return result.UUID, nil
@@ -2480,11 +2484,11 @@ ON CONFLICT(secret_id, subject_uuid) DO UPDATE SET
 
 	insertStmt, err := st.Prepare(insertQuery, secretPermission{})
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	if err := tx.Query(ctx, insertStmt, perm).Run(); err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	return nil
 
@@ -2496,7 +2500,7 @@ ON CONFLICT(secret_id, subject_uuid) DO UPDATE SET
 func (st State) RevokeAccess(ctx context.Context, uri *coresecrets.URI, params domainsecret.AccessParams) error {
 	db, err := st.DB()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	deleteQuery := `
@@ -2511,12 +2515,12 @@ AND    subject_uuid = $secretPermission.subject_uuid`
 	}
 	deleteStmt, err := st.Prepare(deleteQuery, perm)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		if isLocal, err := st.checkExistsIfLocal(ctx, tx, uri); err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		} else if !isLocal {
 			// Should never happen.
 			return secreterrors.SecretIsNotLocal
@@ -2525,12 +2529,12 @@ AND    subject_uuid = $secretPermission.subject_uuid`
 		// Look up the UUID of the subject.
 		perm.SubjectUUID, err = st.lookupSubjectUUID(ctx, tx, params.SubjectID, params.SubjectTypeID)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		err = tx.Query(ctx, deleteStmt, perm).Run()
-		return errors.Annotatef(err, "deleting secret grant for %q on %q", params.SubjectID, uri)
+		return errors.Errorf("deleting secret grant for %q on %q %w", params.SubjectID, uri, err)
 	})
-	return errors.Trace(err)
+	return errors.Capture(err)
 }
 
 // GetSecretAccess returns the access to the secret for the specified accessor.
@@ -2541,7 +2545,7 @@ func (st State) GetSecretAccess(
 ) (string, error) {
 	db, err := st.DB()
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", errors.Capture(err)
 	}
 
 	query := `
@@ -2559,13 +2563,13 @@ AND    subject_id = $secretAccessor.subject_id`
 	}
 	selectRoleStmt, err := st.Prepare(query, access, sqlair.M{})
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", errors.Capture(err)
 	}
 
 	var role string
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		if isLocal, err := st.checkExistsIfLocal(ctx, tx, uri); err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		} else if !isLocal {
 			// Should never happen.
 			return secreterrors.SecretIsNotLocal
@@ -2576,9 +2580,9 @@ AND    subject_id = $secretAccessor.subject_id`
 			role, _ = result["role"].(string)
 			return nil
 		}
-		return errors.Annotatef(err, "looking up secret grant for %q on %q", params.SubjectID, uri)
+		return errors.Errorf("looking up secret grant for %q on %q %w", params.SubjectID, uri, err)
 	})
-	return role, errors.Trace(err)
+	return role, errors.Capture(err)
 }
 
 // GetSecretAccessScope returns the access scope for the specified accessor's
@@ -2589,7 +2593,7 @@ func (st State) GetSecretAccessScope(
 ) (*domainsecret.AccessScope, error) {
 	db, err := st.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	query := `
@@ -2606,27 +2610,28 @@ AND    subject_id = $secretAccessor.subject_id`
 	}
 	selectScopeStmt, err := st.Prepare(query, access, secretAccessScope{})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	result := secretAccessScope{}
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		if isLocal, err := st.checkExistsIfLocal(ctx, tx, uri); err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		} else if !isLocal {
 			// Should never happen.
 			return secreterrors.SecretIsNotLocal
 		}
 		err = tx.Query(ctx, selectScopeStmt, access).Get(&result)
 		if errors.Is(err, sqlair.ErrNoRows) {
-			return fmt.Errorf(
-				"access scope for %q on secret %q not found%w",
-				params.SubjectID, uri, errors.Hide(secreterrors.SecretAccessScopeNotFound))
+			return errors.Errorf(
+				"access scope for %q on secret %q not found",
+				params.SubjectID, uri).Add(secreterrors.SecretAccessScopeNotFound)
+
 		}
-		return errors.Annotatef(err, "looking up secret access scope for %q on %q", params.SubjectID, uri)
+		return errors.Errorf("looking up secret access scope for %q on %q %w", params.SubjectID, uri, err)
 	})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	return &domainsecret.AccessScope{
 		ScopeTypeID: result.ScopeTypeID,
@@ -2641,7 +2646,7 @@ func (st State) GetSecretGrants(
 ) ([]domainsecret.GrantParams, error) {
 	db, err := st.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	query := `
@@ -2657,7 +2662,7 @@ AND    subject_type_id != $M.remote_application_type`
 
 	selectStmt, err := st.Prepare(query, secretID{}, secretAccessor{}, secretAccessScope{}, arg)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	secretIDParam := secretID{
@@ -2673,7 +2678,7 @@ AND    subject_type_id != $M.remote_application_type`
 	)
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		if isLocal, err := st.checkExistsIfLocal(ctx, tx, uri); err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		} else if !isLocal {
 			// Should never happen.
 			return secreterrors.SecretIsNotLocal
@@ -2682,10 +2687,10 @@ AND    subject_type_id != $M.remote_application_type`
 		if errors.Is(err, sqlair.ErrNoRows) {
 			return nil
 		}
-		return errors.Annotatef(err, "looking up secret grants for %q", uri)
+		return errors.Errorf("looking up secret grants for %q %w", uri, err)
 	})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	return accessors.toSecretGrants(accessScopes)
 }
@@ -2694,7 +2699,7 @@ AND    subject_type_id != $M.remote_application_type`
 func (st State) AllSecretGrants(ctx context.Context) (map[string][]domainsecret.GrantParams, error) {
 	db, err := st.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	query := `
@@ -2705,7 +2710,7 @@ FROM   v_secret_permission sp
 
 	selectStmt, err := st.Prepare(query, secretAccessor{}, secretAccessScope{})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	var (
@@ -2717,10 +2722,10 @@ FROM   v_secret_permission sp
 		if errors.Is(err, sqlair.ErrNoRows) {
 			return nil
 		}
-		return errors.Annotate(err, "looking up secret grants")
+		return errors.Errorf("looking up secret grants %w", err)
 	})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	return accessors.toSecretGrantsBySecret(accessScopes)
 }
@@ -2739,7 +2744,7 @@ func (st State) ListGrantedSecretsForBackend(
 ) ([]*coresecrets.SecretRevisionRef, error) {
 	db, err := st.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	query := `
@@ -2793,7 +2798,7 @@ AND    (subject_type_id = $secretAccessorType.unit_type_id AND subject_id IN ($u
 
 	queryStmt, err := st.Prepare(query, append(queryParams, secretInfo{}, secretValueRef{})...)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	var revisionResult []*coresecrets.SecretRevisionRef
@@ -2805,12 +2810,12 @@ AND    (subject_type_id = $secretAccessorType.unit_type_id AND subject_id IN ($u
 		)
 		err = tx.Query(ctx, queryStmt, queryParams...).GetAll(&dbSecrets, &dbValueRefs)
 		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-			return errors.Annotate(err, "querying accessible secrets")
+			return errors.Errorf("querying accessible secrets %w", err)
 		}
 		revisionResult, err = dbSecrets.toSecretRevisionRef(dbValueRefs)
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}); err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	return revisionResult, nil
 }
@@ -2820,7 +2825,7 @@ AND    (subject_type_id = $secretAccessorType.unit_type_id AND subject_id IN ($u
 func (st State) GetSecretRevisionID(ctx context.Context, uri *coresecrets.URI, revision int) (string, error) {
 	db, err := st.DB()
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", errors.Capture(err)
 	}
 
 	secretRev := secretRevision{
@@ -2833,17 +2838,17 @@ FROM   secret_revision
 WHERE  secret_id = $secretRevision.secret_id
     AND    revision = $secretRevision.revision`, secretRev)
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", errors.Capture(err)
 	}
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err := tx.Query(ctx, stmt, secretRev).Get(&secretRev)
 		if errors.Is(err, sqlair.ErrNoRows) {
-			return fmt.Errorf("%w: %s/%d", secreterrors.SecretRevisionNotFound, uri, revision)
+			return errors.Errorf("%w: %s/%d", secreterrors.SecretRevisionNotFound, uri, revision)
 		}
-		return errors.Trace(err)
+		return errors.Capture(err)
 	})
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", errors.Capture(err)
 	}
 	return secretRev.ID, nil
 }
@@ -2869,7 +2874,7 @@ HAVING   suc.current_revision < MAX(sr.revision)`
 
 		stmt, err := st.Prepare(q, append(queryParams, revisionUUID{})...)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, errors.Capture(err)
 		}
 
 		var revUUIDs dbrevisionUUIDs
@@ -2879,10 +2884,10 @@ HAVING   suc.current_revision < MAX(sr.revision)`
 				// No consumed secrets found.
 				return nil
 			}
-			return errors.Trace(err)
+			return errors.Capture(err)
 		})
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, errors.Capture(err)
 		}
 
 		result := make([]string, len(revUUIDs))
@@ -2901,7 +2906,7 @@ func (st State) GetConsumedSecretURIsWithChanges(
 ) ([]string, error) {
 	db, err := st.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	q := `
@@ -2925,7 +2930,7 @@ HAVING suc.current_revision < MAX(sr.revision)`
 
 	stmt, err := st.Prepare(q, append(queryParams, secretUnitConsumer{})...)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	var dbConsumers secretUnitConsumers
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
@@ -2934,17 +2939,17 @@ HAVING suc.current_revision < MAX(sr.revision)`
 			// No consumed secrets found.
 			return nil
 		}
-		return errors.Trace(err)
+		return errors.Capture(err)
 	})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	secretURIs := make([]string, len(dbConsumers))
 	for i, consumer := range dbConsumers {
 		uri, err := coresecrets.ParseURI(consumer.SecretID)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, errors.Capture(err)
 		}
 		secretURIs[i] = uri.String()
 	}
@@ -2973,7 +2978,7 @@ HAVING   suc.current_revision < sr.latest_revision`
 
 		stmt, err := st.Prepare(q, append(queryParams, remoteSecret{})...)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, errors.Capture(err)
 		}
 		var referenceIDs remoteSecrets
 		err = runner.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
@@ -2982,10 +2987,10 @@ HAVING   suc.current_revision < sr.latest_revision`
 				// No consumed remote secrets found.
 				return nil
 			}
-			return errors.Trace(err)
+			return errors.Capture(err)
 		})
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, errors.Capture(err)
 		}
 
 		result := make([]string, len(referenceIDs))
@@ -3005,7 +3010,7 @@ func (st State) GetConsumedRemoteSecretURIsWithChanges(
 ) ([]string, error) {
 	db, err := st.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	q := `
@@ -3030,7 +3035,7 @@ HAVING suc.current_revision < sr.latest_revision`
 
 	stmt, err := st.Prepare(q, append(queryParams, secretUnitConsumer{})...)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	var consumers secretUnitConsumers
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
@@ -3039,17 +3044,17 @@ HAVING suc.current_revision < sr.latest_revision`
 			// No consumed secrets found.
 			return nil
 		}
-		return errors.Trace(err)
+		return errors.Capture(err)
 	})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	secretURIs := make([]string, len(consumers))
 	for i, consumer := range consumers {
 		uri, err := coresecrets.ParseURI(consumer.SecretID)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, errors.Capture(err)
 		}
 		uri.SourceUUID = consumer.SourceModelUUID
 		secretURIs[i] = uri.String()
@@ -3088,7 +3093,7 @@ GROUP BY sruc.secret_id
 HAVING sruc.current_revision < MAX(sr.revision)`
 		stmt, err := st.Prepare(q, append(queryParams, revisionUUID{})...)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, errors.Capture(err)
 		}
 		var revisionUUIDs dbrevisionUUIDs
 		err = runner.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
@@ -3097,10 +3102,10 @@ HAVING sruc.current_revision < MAX(sr.revision)`
 				// No consumed secrets found.
 				return nil
 			}
-			return errors.Trace(err)
+			return errors.Capture(err)
 		})
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, errors.Capture(err)
 		}
 		revUUIDs := make([]string, len(revisionUUIDs))
 		for i, rev := range revisionUUIDs {
@@ -3119,7 +3124,7 @@ func (st State) GetRemoteConsumedSecretURIsWithChangesFromOfferingSide(
 ) ([]string, error) {
 	db, err := st.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	// TODO: sqlair does not support inject parameters into values in quotation marks.
 	// Use sqlair to generate the query once https://github.com/canonical/sqlair/issues/148 is fixed.
@@ -3148,7 +3153,7 @@ GROUP BY sruc.secret_id
 HAVING sruc.current_revision < MAX(sr.revision)`
 	stmt, err := st.Prepare(q, append(queryParams, secretRemoteUnitConsumer{})...)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	var remoteConsumers secretRemoteUnitConsumers
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
@@ -3157,20 +3162,20 @@ HAVING sruc.current_revision < MAX(sr.revision)`
 			// No consumed secrets found.
 			return nil
 		}
-		return errors.Trace(err)
+		return errors.Capture(err)
 	})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	modelUUID, err := st.GetModelUUID(ctx)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	secretURIs := make([]string, len(remoteConsumers))
 	for i, consumer := range remoteConsumers {
 		uri, err := coresecrets.ParseURI(consumer.SecretID)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, errors.Capture(err)
 		}
 		// We need to set the source model UUID to mark it as a remote secret for consumer side to use.
 		uri.SourceUUID = modelUUID
@@ -3192,7 +3197,7 @@ func (st State) InitialWatchStatementForObsoleteRevision(
 			ctx, runner, "sro.revision_uuid AS &secretRevision.uuid", secretRevision{}, &revisions,
 			appOwners, unitOwners,
 		); err != nil {
-			return nil, errors.Trace(err)
+			return nil, errors.Capture(err)
 		}
 		revUUIDs := make([]string, len(revisions))
 		for i, rev := range revisions {
@@ -3217,7 +3222,7 @@ func (st State) GetRevisionIDsForObsolete(
 	}
 	db, err := st.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	var rows obsoleteRevisionRows
@@ -3226,7 +3231,7 @@ func (st State) GetRevisionIDsForObsolete(
 		"(sr.revision, sr.secret_id) AS (&obsoleteRevisionRow.*)", obsoleteRevisionRow{}, &rows,
 		appOwners, unitOwners, revisionUUIDs...,
 	); err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	return rows.toRevIDs(), nil
 }
@@ -3297,7 +3302,7 @@ FROM secret_revision_obsolete sro
 	)
 	stmt, err := st.Prepare(q, append(queryParams, outputType)...)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	err = runner.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err := tx.Query(ctx, stmt, queryParams...).GetAll(result)
@@ -3305,9 +3310,9 @@ FROM secret_revision_obsolete sro
 			// It's ok, the revisions probably have already been pruned.
 			return nil
 		}
-		return errors.Trace(err)
+		return errors.Capture(err)
 	})
-	return errors.Trace(err)
+	return errors.Capture(err)
 }
 
 type (
@@ -3321,10 +3326,10 @@ func (st State) DeleteSecret(ctx domain.AtomicContext, uri *coresecrets.URI, rev
 	err := domain.Run(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		var err error
 		_, err = st.deleteSecretRevisions(ctx, tx, uri, revs)
-		return errors.Trace(err)
+		return errors.Capture(err)
 	})
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	return nil
 }
@@ -3334,7 +3339,7 @@ func (st State) DeleteSecret(ctx domain.AtomicContext, uri *coresecrets.URI, rev
 func (st State) DeleteObsoleteUserSecretRevisions(ctx context.Context) ([]string, error) {
 	db, err := st.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	q := `
@@ -3348,7 +3353,7 @@ WHERE  sm.auto_prune = true AND sro.obsolete = true`
 
 	stmt, err := st.Prepare(q, secretID{}, secretExternalRevision{}, revisions{})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	var deletedRevisionIDs []string
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
@@ -3362,11 +3367,11 @@ WHERE  sm.auto_prune = true AND sro.obsolete = true`
 			return nil
 		}
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		itemsToDelete, err := dbSecrets.toSecretMetadataForDrain(dbsecretRevs)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		for _, toDelete := range itemsToDelete {
 			revs := make([]int, len(toDelete.Revisions))
@@ -3375,14 +3380,14 @@ WHERE  sm.auto_prune = true AND sro.obsolete = true`
 			}
 			deleted, err := st.deleteSecretRevisions(ctx, tx, toDelete.URI, revs)
 			if err != nil {
-				return errors.Trace(err)
+				return errors.Capture(err)
 			}
 			deletedRevisionIDs = append(deletedRevisionIDs, deleted...)
 		}
 		return nil
 	})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	return deletedRevisionIDs, nil
 }
@@ -3408,13 +3413,13 @@ WHERE  secret_id = $secretID.id%s
 `, revFilter)
 	selectRevisionStmt, err := st.Prepare(selectRevsToDelete, append(selectRevisionParams, revisionUUID{})...)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	countRevisions := `SELECT count(*) AS &M.count FROM secret_revision WHERE secret_id = $secretID.id`
 	countRevisionsStmt, err := st.Prepare(countRevisions, secretID{}, sqlair.M{})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	deleteRevisionExpire := `
@@ -3444,12 +3449,12 @@ DELETE FROM secret_revision WHERE uuid IN ($revisionUUIDs[:])`
 	for i, q := range deleteRevisionQueries {
 		deleteRevisionStmts[i], err = st.Prepare(q, revisionUUIDs{})
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, errors.Capture(err)
 		}
 	}
 
 	if isLocal, err := st.checkExistsIfLocal(ctx, tx, uri); err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	} else if !isLocal {
 		// Should never happen.
 		return nil, secreterrors.SecretIsNotLocal
@@ -3458,10 +3463,10 @@ DELETE FROM secret_revision WHERE uuid IN ($revisionUUIDs[:])`
 	result := []revisionUUID{}
 	err = tx.Query(ctx, selectRevisionStmt, selectRevisionParams...).GetAll(&result)
 	if errors.Is(err, sqlair.ErrNoRows) {
-		return nil, fmt.Errorf("secret revisions %v not found%w", revs, errors.Hide(secreterrors.SecretRevisionNotFound))
+		return nil, errors.Errorf("secret revisions %v not found", revs).Add(secreterrors.SecretRevisionNotFound)
 	}
 	if err != nil {
-		return nil, errors.Annotatef(err, "selecting revision UUIDs to delete for secret %q", uri)
+		return nil, errors.Errorf("selecting revision UUIDs to delete for secret %q %w", uri, err)
 	}
 
 	toDelete := make(revisionUUIDs, len(result))
@@ -3471,14 +3476,14 @@ DELETE FROM secret_revision WHERE uuid IN ($revisionUUIDs[:])`
 	for _, stmt := range deleteRevisionStmts {
 		err = tx.Query(ctx, stmt, toDelete).Run()
 		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-			return nil, errors.Annotatef(err, "deleting revision info for secret %q", uri)
+			return nil, errors.Errorf("deleting revision info for secret %q %w", uri, err)
 		}
 	}
 
 	countResult := sqlair.M{}
 	err = tx.Query(ctx, countRevisionsStmt, selectRevisionParams[0]).Get(&countResult)
 	if err != nil {
-		return nil, errors.Annotatef(err, "counting remaining revisions for secret %q", uri)
+		return nil, errors.Errorf("counting remaining revisions for secret %q %w", uri, err)
 	}
 	count, _ := strconv.Atoi(fmt.Sprint(countResult["count"]))
 	if count > 0 {
@@ -3486,7 +3491,7 @@ DELETE FROM secret_revision WHERE uuid IN ($revisionUUIDs[:])`
 	}
 	// No revisions left so delete the secret.
 	if err := st.deleteSecret(ctx, tx, uri); err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	return toDelete, nil
 }
@@ -3535,14 +3540,14 @@ DELETE FROM secret WHERE id = $secretID.id`
 	for i, q := range deleteSecretQueries {
 		deleteSecretStmts[i], err = st.Prepare(q, secretIDParamParam)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 	}
 
 	for _, stmt := range deleteSecretStmts {
 		err = tx.Query(ctx, stmt, secretIDParamParam).Run()
 		if err != nil {
-			return errors.Annotatef(err, "deleting info for secret %q", uri)
+			return errors.Errorf("deleting info for secret %q %w", uri, err)
 		}
 	}
 	return nil
@@ -3552,14 +3557,14 @@ DELETE FROM secret WHERE id = $secretID.id`
 func (st State) SecretRotated(ctx context.Context, uri *coresecrets.URI, next time.Time) error {
 	db, err := st.DB()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err := st.upsertSecretNextRotateTime(ctx, tx, uri, next)
-		return errors.Trace(err)
+		return errors.Capture(err)
 	})
-	return errors.Trace(err)
+	return errors.Capture(err)
 }
 
 func (st State) getSecretsRotationChanges(
@@ -3628,7 +3633,7 @@ GROUP BY sro.secret_id`
 
 	stmt, err := st.Prepare(q, append(queryParams, secretRotationChange{})...)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	var data []secretRotationChange
 	err = runner.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
@@ -3637,11 +3642,11 @@ GROUP BY sro.secret_id`
 			// It's ok because the secret or the rotation was just deleted.
 			return nil
 		}
-		return errors.Trace(err)
+		return errors.Capture(err)
 	})
 
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	result := make([]domainsecret.RotationInfo, len(data))
 	for i, d := range data {
@@ -3651,7 +3656,7 @@ GROUP BY sro.secret_id`
 		}
 		uri, err := coresecrets.ParseURI(d.SecretID)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, errors.Capture(err)
 		}
 		result[i].URI = uri
 	}
@@ -3671,7 +3676,7 @@ func (st State) ChangeSecretBackend(
 	}
 	db, err := st.DB()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	input := revisionUUID{
@@ -3682,37 +3687,37 @@ func (st State) ChangeSecretBackend(
 DELETE FROM secret_value_ref
 WHERE revision_uuid = $revisionUUID.uuid`, input)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	deleteDataQ, err := st.Prepare(`
 DELETE FROM secret_content
 WHERE revision_uuid = $revisionUUID.uuid`, input)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		if valueRef != nil {
 			if err := st.upsertSecretValueRef(ctx, tx, input.UUID, valueRef); err != nil {
-				return errors.Trace(err)
+				return errors.Capture(err)
 			}
 		} else {
 			if err = tx.Query(ctx, deleteValueRefQ, input).Run(); err != nil {
-				return errors.Trace(err)
+				return errors.Capture(err)
 			}
 		}
 		if len(data) > 0 {
 			if err := st.updateSecretContent(ctx, tx, input.UUID, data); err != nil {
-				return errors.Trace(err)
+				return errors.Capture(err)
 			}
 		} else {
 			if err = tx.Query(ctx, deleteDataQ, input).Run(); err != nil {
-				return errors.Trace(err)
+				return errors.Capture(err)
 			}
 		}
-		return errors.Trace(err)
+		return errors.Capture(err)
 	})
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	return nil
 }
@@ -3725,7 +3730,7 @@ func (st State) InitialWatchStatementForSecretsRotationChanges(
 	queryFunc := func(ctx context.Context, runner coredatabase.TxnRunner) ([]string, error) {
 		result, err := st.getSecretsRotationChanges(ctx, runner, appOwners, unitOwners)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, errors.Capture(err)
 		}
 		secretIDs := make([]string, len(result))
 		for i, d := range result {
@@ -3742,7 +3747,7 @@ func (st State) GetSecretsRotationChanges(
 ) ([]domainsecret.RotationInfo, error) {
 	db, err := st.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	return st.getSecretsRotationChanges(ctx, db, appOwners, unitOwners, secretIDs...)
 }
@@ -3814,7 +3819,7 @@ GROUP BY sr.secret_id`
 
 	stmt, err := st.Prepare(q, append(queryParams, secretRevisionExpireChange{})...)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	var data []secretRevisionExpireChange
 	err = runner.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
@@ -3823,11 +3828,11 @@ GROUP BY sr.secret_id`
 			// It's ok because the secret or the expiry was just deleted.
 			return nil
 		}
-		return errors.Trace(err)
+		return errors.Capture(err)
 	})
 
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	result := make([]domainsecret.ExpiryInfo, len(data))
 	for i, d := range data {
@@ -3838,7 +3843,7 @@ GROUP BY sr.secret_id`
 		}
 		uri, err := coresecrets.ParseURI(d.SecretID)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, errors.Capture(err)
 		}
 		result[i].URI = uri
 	}
@@ -3853,7 +3858,7 @@ func (st State) InitialWatchStatementForSecretsRevisionExpiryChanges(
 	queryFunc := func(ctx context.Context, runner coredatabase.TxnRunner) ([]string, error) {
 		result, err := st.getSecretsRevisionExpiryChanges(ctx, runner, appOwners, unitOwners)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, errors.Capture(err)
 		}
 		revisionUUIDs := make([]string, len(result))
 		for i, d := range result {
@@ -3870,7 +3875,7 @@ func (st State) GetSecretsRevisionExpiryChanges(
 ) ([]domainsecret.ExpiryInfo, error) {
 	db, err := st.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	return st.getSecretsRevisionExpiryChanges(ctx, db, appOwners, unitOwners, revisionUUIDs...)
 }
@@ -3879,7 +3884,7 @@ func (st State) GetSecretsRevisionExpiryChanges(
 func (st State) GetObsoleteUserSecretRevisionsReadyToPrune(ctx context.Context) ([]string, error) {
 	db, err := st.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	q := `
 SELECT (sr.revision, sr.secret_id) AS (&obsoleteRevisionRow.*)
@@ -3890,7 +3895,7 @@ FROM   secret_model_owner smo
 WHERE  sm.auto_prune = true AND sro.obsolete = true`
 	stmt, err := st.Prepare(q, obsoleteRevisionRow{})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	var result obsoleteRevisionRows
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
@@ -3899,10 +3904,10 @@ WHERE  sm.auto_prune = true AND sro.obsolete = true`
 			// It's ok, the revision probably has already been pruned.
 			return nil
 		}
-		return errors.Trace(err)
+		return errors.Capture(err)
 	})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	return result.toRevIDs(), nil
 }

--- a/domain/secret/state/state_test.go
+++ b/domain/secret/state/state_test.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -22,6 +21,7 @@ import (
 	"github.com/juju/juju/domain/schema/testing"
 	domainsecret "github.com/juju/juju/domain/secret"
 	secreterrors "github.com/juju/juju/domain/secret/errors"
+	"github.com/juju/juju/internal/errors"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 	coretesting "github.com/juju/juju/internal/testing"
 	"github.com/juju/juju/internal/uuid"
@@ -682,7 +682,7 @@ INSERT INTO charm (uuid, reference_name, architecture_id)
 VALUES (?, ?, 0);
 `, charmUUID, appName)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		_, err = tx.ExecContext(ctx, `
@@ -690,7 +690,7 @@ INSERT INTO charm_metadata (charm_uuid, name)
 VALUES (?, ?);
 		`, charmUUID, appName)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		applicationUUID := uuid.MustNewUUID().String()
@@ -699,7 +699,7 @@ INSERT INTO application (uuid, charm_uuid, name, life_id)
 VALUES (?, ?, ?, ?)
 `, applicationUUID, charmUUID, appName, life.Alive)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		// Do 2 units.
@@ -707,7 +707,7 @@ VALUES (?, ?, ?, ?)
 			netNodeUUID := uuid.MustNewUUID().String()
 			_, err = tx.ExecContext(ctx, "INSERT INTO net_node (uuid) VALUES (?)", netNodeUUID)
 			if err != nil {
-				return errors.Trace(err)
+				return errors.Capture(err)
 			}
 			unitUUID := uuid.MustNewUUID().String()
 			_, err = tx.ExecContext(ctx, `
@@ -715,7 +715,7 @@ INSERT INTO unit (uuid, life_id, name, net_node_uuid, application_uuid)
 VALUES (?, ?, ?, ?, (SELECT uuid from application WHERE name = ?))
 `, unitUUID, life.Alive, appName+fmt.Sprintf("/%d", i), netNodeUUID, appName)
 			if err != nil {
-				return errors.Trace(err)
+				return errors.Capture(err)
 			}
 		}
 		return nil

--- a/domain/secret/state/types.go
+++ b/domain/secret/state/types.go
@@ -7,12 +7,12 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/juju/errors"
-
 	coreapplication "github.com/juju/juju/core/application"
+	coreerrors "github.com/juju/juju/core/errors"
 	coresecrets "github.com/juju/juju/core/secrets"
 	coreunit "github.com/juju/juju/core/unit"
 	domainsecret "github.com/juju/juju/domain/secret"
+	"github.com/juju/juju/internal/errors"
 )
 
 // These structs represent the persistent secretMetadata entity schema in the database.
@@ -241,7 +241,7 @@ func (rows secretInfos) toSecretMetadata(secretOwners []secretOwner) ([]*coresec
 	for i, row := range rows {
 		uri, err := coresecrets.ParseURI(row.ID)
 		if err != nil {
-			return nil, errors.NotValidf("secret URI %q", row.ID)
+			return nil, errors.Errorf("secret URI %q %w", row.ID, coreerrors.NotValid)
 		}
 		result[i] = &coresecrets.SecretMetadata{
 			URI:         uri,
@@ -279,7 +279,7 @@ func (rows secretInfos) toSecretRevisionRef(refs secretValueRefs) ([]*coresecret
 	for i, row := range rows {
 		uri, err := coresecrets.ParseURI(row.ID)
 		if err != nil {
-			return nil, errors.NotValidf("secret URI %q", row.ID)
+			return nil, errors.Errorf("secret URI %q %w", row.ID, coreerrors.NotValid)
 		}
 		result[i] = &coresecrets.SecretRevisionRef{
 			URI:        uri,
@@ -321,7 +321,7 @@ func (rows secretIDs) toSecretMetadataForDrain(revRows secretExternalRevisions) 
 			// Encountered a new record.
 			uri, err := coresecrets.ParseURI(row.ID)
 			if err != nil {
-				return nil, errors.NotValidf("secret URI %q", row.ID)
+				return nil, errors.Errorf("secret URI %q %w", row.ID, coreerrors.NotValid)
 			}
 			md := coresecrets.SecretMetadataForDrain{
 				URI: uri,

--- a/domain/secretbackend/backendtype.go
+++ b/domain/secretbackend/backendtype.go
@@ -4,8 +4,8 @@
 package secretbackend
 
 import (
-	"github.com/juju/errors"
-
+	coreerrors "github.com/juju/juju/core/errors"
+	"github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/internal/secrets/provider/juju"
 	"github.com/juju/juju/internal/secrets/provider/kubernetes"
 	"github.com/juju/juju/internal/secrets/provider/vault"
@@ -31,5 +31,5 @@ func MarshallBackendType(backendType string) (BackendType, error) {
 	case vault.BackendType:
 		return BackendTypeVault, nil
 	}
-	return 0, errors.NotValidf("secret backend type %q", backendType)
+	return 0, errors.Errorf("secret backend type %q %w", backendType, coreerrors.NotValid)
 }

--- a/domain/secretbackend/bootstrap/bootstrap.go
+++ b/domain/secretbackend/bootstrap/bootstrap.go
@@ -7,13 +7,13 @@ import (
 	"context"
 
 	"github.com/canonical/sqlair"
-	"github.com/juju/errors"
 
 	"github.com/juju/juju/core/database"
 	coremodel "github.com/juju/juju/core/model"
 	domainsecretbackend "github.com/juju/juju/domain/secretbackend"
 	"github.com/juju/juju/domain/secretbackend/state"
 	internaldatabase "github.com/juju/juju/internal/database"
+	"github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/internal/secrets/provider/juju"
 	"github.com/juju/juju/internal/secrets/provider/kubernetes"
 	"github.com/juju/juju/internal/uuid"
@@ -25,29 +25,29 @@ func CreateDefaultBackends(modelType coremodel.ModelType) internaldatabase.Boots
 		err := controller.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 			err := createBackend(ctx, tx, juju.BackendName, domainsecretbackend.BackendTypeController)
 			if err != nil {
-				return errors.Trace(err)
+				return errors.Capture(err)
 			}
 			err = createBackend(ctx, tx, kubernetes.BackendName, domainsecretbackend.BackendTypeKubernetes)
 			if err != nil {
-				return errors.Trace(err)
+				return errors.Capture(err)
 			}
 			return nil
 		})
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 }
 
 func createBackend(ctx context.Context, tx *sqlair.TX, backendName string, backendType domainsecretbackend.BackendType) error {
 	backendUUID, err := uuid.NewUUID()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	insertBackendStmt, err := sqlair.Prepare(`
 INSERT INTO secret_backend
     (uuid, name, backend_type_id)
 VALUES ($SecretBackend.*)`, state.SecretBackend{})
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	err = tx.Query(ctx, insertBackendStmt, state.SecretBackend{
@@ -56,5 +56,5 @@ VALUES ($SecretBackend.*)`, state.SecretBackend{})
 		BackendTypeID:       backendType,
 		TokenRotateInterval: internaldatabase.NullDuration{},
 	}).Run()
-	return errors.Annotatef(err, "cannot create secret backend %q", backendName)
+	return errors.Errorf("cannot create secret backend %q %w", backendName, err)
 }

--- a/domain/secretbackend/bootstrap/bootstrap.go
+++ b/domain/secretbackend/bootstrap/bootstrap.go
@@ -56,5 +56,9 @@ VALUES ($SecretBackend.*)`, state.SecretBackend{})
 		BackendTypeID:       backendType,
 		TokenRotateInterval: internaldatabase.NullDuration{},
 	}).Run()
-	return errors.Errorf("cannot create secret backend %q %w", backendName, err)
+
+	if err != nil {
+		return errors.Errorf("cannot create secret backend %q %w", backendName, err)
+	}
+	return nil
 }

--- a/domain/secretbackend/errors/errors.go
+++ b/domain/secretbackend/errors/errors.go
@@ -3,9 +3,7 @@
 
 package errors
 
-import (
-	"github.com/juju/errors"
-)
+import "github.com/juju/juju/internal/errors"
 
 const (
 	// AlreadyExists describes an error that occurs when a secret backend already exists.

--- a/domain/secretbackend/params.go
+++ b/domain/secretbackend/params.go
@@ -4,10 +4,10 @@
 package secretbackend
 
 import (
-	"fmt"
 	"time"
 
 	backenderrors "github.com/juju/juju/domain/secretbackend/errors"
+	"github.com/juju/juju/internal/errors"
 )
 
 // BackendIdentifier is used to identify a secret backend.
@@ -36,22 +36,24 @@ type CreateSecretBackendParams struct {
 // Validate checks that the parameters are valid.
 func (p CreateSecretBackendParams) Validate() error {
 	if p.ID == "" {
-		return fmt.Errorf("%w: ID is missing", backenderrors.NotValid)
+		return errors.Errorf("%w: ID is missing", backenderrors.NotValid)
 	}
 	if p.Name == "" {
-		return fmt.Errorf("%w: name is missing", backenderrors.NotValid)
+		return errors.Errorf("%w: name is missing", backenderrors.NotValid)
 	}
 	if p.BackendType == "" {
-		return fmt.Errorf("%w: type is missing", backenderrors.NotValid)
+		return errors.Errorf("%w: type is missing", backenderrors.NotValid)
 	}
 	for k, v := range p.Config {
 		if k == "" {
-			return fmt.Errorf(
+			return errors.Errorf(
 				"%w: empty config key for %q", backenderrors.NotValid, p.Name)
+
 		}
 		if v == "" {
-			return fmt.Errorf(
+			return errors.Errorf(
 				"%w: empty config value for %q", backenderrors.NotValid, p.Name)
+
 		}
 	}
 	return nil
@@ -71,23 +73,25 @@ func (p UpdateSecretBackendParams) Validate() error {
 	if p.ID == "" && p.Name == "" {
 		// We need at least one identifier.
 		// So we can identify the secret backend to update by ID or name.
-		return fmt.Errorf("%w: both ID and name are missing", backenderrors.NotValid)
+		return errors.Errorf("%w: both ID and name are missing", backenderrors.NotValid)
 	}
 	if p.ID != "" && p.Name != "" {
 		// We just need one identifier.
-		return fmt.Errorf("%w: both ID and name are set", backenderrors.NotValid)
+		return errors.Errorf("%w: both ID and name are set", backenderrors.NotValid)
 	}
 	if p.NewName != nil && *p.NewName == "" {
-		return fmt.Errorf("%w: name cannot be set to empty", backenderrors.NotValid)
+		return errors.Errorf("%w: name cannot be set to empty", backenderrors.NotValid)
 	}
 	for k, v := range p.Config {
 		if k == "" {
-			return fmt.Errorf(
+			return errors.Errorf(
 				"%w: empty config key for %q", backenderrors.NotValid, p.ID)
+
 		}
 		if v == "" {
-			return fmt.Errorf(
+			return errors.Errorf(
 				"%w: empty config value for %q", backenderrors.NotValid, p.ID)
+
 		}
 	}
 	return nil

--- a/domain/secretbackend/service/service.go
+++ b/domain/secretbackend/service/service.go
@@ -11,10 +11,10 @@ import (
 	"github.com/juju/clock"
 	"github.com/juju/collections/set"
 	"github.com/juju/collections/transform"
-	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 
 	"github.com/juju/juju/core/changestream"
+	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/leadership"
 	"github.com/juju/juju/core/logger"
 	coremodel "github.com/juju/juju/core/model"
@@ -25,6 +25,7 @@ import (
 	secretservice "github.com/juju/juju/domain/secret/service"
 	"github.com/juju/juju/domain/secretbackend"
 	secretbackenderrors "github.com/juju/juju/domain/secretbackend/errors"
+	"github.com/juju/juju/internal/errors"
 	internalsecrets "github.com/juju/juju/internal/secrets"
 	"github.com/juju/juju/internal/secrets/provider"
 	"github.com/juju/juju/internal/secrets/provider/juju"
@@ -68,7 +69,7 @@ func newService(
 func (s *Service) GetSecretBackendConfigForAdmin(ctx context.Context, modelUUID coremodel.UUID) (*provider.ModelBackendConfigInfo, error) {
 	modelSecretBackend, err := s.st.GetModelSecretBackendDetails(ctx, modelUUID)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	// We need to include builtin backends for secret draining and accessing those secrets while drain is in progress.
@@ -76,7 +77,7 @@ func (s *Service) GetSecretBackendConfigForAdmin(ctx context.Context, modelUUID 
 	// For now, we'll return all backends on the controller.
 	backends, err := s.st.ListSecretBackendsForModel(ctx, modelUUID, true)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	currentBackendName := modelSecretBackend.SecretBackendName
 
@@ -97,7 +98,7 @@ func (s *Service) GetSecretBackendConfigForAdmin(ctx context.Context, modelUUID 
 		}
 	}
 	if info.ActiveID == "" {
-		return nil, fmt.Errorf("%w: %q", secretbackenderrors.NotFound, currentBackendName)
+		return nil, errors.Errorf("%w: %q", secretbackenderrors.NotFound, currentBackendName)
 	}
 	return &info, nil
 }
@@ -107,12 +108,12 @@ func (s *Service) DrainBackendConfigInfo(
 	ctx context.Context, p DrainBackendConfigParams,
 ) (*provider.ModelBackendConfigInfo, error) {
 	if p.Accessor.Kind != secretservice.UnitAccessor && p.Accessor.Kind != secretservice.ModelAccessor {
-		return nil, errors.NotSupportedf("secret accessor kind %q", p.Accessor.Kind)
+		return nil, errors.Errorf("secret accessor kind %q %w", p.Accessor.Kind, coreerrors.NotSupported)
 	}
 
 	adminModelCfg, err := s.GetSecretBackendConfigForAdmin(ctx, p.ModelUUID)
 	if err != nil {
-		return nil, errors.Annotatef(err, "getting admin config for secret backend %q", p.BackendID)
+		return nil, errors.Errorf("getting admin config for secret backend %q %w", p.BackendID, err)
 	}
 	result := provider.ModelBackendConfigInfo{
 		ActiveID: adminModelCfg.ActiveID,
@@ -129,7 +130,7 @@ func (s *Service) DrainBackendConfigInfo(
 	backendCfg, err := s.backendConfigInfo(ctx,
 		p.GrantedSecretsGetter, p.BackendID, &cfg, p.Accessor, p.LeaderToken, true, true)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	result.Configs[p.BackendID] = *backendCfg
 	return &result, nil
@@ -147,12 +148,12 @@ func (s *Service) BackendConfigInfo(
 	ctx context.Context, p BackendConfigParams,
 ) (*provider.ModelBackendConfigInfo, error) {
 	if p.Accessor.Kind != secretservice.UnitAccessor && p.Accessor.Kind != secretservice.ModelAccessor {
-		return nil, errors.NotSupportedf("secret accessor kind %q", p.Accessor.Kind)
+		return nil, errors.Errorf("secret accessor kind %q %w", p.Accessor.Kind, coreerrors.NotSupported)
 	}
 
 	adminModelCfg, err := s.GetSecretBackendConfigForAdmin(ctx, p.ModelUUID)
 	if err != nil {
-		return nil, errors.Annotate(err, "getting configured secrets providers")
+		return nil, errors.Errorf("getting configured secrets providers %w", err)
 	}
 	result := provider.ModelBackendConfigInfo{
 		ActiveID: adminModelCfg.ActiveID,
@@ -169,7 +170,7 @@ func (s *Service) BackendConfigInfo(
 		backendCfg, err := s.backendConfigInfo(ctx,
 			p.GrantedSecretsGetter, backendID, &cfg, p.Accessor, p.LeaderToken, p.SameController, false)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, errors.Capture(err)
 		}
 		result.Configs[backendID] = *backendCfg
 	}
@@ -188,11 +189,11 @@ func (s *Service) backendConfigInfo(
 
 	p, err := s.registry(cfg.BackendType)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	err = p.Initialise(cfg)
 	if err != nil {
-		return nil, errors.Annotate(err, "initialising secrets provider")
+		return nil, errors.Errorf("initialising secrets provider %w", err)
 	}
 
 	ownedRevisions := provider.SecretRevisions{}
@@ -215,7 +216,7 @@ func (s *Service) backendConfigInfo(
 		if token != nil {
 			err := token.Check()
 			if err != nil && !leadership.IsNotLeaderError(err) {
-				return nil, errors.Trace(err)
+				return nil, errors.Capture(err)
 			}
 			isLeader = err == nil
 		}
@@ -234,7 +235,7 @@ func (s *Service) backendConfigInfo(
 			}
 			revInfo, err := grantedSecretsGetter(ctx, backendID, coresecrets.RoleView, readOnlyOwner)
 			if err != nil {
-				return nil, errors.Trace(err)
+				return nil, errors.Capture(err)
 			}
 			for _, r := range revInfo {
 				readRevisions.Add(r.URI, r.RevisionID)
@@ -242,7 +243,7 @@ func (s *Service) backendConfigInfo(
 		}
 		revInfo, err := grantedSecretsGetter(ctx, backendID, coresecrets.RoleManage, owners...)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, errors.Capture(err)
 		}
 		for _, r := range revInfo {
 			ownedRevisions.Add(r.URI, r.RevisionID)
@@ -259,7 +260,7 @@ func (s *Service) backendConfigInfo(
 		}}
 		revInfo, err = grantedSecretsGetter(ctx, backendID, coresecrets.RoleView, consumers...)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, errors.Capture(err)
 		}
 		for _, r := range revInfo {
 			readRevisions.Add(r.URI, r.RevisionID)
@@ -271,19 +272,19 @@ func (s *Service) backendConfigInfo(
 		}
 		revInfo, err := grantedSecretsGetter(ctx, backendID, coresecrets.RoleManage, accessor)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, errors.Capture(err)
 		}
 		for _, r := range revInfo {
 			ownedRevisions.Add(r.URI, r.RevisionID)
 		}
 	default:
-		return nil, errors.NotSupportedf("secret accessor kind %q", accessor.Kind)
+		return nil, errors.Errorf("secret accessor kind %q %w", accessor.Kind, coreerrors.NotSupported)
 	}
 
 	s.logger.Debugf("secrets for %s:\nowned: %v\nconsumed:%v", accessor, ownedRevisions, readRevisions)
 	restrictedConfig, err := p.RestrictedConfig(ctx, cfg, sameController, forDrain, coreAccessor, ownedRevisions, readRevisions)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	info := &provider.ModelBackendConfig{
 		ControllerUUID: cfg.ControllerUUID,
@@ -308,7 +309,7 @@ func convertConfigToString(config map[string]interface{}) map[string]string {
 func (s *Service) BackendSummaryInfoForModel(ctx context.Context, modelUUID coremodel.UUID) ([]*SecretBackendInfo, error) {
 	backends, err := s.st.ListSecretBackendsForModel(ctx, modelUUID, false)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	backendInfos := make([]*SecretBackendInfo, 0, len(backends))
 	for _, b := range backends {
@@ -331,7 +332,7 @@ func (s *Service) BackendSummaryInfoForModel(ctx context.Context, modelUUID core
 func (s *Service) BackendSummaryInfo(ctx context.Context, reveal bool, names ...string) ([]*SecretBackendInfo, error) {
 	backends, err := s.st.ListSecretBackends(ctx)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	backendInfos := make([]*SecretBackendInfo, 0, len(backends))
 	for _, b := range backends {
@@ -361,7 +362,7 @@ func (s *Service) composeBackendInfoResults(backendInfos []*SecretBackendInfo, r
 		}
 		p, err := s.registry(b.BackendType)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, errors.Capture(err)
 		}
 		b.Status = status.Active.String()
 		if b.BackendType != juju.BackendType && b.BackendType != kubernetes.BackendType {
@@ -393,7 +394,7 @@ func pingBackend(p provider.SecretBackendProvider, cfg provider.ConfigAttrs) err
 		BackendConfig: provider.BackendConfig{BackendType: p.Type(), Config: cfg},
 	})
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	return b.Ping()
 }
@@ -403,7 +404,7 @@ func validateExternalBackendName(name string) error {
 		name == kubernetes.BackendName ||
 		name == provider.Auto ||
 		name == provider.Internal {
-		return fmt.Errorf("%w: reserved name %q", secretbackenderrors.NotValid, name)
+		return errors.Errorf("%w: reserved name %q", secretbackenderrors.NotValid, name)
 	}
 	return nil
 }
@@ -412,7 +413,7 @@ func validateExternalBackendName(name string) error {
 func (s *Service) ListBackendIDs(ctx context.Context) ([]string, error) {
 	result, err := s.st.ListSecretBackendIDs(ctx)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	return result, nil
 }
@@ -420,17 +421,17 @@ func (s *Service) ListBackendIDs(ctx context.Context) ([]string, error) {
 // CreateSecretBackend creates a new secret backend.
 func (s *Service) CreateSecretBackend(ctx context.Context, backend coresecrets.SecretBackend) error {
 	if backend.ID == "" {
-		return fmt.Errorf("%w: missing ID", secretbackenderrors.NotValid)
+		return errors.Errorf("%w: missing ID", secretbackenderrors.NotValid)
 	}
 	if backend.Name == "" {
-		return fmt.Errorf("%w: missing name", secretbackenderrors.NotValid)
+		return errors.Errorf("%w: missing name", secretbackenderrors.NotValid)
 	}
 	if err := validateExternalBackendName(backend.Name); err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	p, err := s.registry(backend.BackendType)
 	if err != nil {
-		return fmt.Errorf("getting backend provider type %q: %w", backend.BackendType, err)
+		return errors.Errorf("getting backend provider type %q: %w", backend.BackendType, err)
 	}
 	configValidator, ok := p.(provider.ProviderConfig)
 	if ok {
@@ -445,21 +446,21 @@ func (s *Service) CreateSecretBackend(ctx context.Context, backend coresecrets.S
 		}
 		err = configValidator.ValidateConfig(nil, backend.Config)
 		if err != nil {
-			return fmt.Errorf("%w: config for provider %q: %w", secretbackenderrors.NotValid, backend.BackendType, err)
+			return errors.Errorf("%w: config for provider %q: %w", secretbackenderrors.NotValid, backend.BackendType, err)
 		}
 	}
 	if err := pingBackend(p, backend.Config); err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	var nextRotateTime *time.Time
 	if backend.TokenRotateInterval != nil && *backend.TokenRotateInterval > 0 {
 		if !provider.HasAuthRefresh(p) {
-			return fmt.Errorf("%w: token refresh on secret backend of type %q", secretbackenderrors.NotSupported, p.Type())
+			return errors.Errorf("%w: token refresh on secret backend of type %q", secretbackenderrors.NotSupported, p.Type())
 		}
 		nextRotateTime, err = coresecrets.NextBackendRotateTime(s.clock.Now(), *backend.TokenRotateInterval)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 	}
 	_, err = s.st.CreateSecretBackend(
@@ -474,29 +475,29 @@ func (s *Service) CreateSecretBackend(ctx context.Context, backend coresecrets.S
 			NextRotateTime:      nextRotateTime,
 		},
 	)
-	return errors.Trace(err)
+	return errors.Capture(err)
 }
 
 // UpdateSecretBackend updates an existing secret backend.
 func (s *Service) UpdateSecretBackend(ctx context.Context, params UpdateSecretBackendParams) error {
 	if err := params.Validate(); err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	if params.NewName != nil {
 		if err := validateExternalBackendName(*params.NewName); err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 	}
 
 	existing, err := s.st.GetSecretBackend(ctx, params.BackendIdentifier)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	p, err := s.registry(existing.BackendType)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	cfgToApply := make(map[string]interface{})
@@ -519,27 +520,27 @@ func (s *Service) UpdateSecretBackend(ctx context.Context, params UpdateSecretBa
 		}
 		err = configValidator.ValidateConfig(existing.Config, cfgToApply)
 		if err != nil {
-			return fmt.Errorf("%w: config for provider %q: %w", secretbackenderrors.NotValid, existing.BackendType, err)
+			return errors.Errorf("%w: config for provider %q: %w", secretbackenderrors.NotValid, existing.BackendType, err)
 		}
 	}
 	if !params.SkipPing {
 		if err := pingBackend(p, cfgToApply); err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 	}
 	params.Config = convertConfigToString(cfgToApply)
 
 	if params.TokenRotateInterval != nil && *params.TokenRotateInterval > 0 {
 		if !provider.HasAuthRefresh(p) {
-			return errors.NotSupportedf("token refresh on secret backend of type %q", p.Type())
+			return errors.Errorf("token refresh on secret backend of type %q %w", p.Type(), coreerrors.NotSupported)
 		}
 		params.NextRotateTime, err = coresecrets.NextBackendRotateTime(s.clock.Now(), *params.TokenRotateInterval)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 	}
 	_, err = s.st.UpdateSecretBackend(ctx, params.UpdateSecretBackendParams)
-	return errors.Trace(err)
+	return errors.Capture(err)
 }
 
 // DeleteSecretBackend deletes a secret backend.
@@ -551,11 +552,11 @@ func (s *Service) DeleteSecretBackend(ctx context.Context, params DeleteSecretBa
 func (s *Service) RotateBackendToken(ctx context.Context, backendID string) error {
 	backendInfo, err := s.st.GetSecretBackend(ctx, secretbackend.BackendIdentifier{ID: backendID})
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	p, err := s.registry(backendInfo.BackendType)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	if !provider.HasAuthRefresh(p) {
 		return nil
@@ -579,7 +580,7 @@ func (s *Service) RotateBackendToken(ctx context.Context, backendID string) erro
 		s.logger.Debugf("refreshing auth token for %q: %v", backendInfo.Name, err)
 		// If there's a permission error, we can't recover from that.
 		if errors.Is(err, internalsecrets.PermissionDenied) {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 	} else {
 		_, err = s.st.UpdateSecretBackend(ctx, secretbackend.UpdateSecretBackendParams{
@@ -597,7 +598,7 @@ func (s *Service) RotateBackendToken(ctx context.Context, backendID string) erro
 	}
 	s.logger.Debugf("updating token rotation for %q, next: %s", backendInfo.Name, nextRotateTime)
 	err = s.st.SecretBackendRotated(ctx, backendID, nextRotateTime)
-	return errors.Trace(err)
+	return errors.Capture(err)
 }
 
 // GetRevisionsToDrain looks at the supplied revisions and returns any which should be
@@ -605,7 +606,7 @@ func (s *Service) RotateBackendToken(ctx context.Context, backendID string) erro
 func (s *Service) GetRevisionsToDrain(ctx context.Context, modelUUID coremodel.UUID, revs []coresecrets.SecretExternalRevision) ([]RevisionInfo, error) {
 	internalBackendUUID, activeBackendUUID, err := s.st.GetInternalAndActiveBackendUUIDs(ctx, modelUUID)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	var result []RevisionInfo
 	for _, r := range revs {
@@ -671,7 +672,7 @@ func (s *WatchableService) WatchSecretBackendRotationChanges(context.Context) (w
 	tableName, initialQ := s.st.InitialWatchStatementForSecretBackendRotationChanges()
 	w, err := s.watcherFactory.NewNamespaceWatcher(tableName, changestream.All, InitialNamespaceChanges(initialQ))
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	return newSecretBackendRotateWatcher(w, s.logger, s.st.GetSecretBackendRotateChanges)
 }
@@ -680,7 +681,7 @@ func (s *WatchableService) WatchSecretBackendRotationChanges(context.Context) (w
 func (s *WatchableService) WatchModelSecretBackendChanged(_ context.Context, modelUUID coremodel.UUID) (watcher.NotifyWatcher, error) {
 	w, err := s.watcherFactory.NewValueWatcher("model_secret_backend", modelUUID.String(), changestream.Update)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	return w, nil
 }

--- a/domain/secretbackend/service/service_test.go
+++ b/domain/secretbackend/service/service_test.go
@@ -5,12 +5,10 @@ package service
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/juju/clock/testclock"
 	"github.com/juju/collections/set"
-	"github.com/juju/errors"
 	"github.com/juju/schema"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -33,6 +31,7 @@ import (
 	secretservice "github.com/juju/juju/domain/secret/service"
 	"github.com/juju/juju/domain/secretbackend"
 	secretbackenderrors "github.com/juju/juju/domain/secretbackend/errors"
+	"github.com/juju/juju/internal/errors"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 	"github.com/juju/juju/internal/secrets/provider"
 	"github.com/juju/juju/internal/secrets/provider/juju"
@@ -68,7 +67,7 @@ func (providerWithConfig) ConfigDefaults() schema.Defaults {
 
 func (p providerWithConfig) ValidateConfig(oldCfg, newCfg provider.ConfigAttrs) error {
 	if p.Type() == "something" {
-		return fmt.Errorf("bad config for %q", p.Type())
+		return errors.Errorf("bad config for %q", p.Type())
 	}
 	return nil
 }
@@ -1079,7 +1078,7 @@ func (s *serviceSuite) TestCreateSecretBackendFailed(c *gc.C) {
 		BackendType: "something",
 	})
 	c.Check(err, jc.ErrorIs, secretbackenderrors.NotValid)
-	c.Check(errors.Cause(err), gc.ErrorMatches, `secret backend not valid: config for provider "something": bad config for "something"`)
+	c.Check(err, gc.ErrorMatches, `secret backend not valid: config for provider "something": bad config for "something"`)
 }
 
 func (s *serviceSuite) TestCreateSecretBackend(c *gc.C) {
@@ -1174,7 +1173,7 @@ func (s *serviceSuite) TestUpdateSecretBackendFailed(c *gc.C) {
 	arg.ID = "backend-uuid"
 	err = svc.UpdateSecretBackend(context.Background(), arg)
 	c.Check(err, jc.ErrorIs, secretbackenderrors.NotValid)
-	c.Check(errors.Cause(err), gc.ErrorMatches, `secret backend not valid: config for provider "something": bad config for "something"`)
+	c.Check(err, gc.ErrorMatches, `secret backend not valid: config for provider "something": bad config for "something"`)
 }
 
 func (s *serviceSuite) assertUpdateSecretBackend(c *gc.C, byName, skipPing bool) {

--- a/domain/secretbackend/service/watcher.go
+++ b/domain/secretbackend/service/watcher.go
@@ -6,12 +6,12 @@ package service
 import (
 	"context"
 
-	"github.com/juju/errors"
 	"github.com/juju/worker/v4"
 	"github.com/juju/worker/v4/catacomb"
 
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/watcher"
+	"github.com/juju/juju/internal/errors"
 )
 
 type secretBackendRotateWatcher struct {
@@ -39,7 +39,7 @@ func newSecretBackendRotateWatcher(
 		Work: w.loop,
 		Init: []worker.Worker{sourceWatcher},
 	})
-	return w, errors.Trace(err)
+	return w, errors.Capture(err)
 }
 
 func (w *secretBackendRotateWatcher) scopedContext() (context.Context, context.CancelFunc) {
@@ -67,7 +67,7 @@ func (w *secretBackendRotateWatcher) loop() (err error) {
 			changes, err = w.processChanges(ctx, backendIDs...)
 			cancel()
 			if err != nil {
-				return errors.Trace(err)
+				return errors.Capture(err)
 			}
 			if len(changes) > 0 {
 				out = w.out

--- a/domain/secretbackend/state/state.go
+++ b/domain/secretbackend/state/state.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/canonical/sqlair"
 	"github.com/juju/collections/transform"
-	"github.com/juju/errors"
 
 	"github.com/juju/juju/cloud"
 	coredatabase "github.com/juju/juju/core/database"
@@ -26,6 +25,7 @@ import (
 	secretbackenderrors "github.com/juju/juju/domain/secretbackend/errors"
 	"github.com/juju/juju/environs/cloudspec"
 	"github.com/juju/juju/internal/database"
+	"github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/internal/secrets/provider"
 	"github.com/juju/juju/internal/secrets/provider/juju"
 	"github.com/juju/juju/internal/secrets/provider/kubernetes"
@@ -50,7 +50,7 @@ func NewState(factory coredatabase.TxnRunnerFactory, logger logger.Logger) *Stat
 func (s *State) GetModelSecretBackendDetails(ctx context.Context, uuid coremodel.UUID) (secretbackend.ModelSecretBackend, error) {
 	db, err := s.DB()
 	if err != nil {
-		return secretbackend.ModelSecretBackend{}, errors.Trace(err)
+		return secretbackend.ModelSecretBackend{}, errors.Capture(err)
 	}
 
 	stmt, err := s.Prepare(`
@@ -58,18 +58,18 @@ SELECT &ModelSecretBackend.*
 FROM   v_model_secret_backend
 WHERE  uuid = $M.uuid`, sqlair.M{}, ModelSecretBackend{})
 	if err != nil {
-		return secretbackend.ModelSecretBackend{}, errors.Trace(err)
+		return secretbackend.ModelSecretBackend{}, errors.Capture(err)
 	}
 	var m ModelSecretBackend
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err := tx.Query(ctx, stmt, sqlair.M{"uuid": uuid}).Get(&m)
 		if errors.Is(err, sql.ErrNoRows) {
-			return fmt.Errorf("cannot get secret backend for model %q: %w", uuid, modelerrors.NotFound)
+			return errors.Errorf("cannot get secret backend for model %q: %w", uuid, modelerrors.NotFound)
 		}
-		return errors.Trace(err)
+		return errors.Capture(err)
 	})
 	if err != nil {
-		return secretbackend.ModelSecretBackend{}, errors.Trace(err)
+		return secretbackend.ModelSecretBackend{}, errors.Capture(err)
 	}
 	return secretbackend.ModelSecretBackend{
 		ControllerUUID:    m.ControllerUUID,
@@ -85,7 +85,7 @@ WHERE  uuid = $M.uuid`, sqlair.M{}, ModelSecretBackend{})
 func (s *State) GetModelType(ctx context.Context, modelUUID coremodel.UUID) (coremodel.ModelType, error) {
 	db, err := s.DB()
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", errors.Capture(err)
 	}
 
 	mDetails := modelDetails{UUID: modelUUID}
@@ -96,17 +96,17 @@ JOIN   model_type mt ON mt.id = model_type_id
 WHERE  m.uuid = $modelDetails.uuid
 `, modelDetails{})
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", errors.Capture(err)
 	}
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err := tx.Query(ctx, stmt, mDetails).Get(&mDetails)
 		if errors.Is(err, sql.ErrNoRows) {
-			return fmt.Errorf("cannot get model type for model %q: %w", modelUUID, modelerrors.NotFound)
+			return errors.Errorf("cannot get model type for model %q: %w", modelUUID, modelerrors.NotFound)
 		}
-		return errors.Trace(err)
+		return errors.Capture(err)
 	})
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", errors.Capture(err)
 	}
 	return mDetails.Type, nil
 }
@@ -115,7 +115,7 @@ WHERE  m.uuid = $modelDetails.uuid
 func (s *State) GetInternalAndActiveBackendUUIDs(ctx context.Context, modelUUID coremodel.UUID) (string, string, error) {
 	db, err := s.DB()
 	if err != nil {
-		return "", "", errors.Trace(err)
+		return "", "", errors.Capture(err)
 	}
 
 	activeBackend := ModelSecretBackend{ModelID: modelUUID}
@@ -126,7 +126,7 @@ SELECT secret_backend_uuid AS &ModelSecretBackend.secret_backend_uuid
 FROM   v_model_secret_backend
 WHERE  uuid = $ModelSecretBackend.uuid`, activeBackend)
 	if err != nil {
-		return "", "", errors.Trace(err)
+		return "", "", errors.Capture(err)
 	}
 
 	stmtBackendUUID, err := s.Prepare(`
@@ -134,23 +134,23 @@ SELECT uuid AS &SecretBackend.uuid
 FROM   secret_backend
 WHERE  name = $SecretBackend.name`, internalBackend)
 	if err != nil {
-		return "", "", errors.Trace(err)
+		return "", "", errors.Capture(err)
 	}
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err := tx.Query(ctx, stmtActiveBackend, activeBackend).Get(&activeBackend)
 		if errors.Is(err, sql.ErrNoRows) {
-			return fmt.Errorf("cannot get active secret backend for model %q: %w", modelUUID, modelerrors.NotFound)
+			return errors.Errorf("cannot get active secret backend for model %q: %w", modelUUID, modelerrors.NotFound)
 		}
 
 		err = tx.Query(ctx, stmtBackendUUID, internalBackend).Get(&internalBackend)
 		if errors.Is(err, sql.ErrNoRows) {
-			return fmt.Errorf("cannot get secret backend %q: %w", juju.BackendName, secretbackenderrors.NotFound)
+			return errors.Errorf("cannot get secret backend %q: %w", juju.BackendName, secretbackenderrors.NotFound)
 		}
-		return errors.Trace(err)
+		return errors.Capture(err)
 	})
 	if err != nil {
-		return "", "", errors.Trace(err)
+		return "", "", errors.Capture(err)
 	}
 	return internalBackend.ID, activeBackend.SecretBackendID, nil
 }
@@ -158,12 +158,12 @@ WHERE  name = $SecretBackend.name`, internalBackend)
 // CreateSecretBackend creates a new secret backend.
 func (s *State) CreateSecretBackend(ctx context.Context, params secretbackend.CreateSecretBackendParams) (string, error) {
 	if err := params.Validate(); err != nil {
-		return "", errors.Trace(err)
+		return "", errors.Capture(err)
 	}
 
 	db, err := s.DB()
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", errors.Capture(err)
 	}
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		_, err := s.upsertSecretBackend(ctx, tx, upsertSecretBackendParams{
@@ -174,11 +174,11 @@ func (s *State) CreateSecretBackend(ctx context.Context, params secretbackend.Cr
 			NextRotateTime:      params.NextRotateTime,
 			Config:              params.Config,
 		})
-		return errors.Trace(err)
+		return errors.Capture(err)
 	})
 	if err != nil {
 		if database.IsErrConstraintUnique(err) {
-			return "", fmt.Errorf("%w: secret backend with name %q", secretbackenderrors.AlreadyExists, params.Name)
+			return "", errors.Errorf("%w: secret backend with name %q", secretbackenderrors.AlreadyExists, params.Name)
 		}
 		return "", err
 	}
@@ -188,17 +188,17 @@ func (s *State) CreateSecretBackend(ctx context.Context, params secretbackend.Cr
 // UpdateSecretBackend updates the secret backend.
 func (s *State) UpdateSecretBackend(ctx context.Context, params secretbackend.UpdateSecretBackendParams) (string, error) {
 	if err := params.Validate(); err != nil {
-		return "", errors.Trace(err)
+		return "", errors.Capture(err)
 	}
 
 	db, err := s.DB()
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", errors.Capture(err)
 	}
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		existing, err := s.getSecretBackend(ctx, tx, params.BackendIdentifier)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		upsertParams := upsertSecretBackendParams{
 			// secret_backend table.
@@ -220,19 +220,19 @@ func (s *State) UpdateSecretBackend(ctx context.Context, params secretbackend.Up
 			upsertParams.TokenRotateInterval = params.TokenRotateInterval
 		}
 		_, err = s.upsertSecretBackend(ctx, tx, upsertParams)
-		return errors.Trace(err)
+		return errors.Capture(err)
 	})
 	return params.ID, err
 }
 
 func (s *State) upsertSecretBackend(ctx context.Context, tx *sqlair.TX, params upsertSecretBackendParams) (string, error) {
 	if err := params.Validate(); err != nil {
-		return "", errors.Trace(err)
+		return "", errors.Capture(err)
 	}
 
 	backendTypeID, err := domainsecretbackend.MarshallBackendType(params.BackendType)
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", errors.Capture(err)
 	}
 	sb := SecretBackend{
 		ID:            params.ID,
@@ -244,21 +244,21 @@ func (s *State) upsertSecretBackend(ctx context.Context, tx *sqlair.TX, params u
 	}
 
 	if err := s.upsertBackend(ctx, tx, sb); err != nil {
-		return params.ID, errors.Trace(err)
+		return params.ID, errors.Capture(err)
 	}
 	if params.NextRotateTime != nil && !params.NextRotateTime.IsZero() {
 		if err := s.upsertBackendRotation(ctx, tx, SecretBackendRotation{
 			ID:               params.ID,
 			NextRotationTime: sql.NullTime{Time: *params.NextRotateTime, Valid: true},
 		}); err != nil {
-			return params.ID, errors.Trace(err)
+			return params.ID, errors.Capture(err)
 		}
 	}
 	if len(params.Config) == 0 {
 		return params.ID, nil
 	}
 	if err := s.upsertBackendConfig(ctx, tx, params.ID, params.Config); err != nil {
-		return params.ID, errors.Trace(err)
+		return params.ID, errors.Capture(err)
 	}
 	return params.ID, nil
 }
@@ -267,7 +267,7 @@ func (s *State) upsertSecretBackend(ctx context.Context, tx *sqlair.TX, params u
 func (s *State) DeleteSecretBackend(ctx context.Context, identifier secretbackend.BackendIdentifier, deleteInUse bool) error {
 	db, err := s.DB()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	input := SecretBackend{ID: identifier.ID, Name: identifier.Name}
@@ -277,18 +277,18 @@ SELECT COUNT(*) AS &Count.num
 FROM   secret_backend_reference
 WHERE  secret_backend_uuid = $SecretBackend.uuid`, input, Count{})
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	cfgStmt, err := s.Prepare(`
 DELETE FROM secret_backend_config WHERE backend_uuid = $SecretBackend.uuid`, input)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	rotationStmt, err := s.Prepare(`
 DELETE FROM secret_backend_rotation WHERE backend_uuid = $SecretBackend.uuid`, input)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	// TODO(secrets) - use a struct not string literals
@@ -306,18 +306,18 @@ SET secret_backend_uuid = (
 )
 WHERE secret_backend_uuid = $SecretBackend.uuid`, input)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	backendStmt, err := s.Prepare(`
 DELETE FROM secret_backend WHERE uuid = $SecretBackend.uuid`, input)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		if identifier.ID == "" {
 			sb, err := s.getSecretBackend(ctx, tx, identifier)
 			if err != nil {
-				return errors.Trace(err)
+				return errors.Capture(err)
 			}
 			input.ID = sb.ID
 		}
@@ -326,31 +326,31 @@ DELETE FROM secret_backend WHERE uuid = $SecretBackend.uuid`, input)
 			var count Count
 			err := tx.Query(ctx, checkInUseStmt, input).Get(&count)
 			if err != nil {
-				return fmt.Errorf("checking if secret backend %q is in use: %w", input.ID, err)
+				return errors.Errorf("checking if secret backend %q is in use: %w", input.ID, err)
 			}
 			if count.Num > 0 {
-				return fmt.Errorf("%w: %q is in use", secretbackenderrors.Forbidden, input.ID)
+				return errors.Errorf("%w: %q is in use", secretbackenderrors.Forbidden, input.ID)
 			}
 		}
 
 		if err := tx.Query(ctx, cfgStmt, input).Run(); err != nil {
-			return fmt.Errorf("deleting secret backend config for %q: %w", input.ID, err)
+			return errors.Errorf("deleting secret backend config for %q: %w", input.ID, err)
 		}
 		if err := tx.Query(ctx, rotationStmt, input).Run(); err != nil {
-			return fmt.Errorf("deleting secret backend rotation for %q: %w", input.ID, err)
+			return errors.Errorf("deleting secret backend rotation for %q: %w", input.ID, err)
 		}
 		if err = tx.Query(ctx, modelSecretBackendStmt, input).Run(); err != nil {
-			return fmt.Errorf("resetting secret backend %q to NULL for models: %w", input.ID, err)
+			return errors.Errorf("resetting secret backend %q to NULL for models: %w", input.ID, err)
 		}
 		if err := s.removeSecretBackendReferenceForBackend(ctx, tx, input.ID); err != nil {
-			return fmt.Errorf("removing secret backend reference for %q: %w", input.ID, err)
+			return errors.Errorf("removing secret backend reference for %q: %w", input.ID, err)
 		}
 		err = tx.Query(ctx, backendStmt, input).Run()
 		if database.IsErrConstraintTrigger(err) {
-			return fmt.Errorf("%w: %q is immutable", secretbackenderrors.Forbidden, input.ID)
+			return errors.Errorf("%w: %q is immutable", secretbackenderrors.Forbidden, input.ID)
 		}
 		if err != nil {
-			return fmt.Errorf("deleting secret backend for %q: %w", input.ID, err)
+			return errors.Errorf("deleting secret backend for %q: %w", input.ID, err)
 		}
 		return nil
 	})
@@ -361,14 +361,14 @@ DELETE FROM secret_backend WHERE uuid = $SecretBackend.uuid`, input)
 func (s *State) ListSecretBackendIDs(ctx context.Context) ([]string, error) {
 	db, err := s.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	stmt, err := s.Prepare(`
 SELECT
     b.uuid AS &SecretBackendRow.uuid
 FROM secret_backend b`, SecretBackendRow{})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	var rows secretBackendRows
@@ -378,12 +378,12 @@ FROM secret_backend b`, SecretBackendRow{})
 			return nil
 		}
 		if err != nil {
-			return fmt.Errorf("querying secret backends: %w", err)
+			return errors.Errorf("querying secret backends: %w", err)
 		}
 		return nil
 	})
 	if err != nil {
-		return nil, fmt.Errorf("cannot list secret backend ids: %w", err)
+		return nil, errors.Errorf("cannot list secret backend ids: %w", err)
 	}
 
 	result := make([]string, len(rows))
@@ -397,7 +397,7 @@ FROM secret_backend b`, SecretBackendRow{})
 func (s *State) ListSecretBackends(ctx context.Context) ([]*secretbackend.SecretBackend, error) {
 	db, err := s.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	nonK8sQuery := fmt.Sprintf(`
 SELECT
@@ -416,7 +416,7 @@ WHERE b.name <> '%s'
 GROUP BY b.name, c.name`, kubernetes.BackendName)
 	nonK8sStmt, err := s.Prepare(nonK8sQuery, SecretBackendRow{})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	var result []*secretbackend.SecretBackend
@@ -424,7 +424,7 @@ GROUP BY b.name, c.name`, kubernetes.BackendName)
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		result, err = s.listInUseKubernetesSecretBackends(ctx, tx)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		err = tx.Query(ctx, nonK8sStmt).GetAll(&nonK8sRows)
 		if errors.Is(err, sql.ErrNoRows) {
@@ -434,12 +434,12 @@ GROUP BY b.name, c.name`, kubernetes.BackendName)
 			return nil
 		}
 		if err != nil {
-			return fmt.Errorf("querying secret backends: %w", err)
+			return errors.Errorf("querying secret backends: %w", err)
 		}
 		return nil
 	})
 	if err != nil {
-		return nil, fmt.Errorf("cannot list secret backends: %w", err)
+		return nil, errors.Errorf("cannot list secret backends: %w", err)
 	}
 	return append(result, nonK8sRows.toSecretBackends()...), nil
 }
@@ -478,7 +478,7 @@ WHERE b.name = '%s'
 GROUP BY vm.name, vcca.attribute_key`, kubernetes.BackendName)
 	backendStmt, err := s.Prepare(backendQuery, secretBackendForK8sModelRow{}, cloudRow{}, cloudCredentialRow{})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	var sbData secretBackendForK8sModelRows
@@ -493,7 +493,7 @@ GROUP BY vm.name, vcca.attribute_key`, kubernetes.BackendName)
 		return nil, nil
 	}
 	if err != nil {
-		return nil, fmt.Errorf("querying kubernetes secret backends: %w", err)
+		return nil, errors.Errorf("querying kubernetes secret backends: %w", err)
 	}
 	return sbData.toSecretBackend(cloudData, credentialData)
 }
@@ -501,11 +501,11 @@ GROUP BY vm.name, vcca.attribute_key`, kubernetes.BackendName)
 func getK8sBackendConfig(cloud cloud.Cloud, cred cloud.Credential) (*provider.BackendConfig, error) {
 	spec, err := cloudspec.MakeCloudSpec(cloud, "", &cred)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	k8sConfig, err := kubernetes.BuiltInConfig(spec)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	return k8sConfig, nil
 }
@@ -516,7 +516,7 @@ func getK8sBackendConfig(cloud cloud.Cloud, cred cloud.Credential) (*provider.Ba
 func (s *State) ListSecretBackendsForModel(ctx context.Context, modelUUID coremodel.UUID, includeEmpty bool) ([]*secretbackend.SecretBackend, error) {
 	db, err := s.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	inUseCondition := ""
@@ -546,7 +546,7 @@ FROM secret_backend b
 ORDER BY b.name`, inUseCondition)
 	nonK8sStmt, err := s.Prepare(nonK8sQuery, append(nonK8sArgs, SecretBackendRow{})...)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	getModelStmt, err := s.Prepare(`
@@ -556,7 +556,7 @@ JOIN   model_type mt ON mt.id = model_type_id
 WHERE  m.uuid = $M.uuid
 `, modelDetails{}, sqlair.M{})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	var (
@@ -569,10 +569,10 @@ WHERE  m.uuid = $M.uuid
 		err := tx.Query(ctx, getModelStmt, sqlair.M{"uuid": modelUUID}).Get(&modelDetails)
 		if errors.Is(err, sql.ErrNoRows) {
 			// Should never happen.
-			return fmt.Errorf("%w: %s", modelerrors.NotFound, modelUUID)
+			return errors.Errorf("%w: %s", modelerrors.NotFound, modelUUID)
 		}
 		if err != nil {
-			return fmt.Errorf("querying model: %w", err)
+			return errors.Errorf("querying model: %w", err)
 		}
 		modelType = modelDetails.Type
 
@@ -584,16 +584,16 @@ WHERE  m.uuid = $M.uuid
 			return nil
 		}
 		if err != nil {
-			return fmt.Errorf("querying secret backends: %w", err)
+			return errors.Errorf("querying secret backends: %w", err)
 		}
 		if modelType != coremodel.CAAS {
 			return nil
 		}
 		currentK8sBackend, err = s.getK8sSecretBackendForModel(ctx, tx, modelUUID)
-		return errors.Trace(err)
+		return errors.Capture(err)
 	})
 	if err != nil {
-		return nil, fmt.Errorf("cannot list secret backends: %w", err)
+		return nil, errors.Errorf("cannot list secret backends: %w", err)
 	}
 
 	var result []*secretbackend.SecretBackend
@@ -606,7 +606,7 @@ WHERE  m.uuid = $M.uuid
 	if currentK8sBackend != nil {
 		result = append(result, currentK8sBackend)
 	}
-	return result, errors.Trace(err)
+	return result, errors.Capture(err)
 }
 
 func (s *State) getK8sSecretBackendForModel(ctx context.Context, tx *sqlair.TX, modelUUID coremodel.UUID) (*secretbackend.SecretBackend, error) {
@@ -634,7 +634,7 @@ FROM v_model vm
 WHERE vm.uuid = $modelIdentifier.uuid
 GROUP BY vm.name, vcca.attribute_key`, modelIdentifier{}, modelDetails{}, secretBackendForK8sModelRow{}, cloudRow{}, cloudCredentialRow{})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	var models []modelDetails
 	var sbCloudCredentialIDs secretBackendForK8sModelRows
@@ -642,17 +642,17 @@ GROUP BY vm.name, vcca.attribute_key`, modelIdentifier{}, modelDetails{}, secret
 	var creds cloudCredentialRows
 	err = tx.Query(ctx, stmt, modelIdentifier{ModelID: modelUUID}).GetAll(&models, &sbCloudCredentialIDs, &clds, &creds)
 	if errors.Is(err, sql.ErrNoRows) {
-		return nil, fmt.Errorf("%w: %q", modelerrors.NotFound, modelUUID)
+		return nil, errors.Errorf("%w: %q", modelerrors.NotFound, modelUUID)
 	}
 	if err != nil {
-		return nil, fmt.Errorf("cannot fetch k8s secret backend credential for model %q: %w", modelUUID, err)
+		return nil, errors.Errorf("cannot fetch k8s secret backend credential for model %q: %w", modelUUID, err)
 	}
 	if len(models) == 0 || len(sbCloudCredentialIDs) == 0 {
-		return nil, fmt.Errorf("%w: %q", modelerrors.NotFound, modelUUID)
+		return nil, errors.Errorf("%w: %q", modelerrors.NotFound, modelUUID)
 	}
 	model := models[0]
 	if model.Type != coremodel.CAAS {
-		return nil, fmt.Errorf("%w: %q", modelerrors.NotFound, modelUUID)
+		return nil, errors.Errorf("%w: %q", modelerrors.NotFound, modelUUID)
 	}
 	sbCloudCredentialID := sbCloudCredentialIDs[0]
 
@@ -660,11 +660,11 @@ GROUP BY vm.name, vcca.attribute_key`, modelIdentifier{}, modelDetails{}, secret
 	cred := creds.toCloudCredentials()[sbCloudCredentialID.CredentialID]
 	k8sConfig, err := getK8sBackendConfig(cld, cred)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	sb, err := s.getSecretBackend(ctx, tx, secretbackend.BackendIdentifier{Name: kubernetes.BackendName})
 	if err != nil {
-		return nil, fmt.Errorf("cannot get k8s secret backend for model %q: %w", modelUUID, err)
+		return nil, errors.Errorf("cannot get k8s secret backend for model %q: %w", modelUUID, err)
 	}
 	sb.Config = k8sConfig.Config
 	return sb, nil
@@ -672,10 +672,10 @@ GROUP BY vm.name, vcca.attribute_key`, modelIdentifier{}, modelDetails{}, secret
 
 func (s *State) getSecretBackend(ctx context.Context, tx *sqlair.TX, identifier secretbackend.BackendIdentifier) (*secretbackend.SecretBackend, error) {
 	if identifier.ID == "" && identifier.Name == "" {
-		return nil, fmt.Errorf("%w: both ID and name are missing", secretbackenderrors.NotValid)
+		return nil, errors.Errorf("%w: both ID and name are missing", secretbackenderrors.NotValid)
 	}
 	if identifier.ID != "" && identifier.Name != "" {
-		return nil, fmt.Errorf("%w: both ID and name are provided", secretbackenderrors.NotValid)
+		return nil, errors.Errorf("%w: both ID and name are provided", secretbackenderrors.NotValid)
 	}
 	columName := "uuid"
 	v := identifier.ID
@@ -698,16 +698,16 @@ FROM secret_backend b
 WHERE b.%s = $M.identifier`, columName)
 	stmt, err := s.Prepare(q, sqlair.M{}, SecretBackendRow{})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	var rows secretBackendRows
 	err = tx.Query(ctx, stmt, sqlair.M{"identifier": v}).GetAll(&rows)
 	if errors.Is(err, sql.ErrNoRows) || len(rows) == 0 {
-		return nil, fmt.Errorf("%w: %q", secretbackenderrors.NotFound, v)
+		return nil, errors.Errorf("%w: %q", secretbackenderrors.NotFound, v)
 	}
 	if err != nil {
-		return nil, fmt.Errorf("querying secret backends: %w", err)
+		return nil, errors.Errorf("querying secret backends: %w", err)
 	}
 	return rows.toSecretBackends()[0], nil
 }
@@ -715,22 +715,22 @@ WHERE b.%s = $M.identifier`, columName)
 // GetSecretBackend returns the secret backend for the given backend ID or Name.
 func (s *State) GetSecretBackend(ctx context.Context, params secretbackend.BackendIdentifier) (*secretbackend.SecretBackend, error) {
 	if params.ID == "" && params.Name == "" {
-		return nil, fmt.Errorf("%w: both ID and name are missing", secretbackenderrors.NotValid)
+		return nil, errors.Errorf("%w: both ID and name are missing", secretbackenderrors.NotValid)
 	}
 	if params.ID != "" && params.Name != "" {
-		return nil, fmt.Errorf("%w: both ID and name are provided", secretbackenderrors.NotValid)
+		return nil, errors.Errorf("%w: both ID and name are provided", secretbackenderrors.NotValid)
 	}
 
 	db, err := s.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	var sb *secretbackend.SecretBackend
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		var err error
 		sb, err = s.getSecretBackend(ctx, tx, params)
-		return errors.Trace(err)
+		return errors.Capture(err)
 	})
 	return sb, err
 }
@@ -739,7 +739,7 @@ func (s *State) GetSecretBackend(ctx context.Context, params secretbackend.Backe
 func (s *State) SecretBackendRotated(ctx context.Context, backendID string, next time.Time) error {
 	db, err := s.DB()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	updateStmt, err := s.Prepare(`
 UPDATE secret_backend_rotation
@@ -747,14 +747,14 @@ SET next_rotation_time = $SecretBackendRotation.next_rotation_time
 WHERE backend_uuid = $SecretBackendRotation.backend_uuid
     AND $SecretBackendRotation.next_rotation_time < next_rotation_time`, SecretBackendRotation{})
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	getStmt, err := s.Prepare(`
 SELECT uuid AS &SecretBackendRotationRow.uuid
 FROM secret_backend
 WHERE uuid = $M.uuid`, sqlair.M{}, SecretBackendRotationRow{})
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
@@ -762,10 +762,10 @@ WHERE uuid = $M.uuid`, sqlair.M{}, SecretBackendRotationRow{})
 		var sb SecretBackendRotationRow
 		err := tx.Query(ctx, getStmt, sqlair.M{"uuid": backendID}).Get(&sb)
 		if errors.Is(err, sql.ErrNoRows) {
-			return fmt.Errorf("%w: %q", secretbackenderrors.NotFound, backendID)
+			return errors.Errorf("%w: %q", secretbackenderrors.NotFound, backendID)
 		}
 		if err != nil {
-			return fmt.Errorf("checking if secret backend %q exists: %w", backendID, err)
+			return errors.Errorf("checking if secret backend %q exists: %w", backendID, err)
 		}
 
 		err = tx.Query(ctx, updateStmt,
@@ -775,7 +775,7 @@ WHERE uuid = $M.uuid`, sqlair.M{}, SecretBackendRotationRow{})
 			},
 		).Run()
 		if err != nil {
-			return fmt.Errorf("updating secret backend rotation: %w", err)
+			return errors.Errorf("updating secret backend rotation: %w", err)
 		}
 		return nil
 	})
@@ -788,7 +788,7 @@ WHERE uuid = $M.uuid`, sqlair.M{}, SecretBackendRotationRow{})
 func (s *State) SetModelSecretBackend(ctx context.Context, modelUUID coremodel.UUID, secretBackendName string) error {
 	db, err := s.DB()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	backendInfo := ModelSecretBackend{
@@ -803,7 +803,7 @@ WHERE  b.name = $ModelSecretBackend.secret_backend_name
 `
 	secretBackendSelectStmt, err := s.Prepare(secretBackendSelectQ, backendInfo)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	modelBackendUpdate := `
@@ -812,31 +812,31 @@ SET    secret_backend_uuid = $ModelSecretBackend.secret_backend_uuid
 WHERE  model_uuid = $ModelSecretBackend.uuid`
 	modelBackendUpdateStmt, err := s.Prepare(modelBackendUpdate, backendInfo)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err = tx.Query(ctx, secretBackendSelectStmt, backendInfo).Get(&backendInfo)
 		if errors.Is(err, sql.ErrNoRows) {
-			return fmt.Errorf("cannot get secret backend %q: %w", backendInfo.SecretBackendName, secretbackenderrors.NotFound)
+			return errors.Errorf("cannot get secret backend %q: %w", backendInfo.SecretBackendName, secretbackenderrors.NotFound)
 		}
 		if err != nil {
-			return fmt.Errorf("cannot get secret backend %q: %w", backendInfo.SecretBackendName, err)
+			return errors.Errorf("cannot get secret backend %q: %w", backendInfo.SecretBackendName, err)
 		}
 
 		var outcome sqlair.Outcome
 		err = tx.Query(ctx, modelBackendUpdateStmt, backendInfo).Get(&outcome)
 		if err != nil {
-			return fmt.Errorf("setting secret backend %q for model %q: %w", backendInfo.SecretBackendName, modelUUID, err)
+			return errors.Errorf("setting secret backend %q for model %q: %w", backendInfo.SecretBackendName, modelUUID, err)
 		}
 		affected, err := outcome.Result().RowsAffected()
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		if affected == 0 {
-			return fmt.Errorf("cannot set secret backend %q for model %q: %w",
-				backendInfo.SecretBackendName, backendInfo.ModelID, modelerrors.NotFound,
-			)
+			return errors.Errorf("cannot set secret backend %q for model %q: %w",
+				backendInfo.SecretBackendName, backendInfo.ModelID, modelerrors.NotFound)
+
 		}
 		return nil
 	})
@@ -847,7 +847,7 @@ WHERE  model_uuid = $ModelSecretBackend.uuid`
 func (s *State) GetSecretBackendReferenceCount(ctx context.Context, backendID string) (int, error) {
 	db, err := s.DB()
 	if err != nil {
-		return -1, errors.Trace(err)
+		return -1, errors.Capture(err)
 	}
 	input := SecretBackendReference{BackendID: backendID}
 	result := Count{}
@@ -856,14 +856,14 @@ SELECT COUNT(*) AS &Count.num
 FROM   secret_backend_reference
 WHERE  secret_backend_uuid = $SecretBackendReference.secret_backend_uuid`, input, result)
 	if err != nil {
-		return -1, errors.Trace(err)
+		return -1, errors.Capture(err)
 	}
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err := tx.Query(ctx, stmt, input).Get(&result)
-		return errors.Trace(err)
+		return errors.Capture(err)
 	})
 	if err != nil {
-		return -1, fmt.Errorf("cannot get secret backend reference count for %q: %w", backendID, err)
+		return -1, errors.Errorf("cannot get secret backend reference count for %q: %w", backendID, err)
 	}
 	return result.Num, nil
 }
@@ -879,20 +879,20 @@ func (s *State) AddSecretBackendReference(
 ) (func() error, error) {
 	db, err := s.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	var backendID string
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		backendID, err = s.getSecretBackendID(ctx, tx, valueRef)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		err := s.addSecretBackendReference(ctx, tx, backendID, modelID, revisionID)
-		return errors.Trace(err)
+		return errors.Capture(err)
 	})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	return func() error {
 		err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
@@ -905,18 +905,18 @@ DELETE FROM secret_backend_reference
 WHERE  secret_backend_uuid = $SecretBackendReference.secret_backend_uuid
     AND secret_revision_uuid = $SecretBackendReference.secret_revision_uuid`, input)
 			if err != nil {
-				return errors.Trace(err)
+				return errors.Capture(err)
 			}
 			err = tx.Query(ctx, stmt, input).Run()
 			if err != nil {
-				return fmt.Errorf(
+				return errors.Errorf(
 					"cannot revert secret backend reference for secret backend %q secret revision %q: %w",
-					backendID, revisionID, err,
-				)
+					backendID, revisionID, err)
+
 			}
 			return nil
 		})
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}, nil
 }
 
@@ -931,7 +931,7 @@ func (s *State) getSecretBackendID(ctx context.Context, tx *sqlair.TX, valueRef 
 
 	backend, err := s.getSecretBackend(ctx, tx, arg)
 	if err != nil {
-		return "", fmt.Errorf("cannot get secret backend ID for %q: %w", arg, err)
+		return "", errors.Errorf("cannot get secret backend ID for %q: %w", arg, err)
 	}
 	return backend.ID, nil
 }
@@ -949,22 +949,22 @@ func (s *State) addSecretBackendReference(
 INSERT INTO secret_backend_reference (*)
 VALUES ($SecretBackendReference.*)`, ref)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	err = tx.Query(ctx, stmt, ref).Run()
 	if database.IsErrConstraintForeignKey(err) {
-		return fmt.Errorf("%w: model %q", modelerrors.NotFound, ref.ModelID)
+		return errors.Errorf("%w: model %q", modelerrors.NotFound, ref.ModelID)
 	}
 	if database.IsErrConstraintPrimaryKey(err) {
-		return fmt.Errorf(
+		return errors.Errorf(
 			"%w: backend %q model %q secret revision %q",
 			secretbackenderrors.RefCountAlreadyExists,
-			ref.BackendID, ref.ModelID, ref.SecretRevisionID,
-		)
+			ref.BackendID, ref.ModelID, ref.SecretRevisionID)
+
 	}
 	if err != nil {
-		return fmt.Errorf("cannot add secret backend reference for secret revision %q: %w", revisionID, err)
+		return errors.Errorf("cannot add secret backend reference for secret revision %q: %w", revisionID, err)
 	}
 	return nil
 }
@@ -982,21 +982,21 @@ FROM   secret_backend_reference
 WHERE  model_uuid = $SecretBackendReference.model_uuid
 	AND secret_revision_uuid = $SecretBackendReference.secret_revision_uuid`, ref)
 	if err != nil {
-		return SecretBackendReference{}, errors.Trace(err)
+		return SecretBackendReference{}, errors.Capture(err)
 	}
 
 	err = tx.Query(ctx, stmt, ref).Get(&ref)
 	if errors.Is(err, sql.ErrNoRows) {
-		return SecretBackendReference{}, fmt.Errorf(
+		return SecretBackendReference{}, errors.Errorf(
 			"%w: model %q secret revision %q",
-			secretbackenderrors.RefCountNotFound, modelID, revisionID,
-		)
+			secretbackenderrors.RefCountNotFound, modelID, revisionID)
+
 	}
 	if err != nil {
-		return SecretBackendReference{}, fmt.Errorf(
+		return SecretBackendReference{}, errors.Errorf(
 			"cannot get secret backend reference for model %q secret revision %q: %w",
-			modelID, revisionID, err,
-		)
+			modelID, revisionID, err)
+
 	}
 	return ref, nil
 }
@@ -1009,40 +1009,40 @@ func (s *State) UpdateSecretBackendReference(
 ) (func() error, error) {
 	db, err := s.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	var existing SecretBackendReference
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		existing, err = s.getSecretBackendReferenceBackendID(ctx, tx, modelID, revisionID)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		backendID, err := s.getSecretBackendID(ctx, tx, valueRef)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		if err := s.removeSecretBackendReferenceForRevisions(ctx, tx, revisionID); err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		if err := s.addSecretBackendReference(ctx, tx, backendID, modelID, revisionID); err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		return nil
 	})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	return func() error {
 		err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 			if err := s.removeSecretBackendReferenceForRevisions(ctx, tx, revisionID); err != nil {
-				return errors.Trace(err)
+				return errors.Capture(err)
 			}
 			err := s.addSecretBackendReference(ctx, tx, existing.BackendID, modelID, revisionID)
-			return errors.Trace(err)
+			return errors.Capture(err)
 		})
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}, nil
 }
 
@@ -1056,14 +1056,14 @@ func (s *State) RemoveSecretBackendReference(ctx context.Context, revisionIDs ..
 
 	db, err := s.DB()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err := s.removeSecretBackendReferenceForRevisions(ctx, tx, revisionIDs...)
-		return errors.Trace(err)
+		return errors.Capture(err)
 	})
-	return errors.Trace(err)
+	return errors.Capture(err)
 }
 
 func (s *State) removeSecretBackendReferenceForRevisions(ctx context.Context, tx *sqlair.TX, revisionIDs ...string) error {
@@ -1076,14 +1076,14 @@ func (s *State) removeSecretBackendReferenceForRevisions(ctx context.Context, tx
 DELETE FROM secret_backend_reference
 WHERE  secret_revision_uuid IN ($secretRevisionIDs[:])`, input)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	err = tx.Query(ctx, stmt, input).Run()
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil
 	}
 	if err != nil {
-		return fmt.Errorf("cannot remove secret backend reference for %d secret revision(s): %w", len(revisionIDs), err)
+		return errors.Errorf("cannot remove secret backend reference for %d secret revision(s): %w", len(revisionIDs), err)
 	}
 	return nil
 }
@@ -1094,14 +1094,14 @@ func (s *State) removeSecretBackendReferenceForBackend(ctx context.Context, tx *
 DELETE FROM secret_backend_reference
 WHERE  secret_backend_uuid = $SecretBackendReference.secret_backend_uuid`, input)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	err = tx.Query(ctx, stmt, input).Run()
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil
 	}
 	if err != nil {
-		return fmt.Errorf("cannot remove secret backend reference for secret backend %q: %w", backendID, err)
+		return errors.Errorf("cannot remove secret backend reference for secret backend %q: %w", backendID, err)
 	}
 	return nil
 }
@@ -1117,7 +1117,7 @@ func (s *State) InitialWatchStatementForSecretBackendRotationChanges() (string, 
 func (s *State) GetSecretBackendRotateChanges(ctx context.Context, backendIDs ...string) ([]watcher.SecretBackendRotateChange, error) {
 	db, err := s.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	stmt, err := s.Prepare(`
@@ -1131,7 +1131,7 @@ WHERE b.uuid IN ($S[:])`,
 		sqlair.S{}, SecretBackendRotationRow{},
 	)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	var rows SecretBackendRotationRows
@@ -1144,9 +1144,9 @@ WHERE b.uuid IN ($S[:])`,
 			return nil
 		}
 		if err != nil {
-			return fmt.Errorf("querying secret backend rotation changes: %w", err)
+			return errors.Errorf("querying secret backend rotation changes: %w", err)
 		}
 		return nil
 	})
-	return rows.toChanges(s.logger), errors.Trace(err)
+	return rows.toChanges(s.logger), errors.Capture(err)
 }

--- a/domain/secretbackend/state/types.go
+++ b/domain/secretbackend/state/types.go
@@ -5,12 +5,10 @@ package state
 
 import (
 	"database/sql"
-	"fmt"
 	"sort"
 	"time"
 
 	"github.com/juju/collections/set"
-	"github.com/juju/errors"
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/core/logger"
@@ -20,6 +18,7 @@ import (
 	"github.com/juju/juju/domain/secretbackend"
 	backenderrors "github.com/juju/juju/domain/secretbackend/errors"
 	"github.com/juju/juju/internal/database"
+	"github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/internal/secrets/provider/kubernetes"
 )
 
@@ -50,7 +49,7 @@ type modelIdentifier struct {
 // Validate checks that the model identifier is valid.
 func (m modelIdentifier) Validate() error {
 	if m.ModelID == "" && m.ModelName == "" {
-		return fmt.Errorf("both model ID and name are missing")
+		return errors.Errorf("both model ID and name are missing")
 	}
 	return nil
 }
@@ -84,22 +83,24 @@ type upsertSecretBackendParams struct {
 // Validate checks that the parameters are valid.
 func (p upsertSecretBackendParams) Validate() error {
 	if p.ID == "" {
-		return fmt.Errorf("%w: ID is missing", backenderrors.NotValid)
+		return errors.Errorf("%w: ID is missing", backenderrors.NotValid)
 	}
 	if p.Name == "" {
-		return fmt.Errorf("%w: name is missing", backenderrors.NotValid)
+		return errors.Errorf("%w: name is missing", backenderrors.NotValid)
 	}
 	if p.BackendType == "" {
-		return fmt.Errorf("%w: type is missing", backenderrors.NotValid)
+		return errors.Errorf("%w: type is missing", backenderrors.NotValid)
 	}
 	for k, v := range p.Config {
 		if k == "" {
-			return fmt.Errorf(
+			return errors.Errorf(
 				"%w: empty config key for %q", backenderrors.NotValid, p.Name)
+
 		}
 		if v == "" {
-			return fmt.Errorf(
+			return errors.Errorf(
 				"%w: empty config value for %q", backenderrors.NotValid, p.Name)
+
 		}
 	}
 	return nil
@@ -232,7 +233,7 @@ func (rows secretBackendForK8sModelRows) toSecretBackend(cldData cloudRows, cred
 		}
 		k8sConfig, err := getK8sBackendConfig(clds[row.CloudID], creds[row.CredentialID])
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, errors.Capture(err)
 		}
 		result = append(result, &secretbackend.SecretBackend{
 			ID:          row.ID,

--- a/domain/secretbackend/state/upserts.go
+++ b/domain/secretbackend/state/upserts.go
@@ -5,13 +5,12 @@ package state
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/canonical/sqlair"
-	"github.com/juju/errors"
 
 	backenderrors "github.com/juju/juju/domain/secretbackend/errors"
 	"github.com/juju/juju/internal/database"
+	"github.com/juju/juju/internal/errors"
 )
 
 func (s *State) upsertBackend(ctx context.Context, tx *sqlair.TX, sb SecretBackend) error {
@@ -23,17 +22,17 @@ ON CONFLICT (uuid) DO UPDATE SET
     name=EXCLUDED.name,
     token_rotate_interval=EXCLUDED.token_rotate_interval;`, SecretBackend{})
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	err = tx.Query(ctx, upsertBackendStmt, sb).Run()
 	if database.IsErrConstraintUnique(err) {
-		return fmt.Errorf("%w: name %q", backenderrors.AlreadyExists, sb.Name)
+		return errors.Errorf("%w: name %q", backenderrors.AlreadyExists, sb.Name)
 	}
 	if database.IsErrConstraintTrigger(err) {
-		return fmt.Errorf("%w: %q is immutable", backenderrors.Forbidden, sb.ID)
+		return errors.Errorf("%w: %q is immutable", backenderrors.Forbidden, sb.ID)
 	}
 	if err != nil {
-		return fmt.Errorf("cannot upsert secret backend %q: %w", sb.Name, err)
+		return errors.Errorf("cannot upsert secret backend %q: %w", sb.Name, err)
 	}
 	return nil
 }
@@ -47,10 +46,10 @@ ON CONFLICT (backend_uuid) DO UPDATE SET
     next_rotation_time=EXCLUDED.next_rotation_time;`,
 		SecretBackendRotation{})
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	if err = tx.Query(ctx, upsertRotationStmt, r).Run(); err != nil {
-		return fmt.Errorf("cannot upsert secret backend rotation time for %q: %w", r.ID, err)
+		return errors.Errorf("cannot upsert secret backend rotation time for %q: %w", r.ID, err)
 	}
 	return nil
 }
@@ -61,7 +60,7 @@ DELETE FROM secret_backend_config
 WHERE backend_uuid = $M.uuid AND name NOT IN ($S[:]);`,
 		sqlair.M{}, sqlair.S{})
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	upsertConfigStmt, err := s.Prepare(`
@@ -72,7 +71,7 @@ ON CONFLICT (backend_uuid, name) DO UPDATE SET
     content = EXCLUDED.content`,
 		SecretBackendConfig{})
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	namesToKeep := make(sqlair.S, 0, len(cfg))
@@ -80,7 +79,7 @@ ON CONFLICT (backend_uuid, name) DO UPDATE SET
 		namesToKeep = append(namesToKeep, k)
 	}
 	if err = tx.Query(ctx, clearConfigStmt, sqlair.M{"uuid": id}, namesToKeep).Run(); err != nil {
-		return fmt.Errorf("cannot clear secret backend config for %q: %w", id, err)
+		return errors.Errorf("cannot clear secret backend config for %q: %w", id, err)
 	}
 	for k, v := range cfg {
 		// TODO: this needs to be fixed once the sqlair supports bulk insert.
@@ -90,7 +89,7 @@ ON CONFLICT (backend_uuid, name) DO UPDATE SET
 			Content: v,
 		}).Run()
 		if err != nil {
-			return fmt.Errorf("cannot upsert secret backend config for %q: %w", id, err)
+			return errors.Errorf("cannot upsert secret backend config for %q: %w", id, err)
 		}
 	}
 	return nil

--- a/domain/services/testing/suite.go
+++ b/domain/services/testing/suite.go
@@ -10,13 +10,13 @@ import (
 	"net/http"
 
 	"github.com/juju/clock"
-	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/credential"
+	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/lease"
 	"github.com/juju/juju/core/model"
 	coremodel "github.com/juju/juju/core/model"
@@ -41,6 +41,7 @@ import (
 	domainservicefactory "github.com/juju/juju/domain/services"
 	"github.com/juju/juju/internal/auth"
 	databasetesting "github.com/juju/juju/internal/database/testing"
+	"github.com/juju/juju/internal/errors"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 	_ "github.com/juju/juju/internal/provider/dummy"
 	"github.com/juju/juju/internal/services"
@@ -357,7 +358,7 @@ type TestingObjectStore struct{}
 // Get returns an io.ReadCloser for data at path, namespaced to the
 // model.
 func (TestingObjectStore) Get(ctx context.Context, name string) (io.ReadCloser, int64, error) {
-	return nil, 0, errors.NotFoundf(name)
+	return nil, 0, errors.Errorf(name+" %w", coreerrors.NotFound)
 }
 
 // GetBySHA256Prefix returns an io.ReadCloser for data at path, namespaced to the

--- a/domain/services/testing/suite.go
+++ b/domain/services/testing/suite.go
@@ -364,7 +364,7 @@ func (TestingObjectStore) Get(ctx context.Context, name string) (io.ReadCloser, 
 // GetBySHA256Prefix returns an io.ReadCloser for data at path, namespaced to the
 // model.
 func (TestingObjectStore) GetBySHA256Prefix(ctx context.Context, sha256 string) (io.ReadCloser, int64, error) {
-	return nil, 0, errors.NotFoundf(sha256)
+	return nil, 0, errors.Errorf("%q does not exist", sha256).Add(coreerrors.NotFound)
 }
 
 // Put stores data from reader at path, namespaced to the model.

--- a/domain/state.go
+++ b/domain/state.go
@@ -5,13 +5,12 @@ package domain
 
 import (
 	"context"
-	"fmt"
 	"sync"
 
 	"github.com/canonical/sqlair"
-	"github.com/juju/errors"
 
 	"github.com/juju/juju/core/database"
+	"github.com/juju/juju/internal/errors"
 )
 
 // TxnRunner is an interface that provides a method for executing a closure
@@ -75,7 +74,7 @@ func (st *StateBase) DB() (TxnRunner, error) {
 
 	db, err := st.getDB()
 	if err != nil {
-		return nil, errors.Annotate(err, "invoking getDB")
+		return nil, errors.Errorf("invoking getDB %w", err)
 	}
 	st.db = &txnRunner{runner: db}
 	return st.db, nil
@@ -108,7 +107,7 @@ func (st *StateBase) Prepare(query string, typeSamples ...any) (*sqlair.Statemen
 
 	stmt, err := sqlair.Prepare(query, typeSamples...)
 	if err != nil {
-		return nil, errors.Annotate(err, "preparing:")
+		return nil, errors.Errorf("preparing: %w", err)
 	}
 
 	st.statements[query] = stmt
@@ -125,7 +124,7 @@ func (st *StateBase) Prepare(query string, typeSamples ...any) (*sqlair.Statemen
 func (st *StateBase) RunAtomic(ctx context.Context, fn func(AtomicContext) error) error {
 	db, err := st.DB()
 	if err != nil {
-		return errors.Annotate(err, "getting database")
+		return errors.Errorf("getting database %w", err)
 	}
 
 	return db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
@@ -174,7 +173,7 @@ func Run(ctx AtomicContext, fn func(context.Context, *sqlair.TX) error) error {
 		// If you're seeing this error, it means that the atomicContext was not
 		// created by RunAtomic. This is a programming error. Did you attempt to
 		// wrap the context in a custom context and pass it to Run?
-		return fmt.Errorf("programmatic error: AtomicContext is not a *atomicContext: %T", ctx)
+		return errors.Errorf("programmatic error: AtomicContext is not a *atomicContext: %T", ctx)
 	}
 
 	// Ensure that we can lock the context for the duration of the run function.
@@ -190,7 +189,7 @@ func Run(ctx AtomicContext, fn func(context.Context, *sqlair.TX) error) error {
 		// created by RunAtomic. This is a programming error. Did you capture
 		// the AtomicContext from a RunAtomic closure and try to use it outside
 		// of the closure?
-		return fmt.Errorf("programmatic error: AtomicContext does not have a transaction")
+		return errors.Errorf("programmatic error: AtomicContext does not have a transaction")
 	}
 
 	// Execute the function with the transaction.

--- a/domain/state_test.go
+++ b/domain/state_test.go
@@ -6,7 +6,6 @@ package domain
 import (
 	"context"
 	"database/sql"
-	"fmt"
 	"sync/atomic"
 	"time"
 
@@ -15,6 +14,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	schematesting "github.com/juju/juju/domain/schema/testing"
+	"github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/internal/testing"
 )
 
@@ -268,7 +268,7 @@ func (s *stateSuite) TestStateBaseRunAtomicWithRunFailsConcurrently(c *gc.C) {
 			select {
 			case <-start:
 			case <-time.After(testing.LongWait):
-				secondErr <- fmt.Errorf("failed to start in time")
+				secondErr <- errors.Errorf("failed to start in time")
 				return
 			}
 
@@ -278,7 +278,7 @@ func (s *stateSuite) TestStateBaseRunAtomicWithRunFailsConcurrently(c *gc.C) {
 				// will be 2. This isn't exact, but it should be good enough
 				// to ensure that the first run has completed.
 				if atomic.LoadInt64(&called) != 2 {
-					return fmt.Errorf("called before first run completed")
+					return errors.Errorf("called before first run completed")
 				}
 
 				atomic.AddInt64(&called, 1)
@@ -294,13 +294,13 @@ func (s *stateSuite) TestStateBaseRunAtomicWithRunFailsConcurrently(c *gc.C) {
 				return err
 			}
 		case <-time.After(testing.LongWait):
-			return fmt.Errorf("failed to complete first run in time")
+			return errors.Errorf("failed to complete first run in time")
 		}
 		select {
 		case err := <-secondErr:
 			return err
 		case <-time.After(testing.LongWait):
-			return fmt.Errorf("failed to complete second run in time")
+			return errors.Errorf("failed to complete second run in time")
 		}
 	})
 	c.Assert(err, jc.ErrorIsNil)

--- a/domain/storage/defaults.go
+++ b/domain/storage/defaults.go
@@ -4,15 +4,13 @@
 package storage
 
 import (
-	"fmt"
 	"maps"
-
-	"github.com/juju/errors"
 
 	k8sconstants "github.com/juju/juju/caas/kubernetes/provider/constants"
 	coremodel "github.com/juju/juju/core/model"
 	storageerrors "github.com/juju/juju/domain/storage/errors"
 	"github.com/juju/juju/internal/charm"
+	"github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/internal/storage"
 	"github.com/juju/juju/internal/storage/provider"
 )
@@ -48,16 +46,16 @@ func StorageDirectivesWithDefaults(
 		if !ok {
 			if storage.Shared {
 				// TODO(axw) get the model's default shared storage pool, and create constraints here.
-				return nil, fmt.Errorf(
+				return nil, errors.Errorf(
 					"%w for shared charm storage %q",
 					storageerrors.MissingSharedStorageDirectiveError,
-					name,
-				)
+					name)
+
 			}
 		}
 		cons, err := storageDirectivesWithDefaults(storage, modelType, defaults, cons)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, errors.Capture(err)
 		}
 		result[name] = cons
 	}
@@ -77,7 +75,7 @@ func storageDirectivesWithDefaults(
 		kind := storageKind(charmStorage.Type)
 		poolName, err := defaultStoragePool(defaults, modelType, kind, directive)
 		if err != nil {
-			return withDefaults, errors.Annotatef(err, "finding default pool for %q storage", charmStorage.Name)
+			return withDefaults, errors.Errorf("finding default pool for %q storage %w", charmStorage.Name, err)
 		}
 		withDefaults.Pool = poolName
 	}

--- a/domain/storage/errors/errors.go
+++ b/domain/storage/errors/errors.go
@@ -3,9 +3,7 @@
 
 package errors
 
-import (
-	"github.com/juju/errors"
-)
+import "github.com/juju/juju/internal/errors"
 
 // These errors are used for storage pool operations.
 const (

--- a/domain/storage/modelmigration/export.go
+++ b/domain/storage/modelmigration/export.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/juju/collections/set"
 	"github.com/juju/description/v8"
-	"github.com/juju/errors"
 
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/modelmigration"
@@ -16,6 +15,7 @@ import (
 	domainstorage "github.com/juju/juju/domain/storage"
 	"github.com/juju/juju/domain/storage/service"
 	"github.com/juju/juju/domain/storage/state"
+	"github.com/juju/juju/internal/errors"
 	internalstorage "github.com/juju/juju/internal/storage"
 )
 
@@ -59,12 +59,12 @@ func (e *exportOperation) Setup(scope modelmigration.Scope) error {
 func (e *exportOperation) Execute(ctx context.Context, model description.Model) error {
 	poolConfigs, err := e.service.AllStoragePools(ctx)
 	if err != nil {
-		return errors.Annotate(err, "listing pools")
+		return errors.Errorf("listing pools %w", err)
 	}
 
 	builtIn, err := domainstorage.BuiltInStoragePools()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	builtInNames := set.Strings{}
 	for _, p := range builtIn {

--- a/domain/storage/modelmigration/import.go
+++ b/domain/storage/modelmigration/import.go
@@ -7,13 +7,13 @@ import (
 	"context"
 
 	"github.com/juju/description/v8"
-	"github.com/juju/errors"
 
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/modelmigration"
 	corestorage "github.com/juju/juju/core/storage"
 	"github.com/juju/juju/domain/storage/service"
 	"github.com/juju/juju/domain/storage/state"
+	"github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/internal/storage"
 )
 
@@ -62,7 +62,7 @@ func (i *importOperation) Execute(ctx context.Context, model description.Model) 
 	for _, pool := range model.StoragePools() {
 		err := i.service.CreateStoragePool(ctx, pool.Name(), storage.ProviderType(pool.Provider()), pool.Attributes())
 		if err != nil {
-			return errors.Annotatef(err, "creating storage pool %q", pool.Name())
+			return errors.Errorf("creating storage pool %q %w", pool.Name(), err)
 		}
 	}
 	return nil

--- a/domain/storage/service/service_test.go
+++ b/domain/storage/service/service_test.go
@@ -6,12 +6,12 @@ package service
 import (
 	"context"
 
-	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/internal/errors"
 	logtesting "github.com/juju/juju/internal/logger/testing"
 )
 

--- a/domain/storage/service/storagepool.go
+++ b/domain/storage/service/storagepool.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 
 	"github.com/juju/collections/transform"
-	"github.com/juju/errors"
 
 	"github.com/juju/juju/core/logger"
 	corestorage "github.com/juju/juju/core/storage"
 	domainstorage "github.com/juju/juju/domain/storage"
 	storageerrors "github.com/juju/juju/domain/storage/errors"
+	"github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/internal/storage"
 )
 
@@ -41,7 +41,7 @@ type PoolAttrs map[string]any
 func (s *StoragePoolService) CreateStoragePool(ctx context.Context, name string, providerType storage.ProviderType, attrs PoolAttrs) error {
 	err := s.validateConfig(ctx, name, providerType, attrs)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	attrsToSave := transform.Map(attrs, func(k string, v any) (string, string) { return k, fmt.Sprint(v) })
@@ -51,7 +51,7 @@ func (s *StoragePoolService) CreateStoragePool(ctx context.Context, name string,
 		Attrs:    attrsToSave,
 	}
 	err = s.st.CreateStoragePool(ctx, sp)
-	return errors.Annotatef(err, "creating storage pool %q", name)
+	return errors.Errorf("creating storage pool %q %w", name, err)
 }
 
 func (s *StoragePoolService) validateConfig(ctx context.Context, name string, providerType storage.ProviderType, attrs map[string]interface{}) error {
@@ -59,7 +59,7 @@ func (s *StoragePoolService) validateConfig(ctx context.Context, name string, pr
 		return storageerrors.MissingPoolNameError
 	}
 	if !storage.IsValidPoolName(name) {
-		return fmt.Errorf("pool name %q not valid%w", name, errors.Hide(storageerrors.InvalidPoolNameError))
+		return errors.Errorf("pool name %q not valid", name).Add(storageerrors.InvalidPoolNameError)
 	}
 	if providerType == "" {
 		return storageerrors.MissingPoolTypeError
@@ -67,22 +67,22 @@ func (s *StoragePoolService) validateConfig(ctx context.Context, name string, pr
 
 	cfg, err := storage.NewConfig(name, providerType, attrs)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	// GetStorageRegistry result for a given model will be cached after the
 	// initial call, so this should be cheap to call.
 	registry, err := s.registryGetter.GetStorageRegistry(ctx)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	p, err := registry.StorageProvider(providerType)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	if err := p.ValidateConfig(cfg); err != nil {
-		return errors.Annotate(err, "validating storage provider config")
+		return errors.Errorf("validating storage provider config %w", err)
 	}
 	return nil
 }
@@ -118,7 +118,7 @@ func (s *StoragePoolService) DeleteStoragePool(ctx context.Context, name string)
 		}
 	*/
 	err := s.st.DeleteStoragePool(ctx, name)
-	return errors.Annotatef(err, "deleting storage pool %q", name)
+	return errors.Errorf("deleting storage pool %q %w", name, err)
 }
 
 // ReplaceStoragePool replaces an existing storage pool, returning an error
@@ -128,14 +128,14 @@ func (s *StoragePoolService) ReplaceStoragePool(ctx context.Context, name string
 	if providerType == "" {
 		existingConfig, err := s.st.GetStoragePoolByName(ctx, name)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		providerType = storage.ProviderType(existingConfig.Provider)
 	}
 
 	err := s.validateConfig(ctx, name, providerType, attrs)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	attrsToSave := transform.Map(attrs, func(k string, v any) (string, string) { return k, fmt.Sprint(v) })
@@ -145,7 +145,7 @@ func (s *StoragePoolService) ReplaceStoragePool(ctx context.Context, name string
 		Attrs:    attrsToSave,
 	}
 	err = s.st.ReplaceStoragePool(ctx, sp)
-	return errors.Annotatef(err, "replacing storage pool %q", name)
+	return errors.Errorf("replacing storage pool %q %w", name, err)
 }
 
 // AllStoragePools returns the all storage pools.
@@ -156,17 +156,17 @@ func (s *StoragePoolService) AllStoragePools(ctx context.Context) ([]*storage.Co
 // ListStoragePools returns the storage pools matching the specified filter.
 func (s *StoragePoolService) ListStoragePools(ctx context.Context, names domainstorage.Names, providers domainstorage.Providers) ([]*storage.Config, error) {
 	if err := s.validatePoolListFilterTerms(ctx, names, providers); err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	pools, err := domainstorage.BuiltInStoragePools()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	sp, err := s.st.ListStoragePools(ctx, names, providers)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	pools = append(pools, sp...)
 
@@ -174,7 +174,7 @@ func (s *StoragePoolService) ListStoragePools(ctx context.Context, names domains
 	for i, p := range pools {
 		results[i], err = s.storageConfig(ctx, p)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, errors.Capture(err)
 		}
 	}
 	return results, nil
@@ -182,10 +182,10 @@ func (s *StoragePoolService) ListStoragePools(ctx context.Context, names domains
 
 func (s *StoragePoolService) validatePoolListFilterTerms(ctx context.Context, names domainstorage.Names, providers domainstorage.Providers) error {
 	if err := s.validateProviderCriteria(ctx, providers); err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	if err := s.validateNameCriteria(names); err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	return nil
 }
@@ -193,7 +193,7 @@ func (s *StoragePoolService) validatePoolListFilterTerms(ctx context.Context, na
 func (s *StoragePoolService) validateNameCriteria(names []string) error {
 	for _, n := range names {
 		if !storage.IsValidPoolName(n) {
-			return fmt.Errorf("pool name %q not valid%w", n, errors.Hide(storageerrors.InvalidPoolNameError))
+			return errors.Errorf("pool name %q not valid", n).Add(storageerrors.InvalidPoolNameError)
 		}
 	}
 	return nil
@@ -204,13 +204,13 @@ func (s *StoragePoolService) validateProviderCriteria(ctx context.Context, provi
 	// initial call, so this should be cheap to call.
 	registry, err := s.registryGetter.GetStorageRegistry(ctx)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	for _, p := range providers {
 		_, err := registry.StorageProvider(storage.ProviderType(p))
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 	}
 	return nil
@@ -220,12 +220,12 @@ func (s *StoragePoolService) validateProviderCriteria(ctx context.Context, provi
 // satisfying [storageerrors.PoolNotFoundError] if it doesn't exist.
 func (s *StoragePoolService) GetStoragePoolByName(ctx context.Context, name string) (*storage.Config, error) {
 	if !storage.IsValidPoolName(name) {
-		return nil, fmt.Errorf("pool name %q not valid%w", name, errors.Hide(storageerrors.InvalidPoolNameError))
+		return nil, errors.Errorf("pool name %q not valid", name).Add(storageerrors.InvalidPoolNameError)
 	}
 
 	builtIn, err := domainstorage.BuiltInStoragePools()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	for _, p := range builtIn {
 		if p.Name == name {
@@ -235,7 +235,7 @@ func (s *StoragePoolService) GetStoragePoolByName(ctx context.Context, name stri
 
 	sp, err := s.st.GetStoragePoolByName(ctx, name)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	return s.storageConfig(ctx, sp)
 }
@@ -245,7 +245,7 @@ func (s *StoragePoolService) storageConfig(ctx context.Context, sp domainstorage
 	// initial call, so this should be cheap to call.
 	registry, err := s.registryGetter.GetStorageRegistry(ctx)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	var attr map[string]any
@@ -254,14 +254,14 @@ func (s *StoragePoolService) storageConfig(ctx context.Context, sp domainstorage
 	}
 	cfg, err := storage.NewConfig(sp.Name, storage.ProviderType(sp.Provider), attr)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	p, err := registry.StorageProvider(cfg.Provider())
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	if err := p.ValidateConfig(cfg); err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 	return cfg, nil
 }

--- a/domain/storage/service/storagepool_test.go
+++ b/domain/storage/service/storagepool_test.go
@@ -6,14 +6,15 @@ package service
 import (
 	"context"
 
-	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
+	coreerrors "github.com/juju/juju/core/errors"
 	domainstorage "github.com/juju/juju/domain/storage"
 	storageerrors "github.com/juju/juju/domain/storage/errors"
+	"github.com/juju/juju/internal/errors"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 	"github.com/juju/juju/internal/storage"
 	"github.com/juju/juju/internal/storage/provider"
@@ -230,7 +231,7 @@ func (s *storagePoolServiceSuite) TestListStoragePoolsInvalidFilterProvider(c *g
 	defer s.setupMocks(c).Finish()
 
 	_, err := s.service(c).ListStoragePools(context.Background(), domainstorage.NilNames, domainstorage.Providers{"invalid"})
-	c.Assert(err, jc.ErrorIs, errors.NotFound)
+	c.Assert(err, jc.ErrorIs, coreerrors.NotFound)
 	c.Assert(err, gc.ErrorMatches, `storage provider "invalid" not found`)
 }
 

--- a/domain/storage/state/storagepool.go
+++ b/domain/storage/state/storagepool.go
@@ -8,11 +8,11 @@ import (
 	"fmt"
 
 	"github.com/canonical/sqlair"
-	"github.com/juju/errors"
 
 	"github.com/juju/juju/domain"
 	domainstorage "github.com/juju/juju/domain/storage"
 	storageerrors "github.com/juju/juju/domain/storage/errors"
+	"github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/internal/uuid"
 )
 
@@ -28,7 +28,7 @@ type poolAttributes map[string]string
 func (st StoragePoolState) CreateStoragePool(ctx context.Context, pool domainstorage.StoragePoolDetails) error {
 	db, err := st.DB()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	return CreateStoragePools(ctx, db, []domainstorage.StoragePoolDetails{pool})
@@ -39,16 +39,16 @@ func (st StoragePoolState) CreateStoragePool(ctx context.Context, pool domainsto
 func CreateStoragePools(ctx context.Context, db domain.TxnRunner, pools []domainstorage.StoragePoolDetails) error {
 	selectUUIDStmt, err := sqlair.Prepare("SELECT &StoragePool.uuid FROM storage_pool WHERE name = $StoragePool.name", StoragePool{})
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	storagePoolUpserter, err := storagePoolUpserter()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	poolAttributesUpdater, err := poolAttributesUpdater()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	poolsUUIDs := make([]string, len(pools))
@@ -60,25 +60,25 @@ func CreateStoragePools(ctx context.Context, db domain.TxnRunner, pools []domain
 			dbPool := StoragePool{Name: pool.Name}
 			err := tx.Query(ctx, selectUUIDStmt, dbPool).Get(&dbPool)
 			if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-				return errors.Trace(err)
+				return errors.Capture(err)
 			}
 			if err == nil {
-				return fmt.Errorf("storage pool %q %w", pool.Name, storageerrors.PoolAlreadyExists)
+				return errors.Errorf("storage pool %q %w", pool.Name, storageerrors.PoolAlreadyExists)
 			}
 			poolUUID := poolsUUIDs[i]
 
 			if err := storagePoolUpserter(ctx, tx, poolUUID, pool.Name, pool.Provider); err != nil {
-				return errors.Annotatef(err, "creating storage pool %q", pool.Name)
+				return errors.Errorf("creating storage pool %q %w", pool.Name, err)
 			}
 
 			if err := poolAttributesUpdater(ctx, tx, poolUUID, pool.Attrs); err != nil {
-				return errors.Annotatef(err, "creating storage pool %q attributes", pool.Name)
+				return errors.Errorf("creating storage pool %q attributes %w", pool.Name, err)
 			}
 		}
 		return nil
 	})
 
-	return errors.Trace(err)
+	return errors.Capture(err)
 }
 
 type upsertStoragePoolFunc func(ctx context.Context, tx *sqlair.TX, poolUUID string, name string, providerType string) error
@@ -97,15 +97,15 @@ ON CONFLICT(uuid) DO UPDATE SET name=excluded.name,
 
 	insertStmt, err := sqlair.Prepare(insertQuery, StoragePool{})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	return func(ctx context.Context, tx *sqlair.TX, poolUUID string, name string, providerType string) error {
 		if name == "" {
-			return fmt.Errorf("storage pool name cannot be empty%w", errors.Hide(storageerrors.MissingPoolNameError))
+			return errors.Errorf("storage pool name cannot be empty").Add(storageerrors.MissingPoolNameError)
 		}
 		if providerType == "" {
-			return fmt.Errorf("storage pool type cannot be empty%w", errors.Hide(storageerrors.MissingPoolTypeError))
+			return errors.Errorf("storage pool type cannot be empty").Add(storageerrors.MissingPoolTypeError)
 		}
 
 		dbPool := StoragePool{
@@ -116,7 +116,7 @@ ON CONFLICT(uuid) DO UPDATE SET name=excluded.name,
 
 		err = tx.Query(ctx, insertStmt, dbPool).Run()
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		return nil
 	}, nil
@@ -136,7 +136,7 @@ AND          key NOT IN ($keysToKeep[:])
 
 	deleteStmt, err := sqlair.Prepare(deleteQuery, sqlair.M{}, keysToKeep{})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	insertQuery := `
@@ -151,7 +151,7 @@ ON CONFLICT(storage_pool_uuid, key) DO UPDATE SET key=excluded.key,
 `
 	insertStmt, err := sqlair.Prepare(insertQuery, poolAttribute{})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	return func(ctx context.Context, tx *sqlair.TX, storagePoolUUID string, attr domainstorage.Attrs) error {
@@ -160,7 +160,7 @@ ON CONFLICT(storage_pool_uuid, key) DO UPDATE SET key=excluded.key,
 			keys = append(keys, k)
 		}
 		if err := tx.Query(ctx, deleteStmt, sqlair.M{"uuid": storagePoolUUID}, keys).Run(); err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		for key, value := range attr {
 			if err := tx.Query(ctx, insertStmt, poolAttribute{
@@ -168,7 +168,7 @@ ON CONFLICT(storage_pool_uuid, key) DO UPDATE SET key=excluded.key,
 				Key:   key,
 				Value: value,
 			}).Run(); err != nil {
-				return errors.Trace(err)
+				return errors.Capture(err)
 			}
 		}
 		return nil
@@ -180,7 +180,7 @@ ON CONFLICT(storage_pool_uuid, key) DO UPDATE SET key=excluded.key,
 func (st StoragePoolState) DeleteStoragePool(ctx context.Context, name string) error {
 	db, err := st.DB()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	poolAttributeDeleteQ := `
@@ -195,33 +195,33 @@ WHERE  storage_pool.uuid = (select uuid FROM storage_pool WHERE name = $M.name)
 
 	poolAttributeDeleteStmt, err := st.Prepare(poolAttributeDeleteQ, sqlair.M{})
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	poolDeleteStmt, err := st.Prepare(poolDeleteQ, sqlair.M{})
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		nameMap := sqlair.M{"name": name}
 		if err := tx.Query(ctx, poolAttributeDeleteStmt, nameMap).Run(); err != nil {
-			return errors.Annotate(err, "deleting storage pool attributes")
+			return errors.Errorf("deleting storage pool attributes %w", err)
 		}
 		var outcome = sqlair.Outcome{}
 		err = tx.Query(ctx, poolDeleteStmt, nameMap).Get(&outcome)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		rowsAffected, err := outcome.Result().RowsAffected()
 		if err != nil {
-			return errors.Annotate(err, "deleting storage pool")
+			return errors.Errorf("deleting storage pool %w", err)
 		}
 		if rowsAffected == 0 {
-			return fmt.Errorf("storage pool %q not found%w", name, errors.Hide(storageerrors.PoolNotFoundError))
+			return errors.Errorf("storage pool %q not found", name).Add(storageerrors.PoolNotFoundError)
 		}
-		return errors.Annotate(err, "deleting storage pool")
+		return errors.Errorf("deleting storage pool %w", err)
 	})
-	return errors.Trace(err)
+	return errors.Capture(err)
 }
 
 // ReplaceStoragePool replaces an existing storage pool, returning an error
@@ -229,44 +229,44 @@ WHERE  storage_pool.uuid = (select uuid FROM storage_pool WHERE name = $M.name)
 func (st StoragePoolState) ReplaceStoragePool(ctx context.Context, pool domainstorage.StoragePoolDetails) error {
 	db, err := st.DB()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	selectUUIDStmt, err := st.Prepare("SELECT &StoragePool.uuid FROM storage_pool WHERE name = $StoragePool.name", StoragePool{})
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	storagePoolUpserter, err := storagePoolUpserter()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	poolAttributesUpdater, err := poolAttributesUpdater()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		dbPool := StoragePool{Name: pool.Name}
 		err := tx.Query(ctx, selectUUIDStmt, dbPool).Get(&dbPool)
 		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		if err != nil {
-			return fmt.Errorf("storage pool %q not found%w", pool.Name, errors.Hide(storageerrors.PoolNotFoundError))
+			return errors.Errorf("storage pool %q not found", pool.Name).Add(storageerrors.PoolNotFoundError)
 		}
 		poolUUID := dbPool.ID
 		if err := storagePoolUpserter(ctx, tx, poolUUID, pool.Name, pool.Provider); err != nil {
-			return errors.Annotate(err, "updating storage pool")
+			return errors.Errorf("updating storage pool %w", err)
 		}
 
 		if err := poolAttributesUpdater(ctx, tx, poolUUID, pool.Attrs); err != nil {
-			return errors.Annotatef(err, "updating storage pool %s attributes", poolUUID)
+			return errors.Errorf("updating storage pool %s attributes %w", poolUUID, err)
 		}
 		return nil
 	})
 
-	return errors.Trace(err)
+	return errors.Capture(err)
 }
 
 type loadStoragePoolsFunc func(ctx context.Context, tx *sqlair.TX) ([]domainstorage.StoragePoolDetails, error)
@@ -294,7 +294,7 @@ FROM   storage_pool sp
 
 	queryStmt, err := sqlair.Prepare(query, types...)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	return func(ctx context.Context, tx *sqlair.TX) ([]domainstorage.StoragePoolDetails, error) {
@@ -304,7 +304,7 @@ FROM   storage_pool sp
 		)
 		err = tx.Query(ctx, queryStmt, queryArgs...).GetAll(&dbRows, &keyValues)
 		if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-			return nil, errors.Annotate(err, "loading storage pool")
+			return nil, errors.Errorf("loading storage pool %w", err)
 		}
 		return dbRows.toStoragePools(keyValues)
 	}, nil
@@ -314,21 +314,21 @@ FROM   storage_pool sp
 func (st StoragePoolState) ListStoragePools(ctx context.Context, names domainstorage.Names, providers domainstorage.Providers) ([]domainstorage.StoragePoolDetails, error) {
 	db, err := st.DB()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	storagePoolsLoader, err := storagePoolsLoader(names, providers)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	var result []domainstorage.StoragePoolDetails
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		var err error
 		result, err = storagePoolsLoader(ctx, tx)
-		return errors.Trace(err)
+		return errors.Capture(err)
 	})
-	return result, errors.Trace(err)
+	return result, errors.Capture(err)
 }
 
 func buildStoragePoolsFilter(wantNames domainstorage.Names, wantProviders domainstorage.Providers) (string, []any) {
@@ -355,7 +355,7 @@ func buildStoragePoolsFilter(wantNames domainstorage.Names, wantProviders domain
 func (st StoragePoolState) GetStoragePoolByName(ctx context.Context, name string) (domainstorage.StoragePoolDetails, error) {
 	db, err := st.DB()
 	if err != nil {
-		return domainstorage.StoragePoolDetails{}, errors.Trace(err)
+		return domainstorage.StoragePoolDetails{}, errors.Capture(err)
 	}
 	return GetStoragePoolByName(ctx, db, name)
 }
@@ -366,23 +366,23 @@ func (st StoragePoolState) GetStoragePoolByName(ctx context.Context, name string
 func GetStoragePoolByName(ctx context.Context, db domain.TxnRunner, name string) (domainstorage.StoragePoolDetails, error) {
 	storagePoolsLoader, err := storagePoolsLoader(domainstorage.Names{name}, nil)
 	if err != nil {
-		return domainstorage.StoragePoolDetails{}, errors.Trace(err)
+		return domainstorage.StoragePoolDetails{}, errors.Capture(err)
 	}
 
 	var storagePools []domainstorage.StoragePoolDetails
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		var err error
 		storagePools, err = storagePoolsLoader(ctx, tx)
-		return errors.Trace(err)
+		return errors.Capture(err)
 	})
 	if err != nil {
-		return domainstorage.StoragePoolDetails{}, errors.Trace(err)
+		return domainstorage.StoragePoolDetails{}, errors.Capture(err)
 	}
 	if len(storagePools) == 0 {
-		return domainstorage.StoragePoolDetails{}, fmt.Errorf("storage pool %q %w", name, storageerrors.PoolNotFoundError)
+		return domainstorage.StoragePoolDetails{}, errors.Errorf("storage pool %q %w", name, storageerrors.PoolNotFoundError)
 	}
 	if len(storagePools) > 1 {
 		return domainstorage.StoragePoolDetails{}, errors.Errorf("expected 1 storage pool, got %d", len(storagePools))
 	}
-	return storagePools[0], errors.Trace(err)
+	return storagePools[0], errors.Capture(err)
 }

--- a/domain/storage/state/storagepool_test.go
+++ b/domain/storage/state/storagepool_test.go
@@ -6,7 +6,6 @@ package state
 import (
 	"context"
 
-	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -15,6 +14,7 @@ import (
 	"github.com/juju/juju/domain/schema/testing"
 	domainstorage "github.com/juju/juju/domain/storage"
 	storageerrors "github.com/juju/juju/domain/storage/errors"
+	"github.com/juju/juju/internal/errors"
 )
 
 type storagePoolSuite struct {

--- a/domain/storage/state/storagepooltypes.go
+++ b/domain/storage/state/storagepooltypes.go
@@ -4,9 +4,8 @@
 package state
 
 import (
-	"github.com/juju/errors"
-
 	"github.com/juju/juju/domain/storage"
+	"github.com/juju/juju/internal/errors"
 )
 
 // These structs represent the persistent storage pool entity schema in the database.

--- a/domain/storage/types.go
+++ b/domain/storage/types.go
@@ -4,8 +4,7 @@
 package storage
 
 import (
-	"github.com/juju/errors"
-
+	"github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/internal/storage"
 	"github.com/juju/juju/internal/storage/provider"
 )
@@ -43,7 +42,7 @@ var (
 func BuiltInStoragePools() ([]StoragePoolDetails, error) {
 	providerTypes, err := provider.CommonStorageProviders().StorageProviderTypes()
 	if err != nil {
-		return nil, errors.Annotate(err, "getting built in storage provider types")
+		return nil, errors.Errorf("getting built in storage provider types %w", err)
 	}
 	result := make([]StoragePoolDetails, len(providerTypes))
 	for i, pType := range providerTypes {
@@ -61,12 +60,12 @@ func DefaultStoragePools(registry storage.ProviderRegistry) ([]*storage.Config, 
 	var result []*storage.Config
 	providerTypes, err := registry.StorageProviderTypes()
 	if err != nil {
-		return nil, errors.Annotate(err, "getting storage provider types")
+		return nil, errors.Errorf("getting storage provider types %w", err)
 	}
 	for _, providerType := range providerTypes {
 		p, err := registry.StorageProvider(providerType)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, errors.Capture(err)
 		}
 		result = append(result, p.DefaultPools()...)
 	}

--- a/domain/storage/validation.go
+++ b/domain/storage/validation.go
@@ -8,11 +8,12 @@ import (
 
 	"github.com/dustin/go-humanize"
 	"github.com/juju/collections/transform"
-	"github.com/juju/errors"
 
+	coreerrors "github.com/juju/juju/core/errors"
 	coremodel "github.com/juju/juju/core/model"
 	storageerrors "github.com/juju/juju/domain/storage/errors"
 	"github.com/juju/juju/internal/charm"
+	"github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/internal/storage"
 )
 
@@ -70,7 +71,7 @@ func (v storageDirectivesValidator) ValidateStorageDirectivesAgainstCharm(
 				count = arg.Count
 			}
 			if charmStorage.CountMin > 0 || count > 0 {
-				return errors.NotSupportedf("block storage on a container model")
+				return errors.Errorf("block storage on a container model %w", coreerrors.NotSupported)
 			}
 		}
 	}
@@ -84,19 +85,19 @@ func (v storageDirectivesValidator) ValidateStorageDirectivesAgainstCharm(
 			// TODO(axw) implement shared storage support.
 			return errors.Errorf(
 				"charm %q store %q: shared storage support not implemented",
-				meta.Name, name,
-			)
+				meta.Name, name)
+
 		}
 		if err := v.validateCharmStorageCount(charmStorage, directive.Count); err != nil {
-			return errors.Annotatef(err, "charm %q store %q", meta.Name, name)
+			return errors.Errorf("charm %q store %q %w", meta.Name, name, err)
 		}
 		if charmStorage.MinimumSize > 0 && directive.Size < charmStorage.MinimumSize {
 			return errors.Errorf(
 				"charm %q store %q: minimum storage size is %s, %s specified",
 				meta.Name, name,
 				humanize.Bytes(charmStorage.MinimumSize*humanize.MByte),
-				humanize.Bytes(directive.Size*humanize.MByte),
-			)
+				humanize.Bytes(directive.Size*humanize.MByte))
+
 		}
 		kind := storageKind(charmStorage.Type)
 		if err := v.validateStoragePool(ctx, directive.Pool, kind); err != nil {
@@ -113,14 +114,14 @@ func (v storageDirectivesValidator) validateCharmStorageCount(charmStorage charm
 	if count < uint64(charmStorage.CountMin) {
 		return errors.Errorf(
 			"%d instances required, %d specified",
-			charmStorage.CountMin, count,
-		)
+			charmStorage.CountMin, count)
+
 	}
 	if charmStorage.CountMax >= 0 && count > uint64(charmStorage.CountMax) {
 		return errors.Errorf(
 			"at most %d instances supported, %d specified",
-			charmStorage.CountMax, count,
-		)
+			charmStorage.CountMax, count)
+
 	}
 	return nil
 }
@@ -135,7 +136,7 @@ func (v storageDirectivesValidator) validateStoragePool(
 	}
 	providerType, aProvider, poolConfig, err := v.poolStorageProvider(ctx, poolName)
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	// Ensure the storage provider supports the specified kind.
@@ -152,7 +153,7 @@ func (v storageDirectivesValidator) validateStoragePool(
 
 	if v.modelType == coremodel.CAAS {
 		if err := aProvider.ValidateForK8s(poolConfig); err != nil {
-			return errors.Annotatef(err, "invalid storage config")
+			return errors.Errorf("invalid storage config %w", err)
 		}
 	}
 	return nil
@@ -171,16 +172,16 @@ func (v storageDirectivesValidator) poolStorageProvider(
 		if err1 != nil {
 			// The name can't be resolved as a storage provider type,
 			// so return the original "pool not found" error.
-			return "", nil, nil, errors.Trace(err)
+			return "", nil, nil, errors.Capture(err)
 		}
 		return providerType, aProvider, nil, nil
 	} else if err != nil {
-		return "", nil, nil, errors.Trace(err)
+		return "", nil, nil, errors.Capture(err)
 	}
 	providerType := storage.ProviderType(pool.Provider)
 	aProvider, err := v.registry.StorageProvider(providerType)
 	if err != nil {
-		return "", nil, nil, errors.Trace(err)
+		return "", nil, nil, errors.Capture(err)
 	}
 	attrs := transform.Map(pool.Attrs, func(k, v string) (string, any) { return k, v })
 	return providerType, aProvider, attrs, nil

--- a/domain/storage/validation_test.go
+++ b/domain/storage/validation_test.go
@@ -5,9 +5,7 @@ package storage_test
 
 import (
 	"context"
-	"fmt"
 
-	"github.com/juju/errors"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -16,6 +14,7 @@ import (
 	domainstorage "github.com/juju/juju/domain/storage"
 	storageerrors "github.com/juju/juju/domain/storage/errors"
 	"github.com/juju/juju/internal/charm"
+	"github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/internal/storage"
 	"github.com/juju/juju/internal/storage/provider"
 )
@@ -70,13 +69,13 @@ func (mockStoragePoolGetter) GetStoragePoolByName(_ context.Context, name string
 	case "tmp":
 		return domainstorage.StoragePoolDetails{Name: name, Provider: "tmpfs", Attrs: map[string]string{"storage-medium": "foo"}}, nil
 	}
-	return domainstorage.StoragePoolDetails{}, fmt.Errorf("storage pool %q not found%w", name, errors.Hide(storageerrors.PoolNotFoundError))
+	return domainstorage.StoragePoolDetails{}, errors.Errorf("storage pool %q not found", name).Add(storageerrors.PoolNotFoundError)
 }
 
 func (s *validationSuite) validateStorageDirectives(storage map[string]storage.Directive) error {
 	validator, err := domainstorage.NewStorageDirectivesValidator(s.modelType, provider.CommonStorageProviders(), mockStoragePoolGetter{})
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	return validator.ValidateStorageDirectivesAgainstCharm(
 		context.Background(),

--- a/domain/stub/service.go
+++ b/domain/stub/service.go
@@ -7,7 +7,6 @@ import (
 	"context"
 
 	"github.com/canonical/sqlair"
-	jujuerrors "github.com/juju/errors"
 
 	"github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/unit"
@@ -47,7 +46,7 @@ func NewStubService(
 func (s *StubService) AssignUnitsToMachines(ctx context.Context, groupedUnitsByMachine map[string][]unit.Name) error {
 	db, err := s.DB()
 	if err != nil {
-		return jujuerrors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	getNetNodeQuery, err := s.Prepare(`

--- a/domain/testing/controllerconfigsuite.go
+++ b/domain/testing/controllerconfigsuite.go
@@ -8,12 +8,12 @@ import (
 	"database/sql"
 
 	"github.com/canonical/sqlair"
-	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/controller"
 	coredatabase "github.com/juju/juju/core/database"
+	coreerrors "github.com/juju/juju/core/errors"
 	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/domain/controllerconfig/bootstrap"
 )
@@ -36,9 +36,9 @@ func SeedControllerConfig(
 type noopTxnRunner struct{}
 
 func (noopTxnRunner) Txn(context.Context, func(context.Context, *sqlair.TX) error) error {
-	return errors.NotImplemented
+	return coreerrors.NotImplemented
 }
 
 func (noopTxnRunner) StdTxn(context.Context, func(context.Context, *sql.Tx) error) error {
-	return errors.NotImplemented
+	return coreerrors.NotImplemented
 }

--- a/domain/testing/watcher.go
+++ b/domain/testing/watcher.go
@@ -5,12 +5,12 @@ package testing
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/juju/juju/core/changestream"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/core/watcher/eventsource"
 	"github.com/juju/juju/core/watcher/watchertest"
+	"github.com/juju/juju/internal/errors"
 )
 
 // NamespaceWatcherFactory implements a simple NamespaceWatcher creation process
@@ -48,7 +48,7 @@ func (f *NamespaceWatcherFactory) FeedChange(
 
 	select {
 	case <-ctx.Done():
-		return fmt.Errorf("unable to feed watcher change for namespace %q: %w", namespace, ctx.Err())
+		return errors.Errorf("unable to feed watcher change for namespace %q: %w", namespace, ctx.Err())
 	case ch <- change:
 	}
 	return nil
@@ -68,7 +68,7 @@ func (f *NamespaceWatcherFactory) NewNamespaceWatcher(
 	if f.InitialStateFunc != nil {
 		state, err := f.InitialStateFunc()
 		if err != nil {
-			return nil, fmt.Errorf("fetching initial state for watcher: %w", err)
+			return nil, errors.Errorf("fetching initial state for watcher: %w", err)
 		}
 		ch <- state
 	}

--- a/domain/unitstate/errors/errors.go
+++ b/domain/unitstate/errors/errors.go
@@ -3,7 +3,7 @@
 
 package errors
 
-import "github.com/juju/errors"
+import "github.com/juju/juju/internal/errors"
 
 const (
 	// UnitNotFound describes an error that occurs when

--- a/domain/upgrade/errors/errors.go
+++ b/domain/upgrade/errors/errors.go
@@ -3,9 +3,7 @@
 
 package errors
 
-import (
-	"github.com/juju/errors"
-)
+import "github.com/juju/juju/internal/errors"
 
 const (
 	// AlreadyStarted states that the upgrade could not be started.

--- a/domain/upgrade/service/service.go
+++ b/domain/upgrade/service/service.go
@@ -6,16 +6,17 @@ package service
 import (
 	"context"
 
-	"github.com/juju/errors"
 	"github.com/juju/version/v2"
 
 	"github.com/juju/juju/core/changestream"
 	coredatabase "github.com/juju/juju/core/database"
+	coreerrors "github.com/juju/juju/core/errors"
 	coreupgrade "github.com/juju/juju/core/upgrade"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/core/watcher/eventsource"
 	"github.com/juju/juju/domain/upgrade"
 	upgradeerrors "github.com/juju/juju/domain/upgrade/errors"
+	"github.com/juju/juju/internal/errors"
 )
 
 // State describes retrieval and persistence methods for upgrade info.
@@ -52,7 +53,7 @@ func NewService(st State, wf WatcherFactory) *Service {
 // If an upgrade is already running/pending, return an AlreadyExists err
 func (s *Service) CreateUpgrade(ctx context.Context, previousVersion, targetVersion version.Number) (upgrade.UUID, error) {
 	if previousVersion.Compare(targetVersion) >= 0 {
-		return "", errors.NotValidf("target version %q must be greater than current version %q", targetVersion, previousVersion)
+		return "", errors.Errorf("target version %q must be greater than current version %q %w", targetVersion, previousVersion, coreerrors.NotValid)
 	}
 	return s.st.CreateUpgrade(ctx, previousVersion, targetVersion)
 }
@@ -62,7 +63,7 @@ func (s *Service) CreateUpgrade(ctx context.Context, previousVersion, targetVers
 // before an upgrade can start
 func (s *Service) SetControllerReady(ctx context.Context, upgradeUUID upgrade.UUID, controllerID string) error {
 	if err := upgradeUUID.Validate(); err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	err := s.st.SetControllerReady(ctx, upgradeUUID, controllerID)
 	return err
@@ -71,7 +72,7 @@ func (s *Service) SetControllerReady(ctx context.Context, upgradeUUID upgrade.UU
 // StartUpgrade starts the current upgrade if it exists
 func (s *Service) StartUpgrade(ctx context.Context, upgradeUUID upgrade.UUID) error {
 	if err := upgradeUUID.Validate(); err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	return s.st.StartUpgrade(ctx, upgradeUUID)
 }
@@ -81,7 +82,7 @@ func (s *Service) StartUpgrade(ctx context.Context, upgradeUUID upgrade.UUID) er
 // last provisioned controller, the upgrade will be archived.
 func (s *Service) SetControllerDone(ctx context.Context, upgradeUUID upgrade.UUID, controllerID string) error {
 	if err := upgradeUUID.Validate(); err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	return s.st.SetControllerDone(ctx, upgradeUUID, controllerID)
 }
@@ -89,7 +90,7 @@ func (s *Service) SetControllerDone(ctx context.Context, upgradeUUID upgrade.UUI
 // SetDBUpgradeCompleted marks the upgrade as completed in the database
 func (s *Service) SetDBUpgradeCompleted(ctx context.Context, upgradeUUID upgrade.UUID) error {
 	if err := upgradeUUID.Validate(); err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	return s.st.SetDBUpgradeCompleted(ctx, upgradeUUID)
 }
@@ -98,7 +99,7 @@ func (s *Service) SetDBUpgradeCompleted(ctx context.Context, upgradeUUID upgrade
 // Manual intervention will be required if this has been invoked.
 func (s *Service) SetDBUpgradeFailed(ctx context.Context, upgradeUUID upgrade.UUID) error {
 	if err := upgradeUUID.Validate(); err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	return s.st.SetDBUpgradeFailed(ctx, upgradeUUID)
 }
@@ -112,7 +113,7 @@ func (s *Service) ActiveUpgrade(ctx context.Context) (upgrade.UUID, error) {
 // UpgradeInfo returns the upgrade info for the supplied upgradeUUID
 func (s *Service) UpgradeInfo(ctx context.Context, upgradeUUID upgrade.UUID) (coreupgrade.Info, error) {
 	if err := upgradeUUID.Validate(); err != nil {
-		return coreupgrade.Info{}, errors.Trace(err)
+		return coreupgrade.Info{}, errors.Capture(err)
 	}
 	return s.st.UpgradeInfo(ctx, upgradeUUID)
 }
@@ -129,7 +130,7 @@ func (s *Service) IsUpgrading(ctx context.Context) (bool, error) {
 		return false, nil
 	}
 
-	return false, errors.Trace(err)
+	return false, errors.Capture(err)
 }
 
 // WatchableService provides the API for working with upgrade info
@@ -152,14 +153,14 @@ func NewWatchableService(st State, wf WatcherFactory) *WatchableService {
 // nodes have been registered, meaning the upgrade is ready to start.
 func (s *WatchableService) WatchForUpgradeReady(ctx context.Context, upgradeUUID upgrade.UUID) (watcher.NotifyWatcher, error) {
 	if err := upgradeUUID.Validate(); err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	mask := changestream.Create | changestream.Update
 	mapper := func(ctx context.Context, db coredatabase.TxnRunner, changes []changestream.ChangeEvent) ([]changestream.ChangeEvent, error) {
 		ready, err := s.st.AllProvisionedControllersReady(ctx, upgradeUUID)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, errors.Capture(err)
 		}
 		// Only dispatch if all controllers are ready.
 		if ready {
@@ -174,14 +175,14 @@ func (s *WatchableService) WatchForUpgradeReady(ctx context.Context, upgradeUUID
 // has reached the given state.
 func (s *WatchableService) WatchForUpgradeState(ctx context.Context, upgradeUUID upgrade.UUID, state coreupgrade.State) (watcher.NotifyWatcher, error) {
 	if err := upgradeUUID.Validate(); err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Capture(err)
 	}
 
 	mask := changestream.Create | changestream.Update
 	mapper := func(ctx context.Context, db coredatabase.TxnRunner, changes []changestream.ChangeEvent) ([]changestream.ChangeEvent, error) {
 		info, err := s.st.UpgradeInfo(ctx, upgradeUUID)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, errors.Capture(err)
 		}
 		if info.State == state {
 			return changes, nil

--- a/domain/upgrade/service/service_test.go
+++ b/domain/upgrade/service/service_test.go
@@ -6,15 +6,16 @@ package service
 import (
 	"context"
 
-	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/version/v2"
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
+	coreerrors "github.com/juju/juju/core/errors"
 	coreupgrade "github.com/juju/juju/core/upgrade"
 	"github.com/juju/juju/core/watcher/watchertest"
 	upgradeerrors "github.com/juju/juju/domain/upgrade/errors"
+	"github.com/juju/juju/internal/errors"
 )
 
 type serviceSuite struct {
@@ -59,10 +60,10 @@ func (s *serviceSuite) TestCreateUpgradeAlreadyExists(c *gc.C) {
 
 func (s *serviceSuite) TestCreateUpgradeInvalidVersions(c *gc.C) {
 	_, err := s.service.CreateUpgrade(context.Background(), version.MustParse("3.0.1"), version.MustParse("3.0.0"))
-	c.Assert(err, jc.ErrorIs, errors.NotValid)
+	c.Assert(err, jc.ErrorIs, coreerrors.NotValid)
 
 	_, err = s.service.CreateUpgrade(context.Background(), version.MustParse("3.0.1"), version.MustParse("3.0.1"))
-	c.Assert(err, jc.ErrorIs, errors.NotValid)
+	c.Assert(err, jc.ErrorIs, coreerrors.NotValid)
 }
 
 func (s *serviceSuite) TestSetControllerReady(c *gc.C) {
@@ -115,7 +116,7 @@ func (s *serviceSuite) TestActiveUpgrade(c *gc.C) {
 func (s *serviceSuite) TestActiveUpgradeNoUpgrade(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().ActiveUpgrade(gomock.Any()).Return(s.upgradeUUID, errors.Trace(upgradeerrors.NotFound))
+	s.state.EXPECT().ActiveUpgrade(gomock.Any()).Return(s.upgradeUUID, errors.Capture(upgradeerrors.NotFound))
 
 	_, err := s.service.ActiveUpgrade(context.Background())
 	c.Assert(err, jc.ErrorIs, upgradeerrors.NotFound)
@@ -185,7 +186,7 @@ func (s *serviceSuite) TestIsUpgrade(c *gc.C) {
 func (s *serviceSuite) TestIsUpgradeNoUpgrade(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().ActiveUpgrade(gomock.Any()).Return(s.upgradeUUID, errors.Trace(upgradeerrors.NotFound))
+	s.state.EXPECT().ActiveUpgrade(gomock.Any()).Return(s.upgradeUUID, errors.Capture(upgradeerrors.NotFound))
 
 	upgrading, err := s.service.IsUpgrading(context.Background())
 	c.Assert(err, jc.ErrorIsNil)

--- a/domain/upgrade/state/state.go
+++ b/domain/upgrade/state/state.go
@@ -7,7 +7,6 @@ import (
 	"context"
 
 	"github.com/canonical/sqlair"
-	"github.com/juju/errors"
 	"github.com/juju/version/v2"
 
 	coredatabase "github.com/juju/juju/core/database"
@@ -16,6 +15,7 @@ import (
 	domainupgrade "github.com/juju/juju/domain/upgrade"
 	upgradeerrors "github.com/juju/juju/domain/upgrade/errors"
 	"github.com/juju/juju/internal/database"
+	"github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/internal/uuid"
 )
 
@@ -37,12 +37,12 @@ func NewState(factory coredatabase.TxnRunnerFactory) *State {
 func (st *State) CreateUpgrade(ctx context.Context, previousVersion, targetVersion version.Number) (domainupgrade.UUID, error) {
 	db, err := st.DB()
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", errors.Capture(err)
 	}
 
 	upgradeUUID, err := uuid.NewUUID()
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", errors.Capture(err)
 	}
 	info := Info{
 		UUID:            upgradeUUID.String(),
@@ -55,7 +55,7 @@ func (st *State) CreateUpgrade(ctx context.Context, previousVersion, targetVersi
 INSERT INTO upgrade_info (*) 
 VALUES ($Info.*)`, info)
 	if err != nil {
-		return "", errors.Annotatef(err, "preparing insert upgrade info statement")
+		return "", errors.Errorf("preparing insert upgrade info statement %w", err)
 	}
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
@@ -63,12 +63,12 @@ VALUES ($Info.*)`, info)
 		if database.IsErrConstraintUnique(err) {
 			return upgradeerrors.AlreadyExists
 		} else if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		return nil
 	})
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", errors.Capture(err)
 	}
 
 	return domainupgrade.UUID(upgradeUUID.String()), nil
@@ -82,12 +82,12 @@ VALUES ($Info.*)`, info)
 func (st *State) SetControllerReady(ctx context.Context, upgradeUUID domainupgrade.UUID, controllerID string) error {
 	db, err := st.DB()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	uuid, err := uuid.NewUUID()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	controllerNodeInfo := ControllerNodeInfo{
@@ -103,7 +103,7 @@ WHERE   upgrade_info_uuid = $ControllerNodeInfo.upgrade_info_uuid
 AND     controller_node_id = $ControllerNodeInfo.controller_node_id;
 `, controllerNodeInfo)
 	if err != nil {
-		return errors.Annotatef(err, "preparing check exists node statement")
+		return errors.Errorf("preparing check exists node statement %w", err)
 	}
 
 	insertUpgradeNodeStmt, err := st.Prepare(`
@@ -111,7 +111,7 @@ INSERT INTO upgrade_info_controller_node (uuid, controller_node_id, upgrade_info
 VALUES ($ControllerNodeInfo.*);
 `, controllerNodeInfo)
 	if err != nil {
-		return errors.Annotatef(err, "preparing insert upgrade node statement")
+		return errors.Errorf("preparing insert upgrade node statement %w", err)
 	}
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err := tx.Query(ctx, checkExistsNodeStmt, controllerNodeInfo).Get(&ControllerNodeInfo{})
@@ -119,18 +119,18 @@ VALUES ($ControllerNodeInfo.*);
 			// The controller node already exists, so return.
 			return nil
 		} else if !errors.Is(err, sqlair.ErrNoRows) {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		err = tx.Query(ctx, insertUpgradeNodeStmt, controllerNodeInfo).Run()
 		if database.IsErrConstraintForeignKey(err) {
-			return errors.Annotatef(upgradeerrors.NotFound, "upgrade %q", upgradeUUID)
+			return errors.Errorf("upgrade %q %w", upgradeUUID, upgradeerrors.NotFound)
 		} else if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		return nil
 	})
-	return errors.Trace(err)
+	return errors.Capture(err)
 }
 
 // AllProvisionedControllersReady returns true if and only if all controllers
@@ -139,7 +139,7 @@ VALUES ($ControllerNodeInfo.*);
 func (st *State) AllProvisionedControllersReady(ctx context.Context, upgradeUUID domainupgrade.UUID) (bool, error) {
 	db, err := st.DB()
 	if err != nil {
-		return false, errors.Trace(err)
+		return false, errors.Capture(err)
 	}
 	var count Count
 	controllerNodeInfo := ControllerNodeInfo{
@@ -155,20 +155,20 @@ WHERE  node.dqlite_node_id IS NOT NULL
 AND    upgrade_node.controller_node_id IS NULL;
 `, count, controllerNodeInfo)
 	if err != nil {
-		return false, errors.Annotate(err, "preparing select count provisioned controllers statement")
+		return false, errors.Errorf("preparing select count provisioned controllers statement %w", err)
 	}
 
 	var allReady bool
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err := tx.Query(ctx, stmt, controllerNodeInfo).Get(&count)
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		allReady = count.Num == 0
 		return nil
 	})
 	if err != nil {
-		return false, errors.Trace(err)
+		return false, errors.Capture(err)
 	}
 	return allReady, nil
 }
@@ -182,7 +182,7 @@ AND    upgrade_node.controller_node_id IS NULL;
 func (st *State) StartUpgrade(ctx context.Context, upgradeUUID domainupgrade.UUID) error {
 	db, err := st.DB()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	info := Info{
@@ -195,70 +195,70 @@ FROM   upgrade_info
 WHERE  uuid = $Info.uuid
 `, info)
 	if err != nil {
-		return errors.Annotate(err, "preparing select started upgrade statement")
+		return errors.Errorf("preparing select started upgrade statement %w", err)
 	}
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err := tx.Query(ctx, getUpgradeStartedStmt, info).Get(&info)
 		if errors.Is(err, sqlair.ErrNoRows) {
 			if database.IsErrNotFound(err) {
-				return errors.Annotatef(upgradeerrors.NotFound, "upgrade %q", upgradeUUID)
+				return errors.Errorf("upgrade %q %w", upgradeUUID, upgradeerrors.NotFound)
 			}
 		}
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		// If the upgrade is already started, return an error.
 		if err := upgrade.State(info.StateIDType).TransitionTo(upgrade.Started); err != nil {
 			if errors.Is(err, upgrade.ErrAlreadyAtState) {
-				return errors.Annotatef(upgradeerrors.AlreadyStarted, "upgrade %q already started", upgradeUUID)
+				return errors.Errorf("upgrade %q already started %w", upgradeUUID, upgradeerrors.AlreadyStarted)
 			}
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		// Start the upgrade by setting the state to "Started".
 		err = st.updateState(ctx, tx, info.UUID, upgrade.Created, upgrade.Started)
 		if err != nil {
-			return errors.Annotatef(err, "expected to set upgrade state to started")
+			return errors.Errorf("expected to set upgrade state to started %w", err)
 		}
 		return nil
 	})
-	return errors.Trace(err)
+	return errors.Capture(err)
 }
 
 // SetDBUpgradeCompleted marks the database upgrade as completed.
 func (st *State) SetDBUpgradeCompleted(ctx context.Context, upgradeUUID domainupgrade.UUID) error {
 	db, err := st.DB()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err := st.updateState(ctx, tx, upgradeUUID.String(), upgrade.Started, upgrade.DBCompleted)
 		if err != nil {
-			return errors.Annotatef(err, "expected to set upgrade state to db complete")
+			return errors.Errorf("expected to set upgrade state to db complete %w", err)
 		}
 		return nil
 	})
-	return errors.Trace(err)
+	return errors.Capture(err)
 }
 
 // SetDBUpgradeFailed marks the database upgrade as failed.
 func (st *State) SetDBUpgradeFailed(ctx context.Context, upgradeUUID domainupgrade.UUID) error {
 	db, err := st.DB()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err := st.updateState(ctx, tx, upgradeUUID.String(), upgrade.Started, upgrade.Error)
 		if err != nil {
-			return errors.Annotatef(err, "expected to set upgrade state to error")
+			return errors.Errorf("expected to set upgrade state to error %w", err)
 		}
 		return nil
 	})
-	return errors.Trace(err)
+	return errors.Capture(err)
 }
 
 // SetControllerDone marks the supplied controllerID as having completed its
@@ -270,7 +270,7 @@ func (st *State) SetDBUpgradeFailed(ctx context.Context, upgradeUUID domainupgra
 func (st *State) SetControllerDone(ctx context.Context, upgradeUUID domainupgrade.UUID, controllerID string) error {
 	db, err := st.DB()
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	controllerNodeInfo := ControllerNodeInfo{
@@ -288,7 +288,7 @@ WHERE  upgrade_info_uuid = $ControllerNodeInfo.upgrade_info_uuid
 AND    controller_node_id = $ControllerNodeInfo.controller_node_id;
 `, controllerNodeInfo)
 	if err != nil {
-		return errors.Annotate(err, "preparing select done query")
+		return errors.Errorf("preparing select done query %w", err)
 	}
 
 	setNodeToDoneStmt, err := st.Prepare(`
@@ -299,7 +299,7 @@ AND     controller_node_id = $ControllerNodeInfo.controller_node_id
 AND     node_upgrade_completed_at IS NULL;
 `, controllerNodeInfo)
 	if err != nil {
-		return errors.Annotatef(err, "preparing update node query")
+		return errors.Errorf("preparing update node query %w", err)
 	}
 
 	m := sqlair.M{
@@ -322,7 +322,7 @@ AND (
 );
 `, info, m)
 	if err != nil {
-		return errors.Annotatef(err, "preparing complete upgrade query")
+		return errors.Errorf("preparing complete upgrade query %w", err)
 	}
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
@@ -332,18 +332,18 @@ AND (
 			if errors.Is(err, sqlair.ErrNoRows) {
 				return errors.Errorf("controller node %q not ready", controllerID)
 			}
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
 		err = tx.Query(ctx, setNodeToDoneStmt, controllerNodeInfo).Run()
 		if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 
-		return errors.Trace(tx.Query(ctx, completeUpgradeStmt, info, m).Run())
+		return errors.Capture(tx.Query(ctx, completeUpgradeStmt, info, m).Run())
 	})
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	return nil
 }
@@ -354,7 +354,7 @@ AND (
 func (st *State) ActiveUpgrade(ctx context.Context) (domainupgrade.UUID, error) {
 	db, err := st.DB()
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", errors.Capture(err)
 	}
 
 	info := Info{
@@ -367,19 +367,19 @@ FROM upgrade_info
 WHERE state_type_id < $Info.state_type_id
 `, info)
 	if err != nil {
-		return "", errors.Annotate(err, "preparing select active upgrade statement")
+		return "", errors.Errorf("preparing select active upgrade statement %w", err)
 	}
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err := tx.Query(ctx, stmt, info).Get(&info)
 		if errors.Is(err, sqlair.ErrNoRows) {
-			return errors.Annotatef(upgradeerrors.NotFound, "active upgrade")
+			return errors.Errorf("active upgrade %w", upgradeerrors.NotFound)
 		} else if err != nil {
-			return errors.Trace(err)
+			return errors.Capture(err)
 		}
 		return nil
 	})
-	return domainupgrade.UUID(info.UUID), errors.Trace(err)
+	return domainupgrade.UUID(info.UUID), errors.Capture(err)
 }
 
 // UpgradeInfo returns the upgrade info for the provided upgradeUUID. It returns
@@ -387,7 +387,7 @@ WHERE state_type_id < $Info.state_type_id
 func (st *State) UpgradeInfo(ctx context.Context, upgradeUUID domainupgrade.UUID) (upgrade.Info, error) {
 	db, err := st.DB()
 	if err != nil {
-		return upgrade.Info{}, errors.Trace(err)
+		return upgrade.Info{}, errors.Capture(err)
 	}
 	info := Info{
 		UUID: upgradeUUID.String(),
@@ -402,16 +402,16 @@ WHERE uuid = $Info.uuid
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err = tx.Query(ctx, stmt, info).Get(&info)
 		if errors.Is(err, sqlair.ErrNoRows) {
-			return errors.Annotatef(upgradeerrors.NotFound, "upgrade %q", upgradeUUID)
+			return errors.Errorf("upgrade %q %w", upgradeUUID, upgradeerrors.NotFound)
 		}
 		return err
 	})
 	if err != nil {
-		return upgrade.Info{}, errors.Trace(err)
+		return upgrade.Info{}, errors.Capture(err)
 	}
 
 	result, err := info.ToUpgradeInfo()
-	return result, errors.Trace(err)
+	return result, errors.Capture(err)
 }
 
 // updateState updates the state of an ongoing upgrade.
@@ -420,7 +420,7 @@ func (st *State) updateState(ctx context.Context, tx *sqlair.TX, uuid string, fr
 		if errors.Is(err, upgrade.ErrAlreadyAtState) {
 			return nil
 		}
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 
 	info := Info{
@@ -436,15 +436,15 @@ SET state_type_id = $M.to
 WHERE uuid = $Info.uuid
 AND state_type_id = $M.from;`, info, m)
 	if err != nil {
-		return errors.Annotatef(err, "preparing update from %q to %q statement", from, to)
+		return errors.Errorf("preparing update from %q to %q statement %w", from, to, err)
 	}
 
 	var outcome sqlair.Outcome
 	if err = tx.Query(ctx, stmt, info, m).Get(&outcome); err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	}
 	if num, err := outcome.Result().RowsAffected(); err != nil {
-		return errors.Trace(err)
+		return errors.Capture(err)
 	} else if num != 1 {
 		return errors.Errorf("setting from %q to %q, but %d rows were affected", from, to, num)
 	}

--- a/domain/upgrade/state/types.go
+++ b/domain/upgrade/state/types.go
@@ -5,9 +5,9 @@ package state
 
 import (
 	"database/sql"
-	"fmt"
 
 	"github.com/juju/juju/core/upgrade"
+	"github.com/juju/juju/internal/errors"
 )
 
 // Info holds the information about database upgrade
@@ -26,7 +26,7 @@ type Info struct {
 func (i Info) ToUpgradeInfo() (upgrade.Info, error) {
 	state := upgrade.State(i.StateIDType)
 	if _, ok := upgrade.States[state]; !ok {
-		return upgrade.Info{}, fmt.Errorf("unknown state id %q", i)
+		return upgrade.Info{}, errors.Errorf("unknown state id %q", i)
 	}
 	result := upgrade.Info{
 		UUID:            i.UUID,

--- a/domain/upgrade/types.go
+++ b/domain/upgrade/types.go
@@ -4,9 +4,9 @@
 package upgrade
 
 import (
-	"github.com/juju/errors"
 	"github.com/juju/utils/v4"
 
+	"github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/internal/uuid"
 )
 
@@ -17,7 +17,7 @@ type UUID string
 func NewUUID() (UUID, error) {
 	uuid, err := uuid.NewUUID()
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", errors.Capture(err)
 	}
 	return UUID(uuid.String()), nil
 }

--- a/domain/watcher.go
+++ b/domain/watcher.go
@@ -6,12 +6,11 @@ package domain
 import (
 	"sync"
 
-	"github.com/juju/errors"
-
 	"github.com/juju/juju/core/changestream"
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/core/watcher/eventsource"
+	"github.com/juju/juju/internal/errors"
 )
 
 // WatchableDBFactory is a function that returns a WatchableDB or an error.
@@ -40,7 +39,7 @@ func (f *WatcherFactory) NewUUIDsWatcher(
 	tableName string, changeMask changestream.ChangeType,
 ) (watcher.StringsWatcher, error) {
 	w, err := f.NewNamespaceWatcher(tableName, changeMask, eventsource.InitialNamespaceChanges("SELECT uuid from "+tableName))
-	return w, errors.Trace(err)
+	return w, errors.Capture(err)
 }
 
 // NewNamespaceWatcher returns a new namespace watcher
@@ -51,7 +50,7 @@ func (f *WatcherFactory) NewNamespaceWatcher(
 ) (watcher.StringsWatcher, error) {
 	base, err := f.newBaseWatcher()
 	if err != nil {
-		return nil, errors.Annotate(err, "creating base watcher")
+		return nil, errors.Errorf("creating base watcher %w", err)
 	}
 
 	return eventsource.NewNamespaceWatcher(base, namespace, changeMask, initialStateQuery), nil
@@ -66,7 +65,7 @@ func (f *WatcherFactory) NewNamespaceMapperWatcher(
 ) (watcher.StringsWatcher, error) {
 	base, err := f.newBaseWatcher()
 	if err != nil {
-		return nil, errors.Annotate(err, "creating base watcher")
+		return nil, errors.Errorf("creating base watcher %w", err)
 	}
 
 	return eventsource.NewNamespaceMapperWatcher(
@@ -82,7 +81,7 @@ func (f *WatcherFactory) NewNamespaceNotifyWatcher(
 ) (watcher.NotifyWatcher, error) {
 	base, err := f.newBaseWatcher()
 	if err != nil {
-		return nil, errors.Annotate(err, "creating base watcher")
+		return nil, errors.Errorf("creating base watcher %w", err)
 	}
 
 	return eventsource.NewNamespaceNotifyWatcher(base, namespace, changeMask), nil
@@ -95,7 +94,7 @@ func (f *WatcherFactory) NewNamespaceNotifyMapperWatcher(
 ) (watcher.NotifyWatcher, error) {
 	base, err := f.newBaseWatcher()
 	if err != nil {
-		return nil, errors.Annotate(err, "creating base watcher")
+		return nil, errors.Errorf("creating base watcher %w", err)
 	}
 
 	return eventsource.NewNamespaceNotifyMapperWatcher(base, namespace, changeMask, mapper), nil
@@ -108,7 +107,7 @@ func (f *WatcherFactory) NewValueWatcher(
 ) (watcher.NotifyWatcher, error) {
 	base, err := f.newBaseWatcher()
 	if err != nil {
-		return nil, errors.Annotate(err, "creating base watcher")
+		return nil, errors.Errorf("creating base watcher %w", err)
 	}
 
 	return eventsource.NewValueWatcher(base, namespace, changeValue, changeMask), nil
@@ -123,7 +122,7 @@ func (f *WatcherFactory) NewValueMapperWatcher(
 ) (watcher.NotifyWatcher, error) {
 	base, err := f.newBaseWatcher()
 	if err != nil {
-		return nil, errors.Annotate(err, "creating base watcher")
+		return nil, errors.Errorf("creating base watcher %w", err)
 	}
 
 	return eventsource.NewValueMapperWatcher(base, namespace, changeValue, changeMask, mapper), nil
@@ -136,7 +135,7 @@ func (f *WatcherFactory) newBaseWatcher() (*eventsource.BaseWatcher, error) {
 	if f.watchableDB == nil {
 		var err error
 		if f.watchableDB, err = f.getDB(); err != nil {
-			return nil, errors.Trace(err)
+			return nil, errors.Capture(err)
 		}
 	}
 

--- a/scripts/errors-patch/README.md
+++ b/scripts/errors-patch/README.md
@@ -1,0 +1,14 @@
+# Introduction
+This folder contains scripts and resources for converting Juju packages from
+using github.com/juju/errors to using github.com/juju/juju/internal/errors.
+
+# Usage
+The scripts expect to be run from the root of the project. Example refactor of
+ever go file under the domain package:
+```bash
+./scripts/errors-patch/run.sh domain
+```
+
+# Notes
+These scripts are not perfect and cannot fix every variation of error generation
+that exists. Some manual refactoring can be expected.

--- a/scripts/errors-patch/errors-coalesce.patch
+++ b/scripts/errors-patch/errors-coalesce.patch
@@ -1,0 +1,20 @@
+# Patch file for coalescing the import names that we give internal/errors.
+# Due to the way that gopatch works we need a well known target to hit for
+# naming the internal errors import.
+@@
+var x identifier
+@@
+- import internalerrors "github.com/juju/juju/internal/errors"
++ import interrors "github.com/juju/juju/internal/errors"
+
+-internalerrors.x
++interrors.x
+
+@@
+var x identifier
+@@
+- import "github.com/juju/juju/internal/errors"
++ import interrors "github.com/juju/juju/internal/errors"
+
+-errors.x
++interrors.x

--- a/scripts/errors-patch/errors-rename.patch
+++ b/scripts/errors-patch/errors-rename.patch
@@ -1,0 +1,9 @@
+# Something
+@@
+var x, interrors identifier
+@@
+import interrors "github.com/juju/juju/internal/errors"
++import "github.com/juju/juju/internal/errors"
+
+-interrors.x
++errors.x

--- a/scripts/errors-patch/errors.patch
+++ b/scripts/errors-patch/errors.patch
@@ -1,0 +1,251 @@
+# Patch file for wiring through internal/errors into Juju
+@@
+var errors identifier
+@@
+import errors "github.com/juju/errors"
++import interrors "github.com/juju/juju/internal/errors"
+
+-errors.Trace(...)
++interrors.Capture(...)
+
+@@
+var errors identifier
+@@
+import errors "github.com/juju/errors"
++import interrors "github.com/juju/juju/internal/errors"
+
+-errors.New(...)
++interrors.New(...)
+
+@@
+var errors identifier
+@@
+import errors "github.com/juju/errors"
++import interrors "github.com/juju/juju/internal/errors"
+
+-errors.ConstError(...)
++interrors.ConstError(...)
+
+@@
+var fmt identifier
+@@
+import fmt "fmt"
++import interrors "github.com/juju/juju/internal/errors"
+
+-fmt.Errorf(...)
++interrors.Errorf(...)
+
+@@
+var errors identifier
+var x expression
+var fmtStr expression
+@@
+import errors "github.com/juju/errors"
++import interrors "github.com/juju/juju/internal/errors"
+
+-errors.Annotatef(x, fmtStr, ...)
++interrors.Errorf(fmtStr + " %w", ..., x)
+
+@@
+var errors identifier
+var err, errMsg expression
+@@
+import errors "github.com/juju/errors"
++import interrors "github.com/juju/juju/internal/errors"
+
+-errors.Annotate(err, errMsg)
++interrors.Errorf(errMsg + " %w", err)
+
+@@
+var errors identifier
+var errMsg expression
+@@
+import errors "github.com/juju/errors"
++import coreerrors "github.com/juju/juju/core/errors"
++import interrors "github.com/juju/juju/internal/errors"
+
+-errors.NewNotImplemented(nil, errMsg) 
++interrors.Errorf(errMsg + " %w", coreerrors.NotImplemented)
+
+@@
+var errors identifier
+var fmtStr expression
+@@
+import errors "github.com/juju/errors"
++import coreerrors "github.com/juju/juju/core/errors"
++import interrors "github.com/juju/juju/internal/errors"
+
+-errors.NotSupportedf(fmtStr, ...)
++interrors.Errorf(fmtStr + " %w", ..., coreerrors.NotSupported)
+
+@@
+var errors identifier
+@@
+import errors "github.com/juju/errors"
++import coreerrors "github.com/juju/juju/core/errors"
+
+- errors.NotSupported
++ coreerrors.NotSupported
+
+@@
+var errors identifier
+var fmtStr expression
+@@
+import errors "github.com/juju/errors"
++import coreerrors "github.com/juju/juju/core/errors"
++import interrors "github.com/juju/juju/internal/errors"
+
+-errors.NotFoundf(fmtStr, ...)
++interrors.Errorf(fmtStr + " %w", ..., coreerrors.NotFound)
+
+@@
+var errors identifier
+@@
+import errors "github.com/juju/errors"
++import coreerrors "github.com/juju/juju/core/errors"
+
+- errors.NotFound
++ coreerrors.NotFound
+
+@@
+var errors identifier
+var fmtStr expression
+@@
+import errors "github.com/juju/errors"
++import coreerrors "github.com/juju/juju/core/errors"
++import interrors "github.com/juju/juju/internal/errors"
+
+-errors.NotYetAvailablef(fmtStr, ...)
++interrors.Errorf(fmtStr + " %w", ..., coreerrors.NotYetAvailable)
+
+@@
+var errors identifier
+var fmtStr expression
+@@
+import errors "github.com/juju/errors"
++import coreerrors "github.com/juju/juju/core/errors"
++import interrors "github.com/juju/juju/internal/errors"
+
+-errors.NotValidf(fmtStr, ...)
++interrors.Errorf(fmtStr + " %w", ..., coreerrors.NotValid)
+
+@@
+var errors identifier
+@@
+import errors "github.com/juju/errors"
++import coreerrors "github.com/juju/juju/core/errors"
+
+- errors.NotValid
++ coreerrors.NotValid
+
+@@
+var errors identifier
+var fmtStr expression
+@@
+import errors "github.com/juju/errors"
++import coreerrors "github.com/juju/juju/core/errors"
++import interrors "github.com/juju/juju/internal/errors"
+
+-errors.AlreadyExistsf(fmtStr, ...)
++interrors.Errorf(fmtStr + " %w", ..., coreerrors.AlreadyExists)
+
+@@
+var errors identifier
+@@
+import errors "github.com/juju/errors"
++import coreerrors "github.com/juju/juju/core/errors"
+
+- errors.AlreadyExists
++ coreerrors.AlreadyExists
+
+@@
+var errors identifier
+var fmtStr expression
+@@
+import errors "github.com/juju/errors"
++import coreerrors "github.com/juju/juju/core/errors"
++import interrors "github.com/juju/juju/internal/errors"
+
+-errors.NotImplementedf(fmtStr, ...)
++interrors.Errorf(fmtStr + " %w", ..., coreerrors.NotImplemented)
+
+@@
+var errors identifier
+@@
+import errors "github.com/juju/errors"
++import coreerrors "github.com/juju/juju/core/errors"
+
+- errors.NotImplemented
++ coreerrors.NotImplemented
+
+@@
+var errors identifier
+var fmtStr expression
+@@
+import errors "github.com/juju/errors"
+
++import coreerrors "github.com/juju/juju/core/errors"
++import interrors "github.com/juju/juju/internal/errors"
+
+-errors.NotProvisionedf(fmtStr, ...)
++interrors.Errorf(fmtStr + " %w", ..., coreerrors.NotProvisioned)
+
+@@
+var errors identifier
+@@
+import errors "github.com/juju/errors"
++import coreerrors "github.com/juju/juju/core/errors"
+
+- errors.NotProvisioned
++ coreerrors.NotProvisioned
+
+@@
+var errors identifier
+var x expression
+@@
+import errors "github.com/juju/errors"
+
+-errors.Cause(x)
++x
+@@
+var errors identifier
+@@
+import errors "github.com/juju/errors"
++ import interrors "github.com/juju/juju/internal/errors"
+
+-errors.As(...)
++interrors.As(...)
+
+@@
+var errors identifier
+@@
+import errors "github.com/juju/errors"
++import interrors "github.com/juju/juju/internal/errors"
+
+-errors.Is(...)
++interrors.Is(...)
+
+@@
+var errors identifier
+@@
+import errors "errors"
++import interrors "github.com/juju/juju/internal/errors"
+
+-errors.Join(...)
++interrors.Join(...)
+
+@@
+var errors identifier
+@@
+import errors "github.com/juju/errors"
++import interrors "github.com/juju/juju/internal/errors"
+
+-errors.Errorf(...)
++interrors.Errorf(...)
+
+@@
+var x, y identifier
+var z expression
+@@
+-x.Errorf(..., y.Hide(z))
++x.Errorf(...).Add(z)

--- a/scripts/errors-patch/run.sh
+++ b/scripts/errors-patch/run.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+set -e
+
+if [ "$#" -ne 1 ]; then
+    echo "need one package to refactor"
+fi
+
 set -xe
 
 # Step 1: Run the go patch files over the target directory.

--- a/scripts/errors-patch/run.sh
+++ b/scripts/errors-patch/run.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -xe
+
+# Step 1: Run the go patch files over the target directory.
+gopatch -p scripts/errors-patch/errors-coalesce.patch "${1}/..."
+gopatch -p scripts/errors-patch/errors.patch "${1}/..."
+goimports -w "${1}/."
+gopatch -p scripts/errors-patch/errors-rename.patch "${1}/..."
+
+# Step 2: Run sed replacement steps over go patched files.
+
+# Step 2a: Fix up patch of errors that took err as the first argument.
+# This sed step is fixing lines of the form:
+# - errors.Errorf("some message" + " %w", err) to errors.Errorf("some message %w", err)
+# We do this because go patch doesn't have the ability to modify strings.
+find "$1" -type f -iname '*.go' -exec sed -i '' -E "s,\"(.*)\"[ ]?\+[ ]?\" \%w\",\"\1 \%w\",g" "{}" +;
+
+# Step 2b: Remove %w for errors that were using errors.Hide
+# This sed step is fixing lines of the form:
+# - errors.Errorf("some message%w").Add(someerror) to errors.Errorf("some message").Add(someerror)
+# We do this because go patch doesn't have the ability to modify strings. We
+# have ended up with these forms as errors.Hide gets removed.
+find "$1" -type f -iname '*.go' -exec sed -i '' -E "s,\"(.*[^ ])\%w\",\"\1\",g" "{}" +;
+
+# Step 3 fix up imports that have been modified by go patch.
+gci  write --skip-generated -s standard -s default -s 'Prefix(github.com/juju/juju)' "${1}/."


### PR DESCRIPTION
This is a trial run pull request to remove juju/errors from the domain package completely. As we want to remove `juju/errors` from Juju in 4.0 there exists a set of scripts included in this pull request that can automatically go through and perform the refactor of removing `juju/errors`.

To test the scripts in this pull request I did  the following `scripts/errors-patch/run.sh  domain`

If succsefull in landing this PR the goal will be to keep running these scripts on other packages in Juju with associated PR's and extending the scripts to support new use cases discovered.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- ~[ ] Go unit tests, with comments saying what you're testing~
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

See above for steps to run the scripts.

## Documentation changes

N/A

## Links

**Jira card:** JUJU-

