### PR TITLE
chore(test): set all true on destroy/kill controller

### DIFF
--- a/tests/includes/juju.sh
+++ b/tests/includes/juju.sh
@@ -546,9 +546,9 @@ destroy_controller() {
 
 	echo "====> Destroying juju ($(green "${name}"))"
 	if [[ ${KILL_CONTROLLER:-} != "true" ]]; then
-		echo "${name}" | xargs -I % timeout "${DESTROY_TIMEOUT}" juju destroy-controller --destroy-all-models --destroy-storage --no-prompt % 2>&1 | OUTPUT "${output}"
+		echo "${name}" | xargs -I % timeout "${DESTROY_TIMEOUT}" juju destroy-controller --destroy-all-models --destroy-storage --no-prompt % 2>&1 | OUTPUT "${output}" || true
 	else
-		echo "${name}" | xargs -I % timeout "${DESTROY_TIMEOUT}" juju kill-controller -t 0 --no-prompt % 2>&1 | OUTPUT "${output}"
+		echo "${name}" | xargs -I % timeout "${DESTROY_TIMEOUT}" juju kill-controller -t 0 --no-prompt % 2>&1 | OUTPUT "${output}" || true
 	fi
 
 	set +e


### PR DESCRIPTION
This PR implemented functionality to set all values to true when destroying the controller in our CI tests. This will help to ignore problems on teardown.

```sh
cd tests
./main.sh -v actions run_actions_params
# test should finish in 15 mins without an error.
```

## Links

**Jira card:** JUJU-

