### PR TITLE
fix: correct case of JSON/YAML field name for FilesystemInfo.Attachments

### DIFF
--- a/cmd/juju/storage/filesystem.go
+++ b/cmd/juju/storage/filesystem.go
@@ -32,7 +32,7 @@ type FilesystemInfo struct {
 	Storage string `yaml:"storage,omitempty" json:"storage,omitempty"`
 
 	// Attachments is the set of entities attached to the filesystem.
-	Attachments *FilesystemAttachments
+	Attachments *FilesystemAttachments `yaml:"attachments,omitempty" json:"attachments,omitempty"`
 
 	// Pool is the name of the storage pool that the filesystem came from.
 	Pool string `yaml:"pool,omitempty" json:"pool,omitempty"`


### PR DESCRIPTION
Currently it serializes as "Attachments", but it should be "attachments" like all the other fields. This is a breaking change, but we're considering it a bug fix, and it's very unlikely to break anyone.
