### PR TITLE
chore: make Unit.Status private

### DIFF
--- a/apiserver/common/crossmodel/interface.go
+++ b/apiserver/common/crossmodel/interface.go
@@ -218,15 +218,6 @@ type Application interface {
 
 	// Status returns the status of the application.
 	Status() (status.StatusInfo, error)
-
-	// AllUnits returns all units of the application.
-	AllUnits() ([]Unit, error)
-}
-
-// Unit represents the state of a unit hosted in the local model.
-type Unit interface {
-	// Status returns the status of the unit.
-	Status() (status.StatusInfo, error)
 }
 
 // Bindings defines a subset of the functionality provided by the

--- a/apiserver/common/crossmodel/state.go
+++ b/apiserver/common/crossmodel/state.go
@@ -64,18 +64,6 @@ func (a applicationShim) EndpointBindings() (Bindings, error) {
 	return a.Application.EndpointBindings()
 }
 
-func (a applicationShim) AllUnits() ([]Unit, error) {
-	all, err := a.Application.AllUnits()
-	if err != nil {
-		return nil, err
-	}
-	result := make([]Unit, len(all))
-	for i, u := range all {
-		result[i] = u
-	}
-	return result, nil
-}
-
 func (st stateShim) Application(name string) (Application, error) {
 	a, err := st.State.Application(name)
 	if err != nil {

--- a/apiserver/facades/agent/uniter/uniter_legacy_test.go
+++ b/apiserver/facades/agent/uniter/uniter_legacy_test.go
@@ -216,15 +216,19 @@ func (s *uniterLegacySuite) TestSetUnitStatus(c *gc.C) {
 	})
 
 	// Verify mysqlUnit - no change.
-	statusInfo, err := s.mysqlUnit.Status()
+	statusInfo, err := s.uniter.UnitStatus(context.Background(), params.Entities{Entities: []params.Entity{{Tag: s.mysqlUnit.Tag().String()}}})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(statusInfo.Status, gc.Equals, status.Terminated)
-	c.Assert(statusInfo.Message, gc.Equals, "foo")
+	c.Assert(statusInfo.Results, gc.HasLen, 1)
+	c.Assert(statusInfo.Results[0].Error, jc.ErrorIsNil)
+	c.Assert(statusInfo.Results[0].Status, gc.Equals, status.Terminated)
+	c.Assert(statusInfo.Results[0].Info, gc.Equals, "foo")
 	// ...wordpressUnit is fine though.
-	statusInfo, err = s.wordpressUnit.Status()
+	statusInfo, err = s.uniter.UnitStatus(context.Background(), params.Entities{Entities: []params.Entity{{Tag: s.wordpressUnit.Tag().String()}}})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(statusInfo.Status, gc.Equals, status.Terminated)
-	c.Assert(statusInfo.Message, gc.Equals, "foobar")
+	c.Assert(statusInfo.Results, gc.HasLen, 1)
+	c.Assert(statusInfo.Results[0].Error, jc.ErrorIsNil)
+	c.Assert(statusInfo.Results[0].Status, gc.Equals, status.Terminated)
+	c.Assert(statusInfo.Results[0].Info, gc.Equals, "foobar")
 }
 
 func (s *uniterLegacySuite) TestLife(c *gc.C) {

--- a/apiserver/facades/client/machinemanager/package_mock_test.go
+++ b/apiserver/facades/client/machinemanager/package_mock_test.go
@@ -768,45 +768,6 @@ func (c *MockBackendToolsStorageCall) DoAndReturn(f func(objectstore.ObjectStore
 	return c
 }
 
-// Unit mocks base method.
-func (m *MockBackend) Unit(arg0 string) (Unit, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Unit", arg0)
-	ret0, _ := ret[0].(Unit)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Unit indicates an expected call of Unit.
-func (mr *MockBackendMockRecorder) Unit(arg0 any) *MockBackendUnitCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Unit", reflect.TypeOf((*MockBackend)(nil).Unit), arg0)
-	return &MockBackendUnitCall{Call: call}
-}
-
-// MockBackendUnitCall wrap *gomock.Call
-type MockBackendUnitCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockBackendUnitCall) Return(arg0 Unit, arg1 error) *MockBackendUnitCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockBackendUnitCall) Do(f func(string) (Unit, error)) *MockBackendUnitCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockBackendUnitCall) DoAndReturn(f func(string) (Unit, error)) *MockBackendUnitCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // MockStorageInterface is a mock of StorageInterface interface.
 type MockStorageInterface struct {
 	ctrl     *gomock.Controller
@@ -1724,45 +1685,6 @@ func (c *MockUnitNameCall) Do(f func() string) *MockUnitNameCall {
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockUnitNameCall) DoAndReturn(f func() string) *MockUnitNameCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// Status mocks base method.
-func (m *MockUnit) Status() (status.StatusInfo, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Status")
-	ret0, _ := ret[0].(status.StatusInfo)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Status indicates an expected call of Status.
-func (mr *MockUnitMockRecorder) Status() *MockUnitStatusCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Status", reflect.TypeOf((*MockUnit)(nil).Status))
-	return &MockUnitStatusCall{Call: call}
-}
-
-// MockUnitStatusCall wrap *gomock.Call
-type MockUnitStatusCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockUnitStatusCall) Return(arg0 status.StatusInfo, arg1 error) *MockUnitStatusCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockUnitStatusCall) Do(f func() (status.StatusInfo, error)) *MockUnitStatusCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockUnitStatusCall) DoAndReturn(f func() (status.StatusInfo, error)) *MockUnitStatusCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/client/machinemanager/state.go
+++ b/apiserver/facades/client/machinemanager/state.go
@@ -24,7 +24,6 @@ type Backend interface {
 	Application(string) (Application, error)
 	Machine(string) (Machine, error)
 	AllMachines() ([]Machine, error)
-	Unit(string) (Unit, error)
 	AddOneMachine(template state.MachineTemplate) (Machine, error)
 	AddMachineInsideNewMachine(template, parentTemplate state.MachineTemplate, containerType instance.ContainerType) (Machine, error)
 	AddMachineInsideMachine(template state.MachineTemplate, parentId string, containerType instance.ContainerType) (Machine, error)
@@ -116,16 +115,6 @@ func (s stateShim) AllMachines() ([]Machine, error) {
 	return result, nil
 }
 
-func (s stateShim) Unit(name string) (Unit, error) {
-	u, err := s.State.Unit(name)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return unitShim{
-		Unit: u,
-	}, nil
-}
-
 type poolShim struct {
 	pool *state.StatePool
 }
@@ -154,15 +143,10 @@ func (m machineShim) Units() ([]Unit, error) {
 	return out, nil
 }
 
-type unitShim struct {
-	*state.Unit
-}
-
 type Unit interface {
 	UnitTag() names.UnitTag
 	Name() string
 	AgentStatus() (status.StatusInfo, error)
-	Status() (status.StatusInfo, error)
 }
 
 type StorageInterface interface {

--- a/internal/migration/interface.go
+++ b/internal/migration/interface.go
@@ -113,7 +113,6 @@ type PrecheckUnit interface {
 	Life() state.Life
 	CharmURL() *string
 	AgentStatus() (status.StatusInfo, error)
-	Status() (status.StatusInfo, error)
 	ShouldBeAssigned() bool
 }
 

--- a/state/unit.go
+++ b/state/unit.go
@@ -1319,7 +1319,7 @@ func (u *Unit) AgentStatus() (status.StatusInfo, error) {
 // This method relies on globalKey instead of globalAgentKey since it is part of
 // the effort to separate Unit from UnitAgent. Now the Status for UnitAgent is in
 // the UnitAgent struct.
-func (u *Unit) Status() (status.StatusInfo, error) {
+func (u *Unit) status() (status.StatusInfo, error) {
 	// The current health spec says when a hook error occurs, the workload should
 	// be in error state, but the state model more correctly records the agent
 	// itself as being in error. So we'll do that model translation here.
@@ -2368,7 +2368,7 @@ func (u *Unit) Resolve(retryHooks bool) error {
 	// We currently check agent status to see if a unit is
 	// in error state. As the new Juju Health work is completed,
 	// this will change to checking the unit status.
-	statusInfo, err := u.Status()
+	statusInfo, err := u.status()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This legacy state method is now no longer used outside of state. Make the method private, and drop it from the interfaces it was left on.

## QA steps

unit tests pass