### PR TITLE
chore: rename the cloud_container and cloud_service tables

### DIFF
--- a/domain/application/service_test.go
+++ b/domain/application/service_test.go
@@ -409,8 +409,8 @@ JOIN unit u ON u.net_node_uuid = lld.net_node_uuid WHERE u.name = ?
 			return err
 		}
 		rows, err := tx.QueryContext(ctx, `
-SELECT port FROM cloud_container_port ccp
-JOIN cloud_container cc ON cc.unit_uuid = ccp.unit_uuid
+SELECT port FROM k8s_pod_port ccp
+JOIN k8s_pod cc ON cc.unit_uuid = ccp.unit_uuid
 JOIN unit u ON u.uuid = cc.unit_uuid WHERE u.name = ?
 `, name)
 		if err != nil {

--- a/domain/application/status.go
+++ b/domain/application/status.go
@@ -28,7 +28,7 @@ const (
 )
 
 // CloudContainerStatusType represents the status of a cloud container
-// as recorded in the cloud_container_status_value lookup table.
+// as recorded in the k8s_pod_status_value lookup table.
 type CloudContainerStatusType int
 
 const (

--- a/domain/application/status_test.go
+++ b/domain/application/status_test.go
@@ -21,7 +21,7 @@ var _ = gc.Suite(&statusSuite{})
 // state packages.
 func (s *statusSuite) TestCloudContainerStatusDBValues(c *gc.C) {
 	db := s.DB()
-	rows, err := db.Query("SELECT id, status FROM cloud_container_status_value")
+	rows, err := db.Query("SELECT id, status FROM k8s_pod_status_value")
 	c.Assert(err, jc.ErrorIsNil)
 	defer rows.Close()
 

--- a/domain/schema/model/sql/0019-application.sql
+++ b/domain/schema/model/sql/0019-application.sql
@@ -23,27 +23,27 @@ CREATE TABLE application (
 CREATE UNIQUE INDEX idx_application_name
 ON application (name);
 
-CREATE TABLE cloud_service (
+CREATE TABLE k8s_service (
     uuid TEXT NOT NULL PRIMARY KEY,
     application_uuid TEXT NOT NULL,
     net_node_uuid TEXT NOT NULL,
     provider_id TEXT NOT NULL,
-    CONSTRAINT fk_cloud_service_application
+    CONSTRAINT fk_k8s_service_application
     FOREIGN KEY (application_uuid)
     REFERENCES application (uuid),
-    CONSTRAINT fk_cloud_service_net_node
+    CONSTRAINT fk_k8s_service_net_node
     FOREIGN KEY (net_node_uuid)
     REFERENCES net_node (uuid)
 );
 
-CREATE UNIQUE INDEX idx_cloud_service_provider
-ON cloud_service (provider_id);
+CREATE UNIQUE INDEX idx_k8s_service_provider
+ON k8s_service (provider_id);
 
-CREATE INDEX idx_cloud_service_application
-ON cloud_service (application_uuid);
+CREATE INDEX idx_k8s_service_application
+ON k8s_service (application_uuid);
 
-CREATE UNIQUE INDEX idx_cloud_service_net_node
-ON cloud_service (net_node_uuid);
+CREATE UNIQUE INDEX idx_k8s_service_net_node
+ON k8s_service (net_node_uuid);
 
 -- Application scale is currently only targeting k8s applications.
 CREATE TABLE application_scale (

--- a/domain/schema/model/sql/0020-unit.sql
+++ b/domain/schema/model/sql/0020-unit.sql
@@ -121,25 +121,25 @@ CREATE TABLE unit_state_relation (
 );
 
 -- cloud containers belong to a k8s unit.
-CREATE TABLE cloud_container (
+CREATE TABLE k8s_pod (
     unit_uuid TEXT NOT NULL PRIMARY KEY,
     -- provider_id comes from the provider, no FK.
     -- it represents the k8s pod UID.
     provider_id TEXT NOT NULL,
-    CONSTRAINT fk_cloud_container_unit
+    CONSTRAINT fk_k8s_pod_unit
     FOREIGN KEY (unit_uuid)
     REFERENCES unit (uuid)
 );
 
-CREATE UNIQUE INDEX idx_cloud_container_provider
-ON cloud_container (provider_id);
+CREATE UNIQUE INDEX idx_k8s_pod_provider
+ON k8s_pod (provider_id);
 
-CREATE TABLE cloud_container_port (
+CREATE TABLE k8s_pod_port (
     unit_uuid TEXT NOT NULL,
     port TEXT NOT NULL,
-    CONSTRAINT fk_cloud_container_port_cloud_container
+    CONSTRAINT fk_k8s_pod_port_k8s_pod
     FOREIGN KEY (unit_uuid)
-    REFERENCES cloud_container (unit_uuid),
+    REFERENCES k8s_pod (unit_uuid),
     PRIMARY KEY (unit_uuid, port)
 );
 
@@ -159,12 +159,12 @@ INSERT INTO unit_agent_status_value VALUES
 (6, 'rebooting');
 
 -- Status values for cloud containers.
-CREATE TABLE cloud_container_status_value (
+CREATE TABLE k8s_pod_status_value (
     id INT PRIMARY KEY,
     status TEXT NOT NULL
 );
 
-INSERT INTO cloud_container_status_value VALUES
+INSERT INTO k8s_pod_status_value VALUES
 (0, 'waiting'),
 (1, 'blocked'),
 (2, 'running');
@@ -197,16 +197,16 @@ CREATE TABLE unit_workload_status (
     REFERENCES workload_status_value (id)
 );
 
-CREATE TABLE cloud_container_status (
+CREATE TABLE k8s_pod_status (
     unit_uuid TEXT NOT NULL PRIMARY KEY,
     status_id INT NOT NULL,
     message TEXT,
     data TEXT,
     updated_at DATETIME,
-    CONSTRAINT fk_cloud_container_status_unit
+    CONSTRAINT fk_k8s_pod_status_unit
     FOREIGN KEY (unit_uuid)
     REFERENCES unit (uuid),
-    CONSTRAINT fk_cloud_container_status_status
+    CONSTRAINT fk_k8s_pod_status_status
     FOREIGN KEY (status_id)
-    REFERENCES cloud_container_status_value (id)
+    REFERENCES k8s_pod_status_value (id)
 );

--- a/domain/schema/model_schema_test.go
+++ b/domain/schema/model_schema_test.go
@@ -37,7 +37,7 @@ func (s *modelSchemaSuite) TestModelTables(c *gc.C) {
 		"application_scale",
 		"application_setting",
 		"application_status",
-		"cloud_service",
+		"k8s_service",
 		"workload_status_value",
 
 		// Annotations
@@ -103,10 +103,10 @@ func (s *modelSchemaSuite) TestModelTables(c *gc.C) {
 		"ip_address_dns_server_address",
 
 		// Unit
-		"cloud_container_port",
-		"cloud_container_status_value",
-		"cloud_container_status",
-		"cloud_container",
+		"k8s_pod_port",
+		"k8s_pod_status_value",
+		"k8s_pod_status",
+		"k8s_pod",
 		"unit_agent_status_value",
 		"unit_agent_status",
 		"unit_agent",


### PR DESCRIPTION
This patch renames the cloud_service table to k8s_service, along with all the foreign key names and also renames all the cloud_container* tables to k8s_pod* tables.


## QA steps

Unit tests pass, it's just a table renaming.


## Links

**Jira card:** JUJU-7520

