### PR TITLE
fix(bootstrap): use the correct charm ReferenceName

### DIFF
--- a/internal/bootstrap/deployer.go
+++ b/internal/bootstrap/deployer.go
@@ -392,7 +392,7 @@ func (b *baseDeployer) AddControllerApplication(ctx context.Context, curl string
 		bootstrap.ControllerApplicationName,
 		ch, origin,
 		applicationservice.AddApplicationArgs{
-			ReferenceName: bootstrap.ControllerApplicationName,
+			ReferenceName: bootstrap.ControllerCharmName,
 			DownloadInfo: &applicationcharm.DownloadInfo{
 				// We do have all the information we need to download the charm,
 				// we should fill this in with the correct information.

--- a/internal/bootstrap/deployer_test.go
+++ b/internal/bootstrap/deployer_test.go
@@ -282,7 +282,7 @@ func (s *deployerSuite) TestAddControllerApplication(c *gc.C) {
 			},
 		},
 		applicationservice.AddApplicationArgs{
-			ReferenceName: bootstrap.ControllerApplicationName,
+			ReferenceName: bootstrap.ControllerCharmName,
 			DownloadInfo: &applicationcharm.DownloadInfo{
 				Provenance: applicationcharm.ProvenanceBootstrap,
 			},


### PR DESCRIPTION
We accidentally set this to 'ControllerApplicationName' which is 'controller', when we want the charm name, 'ControllerCharmName', which is set to 'juju-controller'.

## QA steps

```
juju bootstrap lxd lxd
```