### PR TITLE
fix(bootstrap): fix bootstrap mirror bug on noble

### DIFF
--- a/cloudconfig/cloudinit/cloudinit.go
+++ b/cloudconfig/cloudinit/cloudinit.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
-	"github.com/juju/packaging/v3/commands"
-	"github.com/juju/packaging/v3/config"
+	"github.com/juju/packaging/v4/commands"
+	"github.com/juju/packaging/v4/config"
 	"github.com/juju/utils/v3/shell"
 	"github.com/juju/utils/v3/ssh"
 

--- a/cloudconfig/cloudinit/cloudinit_centos.go
+++ b/cloudconfig/cloudinit/cloudinit_centos.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/juju/packaging/v3"
-	"github.com/juju/packaging/v3/config"
+	"github.com/juju/packaging/v4"
+	"github.com/juju/packaging/v4/config"
 	"gopkg.in/yaml.v2"
 
 	corenetwork "github.com/juju/juju/core/network"

--- a/cloudconfig/cloudinit/cloudinit_test.go
+++ b/cloudconfig/cloudinit/cloudinit_test.go
@@ -7,7 +7,7 @@ package cloudinit_test
 import (
 	"fmt"
 
-	"github.com/juju/packaging/v3"
+	"github.com/juju/packaging/v4"
 	jc "github.com/juju/testing/checkers"
 	sshtesting "github.com/juju/utils/v3/ssh/testing"
 	"golang.org/x/crypto/ssh"

--- a/cloudconfig/cloudinit/cloudinit_ubuntu.go
+++ b/cloudconfig/cloudinit/cloudinit_ubuntu.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
-	"github.com/juju/packaging/v3"
-	"github.com/juju/packaging/v3/config"
+	"github.com/juju/packaging/v4"
+	"github.com/juju/packaging/v4/config"
 	"github.com/juju/proxy"
 	"github.com/juju/utils/v3"
 	"gopkg.in/yaml.v2"

--- a/cloudconfig/cloudinit/interface.go
+++ b/cloudconfig/cloudinit/interface.go
@@ -6,9 +6,9 @@ package cloudinit
 
 import (
 	"github.com/juju/errors"
-	"github.com/juju/packaging/v3"
-	"github.com/juju/packaging/v3/commands"
-	"github.com/juju/packaging/v3/config"
+	"github.com/juju/packaging/v4"
+	"github.com/juju/packaging/v4/commands"
+	"github.com/juju/packaging/v4/config"
 	"github.com/juju/proxy"
 	"github.com/juju/utils/v3/shell"
 	"golang.org/x/crypto/ssh"

--- a/cloudconfig/cloudinit/renderscript_test.go
+++ b/cloudconfig/cloudinit/renderscript_test.go
@@ -6,7 +6,7 @@ package cloudinit_test
 import (
 	"regexp"
 
-	"github.com/juju/packaging/v3"
+	"github.com/juju/packaging/v4"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -39,6 +39,12 @@ func assertScriptMatches(c *gc.C, cfg cloudinit.CloudConfig, pattern string, mat
 		checker = gc.Not(checker)
 	}
 	c.Assert(script, checker, pattern)
+}
+
+func assertScriptContains(c *gc.C, cfg cloudinit.CloudConfig, substring string) {
+	script, err := cfg.RenderScript()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(script, jc.Contains, substring)
 }
 
 func (s *configureSuite) TestAptUpdate(c *gc.C) {
@@ -84,11 +90,12 @@ func (s *configureSuite) TestAptUpgrade(c *gc.C) {
 }
 
 func (s *configureSuite) TestAptMirrorWrapper(c *gc.C) {
-	expectedCommands := regexp.QuoteMeta(`
+	expectedCommands := `
 echo 'Changing apt mirror to "http://woat.com"' >&$JUJU_PROGRESS_FD
-old_archive_mirror=$(awk "/^deb .* $(awk -F= '/DISTRIB_CODENAME=/ {gsub(/"/,""); print $2}' /etc/lsb-release) .*main.*\$/{print \$2;exit}" /etc/apt/sources.list)
-new_archive_mirror=http://woat.com
-sed -i s,$old_archive_mirror,$new_archive_mirror, /etc/apt/sources.list
+old_archive_mirror=$(apt-cache policy | grep http | awk '{ $1="" ; print }' | sed 's/^ //g'  | grep "$(lsb_release -c -s)/main" | awk '{print $1; exit}')
+new_archive_mirror="http://woat.com"
+[ -f "/etc/apt/sources.list" ] && sed -i s,$old_archive_mirror,$new_archive_mirror, "/etc/apt/sources.list"
+[ -f "/etc/apt/sources.list.d/ubuntu.sources" ] && sed -i s,$old_archive_mirror,$new_archive_mirror, "/etc/apt/sources.list.d/ubuntu.sources"
 old_prefix=/var/lib/apt/lists/$(echo $old_archive_mirror | sed 's,.*://,,' | sed 's,/$,,' | tr / _)
 new_prefix=/var/lib/apt/lists/$(echo $new_archive_mirror | sed 's,.*://,,' | sed 's,/$,,' | tr / _)
 [ "$old_prefix" != "$new_prefix" ] &&
@@ -98,9 +105,10 @@ for old in ${old_prefix}_*; do
       mv $old $new
     fi
 done
-old_security_mirror=$(awk "/^deb .* $(awk -F= '/DISTRIB_CODENAME=/ {gsub(/"/,""); print $2}' /etc/lsb-release)-security .*main.*\$/{print \$2;exit}" /etc/apt/sources.list)
-new_security_mirror=http://woat.com
-sed -i s,$old_security_mirror,$new_security_mirror, /etc/apt/sources.list
+old_security_mirror=$(apt-cache policy | grep http | awk '{ $1="" ; print }' | sed 's/^ //g'  | grep "$(lsb_release -c -s)-security/main" | awk '{print $1; exit}')
+new_security_mirror="http://woat.com"
+[ -f "/etc/apt/sources.list" ] && sed -i s,$old_security_mirror,$new_security_mirror, "/etc/apt/sources.list"
+[ -f "/etc/apt/sources.list.d/ubuntu.sources" ] && sed -i s,$old_security_mirror,$new_security_mirror, "/etc/apt/sources.list.d/ubuntu.sources"
 old_prefix=/var/lib/apt/lists/$(echo $old_security_mirror | sed 's,.*://,,' | sed 's,/$,,' | tr / _)
 new_prefix=/var/lib/apt/lists/$(echo $new_security_mirror | sed 's,.*://,,' | sed 's,/$,,' | tr / _)
 [ "$old_prefix" != "$new_prefix" ] &&
@@ -109,10 +117,10 @@ for old in ${old_prefix}_*; do
     if [ -f $old ]; then
       mv $old $new
     fi
-done`)
-	aptMirrorRegexp := "(.|\n)*" + expectedCommands + "(.|\n)*"
+done`
+
 	cfg, err := cloudinit.New("ubuntu")
 	c.Assert(err, jc.ErrorIsNil)
 	cfg.SetPackageMirror("http://woat.com")
-	assertScriptMatches(c, cfg, aptMirrorRegexp, true)
+	assertScriptContains(c, cfg, expectedCommands)
 }

--- a/cloudconfig/cloudinit/utils.go
+++ b/cloudconfig/cloudinit/utils.go
@@ -9,8 +9,8 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/juju/packaging/v3"
-	"github.com/juju/packaging/v3/config"
+	"github.com/juju/packaging/v4"
+	"github.com/juju/packaging/v4/config"
 	"github.com/juju/utils/v3"
 
 	jujupackaging "github.com/juju/juju/packaging"

--- a/container/lxd/initialisation_linux.go
+++ b/container/lxd/initialisation_linux.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/os/v2/series"
-	"github.com/juju/packaging/v3/manager"
+	"github.com/juju/packaging/v4/manager"
 	"github.com/juju/proxy"
 
 	"github.com/juju/juju/container"

--- a/container/lxd/initialisation_test.go
+++ b/container/lxd/initialisation_test.go
@@ -10,8 +10,8 @@ import (
 
 	lxd "github.com/canonical/lxd/client"
 	"github.com/canonical/lxd/shared/api"
-	"github.com/juju/packaging/v3/commands"
-	"github.com/juju/packaging/v3/manager"
+	"github.com/juju/packaging/v4/commands"
+	"github.com/juju/packaging/v4/manager"
 	"github.com/juju/proxy"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"

--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/juju/names/v5 v5.0.0
 	github.com/juju/naturalsort v1.0.0
 	github.com/juju/os/v2 v2.2.5
-	github.com/juju/packaging/v3 v3.1.0
+	github.com/juju/packaging/v4 v4.0.0
 	github.com/juju/persistent-cookiejar v1.0.0
 	github.com/juju/proxy v1.0.0
 	github.com/juju/pubsub/v2 v2.0.0

--- a/go.sum
+++ b/go.sum
@@ -544,8 +544,8 @@ github.com/juju/naturalsort v1.0.0 h1:kGmUUy3h8mJ5/SJYaqKOBR3f3owEd5R52Lh+Tjg/dN
 github.com/juju/naturalsort v1.0.0/go.mod h1:Zqa/vGkXr78k47zM6tFmU9phhxKz/PIdqBzpLhJ86zc=
 github.com/juju/os/v2 v2.2.5 h1:Ayw9aC7axKtGgzy3dFRKx84FxasfISMege0iYDsH6io=
 github.com/juju/os/v2 v2.2.5/go.mod h1:igGQLjgRSwUery5ZhV/1pZjZkMwnfkAwWCwh5ZfIg+c=
-github.com/juju/packaging/v3 v3.1.0 h1:P5RyXSKVLNWqbpr8XcdDI17wYdTGYg7KTHce8DMeoSk=
-github.com/juju/packaging/v3 v3.1.0/go.mod h1:WXh/SXqh1du8SFzwb1KC+yZuV4Qc4alWP3MEPqFX9Lw=
+github.com/juju/packaging/v4 v4.0.0 h1:bcEyFaZgGZ3iLX56Q7mtNbYI81EqPVO0km1Qx3eaB2o=
+github.com/juju/packaging/v4 v4.0.0/go.mod h1:hAyOuBQrYqXMpXFwz/Fq2PCP8Uc9ACF7Pe3fInQawvw=
 github.com/juju/persistent-cookiejar v1.0.0 h1:Ag7+QLzqC2m+OYXy2QQnRjb3gTkEBSZagZ6QozwT3EQ=
 github.com/juju/persistent-cookiejar v1.0.0/go.mod h1:zrbmo4nBKaiP/Ez3F67ewkMbzGYfXyMvRtbOfuAwG0w=
 github.com/juju/postgrestest v1.1.0/go.mod h1:/n17Y2T6iFozzXwSCO0JYJ5gSiz2caEtSwAjh/uLXDM=

--- a/packaging/manager.go
+++ b/packaging/manager.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
-	"github.com/juju/packaging/v3/manager"
+	"github.com/juju/packaging/v4/manager"
 
 	"github.com/juju/juju/core/base"
 )

--- a/upgrades/preupgradesteps.go
+++ b/upgrades/preupgradesteps.go
@@ -6,7 +6,7 @@ package upgrades
 import (
 	"github.com/dustin/go-humanize"
 	"github.com/juju/errors"
-	"github.com/juju/packaging/v3/manager"
+	"github.com/juju/packaging/v4/manager"
 	"github.com/juju/utils/v3/du"
 
 	"github.com/juju/juju/agent"

--- a/upgrades/preupgradesteps_test.go
+++ b/upgrades/preupgradesteps_test.go
@@ -7,7 +7,7 @@ import (
 	"os/exec"
 
 	"github.com/dustin/go-humanize"
-	pkgmgr "github.com/juju/packaging/v3/manager"
+	pkgmgr "github.com/juju/packaging/v4/manager"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 

--- a/worker/proxyupdater/proxyupdater.go
+++ b/worker/proxyupdater/proxyupdater.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/juju/os/v2/series"
-	"github.com/juju/packaging/v3/commands"
-	"github.com/juju/packaging/v3/config"
+	"github.com/juju/packaging/v4/commands"
+	"github.com/juju/packaging/v4/config"
 	"github.com/juju/proxy"
 	"github.com/juju/worker/v3"
 

--- a/worker/proxyupdater/proxyupdater_test.go
+++ b/worker/proxyupdater/proxyupdater_test.go
@@ -16,8 +16,8 @@ import (
 	"github.com/juju/errors"
 	"github.com/juju/loggo"
 	jujuos "github.com/juju/os/v2"
-	"github.com/juju/packaging/v3/commands"
-	pacconfig "github.com/juju/packaging/v3/config"
+	"github.com/juju/packaging/v4/commands"
+	pacconfig "github.com/juju/packaging/v4/config"
 	"github.com/juju/proxy"
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/worker/v3"
@@ -624,9 +624,10 @@ func (s *ProxyUpdaterSuite) TestAptMirror(c *gc.C) {
 #!/bin/bash
 set -e
 (
-old_archive_mirror=$(awk "/^deb .* $(awk -F= '/DISTRIB_CODENAME=/ {gsub(/"/,""); print $2}' /etc/lsb-release) .*main.*\$/{print \$2;exit}" /etc/apt/sources.list)
-new_archive_mirror=http://mirror
-sed -i s,$old_archive_mirror,$new_archive_mirror, /etc/apt/sources.list
+old_archive_mirror=$(apt-cache policy | grep http | awk '{ $1="" ; print }' | sed 's/^ //g'  | grep "$(lsb_release -c -s)/main" | awk '{print $1; exit}')
+new_archive_mirror="http://mirror"
+[ -f "/etc/apt/sources.list" ] && sed -i s,$old_archive_mirror,$new_archive_mirror, "/etc/apt/sources.list"
+[ -f "/etc/apt/sources.list.d/ubuntu.sources" ] && sed -i s,$old_archive_mirror,$new_archive_mirror, "/etc/apt/sources.list.d/ubuntu.sources"
 old_prefix=/var/lib/apt/lists/$(echo $old_archive_mirror | sed 's,.*://,,' | sed 's,/$,,' | tr / _)
 new_prefix=/var/lib/apt/lists/$(echo $new_archive_mirror | sed 's,.*://,,' | sed 's,/$,,' | tr / _)
 [ "$old_prefix" != "$new_prefix" ] &&
@@ -636,9 +637,10 @@ for old in ${old_prefix}_*; do
       mv $old $new
     fi
 done
-old_security_mirror=$(awk "/^deb .* $(awk -F= '/DISTRIB_CODENAME=/ {gsub(/"/,""); print $2}' /etc/lsb-release)-security .*main.*\$/{print \$2;exit}" /etc/apt/sources.list)
-new_security_mirror=http://mirror
-sed -i s,$old_security_mirror,$new_security_mirror, /etc/apt/sources.list
+old_security_mirror=$(apt-cache policy | grep http | awk '{ $1="" ; print }' | sed 's/^ //g'  | grep "$(lsb_release -c -s)-security/main" | awk '{print $1; exit}')
+new_security_mirror="http://mirror"
+[ -f "/etc/apt/sources.list" ] && sed -i s,$old_security_mirror,$new_security_mirror, "/etc/apt/sources.list"
+[ -f "/etc/apt/sources.list.d/ubuntu.sources" ] && sed -i s,$old_security_mirror,$new_security_mirror, "/etc/apt/sources.list.d/ubuntu.sources"
 old_prefix=/var/lib/apt/lists/$(echo $old_security_mirror | sed 's,.*://,,' | sed 's,/$,,' | tr / _)
 new_prefix=/var/lib/apt/lists/$(echo $new_security_mirror | sed 's,.*://,,' | sed 's,/$,,' | tr / _)
 [ "$old_prefix" != "$new_prefix" ] &&


### PR DESCRIPTION
Starting with Noble, the format and location of the default ubuntu apt
repository details changed. This caused our package juju/packaging to
break.

This was fixed in v4.0.0. Upgrade our dependency to that version

## QA steps

```
$ juju bootstrap --config apt-mirror=https://mirror.fsmg.org.nz/ubuntu --bootstrap-base ubuntu@24.04 lxd lxd
$ juju status -m controller
Model       Controller  Cloud/Region         Version  SLA          Timestamp
controller  lxd         localhost/localhost  3.5.6.1  unsupported  14:00:55Z

App         Version  Status  Scale  Charm            Channel     Rev  Exposed  Message
controller           active      1  juju-controller  3.5/stable  105  no       

Unit           Workload  Agent  Machine  Public address  Ports  Message
controller/0*  active    idle   0        10.51.45.6             

Machine  State    Address     Inst id        Base          AZ  Message
0        started  10.51.45.6  juju-d89eee-0  ubuntu@24.04      Running

$ lxc exec juju-d89eee-0 bash
# apt update
Hit:1 https://mirror.fsmg.org.nz/ubuntu noble InRelease
Hit:2 https://mirror.fsmg.org.nz/ubuntu noble-updates InRelease
Hit:3 https://mirror.fsmg.org.nz/ubuntu noble-backports InRelease
Hit:4 https://mirror.fsmg.org.nz/ubuntu noble-security InRelease
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
All packages are up to date.
```
```
$ juju bootstrap --config apt-mirror=https://mirror.fsmg.org.nz/ubuntu --bootstrap-base ubuntu@22.04 lxd lxd-jammy
$ juju status -m controller
Model       Controller  Cloud/Region         Version  SLA          Timestamp
controller  lxd-jammy   localhost/localhost  3.5.6.1  unsupported  14:03:41Z

App         Version  Status   Scale  Charm            Channel     Rev  Exposed  Message
controller           waiting    0/1  juju-controller  3.5/stable  105  no       agent initialising

Unit           Workload  Agent       Machine  Public address  Ports  Message
controller/0*  waiting   allocating  0        10.51.45.83            agent initialising

Machine  State    Address      Inst id        Base          AZ  Message
0        started  10.51.45.83  juju-737bda-0  ubuntu@22.04      Running

$ lxc exec juju-737bda-0 bash
# apt update
Hit:1 https://mirror.fsmg.org.nz/ubuntu jammy InRelease
Hit:2 https://mirror.fsmg.org.nz/ubuntu jammy-updates InRelease
Hit:3 https://mirror.fsmg.org.nz/ubuntu jammy-backports InRelease
Hit:4 https://mirror.fsmg.org.nz/ubuntu jammy-security InRelease
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
All packages are up to date.
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/2093292