### PR TITLE
refactor remove status set in undertaker worker

### DIFF
--- a/api/controller/undertaker/undertaker.go
+++ b/api/controller/undertaker/undertaker.go
@@ -12,7 +12,6 @@ import (
 	"github.com/juju/juju/api/base"
 	"github.com/juju/juju/api/common"
 	"github.com/juju/juju/api/common/cloudspec"
-	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/rpc/params"
 )
@@ -68,26 +67,6 @@ func (c *Client) ProcessDyingModel(ctx context.Context) error {
 // RemoveModel removes any records of this model from Juju.
 func (c *Client) RemoveModel(ctx context.Context) error {
 	return c.entityFacadeCall(ctx, "RemoveModel", nil)
-}
-
-// SetStatus sets the status of the model.
-func (c *Client) SetStatus(ctx context.Context, status status.Status, message string, data map[string]interface{}) error {
-	args := params.SetStatus{
-		Entities: []params.EntityStatusArgs{
-			{Tag: c.modelTag.String(), Status: status.String(), Info: message, Data: data},
-		},
-	}
-	var results params.ErrorResults
-	if err := c.caller.FacadeCall(ctx, "SetStatus", args, &results); err != nil {
-		return errors.Trace(err)
-	}
-	if len(results.Results) != 1 {
-		return errors.Errorf("expected 1 result, got %d", len(results.Results))
-	}
-	if results.Results[0].Error != nil {
-		return errors.Trace(results.Results[0].Error)
-	}
-	return nil
 }
 
 func (c *Client) entityFacadeCall(ctx context.Context, name string, results interface{}) error {

--- a/apiserver/facades/controller/undertaker/undertaker.go
+++ b/apiserver/facades/controller/undertaker/undertaker.go
@@ -7,7 +7,6 @@ import (
 	"context"
 
 	"github.com/juju/errors"
-	"github.com/juju/names/v5"
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/common/cloudspec"
@@ -32,7 +31,6 @@ type UndertakerAPI struct {
 	st        State
 	resources facade.Resources
 
-	*common.StatusSetter
 	*common.ModelConfigWatcher
 	cloudspec.CloudSpecer
 
@@ -51,28 +49,11 @@ func newUndertakerAPI(
 	if !authorizer.AuthController() {
 		return nil, apiservererrors.ErrPerm
 	}
-	model, err := st.Model()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	getCanModifyModel := func() (common.AuthFunc, error) {
-		return func(tag names.Tag) bool {
-			if st.IsController() {
-				return true
-			}
-			// Only the agent's model can be modified.
-			modelTag, ok := tag.(names.ModelTag)
-			if !ok {
-				return false
-			}
-			return modelTag.Id() == model.UUID()
-		}, nil
-	}
+
 	return &UndertakerAPI{
 		st:                   st,
 		resources:            resources,
 		secretBackendService: secretBackendService,
-		StatusSetter:         common.NewStatusSetter(st, getCanModifyModel),
 		ModelConfigWatcher:   common.NewModelConfigWatcher(modelConfigService, watcherRegistry),
 		CloudSpecer:          cloudSpecer,
 	}, nil


### PR DESCRIPTION
This PR ensures no model status is set in the undertaker worker.
It also removes the SetStatus method from both client and apiserver facade.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

```
```

## Documentation changes

No

## Links

**Jira card:** [JUJU-7111](https://warthogs.atlassian.net/browse/JUJU-7111)

