### PR TITLE
refactor(refresh): improve local refresh name checks

### DIFF
--- a/cmd/juju/application/refresh_test.go
+++ b/cmd/juju/application/refresh_test.go
@@ -1325,7 +1325,7 @@ func (s *RefreshSuccessStateSuite) TestCharmPathDifferentNameFails(c *gc.C) {
 		c.Fatal("cannot write to metadata.yaml")
 	}
 	_, err = s.runRefresh(c, s.cmd, "riak", "--path", myriakPath)
-	c.Assert(err, gc.ErrorMatches, `cannot refresh "riak" to "myriak"`)
+	c.Assert(err, gc.ErrorMatches, `(?m).*refreshing "local:riak-7" to "local:myriak-7".*is not supported.*`)
 }
 
 type mockAPIConnection struct {


### PR DESCRIPTION
Juju does not allow refreshing charms to change the actual charm itself.

This is easy to enforce for charmhub, since we only allow refreshing to change the channel, revision, etc. of the same charm in charmhub.

However, for local charm, which are user-controlled opaque-ish blobs to the CLI, this is not possible to do so with rigour. A user could put anything they like in a blob, so it's up to best guess.

One of the safety guard we put in place is we check the name of the charm has not changed. We do this by querying the controller for the charm url, and comparing that to the name of our local charm in metadata.

However, charmhub charms are not necessarily named the same in charmhub as they are in their metadata. For instance, juju-qa-dummy-subordinate has that name in charmhub, but the name in metadata is just dummy-subordinate. That means we cannot refresh the charm, even to an identical local copy of itself.

This could be improved by querying the controller instead for the name in metadata, not the charm url, but that is simply not worth it, since we'd need a new facade endpoint for this very niche scenerio.

Instead, I have simply improved the warning, and allow you to skip the check by using the pre-existing --force flag.

## QA steps

```
$ juju bootstrap lxd lxd
$ juju add-model default
$ juju deploy juju-qa-test
$ juju deploy juju-qa-dummy-subordinate
$ juju integrate juju-qa-test dummy-subordinate
$ juju status
Model    Controller  Cloud/Region         Version  SLA          Timestamp
default  lxd         localhost/localhost  3.6.3.1  unsupported  13:10:08Z

App                Version  Status       Scale  Charm                      Channel        Rev  Exposed  Message
dummy-subordinate           maintenance      1  juju-qa-dummy-subordinate  latest/stable    5  no       Started
juju-qa-test                active           1  juju-qa-test               latest/stable   25  no       hello

Unit                    Workload     Agent  Machine  Public address  Ports  Message
juju-qa-test/0*         active       idle   0        10.51.45.161           hello
  dummy-subordinate/0*  maintenance  idle            10.51.45.161           Started

Machine  State    Address       Inst id        Base          AZ  Message
0        started  10.51.45.161  juju-452e94-0  ubuntu@20.04      Running

$ juju download juju-qa-dummy-subordinate
Base "ubuntu@24.04" is not supported for charm "juju-qa-dummy-subordinate", trying base "ubuntu@20.04"
Fetching charm "juju-qa-dummy-subordinate" revision 5 using "stable" channel and base "amd64/ubuntu/20.04"
Install the "juju-qa-dummy-subordinate" charm with:
    juju deploy ./juju-qa-dummy-subordinate_r5.charm

$ juju refresh dummy-subordinate --path ./juju-qa-dummy-subordinate_r5.charm
$ juju refresh dummy-subordinate --path ./juju-qa-dummy-subordinate_r5.charm
ERROR By refreshing "ch:amd64/juju-qa-dummy-subordinate-5" to "local:dummy-subordinate-0" it looks like you're changing the charm itself, which is not supported.

Use the --force flag to override.
$ juju refresh dummy-subordinate --path ./juju-qa-dummy-subordinate_r5.charm --force
Added local charm "dummy-subordinate", revision 0, to the model
no change to endpoint in space "alpha": sink
```
