### PR TITLE
feat(storage): save storage directive info when adding an application

### DIFF
--- a/domain/application/service/application_test.go
+++ b/domain/application/service/application_test.go
@@ -491,7 +491,13 @@ func (s *applicationServiceSuite) TestCreateWithStorageBlock(c *gc.C) {
 			DownloadSize:       42,
 		},
 		Platform: platform,
-		Scale:    1,
+		Storage: []application.AddApplicationStorageArg{{
+			Name:  "data",
+			Pool:  "loop",
+			Size:  10,
+			Count: 1,
+		}},
+		Scale: 1,
 	}
 	s.state.EXPECT().GetModelType(gomock.Any()).Return("iaas", nil)
 	s.state.EXPECT().StorageDefaults(gomock.Any()).Return(domainstorage.StorageDefaults{}, nil)
@@ -597,7 +603,13 @@ func (s *applicationServiceSuite) TestCreateWithStorageBlockDefaultSource(c *gc.
 			DownloadSize:       42,
 		},
 		Platform: platform,
-		Scale:    1,
+		Storage: []application.AddApplicationStorageArg{{
+			Name:  "data",
+			Pool:  "fast",
+			Size:  10,
+			Count: 2,
+		}},
+		Scale: 1,
 	}
 	s.state.EXPECT().GetModelType(gomock.Any()).Return("iaas", nil)
 	s.state.EXPECT().StorageDefaults(gomock.Any()).Return(domainstorage.StorageDefaults{DefaultBlockSource: ptr("fast")}, nil)
@@ -707,7 +719,13 @@ func (s *applicationServiceSuite) TestCreateWithStorageFilesystem(c *gc.C) {
 			DownloadSize:       42,
 		},
 		Platform: platform,
-		Scale:    1,
+		Storage: []application.AddApplicationStorageArg{{
+			Name:  "data",
+			Pool:  "rootfs",
+			Size:  10,
+			Count: 1,
+		}},
+		Scale: 1,
 	}
 	s.state.EXPECT().GetModelType(gomock.Any()).Return("iaas", nil)
 	s.state.EXPECT().StorageDefaults(gomock.Any()).Return(domainstorage.StorageDefaults{}, nil)
@@ -814,7 +832,13 @@ func (s *applicationServiceSuite) TestCreateWithStorageFilesystemDefaultSource(c
 			DownloadSize:       42,
 		},
 		Platform: platform,
-		Scale:    1,
+		Storage: []application.AddApplicationStorageArg{{
+			Name:  "data",
+			Pool:  "fast",
+			Size:  10,
+			Count: 2,
+		}},
+		Scale: 1,
 	}
 	s.state.EXPECT().GetModelType(gomock.Any()).Return("iaas", nil)
 	s.state.EXPECT().StorageDefaults(gomock.Any()).Return(domainstorage.StorageDefaults{DefaultFilesystemSource: ptr("fast")}, nil)

--- a/domain/application/state/application.go
+++ b/domain/application/state/application.go
@@ -187,6 +187,9 @@ func (st *State) CreateApplication(
 		if err := st.insertResources(ctx, tx, appDetails, args.Resources); err != nil {
 			return errors.Errorf("inserting resources for application %q: %w", name, err)
 		}
+		if err := st.insertStorage(ctx, tx, appDetails, args.Storage); err != nil {
+			return errors.Errorf("inserting storage for application %q: %w", name, err)
+		}
 		if err := st.insertApplicationConfig(ctx, tx, appDetails.UUID, args.Config); err != nil {
 			return errors.Errorf("inserting config for application %q: %w", name, err)
 		}

--- a/domain/application/state/charm_test.go
+++ b/domain/application/state/charm_test.go
@@ -851,7 +851,6 @@ func (s *charmStateSuite) TestGetCharmMetadataWithStorageWithNoProperties(c *gc.
 		_, err = tx.ExecContext(ctx, `
 INSERT INTO charm_storage (
     charm_uuid,
-    key,
     name,
     description,
     storage_kind_id,
@@ -862,8 +861,8 @@ INSERT INTO charm_storage (
     minimum_size_mib,
     location
 ) VALUES
-    (?, 'foo', 'bar', 'description 1', 1, true, true, 1, 2, 3, '/tmp'),
-    (?, 'fred', 'baz', 'description 2', 0, false, false, 4, 5, 6, '/var/mount');`,
+    (?, 'foo', 'description 1', 1, true, true, 1, 2, 3, '/tmp'),
+    (?, 'fred', 'description 2', 0, false, false, 4, 5, 6, '/var/mount');`,
 			uuid, uuid)
 		if err != nil {
 			return errors.Trace(err)
@@ -875,7 +874,7 @@ INSERT INTO charm_storage (
 
 	expectedStorage := map[string]charm.Storage{
 		"foo": {
-			Name:        "bar",
+			Name:        "foo",
 			Type:        charm.StorageFilesystem,
 			Description: "description 1",
 			Shared:      true,
@@ -886,7 +885,7 @@ INSERT INTO charm_storage (
 			Location:    "/tmp",
 		},
 		"fred": {
-			Name:        "baz",
+			Name:        "fred",
 			Type:        charm.StorageBlock,
 			Description: "description 2",
 			Shared:      false,
@@ -929,7 +928,6 @@ func (s *charmStateSuite) TestGetCharmMetadataWithStorageWithProperties(c *gc.C)
 		_, err = tx.ExecContext(ctx, `
 INSERT INTO charm_storage (
     charm_uuid,
-    key,
     name,
     description,
     storage_kind_id,
@@ -940,8 +938,8 @@ INSERT INTO charm_storage (
     minimum_size_mib,
     location
 ) VALUES
-    (?, 'foo', 'bar', 'description 1', 1, true, true, 1, 2, 3, '/tmp'),
-    (?, 'fred', 'baz', 'description 2', 0, false, false, 4, 5, 6, '/var/mount');`,
+    (?, 'foo', 'description 1', 1, true, true, 1, 2, 3, '/tmp'),
+    (?, 'fred', 'description 2', 0, false, false, 4, 5, 6, '/var/mount');`,
 			uuid, uuid)
 		if err != nil {
 			return errors.Trace(err)
@@ -950,7 +948,7 @@ INSERT INTO charm_storage (
 		_, err = tx.ExecContext(ctx, `
 INSERT INTO charm_storage_property (
     charm_uuid,
-    charm_storage_key,
+    charm_storage_name,
     array_index,
     value
 ) VALUES
@@ -968,7 +966,7 @@ INSERT INTO charm_storage_property (
 
 	expectedStorage := map[string]charm.Storage{
 		"foo": {
-			Name:        "bar",
+			Name:        "foo",
 			Type:        charm.StorageFilesystem,
 			Description: "description 1",
 			Shared:      true,
@@ -980,7 +978,7 @@ INSERT INTO charm_storage_property (
 			Properties:  []string{"alpha", "beta", "beta"},
 		},
 		"fred": {
-			Name:        "baz",
+			Name:        "fred",
 			Type:        charm.StorageBlock,
 			Description: "description 2",
 			Shared:      false,
@@ -2027,7 +2025,7 @@ func (s *charmStateSuite) TestSetCharmThenGetCharmMetadataWithStorageWithNoPrope
 		Assumes:        []byte("null"),
 		Storage: map[string]charm.Storage{
 			"foo": {
-				Name:        "bar",
+				Name:        "foo",
 				Type:        charm.StorageFilesystem,
 				Description: "description 1",
 				Shared:      true,
@@ -2038,7 +2036,7 @@ func (s *charmStateSuite) TestSetCharmThenGetCharmMetadataWithStorageWithNoPrope
 				Location:    "/tmp",
 			},
 			"fred": {
-				Name:        "baz",
+				Name:        "fred",
 				Type:        charm.StorageBlock,
 				Description: "description 2",
 				Shared:      false,
@@ -2087,7 +2085,7 @@ func (s *charmStateSuite) TestSetCharmThenGetCharmMetadataWithStorageWithPropert
 		Assumes:        []byte("null"),
 		Storage: map[string]charm.Storage{
 			"foo": {
-				Name:        "bar",
+				Name:        "foo",
 				Type:        charm.StorageFilesystem,
 				Description: "description 1",
 				Shared:      true,
@@ -2099,7 +2097,7 @@ func (s *charmStateSuite) TestSetCharmThenGetCharmMetadataWithStorageWithPropert
 				Properties:  []string{"alpha", "beta", "beta"},
 			},
 			"fred": {
-				Name:        "baz",
+				Name:        "fred",
 				Type:        charm.StorageBlock,
 				Description: "description 2",
 				Shared:      false,

--- a/domain/application/state/metadata.go
+++ b/domain/application/state/metadata.go
@@ -233,11 +233,11 @@ func decodeStorage(storages []charmStorage) (map[string]charm.Storage, error) {
 	for _, storage := range storages {
 		// If the storage for the key already exists, then we need to merge the
 		// information. Generally, this will be a property addition.
-		if existing, ok := result[storage.Key]; ok {
+		if existing, ok := result[storage.Name]; ok {
 			existing.Properties = append(existing.Properties, storage.Property)
 
 			// Ensure we write it back to the map.
-			result[storage.Key] = existing
+			result[storage.Name] = existing
 			continue
 		}
 
@@ -253,7 +253,7 @@ func decodeStorage(storages []charmStorage) (map[string]charm.Storage, error) {
 			properties = append(properties, storage.Property)
 		}
 
-		result[storage.Key] = charm.Storage{
+		result[storage.Name] = charm.Storage{
 			Name:        storage.Name,
 			Description: storage.Description,
 			Type:        kind,
@@ -571,7 +571,7 @@ func encodeStorage(id corecharm.ID, storage map[string]charm.Storage) ([]setChar
 		storages   []setCharmStorage
 		properties []setCharmStorageProperty
 	)
-	for key, storage := range storage {
+	for _, storage := range storage {
 		kind, err := encodeStorageType(storage.Type)
 		if err != nil {
 			return nil, nil, fmt.Errorf("cannot encode storage type %q: %w", storage.Type, err)
@@ -579,7 +579,6 @@ func encodeStorage(id corecharm.ID, storage map[string]charm.Storage) ([]setChar
 
 		storages = append(storages, setCharmStorage{
 			CharmUUID:   id.String(),
-			Key:         key,
 			Name:        storage.Name,
 			Description: storage.Description,
 			KindID:      kind,
@@ -594,7 +593,7 @@ func encodeStorage(id corecharm.ID, storage map[string]charm.Storage) ([]setChar
 		for i, property := range storage.Properties {
 			properties = append(properties, setCharmStorageProperty{
 				CharmUUID: id.String(),
-				Key:       key,
+				Name:      storage.Name,
 				Index:     i,
 				Value:     property,
 			})

--- a/domain/application/state/metadata_test.go
+++ b/domain/application/state/metadata_test.go
@@ -216,8 +216,7 @@ var metadataDecodeTestCases = [...]struct {
 		inputArgs: decodeMetadataArgs{
 			storage: []charmStorage{
 				{
-					Key:         "foo",
-					Name:        "name1",
+					Name:        "foo",
 					Description: "description1",
 					Kind:        "block",
 					Shared:      true,
@@ -229,8 +228,7 @@ var metadataDecodeTestCases = [...]struct {
 					Property:    "property1",
 				},
 				{
-					Key:         "foo",
-					Name:        "name1",
+					Name:        "foo",
 					Description: "description1",
 					Kind:        "block",
 					Shared:      true,
@@ -242,8 +240,7 @@ var metadataDecodeTestCases = [...]struct {
 					Property:    "property2",
 				},
 				{
-					Key:         "bar",
-					Name:        "name2",
+					Name:        "bar",
 					Description: "description2",
 					Kind:        "block",
 					Shared:      true,
@@ -260,7 +257,7 @@ var metadataDecodeTestCases = [...]struct {
 			RunAs: charm.RunAsDefault,
 			Storage: map[string]charm.Storage{
 				"foo": {
-					Name:        "name1",
+					Name:        "foo",
 					Description: "description1",
 					Type:        charm.StorageBlock,
 					Shared:      true,
@@ -272,7 +269,7 @@ var metadataDecodeTestCases = [...]struct {
 					Properties:  []string{"property1", "property2"},
 				},
 				"bar": {
-					Name:        "name2",
+					Name:        "bar",
 					Description: "description2",
 					Type:        charm.StorageBlock,
 					Shared:      true,

--- a/domain/application/state/package_test.go
+++ b/domain/application/state/package_test.go
@@ -109,6 +109,48 @@ INSERT INTO object_store_metadata_path (path, metadata_uuid) VALUES (?, ?)
 	return uuid
 }
 
+func (s *baseSuite) addApplicationArgForStorage(c *gc.C,
+	name string,
+	charmStorage []charm.Storage,
+	addStorageArgs []application.AddApplicationStorageArg) application.AddApplicationArg {
+	platform := application.Platform{
+		Channel:      "666",
+		OSType:       application.Ubuntu,
+		Architecture: architecture.ARM64,
+	}
+	channel := &application.Channel{
+		Track:  "track",
+		Risk:   "risk",
+		Branch: "branch",
+	}
+
+	metadata := s.minimalMetadata(c, name)
+	metadata.Storage = make(map[string]charm.Storage)
+	for _, stor := range charmStorage {
+		metadata.Storage[stor.Name] = stor
+	}
+	return application.AddApplicationArg{
+		Platform: platform,
+		Charm: charm.Charm{
+			Metadata:      metadata,
+			Manifest:      s.minimalManifest(c),
+			Source:        charm.CharmHubSource,
+			ReferenceName: name,
+			Revision:      42,
+			Architecture:  architecture.ARM64,
+		},
+		CharmDownloadInfo: &charm.DownloadInfo{
+			Provenance:         charm.ProvenanceDownload,
+			CharmhubIdentifier: "ident-1",
+			DownloadURL:        "http://example.com/charm",
+			DownloadSize:       666,
+		},
+		Scale:   1,
+		Channel: channel,
+		Storage: addStorageArgs,
+	}
+}
+
 func (s *baseSuite) createApplication(c *gc.C, name string, l life.Life, units ...application.InsertUnitArg) coreapplication.ID {
 	state := NewState(s.TxnRunnerFactory(), clock.WallClock, loggertesting.WrapCheckLog(c))
 

--- a/domain/application/state/storage.go
+++ b/domain/application/state/storage.go
@@ -1,0 +1,74 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"context"
+
+	"github.com/canonical/sqlair"
+	"github.com/juju/collections/set"
+
+	"github.com/juju/juju/domain/application"
+	"github.com/juju/juju/internal/errors"
+)
+
+// insertStorage constructs inserts storage directive records for the application.
+func (st *State) insertStorage(ctx context.Context, tx *sqlair.TX, appDetails applicationDetails, appStorage []application.AddApplicationStorageArg) error {
+	if len(appStorage) == 0 {
+		return nil
+	}
+
+	// This check is here until we rework all of the AddApplication logic to
+	// run in a single transaction. There's a TO-DO in the AddApplication service method.
+	queryStmt, err := st.Prepare(`
+SELECT &charmStorage.name FROM charm_storage
+WHERE charm_uuid = $applicationDetails.charm_uuid
+`, appDetails, charmStorage{})
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	var storageMetadata []charmStorage
+	err = tx.Query(ctx, queryStmt, appDetails).GetAll(&storageMetadata)
+	if err != nil {
+		return errors.Errorf("querying supported charm storage: %w", err)
+	}
+	supportedStorage := set.NewStrings()
+	for _, stor := range storageMetadata {
+		supportedStorage.Add(stor.Name)
+	}
+	wantStorage := set.NewStrings()
+	for _, stor := range appStorage {
+		wantStorage.Add(stor.Name)
+	}
+	unsupportedStorage := wantStorage.Difference(supportedStorage)
+	if unsupportedStorage.Size() > 0 {
+		return errors.Errorf("storage %q is not supported", unsupportedStorage.SortedValues())
+	}
+
+	storage := make([]storageToAdd, len(appStorage))
+	for i, stor := range appStorage {
+		storage[i] = storageToAdd{
+			ApplicationUUID: appDetails.UUID.String(),
+			CharmUUID:       appDetails.CharmID,
+			StorageName:     stor.Name,
+			StoragePool:     stor.Pool,
+			Size:            uint(stor.Size),
+			Count:           uint(stor.Count),
+		}
+	}
+
+	insertStmt, err := st.Prepare(`
+INSERT INTO application_storage_directive (*)
+VALUES ($storageToAdd.*)`, storageToAdd{})
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	err = tx.Query(ctx, insertStmt, storage).Run()
+	if err != nil {
+		return errors.Capture(err)
+	}
+	return nil
+}

--- a/domain/application/state/storage_test.go
+++ b/domain/application/state/storage_test.go
@@ -1,0 +1,123 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"context"
+	"database/sql"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/domain/application"
+	"github.com/juju/juju/domain/application/charm"
+	"github.com/juju/juju/internal/errors"
+)
+
+// TestCreateApplicationWithResources tests creation of an application with
+// specified resources.
+// It verifies that the charm_resource table is populated, alongside the
+// resource and application_resource table with datas from charm and arguments.
+func (s *applicationStateSuite) TestCreateApplicationWithStorage(c *gc.C) {
+	chStorage := []charm.Storage{{
+		Name: "database",
+		Type: "block",
+	}, {
+		Name: "logs",
+		Type: "filesystem",
+	}}
+	addStorageArgs := []application.AddApplicationStorageArg{
+		{
+			Name:  "database",
+			Pool:  "ebs",
+			Size:  10,
+			Count: 2,
+		},
+		{
+			Name:  "logs",
+			Pool:  "rootfs",
+			Size:  20,
+			Count: 1,
+		},
+	}
+	ctx := context.Background()
+
+	appUUID, err := s.state.CreateApplication(ctx, "666", s.addApplicationArgForStorage(c, "666",
+		chStorage, addStorageArgs), nil)
+	c.Assert(err, jc.ErrorIsNil)
+
+	var charmUUID string
+	err = s.TxnRunner().StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		return tx.QueryRowContext(ctx, `
+SELECT charm_uuid
+FROM application
+WHERE name=?`, "666").Scan(&charmUUID)
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	var (
+		foundCharmStorage []charm.Storage
+		foundAppStorage   []application.AddApplicationStorageArg
+	)
+
+	err = s.TxnRunner().StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		rows, err := tx.QueryContext(ctx, `
+SELECT cs.name, csk.name as kind
+FROM charm_storage cs
+JOIN charm_storage_kind csk ON csk.id=cs.storage_kind_id
+WHERE charm_uuid=?`, charmUUID)
+		if err != nil {
+			return errors.Capture(err)
+		}
+		defer func() { _ = rows.Close() }()
+		for rows.Next() {
+			var stor charm.Storage
+			if err := rows.Scan(&stor.Name, &stor.Type); err != nil {
+				return errors.Capture(err)
+			}
+			foundCharmStorage = append(foundCharmStorage, stor)
+		}
+		return nil
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.TxnRunner().StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		rows, err := tx.QueryContext(ctx, `
+SELECT storage_name, storage_pool, size, count
+FROM application_storage_directive
+WHERE application_uuid = ? AND charm_uuid = ?`, appUUID, charmUUID)
+		if err != nil {
+			return errors.Capture(err)
+		}
+		defer func() { _ = rows.Close() }()
+		for rows.Next() {
+			var stor application.AddApplicationStorageArg
+			if err := rows.Scan(&stor.Name, &stor.Pool, &stor.Size, &stor.Count); err != nil {
+				return errors.Capture(err)
+			}
+			foundAppStorage = append(foundAppStorage, stor)
+		}
+		return nil
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(foundCharmStorage, jc.SameContents, chStorage)
+	c.Assert(foundAppStorage, jc.SameContents, addStorageArgs)
+}
+
+func (s *applicationStateSuite) TestCreateApplicationWithUnrecognisedStorage(c *gc.C) {
+	chStorage := []charm.Storage{{
+		Name: "database",
+		Type: "block",
+	}}
+	addStorageArgs := []application.AddApplicationStorageArg{{
+		Name:  "foo",
+		Pool:  "rootfs",
+		Size:  20,
+		Count: 1,
+	}}
+	ctx := context.Background()
+
+	_, err := s.state.CreateApplication(ctx, "666", s.addApplicationArgForStorage(c, "666",
+		chStorage, addStorageArgs), nil)
+	c.Assert(err, gc.ErrorMatches, `.*storage \["foo"\] is not supported`)
+}

--- a/domain/application/state/types.go
+++ b/domain/application/state/types.go
@@ -419,7 +419,6 @@ type setCharmExtraBinding struct {
 // for the property field.
 type charmStorage struct {
 	CharmUUID   string `db:"charm_uuid"`
-	Key         string `db:"key"`
 	Name        string `db:"name"`
 	Description string `db:"description"`
 	Kind        string `db:"kind"`
@@ -435,7 +434,6 @@ type charmStorage struct {
 // setCharmStorage is used to set the storage of a charm.
 type setCharmStorage struct {
 	CharmUUID   string `db:"charm_uuid"`
-	Key         string `db:"key"`
 	Name        string `db:"name"`
 	Description string `db:"description"`
 	KindID      int    `db:"storage_kind_id"`
@@ -450,7 +448,7 @@ type setCharmStorage struct {
 // setCharmStorageProperty is used to set the storage property of a charm.
 type setCharmStorageProperty struct {
 	CharmUUID string `db:"charm_uuid"`
-	Key       string `db:"charm_storage_key"`
+	Name      string `db:"charm_storage_name"`
 	Index     int    `db:"array_index"`
 	Value     string `db:"value"`
 }
@@ -653,6 +651,15 @@ type resourceToAdd struct {
 	Origin    string    `db:"origin_type_name"`
 	State     string    `db:"state_name"`
 	CreatedAt time.Time `db:"created_at"`
+}
+
+type storageToAdd struct {
+	ApplicationUUID string `db:"application_uuid"`
+	CharmUUID       string `db:"charm_uuid"`
+	StorageName     string `db:"storage_name"`
+	StoragePool     string `db:"storage_pool"`
+	Size            uint   `db:"size"`
+	Count           uint   `db:"count"`
 }
 
 type linkResourceApplication struct {

--- a/domain/application/types.go
+++ b/domain/application/types.go
@@ -36,6 +36,9 @@ type AddApplicationArg struct {
 	// Resources defines the list of resources to add to an application.
 	// They should match all the resources defined in the Charm.
 	Resources []AddApplicationResourceArg
+	// Storage defines the list of storage directives to add to an application.
+	// The Name values should match the storage defined in the Charm.
+	Storage []AddApplicationStorageArg
 	// Config contains the configuration for the application, overlaid on top
 	// of the charm's default configuration.
 	Config map[string]ApplicationConfig
@@ -51,6 +54,14 @@ type AddApplicationResourceArg struct {
 	Name     string
 	Revision *int
 	Origin   charmresource.Origin
+}
+
+// AddApplicationStorageArg defines the arguments required to add storage to an application.
+type AddApplicationStorageArg struct {
+	Name  string
+	Pool  string
+	Size  uint64
+	Count uint64
 }
 
 // Channel represents the channel of a application charm.

--- a/domain/schema/model/sql/0011-storage.sql
+++ b/domain/schema/model/sql/0011-storage.sql
@@ -43,7 +43,7 @@ INSERT INTO storage_kind VALUES
 CREATE TABLE application_storage_directive (
     application_uuid TEXT NOT NULL,
     charm_uuid TEXT NOT NULL,
-    storage_key TEXT NOT NULL,
+    storage_name TEXT NOT NULL,
     -- These attributes are filled in by sourcing data from:
     -- user supplied, model config, charm config, opinionated fallbacks.
     -- By the time the row is written, all values are known.
@@ -64,9 +64,9 @@ CREATE TABLE application_storage_directive (
     FOREIGN KEY (application_uuid)
     REFERENCES application (uuid),
     CONSTRAINT fk_application_storage_directive_charm_storage
-    FOREIGN KEY (charm_uuid, storage_key)
-    REFERENCES charm_storage (charm_uuid, "key"),
-    PRIMARY KEY (application_uuid, charm_uuid, storage_key)
+    FOREIGN KEY (charm_uuid, storage_name)
+    REFERENCES charm_storage (charm_uuid, name),
+    PRIMARY KEY (application_uuid, charm_uuid, storage_name)
 );
 
 -- Note that this is not unique; it speeds access by application.
@@ -83,7 +83,7 @@ ON application_storage_directive (application_uuid);
 CREATE TABLE unit_storage_directive (
     unit_uuid TEXT NOT NULL,
     charm_uuid TEXT NOT NULL,
-    storage_key TEXT NOT NULL,
+    storage_name TEXT NOT NULL,
     -- These attributes are filled in by sourcing data from:
     -- user supplied, model config, charm config, opinionated fallbacks.
     -- By the time the row is written, all values are known.
@@ -101,9 +101,9 @@ CREATE TABLE unit_storage_directive (
     size INT NOT NULL,
     count INT NOT NULL,
     CONSTRAINT fk_unit_storage_directive_charm_storage
-    FOREIGN KEY (charm_uuid, storage_key)
-    REFERENCES charm_storage (charm_uuid, "key"),
-    PRIMARY KEY (unit_uuid, charm_uuid, storage_key)
+    FOREIGN KEY (charm_uuid, storage_name)
+    REFERENCES charm_storage (charm_uuid, name),
+    PRIMARY KEY (unit_uuid, charm_uuid, storage_name)
 );
 
 -- Note that this is not unique; it speeds access by unit.

--- a/domain/schema/model/sql/0015-charm.sql
+++ b/domain/schema/model/sql/0015-charm.sql
@@ -373,8 +373,7 @@ INSERT INTO charm_storage_kind VALUES
 
 CREATE TABLE charm_storage (
     charm_uuid TEXT NOT NULL,
-    "key" TEXT NOT NULL,
-    name TEXT,
+    name TEXT NOT NULL,
     description TEXT,
     storage_kind_id INT NOT NULL,
     shared BOOLEAN,
@@ -389,13 +388,12 @@ CREATE TABLE charm_storage (
     CONSTRAINT fk_charm_storage_charm
     FOREIGN KEY (charm_uuid)
     REFERENCES charm (uuid),
-    PRIMARY KEY (charm_uuid, "key")
+    PRIMARY KEY (charm_uuid, name)
 );
 
 CREATE VIEW v_charm_storage AS
 SELECT
     cs.charm_uuid,
-    cs."key",
     cs.name,
     cs.description,
     csk.name AS kind,
@@ -409,23 +407,23 @@ SELECT
     csp.value AS property
 FROM charm_storage AS cs
 LEFT JOIN charm_storage_kind AS csk ON cs.storage_kind_id = csk.id
-LEFT JOIN charm_storage_property AS csp ON cs.charm_uuid = csp.charm_uuid AND cs."key" = csp.charm_storage_key;
+LEFT JOIN charm_storage_property AS csp ON cs.charm_uuid = csp.charm_uuid AND cs.name = csp.charm_storage_name;
 
 CREATE INDEX idx_charm_storage_charm
 ON charm_storage (charm_uuid);
 
 CREATE TABLE charm_storage_property (
     charm_uuid TEXT NOT NULL,
-    charm_storage_key TEXT NOT NULL,
+    charm_storage_name TEXT NOT NULL,
     array_index INT NOT NULL,
     value TEXT NOT NULL,
     CONSTRAINT fk_charm_storage_property_charm
     FOREIGN KEY (charm_uuid)
     REFERENCES charm (uuid),
     CONSTRAINT fk_charm_storage_property_charm_storage
-    FOREIGN KEY (charm_uuid, charm_storage_key)
-    REFERENCES charm_storage (charm_uuid, "key"),
-    PRIMARY KEY (charm_uuid, charm_storage_key, array_index, value)
+    FOREIGN KEY (charm_uuid, charm_storage_name)
+    REFERENCES charm_storage (charm_uuid, name),
+    PRIMARY KEY (charm_uuid, charm_storage_name, array_index, value)
 );
 
 CREATE INDEX idx_charm_storage_property_charm


### PR DESCRIPTION
When adding an application, we fill in defaults and validate any storage directives relevant to the charm being deployed. This PR adds the state layer support for persisting that storage info to the application_storage_directive table.

While doing the work, I noticed that we have separately storing the charm storage "key" and "name", as table columns in the charm_storage table as well as struct attributes. These are actually the same thing - the charm metadata exposes storage as a map of storage where the map keys are actually just the name of each value in the map. There's no need to store this twice. So the PR fixes that as a drive by. 

Note: the device metadata will need the same treatment.

Because the work to make AddApplication atomic is ongoing, I've added in an extra check (which we can remove later) when adding storage records, to guard against FK constraint errors, since the storage names need to match what the charm supports. NB we do already check in the service layer; this is just a safe guard.

Migration of application_storage_directive is out of scope for this PR.

## QA steps

```
$ juju deploy postgresql --storage foo=rootfs
ERROR cannot add application "postgresql": charm "postgresql" has no store called "foo"
ERROR failed to deploy charm "postgresql"
$ juju deploy postgresql --storage pgdata=loop,10M
Deployed "postgresql" from charm-hub charm "postgresql", revision 468 in channel 14/stable on ubuntu@22.04/stable

```

```
select * from application_storage_directive;
application_uuid                        charm_uuid                              storage_name    storage_pool    size    count
ef98bf33-1630-4d4a-87b7-d1211f9def8e    2ceb9027-3f1a-41a0-8823-0368d4184d23    pgdata          loop            10      1
```

## Links

**Jira card:** [JUJU-7473](https://warthogs.atlassian.net/browse/JUJU-7473)

