### PR TITLE
feat: store new revisions

### DIFF
--- a/domain/application/service/charm.go
+++ b/domain/application/service/charm.go
@@ -886,6 +886,17 @@ func (s *Service) setCharm(ctx context.Context, args charm.SetCharmArgs) (setCha
 	}, warnings, nil
 }
 
+// ReserveCharmRevision reserves a charm revision for the given charm id.
+// If there are any non-blocking issues with the charm metadata, actions,
+// config or manifest, a set of warnings will be returned.
+func (s *Service) ReserveCharmRevision(ctx context.Context, args charm.SetCharmArgs) (corecharm.ID, []string, error) {
+	result, warnings, err := s.setCharm(ctx, args)
+	if err != nil {
+		return "", nil, errors.Trace(err)
+	}
+	return result.ID, warnings, nil
+}
+
 // WatchCharms returns a watcher that observes changes to charms.
 func (s *WatchableService) WatchCharms() (watcher.StringsWatcher, error) {
 	return s.watcherFactory.NewUUIDsWatcher(

--- a/domain/application/state/application.go
+++ b/domain/application/state/application.go
@@ -2175,6 +2175,7 @@ FROM v_revision_updater_application_unit
 				Architecture: charmArch,
 			},
 			Origin: application.Origin{
+				ID:       r.CharmhubIdentifier,
 				Revision: r.Revision,
 				Channel: application.Channel{
 					Track:  r.ChannelTrack,

--- a/domain/application/state/application_test.go
+++ b/domain/application/state/application_test.go
@@ -2430,6 +2430,7 @@ func (s *applicationStateSuite) TestGetApplicationsForRevisionUpdater(c *gc.C) {
 				Architecture: architecture.ARM64,
 			},
 			Revision: 42,
+			ID:       "ident",
 		},
 		NumUnits: 0,
 	}, {
@@ -2452,6 +2453,7 @@ func (s *applicationStateSuite) TestGetApplicationsForRevisionUpdater(c *gc.C) {
 				Architecture: architecture.ARM64,
 			},
 			Revision: 42,
+			ID:       "ident",
 		},
 		NumUnits: 1,
 	}})

--- a/domain/application/state/types.go
+++ b/domain/application/state/types.go
@@ -661,6 +661,7 @@ type revisionUpdaterApplication struct {
 	PlatformOSID           sql.NullInt64 `db:"platform_os_id"`
 	PlatformChannel        string        `db:"platform_channel"`
 	PlatformArchitectureID sql.NullInt64 `db:"platform_architecture_id"`
+	CharmhubIdentifier     string        `db:"charmhub_identifier"`
 }
 
 type revisionUpdaterApplicationNumUnits struct {

--- a/domain/schema/model/sql/0025-revision-updater.sql
+++ b/domain/schema/model/sql/0025-revision-updater.sql
@@ -10,11 +10,13 @@ SELECT
     ac.branch AS channel_branch,
     ap.os_id AS platform_os_id,
     ap.channel AS platform_channel,
-    ap.architecture_id AS platform_architecture_id
+    ap.architecture_id AS platform_architecture_id,
+    cdi.charmhub_identifier
 FROM application AS a
 LEFT JOIN charm AS c ON a.charm_uuid = c.uuid
 LEFT JOIN application_channel AS ac ON a.uuid = ac.application_uuid
 LEFT JOIN application_platform AS ap ON a.uuid = ap.application_uuid
+LEFT JOIN charm_download_info AS cdi ON c.uuid = cdi.charm_uuid
 WHERE a.life_id = 0 AND c.source_id = 1;
 
 CREATE VIEW v_revision_updater_application_unit AS

--- a/internal/worker/charmrevisioner/package_mocks_test.go
+++ b/internal/worker/charmrevisioner/package_mocks_test.go
@@ -13,9 +13,11 @@ import (
 	context "context"
 	reflect "reflect"
 
+	charm "github.com/juju/juju/core/charm"
 	model "github.com/juju/juju/core/model"
 	watcher "github.com/juju/juju/core/watcher"
 	application "github.com/juju/juju/domain/application"
+	charm0 "github.com/juju/juju/domain/application/charm"
 	config "github.com/juju/juju/environs/config"
 	charmhub "github.com/juju/juju/internal/charmhub"
 	transport "github.com/juju/juju/internal/charmhub/transport"
@@ -281,6 +283,46 @@ func (c *MockApplicationServiceGetApplicationsForRevisionUpdaterCall) Do(f func(
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockApplicationServiceGetApplicationsForRevisionUpdaterCall) DoAndReturn(f func(context.Context) ([]application.RevisionUpdaterApplication, error)) *MockApplicationServiceGetApplicationsForRevisionUpdaterCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// ReserveCharmRevision mocks base method.
+func (m *MockApplicationService) ReserveCharmRevision(arg0 context.Context, arg1 charm0.SetCharmArgs) (charm.ID, []string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReserveCharmRevision", arg0, arg1)
+	ret0, _ := ret[0].(charm.ID)
+	ret1, _ := ret[1].([]string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// ReserveCharmRevision indicates an expected call of ReserveCharmRevision.
+func (mr *MockApplicationServiceMockRecorder) ReserveCharmRevision(arg0, arg1 any) *MockApplicationServiceReserveCharmRevisionCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReserveCharmRevision", reflect.TypeOf((*MockApplicationService)(nil).ReserveCharmRevision), arg0, arg1)
+	return &MockApplicationServiceReserveCharmRevisionCall{Call: call}
+}
+
+// MockApplicationServiceReserveCharmRevisionCall wrap *gomock.Call
+type MockApplicationServiceReserveCharmRevisionCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockApplicationServiceReserveCharmRevisionCall) Return(arg0 charm.ID, arg1 []string, arg2 error) *MockApplicationServiceReserveCharmRevisionCall {
+	c.Call = c.Call.Return(arg0, arg1, arg2)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockApplicationServiceReserveCharmRevisionCall) Do(f func(context.Context, charm0.SetCharmArgs) (charm.ID, []string, error)) *MockApplicationServiceReserveCharmRevisionCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockApplicationServiceReserveCharmRevisionCall) DoAndReturn(f func(context.Context, charm0.SetCharmArgs) (charm.ID, []string, error)) *MockApplicationServiceReserveCharmRevisionCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/charmrevisioner/package_test.go
+++ b/internal/worker/charmrevisioner/package_test.go
@@ -19,3 +19,7 @@ func TestPackage(t *testing.T) {
 
 	gc.TestingT(t)
 }
+
+func ptr[T any](v T) *T {
+	return &v
+}

--- a/internal/worker/charmrevisioner/worker.go
+++ b/internal/worker/charmrevisioner/worker.go
@@ -28,6 +28,7 @@ import (
 	"github.com/juju/juju/domain/application"
 	"github.com/juju/juju/domain/application/architecture"
 	applicationcharm "github.com/juju/juju/domain/application/charm"
+	applicationerrors "github.com/juju/juju/domain/application/errors"
 	"github.com/juju/juju/environs/config"
 	"github.com/juju/juju/internal/charm"
 	internalcharm "github.com/juju/juju/internal/charm"
@@ -63,6 +64,11 @@ type ApplicationService interface {
 	// GetApplicationsForRevisionUpdater returns the applications that should be
 	// used by the revision updater.
 	GetApplicationsForRevisionUpdater(context.Context) ([]application.RevisionUpdaterApplication, error)
+
+	// ReserveCharmRevision reserves a charm revision for the given charm id.
+	// If there are any non-blocking issues with the charm metadata, actions,
+	// config or manifest, a set of warnings will be returned.
+	ReserveCharmRevision(ctx context.Context, args applicationcharm.SetCharmArgs) (corecharm.ID, []string, error)
 }
 
 // ModelService provides access to the model.
@@ -227,6 +233,7 @@ func (w *revisionUpdateWorker) loop() error {
 			// information.
 			// If the update fails, the worker will log an error and continue
 			// to the next application.
+
 			latestInfo, err := w.fetch(ctx, charmhubClient)
 			if errors.Is(err, ErrFailedToSendMetrics) {
 				logger.Warningf("failed to send metrics: %v", err)
@@ -234,11 +241,22 @@ func (w *revisionUpdateWorker) loop() error {
 			} else if err != nil {
 				logger.Errorf("failed to fetch revisions: %v", err)
 				continue
+			} else if len(latestInfo) == 0 {
+				if err := w.recordNoApplications(ctx, charmhubClient); err != nil {
+					logger.Warningf("failed to record no applications: %v", err)
+				}
+				logger.Debugf("no new application revisions")
+				continue
 			}
 
 			logger.Debugf("revisions fetched for %d applications", len(latestInfo))
 
-			// TODO (stickupkid): Insert charms with the latest revisions.
+			if err := w.storeNewRevisions(ctx, latestInfo); err != nil {
+				logger.Warningf("failed to store revisions: %v", err)
+				continue
+			}
+
+			logger.Debugf("revisions stored for %d applications", len(latestInfo))
 
 		case changes, ok := <-configWatcher.Changes():
 			if !ok {
@@ -274,27 +292,20 @@ func (w *revisionUpdateWorker) fetch(ctx context.Context, client CharmhubClient)
 		return nil, internalerrors.Capture(err)
 	}
 
-	cfg, err := w.config.ModelConfigService.ModelConfig(ctx)
-	if err != nil {
-		return nil, internalerrors.Capture(err)
+	if len(applications) == 0 {
+		return nil, nil
 	}
 
-	buildTelemetry := cfg.Telemetry()
-
-	if len(applications) == 0 {
-		return nil, w.sendEmptyModelMetrics(ctx, client, buildTelemetry)
+	buildTelemetry, err := w.shouldBuildTelemetry(ctx)
+	if err != nil {
+		w.config.Logger.Infof("checking telemetry config: %v", err)
+		buildTelemetry = false
 	}
 
 	charmhubIDs := make([]charmhubID, len(applications))
 	charmhubApps := make([]appInfo, len(applications))
 
 	for i, app := range applications {
-		charmURL, err := encodeCharmURL(app.CharmLocator)
-		if err != nil {
-			w.config.Logger.Infof("encoding charm URL for %q: %v", app.Name, err)
-			continue
-		}
-
 		charmhubID, err := encodeCharmhubID(app, w.config.ModelTag)
 		if err != nil {
 			w.config.Logger.Infof("encoding charmhub ID for %q: %v", app.Name, err)
@@ -309,12 +320,32 @@ func (w *revisionUpdateWorker) fetch(ctx context.Context, client CharmhubClient)
 
 		charmhubIDs[i] = charmhubID
 		charmhubApps[i] = appInfo{
-			id:       app.Name,
-			charmURL: charmURL,
+			id:           app.Name,
+			charmLocator: app.CharmLocator,
+			origin:       app.Origin,
 		}
 	}
 
 	return w.fetchInfo(ctx, client, buildTelemetry, charmhubIDs, charmhubApps)
+}
+
+func (w *revisionUpdateWorker) recordNoApplications(ctx context.Context, client CharmhubClient) error {
+	buildTelemetry, err := w.shouldBuildTelemetry(ctx)
+	if err != nil {
+		w.config.Logger.Infof("checking telemetry config: %v", err)
+		buildTelemetry = false
+	}
+
+	return w.sendEmptyModelMetrics(ctx, client, buildTelemetry)
+}
+
+func (w *revisionUpdateWorker) shouldBuildTelemetry(ctx context.Context) (bool, error) {
+	cfg, err := w.config.ModelConfigService.ModelConfig(ctx)
+	if err != nil {
+		return false, internalerrors.Capture(err)
+	}
+
+	return cfg.Telemetry(), nil
 }
 
 func (w *revisionUpdateWorker) sendEmptyModelMetrics(ctx context.Context, client CharmhubClient, buildTelemetry bool) error {
@@ -359,12 +390,34 @@ func (w *revisionUpdateWorker) fetchInfo(ctx context.Context, client CharmhubCli
 
 	var latest []latestCharmInfo
 	for i, result := range response {
+		// The platform can't change during the lifecycle of an application,
+		// with at least intervention from the user. We therefore must use
+		// the platform from the origin of the application.
+		origin := apps[i].origin
+		arch, err := encodeArchitecture(origin.Platform.Architecture)
+		if err != nil {
+			return nil, internalerrors.Errorf("encoding architecture: %w", err)
+		}
+
+		osType, err := encodeOSType(origin.Platform.OSType)
+		if err != nil {
+			return nil, internalerrors.Errorf("encoding os type: %w", err)
+		}
+
+		essentialMetadata := result.essentialMetadata
+		essentialMetadata.ResolvedOrigin.Platform = corecharm.Platform{
+			Architecture: arch,
+			OS:           osType,
+			Channel:      origin.Platform.Channel,
+		}
+
 		latest = append(latest, latestCharmInfo{
-			url:       apps[i].charmURL,
-			timestamp: result.timestamp,
-			revision:  result.revision,
-			resources: result.resources,
-			appID:     apps[i].id,
+			charmLocator:      apps[i].charmLocator,
+			essentialMetadata: essentialMetadata,
+			timestamp:         result.timestamp,
+			revision:          result.revision,
+			resources:         result.resources,
+			appID:             apps[i].id,
 		})
 	}
 
@@ -396,18 +449,77 @@ func (w *revisionUpdateWorker) request(ctx context.Context, client CharmhubClien
 	ctx, cancel := context.WithTimeout(ctx, charmhub.RefreshTimeout)
 	defer cancel()
 
+	w.config.Logger.Debugf("refreshing %d charms", len(configs))
+
 	responses, err := client.RefreshWithRequestMetrics(ctx, config, metrics)
 	if err != nil {
 		return nil, internalerrors.Capture(err)
 	}
 
+	if len(responses) != len(ids) {
+		return nil, internalerrors.Errorf("expected %d responses, got %d", len(ids), len(responses))
+	}
+
 	results := make([]charmhubResult, len(responses))
 	for i, response := range responses {
-		if results[i], err = w.refreshResponseToCharmhubResult(response); err != nil {
+		result, err := w.refreshResponseToCharmhubResult(response)
+		if err != nil {
 			return nil, internalerrors.Capture(err)
 		}
+		results[i] = result
 	}
 	return results, nil
+}
+
+func (w *revisionUpdateWorker) storeNewRevisions(ctx context.Context, latestInfo []latestCharmInfo) error {
+	for _, info := range latestInfo {
+		if err := w.storeNewRevision(ctx, info); err != nil {
+			return internalerrors.Capture(err)
+		}
+	}
+	return nil
+}
+
+func (w *revisionUpdateWorker) storeNewRevision(ctx context.Context, info latestCharmInfo) error {
+	// Insert the new charm revision into the model.
+	service := w.config.ApplicationService
+
+	essentialMetadata := info.essentialMetadata
+	downloadInfo := essentialMetadata.DownloadInfo
+	origin := essentialMetadata.ResolvedOrigin
+
+	_, warnings, err := service.ReserveCharmRevision(ctx, applicationcharm.SetCharmArgs{
+		Charm: internalcharm.NewCharmBase(
+			essentialMetadata.Meta,
+			essentialMetadata.Manifest,
+			essentialMetadata.Config,
+			// These will be filled in once we have all the data in the
+			// response from the charmhub.
+			nil, nil,
+		),
+		// This will always be a charmhub charm.
+		Source:        corecharm.CharmHub,
+		ReferenceName: info.charmLocator.Name,
+		// This is the new revision located from the fetch.
+		Revision: info.revision,
+		DownloadInfo: &applicationcharm.DownloadInfo{
+			Provenance:         applicationcharm.ProvenanceDownload,
+			CharmhubIdentifier: downloadInfo.CharmhubIdentifier,
+			DownloadURL:        downloadInfo.DownloadURL,
+			DownloadSize:       downloadInfo.DownloadSize,
+		},
+		Hash:         origin.Hash,
+		Architecture: origin.Platform.Architecture,
+	})
+	if errors.Is(err, applicationerrors.CharmAlreadyExists) {
+		return nil
+	} else if err != nil {
+		return internalerrors.Capture(err)
+	} else if len(warnings) > 0 {
+		w.config.Logger.Infof("reserving charm revision for %q: %v", info.appID, warnings)
+	}
+
+	return nil
 }
 
 func (w *revisionUpdateWorker) getCharmhubClient(ctx context.Context) (CharmhubClient, error) {
@@ -472,6 +584,23 @@ func (w *revisionUpdateWorker) refreshResponseToCharmhubResult(response transpor
 		return charmhubResult{}, internalerrors.Capture(err)
 	}
 
+	channel, err := internalcharm.ParseChannelNormalize(response.EffectiveChannel)
+	if err != nil {
+		return charmhubResult{}, internalerrors.Errorf("parsing effective channel %q: %w", response.EffectiveChannel, err)
+	}
+
+	// The charmhub origin is resolved from the response.
+	metadata.ResolvedOrigin = corecharm.Origin{
+		Source:   corecharm.CharmHub,
+		Hash:     response.Entity.Download.HashSHA256,
+		Type:     response.Entity.Type.String(),
+		ID:       response.Entity.ID,
+		Revision: &response.Entity.Revision,
+		Channel:  &channel,
+		// The platform is not filled in here, instead it's the same as the
+		// origin platform of the application.
+	}
+
 	var resources []resource.Resource
 	for _, r := range response.Entity.Resources {
 		fingerprint, err := resource.ParseFingerprint(r.Download.HashSHA384)
@@ -519,34 +648,16 @@ func (w *revisionUpdateWorker) reportInternalState(state string) {
 	}
 }
 
-func encodeCharmURL(locator applicationcharm.CharmLocator) (*charm.URL, error) {
-	// We only support charmhub charms, anything else is an error.
-	if locator.Source != applicationcharm.CharmHubSource {
-		return nil, internalerrors.Errorf("unsupported charm source %q", locator.Source)
-	}
-
-	arch, err := encodeArchitecture(locator.Architecture)
-	if err != nil {
-		return nil, internalerrors.Errorf("encoding architecture: %w", err)
-	}
-
-	return &charm.URL{
-		Schema:       charm.CharmHub.String(),
-		Name:         locator.Name,
-		Revision:     locator.Revision,
-		Architecture: arch,
-	}, nil
-}
-
 func jitter(period time.Duration) time.Duration {
 	return retry.ExpBackoff(period, period*2, 2, true)(0, 1)
 }
 
 func encodeCharmhubID(app application.RevisionUpdaterApplication, modelTag names.ModelTag) (charmhubID, error) {
-	appTag, err := names.ParseApplicationTag(app.Name)
-	if err != nil {
-		return charmhubID{}, internalerrors.Errorf("parsing application tag: %w", err)
+	if !names.IsValidApplication(app.Name) {
+		return charmhubID{}, internalerrors.Errorf("invalid application name %q", app.Name)
 	}
+
+	appTag := names.NewApplicationTag(app.Name)
 
 	origin := app.Origin
 	risk, err := encodeRisk(origin.Channel.Risk)
@@ -624,8 +735,9 @@ func encodeRisk(r application.ChannelRisk) (string, error) {
 }
 
 type appInfo struct {
-	id       string
-	charmURL *charm.URL
+	id           string
+	charmLocator applicationcharm.CharmLocator
+	origin       application.Origin
 }
 
 // charmhubID holds identifying information for several charms for a
@@ -645,11 +757,12 @@ type charmhubID struct {
 }
 
 type latestCharmInfo struct {
-	url       *charm.URL
-	timestamp time.Time
-	revision  int
-	resources []resource.Resource
-	appID     string
+	charmLocator      applicationcharm.CharmLocator
+	essentialMetadata corecharm.EssentialMetadata
+	timestamp         time.Time
+	revision          int
+	resources         []resource.Resource
+	appID             string
 }
 
 // charmhubResult is the type charmhubLatestCharmInfo returns: information

--- a/internal/worker/charmrevisioner/worker_test.go
+++ b/internal/worker/charmrevisioner/worker_test.go
@@ -15,6 +15,8 @@ import (
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/core/charm"
+	corecharm "github.com/juju/juju/core/charm"
 	charmmetrics "github.com/juju/juju/core/charm/metrics"
 	http "github.com/juju/juju/core/http"
 	"github.com/juju/juju/core/logger"
@@ -26,7 +28,7 @@ import (
 	"github.com/juju/juju/domain/application/architecture"
 	applicationcharm "github.com/juju/juju/domain/application/charm"
 	config "github.com/juju/juju/environs/config"
-	"github.com/juju/juju/internal/charm"
+	internalcharm "github.com/juju/juju/internal/charm"
 	"github.com/juju/juju/internal/charm/resource"
 	"github.com/juju/juju/internal/charmhub"
 	"github.com/juju/juju/internal/charmhub/transport"
@@ -47,6 +49,8 @@ type WorkerSuite struct {
 	httpClient         *MockHTTPClient
 	httpClientGetter   *MockHTTPClientGetter
 	clock              *MockClock
+
+	modelTag names.ModelTag
 }
 
 var _ = gc.Suite(&WorkerSuite{})
@@ -199,6 +203,91 @@ func (s *WorkerSuite) TestSendEmptyModelMetricsWithNoTelemetry(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
+func (s *WorkerSuite) TestFetch(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.expectWatcher(c)
+	s.expectModelConfig(c)
+	s.expectModelConfig(c)
+
+	charmLocator := applicationcharm.CharmLocator{
+		Source:       applicationcharm.CharmHubSource,
+		Name:         "foo",
+		Revision:     42,
+		Architecture: architecture.AMD64,
+	}
+
+	s.applicationService.EXPECT().GetApplicationsForRevisionUpdater(gomock.Any()).DoAndReturn(func(ctx context.Context) ([]application.RevisionUpdaterApplication, error) {
+		return []application.RevisionUpdaterApplication{{
+			Name:         "foo",
+			CharmLocator: charmLocator,
+			Origin: application.Origin{
+				ID:       "foo",
+				Revision: 42,
+				Channel: application.Channel{
+					Risk: "stable",
+				},
+				Platform: application.Platform{
+					Architecture: architecture.AMD64,
+					Channel:      "22.04",
+					OSType:       application.Ubuntu,
+				},
+			},
+		}}, nil
+	})
+
+	model := coremodel.ReadOnlyModel{
+		UUID:           modeltesting.GenModelUUID(c),
+		ControllerUUID: uuid.MustNewUUID(),
+		Cloud:          "aws",
+		CloudType:      "ec2",
+		CloudRegion:    "us-east-1",
+	}
+
+	s.modelService.EXPECT().GetModelMetrics(gomock.Any()).Return(coremodel.ModelMetrics{
+		Model:            model,
+		ApplicationCount: 1,
+		MachineCount:     2,
+		UnitCount:        3,
+	}, nil)
+
+	s.charmhubClient.EXPECT().RefreshWithRequestMetrics(gomock.Any(), gomock.Any(), gomock.Any()).Return([]transport.RefreshResponse{{
+		Name:             "foo",
+		EffectiveChannel: "latest/stable",
+		Entity: transport.RefreshEntity{
+			Revision: 666,
+		},
+	}}, nil)
+
+	w := s.newWorker(c)
+	defer workertest.DirtyKill(c, w)
+
+	s.ensureStartup(c)
+
+	result, err := w.fetch(context.Background(), s.charmhubClient)
+	c.Assert(err, jc.ErrorIsNil)
+
+	channel := internalcharm.MakePermissiveChannel("latest", "stable", "")
+	c.Check(result, jc.DeepEquals, []latestCharmInfo{{
+		essentialMetadata: charm.EssentialMetadata{
+			ResolvedOrigin: charm.Origin{
+				Source:   charm.CharmHub,
+				Revision: ptr(666),
+				Channel:  &channel,
+				Platform: charm.Platform{
+					Architecture: "amd64",
+					OS:           "ubuntu",
+					Channel:      "22.04",
+				},
+			},
+		},
+		charmLocator: charmLocator,
+		timestamp:    s.now,
+		revision:     666,
+		appID:        "foo",
+	}})
+}
+
 func (s *WorkerSuite) TestFetchInfo(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
@@ -249,8 +338,13 @@ func (s *WorkerSuite) TestFetchInfo(c *gc.C) {
 	id := ids[0]
 
 	apps := []appInfo{{
-		id:       "foo",
-		charmURL: charm.MustParseURL("ch:foo-42"),
+		id: "foo",
+		charmLocator: applicationcharm.CharmLocator{
+			Source:       applicationcharm.CharmHubSource,
+			Name:         "foo",
+			Revision:     42,
+			Architecture: architecture.AMD64,
+		},
 	}}
 
 	cfg, err := charmhub.RefreshOne(id.instanceKey, id.id, id.revision, id.channel, charmhub.RefreshBase{
@@ -263,7 +357,8 @@ func (s *WorkerSuite) TestFetchInfo(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.charmhubClient.EXPECT().RefreshWithRequestMetrics(gomock.Any(), charmhub.RefreshMany(cfg), metrics).Return([]transport.RefreshResponse{{
-		Name: id.id,
+		Name:             id.id,
+		EffectiveChannel: "latest/stable",
 		Entity: transport.RefreshEntity{
 			Revision: 666,
 		},
@@ -276,11 +371,24 @@ func (s *WorkerSuite) TestFetchInfo(c *gc.C) {
 
 	result, err := w.fetchInfo(context.Background(), s.charmhubClient, true, ids, apps)
 	c.Assert(err, jc.ErrorIsNil)
+
+	channel := internalcharm.MakePermissiveChannel("latest", "stable", "")
 	c.Check(result, jc.DeepEquals, []latestCharmInfo{{
-		url:       apps[0].charmURL,
-		timestamp: s.now,
-		revision:  666,
-		appID:     "foo",
+		essentialMetadata: charm.EssentialMetadata{
+			ResolvedOrigin: charm.Origin{
+				Source:   charm.CharmHub,
+				Revision: ptr(666),
+				Channel:  &channel,
+				Platform: charm.Platform{
+					Architecture: "amd64",
+					OS:           "ubuntu",
+				},
+			},
+		},
+		charmLocator: apps[0].charmLocator,
+		timestamp:    s.now,
+		revision:     666,
+		appID:        "foo",
 	}})
 }
 
@@ -345,7 +453,8 @@ func (s *WorkerSuite) TestFetchInfoInvalidResponseLength(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.charmhubClient.EXPECT().RefreshWithRequestMetrics(gomock.Any(), charmhub.RefreshMany(cfg), metrics).Return([]transport.RefreshResponse{{
-		Name: id.id,
+		Name:             id.id,
+		EffectiveChannel: "latest/stable",
 		Entity: transport.RefreshEntity{
 			Revision: 666,
 		},
@@ -412,7 +521,11 @@ func (s *WorkerSuite) TestRequest(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	s.charmhubClient.EXPECT().RefreshWithRequestMetrics(gomock.Any(), charmhub.RefreshMany(cfg), metrics).Return([]transport.RefreshResponse{{
-		Name: id.id,
+		Name:             id.id,
+		EffectiveChannel: "latest/stable",
+		Entity: transport.RefreshEntity{
+			Revision: 666,
+		},
 	}}, nil)
 
 	w := s.newWorker(c)
@@ -420,11 +533,20 @@ func (s *WorkerSuite) TestRequest(c *gc.C) {
 
 	s.ensureStartup(c)
 
+	channel := internalcharm.MakePermissiveChannel("latest", "stable", "")
 	result, err := w.request(context.Background(), s.charmhubClient, metrics, ids)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(result, jc.DeepEquals, []charmhubResult{{
 		name:      id.id,
 		timestamp: s.now,
+		essentialMetadata: charm.EssentialMetadata{
+			ResolvedOrigin: charm.Origin{
+				Source:   charm.CharmHub,
+				Revision: ptr(666),
+				Channel:  &channel,
+			},
+		},
+		revision: 666,
 	}})
 }
 
@@ -482,8 +604,10 @@ func (s *WorkerSuite) TestRequestWithResources(c *gc.C) {
 	hash384 := "e8e4d9727695438c7f5c91347e50e3d68eaab5fe3f856685de5a80fbaafb3c1700776dea0eb7db09c940466ba270a4e4"
 
 	s.charmhubClient.EXPECT().RefreshWithRequestMetrics(gomock.Any(), charmhub.RefreshMany(cfg), metrics).Return([]transport.RefreshResponse{{
-		Name: id.id,
+		Name:             id.id,
+		EffectiveChannel: "latest/stable",
 		Entity: transport.RefreshEntity{
+			Revision: 666,
 			Resources: []transport.ResourceRevision{{
 				Type:     "file",
 				Revision: 42,
@@ -502,6 +626,7 @@ func (s *WorkerSuite) TestRequestWithResources(c *gc.C) {
 
 	s.ensureStartup(c)
 
+	channel := internalcharm.MakePermissiveChannel("latest", "stable", "")
 	result, err := w.request(context.Background(), s.charmhubClient, metrics, ids)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(result, jc.DeepEquals, []charmhubResult{{
@@ -515,6 +640,14 @@ func (s *WorkerSuite) TestRequestWithResources(c *gc.C) {
 			Fingerprint: fingerprint,
 			Revision:    42,
 		}},
+		essentialMetadata: charm.EssentialMetadata{
+			ResolvedOrigin: charm.Origin{
+				Source:   charm.CharmHub,
+				Revision: ptr(666),
+				Channel:  &channel,
+			},
+		},
+		revision: 666,
 	}})
 }
 
@@ -575,41 +708,121 @@ func (s *WorkerSuite) TestRequestWithError(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, "*api-error: boom")
 }
 
-func (s *WorkerSuite) TestEncodeCharmURL(c *gc.C) {
-	url, err := encodeCharmURL(applicationcharm.CharmLocator{
-		Source:       applicationcharm.CharmHubSource,
-		Name:         "foo",
-		Revision:     42,
-		Architecture: architecture.AMD64,
-	})
+func (s *WorkerSuite) TestStoreNewRevisionsNoUpdates(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.expectWatcher(c)
+	s.expectModelConfig(c)
+
+	latestCharmInfos := []latestCharmInfo{}
+
+	w := s.newWorker(c)
+	defer workertest.DirtyKill(c, w)
+
+	s.ensureStartup(c)
+
+	err := w.storeNewRevisions(context.Background(), latestCharmInfos)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(url.String(), gc.Equals, "ch:amd64/foo-42")
 }
 
-func (s *WorkerSuite) TestEncodeCharmURLLocalCharmSource(c *gc.C) {
-	_, err := encodeCharmURL(applicationcharm.CharmLocator{
-		Source:       applicationcharm.LocalSource,
-		Name:         "foo",
-		Revision:     42,
-		Architecture: architecture.AMD64,
-	})
-	c.Assert(err, gc.ErrorMatches, `unsupported charm source "local"`)
+func (s *WorkerSuite) TestStoreNewRevisions(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.expectWatcher(c)
+	s.expectModelConfig(c)
+
+	latestCharmInfos := []latestCharmInfo{{
+		charmLocator: applicationcharm.CharmLocator{
+			Source:       applicationcharm.CharmHubSource,
+			Name:         "foo",
+			Revision:     42,
+			Architecture: architecture.AMD64,
+		},
+		essentialMetadata: charm.EssentialMetadata{
+			Meta: &internalcharm.Meta{
+				Name: "foo",
+			},
+			Manifest: &internalcharm.Manifest{
+				Bases: []internalcharm.Base{{
+					Name: "ubuntu",
+					Channel: internalcharm.Channel{
+						Risk: "stable",
+					},
+					Architectures: []string{"amd64"},
+				}},
+			},
+			DownloadInfo: corecharm.DownloadInfo{
+				CharmhubIdentifier: "abc123",
+				DownloadURL:        "https://example.com/foo",
+				DownloadSize:       123,
+			},
+		},
+		timestamp: s.now,
+		revision:  43,
+		appID:     "foo",
+	}}
+	essentialMetadata := latestCharmInfos[0].essentialMetadata
+
+	s.applicationService.EXPECT().ReserveCharmRevision(gomock.Any(), applicationcharm.SetCharmArgs{
+		Charm: internalcharm.NewCharmBase(
+			essentialMetadata.Meta,
+			essentialMetadata.Manifest,
+			essentialMetadata.Config,
+			// These will be filled in once we have all the data in the
+			// response from the charmhub.
+			nil, nil,
+		),
+
+		Source:        corecharm.CharmHub,
+		ReferenceName: "foo",
+		Revision:      43,
+		DownloadInfo: &applicationcharm.DownloadInfo{
+			Provenance:         applicationcharm.ProvenanceDownload,
+			CharmhubIdentifier: "abc123",
+			DownloadURL:        "https://example.com/foo",
+			DownloadSize:       123,
+		},
+	}).Return(charm.ID("foo"), nil, nil)
+
+	w := s.newWorker(c)
+	defer workertest.DirtyKill(c, w)
+
+	s.ensureStartup(c)
+
+	err := w.storeNewRevisions(context.Background(), latestCharmInfos)
+	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *WorkerSuite) TestEncodeCharmURLInvalidArchitecture(c *gc.C) {
-	_, err := encodeCharmURL(applicationcharm.CharmLocator{
-		Source:       applicationcharm.CharmHubSource,
-		Name:         "foo",
-		Revision:     42,
-		Architecture: architecture.Architecture(99),
-	})
-	c.Assert(err, gc.ErrorMatches, `.*unsupported architecture .*`)
+func (s *WorkerSuite) TestStoreNewRevisionsError(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.expectWatcher(c)
+	s.expectModelConfig(c)
+
+	latestCharmInfos := []latestCharmInfo{{
+		charmLocator: applicationcharm.CharmLocator{
+			Source:       applicationcharm.CharmHubSource,
+			Name:         "foo",
+			Revision:     42,
+			Architecture: architecture.AMD64,
+		},
+	}}
+
+	s.applicationService.EXPECT().ReserveCharmRevision(gomock.Any(), gomock.Any()).Return(charm.ID("foo"), nil, errors.New("boom"))
+
+	w := s.newWorker(c)
+	defer workertest.DirtyKill(c, w)
+
+	s.ensureStartup(c)
+
+	err := w.storeNewRevisions(context.Background(), latestCharmInfos)
+	c.Assert(err, gc.ErrorMatches, "boom")
 }
 
 func (s *WorkerSuite) TestEncodeCharmID(c *gc.C) {
 	modelTag := names.NewModelTag(uuid.MustNewUUID().String())
 	id, err := encodeCharmhubID(application.RevisionUpdaterApplication{
-		Name: "application-foo",
+		Name: "foo",
 		CharmLocator: applicationcharm.CharmLocator{
 			Source:       applicationcharm.LocalSource,
 			Name:         "foo",
@@ -649,9 +862,9 @@ func (s *WorkerSuite) TestEncodeCharmID(c *gc.C) {
 func (s *WorkerSuite) TestEncodeCharmIDInvalidApplicationTag(c *gc.C) {
 	modelTag := names.NewModelTag(uuid.MustNewUUID().String())
 	_, err := encodeCharmhubID(application.RevisionUpdaterApplication{
-		Name: "app-foo",
+		Name: "!foo",
 	}, modelTag)
-	c.Assert(err, gc.ErrorMatches, `parsing application tag: "app-foo".*`)
+	c.Assert(err, gc.ErrorMatches, `invalid application name "!foo"`)
 }
 
 func (s *WorkerSuite) TestEncodeCharmIDInvalidRisk(c *gc.C) {
@@ -794,6 +1007,8 @@ func (s *WorkerSuite) setupMocks(c *gc.C) *gomock.Controller {
 	s.clock = NewMockClock(ctrl)
 	s.clock.EXPECT().Now().Return(s.now).AnyTimes()
 
+	s.modelTag = names.NewModelTag(uuid.MustNewUUID().String())
+
 	return ctrl
 }
 
@@ -802,7 +1017,7 @@ func (s *WorkerSuite) newWorker(c *gc.C) *revisionUpdateWorker {
 		ModelConfigService: s.modelConfigService,
 		ApplicationService: s.applicationService,
 		ModelService:       s.modelService,
-		ModelTag:           names.NewModelTag(uuid.MustNewUUID().String()),
+		ModelTag:           s.modelTag,
 		NewHTTPClient: func(context.Context, http.HTTPClientGetter) (http.HTTPClient, error) {
 			return s.httpClient, nil
 		},

--- a/internal/worker/dbrepl/worker.go
+++ b/internal/worker/dbrepl/worker.go
@@ -246,14 +246,14 @@ func (w *dbReplWorker) loop() (err error) {
 
 func (w *dbReplWorker) execSwitch(ctx context.Context, args []string) {
 	if len(args) != 1 {
-		fmt.Fprintln(w.cfg.Stderr, "usage: .switch <name>")
+		fmt.Fprintln(w.cfg.Stderr, "usage: .switch model-<name> or .switch controller for global controller database")
 		return
 	}
 
 	argName := args[0]
 	if argName == "controller" {
 		w.currentDB = w.controllerDB
-		w.currentNamespace = "*"
+		w.currentNamespace = argName
 		return
 	}
 
@@ -426,15 +426,14 @@ func filterInput(r rune) (rune, bool) {
 const helpText = `
 The following commands are available:
 
-  .exit, .quit       Exit the REPL.
-  .help, .h          Show this help message.
-  .models            Show all models.
-  .switch <model>    Switch to a different model (or global database).
-  .tables            Show all standard tables in the current database.
-  .triggers          Show all trigger tables in the current database.
-  .views             Show all views in the current database.
-  .ddl <name>        Show the DDL for the specified table, trigger, or view.
+  .exit, .quit             Exit the REPL.
+  .help, .h                Show this help message.
+  .models                  Show all models.
+  .switch model-<model>    Switch to a different model.
+  .switch controller       Switch to the controller global database.
+  .tables                  Show all standard tables in the current database.
+  .triggers                Show all trigger tables in the current database.
+  .views                   Show all views in the current database.
+  .ddl <name>              Show the DDL for the specified table, trigger, or view.
 
-The global database can be accessed by using the '*' or 'global' keyword
-when switching databases. 
 `


### PR DESCRIPTION
Once the charm revision worker has run, we need to store the new revisions. These revisions need to contain all the essential metadata so that when the charm is swapped to the new one, it can be downloaded with all the correct data. Effectively, the charm is deployed in all circumstances.

Reworking the charmrevisioner to remove the charm URL and just using the charm locator removes a needless encoding of the charm URL.

The architecture is tricky because it should just be the same as the existing application, but there is no way to verify that using the response. We just have to trust the API.

-----

This pull request includes several changes to the `charmrevisioner` worker to improve the handling of charm revisions and their metadata. The most important changes include the addition of a new method to reserve charm revisions, updates to the application state to include a new identifier, and enhancements to the worker's revision update process.

### Enhancements to charm revision handling:

* [`domain/application/service/charm.go`](diffhunk://#diff-f634e196c8c372b1bc36ad4d6db384d26713e39a92b90c981816480a2d1e91d6R889-R899): Added a new method `ReserveCharmRevision` to reserve a charm revision for a given charm ID, returning warnings if there are non-blocking issues.
* [`internal/worker/charmrevisioner/worker.go`](diffhunk://#diff-8bd3a975a51af8c1205ea4861c5103f7097a13c3b4c4b1849da3d20739524374R67-R71): Updated the `ApplicationService` interface and the `revisionUpdateWorker` to include the `ReserveCharmRevision` method and handle new charm revision storage. Added methods to store new revisions and handle telemetry configuration. [[1]](diffhunk://#diff-8bd3a975a51af8c1205ea4861c5103f7097a13c3b4c4b1849da3d20739524374R67-R71) [[2]](diffhunk://#diff-8bd3a975a51af8c1205ea4861c5103f7097a13c3b4c4b1849da3d20739524374R236-R259) [[3]](diffhunk://#diff-8bd3a975a51af8c1205ea4861c5103f7097a13c3b4c4b1849da3d20739524374L277-L297) [[4]](diffhunk://#diff-8bd3a975a51af8c1205ea4861c5103f7097a13c3b4c4b1849da3d20739524374L313-R350) [[5]](diffhunk://#diff-8bd3a975a51af8c1205ea4861c5103f7097a13c3b4c4b1849da3d20739524374R393-R416) [[6]](diffhunk://#diff-8bd3a975a51af8c1205ea4861c5103f7097a13c3b4c4b1849da3d20739524374R452-R524) [[7]](diffhunk://#diff-8bd3a975a51af8c1205ea4861c5103f7097a13c3b4c4b1849da3d20739524374R587-R603)

### Updates to application state:

* [`domain/application/state/application.go`](diffhunk://#diff-994df01f80f2f62fa018f73b1f15b583e059dd830bda4c524f4824df8764bb08R2178): Added a new field `CharmhubIdentifier` to the `Origin` struct to store the charmhub identifier.
* [`domain/application/state/types.go`](diffhunk://#diff-1129494fcd03573fb4e70eca0f2e6bd6d86cb7ccdace444e6cd1a5effb6795e1R664): Added the `CharmhubIdentifier` field to the `revisionUpdaterApplication` struct.
* [`domain/schema/model/sql/0025-revision-updater.sql`](diffhunk://#diff-aab4704c2a1516a3dc1522d668e07ba0e245252ccd404567832a62682ea8bb68L13-R19): Updated the SQL schema to include the `charmhub_identifier` field in the `v_revision_updater_application_unit` view.

### Test and mock updates:

* [`internal/worker/charmrevisioner/package_mocks_test.go`](diffhunk://#diff-1775e1c26124f986647875f18015714002ff3d4b44d6067a63396d802d7b6211R290-R329): Added mocks for the `ReserveCharmRevision` method.
* [`internal/worker/charmrevisioner/worker_test.go`](diffhunk://#diff-a339279173bc60eecdeecd5d28d248bb3d4f575e332f1cbf60af2793059b1b4bR18-R19): Updated tests to include the new `ReserveCharmRevision` method and added a utility function `ptr`. [[1]](diffhunk://#diff-a339279173bc60eecdeecd5d28d248bb3d4f575e332f1cbf60af2793059b1b4bR18-R19) [[2]](diffhunk://#diff-a339279173bc60eecdeecd5d28d248bb3d4f575e332f1cbf60af2793059b1b4bL29-R31) [[3]](diffhunk://#diff-a339279173bc60eecdeecd5d28d248bb3d4f575e332f1cbf60af2793059b1b4bR52-R53) [[4]](diffhunk://#diff-23db611b4cb037ae2785eee165720f96713ed880b4312cebbfc3c0b98fb498d9R22-R25)

These changes collectively enhance the charm revision handling capabilities and improve the robustness of the `charmrevisioner` worker.


## QA steps

Apply the following diff:

```
diff --git a/cmd/jujud-controller/agent/machine.go b/cmd/jujud-controller/agent/machine.go
index 3f9ebeca0a..baa329e557 100644
--- a/cmd/jujud-controller/agent/machine.go
+++ b/cmd/jujud-controller/agent/machine.go
@@ -980,7 +980,7 @@ func (a *MachineAgent) startModelWorkers(cfg modelworkermanager.NewModelConfig)
                Clock:                       clock.WallClock,
                LoggingContext:              loggingContext,
                RunFlagDuration:             time.Minute,
-               CharmRevisionUpdateInterval: 24 * time.Hour,
+               CharmRevisionUpdateInterval: 30 * time.Second,
                StatusHistoryPrunerInterval: 5 * time.Minute,
                ActionPrunerInterval:        24 * time.Hour,
                NewEnvironFunc:              newEnvirons,
```

```
$ juju bootstrap lxd test
$ juju add-model default
$ juju deploy ubuntu --revision=24 --channel=stable
$ juju ssh -m controller 0
$ sudo /var/lib/juju/tools/machine-0/jujud db-repl --machine-id 0
repl (controller)> .switch model-controller
repl (model-controller)> SELECT * FROM charm
uuid                                    archive_path            object_store_uuid                       available       version lxd_profile     source_id       revision        architecture_id reference_name
328b315e-df08-4d7e-8ab8-a5ec252f92e7    dbvXVgKNSL6JQ1LTyMQ/Rw  9050925d-2dc1-4d14-81cc-7c15abb078e7    true                    []              1               117             0               juju-controller

repl (model-controller)> .switch model-default
repl (model-default)> SELECT * FROM charm
uuid                                    archive_path            object_store_uuid                       available       version lxd_profile     source_id       revision        architecture_id reference_name
5e135085-c4c2-49ce-8632-1e1d5a6c4052    1nmQUJneSDSLSz8ah8cCew  cd3e18c0-2d08-441b-893d-e16b63367384    true                    []              1               24              0               ubuntu

repl (model-default)> SELECT * FROM charm
uuid                                    archive_path            object_store_uuid                       available       version lxd_profile     source_id       revision        architecture_id reference_name
5e135085-c4c2-49ce-8632-1e1d5a6c4052    1nmQUJneSDSLSz8ah8cCew  cd3e18c0-2d08-441b-893d-e16b63367384    true                    []              1               24              0               ubuntu

repl (model-default)> SELECT * FROM charm
uuid                                    archive_path            object_store_uuid                       available       version lxd_profile     source_id       revision        architecture_id reference_name
5e135085-c4c2-49ce-8632-1e1d5a6c4052    1nmQUJneSDSLSz8ah8cCew  cd3e18c0-2d08-441b-893d-e16b63367384    true                    []              1               24              0               ubuntu

repl (model-default)> SELECT * FROM charm
uuid                                    archive_path            object_store_uuid                       available       version lxd_profile     source_id       revision        architecture_id reference_name
5e135085-c4c2-49ce-8632-1e1d5a6c4052    1nmQUJneSDSLSz8ah8cCew  cd3e18c0-2d08-441b-893d-e16b63367384    true                    []              1               24              0               ubuntu
81a123be-9268-472b-8795-b077323d9dd7                            <nil>                                   false                   []              1               25              0               ubuntu

repl (model-default)> SELECT * FROM charm_hash
charm_uuid                              hash_kind_id    hash
5e135085-c4c2-49ce-8632-1e1d5a6c4052    0               9b2877f7ebf04b348cf40ace32fdfc6d1cc0157dea7fd6740c4ba74e0e201e5b
81a123be-9268-472b-8795-b077323d9dd7    0               75e3bf60b79f9902cae89cf242c6e197d9744b2d25bd5835f7101b77913f0e10

repl (model-default)> SELECT * FROM charm_download_info
charm_uuid                              provenance_id   charmhub_identifier                     download_url                                                                                    download_size
5e135085-c4c2-49ce-8632-1e1d5a6c4052    0               DksXQKAQTZfsUmBAGanZAhpoS4dpmXel        https://api.charmhub.io/api/v1/charms/download/DksXQKAQTZfsUmBAGanZAhpoS4dpmXel_24.charm        2139977
81a123be-9268-472b-8795-b077323d9dd7    0               DksXQKAQTZfsUmBAGanZAhpoS4dpmXel        https://api.charmhub.io/api/v1/charms/download/DksXQKAQTZfsUmBAGanZAhpoS4dpmXel_25.charm        5227288

repl (model-default)> SELECT * FROM charm_hash
charm_uuid                              hash_kind_id    hash
5e135085-c4c2-49ce-8632-1e1d5a6c4052    0               9b2877f7ebf04b348cf40ace32fdfc6d1cc0157dea7fd6740c4ba74e0e201e5b
81a123be-9268-472b-8795-b077323d9dd7    0               75e3bf60b79f9902cae89cf242c6e197d9744b2d25bd5835f7101b77913f0e10

repl (model-default)> SELECT * FROM charm_metadata
charm_uuid                              name                            description     summary subordinate     min_juju_version        run_as_id       assumes
5e135085-c4c2-49ce-8632-1e1d5a6c4052    ubuntu                          This simply deploys the Ubuntu Cloud/Server image
                                        A pristine Ubuntu Server        false   0.0.0   0       []
81a123be-9268-472b-8795-b077323d9dd7    ubuntu                          This simply deploys the Ubuntu Cloud/Server image
                                        A pristine Ubuntu Server        false   0.0.0   0       []

repl (model-default)> SELECT * FROM charm_hash
charm_uuid                              hash_kind_id    hash
5e135085-c4c2-49ce-8632-1e1d5a6c4052    0               9b2877f7ebf04b348cf40ace32fdfc6d1cc0157dea7fd6740c4ba74e0e201e5b
81a123be-9268-472b-8795-b077323d9dd7    0               75e3bf60b79f9902cae89cf242c6e197d9744b2d25bd5835f7101b77913f0e10

repl (model-default)> SELECT * FROM charm
uuid                                    archive_path            object_store_uuid                       available       version lxd_profile     source_id       revision        architecture_id reference_name
5e135085-c4c2-49ce-8632-1e1d5a6c4052    1nmQUJneSDSLSz8ah8cCew  cd3e18c0-2d08-441b-893d-e16b63367384    true                    []              1               24              0               ubuntu
81a123be-9268-472b-8795-b077323d9dd7                            <nil>                                   false                   []              1               25              0               ubuntu
```

## Links


**Jira card:** [ JUJU-7279](https://warthogs.atlassian.net/browse/JUJU-7279)

