### PR TITLE
chore: remove application scale related methods and fields from legacy state.

### DIFF
--- a/apiserver/facades/client/client/service.go
+++ b/apiserver/facades/client/client/service.go
@@ -51,6 +51,11 @@ type ApplicationService interface {
 	// It returns an error satisfying [applicationerrors.UnitNotFound] if the unit doesn't
 	// exist.
 	GetUnitDisplayStatus(context.Context, unit.Name) (*status.StatusInfo, error)
+
+	// GetApplicationScale returns the desired scale of an application, returning an error
+	// satisfying [applicationerrors.ApplicationNotFoundError] if the application doesn't exist.
+	// This is used on CAAS models.
+	GetApplicationScale(ctx context.Context, appName string) (int, error)
 }
 
 // BlockDeviceService instances can fetch block devices for a machine.

--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -1231,7 +1231,12 @@ func (context *statusContext) processApplication(ctx context.Context, applicatio
 		} else {
 			logger.Debugf(ctx, "no service details for %v: %v", application.Name(), err)
 		}
-		processedStatus.Scale = application.GetScale()
+		appScale, err := context.applicationService.GetApplicationScale(ctx, application.Name())
+		if err == nil {
+			processedStatus.Scale = appScale
+		} else {
+			logger.Debugf(ctx, "no application scale for %v: %v", application.Name(), err)
+		}
 	}
 	processedStatus.EndpointBindings = context.allAppsUnitsCharmBindings.endpointBindings[application.Name()]
 	return processedStatus

--- a/state/errors/application.go
+++ b/state/errors/application.go
@@ -8,10 +8,6 @@ import (
 )
 
 const (
-	// ProvisioningStateInconsistent is returned by SetProvisioningState when the provisioning state
-	// is inconsistent with the application scale.
-	ProvisioningStateInconsistent = errors.ConstError("provisioning state is inconsistent")
-
 	// ErrApplicationShouldNotHaveUnits is returned by SetCharm when the application has units when
 	// it is expected to not have units. Used for upgrading from podspec to sidecar charms.
 	ErrApplicationShouldNotHaveUnits = errors.ConstError("application should not have units")

--- a/state/migration_export.go
+++ b/state/migration_export.go
@@ -534,7 +534,6 @@ func (e *exporter) addApplication(ctx addApplicationContext) error {
 		PasswordHash:         application.doc.PasswordHash,
 		Placement:            application.doc.Placement,
 		HasResources:         application.doc.HasResources,
-		DesiredScale:         application.doc.DesiredScale,
 		EndpointBindings:     map[string]string(ctx.endpointBindings[globalKey]),
 		ApplicationConfig:    applicationConfig,
 		CharmConfig:          charmConfig,
@@ -546,13 +545,6 @@ func (e *exporter) addApplication(ctx addApplicationContext) error {
 	}
 	if constraints, found := e.modelStorageConstraints[storageConstraintsKey]; found {
 		args.StorageDirectives = e.storageDirectives(constraints)
-	}
-
-	if ps := application.ProvisioningState(); ps != nil {
-		args.ProvisioningState = &description.ProvisioningStateArgs{
-			Scaling:     ps.Scaling,
-			ScaleTarget: ps.ScaleTarget,
-		}
 	}
 
 	// Include exposed endpoint details

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -900,16 +900,8 @@ func (i *importer) makeApplicationDoc(a description.Application) (*applicationDo
 		Exposed:              a.Exposed(),
 		ExposedEndpoints:     exposedEndpoints,
 		Tools:                agentTools,
-		DesiredScale:         a.DesiredScale(),
 		Placement:            a.Placement(),
 		HasResources:         a.HasResources(),
-	}
-
-	if ps := a.ProvisioningState(); ps != nil {
-		appDoc.ProvisioningState = &ApplicationProvisioningState{
-			Scaling:     ps.Scaling(),
-			ScaleTarget: ps.ScaleTarget(),
-		}
 	}
 
 	return appDoc, nil

--- a/state/state.go
+++ b/state/state.go
@@ -1031,7 +1031,6 @@ func (st *State) AddApplication(
 
 	// Perform model specific arg processing.
 	var (
-		scale             int
 		placement         string
 		hasResources      bool
 		operatorStatusDoc *statusDoc
@@ -1047,7 +1046,6 @@ func (st *State) AddApplication(
 		if err := st.processCAASModelApplicationArgs(&args); err != nil {
 			return nil, errors.Trace(err)
 		}
-		scale = args.NumUnits
 		if len(args.Placement) == 1 {
 			placement = args.Placement[0].Directive
 		}
@@ -1079,7 +1077,6 @@ func (st *State) AddApplication(
 		UnitCount:     args.NumUnits,
 
 		// CAAS
-		DesiredScale: scale,
 		Placement:    placement,
 		HasResources: hasResources,
 	}

--- a/state/watcher.go
+++ b/state/watcher.go
@@ -455,33 +455,6 @@ func (a *Application) WatchUnits() StringsWatcher {
 	return newLifecycleWatcher(a.st, unitsC, members, filter, nil)
 }
 
-// WatchScale returns a new NotifyWatcher watching for
-// changes to the specified application's scale value.
-func (a *Application) WatchScale() NotifyWatcher {
-	currentScale := -1
-	filter := func(id interface{}) bool {
-		k, err := a.st.strictLocalID(id.(string))
-		if err != nil {
-			return false
-		}
-		if k != a.doc.Name {
-			return false
-		}
-		applications, closer := a.st.db().GetCollection(applicationsC)
-		defer closer()
-
-		var scaleField = bson.D{{"scale", 1}}
-		var doc *applicationDoc
-		if err := applications.FindId(k).Select(scaleField).One(&doc); err != nil {
-			return false
-		}
-		match := doc.DesiredScale != currentScale
-		currentScale = doc.DesiredScale
-		return match
-	}
-	return newNotifyCollWatcher(a.st, applicationsC, filter)
-}
-
 // WatchRelations returns a StringsWatcher that notifies of changes to the
 // lifecycles of relations involving a.
 func (a *Application) WatchRelations() StringsWatcher {


### PR DESCRIPTION
This patch cleans up the legacy state regarding application scale (methods, doc fields and structs).

There was only one usage which wasn't wired in the client facade for status (see `apiserver/facades/client/client/status.go`).

## QA steps

Bootstrap on k8s, deploy and check status (scale should be correct - `1`):

``` 
$ juju bootstrap microk8s c
$ juju add-model m
$ juju deploy snappass-test
$ juju status
Model  Controller  Cloud/Region        Version    Timestamp
m      c           microk8s/localhost  4.0-beta6  15:38:28+01:00

App            Version  Status  Scale  Charm          Channel        Rev  Address  Exposed  Message
snappass-test           active      1  snappass-test  latest/stable    9           no       redis started

Unit              Workload  Agent  Address  Ports  Message
snappass-test/0*  active    idle                   redis started
```

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/

**Jira card:** JUJU-7519

