### PR TITLE
ci: fix rtd build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -779,8 +779,8 @@ docs:
 .PHONY: docs-help
 docs-help: docs
 
+# Build the sphinx documentation
 docs-%:
-## Build the sphinx documentation
 	cd docs && $(MAKE) -f Makefile.sp sp-$* ALLFILES='*.md **/*.md'
 
 

--- a/docs/.readthedocs.yaml
+++ b/docs/.readthedocs.yaml
@@ -10,10 +10,31 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
-  jobs:
-    pre_install:
-      - git fetch --unshallow || true
-      - make go-install
+    golang: latest
+  commands:
+    # TODO(aflynn): This is a hack, the "commands" config option override the
+    # RTD build process completely. This is done so that we can use the "juju
+    # documentation" command to auto-generate CLI docs. For this the "juju"
+    # command needs to be built and put on the path for the documentation build.
+    # Once CLI documentation is autogenerate with a script rather than with
+    # "juju documentation" we can call this script from the conf.py instead and
+    # use the default RTD build process.
+
+    # Build juju
+    - git fetch --unshallow || true
+    - mkdir $HOME/_juju_builds
+    - GOBIN=$HOME/_juju_builds make juju
+
+    # Install build requirements
+    - python -mvirtualenv $READTHEDOCS_VIRTUALENV_PATH
+    - python -m pip install --upgrade --no-cache-dir pip setuptools
+    - python -m pip install --exists-action=w --no-cache-dir -r docs/.sphinx/requirements.txt
+
+    # Print config
+    - cat docs/conf.py
+
+    # Build sphinx with juju on the PATH.
+    - cd docs && PATH=$PATH:$HOME/_juju_builds python -m sphinx -T --keep-going -b dirhtml -d _build/doctrees -D language=en . $READTHEDOCS_OUTPUT/html
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/docs/.readthedocs.yaml
+++ b/docs/.readthedocs.yaml
@@ -22,8 +22,8 @@ build:
 
     # Build juju
     - git fetch --unshallow || true
-    - mkdir $HOME/_juju_builds
-    - GOBIN=$HOME/_juju_builds make juju
+    - mkdir $HOME/_rtd_juju_build
+    - GOBIN=$HOME/_rtd_juju_build make juju
 
     # Install build requirements
     - python -mvirtualenv $READTHEDOCS_VIRTUALENV_PATH
@@ -34,7 +34,7 @@ build:
     - cat docs/conf.py
 
     # Build sphinx with juju on the PATH.
-    - cd docs && PATH=$PATH:$HOME/_juju_builds python -m sphinx -T --keep-going -b dirhtml -d _build/doctrees -D language=en . $READTHEDOCS_OUTPUT/html
+    - cd docs && PATH=$PATH:$HOME/_rtd_juju_build python -m sphinx -T --keep-going -b dirhtml -d _build/doctrees -D language=en . $READTHEDOCS_OUTPUT/html
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:


### PR DESCRIPTION
The sphinx documentation is automatically built by RTD using the
template in the .readthedocs.yaml file. Because we auto generate the CLI
documentation using the juju documentation command, it the juju command
itself to be built. To do this requires some hackery.

The RTD build process is overwritten using the commands config option.
In it, we build juju, then make the docs with the juju executable on the
path.

**Flyby:**
docs: fix docs make help command

A comment was appearing in the make help (the message that appears when
you just do `make`) that shouldn't have been. Change the comment format
so it is excluded.
## QA Steps
The configuration file was iterated upon by setting the RTD build process point to my juju repo (Aflynn50/juju) and iterating on that. It is the result of many rounds of trial and error.

The sccuessful build is here: https://readthedocs.com/projects/canonical-juju/builds/2694061/
And the results can be viewed here: https://canonical-juju.readthedocs-hosted.com/en/latest/

As part of the build, the "fail on warning" option was disabled. It is not in the scope of this PR to fix all the warning that came with moving the legacy docs onto RTD, so there may be visual defects on some of the pages.
