### PR TITLE
chore: dangling state trackers

### DIFF
--- a/worker/modelworkermanager/manifold.go
+++ b/worker/modelworkermanager/manifold.go
@@ -125,6 +125,7 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 
 	systemState, err := statePool.SystemState()
 	if err != nil {
+		_ = stTracker.Done()
 		return nil, errors.Trace(err)
 	}
 	w, err := config.NewWorker(Config{

--- a/worker/multiwatcher/manifold.go
+++ b/worker/multiwatcher/manifold.go
@@ -97,6 +97,7 @@ func (config ManifoldConfig) start(context dependency.Context) (worker.Worker, e
 
 	allWatcher, err := config.NewAllWatcher(pool)
 	if err != nil {
+		_ = stTracker.Done()
 		return nil, errors.Trace(err)
 	}
 


### PR DESCRIPTION
While investigating bug[1], I noticed we aren't correctly releasing the state tracker on errors. Accessing state like this is always prone to errors. We've fixed this in 4.0, but we can't do it here, so we need to audit every access pattern to ensure it's correct.

This doesn't solve the bug[1], but it should handle error cases.

 1. https://bugs.launchpad.net/juju/+bug/2078459

## QA steps

N/A

## Links

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2078459


