### PR TITLE
refactor(status): push leadership checks into service

### DIFF
--- a/apiserver/facades/agent/uniter/service.go
+++ b/apiserver/facades/agent/uniter/service.go
@@ -143,6 +143,20 @@ type ApplicationService interface {
 	// application.
 	GetCharmModifiedVersion(ctx context.Context, id coreapplication.ID) (int, error)
 
+	// GetApplicationAndUnitStatusesForUnitWithLeader returns the display status
+	// of the application the specified unit belongs to, and the workload statuses
+	// of all the units that belong to that application, indexed by unit name.
+	// If no application is found for the unit name, an error satisfying
+	// [applicationerrors.ApplicationNotFound] is returned
+	GetApplicationAndUnitStatusesForUnitWithLeader(
+		context.Context,
+		coreunit.Name,
+	) (
+		*corestatus.StatusInfo,
+		map[coreunit.Name]corestatus.StatusInfo,
+		error,
+	)
+
 	// GetUnitWorkloadStatusesForApplication returns the workload statuses of
 	// all units in the specified application, indexed by unit name, returning
 	// an error satisfying [applicationerrors.ApplicationNotFound] if the

--- a/apiserver/facades/agent/uniter/service_mock_test.go
+++ b/apiserver/facades/agent/uniter/service_mock_test.go
@@ -165,6 +165,46 @@ func (c *MockApplicationServiceEnsureUnitDeadCall) DoAndReturn(f func(context.Co
 	return c
 }
 
+// GetApplicationAndUnitStatusesForUnitWithLeader mocks base method.
+func (m *MockApplicationService) GetApplicationAndUnitStatusesForUnitWithLeader(arg0 context.Context, arg1 unit.Name) (*status.StatusInfo, map[unit.Name]status.StatusInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetApplicationAndUnitStatusesForUnitWithLeader", arg0, arg1)
+	ret0, _ := ret[0].(*status.StatusInfo)
+	ret1, _ := ret[1].(map[unit.Name]status.StatusInfo)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetApplicationAndUnitStatusesForUnitWithLeader indicates an expected call of GetApplicationAndUnitStatusesForUnitWithLeader.
+func (mr *MockApplicationServiceMockRecorder) GetApplicationAndUnitStatusesForUnitWithLeader(arg0, arg1 any) *MockApplicationServiceGetApplicationAndUnitStatusesForUnitWithLeaderCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetApplicationAndUnitStatusesForUnitWithLeader", reflect.TypeOf((*MockApplicationService)(nil).GetApplicationAndUnitStatusesForUnitWithLeader), arg0, arg1)
+	return &MockApplicationServiceGetApplicationAndUnitStatusesForUnitWithLeaderCall{Call: call}
+}
+
+// MockApplicationServiceGetApplicationAndUnitStatusesForUnitWithLeaderCall wrap *gomock.Call
+type MockApplicationServiceGetApplicationAndUnitStatusesForUnitWithLeaderCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockApplicationServiceGetApplicationAndUnitStatusesForUnitWithLeaderCall) Return(arg0 *status.StatusInfo, arg1 map[unit.Name]status.StatusInfo, arg2 error) *MockApplicationServiceGetApplicationAndUnitStatusesForUnitWithLeaderCall {
+	c.Call = c.Call.Return(arg0, arg1, arg2)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockApplicationServiceGetApplicationAndUnitStatusesForUnitWithLeaderCall) Do(f func(context.Context, unit.Name) (*status.StatusInfo, map[unit.Name]status.StatusInfo, error)) *MockApplicationServiceGetApplicationAndUnitStatusesForUnitWithLeaderCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockApplicationServiceGetApplicationAndUnitStatusesForUnitWithLeaderCall) DoAndReturn(f func(context.Context, unit.Name) (*status.StatusInfo, map[unit.Name]status.StatusInfo, error)) *MockApplicationServiceGetApplicationAndUnitStatusesForUnitWithLeaderCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetApplicationDisplayStatus mocks base method.
 func (m *MockApplicationService) GetApplicationDisplayStatus(arg0 context.Context, arg1 application.ID) (*status.StatusInfo, error) {
 	m.ctrl.T.Helper()

--- a/apiserver/facades/agent/uniter/status.go
+++ b/apiserver/facades/agent/uniter/status.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/juju/juju/apiserver/common"
 	apiservererrors "github.com/juju/juju/apiserver/errors"
-	coreapplication "github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/leadership"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/unit"
@@ -25,8 +24,6 @@ import (
 // status from different entities, this particular separation from
 // base is because we have a shim to support unit/agent split.
 type StatusAPI struct {
-	leadershipChecker leadership.Checker
-
 	applicationService ApplicationService
 
 	unitSetter        *common.UnitStatusSetter
@@ -43,7 +40,6 @@ func NewStatusAPI(st *state.State, applicationService ApplicationService, getCan
 	unitGetter := common.NewUnitStatusGetter(applicationService, clock, getCanModify)
 	applicationSetter := common.NewApplicationStatusSetter(st, getCanModify, leadershipChecker)
 	return &StatusAPI{
-		leadershipChecker:  leadershipChecker,
 		applicationService: applicationService,
 		unitSetter:         unitSetter,
 		unitGetter:         unitGetter,
@@ -129,58 +125,38 @@ func (s *StatusAPI) ApplicationStatus(ctx context.Context, args params.Entities)
 		// TODO(fwereade): the auth is basically nonsense, and basically only
 		// works by coincidence (and is happening at the wrong layer anyway).
 		// Read carefully.
-
-		// We "know" that arg.Tag is either the calling unit or its application
-		// (because getCanAccess is authUnitOrApplication, and we'll fail out if
-		// it isn't); and, in practice, it's always going to be the calling
-		// unit (because, /sigh, we don't actually use application tags to refer
-		// to applications in this method).
-		tag, err := names.ParseTag(arg.Tag)
+		unitTag, err := names.ParseUnitTag(arg.Tag)
 		if err != nil {
 			result.Results[i].Error = apiservererrors.ServerError(err)
 			continue
 		}
-		if !canAccess(tag) {
+		if !canAccess(unitTag) {
 			result.Results[i].Error = apiservererrors.ServerError(apiservererrors.ErrPerm)
 			continue
 		}
-		unitTag, ok := tag.(names.UnitTag)
-		if !ok {
-			// No matter what the canAccess says, if this entity is not
-			// a unit, we say "NO".
-			result.Results[i].Error = apiservererrors.ServerError(apiservererrors.ErrPerm)
-			continue
-		}
-		unitName := unitTag.Id()
-
-		// Now we have the unit, we can get the application that should have been
-		// specified in the first place...
-		applicationName, err := names.UnitApplication(unitName)
+		unitName, err := unit.NewName(unitTag.Id())
 		if err != nil {
 			result.Results[i].Error = apiservererrors.ServerError(err)
 			continue
 		}
 
-		// ...so we can check the unit's application leadership...
-		token := s.leadershipChecker.LeadershipCheck(applicationName, unitName)
-		if err := token.Check(); err != nil {
-			// TODO(fwereade) this should probably be ErrPerm in certain cases,
-			// but I don't think I implemented an exported ErrNotLeader.
-			// I should have done, though.
-			result.Results[i].Error = apiservererrors.ServerError(err)
-			continue
-		}
-
-		applicationID, err := s.applicationService.GetApplicationIDByName(ctx, applicationName)
+		appStatus, unitStatuses, err := s.applicationService.GetApplicationAndUnitStatusesForUnitWithLeader(ctx, unitName)
 		if errors.Is(err, applicationerrors.ApplicationNotFound) {
-			result.Results[i].Error = apiservererrors.ServerError(errors.NotFoundf("application %q", applicationName))
+			result.Results[i].Error = apiservererrors.ServerError(errors.NotFoundf("application %q", unitName.Application()))
 			continue
 		} else if err != nil {
 			result.Results[i].Error = apiservererrors.ServerError(err)
 			continue
 		}
 
-		result.Results[i] = s.getAppAndUnitStatus(ctx, applicationID)
+		res := params.ApplicationStatusResult{
+			Application: s.toStatusResult(*appStatus),
+			Units:       make(map[string]params.StatusResult),
+		}
+		for name, status := range unitStatuses {
+			res.Units[name.String()] = s.toStatusResult(status)
+		}
+		result.Results[i] = res
 	}
 	return result, nil
 }
@@ -192,28 +168,4 @@ func (s *StatusAPI) toStatusResult(i status.StatusInfo) params.StatusResult {
 		Data:   i.Data,
 		Since:  i.Since,
 	}
-}
-
-func (s *StatusAPI) getAppAndUnitStatus(ctx context.Context, applicationId coreapplication.ID) params.ApplicationStatusResult {
-	result := params.ApplicationStatusResult{
-		Units: make(map[string]params.StatusResult),
-	}
-	appStatus := status.StatusInfo{Status: status.Unknown}
-	aStatus, err := s.applicationService.GetApplicationDisplayStatus(ctx, applicationId)
-	if err == nil && aStatus != nil {
-		appStatus = *aStatus
-	}
-	result.Application = s.toStatusResult(appStatus)
-
-	unitStatuses, err := s.applicationService.GetUnitWorkloadStatusesForApplication(ctx, applicationId)
-	if errors.Is(err, applicationerrors.ApplicationNotFound) {
-		result.Error = apiservererrors.ServerError(errors.NotFoundf("application %q", applicationId))
-	} else if err != nil {
-		result.Error = apiservererrors.ServerError(err)
-	} else {
-		for name, status := range unitStatuses {
-			result.Units[name.String()] = s.toStatusResult(status)
-		}
-	}
-	return result
 }

--- a/domain/application/service/migration.go
+++ b/domain/application/service/migration.go
@@ -190,10 +190,7 @@ func (s *MigrationService) GetApplicationStatus(ctx context.Context, name string
 		return nil, errors.Errorf("application %q has no status", name)
 	}
 
-	decodedStatus, err := decodeWorkloadStatus(&application.UnitStatusInfo[application.WorkloadStatusType]{
-		StatusInfo: *status,
-		Present:    true,
-	})
+	decodedStatus, err := decodeApplicationStatus(status)
 	if err != nil {
 		return nil, errors.Annotatef(err, "decoding workload status")
 	}
@@ -244,7 +241,7 @@ func (s *MigrationService) GetUnitWorkloadStatus(ctx context.Context, unitUUID c
 		return nil, errors.Trace(err)
 	}
 
-	return decodeWorkloadStatus(workloadStatus)
+	return decodeUnitWorkloadStatus(workloadStatus)
 }
 
 // GetUnitAgentStatus returns the agent status of the specified unit, returning

--- a/domain/application/service/provider.go
+++ b/domain/application/service/provider.go
@@ -330,7 +330,7 @@ func (s *ProviderService) AddUnits(ctx context.Context, storageParentDir, appNam
 			}
 		}
 
-		if workloadStatus, err := decodeWorkloadStatus(&application.UnitStatusInfo[application.WorkloadStatusType]{
+		if workloadStatus, err := decodeUnitWorkloadStatus(&application.UnitStatusInfo[application.WorkloadStatusType]{
 			StatusInfo: *arg.WorkloadStatus,
 			Present:    true,
 		}); err == nil && workloadStatus != nil {

--- a/domain/application/service/status_test.go
+++ b/domain/application/service/status_test.go
@@ -253,7 +253,7 @@ func (s *statusSuite) TestEncodeWorkloadStatus(c *gc.C) {
 		output, err := encodeWorkloadStatus(test.input)
 		c.Assert(err, jc.ErrorIsNil)
 		c.Check(output, jc.DeepEquals, test.output)
-		result, err := decodeWorkloadStatus(&application.UnitStatusInfo[application.WorkloadStatusType]{
+		result, err := decodeUnitWorkloadStatus(&application.UnitStatusInfo[application.WorkloadStatusType]{
 			StatusInfo: *output,
 			Present:    true,
 		})
@@ -263,13 +263,13 @@ func (s *statusSuite) TestEncodeWorkloadStatus(c *gc.C) {
 }
 
 func (s *statusSuite) TestReduceWorkloadStatusesEmpty(c *gc.C) {
-	info, err := reduceWorkloadStatuses(nil)
+	info, err := reduceUnitWorkloadStatuses(nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(info, jc.DeepEquals, &status.StatusInfo{
 		Status: status.Unknown,
 	})
 
-	info, err = reduceWorkloadStatuses([]application.UnitStatusInfo[application.WorkloadStatusType]{})
+	info, err = reduceUnitWorkloadStatuses([]application.UnitStatusInfo[application.WorkloadStatusType]{})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(info, jc.DeepEquals, &status.StatusInfo{
 		Status: status.Unknown,
@@ -283,7 +283,7 @@ func (s *statusSuite) TestReduceWorkloadStatusesBringsAllDetails(c *gc.C) {
 		Data:    []byte(`{"key":"value"}`),
 		Since:   &now,
 	}
-	info, err := reduceWorkloadStatuses([]application.UnitStatusInfo[application.WorkloadStatusType]{{
+	info, err := reduceUnitWorkloadStatuses([]application.UnitStatusInfo[application.WorkloadStatusType]{{
 		StatusInfo: value,
 		Present:    true,
 	}})
@@ -317,7 +317,7 @@ func (s *statusSuite) TestReduceWorkloadStatusesPriority(c *gc.C) {
 		// Blocked trumps maintenance
 		{status1: application.WorkloadStatusMaintenance, status2: application.WorkloadStatusBlocked, expected: status.Blocked},
 	} {
-		value, err := reduceWorkloadStatuses([]application.UnitStatusInfo[application.WorkloadStatusType]{
+		value, err := reduceUnitWorkloadStatuses([]application.UnitStatusInfo[application.WorkloadStatusType]{
 			{
 				StatusInfo: application.StatusInfo[application.WorkloadStatusType]{
 					Status: t.status1,

--- a/domain/application/service/unit.go
+++ b/domain/application/service/unit.go
@@ -228,7 +228,7 @@ func (s *Service) GetUnitWorkloadStatus(ctx context.Context, unitName coreunit.N
 		return nil, errors.Trace(err)
 	}
 
-	return decodeWorkloadStatus(workloadStatus)
+	return decodeUnitWorkloadStatus(workloadStatus)
 }
 
 // SetUnitAgentStatus sets the agent status of the specified unit,
@@ -310,15 +310,11 @@ func (s *Service) GetUnitWorkloadStatusesForApplication(ctx context.Context, app
 		return nil, internalerrors.Capture(err)
 	}
 
-	ret := make(map[coreunit.Name]corestatus.StatusInfo, len(statuses))
-	for unitName, status := range statuses {
-		info, err := decodeWorkloadStatus(&status)
-		if err != nil {
-			return nil, internalerrors.Capture(err)
-		}
-		ret[unitName] = *info
+	decoded, err := decodeUnitWorkloadStatuses(statuses)
+	if err != nil {
+		return nil, internalerrors.Capture(err)
 	}
-	return ret, nil
+	return decoded, nil
 }
 
 // GetUnitDisplayStatus returns the display status of the specified unit. The display


### PR DESCRIPTION
We're trying to drop leadership concerns from facades. They're business logic that should be in the service layer.

Create a new service method that checks for leadership and returns all the required statuses for the uniter ApplicationStatus facade.

## QA steps

```
$ juju bootstrap lxd lxd
$ juju add-model m
$ juju deploy ubuntu -n2
$ juju status
```
& confirm the app + units become active/idle