### PR TITLE
chore: remove unnecessary bson tags from charm structs

### DIFF
--- a/internal/charm/actions.go
+++ b/internal/charm/actions.go
@@ -26,7 +26,7 @@ func GetActionNameRule() *regexp.Regexp {
 // Actions defines the available actions for the charm. Additional params
 // may be added as metadata at a future time (e.g. version.)
 type Actions struct {
-	ActionSpecs map[string]ActionSpec `yaml:"actions,omitempty" bson:",omitempty"`
+	ActionSpecs map[string]ActionSpec `yaml:"actions,omitempty"`
 }
 
 // Build this out further if it becomes necessary.

--- a/internal/charm/assumes/parser_test.go
+++ b/internal/charm/assumes/parser_test.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"strings"
 
-	"github.com/juju/mgo/v3/bson"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/version/v2"
 	gc "gopkg.in/check.v1"
@@ -357,50 +356,4 @@ func (s *ParserSuite) TestMarshalToJSON(c *gc.C) {
 	err = enc.Encode(dst)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(buf.String(), gc.Equals, payload, gc.Commentf("serialized assumes block not matching original input"))
-}
-
-func (s *ParserSuite) TestMarshalToBSONAndBack(c *gc.C) {
-	payload := `
-{
-  "assumes": [
-    "chips",
-    {
-      "any-of": [
-        "guacamole",
-        "salsa",
-        {
-          "any-of": [
-            "good-weather",
-            "great-music"
-          ]
-        }
-      ]
-    },
-    {
-      "all-of": [
-        "table",
-        "lazy-suzan"
-      ]
-    }
-  ]
-}
-`[1:]
-
-	src := struct {
-		Assumes *ExpressionTree `json:"assumes,omitempty" bson:"assumes,omitempty"`
-	}{}
-	err := json.NewDecoder(strings.NewReader(payload)).Decode(&src)
-	c.Assert(err, jc.ErrorIsNil)
-
-	// Marshal to bson
-	marshaledBSON, err := bson.Marshal(src)
-	c.Assert(err, jc.ErrorIsNil)
-
-	// Unmarshal expression tree
-	dst := struct {
-		Assumes *ExpressionTree `json:"assumes,omitempty" bson:"assumes,omitempty"`
-	}{}
-	err = bson.Unmarshal(marshaledBSON, &dst)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(src, gc.DeepEquals, dst, gc.Commentf("serialized assumes block not matching original input"))
 }

--- a/internal/charm/base.go
+++ b/internal/charm/base.go
@@ -15,9 +15,9 @@ import (
 // Base represents an OS/Channel.
 // Bases can also be converted to and from a series string.
 type Base struct {
-	Name          string   `bson:"name,omitempty" json:"name,omitempty"`
-	Channel       Channel  `bson:"channel,omitempty" json:"channel,omitempty"`
-	Architectures []string `bson:"architectures,omitempty" json:"architectures,omitempty"`
+	Name          string   `json:"name,omitempty"`
+	Channel       Channel  `json:"channel,omitempty"`
+	Architectures []string `json:"architectures,omitempty"`
 }
 
 // Validate returns with no error when the Base is valid.

--- a/internal/charm/bundledata.go
+++ b/internal/charm/bundledata.go
@@ -16,7 +16,6 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
-	"github.com/juju/mgo/v3/bson"
 	"github.com/juju/names/v5"
 	"github.com/juju/utils/v4/keyvalues"
 )
@@ -27,28 +26,28 @@ const kubernetes = "kubernetes"
 type BundleData struct {
 	// Type is used to signify whether this bundle is for IAAS or Kubernetes deployments.
 	// Valid values are "Kubernetes" or "", with empty signifying an IAAS bundle.
-	Type string `bson:"bundle,omitempty" json:"bundle,omitempty" yaml:"bundle,omitempty"`
+	Type string `json:"bundle,omitempty" yaml:"bundle,omitempty"`
 
 	// Applications holds one entry for each application
 	// that the bundle will create, indexed by
 	// the application name.
-	Applications map[string]*ApplicationSpec `bson:"applications,omitempty" json:"applications,omitempty" yaml:"applications,omitempty"`
+	Applications map[string]*ApplicationSpec `json:"applications,omitempty" yaml:"applications,omitempty"`
 
 	// Machines holds one entry for each machine referred to
 	// by unit placements. These will be mapped onto actual
 	// machines at bundle deployment time.
 	// It is an error if a machine is specified but
 	// not referred to by a unit placement directive.
-	Machines map[string]*MachineSpec `bson:",omitempty" json:",omitempty" yaml:",omitempty"`
+	Machines map[string]*MachineSpec `json:",omitempty" yaml:",omitempty"`
 
 	// Saas holds one entry for each software as a service (SAAS) for cross
 	// model relation (CMR). These will be mapped to the consuming side when
 	// deploying a bundle.
-	Saas map[string]*SaasSpec `bson:"saas,omitempty" json:"saas,omitempty" yaml:"saas,omitempty"`
+	Saas map[string]*SaasSpec `json:"saas,omitempty" yaml:"saas,omitempty"`
 
 	// Base holds the default base to use when the bundle deploys
 	// applications. A base defined for an application takes precedence.
-	DefaultBase string `bson:"default-base,omitempty" json:"default-base,omitempty" yaml:"default-base,omitempty"`
+	DefaultBase string `json:"default-base,omitempty" yaml:"default-base,omitempty"`
 
 	// Relations holds a slice of 2-element slices,
 	// each specifying a relation between two applications.
@@ -58,27 +57,27 @@ type BundleData struct {
 	// The relation is made between each. If the relation
 	// name is omitted, it will be inferred from the available
 	// relations defined in the applications' charms.
-	Relations [][]string `bson:",omitempty" json:",omitempty" yaml:",omitempty"`
+	Relations [][]string `json:",omitempty" yaml:",omitempty"`
 
 	// White listed set of tags to categorize bundles as we do charms.
-	Tags []string `bson:",omitempty" json:",omitempty" yaml:",omitempty"`
+	Tags []string `json:",omitempty" yaml:",omitempty"`
 
 	// Short paragraph explaining what the bundle is useful for.
-	Description string `bson:",omitempty" json:",omitempty" yaml:",omitempty"`
+	Description string `json:",omitempty" yaml:",omitempty"`
 }
 
 // SaasSpec represents a single software as a service (SAAS) node.
 // This will be mapped to consuming of offers from a bundle deployment.
 type SaasSpec struct {
-	URL string `bson:",omitempty" json:",omitempty" yaml:",omitempty"`
+	URL string `json:",omitempty" yaml:",omitempty"`
 }
 
 // MachineSpec represents a notional machine that will be mapped
 // onto an actual machine at bundle deployment time.
 type MachineSpec struct {
-	Constraints string            `bson:",omitempty" json:",omitempty" yaml:",omitempty"`
-	Annotations map[string]string `bson:",omitempty" json:",omitempty" yaml:",omitempty"`
-	Base        string            `bson:",omitempty" json:",omitempty" yaml:",omitempty"`
+	Constraints string            `json:",omitempty" yaml:",omitempty"`
+	Annotations map[string]string `json:",omitempty" yaml:",omitempty"`
+	Base        string            `json:",omitempty" yaml:",omitempty"`
 }
 
 // ApplicationSpec represents a single application that will
@@ -86,24 +85,24 @@ type MachineSpec struct {
 type ApplicationSpec struct {
 	// Charm holds the charm URL of the charm to
 	// use for the given application.
-	Charm string `bson:",omitempty" yaml:",omitempty" json:",omitempty"`
+	Charm string `yaml:",omitempty" json:",omitempty"`
 
 	// Channel describes the preferred channel to use when deploying a
 	// remote charm.
-	Channel string `bson:"channel,omitempty" yaml:"channel,omitempty" json:"channel,omitempty"`
+	Channel string `yaml:"channel,omitempty" json:"channel,omitempty"`
 
 	// Revision describes the revision of the charm to use when deploying.
-	Revision *int `bson:"revision,omitempty" yaml:"revision,omitempty" json:"revision,omitempty"`
+	Revision *int `yaml:"revision,omitempty" json:"revision,omitempty"`
 
 	// Base is the base to use when deploying the application.
-	Base string `bson:",omitempty" yaml:",omitempty" json:",omitempty"`
+	Base string `yaml:",omitempty" json:",omitempty"`
 
 	// Resources is the set of resource revisions to deploy for the
 	// application. Bundles only support charm store resources and not ones
 	// that were uploaded to the controller.
 	// A resource value can either be an integer revision number,
 	// or a string holding a path to a local resource file.
-	Resources map[string]interface{} `bson:",omitempty" yaml:",omitempty" json:",omitempty"`
+	Resources map[string]interface{} `yaml:",omitempty" json:",omitempty"`
 
 	// NumUnits holds the number of units of the
 	// application that will be deployed.
@@ -112,11 +111,11 @@ type ApplicationSpec struct {
 	// For a subordinate application, this actually represents
 	// an arbitrary number of units depending on
 	// the application it is related to.
-	NumUnits int `bson:",omitempty" yaml:"num_units,omitempty" json:",omitempty"`
+	NumUnits int `yaml:"num_units,omitempty" json:",omitempty"`
 
 	// Scale_ holds the number of pods required for the application.
 	// For IAAS bundles, this will be an alias for NumUnits.
-	Scale_ int `bson:"scale,omitempty" yaml:"scale,omitempty" json:"scale,omitempty"`
+	Scale_ int `yaml:"scale,omitempty" json:"scale,omitempty"`
 
 	// To is interpreted according to whether this is an
 	// IAAS or Kubernetes bundle.
@@ -170,15 +169,15 @@ type ApplicationSpec struct {
 	// The above example is the same as this:
 	//
 	//     wordpress wordpress lxc:0 kvm:new
-	To []string `bson:",omitempty" json:",omitempty" yaml:",omitempty"`
+	To []string `json:",omitempty" yaml:",omitempty"`
 
 	// Placement_ holds a model selector/affinity expression used to specify
 	// pod placement for Kubernetes applications.
 	// Not relevant for IAAS applications.
-	Placement_ string `bson:"placement,omitempty" json:"placement,omitempty" yaml:"placement,omitempty"`
+	Placement_ string `json:"placement,omitempty" yaml:"placement,omitempty"`
 
 	// Expose holds whether the application must be exposed.
-	Expose bool `bson:",omitempty" json:",omitempty" yaml:",omitempty"`
+	Expose bool `json:",omitempty" yaml:",omitempty"`
 
 	// ExposedEndpoints defines on a per-endpoint basis, the list of space
 	// names and/or CIDRs that should be able to access the ports opened
@@ -188,45 +187,45 @@ type ApplicationSpec struct {
 	//
 	// This attribute cannot be used in tandem with the 'expose: true'
 	// flag; a validation error will be raised if both fields are specified.
-	ExposedEndpoints map[string]ExposedEndpointSpec `bson:"exposed-endpoints,omitempty" json:"exposed-endpoints,omitempty" yaml:"exposed-endpoints,omitempty" source:"overlay-only"`
+	ExposedEndpoints map[string]ExposedEndpointSpec `json:"exposed-endpoints,omitempty" yaml:"exposed-endpoints,omitempty" source:"overlay-only"`
 
 	// Options holds the configuration values
 	// to apply to the new application. They should
 	// be compatible with the charm configuration.
-	Options map[string]interface{} `bson:",omitempty" json:",omitempty" yaml:",omitempty"`
+	Options map[string]interface{} `json:",omitempty" yaml:",omitempty"`
 
 	// Annotations holds any annotations to apply to the
 	// application when deployed.
-	Annotations map[string]string `bson:",omitempty" json:",omitempty" yaml:",omitempty"`
+	Annotations map[string]string `json:",omitempty" yaml:",omitempty"`
 
 	// Constraints holds the default constraints to apply
 	// when creating new machines for units of the application.
 	// This is ignored for units with explicit placement directives.
-	Constraints string `bson:",omitempty" json:",omitempty" yaml:",omitempty"`
+	Constraints string `json:",omitempty" yaml:",omitempty"`
 
 	// Storage holds the constraints for storage to assign
 	// to units of the application.
-	Storage map[string]string `bson:",omitempty" json:",omitempty" yaml:",omitempty"`
+	Storage map[string]string `json:",omitempty" yaml:",omitempty"`
 
 	// Devices holds the constraints for devices to assign
 	// to units of the application.
-	Devices map[string]string `bson:",omitempty" json:",omitempty" yaml:",omitempty"`
+	Devices map[string]string `json:",omitempty" yaml:",omitempty"`
 
 	// EndpointBindings maps how endpoints are bound to spaces
-	EndpointBindings map[string]string `bson:"bindings,omitempty" json:"bindings,omitempty" yaml:"bindings,omitempty"`
+	EndpointBindings map[string]string `json:"bindings,omitempty" yaml:"bindings,omitempty"`
 
 	// Offers holds one entry for each exported offer for this application
 	// where the key is the offer name.
-	Offers map[string]*OfferSpec `bson:"offers,omitempty" json:"offers,omitempty" yaml:"offers,omitempty" source:"overlay-only"`
+	Offers map[string]*OfferSpec `json:"offers,omitempty" yaml:"offers,omitempty" source:"overlay-only"`
 
 	// Plan specifies the plan under which the application is to be deployed.
 	// If "default", the default plan will be used for the charm
-	Plan string `bson:"plan,omitempty" json:"plan,omitempty" yaml:"plan,omitempty"`
+	Plan string `json:"plan,omitempty" yaml:"plan,omitempty"`
 
 	// RequiresTrust indicates that the application requires access to
 	// cloud credentials and must therefore be explicitly trusted by the
 	// operator before it can be deployed.
-	RequiresTrust bool `bson:"trust,omitempty" json:"trust,omitempty" yaml:"trust,omitempty"`
+	RequiresTrust bool `json:"trust,omitempty" yaml:"trust,omitempty"`
 }
 
 // maskedBundleData and bundleData are here to perform a way to normalize the
@@ -243,7 +242,7 @@ type ApplicationSpec struct {
 type maskedBundleData BundleData
 
 type bundleData struct {
-	maskedBundleData `bson:",inline" yaml:",inline" json:",inline"`
+	maskedBundleData `yaml:",inline" json:",inline"`
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface.
@@ -261,21 +260,6 @@ func (bd *BundleData) UnmarshalYAML(f func(interface{}) error) error {
 	var in bundleData
 	if err := f(&in); err != nil {
 		return err
-	}
-	*bd = BundleData(in.maskedBundleData)
-	return bd.normalizeData()
-}
-
-// SetBSON implements the bson.Setter interface.
-func (bd *BundleData) SetBSON(raw bson.Raw) error {
-	// TODO(wallyworld) - bson deserialisation is not handling the inline directive,
-	// so we need to unmarshal the bundle data manually.
-	var in *bundleData
-	if err := raw.Unmarshal(&in); err != nil {
-		return err
-	}
-	if in == nil {
-		return bson.SetZero
 	}
 	*bd = BundleData(in.maskedBundleData)
 	return bd.normalizeData()
@@ -320,22 +304,22 @@ type ExposedEndpointSpec struct {
 	// ExposeToSpaces contains a list of spaces that should be able to
 	// access the application ports opened for an endpoint when the
 	// application is exposed.
-	ExposeToSpaces []string `bson:"expose-to-spaces,omitempty" json:"expose-to-spaces,omitempty" yaml:"expose-to-spaces,omitempty" source:"overlay-only"`
+	ExposeToSpaces []string `json:"expose-to-spaces,omitempty" yaml:"expose-to-spaces,omitempty" source:"overlay-only"`
 
 	// ExposeToCIDRs contains a list of CIDRs that should be able to access
 	// the application ports opened for an endpoint when the application is
 	// exposed.
-	ExposeToCIDRs []string `bson:"expose-to-cidrs,omitempty" json:"expose-to-cidrs,omitempty" yaml:"expose-to-cidrs,omitempty" source:"overlay-only"`
+	ExposeToCIDRs []string `json:"expose-to-cidrs,omitempty" yaml:"expose-to-cidrs,omitempty" source:"overlay-only"`
 }
 
 // OfferSpec describes an offer for a particular application.
 type OfferSpec struct {
 	// The list of endpoints exposed via the offer.
-	Endpoints []string `bson:"endpoints" json:"endpoints" yaml:"endpoints" source:"overlay-only"`
+	Endpoints []string `json:"endpoints" yaml:"endpoints" source:"overlay-only"`
 
 	// The access control list for this offer. The keys are users and the
 	// values are access permissions.
-	ACL map[string]string `bson:"acl,omitempty" json:"acl,omitempty" yaml:"acl,omitempty" source:"overlay-only"`
+	ACL map[string]string `json:"acl,omitempty" yaml:"acl,omitempty" source:"overlay-only"`
 }
 
 // ReadBundleData reads bundle data from the given reader.

--- a/internal/charm/bundledata_test.go
+++ b/internal/charm/bundledata_test.go
@@ -10,7 +10,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/juju/mgo/v3/bson"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -419,18 +418,6 @@ func (*bundleDataSuite) TestParseLocal(c *gc.C) {
 				NumUnits: 1,
 			},
 		}})
-}
-
-func (s *bundleDataSuite) TestBSONNilData(c *gc.C) {
-	bd := map[string]*charm.BundleData{
-		"test": nil,
-	}
-	data, err := bson.Marshal(bd)
-	c.Assert(err, jc.ErrorIsNil)
-	var result map[string]*charm.BundleData
-	err = bson.Unmarshal(data, &result)
-	c.Assert(err, gc.IsNil)
-	c.Assert(result["test"], gc.IsNil)
 }
 
 var verifyErrorsTests = []struct {

--- a/internal/charm/extra_bindings.go
+++ b/internal/charm/extra_bindings.go
@@ -13,7 +13,7 @@ import (
 
 // ExtraBinding represents an extra bindable endpoint that is not a relation.
 type ExtraBinding struct {
-	Name string `bson:"name" json:"Name"`
+	Name string `json:"Name"`
 }
 
 // When specified, the "extra-bindings" section in the metadata.yaml

--- a/internal/charm/meta.go
+++ b/internal/charm/meta.go
@@ -57,45 +57,45 @@ type Storage struct {
 	// Name is the name of the store.
 	//
 	// Name has no default, and must be specified.
-	Name string `bson:"name"`
+	Name string
 
 	// Description is a description of the store.
 	//
 	// Description has no default, and is optional.
-	Description string `bson:"description"`
+	Description string
 
 	// Type is the storage type: filesystem or block-device.
 	//
 	// Type has no default, and must be specified.
-	Type StorageType `bson:"type"`
+	Type StorageType
 
 	// Shared indicates that the storage is shared between all units of
 	// an application deployed from the charm. It is an error to attempt to
 	// assign non-shareable storage to a "shared" storage requirement.
 	//
 	// Shared defaults to false.
-	Shared bool `bson:"shared"`
+	Shared bool
 
 	// ReadOnly indicates that the storage should be made read-only if
 	// possible. If the storage cannot be made read-only, Juju will warn
 	// the user.
 	//
 	// ReadOnly defaults to false.
-	ReadOnly bool `bson:"read-only"`
+	ReadOnly bool
 
 	// CountMin is the number of storage instances that must be attached
 	// to the charm for it to be useful; the charm will not install until
 	// this number has been satisfied. This must be a non-negative number.
 	//
 	// CountMin defaults to 1 for singleton stores.
-	CountMin int `bson:"countmin"`
+	CountMin int
 
 	// CountMax is the largest number of storage instances that can be
 	// attached to the charm. If CountMax is -1, then there is no upper
 	// bound.
 	//
 	// CountMax defaults to 1 for singleton stores.
-	CountMax int `bson:"countmax"`
+	CountMax int
 
 	// MinimumSize is the minimum size of store that the charm needs to
 	// work at all. This is not a recommended size or a comfortable size
@@ -105,14 +105,14 @@ type Storage struct {
 	//
 	// There is no default MinimumSize; if left unspecified, a provider
 	// specific default will be used, typically 1GB for block storage.
-	MinimumSize uint64 `bson:"minimum-size"`
+	MinimumSize uint64
 
 	// Location is the mount location for filesystem stores. For multi-
 	// stores, the location acts as the parent directory for each mounted
 	// store.
 	//
 	// Location has no default, and is optional.
-	Location string `bson:"location,omitempty"`
+	Location string
 
 	// Properties allow the charm author to characterise the relative storage
 	// performance requirements and sensitivities for each store.
@@ -120,7 +120,7 @@ type Storage struct {
 	// such as tmpfs or ephemeral instance disks.
 	//
 	// Properties has no default, and is optional.
-	Properties []string `bson:"properties,omitempty"`
+	Properties []string
 }
 
 // DeviceType defines a device type.
@@ -129,34 +129,34 @@ type DeviceType string
 // Device represents a charm's device requirement (GPU for example).
 type Device struct {
 	// Name is the name of the device.
-	Name string `bson:"name"`
+	Name string
 
 	// Description is a description of the device.
-	Description string `bson:"description"`
+	Description string
 
 	// Type is the device type.
 	// currently supported types are
 	// - gpu
 	// - nvidia.com/gpu
 	// - amd.com/gpu
-	Type DeviceType `bson:"type"`
+	Type DeviceType
 
 	// CountMin is the min number of devices that the charm requires.
-	CountMin int64 `bson:"countmin"`
+	CountMin int64
 
 	// CountMax is the max number of devices that the charm requires.
-	CountMax int64 `bson:"countmax"`
+	CountMax int64
 }
 
 // Relation represents a single relation defined in the charm
 // metadata.yaml file.
 type Relation struct {
-	Name      string        `bson:"name"`
-	Role      RelationRole  `bson:"role"`
-	Interface string        `bson:"interface"`
-	Optional  bool          `bson:"optional"`
-	Limit     int           `bson:"limit"`
-	Scope     RelationScope `bson:"scope"`
+	Name      string
+	Role      RelationRole
+	Interface string
+	Optional  bool
+	Limit     int
+	Scope     RelationScope
 }
 
 // ImplementedBy returns whether the relation is implemented by the supplied charm.
@@ -213,40 +213,40 @@ const (
 // Meta represents all the known content that may be defined
 // within a charm's metadata.yaml file.
 type Meta struct {
-	Name           string                   `bson:"name" json:"Name"`
-	Summary        string                   `bson:"summary" json:"Summary"`
-	Description    string                   `bson:"description" json:"Description"`
-	Subordinate    bool                     `bson:"subordinate" json:"Subordinate"`
-	Provides       map[string]Relation      `bson:"provides,omitempty" json:"Provides,omitempty"`
-	Requires       map[string]Relation      `bson:"requires,omitempty" json:"Requires,omitempty"`
-	Peers          map[string]Relation      `bson:"peers,omitempty" json:"Peers,omitempty"`
-	ExtraBindings  map[string]ExtraBinding  `bson:"extra-bindings,omitempty" json:"ExtraBindings,omitempty"`
-	Categories     []string                 `bson:"categories,omitempty" json:"Categories,omitempty"`
-	Tags           []string                 `bson:"tags,omitempty" json:"Tags,omitempty"`
-	Storage        map[string]Storage       `bson:"storage,omitempty" json:"Storage,omitempty"`
-	Devices        map[string]Device        `bson:"devices,omitempty" json:"Devices,omitempty"`
-	Resources      map[string]resource.Meta `bson:"resources,omitempty" json:"Resources,omitempty"`
-	Terms          []string                 `bson:"terms,omitempty" json:"Terms,omitempty"`
-	MinJujuVersion version.Number           `bson:"min-juju-version,omitempty" json:"min-juju-version,omitempty"`
+	Name           string                   `json:"Name"`
+	Summary        string                   `json:"Summary"`
+	Description    string                   `json:"Description"`
+	Subordinate    bool                     `json:"Subordinate"`
+	Provides       map[string]Relation      `json:"Provides,omitempty"`
+	Requires       map[string]Relation      `json:"Requires,omitempty"`
+	Peers          map[string]Relation      `json:"Peers,omitempty"`
+	ExtraBindings  map[string]ExtraBinding  `json:"ExtraBindings,omitempty"`
+	Categories     []string                 `json:"Categories,omitempty"`
+	Tags           []string                 `json:"Tags,omitempty"`
+	Storage        map[string]Storage       `json:"Storage,omitempty"`
+	Devices        map[string]Device        `json:"Devices,omitempty"`
+	Resources      map[string]resource.Meta `json:"Resources,omitempty"`
+	Terms          []string                 `json:"Terms,omitempty"`
+	MinJujuVersion version.Number           `json:"min-juju-version,omitempty"`
 
 	// v2
-	Containers map[string]Container    `bson:"containers,omitempty" json:"containers,omitempty" yaml:"containers,omitempty"`
-	Assumes    *assumes.ExpressionTree `bson:"assumes,omitempty" json:"assumes,omitempty" yaml:"assumes,omitempty"`
-	CharmUser  RunAs                   `bson:"charm-user,omitempty" json:"charm-user,omitempty" yaml:"charm-user,omitempty"`
+	Containers map[string]Container    `json:"containers,omitempty" yaml:"containers,omitempty"`
+	Assumes    *assumes.ExpressionTree `json:"assumes,omitempty" yaml:"assumes,omitempty"`
+	CharmUser  RunAs                   `json:"charm-user,omitempty" yaml:"charm-user,omitempty"`
 }
 
 // Container specifies the possible systems it supports and mounts it wants.
 type Container struct {
-	Resource string  `bson:"resource,omitempty" json:"resource,omitempty" yaml:"resource,omitempty"`
-	Mounts   []Mount `bson:"mounts,omitempty" json:"mounts,omitempty" yaml:"mounts,omitempty"`
-	Uid      *int    `bson:"uid,omitempty" json:"uid,omitempty" yaml:"uid,omitempty"`
-	Gid      *int    `bson:"gid,omitempty" json:"gid,omitempty" yaml:"gid,omitempty"`
+	Resource string  `json:"resource,omitempty" yaml:"resource,omitempty"`
+	Mounts   []Mount `json:"mounts,omitempty" yaml:"mounts,omitempty"`
+	Uid      *int    `json:"uid,omitempty" yaml:"uid,omitempty"`
+	Gid      *int    `json:"gid,omitempty" yaml:"gid,omitempty"`
 }
 
 // Mount allows a container to mount a storage filesystem from the storage top-level directive.
 type Mount struct {
-	Storage  string `bson:"storage,omitempty" json:"storage,omitempty" yaml:"storage,omitempty"`
-	Location string `bson:"location,omitempty" json:"location,omitempty" yaml:"location,omitempty"`
+	Storage  string `json:"storage,omitempty" yaml:"storage,omitempty"`
+	Location string `json:"location,omitempty" yaml:"location,omitempty"`
 }
 
 func generateRelationHooks(relName string, allHooks map[string]bool) {

--- a/internal/charm/url.go
+++ b/internal/charm/url.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
-	"github.com/juju/mgo/v3/bson"
 
 	"github.com/juju/juju/core/arch"
 )
@@ -232,42 +231,6 @@ func (u *URL) Path() string {
 // String returns the string representation of the URL.
 func (u *URL) String() string {
 	return u.FullPath()
-}
-
-// GetBSON turns u into a bson.Getter so it can be saved directly
-// on a MongoDB database with mgo.
-//
-// TODO (stickupkid): This should not be here, as this is purely for mongo
-// data stores and that should be implemented at the site of data store, not
-// dependant on the library.
-func (u *URL) GetBSON() (interface{}, error) {
-	if u == nil {
-		return nil, nil
-	}
-	return u.String(), nil
-}
-
-// SetBSON turns u into a bson.Setter so it can be loaded directly
-// from a MongoDB database with mgo.
-//
-// TODO (stickupkid): This should not be here, as this is purely for mongo
-// data stores and that should be implemented at the site of data store, not
-// dependant on the library.
-func (u *URL) SetBSON(raw bson.Raw) error {
-	if raw.Kind == 10 {
-		return bson.SetZero
-	}
-	var s string
-	err := raw.Unmarshal(&s)
-	if err != nil {
-		return err
-	}
-	url, err := ParseURL(s)
-	if err != nil {
-		return err
-	}
-	*u = *url
-	return nil
 }
 
 // MarshalJSON will marshal the URL into a slice of bytes in a JSON

--- a/internal/charm/url_test.go
+++ b/internal/charm/url_test.go
@@ -9,7 +9,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/juju/mgo/v3/bson"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/yaml.v2"
@@ -214,10 +213,6 @@ var codecs = []struct {
 	Marshal   func(interface{}) ([]byte, error)
 	Unmarshal func([]byte, interface{}) error
 }{{
-	Name:      "bson",
-	Marshal:   bson.Marshal,
-	Unmarshal: bson.Unmarshal,
-}, {
 	Name:      "json",
 	Marshal:   json.Marshal,
 	Unmarshal: json.Unmarshal,
@@ -231,7 +226,7 @@ func (s *URLSuite) TestURLCodecs(c *gc.C) {
 	for i, codec := range codecs {
 		c.Logf("codec %d: %v", i, codec.Name)
 		type doc struct {
-			URL *charm.URL `json:",omitempty" bson:",omitempty" yaml:",omitempty"`
+			URL *charm.URL `json:",omitempty" yaml:",omitempty"`
 		}
 		url := charm.MustParseURL("ch:name")
 		v0 := doc{URL: url}


### PR DESCRIPTION
Charm metadata is no longer stored in Mongo. As such, we do not need to serialise our charm structs to bson. So these tags are now superfluous. Remove them

## QA steps

```
$ juju bootstrap lxd lxd
$ juju add-model m
$ juju deploy ubuntu
```