### PR TITLE
fix: facade restriction for "sshserver" facade

### DIFF
--- a/apiserver/restrict_controller.go
+++ b/apiserver/restrict_controller.go
@@ -44,6 +44,8 @@ var commonFacadeNames = set.NewStrings(
 
 	// ModelConfig may be used for letting controller commands access provider, for example, juju add-k8s.
 	"ModelConfig",
+
+	"SSHServer",
 )
 
 func controllerFacadesOnly(facadeName, _ string) error {


### PR DESCRIPTION
We were receiving the error in the controller logs of:
```
2025-03-18T06:50:13.264Z [jujud] 2025-03-18 06:50:13 ERROR juju.worker.dependency engine.go:695 "ssh-server" manifold worker returned unexpected error: facade "SSHServer" not supported on container models (not supported)
2025-03-18T06:50:13.264Z [jujud] eb130206-21a1-4948-88eb-c5c0a774c33d: controller-0 2025-03-18 06:50:13 ERROR juju.worker.dependency engine.go:695 "ssh-server" manifold worker returned unexpected error: facade "SSHServer" not supported on container models (not supported)
```

This seemed to be because it wasn't added to the restrict list. I added it to commonFacadeNames, which is called by "isCAASModelFacade" to check if it contains this facade. 

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps
1. `juju bootstrap microk8s a`
2. `juju debug-log -m controller` - and check the logs are clear.

Next, check the server is fine via:
1. `kubectl port-forward -n controller-a controller-0 17022:17022` - port forward the api-server over. 
2. `ssh -J localhost:17022 ubuntu@app.controller.model` - ssh to the server.
<!-- 

Describe steps to verify that the change works. 

If you're changing any of the facades, you need to ensure that you've tested
a model migration from 3.6 to 4.0 and from 4.0 to 4.0.

The following steps are a good starting point:

 1. Bootstrap a 3.6 controller and deploy a charm.

```sh
$ juju bootstrap lxd src36
$ juju add-model moveme1
$ juju deploy juju-qa-test
```

 4. Bootstrap a 4.0 controller with the changes and migrate the model.

```sh
$ juju bootstrap lxd dst40
$ juju migrate src36:moveme1 dst40
$ juju add-unit juju-qa-test
```

 5. Verify no errors exist in the model logs for the agents. If there are
    errors, this is a bug and should be fixed before merging. The fix can
    either be applied to the 4.0 branch (preferable) or the 3.6 branch, though
    that needs to be discussed with the team.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme1
```

    6. We also need to test a model migration from 4.0 to 4.0.

```sh
$ juju bootstrap lxd src40
$ juju add-model moveme2
$ juju deploy juju-qa-test
```

```sh
$ juju migrate src40:moveme2 dst40
$ juju add-unit juju-qa-test
```

    7. Verify that there are no errors in the controller or model logs.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme2
```

-->

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/

**Jira card:** JUJU-

