### PR TITLE
Merge 3.6 into main

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,147 +1,166 @@
-Thanks for your interest in Juju! Contributions like yours make good projects
-great.
+Thanks for your interest in Juju -- contributions like yours make good projects
+great!
 
-# TL;DR
-- Bug reports should be filed on GitHub [juju/juju](https://github.com/juju/juju/issues).
-  Please check that your bug has not already been reported.
-- When opening a pull request:
-  - Check that all your [commits are signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
-  - Use [Conventional Commits](#conventional-commits) for commit messages.
-  - Check that your patch is [targeting the correct branch](#branches) -
-    if not, please rebase it.
-  - Please [sign the CLA](#contributor-licence-agreement) if you haven't already.
-  - Use the checklist on the [pull request template](PULL_REQUEST_TEMPLATE.md#checklist)
-    to check you haven't forgotten anything.
+Whether it is code or docs, there are two basic ways to contribute: by opening
+an issue or by creating a PR. This document gives detailed information about
+both.
 
-Contents
-========
+> Note: If at any point you get stuck, come chat with us on
+[Matrix](https://matrix.to/#/#charmhub-juju:ubuntu.com).
 
-- [Quick links](#quick-links)
-- [Building Juju](#building-juju)
-- [Getting started](#getting-started)
-- [Dependency management](#dependency-management)
-- [Code formatting](#code-formatting)
-- [Workflow](#workflow)
-   - [Conventional commits](#conventional-commits)
-   - [Contributor licence agreement](#contributor-licence-agreement)
-- [Community](#community)
+## Open an issue
 
-Quick links
-===========
+You will need a GitHub account ([sign up](https://github.com/signup)).
 
-Issue tracker: https://github.com/juju/juju/issues
+### Open an issue for docs
 
-Documentation:
-* https://canonical-juju.readthedocs-hosted.com/en/latest/
-* [source tree docs](docs/dev)
+To open an issue for a specific doc, find the doc on
+[RTD](https://canonical-juju.readthedocs-hosted.com), then scroll to the bottom
+of the page, click on **Open a GitHub issue for this page**, edit the issue
+template that pops up, then submit.
 
-Community:
-* https://chat.charmhub.io
-* https://discourse.charmhub.io/
+To open an issue for docs in general, do the same for the homepage of the docs
+(i.e., use the link from the bottom of the [RTD
+homepage](https://canonical-juju.readthedocs-hosted.com) or go to
+https://github.com/juju/juju/issues , click on **New issue** (top right corner
+of the page), select “Documentation issue”, then fill out the issue template and
+submit the issue.
 
-Building Juju
-=============
+### Open an issue for code
 
-## Installing Go
+Go to https://github.com/juju/juju/issues  click on **New issue** (top right
+corner of the page), select whatever is appropriate, then fill out the issue
+template and submit the issue.
 
-`juju` is written in [Go](https://go.dev/), a modern, compiled, statically typed,
-concurrent language.
+> Note: For feature requests please use
+https://matrix.to/#/#charmhub-juju:ubuntu.com
 
-Generally, Juju is built against a recent version of Go, with the caveat
-that Go versions are not incremented during a release cycle. Check the `go.mod`
-file at the root of the project for the targeted version of Go, as this is
-authoritative.
+## Make your first contribution
 
-For example, the following indicates that Go 1.23 is targeted:
+You will need a GitHub account ([sign up](https://github.com/signup) and [add
+your public SSH key](https://github.com/settings/ssh)) and `git` ([get
+started](https://git-scm.com/book/en/v2/Getting-Started-What-is-Git%3F)).
+
+Then:
+
+1. [Sign the Canonical Contributor Licence Agreement
+   (CLA)](https://ubuntu.com/legal/contributors).
+
+2. Configure your `git` so your commits are signed:
 
 ```
-module github.com/juju/juju
-
-go 1.23
-```
-
-### Official distribution
-
-Go can be [installed](https://golang.org/doc/install#install) from the official
-distribution.
-
-## Build Juju and its dependencies
-
-The easiest way to get the Juju source code is to clone the GitHub repository:
-
-    git clone https://github.com/juju/juju.git
-
-To build/install from source, `cd` into the root directory of the cloned repo,
-and use `make`.
-- `make build` will build the Juju binaries and put them in a
-  `_build` subdirectory.
-- `make install` will build the Juju binaries and install them in your
-  [$GOBIN directory](https://pkg.go.dev/cmd/go#hdr-Compile_and_install_packages_and_dependencies)
-  (which defaults to `$GOPATH/bin` or `~/go/bin`).
-
-Getting started
-===============
-
-Git
----
-
-Juju uses `git` for version control. To get started, install it and configure
-your username:
-
-```bash
 git config --global user.name "A. Hacker"
 git config --global user.email "a.hacker@example.com"
+git config --global commit.gpgsign true
 ```
 
-For information on setting up and using `git`, check out the following:
+> See more: [GitHub | Authentication > Signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
 
-* https://www.atlassian.com/git/tutorials/
-* http://git-scm.com/book/en/Getting-Started-Git-Basics
-* [GitHub bootcamp](https://help.github.com/categories/54/articles)
+3. Fork juju/juju. This will create `https://github.com/<user>/juju`.
 
-GitHub
-------
+4. Clone your fork locally.
 
-The upstream Juju repository is hosted on [GitHub](http://github.com). Patches
-to Juju are contributed through pull requests (more on that in the
-[Pushing](#pushing) section). So you should have a github account and a fork
-there. The following steps will help you get that ready:
+```
+git clone git@github.com:<user>/juju.git
+```
 
-1. Sign up for GitHub (a free account is fine): https://github.com/join
-2. Add your ssh public key to your account: https://github.com/settings/ssh
-3. Hit the "Fork" button on the web page for the Juju repo:
-    https://github.com/juju/juju
+5. Add a new remote with the name `upstream` and set it to point to the upstream
+   `juju` repo.
 
-At this point you will have your own copy under your github account. Note
-that your fork is not automatically kept in sync with the official Juju repo
-(see [Staying in sync](#staying-in-sync)).
+```
+git remote add upstream git@github.com:juju/juju.git
+```
 
-Note that Juju has dependencies hosted elsewhere with other version control
-tools.
+6. Set your local branches to track the `upstream` remote (not your fork). E.g.,
 
-Staying in sync
----------------
+```
+git checkout 3.6
+git branch --set-upstream-to=upstream/3.6
+git checkout main
+git branch --set-upstream-to=upstream/main
+```
 
-Make sure your local copy and GitHub fork stay in sync with upstream:
+7. Sync your local branches with the upstream, then check out the branch you
+   want to contribute to and create a feature branch based on it. **If your
+   contribution is not specific to a particular branch, please target the lowest that
+   applies.** (All patches in earlier versions are eventually merged through to later
+   versions.) E.g., for a change that should go into both Juju 3.6 and Juju 4
+   (`main`):
 
-```bash
+```
+git fetch upstream
+git checkout 3.6
+git pull
+git checkout -b 3.6-new-stuff # your feature branch
+```
+
+8. Make the desired changes. Test changes locally.
+
+
+----------------
+<details>
+
+<summary>Further info: Docs</summary>
+
+The documentation is in `juju/docs`, which is further split into `user/` and
+`contributor/`. Some user reference docs (for the `juju` CLI commands, the
+controller and model configs, and the hook commands) are autogenerated from
+source, and must be updated in source.
+
+> Tip: If you start from an existing doc on
+https://canonical-juju.readthedocs-hosted.com/en/latest/, you can find its
+source file by scrolling to the bottom of the page and clicking on **Edit this
+page on GitHub** -- though we still recommend you do not make changes there
+directly there but rather in a local clone, as that will make it easier for you
+to iterate during the PR review process.
+
+### Standards
+
+All changes should follow the existing patterns, including
+[Diátaxis](https://diataxis.fr), the [Canonical Documentation Style
+Guide](https://docs.ubuntu.com/styleguide/en), the modular structure, the
+cross-referencing pattern, [MyST
+Markdown](https://canonical-documentation-with-sphinx-and-readthedocscom.readthedocs-hosted.com/style-guide-myst/),
+etc.
+
+### Testing
+
+Changes should be inspected by building the docs and fixing any issues
+discovered that way. To preview the docs as they will be rendered on RTD, in
+`juju/docs` run `make run` and open the provided link in a browser. If you get
+errors, try `make clean`, then `make run` again. For other checks, see `make
+[Tab]` and select the command for the desired check.
+
+</details>
+
+----------------
+
+----------------
+<details>
+
+<summary>Further info: Code</summary>
+
+### Installing Go
+
+`juju` is written in [Go](https://go.dev/). To install Go see [Go
+docs](https://golang.org/doc/install#install).
+
+### Building Juju and its dependencies
+
+Fork and clone the Juju repo, then navigate to the root directory and run `make
+install`:
+
+```
+git clone https://github.com/<user>/juju.git
 cd juju
-git pull upstream
+make install
 ```
 
-Dependency management
-=====================
+### Updating Go dependencies
 
-go mod
-------
-
-Juju uses Go modules to manage dependencies.
-
-Updating dependencies
----------------------
-
-To update a dependency, use the following, ensuring that the dependency is
-using a version where possible, or a commit hash if not available:
+Juju uses Go modules to manage dependencies. To update a dependency, use the
+following, ensuring that the dependency is using a version where possible, or a
+commit hash if not available:
 
 
 ```
@@ -149,14 +168,14 @@ go get -u github.com/the/dependency@v1.2.3
 go mod tidy
 ```
 
-Code formatting
-===============
+### Code formatting
 
-Go provides a tool, `go fmt`, which facilitates a standardized format to go
-source code.  The Juju project has one additional policy:
+To format your code, run `go fmt`.
 
-Imports
--------
+> Note: Your editor may do this automatically.
+
+
+### Imports
 
 Import statements are grouped into 3 sections: standard library, 3rd party
 libraries, juju imports. The tool "go fmt" can be used to ensure each
@@ -168,60 +187,15 @@ group is alphabetically sorted. eg:
         "time"
 
         "labix.org/v2/mgo"
-        "github.com/juju/loggo/v2"
+        "github.com/juju/loggo"
         gc "gopkg.in/check.v1"
 
         "github.com/juju/juju/state"
-        "github.com/juju/worker/v4"
+        "github.com/juju/worker/v3"
     )
 ```
 
-Workflow
-========
-
-As a project, Juju follows a specific workflow:
-
-1. sync with upstream
-2. create a local feature branch
-3. make desired changes
-4. test the changes
-5. push the feature branch to your github fork
-6. reviews
-7. auto-merge
-8. continuous-integration
-
-Naturally, it is not so linear in practice. Each of these is elaborated below.
-
-Branches
---------
-
-Generally there are multiple versions of Juju in development concurrently,
-and so we keep a separate Git branch for each version. When submitting a
-patch, please make sure your changes are targeted to the correct branch.
-
-We keep a branch for each minor version of Juju in active development (e.g.
-`3.4`, `3.5`) - bug fixes should go into the relevant branch. We also keep a
-`main` branch, which will become the next minor version of Juju. All new
-features should go into `main`.
-
-If a bug affects multiple Juju versions, please target the **lowest version**
-of Juju which is affected. All patches in earlier versions are eventually
-"merged through" to later versions.
-
-Creating a new branch
----------------------
-
-All development should be done on a new branch, based on the correct branch
-determined above. Pull the latest version of this branch, then create and
-checkout a new branch for your changes - e.g. for a patch targeting `main`:
-
-```
-git pull upstream main
-git checkout -b new_feature main
-```
-
-Testing
--------
+### Testing
 
 Some tests may require local lxd to be installed, see
 [installing lxd via snap](https://stgraber.org/2016/10/17/lxd-snap-available/).
@@ -230,237 +204,81 @@ Juju uses the `gocheck` testing framework, which is automatically installed
 as a dependency of `juju`. You can read more about `gocheck` at
 http://godoc.org/gopkg.in/check.v1. `gocheck` is integrated into the source of
 each package so the standard `go test` command is used to run `gocheck` tests.
-For example
+For example:
 
-```bash
-go test github.com/juju/juju/...
+```
+go test -v github.com/juju/juju/core/config -check.v
 ```
 
-will run all the tests in the Juju project. By default `gocheck` prints only
-minimal output, and as `gocheck` is hooked into the testing framework via a
-single `go test` test per package, the usual `go test -v` flags are less
-useful. As a replacement the following commands produce more output from
-`gocheck`.
-
-```bash
-go test -gocheck.v
-```
-
-is similar to `go test -v` and outputs the name of each test as it is run as
-well as any logging statements. It is important to note that these statements
-are buffered until the test completes.
-
-```bash
-go test -gocheck.vv
-```
-
-extends the previous example by outputting any logging data immediately, rather
-than waiting for the test to complete. By default `gocheck` will run all tests
+By default `gocheck` will run all tests
 in a package, selected tests can by run by passing `-gocheck.f` to match a
 subset of test names.
 
-```bash
+```
 go test -gocheck.f '$REGEX'
 ```
 
-Finally, because by default `go test` runs the tests in the current package,
-and is not recursive, the following commands are equal, and will produce no
-output.
 
-```bash
-cd juju
-go test
-go test github.com/juju/juju
-```
-
-Testing and MongoDB
--------------------
+### Testing and MongoDB
 
 Many tests use a standalone instance of `mongod` as part of their setup. The
 `mongod` binary found in `$PATH` is executed by these suites.  If you don't
-already have MongoDB installed, or have difficulty using your installed version
-to run Juju tests, you may want to install the [`juju-db` snap](https://snapcraft.io/juju-db), which is guaranteed to work with Juju.
+already have MongoDB installed, run
 
-```bash
-sudo snap install juju-db --channel 4.4/stable
+```
+make install-mongo-dependencies
+```
+</details>
+
+----------------
+
+
+
+9. As you make your changes, ensure that you always remain in sync with the upstream:
+
+```
+git pull upstream 3.6 --rebase
 ```
 
-Optionally, you can create aliases for `mongod` and `mongo` to make it easier to
-use the snap version:
+10. Stage, commit and push regularly to your fork. Make sure your commit messages
+    comply with conventional commits ([see upstream
+    standard](https://www.conventionalcommits.org/en/v1.0.0/), [see adaptation in
+    Juju](./docs/contributor/reference/conventional-commits.md)). E.g.,
 
-```bash
-sudo snap alias juju-db.mongod mongod
-sudo snap alias juju-db.mongo mongo
+```
+git add .
+git commit -m "docs: add setup and teardown anchors"
+git push origin 3.6-new-stuff
 ```
 
-Some tests (particularly those under `./store/...`) assume a MongoDB instance
-that supports Javascript for map-reduce functions. These functions are not
-supported by `juju-mongodb` and the associated tests will fail unless disabled
-with an environment variable:
+> Note: For most code PRs, it's best to type just `git commit`, then return; the
+terminal will open a text editor, enabling you to write a lengthier, more
+explicit message.
 
-```bash
-JUJU_NOTEST_MONGOJS=1 go test github.com/juju/juju/...
-```
+> Tip: If you've set things up correctly, typing just `git push` and returning
+may be enough for `git` to prompt you with the correct arguments.
 
-Conventional commits
---------------------
+> Tip: If you don't want to create a new commit message every time, do
+`git commit --amend --no-edit`, then `git push --force`.
 
-Once you have written some code and have tested the changes, the next step is to
-`git commit` it. For commit messages Juju follows
-[conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) -- see our
-[conventional commits guidelines](doc/conventional-commits.md) for our commit types.
-In short the commits should be of the following form:
-```
-<type>(optional <scope>): <description>
+11. Create the PR. In the PR window make sure to select the correct target base
+    branch. In your PR description make sure to comply with the template rules (e.g.,
+    explain _why_ you're making the change). If your change should target multiple
+    branches, add a note at the top of your PR to say so (e.g., "This PR should be
+    merged into both `3.6` and `main`").
 
-[optional body]
+12. Ensure GitHub tests pass.
 
-[optional footer(s)]
-```
-- **Type:** The type describes the kind of change (e.g., feat, fix, docs, style,
-  refactor, test, chore).
-- **Scope:** The scope indicates the part of the codebase affected (e.g., model,
-  api, cli).
-- **Description:** The description briefly describes the change. It should not
-  end in any punctuation.
-- **Body:** The body should be a detailed explanation of the change. It should
-  specify what has been changed and why and include descriptions of the
-  behaviour before and after.
-- **Footer:**  The footer includes information about breaking changes, issues
-  closed, etc.
+13. In [the Matrix Juju Development
+    channel](https://matrix.to/#/#charmhub-jujudev:ubuntu.com), drop a link to your
+    PR with the mention that it needs reviews. Someone will review your PR. Make all
+    the requested changes.
 
-The type, scope and description should all begin with a lower case letter. None
-of the lines can exceed 100 characters in length.
+14. When you've received two approvals, your PR can be merged. If you are part
+    of the `juju` organization, at this point in the Conversation view of your PR
+    you can type `/merge` to merge. If not, ping one of your reviewers and ask them
+    to help merge.
 
-There is a CI action on the Juju GitHub repository that will flag any syntactic
-issues with your commit messages. The action is required to pass before code can
-be merged so make sure to take a look once your PR is up.
+> Tip: After your first contribution, you will only have to repeat steps 7-14.
 
-Pushing
--------
-
-When ready for feedback, push your feature branch to github, optionally after
-collapsing multiple commits into discrete changes:
-
-```bash
-git rebase -i --autosquash main
-git push origin new_feature
-```
-
-Go to the web page (https://github.com/$YOUR_GITHUB_USERNAME/juju) and hit the
-"Pull Request" button, selecting `main` as the target.
-
-This creates a numbered pull request on the github site, where members of the
-Juju project can see and comment on the changes.
-
-The title of the PR should match the form of the title of a conventional commit.
-This can be the title of the most significant commit in the PR.
-
-Make sure to add a clear description of why and what has been changed, and
-include the GitHub issue number or Launchpad bug number if one exists.
-
-It is often helpful to mention newly created proposals on the Discourse forum,
-especially if you would like a specific developer to be aware of the proposal.
-
-Note that updates to your GitHub project will automatically be reflected in
-your pull request.
-
-Be sure to have a look at:
-
-https://help.github.com/articles/using-pull-requests
-
-
-Contributor licence agreement
-----------------------
-
-We welcome external contributions to Juju, but in order to incorporate these
-into the codebase, we will need you to sign the
-[Canonical contributor licence agreement (CLA)](https://ubuntu.com/legal/contributors).
-This just gives us permission to use your contributions - you still retain full
-copyright of your code.
-
-We have a GitHub Action which checks if you have signed the CLA. To ensure this
-passes, please follow these steps:
-
-1. Ensure your Git commits are signed by an email that you can access
-   (you can't use the `@users.noreply.github.com` email that GitHub provides).
-2. Visit the [CLA website](https://ubuntu.com/legal/contributors), scroll down
-   and press "Sign the contributor agreement".
-3. Read the agreement and fill in your contact details.
-4. Press "I agree" to sign the CLA.
-
-
-Sanity checking PRs and unit tests
-----------------------
-
-All PRs run pre-merge check - unit tests and a small but representative sample
-of functional tests. This check is re-run anytime the PR changes, for example
-when a new commit is added.
-
-You can also initiate this check by commenting `/build` in the PR.
-
-Code review
------------
-
-The Juju project uses peer review of pull requests prior to merging to
-facilitate improvements both in code quality and in design.
-
-Once you have created your pull request, it will be reviewed. Make sure to
-address the feedback. Your request might go through several rounds of feedback
-before the patch is approved or rejected. Once you get an approval from a
-member of the Juju project, you are ready to have your patch merged.
-Congratulations!
-
-Continuous integration
-----------------------
-
-Continuous integration is automated through Jenkins:
-
-The bot runs on all commits during the PRE process, as well as handles merges.
-Use the `/merge` comment to land a PR.
-
-Static Analysis
----------------
-
-Static Analysis can be performed by running `make static-analysis`
-
-Required dependencies for full static analysis are:
- - *nix tools (sh, grep etc.)
- - shellcheck
- - python3
- - go
- - golangci-lint
-
-Documentation
-=============
-
-Juju's documentation is stored in the `doc` directory of the repository. It is
-based on the [Canonical starter
-pack](https://canonical-starter-pack.readthedocs-hosted.com/latest/) and hosted
-on [Read the Docs](https://about.readthedocs.com/).
-
-For general guidance, refer to the [starter pack
-guide](https://canonical-starter-pack.readthedocs-hosted.com/latest/).
-
-For syntax help and guidelines, refer to the [Canonical style
-guides](https://canonical-documentation-with-sphinx-and-readthedocscom.readthedocs-hosted.com/#style-guides).
-
-In structuring, the documentation employs the [Diátaxis](https://diataxis.fr/)
-approach.
-
-To run the documentation locally before submitting your changes:
-```
-make docs-run
-```
-
-Community
-=========
-
-The Juju community is growing and you have a number of options for interacting
-beyond the [juju/juju](https://github.com/juju/juju) GitHub repository.
-
-Use the following links to contact the community:
-
- - Matrix juju chat: [https://matrix.to/#/#charmhub-juju:ubuntu.com](https://matrix.to/#/#charmhub-juju:ubuntu.com)
- - Matrix juju development chat: [https://matrix.to/#/#charmhub-jujudev:ubuntu.com](https://matrix.to/#/#charmhub-jujudev:ubuntu.com)
- - Discourse forum: [https://discourse.charmhub.io/](https://discourse.charmhub.io/)
+Congratulations and thank you!

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,7 @@
 import ast
 import datetime
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -314,10 +315,74 @@ latex_elements = ast.literal_eval(latex_config.replace("$PROJECT", project))
 # Auto-generation of documentation
 ##################################
 
+def _major_minor_from_version_string(version):
+    """Get a tuple of version from a juju version string.
+
+    Note that release of juju use Major.Minor.Patch (eg, 3.6.0) but releases will use Major.Minor-betaBeta.
+    This returns a tuple of either (3,6,0) or (3, 6, 'beta5').
+    If neither can be found, this returns None
+    """
+    version_re = re.compile('(?P<major>\d+)\.(?P<minor>\d+)(\.(?P<patch>\d+)|-(?P<beta>beta\d+))(-.*)?')
+    m = version_re.match(version)
+    if m is None:
+        return None
+    return (int(m['major']), int(m['minor']))
+
+
+def _extract_version_from_version_go(version_file):
+    """Extract the version string from a juju version.go file"""
+    # Note that this assumes Major and Minor are integers, but patch might be an integer or something like beta5.
+    version_re = re.compile('const version = "(?P<version>[^"]*)"')
+    for line in version_file:
+        m = version_re.match(line)
+        if m is None:
+            continue
+        version = m['version']
+        return _major_minor_from_version_string(version), version
+    return None, None
+
+
+def get_tree_juju_version():
+    """Read the version of juju as reported by the juju branch that we're building."""
+    try:
+        # This is the location in Juju 3.6
+        with open('../version/version.go', 'rt') as version_file:
+            major_minor, version = _extract_version_from_version_go(version_file)
+    except FileNotFoundError:
+        # This is the location in Juju 4.0
+        with open('../core/version/version.go', 'rt') as version_file:
+            major_minor, version = _extract_version_from_version_go(version_file)
+    if major_minor is None:
+        raise RuntimeError("could not determine the version of Juju for this directory")
+    return major_minor, version
+
+
+def get_juju_version():
+    """Check to see what version of Juju we are running."""
+    # There is probably more that could be done here about all the possible
+    # version strings juju spits out, but this should cover stripping things
+    # like 'genericlinux' and the architecture out.
+    result = subprocess.run(['juju', 'version'], capture_output=True, text=True)
+    version = result.stdout.rstrip()
+    major_minor = _major_minor_from_version_string(version)
+    if major_minor is None:
+        raise RuntimeError('could not determine version from `juju version`: {}'.format(version))
+    return major_minor, version
+
+
 def generate_cli_docs():
     cli_dir = "user/reference/juju-cli/"
     generated_cli_docs_dir = cli_dir + "list-of-juju-cli-commands/"
     cli_index_header = cli_dir + 'cli_index'
+
+    tree_major_minor, tree_version = get_tree_juju_version()
+    juju_major_minor, juju_version = get_juju_version()
+    if tree_major_minor != juju_major_minor:
+        warning = "refusing to rebuild docs with a mismatched minor juju version. Found juju {} in $PATH, but the tree reports version {}".format(juju_version, tree_version)
+        print(warning)
+        raise RuntimeError(warning)
+    else:
+        print("generating cli command docs using juju version found in path: {} for tree version {}".format(juju_version, tree_version))
 
     # Remove existing cli folder to regenerate it
     if os.path.exists(generated_cli_docs_dir):
@@ -343,9 +408,6 @@ def generate_cli_docs():
     # Add in the index file containing the command list.
     subprocess.run(['cp', cli_index_header, generated_cli_docs_dir + 'index.md'])
 
-
-    result = subprocess.run(['juju', 'version'], capture_output=True, text=True)
-    print("generated cli command docs using juju version found in path: " + result.stdout.rstrip())
 
 def generate_controller_config_docs():
     config_reference_dir = 'user/reference/configuration/'

--- a/docs/contributor/reference/conventional-commits.md
+++ b/docs/contributor/reference/conventional-commits.md
@@ -62,7 +62,7 @@ feat(api): add user authentication feature
 # "add user authentication feature" summarizes the change concisely
 
 This commit adds user authentication to the API. Users can now sign up,
-log in, and log out. Passwords are hashed using bcrypt. Token-based 
+log in, and log out. Passwords are hashed using bcrypt. Token-based
 authentication is implemented using JWT.
 
 # body: Detailed explanation of the change

--- a/docs/user/howto/manage-juju.md
+++ b/docs/user/howto/manage-juju.md
@@ -1,5 +1,5 @@
 (manage-juju)=
-# How  manage the `juju` CLI client
+# How to manage the `juju` CLI client
 
 > See also: {ref}`juju-cli`
 
@@ -7,9 +7,9 @@
 ## Install `juju`
 
 ``````{tabs}
- 
+
 `````{tab} Linux
- 
+
 **Install from snap.**
 
 ```{important}
@@ -42,27 +42,27 @@ license:   AGPL-3.0
 description: |
   A model-driven **universal operator lifecycle manager** for multi cloud and
   hybrid cloud application management on K8s and machines.
-  
+
   **What is an operator lifecycle manager?**
   Kubernetes operators are containers with operations code, that drive your
   applications on K8s. Juju is an operator lifecycle manager that manages the
   installation, integration and configuration of operators on the cluster.
   Juju also extends the idea of operators to traditional application
   management on Linux and Windows servers, or cloud instances.
-  
+
   **Model-driven operations and integration**
   Organise your operators into models, which group together applications that
   can be tightly integrated on the same substrate and operated by the same
   team. Capture resource allocation, storage, networking and integration
   information in the model to simplify ongoing operations.
-  
+
   **Better day-2 operations**
   Each operator code package, called a charm, declares methods for actions
   like back, restore, or security audit. Calling these methods provides
   remote administration of the application with no low-level access required.
-  
+
   **Learn more**
-  
+
    - https://juju.is/
    - https://discourse.charmhub.io/
    - https://github.com/juju/juju
@@ -75,45 +75,45 @@ tracking:     3.1/stable
 refresh-date: 2024-01-03
 channels:
   3/stable:      3.4.0             2024-03-07 (26548)  99MB -
-  3/candidate:   ↑                                          
-  3/beta:        ↑                                          
-  3/edge:        ↑                                          
-  4.0/stable:    –                                          
-  4.0/candidate: –                                          
+  3/candidate:   ↑
+  3/beta:        ↑
+  3/edge:        ↑
+  4.0/stable:    –
+  4.0/candidate: –
   4.0/beta:      4.0-beta2         2024-01-11 (25984)  98MB -
   4.0/edge:      4.0-beta3-ec9b93b 2024-02-19 (26600)  98MB -
-  4/stable:      –                                          
-  4/candidate:   –                                          
+  4/stable:      –
+  4/candidate:   –
   4/beta:        4.0-beta2         2024-01-17 (25984)  98MB -
-  4/edge:        ↑                                          
-  3.5/stable:    –                                          
-  3.5/candidate: –                                          
-  3.5/beta:      –                                          
+  4/edge:        ↑
+  3.5/stable:    –
+  3.5/candidate: –
+  3.5/beta:      –
   3.5/edge:      3.5-beta1-c3de749 2024-03-12 (26766)  98MB -
   3.4/stable:    3.4.0             2024-02-15 (26548)  99MB -
-  3.4/candidate: ↑                                          
-  3.4/beta:      ↑                                          
+  3.4/candidate: ↑
+  3.4/beta:      ↑
   3.4/edge:      3.4.1-14d5608     2024-03-13 (26783)  98MB -
   3.3/stable:    3.3.3             2024-03-06 (26652)  99MB -
-  3.3/candidate: ↑                                          
-  3.3/beta:      ↑                                          
+  3.3/candidate: ↑
+  3.3/beta:      ↑
   3.3/edge:      3.3.4-65b78cd     2024-03-13 (26779)  99MB -
   3.2/stable:    3.2.4             2023-11-22 (25443)  95MB -
-  3.2/candidate: ↑                                          
-  3.2/beta:      ↑                                          
+  3.2/candidate: ↑
+  3.2/beta:      ↑
   3.2/edge:      3.2.5-9e20221     2023-11-17 (25455)  95MB -
   3.1/stable:    3.1.7             2024-01-03 (25751)  95MB -
-  3.1/candidate: ↑                                          
-  3.1/beta:      ↑                                          
+  3.1/candidate: ↑
+  3.1/beta:      ↑
   3.1/edge:      3.1.8-1a8d6a3     2024-03-12 (26750)  95MB -
   2.9/stable:    2.9.46            2023-12-05 (25672) 120MB classic
   2.9/candidate: 2.9.47            2024-03-07 (26724) 120MB classic
-  2.9/beta:      ↑                                          
+  2.9/beta:      ↑
   2.9/edge:      2.9.48-dfd7fee    2024-03-07 (26740) 120MB classic
   2.8/stable:    2.8.13            2021-11-11 (17665)  74MB classic
-  2.8/candidate: ↑                                          
-  2.8/beta:      ↑                                          
-  2.8/edge:      ↑                                          
+  2.8/candidate: ↑
+  2.8/beta:      ↑
+  2.8/edge:      ↑
 installed:       3.1.7                        (25751)  95MB -
 
 $ sudo snap install juju --channel=3.4/stable
@@ -124,7 +124,7 @@ $ sudo snap install juju --channel=3.4/stable
 ````
 
 To install multiple versions of `juju` via snap, enable `snap`'s experimental parallel-install feature, reboot, then install a different version with a different name.
- 
+
 > See more: [Snap | Channels](https://snapcraft.io/docs/channels)
 
 ````{dropdown} Example
@@ -246,14 +246,14 @@ Use the `juju` CLI client reference and the Juju how-to guides to build up your 
 ## Back up Juju
 
 ```{note}
-A backup of the client enables one to regain management control of one's controllers and associated cloud environments. 
+A backup of the client enables one to regain management control of one's controllers and associated cloud environments.
 ```
 
 **Create a backup of the `juju` client.** Making a copy of the client directory is sufficient for backing up the client. This is normally done with backup software that compresses the data into a single file (archive). On a Linux/Ubuntu system, the `tar` program is a common choice:
 
 ``` text
 cd ~
-tar -cpzf juju-client-$(date "+%Y%m%d-%H%M%S").tar.gz .local/share/juju 
+tar -cpzf juju-client-$(date "+%Y%m%d-%H%M%S").tar.gz .local/share/juju
 ```
 
 ```{note}
@@ -282,7 +282,7 @@ This command will extract the contents of the archive and overwrite any existing
 
 ``` text
 cd ~
-tar -xzf juju-yymmdd-hhmmss.tar.gz 
+tar -xzf juju-yymmdd-hhmmss.tar.gz
 ```
 
 (upgrade-juju)=
@@ -294,7 +294,7 @@ tar -xzf juju-yymmdd-hhmmss.tar.gz
 
 `````{tab} Linux
 
-**If you've installed via `snap`.** 
+**If you've installed via `snap`.**
 
 ```{note}
 Ensure you've created a backup of your ./local/share/juju before starting the upgrade process for the client.


### PR DESCRIPTION
Partial merge of 3.6 up to main with the following patches:
- #18826 from jameinel/3.6-doc-juju-version-check
- #18855 from tmihoc/3.6-fix-big-typo-in-manage-juju
- #18846 from tmihoc/3.6-update-contributing
- #18808 from wallyworld/hook-doc2

Conflicts in CONTRIBUTING.md resolved by taking the 3.6 version.