### PR TITLE
docs: fix PR template link for conventional-commits.md

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 The PR title should match: <type>(optional <scope>): <description>.
 
 Please also ensure all commits in this PR comply with our conventional commits specification:
-https://docs.google.com/document/d/1SYUo9G7qZ_jdoVXpUVamS5VCgHmtZ0QA-wZxKoMS-C0 
+https://github.com/juju/juju/blob/main/docs/contributor/reference/conventional-commits.md
 -->
 
 <!-- Why this change is needed and what it does. -->
@@ -32,4 +32,3 @@ https://docs.google.com/document/d/1SYUo9G7qZ_jdoVXpUVamS5VCgHmtZ0QA-wZxKoMS-C0
 **Launchpad bug:** https://bugs.launchpad.net/juju/+bug/
 
 **Jira card:** JUJU-
-


### PR DESCRIPTION
<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://github.com/juju/juju/blob/main/doc/conventional-commits.md
-->

<!-- Why this change is needed and what it does. -->

This is a very small fix for the link to the `conventional-commits.md` in the PR template.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Fix Issue:** #18904 

