### PR TITLE
fix: use reference name when decoding charm locator

### DIFF
--- a/domain/application/state/application_test.go
+++ b/domain/application/state/application_test.go
@@ -302,11 +302,12 @@ func (s *applicationStateSuite) TestCreateApplicationsWithSameCharm(c *gc.C) {
 		Platform: platform,
 		Channel:  channel,
 		Charm: charm.Charm{
-			Metadata:     s.minimalMetadata(c, "foo"),
-			Manifest:     s.minimalManifest(c),
-			Source:       charm.LocalSource,
-			Revision:     42,
-			Architecture: architecture.ARM64,
+			Metadata:      s.minimalMetadata(c, "foo"),
+			Manifest:      s.minimalManifest(c),
+			Source:        charm.LocalSource,
+			Revision:      42,
+			Architecture:  architecture.ARM64,
+			ReferenceName: "foo",
 		},
 	}, nil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -315,11 +316,12 @@ func (s *applicationStateSuite) TestCreateApplicationsWithSameCharm(c *gc.C) {
 		Platform: platform,
 		Channel:  channel,
 		Charm: charm.Charm{
-			Metadata:     s.minimalMetadata(c, "foo"),
-			Manifest:     s.minimalManifest(c),
-			Source:       charm.LocalSource,
-			Revision:     42,
-			Architecture: architecture.ARM64,
+			Metadata:      s.minimalMetadata(c, "foo"),
+			Manifest:      s.minimalManifest(c),
+			Source:        charm.LocalSource,
+			Revision:      42,
+			Architecture:  architecture.ARM64,
+			ReferenceName: "foo",
 		},
 	}, nil)
 	c.Assert(err, jc.ErrorIsNil)
@@ -367,10 +369,11 @@ func (s *applicationStateSuite) TestCreateApplicationWithEmptyChannel(c *gc.C) {
 	_, err := s.state.CreateApplication(ctx, "666", application.AddApplicationArg{
 		Platform: platform,
 		Charm: charm.Charm{
-			Metadata: s.minimalMetadata(c, "666"),
-			Manifest: s.minimalManifest(c),
-			Source:   charm.LocalSource,
-			Revision: 42,
+			Metadata:      s.minimalMetadata(c, "666"),
+			Manifest:      s.minimalManifest(c),
+			Source:        charm.LocalSource,
+			Revision:      42,
+			ReferenceName: "666",
 		},
 		Scale: 1,
 	}, nil)
@@ -391,12 +394,13 @@ func (s *applicationStateSuite) TestCreateApplicationWithCharmStoragePath(c *gc.
 	_, err := s.state.CreateApplication(ctx, "666", application.AddApplicationArg{
 		Platform: platform,
 		Charm: charm.Charm{
-			Metadata:    s.minimalMetadata(c, "666"),
-			Manifest:    s.minimalManifest(c),
-			Source:      charm.LocalSource,
-			Revision:    42,
-			ArchivePath: "/some/path",
-			Available:   true,
+			Metadata:      s.minimalMetadata(c, "666"),
+			Manifest:      s.minimalManifest(c),
+			Source:        charm.LocalSource,
+			Revision:      42,
+			ArchivePath:   "/some/path",
+			Available:     true,
+			ReferenceName: "666",
 		},
 		Scale: 1,
 	}, nil)
@@ -1390,14 +1394,15 @@ func (s *applicationStateSuite) TestGetCharmByApplicationID(c *gc.C) {
 
 	appID, err := s.state.CreateApplication(ctx, "foo", application.AddApplicationArg{
 		Charm: charm.Charm{
-			Metadata:     expectedMetadata,
-			Manifest:     expectedManifest,
-			Actions:      expectedActions,
-			Config:       expectedConfig,
-			LXDProfile:   expectedLXDProfile,
-			Source:       charm.LocalSource,
-			Revision:     42,
-			Architecture: architecture.AMD64,
+			Metadata:      expectedMetadata,
+			Manifest:      expectedManifest,
+			Actions:       expectedActions,
+			Config:        expectedConfig,
+			LXDProfile:    expectedLXDProfile,
+			Source:        charm.LocalSource,
+			Revision:      42,
+			Architecture:  architecture.AMD64,
+			ReferenceName: "ubuntu",
 		},
 		Channel: &application.Channel{
 			Track:  "track",
@@ -1411,14 +1416,15 @@ func (s *applicationStateSuite) TestGetCharmByApplicationID(c *gc.C) {
 	ch, err := s.state.GetCharmByApplicationID(context.Background(), appID)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(ch, gc.DeepEquals, charm.Charm{
-		Metadata:     expectedMetadata,
-		Manifest:     expectedManifest,
-		Actions:      expectedActions,
-		Config:       expectedConfig,
-		LXDProfile:   expectedLXDProfile,
-		Source:       charm.LocalSource,
-		Revision:     42,
-		Architecture: architecture.AMD64,
+		Metadata:      expectedMetadata,
+		Manifest:      expectedManifest,
+		Actions:       expectedActions,
+		Config:        expectedConfig,
+		LXDProfile:    expectedLXDProfile,
+		Source:        charm.LocalSource,
+		Revision:      42,
+		Architecture:  architecture.AMD64,
+		ReferenceName: "ubuntu",
 	})
 
 	// Ensure that the charm platform is also set AND it's the same as the
@@ -1482,13 +1488,14 @@ func (s *applicationStateSuite) TestCreateApplicationDefaultSourceIsCharmhub(c *
 
 	appID, err := s.state.CreateApplication(ctx, "foo", application.AddApplicationArg{
 		Charm: charm.Charm{
-			Metadata:     expectedMetadata,
-			Manifest:     expectedManifest,
-			Actions:      expectedActions,
-			Config:       expectedConfig,
-			Revision:     42,
-			Source:       charm.LocalSource,
-			Architecture: architecture.AMD64,
+			Metadata:      expectedMetadata,
+			Manifest:      expectedManifest,
+			Actions:       expectedActions,
+			Config:        expectedConfig,
+			Revision:      42,
+			Source:        charm.LocalSource,
+			Architecture:  architecture.AMD64,
+			ReferenceName: "ubuntu",
 		},
 		Platform: application.Platform{
 			OSType:       application.Ubuntu,
@@ -1501,13 +1508,14 @@ func (s *applicationStateSuite) TestCreateApplicationDefaultSourceIsCharmhub(c *
 	ch, err := s.state.GetCharmByApplicationID(context.Background(), appID)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(ch, gc.DeepEquals, charm.Charm{
-		Metadata:     expectedMetadata,
-		Manifest:     expectedManifest,
-		Actions:      expectedActions,
-		Config:       expectedConfig,
-		Revision:     42,
-		Source:       charm.LocalSource,
-		Architecture: architecture.AMD64,
+		Metadata:      expectedMetadata,
+		Manifest:      expectedManifest,
+		Actions:       expectedActions,
+		Config:        expectedConfig,
+		Revision:      42,
+		Source:        charm.LocalSource,
+		Architecture:  architecture.AMD64,
+		ReferenceName: "ubuntu",
 	})
 }
 
@@ -1525,9 +1533,10 @@ func (s *applicationStateSuite) TestSetCharmThenGetCharmByApplicationNameInvalid
 
 	_, err := s.state.CreateApplication(ctx, "foo", application.AddApplicationArg{
 		Charm: charm.Charm{
-			Metadata: expectedMetadata,
-			Manifest: s.minimalManifest(c),
-			Source:   charm.LocalSource,
+			Metadata:      expectedMetadata,
+			Manifest:      s.minimalManifest(c),
+			Source:        charm.LocalSource,
+			ReferenceName: "ubuntu",
 		},
 	}, nil)
 	c.Assert(err, jc.ErrorIsNil)

--- a/domain/application/state/charm.go
+++ b/domain/application/state/charm.go
@@ -1032,7 +1032,7 @@ func decodeCharmLocator(c charmLocator) (charm.CharmLocator, error) {
 	}
 
 	return charm.CharmLocator{
-		Name:         c.Name,
+		Name:         c.ReferenceName,
 		Revision:     c.Revision,
 		Source:       source,
 		Architecture: architecture,

--- a/domain/schema/model/sql/0015-charm.sql
+++ b/domain/schema/model/sql/0015-charm.sql
@@ -68,7 +68,11 @@ CREATE TABLE charm (
 
     -- Ensure we have an architecture if the source is charmhub.
     CONSTRAINT chk_charm_architecture
-    CHECK (source_id = 0 OR source_id = 1 AND architecture_id >= 0)
+    CHECK (source_id = 0 OR source_id = 1 AND architecture_id >= 0),
+
+    -- Ensure we don't have an empty reference
+    CONSTRAINT chk_charm_reference_name
+    CHECK (reference_name <> '')
 );
 
 -- This ensures that the reference name and revision are unique. This is to


### PR DESCRIPTION
We were incorrectly using the Name in the charm locator struct instead
of the reference name when passing it through to retrieve the charm id.
This patch adds a check to validate that the reference name is not
empty, in that case use it as Name in the charm locator. If it's empty
then use the Name (this case shouldn't happen but it's better to fail
when trying to retrieve the charm).

## QA steps

```
$ juju bootstrap lxd c --build-agent
$ juju add-model m
$ juju deploy juju-qa-dummy-source
```
Then check that there are no errors in debug-log and check the state to make sure the new application is created and the machine provisioned correctly.

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/

**Jira card:** JUJU-

