### PR TITLE
chore: add CharmUpgradeOnError to SetCharm facade

### DIFF
--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -1083,7 +1083,6 @@ func (api *APIBase) applicationSetCharm(
 		return errors.New("cannot downgrade from v2 charm format to v1")
 	}
 
-	// TODO(dqlite) - remove SetCharm (replaced below with UpdateApplicationCharm).
 	if err := params.Application.SetCharm(cfg, api.store); err != nil {
 		return errors.Annotate(err, "updating charm config")
 	}
@@ -1102,9 +1101,10 @@ func (api *APIBase) applicationSetCharm(
 			storageDirectives[name] = sc
 		}
 	}
-	if err := api.applicationService.UpdateApplicationCharm(ctx, params.AppName, applicationservice.UpdateCharmParams{
-		Charm:   newCharm,
-		Storage: storageDirectives,
+	if err := api.applicationService.SetApplicationCharm(ctx, params.AppName, applicationservice.UpdateCharmParams{
+		Charm:               newCharm,
+		Storage:             storageDirectives,
+		CharmUpgradeOnError: params.Force.ForceUnits,
 	}); err != nil {
 		return errors.Annotatef(err, "updating charm for application %q", params.AppName)
 	}

--- a/apiserver/facades/client/application/application_test.go
+++ b/apiserver/facades/client/application/application_test.go
@@ -78,6 +78,7 @@ func (s *applicationSuite) TestSetCharm(c *gc.C) {
 			"trust":        "true",
 		},
 		ConfigSettingsYAML: `foo: {"stringOption": "bar"}`,
+		ForceUnits:         true,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -175,6 +176,7 @@ func (s *applicationSuite) TestSetCharmEndpointBindings(c *gc.C) {
 		EndpointBindings: map[string]string{
 			"baz": "bar",
 		},
+		ForceUnits: true,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result.CharmOrigin, gc.DeepEquals, &state.CharmOrigin{
@@ -326,6 +328,7 @@ func (s *applicationSuite) TestSetCharmWithoutTrust(c *gc.C) {
 			"stringOption": "foo",
 		},
 		ConfigSettingsYAML: `foo: {"stringOption": "bar"}`,
+		ForceUnits:         true,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -838,7 +841,7 @@ func (s *applicationSuite) expectSetCharm(c *gc.C, name string, fn func(*gc.C, s
 	})
 
 	// TODO (stickupkid): This isn't actually checking much here...
-	s.applicationService.EXPECT().UpdateApplicationCharm(gomock.Any(), name, gomock.Any()).DoAndReturn(func(_ context.Context, _ string, params applicationservice.UpdateCharmParams) error {
+	s.applicationService.EXPECT().SetApplicationCharm(gomock.Any(), name, gomock.Any()).DoAndReturn(func(_ context.Context, _ string, params applicationservice.UpdateCharmParams) error {
 		c.Assert(params.Charm, gc.DeepEquals, &domainCharm{
 			charm: s.charm,
 			locator: applicationcharm.CharmLocator{
@@ -848,6 +851,7 @@ func (s *applicationSuite) expectSetCharm(c *gc.C, name string, fn func(*gc.C, s
 			},
 			available: true,
 		})
+		c.Assert(params.CharmUpgradeOnError, gc.Equals, true)
 		return nil
 	})
 }

--- a/apiserver/facades/client/application/service.go
+++ b/apiserver/facades/client/application/service.go
@@ -124,9 +124,9 @@ type ApplicationService interface {
 	CreateApplication(ctx context.Context, name string, charm internalcharm.Charm, origin corecharm.Origin, params applicationservice.AddApplicationArgs, units ...applicationservice.AddUnitArg) (coreapplication.ID, error)
 	// AddUnits adds units to the application.
 	AddUnits(ctx context.Context, name string, units ...applicationservice.AddUnitArg) error
-	// UpdateApplicationCharm sets a new charm for the application, validating that aspects such
+	// SetApplicationCharm sets a new charm for the application, validating that aspects such
 	// as storage are still viable with the new charm.
-	UpdateApplicationCharm(ctx context.Context, name string, params applicationservice.UpdateCharmParams) error
+	SetApplicationCharm(ctx context.Context, name string, params applicationservice.UpdateCharmParams) error
 	// SetApplicationScale sets the application's desired scale value.
 	// This is used on CAAS models.
 	SetApplicationScale(ctx context.Context, name string, scale int) error

--- a/apiserver/facades/client/application/services_mock_test.go
+++ b/apiserver/facades/client/application/services_mock_test.go
@@ -1550,6 +1550,44 @@ func (c *MockApplicationServiceIsCharmAvailableCall) DoAndReturn(f func(context.
 	return c
 }
 
+// SetApplicationCharm mocks base method.
+func (m *MockApplicationService) SetApplicationCharm(arg0 context.Context, arg1 string, arg2 service.UpdateCharmParams) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetApplicationCharm", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetApplicationCharm indicates an expected call of SetApplicationCharm.
+func (mr *MockApplicationServiceMockRecorder) SetApplicationCharm(arg0, arg1, arg2 any) *MockApplicationServiceSetApplicationCharmCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetApplicationCharm", reflect.TypeOf((*MockApplicationService)(nil).SetApplicationCharm), arg0, arg1, arg2)
+	return &MockApplicationServiceSetApplicationCharmCall{Call: call}
+}
+
+// MockApplicationServiceSetApplicationCharmCall wrap *gomock.Call
+type MockApplicationServiceSetApplicationCharmCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockApplicationServiceSetApplicationCharmCall) Return(arg0 error) *MockApplicationServiceSetApplicationCharmCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockApplicationServiceSetApplicationCharmCall) Do(f func(context.Context, string, service.UpdateCharmParams) error) *MockApplicationServiceSetApplicationCharmCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockApplicationServiceSetApplicationCharmCall) DoAndReturn(f func(context.Context, string, service.UpdateCharmParams) error) *MockApplicationServiceSetApplicationCharmCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // SetApplicationConstraints mocks base method.
 func (m *MockApplicationService) SetApplicationConstraints(arg0 context.Context, arg1 application.ID, arg2 constraints.Value) error {
 	m.ctrl.T.Helper()
@@ -1622,44 +1660,6 @@ func (c *MockApplicationServiceSetApplicationScaleCall) Do(f func(context.Contex
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockApplicationServiceSetApplicationScaleCall) DoAndReturn(f func(context.Context, string, int) error) *MockApplicationServiceSetApplicationScaleCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// UpdateApplicationCharm mocks base method.
-func (m *MockApplicationService) UpdateApplicationCharm(arg0 context.Context, arg1 string, arg2 service.UpdateCharmParams) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateApplicationCharm", arg0, arg1, arg2)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// UpdateApplicationCharm indicates an expected call of UpdateApplicationCharm.
-func (mr *MockApplicationServiceMockRecorder) UpdateApplicationCharm(arg0, arg1, arg2 any) *MockApplicationServiceUpdateApplicationCharmCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateApplicationCharm", reflect.TypeOf((*MockApplicationService)(nil).UpdateApplicationCharm), arg0, arg1, arg2)
-	return &MockApplicationServiceUpdateApplicationCharmCall{Call: call}
-}
-
-// MockApplicationServiceUpdateApplicationCharmCall wrap *gomock.Call
-type MockApplicationServiceUpdateApplicationCharmCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockApplicationServiceUpdateApplicationCharmCall) Return(arg0 error) *MockApplicationServiceUpdateApplicationCharmCall {
-	c.Call = c.Call.Return(arg0)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockApplicationServiceUpdateApplicationCharmCall) Do(f func(context.Context, string, service.UpdateCharmParams) error) *MockApplicationServiceUpdateApplicationCharmCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockApplicationServiceUpdateApplicationCharmCall) DoAndReturn(f func(context.Context, string, service.UpdateCharmParams) error) *MockApplicationServiceUpdateApplicationCharmCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/application/service/application.go
+++ b/domain/application/service/application.go
@@ -1006,9 +1006,9 @@ func (s *Service) MarkApplicationDead(ctx context.Context, appName string) error
 	return nil
 }
 
-// UpdateApplicationCharm sets a new charm for the application, validating that aspects such
+// SetApplicationCharm sets a new charm for the application, validating that aspects such
 // as storage are still viable with the new charm.
-func (s *Service) UpdateApplicationCharm(ctx context.Context, name string, params UpdateCharmParams) error {
+func (s *Service) SetApplicationCharm(ctx context.Context, name string, params UpdateCharmParams) error {
 	//TODO(storage) - update charm and storage directive for app
 	return nil
 }

--- a/domain/application/service/params.go
+++ b/domain/application/service/params.go
@@ -125,6 +125,10 @@ type UpdateCharmParams struct {
 	// unaffected; the storage directives will only be used for
 	// provisioning new storage instances.
 	Storage map[string]storage.Directive
+
+	// CharmUpgradeOnError indicates whether the charm must be upgraded
+	// even when on error.
+	CharmUpgradeOnError bool
 }
 
 // ResolvedResources is a collection of ResolvedResource elements.
@@ -211,6 +215,11 @@ type ImportApplicationArgs struct {
 
 	// Units contains the units to import.
 	Units []ImportUnitArg
+
 	// ApplicationConstraints contains the application constraints.
 	ApplicationConstraints constraints.Value
+
+	// CharmUpgradeOnError indicates whether the charm must be upgraded
+	// even when on error.
+	CharmUpgradeOnError bool
 }


### PR DESCRIPTION
The ForceUnits field on the SetCharm facade needs to be wired. Although the service method isn't implemented yet, we can still add the CharmUpgradeOnError field to its parameters (named as the column in the application table).
Also, this commit renames the UpdateApplicationCharm domain method as SetApplicationCharm.

## QA steps

Nothing is wired, only unit tests should pass.

## Links


**Jira card:** JUJU-7072

