### PR TITLE
fix(model): change destroy model bash test

### DIFF
--- a/cmd/juju/model/destroy.go
+++ b/cmd/juju/model/destroy.go
@@ -67,7 +67,7 @@ var destroyDoc = `
 Destroys the specified model. This will result in the non-recoverable
 removal of all the units operating in the model and any resources stored
 there. Due to the irreversible nature of the command, it will prompt for
-confirmation (unless overridden with the '-y' option) before taking any
+confirmation (unless overridden with the '--no-prompt' option) before taking any
 action.
 
 If there is persistent storage in any of the models managed by the

--- a/tests/suites/model/destroy.sh
+++ b/tests/suites/model/destroy.sh
@@ -12,23 +12,27 @@ run_model_destroy() {
 	ensure "model-destroy" "${file}"
 
 	echo "Ensure current model is 'model-destroy'"
-	juju models --format json | jq -r '."current-model"' | check model-destroy
+	juju models --format json | jq -r '."current-model"' | check 'model-destroy'
 
 	echo "Add new model 'model-new'"
 	juju add-model model-new
 
 	echo "Ensure current model is 'model-new'"
-	juju models --format json | jq -r '."current-model"' | check model-new
+	juju models --format json | jq -r '."current-model"' | check 'model-new'
 
-	destroy_model "model-new"
+  echo "Destroy model 'model-new'"
+	juju destroy-model --no-prompt 'model-new'
+
+  echo "Ensure model 'model-new' is destroyed"
 	is_destroyed=$(juju models --format json | jq -r '.models[] | select(."short-name" == "model-new")')
 	if [[ -z ${is_destroyed} ]]; then is_destroyed=true; fi
 	check_contains "${is_destroyed}" true
 
+  echo "Switch to model 'model-destroy'"
 	juju switch model-destroy
 
 	echo "Ensure current model is 'model-destroy'"
-	juju models --format json | jq -r '."current-model"' | check model-destroy
+	juju models --format json | jq -r '."current-model"' | check 'model-destroy'
 
 	destroy_model "model-destroy"
 }


### PR DESCRIPTION
- Added direct use of juju cli instead of build-in destroy_model function
- Fixed incorrectly mentioned flag in `destroy-model` help description

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

```sh
cd tests
./main.sh -v model test_model_destroy
```

**Jira card:** JUJU-

