### PR TITLE
Plumb sshserver config in

### DIFF
--- a/worker/sshserver/export_test.go
+++ b/worker/sshserver/export_test.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package sshserver
 
 var (

--- a/worker/sshserver/export_test.go
+++ b/worker/sshserver/export_test.go
@@ -1,0 +1,5 @@
+package sshserver
+
+var (
+	NewAcceptOnceListener = newAcceptOnceListener
+)

--- a/worker/sshserver/export_test.go
+++ b/worker/sshserver/export_test.go
@@ -4,5 +4,5 @@
 package sshserver
 
 var (
-	NewAcceptOnceListener = newAcceptOnceListener
+	NewSSHServerListener = newSSHServerListener
 )

--- a/worker/sshserver/listener.go
+++ b/worker/sshserver/listener.go
@@ -34,7 +34,7 @@ type acceptOnceListener struct {
 
 // newAcceptOnceListener returns a listener and a closedAllowed channel. You are
 // expected to receive from the closeAlloed channel within your Close() function.
-// The channel is closed once an accept has occured at least once.
+// The channel is closed once an accept has occurred at least once.
 func newAcceptOnceListener(l net.Listener) (acceptOnceListener, chan struct{}) {
 	c := make(chan struct{})
 	return acceptOnceListener{

--- a/worker/sshserver/listener.go
+++ b/worker/sshserver/listener.go
@@ -1,3 +1,6 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package sshserver
 
 import (

--- a/worker/sshserver/listener.go
+++ b/worker/sshserver/listener.go
@@ -1,0 +1,49 @@
+package sshserver
+
+import (
+	"net"
+	"sync"
+)
+
+// acceptOnceListener is required to prevent a race condition
+// that can occur in tests.
+//
+// The SSH server tracks the listeners in use
+// but if the server's close() method executes
+// before we reach a safe point in the Serve() method
+// then the server's map of listeners will be empty.
+// A safe point to indicate the server is ready is
+// right before we start accepting connections.
+// Accept() will return with error if the underlying
+// listener is already closed.
+//
+// As such, we ensure accept has been called at least once
+// before allowing a close to take effect. The corresponding
+// piece to this is to receive from the closeAllowed channel
+// within your cleanup routine.
+type acceptOnceListener struct {
+	net.Listener
+	// closeAllowed indicates when the server has reached
+	// a safe point that it can be killed.
+	closeAllowed chan struct{}
+	once         *sync.Once
+}
+
+// newAcceptOnceListener returns a listener and a closedAllowed channel. You are
+// expected to receive from the closeAlloed channel within your Close() function.
+// The channel is closed once an accept has occured once.
+func newAcceptOnceListener(l net.Listener) (acceptOnceListener, chan struct{}) {
+	c := make(chan struct{})
+	return acceptOnceListener{
+		Listener:     l,
+		closeAllowed: c,
+		once:         &sync.Once{},
+	}, c
+}
+
+func (l acceptOnceListener) Accept() (net.Conn, error) {
+	l.once.Do(func() {
+		close(l.closeAllowed)
+	})
+	return l.Listener.Accept()
+}

--- a/worker/sshserver/listener.go
+++ b/worker/sshserver/listener.go
@@ -44,6 +44,8 @@ func newAcceptOnceListener(l net.Listener) (acceptOnceListener, chan struct{}) {
 	}, c
 }
 
+// Accept runs the listeners accept, but firstly closes the closeAllowed channel,
+// signalling that any routines waiting to close the listener may proceed.
 func (l acceptOnceListener) Accept() (net.Conn, error) {
 	l.once.Do(func() {
 		close(l.closeAllowed)

--- a/worker/sshserver/listener.go
+++ b/worker/sshserver/listener.go
@@ -34,7 +34,7 @@ type acceptOnceListener struct {
 
 // newAcceptOnceListener returns a listener and a closedAllowed channel. You are
 // expected to receive from the closeAlloed channel within your Close() function.
-// The channel is closed once an accept has occured once.
+// The channel is closed once an accept has occured at least once.
 func newAcceptOnceListener(l net.Listener) (acceptOnceListener, chan struct{}) {
 	c := make(chan struct{})
 	return acceptOnceListener{

--- a/worker/sshserver/listener_test.go
+++ b/worker/sshserver/listener_test.go
@@ -1,0 +1,45 @@
+package sshserver_test
+
+import (
+	"sync"
+	"time"
+
+	"github.com/juju/juju/worker/sshserver"
+	"github.com/juju/testing"
+	"google.golang.org/grpc/test/bufconn"
+	gc "gopkg.in/check.v1"
+)
+
+type listenerSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&listenerSuite{})
+
+func (s *listenerSuite) TestAcceptOnceListener(c *gc.C) {
+	listener := bufconn.Listen(8 * 1024)
+
+	acceptOnceListener, closeAllowed := sshserver.NewAcceptOnceListener(listener)
+	c.Assert(acceptOnceListener, gc.NotNil)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		<-closeAllowed
+		listener.Close()
+	}()
+
+	// Artificial sleep to ensure close is definitely waiting on <-closeAllowed
+	time.Sleep(100 * time.Millisecond)
+
+	go func() {
+		defer wg.Done()
+		// Accept runs and sends down the channel, it is blocked then until
+		// Close continues.
+		acceptOnceListener.Accept()
+	}()
+
+	wg.Wait()
+}

--- a/worker/sshserver/listener_test.go
+++ b/worker/sshserver/listener_test.go
@@ -5,7 +5,6 @@ package sshserver_test
 
 import (
 	"sync"
-	"time"
 
 	"github.com/juju/testing"
 	"google.golang.org/grpc/test/bufconn"
@@ -34,9 +33,6 @@ func (s *listenerSuite) TestAcceptOnceListener(c *gc.C) {
 		<-closeAllowed
 		listener.Close()
 	}()
-
-	// Artificial sleep to ensure close is definitely waiting on <-closeAllowed
-	time.Sleep(100 * time.Millisecond)
 
 	go func() {
 		defer wg.Done()

--- a/worker/sshserver/listener_test.go
+++ b/worker/sshserver/listener_test.go
@@ -1,13 +1,17 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
 package sshserver_test
 
 import (
 	"sync"
 	"time"
 
-	"github.com/juju/juju/worker/sshserver"
 	"github.com/juju/testing"
 	"google.golang.org/grpc/test/bufconn"
 	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/worker/sshserver"
 )
 
 type listenerSuite struct {

--- a/worker/sshserver/manifold.go
+++ b/worker/sshserver/manifold.go
@@ -80,7 +80,6 @@ func (config ManifoldConfig) startWrapperWorker(context dependency.Context) (wor
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-
 	w, err := config.NewServerWrapperWorker(ServerWrapperWorkerConfig{
 		SystemState:     sysState,
 		NewServerWorker: config.NewServerWorker,

--- a/worker/sshserver/mocks/system_state_mock.go
+++ b/worker/sshserver/mocks/system_state_mock.go
@@ -12,6 +12,7 @@ package mocks
 import (
 	reflect "reflect"
 
+	controller "github.com/juju/juju/controller"
 	state "github.com/juju/juju/state"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -37,6 +38,36 @@ func NewMockSystemState(ctrl *gomock.Controller) *MockSystemState {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockSystemState) EXPECT() *MockSystemStateMockRecorder {
 	return m.recorder
+}
+
+// ControllerConfig mocks base method.
+func (m *MockSystemState) ControllerConfig() (controller.Config, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ControllerConfig")
+	ret0, _ := ret[0].(controller.Config)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ControllerConfig indicates an expected call of ControllerConfig.
+func (mr *MockSystemStateMockRecorder) ControllerConfig() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ControllerConfig", reflect.TypeOf((*MockSystemState)(nil).ControllerConfig))
+}
+
+// SSHServerHostKey mocks base method.
+func (m *MockSystemState) SSHServerHostKey() (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SSHServerHostKey")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SSHServerHostKey indicates an expected call of SSHServerHostKey.
+func (mr *MockSystemStateMockRecorder) SSHServerHostKey() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SSHServerHostKey", reflect.TypeOf((*MockSystemState)(nil).SSHServerHostKey))
 }
 
 // WatchControllerConfig mocks base method.

--- a/worker/sshserver/server.go
+++ b/worker/sshserver/server.go
@@ -91,7 +91,7 @@ func NewServerWorker(config ServerWorkerConfig) (worker.Worker, error) {
 		s.config.Listener = listener
 	}
 
-	listener, closeAllowed := newAcceptOnceListener(s.config.Listener)
+	listener, closeAllowed := newSSHServerListener(s.config.Listener)
 
 	// Start server.
 	s.tomb.Go(func() error {

--- a/worker/sshserver/server_test.go
+++ b/worker/sshserver/server_test.go
@@ -58,13 +58,12 @@ func newServerWorkerConfig(
 
 func (s *sshServerSuite) TestValidate(c *gc.C) {
 	cfg := &sshserver.ServerWorkerConfig{}
+	l := loggo.GetLogger("test")
 
 	c.Assert(cfg.Validate(), gc.ErrorMatches, ".*not valid.*")
 
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
-
-	l := loggo.GetLogger("test")
 
 	// Test no Logger.
 	cfg = newServerWorkerConfig(l, "jumpHostKey", func(cfg *sshserver.ServerWorkerConfig) {

--- a/worker/sshserver/server_test.go
+++ b/worker/sshserver/server_test.go
@@ -16,6 +16,7 @@ import (
 	"google.golang.org/grpc/test/bufconn"
 	gc "gopkg.in/check.v1"
 
+	jujutesting "github.com/juju/juju/testing"
 	"github.com/juju/juju/worker/sshserver"
 )
 
@@ -40,9 +41,42 @@ func (s *sshServerSuite) SetUpSuite(c *gc.C) {
 	s.userSigner = userSigner
 }
 
+func newServerWorkerConfig(
+	l sshserver.Logger,
+	j string,
+	modifier func(*sshserver.ServerWorkerConfig),
+) *sshserver.ServerWorkerConfig {
+	cfg := &sshserver.ServerWorkerConfig{
+		Logger:      l,
+		JumpHostKey: j,
+	}
+
+	modifier(cfg)
+
+	return cfg
+}
+
 func (s *sshServerSuite) TestValidate(c *gc.C) {
-	cfg := sshserver.ServerWorkerConfig{}
-	c.Assert(cfg.Validate(), gc.ErrorMatches, ".*is required.*")
+	cfg := &sshserver.ServerWorkerConfig{}
+
+	c.Assert(cfg.Validate(), gc.ErrorMatches, ".*not valid.*")
+
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	l := loggo.GetLogger("test")
+
+	// Test no Logger.
+	cfg = newServerWorkerConfig(l, "jumpHostKey", func(cfg *sshserver.ServerWorkerConfig) {
+		cfg.Logger = nil
+	})
+	c.Assert(cfg.Validate(), gc.ErrorMatches, ".*not valid.*")
+
+	// Test no JumpHostKey.
+	cfg = newServerWorkerConfig(l, "jumpHostKey", func(cfg *sshserver.ServerWorkerConfig) {
+		cfg.JumpHostKey = ""
+	})
+	c.Assert(cfg.Validate(), gc.ErrorMatches, ".*not valid.*")
 }
 
 func (s *sshServerSuite) TestSSHServer(c *gc.C) {
@@ -53,8 +87,9 @@ func (s *sshServerSuite) TestSSHServer(c *gc.C) {
 	listener := bufconn.Listen(8 * 1024)
 
 	server, err := sshserver.NewServerWorker(sshserver.ServerWorkerConfig{
-		Logger:   loggo.GetLogger("test"),
-		Listener: listener,
+		Logger:      loggo.GetLogger("test"),
+		Listener:    listener,
+		JumpHostKey: jujutesting.SSHServerHostKey,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	defer workertest.DirtyKill(c, server)

--- a/worker/sshserver/worker_test.go
+++ b/worker/sshserver/worker_test.go
@@ -217,7 +217,6 @@ func (s *workerSuite) TestSSHServerWrapperWorkerErrorsOnMissingHostKey(c *gc.C) 
 
 	ctrl := gomock.NewController(c)
 	defer ctrl.Finish()
-
 	mockSystemState := mocks.NewMockSystemState(ctrl)
 
 	serverWorker := workertest.NewErrorWorker(nil)

--- a/worker/sshserver/worker_test.go
+++ b/worker/sshserver/worker_test.go
@@ -4,6 +4,8 @@
 package sshserver_test
 
 import (
+	"errors"
+
 	"github.com/juju/loggo"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -12,6 +14,7 @@ import (
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/controller"
 	"github.com/juju/juju/worker/sshserver"
 	"github.com/juju/juju/worker/sshserver/mocks"
 )
@@ -91,8 +94,17 @@ func (s *workerSuite) TestSSHServerWrapperWorkerCanBeKilled(c *gc.C) {
 	controllerConfigWatcher := workertest.NewFakeWatcher(1, 0)
 	defer workertest.DirtyKill(c, controllerConfigWatcher)
 
+	// Expect SSHServerHostKey to be retrieved
+	mockSystemState.EXPECT().SSHServerHostKey().Return("key", nil).Times(1)
 	// Expect WatchControllerConfig call
 	mockSystemState.EXPECT().WatchControllerConfig().Return(controllerConfigWatcher)
+
+	// Expect config to be called just the once.
+	ctrlCfg := controller.Config{
+		controller.SSHServerPort:               22,
+		controller.SSHMaxConcurrentConnections: 10,
+	}
+	mockSystemState.EXPECT().ControllerConfig().Return(ctrlCfg, nil).Times(1)
 
 	cfg := sshserver.ServerWrapperWorkerConfig{
 		SystemState: mockSystemState,
@@ -131,8 +143,33 @@ func (s *workerSuite) TestSSHServerWrapperWorkerRestartsServerWorker(c *gc.C) {
 	controllerConfigWatcher := workertest.NewFakeWatcher(1, 0)
 	defer workertest.DirtyKill(c, controllerConfigWatcher)
 
+	// Expect SSHServerHostKey to be retrieved
+	mockSystemState.EXPECT().SSHServerHostKey().Return("key", nil).Times(1)
 	// Expect WatchControllerConfig call
 	mockSystemState.EXPECT().WatchControllerConfig().Return(controllerConfigWatcher)
+
+	// Expect first call to have port of 22 and called once.
+	mockSystemState.EXPECT().
+		ControllerConfig().
+		Return(
+			controller.Config{
+				controller.SSHServerPort:               22,
+				controller.SSHMaxConcurrentConnections: 10,
+			},
+			nil,
+		).
+		Times(1)
+	// The second call, we're updating the port and should see it changes in our NewServerWorker call.
+	mockSystemState.EXPECT().
+		ControllerConfig().
+		Return(
+			controller.Config{
+				controller.SSHServerPort:               2222,
+				controller.SSHMaxConcurrentConnections: 10,
+			},
+			nil,
+		).
+		Times(1)
 
 	startCounter := 0
 	cfg := sshserver.ServerWrapperWorkerConfig{
@@ -140,6 +177,12 @@ func (s *workerSuite) TestSSHServerWrapperWorkerRestartsServerWorker(c *gc.C) {
 		Logger:      loggo.GetLogger("test"),
 		NewServerWorker: func(swc sshserver.ServerWorkerConfig) (worker.Worker, error) {
 			startCounter++
+			if startCounter == 1 {
+				c.Assert(swc.Port, gc.Equals, 22)
+			}
+			if startCounter == 2 {
+				c.Assert(swc.Port, gc.Equals, 2222)
+			}
 			return serverWorker, nil
 		},
 	}
@@ -167,4 +210,54 @@ func (s *workerSuite) TestSSHServerWrapperWorkerRestartsServerWorker(c *gc.C) {
 	// 1 for the initial start.
 	// 1 for the restart.
 	c.Assert(startCounter, gc.Equals, 2)
+}
+
+func (s *workerSuite) TestSSHServerWrapperWorkerErrorsOnMissingHostKey(c *gc.C) {
+	l := loggo.GetLogger("test")
+
+	ctrl := gomock.NewController(c)
+	defer ctrl.Finish()
+
+	mockSystemState := mocks.NewMockSystemState(ctrl)
+
+	serverWorker := workertest.NewErrorWorker(nil)
+	defer workertest.DirtyKill(c, serverWorker)
+
+	controllerConfigWatcher := workertest.NewFakeWatcher(1, 0)
+	defer workertest.DirtyKill(c, controllerConfigWatcher)
+
+	// Test where the host key is an empty
+	mockSystemState.EXPECT().SSHServerHostKey().Return("", nil).Times(1)
+
+	cfg := sshserver.ServerWrapperWorkerConfig{
+		SystemState: mockSystemState,
+		Logger:      l,
+		NewServerWorker: func(swc sshserver.ServerWorkerConfig) (worker.Worker, error) {
+			return serverWorker, nil
+		},
+	}
+	w1, err := sshserver.NewServerWrapperWorker(cfg)
+	c.Assert(err, gc.IsNil)
+	defer workertest.DirtyKill(c, w1)
+
+	err = workertest.CheckKilled(c, w1)
+	c.Assert(err, gc.ErrorMatches, "jump host key is empty")
+
+	// Test where the host key state method errors
+	mockSystemState.EXPECT().SSHServerHostKey().Return("", errors.New("state failed")).Times(1)
+
+	cfg = sshserver.ServerWrapperWorkerConfig{
+		SystemState: mockSystemState,
+		Logger:      l,
+		NewServerWorker: func(swc sshserver.ServerWorkerConfig) (worker.Worker, error) {
+			return serverWorker, nil
+		},
+	}
+	w2, err := sshserver.NewServerWrapperWorker(cfg)
+	c.Assert(err, gc.IsNil)
+	defer workertest.DirtyKill(c, w2)
+
+	err = workertest.CheckKilled(c, w2)
+	c.Assert(err, gc.ErrorMatches, "state failed")
+
 }


### PR DESCRIPTION
This PR plumbs the configuration into the workers. Additionally it tests that on watcher updates the config is changed. Finally,  I've added a small test for the acceptOnceListener to ensure that closers do indeed wait for an Accept to run and it works as expected.

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps
Currently Q/Aing.

1. make install
2. juju bootstrap lxd b
3. juju controller-config (check ssh server port)
4. juju ssh -m controller 0
5. ssh-keygen -t rsa -b 4096 -f ./id_rsa (you need some key at least to see the handler resolves)
6. ssh -i ./id_rsa -J localhost:17022 ubuntu@app.controller.model
7. Should ask for fingerprint to be added twice and final handler runs
8. Final output of
Your final destination is: app.controller.model as user: ubuntu
Connection to app.controller.model closed.
9. Exit the controller machine
10. juju controller-config ssh-server-port=17001
11. juju controller-config (ensure config output has changed to 17001)
12. juju ssh -m controller 0
13. ssh -i ./id_rsa -J localhost:17022 ubuntu@app.controller.model (should fail as port changed)
14. ssh -i ./id_rsa -J localhost:17001 ubuntu@app.controller.model
15.  ssh-keygen -f '/home/ubuntu/.ssh/known_hosts' -R 'app.controller.model'
16. ssh -i ./id_rsa -J localhost:17001 ubuntu@app.controller.model
17. Should ask for fingerprint to be added twice and final handler runs
18. Should ask for fingerprint to be added twice and final handler runs
Final output of
Your final destination is: app.controller.model as user: ubuntu
<!-- 

Describe steps to verify that the change works. 

If you're changing any of the facades, you need to ensure that you've tested
a model migration from 3.6 to 4.0 and from 4.0 to 4.0.

The following steps are a good starting point:

 1. Bootstrap a 3.6 controller and deploy a charm.

```sh
$ juju bootstrap lxd src36
$ juju add-model moveme1
$ juju deploy juju-qa-test
```

 2. Bootstrap a 4.0 controller with the changes and migrate the model.

```sh
$ juju bootstrap lxd dst40
$ juju migrate src36:moveme1 dst40
$ juju add-unit juju-qa-test
```

 3. Verify no errors exist in the model logs for the agents. If there are
    errors, this is a bug and should be fixed before merging. The fix can
    either be applied to the 4.0 branch (preferable) or the 3.6 branch, though
    that needs to be discussed with the team.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme1
```

    4. We also need to test a model migration from 4.0 to 4.0.

```sh
$ juju bootstrap lxd src40
$ juju add-model moveme2
$ juju deploy juju-qa-test
```

```sh
$ juju migrate src40:moveme2 dst40
$ juju add-unit juju-qa-test
```

    5. Verify that there are no errors in the controller or model logs.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme2
```

-->

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/

**Jira card:** JUJU-

