### PR TITLE
chore: align all charm encoding

### DIFF
--- a/apiserver/common/charms/common.go
+++ b/apiserver/common/charms/common.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/juju/apiserver/facade"
 	coreapplication "github.com/juju/juju/core/application"
+	"github.com/juju/juju/core/arch"
 	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/domain/application"
@@ -155,33 +156,33 @@ func (a *ApplicationCharmInfoAPI) ApplicationCharmInfo(ctx context.Context, args
 func convertSource(source applicationcharm.CharmSource) (string, error) {
 	switch source {
 	case applicationcharm.CharmHubSource:
-		return "ch", nil
+		return charm.CharmHub.String(), nil
 	case applicationcharm.LocalSource:
-		return "local", nil
+		return charm.Local.String(), nil
 	default:
 		return "", errors.Errorf("unsupported source %q", source)
 	}
 }
 
-func convertApplication(arch application.Architecture) (string, error) {
-	switch arch {
+func convertApplication(a application.Architecture) (string, error) {
+	switch a {
 	case architecture.AMD64:
-		return "amd64", nil
+		return arch.AMD64, nil
 	case architecture.ARM64:
-		return "arm64", nil
+		return arch.ARM64, nil
 	case architecture.PPC64EL:
-		return "ppc64el", nil
+		return arch.PPC64EL, nil
 	case architecture.S390X:
-		return "s390x", nil
-	case architecture.RISV64:
-		return "riscv64", nil
+		return arch.S390X, nil
+	case architecture.RISCV64:
+		return arch.RISCV64, nil
 
 	// This is a valid case if we're uploading charms and the value isn't
 	// supplied.
 	case architecture.Unknown:
 		return "", nil
 	default:
-		return "", errors.Errorf("unsupported architecture %q", arch)
+		return "", errors.Errorf("unsupported architecture %q", a)
 	}
 }
 

--- a/apiserver/facades/client/application/application_get.go
+++ b/apiserver/facades/client/application/application_get.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/schema"
 
 	apiservererrors "github.com/juju/juju/apiserver/errors"
+	"github.com/juju/juju/core/arch"
 	corebase "github.com/juju/juju/core/base"
 	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/core/config"
@@ -332,9 +333,9 @@ func (c *domainCharm) IsUploaded() bool {
 }
 
 func (c *domainCharm) URL() string {
-	schema := "local"
+	schema := charm.Local.String()
 	if c.locator.Source == applicationcharm.CharmHubSource {
-		schema = "ch"
+		schema = charm.CharmHub.String()
 	}
 
 	name := c.charm.Meta().Name
@@ -342,18 +343,18 @@ func (c *domainCharm) URL() string {
 		panic(fmt.Sprintf("charm name is empty %+v", c.charm))
 	}
 
-	var arch string
+	var a string
 	switch c.locator.Architecture {
 	case architecture.AMD64:
-		arch = "amd64"
+		a = arch.AMD64
 	case architecture.ARM64:
-		arch = "arm64"
+		a = arch.ARM64
 	case architecture.PPC64EL:
-		arch = "ppc64el"
+		a = arch.PPC64EL
 	case architecture.S390X:
-		arch = "s390x"
-	case architecture.RISV64:
-		arch = "risv64"
+		a = arch.S390X
+	case architecture.RISCV64:
+		a = arch.RISCV64
 	default:
 		// If there is no architecture set, we should ignore it.
 	}
@@ -362,7 +363,7 @@ func (c *domainCharm) URL() string {
 		Schema:       schema,
 		Name:         name,
 		Revision:     c.locator.Revision,
-		Architecture: arch,
+		Architecture: a,
 	}
 	return curl.String()
 }

--- a/apiserver/facades/client/charms/client.go
+++ b/apiserver/facades/client/charms/client.go
@@ -678,32 +678,32 @@ func charmURLFromLocator(name string, locator applicationcharm.CharmLocator) (st
 func convertSource(source applicationcharm.CharmSource) (string, error) {
 	switch source {
 	case applicationcharm.CharmHubSource:
-		return "ch", nil
+		return charm.CharmHub.String(), nil
 	case applicationcharm.LocalSource:
-		return "local", nil
+		return charm.Local.String(), nil
 	default:
 		return "", errors.Errorf("unsupported source %q", source)
 	}
 }
 
-func convertApplication(arch application.Architecture) (string, error) {
-	switch arch {
+func convertApplication(a application.Architecture) (string, error) {
+	switch a {
 	case architecture.AMD64:
-		return "amd64", nil
+		return arch.AMD64, nil
 	case architecture.ARM64:
-		return "arm64", nil
+		return arch.ARM64, nil
 	case architecture.PPC64EL:
-		return "ppc64el", nil
+		return arch.PPC64EL, nil
 	case architecture.S390X:
-		return "s390x", nil
-	case architecture.RISV64:
-		return "riscv64", nil
+		return arch.S390X, nil
+	case architecture.RISCV64:
+		return arch.RISCV64, nil
 
 	// This is a valid case if we're uploading charms and the value isn't
 	// supplied.
 	case architecture.Unknown:
 		return "", nil
 	default:
-		return "", errors.Errorf("unsupported architecture %q", arch)
+		return "", errors.Errorf("unsupported architecture %q", a)
 	}
 }

--- a/apiserver/objects.go
+++ b/apiserver/objects.go
@@ -15,6 +15,7 @@ import (
 	jujuerrors "github.com/juju/errors"
 
 	apiservererrors "github.com/juju/juju/apiserver/errors"
+	"github.com/juju/juju/core/arch"
 	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/domain/application"
 	"github.com/juju/juju/domain/application/architecture"
@@ -381,32 +382,32 @@ func (a *migratingApplicationServiceGetter) Application(r *http.Request) (Applic
 func convertSource(source applicationcharm.CharmSource) (string, error) {
 	switch source {
 	case applicationcharm.CharmHubSource:
-		return "ch", nil
+		return charm.CharmHub.String(), nil
 	case applicationcharm.LocalSource:
-		return "local", nil
+		return charm.Local.String(), nil
 	default:
 		return "", errors.Errorf("unsupported source %q", source)
 	}
 }
 
-func convertApplication(arch application.Architecture) (string, error) {
-	switch arch {
+func convertApplication(a application.Architecture) (string, error) {
+	switch a {
 	case architecture.AMD64:
-		return "amd64", nil
+		return arch.AMD64, nil
 	case architecture.ARM64:
-		return "arm64", nil
+		return arch.ARM64, nil
 	case architecture.PPC64EL:
-		return "ppc64el", nil
+		return arch.PPC64EL, nil
 	case architecture.S390X:
-		return "s390x", nil
-	case architecture.RISV64:
-		return "riscv64", nil
+		return arch.S390X, nil
+	case architecture.RISCV64:
+		return arch.RISCV64, nil
 
 	// This is a valid case if we're uploading charms and the value isn't
 	// supplied.
 	case architecture.Unknown:
 		return "", nil
 	default:
-		return "", errors.Errorf("unsupported architecture %q", arch)
+		return "", errors.Errorf("unsupported architecture %q", a)
 	}
 }

--- a/domain/application/architecture/types.go
+++ b/domain/application/architecture/types.go
@@ -13,5 +13,5 @@ const (
 	ARM64
 	PPC64EL
 	S390X
-	RISV64
+	RISCV64
 )

--- a/domain/application/service/service.go
+++ b/domain/application/service/service.go
@@ -703,7 +703,7 @@ func encodeArchitecture(a string) application.Architecture {
 	case arch.S390X:
 		return architecture.S390X
 	case arch.RISCV64:
-		return architecture.RISV64
+		return architecture.RISCV64
 	default:
 		return architecture.Unknown
 	}

--- a/domain/application/state/state.go
+++ b/domain/application/state/state.go
@@ -1372,7 +1372,7 @@ func decodeArchitecture(arch sql.NullInt64) (application.Architecture, error) {
 	case 3:
 		return architecture.S390X, nil
 	case 4:
-		return architecture.RISV64, nil
+		return architecture.RISCV64, nil
 	default:
 		return -1, fmt.Errorf("unsupported architecture: %d", arch.Int64)
 	}
@@ -1403,7 +1403,7 @@ func encodeArchitecture(a architecture.Architecture) (int, error) {
 		return 2, nil
 	case architecture.S390X:
 		return 3, nil
-	case architecture.RISV64:
+	case architecture.RISCV64:
 		return 4, nil
 	default:
 		return 0, internalerrors.Errorf("unsupported architecture: %d", a)


### PR DESCRIPTION
Align all charm encoding for charm URLs. These methods are becoming commonplace now, so we could consider moving this to somewhere useful, although I'm not sure where, as each place serves different functions.


## QA steps

The tests should pass, but a simple regression test should suffice.

```sh
$ juju bootstrap lxd test
$ juju add-model default
$ juju deploy ubuntu
```

## Links


**Jira card:** Part of work towards: [JUJU-7280](https://warthogs.atlassian.net/browse/JUJU-7280)

