### PR TITLE
refactor: aws credential invalidator 

### DIFF
--- a/environs/jujutest/tests.go
+++ b/environs/jujutest/tests.go
@@ -189,7 +189,8 @@ func (t *Tests) TestStartStop(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	insts, err = e.Instances(t.ProviderCallContext, []instance.Id{id0, id1})
-	c.Assert(err, gc.Equals, environs.ErrPartialInstances)
+	c.Assert(err, jc.ErrorIs, environs.ErrPartialInstances)
+	c.Assert(insts, gc.HasLen, 2)
 	c.Assert(insts[0], gc.IsNil)
 	c.Assert(insts[1].Id(), gc.Equals, id1)
 

--- a/internal/provider/common/credentialinvalidator.go
+++ b/internal/provider/common/credentialinvalidator.go
@@ -104,6 +104,9 @@ func HandleCredentialError(ctx context.Context, invalidator environs.CredentialI
 		return false, err
 	}
 
+	// TODO (stickupkid): We should remove the `errors.Cause` and let the caller
+	// handle this, otherwise we could be dropping vital information when each
+	// provider checks the error.
 	if denied := isAuthError(errors.Cause(err)); denied {
 		converted := fmt.Errorf("cloud denied access: %w", CredentialNotValidError(err))
 		invalidateErr := invalidator.InvalidateCredentials(ctx, environs.CredentialInvalidReason(converted.Error()))

--- a/internal/provider/ec2/client.go
+++ b/internal/provider/ec2/client.go
@@ -97,7 +97,7 @@ type awsLogger struct {
 }
 
 func (l awsLogger) Write(p []byte) (n int, err error) {
-	logger.Tracef(context.TODO(), "awsLogger %p: %s", l.cfg, p)
+	logger.Tracef(context.Background(), "awsLogger %p: %s", l.cfg, p)
 	return len(p), nil
 }
 

--- a/internal/provider/ec2/config.go
+++ b/internal/provider/ec2/config.go
@@ -60,7 +60,7 @@ func (p environProvider) newConfig(ctx context.Context, cfg *config.Config) (*en
 	if err != nil {
 		return nil, err
 	}
-	return &environConfig{valid, valid.UnknownAttrs()}, nil
+	return &environConfig{Config: valid, attrs: valid.UnknownAttrs()}, nil
 }
 
 // ModelConfigDefaults provides a set of default model config attributes that
@@ -101,7 +101,7 @@ func validateConfig(ctx context.Context, cfg, old *config.Config) (*environConfi
 	if err != nil {
 		return nil, err
 	}
-	ecfg := &environConfig{cfg, validated}
+	ecfg := &environConfig{Config: cfg, attrs: validated}
 
 	if vpcID := ecfg.vpcID(); isVPCIDSetButInvalid(vpcID) {
 		return nil, fmt.Errorf("vpc-id: %q is not a valid AWS VPC ID", vpcID)

--- a/internal/provider/ec2/credentials.go
+++ b/internal/provider/ec2/credentials.go
@@ -35,13 +35,13 @@ func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.C
 	return map[cloud.AuthType]cloud.CredentialSchema{
 		cloud.AccessKeyAuthType: {
 			{
-				"access-key",
-				cloud.CredentialAttr{
+				Name: "access-key",
+				CredentialAttr: cloud.CredentialAttr{
 					Description: "The EC2 access key",
 				},
 			}, {
-				"secret-key",
-				cloud.CredentialAttr{
+				Name: "secret-key",
+				CredentialAttr: cloud.CredentialAttr{
 					Description: "The EC2 secret key",
 					Hidden:      true,
 				},
@@ -49,8 +49,8 @@ func (environProviderCredentials) CredentialSchemas() map[cloud.AuthType]cloud.C
 		},
 		cloud.InstanceRoleAuthType: {
 			{
-				"instance-profile-name",
-				cloud.CredentialAttr{
+				Name: "instance-profile-name",
+				CredentialAttr: cloud.CredentialAttr{
 					Description: "The AWS Instance Profile name",
 				},
 			},

--- a/internal/provider/ec2/export_test.go
+++ b/internal/provider/ec2/export_test.go
@@ -71,7 +71,9 @@ var (
 	DestroyVolumeAttempt           = &destroyVolumeAttempt
 	DeleteSecurityGroupInsistently = &deleteSecurityGroupInsistently
 	TerminateInstancesById         = &terminateInstancesById
-	MaybeConvertCredentialError    = maybeConvertCredentialError
+
+	IsAuthorizationError      = isAuthorizationError
+	ConvertAuthorizationError = convertAuthorizationError
 )
 
 const (
@@ -91,6 +93,6 @@ func (s *stubAccountAPIClient) DescribeAccountAttributes(
 	return nil, errors.New("boom")
 }
 
-func VerifyCredentials(ctx envcontext.ProviderCallContext) error {
-	return verifyCredentials(&stubAccountAPIClient{}, ctx)
+func VerifyCredentials(ctx context.Context, invalidator environs.CredentialInvalidator) error {
+	return verifyCredentials(ctx, invalidator, &stubAccountAPIClient{})
 }

--- a/internal/provider/ec2/instance.go
+++ b/internal/provider/ec2/instance.go
@@ -161,7 +161,7 @@ type FetchInstanceClient interface {
 // available instance types for an AWS region. This func assumes that the ec2
 // client provided is scoped to a region already.
 func FetchInstanceTypeInfo(
-	ctx envcontext.ProviderCallContext,
+	ctx context.Context,
 	ec2Client FetchInstanceClient,
 ) ([]types.InstanceTypeInfo, error) {
 	const maxResults = int32(100)
@@ -174,7 +174,6 @@ func FetchInstanceTypeInfo(
 			NextToken:  nextToken,
 		})
 		if err != nil {
-			err = maybeConvertCredentialError(err, ctx)
 			return nil, fmt.Errorf("describing instance types: %w", err)
 		}
 		instanceTypes = append(instanceTypes, instTypeResults.InstanceTypes...)

--- a/internal/provider/ec2/securitygroups_test.go
+++ b/internal/provider/ec2/securitygroups_test.go
@@ -26,7 +26,7 @@ type SecurityGroupSuite struct {
 	coretesting.BaseSuite
 
 	clientStub   *stubClient
-	deleteFunc   func(ec2.SecurityGroupCleaner, envcontext.ProviderCallContext, types.GroupIdentifier, clock.Clock) error
+	deleteFunc   func(context.Context, ec2.SecurityGroupCleaner, types.GroupIdentifier, clock.Clock) error
 	cloudCallCtx envcontext.ProviderCallContext
 }
 
@@ -49,7 +49,7 @@ func (s *SecurityGroupSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *SecurityGroupSuite) TestDeleteSecurityGroupSuccess(c *gc.C) {
-	err := s.deleteFunc(s.clientStub, s.cloudCallCtx, types.GroupIdentifier{}, testclock.NewClock(time.Time{}))
+	err := s.deleteFunc(context.Background(), s.clientStub, types.GroupIdentifier{}, testclock.NewClock(time.Time{}))
 	c.Assert(err, jc.ErrorIsNil)
 	s.clientStub.CheckCallNames(c, "DeleteSecurityGroup")
 }
@@ -58,7 +58,7 @@ func (s *SecurityGroupSuite) TestDeleteSecurityGroupInvalidGroupNotFound(c *gc.C
 	s.clientStub.deleteSecurityGroup = func(group types.GroupIdentifier) (resp *awsec2.DeleteSecurityGroupOutput, err error) {
 		return nil, &smithy.GenericAPIError{Code: "InvalidGroup.NotFound"}
 	}
-	err := s.deleteFunc(s.clientStub, s.cloudCallCtx, types.GroupIdentifier{}, testclock.NewClock(time.Time{}))
+	err := s.deleteFunc(context.Background(), s.clientStub, types.GroupIdentifier{}, testclock.NewClock(time.Time{}))
 	c.Assert(err, jc.ErrorIsNil)
 	s.clientStub.CheckCallNames(c, "DeleteSecurityGroup")
 }
@@ -83,7 +83,7 @@ func (s *SecurityGroupSuite) TestDeleteSecurityGroupFewCalls(c *gc.C) {
 		}
 		return nil, nil
 	}
-	err := s.deleteFunc(s.clientStub, s.cloudCallCtx, types.GroupIdentifier{}, clock)
+	err := s.deleteFunc(context.Background(), s.clientStub, types.GroupIdentifier{}, clock)
 	c.Assert(err, jc.ErrorIsNil)
 
 	expectedCalls := make([]string, maxCalls+1)


### PR DESCRIPTION
Following on from[1][2], this continues on the work of removing
the provider credential invalidator from the providers. This is
the AWS EC2 one. This uses the new common.CredentialInvalidator
and to invalidate the credentials. The only difference from this
provider over the prior two PR changes, is that we give better
error messages and so we have to wrap the common one with our
own that handles those cases better.

  1. https://github.com/juju/juju/pull/18936
  2. https://github.com/juju/juju/pull/19007

## QA steps

The invalidators aren't wired up yet, so this is just the plumbing to reinstate the call sites.

The following ensures we haven't regressed:

```sh
$ juju bootstrap aws test --bootstrap-constraints="arch=amd64 cores=4 mem=16G" --debug
$ juju add-model default
$ juju deploy ubuntu
```

## Links

Jira card: [JUJU-7590](https://warthogs.atlassian.net/browse/JUJU-7590)

