### PR TITLE
chore: generate virtual host keys on migration

### DIFF
--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -33,6 +33,7 @@ import (
 	"github.com/juju/juju/core/permission"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/environs/config"
+	"github.com/juju/juju/pki/ssh"
 	secretsprovider "github.com/juju/juju/secrets/provider"
 	"github.com/juju/juju/state/cloudimagemetadata"
 	"github.com/juju/juju/storage"
@@ -2855,6 +2856,13 @@ func (i *importer) remoteSecrets() error {
 
 func (i *importer) virtualHostKeys() error {
 	i.logger.Debugf("importing virtual host key")
+
+	vhKeys := i.model.VirtualHostKeys()
+	// Generate virtual host keys when migrating from an old controller.
+	if len(vhKeys) == 0 {
+		return i.generateMissingVirtualHostKeys()
+	}
+
 	migration := &ImportStateMigration{
 		src: i.model,
 		dst: i.st.db(),
@@ -2871,4 +2879,49 @@ func (i *importer) virtualHostKeys() error {
 	}
 	i.logger.Debugf("importing virtual host key succeeded")
 	return nil
+}
+
+func (i *importer) generateMissingVirtualHostKeys() error {
+	machines := i.model.Machines()
+	modelUUID := i.model.Tag().Id()
+
+	var ops []txn.Op
+	for _, machine := range machines {
+		key, err := ssh.NewMarshalledED25519()
+		if err != nil {
+			return errors.Trace(err)
+		}
+		addOps, err := newMachineVirtualHostKeysOps(modelUUID, machine.Id(), key)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		ops = append(ops, addOps...)
+	}
+
+	modelType, err := ParseModelType(i.model.Type())
+	if err != nil {
+		return errors.Annotate(err, "unknown model type")
+	}
+
+	if modelType == ModelTypeCAAS {
+		var units []*Unit
+		for _, apps := range i.applicationUnits {
+			for _, unit := range apps {
+				units = append(units, unit)
+			}
+		}
+		// add host keys for CaaS units.
+		for _, unit := range units {
+			key, err := ssh.NewMarshalledED25519()
+			if err != nil {
+				return errors.Trace(err)
+			}
+			addOps, err := newUnitVirtualHostKeysOps(modelUUID, unit.Tag().Id(), key)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			ops = append(ops, addOps...)
+		}
+	}
+	return errors.Trace(i.st.db().RunTransaction(ops))
 }

--- a/state/migration_import_test.go
+++ b/state/migration_import_test.go
@@ -3544,7 +3544,23 @@ func (s *MigrationImportSuite) TestVirtualHostKeys(c *gc.C) {
 	newVirtualHostKey, err := newSt.MachineVirtualHostKey(machineTag.Id())
 	c.Assert(err, gc.IsNil)
 	c.Assert(newVirtualHostKey.HostKey(), gc.DeepEquals, testHostKey)
+}
 
+func (s *MigrationImportSuite) TestGenerateMissingVirtualHostKeys(c *gc.C) {
+	machine := s.Factory.MakeMachine(c, &factory.MachineParams{
+		Constraints: constraints.MustParse("arch=amd64 mem=8G"),
+	})
+	existingVirtualHostKey, err := s.State.MachineVirtualHostKey(machine.Tag().Id())
+	c.Assert(err, gc.IsNil)
+	c.Assert(string(existingVirtualHostKey.HostKey()), gc.Equals, "fake-host-key")
+
+	state.RemoveVirtualHostKey(c, s.State, existingVirtualHostKey)
+
+	_, newSt := s.importModel(c, s.State)
+
+	newVirtualHostKey, err := newSt.MachineVirtualHostKey(machine.Tag().Id())
+	c.Assert(err, gc.IsNil)
+	c.Assert(string(newVirtualHostKey.HostKey()), gc.Matches, `(?s)-----BEGIN OPENSSH PRIVATE KEY-----.*`)
 }
 
 // newModel replaces the uuid and name of the config attributes so we


### PR DESCRIPTION
This PR updates the importer for virtual host keys. In cases where there are no virtual host keys for an incoming model we can assume one of two things:
1. The incoming model has no machines or units.
2. The incoming model is from an older version controller that does not include virtual host keys.

If we assume scenario 2 we can do a low-cost set of operations to loop through all machines and units and generate host keys where appropriate.

**Question:** How do we handle failed migrations? Does the partially migrated model get cleaned up automatically?

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

- `sudo snap install --revision=29130 juju (3.6.0)`.
- `/snap/bin/juju bootstrap lxd lxd --debug.`
- `juju add-model foo`
- `juju deploy ubuntu`
- With this patch,  `juju bootstrap lxd-36-dev --build-agent`.
- `juju switch lxd`
- `juju migrate foo lxd-36-dev`
- `juju status` (wait for migration to complete)
- `juju switch lxd-36-dev`
- Connect to Mongo (using [this script](https://discourse.charmhub.io/t/login-into-mongodb/309) and:
- `db.virtualhostkeys.find().pretty()`
```
> juju:PRIMARY> db.virtualhostkeys.find().pretty()
{
        "_id" : "9bf69610-9700-4baf-877c-bd4d5fd7f896:machine-0-hostkey",
        "hostkey" : BinData(0,"<key>"),
        "model-uuid" : "9bf69610-9700-4baf-877c-bd4d5fd7f896",
        "txn-revno" : 2
}
{
        "_id" : "b3390fe0-c196-4950-836f-cd3d0b51ef20:machine-0-hostkey",
        "hostkey" : BinData(0,"<key>"),
        "model-uuid" : "b3390fe0-c196-4950-836f-cd3d0b51ef20",
        "txn-revno" : 2
}
```

## Links

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/

**Jira card:** [JUJU-7334](https://warthogs.atlassian.net/browse/JUJU-7334)

