### PR TITLE
chore: update to the latest dqlite dependency

### DIFF
--- a/scripts/dqlite/scripts/env.sh
+++ b/scripts/dqlite/scripts/env.sh
@@ -65,7 +65,7 @@ TAG_LIBNSL=v2.0.0
 TAG_LIBUV=v1.46.0
 TAG_LIBLZ4=v1.9.4
 TAG_SQLITE=version-3.46.0
-TAG_DQLITE=v1.16.7
+TAG_DQLITE=v1.18.0
 
 S3_BUCKET=s3://dqlite-static-libs
 S3_ARCHIVE_NAME=$(date -u +"%Y-%m-%d")-dqlite-deps-${BUILD_ARCH}.tar.bz2

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -224,7 +224,7 @@ parts:
       - libuv
       - libsqlite3
     source: https://github.com/canonical/dqlite.git
-    source-tag: v1.16.7
+    source-tag: v1.18.0
     source-type: git
     source-depth: 1
     plugin: nil


### PR DESCRIPTION
We need to commit this, so Jenkins can then pick this up with the latest changes.

This will all go once we're only using charms.