### PR TITLE
docs: fix typo and minor language improvement

### DIFF
--- a/docs/user/howto/manage-users.md
+++ b/docs/user/howto/manage-users.md
@@ -177,7 +177,7 @@ juju revoke-cloud joe add-model fluffy
 > See more: {ref}`command-juju-revoke-cloud`
 
 (manage-a-users-login-details)=
-## Manager a user's login details
+## Manage a user's login details
 
 **Set a password.** The procedure for how to set a password depends on whether you are the controller creator or rather some other user.
 
@@ -213,11 +213,11 @@ The command also allows an optional username argument, and flags, allowing an ad
 **Log in.** 
 
 ```{important}
-**If you're the controller creator:** <br> You've already been logged in as the `admin` user. To verify, run `juju whoami` or `juju show-user admin`; to set a password, run `juju change-user-password` to set a password; to log out, run `juju logout`.
+**If you're the controller creator:** <br> You've already been logged in as the `admin` user. To verify, run `juju whoami` or `juju show-user admin`; to set a password, run `juju change-user-password`; to log out, run `juju logout`.
 ```
 
 ```{important}
-**If you've just registered an external controller with your client (via `juju register`):** <br> You're already logged in. Run `juju whoami` or `juju show-user <username` to view your user details. 
+**If you've just registered an external controller with your client (via `juju register`):** <br> You're already logged in. Run `juju whoami` or `juju show-user <username>` to view your user details. 
 
 ```
 


### PR DESCRIPTION
Typos and a minor improvement

<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://github.com/juju/juju/blob/main/doc/conventional-commits.md
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- ~[ ] Code style: imports ordered, good names, simple structure, etc~
- ~[ ] Comments saying why design decisions were made~
- ~[ ] Go unit tests, with comments saying what you're testing~
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

None - this was edited only in the GH UI, no tests ran because I didn't pull it down locally.

## Documentation changes

This is only a documentation change

## Links

n/a

