### PR TITLE
refactor: replace names.UnitApplication() in domain state with a core method

### DIFF
--- a/apiserver/facades/agent/secretsmanager/mocks/secrets.go
+++ b/apiserver/facades/agent/secretsmanager/mocks/secrets.go
@@ -14,6 +14,7 @@ import (
 	reflect "reflect"
 
 	secrets "github.com/juju/juju/core/secrets"
+	unit "github.com/juju/juju/core/unit"
 	watcher "github.com/juju/juju/core/watcher"
 	service "github.com/juju/juju/domain/secret/service"
 	service0 "github.com/juju/juju/domain/secretbackend/service"
@@ -238,7 +239,7 @@ func (m *MockSecretsConsumer) EXPECT() *MockSecretsConsumerMockRecorder {
 }
 
 // GetConsumedRevision mocks base method.
-func (m *MockSecretsConsumer) GetConsumedRevision(ctx context.Context, uri *secrets.URI, unitName string, refresh, peek bool, labelToUpdate *string) (int, error) {
+func (m *MockSecretsConsumer) GetConsumedRevision(ctx context.Context, uri *secrets.URI, unitName unit.Name, refresh, peek bool, labelToUpdate *string) (int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetConsumedRevision", ctx, uri, unitName, refresh, peek, labelToUpdate)
 	ret0, _ := ret[0].(int)
@@ -265,19 +266,19 @@ func (c *MockSecretsConsumerGetConsumedRevisionCall) Return(arg0 int, arg1 error
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSecretsConsumerGetConsumedRevisionCall) Do(f func(context.Context, *secrets.URI, string, bool, bool, *string) (int, error)) *MockSecretsConsumerGetConsumedRevisionCall {
+func (c *MockSecretsConsumerGetConsumedRevisionCall) Do(f func(context.Context, *secrets.URI, unit.Name, bool, bool, *string) (int, error)) *MockSecretsConsumerGetConsumedRevisionCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSecretsConsumerGetConsumedRevisionCall) DoAndReturn(f func(context.Context, *secrets.URI, string, bool, bool, *string) (int, error)) *MockSecretsConsumerGetConsumedRevisionCall {
+func (c *MockSecretsConsumerGetConsumedRevisionCall) DoAndReturn(f func(context.Context, *secrets.URI, unit.Name, bool, bool, *string) (int, error)) *MockSecretsConsumerGetConsumedRevisionCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetSecretConsumer mocks base method.
-func (m *MockSecretsConsumer) GetSecretConsumer(ctx context.Context, uri *secrets.URI, unitName string) (*secrets.SecretConsumerMetadata, error) {
+func (m *MockSecretsConsumer) GetSecretConsumer(ctx context.Context, uri *secrets.URI, unitName unit.Name) (*secrets.SecretConsumerMetadata, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSecretConsumer", ctx, uri, unitName)
 	ret0, _ := ret[0].(*secrets.SecretConsumerMetadata)
@@ -304,19 +305,19 @@ func (c *MockSecretsConsumerGetSecretConsumerCall) Return(arg0 *secrets.SecretCo
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSecretsConsumerGetSecretConsumerCall) Do(f func(context.Context, *secrets.URI, string) (*secrets.SecretConsumerMetadata, error)) *MockSecretsConsumerGetSecretConsumerCall {
+func (c *MockSecretsConsumerGetSecretConsumerCall) Do(f func(context.Context, *secrets.URI, unit.Name) (*secrets.SecretConsumerMetadata, error)) *MockSecretsConsumerGetSecretConsumerCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSecretsConsumerGetSecretConsumerCall) DoAndReturn(f func(context.Context, *secrets.URI, string) (*secrets.SecretConsumerMetadata, error)) *MockSecretsConsumerGetSecretConsumerCall {
+func (c *MockSecretsConsumerGetSecretConsumerCall) DoAndReturn(f func(context.Context, *secrets.URI, unit.Name) (*secrets.SecretConsumerMetadata, error)) *MockSecretsConsumerGetSecretConsumerCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetSecretConsumerAndLatest mocks base method.
-func (m *MockSecretsConsumer) GetSecretConsumerAndLatest(ctx context.Context, uri *secrets.URI, unitName string) (*secrets.SecretConsumerMetadata, int, error) {
+func (m *MockSecretsConsumer) GetSecretConsumerAndLatest(ctx context.Context, uri *secrets.URI, unitName unit.Name) (*secrets.SecretConsumerMetadata, int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSecretConsumerAndLatest", ctx, uri, unitName)
 	ret0, _ := ret[0].(*secrets.SecretConsumerMetadata)
@@ -344,19 +345,19 @@ func (c *MockSecretsConsumerGetSecretConsumerAndLatestCall) Return(arg0 *secrets
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSecretsConsumerGetSecretConsumerAndLatestCall) Do(f func(context.Context, *secrets.URI, string) (*secrets.SecretConsumerMetadata, int, error)) *MockSecretsConsumerGetSecretConsumerAndLatestCall {
+func (c *MockSecretsConsumerGetSecretConsumerAndLatestCall) Do(f func(context.Context, *secrets.URI, unit.Name) (*secrets.SecretConsumerMetadata, int, error)) *MockSecretsConsumerGetSecretConsumerAndLatestCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSecretsConsumerGetSecretConsumerAndLatestCall) DoAndReturn(f func(context.Context, *secrets.URI, string) (*secrets.SecretConsumerMetadata, int, error)) *MockSecretsConsumerGetSecretConsumerAndLatestCall {
+func (c *MockSecretsConsumerGetSecretConsumerAndLatestCall) DoAndReturn(f func(context.Context, *secrets.URI, unit.Name) (*secrets.SecretConsumerMetadata, int, error)) *MockSecretsConsumerGetSecretConsumerAndLatestCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetURIByConsumerLabel mocks base method.
-func (m *MockSecretsConsumer) GetURIByConsumerLabel(ctx context.Context, label, unitName string) (*secrets.URI, error) {
+func (m *MockSecretsConsumer) GetURIByConsumerLabel(ctx context.Context, label string, unitName unit.Name) (*secrets.URI, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetURIByConsumerLabel", ctx, label, unitName)
 	ret0, _ := ret[0].(*secrets.URI)
@@ -383,13 +384,13 @@ func (c *MockSecretsConsumerGetURIByConsumerLabelCall) Return(arg0 *secrets.URI,
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSecretsConsumerGetURIByConsumerLabelCall) Do(f func(context.Context, string, string) (*secrets.URI, error)) *MockSecretsConsumerGetURIByConsumerLabelCall {
+func (c *MockSecretsConsumerGetURIByConsumerLabelCall) Do(f func(context.Context, string, unit.Name) (*secrets.URI, error)) *MockSecretsConsumerGetURIByConsumerLabelCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSecretsConsumerGetURIByConsumerLabelCall) DoAndReturn(f func(context.Context, string, string) (*secrets.URI, error)) *MockSecretsConsumerGetURIByConsumerLabelCall {
+func (c *MockSecretsConsumerGetURIByConsumerLabelCall) DoAndReturn(f func(context.Context, string, unit.Name) (*secrets.URI, error)) *MockSecretsConsumerGetURIByConsumerLabelCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -471,7 +472,7 @@ func (c *MockSecretsConsumerRevokeSecretAccessCall) DoAndReturn(f func(context.C
 }
 
 // SaveSecretConsumer mocks base method.
-func (m *MockSecretsConsumer) SaveSecretConsumer(ctx context.Context, uri *secrets.URI, unitName string, md *secrets.SecretConsumerMetadata) error {
+func (m *MockSecretsConsumer) SaveSecretConsumer(ctx context.Context, uri *secrets.URI, unitName unit.Name, md *secrets.SecretConsumerMetadata) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SaveSecretConsumer", ctx, uri, unitName, md)
 	ret0, _ := ret[0].(error)
@@ -497,19 +498,19 @@ func (c *MockSecretsConsumerSaveSecretConsumerCall) Return(arg0 error) *MockSecr
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSecretsConsumerSaveSecretConsumerCall) Do(f func(context.Context, *secrets.URI, string, *secrets.SecretConsumerMetadata) error) *MockSecretsConsumerSaveSecretConsumerCall {
+func (c *MockSecretsConsumerSaveSecretConsumerCall) Do(f func(context.Context, *secrets.URI, unit.Name, *secrets.SecretConsumerMetadata) error) *MockSecretsConsumerSaveSecretConsumerCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSecretsConsumerSaveSecretConsumerCall) DoAndReturn(f func(context.Context, *secrets.URI, string, *secrets.SecretConsumerMetadata) error) *MockSecretsConsumerSaveSecretConsumerCall {
+func (c *MockSecretsConsumerSaveSecretConsumerCall) DoAndReturn(f func(context.Context, *secrets.URI, unit.Name, *secrets.SecretConsumerMetadata) error) *MockSecretsConsumerSaveSecretConsumerCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // WatchConsumedSecretsChanges mocks base method.
-func (m *MockSecretsConsumer) WatchConsumedSecretsChanges(ctx context.Context, unitName string) (watcher.StringsWatcher, error) {
+func (m *MockSecretsConsumer) WatchConsumedSecretsChanges(ctx context.Context, unitName unit.Name) (watcher.StringsWatcher, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WatchConsumedSecretsChanges", ctx, unitName)
 	ret0, _ := ret[0].(watcher.StringsWatcher)
@@ -536,13 +537,13 @@ func (c *MockSecretsConsumerWatchConsumedSecretsChangesCall) Return(arg0 watcher
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSecretsConsumerWatchConsumedSecretsChangesCall) Do(f func(context.Context, string) (watcher.StringsWatcher, error)) *MockSecretsConsumerWatchConsumedSecretsChangesCall {
+func (c *MockSecretsConsumerWatchConsumedSecretsChangesCall) Do(f func(context.Context, unit.Name) (watcher.StringsWatcher, error)) *MockSecretsConsumerWatchConsumedSecretsChangesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSecretsConsumerWatchConsumedSecretsChangesCall) DoAndReturn(f func(context.Context, string) (watcher.StringsWatcher, error)) *MockSecretsConsumerWatchConsumedSecretsChangesCall {
+func (c *MockSecretsConsumerWatchConsumedSecretsChangesCall) DoAndReturn(f func(context.Context, unit.Name) (watcher.StringsWatcher, error)) *MockSecretsConsumerWatchConsumedSecretsChangesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -816,7 +817,7 @@ func (c *MockSecretServiceListGrantedSecretsForBackendCall) DoAndReturn(f func(c
 }
 
 // ProcessCharmSecretConsumerLabel mocks base method.
-func (m *MockSecretService) ProcessCharmSecretConsumerLabel(ctx context.Context, unitName string, uri *secrets.URI, label string) (*secrets.URI, *string, error) {
+func (m *MockSecretService) ProcessCharmSecretConsumerLabel(ctx context.Context, unitName unit.Name, uri *secrets.URI, label string) (*secrets.URI, *string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProcessCharmSecretConsumerLabel", ctx, unitName, uri, label)
 	ret0, _ := ret[0].(*secrets.URI)
@@ -844,13 +845,13 @@ func (c *MockSecretServiceProcessCharmSecretConsumerLabelCall) Return(arg0 *secr
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSecretServiceProcessCharmSecretConsumerLabelCall) Do(f func(context.Context, string, *secrets.URI, string) (*secrets.URI, *string, error)) *MockSecretServiceProcessCharmSecretConsumerLabelCall {
+func (c *MockSecretServiceProcessCharmSecretConsumerLabelCall) Do(f func(context.Context, unit.Name, *secrets.URI, string) (*secrets.URI, *string, error)) *MockSecretServiceProcessCharmSecretConsumerLabelCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSecretServiceProcessCharmSecretConsumerLabelCall) DoAndReturn(f func(context.Context, string, *secrets.URI, string) (*secrets.URI, *string, error)) *MockSecretServiceProcessCharmSecretConsumerLabelCall {
+func (c *MockSecretServiceProcessCharmSecretConsumerLabelCall) DoAndReturn(f func(context.Context, unit.Name, *secrets.URI, string) (*secrets.URI, *string, error)) *MockSecretServiceProcessCharmSecretConsumerLabelCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/agent/secretsmanager/secrets_test.go
+++ b/apiserver/facades/agent/secretsmanager/secrets_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/juju/juju/apiserver/facades/agent/secretsmanager/mocks"
 	"github.com/juju/juju/core/model"
 	coresecrets "github.com/juju/juju/core/secrets"
+	unittesting "github.com/juju/juju/core/unit/testing"
 	corewatcher "github.com/juju/juju/core/watcher"
 	secreterrors "github.com/juju/juju/domain/secret/errors"
 	secretservice "github.com/juju/juju/domain/secret/service"
@@ -254,7 +255,7 @@ func (s *SecretsManagerSuite) TestGetConsumerSecretsRevisionInfoHavingConsumerLa
 	defer s.setup(c).Finish()
 
 	uri := coresecrets.NewURI()
-	s.secretsConsumer.EXPECT().GetSecretConsumerAndLatest(gomock.Any(), uri, "mariadb/0").Return(
+	s.secretsConsumer.EXPECT().GetSecretConsumerAndLatest(gomock.Any(), uri, unittesting.GenNewName(c, "mariadb/0")).Return(
 		&coresecrets.SecretConsumerMetadata{
 			Label: "label",
 		}, 666, nil)
@@ -276,7 +277,7 @@ func (s *SecretsManagerSuite) TestGetConsumerSecretsRevisionInfoHavingNoConsumer
 	defer s.setup(c).Finish()
 
 	uri := coresecrets.NewURI()
-	s.secretsConsumer.EXPECT().GetSecretConsumerAndLatest(gomock.Any(), uri, "mariadb/0").Return(
+	s.secretsConsumer.EXPECT().GetSecretConsumerAndLatest(gomock.Any(), uri, unittesting.GenNewName(c, "mariadb/0")).Return(
 		&coresecrets.SecretConsumerMetadata{
 			CurrentRevision: 665,
 		}, 666, nil)
@@ -297,7 +298,7 @@ func (s *SecretsManagerSuite) TestGetConsumerSecretsRevisionInfoForPeerUnitsAcce
 	defer s.setup(c).Finish()
 
 	uri := coresecrets.NewURI()
-	s.secretsConsumer.EXPECT().GetSecretConsumerAndLatest(gomock.Any(), uri, "mariadb/0").Return(
+	s.secretsConsumer.EXPECT().GetSecretConsumerAndLatest(gomock.Any(), uri, unittesting.GenNewName(c, "mariadb/0")).Return(
 		&coresecrets.SecretConsumerMetadata{
 			CurrentRevision: 665,
 			Label:           "owner-label",
@@ -411,9 +412,9 @@ func (s *SecretsManagerSuite) TestGetSecretContentForOwnerSecretURIArg(c *gc.C) 
 	val := coresecrets.NewSecretValue(data)
 	uri := coresecrets.NewURI()
 
-	s.secretService.EXPECT().ProcessCharmSecretConsumerLabel(gomock.Any(), "mariadb/0", uri, "").Return(uri, nil, nil)
+	s.secretService.EXPECT().ProcessCharmSecretConsumerLabel(gomock.Any(), unittesting.GenNewName(c, "mariadb/0"), uri, "").Return(uri, nil, nil)
 
-	s.secretsConsumer.EXPECT().GetConsumedRevision(gomock.Any(), uri, "mariadb/0", false, false, nil).
+	s.secretsConsumer.EXPECT().GetConsumedRevision(gomock.Any(), uri, unittesting.GenNewName(c, "mariadb/0"), false, false, nil).
 		Return(668, nil)
 
 	s.secretService.EXPECT().GetSecretValue(gomock.Any(), uri, 668, secretservice.SecretAccessor{
@@ -443,9 +444,9 @@ func (s *SecretsManagerSuite) TestGetSecretContentForOwnerSecretLabelArg(c *gc.C
 	val := coresecrets.NewSecretValue(data)
 	uri := coresecrets.NewURI()
 
-	s.secretService.EXPECT().ProcessCharmSecretConsumerLabel(gomock.Any(), "mariadb/0", nil, "foo").Return(uri, nil, nil)
+	s.secretService.EXPECT().ProcessCharmSecretConsumerLabel(gomock.Any(), unittesting.GenNewName(c, "mariadb/0"), nil, "foo").Return(uri, nil, nil)
 
-	s.secretsConsumer.EXPECT().GetConsumedRevision(gomock.Any(), uri, "mariadb/0", false, false, nil).
+	s.secretsConsumer.EXPECT().GetConsumedRevision(gomock.Any(), uri, unittesting.GenNewName(c, "mariadb/0"), false, false, nil).
 		Return(668, nil)
 
 	s.secretService.EXPECT().GetSecretValue(gomock.Any(), uri, 668, secretservice.SecretAccessor{
@@ -475,9 +476,9 @@ func (s *SecretsManagerSuite) TestGetSecretContentForAppSecretUpdateLabel(c *gc.
 	val := coresecrets.NewSecretValue(data)
 	uri := coresecrets.NewURI()
 
-	s.secretService.EXPECT().ProcessCharmSecretConsumerLabel(gomock.Any(), "mariadb/0", uri, "foo").Return(uri, nil, nil)
+	s.secretService.EXPECT().ProcessCharmSecretConsumerLabel(gomock.Any(), unittesting.GenNewName(c, "mariadb/0"), uri, "foo").Return(uri, nil, nil)
 
-	s.secretsConsumer.EXPECT().GetConsumedRevision(gomock.Any(), uri, "mariadb/0", false, false, nil).
+	s.secretsConsumer.EXPECT().GetConsumedRevision(gomock.Any(), uri, unittesting.GenNewName(c, "mariadb/0"), false, false, nil).
 		Return(668, nil)
 	s.secretService.EXPECT().GetSecretValue(gomock.Any(), uri, 668, secretservice.SecretAccessor{
 		Kind: secretservice.UnitAccessor,
@@ -506,9 +507,9 @@ func (s *SecretsManagerSuite) TestGetSecretContentForUnitAccessApplicationOwnedS
 	val := coresecrets.NewSecretValue(data)
 	uri := coresecrets.NewURI()
 
-	s.secretService.EXPECT().ProcessCharmSecretConsumerLabel(gomock.Any(), "mariadb/0", nil, "foo").Return(uri, nil, nil)
+	s.secretService.EXPECT().ProcessCharmSecretConsumerLabel(gomock.Any(), unittesting.GenNewName(c, "mariadb/0"), nil, "foo").Return(uri, nil, nil)
 
-	s.secretsConsumer.EXPECT().GetConsumedRevision(gomock.Any(), uri, "mariadb/0", false, false, nil).
+	s.secretsConsumer.EXPECT().GetConsumedRevision(gomock.Any(), uri, unittesting.GenNewName(c, "mariadb/0"), false, false, nil).
 		Return(668, nil)
 
 	s.secretService.EXPECT().GetSecretValue(gomock.Any(), uri, 668, secretservice.SecretAccessor{
@@ -540,8 +541,8 @@ func (s *SecretsManagerSuite) TestGetSecretContentConsumerUnitAgent(c *gc.C) {
 	val := coresecrets.NewSecretValue(data)
 	uri := coresecrets.NewURI()
 
-	s.secretService.EXPECT().ProcessCharmSecretConsumerLabel(gomock.Any(), "mariadb/0", uri, "").Return(uri, nil, nil)
-	s.secretsConsumer.EXPECT().GetConsumedRevision(gomock.Any(), uri, "mariadb/0", false, false, nil).
+	s.secretService.EXPECT().ProcessCharmSecretConsumerLabel(gomock.Any(), unittesting.GenNewName(c, "mariadb/0"), uri, "").Return(uri, nil, nil)
+	s.secretsConsumer.EXPECT().GetConsumedRevision(gomock.Any(), uri, unittesting.GenNewName(c, "mariadb/0"), false, false, nil).
 		Return(666, nil)
 	s.secretService.EXPECT().GetSecretValue(gomock.Any(), uri, 666, secretservice.SecretAccessor{
 		Kind: secretservice.UnitAccessor,
@@ -570,8 +571,8 @@ func (s *SecretsManagerSuite) TestGetSecretContentConsumerLabelOnly(c *gc.C) {
 	val := coresecrets.NewSecretValue(data)
 	uri := coresecrets.NewURI()
 
-	s.secretService.EXPECT().ProcessCharmSecretConsumerLabel(gomock.Any(), "mariadb/0", nil, "label").Return(uri, nil, nil)
-	s.secretsConsumer.EXPECT().GetConsumedRevision(gomock.Any(), uri, "mariadb/0", false, false, nil).
+	s.secretService.EXPECT().ProcessCharmSecretConsumerLabel(gomock.Any(), unittesting.GenNewName(c, "mariadb/0"), nil, "label").Return(uri, nil, nil)
+	s.secretsConsumer.EXPECT().GetConsumedRevision(gomock.Any(), uri, unittesting.GenNewName(c, "mariadb/0"), false, false, nil).
 		Return(666, nil)
 	s.secretService.EXPECT().GetSecretValue(gomock.Any(), uri, 666, secretservice.SecretAccessor{
 		Kind: secretservice.UnitAccessor,
@@ -600,8 +601,8 @@ func (s *SecretsManagerSuite) TestGetSecretContentConsumerUpdateArg(c *gc.C) {
 	val := coresecrets.NewSecretValue(data)
 	uri := coresecrets.NewURI()
 
-	s.secretService.EXPECT().ProcessCharmSecretConsumerLabel(gomock.Any(), "mariadb/0", uri, "label").Return(uri, ptr("label"), nil)
-	s.secretsConsumer.EXPECT().GetConsumedRevision(gomock.Any(), uri, "mariadb/0", true, false, ptr("label")).
+	s.secretService.EXPECT().ProcessCharmSecretConsumerLabel(gomock.Any(), unittesting.GenNewName(c, "mariadb/0"), uri, "label").Return(uri, ptr("label"), nil)
+	s.secretsConsumer.EXPECT().GetConsumedRevision(gomock.Any(), uri, unittesting.GenNewName(c, "mariadb/0"), true, false, ptr("label")).
 		Return(668, nil)
 
 	s.secretService.EXPECT().GetSecretValue(gomock.Any(), uri, 668, secretservice.SecretAccessor{
@@ -631,8 +632,8 @@ func (s *SecretsManagerSuite) TestGetSecretContentConsumerPeekArg(c *gc.C) {
 	val := coresecrets.NewSecretValue(data)
 	uri := coresecrets.NewURI()
 
-	s.secretService.EXPECT().ProcessCharmSecretConsumerLabel(gomock.Any(), "mariadb/0", uri, "").Return(uri, nil, nil)
-	s.secretsConsumer.EXPECT().GetConsumedRevision(gomock.Any(), uri, "mariadb/0", false, true, nil).
+	s.secretService.EXPECT().ProcessCharmSecretConsumerLabel(gomock.Any(), unittesting.GenNewName(c, "mariadb/0"), uri, "").Return(uri, nil, nil)
+	s.secretsConsumer.EXPECT().GetConsumedRevision(gomock.Any(), uri, unittesting.GenNewName(c, "mariadb/0"), false, true, nil).
 		Return(668, nil)
 	s.secretService.EXPECT().GetSecretValue(gomock.Any(), uri, 668, secretservice.SecretAccessor{
 		Kind: secretservice.UnitAccessor,
@@ -668,8 +669,8 @@ func (s *SecretsManagerSuite) TestGetSecretContentCrossModelExistingConsumerNoRe
 	s.remoteClient.EXPECT().Close().Return(nil)
 
 	s.crossModelState.EXPECT().GetToken(names.NewApplicationTag("mariadb")).Return("token", nil)
-	s.secretService.EXPECT().ProcessCharmSecretConsumerLabel(gomock.Any(), "mariadb/0", uri, "").Return(uri, nil, nil)
-	s.secretsConsumer.EXPECT().GetSecretConsumer(gomock.Any(), uri, "mariadb/0").Return(&coresecrets.SecretConsumerMetadata{
+	s.secretService.EXPECT().ProcessCharmSecretConsumerLabel(gomock.Any(), unittesting.GenNewName(c, "mariadb/0"), uri, "").Return(uri, nil, nil)
+	s.secretsConsumer.EXPECT().GetSecretConsumer(gomock.Any(), uri, unittesting.GenNewName(c, "mariadb/0")).Return(&coresecrets.SecretConsumerMetadata{
 		CurrentRevision: 665,
 	}, nil)
 
@@ -735,8 +736,8 @@ func (s *SecretsManagerSuite) TestGetSecretContentCrossModelExistingConsumerNoRe
 	s.remoteClient.EXPECT().Close().Return(nil)
 
 	s.crossModelState.EXPECT().GetToken(names.NewApplicationTag("mariadb")).Return("token", nil)
-	s.secretService.EXPECT().ProcessCharmSecretConsumerLabel(gomock.Any(), "mariadb/0", uri, "foo").Return(uri, nil, nil)
-	s.secretsConsumer.EXPECT().GetSecretConsumer(gomock.Any(), uri, "mariadb/0").Return(&coresecrets.SecretConsumerMetadata{
+	s.secretService.EXPECT().ProcessCharmSecretConsumerLabel(gomock.Any(), unittesting.GenNewName(c, "mariadb/0"), uri, "foo").Return(uri, nil, nil)
+	s.secretsConsumer.EXPECT().GetSecretConsumer(gomock.Any(), uri, unittesting.GenNewName(c, "mariadb/0")).Return(&coresecrets.SecretConsumerMetadata{
 		CurrentRevision: 665,
 	}, nil)
 
@@ -802,8 +803,8 @@ func (s *SecretsManagerSuite) TestGetSecretContentCrossModelExistingConsumerRefr
 	s.remoteClient.EXPECT().Close().Return(nil)
 
 	s.crossModelState.EXPECT().GetToken(names.NewApplicationTag("mariadb")).Return("token", nil)
-	s.secretService.EXPECT().ProcessCharmSecretConsumerLabel(gomock.Any(), "mariadb/0", uri, "").Return(uri, nil, nil)
-	s.secretsConsumer.EXPECT().GetSecretConsumer(gomock.Any(), uri, "mariadb/0").Return(&coresecrets.SecretConsumerMetadata{
+	s.secretService.EXPECT().ProcessCharmSecretConsumerLabel(gomock.Any(), unittesting.GenNewName(c, "mariadb/0"), uri, "").Return(uri, nil, nil)
+	s.secretsConsumer.EXPECT().GetSecretConsumer(gomock.Any(), uri, unittesting.GenNewName(c, "mariadb/0")).Return(&coresecrets.SecretConsumerMetadata{
 		CurrentRevision: 665,
 	}, nil)
 
@@ -827,7 +828,7 @@ func (s *SecretsManagerSuite) TestGetSecretContentCrossModelExistingConsumerRefr
 			},
 		}, 666, true, nil)
 
-	s.secretsConsumer.EXPECT().SaveSecretConsumer(gomock.Any(), uri, "mariadb/0", &coresecrets.SecretConsumerMetadata{
+	s.secretsConsumer.EXPECT().SaveSecretConsumer(gomock.Any(), uri, unittesting.GenNewName(c, "mariadb/0"), &coresecrets.SecretConsumerMetadata{
 		CurrentRevision: 666,
 	})
 
@@ -881,8 +882,8 @@ func (s *SecretsManagerSuite) assertGetSecretContentCrossModelNewConsumer(c *gc.
 	s.remoteClient.EXPECT().Close().Return(nil)
 
 	s.crossModelState.EXPECT().GetToken(names.NewApplicationTag("mariadb")).Return("token", nil)
-	s.secretsConsumer.EXPECT().GetSecretConsumer(gomock.Any(), uri, "mariadb/0").Return(nil, consumerErr)
-	s.secretService.EXPECT().ProcessCharmSecretConsumerLabel(gomock.Any(), "mariadb/0", uri, "").Return(uri, nil, nil)
+	s.secretsConsumer.EXPECT().GetSecretConsumer(gomock.Any(), uri, unittesting.GenNewName(c, "mariadb/0")).Return(nil, consumerErr)
+	s.secretService.EXPECT().ProcessCharmSecretConsumerLabel(gomock.Any(), unittesting.GenNewName(c, "mariadb/0"), uri, "").Return(uri, nil, nil)
 
 	s.remoteClient.EXPECT().GetSecretAccessScope(gomock.Any(), uri, "token", 0).Return("scope-token", nil)
 	s.crossModelState.EXPECT().GetRemoteEntity("scope-token").Return(scopeTag, nil)
@@ -904,7 +905,7 @@ func (s *SecretsManagerSuite) assertGetSecretContentCrossModelNewConsumer(c *gc.
 			},
 		}, 666, true, nil)
 
-	s.secretsConsumer.EXPECT().SaveSecretConsumer(gomock.Any(), uri, "mariadb/0", &coresecrets.SecretConsumerMetadata{
+	s.secretsConsumer.EXPECT().SaveSecretConsumer(gomock.Any(), uri, unittesting.GenNewName(c, "mariadb/0"), &coresecrets.SecretConsumerMetadata{
 		CurrentRevision: 666,
 	})
 
@@ -939,7 +940,7 @@ func (s *SecretsManagerSuite) assertGetSecretContentCrossModelNewConsumer(c *gc.
 func (s *SecretsManagerSuite) TestWatchConsumedSecretsChanges(c *gc.C) {
 	defer s.setup(c).Finish()
 
-	s.secretsConsumer.EXPECT().WatchConsumedSecretsChanges(gomock.Any(), "mariadb/0").Return(
+	s.secretsConsumer.EXPECT().WatchConsumedSecretsChanges(gomock.Any(), unittesting.GenNewName(c, "mariadb/0")).Return(
 		s.secretsWatcher, nil,
 	)
 	s.watcherRegistry.EXPECT().Register(s.secretsWatcher).Return("1", nil)

--- a/apiserver/facades/agent/secretsmanager/service.go
+++ b/apiserver/facades/agent/secretsmanager/service.go
@@ -7,6 +7,7 @@ import (
 	"context"
 
 	"github.com/juju/juju/core/secrets"
+	"github.com/juju/juju/core/unit"
 	"github.com/juju/juju/core/watcher"
 	secretservice "github.com/juju/juju/domain/secret/service"
 	secretbackendservice "github.com/juju/juju/domain/secretbackend/service"
@@ -23,14 +24,14 @@ type SecretTriggers interface {
 
 // SecretsConsumer instances provide secret consumer apis.
 type SecretsConsumer interface {
-	GetSecretConsumer(ctx context.Context, uri *secrets.URI, unitName string) (*secrets.SecretConsumerMetadata, error)
-	GetSecretConsumerAndLatest(ctx context.Context, uri *secrets.URI, unitName string) (*secrets.SecretConsumerMetadata, int, error)
-	GetURIByConsumerLabel(ctx context.Context, label string, unitName string) (*secrets.URI, error)
-	SaveSecretConsumer(ctx context.Context, uri *secrets.URI, unitName string, md *secrets.SecretConsumerMetadata) error
+	GetSecretConsumer(ctx context.Context, uri *secrets.URI, unitName unit.Name) (*secrets.SecretConsumerMetadata, error)
+	GetSecretConsumerAndLatest(ctx context.Context, uri *secrets.URI, unitName unit.Name) (*secrets.SecretConsumerMetadata, int, error)
+	GetURIByConsumerLabel(ctx context.Context, label string, unitName unit.Name) (*secrets.URI, error)
+	SaveSecretConsumer(ctx context.Context, uri *secrets.URI, unitName unit.Name, md *secrets.SecretConsumerMetadata) error
 	GetConsumedRevision(
-		ctx context.Context, uri *secrets.URI, unitName string,
+		ctx context.Context, uri *secrets.URI, unitName unit.Name,
 		refresh, peek bool, labelToUpdate *string) (int, error)
-	WatchConsumedSecretsChanges(ctx context.Context, unitName string) (watcher.StringsWatcher, error)
+	WatchConsumedSecretsChanges(ctx context.Context, unitName unit.Name) (watcher.StringsWatcher, error)
 	GrantSecretAccess(context.Context, *secrets.URI, secretservice.SecretAccessParams) error
 	RevokeSecretAccess(context.Context, *secrets.URI, secretservice.SecretAccessParams) error
 }
@@ -41,7 +42,7 @@ type SecretService interface {
 	GetSecretValue(context.Context, *secrets.URI, int, secretservice.SecretAccessor) (secrets.SecretValue, *secrets.ValueRef, error)
 	ListCharmSecrets(context.Context, ...secretservice.CharmSecretOwner) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error)
 	ProcessCharmSecretConsumerLabel(
-		ctx context.Context, unitName string, uri *secrets.URI, label string,
+		ctx context.Context, unitName unit.Name, uri *secrets.URI, label string,
 	) (*secrets.URI, *string, error)
 	ChangeSecretBackend(ctx context.Context, uri *secrets.URI, revision int, params secretservice.ChangeSecretBackendParams) error
 	GetSecretGrants(ctx context.Context, uri *secrets.URI, role secrets.SecretRole) ([]secretservice.SecretAccess, error)

--- a/apiserver/facades/agent/uniter/secret_mocks_test.go
+++ b/apiserver/facades/agent/uniter/secret_mocks_test.go
@@ -14,6 +14,7 @@ import (
 	reflect "reflect"
 
 	secrets "github.com/juju/juju/core/secrets"
+	unit "github.com/juju/juju/core/unit"
 	service "github.com/juju/juju/domain/secret/service"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -118,7 +119,7 @@ func (c *MockSecretServiceDeleteSecretCall) DoAndReturn(f func(context.Context, 
 }
 
 // GetConsumedRevision mocks base method.
-func (m *MockSecretService) GetConsumedRevision(arg0 context.Context, arg1 *secrets.URI, arg2 string, arg3, arg4 bool, arg5 *string) (int, error) {
+func (m *MockSecretService) GetConsumedRevision(arg0 context.Context, arg1 *secrets.URI, arg2 unit.Name, arg3, arg4 bool, arg5 *string) (int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetConsumedRevision", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(int)
@@ -145,13 +146,13 @@ func (c *MockSecretServiceGetConsumedRevisionCall) Return(arg0 int, arg1 error) 
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSecretServiceGetConsumedRevisionCall) Do(f func(context.Context, *secrets.URI, string, bool, bool, *string) (int, error)) *MockSecretServiceGetConsumedRevisionCall {
+func (c *MockSecretServiceGetConsumedRevisionCall) Do(f func(context.Context, *secrets.URI, unit.Name, bool, bool, *string) (int, error)) *MockSecretServiceGetConsumedRevisionCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSecretServiceGetConsumedRevisionCall) DoAndReturn(f func(context.Context, *secrets.URI, string, bool, bool, *string) (int, error)) *MockSecretServiceGetConsumedRevisionCall {
+func (c *MockSecretServiceGetConsumedRevisionCall) DoAndReturn(f func(context.Context, *secrets.URI, unit.Name, bool, bool, *string) (int, error)) *MockSecretServiceGetConsumedRevisionCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/agent/uniter/secrets_test.go
+++ b/apiserver/facades/agent/uniter/secrets_test.go
@@ -19,6 +19,7 @@ import (
 
 	facademocks "github.com/juju/juju/apiserver/facade/mocks"
 	coresecrets "github.com/juju/juju/core/secrets"
+	unittesting "github.com/juju/juju/core/unit/testing"
 	secreterrors "github.com/juju/juju/domain/secret/errors"
 	secretservice "github.com/juju/juju/domain/secret/service"
 	"github.com/juju/juju/internal/secrets"
@@ -394,7 +395,7 @@ func (s *UniterSecretsSuite) TestUpdateTrackedRevisions(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	uri := coresecrets.NewURI()
-	s.secretService.EXPECT().GetConsumedRevision(gomock.Any(), uri, "mariadb/0", true, false, nil).
+	s.secretService.EXPECT().GetConsumedRevision(gomock.Any(), uri, unittesting.GenNewName(c, "mariadb/0"), true, false, nil).
 		Return(668, nil)
 	result, err := s.facade.updateTrackedRevisions(context.Background(), []string{uri.ID})
 	c.Assert(err, jc.ErrorIsNil)

--- a/apiserver/facades/controller/crossmodelsecrets/crossmodelsecrets.go
+++ b/apiserver/facades/controller/crossmodelsecrets/crossmodelsecrets.go
@@ -23,6 +23,7 @@ import (
 	corelogger "github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/model"
 	coresecrets "github.com/juju/juju/core/secrets"
+	"github.com/juju/juju/core/unit"
 	secreterrors "github.com/juju/juju/domain/secret/errors"
 	secretservice "github.com/juju/juju/domain/secret/service"
 	secretbackendservice "github.com/juju/juju/domain/secretbackend/service"
@@ -266,7 +267,11 @@ func (s *CrossModelSecretsAPI) getSecretContent(ctx context.Context, arg params.
 	// Use the latest revision as the current one if --peek.
 	if arg.Peek || arg.Refresh {
 		var err error
-		latestRevision, err = secretService.UpdateRemoteConsumedRevision(ctx, uri, consumer.Id(), arg.Refresh)
+		unitName, err := unit.NewName(consumer.Id())
+		if err != nil {
+			return nil, nil, 0, errors.Trace(err)
+		}
+		latestRevision, err = secretService.UpdateRemoteConsumedRevision(ctx, uri, unitName, arg.Refresh)
 		if err != nil {
 			return nil, nil, 0, errors.Trace(err)
 		}

--- a/apiserver/facades/controller/crossmodelsecrets/crossmodelsecrets_test.go
+++ b/apiserver/facades/controller/crossmodelsecrets/crossmodelsecrets_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/juju/juju/apiserver/facades/controller/crossmodelsecrets/mocks"
 	"github.com/juju/juju/core/model"
 	coresecrets "github.com/juju/juju/core/secrets"
+	unittesting "github.com/juju/juju/core/unit/testing"
 	secretservice "github.com/juju/juju/domain/secret/service"
 	secretbackendservice "github.com/juju/juju/domain/secretbackend/service"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
@@ -178,7 +179,7 @@ func (s *CrossModelSecretsSuite) assertGetSecretContentInfo(c *gc.C, newConsumer
 		Kind: secretservice.UnitAccessor,
 		ID:   "remote-app/666",
 	}
-	s.secretService.EXPECT().UpdateRemoteConsumedRevision(gomock.Any(), uri, "remote-app/666", true).Return(667, nil)
+	s.secretService.EXPECT().UpdateRemoteConsumedRevision(gomock.Any(), uri, unittesting.GenNewName(c, "remote-app/666"), true).Return(667, nil)
 	s.secretService.EXPECT().GetSecretValue(gomock.Any(), uri, 667, consumer).Return(
 		nil,
 		&coresecrets.ValueRef{

--- a/apiserver/facades/controller/crossmodelsecrets/mocks/secretservice.go
+++ b/apiserver/facades/controller/crossmodelsecrets/mocks/secretservice.go
@@ -14,6 +14,7 @@ import (
 	reflect "reflect"
 
 	secrets "github.com/juju/juju/core/secrets"
+	unit "github.com/juju/juju/core/unit"
 	service "github.com/juju/juju/domain/secret/service"
 	service0 "github.com/juju/juju/domain/secretbackend/service"
 	provider "github.com/juju/juju/internal/secrets/provider"
@@ -206,7 +207,7 @@ func (c *MockSecretServiceListGrantedSecretsForBackendCall) DoAndReturn(f func(c
 }
 
 // UpdateRemoteConsumedRevision mocks base method.
-func (m *MockSecretService) UpdateRemoteConsumedRevision(arg0 context.Context, arg1 *secrets.URI, arg2 string, arg3 bool) (int, error) {
+func (m *MockSecretService) UpdateRemoteConsumedRevision(arg0 context.Context, arg1 *secrets.URI, arg2 unit.Name, arg3 bool) (int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateRemoteConsumedRevision", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(int)
@@ -233,13 +234,13 @@ func (c *MockSecretServiceUpdateRemoteConsumedRevisionCall) Return(arg0 int, arg
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSecretServiceUpdateRemoteConsumedRevisionCall) Do(f func(context.Context, *secrets.URI, string, bool) (int, error)) *MockSecretServiceUpdateRemoteConsumedRevisionCall {
+func (c *MockSecretServiceUpdateRemoteConsumedRevisionCall) Do(f func(context.Context, *secrets.URI, unit.Name, bool) (int, error)) *MockSecretServiceUpdateRemoteConsumedRevisionCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSecretServiceUpdateRemoteConsumedRevisionCall) DoAndReturn(f func(context.Context, *secrets.URI, string, bool) (int, error)) *MockSecretServiceUpdateRemoteConsumedRevisionCall {
+func (c *MockSecretServiceUpdateRemoteConsumedRevisionCall) DoAndReturn(f func(context.Context, *secrets.URI, unit.Name, bool) (int, error)) *MockSecretServiceUpdateRemoteConsumedRevisionCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/controller/crossmodelsecrets/service.go
+++ b/apiserver/facades/controller/crossmodelsecrets/service.go
@@ -7,6 +7,7 @@ import (
 	"context"
 
 	"github.com/juju/juju/core/secrets"
+	"github.com/juju/juju/core/unit"
 	secretservice "github.com/juju/juju/domain/secret/service"
 	secretbackendservice "github.com/juju/juju/domain/secretbackend/service"
 	"github.com/juju/juju/internal/secrets/provider"
@@ -17,7 +18,7 @@ import (
 type SecretService interface {
 	GetSecret(context.Context, *secrets.URI) (*secrets.SecretMetadata, error)
 	GetSecretValue(context.Context, *secrets.URI, int, secretservice.SecretAccessor) (secrets.SecretValue, *secrets.ValueRef, error)
-	UpdateRemoteConsumedRevision(ctx context.Context, uri *secrets.URI, unitName string, refresh bool) (int, error)
+	UpdateRemoteConsumedRevision(ctx context.Context, uri *secrets.URI, unitName unit.Name, refresh bool) (int, error)
 	GetSecretAccessScope(ctx context.Context, uri *secrets.URI, accessor secretservice.SecretAccessor) (secretservice.SecretAccessScope, error)
 	ListGrantedSecretsForBackend(
 		ctx context.Context, backendID string, role secrets.SecretRole, consumers ...secretservice.SecretAccessor,

--- a/core/unit/name.go
+++ b/core/unit/name.go
@@ -65,3 +65,14 @@ func (n Name) Validate() error {
 	}
 	return nil
 }
+
+// Application returns the name of the application that the unit is
+// associated with. The name must be valid.
+func (n Name) Application() string {
+	s := validUnit.FindStringSubmatch(n.String())
+	if s == nil {
+		// Should never happen.
+		return ""
+	}
+	return s[1]
+}

--- a/core/unit/name_test.go
+++ b/core/unit/name_test.go
@@ -153,3 +153,9 @@ func (*unitNameSuite) TestNewNameFromParts(c *gc.C) {
 		c.Check(err, jc.ErrorIs, test.err)
 	}
 }
+
+func (*unitNameSuite) TestApplicationName(c *gc.C) {
+	unitName, err := NewName("app/666")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(unitName.Application(), gc.Equals, "app")
+}

--- a/core/unit/testing/testing.go
+++ b/core/unit/testing/testing.go
@@ -17,3 +17,11 @@ func GenUnitUUID(c *gc.C) coreunit.UUID {
 	c.Assert(err, jc.ErrorIsNil)
 	return uuid
 }
+
+// GenNewName returns a new unit name object.
+// It asserts that the unit name is valid.
+func GenNewName(c *gc.C, name string) coreunit.Name {
+	un, err := coreunit.NewName(name)
+	c.Assert(err, jc.ErrorIsNil)
+	return un
+}

--- a/domain/application/service/unit.go
+++ b/domain/application/service/unit.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 
 	"github.com/juju/errors"
-	"github.com/juju/names/v6"
 
 	"github.com/juju/juju/caas"
 	coreapplication "github.com/juju/juju/core/application"
@@ -244,10 +243,7 @@ func (s *Service) RegisterCAASUnit(ctx context.Context, appName string, args app
 // satisfying applicationerrors.ApplicationNotAlive if the unit's
 // application is not alive.
 func (s *Service) UpdateCAASUnit(ctx context.Context, unitName coreunit.Name, params UpdateCAASUnitParams) error {
-	appName, err := names.UnitApplication(unitName.String())
-	if err != nil {
-		return errors.Trace(err)
-	}
+	appName := unitName.Application()
 	_, appLife, err := s.st.GetApplicationLife(ctx, appName)
 	if err != nil {
 		return internalerrors.Errorf("getting application %q life: %w", appName, err)
@@ -304,7 +300,7 @@ func (s *Service) RemoveUnit(ctx context.Context, unitName coreunit.Name, leader
 	if err != nil {
 		return errors.Annotatef(err, "removing unit %q", unitName)
 	}
-	appName, _ := names.UnitApplication(unitName.String())
+	appName := unitName.Application()
 	if err := leadershipRevoker.RevokeLeadership(appName, unitName); err != nil && !errors.Is(err, leadership.ErrClaimNotHeld) {
 		s.logger.Warningf(ctx, "cannot revoke lease for dead unit %q", unitName)
 	}
@@ -345,7 +341,7 @@ func (s *Service) EnsureUnitDead(ctx context.Context, unitName coreunit.Name, le
 	} else if err != nil {
 		return errors.Annotatef(err, "marking unit %q is dead", unitName)
 	}
-	appName, _ := names.UnitApplication(unitName.String())
+	appName := unitName.Application()
 	if err := leadershipRevoker.RevokeLeadership(appName, unitName); err != nil && !errors.Is(err, leadership.ErrClaimNotHeld) {
 		s.logger.Warningf(ctx, "cannot revoke lease for dead unit %q", unitName)
 	}

--- a/domain/application/service_test.go
+++ b/domain/application/service_test.go
@@ -109,7 +109,7 @@ func (s *serviceSuite) TestDestroyApplication(c *gc.C) {
 	c.Assert(gotLife, gc.Equals, 1)
 }
 
-func (s *serviceSuite) createSecrets(c *gc.C, appUUID coreapplication.ID, unitName string) (appSecretURI *coresecrets.URI, unitSecretURI *coresecrets.URI) {
+func (s *serviceSuite) createSecrets(c *gc.C, appUUID coreapplication.ID, unitName coreunit.Name) (appSecretURI *coresecrets.URI, unitSecretURI *coresecrets.URI) {
 	ctx := context.Background()
 	appSecretURI = coresecrets.NewURI()
 	sp := domainsecret.UpsertSecretParams{

--- a/domain/secret/service/consume.go
+++ b/domain/secret/service/consume.go
@@ -9,6 +9,7 @@ import (
 	"github.com/juju/errors"
 
 	"github.com/juju/juju/core/secrets"
+	"github.com/juju/juju/core/unit"
 	domainsecret "github.com/juju/juju/domain/secret"
 	secreterrors "github.com/juju/juju/domain/secret/errors"
 )
@@ -19,7 +20,7 @@ import (
 // If the secret does not exist, an error satisfying [secreterrors.SecretNotFound] is returned.
 // If there's not currently a consumer record for the secret, the latest revision is still returned,
 // along with an error satisfying [secreterrors.SecretConsumerNotFound].
-func (s *SecretService) GetSecretConsumerAndLatest(ctx context.Context, uri *secrets.URI, unitName string) (*secrets.SecretConsumerMetadata, int, error) {
+func (s *SecretService) GetSecretConsumerAndLatest(ctx context.Context, uri *secrets.URI, unitName unit.Name) (*secrets.SecretConsumerMetadata, int, error) {
 	consumerMetadata, latestRevision, err := s.secretState.GetSecretConsumer(ctx, uri, unitName)
 	if err != nil {
 		return nil, latestRevision, errors.Trace(err)
@@ -46,7 +47,7 @@ func (s *SecretService) GetSecretConsumerAndLatest(ctx context.Context, uri *sec
 // If the secret does not exist, an error satisfying [secreterrors.SecretNotFound] is returned.
 // If there's not currently a consumer record for the secret, an error satisfying [secreterrors.SecretConsumerNotFound]
 // is returned.
-func (s *SecretService) GetSecretConsumer(ctx context.Context, uri *secrets.URI, unitName string) (*secrets.SecretConsumerMetadata, error) {
+func (s *SecretService) GetSecretConsumer(ctx context.Context, uri *secrets.URI, unitName unit.Name) (*secrets.SecretConsumerMetadata, error) {
 	result, _, err := s.GetSecretConsumerAndLatest(ctx, uri, unitName)
 	return result, err
 }
@@ -54,20 +55,20 @@ func (s *SecretService) GetSecretConsumer(ctx context.Context, uri *secrets.URI,
 // SaveSecretConsumer saves the consumer metadata for the given secret and unit.
 // If the unit does not exist, an error satisfying [applicationerrors.UnitNotFound] is returned.
 // If the secret does not exist, an error satisfying [secreterrors.SecretNotFound] is returned.
-func (s *SecretService) SaveSecretConsumer(ctx context.Context, uri *secrets.URI, unitName string, md *secrets.SecretConsumerMetadata) error {
+func (s *SecretService) SaveSecretConsumer(ctx context.Context, uri *secrets.URI, unitName unit.Name, md *secrets.SecretConsumerMetadata) error {
 	return s.secretState.SaveSecretConsumer(ctx, uri, unitName, md)
 }
 
 // GetURIByConsumerLabel looks up the secret URI using the label previously registered by the specified unit,
 // returning an error satisfying [secreterrors.SecretNotFound] if there's no corresponding URI.
 // If the unit does not exist, an error satisfying [applicationerrors.UnitNotFound] is returned.
-func (s *SecretService) GetURIByConsumerLabel(ctx context.Context, label string, unitName string) (*secrets.URI, error) {
+func (s *SecretService) GetURIByConsumerLabel(ctx context.Context, label string, unitName unit.Name) (*secrets.URI, error) {
 	return s.secretState.GetURIByConsumerLabel(ctx, label, unitName)
 }
 
 // GetConsumedRevision returns the secret revision number for the specified consumer, possibly updating
 // the label associated with the secret for the consumer.
-func (s *SecretService) GetConsumedRevision(ctx context.Context, uri *secrets.URI, unitName string, refresh, peek bool, labelToUpdate *string) (int, error) {
+func (s *SecretService) GetConsumedRevision(ctx context.Context, uri *secrets.URI, unitName unit.Name, refresh, peek bool, labelToUpdate *string) (int, error) {
 	consumerInfo, latestRevision, err := s.GetSecretConsumerAndLatest(ctx, uri, unitName)
 	if err != nil && !errors.Is(err, secreterrors.SecretConsumerNotFound) {
 		return 0, errors.Trace(err)
@@ -130,7 +131,7 @@ func (s *SecretService) ListGrantedSecretsForBackend(
 
 // UpdateRemoteConsumedRevision returns the latest revision for the specified secret,
 // updating the tracked revision for the specified consumer if refresh is true.
-func (s *SecretService) UpdateRemoteConsumedRevision(ctx context.Context, uri *secrets.URI, unitName string, refresh bool) (int, error) {
+func (s *SecretService) UpdateRemoteConsumedRevision(ctx context.Context, uri *secrets.URI, unitName unit.Name, refresh bool) (int, error) {
 	consumerInfo, latestRevision, err := s.secretState.GetSecretRemoteConsumer(ctx, uri, unitName)
 	if err != nil && !errors.Is(err, secreterrors.SecretConsumerNotFound) {
 		return 0, errors.Trace(err)

--- a/domain/secret/service/exportimport_test.go
+++ b/domain/secret/service/exportimport_test.go
@@ -13,6 +13,7 @@ import (
 
 	coreapplication "github.com/juju/juju/core/application"
 	coresecrets "github.com/juju/juju/core/secrets"
+	unittesting "github.com/juju/juju/core/unit/testing"
 	domainsecret "github.com/juju/juju/domain/secret"
 	domaintesting "github.com/juju/juju/domain/testing"
 	"github.com/juju/juju/internal/testing"
@@ -187,7 +188,7 @@ func (s *serviceSuite) TestImportSecrets(c *gc.C) {
 	}
 
 	s.state.EXPECT().UpdateRemoteSecretRevision(gomock.Any(), uri2, 668)
-	s.state.EXPECT().SaveSecretConsumer(gomock.Any(), uri2, "mysql/0", &coresecrets.SecretConsumerMetadata{
+	s.state.EXPECT().SaveSecretConsumer(gomock.Any(), uri2, unittesting.GenNewName(c, "mysql/0"), &coresecrets.SecretConsumerMetadata{
 		Label:           "remote label",
 		CurrentRevision: 666,
 	})
@@ -226,11 +227,11 @@ func (s *serviceSuite) TestImportSecrets(c *gc.C) {
 	}, s.modelID, s.fakeUUID.String()).Return(
 		func() error { return nil }, nil,
 	)
-	s.state.EXPECT().SaveSecretConsumer(gomock.Any(), uri, "mysql/0", &coresecrets.SecretConsumerMetadata{
+	s.state.EXPECT().SaveSecretConsumer(gomock.Any(), uri, unittesting.GenNewName(c, "mysql/0"), &coresecrets.SecretConsumerMetadata{
 		Label:           "my label",
 		CurrentRevision: 666,
 	})
-	s.state.EXPECT().SaveSecretRemoteConsumer(gomock.Any(), uri, "remote-app/0", &coresecrets.SecretConsumerMetadata{
+	s.state.EXPECT().SaveSecretRemoteConsumer(gomock.Any(), uri, unittesting.GenNewName(c, "remote-app/0"), &coresecrets.SecretConsumerMetadata{
 		CurrentRevision: 668,
 	})
 	s.state.EXPECT().GrantAccess(gomock.Any(), uri, domainsecret.GrantParams{

--- a/domain/secret/service/interface.go
+++ b/domain/secret/service/interface.go
@@ -32,7 +32,7 @@ type AtomicState interface {
 	) ([]*secrets.URI, error)
 
 	GetApplicationUUID(ctx domain.AtomicContext, appName string) (coreapplication.ID, error)
-	GetUnitUUID(ctx domain.AtomicContext, unitName string) (coreunit.UUID, error)
+	GetUnitUUID(ctx domain.AtomicContext, name coreunit.Name) (coreunit.UUID, error)
 	GetSecretOwner(ctx domain.AtomicContext, uri *secrets.URI) (domainsecret.Owner, error)
 
 	CheckUserSecretLabelExists(ctx domain.AtomicContext, label string) (bool, error)
@@ -66,12 +66,12 @@ type State interface {
 	ListCharmSecrets(ctx context.Context,
 		appOwners domainsecret.ApplicationOwners, unitOwners domainsecret.UnitOwners,
 	) ([]*secrets.SecretMetadata, [][]*secrets.SecretRevisionMetadata, error)
-	GetSecretConsumer(ctx context.Context, uri *secrets.URI, unitName string) (*secrets.SecretConsumerMetadata, int, error)
-	SaveSecretConsumer(ctx context.Context, uri *secrets.URI, unitName string, md *secrets.SecretConsumerMetadata) error
+	GetSecretConsumer(ctx context.Context, uri *secrets.URI, unitName coreunit.Name) (*secrets.SecretConsumerMetadata, int, error)
+	SaveSecretConsumer(ctx context.Context, uri *secrets.URI, unitName coreunit.Name, md *secrets.SecretConsumerMetadata) error
 	GetUserSecretURIByLabel(ctx context.Context, label string) (*secrets.URI, error)
-	GetURIByConsumerLabel(ctx context.Context, label string, unitName string) (*secrets.URI, error)
-	GetSecretRemoteConsumer(ctx context.Context, uri *secrets.URI, unitName string) (*secrets.SecretConsumerMetadata, int, error)
-	SaveSecretRemoteConsumer(ctx context.Context, uri *secrets.URI, unitName string, md *secrets.SecretConsumerMetadata) error
+	GetURIByConsumerLabel(ctx context.Context, label string, unitName coreunit.Name) (*secrets.URI, error)
+	GetSecretRemoteConsumer(ctx context.Context, uri *secrets.URI, unitName coreunit.Name) (*secrets.SecretConsumerMetadata, int, error)
+	SaveSecretRemoteConsumer(ctx context.Context, uri *secrets.URI, unitName coreunit.Name, md *secrets.SecretConsumerMetadata) error
 	UpdateRemoteSecretRevision(ctx context.Context, uri *secrets.URI, latestRevision int) error
 	GrantAccess(ctx context.Context, uri *secrets.URI, params domainsecret.GrantParams) error
 	RevokeAccess(ctx context.Context, uri *secrets.URI, params domainsecret.AccessParams) error
@@ -106,12 +106,12 @@ type State interface {
 	GetObsoleteUserSecretRevisionsReadyToPrune(ctx context.Context) ([]string, error)
 
 	// For watching consumed local secret changes.
-	InitialWatchStatementForConsumedSecretsChange(unitName string) (string, eventsource.NamespaceQuery)
-	GetConsumedSecretURIsWithChanges(ctx context.Context, unitName string, revisionIDs ...string) ([]string, error)
+	InitialWatchStatementForConsumedSecretsChange(unitName coreunit.Name) (string, eventsource.NamespaceQuery)
+	GetConsumedSecretURIsWithChanges(ctx context.Context, unitName coreunit.Name, revisionIDs ...string) ([]string, error)
 
 	// For watching consumed remote secret changes.
-	InitialWatchStatementForConsumedRemoteSecretsChange(unitName string) (string, eventsource.NamespaceQuery)
-	GetConsumedRemoteSecretURIsWithChanges(ctx context.Context, unitName string, secretIDs ...string) (secretURIs []string, err error)
+	InitialWatchStatementForConsumedRemoteSecretsChange(unitName coreunit.Name) (string, eventsource.NamespaceQuery)
+	GetConsumedRemoteSecretURIsWithChanges(ctx context.Context, unitName coreunit.Name, secretIDs ...string) (secretURIs []string, err error)
 
 	// For watching local secret changes that consumed by remote consumers.
 	InitialWatchStatementForRemoteConsumedSecretsChangesFromOfferingSide(appName string) (string, eventsource.NamespaceQuery)

--- a/domain/secret/service/package_mock_test.go
+++ b/domain/secret/service/package_mock_test.go
@@ -594,7 +594,7 @@ func (c *MockStateGetApplicationUUIDCall) DoAndReturn(f func(domain.AtomicContex
 }
 
 // GetConsumedRemoteSecretURIsWithChanges mocks base method.
-func (m *MockState) GetConsumedRemoteSecretURIsWithChanges(arg0 context.Context, arg1 string, arg2 ...string) ([]string, error) {
+func (m *MockState) GetConsumedRemoteSecretURIsWithChanges(arg0 context.Context, arg1 unit.Name, arg2 ...string) ([]string, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -626,19 +626,19 @@ func (c *MockStateGetConsumedRemoteSecretURIsWithChangesCall) Return(arg0 []stri
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetConsumedRemoteSecretURIsWithChangesCall) Do(f func(context.Context, string, ...string) ([]string, error)) *MockStateGetConsumedRemoteSecretURIsWithChangesCall {
+func (c *MockStateGetConsumedRemoteSecretURIsWithChangesCall) Do(f func(context.Context, unit.Name, ...string) ([]string, error)) *MockStateGetConsumedRemoteSecretURIsWithChangesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetConsumedRemoteSecretURIsWithChangesCall) DoAndReturn(f func(context.Context, string, ...string) ([]string, error)) *MockStateGetConsumedRemoteSecretURIsWithChangesCall {
+func (c *MockStateGetConsumedRemoteSecretURIsWithChangesCall) DoAndReturn(f func(context.Context, unit.Name, ...string) ([]string, error)) *MockStateGetConsumedRemoteSecretURIsWithChangesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetConsumedSecretURIsWithChanges mocks base method.
-func (m *MockState) GetConsumedSecretURIsWithChanges(arg0 context.Context, arg1 string, arg2 ...string) ([]string, error) {
+func (m *MockState) GetConsumedSecretURIsWithChanges(arg0 context.Context, arg1 unit.Name, arg2 ...string) ([]string, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -670,13 +670,13 @@ func (c *MockStateGetConsumedSecretURIsWithChangesCall) Return(arg0 []string, ar
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetConsumedSecretURIsWithChangesCall) Do(f func(context.Context, string, ...string) ([]string, error)) *MockStateGetConsumedSecretURIsWithChangesCall {
+func (c *MockStateGetConsumedSecretURIsWithChangesCall) Do(f func(context.Context, unit.Name, ...string) ([]string, error)) *MockStateGetConsumedSecretURIsWithChangesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetConsumedSecretURIsWithChangesCall) DoAndReturn(f func(context.Context, string, ...string) ([]string, error)) *MockStateGetConsumedSecretURIsWithChangesCall {
+func (c *MockStateGetConsumedSecretURIsWithChangesCall) DoAndReturn(f func(context.Context, unit.Name, ...string) ([]string, error)) *MockStateGetConsumedSecretURIsWithChangesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1082,7 +1082,7 @@ func (c *MockStateGetSecretAccessScopeCall) DoAndReturn(f func(context.Context, 
 }
 
 // GetSecretConsumer mocks base method.
-func (m *MockState) GetSecretConsumer(arg0 context.Context, arg1 *secrets.URI, arg2 string) (*secrets.SecretConsumerMetadata, int, error) {
+func (m *MockState) GetSecretConsumer(arg0 context.Context, arg1 *secrets.URI, arg2 unit.Name) (*secrets.SecretConsumerMetadata, int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSecretConsumer", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*secrets.SecretConsumerMetadata)
@@ -1110,13 +1110,13 @@ func (c *MockStateGetSecretConsumerCall) Return(arg0 *secrets.SecretConsumerMeta
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetSecretConsumerCall) Do(f func(context.Context, *secrets.URI, string) (*secrets.SecretConsumerMetadata, int, error)) *MockStateGetSecretConsumerCall {
+func (c *MockStateGetSecretConsumerCall) Do(f func(context.Context, *secrets.URI, unit.Name) (*secrets.SecretConsumerMetadata, int, error)) *MockStateGetSecretConsumerCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetSecretConsumerCall) DoAndReturn(f func(context.Context, *secrets.URI, string) (*secrets.SecretConsumerMetadata, int, error)) *MockStateGetSecretConsumerCall {
+func (c *MockStateGetSecretConsumerCall) DoAndReturn(f func(context.Context, *secrets.URI, unit.Name) (*secrets.SecretConsumerMetadata, int, error)) *MockStateGetSecretConsumerCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1200,7 +1200,7 @@ func (c *MockStateGetSecretOwnerCall) DoAndReturn(f func(domain.AtomicContext, *
 }
 
 // GetSecretRemoteConsumer mocks base method.
-func (m *MockState) GetSecretRemoteConsumer(arg0 context.Context, arg1 *secrets.URI, arg2 string) (*secrets.SecretConsumerMetadata, int, error) {
+func (m *MockState) GetSecretRemoteConsumer(arg0 context.Context, arg1 *secrets.URI, arg2 unit.Name) (*secrets.SecretConsumerMetadata, int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSecretRemoteConsumer", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*secrets.SecretConsumerMetadata)
@@ -1228,13 +1228,13 @@ func (c *MockStateGetSecretRemoteConsumerCall) Return(arg0 *secrets.SecretConsum
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetSecretRemoteConsumerCall) Do(f func(context.Context, *secrets.URI, string) (*secrets.SecretConsumerMetadata, int, error)) *MockStateGetSecretRemoteConsumerCall {
+func (c *MockStateGetSecretRemoteConsumerCall) Do(f func(context.Context, *secrets.URI, unit.Name) (*secrets.SecretConsumerMetadata, int, error)) *MockStateGetSecretRemoteConsumerCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetSecretRemoteConsumerCall) DoAndReturn(f func(context.Context, *secrets.URI, string) (*secrets.SecretConsumerMetadata, int, error)) *MockStateGetSecretRemoteConsumerCall {
+func (c *MockStateGetSecretRemoteConsumerCall) DoAndReturn(f func(context.Context, *secrets.URI, unit.Name) (*secrets.SecretConsumerMetadata, int, error)) *MockStateGetSecretRemoteConsumerCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1446,7 +1446,7 @@ func (c *MockStateGetSecretsRotationChangesCall) DoAndReturn(f func(context.Cont
 }
 
 // GetURIByConsumerLabel mocks base method.
-func (m *MockState) GetURIByConsumerLabel(arg0 context.Context, arg1, arg2 string) (*secrets.URI, error) {
+func (m *MockState) GetURIByConsumerLabel(arg0 context.Context, arg1 string, arg2 unit.Name) (*secrets.URI, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetURIByConsumerLabel", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*secrets.URI)
@@ -1473,19 +1473,19 @@ func (c *MockStateGetURIByConsumerLabelCall) Return(arg0 *secrets.URI, arg1 erro
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetURIByConsumerLabelCall) Do(f func(context.Context, string, string) (*secrets.URI, error)) *MockStateGetURIByConsumerLabelCall {
+func (c *MockStateGetURIByConsumerLabelCall) Do(f func(context.Context, string, unit.Name) (*secrets.URI, error)) *MockStateGetURIByConsumerLabelCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetURIByConsumerLabelCall) DoAndReturn(f func(context.Context, string, string) (*secrets.URI, error)) *MockStateGetURIByConsumerLabelCall {
+func (c *MockStateGetURIByConsumerLabelCall) DoAndReturn(f func(context.Context, string, unit.Name) (*secrets.URI, error)) *MockStateGetURIByConsumerLabelCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetUnitUUID mocks base method.
-func (m *MockState) GetUnitUUID(arg0 domain.AtomicContext, arg1 string) (unit.UUID, error) {
+func (m *MockState) GetUnitUUID(arg0 domain.AtomicContext, arg1 unit.Name) (unit.UUID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetUnitUUID", arg0, arg1)
 	ret0, _ := ret[0].(unit.UUID)
@@ -1512,13 +1512,13 @@ func (c *MockStateGetUnitUUIDCall) Return(arg0 unit.UUID, arg1 error) *MockState
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetUnitUUIDCall) Do(f func(domain.AtomicContext, string) (unit.UUID, error)) *MockStateGetUnitUUIDCall {
+func (c *MockStateGetUnitUUIDCall) Do(f func(domain.AtomicContext, unit.Name) (unit.UUID, error)) *MockStateGetUnitUUIDCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetUnitUUIDCall) DoAndReturn(f func(domain.AtomicContext, string) (unit.UUID, error)) *MockStateGetUnitUUIDCall {
+func (c *MockStateGetUnitUUIDCall) DoAndReturn(f func(domain.AtomicContext, unit.Name) (unit.UUID, error)) *MockStateGetUnitUUIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1601,7 +1601,7 @@ func (c *MockStateGrantAccessCall) DoAndReturn(f func(context.Context, *secrets.
 }
 
 // InitialWatchStatementForConsumedRemoteSecretsChange mocks base method.
-func (m *MockState) InitialWatchStatementForConsumedRemoteSecretsChange(arg0 string) (string, eventsource.NamespaceQuery) {
+func (m *MockState) InitialWatchStatementForConsumedRemoteSecretsChange(arg0 unit.Name) (string, eventsource.NamespaceQuery) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InitialWatchStatementForConsumedRemoteSecretsChange", arg0)
 	ret0, _ := ret[0].(string)
@@ -1628,19 +1628,19 @@ func (c *MockStateInitialWatchStatementForConsumedRemoteSecretsChangeCall) Retur
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateInitialWatchStatementForConsumedRemoteSecretsChangeCall) Do(f func(string) (string, eventsource.NamespaceQuery)) *MockStateInitialWatchStatementForConsumedRemoteSecretsChangeCall {
+func (c *MockStateInitialWatchStatementForConsumedRemoteSecretsChangeCall) Do(f func(unit.Name) (string, eventsource.NamespaceQuery)) *MockStateInitialWatchStatementForConsumedRemoteSecretsChangeCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateInitialWatchStatementForConsumedRemoteSecretsChangeCall) DoAndReturn(f func(string) (string, eventsource.NamespaceQuery)) *MockStateInitialWatchStatementForConsumedRemoteSecretsChangeCall {
+func (c *MockStateInitialWatchStatementForConsumedRemoteSecretsChangeCall) DoAndReturn(f func(unit.Name) (string, eventsource.NamespaceQuery)) *MockStateInitialWatchStatementForConsumedRemoteSecretsChangeCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // InitialWatchStatementForConsumedSecretsChange mocks base method.
-func (m *MockState) InitialWatchStatementForConsumedSecretsChange(arg0 string) (string, eventsource.NamespaceQuery) {
+func (m *MockState) InitialWatchStatementForConsumedSecretsChange(arg0 unit.Name) (string, eventsource.NamespaceQuery) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InitialWatchStatementForConsumedSecretsChange", arg0)
 	ret0, _ := ret[0].(string)
@@ -1667,13 +1667,13 @@ func (c *MockStateInitialWatchStatementForConsumedSecretsChangeCall) Return(arg0
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateInitialWatchStatementForConsumedSecretsChangeCall) Do(f func(string) (string, eventsource.NamespaceQuery)) *MockStateInitialWatchStatementForConsumedSecretsChangeCall {
+func (c *MockStateInitialWatchStatementForConsumedSecretsChangeCall) Do(f func(unit.Name) (string, eventsource.NamespaceQuery)) *MockStateInitialWatchStatementForConsumedSecretsChangeCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateInitialWatchStatementForConsumedSecretsChangeCall) DoAndReturn(f func(string) (string, eventsource.NamespaceQuery)) *MockStateInitialWatchStatementForConsumedSecretsChangeCall {
+func (c *MockStateInitialWatchStatementForConsumedSecretsChangeCall) DoAndReturn(f func(unit.Name) (string, eventsource.NamespaceQuery)) *MockStateInitialWatchStatementForConsumedSecretsChangeCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -2108,7 +2108,7 @@ func (c *MockStateRunAtomicCall) DoAndReturn(f func(context.Context, func(domain
 }
 
 // SaveSecretConsumer mocks base method.
-func (m *MockState) SaveSecretConsumer(arg0 context.Context, arg1 *secrets.URI, arg2 string, arg3 *secrets.SecretConsumerMetadata) error {
+func (m *MockState) SaveSecretConsumer(arg0 context.Context, arg1 *secrets.URI, arg2 unit.Name, arg3 *secrets.SecretConsumerMetadata) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SaveSecretConsumer", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
@@ -2134,19 +2134,19 @@ func (c *MockStateSaveSecretConsumerCall) Return(arg0 error) *MockStateSaveSecre
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateSaveSecretConsumerCall) Do(f func(context.Context, *secrets.URI, string, *secrets.SecretConsumerMetadata) error) *MockStateSaveSecretConsumerCall {
+func (c *MockStateSaveSecretConsumerCall) Do(f func(context.Context, *secrets.URI, unit.Name, *secrets.SecretConsumerMetadata) error) *MockStateSaveSecretConsumerCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateSaveSecretConsumerCall) DoAndReturn(f func(context.Context, *secrets.URI, string, *secrets.SecretConsumerMetadata) error) *MockStateSaveSecretConsumerCall {
+func (c *MockStateSaveSecretConsumerCall) DoAndReturn(f func(context.Context, *secrets.URI, unit.Name, *secrets.SecretConsumerMetadata) error) *MockStateSaveSecretConsumerCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // SaveSecretRemoteConsumer mocks base method.
-func (m *MockState) SaveSecretRemoteConsumer(arg0 context.Context, arg1 *secrets.URI, arg2 string, arg3 *secrets.SecretConsumerMetadata) error {
+func (m *MockState) SaveSecretRemoteConsumer(arg0 context.Context, arg1 *secrets.URI, arg2 unit.Name, arg3 *secrets.SecretConsumerMetadata) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SaveSecretRemoteConsumer", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
@@ -2172,13 +2172,13 @@ func (c *MockStateSaveSecretRemoteConsumerCall) Return(arg0 error) *MockStateSav
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateSaveSecretRemoteConsumerCall) Do(f func(context.Context, *secrets.URI, string, *secrets.SecretConsumerMetadata) error) *MockStateSaveSecretRemoteConsumerCall {
+func (c *MockStateSaveSecretRemoteConsumerCall) Do(f func(context.Context, *secrets.URI, unit.Name, *secrets.SecretConsumerMetadata) error) *MockStateSaveSecretRemoteConsumerCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateSaveSecretRemoteConsumerCall) DoAndReturn(f func(context.Context, *secrets.URI, string, *secrets.SecretConsumerMetadata) error) *MockStateSaveSecretRemoteConsumerCall {
+func (c *MockStateSaveSecretRemoteConsumerCall) DoAndReturn(f func(context.Context, *secrets.URI, unit.Name, *secrets.SecretConsumerMetadata) error) *MockStateSaveSecretRemoteConsumerCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/secret/service/service_test.go
+++ b/domain/secret/service/service_test.go
@@ -22,6 +22,7 @@ import (
 	modeltesting "github.com/juju/juju/core/model/testing"
 	coresecrets "github.com/juju/juju/core/secrets"
 	coreunit "github.com/juju/juju/core/unit"
+	unittesting "github.com/juju/juju/core/unit/testing"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/core/watcher/eventsource"
 	"github.com/juju/juju/core/watcher/watchertest"
@@ -417,7 +418,7 @@ func (s *serviceSuite) TestCreateCharmUnitSecret(c *gc.C) {
 	unitUUID, err := coreunit.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.state.EXPECT().GetUnitUUID(domaintesting.IsAtomicContextChecker, "mariadb/0").Return(unitUUID, nil)
+	s.state.EXPECT().GetUnitUUID(domaintesting.IsAtomicContextChecker, unittesting.GenNewName(c, "mariadb/0")).Return(unitUUID, nil)
 	s.state.EXPECT().CheckUnitSecretLabelExists(domaintesting.IsAtomicContextChecker, unitUUID, "my secret").Return(false, nil)
 	s.state.EXPECT().CreateCharmUnitSecret(domaintesting.IsAtomicContextChecker, 1, uri, unitUUID, gomock.AssignableToTypeOf(p)).
 		DoAndReturn(func(_ domain.AtomicContext, _ int, _ *coresecrets.URI, _ coreunit.UUID, got domainsecret.UpsertSecretParams) error {
@@ -468,7 +469,7 @@ func (s *serviceSuite) TestCreateCharmUnitSecretFailedLabelAlreadyExists(c *gc.C
 	unitUUID, err := coreunit.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
 
-	s.state.EXPECT().GetUnitUUID(domaintesting.IsAtomicContextChecker, "mariadb/0").Return(unitUUID, nil)
+	s.state.EXPECT().GetUnitUUID(domaintesting.IsAtomicContextChecker, unittesting.GenNewName(c, "mariadb/0")).Return(unitUUID, nil)
 	s.state.EXPECT().CheckUnitSecretLabelExists(domaintesting.IsAtomicContextChecker, unitUUID, "my secret").Return(true, nil)
 	s.state.EXPECT().GetModelUUID(gomock.Any()).Return(s.modelID, nil)
 	rollbackCalled := false
@@ -902,7 +903,7 @@ func (s *serviceSuite) TestGetSecretConsumer(c *gc.C) {
 		CurrentRevision: 666,
 	}
 
-	s.state.EXPECT().GetSecretConsumer(gomock.Any(), uri, "mysql/0").Return(consumer, 666, nil)
+	s.state.EXPECT().GetSecretConsumer(gomock.Any(), uri, unittesting.GenNewName(c, "mysql/0")).Return(consumer, 666, nil)
 
 	got, err := s.service.GetSecretConsumer(context.Background(), uri, "mysql/0")
 	c.Assert(err, jc.ErrorIsNil)
@@ -918,7 +919,7 @@ func (s *serviceSuite) TestGetSecretConsumerAndLatest(c *gc.C) {
 		CurrentRevision: 666,
 	}
 
-	s.state.EXPECT().GetSecretConsumer(gomock.Any(), uri, "mysql/0").Return(consumer, 666, nil)
+	s.state.EXPECT().GetSecretConsumer(gomock.Any(), uri, unittesting.GenNewName(c, "mysql/0")).Return(consumer, 666, nil)
 
 	got, latest, err := s.service.GetSecretConsumerAndLatest(context.Background(), uri, "mysql/0")
 	c.Assert(err, jc.ErrorIsNil)
@@ -935,7 +936,7 @@ func (s *serviceSuite) TestSaveSecretConsumer(c *gc.C) {
 		CurrentRevision: 666,
 	}
 
-	s.state.EXPECT().SaveSecretConsumer(gomock.Any(), uri, "mysql/0", consumer).Return(nil)
+	s.state.EXPECT().SaveSecretConsumer(gomock.Any(), uri, unittesting.GenNewName(c, "mysql/0"), consumer).Return(nil)
 
 	err := s.service.SaveSecretConsumer(context.Background(), uri, "mysql/0", consumer)
 	c.Assert(err, jc.ErrorIsNil)
@@ -1066,7 +1067,7 @@ func (s *serviceSuite) TestGetURIByConsumerLabel(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	uri := coresecrets.NewURI()
-	s.state.EXPECT().GetURIByConsumerLabel(gomock.Any(), "my label", "mysql/0").Return(uri, nil)
+	s.state.EXPECT().GetURIByConsumerLabel(gomock.Any(), "my label", unittesting.GenNewName(c, "mysql/0")).Return(uri, nil)
 
 	got, err := s.service.GetURIByConsumerLabel(context.Background(), "my label", "mysql/0")
 	c.Assert(err, jc.ErrorIsNil)
@@ -1087,10 +1088,10 @@ func (s *serviceSuite) TestUpdateRemoteConsumedRevision(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	uri := coresecrets.NewURI()
-	s.state.EXPECT().GetSecretRemoteConsumer(gomock.Any(), uri, "remote-app/0").
+	s.state.EXPECT().GetSecretRemoteConsumer(gomock.Any(), uri, unittesting.GenNewName(c, "remote-app/0")).
 		Return(&coresecrets.SecretConsumerMetadata{}, 666, nil)
 
-	got, err := s.service.UpdateRemoteConsumedRevision(context.Background(), uri, "remote-app/0", false)
+	got, err := s.service.UpdateRemoteConsumedRevision(context.Background(), uri, unittesting.GenNewName(c, "remote-app/0"), false)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(got, gc.Equals, 666)
 }
@@ -1102,11 +1103,11 @@ func (s *serviceSuite) TestUpdateRemoteConsumedRevisionRefresh(c *gc.C) {
 		CurrentRevision: 666,
 	}
 	uri := coresecrets.NewURI()
-	s.state.EXPECT().GetSecretRemoteConsumer(gomock.Any(), uri, "remote-app/0").
+	s.state.EXPECT().GetSecretRemoteConsumer(gomock.Any(), uri, unittesting.GenNewName(c, "remote-app/0")).
 		Return(&coresecrets.SecretConsumerMetadata{}, 666, nil)
-	s.state.EXPECT().SaveSecretRemoteConsumer(gomock.Any(), uri, "remote-app/0", consumer).Return(nil)
+	s.state.EXPECT().SaveSecretRemoteConsumer(gomock.Any(), uri, unittesting.GenNewName(c, "remote-app/0"), consumer).Return(nil)
 
-	got, err := s.service.UpdateRemoteConsumedRevision(context.Background(), uri, "remote-app/0", true)
+	got, err := s.service.UpdateRemoteConsumedRevision(context.Background(), uri, unittesting.GenNewName(c, "remote-app/0"), true)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(got, gc.Equals, 666)
 }
@@ -1118,11 +1119,11 @@ func (s *serviceSuite) TestUpdateRemoteConsumedRevisionFirstTimeRefresh(c *gc.C)
 		CurrentRevision: 666,
 	}
 	uri := coresecrets.NewURI()
-	s.state.EXPECT().GetSecretRemoteConsumer(gomock.Any(), uri, "remote-app/0").
+	s.state.EXPECT().GetSecretRemoteConsumer(gomock.Any(), uri, unittesting.GenNewName(c, "remote-app/0")).
 		Return(nil, 666, secreterrors.SecretConsumerNotFound)
-	s.state.EXPECT().SaveSecretRemoteConsumer(gomock.Any(), uri, "remote-app/0", consumer).Return(nil)
+	s.state.EXPECT().SaveSecretRemoteConsumer(gomock.Any(), uri, unittesting.GenNewName(c, "remote-app/0"), consumer).Return(nil)
 
-	got, err := s.service.UpdateRemoteConsumedRevision(context.Background(), uri, "remote-app/0", true)
+	got, err := s.service.UpdateRemoteConsumedRevision(context.Background(), uri, unittesting.GenNewName(c, "remote-app/0"), true)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(got, gc.Equals, 666)
 }
@@ -1715,8 +1716,8 @@ func (s *serviceSuite) TestGetConsumedRevisionFirstTime(c *gc.C) {
 
 	uri := coresecrets.NewURI()
 
-	s.state.EXPECT().GetSecretConsumer(gomock.Any(), uri, "mariadb/0").Return(nil, 666, secreterrors.SecretConsumerNotFound)
-	s.state.EXPECT().SaveSecretConsumer(gomock.Any(), uri, "mariadb/0", &coresecrets.SecretConsumerMetadata{
+	s.state.EXPECT().GetSecretConsumer(gomock.Any(), uri, unittesting.GenNewName(c, "mariadb/0")).Return(nil, 666, secreterrors.SecretConsumerNotFound)
+	s.state.EXPECT().SaveSecretConsumer(gomock.Any(), uri, unittesting.GenNewName(c, "mariadb/0"), &coresecrets.SecretConsumerMetadata{
 		CurrentRevision: 666,
 	})
 
@@ -1730,8 +1731,8 @@ func (s *serviceSuite) TestGetConsumedRevisionFirstTimeUpdateLabel(c *gc.C) {
 
 	uri := coresecrets.NewURI()
 
-	s.state.EXPECT().GetSecretConsumer(gomock.Any(), uri, "mariadb/0").Return(nil, 666, secreterrors.SecretConsumerNotFound)
-	s.state.EXPECT().SaveSecretConsumer(gomock.Any(), uri, "mariadb/0", &coresecrets.SecretConsumerMetadata{
+	s.state.EXPECT().GetSecretConsumer(gomock.Any(), uri, unittesting.GenNewName(c, "mariadb/0")).Return(nil, 666, secreterrors.SecretConsumerNotFound)
+	s.state.EXPECT().SaveSecretConsumer(gomock.Any(), uri, unittesting.GenNewName(c, "mariadb/0"), &coresecrets.SecretConsumerMetadata{
 		Label:           "label",
 		CurrentRevision: 666,
 	})
@@ -1746,11 +1747,11 @@ func (s *serviceSuite) TestGetSecretConsumedRevisionUpdateLabel(c *gc.C) {
 
 	uri := coresecrets.NewURI()
 
-	s.state.EXPECT().GetSecretConsumer(gomock.Any(), uri, "mariadb/0").Return(&coresecrets.SecretConsumerMetadata{
+	s.state.EXPECT().GetSecretConsumer(gomock.Any(), uri, unittesting.GenNewName(c, "mariadb/0")).Return(&coresecrets.SecretConsumerMetadata{
 		Label:           "old-label",
 		CurrentRevision: 666,
 	}, 666, nil)
-	s.state.EXPECT().SaveSecretConsumer(gomock.Any(), uri, "mariadb/0", &coresecrets.SecretConsumerMetadata{
+	s.state.EXPECT().SaveSecretConsumer(gomock.Any(), uri, unittesting.GenNewName(c, "mariadb/0"), &coresecrets.SecretConsumerMetadata{
 		Label:           "new-label",
 		CurrentRevision: 666,
 	})
@@ -1765,11 +1766,11 @@ func (s *serviceSuite) TestGetSecretConsumedRevisionRefresh(c *gc.C) {
 
 	uri := coresecrets.NewURI()
 
-	s.state.EXPECT().GetSecretConsumer(gomock.Any(), uri, "mariadb/0").Return(&coresecrets.SecretConsumerMetadata{
+	s.state.EXPECT().GetSecretConsumer(gomock.Any(), uri, unittesting.GenNewName(c, "mariadb/0")).Return(&coresecrets.SecretConsumerMetadata{
 		Label:           "old-label",
 		CurrentRevision: 666,
 	}, 668, nil)
-	s.state.EXPECT().SaveSecretConsumer(gomock.Any(), uri, "mariadb/0", &coresecrets.SecretConsumerMetadata{
+	s.state.EXPECT().SaveSecretConsumer(gomock.Any(), uri, unittesting.GenNewName(c, "mariadb/0"), &coresecrets.SecretConsumerMetadata{
 		Label:           "old-label",
 		CurrentRevision: 668,
 	})
@@ -1784,7 +1785,7 @@ func (s *serviceSuite) TestGetSecretConsumedRevisionPeek(c *gc.C) {
 
 	uri := coresecrets.NewURI()
 
-	s.state.EXPECT().GetSecretConsumer(gomock.Any(), uri, "mariadb/0").Return(&coresecrets.SecretConsumerMetadata{
+	s.state.EXPECT().GetSecretConsumer(gomock.Any(), uri, unittesting.GenNewName(c, "mariadb/0")).Return(&coresecrets.SecretConsumerMetadata{
 		Label:           "old-label",
 		CurrentRevision: 666,
 	}, 668, nil)
@@ -1799,10 +1800,10 @@ func (s *serviceSuite) TestGetSecretConsumedRevisionSecretNotFound(c *gc.C) {
 
 	uri := coresecrets.NewURI()
 
-	s.state.EXPECT().GetSecretConsumer(gomock.Any(), uri, "mariadb/0").Return(&coresecrets.SecretConsumerMetadata{
+	s.state.EXPECT().GetSecretConsumer(gomock.Any(), uri, unittesting.GenNewName(c, "mariadb/0")).Return(&coresecrets.SecretConsumerMetadata{
 		CurrentRevision: 666,
 	}, 668, nil)
-	s.state.EXPECT().SaveSecretConsumer(gomock.Any(), uri, "mariadb/0", &coresecrets.SecretConsumerMetadata{
+	s.state.EXPECT().SaveSecretConsumer(gomock.Any(), uri, unittesting.GenNewName(c, "mariadb/0"), &coresecrets.SecretConsumerMetadata{
 		CurrentRevision: 668,
 	})
 
@@ -1899,7 +1900,7 @@ func (s *serviceSuite) TestProcessCharmSecretConsumerLabelLookupURI(c *gc.C) {
 	s.state.EXPECT().ListCharmSecrets(gomock.Any(), domainsecret.ApplicationOwners{"mariadb"}, domainsecret.UnitOwners{"mariadb/0"}).
 		Return(md, revs, nil)
 	s.state.EXPECT().GetModelUUID(gomock.Any()).Return(coremodel.UUID(coretesting.ModelTag.Id()), nil)
-	s.state.EXPECT().GetURIByConsumerLabel(gomock.Any(), "foo", "mariadb/0").Return(uri, nil)
+	s.state.EXPECT().GetURIByConsumerLabel(gomock.Any(), "foo", unittesting.GenNewName(c, "mariadb/0")).Return(uri, nil)
 
 	gotURI, gotLabel, err := s.service.ProcessCharmSecretConsumerLabel(context.Background(), "mariadb/0", nil, "foo")
 	c.Assert(err, jc.ErrorIsNil)
@@ -2067,16 +2068,16 @@ func (s *serviceSuite) TestWatchConsumedSecretsChanges(c *gc.C) {
 	var namespaceQuery eventsource.NamespaceQuery = func(context.Context, database.TxnRunner) ([]string, error) {
 		return nil, nil
 	}
-	s.state.EXPECT().InitialWatchStatementForConsumedSecretsChange("mysql/0").Return("secret_revision", namespaceQuery)
-	s.state.EXPECT().InitialWatchStatementForConsumedRemoteSecretsChange("mysql/0").Return("secret_reference", namespaceQuery)
+	s.state.EXPECT().InitialWatchStatementForConsumedSecretsChange(unittesting.GenNewName(c, "mysql/0")).Return("secret_revision", namespaceQuery)
+	s.state.EXPECT().InitialWatchStatementForConsumedRemoteSecretsChange(unittesting.GenNewName(c, "mysql/0")).Return("secret_reference", namespaceQuery)
 	mockWatcherFactory.EXPECT().NewNamespaceWatcher("secret_revision", changestream.Changed, gomock.Any()).Return(mockStringWatcher, nil)
 	mockWatcherFactory.EXPECT().NewNamespaceWatcher("secret_reference", changestream.All, gomock.Any()).Return(mockStringWatcherRemote, nil)
 
 	s.state.EXPECT().GetConsumedSecretURIsWithChanges(gomock.Any(),
-		"mysql/0", "revision-uuid-1",
+		unittesting.GenNewName(c, "mysql/0"), "revision-uuid-1",
 	).Return([]string{uri1.String()}, nil)
 	s.state.EXPECT().GetConsumedRemoteSecretURIsWithChanges(gomock.Any(),
-		"mysql/0", "revision-uuid-2",
+		unittesting.GenNewName(c, "mysql/0"), "revision-uuid-2",
 	).Return([]string{uri2.String()}, nil)
 
 	svc := NewWatchableService(

--- a/domain/secret/service/watcher.go
+++ b/domain/secret/service/watcher.go
@@ -16,6 +16,7 @@ import (
 	coredatabase "github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/leadership"
 	"github.com/juju/juju/core/logger"
+	coreunit "github.com/juju/juju/core/unit"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/core/watcher/eventsource"
 )
@@ -43,7 +44,7 @@ func NewWatchableService(
 
 // WatchConsumedSecretsChanges watches secrets consumed by the specified unit
 // and returns a watcher which notifies of secret URIs that have had a new revision added.
-func (s *WatchableService) WatchConsumedSecretsChanges(ctx context.Context, unitName string) (watcher.StringsWatcher, error) {
+func (s *WatchableService) WatchConsumedSecretsChanges(ctx context.Context, unitName coreunit.Name) (watcher.StringsWatcher, error) {
 	tableLocal, queryLocal := s.secretState.InitialWatchStatementForConsumedSecretsChange(unitName)
 	wLocal, err := s.watcherFactory.NewNamespaceWatcher(
 		// We are only interested in CREATE changes because

--- a/domain/secret/state/package_test.go
+++ b/domain/secret/state/package_test.go
@@ -30,7 +30,7 @@ func getApplicationUUID(ctx context.Context, st *State, appName string) (coreapp
 	return uuid, err
 }
 
-func getUnitUUID(ctx context.Context, st *State, unitName string) (coreunit.UUID, error) {
+func getUnitUUID(ctx context.Context, st *State, unitName coreunit.Name) (coreunit.UUID, error) {
 	var uuid coreunit.UUID
 	err := st.RunAtomic(ctx, func(ctx domain.AtomicContext) error {
 		var err error
@@ -96,7 +96,7 @@ func createCharmApplicationSecret(ctx context.Context, st *State, version int, u
 	})
 }
 
-func createCharmUnitSecret(ctx context.Context, st *State, version int, uri *coresecrets.URI, unitName string, secret domainsecret.UpsertSecretParams) error {
+func createCharmUnitSecret(ctx context.Context, st *State, version int, uri *coresecrets.URI, unitName coreunit.Name, secret domainsecret.UpsertSecretParams) error {
 	return st.RunAtomic(ctx, func(ctx domain.AtomicContext) error {
 		unitUUID, err := st.GetUnitUUID(ctx, unitName)
 		if err != nil {

--- a/domain/secret/state/state_test.go
+++ b/domain/secret/state/state_test.go
@@ -15,6 +15,7 @@ import (
 
 	coredatabase "github.com/juju/juju/core/database"
 	coresecrets "github.com/juju/juju/core/secrets"
+	unittesting "github.com/juju/juju/core/unit/testing"
 	"github.com/juju/juju/domain"
 	applicationerrors "github.com/juju/juju/domain/application/errors"
 	"github.com/juju/juju/domain/life"
@@ -3687,7 +3688,8 @@ func (s *stateSuite) prepareWatchForConsumedSecrets(c *gc.C, ctx context.Context
 		consumer := &coresecrets.SecretConsumerMetadata{
 			CurrentRevision: revision,
 		}
-		err := st.SaveSecretConsumer(ctx, uri, consumerID, consumer)
+		unitName := unittesting.GenNewName(c, consumerID)
+		err := st.SaveSecretConsumer(ctx, uri, unitName, consumer)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 
@@ -3752,7 +3754,8 @@ func (s *stateSuite) prepareWatchForRemoteConsumedSecrets(c *gc.C, ctx context.C
 		consumer := &coresecrets.SecretConsumerMetadata{
 			CurrentRevision: revision,
 		}
-		err := st.SaveSecretConsumer(ctx, uri, consumerID, consumer)
+		unitName := unittesting.GenNewName(c, consumerID)
+		err := st.SaveSecretConsumer(ctx, uri, unitName, consumer)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 
@@ -3810,7 +3813,8 @@ func (s *stateSuite) prepareWatchForRemoteConsumedSecretsChangesFromOfferingSide
 		consumer := &coresecrets.SecretConsumerMetadata{
 			CurrentRevision: revision,
 		}
-		err := st.SaveSecretRemoteConsumer(ctx, uri, consumerID, consumer)
+		unitName := unittesting.GenNewName(c, consumerID)
+		err := st.SaveSecretRemoteConsumer(ctx, uri, unitName, consumer)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 

--- a/domain/secret/state/types.go
+++ b/domain/secret/state/types.go
@@ -41,7 +41,7 @@ type entityRef struct {
 
 type unit struct {
 	UUID coreunit.UUID `db:"uuid"`
-	Name string        `db:"name"`
+	Name coreunit.Name `db:"name"`
 }
 
 type application struct {
@@ -170,9 +170,9 @@ type secretUnitConsumer struct {
 }
 
 type secretRemoteUnitConsumer struct {
-	UnitName        string `db:"unit_name"`
-	SecretID        string `db:"secret_id"`
-	CurrentRevision int    `db:"current_revision"`
+	UnitName        coreunit.Name `db:"unit_name"`
+	SecretID        string        `db:"secret_id"`
+	CurrentRevision int           `db:"current_revision"`
 }
 
 type secretUnitConsumerInfo struct {

--- a/domain/secret/watcher_test.go
+++ b/domain/secret/watcher_test.go
@@ -18,6 +18,7 @@ import (
 	coresecrets "github.com/juju/juju/core/secrets"
 	corestorage "github.com/juju/juju/core/storage"
 	"github.com/juju/juju/core/unit"
+	unittesting "github.com/juju/juju/core/unit/testing"
 	corewatcher "github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/core/watcher/watchertest"
 	"github.com/juju/juju/domain"
@@ -360,7 +361,8 @@ func (s *watcherSuite) TestWatchConsumedSecretsChanges(c *gc.C) {
 		consumer := &coresecrets.SecretConsumerMetadata{
 			CurrentRevision: revision,
 		}
-		err := st.SaveSecretConsumer(ctx, uri, consumerID, consumer)
+		unitName := unittesting.GenNewName(c, consumerID)
+		err := st.SaveSecretConsumer(ctx, uri, unitName, consumer)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 
@@ -456,7 +458,8 @@ func (s *watcherSuite) TestWatchConsumedRemoteSecretsChanges(c *gc.C) {
 		consumer := &coresecrets.SecretConsumerMetadata{
 			CurrentRevision: revision,
 		}
-		err := st.SaveSecretConsumer(ctx, uri, consumerID, consumer)
+		unitName := unittesting.GenNewName(c, consumerID)
+		err := st.SaveSecretConsumer(ctx, uri, unitName, consumer)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 
@@ -543,7 +546,8 @@ func (s *watcherSuite) TestWatchRemoteConsumedSecretsChanges(c *gc.C) {
 		consumer := &coresecrets.SecretConsumerMetadata{
 			CurrentRevision: revision,
 		}
-		err := st.SaveSecretRemoteConsumer(ctx, uri, consumerID, consumer)
+		unitName := unittesting.GenNewName(c, consumerID)
+		err := st.SaveSecretRemoteConsumer(ctx, uri, unitName, consumer)
 		c.Assert(err, jc.ErrorIsNil)
 	}
 
@@ -933,7 +937,7 @@ func createCharmApplicationSecret(ctx context.Context, st *state.State, version 
 	})
 }
 
-func createCharmUnitSecret(ctx context.Context, st *state.State, version int, uri *coresecrets.URI, unitName string, secret secret.UpsertSecretParams) error {
+func createCharmUnitSecret(ctx context.Context, st *state.State, version int, uri *coresecrets.URI, unitName unit.Name, secret secret.UpsertSecretParams) error {
 	return st.RunAtomic(ctx, func(ctx domain.AtomicContext) error {
 		unitUUID, err := st.GetUnitUUID(ctx, unitName)
 		if err != nil {


### PR DESCRIPTION
We want to stop importing names package in domain.
A common use of names is to call the UnitApplication() method to get the app name for a unit.

The PR replaces the above method with a new one added to the core unit Name struct.

There's a bit of fallout because various secret apis used a unit name param as a string and these needed to be converted across to be a unit.Name instead.

When https://github.com/juju/juju/pull/19096 lands, we're almost ready to stop using names from domain.

## QA steps

main.sh -v secrets_iaas
main.sh -v secrets_k8s

## Links

**Jira card:** [JUJU-7667](https://warthogs.atlassian.net/browse/JUJU-7667)

