### PR TITLE
docs: main remove leftover branch text in juju config help

### DIFF
--- a/cmd/juju/application/config.go
+++ b/cmd/juju/application/config.go
@@ -32,7 +32,7 @@ const (
 To view all configuration values for an application:
 
     juju config <app>
-    
+
 By default, the config will be printed in yaml format. You can instead print it
 in json format using the --format flag:
 
@@ -41,21 +41,21 @@ in json format using the --format flag:
 To view the value of a single config key, run
 
     juju config <app> key
-    
+
 To set config values, run
 
     juju config <app> key1=val1 key2=val2 ...
-    
+
 This sets "key1" to "val1", etc. Using the @ directive, you can set a config
 key's value to the contents of a file:
 
     juju config <app> key=@/tmp/configvalue
-    
+
 You can also reset config keys to their default values:
 
     juju config <app> --reset key1
     juju config <app> --reset key1,key2,key3
-    
+
 You may simultaneously set some keys and reset others:
 
     juju config <app> key1=val1 key2=val2 --reset key3,key4
@@ -63,33 +63,25 @@ You may simultaneously set some keys and reset others:
 Config values can be imported from a yaml file using the --file flag:
 
     juju config <app> --file=path/to/cfg.yaml
-    
+
 The yaml file should be in the following format:
 
     apache2:                        # application name
       servername: "example.com"     # key1: val1
       lb_balancer_timeout: 60       # key2: val2
       ...
-      
+
 This allows you to e.g. save an app's config to a file:
 
     juju config app1 > cfg.yaml
-    
+
 and then import the config later. You can also read from stdin using "-",
 which allows you to pipe config values from one app to another:
 
     juju config app1 | juju config app2 --file -
-    
+
 You can simultaneously read config from a yaml file and set/reset config keys
 as above. The command-line args will override any values specified in the file.
-
-By default, any configuration changes will be applied to the currently active
-branch. A specific branch can be targeted using the --branch option. Changes
-can be immediately be applied to the model by specifying --branch=master. For
-example:
-
-    juju config apache2 --branch=master servername=example.com
-    juju config apache2 --branch test-branch servername=staging.example.com
 
 Rather than specifying each setting name/value inline, the --file flag option
 may be used to provide a list of settings to be updated as a yaml file. The

--- a/docs/user/reference/juju-cli/list-of-juju-cli-commands/config.md
+++ b/docs/user/reference/juju-cli/list-of-juju-cli-commands/config.md
@@ -44,7 +44,7 @@ To set a configuration value for an application from a file:
 To view all configuration values for an application:
 
     juju config <app>
-    
+
 By default, the config will be printed in yaml format. You can instead print it
 in json format using the --format flag:
 
@@ -53,21 +53,21 @@ in json format using the --format flag:
 To view the value of a single config key, run
 
     juju config <app> key
-    
+
 To set config values, run
 
     juju config <app> key1=val1 key2=val2 ...
-    
+
 This sets "key1" to "val1", etc. Using the @ directive, you can set a config
 key's value to the contents of a file:
 
     juju config <app> key=@/tmp/configvalue
-    
+
 You can also reset config keys to their default values:
 
     juju config <app> --reset key1
     juju config <app> --reset key1,key2,key3
-    
+
 You may simultaneously set some keys and reset others:
 
     juju config <app> key1=val1 key2=val2 --reset key3,key4
@@ -75,33 +75,25 @@ You may simultaneously set some keys and reset others:
 Config values can be imported from a yaml file using the --file flag:
 
     juju config <app> --file=path/to/cfg.yaml
-    
+
 The yaml file should be in the following format:
 
     apache2:                        # application name
       servername: "example.com"     # key1: val1
       lb_balancer_timeout: 60       # key2: val2
       ...
-      
+
 This allows you to e.g. save an app's config to a file:
 
     juju config app1 > cfg.yaml
-    
+
 and then import the config later. You can also read from stdin using "-",
 which allows you to pipe config values from one app to another:
 
     juju config app1 | juju config app2 --file -
-    
+
 You can simultaneously read config from a yaml file and set/reset config keys
 as above. The command-line args will override any values specified in the file.
-
-By default, any configuration changes will be applied to the currently active
-branch. A specific branch can be targeted using the --branch option. Changes
-can be immediately be applied to the model by specifying --branch=master. For
-example:
-
-    juju config apache2 --branch=master servername=example.com
-    juju config apache2 --branch test-branch servername=staging.example.com
 
 Rather than specifying each setting name/value inline, the --file flag option
 may be used to provide a list of settings to be updated as a yaml file. The


### PR DESCRIPTION
In Juju 4 `juju config` seems to no longer support `--branch` but the command help details still showed that: https://github.com/juju/juju/issues/18952#event-16363416626 This PR fixes that.

## Checklist

## QA steps

In `juju/docs`, run `make run` and follow the browser link.

## Documentation changes

This is a documentation change.

## Links

This fixes issue https://github.com/juju/juju/issues/18952#event-16363416626
