### PR TITLE
fix: remove server side constraints

### DIFF
--- a/apiserver/debuglog.go
+++ b/apiserver/debuglog.go
@@ -196,17 +196,10 @@ type debugLogParams struct {
 }
 
 func readDebugLogParams(queryMap url.Values) (debugLogParams, error) {
-	var (
-		params      debugLogParams
-		err         error
-		backLogVal  uint64
-		maxLinesVal uint64
-		noTail      bool
-		replay      bool
-	)
+	var params debugLogParams
 
 	if value := queryMap.Get("backlog"); value != "" {
-		backLogVal, err = strconv.ParseUint(value, 10, 64)
+		backLogVal, err := strconv.ParseUint(value, 10, 64)
 		if err != nil {
 			return params, errors.Errorf("backlog value %q is not a valid unsigned number", value)
 		}
@@ -214,7 +207,7 @@ func readDebugLogParams(queryMap url.Values) (debugLogParams, error) {
 	}
 
 	if value := queryMap.Get("maxLines"); value != "" {
-		maxLinesVal, err = strconv.ParseUint(value, 10, 64)
+		maxLinesVal, err := strconv.ParseUint(value, 10, 64)
 		if err != nil {
 			return params, errors.Errorf("maxLines value %q is not a valid unsigned number", value)
 		}
@@ -222,7 +215,7 @@ func readDebugLogParams(queryMap url.Values) (debugLogParams, error) {
 	}
 
 	if value := queryMap.Get("noTail"); value != "" {
-		noTail, err = strconv.ParseBool(value)
+		noTail, err := strconv.ParseBool(value)
 		if err != nil {
 			return params, errors.Errorf("noTail value %q is not a valid boolean", value)
 		}
@@ -230,27 +223,11 @@ func readDebugLogParams(queryMap url.Values) (debugLogParams, error) {
 	}
 
 	if value := queryMap.Get("replay"); value != "" {
-		replay, err = strconv.ParseBool(value)
+		replay, err := strconv.ParseBool(value)
 		if err != nil {
 			return params, errors.Errorf("replay value %q is not a valid boolean", value)
 		}
 		params.fromTheStart = replay
-	}
-
-	if !noTail && maxLinesVal != 0 {
-		return params, errors.Errorf("tail not valid with maxLines")
-	}
-
-	if noTail && backLogVal != 0 {
-		return params, errors.Errorf("noTail not valid with backLog")
-	}
-
-	if maxLinesVal != 0 && backLogVal != 0 {
-		return params, errors.Errorf("maxLines not valid with backLog")
-	}
-
-	if replay && backLogVal != 0 {
-		return params, errors.Errorf("replay not valid with backLog")
 	}
 
 	if value := queryMap.Get("level"); value != "" {


### PR DESCRIPTION
This is a fix and an extension to the previous PR: https://github.com/juju/juju/pull/18569.


These are the specific issues that were fixed from the previous PR:
1. --replay and --no-tail now prints the whole log instead of only 10 log lines
2. refactor --notail to --no-tail in help text

These are some changes made in extension to the previous PR:
1. set default backlog lines 10 only when user has not set limit, lines and replay
2. The combination of --replay and --lines is no longer supported. Previously, this combination functioned like --replay alone and did not display the specified number of lines before tailing logs from the current time. On the other hand, --replay and --limit correctly limits the number of replayed log lines. Furthermore, having both lines and replay would skip logs between the replayed lines and the current tailing point, which probably has little to no use cases. To avoid confusion, we have decided to deprecate the use of --replay with --lines.
3. This change also fixes previous issues where --limit is > 10, i.e Assuming there are only 100 log lines as output, juju debug-log --include-module "juju.apiserver" --limit 15 only prints 10 log lines, and continues to tail until it hits 15. Now it just prints 15 lines and exits.

Note:
--limit 30 prints the first 30 lines in the previous 3.5 implementation instead of the latest. This change is only updated when the controller code is updated.

## Checklist
~~- [ ] Code style: imports ordered, good names, simple structure, etc~~
~~- [ ] Comments saying why design decisions were made~~
~~- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~~
~~- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~~
- [x] Go unit tests, with comments saying what you're testing

## QA steps

__1. Bootstrap a 3.5 controller and deploy a charm__
```sh
$ juju bootstrap lxd test
$ juju add-model test
$ juju deploy mysql
```

__2. Test out debug-log help commands to see the updated help changes__
```sh
$ juju help debug-log 
```

__3. Test out debug-log replay with no-tail command (assuming 1 is the first log and 15 is the last log)__
```sh
$ juju debug-log --no-tail --replay
```

Prior debug-log output
```sh
2024-12-20 13:41:01 INFO juju.worker.logfetcher: log entry 1
2024-12-20 13:41:02 INFO juju.worker.logfetcher: log entry 2
2024-12-20 13:41:03 INFO juju.worker.logfetcher: log entry 3
2024-12-20 13:41:04 INFO juju.worker.logfetcher: log entry 4
2024-12-20 13:41:05 INFO juju.worker.logfetcher: log entry 5
2024-12-20 13:41:05 INFO juju.worker.logfetcher: log entry 6
2024-12-20 13:41:05 INFO juju.worker.logfetcher: log entry 7
2024-12-20 13:41:05 INFO juju.worker.logfetcher: log entry 8
2024-12-20 13:41:05 INFO juju.worker.logfetcher: log entry 9
2024-12-20 13:41:05 INFO juju.worker.logfetcher: log entry 10
```

Current debug-log output
```sh
2024-12-20 13:41:01 INFO juju.worker.logfetcher: log entry 1
2024-12-20 13:41:02 INFO juju.worker.logfetcher: log entry 2
2024-12-20 13:41:03 INFO juju.worker.logfetcher: log entry 3
2024-12-20 13:41:04 INFO juju.worker.logfetcher: log entry 4
2024-12-20 13:41:05 INFO juju.worker.logfetcher: log entry 5
2024-12-20 13:41:05 INFO juju.worker.logfetcher: log entry 6
2024-12-20 13:41:05 INFO juju.worker.logfetcher: log entry 7
2024-12-20 13:41:05 INFO juju.worker.logfetcher: log entry 8
2024-12-20 13:41:05 INFO juju.worker.logfetcher: log entry 9
2024-12-20 13:41:05 INFO juju.worker.logfetcher: log entry 10
2024-12-20 13:41:05 INFO juju.worker.logfetcher: log entry 11
2024-12-20 13:41:05 INFO juju.worker.logfetcher: log entry 12
2024-12-20 13:41:05 INFO juju.worker.logfetcher: log entry 13
2024-12-20 13:41:05 INFO juju.worker.logfetcher: log entry 14
2024-12-20 13:41:05 INFO juju.worker.logfetcher: log entry 15
```

__4. Test out debug-log replay with limit command (assuming 1 is the first log and 15 is the last log)__
```sh
$ juju debug-log --limit 5 --replay
```

Prior debug-log output
```sh
2024-12-20 13:41:01 INFO juju.worker.logfetcher: log entry 1
2024-12-20 13:41:02 INFO juju.worker.logfetcher: log entry 2
2024-12-20 13:41:03 INFO juju.worker.logfetcher: log entry 3
2024-12-20 13:41:04 INFO juju.worker.logfetcher: log entry 4
2024-12-20 13:41:05 INFO juju.worker.logfetcher: log entry 5
```

Current debug-log output
```sh
2024-12-20 13:41:01 INFO juju.worker.logfetcher: log entry 1
2024-12-20 13:41:02 INFO juju.worker.logfetcher: log entry 2
2024-12-20 13:41:03 INFO juju.worker.logfetcher: log entry 3
2024-12-20 13:41:04 INFO juju.worker.logfetcher: log entry 4
2024-12-20 13:41:05 INFO juju.worker.logfetcher: log entry 5
```


__5. Test out debug-log replay with multiple flags command (assuming 1 is the first log and 15 is the last log)__
```sh
juju debug-log --include-module "juju.cmd" --replay --limit 5
```

Prior debug-log output
```sh
2024-12-20 13:41:01 INFO juju.worker.logfetcher: log entry 1
2024-12-20 13:41:02 INFO juju.worker.logfetcher: log entry 2
2024-12-20 13:41:03 INFO juju.worker.logfetcher: log entry 3
2024-12-20 13:41:04 INFO juju.worker.logfetcher: log entry 4
2024-12-20 13:41:05 INFO juju.worker.logfetcher: log entry 5
```

Current debug-log output
```sh
2024-12-20 13:41:01 INFO juju.worker.logfetcher: log entry 1
2024-12-20 13:41:02 INFO juju.worker.logfetcher: log entry 2
2024-12-20 13:41:03 INFO juju.worker.logfetcher: log entry 3
2024-12-20 13:41:04 INFO juju.worker.logfetcher: log entry 4
2024-12-20 13:41:05 INFO juju.worker.logfetcher: log entry 5
```

__6. Test out debug-log replay with lines command (assuming 1 is the first log and 15 is the last log)__
```sh
$ juju debug-log --replay --lines 5
```

Prior debug-log output
```sh
2024-12-20 13:41:01 INFO juju.worker.logfetcher: log entry 1
2024-12-20 13:41:02 INFO juju.worker.logfetcher: log entry 2
2024-12-20 13:41:03 INFO juju.worker.logfetcher: log entry 3
2024-12-20 13:41:04 INFO juju.worker.logfetcher: log entry 4
2024-12-20 13:41:05 INFO juju.worker.logfetcher: log entry 5
2024-12-20 13:41:05 INFO juju.worker.logfetcher: log entry 6
2024-12-20 13:41:05 INFO juju.worker.logfetcher: log entry 7
2024-12-20 13:41:05 INFO juju.worker.logfetcher: log entry 8
2024-12-20 13:41:05 INFO juju.worker.logfetcher: log entry 9
2024-12-20 13:41:05 INFO juju.worker.logfetcher: log entry 10
2024-12-20 13:41:05 INFO juju.worker.logfetcher: log entry 11
2024-12-20 13:41:05 INFO juju.worker.logfetcher: log entry 12
2024-12-20 13:41:05 INFO juju.worker.logfetcher: log entry 13
2024-12-20 13:41:05 INFO juju.worker.logfetcher: log entry 14
2024-12-20 13:41:05 INFO juju.worker.logfetcher: log entry 15
```

Current debug-log output
```sh
ERROR setting --replay and --lines not valid
```

__7. Test out debug-log replay with limit > 10 command (assuming 1 is the first log and 15 is the last log)__
```sh
$ juju debug-log --include-module "juju.apiserver" --limit 15
```

Prior debug-log output
```sh
2024-12-20 13:41:01 INFO juju.worker.logfetcher: log entry 1
2024-12-20 13:41:02 INFO juju.worker.logfetcher: log entry 2
2024-12-20 13:41:03 INFO juju.worker.logfetcher: log entry 3
2024-12-20 13:41:04 INFO juju.worker.logfetcher: log entry 4
2024-12-20 13:41:05 INFO juju.worker.logfetcher: log entry 5
2024-12-20 13:41:05 INFO juju.worker.logfetcher: log entry 6
2024-12-20 13:41:05 INFO juju.worker.logfetcher: log entry 7
2024-12-20 13:41:05 INFO juju.worker.logfetcher: log entry 8
2024-12-20 13:41:05 INFO juju.worker.logfetcher: log entry 9
2024-12-20 13:41:05 INFO juju.worker.logfetcher: log entry 10
```

Current debug-log output
```sh
2024-12-20 13:41:01 INFO juju.worker.logfetcher: log entry 1
2024-12-20 13:41:02 INFO juju.worker.logfetcher: log entry 2
2024-12-20 13:41:03 INFO juju.worker.logfetcher: log entry 3
2024-12-20 13:41:04 INFO juju.worker.logfetcher: log entry 4
2024-12-20 13:41:05 INFO juju.worker.logfetcher: log entry 5
2024-12-20 13:41:05 INFO juju.worker.logfetcher: log entry 6
2024-12-20 13:41:05 INFO juju.worker.logfetcher: log entry 7
2024-12-20 13:41:05 INFO juju.worker.logfetcher: log entry 8
2024-12-20 13:41:05 INFO juju.worker.logfetcher: log entry 9
2024-12-20 13:41:05 INFO juju.worker.logfetcher: log entry 10
2024-12-20 13:41:05 INFO juju.worker.logfetcher: log entry 11
2024-12-20 13:41:05 INFO juju.worker.logfetcher: log entry 12
2024-12-20 13:41:05 INFO juju.worker.logfetcher: log entry 13
2024-12-20 13:41:05 INFO juju.worker.logfetcher: log entry 14
2024-12-20 13:41:05 INFO juju.worker.logfetcher: log entry 15
```

## Links

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2091329

**Jira card:** https://warthogs.atlassian.net/browse/JUJU-7319