### PR TITLE
fix: reflecting watcher in error handling

### DIFF
--- a/state/watcher/helpers.go
+++ b/state/watcher/helpers.go
@@ -34,12 +34,13 @@ func Stop(w Stopper, t *tomb.Tomb) {
 
 // EnsureErr returns the error with which w died. Calling it will also
 // return an error if w is still running or was stopped cleanly.
+// Deprecated: This function is deprecated. Use apiserver/internal/EnsureRegisterWatcher
 func EnsureErr(w Errer) error {
 	err := w.Err()
 	if err == nil {
-		return errors.Errorf("expected an error from %v, got nil", w)
+		return errors.Errorf("expected an error from watcher, got nil")
 	} else if err == tomb.ErrStillAlive {
-		return errors.Annotatef(err, "expected %v to be stopped", w)
+		return errors.Annotatef(err, "expected watcher to be stopped")
 	}
 	return errors.Trace(err)
 }


### PR DESCRIPTION
Fixes data race when serialising a watcher/worker in `state/watcher.EnsureErr`
while the watcher is dying.

```
05:11:22 WARNING: DATA RACE
05:11:22 Write at 0x00c0003808c0 by goroutine 66:
05:11:22   sync/atomic.CompareAndSwapInt32()
05:11:22       /usr/local/go/src/runtime/race_amd64.s:361 +0xb
05:11:22   sync/atomic.CompareAndSwapInt32()
05:11:22       <autogenerated>:1 +0x18
05:11:22   gopkg.in/tomb%2ev2.(*Tomb).init()
05:11:22       /home/jenkins/workspace/unit-tests-race-amd64/go-path/src/github.com/juju/juju/vendor/gopkg.in/tomb.v2/tomb.go:99 +0x30
05:11:22   gopkg.in/tomb%2ev2.(*Tomb).Dying()
05:11:22       /home/jenkins/workspace/unit-tests-race-amd64/go-path/src/github.com/juju/juju/vendor/gopkg.in/tomb.v2/tomb.go:118 +0x39
05:11:22 
05:11:22 Previous read at 0x00c0003808c0 by goroutine 64:
05:11:22   fmt.Sprintf()
05:11:22       /usr/local/go/src/fmt/print.go:239 +0x5c
05:11:22   github.com/juju/errors.Annotatef()
05:11:22       /home/jenkins/workspace/unit-tests-race-amd64/go-path/src/github.com/juju/juju/vendor/github.com/juju/errors/functions.go:106 +0x9c
05:11:22   github.com/juju/juju/state/watcher.EnsureErr()
05:11:22       /home/jenkins/workspace/unit-tests-race-amd64/go-path/src/github.com/juju/juju/state/watcher/helpers.go:43 +0x19c
05:11:22   github.com/juju/juju/apiserver/facades/agent/storageprovisioner.(*StorageProvisionerAPIv4).WatchApplications()
```

## QA steps

Run race tests.
