### PR TITLE
feat: debug log when we can not find an image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ tests/tmp.*
 *.bundle
 *.log
 dqlite-deps.tar.bz2
+docs/


### PR DESCRIPTION
To help with debugging it's useful to know why we failed to get an image using the alias type. Currently, we skip this and it makes it very hard to know this is happening.

## QA steps

```sh
$ juju bootstrap lxd --bootstrap-base=ubuntu@24.04 --debug --build-agent
$ juju add-model default
$ juju deploy ubuntu --base=ubuntu@22.04
$ lxd image delete juju/ubuntu@24.04/amd64
$ juju deploy ubuntu --base=ubuntu@24.04
$ juju add-machine -n 1
$ juju deploy ubuntu ubuntu-container --to lxd:1 --base=ubuntu@24.04
```

## Links

Work towards helping to diagnose https://github.com/juju/juju/issues/18657

