### PR TITLE
chore: replace the 0 constant by (namespaced) UUID for alpha

### DIFF
--- a/cmd/juju/space/list_test.go
+++ b/cmd/juju/space/list_test.go
@@ -87,10 +87,10 @@ func (s *ListSuite) TestOutputFormats(c *gc.C) {
 	outDir := c.MkDir()
 	expectedYAML := `
 spaces:
-- id: "0"
+- id: 00000001-0000-7000-b000-7a770aed04bc
   name: alpha
   subnets: {}
-- id: "1"
+- id: deadbeef1
   name: space1
   subnets:
     2001:db8::/32:
@@ -105,7 +105,7 @@ spaces:
       status: 'error: invalid subnet CIDR: invalid'
       zones:
       - zone1
-- id: "2"
+- id: deadbeef2
   name: space2
   subnets:
     4.3.2.0/28:
@@ -127,12 +127,12 @@ spaces:
 {
   "spaces": [
     {
-      "id": "0",
+      "id": "00000001-0000-7000-b000-7a770aed04bc",
       "name": "alpha",
       "subnets": {}
     },
     {
-      "id": "1",
+      "id": "deadbeef1",
       "name": "space1",
       "subnets": {
         "2001:db8::/32": {
@@ -154,7 +154,7 @@ spaces:
       }
     },
     {
-      "id": "2",
+      "id": "deadbeef2",
       "name": "space2",
       "subnets": {
         "10.1.2.0/24": {
@@ -204,13 +204,13 @@ spaces:
 `, "") + "\n"
 
 	expectedTabular := `
-Name    Space ID  Subnets      
-alpha   0                      
-space1  1         2001:db8::/32
-                  invalid      
-space2  2         10.1.2.0/24  
-                  4.3.2.0/28   
-                               
+Name    Space ID                              Subnets      
+alpha   00000001-0000-7000-b000-7a770aed04bc               
+space1  deadbeef1                             2001:db8::/32
+                                              invalid      
+space2  deadbeef2                             10.1.2.0/24  
+                                              4.3.2.0/28   
+                                                           
 `[1:]
 
 	expectedShortTabular := `

--- a/cmd/juju/space/list_test.go
+++ b/cmd/juju/space/list_test.go
@@ -87,7 +87,7 @@ func (s *ListSuite) TestOutputFormats(c *gc.C) {
 	outDir := c.MkDir()
 	expectedYAML := `
 spaces:
-- id: 00000001-0000-7000-b000-7a770aed04bc
+- id: 656b4a82-e28c-53d6-a014-f0dd53417eb6
   name: alpha
   subnets: {}
 - id: deadbeef1
@@ -127,7 +127,7 @@ spaces:
 {
   "spaces": [
     {
-      "id": "00000001-0000-7000-b000-7a770aed04bc",
+      "id": "656b4a82-e28c-53d6-a014-f0dd53417eb6",
       "name": "alpha",
       "subnets": {}
     },
@@ -205,7 +205,7 @@ spaces:
 
 	expectedTabular := `
 Name    Space ID                              Subnets      
-alpha   00000001-0000-7000-b000-7a770aed04bc               
+alpha   656b4a82-e28c-53d6-a014-f0dd53417eb6               
 space1  deadbeef1                             2001:db8::/32
                                               invalid      
 space2  deadbeef2                             10.1.2.0/24  

--- a/cmd/juju/space/package_test.go
+++ b/cmd/juju/space/package_test.go
@@ -191,14 +191,14 @@ func NewStubAPI() *StubAPI {
 		VLANTag:    42,
 	}}
 	spaces := []params.Space{{
-		Id:   "0",
+		Id:   network.AlphaSpaceId,
 		Name: network.AlphaSpaceName,
 	}, {
-		Id:      "1",
+		Id:      "deadbeef1",
 		Name:    "space1",
 		Subnets: append([]params.Subnet{}, subnets[:2]...),
 	}, {
-		Id:      "2",
+		Id:      "deadbeef2",
 		Name:    "space2",
 		Subnets: append([]params.Subnet{}, subnets[2:]...),
 	}}

--- a/core/network/space.go
+++ b/core/network/space.go
@@ -20,7 +20,7 @@ const (
 	// AlphaSpaceId is the ID of the alpha network space.
 	// Application endpoints are bound to this space by default
 	// if no explicit binding is specified.
-	AlphaSpaceId = "019593ec-84f2-7772-bad2-7a770aed04bc"
+	AlphaSpaceId = "00000001-0000-7000-b000-7a770aed04bc"
 
 	// AlphaSpaceName is the name of the alpha network space.
 	AlphaSpaceName = "alpha"

--- a/core/network/space.go
+++ b/core/network/space.go
@@ -20,7 +20,7 @@ const (
 	// AlphaSpaceId is the ID of the alpha network space.
 	// Application endpoints are bound to this space by default
 	// if no explicit binding is specified.
-	AlphaSpaceId = "00000001-0000-7000-b000-7a770aed04bc"
+	AlphaSpaceId = "656b4a82-e28c-53d6-a014-f0dd53417eb6"
 
 	// AlphaSpaceName is the name of the alpha network space.
 	AlphaSpaceName = "alpha"

--- a/core/network/space.go
+++ b/core/network/space.go
@@ -20,7 +20,7 @@ const (
 	// AlphaSpaceId is the ID of the alpha network space.
 	// Application endpoints are bound to this space by default
 	// if no explicit binding is specified.
-	AlphaSpaceId = "0"
+	AlphaSpaceId = "019593ec-84f2-7772-bad2-7a770aed04bc"
 
 	// AlphaSpaceName is the name of the alpha network space.
 	AlphaSpaceName = "alpha"

--- a/core/network/space_test.go
+++ b/core/network/space_test.go
@@ -4,6 +4,7 @@
 package network_test
 
 import (
+	"github.com/google/uuid"
 	"github.com/juju/collections/set"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -205,4 +206,20 @@ func (s *spaceSuite) TestConvertSpaceName(c *gc.C) {
 		result := network.ConvertSpaceName(test.name, test.existing)
 		c.Check(result, gc.Equals, test.expected)
 	}
+}
+
+// This test guarantees that the AlphaSpaceId is a crafted, well-known v5 UUID
+// using a Juju namespace and a fixed string ("juju.network.space.alpha").
+func (s *spaceSuite) TestAlphaSpaceID(c *gc.C) {
+	// Juju UUID namespace that we (should) use for all Juju well-known UUIDs.
+	jujuUUIDNamespace := "96bb15e6-8b85-448b-9fce-ede1a1700e64"
+	namespaceUUID, err := uuid.Parse(jujuUUIDNamespace)
+	c.Assert(err, jc.ErrorIsNil)
+
+	alphaSpaceUUID := uuid.NewSHA1(namespaceUUID, []byte("juju.network.space.alpha"))
+	c.Assert(alphaSpaceUUID.String(), gc.Equals, network.AlphaSpaceId)
+}
+
+func (s *spaceSuite) TestAlphaSpaceName(c *gc.C) {
+	c.Assert(network.AlphaSpaceName, gc.Equals, "alpha")
 }

--- a/domain/relation/state/relation_test.go
+++ b/domain/relation/state/relation_test.go
@@ -818,8 +818,8 @@ VALUES (?,?,?,?,?)
 func (s *relationSuite) addApplicationEndpoint(c *gc.C, applicationEndpointUUID string, applicationUUID, charmRelationUUID string) {
 	s.query(c, `
 INSERT INTO application_endpoint (uuid, application_uuid, charm_relation_uuid,space_uuid)
-VALUES (?,?,?,0)
-`, applicationEndpointUUID, applicationUUID, charmRelationUUID)
+VALUES (?, ?, ?, ?)
+`, applicationEndpointUUID, applicationUUID, charmRelationUUID, network.AlphaSpaceId)
 }
 
 // addCharm inserts a new charm into the database with the given UUID.

--- a/domain/relation/watcher_test.go
+++ b/domain/relation/watcher_test.go
@@ -131,8 +131,8 @@ VALUES (?, ?, ?, ?, ?)
 func (s *watcherSuite) addApplicationEndpoint(c *gc.C, applicationEndpointUUID string, applicationUUID, charmRelationUUID string) {
 	s.arrange(c, `
 INSERT INTO application_endpoint (uuid, application_uuid, charm_relation_uuid,space_uuid)
-VALUES (?,?,?,0)
-`, applicationEndpointUUID, applicationUUID, charmRelationUUID)
+VALUES (?, ?, ?, ?)
+`, applicationEndpointUUID, applicationUUID, charmRelationUUID, network.AlphaSpaceId)
 }
 
 // addCharm inserts a new charm into the database with a predefined UUID, reference name, and architecture ID.

--- a/domain/schema/model/sql/0008-space.sql
+++ b/domain/schema/model/sql/0008-space.sql
@@ -14,7 +14,7 @@ CREATE TABLE provider_space (
 CREATE UNIQUE INDEX idx_provider_space_space_uuid ON provider_space (space_uuid);
 
 INSERT INTO space VALUES
-('00000001-0000-7000-b000-7a770aed04bc', 'alpha');
+('656b4a82-e28c-53d6-a014-f0dd53417eb6', 'alpha');
 
 CREATE VIEW v_space_subnet AS
 SELECT

--- a/domain/schema/model/sql/0008-space.sql
+++ b/domain/schema/model/sql/0008-space.sql
@@ -14,7 +14,7 @@ CREATE TABLE provider_space (
 CREATE UNIQUE INDEX idx_provider_space_space_uuid ON provider_space (space_uuid);
 
 INSERT INTO space VALUES
-('019593ec-84f2-7772-bad2-7a770aed04bc', 'alpha');
+('00000001-0000-7000-b000-7a770aed04bc', 'alpha');
 
 CREATE VIEW v_space_subnet AS
 SELECT

--- a/domain/schema/model/sql/0008-space.sql
+++ b/domain/schema/model/sql/0008-space.sql
@@ -3,22 +3,18 @@ CREATE TABLE space (
     name TEXT NOT NULL
 );
 
-CREATE UNIQUE INDEX idx_spaces_uuid_name
-ON space (name);
+CREATE UNIQUE INDEX idx_spaces_uuid_name ON space (name);
 
 CREATE TABLE provider_space (
     provider_id TEXT NOT NULL PRIMARY KEY,
     space_uuid TEXT NOT NULL,
-    CONSTRAINT fk_provider_space_space_uuid
-    FOREIGN KEY (space_uuid)
-    REFERENCES space (uuid)
+    CONSTRAINT fk_provider_space_space_uuid FOREIGN KEY (space_uuid) REFERENCES space (uuid)
 );
 
-CREATE UNIQUE INDEX idx_provider_space_space_uuid
-ON provider_space (space_uuid);
+CREATE UNIQUE INDEX idx_provider_space_space_uuid ON provider_space (space_uuid);
 
 INSERT INTO space VALUES
-(0, 'alpha');
+('019593ec-84f2-7772-bad2-7a770aed04bc', 'alpha');
 
 CREATE VIEW v_space_subnet AS
 SELECT
@@ -34,18 +30,12 @@ SELECT
     provider_network.provider_network_id AS subnet_provider_network_id,
     availability_zone.name AS subnet_az,
     provider_space.provider_id AS subnet_provider_space_uuid
-FROM space
-LEFT JOIN provider_space
-    ON space.uuid = provider_space.space_uuid
-LEFT JOIN subnet
-    ON space.uuid = subnet.space_uuid
-LEFT JOIN provider_subnet
-    ON subnet.uuid = provider_subnet.subnet_uuid
-LEFT JOIN provider_network_subnet
-    ON subnet.uuid = provider_network_subnet.subnet_uuid
-LEFT JOIN provider_network
-    ON provider_network_subnet.provider_network_uuid = provider_network.uuid
-LEFT JOIN availability_zone_subnet
-    ON subnet.uuid = availability_zone_subnet.subnet_uuid
-LEFT JOIN availability_zone
-    ON availability_zone_subnet.availability_zone_uuid = availability_zone.uuid;
+FROM
+    space
+LEFT JOIN provider_space ON space.uuid = provider_space.space_uuid
+LEFT JOIN subnet ON space.uuid = subnet.space_uuid
+LEFT JOIN provider_subnet ON subnet.uuid = provider_subnet.subnet_uuid
+LEFT JOIN provider_network_subnet ON subnet.uuid = provider_network_subnet.subnet_uuid
+LEFT JOIN provider_network ON provider_network_subnet.provider_network_uuid = provider_network.uuid
+LEFT JOIN availability_zone_subnet ON subnet.uuid = availability_zone_subnet.subnet_uuid
+LEFT JOIN availability_zone ON availability_zone_subnet.availability_zone_uuid = availability_zone.uuid;

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -668,12 +668,19 @@ func (i *importer) parseBindings(bindingsMap map[string]string) (*Bindings, erro
 	if bindingsMap == nil {
 		bindingsMap = make(map[string]string, 1)
 	}
-	if _, exists := bindingsMap[defaultEndpointName]; !exists {
+	spaceID, exists := bindingsMap[defaultEndpointName]
+	if !exists {
 		if defaultMappingsAreIds {
 			bindingsMap[defaultEndpointName] = network.AlphaSpaceId
 		} else {
 			bindingsMap[defaultEndpointName] = network.AlphaSpaceName
 		}
+	} else if spaceID == "0" {
+		// In pre-4.0 versions we used the "0" string as space ID for the
+		// default (alpha) space instad of a UUID. If we find this ID when
+		// importing, then we need to update it to the new default space ID.
+		// This is of course temporary until the whole legacy state is removed.
+		bindingsMap[defaultEndpointName] = network.AlphaSpaceId
 	}
 
 	return NewBindings(i.st, bindingsMap)


### PR DESCRIPTION
The alpha space currently has a hard-coded ID `0`, which is inconvenient both because the DDL has `uuid` in the space table (which `0` isn't) and also because when we list the spaces on the CLI we get inconsistent output between alpha and the manually created spaces:
```
Name   Space ID                              Subnets
alpha  0                                     172.31.0.0/20
beta   0195942d-54fc-77b6-99be-1c36e21da0d6  172.31.16.0/20
gamma  0195942d-9b23-7a6b-ba13-04bab64c628e  172.31.32.0/20
```

This patch addresses these issues and assigns a static constant UUID v7 to the alpha space.
The DDL had to be updated to take this new value into account, as well as the tests.

<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://github.com/juju/juju/blob/main/doc/conventional-commits.md
-->

<!-- Why this change is needed and what it does. -->


## QA steps

__Note: we cannot test the relations (of previously bound endpoints) because they are disabled until their migration to dqlite.__

The scenario to flex this changes include listing spaces, creating spaces, moving subnets and binding endpoints.
It's better to test this on AWS so we have access to multiple subnets.
```
$ juju bootstrap aws c
$ juju add-model m
$ juju spaces 
Name   Space ID                              Subnets
alpha  019593ec-84f2-7772-bad2-7a770aed04bc  172.31.0.0/20
                                             172.31.16.0/20
                                             172.31.32.0/20
$ juju add-space beta
$ juju add-space gamma
$ juju spaces
Name   Space ID                              Subnets
alpha  019593ec-84f2-7772-bad2-7a770aed04bc  172.31.0.0/20
                                             172.31.16.0/20
                                             172.31.32.0/20
beta   0195a8bf-fe16-7451-811e-98fc839dbf8d
gamma  0195a8c0-06bf-7eb8-9c9a-204219cb9703
$ juju move-to-space beta 172.31.16.0/20
Subnet 172.31.16.0/20 moved from alpha to beta
$ juju move-to-space gamma 172.31.32.0/20
Subnet 172.31.32.0/20 moved from alpha to gamma
$ juju spaces 
Name   Space ID                              Subnets
gamma  0195a8c0-06bf-7eb8-9c9a-204219cb9703  172.31.32.0/20
alpha  019593ec-84f2-7772-bad2-7a770aed04bc  172.31.0.0/20
beta   0195a8bf-fe16-7451-811e-98fc839dbf8d  172.31.16.0/20
$ juju subnets
subnets:
  172.31.0.0/20:
    type: ipv4
    provider-id: subnet-01458fe756249e784
    provider-network-id: vpc-012fb34653f767f98
    space: alpha
    zones:
    - eu-west-3a
  172.31.16.0/20:
    type: ipv4
    provider-id: subnet-00c48f5bd8a2040a0
    provider-network-id: vpc-012fb34653f767f98
    space: beta
    zones:
    - eu-west-3b
  172.31.32.0/20:
    type: ipv4
    provider-id: subnet-020aa8c5ba9bfb9e2
    provider-network-id: vpc-012fb34653f767f98
    space: gamma
    zones:
    - eu-west-3c
```
Now we can deploy and bind:
```
$ juju deploy influxdb
Deployed "influxdb" from charm-hub charm "influxdb", revision 28 in channel latest/stable on ubuntu@20.04/stable
$ juju show-application influxdb
influxdb:
  charm: influxdb
  base: ubuntu@20.04
  channel: latest/stable
  principal: true
  exposed: false
  remote: false
  life: alive
  endpoint-bindings:
    "": alpha
    admin: alpha
    grafana-source: alpha
    nrpe-external-master: alpha
    query: alpha
$ juju bind influxdb admin=beta
moving endpoint "admin" from space "alpha" to "beta"
no change to endpoints in space "alpha": grafana-source, nrpe-external-master, query
$ juju show-application influxdb
influxdb:
  charm: influxdb
  base: ubuntu@20.04
  channel: latest/stable
  principal: true
  exposed: false
  remote: false
  life: alive
  endpoint-bindings:
    "": alpha
    admin: beta
    grafana-source: alpha
    nrpe-external-master: alpha
    query: alpha
$ juju bind influxdb gamma
moving endpoint "grafana-source" from space "alpha" to "gamma"
moving endpoint "nrpe-external-master" from space "alpha" to "gamma"
moving endpoint "query" from space "alpha" to "gamma"
no change to endpoint in space "beta": admin
$ juju show-application influxdb
influxdb:
  charm: influxdb
  base: ubuntu@20.04
  channel: latest/stable
  principal: true
  exposed: false
  remote: false
  life: alive
  endpoint-bindings:
    "": gamma
    admin: beta
    grafana-source: gamma
    nrpe-external-master: gamma
    query: gamma
```

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/

**Jira card:** JUJU-

