### PR TITLE
fix: upgrade go version to 1.23.6 to address GO-2025-3447 vuln

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/juju/juju
 
-go 1.23.5
+go 1.23.6
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.12.0


### PR DESCRIPTION
Reported by govulncheck, see https://pkg.go.dev/vuln/GO-2025-3447.

## QA Steps

`govulncheck ./...`, as run in the static analysis job should pass.