### PR TITLE
feat: migrate application status

### DIFF
--- a/domain/application/modelmigration/migrations_mock_test.go
+++ b/domain/application/modelmigration/migrations_mock_test.go
@@ -15,6 +15,7 @@ import (
 
 	charm "github.com/juju/juju/core/charm"
 	config "github.com/juju/juju/core/config"
+	status "github.com/juju/juju/core/status"
 	application "github.com/juju/juju/domain/application"
 	charm0 "github.com/juju/juju/domain/application/charm"
 	service "github.com/juju/juju/domain/application/service"
@@ -184,42 +185,81 @@ func (c *MockExportServiceGetApplicationConfigAndSettingsCall) DoAndReturn(f fun
 	return c
 }
 
-// GetCharm mocks base method.
-func (m *MockExportService) GetCharm(arg0 context.Context, arg1 charm.ID) (charm1.Charm, charm0.CharmLocator, error) {
+// GetApplicationStatus mocks base method.
+func (m *MockExportService) GetApplicationStatus(arg0 context.Context, arg1 string) (*status.StatusInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCharm", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetApplicationStatus", arg0, arg1)
+	ret0, _ := ret[0].(*status.StatusInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetApplicationStatus indicates an expected call of GetApplicationStatus.
+func (mr *MockExportServiceMockRecorder) GetApplicationStatus(arg0, arg1 any) *MockExportServiceGetApplicationStatusCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetApplicationStatus", reflect.TypeOf((*MockExportService)(nil).GetApplicationStatus), arg0, arg1)
+	return &MockExportServiceGetApplicationStatusCall{Call: call}
+}
+
+// MockExportServiceGetApplicationStatusCall wrap *gomock.Call
+type MockExportServiceGetApplicationStatusCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockExportServiceGetApplicationStatusCall) Return(arg0 *status.StatusInfo, arg1 error) *MockExportServiceGetApplicationStatusCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockExportServiceGetApplicationStatusCall) Do(f func(context.Context, string) (*status.StatusInfo, error)) *MockExportServiceGetApplicationStatusCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockExportServiceGetApplicationStatusCall) DoAndReturn(f func(context.Context, string) (*status.StatusInfo, error)) *MockExportServiceGetApplicationStatusCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetCharmByApplicationName mocks base method.
+func (m *MockExportService) GetCharmByApplicationName(arg0 context.Context, arg1 string) (charm1.Charm, charm0.CharmLocator, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCharmByApplicationName", arg0, arg1)
 	ret0, _ := ret[0].(charm1.Charm)
 	ret1, _ := ret[1].(charm0.CharmLocator)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
 
-// GetCharm indicates an expected call of GetCharm.
-func (mr *MockExportServiceMockRecorder) GetCharm(arg0, arg1 any) *MockExportServiceGetCharmCall {
+// GetCharmByApplicationName indicates an expected call of GetCharmByApplicationName.
+func (mr *MockExportServiceMockRecorder) GetCharmByApplicationName(arg0, arg1 any) *MockExportServiceGetCharmByApplicationNameCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCharm", reflect.TypeOf((*MockExportService)(nil).GetCharm), arg0, arg1)
-	return &MockExportServiceGetCharmCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCharmByApplicationName", reflect.TypeOf((*MockExportService)(nil).GetCharmByApplicationName), arg0, arg1)
+	return &MockExportServiceGetCharmByApplicationNameCall{Call: call}
 }
 
-// MockExportServiceGetCharmCall wrap *gomock.Call
-type MockExportServiceGetCharmCall struct {
+// MockExportServiceGetCharmByApplicationNameCall wrap *gomock.Call
+type MockExportServiceGetCharmByApplicationNameCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockExportServiceGetCharmCall) Return(arg0 charm1.Charm, arg1 charm0.CharmLocator, arg2 error) *MockExportServiceGetCharmCall {
+func (c *MockExportServiceGetCharmByApplicationNameCall) Return(arg0 charm1.Charm, arg1 charm0.CharmLocator, arg2 error) *MockExportServiceGetCharmByApplicationNameCall {
 	c.Call = c.Call.Return(arg0, arg1, arg2)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockExportServiceGetCharmCall) Do(f func(context.Context, charm.ID) (charm1.Charm, charm0.CharmLocator, error)) *MockExportServiceGetCharmCall {
+func (c *MockExportServiceGetCharmByApplicationNameCall) Do(f func(context.Context, string) (charm1.Charm, charm0.CharmLocator, error)) *MockExportServiceGetCharmByApplicationNameCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockExportServiceGetCharmCall) DoAndReturn(f func(context.Context, charm.ID) (charm1.Charm, charm0.CharmLocator, error)) *MockExportServiceGetCharmCall {
+func (c *MockExportServiceGetCharmByApplicationNameCall) DoAndReturn(f func(context.Context, string) (charm1.Charm, charm0.CharmLocator, error)) *MockExportServiceGetCharmByApplicationNameCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/application/service/application.go
+++ b/domain/application/service/application.go
@@ -473,9 +473,6 @@ func makeCreateApplicationArgs(
 	origin corecharm.Origin,
 	args AddApplicationArgs,
 ) (application.AddApplicationArg, error) {
-	// TODO (stickupkid): These should be done either in the application
-	// state in one transaction, or be operating on the domain/charm types.
-
 	storageDirectives := make(map[string]storage.Directive)
 	for n, sc := range args.Storage {
 		storageDirectives[n] = sc
@@ -532,6 +529,11 @@ func makeCreateApplicationArgs(
 		return application.AddApplicationArg{}, fmt.Errorf("encoding application config: %w", err)
 	}
 
+	applicationStatus, err := encodeWorkloadStatus(args.ApplicationStatus)
+	if err != nil {
+		return application.AddApplicationArg{}, fmt.Errorf("encoding application status: %w", err)
+	}
+
 	return application.AddApplicationArg{
 		Charm:             ch,
 		CharmDownloadInfo: args.DownloadInfo,
@@ -542,6 +544,7 @@ func makeCreateApplicationArgs(
 		Storage:           makeStorageArgs(storageDirectives),
 		Config:            applicationConfig,
 		Settings:          args.ApplicationSettings,
+		Status:            applicationStatus,
 	}, nil
 }
 

--- a/domain/application/service/migration_test.go
+++ b/domain/application/service/migration_test.go
@@ -99,6 +99,7 @@ func (s *migrationServiceSuite) TestGetCharm(c *gc.C) {
 
 	id := charmtesting.GenCharmID(c)
 
+	s.state.EXPECT().GetCharmIDByApplicationName(gomock.Any(), "foo").Return(id, nil)
 	s.state.EXPECT().GetCharm(gomock.Any(), id).Return(domaincharm.Charm{
 		Metadata: domaincharm.Metadata{
 			Name: "foo",
@@ -112,7 +113,7 @@ func (s *migrationServiceSuite) TestGetCharm(c *gc.C) {
 		Available: true,
 	}, nil, nil)
 
-	metadata, locator, err := s.service.GetCharm(context.Background(), id)
+	metadata, locator, err := s.service.GetCharmByApplicationName(context.Background(), "foo")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(metadata.Meta(), gc.DeepEquals, &charm.Meta{
 		Name: "foo",
@@ -130,6 +131,7 @@ func (s *migrationServiceSuite) TestGetCharmInvalidMetadata(c *gc.C) {
 
 	id := charmtesting.GenCharmID(c)
 
+	s.state.EXPECT().GetCharmIDByApplicationName(gomock.Any(), "foo").Return(id, nil)
 	s.state.EXPECT().GetCharm(gomock.Any(), id).Return(domaincharm.Charm{
 		Metadata: domaincharm.Metadata{
 			Name:  "foo",
@@ -140,7 +142,7 @@ func (s *migrationServiceSuite) TestGetCharmInvalidMetadata(c *gc.C) {
 		Available: true,
 	}, nil, nil)
 
-	_, _, err := s.service.GetCharm(context.Background(), id)
+	_, _, err := s.service.GetCharmByApplicationName(context.Background(), "foo")
 	c.Assert(err, gc.ErrorMatches, `.*decode charm user.*`)
 }
 
@@ -149,6 +151,7 @@ func (s *migrationServiceSuite) TestGetCharmInvalidManifest(c *gc.C) {
 
 	id := charmtesting.GenCharmID(c)
 
+	s.state.EXPECT().GetCharmIDByApplicationName(gomock.Any(), "foo").Return(id, nil)
 	s.state.EXPECT().GetCharm(gomock.Any(), id).Return(domaincharm.Charm{
 		Metadata: domaincharm.Metadata{
 			Name:  "foo",
@@ -166,7 +169,7 @@ func (s *migrationServiceSuite) TestGetCharmInvalidManifest(c *gc.C) {
 		Available: true,
 	}, nil, nil)
 
-	_, _, err := s.service.GetCharm(context.Background(), id)
+	_, _, err := s.service.GetCharmByApplicationName(context.Background(), "foo")
 	c.Assert(err, gc.ErrorMatches, `.*decode bases: decode base.*`)
 }
 
@@ -175,6 +178,7 @@ func (s *migrationServiceSuite) TestGetCharmInvalidActions(c *gc.C) {
 
 	id := charmtesting.GenCharmID(c)
 
+	s.state.EXPECT().GetCharmIDByApplicationName(gomock.Any(), "foo").Return(id, nil)
 	s.state.EXPECT().GetCharm(gomock.Any(), id).Return(domaincharm.Charm{
 		Metadata: domaincharm.Metadata{
 			Name:  "foo",
@@ -192,7 +196,7 @@ func (s *migrationServiceSuite) TestGetCharmInvalidActions(c *gc.C) {
 		Available: true,
 	}, nil, nil)
 
-	_, _, err := s.service.GetCharm(context.Background(), id)
+	_, _, err := s.service.GetCharmByApplicationName(context.Background(), "foo")
 	c.Assert(err, gc.ErrorMatches, `.*decode action params: unmarshal.*`)
 }
 
@@ -201,6 +205,7 @@ func (s *migrationServiceSuite) TestGetCharmInvalidConfig(c *gc.C) {
 
 	id := charmtesting.GenCharmID(c)
 
+	s.state.EXPECT().GetCharmIDByApplicationName(gomock.Any(), "foo").Return(id, nil)
 	s.state.EXPECT().GetCharm(gomock.Any(), id).Return(domaincharm.Charm{
 		Metadata: domaincharm.Metadata{
 			Name:  "foo",
@@ -218,7 +223,7 @@ func (s *migrationServiceSuite) TestGetCharmInvalidConfig(c *gc.C) {
 		Available: true,
 	}, nil, nil)
 
-	_, _, err := s.service.GetCharm(context.Background(), id)
+	_, _, err := s.service.GetCharmByApplicationName(context.Background(), "foo")
 	c.Assert(err, gc.ErrorMatches, `.*decode config.*`)
 }
 
@@ -227,6 +232,7 @@ func (s *migrationServiceSuite) TestGetCharmInvalidLXDProfile(c *gc.C) {
 
 	id := charmtesting.GenCharmID(c)
 
+	s.state.EXPECT().GetCharmIDByApplicationName(gomock.Any(), "foo").Return(id, nil)
 	s.state.EXPECT().GetCharm(gomock.Any(), id).Return(domaincharm.Charm{
 		Metadata: domaincharm.Metadata{
 			Name:  "foo",
@@ -238,7 +244,7 @@ func (s *migrationServiceSuite) TestGetCharmInvalidLXDProfile(c *gc.C) {
 		Available:  true,
 	}, nil, nil)
 
-	_, _, err := s.service.GetCharm(context.Background(), id)
+	_, _, err := s.service.GetCharmByApplicationName(context.Background(), "foo")
 	c.Assert(err, gc.ErrorMatches, `.*unmarshal lxd profile.*`)
 }
 
@@ -247,17 +253,18 @@ func (s *migrationServiceSuite) TestGetCharmCharmNotFound(c *gc.C) {
 
 	id := charmtesting.GenCharmID(c)
 
+	s.state.EXPECT().GetCharmIDByApplicationName(gomock.Any(), "foo").Return(id, nil)
 	s.state.EXPECT().GetCharm(gomock.Any(), id).Return(domaincharm.Charm{}, nil, applicationerrors.CharmNotFound)
 
-	_, _, err := s.service.GetCharm(context.Background(), id)
+	_, _, err := s.service.GetCharmByApplicationName(context.Background(), "foo")
 	c.Assert(err, jc.ErrorIs, applicationerrors.CharmNotFound)
 }
 
 func (s *migrationServiceSuite) TestGetCharmInvalidUUID(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	_, _, err := s.service.GetCharm(context.Background(), "")
-	c.Assert(err, jc.ErrorIs, errors.NotValid)
+	_, _, err := s.service.GetCharmByApplicationName(context.Background(), "")
+	c.Assert(err, jc.ErrorIs, applicationerrors.ApplicationNameNotValid)
 }
 
 func (s *migrationServiceSuite) TestGetApplicationConfigAndSettings(c *gc.C) {

--- a/domain/application/service/params.go
+++ b/domain/application/service/params.go
@@ -60,6 +60,10 @@ type AddApplicationArgs struct {
 
 	// ApplicationSettings contains the application settings.
 	ApplicationSettings application.ApplicationSettings
+
+	// ApplicationStatus contains the application status. It's optional
+	// and if not provided, the application will be started with no status.
+	ApplicationStatus *status.StatusInfo
 }
 
 // AddressParams contains parameters for a unit/cloud container address.
@@ -195,6 +199,14 @@ type ImportApplicationArgs struct {
 
 	// ApplicationSettings contains the application settings.
 	ApplicationSettings application.ApplicationSettings
+
+	// ApplicationStatus contains the application status. It's optional
+	// and if not provided, the application will be started with no status.
+	ApplicationStatus *status.StatusInfo
+
+	// ResolvedResources contains a list of ResolvedResource instances,
+	// TODO (stickupkid): This isn't currently wired up.
+	ResolvedResources ResolvedResources
 
 	// Units contains the units to import.
 	Units []ImportUnitArg

--- a/domain/application/state/types.go
+++ b/domain/application/state/types.go
@@ -715,6 +715,14 @@ type applicationConfigHash struct {
 	SHA256          string `db:"sha256"`
 }
 
+type applicationStatus struct {
+	ApplicationUUID string     `db:"application_uuid"`
+	StatusID        int        `db:"status_id"`
+	Message         string     `db:"message"`
+	Data            []byte     `db:"data"`
+	UpdatedAt       *time.Time `db:"updated_at"`
+}
+
 // applicationConstraint represents a single returned row when joining the
 // constraint table with the constraint_space, constraint_tag and
 // constraint_zone.

--- a/domain/application/types.go
+++ b/domain/application/types.go
@@ -49,6 +49,8 @@ type AddApplicationArg struct {
 	Settings ApplicationSettings
 	// Scale contains the scale information for the application.
 	Scale int
+	// Status contains the status of the application.
+	Status *StatusInfo[WorkloadStatusType]
 }
 
 // AddApplicationResourceArg defines the arguments required to add a resource to an application.


### PR DESCRIPTION
Adds the ability to migrate the application status if it is set, if it isn't set, then we need to make sure it is set to unset.

This required state changes to the way we create an application, so that adding a status is done in one transaction.

----

This pull request includes several changes to the `domain/application/modelmigration` package to enhance the handling of application statuses during export and import operations. The most important changes include adding methods to fetch application status, updating the export and import operations to use these methods, and updating the corresponding tests.

### Enhancements to application status handling:

* `domain/application/modelmigration/export.go`:
  - Added `GetApplicationStatus` method to the `ExportService` interface to fetch the status of an application.
  - Updated `Execute` method in `exportOperation` to use `GetApplicationStatus` and set the application's status.

* `domain/application/modelmigration/import.go`:
  - Added `convertStatus` and `importApplicationStatus` helper functions to convert and import application statuses. [[1]](diffhunk://#diff-7961d740899680f58e70493a1801eb5c86cf80e665b8615b876d22e0dd14b7faR906-R924) [[2]](diffhunk://#diff-7961d740899680f58e70493a1801eb5c86cf80e665b8615b876d22e0dd14b7faR273-R285)
  - Updated `Execute` method in `importOperation` to use the new status conversion functions. [[1]](diffhunk://#diff-7961d740899680f58e70493a1801eb5c86cf80e665b8615b876d22e0dd14b7faL141-R123) [[2]](diffhunk://#diff-7961d740899680f58e70493a1801eb5c86cf80e665b8615b876d22e0dd14b7faR157-R165)

### Test updates:

* `domain/application/modelmigration/export_test.go`:
  - Added `expectApplicationStatus` method to mock the application status retrieval.
  - Updated various test cases to include clock and status expectations. [[1]](diffhunk://#diff-f393012ad436ff9aecaca64c8e7a3b412b13cd981802fc2bb3f881d51e666a24L62-R70) [[2]](diffhunk://#diff-f393012ad436ff9aecaca64c8e7a3b412b13cd981802fc2bb3f881d51e666a24R190) [[3]](diffhunk://#diff-f393012ad436ff9aecaca64c8e7a3b412b13cd981802fc2bb3f881d51e666a24R314)

* `domain/application/modelmigration/import_test.go`:
  - Added test cases to verify application status import. [[1]](diffhunk://#diff-047ae63801a9a92984d302ec77ed56c089f8617c49c899597fcabfea12fe53eaR147-R152) [[2]](diffhunk://#diff-047ae63801a9a92984d302ec77ed56c089f8617c49c899597fcabfea12fe53eaR226-R274) [[3]](diffhunk://#diff-047ae63801a9a92984d302ec77ed56c089f8617c49c899597fcabfea12fe53eaR352-R355)

### Import changes:

* `domain/application/modelmigration/import.go`:
  - Removed the `makeStatusParam` function and replaced its usage with the new `convertStatus` function. [[1]](diffhunk://#diff-7961d740899680f58e70493a1801eb5c86cf80e665b8615b876d22e0dd14b7faL94-L112) [[2]](diffhunk://#diff-7961d740899680f58e70493a1801eb5c86cf80e665b8615b876d22e0dd14b7faL141-R123)

These changes collectively improve the handling and testing of application statuses during model migration processes.

## QA steps


1. Bootstrap a 3.6 controller and deploy a charm.

```sh
$ juju bootstrap lxd src36
$ juju add-model moveme1
$ juju deploy juju-qa-test
```

 2. Bootstrap a 4.0 controller with the changes and migrate the model.

```sh
$ juju bootstrap lxd dst40
$ juju migrate src36:moveme1 dst40
$ juju add-unit juju-qa-test
```

 3. Verify no errors exist in the model logs for the agents.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme1
```

 4. We also need to test a model migration from 4.0 to 4.0.

```sh
$ juju bootstrap lxd src40
$ juju add-model moveme2
$ juju deploy juju-qa-test
```

```sh
$ juju migrate src40:moveme2 dst40
$ juju add-unit juju-qa-test
```

 5. Verify that there are no errors in the controller or model logs.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme2
```

## Links

**Jira card:** [JUJU-7424](https://warthogs.atlassian.net/browse/JUJU-7424)



[JUJU-7424]: https://warthogs.atlassian.net/browse/JUJU-7424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ