### PR TITLE
[DRAFT] Export model providers version

### DIFF
--- a/api/client/modelmanager/modelmanager.go
+++ b/api/client/modelmanager/modelmanager.go
@@ -57,6 +57,7 @@ func (c *Client) CreateModel(
 	name, owner, cloud, cloudRegion string,
 	cloudCredential names.CloudCredentialTag,
 	config map[string]interface{},
+	environVersion int,
 ) (base.ModelInfo, error) {
 	var result base.ModelInfo
 	if !names.IsValidUser(owner) {
@@ -80,6 +81,7 @@ func (c *Client) CreateModel(
 		CloudTag:           cloudTag,
 		CloudRegion:        cloudRegion,
 		CloudCredentialTag: cloudCredentialTag,
+		EnvironVersion:     environVersion,
 	}
 	var modelInfo params.ModelInfo
 	err := c.facade.FacadeCall(ctx, "CreateModel", createArgs, &modelInfo)

--- a/api/client/modelmanager/modelmanager_test.go
+++ b/api/client/modelmanager/modelmanager_test.go
@@ -37,7 +37,7 @@ func (s *modelmanagerSuite) TestCreateModelBadUser(c *gc.C) {
 	defer ctrl.Finish()
 	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
 	client := modelmanager.NewClientFromCaller(mockFacadeCaller)
-	_, err := client.CreateModel(context.Background(), "mymodel", "not a user", "", "", names.CloudCredentialTag{}, nil)
+	_, err := client.CreateModel(context.Background(), "mymodel", "not a user", "", "", names.CloudCredentialTag{}, nil, 0)
 	c.Assert(err, gc.ErrorMatches, `invalid owner name "not a user"`)
 }
 
@@ -46,7 +46,7 @@ func (s *modelmanagerSuite) TestCreateModelBadCloud(c *gc.C) {
 	defer ctrl.Finish()
 	mockFacadeCaller := basemocks.NewMockFacadeCaller(ctrl)
 	client := modelmanager.NewClientFromCaller(mockFacadeCaller)
-	_, err := client.CreateModel(context.Background(), "mymodel", "bob", "123!", "", names.CloudCredentialTag{}, nil)
+	_, err := client.CreateModel(context.Background(), "mymodel", "bob", "123!", "", names.CloudCredentialTag{}, nil, 0)
 	c.Assert(err, gc.ErrorMatches, `invalid cloud name "123!"`)
 }
 
@@ -86,6 +86,7 @@ func (s *modelmanagerSuite) TestCreateModel(c *gc.C) {
 		"catbus",
 		names.CloudCredentialTag{},
 		map[string]interface{}{"abc": 123},
+		0,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -451,7 +451,7 @@ func (m *ModelManagerAPI) CreateModel(ctx context.Context, args params.ModelCrea
 	if err != nil {
 		return result, errors.Trace(err)
 	}
-
+	args.EnvironVersion = 6
 	// createModelNew represents the logic needed for moving to DQlite. It is in
 	// a half finished state at the moment for the purpose of removing the model
 	// manager service. This check will go in the very near future.
@@ -478,7 +478,6 @@ func (m *ModelManagerAPI) CreateModel(ctx context.Context, args params.ModelCrea
 		return result, errors.Annotate(err, "failed to get config")
 	}
 
-	args.EnvironVersion = 6
 	var createdModel common.Model
 	if jujucloud.CloudIsCAAS(*cloud) {
 		createdModel, err = m.newCAASModel(
@@ -564,7 +563,7 @@ Please choose a different model name.
 		Config:                  newConfig,
 		Owner:                   ownerTag,
 		StorageProviderRegistry: storageProviderRegistry,
-		EnvironVersion:          createArgs.EnvironVersion,
+		EnvironVersion:          broker.Provider().Version(),
 	})
 	if err != nil {
 		return nil, errors.Annotate(err, "failed to create new model")

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -451,7 +451,6 @@ func (m *ModelManagerAPI) CreateModel(ctx context.Context, args params.ModelCrea
 	if err != nil {
 		return result, errors.Trace(err)
 	}
-	args.EnvironVersion = 6
 	// createModelNew represents the logic needed for moving to DQlite. It is in
 	// a half finished state at the moment for the purpose of removing the model
 	// manager service. This check will go in the very near future.

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -276,6 +276,7 @@ func (m *ModelManagerAPI) createModelNew(
 		creationArgs.Credential = credential.KeyFromTag(cloudCredentialTag)
 	}
 
+	creationArgs.EnvironVersion = args.EnvironVersion
 	// Create the model in the controller database.
 	modelID, activator, err := m.modelService.CreateModel(ctx, creationArgs)
 	if err != nil {
@@ -477,6 +478,7 @@ func (m *ModelManagerAPI) CreateModel(ctx context.Context, args params.ModelCrea
 		return result, errors.Annotate(err, "failed to get config")
 	}
 
+	args.EnvironVersion = 6
 	var createdModel common.Model
 	if jujucloud.CloudIsCAAS(*cloud) {
 		createdModel, err = m.newCAASModel(
@@ -562,6 +564,7 @@ Please choose a different model name.
 		Config:                  newConfig,
 		Owner:                   ownerTag,
 		StorageProviderRegistry: storageProviderRegistry,
+		EnvironVersion:          createArgs.EnvironVersion,
 	})
 	if err != nil {
 		return nil, errors.Annotate(err, "failed to create new model")

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -11142,6 +11142,9 @@
                         "credential": {
                             "type": "string"
                         },
+                        "environ-version": {
+                            "type": "integer"
+                        },
                         "name": {
                             "type": "string"
                         },

--- a/cmd/juju/controller/addmodel_test.go
+++ b/cmd/juju/controller/addmodel_test.go
@@ -702,6 +702,7 @@ type fakeAddClient struct {
 	config          map[string]interface{}
 	err             error
 	model           base.ModelInfo
+	environVersion  int
 }
 
 var _ controller.AddModelAPI = (*fakeAddClient)(nil)
@@ -710,7 +711,7 @@ func (*fakeAddClient) Close() error {
 	return nil
 }
 
-func (f *fakeAddClient) CreateModel(ctx context.Context, name, owner, cloudName, cloudRegion string, cloudCredential names.CloudCredentialTag, config map[string]interface{}) (base.ModelInfo, error) {
+func (f *fakeAddClient) CreateModel(ctx context.Context, name, owner, cloudName, cloudRegion string, cloudCredential names.CloudCredentialTag, config map[string]interface{}, environVersion int) (base.ModelInfo, error) {
 	if f.err != nil {
 		return base.ModelInfo{}, f.err
 	}
@@ -719,6 +720,7 @@ func (f *fakeAddClient) CreateModel(ctx context.Context, name, owner, cloudName,
 	f.cloudName = cloudName
 	f.cloudRegion = cloudRegion
 	f.config = config
+	f.environVersion = environVersion
 	return f.model, nil
 }
 

--- a/core/model/model.go
+++ b/core/model/model.go
@@ -85,6 +85,8 @@ type Model struct {
 	// OwnerName is the name of the owner in the Juju controller.
 	OwnerName user.Name
 
+	// EnvironVersion is the version of the model's environ -- the related
+	// cloud provider resources.
 	EnvironVersion int
 }
 

--- a/core/model/model.go
+++ b/core/model/model.go
@@ -84,6 +84,8 @@ type Model struct {
 
 	// OwnerName is the name of the owner in the Juju controller.
 	OwnerName user.Name
+
+	EnvironVersion int
 }
 
 // UUID represents a model unique identifier.

--- a/domain/model/service/modelservice.go
+++ b/domain/model/service/modelservice.go
@@ -103,6 +103,7 @@ func (s *ModelService) CreateModel(
 		CloudRegion:     m.CloudRegion,
 		CredentialOwner: m.Credential.Owner,
 		CredentialName:  m.Credential.Name,
+		EnvironVersion:  m.EnvironVersion,
 	}
 
 	return s.modelSt.Create(ctx, args)

--- a/domain/model/state/controllerstate.go
+++ b/domain/model/state/controllerstate.go
@@ -606,12 +606,13 @@ func createModel(
 	}
 
 	model := dbInitialModel{
-		UUID:      modelUUID.String(),
-		CloudUUID: cloudUUID.UUID,
-		ModelType: modelType.String(),
-		LifeID:    int(life.Alive),
-		Name:      input.Name,
-		OwnerUUID: input.Owner.String(),
+		UUID:           modelUUID.String(),
+		CloudUUID:      cloudUUID.UUID,
+		ModelType:      modelType.String(),
+		LifeID:         int(life.Alive),
+		Name:           input.Name,
+		OwnerUUID:      input.Owner.String(),
+		EnvironVersion: input.EnvironVersion,
 	}
 
 	stmt, err := preparer.Prepare(`
@@ -620,13 +621,15 @@ func createModel(
 		            model_type_id,
 		            life_id,
 		            name,
-		            owner_uuid)
+		            owner_uuid,
+					environ_version)
 		SELECT  $dbInitialModel.uuid, 
 				$dbInitialModel.cloud_uuid, 
 				model_type.id, 
 				$dbInitialModel.life_id, 
 				$dbInitialModel.name,
-				$dbInitialModel.owner_uuid
+				$dbInitialModel.owner_uuid,
+				$dbInitialModel.environ_version
 		FROM model_type
 		WHERE model_type.type = $dbInitialModel.model_type
 		`, model)

--- a/domain/model/state/modelstate.go
+++ b/domain/model/state/modelstate.go
@@ -266,6 +266,7 @@ FROM model
 		CredentialOwner:    args.CredentialOwner.Name(),
 		CredentialName:     args.CredentialName,
 		IsControllerModel:  args.IsControllerModel,
+		EnvironVersion:     args.EnvironVersion,
 	}
 
 	insertStmt, err := preparer.Prepare(`

--- a/domain/model/state/types.go
+++ b/domain/model/state/types.go
@@ -61,6 +61,8 @@ type dbModel struct {
 
 	// OwnerName is the name of the model owner in the Juju controller.
 	OwnerName string `db:"owner_name"`
+
+	EnvironVersion int `db:"environ_version"`
 }
 
 func (m *dbModel) toCoreModel() (coremodel.Model, error) {
@@ -109,8 +111,9 @@ func (m *dbModel) toCoreModel() (coremodel.Model, error) {
 			Cloud: credentialCloudName,
 			Owner: credOwnerName,
 		},
-		Owner:     user.UUID(m.OwnerUUID),
-		OwnerName: ownerName,
+		Owner:          user.UUID(m.OwnerUUID),
+		OwnerName:      ownerName,
+		EnvironVersion: m.EnvironVersion,
 	}, nil
 }
 
@@ -134,6 +137,8 @@ type dbInitialModel struct {
 
 	// OwnerUUID is the uuid of the user that owns this model in the Juju controller.
 	OwnerUUID string `db:"owner_uuid"`
+
+	EnvironVersion int `db:"environ_version"`
 }
 
 type dbNames struct {
@@ -320,6 +325,7 @@ type dbReadOnlyModel struct {
 	CredentialOwner    string         `db:"credential_owner"`
 	CredentialName     string         `db:"credential_name"`
 	IsControllerModel  bool           `db:"is_controller_model"`
+	EnvironVersion     int            `db:"environ_version"`
 }
 
 type dbModelMetrics struct {

--- a/domain/model/state/types.go
+++ b/domain/model/state/types.go
@@ -62,6 +62,8 @@ type dbModel struct {
 	// OwnerName is the name of the model owner in the Juju controller.
 	OwnerName string `db:"owner_name"`
 
+	// EnvironVersion is the version of the model's environ -- the related
+	// cloud provider resources.
 	EnvironVersion int `db:"environ_version"`
 }
 
@@ -138,6 +140,8 @@ type dbInitialModel struct {
 	// OwnerUUID is the uuid of the user that owns this model in the Juju controller.
 	OwnerUUID string `db:"owner_uuid"`
 
+	// EnvironVersion is the version of the model's environ -- the related
+	// cloud provider resources.
 	EnvironVersion int `db:"environ_version"`
 }
 

--- a/domain/model/types.go
+++ b/domain/model/types.go
@@ -48,6 +48,8 @@ type ModelCreationArgs struct {
 	// chosen at creation time.
 	SecretBackend string
 
+	// EnvironVersion is the version of the model's environ -- the related
+	// cloud provider resources.
 	EnvironVersion int
 }
 
@@ -147,6 +149,8 @@ type ReadOnlyModelCreationArgs struct {
 	// controller model.
 	IsControllerModel bool
 
+	// EnvironVersion is the version of the model's environ -- the related
+	// cloud provider resources.
 	EnvironVersion int
 }
 

--- a/domain/model/types.go
+++ b/domain/model/types.go
@@ -47,6 +47,8 @@ type ModelCreationArgs struct {
 	// created model. SecretBackend can be left empty and a default will be
 	// chosen at creation time.
 	SecretBackend string
+
+	EnvironVersion int
 }
 
 // Validate is responsible for checking all of the fields of ModelCreationArgs
@@ -144,6 +146,8 @@ type ReadOnlyModelCreationArgs struct {
 	// IsControllerModel is a boolean value that indicates if the model is the
 	// controller model.
 	IsControllerModel bool
+
+	EnvironVersion int
 }
 
 // DeleteModelOptions is a struct that is used to modify the behavior of the

--- a/domain/schema/controller/sql/0007-model.sql
+++ b/domain/schema/controller/sql/0007-model.sql
@@ -37,6 +37,7 @@ CREATE TABLE model (
     life_id INT NOT NULL,
     name TEXT NOT NULL,
     owner_uuid TEXT NOT NULL,
+    environ_version INT NOT NULL,
     CONSTRAINT fk_model_cloud
     FOREIGN KEY (cloud_uuid)
     REFERENCES cloud (uuid),
@@ -84,6 +85,7 @@ SELECT
     mt.type AS model_type,
     m.name,
     m.owner_uuid,
+    m.environ_version AS environ_version,
     o.name AS owner_name,
     l.value AS life,
     ma.target_version AS target_agent_version

--- a/domain/schema/model/sql/0004-read-only-model.sql
+++ b/domain/schema/model/sql/0004-read-only-model.sql
@@ -16,7 +16,8 @@ CREATE TABLE model (
     cloud_region TEXT,
     credential_owner TEXT,
     credential_name TEXT,
-    is_controller_model BOOLEAN DEFAULT FALSE
+    is_controller_model BOOLEAN DEFAULT FALSE,
+    environ_version INT DEFAULT 0
 );
 
 -- A unique constraint over a constant index ensures only 1 entry matching the

--- a/internal/provider/ec2/provider.go
+++ b/internal/provider/ec2/provider.go
@@ -34,7 +34,7 @@ var providerInstance environProvider
 
 // Version is part of the EnvironProvider interface.
 func (environProvider) Version() int {
-	return 0
+	return 6
 }
 
 // Open is specified in the EnvironProvider interface.

--- a/internal/provider/lxd/provider.go
+++ b/internal/provider/lxd/provider.go
@@ -141,7 +141,7 @@ func NewProvider() environs.CloudEnvironProvider {
 
 // Version is part of the EnvironProvider interface.
 func (*environProvider) Version() int {
-	return 0
+	return 4
 }
 
 // Open implements environs.EnvironProvider.

--- a/rpc/params/internal.go
+++ b/rpc/params/internal.go
@@ -150,6 +150,10 @@ type ModelCreateArgs struct {
 	// and the owner is the controller owner, the same credential
 	// used for the controller model will be used.
 	CloudCredentialTag string `json:"credential,omitempty"`
+
+	// EnvironVersion is the version of the model's environ -- the related
+	// cloud provider resources.
+	EnvironVersion int `json:"environ-version,omitempty"`
 }
 
 // Model holds the result of an API call returning a name and UUID


### PR DESCRIPTION
Note* the current environ version is hardcoded to both 4 and 6 for lxd and aws respectively and will be changed back to 0 after review is done.

## Checklist

~~- [ ] Code style: imports ordered, good names, simple structure, etc~~
~~- [ ] Comments saying why design decisions were made~~
~~- [ ] Go unit tests, with comments saying what you're testing~~
~~- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~~
~~- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~~

## QA steps

 1. Bootstrap a 4.0 controller and check the environ_version in dqlite 
```sh
$ juju bootstrap lxd test
$ juju add-model test
$ dqlite.sh
```

2. Verify environ_version is exported as well using juju dump-model
```sh
$ juju dump-model
```

## Links

**Jira card:** https://warthogs.atlassian.net/browse/JUJU-7231