### PR TITLE
refactor(secrets): update `RemoveSecretsForAgent` and `RemoveUserSecrets` for clarity, performance

### DIFF
--- a/apiserver/common/secrets/secrets.go
+++ b/apiserver/common/secrets/secrets.go
@@ -600,23 +600,57 @@ func GetSecretMetadata(
 	return result, nil
 }
 
+// secretDeletionPreflightCheck parses arguments for secret deletion and validates whether deletion is allowed,
+// returning the secret URI on success
+func secretDeletionPreflightCheck(uri string, label string, removeState SecretsRemoveState, modelUUID string, canDelete func(*coresecrets.URI) error) (*coresecrets.URI, error) {
+	var (
+		uriObject *coresecrets.URI
+		err       error
+	)
+	if uri != "" {
+		uriObject, err = coresecrets.ParseURI(uri)
+	} else {
+		uriObject, err = getSecretURIForLabel(removeState, modelUUID, label)
+	}
+	if err != nil {
+		return nil, errors.New("must specify either URI or label")
+	}
+	if _, err := removeState.GetSecret(uriObject); err != nil {
+		// Check if the uriObject exists or not.
+		return nil, err
+	}
+	if err := canDelete(uriObject); err != nil {
+		return nil, err
+	}
+
+	return uriObject, nil
+}
+
 // RemoveSecretsForAgent removes the specified secrets for agent.
 // The secrets are only removed from the state and
 // the caller must have permission to manage the secret(secret owners remove secrets from the backend on uniter side).
 func RemoveSecretsForAgent(
-	removeState SecretsRemoveState, adminConfigGetter BackendAdminConfigGetter,
+	removeState SecretsRemoveState,
 	args params.DeleteSecretArgs,
 	modelUUID string,
 	canDelete func(*coresecrets.URI) error,
 ) (params.ErrorResults, error) {
-	return removeSecrets(
-		removeState, adminConfigGetter, args,
-		modelUUID,
-		canDelete,
-		func(provider.SecretBackendProvider, provider.ModelBackendConfig, provider.SecretRevisions) error {
-			return nil
-		},
-	)
+	result := params.ErrorResults{
+		Results: make([]params.ErrorResult, len(args.Args)),
+	}
+
+	for i, arg := range args.Args {
+		uri, err := secretDeletionPreflightCheck(arg.URI, arg.Label, removeState, modelUUID, canDelete)
+		if err != nil {
+			result.Results[i].Error = apiservererrors.ServerError(err)
+			continue
+		}
+		if _, err = removeState.DeleteSecret(uri, arg.Revisions...); err != nil {
+			result.Results[i].Error = apiservererrors.ServerError(err)
+			continue
+		}
+	}
+	return result, nil
 }
 
 // RemoveUserSecrets removes the specified user supplied secrets.
@@ -627,50 +661,22 @@ func RemoveUserSecrets(
 	modelUUID string,
 	canDelete func(*coresecrets.URI) error,
 ) (params.ErrorResults, error) {
-	return removeSecrets(
-		removeState, adminConfigGetter, args, modelUUID, canDelete,
-		func(p provider.SecretBackendProvider, cfg provider.ModelBackendConfig, revs provider.SecretRevisions) error {
-			backend, err := p.NewBackend(&cfg)
-			if err != nil {
+	removeFromBackend := func(p provider.SecretBackendProvider, cfg provider.ModelBackendConfig, revs provider.SecretRevisions) error {
+		backend, err := p.NewBackend(&cfg)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		for _, revId := range revs.RevisionIDs() {
+			if err = backend.DeleteContent(context.TODO(), revId); err != nil {
 				return errors.Trace(err)
 			}
-			for _, revId := range revs.RevisionIDs() {
-				if err = backend.DeleteContent(context.TODO(), revId); err != nil {
-					return errors.Trace(err)
-				}
-			}
-			if err := p.CleanupSecrets(&cfg, authTag, revs); err != nil {
-				return errors.Trace(err)
-			}
-			return nil
-		},
-	)
-}
+		}
+		if err := p.CleanupSecrets(&cfg, authTag, revs); err != nil {
+			return errors.Trace(err)
+		}
+		return nil
+	}
 
-func getSecretURIForLabel(secretsState ListSecretsState, modelUUID string, label string) (*coresecrets.URI, error) {
-	results, err := secretsState.ListSecrets(state.SecretsFilter{
-		Label:     &label,
-		OwnerTags: []names.Tag{names.NewModelTag(modelUUID)},
-	})
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	if len(results) == 0 {
-		return nil, errors.NotFoundf("secret %q", label)
-	}
-	if len(results) > 1 {
-		return nil, errors.NotFoundf("more than 1 secret with label %q", label)
-	}
-	return results[0].URI, nil
-}
-
-func removeSecrets(
-	removeState SecretsRemoveState, adminConfigGetter BackendAdminConfigGetter,
-	args params.DeleteSecretArgs,
-	modelUUID string,
-	canDelete func(*coresecrets.URI) error,
-	removeFromBackend func(provider.SecretBackendProvider, provider.ModelBackendConfig, provider.SecretRevisions) error,
-) (params.ErrorResults, error) {
 	result := params.ErrorResults{
 		Results: make([]params.ErrorResult, len(args.Args)),
 	}
@@ -731,30 +737,8 @@ func removeSecrets(
 	}
 
 	for i, arg := range args.Args {
-		if arg.URI == "" && arg.Label == "" {
-			result.Results[i].Error = apiservererrors.ServerError(errors.New("must specify either URI or label"))
-			continue
-		}
-
-		var (
-			uri *coresecrets.URI
-			err error
-		)
-		if arg.URI != "" {
-			uri, err = coresecrets.ParseURI(arg.URI)
-		} else {
-			uri, err = getSecretURIForLabel(removeState, modelUUID, arg.Label)
-		}
+		uri, err := secretDeletionPreflightCheck(arg.URI, arg.Label, removeState, modelUUID, canDelete)
 		if err != nil {
-			result.Results[i].Error = apiservererrors.ServerError(err)
-			continue
-		}
-		if _, err := removeState.GetSecret(uri); err != nil {
-			// Check if the uri exists or not.
-			result.Results[i].Error = apiservererrors.ServerError(err)
-			continue
-		}
-		if err := canDelete(uri); err != nil {
 			result.Results[i].Error = apiservererrors.ServerError(err)
 			continue
 		}
@@ -769,4 +753,22 @@ func removeSecrets(
 		}
 	}
 	return result, nil
+
+}
+
+func getSecretURIForLabel(secretsState ListSecretsState, modelUUID string, label string) (*coresecrets.URI, error) {
+	results, err := secretsState.ListSecrets(state.SecretsFilter{
+		Label:     &label,
+		OwnerTags: []names.Tag{names.NewModelTag(modelUUID)},
+	})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if len(results) == 0 {
+		return nil, errors.NotFoundf("secret %q", label)
+	}
+	if len(results) > 1 {
+		return nil, errors.NotFoundf("more than 1 secret with label %q", label)
+	}
+	return results[0].URI, nil
 }

--- a/apiserver/common/secrets/secrets_test.go
+++ b/apiserver/common/secrets/secrets_test.go
@@ -813,34 +813,13 @@ func (s *secretsSuite) TestRemoveSecretsForSecretOwnersWithRevisions(c *gc.C) {
 	s.PatchValue(&secrets.GetProvider, func(string) (provider.SecretBackendProvider, error) { return mockprovider, nil })
 
 	removeState.EXPECT().GetSecret(&expectURI).Return(&coresecrets.SecretMetadata{}, nil)
-	removeState.EXPECT().GetSecretRevision(&expectURI, 666).Return(&coresecrets.SecretRevisionMetadata{
-		Revision: 666,
-		ValueRef: &coresecrets.ValueRef{BackendID: "backend-id", RevisionID: "rev-666"},
-	}, nil)
 	removeState.EXPECT().DeleteSecret(&expectURI, []int{666}).Return([]coresecrets.ValueRef{{
 		BackendID:  "backend-id",
 		RevisionID: "rev-666",
 	}}, nil)
 
-	adminConfigGetter := func() (*provider.ModelBackendConfigInfo, error) {
-		return &provider.ModelBackendConfigInfo{
-			ActiveID: "backend-id",
-			Configs: map[string]provider.ModelBackendConfig{
-				"backend-id": {
-					ControllerUUID: coretesting.ControllerTag.Id(),
-					ModelUUID:      coretesting.ModelTag.Id(),
-					ModelName:      "fred",
-					BackendConfig: provider.BackendConfig{
-						BackendType: "some-backend",
-						Config:      map[string]interface{}{"foo": "admin"},
-					},
-				},
-			},
-		}, nil
-	}
-
 	results, err := secrets.RemoveSecretsForAgent(
-		removeState, adminConfigGetter,
+		removeState,
 		params.DeleteSecretArgs{
 			Args: []params.DeleteSecretArg{{
 				URI:       expectURI.String(),
@@ -867,39 +846,13 @@ func (s *secretsSuite) TestRemoveSecretsForSecretOwners(c *gc.C) {
 	s.PatchValue(&secrets.GetProvider, func(string) (provider.SecretBackendProvider, error) { return mockprovider, nil })
 
 	removeState.EXPECT().GetSecret(&expectURI).Return(&coresecrets.SecretMetadata{}, nil)
-	removeState.EXPECT().ListSecretRevisions(&expectURI).Return(
-		[]*coresecrets.SecretRevisionMetadata{
-			{
-				Revision: 666,
-				ValueRef: &coresecrets.ValueRef{BackendID: "backend-id", RevisionID: "rev-666"},
-			},
-		},
-		nil,
-	)
 	removeState.EXPECT().DeleteSecret(&expectURI, []int{}).Return([]coresecrets.ValueRef{{
 		BackendID:  "backend-id",
 		RevisionID: "rev-666",
 	}}, nil)
 
-	adminConfigGetter := func() (*provider.ModelBackendConfigInfo, error) {
-		return &provider.ModelBackendConfigInfo{
-			ActiveID: "backend-id",
-			Configs: map[string]provider.ModelBackendConfig{
-				"backend-id": {
-					ControllerUUID: coretesting.ControllerTag.Id(),
-					ModelUUID:      coretesting.ModelTag.Id(),
-					ModelName:      "fred",
-					BackendConfig: provider.BackendConfig{
-						BackendType: "some-backend",
-						Config:      map[string]interface{}{"foo": "admin"},
-					},
-				},
-			},
-		}, nil
-	}
-
 	results, err := secrets.RemoveSecretsForAgent(
-		removeState, adminConfigGetter,
+		removeState,
 		params.DeleteSecretArgs{
 			Args: []params.DeleteSecretArg{{
 				URI: expectURI.String(),
@@ -935,39 +888,13 @@ func (s *secretsSuite) TestRemoveSecretsByLabel(c *gc.C) {
 		URI: uri,
 	}}, nil)
 	removeState.EXPECT().GetSecret(&expectURI).Return(&coresecrets.SecretMetadata{}, nil)
-	removeState.EXPECT().ListSecretRevisions(&expectURI).Return(
-		[]*coresecrets.SecretRevisionMetadata{
-			{
-				Revision: 666,
-				ValueRef: &coresecrets.ValueRef{BackendID: "backend-id", RevisionID: "rev-666"},
-			},
-		},
-		nil,
-	)
 	removeState.EXPECT().DeleteSecret(&expectURI, []int{}).Return([]coresecrets.ValueRef{{
 		BackendID:  "backend-id",
 		RevisionID: "rev-666",
 	}}, nil)
 
-	adminConfigGetter := func() (*provider.ModelBackendConfigInfo, error) {
-		return &provider.ModelBackendConfigInfo{
-			ActiveID: "backend-id",
-			Configs: map[string]provider.ModelBackendConfig{
-				"backend-id": {
-					ControllerUUID: coretesting.ControllerTag.Id(),
-					ModelUUID:      coretesting.ModelTag.Id(),
-					ModelName:      "fred",
-					BackendConfig: provider.BackendConfig{
-						BackendType: "some-backend",
-						Config:      map[string]interface{}{"foo": "admin"},
-					},
-				},
-			},
-		}, nil
-	}
-
 	results, err := secrets.RemoveSecretsForAgent(
-		removeState, adminConfigGetter,
+		removeState,
 		params.DeleteSecretArgs{
 			Args: []params.DeleteSecretArg{{
 				Label: "my-secret",

--- a/apiserver/facades/agent/secretsmanager/secrets.go
+++ b/apiserver/facades/agent/secretsmanager/secrets.go
@@ -378,7 +378,8 @@ func (s *SecretsManagerAPI) updateSecret(arg params.UpdateSecretArg) error {
 // RemoveSecrets removes the specified secrets.
 func (s *SecretsManagerAPI) RemoveSecrets(args params.DeleteSecretArgs) (params.ErrorResults, error) {
 	return commonsecrets.RemoveSecretsForAgent(
-		s.secretsState, s.adminConfigGetter, args,
+		s.secretsState,
+		args,
 		s.modelUUID,
 		func(uri *coresecrets.URI) error {
 			_, err := s.canManage(uri)


### PR DESCRIPTION
`RemoveSecretsForAgent` and `RemoveUserSecrets` require much of the same logic.  Previously, duplication was avoided by putting all logic in `RemoveSecrets`.  This kept things DRY, but:
* led to `RemoveSecretsForAgent` doing some unnecessary extra work searching for revisions that weren't actually in a backend (`gatherExternalRevs` was executed even though there was no external provider)
* made it hard to understand what `RemoveSecretsForAgent` actually did, since much of the work in `RemoveSecrets` was ignored

This change moves logic from `RemoveSecrets` into the calling functions, extracting their shared code into helpers where possible.  The net effect is a bit less code, more explicit intent, and a little performance improvement.  This also removes the need for an adminConfigGetter from `RemoveSecretsForAgent`.

This is also being done as a precursor to fixing some bugs around removing secrets from the backend.  The unraveling of these functions makes the future bugfixes simpler to implement.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~~
- ~~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~~

## QA steps

Existing tests should cover the change

## Documentation changes

No user-facing changes

## Links

Done as a precursor to [lp2093271](https://bugs.launchpad.net/juju/+bug/2093271) and JUJU-7641

