### PR TITLE
chore: bump Pebble version to latest release

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/bmizerany/pat v0.0.0-20210406213842-e4b6760bdd6f
 	github.com/canonical/go-dqlite v1.21.0
 	github.com/canonical/lxd v0.0.0-20231214113525-e676fc63c50a
-	github.com/canonical/pebble v1.17.0
+	github.com/canonical/pebble v1.18.0
 	github.com/chzyer/readline v1.5.1
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/docker/distribution v2.8.3+incompatible

--- a/go.sum
+++ b/go.sum
@@ -152,8 +152,8 @@ github.com/canonical/go-flags v0.0.0-20230403090104-105d09a091b8 h1:zGaJEJI9qPVy
 github.com/canonical/go-flags v0.0.0-20230403090104-105d09a091b8/go.mod h1:ZZFeR9K9iGgpwOaLYF9PdT44/+lfSJ9sQz3B+SsGsYU=
 github.com/canonical/lxd v0.0.0-20231214113525-e676fc63c50a h1:Tfo/MzXK5GeG7gzSHqxGeY/669Mhh5ea43dn1mRDnk8=
 github.com/canonical/lxd v0.0.0-20231214113525-e676fc63c50a/go.mod h1:UxfHGKFoRjgu1NUA9EFiR++dKvyAiT0h9HT0ffMlzjc=
-github.com/canonical/pebble v1.17.0 h1:0XKGmVtvL24akHImflZboo9uwMp9PCC9+N4U9NFPzZQ=
-github.com/canonical/pebble v1.17.0/go.mod h1:iAy6oxSew0En91FA4WdhmKjiuzS2F+hKgOSA4RGjhGg=
+github.com/canonical/pebble v1.18.0 h1:SOlaCDGqxyYzuynZl1rVMGLyIRl6GXkhu6BeTAum4eM=
+github.com/canonical/pebble v1.18.0/go.mod h1:uROQwDXVNnRRNNdiRwaIuSQMfyeKtG3BM4O3yMEoHzU=
 github.com/canonical/x-go v0.0.0-20230522092633-7947a7587f5b h1:Da2fardddn+JDlVEYtrzBLTtyzoyU3nIS0Cf0GvjmwU=
 github.com/canonical/x-go v0.0.0-20230522092633-7947a7587f5b/go.mod h1:upTK9n6rlqITN9rCN69hdreI37dRDFUk2thlGGD5Cg8=
 github.com/cenkalti/backoff/v3 v3.0.0 h1:ske+9nBpD9qZsTBoF41nW5L+AIuFBKMeze18XQ3eG1c=


### PR DESCRIPTION
This Pebble release contains one feature relevant to charms, namely the ability to pass just a user id when performing file operations that can chown the file. Previously a user name was always required, and a user id alone would result in an error.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- ~[x] Code style: imports ordered, good names, simple structure, etc~
- ~[x] Comments saying why design decisions were made~
- ~[x] Go unit tests, with comments saying what you're testing~
- ~[x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Everything Juju side should continue to function with no changes.

## Documentation changes

`ops` documentation will be updated to reflect the availability of this feature after the next Juju release

## Links

Pebble [PR](https://github.com/canonical/pebble/pull/553) that added this feature