### PR TITLE
fix: dummy-sink has an extra folder

### DIFF
--- a/testcharms/charms/dummy-sink/charmcraft.yaml
+++ b/testcharms/charms/dummy-sink/charmcraft.yaml
@@ -45,3 +45,4 @@ parts:
       - copyright
       - hooks
       - metadata.yaml
+      - scripts


### PR DESCRIPTION
charmcraft changed from default to adding files to requiring you to specify them all. Which meant that `charmcraft pack` for dummy-sink stopped building a charm that actually worked, as the hooks/ all refer to a separate script in scripts/ to actually run.


## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

```sh
$ cd testcharms/charms/dummy-sink
$ charmcraft pack
$ juju deploy ./dummy-sink*.charm
$ juju deploy juju-qa-dummy-source
$ juju related dummy-sink dummy-source
$ juju debug-log dummy-sink/0
```

Without this change there will errors/warnings in the log that there is no 'scripts/token' file.
You can also confirm this by doing:

```sh
$ unzip -t ./dummy-sink*.charm
```
And you can see whether that file is actually present.


## Documentation changes

None

## Links

None
