### PR TITLE
feat: remove broker abstraction from domain application service

### DIFF
--- a/apiserver/facades/agent/caasapplication/application.go
+++ b/apiserver/facades/agent/caasapplication/application.go
@@ -18,6 +18,7 @@ import (
 	"github.com/juju/juju/apiserver/facade"
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/controller"
+	"github.com/juju/juju/core/k8s"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/network"
@@ -143,13 +144,13 @@ func (f *Facade) UnitIntroduction(ctx context.Context, args params.CAASUnitIntro
 		return errResp(errors.NotProvisionedf("application"))
 	}
 
-	deploymentType := caas.DeploymentStateful
+	deploymentType := k8s.K8sDeploymentStateful
 
 	upsert := state.UpsertCAASUnitParams{}
 
 	containerID := args.PodName
 	switch deploymentType {
-	case caas.DeploymentStateful:
+	case k8s.K8sDeploymentStateful:
 		splitPodName := strings.Split(args.PodName, "-")
 		ord, err := strconv.Atoi(splitPodName[len(splitPodName)-1])
 		if err != nil {
@@ -168,7 +169,7 @@ func (f *Facade) UnitIntroduction(ctx context.Context, args params.CAASUnitIntro
 	}
 
 	// Find the pod/unit in the provider.
-	caasApp := f.broker.Application(appName, caas.DeploymentStateful)
+	caasApp := f.broker.Application(appName, k8s.K8sDeploymentStateful)
 	pods, err := caasApp.Units()
 	if err != nil {
 		return errResp(err)

--- a/apiserver/facades/agent/caasapplication/state.go
+++ b/apiserver/facades/agent/caasapplication/state.go
@@ -111,5 +111,5 @@ type Unit interface {
 
 // Broker contains methods from the caas.Broker interface used by the caasapplication facade.
 type Broker interface {
-	Application(string, k8s.K8sDeploymentType) caas.Application
+	Application(string, k8s.WorkloadType) caas.Application
 }

--- a/apiserver/facades/agent/caasapplication/state.go
+++ b/apiserver/facades/agent/caasapplication/state.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/controller"
+	"github.com/juju/juju/core/k8s"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/internal/charm"
 	"github.com/juju/juju/state"
@@ -110,5 +111,5 @@ type Unit interface {
 
 // Broker contains methods from the caas.Broker interface used by the caasapplication facade.
 type Broker interface {
-	Application(string, caas.DeploymentType) caas.Application
+	Application(string, k8s.K8sDeploymentType) caas.Application
 }

--- a/caas/broker.go
+++ b/caas/broker.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/devices"
+	"github.com/juju/juju/core/k8s"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/resource"
 	"github.com/juju/juju/core/semversion"
@@ -71,28 +72,6 @@ type NewContainerBrokerFunc func(ctx context.Context, args environs.OpenParams, 
 // StatusCallbackFunc represents a function that can be called to report a status.
 type StatusCallbackFunc func(appName string, settableStatus status.Status, info string, data map[string]interface{}) error
 
-// DeploymentType defines a deployment type.
-type DeploymentType string
-
-// Validate validates if this deployment type is supported.
-func (dt DeploymentType) Validate() error {
-	if dt == "" {
-		return nil
-	}
-	if dt == DeploymentStateless ||
-		dt == DeploymentStateful ||
-		dt == DeploymentDaemon {
-		return nil
-	}
-	return errors.NotSupportedf("deployment type %q", dt)
-}
-
-const (
-	DeploymentStateless DeploymentType = "stateless"
-	DeploymentStateful  DeploymentType = "stateful"
-	DeploymentDaemon    DeploymentType = "daemon"
-)
-
 // DeploymentMode defines a deployment mode.
 type DeploymentMode string
 
@@ -113,7 +92,7 @@ const (
 
 // DeploymentParams defines parameters for specifying how a service is deployed.
 type DeploymentParams struct {
-	DeploymentType DeploymentType
+	DeploymentType k8s.K8sDeploymentType
 	ServiceType    ServiceType
 }
 
@@ -207,7 +186,7 @@ type Broker interface {
 // individual applications and watching their units.
 type ApplicationBroker interface {
 	// Application returns the broker interface for an Application
-	Application(string, DeploymentType) Application
+	Application(string, k8s.K8sDeploymentType) Application
 
 	// Units returns all units and any associated filesystems
 	// of the specified application. Filesystems are mounted

--- a/caas/broker.go
+++ b/caas/broker.go
@@ -92,7 +92,7 @@ const (
 
 // DeploymentParams defines parameters for specifying how a service is deployed.
 type DeploymentParams struct {
-	DeploymentType k8s.K8sDeploymentType
+	DeploymentType k8s.WorkloadType
 	ServiceType    ServiceType
 }
 
@@ -186,7 +186,7 @@ type Broker interface {
 // individual applications and watching their units.
 type ApplicationBroker interface {
 	// Application returns the broker interface for an Application
-	Application(string, k8s.K8sDeploymentType) Application
+	Application(string, k8s.WorkloadType) Application
 
 	// Units returns all units and any associated filesystems
 	// of the specified application. Filesystems are mounted

--- a/caas/broker_test.go
+++ b/caas/broker_test.go
@@ -8,7 +8,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/juju/caas"
+	"github.com/juju/juju/core/k8s"
 	"github.com/juju/juju/internal/testing"
 )
 
@@ -20,15 +20,15 @@ var _ = gc.Suite(&brokerSuite{})
 
 func (s *brokerSuite) TestDeploymentTypeValidation(c *gc.C) {
 
-	validTypes := []caas.DeploymentType{
-		caas.DeploymentStateful,
-		caas.DeploymentStateless,
-		caas.DeploymentDaemon,
-		caas.DeploymentType(""), // TODO(caas): change deployment to mandatory.
+	validTypes := []k8s.K8sDeploymentType{
+		k8s.K8sDeploymentStateful,
+		k8s.K8sDeploymentStateless,
+		k8s.K8sDeploymentDaemon,
+		k8s.K8sDeploymentType(""), // TODO(caas): change deployment to mandatory.
 	}
 	for _, t := range validTypes {
 		c.Check(t.Validate(), jc.ErrorIsNil)
 	}
 
-	c.Assert(caas.DeploymentType("bad type").Validate(), jc.ErrorIs, errors.NotSupported)
+	c.Assert(k8s.K8sDeploymentType("bad type").Validate(), jc.ErrorIs, errors.NotSupported)
 }

--- a/caas/broker_test.go
+++ b/caas/broker_test.go
@@ -20,15 +20,15 @@ var _ = gc.Suite(&brokerSuite{})
 
 func (s *brokerSuite) TestDeploymentTypeValidation(c *gc.C) {
 
-	validTypes := []k8s.K8sDeploymentType{
-		k8s.K8sDeploymentStateful,
-		k8s.K8sDeploymentStateless,
-		k8s.K8sDeploymentDaemon,
-		k8s.K8sDeploymentType(""), // TODO(caas): change deployment to mandatory.
+	validTypes := []k8s.WorkloadType{
+		k8s.WorkloadTypeStatefulSet,
+		k8s.WorkloadTypeDeployment,
+		k8s.WorkloadTypeDaemonSet,
+		k8s.WorkloadType(""), // TODO(caas): change deployment to mandatory.
 	}
 	for _, t := range validTypes {
 		c.Check(t.Validate(), jc.ErrorIsNil)
 	}
 
-	c.Assert(k8s.K8sDeploymentType("bad type").Validate(), jc.ErrorIs, errors.NotSupported)
+	c.Assert(k8s.WorkloadType("bad type").Validate(), jc.ErrorIs, errors.NotSupported)
 }

--- a/caas/kubernetes/provider/application.go
+++ b/caas/kubernetes/provider/application.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Application returns an Application interface.
-func (k *kubernetesClient) Application(name string, deploymentType k8s.K8sDeploymentType) caas.Application {
+func (k *kubernetesClient) Application(name string, deploymentType k8s.WorkloadType) caas.Application {
 	return application.NewApplication(name,
 		k.namespace,
 		k.modelUUID,
@@ -25,8 +25,8 @@ func (k *kubernetesClient) Application(name string, deploymentType k8s.K8sDeploy
 }
 
 // DesiredReplicas returns the desired replicas for the given application.
-func (k *kubernetesClient) DesiredReplicas(name string, deploymentType k8s.K8sDeploymentType) (int, error) {
-	app := k.Application(name, k8s.K8sDeploymentStateful)
+func (k *kubernetesClient) DesiredReplicas(name string) (int, error) {
+	app := k.Application(name, k8s.WorkloadTypeStatefulSet)
 	state, err := app.State()
 	if err != nil {
 		return -1, err

--- a/caas/kubernetes/provider/application.go
+++ b/caas/kubernetes/provider/application.go
@@ -6,10 +6,11 @@ package provider
 import (
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/caas/kubernetes/provider/application"
+	"github.com/juju/juju/core/k8s"
 )
 
 // Application returns an Application interface.
-func (k *kubernetesClient) Application(name string, deploymentType caas.DeploymentType) caas.Application {
+func (k *kubernetesClient) Application(name string, deploymentType k8s.K8sDeploymentType) caas.Application {
 	return application.NewApplication(name,
 		k.namespace,
 		k.modelUUID,
@@ -21,4 +22,14 @@ func (k *kubernetesClient) Application(name string, deploymentType caas.Deployme
 		k.clock,
 		k.randomPrefix,
 	)
+}
+
+// DesiredReplicas returns the desired replicas for the given application.
+func (k *kubernetesClient) DesiredReplicas(name string, deploymentType k8s.K8sDeploymentType) (int, error) {
+	app := k.Application(name, k8s.K8sDeploymentStateful)
+	state, err := app.State()
+	if err != nil {
+		return -1, err
+	}
+	return state.DesiredReplicas, nil
 }

--- a/caas/kubernetes/provider/application/application_test.go
+++ b/caas/kubernetes/provider/application/application_test.go
@@ -77,7 +77,7 @@ func (s *applicationSuite) TearDownTest(c *gc.C) {
 	s.BaseSuite.TearDownTest(c)
 }
 
-func (s *applicationSuite) getApp(c *gc.C, deploymentType k8s.K8sDeploymentType, mockApplier bool) (application.ApplicationInterfaceForTest, *gomock.Controller) {
+func (s *applicationSuite) getApp(c *gc.C, deploymentType k8s.WorkloadType, mockApplier bool) (application.ApplicationInterfaceForTest, *gomock.Controller) {
 	watcherFn := k8swatcher.NewK8sWatcherFunc(func(i cache.SharedIndexInformer, n string, c jujuclock.Clock) (k8swatcher.KubernetesNotifyWatcher, error) {
 		if s.k8sWatcherFn == nil {
 			return nil, errors.NewNotFound(nil, "undefined k8sWatcherFn for base test")
@@ -452,7 +452,7 @@ func (s *applicationSuite) assertDelete(c *gc.C, app caas.Application) {
 }
 
 func (s *applicationSuite) TestEnsureStateful(c *gc.C) {
-	app, _ := s.getApp(c, k8s.K8sDeploymentStateful, false)
+	app, _ := s.getApp(c, k8s.WorkloadTypeStatefulSet, false)
 	s.assertEnsure(
 		c, app, false, constraints.Value{}, true, false, "", func() {
 			svc, err := s.client.CoreV1().Services("test").Get(context.Background(), "gitlab-endpoints", metav1.GetOptions{})
@@ -540,7 +540,7 @@ func (s *applicationSuite) TestEnsureStateful(c *gc.C) {
 }
 
 func (s *applicationSuite) TestEnsureStatefulRootless35(c *gc.C) {
-	app, _ := s.getApp(c, k8s.K8sDeploymentStateful, false)
+	app, _ := s.getApp(c, k8s.WorkloadTypeStatefulSet, false)
 	s.assertEnsure(
 		c, app, false, constraints.Value{}, true, true, "3.5-beta1", func() {
 			svc, err := s.client.CoreV1().Services("test").Get(context.Background(), "gitlab-endpoints", metav1.GetOptions{})
@@ -647,7 +647,7 @@ func (s *applicationSuite) TestEnsureStatefulRootless35(c *gc.C) {
 }
 
 func (s *applicationSuite) TestEnsureStatefulRootless(c *gc.C) {
-	app, _ := s.getApp(c, k8s.K8sDeploymentStateful, false)
+	app, _ := s.getApp(c, k8s.WorkloadTypeStatefulSet, false)
 	s.assertEnsure(
 		c, app, false, constraints.Value{}, true, true, "3.6-beta3", func() {
 			svc, err := s.client.CoreV1().Services("test").Get(context.TODO(), "gitlab-endpoints", metav1.GetOptions{})
@@ -736,7 +736,7 @@ func (s *applicationSuite) TestEnsureStatefulRootless(c *gc.C) {
 }
 
 func (s *applicationSuite) TestEnsureTrusted(c *gc.C) {
-	app, _ := s.getApp(c, k8s.K8sDeploymentStateful, false)
+	app, _ := s.getApp(c, k8s.WorkloadTypeStatefulSet, false)
 	s.assertEnsure(
 		c, app, false, constraints.Value{}, true, false, "", func() {},
 	)
@@ -744,7 +744,7 @@ func (s *applicationSuite) TestEnsureTrusted(c *gc.C) {
 }
 
 func (s *applicationSuite) TestEnsureUntrusted(c *gc.C) {
-	app, _ := s.getApp(c, k8s.K8sDeploymentStateful, false)
+	app, _ := s.getApp(c, k8s.WorkloadTypeStatefulSet, false)
 	s.assertEnsure(
 		c, app, false, constraints.Value{}, false, false, "", func() {},
 	)
@@ -752,7 +752,7 @@ func (s *applicationSuite) TestEnsureUntrusted(c *gc.C) {
 }
 
 func (s *applicationSuite) TestEnsureStatefulPrivateImageRepo(c *gc.C) {
-	app, _ := s.getApp(c, k8s.K8sDeploymentStateful, false)
+	app, _ := s.getApp(c, k8s.WorkloadTypeStatefulSet, false)
 
 	podSpec := getPodSpec31()
 	podSpec.ImagePullSecrets = append(
@@ -848,7 +848,7 @@ func (s *applicationSuite) TestEnsureStatefulPrivateImageRepo(c *gc.C) {
 }
 
 func (s *applicationSuite) TestEnsureStateless(c *gc.C) {
-	app, _ := s.getApp(c, k8s.K8sDeploymentStateless, false)
+	app, _ := s.getApp(c, k8s.WorkloadTypeDeployment, false)
 	s.assertEnsure(
 		c, app, false, constraints.Value{}, true, false, "", func() {
 			ss, err := s.client.AppsV1().Deployments("test").Get(context.Background(), "gitlab", metav1.GetOptions{})
@@ -921,7 +921,7 @@ func (s *applicationSuite) TestEnsureStateless(c *gc.C) {
 }
 
 func (s *applicationSuite) TestEnsureDaemon(c *gc.C) {
-	app, _ := s.getApp(c, k8s.K8sDeploymentDaemon, false)
+	app, _ := s.getApp(c, k8s.WorkloadTypeDaemonSet, false)
 	s.assertEnsure(
 		c, app, false, constraints.Value{}, true, false, "", func() {
 			ss, err := s.client.AppsV1().DaemonSets("test").Get(context.Background(), "gitlab", metav1.GetOptions{})
@@ -1001,7 +1001,7 @@ func (s *applicationSuite) TestExistsNotSupported(c *gc.C) {
 func (s *applicationSuite) TestExistsDeployment(c *gc.C) {
 	now := metav1.Now()
 
-	app, _ := s.getApp(c, k8s.K8sDeploymentStateless, false)
+	app, _ := s.getApp(c, k8s.WorkloadTypeDeployment, false)
 	// Deployment does not exists.
 	result, err := app.Exists()
 	c.Assert(err, jc.ErrorIsNil)
@@ -1040,7 +1040,7 @@ func (s *applicationSuite) TestExistsDeployment(c *gc.C) {
 func (s *applicationSuite) TestExistsStatefulSet(c *gc.C) {
 	now := metav1.Now()
 
-	app, _ := s.getApp(c, k8s.K8sDeploymentStateful, false)
+	app, _ := s.getApp(c, k8s.WorkloadTypeStatefulSet, false)
 	// Statefulset does not exists.
 	result, err := app.Exists()
 	c.Assert(err, jc.ErrorIsNil)
@@ -1080,7 +1080,7 @@ func (s *applicationSuite) TestExistsStatefulSet(c *gc.C) {
 func (s *applicationSuite) TestExistsDaemonSet(c *gc.C) {
 	now := metav1.Now()
 
-	app, _ := s.getApp(c, k8s.K8sDeploymentDaemon, false)
+	app, _ := s.getApp(c, k8s.WorkloadTypeDaemonSet, false)
 	// Daemonset does not exists.
 	result, err := app.Exists()
 	c.Assert(err, jc.ErrorIsNil)
@@ -1118,7 +1118,7 @@ func (s *applicationSuite) TestExistsDaemonSet(c *gc.C) {
 
 // Test upgrades are performed by ensure. Regression bug for lp1997253
 func (s *applicationSuite) TestUpgradeStateful(c *gc.C) {
-	app, _ := s.getApp(c, k8s.K8sDeploymentStateful, false)
+	app, _ := s.getApp(c, k8s.WorkloadTypeStatefulSet, false)
 	s.assertEnsure(c, app, false, constraints.Value{}, true, false, "2.9.34", func() {
 		ss, err := s.client.AppsV1().StatefulSets("test").Get(context.Background(), "gitlab", metav1.GetOptions{})
 		c.Assert(err, jc.ErrorIsNil)
@@ -1162,7 +1162,7 @@ func (s *applicationSuite) TestUpgradeStateful(c *gc.C) {
 }
 
 func (s *applicationSuite) TestDeleteStateful(c *gc.C) {
-	app, ctrl := s.getApp(c, k8s.K8sDeploymentStateful, true)
+	app, ctrl := s.getApp(c, k8s.WorkloadTypeStatefulSet, true)
 	defer ctrl.Finish()
 
 	gomock.InOrder(
@@ -1181,7 +1181,7 @@ func (s *applicationSuite) TestDeleteStateful(c *gc.C) {
 }
 
 func (s *applicationSuite) TestDeleteStateless(c *gc.C) {
-	app, ctrl := s.getApp(c, k8s.K8sDeploymentStateless, true)
+	app, ctrl := s.getApp(c, k8s.WorkloadTypeDeployment, true)
 	defer ctrl.Finish()
 
 	gomock.InOrder(
@@ -1199,7 +1199,7 @@ func (s *applicationSuite) TestDeleteStateless(c *gc.C) {
 }
 
 func (s *applicationSuite) TestDeleteDaemon(c *gc.C) {
-	app, ctrl := s.getApp(c, k8s.K8sDeploymentDaemon, true)
+	app, ctrl := s.getApp(c, k8s.WorkloadTypeDaemonSet, true)
 	defer ctrl.Finish()
 
 	gomock.InOrder(
@@ -1230,7 +1230,7 @@ func (s *applicationSuite) TestWatchNotsupported(c *gc.C) {
 }
 
 func (s *applicationSuite) TestWatch(c *gc.C) {
-	app, ctrl := s.getApp(c, k8s.K8sDeploymentDaemon, true)
+	app, ctrl := s.getApp(c, k8s.WorkloadTypeDaemonSet, true)
 	defer ctrl.Finish()
 
 	s.k8sWatcherFn = func(_ cache.SharedIndexInformer, _ string, _ jujuclock.Clock) (k8swatcher.KubernetesNotifyWatcher, error) {
@@ -1250,7 +1250,7 @@ func (s *applicationSuite) TestWatch(c *gc.C) {
 }
 
 func (s *applicationSuite) TestWatchReplicas(c *gc.C) {
-	app, ctrl := s.getApp(c, k8s.K8sDeploymentDaemon, true)
+	app, ctrl := s.getApp(c, k8s.WorkloadTypeDaemonSet, true)
 	defer ctrl.Finish()
 
 	s.k8sWatcherFn = func(_ cache.SharedIndexInformer, _ string, _ jujuclock.Clock) (k8swatcher.KubernetesNotifyWatcher, error) {
@@ -1275,7 +1275,7 @@ func (s *applicationSuite) TestStateNotSupported(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `unknown deployment type not supported`)
 }
 
-func (s *applicationSuite) assertState(c *gc.C, deploymentType k8s.K8sDeploymentType, createMainResource func() int) {
+func (s *applicationSuite) assertState(c *gc.C, deploymentType k8s.WorkloadType, createMainResource func() int) {
 	app, ctrl := s.getApp(c, deploymentType, false)
 	defer ctrl.Finish()
 
@@ -1316,7 +1316,7 @@ func (s *applicationSuite) assertState(c *gc.C, deploymentType k8s.K8sDeployment
 }
 
 func (s *applicationSuite) TestStateStateful(c *gc.C) {
-	s.assertState(c, k8s.K8sDeploymentStateful, func() int {
+	s.assertState(c, k8s.WorkloadTypeStatefulSet, func() int {
 		desiredReplicas := 10
 
 		dmr := &appsv1.StatefulSet{
@@ -1344,7 +1344,7 @@ func (s *applicationSuite) TestStateStateful(c *gc.C) {
 }
 
 func (s *applicationSuite) TestStateStateless(c *gc.C) {
-	s.assertState(c, k8s.K8sDeploymentStateless, func() int {
+	s.assertState(c, k8s.WorkloadTypeDeployment, func() int {
 		desiredReplicas := 10
 
 		dmr := &appsv1.Deployment{
@@ -1372,7 +1372,7 @@ func (s *applicationSuite) TestStateStateless(c *gc.C) {
 }
 
 func (s *applicationSuite) TestStateDaemon(c *gc.C) {
-	s.assertState(c, k8s.K8sDeploymentDaemon, func() int {
+	s.assertState(c, k8s.WorkloadTypeDaemonSet, func() int {
 		desiredReplicas := 10
 
 		dmr := &appsv1.DaemonSet{
@@ -1425,7 +1425,7 @@ func getDefaultSvc() *corev1.Service {
 }
 
 func (s *applicationSuite) TestUpdatePortsStatelessUpdateContainerPorts(c *gc.C) {
-	app, ctrl := s.getApp(c, k8s.K8sDeploymentStateless, true)
+	app, ctrl := s.getApp(c, k8s.WorkloadTypeDeployment, true)
 	defer ctrl.Finish()
 
 	_, err := s.client.CoreV1().Services("test").Create(context.Background(), getDefaultSvc(), metav1.CreateOptions{})
@@ -1554,7 +1554,7 @@ func (s *applicationSuite) TestUpdatePortsStatelessUpdateContainerPorts(c *gc.C)
 }
 
 func (s *applicationSuite) TestUpdatePortsStatefulUpdateContainerPorts(c *gc.C) {
-	app, ctrl := s.getApp(c, k8s.K8sDeploymentStateful, true)
+	app, ctrl := s.getApp(c, k8s.WorkloadTypeStatefulSet, true)
 	defer ctrl.Finish()
 
 	_, err := s.client.CoreV1().Services("test").Create(context.Background(), getDefaultSvc(), metav1.CreateOptions{})
@@ -1683,7 +1683,7 @@ func (s *applicationSuite) TestUpdatePortsStatefulUpdateContainerPorts(c *gc.C) 
 }
 
 func (s *applicationSuite) TestUpdatePortsDaemonUpdateContainerPorts(c *gc.C) {
-	app, ctrl := s.getApp(c, k8s.K8sDeploymentDaemon, true)
+	app, ctrl := s.getApp(c, k8s.WorkloadTypeDaemonSet, true)
 	defer ctrl.Finish()
 
 	_, err := s.client.CoreV1().Services("test").Create(context.Background(), getDefaultSvc(), metav1.CreateOptions{})
@@ -1772,7 +1772,7 @@ func (s *applicationSuite) TestUpdatePortsDaemonUpdateContainerPorts(c *gc.C) {
 }
 
 func (s *applicationSuite) TestUpdatePortsInvalidProtocol(c *gc.C) {
-	app, ctrl := s.getApp(c, k8s.K8sDeploymentStateful, true)
+	app, ctrl := s.getApp(c, k8s.WorkloadTypeStatefulSet, true)
 	defer ctrl.Finish()
 
 	_, err := s.client.CoreV1().Services("test").Create(context.Background(), getDefaultSvc(), metav1.CreateOptions{})
@@ -1789,7 +1789,7 @@ func (s *applicationSuite) TestUpdatePortsInvalidProtocol(c *gc.C) {
 }
 
 func (s *applicationSuite) TestUpdatePortsWithExistingPorts(c *gc.C) {
-	app, ctrl := s.getApp(c, k8s.K8sDeploymentStateful, true)
+	app, ctrl := s.getApp(c, k8s.WorkloadTypeStatefulSet, true)
 	defer ctrl.Finish()
 
 	existingSvc := getDefaultSvc()
@@ -1883,7 +1883,7 @@ func (s *applicationSuite) TestUpdatePortsWithExistingPorts(c *gc.C) {
 }
 
 func (s *applicationSuite) TestUpdatePortsStateless(c *gc.C) {
-	app, ctrl := s.getApp(c, k8s.K8sDeploymentStateless, true)
+	app, ctrl := s.getApp(c, k8s.WorkloadTypeDeployment, true)
 	defer ctrl.Finish()
 
 	_, err := s.client.CoreV1().Services("test").Create(context.Background(), getDefaultSvc(), metav1.CreateOptions{})
@@ -1917,7 +1917,7 @@ func (s *applicationSuite) TestUpdatePortsStateless(c *gc.C) {
 }
 
 func (s *applicationSuite) TestUpdatePortsStateful(c *gc.C) {
-	app, ctrl := s.getApp(c, k8s.K8sDeploymentStateful, true)
+	app, ctrl := s.getApp(c, k8s.WorkloadTypeStatefulSet, true)
 	defer ctrl.Finish()
 
 	_, err := s.client.CoreV1().Services("test").Create(context.Background(), getDefaultSvc(), metav1.CreateOptions{})
@@ -1951,7 +1951,7 @@ func (s *applicationSuite) TestUpdatePortsStateful(c *gc.C) {
 }
 
 func (s *applicationSuite) TestUpdatePortsDaemonUpdate(c *gc.C) {
-	app, ctrl := s.getApp(c, k8s.K8sDeploymentDaemon, true)
+	app, ctrl := s.getApp(c, k8s.WorkloadTypeDaemonSet, true)
 	defer ctrl.Finish()
 
 	_, err := s.client.CoreV1().Services("test").Create(context.Background(), getDefaultSvc(), metav1.CreateOptions{})
@@ -1985,7 +1985,7 @@ func (s *applicationSuite) TestUpdatePortsDaemonUpdate(c *gc.C) {
 }
 
 func (s *applicationSuite) TestUnits(c *gc.C) {
-	app, _ := s.getApp(c, k8s.K8sDeploymentStateful, false)
+	app, _ := s.getApp(c, k8s.WorkloadTypeStatefulSet, false)
 
 	for i := 0; i < 9; i++ {
 		podSpec := getPodSpec31()
@@ -2522,7 +2522,7 @@ func (s *applicationSuite) TestUnits(c *gc.C) {
 }
 
 func (s *applicationSuite) TestServiceActive(c *gc.C) {
-	app, _ := s.getApp(c, k8s.K8sDeploymentStateful, false)
+	app, _ := s.getApp(c, k8s.WorkloadTypeStatefulSet, false)
 	s.assertEnsure(
 		c, app, false, constraints.Value{}, false, false, "", func() {},
 	)
@@ -2561,7 +2561,7 @@ func (s *applicationSuite) TestServiceActive(c *gc.C) {
 }
 
 func (s *applicationSuite) TestServiceNotSupportedDaemon(c *gc.C) {
-	app, _ := s.getApp(c, k8s.K8sDeploymentDaemon, false)
+	app, _ := s.getApp(c, k8s.WorkloadTypeDaemonSet, false)
 	s.assertEnsure(
 		c, app, false, constraints.Value{}, false, false, "", func() {},
 	)
@@ -2574,11 +2574,11 @@ func (s *applicationSuite) TestServiceNotSupportedDaemon(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, err = app.Service()
-	c.Assert(err, gc.ErrorMatches, `deployment type "daemon" not supported`)
+	c.Assert(err, gc.ErrorMatches, `deployment type "DaemonSet" not supported`)
 }
 
 func (s *applicationSuite) TestServiceNotSupportedStateless(c *gc.C) {
-	app, _ := s.getApp(c, k8s.K8sDeploymentStateless, false)
+	app, _ := s.getApp(c, k8s.WorkloadTypeDeployment, false)
 	s.assertEnsure(
 		c, app, false, constraints.Value{}, false, false, "", func() {},
 	)
@@ -2591,11 +2591,11 @@ func (s *applicationSuite) TestServiceNotSupportedStateless(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	_, err = app.Service()
-	c.Assert(err, gc.ErrorMatches, `deployment type "stateless" not supported`)
+	c.Assert(err, gc.ErrorMatches, `deployment type "Deployment" not supported`)
 }
 
 func (s *applicationSuite) TestServiceTerminated(c *gc.C) {
-	app, _ := s.getApp(c, k8s.K8sDeploymentStateful, false)
+	app, _ := s.getApp(c, k8s.WorkloadTypeStatefulSet, false)
 	s.assertEnsure(
 		c, app, false, constraints.Value{}, false, false, "", func() {},
 	)
@@ -2635,7 +2635,7 @@ func (s *applicationSuite) TestServiceTerminated(c *gc.C) {
 }
 
 func (s *applicationSuite) TestServiceError(c *gc.C) {
-	app, _ := s.getApp(c, k8s.K8sDeploymentStateful, false)
+	app, _ := s.getApp(c, k8s.WorkloadTypeStatefulSet, false)
 	s.assertEnsure(
 		c, app, false, constraints.Value{}, false, false, "", func() {},
 	)
@@ -2694,7 +2694,7 @@ func (s *applicationSuite) TestServiceError(c *gc.C) {
 }
 
 func (s *applicationSuite) TestEnsureConstraints(c *gc.C) {
-	app, _ := s.getApp(c, k8s.K8sDeploymentStateful, false)
+	app, _ := s.getApp(c, k8s.WorkloadTypeStatefulSet, false)
 	s.assertEnsure(
 		c, app, false, constraints.MustParse("mem=1G cpu-power=1000 arch=arm64"), true, false, "", func() {
 			svc, err := s.client.CoreV1().Services("test").Get(context.Background(), "gitlab-endpoints", metav1.GetOptions{})
@@ -2794,7 +2794,7 @@ func (s *applicationSuite) TestEnsureConstraints(c *gc.C) {
 }
 
 func (s *applicationSuite) TestPullSecretUpdate(c *gc.C) {
-	app, _ := s.getApp(c, k8s.K8sDeploymentStateful, false)
+	app, _ := s.getApp(c, k8s.WorkloadTypeStatefulSet, false)
 
 	unusedPullSecret := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -2941,7 +2941,7 @@ func (s *applicationSuite) TestLimits(c *gc.C) {
 		corev1.ResourceMemory: *k8sresource.NewQuantity(1024*1024*1024, k8sresource.BinarySI),
 	}
 
-	app, _ := s.getApp(c, k8s.K8sDeploymentStateful, false)
+	app, _ := s.getApp(c, k8s.WorkloadTypeStatefulSet, false)
 	s.assertEnsure(
 		c, app, false, constraints.MustParse("mem=1G cpu-power=1000 arch=arm64"), true, false, "", func() {
 			ss, err := s.client.AppsV1().StatefulSets("test").Get(context.Background(), "gitlab", metav1.GetOptions{})

--- a/caas/kubernetes/provider/application/application_test.go
+++ b/caas/kubernetes/provider/application/application_test.go
@@ -34,6 +34,7 @@ import (
 	k8swatcher "github.com/juju/juju/caas/kubernetes/provider/watcher"
 	k8swatchertest "github.com/juju/juju/caas/kubernetes/provider/watcher/test"
 	"github.com/juju/juju/core/constraints"
+	"github.com/juju/juju/core/k8s"
 	"github.com/juju/juju/core/network"
 	coreresources "github.com/juju/juju/core/resource"
 	"github.com/juju/juju/core/semversion"
@@ -76,7 +77,7 @@ func (s *applicationSuite) TearDownTest(c *gc.C) {
 	s.BaseSuite.TearDownTest(c)
 }
 
-func (s *applicationSuite) getApp(c *gc.C, deploymentType caas.DeploymentType, mockApplier bool) (application.ApplicationInterfaceForTest, *gomock.Controller) {
+func (s *applicationSuite) getApp(c *gc.C, deploymentType k8s.K8sDeploymentType, mockApplier bool) (application.ApplicationInterfaceForTest, *gomock.Controller) {
 	watcherFn := k8swatcher.NewK8sWatcherFunc(func(i cache.SharedIndexInformer, n string, c jujuclock.Clock) (k8swatcher.KubernetesNotifyWatcher, error) {
 		if s.k8sWatcherFn == nil {
 			return nil, errors.NewNotFound(nil, "undefined k8sWatcherFn for base test")
@@ -451,7 +452,7 @@ func (s *applicationSuite) assertDelete(c *gc.C, app caas.Application) {
 }
 
 func (s *applicationSuite) TestEnsureStateful(c *gc.C) {
-	app, _ := s.getApp(c, caas.DeploymentStateful, false)
+	app, _ := s.getApp(c, k8s.K8sDeploymentStateful, false)
 	s.assertEnsure(
 		c, app, false, constraints.Value{}, true, false, "", func() {
 			svc, err := s.client.CoreV1().Services("test").Get(context.Background(), "gitlab-endpoints", metav1.GetOptions{})
@@ -539,7 +540,7 @@ func (s *applicationSuite) TestEnsureStateful(c *gc.C) {
 }
 
 func (s *applicationSuite) TestEnsureStatefulRootless35(c *gc.C) {
-	app, _ := s.getApp(c, caas.DeploymentStateful, false)
+	app, _ := s.getApp(c, k8s.K8sDeploymentStateful, false)
 	s.assertEnsure(
 		c, app, false, constraints.Value{}, true, true, "3.5-beta1", func() {
 			svc, err := s.client.CoreV1().Services("test").Get(context.Background(), "gitlab-endpoints", metav1.GetOptions{})
@@ -646,7 +647,7 @@ func (s *applicationSuite) TestEnsureStatefulRootless35(c *gc.C) {
 }
 
 func (s *applicationSuite) TestEnsureStatefulRootless(c *gc.C) {
-	app, _ := s.getApp(c, caas.DeploymentStateful, false)
+	app, _ := s.getApp(c, k8s.K8sDeploymentStateful, false)
 	s.assertEnsure(
 		c, app, false, constraints.Value{}, true, true, "3.6-beta3", func() {
 			svc, err := s.client.CoreV1().Services("test").Get(context.TODO(), "gitlab-endpoints", metav1.GetOptions{})
@@ -735,7 +736,7 @@ func (s *applicationSuite) TestEnsureStatefulRootless(c *gc.C) {
 }
 
 func (s *applicationSuite) TestEnsureTrusted(c *gc.C) {
-	app, _ := s.getApp(c, caas.DeploymentStateful, false)
+	app, _ := s.getApp(c, k8s.K8sDeploymentStateful, false)
 	s.assertEnsure(
 		c, app, false, constraints.Value{}, true, false, "", func() {},
 	)
@@ -743,7 +744,7 @@ func (s *applicationSuite) TestEnsureTrusted(c *gc.C) {
 }
 
 func (s *applicationSuite) TestEnsureUntrusted(c *gc.C) {
-	app, _ := s.getApp(c, caas.DeploymentStateful, false)
+	app, _ := s.getApp(c, k8s.K8sDeploymentStateful, false)
 	s.assertEnsure(
 		c, app, false, constraints.Value{}, false, false, "", func() {},
 	)
@@ -751,7 +752,7 @@ func (s *applicationSuite) TestEnsureUntrusted(c *gc.C) {
 }
 
 func (s *applicationSuite) TestEnsureStatefulPrivateImageRepo(c *gc.C) {
-	app, _ := s.getApp(c, caas.DeploymentStateful, false)
+	app, _ := s.getApp(c, k8s.K8sDeploymentStateful, false)
 
 	podSpec := getPodSpec31()
 	podSpec.ImagePullSecrets = append(
@@ -847,7 +848,7 @@ func (s *applicationSuite) TestEnsureStatefulPrivateImageRepo(c *gc.C) {
 }
 
 func (s *applicationSuite) TestEnsureStateless(c *gc.C) {
-	app, _ := s.getApp(c, caas.DeploymentStateless, false)
+	app, _ := s.getApp(c, k8s.K8sDeploymentStateless, false)
 	s.assertEnsure(
 		c, app, false, constraints.Value{}, true, false, "", func() {
 			ss, err := s.client.AppsV1().Deployments("test").Get(context.Background(), "gitlab", metav1.GetOptions{})
@@ -920,7 +921,7 @@ func (s *applicationSuite) TestEnsureStateless(c *gc.C) {
 }
 
 func (s *applicationSuite) TestEnsureDaemon(c *gc.C) {
-	app, _ := s.getApp(c, caas.DeploymentDaemon, false)
+	app, _ := s.getApp(c, k8s.K8sDeploymentDaemon, false)
 	s.assertEnsure(
 		c, app, false, constraints.Value{}, true, false, "", func() {
 			ss, err := s.client.AppsV1().DaemonSets("test").Get(context.Background(), "gitlab", metav1.GetOptions{})
@@ -1000,7 +1001,7 @@ func (s *applicationSuite) TestExistsNotSupported(c *gc.C) {
 func (s *applicationSuite) TestExistsDeployment(c *gc.C) {
 	now := metav1.Now()
 
-	app, _ := s.getApp(c, caas.DeploymentStateless, false)
+	app, _ := s.getApp(c, k8s.K8sDeploymentStateless, false)
 	// Deployment does not exists.
 	result, err := app.Exists()
 	c.Assert(err, jc.ErrorIsNil)
@@ -1039,7 +1040,7 @@ func (s *applicationSuite) TestExistsDeployment(c *gc.C) {
 func (s *applicationSuite) TestExistsStatefulSet(c *gc.C) {
 	now := metav1.Now()
 
-	app, _ := s.getApp(c, caas.DeploymentStateful, false)
+	app, _ := s.getApp(c, k8s.K8sDeploymentStateful, false)
 	// Statefulset does not exists.
 	result, err := app.Exists()
 	c.Assert(err, jc.ErrorIsNil)
@@ -1079,7 +1080,7 @@ func (s *applicationSuite) TestExistsStatefulSet(c *gc.C) {
 func (s *applicationSuite) TestExistsDaemonSet(c *gc.C) {
 	now := metav1.Now()
 
-	app, _ := s.getApp(c, caas.DeploymentDaemon, false)
+	app, _ := s.getApp(c, k8s.K8sDeploymentDaemon, false)
 	// Daemonset does not exists.
 	result, err := app.Exists()
 	c.Assert(err, jc.ErrorIsNil)
@@ -1117,7 +1118,7 @@ func (s *applicationSuite) TestExistsDaemonSet(c *gc.C) {
 
 // Test upgrades are performed by ensure. Regression bug for lp1997253
 func (s *applicationSuite) TestUpgradeStateful(c *gc.C) {
-	app, _ := s.getApp(c, caas.DeploymentStateful, false)
+	app, _ := s.getApp(c, k8s.K8sDeploymentStateful, false)
 	s.assertEnsure(c, app, false, constraints.Value{}, true, false, "2.9.34", func() {
 		ss, err := s.client.AppsV1().StatefulSets("test").Get(context.Background(), "gitlab", metav1.GetOptions{})
 		c.Assert(err, jc.ErrorIsNil)
@@ -1161,7 +1162,7 @@ func (s *applicationSuite) TestUpgradeStateful(c *gc.C) {
 }
 
 func (s *applicationSuite) TestDeleteStateful(c *gc.C) {
-	app, ctrl := s.getApp(c, caas.DeploymentStateful, true)
+	app, ctrl := s.getApp(c, k8s.K8sDeploymentStateful, true)
 	defer ctrl.Finish()
 
 	gomock.InOrder(
@@ -1180,7 +1181,7 @@ func (s *applicationSuite) TestDeleteStateful(c *gc.C) {
 }
 
 func (s *applicationSuite) TestDeleteStateless(c *gc.C) {
-	app, ctrl := s.getApp(c, caas.DeploymentStateless, true)
+	app, ctrl := s.getApp(c, k8s.K8sDeploymentStateless, true)
 	defer ctrl.Finish()
 
 	gomock.InOrder(
@@ -1198,7 +1199,7 @@ func (s *applicationSuite) TestDeleteStateless(c *gc.C) {
 }
 
 func (s *applicationSuite) TestDeleteDaemon(c *gc.C) {
-	app, ctrl := s.getApp(c, caas.DeploymentDaemon, true)
+	app, ctrl := s.getApp(c, k8s.K8sDeploymentDaemon, true)
 	defer ctrl.Finish()
 
 	gomock.InOrder(
@@ -1229,7 +1230,7 @@ func (s *applicationSuite) TestWatchNotsupported(c *gc.C) {
 }
 
 func (s *applicationSuite) TestWatch(c *gc.C) {
-	app, ctrl := s.getApp(c, caas.DeploymentDaemon, true)
+	app, ctrl := s.getApp(c, k8s.K8sDeploymentDaemon, true)
 	defer ctrl.Finish()
 
 	s.k8sWatcherFn = func(_ cache.SharedIndexInformer, _ string, _ jujuclock.Clock) (k8swatcher.KubernetesNotifyWatcher, error) {
@@ -1249,7 +1250,7 @@ func (s *applicationSuite) TestWatch(c *gc.C) {
 }
 
 func (s *applicationSuite) TestWatchReplicas(c *gc.C) {
-	app, ctrl := s.getApp(c, caas.DeploymentDaemon, true)
+	app, ctrl := s.getApp(c, k8s.K8sDeploymentDaemon, true)
 	defer ctrl.Finish()
 
 	s.k8sWatcherFn = func(_ cache.SharedIndexInformer, _ string, _ jujuclock.Clock) (k8swatcher.KubernetesNotifyWatcher, error) {
@@ -1274,7 +1275,7 @@ func (s *applicationSuite) TestStateNotSupported(c *gc.C) {
 	c.Assert(err, gc.ErrorMatches, `unknown deployment type not supported`)
 }
 
-func (s *applicationSuite) assertState(c *gc.C, deploymentType caas.DeploymentType, createMainResource func() int) {
+func (s *applicationSuite) assertState(c *gc.C, deploymentType k8s.K8sDeploymentType, createMainResource func() int) {
 	app, ctrl := s.getApp(c, deploymentType, false)
 	defer ctrl.Finish()
 
@@ -1315,7 +1316,7 @@ func (s *applicationSuite) assertState(c *gc.C, deploymentType caas.DeploymentTy
 }
 
 func (s *applicationSuite) TestStateStateful(c *gc.C) {
-	s.assertState(c, caas.DeploymentStateful, func() int {
+	s.assertState(c, k8s.K8sDeploymentStateful, func() int {
 		desiredReplicas := 10
 
 		dmr := &appsv1.StatefulSet{
@@ -1343,7 +1344,7 @@ func (s *applicationSuite) TestStateStateful(c *gc.C) {
 }
 
 func (s *applicationSuite) TestStateStateless(c *gc.C) {
-	s.assertState(c, caas.DeploymentStateless, func() int {
+	s.assertState(c, k8s.K8sDeploymentStateless, func() int {
 		desiredReplicas := 10
 
 		dmr := &appsv1.Deployment{
@@ -1371,7 +1372,7 @@ func (s *applicationSuite) TestStateStateless(c *gc.C) {
 }
 
 func (s *applicationSuite) TestStateDaemon(c *gc.C) {
-	s.assertState(c, caas.DeploymentDaemon, func() int {
+	s.assertState(c, k8s.K8sDeploymentDaemon, func() int {
 		desiredReplicas := 10
 
 		dmr := &appsv1.DaemonSet{
@@ -1424,7 +1425,7 @@ func getDefaultSvc() *corev1.Service {
 }
 
 func (s *applicationSuite) TestUpdatePortsStatelessUpdateContainerPorts(c *gc.C) {
-	app, ctrl := s.getApp(c, caas.DeploymentStateless, true)
+	app, ctrl := s.getApp(c, k8s.K8sDeploymentStateless, true)
 	defer ctrl.Finish()
 
 	_, err := s.client.CoreV1().Services("test").Create(context.Background(), getDefaultSvc(), metav1.CreateOptions{})
@@ -1553,7 +1554,7 @@ func (s *applicationSuite) TestUpdatePortsStatelessUpdateContainerPorts(c *gc.C)
 }
 
 func (s *applicationSuite) TestUpdatePortsStatefulUpdateContainerPorts(c *gc.C) {
-	app, ctrl := s.getApp(c, caas.DeploymentStateful, true)
+	app, ctrl := s.getApp(c, k8s.K8sDeploymentStateful, true)
 	defer ctrl.Finish()
 
 	_, err := s.client.CoreV1().Services("test").Create(context.Background(), getDefaultSvc(), metav1.CreateOptions{})
@@ -1682,7 +1683,7 @@ func (s *applicationSuite) TestUpdatePortsStatefulUpdateContainerPorts(c *gc.C) 
 }
 
 func (s *applicationSuite) TestUpdatePortsDaemonUpdateContainerPorts(c *gc.C) {
-	app, ctrl := s.getApp(c, caas.DeploymentDaemon, true)
+	app, ctrl := s.getApp(c, k8s.K8sDeploymentDaemon, true)
 	defer ctrl.Finish()
 
 	_, err := s.client.CoreV1().Services("test").Create(context.Background(), getDefaultSvc(), metav1.CreateOptions{})
@@ -1771,7 +1772,7 @@ func (s *applicationSuite) TestUpdatePortsDaemonUpdateContainerPorts(c *gc.C) {
 }
 
 func (s *applicationSuite) TestUpdatePortsInvalidProtocol(c *gc.C) {
-	app, ctrl := s.getApp(c, caas.DeploymentStateful, true)
+	app, ctrl := s.getApp(c, k8s.K8sDeploymentStateful, true)
 	defer ctrl.Finish()
 
 	_, err := s.client.CoreV1().Services("test").Create(context.Background(), getDefaultSvc(), metav1.CreateOptions{})
@@ -1788,7 +1789,7 @@ func (s *applicationSuite) TestUpdatePortsInvalidProtocol(c *gc.C) {
 }
 
 func (s *applicationSuite) TestUpdatePortsWithExistingPorts(c *gc.C) {
-	app, ctrl := s.getApp(c, caas.DeploymentStateful, true)
+	app, ctrl := s.getApp(c, k8s.K8sDeploymentStateful, true)
 	defer ctrl.Finish()
 
 	existingSvc := getDefaultSvc()
@@ -1882,7 +1883,7 @@ func (s *applicationSuite) TestUpdatePortsWithExistingPorts(c *gc.C) {
 }
 
 func (s *applicationSuite) TestUpdatePortsStateless(c *gc.C) {
-	app, ctrl := s.getApp(c, caas.DeploymentStateless, true)
+	app, ctrl := s.getApp(c, k8s.K8sDeploymentStateless, true)
 	defer ctrl.Finish()
 
 	_, err := s.client.CoreV1().Services("test").Create(context.Background(), getDefaultSvc(), metav1.CreateOptions{})
@@ -1916,7 +1917,7 @@ func (s *applicationSuite) TestUpdatePortsStateless(c *gc.C) {
 }
 
 func (s *applicationSuite) TestUpdatePortsStateful(c *gc.C) {
-	app, ctrl := s.getApp(c, caas.DeploymentStateful, true)
+	app, ctrl := s.getApp(c, k8s.K8sDeploymentStateful, true)
 	defer ctrl.Finish()
 
 	_, err := s.client.CoreV1().Services("test").Create(context.Background(), getDefaultSvc(), metav1.CreateOptions{})
@@ -1950,7 +1951,7 @@ func (s *applicationSuite) TestUpdatePortsStateful(c *gc.C) {
 }
 
 func (s *applicationSuite) TestUpdatePortsDaemonUpdate(c *gc.C) {
-	app, ctrl := s.getApp(c, caas.DeploymentDaemon, true)
+	app, ctrl := s.getApp(c, k8s.K8sDeploymentDaemon, true)
 	defer ctrl.Finish()
 
 	_, err := s.client.CoreV1().Services("test").Create(context.Background(), getDefaultSvc(), metav1.CreateOptions{})
@@ -1984,7 +1985,7 @@ func (s *applicationSuite) TestUpdatePortsDaemonUpdate(c *gc.C) {
 }
 
 func (s *applicationSuite) TestUnits(c *gc.C) {
-	app, _ := s.getApp(c, caas.DeploymentStateful, false)
+	app, _ := s.getApp(c, k8s.K8sDeploymentStateful, false)
 
 	for i := 0; i < 9; i++ {
 		podSpec := getPodSpec31()
@@ -2521,7 +2522,7 @@ func (s *applicationSuite) TestUnits(c *gc.C) {
 }
 
 func (s *applicationSuite) TestServiceActive(c *gc.C) {
-	app, _ := s.getApp(c, caas.DeploymentStateful, false)
+	app, _ := s.getApp(c, k8s.K8sDeploymentStateful, false)
 	s.assertEnsure(
 		c, app, false, constraints.Value{}, false, false, "", func() {},
 	)
@@ -2560,7 +2561,7 @@ func (s *applicationSuite) TestServiceActive(c *gc.C) {
 }
 
 func (s *applicationSuite) TestServiceNotSupportedDaemon(c *gc.C) {
-	app, _ := s.getApp(c, caas.DeploymentDaemon, false)
+	app, _ := s.getApp(c, k8s.K8sDeploymentDaemon, false)
 	s.assertEnsure(
 		c, app, false, constraints.Value{}, false, false, "", func() {},
 	)
@@ -2577,7 +2578,7 @@ func (s *applicationSuite) TestServiceNotSupportedDaemon(c *gc.C) {
 }
 
 func (s *applicationSuite) TestServiceNotSupportedStateless(c *gc.C) {
-	app, _ := s.getApp(c, caas.DeploymentStateless, false)
+	app, _ := s.getApp(c, k8s.K8sDeploymentStateless, false)
 	s.assertEnsure(
 		c, app, false, constraints.Value{}, false, false, "", func() {},
 	)
@@ -2594,7 +2595,7 @@ func (s *applicationSuite) TestServiceNotSupportedStateless(c *gc.C) {
 }
 
 func (s *applicationSuite) TestServiceTerminated(c *gc.C) {
-	app, _ := s.getApp(c, caas.DeploymentStateful, false)
+	app, _ := s.getApp(c, k8s.K8sDeploymentStateful, false)
 	s.assertEnsure(
 		c, app, false, constraints.Value{}, false, false, "", func() {},
 	)
@@ -2634,7 +2635,7 @@ func (s *applicationSuite) TestServiceTerminated(c *gc.C) {
 }
 
 func (s *applicationSuite) TestServiceError(c *gc.C) {
-	app, _ := s.getApp(c, caas.DeploymentStateful, false)
+	app, _ := s.getApp(c, k8s.K8sDeploymentStateful, false)
 	s.assertEnsure(
 		c, app, false, constraints.Value{}, false, false, "", func() {},
 	)
@@ -2693,7 +2694,7 @@ func (s *applicationSuite) TestServiceError(c *gc.C) {
 }
 
 func (s *applicationSuite) TestEnsureConstraints(c *gc.C) {
-	app, _ := s.getApp(c, caas.DeploymentStateful, false)
+	app, _ := s.getApp(c, k8s.K8sDeploymentStateful, false)
 	s.assertEnsure(
 		c, app, false, constraints.MustParse("mem=1G cpu-power=1000 arch=arm64"), true, false, "", func() {
 			svc, err := s.client.CoreV1().Services("test").Get(context.Background(), "gitlab-endpoints", metav1.GetOptions{})
@@ -2793,7 +2794,7 @@ func (s *applicationSuite) TestEnsureConstraints(c *gc.C) {
 }
 
 func (s *applicationSuite) TestPullSecretUpdate(c *gc.C) {
-	app, _ := s.getApp(c, caas.DeploymentStateful, false)
+	app, _ := s.getApp(c, k8s.K8sDeploymentStateful, false)
 
 	unusedPullSecret := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -2940,7 +2941,7 @@ func (s *applicationSuite) TestLimits(c *gc.C) {
 		corev1.ResourceMemory: *k8sresource.NewQuantity(1024*1024*1024, k8sresource.BinarySI),
 	}
 
-	app, _ := s.getApp(c, caas.DeploymentStateful, false)
+	app, _ := s.getApp(c, k8s.K8sDeploymentStateful, false)
 	s.assertEnsure(
 		c, app, false, constraints.MustParse("mem=1G cpu-power=1000 arch=arm64"), true, false, "", func() {
 			ss, err := s.client.AppsV1().StatefulSets("test").Get(context.Background(), "gitlab", metav1.GetOptions{})

--- a/caas/kubernetes/provider/application/package_test.go
+++ b/caas/kubernetes/provider/application/package_test.go
@@ -40,7 +40,7 @@ func NewApplicationForTest(
 	modelUUID string,
 	modelName string,
 	legacyLabels bool,
-	deploymentType k8s.K8sDeploymentType,
+	deploymentType k8s.WorkloadType,
 	client kubernetes.Interface,
 	newWatcher k8swatcher.NewK8sWatcherFunc,
 	clock clock.Clock,

--- a/caas/kubernetes/provider/application/package_test.go
+++ b/caas/kubernetes/provider/application/package_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/caas/kubernetes/provider/resources"
 	k8sutils "github.com/juju/juju/caas/kubernetes/provider/utils"
 	k8swatcher "github.com/juju/juju/caas/kubernetes/provider/watcher"
+	"github.com/juju/juju/core/k8s"
 )
 
 func Test(t *testing.T) {
@@ -39,7 +40,7 @@ func NewApplicationForTest(
 	modelUUID string,
 	modelName string,
 	legacyLabels bool,
-	deploymentType caas.DeploymentType,
+	deploymentType k8s.K8sDeploymentType,
 	client kubernetes.Interface,
 	newWatcher k8swatcher.NewK8sWatcherFunc,
 	clock clock.Clock,

--- a/caas/kubernetes/provider/application/scale.go
+++ b/caas/kubernetes/provider/application/scale.go
@@ -11,8 +11,8 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/juju/juju/caas"
 	"github.com/juju/juju/caas/kubernetes/provider/scale"
+	"github.com/juju/juju/core/k8s"
 )
 
 // Scale scales the Application's unit to the value specificied. Scale must
@@ -20,14 +20,14 @@ import (
 // defined.
 func (a *app) Scale(scaleTo int) error {
 	switch a.deploymentType {
-	case caas.DeploymentStateful:
+	case k8s.K8sDeploymentStateful:
 		return scale.PatchReplicasToScale(
 			context.Background(),
 			a.name,
 			int32(scaleTo),
 			scale.StatefulSetScalePatcher(a.client.AppsV1().StatefulSets(a.namespace)),
 		)
-	case caas.DeploymentStateless:
+	case k8s.K8sDeploymentStateless:
 		return scale.PatchReplicasToScale(
 			context.Background(),
 			a.name,
@@ -45,7 +45,7 @@ func (a *app) Scale(scaleTo int) error {
 // many units is Kubernetes currently running for application x.
 func (a *app) currentScale(ctx context.Context) (int, error) {
 	switch a.deploymentType {
-	case caas.DeploymentStateful:
+	case k8s.K8sDeploymentStateful:
 		ss, err := a.client.AppsV1().StatefulSets(a.namespace).Get(ctx, a.name, meta.GetOptions{})
 		if k8serrors.IsNotFound(err) {
 			err = errors.WithType(err, errors.NotFound)

--- a/caas/kubernetes/provider/application/scale.go
+++ b/caas/kubernetes/provider/application/scale.go
@@ -20,14 +20,14 @@ import (
 // defined.
 func (a *app) Scale(scaleTo int) error {
 	switch a.deploymentType {
-	case k8s.K8sDeploymentStateful:
+	case k8s.WorkloadTypeStatefulSet:
 		return scale.PatchReplicasToScale(
 			context.Background(),
 			a.name,
 			int32(scaleTo),
 			scale.StatefulSetScalePatcher(a.client.AppsV1().StatefulSets(a.namespace)),
 		)
-	case k8s.K8sDeploymentStateless:
+	case k8s.WorkloadTypeDeployment:
 		return scale.PatchReplicasToScale(
 			context.Background(),
 			a.name,
@@ -45,7 +45,7 @@ func (a *app) Scale(scaleTo int) error {
 // many units is Kubernetes currently running for application x.
 func (a *app) currentScale(ctx context.Context) (int, error) {
 	switch a.deploymentType {
-	case k8s.K8sDeploymentStateful:
+	case k8s.WorkloadTypeStatefulSet:
 		ss, err := a.client.AppsV1().StatefulSets(a.namespace).Get(ctx, a.name, meta.GetOptions{})
 		if k8serrors.IsNotFound(err) {
 			err = errors.WithType(err, errors.NotFound)

--- a/caas/kubernetes/provider/application/scale_test.go
+++ b/caas/kubernetes/provider/application/scale_test.go
@@ -11,12 +11,12 @@ import (
 	gc "gopkg.in/check.v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/juju/juju/caas"
 	"github.com/juju/juju/core/constraints"
+	"github.com/juju/juju/core/k8s"
 )
 
 func (s *applicationSuite) TestApplicationScaleStateful(c *gc.C) {
-	app, _ := s.getApp(c, caas.DeploymentStateful, false)
+	app, _ := s.getApp(c, k8s.K8sDeploymentStateful, false)
 	s.assertEnsure(c, app, false, constraints.Value{}, false, false, "", func() {})
 
 	c.Assert(app.Scale(20), jc.ErrorIsNil)
@@ -30,7 +30,7 @@ func (s *applicationSuite) TestApplicationScaleStateful(c *gc.C) {
 }
 
 func (s *applicationSuite) TestApplicationScaleStateless(c *gc.C) {
-	app, _ := s.getApp(c, caas.DeploymentStateless, false)
+	app, _ := s.getApp(c, k8s.K8sDeploymentStateless, false)
 	s.assertEnsure(c, app, false, constraints.Value{}, false, false, "", func() {})
 
 	c.Assert(app.Scale(20), jc.ErrorIsNil)
@@ -44,14 +44,14 @@ func (s *applicationSuite) TestApplicationScaleStateless(c *gc.C) {
 }
 
 func (s *applicationSuite) TestApplicationScaleStatefulLessThanZero(c *gc.C) {
-	app, _ := s.getApp(c, caas.DeploymentStateful, false)
+	app, _ := s.getApp(c, k8s.K8sDeploymentStateful, false)
 	s.assertEnsure(c, app, false, constraints.Value{}, false, false, "", func() {})
 
 	c.Assert(app.Scale(-1), jc.ErrorIs, errors.NotValid)
 }
 
 func (s *applicationSuite) TestCurrentScale(c *gc.C) {
-	app, _ := s.getApp(c, caas.DeploymentStateful, false)
+	app, _ := s.getApp(c, k8s.K8sDeploymentStateful, false)
 	s.assertEnsure(c, app, false, constraints.Value{}, false, false, "", func() {})
 
 	c.Assert(app.Scale(3), jc.ErrorIsNil)

--- a/caas/kubernetes/provider/application/scale_test.go
+++ b/caas/kubernetes/provider/application/scale_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func (s *applicationSuite) TestApplicationScaleStateful(c *gc.C) {
-	app, _ := s.getApp(c, k8s.K8sDeploymentStateful, false)
+	app, _ := s.getApp(c, k8s.WorkloadTypeStatefulSet, false)
 	s.assertEnsure(c, app, false, constraints.Value{}, false, false, "", func() {})
 
 	c.Assert(app.Scale(20), jc.ErrorIsNil)
@@ -30,7 +30,7 @@ func (s *applicationSuite) TestApplicationScaleStateful(c *gc.C) {
 }
 
 func (s *applicationSuite) TestApplicationScaleStateless(c *gc.C) {
-	app, _ := s.getApp(c, k8s.K8sDeploymentStateless, false)
+	app, _ := s.getApp(c, k8s.WorkloadTypeDeployment, false)
 	s.assertEnsure(c, app, false, constraints.Value{}, false, false, "", func() {})
 
 	c.Assert(app.Scale(20), jc.ErrorIsNil)
@@ -44,14 +44,14 @@ func (s *applicationSuite) TestApplicationScaleStateless(c *gc.C) {
 }
 
 func (s *applicationSuite) TestApplicationScaleStatefulLessThanZero(c *gc.C) {
-	app, _ := s.getApp(c, k8s.K8sDeploymentStateful, false)
+	app, _ := s.getApp(c, k8s.WorkloadTypeStatefulSet, false)
 	s.assertEnsure(c, app, false, constraints.Value{}, false, false, "", func() {})
 
 	c.Assert(app.Scale(-1), jc.ErrorIs, errors.NotValid)
 }
 
 func (s *applicationSuite) TestCurrentScale(c *gc.C) {
-	app, _ := s.getApp(c, k8s.K8sDeploymentStateful, false)
+	app, _ := s.getApp(c, k8s.WorkloadTypeStatefulSet, false)
 	s.assertEnsure(c, app, false, constraints.Value{}, false, false, "", func() {})
 
 	c.Assert(app.Scale(3), jc.ErrorIsNil)

--- a/caas/kubernetes/provider/application/trust_test.go
+++ b/caas/kubernetes/provider/application/trust_test.go
@@ -7,17 +7,16 @@ import (
 	"context"
 
 	"github.com/juju/errors"
+	"github.com/juju/juju/core/k8s"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/juju/juju/caas"
 )
 
 func (s *applicationSuite) TestTrust(c *gc.C) {
-	app, ctrl := s.getApp(c, caas.DeploymentStateless, true)
+	app, ctrl := s.getApp(c, k8s.K8sDeploymentStateless, true)
 	defer ctrl.Finish()
 
 	_, err := s.client.RbacV1().Roles(s.namespace).Create(context.Background(), &rbacv1.Role{
@@ -57,7 +56,7 @@ func (s *applicationSuite) TestTrust(c *gc.C) {
 }
 
 func (s *applicationSuite) TestTrustRoleNotFound(c *gc.C) {
-	app, ctrl := s.getApp(c, caas.DeploymentStateless, true)
+	app, ctrl := s.getApp(c, k8s.K8sDeploymentStateless, true)
 	defer ctrl.Finish()
 
 	err := app.Trust(true)
@@ -65,7 +64,7 @@ func (s *applicationSuite) TestTrustRoleNotFound(c *gc.C) {
 }
 
 func (s *applicationSuite) TestTrustClusterRoleNotFound(c *gc.C) {
-	app, ctrl := s.getApp(c, caas.DeploymentStateless, true)
+	app, ctrl := s.getApp(c, k8s.K8sDeploymentStateless, true)
 	defer ctrl.Finish()
 
 	_, err := s.client.RbacV1().Roles(s.namespace).Create(context.Background(), &rbacv1.Role{
@@ -86,7 +85,7 @@ func (s *applicationSuite) TestTrustClusterRoleNotFound(c *gc.C) {
 }
 
 func (s *applicationSuite) TestRemoveTrust(c *gc.C) {
-	app, ctrl := s.getApp(c, caas.DeploymentStateless, true)
+	app, ctrl := s.getApp(c, k8s.K8sDeploymentStateless, true)
 	defer ctrl.Finish()
 
 	_, err := s.client.RbacV1().Roles(s.namespace).Create(context.Background(), &rbacv1.Role{

--- a/caas/kubernetes/provider/application/trust_test.go
+++ b/caas/kubernetes/provider/application/trust_test.go
@@ -7,16 +7,17 @@ import (
 	"context"
 
 	"github.com/juju/errors"
-	"github.com/juju/juju/core/k8s"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/juju/juju/core/k8s"
 )
 
 func (s *applicationSuite) TestTrust(c *gc.C) {
-	app, ctrl := s.getApp(c, k8s.K8sDeploymentStateless, true)
+	app, ctrl := s.getApp(c, k8s.WorkloadTypeDeployment, true)
 	defer ctrl.Finish()
 
 	_, err := s.client.RbacV1().Roles(s.namespace).Create(context.Background(), &rbacv1.Role{
@@ -56,7 +57,7 @@ func (s *applicationSuite) TestTrust(c *gc.C) {
 }
 
 func (s *applicationSuite) TestTrustRoleNotFound(c *gc.C) {
-	app, ctrl := s.getApp(c, k8s.K8sDeploymentStateless, true)
+	app, ctrl := s.getApp(c, k8s.WorkloadTypeDeployment, true)
 	defer ctrl.Finish()
 
 	err := app.Trust(true)
@@ -64,7 +65,7 @@ func (s *applicationSuite) TestTrustRoleNotFound(c *gc.C) {
 }
 
 func (s *applicationSuite) TestTrustClusterRoleNotFound(c *gc.C) {
-	app, ctrl := s.getApp(c, k8s.K8sDeploymentStateless, true)
+	app, ctrl := s.getApp(c, k8s.WorkloadTypeDeployment, true)
 	defer ctrl.Finish()
 
 	_, err := s.client.RbacV1().Roles(s.namespace).Create(context.Background(), &rbacv1.Role{
@@ -85,7 +86,7 @@ func (s *applicationSuite) TestTrustClusterRoleNotFound(c *gc.C) {
 }
 
 func (s *applicationSuite) TestRemoveTrust(c *gc.C) {
-	app, ctrl := s.getApp(c, k8s.K8sDeploymentStateless, true)
+	app, ctrl := s.getApp(c, k8s.WorkloadTypeDeployment, true)
 	defer ctrl.Finish()
 
 	_, err := s.client.RbacV1().Roles(s.namespace).Create(context.Background(), &rbacv1.Role{

--- a/caas/kubernetes/provider/bootstrap.go
+++ b/caas/kubernetes/provider/bootstrap.go
@@ -1618,7 +1618,7 @@ func (c *controllerStack) buildContainerSpecForCommands(setupCmd, machineCmd str
 		c.broker.modelUUID,
 		environsbootstrap.ControllerModelName,
 		false,
-		corek8s.K8sDeploymentStateful,
+		corek8s.WorkloadTypeStatefulSet,
 		c.broker.client(),
 		c.broker.newWatcher,
 		c.broker.clock,

--- a/caas/kubernetes/provider/bootstrap.go
+++ b/caas/kubernetes/provider/bootstrap.go
@@ -38,6 +38,7 @@ import (
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/controller"
 	k8sannotations "github.com/juju/juju/core/annotations"
+	corek8s "github.com/juju/juju/core/k8s"
 	"github.com/juju/juju/core/paths"
 	"github.com/juju/juju/core/version"
 	"github.com/juju/juju/core/watcher"
@@ -1617,7 +1618,7 @@ func (c *controllerStack) buildContainerSpecForCommands(setupCmd, machineCmd str
 		c.broker.modelUUID,
 		environsbootstrap.ControllerModelName,
 		false,
-		caas.DeploymentStateful,
+		corek8s.K8sDeploymentStateful,
 		c.broker.client(),
 		c.broker.newWatcher,
 		c.broker.clock,

--- a/caas/mocks/broker_mock.go
+++ b/caas/mocks/broker_mock.go
@@ -15,8 +15,8 @@ import (
 
 	caas "github.com/juju/juju/caas"
 	constraints "github.com/juju/juju/core/constraints"
-	semversion "github.com/juju/juju/core/semversion"
 	k8s "github.com/juju/juju/core/k8s"
+	semversion "github.com/juju/juju/core/semversion"
 	environs "github.com/juju/juju/environs"
 	config "github.com/juju/juju/environs/config"
 	envcontext "github.com/juju/juju/environs/envcontext"
@@ -166,7 +166,7 @@ func (c *MockBrokerAnnotateUnitCall) DoAndReturn(f func(context.Context, string,
 }
 
 // Application mocks base method.
-func (m *MockBroker) Application(arg0 string, arg1 k8s.K8sDeploymentType) caas.Application {
+func (m *MockBroker) Application(arg0 string, arg1 k8s.WorkloadType) caas.Application {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Application", arg0, arg1)
 	ret0, _ := ret[0].(caas.Application)
@@ -192,13 +192,13 @@ func (c *MockBrokerApplicationCall) Return(arg0 caas.Application) *MockBrokerApp
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockBrokerApplicationCall) Do(f func(string, k8s.K8sDeploymentType) caas.Application) *MockBrokerApplicationCall {
+func (c *MockBrokerApplicationCall) Do(f func(string, k8s.WorkloadType) caas.Application) *MockBrokerApplicationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockBrokerApplicationCall) DoAndReturn(f func(string, k8s.K8sDeploymentType) caas.Application) *MockBrokerApplicationCall {
+func (c *MockBrokerApplicationCall) DoAndReturn(f func(string, k8s.WorkloadType) caas.Application) *MockBrokerApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/caas/mocks/broker_mock.go
+++ b/caas/mocks/broker_mock.go
@@ -16,6 +16,7 @@ import (
 	caas "github.com/juju/juju/caas"
 	constraints "github.com/juju/juju/core/constraints"
 	semversion "github.com/juju/juju/core/semversion"
+	k8s "github.com/juju/juju/core/k8s"
 	environs "github.com/juju/juju/environs"
 	config "github.com/juju/juju/environs/config"
 	envcontext "github.com/juju/juju/environs/envcontext"
@@ -165,7 +166,7 @@ func (c *MockBrokerAnnotateUnitCall) DoAndReturn(f func(context.Context, string,
 }
 
 // Application mocks base method.
-func (m *MockBroker) Application(arg0 string, arg1 caas.DeploymentType) caas.Application {
+func (m *MockBroker) Application(arg0 string, arg1 k8s.K8sDeploymentType) caas.Application {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Application", arg0, arg1)
 	ret0, _ := ret[0].(caas.Application)
@@ -191,13 +192,13 @@ func (c *MockBrokerApplicationCall) Return(arg0 caas.Application) *MockBrokerApp
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockBrokerApplicationCall) Do(f func(string, caas.DeploymentType) caas.Application) *MockBrokerApplicationCall {
+func (c *MockBrokerApplicationCall) Do(f func(string, k8s.K8sDeploymentType) caas.Application) *MockBrokerApplicationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockBrokerApplicationCall) DoAndReturn(f func(string, caas.DeploymentType) caas.Application) *MockBrokerApplicationCall {
+func (c *MockBrokerApplicationCall) DoAndReturn(f func(string, k8s.K8sDeploymentType) caas.Application) *MockBrokerApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/core/k8s/provider.go
+++ b/core/k8s/provider.go
@@ -5,24 +5,27 @@ package k8s
 
 import "github.com/juju/errors"
 
-// K8sDeploymentType defines a deployment type.
-type K8sDeploymentType string
+// WorkloadType defines a workload type on k8s.
+type WorkloadType string
 
-// Validate validates if this deployment type is supported.
-func (dt K8sDeploymentType) Validate() error {
+// Validate validates if this workload type is supported.
+func (dt WorkloadType) Validate() error {
 	if dt == "" {
 		return nil
 	}
-	if dt == K8sDeploymentStateless ||
-		dt == K8sDeploymentStateful ||
-		dt == K8sDeploymentDaemon {
+	if dt == WorkloadTypeDeployment ||
+		dt == WorkloadTypeStatefulSet ||
+		dt == WorkloadTypeDaemonSet {
 		return nil
 	}
-	return errors.NotSupportedf("deployment type %q", dt)
+	return errors.NotSupportedf("workload type %q", dt)
 }
 
 const (
-	K8sDeploymentStateless K8sDeploymentType = "stateless"
-	K8sDeploymentStateful  K8sDeploymentType = "stateful"
-	K8sDeploymentDaemon    K8sDeploymentType = "daemon"
+	// WorkloadTypeDeployment represents the "Deployment" workload type in k8s.
+	WorkloadTypeDeployment WorkloadType = "Deployment"
+	// WorkloadTypeStatefulSet represents the "StatefulSet" workload type in k8s.
+	WorkloadTypeStatefulSet WorkloadType = "StatefulSet"
+	// WorkloadTypeDaemonSet represents the "DaemonSet" workload type in k8s.
+	WorkloadTypeDaemonSet WorkloadType = "DaemonSet"
 )

--- a/core/k8s/provider.go
+++ b/core/k8s/provider.go
@@ -1,0 +1,28 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package k8s
+
+import "github.com/juju/errors"
+
+// K8sDeploymentType defines a deployment type.
+type K8sDeploymentType string
+
+// Validate validates if this deployment type is supported.
+func (dt K8sDeploymentType) Validate() error {
+	if dt == "" {
+		return nil
+	}
+	if dt == K8sDeploymentStateless ||
+		dt == K8sDeploymentStateful ||
+		dt == K8sDeploymentDaemon {
+		return nil
+	}
+	return errors.NotSupportedf("deployment type %q", dt)
+}
+
+const (
+	K8sDeploymentStateless K8sDeploymentType = "stateless"
+	K8sDeploymentStateful  K8sDeploymentType = "stateful"
+	K8sDeploymentDaemon    K8sDeploymentType = "daemon"
+)

--- a/domain/application/package_mock_test.go
+++ b/domain/application/package_mock_test.go
@@ -13,6 +13,7 @@ import (
 	reflect "reflect"
 
 	caas "github.com/juju/juju/caas"
+	k8s "github.com/juju/juju/core/k8s"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -40,7 +41,7 @@ func (m *MockBroker) EXPECT() *MockBrokerMockRecorder {
 }
 
 // Application mocks base method.
-func (m *MockBroker) Application(arg0 string, arg1 caas.DeploymentType) caas.Application {
+func (m *MockBroker) Application(arg0 string, arg1 k8s.K8sDeploymentType) caas.Application {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Application", arg0, arg1)
 	ret0, _ := ret[0].(caas.Application)
@@ -66,13 +67,13 @@ func (c *MockBrokerApplicationCall) Return(arg0 caas.Application) *MockBrokerApp
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockBrokerApplicationCall) Do(f func(string, caas.DeploymentType) caas.Application) *MockBrokerApplicationCall {
+func (c *MockBrokerApplicationCall) Do(f func(string, k8s.K8sDeploymentType) caas.Application) *MockBrokerApplicationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockBrokerApplicationCall) DoAndReturn(f func(string, caas.DeploymentType) caas.Application) *MockBrokerApplicationCall {
+func (c *MockBrokerApplicationCall) DoAndReturn(f func(string, k8s.K8sDeploymentType) caas.Application) *MockBrokerApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/application/package_mock_test.go
+++ b/domain/application/package_mock_test.go
@@ -41,7 +41,7 @@ func (m *MockBroker) EXPECT() *MockBrokerMockRecorder {
 }
 
 // Application mocks base method.
-func (m *MockBroker) Application(arg0 string, arg1 k8s.K8sDeploymentType) caas.Application {
+func (m *MockBroker) Application(arg0 string, arg1 k8s.WorkloadType) caas.Application {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Application", arg0, arg1)
 	ret0, _ := ret[0].(caas.Application)
@@ -67,13 +67,13 @@ func (c *MockBrokerApplicationCall) Return(arg0 caas.Application) *MockBrokerApp
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockBrokerApplicationCall) Do(f func(string, k8s.K8sDeploymentType) caas.Application) *MockBrokerApplicationCall {
+func (c *MockBrokerApplicationCall) Do(f func(string, k8s.WorkloadType) caas.Application) *MockBrokerApplicationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockBrokerApplicationCall) DoAndReturn(f func(string, k8s.K8sDeploymentType) caas.Application) *MockBrokerApplicationCall {
+func (c *MockBrokerApplicationCall) DoAndReturn(f func(string, k8s.WorkloadType) caas.Application) *MockBrokerApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/application/service/application.go
+++ b/domain/application/service/application.go
@@ -726,7 +726,7 @@ func (s *Service) UpdateCloudService(ctx context.Context, appName, providerID st
 // Broker provides access to the k8s cluster to guery the scale
 // of a specified application.
 type Broker interface {
-	Application(string, k8s.K8sDeploymentType) caas.Application
+	Application(string, k8s.WorkloadType) caas.Application
 }
 
 // GetApplicationLife looks up the life of the specified application, returning

--- a/domain/application/service/application.go
+++ b/domain/application/service/application.go
@@ -17,6 +17,7 @@ import (
 	"github.com/juju/juju/core/config"
 	coreconstraints "github.com/juju/juju/core/constraints"
 	coreerrors "github.com/juju/juju/core/errors"
+	"github.com/juju/juju/core/k8s"
 	corelife "github.com/juju/juju/core/life"
 	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/network"
@@ -725,7 +726,7 @@ func (s *Service) UpdateCloudService(ctx context.Context, appName, providerID st
 // Broker provides access to the k8s cluster to guery the scale
 // of a specified application.
 type Broker interface {
-	Application(string, caas.DeploymentType) caas.Application
+	Application(string, k8s.K8sDeploymentType) caas.Application
 }
 
 // GetApplicationLife looks up the life of the specified application, returning

--- a/domain/application/service/package_mock_test.go
+++ b/domain/application/service/package_mock_test.go
@@ -3698,31 +3698,70 @@ func (c *MockProviderConstraintsValidatorCall) DoAndReturn(f func(envcontext.Pro
 	return c
 }
 
-// MockSupportedFeatureProvider is a mock of SupportedFeatureProvider interface.
-type MockSupportedFeatureProvider struct {
+// MockK8sProvider is a mock of K8sProvider interface.
+type MockK8sProvider struct {
 	ctrl     *gomock.Controller
-	recorder *MockSupportedFeatureProviderMockRecorder
+	recorder *MockK8sProviderMockRecorder
 }
 
-// MockSupportedFeatureProviderMockRecorder is the mock recorder for MockSupportedFeatureProvider.
-type MockSupportedFeatureProviderMockRecorder struct {
-	mock *MockSupportedFeatureProvider
+// MockK8sProviderMockRecorder is the mock recorder for MockK8sProvider.
+type MockK8sProviderMockRecorder struct {
+	mock *MockK8sProvider
 }
 
-// NewMockSupportedFeatureProvider creates a new mock instance.
-func NewMockSupportedFeatureProvider(ctrl *gomock.Controller) *MockSupportedFeatureProvider {
-	mock := &MockSupportedFeatureProvider{ctrl: ctrl}
-	mock.recorder = &MockSupportedFeatureProviderMockRecorder{mock}
+// NewMockK8sProvider creates a new mock instance.
+func NewMockK8sProvider(ctrl *gomock.Controller) *MockK8sProvider {
+	mock := &MockK8sProvider{ctrl: ctrl}
+	mock.recorder = &MockK8sProviderMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockSupportedFeatureProvider) EXPECT() *MockSupportedFeatureProviderMockRecorder {
+func (m *MockK8sProvider) EXPECT() *MockK8sProviderMockRecorder {
 	return m.recorder
 }
 
+// DesiredReplicas mocks base method.
+func (m *MockK8sProvider) DesiredReplicas(name string) (int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DesiredReplicas", name)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DesiredReplicas indicates an expected call of DesiredReplicas.
+func (mr *MockK8sProviderMockRecorder) DesiredReplicas(name any) *MockK8sProviderDesiredReplicasCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DesiredReplicas", reflect.TypeOf((*MockK8sProvider)(nil).DesiredReplicas), name)
+	return &MockK8sProviderDesiredReplicasCall{Call: call}
+}
+
+// MockK8sProviderDesiredReplicasCall wrap *gomock.Call
+type MockK8sProviderDesiredReplicasCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockK8sProviderDesiredReplicasCall) Return(arg0 int, arg1 error) *MockK8sProviderDesiredReplicasCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockK8sProviderDesiredReplicasCall) Do(f func(string) (int, error)) *MockK8sProviderDesiredReplicasCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockK8sProviderDesiredReplicasCall) DoAndReturn(f func(string) (int, error)) *MockK8sProviderDesiredReplicasCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // SupportedFeatures mocks base method.
-func (m *MockSupportedFeatureProvider) SupportedFeatures() (assumes.FeatureSet, error) {
+func (m *MockK8sProvider) SupportedFeatures() (assumes.FeatureSet, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SupportedFeatures")
 	ret0, _ := ret[0].(assumes.FeatureSet)
@@ -3731,31 +3770,31 @@ func (m *MockSupportedFeatureProvider) SupportedFeatures() (assumes.FeatureSet, 
 }
 
 // SupportedFeatures indicates an expected call of SupportedFeatures.
-func (mr *MockSupportedFeatureProviderMockRecorder) SupportedFeatures() *MockSupportedFeatureProviderSupportedFeaturesCall {
+func (mr *MockK8sProviderMockRecorder) SupportedFeatures() *MockK8sProviderSupportedFeaturesCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SupportedFeatures", reflect.TypeOf((*MockSupportedFeatureProvider)(nil).SupportedFeatures))
-	return &MockSupportedFeatureProviderSupportedFeaturesCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SupportedFeatures", reflect.TypeOf((*MockK8sProvider)(nil).SupportedFeatures))
+	return &MockK8sProviderSupportedFeaturesCall{Call: call}
 }
 
-// MockSupportedFeatureProviderSupportedFeaturesCall wrap *gomock.Call
-type MockSupportedFeatureProviderSupportedFeaturesCall struct {
+// MockK8sProviderSupportedFeaturesCall wrap *gomock.Call
+type MockK8sProviderSupportedFeaturesCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockSupportedFeatureProviderSupportedFeaturesCall) Return(arg0 assumes.FeatureSet, arg1 error) *MockSupportedFeatureProviderSupportedFeaturesCall {
+func (c *MockK8sProviderSupportedFeaturesCall) Return(arg0 assumes.FeatureSet, arg1 error) *MockK8sProviderSupportedFeaturesCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockSupportedFeatureProviderSupportedFeaturesCall) Do(f func() (assumes.FeatureSet, error)) *MockSupportedFeatureProviderSupportedFeaturesCall {
+func (c *MockK8sProviderSupportedFeaturesCall) Do(f func() (assumes.FeatureSet, error)) *MockK8sProviderSupportedFeaturesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockSupportedFeatureProviderSupportedFeaturesCall) DoAndReturn(f func() (assumes.FeatureSet, error)) *MockSupportedFeatureProviderSupportedFeaturesCall {
+func (c *MockK8sProviderSupportedFeaturesCall) DoAndReturn(f func() (assumes.FeatureSet, error)) *MockK8sProviderSupportedFeaturesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/application/service/package_test.go
+++ b/domain/application/service/package_test.go
@@ -41,14 +41,14 @@ type baseSuite struct {
 
 	modelID model.UUID
 
-	state                     *MockState
-	charm                     *MockCharm
-	charmStore                *MockCharmStore
-	agentVersionGetter        *MockAgentVersionGetter
-	provider                  *MockProvider
-	supportedFeaturesProvider *MockSupportedFeatureProvider
-	leadership                *MockEnsurer
-	validator                 *MockValidator
+	state              *MockState
+	charm              *MockCharm
+	charmStore         *MockCharmStore
+	agentVersionGetter *MockAgentVersionGetter
+	provider           *MockProvider
+	k8sProvider        *MockK8sProvider
+	leadership         *MockEnsurer
+	validator          *MockValidator
 
 	storageRegistryGetter corestorage.ModelStorageRegistryGetter
 	clock                 *testclock.Clock
@@ -60,7 +60,7 @@ type baseSuite struct {
 func (s *baseSuite) setupMocksWithProvider(
 	c *gc.C,
 	providerGetter func(ctx context.Context) (Provider, error),
-	supportFeaturesProviderGetter func(ctx context.Context) (SupportedFeatureProvider, error),
+	supportFeaturesProviderGetter func(ctx context.Context) (K8sProvider, error),
 ) *gomock.Controller {
 	ctrl := gomock.NewController(c)
 
@@ -69,7 +69,7 @@ func (s *baseSuite) setupMocksWithProvider(
 
 	s.agentVersionGetter = NewMockAgentVersionGetter(ctrl)
 	s.provider = NewMockProvider(ctrl)
-	s.supportedFeaturesProvider = NewMockSupportedFeatureProvider(ctrl)
+	s.k8sProvider = NewMockK8sProvider(ctrl)
 	s.leadership = NewMockEnsurer(ctrl)
 
 	s.state = NewMockState(ctrl)
@@ -115,7 +115,7 @@ func (s *baseSuite) setupMocksWithStatusHistory(c *gc.C, statusHistory StatusHis
 
 	s.agentVersionGetter = NewMockAgentVersionGetter(ctrl)
 	s.provider = NewMockProvider(ctrl)
-	s.supportedFeaturesProvider = NewMockSupportedFeatureProvider(ctrl)
+	s.k8sProvider = NewMockK8sProvider(ctrl)
 	s.leadership = NewMockEnsurer(ctrl)
 
 	s.state = NewMockState(ctrl)
@@ -140,8 +140,8 @@ func (s *baseSuite) setupMocksWithStatusHistory(c *gc.C, statusHistory StatusHis
 		func(ctx context.Context) (Provider, error) {
 			return s.provider, nil
 		},
-		func(ctx context.Context) (SupportedFeatureProvider, error) {
-			return s.supportedFeaturesProvider, nil
+		func(ctx context.Context) (K8sProvider, error) {
+			return s.k8sProvider, nil
 		},
 		s.charmStore,
 		statusHistory,

--- a/domain/application/service/service.go
+++ b/domain/application/service/service.go
@@ -105,10 +105,11 @@ type Provider interface {
 	environs.ConstraintsChecker
 }
 
-// SupportedFeatureProvider defines the interface for interacting with the
-// a model provider that satisfies the SupportedFeatureEnumerator interface.
-type SupportedFeatureProvider interface {
+// K8sProvider defines the interface for interacting with underlying k8s model
+// provider.
+type K8sProvider interface {
 	environs.SupportedFeatureEnumerator
+	environs.DesiredReplicasGetter
 }
 
 // WatcherFactory instances return watchers for a given namespace and UUID.
@@ -160,7 +161,7 @@ func NewWatchableService(
 	watcherFactory WatcherFactory,
 	agentVersionGetter AgentVersionGetter,
 	provider providertracker.ProviderGetter[Provider],
-	supportedFeatureProvider providertracker.ProviderGetter[SupportedFeatureProvider],
+	supportedFeatureProvider providertracker.ProviderGetter[K8sProvider],
 	charmStore CharmStore,
 	statusHistory StatusHistory,
 	clock clock.Clock,

--- a/domain/application/service/unit.go
+++ b/domain/application/service/unit.go
@@ -10,6 +10,8 @@ import (
 	"github.com/juju/juju/core/agentbinary"
 	coreapplication "github.com/juju/juju/core/application"
 	coreerrors "github.com/juju/juju/core/errors"
+	coreapplication "github.com/juju/juju/core/application"
+	"github.com/juju/juju/core/k8s"
 	"github.com/juju/juju/core/leadership"
 	corelife "github.com/juju/juju/core/life"
 	coremodel "github.com/juju/juju/core/model"
@@ -372,12 +374,12 @@ func (s *Service) DeleteUnit(ctx context.Context, unitName coreunit.Name) error 
 // probably make it a service attribute once more use cases emerge.
 func (s *Service) CAASUnitTerminating(ctx context.Context, appName string, unitNum int, broker Broker) (bool, error) {
 	// TODO(sidecar): handle deployment other than statefulset
-	deploymentType := caas.DeploymentStateful
+	deploymentType := k8s.K8sDeploymentStateful
 	restart := true
 
 	switch deploymentType {
-	case caas.DeploymentStateful:
-		caasApp := broker.Application(appName, caas.DeploymentStateful)
+	case k8s.K8sDeploymentStateful:
+		caasApp := broker.Application(appName, k8s.K8sDeploymentStateful)
 		appState, err := caasApp.State()
 		if err != nil {
 			return false, errors.Capture(err)
@@ -393,7 +395,7 @@ func (s *Service) CAASUnitTerminating(ctx context.Context, appName string, unitN
 		if unitNum >= scaleInfo.Scale || unitNum >= appState.DesiredReplicas {
 			restart = false
 		}
-	case caas.DeploymentStateless, caas.DeploymentDaemon:
+	case k8s.K8sDeploymentStateless, k8s.K8sDeploymentDaemon:
 		// Both handled the same way.
 		restart = true
 	default:

--- a/domain/application/service/unit.go
+++ b/domain/application/service/unit.go
@@ -6,11 +6,9 @@ package service
 import (
 	"context"
 
-	"github.com/juju/juju/caas"
 	"github.com/juju/juju/core/agentbinary"
 	coreapplication "github.com/juju/juju/core/application"
 	coreerrors "github.com/juju/juju/core/errors"
-	coreapplication "github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/k8s"
 	"github.com/juju/juju/core/leadership"
 	corelife "github.com/juju/juju/core/life"
@@ -374,12 +372,12 @@ func (s *Service) DeleteUnit(ctx context.Context, unitName coreunit.Name) error 
 // probably make it a service attribute once more use cases emerge.
 func (s *Service) CAASUnitTerminating(ctx context.Context, appName string, unitNum int, broker Broker) (bool, error) {
 	// TODO(sidecar): handle deployment other than statefulset
-	deploymentType := k8s.K8sDeploymentStateful
+	deploymentType := k8s.WorkloadTypeStatefulSet
 	restart := true
 
 	switch deploymentType {
-	case k8s.K8sDeploymentStateful:
-		caasApp := broker.Application(appName, k8s.K8sDeploymentStateful)
+	case k8s.WorkloadTypeStatefulSet:
+		caasApp := broker.Application(appName, k8s.WorkloadTypeStatefulSet)
 		appState, err := caasApp.State()
 		if err != nil {
 			return false, errors.Capture(err)
@@ -395,7 +393,7 @@ func (s *Service) CAASUnitTerminating(ctx context.Context, appName string, unitN
 		if unitNum >= scaleInfo.Scale || unitNum >= appState.DesiredReplicas {
 			restart = false
 		}
-	case k8s.K8sDeploymentStateless, k8s.K8sDeploymentDaemon:
+	case k8s.WorkloadTypeDeployment, k8s.WorkloadTypeDaemonSet:
 		// Both handled the same way.
 		restart = true
 	default:

--- a/domain/application/service_test.go
+++ b/domain/application/service_test.go
@@ -17,6 +17,7 @@ import (
 	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/database"
+	"github.com/juju/juju/core/k8s"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/model"
 	coresecrets "github.com/juju/juju/core/secrets"
@@ -755,7 +756,7 @@ func (s *serviceSuite) TestCAASUnitTerminatingUnitNumLessThanScale(c *gc.C) {
 		DesiredReplicas: 6,
 	}, nil)
 	broker := application.NewMockBroker(ctrl)
-	broker.EXPECT().Application("foo", caas.DeploymentStateful).Return(app)
+	broker.EXPECT().Application("foo", k8s.K8sDeploymentStateful).Return(app)
 	willRestart, err := s.svc.CAASUnitTerminating(context.Background(), "foo", 1, broker)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(willRestart, jc.IsTrue)
@@ -775,7 +776,7 @@ func (s *serviceSuite) TestCAASUnitTerminatingUnitNumGreaterThanScale(c *gc.C) {
 		DesiredReplicas: 6,
 	}, nil)
 	broker := application.NewMockBroker(ctrl)
-	broker.EXPECT().Application("foo", caas.DeploymentStateful).Return(app)
+	broker.EXPECT().Application("foo", k8s.K8sDeploymentStateful).Return(app)
 	willRestart, err := s.svc.CAASUnitTerminating(context.Background(), "foo", 666, broker)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(willRestart, jc.IsFalse)
@@ -801,7 +802,7 @@ func (s *serviceSuite) TestCAASUnitTerminatingUnitNumLessThanDesired(c *gc.C) {
 		DesiredReplicas: 6,
 	}, nil)
 	broker := application.NewMockBroker(ctrl)
-	broker.EXPECT().Application("foo", caas.DeploymentStateful).Return(app)
+	broker.EXPECT().Application("foo", k8s.K8sDeploymentStateful).Return(app)
 	err := s.svc.SetApplicationScalingState(context.Background(), "foo", 6, false)
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -830,7 +831,7 @@ func (s *serviceSuite) TestCAASUnitTerminatingUnitNumGreaterThanDesired(c *gc.C)
 		DesiredReplicas: 1,
 	}, nil)
 	broker := application.NewMockBroker(ctrl)
-	broker.EXPECT().Application("foo", caas.DeploymentStateful).Return(app)
+	broker.EXPECT().Application("foo", k8s.K8sDeploymentStateful).Return(app)
 	err := s.svc.SetApplicationScalingState(context.Background(), "foo", 6, false)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/domain/application/watcher_test.go
+++ b/domain/application/watcher_test.go
@@ -710,7 +710,7 @@ func (s *watcherSuite) setupService(c *gc.C, factory domain.WatchableDBFactory) 
 	notSupportedProviderGetter := func(ctx context.Context) (service.Provider, error) {
 		return nil, coreerrors.NotSupported
 	}
-	notSupportedFeatureProviderGetter := func(ctx context.Context) (service.SupportedFeatureProvider, error) {
+	notSupportedFeatureProviderGetter := func(ctx context.Context) (service.K8sProvider, error) {
 		return nil, coreerrors.NotSupported
 	}
 

--- a/domain/secret/service_test.go
+++ b/domain/secret/service_test.go
@@ -135,7 +135,7 @@ func (s *serviceSuite) createSecret(c *gc.C, data map[string]string, valueRef *c
 		func(ctx context.Context) (applicationservice.Provider, error) {
 			return serviceProvider{}, nil
 		},
-		func(ctx context.Context) (applicationservice.SupportedFeatureProvider, error) {
+		func(ctx context.Context) (applicationservice.K8sProvider, error) {
 			return serviceProvider{}, nil
 		},
 		nil,
@@ -176,7 +176,7 @@ func (s *serviceSuite) createSecret(c *gc.C, data map[string]string, valueRef *c
 
 type serviceProvider struct {
 	applicationservice.Provider
-	applicationservice.SupportedFeatureProvider
+	applicationservice.K8sProvider
 }
 
 func (serviceProvider) ConstraintsValidator(ctx envcontext.ProviderCallContext) (constraints.Validator, error) {

--- a/domain/secret/watcher_test.go
+++ b/domain/secret/watcher_test.go
@@ -869,7 +869,7 @@ func (s *watcherSuite) setupUnits(c *gc.C, appName string) {
 		func(ctx context.Context) (applicationservice.Provider, error) {
 			return serviceProvider{}, nil
 		},
-		func(ctx context.Context) (applicationservice.SupportedFeatureProvider, error) {
+		func(ctx context.Context) (applicationservice.K8sProvider, error) {
 			return serviceProvider{}, nil
 		},
 		nil,

--- a/domain/services/model.go
+++ b/domain/services/model.go
@@ -190,7 +190,7 @@ func (s *ModelServices) Application() *applicationservice.WatchableService {
 		s.modelWatcherFactory("application"),
 		modelagentstate.NewState(changestream.NewTxnRunnerFactory(s.modelDB)),
 		providertracker.ProviderRunner[applicationservice.Provider](s.providerFactory, s.modelUUID.String()),
-		providertracker.ProviderRunner[applicationservice.SupportedFeatureProvider](s.providerFactory, s.modelUUID.String()),
+		providertracker.ProviderRunner[applicationservice.K8sProvider](s.providerFactory, s.modelUUID.String()),
 		charmstore.NewCharmStore(s.objectstore, logger.Child("charmstore")),
 		domain.NewStatusHistory(logger, s.clock),
 		s.clock,

--- a/environs/interface.go
+++ b/environs/interface.go
@@ -673,3 +673,9 @@ type CloudEndpointChecker interface {
 	// endpoint and returns nil if no problems.
 	ValidateCloudEndpoint(ctx context.Context) error
 }
+
+// DesiredReplicasGetter defines a method for getting the desired
+// replicas for a given application.
+type DesiredReplicasGetter interface {
+	DesiredReplicas(name string) (int, error)
+}

--- a/internal/worker/caasapplicationprovisioner/application.go
+++ b/internal/worker/caasapplicationprovisioner/application.go
@@ -15,6 +15,7 @@ import (
 	"github.com/juju/worker/v4/catacomb"
 
 	"github.com/juju/juju/caas"
+	"github.com/juju/juju/core/k8s"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/status"
@@ -110,7 +111,7 @@ func (a *appWorker) loop() error {
 	defer cancel()
 
 	// TODO(sidecar): support more than statefulset
-	app := a.broker.Application(a.name, caas.DeploymentStateful)
+	app := a.broker.Application(a.name, k8s.K8sDeploymentStateful)
 
 	// If the application no longer exists, return immediately. If it's in
 	// Dead state, ensure it's deleted and terminated.

--- a/internal/worker/caasapplicationprovisioner/application.go
+++ b/internal/worker/caasapplicationprovisioner/application.go
@@ -111,7 +111,7 @@ func (a *appWorker) loop() error {
 	defer cancel()
 
 	// TODO(sidecar): support more than statefulset
-	app := a.broker.Application(a.name, k8s.K8sDeploymentStateful)
+	app := a.broker.Application(a.name, k8s.WorkloadTypeStatefulSet)
 
 	// If the application no longer exists, return immediately. If it's in
 	// Dead state, ensure it's deleted and terminated.

--- a/internal/worker/caasapplicationprovisioner/application_test.go
+++ b/internal/worker/caasapplicationprovisioner/application_test.go
@@ -95,7 +95,7 @@ func (s *ApplicationWorkerSuite) TestLifeNotFound(c *gc.C) {
 	done := make(chan struct{})
 
 	gomock.InOrder(
-		broker.EXPECT().Application("test", k8s.K8sDeploymentStateful).Return(brokerApp),
+		broker.EXPECT().Application("test", k8s.WorkloadTypeStatefulSet).Return(brokerApp),
 		facade.EXPECT().Life(gomock.Any(), "test").DoAndReturn(func(ctx context.Context, appName string) (life.Value, error) {
 			close(done)
 			return "", errors.NotFoundf("test charm")
@@ -121,7 +121,7 @@ func (s *ApplicationWorkerSuite) TestLifeDead(c *gc.C) {
 	done := make(chan struct{})
 
 	gomock.InOrder(
-		broker.EXPECT().Application("test", k8s.K8sDeploymentStateful).Return(app),
+		broker.EXPECT().Application("test", k8s.WorkloadTypeStatefulSet).Return(app),
 		facade.EXPECT().Life(gomock.Any(), "test").Return(life.Dead, nil),
 		ops.EXPECT().AppDying(gomock.Any(), "test", app, life.Dead, facade, unitFacade, s.logger).Return(nil),
 		ops.EXPECT().AppDead(gomock.Any(), "test", app, broker, facade, unitFacade, clk, s.logger).
@@ -161,7 +161,7 @@ func (s *ApplicationWorkerSuite) TestWorker(c *gc.C) {
 	ops.EXPECT().RefreshApplicationStatus(gomock.Any(), "test", app, gomock.Any(), facade, s.logger).Return(nil).AnyTimes()
 
 	gomock.InOrder(
-		broker.EXPECT().Application("test", k8s.K8sDeploymentStateful).Return(app),
+		broker.EXPECT().Application("test", k8s.WorkloadTypeStatefulSet).Return(app),
 		facade.EXPECT().Life(gomock.Any(), "test").Return(life.Alive, nil),
 
 		ops.EXPECT().CheckCharmFormat(gomock.Any(), "test", gomock.Any(), gomock.Any()).Return(true, nil),
@@ -264,7 +264,7 @@ func (s *ApplicationWorkerSuite) TestWorkerStatusOnly(c *gc.C) {
 	ops.EXPECT().RefreshApplicationStatus(gomock.Any(), "test", app, gomock.Any(), facade, s.logger).Return(nil).AnyTimes()
 
 	gomock.InOrder(
-		broker.EXPECT().Application("test", k8s.K8sDeploymentStateful).Return(app),
+		broker.EXPECT().Application("test", k8s.WorkloadTypeStatefulSet).Return(app),
 		facade.EXPECT().Life(gomock.Any(), "test").Return(life.Alive, nil),
 
 		ops.EXPECT().CheckCharmFormat(gomock.Any(), "test", gomock.Any(), gomock.Any()).Return(true, nil),
@@ -339,7 +339,7 @@ func (s *ApplicationWorkerSuite) TestNotProvisionedRetry(c *gc.C) {
 	ops.EXPECT().RefreshApplicationStatus(gomock.Any(), "test", app, gomock.Any(), facade, s.logger).Return(nil).AnyTimes()
 
 	gomock.InOrder(
-		broker.EXPECT().Application("test", caas.DeploymentStateful).Return(app),
+		broker.EXPECT().Application("test", k8s.WorkloadTypeDeployment).Return(app),
 		facade.EXPECT().Life(gomock.Any(), "test").Return(life.Alive, nil),
 
 		ops.EXPECT().CheckCharmFormat(gomock.Any(), "test", gomock.Any(), gomock.Any()).Return(true, nil),

--- a/internal/worker/caasapplicationprovisioner/application_test.go
+++ b/internal/worker/caasapplicationprovisioner/application_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/juju/juju/caas"
 	caasmocks "github.com/juju/juju/caas/mocks"
+	"github.com/juju/juju/core/k8s"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/status"
@@ -94,7 +95,7 @@ func (s *ApplicationWorkerSuite) TestLifeNotFound(c *gc.C) {
 	done := make(chan struct{})
 
 	gomock.InOrder(
-		broker.EXPECT().Application("test", caas.DeploymentStateful).Return(brokerApp),
+		broker.EXPECT().Application("test", k8s.K8sDeploymentStateful).Return(brokerApp),
 		facade.EXPECT().Life(gomock.Any(), "test").DoAndReturn(func(ctx context.Context, appName string) (life.Value, error) {
 			close(done)
 			return "", errors.NotFoundf("test charm")
@@ -120,7 +121,7 @@ func (s *ApplicationWorkerSuite) TestLifeDead(c *gc.C) {
 	done := make(chan struct{})
 
 	gomock.InOrder(
-		broker.EXPECT().Application("test", caas.DeploymentStateful).Return(app),
+		broker.EXPECT().Application("test", k8s.K8sDeploymentStateful).Return(app),
 		facade.EXPECT().Life(gomock.Any(), "test").Return(life.Dead, nil),
 		ops.EXPECT().AppDying(gomock.Any(), "test", app, life.Dead, facade, unitFacade, s.logger).Return(nil),
 		ops.EXPECT().AppDead(gomock.Any(), "test", app, broker, facade, unitFacade, clk, s.logger).
@@ -160,7 +161,7 @@ func (s *ApplicationWorkerSuite) TestWorker(c *gc.C) {
 	ops.EXPECT().RefreshApplicationStatus(gomock.Any(), "test", app, gomock.Any(), facade, s.logger).Return(nil).AnyTimes()
 
 	gomock.InOrder(
-		broker.EXPECT().Application("test", caas.DeploymentStateful).Return(app),
+		broker.EXPECT().Application("test", k8s.K8sDeploymentStateful).Return(app),
 		facade.EXPECT().Life(gomock.Any(), "test").Return(life.Alive, nil),
 
 		ops.EXPECT().CheckCharmFormat(gomock.Any(), "test", gomock.Any(), gomock.Any()).Return(true, nil),
@@ -263,7 +264,7 @@ func (s *ApplicationWorkerSuite) TestWorkerStatusOnly(c *gc.C) {
 	ops.EXPECT().RefreshApplicationStatus(gomock.Any(), "test", app, gomock.Any(), facade, s.logger).Return(nil).AnyTimes()
 
 	gomock.InOrder(
-		broker.EXPECT().Application("test", caas.DeploymentStateful).Return(app),
+		broker.EXPECT().Application("test", k8s.K8sDeploymentStateful).Return(app),
 		facade.EXPECT().Life(gomock.Any(), "test").Return(life.Alive, nil),
 
 		ops.EXPECT().CheckCharmFormat(gomock.Any(), "test", gomock.Any(), gomock.Any()).Return(true, nil),

--- a/internal/worker/caasapplicationprovisioner/mocks/broker_mock.go
+++ b/internal/worker/caasapplicationprovisioner/mocks/broker_mock.go
@@ -14,6 +14,7 @@ import (
 	reflect "reflect"
 
 	caas "github.com/juju/juju/caas"
+	k8s "github.com/juju/juju/core/k8s"
 	names "github.com/juju/names/v6"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -80,7 +81,7 @@ func (c *MockCAASBrokerAnnotateUnitCall) DoAndReturn(f func(context.Context, str
 }
 
 // Application mocks base method.
-func (m *MockCAASBroker) Application(arg0 string, arg1 caas.DeploymentType) caas.Application {
+func (m *MockCAASBroker) Application(arg0 string, arg1 k8s.K8sDeploymentType) caas.Application {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Application", arg0, arg1)
 	ret0, _ := ret[0].(caas.Application)
@@ -106,13 +107,13 @@ func (c *MockCAASBrokerApplicationCall) Return(arg0 caas.Application) *MockCAASB
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockCAASBrokerApplicationCall) Do(f func(string, caas.DeploymentType) caas.Application) *MockCAASBrokerApplicationCall {
+func (c *MockCAASBrokerApplicationCall) Do(f func(string, k8s.K8sDeploymentType) caas.Application) *MockCAASBrokerApplicationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockCAASBrokerApplicationCall) DoAndReturn(f func(string, caas.DeploymentType) caas.Application) *MockCAASBrokerApplicationCall {
+func (c *MockCAASBrokerApplicationCall) DoAndReturn(f func(string, k8s.K8sDeploymentType) caas.Application) *MockCAASBrokerApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/caasapplicationprovisioner/mocks/broker_mock.go
+++ b/internal/worker/caasapplicationprovisioner/mocks/broker_mock.go
@@ -81,7 +81,7 @@ func (c *MockCAASBrokerAnnotateUnitCall) DoAndReturn(f func(context.Context, str
 }
 
 // Application mocks base method.
-func (m *MockCAASBroker) Application(arg0 string, arg1 k8s.K8sDeploymentType) caas.Application {
+func (m *MockCAASBroker) Application(arg0 string, arg1 k8s.WorkloadType) caas.Application {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Application", arg0, arg1)
 	ret0, _ := ret[0].(caas.Application)
@@ -107,13 +107,13 @@ func (c *MockCAASBrokerApplicationCall) Return(arg0 caas.Application) *MockCAASB
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockCAASBrokerApplicationCall) Do(f func(string, k8s.K8sDeploymentType) caas.Application) *MockCAASBrokerApplicationCall {
+func (c *MockCAASBrokerApplicationCall) Do(f func(string, k8s.WorkloadType) caas.Application) *MockCAASBrokerApplicationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockCAASBrokerApplicationCall) DoAndReturn(f func(string, k8s.K8sDeploymentType) caas.Application) *MockCAASBrokerApplicationCall {
+func (c *MockCAASBrokerApplicationCall) DoAndReturn(f func(string, k8s.WorkloadType) caas.Application) *MockCAASBrokerApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/caasapplicationprovisioner/worker.go
+++ b/internal/worker/caasapplicationprovisioner/worker.go
@@ -25,6 +25,7 @@ import (
 	charmscommon "github.com/juju/juju/api/common/charms"
 	api "github.com/juju/juju/api/controller/caasapplicationprovisioner"
 	"github.com/juju/juju/caas"
+	"github.com/juju/juju/core/k8s"
 	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/resource"
@@ -67,7 +68,7 @@ type CAASProvisionerFacade interface {
 
 // CAASBroker exposes CAAS broker functionality to a worker.
 type CAASBroker interface {
-	Application(string, caas.DeploymentType) caas.Application
+	Application(string, k8s.K8sDeploymentType) caas.Application
 	AnnotateUnit(ctx context.Context, appName string, podName string, unit names.UnitTag) error
 	Units(ctx context.Context, appName string) ([]caas.Unit, error)
 }

--- a/internal/worker/caasapplicationprovisioner/worker.go
+++ b/internal/worker/caasapplicationprovisioner/worker.go
@@ -68,7 +68,7 @@ type CAASProvisionerFacade interface {
 
 // CAASBroker exposes CAAS broker functionality to a worker.
 type CAASBroker interface {
-	Application(string, k8s.K8sDeploymentType) caas.Application
+	Application(string, k8s.WorkloadType) caas.Application
 	AnnotateUnit(ctx context.Context, appName string, podName string, unit names.UnitTag) error
 	Units(ctx context.Context, appName string) ([]caas.Unit, error)
 }

--- a/internal/worker/caasfirewaller/applicationworker.go
+++ b/internal/worker/caasfirewaller/applicationworker.go
@@ -106,7 +106,7 @@ func (w *applicationWorker) setUp(ctx context.Context) (err error) {
 	}
 
 	// TODO(sidecar): support deployment other than statefulset
-	app := w.broker.Application(w.appName, k8s.K8sDeploymentStateful)
+	app := w.broker.Application(w.appName, k8s.WorkloadTypeStatefulSet)
 	w.portMutator = app
 	w.serviceUpdater = app
 

--- a/internal/worker/caasfirewaller/applicationworker.go
+++ b/internal/worker/caasfirewaller/applicationworker.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/juju/juju/caas"
 	"github.com/juju/juju/core/application"
+	"github.com/juju/juju/core/k8s"
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/watcher"
@@ -105,7 +106,7 @@ func (w *applicationWorker) setUp(ctx context.Context) (err error) {
 	}
 
 	// TODO(sidecar): support deployment other than statefulset
-	app := w.broker.Application(w.appName, caas.DeploymentStateful)
+	app := w.broker.Application(w.appName, k8s.K8sDeploymentStateful)
 	w.portMutator = app
 	w.serviceUpdater = app
 

--- a/internal/worker/caasfirewaller/applicationworker_test.go
+++ b/internal/worker/caasfirewaller/applicationworker_test.go
@@ -124,7 +124,7 @@ func (s *appWorkerSuite) TestWorker(c *gc.C) {
 	gomock.InOrder(
 		s.firewallerAPI.EXPECT().WatchApplication(gomock.Any(), s.appName).Return(s.appsWatcher, nil),
 		s.portService.EXPECT().WatchOpenedPortsForApplication(gomock.Any(), s.appUUID).Return(s.portsWatcher, nil),
-		s.broker.EXPECT().Application(s.appName, k8s.K8sDeploymentStateful).Return(s.brokerApp),
+		s.broker.EXPECT().Application(s.appName, k8s.WorkloadTypeStatefulSet).Return(s.brokerApp),
 
 		// initial fetch.
 		s.portService.EXPECT().GetApplicationOpenedPortsByEndpoint(gomock.Any(), s.appUUID).Return(network.GroupedPortRanges{}, nil),

--- a/internal/worker/caasfirewaller/applicationworker_test.go
+++ b/internal/worker/caasfirewaller/applicationworker_test.go
@@ -17,6 +17,7 @@ import (
 	caasmocks "github.com/juju/juju/caas/mocks"
 	coreapplication "github.com/juju/juju/core/application"
 	applicationtesting "github.com/juju/juju/core/application/testing"
+	"github.com/juju/juju/core/k8s"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/core/watcher/watchertest"
@@ -123,7 +124,7 @@ func (s *appWorkerSuite) TestWorker(c *gc.C) {
 	gomock.InOrder(
 		s.firewallerAPI.EXPECT().WatchApplication(gomock.Any(), s.appName).Return(s.appsWatcher, nil),
 		s.portService.EXPECT().WatchOpenedPortsForApplication(gomock.Any(), s.appUUID).Return(s.portsWatcher, nil),
-		s.broker.EXPECT().Application(s.appName, caas.DeploymentStateful).Return(s.brokerApp),
+		s.broker.EXPECT().Application(s.appName, k8s.K8sDeploymentStateful).Return(s.brokerApp),
 
 		// initial fetch.
 		s.portService.EXPECT().GetApplicationOpenedPortsByEndpoint(gomock.Any(), s.appUUID).Return(network.GroupedPortRanges{}, nil),

--- a/internal/worker/caasfirewaller/broker.go
+++ b/internal/worker/caasfirewaller/broker.go
@@ -5,11 +5,12 @@ package caasfirewaller
 
 import (
 	"github.com/juju/juju/caas"
+	"github.com/juju/juju/core/k8s"
 )
 
 // CAASBroker exposes CAAS broker functionality to a worker.
 type CAASBroker interface {
-	Application(string, caas.DeploymentType) caas.Application
+	Application(string, k8s.K8sDeploymentType) caas.Application
 }
 
 // PortMutator exposes CAAS application functionality to a worker.

--- a/internal/worker/caasfirewaller/broker.go
+++ b/internal/worker/caasfirewaller/broker.go
@@ -10,7 +10,7 @@ import (
 
 // CAASBroker exposes CAAS broker functionality to a worker.
 type CAASBroker interface {
-	Application(string, k8s.K8sDeploymentType) caas.Application
+	Application(string, k8s.WorkloadType) caas.Application
 }
 
 // PortMutator exposes CAAS application functionality to a worker.

--- a/internal/worker/caasfirewaller/mocks/broker_mock.go
+++ b/internal/worker/caasfirewaller/mocks/broker_mock.go
@@ -41,7 +41,7 @@ func (m *MockCAASBroker) EXPECT() *MockCAASBrokerMockRecorder {
 }
 
 // Application mocks base method.
-func (m *MockCAASBroker) Application(arg0 string, arg1 k8s.K8sDeploymentType) caas.Application {
+func (m *MockCAASBroker) Application(arg0 string, arg1 k8s.WorkloadType) caas.Application {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Application", arg0, arg1)
 	ret0, _ := ret[0].(caas.Application)
@@ -67,13 +67,13 @@ func (c *MockCAASBrokerApplicationCall) Return(arg0 caas.Application) *MockCAASB
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockCAASBrokerApplicationCall) Do(f func(string, k8s.K8sDeploymentType) caas.Application) *MockCAASBrokerApplicationCall {
+func (c *MockCAASBrokerApplicationCall) Do(f func(string, k8s.WorkloadType) caas.Application) *MockCAASBrokerApplicationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockCAASBrokerApplicationCall) DoAndReturn(f func(string, k8s.K8sDeploymentType) caas.Application) *MockCAASBrokerApplicationCall {
+func (c *MockCAASBrokerApplicationCall) DoAndReturn(f func(string, k8s.WorkloadType) caas.Application) *MockCAASBrokerApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/caasfirewaller/mocks/broker_mock.go
+++ b/internal/worker/caasfirewaller/mocks/broker_mock.go
@@ -13,6 +13,7 @@ import (
 	reflect "reflect"
 
 	caas "github.com/juju/juju/caas"
+	k8s "github.com/juju/juju/core/k8s"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -40,7 +41,7 @@ func (m *MockCAASBroker) EXPECT() *MockCAASBrokerMockRecorder {
 }
 
 // Application mocks base method.
-func (m *MockCAASBroker) Application(arg0 string, arg1 caas.DeploymentType) caas.Application {
+func (m *MockCAASBroker) Application(arg0 string, arg1 k8s.K8sDeploymentType) caas.Application {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Application", arg0, arg1)
 	ret0, _ := ret[0].(caas.Application)
@@ -66,13 +67,13 @@ func (c *MockCAASBrokerApplicationCall) Return(arg0 caas.Application) *MockCAASB
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockCAASBrokerApplicationCall) Do(f func(string, caas.DeploymentType) caas.Application) *MockCAASBrokerApplicationCall {
+func (c *MockCAASBrokerApplicationCall) Do(f func(string, k8s.K8sDeploymentType) caas.Application) *MockCAASBrokerApplicationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockCAASBrokerApplicationCall) DoAndReturn(f func(string, caas.DeploymentType) caas.Application) *MockCAASBrokerApplicationCall {
+func (c *MockCAASBrokerApplicationCall) DoAndReturn(f func(string, k8s.K8sDeploymentType) caas.Application) *MockCAASBrokerApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/providertracker/caas_mock_test.go
+++ b/internal/worker/providertracker/caas_mock_test.go
@@ -15,8 +15,8 @@ import (
 
 	caas "github.com/juju/juju/caas"
 	constraints "github.com/juju/juju/core/constraints"
-	semversion "github.com/juju/juju/core/semversion"
 	k8s "github.com/juju/juju/core/k8s"
+	semversion "github.com/juju/juju/core/semversion"
 	environs "github.com/juju/juju/environs"
 	config "github.com/juju/juju/environs/config"
 	envcontext "github.com/juju/juju/environs/envcontext"
@@ -166,7 +166,7 @@ func (c *MockBrokerAnnotateUnitCall) DoAndReturn(f func(context.Context, string,
 }
 
 // Application mocks base method.
-func (m *MockBroker) Application(arg0 string, arg1 k8s.K8sDeploymentType) caas.Application {
+func (m *MockBroker) Application(arg0 string, arg1 k8s.WorkloadType) caas.Application {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Application", arg0, arg1)
 	ret0, _ := ret[0].(caas.Application)
@@ -192,13 +192,13 @@ func (c *MockBrokerApplicationCall) Return(arg0 caas.Application) *MockBrokerApp
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockBrokerApplicationCall) Do(f func(string, k8s.K8sDeploymentType) caas.Application) *MockBrokerApplicationCall {
+func (c *MockBrokerApplicationCall) Do(f func(string, k8s.WorkloadType) caas.Application) *MockBrokerApplicationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockBrokerApplicationCall) DoAndReturn(f func(string, k8s.K8sDeploymentType) caas.Application) *MockBrokerApplicationCall {
+func (c *MockBrokerApplicationCall) DoAndReturn(f func(string, k8s.WorkloadType) caas.Application) *MockBrokerApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/providertracker/caas_mock_test.go
+++ b/internal/worker/providertracker/caas_mock_test.go
@@ -16,6 +16,7 @@ import (
 	caas "github.com/juju/juju/caas"
 	constraints "github.com/juju/juju/core/constraints"
 	semversion "github.com/juju/juju/core/semversion"
+	k8s "github.com/juju/juju/core/k8s"
 	environs "github.com/juju/juju/environs"
 	config "github.com/juju/juju/environs/config"
 	envcontext "github.com/juju/juju/environs/envcontext"
@@ -165,7 +166,7 @@ func (c *MockBrokerAnnotateUnitCall) DoAndReturn(f func(context.Context, string,
 }
 
 // Application mocks base method.
-func (m *MockBroker) Application(arg0 string, arg1 caas.DeploymentType) caas.Application {
+func (m *MockBroker) Application(arg0 string, arg1 k8s.K8sDeploymentType) caas.Application {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Application", arg0, arg1)
 	ret0, _ := ret[0].(caas.Application)
@@ -191,13 +192,13 @@ func (c *MockBrokerApplicationCall) Return(arg0 caas.Application) *MockBrokerApp
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockBrokerApplicationCall) Do(f func(string, caas.DeploymentType) caas.Application) *MockBrokerApplicationCall {
+func (c *MockBrokerApplicationCall) Do(f func(string, k8s.K8sDeploymentType) caas.Application) *MockBrokerApplicationCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockBrokerApplicationCall) DoAndReturn(f func(string, caas.DeploymentType) caas.Application) *MockBrokerApplicationCall {
+func (c *MockBrokerApplicationCall) DoAndReturn(f func(string, k8s.K8sDeploymentType) caas.Application) *MockBrokerApplicationCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }


### PR DESCRIPTION
This patch adds the DesiredReplicas method to the environs interface.
It also removes the broker injection on CAASUnitTerminating by moving
the method to the provider service.

By doing this, we can directly use the provider instead of injecting a
(caas only) abstraction layer to a service method.

As a previous step, a new method to the kubernetes client was added which is actually
a subset of the returned structs by Application().
Also, since the goal of this is to have `DesiredReplicas()` as part of
the environs interface, we move the input type `DeploymentType` to core,
since leaving it in caas would create a circular dependency. 

## QA steps

Bootstrap on k8s and deploy a charm, then delete the application's pod and the unit should bounce (don't forget to push the image to microk8s first):

```
$ juju bootstrap microk8s c
$ juju add-model m
$ juju deploy snappass-test
$ microk8s.kubectl delete pod snappass-test-0  -n m
```
At this point, you should see the following logs, and the unit gets restarted:
```
unit-snappass-test-0: 16:43:44 INFO juju.worker.caasunitterminationworker terminating due to SIGTERM
controller-0: 16:43:44 INFO juju.services.application.status-history logger-tags:status-history,message:stopping charm software,namespace_id:snappass-test/0,namespace_name:unit-workload,since:2025-03-14T15:43:44Z,status:maintenance,category:status-history,data:null status-history (status: "maintenance", status-message: "stopping charm software")
controller-0: 16:43:44 INFO juju.services.application.status-history data:null,logger-tags:status-history,message:running stop hook,namespace_id:snappass-test/0,namespace_name:unit-agent,since:2025-03-14T15:43:44Z,status:executing,category:status-history status-history (status: "executing", status-message: "running stop hook")
unit-snappass-test-0: 16:43:44 INFO juju.worker.uniter.operation ran "stop" hook (via hook dispatching script: dispatch)
controller-0: 16:43:44 INFO juju.services.application.status-history namespace_id:snappass-test/0,namespace_name:unit-workload,since:2025-03-14T15:43:44Z,status:maintenance,category:status-history,data:null,logger-tags:status-history,message: status-history (status: "maintenance", status-message: "")
unit-snappass-test-0: 16:43:44 INFO juju.worker.uniter unit "snappass-test/0" shutting down: agent should be terminated
```


## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/

**Jira card:** JUJU-

