### PR TITLE
fix: unqualified login via external provider

### DIFF
--- a/juju/api.go
+++ b/juju/api.go
@@ -119,7 +119,13 @@ func NewAPIConnection(args NewAPIConnectionParams) (_ api.Connection, err error)
 
 	// If the account details are set, ensure that the user we've logged in as
 	// matches the user we expected to log in as.
-	if args.AccountDetails != nil && st.AuthTag() != nil && args.AccountDetails.User != st.AuthTag().Id() {
+	// This only applies if the user was explicitly set.
+	// Logging in via an external auth provider is allowed with specifying a
+	// user in the args - that comes from the provider.
+	if args.AccountDetails != nil &&
+		args.AccountDetails.User != "" &&
+		st.AuthTag() != nil &&
+		args.AccountDetails.User != st.AuthTag().Id() {
 		return nil, errors.Unauthorizedf("attempted login as %q for user %q", st.AuthTag().Id(), args.AccountDetails.User)
 	}
 


### PR DESCRIPTION
The change under #17667 broke the case of using an unqualified `juju login` with an external provider. 

This fixes it. 

We will still compare the logged in user with an explicitly specified user argument.

## QA steps

- `juju bootstrap lxd lxd --config identity-url=https://api.jujucharms.com/identity --config allow-model-access=true`
- `juju grant <your LP ID>@external superuser`
- `juju change-user-password admin`
- `juju logout`
- `juju login`
- Do the SSO dance and observe that you were logged in to the controller as your external user.

## Documentation changes

None.

