### PR TITLE
test: improve smoke test with more charms deployed

### DIFF
--- a/tests/suites/smoke/deploy.sh
+++ b/tests/suites/smoke/deploy.sh
@@ -34,9 +34,21 @@ run_charmhub_deploy() {
 
 	ensure "${model_name}" "${file}"
 
-	charm="juju-qa-test"
-	juju deploy "$charm" --revision 22 --channel stable "$charm"
-	wait_for "$charm" "$(idle_condition "$charm")"
+	juju deploy "juju-qa-test" --revision 22 --channel stable "juju-qa-test"
+	# TODO(nvinuesa): Ideally, we want to deploy the next 2 charms with a
+	# placement directive, both to make the test faster and also to test
+	# the placement directives. However, until machines are not fully
+	# migrated to dqlite, placement directives are broken.
+	juju deploy "juju-qa-dummy-source"
+	juju deploy "juju-qa-dummy-sink"
+
+	wait_for "juju-qa-test" "$(idle_condition "juju-qa-test" 2)"
+	wait_for "dummy-source" "$(idle_condition "dummy-source" 1)"
+	wait_for "dummy-sink" "$(idle_condition "dummy-sink" 0)"
+	# TODO(nvinuesa): When relations are finished implementing in 4.0, we
+	# should integrate dummy-source with dummy-sink.
+	# juju integrate dummy-source dummy-sink
+	# juju expose dummy-sink
 
 	# Refresh is removed, add it back in when we support refresh.
 	# juju refresh "$charm" --revision 23


### PR DESCRIPTION
We have recently discovered breakages in main that weren't picked up by the smoke tests. Although these aren't expected to fully test Juju, they should at least test basic paths correctly.

This patch improves the smoke test by deploying the dummy-sink and dummy-source charms as well as qa-test.
Unfortunately we cannot use placement directives (to increase speed and also test the placement directive itself) because they are broken until machines are fully migrated to dqlite nor the integration between sink and source because relations are currently broken.

## QA steps

```
$ cd tests && ./main.sh -v smoke test_deploy
```

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/

**Jira card:** JUJU-

