### PR TITLE
fix: ensure 'app.kubernetes.io/name' label is set for user secrets

### DIFF
--- a/secrets/provider/kubernetes/provider.go
+++ b/secrets/provider/kubernetes/provider.go
@@ -933,16 +933,14 @@ func (k *kubernetesClient) ensureSecretAccessToken(
 		modelIdKey:      k.modelUUID,
 	}
 
-	if consumer.Kind() != names.ModelTagKind {
-		appName := consumer.Id()
-		if consumer.Kind() == names.UnitTagKind {
-			appName, _ = names.UnitApplication(consumer.Id())
-		}
-		labels = utils.LabelsMerge(labels,
-			map[string]string{
-				constants.LabelKubernetesAppName: appName,
-			})
+	appName := consumer.Id()
+	if consumer.Kind() == names.UnitTagKind {
+		appName, _ = names.UnitApplication(consumer.Id())
 	}
+	labels = utils.LabelsMerge(labels,
+		map[string]string{
+			constants.LabelKubernetesAppName: appName,
+		})
 
 	// Compose the name of the service account and role and role binding.
 	// We'll use the tag string, but for models we'll use the model name, since


### PR DESCRIPTION
When creating user secrets, the service account used to mint the access token needs to have the `app.kubernetes.io/name` label set to the model UUID, even though this is a bit of a lie. This label value is used to set the `app.juju.is/created-by` label on the secret which is used in tests to see if the secret exists. There's nothing in Juju itself which needs this secret label, but best to retain it for compatibility.

## QA steps

`./main.sh -v -p microk8s secrets_k8s`

## Links

**Jira card:** [JUJU-7592](https://warthogs.atlassian.net/browse/JUJU-7592)

