### PR TITLE
fix: rename ReadOnlyModel core type

### DIFF
--- a/apiserver/facades/agent/provisioner/provisioninginfo.go
+++ b/apiserver/facades/agent/provisioner/provisioninginfo.go
@@ -125,7 +125,7 @@ func (api *ProvisionerAPI) getProvisioningInfoBase(
 	env environs.Environ,
 	endpointBindings map[string]string,
 	modelConfig *config.Config,
-	modelInfo model.ReadOnlyModel,
+	modelInfo model.ModelInfo,
 ) (params.ProvisioningInfo, error) {
 	base := m.Base()
 	result := params.ProvisioningInfo{
@@ -282,7 +282,7 @@ func (api *ProvisionerAPI) machineTags(
 	m *state.Machine,
 	isController bool,
 	modelConfig *config.Config,
-	modelInfo model.ReadOnlyModel,
+	modelInfo model.ModelInfo,
 ) (map[string]string, error) {
 	// Names of all units deployed to the machine.
 	//

--- a/apiserver/facades/agent/provisioner/service.go
+++ b/apiserver/facades/agent/provisioner/service.go
@@ -52,7 +52,7 @@ type ModelConfigService interface {
 type ModelInfoService interface {
 	// GetModelInfo returns the readonly model information for the model in
 	// question.
-	GetModelInfo(context.Context) (model.ReadOnlyModel, error)
+	GetModelInfo(context.Context) (model.ModelInfo, error)
 }
 
 // MachineService defines the methods that the facade assumes from the Machine

--- a/apiserver/facades/agent/uniter/legacy_service_mock_test.go
+++ b/apiserver/facades/agent/uniter/legacy_service_mock_test.go
@@ -152,10 +152,10 @@ func (m *MockModelInfoService) EXPECT() *MockModelInfoServiceMockRecorder {
 }
 
 // GetModelInfo mocks base method.
-func (m *MockModelInfoService) GetModelInfo(arg0 context.Context) (model.ReadOnlyModel, error) {
+func (m *MockModelInfoService) GetModelInfo(arg0 context.Context) (model.ModelInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetModelInfo", arg0)
-	ret0, _ := ret[0].(model.ReadOnlyModel)
+	ret0, _ := ret[0].(model.ModelInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -173,19 +173,19 @@ type MockModelInfoServiceGetModelInfoCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockModelInfoServiceGetModelInfoCall) Return(arg0 model.ReadOnlyModel, arg1 error) *MockModelInfoServiceGetModelInfoCall {
+func (c *MockModelInfoServiceGetModelInfoCall) Return(arg0 model.ModelInfo, arg1 error) *MockModelInfoServiceGetModelInfoCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockModelInfoServiceGetModelInfoCall) Do(f func(context.Context) (model.ReadOnlyModel, error)) *MockModelInfoServiceGetModelInfoCall {
+func (c *MockModelInfoServiceGetModelInfoCall) Do(f func(context.Context) (model.ModelInfo, error)) *MockModelInfoServiceGetModelInfoCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockModelInfoServiceGetModelInfoCall) DoAndReturn(f func(context.Context) (model.ReadOnlyModel, error)) *MockModelInfoServiceGetModelInfoCall {
+func (c *MockModelInfoServiceGetModelInfoCall) DoAndReturn(f func(context.Context) (model.ModelInfo, error)) *MockModelInfoServiceGetModelInfoCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/agent/uniter/newlxdprofile_test.go
+++ b/apiserver/facades/agent/uniter/newlxdprofile_test.go
@@ -150,7 +150,7 @@ func (s *newLxdProfileSuite) TestLXDProfileRequired(c *gc.C) {
 
 func (s *newLxdProfileSuite) TestCanApplyLXDProfileUnauthorized(c *gc.C) {
 	defer s.setupMocks(c).Finish()
-	s.modelInfoService.EXPECT().GetModelInfo(gomock.Any()).Return(model.ReadOnlyModel{
+	s.modelInfoService.EXPECT().GetModelInfo(gomock.Any()).Return(model.ModelInfo{
 		Type:      model.IAAS,
 		CloudType: "lxd",
 	}, nil)
@@ -178,7 +178,7 @@ func (s *newLxdProfileSuite) TestCanApplyLXDProfileIAASLXDNotManual(c *gc.C) {
 	// manual: false
 	defer s.setupMocks(c).Finish()
 	s.expectUnitAndMachine(1)
-	s.modelInfoService.EXPECT().GetModelInfo(gomock.Any()).Return(model.ReadOnlyModel{
+	s.modelInfoService.EXPECT().GetModelInfo(gomock.Any()).Return(model.ModelInfo{
 		Type:      model.IAAS,
 		CloudType: "lxd",
 	}, nil)
@@ -193,7 +193,7 @@ func (s *newLxdProfileSuite) TestCanApplyLXDProfileIAASLXDManual(c *gc.C) {
 	// manual: true
 	defer s.setupMocks(c).Finish()
 	s.expectUnitAndMachine(1)
-	s.modelInfoService.EXPECT().GetModelInfo(gomock.Any()).Return(model.ReadOnlyModel{
+	s.modelInfoService.EXPECT().GetModelInfo(gomock.Any()).Return(model.ModelInfo{
 		Type:      model.IAAS,
 		CloudType: "lxd",
 	}, nil)
@@ -206,7 +206,7 @@ func (s *newLxdProfileSuite) TestCanApplyLXDProfileCAAS(c *gc.C) {
 	// model type: CAAS
 	// provider type: k8s
 	defer s.setupMocks(c).Finish()
-	s.modelInfoService.EXPECT().GetModelInfo(gomock.Any()).Return(model.ReadOnlyModel{
+	s.modelInfoService.EXPECT().GetModelInfo(gomock.Any()).Return(model.ModelInfo{
 		Type:      model.CAAS,
 		CloudType: "k8s",
 	}, nil)
@@ -221,7 +221,7 @@ func (s *newLxdProfileSuite) TestCanApplyLXDProfileIAASMAASNotManualLXD(c *gc.C)
 	// container: LXD
 	defer s.setupMocks(c).Finish()
 	s.expectUnitAndMachine(1)
-	s.modelInfoService.EXPECT().GetModelInfo(gomock.Any()).Return(model.ReadOnlyModel{
+	s.modelInfoService.EXPECT().GetModelInfo(gomock.Any()).Return(model.ModelInfo{
 		Type:      model.IAAS,
 		CloudType: "maas",
 	}, nil)

--- a/apiserver/facades/agent/uniter/service.go
+++ b/apiserver/facades/agent/uniter/service.go
@@ -42,7 +42,7 @@ type ModelConfigService interface {
 type ModelInfoService interface {
 	// GetModelInfo returns the readonly model information for the model in
 	// question.
-	GetModelInfo(context.Context) (model.ReadOnlyModel, error)
+	GetModelInfo(context.Context) (model.ModelInfo, error)
 }
 
 // CloudService provides access to clouds.

--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -80,7 +80,7 @@ type APIBase struct {
 	repoDeploy                DeployFromRepository
 
 	model              Model
-	modelInfo          model.ReadOnlyModel
+	modelInfo          model.ModelInfo
 	modelConfigService ModelConfigService
 	machineService     MachineService
 	applicationService ApplicationService
@@ -213,7 +213,7 @@ type DeployApplicationFunc = func(
 	context.Context,
 	ApplicationDeployer,
 	Model,
-	model.ReadOnlyModel,
+	model.ModelInfo,
 	ApplicationService,
 	objectstore.ObjectStore,
 	DeployApplicationParams,
@@ -228,7 +228,7 @@ func NewAPIBase(
 	authorizer facade.Authorizer,
 	blockChecker BlockChecker,
 	model Model,
-	modelInfo model.ReadOnlyModel,
+	modelInfo model.ModelInfo,
 	leadershipReader Leadership,
 	repoDeploy DeployFromRepository,
 	deployApplication DeployApplicationFunc,

--- a/apiserver/facades/client/application/deploy.go
+++ b/apiserver/facades/client/application/deploy.go
@@ -80,7 +80,7 @@ type UnitAdder interface {
 // DeployApplication takes a charm and various parameters and deploys it.
 func DeployApplication(
 	ctx context.Context, st ApplicationDeployer, model Model,
-	modelInfo coremodel.ReadOnlyModel,
+	modelInfo coremodel.ModelInfo,
 	applicationService ApplicationService,
 	store objectstore.ObjectStore,
 	args DeployApplicationParams,

--- a/apiserver/facades/client/application/deployrepository.go
+++ b/apiserver/facades/client/application/deployrepository.go
@@ -257,7 +257,7 @@ type validatorConfig struct {
 	charmhubHTTPClient facade.HTTPClient
 	caasBroker         CaasBrokerInterface
 	model              Model
-	modelInfo          model.ReadOnlyModel
+	modelInfo          model.ModelInfo
 	modelConfigService ModelConfigService
 	applicationService ApplicationService
 	machineService     MachineService
@@ -314,7 +314,7 @@ func makeDeployFromRepositoryValidator(ctx context.Context, cfg validatorConfig)
 
 type deployFromRepositoryValidator struct {
 	model              Model
-	modelInfo          model.ReadOnlyModel
+	modelInfo          model.ModelInfo
 	modelConfigService ModelConfigService
 	applicationService ApplicationService
 	machineService     MachineService

--- a/apiserver/facades/client/application/package_test.go
+++ b/apiserver/facades/client/application/package_test.go
@@ -57,7 +57,7 @@ type baseSuite struct {
 	charmRepositoryFactory *MockRepositoryFactory
 
 	modelUUID model.UUID
-	modelInfo model.ReadOnlyModel
+	modelInfo model.ModelInfo
 
 	// Legacy types that we're transitioning away from.
 	backend           *MockBackend
@@ -140,7 +140,7 @@ func (s *baseSuite) newCAASAPI(c *gc.C) {
 }
 
 func (s *baseSuite) newAPI(c *gc.C, modelType model.ModelType) {
-	s.modelInfo = model.ReadOnlyModel{
+	s.modelInfo = model.ModelInfo{
 		UUID: s.modelUUID,
 		Type: modelType,
 	}

--- a/apiserver/facades/client/client/service.go
+++ b/apiserver/facades/client/client/service.go
@@ -36,7 +36,7 @@ type NetworkService interface {
 // ModelInfoService provides access to information about the model.
 type ModelInfoService interface {
 	// GetModelInfo returns information about the current model.
-	GetModelInfo(context.Context) (model.ReadOnlyModel, error)
+	GetModelInfo(context.Context) (model.ModelInfo, error)
 	// GetStatus returns the current status of the model.
 	// The following error types can be expected to be returned:
 	// - [modelerrors.NotFound]: When the model does not exist.

--- a/apiserver/facades/client/client/service_mock_test.go
+++ b/apiserver/facades/client/client/service_mock_test.go
@@ -135,10 +135,10 @@ func (m *MockModelInfoService) EXPECT() *MockModelInfoServiceMockRecorder {
 }
 
 // GetModelInfo mocks base method.
-func (m *MockModelInfoService) GetModelInfo(arg0 context.Context) (model.ReadOnlyModel, error) {
+func (m *MockModelInfoService) GetModelInfo(arg0 context.Context) (model.ModelInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetModelInfo", arg0)
-	ret0, _ := ret[0].(model.ReadOnlyModel)
+	ret0, _ := ret[0].(model.ModelInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/apiserver/facades/client/client/status_test.go
+++ b/apiserver/facades/client/client/status_test.go
@@ -43,7 +43,7 @@ func (s *statusSuite) TestModelStatus(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	now := time.Now()
-	s.modelInfoService.EXPECT().GetModelInfo(gomock.Any()).Return(model.ReadOnlyModel{
+	s.modelInfoService.EXPECT().GetModelInfo(gomock.Any()).Return(model.ModelInfo{
 		UUID:         s.modelUUID,
 		Name:         "model-name",
 		Type:         model.IAAS,
@@ -77,7 +77,7 @@ func (s *statusSuite) TestModelStatus(c *gc.C) {
 func (s *statusSuite) TestModelStatusModelNotFound(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.modelInfoService.EXPECT().GetModelInfo(gomock.Any()).Return(model.ReadOnlyModel{
+	s.modelInfoService.EXPECT().GetModelInfo(gomock.Any()).Return(model.ModelInfo{
 		UUID:         s.modelUUID,
 		Name:         "model-name",
 		Type:         model.IAAS,

--- a/apiserver/facades/client/imagemetadatamanager/metadata_test.go
+++ b/apiserver/facades/client/imagemetadatamanager/metadata_test.go
@@ -103,7 +103,7 @@ func (s *metadataSuite) TestSaveEmpty(c *gc.C) {
 	defer s.setupAPI(c).Finish()
 
 	s.modelInfoService.EXPECT().GetModelInfo(gomock.Any()).Return(
-		coremodel.ReadOnlyModel{
+		coremodel.ModelInfo{
 			CloudRegion: "region1",
 		}, nil,
 	)
@@ -120,7 +120,7 @@ func (s *metadataSuite) TestSave(c *gc.C) {
 		return config.New(config.UseDefaults, coretesting.FakeConfig())
 	})
 	s.modelInfoService.EXPECT().GetModelInfo(gomock.Any()).Return(
-		coremodel.ReadOnlyModel{
+		coremodel.ModelInfo{
 			CloudRegion: "east",
 		}, nil,
 	)
@@ -183,7 +183,7 @@ func (s *metadataSuite) TestSaveModelCfgFailed(c *gc.C) {
 	msg := "save error"
 	s.modelConfigService.EXPECT().ModelConfig(gomock.Any()).Return(nil, errors.New(msg))
 	s.modelInfoService.EXPECT().GetModelInfo(gomock.Any()).Return(
-		coremodel.ReadOnlyModel{
+		coremodel.ModelInfo{
 			CloudRegion: "region1",
 		}, nil,
 	)

--- a/apiserver/facades/client/imagemetadatamanager/service.go
+++ b/apiserver/facades/client/imagemetadatamanager/service.go
@@ -20,7 +20,7 @@ type ModelConfigService interface {
 // the current model being worked on.
 type ModelInfoService interface {
 	// GetModelInfo returns the information associated with the current model.
-	GetModelInfo(context.Context) (coremodel.ReadOnlyModel, error)
+	GetModelInfo(context.Context) (coremodel.ModelInfo, error)
 }
 
 // MetadataService defines methods to access and manipulate cloud image metadata.

--- a/apiserver/facades/client/imagemetadatamanager/service_mock_test.go
+++ b/apiserver/facades/client/imagemetadatamanager/service_mock_test.go
@@ -81,10 +81,10 @@ func (m *MockModelInfoService) EXPECT() *MockModelInfoServiceMockRecorder {
 }
 
 // GetModelInfo mocks base method.
-func (m *MockModelInfoService) GetModelInfo(arg0 context.Context) (model.ReadOnlyModel, error) {
+func (m *MockModelInfoService) GetModelInfo(arg0 context.Context) (model.ModelInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetModelInfo", arg0)
-	ret0, _ := ret[0].(model.ReadOnlyModel)
+	ret0, _ := ret[0].(model.ModelInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/apiserver/facades/client/machinemanager/machinemanager.go
+++ b/apiserver/facades/client/machinemanager/machinemanager.go
@@ -137,7 +137,7 @@ type BlockCommandService interface {
 
 // MachineManagerAPI provides access to the MachineManager API facade.
 type MachineManagerAPI struct {
-	model                   coremodel.ReadOnlyModel
+	model                   coremodel.ModelInfo
 	controllerConfigService ControllerConfigService
 	st                      Backend
 	cloudService            common.CloudService
@@ -162,7 +162,7 @@ type MachineManagerAPI struct {
 
 // NewMachineManagerAPI creates a new server-side MachineManager API facade.
 func NewMachineManagerAPI(
-	model coremodel.ReadOnlyModel,
+	model coremodel.ModelInfo,
 	controllerConfigService ControllerConfigService,
 	backend Backend,
 	cloudService common.CloudService,

--- a/apiserver/facades/client/machinemanager/machinemanager_test.go
+++ b/apiserver/facades/client/machinemanager/machinemanager_test.go
@@ -39,7 +39,7 @@ import (
 
 type AddMachineManagerSuite struct {
 	authorizer    *apiservertesting.FakeAuthorizer
-	model         model.ReadOnlyModel
+	model         model.ModelInfo
 	st            *MockBackend
 	storageAccess *MockStorageInterface
 	pool          *MockPool
@@ -59,7 +59,7 @@ var _ = gc.Suite(&AddMachineManagerSuite{})
 
 func (s *AddMachineManagerSuite) SetUpTest(c *gc.C) {
 	s.authorizer = &apiservertesting.FakeAuthorizer{Tag: names.NewUserTag("admin")}
-	s.model = model.ReadOnlyModel{
+	s.model = model.ModelInfo{
 		UUID: modeltesting.GenModelUUID(c),
 	}
 }
@@ -200,7 +200,7 @@ type DestroyMachineManagerSuite struct {
 	cloudService  *commonmocks.MockCloudService
 	credService   *commonmocks.MockCredentialService
 	api           *MachineManagerAPI
-	model         model.ReadOnlyModel
+	model         model.ModelInfo
 
 	controllerConfigService *MockControllerConfigService
 	machineService          *MockMachineService
@@ -215,7 +215,7 @@ func (s *DestroyMachineManagerSuite) SetUpTest(c *gc.C) {
 	s.CleanupSuite.SetUpTest(c)
 	s.authorizer = &apiservertesting.FakeAuthorizer{Tag: names.NewUserTag("admin")}
 	s.PatchValue(&ClassifyDetachedStorage, mockedClassifyDetachedStorage)
-	s.model = model.ReadOnlyModel{
+	s.model = model.ModelInfo{
 		UUID: modeltesting.GenModelUUID(c),
 	}
 }
@@ -729,7 +729,7 @@ type ProvisioningMachineManagerSuite struct {
 	cloudService *commonmocks.MockCloudService
 	credService  *commonmocks.MockCredentialService
 	api          *MachineManagerAPI
-	model        model.ReadOnlyModel
+	model        model.ModelInfo
 
 	controllerConfigService *MockControllerConfigService
 	machineService          *MockMachineService
@@ -749,7 +749,7 @@ func (s *ProvisioningMachineManagerSuite) SetUpTest(c *gc.C) {
 func (s *ProvisioningMachineManagerSuite) setupMocks(c *gc.C) *gomock.Controller {
 	ctrl := gomock.NewController(c)
 
-	s.model = model.ReadOnlyModel{
+	s.model = model.ModelInfo{
 		UUID: modeltesting.GenModelUUID(c),
 	}
 

--- a/apiserver/facades/client/modelmanager/mocks/service_mock.go
+++ b/apiserver/facades/client/modelmanager/mocks/service_mock.go
@@ -1128,10 +1128,10 @@ func (c *MockModelInfoServiceDeleteModelCall) DoAndReturn(f func(context.Context
 }
 
 // GetModelInfo mocks base method.
-func (m *MockModelInfoService) GetModelInfo(arg0 context.Context) (model.ReadOnlyModel, error) {
+func (m *MockModelInfoService) GetModelInfo(arg0 context.Context) (model.ModelInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetModelInfo", arg0)
-	ret0, _ := ret[0].(model.ReadOnlyModel)
+	ret0, _ := ret[0].(model.ModelInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1149,19 +1149,19 @@ type MockModelInfoServiceGetModelInfoCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockModelInfoServiceGetModelInfoCall) Return(arg0 model.ReadOnlyModel, arg1 error) *MockModelInfoServiceGetModelInfoCall {
+func (c *MockModelInfoServiceGetModelInfoCall) Return(arg0 model.ModelInfo, arg1 error) *MockModelInfoServiceGetModelInfoCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockModelInfoServiceGetModelInfoCall) Do(f func(context.Context) (model.ReadOnlyModel, error)) *MockModelInfoServiceGetModelInfoCall {
+func (c *MockModelInfoServiceGetModelInfoCall) Do(f func(context.Context) (model.ModelInfo, error)) *MockModelInfoServiceGetModelInfoCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockModelInfoServiceGetModelInfoCall) DoAndReturn(f func(context.Context) (model.ReadOnlyModel, error)) *MockModelInfoServiceGetModelInfoCall {
+func (c *MockModelInfoServiceGetModelInfoCall) DoAndReturn(f func(context.Context) (model.ModelInfo, error)) *MockModelInfoServiceGetModelInfoCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/client/modelmanager/modelinfo_test.go
+++ b/apiserver/facades/client/modelmanager/modelinfo_test.go
@@ -218,7 +218,7 @@ func (s *modelInfoSuite) getAPI(c *gc.C) (*modelmanager.ModelManagerAPI, *gomock
 		Status: status.Active,
 		Since:  time.Now(),
 	}, nil)
-	modelInfoService.EXPECT().GetModelInfo(gomock.Any()).Return(coremodel.ReadOnlyModel{
+	modelInfoService.EXPECT().GetModelInfo(gomock.Any()).Return(coremodel.ModelInfo{
 		AgentVersion:   version.MustParse("1.99.9"),
 		ControllerUUID: s.controllerUUID,
 		Cloud:          "dummy",
@@ -472,7 +472,7 @@ func (s *modelInfoSuite) TestModelInfoWriteAccess(c *gc.C) {
 		Status: status.Active,
 		Since:  time.Now(),
 	}, nil)
-	modelInfoService.EXPECT().GetModelInfo(gomock.Any()).Return(coremodel.ReadOnlyModel{
+	modelInfoService.EXPECT().GetModelInfo(gomock.Any()).Return(coremodel.ModelInfo{
 		AgentVersion:   version.MustParse("1.99.9"),
 		ControllerUUID: s.controllerUUID,
 		Cloud:          "dummy",
@@ -507,7 +507,7 @@ func (s *modelInfoSuite) TestModelInfoNonOwner(c *gc.C) {
 	modelInfoService := mocks.NewMockModelInfoService(ctrl)
 	modelAgentService := mocks.NewMockModelAgentService(ctrl)
 	modelAgentService.EXPECT().GetModelTargetAgentVersion(gomock.Any()).Return(jujuversion.Current, nil)
-	modelInfoService.EXPECT().GetModelInfo(gomock.Any()).Return(coremodel.ReadOnlyModel{
+	modelInfoService.EXPECT().GetModelInfo(gomock.Any()).Return(coremodel.ModelInfo{
 		AgentVersion:   version.MustParse("1.99.9"),
 		ControllerUUID: s.controllerUUID,
 		Cloud:          "dummy",
@@ -681,7 +681,7 @@ func (s *modelInfoSuite) TestAliveModelWithGetModelInfoFailure(c *gc.C) {
 	s.mockDomainServicesGetter.EXPECT().DomainServicesForModel(gomock.Any()).Return(modelDomainServices).AnyTimes()
 	modelInfoService := mocks.NewMockModelInfoService(ctrl)
 	modelDomainServices.EXPECT().ModelInfo().Return(modelInfoService)
-	modelInfoService.EXPECT().GetModelInfo(gomock.Any()).Return(coremodel.ReadOnlyModel{}, errors.NotFoundf("model info"))
+	modelInfoService.EXPECT().GetModelInfo(gomock.Any()).Return(coremodel.ModelInfo{}, errors.NotFoundf("model info"))
 
 	s.st.model.life = state.Alive
 	s.testModelInfoError(c, api, s.st.model.tag.String(), "model info not found")
@@ -694,7 +694,7 @@ func (s *modelInfoSuite) TestAliveModelWithGetModelTargetAgentVersionFailure(c *
 	s.mockDomainServicesGetter.EXPECT().DomainServicesForModel(gomock.Any()).Return(modelDomainServices).AnyTimes()
 	modelInfoService := mocks.NewMockModelInfoService(ctrl)
 	modelDomainServices.EXPECT().ModelInfo().Return(modelInfoService)
-	modelInfoService.EXPECT().GetModelInfo(gomock.Any()).Return(coremodel.ReadOnlyModel{}, nil)
+	modelInfoService.EXPECT().GetModelInfo(gomock.Any()).Return(coremodel.ModelInfo{}, nil)
 	modelAgentService := mocks.NewMockModelAgentService(ctrl)
 	modelDomainServices.EXPECT().Agent().Return(modelAgentService)
 	modelAgentService.EXPECT().GetModelTargetAgentVersion(gomock.Any()).Return(version.Zero, errors.NotFoundf("model agent version"))
@@ -750,7 +750,7 @@ func (s *modelInfoSuite) TestDeadModelWithGetModelInfoFailure(c *gc.C) {
 	s.mockDomainServicesGetter.EXPECT().DomainServicesForModel(gomock.Any()).Return(modelDomainServices).AnyTimes()
 	modelInfoService := mocks.NewMockModelInfoService(ctrl)
 	modelDomainServices.EXPECT().ModelInfo().Return(modelInfoService)
-	modelInfoService.EXPECT().GetModelInfo(gomock.Any()).Return(coremodel.ReadOnlyModel{}, errors.NotFoundf("model info"))
+	modelInfoService.EXPECT().GetModelInfo(gomock.Any()).Return(coremodel.ModelInfo{}, errors.NotFoundf("model info"))
 
 	modelAgentService := mocks.NewMockModelAgentService(ctrl)
 	modelDomainServices.EXPECT().Agent().Return(modelAgentService)
@@ -777,7 +777,7 @@ func (s *modelInfoSuite) TestDeadModelWithGetModelTargetAgentVersionFailure(c *g
 	s.mockDomainServicesGetter.EXPECT().DomainServicesForModel(gomock.Any()).Return(modelDomainServices).AnyTimes()
 	modelInfoService := mocks.NewMockModelInfoService(ctrl)
 	modelDomainServices.EXPECT().ModelInfo().Return(modelInfoService)
-	modelInfoService.EXPECT().GetModelInfo(gomock.Any()).Return(coremodel.ReadOnlyModel{}, nil)
+	modelInfoService.EXPECT().GetModelInfo(gomock.Any()).Return(coremodel.ModelInfo{}, nil)
 
 	modelAgentService := mocks.NewMockModelAgentService(ctrl)
 	modelDomainServices.EXPECT().Agent().Return(modelAgentService)
@@ -841,7 +841,7 @@ func (s *modelInfoSuite) TestDyingModelWithGetModelInfoFailure(c *gc.C) {
 	s.mockDomainServicesGetter.EXPECT().DomainServicesForModel(gomock.Any()).Return(modelDomainServices).AnyTimes()
 	modelInfoService := mocks.NewMockModelInfoService(ctrl)
 	modelDomainServices.EXPECT().ModelInfo().Return(modelInfoService)
-	modelInfoService.EXPECT().GetModelInfo(gomock.Any()).Return(coremodel.ReadOnlyModel{}, errors.NotFoundf("model info"))
+	modelInfoService.EXPECT().GetModelInfo(gomock.Any()).Return(coremodel.ModelInfo{}, errors.NotFoundf("model info"))
 
 	modelAgentService := mocks.NewMockModelAgentService(ctrl)
 	modelDomainServices.EXPECT().Agent().Return(modelAgentService)
@@ -868,7 +868,7 @@ func (s *modelInfoSuite) TestDyingModelWithGetModelTargetAgentVersionFailure(c *
 	s.mockDomainServicesGetter.EXPECT().DomainServicesForModel(gomock.Any()).Return(modelDomainServices).AnyTimes()
 	modelInfoService := mocks.NewMockModelInfoService(ctrl)
 	modelDomainServices.EXPECT().ModelInfo().Return(modelInfoService)
-	modelInfoService.EXPECT().GetModelInfo(gomock.Any()).Return(coremodel.ReadOnlyModel{}, nil)
+	modelInfoService.EXPECT().GetModelInfo(gomock.Any()).Return(coremodel.ModelInfo{}, nil)
 
 	modelAgentService := mocks.NewMockModelAgentService(ctrl)
 	modelDomainServices.EXPECT().Agent().Return(modelAgentService)
@@ -948,7 +948,7 @@ func (s *modelInfoSuite) TestImportingModelWithGetModelInfoFailure(c *gc.C) {
 	s.mockDomainServicesGetter.EXPECT().DomainServicesForModel(gomock.Any()).Return(modelDomainServices).AnyTimes()
 	modelInfoService := mocks.NewMockModelInfoService(ctrl)
 	modelDomainServices.EXPECT().ModelInfo().Return(modelInfoService)
-	modelInfoService.EXPECT().GetModelInfo(gomock.Any()).Return(coremodel.ReadOnlyModel{}, errors.NotFoundf("model info"))
+	modelInfoService.EXPECT().GetModelInfo(gomock.Any()).Return(coremodel.ModelInfo{}, errors.NotFoundf("model info"))
 
 	modelAgentService := mocks.NewMockModelAgentService(ctrl)
 	modelDomainServices.EXPECT().Agent().Return(modelAgentService)
@@ -976,7 +976,7 @@ func (s *modelInfoSuite) TestImportingModelWithGetModelTargetAgentVersionFailure
 	s.mockDomainServicesGetter.EXPECT().DomainServicesForModel(gomock.Any()).Return(modelDomainServices).AnyTimes()
 	modelInfoService := mocks.NewMockModelInfoService(ctrl)
 	modelDomainServices.EXPECT().ModelInfo().Return(modelInfoService)
-	modelInfoService.EXPECT().GetModelInfo(gomock.Any()).Return(coremodel.ReadOnlyModel{}, nil)
+	modelInfoService.EXPECT().GetModelInfo(gomock.Any()).Return(coremodel.ModelInfo{}, nil)
 
 	modelAgentService := mocks.NewMockModelAgentService(ctrl)
 	modelDomainServices.EXPECT().Agent().Return(modelAgentService)

--- a/apiserver/facades/client/modelmanager/modelmanager_test.go
+++ b/apiserver/facades/client/modelmanager/modelmanager_test.go
@@ -399,9 +399,9 @@ func (s *modelManagerSuite) expectCreateModelOnModelDB(
 		Status: status.Available,
 		Since:  time.Now(),
 	}, nil)
-	modelInfoService.EXPECT().GetModelInfo(gomock.Any()).Return(coremodel.ReadOnlyModel{
+	modelInfoService.EXPECT().GetModelInfo(gomock.Any()).Return(coremodel.ModelInfo{
 		// Use a version we shouldn't have now to ensure we're using the
-		// ModelAgentService rather than the ReadOnlyModel data.
+		// ModelAgentService rather than the ModelInfo data.
 		AgentVersion:   version.MustParse("2.6.5"),
 		ControllerUUID: s.controllerUUID,
 		Cloud:          "dummy",
@@ -1163,10 +1163,10 @@ func (s *modelManagerStateSuite) expectCreateModelStateSuite(
 		Status: status.Active,
 		Since:  time.Now(),
 	}, nil)
-	s.modelInfoService.EXPECT().GetModelInfo(gomock.Any()).Return(coremodel.ReadOnlyModel{
+	s.modelInfoService.EXPECT().GetModelInfo(gomock.Any()).Return(coremodel.ModelInfo{
 		UUID: modelUUID,
 		// Use a version we shouldn't have now to ensure we're using the
-		// ModelAgentService rather than the ReadOnlyModel data.
+		// ModelAgentService rather than the ModelInfo data.
 		AgentVersion:   version.MustParse("2.6.5"),
 		ControllerUUID: s.controllerUUID,
 		Cloud:          "dummy",

--- a/apiserver/facades/client/modelmanager/services.go
+++ b/apiserver/facades/client/modelmanager/services.go
@@ -41,10 +41,9 @@ type ModelDomainServices interface {
 	// Config returns the model config service.
 	Config() ModelConfigService
 
-	// ModelInfo returns the model service for the model. The model info
-	// contains read-only information about the model.
+	// ModelInfo returns the model service for the model.
 	// Note: This should be called model, but we have naming conflicts with
-	// the model service. As this is only for read-only model information, we
+	// the model service. As this is only for model information, we
 	// can rename it to the more obscure version.
 	ModelInfo() ModelInfoService
 
@@ -164,7 +163,7 @@ type ModelInfoService interface {
 
 	// GetModelInfo returns the readonly model information for the model in
 	// question.
-	GetModelInfo(context.Context) (coremodel.ReadOnlyModel, error)
+	GetModelInfo(context.Context) (coremodel.ModelInfo, error)
 
 	// GetStatus returns the current status of the model.
 	// The following error types can be expected to be returned:

--- a/apiserver/facades/controller/caasapplicationprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/provisioner_test.go
@@ -162,7 +162,7 @@ func (s *CAASApplicationProvisionerSuite) TestProvisioningInfo(c *gc.C) {
 	s.controllerConfigService.EXPECT().ControllerConfig(gomock.Any()).Return(coretesting.FakeControllerConfig(), nil)
 	s.modelConfigService.EXPECT().ModelConfig(gomock.Any()).Return(s.fakeModelConfig())
 
-	modelInfo := model.ReadOnlyModel{
+	modelInfo := model.ModelInfo{
 		UUID: model.UUID(coretesting.ModelTag.Id()),
 	}
 	s.modelInfoService.EXPECT().GetModelInfo(gomock.Any()).Return(modelInfo, nil)

--- a/apiserver/facades/controller/caasapplicationprovisioner/service.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/service.go
@@ -42,7 +42,7 @@ type ModelConfigService interface {
 type ModelInfoService interface {
 	// GetModelInfo returns the readonly model information for the model in
 	// question.
-	GetModelInfo(context.Context) (model.ReadOnlyModel, error)
+	GetModelInfo(context.Context) (model.ModelInfo, error)
 }
 
 // ApplicationService describes the service for accessing application scaling info.

--- a/apiserver/facades/controller/caasapplicationprovisioner/service_mock_test.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/service_mock_test.go
@@ -157,10 +157,10 @@ func (m *MockModelInfoService) EXPECT() *MockModelInfoServiceMockRecorder {
 }
 
 // GetModelInfo mocks base method.
-func (m *MockModelInfoService) GetModelInfo(arg0 context.Context) (model.ReadOnlyModel, error) {
+func (m *MockModelInfoService) GetModelInfo(arg0 context.Context) (model.ModelInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetModelInfo", arg0)
-	ret0, _ := ret[0].(model.ReadOnlyModel)
+	ret0, _ := ret[0].(model.ModelInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/apiserver/facades/controller/migrationmaster/facade_test.go
+++ b/apiserver/facades/controller/migrationmaster/facade_test.go
@@ -180,7 +180,7 @@ func (s *Suite) TestMigrationStatus(c *gc.C) {
 func (s *Suite) TestModelInfo(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.modelInfoService.EXPECT().GetModelInfo(gomock.Any()).Return(model.ReadOnlyModel{
+	s.modelInfoService.EXPECT().GetModelInfo(gomock.Any()).Return(model.ModelInfo{
 		UUID:            "model-uuid",
 		Name:            "model-name",
 		CredentialOwner: usertesting.GenNewName(c, "owner"),
@@ -322,7 +322,7 @@ func (s *Suite) TestSetStatusMessageError(c *gc.C) {
 func (s *Suite) TestPrechecksModelError(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.modelInfoService.EXPECT().GetModelInfo(gomock.Any()).Return(model.ReadOnlyModel{}, errors.New("boom"))
+	s.modelInfoService.EXPECT().GetModelInfo(gomock.Any()).Return(model.ModelInfo{}, errors.New("boom"))
 
 	err := s.mustMakeAPI(c).Prechecks(context.Background(), params.PrechecksArgs{TargetControllerVersion: version.MustParse("2.9.32")})
 	c.Assert(err, gc.ErrorMatches, "retrieving model info: boom")

--- a/apiserver/facades/controller/migrationmaster/mocks/backend.go
+++ b/apiserver/facades/controller/migrationmaster/mocks/backend.go
@@ -614,10 +614,10 @@ func (m *MockModelInfoService) EXPECT() *MockModelInfoServiceMockRecorder {
 }
 
 // GetModelInfo mocks base method.
-func (m *MockModelInfoService) GetModelInfo(arg0 context.Context) (model.ReadOnlyModel, error) {
+func (m *MockModelInfoService) GetModelInfo(arg0 context.Context) (model.ModelInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetModelInfo", arg0)
-	ret0, _ := ret[0].(model.ReadOnlyModel)
+	ret0, _ := ret[0].(model.ModelInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -635,19 +635,19 @@ type MockModelInfoServiceGetModelInfoCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockModelInfoServiceGetModelInfoCall) Return(arg0 model.ReadOnlyModel, arg1 error) *MockModelInfoServiceGetModelInfoCall {
+func (c *MockModelInfoServiceGetModelInfoCall) Return(arg0 model.ModelInfo, arg1 error) *MockModelInfoServiceGetModelInfoCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockModelInfoServiceGetModelInfoCall) Do(f func(context.Context) (model.ReadOnlyModel, error)) *MockModelInfoServiceGetModelInfoCall {
+func (c *MockModelInfoServiceGetModelInfoCall) Do(f func(context.Context) (model.ModelInfo, error)) *MockModelInfoServiceGetModelInfoCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockModelInfoServiceGetModelInfoCall) DoAndReturn(f func(context.Context) (model.ReadOnlyModel, error)) *MockModelInfoServiceGetModelInfoCall {
+func (c *MockModelInfoServiceGetModelInfoCall) DoAndReturn(f func(context.Context) (model.ModelInfo, error)) *MockModelInfoServiceGetModelInfoCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/controller/migrationmaster/service.go
+++ b/apiserver/facades/controller/migrationmaster/service.go
@@ -36,7 +36,7 @@ type ModelConfigService interface {
 type ModelInfoService interface {
 	// GetModelInfo returns the readonly model information for the model in
 	// question.
-	GetModelInfo(context.Context) (model.ReadOnlyModel, error)
+	GetModelInfo(context.Context) (model.ModelInfo, error)
 }
 
 // ModelService provides access to currently deployed models.

--- a/apiserver/service.go
+++ b/apiserver/service.go
@@ -57,8 +57,8 @@ type BakeryConfigService interface {
 
 // ModelInfoService provides access to information about the current model.
 type ModelInfoService interface {
-	// GetModelInfo returns the read-only information for the current model.
-	GetModelInfo(ctx context.Context) (model.ReadOnlyModel, error)
+	// GetModelInfo returns the information for the current model.
+	GetModelInfo(ctx context.Context) (model.ModelInfo, error)
 }
 
 // AccessService provides information about users and permissions.

--- a/core/model/modelinfo.go
+++ b/core/model/modelinfo.go
@@ -10,10 +10,8 @@ import (
 	"github.com/juju/juju/internal/uuid"
 )
 
-// ReadOnlyModel represents the state of a read-only model found in the
-// model database, not the controller database.
-// All the fields are are denormalized from the model database.
-type ReadOnlyModel struct {
+// ModelInfo represents the state of a model found in the  model database.
+type ModelInfo struct {
 	// UUID represents the model UUID.
 	UUID UUID
 
@@ -51,8 +49,8 @@ type ReadOnlyModel struct {
 
 // ModelMetrics represents the metrics information set in the database.
 type ModelMetrics struct {
-	// Model returns the read only model.
-	Model ReadOnlyModel
+	// Model is the detail from the model database.
+	Model ModelInfo
 
 	// ApplicationCount is the number of applications in the model.
 	ApplicationCount int

--- a/domain/agentprovisioner/state/state_test.go
+++ b/domain/agentprovisioner/state/state_test.go
@@ -104,7 +104,7 @@ func (s *suite) TestGetModelConfigKeyValuesGetNoKeys(c *gc.C) {
 
 // TestModelID tests that State.ModelID works as expected.
 func (s *suite) TestModelID(c *gc.C) {
-	// Create a read-only model
+	// Create model info.
 	modelID := modeltesting.GenModelUUID(c)
 	modelSt := modelstate.NewModelState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 	err := modelSt.Create(context.Background(), model.ReadOnlyModelCreationArgs{

--- a/domain/model/modelmigration/import_test.go
+++ b/domain/model/modelmigration/import_test.go
@@ -277,7 +277,7 @@ func (i *importSuite) TestModelCreateRollbacksOnFailure(c *gc.C) {
 	err = coordinator.Perform(context.Background(), modelmigration.NewScope(nil, nil, nil), model)
 	c.Check(err, gc.ErrorMatches, `.*boom.*`)
 
-	// TODO (stickupkid): This is incorrect until the read-only model is
+	// TODO (stickupkid): This is incorrect until the model info is
 	// correctly saved.
 	c.Check(activated, jc.IsTrue)
 }
@@ -357,7 +357,7 @@ func (i *importSuite) TestModelCreateRollbacksOnFailureIgnoreNotFoundModel(c *gc
 	err = coordinator.Perform(context.Background(), modelmigration.NewScope(nil, nil, nil), model)
 	c.Check(err, gc.ErrorMatches, `.*boom.*`)
 
-	// TODO (stickupkid): This is incorrect until the read-only model is
+	// TODO (stickupkid): This is incorrect until the model info is
 	// correctly saved.
 	c.Check(activated, jc.IsTrue)
 }
@@ -437,7 +437,7 @@ func (i *importSuite) TestModelCreateRollbacksOnFailureIgnoreNotFoundReadOnlyMod
 	err = coordinator.Perform(context.Background(), modelmigration.NewScope(nil, nil, nil), model)
 	c.Check(err, gc.ErrorMatches, `.*boom.*`)
 
-	// TODO (stickupkid): This is incorrect until the read-only model is
+	// TODO (stickupkid): This is incorrect until the model info is
 	// correctly saved.
 	c.Check(activated, jc.IsTrue)
 }

--- a/domain/model/service/modelservice.go
+++ b/domain/model/service/modelservice.go
@@ -25,7 +25,7 @@ type ModelState interface {
 	Delete(context.Context, coremodel.UUID) error
 
 	// GetModel returns the read only model information set in the database.
-	GetModel(context.Context) (coremodel.ReadOnlyModel, error)
+	GetModel(context.Context) (coremodel.ModelInfo, error)
 
 	// GetModelMetrics returns the model metrics information set in the
 	// database.
@@ -68,7 +68,7 @@ func NewModelService(
 
 // GetModelInfo returns the readonly model information for the model in
 // question.
-func (s *ModelService) GetModelInfo(ctx context.Context) (coremodel.ReadOnlyModel, error) {
+func (s *ModelService) GetModelInfo(ctx context.Context) (coremodel.ModelInfo, error) {
 	return s.modelSt.GetModel(ctx)
 }
 

--- a/domain/model/service/modelservice_test.go
+++ b/domain/model/service/modelservice_test.go
@@ -64,7 +64,7 @@ func (s *modelServiceSuite) TestModelCreation(c *gc.C) {
 
 	readonlyVal, err := svc.GetModelInfo(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(readonlyVal, gc.Equals, coremodel.ReadOnlyModel{
+	c.Check(readonlyVal, gc.Equals, coremodel.ModelInfo{
 		UUID:           id,
 		ControllerUUID: s.controllerUUID,
 		Name:           "my-awesome-model",
@@ -97,7 +97,7 @@ func (s *modelServiceSuite) TestGetModelMetrics(c *gc.C) {
 	readonlyVal, err := svc.GetModelMetrics(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(readonlyVal, gc.Equals, coremodel.ModelMetrics{
-		Model: coremodel.ReadOnlyModel{
+		Model: coremodel.ModelInfo{
 			UUID:           id,
 			ControllerUUID: s.controllerUUID,
 			Name:           "my-awesome-model",
@@ -275,13 +275,13 @@ func (d *dummyModelState) Create(ctx context.Context, args model.ReadOnlyModelCr
 	return nil
 }
 
-func (d *dummyModelState) GetModel(ctx context.Context) (coremodel.ReadOnlyModel, error) {
+func (d *dummyModelState) GetModel(ctx context.Context) (coremodel.ModelInfo, error) {
 	if d.setID == coremodel.UUID("") {
-		return coremodel.ReadOnlyModel{}, modelerrors.NotFound
+		return coremodel.ModelInfo{}, modelerrors.NotFound
 	}
 
 	args := d.models[d.setID]
-	return coremodel.ReadOnlyModel{
+	return coremodel.ModelInfo{
 		UUID:            args.UUID,
 		AgentVersion:    args.AgentVersion,
 		ControllerUUID:  args.ControllerUUID,
@@ -302,7 +302,7 @@ func (d *dummyModelState) GetModelMetrics(ctx context.Context) (coremodel.ModelM
 
 	args := d.models[d.setID]
 	return coremodel.ModelMetrics{
-		Model: coremodel.ReadOnlyModel{
+		Model: coremodel.ModelInfo{
 			UUID:            args.UUID,
 			AgentVersion:    args.AgentVersion,
 			ControllerUUID:  args.ControllerUUID,

--- a/domain/model/service/providerservice.go
+++ b/domain/model/service/providerservice.go
@@ -12,8 +12,8 @@ import (
 // ProviderState is the model state required by the provide service. This is
 // the model database state, not the controller state.
 type ProviderState interface {
-	// Model returns a read-only model.
-	GetModel(context.Context) (coremodel.ReadOnlyModel, error)
+	// GetModel returns a the model info.
+	GetModel(context.Context) (coremodel.ModelInfo, error)
 }
 
 // ProviderService defines a service for interacting with the underlying model
@@ -29,10 +29,10 @@ func NewProviderService(st ProviderState) *ProviderService {
 	}
 }
 
-// Model returns a read-only model.
+// Model returns model info for the current service.
 //
 // The following error types can be expected to be returned:
 // - [modelerrors.NotFound]: When the model is not found for a given uuid.
-func (s *ProviderService) Model(ctx context.Context) (coremodel.ReadOnlyModel, error) {
+func (s *ProviderService) Model(ctx context.Context) (coremodel.ModelInfo, error) {
 	return s.st.GetModel(ctx)
 }

--- a/domain/model/service/providerservice_test.go
+++ b/domain/model/service/providerservice_test.go
@@ -16,14 +16,14 @@ import (
 )
 
 type dummyProviderState struct {
-	model *coremodel.ReadOnlyModel
+	model *coremodel.ModelInfo
 }
 
-func (d *dummyProviderState) GetModel(ctx context.Context) (coremodel.ReadOnlyModel, error) {
+func (d *dummyProviderState) GetModel(ctx context.Context) (coremodel.ModelInfo, error) {
 	if d.model != nil {
 		return *d.model, nil
 	}
-	return coremodel.ReadOnlyModel{}, modelerrors.NotFound
+	return coremodel.ModelInfo{}, modelerrors.NotFound
 }
 
 type providerServiceSuite struct {
@@ -42,7 +42,7 @@ func (s *providerServiceSuite) TestModel(c *gc.C) {
 	svc := NewProviderService(s.state)
 
 	id := modeltesting.GenModelUUID(c)
-	model := coremodel.ReadOnlyModel{
+	model := coremodel.ModelInfo{
 		UUID:        id,
 		Name:        "my-awesome-model",
 		Cloud:       "aws",

--- a/domain/model/state/modelstate_test.go
+++ b/domain/model/state/modelstate_test.go
@@ -56,7 +56,7 @@ func (s *modelSuite) TestCreateAndReadModel(c *gc.C) {
 	// Check that it was written correctly.
 	model, err := state.GetModel(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(model, jc.DeepEquals, coremodel.ReadOnlyModel{
+	c.Check(model, jc.DeepEquals, coremodel.ModelInfo{
 		UUID:            id,
 		AgentVersion:    jujuversion.Current,
 		ControllerUUID:  s.controllerUUID,
@@ -242,7 +242,7 @@ func (s *modelSuite) TestGetModelMetrics(c *gc.C) {
 	model, err := state.GetModelMetrics(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(model, jc.DeepEquals, coremodel.ModelMetrics{
-		Model: coremodel.ReadOnlyModel{
+		Model: coremodel.ModelInfo{
 			UUID:            id,
 			AgentVersion:    jujuversion.Current,
 			ControllerUUID:  s.controllerUUID,

--- a/internal/services/interface.go
+++ b/internal/services/interface.go
@@ -106,10 +106,9 @@ type ModelDomainServices interface {
 	Storage() *storageservice.Service
 	// Secret returns the secret service.
 	Secret(secretservice.SecretServiceParams) *secretservice.WatchableService
-	// ModelInfo returns the model service for the model. The model info
-	// contains read-only information about the model.
+	// ModelInfo returns the model service for the model.
 	// Note: This should be called model, but we have naming conflicts with
-	// the model service. As this is only for read-only model information, we
+	// the model service. As this is only for model information, we
 	// can rename it to the more obscure version.
 	ModelInfo() *modelservice.ModelService
 	// ModelMigration returns the model's migration service for support

--- a/internal/worker/charmrevisioner/worker_test.go
+++ b/internal/worker/charmrevisioner/worker_test.go
@@ -236,7 +236,7 @@ func (s *WorkerSuite) TestFetch(c *gc.C) {
 		}}, nil
 	})
 
-	model := coremodel.ReadOnlyModel{
+	model := coremodel.ModelInfo{
 		UUID:           modeltesting.GenModelUUID(c),
 		ControllerUUID: uuid.MustNewUUID(),
 		Cloud:          "aws",
@@ -294,7 +294,7 @@ func (s *WorkerSuite) TestFetchInfo(c *gc.C) {
 	s.expectWatcher(c)
 	s.expectModelConfig(c)
 
-	model := coremodel.ReadOnlyModel{
+	model := coremodel.ModelInfo{
 		UUID:           modeltesting.GenModelUUID(c),
 		ControllerUUID: uuid.MustNewUUID(),
 		Cloud:          "aws",
@@ -398,7 +398,7 @@ func (s *WorkerSuite) TestFetchInfoInvalidResponseLength(c *gc.C) {
 	s.expectWatcher(c)
 	s.expectModelConfig(c)
 
-	model := coremodel.ReadOnlyModel{
+	model := coremodel.ModelInfo{
 		UUID:           modeltesting.GenModelUUID(c),
 		ControllerUUID: uuid.MustNewUUID(),
 		Cloud:          "aws",
@@ -475,7 +475,7 @@ func (s *WorkerSuite) TestRequest(c *gc.C) {
 	s.expectWatcher(c)
 	s.expectModelConfig(c)
 
-	model := coremodel.ReadOnlyModel{
+	model := coremodel.ModelInfo{
 		UUID:           modeltesting.GenModelUUID(c),
 		ControllerUUID: uuid.MustNewUUID(),
 		Cloud:          "aws",
@@ -556,7 +556,7 @@ func (s *WorkerSuite) TestRequestWithResources(c *gc.C) {
 	s.expectWatcher(c)
 	s.expectModelConfig(c)
 
-	model := coremodel.ReadOnlyModel{
+	model := coremodel.ModelInfo{
 		UUID:           modeltesting.GenModelUUID(c),
 		ControllerUUID: uuid.MustNewUUID(),
 		Cloud:          "aws",
@@ -657,7 +657,7 @@ func (s *WorkerSuite) TestRequestWithError(c *gc.C) {
 	s.expectWatcher(c)
 	s.expectModelConfig(c)
 
-	model := coremodel.ReadOnlyModel{
+	model := coremodel.ModelInfo{
 		UUID:           modeltesting.GenModelUUID(c),
 		ControllerUUID: uuid.MustNewUUID(),
 		Cloud:          "aws",
@@ -1047,7 +1047,7 @@ func (s *WorkerSuite) expectModelConfig(c *gc.C) {
 }
 
 func (s *WorkerSuite) expectSendEmptyModelMetrics(c *gc.C) {
-	model := coremodel.ReadOnlyModel{
+	model := coremodel.ModelInfo{
 		UUID:           modeltesting.GenModelUUID(c),
 		ControllerUUID: uuid.MustNewUUID(),
 		Cloud:          "aws",

--- a/internal/worker/modelworkermanager/providerservice.go
+++ b/internal/worker/modelworkermanager/providerservice.go
@@ -15,8 +15,8 @@ import (
 
 // ProviderModelService represents the model service provided by the provider.
 type ProviderModelService interface {
-	// Model returns the read-only default model.
-	Model(ctx context.Context) (coremodel.ReadOnlyModel, error)
+	// Model returns information for the current model
+	Model(ctx context.Context) (coremodel.ModelInfo, error)
 }
 
 // ProviderCloudService represents the cloud service provided by the provider.
@@ -31,7 +31,7 @@ type ProviderCloudService interface {
 type ProviderConfigService interface {
 	// ModelConfig returns the model configuration for the given tag.
 	ModelConfig(ctx context.Context) (*config.Config, error)
-	// WatchModelConfig returns a watcher that observes changes to the specified
+	// Watch returns a watcher that observes changes to the specified
 	// model configuration.
 	Watch() (watcher.StringsWatcher, error)
 }

--- a/internal/worker/providertracker/providerservice.go
+++ b/internal/worker/providertracker/providerservice.go
@@ -34,8 +34,8 @@ type DomainServices interface {
 
 // ModelService represents the model service provided by the provider.
 type ModelService interface {
-	// Model returns the read-only default model.
-	Model(ctx context.Context) (model.ReadOnlyModel, error)
+	// Model returns information for the current model.
+	Model(ctx context.Context) (model.ModelInfo, error)
 }
 
 // CloudService represents the cloud service provided by the provider.

--- a/internal/worker/providertracker/providertracker_mock_test.go
+++ b/internal/worker/providertracker/providertracker_mock_test.go
@@ -281,10 +281,10 @@ func (m *MockModelService) EXPECT() *MockModelServiceMockRecorder {
 }
 
 // Model mocks base method.
-func (m *MockModelService) Model(arg0 context.Context) (model.ReadOnlyModel, error) {
+func (m *MockModelService) Model(arg0 context.Context) (model.ModelInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Model", arg0)
-	ret0, _ := ret[0].(model.ReadOnlyModel)
+	ret0, _ := ret[0].(model.ModelInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -302,19 +302,19 @@ type MockModelServiceModelCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockModelServiceModelCall) Return(arg0 model.ReadOnlyModel, arg1 error) *MockModelServiceModelCall {
+func (c *MockModelServiceModelCall) Return(arg0 model.ModelInfo, arg1 error) *MockModelServiceModelCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockModelServiceModelCall) Do(f func(context.Context) (model.ReadOnlyModel, error)) *MockModelServiceModelCall {
+func (c *MockModelServiceModelCall) Do(f func(context.Context) (model.ModelInfo, error)) *MockModelServiceModelCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockModelServiceModelCall) DoAndReturn(f func(context.Context) (model.ReadOnlyModel, error)) *MockModelServiceModelCall {
+func (c *MockModelServiceModelCall) DoAndReturn(f func(context.Context) (model.ModelInfo, error)) *MockModelServiceModelCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/providertracker/trackerworker.go
+++ b/internal/worker/providertracker/trackerworker.go
@@ -64,7 +64,7 @@ type trackerWorker struct {
 	internalStates chan string
 
 	config           TrackerConfig
-	model            coremodel.ReadOnlyModel
+	model            coremodel.ModelInfo
 	provider         Provider
 	currentCloudSpec environscloudspec.CloudSpec
 
@@ -326,7 +326,7 @@ func (t *trackerWorker) addStringsWatcher(ctx context.Context, watcher eventsour
 }
 
 type providerGetter struct {
-	model             coremodel.ReadOnlyModel
+	model             coremodel.ModelInfo
 	cloudService      CloudService
 	configService     ConfigService
 	credentialService CredentialService
@@ -357,7 +357,7 @@ func (g providerGetter) CloudSpec(ctx context.Context) (environscloudspec.CloudS
 	return environscloudspec.MakeCloudSpec(*modelCloud, g.model.CloudRegion, modelCredentials)
 }
 
-func modelCredentials(ctx context.Context, credentialService CredentialService, model coremodel.ReadOnlyModel) (*cloud.Credential, error) {
+func modelCredentials(ctx context.Context, credentialService CredentialService, model coremodel.ModelInfo) (*cloud.Credential, error) {
 	if model.CredentialName == "" {
 		return nil, nil
 	}

--- a/internal/worker/providertracker/trackerworker_test.go
+++ b/internal/worker/providertracker/trackerworker_test.go
@@ -201,7 +201,7 @@ func (s *trackerWorkerSuite) getConfig(c *gc.C, environ environs.Environ) Tracke
 func (s *trackerWorkerSuite) expectModel(c *gc.C) coremodel.UUID {
 	id := modeltesting.GenModelUUID(c)
 
-	s.modelService.EXPECT().Model(gomock.Any()).Return(coremodel.ReadOnlyModel{
+	s.modelService.EXPECT().Model(gomock.Any()).Return(coremodel.ModelInfo{
 		UUID:            id,
 		Name:            "model",
 		Type:            coremodel.IAAS,


### PR DESCRIPTION
There should never have been a type named `ReadOnlyModel`.
1. It ties what is a container type for data to an implementation detail.
2. The name is violated in the event that the data is not read only, which it isn't - neither agent version nor credential name are constrained in this way.

This particular change is part of the work to move agent version from the controller database to the model-specific database.

The typed is renamed to `ModelInfo`, which is congruent with its method on the service of the same name.