### PR TITLE
feat: retrieve unit host keys

### DIFF
--- a/apiserver/facades/client/sshclient/mocks/state_mock.go
+++ b/apiserver/facades/client/sshclient/mocks/state_mock.go
@@ -24,6 +24,7 @@ import (
 type MockBackend struct {
 	ctrl     *gomock.Controller
 	recorder *MockBackendMockRecorder
+	isgomock struct{}
 }
 
 // MockBackendMockRecorder is the mock recorder for MockBackend.
@@ -73,18 +74,18 @@ func (mr *MockBackendMockRecorder) ControllerTag() *gomock.Call {
 }
 
 // GetMachineForEntity mocks base method.
-func (m *MockBackend) GetMachineForEntity(arg0 string) (sshclient.SSHMachine, error) {
+func (m *MockBackend) GetMachineForEntity(tag string) (sshclient.SSHMachine, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMachineForEntity", arg0)
+	ret := m.ctrl.Call(m, "GetMachineForEntity", tag)
 	ret0, _ := ret[0].(sshclient.SSHMachine)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetMachineForEntity indicates an expected call of GetMachineForEntity.
-func (mr *MockBackendMockRecorder) GetMachineForEntity(arg0 any) *gomock.Call {
+func (mr *MockBackendMockRecorder) GetMachineForEntity(tag any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMachineForEntity", reflect.TypeOf((*MockBackend)(nil).GetMachineForEntity), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMachineForEntity", reflect.TypeOf((*MockBackend)(nil).GetMachineForEntity), tag)
 }
 
 // GetSSHHostKeys mocks base method.
@@ -100,6 +101,21 @@ func (m *MockBackend) GetSSHHostKeys(arg0 names.MachineTag) (state.SSHHostKeys, 
 func (mr *MockBackendMockRecorder) GetSSHHostKeys(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSSHHostKeys", reflect.TypeOf((*MockBackend)(nil).GetSSHHostKeys), arg0)
+}
+
+// MachineVirtualHostKeyPEM mocks base method.
+func (m *MockBackend) MachineVirtualHostKeyPEM(machineID int) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MachineVirtualHostKeyPEM", machineID)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// MachineVirtualHostKeyPEM indicates an expected call of MachineVirtualHostKeyPEM.
+func (mr *MockBackendMockRecorder) MachineVirtualHostKeyPEM(machineID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MachineVirtualHostKeyPEM", reflect.TypeOf((*MockBackend)(nil).MachineVirtualHostKeyPEM), machineID)
 }
 
 // Model mocks base method.
@@ -146,10 +162,41 @@ func (mr *MockBackendMockRecorder) ModelTag() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModelTag", reflect.TypeOf((*MockBackend)(nil).ModelTag))
 }
 
+// SSHServerHostKey mocks base method.
+func (m *MockBackend) SSHServerHostKey() (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SSHServerHostKey")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SSHServerHostKey indicates an expected call of SSHServerHostKey.
+func (mr *MockBackendMockRecorder) SSHServerHostKey() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SSHServerHostKey", reflect.TypeOf((*MockBackend)(nil).SSHServerHostKey))
+}
+
+// UnitVirtualHostKeyPEM mocks base method.
+func (m *MockBackend) UnitVirtualHostKeyPEM(unitID string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UnitVirtualHostKeyPEM", unitID)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UnitVirtualHostKeyPEM indicates an expected call of UnitVirtualHostKeyPEM.
+func (mr *MockBackendMockRecorder) UnitVirtualHostKeyPEM(unitID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnitVirtualHostKeyPEM", reflect.TypeOf((*MockBackend)(nil).UnitVirtualHostKeyPEM), unitID)
+}
+
 // MockModel is a mock of Model interface.
 type MockModel struct {
 	ctrl     *gomock.Controller
 	recorder *MockModelMockRecorder
+	isgomock struct{}
 }
 
 // MockModelMockRecorder is the mock recorder for MockModel.
@@ -216,6 +263,7 @@ func (mr *MockModelMockRecorder) Type() *gomock.Call {
 type MockBroker struct {
 	ctrl     *gomock.Controller
 	recorder *MockBrokerMockRecorder
+	isgomock struct{}
 }
 
 // MockBrokerMockRecorder is the mock recorder for MockBroker.
@@ -236,16 +284,16 @@ func (m *MockBroker) EXPECT() *MockBrokerMockRecorder {
 }
 
 // GetSecretToken mocks base method.
-func (m *MockBroker) GetSecretToken(arg0 string) (string, error) {
+func (m *MockBroker) GetSecretToken(name string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetSecretToken", arg0)
+	ret := m.ctrl.Call(m, "GetSecretToken", name)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetSecretToken indicates an expected call of GetSecretToken.
-func (mr *MockBrokerMockRecorder) GetSecretToken(arg0 any) *gomock.Call {
+func (mr *MockBrokerMockRecorder) GetSecretToken(name any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecretToken", reflect.TypeOf((*MockBroker)(nil).GetSecretToken), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecretToken", reflect.TypeOf((*MockBroker)(nil).GetSecretToken), name)
 }

--- a/apiserver/facades/client/sshclient/shim.go
+++ b/apiserver/facades/client/sshclient/shim.go
@@ -23,6 +23,19 @@ type Backend interface {
 	ControllerTag() names.ControllerTag
 	Model() (Model, error)
 	CloudSpec() (environscloudspec.CloudSpec, error)
+
+	// SSHServerHostKey returns the host key for the SSH server.
+	// This key was set during the controller bootstrap process via
+	// bootstrap-state and is currently a FIXED value.
+	SSHServerHostKey() (string, error)
+
+	// UnitVirtualHostKey calls the underlying UnitVirtualHostKey state method
+	// and encodes the result into a PEM string.
+	UnitVirtualHostKeyPEM(unitID string) (string, error)
+
+	// MachineVirtualHostKey calls the underlying MachineVirtualHostKey state method
+	// and encodes the result into a PEM string.
+	MachineVirtualHostKeyPEM(machineID int) (string, error)
 }
 
 // Model defines a point of use interface for the model from state.
@@ -133,4 +146,18 @@ func (b *backend) GetMachineForEntity(tagString string) (SSHMachine, error) {
 	default:
 		return nil, errors.Errorf("unsupported entity: %q", tagString)
 	}
+}
+
+// UnitVirtualHostKey calls the underlying UnitVirtualHostKey state method
+// and encodes the result into a PEM string.
+func (b *backend) UnitVirtualHostKeyPEM(unitID string) (string, error) {
+	// TODO(ale8k): Plug in state method once merged.
+	return "", errors.NotImplementedf("UnitVirtualHostKeyPEM")
+}
+
+// MachineVirtualHostKey calls the underlying MachineVirtualHostKey state method
+// and encodes the result into a PEM string.
+func (b *backend) MachineVirtualHostKeyPEM(machineID int) (string, error) {
+	// TODO(ale8k): Plug in state method once merged.
+	return "", errors.NotImplementedf("MachineVirtualHostKey")
 }

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -14066,6 +14066,17 @@
                         }
                     }
                 },
+                "HostKeyForTarget": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/SSHHostKeyRequestArg"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/SSHHostKeyResult"
+                        }
+                    }
+                },
                 "ModelCredentialForSSH": {
                     "type": "object",
                     "properties": {
@@ -14308,6 +14319,37 @@
                     "additionalProperties": false,
                     "required": [
                         "results"
+                    ]
+                },
+                "SSHHostKeyRequestArg": {
+                    "type": "object",
+                    "properties": {
+                        "hostname": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "hostname"
+                    ]
+                },
+                "SSHHostKeyResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "host-key": {
+                            "type": "string"
+                        },
+                        "jump-server-host-key": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "host-key",
+                        "jump-server-host-key"
                     ]
                 },
                 "SSHProxyResult": {

--- a/rpc/params/ssh.go
+++ b/rpc/params/ssh.go
@@ -58,3 +58,19 @@ type SSHPublicKeysResult struct {
 	Error      *Error   `json:"error,omitempty"`
 	PublicKeys []string `json:"public-keys,omitempty"`
 }
+
+// SSHHostKeyRequestArg provides a hostname to request the hostkey for.
+type SSHHostKeyRequestArg struct {
+	Hostname string `json:"hostname"`
+}
+
+// SSHHostKeyResult returns the host key for the target hostname.
+// Additionally, it returns the controller's SSH jump server's host key.
+//
+// We return the jump server's host key as to SSH to this unit, clients MUST
+// jump through the controller.
+type SSHHostKeyResult struct {
+	Error             *Error `json:"error,omitempty"`
+	HostKey           string `json:"host-key"`
+	JumpServerHostKey string `json:"jump-server-host-key"`
+}


### PR DESCRIPTION
This PR adds a new facade method to ssh client enabling the juju cli to retrieve the hostkey for units and the host key for the server. I haven't plugged in the state methods as they're waiting on #18829. For now, I've added a shim (which will legitimately send them to PEM so it's not completely useless).

From what I could tell the schema needed to be rebuilt and I can see we restrict some facades in certain scenarios, such as upgrading. I don't think this facade needs restricting but I may be wrong.

I'm also unsure versioning, currently SSHClient is at 4 here. Does it need bumping? 

If there's anything else missing please let me know! 


<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://github.com/juju/juju/blob/main/doc/conventional-commits.md
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

<!-- 

Describe steps to verify that the change works. 

If you're changing any of the facades, you need to ensure that you've tested
a model migration from 3.6 to 4.0 and from 4.0 to 4.0.

The following steps are a good starting point:

 1. Bootstrap a 3.6 controller and deploy a charm.

```sh
$ juju bootstrap lxd src36
$ juju add-model moveme1
$ juju deploy juju-qa-test
```

 2. Bootstrap a 4.0 controller with the changes and migrate the model.

```sh
$ juju bootstrap lxd dst40
$ juju migrate src36:moveme1 dst40
$ juju add-unit juju-qa-test
```

 3. Verify no errors exist in the model logs for the agents. If there are
    errors, this is a bug and should be fixed before merging. The fix can
    either be applied to the 4.0 branch (preferable) or the 3.6 branch, though
    that needs to be discussed with the team.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme1
```

    4. We also need to test a model migration from 4.0 to 4.0.

```sh
$ juju bootstrap lxd src40
$ juju add-model moveme2
$ juju deploy juju-qa-test
```

```sh
$ juju migrate src40:moveme2 dst40
$ juju add-unit juju-qa-test
```

    5. Verify that there are no errors in the controller or model logs.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme2
```

-->

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/

**Jira card:** JUJU-7330

