### PR TITLE
fix: revert "fix: remove gce firewall during teardown"

### DIFF
--- a/provider/gce/environ_firewall.go
+++ b/provider/gce/environ_firewall.go
@@ -40,8 +40,3 @@ func (env *environ) IngressRules(ctx context.ProviderCallContext) (firewall.Ingr
 	rules, err := env.gce.IngressRules(env.globalFirewallName())
 	return rules, google.HandleCredentialError(errors.Trace(err), ctx)
 }
-
-func (env *environ) cleanupFirewall(ctx context.ProviderCallContext) error {
-	err := env.gce.RemoveFirewall(env.globalFirewallName())
-	return google.HandleCredentialError(errors.Trace(err), ctx)
-}

--- a/provider/gce/environ_test.go
+++ b/provider/gce/environ_test.go
@@ -194,7 +194,7 @@ func (s *environSuite) TestDestroyAPI(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Check(s.FakeConn.Calls, gc.HasLen, 1)
-	c.Check(s.FakeConn.Calls[0].FuncName, gc.Equals, "RemoveFirewall")
+	c.Check(s.FakeConn.Calls[0].FuncName, gc.Equals, "Ports")
 	fwname := common.EnvFullName(s.Env.Config().UUID())
 	c.Check(s.FakeConn.Calls[0].FirewallName, gc.Equals, fwname)
 	s.FakeCommon.CheckCalls(c, []gce.FakeCall{{

--- a/provider/gce/google/conn.go
+++ b/provider/gce/google/conn.go
@@ -71,7 +71,7 @@ type service interface {
 	// firewall is updated or the request fails.
 	UpdateFirewall(projectID, name string, firewall *compute.Firewall) error
 
-	// RemoveFirewall removes the named firewall from the project. If it
+	// RemoveFirewall removed the named firewall from the project. If it
 	// does not exist then this is a noop. The call blocks until the
 	// firewall is added or the request fails.
 	RemoveFirewall(projectID, name string) error

--- a/provider/gce/google/conn_network.go
+++ b/provider/gce/google/conn_network.go
@@ -216,11 +216,6 @@ func (gce Connection) ClosePorts(target string, rules corefirewall.IngressRules)
 	return nil
 }
 
-// RemoveFirewall removes the named firewall from the project.
-func (gce Connection) RemoveFirewall(fwname string) error {
-	return gce.service.RemoveFirewall(gce.projectID, fwname)
-}
-
 // Subnetworks returns the subnets available in this region.
 func (gce Connection) Subnetworks(region string) ([]*compute.Subnetwork, error) {
 	results, err := gce.service.ListSubnetworks(gce.projectID, region)

--- a/provider/gce/google/conn_network_test.go
+++ b/provider/gce/google/conn_network_test.go
@@ -426,16 +426,6 @@ func (s *connSuite) TestConnectionClosePortsRemoveCIDR(c *gc.C) {
 	})
 }
 
-func (s *connSuite) TestRemoveFirewall(c *gc.C) {
-	err := s.Conn.RemoveFirewall("glass-onion")
-	c.Assert(err, jc.ErrorIsNil)
-
-	c.Check(s.FakeConn.Calls, gc.HasLen, 1)
-	c.Check(s.FakeConn.Calls[0].FuncName, gc.Equals, "RemoveFirewall")
-	c.Check(s.FakeConn.Calls[0].ProjectID, gc.Equals, "spam")
-	c.Check(s.FakeConn.Calls[0].Name, gc.Equals, "glass-onion")
-}
-
 func (s *connSuite) TestConnectionCloseMoMatches(c *gc.C) {
 	s.FakeConn.Firewalls = []*compute.Firewall{{
 		Name:         "spam",

--- a/provider/gce/testing_test.go
+++ b/provider/gce/testing_test.go
@@ -605,14 +605,6 @@ func (fc *fakeConn) ClosePorts(fwname string, rules firewall.IngressRules) error
 	return fc.err()
 }
 
-func (fc *fakeConn) RemoveFirewall(fwname string) error {
-	fc.Calls = append(fc.Calls, fakeConnCall{
-		FuncName:     "RemoveFirewall",
-		FirewallName: fwname,
-	})
-	return fc.err()
-}
-
 func (fc *fakeConn) AvailabilityZones(region string) ([]google.AvailabilityZone, error) {
 	fc.Calls = append(fc.Calls, fakeConnCall{
 		FuncName: "AvailabilityZones",


### PR DESCRIPTION
This reverts commit a2b679d5300fa90ae7d3b19ba7394c4210ca9242.

This change was causing tests to fail on the google compute engine. Reverting until a revised version is added.