### PR TITLE
fix: google model destruction when missing model firewall

### DIFF
--- a/provider/gce/google/conn_network.go
+++ b/provider/gce/google/conn_network.go
@@ -218,7 +218,13 @@ func (gce Connection) ClosePorts(target string, rules corefirewall.IngressRules)
 
 // RemoveFirewall removes the named firewall from the project.
 func (gce Connection) RemoveFirewall(fwname string) error {
-	return gce.service.RemoveFirewall(gce.projectID, fwname)
+	err := gce.service.RemoveFirewall(gce.projectID, fwname)
+	if IsNotFound(err) {
+		return nil
+	} else if err != nil {
+		return err
+	}
+	return nil
 }
 
 // Subnetworks returns the subnets available in this region.


### PR DESCRIPTION
#18463 added clean-up of per model firewalls on google cloud based models.
Since model firewalls are not always created or they were already deleted, it
would cause google cloud based models to fail in destruction.

## QA steps

TODO

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/

**Jira card:** JUJU-

