### PR TITLE
feat: allow k8s to skip destroy

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -101,4 +101,7 @@ jobs:
         cd tests
         export MODEL_ARCH=$(go env GOARCH)
 
+        # Skip destroy to keep the environment up.
+        export SKIP_DESTROY=true
+
         sg snap_microk8s './main.sh -c microk8s -v smoke_k8s'


### PR DESCRIPTION
We skip destroying for LXD we should do the same for k8s. This way we can see if it's working or not. Once the removal and cleanup epic is done, this should be put back to false. For now, skip it!

## QA steps

k8s github action passes.

