### PR TITLE
chore: remove context todo in environs

### DIFF
--- a/internal/provider/azure/config.go
+++ b/internal/provider/azure/config.go
@@ -205,7 +205,7 @@ Please choose a model name of no more than %d characters.`,
 		loadBalancerSkuNameTitle := strings.Title(loadBalancerSkuName)
 		if loadBalancerSkuName != loadBalancerSkuNameTitle {
 			loadBalancerSkuName = loadBalancerSkuNameTitle
-			logger.Infof(context.TODO(), "using %q for config parameter %s", loadBalancerSkuName, configAttrLoadBalancerSkuName)
+			logger.Infof(ctx, "using %q for config parameter %s", loadBalancerSkuName, configAttrLoadBalancerSkuName)
 		}
 		if !isKnownLoadBalancerSkuName(loadBalancerSkuName) {
 			return nil, errors.Errorf(

--- a/internal/provider/azure/identity.go
+++ b/internal/provider/azure/identity.go
@@ -4,7 +4,6 @@
 package azure
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"sync"
@@ -160,7 +159,7 @@ func (env *azureEnviron) ensureControllerManagedIdentity(
 		Resources: res,
 	}
 
-	logger.Debugf(context.TODO(), "running deployment to create managed identity role assignment %s", identityName)
+	logger.Debugf(callCtx, "running deployment to create managed identity role assignment %s", identityName)
 	if err := env.createSubscriptionDeployment(
 		callCtx,
 		env.location,
@@ -171,7 +170,7 @@ func (env *azureEnviron) ensureControllerManagedIdentity(
 		// First cancel any in-progress deployment.
 		var wg sync.WaitGroup
 		var cancelResult error
-		logger.Debugf(context.TODO(), "canceling deployment for managed identity")
+		logger.Debugf(callCtx, "canceling deployment for managed identity")
 		wg.Add(1)
 		go func(id string) {
 			defer wg.Done()
@@ -187,7 +186,7 @@ func (env *azureEnviron) ensureControllerManagedIdentity(
 
 		// Then cleanup the resource group.
 		if err := env.Destroy(callCtx); err != nil {
-			logger.Errorf(context.TODO(), "failed to destroy controller: %v", err)
+			logger.Errorf(callCtx, "failed to destroy controller: %v", err)
 		}
 		return nil, errors.Trace(err)
 	}

--- a/internal/provider/azure/instance.go
+++ b/internal/provider/azure/instance.go
@@ -311,10 +311,10 @@ func (inst *azureInstance) openPortsOnGroup(
 			}
 		}
 		if found {
-			logger.Debugf(context.TODO(), "security rule %q already exists", ruleName)
+			logger.Debugf(ctx, "security rule %q already exists", ruleName)
 			continue
 		}
-		logger.Debugf(context.TODO(), "creating security rule %q", ruleName)
+		logger.Debugf(ctx, "creating security rule %q", ruleName)
 
 		priority, err := nextSecurityRulePriority(nsg, securityRuleInternalMax+1, securityRuleMax)
 		if err != nil {
@@ -400,7 +400,7 @@ func (inst *azureInstance) closePortsOnGroup(
 	singleSourceIngressRules := explodeIngressRules(rules)
 	for _, rule := range singleSourceIngressRules {
 		ruleName := securityRuleName(prefix, rule)
-		logger.Debugf(context.TODO(), "deleting security rule %q", ruleName)
+		logger.Debugf(ctx, "deleting security rule %q", ruleName)
 		poller, err := securityRules.BeginDelete(
 			ctx,
 			nsgInfo.resourceGroup, toValue(nsgInfo.securityGroup.Name), ruleName,

--- a/internal/provider/azure/internal/azureauth/serviceprincipal.go
+++ b/internal/provider/azure/internal/azureauth/serviceprincipal.go
@@ -222,7 +222,7 @@ func (c *ServicePrincipalCreator) ensureRoleDefinition(
 		roleDefinitionId, err = c.getExistingRoleDefinition(ctx, roleDefinitionClient, "", roleName)
 	}
 	if err == nil {
-		logger.Debugf(context.TODO(), "found existing role definition %q", roleDefinitionId)
+		logger.Debugf(ctx, "found existing role definition %q", roleDefinitionId)
 		return roleDefinitionId, nil
 	} else if !errors.Is(err, errors.NotFound) {
 		return "", errors.Annotate(err, "finding existing tenant scoped role definition")
@@ -272,7 +272,7 @@ func (c *ServicePrincipalCreator) ensureEnterpriseApplication(
 	result := resp.GetValue()
 	if len(result) > 0 {
 		id := toValue(result[0].GetAppId())
-		logger.Debugf(context.TODO(), "found existing Juju application %q", id)
+		logger.Debugf(ctx, "found existing Juju application %q", id)
 		return id, nil
 	}
 

--- a/internal/provider/azure/internal/azuretesting/senders.go
+++ b/internal/provider/azure/internal/azuretesting/senders.go
@@ -286,7 +286,7 @@ func SetResponseHeaderValues(resp *http.Response, h string, values []string) {
 type Senders []policy.Transporter
 
 func (s *Senders) Do(req *http.Request) (*http.Response, error) {
-	logger.Debugf(context.TODO(), "Senders.Do(%s)", req.URL)
+	logger.Debugf(req.Context(), "Senders.Do(%s)", req.URL)
 	if len(*s) == 0 {
 		response := NewResponseWithStatus("", http.StatusInternalServerError)
 		return response, fmt.Errorf("no sender for %q", req.URL)

--- a/internal/provider/azure/internal/tracing/tracing.go
+++ b/internal/provider/azure/internal/tracing/tracing.go
@@ -4,7 +4,6 @@
 package tracing
 
 import (
-	"context"
 	"net/http"
 	"net/http/httputil"
 
@@ -21,20 +20,20 @@ func (p *LoggingPolicy) Do(req *policy.Request) (*http.Response, error) {
 	if p.Logger.IsLevelEnabled(logger.TRACE) {
 		dump, err := httputil.DumpRequest(req.Raw(), true)
 		if err != nil {
-			p.Logger.Tracef(context.TODO(), "failed to dump request: %v", err)
-			p.Logger.Tracef(context.TODO(), "%+v", req.Raw())
+			p.Logger.Tracef(req.Raw().Context(), "failed to dump request: %v", err)
+			p.Logger.Tracef(req.Raw().Context(), "%+v", req.Raw())
 		} else {
-			p.Logger.Tracef(context.TODO(), "%s", dump)
+			p.Logger.Tracef(req.Raw().Context(), "%s", dump)
 		}
 	}
 	resp, err := req.Next()
 	if err == nil && p.Logger.IsLevelEnabled(logger.TRACE) {
 		dump, err := httputil.DumpResponse(resp, true)
 		if err != nil {
-			p.Logger.Tracef(context.TODO(), "failed to dump response: %v", err)
-			p.Logger.Tracef(context.TODO(), "%+v", resp)
+			p.Logger.Tracef(req.Raw().Context(), "failed to dump response: %v", err)
+			p.Logger.Tracef(req.Raw().Context(), "%+v", resp)
 		} else {
-			p.Logger.Tracef(context.TODO(), "%s", dump)
+			p.Logger.Tracef(req.Raw().Context(), "%s", dump)
 		}
 	}
 	return resp, err

--- a/internal/provider/common/bootstrap.go
+++ b/internal/provider/common/bootstrap.go
@@ -237,7 +237,7 @@ func BootstrapInstance(
 		// a blank StartInstanceParams.AvailabilityZone.
 		zones = []string{""}
 		if args.BootstrapConstraints.HasZones() {
-			logger.Debugf(context.TODO(), "environ doesn't support zones: ignoring bootstrap zone constraints")
+			logger.Debugf(callCtx, "environ doesn't support zones: ignoring bootstrap zone constraints")
 		}
 	} else if err != nil {
 		return nil, nil, nil, errors.Annotate(err, "cannot start bootstrap instance")
@@ -285,7 +285,7 @@ func BootstrapInstance(
 
 		if i < len(zones)-1 {
 			// Try the next zone.
-			logger.Debugf(context.TODO(), "failed to start instance in availability zone %q: %s", zone, err)
+			logger.Debugf(callCtx, "failed to start instance in availability zone %q: %s", zone, err)
 			continue
 		}
 		// This is the last zone in the list, error.

--- a/internal/provider/common/credentialinvalidator.go
+++ b/internal/provider/common/credentialinvalidator.go
@@ -128,7 +128,7 @@ func LegacyHandleCredentialError(isAuthError func(error) bool, err error, ctx en
 		converted := fmt.Errorf("cloud denied access: %w", CredentialNotValidError(err))
 		invalidateErr := ctx.InvalidateCredential(converted.Error())
 		if invalidateErr != nil {
-			logger.Warningf(context.TODO(), "could not invalidate stored cloud credential on the controller: %v", invalidateErr)
+			logger.Warningf(ctx, "could not invalidate stored cloud credential on the controller: %v", invalidateErr)
 		}
 	}
 	return denied

--- a/internal/provider/common/destroy.go
+++ b/internal/provider/common/destroy.go
@@ -4,7 +4,6 @@
 package common
 
 import (
-	"context"
 	"strings"
 
 	"github.com/juju/errors"
@@ -19,7 +18,7 @@ import (
 // environs.Environ; we strongly recommend that this implementation be
 // used when writing a new provider.
 func Destroy(env environs.Environ, ctx envcontext.ProviderCallContext) error {
-	logger.Infof(context.TODO(), "destroying model %q", env.Config().Name())
+	logger.Infof(ctx, "destroying model %q", env.Config().Name())
 	if err := destroyInstances(env, ctx); err != nil {
 		return errors.Annotate(err, "destroying instances")
 	}
@@ -30,7 +29,7 @@ func Destroy(env environs.Environ, ctx envcontext.ProviderCallContext) error {
 }
 
 func destroyInstances(env environs.Environ, ctx envcontext.ProviderCallContext) error {
-	logger.Infof(context.TODO(), "destroying instances")
+	logger.Infof(ctx, "destroying instances")
 	instances, err := env.AllInstances(ctx)
 	switch err {
 	case nil:
@@ -54,7 +53,7 @@ func destroyInstances(env environs.Environ, ctx envcontext.ProviderCallContext) 
 // source abstraction doesn't work well with dynamic, non-persistent
 // storage like tmpfs, rootfs, etc.
 func destroyStorage(env environs.Environ, ctx envcontext.ProviderCallContext) error {
-	logger.Infof(context.TODO(), "destroying storage")
+	logger.Infof(ctx, "destroying storage")
 	storageProviderTypes, err := env.StorageProviderTypes()
 	if err != nil {
 		return errors.Trace(err)

--- a/internal/provider/dummy/environs.go
+++ b/internal/provider/dummy/environs.go
@@ -397,7 +397,7 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, callCtx envcontext.Pr
 		return nil, errors.New("no CA certificate in controller configuration")
 	}
 
-	logger.Infof(context.TODO(), "would pick agent binaries from %s", availableTools)
+	logger.Infof(ctx, "would pick agent binaries from %s", availableTools)
 
 	estate, err := e.state()
 	if err != nil {
@@ -407,7 +407,7 @@ func (e *environ) Bootstrap(ctx environs.BootstrapContext, callCtx envcontext.Pr
 	defer estate.mu.Unlock()
 
 	// Create an instance for the bootstrap node.
-	logger.Infof(context.TODO(), "creating bootstrap instance")
+	logger.Infof(ctx, "creating bootstrap instance")
 	i := &dummyInstance{
 		id:           BootstrapInstanceId,
 		addresses:    network.NewMachineAddresses([]string{"localhost"}).AsProviderAddresses(),
@@ -560,10 +560,10 @@ func (e *environ) ConstraintsValidator(envcontext.ProviderCallContext) (constrai
 }
 
 // StartInstance is specified in the InstanceBroker interface.
-func (e *environ) StartInstance(_ envcontext.ProviderCallContext, args environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
+func (e *environ) StartInstance(ctx envcontext.ProviderCallContext, args environs.StartInstanceParams) (*environs.StartInstanceResult, error) {
 	defer delay()
 	machineId := args.InstanceConfig.MachineId
-	logger.Infof(context.TODO(), "dummy startinstance, machine %s", machineId)
+	logger.Infof(ctx, "dummy startinstance, machine %s", machineId)
 	if err := e.checkBroken("StartInstance"); err != nil {
 		return nil, err
 	}
@@ -592,13 +592,13 @@ func (e *environ) StartInstance(_ envcontext.ProviderCallContext, args environs.
 	if args.InstanceConfig.APIInfo.Tag != names.NewMachineTag(machineId) {
 		return nil, errors.New("entity tag must match started machine")
 	}
-	logger.Infof(context.TODO(), "would pick agent binaries from %s", args.Tools)
+	logger.Infof(ctx, "would pick agent binaries from %s", args.Tools)
 
 	idString := fmt.Sprintf("%s-%d", e.name, estate.maxId)
 	// Add the addresses we want to see in the machine doc. This means both
 	// IPv4 and IPv6 loopback, as well as the DNS name.
 	addrs := network.NewMachineAddresses([]string{idString + ".dns", "127.0.0.1", "::1"}).AsProviderAddresses()
-	logger.Debugf(context.TODO(), "StartInstance addresses: %v", addrs)
+	logger.Debugf(ctx, "StartInstance addresses: %v", addrs)
 	i := &dummyInstance{
 		id:           instance.Id(idString),
 		addresses:    addrs,

--- a/internal/provider/ec2/ebs.go
+++ b/internal/provider/ec2/ebs.go
@@ -390,7 +390,7 @@ func (v *ebsVolumeSource) CreateVolumes(ctx envcontext.ProviderCallContext, para
 	if instanceIds.Size() > 1 {
 		if err := instances.update(ctx, v.env.ec2Client, instanceIds.Values()...); err != nil {
 			err := v.env.HandleCredentialError(ctx, err)
-			logger.Debugf(context.TODO(), "querying running instances: %v", err)
+			logger.Debugf(ctx, "querying running instances: %v", err)
 			// We ignore the error, because we don't want an invalid
 			// InstanceId reference from one VolumeParams to prevent
 			// the creation of another volume.
@@ -425,7 +425,7 @@ func (v *ebsVolumeSource) createVolume(ctx envcontext.ProviderCallContext, p sto
 		if _, err := v.env.ec2Client.DeleteVolume(ctx, &ec2.DeleteVolumeInput{
 			VolumeId: volumeId,
 		}); err != nil {
-			logger.Errorf(context.TODO(), "error cleaning up volume %v: %v", *volumeId, v.env.HandleCredentialError(ctx, err))
+			logger.Errorf(ctx, "error cleaning up volume %v: %v", *volumeId, v.env.HandleCredentialError(ctx, err))
 		}
 	}()
 
@@ -602,13 +602,13 @@ func destroyVolume(ctx context.Context, client Client, volumeId string) (err err
 				// instance corresponding to a DeleteOnTermination
 				// attachment; in either case, the volume is or will
 				// be destroyed.
-				logger.Tracef(context.TODO(), "Ignoring error destroying volume %q: %v", volumeId, err)
+				logger.Tracef(ctx, "Ignoring error destroying volume %q: %v", volumeId, err)
 				err = nil
 			}
 		}
 	}()
 
-	logger.Debugf(context.TODO(), "destroying %q", volumeId)
+	logger.Debugf(ctx, "destroying %q", volumeId)
 
 	// Volumes must not be in-use when destroying. A volume may
 	// still be in-use when the instance it is attached to is
@@ -707,7 +707,7 @@ func destroyVolume(ctx context.Context, client Client, volumeId string) (err err
 }
 
 func releaseVolume(ctx context.Context, client Client, volumeId string) error {
-	logger.Debugf(context.TODO(), "releasing %q", volumeId)
+	logger.Debugf(ctx, "releasing %q", volumeId)
 	_, err := waitVolume(ctx, client, volumeId, destroyVolumeAttempt, func(volume *types.Volume) (bool, error) {
 		if volume.State == volumeStatusAvailable {
 			return true, nil
@@ -792,7 +792,7 @@ func (v *ebsVolumeSource) AttachVolumes(ctx envcontext.ProviderCallContext, atta
 	instances := make(instanceCache)
 	if err := instances.update(ctx, v.env.ec2Client, instIds.Values()...); err != nil {
 		err := v.env.HandleCredentialError(ctx, err)
-		logger.Debugf(context.TODO(), "querying running instances: %v", err)
+		logger.Debugf(ctx, "querying running instances: %v", err)
 		// We ignore the error, because we don't want an invalid
 		// InstanceId reference from one VolumeParams to prevent
 		// the creation of another volume.

--- a/internal/provider/ec2/environ.go
+++ b/internal/provider/ec2/environ.go
@@ -422,7 +422,7 @@ func (e *environ) parsePlacement(ctx envcontext.ProviderCallContext, placement s
 		}
 		return nil, fmt.Errorf("invalid availability zone %q", availabilityZone)
 	case "subnet":
-		logger.Debugf(context.TODO(), "searching for subnet matching placement directive %q", value)
+		logger.Debugf(ctx, "searching for subnet matching placement directive %q", value)
 		matcher := CreateSubnetMatcher(value)
 		// Get all known subnets, look for a match
 		subnets, vpcID, err := e.subnetsForVPC(ctx)
@@ -448,7 +448,7 @@ func (e *environ) parsePlacement(ctx envcontext.ProviderCallContext, placement s
 						}, nil
 					}
 				}
-				logger.Debugf(context.TODO(), "found a matching subnet (%v) but couldn't find the AZ", subnet)
+				logger.Debugf(ctx, "found a matching subnet (%v) but couldn't find the AZ", subnet)
 			}
 		}
 		return nil, fmt.Errorf("unable to find subnet %q in %v for vpi-id %q%w", value, subnetIDs, vpcID, errors.Hide(errors.NotFound))
@@ -553,7 +553,7 @@ func (e *environ) StartInstance(
 		}
 		if err := e.StopInstances(ctx, inst.Id()); err != nil {
 			_ = callback(ctx, status.Error, fmt.Sprintf("error stopping failed instance: %v", err), nil)
-			logger.Errorf(context.TODO(), "error stopping failed instance: %v", err)
+			logger.Errorf(ctx, "error stopping failed instance: %v", err)
 		}
 	}()
 
@@ -590,7 +590,7 @@ func (e *environ) StartInstance(
 		return nil, errors.Trace(err)
 	}
 
-	subnetZones, err := getValidSubnetZoneMap(args)
+	subnetZones, err := getValidSubnetZoneMap(ctx, args)
 	if err != nil {
 		return nil, environs.ZoneIndependentError(err)
 	}
@@ -625,6 +625,7 @@ func (e *environ) StartInstance(
 	}
 
 	spec, err := findInstanceSpec(
+		ctx,
 		args.InstanceConfig.IsController(),
 		args.ImageMetadata,
 		instanceTypes,
@@ -649,7 +650,7 @@ func (e *environ) StartInstance(
 	if err != nil {
 		return nil, environs.ZoneIndependentError(fmt.Errorf("constructing user data: %w", err))
 	}
-	logger.Debugf(context.TODO(), "ec2 user data; %d bytes", len(userData))
+	logger.Debugf(ctx, "ec2 user data; %d bytes", len(userData))
 
 	_ = callback(ctx, status.Allocating, "Setting up groups", nil)
 	groupIDs, err := e.setUpGroups(ctx, args.ControllerUUID, args.InstanceConfig.MachineId)
@@ -758,9 +759,9 @@ func (e *environ) StartInstance(
 	if hasVPCID {
 		instVPC := e.ecfg().vpcID()
 		instSubnet := aws.ToString(inst.i.SubnetId)
-		logger.Infof(context.TODO(), "started instance %q in AZ %q, subnet %q, VPC %q", inst.Id(), instAZ, instSubnet, instVPC)
+		logger.Infof(ctx, "started instance %q in AZ %q, subnet %q, VPC %q", inst.Id(), instAZ, instSubnet, instVPC)
 	} else {
-		logger.Infof(context.TODO(), "started instance %q in AZ %q", inst.Id(), instAZ)
+		logger.Infof(ctx, "started instance %q in AZ %q", inst.Id(), instAZ)
 	}
 
 	hc := instance.HardwareCharacteristics{
@@ -843,7 +844,7 @@ func (e *environ) finishInstanceConfig(args *environs.StartInstanceParams, spec 
 // requirements are congruent and can be met, and that the representative
 // subnet-zone map is returned, with Fan networks filtered out.
 // The returned map will be nil if there are no space requirements.
-func getValidSubnetZoneMap(args environs.StartInstanceParams) (map[network.Id][]string, error) {
+func getValidSubnetZoneMap(ctx context.Context, args environs.StartInstanceParams) (map[network.Id][]string, error) {
 	spaceCons := args.Constraints.IncludeSpaces()
 
 	bindings := set.NewStrings()
@@ -898,7 +899,7 @@ func getValidSubnetZoneMap(args environs.StartInstanceParams) (map[network.Id][]
 	// It will not take too much effort to enable multi-NIC support for EC2
 	// if we use them all when constructing the instance creation request.
 	if conCount > 1 || bindCount > 1 {
-		logger.Warningf(context.TODO(), "only considering the space requirement for %q", allSpaceReqs[indexInCommon])
+		logger.Warningf(ctx, "only considering the space requirement for %q", allSpaceReqs[indexInCommon])
 	}
 
 	// We should always have a mapping if there are space requirements,
@@ -908,7 +909,7 @@ func getValidSubnetZoneMap(args environs.StartInstanceParams) (map[network.Id][]
 	// panicking, log a warning and let the provisioning continue.
 	mappingCount := len(args.SubnetsToZones)
 	if mappingCount == 0 || mappingCount <= indexInCommon {
-		logger.Warningf(context.TODO(),
+		logger.Warningf(ctx,
 			"got space requirements, but not a valid subnet-zone map; constraints/bindings not applied")
 		return nil, nil
 	}
@@ -973,7 +974,7 @@ func (e *environ) selectSubnetForInstance(ctx envcontext.ProviderCallContext,
 	var subnet types.Subnet
 	if len(preferredSubnets) != 0 {
 		subnet = preferredSubnets[rand.Intn(len(preferredSubnets))]
-		logger.Debugf(context.TODO(),
+		logger.Debugf(ctx,
 			"selecting random preferred subnet %q from %d matching in zone %q",
 			*subnet.SubnetId,
 			len(preferredSubnets),
@@ -981,7 +982,7 @@ func (e *environ) selectSubnetForInstance(ctx envcontext.ProviderCallContext,
 		)
 	} else {
 		subnet = usableSubnets[rand.Intn(len(usableSubnets))]
-		logger.Debugf(context.TODO(),
+		logger.Debugf(ctx,
 			"selected random subnet %q from %d matching in zone %q",
 			*subnet.SubnetId,
 			len(usableSubnets),
@@ -1394,7 +1395,7 @@ func (e *environ) NetworkInterfaces(ctx envcontext.ProviderCallContext, ids []in
 		// Network interfaces are not currently tagged so we cannot
 		// use a model filter here.
 		filter := makeFilter("attachment.instance-id", need...)
-		logger.Tracef(context.TODO(), "retrieving NICs for instances %v", need)
+		logger.Tracef(ctx, "retrieving NICs for instances %v", need)
 		return e.gatherNetworkInterfaceInfo(ctx, filter, infos, idToInfosIndex, subMap)
 	}
 	err = retry.Call(retryStrategy)
@@ -1497,10 +1498,10 @@ func (e *environ) networkInterfacesForInstance(ctx envcontext.ProviderCallContex
 		return errors.Is(err, common.ErrorCredentialNotValid)
 	}
 	retryStrategy.NotifyFunc = func(lastError error, attempt int) {
-		logger.Errorf(context.TODO(), "failed to get instance %q interfaces: %v (retrying)", instId, lastError)
+		logger.Errorf(ctx, "failed to get instance %q interfaces: %v (retrying)", instId, lastError)
 	}
 	retryStrategy.Func = func() error {
-		logger.Tracef(context.TODO(), "retrieving NICs for instance %q", instId)
+		logger.Tracef(ctx, "retrieving NICs for instance %q", instId)
 		filter := makeFilter("attachment.instance-id", string(instId))
 
 		var err error
@@ -1512,11 +1513,11 @@ func (e *environ) networkInterfacesForInstance(ctx envcontext.ProviderCallContex
 		}
 		if len(resp.NetworkInterfaces) == 0 {
 			msg := fmt.Sprintf("instance %q has no NIC attachment yet, retrying...", instId)
-			logger.Tracef(context.TODO(), "%s", msg)
+			logger.Tracef(ctx, "%s", msg)
 			return errors.New(msg)
 		}
 		if logger.IsLevelEnabled(corelogger.TRACE) {
-			logger.Tracef(context.TODO(), "found instance %q NICs: %s", instId, pretty.Sprint(resp.NetworkInterfaces))
+			logger.Tracef(ctx, "found instance %q NICs: %s", instId, pretty.Sprint(resp.NetworkInterfaces))
 		}
 		return nil
 	}
@@ -1604,6 +1605,7 @@ func mapNetworkInterface(iface types.NetworkInterface, subnet types.Subnet) netw
 }
 
 func makeSubnetInfo(
+	ctx context.Context,
 	cidr string, subnetId, providerNetworkId network.Id, availZones []string,
 ) (network.SubnetInfo, error) {
 	_, _, err := net.ParseCIDR(cidr)
@@ -1618,7 +1620,7 @@ func makeSubnetInfo(
 		VLANTag:           0, // Not supported on EC2
 		AvailabilityZones: availZones,
 	}
-	logger.Tracef(context.TODO(), "found subnet with info %#v", info)
+	logger.Tracef(ctx, "found subnet with info %#v", info)
 	return info, nil
 
 }
@@ -1649,11 +1651,12 @@ func (e *environ) Subnets(
 		for _, iface := range interfaces {
 			_, ok := subIdSet[string(iface.ProviderSubnetId)]
 			if !ok {
-				logger.Tracef(context.TODO(), "subnet %q not in %v, skipping", iface.ProviderSubnetId, subnetIds)
+				logger.Tracef(ctx, "subnet %q not in %v, skipping", iface.ProviderSubnetId, subnetIds)
 				continue
 			}
 			subIdSet[string(iface.ProviderSubnetId)] = true
 			info, err := makeSubnetInfo(
+				ctx,
 				iface.PrimaryAddress().CIDR, iface.ProviderSubnetId, iface.ProviderNetworkId, iface.AvailabilityZones)
 			if err != nil {
 				// Error will already have been logged.
@@ -1676,12 +1679,13 @@ func (e *environ) Subnets(
 			subnetID := aws.ToString(subnet.SubnetId)
 			_, ok := subIdSet[subnetID]
 			if !ok {
-				logger.Tracef(context.TODO(), "subnet %q not in %v, skipping", subnetID, subnetIds)
+				logger.Tracef(ctx, "subnet %q not in %v, skipping", subnetID, subnetIds)
 				continue
 			}
 			subIdSet[subnetID] = true
 			cidr := aws.ToString(subnet.CidrBlock)
 			info, err := makeSubnetInfo(
+				ctx,
 				cidr, network.Id(subnetID), network.Id(aws.ToString(subnet.VpcId)), []string{aws.ToString(subnet.AvailabilityZone)})
 			if err != nil {
 				// Error will already have been logged.
@@ -1911,7 +1915,7 @@ func (e *environ) destroyControllerManagedModels(ctx envcontext.ProviderCallCont
 
 	instanceProfiles, err := listInstanceProfilesForController(ctx, e.iamClient, controllerUUID)
 	if errors.Is(err, errors.Unauthorized) {
-		logger.Warningf(context.TODO(), "unable to list Instance Profiles for deletion, Instance Profiles may have to be manually cleaned up for controller %q", controllerUUID)
+		logger.Warningf(ctx, "unable to list Instance Profiles for deletion, Instance Profiles may have to be manually cleaned up for controller %q", controllerUUID)
 	} else if err != nil {
 		return errors.Annotatef(err, "listing instance profiles for controller uuid %q", controllerUUID)
 	}
@@ -1925,7 +1929,7 @@ func (e *environ) destroyControllerManagedModels(ctx envcontext.ProviderCallCont
 
 	roles, err := listRolesForController(ctx, e.iamClient, controllerUUID)
 	if errors.Is(err, errors.Unauthorized) {
-		logger.Warningf(context.TODO(), "unable to list Roles for deletion, Roles may have to be manually cleaned up for controller %q", controllerUUID)
+		logger.Warningf(ctx, "unable to list Roles for deletion, Roles may have to be manually cleaned up for controller %q", controllerUUID)
 	} else if err != nil {
 		return errors.Annotatef(err, "listing roles for controller uuid %q", controllerUUID)
 	}
@@ -2098,7 +2102,7 @@ func (e *environ) OpenPorts(ctx envcontext.ProviderCallContext, rules firewall.I
 	if err := e.openPortsInGroup(ctx, e.globalGroupName(), rules); err != nil {
 		return errors.Trace(err)
 	}
-	logger.Infof(context.TODO(), "opened ports in global group: %v", rules)
+	logger.Infof(ctx, "opened ports in global group: %v", rules)
 	return nil
 }
 
@@ -2109,7 +2113,7 @@ func (e *environ) ClosePorts(ctx envcontext.ProviderCallContext, rules firewall.
 	if err := e.closePortsInGroup(ctx, e.globalGroupName(), rules); err != nil {
 		return errors.Trace(err)
 	}
-	logger.Infof(context.TODO(), "closed ports in global group: %v", rules)
+	logger.Infof(ctx, "closed ports in global group: %v", rules)
 	return nil
 }
 
@@ -2164,7 +2168,7 @@ func (e *environ) instanceSecurityGroups(ctx envcontext.ProviderCallContext, ins
 	var securityGroups []types.GroupIdentifier
 	for _, res := range resp.Reservations {
 		for _, inst := range res.Instances {
-			logger.Debugf(context.TODO(), "instance %q has security groups %s", aws.ToString(inst.InstanceId), pretty.Sprint(inst.SecurityGroups))
+			logger.Debugf(ctx, "instance %q has security groups %s", aws.ToString(inst.InstanceId), pretty.Sprint(inst.SecurityGroups))
 			securityGroups = append(securityGroups, inst.SecurityGroups...)
 		}
 	}
@@ -2208,7 +2212,7 @@ func (e *environ) cleanModelSecurityGroups(ctx envcontext.ProviderCallContext) e
 		return errors.Annotatef(err, "cannot retrieve security groups for model %q", e.uuid())
 	}
 	for _, g := range groups {
-		logger.Debugf(context.TODO(), "deleting model security group %q (%q)", aws.ToString(g.GroupName), aws.ToString(g.GroupId))
+		logger.Debugf(ctx, "deleting model security group %q (%q)", aws.ToString(g.GroupName), aws.ToString(g.GroupId))
 		if err := deleteSecurityGroupInsistently(ctx, e.ec2Client, g, clock.WallClock); err != nil {
 			return errors.Trace(e.HandleCredentialError(ctx, err))
 		}
@@ -2247,7 +2251,7 @@ func (e *environ) terminateInstances(ctx envcontext.ProviderCallContext, ids []i
 		if err == nil {
 			for i, sc := range resp {
 				if !terminatingStates.Contains(string(sc.CurrentState.Name)) {
-					logger.Warningf(context.TODO(), "instance %d has been terminated but is in state %q", ids[i], sc.CurrentState.Name)
+					logger.Warningf(ctx, "instance %d has been terminated but is in state %q", ids[i], sc.CurrentState.Name)
 				}
 			}
 		}
@@ -2279,7 +2283,7 @@ func (e *environ) terminateInstances(ctx envcontext.ProviderCallContext, ids []i
 		if err == nil {
 			scName := string(resp[0].CurrentState.Name)
 			if !terminatingStates.Contains(scName) {
-				logger.Warningf(context.TODO(), "instance %d has been terminated but is in state %q", id, scName)
+				logger.Warningf(ctx, "instance %d has been terminated but is in state %q", id, scName)
 			}
 			deletedIDs = append(deletedIDs, id)
 		}
@@ -2310,7 +2314,7 @@ var terminateInstancesById = func(ctx context.Context, ec2inst Client, ids ...in
 
 func (e *environ) deleteSecurityGroupsForInstances(ctx envcontext.ProviderCallContext, ids []instance.Id) {
 	if len(ids) == 0 {
-		logger.Debugf(context.TODO(), "no need to delete security groups: no intances were terminated successfully")
+		logger.Debugf(ctx, "no need to delete security groups: no intances were terminated successfully")
 		return
 	}
 
@@ -2318,7 +2322,7 @@ func (e *environ) deleteSecurityGroupsForInstances(ctx envcontext.ProviderCallCo
 	// instances that have been successfully terminated.
 	securityGroups, err := e.instanceSecurityGroups(ctx, ids, terminatingStates.Values()...)
 	if err != nil {
-		logger.Errorf(context.TODO(), "cannot determine security groups to delete: %v", err)
+		logger.Errorf(ctx, "cannot determine security groups to delete: %v", err)
 		return
 	}
 
@@ -2340,7 +2344,7 @@ func (e *environ) deleteSecurityGroupsForInstances(ctx envcontext.ProviderCallCo
 			// In this case, our failure to delete security group is reasonable: it's still in use.
 			// 2. Some security groups may be shared by multiple instances,
 			// for example, global firewalling. We should not delete these.
-			logger.Warningf(context.TODO(), "%v", e.HandleCredentialError(ctx, err))
+			logger.Warningf(ctx, "%v", e.HandleCredentialError(ctx, err))
 		}
 	}
 }
@@ -2364,7 +2368,7 @@ var deleteSecurityGroupInsistently = func(ctx context.Context, client SecurityGr
 				GroupId: g.GroupId,
 			})
 			if err == nil || isNotFoundError(err) {
-				logger.Debugf(context.TODO(), "deleting security group %q", aws.ToString(g.GroupName))
+				logger.Debugf(ctx, "deleting security group %q", aws.ToString(g.GroupName))
 				return nil
 			}
 			return errors.Trace(err)
@@ -2373,7 +2377,7 @@ var deleteSecurityGroupInsistently = func(ctx context.Context, client SecurityGr
 			return errors.Is(err, common.ErrorCredentialNotValid)
 		},
 		NotifyFunc: func(err error, attempt int) {
-			logger.Debugf(context.TODO(), "deleting security group %q, attempt %d (%v)", aws.ToString(g.GroupName), attempt, err)
+			logger.Debugf(ctx, "deleting security group %q, attempt %d (%v)", aws.ToString(g.GroupName), attempt, err)
 		},
 	})
 	if err != nil {
@@ -2534,7 +2538,7 @@ func (e *environ) ensureGroup(ctx envcontext.ProviderCallContext, name string, i
 		return types.SecurityGroup{}, errors.NotFoundf("security group %q%s", name, inVPCLogSuffix)
 	}
 	if len(groups) > 1 {
-		logger.Debugf(context.TODO(), "more than one security group with name %q", name)
+		logger.Debugf(ctx, "more than one security group with name %q", name)
 	}
 	group := groups[0]
 

--- a/internal/provider/ec2/environ_test.go
+++ b/internal/provider/ec2/environ_test.go
@@ -279,7 +279,7 @@ func (*Suite) TestGetValidSubnetZoneMapOneSpaceConstraint(c *gc.C) {
 		SubnetsToZones: allSubnetZones,
 	}
 
-	subnetZones, err := getValidSubnetZoneMap(args)
+	subnetZones, err := getValidSubnetZoneMap(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(subnetZones, gc.DeepEquals, allSubnetZones[0])
 }
@@ -299,7 +299,7 @@ func (*Suite) TestGetValidSubnetZoneMapOneBindingFanFiltered(c *gc.C) {
 		},
 	}
 
-	subnetZones, err := getValidSubnetZoneMap(args)
+	subnetZones, err := getValidSubnetZoneMap(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(subnetZones, gc.DeepEquals, map[network.Id][]string{
 		"sub-1": {"az-1"},
@@ -322,7 +322,7 @@ func (*Suite) TestGetValidSubnetZoneMapNoIntersectionError(c *gc.C) {
 		},
 	}
 
-	_, err := getValidSubnetZoneMap(args)
+	_, err := getValidSubnetZoneMap(context.Background(), args)
 	c.Assert(err, gc.ErrorMatches,
 		`unable to satisfy supplied space requirements; spaces: \[admin\], bindings: \[space-1\]`)
 }
@@ -349,7 +349,7 @@ func (*Suite) TestGetValidSubnetZoneMapIntersectionSelectsCorrectIndex(c *gc.C) 
 	// This should result in the selection of the same index from the
 	// subnets-to-zones map.
 
-	subnetZones, err := getValidSubnetZoneMap(args)
+	subnetZones, err := getValidSubnetZoneMap(context.Background(), args)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(subnetZones, gc.DeepEquals, allSubnetZones[1])
 }

--- a/internal/provider/ec2/environ_vpc_test.go
+++ b/internal/provider/ec2/environ_vpc_test.go
@@ -425,7 +425,7 @@ func (s *vpcSuite) TestCheckVPCRouteTableRoutesWithNoDefaultRoute(c *gc.C) {
 	c.Check(table.Routes, gc.HasLen, 0) // no routes at all
 
 	checkFailed := func() {
-		err := checkVPCRouteTableRoutes(&vpc, &table, &gateway)
+		err := checkVPCRouteTableRoutes(context.Background(), &vpc, &table, &gateway)
 		c.Assert(err, gc.ErrorMatches, `missing default route via gateway "igw-anything"`)
 		c.Check(err, jc.ErrorIs, errorVPCNotRecommended)
 	}
@@ -448,7 +448,7 @@ func (s *vpcSuite) TestCheckVPCRouteTableRoutesWithDefaultButNoLocalRoutes(c *gc
 	table.Routes = makeEC2Routes(gatewayID, "", types.RouteStateActive, 3) // default and 3 extra routes; no local route
 
 	checkFailed := func() {
-		err := checkVPCRouteTableRoutes(&vpc, &table, &gateway)
+		err := checkVPCRouteTableRoutes(context.Background(), &vpc, &table, &gateway)
 		c.Assert(err, gc.ErrorMatches, `missing local route with destination "0.1.0.0/16"`)
 		c.Check(err, jc.ErrorIs, errorVPCNotRecommended)
 	}
@@ -462,7 +462,7 @@ func (s *vpcSuite) TestCheckVPCRouteTableRoutesSuccess(c *gc.C) {
 	vpc, table, gateway := prepareCheckVPCRouteTableRoutesArgs()
 	table.Routes = makeEC2Routes(aws.ToString(gateway.InternetGatewayId), aws.ToString(vpc.CidrBlock), types.RouteStateActive, 3) // default, local and 3 extra routes
 
-	err := checkVPCRouteTableRoutes(&vpc, &table, &gateway)
+	err := checkVPCRouteTableRoutes(context.Background(), &vpc, &table, &gateway)
 	c.Assert(err, jc.ErrorIsNil)
 }
 

--- a/internal/provider/ec2/iam.go
+++ b/internal/provider/ec2/iam.go
@@ -215,7 +215,7 @@ func ensureControllerInstanceProfile(
 			InstanceProfileName: res.InstanceProfile.InstanceProfileName,
 		})
 		if err != nil {
-			logger.Errorf(context.TODO(), "cleanup delete instance profile %q: %v",
+			logger.Errorf(ctx, "cleanup delete instance profile %q: %v",
 				*res.InstanceProfile.InstanceProfileName,
 				err)
 		}
@@ -241,7 +241,7 @@ func ensureControllerInstanceProfile(
 			RoleName:            role.RoleName,
 		})
 		if err != nil {
-			logger.Errorf(context.TODO(), "cleanup remove role %q from instance profile %q: %v",
+			logger.Errorf(ctx, "cleanup remove role %q from instance profile %q: %v",
 				*role.RoleName,
 				*res.InstanceProfile.InstanceProfileName,
 				err)
@@ -288,7 +288,7 @@ func ensureControllerInstanceRole(
 			RoleName: res.Role.RoleName,
 		})
 		if err != nil {
-			logger.Errorf(context.TODO(), "cleanup delete role %q: %v",
+			logger.Errorf(ctx, "cleanup delete role %q: %v",
 				*res.Role.RoleName,
 				err)
 		}
@@ -310,7 +310,7 @@ func ensureControllerInstanceRole(
 			RoleName:   res.Role.RoleName,
 		})
 		if err != nil {
-			logger.Errorf(context.TODO(), "cleanup delete role %q policy %q: %v",
+			logger.Errorf(ctx, "cleanup delete role %q policy %q: %v",
 				*res.Role.RoleName,
 				roleName,
 				err)

--- a/internal/provider/ec2/image_test.go
+++ b/internal/provider/ec2/image_test.go
@@ -4,6 +4,8 @@
 package ec2
 
 import (
+	"context"
+
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -235,6 +237,7 @@ func (s *specSuite) TestFindInstanceSpec(c *gc.C) {
 		)
 		base := corebase.MakeDefaultBase("ubuntu", test.version)
 		spec, err := findInstanceSpec(
+			context.Background(),
 			false, // non-controller
 			imageMetadata,
 			testInstanceTypes,
@@ -260,6 +263,7 @@ func (s *specSuite) TestFindInstanceSpecNotSetCpuPowerWhenInstanceTypeSet(c *gc.
 
 	c.Check(instanceConstraint.Constraints.CpuPower, gc.IsNil)
 	_, err := findInstanceSpec(
+		context.Background(),
 		false, // non-controller
 		TestImageMetadata,
 		testInstanceTypes,
@@ -303,6 +307,7 @@ func (s *specSuite) TestFindInstanceSpecErrors(c *gc.C) {
 			c, TestImageMetadata, t.base.Channel.Track, t.arch,
 		)
 		_, err := findInstanceSpec(
+			context.Background(),
 			false, // non-controller
 			imageMetadata,
 			testInstanceTypes,
@@ -334,7 +339,7 @@ func filterImageMetadata(
 }
 
 func (*specSuite) TestFilterImagesAcceptsNil(c *gc.C) {
-	c.Check(filterImages(nil, nil), gc.HasLen, 0)
+	c.Check(filterImages(context.Background(), nil, nil), gc.HasLen, 0)
 }
 
 func (*specSuite) TestFilterImagesReturnsSelectively(c *gc.C) {
@@ -344,7 +349,7 @@ func (*specSuite) TestFilterImagesReturnsSelectively(c *gc.C) {
 	expectation := []*imagemetadata.ImageMetadata{&good}
 
 	ic := &instances.InstanceConstraint{Storage: []string{"ebs"}}
-	c.Check(filterImages(input, ic), gc.DeepEquals, expectation)
+	c.Check(filterImages(context.Background(), input, ic), gc.DeepEquals, expectation)
 }
 
 func (*specSuite) TestFilterImagesMaintainsOrdering(c *gc.C) {
@@ -354,5 +359,5 @@ func (*specSuite) TestFilterImagesMaintainsOrdering(c *gc.C) {
 		{Id: "three", Storage: "ebs"},
 	}
 	ic := &instances.InstanceConstraint{Storage: []string{"ebs"}}
-	c.Check(filterImages(input, ic), gc.DeepEquals, input)
+	c.Check(filterImages(context.Background(), input, ic), gc.DeepEquals, input)
 }

--- a/internal/provider/ec2/instance.go
+++ b/internal/provider/ec2/instance.go
@@ -115,7 +115,7 @@ func (inst *sdkInstance) OpenPorts(ctx envcontext.ProviderCallContext, machineId
 	if err := inst.e.openPortsInGroup(ctx, name, rules); err != nil {
 		return err
 	}
-	logger.Infof(context.TODO(), "opened ports in security group %s: %v", name, rules)
+	logger.Infof(ctx, "opened ports in security group %s: %v", name, rules)
 	return nil
 }
 
@@ -129,7 +129,7 @@ func (inst *sdkInstance) ClosePorts(ctx envcontext.ProviderCallContext, machineI
 	if err := inst.e.closePortsInGroup(ctx, name, ports); err != nil {
 		return err
 	}
-	logger.Infof(context.TODO(), "closed ports in security group %s: %v", name, ports)
+	logger.Infof(ctx, "closed ports in security group %s: %v", name, ports)
 	return nil
 }
 

--- a/internal/provider/gce/disks.go
+++ b/internal/provider/gce/disks.go
@@ -4,7 +4,6 @@
 package gce
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"sync"
@@ -139,7 +138,7 @@ func (v *volumeSource) CreateVolumes(ctx envcontext.ProviderCallContext, params 
 	instances := make(instanceCache)
 	if instanceIds.Size() > 1 {
 		if err := instances.update(v.gce, ctx, instanceIds.Values()...); err != nil {
-			logger.Debugf(context.TODO(), "querying running instances: %v", err)
+			logger.Debugf(ctx, "querying running instances: %v", err)
 			// We ignore the error, because we don't want an invalid
 			// InstanceId reference from one VolumeParams to prevent
 			// the creation of another volume.
@@ -158,7 +157,7 @@ func (v *volumeSource) CreateVolumes(ctx envcontext.ProviderCallContext, params 
 		volume, attachment, err := v.createOneVolume(ctx, p, instances)
 		if err != nil {
 			results[i].Error = err
-			logger.Errorf(context.TODO(), "could not create one volume (or attach it): %v", err)
+			logger.Errorf(ctx, "could not create one volume (or attach it): %v", err)
 			// ... Unless the error is due to an invalid credential, in which case, continuing with this call
 			// is pointless and creates an unnecessary churn: we know all calls will fail with the same error.
 			if google.HasDenialStatusCode(err) {
@@ -196,7 +195,7 @@ func (v *volumeSource) createOneVolume(ctx envcontext.ProviderCallContext, p sto
 			return
 		}
 		if err := v.gce.RemoveDisk(zone, volumeName); err != nil {
-			logger.Errorf(context.TODO(), "error cleaning up volume %v: %v", volumeName, google.HandleCredentialError(err, ctx))
+			logger.Errorf(ctx, "error cleaning up volume %v: %v", volumeName, google.HandleCredentialError(err, ctx))
 		}
 	}()
 
@@ -442,7 +441,7 @@ func (v *volumeSource) AttachVolumes(ctx envcontext.ProviderCallContext, attachP
 		instanceId := attachment.InstanceId
 		attached, err := v.attachOneVolume(ctx, volumeName, mode, instanceId.String())
 		if err != nil {
-			logger.Errorf(context.TODO(), "could not attach %q to %q: %v", volumeName, instanceId, err)
+			logger.Errorf(ctx, "could not attach %q to %q: %v", volumeName, instanceId, err)
 			results[i].Error = err
 			// ... Unless the error is due to an invalid credential, in which case, continuing with this call
 			// is pointless and creates an unnecessary churn: we know all calls will fail with the same error.

--- a/internal/provider/gce/environ_broker.go
+++ b/internal/provider/gce/environ_broker.go
@@ -48,7 +48,7 @@ func (env *environ) StartInstance(ctx envcontext.ProviderCallContext, args envir
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	logger.Infof(context.TODO(), "started instance %q in zone %q", raw.ID, raw.ZoneName)
+	logger.Infof(ctx, "started instance %q in zone %q", raw.ID, raw.ZoneName)
 	inst := newInstance(raw, env)
 
 	// Build the result.

--- a/internal/provider/gce/environ_instance.go
+++ b/internal/provider/gce/environ_instance.go
@@ -4,7 +4,6 @@
 package gce
 
 import (
-	"context"
 	"strings"
 
 	"github.com/juju/errors"
@@ -43,7 +42,7 @@ func (env *environ) Instances(ctx envcontext.ProviderCallContext, ids []instance
 		// for each ID into the result. If there is a problem then we
 		// will return either ErrPartialInstances or ErrNoInstances.
 		// TODO(ericsnow) Skip returning here only for certain errors?
-		logger.Errorf(context.TODO(), "failed to get instances from GCE: %v", err)
+		logger.Errorf(ctx, "failed to get instances from GCE: %v", err)
 		err = errors.Trace(err)
 	}
 
@@ -188,7 +187,7 @@ func (env *environ) checkInstanceType(ctx envcontext.ProviderCallContext, cons c
 	// fetch all instance types and check manually.
 	instTypesAndCosts, err := env.InstanceTypes(ctx, constraints.Value{})
 	if err != nil {
-		logger.Errorf(context.TODO(), "unable to fetch GCE instance types: %v", err)
+		logger.Errorf(ctx, "unable to fetch GCE instance types: %v", err)
 		return false
 	}
 

--- a/internal/provider/gce/google/errors.go
+++ b/internal/provider/gce/google/errors.go
@@ -4,7 +4,6 @@
 package google
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -79,7 +78,7 @@ func maybeInvalidateCredential(err error, ctx envcontext.ProviderCallContext) bo
 	converted := fmt.Errorf("google cloud denied access: %w", common.CredentialNotValidError(err))
 	invalidateErr := ctx.InvalidateCredential(converted.Error())
 	if invalidateErr != nil {
-		logger.Warningf(context.TODO(), "could not invalidate stored google cloud credential on the controller: %v", invalidateErr)
+		logger.Warningf(ctx, "could not invalidate stored google cloud credential on the controller: %v", invalidateErr)
 	}
 	return true
 }

--- a/internal/provider/lxd/environ_network.go
+++ b/internal/provider/lxd/environ_network.go
@@ -78,7 +78,7 @@ func (e *environ) Subnets(ctx envcontext.ProviderCallContext, inst instance.Id, 
 			// so this call will fail. If that's the case then
 			// use a fallback method for detecting subnets.
 			if isErrMissingAPIExtension(err, "network_state") {
-				return e.subnetDetectionFallback(srv, inst, keepList, availabilityZones)
+				return e.subnetDetectionFallback(ctx, srv, inst, keepList, availabilityZones)
 			}
 			return nil, errors.Annotatef(err, "querying lxd server for state of network %q", networkName)
 		}
@@ -125,8 +125,8 @@ func (e *environ) Subnets(ctx envcontext.ProviderCallContext, inst instance.Id, 
 // Caveat: this method offers lower data fidelity compared to Subnets() as it
 // cannot accurately detect the CIDRs for any host devices that are not bridged
 // into the container.
-func (e *environ) subnetDetectionFallback(srv Server, inst instance.Id, keepSubnetIDs set.Strings, availabilityZones network.AvailabilityZones) ([]network.SubnetInfo, error) {
-	logger.Warningf(context.TODO(), "falling back to subnet discovery via introspection of devices bridged to the controller container; consider upgrading to a newer LXD version and running 'juju reload-spaces' to get full subnet discovery for the LXD host")
+func (e *environ) subnetDetectionFallback(ctx context.Context, srv Server, inst instance.Id, keepSubnetIDs set.Strings, availabilityZones network.AvailabilityZones) ([]network.SubnetInfo, error) {
+	logger.Warningf(ctx, "falling back to subnet discovery via introspection of devices bridged to the controller container; consider upgrading to a newer LXD version and running 'juju reload-spaces' to get full subnet discovery for the LXD host")
 
 	// If no instance ID is specified, list the alive containers, query the
 	// state of the first one on the list and use it to extrapolate the

--- a/internal/provider/lxd/export_test.go
+++ b/internal/provider/lxd/export_test.go
@@ -4,6 +4,7 @@
 package lxd
 
 import (
+	"context"
 	"errors"
 	"net/http"
 
@@ -92,5 +93,5 @@ func GetImageSources(env environs.Environ) ([]lxd.ServerSpec, error) {
 	if !ok {
 		return nil, errors.New("not a LXD environ")
 	}
-	return lxdEnv.getImageSources()
+	return lxdEnv.getImageSources(context.Background())
 }

--- a/internal/provider/maas/environprovider.go
+++ b/internal/provider/maas/environprovider.go
@@ -59,7 +59,7 @@ func (EnvironProvider) Version() int {
 }
 
 func (EnvironProvider) Open(ctx context.Context, args environs.OpenParams, invalidator environs.CredentialInvalidator) (environs.Environ, error) {
-	logger.Debugf(context.TODO(), "opening model %q.", args.Config.Name())
+	logger.Debugf(ctx, "opening model %q.", args.Config.Name())
 	if err := validateCloudSpec(args.Cloud); err != nil {
 		return nil, errors.Annotate(err, "validating cloud spec")
 	}
@@ -80,13 +80,13 @@ func (p EnvironProvider) Ping(ctx envcontext.ProviderCallContext, endpoint strin
 	var err error
 	base, version, includesVersion := gomaasapi.SplitVersionedURL(endpoint)
 	if includesVersion {
-		err = p.checkMaas(base, version)
+		err = p.checkMaas(ctx, base, version)
 		if err == nil {
 			return nil
 		}
 	} else {
 		// No version info in the endpoint - try both in preference order.
-		err = p.checkMaas(endpoint, apiVersion2)
+		err = p.checkMaas(ctx, endpoint, apiVersion2)
 		if err == nil {
 			return nil
 		}
@@ -94,14 +94,14 @@ func (p EnvironProvider) Ping(ctx envcontext.ProviderCallContext, endpoint strin
 	return errors.Annotatef(err, "No MAAS server running at %s", endpoint)
 }
 
-func (p EnvironProvider) checkMaas(endpoint, ver string) error {
+func (p EnvironProvider) checkMaas(ctx context.Context, endpoint, ver string) error {
 	c, err := gomaasapi.NewAnonymousClient(endpoint, ver)
 	if err != nil {
-		logger.Debugf(context.TODO(), "Can't create maas API %s client for %q: %v", ver, endpoint, err)
+		logger.Debugf(ctx, "Can't create maas API %s client for %q: %v", ver, endpoint, err)
 		return errors.Trace(err)
 	}
 	maas := gomaasapi.NewMAAS(*c)
-	_, err = p.GetCapabilities(maas, endpoint)
+	_, err = p.GetCapabilities(ctx, maas, endpoint)
 	return errors.Trace(err)
 }
 

--- a/internal/provider/maas/environprovider_test.go
+++ b/internal/provider/maas/environprovider_test.go
@@ -141,7 +141,7 @@ func (s *MaasPingSuite) TestPingNoEndpoint(c *gc.C) {
 	endpoint := "https://foo.com/MAAS"
 	var serverURLs []string
 	err := ping(c, s.callCtx, endpoint,
-		func(client *gomaasapi.MAASObject, serverURL string) (set.Strings, error) {
+		func(ctx context.Context, client *gomaasapi.MAASObject, serverURL string) (set.Strings, error) {
 			serverURLs = append(serverURLs, client.URL().String())
 			c.Assert(serverURL, gc.Equals, endpoint)
 			return nil, errors.New("nope")
@@ -157,7 +157,7 @@ func (s *MaasPingSuite) TestPingOK(c *gc.C) {
 	endpoint := "https://foo.com/MAAS"
 	var serverURLs []string
 	err := ping(c, s.callCtx, endpoint,
-		func(client *gomaasapi.MAASObject, serverURL string) (set.Strings, error) {
+		func(ctx context.Context, client *gomaasapi.MAASObject, serverURL string) (set.Strings, error) {
 			serverURLs = append(serverURLs, client.URL().String())
 			c.Assert(serverURL, gc.Equals, endpoint)
 			return set.NewStrings("network-deployment-ubuntu"), nil
@@ -173,7 +173,7 @@ func (s *MaasPingSuite) TestPingVersionURLOK(c *gc.C) {
 	endpoint := "https://foo.com/MAAS/api/10.1/"
 	var serverURLs []string
 	err := ping(c, s.callCtx, endpoint,
-		func(client *gomaasapi.MAASObject, serverURL string) (set.Strings, error) {
+		func(ctx context.Context, client *gomaasapi.MAASObject, serverURL string) (set.Strings, error) {
 			serverURLs = append(serverURLs, client.URL().String())
 			c.Assert(serverURL, gc.Equals, "https://foo.com/MAAS/")
 			return set.NewStrings("network-deployment-ubuntu"), nil
@@ -189,7 +189,7 @@ func (s *MaasPingSuite) TestPingVersionURLBad(c *gc.C) {
 	endpoint := "https://foo.com/MAAS/api/10.1/"
 	var serverURLs []string
 	err := ping(c, s.callCtx, endpoint,
-		func(client *gomaasapi.MAASObject, serverURL string) (set.Strings, error) {
+		func(ctx context.Context, client *gomaasapi.MAASObject, serverURL string) (set.Strings, error) {
 			serverURLs = append(serverURLs, client.URL().String())
 			c.Assert(serverURL, gc.Equals, "https://foo.com/MAAS/")
 			return nil, errors.New("nope")

--- a/internal/provider/maas/instance.go
+++ b/internal/provider/maas/instance.go
@@ -84,11 +84,11 @@ func (mi *maasInstance) Addresses(ctx envcontext.ProviderCallContext) (corenetwo
 		if primAddr := iface.PrimaryAddress(); primAddr.Value != "" {
 			addresses = append(addresses, primAddr)
 		} else {
-			logger.Debugf(context.TODO(), "no address found on interface %q", iface.InterfaceName)
+			logger.Debugf(ctx, "no address found on interface %q", iface.InterfaceName)
 		}
 	}
 
-	logger.Debugf(context.TODO(), "%q has addresses %q", mi.machine.Hostname(), addresses)
+	logger.Debugf(ctx, "%q has addresses %q", mi.machine.Hostname(), addresses)
 	return addresses, nil
 }
 
@@ -101,14 +101,14 @@ func (mi *maasInstance) Status(ctx envcontext.ProviderCallContext) instance.Stat
 	// returning them.
 	statusName := mi.machine.StatusName()
 	statusMsg := mi.machine.StatusMessage()
-	return convertInstanceStatus(statusName, statusMsg, mi.Id())
+	return convertInstanceStatus(ctx, statusName, statusMsg, mi.Id())
 }
 
-func convertInstanceStatus(statusMsg, substatus string, id instance.Id) instance.Status {
+func convertInstanceStatus(ctx context.Context, statusMsg, substatus string, id instance.Id) instance.Status {
 	maasInstanceStatus := status.Empty
 	switch normalizeStatus(statusMsg) {
 	case "":
-		logger.Debugf(context.TODO(), "unable to obtain status of instance %s", id)
+		logger.Debugf(ctx, "unable to obtain status of instance %s", id)
 		statusMsg = "error in getting status"
 	case "deployed":
 		maasInstanceStatus = status.Running
@@ -138,17 +138,17 @@ func normalizeStatus(statusMsg string) string {
 
 // MAAS does not do firewalling so these port methods do nothing.
 
-func (mi *maasInstance) OpenPorts(_ envcontext.ProviderCallContext, _ string, _ firewall.IngressRules) error {
-	logger.Debugf(context.TODO(), "unimplemented OpenPorts() called")
+func (mi *maasInstance) OpenPorts(ctx envcontext.ProviderCallContext, _ string, _ firewall.IngressRules) error {
+	logger.Debugf(ctx, "unimplemented OpenPorts() called")
 	return nil
 }
 
-func (mi *maasInstance) ClosePorts(_ envcontext.ProviderCallContext, _ string, _ firewall.IngressRules) error {
-	logger.Debugf(context.TODO(), "unimplemented ClosePorts() called")
+func (mi *maasInstance) ClosePorts(ctx envcontext.ProviderCallContext, _ string, _ firewall.IngressRules) error {
+	logger.Debugf(ctx, "unimplemented ClosePorts() called")
 	return nil
 }
 
-func (mi *maasInstance) IngressRules(_ envcontext.ProviderCallContext, _ string) (firewall.IngressRules, error) {
-	logger.Debugf(context.TODO(), "unimplemented IngressRules() called")
+func (mi *maasInstance) IngressRules(ctx envcontext.ProviderCallContext, _ string) (firewall.IngressRules, error) {
+	logger.Debugf(ctx, "unimplemented IngressRules() called")
 	return nil, nil
 }

--- a/internal/provider/maas/interfaces.go
+++ b/internal/provider/maas/interfaces.go
@@ -4,7 +4,6 @@
 package maas
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -154,7 +153,7 @@ func (env *maasEnviron) networkInterfacesForInstance(ctx envcontext.ProviderCall
 }
 
 func maasNetworkInterfaces(
-	_ envcontext.ProviderCallContext,
+	ctx envcontext.ProviderCallContext,
 	instance *maasInstance,
 	subnetsMap map[string]corenetwork.Id,
 	dnsSearchDomains ...string,
@@ -206,7 +205,7 @@ func maasNetworkInterfaces(
 		}
 
 		if len(iface.Links()) == 0 {
-			logger.Debugf(context.TODO(), "interface %q has no links", iface.Name())
+			logger.Debugf(ctx, "interface %q has no links", iface.Name())
 			infos = append(infos, nicInfo)
 			continue
 		}
@@ -215,7 +214,7 @@ func maasNetworkInterfaces(
 			configType := maasLinkToInterfaceConfigType(link.Mode())
 
 			if link.IPAddress() == "" && link.Subnet() == nil {
-				logger.Debugf(context.TODO(), "interface %q link %d has neither subnet nor address", iface.Name(), link.ID())
+				logger.Debugf(ctx, "interface %q link %d has neither subnet nor address", iface.Name(), link.ID())
 				infos = append(infos, nicInfo)
 			} else {
 				// We set it here initially without a space, just so we don't
@@ -231,7 +230,7 @@ func maasNetworkInterfaces(
 
 			sub := link.Subnet()
 			if sub == nil {
-				logger.Debugf(context.TODO(), "interface %q link %d missing subnet", iface.Name(), link.ID())
+				logger.Debugf(ctx, "interface %q link %d missing subnet", iface.Name(), link.ID())
 				infos = append(infos, nicInfo)
 				continue
 			}
@@ -253,7 +252,7 @@ func maasNetworkInterfaces(
 			if !ok {
 				// The space we found is not recognised.
 				// No provider space info is available.
-				logger.Warningf(context.TODO(), "interface %q link %d has unrecognised space %q", iface.Name(), link.ID(), sub.Space())
+				logger.Warningf(ctx, "interface %q link %d has unrecognised space %q", iface.Name(), link.ID(), sub.Space())
 			} else {
 				nicInfo.Addresses[0].ProviderSpaceID = spaceId
 				nicInfo.ProviderSpaceId = spaceId

--- a/internal/provider/maas/volumes.go
+++ b/internal/provider/maas/volumes.go
@@ -181,6 +181,7 @@ func buildMAASVolumeParameters(args []storage.VolumeParams, cons constraints.Val
 }
 
 func (mi *maasInstance) volumes(
+	ctx context.Context,
 	mTag names.MachineTag, requestedVolumes []names.VolumeTag,
 ) (
 	[]storage.Volume, []storage.VolumeAttachment, error,
@@ -217,7 +218,7 @@ func (mi *maasInstance) volumes(
 			// This should never happen, as we only request one block
 			// device per label. If it does happen, we'll just report
 			// the first block device and log this warning.
-			logger.Warningf(context.TODO(),
+			logger.Warningf(ctx,
 				"expected 1 block device for label %s, received %d",
 				label, len(devices),
 			)

--- a/internal/provider/maas/volumes_test.go
+++ b/internal/provider/maas/volumes_test.go
@@ -4,6 +4,8 @@
 package maas
 
 import (
+	"context"
+
 	"github.com/juju/gomaasapi/v2"
 	"github.com/juju/names/v6"
 	"github.com/juju/testing"
@@ -98,13 +100,16 @@ func (s *volumeSuite) TestInstanceVolumesMAAS2(c *gc.C) {
 		},
 	}
 	mTag := names.NewMachineTag("1")
-	volumes, attachments, err := instance.volumes(mTag, []names.VolumeTag{
-		names.NewVolumeTag("1"),
-		names.NewVolumeTag("2"),
-		names.NewVolumeTag("3"),
-		names.NewVolumeTag("4"),
-		names.NewVolumeTag("5"),
-	})
+	volumes, attachments, err := instance.volumes(
+		context.Background(),
+		mTag, []names.VolumeTag{
+			names.NewVolumeTag("1"),
+			names.NewVolumeTag("2"),
+			names.NewVolumeTag("3"),
+			names.NewVolumeTag("4"),
+			names.NewVolumeTag("5"),
+		},
+	)
 	c.Assert(err, jc.ErrorIsNil)
 	// Expect 4 volumes - root volume is ignored, as are volumes
 	// with tags we did not request.

--- a/internal/provider/manual/environ.go
+++ b/internal/provider/manual/environ.go
@@ -144,14 +144,14 @@ func (e *manualEnviron) ControllerInstances(ctx envcontext.ProviderCallContext, 
 	if !isRunningController() {
 		// Not running inside the controller, so we must
 		// verify the host.
-		if err := e.verifyBootstrapHost(); err != nil {
+		if err := e.verifyBootstrapHost(ctx); err != nil {
 			return nil, err
 		}
 	}
 	return []instance.Id{BootstrapInstanceId}, nil
 }
 
-func (e *manualEnviron) verifyBootstrapHost() error {
+func (e *manualEnviron) verifyBootstrapHost(ctx context.Context) error {
 	// First verify that the environment is bootstrapped by checking
 	// if the agents directory exists. Note that we cannot test the
 	// root data directory, as that is created in the process of
@@ -176,7 +176,7 @@ func (e *manualEnviron) verifyBootstrapHost() error {
 			return environs.ErrNotBootstrapped
 		}
 		err := errors.Errorf("unexpected output: %q", out)
-		logger.Infof(context.TODO(), err.Error())
+		logger.Infof(ctx, err.Error())
 		return err
 	}
 	return nil
@@ -298,13 +298,13 @@ exit 0
 		diagnostics,
 		mongo.ServiceName,
 	)
-	logger.Tracef(context.TODO(), "destroy controller script: %s", script)
+	logger.Tracef(ctx, "destroy controller script: %s", script)
 	stdout, stderr, err := runSSHCommand(
 		"ubuntu@"+e.host,
 		[]string{"sudo", "/bin/bash"}, script,
 	)
-	logger.Debugf(context.TODO(), "script stdout: \n%s", stdout)
-	logger.Debugf(context.TODO(), "script stderr: \n%s", stderr)
+	logger.Debugf(ctx, "script stdout: \n%s", stdout)
+	logger.Debugf(ctx, "script stderr: \n%s", stderr)
 	return err
 }
 

--- a/internal/provider/manual/provider.go
+++ b/internal/provider/manual/provider.go
@@ -36,10 +36,10 @@ var initUbuntuUser = sshprovisioner.InitUbuntuUser
 func ensureBootstrapUbuntuUser(ctx environs.BootstrapContext, host, user string, cfg *environConfig) error {
 	err := initUbuntuUser(host, user, cfg.AuthorizedKeys(), "", ctx.GetStdin(), ctx.GetStdout())
 	if err != nil {
-		logger.Errorf(context.TODO(), "initializing ubuntu user: %v", err)
+		logger.Errorf(ctx, "initializing ubuntu user: %v", err)
 		return err
 	}
-	logger.Infof(context.TODO(), "initialized ubuntu user")
+	logger.Infof(ctx, "initialized ubuntu user")
 	return nil
 }
 
@@ -74,7 +74,7 @@ func (p ManualProvider) Ping(ctx envcontext.ProviderCallContext, endpoint string
 }
 
 var echo = func(s string) error {
-	logger.Infof(context.TODO(), "trying to ssh using %q", s)
+	logger.Infof(context.Background(), "trying to ssh using %q", s)
 	command := ssh.Command(s, []string{"echo", "hi"}, nil)
 	// os/exec just returns an error that contains the error code from the
 	// executable, which is basically useless, but stderr usually shows
@@ -171,7 +171,7 @@ func (p ManualProvider) validate(ctx context.Context, cfg, old *config.Config) (
 	// given value.
 	defineIfNot := func(keyName string, value interface{}) {
 		if _, defined := cfg.AllAttrs()[keyName]; !defined {
-			logger.Infof(context.TODO(), "%s was not defined. Defaulting to %v.", keyName, value)
+			logger.Infof(ctx, "%s was not defined. Defaulting to %v.", keyName, value)
 			envConfig.attrs[keyName] = value
 		}
 	}

--- a/internal/provider/oci/images.go
+++ b/internal/provider/oci/images.go
@@ -420,7 +420,7 @@ func instTypeByShapeName(shape string) string {
 	}
 }
 
-func refreshImageCache(cli ComputeClient, compartmentID *string) (*ImageCache, error) {
+func refreshImageCache(ctx context.Context, cli ComputeClient, compartmentID *string) (*ImageCache, error) {
 	cacheMutex.Lock()
 	defer cacheMutex.Unlock()
 
@@ -439,15 +439,15 @@ func refreshImageCache(cli ComputeClient, compartmentID *string) (*ImageCache, e
 		img, arch, err := NewInstanceImage(val, compartmentID)
 		if err != nil {
 			if val.Id != nil {
-				logger.Debugf(context.TODO(), "error parsing image %q: %q", *val.Id, err)
+				logger.Debugf(ctx, "error parsing image %q: %q", *val.Id, err)
 			} else {
-				logger.Debugf(context.TODO(), "error parsing image %q", err)
+				logger.Debugf(ctx, "error parsing image %q", err)
 			}
 			continue
 		}
 		// For the moment juju does not support minimal ubuntu
 		if img.IsMinimal {
-			logger.Tracef(context.TODO(), "ubuntu minimal images (%q), not supported", *val.DisplayName)
+			logger.Tracef(ctx, "ubuntu minimal images (%q), not supported", *val.DisplayName)
 			continue
 		}
 		// Only set the instance types to the images that we correctly
@@ -463,7 +463,7 @@ func refreshImageCache(cli ComputeClient, compartmentID *string) (*ImageCache, e
 		// in case one of them doesn't.
 		for _, instType := range instTypes {
 			if instType.Arch != arch {
-				logger.Debugf(context.TODO(), "instance type %s has arch %s while image %s only supports %s", instType.Name, instType.Arch, *val.Id, arch)
+				logger.Debugf(ctx, "instance type %s has arch %s while image %s only supports %s", instType.Name, instType.Arch, *val.Id, arch)
 			}
 		}
 		img.SetInstanceTypes(instTypes)
@@ -491,13 +491,14 @@ func refreshImageCache(cli ComputeClient, compartmentID *string) (*ImageCache, e
 // findInstanceSpec returns an *InstanceSpec, imagelist name
 // satisfying the supplied instanceConstraint
 func findInstanceSpec(
+	ctx context.Context,
 	base corebase.Base,
 	arch string,
 	constraints coreconstraints.Value,
 	imgCache *ImageCache,
 ) (*instances.InstanceSpec, string, error) {
 	allImageMetadata := imgCache.ImageMetadata(base, arch, *constraints.VirtType)
-	logger.Debugf(context.TODO(), "received %d image(s): %v", len(allImageMetadata), allImageMetadata)
+	logger.Debugf(ctx, "received %d image(s): %v", len(allImageMetadata), allImageMetadata)
 
 	ic := &instances.InstanceConstraint{
 		Base:        base,

--- a/internal/provider/oci/images_integration_test.go
+++ b/internal/provider/oci/images_integration_test.go
@@ -343,7 +343,7 @@ func (s *imagesSuite) TestRefreshImageCache(c *gc.C) {
 	compute.EXPECT().ListShapes(context.Background(), &s.testCompartment, &fakeUbuntu3).Return(listShapesResponse(), nil)
 	compute.EXPECT().ListShapes(context.Background(), &s.testCompartment, &fakeUbuntu4).Return(listShapesResponse(), nil)
 
-	imgCache, err := oci.RefreshImageCache(compute, &s.testCompartment)
+	imgCache, err := oci.RefreshImageCache(context.Background(), compute, &s.testCompartment)
 	c.Assert(err, gc.IsNil)
 	c.Assert(imgCache, gc.NotNil)
 	c.Check(imgCache.ImageMap(), gc.HasLen, 1)
@@ -375,11 +375,11 @@ func (s *imagesSuite) TestRefreshImageCacheFetchFromCache(c *gc.C) {
 
 	compute.EXPECT().ListImages(gomock.Any(), gomock.Any()).Return([]ociCore.Image{}, nil)
 
-	imgCache, err := oci.RefreshImageCache(compute, &s.testCompartment)
+	imgCache, err := oci.RefreshImageCache(context.Background(), compute, &s.testCompartment)
 	c.Assert(err, gc.IsNil)
 	c.Assert(imgCache, gc.NotNil)
 
-	fromCache, err := oci.RefreshImageCache(compute, &s.testCompartment)
+	fromCache, err := oci.RefreshImageCache(context.Background(), compute, &s.testCompartment)
 	c.Assert(err, gc.IsNil)
 	c.Check(imgCache, gc.DeepEquals, fromCache)
 }
@@ -391,7 +391,7 @@ func (s *imagesSuite) TestRefreshImageCacheStaleCache(c *gc.C) {
 
 	compute.EXPECT().ListImages(gomock.Any(), gomock.Any()).Return([]ociCore.Image{}, nil).Times(2)
 
-	imgCache, err := oci.RefreshImageCache(compute, &s.testCompartment)
+	imgCache, err := oci.RefreshImageCache(context.Background(), compute, &s.testCompartment)
 	c.Assert(err, gc.IsNil)
 	c.Assert(imgCache, gc.NotNil)
 
@@ -400,7 +400,7 @@ func (s *imagesSuite) TestRefreshImageCacheStaleCache(c *gc.C) {
 	// No need to check the value. gomock will assert if ListImages
 	// is not called twice
 	imgCache.SetLastRefresh(now.Add(-31 * time.Minute))
-	_, err = oci.RefreshImageCache(compute, &s.testCompartment)
+	_, err = oci.RefreshImageCache(context.Background(), compute, &s.testCompartment)
 	c.Assert(err, gc.IsNil)
 }
 
@@ -432,7 +432,7 @@ func (s *imagesSuite) TestRefreshImageCacheWithInvalidImage(c *gc.C) {
 	// is invalid.
 	compute.EXPECT().ListShapes(context.Background(), &s.testCompartment, &fakeUbuntuID).Return(listShapesResponse(), nil)
 
-	imgCache, err := oci.RefreshImageCache(compute, &s.testCompartment)
+	imgCache, err := oci.RefreshImageCache(context.Background(), compute, &s.testCompartment)
 	c.Assert(err, gc.IsNil)
 	c.Assert(imgCache, gc.NotNil)
 	c.Check(imgCache.ImageMap(), gc.HasLen, 1)

--- a/internal/provider/oci/instance.go
+++ b/internal/provider/oci/instance.go
@@ -185,13 +185,13 @@ func (o *ociInstance) waitForPublicIP(ctx envcontext.ProviderCallContext) error 
 			return errors.Trace(err)
 		}
 		if iteration >= maxPollIterations {
-			logger.Debugf(context.TODO(), "could not find a public IP after %s. breaking loop", time.Since(startTime))
+			logger.Debugf(ctx, "could not find a public IP after %s. breaking loop", time.Since(startTime))
 			break
 		}
 
 		for _, val := range addresses {
 			if val.Scope == corenetwork.ScopePublic {
-				logger.Infof(context.TODO(), "Found public IP: %s", val)
+				logger.Infof(ctx, "Found public IP: %s", val)
 				return nil
 			}
 		}
@@ -209,7 +209,7 @@ func (o *ociInstance) deleteInstance(ctx envcontext.ProviderCallContext) error {
 	}
 
 	if o.isTerminating() {
-		logger.Debugf(context.TODO(), "instance %q is alrealy in terminating state", *o.raw.Id)
+		logger.Debugf(ctx, "instance %q is alrealy in terminating state", *o.raw.Id)
 		return nil
 	}
 	request := ociCore.TerminateInstanceRequest{
@@ -230,7 +230,7 @@ func (o *ociInstance) deleteInstance(ctx envcontext.ProviderCallContext) error {
 			ocicommon.HandleCredentialError(err, ctx)
 			return err
 		}
-		logger.Infof(context.TODO(), "Waiting for machine to transition to Terminating: %s", o.raw.LifecycleState)
+		logger.Infof(ctx, "Waiting for machine to transition to Terminating: %s", o.raw.LifecycleState)
 		if o.isTerminating() {
 			break
 		}

--- a/internal/provider/oci/provider.go
+++ b/internal/provider/oci/provider.go
@@ -201,7 +201,7 @@ func (e EnvironProvider) ValidateCloud(ctx context.Context, spec environscloudsp
 
 // Open implements environs.EnvironProvider.
 func (e *EnvironProvider) Open(ctx context.Context, params environs.OpenParams, invalidator environs.CredentialInvalidator) (environs.Environ, error) {
-	logger.Infof(context.TODO(), "opening model %q", params.Config.Name())
+	logger.Infof(ctx, "opening model %q", params.Config.Name())
 
 	if err := validateCloudSpec(params.Cloud); err != nil {
 		return nil, errors.Trace(err)
@@ -219,7 +219,7 @@ func (e *EnvironProvider) Open(ctx context.Context, params environs.OpenParams, 
 	// We don't support setting a default region in the credentials anymore. Because, such approach conflicts with the
 	// way we handle regions in Juju.
 	if creds["region"] != "" {
-		logger.Warningf(context.TODO(), "Setting a default region in Oracle Cloud credentials is not supported.")
+		logger.Warningf(ctx, "Setting a default region in Oracle Cloud credentials is not supported.")
 	}
 	err := providerConfig.Validate()
 	if err != nil {

--- a/internal/provider/oci/storage_volumes.go
+++ b/internal/provider/oci/storage_volumes.go
@@ -67,7 +67,7 @@ func (v *volumeSource) createVolume(ctx envcontext.ProviderCallContext, p storag
 			}
 			response, nestedErr := v.storageAPI.DeleteVolume(context.Background(), req)
 			if nestedErr != nil && !v.env.isNotFound(response.RawResponse) {
-				logger.Warningf(context.TODO(), "failed to cleanup volume: %s", *details.Id)
+				logger.Warningf(ctx, "failed to cleanup volume: %s", *details.Id)
 				return
 			}
 			nestedErr = v.env.waitForResourceStatus(
@@ -75,7 +75,7 @@ func (v *volumeSource) createVolume(ctx envcontext.ProviderCallContext, p storag
 				string(ociCore.VolumeLifecycleStateTerminated),
 				5*time.Minute)
 			if nestedErr != nil && !errors.Is(nestedErr, errors.NotFound) {
-				logger.Warningf(context.TODO(), "failed to cleanup volume: %s", *details.Id)
+				logger.Warningf(ctx, "failed to cleanup volume: %s", *details.Id)
 				return
 			}
 		}
@@ -158,7 +158,7 @@ func makeVolumeInfo(vol ociCore.Volume) storage.VolumeInfo {
 }
 
 func (v *volumeSource) CreateVolumes(ctx envcontext.ProviderCallContext, params []storage.VolumeParams) ([]storage.CreateVolumesResult, error) {
-	logger.Debugf(context.TODO(), "Creating volumes: %v", params)
+	logger.Debugf(ctx, "Creating volumes: %v", params)
 	if params == nil {
 		return []storage.CreateVolumesResult{}, nil
 	}
@@ -423,7 +423,7 @@ func (v *volumeSource) attachVolume(ctx envcontext.ProviderCallContext, param st
 			}
 			res, nestedErr := v.computeAPI.DetachVolume(context.Background(), req)
 			if nestedErr != nil && !v.env.isNotFound(res.RawResponse) {
-				logger.Warningf(context.TODO(), "failed to cleanup volume attachment: %v", volAttach.GetId())
+				logger.Warningf(ctx, "failed to cleanup volume attachment: %v", volAttach.GetId())
 				return
 			}
 			nestedErr = v.env.waitForResourceStatus(
@@ -431,7 +431,7 @@ func (v *volumeSource) attachVolume(ctx envcontext.ProviderCallContext, param st
 				string(ociCore.VolumeAttachmentLifecycleStateDetached),
 				5*time.Minute)
 			if nestedErr != nil && !errors.Is(nestedErr, errors.NotFound) {
-				logger.Warningf(context.TODO(), "failed to cleanup volume attachment: %v", volAttach.GetId())
+				logger.Warningf(ctx, "failed to cleanup volume attachment: %v", volAttach.GetId())
 				return
 			}
 		}
@@ -609,7 +609,7 @@ func (v *volumeSource) DetachVolumes(ctx envcontext.ProviderCallContext, params 
 				ret[idx] = errors.Trace(credErr)
 				continue
 			}
-			logger.Tracef(context.TODO(), "volume ID is: %v", attachment.VolumeId)
+			logger.Tracef(ctx, "volume ID is: %v", attachment.VolumeId)
 			if attachment.VolumeId != nil && param.VolumeId == *attachment.VolumeId && attachment.LifecycleState != ociCore.VolumeAttachmentLifecycleStateDetached {
 				if attachment.LifecycleState != ociCore.VolumeAttachmentLifecycleStateDetaching {
 					request := ociCore.DetachVolumeRequest{
@@ -636,7 +636,7 @@ func (v *volumeSource) DetachVolumes(ctx envcontext.ProviderCallContext, params 
 						common.HandleCredentialError(err, ctx)
 					}
 					ret[idx] = errors.Trace(err)
-					logger.Warningf(context.TODO(), "failed to detach volume: %s", *attachment.Id)
+					logger.Warningf(ctx, "failed to detach volume: %s", *attachment.Id)
 				} else {
 					ret[idx] = nil
 				}

--- a/internal/provider/openstack/cinder_test.go
+++ b/internal/provider/openstack/cinder_test.go
@@ -951,7 +951,7 @@ func (s *cinderVolumeSourceSuite) TestGetVolumeEndpointVolume(c *gc.C) {
 	client := &testEndpointResolver{regionEndpoints: map[string]identity.ServiceURLs{
 		"west": map[string]string{"volume": "http://cinder.testing/v1"},
 	}}
-	url, err := openstack.GetVolumeEndpointURL(client, "west")
+	url, err := openstack.GetVolumeEndpointURL(context.Background(), client, "west")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(url.String(), gc.Equals, "http://cinder.testing/v1")
 }
@@ -960,7 +960,7 @@ func (s *cinderVolumeSourceSuite) TestGetVolumeEndpointVolumeV2(c *gc.C) {
 	client := &testEndpointResolver{regionEndpoints: map[string]identity.ServiceURLs{
 		"west": map[string]string{"volumev2": "http://cinder.testing/v2"},
 	}}
-	url, err := openstack.GetVolumeEndpointURL(client, "west")
+	url, err := openstack.GetVolumeEndpointURL(context.Background(), client, "west")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(url.String(), gc.Equals, "http://cinder.testing/v2")
 }
@@ -972,7 +972,7 @@ func (s *cinderVolumeSourceSuite) TestGetVolumeEndpointV2IfNoV3(c *gc.C) {
 			"volumev2": "http://cinder.testing/v2",
 		},
 	}}
-	url, err := openstack.GetVolumeEndpointURL(client, "south")
+	url, err := openstack.GetVolumeEndpointURL(context.Background(), client, "south")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(url.String(), gc.Equals, "http://cinder.testing/v2")
 }
@@ -985,14 +985,14 @@ func (s *cinderVolumeSourceSuite) TestGetVolumeEndpointPreferV3(c *gc.C) {
 			"volumev3": "http://cinder.testing/v3",
 		},
 	}}
-	url, err := openstack.GetVolumeEndpointURL(client, "south")
+	url, err := openstack.GetVolumeEndpointURL(context.Background(), client, "south")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(url.String(), gc.Equals, "http://cinder.testing/v3")
 }
 
 func (s *cinderVolumeSourceSuite) TestGetVolumeEndpointMissing(c *gc.C) {
 	client := &testEndpointResolver{}
-	url, err := openstack.GetVolumeEndpointURL(client, "east")
+	url, err := openstack.GetVolumeEndpointURL(context.Background(), client, "east")
 	c.Assert(err, gc.ErrorMatches, `endpoint "volume" in region "east" not found`)
 	c.Assert(err, jc.ErrorIs, errors.NotFound)
 	c.Assert(url, gc.IsNil)
@@ -1002,7 +1002,7 @@ func (s *cinderVolumeSourceSuite) TestGetVolumeEndpointBadURL(c *gc.C) {
 	client := &testEndpointResolver{regionEndpoints: map[string]identity.ServiceURLs{
 		"north": map[string]string{"volumev2": "some %4"},
 	}}
-	url, err := openstack.GetVolumeEndpointURL(client, "north")
+	url, err := openstack.GetVolumeEndpointURL(context.Background(), client, "north")
 	// NOTE(achilleasa): go1.14 quotes malformed URLs in error messages
 	// hence the optional quotes in the regex below.
 	c.Assert(err, gc.ErrorMatches, `parse ("?)some %4("?): .*`)

--- a/internal/provider/openstack/client.go
+++ b/internal/provider/openstack/client.go
@@ -280,5 +280,5 @@ func (c *wrappedLogger) Debugf(msg string, args ...any) {
 	// We should either fix the goose logger to use a context, or we should
 	// instantiate a new client for each request rather than caching it for
 	// the lifetime of the provider.
-	c.logger.Debugf(context.TODO(), msg, args...)
+	c.logger.Debugf(context.Background(), msg, args...)
 }

--- a/internal/provider/openstack/config.go
+++ b/internal/provider/openstack/config.go
@@ -164,7 +164,7 @@ func (p EnvironProvider) Validate(ctx context.Context, cfg, old *config.Config) 
 				"existing image metadata, please run 'juju-metadata help' to see how suitable image"+
 				"metadata can be generated.",
 			"default-image-id", defaultImageId)
-		logger.Warningf(context.TODO(), msg)
+		logger.Warningf(ctx, msg)
 	}
 	if defaultInstanceType := cfgAttrs["default-instance-type"]; defaultInstanceType != nil && defaultInstanceType.(string) != "" {
 		msg := fmt.Sprintf(
@@ -173,7 +173,7 @@ func (p EnvironProvider) Validate(ctx context.Context, cfg, old *config.Config) 
 				"when an model is bootstrapped, or individually when a charm is deployed.\n"+
 				"See 'juju help bootstrap' or 'juju help deploy'.",
 			"default-instance-type", defaultInstanceType)
-		logger.Warningf(context.TODO(), msg)
+		logger.Warningf(ctx, msg)
 	}
 
 	// Construct a new config with the ignored, deprecated attributes removed.

--- a/internal/provider/openstack/credentials.go
+++ b/internal/provider/openstack/credentials.go
@@ -113,7 +113,7 @@ func (c OpenstackCredentials) DetectCredentials(cloudName string) (*cloud.CloudC
 	}
 
 	// Try just using environment variables
-	creds, user, region, err := c.detectCredential()
+	creds, user, region, err := c.detectCredential(context.TODO())
 	if err == nil {
 		result.DefaultRegion = region
 		result.AuthCredentials[user] = *creds
@@ -132,7 +132,7 @@ func (c OpenstackCredentials) DetectCredentials(cloudName string) (*cloud.CloudC
 			k = stripExport.ReplaceAllString(k, "")
 			os.Setenv(k, v)
 		}
-		creds, user, region, err := c.detectCredential()
+		creds, user, region, err := c.detectCredential(context.TODO())
 		if err == nil {
 			result.DefaultRegion = region
 			result.AuthCredentials[user] = *creds
@@ -144,16 +144,16 @@ func (c OpenstackCredentials) DetectCredentials(cloudName string) (*cloud.CloudC
 	return &result, nil
 }
 
-func (c OpenstackCredentials) detectCredential() (*cloud.Credential, string, string, error) {
+func (c OpenstackCredentials) detectCredential(ctx context.Context) (*cloud.Credential, string, string, error) {
 	creds, err := identity.CredentialsFromEnv()
 	if err != nil {
 		return nil, "", "", errors.Errorf("failed to retrieve credential from env : %v", err)
 	}
 	if creds.TenantName == "" {
-		logger.Debugf(context.TODO(), "neither OS_TENANT_NAME nor OS_PROJECT_NAME environment variable not set")
+		logger.Debugf(ctx, "neither OS_TENANT_NAME nor OS_PROJECT_NAME environment variable not set")
 	}
 	if creds.TenantID == "" {
-		logger.Debugf(context.TODO(), "neither OS_TENANT_ID nor OS_PROJECT_ID environment variable not set")
+		logger.Debugf(ctx, "neither OS_TENANT_ID nor OS_PROJECT_ID environment variable not set")
 	}
 	if creds.User == "" {
 		return nil, "", "", errors.NewNotFound(nil, "neither OS_USERNAME nor OS_ACCESS_KEY environment variable not set")

--- a/internal/provider/openstack/firewaller.go
+++ b/internal/provider/openstack/firewaller.go
@@ -4,7 +4,6 @@
 package openstack
 
 import (
-	"context"
 	"fmt"
 	"regexp"
 	"strings"
@@ -216,7 +215,7 @@ func deleteSecurityGroup(
 	name, id string,
 	clock clock.Clock,
 ) {
-	logger.Debugf(context.TODO(), "deleting security group %q", name)
+	logger.Debugf(ctx, "deleting security group %q", name)
 	err := retry.Call(retry.CallArgs{
 		Func: func() error {
 			if err := deleteSecurityGroupByID(id); err != nil {
@@ -234,7 +233,7 @@ func deleteSecurityGroup(
 				if attempt != 4 {
 					message = "still " + message
 				}
-				logger.Debugf(context.TODO(), message)
+				logger.Debugf(ctx, message)
 			}
 		},
 		Attempts: 30,
@@ -242,7 +241,7 @@ func deleteSecurityGroup(
 		Clock:    clock,
 	})
 	if err != nil {
-		logger.Warningf(context.TODO(), "cannot delete security group %q. Used by another model?", name)
+		logger.Warningf(ctx, "cannot delete security group %q. Used by another model?", name)
 	}
 }
 
@@ -496,7 +495,7 @@ func (c *neutronFirewaller) UpdateGroupController(ctx envcontext.ProviderCallCon
 		}
 		err := c.updateGroupControllerUUID(&group, controllerUUID)
 		if err != nil {
-			logger.Errorf(context.TODO(), "error updating controller for security group %s: %v", group.Id, err)
+			logger.Errorf(ctx, "error updating controller for security group %s: %v", group.Id, err)
 			failed = append(failed, group.Id)
 			if common.LegacyHandleCredentialError(IsAuthorisationFailure, err, ctx) {
 				// No need to continue here since we will 100% fail with an invalid credential.
@@ -531,7 +530,7 @@ func (c *neutronFirewaller) OpenPorts(ctx envcontext.ProviderCallContext, rules 
 		handleCredentialError(err, ctx)
 		return errors.Trace(err)
 	}
-	logger.Infof(context.TODO(), "opened ports in global group: %v", rules)
+	logger.Infof(ctx, "opened ports in global group: %v", rules)
 	return nil
 }
 
@@ -545,7 +544,7 @@ func (c *neutronFirewaller) ClosePorts(ctx envcontext.ProviderCallContext, rules
 		handleCredentialError(err, ctx)
 		return errors.Trace(err)
 	}
-	logger.Infof(context.TODO(), "closed ports in global group: %v", rules)
+	logger.Infof(ctx, "closed ports in global group: %v", rules)
 	return nil
 }
 
@@ -567,14 +566,14 @@ func (c *neutronFirewaller) IngressRules(ctx envcontext.ProviderCallContext) (fi
 func (c *neutronFirewaller) OpenModelPorts(ctx envcontext.ProviderCallContext, rules firewall.IngressRules) error {
 	err := c.openPortsInGroup(ctx, c.jujuGroupRegexp(), rules)
 	if errors.Is(err, errors.NotFound) && !c.environ.usingSecurityGroups {
-		logger.Warningf(context.TODO(), "attempted to open %v but network port security is disabled. Already open", rules)
+		logger.Warningf(ctx, "attempted to open %v but network port security is disabled. Already open", rules)
 		return nil
 	}
 	if err != nil {
 		handleCredentialError(err, ctx)
 		return errors.Trace(err)
 	}
-	logger.Infof(context.TODO(), "opened ports in model group: %v", rules)
+	logger.Infof(ctx, "opened ports in model group: %v", rules)
 	return nil
 }
 
@@ -584,7 +583,7 @@ func (c *neutronFirewaller) CloseModelPorts(ctx envcontext.ProviderCallContext, 
 		handleCredentialError(err, ctx)
 		return errors.Trace(err)
 	}
-	logger.Infof(context.TODO(), "closed ports in global group: %v", rules)
+	logger.Infof(ctx, "closed ports in global group: %v", rules)
 	return nil
 }
 
@@ -616,7 +615,7 @@ func (c *neutronFirewaller) OpenInstancePorts(ctx envcontext.ProviderCallContext
 		handleCredentialError(err, ctx)
 		return errors.Trace(err)
 	}
-	logger.Infof(context.TODO(), "opened ports in security group %s-%s: %v", c.environ.Config().UUID(), machineID, ports)
+	logger.Infof(ctx, "opened ports in security group %s-%s: %v", c.environ.Config().UUID(), machineID, ports)
 	return nil
 }
 
@@ -638,7 +637,7 @@ func (c *neutronFirewaller) CloseInstancePorts(ctx envcontext.ProviderCallContex
 		handleCredentialError(err, ctx)
 		return errors.Trace(err)
 	}
-	logger.Infof(context.TODO(), "closed ports in security group %s-%s: %v", c.environ.Config().UUID(), machineID, ports)
+	logger.Infof(ctx, "closed ports in security group %s-%s: %v", c.environ.Config().UUID(), machineID, ports)
 	return nil
 }
 

--- a/internal/provider/openstack/provider_test.go
+++ b/internal/provider/openstack/provider_test.go
@@ -918,7 +918,7 @@ func (s *providerUnitTests) TestNetworksForInstance(c *gc.C) {
 		AvailabilityZone: "eu-west-az",
 	}
 
-	result, err := envWithNetworking(mockNetworking, netID).networksForInstance(siParams, netCfg)
+	result, err := envWithNetworking(mockNetworking, netID).networksForInstance(context.Background(), siParams, netCfg)
 
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, []nova.ServerNetworks{
@@ -946,7 +946,7 @@ func (s *providerUnitTests) TestNetworksForInstanceNoConfigMultiNet(c *gc.C) {
 		AvailabilityZone: "eu-west-az",
 	}
 
-	result, err := envWithNetworking(mockNetworking, "").networksForInstance(siParams, netCfg)
+	result, err := envWithNetworking(mockNetworking, "").networksForInstance(context.Background(), siParams, netCfg)
 
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, []nova.ServerNetworks{
@@ -971,7 +971,7 @@ func (s *providerUnitTests) TestNetworksForInstanceMultiConfigMultiNet(c *gc.C) 
 		AvailabilityZone: "eu-west-az",
 	}
 
-	result, err := envWithNetworking(mockNetworking, "network-id-foo,network-id-bar").networksForInstance(siParams, netCfg)
+	result, err := envWithNetworking(mockNetworking, "network-id-foo,network-id-bar").networksForInstance(context.Background(), siParams, netCfg)
 
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, []nova.ServerNetworks{
@@ -1016,7 +1016,7 @@ func (s *providerUnitTests) TestNetworksForInstanceWithAZ(c *gc.C) {
 		SubnetsToZones:   []map[network.Id][]string{{"subnet-foo": {"eu-west-az", "eu-east-az"}}},
 	}
 
-	result, err := envWithNetworking(mockNetworking, netID).networksForInstance(siParams, netCfg)
+	result, err := envWithNetworking(mockNetworking, netID).networksForInstance(context.Background(), siParams, netCfg)
 
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, []nova.ServerNetworks{
@@ -1089,7 +1089,7 @@ func (s *providerUnitTests) TestNetworksForInstanceWithAZNoConfigMultiNet(c *gc.
 		},
 	}
 
-	result, err := envWithNetworking(mockNetworking, "").networksForInstance(siParams, netCfg)
+	result, err := envWithNetworking(mockNetworking, "").networksForInstance(context.Background(), siParams, netCfg)
 
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, []nova.ServerNetworks{
@@ -1126,7 +1126,7 @@ func (s *providerUnitTests) TestNetworksForInstanceWithNoMatchingAZ(c *gc.C) {
 		},
 	}
 
-	_, err := envWithNetworking(mockNetworking, netID).networksForInstance(siParams, netCfg)
+	_, err := envWithNetworking(mockNetworking, netID).networksForInstance(context.Background(), siParams, netCfg)
 	c.Assert(err, gc.ErrorMatches, "determining subnets in zone \"us-east-az\": subnets in AZ \"us-east-az\" not found")
 }
 
@@ -1171,7 +1171,7 @@ func (s *providerUnitTests) TestNetworksForInstanceNoSubnetAZsStillConsidered(c 
 		}},
 	}
 
-	result, err := envWithNetworking(mockNetworking, netID).networksForInstance(siParams, netCfg)
+	result, err := envWithNetworking(mockNetworking, netID).networksForInstance(context.Background(), siParams, netCfg)
 
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, []nova.ServerNetworks{

--- a/internal/provider/openstack/series_test.go
+++ b/internal/provider/openstack/series_test.go
@@ -5,6 +5,7 @@ package openstack
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"html/template"
 	"strings"
@@ -51,7 +52,7 @@ func MetadataStorage(e environs.Environ) envstorage.Storage {
 }
 
 func InstanceAddress(publicIP string, addresses map[string][]nova.IPAddress) string {
-	addr, _ := convertNovaAddresses(publicIP, addresses).OneMatchingScope(network.ScopeMatchPublic)
+	addr, _ := convertNovaAddresses(context.Background(), publicIP, addresses).OneMatchingScope(network.ScopeMatchPublic)
 	return addr.Value
 }
 

--- a/internal/provider/vsphere/environ_availzones.go
+++ b/internal/provider/vsphere/environ_availzones.go
@@ -4,7 +4,6 @@
 package vsphere
 
 import (
-	"context"
 	"sort"
 	"strings"
 
@@ -56,7 +55,7 @@ func (env *sessionEnviron) AvailabilityZones(ctx envcontext.ProviderCallContext)
 		HandleCredentialError(err, env, ctx)
 		return nil, errors.Trace(err)
 	}
-	logger.Tracef(context.TODO(), "host folder InventoryPath=%q, Name=%q",
+	logger.Tracef(ctx, "host folder InventoryPath=%q, Name=%q",
 		folders.HostFolder.InventoryPath, folders.HostFolder.Name())
 	hostFolder := folders.HostFolder.InventoryPath
 
@@ -68,7 +67,7 @@ func (env *sessionEnviron) AvailabilityZones(ctx envcontext.ProviderCallContext)
 	var zones network.AvailabilityZones
 	for _, cr := range computeResources {
 		if cr.Resource.Summary.GetComputeResourceSummary().EffectiveCpu == 0 {
-			logger.Debugf(context.TODO(), "skipping empty compute resource %q", cr.Resource.Name)
+			logger.Debugf(ctx, "skipping empty compute resource %q", cr.Resource.Name)
 			continue
 		}
 
@@ -85,7 +84,7 @@ func (env *sessionEnviron) AvailabilityZones(ctx envcontext.ProviderCallContext)
 				pool: pool,
 				name: makeAvailZoneName(hostFolder, cr.Path, pool.InventoryPath),
 			}
-			logger.Tracef(context.TODO(), "zone: %s (cr.Name=%q pool.InventoryPath=%q)",
+			logger.Tracef(ctx, "zone: %s (cr.Name=%q pool.InventoryPath=%q)",
 				zone.Name(), zone.r.Name, zone.pool.InventoryPath)
 			zones = append(zones, zone)
 		}
@@ -97,7 +96,7 @@ func (env *sessionEnviron) AvailabilityZones(ctx envcontext.ProviderCallContext)
 			zoneNames[i] = zone.Name()
 		}
 		sort.Strings(zoneNames)
-		logger.Debugf(context.TODO(), "fetched availability zones: %q", zoneNames)
+		logger.Debugf(ctx, "fetched availability zones: %q", zoneNames)
 	}
 
 	env.zones = zones

--- a/internal/provider/vsphere/environ_broker.go
+++ b/internal/provider/vsphere/environ_broker.go
@@ -4,7 +4,6 @@
 package vsphere
 
 import (
-	"context"
 	"fmt"
 	"path"
 	"sync"
@@ -88,8 +87,8 @@ func (env *sessionEnviron) StartInstance(ctx envcontext.ProviderCallContext, arg
 		return nil, errors.Trace(err)
 	}
 
-	logger.Infof(context.TODO(), "started instance %q", vm.Name)
-	logger.Tracef(context.TODO(), "instance data %+v", vm)
+	logger.Infof(ctx, "started instance %q", vm.Name)
+	logger.Tracef(ctx, "instance data %+v", vm)
 	inst := newInstance(vm, env.environ)
 	result := environs.StartInstanceResult{
 		Instance: inst,
@@ -135,7 +134,7 @@ func (env *sessionEnviron) newRawInstance(
 	}
 
 	// Attempt to create a VM in each of the AZs in turn.
-	logger.Debugf(context.TODO(), "attempting to create VM in availability zone %q", args.AvailabilityZone)
+	logger.Debugf(ctx, "attempting to create VM in availability zone %q", args.AvailabilityZone)
 	availZone, err := env.availZone(ctx, args.AvailabilityZone)
 	if err != nil {
 		return nil, nil, errors.Trace(err)
@@ -246,7 +245,7 @@ func (env *sessionEnviron) newRawInstance(
 			errors.Annotate(err, "cannot make user data"),
 		)
 	}
-	logger.Debugf(context.TODO(), "Vmware user data; %d bytes", len(userData))
+	logger.Debugf(ctx, "Vmware user data; %d bytes", len(userData))
 
 	createVMArgs := vsphereclient.CreateVirtualMachineParams{
 		Name:                   vmName,

--- a/internal/provider/vsphere/instance.go
+++ b/internal/provider/vsphere/instance.go
@@ -4,8 +4,6 @@
 package vsphere
 
 import (
-	"context"
-
 	"github.com/juju/errors"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
@@ -94,7 +92,7 @@ func (inst *environInstance) changeIngressRules(ctx envcontext.ProviderCallConte
 		// Open/Close port without an externalNetwork defined is treated as a no-op.
 		// We don't firewall the internal network, and without an external network we don't have any iptables rules
 		// to define.
-		logger.Warningf(context.TODO(), "ingress rules changing without an external network defined, no changes will be made")
+		logger.Warningf(ctx, "ingress rules changing without an external network defined, no changes will be made")
 		return nil
 	}
 	addresses, client, err := inst.getInstanceConfigurator(ctx)

--- a/internal/provider/vsphere/internal/vsphereclient/client_test.go
+++ b/internal/provider/vsphere/internal/vsphereclient/client_test.go
@@ -535,7 +535,7 @@ func (s *clientSuite) SetUpTest(c *gc.C) {
 	s.uploadRequests = nil
 	s.onImageUpload = nil
 	s.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		logger.Infof(context.TODO(), "HTTP %#v", r)
+		logger.Infof(r.Context(), "HTTP %#v", r)
 		var buf bytes.Buffer
 		io.Copy(&buf, r.Body)
 		rcopy := *r

--- a/internal/provider/vsphere/internal/vsphereclient/mock_test.go
+++ b/internal/provider/vsphere/internal/vsphereclient/mock_test.go
@@ -120,7 +120,7 @@ func (r *mockRoundTripper) RoundTrip(ctx context.Context, req, res soap.HasFault
 		res.Res = &types.CloneVM_TaskResponse{Returnval: cloneVMTask}
 	case *methods.CreateFolderBody:
 		req := req.(*methods.CreateFolderBody).Req
-		logger.Debugf(context.TODO(), "CreateFolder: %q", req.Name)
+		logger.Debugf(ctx, "CreateFolder: %q", req.Name)
 		r.MethodCall(r, "CreateFolder", req.Name)
 		res.Res = &types.CreateFolderResponse{}
 	case *methods.CreateImportSpecBody:
@@ -189,7 +189,7 @@ func (r *mockRoundTripper) RoundTrip(ctx context.Context, req, res soap.HasFault
 	case *methods.HttpNfcLeaseProgressBody:
 		req := req.(*methods.HttpNfcLeaseProgressBody).Req
 		r.MethodCall(r, "HttpNfcLeaseProgressBody", req.This.Value)
-		logger.Infof(context.TODO(), "%s", req.This.Value)
+		logger.Infof(ctx, "%s", req.This.Value)
 		//delete(r.collectors, req.This.Value)
 		res.Res = &types.HttpNfcLeaseProgressResponse{}
 	case *methods.HttpNfcLeaseCompleteBody:
@@ -252,7 +252,7 @@ func (r *mockRoundTripper) RoundTrip(ctx context.Context, req, res soap.HasFault
 	case *methods.FindByInventoryPathBody:
 		req := req.(*methods.FindByInventoryPathBody).Req
 		r.MethodCall(r, "FindByInventoryPath", req.This.Value, req.InventoryPath)
-		logger.Debugf(context.TODO(), "FindByInventoryPath ref: %q, path: %q", req.This.Value, req.InventoryPath)
+		logger.Debugf(ctx, "FindByInventoryPath ref: %q, path: %q", req.This.Value, req.InventoryPath)
 		var findResponse *types.FindByInventoryPathResponse
 		if req.InventoryPath == "/dc0/datastore" {
 			findResponse = &types.FindByInventoryPathResponse{
@@ -306,7 +306,7 @@ func (r *mockRoundTripper) RoundTrip(ctx context.Context, req, res soap.HasFault
 			},
 		}
 	default:
-		logger.Debugf(context.TODO(), "mockRoundTripper: unknown res type %T", res)
+		logger.Debugf(ctx, "mockRoundTripper: unknown res type %T", res)
 		panic(fmt.Sprintf("unknown type %T", res))
 		//		return errors.Errorf("unknown type %T", res)
 	}
@@ -324,7 +324,7 @@ func (r *mockRoundTripper) retrieveProperties(req *types.RetrieveProperties) *ty
 		typeNames = append(typeNames, prop.Type)
 	}
 	r.MethodCall(r, "RetrieveProperties", args...)
-	logger.Debugf(context.TODO(), "RetrieveProperties for %s expecting %v", args, typeNames)
+	logger.Debugf(context.Background(), "RetrieveProperties for %s expecting %v", args, typeNames)
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	var contents []types.ObjectContent
@@ -342,7 +342,7 @@ func (r *mockRoundTripper) retrieveProperties(req *types.RetrieveProperties) *ty
 			}
 		}
 	}
-	logger.Debugf(context.TODO(), "received %s", contents)
+	logger.Debugf(context.Background(), "received %s", contents)
 	return &types.RetrievePropertiesResponse{Returnval: contents}
 }
 

--- a/internal/provider/vsphere/provider.go
+++ b/internal/provider/vsphere/provider.go
@@ -128,7 +128,7 @@ func (p *environProvider) Ping(callCtx callcontext.ProviderCallContext, endpoint
 			// vSphere without any creds, so return nil.
 			return nil
 		}
-		logger.Errorf(context.TODO(), "Unexpected error dialing vSphere connection: %v", err)
+		logger.Errorf(ctx, "Unexpected error dialing vSphere connection: %v", err)
 		return errors.Errorf("No vCenter/ESXi available at %s", endpoint)
 	}
 	defer client.Close(ctx)

--- a/internal/provider/vsphere/upgrades.go
+++ b/internal/provider/vsphere/upgrades.go
@@ -4,7 +4,6 @@
 package vsphere
 
 import (
-	"context"
 	"path"
 
 	"github.com/juju/errors"
@@ -121,7 +120,7 @@ func (step modelFoldersUpgradeStep) Run(ctx envcontext.ProviderCallContext) erro
 		}
 		refs := make([]types.ManagedObjectReference, len(vms))
 		for i, vm := range vms {
-			logger.Debugf(context.TODO(), "moving VM %q into %q", vm.Name, modelFolderPath)
+			logger.Debugf(ctx, "moving VM %q into %q", vm.Name, modelFolderPath)
 			refs[i] = vm.Reference()
 		}
 		if err := env.client.MoveVMsInto(env.ctx, modelFolderPath, refs...); err != nil {

--- a/internal/provider/vsphere/vm_template.go
+++ b/internal/provider/vsphere/vm_template.go
@@ -44,30 +44,30 @@ type vmTemplateManager struct {
 // to import a new template from simplestreams.
 func (v *vmTemplateManager) EnsureTemplate(ctx context.Context, b base.Base, agentArch string) (*object.VirtualMachine, string, error) {
 	// Attempt to find image in image-metadata
-	logger.Debugf(context.TODO(), "looking for local templates")
+	logger.Debugf(ctx, "looking for local templates")
 	tpl, arch, err := v.findTemplate(ctx)
 	if err == nil {
-		logger.Debugf(context.TODO(), "found requested template for base %s", b)
+		logger.Debugf(ctx, "found requested template for base %s", b)
 		return tpl, arch, nil
 	}
 	if !errors.Is(err, errors.NotFound) {
 		return nil, "", errors.Annotate(err, "searching for template")
 	}
 
-	logger.Debugf(context.TODO(), "looking for already imported templates for base %q", b)
+	logger.Debugf(ctx, "looking for already imported templates for base %q", b)
 	// Attempt to find a previously imported instance template
 	importedTemplate, arch, err := v.getImportedTemplate(ctx, b, agentArch)
 	if err == nil {
-		logger.Debugf(context.TODO(), "using already imported template for base %s", b)
+		logger.Debugf(ctx, "using already imported template for base %s", b)
 		return importedTemplate, arch, nil
 	}
-	logger.Debugf(context.TODO(), "could not find cached image: %s", err)
+	logger.Debugf(ctx, "could not find cached image: %s", err)
 	// Exit here if we do not have a Not Found error. A Not Found error means we we have
 	// not imported a template yet, keep going
 	if !errors.Is(err, errors.NotFound) {
 		return nil, "", errors.Trace(err)
 	}
-	logger.Debugf(context.TODO(), "downloading and importing template from simplestreams")
+	logger.Debugf(ctx, "downloading and importing template from simplestreams")
 	// Last resort, download and import a template.
 	return v.downloadAndImportTemplate(ctx, b, agentArch)
 }
@@ -130,14 +130,14 @@ func (v *vmTemplateManager) getVMArch(ctx context.Context, vmObj *object.Virtual
 }
 
 func (v *vmTemplateManager) getImportedTemplate(ctx context.Context, b base.Base, agentArch string) (*object.VirtualMachine, string, error) {
-	logger.Tracef(context.TODO(), "getImportedTemplate for base %q, arch %q", b, agentArch)
+	logger.Tracef(ctx, "getImportedTemplate for base %q, arch %q", b, agentArch)
 	baseTemplateFolder := v.baseTemplateFolder(b)
 	baseTemplates, err := v.client.ListVMTemplates(ctx, path.Join(baseTemplateFolder, "*"))
 	if err != nil {
-		logger.Tracef(context.TODO(), "failed to fetch templates: %v", err)
+		logger.Tracef(ctx, "failed to fetch templates: %v", err)
 		return nil, "", errors.Trace(err)
 	}
-	logger.Tracef(context.TODO(), "Base templates: %v", baseTemplates)
+	logger.Tracef(ctx, "Base templates: %v", baseTemplates)
 	if len(baseTemplates) == 0 {
 		return nil, "", errors.NotFoundf("%s templates", b)
 	}
@@ -147,9 +147,9 @@ func (v *vmTemplateManager) getImportedTemplate(ctx context.Context, b base.Base
 		arch, err = v.getVMArch(ctx, item)
 		if err != nil {
 			if errors.Is(err, errors.NotFound) {
-				logger.Debugf(context.TODO(), "failed find arch for template %q: %s", item.InventoryPath, err)
+				logger.Debugf(ctx, "failed find arch for template %q: %s", item.InventoryPath, err)
 			} else {
-				logger.Infof(context.TODO(), "failed to get arch for template %q: %s", item.InventoryPath, err)
+				logger.Infof(ctx, "failed to get arch for template %q: %s", item.InventoryPath, err)
 			}
 			continue
 		}
@@ -161,7 +161,7 @@ func (v *vmTemplateManager) getImportedTemplate(ctx context.Context, b base.Base
 	}
 	if vmTpl == nil {
 		// Templates created by juju before 2.9, do not have an arch tag.
-		logger.Warningf(context.TODO(), "using default template since old templates do not contain arch")
+		logger.Warningf(ctx, "using default template since old templates do not contain arch")
 		vmTpl = baseTemplates[0]
 	}
 


### PR DESCRIPTION
This removes most of the context.TODO() placeholders in the provider package. There is still a very small amount of them left, but they can be cleaned up at a later date.

The strategy is to remove as many as possible.


## QA steps

```sh
$ juju bootstrap lxd test
$ juju add-model default
$ juju deploy ubuntu
```

```sh
$ juju bootstrap aws
$ juju add-model default
$ juju deploy ubuntu
```
