### PR TITLE
chore(docs): remove juju_agent and juju_agent_call introspect macros

### DIFF
--- a/docs/user/reference/resource-compute/list-of-commands-available-on-a-compute-resource-provisioned-by-juju/list-of-juju-introspect-macros/juju_agent.md
+++ b/docs/user/reference/resource-compute/list-of-commands-available-on-a-compute-resource-provisioned-by-juju/list-of-juju-introspect-macros/juju_agent.md
@@ -1,4 +1,0 @@
-(juju_agent)=
-# `juju_agent`
-
-TBA

--- a/docs/user/reference/resource-compute/list-of-commands-available-on-a-compute-resource-provisioned-by-juju/list-of-juju-introspect-macros/juju_agent_call.md
+++ b/docs/user/reference/resource-compute/list-of-commands-available-on-a-compute-resource-provisioned-by-juju/list-of-juju-introspect-macros/juju_agent_call.md
@@ -1,4 +1,0 @@
-(juju_agent_call)=
-# `juju_agent_call`
-
-TBA


### PR DESCRIPTION
This patch removes the two documentation pages for the juju_agent and juju_agent_call functions that are exported for usage with juju-introspect.
The reason we're removing them is that these two functions are actually low-level, juju internals functions and the regular user should not have to call them directly:
- juju_agent is a proxy used by all the other macros to correctly select the agent on which the juju-introspect command and its macro will be executed.
- juju_agent_call determines whether juju-introspect must be run with sudo and prepends it.


## Links


**Jira card:** JUJU-6580

