### PR TITLE
ci: fix terraform smoke test

### DIFF
--- a/.github/workflows/terraform-smoke.yml
+++ b/.github/workflows/terraform-smoke.yml
@@ -42,6 +42,19 @@ jobs:
         run: |
           make go-install
 
+      - name: Install microk8s
+        run: |
+          sudo snap install microk8s --channel=1.28-strict/stable
+          sudo usermod -a -G snap_microk8s $USER
+          sudo chown -R $USER ~/.kube
+          sudo microk8s.enable dns storage
+          sudo microk8s.enable dns local-storage
+          sudo -g snap_microk8s -E microk8s status --wait-ready --timeout=600
+
+      - name: Set additional environment for LXD
+        run: |
+          sudo microk8s.config > /home/$USER/microk8s-config.yaml
+
       - name: Bootstrap Juju - localhost
         shell: bash
         run: |


### PR DESCRIPTION
Sets up microk8s in the terraform smoke test workflow. 

Terraform provider tests with lxd require that microk8s be installed.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

-~[ ] Code style: imports ordered, good names, simple structure, etc~
-~[ ] Comments saying why design decisions were made~
-~[ ] Go unit tests, with comments saying what you're testing`
-~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
-~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Terraform smoke tests must pass.

## Documentation changes

N/A

## Links

N/A

