### PR TITLE
test: fix flakiness in api remote caller

### DIFF
--- a/internal/worker/apiremotecaller/package_test.go
+++ b/internal/worker/apiremotecaller/package_test.go
@@ -61,3 +61,12 @@ func (s *baseSuite) ensureStartup(c *gc.C) {
 		c.Fatalf("timed out waiting for startup")
 	}
 }
+
+func (s *baseSuite) ensureChanged(c *gc.C) {
+	select {
+	case state := <-s.states:
+		c.Assert(state, gc.Equals, stateChanged)
+	case <-time.After(jujutesting.ShortWait * 10):
+		c.Fatalf("timed out waiting for startup")
+	}
+}

--- a/internal/worker/apiremotecaller/remote.go
+++ b/internal/worker/apiremotecaller/remote.go
@@ -219,6 +219,8 @@ func (w *remoteServer) loop() error {
 			w.info.Addrs = addresses
 			connected = true
 
+			w.reportInternalState(stateChanged)
+
 		case <-monitor:
 			// If the connection is lost, force the worker to restart. We
 			// won't attempt to reconnect here, just make the worker die.

--- a/internal/worker/apiremotecaller/remote_test.go
+++ b/internal/worker/apiremotecaller/remote_test.go
@@ -67,7 +67,11 @@ func (s *RemoteSuite) TestConnect(c *gc.C) {
 		c.Fatalf("timed out waiting for API connect")
 	}
 
-	c.Assert(w.Connection().Addr(), jc.DeepEquals, addrs[0])
+	s.ensureChanged(c)
+
+	conn := w.Connection()
+	c.Assert(conn, gc.NotNil)
+	c.Check(conn.Addr(), jc.DeepEquals, addrs[0])
 
 	workertest.CleanKill(c, w)
 }
@@ -118,7 +122,11 @@ func (s *RemoteSuite) TestConnectWhilstConnecting(c *gc.C) {
 		c.Fatalf("timed out waiting for API connect")
 	}
 
-	c.Assert(w.Connection().Addr(), jc.DeepEquals, addrs1[0])
+	s.ensureChanged(c)
+
+	conn := w.Connection()
+	c.Assert(conn, gc.NotNil)
+	c.Check(conn.Addr(), jc.DeepEquals, addrs1[0])
 
 	workertest.CleanKill(c, w)
 }

--- a/internal/worker/apiremotecaller/worker.go
+++ b/internal/worker/apiremotecaller/worker.go
@@ -25,6 +25,7 @@ import (
 const (
 	// States which report the state of the worker.
 	stateStarted = "started"
+	stateChanged = "changed"
 )
 
 // WorkerConfig defines the configuration values that the pubsub worker needs
@@ -219,6 +220,8 @@ func (w *remoteWorker) loop() error {
 			w.mu.Lock()
 			w.apiRemotes = slices.Collect(maps.Values(required))
 			w.mu.Unlock()
+
+			w.reportInternalState(stateChanged)
 		}
 	}
 }

--- a/internal/worker/apiremotecaller/worker_test.go
+++ b/internal/worker/apiremotecaller/worker_test.go
@@ -164,11 +164,13 @@ func (s *WorkerSuite) TestWorkerAPIServerChanges(c *gc.C) {
 		c.Fatalf("timed out waiting for worker to finish")
 	}
 
+	s.ensureChanged(c)
+
 	c.Check(w.runner.WorkerNames(), gc.DeepEquals, []string{"1"})
 
 	remotes := w.GetAPIRemotes()
 	c.Assert(remotes, gc.HasLen, 1)
-	c.Assert(remotes[0].Connection().Addr(), gc.Equals, "192.168.0.17")
+	c.Check(remotes[0].Connection().Addr(), gc.Equals, "192.168.0.17")
 
 	workertest.CleanKill(c, w)
 }
@@ -207,6 +209,8 @@ func (s *WorkerSuite) TestWorkerAPIServerChangesNonInternalAddress(c *gc.C) {
 	case <-time.After(testing.LongWait):
 		c.Fatalf("timed out waiting for worker to finish")
 	}
+
+	s.ensureChanged(c)
 
 	c.Check(w.runner.WorkerNames(), gc.DeepEquals, []string{"1"})
 
@@ -294,6 +298,8 @@ func (s *WorkerSuite) TestWorkerAPIServerChangesRemovesOldAddress(c *gc.C) {
 	case <-time.After(testing.LongWait):
 		c.Fatalf("timed out waiting for worker to finish")
 	}
+
+	s.ensureChanged(c)
 
 	c.Check(w.runner.WorkerNames(), gc.DeepEquals, []string{"2"})
 	c.Check(s.called, jc.DeepEquals, map[string]int{


### PR DESCRIPTION
Introduce more sync points to prevent the worker from finishing the test before the worker gets to the right stage.

## QA steps

Ensure the tests pass by running it a few times :)

```
go test -v ./internal/worker/apiremotecaller -check.v -count=100
```