### PR TITLE
fix(apiserver): pass the right machine service to modelstatus

### DIFF
--- a/apiserver/common/modelstatus_test.go
+++ b/apiserver/common/modelstatus_test.go
@@ -19,6 +19,7 @@ import (
 	apiservertesting "github.com/juju/juju/apiserver/testing"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/life"
+	"github.com/juju/juju/core/model"
 	storageerrors "github.com/juju/juju/domain/storage/errors"
 	"github.com/juju/juju/environs/envcontext"
 	"github.com/juju/juju/internal/storage"
@@ -86,7 +87,7 @@ func (s *modelStatusSuite) TestModelStatusNonAuth(c *gc.C) {
 
 	api := common.NewModelStatusAPI(
 		common.NewModelManagerBackend(s.Model, s.StatePool),
-		s.machineService,
+		s.machineServiceGetter,
 		anAuthoriser,
 		anAuthoriser.GetAuthTag().(names.UserTag),
 	)
@@ -112,7 +113,7 @@ func (s *modelStatusSuite) TestModelStatusOwnerAllowed(c *gc.C) {
 	defer st.Close()
 	api := common.NewModelStatusAPI(
 		common.NewModelManagerBackend(s.Model, s.StatePool),
-		s.machineService,
+		s.machineServiceGetter,
 		anAuthoriser,
 		anAuthoriser.GetAuthTag().(names.UserTag),
 	)
@@ -149,13 +150,17 @@ func (s *modelStatusSuite) TestModelStatusRunsForAllModels(c *gc.C) {
 	}
 	modelStatusAPI := common.NewModelStatusAPI(
 		common.NewModelManagerBackend(s.Model, s.StatePool),
-		s.machineService,
+		s.machineServiceGetter,
 		s.authorizer,
 		s.authorizer.GetAuthTag().(names.UserTag),
 	)
 	result, err := modelStatusAPI.ModelStatus(context.Background(), req)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, jc.DeepEquals, expected)
+}
+
+func (s *modelStatusSuite) machineServiceGetter(uuid model.UUID) common.MachineService {
+	return s.machineService
 }
 
 type noopStoragePoolGetter struct{}

--- a/apiserver/facades/client/controller/controller.go
+++ b/apiserver/facades/client/controller/controller.go
@@ -110,7 +110,7 @@ func NewControllerAPI(
 	credentialService common.CredentialService,
 	upgradeService UpgradeService,
 	accessService ControllerAccessService,
-	machineService MachineService,
+	machineServiceGetter func(coremodel.UUID) common.MachineService,
 	modelService ModelService,
 	modelInfoService ModelInfoService,
 	blockCommandService common.BlockCommandService,
@@ -143,7 +143,7 @@ func NewControllerAPI(
 		),
 		ModelStatusAPI: common.NewModelStatusAPI(
 			common.NewModelManagerBackend(model, pool),
-			machineService,
+			machineServiceGetter,
 			authorizer,
 			apiUser,
 		),

--- a/apiserver/facades/client/controller/register.go
+++ b/apiserver/facades/client/controller/register.go
@@ -55,6 +55,9 @@ func makeControllerAPI(stdCtx context.Context, ctx facade.MultiModelContext) (*C
 	blockCommandServiceGetter := func(modelID model.UUID) BlockCommandService {
 		return ctx.DomainServicesForModel(modelID).BlockCommand()
 	}
+	machineServiceGetter := func(modelID model.UUID) common.MachineService {
+		return ctx.DomainServicesForModel(modelID).Machine()
+	}
 
 	return NewControllerAPI(
 		stdCtx,
@@ -71,7 +74,7 @@ func makeControllerAPI(stdCtx context.Context, ctx facade.MultiModelContext) (*C
 		domainServices.Credential(),
 		domainServices.Upgrade(),
 		domainServices.Access(),
-		domainServices.Machine(),
+		machineServiceGetter,
 		domainServices.Model(),
 		domainServices.ModelInfo(),
 		domainServices.BlockCommand(),

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -76,7 +76,6 @@ type ModelManagerAPI struct {
 	applicationService   ApplicationService
 	cloudService         CloudService
 	credentialService    CredentialService
-	machineService       MachineService
 	modelService         ModelService
 	modelDefaultsService ModelDefaultsService
 	networkService       NetworkService
@@ -122,8 +121,12 @@ func NewModelManagerAPI(
 	}
 	isAdmin := err == nil
 
+	machinServiceGetter := func(modelUUID coremodel.UUID) common.MachineService {
+		return services.DomainServicesGetter.DomainServicesForModel(modelUUID).Machine()
+	}
+
 	return &ModelManagerAPI{
-		ModelStatusAPI:       common.NewModelStatusAPI(st, services.MachineService, authorizer, apiUser),
+		ModelStatusAPI:       common.NewModelStatusAPI(st, machinServiceGetter, authorizer, apiUser),
 		state:                st,
 		domainServicesGetter: services.DomainServicesGetter,
 		modelExporter:        modelExporter,
@@ -131,7 +134,6 @@ func NewModelManagerAPI(
 		cloudService:         services.CloudService,
 		credentialService:    services.CredentialService,
 		networkService:       services.NetworkService,
-		machineService:       services.MachineService,
 		applicationService:   services.ApplicationService,
 		store:                services.ObjectStore,
 		getBroker:            getBroker,

--- a/apiserver/facades/client/modelmanager/modelmanager_test.go
+++ b/apiserver/facades/client/modelmanager/modelmanager_test.go
@@ -82,6 +82,7 @@ type modelManagerSuite struct {
 	modelDefaultService  *mocks.MockModelDefaultsService
 	modelExporter        *mocks.MockModelExporter
 	domainServicesGetter *mocks.MockDomainServicesGetter
+	domainServices       *mocks.MockModelDomainServices
 	applicationService   *mocks.MockApplicationService
 	blockCommandService  *mocks.MockBlockCommandService
 	authoriser           apiservertesting.FakeAuthorizer
@@ -89,6 +90,7 @@ type modelManagerSuite struct {
 	caasApi              *modelmanager.ModelManagerAPI
 	controllerUUID       uuid.UUID
 	modelConfigService   *mocks.MockModelConfigService
+	machineService       *mocks.MockMachineService
 }
 
 var _ = gc.Suite(&modelManagerSuite{})
@@ -103,6 +105,9 @@ func (s *modelManagerSuite) setUpMocks(c *gc.C) *gomock.Controller {
 	s.domainServicesGetter = mocks.NewMockDomainServicesGetter(ctrl)
 	s.applicationService = mocks.NewMockApplicationService(ctrl)
 	s.blockCommandService = mocks.NewMockBlockCommandService(ctrl)
+	s.machineService = mocks.NewMockMachineService(ctrl)
+	s.domainServices = mocks.NewMockModelDomainServices(ctrl)
+
 	return ctrl
 }
 
@@ -1688,6 +1693,9 @@ func (s *modelManagerStateSuite) TestModelInfoForMigratedModel(c *gc.C) {
 
 func (s *modelManagerSuite) TestModelStatus(c *gc.C) {
 	defer s.setUpAPI(c).Finish()
+
+	s.domainServicesGetter.EXPECT().DomainServicesForModel(gomock.Any()).Return(s.domainServices).AnyTimes()
+	s.domainServices.EXPECT().Machine().Return(s.machineService).AnyTimes()
 
 	// Check that we don't err out immediately if a model errs.
 	results, err := s.api.ModelStatus(stdcontext.Background(), params.Entities{Entities: []params.Entity{{


### PR DESCRIPTION
This change is necessary because destroying model is broken: if a model has more machine than the controller model, it won't be destroyed due to an error. This error is that a call to model status try to get the UUID of a machine, and get rejected because it use to call the controller's machine service (instead of the model-to-be-destroyed machine service), leading to error if there is more machine in model than in controller.

- Before this commit, the `MachineService` was passed directly to ModelStatusAPIs, which was wrong since ModelStatus have endpoint addressing multiple model, and machine service is bounded to a unique model.
- After this commit, machine service access is now retrieved dynamically using a model-specific getter function, allowing ModelStatus to correctly handle multiple model requests.

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [X] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [X] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

You can check it fixed by running the above Integration test:

```sh
cd tests
./main.sh constraints run_constraints_lxd
```

## Documentation changes

None

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/

SHould help to fix some of the case below:

**Jira card:** JUJU-[6897](https://warthogs.atlassian.net/browse/JUJU-6897)

