### PR TITLE
docs: improve juju introspect functions doc

### DIFF
--- a/docs/user/reference/resource-compute/list-of-commands-available-on-a-compute-resource-provisioned-by-juju/list-of-juju-introspect-macros/juju_application_agent_name.md
+++ b/docs/user/reference/resource-compute/list-of-commands-available-on-a-compute-resource-provisioned-by-juju/list-of-juju-introspect-macros/juju_application_agent_name.md
@@ -1,4 +1,0 @@
-(juju-application-agent-name)=
-# `juju_application_agent_name`
-
-TBA

--- a/docs/user/reference/resource-compute/list-of-commands-available-on-a-compute-resource-provisioned-by-juju/list-of-juju-introspect-macros/juju_controller_agent_name.md
+++ b/docs/user/reference/resource-compute/list-of-commands-available-on-a-compute-resource-provisioned-by-juju/list-of-juju-introspect-macros/juju_controller_agent_name.md
@@ -1,4 +1,21 @@
 (juju_controller_agent_name)=
 # `juju_controller_agent_name`
 
-TBA
+The `juju_controller_agent_name` macro returns the name of the controller 
+agent that is currently running.
+
+## Usage
+
+```python
+juju_controller_agent_name
+```
+
+Returns a string containing the agent (controller) name.
+
+This macro is only available on controller machines -- everywhere else it returns an empty string.
+
+## Example output
+
+```bash
+controller-0
+``` 

--- a/docs/user/reference/resource-compute/list-of-commands-available-on-a-compute-resource-provisioned-by-juju/list-of-juju-introspect-macros/juju_cpu_profile.md
+++ b/docs/user/reference/resource-compute/list-of-commands-available-on-a-compute-resource-provisioned-by-juju/list-of-juju-introspect-macros/juju_cpu_profile.md
@@ -1,4 +1,22 @@
 (juju_cpu_profile)=
 # `juju_cpu_profile`
 
-TBA
+The `juju_cpu_profile` introspection function provides a CPU profile of the 
+current Juju agent process.  This is useful for debugging performance issues and 
+it is primarily intended for use by Juju developers.
+Under the hood this uses the [pprof](https://golang.org/pkg/net/http/pprof/) 
+package.
+
+This function is equivalent to `juju_heap_profile` but for CPU profiling.
+
+## Usage
+
+The `juju_cpu_profile` function will take samples during 30 seconds.
+You can write the output of this function to a file:
+
+```python
+juju_cpu_profile > cpu.prof
+```
+
+Then you can use the pprof tool to analyze the profile.
+

--- a/docs/user/reference/resource-compute/list-of-commands-available-on-a-compute-resource-provisioned-by-juju/list-of-juju-introspect-macros/juju_machine_agent_name.md
+++ b/docs/user/reference/resource-compute/list-of-commands-available-on-a-compute-resource-provisioned-by-juju/list-of-juju-introspect-macros/juju_machine_agent_name.md
@@ -1,4 +1,17 @@
 (juju-machine-agent-name)=
 # `juju_controller_agent_name`
 
-TBA
+The `juju_machine_agent_name` macro returns the name of the machine agent 
+that is currently running.
+
+## Usage
+
+```python
+juju_machine_agent_name
+```
+
+## Example output
+
+```bash
+machine-0
+```             

--- a/docs/user/reference/resource-compute/list-of-commands-available-on-a-compute-resource-provisioned-by-juju/list-of-juju-introspect-macros/juju_unit_agent_name.md
+++ b/docs/user/reference/resource-compute/list-of-commands-available-on-a-compute-resource-provisioned-by-juju/list-of-juju-introspect-macros/juju_unit_agent_name.md
@@ -1,0 +1,19 @@
+(juju-unit-agent-name)=
+# `juju_unit_agent_name`
+
+The `juju_unit_agent_name` macro returns the name of the unit 
+agent that is currently running.
+
+## Usage
+
+```python
+juju_unit_agent_name
+```
+
+Returns a string containing the agent (unit / application) name.
+
+## Example output:
+
+```bash
+unit-ubuntu-0
+```             

--- a/docs/user/reference/resource-compute/list-of-commands-available-on-a-compute-resource-provisioned-by-juju/list-of-juju-introspect-macros/juju_unit_status.md
+++ b/docs/user/reference/resource-compute/list-of-commands-available-on-a-compute-resource-provisioned-by-juju/list-of-juju-introspect-macros/juju_unit_status.md
@@ -1,5 +1,5 @@
 (juju_unit_status)=
-# juju_unit_status
+# `juju_unit_status`
 
 The `juju_unit_status` introspection function was introduced in 2.9.
 


### PR DESCRIPTION
This patch adds documention for the following functions (which were undocumented):
- juju_cpu_profile
- juju_machine_agent_name
- juju_unit_agent_name
- juju_controller_agente_name
