### PR TITLE
chore: bump names/v6 to include spaces/subnets support of UUIDs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -61,7 +61,7 @@ require (
 	github.com/juju/lumberjack/v2 v2.0.2
 	github.com/juju/mgo/v3 v3.0.4
 	github.com/juju/mutex/v2 v2.0.0
-	github.com/juju/names/v6 v6.0.0-20250122164631-383bcab851ca
+	github.com/juju/names/v6 v6.0.0-20250311151448-68186dd8ce9d
 	github.com/juju/naturalsort v1.0.0
 	github.com/juju/os/v2 v2.2.5
 	github.com/juju/persistent-cookiejar v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -426,8 +426,8 @@ github.com/juju/mutex/v2 v2.0.0-20220128011612-57176ebdcfa3/go.mod h1:TTCG9BJD9r
 github.com/juju/mutex/v2 v2.0.0-20220203023141-11eeddb42c6c/go.mod h1:jwCfBs/smYDaeZLqeaCi8CB8M+tOes4yf827HoOEoqk=
 github.com/juju/mutex/v2 v2.0.0 h1:rVmJdOaXGWF8rjcFHBNd4x57/1tks5CgXHx55O55SB0=
 github.com/juju/mutex/v2 v2.0.0/go.mod h1:jwCfBs/smYDaeZLqeaCi8CB8M+tOes4yf827HoOEoqk=
-github.com/juju/names/v6 v6.0.0-20250122164631-383bcab851ca h1:rvttn1X8XuJwysMtQnDmSl59MV4r0Go37E/rgg65+eM=
-github.com/juju/names/v6 v6.0.0-20250122164631-383bcab851ca/go.mod h1:msqFCjHhF+wL7NR5aEDRlpxCybna0+5E9kbRSb2fiz4=
+github.com/juju/names/v6 v6.0.0-20250311151448-68186dd8ce9d h1:ibqSeSEwCdwazMdqIAzQRY/7Hcgo/ul8yGgX6MqYdbY=
+github.com/juju/names/v6 v6.0.0-20250311151448-68186dd8ce9d/go.mod h1:msqFCjHhF+wL7NR5aEDRlpxCybna0+5E9kbRSb2fiz4=
 github.com/juju/naturalsort v1.0.0 h1:kGmUUy3h8mJ5/SJYaqKOBR3f3owEd5R52Lh+Tjg/dNM=
 github.com/juju/naturalsort v1.0.0/go.mod h1:Zqa/vGkXr78k47zM6tFmU9phhxKz/PIdqBzpLhJ86zc=
 github.com/juju/os/v2 v2.2.5 h1:Ayw9aC7axKtGgzy3dFRKx84FxasfISMege0iYDsH6io=


### PR DESCRIPTION
This patch bumps names/v6 to include the spaces/subnets tag creation issue which didn't take into account the UUIDs as space/subnet IDs, see https://github.com/juju/names/pull/118.


## QA steps

Same QA as https://github.com/juju/names/pull/118:
```
$ juju bootstrap lxd c --build-agent
$ juju add-model m
$ juju add-space beta
$ juju spaces
Name   Space ID                              Subnets
alpha  0                                     10.165.241.0/24
                                             10.254.213.0/24
beta   019585a6-b393-7cbe-b131-51bb67af8f52
$ juju subnets
subnets:
  10.165.241.0/24:
    type: ipv4
    provider-id: subnet-lxdbr0-10.165.241.0/24
    provider-network-id: net-lxdbr0
    space: alpha
    zones:
    - newells
  10.254.213.0/24:
    type: ipv4
    provider-id: subnet-mpqemubr0-10.254.213.0/24
    provider-network-id: net-mpqemubr0
    space: alpha
    zones:
    - newells
$ juju move-to-space beta 10.254.213.0/24
$ juju spaces
Name   Space ID                              Subnets
alpha  0                                     10.165.241.0/24
beta   019585a6-b393-7cbe-b131-51bb67af8f52  10.254.213.0/24
$ juju subnets
subnets:
  10.165.241.0/24:
    type: ipv4
    provider-id: subnet-lxdbr0-10.165.241.0/24
    provider-network-id: net-lxdbr0
    space: alpha
    zones:
    - newells
  10.254.213.0/24:
    type: ipv4
    provider-id: subnet-mpqemubr0-10.254.213.0/24
    provider-network-id: net-mpqemubr0
    space: beta
    zones:
    - newells
```
## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/

**Jira card:** JUJU-

