### PR TITLE
feat(resources): add new update resource method

### DIFF
--- a/domain/resource/state/types.go
+++ b/domain/resource/state/types.go
@@ -33,6 +33,11 @@ type localUUID struct {
 	UUID string `db:"uuid"`
 }
 
+// resourceUUID represents a unique identifier for a resource.
+type resourceUUID struct {
+	UUID string `db:"uuid"`
+}
+
 // charmUUID represents the unique identifier of a charm.
 type charmUUID struct {
 	UUID string `db:"uuid"`
@@ -161,6 +166,12 @@ type getApplicationAndCharmID struct {
 	Name          string             `db:"name"`
 }
 
+type getResourceCharmID struct {
+	ApplicationID coreapplication.ID `db:"application_uuid"`
+	CharmID       charm.ID           `db:"charm_uuid"`
+	ResourceName  string             `db:"name"`
+}
+
 // kubernetesApplicationResource represents the mapping of a resource to a unit.
 type kubernetesApplicationResource struct {
 	ResourceUUID string    `db:"resource_uuid"`
@@ -220,4 +231,15 @@ type setResource struct {
 	OriginTypeId int       `db:"origin_type_id"`
 	StateID      int       `db:"state_id"`
 	CreatedAt    time.Time `db:"created_at"`
+}
+
+// addResource is used to set resource rows in the resource table.
+type addResource struct {
+	UUID      string    `db:"uuid"`
+	CharmUUID string    `db:"charm_uuid"`
+	Name      string    `db:"charm_resource_name"`
+	Revision  *int      `db:"revision"`
+	Origin    string    `db:"origin_type_name"`
+	State     string    `db:"state_name"`
+	CreatedAt time.Time `db:"created_at"`
 }

--- a/domain/resource/types.go
+++ b/domain/resource/types.go
@@ -125,6 +125,19 @@ type AddResourceDetails struct {
 	Revision *int
 }
 
+// UpdateResourceArgs holds arguments to add a new resource revision and link it
+// to the application.
+type UpdateResourceArgs struct {
+	// ApplicationID is the ID of the application this resource belongs to.
+	ApplicationID application.ID
+	// Name is the resource name.
+	Name string
+	// Revision is the revision of the resource to use.
+	Revision *int
+	// Origin is the origin of the resource to use.
+	Origin charmresource.Origin
+}
+
 // UpdateResourceRevisionArgs holds arguments to update a resource to have
 // a new revision.
 type UpdateResourceRevisionArgs struct {


### PR DESCRIPTION
This update resource function adds a new row to the resources table and updates the application_resource table to point to the new resource. It then increments the charm modified version.

It was realised that an issue in the resource domain meant that the revisions of unit resources and kubernetes application resources were not being correctly tracked. This was because these tables only linked to the resource table, and did not themselves keep track of the revision or origin. The resource table was being updated when a new revision was added thus implicitly also updating the unit and kubernetes application resources versions.

The resource schema was designed so that when a new resource revision was added, a new row would be added to the resource table. When a blob was uploaded it would be linked to this new resource. The old resource record remains, and is still linked by the unit and application, which will update to the new version of the resource after their watcher spots the change.

There will need to be some worker that removes old orphaned resources. As discussed with @manadart, this is the cleanest way to deal with these old blobs and old resource records.

<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://github.com/juju/juju/blob/main/doc/conventional-commits.md
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

<!-- 

Describe steps to verify that the change works. 

If you're changing any of the facades, you need to ensure that you've tested
a model migration from 3.6 to 4.0 and from 4.0 to 4.0.

The following steps are a good starting point:

 1. Bootstrap a 3.6 controller and deploy a charm.

```sh
$ juju bootstrap lxd src36
$ juju add-model moveme1
$ juju deploy juju-qa-test
```

 2. Bootstrap a 4.0 controller with the changes and migrate the model.

```sh
$ juju bootstrap lxd dst40
$ juju migrate src36:moveme1 dst40
$ juju add-unit juju-qa-test
```

 3. Verify no errors exist in the model logs for the agents. If there are
    errors, this is a bug and should be fixed before merging. The fix can
    either be applied to the 4.0 branch (preferable) or the 3.6 branch, though
    that needs to be discussed with the team.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme1
```

    4. We also need to test a model migration from 4.0 to 4.0.

```sh
$ juju bootstrap lxd src40
$ juju add-model moveme2
$ juju deploy juju-qa-test
```

```sh
$ juju migrate src40:moveme2 dst40
$ juju add-unit juju-qa-test
```

    5. Verify that there are no errors in the controller or model logs.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme2
```

-->

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/

**Jira card:** JUJU-

