### PR TITLE
test: building dqlite for s390x and ppc64el

### DIFF
--- a/scripts/dqlite/scripts/dqlite/dqlite-install.sh
+++ b/scripts/dqlite/scripts/dqlite/dqlite-install.sh
@@ -10,6 +10,8 @@ sha() {
 	case ${BUILD_ARCH} in
 		amd64) echo "28d35a2c524f96df872ef2bb70e537170fac43985e6d260439c8cbcc80aa728b" ;;
 		arm64) echo "d68a758d0d4c6f514d35ea6190f14f3e41b6f67564e1f579ccb0a63f13e1a220" ;;
+		s390x) echo "8561238d7cdc2036fee321b7f8f1b563500325b4b1ed172002a56aca79ddb936" ;;
+		ppc64le) echo "950f55a4aa10a7209ede86cf4c023ec1dc79a31317f9e6d5378d7897beb26b35" ;;
 		*) { echo "Unsupported arch ${BUILD_ARCH}."; exit 1; } ;;
 	esac
 }


### PR DESCRIPTION
Both s390x and ppc64el were removed to allow us to progress with the update of dqlite and give us time to figure out how to fix the other architectures.

The issue was that the templating in Jenkins had changed, and we could no longer encode the arch correctly. This was fixed in Jenkins directly, and it allows us to build the other two arches.


## QA steps

This is difficult, you have to land this then watch for https://jenkins.juju.canonical.com/job/ci-build-juju/ green on this commit.