### PR TITLE
feat: implement migration for application constraints

### DIFF
--- a/domain/application/modelmigration/migrations_mock_test.go
+++ b/domain/application/modelmigration/migrations_mock_test.go
@@ -15,6 +15,7 @@ import (
 
 	charm "github.com/juju/juju/core/charm"
 	config "github.com/juju/juju/core/config"
+	constraints "github.com/juju/juju/core/constraints"
 	status "github.com/juju/juju/core/status"
 	application "github.com/juju/juju/domain/application"
 	charm0 "github.com/juju/juju/domain/application/charm"
@@ -181,6 +182,45 @@ func (c *MockExportServiceGetApplicationConfigAndSettingsCall) Do(f func(context
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockExportServiceGetApplicationConfigAndSettingsCall) DoAndReturn(f func(context.Context, string) (config.ConfigAttributes, application.ApplicationSettings, error)) *MockExportServiceGetApplicationConfigAndSettingsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetApplicationConstraints mocks base method.
+func (m *MockExportService) GetApplicationConstraints(arg0 context.Context, arg1 string) (constraints.Value, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetApplicationConstraints", arg0, arg1)
+	ret0, _ := ret[0].(constraints.Value)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetApplicationConstraints indicates an expected call of GetApplicationConstraints.
+func (mr *MockExportServiceMockRecorder) GetApplicationConstraints(arg0, arg1 any) *MockExportServiceGetApplicationConstraintsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetApplicationConstraints", reflect.TypeOf((*MockExportService)(nil).GetApplicationConstraints), arg0, arg1)
+	return &MockExportServiceGetApplicationConstraintsCall{Call: call}
+}
+
+// MockExportServiceGetApplicationConstraintsCall wrap *gomock.Call
+type MockExportServiceGetApplicationConstraintsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockExportServiceGetApplicationConstraintsCall) Return(arg0 constraints.Value, arg1 error) *MockExportServiceGetApplicationConstraintsCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockExportServiceGetApplicationConstraintsCall) Do(f func(context.Context, string) (constraints.Value, error)) *MockExportServiceGetApplicationConstraintsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockExportServiceGetApplicationConstraintsCall) DoAndReturn(f func(context.Context, string) (constraints.Value, error)) *MockExportServiceGetApplicationConstraintsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/application/service/params.go
+++ b/domain/application/service/params.go
@@ -6,6 +6,7 @@ package service
 import (
 	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/core/config"
+	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/core/resource"
 	"github.com/juju/juju/core/status"
@@ -210,4 +211,6 @@ type ImportApplicationArgs struct {
 
 	// Units contains the units to import.
 	Units []ImportUnitArg
+	// ApplicationConstraints contains the application constraints.
+	ApplicationConstraints constraints.Value
 }


### PR DESCRIPTION
This patch adds model migration for domain application constraints.

Note: The migration import does not use the validation that is used when setting constraints in the app service. The reason is that we don't have a provider for migration yet. The validation will be added in a follow-up patch.


## QA steps


 1. Bootstrap a 3.6 controller and deploy a charm.

```sh
$ juju bootstrap lxd src36
$ juju add-model moveme1
$ juju deploy juju-qa-test
$ juju set-constraints juju-qa-test spaces=^alpha cpu-cores=2
```

 2. Bootstrap a 4.0 controller with the changes and migrate the model.

```sh
$ juju bootstrap lxd dst40
$ juju migrate src36:moveme1 dst40
$ juju add-unit juju-qa-test
$ juju constraints juju-qa-test
cores=2 spaces=^alpha
```

 3. Verify no errors exist in the model logs for the agents. If there are
    errors, this is a bug and should be fixed before merging. The fix can
    either be applied to the 4.0 branch (preferable) or the 3.6 branch, though
    that needs to be discussed with the team.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme1
```

 4. We also need to test a model migration from 4.0 to 4.0.

```sh
$ juju bootstrap lxd src40
$ juju add-model moveme2
$ juju deploy juju-qa-test
$ juju set-constraints juju-qa-test spaces=^alpha cpu-cores=2
```

```sh
$ juju migrate src40:moveme2 dst40
$ juju add-unit juju-qa-test
$ juju constraints juju-qa-test
cores=2 spaces=^alpha
```

 5. Verify that there are no errors in the controller or model logs.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme2
```

## Links


**Jira card:** JUJU-7420

