### PR TITLE
feat: create service methods for exposed endpoints in app

### DIFF
--- a/domain/application/service/application.go
+++ b/domain/application/service/application.go
@@ -270,6 +270,39 @@ type ApplicationState interface {
 	// NamespaceForWatchApplicationScale returns the namespace identifier
 	// for application scale change watchers.
 	NamespaceForWatchApplicationScale() string
+
+	// ApplicationExposed returns whether the provided application is exposed or
+	// not.
+	//
+	// If no application is found, an error satisfying
+	// [applicationerrors.ApplicationNotFound] is returned.
+	ApplicationExposed(ctx context.Context, appID coreapplication.ID) (bool, error)
+
+	// GetExposedEndpoints returns map where keys are endpoint names (or the ""
+	// value which represents all endpoints) and values are ExposedEndpoint
+	// instances that specify which sources (spaces or CIDRs) can access the
+	// opened ports for each endpoint once the application is exposed.
+	//
+	// If no application is found, an error satisfying
+	// [applicationerrors.ApplicationNotFound] is returned.
+	GetExposedEndpoints(ctx context.Context, appID coreapplication.ID) (map[string]application.ExposedEndpoint, error)
+
+	// UnsetExposeSettings removes the expose settings for the provided list of
+	// endpoint names. If the resulting exposed endpoints map for the application
+	// becomes empty after the settings are removed, the application will be
+	// automatically unexposed.
+	//
+	// If no application is found, an error satisfying
+	// [applicationerrors.ApplicationNotFound] is returned.
+	UnsetExposeSettings(ctx context.Context, appID coreapplication.ID, exposedEndpoints set.Strings) error
+
+	// MergeExposeSettings marks the application as exposed and merges the provided
+	// ExposedEndpoint details into the current set of expose settings. The merge
+	// operation will overwrite expose settings for each existing endpoint name.
+	//
+	// If no application is found, an error satisfying
+	// [applicationerrors.ApplicationNotFound] is returned.
+	MergeExposeSettings(ctx context.Context, appID coreapplication.ID, exposedEndpoints map[string]application.ExposedEndpoint) error
 }
 
 func validateCharmAndApplicationParams(

--- a/domain/application/service/exposed.go
+++ b/domain/application/service/exposed.go
@@ -1,0 +1,73 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package service
+
+import (
+	"context"
+
+	"github.com/juju/collections/set"
+
+	"github.com/juju/juju/domain/application"
+	internalerrors "github.com/juju/juju/internal/errors"
+)
+
+// ApplicationExposed returns whether the provided application is exposed or not.
+//
+// If no application is found, an error satisfying
+// [applicationerrors.ApplicationNotFound] is returned.
+func (s *Service) ApplicationExposed(ctx context.Context, appName string) (bool, error) {
+	appID, err := s.st.GetApplicationIDByName(ctx, appName)
+	if err != nil {
+		return false, internalerrors.Capture(err)
+	}
+
+	return s.st.ApplicationExposed(ctx, appID)
+}
+
+// GetExposedEndpoints returns map where keys are endpoint names (or the ""
+// value which represents all endpoints) and values are ExposedEndpoint
+// instances that specify which sources (spaces or CIDRs) can access the
+// opened ports for each endpoint once the application is exposed.
+//
+// If no application is found, an error satisfying
+// [applicationerrors.ApplicationNotFound] is returned.
+func (s *Service) GetExposedEndpoints(ctx context.Context, appName string) (map[string]application.ExposedEndpoint, error) {
+	appID, err := s.st.GetApplicationIDByName(ctx, appName)
+	if err != nil {
+		return nil, internalerrors.Capture(err)
+	}
+
+	return s.st.GetExposedEndpoints(ctx, appID)
+}
+
+// UnsetExposeSettings removes the expose settings for the provided list of
+// endpoint names. If the resulting exposed endpoints map for the application
+// becomes empty after the settings are removed, the application will be
+// automatically unexposed.
+//
+// If no application is found, an error satisfying
+// [applicationerrors.ApplicationNotFound] is returned.
+func (s *Service) UnsetExposeSettings(ctx context.Context, appName string, exposedEndpoints set.Strings) error {
+	appID, err := s.st.GetApplicationIDByName(ctx, appName)
+	if err != nil {
+		return internalerrors.Capture(err)
+	}
+
+	return s.st.UnsetExposeSettings(ctx, appID, exposedEndpoints)
+}
+
+// MergeExposeSettings marks the application as exposed and merges the provided
+// ExposedEndpoint details into the current set of expose settings. The merge
+// operation will overwrite expose settings for each existing endpoint name.
+//
+// If no application is found, an error satisfying
+// [applicationerrors.ApplicationNotFound] is returned.
+func (s *Service) MergeExposeSettings(ctx context.Context, appName string, exposedEndpoints map[string]application.ExposedEndpoint) error {
+	appID, err := s.st.GetApplicationIDByName(ctx, appName)
+	if err != nil {
+		return internalerrors.Capture(err)
+	}
+
+	return s.st.MergeExposeSettings(ctx, appID, exposedEndpoints)
+}

--- a/domain/application/service/exposed_test.go
+++ b/domain/application/service/exposed_test.go
@@ -1,0 +1,95 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package service
+
+import (
+	"context"
+
+	"github.com/juju/collections/set"
+	jc "github.com/juju/testing/checkers"
+	"go.uber.org/mock/gomock"
+	gc "gopkg.in/check.v1"
+
+	coreapplication "github.com/juju/juju/core/application"
+	applicationtesting "github.com/juju/juju/core/application/testing"
+	"github.com/juju/juju/domain/application"
+	applicationerrors "github.com/juju/juju/domain/application/errors"
+)
+
+type exposedServiceSuite struct {
+	baseSuite
+}
+
+var _ = gc.Suite(&exposedServiceSuite{})
+
+func (s *exposedServiceSuite) TestApplicationExposedNotFound(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(coreapplication.ID(""), applicationerrors.ApplicationNotFound)
+
+	_, err := s.service.ApplicationExposed(context.Background(), "foo")
+	c.Assert(err, gc.ErrorMatches, "application not found")
+}
+
+func (s *exposedServiceSuite) TestApplicationExposed(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	applicationUUID := applicationtesting.GenApplicationUUID(c)
+	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(applicationUUID, nil)
+	s.state.EXPECT().ApplicationExposed(gomock.Any(), applicationUUID).Return(true, nil)
+
+	exposed, err := s.service.ApplicationExposed(context.Background(), "foo")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(exposed, jc.IsTrue)
+}
+
+func (s *exposedServiceSuite) TestExposedEndpointsNotFound(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(coreapplication.ID(""), applicationerrors.ApplicationNotFound)
+
+	_, err := s.service.GetExposedEndpoints(context.Background(), "foo")
+	c.Assert(err, gc.ErrorMatches, "application not found")
+}
+
+func (s *exposedServiceSuite) TestExposedEndpoints(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	applicationUUID := applicationtesting.GenApplicationUUID(c)
+	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(applicationUUID, nil)
+	expected := map[string]application.ExposedEndpoint{
+		"endpoint0": {
+			ExposeToSpaceIDs: set.NewStrings("space0", "space1"),
+		},
+		"endpoint1": {
+			ExposeToCIDRs: set.NewStrings("10.0.0.0/24", "10.0.1.0/24"),
+		},
+	}
+	s.state.EXPECT().GetExposedEndpoints(gomock.Any(), applicationUUID).Return(expected, nil)
+
+	obtained, err := s.service.GetExposedEndpoints(context.Background(), "foo")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(obtained, gc.DeepEquals, expected)
+}
+
+func (s *exposedServiceSuite) TestUnsetExposeSettingsNotFound(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(coreapplication.ID(""), applicationerrors.ApplicationNotFound)
+
+	err := s.service.UnsetExposeSettings(context.Background(), "foo", set.NewStrings("endpoint0"))
+	c.Assert(err, gc.ErrorMatches, "application not found")
+}
+
+func (s *exposedServiceSuite) TestUnsetExposeSettings(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	applicationUUID := applicationtesting.GenApplicationUUID(c)
+	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(applicationUUID, nil)
+	exposedEndpoints := set.NewStrings("endpoint0", "endpoint1")
+	s.state.EXPECT().UnsetExposeSettings(gomock.Any(), applicationUUID, exposedEndpoints).Return(nil)
+
+	err := s.service.UnsetExposeSettings(context.Background(), "foo", exposedEndpoints)
+	c.Assert(err, jc.ErrorIsNil)
+}

--- a/domain/application/service/package_mock_test.go
+++ b/domain/application/service/package_mock_test.go
@@ -13,6 +13,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	set "github.com/juju/collections/set"
 	application "github.com/juju/juju/core/application"
 	assumes "github.com/juju/juju/core/assumes"
 	charm "github.com/juju/juju/core/charm"
@@ -178,6 +179,45 @@ func (c *MockStateAddStorageForUnitCall) Do(f func(context.Context, storage.Name
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockStateAddStorageForUnitCall) DoAndReturn(f func(context.Context, storage.Name, unit.UUID, storage1.Directive) ([]storage.ID, error)) *MockStateAddStorageForUnitCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// ApplicationExposed mocks base method.
+func (m *MockState) ApplicationExposed(ctx context.Context, appID application.ID) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApplicationExposed", ctx, appID)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ApplicationExposed indicates an expected call of ApplicationExposed.
+func (mr *MockStateMockRecorder) ApplicationExposed(ctx, appID any) *MockStateApplicationExposedCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplicationExposed", reflect.TypeOf((*MockState)(nil).ApplicationExposed), ctx, appID)
+	return &MockStateApplicationExposedCall{Call: call}
+}
+
+// MockStateApplicationExposedCall wrap *gomock.Call
+type MockStateApplicationExposedCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateApplicationExposedCall) Return(arg0 bool, arg1 error) *MockStateApplicationExposedCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateApplicationExposedCall) Do(f func(context.Context, application.ID) (bool, error)) *MockStateApplicationExposedCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateApplicationExposedCall) DoAndReturn(f func(context.Context, application.ID) (bool, error)) *MockStateApplicationExposedCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -1866,6 +1906,45 @@ func (c *MockStateGetCharmModifiedVersionCall) DoAndReturn(f func(context.Contex
 	return c
 }
 
+// GetExposedEndpoints mocks base method.
+func (m *MockState) GetExposedEndpoints(ctx context.Context, appID application.ID) (map[string]application0.ExposedEndpoint, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetExposedEndpoints", ctx, appID)
+	ret0, _ := ret[0].(map[string]application0.ExposedEndpoint)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetExposedEndpoints indicates an expected call of GetExposedEndpoints.
+func (mr *MockStateMockRecorder) GetExposedEndpoints(ctx, appID any) *MockStateGetExposedEndpointsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetExposedEndpoints", reflect.TypeOf((*MockState)(nil).GetExposedEndpoints), ctx, appID)
+	return &MockStateGetExposedEndpointsCall{Call: call}
+}
+
+// MockStateGetExposedEndpointsCall wrap *gomock.Call
+type MockStateGetExposedEndpointsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateGetExposedEndpointsCall) Return(arg0 map[string]application0.ExposedEndpoint, arg1 error) *MockStateGetExposedEndpointsCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateGetExposedEndpointsCall) Do(f func(context.Context, application.ID) (map[string]application0.ExposedEndpoint, error)) *MockStateGetExposedEndpointsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateGetExposedEndpointsCall) DoAndReturn(f func(context.Context, application.ID) (map[string]application0.ExposedEndpoint, error)) *MockStateGetExposedEndpointsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetLatestPendingCharmhubCharm mocks base method.
 func (m *MockState) GetLatestPendingCharmhubCharm(ctx context.Context, name string, arch architecture.Architecture) (charm0.CharmLocator, error) {
 	m.ctrl.T.Helper()
@@ -2611,6 +2690,44 @@ func (c *MockStateListCharmLocatorsByNamesCall) Do(f func(context.Context, []str
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockStateListCharmLocatorsByNamesCall) DoAndReturn(f func(context.Context, []string) ([]charm0.CharmLocator, error)) *MockStateListCharmLocatorsByNamesCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// MergeExposeSettings mocks base method.
+func (m *MockState) MergeExposeSettings(ctx context.Context, appID application.ID, exposedEndpoints map[string]application0.ExposedEndpoint) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MergeExposeSettings", ctx, appID, exposedEndpoints)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// MergeExposeSettings indicates an expected call of MergeExposeSettings.
+func (mr *MockStateMockRecorder) MergeExposeSettings(ctx, appID, exposedEndpoints any) *MockStateMergeExposeSettingsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MergeExposeSettings", reflect.TypeOf((*MockState)(nil).MergeExposeSettings), ctx, appID, exposedEndpoints)
+	return &MockStateMergeExposeSettingsCall{Call: call}
+}
+
+// MockStateMergeExposeSettingsCall wrap *gomock.Call
+type MockStateMergeExposeSettingsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateMergeExposeSettingsCall) Return(arg0 error) *MockStateMergeExposeSettingsCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateMergeExposeSettingsCall) Do(f func(context.Context, application.ID, map[string]application0.ExposedEndpoint) error) *MockStateMergeExposeSettingsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateMergeExposeSettingsCall) DoAndReturn(f func(context.Context, application.ID, map[string]application0.ExposedEndpoint) error) *MockStateMergeExposeSettingsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -3376,6 +3493,44 @@ func (c *MockStateUnsetApplicationConfigKeysCall) Do(f func(context.Context, app
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockStateUnsetApplicationConfigKeysCall) DoAndReturn(f func(context.Context, application.ID, []string) error) *MockStateUnsetApplicationConfigKeysCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// UnsetExposeSettings mocks base method.
+func (m *MockState) UnsetExposeSettings(ctx context.Context, appID application.ID, exposedEndpoints set.Strings) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UnsetExposeSettings", ctx, appID, exposedEndpoints)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UnsetExposeSettings indicates an expected call of UnsetExposeSettings.
+func (mr *MockStateMockRecorder) UnsetExposeSettings(ctx, appID, exposedEndpoints any) *MockStateUnsetExposeSettingsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnsetExposeSettings", reflect.TypeOf((*MockState)(nil).UnsetExposeSettings), ctx, appID, exposedEndpoints)
+	return &MockStateUnsetExposeSettingsCall{Call: call}
+}
+
+// MockStateUnsetExposeSettingsCall wrap *gomock.Call
+type MockStateUnsetExposeSettingsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateUnsetExposeSettingsCall) Return(arg0 error) *MockStateUnsetExposeSettingsCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateUnsetExposeSettingsCall) Do(f func(context.Context, application.ID, set.Strings) error) *MockStateUnsetExposeSettingsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateUnsetExposeSettingsCall) DoAndReturn(f func(context.Context, application.ID, set.Strings) error) *MockStateUnsetExposeSettingsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/application/state/exposed.go
+++ b/domain/application/state/exposed.go
@@ -1,0 +1,42 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"context"
+
+	"github.com/juju/collections/set"
+
+	coreapplication "github.com/juju/juju/core/application"
+	"github.com/juju/juju/domain/application"
+)
+
+// ApplicationExposed returns whether the provided application is exposed or
+// not.
+func (s *State) ApplicationExposed(ctx context.Context, appID coreapplication.ID) (bool, error) {
+	return false, nil
+}
+
+// GetExposedEndpoints returns map where keys are endpoint names (or the ""
+// value which represents all endpoints) and values are ExposedEndpoint
+// instances that specify which sources (spaces or CIDRs) can access the
+// opened ports for each endpoint once the application is exposed.
+func (s *State) GetExposedEndpoints(ctx context.Context, appID coreapplication.ID) (map[string]application.ExposedEndpoint, error) {
+	return nil, nil
+}
+
+// UnsetExposeSettings removes the expose settings for the provided list of
+// endpoint names. If the resulting exposed endpoints map for the application
+// becomes empty after the settings are removed, the application will be
+// automatically unexposed.
+func (s *State) UnsetExposeSettings(ctx context.Context, appID coreapplication.ID, exposedEndpoints set.Strings) error {
+	return nil
+}
+
+// MergeExposeSettings marks the application as exposed and merges the provided
+// ExposedEndpoint details into the current set of expose settings. The merge
+// operation will overwrite expose settings for each existing endpoint name.
+func (s *State) MergeExposeSettings(ctx context.Context, appID coreapplication.ID, exposedEndpoints map[string]application.ExposedEndpoint) error {
+	return nil
+}

--- a/domain/application/types.go
+++ b/domain/application/types.go
@@ -4,6 +4,8 @@
 package application
 
 import (
+	"github.com/juju/collections/set"
+
 	"github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/charm"
 	"github.com/juju/juju/core/network"
@@ -343,4 +345,17 @@ type ExportApplication struct {
 	PasswordHash string
 	Exposed      bool
 	Subordinate  bool
+}
+
+// ExposedEndpoint encapsulates the expose-related details of a particular
+// application endpoint with respect to the sources (CIDRs or space IDs) that
+// should be able to access the ports opened by the application charm for an
+// endpoint.
+type ExposedEndpoint struct {
+	// A list of spaces that should be able to reach the opened ports
+	// for an exposed application's endpoint.
+	ExposeToSpaceIDs set.Strings
+	// A list of CIDRs that should be able to reach the opened ports
+	// for an exposed application's endpoint.
+	ExposeToCIDRs set.Strings
 }


### PR DESCRIPTION
__Note: I did hesitated a little bit on the file names (`exposed(_test?).go`) but it makes sense since the noun would be more confusing IMO.__

Basic scaffolding, service methods that are basically proxying the state methods which will be implemented in a follow-up patch.

The state methods will have to implement most of the "logic" here, the reason being that we want to avoid races.

## QA steps

Only scaffolding and nothing wired up, unit tests should pass.


## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/

**Jira card:** JUJU-7505

