### PR TITLE
chore: add github issue templates for bugs, features and docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,58 @@
+name: Bug Report
+description: Create a report to help us improve Juju
+labels:
+  - kind/bug
+  - needs-triage
+body:
+  - type: textarea
+    id: Description
+    attributes:
+      label: Description
+      description: "Please describe the bug for us: "
+      placeholder: ex. "`juju status` returns the error `not found`"
+    validations:
+      required: true
+
+  - type: input
+    id: Version
+    attributes:
+      label: Juju version
+      description: "What version of Juju are you using?"
+      placeholder: ex. 3.6.1
+    validations:
+      required: true
+
+  - type: input
+    id: Cloud
+    attributes:
+      label: Cloud
+      description: What cloud are you using?
+      placeholder: ex. AWS
+    validations:
+      required: false
+
+  - type: textarea
+    id: Expected-Behaviour
+    attributes:
+      label: Expected behaviour
+      description: "Describe of what you expected to happen: "
+      placeholder: ex. "`juju status` should tell me what was not found"
+    validations:
+      required: true
+
+  - type: textarea
+    id: Reproduction-Steps
+    attributes:
+      label: "Reproduce / Test"
+      description: "Steps to reproduce the behaviour: "
+      placeholder: ex. "juju bootstrap aws && juju status"
+    validations:
+      required: false
+
+  - type: textarea
+    id: Info-Notes
+    attributes:
+      label: "Notes & References"
+      description: "Please add relevant notes, other related issues/PRs, anything to help diagnose and solve the issue."
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/doc-issue.yml
+++ b/.github/ISSUE_TEMPLATE/doc-issue.yml
@@ -1,0 +1,31 @@
+name: Documentation issue
+description: Highlight a documentation issue
+labels:
+  - kind/doc
+  - needs-triage
+body:
+  - type: textarea
+    id: Inquiry
+    attributes:
+      label: Inquiry
+      description: "Describe what you were looking for in the documentation: "
+      placeholder: ex. "How to bootstrap onto AWS."
+    validations:
+      required: true
+
+  - type: textarea
+    id: Improvement
+    attributes:
+      label: Improvement
+      description: "Describe what improvement you would like to see: "
+      placeholder: ex. "That there is a document the describes bootstraping AWS and links to recommended configuration for production use."
+    validations:
+      required: false
+
+  - type: textarea
+    id: Info-Notes
+    attributes:
+      label: "Notes & References"
+      description: "Please add relevant notes, other related issues/PRs, anything else to help improve the documentation."
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,31 @@
+name: Feature Request
+description: Suggest a new feature for Juju
+labels:
+  - kind/feature
+  - needs-triage
+body:
+  - type: textarea
+    id: Problem-Description
+    attributes:
+      label: Problem description
+      description: "Describe the problem/use-case: "
+      placeholder: ex. "I need to be able to see the local time on each machine."
+    validations:
+      required: true
+
+  - type: textarea
+    id: Desired-Solution
+    attributes:
+      label: Desired solution
+      description: "Describe an acceptable solution: "
+      placeholder: ex. "`juju status` could return the current time reported by each machine."
+    validations:
+      required: false
+
+  - type: textarea
+    id: Info-Notes
+    attributes:
+      label: "Notes & References"
+      description: "Please add relevant notes, other related issues/PRs, anything to help build a solution."
+    validations:
+      required: false


### PR DESCRIPTION
This adds an issue template for the three main expected issues raised for Juju, once we turn on issues.

You can try them out [here](https://github.com/juju/bot-playground/issues/new/choose).