### PR TITLE
chore: merge 3.6

### DIFF
--- a/api/client/sshclient/facade.go
+++ b/api/client/sshclient/facade.go
@@ -72,6 +72,27 @@ func (facade *Facade) AllAddresses(ctx context.Context, target string) ([]string
 	return out.Results[0].Addresses, nil
 }
 
+// VirtualHostname returns the virtual hostname for the SSH target provided.
+func (facade *Facade) VirtualHostname(ctx context.Context, target string, container *string) (string, error) {
+	tag, err := targetToTag(target)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	in := params.VirtualHostnameTargetArg{
+		Tag:       tag.String(),
+		Container: container,
+	}
+	var out params.SSHAddressResult
+	err = facade.caller.FacadeCall(ctx, "VirtualHostname", in, &out)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	if err := out.Error; err != nil {
+		return "", errors.Trace(err)
+	}
+	return out.Address, nil
+}
+
 func (facade *Facade) addressCall(ctx context.Context, callName, target string) (string, error) {
 	entities, err := targetToEntities(target)
 	if err != nil {

--- a/api/facadeversions.go
+++ b/api/facadeversions.go
@@ -105,7 +105,7 @@ var facadeVersions = facades.FacadeVersions{
 	"UserSecretsManager":           {1},
 	"Singular":                     {2},
 	"Spaces":                       {6},
-	"SSHClient":                    {4},
+	"SSHClient":                    {4, 5},
 	"Storage":                      {6},
 	"StorageProvisioner":           {4},
 	"StringsWatcher":               {1},

--- a/apiserver/facades/client/sshclient/register.go
+++ b/apiserver/facades/client/sshclient/register.go
@@ -18,11 +18,30 @@ import (
 // Register is called to expose a package of facades onto a given registry.
 func Register(registry facade.FacadeRegistry) {
 	registry.MustRegister("SSHClient", 4, func(stdCtx context.Context, ctx facade.ModelContext) (facade.Facade, error) {
-		return newFacade(ctx)
-	}, reflect.TypeOf((*Facade)(nil)))
+		return newFacadeV4(ctx)
+	}, reflect.TypeOf((*FacadeV4)(nil)))
+	registry.MustRegister("SSHClient", 5, func(stdCtx context.Context, ctx facade.ModelContext) (facade.Facade, error) {
+		return newFacadeV5(ctx)
+	}, reflect.TypeOf((*FacadeV5)(nil)))
 }
 
-func newFacade(ctx facade.ModelContext) (*Facade, error) {
+func newFacadeV5(ctx facade.ModelContext) (*FacadeV5, error) {
+	facade, err := newFacadeBase(ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &FacadeV5{facade}, nil
+}
+
+func newFacadeV4(ctx facade.ModelContext) (*FacadeV4, error) {
+	facade, err := newFacadeV5(ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &FacadeV4{facade}, nil
+}
+
+func newFacadeBase(ctx facade.ModelContext) (*Facade, error) {
 	st := ctx.State()
 	m, err := st.Model()
 	if err != nil {

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -12549,7 +12549,7 @@
     {
         "Name": "SSHClient",
         "Description": "",
-        "Version": 4,
+        "Version": 5,
         "AvailableTo": [
             "controller-machine-agent",
             "machine-agent",
@@ -12616,6 +12616,17 @@
                         },
                         "Result": {
                             "$ref": "#/definitions/SSHPublicKeysResults"
+                        }
+                    }
+                },
+                "VirtualHostname": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/VirtualHostnameTargetArg"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/SSHAddressResult"
                         }
                     }
                 }
@@ -12854,6 +12865,21 @@
                     "additionalProperties": false,
                     "required": [
                         "results"
+                    ]
+                },
+                "VirtualHostnameTargetArg": {
+                    "type": "object",
+                    "properties": {
+                        "container": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag"
                     ]
                 }
             }

--- a/core/virtualhostname/virtualhostname_integration_test.go
+++ b/core/virtualhostname/virtualhostname_integration_test.go
@@ -58,7 +58,7 @@ func (s *HostnameSuite) TestParseMachineHostname(c *gc.C) {
 	c.Assert(err, gc.IsNil)
 
 	unitName, valid := res.Unit()
-	c.Check(unitName, gc.Equals, "")
+	c.Check(unitName, gc.Equals, "/0")
 	c.Check(valid, gc.Equals, false)
 
 	containerName, valid := res.Container()

--- a/docs/user/reference/resource-compute/list-of-commands-available-on-a-compute-resource-provisioned-by-juju/list-of-juju-introspect-macros/juju_goroutines.md
+++ b/docs/user/reference/resource-compute/list-of-commands-available-on-a-compute-resource-provisioned-by-juju/list-of-juju-introspect-macros/juju_goroutines.md
@@ -14,7 +14,7 @@ goroutine profile: total 234
 19 @ 0x42f59a 0x42f64e 0x406c62 0x40691b 0x951ada 0x9c34ed 0x9c0177 0x45b211
 #	0x951ad9	gopkg.in/tomb%2ev1.(*Tomb).Wait+0x49				/home/tim/go/src/gopkg.in/tomb.v1/tomb.go:113
 #	0x9c34ec	github.com/juju/juju/api/watcher.(*commonWatcher).Wait+0x2c	/home/tim/go/src/github.com/juju/juju/api/watcher/watcher.go:138
-#	0x9c0176	github.com/juju/juju/worker/catacomb.(*Catacomb).add.func1+0x86	/home/tim/go/src/github.com/juju/juju/worker/catacomb/catacomb.go:175
+#	0x9c0176	github.com/juju/juju/internal/worker/catacomb.(*Catacomb).add.func1+0x86	/home/tim/go/src/github.com/juju/juju/internal/worker/catacomb/catacomb.go:175
 
 19 @ 0x42f59a 0x42f64e 0x406c62 0x40691b 0x9599f9 0xa20249 0x9c6673 0x9c69e9 0x45b211
 #	0x9599f8	github.com/juju/juju/rpc.(*Conn).Call+0x128				/home/tim/go/src/github.com/juju/juju/rpc/client.go:148
@@ -31,14 +31,14 @@ goroutine profile: total 234
 #	0x9c3437	github.com/juju/juju/api/watcher.(*commonWatcher).commonLoop+0xf7	/home/tim/go/src/github.com/juju/juju/api/watcher/watcher.go:128
 
 19 @ 0x42f59a 0x43f2b0 0x9c02d8 0x45b211
-#	0x9c02d7	github.com/juju/juju/worker/catacomb.(*Catacomb).add.func2+0x107	/home/tim/go/src/github.com/juju/juju/worker/catacomb/catacomb.go:181
+#	0x9c02d7	github.com/juju/juju/internal/worker/catacomb.(*Catacomb).add.func2+0x107	/home/tim/go/src/github.com/juju/juju/internal/worker/catacomb/catacomb.go:181
 
 15 @ 0x42f59a 0x43f2b0 0x9bffcd 0x45b211
-#	0x9bffcc	github.com/juju/juju/worker/catacomb.Invoke.func2+0x14c	/home/tim/go/src/github.com/juju/juju/worker/catacomb/catacomb.go:101
+#	0x9bffcc	github.com/juju/juju/internal/worker/catacomb.Invoke.func2+0x14c	/home/tim/go/src/github.com/juju/juju/internal/worker/catacomb/catacomb.go:101
 
 13 @ 0x42f59a 0x42f64e 0x406c62 0x40691b 0xe5ee92 0xe60115 0x45b211
-#	0xe5ee91	github.com/juju/juju/worker/fortress.(*fortress).Visit+0x191	/home/tim/go/src/github.com/juju/juju/worker/fortress/fortress.go:63
-#	0xe60114	github.com/juju/juju/worker/fortress.Occupy.func2+0x44		/home/tim/go/src/github.com/juju/juju/worker/fortress/occupy.go:50
+#	0xe5ee91	github.com/juju/juju/internal/worker/fortress.(*fortress).Visit+0x191	/home/tim/go/src/github.com/juju/juju/internal/worker/fortress/fortress.go:63
+#	0xe60114	github.com/juju/juju/internal/worker/fortress.Occupy.func2+0x44		/home/tim/go/src/github.com/juju/juju/internal/worker/fortress/occupy.go:50
 
 11 @ 0x42f59a 0x42f64e 0x406c62 0x40695b 0x9c3813 0x9c6c73 0x45b211
 #	0x9c3812	github.com/juju/juju/api/watcher.(*notifyWatcher).loop+0x1c2	/home/tim/go/src/github.com/juju/juju/api/watcher/watcher.go:180
@@ -47,22 +47,22 @@ goroutine profile: total 234
 7 @ 0x42f59a 0x43f2b0 0x9c0e35 0x9c1aca 0x9bfdd5 0x9c00a1 0x45b211
 #	0x9c0e34	github.com/juju/juju/watcher.(*NotifyWorker).loop+0x154						/home/tim/go/src/github.com/juju/juju/watcher/notify.go:90
 #	0x9c1ac9	github.com/juju/juju/watcher.(*NotifyWorker).(github.com/juju/juju/watcher.loop)-fm+0x29	/home/tim/go/src/github.com/juju/juju/watcher/notify.go:71
-#	0x9bfdd4	github.com/juju/juju/worker/catacomb.runSafely+0x54						/home/tim/go/src/github.com/juju/juju/worker/catacomb/catacomb.go:289
-#	0x9c00a0	github.com/juju/juju/worker/catacomb.Invoke.func3+0x80						/home/tim/go/src/github.com/juju/juju/worker/catacomb/catacomb.go:116
+#	0x9bfdd4	github.com/juju/juju/internal/worker/catacomb.runSafely+0x54						/home/tim/go/src/github.com/juju/juju/internal/worker/catacomb/catacomb.go:289
+#	0x9c00a0	github.com/juju/juju/internal/worker/catacomb.Invoke.func3+0x80						/home/tim/go/src/github.com/juju/juju/internal/worker/catacomb/catacomb.go:116
 
 6 @ 0x42f59a 0x42f64e 0x406c62 0x40691b 0x951ada 0x9bf89d 0x9c11f1 0xe5e49f 0xe5bbd7 0x45b211
 #	0x951ad9	gopkg.in/tomb%2ev1.(*Tomb).Wait+0x49					/home/tim/go/src/gopkg.in/tomb.v1/tomb.go:113
-#	0x9bf89c	github.com/juju/juju/worker/catacomb.(*Catacomb).Wait+0x2c		/home/tim/go/src/github.com/juju/juju/worker/catacomb/catacomb.go:204
+#	0x9bf89c	github.com/juju/juju/internal/worker/catacomb.(*Catacomb).Wait+0x2c		/home/tim/go/src/github.com/juju/juju/internal/worker/catacomb/catacomb.go:204
 #	0x9c11f0	github.com/juju/juju/watcher.(*NotifyWorker).Wait+0x30			/home/tim/go/src/github.com/juju/juju/watcher/notify.go:138
-#	0xe5e49e	github.com/juju/juju/worker/dependency.(*Engine).runWorker.func2+0x4ce	/home/tim/go/src/github.com/juju/juju/worker/dependency/engine.go:464
-#	0xe5bbd6	github.com/juju/juju/worker/dependency.(*Engine).runWorker+0x1c6	/home/tim/go/src/github.com/juju/juju/worker/dependency/engine.go:468
+#	0xe5e49e	github.com/juju/juju/internal/worker/dependency.(*Engine).runWorker.func2+0x4ce	/home/tim/go/src/github.com/juju/juju/internal/worker/dependency/engine.go:464
+#	0xe5bbd6	github.com/juju/juju/internal/worker/dependency.(*Engine).runWorker+0x1c6	/home/tim/go/src/github.com/juju/juju/internal/worker/dependency/engine.go:468
 
 6 @ 0x42f59a 0x42f64e 0x406c62 0x40691b 0x951ada 0x9bf89d 0x9c11f1 0xe600bb 0xe5f6e1 0x45b211
 #	0x951ad9	gopkg.in/tomb%2ev1.(*Tomb).Wait+0x49				/home/tim/go/src/gopkg.in/tomb.v1/tomb.go:113
-#	0x9bf89c	github.com/juju/juju/worker/catacomb.(*Catacomb).Wait+0x2c	/home/tim/go/src/github.com/juju/juju/worker/catacomb/catacomb.go:204
+#	0x9bf89c	github.com/juju/juju/internal/worker/catacomb.(*Catacomb).Wait+0x2c	/home/tim/go/src/github.com/juju/juju/internal/worker/catacomb/catacomb.go:204
 #	0x9c11f0	github.com/juju/juju/watcher.(*NotifyWorker).Wait+0x30		/home/tim/go/src/github.com/juju/juju/watcher/notify.go:138
-#	0xe600ba	github.com/juju/juju/worker/fortress.Occupy.func1+0xca		/home/tim/go/src/github.com/juju/juju/worker/fortress/occupy.go:38
-#	0xe5f6e0	github.com/juju/juju/worker/fortress.guestTicket.complete+0x40	/home/tim/go/src/github.com/juju/juju/worker/fortress/fortress.go:151
+#	0xe600ba	github.com/juju/juju/internal/worker/fortress.Occupy.func1+0xca		/home/tim/go/src/github.com/juju/juju/internal/worker/fortress/occupy.go:38
+#	0xe5f6e0	github.com/juju/juju/internal/worker/fortress.guestTicket.complete+0x40	/home/tim/go/src/github.com/juju/juju/internal/worker/fortress/fortress.go:151
 
 [extra bits snipped for brevity]
 ```
@@ -74,12 +74,12 @@ $ juju_goroutines unit-ubuntu-lite-2
 Querying @jujud-unit-ubuntu-lite-2 introspection socket: /debug/pprof/goroutine?debug=1
 goroutine profile: total 216
 19 @ 0x42f59a 0x43f2b0 0x9c02d8 0x45b211
-#	0x9c02d7	github.com/juju/juju/worker/catacomb.(*Catacomb).add.func2+0x107	/home/tim/go/src/github.com/juju/juju/worker/catacomb/catacomb.go:181
+#	0x9c02d7	github.com/juju/juju/internal/worker/catacomb.(*Catacomb).add.func2+0x107	/home/tim/go/src/github.com/juju/juju/internal/worker/catacomb/catacomb.go:181
 
 17 @ 0x42f59a 0x42f64e 0x406c62 0x40691b 0x951ada 0x9c34ed 0x9c0177 0x45b211
 #	0x951ad9	gopkg.in/tomb%2ev1.(*Tomb).Wait+0x49				/home/tim/go/src/gopkg.in/tomb.v1/tomb.go:113
 #	0x9c34ec	github.com/juju/juju/api/watcher.(*commonWatcher).Wait+0x2c	/home/tim/go/src/github.com/juju/juju/api/watcher/watcher.go:138
-#	0x9c0176	github.com/juju/juju/worker/catacomb.(*Catacomb).add.func1+0x86	/home/tim/go/src/github.com/juju/juju/worker/catacomb/catacomb.go:175
+#	0x9c0176	github.com/juju/juju/internal/worker/catacomb.(*Catacomb).add.func1+0x86	/home/tim/go/src/github.com/juju/juju/internal/worker/catacomb/catacomb.go:175
 
 17 @ 0x42f59a 0x42f64e 0x406c62 0x40691b 0x9599f9 0xa20249 0x9c6673 0x9c69e9 0x45b211
 #	0x9599f8	github.com/juju/juju/rpc.(*Conn).Call+0x128				/home/tim/go/src/github.com/juju/juju/rpc/client.go:148
@@ -100,27 +100,27 @@ goroutine profile: total 216
 #	0x9c6c72	github.com/juju/juju/api/watcher.NewNotifyWatcher.func1+0x52	/home/tim/go/src/github.com/juju/juju/api/watcher/watcher.go:160
 
 11 @ 0x42f59a 0x42f64e 0x406c62 0x40691b 0xe5ee92 0xe60115 0x45b211
-#	0xe5ee91	github.com/juju/juju/worker/fortress.(*fortress).Visit+0x191	/home/tim/go/src/github.com/juju/juju/worker/fortress/fortress.go:63
-#	0xe60114	github.com/juju/juju/worker/fortress.Occupy.func2+0x44		/home/tim/go/src/github.com/juju/juju/worker/fortress/occupy.go:50
+#	0xe5ee91	github.com/juju/juju/internal/worker/fortress.(*fortress).Visit+0x191	/home/tim/go/src/github.com/juju/juju/internal/worker/fortress/fortress.go:63
+#	0xe60114	github.com/juju/juju/internal/worker/fortress.Occupy.func2+0x44		/home/tim/go/src/github.com/juju/juju/internal/worker/fortress/occupy.go:50
 
 10 @ 0x42f59a 0x42f64e 0x406c62 0x40695b 0xa2f2b8 0x45b211
 #	0xa2f2b7	gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun+0x57	/home/tim/go/src/gopkg.in/natefinch/lumberjack.v2/lumberjack.go:379
 
 10 @ 0x42f59a 0x43f2b0 0x9bffcd 0x45b211
-#	0x9bffcc	github.com/juju/juju/worker/catacomb.Invoke.func2+0x14c	/home/tim/go/src/github.com/juju/juju/worker/catacomb/catacomb.go:101
+#	0x9bffcc	github.com/juju/juju/internal/worker/catacomb.Invoke.func2+0x14c	/home/tim/go/src/github.com/juju/juju/internal/worker/catacomb/catacomb.go:101
 
 5 @ 0x42f59a 0x42f64e 0x406c62 0x40691b 0x951ada 0x9bf89d 0x9c11f1 0xe5e49f 0xe5bbd7 0x45b211
 #	0x951ad9	gopkg.in/tomb%2ev1.(*Tomb).Wait+0x49					/home/tim/go/src/gopkg.in/tomb.v1/tomb.go:113
-#	0x9bf89c	github.com/juju/juju/worker/catacomb.(*Catacomb).Wait+0x2c		/home/tim/go/src/github.com/juju/juju/worker/catacomb/catacomb.go:204
+#	0x9bf89c	github.com/juju/juju/internal/worker/catacomb.(*Catacomb).Wait+0x2c		/home/tim/go/src/github.com/juju/juju/internal/worker/catacomb/catacomb.go:204
 #	0x9c11f0	github.com/juju/juju/watcher.(*NotifyWorker).Wait+0x30			/home/tim/go/src/github.com/juju/juju/watcher/notify.go:138
-#	0xe5e49e	github.com/juju/juju/worker/dependency.(*Engine).runWorker.func2+0x4ce	/home/tim/go/src/github.com/juju/juju/worker/dependency/engine.go:464
-#	0xe5bbd6	github.com/juju/juju/worker/dependency.(*Engine).runWorker+0x1c6	/home/tim/go/src/github.com/juju/juju/worker/dependency/engine.go:468
+#	0xe5e49e	github.com/juju/juju/internal/worker/dependency.(*Engine).runWorker.func2+0x4ce	/home/tim/go/src/github.com/juju/juju/internal/worker/dependency/engine.go:464
+#	0xe5bbd6	github.com/juju/juju/internal/worker/dependency.(*Engine).runWorker+0x1c6	/home/tim/go/src/github.com/juju/juju/internal/worker/dependency/engine.go:468
 
 5 @ 0x42f59a 0x42f64e 0x406c62 0x40691b 0x951ada 0x9bf89d 0x9c11f1 0xe600bb 0xe5f6e1 0x45b211
 #	0x951ad9	gopkg.in/tomb%2ev1.(*Tomb).Wait+0x49				/home/tim/go/src/gopkg.in/tomb.v1/tomb.go:113
-#	0x9bf89c	github.com/juju/juju/worker/catacomb.(*Catacomb).Wait+0x2c	/home/tim/go/src/github.com/juju/juju/worker/catacomb/catacomb.go:204
+#	0x9bf89c	github.com/juju/juju/internal/worker/catacomb.(*Catacomb).Wait+0x2c	/home/tim/go/src/github.com/juju/juju/internal/worker/catacomb/catacomb.go:204
 #	0x9c11f0	github.com/juju/juju/watcher.(*NotifyWorker).Wait+0x30		/home/tim/go/src/github.com/juju/juju/watcher/notify.go:138
-#	0xe600ba	github.com/juju/juju/worker/fortress.Occupy.func1+0xca		/home/tim/go/src/github.com/juju/juju/worker/fortress/occupy.go:38
-#	0xe5f6e0	github.com/juju/juju/worker/fortress.guestTicket.complete+0x40	/home/tim/go/src/github.com/juju/juju/worker/fortress/fortress.go:151
+#	0xe600ba	github.com/juju/juju/internal/worker/fortress.Occupy.func1+0xca		/home/tim/go/src/github.com/juju/juju/internal/worker/fortress/occupy.go:38
+#	0xe5f6e0	github.com/juju/juju/internal/worker/fortress.guestTicket.complete+0x40	/home/tim/go/src/github.com/juju/juju/internal/worker/fortress/fortress.go:151
 [extra bits snipped for brevity]
 ```

--- a/docs/user/reference/resource-compute/list-of-commands-available-on-a-compute-resource-provisioned-by-juju/list-of-juju-introspect-macros/juju_heap_profile.md
+++ b/docs/user/reference/resource-compute/list-of-commands-available-on-a-compute-resource-provisioned-by-juju/list-of-juju-introspect-macros/juju_heap_profile.md
@@ -35,8 +35,8 @@ heap profile: 31: 694464 [33638: 106713992] @ heap/1048576
 
 1: 196608 [1: 196608] @ 0x2ffcec5 0x2ffce0e 0x2ffd07c 0x778495 0x468fc1
 #       0x2ffcec4       github.com/juju/juju/core/logger.NewBufferedLogger+0x264                                        /home/heather/work-test/src/github.com/juju/juju/core/logger/buf.go:43
-#       0x2ffce0d       github.com/juju/juju/worker/modelworkermanager.newModelLogger+0x1ad                             /home/heather/work-test/src/github.com/juju/juju/worker/modelworkermanager/recordlogger.go:28
-#       0x2ffd07b       github.com/juju/juju/worker/modelworkermanager.(*modelWorkerManager).starter.func1+0x41b        /home/heather/work-test/src/github.com/juju/juju/worker/modelworkermanager/modelworkermanager.go:261
+#       0x2ffce0d       github.com/juju/juju/internal/worker/modelworkermanager.newModelLogger+0x1ad                             /home/heather/work-test/src/github.com/juju/juju/internal/worker/modelworkermanager/recordlogger.go:28
+#       0x2ffd07b       github.com/juju/juju/internal/worker/modelworkermanager.(*modelWorkerManager).starter.func1+0x41b        /home/heather/work-test/src/github.com/juju/juju/internal/worker/modelworkermanager/modelworkermanager.go:261
 #       0x778494        github.com/juju/worker/v3.(*Runner).runWorker+0x2d4                                             /home/heather/work-test/pkg/mod/github.com/juju/worker/v3@v3.0.0-20220204100750-e23db69a42d2/runner.go:580
 
 # and many more

--- a/rpc/params/params.go
+++ b/rpc/params/params.go
@@ -1439,3 +1439,10 @@ type CLICommandStatus struct {
 	Done   bool     `json:"done,omitempty"`
 	Error  *Error   `json:"error,omitempty"`
 }
+
+// VirtualHostnameTargetArg holds the target tag and an optional container
+// name to resolve a virtual hostname.
+type VirtualHostnameTargetArg struct {
+	Tag       string  `json:"tag"`
+	Container *string `json:"container,omitempty"`
+}


### PR DESCRIPTION
Merge 3.6

The only functional change is this PR:

https://github.com/juju/juju/pull/18995 [from SimoneDutto/JUJU-7329/add-facade-hostname](https://github.com/juju/juju/commit/f7ead0ff4b2414b4f75ddbb29e039450a4cdcbe0)

Conflicts for the above were for infra changes in main vs 3.6

The other PR was

https://github.com/juju/juju/pull/19132 [from wallyworld/move-worker-internal](https://github.com/juju/juju/commit/aa28be134d08622c1d76679ac358fec125383f94)

which moved workers to the internal package to conform with what's done in main.
There were many conflicts, but the timing of the work was such that the resolution was to accept the main versions.