### PR TITLE
chore: remove unused information from migrationmaster Export

### DIFF
--- a/api/controller/migrationmaster/client.go
+++ b/api/controller/migrationmaster/client.go
@@ -377,13 +377,13 @@ func groupTagIds(tagStrs []string) ([]string, []string, []string, error) {
 	return machines, units, applications, nil
 }
 
-func convertResources(in []params.SerializedModelResource) ([]migration.SerializedModelResource, error) {
+func convertResources(in []params.SerializedModelResource) ([]resource.Resource, error) {
 	if len(in) == 0 {
 		return nil, nil
 	}
-	out := make([]migration.SerializedModelResource, 0, len(in))
+	out := make([]resource.Resource, 0, len(in))
 	for _, resource := range in {
-		outResource, err := convertAppResource(resource)
+		outResource, err := convertResource(resource)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -392,32 +392,7 @@ func convertResources(in []params.SerializedModelResource) ([]migration.Serializ
 	return out, nil
 }
 
-func convertAppResource(in params.SerializedModelResource) (migration.SerializedModelResource, error) {
-	var empty migration.SerializedModelResource
-	appRev, err := convertResourceRevision(in.Application, in.Name, in.ApplicationRevision)
-	if err != nil {
-		return empty, errors.Annotate(err, "application revision")
-	}
-	csRev, err := convertResourceRevision(in.Application, in.Name, in.CharmStoreRevision)
-	if err != nil {
-		return empty, errors.Annotate(err, "charmstore revision")
-	}
-	unitRevs := make(map[string]resource.Resource)
-	for unitName, inUnitRev := range in.UnitRevisions {
-		unitRev, err := convertResourceRevision(in.Application, in.Name, inUnitRev)
-		if err != nil {
-			return empty, errors.Annotate(err, "unit revision")
-		}
-		unitRevs[unitName] = unitRev
-	}
-	return migration.SerializedModelResource{
-		ApplicationRevision: appRev,
-		CharmStoreRevision:  csRev,
-		UnitRevisions:       unitRevs,
-	}, nil
-}
-
-func convertResourceRevision(app, name string, rev params.SerializedModelResourceRevision) (resource.Resource, error) {
+func convertResource(rev params.SerializedModelResource) (resource.Resource, error) {
 	var empty resource.Resource
 	type_, err := charmresource.ParseType(rev.Type)
 	if err != nil {
@@ -436,17 +411,15 @@ func convertResourceRevision(app, name string, rev params.SerializedModelResourc
 	return resource.Resource{
 		Resource: charmresource.Resource{
 			Meta: charmresource.Meta{
-				Name:        name,
-				Type:        type_,
-				Path:        rev.Path,
-				Description: rev.Description,
+				Name: rev.Name,
+				Type: type_,
 			},
 			Origin:      origin,
 			Revision:    rev.Revision,
 			Size:        rev.Size,
 			Fingerprint: fp,
 		},
-		ApplicationName: app,
+		ApplicationName: rev.Application,
 		RetrievedBy:     rev.Username,
 		Timestamp:       rev.Timestamp,
 	}, nil

--- a/api/controller/migrationmaster/client_test.go
+++ b/api/controller/migrationmaster/client_test.go
@@ -311,10 +311,8 @@ func (s *ClientSuite) TestExport(c *gc.C) {
 
 	fpHash := charmresource.NewFingerprintHash()
 	appFp := fpHash.Fingerprint()
-	unitFp := fpHash.Fingerprint()
 
 	appTs := time.Now()
-	unitTs := appTs.Add(time.Hour)
 
 	apiCaller := apitesting.APICallerFunc(func(objType string, version int, id, request string, arg, result interface{}) error {
 		stub.AddCall(objType+"."+request, id, arg)
@@ -327,43 +325,15 @@ func (s *ClientSuite) TestExport(c *gc.C) {
 				URI:     "/tools/0",
 			}},
 			Resources: []params.SerializedModelResource{{
-				Application: "fooapp",
-				Name:        "bin",
-				ApplicationRevision: params.SerializedModelResourceRevision{
-					Revision:       2,
-					Type:           "file",
-					Path:           "bin.tar.gz",
-					Description:    "who knows",
-					Origin:         "upload",
-					FingerprintHex: appFp.Hex(),
-					Size:           123,
-					Timestamp:      appTs,
-					Username:       "bob",
-				},
-				CharmStoreRevision: params.SerializedModelResourceRevision{
-					// Imitate a placeholder for the test by having no Timestamp
-					// and an empty Fingerpritn
-					Revision:    3,
-					Type:        "file",
-					Path:        "fink.tar.gz",
-					Description: "knows who",
-					Origin:      "store",
-					Size:        321,
-					Username:    "xena",
-				},
-				UnitRevisions: map[string]params.SerializedModelResourceRevision{
-					"fooapp/0": {
-						Revision:       1,
-						Type:           "file",
-						Path:           "blink.tar.gz",
-						Description:    "bo knows",
-						Origin:         "store",
-						FingerprintHex: unitFp.Hex(),
-						Size:           222,
-						Timestamp:      unitTs,
-						Username:       "bambam",
-					},
-				},
+				Application:    "fooapp",
+				Name:           "bin",
+				Revision:       2,
+				Type:           "file",
+				Origin:         "upload",
+				FingerprintHex: appFp.Hex(),
+				Size:           123,
+				Timestamp:      appTs,
+				Username:       "bob",
 			}},
 		}
 		return nil
@@ -380,58 +350,20 @@ func (s *ClientSuite) TestExport(c *gc.C) {
 		Tools: map[version.Binary]string{
 			version.MustParseBinary("2.0.0-ubuntu-amd64"): "/tools/0",
 		},
-		Resources: []migration.SerializedModelResource{{
-			ApplicationRevision: resource.Resource{
-				Resource: charmresource.Resource{
-					Meta: charmresource.Meta{
-						Name:        "bin",
-						Type:        charmresource.TypeFile,
-						Path:        "bin.tar.gz",
-						Description: "who knows",
-					},
-					Origin:      charmresource.OriginUpload,
-					Revision:    2,
-					Fingerprint: appFp,
-					Size:        123,
+		Resources: []resource.Resource{{
+			Resource: charmresource.Resource{
+				Meta: charmresource.Meta{
+					Name: "bin",
+					Type: charmresource.TypeFile,
 				},
-				ApplicationName: "fooapp",
-				RetrievedBy:     "bob",
-				Timestamp:       appTs,
+				Origin:      charmresource.OriginUpload,
+				Revision:    2,
+				Fingerprint: appFp,
+				Size:        123,
 			},
-			CharmStoreRevision: resource.Resource{
-				Resource: charmresource.Resource{
-					Meta: charmresource.Meta{
-						Name:        "bin",
-						Type:        charmresource.TypeFile,
-						Path:        "fink.tar.gz",
-						Description: "knows who",
-					},
-					Origin:   charmresource.OriginStore,
-					Revision: 3,
-					Size:     321,
-				},
-				ApplicationName: "fooapp",
-				RetrievedBy:     "xena",
-			},
-			UnitRevisions: map[string]resource.Resource{
-				"fooapp/0": {
-					Resource: charmresource.Resource{
-						Meta: charmresource.Meta{
-							Name:        "bin",
-							Type:        charmresource.TypeFile,
-							Path:        "blink.tar.gz",
-							Description: "bo knows",
-						},
-						Origin:      charmresource.OriginStore,
-						Revision:    1,
-						Fingerprint: unitFp,
-						Size:        222,
-					},
-					ApplicationName: "fooapp",
-					RetrievedBy:     "bambam",
-					Timestamp:       unitTs,
-				},
-			},
+			ApplicationName: "fooapp",
+			RetrievedBy:     "bob",
+			Timestamp:       appTs,
 		}},
 	})
 }

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -72,7 +72,7 @@ var facadeVersions = facades.FacadeVersions{
 	"MachineUndertaker":            {1},
 	"Machiner":                     {5, 6},
 	"MigrationFlag":                {1},
-	"MigrationMaster":              {3},
+	"MigrationMaster":              {4},
 	"MigrationMinion":              {1},
 	"MigrationStatusWatcher":       {1},
 	"MigrationTarget":              {3},

--- a/apiserver/facades/controller/migrationmaster/facade.go
+++ b/apiserver/facades/controller/migrationmaster/facade.go
@@ -475,22 +475,7 @@ func getUsedResources(model description.Model) []params.SerializedModelResource 
 	var out []params.SerializedModelResource
 	for _, app := range model.Applications() {
 		for _, resource := range app.Resources() {
-			outRes := resourceToSerialized(app.Name(), resource)
-
-			// Hunt through the application's units and look for
-			// revisions of this resource. This is particularly
-			// efficient or clever but will be fine even with 1000's
-			// of units and 10's of resources.
-			outRes.UnitRevisions = make(map[string]params.SerializedModelResourceRevision)
-			for _, unit := range app.Units() {
-				for _, unitResource := range unit.Resources() {
-					if unitResource.Name() == resource.Name() {
-						outRes.UnitRevisions[unit.Name()] = revisionToSerialized(unitResource.Revision())
-					}
-				}
-			}
-
-			out = append(out, outRes)
+			out = append(out, resourceToSerialized(app.Name(), resource))
 		}
 
 	}
@@ -498,27 +483,20 @@ func getUsedResources(model description.Model) []params.SerializedModelResource 
 }
 
 func resourceToSerialized(app string, desc description.Resource) params.SerializedModelResource {
-	return params.SerializedModelResource{
-		Application:         app,
-		Name:                desc.Name(),
-		ApplicationRevision: revisionToSerialized(desc.ApplicationRevision()),
-		CharmStoreRevision:  revisionToSerialized(desc.CharmStoreRevision()),
+	res := params.SerializedModelResource{
+		Application: app,
+		Name:        desc.Name(),
 	}
-}
-
-func revisionToSerialized(rr description.ResourceRevision) params.SerializedModelResourceRevision {
+	rr := desc.ApplicationRevision()
 	if rr == nil {
-		return params.SerializedModelResourceRevision{}
+		return res
 	}
-	return params.SerializedModelResourceRevision{
-		Revision:       rr.Revision(),
-		Type:           rr.Type(),
-		Path:           rr.Path(),
-		Description:    rr.Description(),
-		Origin:         rr.Origin(),
-		FingerprintHex: rr.FingerprintHex(),
-		Size:           rr.Size(),
-		Timestamp:      rr.Timestamp(),
-		Username:       rr.Username(),
-	}
+	res.Revision = rr.Revision()
+	res.Type = rr.Type()
+	res.Origin = rr.Origin()
+	res.FingerprintHex = rr.FingerprintHex()
+	res.Size = rr.Size()
+	res.Timestamp = rr.Timestamp()
+	res.Username = rr.Username()
+	return res
 }

--- a/apiserver/facades/controller/migrationmaster/facade_test.go
+++ b/apiserver/facades/controller/migrationmaster/facade_test.go
@@ -374,17 +374,6 @@ func (s *Suite) assertExport(c *gc.C, modelType string) {
 		Timestamp:      time.Now(),
 		Username:       "bob",
 	})
-	csRev := res.SetCharmStoreRevision(description.ResourceRevisionArgs{
-		Revision:       3,
-		Type:           "file",
-		Path:           "fink.tar.gz",
-		Description:    "knows who",
-		Origin:         "store",
-		FingerprintHex: "deaf",
-		Size:           321,
-		Timestamp:      time.Now(),
-		Username:       "xena",
-	})
 
 	unit := app.AddUnit(description.UnitArgs{
 		Tag: names.NewUnitTag("foo/0"),
@@ -392,21 +381,6 @@ func (s *Suite) assertExport(c *gc.C, modelType string) {
 	unit.SetTools(description.AgentToolsArgs{
 		Version: version.MustParseBinary(tools0),
 	})
-	unitRes := unit.AddResource(description.UnitResourceArgs{
-		Name: "bin",
-		RevisionArgs: description.ResourceRevisionArgs{
-			Revision:       1,
-			Type:           "file",
-			Path:           "bin.tar.gz",
-			Description:    "nose knows",
-			Origin:         "upload",
-			FingerprintHex: "beef",
-			Size:           222,
-			Timestamp:      time.Now(),
-			Username:       "bambam",
-		},
-	})
-	unitRev := unitRes.Revision()
 
 	s.modelExporter.EXPECT().ExportModel(gomock.Any(), map[string]string{}, s.store).Return(s.model, nil)
 
@@ -428,43 +402,15 @@ func (s *Suite) assertExport(c *gc.C, modelType string) {
 		})
 	}
 	c.Check(serialized.Resources, gc.DeepEquals, []params.SerializedModelResource{{
-		Application: "foo",
-		Name:        "bin",
-		ApplicationRevision: params.SerializedModelResourceRevision{
-			Revision:       appRev.Revision(),
-			Type:           appRev.Type(),
-			Path:           appRev.Path(),
-			Description:    appRev.Description(),
-			Origin:         appRev.Origin(),
-			FingerprintHex: appRev.FingerprintHex(),
-			Size:           appRev.Size(),
-			Timestamp:      appRev.Timestamp(),
-			Username:       appRev.Username(),
-		},
-		CharmStoreRevision: params.SerializedModelResourceRevision{
-			Revision:       csRev.Revision(),
-			Type:           csRev.Type(),
-			Path:           csRev.Path(),
-			Description:    csRev.Description(),
-			Origin:         csRev.Origin(),
-			FingerprintHex: csRev.FingerprintHex(),
-			Size:           csRev.Size(),
-			Timestamp:      csRev.Timestamp(),
-			Username:       csRev.Username(),
-		},
-		UnitRevisions: map[string]params.SerializedModelResourceRevision{
-			"foo/0": {
-				Revision:       unitRev.Revision(),
-				Type:           unitRev.Type(),
-				Path:           unitRev.Path(),
-				Description:    unitRev.Description(),
-				Origin:         unitRev.Origin(),
-				FingerprintHex: unitRev.FingerprintHex(),
-				Size:           unitRev.Size(),
-				Timestamp:      unitRev.Timestamp(),
-				Username:       unitRev.Username(),
-			},
-		},
+		Application:    "foo",
+		Name:           "bin",
+		Revision:       appRev.Revision(),
+		Type:           appRev.Type(),
+		Origin:         appRev.Origin(),
+		FingerprintHex: appRev.FingerprintHex(),
+		Size:           appRev.Size(),
+		Timestamp:      appRev.Timestamp(),
+		Username:       appRev.Username(),
 	}})
 }
 

--- a/apiserver/facades/controller/migrationmaster/register.go
+++ b/apiserver/facades/controller/migrationmaster/register.go
@@ -17,7 +17,7 @@ import (
 
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
-	registry.MustRegister("MigrationMaster", 3, func(stdCtx context.Context, ctx facade.ModelContext) (facade.Facade, error) {
+	registry.MustRegister("MigrationMaster", 4, func(stdCtx context.Context, ctx facade.ModelContext) (facade.Facade, error) {
 		return newMigrationMasterFacade(ctx) // Adds MinionReportTimeout.
 	}, reflect.TypeOf((*API)(nil)))
 }

--- a/core/migration/migration.go
+++ b/core/migration/migration.go
@@ -51,15 +51,7 @@ type SerializedModel struct {
 	Tools map[version.Binary]string // version -> tools URI
 
 	// Resources represents all the resources in use in the model.
-	Resources []SerializedModelResource
-}
-
-// SerializedModelResource defines the resource revisions for a
-// specific application and its units.
-type SerializedModelResource struct {
-	ApplicationRevision resource.Resource
-	CharmStoreRevision  resource.Resource
-	UnitRevisions       map[string]resource.Resource
+	Resources []resource.Resource
 }
 
 // ModelInfo is used to report basic details about a model.

--- a/core/resource/resource.go
+++ b/core/resource/resource.go
@@ -78,7 +78,6 @@ func (res Resource) Validate() error {
 	}
 
 	// TODO(ericsnow) Require that RetrievedBy be set if timestamp is?
-
 	if res.Timestamp.IsZero() && res.RetrievedBy != "" {
 		return errors.NewNotValid(nil, "missing timestamp")
 	}

--- a/internal/migration/migration.go
+++ b/internal/migration/migration.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/juju/juju/controller"
 	corelogger "github.com/juju/juju/core/logger"
-	"github.com/juju/juju/core/migration"
 	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/modelmigration"
 	"github.com/juju/juju/core/objectstore"
@@ -276,7 +275,7 @@ type UploadBinariesConfig struct {
 	ToolsDownloader ToolsDownloader
 	ToolsUploader   ToolsUploader
 
-	Resources          []migration.SerializedModelResource
+	Resources          []resource.Resource
 	ResourceDownloader ResourceDownloader
 	ResourceUploader   ResourceUploader
 }
@@ -412,11 +411,8 @@ func uploadTools(ctx context.Context, config UploadBinariesConfig, logger corelo
 
 func uploadResources(ctx context.Context, config UploadBinariesConfig, logger corelogger.Logger) error {
 	for _, res := range config.Resources {
-		if res.ApplicationRevision.IsPlaceholder() {
-			// Resource placeholders created in the migration import rather
-			// than attempting to post empty resources.
-		} else {
-			err := uploadAppResource(ctx, config, res.ApplicationRevision, logger)
+		if !res.IsPlaceholder() {
+			err := uploadAppResource(ctx, config, res, logger)
 			if err != nil {
 				return errors.Trace(err)
 			}

--- a/internal/migration/migration_test.go
+++ b/internal/migration/migration_test.go
@@ -22,7 +22,6 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/controller"
-	coremigration "github.com/juju/juju/core/migration"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/modelmigration"
 	"github.com/juju/juju/core/resource"
@@ -239,13 +238,7 @@ func (s *ImportSuite) TestBinariesMigration(c *gc.C) {
 	app0Res := resourcetesting.NewResource(c, nil, "blob0", "app0", "blob0").Resource
 	app1Res := resourcetesting.NewResource(c, nil, "blob1", "app1", "blob1").Resource
 	app2Res := resourcetesting.NewPlaceholderResource(c, "blob2", "app2")
-	resources := []coremigration.SerializedModelResource{
-		{ApplicationRevision: app0Res},
-		{
-			ApplicationRevision: app1Res,
-		},
-		{ApplicationRevision: app2Res},
-	}
+	resources := []resource.Resource{app0Res, app1Res, app2Res}
 
 	s.charmService.EXPECT().GetCharmArchive(gomock.Any(), domaincharm.CharmLocator{
 		Name:     "postgresql",

--- a/internal/worker/migrationmaster/worker_test.go
+++ b/internal/worker/migrationmaster/worker_test.go
@@ -31,6 +31,7 @@ import (
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/core/logger"
 	coremigration "github.com/juju/juju/core/migration"
+	coreresource "github.com/juju/juju/core/resource"
 	resourcetesting "github.com/juju/juju/core/resource/testing"
 	jujuversion "github.com/juju/juju/core/version"
 	"github.com/juju/juju/core/watcher"
@@ -223,9 +224,9 @@ func (s *Suite) makeStatus(phase coremigration.Phase) coremigration.MigrationSta
 }
 
 func (s *Suite) TestSuccessfulMigration(c *gc.C) {
-	s.facade.exportedResources = []coremigration.SerializedModelResource{{
-		ApplicationRevision: resourcetesting.NewResource(c, nil, "blob", "app", "").Resource,
-	}}
+	s.facade.exportedResources = []coreresource.Resource{
+		resourcetesting.NewResource(c, nil, "blob", "app", "").Resource,
+	}
 
 	s.facade.queueStatus(s.makeStatus(coremigration.QUIESCE))
 	s.facade.queueMinionReports(makeMinionReports(coremigration.QUIESCE))
@@ -311,9 +312,9 @@ func (s *Suite) TestSuccessfulMigration(c *gc.C) {
 
 func (s *Suite) TestIncompatibleTarget(c *gc.C) {
 	s.connection.facadeVersion = 1
-	s.facade.exportedResources = []coremigration.SerializedModelResource{{
-		ApplicationRevision: resourcetesting.NewResource(c, nil, "blob", "app", "").Resource,
-	}}
+	s.facade.exportedResources = []coreresource.Resource{
+		resourcetesting.NewResource(c, nil, "blob", "app", "").Resource,
+	}
 
 	s.facade.queueStatus(s.makeStatus(coremigration.QUIESCE))
 	s.facade.queueMinionReports(makeMinionReports(coremigration.QUIESCE))
@@ -1250,7 +1251,7 @@ type stubMasterFacade struct {
 	minionReportsErr      error
 	minionReportTimeout   time.Duration
 
-	exportedResources []coremigration.SerializedModelResource
+	exportedResources []coreresource.Resource
 
 	statuses []string
 }

--- a/rpc/params/migration.go
+++ b/rpc/params/migration.go
@@ -105,20 +105,10 @@ type SerializedModelTools struct {
 // SerializedModelResource holds the details for a single resource for
 // an application in a serialized model.
 type SerializedModelResource struct {
-	Application         string                                     `json:"application"`
-	Name                string                                     `json:"name"`
-	ApplicationRevision SerializedModelResourceRevision            `json:"application-revision"`
-	CharmStoreRevision  SerializedModelResourceRevision            `json:"charmstore-revision"`
-	UnitRevisions       map[string]SerializedModelResourceRevision `json:"unit-revisions"`
-}
-
-// SerializedModelResourceRevision holds the details for a single
-// resource revision for an application in a serialized model.
-type SerializedModelResourceRevision struct {
+	Application    string    `json:"application"`
+	Name           string    `json:"name"`
 	Revision       int       `json:"revision"`
 	Type           string    `json:"type"`
-	Path           string    `json:"path"`
-	Description    string    `json:"description"`
 	Origin         string    `json:"origin"`
 	FingerprintHex string    `json:"fingerprint"`
 	Size           int64     `json:"size"`


### PR DESCRIPTION
Remove the unit and charm resource information from the migration master APIs Export method and rev the facade.

The information about the unit and charm resources is no longer needed in the migrationmaster worker due to a previous change. The information was still transmitted in the facade.

Not transmitting this information will allow for easier changes to the description package as it is fetched from the exported model description.

The facade is only used by the controller to communicate with the migrationmaster worker. Therefore, revving the facade should not cause any issues with migration to and from other clients.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

We can test that a migration from 4.0 from 4.0 succeeds, but at the moment, the resources are not migrated, so this will fail.
```
juju bootstrap lxd source
juju bootstrap lxd target
juju switch source
juju add-model test-mig
echo "spam" > test.txt
juju deploy juju-qa-test --resource=./test.txt
juju config juju-qa-test foo-file=true
juju migrate source:test-mig target
juju switch test-mig:target
juju status
Model     Controller  Cloud/Region  Version      Timestamp
test-mig  target      lxd/default   4.0-beta5.1  16:48:16Z

App           Version  Status  Scale  Charm         Channel        Rev  Exposed  Message
juju-qa-test           active      1  juju-qa-test  latest/stable   25  no       resource line one: spam

Unit            Workload  Agent  Machine  Public address  Ports  Message
juju-qa-test/0  active    idle   0        10.101.18.117          resource line one: spam

Machine  State    Address        Inst id        Base          AZ  Message
0        started  10.101.18.117  juju-479b68-0  ubuntu@20.04      

juju switch source:controller
juju debug-log -m controller --replay
# Check no error occurred during migration
```

## Links


**Jira card:** [JUJU-7582](https://warthogs.atlassian.net/browse/JUJU-7582)
