### PR TITLE
feat: move to dqlite v1.18.1

### DIFF
--- a/scripts/dqlite/scripts/env.sh
+++ b/scripts/dqlite/scripts/env.sh
@@ -66,7 +66,7 @@ TAG_LIBNSL=v2.0.0
 TAG_LIBUV=v1.46.0
 TAG_LIBLZ4=v1.9.4
 TAG_SQLITE=version-3.46.0
-TAG_DQLITE=v1.18.0
+TAG_DQLITE=v1.18.1
 
 S3_BUCKET=s3://dqlite-static-libs
 S3_ARCHIVE_NAME=$(date -u +"%Y-%m-%d")-dqlite-deps-${BUILD_ARCH}.tar.bz2

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -224,7 +224,7 @@ parts:
       - libuv
       - libsqlite3
     source: https://github.com/canonical/dqlite.git
-    source-tag: v1.18.0
+    source-tag: v1.18.1
     source-type: git
     source-depth: 1
     plugin: nil


### PR DESCRIPTION
In attempt to prevent core dumps happening all the time, we need to move to the following change[1], which has been released as v1.18.1[2]

 1. https://github.com/canonical/dqlite/pull/728
 2. https://github.com/canonical/dqlite/releases/tag/v1.18.1

