### PR TITLE
test: ensure secrets ns sa is created when preparing k8s

### DIFF
--- a/tests/suites/secrets_iaas/k8s.sh
+++ b/tests/suites/secrets_iaas/k8s.sh
@@ -46,6 +46,7 @@ prepare_k8s() {
 	namespace=juju-secrets
 	serviceaccount=default
 	microk8s.kubectl create ns ${namespace} --dry-run=client -o yaml | microk8s.kubectl apply -f -
+	microk8s.kubectl create --save-config -n ${namespace} serviceaccount ${serviceaccount} --dry-run=client -o yaml | microk8s.kubectl apply -f -
 	microk8s.kubectl create --save-config clusterrole juju-secrets --verb='*' \
 		--resource=namespaces,secrets,serviceaccounts,serviceaccounts/token,clusterroles,clusterrolebindings --dry-run=client -o yaml | microk8s.kubectl apply -f -
 	microk8s.kubectl create --save-config clusterrolebinding juju-secrets --clusterrole=juju-secrets \


### PR DESCRIPTION
When running the iaas k8s secrets ci test on jenkins, the namespace created to hold the secrets did not get created with a default service account. Adjust the set up script to add one.

## QA steps

The test worked locally previously. I deleted the sa and ran the test and it seemed ok. Let's see if jenkins thinks the same.
