### PR TITLE
fix: panic in debug-log

### DIFF
--- a/state/logs.go
+++ b/state/logs.go
@@ -552,7 +552,7 @@ func (t *logTailer) processReversed(query *mgo.Query) error {
 		Iter()
 	defer iter.Close()
 
-	queue := make([]logDoc, t.params.InitialLines)
+	queue := make([]logDoc, 0, t.params.InitialLines)
 	var doc logDoc
 	for iter.Next(&doc) {
 		select {


### PR DESCRIPTION
A small mistake was made during a forward merge that resulted in a panic when running debug-log.

Resolve this panic

## QA steps

```
juju bootstrap lxd lxd
juju debug-log -m controller
```
Observe that there is no panic