### PR TITLE
chore: regen docs

### DIFF
--- a/docs/user/reference/juju-cli/list-of-juju-cli-commands/destroy-model.md
+++ b/docs/user/reference/juju-cli/list-of-juju-cli-commands/destroy-model.md
@@ -33,7 +33,7 @@ Terminate all machines/containers and resources for a non-controller model.
 Destroys the specified model. This will result in the non-recoverable
 removal of all the units operating in the model and any resources stored
 there. Due to the irreversible nature of the command, it will prompt for
-confirmation (unless overridden with the '-y' option) before taking any
+confirmation (unless overridden with the '--no-prompt' option) before taking any
 action.
 
 If there is persistent storage in any of the models managed by the


### PR DESCRIPTION
Recently a PR managed to merge into main without regenerating docs. This has lead to future PRs failing their doc generation tasks, despite not making any changes that require doc changes.

Regenerate docs separately to accommodate for this change

## QA steps

github actions pass