### PR TITLE
fix(docs): mark `virt-type` as supported constraint for lxd

### DIFF
--- a/docs/user/reference/cloud/list-of-supported-clouds/the-lxd-cloud-and-juju.md
+++ b/docs/user/reference/cloud/list-of-supported-clouds/the-lxd-cloud-and-juju.md
@@ -102,7 +102,7 @@ With LXD system containers, constraints are interpreted as resource *maximums* (
 | - {ref}`constraint-root-disk-source`   | &#10003;  <br> `root-disk-source` is the LXD storage pool for the root disk. The default LXD storage pool is used if root-disk-source is not specified. |
 | - {ref}`constraint-spaces`             | &#10005;                                                                                                                                                |
 | - {ref}`constraint-tags`               | &#10005;                                                                                                                                                |
-| - {ref}`constraint-virt-type`          | &#10005;                                                                                                                                                |
+| - {ref}`constraint-virt-type`          | &#10003;                                                                                                                                                |
 | - {ref}`constraint-zones`              | &#10005;                                                                                                                                                |
 	
 


### PR DESCRIPTION
This change to the documentation is required because recent versions of Juju support requesting both virtual machines and containers in LXD clouds. 

For example, in HPC we use the constraint  `virt-type=virtual-machine` to deploy Slurm to LXD virtual machines rather than containers since containers don't allow certain Slurm functionality:

- https://canonical-charmed-hpc.readthedocs-hosted.com/en/latest/howto/setup/deploy-slurm/#deploying-slurm-on-lxd

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] ~~Code style: imports ordered, good names, simple structure, etc~~
- [ ] ~~Comments saying why design decisions were made~~
- [ ] ~~Go unit tests, with comments saying what you're testing~~
- [ ]  ~~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~~
- [ ] ~~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~~

## Documentation changes

Updated `virt-type` row on the LXD cloud page to be a checkmark rather than an X.

## Links

Related Juju documentation page: https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/cloud/list-of-supported-clouds/the-lxd-cloud-and-juju/#cloud-lxd

