### PR TITLE
feat: implement unit scale migration

### DIFF
--- a/domain/application/modelmigration/export_charm_test.go
+++ b/domain/application/modelmigration/export_charm_test.go
@@ -13,6 +13,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/constraints"
+	"github.com/juju/juju/domain/application"
 	internalcharm "github.com/juju/juju/internal/charm"
 	"github.com/juju/juju/internal/charm/assumes"
 	"github.com/juju/juju/internal/charm/resource"
@@ -43,6 +44,7 @@ func (s *exportCharmSuite) TestApplicationExportMinimalCharm(c *gc.C) {
 	s.expectApplicationStatus()
 	s.expectApplicationUnitStatus(c)
 	s.expectApplicationConstraints(constraints.Value{})
+	s.expectGetApplicationScaleState(application.ScaleState{})
 
 	exportOp := exportOperation{
 		service: s.exportService,

--- a/domain/application/modelmigration/export_unit_test.go
+++ b/domain/application/modelmigration/export_unit_test.go
@@ -17,6 +17,7 @@ import (
 	corestatus "github.com/juju/juju/core/status"
 	coreunit "github.com/juju/juju/core/unit"
 	unittesting "github.com/juju/juju/core/unit/testing"
+	"github.com/juju/juju/domain/application"
 )
 
 type exportUnitSuite struct {
@@ -48,6 +49,7 @@ func (s *exportUnitSuite) TestApplicationExportUnitWorkloadStatus(c *gc.C) {
 	s.expectApplicationConfig()
 	s.expectApplicationStatus()
 	s.expectApplicationConstraints(constraints.Value{})
+	s.expectGetApplicationScaleState(application.ScaleState{})
 
 	exportOp := exportOperation{
 		service: s.exportService,

--- a/domain/application/modelmigration/import.go
+++ b/domain/application/modelmigration/import.go
@@ -157,6 +157,14 @@ func (i *importOperation) Execute(ctx context.Context, model description.Model) 
 		}
 
 		applicationStatus := i.importStatus(app.Status())
+		scaleState := application.ScaleState{
+			Scale: app.DesiredScale(),
+		}
+
+		if provisioningState := app.ProvisioningState(); provisioningState != nil {
+			scaleState.Scaling = provisioningState.Scaling()
+			scaleState.ScaleTarget = provisioningState.ScaleTarget()
+		}
 
 		err = i.service.ImportApplication(ctx, app.Name(), service.ImportApplicationArgs{
 			Charm:                  charm,
@@ -166,6 +174,7 @@ func (i *importOperation) Execute(ctx context.Context, model description.Model) 
 			ApplicationSettings:    applicationSettings,
 			ApplicationStatus:      &applicationStatus,
 			ApplicationConstraints: i.importApplicationConstraints(app),
+			ScaleState:             scaleState,
 
 			// ReferenceName is the name of the charm URL, not the application
 			// name and not the charm name in the metadata, but the name of

--- a/domain/application/modelmigration/migrations_mock_test.go
+++ b/domain/application/modelmigration/migrations_mock_test.go
@@ -226,6 +226,45 @@ func (c *MockExportServiceGetApplicationConstraintsCall) DoAndReturn(f func(cont
 	return c
 }
 
+// GetApplicationScaleState mocks base method.
+func (m *MockExportService) GetApplicationScaleState(arg0 context.Context, arg1 string) (application.ScaleState, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetApplicationScaleState", arg0, arg1)
+	ret0, _ := ret[0].(application.ScaleState)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetApplicationScaleState indicates an expected call of GetApplicationScaleState.
+func (mr *MockExportServiceMockRecorder) GetApplicationScaleState(arg0, arg1 any) *MockExportServiceGetApplicationScaleStateCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetApplicationScaleState", reflect.TypeOf((*MockExportService)(nil).GetApplicationScaleState), arg0, arg1)
+	return &MockExportServiceGetApplicationScaleStateCall{Call: call}
+}
+
+// MockExportServiceGetApplicationScaleStateCall wrap *gomock.Call
+type MockExportServiceGetApplicationScaleStateCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockExportServiceGetApplicationScaleStateCall) Return(arg0 application.ScaleState, arg1 error) *MockExportServiceGetApplicationScaleStateCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockExportServiceGetApplicationScaleStateCall) Do(f func(context.Context, string) (application.ScaleState, error)) *MockExportServiceGetApplicationScaleStateCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockExportServiceGetApplicationScaleStateCall) DoAndReturn(f func(context.Context, string) (application.ScaleState, error)) *MockExportServiceGetApplicationScaleStateCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetApplicationStatus mocks base method.
 func (m *MockExportService) GetApplicationStatus(arg0 context.Context, arg1 string) (*status.StatusInfo, error) {
 	m.ctrl.T.Helper()

--- a/domain/application/service/migration_test.go
+++ b/domain/application/service/migration_test.go
@@ -478,6 +478,9 @@ func (s *migrationServiceSuite) TestImportApplication(c *gc.C) {
 
 	s.state.EXPECT().SetApplicationConstraints(gomock.Any(), id, domainconstraints.DecodeConstraints(cons)).Return(nil)
 
+	s.state.EXPECT().SetDesiredApplicationScale(gomock.Any(), id, 1).Return(nil)
+	s.state.EXPECT().SetApplicationScalingState(gomock.Any(), "ubuntu", 42, true).Return(nil)
+
 	err := s.service.ImportApplication(context.Background(), "ubuntu", ImportApplicationArgs{
 		Charm: s.charm,
 		CharmOrigin: corecharm.Origin{
@@ -496,6 +499,11 @@ func (s *migrationServiceSuite) TestImportApplication(c *gc.C) {
 		},
 		Units: []ImportUnitArg{
 			unitArg,
+		},
+		ScaleState: application.ScaleState{
+			Scale:       1,
+			Scaling:     true,
+			ScaleTarget: 42,
 		},
 	})
 	c.Assert(err, jc.ErrorIsNil)

--- a/domain/application/service/params.go
+++ b/domain/application/service/params.go
@@ -225,4 +225,8 @@ type ImportApplicationArgs struct {
 	// CharmUpgradeOnError indicates whether the charm must be upgraded
 	// even when on error.
 	CharmUpgradeOnError bool
+
+	// ScaleState is the scale state (including scaling, scale and scale
+	// target) of the application.
+	ScaleState application.ScaleState
 }

--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/juju/ansiterm v1.0.0
 	github.com/juju/clock v1.1.1
 	github.com/juju/collections v1.0.4
-	github.com/juju/description/v9 v9.0.0-20250305234742-e64be4ed3995
+	github.com/juju/description/v9 v9.0.0-20250312165826-51f91f8806d8
 	github.com/juju/errors v1.0.0
 	github.com/juju/gnuflag v1.0.0
 	github.com/juju/gojsonschema v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -377,8 +377,8 @@ github.com/juju/collections v0.0.0-20220203020748-febd7cad8a7a/go.mod h1:JWeZdyt
 github.com/juju/collections v1.0.0/go.mod h1:JWeZdyttIEbkR51z2S13+J+aCuHVe0F6meRy+P0YGDo=
 github.com/juju/collections v1.0.4 h1:GjL+aN512m2rVDqhPII7P6qB0e+iYFubz8sqBhZaZtk=
 github.com/juju/collections v1.0.4/go.mod h1:hVrdB0Zwq9wIU1Fl6ItD2+UETeNeOEs+nGvJufVe+0c=
-github.com/juju/description/v9 v9.0.0-20250305234742-e64be4ed3995 h1:NveWeONMuaPBlBoHqdTFlf7K/aYbxz2gRrIzEjyqWhg=
-github.com/juju/description/v9 v9.0.0-20250305234742-e64be4ed3995/go.mod h1:tpLBdzbSgWx/sPBSvQW+DK8Ycc1HhyNpSn16DL+U6zI=
+github.com/juju/description/v9 v9.0.0-20250312165826-51f91f8806d8 h1:AyUDgdEGE3wvCx6TjSREYncGRfQqzsoZ3zhprcQbGcg=
+github.com/juju/description/v9 v9.0.0-20250312165826-51f91f8806d8/go.mod h1:tpLBdzbSgWx/sPBSvQW+DK8Ycc1HhyNpSn16DL+U6zI=
 github.com/juju/errors v0.0.0-20150916125642-1b5e39b83d18/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
 github.com/juju/errors v0.0.0-20200330140219-3fe23663418f/go.mod h1:W54LbzXuIE0boCoNJfwqpmkKJ1O4TCTZMetAt6jGk7Q=
 github.com/juju/errors v0.0.0-20210818161939-5560c4c073ff/go.mod h1:i1eL7XREII6aHpQ2gApI/v6FkVUDEBremNkcBCKYAcY=


### PR DESCRIPTION
This patch implements migration of the unit sacle state (including desired scale -> scale).

## QA steps

<!--
Migrate a k8s controller with some scaling set:

```
$ juju bootstrap microk8s dst
$ juju bootstrap microk8s src
$ juju add-model m
$ juju deploy snappass-test
# scale the app now
$  juju scale-application snappass-test 3
snappass-test scaled to 3 units
$ juju status
Model  Controller  Cloud/Region        Version    Timestamp
m      src         microk8s/localhost  4.0-beta6  11:21:00+01:00

App            Version  Status  Scale  Charm          Channel        Rev  Address  Exposed  Message
snappass-test           active      3  snappass-test  latest/stable    9           no       snappass started

Unit              Workload  Agent  Address       Ports  Message
snappass-test/0*  active    idle   10.1.211.233         snappass started
snappass-test/1   active    idle   10.1.211.250         snappass started
snappass-test/2   active    idle   10.1.211.234         snappass started
```
At this point we can start the migration and expect 3 units of the app on the destination controller:
```
```
-->
Currently, migrations on k8s are broken because of resources migration:
```
controller-0: 12:04:20 INFO juju.worker.migrationmaster.5369df logger-tags:migration uploading model binaries into target controller
controller-0: 12:04:20 ERROR juju.apiserver resource download failed: http: wrote more than the declared Content-Length
controller-0: 12:04:20 ERROR juju.worker.migrationmaster.5369df logger-tags:migration model data transfer failed, failed to migrate binaries: cannot upload resources: unexpected EOF
```
So fully QAing this is not possible at the moment.


## Links

**Jira card:** JUJU-7518

