### PR TITLE
fix: do not set provider addresses for manually provisioned machines

### DIFF
--- a/environs/manual/sshprovisioner/provisioner_test.go
+++ b/environs/manual/sshprovisioner/provisioner_test.go
@@ -95,15 +95,19 @@ func (s *provisionerSuite) TestProvisionMachine(c *gc.C) {
 			c.Assert(machineId, gc.Equals, "")
 		} else {
 			c.Assert(err, jc.ErrorIsNil)
-			c.Assert(machineId, gc.Not(gc.Equals), "")
+			c.Check(machineId, gc.Not(gc.Equals), "")
 			// machine ID will be incremented. Even though we failed and the
 			// machine is removed, the ID is not reused.
-			c.Assert(machineId, gc.Equals, fmt.Sprint(i+1))
+			c.Check(machineId, gc.Equals, fmt.Sprint(i+1))
+
 			m, err := s.State.Machine(machineId)
 			c.Assert(err, jc.ErrorIsNil)
+			c.Check(m.Addresses(), gc.HasLen, 0)
+
 			instanceId, err := m.InstanceId()
 			c.Assert(err, jc.ErrorIsNil)
-			c.Assert(instanceId, gc.Equals, instance.Id("manual:"+hostname))
+
+			c.Check(instanceId, gc.Equals, instance.Id("manual:"+hostname))
 		}
 	}
 

--- a/environs/manual/sshprovisioner/sshprovisioner.go
+++ b/environs/manual/sshprovisioner/sshprovisioner.go
@@ -222,11 +222,6 @@ func gatherMachineParams(hostname string) (*params.AddMachineParams, error) {
 		return nil, err
 	}
 
-	addr, err := manual.HostAddress(hostname)
-	if err != nil {
-		return nil, errors.Annotatef(err, "failed to compute public address for %q", hostname)
-	}
-
 	provisioned, err := checkProvisioned(hostname)
 	if err != nil {
 		return nil, errors.Annotatef(err, "error checking if provisioned")
@@ -260,7 +255,6 @@ func gatherMachineParams(hostname string) (*params.AddMachineParams, error) {
 		HardwareCharacteristics: hc,
 		InstanceId:              instanceId,
 		Nonce:                   nonce,
-		Addrs:                   params.FromProviderAddresses(addr),
 		Jobs:                    []model.MachineJob{model.JobHostUnits},
 	}
 	return machineParams, nil


### PR DESCRIPTION
Manually provisioned machines set the `addresses` field of the initial machine document to the address for the host that was supplied in the `add-machine` command.

Because manually provisioned machines are never updated by the instance-poller, this address will not reflect space changes in the model.

In turn, when listing machine addresses, these (provider) addresses supersede those that come from `machine-addresses` ++which may have correct space decoration++.

This was already fixed for manual _bootstrap_ under https://github.com/juju/juju/pull/17455.

Failure to also fix for subsequent machines was overlooked, and now fixed by this patch.

## QA steps

- With this patch, provision any manual machine (`juju add-machine ssh:ubuntu@<IP>`).
- Connect to mongo and check that the machine document has a zero-length `addresses` field.

## Documentation changes

None.

## Links

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2091088

