### PR TITLE
test: quote table for dump table query

### DIFF
--- a/internal/database/testing/database.go
+++ b/internal/database/testing/database.go
@@ -21,7 +21,7 @@ import (
 // in production code.
 func DumpTable(c *gc.C, db *sql.DB, table string, extraTables ...string) {
 	for _, t := range append([]string{table}, extraTables...) {
-		rows, err := db.Query("SELECT * FROM " + t)
+		rows, err := db.Query(fmt.Sprintf("SELECT * FROM %q", t))
 		c.Assert(err, jc.ErrorIsNil)
 		defer rows.Close()
 


### PR DESCRIPTION
This change now quotes the table name when calling dump table. This is needed as we now have DDL tables that are reserved keywords in the sql namespace like constraint.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- ~[ ] Comments saying why design decisions were made~
- ~[ ] Go unit tests, with comments saying what you're testing~
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Modify a unit test in a state package to call `DumpTable` with any table and also the constraint table from the model database.

## Documentation changes

N/A

## Links

N/A

