### PR TITLE
fix: backport azure image lookup fix

### DIFF
--- a/provider/azure/environ.go
+++ b/provider/azure/environ.go
@@ -486,6 +486,7 @@ func (env *azureEnviron) StartInstance(ctx context.ProviderCallContext, args env
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	preferGen1Image := false
 	for i := 0; i < 15; i++ {
 		// Identify the instance type and image to provision.
 		instanceSpec, err := env.findInstanceSpec(
@@ -497,7 +498,7 @@ func (env *azureEnviron) StartInstance(ctx context.ProviderCallContext, args env
 				Arch:        arch,
 				Constraints: args.Constraints,
 			},
-			imageStream,
+			imageStream, preferGen1Image,
 		)
 		if err != nil {
 			return nil, err
@@ -515,10 +516,18 @@ func (env *azureEnviron) StartInstance(ctx context.ProviderCallContext, args env
 			deleteInstanceFamily(instanceTypes, instanceSpec.InstanceType.Name)
 			continue
 		}
+		hypervisorGenErr, ok := errorutils.MaybeHypervisorGenNotSupportedError(err)
+		if ok && !preferGen1Image {
+			logger.Warningf("hypervisor generation 2 not supported for %q error: %q", instanceSpec.InstanceType.Name, hypervisorGenErr.Error())
+			logger.Warningf("retrying with generation 1 image")
+			preferGen1Image = true
+			continue
+		}
 		return result, errorutils.SimpleError(err)
 	}
 	return nil, errors.New("no suitable instance type found for this subscription")
 }
+
 func (env *azureEnviron) startInstance(
 	ctx context.ProviderCallContext, args environs.StartInstanceParams,
 	instanceSpec *instances.InstanceSpec, envTags map[string]string,

--- a/provider/azure/environ_test.go
+++ b/provider/azure/environ_test.go
@@ -51,16 +51,17 @@ import (
 	"github.com/juju/juju/provider/azure"
 	"github.com/juju/juju/provider/azure/internal/armtemplates"
 	"github.com/juju/juju/provider/azure/internal/azuretesting"
+	"github.com/juju/juju/provider/azure/internal/errorutils"
 	jujustorage "github.com/juju/juju/storage"
 	"github.com/juju/juju/testing"
 	"github.com/juju/juju/tools"
 )
 
 var (
-	jammyImageReference = armcompute.ImageReference{
+	jammyImageReferenceGen2 = armcompute.ImageReference{
 		Publisher: to.Ptr("Canonical"),
 		Offer:     to.Ptr("0001-com-ubuntu-server-jammy"),
-		SKU:       to.Ptr("22_04-LTS"),
+		SKU:       to.Ptr("22_04-lts-gen2"),
 		Version:   to.Ptr("latest"),
 	}
 	centos7ImageReference = armcompute.ImageReference{
@@ -195,15 +196,16 @@ func (s *environSuite) SetUpTest(c *gc.C) {
 	s.skus = resourceSKUs
 
 	s.ubuntuServerSKUs = []armcompute.VirtualMachineImageResource{
-		{Name: to.Ptr("12.04-LTS")},
+		{Name: to.Ptr("12.04-lts")},
 		{Name: to.Ptr("12.10")},
-		{Name: to.Ptr("14.04-LTS")},
+		{Name: to.Ptr("14.04-lts")},
 		{Name: to.Ptr("15.04")},
 		{Name: to.Ptr("15.10")},
-		{Name: to.Ptr("16.04-LTS")},
-		{Name: to.Ptr("18.04-LTS")},
-		{Name: to.Ptr("20_04-LTS")},
-		{Name: to.Ptr("22_04-LTS")},
+		{Name: to.Ptr("16.04-lts")},
+		{Name: to.Ptr("18.04-lts")},
+		{Name: to.Ptr("20_04-lts")},
+		{Name: to.Ptr("22_04-lts")},
+		{Name: to.Ptr("22_04-lts-gen2")},
 	}
 
 	s.commonDeployment = &armresources.DeploymentExtended{
@@ -265,7 +267,6 @@ func openEnviron(
 	*sender = azuretesting.Senders{
 		discoverAuthSender(),
 		makeResourceGroupNotFoundSender(fmt.Sprintf(".*/resourcegroups/juju-%s-model-deadbeef-.*", cfg.Name())),
-		makeSender(fmt.Sprintf(".*/resourcegroups/juju-%s-.*", cfg.Name()), makeResourceGroupResult()),
 	}
 	env, err := environs.Open(stdcontext.TODO(), provider, environs.OpenParams{
 		Cloud:  fakeCloudSpec(),
@@ -347,13 +348,14 @@ type startInstanceSenderParams struct {
 	vaultKeyName            string
 	existingNetwork         string
 	withQuotaRetry          bool
+	withHypervisorGenRetry  bool
 	withConflictRetry       bool
 	existingAvailabilitySet bool
 	existingCommon          bool
 	hasSpaceConstraints     bool
 }
 
-func (s *environSuite) startInstanceSenders(args startInstanceSenderParams) azuretesting.Senders {
+func (s *environSuite) startInstanceSenders(c *gc.C, args startInstanceSenderParams) azuretesting.Senders {
 	senders := azuretesting.Senders{}
 	if args.existingAvailabilitySet {
 		senders = append(senders, makeSender("/availabilitySets/mysql", &armcompute.AvailabilitySet{}))
@@ -422,12 +424,27 @@ func (s *environSuite) startInstanceSenders(args startInstanceSenderParams) azur
 		}))
 	}
 	if args.withQuotaRetry {
-		quotaErr := newAzureResponseError(http.StatusBadRequest, "QuotaExceeded")
+		quotaErr := newAzureResponseError(c, http.StatusBadRequest, "QuotaExceeded", "")
 		senders = append(senders, s.makeErrorSender("/deployments/juju-06f00d-0", quotaErr, 1))
 		return senders
 	}
+	if args.withHypervisorGenRetry {
+		requestError := errorutils.RequestError{
+			ServiceError: &errorutils.ServiceError{
+				Code:    "BadRequest",
+				Message: "The selected VM size 'Standard_D2_v2' cannot boot Hypervisor Generation '2'. If this was a Create operation please check that the Hypervisor Generation of the Image matches the Hypervisor Generation of the selected VM Size. If this was an Update operation please select a Hypervisor Generation '2' VM Size. For more information, see https://aka.ms/azuregen2vm",
+			},
+		}
+		rErr, err := json.Marshal(requestError)
+		c.Assert(err, jc.ErrorIsNil)
+		hypervisorGenErr := newAzureResponseError(c, http.StatusBadRequest,
+			"DeploymentFailed", string(rErr),
+		)
+		senders = append(senders, s.makeErrorSender("/deployments/juju-06f00d-0", hypervisorGenErr, 1))
+		return senders
+	}
 	if args.withConflictRetry {
-		conflictErr := newAzureResponseError(http.StatusConflict, "Conflict")
+		conflictErr := newAzureResponseError(c, http.StatusConflict, "Conflict", "")
 		senders = append(senders, s.makeErrorSender("/deployments/juju-06f00d-0", conflictErr, 1))
 		return senders
 	}
@@ -478,10 +495,19 @@ func makeSenderWithStatus(pattern string, statusCode int) *azuretesting.MockSend
 	return &sender
 }
 
-func newAzureResponseError(code int, status string) error {
+func newAzureResponseError(c *gc.C, code int, status, message string) error {
 	header := make(http.Header)
 	header.Set("Content-Type", "application/json")
-	body := fmt.Sprintf(`{"error": {"code": "DeployError", "details": [{"code": "%s", "message": "boom"}]}}`, status)
+	requestError := errorutils.RequestError{
+		ServiceError: &errorutils.ServiceError{
+			Code: "DeployError",
+			Details: []errorutils.ServiceErrorDetail{
+				{Code: status, Message: message},
+			},
+		},
+	}
+	body, err := json.Marshal(requestError)
+	c.Assert(err, jc.ErrorIsNil)
 	return &azcore.ResponseError{
 		ErrorCode:  status,
 		StatusCode: code,
@@ -491,7 +517,7 @@ func newAzureResponseError(code int, status string) error {
 			},
 			Header:     header,
 			StatusCode: code,
-			Body:       io.NopCloser(bytes.NewBufferString(body)),
+			Body:       io.NopCloser(bytes.NewBuffer(body)),
 		},
 	}
 }
@@ -575,34 +601,38 @@ func (s *environSuite) TestOpen(c *gc.C) {
 }
 
 func (s *environSuite) TestStartInstance(c *gc.C) {
-	s.assertStartInstance(c, nil, nil, true, false, false)
+	s.assertStartInstance(c, nil, nil, true, false, false, false)
 }
 
 func (s *environSuite) TestStartInstancePrivateIP(c *gc.C) {
-	s.assertStartInstance(c, nil, nil, false, false, false)
+	s.assertStartInstance(c, nil, nil, false, false, false, false)
 }
 
 func (s *environSuite) TestStartInstanceRootDiskSmallerThanMin(c *gc.C) {
 	wantedRootDisk := 22
-	s.assertStartInstance(c, &wantedRootDisk, nil, true, false, false)
+	s.assertStartInstance(c, &wantedRootDisk, nil, true, false, false, false)
 }
 
 func (s *environSuite) TestStartInstanceRootDiskLargerThanMin(c *gc.C) {
 	wantedRootDisk := 40
-	s.assertStartInstance(c, &wantedRootDisk, nil, true, false, false)
+	s.assertStartInstance(c, &wantedRootDisk, nil, true, false, false, false)
 }
 
 func (s *environSuite) TestStartInstanceQuotaRetry(c *gc.C) {
-	s.assertStartInstance(c, nil, nil, false, true, false)
+	s.assertStartInstance(c, nil, nil, false, true, false, false)
+}
+
+func (s *environSuite) TestStartInstanceHypervisorGenRetry(c *gc.C) {
+	s.assertStartInstance(c, nil, nil, false, false, true, false)
 }
 
 func (s *environSuite) TestStartInstanceConflictRetry(c *gc.C) {
-	s.assertStartInstance(c, nil, nil, false, false, true)
+	s.assertStartInstance(c, nil, nil, false, false, false, true)
 }
 
 func (s *environSuite) assertStartInstance(
 	c *gc.C, wantedRootDisk *int, rootDiskSourceParams map[string]interface{},
-	publicIP, withQuotaRetry, withConflictRetry bool,
+	publicIP, withQuotaRetry, withHypervisorGenRetry, withConflictRetry bool,
 ) {
 	env := s.openEnviron(c)
 
@@ -625,18 +655,19 @@ func (s *environSuite) assertStartInstance(
 			vaultKeyName, _ = rootDiskSourceParams["vault-key-name"].(string)
 		}
 	}
-	s.sender = s.startInstanceSenders(startInstanceSenderParams{
-		bootstrap:             false,
-		diskEncryptionSetName: diskEncryptionSetName,
-		vaultName:             vaultName,
-		vaultKeyName:          vaultKeyName,
-		withQuotaRetry:        withQuotaRetry,
-		withConflictRetry:     withConflictRetry,
+	s.sender = s.startInstanceSenders(c, startInstanceSenderParams{
+		bootstrap:              false,
+		diskEncryptionSetName:  diskEncryptionSetName,
+		vaultName:              vaultName,
+		vaultKeyName:           vaultKeyName,
+		withQuotaRetry:         withQuotaRetry,
+		withHypervisorGenRetry: withHypervisorGenRetry,
+		withConflictRetry:      withConflictRetry,
 	})
 	if withConflictRetry {
 		// Retry after a conflict - the same instance creation senders are
 		// used except that the availability set now exists.
-		s.sender = append(s.sender, s.startInstanceSenders(startInstanceSenderParams{
+		s.sender = append(s.sender, s.startInstanceSenders(c, startInstanceSenderParams{
 			bootstrap:               false,
 			diskEncryptionSetName:   diskEncryptionSetName,
 			vaultName:               vaultName,
@@ -645,11 +676,24 @@ func (s *environSuite) assertStartInstance(
 			existingAvailabilitySet: true,
 		})...)
 	}
+	if withHypervisorGenRetry {
+		// Retry after a hypervisor generation error - the same instance creation senders are
+		// used except that the VM size is changed.
+		// s.sender = append(s.sender, makeSender(".*/deployments/juju-06f00d-0/cancel", http.StatusNoContent))
+		s.sender = append(s.sender, s.startInstanceSenders(c, startInstanceSenderParams{
+			bootstrap:             false,
+			diskEncryptionSetName: diskEncryptionSetName,
+			vaultName:             vaultName,
+			vaultKeyName:          vaultKeyName,
+			existingCommon:        true,
+		})...)
+
+	}
 	if withQuotaRetry {
 		// Retry after a quota error - the same instance creation senders are
 		// used except that the availability set now exists.
 		s.sender = append(s.sender, makeSenderWithStatus(".*/deployments/juju-06f00d-0/cancel", http.StatusNoContent))
-		s.sender = append(s.sender, s.startInstanceSenders(startInstanceSenderParams{
+		s.sender = append(s.sender, s.startInstanceSenders(c, startInstanceSenderParams{
 			bootstrap:             false,
 			diskEncryptionSetName: diskEncryptionSetName,
 			vaultName:             vaultName,
@@ -692,15 +736,16 @@ func (s *environSuite) assertStartInstance(
 		CpuCores: &cpuCores,
 	})
 	startParams := assertStartInstanceRequestsParams{
-		imageReference:    &jammyImageReference,
-		diskSizeGB:        expectedDiskSize,
-		osProfile:         &s.linuxOsProfile,
-		instanceType:      "Standard_A1",
-		publicIP:          publicIP,
-		diskEncryptionSet: diskEncryptionSetName,
-		vaultName:         vaultName,
-		withQuotaRetry:    withQuotaRetry,
-		withConflictRetry: withConflictRetry,
+		imageReference:         &jammyImageReferenceGen2,
+		diskSizeGB:             expectedDiskSize,
+		osProfile:              &s.linuxOsProfile,
+		instanceType:           "Standard_A1",
+		publicIP:               publicIP,
+		diskEncryptionSet:      diskEncryptionSetName,
+		vaultName:              vaultName,
+		withQuotaRetry:         withQuotaRetry,
+		withHypervisorGenRetry: withHypervisorGenRetry,
+		withConflictRetry:      withConflictRetry,
 	}
 	if withConflictRetry {
 		startParams.availabilitySetName = "mysql"
@@ -715,7 +760,7 @@ func (s *environSuite) TestStartInstanceNoAuthorizedKeys(c *gc.C) {
 	err = env.SetConfig(cfg)
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.sender = s.startInstanceSenders(startInstanceSenderParams{bootstrap: false})
+	s.sender = s.startInstanceSenders(c, startInstanceSenderParams{bootstrap: false})
 	s.requests = nil
 	_, err = env.StartInstance(s.callCtx, makeStartInstanceParams(c, s.controllerUUID, corebase.MakeDefaultBase("ubuntu", "22.04")))
 	c.Assert(err, jc.ErrorIsNil)
@@ -725,7 +770,7 @@ func (s *environSuite) TestStartInstanceNoAuthorizedKeys(c *gc.C) {
 		KeyData: to.Ptr("public"),
 	}}
 	s.assertStartInstanceRequests(c, s.requests, assertStartInstanceRequestsParams{
-		imageReference: &jammyImageReference,
+		imageReference: &jammyImageReferenceGen2,
 		diskSizeGB:     32,
 		osProfile:      &s.linuxOsProfile,
 		instanceType:   "Standard_A1",
@@ -760,7 +805,7 @@ func (s *environSuite) TestStartInstanceCentOS(c *gc.C) {
 	s.PatchValue(&s.ubuntuServerSKUs, nil)
 
 	env := s.openEnviron(c)
-	s.sender = s.startInstanceSenders(startInstanceSenderParams{bootstrap: false})
+	s.sender = s.startInstanceSenders(c, startInstanceSenderParams{bootstrap: false})
 	s.requests = nil
 	args := makeStartInstanceParams(c, s.controllerUUID, corebase.MakeDefaultBase("centos", "7"))
 	_, err := env.StartInstance(s.callCtx, args)
@@ -793,7 +838,7 @@ func (s *environSuite) TestStartInstanceCommonDeployment(c *gc.C) {
 	s.commonDeployment.Properties.ProvisioningState = to.Ptr(armresources.ProvisioningStateFailed)
 
 	env := s.openEnviron(c)
-	senders := s.startInstanceSenders(startInstanceSenderParams{bootstrap: false})
+	senders := s.startInstanceSenders(c, startInstanceSenderParams{bootstrap: false})
 	s.sender = senders
 	s.requests = nil
 
@@ -810,7 +855,7 @@ func (s *environSuite) TestStartInstanceCommonDeploymentRetryTimeout(c *gc.C) {
 	s.commonDeployment.Properties.ProvisioningState = to.Ptr(armresources.ProvisioningStateCreating)
 
 	env := s.openEnviron(c)
-	senders := s.startInstanceSenders(startInstanceSenderParams{bootstrap: false})
+	senders := s.startInstanceSenders(c, startInstanceSenderParams{bootstrap: false})
 
 	const failures = 60 // 5 minutes / 5 seconds
 	head, tail := senders[:2], senders[2:]
@@ -839,7 +884,7 @@ func (s *environSuite) TestStartInstanceCommonDeploymentRetryTimeout(c *gc.C) {
 func (s *environSuite) TestStartInstanceServiceAvailabilitySet(c *gc.C) {
 	env := s.openEnviron(c)
 	s.vmTags[tags.JujuUnitsDeployed] = "mysql/0 wordpress/0"
-	s.sender = s.startInstanceSenders(startInstanceSenderParams{bootstrap: false})
+	s.sender = s.startInstanceSenders(c, startInstanceSenderParams{bootstrap: false})
 	s.requests = nil
 	params := makeStartInstanceParams(c, s.controllerUUID, corebase.MakeDefaultBase("ubuntu", "22.04"))
 	params.InstanceConfig.Tags[tags.JujuUnitsDeployed] = "mysql/0 wordpress/0"
@@ -848,7 +893,7 @@ func (s *environSuite) TestStartInstanceServiceAvailabilitySet(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertStartInstanceRequests(c, s.requests, assertStartInstanceRequestsParams{
 		availabilitySetName: "mysql",
-		imageReference:      &jammyImageReference,
+		imageReference:      &jammyImageReferenceGen2,
 		diskSizeGB:          32,
 		osProfile:           &s.linuxOsProfile,
 		instanceType:        "Standard_A1",
@@ -858,7 +903,7 @@ func (s *environSuite) TestStartInstanceServiceAvailabilitySet(c *gc.C) {
 
 func (s *environSuite) TestStartInstanceWithSpaceConstraints(c *gc.C) {
 	env := s.openEnviron(c)
-	s.sender = s.startInstanceSenders(startInstanceSenderParams{bootstrap: false, hasSpaceConstraints: true})
+	s.sender = s.startInstanceSenders(c, startInstanceSenderParams{bootstrap: false, hasSpaceConstraints: true})
 	s.requests = nil
 	params := makeStartInstanceParams(c, s.controllerUUID, corebase.MakeDefaultBase("ubuntu", "22.04"))
 	params.Constraints.Spaces = &[]string{"foo", "bar"}
@@ -870,7 +915,7 @@ func (s *environSuite) TestStartInstanceWithSpaceConstraints(c *gc.C) {
 	_, err := env.StartInstance(s.callCtx, params)
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertStartInstanceRequests(c, s.requests, assertStartInstanceRequestsParams{
-		imageReference:      &jammyImageReference,
+		imageReference:      &jammyImageReferenceGen2,
 		diskSizeGB:          32,
 		osProfile:           &s.linuxOsProfile,
 		instanceType:        "Standard_A1",
@@ -882,7 +927,7 @@ func (s *environSuite) TestStartInstanceWithSpaceConstraints(c *gc.C) {
 
 func (s *environSuite) TestStartInstanceWithInvalidPlacement(c *gc.C) {
 	env := s.openEnviron(c)
-	s.sender = s.startInstanceSenders(startInstanceSenderParams{bootstrap: false})
+	s.sender = s.startInstanceSenders(c, startInstanceSenderParams{bootstrap: false})
 	s.requests = nil
 	params := makeStartInstanceParams(c, s.controllerUUID, corebase.MakeDefaultBase("ubuntu", "22.04"))
 	params.Placement = "foo"
@@ -893,7 +938,7 @@ func (s *environSuite) TestStartInstanceWithInvalidPlacement(c *gc.C) {
 
 func (s *environSuite) TestStartInstanceWithInvalidSubnet(c *gc.C) {
 	env := s.openEnviron(c)
-	s.sender = s.startInstanceSenders(startInstanceSenderParams{bootstrap: false})
+	s.sender = s.startInstanceSenders(c, startInstanceSenderParams{bootstrap: false})
 	s.requests = nil
 	params := makeStartInstanceParams(c, s.controllerUUID, corebase.MakeDefaultBase("ubuntu", "22.04"))
 	params.Placement = "subnet=foo"
@@ -917,7 +962,7 @@ func (s *environSuite) TestStartInstanceWithPlacementNoSpacesConstraint(c *gc.C)
 			AddressPrefix: to.Ptr("192.168.1.0/20"),
 		},
 	}}
-	s.sender = s.startInstanceSenders(startInstanceSenderParams{
+	s.sender = s.startInstanceSenders(c, startInstanceSenderParams{
 		bootstrap: false,
 		subnets:   subnets,
 	})
@@ -928,7 +973,7 @@ func (s *environSuite) TestStartInstanceWithPlacementNoSpacesConstraint(c *gc.C)
 	_, err := env.StartInstance(s.callCtx, params)
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertStartInstanceRequests(c, s.requests, assertStartInstanceRequestsParams{
-		imageReference:  &jammyImageReference,
+		imageReference:  &jammyImageReferenceGen2,
 		diskSizeGB:      32,
 		osProfile:       &s.linuxOsProfile,
 		instanceType:    "Standard_A1",
@@ -953,7 +998,7 @@ func (s *environSuite) TestStartInstanceWithPlacement(c *gc.C) {
 			AddressPrefix: to.Ptr("192.168.1.0/20"),
 		},
 	}}
-	s.sender = s.startInstanceSenders(startInstanceSenderParams{
+	s.sender = s.startInstanceSenders(c, startInstanceSenderParams{
 		bootstrap: false,
 		subnets:   subnets,
 	})
@@ -969,7 +1014,7 @@ func (s *environSuite) TestStartInstanceWithPlacement(c *gc.C) {
 	_, err := env.StartInstance(s.callCtx, params)
 	c.Assert(err, jc.ErrorIsNil)
 	s.assertStartInstanceRequests(c, s.requests, assertStartInstanceRequestsParams{
-		imageReference:  &jammyImageReference,
+		imageReference:  &jammyImageReferenceGen2,
 		diskSizeGB:      32,
 		osProfile:       &s.linuxOsProfile,
 		instanceType:    "Standard_A1",
@@ -988,24 +1033,26 @@ const (
 )
 
 type assertStartInstanceRequestsParams struct {
-	autocert            bool
-	availabilitySetName string
-	imageReference      *armcompute.ImageReference
-	vmExtension         *armcompute.VirtualMachineExtensionProperties
-	diskSizeGB          int
-	diskEncryptionSet   string
-	vaultName           string
-	osProfile           *armcompute.OSProfile
-	needsProviderInit   bool
-	resourceGroupName   string
-	instanceType        string
-	publicIP            bool
-	existingNetwork     string
-	subnets             []string
-	placementSubnet     string
-	withQuotaRetry      bool
-	withConflictRetry   bool
-	hasSpaceConstraints bool
+	autocert               bool
+	availabilitySetName    string
+	imageReference         *armcompute.ImageReference
+	vmExtension            *armcompute.VirtualMachineExtensionProperties
+	diskSizeGB             int
+	diskEncryptionSet      string
+	vaultName              string
+	osProfile              *armcompute.OSProfile
+	needsProviderInit      bool
+	resourceGroupName      string
+	instanceType           string
+	publicIP               bool
+	existingNetwork        string
+	subnets                []string
+	placementSubnet        string
+	withQuotaRetry         bool
+	withHypervisorGenRetry bool
+	withConflictRetry      bool
+	hasSpaceConstraints    bool
+	managedIdentity        string
 }
 
 func (s *environSuite) assertStartInstanceRequests(
@@ -1279,7 +1326,7 @@ func (s *environSuite) assertStartInstanceRequests(
 		})
 	}
 	templateResources = append(templateResources, nicResources...)
-	templateResources = append(templateResources, []armtemplates.Resource{{
+	vmTemplate := armtemplates.Resource{
 		APIVersion: azure.ComputeAPIVersion,
 		Type:       "Microsoft.Compute/virtualMachines",
 		Name:       "juju-06f00d-0",
@@ -1300,7 +1347,18 @@ func (s *environSuite) assertStartInstanceRequests(
 			AvailabilitySet: availabilitySetSubResource,
 		},
 		DependsOn: vmDependsOn,
-	}}...)
+	}
+	if args.managedIdentity != "" {
+		vmTemplate.Identity = &armcompute.VirtualMachineIdentity{
+			Type: to.Ptr(armcompute.ResourceIdentityTypeUserAssigned),
+			UserAssignedIdentities: map[string]*armcompute.UserAssignedIdentitiesValue{
+				fmt.Sprintf(
+					"/subscriptions/%s/resourcegroups/%s/providers/Microsoft.ManagedIdentity/userAssignedIdentities/%s",
+					fakeManagedSubscriptionId, resourceGroupName, args.managedIdentity): nil,
+			},
+		}
+	}
+	templateResources = append(templateResources, vmTemplate)
 	if args.vmExtension != nil {
 		templateResources = append(templateResources, armtemplates.Resource{
 			APIVersion: azure.ComputeAPIVersion,
@@ -1313,7 +1371,7 @@ func (s *environSuite) assertStartInstanceRequests(
 		})
 	}
 	templateMap := map[string]interface{}{
-		"$schema":        "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+		"$schema":        "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
 		"contentVersion": "1.0.0.0",
 		"resources":      templateResources,
 	}
@@ -1354,6 +1412,8 @@ func (s *environSuite) assertStartInstanceRequests(
 				c.Assert(requests, gc.HasLen, numExpectedStartInstanceRequests+3)
 			} else if args.withQuotaRetry {
 				c.Assert(requests, gc.HasLen, numExpectedStartInstanceRequests+5)
+			} else if args.withHypervisorGenRetry {
+				c.Assert(requests, gc.HasLen, numExpectedStartInstanceRequests+4)
 			} else {
 				c.Assert(requests, gc.HasLen, numExpectedStartInstanceRequests)
 			}
@@ -1423,6 +1483,18 @@ func (s *environSuite) assertStartInstanceRequests(
 	vmResourceProperties := vmResource["properties"].(map[string]interface{})
 	osProfile := vmResourceProperties["osProfile"].(map[string]interface{})
 	osProfile["customData"] = "<juju-goes-here>"
+
+	// Fix the round tripping of the vm identities.
+	resources, ok = expected.Properties.Template.(map[string]interface{})["resources"].([]interface{})
+	c.Assert(ok, jc.IsTrue)
+	identity, _ := resources[vmResourceIndex].(map[string]interface{})["identity"]
+	if identity != nil {
+		userAssignedIdentities, _ := identity.(map[string]interface{})["userAssignedIdentities"].(map[string]interface{})
+		for k := range userAssignedIdentities {
+			userAssignedIdentities[k] = map[string]interface{}{}
+		}
+	}
+
 	c.Assert(actual, jc.DeepEquals, expected)
 
 	return startInstanceRequests
@@ -1444,15 +1516,15 @@ func (s *environSuite) TestBootstrap(c *gc.C) {
 	env := prepareForBootstrap(c, ctx, s.provider, &s.sender)
 
 	s.sender = s.initResourceGroupSenders(resourceGroupName)
-	s.sender = append(s.sender, s.startInstanceSenders(startInstanceSenderParams{bootstrap: true})...)
+	s.sender = append(s.sender, s.startInstanceSenders(c, startInstanceSenderParams{bootstrap: true})...)
 	s.requests = nil
 	result, err := env.Bootstrap(
 		ctx, s.callCtx, environs.BootstrapParams{
-			ControllerConfig:         testing.FakeControllerConfig(),
-			AvailableTools:           makeToolsList("ubuntu"),
-			BootstrapSeries:          "jammy",
-			BootstrapConstraints:     constraints.MustParse("mem=3.5G"),
-			SupportedBootstrapSeries: testing.FakeSupportedJujuSeries,
+			ControllerConfig:        testing.FakeControllerConfig(),
+			AvailableTools:          makeToolsList("ubuntu"),
+			BootstrapBase:           corebase.MustParseBaseFromString("ubuntu@22.04"),
+			BootstrapConstraints:    constraints.MustParse("mem=3.5G"),
+			SupportedBootstrapBases: testing.FakeSupportedJujuBases,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1463,7 +1535,7 @@ func (s *environSuite) TestBootstrap(c *gc.C) {
 	s.vmTags[tags.JujuIsController] = "true"
 	s.assertStartInstanceRequests(c, s.requests[1:], assertStartInstanceRequestsParams{
 		availabilitySetName: "juju-controller",
-		imageReference:      &jammyImageReference,
+		imageReference:      &jammyImageReferenceGen2,
 		diskSizeGB:          32,
 		osProfile:           &s.linuxOsProfile,
 		instanceType:        "Standard_D1",
@@ -1478,15 +1550,15 @@ func (s *environSuite) TestBootstrapPrivateIP(c *gc.C) {
 	env := prepareForBootstrap(c, ctx, s.provider, &s.sender)
 
 	s.sender = s.initResourceGroupSenders(resourceGroupName)
-	s.sender = append(s.sender, s.startInstanceSenders(startInstanceSenderParams{bootstrap: true})...)
+	s.sender = append(s.sender, s.startInstanceSenders(c, startInstanceSenderParams{bootstrap: true})...)
 	s.requests = nil
 	result, err := env.Bootstrap(
 		ctx, s.callCtx, environs.BootstrapParams{
-			ControllerConfig:         testing.FakeControllerConfig(),
-			AvailableTools:           makeToolsList("ubuntu"),
-			BootstrapSeries:          "jammy",
-			BootstrapConstraints:     constraints.MustParse("mem=3.5G allocate-public-ip=false"),
-			SupportedBootstrapSeries: testing.FakeSupportedJujuSeries,
+			ControllerConfig:        testing.FakeControllerConfig(),
+			AvailableTools:          makeToolsList("ubuntu"),
+			BootstrapBase:           corebase.MustParseBaseFromString("ubuntu@22.04"),
+			BootstrapConstraints:    constraints.MustParse("mem=3.5G allocate-public-ip=false"),
+			SupportedBootstrapBases: testing.FakeSupportedJujuBases,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1497,7 +1569,7 @@ func (s *environSuite) TestBootstrapPrivateIP(c *gc.C) {
 	s.vmTags[tags.JujuIsController] = "true"
 	s.assertStartInstanceRequests(c, s.requests[1:], assertStartInstanceRequestsParams{
 		availabilitySetName: "juju-controller",
-		imageReference:      &jammyImageReference,
+		imageReference:      &jammyImageReferenceGen2,
 		diskSizeGB:          32,
 		osProfile:           &s.linuxOsProfile,
 		instanceType:        "Standard_D1",
@@ -1511,16 +1583,15 @@ func (s *environSuite) TestBootstrapCustomNetwork(c *gc.C) {
 	env := prepareForBootstrap(c, ctx, s.provider, &s.sender, testing.Attrs{"network": "mynetwork"})
 
 	s.sender = s.initResourceGroupSenders(resourceGroupName)
-	s.sender = append(s.sender, s.startInstanceSenders(
-		startInstanceSenderParams{bootstrap: true, existingNetwork: "mynetwork"})...)
+	s.sender = append(s.sender, s.startInstanceSenders(c, startInstanceSenderParams{bootstrap: true, existingNetwork: "mynetwork"})...)
 	s.requests = nil
 	result, err := env.Bootstrap(
 		ctx, s.callCtx, environs.BootstrapParams{
-			ControllerConfig:         testing.FakeControllerConfig(),
-			AvailableTools:           makeToolsList("ubuntu"),
-			BootstrapSeries:          "jammy",
-			BootstrapConstraints:     constraints.MustParse("mem=3.5G"),
-			SupportedBootstrapSeries: testing.FakeSupportedJujuSeries,
+			ControllerConfig:        testing.FakeControllerConfig(),
+			AvailableTools:          makeToolsList("ubuntu"),
+			BootstrapBase:           corebase.MustParseBaseFromString("ubuntu@22.04"),
+			BootstrapConstraints:    constraints.MustParse("mem=3.5G"),
+			SupportedBootstrapBases: testing.FakeSupportedJujuBases,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1532,12 +1603,47 @@ func (s *environSuite) TestBootstrapCustomNetwork(c *gc.C) {
 	s.vmTags[tags.JujuIsController] = "true"
 	s.assertStartInstanceRequests(c, s.requests[1:], assertStartInstanceRequestsParams{
 		availabilitySetName: "juju-controller",
-		imageReference:      &jammyImageReference,
+		imageReference:      &jammyImageReferenceGen2,
 		diskSizeGB:          32,
 		osProfile:           &s.linuxOsProfile,
 		instanceType:        "Standard_D1",
 		publicIP:            true,
 		existingNetwork:     "mynetwork",
+	})
+}
+
+func (s *environSuite) TestBootstrapUserSpecifiedManagedIdentity(c *gc.C) {
+	defer envtesting.DisableFinishBootstrap()()
+
+	ctx := envtesting.BootstrapTODOContext(c)
+	env := prepareForBootstrap(c, ctx, s.provider, &s.sender)
+
+	s.sender = s.initResourceGroupSenders(resourceGroupName)
+	s.sender = append(s.sender, s.startInstanceSenders(c, startInstanceSenderParams{bootstrap: true})...)
+	s.requests = nil
+	result, err := env.Bootstrap(
+		ctx, s.callCtx, environs.BootstrapParams{
+			ControllerConfig:        testing.FakeControllerConfig(),
+			AvailableTools:          makeToolsList("ubuntu"),
+			BootstrapBase:           corebase.MustParseBaseFromString("ubuntu@22.04"),
+			BootstrapConstraints:    constraints.MustParse("mem=3.5G instance-role=myidentity"),
+			SupportedBootstrapBases: testing.FakeSupportedJujuBases,
+		},
+	)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(result.Arch, gc.Equals, "amd64")
+	c.Assert(result.Base.DisplayString(), gc.Equals, "ubuntu@22.04")
+
+	c.Assert(len(s.requests), gc.Equals, numExpectedBootstrapStartInstanceRequests)
+	s.vmTags[tags.JujuIsController] = "true"
+	s.assertStartInstanceRequests(c, s.requests[1:], assertStartInstanceRequestsParams{
+		availabilitySetName: "juju-controller",
+		imageReference:      &jammyImageReferenceGen2,
+		diskSizeGB:          32,
+		osProfile:           &s.linuxOsProfile,
+		instanceType:        "Standard_D1",
+		publicIP:            true,
+		managedIdentity:     "myidentity",
 	})
 }
 
@@ -1548,17 +1654,17 @@ func (s *environSuite) TestBootstrapWithInvalidCredential(c *gc.C) {
 	env := prepareForBootstrap(c, ctx, s.provider, &s.sender)
 
 	s.createSenderWithUnauthorisedStatusCode(c)
-	s.sender = append(s.sender, s.startInstanceSenders(startInstanceSenderParams{bootstrap: true})...)
+	s.sender = append(s.sender, s.startInstanceSenders(c, startInstanceSenderParams{bootstrap: true})...)
 	s.requests = nil
 
 	c.Assert(s.invalidatedCredential, jc.IsFalse)
 	_, err := env.Bootstrap(
 		ctx, s.callCtx, environs.BootstrapParams{
-			ControllerConfig:         testing.FakeControllerConfig(),
-			AvailableTools:           makeToolsList("ubuntu"),
-			BootstrapSeries:          "jammy",
-			BootstrapConstraints:     constraints.MustParse("mem=3.5G"),
-			SupportedBootstrapSeries: testing.FakeSupportedJujuSeries,
+			ControllerConfig:        testing.FakeControllerConfig(),
+			AvailableTools:          makeToolsList("ubuntu"),
+			BootstrapBase:           corebase.MustParseBaseFromString("ubuntu@22.04"),
+			BootstrapConstraints:    constraints.MustParse("mem=3.5G"),
+			SupportedBootstrapBases: testing.FakeSupportedJujuBases,
 		},
 	)
 	c.Assert(err, gc.NotNil)
@@ -1610,7 +1716,7 @@ func (s *environSuite) TestBootstrapInstanceConstraints(c *gc.C) {
 	s.vmTags[tags.JujuIsController] = "true"
 	s.assertStartInstanceRequests(c, s.requests[1:], assertStartInstanceRequestsParams{
 		availabilitySetName: "juju-controller",
-		imageReference:      &jammyImageReference,
+		imageReference:      &jammyImageReferenceGen2,
 		diskSizeGB:          32,
 		osProfile:           &s.linuxOsProfile,
 		needsProviderInit:   true,
@@ -1661,7 +1767,7 @@ func (s *environSuite) TestBootstrapCustomResourceGroup(c *gc.C) {
 	s.vmTags[tags.JujuIsController] = "true"
 	s.assertStartInstanceRequests(c, s.requests[1:], assertStartInstanceRequestsParams{
 		availabilitySetName: "juju-controller",
-		imageReference:      &jammyImageReference,
+		imageReference:      &jammyImageReferenceGen2,
 		diskSizeGB:          32,
 		osProfile:           &s.linuxOsProfile,
 		needsProviderInit:   true,
@@ -1678,18 +1784,18 @@ func (s *environSuite) TestBootstrapWithAutocert(c *gc.C) {
 	env := prepareForBootstrap(c, ctx, s.provider, &s.sender)
 
 	s.sender = s.initResourceGroupSenders(resourceGroupName)
-	s.sender = append(s.sender, s.startInstanceSenders(startInstanceSenderParams{bootstrap: true})...)
+	s.sender = append(s.sender, s.startInstanceSenders(c, startInstanceSenderParams{bootstrap: true})...)
 	s.requests = nil
 	config := testing.FakeControllerConfig()
 	config["api-port"] = 443
 	config["autocert-dns-name"] = "example.com"
 	result, err := env.Bootstrap(
 		ctx, s.callCtx, environs.BootstrapParams{
-			ControllerConfig:         config,
-			AvailableTools:           makeToolsList("ubuntu"),
-			BootstrapSeries:          "jammy",
-			BootstrapConstraints:     constraints.MustParse("mem=3.5G"),
-			SupportedBootstrapSeries: testing.FakeSupportedJujuSeries,
+			ControllerConfig:        config,
+			AvailableTools:          makeToolsList("ubuntu"),
+			BootstrapBase:           corebase.MustParseBaseFromString("ubuntu@22.04"),
+			BootstrapConstraints:    constraints.MustParse("mem=3.5G"),
+			SupportedBootstrapBases: testing.FakeSupportedJujuBases,
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1701,7 +1807,7 @@ func (s *environSuite) TestBootstrapWithAutocert(c *gc.C) {
 	s.assertStartInstanceRequests(c, s.requests[1:], assertStartInstanceRequestsParams{
 		autocert:            true,
 		availabilitySetName: "juju-controller",
-		imageReference:      &jammyImageReference,
+		imageReference:      &jammyImageReferenceGen2,
 		diskSizeGB:          32,
 		osProfile:           &s.linuxOsProfile,
 		instanceType:        "Standard_D1",
@@ -1882,11 +1988,11 @@ func (s *environSuite) TestConstraintsValidatorVocabulary(c *gc.C) {
 	validator := s.constraintsValidator(c)
 	_, err := validator.Validate(constraints.MustParse("arch=s390x"))
 	c.Assert(err, gc.ErrorMatches,
-		"invalid constraint value: arch=s390x\nvalid values are: amd64",
+		"invalid constraint value: arch=s390x\nvalid values are: \\[amd64\\]",
 	)
 	_, err = validator.Validate(constraints.MustParse("instance-type=t1.micro"))
 	c.Assert(err, gc.ErrorMatches,
-		"invalid constraint value: instance-type=t1.micro\nvalid values are: A1 D1 D2 Standard_A1 Standard_D1 Standard_D2",
+		"invalid constraint value: instance-type=t1.micro\nvalid values are: \\[A1 D1 D2 Standard_A1 Standard_D1 Standard_D2\\]",
 	)
 }
 
@@ -1962,14 +2068,14 @@ func (s *environSuite) TestDestroyHostedModelCustomResourceGroup(c *gc.C) {
 		makeSenderWithStatus(".*/deployments/juju-06f00d-0/cancel", http.StatusNoContent), // POST
 		s.networkInterfacesSender(nic0),
 		s.publicIPAddressesSender(makePublicIPAddress("pip-0", "juju-06f00d-0", "1.2.3.4")),
-		makeSender(".*/virtualMachines/juju-06f00d-0", nil),                                                       // DELETE
-		makeSender(".*/disks/juju-06f00d-0", nil),                                                                 // DELETE
-		makeSender(".*/networkInterfaces/nic-0", nil),                                                             // DELETE
-		makeSender(".*/publicIPAddresses/pip-0", nil),                                                             // DELETE
-		makeSenderWithStatus(".*/deployments/juju-06f00d-0", http.StatusNoContent),                                // DELETE
-		s.makeErrorSender("/networkSecurityGroups/nsg-0", newAzureResponseError(http.StatusConflict, "InUse"), 1), // DELETE
-		makeSender("/networkSecurityGroups/nsg-0", nil),                                                           // DELETE
-		makeSender(".*/vaults/secret-0", nil),                                                                     // DELETE
+		makeSender(".*/virtualMachines/juju-06f00d-0", nil),                                                              // DELETE
+		makeSender(".*/disks/juju-06f00d-0", nil),                                                                        // DELETE
+		makeSender(".*/networkInterfaces/nic-0", nil),                                                                    // DELETE
+		makeSender(".*/publicIPAddresses/pip-0", nil),                                                                    // DELETE
+		makeSenderWithStatus(".*/deployments/juju-06f00d-0", http.StatusNoContent),                                       // DELETE
+		s.makeErrorSender("/networkSecurityGroups/nsg-0", newAzureResponseError(c, http.StatusConflict, "InUse", ""), 1), // DELETE
+		makeSender("/networkSecurityGroups/nsg-0", nil),                                                                  // DELETE
+		makeSender(".*/vaults/secret-0", nil),                                                                            // DELETE
 	}
 	err := env.Destroy(s.callCtx)
 	c.Assert(err, jc.ErrorIsNil)
@@ -2007,14 +2113,17 @@ func (s *environSuite) TestDestroyController(c *gc.C) {
 
 	env := s.openEnviron(c)
 	s.sender = azuretesting.Senders{
-		makeSender(".*/resourcegroups", result),        // GET
-		makeSender(".*/resourcegroups/group[12]", nil), // DELETE
-		makeSender(".*/resourcegroups/group[12]", nil), // DELETE
+		makeSender(".*/resourcegroups", result),                        // GET
+		makeSender(".*/resourcegroups/group[12]", nil),                 // DELETE
+		makeSender(".*/resourcegroups/group[12]", nil),                 // DELETE
+		makeSender(".*/roleDefinitions*", nil),                         // GET
+		makeSender(".*/roleAssignments*", nil),                         // GET
+		makeSender(".*/userAssignedIdentities/juju-controller-*", nil), // DELETE
 	}
 	err := env.DestroyController(s.callCtx, s.controllerUUID)
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Assert(s.requests, gc.HasLen, 3)
+	c.Assert(s.requests, gc.HasLen, 6)
 	c.Assert(s.requests[0].Method, gc.Equals, "GET")
 	c.Assert(s.requests[0].URL.Query().Get("$filter"), gc.Equals, fmt.Sprintf(
 		"tagName eq 'juju-controller-uuid' and tagValue eq '%s'",
@@ -2029,6 +2138,11 @@ func (s *environSuite) TestDestroyController(c *gc.C) {
 		path.Base(s.requests[2].URL.Path),
 	}
 	c.Assert(groupsDeleted, jc.SameContents, []string{"group1", "group2"})
+
+	c.Assert(s.requests[3].Method, gc.Equals, "GET")
+	c.Assert(s.requests[4].Method, gc.Equals, "GET")
+	c.Assert(s.requests[5].Method, gc.Equals, "DELETE")
+	c.Assert(path.Base(s.requests[5].URL.Path), gc.Equals, "juju-controller-"+testing.ControllerTag.Id())
 }
 
 func (s *environSuite) TestDestroyControllerWithInvalidCredential(c *gc.C) {
@@ -2090,7 +2204,7 @@ func (s *environSuite) TestDestroyControllerErrors(c *gc.C) {
 
 func (s *environSuite) TestInstanceInformation(c *gc.C) {
 	env := s.openEnviron(c)
-	s.sender = s.startInstanceSenders(startInstanceSenderParams{bootstrap: false})
+	s.sender = s.startInstanceSenders(c, startInstanceSenderParams{bootstrap: false})
 	types, err := env.InstanceTypes(s.callCtx, constraints.Value{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(types.InstanceTypes, gc.HasLen, 4)
@@ -2426,7 +2540,7 @@ func (s *environSuite) TestStartInstanceEncryptedRootDiskExistingDES(c *gc.C) {
 		"encrypted":                "true",
 		"disk-encryption-set-name": "my-disk-encryption-set",
 	}
-	s.assertStartInstance(c, nil, rootDiskParams, true, false, false)
+	s.assertStartInstance(c, nil, rootDiskParams, true, false, false, false)
 }
 
 func (s *environSuite) TestStartInstanceEncryptedRootDisk(c *gc.C) {
@@ -2436,5 +2550,5 @@ func (s *environSuite) TestStartInstanceEncryptedRootDisk(c *gc.C) {
 		"vault-name-prefix":        "my-vault",
 		"vault-key-name":           "shhhh",
 	}
-	s.assertStartInstance(c, nil, rootDiskParams, true, false, false)
+	s.assertStartInstance(c, nil, rootDiskParams, true, false, false, false)
 }

--- a/provider/azure/instancetype.go
+++ b/provider/azure/instancetype.go
@@ -525,7 +525,11 @@ func (env *azureEnviron) findInstanceSpec(
 	instanceTypesMap map[string]instances.InstanceType,
 	constraint *instances.InstanceConstraint,
 	imageStream string,
+	preferGen1Image bool,
 ) (*instances.InstanceSpec, error) {
+	if !constraint.Constraints.HasArch() && constraint.Arch != "" {
+		constraint.Constraints.Arch = &constraint.Arch
+	}
 
 	if constraint.Arch != arch.AMD64 {
 		// Azure only supports AMD64.
@@ -536,7 +540,7 @@ func (env *azureEnviron) findInstanceSpec(
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	image, err := imageutils.BaseImage(ctx, constraint.Base, imageStream, constraint.Region, client)
+	image, err := imageutils.BaseImage(ctx, constraint.Base, imageStream, constraint.Region, client, preferGen1Image)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/provider/azure/internal/errorutils/errors.go
+++ b/provider/azure/internal/errorutils/errors.go
@@ -6,6 +6,7 @@ package errorutils
 import (
 	"fmt"
 	"net/http"
+	"regexp"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
@@ -18,17 +19,20 @@ import (
 
 var logger = loggo.GetLogger("juju.provider.azure")
 
-type requestError struct {
-	ServiceError *serviceError `json:"error"`
+// RequestError represents an error response from Azure.
+type RequestError struct {
+	ServiceError *ServiceError `json:"error"`
 }
 
-type serviceError struct {
-	Code    string                `json:"code"`
-	Message string                `json:"message"`
-	Details []serviceErrorDetails `json:"details"`
+// ServiceError represents an error response from Azure.
+type ServiceError struct {
+	Code    string               `json:"code"`
+	Message string               `json:"message"`
+	Details []ServiceErrorDetail `json:"details"`
 }
 
-type serviceErrorDetails struct {
+// ServiceErrorDetail represents an error detail from Azure.
+type ServiceErrorDetail struct {
 	Code    string `json:"code"`
 	Message string `json:"message"`
 }
@@ -43,7 +47,7 @@ func MaybeQuotaExceededError(err error) (error, bool) {
 	if respErr.StatusCode != http.StatusBadRequest {
 		return respErr, false
 	}
-	var reqErr requestError
+	var reqErr RequestError
 	if err = runtime.UnmarshalAsJSON(respErr.RawResponse, &reqErr); err != nil {
 		return respErr, false
 	}
@@ -61,11 +65,58 @@ func MaybeQuotaExceededError(err error) (error, bool) {
 	return respErr, false
 }
 
+var hypervisorGenNotSupportedErrorRegex = regexp.MustCompile(`The selected VM size '.*?' cannot boot Hypervisor Generation '2'.*`)
+
+// MaybeHypervisorGenNotSupportedError returns the relevant error message and true
+// if the error is caused by a Hypervisor Generation not supported for the selected VM size.
+// Azure does not give a specific error code for this issue, so we have to check the error message.
+// Example error message:
+//
+//	&errorutils.serviceError{
+//	    Code:    "DeploymentFailed",
+//	    Message: "At least one resource deployment operation failed. Please list deployment operations for details. Please see https://aka.ms/arm-deployment-operations for usage details.",
+//	    Details: {
+//	        {Code:"BadRequest", Message:"{
+//	          "error": {
+//	            "code": "BadRequest",
+//	            "message": "The selected VM size 'Standard_D2_v2' cannot boot Hypervisor Generation '2'. If this was a Create operation please check that the Hypervisor Generation of the Image matches the Hypervisor Generation of the selected VM Size. If this was an Update operation please select a Hypervisor Generation '2' VM Size. For more information, see https://aka.ms/azuregen2vm"
+//	          }
+//	        }"},
+//	    },
+//	}
+func MaybeHypervisorGenNotSupportedError(err error) (error, bool) {
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) {
+		return err, false
+	}
+	if respErr.ErrorCode != "DeploymentFailed" {
+		return respErr, false
+	}
+
+	var reqErr RequestError
+	if err = runtime.UnmarshalAsJSON(respErr.RawResponse, &reqErr); err != nil {
+		return respErr, false
+	}
+	if reqErr.ServiceError == nil {
+		return respErr, false
+	}
+
+	if hypervisorGenNotSupportedErrorRegex.MatchString(reqErr.ServiceError.Message) {
+		return errors.New(reqErr.ServiceError.Message), true
+	}
+	for _, d := range reqErr.ServiceError.Details {
+		if hypervisorGenNotSupportedErrorRegex.MatchString(d.Message) {
+			return errors.New(d.Message), true
+		}
+	}
+	return respErr, false
+}
+
 func hasErrorCode(resp *http.Response, code string) bool {
 	if resp == nil {
 		return false
 	}
-	var reqErr requestError
+	var reqErr RequestError
 	if err := runtime.UnmarshalAsJSON(resp, &reqErr); err != nil {
 		return false
 	}
@@ -143,7 +194,7 @@ func SimpleError(err error) error {
 	if !errors.As(err, &respErr) {
 		return err
 	}
-	var reqErr requestError
+	var reqErr RequestError
 	if err := runtime.UnmarshalAsJSON(respErr.RawResponse, &reqErr); err != nil {
 		return respErr
 	}

--- a/provider/azure/internal/errorutils/errors_test.go
+++ b/provider/azure/internal/errorutils/errors_test.go
@@ -112,6 +112,20 @@ func (*ErrorSuite) TestMaybeQuotaExceededError(c *gc.C) {
 	c.Assert(quotaErr, gc.ErrorMatches, "boom")
 }
 
+func (*ErrorSuite) TestMaybeHypervisorGenNotSupportedError(c *gc.C) {
+	buf := strings.NewReader(`
+{"error":{"code":"DeployError","message":"","details":[{"code":"DeploymentFailed","message":"{\"error\":{\"code\":\"BadRequest\",\"message\":\"The selected VM size 'Standard_D2_v2' cannot boot Hypervisor Generation '2'. If this was a Create operation please check that the Hypervisor Generation of the Image matches the Hypervisor Generation of the selected VM Size. If this was an Update operation please select a Hypervisor Generation '2' VM Size. For more information, see https://aka.ms/azuregen2vm\",\"details\":null}}"}]}}`[1:])
+	re := &azcore.ResponseError{
+		StatusCode: http.StatusBadRequest,
+		ErrorCode:  "DeploymentFailed",
+		RawResponse: &http.Response{
+			Body: io.NopCloser(buf),
+		},
+	}
+	_, ok := errorutils.MaybeHypervisorGenNotSupportedError(re)
+	c.Assert(ok, jc.IsTrue)
+}
+
 func (*ErrorSuite) TestIsConflictError(c *gc.C) {
 	buf := strings.NewReader(
 		`{"error": {"code": "DeployError", "details": [{"code": "Conflict", "message": "boom"}]}}`)

--- a/provider/azure/internal/imageutils/images.go
+++ b/provider/azure/internal/imageutils/images.go
@@ -31,7 +31,10 @@ const (
 
 	dailyStream = "daily"
 
-	plan = "server-gen1"
+	planV2                = "server"
+	planV1                = "server-gen1"
+	legacyPlanGen2Suffix  = "-gen2"
+	legacyPlanArm64Suffix = "-arm64"
 )
 
 // BaseImage gets an instances.Image for the specified base, image stream
@@ -44,6 +47,7 @@ func BaseImage(
 	ctx context.ProviderCallContext,
 	base jujubase.Base, stream, location string,
 	client *armcompute.VirtualMachineImagesClient,
+	preferGen1Image bool,
 ) (*instances.Image, error) {
 	seriesOS := jujuos.OSTypeForName(base.OS)
 
@@ -52,7 +56,7 @@ func BaseImage(
 	case os.Ubuntu:
 		publisher = ubuntuPublisher
 		var err error
-		sku, offering, err = ubuntuSKU(ctx, base, stream, location, client)
+		sku, offering, err = ubuntuSKU(ctx, base, stream, location, client, preferGen1Image)
 		if err != nil {
 			return nil, errors.Annotatef(err, "selecting SKU for %s", base.DisplayString())
 		}
@@ -92,9 +96,9 @@ func BaseImage(
 //
 // The new format offer ids have format `ubuntu-${version_number}`,
 // `ubuntu-${version_number}-lts`, `ubuntu-${version_number}-lts-daily`,
-// etc. and have SKUs `server`, `server-gen1`m, `server-arm64`, etc.
+// etc. and have SKUs `server`, `server-gen1`, `server-arm64`, etc.
 //
-// Since there are only a finte number of Ubuntu versions we support
+// Since there are only a finite number of Ubuntu versions we support
 // before Noble, we hardcode this list. So when new versions of Ubuntu
 // are
 //
@@ -122,9 +126,12 @@ func ubuntuBaseIslegacy(base jujubase.Base) bool {
 
 // ubuntuSKU returns the best SKU for the Canonical:UbuntuServer offering,
 // matching the given series.
-func ubuntuSKU(ctx context.ProviderCallContext, base jujubase.Base, stream, location string, client *armcompute.VirtualMachineImagesClient) (string, string, error) {
+func ubuntuSKU(
+	ctx context.ProviderCallContext, base jujubase.Base, stream, location string,
+	client *armcompute.VirtualMachineImagesClient, preferGen1Image bool,
+) (string, string, error) {
 	if ubuntuBaseIslegacy(base) {
-		return legacyUbuntuSKU(ctx, base, stream, location, client)
+		return legacyUbuntuSKU(ctx, base, stream, location, client, preferGen1Image)
 	}
 
 	offer := fmt.Sprintf("ubuntu-%s", strings.ReplaceAll(base.Channel.Track, ".", "_"))
@@ -140,18 +147,30 @@ func ubuntuSKU(ctx context.ProviderCallContext, base jujubase.Base, stream, loca
 	if err != nil {
 		return "", "", errorutils.HandleCredentialError(errors.Annotate(err, "listing Ubuntu SKUs"), ctx)
 	}
+	// We prefer to use v2 SKU if available. But if not, we fall back to v1 SKU.
+	var v1SKU string
 	for _, img := range result.VirtualMachineImageResourceArray {
 		skuName := *img.Name
-		if skuName == plan {
+		if skuName == planV2 && !preferGen1Image {
 			logger.Debugf("found Azure SKU Name: %v", skuName)
 			return skuName, offer, nil
 		}
+		if skuName == planV1 {
+			v1SKU = skuName
+			continue
+		}
 		logger.Debugf("ignoring Azure SKU Name: %v", skuName)
+	}
+	if v1SKU != "" {
+		return v1SKU, offer, nil
 	}
 	return "", "", errors.NotFoundf("ubuntu %q SKUs for %v stream", base, stream)
 }
 
-func legacyUbuntuSKU(ctx context.ProviderCallContext, base jujubase.Base, stream, location string, client *armcompute.VirtualMachineImagesClient) (string, string, error) {
+func legacyUbuntuSKU(
+	ctx context.ProviderCallContext, base jujubase.Base, stream, location string,
+	client *armcompute.VirtualMachineImagesClient, preferGen1Image bool,
+) (string, string, error) {
 	series, err := jujubase.GetSeriesFromBase(base)
 	if err != nil {
 		return "", "", errors.Trace(err)
@@ -160,22 +179,38 @@ func legacyUbuntuSKU(ctx context.ProviderCallContext, base jujubase.Base, stream
 	if stream == dailyStream {
 		offer = fmt.Sprintf("%s-daily", offer)
 	}
-	desiredSKUPrefix := strings.ReplaceAll(base.Channel.Track, ".", "_")
 
-	logger.Debugf("listing SKUs: Location=%s, Publisher=%s, Offer=%s", location, ubuntuPublisher, offer)
+	logger.Debugf(
+		"listing SKUs: Base=%s, Series=%s, Location=%s, Stream=%s, Publisher=%s, Offer=%s",
+		base.Channel.Track, series, location, stream, ubuntuPublisher, offer,
+	)
 	result, err := client.ListSKUs(ctx, location, ubuntuPublisher, offer, nil)
 	if err != nil {
 		return "", "", errorutils.HandleCredentialError(errors.Annotate(err, "listing Ubuntu SKUs"), ctx)
 	}
-	for _, img := range result.VirtualMachineImageResourceArray {
-		skuName := *img.Name
-		logger.Debugf("found Azure SKU Name: %v", skuName)
-		if !strings.HasPrefix(skuName, desiredSKUPrefix) {
-			logger.Debugf("ignoring SKU %q (does not match series %q)", skuName, series)
-			continue
+
+	skuName, err := selectUbuntuSKULegacy(base, series, stream, result.VirtualMachineImageResourceArray, preferGen1Image)
+	if err != nil {
+		return "", "", errors.Trace(err)
+	}
+	return skuName, offer, nil
+}
+
+func selectUbuntuSKULegacy(
+	base jujubase.Base, series, stream string,
+	images []*armcompute.VirtualMachineImageResource, preferGen1Image bool,
+) (string, error) {
+	// We prefer to use v2 SKU if available. But if not, we fall back to v1 SKU.
+	var v1SKU string
+	desiredSKUVersionPrefix := strings.ReplaceAll(base.Channel.Track, ".", "_")
+
+	validStream := func(skuName string) bool {
+		if skuName == "" {
+			return false
 		}
+
 		tag := getLegacyUbuntuSKUTag(skuName)
-		logger.Debugf("SKU has tag %q", tag)
+		logger.Debugf("SKU %q has tag %q", skuName, tag)
 		var skuStream string
 		switch tag {
 		case "", "LTS":
@@ -185,19 +220,42 @@ func legacyUbuntuSKU(ctx context.ProviderCallContext, base jujubase.Base, stream
 		}
 		if skuStream == "" || skuStream != stream {
 			logger.Debugf("ignoring SKU %q (not in %q stream)", skuName, stream)
+			return false
+		}
+		return true
+	}
+
+	for _, img := range images {
+		skuName := *img.Name
+		logger.Debugf("Azure SKU Name: %v", skuName)
+		if strings.HasSuffix(skuName, legacyPlanArm64Suffix) {
+			// TODO: we don't support arm64 yet for azure.
 			continue
 		}
-		return skuName, offer, nil
-
+		if !strings.HasPrefix(skuName, desiredSKUVersionPrefix) {
+			logger.Debugf("ignoring SKU %q (does not match series %q)", skuName, series)
+			continue
+		}
+		if strings.HasSuffix(skuName, legacyPlanGen2Suffix) {
+			if preferGen1Image || !validStream(skuName) {
+				continue
+			}
+			return skuName, nil
+		}
+		v1SKU = skuName
 	}
-	return "", "", errors.NotFoundf("legacy ubuntu %q SKUs for %s stream", series, stream)
+	if validStream(v1SKU) {
+		return v1SKU, nil
+	}
+	return "", errors.NotFoundf("legacy ubuntu %q SKUs for %s stream", series, stream)
 }
 
-// getLegacyUbuntuSKUTag splits an UbuntuServer SKU and extracts
-// the tag ("LTS") part.
+// getLegacyUbuntuSKUTag splits an UbuntuServer SKU and extracts the tag ("LTS") part.
+// The SKU is expected to be in the format "${version_number}-${tag}[-${gen}]" or "${version_number}-${tag}-arm64".
+// For example, "22_04-lts", "22_04-lts-gen2", "22_04-lts-arm64".
 func getLegacyUbuntuSKUTag(sku string) string {
 	var tag string
-	parts := strings.SplitN(sku, "-", 2)
+	parts := strings.SplitN(sku, "-", -1)
 	if len(parts) > 1 {
 		tag = strings.ToUpper(parts[1])
 	}

--- a/provider/azure/internal/imageutils/images.go
+++ b/provider/azure/internal/imageutils/images.go
@@ -147,7 +147,9 @@ func ubuntuSKU(
 	if err != nil {
 		return "", "", errorutils.HandleCredentialError(errors.Annotate(err, "listing Ubuntu SKUs"), ctx)
 	}
-	// We prefer to use v2 SKU if available. But if not, we fall back to v1 SKU.
+	// We prefer to use v2 SKU if available.
+	// If we don't find any v2 SKU, we return the v1 SKU.
+	// If preferGen1Image is true, we return the v1 SKU.
 	var v1SKU string
 	for _, img := range result.VirtualMachineImageResourceArray {
 		skuName := *img.Name
@@ -200,7 +202,9 @@ func selectUbuntuSKULegacy(
 	base jujubase.Base, series, stream string,
 	images []*armcompute.VirtualMachineImageResource, preferGen1Image bool,
 ) (string, error) {
-	// We prefer to use v2 SKU if available. But if not, we fall back to v1 SKU.
+	// We prefer to use v2 SKU if available.
+	// If we don't find any v2 SKU, we return the v1 SKU.
+	// If preferGen1Image is true, we return the v1 SKU.
 	var v1SKU string
 	desiredSKUVersionPrefix := strings.ReplaceAll(base.Channel.Track, ".", "_")
 

--- a/provider/azure/internal/imageutils/images_test.go
+++ b/provider/azure/internal/imageutils/images_test.go
@@ -45,7 +45,7 @@ func (s *imageutilsSuite) SetUpTest(c *gc.C) {
 	s.callCtx = context.NewEmptyCloudCallContext()
 }
 
-func (s *imageutilsSuite) TestBaseImageOldStyle(c *gc.C) {
+func (s *imageutilsSuite) TestBaseImageOldStyleGen2(c *gc.C) {
 	s.mockSender.AppendResponse(azuretesting.NewResponseWithContent(
 		`[{"name": "20_04-lts-gen2"}, {"name": "20_04-lts"}, {"name": "20_04-lts-arm64"}]`,
 	))
@@ -54,6 +54,20 @@ func (s *imageutilsSuite) TestBaseImageOldStyle(c *gc.C) {
 	c.Assert(image, gc.NotNil)
 	c.Assert(image, jc.DeepEquals, &instances.Image{
 		Id:       "Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:latest",
+		Arch:     arch.AMD64,
+		VirtType: "Hyper-V",
+	})
+}
+
+func (s *imageutilsSuite) TestBaseImageOldStyleFallbackToGen1(c *gc.C) {
+	s.mockSender.AppendResponse(azuretesting.NewResponseWithContent(
+		`[{"name": "20_04-lts-gen2"}, {"name": "20_04-lts"}, {"name": "20_04-lts-arm64"}]`,
+	))
+	image, err := imageutils.BaseImage(s.callCtx, corebase.MakeDefaultBase("ubuntu", "20.04"), "released", "westus", s.client, true)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(image, gc.NotNil)
+	c.Assert(image, jc.DeepEquals, &instances.Image{
+		Id:       "Canonical:0001-com-ubuntu-server-focal:20_04-lts:latest",
 		Arch:     arch.AMD64,
 		VirtType: "Hyper-V",
 	})
@@ -73,7 +87,7 @@ func (s *imageutilsSuite) TestBaseImageOldStyleInvalidSKU(c *gc.C) {
 	})
 }
 
-func (s *imageutilsSuite) TestBaseImage(c *gc.C) {
+func (s *imageutilsSuite) TestBaseImageGen2(c *gc.C) {
 	s.mockSender.AppendResponse(azuretesting.NewResponseWithContent(
 		`[{"name": "server"}, {"name": "server-gen1"}, {"name": "server-arm64"}]`,
 	))
@@ -82,6 +96,20 @@ func (s *imageutilsSuite) TestBaseImage(c *gc.C) {
 	c.Assert(image, gc.NotNil)
 	c.Assert(image, jc.DeepEquals, &instances.Image{
 		Id:       "Canonical:ubuntu-24_04-lts:server:latest",
+		Arch:     arch.AMD64,
+		VirtType: "Hyper-V",
+	})
+}
+
+func (s *imageutilsSuite) TestBaseImageFallbackToGen1(c *gc.C) {
+	s.mockSender.AppendResponse(azuretesting.NewResponseWithContent(
+		`[{"name": "server"}, {"name": "server-gen1"}, {"name": "server-arm64"}]`,
+	))
+	image, err := imageutils.BaseImage(s.callCtx, corebase.MakeDefaultBase("ubuntu", "24.04"), "released", "westus", s.client, true)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(image, gc.NotNil)
+	c.Assert(image, jc.DeepEquals, &instances.Image{
+		Id:       "Canonical:ubuntu-24_04-lts:server-gen1:latest",
 		Arch:     arch.AMD64,
 		VirtType: "Hyper-V",
 	})

--- a/provider/azure/internal/imageutils/images_test.go
+++ b/provider/azure/internal/imageutils/images_test.go
@@ -47,13 +47,13 @@ func (s *imageutilsSuite) SetUpTest(c *gc.C) {
 
 func (s *imageutilsSuite) TestBaseImageOldStyle(c *gc.C) {
 	s.mockSender.AppendResponse(azuretesting.NewResponseWithContent(
-		`[{"name": "20_04-gen2"}, {"name": "20_04-lts"}, {"name": "20_04-arm64"}]`,
+		`[{"name": "20_04-lts-gen2"}, {"name": "20_04-lts"}, {"name": "20_04-lts-arm64"}]`,
 	))
-	image, err := imageutils.BaseImage(s.callCtx, corebase.MakeDefaultBase("ubuntu", "20.04"), "released", "westus", s.client)
+	image, err := imageutils.BaseImage(s.callCtx, corebase.MakeDefaultBase("ubuntu", "20.04"), "released", "westus", s.client, false)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(image, gc.NotNil)
 	c.Assert(image, jc.DeepEquals, &instances.Image{
-		Id:       "Canonical:0001-com-ubuntu-server-focal:20_04-lts:latest",
+		Id:       "Canonical:0001-com-ubuntu-server-focal:20_04-lts-gen2:latest",
 		Arch:     arch.AMD64,
 		VirtType: "Hyper-V",
 	})
@@ -63,7 +63,7 @@ func (s *imageutilsSuite) TestBaseImageOldStyleInvalidSKU(c *gc.C) {
 	s.mockSender.AppendResponse(azuretesting.NewResponseWithContent(
 		`[{"name": "22_04-invalid"}, {"name": "22_04-lts"}]`,
 	))
-	image, err := imageutils.BaseImage(s.callCtx, corebase.MakeDefaultBase("ubuntu", "22.04"), "released", "westus", s.client)
+	image, err := imageutils.BaseImage(s.callCtx, corebase.MakeDefaultBase("ubuntu", "22.04"), "released", "westus", s.client, false)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(image, gc.NotNil)
 	c.Assert(image, jc.DeepEquals, &instances.Image{
@@ -77,11 +77,11 @@ func (s *imageutilsSuite) TestBaseImage(c *gc.C) {
 	s.mockSender.AppendResponse(azuretesting.NewResponseWithContent(
 		`[{"name": "server"}, {"name": "server-gen1"}, {"name": "server-arm64"}]`,
 	))
-	image, err := imageutils.BaseImage(s.callCtx, corebase.MakeDefaultBase("ubuntu", "24.04"), "released", "westus", s.client)
+	image, err := imageutils.BaseImage(s.callCtx, corebase.MakeDefaultBase("ubuntu", "24.04"), "released", "westus", s.client, false)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(image, gc.NotNil)
 	c.Assert(image, jc.DeepEquals, &instances.Image{
-		Id:       "Canonical:ubuntu-24_04-lts:server-gen1:latest",
+		Id:       "Canonical:ubuntu-24_04-lts:server:latest",
 		Arch:     arch.AMD64,
 		VirtType: "Hyper-V",
 	})
@@ -91,11 +91,11 @@ func (s *imageutilsSuite) TestBaseImageNonLTS(c *gc.C) {
 	s.mockSender.AppendResponse(azuretesting.NewResponseWithContent(
 		`[{"name": "server"}, {"name": "server-gen1"}, {"name": "server-arm64"}]`,
 	))
-	image, err := imageutils.BaseImage(s.callCtx, corebase.MakeDefaultBase("ubuntu", "25.04"), "released", "westus", s.client)
+	image, err := imageutils.BaseImage(s.callCtx, corebase.MakeDefaultBase("ubuntu", "25.04"), "released", "westus", s.client, false)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(image, gc.NotNil)
 	c.Assert(image, jc.DeepEquals, &instances.Image{
-		Id:       "Canonical:ubuntu-25_04:server-gen1:latest",
+		Id:       "Canonical:ubuntu-25_04:server:latest",
 		Arch:     arch.AMD64,
 		VirtType: "Hyper-V",
 	})
@@ -104,7 +104,7 @@ func (s *imageutilsSuite) TestBaseImageNonLTS(c *gc.C) {
 func (s *imageutilsSuite) TestBaseImageCentOS(c *gc.C) {
 	for _, cseries := range []string{"7", "8"} {
 		base := corebase.MakeDefaultBase("centos", cseries)
-		image, err := imageutils.BaseImage(s.callCtx, base, "released", "westus", s.client)
+		image, err := imageutils.BaseImage(s.callCtx, base, "released", "westus", s.client, false)
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(image.Id, gc.Equals, "OpenLogic:CentOS:7.3:latest")
 	}
@@ -112,31 +112,31 @@ func (s *imageutilsSuite) TestBaseImageCentOS(c *gc.C) {
 
 func (s *imageutilsSuite) TestBaseImageStreamDaily(c *gc.C) {
 	s.mockSender.AppendAndRepeatResponse(azuretesting.NewResponseWithContent(
-		`[{"name": "22_04-daily-lts-gen2"}, {"name": "22_04-daily-lts"}, {"name": "22_04-daily-lts-arm64"}]`), 2)
-	base := corebase.MakeDefaultBase("ubuntu", "22.04")
+		`[{"name": "server"}, {"name": "minimal-gen1"}, {"name": "minimal-arm64"}, {"name": "minimal"}]`), 2)
+	base := corebase.MakeDefaultBase("ubuntu", "24.04")
 
-	image, err := imageutils.BaseImage(s.callCtx, base, "daily", "westus", s.client)
+	image, err := imageutils.BaseImage(s.callCtx, base, "daily", "westus", s.client, false)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(image.Id, gc.Equals, "Canonical:0001-com-ubuntu-server-jammy-daily:22_04-daily-lts:latest")
+	c.Assert(image.Id, gc.Equals, "Canonical:ubuntu-24_04-lts-daily:server:latest")
 }
 
 func (s *imageutilsSuite) TestBaseImageOldStyleNotFound(c *gc.C) {
 	s.mockSender.AppendResponse(azuretesting.NewResponseWithContent(`[]`))
-	image, err := imageutils.BaseImage(s.callCtx, corebase.MakeDefaultBase("ubuntu", "22.04"), "released", "westus", s.client)
+	image, err := imageutils.BaseImage(s.callCtx, corebase.MakeDefaultBase("ubuntu", "22.04"), "released", "westus", s.client, false)
 	c.Assert(err, gc.ErrorMatches, `selecting SKU for ubuntu@22.04: legacy ubuntu "jammy" SKUs for released stream not found`)
 	c.Assert(image, gc.IsNil)
 }
 
 func (s *imageutilsSuite) TestBaseImageNotFound(c *gc.C) {
 	s.mockSender.AppendResponse(azuretesting.NewResponseWithContent(`[]`))
-	image, err := imageutils.BaseImage(s.callCtx, corebase.MakeDefaultBase("ubuntu", "24.04"), "released", "westus", s.client)
+	image, err := imageutils.BaseImage(s.callCtx, corebase.MakeDefaultBase("ubuntu", "24.04"), "released", "westus", s.client, false)
 	c.Assert(err, gc.ErrorMatches, `selecting SKU for ubuntu@24.04: ubuntu "ubuntu@24.04/stable" SKUs for released stream not found`)
 	c.Assert(image, gc.IsNil)
 }
 
 func (s *imageutilsSuite) TestBaseImageStreamNotFound(c *gc.C) {
 	s.mockSender.AppendResponse(azuretesting.NewResponseWithContent(`[{"name": "22_04-beta1"}]`))
-	_, err := imageutils.BaseImage(s.callCtx, corebase.MakeDefaultBase("ubuntu", "22.04"), "whatever", "westus", s.client)
+	_, err := imageutils.BaseImage(s.callCtx, corebase.MakeDefaultBase("ubuntu", "22.04"), "whatever", "westus", s.client, false)
 	c.Assert(err, gc.ErrorMatches, `selecting SKU for ubuntu@22.04: legacy ubuntu "jammy" SKUs for whatever stream not found`)
 }
 
@@ -148,7 +148,7 @@ func (s *imageutilsSuite) TestBaseImageStreamThrewCredentialError(c *gc.C) {
 		return nil
 	}
 
-	_, err := imageutils.BaseImage(s.callCtx, corebase.MakeDefaultBase("ubuntu", "22.04"), "whatever", "westus", s.client)
+	_, err := imageutils.BaseImage(s.callCtx, corebase.MakeDefaultBase("ubuntu", "22.04"), "whatever", "westus", s.client, false)
 	c.Assert(err.Error(), jc.Contains, "RESPONSE 401")
 	c.Assert(called, jc.IsTrue)
 }
@@ -161,7 +161,7 @@ func (s *imageutilsSuite) TestBaseImageStreamThrewNonCredentialError(c *gc.C) {
 		return nil
 	}
 
-	_, err := imageutils.BaseImage(s.callCtx, corebase.MakeDefaultBase("ubuntu", "22.04"), "whatever", "westus", s.client)
+	_, err := imageutils.BaseImage(s.callCtx, corebase.MakeDefaultBase("ubuntu", "22.04"), "whatever", "westus", s.client, false)
 	c.Assert(err.Error(), jc.Contains, "RESPONSE 308")
 	c.Assert(called, jc.IsFalse)
 }


### PR DESCRIPTION
This is the backport of PR #18264 to avoid Azure instances problems on the 3.5 branch. 

## QA steps

Follow steps in #18264.

Additional steps:

```sh
juju bootstrap azure c --bootstrap-constraints 'mem=6G cores=2'
```