### PR TITLE
feat: implement state layer for application constraints

### DIFF
--- a/domain/application/errors/errors.go
+++ b/domain/application/errors/errors.go
@@ -204,4 +204,10 @@ const (
 	// ApplicationHasDifferentCharm describes an error that occurs when the
 	// application has a different charm.
 	ApplicationHasDifferentCharm = errors.ConstError("application has different charm")
+
+	// InvalidApplicationConstraints describes an error that occurs when the
+	// application constraints are not valid. This happens when if the
+	// provided space constraints do not exist or the container type is not
+	// supported.
+	InvalidApplicationConstraints = errors.ConstError("invalid application constraints")
 )

--- a/domain/application/state/application.go
+++ b/domain/application/state/application.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/canonical/sqlair"
+	"github.com/juju/collections/set"
 	"github.com/juju/collections/transform"
 	jujuerrors "github.com/juju/errors"
 
@@ -3276,9 +3277,9 @@ func decodeConstraints(cons applicationConstraints) constraints.Value {
 	}
 
 	// Unique spaces, tags and zones:
-	spaces := make(map[string]string)
-	tags := make(map[string]string)
-	zones := make(map[string]string)
+	spaces := set.NewStrings()
+	tags := set.NewStrings()
+	zones := set.NewStrings()
 
 	for _, row := range cons {
 		if row.Arch.Valid {
@@ -3323,36 +3324,27 @@ func decodeConstraints(cons applicationConstraints) constraints.Value {
 			res.ImageID = &row.ImageID.String
 		}
 		if row.Space.Valid {
-			spaces[row.Space.String] = row.Space.String
+			spaces.Add(row.Space.String)
 		}
 		if row.Tag.Valid {
-			tags[row.Tag.String] = row.Tag.String
+			tags.Add(row.Tag.String)
 		}
 		if row.Zone.Valid {
-			zones[row.Zone.String] = row.Zone.String
+			zones.Add(row.Zone.String)
 		}
 	}
 
 	// Add the unique spaces, tags and zones to the result:
 	if len(spaces) > 0 {
-		spacesSlice := make([]string, 0, len(spaces))
-		for _, space := range spaces {
-			spacesSlice = append(spacesSlice, space)
-		}
+		spacesSlice := spaces.SortedValues()
 		res.Spaces = &spacesSlice
 	}
 	if len(tags) > 0 {
-		tagsSlice := make([]string, 0, len(tags))
-		for _, tag := range tags {
-			tagsSlice = append(tagsSlice, tag)
-		}
+		tagsSlice := tags.SortedValues()
 		res.Tags = &tagsSlice
 	}
 	if len(zones) > 0 {
-		zonesSlice := make([]string, 0, len(zones))
-		for _, zone := range zones {
-			zonesSlice = append(zonesSlice, zone)
-		}
+		zonesSlice := zones.SortedValues()
 		res.Zones = &zonesSlice
 	}
 
@@ -3373,8 +3365,8 @@ func encodeConstraints(constraintUUID string, cons constraints.Value, containerT
 		InstanceRole:     cons.InstanceRole,
 		InstanceType:     cons.InstanceType,
 		VirtType:         cons.VirtType,
-		AllocatePublicIP: cons.AllocatePublicIP,
 		ImageID:          cons.ImageID,
+		AllocatePublicIP: cons.AllocatePublicIP,
 	}
 	if cons.Container != nil {
 		res.ContainerTypeID = &containerTypeID

--- a/domain/application/state/application_test.go
+++ b/domain/application/state/application_test.go
@@ -20,6 +20,8 @@ import (
 	coreapplication "github.com/juju/juju/core/application"
 	applicationtesting "github.com/juju/juju/core/application/testing"
 	charmtesting "github.com/juju/juju/core/charm/testing"
+	"github.com/juju/juju/core/constraints"
+	"github.com/juju/juju/core/instance"
 	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/network"
 	coreunit "github.com/juju/juju/core/unit"
@@ -3026,6 +3028,327 @@ func (s *applicationStateSuite) TestHashConfigAndSettings(c *gc.C) {
 		c.Assert(err, jc.ErrorIsNil)
 		c.Check(hash, gc.Equals, test.expected)
 	}
+}
+
+func (s *applicationStateSuite) TestConstraintFull(c *gc.C) {
+	id := s.createApplication(c, "foo", life.Alive)
+
+	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		addConstraintStmt := `INSERT INTO "constraint" (uuid, arch, cpu_cores, cpu_power, mem, root_disk, root_disk_source, instance_role, instance_type, container_type_id, virt_type, allocate_public_ip, image_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+		_, err := tx.ExecContext(ctx, addConstraintStmt, "constraint-uuid", "amd64", 2, 42, 8, 256, "root-disk-source", "instance-role", "instance-type", 1, "virt-type", true, "image-id")
+		if err != nil {
+			return err
+		}
+
+		addTag0ConsStmt := `INSERT INTO constraint_tag (constraint_uuid, tag) VALUES (?, ?)`
+		_, err = tx.ExecContext(ctx, addTag0ConsStmt, "constraint-uuid", "tag0")
+		if err != nil {
+			return err
+		}
+		addTag1ConsStmt := `INSERT INTO constraint_tag (constraint_uuid, tag) VALUES (?, ?)`
+		_, err = tx.ExecContext(ctx, addTag1ConsStmt, "constraint-uuid", "tag1")
+		if err != nil {
+			return err
+		}
+		addSpace0Stmt := `INSERT INTO space (uuid, name) VALUES (?, ?)`
+		_, err = tx.ExecContext(ctx, addSpace0Stmt, "space0-uuid", "space0")
+		if err != nil {
+			return err
+		}
+		addSpace1Stmt := `INSERT INTO space (uuid, name) VALUES (?, ?)`
+		_, err = tx.ExecContext(ctx, addSpace1Stmt, "space1-uuid", "space1")
+		if err != nil {
+			return err
+		}
+		addSpace0ConsStmt := `INSERT INTO constraint_space (constraint_uuid, space) VALUES (?, ?)`
+		_, err = tx.ExecContext(ctx, addSpace0ConsStmt, "constraint-uuid", "space0")
+		if err != nil {
+			return err
+		}
+		addSpace1ConsStmt := `INSERT INTO constraint_space (constraint_uuid, space) VALUES (?, ?)`
+		_, err = tx.ExecContext(ctx, addSpace1ConsStmt, "constraint-uuid", "space1")
+		if err != nil {
+			return err
+		}
+		addZone0ConsStmt := `INSERT INTO constraint_zone (constraint_uuid, zone) VALUES (?, ?)`
+		_, err = tx.ExecContext(ctx, addZone0ConsStmt, "constraint-uuid", "zone0")
+		if err != nil {
+			return err
+		}
+		addZone1ConsStmt := `INSERT INTO constraint_zone (constraint_uuid, zone) VALUES (?, ?)`
+		_, err = tx.ExecContext(ctx, addZone1ConsStmt, "constraint-uuid", "zone1")
+		if err != nil {
+			return err
+		}
+
+		addAppConstraintStmt := `INSERT INTO application_constraint (application_uuid, constraint_uuid) VALUES (?, ?)`
+		_, err = tx.ExecContext(ctx, addAppConstraintStmt, id, "constraint-uuid")
+		return err
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	cons, err := s.state.GetApplicationConstraints(context.Background(), id)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(*cons.Tags, jc.SameContents, []string{"tag0", "tag1"})
+	c.Check(*cons.Spaces, jc.SameContents, []string{"space0", "space1"})
+	c.Check(*cons.Zones, jc.SameContents, []string{"zone0", "zone1"})
+	c.Check(cons.Arch, jc.DeepEquals, ptr("amd64"))
+	c.Check(cons.CpuCores, jc.DeepEquals, ptr(uint64(2)))
+	c.Check(cons.CpuPower, jc.DeepEquals, ptr(uint64(42)))
+	c.Check(cons.Mem, jc.DeepEquals, ptr(uint64(8)))
+	c.Check(cons.RootDisk, jc.DeepEquals, ptr(uint64(256)))
+	c.Check(cons.RootDiskSource, jc.DeepEquals, ptr("root-disk-source"))
+	c.Check(cons.InstanceRole, jc.DeepEquals, ptr("instance-role"))
+	c.Check(cons.InstanceType, jc.DeepEquals, ptr("instance-type"))
+	c.Check(cons.Container, jc.DeepEquals, ptr(instance.LXD))
+	c.Check(cons.VirtType, jc.DeepEquals, ptr("virt-type"))
+	c.Check(cons.AllocatePublicIP, jc.DeepEquals, ptr(true))
+	c.Check(cons.ImageID, jc.DeepEquals, ptr("image-id"))
+}
+
+func (s *applicationStateSuite) TestConstraintPartial(c *gc.C) {
+	id := s.createApplication(c, "foo", life.Alive)
+
+	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		addConstraintStmt := `INSERT INTO "constraint" (uuid, arch, cpu_cores, allocate_public_ip, image_id) VALUES (?, ?, ?, ?, ?)`
+		_, err := tx.ExecContext(ctx, addConstraintStmt, "constraint-uuid", "amd64", 2, true, "image-id")
+		if err != nil {
+			return err
+		}
+		addAppConstraintStmt := `INSERT INTO application_constraint (application_uuid, constraint_uuid) VALUES (?, ?)`
+		_, err = tx.ExecContext(ctx, addAppConstraintStmt, id, "constraint-uuid")
+		return err
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	cons, err := s.state.GetApplicationConstraints(context.Background(), id)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(cons, jc.DeepEquals, constraints.Value{
+		Arch:             ptr("amd64"),
+		CpuCores:         ptr(uint64(2)),
+		AllocatePublicIP: ptr(true),
+		ImageID:          ptr("image-id"),
+	})
+}
+
+func (s *applicationStateSuite) TestConstraintEmpty(c *gc.C) {
+	id := s.createApplication(c, "foo", life.Alive)
+
+	cons, err := s.state.GetApplicationConstraints(context.Background(), id)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(cons, jc.DeepEquals, constraints.Value{})
+}
+
+func (s *applicationStateSuite) TestConstraintsApplicationNotFound(c *gc.C) {
+	_, err := s.state.GetApplicationConstraints(context.Background(), "foo")
+	c.Assert(err, jc.ErrorIs, applicationerrors.ApplicationNotFound)
+}
+
+func (s *applicationStateSuite) TestSetConstraintFull(c *gc.C) {
+	id := s.createApplication(c, "foo", life.Alive)
+
+	cons := constraints.Value{
+		Arch:             ptr("amd64"),
+		CpuCores:         ptr(uint64(2)),
+		CpuPower:         ptr(uint64(42)),
+		Mem:              ptr(uint64(8)),
+		RootDisk:         ptr(uint64(256)),
+		RootDiskSource:   ptr("root-disk-source"),
+		InstanceRole:     ptr("instance-role"),
+		InstanceType:     ptr("instance-type"),
+		Container:        ptr(instance.LXD),
+		VirtType:         ptr("virt-type"),
+		AllocatePublicIP: ptr(true),
+		ImageID:          ptr("image-id"),
+		Spaces:           ptr([]string{"space0", "space1"}),
+		Tags:             ptr([]string{"tag0", "tag1"}),
+		Zones:            ptr([]string{"zone0", "zone1"}),
+	}
+
+	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		insertSpace0Stmt := `INSERT INTO space (uuid, name) VALUES (?, ?)`
+		_, err := tx.ExecContext(ctx, insertSpace0Stmt, "space0-uuid", "space0")
+		if err != nil {
+			return err
+		}
+		insertSpace1Stmt := `INSERT INTO space (uuid, name) VALUES (?, ?)`
+		_, err = tx.ExecContext(ctx, insertSpace1Stmt, "space1-uuid", "space1")
+		return err
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.state.SetApplicationConstraints(context.Background(), id, cons)
+	c.Assert(err, jc.ErrorIsNil)
+
+	var (
+		applicationUUID                                                     string
+		constraintUUID                                                      string
+		constraintSpaces                                                    []string
+		constraintTags                                                      []string
+		constraintZones                                                     []string
+		arch, rootDiskSource, instanceRole, instanceType, virtType, imageID string
+		cpuCores, cpuPower, mem, rootDisk, containerTypeID                  int
+		allocatePublicIP                                                    bool
+	)
+	err = s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		err := tx.QueryRowContext(ctx, "SELECT application_uuid, constraint_uuid FROM application_constraint WHERE application_uuid=?", id).Scan(&applicationUUID, &constraintUUID)
+		if err != nil {
+			return err
+		}
+
+		rows, err := tx.QueryContext(ctx, "SELECT space FROM constraint_space WHERE constraint_uuid=?", constraintUUID)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var space string
+			if err := rows.Scan(&space); err != nil {
+				return err
+			}
+			constraintSpaces = append(constraintSpaces, space)
+		}
+		if rows.Err() != nil {
+			return rows.Err()
+		}
+
+		rows, err = tx.QueryContext(ctx, "SELECT tag FROM constraint_tag WHERE constraint_uuid=?", constraintUUID)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var tag string
+			if err := rows.Scan(&tag); err != nil {
+				return err
+			}
+			constraintTags = append(constraintTags, tag)
+		}
+		if rows.Err() != nil {
+			return rows.Err()
+		}
+
+		rows, err = tx.QueryContext(ctx, "SELECT zone FROM constraint_zone WHERE constraint_uuid=?", constraintUUID)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var zone string
+			if err := rows.Scan(&zone); err != nil {
+				return err
+			}
+			constraintZones = append(constraintZones, zone)
+		}
+
+		row := tx.QueryRowContext(ctx, "SELECT arch, cpu_cores, cpu_power, mem, root_disk, root_disk_source, instance_role, instance_type, container_type_id, virt_type, allocate_public_ip, image_id FROM \"constraint\" WHERE uuid=?", constraintUUID)
+		err = row.Err()
+		if err != nil {
+			return err
+		}
+		if err := row.Scan(&arch, &cpuCores, &cpuPower, &mem, &rootDisk, &rootDiskSource, &instanceRole, &instanceType, &containerTypeID, &virtType, &allocatePublicIP, &imageID); err != nil {
+			return err
+		}
+
+		return nil
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Check(constraintUUID, gc.Not(gc.Equals), "")
+	c.Check(applicationUUID, gc.Equals, id.String())
+
+	c.Check(arch, gc.Equals, "amd64")
+	c.Check(cpuCores, gc.Equals, 2)
+	c.Check(cpuPower, gc.Equals, 42)
+	c.Check(mem, gc.Equals, 8)
+	c.Check(rootDisk, gc.Equals, 256)
+	c.Check(rootDiskSource, gc.Equals, "root-disk-source")
+	c.Check(instanceRole, gc.Equals, "instance-role")
+	c.Check(instanceType, gc.Equals, "instance-type")
+	c.Check(containerTypeID, gc.Equals, 1)
+	c.Check(virtType, gc.Equals, "virt-type")
+	c.Check(allocatePublicIP, gc.Equals, true)
+	c.Check(imageID, gc.Equals, "image-id")
+
+	c.Check(constraintSpaces, jc.DeepEquals, []string{"space0", "space1"})
+	c.Check(constraintTags, jc.DeepEquals, []string{"tag0", "tag1"})
+	c.Check(constraintZones, jc.DeepEquals, []string{"zone0", "zone1"})
+
+}
+
+func (s *applicationStateSuite) TestSetConstraintInvalidContainerType(c *gc.C) {
+	id := s.createApplication(c, "foo", life.Alive)
+
+	cons := constraints.Value{
+		Container: ptr(instance.ContainerType("invalid-container-type")),
+	}
+	err := s.state.SetApplicationConstraints(context.Background(), id, cons)
+	c.Assert(err, jc.ErrorIs, applicationerrors.InvalidApplicationConstraints)
+}
+
+func (s *applicationStateSuite) TestSetConstraintInvalidSpace(c *gc.C) {
+	id := s.createApplication(c, "foo", life.Alive)
+
+	cons := constraints.Value{
+		Spaces: ptr([]string{"invalid-space"}),
+	}
+	err := s.state.SetApplicationConstraints(context.Background(), id, cons)
+	c.Assert(err, jc.ErrorIs, applicationerrors.InvalidApplicationConstraints)
+}
+
+func (s *applicationStateSuite) TestSetConstraintsReplacesPrevious(c *gc.C) {
+	id := s.createApplication(c, "foo", life.Alive)
+
+	err := s.state.SetApplicationConstraints(context.Background(), id, constraints.Value{
+		Mem:      ptr(uint64(8)),
+		CpuCores: ptr(uint64(2)),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	cons, err := s.state.GetApplicationConstraints(context.Background(), id)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(cons, gc.DeepEquals, constraints.Value{
+		Mem:      ptr(uint64(8)),
+		CpuCores: ptr(uint64(2)),
+	})
+
+	err = s.state.SetApplicationConstraints(context.Background(), id, constraints.Value{
+		CpuPower: ptr(uint64(42)),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	cons, err = s.state.GetApplicationConstraints(context.Background(), id)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(cons, gc.DeepEquals, constraints.Value{
+		CpuPower: ptr(uint64(42)),
+	})
+}
+
+func (s *applicationStateSuite) TestSetConstraintsReplacesPreviousZones(c *gc.C) {
+	id := s.createApplication(c, "foo", life.Alive)
+
+	err := s.state.SetApplicationConstraints(context.Background(), id, constraints.Value{
+		Zones: ptr([]string{"zone0", "zone1"}),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	cons, err := s.state.GetApplicationConstraints(context.Background(), id)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(*cons.Zones, jc.SameContents, []string{"zone0", "zone1"})
+
+	err = s.state.SetApplicationConstraints(context.Background(), id, constraints.Value{
+		Tags: ptr([]string{"tag0", "tag1"}),
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	cons, err = s.state.GetApplicationConstraints(context.Background(), id)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(*cons.Tags, jc.SameContents, []string{"tag0", "tag1"})
+}
+
+func (s *applicationStateSuite) TestSetConstraintsApplicationNotFound(c *gc.C) {
+	err := s.state.SetApplicationConstraints(context.Background(), "foo", constraints.Value{Mem: ptr(uint64(8))})
+	c.Assert(err, jc.ErrorIs, applicationerrors.ApplicationNotFound)
 }
 
 func (s *applicationStateSuite) assertApplication(

--- a/domain/application/state/types.go
+++ b/domain/application/state/types.go
@@ -696,3 +696,79 @@ type applicationConfigHash struct {
 	ApplicationUUID string `db:"application_uuid"`
 	SHA256          string `db:"sha256"`
 }
+
+// applicationConstraint represents a single returned row when joining the
+// constraint table with the constraint_space, constraint_tag and
+// constraint_zone.
+type applicationConstraint struct {
+	ApplicationUUID  string         `db:"application_uuid"`
+	Arch             sql.NullString `db:"arch"`
+	CPUCores         sql.NullInt64  `db:"cpu_cores"`
+	CPUPower         sql.NullInt64  `db:"cpu_power"`
+	Mem              sql.NullInt64  `db:"mem"`
+	RootDisk         sql.NullInt64  `db:"root_disk"`
+	RootDiskSource   sql.NullString `db:"root_disk_source"`
+	InstanceRole     sql.NullString `db:"instance_role"`
+	InstanceType     sql.NullString `db:"instance_type"`
+	ContainerType    sql.NullString `db:"container_type"`
+	VirtType         sql.NullString `db:"virt_type"`
+	AllocatePublicIP sql.NullBool   `db:"allocate_public_ip"`
+	ImageID          sql.NullString `db:"image_id"`
+	Space            sql.NullString `db:"space"`
+	Tag              sql.NullString `db:"tag"`
+	Zone             sql.NullString `db:"zone"`
+}
+
+type applicationConstraints []applicationConstraint
+
+type setApplicationConstraint struct {
+	ApplicationUUID string `db:"application_uuid"`
+	ConstraintUUID  string `db:"constraint_uuid"`
+}
+
+type setConstraint struct {
+	UUID             string  `db:"uuid"`
+	Arch             *string `db:"arch"`
+	CPUCores         *uint64 `db:"cpu_cores"`
+	CPUPower         *uint64 `db:"cpu_power"`
+	Mem              *uint64 `db:"mem"`
+	RootDisk         *uint64 `db:"root_disk"`
+	RootDiskSource   *string `db:"root_disk_source"`
+	InstanceRole     *string `db:"instance_role"`
+	InstanceType     *string `db:"instance_type"`
+	ContainerTypeID  *uint64 `db:"container_type_id"`
+	VirtType         *string `db:"virt_type"`
+	AllocatePublicIP *bool   `db:"allocate_public_ip"`
+	ImageID          *string `db:"image_id"`
+}
+
+type containerTypeID struct {
+	ID uint64 `db:"id"`
+}
+
+type containerTypeVal struct {
+	Value string `db:"value"`
+}
+
+type setConstraintTag struct {
+	ConstraintUUID string `db:"constraint_uuid"`
+	Tag            string `db:"tag"`
+}
+
+type setConstraintSpace struct {
+	ConstraintUUID string `db:"constraint_uuid"`
+	Space          string `db:"space"`
+}
+
+type setConstraintZone struct {
+	ConstraintUUID string `db:"constraint_uuid"`
+	Zone           string `db:"zone"`
+}
+
+type applicationUUID struct {
+	ApplicationUUID string `db:"application_uuid"`
+}
+
+type constraintUUID struct {
+	ConstraintUUID string `db:"constraint_uuid"`
+}

--- a/domain/application/state/types.go
+++ b/domain/application/state/types.go
@@ -772,3 +772,12 @@ type applicationUUID struct {
 type constraintUUID struct {
 	ConstraintUUID string `db:"constraint_uuid"`
 }
+
+// These structs are only needed to check existence before adding constraints.
+type spaceName struct {
+	Name string `db:"name"`
+}
+
+type spaceUUID struct {
+	UUID string `db:"uuid"`
+}

--- a/domain/schema/model/sql/0014-constraint.sql
+++ b/domain/schema/model/sql/0014-constraint.sql
@@ -1,3 +1,7 @@
+-- The allocate_public_ip column shold have been a (nullable) boolean, but
+-- there is currently a bug somewhere between dqlite and go-dqlite that returns
+-- a false boolean instead a null. Since the driver will correctly map a INT
+-- to a boolean, then we can safely use it here as a workaround.
 CREATE TABLE "constraint" (
     uuid TEXT NOT NULL PRIMARY KEY,
     arch TEXT,
@@ -10,12 +14,12 @@ CREATE TABLE "constraint" (
     instance_type TEXT,
     container_type_id INT,
     virt_type TEXT,
-    allocate_public_ip BOOLEAN,
+    allocate_public_ip INT,
     image_id TEXT,
     CONSTRAINT fk_constraint_container_type
     FOREIGN KEY (container_type_id)
     REFERENCES container_type (id)
-);
+) STRICT;
 
 -- v_constraint represents a view of the constraints in the model with foreign
 -- keys resolved for the viewer.

--- a/domain/schema/model/sql/0018-application.sql
+++ b/domain/schema/model/sql/0018-application.sql
@@ -154,3 +154,28 @@ CREATE TABLE application_channel (
     REFERENCES application (uuid),
     PRIMARY KEY (application_uuid, track, risk, branch)
 );
+
+CREATE VIEW v_application_constraint AS
+SELECT
+    ac.application_uuid,
+    c.arch,
+    c.cpu_cores,
+    c.cpu_power,
+    c.mem,
+    c.root_disk,
+    c.root_disk_source,
+    c.instance_role,
+    c.instance_type,
+    ctype.value AS container_type,
+    c.virt_type,
+    c.allocate_public_ip,
+    c.image_id,
+    ctag.tag,
+    cspace.space,
+    czone.zone
+FROM application_constraint AS ac
+INNER JOIN "constraint" AS c ON ac.constraint_uuid = c.uuid
+LEFT JOIN container_type AS ctype ON c.container_type_id = ctype.id
+LEFT JOIN constraint_tag AS ctag ON c.uuid = ctag.constraint_uuid
+LEFT JOIN constraint_space AS cspace ON c.uuid = cspace.constraint_uuid
+LEFT JOIN constraint_zone AS czone ON c.uuid = czone.constraint_uuid;

--- a/domain/schema/model_schema_test.go
+++ b/domain/schema/model_schema_test.go
@@ -288,6 +288,7 @@ func (s *modelSchemaSuite) TestModelViews(c *gc.C) {
 		"v_application_charm_download_info",
 		"v_application_config",
 		"v_application_resource",
+		"v_application_constraint",
 		"v_charm_annotation_index",
 		"v_charm_config",
 		"v_charm_container",


### PR DESCRIPTION
This patch implements the state layer in the application domain for application constraints.
Only two methods are needed:
- GetApplicationConstraints
- SetApplicationConstraints

It must be noted that in the case of referential integrity errors (i.e. foreign key constraint errors), the method will return a bespoke error. This was not how juju worked up until 4.0, instead the constraints were accepted but the machine was never started and errors were logged.

<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://github.com/juju/juju/blob/main/doc/conventional-commits.md
-->

<!-- Why this change is needed and what it does. -->


## QA steps

Nothing wired yet, just unit tests must pass.

## Links


**Jira card:** JUJU-7417

