### PR TITLE
refactor: use charm locator rather than charm ID

### DIFF
--- a/domain/resource/service/resource.go
+++ b/domain/resource/service/resource.go
@@ -572,15 +572,14 @@ func (s *Service) SetRepositoryResources(
 // when the application is created using the returned Resource UUIDs.
 //
 // The following error types can be expected to be returned:
-//   - [resourceerrors.CharmIDNotValid] is returned if the Charm ID is not valid.
 //   - [resourceerrors.ArgumentNotValid] is returned if the origin is store and the revision
-//     is empty.
+//     is empty; or the CharmLocator is zero.
 //   - [resourceerrors.ResourceNameNotValid] is returned if resource name is empty.
 //   - [resourceerrors.ApplicationNameNotFound] if the specified application does
 //     not exist.
 func (s *Service) AddResourcesBeforeApplication(ctx context.Context, arg resource.AddResourcesBeforeApplicationArgs) ([]coreresource.UUID, error) {
-	if err := arg.CharmUUID.Validate(); err != nil {
-		return nil, errors.Errorf("%w: %w", resourceerrors.CharmIDNotValid, err)
+	if arg.CharmLocator.IsZero() {
+		return nil, errors.Errorf("charm locator is zero: %w", resourceerrors.ArgumentNotValid)
 	}
 	if !isValidApplicationName(arg.ApplicationName) {
 		return nil, errors.Errorf("application name : %w", resourceerrors.ApplicationNameNotValid)

--- a/domain/resource/service/resource_test.go
+++ b/domain/resource/service/resource_test.go
@@ -17,13 +17,13 @@ import (
 
 	applicationtesting "github.com/juju/juju/core/application/testing"
 	charmtesting "github.com/juju/juju/core/charm/testing"
-	coreerrors "github.com/juju/juju/core/errors"
 	objectstoretesting "github.com/juju/juju/core/objectstore/testing"
 	coreresource "github.com/juju/juju/core/resource"
 	coreresourcestore "github.com/juju/juju/core/resource/store"
 	storetesting "github.com/juju/juju/core/resource/store/testing"
 	resourcetesting "github.com/juju/juju/core/resource/testing"
 	unittesting "github.com/juju/juju/core/unit/testing"
+	"github.com/juju/juju/domain/application/charm"
 	containerimageresourcestoreerrors "github.com/juju/juju/domain/containerimageresourcestore/errors"
 	"github.com/juju/juju/domain/resource"
 	resourceerrors "github.com/juju/juju/domain/resource/errors"
@@ -1189,7 +1189,7 @@ func (s *resourceServiceSuite) TestAddResourcesBeforeApplication(c *gc.C) {
 
 	rev := 7
 	args := resource.AddResourcesBeforeApplicationArgs{
-		CharmUUID:       charmtesting.GenCharmID(c),
+		CharmLocator:    charm.CharmLocator{Name: "testcharm", Source: charm.CharmHubSource},
 		ApplicationName: "testme",
 		ResourceDetails: []resource.AddResourceDetails{
 			{
@@ -1216,7 +1216,7 @@ func (s *resourceServiceSuite) TestAddResourcesBeforeApplicationAppNameNotValid(
 	defer s.setupMocks(c).Finish()
 
 	args := resource.AddResourcesBeforeApplicationArgs{
-		CharmUUID: charmtesting.GenCharmID(c),
+		CharmLocator: charm.CharmLocator{Name: "testcharm", Source: charm.CharmHubSource},
 	}
 
 	_, err := s.service.AddResourcesBeforeApplication(context.Background(), args)
@@ -1229,7 +1229,7 @@ func (s *resourceServiceSuite) TestAddResourcesBeforeApplicationResNameNotValid(
 	defer s.setupMocks(c).Finish()
 
 	args := resource.AddResourcesBeforeApplicationArgs{
-		CharmUUID:       charmtesting.GenCharmID(c),
+		CharmLocator:    charm.CharmLocator{Name: "testcharm", Source: charm.CharmHubSource},
 		ApplicationName: "testme",
 		ResourceDetails: []resource.AddResourceDetails{
 			{
@@ -1242,7 +1242,7 @@ func (s *resourceServiceSuite) TestAddResourcesBeforeApplicationResNameNotValid(
 	c.Assert(err, jc.ErrorIs, resourceerrors.ResourceNameNotValid)
 }
 
-// TestAddResourcesBeforeApplicationArgNotValid tests that a NotValid error is
+// TestAddResourcesBeforeApplicationArgNotValid tests that a ArgumentNotValid error is
 // returned for a bad Charm ID.
 func (s *resourceServiceSuite) TestAddResourcesBeforeApplicationArgNotValid(c *gc.C) {
 	defer s.setupMocks(c).Finish()
@@ -1250,7 +1250,7 @@ func (s *resourceServiceSuite) TestAddResourcesBeforeApplicationArgNotValid(c *g
 	args := resource.AddResourcesBeforeApplicationArgs{}
 
 	_, err := s.service.AddResourcesBeforeApplication(context.Background(), args)
-	c.Assert(err, jc.ErrorIs, coreerrors.NotValid)
+	c.Assert(err, jc.ErrorIs, resourceerrors.ArgumentNotValid)
 }
 
 // TestAddResourcesBeforeApplicationArgNotValidStore tests that a
@@ -1259,7 +1259,7 @@ func (s *resourceServiceSuite) TestAddResourcesBeforeApplicationArgumentNotValid
 	defer s.setupMocks(c).Finish()
 
 	args := resource.AddResourcesBeforeApplicationArgs{
-		CharmUUID:       charmtesting.GenCharmID(c),
+		CharmLocator:    charm.CharmLocator{Name: "testcharm", Source: charm.CharmHubSource},
 		ApplicationName: "testme",
 		ResourceDetails: []resource.AddResourceDetails{
 			{
@@ -1280,7 +1280,7 @@ func (s *resourceServiceSuite) TestAddResourcesBeforeApplicationArgumentNotValid
 
 	rev := 8
 	args := resource.AddResourcesBeforeApplicationArgs{
-		CharmUUID:       charmtesting.GenCharmID(c),
+		CharmLocator:    charm.CharmLocator{Name: "testcharm", Source: charm.CharmHubSource},
 		ApplicationName: "testme",
 		ResourceDetails: []resource.AddResourceDetails{
 			{

--- a/domain/resource/state/types.go
+++ b/domain/resource/state/types.go
@@ -34,8 +34,8 @@ type resourceIdentity struct {
 	Name            string `db:"name"`
 }
 
-// resourceUUID represents the unique identifier of a resource.
-type resourceUUID struct {
+// localUUID represents a unique identifier.
+type localUUID struct {
 	UUID string `db:"uuid"`
 }
 

--- a/domain/resource/types.go
+++ b/domain/resource/types.go
@@ -11,6 +11,7 @@ import (
 	corecharm "github.com/juju/juju/core/charm"
 	coreresource "github.com/juju/juju/core/resource"
 	coreresourcestore "github.com/juju/juju/core/resource/store"
+	"github.com/juju/juju/domain/application/charm"
 	charmresource "github.com/juju/juju/internal/charm/resource"
 )
 
@@ -89,8 +90,8 @@ type RecordStoredResourceArgs struct {
 type AddResourcesBeforeApplicationArgs struct {
 	// ApplicationName is the unique name of the application.
 	ApplicationName string
-	// CharmUUID is the unique identifier of the charm.
-	CharmUUID corecharm.ID
+	// CharmLocator is the unique identifier of the charm.
+	CharmLocator charm.CharmLocator
 	// ResourceDetails contains individual resource details.
 	ResourceDetails []AddResourceDetails
 }


### PR DESCRIPTION

Update AddResourcesBeforeApplication to use a CharmLocator rather than a Charm.ID. The application domain methods have changed such that you cannot get a Charm ID. Determination of whether the charm exists has moved from the resource facade to the resource domain methods.

Renamed resource state structure from resourceUUID to localUUID to allow for easy use in more places.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

This code is not wired up for use yet. No QA steps to complete. Unit tests should pass successfully.

## Links

**Jira card:** JUJU-7526

