### PR TITLE
feat(application): Add methods to retrieve charm by SHA

### DIFF
--- a/apiserver/common/mocks/objectstore_mock.go
+++ b/apiserver/common/mocks/objectstore_mock.go
@@ -81,6 +81,46 @@ func (c *MockObjectStoreGetCall) DoAndReturn(f func(context.Context, string) (io
 	return c
 }
 
+// GetBySHA256Prefix mocks base method.
+func (m *MockObjectStore) GetBySHA256Prefix(arg0 context.Context, arg1 string) (io.ReadCloser, int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBySHA256Prefix", arg0, arg1)
+	ret0, _ := ret[0].(io.ReadCloser)
+	ret1, _ := ret[1].(int64)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetBySHA256Prefix indicates an expected call of GetBySHA256Prefix.
+func (mr *MockObjectStoreMockRecorder) GetBySHA256Prefix(arg0, arg1 any) *MockObjectStoreGetBySHA256PrefixCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBySHA256Prefix", reflect.TypeOf((*MockObjectStore)(nil).GetBySHA256Prefix), arg0, arg1)
+	return &MockObjectStoreGetBySHA256PrefixCall{Call: call}
+}
+
+// MockObjectStoreGetBySHA256PrefixCall wrap *gomock.Call
+type MockObjectStoreGetBySHA256PrefixCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockObjectStoreGetBySHA256PrefixCall) Return(arg0 io.ReadCloser, arg1 int64, arg2 error) *MockObjectStoreGetBySHA256PrefixCall {
+	c.Call = c.Call.Return(arg0, arg1, arg2)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockObjectStoreGetBySHA256PrefixCall) Do(f func(context.Context, string) (io.ReadCloser, int64, error)) *MockObjectStoreGetBySHA256PrefixCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockObjectStoreGetBySHA256PrefixCall) DoAndReturn(f func(context.Context, string) (io.ReadCloser, int64, error)) *MockObjectStoreGetBySHA256PrefixCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // Put mocks base method.
 func (m *MockObjectStore) Put(arg0 context.Context, arg1 string, arg2 io.Reader, arg3 int64) (objectstore.UUID, error) {
 	m.ctrl.T.Helper()

--- a/apiserver/facades/client/application/objectstore_mock_test.go
+++ b/apiserver/facades/client/application/objectstore_mock_test.go
@@ -81,6 +81,46 @@ func (c *MockObjectStoreGetCall) DoAndReturn(f func(context.Context, string) (io
 	return c
 }
 
+// GetBySHA256Prefix mocks base method.
+func (m *MockObjectStore) GetBySHA256Prefix(arg0 context.Context, arg1 string) (io.ReadCloser, int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBySHA256Prefix", arg0, arg1)
+	ret0, _ := ret[0].(io.ReadCloser)
+	ret1, _ := ret[1].(int64)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetBySHA256Prefix indicates an expected call of GetBySHA256Prefix.
+func (mr *MockObjectStoreMockRecorder) GetBySHA256Prefix(arg0, arg1 any) *MockObjectStoreGetBySHA256PrefixCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBySHA256Prefix", reflect.TypeOf((*MockObjectStore)(nil).GetBySHA256Prefix), arg0, arg1)
+	return &MockObjectStoreGetBySHA256PrefixCall{Call: call}
+}
+
+// MockObjectStoreGetBySHA256PrefixCall wrap *gomock.Call
+type MockObjectStoreGetBySHA256PrefixCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockObjectStoreGetBySHA256PrefixCall) Return(arg0 io.ReadCloser, arg1 int64, arg2 error) *MockObjectStoreGetBySHA256PrefixCall {
+	c.Call = c.Call.Return(arg0, arg1, arg2)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockObjectStoreGetBySHA256PrefixCall) Do(f func(context.Context, string) (io.ReadCloser, int64, error)) *MockObjectStoreGetBySHA256PrefixCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockObjectStoreGetBySHA256PrefixCall) DoAndReturn(f func(context.Context, string) (io.ReadCloser, int64, error)) *MockObjectStoreGetBySHA256PrefixCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // Put mocks base method.
 func (m *MockObjectStore) Put(arg0 context.Context, arg1 string, arg2 io.Reader, arg3 int64) (objectstore.UUID, error) {
 	m.ctrl.T.Helper()

--- a/apiserver/facades/client/machinemanager/objectstore_mock_test.go
+++ b/apiserver/facades/client/machinemanager/objectstore_mock_test.go
@@ -81,6 +81,46 @@ func (c *MockObjectStoreGetCall) DoAndReturn(f func(context.Context, string) (io
 	return c
 }
 
+// GetBySHA256Prefix mocks base method.
+func (m *MockObjectStore) GetBySHA256Prefix(arg0 context.Context, arg1 string) (io.ReadCloser, int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBySHA256Prefix", arg0, arg1)
+	ret0, _ := ret[0].(io.ReadCloser)
+	ret1, _ := ret[1].(int64)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetBySHA256Prefix indicates an expected call of GetBySHA256Prefix.
+func (mr *MockObjectStoreMockRecorder) GetBySHA256Prefix(arg0, arg1 any) *MockObjectStoreGetBySHA256PrefixCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBySHA256Prefix", reflect.TypeOf((*MockObjectStore)(nil).GetBySHA256Prefix), arg0, arg1)
+	return &MockObjectStoreGetBySHA256PrefixCall{Call: call}
+}
+
+// MockObjectStoreGetBySHA256PrefixCall wrap *gomock.Call
+type MockObjectStoreGetBySHA256PrefixCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockObjectStoreGetBySHA256PrefixCall) Return(arg0 io.ReadCloser, arg1 int64, arg2 error) *MockObjectStoreGetBySHA256PrefixCall {
+	c.Call = c.Call.Return(arg0, arg1, arg2)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockObjectStoreGetBySHA256PrefixCall) Do(f func(context.Context, string) (io.ReadCloser, int64, error)) *MockObjectStoreGetBySHA256PrefixCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockObjectStoreGetBySHA256PrefixCall) DoAndReturn(f func(context.Context, string) (io.ReadCloser, int64, error)) *MockObjectStoreGetBySHA256PrefixCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // Put mocks base method.
 func (m *MockObjectStore) Put(arg0 context.Context, arg1 string, arg2 io.Reader, arg3 int64) (objectstore.UUID, error) {
 	m.ctrl.T.Helper()

--- a/apiserver/facades/controller/charmrevisionupdater/mocks/objectstore.go
+++ b/apiserver/facades/controller/charmrevisionupdater/mocks/objectstore.go
@@ -81,6 +81,46 @@ func (c *MockObjectStoreGetCall) DoAndReturn(f func(context.Context, string) (io
 	return c
 }
 
+// GetBySHA256Prefix mocks base method.
+func (m *MockObjectStore) GetBySHA256Prefix(arg0 context.Context, arg1 string) (io.ReadCloser, int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBySHA256Prefix", arg0, arg1)
+	ret0, _ := ret[0].(io.ReadCloser)
+	ret1, _ := ret[1].(int64)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetBySHA256Prefix indicates an expected call of GetBySHA256Prefix.
+func (mr *MockObjectStoreMockRecorder) GetBySHA256Prefix(arg0, arg1 any) *MockObjectStoreGetBySHA256PrefixCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBySHA256Prefix", reflect.TypeOf((*MockObjectStore)(nil).GetBySHA256Prefix), arg0, arg1)
+	return &MockObjectStoreGetBySHA256PrefixCall{Call: call}
+}
+
+// MockObjectStoreGetBySHA256PrefixCall wrap *gomock.Call
+type MockObjectStoreGetBySHA256PrefixCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockObjectStoreGetBySHA256PrefixCall) Return(arg0 io.ReadCloser, arg1 int64, arg2 error) *MockObjectStoreGetBySHA256PrefixCall {
+	c.Call = c.Call.Return(arg0, arg1, arg2)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockObjectStoreGetBySHA256PrefixCall) Do(f func(context.Context, string) (io.ReadCloser, int64, error)) *MockObjectStoreGetBySHA256PrefixCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockObjectStoreGetBySHA256PrefixCall) DoAndReturn(f func(context.Context, string) (io.ReadCloser, int64, error)) *MockObjectStoreGetBySHA256PrefixCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // Put mocks base method.
 func (m *MockObjectStore) Put(arg0 context.Context, arg1 string, arg2 io.Reader, arg3 int64) (objectstore.UUID, error) {
 	m.ctrl.T.Helper()

--- a/apiserver/facades/controller/migrationmaster/mocks/objectstore.go
+++ b/apiserver/facades/controller/migrationmaster/mocks/objectstore.go
@@ -81,6 +81,46 @@ func (c *MockObjectStoreGetCall) DoAndReturn(f func(context.Context, string) (io
 	return c
 }
 
+// GetBySHA256Prefix mocks base method.
+func (m *MockObjectStore) GetBySHA256Prefix(arg0 context.Context, arg1 string) (io.ReadCloser, int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBySHA256Prefix", arg0, arg1)
+	ret0, _ := ret[0].(io.ReadCloser)
+	ret1, _ := ret[1].(int64)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetBySHA256Prefix indicates an expected call of GetBySHA256Prefix.
+func (mr *MockObjectStoreMockRecorder) GetBySHA256Prefix(arg0, arg1 any) *MockObjectStoreGetBySHA256PrefixCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBySHA256Prefix", reflect.TypeOf((*MockObjectStore)(nil).GetBySHA256Prefix), arg0, arg1)
+	return &MockObjectStoreGetBySHA256PrefixCall{Call: call}
+}
+
+// MockObjectStoreGetBySHA256PrefixCall wrap *gomock.Call
+type MockObjectStoreGetBySHA256PrefixCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockObjectStoreGetBySHA256PrefixCall) Return(arg0 io.ReadCloser, arg1 int64, arg2 error) *MockObjectStoreGetBySHA256PrefixCall {
+	c.Call = c.Call.Return(arg0, arg1, arg2)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockObjectStoreGetBySHA256PrefixCall) Do(f func(context.Context, string) (io.ReadCloser, int64, error)) *MockObjectStoreGetBySHA256PrefixCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockObjectStoreGetBySHA256PrefixCall) DoAndReturn(f func(context.Context, string) (io.ReadCloser, int64, error)) *MockObjectStoreGetBySHA256PrefixCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // Put mocks base method.
 func (m *MockObjectStore) Put(arg0 context.Context, arg1 string, arg2 io.Reader, arg3 int64) (objectstore.UUID, error) {
 	m.ctrl.T.Helper()

--- a/core/objectstore/metadata.go
+++ b/core/objectstore/metadata.go
@@ -34,6 +34,10 @@ type ObjectStoreMetadata interface {
 	// GetMetadata returns the persistence metadata for the specified path.
 	GetMetadata(ctx context.Context, path string) (Metadata, error)
 
+	// GetMetadataBySHA256Prefix returns the persistence metadata for the object
+	// with SHA256 starting with the provided prefix.
+	GetMetadataBySHA256Prefix(ctx context.Context, sha256Prefix string) (Metadata, error)
+
 	// PutMetadata adds a new specified path for the persistence metadata.
 	PutMetadata(ctx context.Context, metadata Metadata) (UUID, error)
 

--- a/core/objectstore/objectstore.go
+++ b/core/objectstore/objectstore.go
@@ -91,7 +91,16 @@ type ObjectStore interface {
 type ReadObjectStore interface {
 	// Get returns an io.ReadCloser for data at path, namespaced to the
 	// model.
+	//
+	// If the object does not exist, an [objectstore.ObjectNotFound]
+	// error is returned.
 	Get(context.Context, string) (io.ReadCloser, int64, error)
+
+	// GetBySHA256Prefix returns an io.ReadCloser for any object with the a SHA256
+	// hash starting with a given prefix, namespaced to the model.
+	//
+	// If no object is found, an [objectstore.ObjectNotFound] error is returned.
+	GetBySHA256Prefix(context.Context, string) (io.ReadCloser, int64, error)
 }
 
 // WriteObjectStore represents an object store that can only be written to.

--- a/domain/application/charm/store/store_mock_test.go
+++ b/domain/application/charm/store/store_mock_test.go
@@ -81,6 +81,46 @@ func (c *MockObjectStoreGetCall) DoAndReturn(f func(context.Context, string) (io
 	return c
 }
 
+// GetBySHA256Prefix mocks base method.
+func (m *MockObjectStore) GetBySHA256Prefix(arg0 context.Context, arg1 string) (io.ReadCloser, int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBySHA256Prefix", arg0, arg1)
+	ret0, _ := ret[0].(io.ReadCloser)
+	ret1, _ := ret[1].(int64)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetBySHA256Prefix indicates an expected call of GetBySHA256Prefix.
+func (mr *MockObjectStoreMockRecorder) GetBySHA256Prefix(arg0, arg1 any) *MockObjectStoreGetBySHA256PrefixCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBySHA256Prefix", reflect.TypeOf((*MockObjectStore)(nil).GetBySHA256Prefix), arg0, arg1)
+	return &MockObjectStoreGetBySHA256PrefixCall{Call: call}
+}
+
+// MockObjectStoreGetBySHA256PrefixCall wrap *gomock.Call
+type MockObjectStoreGetBySHA256PrefixCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockObjectStoreGetBySHA256PrefixCall) Return(arg0 io.ReadCloser, arg1 int64, arg2 error) *MockObjectStoreGetBySHA256PrefixCall {
+	c.Call = c.Call.Return(arg0, arg1, arg2)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockObjectStoreGetBySHA256PrefixCall) Do(f func(context.Context, string) (io.ReadCloser, int64, error)) *MockObjectStoreGetBySHA256PrefixCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockObjectStoreGetBySHA256PrefixCall) DoAndReturn(f func(context.Context, string) (io.ReadCloser, int64, error)) *MockObjectStoreGetBySHA256PrefixCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // Put mocks base method.
 func (m *MockObjectStore) Put(arg0 context.Context, arg1 string, arg2 io.Reader, arg3 int64) (objectstore.UUID, error) {
 	m.ctrl.T.Helper()

--- a/domain/application/service/charm.go
+++ b/domain/application/service/charm.go
@@ -149,6 +149,10 @@ type CharmStore interface {
 	// GetCharm retrieves a ReadCloser for the charm archive at the give path
 	// from the underlying storage.
 	Get(ctx context.Context, archivePath string) (io.ReadCloser, error)
+
+	// GetBySHA256Prefix retrieves a ReadCloser for a charm archive who's SHA256
+	// hash starts with the provided prefix.
+	GetBySHA256Prefix(ctx context.Context, sha256Prefix string) (io.ReadCloser, error)
 }
 
 // GetCharmID returns a charm ID by name. It returns an error if the charm can
@@ -462,6 +466,20 @@ func (s *Service) GetCharmArchive(ctx context.Context, id corecharm.ID) (io.Read
 	}
 
 	return reader, hash, nil
+}
+
+// GetCharmArchiveBySHA256Prefix returns a ReadCloser stream for the charm
+// archive who's SHA256 hash starts with the provided prefix.
+//
+// If the charm does not exist, a [applicationerrors.CharmNotFound] error is
+// returned.
+func (s *Service) GetCharmArchiveBySHA256Prefix(ctx context.Context, sha256Prefix string) (io.ReadCloser, error) {
+	reader, err := s.charmStore.GetBySHA256Prefix(ctx, sha256Prefix)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	return reader, nil
 }
 
 // IsCharmAvailable returns whether the charm is available for use. This

--- a/domain/application/service/charm_test.go
+++ b/domain/application/service/charm_test.go
@@ -420,6 +420,21 @@ func (s *charmServiceSuite) TestGetCharmArchive(c *gc.C) {
 	c.Check(string(content), gc.Equals, "archive-content")
 }
 
+func (s *charmServiceSuite) TestGetCharmArchiveBySHA256Prefix(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	archive := io.NopCloser(strings.NewReader("archive-content"))
+
+	s.charmStore.EXPECT().GetBySHA256Prefix(gomock.Any(), "prefix").Return(archive, nil)
+
+	reader, err := s.service.GetCharmArchiveBySHA256Prefix(context.Background(), "prefix")
+	c.Assert(err, jc.ErrorIsNil)
+
+	content, err := io.ReadAll(reader)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(string(content), gc.Equals, "archive-content")
+}
+
 func (s *charmServiceSuite) TestSetCharmAvailable(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 

--- a/domain/application/service/package_mock_test.go
+++ b/domain/application/service/package_mock_test.go
@@ -2663,3 +2663,42 @@ func (c *MockCharmStoreGetCall) DoAndReturn(f func(context.Context, string) (io.
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
+
+// GetBySHA256Prefix mocks base method.
+func (m *MockCharmStore) GetBySHA256Prefix(arg0 context.Context, arg1 string) (io.ReadCloser, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBySHA256Prefix", arg0, arg1)
+	ret0, _ := ret[0].(io.ReadCloser)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetBySHA256Prefix indicates an expected call of GetBySHA256Prefix.
+func (mr *MockCharmStoreMockRecorder) GetBySHA256Prefix(arg0, arg1 any) *MockCharmStoreGetBySHA256PrefixCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBySHA256Prefix", reflect.TypeOf((*MockCharmStore)(nil).GetBySHA256Prefix), arg0, arg1)
+	return &MockCharmStoreGetBySHA256PrefixCall{Call: call}
+}
+
+// MockCharmStoreGetBySHA256PrefixCall wrap *gomock.Call
+type MockCharmStoreGetBySHA256PrefixCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockCharmStoreGetBySHA256PrefixCall) Return(arg0 io.ReadCloser, arg1 error) *MockCharmStoreGetBySHA256PrefixCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockCharmStoreGetBySHA256PrefixCall) Do(f func(context.Context, string) (io.ReadCloser, error)) *MockCharmStoreGetBySHA256PrefixCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockCharmStoreGetBySHA256PrefixCall) DoAndReturn(f func(context.Context, string) (io.ReadCloser, error)) *MockCharmStoreGetBySHA256PrefixCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}

--- a/internal/bootstrap/objectstore_mock_test.go
+++ b/internal/bootstrap/objectstore_mock_test.go
@@ -81,6 +81,46 @@ func (c *MockObjectStoreGetCall) DoAndReturn(f func(context.Context, string) (io
 	return c
 }
 
+// GetBySHA256Prefix mocks base method.
+func (m *MockObjectStore) GetBySHA256Prefix(arg0 context.Context, arg1 string) (io.ReadCloser, int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBySHA256Prefix", arg0, arg1)
+	ret0, _ := ret[0].(io.ReadCloser)
+	ret1, _ := ret[1].(int64)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetBySHA256Prefix indicates an expected call of GetBySHA256Prefix.
+func (mr *MockObjectStoreMockRecorder) GetBySHA256Prefix(arg0, arg1 any) *MockObjectStoreGetBySHA256PrefixCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBySHA256Prefix", reflect.TypeOf((*MockObjectStore)(nil).GetBySHA256Prefix), arg0, arg1)
+	return &MockObjectStoreGetBySHA256PrefixCall{Call: call}
+}
+
+// MockObjectStoreGetBySHA256PrefixCall wrap *gomock.Call
+type MockObjectStoreGetBySHA256PrefixCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockObjectStoreGetBySHA256PrefixCall) Return(arg0 io.ReadCloser, arg1 int64, arg2 error) *MockObjectStoreGetBySHA256PrefixCall {
+	c.Call = c.Call.Return(arg0, arg1, arg2)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockObjectStoreGetBySHA256PrefixCall) Do(f func(context.Context, string) (io.ReadCloser, int64, error)) *MockObjectStoreGetBySHA256PrefixCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockObjectStoreGetBySHA256PrefixCall) DoAndReturn(f func(context.Context, string) (io.ReadCloser, int64, error)) *MockObjectStoreGetBySHA256PrefixCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // Put mocks base method.
 func (m *MockObjectStore) Put(arg0 context.Context, arg1 string, arg2 io.Reader, arg3 int64) (objectstore.UUID, error) {
 	m.ctrl.T.Helper()

--- a/internal/objectstore/base.go
+++ b/internal/objectstore/base.go
@@ -53,6 +53,7 @@ type opType int
 
 const (
 	opGet opType = iota
+	opGetByHash
 	opPut
 	opRemove
 )
@@ -60,6 +61,7 @@ const (
 type request struct {
 	op            opType
 	path          string
+	sha256Prefix  string
 	reader        io.Reader
 	size          int64
 	hashValidator hashValidator

--- a/internal/objectstore/errors/errors.go
+++ b/internal/objectstore/errors/errors.go
@@ -1,0 +1,15 @@
+// Copyright 2023 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package errors
+
+import "github.com/juju/juju/internal/errors"
+
+const (
+	// ObjectNotFound is returned when an object is not found in the store.
+	ObjectNotFound = errors.ConstError("object not found")
+
+	// ObjectAlreadyExists is returned an object is placed in the store, but
+	// that object already exists.
+	ObjectAlreadyExists = errors.ConstError("object already exists")
+)

--- a/internal/objectstore/objectstore_mock_test.go
+++ b/internal/objectstore/objectstore_mock_test.go
@@ -81,6 +81,45 @@ func (c *MockObjectStoreMetadataGetMetadataCall) DoAndReturn(f func(context.Cont
 	return c
 }
 
+// GetMetadataBySHA256Prefix mocks base method.
+func (m *MockObjectStoreMetadata) GetMetadataBySHA256Prefix(arg0 context.Context, arg1 string) (objectstore.Metadata, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMetadataBySHA256Prefix", arg0, arg1)
+	ret0, _ := ret[0].(objectstore.Metadata)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetMetadataBySHA256Prefix indicates an expected call of GetMetadataBySHA256Prefix.
+func (mr *MockObjectStoreMetadataMockRecorder) GetMetadataBySHA256Prefix(arg0, arg1 any) *MockObjectStoreMetadataGetMetadataBySHA256PrefixCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMetadataBySHA256Prefix", reflect.TypeOf((*MockObjectStoreMetadata)(nil).GetMetadataBySHA256Prefix), arg0, arg1)
+	return &MockObjectStoreMetadataGetMetadataBySHA256PrefixCall{Call: call}
+}
+
+// MockObjectStoreMetadataGetMetadataBySHA256PrefixCall wrap *gomock.Call
+type MockObjectStoreMetadataGetMetadataBySHA256PrefixCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockObjectStoreMetadataGetMetadataBySHA256PrefixCall) Return(arg0 objectstore.Metadata, arg1 error) *MockObjectStoreMetadataGetMetadataBySHA256PrefixCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockObjectStoreMetadataGetMetadataBySHA256PrefixCall) Do(f func(context.Context, string) (objectstore.Metadata, error)) *MockObjectStoreMetadataGetMetadataBySHA256PrefixCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockObjectStoreMetadataGetMetadataBySHA256PrefixCall) DoAndReturn(f func(context.Context, string) (objectstore.Metadata, error)) *MockObjectStoreMetadataGetMetadataBySHA256PrefixCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // ListMetadata mocks base method.
 func (m *MockObjectStoreMetadata) ListMetadata(arg0 context.Context) ([]objectstore.Metadata, error) {
 	m.ctrl.T.Helper()

--- a/internal/resource/store/object_store_mock_test.go
+++ b/internal/resource/store/object_store_mock_test.go
@@ -81,6 +81,46 @@ func (c *MockObjectStoreGetCall) DoAndReturn(f func(context.Context, string) (io
 	return c
 }
 
+// GetBySHA256Prefix mocks base method.
+func (m *MockObjectStore) GetBySHA256Prefix(arg0 context.Context, arg1 string) (io.ReadCloser, int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBySHA256Prefix", arg0, arg1)
+	ret0, _ := ret[0].(io.ReadCloser)
+	ret1, _ := ret[1].(int64)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetBySHA256Prefix indicates an expected call of GetBySHA256Prefix.
+func (mr *MockObjectStoreMockRecorder) GetBySHA256Prefix(arg0, arg1 any) *MockObjectStoreGetBySHA256PrefixCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBySHA256Prefix", reflect.TypeOf((*MockObjectStore)(nil).GetBySHA256Prefix), arg0, arg1)
+	return &MockObjectStoreGetBySHA256PrefixCall{Call: call}
+}
+
+// MockObjectStoreGetBySHA256PrefixCall wrap *gomock.Call
+type MockObjectStoreGetBySHA256PrefixCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockObjectStoreGetBySHA256PrefixCall) Return(arg0 io.ReadCloser, arg1 int64, arg2 error) *MockObjectStoreGetBySHA256PrefixCall {
+	c.Call = c.Call.Return(arg0, arg1, arg2)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockObjectStoreGetBySHA256PrefixCall) Do(f func(context.Context, string) (io.ReadCloser, int64, error)) *MockObjectStoreGetBySHA256PrefixCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockObjectStoreGetBySHA256PrefixCall) DoAndReturn(f func(context.Context, string) (io.ReadCloser, int64, error)) *MockObjectStoreGetBySHA256PrefixCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // Put mocks base method.
 func (m *MockObjectStore) Put(arg0 context.Context, arg1 string, arg2 io.Reader, arg3 int64) (objectstore.UUID, error) {
 	m.ctrl.T.Helper()

--- a/internal/worker/bootstrap/objectstore_mock_test.go
+++ b/internal/worker/bootstrap/objectstore_mock_test.go
@@ -81,6 +81,46 @@ func (c *MockObjectStoreGetCall) DoAndReturn(f func(context.Context, string) (io
 	return c
 }
 
+// GetBySHA256Prefix mocks base method.
+func (m *MockObjectStore) GetBySHA256Prefix(arg0 context.Context, arg1 string) (io.ReadCloser, int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBySHA256Prefix", arg0, arg1)
+	ret0, _ := ret[0].(io.ReadCloser)
+	ret1, _ := ret[1].(int64)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetBySHA256Prefix indicates an expected call of GetBySHA256Prefix.
+func (mr *MockObjectStoreMockRecorder) GetBySHA256Prefix(arg0, arg1 any) *MockObjectStoreGetBySHA256PrefixCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBySHA256Prefix", reflect.TypeOf((*MockObjectStore)(nil).GetBySHA256Prefix), arg0, arg1)
+	return &MockObjectStoreGetBySHA256PrefixCall{Call: call}
+}
+
+// MockObjectStoreGetBySHA256PrefixCall wrap *gomock.Call
+type MockObjectStoreGetBySHA256PrefixCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockObjectStoreGetBySHA256PrefixCall) Return(arg0 io.ReadCloser, arg1 int64, arg2 error) *MockObjectStoreGetBySHA256PrefixCall {
+	c.Call = c.Call.Return(arg0, arg1, arg2)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockObjectStoreGetBySHA256PrefixCall) Do(f func(context.Context, string) (io.ReadCloser, int64, error)) *MockObjectStoreGetBySHA256PrefixCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockObjectStoreGetBySHA256PrefixCall) DoAndReturn(f func(context.Context, string) (io.ReadCloser, int64, error)) *MockObjectStoreGetBySHA256PrefixCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // Put mocks base method.
 func (m *MockObjectStore) Put(arg0 context.Context, arg1 string, arg2 io.Reader, arg3 int64) (objectstore.UUID, error) {
 	m.ctrl.T.Helper()

--- a/internal/worker/domainservices/objectstore_mock_test.go
+++ b/internal/worker/domainservices/objectstore_mock_test.go
@@ -81,6 +81,46 @@ func (c *MockObjectStoreGetCall) DoAndReturn(f func(context.Context, string) (io
 	return c
 }
 
+// GetBySHA256Prefix mocks base method.
+func (m *MockObjectStore) GetBySHA256Prefix(arg0 context.Context, arg1 string) (io.ReadCloser, int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBySHA256Prefix", arg0, arg1)
+	ret0, _ := ret[0].(io.ReadCloser)
+	ret1, _ := ret[1].(int64)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetBySHA256Prefix indicates an expected call of GetBySHA256Prefix.
+func (mr *MockObjectStoreMockRecorder) GetBySHA256Prefix(arg0, arg1 any) *MockObjectStoreGetBySHA256PrefixCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBySHA256Prefix", reflect.TypeOf((*MockObjectStore)(nil).GetBySHA256Prefix), arg0, arg1)
+	return &MockObjectStoreGetBySHA256PrefixCall{Call: call}
+}
+
+// MockObjectStoreGetBySHA256PrefixCall wrap *gomock.Call
+type MockObjectStoreGetBySHA256PrefixCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockObjectStoreGetBySHA256PrefixCall) Return(arg0 io.ReadCloser, arg1 int64, arg2 error) *MockObjectStoreGetBySHA256PrefixCall {
+	c.Call = c.Call.Return(arg0, arg1, arg2)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockObjectStoreGetBySHA256PrefixCall) Do(f func(context.Context, string) (io.ReadCloser, int64, error)) *MockObjectStoreGetBySHA256PrefixCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockObjectStoreGetBySHA256PrefixCall) DoAndReturn(f func(context.Context, string) (io.ReadCloser, int64, error)) *MockObjectStoreGetBySHA256PrefixCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // Put mocks base method.
 func (m *MockObjectStore) Put(arg0 context.Context, arg1 string, arg2 io.Reader, arg3 int64) (objectstore.UUID, error) {
 	m.ctrl.T.Helper()

--- a/internal/worker/objectstore/objectstore_mock_test.go
+++ b/internal/worker/objectstore/objectstore_mock_test.go
@@ -84,6 +84,46 @@ func (c *MockTrackedObjectStoreGetCall) DoAndReturn(f func(context.Context, stri
 	return c
 }
 
+// GetBySHA256Prefix mocks base method.
+func (m *MockTrackedObjectStore) GetBySHA256Prefix(arg0 context.Context, arg1 string) (io.ReadCloser, int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBySHA256Prefix", arg0, arg1)
+	ret0, _ := ret[0].(io.ReadCloser)
+	ret1, _ := ret[1].(int64)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetBySHA256Prefix indicates an expected call of GetBySHA256Prefix.
+func (mr *MockTrackedObjectStoreMockRecorder) GetBySHA256Prefix(arg0, arg1 any) *MockTrackedObjectStoreGetBySHA256PrefixCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBySHA256Prefix", reflect.TypeOf((*MockTrackedObjectStore)(nil).GetBySHA256Prefix), arg0, arg1)
+	return &MockTrackedObjectStoreGetBySHA256PrefixCall{Call: call}
+}
+
+// MockTrackedObjectStoreGetBySHA256PrefixCall wrap *gomock.Call
+type MockTrackedObjectStoreGetBySHA256PrefixCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockTrackedObjectStoreGetBySHA256PrefixCall) Return(arg0 io.ReadCloser, arg1 int64, arg2 error) *MockTrackedObjectStoreGetBySHA256PrefixCall {
+	c.Call = c.Call.Return(arg0, arg1, arg2)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockTrackedObjectStoreGetBySHA256PrefixCall) Do(f func(context.Context, string) (io.ReadCloser, int64, error)) *MockTrackedObjectStoreGetBySHA256PrefixCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockTrackedObjectStoreGetBySHA256PrefixCall) DoAndReturn(f func(context.Context, string) (io.ReadCloser, int64, error)) *MockTrackedObjectStoreGetBySHA256PrefixCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // Kill mocks base method.
 func (m *MockTrackedObjectStore) Kill() {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
We recently added methods to the object store metadata service to retrieve an object's metadata by it's SHA prefix

Add a method to the object stores, using these, to get charm blobs themselves by their SHA prefix.

Whilst we're here in the objectstore, re-work the errors to use modern juju errors

Also, wire this through into the application service. Add a new method to the application service which queries the objectstore. 

## QA steps

Unit tests pass