### PR TITLE
refactor(actions): remove duplicate jobs from smoke test

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -77,20 +77,6 @@ jobs:
         run: |
           cd tests
           export MODEL_ARCH=$(go env GOARCH)
-          ./main.sh -v -s 'test_build' smoke
-
-      - name: Update microk8s operator image
-        if: matrix.cloud == 'microk8s'
-        run: |
-          # TODO: use temporary Docker account (set DOCKER_USERNAME env var)
-          sg snap_microk8s 'make microk8s-operator-update'
-
-      - name: Smoke test (LXD)
-        if: matrix.cloud == 'localhost'
-        shell: bash
-        run: |
-          cd tests
-          export MODEL_ARCH=$(go env GOARCH)
           export BOOTSTRAP_ADDITIONAL_ARGS="--model-default enable-os-upgrade=false"
           ./main.sh -v -s 'test_build' smoke
 


### PR DESCRIPTION
In a merge forward I suspect, some jobs in our smoke test workflow were duplicated accidentally.

Remove the duplicated jobs

## QA steps

gh actions pass