### PR TITLE
fix: display_clouds assess clouds test

### DIFF
--- a/tests/suites/cli/display_clouds.sh
+++ b/tests/suites/cli/display_clouds.sh
@@ -90,7 +90,7 @@ EOF
 		exit 1
 	fi
 
-	CLOUD_LIST=$(JUJU_DATA="${TEST_DIR}/juju" juju show-cloud finfolk-vmaas --format json --client | jq -S 'with_entries((select(.value!= null)))')
+	CLOUD_LIST=$(JUJU_DATA="${TEST_DIR}/juju" juju show-cloud finfolk-vmaas --format json --client | jq -S '.[] | with_entries((select(.value!= null)))')
 	EXPECTED=$(
 		cat <<'EOF' | jq -S
 	{


### PR DESCRIPTION
This test was failing because the json recieved from the `show-clouds` command was being sorted with JQ. show-clouds was returning a list with one element and the JQ command was written to work on the first element. The fix was to first get the first element of the list and then parse.

I am not sure what changed to cause this test to fail, it passed in 3.6 and none of the commits inbetween appear to affect this. Prehaps the version of JQ was updated somewhere?

## QA steps
Run:
```
cd tests
./main.sh -v cli test_display_clouds
```
<!-- 

Describe steps to verify that the change works. 

If you're changing any of the facades, you need to ensure that you've tested
a model migration from 3.6 to 4.0 and from 4.0 to 4.0.

The following steps are a good starting point:

 1. Bootstrap a 3.6 controller and deploy a charm.

```sh
$ juju bootstrap lxd src36
$ juju add-model moveme1
$ juju deploy juju-qa-test
```

 2. Bootstrap a 4.0 controller with the changes and migrate the model.

```sh
$ juju bootstrap lxd dst40
$ juju migrate src36:moveme1 dst40
$ juju add-unit juju-qa-test
```

 3. Verify no errors exist in the model logs for the agents. If there are
    errors, this is a bug and should be fixed before merging. The fix can
    either be applied to the 4.0 branch (preferable) or the 3.6 branch, though
    that needs to be discussed with the team.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme1
```

    4. We also need to test a model migration from 4.0 to 4.0.

```sh
$ juju bootstrap lxd src40
$ juju add-model moveme2
$ juju deploy juju-qa-test
```

```sh
$ juju migrate src40:moveme2 dst40
$ juju add-unit juju-qa-test
```

    5. Verify that there are no errors in the controller or model logs.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme2
```

-->

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/

**Jira card:** JUJU-

