### PR TITLE
fix: replicaset update after removing a primary controller in HA

### DIFF
--- a/worker/peergrouper/worker.go
+++ b/worker/peergrouper/worker.go
@@ -657,6 +657,11 @@ func (w *pgWorker) updateReplicaSet() (map[string]*replicaset.Member, error) {
 			m := desired.members[id]
 			ms = append(ms, *m)
 		}
+		// In the case of a replica set change after a primary step
+		// down, the session needs to be refreshed on every other node
+		// in the replica set, so that the socket addresses are updated
+		// to the new primary.
+		w.config.MongoSession.Refresh()
 		if err := w.config.MongoSession.Set(ms); err != nil {
 			return nil, errors.WithType(err, replicaSetError)
 		}


### PR DESCRIPTION
Currently in HA controllers, if the machine corresponding to the mongodb PRIMARY goes down, then the replica set is never correctly updated and therefore the resources are never destroyed correctly.

According to my analysis, this happens because the controller machine that performs the StepDownPrimary does refresh the mongo session, and therefore the session will contain the new conn sockets with the correct addresses, but not the other machines, specially the new PRIMARY. The resulting error is that when the new PRIMARY tries to update the replica set then this mongo error is returned:
```
New config is rejected :: caused by :: replSetReconfig should only be run on a writable PRIMARY. Current state SECONDARY
```

The fix is therefore to refresh the session not only after the primary step down (which will refresh the session for the machine going down) but also for the other machines, just before trying to update the replica set.

<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://github.com/juju/juju/blob/main/doc/conventional-commits.md
-->

<!-- Why this change is needed and what it does. -->

## QA steps

The QA consists of setting up a HA controller, removing the PRIMARY machine and making sure the actual resources get removed as well. I QAd on LXD and AWS, feel free to test on whichever substrate you prefer:

```
$ juju bootstrap lxd c
$ juju enable-ha
```
Wait until the controller reaches a stable state, for this make sure that the mongo replicaset contains the 3 members, on mongo run `rs.status()` or `rs.conf()`.

Once the 3 members are in the replica set, proceed to remove the primary machine (beware that the mongodb primary does not always correspond to the machine running the leader controller unit), which you will find in `rs.status()` and `rs.conf()`.

```
$ juju remove-machine -m controller 0 --force --no-prompt
```
The --force flag is needed when removing controller machines.

After a while, the machine should be correctly removed and you should see on the replica set only 2 members and you should find these two lines on the debug logs:
```
$ juju debug-log  --replay --tail -m controller | grep "successfully updated replica set"
machine-0: 18:44:59 INFO juju.worker.peergrouper successfully updated replica set
machine-1: 18:45:28 INFO juju.worker.peergrouper successfully updated replica set
```

```
$ juju status -m controller
Model       Controller  Cloud/Region         Version  SLA          Timestamp
controller  c           localhost/localhost  3.5.7.1  unsupported  16:50:37+01:00

App         Version  Status  Scale  Charm            Channel     Rev  Exposed  Message
controller           active      2  juju-controller  3.5/stable  105  no

Unit           Workload  Agent  Machine  Public address  Ports  Message
controller/1*  active    idle   1        10.165.241.114
controller/2   active    idle   2        10.165.241.190

Machine  State    Address         Inst id        Base          AZ  Message
1        started  10.165.241.114  juju-4cc55c-1  ubuntu@22.04      Running
2        started  10.165.241.190  juju-4cc55c-2  ubuntu@22.04      Running

```

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/2083536

**Jira card:** JUJU-7589

