### PR TITLE
fix(docs): update broken url for metrics collection from Juju controller

### DIFF
--- a/docs/user/tutorial.md
+++ b/docs/user/tutorial.md
@@ -621,7 +621,7 @@ Congratulations, you now have a functional observability setup! But your control
 
 
 
-> See more: [Manage controllers > Collect metrics about a controller](/t/1111#heading--collect-metrics-about-a-controller)
+> See more: [Manage controllers > Collect metrics about a controller](https://canonical-juju.readthedocs-hosted.com/en/latest/user/howto/manage-controllers/#collect-metrics-about-a-controller)
 
 
 ## Tear down your test environment

--- a/docs/user/tutorial.md
+++ b/docs/user/tutorial.md
@@ -621,7 +621,7 @@ Congratulations, you now have a functional observability setup! But your control
 
 
 
-> See more: [Manage controllers > Collect metrics about a controller](howto/manage-controllers.md/#collect-metrics-about-a-controller)
+> See more: [Manage controllers > Collect metrics about a controller](collect-metrics-about-a-controller)
 
 
 ## Tear down your test environment

--- a/docs/user/tutorial.md
+++ b/docs/user/tutorial.md
@@ -621,7 +621,7 @@ Congratulations, you now have a functional observability setup! But your control
 
 
 
-> See more: [Manage controllers > Collect metrics about a controller](collect-metrics-about-a-controller)
+> See more: {ref}`collect-metrics-about-a-controller`
 
 
 ## Tear down your test environment

--- a/docs/user/tutorial.md
+++ b/docs/user/tutorial.md
@@ -621,7 +621,7 @@ Congratulations, you now have a functional observability setup! But your control
 
 
 
-> See more: [Manage controllers > Collect metrics about a controller](https://canonical-juju.readthedocs-hosted.com/en/latest/user/howto/manage-controllers/#collect-metrics-about-a-controller)
+> See more: [Manage controllers > Collect metrics about a controller](howto/manage-controllers.md/#collect-metrics-about-a-controller)
 
 
 ## Tear down your test environment


### PR DESCRIPTION

<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://github.com/juju/juju/blob/main/doc/conventional-commits.md
-->

<!-- Why this change is needed and what it does. -->
Currently "Collect metrics about a controller" URL in user tutorial is broken. This minor fix propose to update the URL to the correct page. 




<!-- 

Describe steps to verify that the change works. 

If you're changing any of the facades, you need to ensure that you've tested
a model migration from 3.6 to 4.0 and from 4.0 to 4.0.

The following steps are a good starting point:

 1. Bootstrap a 3.6 controller and deploy a charm.

```sh
$ juju bootstrap lxd src36
$ juju add-model moveme1
$ juju deploy juju-qa-test
```

 2. Bootstrap a 4.0 controller with the changes and migrate the model.

```sh
$ juju bootstrap lxd dst40
$ juju migrate src36:moveme1 dst40
$ juju add-unit juju-qa-test
```

 3. Verify no errors exist in the model logs for the agents. If there are
    errors, this is a bug and should be fixed before merging. The fix can
    either be applied to the 4.0 branch (preferable) or the 3.6 branch, though
    that needs to be discussed with the team.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme1
```

    4. We also need to test a model migration from 4.0 to 4.0.

```sh
$ juju bootstrap lxd src40
$ juju add-model moveme2
$ juju deploy juju-qa-test
```

```sh
$ juju migrate src40:moveme2 dst40
$ juju add-unit juju-qa-test
```

    5. Verify that there are no errors in the controller or model logs.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme2
```

-->



<!-- How it affects user workflow (CLI or API). -->



<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->



