### PR TITLE
refactor: rename ReadOnlyModelCreationArgs

### DIFF
--- a/domain/agentprovisioner/state/state_test.go
+++ b/domain/agentprovisioner/state/state_test.go
@@ -107,7 +107,7 @@ func (s *suite) TestModelID(c *gc.C) {
 	// Create model info.
 	modelID := modeltesting.GenModelUUID(c)
 	modelSt := modelstate.NewModelState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
-	err := modelSt.Create(context.Background(), model.ReadOnlyModelCreationArgs{
+	err := modelSt.Create(context.Background(), model.ModelDetailArgs{
 		UUID:           modelID,
 		AgentVersion:   version.Number{Major: 4, Minor: 21, Patch: 67},
 		ControllerUUID: uuid.MustNewUUID(),

--- a/domain/keyupdater/state/state_test.go
+++ b/domain/keyupdater/state/state_test.go
@@ -99,7 +99,7 @@ func (s *stateSuite) TestGetModelId(c *gc.C) {
 	mst := modelstate.NewModelState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
 	modelUUID := modeltesting.GenModelUUID(c)
-	args := model.ReadOnlyModelCreationArgs{
+	args := model.ModelDetailArgs{
 		UUID:            modelUUID,
 		AgentVersion:    jujuversion.Current,
 		ControllerUUID:  uuid.MustNewUUID(),

--- a/domain/model/bootstrap/bootstrap.go
+++ b/domain/model/bootstrap/bootstrap.go
@@ -136,7 +136,7 @@ func CreateReadOnlyModel(
 			return fmt.Errorf("getting model for id %q: %w", id, err)
 		}
 
-		args := model.ReadOnlyModelCreationArgs{
+		args := model.ModelDetailArgs{
 			UUID:              m.UUID,
 			AgentVersion:      m.AgentVersion,
 			ControllerUUID:    controllerUUID,

--- a/domain/model/service/modelservice.go
+++ b/domain/model/service/modelservice.go
@@ -21,7 +21,7 @@ import (
 // database state, not the controller state.
 type ModelState interface {
 	// Create creates a new model with all of its associated metadata.
-	Create(context.Context, model.ReadOnlyModelCreationArgs) error
+	Create(context.Context, model.ModelDetailArgs) error
 
 	// Delete deletes a model.
 	Delete(context.Context, coremodel.UUID) error
@@ -146,7 +146,7 @@ func (s *ModelService) CreateModel(
 		return err
 	}
 
-	args := model.ReadOnlyModelCreationArgs{
+	args := model.ModelDetailArgs{
 		UUID:            m.UUID,
 		AgentVersion:    m.AgentVersion,
 		ControllerUUID:  controllerUUID,

--- a/domain/model/service/modelservice_test.go
+++ b/domain/model/service/modelservice_test.go
@@ -233,11 +233,11 @@ var _ = gc.Suite(&legacyModelServiceSuite{})
 
 func (s *legacyModelServiceSuite) SetUpTest(c *gc.C) {
 	s.controllerState = &dummyControllerModelState{
-		models:     map[coremodel.UUID]model.ReadOnlyModelCreationArgs{},
+		models:     map[coremodel.UUID]model.ModelDetailArgs{},
 		modelState: map[coremodel.UUID]model.ModelState{},
 	}
 	s.modelState = &dummyModelState{
-		models: map[coremodel.UUID]model.ReadOnlyModelCreationArgs{},
+		models: map[coremodel.UUID]model.ModelDetailArgs{},
 	}
 
 	s.controllerUUID = uuid.MustNewUUID()
@@ -247,7 +247,7 @@ func (s *legacyModelServiceSuite) TestModelCreation(c *gc.C) {
 	id := modeltesting.GenModelUUID(c)
 	svc := NewModelService(id, s.controllerState, s.modelState, nil)
 
-	m := model.ReadOnlyModelCreationArgs{
+	m := model.ModelDetailArgs{
 		UUID:        id,
 		Name:        "my-awesome-model",
 		Cloud:       "aws",
@@ -279,7 +279,7 @@ func (s *legacyModelServiceSuite) TestGetModelMetrics(c *gc.C) {
 	id := modeltesting.GenModelUUID(c)
 	svc := NewModelService(id, s.controllerState, s.modelState, nil)
 
-	m := model.ReadOnlyModelCreationArgs{
+	m := model.ModelDetailArgs{
 		UUID:        id,
 		Name:        "my-awesome-model",
 		Cloud:       "aws",
@@ -312,7 +312,7 @@ func (s *legacyModelServiceSuite) TestModelDeletion(c *gc.C) {
 	id := modeltesting.GenModelUUID(c)
 	svc := NewModelService(id, s.controllerState, s.modelState, nil)
 
-	m := model.ReadOnlyModelCreationArgs{
+	m := model.ModelDetailArgs{
 		UUID:        id,
 		Name:        "my-awesome-model",
 		Cloud:       "aws",
@@ -426,7 +426,7 @@ func (s *legacyModelServiceSuite) TestStatusFailedModelNotFound(c *gc.C) {
 }
 
 type dummyControllerModelState struct {
-	models     map[coremodel.UUID]model.ReadOnlyModelCreationArgs
+	models     map[coremodel.UUID]model.ModelDetailArgs
 	modelState map[coremodel.UUID]model.ModelState
 }
 
@@ -462,7 +462,7 @@ func (d *dummyControllerModelState) GetModelState(_ context.Context, modelUUID c
 }
 
 type dummyModelState struct {
-	models map[coremodel.UUID]model.ReadOnlyModelCreationArgs
+	models map[coremodel.UUID]model.ModelDetailArgs
 	setID  coremodel.UUID
 }
 
@@ -474,7 +474,7 @@ func (d *dummyModelState) SetModelConstraints(_ context.Context, cons constraint
 	return nil
 }
 
-func (d *dummyModelState) Create(ctx context.Context, args model.ReadOnlyModelCreationArgs) error {
+func (d *dummyModelState) Create(ctx context.Context, args model.ModelDetailArgs) error {
 	if d.setID != coremodel.UUID("") {
 		return modelerrors.AlreadyExists
 	}

--- a/domain/model/service/package_mock_test.go
+++ b/domain/model/service/package_mock_test.go
@@ -205,7 +205,7 @@ func (m *MockModelState) EXPECT() *MockModelStateMockRecorder {
 }
 
 // Create mocks base method.
-func (m *MockModelState) Create(arg0 context.Context, arg1 model0.ReadOnlyModelCreationArgs) error {
+func (m *MockModelState) Create(arg0 context.Context, arg1 model0.ModelDetailArgs) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Create", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -231,13 +231,13 @@ func (c *MockModelStateCreateCall) Return(arg0 error) *MockModelStateCreateCall 
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockModelStateCreateCall) Do(f func(context.Context, model0.ReadOnlyModelCreationArgs) error) *MockModelStateCreateCall {
+func (c *MockModelStateCreateCall) Do(f func(context.Context, model0.ModelDetailArgs) error) *MockModelStateCreateCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockModelStateCreateCall) DoAndReturn(f func(context.Context, model0.ReadOnlyModelCreationArgs) error) *MockModelStateCreateCall {
+func (c *MockModelStateCreateCall) DoAndReturn(f func(context.Context, model0.ModelDetailArgs) error) *MockModelStateCreateCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/model/state/modelstate.go
+++ b/domain/model/state/modelstate.go
@@ -44,7 +44,7 @@ func NewModelState(
 }
 
 // Create creates a new read-only model.
-func (s *ModelState) Create(ctx context.Context, args model.ReadOnlyModelCreationArgs) error {
+func (s *ModelState) Create(ctx context.Context, args model.ModelDetailArgs) error {
 	db, err := s.DB()
 	if err != nil {
 		return errors.Capture(err)
@@ -274,7 +274,7 @@ func (s *ModelState) GetModelCloudType(ctx context.Context) (string, error) {
 // CreateReadOnlyModel is responsible for creating a new model within the model
 // database. If the model already exists then an error satisfying
 // [modelerrors.AlreadyExists] is returned.
-func CreateReadOnlyModel(ctx context.Context, args model.ReadOnlyModelCreationArgs, preparer domain.Preparer, tx *sqlair.TX) error {
+func CreateReadOnlyModel(ctx context.Context, args model.ModelDetailArgs, preparer domain.Preparer, tx *sqlair.TX) error {
 	// This is some defensive programming. The zero value of agent version is
 	// still valid but should really be considered null for the purposes of
 	// allowing the DDL to assert constraints.

--- a/domain/model/state/modelstate_test.go
+++ b/domain/model/state/modelstate_test.go
@@ -38,7 +38,7 @@ func (s *modelSuite) TestCreateAndReadModel(c *gc.C) {
 	state := NewModelState(runner, loggertesting.WrapCheckLog(c))
 
 	id := modeltesting.GenModelUUID(c)
-	args := model.ReadOnlyModelCreationArgs{
+	args := model.ModelDetailArgs{
 		UUID:            id,
 		AgentVersion:    jujuversion.Current,
 		ControllerUUID:  s.controllerUUID,
@@ -75,7 +75,7 @@ func (s *modelSuite) TestDeleteModel(c *gc.C) {
 	state := NewModelState(runner, loggertesting.WrapCheckLog(c))
 
 	id := modeltesting.GenModelUUID(c)
-	args := model.ReadOnlyModelCreationArgs{
+	args := model.ModelDetailArgs{
 		UUID:            id,
 		AgentVersion:    jujuversion.Current,
 		ControllerUUID:  s.controllerUUID,
@@ -108,7 +108,7 @@ func (s *modelSuite) TestCreateModelMultipleTimesWithSameUUID(c *gc.C) {
 	// Ensure that we can't create the same model twice.
 
 	id := modeltesting.GenModelUUID(c)
-	args := model.ReadOnlyModelCreationArgs{
+	args := model.ModelDetailArgs{
 		UUID:           id,
 		AgentVersion:   jujuversion.Current,
 		ControllerUUID: s.controllerUUID,
@@ -130,7 +130,7 @@ func (s *modelSuite) TestCreateModelMultipleTimesWithDifferentUUID(c *gc.C) {
 
 	// Ensure that you can only ever insert one model.
 
-	err := state.Create(context.Background(), model.ReadOnlyModelCreationArgs{
+	err := state.Create(context.Background(), model.ModelDetailArgs{
 		UUID:         modeltesting.GenModelUUID(c),
 		AgentVersion: jujuversion.Current,
 		Name:         "my-awesome-model",
@@ -141,7 +141,7 @@ func (s *modelSuite) TestCreateModelMultipleTimesWithDifferentUUID(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = state.Create(context.Background(), model.ReadOnlyModelCreationArgs{
+	err = state.Create(context.Background(), model.ModelDetailArgs{
 		UUID:         modeltesting.GenModelUUID(c),
 		AgentVersion: jujuversion.Current,
 		Name:         "my-awesome-model",
@@ -160,7 +160,7 @@ func (s *modelSuite) TestCreateModelAndUpdate(c *gc.C) {
 	// Ensure that you can't update it.
 
 	id := modeltesting.GenModelUUID(c)
-	err := state.Create(context.Background(), model.ReadOnlyModelCreationArgs{
+	err := state.Create(context.Background(), model.ModelDetailArgs{
 		UUID:           id,
 		AgentVersion:   jujuversion.Current,
 		ControllerUUID: s.controllerUUID,
@@ -184,7 +184,7 @@ func (s *modelSuite) TestCreateModelAndDelete(c *gc.C) {
 	// Ensure that you can't update it.
 
 	id := modeltesting.GenModelUUID(c)
-	err := state.Create(context.Background(), model.ReadOnlyModelCreationArgs{
+	err := state.Create(context.Background(), model.ModelDetailArgs{
 		UUID:         id,
 		AgentVersion: jujuversion.Current,
 		Name:         "my-awesome-model",
@@ -213,7 +213,7 @@ func (s *modelSuite) TestGetModelMetrics(c *gc.C) {
 	state := NewModelState(runner, loggertesting.WrapCheckLog(c))
 
 	id := modeltesting.GenModelUUID(c)
-	args := model.ReadOnlyModelCreationArgs{
+	args := model.ModelDetailArgs{
 		UUID:            id,
 		AgentVersion:    jujuversion.Current,
 		ControllerUUID:  s.controllerUUID,
@@ -274,7 +274,7 @@ func (s *modelSuite) TestGetModelCloudType(c *gc.C) {
 
 	id := modeltesting.GenModelUUID(c)
 	cloudType := "ec2"
-	args := model.ReadOnlyModelCreationArgs{
+	args := model.ModelDetailArgs{
 		UUID:            id,
 		AgentVersion:    jujuversion.Current,
 		ControllerUUID:  s.controllerUUID,

--- a/domain/model/types.go
+++ b/domain/model/types.go
@@ -96,10 +96,10 @@ func (m ModelImportArgs) Validate() error {
 	return nil
 }
 
-// ReadOnlyModelCreationArgs is a struct that is used to create a model
+// ModelDetailArgs is a struct that is used to create a model
 // within the model database. This struct is used to create a model with all of
 // its associated metadata.
-type ReadOnlyModelCreationArgs struct {
+type ModelDetailArgs struct {
 	// UUID represents the unique id for the model when being created. This
 	// value is optional and if omitted will be generated for the caller. Use
 	// this value when you are trying to import a model during model migration.

--- a/domain/modelmigration/state/state_test.go
+++ b/domain/modelmigration/state/state_test.go
@@ -38,7 +38,7 @@ func (s *migrationSuite) SetUpTest(c *gc.C) {
 	state := modelstate.NewModelState(runner, loggertesting.WrapCheckLog(c))
 
 	id := modeltesting.GenModelUUID(c)
-	args := model.ReadOnlyModelCreationArgs{
+	args := model.ModelDetailArgs{
 		UUID:            id,
 		AgentVersion:    jujuversion.Current,
 		ControllerUUID:  s.controllerUUID,


### PR DESCRIPTION
The container type `ReadOnlyModelCreationArgs` was poorly named in that it reflects a detail from the underlying data store and easily becomes misnamed should that detail change.

This is the case due to requiring an `AgentVersion` member, which is not a read-only aspect.

Accordingly is is renamed `ModelDetailArgs`.