### PR TITLE
refactor(application): refactor out atomicity for method GetUnitLife

### DIFF
--- a/domain/application/service/package_mock_test.go
+++ b/domain/application/service/package_mock_test.go
@@ -1632,7 +1632,7 @@ func (c *MockStateGetStoragePoolByNameCall) DoAndReturn(f func(context.Context, 
 }
 
 // GetUnitLife mocks base method.
-func (m *MockState) GetUnitLife(arg0 domain.AtomicContext, arg1 unit.Name) (life.Life, error) {
+func (m *MockState) GetUnitLife(arg0 context.Context, arg1 unit.Name) (life.Life, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetUnitLife", arg0, arg1)
 	ret0, _ := ret[0].(life.Life)
@@ -1659,13 +1659,13 @@ func (c *MockStateGetUnitLifeCall) Return(arg0 life.Life, arg1 error) *MockState
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetUnitLifeCall) Do(f func(domain.AtomicContext, unit.Name) (life.Life, error)) *MockStateGetUnitLifeCall {
+func (c *MockStateGetUnitLifeCall) Do(f func(context.Context, unit.Name) (life.Life, error)) *MockStateGetUnitLifeCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetUnitLifeCall) DoAndReturn(f func(domain.AtomicContext, unit.Name) (life.Life, error)) *MockStateGetUnitLifeCall {
+func (c *MockStateGetUnitLifeCall) DoAndReturn(f func(context.Context, unit.Name) (life.Life, error)) *MockStateGetUnitLifeCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/application/service_test.go
+++ b/domain/application/service_test.go
@@ -286,7 +286,7 @@ func (s *serviceSuite) TestEnsureUnitDeadNotFound(c *gc.C) {
 	revoker := application.NewMockRevoker(ctrl)
 
 	err := s.svc.EnsureUnitDead(context.Background(), coreunit.Name("foo/666"), revoker)
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(err, jc.ErrorIs, applicationerrors.UnitNotFound)
 }
 
 func (s *serviceSuite) TestDeleteUnit(c *gc.C) {

--- a/domain/application/state/application.go
+++ b/domain/application/state/application.go
@@ -1295,9 +1295,14 @@ func (st *State) GetStoragePoolByName(ctx context.Context, name string) (domains
 
 // GetUnitLife looks up the life of the specified unit, returning an error
 // satisfying [applicationerrors.UnitNotFound] if the unit is not found.
-func (st *State) GetUnitLife(ctx domain.AtomicContext, unitName coreunit.Name) (life.Life, error) {
+func (st *State) GetUnitLife(ctx context.Context, unitName coreunit.Name) (life.Life, error) {
+	db, err := st.DB()
+	if err != nil {
+		return -1, jujuerrors.Trace(err)
+	}
+
 	var life life.Life
-	err := domain.Run(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		var err error
 		life, err = st.getUnitLife(ctx, tx, unitName)
 		return err

--- a/domain/application/state/application_test.go
+++ b/domain/application/state/application_test.go
@@ -979,21 +979,13 @@ func (s *applicationStateSuite) TestGetUnitLife(c *gc.C) {
 	}
 	s.createApplication(c, "foo", life.Alive, u)
 
-	var unitLife life.Life
-	err := s.state.RunAtomic(context.Background(), func(ctx domain.AtomicContext) error {
-		var err error
-		unitLife, err = s.state.GetUnitLife(ctx, "foo/666")
-		return err
-	})
+	unitLife, err := s.state.GetUnitLife(context.Background(), "foo/666")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(unitLife, gc.Equals, life.Alive)
 }
 
 func (s *applicationStateSuite) TestGetUnitLifeNotFound(c *gc.C) {
-	err := s.state.RunAtomic(context.Background(), func(ctx domain.AtomicContext) error {
-		_, err := s.state.GetUnitLife(ctx, "foo/666")
-		return err
-	})
+	_, err := s.state.GetUnitLife(context.Background(), "foo/666")
 	c.Assert(err, jc.ErrorIs, applicationerrors.UnitNotFound)
 }
 


### PR DESCRIPTION
Refactor GetUnitLife so that is it no longer an atomic method.

Similar to GetUnitUUID, this method is purely a getter, so we don't need to worry about keeping it within a transaction.

Make it non-atomic, and move out of RunAtomic calls

## QA steps

```
juju bootstrap lxd lxd
juju add-model m
juju deploy ubuntu
juju destroy-application ubuntu
```

## Links

[JUJU-7406](https://warthogs.atlassian.net/browse/JUJU-7406)

[JUJU-7406]: https://warthogs.atlassian.net/browse/JUJU-7406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ