### PR TITLE
fix: race in application scale update

### DIFF
--- a/domain/application/service/package_mock_test.go
+++ b/domain/application/service/package_mock_test.go
@@ -2826,17 +2826,17 @@ func (c *MockStateSetApplicationLifeCall) DoAndReturn(f func(context.Context, ap
 }
 
 // SetApplicationScalingState mocks base method.
-func (m *MockState) SetApplicationScalingState(ctx context.Context, appID application.ID, scale *int, targetScale int, scaling bool) error {
+func (m *MockState) SetApplicationScalingState(ctx context.Context, appName string, targetScale int, scaling bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetApplicationScalingState", ctx, appID, scale, targetScale, scaling)
+	ret := m.ctrl.Call(m, "SetApplicationScalingState", ctx, appName, targetScale, scaling)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetApplicationScalingState indicates an expected call of SetApplicationScalingState.
-func (mr *MockStateMockRecorder) SetApplicationScalingState(ctx, appID, scale, targetScale, scaling any) *MockStateSetApplicationScalingStateCall {
+func (mr *MockStateMockRecorder) SetApplicationScalingState(ctx, appName, targetScale, scaling any) *MockStateSetApplicationScalingStateCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetApplicationScalingState", reflect.TypeOf((*MockState)(nil).SetApplicationScalingState), ctx, appID, scale, targetScale, scaling)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetApplicationScalingState", reflect.TypeOf((*MockState)(nil).SetApplicationScalingState), ctx, appName, targetScale, scaling)
 	return &MockStateSetApplicationScalingStateCall{Call: call}
 }
 
@@ -2852,13 +2852,13 @@ func (c *MockStateSetApplicationScalingStateCall) Return(arg0 error) *MockStateS
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateSetApplicationScalingStateCall) Do(f func(context.Context, application.ID, *int, int, bool) error) *MockStateSetApplicationScalingStateCall {
+func (c *MockStateSetApplicationScalingStateCall) Do(f func(context.Context, string, int, bool) error) *MockStateSetApplicationScalingStateCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateSetApplicationScalingStateCall) DoAndReturn(f func(context.Context, application.ID, *int, int, bool) error) *MockStateSetApplicationScalingStateCall {
+func (c *MockStateSetApplicationScalingStateCall) DoAndReturn(f func(context.Context, string, int, bool) error) *MockStateSetApplicationScalingStateCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/application/service/package_mock_test.go
+++ b/domain/application/service/package_mock_test.go
@@ -3361,6 +3361,45 @@ func (c *MockStateUnsetApplicationConfigKeysCall) DoAndReturn(f func(context.Con
 	return c
 }
 
+// UpdateApplicationScale mocks base method.
+func (m *MockState) UpdateApplicationScale(ctx context.Context, appUUID application.ID, delta int) (int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateApplicationScale", ctx, appUUID, delta)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateApplicationScale indicates an expected call of UpdateApplicationScale.
+func (mr *MockStateMockRecorder) UpdateApplicationScale(ctx, appUUID, delta any) *MockStateUpdateApplicationScaleCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateApplicationScale", reflect.TypeOf((*MockState)(nil).UpdateApplicationScale), ctx, appUUID, delta)
+	return &MockStateUpdateApplicationScaleCall{Call: call}
+}
+
+// MockStateUpdateApplicationScaleCall wrap *gomock.Call
+type MockStateUpdateApplicationScaleCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateUpdateApplicationScaleCall) Return(arg0 int, arg1 error) *MockStateUpdateApplicationScaleCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateUpdateApplicationScaleCall) Do(f func(context.Context, application.ID, int) (int, error)) *MockStateUpdateApplicationScaleCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateUpdateApplicationScaleCall) DoAndReturn(f func(context.Context, application.ID, int) (int, error)) *MockStateUpdateApplicationScaleCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // UpdateCAASUnit mocks base method.
 func (m *MockState) UpdateCAASUnit(arg0 context.Context, arg1 unit.Name, arg2 application0.UpdateCAASUnitParams) error {
 	m.ctrl.T.Helper()

--- a/domain/application/state/application.go
+++ b/domain/application/state/application.go
@@ -543,6 +543,18 @@ func (st *State) GetApplicationLife(ctx context.Context, appName string) (coreap
 		return "", -1, jujuerrors.Trace(err)
 	}
 
+	var app applicationDetails
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		app, err = st.getApplicationDetails(ctx, tx, appName)
+		if err != nil {
+			return errors.Errorf("querying life for application %q: %w", appName, err)
+		}
+		return nil
+	})
+	return app.UUID, app.LifeID, jujuerrors.Trace(err)
+}
+
+func (st *State) getApplicationDetails(ctx context.Context, tx *sqlair.TX, appName string) (applicationDetails, error) {
 	app := applicationDetails{Name: appName}
 	query := `
 SELECT &applicationDetails.*
@@ -551,19 +563,17 @@ WHERE name = $applicationDetails.name
 `
 	stmt, err := st.Prepare(query, app)
 	if err != nil {
-		return "", -1, jujuerrors.Trace(err)
+		return applicationDetails{}, jujuerrors.Trace(err)
 	}
 
-	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		if err := tx.Query(ctx, stmt, app).Get(&app); err != nil {
-			if !errors.Is(err, sqlair.ErrNoRows) {
-				return errors.Errorf("querying life for application %q: %w", appName, err)
-			}
-			return fmt.Errorf("%w: %s", applicationerrors.ApplicationNotFound, appName)
+	err = tx.Query(ctx, stmt, app).Get(&app)
+	if err != nil {
+		if !errors.Is(err, sqlair.ErrNoRows) {
+			return applicationDetails{}, errors.Errorf("querying application details for application %q: %w", appName, err)
 		}
-		return nil
-	})
-	return app.UUID, app.LifeID, jujuerrors.Trace(err)
+		return applicationDetails{}, errors.Errorf("%w: %s", applicationerrors.ApplicationNotFound, appName)
+	}
+	return app, nil
 }
 
 // SetApplicationLife sets the life of the specified application.
@@ -665,36 +675,59 @@ WHERE application_uuid = $applicationScale.application_uuid
 
 // SetApplicationScalingState sets the scaling details for the given caas
 // application Scale is optional and is only set if not nil.
-func (st *State) SetApplicationScalingState(ctx context.Context, appUUID coreapplication.ID, scale *int, targetScale int, scaling bool) error {
+func (st *State) SetApplicationScalingState(ctx context.Context, appName string, targetScale int, scaling bool) error {
 	db, err := st.DB()
 	if err != nil {
 		return jujuerrors.Trace(err)
 	}
 
 	scaleDetails := applicationScale{
-		ApplicationID: appUUID,
-		Scaling:       scaling,
-		ScaleTarget:   targetScale,
-	}
-	var setScaleTerm string
-	if scale != nil {
-		scaleDetails.Scale = *scale
-		setScaleTerm = "scale = $applicationScale.scale,"
+		Scaling:     scaling,
+		ScaleTarget: targetScale,
 	}
 
 	upsertApplicationScale := fmt.Sprintf(`
 UPDATE application_scale SET
-    %s
+    scale = $applicationScale.scale,
     scaling = $applicationScale.scaling,
     scale_target = $applicationScale.scale_target
 WHERE application_uuid = $applicationScale.application_uuid
-`, setScaleTerm)
+`)
 
 	upsertStmt, err := st.Prepare(upsertApplicationScale, scaleDetails)
 	if err != nil {
 		return jujuerrors.Trace(err)
 	}
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		appDetails, err := st.getApplicationDetails(ctx, tx, appName)
+		if err != nil {
+			return jujuerrors.Trace(err)
+		}
+		scaleDetails.ApplicationID = appDetails.UUID
+
+		currentScaleState, err := st.getApplicationScaleState(ctx, tx, appDetails.UUID)
+		if err != nil {
+			return jujuerrors.Trace(err)
+		}
+
+		if scaling {
+			switch appDetails.LifeID {
+			case life.Alive:
+				// if starting a scale, ensure we are scaling to the same target.
+				if !currentScaleState.Scaling && currentScaleState.Scale != targetScale {
+					return applicationerrors.ScalingStateInconsistent
+				}
+				// Make sure to leave the scale value unchanged.
+				scaleDetails.Scale = currentScaleState.Scale
+			case life.Dying, life.Dead:
+				// force scale to the scale target when dying/dead.
+				scaleDetails.Scale = targetScale
+			}
+		} else {
+			// Make sure to leave the scale value unchanged.
+			scaleDetails.Scale = currentScaleState.Scale
+		}
+
 		return tx.Query(ctx, upsertStmt, scaleDetails).Run()
 	})
 	return jujuerrors.Trace(err)

--- a/domain/application/state/application_test.go
+++ b/domain/application/state/application_test.go
@@ -992,7 +992,7 @@ func (s *applicationStateSuite) TestGetApplicationScaleState(c *gc.C) {
 
 	scaleState, err := s.state.GetApplicationScaleState(context.Background(), appID)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(scaleState, jc.DeepEquals, application.ScaleState{
+	c.Check(scaleState, jc.DeepEquals, application.ScaleState{
 		Scale: 1,
 	})
 }
@@ -1015,7 +1015,37 @@ func (s *applicationStateSuite) TestSetDesiredApplicationScale(c *gc.C) {
 		return err
 	})
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(gotScale, jc.DeepEquals, 666)
+	c.Check(gotScale, jc.DeepEquals, 666)
+}
+
+func (s *applicationStateSuite) TestUpdateApplicationScale(c *gc.C) {
+	appID := s.createApplication(c, "foo", life.Alive)
+
+	err := s.state.SetDesiredApplicationScale(context.Background(), appID, 666)
+	c.Assert(err, jc.ErrorIsNil)
+
+	newScale, err := s.state.UpdateApplicationScale(context.Background(), appID, 2)
+	c.Assert(err, jc.ErrorIsNil)
+
+	var gotScale int
+	err = s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		err := tx.QueryRowContext(ctx, "SELECT scale FROM application_scale WHERE application_uuid=?", appID).
+			Scan(&gotScale)
+		return err
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(gotScale, jc.DeepEquals, 666+2)
+	c.Check(newScale, jc.DeepEquals, 666+2)
+}
+
+func (s *applicationStateSuite) TestUpdateApplicationScaleInvalidScale(c *gc.C) {
+	appID := s.createApplication(c, "foo", life.Alive)
+
+	err := s.state.SetDesiredApplicationScale(context.Background(), appID, 666)
+	c.Assert(err, jc.ErrorIsNil)
+
+	_, err = s.state.UpdateApplicationScale(context.Background(), appID, -667)
+	c.Assert(err, gc.ErrorMatches, `scale change invalid: cannot remove more units than currently exist`)
 }
 
 func (s *applicationStateSuite) TestSetApplicationScalingState(c *gc.C) {


### PR DESCRIPTION
Currently we have a race in the `ChangeApplicationScale()` method of the application service layer.
The issue is that we retrieve the current scale value and update it in two separate transactions.
Even though we agreed not to have bussiness logic in the state layer, doing this check under the same transaction is a necessity, so the validation (for when the new desired scale is less than 0) is therefore done in the state layer.

Tests were updated accordingly.

## QA steps

```
$ make microk8s-operator-update
$ juju bootstrap microk8s c
$ juju add-model m
$ juju deploy grafana-k8s
```
Now test the change (only via remove-units):
```
$ juju remove-unit grafana-k8s --num-units 2
ERROR changing scaling state for "grafana-k8s": scale change invalid: cannot remove more units than currently exist
```
And only one unit should work:

```
$ juju remove-unit grafana-k8s --num-units 1
scaling down to 0 units
```
## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/

**Jira card:** JUJU-

