### PR TITLE
docs: add a header for charm docs best practices

### DIFF
--- a/docs/user/reference/charm/charm-development-best-practices.md
+++ b/docs/user/reference/charm/charm-development-best-practices.md
@@ -157,6 +157,7 @@ Limit the use of shell scripts and commands as much as possible in favour of wri
 * Extracting data from a machine or container which can't be obtained through Python
 * Issuing commands to applications that do not have Python bindings (e.g., starting a process on a machine)
 
+(charm-documentation-best-practices)=
 ## Documentation
 
 Documentation should be considered the user’s handbook for using a charmed application safely and successfully.


### PR DESCRIPTION
This adds a reference for charm documentation best practices, allowing the Charmcraft documentation to use intersphinx to link to it.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] ~Code style: imports ordered, good names, simple structure, etc~
- [ ] ~Comments saying why design decisions were made~
- [ ] ~Go unit tests, with comments saying what you're testing~
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Check that the header is exported in the Sphinx `objects.inv` file. Using [sphobjinv](https://github.com/bskinn/sphobjinv) this can be done with:

```
sphobjinv suggest -t 50 objects.inv documentation
```

## Documentation changes

Just this

## Links

Blocker for https://github.com/canonical/charmcraft/issues/2090