### PR TITLE
refactor(application): derive application status from units

### DIFF
--- a/domain/application/service/application.go
+++ b/domain/application/service/application.go
@@ -78,6 +78,11 @@ type ApplicationState interface {
 	// SetUnitWorkloadStatus sets the workload status of the specified unit.
 	SetUnitWorkloadStatus(context.Context, coreunit.UUID, *application.StatusInfo[application.WorkloadStatusType]) error
 
+	// GetUnitWorkloadStatusesForApplication returns the workload statuses for all units
+	// of the specified application, returning an error satisfying
+	// [applicationerrors.ApplicationNotFound] if the application doesn't exist.
+	GetUnitWorkloadStatusesForApplication(context.Context, coreapplication.ID) (map[coreunit.UUID]application.StatusInfo[application.WorkloadStatusType], error)
+
 	// DeleteUnit deletes the specified unit.
 	// If the unit's application is Dying and no
 	// other references to it exist, true is returned to
@@ -1541,11 +1546,39 @@ func (s *Service) GetApplicationStatus(ctx context.Context, appID coreapplicatio
 		return nil, internalerrors.Errorf("application ID: %w", err)
 	}
 
-	info, err := s.st.GetApplicationStatus(ctx, appID)
+	applicationStatus, err := s.st.GetApplicationStatus(ctx, appID)
 	if err != nil {
 		return nil, internalerrors.Capture(err)
 	}
-	return decodeWorkloadStatus(info)
+	if applicationStatus.Status != application.WorkloadStatusUnset {
+		return decodeWorkloadStatus(applicationStatus)
+	}
+
+	// The application status is unset. However, we can still derive the status
+	// of the application using the workload statuses of all the application's
+	// units.
+	//
+	// NOTE: It is possible that between these two calls to state someone else
+	// calls SetApplicationStatus and changes the status. This would potentially
+	// lead to an out of date status being returned here. In this specific case,
+	// we don't mind so long as we have 'eventual' (i.e. milliseconds) consistency.
+
+	unitStatuses, err := s.st.GetUnitWorkloadStatusesForApplication(ctx, appID)
+	if err != nil {
+		return nil, internalerrors.Capture(err)
+	}
+
+	deocodedStatuses := []corestatus.StatusInfo{}
+	for _, unitStatus := range unitStatuses {
+		status, err := decodeWorkloadStatus(&unitStatus)
+		if err != nil {
+			return nil, internalerrors.Capture(err)
+		}
+		deocodedStatuses = append(deocodedStatuses, *status)
+	}
+	derivedStatus := corestatus.DeriveStatus(deocodedStatuses)
+	return &derivedStatus, nil
+
 }
 
 // SetApplicationStatus saves the given application status, overwriting any

--- a/domain/application/service/package_mock_test.go
+++ b/domain/application/service/package_mock_test.go
@@ -2012,6 +2012,45 @@ func (c *MockStateGetUnitWorkloadStatusCall) DoAndReturn(f func(context.Context,
 	return c
 }
 
+// GetUnitWorkloadStatusesForApplication mocks base method.
+func (m *MockState) GetUnitWorkloadStatusesForApplication(arg0 context.Context, arg1 application.ID) (map[unit.UUID]application0.StatusInfo[application0.WorkloadStatusType], error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUnitWorkloadStatusesForApplication", arg0, arg1)
+	ret0, _ := ret[0].(map[unit.UUID]application0.StatusInfo[application0.WorkloadStatusType])
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUnitWorkloadStatusesForApplication indicates an expected call of GetUnitWorkloadStatusesForApplication.
+func (mr *MockStateMockRecorder) GetUnitWorkloadStatusesForApplication(arg0, arg1 any) *MockStateGetUnitWorkloadStatusesForApplicationCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnitWorkloadStatusesForApplication", reflect.TypeOf((*MockState)(nil).GetUnitWorkloadStatusesForApplication), arg0, arg1)
+	return &MockStateGetUnitWorkloadStatusesForApplicationCall{Call: call}
+}
+
+// MockStateGetUnitWorkloadStatusesForApplicationCall wrap *gomock.Call
+type MockStateGetUnitWorkloadStatusesForApplicationCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateGetUnitWorkloadStatusesForApplicationCall) Return(arg0 map[unit.UUID]application0.StatusInfo[application0.WorkloadStatusType], arg1 error) *MockStateGetUnitWorkloadStatusesForApplicationCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateGetUnitWorkloadStatusesForApplicationCall) Do(f func(context.Context, application.ID) (map[unit.UUID]application0.StatusInfo[application0.WorkloadStatusType], error)) *MockStateGetUnitWorkloadStatusesForApplicationCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateGetUnitWorkloadStatusesForApplicationCall) DoAndReturn(f func(context.Context, application.ID) (map[unit.UUID]application0.StatusInfo[application0.WorkloadStatusType], error)) *MockStateGetUnitWorkloadStatusesForApplicationCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // InitialWatchStatementApplicationConfigHash mocks base method.
 func (m *MockState) InitialWatchStatementApplicationConfigHash(appName string) (string, eventsource.NamespaceQuery) {
 	m.ctrl.T.Helper()

--- a/domain/application/state/application_test.go
+++ b/domain/application/state/application_test.go
@@ -1742,6 +1742,91 @@ func (s *applicationStateSuite) TestSetUnitWorkloadStatusNotFound(c *gc.C) {
 	c.Assert(err, jc.ErrorIs, applicationerrors.UnitNotFound)
 }
 
+func (s *applicationStateSuite) TestGetUnitWorkloadStatusesForApplication(c *gc.C) {
+	u1 := application.InsertUnitArg{
+		UnitName: "foo/666",
+	}
+	appId := s.createApplication(c, "foo", life.Alive, u1)
+
+	unitUUID, err := s.state.GetUnitUUIDByName(context.Background(), u1.UnitName)
+	c.Assert(err, jc.ErrorIsNil)
+
+	status := &application.StatusInfo[application.WorkloadStatusType]{
+		Status:  application.WorkloadStatusActive,
+		Message: "it's active!",
+		Data:    []byte(`{"foo": "bar"}`),
+		Since:   ptr(time.Now()),
+	}
+	err = s.state.SetUnitWorkloadStatus(context.Background(), unitUUID, status)
+	c.Assert(err, jc.ErrorIsNil)
+
+	results, err := s.state.GetUnitWorkloadStatusesForApplication(context.Background(), appId)
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(results, gc.HasLen, 1)
+	result, ok := results[unitUUID]
+	c.Assert(ok, jc.IsTrue)
+	assertStatusInfoEqual(c, &result, status)
+}
+
+func (s *applicationStateSuite) TestGetUnitWorkloadStatusesForApplicationMultipleUnits(c *gc.C) {
+	u1 := application.InsertUnitArg{
+		UnitName: "foo/666",
+	}
+	u2 := application.InsertUnitArg{
+		UnitName: "foo/667",
+	}
+	appId := s.createApplication(c, "foo", life.Alive, u1, u2)
+
+	unitUUID1, err := s.state.GetUnitUUIDByName(context.Background(), u1.UnitName)
+	c.Assert(err, jc.ErrorIsNil)
+	unitUUID2, err := s.state.GetUnitUUIDByName(context.Background(), u2.UnitName)
+	c.Assert(err, jc.ErrorIsNil)
+
+	status1 := &application.StatusInfo[application.WorkloadStatusType]{
+		Status:  application.WorkloadStatusActive,
+		Message: "it's active!",
+		Data:    []byte(`{"foo": "bar"}`),
+		Since:   ptr(time.Now()),
+	}
+	err = s.state.SetUnitWorkloadStatus(context.Background(), unitUUID1, status1)
+	c.Assert(err, jc.ErrorIsNil)
+
+	status2 := &application.StatusInfo[application.WorkloadStatusType]{
+		Status:  application.WorkloadStatusTerminated,
+		Message: "it's terminated",
+		Data:    []byte(`{"bar": "foo"}`),
+		Since:   ptr(time.Now()),
+	}
+	err = s.state.SetUnitWorkloadStatus(context.Background(), unitUUID2, status2)
+	c.Assert(err, jc.ErrorIsNil)
+
+	results, err := s.state.GetUnitWorkloadStatusesForApplication(context.Background(), appId)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, gc.HasLen, 2)
+
+	result1, ok := results[unitUUID1]
+	c.Assert(ok, jc.IsTrue)
+	assertStatusInfoEqual(c, &result1, status1)
+
+	result2, ok := results[unitUUID2]
+	c.Assert(ok, jc.IsTrue)
+	assertStatusInfoEqual(c, &result2, status2)
+}
+
+func (s *applicationStateSuite) TestGetUnitWorkloadStatusesForApplicationNotFound(c *gc.C) {
+	_, err := s.state.GetUnitWorkloadStatusesForApplication(context.Background(), "missing")
+	c.Assert(err, jc.ErrorIs, applicationerrors.ApplicationNotFound)
+}
+
+func (s *applicationStateSuite) TestGetUnitWorkloadStatusesForApplicationNoUnits(c *gc.C) {
+	appId := s.createApplication(c, "foo", life.Alive)
+
+	results, err := s.state.GetUnitWorkloadStatusesForApplication(context.Background(), appId)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(results, gc.HasLen, 0)
+}
+
 func (s *applicationStateSuite) TestGetApplicationScaleState(c *gc.C) {
 	u := application.InsertUnitArg{
 		UnitName: "foo/666",


### PR DESCRIPTION
If an application's explicit status is not set, fallback to deriving the status from the application's units.

Encupsulate this logic in the application service layer

This will be useful in the future, since we currently perform this logic in the apiserver

## QA steps

Uni tests pass