### PR TITLE
feat(status): cut over ModelPresenceContext to use domain

### DIFF
--- a/apiserver/common/presence_test.go
+++ b/apiserver/common/presence_test.go
@@ -182,155 +182,144 @@ var _ = gc.Suite(&UnitStatusSuite{})
 func (s *UnitStatusSuite) SetUpTest(c *gc.C) {
 	c.Skip("skipping factory based tests. TODO: Re-write without factories")
 	s.unit = &fakeStatusUnit{
-		app: "foo",
-		agentStatus: status.StatusInfo{
-			Status:  status.Started,
-			Message: "agent ok",
-		},
-		status: status.StatusInfo{
-			Status:  status.Idle,
-			Message: "unit ok",
-		},
-		presence:         true,
-		shouldBeAssigned: true,
+		app:      "foo",
+		presence: true,
 	}
 	s.ctx = common.ModelPresenceContext{
 		Presence: agentAlive(names.NewUnitTag(s.unit.Name()).String()),
 	}
 }
 
-func (s *UnitStatusSuite) checkUntouched(c *gc.C) {
-	agent, workload := s.ctx.UnitStatus(context.Background(), s.unit)
-	c.Check(agent.Status, jc.DeepEquals, s.unit.agentStatus)
-	c.Check(agent.Err, jc.ErrorIsNil)
-	c.Check(workload.Status, jc.DeepEquals, s.unit.status)
-	c.Check(workload.Err, jc.ErrorIsNil)
+var (
+	agentStatus = status.StatusInfo{
+		Status:  status.Started,
+		Message: "agent ok",
+	}
+	workloadStatus = status.StatusInfo{
+		Status:  status.Idle,
+		Message: "unit ok",
+	}
+)
+
+func (s *UnitStatusSuite) checkUntouched(c *gc.C, agentStatus, workloadStatus status.StatusInfo) {
+	agent, workload := s.ctx.UnitStatus(context.Background(), s.unit, agentStatus, workloadStatus)
+	c.Check(agent, jc.DeepEquals, agentStatus)
+	c.Check(workload, jc.DeepEquals, workloadStatus)
 }
 
-func (s *UnitStatusSuite) checkLost(c *gc.C) {
-	agent, workload := s.ctx.UnitStatus(context.Background(), s.unit)
-	c.Check(agent.Status, jc.DeepEquals, status.StatusInfo{
+func (s *UnitStatusSuite) checkLost(c *gc.C, agentStatus, workloadStatus status.StatusInfo) {
+	agent, workload := s.ctx.UnitStatus(context.Background(), s.unit, agentStatus, workloadStatus)
+	c.Check(agent, jc.DeepEquals, status.StatusInfo{
 		Status:  status.Lost,
 		Message: "agent is not communicating with the server",
 	})
-	c.Check(agent.Err, jc.ErrorIsNil)
-	c.Check(workload.Status, jc.DeepEquals, status.StatusInfo{
+	c.Check(workload, jc.DeepEquals, status.StatusInfo{
 		Status:  status.Unknown,
 		Message: "agent lost, see 'juju show-status-log foo/2'",
 	})
-	c.Check(workload.Err, jc.ErrorIsNil)
 }
 
 func (s *UnitStatusSuite) TestNormal(c *gc.C) {
-	s.checkUntouched(c)
+	s.checkUntouched(c, agentStatus, workloadStatus)
 }
 
 func (s *UnitStatusSuite) TestCAASNormal(c *gc.C) {
-	s.unit.shouldBeAssigned = false
 	s.ctx.Presence = agentAlive(names.NewApplicationTag(s.unit.app).String())
-	s.checkUntouched(c)
-}
-
-func (s *UnitStatusSuite) TestErrors(c *gc.C) {
-	s.unit.agentStatusErr = errors.New("agent status error")
-	s.unit.statusErr = errors.New("status error")
-
-	agent, workload := s.ctx.UnitStatus(context.Background(), s.unit)
-	c.Check(agent.Err, gc.ErrorMatches, "agent status error")
-	c.Check(workload.Err, gc.ErrorMatches, "status error")
+	s.checkUntouched(c, agentStatus, workloadStatus)
 }
 
 func (s *UnitStatusSuite) TestLost(c *gc.C) {
 	s.ctx.Presence = agentDown(s.unit.Tag().String())
-	s.checkLost(c)
+	s.checkLost(c, agentStatus, workloadStatus)
 }
 
 func (s *UnitStatusSuite) TestCAASLost(c *gc.C) {
-	s.unit.shouldBeAssigned = false
 	s.ctx.Presence = agentDown(names.NewApplicationTag(s.unit.app).String())
-	s.checkLost(c)
+	s.checkLost(c, agentStatus, workloadStatus)
 }
 
 func (s *UnitStatusSuite) TestLostTerminated(c *gc.C) {
-	s.unit.status.Status = status.Terminated
-	s.unit.status.Message = ""
+	workloadStatus := status.StatusInfo{
+		Status:  status.Terminated,
+		Message: "",
+	}
 
 	s.ctx.Presence = agentDown(s.unit.Tag().String())
 
-	agent, workload := s.ctx.UnitStatus(context.Background(), s.unit)
+	agent, workload := s.ctx.UnitStatus(context.Background(), s.unit, agentStatus, workloadStatus)
 	c.Check(agent.Status, jc.DeepEquals, status.StatusInfo{
 		Status:  status.Lost,
 		Message: "agent is not communicating with the server",
 	})
-	c.Check(agent.Err, jc.ErrorIsNil)
 	c.Check(workload.Status, jc.DeepEquals, status.StatusInfo{
 		Status:  status.Terminated,
 		Message: "",
 	})
-	c.Check(workload.Err, jc.ErrorIsNil)
 }
 
 func (s *UnitStatusSuite) TestCAASLostTerminated(c *gc.C) {
-	s.unit.shouldBeAssigned = false
-	s.unit.status.Status = status.Terminated
-	s.unit.status.Message = ""
+	wokloadStatus := status.StatusInfo{
+		Status:  status.Terminated,
+		Message: "",
+	}
 
 	s.ctx.Presence = agentDown(names.NewApplicationTag(s.unit.app).String())
 
-	agent, workload := s.ctx.UnitStatus(context.Background(), s.unit)
+	agent, workload := s.ctx.UnitStatus(context.Background(), s.unit, agentStatus, wokloadStatus)
 	c.Check(agent.Status, jc.DeepEquals, status.StatusInfo{
 		Status:  status.Lost,
 		Message: "agent is not communicating with the server",
 	})
-	c.Check(agent.Err, jc.ErrorIsNil)
 	c.Check(workload.Status, jc.DeepEquals, status.StatusInfo{
 		Status:  status.Terminated,
 		Message: "",
 	})
-	c.Check(workload.Err, jc.ErrorIsNil)
 }
+
 func (s *UnitStatusSuite) TestLostAndDead(c *gc.C) {
 	s.ctx.Presence = agentDown(s.unit.Tag().String())
 	s.unit.life = state.Dead
 	// Status is untouched if unit is Dead.
-	s.checkUntouched(c)
+	s.checkUntouched(c, agentStatus, workloadStatus)
 }
 
 func (s *UnitStatusSuite) TestPresenceError(c *gc.C) {
 	s.ctx.Presence = presenceError(s.unit.Tag().String())
 	// Presence error gets ignored, so no output is unchanged.
-	s.checkUntouched(c)
+	s.checkUntouched(c, agentStatus, workloadStatus)
 }
 
 func (s *UnitStatusSuite) TestNotLostIfAllocating(c *gc.C) {
 	s.ctx.Presence = agentDown(s.unit.Tag().String())
-	s.unit.agentStatus.Status = status.Allocating
-	s.checkUntouched(c)
+	agentStatus := status.StatusInfo{
+		Status:  status.Allocating,
+		Message: "allocating",
+	}
+	s.checkUntouched(c, agentStatus, workloadStatus)
 }
 
 func (s *UnitStatusSuite) TestCantBeLostDuringInstall(c *gc.C) {
 	s.ctx.Presence = agentDown(s.unit.Tag().String())
-	s.unit.agentStatus.Status = status.Executing
-	s.unit.agentStatus.Message = "running install hook"
-	s.checkUntouched(c)
+	agentStatus := status.StatusInfo{
+		Status:  status.Executing,
+		Message: "running install hook",
+	}
+	s.checkUntouched(c, agentStatus, workloadStatus)
 }
 
 func (s *UnitStatusSuite) TestCantBeLostDuringWorkloadInstall(c *gc.C) {
 	s.ctx.Presence = agentDown(s.unit.Tag().String())
-	s.unit.status.Status = status.Maintenance
-	s.unit.status.Message = "installing charm software"
-	s.checkUntouched(c)
+	workloadStatus := status.StatusInfo{
+		Status:  status.Maintenance,
+		Message: "installing charm software",
+	}
+	s.checkUntouched(c, agentStatus, workloadStatus)
 }
 
 type fakeStatusUnit struct {
-	app              string
-	agentStatus      status.StatusInfo
-	agentStatusErr   error
-	status           status.StatusInfo
-	statusErr        error
-	presence         bool
-	life             state.Life
-	shouldBeAssigned bool
+	app      string
+	presence bool
+	life     state.Life
 }
 
 func (u *fakeStatusUnit) Name() string {
@@ -341,22 +330,6 @@ func (u *fakeStatusUnit) Tag() names.Tag {
 	return names.NewUnitTag(u.Name())
 }
 
-func (u *fakeStatusUnit) AgentStatus() (status.StatusInfo, error) {
-	return u.agentStatus, u.agentStatusErr
-}
-
-func (u *fakeStatusUnit) Status() (status.StatusInfo, error) {
-	return u.status, u.statusErr
-}
-
 func (u *fakeStatusUnit) Life() state.Life {
 	return u.life
-}
-
-func (u *fakeStatusUnit) ShouldBeAssigned() bool {
-	return u.shouldBeAssigned
-}
-
-func (u *fakeStatusUnit) IsSidecar() (bool, error) {
-	return false, nil
 }

--- a/apiserver/facades/client/client/service.go
+++ b/apiserver/facades/client/client/service.go
@@ -84,6 +84,12 @@ type ApplicationService interface {
 	// If no application is found, an error satisfying [applicationerrors.ApplicationNotFound]
 	// is returned.
 	GetApplicationDisplayStatus(context.Context, application.ID) (*status.StatusInfo, error)
+
+	// GetUnitDisplayStatus returns the display status of the specified unit. The display
+	// status a function of both the unit workload status and the cloud container status.
+	// It returns an error satisfying [applicationerrors.UnitNotFound] if the unit doesn't
+	// exist.
+	GetUnitDisplayStatus(context.Context, unit.Name) (*status.StatusInfo, error)
 }
 
 // PortService defines the methods that the facade assumes from the Port

--- a/apiserver/facades/client/controller/service.go
+++ b/apiserver/facades/client/controller/service.go
@@ -17,6 +17,8 @@ import (
 	"github.com/juju/juju/core/machine"
 	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/permission"
+	"github.com/juju/juju/core/status"
+	"github.com/juju/juju/core/unit"
 	"github.com/juju/juju/core/user"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/domain/access"
@@ -95,6 +97,8 @@ type ModelInfoService interface {
 type ApplicationService interface {
 	// GetApplicationLife returns the life value of the application with the given name.
 	GetApplicationLife(ctx context.Context, name string) (life.Value, error)
+	// GetUnitWorkloadStatus returns the workload status of the specified unit.
+	GetUnitWorkloadStatus(context.Context, unit.Name) (*status.StatusInfo, error)
 }
 
 // ProxyService provides access to the proxy service.

--- a/apiserver/facades/controller/migrationmaster/mocks/backend.go
+++ b/apiserver/facades/controller/migrationmaster/mocks/backend.go
@@ -21,6 +21,8 @@ import (
 	model "github.com/juju/juju/core/model"
 	network "github.com/juju/juju/core/network"
 	objectstore "github.com/juju/juju/core/objectstore"
+	status "github.com/juju/juju/core/status"
+	unit "github.com/juju/juju/core/unit"
 	config "github.com/juju/juju/environs/config"
 	state "github.com/juju/juju/state"
 	version "github.com/juju/version/v2"
@@ -836,6 +838,45 @@ func (c *MockApplicationServiceGetApplicationLifeCall) Do(f func(context.Context
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockApplicationServiceGetApplicationLifeCall) DoAndReturn(f func(context.Context, string) (life.Value, error)) *MockApplicationServiceGetApplicationLifeCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetUnitWorkloadStatus mocks base method.
+func (m *MockApplicationService) GetUnitWorkloadStatus(arg0 context.Context, arg1 unit.Name) (*status.StatusInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUnitWorkloadStatus", arg0, arg1)
+	ret0, _ := ret[0].(*status.StatusInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUnitWorkloadStatus indicates an expected call of GetUnitWorkloadStatus.
+func (mr *MockApplicationServiceMockRecorder) GetUnitWorkloadStatus(arg0, arg1 any) *MockApplicationServiceGetUnitWorkloadStatusCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnitWorkloadStatus", reflect.TypeOf((*MockApplicationService)(nil).GetUnitWorkloadStatus), arg0, arg1)
+	return &MockApplicationServiceGetUnitWorkloadStatusCall{Call: call}
+}
+
+// MockApplicationServiceGetUnitWorkloadStatusCall wrap *gomock.Call
+type MockApplicationServiceGetUnitWorkloadStatusCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockApplicationServiceGetUnitWorkloadStatusCall) Return(arg0 *status.StatusInfo, arg1 error) *MockApplicationServiceGetUnitWorkloadStatusCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockApplicationServiceGetUnitWorkloadStatusCall) Do(f func(context.Context, unit.Name) (*status.StatusInfo, error)) *MockApplicationServiceGetUnitWorkloadStatusCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockApplicationServiceGetUnitWorkloadStatusCall) DoAndReturn(f func(context.Context, unit.Name) (*status.StatusInfo, error)) *MockApplicationServiceGetUnitWorkloadStatusCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/controller/migrationmaster/service.go
+++ b/apiserver/facades/controller/migrationmaster/service.go
@@ -13,6 +13,8 @@ import (
 	"github.com/juju/juju/core/credential"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/model"
+	"github.com/juju/juju/core/status"
+	"github.com/juju/juju/core/unit"
 	"github.com/juju/juju/environs/config"
 )
 
@@ -49,7 +51,10 @@ type ModelService interface {
 
 // ApplicationService provides access to the application service.
 type ApplicationService interface {
-	GetApplicationLife(context.Context, string) (life.Value, error)
+	// GetApplicationLife returns the life value of the application with the given name.
+	GetApplicationLife(ctx context.Context, name string) (life.Value, error)
+	// GetUnitWorkloadStatus returns the workload status of the specified unit.
+	GetUnitWorkloadStatus(context.Context, unit.Name) (*status.StatusInfo, error)
 }
 
 // ModelAgentService provides access to the Juju agent version for the model.

--- a/apiserver/facades/controller/migrationtarget/domain_mock_test.go
+++ b/apiserver/facades/controller/migrationtarget/domain_mock_test.go
@@ -16,6 +16,8 @@ import (
 	controller "github.com/juju/juju/controller"
 	crossmodel "github.com/juju/juju/core/crossmodel"
 	life "github.com/juju/juju/core/life"
+	status "github.com/juju/juju/core/status"
+	unit "github.com/juju/juju/core/unit"
 	modelmigration "github.com/juju/juju/domain/modelmigration"
 	state "github.com/juju/juju/state"
 	version "github.com/juju/version/v2"
@@ -467,6 +469,45 @@ func (c *MockApplicationServiceGetApplicationLifeCall) Do(f func(context.Context
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockApplicationServiceGetApplicationLifeCall) DoAndReturn(f func(context.Context, string) (life.Value, error)) *MockApplicationServiceGetApplicationLifeCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetUnitWorkloadStatus mocks base method.
+func (m *MockApplicationService) GetUnitWorkloadStatus(arg0 context.Context, arg1 unit.Name) (*status.StatusInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUnitWorkloadStatus", arg0, arg1)
+	ret0, _ := ret[0].(*status.StatusInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUnitWorkloadStatus indicates an expected call of GetUnitWorkloadStatus.
+func (mr *MockApplicationServiceMockRecorder) GetUnitWorkloadStatus(arg0, arg1 any) *MockApplicationServiceGetUnitWorkloadStatusCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnitWorkloadStatus", reflect.TypeOf((*MockApplicationService)(nil).GetUnitWorkloadStatus), arg0, arg1)
+	return &MockApplicationServiceGetUnitWorkloadStatusCall{Call: call}
+}
+
+// MockApplicationServiceGetUnitWorkloadStatusCall wrap *gomock.Call
+type MockApplicationServiceGetUnitWorkloadStatusCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockApplicationServiceGetUnitWorkloadStatusCall) Return(arg0 *status.StatusInfo, arg1 error) *MockApplicationServiceGetUnitWorkloadStatusCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockApplicationServiceGetUnitWorkloadStatusCall) Do(f func(context.Context, unit.Name) (*status.StatusInfo, error)) *MockApplicationServiceGetUnitWorkloadStatusCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockApplicationServiceGetUnitWorkloadStatusCall) DoAndReturn(f func(context.Context, unit.Name) (*status.StatusInfo, error)) *MockApplicationServiceGetUnitWorkloadStatusCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/controller/migrationtarget/migrationtarget.go
+++ b/apiserver/facades/controller/migrationtarget/migrationtarget.go
@@ -26,6 +26,8 @@ import (
 	coremigration "github.com/juju/juju/core/migration"
 	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/permission"
+	"github.com/juju/juju/core/status"
+	"github.com/juju/juju/core/unit"
 	"github.com/juju/juju/domain/modelmigration"
 	"github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/internal/migration"
@@ -61,7 +63,10 @@ type ControllerConfigService interface {
 
 // ApplicationService provides access to the application service.
 type ApplicationService interface {
-	GetApplicationLife(context.Context, string) (life.Value, error)
+	// GetApplicationLife returns the life value of the application with the given name.
+	GetApplicationLife(ctx context.Context, name string) (life.Value, error)
+	// GetUnitWorkloadStatus returns the workload status of the specified unit.
+	GetUnitWorkloadStatus(context.Context, unit.Name) (*status.StatusInfo, error)
 }
 
 // ModelManagerService describes the method needed to update model metadata.

--- a/internal/migration/interface.go
+++ b/internal/migration/interface.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/presence"
 	"github.com/juju/juju/core/status"
+	"github.com/juju/juju/core/unit"
 	environscloudspec "github.com/juju/juju/environs/cloudspec"
 	"github.com/juju/juju/internal/relation"
 	"github.com/juju/juju/internal/tools"
@@ -49,7 +50,15 @@ type UpgradeService interface {
 
 // ApplicationService provides access to the application service.
 type ApplicationService interface {
+	// GetApplicationLife looks up the life of the specified application, returning
+	// an error satisfying [applicationerrors.ApplicationNotFoundError] if the
+	// application is not found.
 	GetApplicationLife(context.Context, string) (life.Value, error)
+
+	// GetUnitWorkloadStatus returns the workload status of the specified unit,
+	// returning an error satisfying [applicationerrors.UnitNotFound] if the unit
+	// doesn't exist.
+	GetUnitWorkloadStatus(context.Context, unit.Name) (*status.StatusInfo, error)
 }
 
 // ControllerConfigService describes the method needed to get the

--- a/internal/migration/migration_mock_test.go
+++ b/internal/migration/migration_mock_test.go
@@ -18,7 +18,9 @@ import (
 	controller "github.com/juju/juju/controller"
 	life "github.com/juju/juju/core/life"
 	modelmigration "github.com/juju/juju/core/modelmigration"
+	status "github.com/juju/juju/core/status"
 	storage "github.com/juju/juju/core/storage"
+	unit "github.com/juju/juju/core/unit"
 	charm "github.com/juju/juju/domain/application/charm"
 	version "github.com/juju/version/v2"
 	gomock "go.uber.org/mock/gomock"
@@ -206,6 +208,45 @@ func (c *MockApplicationServiceGetApplicationLifeCall) Do(f func(context.Context
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockApplicationServiceGetApplicationLifeCall) DoAndReturn(f func(context.Context, string) (life.Value, error)) *MockApplicationServiceGetApplicationLifeCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetUnitWorkloadStatus mocks base method.
+func (m *MockApplicationService) GetUnitWorkloadStatus(arg0 context.Context, arg1 unit.Name) (*status.StatusInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUnitWorkloadStatus", arg0, arg1)
+	ret0, _ := ret[0].(*status.StatusInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUnitWorkloadStatus indicates an expected call of GetUnitWorkloadStatus.
+func (mr *MockApplicationServiceMockRecorder) GetUnitWorkloadStatus(arg0, arg1 any) *MockApplicationServiceGetUnitWorkloadStatusCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnitWorkloadStatus", reflect.TypeOf((*MockApplicationService)(nil).GetUnitWorkloadStatus), arg0, arg1)
+	return &MockApplicationServiceGetUnitWorkloadStatusCall{Call: call}
+}
+
+// MockApplicationServiceGetUnitWorkloadStatusCall wrap *gomock.Call
+type MockApplicationServiceGetUnitWorkloadStatusCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockApplicationServiceGetUnitWorkloadStatusCall) Return(arg0 *status.StatusInfo, arg1 error) *MockApplicationServiceGetUnitWorkloadStatusCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockApplicationServiceGetUnitWorkloadStatusCall) Do(f func(context.Context, unit.Name) (*status.StatusInfo, error)) *MockApplicationServiceGetUnitWorkloadStatusCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockApplicationServiceGetUnitWorkloadStatusCall) DoAndReturn(f func(context.Context, unit.Name) (*status.StatusInfo, error)) *MockApplicationServiceGetUnitWorkloadStatusCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/migration/package_test.go
+++ b/internal/migration/package_test.go
@@ -11,6 +11,8 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/life"
+	"github.com/juju/juju/core/status"
+	coreunit "github.com/juju/juju/core/unit"
 	"github.com/juju/juju/internal/migration"
 	"github.com/juju/juju/internal/testing"
 	upgradevalidationmocks "github.com/juju/juju/internal/upgrades/upgradevalidation/mocks"
@@ -73,6 +75,10 @@ func (s *precheckBaseSuite) setupMocks(c *gc.C) *gomock.Controller {
 
 func (s *precheckBaseSuite) expectApplicationLife(appName string, l life.Value) {
 	s.applicationService.EXPECT().GetApplicationLife(gomock.Any(), appName).Return(l, nil)
+}
+
+func (s *precheckBaseSuite) expectUnitWorkloadStatus(unitName string, status status.StatusInfo) {
+	s.applicationService.EXPECT().GetUnitWorkloadStatus(gomock.Any(), coreunit.Name(unitName)).Return(&status, nil)
 }
 
 func (s *precheckBaseSuite) expectIsUpgrade(upgrading bool) {

--- a/internal/migration/precheck_test.go
+++ b/internal/migration/precheck_test.go
@@ -72,6 +72,9 @@ func (s *SourcePrecheckSuite) TestSuccess(c *gc.C) {
 	s.expectIsUpgrade(false)
 	s.expectApplicationLife("foo", life.Alive)
 	s.expectApplicationLife("bar", life.Alive)
+	s.expectUnitWorkloadStatus("foo/0", status.StatusInfo{Status: status.Active})
+	s.expectUnitWorkloadStatus("bar/0", status.StatusInfo{Status: status.Active})
+	s.expectUnitWorkloadStatus("bar/1", status.StatusInfo{Status: status.Active})
 
 	backend := newHappyBackend()
 	backend.controllerBackend = newHappyBackend()
@@ -102,6 +105,8 @@ func (s *SourcePrecheckSuite) TestCharmUpgrades(c *gc.C) {
 	defer s.setupMocksWithDefaultAgentVersion(c).Finish()
 
 	s.expectApplicationLife("spanner", life.Alive)
+	s.expectUnitWorkloadStatus("spanner/0", status.StatusInfo{Status: status.Active})
+	s.expectUnitWorkloadStatus("spanner/1", status.StatusInfo{Status: status.Active})
 
 	backend := &fakeBackend{
 		apps: []migration.PrecheckApplication{
@@ -343,6 +348,9 @@ func (s *SourcePrecheckSuite) TestUnitVersionsDoNotMatch(c *gc.C) {
 
 	s.expectApplicationLife("foo", life.Alive)
 	s.expectApplicationLife("bar", life.Alive)
+	s.expectUnitWorkloadStatus("foo/0", status.StatusInfo{Status: status.Active})
+	s.expectUnitWorkloadStatus("bar/0", status.StatusInfo{Status: status.Active})
+	s.expectUnitWorkloadStatus("bar/1", status.StatusInfo{Status: status.Active})
 
 	backend := &fakeBackend{
 		model: fakeModel{modelType: state.ModelTypeIAAS},
@@ -369,6 +377,7 @@ func (s *SourcePrecheckSuite) TestCAASModelNoUnitVersionCheck(c *gc.C) {
 
 	s.expectIsUpgrade(false)
 	s.expectApplicationLife("foo", life.Alive)
+	s.expectUnitWorkloadStatus("foo/0", status.StatusInfo{Status: status.Active})
 
 	backend := &fakeBackend{
 		model: fakeModel{modelType: state.ModelTypeCAAS},
@@ -407,6 +416,7 @@ func (s *SourcePrecheckSuite) TestUnitExecuting(c *gc.C) {
 
 	s.expectIsUpgrade(false)
 	s.expectApplicationLife("foo", life.Alive)
+	s.expectUnitWorkloadStatus("foo/0", status.StatusInfo{Status: status.Active})
 
 	backend := &fakeBackend{
 		apps: []migration.PrecheckApplication{
@@ -426,6 +436,7 @@ func (s *SourcePrecheckSuite) TestUnitNotIdle(c *gc.C) {
 	defer s.setupMocksWithDefaultAgentVersion(c).Finish()
 
 	s.expectApplicationLife("foo", life.Alive)
+	s.expectUnitWorkloadStatus("foo/0", status.StatusInfo{Status: status.Active})
 
 	backend := &fakeBackend{
 		apps: []migration.PrecheckApplication{
@@ -446,6 +457,7 @@ func (s *SourcePrecheckSuite) TestUnitLost(c *gc.C) {
 
 	s.expectAgentVersion(2)
 	s.expectApplicationLife("foo", life.Alive)
+	s.expectUnitWorkloadStatus("foo/0", status.StatusInfo{Status: status.Active})
 
 	backend := newHappyBackend()
 	modelPresence := downAgentPresence("unit-foo-0")
@@ -552,6 +564,9 @@ func (s *SourcePrecheckSuite) TestUnitsAllInScope(c *gc.C) {
 	s.expectIsUpgrade(false)
 	s.expectApplicationLife("foo", life.Alive)
 	s.expectApplicationLife("bar", life.Alive)
+	s.expectUnitWorkloadStatus("foo/0", status.StatusInfo{Status: status.Active})
+	s.expectUnitWorkloadStatus("bar/0", status.StatusInfo{Status: status.Active})
+	s.expectUnitWorkloadStatus("bar/1", status.StatusInfo{Status: status.Active})
 
 	backend := newHappyBackend()
 	backend.relations = []migration.PrecheckRelation{&fakeRelation{
@@ -575,6 +590,9 @@ func (s *SourcePrecheckSuite) TestSubordinatesNotYetInScope(c *gc.C) {
 	s.expectAgentVersion(2)
 	s.expectApplicationLife("foo", life.Alive)
 	s.expectApplicationLife("bar", life.Alive)
+	s.expectUnitWorkloadStatus("foo/0", status.StatusInfo{Status: status.Active})
+	s.expectUnitWorkloadStatus("bar/0", status.StatusInfo{Status: status.Active})
+	s.expectUnitWorkloadStatus("bar/1", status.StatusInfo{Status: status.Active})
 
 	backend := newHappyBackend()
 	backend.relations = []migration.PrecheckRelation{&fakeRelation{
@@ -600,6 +618,9 @@ func (s *SourcePrecheckSuite) TestSubordinatesInvalidUnitsNotYetInScope(c *gc.C)
 	s.expectIsUpgrade(false)
 	s.expectApplicationLife("foo", life.Alive)
 	s.expectApplicationLife("bar", life.Alive)
+	s.expectUnitWorkloadStatus("foo/0", status.StatusInfo{Status: status.Active})
+	s.expectUnitWorkloadStatus("bar/0", status.StatusInfo{Status: status.Active})
+	s.expectUnitWorkloadStatus("bar/1", status.StatusInfo{Status: status.Active})
 
 	backend := newHappyBackend()
 	backend.relations = []migration.PrecheckRelation{&fakeRelation{
@@ -624,6 +645,9 @@ func (s *SourcePrecheckSuite) TestCrossModelUnitsNotYetInScope(c *gc.C) {
 	s.expectAgentVersion(2)
 	s.expectApplicationLife("foo", life.Alive)
 	s.expectApplicationLife("bar", life.Alive)
+	s.expectUnitWorkloadStatus("foo/0", status.StatusInfo{Status: status.Active})
+	s.expectUnitWorkloadStatus("bar/0", status.StatusInfo{Status: status.Active})
+	s.expectUnitWorkloadStatus("bar/1", status.StatusInfo{Status: status.Active})
 
 	backend := newHappyBackend()
 	backend.relations = []migration.PrecheckRelation{&fakeRelation{

--- a/state/status.go
+++ b/state/status.go
@@ -121,36 +121,6 @@ func (m *ModelStatus) UnitAgent(unitName string) (status.StatusInfo, error) {
 	return info, nil
 }
 
-// UnitWorkload returns the status of the unit's workload.
-func (m *ModelStatus) UnitWorkload(unitName string) (status.StatusInfo, error) {
-	// We do horrible things with unit status.
-	// See notes in unit.go.
-	info, err := m.getStatus(unitAgentGlobalKey(unitName), "unit")
-	if err != nil {
-		return info, err
-	} else if info.Status == status.Error {
-		return info, nil
-	}
-
-	// (for CAAS models) Use cloud container status over unit if the cloud
-	// container status is error or active or the unit status hasn't shifted
-	// from 'allocating'
-	info, err = m.getStatus(unitGlobalKey(unitName), "workload")
-	if err != nil {
-		return info, errors.Trace(err)
-	}
-
-	if m.model.Type() == ModelTypeIAAS {
-		return info, nil
-	}
-
-	containerInfo, err := m.getStatus(globalCloudContainerKey(unitName), "cloud container")
-	if err != nil && !errors.Is(err, errors.NotFound) {
-		return info, err
-	}
-	return status.UnitDisplayStatus(info, containerInfo), nil
-}
-
 type statusDocWithID struct {
 	ID         string                 `bson:"_id"`
 	ModelUUID  string                 `bson:"model-uuid"`


### PR DESCRIPTION
The ModelPresenceContext struct, which exposes some methods which mutate statuses to take into account the 'presence' of entities, is now backed by DQLite.

The method UnitStatus, however, in different places would work upon either the workload status or the display status, hidden behind an interface.

This suggests that the abstraction is wrong. So I have refactored this method to accept the unit status and agent status in it's params, and to leave it to the caller to decide where to get these statuses from.

NOTE: the client status facade would read the unit status from a cache, instead of Mongo directly. I have dropped this caching layer. This is because, in the long term, we will be re-writing status to use it's own domain.

## QA steps

```
$ juju bootstrap lxd dst
$ juju bootstrap lxd src
$ juju add-model m
$ juju deploy ubuntu
```
& verify that the unit becomes active/idle
```
juju migrate m dst
```
& verify the migration completes successfully