### PR TITLE
chore: merge up 3.6 to  main

### DIFF
--- a/.github/workflows/docs-sphinx-python-dependency-build-checks.yml
+++ b/.github/workflows/docs-sphinx-python-dependency-build-checks.yml
@@ -11,9 +11,10 @@
 # succeed.
 name: Check and document build requirements for Sphinx venv
 on:
-  - push
-  - pull_request
-  - workflow_dispatch
+  schedule:
+    - cron: "0 2 * * 1,5" # Runs at 02:00 AM on every Monday and Friday.
+  workflow_dispatch:
+
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -22,7 +23,7 @@ concurrency:
 jobs:
   build:
     name: build
-    runs-on: ubuntu-latest
+    runs-on: [linux, self-hosted, x64, large, jammy]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/cmd/containeragent/unit/manifolds.go
+++ b/cmd/containeragent/unit/manifolds.go
@@ -57,6 +57,7 @@ import (
 	"github.com/juju/juju/internal/worker/uniter"
 	"github.com/juju/juju/internal/worker/units3caller"
 	"github.com/juju/juju/internal/worker/upgradestepsmachine"
+	"github.com/juju/juju/worker/caasprobebinder"
 )
 
 // manifoldsConfig allows specialisation of the result of Manifolds.
@@ -333,15 +334,17 @@ func Manifolds(config manifoldsConfig) dependency.Manifolds {
 
 		// Kubernetes probe handler responsible for reporting status for
 		// Kubernetes probes
-		caasProberName: ifNotDead(caasprober.Manifold(caasprober.ManifoldConfig{
+		caasProberName: caasprober.Manifold(caasprober.ManifoldConfig{
 			MuxName: probeHTTPServerName,
-			Providers: []string{
-				uniterName,
-			},
+		}),
+
+		caasUniterProberBinderName: ifNotDead(caasprobebinder.Manifold(caasprobebinder.ManifoldConfig{
+			ProberName:         caasProberName,
+			ProbeProviderNames: []string{uniterName},
 		})),
 
-		caasZombieProberName: ifDead(caasprober.Manifold(caasprober.ManifoldConfig{
-			MuxName: probeHTTPServerName,
+		caasZombieProberBinderName: ifDead(caasprobebinder.Manifold(caasprobebinder.ManifoldConfig{
+			ProberName: caasProberName,
 			DefaultProviders: map[string]probe.ProbeProvider{
 				"zombie-readiness": probe.ReadinessProvider(probe.Failure),
 			},
@@ -479,9 +482,10 @@ const (
 	migrationInactiveFlagName = "migration-inactive-flag"
 	migrationMinionName       = "migration-minion"
 
-	caasProberName       = "caas-prober"
-	caasZombieProberName = "caas-zombie-prober"
-	probeHTTPServerName  = "probe-http-server"
+	caasProberName             = "caas-prober"
+	caasZombieProberBinderName = "caas-zombie-prober-binder"
+	caasUniterProberBinderName = "caas-unit-prober-binder"
+	probeHTTPServerName        = "probe-http-server"
 
 	proxyConfigUpdaterName   = "proxy-config-updater"
 	loggingConfigUpdaterName = "logging-config-updater"

--- a/cmd/containeragent/unit/manifolds_test.go
+++ b/cmd/containeragent/unit/manifolds_test.go
@@ -36,44 +36,36 @@ func (s *ManifoldsSuite) TestManifoldNames(c *gc.C) {
 	manifolds := unit.Manifolds(config)
 	expectedKeys := []string{
 		"agent",
-		"api-config-watcher",
+		"api-address-updater",
 		"api-caller",
-		"s3-caller",
-		"uniter",
-		"log-sender",
-
+		"api-config-watcher",
+		"caas-prober",
+		"caas-unit-termination-worker",
+		"caas-unit-prober-binder",
+		"caas-units-manager",
+		"caas-zombie-prober-binder",
 		"charm-dir",
-		"leadership-tracker",
+		"dead-flag",
 		"hook-retry-strategy",
-
+		"leadership-tracker",
+		"log-sender",
+		"logging-config-updater",
 		"migration-fortress",
 		"migration-inactive-flag",
 		"migration-minion",
-
-		"proxy-config-updater",
-		"logging-config-updater",
-		"api-address-updater",
-
-		"caas-prober",
-		"probe-http-server",
-
-		"upgrader",
-		"upgrade-steps-runner",
-		"upgrade-steps-gate",
-		"upgrade-steps-flag",
-
-		"caas-unit-termination-worker",
-		"caas-units-manager",
-		"secret-drain-worker",
-
-		"caas-zombie-prober",
-
-		"dead-flag",
 		"not-dead-flag",
-
+		"probe-http-server",
+		"proxy-config-updater",
+		"s3-caller",
+		"secret-drain-worker",
 		"signal-handler",
 
 		"trace",
+		"uniter",
+		"upgrade-steps-flag",
+		"upgrade-steps-gate",
+		"upgrade-steps-runner",
+		"upgrader",
 	}
 	keys := make([]string, 0, len(manifolds))
 	for k := range manifolds {
@@ -89,41 +81,35 @@ func (s *ManifoldsSuite) TestManifoldNamesColocatedController(c *gc.C) {
 	manifolds := unit.Manifolds(config)
 	expectedKeys := []string{
 		"agent",
-		"api-config-watcher",
 		"api-caller",
-		"s3-caller",
+		"api-config-watcher",
 		"caas-prober",
-		"probe-http-server",
-		"uniter",
-		"log-sender",
-
+		"caas-unit-prober-binder",
+		"caas-unit-termination-worker",
+		"caas-units-manager",
+		"caas-zombie-prober-binder",
 		"charm-dir",
-		"leadership-tracker",
+		"dead-flag",
 		"hook-retry-strategy",
-
+		"leadership-tracker",
+		"log-sender",
+		"logging-config-updater",
 		"migration-fortress",
 		"migration-inactive-flag",
 		"migration-minion",
-
-		"proxy-config-updater",
-		"logging-config-updater",
-
-		"upgrader",
-		"upgrade-steps-runner",
-		"upgrade-steps-gate",
-		"upgrade-steps-flag",
-
-		"caas-unit-termination-worker",
-		"caas-units-manager",
-		"secret-drain-worker",
-		"caas-zombie-prober",
-
-		"dead-flag",
 		"not-dead-flag",
-
+		"probe-http-server",
+		"proxy-config-updater",
+		"s3-caller",
+		"secret-drain-worker",
 		"signal-handler",
 
 		"trace",
+		"uniter",
+		"upgrade-steps-flag",
+		"upgrade-steps-gate",
+		"upgrade-steps-runner",
+		"upgrader",
 	}
 	keys := make([]string, 0, len(manifolds))
 	for k := range manifolds {
@@ -140,6 +126,7 @@ func (*ManifoldsSuite) TestMigrationGuards(c *gc.C) {
 		"s3-caller",
 		"caas-prober",
 		"probe-http-server",
+		"caas-unit-prober-binder",
 		"log-sender",
 
 		"migration-fortress",
@@ -157,6 +144,7 @@ func (*ManifoldsSuite) TestMigrationGuards(c *gc.C) {
 		"not-dead-flag",
 		"signal-handler",
 		"caas-zombie-prober",
+		"caas-zombie-prober-binder",
 
 		"trace",
 	)
@@ -289,14 +277,6 @@ var expectedUnitManifoldsWithDependencies = map[string][]string{
 	},
 	"probe-http-server": {},
 	"caas-prober": {
-		"agent",
-		"api-caller",
-		"api-config-watcher",
-		"charm-dir",
-		"hook-retry-strategy",
-		"leadership-tracker",
-		"migration-fortress",
-		"migration-inactive-flag",
 		"probe-http-server",
 		"s3-caller",
 		"uniter",
@@ -342,10 +322,26 @@ var expectedUnitManifoldsWithDependencies = map[string][]string{
 		"api-config-watcher",
 		"not-dead-flag",
 	},
-	"caas-zombie-prober": {
+	"caas-unit-prober-binder": {
 		"agent",
 		"api-caller",
 		"api-config-watcher",
+		"caas-prober",
+		"charm-dir",
+		"hook-retry-strategy",
+		"leadership-tracker",
+		"migration-fortress",
+		"migration-inactive-flag",
+		"not-dead-flag",
+		"probe-http-server",
+		"s3-caller",
+		"uniter",
+	},
+	"caas-zombie-prober-binder": {
+		"agent",
+		"api-caller",
+		"api-config-watcher",
+		"caas-prober",
 		"dead-flag",
 		"probe-http-server",
 	},

--- a/internal/observability/probe/prober.go
+++ b/internal/observability/probe/prober.go
@@ -92,6 +92,14 @@ func ReadinessProvider(probe Prober) ProbeProvider {
 	})
 }
 
+// StartupProvider is a utility function for returning a ProbeProvider for the
+// provided startup probe.
+func StartupProvider(probe Prober) ProbeProvider {
+	return Provider(SupportedProbes{
+		ProbeStartup: probe,
+	})
+}
+
 // Probe implements Prober interface
 func (p ProberFn) Probe() (bool, error) {
 	return p()

--- a/internal/worker/caasprober/controller.go
+++ b/internal/worker/caasprober/controller.go
@@ -4,9 +4,12 @@
 package caasprober
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"net/http"
 	"strconv"
+	"sync/atomic"
 
 	jujuerrors "github.com/juju/errors"
 	"github.com/juju/worker/v4/catacomb"
@@ -22,6 +25,9 @@ type Mux interface {
 
 type Controller struct {
 	catacomb catacomb.Catacomb
+
+	mux    Mux
+	probes *CAASProbes
 }
 
 const (
@@ -33,11 +39,14 @@ const (
 
 // NewController constructs a new caas prober Controller.
 func NewController(probes *CAASProbes, mux Mux) (*Controller, error) {
-	c := &Controller{}
+	c := &Controller{
+		mux:    mux,
+		probes: probes,
+	}
 
 	if err := catacomb.Invoke(catacomb.Plan{
 		Site: &c.catacomb,
-		Work: c.makeLoop(probes, mux),
+		Work: c.loop,
 	}); err != nil {
 		return c, jujuerrors.Trace(err)
 	}
@@ -50,46 +59,38 @@ func (c *Controller) Kill() {
 	c.catacomb.Kill(nil)
 }
 
-// makeLoop is responsible for producing the loop needed to run as part of the
-// controller worker.
-func (c *Controller) makeLoop(
-	probes *CAASProbes,
-	mux Mux,
-) func() error {
-	return func() error {
-		if err := mux.AddHandler(
-			http.MethodGet,
-			k8sconstants.AgentHTTPPathLiveness,
-			ProbeHandler("liveness", probes.Liveness)); err != nil {
-			return jujuerrors.Trace(err)
-		}
-		defer mux.RemoveHandler(http.MethodGet, PathLivenessProbe)
-
-		if err := mux.AddHandler(
-			http.MethodGet,
-			k8sconstants.AgentHTTPPathReadiness,
-			ProbeHandler("readiness", probes.Readiness)); err != nil {
-			return jujuerrors.Trace(err)
-		}
-		defer mux.RemoveHandler(http.MethodGet, PathReadinessProbe)
-
-		if err := mux.AddHandler(
-			http.MethodGet,
-			k8sconstants.AgentHTTPPathStartup,
-			ProbeHandler("startup", probes.Startup)); err != nil {
-			return jujuerrors.Trace(err)
-		}
-		defer mux.RemoveHandler(http.MethodGet, PathStartupProbe)
-
-		select {
-		case <-c.catacomb.Dying():
-			return c.catacomb.ErrDying()
-		}
+func (c *Controller) loop() error {
+	if err := c.mux.AddHandler(
+		http.MethodGet,
+		k8sconstants.AgentHTTPPathLiveness,
+		ProbeHandler(probe.ProbeLiveness, c.probes)); err != nil {
+		return jujuerrors.Trace(err)
 	}
+	defer c.mux.RemoveHandler(http.MethodGet, PathLivenessProbe)
+
+	if err := c.mux.AddHandler(
+		http.MethodGet,
+		k8sconstants.AgentHTTPPathReadiness,
+		ProbeHandler(probe.ProbeReadiness, c.probes)); err != nil {
+		return jujuerrors.Trace(err)
+	}
+	defer c.mux.RemoveHandler(http.MethodGet, PathReadinessProbe)
+
+	if err := c.mux.AddHandler(
+		http.MethodGet,
+		k8sconstants.AgentHTTPPathStartup,
+		ProbeHandler(probe.ProbeStartup, c.probes)); err != nil {
+		return jujuerrors.Trace(err)
+	}
+	defer c.mux.RemoveHandler(http.MethodGet, PathStartupProbe)
+
+	<-c.catacomb.Dying()
+	return c.catacomb.ErrDying()
 }
 
 // ProbeHandler implements a http handler for the supplied probe and probe name.
-func ProbeHandler(name string, aggProbe *probe.Aggregate) http.Handler {
+func ProbeHandler(name probe.ProbeType, probes *CAASProbes) http.Handler {
+	var last atomic.Bool
 	return http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 		shouldDetailResponse := false
 		detailedVals, exists := req.URL.Query()[DetailedResponseQueryKey]
@@ -103,7 +104,16 @@ func ProbeHandler(name string, aggProbe *probe.Aggregate) http.Handler {
 			shouldDetailResponse = val
 		}
 
-		good, err := aggProbe.ProbeWithResultCallback(
+		aggProbe, ok := probes.ProbeAggregate(name)
+		if !ok {
+			http.Error(res, fmt.Sprintf("%s: probe %s",
+				http.StatusText(http.StatusNotImplemented), name),
+				http.StatusNotImplemented)
+			return
+		}
+
+		detail := &bytes.Buffer{}
+		good, n, err := aggProbe.ProbeWithResultCallback(
 			probe.ProbeResultCallback(func(probeKey string, val bool, err error) {
 				if !shouldDetailResponse {
 					return
@@ -116,22 +126,22 @@ func ProbeHandler(name string, aggProbe *probe.Aggregate) http.Handler {
 
 				if val {
 					// Print + on probe success
-					fmt.Fprintf(res, "+ ")
+					fmt.Fprintf(detail, "+ ")
 				} else {
 					// Print - on probe failure
-					fmt.Fprintf(res, "- ")
+					fmt.Fprintf(detail, "- ")
 				}
 
 				// Print the probe name
-				fmt.Fprintf(res, "%s", probeKey)
+				fmt.Fprintf(detail, "%s", probeKey)
 
 				// Print the error if one exists
 				if err != nil {
-					fmt.Fprintf(res, ": %s", err)
+					fmt.Fprintf(detail, ": %s", err)
 				}
 
 				// Finish the current line
-				fmt.Fprintf(res, "\n")
+				fmt.Fprintf(detail, "\n")
 			}),
 		)
 
@@ -140,12 +150,18 @@ func ProbeHandler(name string, aggProbe *probe.Aggregate) http.Handler {
 				http.StatusText(http.StatusNotImplemented), name),
 				http.StatusNotImplemented)
 			return
-		}
-		if err != nil {
+		} else if err != nil {
 			http.Error(res, fmt.Sprintf("%s: probe %s",
 				http.StatusText(http.StatusInternalServerError), name),
 				http.StatusInternalServerError)
 			return
+		}
+
+		// If no probers were consulted, return the last value.
+		if n == 0 {
+			good = last.Load()
+		} else {
+			last.Store(good)
 		}
 
 		if !good {
@@ -158,6 +174,9 @@ func ProbeHandler(name string, aggProbe *probe.Aggregate) http.Handler {
 		res.Header().Set("Content-Type", "text/plain; charset=utf-8")
 		res.WriteHeader(http.StatusOK)
 		fmt.Fprintf(res, "%s: probe %s", http.StatusText(http.StatusOK), name)
+		if shouldDetailResponse {
+			_, _ = io.Copy(res, detail)
+		}
 	})
 }
 

--- a/internal/worker/caasprober/controller_test.go
+++ b/internal/worker/caasprober/controller_test.go
@@ -17,15 +17,14 @@ import (
 	"github.com/juju/juju/internal/worker/caasprober"
 )
 
-type ControllerSuite struct {
-}
+type ControllerSuite struct{}
+
+var _ = gc.Suite(&ControllerSuite{})
 
 type dummyMux struct {
 	AddHandlerFunc    func(string, string, http.Handler) error
 	RemoveHandlerFunc func(string, string)
 }
-
-var _ = gc.Suite(&ControllerSuite{})
 
 func (d *dummyMux) AddHandler(i, j string, h http.Handler) error {
 	if d.AddHandlerFunc == nil {
@@ -95,9 +94,12 @@ func (s *ControllerSuite) TestControllerMuxRegistration(c *gc.C) {
 	}
 
 	probes := caasprober.NewCAASProbes()
-	probes.Liveness.Probes["test"] = probe.NotImplemented
-	probes.Readiness.Probes["test"] = probe.NotImplemented
-	probes.Startup.Probes["test"] = probe.NotImplemented
+	livenessAgg, _ := probes.ProbeAggregate(probe.ProbeLiveness)
+	livenessAgg.AddProber("test", probe.NotImplemented)
+	readinessAgg, _ := probes.ProbeAggregate(probe.ProbeReadiness)
+	readinessAgg.AddProber("test", probe.NotImplemented)
+	startupAgg, _ := probes.ProbeAggregate(probe.ProbeStartup)
+	startupAgg.AddProber("test", probe.NotImplemented)
 
 	controller, err := caasprober.NewController(probes, &mux)
 	c.Assert(err, jc.ErrorIsNil)
@@ -135,9 +137,12 @@ func (s *ControllerSuite) TestControllerNotImplemented(c *gc.C) {
 	}
 
 	probes := caasprober.NewCAASProbes()
-	probes.Liveness.Probes["test"] = probe.NotImplemented
-	probes.Readiness.Probes["test"] = probe.NotImplemented
-	probes.Startup.Probes["test"] = probe.NotImplemented
+	livenessAgg, _ := probes.ProbeAggregate(probe.ProbeLiveness)
+	livenessAgg.AddProber("test", probe.NotImplemented)
+	readinessAgg, _ := probes.ProbeAggregate(probe.ProbeReadiness)
+	readinessAgg.AddProber("test", probe.NotImplemented)
+	startupAgg, _ := probes.ProbeAggregate(probe.ProbeStartup)
+	startupAgg.AddProber("test", probe.NotImplemented)
 
 	controller, err := caasprober.NewController(probes, &mux)
 	c.Assert(err, jc.ErrorIsNil)
@@ -169,10 +174,12 @@ func (s *ControllerSuite) TestControllerProbeError(c *gc.C) {
 	})
 
 	probes := caasprober.NewCAASProbes()
-	probes.Liveness.Probes["test"] = probeErr
-	probes.Readiness.Probes["test"] = probeErr
-	probes.Startup.Probes["test"] = probeErr
-
+	livenessAgg, _ := probes.ProbeAggregate(probe.ProbeLiveness)
+	livenessAgg.AddProber("test", probeErr)
+	readinessAgg, _ := probes.ProbeAggregate(probe.ProbeReadiness)
+	readinessAgg.AddProber("test", probeErr)
+	startupAgg, _ := probes.ProbeAggregate(probe.ProbeStartup)
+	startupAgg.AddProber("test", probeErr)
 	controller, err := caasprober.NewController(probes, &mux)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -203,10 +210,12 @@ func (s *ControllerSuite) TestControllerProbeFail(c *gc.C) {
 	})
 
 	probes := caasprober.NewCAASProbes()
-	probes.Liveness.Probes["test"] = probeFail
-	probes.Readiness.Probes["test"] = probeFail
-	probes.Startup.Probes["test"] = probeFail
-
+	livenessAgg, _ := probes.ProbeAggregate(probe.ProbeLiveness)
+	livenessAgg.AddProber("test", probeFail)
+	readinessAgg, _ := probes.ProbeAggregate(probe.ProbeReadiness)
+	readinessAgg.AddProber("test", probeFail)
+	startupAgg, _ := probes.ProbeAggregate(probe.ProbeStartup)
+	startupAgg.AddProber("test", probeFail)
 	controller, err := caasprober.NewController(probes, &mux)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -233,9 +242,12 @@ func (s *ControllerSuite) TestControllerProbePass(c *gc.C) {
 	}
 
 	probes := caasprober.NewCAASProbes()
-	probes.Liveness.Probes["test"] = probe.Success
-	probes.Readiness.Probes["test"] = probe.Success
-	probes.Startup.Probes["test"] = probe.Success
+	livenessAgg, _ := probes.ProbeAggregate(probe.ProbeLiveness)
+	livenessAgg.AddProber("test", probe.Success)
+	readinessAgg, _ := probes.ProbeAggregate(probe.ProbeReadiness)
+	readinessAgg.AddProber("test", probe.Success)
+	startupAgg, _ := probes.ProbeAggregate(probe.ProbeStartup)
+	startupAgg.AddProber("test", probe.Success)
 
 	controller, err := caasprober.NewController(probes, &mux)
 	c.Assert(err, jc.ErrorIsNil)
@@ -256,8 +268,7 @@ func (s *ControllerSuite) TestControllerProbePassDetailed(c *gc.C) {
 			recorder := httptest.NewRecorder()
 			h.ServeHTTP(recorder, req)
 			c.Check(recorder.Result().StatusCode, gc.Equals, http.StatusOK)
-			c.Check(recorder.Body.String(), jc.HasPrefix, `+ test
-OK: probe`)
+			c.Check(recorder.Body.String(), gc.Matches, `(?m)OK: probe (liveness|readiness|startup)\+ test`)
 			waitGroup.Done()
 			return nil
 		},
@@ -265,9 +276,12 @@ OK: probe`)
 	}
 
 	probes := caasprober.NewCAASProbes()
-	probes.Liveness.Probes["test"] = probe.Success
-	probes.Readiness.Probes["test"] = probe.Success
-	probes.Startup.Probes["test"] = probe.Success
+	livenessAgg, _ := probes.ProbeAggregate(probe.ProbeLiveness)
+	livenessAgg.AddProber("test", probe.Success)
+	readinessAgg, _ := probes.ProbeAggregate(probe.ProbeReadiness)
+	readinessAgg.AddProber("test", probe.Success)
+	startupAgg, _ := probes.ProbeAggregate(probe.ProbeStartup)
+	startupAgg.AddProber("test", probe.Success)
 
 	controller, err := caasprober.NewController(probes, &mux)
 	c.Assert(err, jc.ErrorIsNil)
@@ -287,9 +301,8 @@ func (s *ControllerSuite) TestControllerProbeFailDetailed(c *gc.C) {
 			req := httptest.NewRequest(m, p+"?detailed=true", nil)
 			recorder := httptest.NewRecorder()
 			h.ServeHTTP(recorder, req)
-			c.Check(recorder.Result().StatusCode, gc.Equals, http.StatusOK)
-			c.Check(recorder.Body.String(), jc.HasPrefix, `- test: test error
-Internal Server Error: probe`)
+			c.Check(recorder.Result().StatusCode, gc.Equals, http.StatusInternalServerError)
+			c.Check(recorder.Body.String(), gc.Matches, `(?m)Internal Server Error: probe (liveness|readiness|startup)`)
 			waitGroup.Done()
 			return nil
 		},
@@ -301,10 +314,12 @@ Internal Server Error: probe`)
 	})
 
 	probes := caasprober.NewCAASProbes()
-	probes.Liveness.Probes["test"] = probeFail
-	probes.Readiness.Probes["test"] = probeFail
-	probes.Startup.Probes["test"] = probeFail
-
+	livenessAgg, _ := probes.ProbeAggregate(probe.ProbeLiveness)
+	livenessAgg.AddProber("test", probeFail)
+	readinessAgg, _ := probes.ProbeAggregate(probe.ProbeReadiness)
+	readinessAgg.AddProber("test", probeFail)
+	startupAgg, _ := probes.ProbeAggregate(probe.ProbeStartup)
+	startupAgg.AddProber("test", probeFail)
 	controller, err := caasprober.NewController(probes, &mux)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/internal/worker/caasprober/probe.go
+++ b/internal/worker/caasprober/probe.go
@@ -4,22 +4,32 @@
 package caasprober
 
 import (
+	"sync"
+
 	"github.com/juju/juju/internal/observability/probe"
 )
 
 // CaasProbes provides a private internal implementation of CAASProbes.
 type CAASProbes struct {
-	Liveness  *probe.Aggregate
-	Readiness *probe.Aggregate
-	Startup   *probe.Aggregate
+	mut    sync.Mutex
+	probes map[probe.ProbeType]*probe.Aggregate
 }
 
 // NewCAASProbes is responsible for constructing a new CAASProbes struct with
 // its members initialised.
 func NewCAASProbes() *CAASProbes {
 	return &CAASProbes{
-		Liveness:  probe.NewAggregate(),
-		Readiness: probe.NewAggregate(),
-		Startup:   probe.NewAggregate(),
+		probes: map[probe.ProbeType]*probe.Aggregate{
+			probe.ProbeLiveness:  probe.NewAggregate(),
+			probe.ProbeReadiness: probe.NewAggregate(),
+			probe.ProbeStartup:   probe.NewAggregate(),
+		},
 	}
+}
+
+func (p *CAASProbes) ProbeAggregate(name probe.ProbeType) (*probe.Aggregate, bool) {
+	p.mut.Lock()
+	defer p.mut.Unlock()
+	probe, ok := p.probes[name]
+	return probe, ok
 }

--- a/tests/suites/cli/display_clouds.sh
+++ b/tests/suites/cli/display_clouds.sh
@@ -90,7 +90,7 @@ EOF
 		exit 1
 	fi
 
-	CLOUD_LIST=$(JUJU_DATA="${TEST_DIR}/juju" juju show-cloud finfolk-vmaas --format json --client | jq -S 'with_entries((select(.value!= null)))')
+	CLOUD_LIST=$(JUJU_DATA="${TEST_DIR}/juju" juju show-cloud finfolk-vmaas --format json --client | jq -S '.[] | with_entries((select(.value!= null)))')
 	EXPECTED=$(
 		cat <<'EOF' | jq -S
 	{

--- a/worker/caasprobebinder/doc.go
+++ b/worker/caasprobebinder/doc.go
@@ -1,0 +1,5 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package caasprobebinder exists to bind probe providers to the caasprober.
+package caasprobebinder

--- a/worker/caasprobebinder/manifold.go
+++ b/worker/caasprobebinder/manifold.go
@@ -1,0 +1,70 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasprobebinder
+
+import (
+	"maps"
+
+	"github.com/juju/errors"
+	"github.com/juju/worker/v3"
+	"github.com/juju/worker/v3/dependency"
+
+	"github.com/juju/juju/observability/probe"
+	"github.com/juju/juju/worker/caasprober"
+)
+
+// ManifoldConfig is the configuration used to setup a new caasprober.
+type ManifoldConfig struct {
+	// ProberName is the name of the caasprober worker to get from the
+	// dependency engine.
+	ProberName string
+
+	// ProbeProviderNames is a list of probe providers to fetch from the
+	// dependency engine.
+	ProbeProviderNames []string
+
+	// DefaultProviders is a list of probe providers that are given to this
+	// worker at instantiation and not fetched from the dependency engine.
+	DefaultProviders map[string]probe.ProbeProvider
+}
+
+// Manifold returns a new manifold for a caasprobebinder worker.
+func Manifold(config ManifoldConfig) dependency.Manifold {
+	return dependency.Manifold{
+		Inputs: append([]string{config.ProberName}, config.ProbeProviderNames...),
+		Start:  config.Start,
+	}
+}
+
+func (c ManifoldConfig) Start(context dependency.Context) (worker.Worker, error) {
+	if err := c.Validate(); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	var probes *caasprober.CAASProbes
+	if err := context.Get(c.ProberName, &probes); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	providers := maps.Clone(c.DefaultProviders)
+	if providers == nil {
+		providers = make(map[string]probe.ProbeProvider)
+	}
+	for _, k := range c.ProbeProviderNames {
+		var provider probe.ProbeProvider
+		if err := context.Get(k, &provider); err != nil {
+			return nil, errors.Trace(err)
+		}
+		providers[k] = provider
+	}
+
+	return NewProbeBinder(probes, providers)
+}
+
+func (c ManifoldConfig) Validate() error {
+	if c.ProberName == "" {
+		return errors.NotValidf("empty prober name")
+	}
+	return nil
+}

--- a/worker/caasprobebinder/package_test.go
+++ b/worker/caasprobebinder/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasprobebinder_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func Test(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/worker/caasprobebinder/probebinder.go
+++ b/worker/caasprobebinder/probebinder.go
@@ -1,0 +1,61 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasprobebinder
+
+import (
+	"github.com/juju/errors"
+	"github.com/juju/worker/v3/catacomb"
+
+	"github.com/juju/juju/observability/probe"
+	"github.com/juju/juju/worker/caasprober"
+)
+
+// ProbeBinder is a worker that binds a set of probe providers
+// onto a caasprober worker.
+type ProbeBinder struct {
+	catacomb catacomb.Catacomb
+
+	probes    *caasprober.CAASProbes
+	providers map[string]probe.ProbeProvider
+}
+
+// NewProbeBinder constructs a new caas probe binder worker.
+func NewProbeBinder(probes *caasprober.CAASProbes, providers map[string]probe.ProbeProvider) (*ProbeBinder, error) {
+	pb := &ProbeBinder{
+		probes:    probes,
+		providers: providers,
+	}
+	if err := catacomb.Invoke(catacomb.Plan{
+		Site: &pb.catacomb,
+		Work: pb.loop,
+	}); err != nil {
+		return pb, errors.Trace(err)
+	}
+	return pb, nil
+}
+
+// Kill implements worker.Kill
+func (c *ProbeBinder) Kill() {
+	c.catacomb.Kill(nil)
+}
+
+// loop adds all the probers to the probe aggregates and
+// removes them when the worker dies.
+func (c *ProbeBinder) loop() error {
+	for id, provider := range c.providers {
+		for k, v := range provider.SupportedProbes() {
+			if agg, ok := c.probes.ProbeAggregate(k); ok {
+				agg.AddProber(id, v)
+				defer agg.RemoveProber(id)
+			}
+		}
+	}
+	<-c.catacomb.Dying()
+	return c.catacomb.ErrDying()
+}
+
+// Wait implements worker.Wait
+func (c *ProbeBinder) Wait() error {
+	return c.catacomb.Wait()
+}

--- a/worker/caasprobebinder/probebinder_test.go
+++ b/worker/caasprobebinder/probebinder_test.go
@@ -1,0 +1,61 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package caasprobebinder_test
+
+import (
+	"time"
+
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/worker/v3/workertest"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/observability/probe"
+	"github.com/juju/juju/testing"
+	"github.com/juju/juju/worker/caasprobebinder"
+	"github.com/juju/juju/worker/caasprober"
+)
+
+type binderSuite struct{}
+
+var _ = gc.Suite(&binderSuite{})
+
+func (s *binderSuite) TestBindingUnbinding(c *gc.C) {
+	probes := caasprober.NewCAASProbes()
+	worker, err := caasprobebinder.NewProbeBinder(probes, map[string]probe.ProbeProvider{
+		"a": probe.LivenessProvider(probe.Failure),
+		"b": probe.ReadinessProvider(probe.Failure),
+		"c": probe.StartupProvider(probe.Failure),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	checkAdded := func(pt probe.ProbeType) {
+		for i := 0; i < 10; i++ {
+			agg, ok := probes.ProbeAggregate(pt)
+			c.Assert(ok, jc.IsTrue)
+			ok, n, err := agg.Probe()
+			c.Assert(err, jc.ErrorIsNil)
+			if ok == false && n == 1 {
+				return
+			}
+			time.Sleep(testing.ShortWait)
+		}
+		c.Fatalf("failed to wait for probe %s to be registered", pt)
+	}
+	checkAdded(probe.ProbeLiveness)
+	checkAdded(probe.ProbeReadiness)
+	checkAdded(probe.ProbeStartup)
+
+	workertest.CleanKill(c, worker)
+
+	checkRemoved := func(pt probe.ProbeType) {
+		agg, ok := probes.ProbeAggregate(pt)
+		c.Assert(ok, jc.IsTrue)
+		ok, n, err := agg.Probe()
+		c.Assert(err, jc.ErrorIsNil)
+		c.Assert(ok, jc.IsTrue)
+		c.Assert(n, gc.Equals, 0)
+	}
+	checkRemoved(probe.ProbeLiveness)
+	checkRemoved(probe.ProbeReadiness)
+	checkRemoved(probe.ProbeStartup)
+}


### PR DESCRIPTION
Merge up 3.6 to main, this PR contains:
- #18427 from Aflynn50
- #18475 from Aflynn50
- #18473 from Aflynn50
- #18471 from hpidcock
  - #18463 from hpidcock
  - #18468 from hpidcock
    Conflicts:
     - CONFLICT (content): Merge conflict in cmd/containeragent/unit/manifolds.go
       CONFLICT (content): Merge conflict in cmd/containeragent/unit/manifolds_test.go
       CONFLICT (content): Merge conflict in internal/worker/caasprober/controller.go
       CONFLICT (content): Merge conflict in internal/worker/caasprober/manifold.go
       CONFLICT (content): Merge conflict in internal/worker/caasprober/probe.go
       I fixed up the 4.0 version to use the map for the liveness/readiness/startup types, and switched from editing the map directly to using the `AddProbe` method in the `gatherCAASProbes` method that was introduced in 4.0. Apart from these changes, the rest were trivial to resolve (package name conflicts and such). My work should be checked by @hpidcock 




<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://github.com/juju/juju/blob/main/doc/conventional-commits.md
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

<!-- 

Describe steps to verify that the change works. 

If you're changing any of the facades, you need to ensure that you've tested
a model migration from 3.6 to 4.0 and from 4.0 to 4.0.

The following steps are a good starting point:

 1. Bootstrap a 3.6 controller and deploy a charm.

```sh
$ juju bootstrap lxd src36
$ juju add-model moveme1
$ juju deploy juju-qa-test
```

 2. Bootstrap a 4.0 controller with the changes and migrate the model.

```sh
$ juju bootstrap lxd dst40
$ juju migrate src36:moveme1 dst40
$ juju add-unit juju-qa-test
```

 3. Verify no errors exist in the model logs for the agents. If there are
    errors, this is a bug and should be fixed before merging. The fix can
    either be applied to the 4.0 branch (preferable) or the 3.6 branch, though
    that needs to be discussed with the team.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme1
```

    4. We also need to test a model migration from 4.0 to 4.0.

```sh
$ juju bootstrap lxd src40
$ juju add-model moveme2
$ juju deploy juju-qa-test
```

```sh
$ juju migrate src40:moveme2 dst40
$ juju add-unit juju-qa-test
```

    5. Verify that there are no errors in the controller or model logs.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme2
```

-->

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/

**Jira card:** JUJU-

