### PR TITLE
feat: add boilerplace for removal domain

### DIFF
--- a/domain/removal/service/service.go
+++ b/domain/removal/service/service.go
@@ -1,0 +1,50 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package service
+
+import (
+	"github.com/juju/juju/core/changestream"
+	"github.com/juju/juju/core/logger"
+	"github.com/juju/juju/core/watcher"
+	"github.com/juju/juju/core/watcher/eventsource"
+)
+
+// State describes retrieval and persistence methods for entity removal.
+type State interface{}
+
+// WatcherFactory describes methods for creating watchers.
+type WatcherFactory interface {
+	// NewNamespaceWatcher returns a new namespace watcher
+	// for events based on the input change mask.
+	NewNamespaceWatcher(string, changestream.ChangeType, eventsource.NamespaceQuery) (watcher.StringsWatcher, error)
+}
+
+// Service provides the API for working with entity removal.
+type Service struct {
+	st     State
+	logger logger.Logger
+}
+
+// WatchableService provides the API for working with entity removal,
+// including the ability to create watchers.
+type WatchableService struct {
+	Service
+	watcherFactory WatcherFactory
+}
+
+// NewWatchableService creates a new WatchableService
+// for working with entity removal.
+func NewWatchableService(
+	st State,
+	watcherFactory WatcherFactory,
+	logger logger.Logger,
+) *WatchableService {
+	return &WatchableService{
+		Service: Service{
+			st:     st,
+			logger: logger,
+		},
+		watcherFactory: watcherFactory,
+	}
+}

--- a/domain/removal/state/state.go
+++ b/domain/removal/state/state.go
@@ -1,0 +1,24 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"github.com/juju/juju/core/database"
+	"github.com/juju/juju/core/logger"
+	"github.com/juju/juju/domain"
+)
+
+// State provides persistence and retrieval associated with entity removal.
+type State struct {
+	*domain.StateBase
+	logger logger.Logger
+}
+
+// NewState returns a new state reference.
+func NewState(factory database.TxnRunnerFactory, logger logger.Logger) *State {
+	return &State{
+		StateBase: domain.NewStateBase(factory),
+		logger:    logger,
+	}
+}

--- a/domain/services/model.go
+++ b/domain/services/model.go
@@ -56,6 +56,8 @@ import (
 	proxy "github.com/juju/juju/domain/proxy/service"
 	relationservice "github.com/juju/juju/domain/relation/service"
 	relationstate "github.com/juju/juju/domain/relation/state"
+	removalservice "github.com/juju/juju/domain/removal/service"
+	removalstate "github.com/juju/juju/domain/removal/state"
 	resourceservice "github.com/juju/juju/domain/resource/service"
 	resourcestate "github.com/juju/juju/domain/resource/state"
 	secretservice "github.com/juju/juju/domain/secret/service"
@@ -386,6 +388,18 @@ func (s *ModelServices) Relation() *relationservice.WatchableService {
 		),
 		s.modelWatcherFactory("relation.watcher"),
 		s.logger.Child("relation.service"),
+	)
+}
+
+// Removal returns the service for working
+// with entity removals in the current model.
+func (s *ModelServices) Removal() *removalservice.WatchableService {
+	log := s.logger.Child("removal")
+
+	return removalservice.NewWatchableService(
+		removalstate.NewState(changestream.NewTxnRunnerFactory(s.modelDB), log),
+		s.modelWatcherFactory("removal"),
+		log,
 	)
 }
 


### PR DESCRIPTION
Adds the skeleton service, state and factory method for the `removal` domain.

There is no domain functionality at this point.
