### PR TITLE
chore: remove context todo in environs

### DIFF
--- a/cmd/plugins/juju-metadata/generateagents.go
+++ b/cmd/plugins/juju-metadata/generateagents.go
@@ -132,7 +132,7 @@ func (c *generateAgentsCommand) Run(context *cmd.Context) error {
 	ss := simplestreams.NewSimpleStreams(simplestreams.DefaultDataSourceFactory())
 
 	fmt.Fprintf(context.Stdout, "Finding agent binaries in %s for stream %s.\n", c.metadataDir, c.stream)
-	toolsList, err := envtools.ReadList(sourceStorage, c.stream, -1, -1)
+	toolsList, err := envtools.ReadList(context, sourceStorage, c.stream, -1, -1)
 	if err == envtools.ErrNoTools {
 		if c.preventFallback {
 			return errors.Trace(err)

--- a/environs/bootstrap/bootstrap.go
+++ b/environs/bootstrap/bootstrap.go
@@ -316,9 +316,9 @@ func bootstrapIAAS(
 	cfg := environ.Config()
 
 	_, supportsNetworking := environs.SupportsNetworking(environ)
-	logger.Debugf(context.TODO(), "model %q supports application/machine networks: %v", cfg.Name(), supportsNetworking)
+	logger.Debugf(ctx, "model %q supports application/machine networks: %v", cfg.Name(), supportsNetworking)
 	disableNetworkManagement, _ := cfg.DisableNetworkManagement()
-	logger.Debugf(context.TODO(), "network management by juju enabled: %v", !disableNetworkManagement)
+	logger.Debugf(ctx, "network management by juju enabled: %v", !disableNetworkManagement)
 
 	var ss *simplestreams.Simplestreams
 	if value := ctx.Value(SimplestreamsFetcherContextKey); value == nil {
@@ -356,7 +356,7 @@ func bootstrapIAAS(
 
 		if args.BootstrapBase.Empty() && !detectedBase.Empty() {
 			args.BootstrapBase = detectedBase
-			logger.Debugf(context.TODO(), "auto-selecting bootstrap series %q", args.BootstrapBase.String())
+			logger.Debugf(ctx, "auto-selecting bootstrap series %q", args.BootstrapBase.String())
 		}
 		if args.BootstrapConstraints.Arch == nil &&
 			args.ModelConstraints.Arch == nil &&
@@ -367,7 +367,7 @@ func bootstrapIAAS(
 			if detector.UpdateModelConstraints() {
 				args.ModelConstraints.Arch = &arch
 			}
-			logger.Debugf(context.TODO(), "auto-selecting bootstrap arch %q", arch)
+			logger.Debugf(ctx, "auto-selecting bootstrap arch %q", arch)
 		}
 	}
 
@@ -613,7 +613,7 @@ func bootstrapIAAS(
 	if err != nil {
 		return errors.Annotatef(err, "expected tools for %q", result.Base.OS)
 	}
-	selectedToolsList, err := getBootstrapToolsVersion(matchingTools)
+	selectedToolsList, err := getBootstrapToolsVersion(ctx, matchingTools)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -969,7 +969,7 @@ func bootstrapImageMetadata(
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	logger.Debugf(context.TODO(), "constraints for image metadata lookup %v", imageConstraint)
+	logger.Debugf(ctx, "constraints for image metadata lookup %v", imageConstraint)
 
 	// Get image metadata from all data sources.
 	// Since order of data source matters, order of image metadata matters too. Append is important here.
@@ -977,36 +977,36 @@ func bootstrapImageMetadata(
 	for _, source := range sources {
 		sourceMetadata, _, err := imagemetadata.Fetch(ctx, fetcher, []simplestreams.DataSource{source}, imageConstraint)
 		if errors.Is(err, errors.NotFound) || errors.Is(err, errors.Unauthorized) {
-			logger.Debugf(context.TODO(), "ignoring image metadata in %s: %v", source.Description(), err)
+			logger.Debugf(ctx, "ignoring image metadata in %s: %v", source.Description(), err)
 			// Just keep looking...
 			continue
 		} else if err != nil {
 			// When we get an actual protocol/unexpected error, we need to stop.
 			return nil, errors.Annotatef(err, "failed looking for image metadata in %s", source.Description())
 		}
-		logger.Debugf(context.TODO(), "found %d image metadata in %s", len(sourceMetadata), source.Description())
+		logger.Debugf(ctx, "found %d image metadata in %s", len(sourceMetadata), source.Description())
 		publicImageMetadata = append(publicImageMetadata, sourceMetadata...)
 	}
 
-	logger.Debugf(context.TODO(), "found %d image metadata from all image data sources", len(publicImageMetadata))
+	logger.Debugf(ctx, "found %d image metadata from all image data sources", len(publicImageMetadata))
 	return publicImageMetadata, nil
 }
 
 // getBootstrapToolsVersion returns the newest tools from the given tools list.
-func getBootstrapToolsVersion(possibleTools coretools.List) (coretools.List, error) {
+func getBootstrapToolsVersion(ctx context.Context, possibleTools coretools.List) (coretools.List, error) {
 	if len(possibleTools) == 0 {
 		return nil, errors.New("no bootstrap agent binaries available")
 	}
 	var newVersion version.Number
 	newVersion, toolsList := possibleTools.Newest()
-	logger.Infof(context.TODO(), "newest version: %s", newVersion)
+	logger.Infof(ctx, "newest version: %s", newVersion)
 	bootstrapVersion := newVersion
 	// We should only ever bootstrap the exact same version as the client,
 	// or we risk bootstrap incompatibility.
 	if !isCompatibleVersion(newVersion, jujuversion.Current) {
 		compatibleVersion, compatibleTools := findCompatibleTools(possibleTools, jujuversion.Current)
 		if len(compatibleTools) == 0 {
-			logger.Infof(context.TODO(),
+			logger.Infof(ctx,
 				"failed to find %s agent binaries, will attempt to use %s",
 				jujuversion.Current, newVersion,
 			)
@@ -1014,7 +1014,7 @@ func getBootstrapToolsVersion(possibleTools coretools.List) (coretools.List, err
 			bootstrapVersion, toolsList = compatibleVersion, compatibleTools
 		}
 	}
-	logger.Infof(context.TODO(), "picked bootstrap agent binary version: %s", bootstrapVersion)
+	logger.Infof(ctx, "picked bootstrap agent binary version: %s", bootstrapVersion)
 	return toolsList, nil
 }
 
@@ -1078,17 +1078,17 @@ func setPrivateMetadataSources(ctx context.Context, fetcher imagemetadata.Simple
 		if !os.IsNotExist(err) {
 			return nil, errors.Annotate(err, "cannot access agent metadata")
 		}
-		logger.Debugf(context.TODO(), "no agent directory found, using default agent metadata source: %s", tools.DefaultBaseURL)
+		logger.Debugf(ctx, "no agent directory found, using default agent metadata source: %s", tools.DefaultBaseURL)
 	} else {
 		if ending == storage.BaseToolsPath {
 			// As the specified metadataDir ended in 'tools'
 			// assume that is the only metadata to find and return.
 			tools.DefaultBaseURL = filepath.Dir(metadataDir)
-			logger.Debugf(context.TODO(), "setting default agent metadata source: %s", tools.DefaultBaseURL)
+			logger.Debugf(ctx, "setting default agent metadata source: %s", tools.DefaultBaseURL)
 			return nil, nil
 		} else {
 			tools.DefaultBaseURL = metadataDir
-			logger.Debugf(context.TODO(), "setting default agent metadata source: %s", tools.DefaultBaseURL)
+			logger.Debugf(ctx, "setting default agent metadata source: %s", tools.DefaultBaseURL)
 		}
 	}
 
@@ -1103,7 +1103,7 @@ func setPrivateMetadataSources(ctx context.Context, fetcher imagemetadata.Simple
 		}
 		return nil, nil
 	} else {
-		logger.Debugf(context.TODO(), "setting default image metadata source: %s", imageMetadataDir)
+		logger.Debugf(ctx, "setting default image metadata source: %s", imageMetadataDir)
 	}
 
 	baseURL := fmt.Sprintf("file://%s", filepath.ToSlash(imageMetadataDir))
@@ -1140,7 +1140,7 @@ func setPrivateMetadataSources(ctx context.Context, fetcher imagemetadata.Simple
 	environs.RegisterUserImageDataSourceFunc("bootstrap metadata", func(environs.Environ) (simplestreams.DataSource, error) {
 		return dataSource, nil
 	})
-	logger.Infof(context.TODO(), "custom image metadata added to search path")
+	logger.Infof(ctx, "custom image metadata added to search path")
 	return existingMetadata, nil
 }
 

--- a/environs/bootstrap/bootstrap_test.go
+++ b/environs/bootstrap/bootstrap_test.go
@@ -939,7 +939,7 @@ func (s *bootstrapSuite) TestBootstrapToolsVersion(c *gc.C) {
 		err = env.SetConfig(context.Background(), cfg)
 		c.Assert(err, jc.ErrorIsNil)
 		s.PatchValue(&jujuversion.Current, t.currentVersion)
-		tools, err := bootstrap.GetBootstrapToolsVersion(availableTools)
+		tools, err := bootstrap.GetBootstrapToolsVersion(context.Background(), availableTools)
 		c.Assert(err, jc.ErrorIsNil)
 		c.Assert(tools, gc.Not(gc.HasLen), 0)
 		toolsVersion, _ := tools.Newest()

--- a/environs/bootstrap/prepare.go
+++ b/environs/bootstrap/prepare.go
@@ -4,8 +4,6 @@
 package bootstrap
 
 import (
-	"context"
-
 	"github.com/juju/errors"
 	"github.com/juju/names/v6"
 
@@ -254,7 +252,7 @@ func prepare(
 		if len(args.Cloud.CACertificates) > 0 && args.Cloud.CACertificates[0] != "" {
 			return cfg, details, errors.NotValidf("cloud with both skip-TLS-verify=true and CA certificates")
 		}
-		logger.Warningf(context.TODO(), "controller %v is configured to skip validity checks on the server's certificate", args.ControllerName)
+		logger.Warningf(ctx, "controller %v is configured to skip validity checks on the server's certificate", args.ControllerName)
 	}
 
 	return cfg, details, nil

--- a/environs/bootstrap/tools.go
+++ b/environs/bootstrap/tools.go
@@ -78,9 +78,9 @@ func findPackagedTools(
 			vers = &agentVersion
 		}
 	}
-	logger.Infof(context.TODO(), "looking for bootstrap agent binaries: version=%v", vers)
+	logger.Infof(ctx, "looking for bootstrap agent binaries: version=%v", vers)
 	toolsList, findToolsErr := findBootstrapTools(ctx, env, ss, vers, arch, base)
-	logger.Infof(context.TODO(), "found %d packaged agent binaries", len(toolsList))
+	logger.Infof(ctx, "found %d packaged agent binaries", len(toolsList))
 	if findToolsErr != nil {
 		return nil, findToolsErr
 	}

--- a/environs/config/config.go
+++ b/environs/config/config.go
@@ -477,7 +477,7 @@ func New(withDefaults Defaulting, attrs map[string]any) (*Config, error) {
 	}
 
 	// no old config to compare against
-	if err := Validate(context.TODO(), c, nil); err != nil {
+	if err := Validate(context.Background(), c, nil); err != nil {
 		return nil, errors.Trace(err)
 	}
 	// Copy unknown attributes onto the type-specific map.

--- a/environs/imagemetadata.go
+++ b/environs/imagemetadata.go
@@ -43,7 +43,7 @@ func RegisterUserImageDataSourceFunc(id string, f ImageDataSourceFunc) {
 			return
 		}
 	}
-	logger.Debugf(context.TODO(), "new user image datasource registered: %v", id)
+	logger.Debugf(context.Background(), "new user image datasource registered: %v", id)
 	datasourceFuncs = append([]datasourceFuncId{{id, f}}, datasourceFuncs...)
 }
 
@@ -59,7 +59,7 @@ func RegisterImageDataSourceFunc(id string, f ImageDataSourceFunc) {
 			return
 		}
 	}
-	logger.Debugf(context.TODO(), "new model image datasource registered: %v", id)
+	logger.Debugf(context.Background(), "new model image datasource registered: %v", id)
 	datasourceFuncs = append(datasourceFuncs, datasourceFuncId{id, f})
 }
 
@@ -104,7 +104,7 @@ func ImageMetadataSources(env BootstrapEnviron, dataSourceFactory simplestreams.
 		sources = append(sources, dataSource)
 	}
 
-	envDataSources, err := environmentDataSources(env)
+	envDataSources, err := environmentDataSources(context.TODO(), env)
 	if err != nil {
 		return nil, err
 	}
@@ -130,13 +130,13 @@ func ImageMetadataSources(env BootstrapEnviron, dataSourceFactory simplestreams.
 // environmentDataSources returns simplestreams datasources for the environment
 // by calling the functions registered in RegisterImageDataSourceFunc.
 // The datasources returned will be in the same order the functions were registered.
-func environmentDataSources(bootstrapEnviron BootstrapEnviron) ([]simplestreams.DataSource, error) {
+func environmentDataSources(ctx context.Context, bootstrapEnviron BootstrapEnviron) ([]simplestreams.DataSource, error) {
 	datasourceFuncsMu.RLock()
 	defer datasourceFuncsMu.RUnlock()
 	var datasources []simplestreams.DataSource
 	env, ok := bootstrapEnviron.(Environ)
 	if !ok {
-		logger.Debugf(context.TODO(), "environmentDataSources is supported for IAAS, environ %#v is not Environ", bootstrapEnviron)
+		logger.Debugf(ctx, "environmentDataSources is supported for IAAS, environ %#v is not Environ", bootstrapEnviron)
 		// ignore for CAAS
 		return datasources, nil
 	}

--- a/environs/instances/image.go
+++ b/environs/instances/image.go
@@ -111,8 +111,9 @@ func FindInstanceSpec(possibleImages []Image, ic *InstanceConstraint, allInstanc
 	}
 	if len(specs) > 0 {
 		sort.Sort(byArch(specs))
-		logger.Infof(context.TODO(), "find instance - using %v image of type %v with id: %v", specs[0].Image.Arch, specs[0].InstanceType.Name, specs[0].Image.Id)
-		return specs[0], nil
+		spec := specs[0]
+		logger.Infof(context.TODO(), "find instance - using %v image of type %v with id: %v", spec.Image.Arch, spec.InstanceType.Name, spec.Image.Id)
+		return spec, nil
 	}
 
 	names := make([]string, len(matchingTypes))

--- a/environs/manual/sshprovisioner/provisioner.go
+++ b/environs/manual/sshprovisioner/provisioner.go
@@ -21,13 +21,13 @@ var (
 func ProvisionMachine(ctx context.Context, args manual.ProvisionMachineArgs) (machineId string, err error) {
 	defer func() {
 		if machineId != "" && err != nil {
-			logger.Errorf(context.TODO(), "provisioning failed, removing machine %v: %v", machineId, err)
+			logger.Errorf(ctx, "provisioning failed, removing machine %v: %v", machineId, err)
 			results, cleanupErr := args.Client.DestroyMachinesWithParams(ctx, false, false, false, nil, machineId)
 			if cleanupErr == nil {
 				cleanupErr = results[0].Error
 			}
 			if cleanupErr != nil {
-				logger.Errorf(context.TODO(), "error cleaning up machine: %s", cleanupErr)
+				logger.Errorf(ctx, "error cleaning up machine: %s", cleanupErr)
 			}
 			machineId = ""
 		}
@@ -60,7 +60,7 @@ func ProvisionMachine(ctx context.Context, args manual.ProvisionMachineArgs) (ma
 	})
 
 	if err != nil {
-		logger.Errorf(context.TODO(), "cannot obtain provisioning script")
+		logger.Errorf(ctx, "cannot obtain provisioning script")
 		return "", err
 	}
 
@@ -70,6 +70,6 @@ func ProvisionMachine(ctx context.Context, args manual.ProvisionMachineArgs) (ma
 		return machineId, err
 	}
 
-	logger.Infof(context.TODO(), "Provisioned machine %v", machineId)
+	logger.Infof(ctx, "Provisioned machine %v", machineId)
 	return machineId, nil
 }

--- a/environs/networking.go
+++ b/environs/networking.go
@@ -181,7 +181,7 @@ func SupportsContainerAddresses(ctx envcontext.ProviderCallContext, env Bootstra
 	ok, err := netEnv.SupportsContainerAddresses(ctx)
 	if err != nil {
 		if !errors.Is(err, errors.NotSupported) {
-			logger.Errorf(context.TODO(), "checking model container address support failed with: %v", err)
+			logger.Errorf(ctx, "checking model container address support failed with: %v", err)
 		}
 		return false
 	}

--- a/environs/simplestreams/datasource.go
+++ b/environs/simplestreams/datasource.go
@@ -209,7 +209,7 @@ func (h *urlDataSource) fetch(ctx context.Context, path string) (io.ReadCloser, 
 		// Callers of this mask the actual error.  Therefore warn here.
 		// This is called multiple times when a machine is created, we
 		// only need one success for images and one for tools.
-		logger.Warningf(context.TODO(), "Got error requesting %q: %v", path, err)
+		logger.Warningf(ctx, "Got error requesting %q: %v", path, err)
 		return nil, fmt.Errorf("cannot access URL %q: %w", path, err)
 	}
 	if resp.StatusCode != http.StatusOK {

--- a/environs/sync/sync_test.go
+++ b/environs/sync/sync_test.go
@@ -157,7 +157,7 @@ func (s *syncSuite) TestSyncing(c *gc.C) {
 			err := sync.SyncTools(context.Background(), test.ctx)
 			c.Assert(err, jc.ErrorIsNil)
 
-			ds, err := sync.SelectSourceDatasource(test.ctx)
+			ds, err := sync.SelectSourceDatasource(context.Background(), test.ctx)
 			c.Assert(err, jc.ErrorIsNil)
 
 			// This data source does not require to contain signed data.
@@ -339,7 +339,7 @@ func (s *uploadSuite) assertUploadedTools(c *gc.C, t *coretools.Tools, expectOST
 	s.assertEqualsCurrentVersion(c, t.Version)
 	expectRaw := downloadToolsRaw(c, t)
 
-	list, err := envtools.ReadList(s.targetStorage, stream, jujuversion.Current.Major, jujuversion.Current.Minor)
+	list, err := envtools.ReadList(context.Background(), s.targetStorage, stream, jujuversion.Current.Major, jujuversion.Current.Minor)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(list.AllReleases(), jc.SameContents, expectOSTypes)
 	for _, t := range list {

--- a/environs/testing/bootstrap.go
+++ b/environs/testing/bootstrap.go
@@ -35,7 +35,7 @@ func DisableFinishBootstrap() func() {
 		*instancecfg.InstanceConfig,
 		environs.BootstrapDialOpts,
 	) error {
-		logger.Infof(context.TODO(), "provider/common.FinishBootstrap is disabled")
+		logger.Infof(context.Background(), "provider/common.FinishBootstrap is disabled")
 		return nil
 	}
 	return testing.PatchValue(&common.FinishBootstrap, f)

--- a/environs/testing/tools.go
+++ b/environs/testing/tools.go
@@ -120,7 +120,7 @@ func PrimeTools(c *gc.C, stor storage.Storage, dataDir, toolsDir string, vers ve
 }
 
 func uploadFakeToolsVersion(stor storage.Storage, toolsDir string, vers version.Binary) (*coretools.Tools, error) {
-	logger.Infof(context.TODO(), "uploading FAKE tools %s", vers)
+	logger.Infof(context.Background(), "uploading FAKE tools %s", vers)
 	tgz, checksum := makeFakeTools(vers)
 	size := int64(len(tgz))
 	name := envtools.StorageName(vers, toolsDir)
@@ -157,7 +157,7 @@ func makeFakeTools(vers version.Binary) ([]byte, string) {
 func UploadFakeToolsVersions(store storage.Storage, toolsDir, stream string, versions ...version.Binary) ([]*coretools.Tools, error) {
 	// Leave existing tools alone.
 	existingTools := make(map[version.Binary]*coretools.Tools)
-	existing, _ := envtools.ReadList(store, toolsDir, 1, -1)
+	existing, _ := envtools.ReadList(context.Background(), store, toolsDir, 1, -1)
 	for _, tools := range existing {
 		existingTools[tools.Version] = tools
 	}

--- a/environs/tools/build_test.go
+++ b/environs/tools/build_test.go
@@ -7,6 +7,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"context"
 	"crypto/sha256"
 	"fmt"
 	"io"
@@ -96,7 +97,7 @@ func (b *buildSuite) TestFindExecutable(c *gc.C) {
 		execFile:   "non-existent-exec-file",
 		errorMatch: `could not find "non-existent-exec-file" in the path`,
 	}} {
-		result, err := tools.FindExecutable(test.execFile)
+		result, err := tools.FindExecutable(context.Background(), test.execFile)
 		if test.errorMatch == "" {
 			c.Assert(err, jc.ErrorIsNil)
 			c.Assert(result, gc.Equals, test.expected)
@@ -323,7 +324,9 @@ func (b *buildSuite) TestBundleToolsFailForOfficialBuildWithBuildAgent(c *gc.C) 
 		return version.Binary{}, true, nil
 	}
 
-	_, _, official, _, err := tools.BundleToolsForTest(true, bundleFile,
+	_, _, official, _, err := tools.BundleToolsForTest(
+		context.Background(),
+		true, bundleFile,
 		func(localBinaryVersion version.Number) version.Number { return version.MustParse("1.2.3.1") },
 		jujudVersion)
 	c.Assert(err, gc.ErrorMatches, `cannot build agent for official build`)
@@ -340,7 +343,9 @@ func (b *buildSuite) TestBundleToolsWriteForceVersionFileForOfficial(c *gc.C) {
 		return version.Binary{}, true, nil
 	}
 
-	_, forceVersion, official, _, err := tools.BundleToolsForTest(false, bundleFile,
+	_, forceVersion, official, _, err := tools.BundleToolsForTest(
+		context.Background(),
+		false, bundleFile,
 		func(localBinaryVersion version.Number) version.Number { return version.MustParse("1.2.3.1") },
 		jujudVersion)
 	c.Assert(err, jc.ErrorIsNil)

--- a/environs/tools/marshal.go
+++ b/environs/tools/marshal.go
@@ -28,7 +28,7 @@ func ProductMetadataPath(stream string) string {
 // MarshalToolsMetadataJSON marshals tools metadata to index and products JSON.
 // updated is the time at which the JSON file was updated.
 func MarshalToolsMetadataJSON(metadata map[string][]*ToolsMetadata, updated time.Time) (index, legacyIndex []byte, products map[string][]byte, err error) {
-	if index, legacyIndex, err = marshalToolsMetadataIndexJSON(metadata, updated); err != nil {
+	if index, legacyIndex, err = marshalToolsMetadataIndexJSON(context.TODO(), metadata, updated); err != nil {
 		return nil, nil, nil, err
 	}
 	if products, err = MarshalToolsMetadataProductsJSON(metadata, updated); err != nil {
@@ -39,7 +39,7 @@ func MarshalToolsMetadataJSON(metadata map[string][]*ToolsMetadata, updated time
 
 // marshalToolsMetadataIndexJSON marshals tools metadata to index JSON.
 // updated is the time at which the JSON file was updated.
-func marshalToolsMetadataIndexJSON(streamMetadata map[string][]*ToolsMetadata, updated time.Time) (out, outlegacy []byte, err error) {
+func marshalToolsMetadataIndexJSON(ctx context.Context, streamMetadata map[string][]*ToolsMetadata, updated time.Time) (out, outlegacy []byte, err error) {
 	var indices simplestreams.Indices
 	indices.Updated = updated.Format(time.RFC1123Z)
 	indices.Format = simplestreams.IndexFormat
@@ -55,7 +55,7 @@ func marshalToolsMetadataIndexJSON(streamMetadata map[string][]*ToolsMetadata, u
 			id, err := t.productId()
 			if err != nil {
 				if errors.Is(err, errors.NotValid) {
-					logger.Infof(context.TODO(), "ignoring tools metadata with unknown os type %q", t.Release)
+					logger.Infof(ctx, "ignoring tools metadata with unknown os type %q", t.Release)
 					continue
 				}
 				return nil, nil, err

--- a/environs/tools/marshal_test.go
+++ b/environs/tools/marshal_test.go
@@ -4,6 +4,7 @@
 package tools_test
 
 import (
+	"context"
 	"encoding/json"
 	"time"
 
@@ -250,7 +251,7 @@ var proposedToolMetadataForTesting = []*tools.ToolsMetadata{
 }
 
 func (s *marshalSuite) TestMarshalIndex(c *gc.C) {
-	index, legacyIndex, err := tools.MarshalToolsMetadataIndexJSON(s.streamMetadata, time.Unix(0, 0).UTC())
+	index, legacyIndex, err := tools.MarshalToolsMetadataIndexJSON(context.Background(), s.streamMetadata, time.Unix(0, 0).UTC())
 	c.Assert(err, jc.ErrorIsNil)
 	assertIndex(c, index, expectedIndex)
 	assertIndex(c, legacyIndex, expectedLegacyIndex)

--- a/environs/tools/simplestreams.go
+++ b/environs/tools/simplestreams.go
@@ -351,7 +351,7 @@ func MergeMetadata(tmlist1, tmlist2 []*ToolsMetadata) ([]*ToolsMetadata, error) 
 // ReadMetadata returns the tools metadata from the given storage for the specified stream.
 func ReadMetadata(ctx context.Context, ss SimplestreamsFetcher, store storage.StorageReader, stream string) ([]*ToolsMetadata, error) {
 	dataSource := storage.NewStorageSimpleStreamsDataSource("existing metadata", store, storage.BaseToolsPath, simplestreams.EXISTING_CLOUD_DATA, false)
-	toolsConstraint, err := makeToolsConstraint(simplestreams.CloudSpec{}, stream, -1, -1, coretools.Filter{})
+	toolsConstraint, err := makeToolsConstraint(ctx, simplestreams.CloudSpec{}, stream, -1, -1, coretools.Filter{})
 	if err != nil {
 		return nil, err
 	}

--- a/environs/tools/storage.go
+++ b/environs/tools/storage.go
@@ -37,11 +37,11 @@ func storagePrefix(stream string) string {
 // If minorVersion = -1, then only majorVersion is considered.
 // If majorVersion is -1, then all tools tarballs are used.
 // If store contains no such tools, it returns ErrNoMatches.
-func ReadList(stor storage.StorageReader, toolsDir string, majorVersion, minorVersion int) (coretools.List, error) {
+func ReadList(ctx context.Context, stor storage.StorageReader, toolsDir string, majorVersion, minorVersion int) (coretools.List, error) {
 	if minorVersion >= 0 {
-		logger.Debugf(context.TODO(), "reading v%d.%d agent binaries", majorVersion, minorVersion)
+		logger.Debugf(ctx, "reading v%d.%d agent binaries", majorVersion, minorVersion)
 	} else {
-		logger.Debugf(context.TODO(), "reading v%d.* agent binaries", majorVersion)
+		logger.Debugf(ctx, "reading v%d.* agent binaries", majorVersion)
 	}
 	storagePrefix := storagePrefix(toolsDir)
 	names, err := storage.List(stor, storagePrefix)
@@ -58,7 +58,7 @@ func ReadList(stor storage.StorageReader, toolsDir string, majorVersion, minorVe
 		var t coretools.Tools
 		vers := name[len(storagePrefix) : len(name)-len(toolSuffix)]
 		if t.Version, err = version.ParseBinary(vers); err != nil {
-			logger.Debugf(context.TODO(), "failed to parse version %q: %v", vers, err)
+			logger.Debugf(ctx, "failed to parse version %q: %v", vers, err)
 			continue
 		}
 		foundAnyTools = true
@@ -70,7 +70,7 @@ func ReadList(stor storage.StorageReader, toolsDir string, majorVersion, minorVe
 		if minorVersion >= 0 && t.Version.Minor != minorVersion {
 			continue
 		}
-		logger.Debugf(context.TODO(), "found %s", vers)
+		logger.Debugf(ctx, "found %s", vers)
 		if t.URL, err = stor.URL(name); err != nil {
 			return nil, err
 		}

--- a/environs/tools/storage_test.go
+++ b/environs/tools/storage_test.go
@@ -4,6 +4,8 @@
 package tools_test
 
 import (
+	"context"
+
 	jc "github.com/juju/testing/checkers"
 	"github.com/juju/version/v2"
 	gc "gopkg.in/check.v1"
@@ -30,7 +32,7 @@ func (s *StorageSuite) TestStorageName(c *gc.C) {
 func (s *StorageSuite) TestReadListEmpty(c *gc.C) {
 	stor, err := filestorage.NewFileStorageWriter(c.MkDir())
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = envtools.ReadList(stor, "released", 2, 0)
+	_, err = envtools.ReadList(context.Background(), stor, "released", 2, 0)
 	c.Assert(err, gc.Equals, envtools.ErrNoTools)
 }
 
@@ -52,20 +54,20 @@ func (s *StorageSuite) TestReadList(c *gc.C) {
 		minorVersion int
 		list coretools.List
 	}{{
-		-1, -1, coretools.List{t100, t101, t111, t201},
+		majorVersion: -1, minorVersion: -1, list: coretools.List{t100, t101, t111, t201},
 	}, {
-		1, 0, coretools.List{t100, t101},
+		majorVersion: 1, minorVersion: 0, list: coretools.List{t100, t101},
 	}, {
-		1, 1, coretools.List{t111},
+		majorVersion: 1, minorVersion: 1, list: coretools.List{t111},
 	}, {
-		1, -1, coretools.List{t100, t101, t111},
+		majorVersion: 1, minorVersion: -1, list: coretools.List{t100, t101, t111},
 	}, {
-		1, 2, nil,
+		majorVersion: 1, minorVersion: 2, list: nil,
 	}, {
-		3, 0, nil,
+		majorVersion: 3, minorVersion: 0, list: nil,
 	}} {
 		c.Logf("test %d", i)
-		list, err := envtools.ReadList(stor, "proposed", t.majorVersion, t.minorVersion)
+		list, err := envtools.ReadList(context.Background(), stor, "proposed", t.majorVersion, t.minorVersion)
 		if t.list != nil {
 			c.Assert(err, jc.ErrorIsNil)
 			// ReadList doesn't set the Size or SHA256, so blank out those attributes.

--- a/environs/tools/urls.go
+++ b/environs/tools/urls.go
@@ -87,7 +87,7 @@ func GetMetadataSources(env environs.BootstrapEnviron, dataSourceFactory simples
 		sources = append(sources, dataSource)
 	}
 
-	envDataSources, err := environmentDataSources(env)
+	envDataSources, err := environmentDataSources(context.TODO(), env)
 	if err != nil {
 		return nil, err
 	}
@@ -119,19 +119,19 @@ func GetMetadataSources(env environs.BootstrapEnviron, dataSourceFactory simples
 // environmentDataSources returns simplestreams datasources for the environment
 // by calling the functions registered in RegisterToolsDataSourceFunc.
 // The datasources returned will be in the same order the functions were registered.
-func environmentDataSources(bootstrapEnviron environs.BootstrapEnviron) ([]simplestreams.DataSource, error) {
+func environmentDataSources(ctx context.Context, bootstrapEnviron environs.BootstrapEnviron) ([]simplestreams.DataSource, error) {
 	toolsDatasourceFuncsMu.RLock()
 	defer toolsDatasourceFuncsMu.RUnlock()
 
 	var datasources []simplestreams.DataSource
 	env, ok := bootstrapEnviron.(environs.Environ)
 	if !ok {
-		logger.Debugf(context.TODO(), "environmentDataSources is supported for IAAS, environ %#v is not Environ", bootstrapEnviron)
+		logger.Debugf(ctx, "environmentDataSources is supported for IAAS, environ %#v is not Environ", bootstrapEnviron)
 		// ignore for CAAS
 		return datasources, nil
 	}
 	for _, f := range toolsDatasourceFuncs {
-		logger.Debugf(context.TODO(), "trying datasource %q", f.id)
+		logger.Debugf(ctx, "trying datasource %q", f.id)
 		datasource, err := f.f(env)
 		if err != nil {
 			if errors.Is(err, errors.NotSupported) {

--- a/environs/tools/versionfile.go
+++ b/environs/tools/versionfile.go
@@ -52,7 +52,7 @@ func (v *Versions) VersionsMatching(r io.Reader) ([]string, error) {
 // versionsMatchingHash returns all version numbers for which the SHA256
 // matches the hash passed in.
 func (v *Versions) versionsMatchingHash(h string) []string {
-	logger.Debugf(context.TODO(), "looking for sha256 %s", h)
+	logger.Debugf(context.Background(), "looking for sha256 %s", h)
 	var results []string
 	for i := range v.Versions {
 		if v.Versions[i].SHA256 == h {

--- a/environs/utils.go
+++ b/environs/utils.go
@@ -4,7 +4,6 @@
 package environs
 
 import (
-	"context"
 	"net"
 	"strconv"
 	"time"
@@ -37,7 +36,7 @@ func getAddresses(ctx envcontext.ProviderCallContext, instances []instances.Inst
 		}
 		addrs, err := inst.Addresses(ctx)
 		if err != nil {
-			logger.Debugf(context.TODO(),
+			logger.Debugf(ctx,
 				"failed to get addresses for %v: %v (ignoring)",
 				inst.Id(), err,
 			)
@@ -59,7 +58,7 @@ func waitAnyInstanceAddresses(
 	for a := AddressesRefreshAttempt.Start(); len(addrs) == 0 && a.Next(); {
 		instances, err := env.Instances(ctx, instanceIds)
 		if err != nil && err != ErrPartialInstances {
-			logger.Debugf(context.TODO(), "error getting state instances: %v", err)
+			logger.Debugf(ctx, "error getting state instances: %v", err)
 			return nil, err
 		}
 		addrs = getAddresses(ctx, instances)
@@ -79,7 +78,7 @@ func APIInfo(
 	if err != nil {
 		return nil, err
 	}
-	logger.Debugf(context.TODO(), "ControllerInstances returned: %v", instanceIds)
+	logger.Debugf(ctx, "ControllerInstances returned: %v", instanceIds)
 	addrs, err := waitAnyInstanceAddresses(env, ctx, instanceIds)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This removes most of the context.TODO() placeholders in the environs package. There is still a very small amount of them left, but they can be cleaned up at a later date. The strategy is to remove as many as possible.


## QA steps

Regression test should suffice here:

```sh
$ juju bootstrap lxd test
$ juju add-model default
$ juju deploy ubuntu
```
