### PR TITLE
fix: don't ignore docs dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,3 @@ tests/tmp.*
 *.bundle
 *.log
 dqlite-deps.tar.bz2
-docs/


### PR DESCRIPTION
In 3.5 we want to ignore the docs dir, but not in 3.6 and beyond. However, this .gitignore line was accidentally carried forward in a merge.

Remove it