### PR TITLE
refactor(charm): remove SetDiskRevision

### DIFF
--- a/api/client/charms/localcharmclient.go
+++ b/api/client/charms/localcharmclient.go
@@ -63,22 +63,6 @@ func (c *LocalCharmClient) AddLocalCharm(curl *charm.URL, ch charm.Charm, force 
 	// Package the charm for uploading.
 	var archive *os.File
 	switch ch := ch.(type) {
-	case *charm.CharmDir:
-		var err error
-		if archive, err = os.CreateTemp("", "charm"); err != nil {
-			return nil, errors.Annotate(err, "cannot create temp file")
-		}
-		defer func() {
-			_ = archive.Close()
-			_ = os.Remove(archive.Name())
-		}()
-
-		if err := ch.ArchiveTo(archive); err != nil {
-			return nil, errors.Annotate(err, "cannot repackage charm")
-		}
-		if _, err := archive.Seek(0, os.SEEK_SET); err != nil {
-			return nil, errors.Annotate(err, "cannot rewind packaged charm")
-		}
 	case *charm.CharmArchive:
 		var err error
 		if archive, err = os.Open(ch.Path); err != nil {
@@ -86,7 +70,7 @@ func (c *LocalCharmClient) AddLocalCharm(curl *charm.URL, ch charm.Charm, force 
 		}
 		defer archive.Close()
 	default:
-		return nil, errors.Errorf("unknown charm type %T", ch)
+		return nil, errors.Errorf("unsupported charm type %T", ch)
 	}
 
 	anyHooksOrDispatch, err := hasHooksOrDispatch(archive.Name())

--- a/api/client/charms/localcharmclient_test.go
+++ b/api/client/charms/localcharmclient_test.go
@@ -71,16 +71,13 @@ func (s *addCharmSuite) TestAddLocalCharm(c *gc.C) {
 
 	// Upload a charm directory with changed revision.
 	resp.Header.Set("Juju-Curl", "local:quantal/dummy-42")
-	charmDir := testcharms.Repo.ClonedDir(c.MkDir(), "dummy")
-	err = charmDir.SetDiskRevision(42)
-	c.Assert(err, jc.ErrorIsNil)
-	savedURL, err = client.AddLocalCharm(curl, charmDir, false, vers)
+	savedURL, err = client.AddLocalCharm(curl, charmArchive, false, vers)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(savedURL.Revision, gc.Equals, 42)
 
 	// Upload a charm directory again, revision should be bumped.
 	resp.Header.Set("Juju-Curl", "local:quantal/dummy-43")
-	savedURL, err = client.AddLocalCharm(curl, charmDir, false, vers)
+	savedURL, err = client.AddLocalCharm(curl, charmArchive, false, vers)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(savedURL.String(), gc.Equals, curl.WithRevision(43).String())
 }
@@ -268,7 +265,7 @@ func (s *addCharmSuite) TestAddLocalCharmDefinitelyWithHooks(c *gc.C) {
 	c.Assert(savedCURL.String(), gc.Equals, curl.String())
 }
 
-func (s *addCharmSuite) testCharm(c *gc.C) (*charm.URL, charm.Charm) {
+func (s *addCharmSuite) testCharm(c *gc.C) (*charm.URL, *charm.CharmArchive) {
 	charmArchive := testcharms.Repo.CharmArchive(c.MkDir(), "dummy")
 	curl := charm.MustParseURL(
 		fmt.Sprintf("local:quantal/%s-%d", charmArchive.Meta().Name, charmArchive.Revision()),

--- a/cmd/juju/application/refresh_test.go
+++ b/cmd/juju/application/refresh_test.go
@@ -669,10 +669,13 @@ func (s *RefreshSuite) TestRespectsLocalRevisionWhenPossible(c *gc.C) {
 	s.charmAPIClient.charmOrigin = commoncharm.Origin{Base: corebase.MustParseBaseFromString("ubuntu@18.04")}
 
 	myriakPath := testcharms.RepoWithSeries("bionic").ClonedDirPath(c.MkDir(), "riak")
-	dir, err := charm.ReadCharmDir(myriakPath)
+
+	// Set the disk revision to 42.
+	revFile, err := os.OpenFile(filepath.Join(myriakPath, "revision"), os.O_CREATE|os.O_WRONLY, 0666)
 	c.Assert(err, jc.ErrorIsNil)
-	rev := 42
-	err = dir.SetDiskRevision(rev)
+	_, err = revFile.WriteString("42")
+	c.Check(err, jc.ErrorIsNil)
+	err = revFile.Close()
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, err = s.runRefresh(c, "riak", "--path", s.archivePath(c, myriakPath))
@@ -686,7 +689,7 @@ func (s *RefreshSuite) TestRespectsLocalRevisionWhenPossible(c *gc.C) {
 			Origin: commoncharm.Origin{
 				Base:     s.charmAPIClient.charmOrigin.Base,
 				Source:   "local",
-				Revision: &rev,
+				Revision: ptr(42),
 			},
 		},
 		ConfigSettings:   map[string]string{},

--- a/internal/charm/charmbase.go
+++ b/internal/charm/charmbase.go
@@ -74,10 +74,3 @@ func (c *charmBase) Manifest() *Manifest {
 func (c *charmBase) SetVersion(version string) {
 	c.version = version
 }
-
-// setRevision changes the charm revision. This affects
-// the revision reported by Revision and the revision of the
-// charm created.
-func (c *charmBase) setRevision(revision int) {
-	c.revision = revision
-}

--- a/internal/charm/charmdir.go
+++ b/internal/charm/charmdir.go
@@ -167,19 +167,6 @@ func (dir *CharmDir) join(parts ...string) string {
 	return filepath.Join(parts...)
 }
 
-// SetDiskRevision does the same as SetRevision but also changes
-// the revision file in the charm directory.
-func (dir *CharmDir) SetDiskRevision(revision int) error {
-	dir.setRevision(revision)
-	file, err := os.OpenFile(dir.join("revision"), os.O_WRONLY|os.O_CREATE, 0644)
-	if err != nil {
-		return err
-	}
-	_, err = file.Write([]byte(strconv.Itoa(revision)))
-	file.Close()
-	return err
-}
-
 // resolveSymlinkedRoot returns the target destination of a
 // charm root directory if the root directory is a symlink.
 func resolveSymlinkedRoot(rootPath string) (string, error) {

--- a/internal/charm/charmdir_test.go
+++ b/internal/charm/charmdir_test.go
@@ -338,34 +338,3 @@ func (s *CharmDirSuite) TestDirRevisionFile(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "invalid revision file")
 	c.Assert(dir, gc.IsNil)
 }
-
-func (s *CharmDirSuite) TestDirSetRevision(c *gc.C) {
-	path := cloneDir(c, charmDirPath(c, "dummy"))
-	dir, err := charm.ReadCharmDir(path)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(dir.Revision(), gc.Equals, 1)
-	dir.SetDiskRevision(42)
-	c.Assert(dir.Revision(), gc.Equals, 42)
-
-	var b bytes.Buffer
-	err = dir.ArchiveTo(&b)
-	c.Assert(err, jc.ErrorIsNil)
-
-	archive, err := charm.ReadCharmArchiveBytes(b.Bytes())
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(archive.Revision(), gc.Equals, 42)
-}
-
-func (s *CharmDirSuite) TestDirSetDiskRevision(c *gc.C) {
-	charmDir := cloneDir(c, charmDirPath(c, "dummy"))
-	dir, err := charm.ReadCharmDir(charmDir)
-	c.Assert(err, jc.ErrorIsNil)
-
-	c.Assert(dir.Revision(), gc.Equals, 1)
-	dir.SetDiskRevision(42)
-	c.Assert(dir.Revision(), gc.Equals, 42)
-
-	dir, err = charm.ReadCharmDir(charmDir)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(dir.Revision(), gc.Equals, 42)
-}

--- a/internal/worker/uniter/charm/charm_test.go
+++ b/internal/worker/uniter/charm/charm_test.go
@@ -63,8 +63,6 @@ func (br *bundleReader) AddCustomBundle(c *gc.C, url *jujucharm.URL, customize f
 	}
 	dir, err := jujucharm.ReadCharmDir(dirpath)
 	c.Assert(err, jc.ErrorIsNil)
-	err = dir.SetDiskRevision(url.Revision)
-	c.Assert(err, jc.ErrorIsNil)
 	bunpath := filepath.Join(base, "bundle")
 	file, err := os.Create(bunpath)
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
We have recently decided to make charms immutable, especially their revisions. We made "SetRevision" private.

However, we still exposed "SetDiskRevision", on CharmDir which did the same thing (as well as writing the new revision to the dir revision file).

In some places, this was just used as a proxy to set the revision as usual.

Now that we don't repackage charms on upload, instead relying on therevision in metadata, there are very few places we reasonable need to set the charm revision on disk. Even tests.

These places are limited to how we deal with local charm uploads, because we fall back the the hard-coded revision in the archive if we don't supply a revision in the charm url.

Refactor tests to remove tautological calls to SetDiskRevision. In the client/api tests where we do need this, explicitly write the revision to disk ourselves before the charm is parsed.

As a flyby, since it's closely connected, removed unsupported code paths in the localcharmclient, where we process charm dirs for local upload. We no longer support deploying local charms from directory.

## QA steps

Unit tests pass

```
$ mkdir ubuntu
$ cd ubuntu
$ juju download ubuntu
$ unzip *
$ cd ..
$ juju deploy ./ubuntu
ERROR attempting to deploy "./ubuntu": deploying from directory not supported
```