### PR TITLE
feat: wire application constraints in the apiserver

### DIFF
--- a/apiserver/facades/client/application/backend.go
+++ b/apiserver/facades/client/application/backend.go
@@ -64,7 +64,6 @@ type Application interface {
 	CharmOrigin() *state.CharmOrigin
 	ClearExposed() error
 	CharmConfig() (charm.Settings, error)
-	Constraints() (constraints.Value, error)
 	DestroyOperation(objectstore.ObjectStore) *state.DestroyApplicationOperation
 	EndpointBindings() (Bindings, error)
 	ExposedEndpoints() map[string]state.ExposedEndpoint

--- a/apiserver/facades/client/application/legacy_mock_test.go
+++ b/apiserver/facades/client/application/legacy_mock_test.go
@@ -1014,45 +1014,6 @@ func (c *MockApplicationClearExposedCall) DoAndReturn(f func() error) *MockAppli
 	return c
 }
 
-// Constraints mocks base method.
-func (m *MockApplication) Constraints() (constraints.Value, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Constraints")
-	ret0, _ := ret[0].(constraints.Value)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Constraints indicates an expected call of Constraints.
-func (mr *MockApplicationMockRecorder) Constraints() *MockApplicationConstraintsCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Constraints", reflect.TypeOf((*MockApplication)(nil).Constraints))
-	return &MockApplicationConstraintsCall{Call: call}
-}
-
-// MockApplicationConstraintsCall wrap *gomock.Call
-type MockApplicationConstraintsCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockApplicationConstraintsCall) Return(arg0 constraints.Value, arg1 error) *MockApplicationConstraintsCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockApplicationConstraintsCall) Do(f func() (constraints.Value, error)) *MockApplicationConstraintsCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationConstraintsCall) DoAndReturn(f func() (constraints.Value, error)) *MockApplicationConstraintsCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // DestroyOperation mocks base method.
 func (m *MockApplication) DestroyOperation(arg0 objectstore.ObjectStore) *state.DestroyApplicationOperation {
 	m.ctrl.T.Helper()

--- a/apiserver/facades/client/application/service.go
+++ b/apiserver/facades/client/application/service.go
@@ -12,6 +12,7 @@ import (
 	coreapplication "github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/assumes"
 	corecharm "github.com/juju/juju/core/charm"
+	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/credential"
 	"github.com/juju/juju/core/crossmodel"
 	"github.com/juju/juju/core/instance"
@@ -185,6 +186,31 @@ type ApplicationService interface {
 	// indicates if the charm has been uploaded to the controller.
 	// This will return true if the charm is available, and false otherwise.
 	IsCharmAvailable(ctx context.Context, locator applicationcharm.CharmLocator) (bool, error)
+
+	// GetApplicationIDByName returns an application ID by application name. It
+	// returns an error if the application can not be found by the name.
+	//
+	// Returns [applicationerrors.ApplicationNameNotValid] if the name is not valid,
+	// and [applicationerrors.ApplicationNotFound] if the application is not found.
+	GetApplicationIDByName(ctx context.Context, name string) (coreapplication.ID, error)
+
+	// GetApplicationConstraints returns the application constraints for the
+	// specified application ID.
+	// Empty constraints are returned if no constraints exist for the given
+	// application ID.
+	// If no application is found, an error satisfying
+	// [applicationerrors.ApplicationNotFound] is returned.
+	GetApplicationConstraints(ctx context.Context, appID coreapplication.ID) (constraints.Value, error)
+
+	// SetApplicationConstraints sets the application constraints for the
+	// specified application ID.
+	// This method overwrites the full constraints on every call.
+	// If invalid constraints are provided (e.g. invalid container type or
+	// non-existing space), a [applicationerrors.InvalidApplicationConstraints]
+	// error is returned.
+	// If no application is found, an error satisfying
+	// [applicationerrors.ApplicationNotFound] is returned.
+	SetApplicationConstraints(ctx context.Context, appID coreapplication.ID, cons constraints.Value) error
 }
 
 // ModelConfigService provides access to the model configuration.

--- a/apiserver/facades/client/application/services_mock_test.go
+++ b/apiserver/facades/client/application/services_mock_test.go
@@ -17,6 +17,7 @@ import (
 	application "github.com/juju/juju/core/application"
 	assumes "github.com/juju/juju/core/assumes"
 	charm "github.com/juju/juju/core/charm"
+	constraints "github.com/juju/juju/core/constraints"
 	crossmodel "github.com/juju/juju/core/crossmodel"
 	instance "github.com/juju/juju/core/instance"
 	life "github.com/juju/juju/core/life"
@@ -1039,6 +1040,84 @@ func (c *MockApplicationServiceDestroyUnitCall) DoAndReturn(f func(context.Conte
 	return c
 }
 
+// GetApplicationConstraints mocks base method.
+func (m *MockApplicationService) GetApplicationConstraints(arg0 context.Context, arg1 application.ID) (constraints.Value, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetApplicationConstraints", arg0, arg1)
+	ret0, _ := ret[0].(constraints.Value)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetApplicationConstraints indicates an expected call of GetApplicationConstraints.
+func (mr *MockApplicationServiceMockRecorder) GetApplicationConstraints(arg0, arg1 any) *MockApplicationServiceGetApplicationConstraintsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetApplicationConstraints", reflect.TypeOf((*MockApplicationService)(nil).GetApplicationConstraints), arg0, arg1)
+	return &MockApplicationServiceGetApplicationConstraintsCall{Call: call}
+}
+
+// MockApplicationServiceGetApplicationConstraintsCall wrap *gomock.Call
+type MockApplicationServiceGetApplicationConstraintsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockApplicationServiceGetApplicationConstraintsCall) Return(arg0 constraints.Value, arg1 error) *MockApplicationServiceGetApplicationConstraintsCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockApplicationServiceGetApplicationConstraintsCall) Do(f func(context.Context, application.ID) (constraints.Value, error)) *MockApplicationServiceGetApplicationConstraintsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockApplicationServiceGetApplicationConstraintsCall) DoAndReturn(f func(context.Context, application.ID) (constraints.Value, error)) *MockApplicationServiceGetApplicationConstraintsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetApplicationIDByName mocks base method.
+func (m *MockApplicationService) GetApplicationIDByName(arg0 context.Context, arg1 string) (application.ID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetApplicationIDByName", arg0, arg1)
+	ret0, _ := ret[0].(application.ID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetApplicationIDByName indicates an expected call of GetApplicationIDByName.
+func (mr *MockApplicationServiceMockRecorder) GetApplicationIDByName(arg0, arg1 any) *MockApplicationServiceGetApplicationIDByNameCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetApplicationIDByName", reflect.TypeOf((*MockApplicationService)(nil).GetApplicationIDByName), arg0, arg1)
+	return &MockApplicationServiceGetApplicationIDByNameCall{Call: call}
+}
+
+// MockApplicationServiceGetApplicationIDByNameCall wrap *gomock.Call
+type MockApplicationServiceGetApplicationIDByNameCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockApplicationServiceGetApplicationIDByNameCall) Return(arg0 application.ID, arg1 error) *MockApplicationServiceGetApplicationIDByNameCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockApplicationServiceGetApplicationIDByNameCall) Do(f func(context.Context, string) (application.ID, error)) *MockApplicationServiceGetApplicationIDByNameCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockApplicationServiceGetApplicationIDByNameCall) DoAndReturn(f func(context.Context, string) (application.ID, error)) *MockApplicationServiceGetApplicationIDByNameCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetApplicationLife mocks base method.
 func (m *MockApplicationService) GetApplicationLife(arg0 context.Context, arg1 string) (life.Value, error) {
 	m.ctrl.T.Helper()
@@ -1466,6 +1545,44 @@ func (c *MockApplicationServiceIsCharmAvailableCall) Do(f func(context.Context, 
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockApplicationServiceIsCharmAvailableCall) DoAndReturn(f func(context.Context, charm0.CharmLocator) (bool, error)) *MockApplicationServiceIsCharmAvailableCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// SetApplicationConstraints mocks base method.
+func (m *MockApplicationService) SetApplicationConstraints(arg0 context.Context, arg1 application.ID, arg2 constraints.Value) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetApplicationConstraints", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetApplicationConstraints indicates an expected call of SetApplicationConstraints.
+func (mr *MockApplicationServiceMockRecorder) SetApplicationConstraints(arg0, arg1, arg2 any) *MockApplicationServiceSetApplicationConstraintsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetApplicationConstraints", reflect.TypeOf((*MockApplicationService)(nil).SetApplicationConstraints), arg0, arg1, arg2)
+	return &MockApplicationServiceSetApplicationConstraintsCall{Call: call}
+}
+
+// MockApplicationServiceSetApplicationConstraintsCall wrap *gomock.Call
+type MockApplicationServiceSetApplicationConstraintsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockApplicationServiceSetApplicationConstraintsCall) Return(arg0 error) *MockApplicationServiceSetApplicationConstraintsCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockApplicationServiceSetApplicationConstraintsCall) Do(f func(context.Context, application.ID, constraints.Value) error) *MockApplicationServiceSetApplicationConstraintsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockApplicationServiceSetApplicationConstraintsCall) DoAndReturn(f func(context.Context, application.ID, constraints.Value) error) *MockApplicationServiceSetApplicationConstraintsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/client/charms/client_test.go
+++ b/apiserver/facades/client/charms/client_test.go
@@ -15,6 +15,7 @@ import (
 	apiservermocks "github.com/juju/juju/apiserver/facade/mocks"
 	"github.com/juju/juju/apiserver/facades/client/charms/interfaces"
 	"github.com/juju/juju/apiserver/facades/client/charms/mocks"
+	coreapplication "github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/arch"
 	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/core/constraints"
@@ -297,7 +298,7 @@ func (s *charmsMockSuite) TestCheckCharmPlacementWithConstraintArch(c *gc.C) {
 
 	defer s.setupMocks(c).Finish()
 	s.expectApplication(appName)
-	s.expectApplicationConstraints(constraints.Value{Arch: &arch})
+	s.expectApplicationConstraints(appName, constraints.Value{Arch: &arch})
 
 	api := s.api(c)
 
@@ -320,7 +321,7 @@ func (s *charmsMockSuite) TestCheckCharmPlacementWithNoConstraintArch(c *gc.C) {
 
 	defer s.setupMocks(c).Finish()
 	s.expectApplication(appName)
-	s.expectApplicationConstraints(constraints.Value{})
+	s.expectApplicationConstraints(appName, constraints.Value{})
 	s.expectAllUnits()
 	s.expectUnitMachineID()
 	s.expectMachine()
@@ -349,7 +350,7 @@ func (s *charmsMockSuite) TestCheckCharmPlacementWithNoConstraintArchMachine(c *
 
 	defer s.setupMocks(c).Finish()
 	s.expectApplication(appName)
-	s.expectApplicationConstraints(constraints.Value{})
+	s.expectApplicationConstraints(appName, constraints.Value{})
 	s.expectAllUnits()
 	s.expectUnitMachineID()
 	s.expectMachine()
@@ -376,7 +377,7 @@ func (s *charmsMockSuite) TestCheckCharmPlacementWithNoConstraintArchAndHardware
 
 	defer s.setupMocks(c).Finish()
 	s.expectApplication(appName)
-	s.expectApplicationConstraints(constraints.Value{})
+	s.expectApplicationConstraints(appName, constraints.Value{})
 	s.expectAllUnits()
 	s.expectUnitMachineID()
 	s.expectMachine()
@@ -404,7 +405,7 @@ func (s *charmsMockSuite) TestCheckCharmPlacementWithHeterogeneous(c *gc.C) {
 
 	defer s.setupMocks(c).Finish()
 	s.expectApplication(appName)
-	s.expectApplicationConstraints(constraints.Value{})
+	s.expectApplicationConstraints(appName, constraints.Value{})
 	s.expectHeterogeneousUnits()
 
 	s.expectUnitMachineID()
@@ -560,8 +561,9 @@ func (s *charmsMockSuite) expectSubordinateApplication(name string) {
 	s.application.EXPECT().IsPrincipal().Return(false)
 }
 
-func (s *charmsMockSuite) expectApplicationConstraints(cons constraints.Value) {
-	s.application.EXPECT().Constraints().Return(cons, nil)
+func (s *charmsMockSuite) expectApplicationConstraints(appnName string, cons constraints.Value) {
+	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), appnName).Return(coreapplication.ID("deadbeef"), nil)
+	s.applicationService.EXPECT().GetApplicationConstraints(gomock.Any(), coreapplication.ID("deadbeef")).Return(cons, nil)
 }
 
 func (s *charmsMockSuite) expectAllUnits() {

--- a/apiserver/facades/client/charms/interfaces/state.go
+++ b/apiserver/facades/client/charms/interfaces/state.go
@@ -24,7 +24,6 @@ type BackendState interface {
 // the same names.
 type Application interface {
 	AllUnits() ([]Unit, error)
-	Constraints() (constraints.Value, error)
 	IsPrincipal() bool
 }
 

--- a/apiserver/facades/client/charms/mocks/state_mock.go
+++ b/apiserver/facades/client/charms/mocks/state_mock.go
@@ -301,45 +301,6 @@ func (c *MockApplicationAllUnitsCall) DoAndReturn(f func() ([]interfaces.Unit, e
 	return c
 }
 
-// Constraints mocks base method.
-func (m *MockApplication) Constraints() (constraints.Value, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Constraints")
-	ret0, _ := ret[0].(constraints.Value)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Constraints indicates an expected call of Constraints.
-func (mr *MockApplicationMockRecorder) Constraints() *MockApplicationConstraintsCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Constraints", reflect.TypeOf((*MockApplication)(nil).Constraints))
-	return &MockApplicationConstraintsCall{Call: call}
-}
-
-// MockApplicationConstraintsCall wrap *gomock.Call
-type MockApplicationConstraintsCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockApplicationConstraintsCall) Return(arg0 constraints.Value, arg1 error) *MockApplicationConstraintsCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockApplicationConstraintsCall) Do(f func() (constraints.Value, error)) *MockApplicationConstraintsCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationConstraintsCall) DoAndReturn(f func() (constraints.Value, error)) *MockApplicationConstraintsCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // IsPrincipal mocks base method.
 func (m *MockApplication) IsPrincipal() bool {
 	m.ctrl.T.Helper()

--- a/apiserver/facades/client/charms/service.go
+++ b/apiserver/facades/client/charms/service.go
@@ -6,7 +6,9 @@ package charms
 import (
 	"context"
 
+	coreapplication "github.com/juju/juju/core/application"
 	corecharm "github.com/juju/juju/core/charm"
+	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/machine"
 	"github.com/juju/juju/domain/application/charm"
@@ -31,6 +33,21 @@ type ApplicationService interface {
 	// ListCharmLocators returns a list of charms with the specified
 	// locator by the name. If no names are provided, all charms are returned.
 	ListCharmLocators(ctx context.Context, names ...string) ([]charm.CharmLocator, error)
+
+	// GetApplicationIDByName returns an application ID by application name. It
+	// returns an error if the application can not be found by the name.
+	//
+	// Returns [applicationerrors.ApplicationNameNotValid] if the name is not valid,
+	// and [applicationerrors.ApplicationNotFound] if the application is not found.
+	GetApplicationIDByName(ctx context.Context, name string) (coreapplication.ID, error)
+
+	// GetApplicationConstraints returns the application constraints for the
+	// specified application ID.
+	// Empty constraints are returned if no constraints exist for the given
+	// application ID.
+	// If no application is found, an error satisfying
+	// [applicationerrors.ApplicationNotFound] is returned.
+	GetApplicationConstraints(ctx context.Context, appID coreapplication.ID) (constraints.Value, error)
 }
 
 // MachineService defines the methods that the facade assumes from the Machine

--- a/apiserver/facades/client/charms/service_mock_test.go
+++ b/apiserver/facades/client/charms/service_mock_test.go
@@ -13,7 +13,9 @@ import (
 	context "context"
 	reflect "reflect"
 
+	application "github.com/juju/juju/core/application"
 	charm "github.com/juju/juju/core/charm"
+	constraints "github.com/juju/juju/core/constraints"
 	instance "github.com/juju/juju/core/instance"
 	machine "github.com/juju/juju/core/machine"
 	charm0 "github.com/juju/juju/domain/application/charm"
@@ -104,6 +106,84 @@ func NewMockApplicationService(ctrl *gomock.Controller) *MockApplicationService 
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockApplicationService) EXPECT() *MockApplicationServiceMockRecorder {
 	return m.recorder
+}
+
+// GetApplicationConstraints mocks base method.
+func (m *MockApplicationService) GetApplicationConstraints(arg0 context.Context, arg1 application.ID) (constraints.Value, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetApplicationConstraints", arg0, arg1)
+	ret0, _ := ret[0].(constraints.Value)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetApplicationConstraints indicates an expected call of GetApplicationConstraints.
+func (mr *MockApplicationServiceMockRecorder) GetApplicationConstraints(arg0, arg1 any) *MockApplicationServiceGetApplicationConstraintsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetApplicationConstraints", reflect.TypeOf((*MockApplicationService)(nil).GetApplicationConstraints), arg0, arg1)
+	return &MockApplicationServiceGetApplicationConstraintsCall{Call: call}
+}
+
+// MockApplicationServiceGetApplicationConstraintsCall wrap *gomock.Call
+type MockApplicationServiceGetApplicationConstraintsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockApplicationServiceGetApplicationConstraintsCall) Return(arg0 constraints.Value, arg1 error) *MockApplicationServiceGetApplicationConstraintsCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockApplicationServiceGetApplicationConstraintsCall) Do(f func(context.Context, application.ID) (constraints.Value, error)) *MockApplicationServiceGetApplicationConstraintsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockApplicationServiceGetApplicationConstraintsCall) DoAndReturn(f func(context.Context, application.ID) (constraints.Value, error)) *MockApplicationServiceGetApplicationConstraintsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetApplicationIDByName mocks base method.
+func (m *MockApplicationService) GetApplicationIDByName(arg0 context.Context, arg1 string) (application.ID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetApplicationIDByName", arg0, arg1)
+	ret0, _ := ret[0].(application.ID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetApplicationIDByName indicates an expected call of GetApplicationIDByName.
+func (mr *MockApplicationServiceMockRecorder) GetApplicationIDByName(arg0, arg1 any) *MockApplicationServiceGetApplicationIDByNameCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetApplicationIDByName", reflect.TypeOf((*MockApplicationService)(nil).GetApplicationIDByName), arg0, arg1)
+	return &MockApplicationServiceGetApplicationIDByNameCall{Call: call}
+}
+
+// MockApplicationServiceGetApplicationIDByNameCall wrap *gomock.Call
+type MockApplicationServiceGetApplicationIDByNameCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockApplicationServiceGetApplicationIDByNameCall) Return(arg0 application.ID, arg1 error) *MockApplicationServiceGetApplicationIDByNameCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockApplicationServiceGetApplicationIDByNameCall) Do(f func(context.Context, string) (application.ID, error)) *MockApplicationServiceGetApplicationIDByNameCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockApplicationServiceGetApplicationIDByNameCall) DoAndReturn(f func(context.Context, string) (application.ID, error)) *MockApplicationServiceGetApplicationIDByNameCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
 }
 
 // ListCharmLocators mocks base method.

--- a/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
@@ -482,8 +482,17 @@ func (a *API) provisioningInfo(ctx context.Context, appTag names.ApplicationTag)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	cons, err := app.Constraints()
-	if err != nil {
+
+	appID, err := a.applicationService.GetApplicationIDByName(ctx, appName)
+	if errors.Is(err, applicationerrors.ApplicationNotFound) {
+		return nil, errors.NotFoundf("application %s", appName)
+	} else if err != nil {
+		return nil, errors.Trace(err)
+	}
+	cons, err := a.applicationService.GetApplicationConstraints(ctx, appID)
+	if errors.Is(err, applicationerrors.ApplicationNotFound) {
+		return nil, errors.NotFoundf("application %s", appName)
+	} else if err != nil {
 		return nil, errors.Trace(err)
 	}
 	mergedCons, err := a.state.ResolveConstraints(cons)

--- a/apiserver/facades/controller/caasapplicationprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/provisioner_test.go
@@ -21,7 +21,9 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facades/controller/caasapplicationprovisioner"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
+	coreapplication "github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/config"
+	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/model"
 	jujuresource "github.com/juju/juju/core/resource"
 	"github.com/juju/juju/core/status"
@@ -171,6 +173,8 @@ func (s *CAASApplicationProvisionerSuite) TestProvisioningInfo(c *gc.C) {
 	}
 	s.modelInfoService.EXPECT().GetModelInfo(gomock.Any()).Return(modelInfo, nil)
 	s.applicationService.EXPECT().GetApplicationScale(gomock.Any(), "gitlab").Return(3, nil)
+	s.applicationService.EXPECT().GetApplicationIDByName(gomock.Any(), "gitlab").Return(coreapplication.ID("deadbeef"), nil)
+	s.applicationService.EXPECT().GetApplicationConstraints(gomock.Any(), coreapplication.ID("deadbeef")).Return(constraints.Value{}, nil)
 
 	result, err := s.api.ProvisioningInfo(context.Background(), params.Entities{Entities: []params.Entity{{"application-gitlab"}}})
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/controller/caasapplicationprovisioner/service.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/service.go
@@ -7,6 +7,8 @@ import (
 	"context"
 
 	"github.com/juju/juju/controller"
+	coreapplication "github.com/juju/juju/core/application"
+	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/leadership"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/model"
@@ -70,4 +72,19 @@ type ApplicationService interface {
 	DestroyUnit(context.Context, unit.Name) error
 	RemoveUnit(context.Context, unit.Name, leadership.Revoker) error
 	UpdateCAASUnit(context.Context, unit.Name, service.UpdateCAASUnitParams) error
+
+	// GetApplicationIDByName returns an application ID by application name. It
+	// returns an error if the application can not be found by the name.
+	//
+	// Returns [applicationerrors.ApplicationNameNotValid] if the name is not valid,
+	// and [applicationerrors.ApplicationNotFound] if the application is not found.
+	GetApplicationIDByName(ctx context.Context, name string) (coreapplication.ID, error)
+
+	// GetApplicationConstraints returns the application constraints for the
+	// specified application ID.
+	// Empty constraints are returned if no constraints exist for the given
+	// application ID.
+	// If no application is found, an error satisfying
+	// [applicationerrors.ApplicationNotFound] is returned.
+	GetApplicationConstraints(ctx context.Context, appID coreapplication.ID) (constraints.Value, error)
 }

--- a/apiserver/facades/controller/caasapplicationprovisioner/service_mock_test.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/service_mock_test.go
@@ -14,6 +14,8 @@ import (
 	reflect "reflect"
 
 	controller "github.com/juju/juju/controller"
+	application "github.com/juju/juju/core/application"
+	constraints "github.com/juju/juju/core/constraints"
 	leadership "github.com/juju/juju/core/leadership"
 	life "github.com/juju/juju/core/life"
 	model "github.com/juju/juju/core/model"
@@ -206,6 +208,36 @@ func (m *MockApplicationService) DestroyUnit(arg0 context.Context, arg1 unit.Nam
 func (mr *MockApplicationServiceMockRecorder) DestroyUnit(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DestroyUnit", reflect.TypeOf((*MockApplicationService)(nil).DestroyUnit), arg0, arg1)
+}
+
+// GetApplicationConstraints mocks base method.
+func (m *MockApplicationService) GetApplicationConstraints(arg0 context.Context, arg1 application.ID) (constraints.Value, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetApplicationConstraints", arg0, arg1)
+	ret0, _ := ret[0].(constraints.Value)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetApplicationConstraints indicates an expected call of GetApplicationConstraints.
+func (mr *MockApplicationServiceMockRecorder) GetApplicationConstraints(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetApplicationConstraints", reflect.TypeOf((*MockApplicationService)(nil).GetApplicationConstraints), arg0, arg1)
+}
+
+// GetApplicationIDByName mocks base method.
+func (m *MockApplicationService) GetApplicationIDByName(arg0 context.Context, arg1 string) (application.ID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetApplicationIDByName", arg0, arg1)
+	ret0, _ := ret[0].(application.ID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetApplicationIDByName indicates an expected call of GetApplicationIDByName.
+func (mr *MockApplicationServiceMockRecorder) GetApplicationIDByName(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetApplicationIDByName", reflect.TypeOf((*MockApplicationService)(nil).GetApplicationIDByName), arg0, arg1)
 }
 
 // GetApplicationLife mocks base method.

--- a/apiserver/facades/controller/caasapplicationprovisioner/state.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/state.go
@@ -51,7 +51,6 @@ type Application interface {
 	StorageConstraints() (map[string]state.StorageConstraints, error)
 	DeviceConstraints() (map[string]state.DeviceConstraints, error)
 	Name() string
-	Constraints() (constraints.Value, error)
 	Life() state.Life
 	Base() state.Base
 	SetStatus(statusInfo status.StatusInfo) error

--- a/state/application.go
+++ b/state/application.go
@@ -1888,7 +1888,7 @@ func (a *Application) addUnitOps(
 ) (string, []txn.Op, error) {
 	var cons constraints.Value
 	if !a.doc.Subordinate {
-		scons, err := a.Constraints()
+		scons, err := a.constraints()
 		if errors.Is(err, errors.NotFound) {
 			return "", nil, errors.NotFoundf("application %q", a.Name())
 		}
@@ -2729,7 +2729,7 @@ func (a *Application) UpdateApplicationConfig(
 var ErrSubordinateConstraints = stderrors.New("constraints do not apply to subordinate applications")
 
 // Constraints returns the current application constraints.
-func (a *Application) Constraints() (constraints.Value, error) {
+func (a *Application) constraints() (constraints.Value, error) {
 	if a.doc.Subordinate {
 		return constraints.Value{}, ErrSubordinateConstraints
 	}
@@ -2756,7 +2756,7 @@ func (a *Application) SetConstraints(cons constraints.Value) (err error) {
 	// If the constraints returns a not found error, we don't actually care,
 	// this implies that it's never been set and we want to just take all the
 	// valid constraints.
-	if current, consErr := a.Constraints(); !errors.Is(consErr, errors.NotFound) {
+	if current, consErr := a.constraints(); !errors.Is(consErr, errors.NotFound) {
 		if consErr != nil {
 			return errors.Annotate(consErr, "unable to read constraints")
 		}


### PR DESCRIPTION
This patch wires the recently added application constraints methods from the application domain into the apiserver.

As a side quest, the `Constraints()` method from the legacy state `Application` struct was made private, since it's only used inside the legacy `state/application.go` and making it private we ensure it's not used elsewhere. It must be noted that we cannot remove it because setting the constraints in mongo has to continue until the machine domain is finished.


## QA steps

This changes should only impact application constraints, so setting and retrieving should be enough.
Bootstrap on aws:
```
$ juju bootstrap aws c
$ juju add-model m
$ juju deploy ubuntu
$ juju constraints ubuntu

$ juju set-constraints ubuntu cpu-cores=2
$ juju constraints ubuntu
cores=2
```
Then upscaling the app should work as usual:
```
$ juju add-unit ubuntu
$ juju status
Model  Controller  Cloud/Region   Version      Timestamp
m      c           aws/eu-west-3  4.0-beta5.1  11:02:03+01:00

App     Version  Status  Scale  Charm   Channel        Rev  Exposed  Message
ubuntu           active      2  ubuntu  latest/stable   25  no

Unit       Workload  Agent  Machine  Public address  Ports  Message
ubuntu/0*  active    idle   0        15.236.247.195
ubuntu/1   active    idle   1        13.39.111.63

Machine  State    Address         Inst id              Base          AZ          Message
0        started  xxxx             i-x  ubuntu@24.04  eu-west-3a  running
1        started  xxxx             i-x  ubuntu@24.04  eu-west-3c  running
```



## Links


**Jira card:** JUJU-7502

