### PR TITLE
docs: 3.6+ fix git remote add upstream link in contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ git clone git@github.com:<user>/juju.git
 `juju` repo.
 
 ```
-git remote add upstream https://github.com/juju/juju.git
+git remote add upstream git@github.com:juju/juju.git
 ```
 
 6. Set your local branches to track the `upstream` remote (not your fork). E.g.,


### PR DESCRIPTION
> This PR targets 3.6 and above.

Our CONTRIBUTING.md's upstream link in the `git remote add` line was (I think) wrong. Updated it now to match what works for me.

## Checklist

~- [ ] Code style: imports ordered, good names, simple structure, etc~
~- [ ] Comments saying why design decisions were made~
~- [ ] Go unit tests, with comments saying what you're testing~
~- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
~- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

N/A

## Documentation changes

This is a documentation change.

## Links

N/A
