### PR TITLE
chore(deps): remove viddy from dependencies

### DIFF
--- a/cmd/juju/status/status.go
+++ b/cmd/juju/status/status.go
@@ -413,20 +413,15 @@ func (c *statusCommand) Run(ctx *cmd.Context) error {
 		// Collect all args except the watch flag
 		jujuStatusArgs := c.statusCommandForWatch(os.Args)
 
-		// Check what watch shell command is available. Using the following order:
-		// 1. `viddy`
-		// 2. `watch`
-		// 3. send error to output
+		// Check is  `viddy` shell command available, if not thought the error. In case strictly confined juju snap
+		// viddy installed as a `part`.
 		var watchArgs []string
 		var watchableJujuCmd *exec.Cmd
 		if _, err := exec.LookPath("viddy"); err == nil {
 			watchArgs = append([]string{"--no-title", "--interval", c.watch.String()}, jujuStatusArgs...)
 			watchableJujuCmd = exec.Command("viddy", watchArgs...)
-		} else if _, err = exec.LookPath("watch"); err == nil {
-			watchArgs = append([]string{"-n", strconv.Itoa(int(c.watch.Seconds()))}, jujuStatusArgs...)
-			watchableJujuCmd = exec.Command("watch", watchArgs...)
 		} else {
-			return errors.Annotate(err, "there is no any watch shell command available")
+			return errors.Annotate(err, "`viddy` (watch-command) is not available")
 		}
 		watchableJujuCmd.Stdout = os.Stdout
 		watchableJujuCmd.Stderr = os.Stderr

--- a/cmd/juju/status/status.go
+++ b/cmd/juju/status/status.go
@@ -413,15 +413,15 @@ func (c *statusCommand) Run(ctx *cmd.Context) error {
 		// Collect all args except the watch flag
 		jujuStatusArgs := c.statusCommandForWatch(os.Args)
 
-		// Check is  `viddy` shell command available, if not thought the error. In case strictly confined juju snap
-		// viddy installed as a `part`.
+		// Check is `viddy` shell command available, if not thought the error. In case strictly confined juju snap
+		// juju-watch is installed.
 		var watchArgs []string
 		var watchableJujuCmd *exec.Cmd
 		if _, err := exec.LookPath("viddy"); err == nil {
 			watchArgs = append([]string{"--no-title", "--interval", c.watch.String()}, jujuStatusArgs...)
 			watchableJujuCmd = exec.Command("viddy", watchArgs...)
 		} else {
-			return errors.Annotate(err, "`viddy` (watch-command) is not available")
+			return errors.Annotate(err, "there is no viddy (watch) command available")
 		}
 		watchableJujuCmd.Stdout = os.Stdout
 		watchableJujuCmd.Stderr = os.Stderr

--- a/cmd/juju/status/status_internal_test.go
+++ b/cmd/juju/status/status_internal_test.go
@@ -5563,9 +5563,9 @@ func (s *StatusSuite) TestStatusArgsWithoutWatch(c *gc.C) {
 
 	statusArgsGNUStyle := []string{"juju", "status", "--watch=1s", "--relations"}
 	expectedArgsGNUStyle := []string{"juju", "status", "--relations", "--color"}
-	c.Check(cmd.statusCommandForViddy(statusArgsGNUStyle), jc.SameContents, expectedArgsGNUStyle)
+	c.Check(cmd.statusCommandForWatch(statusArgsGNUStyle), jc.SameContents, expectedArgsGNUStyle)
 
 	statusArgsUnixStyle := []string{"juju", "status", "--watch", "1s", "--relations"}
 	expectedArgsUnixStyle := []string{"juju", "status", "--relations", "--color"}
-	c.Check(cmd.statusCommandForViddy(statusArgsUnixStyle), jc.SameContents, expectedArgsUnixStyle)
+	c.Check(cmd.statusCommandForWatch(statusArgsUnixStyle), jc.SameContents, expectedArgsUnixStyle)
 }

--- a/go.mod
+++ b/go.mod
@@ -74,7 +74,6 @@ require (
 	github.com/juju/txn/v3 v3.0.2
 	github.com/juju/utils/v4 v4.0.2
 	github.com/juju/version/v2 v2.0.1
-	github.com/juju/viddy v0.0.0-beta5
 	github.com/juju/webbrowser v1.0.0
 	github.com/juju/worker/v4 v4.0.0
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -59,6 +59,8 @@ apps:
       - home
       # Needed to that SSO via the web browser can work.
       - desktop
+      # Needed to watch juju status updates.
+      - watch
   fetch-oci:
     daemon: oneshot
     command: wrappers/fetch-oci
@@ -306,22 +308,6 @@ parts:
     stage-packages:
       - openssh-client
 
-  viddy:
-    after:
-      - juju
-    plugin: nil
-    source: .
-    build-packages:
-      - wget
-      - tar
-    override-build: |
-      set -ex
-  
-      wget -O viddy.tar.gz https://github.com/sachaos/viddy/releases/download/v1.3.0/viddy-v1.3.0-linux-x86_64.tar.gz
-      tar xvf viddy.tar.gz
-      mkdir -p ${CRAFT_PART_INSTALL}/bin
-      cp viddy ${CRAFT_PART_INSTALL}/bin/viddy
-
 hooks:
   connect-plug-peers: {}
   disconnect-plug-peers: {}
@@ -390,3 +376,7 @@ plugs:
     interface: personal-files
     read:
       - $HOME/.novarc
+
+  watch:
+    interface: content
+    target: $SNAP/watch

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -306,6 +306,22 @@ parts:
     stage-packages:
       - openssh-client
 
+  viddy:
+    after:
+      - juju
+    plugin: nil
+    source: .
+    build-packages:
+      - wget
+      - tar
+    override-build: |
+      set -ex
+  
+      wget -O viddy.tar.gz https://github.com/sachaos/viddy/releases/download/v1.3.0/viddy-v1.3.0-linux-x86_64.tar.gz
+      tar xvf viddy.tar.gz
+      mkdir -p ${CRAFT_PART_INSTALL}/bin
+      cp viddy ${CRAFT_PART_INSTALL}/bin/viddy
+
 hooks:
   connect-plug-peers: {}
   disconnect-plug-peers: {}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -34,7 +34,7 @@ apps:
   juju:
     environment:
       # Make sure we access snap binaries first (i.e. juju-metadata lp:1759013)
-      PATH: "$SNAP/bin:$SNAP/usr/bin:/snap/bin:$PATH"
+      PATH: "$SNAP/watch/bin:$SNAP/bin:$SNAP/usr/bin:/snap/bin:$PATH"
     command: bin/juju
     plugs:
       - network


### PR DESCRIPTION
- Removed the `viddy` dependency from the `statusCommand` in `cmd/juju/status/status.go`.
- Updated the logic to use the `viddy` command if available, or provided an error message otherwise.
- Added `viddy` as a `part` of juju snap.


## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing

## QA steps

```sh
juju bootstrap lxd lxd 
juju switch controller

# --watch should via `viddy` command
juju status --watch 2s

# If no `viddy,` the result will be an error.
```

### Strictly confined snap case:

#### Create viddy snap
```sh
mkdir ~/tmp/viddy-snap/snap

cat <<EOF > ~/tmp/viddy-snap/snap/snapcraft.yaml
name: viddy # you probably want to 'snapcraft register <name>'
base: core24 # the base snap is the execution environment for this snap
version: '0.0.1' # just for humans, typically '1.2+git' or '1.3.2'
summary: Modern watch command # 79 char long summary
description: |
  This is snap of Modern watch command. Time machine and pager etc.

grade: devel # must be 'stable' to release into candidate/stable channels
confinement: strict # use 'strict' once you have the right plugs and slots. Default is `devmode`

apps:
  viddy:
    command: bin/viddy

parts:
  viddy:
    plugin: rust
    build-snaps:
      - rustup/1.27.1/stable
    source-type: git
    source: https://github.com/sachaos/viddy.git

slots:
  watch:
    interface: content
    read:
    - /
EOF

cd ~/tmp/viddy-snap/
snapcraft pack

# install viddy local snap
sudo snap install viddy_0.0.1_amd64.snap --dangerous
```

```
# in juju home folder
snapcraft pack

sudo snap install juju_4.0-beta5_amd64.snap  --dangerous

sudo snap connect juju:lxd lxd
sudo snap connect juju:config-lxd
sudo snap connect juju:dot-local-share-juju
sudo snap connect juju:ssh-keys

# connect with viddy snap
sudo snap connect juju:watch viddy

snap connections juju

juju status --watch 4s
```


## Documentation changes

...

## Links

**Jira card:** JUJU-

