### PR TITLE
refactor: separately pass in storage service and registry to storage facade

### DIFF
--- a/apiserver/facades/client/storage/base_test.go
+++ b/apiserver/facades/client/storage/base_test.go
@@ -4,7 +4,7 @@
 package storage_test
 
 import (
-	context "context"
+	"context"
 
 	"github.com/juju/errors"
 	"github.com/juju/names/v6"
@@ -16,7 +16,7 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facades/client/storage"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
-	blockcommand "github.com/juju/juju/domain/blockcommand"
+	"github.com/juju/juju/domain/blockcommand"
 	jujustorage "github.com/juju/juju/internal/storage"
 	coretesting "github.com/juju/juju/internal/testing"
 	"github.com/juju/juju/rpc/params"
@@ -71,14 +71,18 @@ func (s *baseStorageSuite) setupMocks(c *gc.C) *gomock.Controller {
 	s.registry = jujustorage.StaticProviderRegistry{Providers: map[jujustorage.ProviderType]jujustorage.Provider{}}
 	s.poolsInUse = []string{}
 
-	s.api = storage.NewStorageAPIForTest(s.state, state.ModelTypeIAAS, s.storageAccessor, s.blockDeviceGetter, s.storageMetadata, s.authorizer, apiservertesting.NoopModelCredentialInvalidatorGetter, s.blockCommandService)
-	s.apiCaas = storage.NewStorageAPIForTest(s.state, state.ModelTypeCAAS, s.storageAccessor, s.blockDeviceGetter, s.storageMetadata, s.authorizer, apiservertesting.NoopModelCredentialInvalidatorGetter, s.blockCommandService)
+	s.api = storage.NewStorageAPIForTest(s.state, state.ModelTypeIAAS, s.storageAccessor, s.blockDeviceGetter,
+		s.storageService, s.storageRegistryGetter, s.authorizer, apiservertesting.NoopModelCredentialInvalidatorGetter,
+		s.blockCommandService)
+	s.apiCaas = storage.NewStorageAPIForTest(s.state, state.ModelTypeCAAS, s.storageAccessor, s.blockDeviceGetter,
+		s.storageService, s.storageRegistryGetter, s.authorizer, apiservertesting.NoopModelCredentialInvalidatorGetter,
+		s.blockCommandService)
 
 	return ctrl
 }
 
-func (s *baseStorageSuite) storageMetadata(context.Context) (storage.StorageService, jujustorage.ProviderRegistry, error) {
-	return s.storageService, s.registry, nil
+func (s *baseStorageSuite) storageRegistryGetter(context.Context) (jujustorage.ProviderRegistry, error) {
+	return s.registry, nil
 }
 
 // TODO(axw) get rid of assertCalls, use stub directly everywhere.

--- a/apiserver/facades/client/storage/storage_test.go
+++ b/apiserver/facades/client/storage/storage_test.go
@@ -796,7 +796,9 @@ func (s *storageSuite) TestListStorageAsAdminOnNotOwnedModel(c *gc.C) {
 	s.authorizer = apiservertesting.FakeAuthorizer{
 		Tag: names.NewUserTag("superuserfoo"),
 	}
-	s.api = facadestorage.NewStorageAPIForTest(s.state, state.ModelTypeIAAS, s.storageAccessor, nil, s.storageMetadata, s.authorizer, apiservertesting.NoopModelCredentialInvalidatorGetter, s.blockCommandService)
+	s.api = facadestorage.NewStorageAPIForTest(s.state, state.ModelTypeIAAS, s.storageAccessor, nil,
+		s.storageService, s.storageRegistryGetter, s.authorizer, apiservertesting.NoopModelCredentialInvalidatorGetter,
+		s.blockCommandService)
 
 	// Sanity check before running test:
 	// Ensure that the user has NO read access to the model but SuperuserAccess
@@ -818,7 +820,9 @@ func (s *storageSuite) TestListStorageAsNonAdminOnNotOwnedModel(c *gc.C) {
 	s.authorizer = apiservertesting.FakeAuthorizer{
 		Tag: names.NewUserTag("userfoo"),
 	}
-	s.api = facadestorage.NewStorageAPIForTest(s.state, state.ModelTypeIAAS, s.storageAccessor, nil, s.storageMetadata, s.authorizer, apiservertesting.NoopModelCredentialInvalidatorGetter, s.blockCommandService)
+	s.api = facadestorage.NewStorageAPIForTest(s.state, state.ModelTypeIAAS, s.storageAccessor, nil,
+		s.storageService, s.storageRegistryGetter, s.authorizer, apiservertesting.NoopModelCredentialInvalidatorGetter,
+		s.blockCommandService)
 
 	// Sanity check before running test:
 	// Ensure that the user has NO read access to the model and NO SuperuserAccess


### PR DESCRIPTION
This is a small refactor to prepare for further work on storage.
The storage facade was being constructed with a helper method to return both the service and the registry.
These are now passed in separately. Subsequent work will remove the need for the facade to use the registry at all, leaving just the service to be passed in.

Also rename stdcontext to context.

## QA steps

deploy postgresql --storage pgdata=ebs

## Links

**Jira card:** [JUJU-7544](https://warthogs.atlassian.net/browse/JUJU-7544)

