### PR TITLE
fix(bootstrap): add support for authorized SSH keys for manual cloud

### DIFF
--- a/cmd/juju/commands/bootstrap.go
+++ b/cmd/juju/commands/bootstrap.go
@@ -808,6 +808,7 @@ to create a new model to deploy %sworkloads.
 
 	bootstrapCtx := environscmd.BootstrapContext(stdCtx, ctx)
 	bootstrapPrepareParams := bootstrap.PrepareParams{
+		AuthorizedKeys:   bootstrapCfg.bootstrap.AuthorizedKeys,
 		ModelConfig:      bootstrapCfg.bootstrapModel,
 		ControllerConfig: bootstrapCfg.controller,
 		ControllerName:   c.controllerName,

--- a/environs/bootstrap/prepare.go
+++ b/environs/bootstrap/prepare.go
@@ -4,6 +4,9 @@
 package bootstrap
 
 import (
+	"maps"
+	"strings"
+
 	"github.com/juju/errors"
 	"github.com/juju/names/v5"
 
@@ -34,6 +37,9 @@ const (
 // PrepareParams contains the parameters for preparing a controller Environ
 // for bootstrapping.
 type PrepareParams struct {
+	// AuthorizedKeys is a list of SSH authorized keys to add to the controller environment.
+	AuthorizedKeys []string
+
 	// ModelConfig contains the base configuration for the controller model.
 	//
 	// This includes the model name, cloud type, any user-supplied
@@ -184,7 +190,12 @@ func prepare(
 ) (*config.Config, prepareDetails, error) {
 	var details prepareDetails
 
-	cfg, err := config.New(config.NoDefaults, args.ModelConfig)
+	completeConfig := map[string]any{
+		config.AuthorizedKeysKey: strings.Join(args.AuthorizedKeys, "\n"),
+	}
+	maps.Copy(completeConfig, args.ModelConfig)
+
+	cfg, err := config.New(config.NoDefaults, completeConfig)
 	if err != nil {
 		return cfg, details, errors.Trace(err)
 	}

--- a/environs/config/schema.go
+++ b/environs/config/schema.go
@@ -85,6 +85,11 @@ var configSchema = environschema.Fields{
 		Type:        environschema.Tstring,
 		Group:       environschema.EnvironGroup,
 	},
+	AuthorizedKeysKey: {
+		Description: "Any authorized SSH public keys for the model, as found in a ~/.ssh/authorized_keys file",
+		Type:        environschema.Tstring,
+		Group:       environschema.EnvironGroup,
+	},
 	DefaultBaseKey: {
 		Description: "The default base image to use for deploying charms, will act like --base when deploying charms",
 		Type:        environschema.Tstring,


### PR DESCRIPTION
Fixup a regression in commit:
https://github.com/juju/juju/commit/4a9a7443613cedbd77817d9e606528a8d931978b

- Before this commit, trying to bootstrap a manual cloud will fails with a permission error, since authorization keys weren't not added to the machine.
- After this commit, authorization keys are correctly pushed to the target machine and the bootstrap works.

> [!WARNING]
> THis may not be the right way to do it, because it implies to restore some "Authorization Keys" field in modelConfig,
> which has been explicitly removed. I am open to a better implementation suggestion (and explanation)

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [X] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [X] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

### Create a multipass VM with ssh enabled:

create a `cloud-init.yaml` file:
```yaml
users:
  - default
  - name: vmuser
    sudo: ALL=(ALL) NOPASSWD:ALL
    ssh_authorized_keys:
    - <a valid key for you>
```

run 
```sh
multipass launch -c 2 -m 4G --cloud-init cloud-init.yaml
multipass list # get the IP
```

Bootstrap on this machine
```sh
juju add-cloud # type lxd, name test, access string vmuser@<the ip>
juju bootstrap test test
```
Should works without permission error.