### PR TITLE
fix: lxd VM instance creation due to duplicate alias

### DIFF
--- a/internal/container/lxd/image_test.go
+++ b/internal/container/lxd/image_test.go
@@ -160,6 +160,7 @@ func (s *imageSuite) TestFindImageRemoteServers(c *gc.C) {
 		rSvr1.EXPECT().GetImageAliasType(imageType, "16.04/"+s.Arch()).Return(nil, lxdtesting.ETag, errors.New("not found")),
 		rSvr2.EXPECT().GetImageAliasType(imageType, "16.04/"+s.Arch()).Return(&alias, lxdtesting.ETag, nil),
 		rSvr2.EXPECT().GetImage("foo-remote-target").Return(&image, lxdtesting.ETag, nil),
+		iSvr.EXPECT().DeleteImageAlias("16.04/amd64").Return(nil),
 	)
 
 	jujuSvr, err := lxd.NewServer(iSvr)
@@ -213,6 +214,7 @@ func (s *imageSuite) TestFindImageRemoteServersCopyLocalNoCallback(c *gc.C) {
 		rSvr.EXPECT().GetImage("foo-remote-target").Return(&image, lxdtesting.ETag, nil),
 		iSvr.EXPECT().CopyImage(rSvr, image, copyReq).Return(copyOp, nil),
 		iSvr.EXPECT().GetImageAliases().Return(nil, nil),
+		iSvr.EXPECT().DeleteImageAlias("16.04/amd64").Return(nil),
 	)
 
 	s.expectAlias(iSvr, "16.04/"+s.Arch(), "fingerprint")


### PR DESCRIPTION
When we try to create a VM instance on lxd (e.g `juju add-machine --constraints="virt-type=virtual-machine"`) we'll get an error stating that it cannot start because of a duplicate alias. This happens because when we copy the lxd images to the local cache we copy the aliases as well, and the original alias is the same for both containers and VMs (e.g. "24.04/amd64").
This patch fixes this behavior by simply removing the original alias from the local image cache and therefore we are able to copy the VM image.



## QA steps

First clear all the lxd images (at least for the same ubuntu base), then bootstrap on lxd, then try to add a VM instance.

```
$ lxc image ls
$ lxc image delete xxx
```

```
$ juju bootstrap lxd c
$ juju add-model m
$ juju add-machine --constraints="virt-type=virtual-machine"
$ juju status
```
The machine should reach a `Started` state and no errors displayed nor in the debug logs nor in the juju status messages.


## Links

**Jira card:** JUJU-7524

