### PR TITLE
fix: returned uuid when inserting charm with same hash

### DIFF
--- a/domain/objectstore/state/state.go
+++ b/domain/objectstore/state/state.go
@@ -198,6 +198,12 @@ AND    size = $dbMetadata.size`, dbMetadata, dbMetadataPath)
 			} else if err != nil {
 				return errors.Annotatef(err, "inserting metadata")
 			}
+			// At this point we need to update the uuid that we'll
+			// return back to be the one that was already in the db.
+			uuid, err = coreobjectstore.ParseUUID(dbMetadataPath.UUID)
+			if err != nil {
+				return errors.Annotatef(err, "parsing present uuid in metadata")
+			}
 		}
 
 		err = tx.Query(ctx, pathStmt, dbMetadataPath).Get(&outcome)

--- a/domain/objectstore/state/state_test.go
+++ b/domain/objectstore/state/state_test.go
@@ -191,11 +191,13 @@ func (s *stateSuite) TestPutMetadataWithSameSHA256AndSize(c *gc.C) {
 		Size:   666,
 	}
 
-	_, err := st.PutMetadata(context.Background(), metadata1)
+	uuid1, err := st.PutMetadata(context.Background(), metadata1)
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = st.PutMetadata(context.Background(), metadata2)
+	uuid2, err := st.PutMetadata(context.Background(), metadata2)
 	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(uuid1, gc.Equals, uuid2)
 }
 
 func (s *stateSuite) TestPutMetadataWithSameSHA384AndSize(c *gc.C) {
@@ -214,11 +216,13 @@ func (s *stateSuite) TestPutMetadataWithSameSHA384AndSize(c *gc.C) {
 		Size:   666,
 	}
 
-	_, err := st.PutMetadata(context.Background(), metadata1)
+	uuid1, err := st.PutMetadata(context.Background(), metadata1)
 	c.Assert(err, jc.ErrorIsNil)
 
-	_, err = st.PutMetadata(context.Background(), metadata2)
+	uuid2, err := st.PutMetadata(context.Background(), metadata2)
 	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(uuid1, gc.Equals, uuid2)
 }
 
 func (s *stateSuite) TestPutMetadataWithSameHashDifferentSize(c *gc.C) {


### PR DESCRIPTION
This fixes an issue presented when we tried to deploy the same charm twice (or the same charm from charmhub and then from local). The error was that in the case of a conflict in the hash, the same line in the db was used for the object store metadata, but the returned UUID was still a new one. Now the UUID corresponding to that line gets returned.

__Note: This issue was discovered on https://github.com/juju/juju/pull/18546.__
## QA steps

The problem was identified when trying to deploy the same charm from different sources (i.e. first from charmhub then from local), so that scenario should work. The fix should not have any other impact:

```
juju bootstrap lxd c
juju add-model m
juju deploy ubuntu ch
juju download ubuntu
juju deploy ./ubuntu_r25.charm lo
```
No errors should be returned from the last command and status should show both charms active.

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/

**Jira card:** JUJU-

