### PR TITLE
feat: introduce environs credential invalidator

### DIFF
--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -429,9 +429,9 @@ func (b *AgentBootstrap) getEnviron(
 		Config:         modelConfig,
 	}
 	if cloud.CloudTypeIsCAAS(cloudSpec.Type) {
-		return caas.Open(ctx, provider, openParams)
+		return caas.Open(ctx, provider, openParams, environs.NoopCredentialInvalidator())
 	}
-	return environs.Open(ctx, provider, openParams)
+	return environs.Open(ctx, provider, openParams, environs.NoopCredentialInvalidator())
 }
 
 // initMongo dials the initial MongoDB connection, setting a

--- a/apiserver/common/environ_config.go
+++ b/apiserver/common/environ_config.go
@@ -28,6 +28,6 @@ func EnvironFuncForModel(model stateenvirons.Model, cloudService CloudService,
 		}
 	}
 	return func(ctx context.Context) (environs.BootstrapEnviron, error) {
-		return environs.GetEnviron(ctx, configGetter, environs.New)
+		return environs.GetEnviron(ctx, configGetter, environs.NoopCredentialInvalidator(), environs.New)
 	}
 }

--- a/apiserver/facades/agent/provisioner/provisioner.go
+++ b/apiserver/facades/agent/provisioner/provisioner.go
@@ -153,7 +153,7 @@ func MakeProvisionerAPI(stdCtx context.Context, ctx facade.ModelContext) (*Provi
 	if isCaasModel {
 		env, err = stateenvirons.GetNewCAASBrokerFunc(caas.New)(model, domainServices.Cloud(), domainServices.Credential(), domainServices.Config())
 	} else {
-		env, err = environs.GetEnviron(stdCtx, configGetter, environs.New)
+		env, err = environs.GetEnviron(stdCtx, configGetter, environs.NoopCredentialInvalidator(), environs.New)
 	}
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -215,7 +215,7 @@ func MakeProvisionerAPI(stdCtx context.Context, ctx facade.ModelContext) (*Provi
 	}
 
 	newEnviron := func(ctx context.Context) (environs.BootstrapEnviron, error) {
-		return environs.GetEnviron(ctx, configGetter, environs.New)
+		return environs.GetEnviron(ctx, configGetter, environs.NoopCredentialInvalidator(), environs.New)
 	}
 
 	api.InstanceIdGetter = common.NewInstanceIdGetter(domainServices.Machine(), getAuthFunc)
@@ -1104,7 +1104,7 @@ func (api *ProvisionerAPI) prepareOrGetContainerInterfaceInfo(
 // prepareContainerAccessEnvironment retrieves the environment, host machine, and access
 // for working with containers.
 func (api *ProvisionerAPI) prepareContainerAccessEnvironment(ctx context.Context) (environs.Environ, *state.Machine, common.AuthFunc, error) {
-	env, err := environs.GetEnviron(ctx, api.configGetter, environs.New)
+	env, err := environs.GetEnviron(ctx, api.configGetter, environs.NoopCredentialInvalidator(), environs.New)
 	if err != nil {
 		return nil, nil, nil, errors.Trace(err)
 	}

--- a/apiserver/facades/agent/provisioner/provisioninginfo.go
+++ b/apiserver/facades/agent/provisioner/provisioninginfo.go
@@ -46,7 +46,7 @@ func (api *ProvisionerAPI) ProvisioningInfo(ctx context.Context, args params.Ent
 		return result, errors.Trace(err)
 	}
 
-	env, err := environs.GetEnviron(ctx, api.configGetter, environs.New)
+	env, err := environs.GetEnviron(ctx, api.configGetter, environs.NoopCredentialInvalidator(), environs.New)
 	if err != nil {
 		return result, errors.Annotate(err, "retrieving environ")
 	}

--- a/apiserver/facades/agent/uniter/uniter_cloudspec_test.go
+++ b/apiserver/facades/agent/uniter/uniter_cloudspec_test.go
@@ -100,7 +100,7 @@ func (s *cloudSpecUniterSuite) TestCloudAPIVersion(c *gc.C) {
 		domainServices.Port(),
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	uniter.SetNewContainerBrokerFunc(uniterAPI, func(context.Context, environs.OpenParams) (caas.Broker, error) {
+	uniter.SetNewContainerBrokerFunc(uniterAPI, func(context.Context, environs.OpenParams, environs.CredentialInvalidator) (caas.Broker, error) {
 		return &fakeBroker{}, nil
 	})
 

--- a/apiserver/facades/client/controller/controller_test.go
+++ b/apiserver/facades/client/controller/controller_test.go
@@ -226,7 +226,7 @@ func (s *controllerSuite) TestHostedModelConfigs_CanOpenEnviron(c *gc.C) {
 		_, err = environs.New(context.Background(), environs.OpenParams{
 			Cloud:  spec,
 			Config: cfg,
-		})
+		}, environs.NoopCredentialInvalidator())
 		c.Assert(err, jc.ErrorIsNil)
 	}
 }

--- a/apiserver/facades/client/modelmanager/modelmanager.go
+++ b/apiserver/facades/client/modelmanager/modelmanager.go
@@ -46,7 +46,7 @@ var (
 	logger = internallogger.GetLogger("juju.apiserver.modelmanager")
 )
 
-type newCaasBrokerFunc func(_ context.Context, args environs.OpenParams) (caas.Broker, error)
+type newCaasBrokerFunc func(_ context.Context, args environs.OpenParams, _ environs.CredentialInvalidator) (caas.Broker, error)
 
 // StateBackend represents the mongo backend.
 type StateBackend interface {
@@ -539,7 +539,7 @@ Please choose a different model name.
 		ControllerUUID: m.controllerUUID.String(),
 		Cloud:          cloudSpec,
 		Config:         newConfig,
-	})
+	}, environs.NoopCredentialInvalidator())
 	if err != nil {
 		return nil, errors.Annotate(err, "failed to open kubernetes client")
 	}
@@ -585,7 +585,7 @@ func (m *ModelManagerAPI) newIAASModel(
 		ControllerUUID: m.controllerUUID.String(),
 		Cloud:          cloudSpec,
 		Config:         newConfig,
-	})
+	}, environs.NoopCredentialInvalidator())
 	if err != nil {
 		return nil, errors.Annotate(err, "failed to open environ")
 	}

--- a/apiserver/facades/client/modelmanager/modelmanager_test.go
+++ b/apiserver/facades/client/modelmanager/modelmanager_test.go
@@ -219,7 +219,7 @@ func (s *modelManagerSuite) setUpAPI(c *gc.C) *gomock.Controller {
 		AuthTypes: []cloud.AuthType{cloud.UserPassAuthType},
 	}
 
-	newBroker := func(_ context.Context, args environs.OpenParams) (caas.Broker, error) {
+	newBroker := func(_ context.Context, args environs.OpenParams, _ environs.CredentialInvalidator) (caas.Broker, error) {
 		s.caasBroker = &mockCaasBroker{namespace: args.Config.Name()}
 		return s.caasBroker, nil
 	}
@@ -283,7 +283,7 @@ func (s *modelManagerSuite) setUpAPI(c *gc.C) *gomock.Controller {
 
 func (s *modelManagerSuite) setAPIUser(c *gc.C, user names.UserTag) {
 	s.authoriser.Tag = user
-	newBroker := func(_ context.Context, args environs.OpenParams) (caas.Broker, error) {
+	newBroker := func(_ context.Context, args environs.OpenParams, _ environs.CredentialInvalidator) (caas.Broker, error) {
 		return s.caasBroker, nil
 	}
 	mm, err := modelmanager.NewModelManagerAPI(

--- a/apiserver/facades/client/sshclient/facade.go
+++ b/apiserver/facades/client/sshclient/facade.go
@@ -23,7 +23,7 @@ import (
 	"github.com/juju/juju/state"
 )
 
-type newCaasBrokerFunc func(_ context.Context, args environs.OpenParams) (Broker, error)
+type newCaasBrokerFunc func(_ context.Context, args environs.OpenParams, _ environs.CredentialInvalidator) (Broker, error)
 
 // Facade implements the API required by the sshclient worker.
 type Facade struct {
@@ -287,7 +287,7 @@ func (facade *Facade) getExecSecretToken(ctx context.Context, cloudSpec environs
 		ControllerUUID: facade.controllerUUID,
 		Cloud:          cloudSpec,
 		Config:         cfg,
-	})
+	}, environs.NoopCredentialInvalidator())
 	if err != nil {
 		return "", errors.Annotate(err, "failed to open kubernetes client")
 	}

--- a/apiserver/facades/client/sshclient/facade_test.go
+++ b/apiserver/facades/client/sshclient/facade_test.go
@@ -71,7 +71,7 @@ func (s *facadeSuite) TestNonClientNotAllowed(c *gc.C) {
 		s.controllerUUID,
 		nil,
 		s.authorizer,
-		func(context.Context, environs.OpenParams) (sshclient.Broker, error) {
+		func(context.Context, environs.OpenParams, environs.CredentialInvalidator) (sshclient.Broker, error) {
 			return s.broker, nil
 		},
 	)
@@ -100,7 +100,7 @@ func (s *facadeSuite) TestNonAuthUserDenied(c *gc.C) {
 		s.controllerUUID,
 		nil,
 		s.authorizer,
-		func(context.Context, environs.OpenParams) (sshclient.Broker, error) {
+		func(context.Context, environs.OpenParams, environs.CredentialInvalidator) (sshclient.Broker, error) {
 			return s.broker, nil
 		},
 	)
@@ -139,7 +139,7 @@ func (s *facadeSuite) TestSuperUserAuth(c *gc.C) {
 		s.controllerUUID,
 		nil,
 		s.authorizer,
-		func(context.Context, environs.OpenParams) (sshclient.Broker, error) {
+		func(context.Context, environs.OpenParams, environs.CredentialInvalidator) (sshclient.Broker, error) {
 			return s.broker, nil
 		},
 	)
@@ -184,7 +184,7 @@ func (s *facadeSuite) TestPublicAddress(c *gc.C) {
 		s.controllerUUID,
 		nil,
 		s.authorizer,
-		func(context.Context, environs.OpenParams) (sshclient.Broker, error) {
+		func(context.Context, environs.OpenParams, environs.CredentialInvalidator) (sshclient.Broker, error) {
 			return s.broker, nil
 		},
 	)
@@ -229,7 +229,7 @@ func (s *facadeSuite) TestPrivateAddress(c *gc.C) {
 		s.controllerUUID,
 		nil,
 		s.authorizer,
-		func(context.Context, environs.OpenParams) (sshclient.Broker, error) {
+		func(context.Context, environs.OpenParams, environs.CredentialInvalidator) (sshclient.Broker, error) {
 			return s.broker, nil
 		},
 	)
@@ -294,7 +294,7 @@ func (s *facadeSuite) TestAllAddresses(c *gc.C) {
 		s.controllerUUID,
 		nil,
 		s.authorizer,
-		func(context.Context, environs.OpenParams) (sshclient.Broker, error) {
+		func(context.Context, environs.OpenParams, environs.CredentialInvalidator) (sshclient.Broker, error) {
 			return s.broker, nil
 		},
 	)
@@ -355,7 +355,7 @@ func (s *facadeSuite) TestPublicKeys(c *gc.C) {
 		s.controllerUUID,
 		nil,
 		s.authorizer,
-		func(context.Context, environs.OpenParams) (sshclient.Broker, error) {
+		func(context.Context, environs.OpenParams, environs.CredentialInvalidator) (sshclient.Broker, error) {
 			return s.broker, nil
 		},
 	)
@@ -399,7 +399,7 @@ func (s *facadeSuite) TestProxyTrue(c *gc.C) {
 		s.controllerUUID,
 		nil,
 		s.authorizer,
-		func(context.Context, environs.OpenParams) (sshclient.Broker, error) {
+		func(context.Context, environs.OpenParams, environs.CredentialInvalidator) (sshclient.Broker, error) {
 			return s.broker, nil
 		},
 	)
@@ -434,7 +434,7 @@ func (s *facadeSuite) TestProxyFalse(c *gc.C) {
 		s.controllerUUID,
 		nil,
 		s.authorizer,
-		func(context.Context, environs.OpenParams) (sshclient.Broker, error) {
+		func(context.Context, environs.OpenParams, environs.CredentialInvalidator) (sshclient.Broker, error) {
 			return s.broker, nil
 		},
 	)
@@ -464,7 +464,7 @@ func (s *facadeSuite) TestModelCredentialForSSHFailedNotAuthorized(c *gc.C) {
 		s.controllerUUID,
 		nil,
 		s.authorizer,
-		func(context.Context, environs.OpenParams) (sshclient.Broker, error) {
+		func(context.Context, environs.OpenParams, environs.CredentialInvalidator) (sshclient.Broker, error) {
 			return s.broker, nil
 		},
 	)
@@ -497,7 +497,7 @@ func (s *facadeSuite) TestModelCredentialForSSHFailedNonCAASModel(c *gc.C) {
 		s.controllerUUID,
 		nil,
 		s.authorizer,
-		func(context.Context, environs.OpenParams) (sshclient.Broker, error) {
+		func(context.Context, environs.OpenParams, environs.CredentialInvalidator) (sshclient.Broker, error) {
 			return s.broker, nil
 		},
 	)
@@ -542,7 +542,7 @@ func (s *facadeSuite) TestModelCredentialForSSHFailedBadCredential(c *gc.C) {
 		s.controllerUUID,
 		nil,
 		s.authorizer,
-		func(context.Context, environs.OpenParams) (sshclient.Broker, error) {
+		func(context.Context, environs.OpenParams, environs.CredentialInvalidator) (sshclient.Broker, error) {
 			return s.broker, nil
 		},
 	)
@@ -621,7 +621,7 @@ func (s *facadeSuite) assertModelCredentialForSSH(c *gc.C) {
 		s.controllerUUID,
 		nil,
 		s.authorizer,
-		func(ctx context.Context, arg environs.OpenParams) (sshclient.Broker, error) {
+		func(ctx context.Context, arg environs.OpenParams, _ environs.CredentialInvalidator) (sshclient.Broker, error) {
 			c.Assert(arg.ControllerUUID, gc.Equals, testing.ControllerTag.Id())
 			c.Assert(arg.Cloud, gc.DeepEquals, cloudSpec)
 			return s.broker, nil

--- a/apiserver/facades/client/sshclient/register.go
+++ b/apiserver/facades/client/sshclient/register.go
@@ -51,8 +51,8 @@ func newFacade(ctx facade.ModelContext) (*Facade, error) {
 		ctx.ControllerUUID(),
 		leadershipReader,
 		ctx.Auth(),
-		func(ctx context.Context, args environs.OpenParams) (Broker, error) {
-			return caas.New(ctx, args)
+		func(ctx context.Context, args environs.OpenParams, invalidator environs.CredentialInvalidator) (Broker, error) {
+			return caas.New(ctx, args, invalidator)
 		},
 	)
 }

--- a/apiserver/facades/client/subnets/cache.go
+++ b/apiserver/facades/client/subnets/cache.go
@@ -79,7 +79,7 @@ func updateZones(ctx envcontext.ProviderCallContext, api Backing) (network.Avail
 // model config. If the model does not support zones, an error satisfying
 // errors.IsNotSupported() will be returned.
 func zonedEnviron(ctx context.Context, api Backing) (providercommon.ZonedEnviron, error) {
-	env, err := environs.GetEnviron(ctx, api, environs.New)
+	env, err := environs.GetEnviron(ctx, api, environs.NoopCredentialInvalidator(), environs.New)
 	if err != nil {
 		return nil, errors.Annotate(err, "opening environment")
 	}

--- a/apiserver/testing/stub_network.go
+++ b/apiserver/testing/stub_network.go
@@ -332,7 +332,7 @@ type StubProvider struct {
 
 var _ environs.EnvironProvider = (*StubProvider)(nil)
 
-func (sp *StubProvider) Open(_ context.Context, args environs.OpenParams) (environs.Environ, error) {
+func (sp *StubProvider) Open(_ context.Context, args environs.OpenParams, _ environs.CredentialInvalidator) (environs.Environ, error) {
 	sp.MethodCall(sp, "Open", args.Config)
 	if err := sp.NextErr(); err != nil {
 		return nil, err

--- a/caas/broker.go
+++ b/caas/broker.go
@@ -32,7 +32,7 @@ type ContainerEnvironProvider interface {
 	//
 	// Open should not perform any expensive operations, such as querying
 	// the cloud API, as it will be called frequently.
-	Open(ctx context.Context, args environs.OpenParams) (Broker, error)
+	Open(ctx context.Context, args environs.OpenParams, invalidator environs.CredentialInvalidator) (Broker, error)
 }
 
 // RegisterContainerProvider is used for providers that we want to use for managing 'instances',
@@ -47,26 +47,26 @@ func RegisterContainerProvider(name string, p ContainerEnvironProvider, alias ..
 }
 
 // New returns a new broker based on the provided configuration.
-func New(ctx context.Context, args environs.OpenParams) (Broker, error) {
+func New(ctx context.Context, args environs.OpenParams, invalidator environs.CredentialInvalidator) (Broker, error) {
 	p, err := environs.Provider(args.Cloud.Type)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return Open(ctx, p, args)
+	return Open(ctx, p, args, invalidator)
 }
 
 // Open creates a Broker instance and errors if the provider is not for
 // a container substrate.
-func Open(ctx context.Context, p environs.EnvironProvider, args environs.OpenParams) (Broker, error) {
+func Open(ctx context.Context, p environs.EnvironProvider, args environs.OpenParams, invalidator environs.CredentialInvalidator) (Broker, error) {
 	if envProvider, ok := p.(ContainerEnvironProvider); !ok {
 		return nil, errors.NotValidf("container environ provider %T", p)
 	} else {
-		return envProvider.Open(ctx, args)
+		return envProvider.Open(ctx, args, invalidator)
 	}
 }
 
 // NewContainerBrokerFunc returns a Container Broker.
-type NewContainerBrokerFunc func(ctx context.Context, args environs.OpenParams) (Broker, error)
+type NewContainerBrokerFunc func(ctx context.Context, args environs.OpenParams, invalidator environs.CredentialInvalidator) (Broker, error)
 
 // StatusCallbackFunc represents a function that can be called to report a status.
 type StatusCallbackFunc func(appName string, settableStatus status.Status, info string, data map[string]interface{}) error

--- a/caas/kubernetes/provider/cloud.go
+++ b/caas/kubernetes/provider/cloud.go
@@ -172,7 +172,7 @@ func (p kubernetesEnvironProvider) FinalizeCloud(ctx environs.FinalizeCloudConte
 	if err != nil {
 		return cloud.Cloud{}, errors.Trace(err)
 	}
-	broker, err := p.brokerGetter(ctx, openParams)
+	broker, err := p.brokerGetter(ctx, openParams, environs.NoopCredentialInvalidator())
 	if err != nil {
 		return cloud.Cloud{}, errors.Trace(err)
 	}

--- a/caas/kubernetes/provider/cloud_test.go
+++ b/caas/kubernetes/provider/cloud_test.go
@@ -116,7 +116,7 @@ func (s *cloudSuite) getProvider() caas.ContainerEnvironProvider {
 		s.runner,
 		credentialGetterFunc(ret),
 		cloudGetterFunc(ret),
-		func(context.Context, environs.OpenParams) (provider.ClusterMetadataStorageChecker, error) {
+		func(context.Context, environs.OpenParams, environs.CredentialInvalidator) (provider.ClusterMetadataStorageChecker, error) {
 			return &s.fakeBroker, nil
 		},
 	)

--- a/caas/kubernetes/provider/detectcloud_test.go
+++ b/caas/kubernetes/provider/detectcloud_test.go
@@ -65,7 +65,7 @@ func (s *detectCloudSuite) getProvider(builtin builtinCloudRet) caas.ContainerEn
 		dummyRunner{},
 		credentialGetterFunc(builtin),
 		cloudGetterFunc(builtin),
-		func(context.Context, environs.OpenParams) (provider.ClusterMetadataStorageChecker, error) {
+		func(context.Context, environs.OpenParams, environs.CredentialInvalidator) (provider.ClusterMetadataStorageChecker, error) {
 			return &fakeK8sClusterMetadataChecker{}, nil
 		},
 	)

--- a/caas/kubernetes/provider/export_test.go
+++ b/caas/kubernetes/provider/export_test.go
@@ -104,7 +104,7 @@ func NewProviderWithFakes(
 	runner CommandRunner,
 	credentialGetter func(context.Context, CommandRunner) (jujucloud.Credential, error),
 	getter func(CommandRunner) (jujucloud.Cloud, error),
-	brokerGetter func(context.Context, environs.OpenParams) (ClusterMetadataStorageChecker, error)) caas.ContainerEnvironProvider {
+	brokerGetter func(context.Context, environs.OpenParams, environs.CredentialInvalidator) (ClusterMetadataStorageChecker, error)) caas.ContainerEnvironProvider {
 	return kubernetesEnvironProvider{
 		environProviderCredentials: environProviderCredentials{
 			cmdRunner:               runner,

--- a/caas/kubernetes/provider/provider_test.go
+++ b/caas/kubernetes/provider/provider_test.go
@@ -82,7 +82,7 @@ func (s *providerSuite) TestOpen(c *gc.C) {
 	broker, err := s.provider.Open(context.Background(), environs.OpenParams{
 		Cloud:  fakeCloudSpec(),
 		Config: config,
-	})
+	}, environs.NoopCredentialInvalidator())
 	c.Check(err, jc.ErrorIsNil)
 	c.Assert(broker, gc.NotNil)
 }
@@ -110,7 +110,7 @@ func (s *providerSuite) testOpenError(c *gc.C, spec environscloudspec.CloudSpec,
 	_, err := s.provider.Open(context.Background(), environs.OpenParams{
 		Cloud:  spec,
 		Config: fakeConfig(c),
-	})
+	}, environs.NoopCredentialInvalidator())
 	c.Assert(err, gc.ErrorMatches, expect)
 }
 

--- a/cmd/juju/caas/add.go
+++ b/cmd/juju/caas/add.go
@@ -708,7 +708,7 @@ func (c *AddCAASCommand) newK8sClusterBroker(ctx context.Context, cloud jujuclou
 		openParams.ControllerUUID = ctrlUUID
 	}
 
-	broker, err := caas.New(ctx, openParams)
+	broker, err := caas.New(ctx, openParams, environs.NoopCredentialInvalidator())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/cmd/juju/caas/update.go
+++ b/cmd/juju/caas/update.go
@@ -167,7 +167,7 @@ func (c *UpdateCAASCommand) newK8sClusterBroker(ctx context.Context, cloud jujuc
 		openParams.ControllerUUID = ctrlUUID
 	}
 
-	broker, err := caas.New(ctx, openParams)
+	broker, err := caas.New(ctx, openParams, environs.NoopCredentialInvalidator())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/cmd/juju/commands/bootstrap_test.go
+++ b/cmd/juju/commands/bootstrap_test.go
@@ -1235,7 +1235,7 @@ func (s *BootstrapSuite) TestAutoSyncLocalSource(c *gc.C) {
 	env, err := environs.New(context.Background(), environs.OpenParams{
 		Cloud:  *spec,
 		Config: cfg,
-	})
+	}, environs.NoopCredentialInvalidator())
 	c.Assert(err, jc.ErrorIsNil)
 	err = env.PrepareForBootstrap(envtesting.BootstrapContext(context.Background(), c), "controller-1")
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/juju/controller/destroy.go
+++ b/cmd/juju/controller/destroy.go
@@ -661,9 +661,9 @@ func (c *destroyCommandBase) getControllerEnvironFromStore(
 		Config:         cfg,
 	}
 	if cloud.CloudTypeIsCAAS(bootstrapConfig.CloudType) {
-		return caas.New(ctx, openParams)
+		return caas.New(ctx, openParams, environs.NoopCredentialInvalidator())
 	}
-	return environs.New(ctx, openParams)
+	return environs.New(ctx, openParams, environs.NoopCredentialInvalidator())
 }
 
 func (c *destroyCommandBase) getControllerEnvironFromAPI(
@@ -696,5 +696,5 @@ func (c *destroyCommandBase) getControllerEnvironFromAPI(
 		ControllerUUID: ctrlCfg.ControllerUUID(),
 		Cloud:          cloudSpec,
 		Config:         cfg,
-	})
+	}, environs.NoopCredentialInvalidator())
 }

--- a/cmd/juju/controller/kill.go
+++ b/cmd/juju/controller/kill.go
@@ -260,9 +260,9 @@ func (c *killCommand) DirectDestroyRemaining(
 			}
 			var env environs.CloudDestroyer
 			if cloud.CloudTypeIsCAAS(model.CloudSpec.Type) {
-				env, err = caas.Open(ctx, cloudProvider, openParams)
+				env, err = caas.Open(ctx, cloudProvider, openParams, environs.NoopCredentialInvalidator())
 			} else {
-				env, err = environs.Open(ctx, cloudProvider, openParams)
+				env, err = environs.Open(ctx, cloudProvider, openParams, environs.NoopCredentialInvalidator())
 			}
 			if err != nil {
 				logger.Warningf(context.TODO(), err.Error())

--- a/cmd/jujud-controller/agent/bootstrap.go
+++ b/cmd/jujud-controller/agent/bootstrap.go
@@ -205,9 +205,9 @@ func (c *BootstrapCommand) Run(ctx *cmd.Context) error {
 
 	var env environs.BootstrapEnviron
 	if isCAAS {
-		env, err = environsNewCAAS(ctx, openParams)
+		env, err = environsNewCAAS(ctx, openParams, environs.NoopCredentialInvalidator())
 	} else {
-		env, err = environsNewIAAS(ctx, openParams)
+		env, err = environsNewIAAS(ctx, openParams, environs.NoopCredentialInvalidator())
 	}
 	if err != nil {
 		return errors.Trace(err)

--- a/cmd/jujud-controller/agent/bootstrap_test.go
+++ b/cmd/jujud-controller/agent/bootstrap_test.go
@@ -422,7 +422,7 @@ func (s *BootstrapSuite) makeTestModel(c *gc.C) {
 	env, err := environs.Open(context.Background(), provider, environs.OpenParams{
 		Cloud:  testing.FakeCloudSpec(),
 		Config: cfg,
-	})
+	}, environs.NoopCredentialInvalidator())
 	c.Assert(err, jc.ErrorIsNil)
 	err = env.PrepareForBootstrap(nullContext(), "controller-1")
 	c.Assert(err, jc.ErrorIsNil)

--- a/cmd/jujud-controller/agent/machine/manifolds.go
+++ b/cmd/jujud-controller/agent/machine/manifolds.go
@@ -285,10 +285,10 @@ type ManifoldsConfig struct {
 
 	// NewEnvironFunc is a function opens a provider "environment"
 	// (typically environs.New).
-	NewEnvironFunc func(context.Context, environs.OpenParams) (environs.Environ, error)
+	NewEnvironFunc func(context.Context, environs.OpenParams, environs.CredentialInvalidator) (environs.Environ, error)
 
 	// NewCAASBrokerFunc is a function opens a CAAS broker.
-	NewCAASBrokerFunc func(context.Context, environs.OpenParams) (caas.Broker, error)
+	NewCAASBrokerFunc func(context.Context, environs.OpenParams, environs.CredentialInvalidator) (caas.Broker, error)
 }
 
 // commonManifolds returns a set of co-configured manifolds covering the
@@ -873,11 +873,11 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			NewWorker:                    providertracker.NewWorker,
 			NewTrackerWorker:             providertracker.NewTrackerWorker,
 			GetProviderServicesGetter:    providertracker.GetProviderServicesGetter,
-			GetIAASProvider: providertracker.IAASGetProvider(func(ctx context.Context, args environs.OpenParams) (environs.Environ, error) {
-				return config.NewEnvironFunc(ctx, args)
+			GetIAASProvider: providertracker.IAASGetProvider(func(ctx context.Context, args environs.OpenParams, invalidator environs.CredentialInvalidator) (environs.Environ, error) {
+				return config.NewEnvironFunc(ctx, args, invalidator)
 			}),
-			GetCAASProvider: providertracker.CAASGetProvider(func(ctx context.Context, args environs.OpenParams) (caas.Broker, error) {
-				return config.NewCAASBrokerFunc(ctx, args)
+			GetCAASProvider: providertracker.CAASGetProvider(func(ctx context.Context, args environs.OpenParams, invalidator environs.CredentialInvalidator) (caas.Broker, error) {
+				return config.NewCAASBrokerFunc(ctx, args, invalidator)
 			}),
 			Logger: internallogger.GetLogger("juju.worker.providertracker"),
 			Clock:  config.Clock,

--- a/cmd/jujud-controller/agent/model/manifolds.go
+++ b/cmd/jujud-controller/agent/model/manifolds.go
@@ -312,11 +312,11 @@ func commonManifolds(config ManifoldsConfig) dependency.Manifolds {
 			NewWorker:                    providertracker.NewWorker,
 			NewTrackerWorker:             providertracker.NewTrackerWorker,
 			GetProviderServicesGetter:    providertracker.GetModelProviderServicesGetter,
-			GetIAASProvider: providertracker.IAASGetProvider(func(ctx context.Context, args environs.OpenParams) (environs.Environ, error) {
-				return config.NewEnvironFunc(ctx, args)
+			GetIAASProvider: providertracker.IAASGetProvider(func(ctx context.Context, args environs.OpenParams, invalidator environs.CredentialInvalidator) (environs.Environ, error) {
+				return config.NewEnvironFunc(ctx, args, invalidator)
 			}),
-			GetCAASProvider: providertracker.CAASGetProvider(func(ctx context.Context, args environs.OpenParams) (caas.Broker, error) {
-				return config.NewContainerBrokerFunc(ctx, args)
+			GetCAASProvider: providertracker.CAASGetProvider(func(ctx context.Context, args environs.OpenParams, invalidator environs.CredentialInvalidator) (caas.Broker, error) {
+				return config.NewContainerBrokerFunc(ctx, args, invalidator)
 			}),
 			Logger: config.LoggingContext.GetLogger("juju.worker.providertracker"),
 			Clock:  config.Clock,
@@ -387,8 +387,8 @@ func IAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 			NewFacade:                    undertaker.NewFacade,
 			NewWorker:                    undertaker.NewWorker,
 			NewCredentialValidatorFacade: common.NewCredentialInvalidatorFacade,
-			NewCloudDestroyerFunc: func(ctx context.Context, params environs.OpenParams) (environs.CloudDestroyer, error) {
-				return config.NewEnvironFunc(ctx, params)
+			NewCloudDestroyerFunc: func(ctx context.Context, params environs.OpenParams, invalidator environs.CredentialInvalidator) (environs.CloudDestroyer, error) {
+				return config.NewEnvironFunc(ctx, params, invalidator)
 			},
 		})),
 
@@ -475,8 +475,8 @@ func CAASManifolds(config ManifoldsConfig) dependency.Manifolds {
 			NewFacade:                    undertaker.NewFacade,
 			NewWorker:                    undertaker.NewWorker,
 			NewCredentialValidatorFacade: common.NewCredentialInvalidatorFacade,
-			NewCloudDestroyerFunc: func(ctx context.Context, params environs.OpenParams) (environs.CloudDestroyer, error) {
-				return config.NewContainerBrokerFunc(ctx, params)
+			NewCloudDestroyerFunc: func(ctx context.Context, params environs.OpenParams, invalidator environs.CredentialInvalidator) (environs.CloudDestroyer, error) {
+				return config.NewContainerBrokerFunc(ctx, params, invalidator)
 			},
 		})),
 

--- a/cmd/jujud/agent/machine/manifolds.go
+++ b/cmd/jujud/agent/machine/manifolds.go
@@ -189,7 +189,7 @@ type ManifoldsConfig struct {
 
 	// NewEnvironFunc is a function opens a provider "environment"
 	// (typically environs.New).
-	NewEnvironFunc func(context.Context, environs.OpenParams) (environs.Environ, error)
+	NewEnvironFunc func(context.Context, environs.OpenParams, environs.CredentialInvalidator) (environs.Environ, error)
 }
 
 type HTTPClient interface {

--- a/cmd/plugins/juju-metadata/imagemetadata.go
+++ b/cmd/plugins/juju-metadata/imagemetadata.go
@@ -54,7 +54,7 @@ func prepare(ctx *cmd.Context, controllerName string, store jujuclient.ClientSto
 	return environs.New(ctx, environs.OpenParams{
 		Cloud:  *spec,
 		Config: cfg,
-	})
+	}, environs.NoopCredentialInvalidator())
 }
 
 func newImageMetadataCommand() cmd.Command {

--- a/domain/credential/service/modelcredential.go
+++ b/domain/credential/service/modelcredential.go
@@ -116,8 +116,11 @@ func (v defaultCredentialValidator) Validate(
 	}
 }
 
+// TODO (stickupkid): This should be removed with haste.
+// Instead the provider factory should allow you to get a provider without a
+// credential validator.
 func checkCAASModelCredential(ctx context.Context, brokerParams environs.OpenParams) ([]error, error) {
-	broker, err := newCAASBroker(ctx, brokerParams)
+	broker, err := newCAASBroker(ctx, brokerParams, environs.NoopCredentialInvalidator())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -128,8 +131,11 @@ func checkCAASModelCredential(ctx context.Context, brokerParams environs.OpenPar
 	return nil, nil
 }
 
+// TODO (stickupkid): This should be removed with haste.
+// Instead the provider factory should allow you to get a provider without a
+// credential validator.
 func checkIAASModelCredential(ctx context.Context, machineState MachineState, machineService MachineService, openParams environs.OpenParams, checkCloudInstances bool) ([]error, error) {
-	env, err := newEnv(ctx, openParams)
+	env, err := newEnv(ctx, openParams, environs.NoopCredentialInvalidator())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/environs/bootstrap/prepare.go
+++ b/environs/bootstrap/prepare.go
@@ -133,10 +133,10 @@ func PrepareController(
 	}
 	if isCAASController {
 		details.ModelType = model.CAAS
-		env, err = caas.Open(ctx, p, openParams)
+		env, err = caas.Open(ctx, p, openParams, environs.NoopCredentialInvalidator())
 	} else {
 		details.ModelType = model.IAAS
-		env, err = environs.Open(ctx, p, openParams)
+		env, err = environs.Open(ctx, p, openParams, environs.NoopCredentialInvalidator())
 	}
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/environs/environ.go
+++ b/environs/environ.go
@@ -14,24 +14,41 @@ import (
 
 // EnvironConfigGetter exposes a model configuration to its clients.
 type EnvironConfigGetter interface {
+	// ModelConfig returns the current config for the model, this is used
+	// to create the environ.
 	ModelConfig(context.Context) (*config.Config, error)
+
+	// CloudSpec returns the cloud spec for the model, this is used to create
+	// the environ.
 	CloudSpec(context.Context) (environscloudspec.CloudSpec, error)
+}
+
+// CredentialInvalidReason is an enumeration of reasons why credentials
+// might be invalidated.
+type CredentialInvalidReason string
+
+// CredentialInvalidator is an interface that can invalidate a provider
+// credentials.
+type CredentialInvalidator interface {
+	// InvalidateCredentials invalidates the credentials for the provider.
+	// The reason argument indicates why the credentials are being invalidated.
+	InvalidateCredentials(context.Context, CredentialInvalidReason) error
 }
 
 // NewEnvironFunc is the type of a function that, given a model config,
 // returns an Environ. This will typically be environs.New.
-type NewEnvironFunc func(context.Context, OpenParams) (Environ, error)
+type NewEnvironFunc func(context.Context, OpenParams, CredentialInvalidator) (Environ, error)
 
 // GetEnviron returns the environs.Environ ("provider") associated
 // with the model.
-func GetEnviron(ctx context.Context, st EnvironConfigGetter, newEnviron NewEnvironFunc) (Environ, error) {
-	env, _, err := GetEnvironAndCloud(ctx, st, newEnviron)
+func GetEnviron(ctx context.Context, st EnvironConfigGetter, invalidator CredentialInvalidator, newEnviron NewEnvironFunc) (Environ, error) {
+	env, _, err := GetEnvironAndCloud(ctx, st, invalidator, newEnviron)
 	return env, err
 }
 
 // GetEnvironAndCloud returns the environs.Environ ("provider") and cloud associated
 // with the model.
-func GetEnvironAndCloud(ctx context.Context, getter EnvironConfigGetter, newEnviron NewEnvironFunc) (Environ, *environscloudspec.CloudSpec, error) {
+func GetEnvironAndCloud(ctx context.Context, getter EnvironConfigGetter, invalidator CredentialInvalidator, newEnviron NewEnvironFunc) (Environ, *environscloudspec.CloudSpec, error) {
 	modelConfig, err := getter.ModelConfig(ctx)
 	if err != nil {
 		return nil, nil, errors.Annotate(err, "retrieving model config")
@@ -46,10 +63,21 @@ func GetEnvironAndCloud(ctx context.Context, getter EnvironConfigGetter, newEnvi
 	env, err := newEnviron(ctx, OpenParams{
 		Cloud:  cloudSpec,
 		Config: modelConfig,
-	})
+	}, invalidator)
 	if err != nil {
 		return nil, nil, errors.Annotatef(
 			err, "creating environ for model %q (%s)", modelConfig.Name(), modelConfig.UUID())
 	}
 	return env, &cloudSpec, nil
+}
+
+// NoopCredentialInvalidator returns a CredentialInvalidator that does nothing.
+func NoopCredentialInvalidator() CredentialInvalidator {
+	return noopCredentialInvalidator{}
+}
+
+type noopCredentialInvalidator struct{}
+
+func (noopCredentialInvalidator) InvalidateCredentials(context.Context, CredentialInvalidReason) error {
+	return nil
 }

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -84,7 +84,7 @@ type CloudEnvironProvider interface {
 	//
 	// Open should not perform any expensive operations, such as querying
 	// the cloud API, as it will be called frequently.
-	Open(context.Context, OpenParams) (Environ, error)
+	Open(context.Context, OpenParams, CredentialInvalidator) (Environ, error)
 }
 
 // OpenParams contains the parameters for EnvironProvider.Open.

--- a/environs/jujutest/tests.go
+++ b/environs/jujutest/tests.go
@@ -67,7 +67,7 @@ func (t *Tests) Open(c *gc.C, ctx context.Context, cfg *config.Config) environs.
 	e, err := environs.New(ctx, environs.OpenParams{
 		Cloud:  t.CloudSpec(),
 		Config: cfg,
-	})
+	}, environs.NoopCredentialInvalidator())
 	c.Assert(err, gc.IsNil, gc.Commentf("opening environ %#v", cfg.AllAttrs()))
 	c.Assert(e, gc.NotNil)
 	return e

--- a/environs/mocks/package_mock.go
+++ b/environs/mocks/package_mock.go
@@ -2153,18 +2153,18 @@ func (c *MockCloudEnvironProviderFinalizeCredentialCall) DoAndReturn(f func(envi
 }
 
 // Open mocks base method.
-func (m *MockCloudEnvironProvider) Open(arg0 context.Context, arg1 environs.OpenParams) (environs.Environ, error) {
+func (m *MockCloudEnvironProvider) Open(arg0 context.Context, arg1 environs.OpenParams, arg2 environs.CredentialInvalidator) (environs.Environ, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Open", arg0, arg1)
+	ret := m.ctrl.Call(m, "Open", arg0, arg1, arg2)
 	ret0, _ := ret[0].(environs.Environ)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Open indicates an expected call of Open.
-func (mr *MockCloudEnvironProviderMockRecorder) Open(arg0, arg1 any) *MockCloudEnvironProviderOpenCall {
+func (mr *MockCloudEnvironProviderMockRecorder) Open(arg0, arg1, arg2 any) *MockCloudEnvironProviderOpenCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Open", reflect.TypeOf((*MockCloudEnvironProvider)(nil).Open), arg0, arg1)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Open", reflect.TypeOf((*MockCloudEnvironProvider)(nil).Open), arg0, arg1, arg2)
 	return &MockCloudEnvironProviderOpenCall{Call: call}
 }
 
@@ -2180,13 +2180,13 @@ func (c *MockCloudEnvironProviderOpenCall) Return(arg0 environs.Environ, arg1 er
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockCloudEnvironProviderOpenCall) Do(f func(context.Context, environs.OpenParams) (environs.Environ, error)) *MockCloudEnvironProviderOpenCall {
+func (c *MockCloudEnvironProviderOpenCall) Do(f func(context.Context, environs.OpenParams, environs.CredentialInvalidator) (environs.Environ, error)) *MockCloudEnvironProviderOpenCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockCloudEnvironProviderOpenCall) DoAndReturn(f func(context.Context, environs.OpenParams) (environs.Environ, error)) *MockCloudEnvironProviderOpenCall {
+func (c *MockCloudEnvironProviderOpenCall) DoAndReturn(f func(context.Context, environs.OpenParams, environs.CredentialInvalidator) (environs.Environ, error)) *MockCloudEnvironProviderOpenCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/environs/open.go
+++ b/environs/open.go
@@ -16,20 +16,20 @@ import (
 const AdminUser = "admin"
 
 // New returns a new environment based on the provided configuration.
-func New(ctx context.Context, args OpenParams) (Environ, error) {
+func New(ctx context.Context, args OpenParams, invalidator CredentialInvalidator) (Environ, error) {
 	p, err := Provider(args.Cloud.Type)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return Open(ctx, p, args)
+	return Open(ctx, p, args, invalidator)
 }
 
 // Open creates an Environ instance and errors if the provider is not for a cloud.
-func Open(ctx context.Context, p EnvironProvider, args OpenParams) (Environ, error) {
+func Open(ctx context.Context, p EnvironProvider, args OpenParams, invalidator CredentialInvalidator) (Environ, error) {
 	if envProvider, ok := p.(CloudEnvironProvider); !ok {
 		return nil, errors.NotValidf("cloud environ provider %T", p)
 	} else {
-		return envProvider.Open(ctx, args)
+		return envProvider.Open(ctx, args, invalidator)
 	}
 }
 

--- a/environs/open_test.go
+++ b/environs/open_test.go
@@ -120,7 +120,7 @@ func (*OpenSuite) TestNewUnknownEnviron(c *gc.C) {
 		Cloud: environscloudspec.CloudSpec{
 			Type: "wondercloud",
 		},
-	})
+	}, environs.NoopCredentialInvalidator())
 	c.Assert(err, gc.ErrorMatches, "no registered provider for.*")
 	c.Assert(env, gc.IsNil)
 }
@@ -137,7 +137,7 @@ func (*OpenSuite) TestNew(c *gc.C) {
 	e, err := environs.New(ctx, environs.OpenParams{
 		Cloud:  testing.FakeCloudSpec(),
 		Config: cfg,
-	})
+	}, environs.NoopCredentialInvalidator())
 	c.Assert(err, jc.ErrorIsNil)
 	_, err = e.ControllerInstances(envcontext.WithoutCredentialInvalidator(ctx), "uuid")
 	c.Assert(err, gc.ErrorMatches, "model is not prepared")

--- a/environs/testing/package_mock.go
+++ b/environs/testing/package_mock.go
@@ -538,18 +538,18 @@ func (c *MockCloudEnvironProviderFinalizeCredentialCall) DoAndReturn(f func(envi
 }
 
 // Open mocks base method.
-func (m *MockCloudEnvironProvider) Open(arg0 context.Context, arg1 environs.OpenParams) (environs.Environ, error) {
+func (m *MockCloudEnvironProvider) Open(arg0 context.Context, arg1 environs.OpenParams, arg2 environs.CredentialInvalidator) (environs.Environ, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Open", arg0, arg1)
+	ret := m.ctrl.Call(m, "Open", arg0, arg1, arg2)
 	ret0, _ := ret[0].(environs.Environ)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Open indicates an expected call of Open.
-func (mr *MockCloudEnvironProviderMockRecorder) Open(arg0, arg1 any) *MockCloudEnvironProviderOpenCall {
+func (mr *MockCloudEnvironProviderMockRecorder) Open(arg0, arg1, arg2 any) *MockCloudEnvironProviderOpenCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Open", reflect.TypeOf((*MockCloudEnvironProvider)(nil).Open), arg0, arg1)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Open", reflect.TypeOf((*MockCloudEnvironProvider)(nil).Open), arg0, arg1, arg2)
 	return &MockCloudEnvironProviderOpenCall{Call: call}
 }
 
@@ -565,13 +565,13 @@ func (c *MockCloudEnvironProviderOpenCall) Return(arg0 environs.Environ, arg1 er
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockCloudEnvironProviderOpenCall) Do(f func(context.Context, environs.OpenParams) (environs.Environ, error)) *MockCloudEnvironProviderOpenCall {
+func (c *MockCloudEnvironProviderOpenCall) Do(f func(context.Context, environs.OpenParams, environs.CredentialInvalidator) (environs.Environ, error)) *MockCloudEnvironProviderOpenCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockCloudEnvironProviderOpenCall) DoAndReturn(f func(context.Context, environs.OpenParams) (environs.Environ, error)) *MockCloudEnvironProviderOpenCall {
+func (c *MockCloudEnvironProviderOpenCall) DoAndReturn(f func(context.Context, environs.OpenParams, environs.CredentialInvalidator) (environs.Environ, error)) *MockCloudEnvironProviderOpenCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/provider/azure/environ_test.go
+++ b/internal/provider/azure/environ_test.go
@@ -317,7 +317,7 @@ func openEnviron(
 	env, err := environs.Open(context.Background(), provider, environs.OpenParams{
 		Cloud:  fakeCloudSpec(),
 		Config: cfg,
-	})
+	}, environs.NoopCredentialInvalidator())
 	c.Assert(err, jc.ErrorIsNil)
 	return env
 }
@@ -344,7 +344,7 @@ func prepareForBootstrap(
 	env, err := environs.Open(context.Background(), provider, environs.OpenParams{
 		Cloud:  fakeCloudSpec(),
 		Config: cfg,
-	})
+	}, environs.NoopCredentialInvalidator())
 	c.Assert(err, jc.ErrorIsNil)
 
 	*sender = azuretesting.Senders{}

--- a/internal/provider/azure/environprovider.go
+++ b/internal/provider/azure/environprovider.go
@@ -118,7 +118,7 @@ func (prov *azureEnvironProvider) Version() int {
 }
 
 // Open is part of the EnvironProvider interface.
-func (prov *azureEnvironProvider) Open(ctx context.Context, args environs.OpenParams) (environs.Environ, error) {
+func (prov *azureEnvironProvider) Open(ctx context.Context, args environs.OpenParams, invalidator environs.CredentialInvalidator) (environs.Environ, error) {
 	logger.Debugf(context.TODO(), "opening model %q", args.Config.Name())
 
 	namespace, err := instance.NewNamespace(args.Config.UUID())

--- a/internal/provider/azure/environprovider_test.go
+++ b/internal/provider/azure/environprovider_test.go
@@ -80,7 +80,7 @@ func (s *environProviderSuite) TestOpen(c *gc.C) {
 	env, err := environs.Open(context.Background(), s.provider, environs.OpenParams{
 		Cloud:  s.spec,
 		Config: makeTestModelConfig(c),
-	})
+	}, environs.NoopCredentialInvalidator())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(env, gc.NotNil)
 }
@@ -104,7 +104,7 @@ func (s *environProviderSuite) testOpenError(c *gc.C, spec environscloudspec.Clo
 	_, err := environs.Open(context.Background(), s.provider, environs.OpenParams{
 		Cloud:  spec,
 		Config: makeTestModelConfig(c),
-	})
+	}, environs.NoopCredentialInvalidator())
 	c.Assert(err, gc.ErrorMatches, expect)
 }
 

--- a/internal/provider/dummy/environs.go
+++ b/internal/provider/dummy/environs.go
@@ -291,7 +291,7 @@ func (*environProvider) Version() int {
 	return 0
 }
 
-func (p *environProvider) Open(ctx context.Context, args environs.OpenParams) (environs.Environ, error) {
+func (p *environProvider) Open(ctx context.Context, args environs.OpenParams, invalidator environs.CredentialInvalidator) (environs.Environ, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	ecfg, err := p.newConfig(ctx, args.Config)

--- a/internal/provider/ec2/config_test.go
+++ b/internal/provider/ec2/config_test.go
@@ -66,7 +66,7 @@ func (t configTest) check(c *gc.C) {
 	e, err := environs.New(context.Background(), environs.OpenParams{
 		Cloud:  cloudSpec,
 		Config: cfg,
-	})
+	}, environs.NoopCredentialInvalidator())
 	if t.change != nil {
 		c.Assert(err, jc.ErrorIsNil)
 

--- a/internal/provider/ec2/ebs_test.go
+++ b/internal/provider/ec2/ebs_test.go
@@ -89,7 +89,7 @@ func (s *ebsSuite) ebsProvider(c *gc.C) storage.Provider {
 			Credential: &credential,
 		},
 		Config: s.modelConfig,
-	})
+	}, environs.NoopCredentialInvalidator())
 	c.Assert(err, jc.ErrorIsNil)
 
 	p, err := env.StorageProvider(ec2.EBS_ProviderType)

--- a/internal/provider/ec2/local_test.go
+++ b/internal/provider/ec2/local_test.go
@@ -592,7 +592,7 @@ func (t *localServerSuite) TestDestroyHostedModelDeleteSecurityGroupInsistentlyE
 	hostedEnv, err := environs.New(t.BootstrapContext, environs.OpenParams{
 		Cloud:  t.CloudSpec(),
 		Config: env.Config(),
-	})
+	}, environs.NoopCredentialInvalidator())
 	c.Assert(err, jc.ErrorIsNil)
 
 	msg := "destroy security group error"
@@ -619,7 +619,7 @@ func (t *localServerSuite) TestDestroyControllerDestroysHostedModelResources(c *
 	env, err := environs.New(t.BootstrapContext, environs.OpenParams{
 		Cloud:  t.CloudSpec(),
 		Config: cfg,
-	})
+	}, environs.NoopCredentialInvalidator())
 	c.Assert(err, jc.ErrorIsNil)
 	inst, _ := testing.AssertStartInstance(c, env, t.callCtx, t.ControllerUUID, "0")
 	c.Assert(err, jc.ErrorIsNil)
@@ -2314,7 +2314,7 @@ func (s *localServerSuite) TestAdoptResources(c *gc.C) {
 		Cloud:          s.CloudSpec(),
 		Config:         cfg,
 		ControllerUUID: coretesting.ControllerTag.Id(),
-	})
+	}, environs.NoopCredentialInvalidator())
 	c.Assert(err, jc.ErrorIsNil)
 	inst, _ := testing.AssertStartInstance(c, env, s.callCtx, s.ControllerUUID, "0")
 	c.Assert(err, jc.ErrorIsNil)

--- a/internal/provider/ec2/provider.go
+++ b/internal/provider/ec2/provider.go
@@ -37,7 +37,7 @@ func (environProvider) Version() int {
 }
 
 // Open is specified in the EnvironProvider interface.
-func (p environProvider) Open(ctx context.Context, args environs.OpenParams) (environs.Environ, error) {
+func (p environProvider) Open(ctx context.Context, args environs.OpenParams, invalidator environs.CredentialInvalidator) (environs.Environ, error) {
 	logger.Debugf(context.TODO(), "opening model %q", args.Config.Name())
 
 	e := newEnviron()

--- a/internal/provider/ec2/provider_test.go
+++ b/internal/provider/ec2/provider_test.go
@@ -55,7 +55,7 @@ func (s *ProviderSuite) TestOpen(c *gc.C) {
 	env, err := environs.Open(context.Background(), s.provider, environs.OpenParams{
 		Cloud:  s.spec,
 		Config: coretesting.ModelConfig(c),
-	})
+	}, environs.NoopCredentialInvalidator())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(env, gc.NotNil)
 }
@@ -75,7 +75,7 @@ func (s *ProviderSuite) testOpenError(c *gc.C, spec environscloudspec.CloudSpec,
 	_, err := environs.Open(context.Background(), s.provider, environs.OpenParams{
 		Cloud:  spec,
 		Config: coretesting.ModelConfig(c),
-	})
+	}, environs.NoopCredentialInvalidator())
 	c.Assert(err, gc.ErrorMatches, expect)
 }
 

--- a/internal/provider/gce/config_test.go
+++ b/internal/provider/gce/config_test.go
@@ -104,7 +104,7 @@ func (s *ConfigSuite) TestNewModelConfig(c *gc.C) {
 		environ, err := environs.New(context.Background(), environs.OpenParams{
 			Cloud:  gce.MakeTestCloudSpec(),
 			Config: testConfig,
-		})
+		}, environs.NoopCredentialInvalidator())
 
 		// Check the result
 		if test.err != "" {
@@ -182,7 +182,7 @@ func (s *ConfigSuite) TestSetConfig(c *gc.C) {
 		environ, err := environs.New(context.Background(), environs.OpenParams{
 			Cloud:  gce.MakeTestCloudSpec(),
 			Config: s.config,
-		})
+		}, environs.NoopCredentialInvalidator())
 		c.Assert(err, jc.ErrorIsNil)
 
 		testConfig := test.newConfig(c)

--- a/internal/provider/gce/provider.go
+++ b/internal/provider/gce/provider.go
@@ -38,7 +38,7 @@ func (environProvider) Version() int {
 }
 
 // Open implements environs.EnvironProvider.
-func (environProvider) Open(ctx context.Context, args environs.OpenParams) (environs.Environ, error) {
+func (environProvider) Open(ctx context.Context, args environs.OpenParams, invalidator environs.CredentialInvalidator) (environs.Environ, error) {
 	if err := validateCloudSpec(args.Cloud); err != nil {
 		return nil, errors.Annotate(err, "validating cloud spec")
 	}

--- a/internal/provider/gce/provider_test.go
+++ b/internal/provider/gce/provider_test.go
@@ -42,7 +42,7 @@ func (s *providerSuite) TestOpen(c *gc.C) {
 	env, err := environs.Open(context.Background(), s.provider, environs.OpenParams{
 		Cloud:  s.spec,
 		Config: s.Config,
-	})
+	}, environs.NoopCredentialInvalidator())
 	c.Check(err, jc.ErrorIsNil)
 
 	envConfig := env.Config()
@@ -69,7 +69,7 @@ func (s *providerSuite) testOpenError(c *gc.C, spec environscloudspec.CloudSpec,
 	_, err := environs.Open(context.Background(), s.provider, environs.OpenParams{
 		Cloud:  spec,
 		Config: s.Config,
-	})
+	}, environs.NoopCredentialInvalidator())
 	c.Assert(err, gc.ErrorMatches, expect)
 }
 

--- a/internal/provider/lxd/config_test.go
+++ b/internal/provider/lxd/config_test.go
@@ -143,7 +143,7 @@ func (s *configSuite) TestNewModelConfig(c *gc.C) {
 		environ, err := environs.New(context.Background(), environs.OpenParams{
 			Cloud:  lxdCloudSpec(),
 			Config: testConfig,
-		})
+		}, environs.NoopCredentialInvalidator())
 
 		// Check the result
 		if test.err != "" {
@@ -233,7 +233,7 @@ func (s *configSuite) TestSetConfig(c *gc.C) {
 		environ, err := environs.New(context.Background(), environs.OpenParams{
 			Cloud:  lxdCloudSpec(),
 			Config: s.config,
-		})
+		}, environs.NoopCredentialInvalidator())
 		c.Assert(err, jc.ErrorIsNil)
 
 		testConfig := test.newConfig(c)

--- a/internal/provider/lxd/provider.go
+++ b/internal/provider/lxd/provider.go
@@ -144,7 +144,7 @@ func (*environProvider) Version() int {
 }
 
 // Open implements environs.EnvironProvider.
-func (p *environProvider) Open(ctx context.Context, args environs.OpenParams) (environs.Environ, error) {
+func (p *environProvider) Open(ctx context.Context, args environs.OpenParams, invalidator environs.CredentialInvalidator) (environs.Environ, error) {
 	if err := p.validateCloudSpec(args.Cloud); err != nil {
 		return nil, errors.Annotate(err, "validating cloud spec")
 	}

--- a/internal/provider/lxd/provider_test.go
+++ b/internal/provider/lxd/provider_test.go
@@ -552,7 +552,7 @@ func (s *ProviderFunctionalSuite) TestOpen(c *gc.C) {
 	env, err := environs.Open(context.Background(), s.provider, environs.OpenParams{
 		Cloud:  lxdCloudSpec(),
 		Config: s.Config,
-	})
+	}, environs.NoopCredentialInvalidator())
 	c.Assert(err, jc.ErrorIsNil)
 	envConfig := env.Config()
 

--- a/internal/provider/maas/environprovider.go
+++ b/internal/provider/maas/environprovider.go
@@ -58,7 +58,7 @@ func (EnvironProvider) Version() int {
 	return 0
 }
 
-func (EnvironProvider) Open(ctx context.Context, args environs.OpenParams) (environs.Environ, error) {
+func (EnvironProvider) Open(ctx context.Context, args environs.OpenParams, invalidator environs.CredentialInvalidator) (environs.Environ, error) {
 	logger.Debugf(context.TODO(), "opening model %q.", args.Config.Name())
 	if err := validateCloudSpec(args.Cloud); err != nil {
 		return nil, errors.Annotate(err, "validating cloud spec")

--- a/internal/provider/maas/environprovider_test.go
+++ b/internal/provider/maas/environprovider_test.go
@@ -99,7 +99,7 @@ func (s *EnvironProviderSuite) TestOpenReturnsNilInterfaceUponFailure(c *gc.C) {
 	env, err := providerInstance.Open(context.Background(), environs.OpenParams{
 		Cloud:  spec,
 		Config: config,
-	})
+	}, environs.NoopCredentialInvalidator())
 	// When Open() fails (i.e. returns a non-nil error), it returns an
 	// environs.Environ interface object with a nil value and a nil
 	// type.

--- a/internal/provider/manual/environ_test.go
+++ b/internal/provider/manual/environ_test.go
@@ -34,7 +34,7 @@ func (s *baseEnvironSuite) SetUpTest(c *gc.C) {
 	env, err := ManualProvider{}.Open(context.Background(), environs.OpenParams{
 		Cloud:  CloudSpec(),
 		Config: MinimalConfig(c),
-	})
+	}, environs.NoopCredentialInvalidator())
 	c.Assert(err, jc.ErrorIsNil)
 	s.env = env.(*manualEnviron)
 	s.callCtx = envcontext.WithoutCredentialInvalidator(context.Background())

--- a/internal/provider/manual/provider.go
+++ b/internal/provider/manual/provider.go
@@ -118,7 +118,7 @@ func (ManualProvider) Version() int {
 	return 0
 }
 
-func (p ManualProvider) Open(ctx context.Context, args environs.OpenParams) (environs.Environ, error) {
+func (p ManualProvider) Open(ctx context.Context, args environs.OpenParams, invaliator environs.CredentialInvalidator) (environs.Environ, error) {
 	if err := validateCloudSpec(args.Cloud); err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/internal/provider/manual/provider_test.go
+++ b/internal/provider/manual/provider_test.go
@@ -70,7 +70,7 @@ func (s *providerSuite) testPrepareForBootstrap(c *gc.C, endpoint, region string
 	env, err := manual.ProviderInstance.Open(context.Background(), environs.OpenParams{
 		Cloud:  cloudSpec,
 		Config: testConfig,
-	})
+	}, environs.NoopCredentialInvalidator())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/provider/oci/common_integration_test.go
+++ b/internal/provider/oci/common_integration_test.go
@@ -303,7 +303,7 @@ func (s *commonSuite) SetUpTest(c *gc.C) {
 	env, err := environs.Open(context.Background(), s.provider, environs.OpenParams{
 		Cloud:  s.spec,
 		Config: config,
-	})
+	}, environs.NoopCredentialInvalidator())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(env, gc.NotNil)
 

--- a/internal/provider/oci/provider.go
+++ b/internal/provider/oci/provider.go
@@ -200,7 +200,7 @@ func (e EnvironProvider) ValidateCloud(ctx context.Context, spec environscloudsp
 }
 
 // Open implements environs.EnvironProvider.
-func (e *EnvironProvider) Open(ctx context.Context, params environs.OpenParams) (environs.Environ, error) {
+func (e *EnvironProvider) Open(ctx context.Context, params environs.OpenParams, invalidator environs.CredentialInvalidator) (environs.Environ, error) {
 	logger.Infof(context.TODO(), "opening model %q", params.Config.Name())
 
 	if err := validateCloudSpec(params.Cloud); err != nil {

--- a/internal/provider/oci/provider_integration_test.go
+++ b/internal/provider/oci/provider_integration_test.go
@@ -199,14 +199,14 @@ func (s *credentialsSuite) TestOpen(c *gc.C) {
 	env, err := environs.Open(stdcontext.Background(), s.provider, environs.OpenParams{
 		Cloud:  s.spec,
 		Config: newConfig(c, jujutesting.Attrs{"compartment-id": "fake"}),
-	})
+	}, environs.NoopCredentialInvalidator())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(env, gc.NotNil)
 
 	env, err = environs.Open(stdcontext.Background(), s.provider, environs.OpenParams{
 		Cloud:  s.spec,
 		Config: newConfig(c, nil),
-	})
+	}, environs.NoopCredentialInvalidator())
 	c.Check(err, gc.ErrorMatches, "compartment-id may not be empty")
 	c.Assert(env, gc.IsNil)
 }

--- a/internal/provider/openstack/local_test.go
+++ b/internal/provider/openstack/local_test.go
@@ -163,7 +163,7 @@ func (s *localHTTPSServerSuite) envUsingCertificate(c *gc.C) environs.Environ {
 	env, err := environs.New(context.Background(), environs.OpenParams{
 		Cloud:  cloudSpec,
 		Config: cfg,
-	})
+	}, environs.NoopCredentialInvalidator())
 	c.Assert(err, jc.ErrorIsNil)
 	return env
 }
@@ -319,7 +319,7 @@ func (s *localServerSuite) openEnviron(c *gc.C, attrs coretesting.Attrs) environ
 	env, err := environs.New(context.Background(), environs.OpenParams{
 		Cloud:  s.CloudSpec(),
 		Config: cfg,
-	})
+	}, environs.NoopCredentialInvalidator())
 	c.Assert(err, jc.ErrorIsNil)
 	return env
 }
@@ -2658,7 +2658,7 @@ func (s *localHTTPSServerSuite) TestMustDisableSSLVerify(c *gc.C) {
 	_, err = environs.New(context.Background(), environs.OpenParams{
 		Cloud:  makeCloudSpec(s.cred),
 		Config: cfg,
-	})
+	}, environs.NoopCredentialInvalidator())
 	c.Assert(err, gc.ErrorMatches, "(.|\n)*x509: certificate signed by unknown authority")
 }
 
@@ -3426,7 +3426,7 @@ func (s *localServerSuite) TestAdoptResources(c *gc.C) {
 	env, err := environs.New(context.Background(), environs.OpenParams{
 		Cloud:  makeCloudSpec(s.cred),
 		Config: cfg,
-	})
+	}, environs.NoopCredentialInvalidator())
 	c.Assert(err, jc.ErrorIsNil)
 	originalController := coretesting.ControllerTag.Id()
 	_, _, _, err = testing.StartInstance(env, s.callCtx, originalController, "0")
@@ -3472,7 +3472,7 @@ func (s *localServerSuite) TestAdoptResourcesNoStorage(c *gc.C) {
 	env, err := environs.New(context.Background(), environs.OpenParams{
 		Cloud:  makeCloudSpec(s.cred),
 		Config: cfg,
-	})
+	}, environs.NoopCredentialInvalidator())
 	c.Assert(err, jc.ErrorIsNil)
 	originalController := coretesting.ControllerTag.Id()
 	_, _, _, err = testing.StartInstance(env, s.callCtx, originalController, "0")

--- a/internal/provider/openstack/provider.go
+++ b/internal/provider/openstack/provider.go
@@ -158,7 +158,7 @@ func (EnvironProvider) Version() int {
 	return 0
 }
 
-func (p EnvironProvider) Open(ctx context.Context, args environs.OpenParams) (environs.Environ, error) {
+func (p EnvironProvider) Open(ctx context.Context, args environs.OpenParams, invalidator environs.CredentialInvalidator) (environs.Environ, error) {
 	logger.Infof(context.TODO(), "opening model %q", args.Config.Name())
 	uuid := args.Config.UUID()
 	namespace, err := instance.NewNamespace(uuid)

--- a/internal/provider/vsphere/config_test.go
+++ b/internal/provider/vsphere/config_test.go
@@ -150,7 +150,7 @@ func (*ConfigSuite) TestNewModelConfig(c *gc.C) {
 		environ, err := environs.New(context.Background(), environs.OpenParams{
 			Cloud:  fakeCloudSpec(),
 			Config: fakeConfig,
-		})
+		}, environs.NoopCredentialInvalidator())
 
 		// Check the result
 		if test.err != "" {
@@ -241,7 +241,7 @@ func (s *ConfigSuite) TestSetConfig(c *gc.C) {
 		environ, err := environs.New(context.Background(), environs.OpenParams{
 			Cloud:  fakeCloudSpec(),
 			Config: s.config,
-		})
+		}, environs.NoopCredentialInvalidator())
 		c.Assert(err, jc.ErrorIsNil)
 
 		fakeConfig := test.newConfig(c)

--- a/internal/provider/vsphere/environ_broker_test.go
+++ b/internal/provider/vsphere/environ_broker_test.go
@@ -183,7 +183,7 @@ func (s *legacyEnvironBrokerSuite) TestStartInstanceNetwork(c *gc.C) {
 			"external-network":   "bar",
 			"image-metadata-url": s.imageServer.URL,
 		}),
-	})
+	}, environs.NoopCredentialInvalidator())
 	c.Assert(err, jc.ErrorIsNil)
 
 	result, err := env.StartInstance(s.callCtx, s.createStartInstanceArgs(c))
@@ -203,7 +203,7 @@ func (s *legacyEnvironBrokerSuite) TestStartInstanceDiskProvisioningMissingModel
 		Config: fakeConfig(c, coretesting.Attrs{
 			"image-metadata-url": s.imageServer.URL,
 		}),
-	})
+	}, environs.NoopCredentialInvalidator())
 	c.Assert(err, jc.ErrorIsNil)
 
 	result, err := env.StartInstance(s.callCtx, s.createStartInstanceArgs(c))
@@ -222,7 +222,7 @@ func (s *legacyEnvironBrokerSuite) TestStartInstanceDiskProvisioningDefaultOptio
 			"image-metadata-url":     s.imageServer.URL,
 			"disk-provisioning-type": "",
 		}),
-	})
+	}, environs.NoopCredentialInvalidator())
 	c.Assert(err, jc.ErrorIsNil)
 
 	result, err := env.StartInstance(s.callCtx, s.createStartInstanceArgs(c))
@@ -241,7 +241,7 @@ func (s *legacyEnvironBrokerSuite) TestStartInstanceDiskProvisioningThinDisk(c *
 			"image-metadata-url":     s.imageServer.URL,
 			"disk-provisioning-type": "thin",
 		}),
-	})
+	}, environs.NoopCredentialInvalidator())
 	c.Assert(err, jc.ErrorIsNil)
 
 	result, err := env.StartInstance(s.callCtx, s.createStartInstanceArgs(c))
@@ -260,7 +260,7 @@ func (s *legacyEnvironBrokerSuite) TestStartInstanceDiskProvisioningThickDisk(c 
 			"image-metadata-url":     s.imageServer.URL,
 			"disk-provisioning-type": "thick",
 		}),
-	})
+	}, environs.NoopCredentialInvalidator())
 	c.Assert(err, jc.ErrorIsNil)
 
 	result, err := env.StartInstance(s.callCtx, s.createStartInstanceArgs(c))
@@ -279,7 +279,7 @@ func (s *legacyEnvironBrokerSuite) TestStartInstanceDiskProvisioningThickEagerZe
 			"image-metadata-url":     s.imageServer.URL,
 			"disk-provisioning-type": "thick",
 		}),
-	})
+	}, environs.NoopCredentialInvalidator())
 	c.Assert(err, jc.ErrorIsNil)
 
 	result, err := env.StartInstance(s.callCtx, s.createStartInstanceArgs(c))
@@ -298,7 +298,7 @@ func (s *legacyEnvironBrokerSuite) TestStartInstanceLongModelName(c *gc.C) {
 			"name":               "supercalifragilisticexpialidocious",
 			"image-metadata-url": s.imageServer.URL,
 		}),
-	})
+	}, environs.NoopCredentialInvalidator())
 	c.Assert(err, jc.ErrorIsNil)
 	startInstArgs := s.createStartInstanceArgs(c)
 	_, err = env.StartInstance(s.callCtx, startInstArgs)
@@ -320,7 +320,7 @@ func (s *legacyEnvironBrokerSuite) TestStartInstanceDiskUUIDDisabled(c *gc.C) {
 			"enable-disk-uuid":   false,
 			"image-metadata-url": s.imageServer.URL,
 		}),
-	})
+	}, environs.NoopCredentialInvalidator())
 	c.Assert(err, jc.ErrorIsNil)
 
 	result, err := env.StartInstance(s.callCtx, s.createStartInstanceArgs(c))
@@ -506,7 +506,7 @@ func (s *environBrokerSuite) setUpClient(c *gc.C) *gomock.Controller {
 		Config: fakeConfig(c, coretesting.Attrs{
 			"image-metadata-url": s.imageServerURL,
 		}),
-	})
+	}, environs.NoopCredentialInvalidator())
 	c.Assert(err, jc.ErrorIsNil)
 	s.env = env
 	return ctrl

--- a/internal/provider/vsphere/fixture_test.go
+++ b/internal/provider/vsphere/fixture_test.go
@@ -64,7 +64,7 @@ func (s *EnvironFixture) SetUpTest(c *gc.C) {
 		Config: fakeConfig(c, coretesting.Attrs{
 			"image-metadata-url": s.imageServer.URL,
 		}),
-	})
+	}, environs.NoopCredentialInvalidator())
 	c.Assert(err, jc.ErrorIsNil)
 	s.env = env
 

--- a/internal/provider/vsphere/provider.go
+++ b/internal/provider/vsphere/provider.go
@@ -55,7 +55,7 @@ func (p *environProvider) Version() int {
 }
 
 // Open implements environs.EnvironProvider.
-func (p *environProvider) Open(ctx stdcontext.Context, args environs.OpenParams) (environs.Environ, error) {
+func (p *environProvider) Open(ctx stdcontext.Context, args environs.OpenParams, invalidator environs.CredentialInvalidator) (environs.Environ, error) {
 	if err := validateCloudSpec(args.Cloud); err != nil {
 		return nil, errors.Annotate(err, "validating cloud spec")
 	}

--- a/internal/provider/vsphere/provider_test.go
+++ b/internal/provider/vsphere/provider_test.go
@@ -36,7 +36,7 @@ func (s *providerSuite) TestOpen(c *gc.C) {
 	env, err := s.provider.Open(stdcontext.Background(), environs.OpenParams{
 		Cloud:  fakeCloudSpec(),
 		Config: config,
-	})
+	}, environs.NoopCredentialInvalidator())
 	c.Assert(err, jc.ErrorIsNil)
 
 	envConfig := env.Config()
@@ -66,7 +66,7 @@ func (s *providerSuite) testOpenError(c *gc.C, spec environscloudspec.CloudSpec,
 	_, err := s.provider.Open(stdcontext.Background(), environs.OpenParams{
 		Cloud:  spec,
 		Config: fakeConfig(c),
-	})
+	}, environs.NoopCredentialInvalidator())
 	c.Assert(err, gc.ErrorMatches, expect)
 }
 

--- a/internal/worker/caasbroker/broker.go
+++ b/internal/worker/caasbroker/broker.go
@@ -87,7 +87,7 @@ func NewTracker(ctx context.Context, config Config) (*Tracker, error) {
 		ControllerUUID: ctrlCfg.ControllerUUID(),
 		Cloud:          cloudSpec,
 		Config:         cfg,
-	})
+	}, environs.NoopCredentialInvalidator())
 	if err != nil {
 		return nil, errors.Annotate(err, "cannot create caas broker")
 	}

--- a/internal/worker/caasbroker/broker_test.go
+++ b/internal/worker/caasbroker/broker_test.go
@@ -30,7 +30,7 @@ var _ = gc.Suite(&TrackerSuite{})
 func (s *TrackerSuite) validConfig(c *gc.C) caasbroker.Config {
 	return caasbroker.Config{
 		ConfigAPI: &runContext{},
-		NewContainerBrokerFunc: func(context.Context, environs.OpenParams) (caas.Broker, error) {
+		NewContainerBrokerFunc: func(context.Context, environs.OpenParams, environs.CredentialInvalidator) (caas.Broker, error) {
 			return nil, errors.NotImplementedf("test func")
 		},
 		Logger: loggertesting.WrapCheckLog(c),
@@ -124,7 +124,7 @@ func (s *TrackerSuite) TestInitialise(c *gc.C) {
 	fix.Run(c, func(runContext *runContext) {
 		tracker, err := caasbroker.NewTracker(context.Background(), caasbroker.Config{
 			ConfigAPI: runContext,
-			NewContainerBrokerFunc: func(_ context.Context, args environs.OpenParams) (caas.Broker, error) {
+			NewContainerBrokerFunc: func(_ context.Context, args environs.OpenParams, _ environs.CredentialInvalidator) (caas.Broker, error) {
 				c.Assert(args.Cloud, jc.DeepEquals, fix.initialSpec)
 				c.Assert(args.Config.Name(), jc.DeepEquals, "testmodel")
 				return nil, errors.NotValidf("cloud spec")
@@ -161,7 +161,7 @@ func (s *TrackerSuite) TestModelConfigInvalid(c *gc.C) {
 	fix.Run(c, func(runContext *runContext) {
 		tracker, err := caasbroker.NewTracker(context.Background(), caasbroker.Config{
 			ConfigAPI: runContext,
-			NewContainerBrokerFunc: func(context.Context, environs.OpenParams) (caas.Broker, error) {
+			NewContainerBrokerFunc: func(context.Context, environs.OpenParams, environs.CredentialInvalidator) (caas.Broker, error) {
 				return nil, errors.NotValidf("config")
 			},
 			Logger: loggertesting.WrapCheckLog(c),
@@ -203,7 +203,7 @@ func (s *TrackerSuite) TestCloudSpecInvalid(c *gc.C) {
 	fix.Run(c, func(runContext *runContext) {
 		tracker, err := caasbroker.NewTracker(context.Background(), caasbroker.Config{
 			ConfigAPI: runContext,
-			NewContainerBrokerFunc: func(_ context.Context, args environs.OpenParams) (caas.Broker, error) {
+			NewContainerBrokerFunc: func(_ context.Context, args environs.OpenParams, _ environs.CredentialInvalidator) (caas.Broker, error) {
 				c.Assert(args.Cloud, jc.DeepEquals, cloudSpec)
 				return nil, errors.NotValidf("cloud spec")
 			},
@@ -299,7 +299,7 @@ func (s *TrackerSuite) TestWatchedModelConfigIncompatible(c *gc.C) {
 	fix.Run(c, func(runContext *runContext) {
 		tracker, err := caasbroker.NewTracker(context.Background(), caasbroker.Config{
 			ConfigAPI: runContext,
-			NewContainerBrokerFunc: func(context.Context, environs.OpenParams) (caas.Broker, error) {
+			NewContainerBrokerFunc: func(context.Context, environs.OpenParams, environs.CredentialInvalidator) (caas.Broker, error) {
 				broker := &mockBroker{}
 				broker.SetErrors(errors.New("SetConfig is broken"))
 				return broker, nil

--- a/internal/worker/caasbroker/fixture_test.go
+++ b/internal/worker/caasbroker/fixture_test.go
@@ -223,7 +223,7 @@ type mockBroker struct {
 	mu        sync.Mutex
 }
 
-func newMockBroker(_ context.Context, args environs.OpenParams) (caas.Broker, error) {
+func newMockBroker(_ context.Context, args environs.OpenParams, _ environs.CredentialInvalidator) (caas.Broker, error) {
 	return &mockBroker{spec: args.Cloud, namespace: args.Config.Name(), cfg: args.Config}, nil
 }
 

--- a/internal/worker/providertracker/trackerworker_test.go
+++ b/internal/worker/providertracker/trackerworker_test.go
@@ -186,10 +186,10 @@ func (s *trackerWorkerSuite) getConfig(c *gc.C, environ environs.Environ) Tracke
 		ConfigService:     s.configService,
 		CredentialService: s.credentialService,
 		GetProviderForType: getProviderForType(
-			IAASGetProvider(func(ctx context.Context, args environs.OpenParams) (environs.Environ, error) {
+			IAASGetProvider(func(_ context.Context, _ environs.OpenParams, _ environs.CredentialInvalidator) (environs.Environ, error) {
 				return environ, nil
 			}),
-			CAASGetProvider(func(ctx context.Context, args environs.OpenParams) (caas.Broker, error) {
+			CAASGetProvider(func(_ context.Context, _ environs.OpenParams, _ environs.CredentialInvalidator) (caas.Broker, error) {
 				c.Fatal("unexpected call")
 				return nil, nil
 			}),

--- a/internal/worker/undertaker/manifold.go
+++ b/internal/worker/undertaker/manifold.go
@@ -27,7 +27,7 @@ type ManifoldConfig struct {
 	NewFacade                    func(base.APICaller) (Facade, error)
 	NewWorker                    func(Config) (worker.Worker, error)
 	NewCredentialValidatorFacade func(base.APICaller) (common.CredentialAPI, error)
-	NewCloudDestroyerFunc        func(context.Context, environs.OpenParams) (environs.CloudDestroyer, error)
+	NewCloudDestroyerFunc        func(context.Context, environs.OpenParams, environs.CredentialInvalidator) (environs.CloudDestroyer, error)
 }
 
 func (config ManifoldConfig) start(context context.Context, getter dependency.Getter) (worker.Worker, error) {

--- a/internal/worker/undertaker/manifold_test.go
+++ b/internal/worker/undertaker/manifold_test.go
@@ -55,7 +55,7 @@ func (s *manifoldSuite) namesConfig(c *gc.C) undertaker.ManifoldConfig {
 		NewCredentialValidatorFacade: func(base.APICaller) (common.CredentialAPI, error) {
 			return &fakeCredentialAPI{}, nil
 		},
-		NewCloudDestroyerFunc: func(ctx context.Context, params environs.OpenParams) (environs.CloudDestroyer, error) {
+		NewCloudDestroyerFunc: func(ctx context.Context, params environs.OpenParams, _ environs.CredentialInvalidator) (environs.CloudDestroyer, error) {
 			return &fakeEnviron{}, nil
 		},
 	}

--- a/internal/worker/undertaker/mock_test.go
+++ b/internal/worker/undertaker/mock_test.go
@@ -155,7 +155,7 @@ func (fix *fixture) run(c *gc.C, test func(worker.Worker)) *testing.Stub {
 		CredentialAPI: &fakeCredentialAPI{},
 		Logger:        loggertesting.WrapCheckLog(c),
 		Clock:         fix.clock,
-		NewCloudDestroyerFunc: func(ctx context.Context, op environs.OpenParams) (environs.CloudDestroyer, error) {
+		NewCloudDestroyerFunc: func(ctx context.Context, op environs.OpenParams, _ environs.CredentialInvalidator) (environs.CloudDestroyer, error) {
 			return &mockDestroyer{stub: stub}, nil
 		},
 	})

--- a/internal/worker/undertaker/undertaker.go
+++ b/internal/worker/undertaker/undertaker.go
@@ -41,7 +41,7 @@ type Config struct {
 	CredentialAPI         common.CredentialAPI
 	Logger                logger.Logger
 	Clock                 clock.Clock
-	NewCloudDestroyerFunc func(context.Context, environs.OpenParams) (environs.CloudDestroyer, error)
+	NewCloudDestroyerFunc func(context.Context, environs.OpenParams, environs.CredentialInvalidator) (environs.CloudDestroyer, error)
 }
 
 // Validate returns an error if the config cannot be expected to drive
@@ -345,7 +345,7 @@ func (u *Undertaker) environ(ctx context.Context) (environs.CloudDestroyer, erro
 	environ, err := u.config.NewCloudDestroyerFunc(ctx, environs.OpenParams{
 		Cloud:  cloudSpec,
 		Config: modelConfig,
-	})
+	}, environs.NoopCredentialInvalidator())
 	if err != nil {
 		return nil, errors.Annotatef(err, "creating environ for model %q (%s)", modelConfig.Name(), modelConfig.UUID())
 	}

--- a/internal/worker/undertaker/undertaker_test.go
+++ b/internal/worker/undertaker/undertaker_test.go
@@ -342,7 +342,7 @@ func (s *UndertakerSuite) TestExitOnModelChanged(c *gc.C) {
 		CredentialAPI: credentialAPI,
 		Logger:        loggertesting.WrapCheckLog(c),
 		Clock:         testclock.NewDilatedWallClock(testing.ShortWait),
-		NewCloudDestroyerFunc: func(ctx context.Context, op environs.OpenParams) (environs.CloudDestroyer, error) {
+		NewCloudDestroyerFunc: func(ctx context.Context, op environs.OpenParams, _ environs.CredentialInvalidator) (environs.CloudDestroyer, error) {
 			return &waitDestroyer{}, nil
 		},
 	})

--- a/internal/worker/undertaker/validate_test.go
+++ b/internal/worker/undertaker/validate_test.go
@@ -56,11 +56,13 @@ func (*ValidateSuite) TestNilClock(c *gc.C) {
 
 func validConfig(c *gc.C) undertaker.Config {
 	return undertaker.Config{
-		Facade:                &fakeFacade{},
-		CredentialAPI:         &fakeCredentialAPI{},
-		Logger:                loggertesting.WrapCheckLog(c),
-		Clock:                 testclock.NewClock(time.Time{}),
-		NewCloudDestroyerFunc: func(ctx context.Context, op environs.OpenParams) (environs.CloudDestroyer, error) { return nil, nil },
+		Facade:        &fakeFacade{},
+		CredentialAPI: &fakeCredentialAPI{},
+		Logger:        loggertesting.WrapCheckLog(c),
+		Clock:         testclock.NewClock(time.Time{}),
+		NewCloudDestroyerFunc: func(context.Context, environs.OpenParams, environs.CredentialInvalidator) (environs.CloudDestroyer, error) {
+			return nil, nil
+		},
 	}
 }
 

--- a/state/stateenvirons/config.go
+++ b/state/stateenvirons/config.go
@@ -85,7 +85,7 @@ func (g EnvironConfigGetter) CloudAPIVersion(spec environscloudspec.CloudSpec) (
 		ControllerUUID: g.Model.ControllerUUID(),
 		Cloud:          spec,
 		Config:         cfg,
-	})
+	}, environs.NoopCredentialInvalidator())
 	if err != nil {
 		return "", errors.Trace(err)
 	}
@@ -138,7 +138,7 @@ func GetNewEnvironFunc(newEnviron environs.NewEnvironFunc) NewEnvironFunc {
 			CredentialService:  credentialService,
 			ModelConfigService: modelConfigService,
 		}
-		return environs.GetEnviron(context.TODO(), g, newEnviron)
+		return environs.GetEnviron(context.TODO(), g, environs.NoopCredentialInvalidator(), newEnviron)
 	}
 }
 
@@ -163,6 +163,6 @@ func GetNewCAASBrokerFunc(newBroker caas.NewContainerBrokerFunc) NewCAASBrokerFu
 			ControllerUUID: m.ControllerUUID(),
 			Cloud:          cloudSpec,
 			Config:         cfg,
-		})
+		}, environs.NoopCredentialInvalidator())
 	}
 }


### PR DESCRIPTION
This is the precursor to removing the ProviderCallContext, by adding an invalidator to every provider, each provider will be allowed to invalidate a credential if they hit an auth error.

This isn't added to the OpenParams for a Provider because we want to ensure that we've not missed anything when compiling. We can move this into the OpenParams struct once everything has been migrated.

The next steps would be the following:

 1. Allow the ProviderTracker to hand out Providers without the ability to invalidate credentials.
 2. Move all providers to use the invalidator instead of the ProviderCallContext.
 3. Migrate workers to use the CredentialAPI as the invalidator when constructing the environ.
 4. Remove ProviderCallContext as it will be deadcode.

The code is relatively simple, it's intruduction of a new interface, nothing calls it yet. It just sets out the plan of action.

----

This pull request introduces changes across multiple files to include `environs.NoopCredentialInvalidator()` as an additional parameter when calling the `environs.GetEnviron` and `caas.Open` functions. This change ensures that a credential invalidator is consistently provided in various contexts.

### Changes to function calls:

* [`agent/agentbootstrap/bootstrap.go`](diffhunk://#diff-ea4f262b8f5d83da16a99c2bcc52a1156553e069197bb2dd9476f3a6db6b88ffL432-R434): Updated `getEnviron` function to include `environs.NoopCredentialInvalidator()` when calling `caas.Open` and `environs.Open`.
* [`apiserver/common/environ_config.go`](diffhunk://#diff-3ed06d8708a8f96ad65dabae2ebdc5c52c7ea2fa23b287b394bf011781597a94L31-R31): Modified `EnvironFuncForModel` to pass `environs.NoopCredentialInvalidator()` to `environs.GetEnviron`.
* [`apiserver/facades/agent/provisioner/provisioner.go`](diffhunk://#diff-92f0963a4a04d3e47c1857a07db34a17d39236ac620508f23a68f38abdfbcb6dL156-R156): Updated multiple instances of `environs.GetEnviron` to include `environs.NoopCredentialInvalidator()`. [[1]](diffhunk://#diff-92f0963a4a04d3e47c1857a07db34a17d39236ac620508f23a68f38abdfbcb6dL156-R156) [[2]](diffhunk://#diff-92f0963a4a04d3e47c1857a07db34a17d39236ac620508f23a68f38abdfbcb6dL218-R218) [[3]](diffhunk://#diff-92f0963a4a04d3e47c1857a07db34a17d39236ac620508f23a68f38abdfbcb6dL1107-R1107) [[4]](diffhunk://#diff-64c8b7dcaf071cce84ea734544d92b2eb414d1366c141fa2e1e2c0005ed31cafL49-R49)
* [`apiserver/facades/client/controller/controller_test.go`](diffhunk://#diff-f974b647c06f585d8243e48b88484581261dac0b47b104a273b2c22bd4501240L229-R229): Added `environs.NoopCredentialInvalidator()` to `environs.New` calls.
* [`apiserver/facades/client/modelmanager/modelmanager.go`](diffhunk://#diff-f910322f8b09cf7b5110c879eeec8ac33366c408b0e6809126cea1762d6d716aL49-R49): Modified `newCaasBrokerFunc` type and updated function calls to include `environs.NoopCredentialInvalidator()`. [[1]](diffhunk://#diff-f910322f8b09cf7b5110c879eeec8ac33366c408b0e6809126cea1762d6d716aL49-R49) [[2]](diffhunk://#diff-f910322f8b09cf7b5110c879eeec8ac33366c408b0e6809126cea1762d6d716aL542-R542) [[3]](diffhunk://#diff-f910322f8b09cf7b5110c879eeec8ac33366c408b0e6809126cea1762d6d716aL588-R588)
* [`apiserver/facades/client/sshclient/facade.go`](diffhunk://#diff-363289be68b0c350e0ba91bfc00ef0edafc8a03438f3699f9884cf9182361323L26-R26): Updated `newCaasBrokerFunc` type and added `environs.NoopCredentialInvalidator()` to function calls. [[1]](diffhunk://#diff-363289be68b0c350e0ba91bfc00ef0edafc8a03438f3699f9884cf9182361323L26-R26) [[2]](diffhunk://#diff-363289be68b0c350e0ba91bfc00ef0edafc8a03438f3699f9884cf9182361323L290-R290)
* [`apiserver/facades/client/sshclient/facade_test.go`](diffhunk://#diff-cfd4e6a84aa3929f5a16222702cee0fa4d184086c119c2865956a52bbb88de0bL74-R74): Modified test functions to include `environs.NoopCredentialInvalidator()` in broker functions. [[1]](diffhunk://#diff-cfd4e6a84aa3929f5a16222702cee0fa4d184086c119c2865956a52bbb88de0bL74-R74) [[2]](diffhunk://#diff-cfd4e6a84aa3929f5a16222702cee0fa4d184086c119c2865956a52bbb88de0bL103-R103) [[3]](diffhunk://#diff-cfd4e6a84aa3929f5a16222702cee0fa4d184086c119c2865956a52bbb88de0bL142-R142) [[4]](diffhunk://#diff-cfd4e6a84aa3929f5a16222702cee0fa4d184086c119c2865956a52bbb88de0bL187-R187) [[5]](diffhunk://#diff-cfd4e6a84aa3929f5a16222702cee0fa4d184086c119c2865956a52bbb88de0bL232-R232) [[6]](diffhunk://#diff-cfd4e6a84aa3929f5a16222702cee0fa4d184086c119c2865956a52bbb88de0bL297-R297) [[7]](diffhunk://#diff-cfd4e6a84aa3929f5a16222702cee0fa4d184086c119c2865956a52bbb88de0bL358-R358) [[8]](diffhunk://#diff-cfd4e6a84aa3929f5a16222702cee0fa4d184086c119c2865956a52bbb88de0bL402-R402) [[9]](diffhunk://#diff-cfd4e6a84aa3929f5a16222702cee0fa4d184086c119c2865956a52bbb88de0bL437-R437) [[10]](diffhunk://#diff-cfd4e6a84aa3929f5a16222702cee0fa4d184086c119c2865956a52bbb88de0bL467-R467) [[11]](diffhunk://#diff-cfd4e6a84aa3929f5a16222702cee0fa4d184086c119c2865956a52bbb88de0bL500-R500) [[12]](diffhunk://#diff-cfd4e6a84aa3929f5a16222702cee0fa4d184086c119c2865956a52bbb88de0bL545-R545) [[13]](diffhunk://#diff-cfd4e6a84aa3929f5a16222702cee0fa4d184086c119c2865956a52bbb88de0bL624-R624)
* [`apiserver/facades/client/sshclient/register.go`](diffhunk://#diff-31a40e0448e00d7162e8f4e32b5703ff7f4a409b0d6b3c9377307ce2e6c42cd9L54-R55): Updated `newFacade` function to pass `environs.NoopCredentialInvalidator()` to `caas.New`.
* [`apiserver/facades/client/subnets/cache.go`](diffhunk://#diff-4b49dcad2436e65d6586325513358703cfab1f8755e4a7669b7a56efaf70b6c5L82-R82): Added `environs.NoopCredentialInvalidator()` to `environs.GetEnviron` call.
* [`apiserver/testing/stub_network.go`](diffhunk://#diff-3aeda08b61875dc8aacbcb56276ec2b5aad245c2d7bf709a950cef372ed78a12L335-R335): Modified `StubProvider` to include `environs.CredentialInvalidator` in the `Open` method.
* [`caas/broker.go`](diffhunk://#diff-83954cddc87d2d0fa34d5506e957cf2ee2d42a1198c5e961880a9fa6ffaec044L35-R35): Updated `ContainerEnvironProvider` interface to include `environs.CredentialInvalidator` in the `Open` method.

## QA Steps

It should be enough to bootstrap to LXD, k8s, and aws.

```
$ juju bootstrap lxd test
```
