### PR TITLE
fix: copy mgo session when bulk deleting secrets

### DIFF
--- a/state/secrets.go
+++ b/state/secrets.go
@@ -580,7 +580,8 @@ func (st *State) deleteSecrets(uris []*secrets.URI, revisions ...int) (external 
 	if len(uris) == 0 || len(uris) > 1 && len(revisions) > 0 {
 		return nil, errors.Errorf("PROGRAMMING ERROR: invalid secret deletion args uris=%v, revisions=%v", uris, revisions)
 	}
-	session := st.MongoSession()
+	session := st.MongoSession().Copy()
+	defer session.Close()
 	err = session.StartTransaction()
 	if err != nil {
 		return nil, errors.Trace(err)


### PR DESCRIPTION
When bulk removing secrets, the session used for the txn is grabbed off the state object but it needs to be copied so as not to interfere with other state usages. This is done in several other places but was missed here. The symptom is a "transaction already started" error in the logs. It needs to have a non trivial deployment to reproduce.

## QA steps

```
# Environment setup
$ sudo tee -a /etc/sysctl.conf > /dev/null <<EOT
vm.max_map_count=262144
vm.swappiness=0
net.ipv4.tcp_retries2=5
fs.file-max=1048576
EOT
$ sudo sysctl -p
$ cat <<EOF > cloudinit-userdata.yaml
cloudinit-userdata: |
  postruncmd:
    - [ 'echo', 'net.ipv4.tcp_retries2=5', '>>', '/etc/sysctl.conf' ]
    - [ 'echo', 'fs.file-max=1048576', '>>', '/etc/sysctl.conf' ]
    - [ 'sysctl', '-p' ]
EOF
$ juju model-config --file=./cloudinit-userdata.yaml


# OpenSearch 
$ juju deploy opensearch -n 3 --channel 2/edge --config profile="testing"
$ juju deploy self-signed-certificates --config ca-common-name="CA"
$ juju integrate self-signed-certificates opensearch
```

Wait for steady state then 
```
juju remove-application opensearch
juju secrets
```

All opensearch secrets should be removed.

## Links

Fixes issue https://github.com/juju/juju/issues/18737
And probably https://bugs.launchpad.net/juju/+bug/2093129

**Jira card:** [JUJU-7559](https://warthogs.atlassian.net/browse/JUJU-7559)

