### PR TITLE
fix(charmhub): resolve misleading output for info

### DIFF
--- a/cmd/juju/charmhub/convert.go
+++ b/cmd/juju/charmhub/convert.go
@@ -308,6 +308,9 @@ func filterChannels(channelMap []transport.InfoChannelMap, arch string, risk cha
 	revisionsSeen := set.NewStrings()
 	channels := make(RevisionsMap)
 
+	riskExists := false
+	checkRisk := risk != ""
+
 	for _, cm := range channelMap {
 		ch := cm.Channel
 		// Per the charmhub/snap channel spec.
@@ -315,7 +318,7 @@ func filterChannels(channelMap []transport.InfoChannelMap, arch string, risk cha
 			ch.Track = "latest"
 		}
 
-		if risk != "" && track == "" {
+		if checkRisk && track == "" {
 			track = ch.Track
 		}
 
@@ -325,6 +328,10 @@ func filterChannels(channelMap []transport.InfoChannelMap, arch string, risk cha
 
 		if revision != -1 && cm.Revision.Revision != revision {
 			continue
+		}
+
+		if checkRisk && ch.Risk == string(risk) {
+			riskExists = true
 		}
 
 		if !tracksSeen.Contains(ch.Track) {
@@ -358,6 +365,10 @@ func filterChannels(channelMap []transport.InfoChannelMap, arch string, risk cha
 			channels[ch.Track] = make(map[string][]Revision)
 		}
 		channels[ch.Track][ch.Risk] = append(channels[ch.Track][ch.Risk], channelRevision)
+	}
+
+	if checkRisk && !riskExists {
+		return []string{}, make(RevisionsMap), nil
 	}
 
 	for _, risks := range channels {

--- a/cmd/juju/charmhub/convert_test.go
+++ b/cmd/juju/charmhub/convert_test.go
@@ -181,6 +181,66 @@ func (filterSuite) TestFilterChannels(c *gc.C) {
 			},
 		},
 	}, {
+		Name:     "filter by channel configured with track and risk",
+		Arch:     "all",
+		Risk:     "beta",
+		Revision: -1,
+		Track:    "2.0",
+		Base:     corebase.Base{},
+		Input: []transport.InfoChannelMap{{
+			Channel: transport.Channel{
+				Track: "1.0",
+				Risk:  "beta",
+			},
+			Revision: transport.InfoRevision{
+				Bases: []transport.Base{{
+					Name:         "ubuntu",
+					Channel:      "18.04",
+					Architecture: "all",
+				}},
+			},
+		}, {
+			Channel: transport.Channel{
+				Track: "2.0",
+				Risk:  "stable",
+			},
+			Revision: transport.InfoRevision{
+				Bases: []transport.Base{{
+					Name:         "ubuntu",
+					Channel:      "18.04",
+					Architecture: "all",
+				}},
+			},
+		}, {
+			Channel: transport.Channel{
+				Track: "2.0",
+				Risk:  "beta",
+			},
+			Revision: transport.InfoRevision{
+				Bases: []transport.Base{{
+					Name:         "ubuntu",
+					Channel:      "18.04",
+					Architecture: "all",
+				}},
+			},
+		}},
+		Expected: RevisionsMap{
+			"2.0": {
+				"stable": {{
+					Track:  "2.0",
+					Risk:   "stable",
+					Arches: arch.AllArches().StringList(),
+					Bases:  []Base{{Name: "ubuntu", Channel: "18.04"}},
+				}},
+				"beta": {{
+					Track:  "2.0",
+					Risk:   "beta",
+					Arches: arch.AllArches().StringList(),
+					Bases:  []Base{{Name: "ubuntu", Channel: "18.04"}},
+				}},
+			},
+		},
+	}, {
 		Name: "match all",
 		Arch: "all",
 		Base: corebase.Base{},


### PR DESCRIPTION
<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://github.com/juju/juju/blob/main/doc/conventional-commits.md
-->

<!-- Why this change is needed and what it does. -->
It was observed that when a user requests a specific channel using --channel 16/stable in `juju info`, the output returned was for 16/edge because that’s the only channel available in the track. Since no charm is published to the stable channel in track 16, this mislead the output. Additionally, the command should fall back to using the store-defined default track when no track is specified.

This PR is to correct channel resolution and enhance the testing for it.
## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

1. The full channel map of track 16: `juju info postgresql --track 16`
```
name: postgresql
publisher: Canonical
summary: Charmed PostgreSQL VM operator
description: |
  Charm to operate the PostgreSQL database on machines.
store-url: https://charmhub.io/postgresql
charm-id: ChgcZB3RhaDOnhkAv9cgRg52LhjBbDt8
supports: ubuntu@22.04
tags: databases
subordinate: false
relations:
  provides:
    cos-agent: cos_agent
    database: postgresql_client
    db: pgsql
    db-admin: pgsql
    replication-offer: postgresql_async
  requires:
    certificates: tls-certificates
    replication: postgresql_async
    s3-parameters: s3
    tracing: tracing
channels: |
  16/stable:     –
  16/candidate:  –
  16/beta:       –
  16/edge:       527  2024-11-27  (527)  32MB  arm64  ubuntu@24.04
```
2. To find the existing risk: `juju info postgresql --channel 16/edge`
```
name: postgresql
publisher: Canonical
summary: Charmed PostgreSQL VM operator
description: |
  Charm to operate the PostgreSQL database on machines.
store-url: https://charmhub.io/postgresql
charm-id: ChgcZB3RhaDOnhkAv9cgRg52LhjBbDt8
supports: ubuntu@22.04
tags: databases
subordinate: false
relations:
  provides:
    cos-agent: cos_agent
    database: postgresql_client
    db: pgsql
    db-admin: pgsql
    replication-offer: postgresql_async
  requires:
    certificates: tls-certificates
    replication: postgresql_async
    s3-parameters: s3
    tracing: tracing
channels: |
  16/stable:     –
  16/candidate:  –
  16/beta:       –
  16/edge:       527  2024-11-27  (527)  32MB  arm64  ubuntu@24.04
```
3. To find the non-existing risk: `juju info postgresql --channel 16/stable`
```
name: postgresql
publisher: Canonical
summary: Charmed PostgreSQL VM operator
description: |
  Charm to operate the PostgreSQL database on machines.
store-url: https://charmhub.io/postgresql
charm-id: ChgcZB3RhaDOnhkAv9cgRg52LhjBbDt8
supports: ubuntu@22.04
tags: databases
subordinate: false
relations:
  provides:
    cos-agent: cos_agent
    database: postgresql_client
    db: pgsql
    db-admin: pgsql
    replication-offer: postgresql_async
  requires:
    certificates: tls-certificates
    replication: postgresql_async
    s3-parameters: s3
    tracing: tracing
```
<!-- How it affects user workflow (CLI or API). -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Jira card:** [JUJU-7642](https://warthogs.atlassian.net/browse/JUJU-7642)

