### PR TITLE
fix(shallow-copy-addrs): fix shallow copy before shuffle

### DIFF
--- a/api/apiclient.go
+++ b/api/apiclient.go
@@ -498,8 +498,8 @@ func dialAPI(ctx context.Context, info *Info, opts0 DialOpts) (*dialResult, erro
 	if len(info.Addrs) == 0 {
 		return nil, errors.New("no API addresses to connect to")
 	}
-
-	addrs := info.Addrs[:]
+	addrs := make([]string, len(info.Addrs))
+	copy(addrs, info.Addrs)
 
 	if info.Proxier != nil {
 		if err := info.Proxier.Start(); err != nil {


### PR DESCRIPTION
Before we were making a shallow copy of `addrs`, causing some race conditions. Now we copy the addrs to a new allocated slice.

Small reproducer: https://go.dev/play/p/l6Wadug0Mgc

This bug was discovered because terraform users were filing issues regarding dial timeouts. After some inspection we found the addr were shallow copied, causing some race conditions where the dial could try two times the same "unreachable" address.

ex. https://github.com/juju/terraform-provider-juju/issues/657

> This is already been fixed in 3.6.3 because the code has changed as part of another refactor.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

- remove the diff from `apiclient.go` and run the provided test. You should see a "dial timeout" error.


