### PR TITLE
feat: wire up credential invalidator

### DIFF
--- a/apiserver/common/environ_config.go
+++ b/apiserver/common/environ_config.go
@@ -28,6 +28,6 @@ func EnvironFuncForModel(model stateenvirons.Model, cloudService CloudService,
 		}
 	}
 	return func(ctx context.Context) (environs.BootstrapEnviron, error) {
-		return environs.GetEnviron(ctx, configGetter, environs.New)
+		return environs.GetEnviron(ctx, configGetter, environs.NoopEnvironCredentialInvalidator{}, environs.New)
 	}
 }

--- a/apiserver/facades/agent/provisioner/provisioner.go
+++ b/apiserver/facades/agent/provisioner/provisioner.go
@@ -153,7 +153,7 @@ func MakeProvisionerAPI(stdCtx context.Context, ctx facade.ModelContext) (*Provi
 	if isCaasModel {
 		env, err = stateenvirons.GetNewCAASBrokerFunc(caas.New)(model, domainServices.Cloud(), domainServices.Credential(), domainServices.Config())
 	} else {
-		env, err = environs.GetEnviron(stdCtx, configGetter, environs.New)
+		env, err = environs.GetEnviron(stdCtx, configGetter, environs.NoopEnvironCredentialInvalidator{}, environs.New)
 	}
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -215,7 +215,7 @@ func MakeProvisionerAPI(stdCtx context.Context, ctx facade.ModelContext) (*Provi
 	}
 
 	newEnviron := func(ctx context.Context) (environs.BootstrapEnviron, error) {
-		return environs.GetEnviron(ctx, configGetter, environs.New)
+		return environs.GetEnviron(ctx, configGetter, environs.NoopEnvironCredentialInvalidator{}, environs.New)
 	}
 
 	api.InstanceIdGetter = common.NewInstanceIdGetter(domainServices.Machine(), getAuthFunc)
@@ -1104,7 +1104,7 @@ func (api *ProvisionerAPI) prepareOrGetContainerInterfaceInfo(
 // prepareContainerAccessEnvironment retrieves the environment, host machine, and access
 // for working with containers.
 func (api *ProvisionerAPI) prepareContainerAccessEnvironment(ctx context.Context) (environs.Environ, *state.Machine, common.AuthFunc, error) {
-	env, err := environs.GetEnviron(ctx, api.configGetter, environs.New)
+	env, err := environs.GetEnviron(ctx, api.configGetter, environs.NoopEnvironCredentialInvalidator{}, environs.New)
 	if err != nil {
 		return nil, nil, nil, errors.Trace(err)
 	}

--- a/apiserver/facades/agent/provisioner/provisioninginfo.go
+++ b/apiserver/facades/agent/provisioner/provisioninginfo.go
@@ -46,7 +46,7 @@ func (api *ProvisionerAPI) ProvisioningInfo(ctx context.Context, args params.Ent
 		return result, errors.Trace(err)
 	}
 
-	env, err := environs.GetEnviron(ctx, api.configGetter, environs.New)
+	env, err := environs.GetEnviron(ctx, api.configGetter, environs.NoopEnvironCredentialInvalidator{}, environs.New)
 	if err != nil {
 		return result, errors.Annotate(err, "retrieving environ")
 	}

--- a/apiserver/facades/client/subnets/cache.go
+++ b/apiserver/facades/client/subnets/cache.go
@@ -79,7 +79,7 @@ func updateZones(ctx envcontext.ProviderCallContext, api Backing) (network.Avail
 // model config. If the model does not support zones, an error satisfying
 // errors.IsNotSupported() will be returned.
 func zonedEnviron(ctx context.Context, api Backing) (providercommon.ZonedEnviron, error) {
-	env, err := environs.GetEnviron(ctx, api, environs.New)
+	env, err := environs.GetEnviron(ctx, api, environs.NoopEnvironCredentialInvalidator{}, environs.New)
 	if err != nil {
 		return nil, errors.Annotate(err, "opening environment")
 	}

--- a/domain/credential/service/providerservice.go
+++ b/domain/credential/service/providerservice.go
@@ -17,10 +17,16 @@ import (
 
 // ProviderState describes retrieval and persistence methods for storage.
 type ProviderState interface {
-	// CloudCredential returns the cloud credential for the given name, cloud, owner.
+	// CloudCredential returns the cloud credential for the given name, cloud,
+	// owner.
 	CloudCredential(ctx context.Context, key corecredential.Key) (credential.CloudCredentialResult, error)
 
-	// WatchCredential returns a new NotifyWatcher watching for changes to the specified credential.
+	// InvalidateCloudCredential marks the cloud credential for the given name,
+	// cloud, owner as invalid.
+	InvalidateCloudCredential(ctx context.Context, key corecredential.Key, reason string) error
+
+	// WatchCredential returns a new NotifyWatcher watching for changes to the
+	// specified credential.
 	WatchCredential(
 		ctx context.Context,
 		getWatcher func(string, string, changestream.ChangeType) (watcher.NotifyWatcher, error),
@@ -57,6 +63,15 @@ func (s *ProviderService) CloudCredential(ctx context.Context, key corecredentia
 	cred.Invalid = credInfo.Invalid
 	cred.InvalidReason = credInfo.InvalidReason
 	return cred, nil
+}
+
+// InvalidateCredential marks the cloud credential for the given name, cloud,
+// owner as invalid.
+func (s *ProviderService) InvalidateCredential(ctx context.Context, key corecredential.Key, reason string) error {
+	if err := key.Validate(); err != nil {
+		return errors.Annotatef(err, "invalid id invalidating cloud credential")
+	}
+	return s.st.InvalidateCloudCredential(ctx, key, reason)
 }
 
 // WatchableProviderService provides the API for working with credentials and

--- a/environs/environ.go
+++ b/environs/environ.go
@@ -16,6 +16,7 @@ import (
 type EnvironConfigGetter interface {
 	ModelConfig(context.Context) (*config.Config, error)
 	CloudSpec(context.Context) (environscloudspec.CloudSpec, error)
+	CredentialInvalidator() ModelCredentialInvalidator
 }
 
 // NewEnvironFunc is the type of a function that, given a model config,
@@ -44,8 +45,9 @@ func GetEnvironAndCloud(ctx context.Context, getter EnvironConfigGetter, newEnvi
 	}
 
 	env, err := newEnviron(ctx, OpenParams{
-		Cloud:  cloudSpec,
-		Config: modelConfig,
+		Cloud:                 cloudSpec,
+		Config:                modelConfig,
+		CredentialInvalidator: getter.CredentialInvalidator(),
 	})
 	if err != nil {
 		return nil, nil, errors.Annotatef(

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -87,6 +87,20 @@ type CloudEnvironProvider interface {
 	Open(context.Context, OpenParams) (Environ, error)
 }
 
+// InvalidationReason is a reason for invalidating a credential.
+type InvalidationReason string
+
+func (r InvalidationReason) String() string {
+	return string(r)
+}
+
+// ModelCredentialInvalidator defines a point of use interface for invalidating
+// a model credential.
+type ModelCredentialInvalidator interface {
+	// InvalidateModelCredential invalidate cloud credential for the model.
+	InvalidateModelCredential(context.Context, InvalidationReason) error
+}
+
 // OpenParams contains the parameters for EnvironProvider.Open.
 type OpenParams struct {
 	// ControllerUUID is the controller UUID.
@@ -97,6 +111,12 @@ type OpenParams struct {
 
 	// Config is the base configuration for the provider.
 	Config *config.Config
+
+	// CredentialInvalidator is used to invalidate any credentials
+	// that are no longer valid. It is the responsibility of the
+	// provider to call this function when a credential is no longer
+	// valid.
+	CredentialInvalidator ModelCredentialInvalidator
 }
 
 // ProviderSchema can be implemented by a provider to provide

--- a/internal/provider/common/errors.go
+++ b/internal/provider/common/errors.go
@@ -41,13 +41,13 @@ var AuthorisationFailureStatusCodes = set.NewInts(
 
 // HandleCredentialError determines if a given error relates to an invalid credential.
 // If it is, the credential is invalidated and the return bool is true.
-func HandleCredentialError(isAuthError func(error) bool, err error, ctx envcontext.ProviderCallContext) bool {
+func HandleCredentialError(ctx context.Context, isAuthError func(error) bool, err error, providerContext envcontext.ProviderCallContext) bool {
 	denied := isAuthError(errors.Cause(err))
 	if denied {
 		converted := fmt.Errorf("cloud denied access: %w", CredentialNotValidError(err))
-		invalidateErr := ctx.InvalidateCredential(converted.Error())
+		invalidateErr := providerContext.InvalidateCredential(converted.Error())
 		if invalidateErr != nil {
-			logger.Warningf(context.TODO(), "could not invalidate stored cloud credential on the controller: %v", invalidateErr)
+			logger.Warningf(ctx, "could not invalidate stored cloud credential on the controller: %v", invalidateErr)
 		}
 	}
 	return denied

--- a/internal/provider/common/errors.go
+++ b/internal/provider/common/errors.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/collections/set"
 	"github.com/juju/errors"
 
+	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/envcontext"
 )
 
@@ -55,4 +56,13 @@ func MaybeHandleCredentialError(isAuthError func(error) bool, err error, ctx env
 // HandleCredentialError determines if a given error relates to an invalid credential.
 func HandleCredentialError(isAuthError func(error) bool, err error, ctx envcontext.ProviderCallContext) {
 	MaybeHandleCredentialError(isAuthError, err, ctx)
+}
+
+// CredentialInvalidatorContext returns a provider call context.
+// This is a stop gap until we can remove all the ProviderCallContexts.
+// Deprecated: this should be removed.
+func CredentialInvalidatorContext(ctx context.Context, invalidator environs.ModelCredentialInvalidator) envcontext.ProviderCallContext {
+	return envcontext.WithCredentialInvalidator(ctx, func(ctx context.Context, reason string) error {
+		return invalidator.InvalidateModelCredential(ctx, environs.InvalidationReason(reason))
+	})
 }

--- a/internal/provider/common/errors.go
+++ b/internal/provider/common/errors.go
@@ -39,9 +39,9 @@ var AuthorisationFailureStatusCodes = set.NewInts(
 	http.StatusProxyAuthRequired,
 )
 
-// MaybeHandleCredentialError determines if a given error relates to an invalid credential.
+// HandleCredentialError determines if a given error relates to an invalid credential.
 // If it is, the credential is invalidated and the return bool is true.
-func MaybeHandleCredentialError(isAuthError func(error) bool, err error, ctx envcontext.ProviderCallContext) bool {
+func HandleCredentialError(isAuthError func(error) bool, err error, ctx envcontext.ProviderCallContext) bool {
 	denied := isAuthError(errors.Cause(err))
 	if denied {
 		converted := fmt.Errorf("cloud denied access: %w", CredentialNotValidError(err))
@@ -51,11 +51,6 @@ func MaybeHandleCredentialError(isAuthError func(error) bool, err error, ctx env
 		}
 	}
 	return denied
-}
-
-// HandleCredentialError determines if a given error relates to an invalid credential.
-func HandleCredentialError(isAuthError func(error) bool, err error, ctx envcontext.ProviderCallContext) {
-	MaybeHandleCredentialError(isAuthError, err, ctx)
 }
 
 // CredentialInvalidatorContext returns a provider call context.

--- a/internal/provider/common/errors_test.go
+++ b/internal/provider/common/errors_test.go
@@ -67,7 +67,7 @@ func (s *ErrorsSuite) TestNoValidation(c *gc.C) {
 	isAuthF := func(e error) bool {
 		return true
 	}
-	denied := common.MaybeHandleCredentialError(isAuthF, authFailureError, envcontext.WithoutCredentialInvalidator(context.Background()))
+	denied := common.HandleCredentialError(isAuthF, authFailureError, envcontext.WithoutCredentialInvalidator(context.Background()))
 	c.Assert(c.GetTestLog(), jc.DeepEquals, "")
 	c.Assert(denied, jc.IsTrue)
 }
@@ -79,7 +79,7 @@ func (s *ErrorsSuite) TestInvalidationCallbackErrorOnlyLogs(c *gc.C) {
 	ctx := envcontext.WithCredentialInvalidator(context.Background(), func(_ context.Context, msg string) error {
 		return errors.New("kaboom")
 	})
-	denied := common.MaybeHandleCredentialError(isAuthF, authFailureError, ctx)
+	denied := common.HandleCredentialError(isAuthF, authFailureError, ctx)
 	c.Assert(c.GetTestLog(), jc.Contains, "could not invalidate stored cloud credential on the controller")
 	c.Assert(denied, jc.IsTrue)
 }
@@ -113,7 +113,7 @@ func (s *ErrorsSuite) checkPermissionHandling(c *gc.C, e error, handled bool) {
 		return nil
 	})
 
-	denied := common.MaybeHandleCredentialError(isAuthF, e, ctx)
+	denied := common.HandleCredentialError(isAuthF, e, ctx)
 	c.Assert(called, gc.Equals, handled)
 	c.Assert(denied, gc.Equals, handled)
 }

--- a/internal/provider/common/errors_test.go
+++ b/internal/provider/common/errors_test.go
@@ -67,7 +67,7 @@ func (s *ErrorsSuite) TestNoValidation(c *gc.C) {
 	isAuthF := func(e error) bool {
 		return true
 	}
-	denied := common.HandleCredentialError(isAuthF, authFailureError, envcontext.WithoutCredentialInvalidator(context.Background()))
+	denied := common.HandleCredentialError(context.Background(), isAuthF, authFailureError, envcontext.WithoutCredentialInvalidator(context.Background()))
 	c.Assert(c.GetTestLog(), jc.DeepEquals, "")
 	c.Assert(denied, jc.IsTrue)
 }
@@ -79,7 +79,7 @@ func (s *ErrorsSuite) TestInvalidationCallbackErrorOnlyLogs(c *gc.C) {
 	ctx := envcontext.WithCredentialInvalidator(context.Background(), func(_ context.Context, msg string) error {
 		return errors.New("kaboom")
 	})
-	denied := common.HandleCredentialError(isAuthF, authFailureError, ctx)
+	denied := common.HandleCredentialError(context.Background(), isAuthF, authFailureError, ctx)
 	c.Assert(c.GetTestLog(), jc.Contains, "could not invalidate stored cloud credential on the controller")
 	c.Assert(denied, jc.IsTrue)
 }
@@ -113,7 +113,7 @@ func (s *ErrorsSuite) checkPermissionHandling(c *gc.C, e error, handled bool) {
 		return nil
 	})
 
-	denied := common.HandleCredentialError(isAuthF, e, ctx)
+	denied := common.HandleCredentialError(context.Background(), isAuthF, e, ctx)
 	c.Assert(called, gc.Equals, handled)
 	c.Assert(denied, gc.Equals, handled)
 }

--- a/internal/provider/lxd/environ.go
+++ b/internal/provider/lxd/environ.go
@@ -226,12 +226,12 @@ func (env *environ) Bootstrap(ctx environs.BootstrapContext, callCtx envcontext.
 // known environment.
 func (env *environ) Destroy(ctx envcontext.ProviderCallContext) error {
 	if err := env.base.DestroyEnv(ctx); err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, common.CredentialInvalidatorContext(ctx, env.credentialInvalidator))
+		common.HandleCredentialError(ctx, IsAuthorisationFailure, err, common.CredentialInvalidatorContext(ctx, env.credentialInvalidator))
 		return errors.Trace(err)
 	}
 	if env.storageSupported() {
 		if err := destroyModelFilesystems(env); err != nil {
-			common.HandleCredentialError(IsAuthorisationFailure, err, common.CredentialInvalidatorContext(ctx, env.credentialInvalidator))
+			common.HandleCredentialError(ctx, IsAuthorisationFailure, err, common.CredentialInvalidatorContext(ctx, env.credentialInvalidator))
 			return errors.Annotate(err, "destroying LXD filesystems for model")
 		}
 	}
@@ -244,12 +244,12 @@ func (env *environ) DestroyController(ctx envcontext.ProviderCallContext, contro
 		return errors.Trace(err)
 	}
 	if err := env.destroyHostedModelResources(controllerUUID); err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, common.CredentialInvalidatorContext(ctx, env.credentialInvalidator))
+		common.HandleCredentialError(ctx, IsAuthorisationFailure, err, common.CredentialInvalidatorContext(ctx, env.credentialInvalidator))
 		return errors.Trace(err)
 	}
 	if env.storageSupported() {
 		if err := destroyControllerFilesystems(env, controllerUUID); err != nil {
-			common.HandleCredentialError(IsAuthorisationFailure, err, common.CredentialInvalidatorContext(ctx, env.credentialInvalidator))
+			common.HandleCredentialError(ctx, IsAuthorisationFailure, err, common.CredentialInvalidatorContext(ctx, env.credentialInvalidator))
 			return errors.Annotate(err, "destroying LXD filesystems for controller")
 		}
 	}
@@ -315,7 +315,7 @@ func (env *environ) AvailabilityZones(ctx envcontext.ProviderCallContext) (netwo
 
 	nodes, err := server.GetClusterMembers()
 	if err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		common.HandleCredentialError(ctx, IsAuthorisationFailure, err, ctx)
 		return nil, errors.Annotate(err, "listing cluster members")
 	}
 	aZones := make(network.AvailabilityZones, len(nodes))

--- a/internal/provider/lxd/environ.go
+++ b/internal/provider/lxd/environ.go
@@ -226,12 +226,12 @@ func (env *environ) Bootstrap(ctx environs.BootstrapContext, callCtx envcontext.
 // known environment.
 func (env *environ) Destroy(ctx envcontext.ProviderCallContext) error {
 	if err := env.base.DestroyEnv(ctx); err != nil {
-		common.HandleCredentialError(ctx, IsAuthorisationFailure, err, common.CredentialInvalidatorContext(ctx, env.credentialInvalidator))
+		common.HandleCredentialError(ctx, env.credentialInvalidator, IsAuthorisationFailure, err)
 		return errors.Trace(err)
 	}
 	if env.storageSupported() {
 		if err := destroyModelFilesystems(env); err != nil {
-			common.HandleCredentialError(ctx, IsAuthorisationFailure, err, common.CredentialInvalidatorContext(ctx, env.credentialInvalidator))
+			common.HandleCredentialError(ctx, env.credentialInvalidator, IsAuthorisationFailure, err)
 			return errors.Annotate(err, "destroying LXD filesystems for model")
 		}
 	}
@@ -244,12 +244,12 @@ func (env *environ) DestroyController(ctx envcontext.ProviderCallContext, contro
 		return errors.Trace(err)
 	}
 	if err := env.destroyHostedModelResources(controllerUUID); err != nil {
-		common.HandleCredentialError(ctx, IsAuthorisationFailure, err, common.CredentialInvalidatorContext(ctx, env.credentialInvalidator))
+		common.HandleCredentialError(ctx, env.credentialInvalidator, IsAuthorisationFailure, err)
 		return errors.Trace(err)
 	}
 	if env.storageSupported() {
 		if err := destroyControllerFilesystems(env, controllerUUID); err != nil {
-			common.HandleCredentialError(ctx, IsAuthorisationFailure, err, common.CredentialInvalidatorContext(ctx, env.credentialInvalidator))
+			common.HandleCredentialError(ctx, env.credentialInvalidator, IsAuthorisationFailure, err)
 			return errors.Annotate(err, "destroying LXD filesystems for controller")
 		}
 	}
@@ -315,7 +315,7 @@ func (env *environ) AvailabilityZones(ctx envcontext.ProviderCallContext) (netwo
 
 	nodes, err := server.GetClusterMembers()
 	if err != nil {
-		common.HandleCredentialError(ctx, IsAuthorisationFailure, err, ctx)
+		common.HandleCredentialError(ctx, env.credentialInvalidator, IsAuthorisationFailure, err)
 		return nil, errors.Annotate(err, "listing cluster members")
 	}
 	aZones := make(network.AvailabilityZones, len(nodes))

--- a/internal/provider/lxd/environ_broker.go
+++ b/internal/provider/lxd/environ_broker.go
@@ -40,7 +40,7 @@ func (env *environ) StartInstance(
 
 	container, err := env.newContainer(ctx, args, arch, virtType)
 	if err != nil {
-		common.HandleCredentialError(ctx, IsAuthorisationFailure, err, ctx)
+		common.HandleCredentialError(ctx, env.credentialInvalidator, IsAuthorisationFailure, err)
 		if args.StatusCallback != nil {
 			_ = args.StatusCallback(ctx, status.ProvisioningError, err.Error(), nil)
 		}
@@ -447,7 +447,7 @@ func (env *environ) StopInstances(ctx envcontext.ProviderCallContext, instances 
 
 	err := env.server().RemoveContainers(names)
 	if err != nil {
-		common.HandleCredentialError(ctx, IsAuthorisationFailure, err, ctx)
+		common.HandleCredentialError(ctx, env.credentialInvalidator, IsAuthorisationFailure, err)
 	}
 	return errors.Trace(err)
 }

--- a/internal/provider/lxd/environ_broker.go
+++ b/internal/provider/lxd/environ_broker.go
@@ -40,7 +40,7 @@ func (env *environ) StartInstance(
 
 	container, err := env.newContainer(ctx, args, arch, virtType)
 	if err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		common.HandleCredentialError(ctx, IsAuthorisationFailure, err, ctx)
 		if args.StatusCallback != nil {
 			_ = args.StatusCallback(ctx, status.ProvisioningError, err.Error(), nil)
 		}
@@ -447,7 +447,7 @@ func (env *environ) StopInstances(ctx envcontext.ProviderCallContext, instances 
 
 	err := env.server().RemoveContainers(names)
 	if err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		common.HandleCredentialError(ctx, IsAuthorisationFailure, err, ctx)
 	}
 	return errors.Trace(err)
 }

--- a/internal/provider/lxd/environ_instance.go
+++ b/internal/provider/lxd/environ_instance.go
@@ -35,7 +35,7 @@ func (env *environ) Instances(ctx envcontext.ProviderCallContext, ids []instance
 		// will return either ErrPartialInstances or ErrNoInstances.
 		// TODO(ericsnow) Skip returning here only for certain errors?
 		logger.Errorf(context.TODO(), "failed to get instances from LXD: %v", err)
-		common.HandleCredentialError(ctx, IsAuthorisationFailure, err, ctx)
+		common.HandleCredentialError(ctx, env.credentialInvalidator, IsAuthorisationFailure, err)
 		err = errors.Trace(err)
 	}
 
@@ -100,7 +100,7 @@ func (env *environ) prefixedInstances(prefix string) ([]*environInstance, error)
 func (env *environ) ControllerInstances(ctx envcontext.ProviderCallContext, controllerUUID string) ([]instance.Id, error) {
 	containers, err := env.server().AliveContainers("juju-")
 	if err != nil {
-		common.HandleCredentialError(ctx, IsAuthorisationFailure, err, ctx)
+		common.HandleCredentialError(ctx, env.credentialInvalidator, IsAuthorisationFailure, err)
 		return nil, errors.Trace(err)
 	}
 
@@ -124,7 +124,7 @@ func (env *environ) ControllerInstances(ctx envcontext.ProviderCallContext, cont
 func (env *environ) AdoptResources(ctx envcontext.ProviderCallContext, controllerUUID string, fromVersion version.Number) error {
 	instances, err := env.AllInstances(ctx)
 	if err != nil {
-		common.HandleCredentialError(ctx, IsAuthorisationFailure, err, ctx)
+		common.HandleCredentialError(ctx, env.credentialInvalidator, IsAuthorisationFailure, err)
 		return errors.Annotate(err, "all instances")
 	}
 

--- a/internal/provider/lxd/environ_instance.go
+++ b/internal/provider/lxd/environ_instance.go
@@ -35,7 +35,7 @@ func (env *environ) Instances(ctx envcontext.ProviderCallContext, ids []instance
 		// will return either ErrPartialInstances or ErrNoInstances.
 		// TODO(ericsnow) Skip returning here only for certain errors?
 		logger.Errorf(context.TODO(), "failed to get instances from LXD: %v", err)
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		common.HandleCredentialError(ctx, IsAuthorisationFailure, err, ctx)
 		err = errors.Trace(err)
 	}
 
@@ -100,7 +100,7 @@ func (env *environ) prefixedInstances(prefix string) ([]*environInstance, error)
 func (env *environ) ControllerInstances(ctx envcontext.ProviderCallContext, controllerUUID string) ([]instance.Id, error) {
 	containers, err := env.server().AliveContainers("juju-")
 	if err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		common.HandleCredentialError(ctx, IsAuthorisationFailure, err, ctx)
 		return nil, errors.Trace(err)
 	}
 
@@ -124,7 +124,7 @@ func (env *environ) ControllerInstances(ctx envcontext.ProviderCallContext, cont
 func (env *environ) AdoptResources(ctx envcontext.ProviderCallContext, controllerUUID string, fromVersion version.Number) error {
 	instances, err := env.AllInstances(ctx)
 	if err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		common.HandleCredentialError(ctx, IsAuthorisationFailure, err, ctx)
 		return errors.Annotate(err, "all instances")
 	}
 

--- a/internal/provider/lxd/provider.go
+++ b/internal/provider/lxd/provider.go
@@ -153,6 +153,7 @@ func (p *environProvider) Open(ctx context.Context, args environs.OpenParams) (e
 		p,
 		args.Cloud,
 		args.Config,
+		args.CredentialInvalidator,
 	)
 	return env, errors.Trace(err)
 }

--- a/internal/provider/lxd/storage.go
+++ b/internal/provider/lxd/storage.go
@@ -246,7 +246,7 @@ func (s *lxdFilesystemSource) CreateFilesystems(ctx envcontext.ProviderCallConte
 		filesystem, err := s.createFilesystem(arg)
 		if err != nil {
 			results[i].Error = err
-			common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+			common.HandleCredentialError(ctx, IsAuthorisationFailure, err, ctx)
 			continue
 		}
 		results[i].Filesystem = filesystem
@@ -359,7 +359,7 @@ func (s *lxdFilesystemSource) DestroyFilesystems(ctx envcontext.ProviderCallCont
 	results := make([]error, len(filesystemIds))
 	for i, filesystemId := range filesystemIds {
 		results[i] = s.destroyFilesystem(filesystemId)
-		common.HandleCredentialError(IsAuthorisationFailure, results[i], ctx)
+		common.HandleCredentialError(ctx, IsAuthorisationFailure, results[i], ctx)
 	}
 	return results, nil
 }
@@ -381,7 +381,7 @@ func (s *lxdFilesystemSource) ReleaseFilesystems(ctx envcontext.ProviderCallCont
 	results := make([]error, len(filesystemIds))
 	for i, filesystemId := range filesystemIds {
 		results[i] = s.releaseFilesystem(filesystemId)
-		common.HandleCredentialError(IsAuthorisationFailure, results[i], ctx)
+		common.HandleCredentialError(ctx, IsAuthorisationFailure, results[i], ctx)
 	}
 	return results, nil
 }
@@ -431,7 +431,7 @@ func (s *lxdFilesystemSource) AttachFilesystems(ctx envcontext.ProviderCallConte
 	switch err {
 	case nil, environs.ErrPartialInstances, environs.ErrNoInstances:
 	default:
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		common.HandleCredentialError(ctx, IsAuthorisationFailure, err, ctx)
 		return nil, errors.Trace(err)
 	}
 
@@ -454,7 +454,7 @@ func (s *lxdFilesystemSource) AttachFilesystems(ctx envcontext.ProviderCallConte
 				names.ReadableString(arg.Filesystem),
 				names.ReadableString(arg.Machine),
 			)
-			common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+			common.HandleCredentialError(ctx, IsAuthorisationFailure, err, ctx)
 			continue
 		}
 		results[i].FilesystemAttachment = attachment
@@ -510,7 +510,7 @@ func (s *lxdFilesystemSource) DetachFilesystems(ctx envcontext.ProviderCallConte
 	switch err {
 	case nil, environs.ErrPartialInstances, environs.ErrNoInstances:
 	default:
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		common.HandleCredentialError(ctx, IsAuthorisationFailure, err, ctx)
 		return nil, errors.Trace(err)
 	}
 
@@ -528,7 +528,7 @@ func (s *lxdFilesystemSource) DetachFilesystems(ctx envcontext.ProviderCallConte
 		}
 		if inst != nil {
 			err := s.detachFilesystem(arg, inst)
-			common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+			common.HandleCredentialError(ctx, IsAuthorisationFailure, err, ctx)
 			results[i] = errors.Annotatef(
 				err, "detaching %s",
 				names.ReadableString(arg.Filesystem),
@@ -559,7 +559,7 @@ func (s *lxdFilesystemSource) ImportFilesystem(
 	}
 	volume, eTag, err := s.env.server().GetStoragePoolVolume(lxdPool, storagePoolVolumeType, volumeName)
 	if err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, callCtx)
+		common.HandleCredentialError(callCtx, IsAuthorisationFailure, err, callCtx)
 		return storage.FilesystemInfo{}, errors.Trace(err)
 	}
 	if len(volume.UsedBy) > 0 {
@@ -595,7 +595,7 @@ func (s *lxdFilesystemSource) ImportFilesystem(
 		}
 		if err := s.env.server().UpdateStoragePoolVolume(
 			lxdPool, storagePoolVolumeType, volumeName, volume.Writable(), eTag); err != nil {
-			common.HandleCredentialError(IsAuthorisationFailure, err, callCtx)
+			common.HandleCredentialError(callCtx, IsAuthorisationFailure, err, callCtx)
 			return storage.FilesystemInfo{}, errors.Annotate(err, "tagging volume")
 		}
 	}

--- a/internal/provider/maas/environ.go
+++ b/internal/provider/maas/environ.go
@@ -98,6 +98,8 @@ type maasEnviron struct {
 	// dealt with by shortRetryStrategy, the latter by longRetryStrategy
 	shortRetryStrategy retry.CallArgs
 	longRetryStrategy  retry.CallArgs
+
+	credentialInvalidator environs.ModelCredentialInvalidator
 }
 
 var (
@@ -109,16 +111,17 @@ var (
 // the capabilities of a MAAS installation.
 type Capabilities = func(client *gomaasapi.MAASObject, serverURL string) (set.Strings, error)
 
-func NewEnviron(ctx context.Context, cloud environscloudspec.CloudSpec, cfg *config.Config, getCaps Capabilities) (*maasEnviron, error) {
+func NewEnviron(ctx context.Context, cloud environscloudspec.CloudSpec, cfg *config.Config, invalidator environs.ModelCredentialInvalidator, getCaps Capabilities) (*maasEnviron, error) {
 	if getCaps == nil {
 		getCaps = getCapabilities
 	}
 	env := &maasEnviron{
-		name:               cfg.Name(),
-		uuid:               cfg.UUID(),
-		GetCapabilities:    getCaps,
-		shortRetryStrategy: defaultShortRetryStrategy,
-		longRetryStrategy:  defaultLongRetryStrategy,
+		name:                  cfg.Name(),
+		uuid:                  cfg.UUID(),
+		GetCapabilities:       getCaps,
+		shortRetryStrategy:    defaultShortRetryStrategy,
+		longRetryStrategy:     defaultLongRetryStrategy,
+		credentialInvalidator: invalidator,
 	}
 	if err := env.SetConfig(ctx, cfg); err != nil {
 		return nil, errors.Trace(err)
@@ -300,7 +303,7 @@ func (env *maasEnviron) getSupportedArchitectures(ctx envcontext.ProviderCallCon
 
 	resources, err := env.maasController.BootResources()
 	if err != nil {
-		common.HandleCredentialError(ctx, IsAuthorisationFailure, err, ctx)
+		common.HandleCredentialError(ctx, env.credentialInvalidator, IsAuthorisationFailure, err)
 		return nil, errors.Trace(err)
 	}
 	architectures := set.NewStrings()
@@ -349,7 +352,7 @@ func (env *maasEnviron) AvailabilityZones(ctx envcontext.ProviderCallContext) (c
 func (env *maasEnviron) availabilityZones(ctx envcontext.ProviderCallContext) (corenetwork.AvailabilityZones, error) {
 	zones, err := env.maasController.Zones()
 	if err != nil {
-		common.HandleCredentialError(ctx, IsAuthorisationFailure, err, ctx)
+		common.HandleCredentialError(ctx, env.credentialInvalidator, IsAuthorisationFailure, err)
 		return nil, errors.Trace(err)
 	}
 	availabilityZones := make(corenetwork.AvailabilityZones, len(zones))
@@ -592,7 +595,7 @@ func (env *maasEnviron) networkSpaceRequirements(ctx envcontext.ProviderCallCont
 			return nil, nil, nil
 		}
 
-		common.HandleCredentialError(ctx, IsAuthorisationFailure, err, ctx)
+		common.HandleCredentialError(ctx, env.credentialInvalidator, IsAuthorisationFailure, err)
 		return nil, nil, errors.Trace(err)
 	}
 
@@ -644,7 +647,7 @@ func (env *maasEnviron) acquireNode(
 	}
 	machine, constraintMatches, err := env.maasController.AllocateMachine(acquireParams)
 	if err != nil {
-		common.HandleCredentialError(ctx, IsAuthorisationFailure, err, ctx)
+		common.HandleCredentialError(ctx, env.credentialInvalidator, IsAuthorisationFailure, err)
 		return nil, errors.Trace(err)
 	}
 	return &maasInstance{
@@ -849,7 +852,7 @@ func (env *maasEnviron) waitForNodeDeployment(ctx envcontext.ProviderCallContext
 		if errors.Is(err, errors.NotProvisioned) {
 			return true
 		}
-		if denied := common.HandleCredentialError(ctx, IsAuthorisationFailure, err, ctx); denied {
+		if denied := common.HandleCredentialError(ctx, env.credentialInvalidator, IsAuthorisationFailure, err); denied {
 			return true
 		}
 		return false
@@ -954,7 +957,7 @@ func (env *maasEnviron) releaseNodes(ctx envcontext.ProviderCallContext, ids []i
 	}
 	err := env.maasController.ReleaseMachines(args)
 
-	denied := common.HandleCredentialError(ctx, IsAuthorisationFailure, err, ctx)
+	denied := common.HandleCredentialError(ctx, env.credentialInvalidator, IsAuthorisationFailure, err)
 	switch {
 	case err == nil:
 		return nil
@@ -990,7 +993,7 @@ func (env *maasEnviron) releaseNodesIndividually(ctx envcontext.ProviderCallCont
 		if err != nil {
 			lastErr = err
 			logger.Errorf(context.TODO(), "error while releasing node %v (%v)", id, err)
-			if denied := common.HandleCredentialError(ctx, IsAuthorisationFailure, err, ctx); denied {
+			if denied := common.HandleCredentialError(ctx, env.credentialInvalidator, IsAuthorisationFailure, err); denied {
 				break
 			}
 		}
@@ -1087,7 +1090,7 @@ func (env *maasEnviron) acquiredInstances(ctx envcontext.ProviderCallContext, id
 func (env *maasEnviron) instances(ctx envcontext.ProviderCallContext, args gomaasapi.MachinesArgs) ([]*maasInstance, error) {
 	machines, err := env.maasController.Machines(args)
 	if err != nil {
-		common.HandleCredentialError(ctx, IsAuthorisationFailure, err, ctx)
+		common.HandleCredentialError(ctx, env.credentialInvalidator, IsAuthorisationFailure, err)
 		return nil, errors.Trace(err)
 	}
 
@@ -1138,7 +1141,7 @@ func (env *maasEnviron) subnetToSpaceIds(ctx envcontext.ProviderCallContext) (ma
 func (env *maasEnviron) Spaces(ctx envcontext.ProviderCallContext) (corenetwork.SpaceInfos, error) {
 	spaces, err := env.maasController.Spaces()
 	if err != nil {
-		common.HandleCredentialError(ctx, IsAuthorisationFailure, err, ctx)
+		common.HandleCredentialError(ctx, env.credentialInvalidator, IsAuthorisationFailure, err)
 		return nil, errors.Trace(err)
 	}
 	var result []corenetwork.SpaceInfo
@@ -1218,7 +1221,7 @@ func (env *maasEnviron) filteredSubnets2(
 	}
 	machines, err := env.maasController.Machines(args)
 	if err != nil {
-		common.HandleCredentialError(ctx, IsAuthorisationFailure, err, ctx)
+		common.HandleCredentialError(ctx, env.credentialInvalidator, IsAuthorisationFailure, err)
 		return nil, errors.Trace(err)
 	}
 	if len(machines) == 0 {
@@ -1361,7 +1364,7 @@ func (env *maasEnviron) ReleaseContainerAddresses(ctx envcontext.ProviderCallCon
 
 	devices, err := env.maasController.Devices(gomaasapi.DevicesArgs{MACAddresses: hwAddresses})
 	if err != nil {
-		common.HandleCredentialError(ctx, IsAuthorisationFailure, err, ctx)
+		common.HandleCredentialError(ctx, env.credentialInvalidator, IsAuthorisationFailure, err)
 		return errors.Trace(err)
 	}
 	logger.Infof(context.TODO(), "found %d MAAS devices to remove", len(devices))
@@ -1430,7 +1433,7 @@ func (*maasEnviron) ProviderSpaceInfo(
 func (env *maasEnviron) Domains(ctx envcontext.ProviderCallContext) ([]string, error) {
 	maasDomains, err := env.maasController.Domains()
 	if err != nil {
-		common.HandleCredentialError(ctx, IsAuthorisationFailure, err, ctx)
+		common.HandleCredentialError(ctx, env.credentialInvalidator, IsAuthorisationFailure, err)
 		return nil, errors.Trace(err)
 	}
 	var result []string

--- a/internal/provider/maas/environ.go
+++ b/internal/provider/maas/environ.go
@@ -849,7 +849,7 @@ func (env *maasEnviron) waitForNodeDeployment(ctx envcontext.ProviderCallContext
 		if errors.Is(err, errors.NotProvisioned) {
 			return true
 		}
-		if denied := common.MaybeHandleCredentialError(IsAuthorisationFailure, err, ctx); denied {
+		if denied := common.HandleCredentialError(IsAuthorisationFailure, err, ctx); denied {
 			return true
 		}
 		return false
@@ -954,7 +954,7 @@ func (env *maasEnviron) releaseNodes(ctx envcontext.ProviderCallContext, ids []i
 	}
 	err := env.maasController.ReleaseMachines(args)
 
-	denied := common.MaybeHandleCredentialError(IsAuthorisationFailure, err, ctx)
+	denied := common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
 	switch {
 	case err == nil:
 		return nil
@@ -990,7 +990,7 @@ func (env *maasEnviron) releaseNodesIndividually(ctx envcontext.ProviderCallCont
 		if err != nil {
 			lastErr = err
 			logger.Errorf(context.TODO(), "error while releasing node %v (%v)", id, err)
-			if denied := common.MaybeHandleCredentialError(IsAuthorisationFailure, err, ctx); denied {
+			if denied := common.HandleCredentialError(IsAuthorisationFailure, err, ctx); denied {
 				break
 			}
 		}

--- a/internal/provider/maas/environ.go
+++ b/internal/provider/maas/environ.go
@@ -300,7 +300,7 @@ func (env *maasEnviron) getSupportedArchitectures(ctx envcontext.ProviderCallCon
 
 	resources, err := env.maasController.BootResources()
 	if err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		common.HandleCredentialError(ctx, IsAuthorisationFailure, err, ctx)
 		return nil, errors.Trace(err)
 	}
 	architectures := set.NewStrings()
@@ -349,7 +349,7 @@ func (env *maasEnviron) AvailabilityZones(ctx envcontext.ProviderCallContext) (c
 func (env *maasEnviron) availabilityZones(ctx envcontext.ProviderCallContext) (corenetwork.AvailabilityZones, error) {
 	zones, err := env.maasController.Zones()
 	if err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		common.HandleCredentialError(ctx, IsAuthorisationFailure, err, ctx)
 		return nil, errors.Trace(err)
 	}
 	availabilityZones := make(corenetwork.AvailabilityZones, len(zones))
@@ -592,7 +592,7 @@ func (env *maasEnviron) networkSpaceRequirements(ctx envcontext.ProviderCallCont
 			return nil, nil, nil
 		}
 
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		common.HandleCredentialError(ctx, IsAuthorisationFailure, err, ctx)
 		return nil, nil, errors.Trace(err)
 	}
 
@@ -644,7 +644,7 @@ func (env *maasEnviron) acquireNode(
 	}
 	machine, constraintMatches, err := env.maasController.AllocateMachine(acquireParams)
 	if err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		common.HandleCredentialError(ctx, IsAuthorisationFailure, err, ctx)
 		return nil, errors.Trace(err)
 	}
 	return &maasInstance{
@@ -849,7 +849,7 @@ func (env *maasEnviron) waitForNodeDeployment(ctx envcontext.ProviderCallContext
 		if errors.Is(err, errors.NotProvisioned) {
 			return true
 		}
-		if denied := common.HandleCredentialError(IsAuthorisationFailure, err, ctx); denied {
+		if denied := common.HandleCredentialError(ctx, IsAuthorisationFailure, err, ctx); denied {
 			return true
 		}
 		return false
@@ -954,7 +954,7 @@ func (env *maasEnviron) releaseNodes(ctx envcontext.ProviderCallContext, ids []i
 	}
 	err := env.maasController.ReleaseMachines(args)
 
-	denied := common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+	denied := common.HandleCredentialError(ctx, IsAuthorisationFailure, err, ctx)
 	switch {
 	case err == nil:
 		return nil
@@ -990,7 +990,7 @@ func (env *maasEnviron) releaseNodesIndividually(ctx envcontext.ProviderCallCont
 		if err != nil {
 			lastErr = err
 			logger.Errorf(context.TODO(), "error while releasing node %v (%v)", id, err)
-			if denied := common.HandleCredentialError(IsAuthorisationFailure, err, ctx); denied {
+			if denied := common.HandleCredentialError(ctx, IsAuthorisationFailure, err, ctx); denied {
 				break
 			}
 		}
@@ -1087,7 +1087,7 @@ func (env *maasEnviron) acquiredInstances(ctx envcontext.ProviderCallContext, id
 func (env *maasEnviron) instances(ctx envcontext.ProviderCallContext, args gomaasapi.MachinesArgs) ([]*maasInstance, error) {
 	machines, err := env.maasController.Machines(args)
 	if err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		common.HandleCredentialError(ctx, IsAuthorisationFailure, err, ctx)
 		return nil, errors.Trace(err)
 	}
 
@@ -1138,7 +1138,7 @@ func (env *maasEnviron) subnetToSpaceIds(ctx envcontext.ProviderCallContext) (ma
 func (env *maasEnviron) Spaces(ctx envcontext.ProviderCallContext) (corenetwork.SpaceInfos, error) {
 	spaces, err := env.maasController.Spaces()
 	if err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		common.HandleCredentialError(ctx, IsAuthorisationFailure, err, ctx)
 		return nil, errors.Trace(err)
 	}
 	var result []corenetwork.SpaceInfo
@@ -1218,7 +1218,7 @@ func (env *maasEnviron) filteredSubnets2(
 	}
 	machines, err := env.maasController.Machines(args)
 	if err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		common.HandleCredentialError(ctx, IsAuthorisationFailure, err, ctx)
 		return nil, errors.Trace(err)
 	}
 	if len(machines) == 0 {
@@ -1361,7 +1361,7 @@ func (env *maasEnviron) ReleaseContainerAddresses(ctx envcontext.ProviderCallCon
 
 	devices, err := env.maasController.Devices(gomaasapi.DevicesArgs{MACAddresses: hwAddresses})
 	if err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		common.HandleCredentialError(ctx, IsAuthorisationFailure, err, ctx)
 		return errors.Trace(err)
 	}
 	logger.Infof(context.TODO(), "found %d MAAS devices to remove", len(devices))
@@ -1430,7 +1430,7 @@ func (*maasEnviron) ProviderSpaceInfo(
 func (env *maasEnviron) Domains(ctx envcontext.ProviderCallContext) ([]string, error) {
 	maasDomains, err := env.maasController.Domains()
 	if err != nil {
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		common.HandleCredentialError(ctx, IsAuthorisationFailure, err, ctx)
 		return nil, errors.Trace(err)
 	}
 	var result []string

--- a/internal/provider/maas/environprovider.go
+++ b/internal/provider/maas/environprovider.go
@@ -63,7 +63,7 @@ func (EnvironProvider) Open(ctx context.Context, args environs.OpenParams) (envi
 	if err := validateCloudSpec(args.Cloud); err != nil {
 		return nil, errors.Annotate(err, "validating cloud spec")
 	}
-	env, err := NewEnviron(ctx, args.Cloud, args.Config, nil)
+	env, err := NewEnviron(ctx, args.Cloud, args.Config, args.CredentialInvalidator, nil)
 	if err != nil {
 		return nil, errors.Annotate(err, "creating MAAS environ")
 	}

--- a/internal/provider/maas/errors_test.go
+++ b/internal/provider/maas/errors_test.go
@@ -32,6 +32,7 @@ func (s *ErrorSuite) SetUpTest(c *gc.C) {
 
 func (s *ErrorSuite) TestNoValidation(c *gc.C) {
 	denied := common.HandleCredentialError(
+		context.Background(),
 		IsAuthorisationFailure, s.maasError, envcontext.WithoutCredentialInvalidator(context.Background()))
 	c.Assert(c.GetTestLog(), jc.DeepEquals, "")
 	c.Assert(denied, jc.IsTrue)
@@ -41,7 +42,7 @@ func (s *ErrorSuite) TestInvalidationCallbackErrorOnlyLogs(c *gc.C) {
 	ctx := envcontext.WithCredentialInvalidator(context.Background(), func(_ context.Context, msg string) error {
 		return errors.New("kaboom")
 	})
-	denied := common.HandleCredentialError(IsAuthorisationFailure, s.maasError, ctx)
+	denied := common.HandleCredentialError(ctx, IsAuthorisationFailure, s.maasError, ctx)
 	c.Assert(c.GetTestLog(), jc.Contains, "could not invalidate stored cloud credential on the controller")
 	c.Assert(denied, jc.IsTrue)
 }
@@ -85,7 +86,7 @@ func (s *ErrorSuite) checkMaasPermissionHandling(c *gc.C, handled bool) {
 		return nil
 	})
 
-	denied := common.HandleCredentialError(IsAuthorisationFailure, s.maasError, ctx)
+	denied := common.HandleCredentialError(ctx, IsAuthorisationFailure, s.maasError, ctx)
 	c.Assert(called, gc.Equals, handled)
 	c.Assert(denied, gc.Equals, handled)
 }

--- a/internal/provider/maas/errors_test.go
+++ b/internal/provider/maas/errors_test.go
@@ -31,7 +31,7 @@ func (s *ErrorSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *ErrorSuite) TestNoValidation(c *gc.C) {
-	denied := common.MaybeHandleCredentialError(
+	denied := common.HandleCredentialError(
 		IsAuthorisationFailure, s.maasError, envcontext.WithoutCredentialInvalidator(context.Background()))
 	c.Assert(c.GetTestLog(), jc.DeepEquals, "")
 	c.Assert(denied, jc.IsTrue)
@@ -41,7 +41,7 @@ func (s *ErrorSuite) TestInvalidationCallbackErrorOnlyLogs(c *gc.C) {
 	ctx := envcontext.WithCredentialInvalidator(context.Background(), func(_ context.Context, msg string) error {
 		return errors.New("kaboom")
 	})
-	denied := common.MaybeHandleCredentialError(IsAuthorisationFailure, s.maasError, ctx)
+	denied := common.HandleCredentialError(IsAuthorisationFailure, s.maasError, ctx)
 	c.Assert(c.GetTestLog(), jc.Contains, "could not invalidate stored cloud credential on the controller")
 	c.Assert(denied, jc.IsTrue)
 }
@@ -85,7 +85,7 @@ func (s *ErrorSuite) checkMaasPermissionHandling(c *gc.C, handled bool) {
 		return nil
 	})
 
-	denied := common.MaybeHandleCredentialError(IsAuthorisationFailure, s.maasError, ctx)
+	denied := common.HandleCredentialError(IsAuthorisationFailure, s.maasError, ctx)
 	c.Assert(called, gc.Equals, handled)
 	c.Assert(denied, gc.Equals, handled)
 }

--- a/internal/provider/maas/maas_environ_whitebox_test.go
+++ b/internal/provider/maas/maas_environ_whitebox_test.go
@@ -83,7 +83,7 @@ func (suite *maasEnvironSuite) getEnvWithServer(c *gc.C) (*maasEnviron, error) {
 	attrs := coretesting.FakeConfig().Merge(maasEnvAttrs)
 	cfg, err := config.New(config.NoDefaults, attrs)
 	c.Assert(err, jc.ErrorIsNil)
-	return NewEnviron(context.Background(), cloud, cfg, nil)
+	return NewEnviron(context.Background(), cloud, cfg, environs.NoopModelCredentialInvalidator{}, nil)
 }
 
 func (suite *maasEnvironSuite) TestNewEnvironWithController(c *gc.C) {

--- a/internal/provider/maas/maas_test.go
+++ b/internal/provider/maas/maas_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/core/version"
+	"github.com/juju/juju/environs"
 	environscloudspec "github.com/juju/juju/environs/cloudspec"
 	"github.com/juju/juju/environs/config"
 	coretesting "github.com/juju/juju/internal/testing"
@@ -63,7 +64,7 @@ func (suite *maasSuite) makeEnviron(c *gc.C, controller gomaasapi.Controller) *m
 	suite.controllerUUID = coretesting.FakeControllerConfig().ControllerUUID()
 	cfg, err := config.New(config.NoDefaults, attrs)
 	c.Assert(err, jc.ErrorIsNil)
-	env, err := NewEnviron(context.Background(), cloud, cfg, nil)
+	env, err := NewEnviron(context.Background(), cloud, cfg, environs.NoopModelCredentialInvalidator{}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(env, gc.NotNil)
 	return env

--- a/internal/provider/oci/common/errors.go
+++ b/internal/provider/oci/common/errors.go
@@ -58,5 +58,5 @@ func IsAuthorisationFailure(err error) bool {
 //
 //	if Oracle believes that they are expired
 func HandleCredentialError(err error, ctx envcontext.ProviderCallContext) {
-	common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+	common.HandleCredentialError(ctx, IsAuthorisationFailure, err, ctx)
 }

--- a/internal/provider/oci/storage_volumes.go
+++ b/internal/provider/oci/storage_volumes.go
@@ -28,7 +28,7 @@ func mibToGib(m uint64) uint64 {
 // isAuthFailure is a helper function that's used to reduce line noise.
 // It's typically called within err != nil blocks.
 var isAuthFailure = func(err error, ctx envcontext.ProviderCallContext) bool {
-	return allProvidersCommon.HandleCredentialError(common.IsAuthorisationFailure, err, ctx)
+	return allProvidersCommon.HandleCredentialError(ctx, common.IsAuthorisationFailure, err, ctx)
 }
 
 type volumeSource struct {

--- a/internal/provider/oci/storage_volumes.go
+++ b/internal/provider/oci/storage_volumes.go
@@ -28,7 +28,7 @@ func mibToGib(m uint64) uint64 {
 // isAuthFailure is a helper function that's used to reduce line noise.
 // It's typically called within err != nil blocks.
 var isAuthFailure = func(err error, ctx envcontext.ProviderCallContext) bool {
-	return allProvidersCommon.MaybeHandleCredentialError(common.IsAuthorisationFailure, err, ctx)
+	return allProvidersCommon.HandleCredentialError(common.IsAuthorisationFailure, err, ctx)
 }
 
 type volumeSource struct {

--- a/internal/provider/openstack/cinder.go
+++ b/internal/provider/openstack/cinder.go
@@ -235,7 +235,7 @@ func (s *cinderVolumeSource) CreateVolumes(
 		volume, err := s.createVolume(ctx, arg)
 		if err != nil {
 			results[i].Error = errors.Trace(err)
-			if denied := common.HandleCredentialError(IsAuthorisationFailure, err, ctx); denied {
+			if denied := common.HandleCredentialError(ctx, IsAuthorisationFailure, err, ctx); denied {
 				// If it is an unauthorised error, no need to continue since we will 100% fail...
 				break
 			}
@@ -543,7 +543,7 @@ func (s *cinderVolumeSource) AttachVolumes(ctx envcontext.ProviderCallContext, a
 		attachment, err := s.attachVolume(arg)
 		if err != nil {
 			results[i].Error = errors.Trace(err)
-			if denial := common.HandleCredentialError(IsAuthorisationFailure, err, ctx); denial {
+			if denial := common.HandleCredentialError(ctx, IsAuthorisationFailure, err, ctx); denial {
 				// We do not want to continue here as we'll 100% fail if we got unauthorised error.
 				break
 			}

--- a/internal/provider/openstack/cinder.go
+++ b/internal/provider/openstack/cinder.go
@@ -235,7 +235,7 @@ func (s *cinderVolumeSource) CreateVolumes(
 		volume, err := s.createVolume(ctx, arg)
 		if err != nil {
 			results[i].Error = errors.Trace(err)
-			if denied := common.MaybeHandleCredentialError(IsAuthorisationFailure, err, ctx); denied {
+			if denied := common.HandleCredentialError(IsAuthorisationFailure, err, ctx); denied {
 				// If it is an unauthorised error, no need to continue since we will 100% fail...
 				break
 			}
@@ -543,7 +543,7 @@ func (s *cinderVolumeSource) AttachVolumes(ctx envcontext.ProviderCallContext, a
 		attachment, err := s.attachVolume(arg)
 		if err != nil {
 			results[i].Error = errors.Trace(err)
-			if denial := common.MaybeHandleCredentialError(IsAuthorisationFailure, err, ctx); denial {
+			if denial := common.HandleCredentialError(IsAuthorisationFailure, err, ctx); denial {
 				// We do not want to continue here as we'll 100% fail if we got unauthorised error.
 				break
 			}

--- a/internal/provider/openstack/errors.go
+++ b/internal/provider/openstack/errors.go
@@ -14,7 +14,7 @@ import (
 // handleCredentialError wraps the common handler,
 // passing the Openstack-specific auth failure detection.
 func handleCredentialError(err error, ctx envcontext.ProviderCallContext) {
-	common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+	common.HandleCredentialError(ctx, IsAuthorisationFailure, err, ctx)
 }
 
 // IsAuthorisationFailure determines if the given error has an

--- a/internal/provider/openstack/firewaller.go
+++ b/internal/provider/openstack/firewaller.go
@@ -498,7 +498,7 @@ func (c *neutronFirewaller) UpdateGroupController(ctx envcontext.ProviderCallCon
 		if err != nil {
 			logger.Errorf(context.TODO(), "error updating controller for security group %s: %v", group.Id, err)
 			failed = append(failed, group.Id)
-			if common.MaybeHandleCredentialError(IsAuthorisationFailure, err, ctx) {
+			if common.HandleCredentialError(IsAuthorisationFailure, err, ctx) {
 				// No need to continue here since we will 100% fail with an invalid credential.
 				break
 			}

--- a/internal/provider/openstack/firewaller.go
+++ b/internal/provider/openstack/firewaller.go
@@ -498,7 +498,7 @@ func (c *neutronFirewaller) UpdateGroupController(ctx envcontext.ProviderCallCon
 		if err != nil {
 			logger.Errorf(context.TODO(), "error updating controller for security group %s: %v", group.Id, err)
 			failed = append(failed, group.Id)
-			if common.HandleCredentialError(IsAuthorisationFailure, err, ctx) {
+			if common.HandleCredentialError(ctx, IsAuthorisationFailure, err, ctx) {
 				// No need to continue here since we will 100% fail with an invalid credential.
 				break
 			}

--- a/internal/provider/openstack/provider.go
+++ b/internal/provider/openstack/provider.go
@@ -1834,7 +1834,7 @@ func (e *Environ) AdoptResources(ctx envcontext.ProviderCallContext, controllerU
 		if err != nil {
 			logger.Errorf(context.TODO(), "error updating controller tag for instance %s: %v", instance.Id(), err)
 			failed = append(failed, instance.Id().String())
-			if denied := common.HandleCredentialError(IsAuthorisationFailure, err, ctx); denied {
+			if denied := common.HandleCredentialError(ctx, IsAuthorisationFailure, err, ctx); denied {
 				// If we have an invvalid credential, there is no need to proceed: we'll fail 100%.
 				break
 			}
@@ -1891,7 +1891,7 @@ func (e *Environ) adoptVolumes(controllerTag map[string]string, ctx envcontext.P
 		if err != nil {
 			logger.Errorf(context.TODO(), "error updating controller tag for volume %s: %v", volumeId, err)
 			failed = append(failed, volumeId)
-			if denied := common.HandleCredentialError(IsAuthorisationFailure, err, ctx); denied {
+			if denied := common.HandleCredentialError(ctx, IsAuthorisationFailure, err, ctx); denied {
 				// If we have an invvalid credential, there is no need to proceed: we'll fail 100%.
 				break
 			}
@@ -2157,7 +2157,7 @@ func (e *Environ) terminateInstances(ctx envcontext.ProviderCallContext, ids []i
 	}
 	if err != nil {
 		logger.Debugf(context.TODO(), "error retrieving security groups for %v: %v", ids, err)
-		if denied := common.HandleCredentialError(IsAuthorisationFailure, err, ctx); denied {
+		if denied := common.HandleCredentialError(ctx, IsAuthorisationFailure, err, ctx); denied {
 			// We'll likely fail all subsequent calls if we have an invalid credential.
 			return errors.Trace(err)
 		}
@@ -2185,7 +2185,7 @@ func (e *Environ) terminateInstances(ctx envcontext.ProviderCallContext, ids []i
 			if firstErr == nil {
 				firstErr = err
 			}
-			if denied := common.HandleCredentialError(IsAuthorisationFailure, err, ctx); denied {
+			if denied := common.HandleCredentialError(ctx, IsAuthorisationFailure, err, ctx); denied {
 				// We'll likely fail all subsequent calls if we have an invalid credential.
 				return errors.Trace(err)
 			}

--- a/internal/provider/openstack/provider.go
+++ b/internal/provider/openstack/provider.go
@@ -1834,7 +1834,7 @@ func (e *Environ) AdoptResources(ctx envcontext.ProviderCallContext, controllerU
 		if err != nil {
 			logger.Errorf(context.TODO(), "error updating controller tag for instance %s: %v", instance.Id(), err)
 			failed = append(failed, instance.Id().String())
-			if denied := common.MaybeHandleCredentialError(IsAuthorisationFailure, err, ctx); denied {
+			if denied := common.HandleCredentialError(IsAuthorisationFailure, err, ctx); denied {
 				// If we have an invvalid credential, there is no need to proceed: we'll fail 100%.
 				break
 			}
@@ -1891,7 +1891,7 @@ func (e *Environ) adoptVolumes(controllerTag map[string]string, ctx envcontext.P
 		if err != nil {
 			logger.Errorf(context.TODO(), "error updating controller tag for volume %s: %v", volumeId, err)
 			failed = append(failed, volumeId)
-			if denied := common.MaybeHandleCredentialError(IsAuthorisationFailure, err, ctx); denied {
+			if denied := common.HandleCredentialError(IsAuthorisationFailure, err, ctx); denied {
 				// If we have an invvalid credential, there is no need to proceed: we'll fail 100%.
 				break
 			}
@@ -2157,7 +2157,7 @@ func (e *Environ) terminateInstances(ctx envcontext.ProviderCallContext, ids []i
 	}
 	if err != nil {
 		logger.Debugf(context.TODO(), "error retrieving security groups for %v: %v", ids, err)
-		if denied := common.MaybeHandleCredentialError(IsAuthorisationFailure, err, ctx); denied {
+		if denied := common.HandleCredentialError(IsAuthorisationFailure, err, ctx); denied {
 			// We'll likely fail all subsequent calls if we have an invalid credential.
 			return errors.Trace(err)
 		}
@@ -2185,7 +2185,7 @@ func (e *Environ) terminateInstances(ctx envcontext.ProviderCallContext, ids []i
 			if firstErr == nil {
 				firstErr = err
 			}
-			if denied := common.MaybeHandleCredentialError(IsAuthorisationFailure, err, ctx); denied {
+			if denied := common.HandleCredentialError(IsAuthorisationFailure, err, ctx); denied {
 				// We'll likely fail all subsequent calls if we have an invalid credential.
 				return errors.Trace(err)
 			}

--- a/internal/provider/vsphere/environ.go
+++ b/internal/provider/vsphere/environ.go
@@ -66,7 +66,7 @@ func (env *environ) withClient(ctx context.Context, callCtx callcontext.Provider
 		// LP #1849194: this is a case at bootstrap time, where a connection
 		// to vsphere failed. It can be wrong Credentials only, differently
 		// from all the other HandleCredentialError cases
-		common.HandleCredentialError(IsAuthorisationFailure, err, callCtx)
+		common.HandleCredentialError(callCtx, IsAuthorisationFailure, err, callCtx)
 		return errors.Annotate(err, "dialing client")
 	}
 	defer client.Close(ctx)

--- a/internal/provider/vsphere/errors.go
+++ b/internal/provider/vsphere/errors.go
@@ -59,6 +59,6 @@ func HandleCredentialError(err error, env *sessionEnviron, ctx envcontext.Provid
 	_, errfind := env.client.FindFolder(env.ctx, env.getVMFolder())
 	if errfind != nil {
 		// This is a credential issue. Now, move to mark credentials as invalid
-		common.HandleCredentialError(IsAuthorisationFailure, err, ctx)
+		common.HandleCredentialError(ctx, IsAuthorisationFailure, err, ctx)
 	}
 }

--- a/internal/worker/modelworkermanager/providerservice.go
+++ b/internal/worker/modelworkermanager/providerservice.go
@@ -41,6 +41,11 @@ type ProviderConfigService interface {
 type ProviderCredentialService interface {
 	// CloudCredential returns the cloud credential for the given tag.
 	CloudCredential(ctx context.Context, key credential.Key) (cloud.Credential, error)
+
+	// InvalidateCredential marks the cloud credential for the given name, cloud,
+	// owner as invalid.
+	InvalidateCredential(ctx context.Context, key credential.Key, reason string) error
+
 	// WatchCredential returns a watcher that observes changes to the specified
 	// credential.
 	WatchCredential(ctx context.Context, key credential.Key) (watcher.NotifyWatcher, error)

--- a/internal/worker/providertracker/manifold.go
+++ b/internal/worker/providertracker/manifold.go
@@ -35,6 +35,10 @@ type ProviderConfigGetter interface {
 
 	// ControllerUUID returns the UUID of the controller.
 	ControllerUUID() uuid.UUID
+
+	// CredentialInvalidator returns a function that invalidates the credentials
+	// for the model.
+	CredentialInvalidator() environs.ModelCredentialInvalidator
 }
 
 // IAASProviderFunc is a function that returns a IAAS provider.
@@ -157,7 +161,7 @@ func IAASGetProvider(newProvider IAASProviderFunc) func(ctx context.Context, get
 		// We can't use newProvider directly, as type invariance prevents us
 		// from using it with the environs.GetEnvironAndCloud function.
 		// Just wrap it in a closure to work around this.
-		provider, spec, err := environs.GetEnvironAndCloud(ctx, getter, func(ctx context.Context, op environs.OpenParams) (environs.Environ, error) {
+		provider, spec, err := environs.GetEnvironAndCloud(ctx, getter, getter, func(ctx context.Context, op environs.OpenParams) (environs.Environ, error) {
 			return newProvider(ctx, op)
 		})
 		if err != nil {

--- a/internal/worker/providertracker/manifold.go
+++ b/internal/worker/providertracker/manifold.go
@@ -181,9 +181,10 @@ func CAASGetProvider(newProvider CAASProviderFunc) func(ctx context.Context, get
 		}
 
 		broker, err := newProvider(ctx, environs.OpenParams{
-			ControllerUUID: getter.ControllerUUID().String(),
-			Cloud:          cloudSpec,
-			Config:         cfg,
+			ControllerUUID:        getter.ControllerUUID().String(),
+			Cloud:                 cloudSpec,
+			Config:                cfg,
+			CredentialInvalidator: getter.CredentialInvalidator(),
 		})
 		if err != nil {
 			return nil, environscloudspec.CloudSpec{}, errors.Annotate(err, "cannot create caas broker")

--- a/internal/worker/providertracker/providerservice.go
+++ b/internal/worker/providertracker/providerservice.go
@@ -60,6 +60,9 @@ type ConfigService interface {
 type CredentialService interface {
 	// CloudCredential returns the cloud credential for the given tag.
 	CloudCredential(ctx context.Context, key credential.Key) (cloud.Credential, error)
+	// InvalidateCredential marks the cloud credential for the given name, cloud,
+	// owner as invalid.
+	InvalidateCredential(ctx context.Context, key credential.Key, reason string) error
 	// WatchCredential returns a watcher that observes changes to the specified
 	// credential.
 	WatchCredential(ctx context.Context, key credential.Key) (watcher.NotifyWatcher, error)

--- a/internal/worker/providertracker/providertracker_mock_test.go
+++ b/internal/worker/providertracker/providertracker_mock_test.go
@@ -583,6 +583,44 @@ func (c *MockCredentialServiceCloudCredentialCall) DoAndReturn(f func(context.Co
 	return c
 }
 
+// InvalidateCredential mocks base method.
+func (m *MockCredentialService) InvalidateCredential(arg0 context.Context, arg1 credential.Key, arg2 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InvalidateCredential", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// InvalidateCredential indicates an expected call of InvalidateCredential.
+func (mr *MockCredentialServiceMockRecorder) InvalidateCredential(arg0, arg1, arg2 any) *MockCredentialServiceInvalidateCredentialCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InvalidateCredential", reflect.TypeOf((*MockCredentialService)(nil).InvalidateCredential), arg0, arg1, arg2)
+	return &MockCredentialServiceInvalidateCredentialCall{Call: call}
+}
+
+// MockCredentialServiceInvalidateCredentialCall wrap *gomock.Call
+type MockCredentialServiceInvalidateCredentialCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockCredentialServiceInvalidateCredentialCall) Return(arg0 error) *MockCredentialServiceInvalidateCredentialCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockCredentialServiceInvalidateCredentialCall) Do(f func(context.Context, credential.Key, string) error) *MockCredentialServiceInvalidateCredentialCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockCredentialServiceInvalidateCredentialCall) DoAndReturn(f func(context.Context, credential.Key, string) error) *MockCredentialServiceInvalidateCredentialCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // WatchCredential mocks base method.
 func (m *MockCredentialService) WatchCredential(arg0 context.Context, arg1 credential.Key) (watcher.Watcher[struct{}], error) {
 	m.ctrl.T.Helper()

--- a/state/stateenvirons/config.go
+++ b/state/stateenvirons/config.go
@@ -138,7 +138,7 @@ func GetNewEnvironFunc(newEnviron environs.NewEnvironFunc) NewEnvironFunc {
 			CredentialService:  credentialService,
 			ModelConfigService: modelConfigService,
 		}
-		return environs.GetEnviron(context.TODO(), g, newEnviron)
+		return environs.GetEnviron(context.TODO(), g, environs.NoopEnvironCredentialInvalidator{}, newEnviron)
 	}
 }
 
@@ -160,9 +160,10 @@ func GetNewCAASBrokerFunc(newBroker caas.NewContainerBrokerFunc) NewCAASBrokerFu
 			return nil, errors.Trace(err)
 		}
 		return newBroker(context.TODO(), environs.OpenParams{
-			ControllerUUID: m.ControllerUUID(),
-			Cloud:          cloudSpec,
-			Config:         cfg,
+			ControllerUUID:        m.ControllerUUID(),
+			Cloud:                 cloudSpec,
+			Config:                cfg,
+			CredentialInvalidator: environs.NoopModelCredentialInvalidator{},
 		})
 	}
 }


### PR DESCRIPTION
This is the first steps towards removing the provider call context. The provider already knows about this information, services shouldn't be required to chase this up.

The solution here is to wire up the credential invalidator into the providers when we open the environ (we can do this now because of the provider tracker), and then pass in the invalidator once we're done.

I've not completely removed the ProviderCallContext, that can come after this PR has landed. It should be a simple job of just swapping it for a context.Context and then passing the invalidator directly into the "MaybeHandleCredentialError" function.

I'm not sure of the need to centralise all of this yet, it seems overkill, but I don't want to change the providers too much.
