### PR TITLE
docs(lxd): add documentation for trust-token auth

### DIFF
--- a/docs/user/reference/cloud/list-of-supported-clouds/the-lxd-cloud-and-juju.md
+++ b/docs/user/reference/cloud/list-of-supported-clouds/the-lxd-cloud-and-juju.md
@@ -61,7 +61,10 @@ Attributes:
 
 #### `interactive`
 Attributes:
-- trust-password: the LXD server trust password (required)
+- trust-token: the LXD server trust token (optional, required if trust-password is not set).
+<br>This is the recommended method for authenticating with a remote LXD server (see [LXD \| Adding client certificates using tokens](https://documentation.ubuntu.com/lxd/en/stable-5.0/authentication/#adding-client-certificates-using-tokens)).
+<br>(Added in Juju 3.6.4)
+- trust-password: the LXD server trust password (optional, required if trust-token is not set)
 
 <!--
 ## Notes on `juju bootstrap`


### PR DESCRIPTION
This patch improves the LXD documentation to include the recent addition of the trust-token flow authentication for LXD clouds in Juju (see https://github.com/juju/juju/pull/18626).

## Documentation changes
Updates https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/cloud/list-of-supported-clouds/the-lxd-cloud-and-juju/

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/

**Jira card:** JUJU-

