### PR TITLE
test(secrets): fix SecretManager facade's TestRemoveSecrets

### DIFF
--- a/apiserver/facades/agent/secretsmanager/secrets_test.go
+++ b/apiserver/facades/agent/secretsmanager/secrets_test.go
@@ -480,7 +480,7 @@ func (s *SecretsManagerSuite) TestRemoveSecrets(c *gc.C) {
 	s.secretsState.EXPECT().GetSecret(&expectURI).Return(&coresecrets.SecretMetadata{}, nil)
 	// DeleteSecret returns the deleted external revisions iff it is deleting all revisions in a secret, so returning
 	// (not nil, nil) simulates that event.
-	s.secretsState.EXPECT().DeleteSecret(&expectURI, []int{666}).Return([]coresecrets.ValueRef{{
+	s.secretsState.EXPECT().DeleteSecret(&expectURI, []int{}).Return([]coresecrets.ValueRef{{
 		BackendID:  "backend-id",
 		RevisionID: "rev-666",
 	}}, nil)
@@ -491,7 +491,7 @@ func (s *SecretsManagerSuite) TestRemoveSecrets(c *gc.C) {
 	results, err := s.facade.RemoveSecrets(params.DeleteSecretArgs{
 		Args: []params.DeleteSecretArg{{
 			URI:       expectURI.String(),
-			Revisions: []int{666},
+			Revisions: []int{},
 		}},
 	})
 	c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://github.com/juju/juju/blob/main/doc/conventional-commits.md
-->

Tests for the SecretManager facade include a white-box test for removing an entire agent secret.  This test mocks out the internal calls to `secretState.*`, including mocking `secretsState.DeleteSecret`'s return to include a slice of revisions.

DeleteSecret only returns a slice of revisions when it deletes only some of the revisions on a secret, not when it deletes the whole secret.  Thus, as previously written, this test isn't really a test of deleting a whole secret but just deleting some revisions - essentially a duplicate of TestRemoveSecretRevision.

This commit updates TestRemoveSecrets to return from DeleteSecret as if an entire secret was deleted.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~~
- ~~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~~

## QA steps

Only unit tests are changed.

## Documentation changes

Only unit tests are changed.

## Links

None