### PR TITLE
chore: update project contribution information

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,1 @@
 blank_issues_enabled: true
-contact_links:
-  - name: Documentation issue
-    url: https://github.com/juju/docs/issues/new
-    about: Please report documentation issues on juju/docs repository

--- a/.github/ISSUE_TEMPLATE/doc-issue.yml
+++ b/.github/ISSUE_TEMPLATE/doc-issue.yml
@@ -1,0 +1,40 @@
+name: Documentation issue
+description: Highlight a documentation issue
+labels:
+  - kind/doc
+  - needs-triage
+body:
+  - type: textarea
+    id: Inquiry
+    attributes:
+      label: Inquiry
+      description: "Describe what you were looking for in the documentation: "
+      placeholder: ex. "How to bootstrap onto AWS."
+    validations:
+      required: true
+
+  - type: textarea
+    id: Improvement
+    attributes:
+      label: Improvement
+      description: "Describe what improvement you would like to see: "
+      placeholder: ex. "That there is a document the describes bootstraping AWS and links to recommended configuration for production use."
+    validations:
+      required: false
+
+  - type: input
+    id: File
+    attributes:
+      label: Documentation File
+      description: "Hint which documentation file needs improvement: "
+      placeholder: ex. docs/howto/manage-juju.md
+    validations:
+      required: false
+
+  - type: textarea
+    id: Info-Notes
+    attributes:
+      label: "Notes & References"
+      description: "Please add relevant notes, other related issues/PRs, anything else to help improve the documentation."
+    validations:
+      required: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,8 +2,8 @@ Thanks for your interest in Juju! Contributions like yours make good projects
 great.
 
 # TL;DR
-- Bug reports should be filed on [Launchpad](https://bugs.launchpad.net/juju/+bugs),
-  not GitHub. Please check that your bug has not already been reported.
+- Bug reports should be filed on Github [juju/juju](https://github.com/juju/juju/issues).
+  Please check that your bug has not already been reported.
 - When opening a pull request:
   - Check that all your [commits are signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
   - Use [Conventional Commits](#conventional-commits) for commit messages.
@@ -29,7 +29,7 @@ Contents
 Quick links
 ===========
 
-Issue tracker: https://bugs.launchpad.net/juju/+bugs
+Issue tracker: https://github.com/juju/juju/issues
 
 Documentation:
 * https://juju.is/docs
@@ -357,7 +357,7 @@ The title of the PR should match the form of the title of a conventional commit.
 This can be the title of the most significant commit in the PR.
 
 Make sure to add a clear description of why and what has been changed, and
-include the Launchpad bug number if one exists.
+include the Github issue number or Launchpad bug number if one exists.
 
 It is often helpful to mention newly created proposals on the Discourse forum,
 especially if you would like a specific developer to be aware of the proposal.
@@ -384,27 +384,10 @@ passes, please follow these steps:
 
 1. Ensure your Git commits are signed by an email that you can access
    (you can't use the `@users.noreply.github.com` email that GitHub provides).
-2. Create an account on [Launchpad](https://launchpad.net/), if you don't
-   already have one.
-3. Ensure the email you used for Git commits is a **verified** email on your
-   Launchpad account. To do this:
-   - Go to your Launchpad homepage (`launchpad.net/~[username]`).
-   - Check the addresses listed under the **Email** heading. If your Git email
-     is listed, you're good.
-   - If not, click "Change email settings".
-   - Add your Git email as a new address.
-   - Follow the instructions to verify your email.
-4. Visit the [CLA website](https://ubuntu.com/legal/contributors), scroll down
+2. Visit the [CLA website](https://ubuntu.com/legal/contributors), scroll down
    and press "Sign the contributor agreement".
-5. Read the agreement and fill in your contact details. Ensure that you provide
-   your Launchpad username in the "Launchpad id" box.
-6. Press "I agree" to sign the CLA.
-
-Eventually, your Launchpad account should be added to the
-["Canonical Contributor Agreement" team](https://launchpad.net/~contributor-agreement-canonical).
-You will see it listed under "Memberships" on your Launchpad homepage.
-Once this happens, the CLA check will pass, and we will happily review
-your contribution.
+3. Read the agreement and fill in your contact details. 
+4. Press "I agree" to sign the CLA.
 
 
 Sanity checking PRs and unit tests
@@ -474,7 +457,7 @@ Community
 =========
 
 The Juju community is growing and you have a number of options for interacting
-beyond the workflow and the [issue tracker](https://bugs.launchpad.net/juju/+bugs).
+beyond the [juju/juju](https://github.com/juju/juju) Github repository.
 
 Use the following links to contact the community:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,36 @@
+# Security policy
+
+## Supported versions
+
+Security updates will be released for versions that [receive security updates](https://juju.is/docs/juju/roadmap).
+
+## Reporting a vulnerability
+
+Please provide a description of the issue, the steps you took to
+create the issue, affected versions, and, if known, mitigations for
+the issue.
+
+The easiest way to report a security issue is through
+[GitHub's security advisory for this project](https://github.com/juju/juju/security/advisories/new). See
+[Privately reporting a security
+vulnerability](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability)
+for instructions on reporting using GitHub's security advisory feature.
+
+The Juju GitHub admins will be notified of the issue and will work with you
+to determine whether the issue qualifies as a security issue and, if so, in
+which component. We will then figure out a fix, get a CVE
+assigned, and coordinate the release of the fix.
+
+You may also send email to security@ubuntu.com. Email may optionally be
+encrypted to OpenPGP key
+[`4072 60F7 616E CE4D 9D12 4627 98E9 740D C345 39E0`](https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x407260f7616ece4d9d12462798e9740dc34539e0)
+
+If you have a deadline for public disclosure, please let us know.
+Our vulnerability management team intends to respond within 3 working
+days of your report. This project aims to resolve all vulnerabilities
+within 90 days.
+
+The [Ubuntu Security disclosure and embargo
+policy](https://ubuntu.com/security/disclosure-policy) contains more
+information about what you can expect when you contact us, and what we
+expect from you.


### PR DESCRIPTION
- Updates CONTRIBUTING.md to refer to Github not Launchpad for filing bugs.
- Adds a SECURITY.md for security guidelines following the SEC0026 spec.
- Adds a documentation issue template and remove link to juju/docs