### PR TITLE
feat(statuses): add domain method to replace UnitStatuses on state

### DIFF
--- a/domain/application/service/package_mock_test.go
+++ b/domain/application/service/package_mock_test.go
@@ -1935,10 +1935,10 @@ func (c *MockStateGetUnitCloudContainerStatusCall) DoAndReturn(f func(context.Co
 }
 
 // GetUnitCloudContainerStatusesForApplication mocks base method.
-func (m *MockState) GetUnitCloudContainerStatusesForApplication(arg0 context.Context, arg1 application.ID) (map[unit.UUID]application0.StatusInfo[application0.CloudContainerStatusType], error) {
+func (m *MockState) GetUnitCloudContainerStatusesForApplication(arg0 context.Context, arg1 application.ID) (map[unit.Name]application0.StatusInfo[application0.CloudContainerStatusType], error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetUnitCloudContainerStatusesForApplication", arg0, arg1)
-	ret0, _ := ret[0].(map[unit.UUID]application0.StatusInfo[application0.CloudContainerStatusType])
+	ret0, _ := ret[0].(map[unit.Name]application0.StatusInfo[application0.CloudContainerStatusType])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -1956,19 +1956,19 @@ type MockStateGetUnitCloudContainerStatusesForApplicationCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockStateGetUnitCloudContainerStatusesForApplicationCall) Return(arg0 map[unit.UUID]application0.StatusInfo[application0.CloudContainerStatusType], arg1 error) *MockStateGetUnitCloudContainerStatusesForApplicationCall {
+func (c *MockStateGetUnitCloudContainerStatusesForApplicationCall) Return(arg0 map[unit.Name]application0.StatusInfo[application0.CloudContainerStatusType], arg1 error) *MockStateGetUnitCloudContainerStatusesForApplicationCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetUnitCloudContainerStatusesForApplicationCall) Do(f func(context.Context, application.ID) (map[unit.UUID]application0.StatusInfo[application0.CloudContainerStatusType], error)) *MockStateGetUnitCloudContainerStatusesForApplicationCall {
+func (c *MockStateGetUnitCloudContainerStatusesForApplicationCall) Do(f func(context.Context, application.ID) (map[unit.Name]application0.StatusInfo[application0.CloudContainerStatusType], error)) *MockStateGetUnitCloudContainerStatusesForApplicationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetUnitCloudContainerStatusesForApplicationCall) DoAndReturn(f func(context.Context, application.ID) (map[unit.UUID]application0.StatusInfo[application0.CloudContainerStatusType], error)) *MockStateGetUnitCloudContainerStatusesForApplicationCall {
+func (c *MockStateGetUnitCloudContainerStatusesForApplicationCall) DoAndReturn(f func(context.Context, application.ID) (map[unit.Name]application0.StatusInfo[application0.CloudContainerStatusType], error)) *MockStateGetUnitCloudContainerStatusesForApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -2091,10 +2091,10 @@ func (c *MockStateGetUnitWorkloadStatusCall) DoAndReturn(f func(context.Context,
 }
 
 // GetUnitWorkloadStatusesForApplication mocks base method.
-func (m *MockState) GetUnitWorkloadStatusesForApplication(arg0 context.Context, arg1 application.ID) (map[unit.UUID]application0.StatusInfo[application0.WorkloadStatusType], error) {
+func (m *MockState) GetUnitWorkloadStatusesForApplication(arg0 context.Context, arg1 application.ID) (map[unit.Name]application0.StatusInfo[application0.WorkloadStatusType], error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetUnitWorkloadStatusesForApplication", arg0, arg1)
-	ret0, _ := ret[0].(map[unit.UUID]application0.StatusInfo[application0.WorkloadStatusType])
+	ret0, _ := ret[0].(map[unit.Name]application0.StatusInfo[application0.WorkloadStatusType])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -2112,19 +2112,19 @@ type MockStateGetUnitWorkloadStatusesForApplicationCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockStateGetUnitWorkloadStatusesForApplicationCall) Return(arg0 map[unit.UUID]application0.StatusInfo[application0.WorkloadStatusType], arg1 error) *MockStateGetUnitWorkloadStatusesForApplicationCall {
+func (c *MockStateGetUnitWorkloadStatusesForApplicationCall) Return(arg0 map[unit.Name]application0.StatusInfo[application0.WorkloadStatusType], arg1 error) *MockStateGetUnitWorkloadStatusesForApplicationCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetUnitWorkloadStatusesForApplicationCall) Do(f func(context.Context, application.ID) (map[unit.UUID]application0.StatusInfo[application0.WorkloadStatusType], error)) *MockStateGetUnitWorkloadStatusesForApplicationCall {
+func (c *MockStateGetUnitWorkloadStatusesForApplicationCall) Do(f func(context.Context, application.ID) (map[unit.Name]application0.StatusInfo[application0.WorkloadStatusType], error)) *MockStateGetUnitWorkloadStatusesForApplicationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetUnitWorkloadStatusesForApplicationCall) DoAndReturn(f func(context.Context, application.ID) (map[unit.UUID]application0.StatusInfo[application0.WorkloadStatusType], error)) *MockStateGetUnitWorkloadStatusesForApplicationCall {
+func (c *MockStateGetUnitWorkloadStatusesForApplicationCall) DoAndReturn(f func(context.Context, application.ID) (map[unit.Name]application0.StatusInfo[application0.WorkloadStatusType], error)) *MockStateGetUnitWorkloadStatusesForApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/application/service/status.go
+++ b/domain/application/service/status.go
@@ -326,8 +326,8 @@ func unitDisplayStatus(
 // applicationDisplayStatusFromUnits returns the status to display for an application
 // based on both the workload and container statuses of its units.
 func applicationDisplayStatusFromUnits(
-	workloadStatus map[coreunit.UUID]application.StatusInfo[application.WorkloadStatusType],
-	containerStatus map[coreunit.UUID]application.StatusInfo[application.CloudContainerStatusType],
+	workloadStatus map[coreunit.Name]application.StatusInfo[application.WorkloadStatusType],
+	containerStatus map[coreunit.Name]application.StatusInfo[application.CloudContainerStatusType],
 ) (*status.StatusInfo, error) {
 	results := make([]*status.StatusInfo, 0, len(workloadStatus))
 

--- a/domain/application/service/status_test.go
+++ b/domain/application/service/status_test.go
@@ -365,15 +365,15 @@ func (s *statusSuite) TestUnitDisplayStatusDefaultsToWorkload(c *gc.C) {
 }
 
 const (
-	unitUUID1 = coreunit.UUID("unit-1")
-	unitUUID2 = coreunit.UUID("unit-2")
-	unitUUID3 = coreunit.UUID("unit-3")
+	unitName1 = coreunit.Name("unit-1")
+	unitName2 = coreunit.Name("unit-2")
+	unitName3 = coreunit.Name("unit-3")
 )
 
 func (s *statusSuite) TestApplicationDisplayStatusFromUnitsNoContainers(c *gc.C) {
-	workloadStatuses := map[coreunit.UUID]application.StatusInfo[application.WorkloadStatusType]{
-		unitUUID1: {Status: application.WorkloadStatusActive},
-		unitUUID2: {Status: application.WorkloadStatusActive},
+	workloadStatuses := map[coreunit.Name]application.StatusInfo[application.WorkloadStatusType]{
+		unitName1: {Status: application.WorkloadStatusActive},
+		unitName2: {Status: application.WorkloadStatusActive},
 	}
 
 	info, err := applicationDisplayStatusFromUnits(workloadStatuses, nil)
@@ -384,7 +384,7 @@ func (s *statusSuite) TestApplicationDisplayStatusFromUnitsNoContainers(c *gc.C)
 
 	info, err = applicationDisplayStatusFromUnits(
 		workloadStatuses,
-		make(map[coreunit.UUID]application.StatusInfo[application.CloudContainerStatusType]),
+		make(map[coreunit.Name]application.StatusInfo[application.CloudContainerStatusType]),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info, jc.DeepEquals, &status.StatusInfo{
@@ -400,8 +400,8 @@ func (s *statusSuite) TestApplicationDisplayStatusFromUnitsEmpty(c *gc.C) {
 	})
 
 	info, err = applicationDisplayStatusFromUnits(
-		map[coreunit.UUID]application.StatusInfo[application.WorkloadStatusType]{},
-		map[coreunit.UUID]application.StatusInfo[application.CloudContainerStatusType]{},
+		map[coreunit.Name]application.StatusInfo[application.WorkloadStatusType]{},
+		map[coreunit.Name]application.StatusInfo[application.CloudContainerStatusType]{},
 	)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(info, jc.DeepEquals, &status.StatusInfo{
@@ -410,14 +410,14 @@ func (s *statusSuite) TestApplicationDisplayStatusFromUnitsEmpty(c *gc.C) {
 }
 
 func (s *statusSuite) TestApplicationDisplayStatusFromUnitsPicksGreatestPrecedenceContainer(c *gc.C) {
-	workloadStatuses := map[coreunit.UUID]application.StatusInfo[application.WorkloadStatusType]{
-		unitUUID1: {Status: application.WorkloadStatusActive},
-		unitUUID2: {Status: application.WorkloadStatusActive},
+	workloadStatuses := map[coreunit.Name]application.StatusInfo[application.WorkloadStatusType]{
+		unitName1: {Status: application.WorkloadStatusActive},
+		unitName2: {Status: application.WorkloadStatusActive},
 	}
 
-	containerStatuses := map[coreunit.UUID]application.StatusInfo[application.CloudContainerStatusType]{
-		unitUUID1: {Status: application.CloudContainerStatusRunning},
-		unitUUID2: {Status: application.CloudContainerStatusBlocked},
+	containerStatuses := map[coreunit.Name]application.StatusInfo[application.CloudContainerStatusType]{
+		unitName1: {Status: application.CloudContainerStatusRunning},
+		unitName2: {Status: application.CloudContainerStatusBlocked},
 	}
 
 	info, err := applicationDisplayStatusFromUnits(workloadStatuses, containerStatuses)
@@ -428,14 +428,14 @@ func (s *statusSuite) TestApplicationDisplayStatusFromUnitsPicksGreatestPreceden
 }
 
 func (s *statusSuite) TestApplicationDisplayStatusFromUnitsPicksGreatestPrecedenceWorkload(c *gc.C) {
-	workloadStatuses := map[coreunit.UUID]application.StatusInfo[application.WorkloadStatusType]{
-		unitUUID1: {Status: application.WorkloadStatusActive},
-		unitUUID2: {Status: application.WorkloadStatusMaintenance},
+	workloadStatuses := map[coreunit.Name]application.StatusInfo[application.WorkloadStatusType]{
+		unitName1: {Status: application.WorkloadStatusActive},
+		unitName2: {Status: application.WorkloadStatusMaintenance},
 	}
 
-	containerStatuses := map[coreunit.UUID]application.StatusInfo[application.CloudContainerStatusType]{
-		unitUUID1: {Status: application.CloudContainerStatusRunning},
-		unitUUID2: {Status: application.CloudContainerStatusBlocked},
+	containerStatuses := map[coreunit.Name]application.StatusInfo[application.CloudContainerStatusType]{
+		unitName1: {Status: application.CloudContainerStatusRunning},
+		unitName2: {Status: application.CloudContainerStatusBlocked},
 	}
 
 	info, err := applicationDisplayStatusFromUnits(workloadStatuses, containerStatuses)
@@ -446,14 +446,14 @@ func (s *statusSuite) TestApplicationDisplayStatusFromUnitsPicksGreatestPreceden
 }
 
 func (s *statusSuite) TestApplicationDisplayStatusFromUnitsPrioritisesUnitWithGreatestStatusPrecedence(c *gc.C) {
-	workloadStatuses := map[coreunit.UUID]application.StatusInfo[application.WorkloadStatusType]{
-		unitUUID1: {Status: application.WorkloadStatusActive},
-		unitUUID2: {Status: application.WorkloadStatusMaintenance},
+	workloadStatuses := map[coreunit.Name]application.StatusInfo[application.WorkloadStatusType]{
+		unitName1: {Status: application.WorkloadStatusActive},
+		unitName2: {Status: application.WorkloadStatusMaintenance},
 	}
 
-	containerStatuses := map[coreunit.UUID]application.StatusInfo[application.CloudContainerStatusType]{
-		unitUUID1: {Status: application.CloudContainerStatusBlocked},
-		unitUUID2: {Status: application.CloudContainerStatusRunning},
+	containerStatuses := map[coreunit.Name]application.StatusInfo[application.CloudContainerStatusType]{
+		unitName1: {Status: application.CloudContainerStatusBlocked},
+		unitName2: {Status: application.CloudContainerStatusRunning},
 	}
 
 	info, err := applicationDisplayStatusFromUnits(workloadStatuses, containerStatuses)

--- a/domain/application/state/application_test.go
+++ b/domain/application/state/application_test.go
@@ -1764,7 +1764,7 @@ func (s *applicationStateSuite) TestGetUnitWorkloadStatusesForApplication(c *gc.
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(results, gc.HasLen, 1)
-	result, ok := results[unitUUID]
+	result, ok := results["foo/666"]
 	c.Assert(ok, jc.IsTrue)
 	assertStatusInfoEqual(c, &result, status)
 }
@@ -1805,11 +1805,11 @@ func (s *applicationStateSuite) TestGetUnitWorkloadStatusesForApplicationMultipl
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(results, gc.HasLen, 2)
 
-	result1, ok := results[unitUUID1]
+	result1, ok := results["foo/666"]
 	c.Assert(ok, jc.IsTrue)
 	assertStatusInfoEqual(c, &result1, status1)
 
-	result2, ok := results[unitUUID2]
+	result2, ok := results["foo/667"]
 	c.Assert(ok, jc.IsTrue)
 	assertStatusInfoEqual(c, &result2, status2)
 }


### PR DESCRIPTION
This method used to return the statuses for all the units on a particular application.

Fortunately, we already have a state method which does exactly that!

However, it needed to be modified slightly, since the api indexed statuses by unit name, whereas our state method did so via unit UUIDs. Patch this method to follow suit

Here is the method I'm intending to replace:
https://github.com/juju/juju/blob/40bbe7a40344bb23737d69291789be642241d58a/state/application.go#L2907-L2953 

## QA steps

Not wired up yet, so passing unit tests