### PR TITLE
fix: allow db repl to switch to models containing "-"

### DIFF
--- a/internal/worker/dbrepl/worker.go
+++ b/internal/worker/dbrepl/worker.go
@@ -256,15 +256,11 @@ func (w *dbReplWorker) execSwitch(ctx context.Context, args []string) {
 		return
 	}
 
-	parts := strings.Split(argName, "-")
-	if len(parts) != 2 {
-		fmt.Fprintln(w.cfg.Stderr, "invalid namespace name")
-		return
-	} else if parts[0] != "model" {
-		fmt.Fprintln(w.cfg.Stderr, "invalid model namespace name")
+	name, ok := strings.CutPrefix(argName, "model-")
+	if !ok {
+		fmt.Fprintln(w.cfg.Stderr, `invalid model namespace name: expected "model-<name>" or "controller"`)
 		return
 	}
-	name := parts[1]
 
 	var uuid string
 	if err := w.controllerDB.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {


### PR DESCRIPTION
The ".switch" command in the DB repl worker used to split by "-" and check that there were two parts. This meant would declare the model name invalid if it contained a "-" as it only expected to find one, located in the prefix "model-".

Change to check for the specific prefix rather than splitting the string by "-".

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps
```
$ juju bootstrap lxd test
$ juju add-model model-with-dash
$ juju ssh -m controller 0
$ sudo /var/lib/juju/tools/machine-0/jujud db-repl --machine-id 0
repl (controller)> .switch model-model-with-dash
```