### PR TITLE
feat: application state and service for export

### DIFF
--- a/domain/application/service/migration.go
+++ b/domain/application/service/migration.go
@@ -29,6 +29,12 @@ import (
 	internalerrors "github.com/juju/juju/internal/errors"
 )
 
+// MigrationState is the state required for migrating applications.
+type MigrationState interface {
+	// ExportApplications returns all the applications in the model.
+	GetApplicationsForExport(ctx context.Context) ([]application.ExportApplication, error)
+}
+
 // MigrationService provides the API for migrating applications.
 type MigrationService struct {
 	st                    State
@@ -140,6 +146,11 @@ func (s *MigrationService) GetCharmByApplicationName(ctx context.Context, name s
 		&actions,
 		&lxdProfile,
 	), locator, nil
+}
+
+// ExportApplications returns all the applications in the model.
+func (s *MigrationService) GetApplicationsForExport(ctx context.Context) ([]application.ExportApplication, error) {
+	return s.st.GetApplicationsForExport(ctx)
 }
 
 // GetApplicationConfigAndSettings returns the application config and settings

--- a/domain/application/service/migration_test.go
+++ b/domain/application/service/migration_test.go
@@ -644,6 +644,34 @@ func (s *migrationServiceSuite) TestGetUnitAgentStatusInvalidUUID(c *gc.C) {
 	c.Assert(err, jc.ErrorIs, errors.NotValid)
 }
 
+func (s *migrationServiceSuite) TestGetApplicationsForExport(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	apps := []application.ExportApplication{
+		{
+			Name: "foo",
+		},
+	}
+
+	s.state.EXPECT().GetApplicationsForExport(gomock.Any()).Return(apps, nil)
+
+	res, err := s.service.GetApplicationsForExport(context.Background())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(res, gc.DeepEquals, apps)
+}
+
+func (s *migrationServiceSuite) TestGetApplicationsForExportNoApplications(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	apps := []application.ExportApplication{}
+
+	s.state.EXPECT().GetApplicationsForExport(gomock.Any()).Return(apps, nil)
+
+	res, err := s.service.GetApplicationsForExport(context.Background())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(res, gc.DeepEquals, apps)
+}
+
 func (s *migrationServiceSuite) setupMocks(c *gc.C) *gomock.Controller {
 	ctrl := s.baseSuite.setupMocks(c)
 

--- a/domain/application/service/package_mock_test.go
+++ b/domain/application/service/package_mock_test.go
@@ -926,6 +926,45 @@ func (c *MockStateGetApplicationUnitLifeCall) DoAndReturn(f func(context.Context
 	return c
 }
 
+// GetApplicationsForExport mocks base method.
+func (m *MockState) GetApplicationsForExport(ctx context.Context) ([]application0.ExportApplication, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetApplicationsForExport", ctx)
+	ret0, _ := ret[0].([]application0.ExportApplication)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetApplicationsForExport indicates an expected call of GetApplicationsForExport.
+func (mr *MockStateMockRecorder) GetApplicationsForExport(ctx any) *MockStateGetApplicationsForExportCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetApplicationsForExport", reflect.TypeOf((*MockState)(nil).GetApplicationsForExport), ctx)
+	return &MockStateGetApplicationsForExportCall{Call: call}
+}
+
+// MockStateGetApplicationsForExportCall wrap *gomock.Call
+type MockStateGetApplicationsForExportCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateGetApplicationsForExportCall) Return(arg0 []application0.ExportApplication, arg1 error) *MockStateGetApplicationsForExportCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateGetApplicationsForExportCall) Do(f func(context.Context) ([]application0.ExportApplication, error)) *MockStateGetApplicationsForExportCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateGetApplicationsForExportCall) DoAndReturn(f func(context.Context) ([]application0.ExportApplication, error)) *MockStateGetApplicationsForExportCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetApplicationsForRevisionUpdater mocks base method.
 func (m *MockState) GetApplicationsForRevisionUpdater(ctx context.Context) ([]application0.RevisionUpdaterApplication, error) {
 	m.ctrl.T.Helper()

--- a/domain/application/service/service.go
+++ b/domain/application/service/service.go
@@ -46,6 +46,7 @@ type State interface {
 	CharmState
 	StorageState
 	UnitState
+	MigrationState
 }
 
 const (

--- a/domain/application/state/application.go
+++ b/domain/application/state/application.go
@@ -718,13 +718,13 @@ func (st *State) SetApplicationScalingState(ctx context.Context, appName string,
 		ScaleTarget: targetScale,
 	}
 
-	upsertApplicationScale := fmt.Sprintf(`
+	upsertApplicationScale := `
 UPDATE application_scale SET
     scale = $applicationScale.scale,
     scaling = $applicationScale.scaling,
     scale_target = $applicationScale.scale_target
 WHERE application_uuid = $applicationScale.application_uuid
-`)
+`
 
 	upsertStmt, err := st.Prepare(upsertApplicationScale, scaleDetails)
 	if err != nil {

--- a/domain/application/state/migration.go
+++ b/domain/application/state/migration.go
@@ -1,0 +1,68 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"context"
+
+	"github.com/canonical/sqlair"
+	"github.com/juju/errors"
+
+	coreapplication "github.com/juju/juju/core/application"
+	corecharm "github.com/juju/juju/core/charm"
+	"github.com/juju/juju/domain/application"
+	"github.com/juju/juju/domain/life"
+)
+
+// ExportApplications returns all the applications in the model.
+func (st *State) GetApplicationsForExport(ctx context.Context) ([]application.ExportApplication, error) {
+	db, err := st.DB()
+	if err != nil {
+		return nil, err
+	}
+
+	var app exportApplication
+	query := `SELECT &exportApplication.* FROM v_application_export`
+	stmt, err := st.Prepare(query, app)
+	if err != nil {
+		return nil, err
+	}
+
+	var apps []exportApplication
+	if err := db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		err := tx.Query(ctx, stmt).GetAll(&apps)
+		if errors.Is(err, sqlair.ErrNoRows) {
+			return nil
+		} else if err != nil {
+			return errors.Annotate(err, "failed to get applications for export")
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	exportApps := make([]application.ExportApplication, len(apps))
+	for i, app := range apps {
+		exportApps[i] = application.ExportApplication{
+			UUID:         app.UUID,
+			Name:         app.Name,
+			CharmUUID:    app.CharmUUID,
+			Life:         app.Life,
+			PasswordHash: app.PasswordHash,
+			Exposed:      app.Exposed,
+			Subordinate:  app.Subordinate,
+		}
+	}
+	return exportApps, nil
+}
+
+type exportApplication struct {
+	UUID         coreapplication.ID `db:"uuid"`
+	Name         string             `db:"name"`
+	CharmUUID    corecharm.ID       `db:"charm_uuid"`
+	Life         life.Life          `db:"life_id"`
+	PasswordHash string             `db:"password_hash"`
+	Exposed      bool               `db:"exposed"`
+	Subordinate  bool               `db:"subordinate"`
+}

--- a/domain/application/state/migration_test.go
+++ b/domain/application/state/migration_test.go
@@ -1,0 +1,110 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/juju/clock"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/domain/application"
+	"github.com/juju/juju/domain/life"
+	loggertesting "github.com/juju/juju/internal/logger/testing"
+)
+
+type migrationStateSuite struct {
+	baseSuite
+}
+
+var _ = gc.Suite(&migrationStateSuite{})
+
+func (s *migrationStateSuite) TestExportApplications(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory(), clock.WallClock, loggertesting.WrapCheckLog(c))
+
+	id := s.createApplication(c, "foo", life.Alive)
+	charmID, err := st.GetCharmIDByApplicationName(context.Background(), "foo")
+	c.Assert(err, jc.ErrorIsNil)
+
+	apps, err := st.GetApplicationsForExport(context.Background())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(apps, gc.DeepEquals, []application.ExportApplication{
+		{
+			UUID:      id,
+			CharmUUID: charmID,
+			Name:      "foo",
+			Life:      life.Alive,
+		},
+	})
+}
+
+func (s *migrationStateSuite) TestExportApplicationsMany(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory(), clock.WallClock, loggertesting.WrapCheckLog(c))
+
+	var want []application.ExportApplication
+
+	for i := 0; i < 10; i++ {
+		name := fmt.Sprintf("foo%d", i)
+		id := s.createApplication(c, name, life.Alive)
+		charmID, err := st.GetCharmIDByApplicationName(context.Background(), name)
+		c.Assert(err, jc.ErrorIsNil)
+
+		want = append(want, application.ExportApplication{
+			UUID:      id,
+			CharmUUID: charmID,
+			Name:      name,
+			Life:      life.Alive,
+		})
+	}
+
+	apps, err := st.GetApplicationsForExport(context.Background())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(apps, gc.DeepEquals, want)
+}
+
+func (s *migrationStateSuite) TestExportApplicationsDeadOrDying(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory(), clock.WallClock, loggertesting.WrapCheckLog(c))
+
+	// The prior state implementation allows for applications to be in the
+	// Dying or Dead state. This test ensures that these states are exported
+	// correctly.
+	// TODO (stickupkid): We should just skip these applications in the export.
+
+	id0 := s.createApplication(c, "foo0", life.Dying)
+	charmID0, err := st.GetCharmIDByApplicationName(context.Background(), "foo0")
+	c.Assert(err, jc.ErrorIsNil)
+
+	id1 := s.createApplication(c, "foo1", life.Dead)
+	charmID1, err := st.GetCharmIDByApplicationName(context.Background(), "foo1")
+	c.Assert(err, jc.ErrorIsNil)
+
+	want := []application.ExportApplication{
+		{
+			UUID:      id0,
+			CharmUUID: charmID0,
+			Name:      "foo0",
+			Life:      life.Dying,
+		},
+		{
+			UUID:      id1,
+			CharmUUID: charmID1,
+			Name:      "foo1",
+			Life:      life.Dead,
+		},
+	}
+
+	apps, err := st.GetApplicationsForExport(context.Background())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(apps, gc.DeepEquals, want)
+}
+
+func (s *migrationStateSuite) TestExportApplicationsWithNoApplications(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory(), clock.WallClock, loggertesting.WrapCheckLog(c))
+
+	apps, err := st.GetApplicationsForExport(context.Background())
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(apps, gc.HasLen, 0)
+}

--- a/domain/application/types.go
+++ b/domain/application/types.go
@@ -4,6 +4,7 @@
 package application
 
 import (
+	"github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/charm"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/objectstore"
@@ -15,6 +16,7 @@ import (
 	domaincharm "github.com/juju/juju/domain/application/charm"
 	"github.com/juju/juju/domain/constraints"
 	"github.com/juju/juju/domain/ipaddress"
+	"github.com/juju/juju/domain/life"
 	"github.com/juju/juju/domain/linklayerdevice"
 	internalcharm "github.com/juju/juju/internal/charm"
 	charmresource "github.com/juju/juju/internal/charm/resource"
@@ -331,3 +333,14 @@ type UnitWorkloadStatuses map[coreunit.Name]UnitStatusInfo[WorkloadStatusType]
 // UnitCloudContainerStatuses represents the cloud container statuses of a collection
 // of units. The statuses are indexed by unit name.
 type UnitCloudContainerStatuses map[coreunit.Name]StatusInfo[CloudContainerStatusType]
+
+// ExportApplication contains parameters for exporting an application.
+type ExportApplication struct {
+	UUID         application.ID
+	Name         string
+	CharmUUID    charm.ID
+	Life         life.Life
+	PasswordHash string
+	Exposed      bool
+	Subordinate  bool
+}

--- a/domain/schema/model/sql/0019-application.sql
+++ b/domain/schema/model/sql/0019-application.sql
@@ -240,3 +240,19 @@ SELECT
     c.source_id
 FROM application AS a
 JOIN charm AS c ON a.charm_uuid = c.uuid;
+
+CREATE VIEW v_application_export AS
+SELECT
+    a.uuid,
+    a.name,
+    a.life_id,
+    a.charm_uuid,
+    a.charm_modified_version,
+    a.charm_upgrade_on_error,
+    a.exposed,
+    a.placement,
+    a.password_hash,
+    cm.subordinate
+FROM application AS a
+JOIN charm AS c ON a.charm_uuid = c.uuid
+JOIN charm_metadata AS cm ON c.uuid = cm.charm_uuid;

--- a/domain/schema/model_schema_test.go
+++ b/domain/schema/model_schema_test.go
@@ -292,6 +292,7 @@ func (s *modelSchemaSuite) TestModelViews(c *gc.C) {
 		"v_application_charm_download_info",
 		"v_application_config",
 		"v_application_constraint",
+		"v_application_export",
 		"v_application_exposed_endpoint",
 		"v_application_origin",
 		"v_application_platform_channel",


### PR DESCRIPTION
Adds an export migration application method to both service and state. This method will start to service as a way to add more fields to enable true migrations from dqilte. This will ensure that we're no longer running from state.

This isn't currently wired up, that will be the next PR, once that PR is wired up, migrations from 4.0 will break for complex applications. This is until everything is correctly wired up.

## QA steps

```sh
$ juju boostrap lxd src
$ juju add-model moveme
$ juju deploy ubuntu
$ juju bootstrap lxd dst
$ juju migrate src:moveme dst
$ juju status -m dst:moveme
```

## Links

**Jira card:** [JUJU-7618](https://warthogs.atlassian.net/browse/JUJU-7618)

