### PR TITLE
refactor: use unit Name type consistently rather than string

### DIFF
--- a/apiserver/facades/agent/uniter/service.go
+++ b/apiserver/facades/agent/uniter/service.go
@@ -261,7 +261,7 @@ type RelationService interface {
 	GetRelationDetailsForUnit(
 		ctx context.Context,
 		relationUUID corerelation.UUID,
-		unitName string,
+		unitName coreunit.Name,
 	) (relation.RelationDetails, error)
 
 	// GetRelationUnit returns the relation unit UUID for the given unit within
@@ -269,7 +269,7 @@ type RelationService interface {
 	GetRelationUnit(
 		ctx context.Context,
 		relationUUID corerelation.UUID,
-		unitName string,
+		unitName coreunit.Name,
 	) (corerelation.UnitUUID, error)
 
 	// GetRelationUnitSettings returns the unit settings for the

--- a/apiserver/facades/agent/uniter/service_mock_test.go
+++ b/apiserver/facades/agent/uniter/service_mock_test.go
@@ -890,7 +890,7 @@ func (c *MockRelationServiceGetRelationDetailsCall) DoAndReturn(f func(context.C
 }
 
 // GetRelationDetailsForUnit mocks base method.
-func (m *MockRelationService) GetRelationDetailsForUnit(arg0 context.Context, arg1 relation.UUID, arg2 string) (relation0.RelationDetails, error) {
+func (m *MockRelationService) GetRelationDetailsForUnit(arg0 context.Context, arg1 relation.UUID, arg2 unit.Name) (relation0.RelationDetails, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRelationDetailsForUnit", arg0, arg1, arg2)
 	ret0, _ := ret[0].(relation0.RelationDetails)
@@ -917,13 +917,13 @@ func (c *MockRelationServiceGetRelationDetailsForUnitCall) Return(arg0 relation0
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockRelationServiceGetRelationDetailsForUnitCall) Do(f func(context.Context, relation.UUID, string) (relation0.RelationDetails, error)) *MockRelationServiceGetRelationDetailsForUnitCall {
+func (c *MockRelationServiceGetRelationDetailsForUnitCall) Do(f func(context.Context, relation.UUID, unit.Name) (relation0.RelationDetails, error)) *MockRelationServiceGetRelationDetailsForUnitCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockRelationServiceGetRelationDetailsForUnitCall) DoAndReturn(f func(context.Context, relation.UUID, string) (relation0.RelationDetails, error)) *MockRelationServiceGetRelationDetailsForUnitCall {
+func (c *MockRelationServiceGetRelationDetailsForUnitCall) DoAndReturn(f func(context.Context, relation.UUID, unit.Name) (relation0.RelationDetails, error)) *MockRelationServiceGetRelationDetailsForUnitCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1046,7 +1046,7 @@ func (c *MockRelationServiceGetRelationUUIDFromKeyCall) DoAndReturn(f func(conte
 }
 
 // GetRelationUnit mocks base method.
-func (m *MockRelationService) GetRelationUnit(arg0 context.Context, arg1 relation.UUID, arg2 string) (relation.UnitUUID, error) {
+func (m *MockRelationService) GetRelationUnit(arg0 context.Context, arg1 relation.UUID, arg2 unit.Name) (relation.UnitUUID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRelationUnit", arg0, arg1, arg2)
 	ret0, _ := ret[0].(relation.UnitUUID)
@@ -1073,13 +1073,13 @@ func (c *MockRelationServiceGetRelationUnitCall) Return(arg0 relation.UnitUUID, 
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockRelationServiceGetRelationUnitCall) Do(f func(context.Context, relation.UUID, string) (relation.UnitUUID, error)) *MockRelationServiceGetRelationUnitCall {
+func (c *MockRelationServiceGetRelationUnitCall) Do(f func(context.Context, relation.UUID, unit.Name) (relation.UnitUUID, error)) *MockRelationServiceGetRelationUnitCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockRelationServiceGetRelationUnitCall) DoAndReturn(f func(context.Context, relation.UUID, string) (relation.UnitUUID, error)) *MockRelationServiceGetRelationUnitCall {
+func (c *MockRelationServiceGetRelationUnitCall) DoAndReturn(f func(context.Context, relation.UUID, unit.Name) (relation.UnitUUID, error)) *MockRelationServiceGetRelationUnitCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -1494,7 +1494,11 @@ func (u *UniterAPI) readLocalUnitSettings(
 		return nil, apiservererrors.ErrPerm
 	}
 
-	relUnitUUID, err := u.relationService.GetRelationUnit(ctx, relUUID, unitTag.Id())
+	unitName, err := coreunit.NewName(unitTag.Id())
+	if err != nil {
+		return nil, internalerrors.Capture(err)
+	}
+	relUnitUUID, err := u.relationService.GetRelationUnit(ctx, relUUID, unitName)
 	if err != nil {
 		return nil, internalerrors.Capture(err)
 	}
@@ -1647,7 +1651,11 @@ func (u *UniterAPI) readOneRemoteSettings(ctx context.Context, canAccess common.
 
 	switch tag := remoteTag.(type) {
 	case names.UnitTag:
-		relUnitUUID, err := u.relationService.GetRelationUnit(ctx, relUUID, tag.Id())
+		unitName, err := coreunit.NewName(tag.Id())
+		if err != nil {
+			return nil, internalerrors.Capture(err)
+		}
+		relUnitUUID, err := u.relationService.GetRelationUnit(ctx, relUUID, unitName)
 		if err != nil {
 			return nil, internalerrors.Capture(err)
 		}
@@ -1947,7 +1955,11 @@ func (u *UniterAPI) getOneRelation(
 	} else if err != nil {
 		return nothing, err
 	}
-	rel, err := u.relationService.GetRelationDetailsForUnit(ctx, relUUID, unitTag.Id())
+	unitName, err := coreunit.NewName(unitTag.Id())
+	if err != nil {
+		return nothing, internalerrors.Capture(err)
+	}
+	rel, err := u.relationService.GetRelationDetailsForUnit(ctx, relUUID, unitName)
 	if errors.Is(err, errors.NotFound) {
 		return nothing, apiservererrors.ErrPerm
 	} else if err != nil {

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -982,7 +982,8 @@ func (s *uniterRelationSuite) expectGetRelationDetailsForUnit(
 	relUUID corerelation.UUID,
 	details relation.RelationDetails,
 ) {
-	s.relationService.EXPECT().GetRelationDetailsForUnit(gomock.Any(), relUUID, s.wordpressUnitTag.Id()).Return(details, nil)
+	unitName := coreunit.Name(s.wordpressUnitTag.Id())
+	s.relationService.EXPECT().GetRelationDetailsForUnit(gomock.Any(), relUUID, unitName).Return(details, nil)
 }
 
 func (s *uniterRelationSuite) expectGetRelationDetailsNotFound(relID int) {
@@ -1030,7 +1031,7 @@ func (s *uniterRelationSuite) expectGetRemoteRelationApplicationSettings(uuid co
 }
 
 func (s *uniterRelationSuite) expectGetRelationUnit(relUUID corerelation.UUID, uuid corerelation.UnitUUID, unitTagID string) {
-	s.relationService.EXPECT().GetRelationUnit(gomock.Any(), relUUID, unitTagID).Return(uuid, nil)
+	s.relationService.EXPECT().GetRelationUnit(gomock.Any(), relUUID, coreunit.Name(unitTagID)).Return(uuid, nil)
 }
 
 func (s *uniterRelationSuite) expectGetRelationUnitSettings(uuid corerelation.UnitUUID, settings map[string]string) {

--- a/domain/relation/service/relation.go
+++ b/domain/relation/service/relation.go
@@ -147,7 +147,7 @@ func (s *Service) GetRelationDetails(ctx context.Context, relationID int) (relat
 func (s *Service) GetRelationDetailsForUnit(
 	ctx context.Context,
 	relationUUID corerelation.UUID,
-	unitName string,
+	unitName unit.Name,
 ) (relation.RelationDetails, error) {
 	// TODO (hml) 2025-03-11
 	// During implementation investigate the difference between the
@@ -220,7 +220,7 @@ func (s *Service) GetRelationsStatusForUnit(
 func (s *Service) GetRelationUnit(
 	ctx context.Context,
 	relationUUID corerelation.UUID,
-	unitName string,
+	unitName unit.Name,
 ) (corerelation.UnitUUID, error) {
 	return "", errors.NotImplemented
 }
@@ -230,7 +230,7 @@ func (s *Service) GetRelationUnit(
 func (s *Service) GetRelationUnitByID(
 	ctx context.Context,
 	relationID int,
-	unitName string,
+	unitName unit.Name,
 ) (corerelation.UnitUUID, error) {
 	return "", errors.NotImplemented
 }


### PR DESCRIPTION
Some methods have unitName as a string, some as a unit.Name. Update so all use the type for consistency.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Juju behavior using this code change is not currently available. Unit tests should all pass.