### PR TITLE
refactor(unitstate): to use new practices

### DIFF
--- a/apiserver/common/mocks/common_mock.go
+++ b/apiserver/common/mocks/common_mock.go
@@ -1450,7 +1450,7 @@ func (m *MockUnitStateService) EXPECT() *MockUnitStateServiceMockRecorder {
 }
 
 // GetState mocks base method.
-func (m *MockUnitStateService) GetState(arg0 context.Context, arg1 string) (unitstate.RetrievedUnitState, error) {
+func (m *MockUnitStateService) GetState(arg0 context.Context, arg1 unit.Name) (unitstate.RetrievedUnitState, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetState", arg0, arg1)
 	ret0, _ := ret[0].(unitstate.RetrievedUnitState)
@@ -1477,52 +1477,13 @@ func (c *MockUnitStateServiceGetStateCall) Return(arg0 unitstate.RetrievedUnitSt
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockUnitStateServiceGetStateCall) Do(f func(context.Context, string) (unitstate.RetrievedUnitState, error)) *MockUnitStateServiceGetStateCall {
+func (c *MockUnitStateServiceGetStateCall) Do(f func(context.Context, unit.Name) (unitstate.RetrievedUnitState, error)) *MockUnitStateServiceGetStateCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockUnitStateServiceGetStateCall) DoAndReturn(f func(context.Context, string) (unitstate.RetrievedUnitState, error)) *MockUnitStateServiceGetStateCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// GetUnitUUIDForName mocks base method.
-func (m *MockUnitStateService) GetUnitUUIDForName(arg0 context.Context, arg1 string) (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetUnitUUIDForName", arg0, arg1)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetUnitUUIDForName indicates an expected call of GetUnitUUIDForName.
-func (mr *MockUnitStateServiceMockRecorder) GetUnitUUIDForName(arg0, arg1 any) *MockUnitStateServiceGetUnitUUIDForNameCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnitUUIDForName", reflect.TypeOf((*MockUnitStateService)(nil).GetUnitUUIDForName), arg0, arg1)
-	return &MockUnitStateServiceGetUnitUUIDForNameCall{Call: call}
-}
-
-// MockUnitStateServiceGetUnitUUIDForNameCall wrap *gomock.Call
-type MockUnitStateServiceGetUnitUUIDForNameCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockUnitStateServiceGetUnitUUIDForNameCall) Return(arg0 string, arg1 error) *MockUnitStateServiceGetUnitUUIDForNameCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockUnitStateServiceGetUnitUUIDForNameCall) Do(f func(context.Context, string) (string, error)) *MockUnitStateServiceGetUnitUUIDForNameCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockUnitStateServiceGetUnitUUIDForNameCall) DoAndReturn(f func(context.Context, string) (string, error)) *MockUnitStateServiceGetUnitUUIDForNameCall {
+func (c *MockUnitStateServiceGetStateCall) DoAndReturn(f func(context.Context, unit.Name) (unitstate.RetrievedUnitState, error)) *MockUnitStateServiceGetStateCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/common/unitstate_test.go
+++ b/apiserver/common/unitstate_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/common/mocks"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
+	unittesting "github.com/juju/juju/core/unit/testing"
 	"github.com/juju/juju/domain/unitstate"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 	"github.com/juju/juju/internal/testing"
@@ -66,7 +67,7 @@ func (s *unitStateSuite) assertBackendApi(c *gc.C) *gomock.Controller {
 	return ctrl
 }
 
-func (s *unitStateSuite) expectGetState(name string) (map[string]string, string, map[int]string, string, string) {
+func (s *unitStateSuite) expectGetState(c *gc.C, name string) (map[string]string, string, map[int]string, string, string) {
 	expCharmState := map[string]string{
 		"foo.bar":  "baz",
 		"payload$": "enc0d3d",
@@ -79,9 +80,9 @@ func (s *unitStateSuite) expectGetState(name string) (map[string]string, string,
 	expStorageState := "storage testing"
 	expSecretState := "secret testing"
 
-	uuid := "some-unit-uuid"
-	s.unitStateService.EXPECT().GetUnitUUIDForName(gomock.Any(), name).Return(uuid, nil)
-	s.unitStateService.EXPECT().GetState(gomock.Any(), uuid).Return(unitstate.RetrievedUnitState{
+	unitName := unittesting.GenNewName(c, name)
+
+	s.unitStateService.EXPECT().GetState(gomock.Any(), unitName).Return(unitstate.RetrievedUnitState{
 		CharmState:    expCharmState,
 		UniterState:   expUniterState,
 		RelationState: expRelationState,
@@ -94,7 +95,7 @@ func (s *unitStateSuite) expectGetState(name string) (map[string]string, string,
 
 func (s *unitStateSuite) TestState(c *gc.C) {
 	defer s.assertBackendApi(c).Finish()
-	expCharmState, expUniterState, expRelationState, expStorageState, expSecretState := s.expectGetState("wordpress/0")
+	expCharmState, expUniterState, expRelationState, expStorageState, expSecretState := s.expectGetState(c, "wordpress/0")
 
 	args := params.Entities{
 		Entities: []params.Entity{

--- a/apiserver/facades/agent/uniter/service.go
+++ b/apiserver/facades/agent/uniter/service.go
@@ -144,12 +144,10 @@ type ApplicationService interface {
 // UnitStateService describes the ability to retrieve and persist
 // unit agent state for informing hook reconciliation.
 type UnitStateService interface {
-	// GetUnitUUIDForName returns the UUID corresponding to the input unit name.
-	GetUnitUUIDForName(ctx context.Context, name string) (string, error)
 	// SetState persists the input unit state.
 	SetState(context.Context, unitstate.UnitState) error
 	// GetState returns the full unit state. The state may be empty.
-	GetState(ctx context.Context, uuid string) (unitstate.RetrievedUnitState, error)
+	GetState(ctx context.Context, uuid coreunit.Name) (unitstate.RetrievedUnitState, error)
 }
 
 // PortService describes the ability to open and close port ranges for units.

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -2776,6 +2776,11 @@ func (u *UniterAPI) commitHookChangesForOneUnit(ctx context.Context, unitTag nam
 			return apiservererrors.ErrPerm
 		}
 
+		unitName, err := coreunit.NewName(unitTag.Id())
+		if err != nil {
+			return errors.Trace(err)
+		}
+
 		// TODO (manadart 2024-10-12): Only charm state is ever set here.
 		// The full state is set in the call to SetState (apiserver/common).
 		// Integrate this into a transaction with other setters once we are also
@@ -2783,7 +2788,7 @@ func (u *UniterAPI) commitHookChangesForOneUnit(ctx context.Context, unitTag nam
 		// We also need to factor ctrlCfg.MaxCharmStateSize() into the service
 		// call.
 		if err := u.unitStateService.SetState(ctx, unitstate.UnitState{
-			Name:       unitTag.Id(),
+			Name:       unitName,
 			CharmState: changes.SetUnitState.CharmState,
 		}); err != nil {
 			return errors.Trace(err)

--- a/domain/unitstate/service/service.go
+++ b/domain/unitstate/service/service.go
@@ -6,6 +6,7 @@ package service
 import (
 	"context"
 
+	coreunit "github.com/juju/juju/core/unit"
 	"github.com/juju/juju/domain"
 	"github.com/juju/juju/domain/unitstate"
 	"github.com/juju/juju/internal/errors"
@@ -17,38 +18,38 @@ type State interface {
 
 	// GetUnitUUIDForName returns the UUID for
 	// the unit identified by the input name.
-	GetUnitUUIDForName(domain.AtomicContext, string) (string, error)
+	GetUnitUUIDForName(domain.AtomicContext, coreunit.Name) (coreunit.UUID, error)
 
 	// EnsureUnitStateRecord ensures that there is a record
 	// for the agent state for the unit with the input UUID.
-	EnsureUnitStateRecord(domain.AtomicContext, string) error
+	EnsureUnitStateRecord(domain.AtomicContext, coreunit.UUID) error
 
 	// UpdateUnitStateUniter updates the agent uniter
 	// state for the unit with the input UUID.
-	UpdateUnitStateUniter(domain.AtomicContext, string, string) error
+	UpdateUnitStateUniter(domain.AtomicContext, coreunit.UUID, string) error
 
 	// UpdateUnitStateStorage updates the agent storage
 	// state for the unit with the input UUID.
-	UpdateUnitStateStorage(domain.AtomicContext, string, string) error
+	UpdateUnitStateStorage(domain.AtomicContext, coreunit.UUID, string) error
 
 	// UpdateUnitStateSecret updates the agent secret
 	// state for the unit with the input UUID.
-	UpdateUnitStateSecret(domain.AtomicContext, string, string) error
+	UpdateUnitStateSecret(domain.AtomicContext, coreunit.UUID, string) error
 
 	// SetUnitStateCharm replaces the agent charm
 	// state for the unit with the input UUID.
-	SetUnitStateCharm(domain.AtomicContext, string, map[string]string) error
+	SetUnitStateCharm(domain.AtomicContext, coreunit.UUID, map[string]string) error
 
 	// SetUnitStateRelation replaces the agent relation
 	// state for the unit with the input UUID.
-	SetUnitStateRelation(domain.AtomicContext, string, map[int]string) error
+	SetUnitStateRelation(domain.AtomicContext, coreunit.UUID, map[int]string) error
 
 	// GetUnitState returns the full unit agent state.
 	// If no unit with the uuid exists, a [unitstateerrors.UnitNotFound] error
 	// is returned.
 	// If the units state is empty [unitstateerrors.EmptyUnitState] error is
 	// returned.
-	GetUnitState(ctx context.Context, uuid string) (unitstate.RetrievedUnitState, error)
+	GetUnitState(ctx context.Context, name coreunit.Name) (unitstate.RetrievedUnitState, error)
 }
 
 // Service defines a service for interacting with the underlying state.
@@ -61,19 +62,6 @@ func NewService(st State) *Service {
 	return &Service{
 		st: st,
 	}
-}
-
-// GetUnitUUIDForName returns the UUID corresponding to the input unit name.
-// If no unit with the name exists, a [unitstateerrors.UnitNotFound] error is
-// returned.
-func (s *Service) GetUnitUUIDForName(ctx context.Context, name string) (string, error) {
-	var uuid string
-	err := s.st.RunAtomic(ctx, func(ctx domain.AtomicContext) error {
-		var err error
-		uuid, err = s.st.GetUnitUUIDForName(ctx, name)
-		return err
-	})
-	return uuid, err
 }
 
 // SetState persists the input unit state selectively,
@@ -124,8 +112,8 @@ func (s *Service) SetState(ctx context.Context, as unitstate.UnitState) error {
 }
 
 // GetState returns the full unit state. The state may be empty.
-func (s *Service) GetState(ctx context.Context, uuid string) (unitstate.RetrievedUnitState, error) {
-	state, err := s.st.GetUnitState(ctx, uuid)
+func (s *Service) GetState(ctx context.Context, name coreunit.Name) (unitstate.RetrievedUnitState, error) {
+	state, err := s.st.GetUnitState(ctx, name)
 	if err != nil {
 		return unitstate.RetrievedUnitState{}, err
 	}

--- a/domain/unitstate/service/state_mock_test.go
+++ b/domain/unitstate/service/state_mock_test.go
@@ -13,6 +13,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	unit "github.com/juju/juju/core/unit"
 	domain "github.com/juju/juju/domain"
 	unitstate "github.com/juju/juju/domain/unitstate"
 	gomock "go.uber.org/mock/gomock"
@@ -42,7 +43,7 @@ func (m *MockState) EXPECT() *MockStateMockRecorder {
 }
 
 // EnsureUnitStateRecord mocks base method.
-func (m *MockState) EnsureUnitStateRecord(arg0 domain.AtomicContext, arg1 string) error {
+func (m *MockState) EnsureUnitStateRecord(arg0 domain.AtomicContext, arg1 unit.UUID) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EnsureUnitStateRecord", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -68,19 +69,19 @@ func (c *MockStateEnsureUnitStateRecordCall) Return(arg0 error) *MockStateEnsure
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateEnsureUnitStateRecordCall) Do(f func(domain.AtomicContext, string) error) *MockStateEnsureUnitStateRecordCall {
+func (c *MockStateEnsureUnitStateRecordCall) Do(f func(domain.AtomicContext, unit.UUID) error) *MockStateEnsureUnitStateRecordCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateEnsureUnitStateRecordCall) DoAndReturn(f func(domain.AtomicContext, string) error) *MockStateEnsureUnitStateRecordCall {
+func (c *MockStateEnsureUnitStateRecordCall) DoAndReturn(f func(domain.AtomicContext, unit.UUID) error) *MockStateEnsureUnitStateRecordCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetUnitState mocks base method.
-func (m *MockState) GetUnitState(arg0 context.Context, arg1 string) (unitstate.RetrievedUnitState, error) {
+func (m *MockState) GetUnitState(arg0 context.Context, arg1 unit.Name) (unitstate.RetrievedUnitState, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetUnitState", arg0, arg1)
 	ret0, _ := ret[0].(unitstate.RetrievedUnitState)
@@ -107,22 +108,22 @@ func (c *MockStateGetUnitStateCall) Return(arg0 unitstate.RetrievedUnitState, ar
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetUnitStateCall) Do(f func(context.Context, string) (unitstate.RetrievedUnitState, error)) *MockStateGetUnitStateCall {
+func (c *MockStateGetUnitStateCall) Do(f func(context.Context, unit.Name) (unitstate.RetrievedUnitState, error)) *MockStateGetUnitStateCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetUnitStateCall) DoAndReturn(f func(context.Context, string) (unitstate.RetrievedUnitState, error)) *MockStateGetUnitStateCall {
+func (c *MockStateGetUnitStateCall) DoAndReturn(f func(context.Context, unit.Name) (unitstate.RetrievedUnitState, error)) *MockStateGetUnitStateCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // GetUnitUUIDForName mocks base method.
-func (m *MockState) GetUnitUUIDForName(arg0 domain.AtomicContext, arg1 string) (string, error) {
+func (m *MockState) GetUnitUUIDForName(arg0 domain.AtomicContext, arg1 unit.Name) (unit.UUID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetUnitUUIDForName", arg0, arg1)
-	ret0, _ := ret[0].(string)
+	ret0, _ := ret[0].(unit.UUID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -140,19 +141,19 @@ type MockStateGetUnitUUIDForNameCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockStateGetUnitUUIDForNameCall) Return(arg0 string, arg1 error) *MockStateGetUnitUUIDForNameCall {
+func (c *MockStateGetUnitUUIDForNameCall) Return(arg0 unit.UUID, arg1 error) *MockStateGetUnitUUIDForNameCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetUnitUUIDForNameCall) Do(f func(domain.AtomicContext, string) (string, error)) *MockStateGetUnitUUIDForNameCall {
+func (c *MockStateGetUnitUUIDForNameCall) Do(f func(domain.AtomicContext, unit.Name) (unit.UUID, error)) *MockStateGetUnitUUIDForNameCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetUnitUUIDForNameCall) DoAndReturn(f func(domain.AtomicContext, string) (string, error)) *MockStateGetUnitUUIDForNameCall {
+func (c *MockStateGetUnitUUIDForNameCall) DoAndReturn(f func(domain.AtomicContext, unit.Name) (unit.UUID, error)) *MockStateGetUnitUUIDForNameCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -196,7 +197,7 @@ func (c *MockStateRunAtomicCall) DoAndReturn(f func(context.Context, func(domain
 }
 
 // SetUnitStateCharm mocks base method.
-func (m *MockState) SetUnitStateCharm(arg0 domain.AtomicContext, arg1 string, arg2 map[string]string) error {
+func (m *MockState) SetUnitStateCharm(arg0 domain.AtomicContext, arg1 unit.UUID, arg2 map[string]string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetUnitStateCharm", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -222,19 +223,19 @@ func (c *MockStateSetUnitStateCharmCall) Return(arg0 error) *MockStateSetUnitSta
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateSetUnitStateCharmCall) Do(f func(domain.AtomicContext, string, map[string]string) error) *MockStateSetUnitStateCharmCall {
+func (c *MockStateSetUnitStateCharmCall) Do(f func(domain.AtomicContext, unit.UUID, map[string]string) error) *MockStateSetUnitStateCharmCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateSetUnitStateCharmCall) DoAndReturn(f func(domain.AtomicContext, string, map[string]string) error) *MockStateSetUnitStateCharmCall {
+func (c *MockStateSetUnitStateCharmCall) DoAndReturn(f func(domain.AtomicContext, unit.UUID, map[string]string) error) *MockStateSetUnitStateCharmCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // SetUnitStateRelation mocks base method.
-func (m *MockState) SetUnitStateRelation(arg0 domain.AtomicContext, arg1 string, arg2 map[int]string) error {
+func (m *MockState) SetUnitStateRelation(arg0 domain.AtomicContext, arg1 unit.UUID, arg2 map[int]string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetUnitStateRelation", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -260,19 +261,19 @@ func (c *MockStateSetUnitStateRelationCall) Return(arg0 error) *MockStateSetUnit
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateSetUnitStateRelationCall) Do(f func(domain.AtomicContext, string, map[int]string) error) *MockStateSetUnitStateRelationCall {
+func (c *MockStateSetUnitStateRelationCall) Do(f func(domain.AtomicContext, unit.UUID, map[int]string) error) *MockStateSetUnitStateRelationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateSetUnitStateRelationCall) DoAndReturn(f func(domain.AtomicContext, string, map[int]string) error) *MockStateSetUnitStateRelationCall {
+func (c *MockStateSetUnitStateRelationCall) DoAndReturn(f func(domain.AtomicContext, unit.UUID, map[int]string) error) *MockStateSetUnitStateRelationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // UpdateUnitStateSecret mocks base method.
-func (m *MockState) UpdateUnitStateSecret(arg0 domain.AtomicContext, arg1, arg2 string) error {
+func (m *MockState) UpdateUnitStateSecret(arg0 domain.AtomicContext, arg1 unit.UUID, arg2 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateUnitStateSecret", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -298,19 +299,19 @@ func (c *MockStateUpdateUnitStateSecretCall) Return(arg0 error) *MockStateUpdate
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateUpdateUnitStateSecretCall) Do(f func(domain.AtomicContext, string, string) error) *MockStateUpdateUnitStateSecretCall {
+func (c *MockStateUpdateUnitStateSecretCall) Do(f func(domain.AtomicContext, unit.UUID, string) error) *MockStateUpdateUnitStateSecretCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateUpdateUnitStateSecretCall) DoAndReturn(f func(domain.AtomicContext, string, string) error) *MockStateUpdateUnitStateSecretCall {
+func (c *MockStateUpdateUnitStateSecretCall) DoAndReturn(f func(domain.AtomicContext, unit.UUID, string) error) *MockStateUpdateUnitStateSecretCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // UpdateUnitStateStorage mocks base method.
-func (m *MockState) UpdateUnitStateStorage(arg0 domain.AtomicContext, arg1, arg2 string) error {
+func (m *MockState) UpdateUnitStateStorage(arg0 domain.AtomicContext, arg1 unit.UUID, arg2 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateUnitStateStorage", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -336,19 +337,19 @@ func (c *MockStateUpdateUnitStateStorageCall) Return(arg0 error) *MockStateUpdat
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateUpdateUnitStateStorageCall) Do(f func(domain.AtomicContext, string, string) error) *MockStateUpdateUnitStateStorageCall {
+func (c *MockStateUpdateUnitStateStorageCall) Do(f func(domain.AtomicContext, unit.UUID, string) error) *MockStateUpdateUnitStateStorageCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateUpdateUnitStateStorageCall) DoAndReturn(f func(domain.AtomicContext, string, string) error) *MockStateUpdateUnitStateStorageCall {
+func (c *MockStateUpdateUnitStateStorageCall) DoAndReturn(f func(domain.AtomicContext, unit.UUID, string) error) *MockStateUpdateUnitStateStorageCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // UpdateUnitStateUniter mocks base method.
-func (m *MockState) UpdateUnitStateUniter(arg0 domain.AtomicContext, arg1, arg2 string) error {
+func (m *MockState) UpdateUnitStateUniter(arg0 domain.AtomicContext, arg1 unit.UUID, arg2 string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateUnitStateUniter", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -374,13 +375,13 @@ func (c *MockStateUpdateUnitStateUniterCall) Return(arg0 error) *MockStateUpdate
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateUpdateUnitStateUniterCall) Do(f func(domain.AtomicContext, string, string) error) *MockStateUpdateUnitStateUniterCall {
+func (c *MockStateUpdateUnitStateUniterCall) Do(f func(domain.AtomicContext, unit.UUID, string) error) *MockStateUpdateUnitStateUniterCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateUpdateUnitStateUniterCall) DoAndReturn(f func(domain.AtomicContext, string, string) error) *MockStateUpdateUnitStateUniterCall {
+func (c *MockStateUpdateUnitStateUniterCall) DoAndReturn(f func(domain.AtomicContext, unit.UUID, string) error) *MockStateUpdateUnitStateUniterCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/unitstate/state/state.go
+++ b/domain/unitstate/state/state.go
@@ -9,6 +9,7 @@ import (
 	"github.com/canonical/sqlair"
 
 	"github.com/juju/juju/core/database"
+	coreunit "github.com/juju/juju/core/unit"
 	"github.com/juju/juju/domain"
 	"github.com/juju/juju/domain/unitstate"
 	uniterrors "github.com/juju/juju/domain/unitstate/errors"
@@ -29,31 +30,24 @@ func NewState(factory database.TxnRunnerFactory) *State {
 
 // GetUnitUUIDForName returns the UUID corresponding to the input unit name.
 // If no unit with the name exists, a [errors.UnitNotFound] error is returned.
-func (st *State) GetUnitUUIDForName(ctx domain.AtomicContext, name string) (string, error) {
-	uName := unitName{Name: name}
-	uuid := unitUUID{}
-
-	q := "SELECT &unitUUID.uuid FROM unit WHERE name = $unitName.name"
-	stmt, err := st.Prepare(q, uName, uuid)
-	if err != nil {
-		return "", errors.Errorf("preparing UUID query: %w", err)
-	}
-
-	err = domain.Run(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		err := tx.Query(ctx, stmt, uName).Get(&uuid)
-		if errors.Is(err, sqlair.ErrNoRows) {
-			return uniterrors.UnitNotFound
-		}
+func (st *State) GetUnitUUIDForName(ctx domain.AtomicContext, name coreunit.Name) (coreunit.UUID, error) {
+	var unitUUID unitUUID
+	err := domain.Run(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		var err error
+		unitUUID, err = st.getUnitUUIDForName(ctx, tx, name)
 		return err
 	})
 
-	return uuid.UUID, err
+	if err != nil {
+		return "", errors.Errorf("getting unit UUID for %q: %w", name, err)
+	}
+	return unitUUID.UUID, nil
 }
 
 // EnsureUnitStateRecord ensures that there is a row in the unit_state table
 // for the input unit UUID. This eliminates the need for upsert statements
 // when updating state for uniter, storage and secrets.
-func (st *State) EnsureUnitStateRecord(ctx domain.AtomicContext, uuid string) error {
+func (st *State) EnsureUnitStateRecord(ctx domain.AtomicContext, uuid coreunit.UUID) error {
 	id := unitUUID{UUID: uuid}
 
 	q := "SELECT unit_uuid AS &unitUUID.uuid FROM unit_state WHERE unit_uuid = $unitUUID.uuid"
@@ -89,7 +83,7 @@ func (st *State) EnsureUnitStateRecord(ctx domain.AtomicContext, uuid string) er
 
 // UpdateUnitStateUniter sets the input uniter
 // state against the input unit UUID.
-func (st *State) UpdateUnitStateUniter(ctx domain.AtomicContext, uuid, state string) error {
+func (st *State) UpdateUnitStateUniter(ctx domain.AtomicContext, uuid coreunit.UUID, state string) error {
 	id := unitUUID{UUID: uuid}
 	uSt := unitState{UniterState: state}
 
@@ -106,7 +100,7 @@ func (st *State) UpdateUnitStateUniter(ctx domain.AtomicContext, uuid, state str
 
 // UpdateUnitStateStorage sets the input storage
 // state against the input unit UUID.
-func (st *State) UpdateUnitStateStorage(ctx domain.AtomicContext, uuid, state string) error {
+func (st *State) UpdateUnitStateStorage(ctx domain.AtomicContext, uuid coreunit.UUID, state string) error {
 	id := unitUUID{UUID: uuid}
 	uSt := unitState{StorageState: state}
 
@@ -123,7 +117,7 @@ func (st *State) UpdateUnitStateStorage(ctx domain.AtomicContext, uuid, state st
 
 // UpdateUnitStateSecret sets the input secret
 // state against the input unit UUID.
-func (st *State) UpdateUnitStateSecret(ctx domain.AtomicContext, uuid, state string) error {
+func (st *State) UpdateUnitStateSecret(ctx domain.AtomicContext, uuid coreunit.UUID, state string) error {
 	id := unitUUID{UUID: uuid}
 	uSt := unitState{SecretState: state}
 
@@ -140,7 +134,7 @@ func (st *State) UpdateUnitStateSecret(ctx domain.AtomicContext, uuid, state str
 
 // SetUnitStateCharm sets the input key/value pairs
 // as the charm state for the input unit UUID.
-func (st *State) SetUnitStateCharm(ctx domain.AtomicContext, uuid string, state map[string]string) error {
+func (st *State) SetUnitStateCharm(ctx domain.AtomicContext, uuid coreunit.UUID, state map[string]string) error {
 	id := unitUUID{UUID: uuid}
 
 	q := "DELETE from unit_state_charm WHERE unit_uuid = $unitUUID.uuid"
@@ -171,7 +165,7 @@ func (st *State) SetUnitStateCharm(ctx domain.AtomicContext, uuid string, state 
 
 // SetUnitStateRelation sets the input key/value pairs
 // as the relation state for the input unit UUID.
-func (st *State) SetUnitStateRelation(ctx domain.AtomicContext, uuid string, state map[int]string) error {
+func (st *State) SetUnitStateRelation(ctx domain.AtomicContext, uuid coreunit.UUID, state map[int]string) error {
 	id := unitUUID{UUID: uuid}
 
 	q := "DELETE from unit_state_relation WHERE unit_uuid = $unitUUID.uuid"
@@ -205,23 +199,15 @@ func (st *State) SetUnitStateRelation(ctx domain.AtomicContext, uuid string, sta
 // GetUnitState returns the full unit state. The state may be
 // empty.
 // If no unit with the uuid exists, a [errors.UnitNotFound] error is returned.
-func (st *State) GetUnitState(ctx context.Context, uuid string) (unitstate.RetrievedUnitState, error) {
+func (st *State) GetUnitState(ctx context.Context, name coreunit.Name) (unitstate.RetrievedUnitState, error) {
 	db, err := st.DB()
 	if err != nil {
 		return unitstate.RetrievedUnitState{}, errors.Errorf("getting db: %w", err)
 	}
 
-	id := unitUUID{UUID: uuid}
-	var count count
-	q := "SELECT COUNT(uuid) AS &count.count FROM unit WHERE uuid = $unitUUID.uuid"
-	unitNameStmt, err := st.Prepare(q, count, id)
-	if err != nil {
-		return unitstate.RetrievedUnitState{}, errors.Errorf("preparing select unit name statement: %w", err)
-	}
-
 	var state unitState
-	q = "SELECT &unitState.* FROM unit_state WHERE unit_uuid = $unitUUID.uuid"
-	unitStateStmt, err := st.Prepare(q, state, id)
+	q := "SELECT &unitState.* FROM unit_state WHERE unit_uuid = $unitUUID.uuid"
+	unitStateStmt, err := st.Prepare(q, state, unitUUID{})
 	if err != nil {
 		return unitstate.RetrievedUnitState{}, errors.Errorf("preparing select unit state statement: %w", err)
 	}
@@ -231,7 +217,7 @@ func (st *State) GetUnitState(ctx context.Context, uuid string) (unitstate.Retri
 SELECT &unitCharmStateKeyVal.*
 FROM unit_state_charm
 WHERE unit_uuid = $unitUUID.uuid`
-	charmStateStmt, err := st.Prepare(q, unitCharmStateKeyVal{}, id)
+	charmStateStmt, err := st.Prepare(q, unitCharmStateKeyVal{}, unitUUID{})
 	if err != nil {
 		return unitstate.RetrievedUnitState{}, errors.Errorf("preparing select unit charm state statement: %w", err)
 	}
@@ -241,17 +227,15 @@ WHERE unit_uuid = $unitUUID.uuid`
 SELECT &unitRelationStateKeyVal.*
 FROM unit_state_relation
 WHERE unit_uuid = $unitUUID.uuid`
-	relationStateStmt, err := st.Prepare(q, unitRelationStateKeyVal{}, id)
+	relationStateStmt, err := st.Prepare(q, unitRelationStateKeyVal{}, unitUUID{})
 	if err != nil {
 		return unitstate.RetrievedUnitState{}, errors.Errorf("preparing select unit relation state statement: %w", err)
 	}
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		err := tx.Query(ctx, unitNameStmt, id).Get(&count)
-		if count.Count < 1 {
-			return uniterrors.UnitNotFound
-		} else if err != nil {
-			return errors.Errorf("getting unit name: %w", err)
+		id, err := st.getUnitUUIDForName(ctx, tx, name)
+		if err != nil {
+			return errors.Errorf("getting unit UUID for %q: %w", name, err)
 		}
 
 		err = tx.Query(ctx, unitStateStmt, id).Get(&state)
@@ -288,4 +272,24 @@ WHERE unit_uuid = $unitUUID.uuid`
 	}
 
 	return unitState, nil
+}
+
+func (st *State) getUnitUUIDForName(ctx context.Context, tx *sqlair.TX, name coreunit.Name) (unitUUID, error) {
+	uName := unitName{Name: name}
+	uuid := unitUUID{}
+
+	q := "SELECT &unitUUID.uuid FROM unit WHERE name = $unitName.name"
+	stmt, err := st.Prepare(q, uName, uuid)
+	if err != nil {
+		return unitUUID{}, errors.Errorf("preparing UUID query: %w", err)
+	}
+
+	err = tx.Query(ctx, stmt, uName).Get(&uuid)
+	if errors.Is(err, sqlair.ErrNoRows) {
+		return unitUUID{}, uniterrors.UnitNotFound
+	} else if err != nil {
+		return unitUUID{}, errors.Errorf("getting unit UUID for %q: %w", name, err)
+	}
+
+	return uuid, nil
 }

--- a/domain/unitstate/state/types.go
+++ b/domain/unitstate/state/types.go
@@ -3,17 +3,19 @@
 
 package state
 
+import "github.com/juju/juju/core/unit"
+
 // unitUUID identifies a unit.
 type unitUUID struct {
 	// UUID is the universally unique identifier for a unit.
-	UUID string `db:"uuid"`
+	UUID unit.UUID `db:"uuid"`
 }
 
 // unitName identifies a unit.
 type unitName struct {
 	// Name uniquely identifies a unit and indicates its application.
 	// For example, postgresql/3.
-	Name string `db:"name"`
+	Name unit.Name `db:"name"`
 }
 
 // unitState contains a YAML string representing the
@@ -30,15 +32,15 @@ type unitState struct {
 // unitStateVal is a type for holding a key/value pair that is
 // a constituent in unit state for charm and relation.
 type unitStateKeyVal[T comparable] struct {
-	UUID  string `db:"unit_uuid"`
-	Key   T      `db:"key"`
-	Value string `db:"value"`
+	UUID  unit.UUID `db:"unit_uuid"`
+	Key   T         `db:"key"`
+	Value string    `db:"value"`
 }
 
 type unitCharmStateKeyVal unitStateKeyVal[string]
 type unitRelationStateKeyVal unitStateKeyVal[int]
 
-func makeUnitCharmStateKeyVals(unitUUID string, kv map[string]string) []unitCharmStateKeyVal {
+func makeUnitCharmStateKeyVals(unitUUID unit.UUID, kv map[string]string) []unitCharmStateKeyVal {
 	keyVals := make([]unitCharmStateKeyVal, 0, len(kv))
 	for k, v := range kv {
 		keyVals = append(keyVals, unitCharmStateKeyVal{
@@ -50,7 +52,7 @@ func makeUnitCharmStateKeyVals(unitUUID string, kv map[string]string) []unitChar
 	return keyVals
 }
 
-func makeUnitRelationStateKeyVals(unitUUID string, kv map[int]string) []unitRelationStateKeyVal {
+func makeUnitRelationStateKeyVals(unitUUID unit.UUID, kv map[int]string) []unitRelationStateKeyVal {
 	keyVals := make([]unitRelationStateKeyVal, 0, len(kv))
 	for k, v := range kv {
 		keyVals = append(keyVals, unitRelationStateKeyVal{
@@ -76,9 +78,4 @@ func makeMapFromRelationUnitStateKeyVals(us []unitRelationStateKeyVal) map[int]s
 		m[kv.Key] = kv.Value
 	}
 	return m
-}
-
-// count stores the count of rows in the DB.
-type count struct {
-	Count int `db:"count"`
 }

--- a/domain/unitstate/types.go
+++ b/domain/unitstate/types.go
@@ -3,11 +3,13 @@
 
 package unitstate
 
+import "github.com/juju/juju/core/unit"
+
 // UnitState represents the state of the world according to a unit agent at
 // hook commit time.
 type UnitState struct {
 	// Name is the unit name.
-	Name string
+	Name unit.Name
 
 	// CharmState is key/value pairs for charm attributes.
 	CharmState *map[string]string


### PR DESCRIPTION
There are two main changes which I have made:
- Unit coreunit.Name and coreunit.UUID throughout the domain
- Replace the uuid parameter of GetState with the unit name.

This allows us to drop GetUnitUUIDForName from the domain, as it is no longer used

A subsequent PR will remove RunAtomic

## QA steps

passing unit tests

```
juju bootstrap lxd lxd
juju add-model m
juju deploy ubuntu
```
And verify app becomes active/idle