### PR TITLE
fix: panic for empty unit relation state

### DIFF
--- a/domain/unitstate/state/state.go
+++ b/domain/unitstate/state/state.go
@@ -182,19 +182,21 @@ func (st *State) SetUnitStateRelation(ctx domain.AtomicContext, uuid string, sta
 
 	keyVals := makeUnitRelationStateKeyVals(uuid, state)
 
-	q = "INSERT INTO unit_state_relation(*) VALUES ($unitRelationStateKeyVal.*)"
-	iStmt, err := st.Prepare(q, keyVals[0])
-	if err != nil {
-		return errors.Errorf("preparing relation state insert query: %w", err)
-	}
-
 	return domain.Run(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		if err := tx.Query(ctx, dStmt, id).Run(); err != nil {
 			return errors.Errorf("deleting unit relation state: %w", err)
 		}
 
-		if err := tx.Query(ctx, iStmt, keyVals).Run(); err != nil {
-			return errors.Errorf("setting unit relation state: %w", err)
+		if len(keyVals) != 0 {
+			q = "INSERT INTO unit_state_relation(*) VALUES ($unitRelationStateKeyVal.*)"
+			iStmt, err := st.Prepare(q, keyVals[0])
+			if err != nil {
+				return errors.Errorf("preparing relation state insert query: %w", err)
+			}
+
+			if err := tx.Query(ctx, iStmt, keyVals).Run(); err != nil {
+				return errors.Errorf("setting unit relation state: %w", err)
+			}
 		}
 		return nil
 	})


### PR DESCRIPTION
This fixes a panic where unit relation state is non-nil, but empty. 

We were attempting to prepare a Dqlite statement with the zero index of an empty slice. Now we just skip the insert operation altogether.

This is code slated for rework under a new `hook` domain, to make it transactional along with ports, secrets etc. This patch constitutes a quality-of life improvement in the interim.

## QA steps

Bootstrap, add a model, deploy a unit.