### PR TITLE
test: fix intermittent failure in TestRecallUnit

### DIFF
--- a/internal/worker/deployer/nested_test.go
+++ b/internal/worker/deployer/nested_test.go
@@ -4,6 +4,8 @@
 package deployer_test
 
 import (
+	"os"
+	"path"
 	"time"
 
 	"github.com/juju/clock"
@@ -18,6 +20,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/agent"
+	"github.com/juju/juju/agent/addons"
 	agentconfig "github.com/juju/juju/agent/config"
 	"github.com/juju/juju/agent/engine"
 	corelogger "github.com/juju/juju/core/logger"
@@ -91,9 +94,7 @@ func (s *NestedContextSuite) SetUpTest(c *gc.C) {
 				loggo.GetLogger("juju.worker.dependency"),
 			)
 		},
-		SetupLogging: func(corelogger.LoggerContext, agent.Config) {
-
-		},
+		SetupLogging:  func(corelogger.LoggerContext, agent.Config) {},
 		UnitManifolds: s.workers.Manifolds,
 	}
 }
@@ -197,12 +198,22 @@ func (s *NestedContextSuite) TestRecallUnit(c *gc.C) {
 	// Wait for unit to start.
 	s.workers.waitForStart(c, unitName)
 
+	// Waiting for the unit to be indicated as started (above) is not sufficient
+	// for this test.
+	// The unitWorkersStub that represents the nested config for the unit
+	// dependency engine indicates that the unit is started as soon as it is
+	// created, but the introspection socket is created subsequently, which can
+	// inhibit removal of the directory during the subsequent call to RecallUnit.
+	// Waiting for the socket file to be present on disk is more robust.
+	socketPath := path.Join(agent.Dir(s.agent.DataDir(), tag), addons.IntrospectionSocketName)
+	err = waitForFile(socketPath)
+	c.Assert(err, jc.ErrorIsNil)
+
 	err = ctx.RecallUnit(unitName)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Unit agent dir no longer exists.
-	unitAgentDir := agent.Dir(s.agent.DataDir(), tag)
-	c.Assert(unitAgentDir, jc.DoesNotExist)
+	c.Assert(agent.Dir(s.agent.DataDir(), tag), jc.DoesNotExist)
 
 	// Unit written into the config value as deployed units.
 	c.Assert(s.agent.CurrentConfig().Value("deployed-units"), gc.HasLen, 0)
@@ -210,6 +221,23 @@ func (s *NestedContextSuite) TestRecallUnit(c *gc.C) {
 	// Recall is idempotent.
 	err = ctx.RecallUnit(unitName)
 	c.Assert(err, jc.ErrorIsNil)
+}
+
+func waitForFile(filePath string) error {
+	maxAttempts := 10
+	pollInterval := 50 * time.Millisecond
+
+	for i := 0; i < maxAttempts; i++ {
+		if _, err := os.Stat(filePath); err == nil {
+			return nil
+		} else if !os.IsNotExist(err) {
+			return err
+		}
+
+		time.Sleep(pollInterval)
+	}
+
+	return errors.New("file not found after 10 attempts")
 }
 
 func (s *NestedContextSuite) TestErrTerminateAgentFromAgentWorker(c *gc.C) {


### PR DESCRIPTION
In the deployer tests, we have `unitWorkersStub`, which is used as the `Manifold` for the unit agent dependency engine.

This effectively represents a unit's workers as started the moment its `Start` function is called. It is *after* this point that the introspection socket is created for the new agent on disk.

This in turn may cause problems in `TestRecallUnit`, because we only check for the started condition above before attempting to recall. `RecallUnit` may then attempt to delete the unit's agent directory while we are creating the socket.

This likely became possible after we switched away from abstract sockets due to security concerns.

Here we simply check for the socket file presence before proceeding.

## QA steps

Run `TestRecallUnit` from /internal/worker/deployer.go in a loop.