### PR TITLE
test: fix remote image lxd test

### DIFF
--- a/internal/container/lxd/image_test.go
+++ b/internal/container/lxd/image_test.go
@@ -214,7 +214,7 @@ func (s *imageSuite) TestFindImageRemoteServersCopyLocalNoCallback(c *gc.C) {
 		rSvr.EXPECT().GetImage("foo-remote-target").Return(&image, lxdtesting.ETag, nil),
 		iSvr.EXPECT().CopyImage(rSvr, image, copyReq).Return(copyOp, nil),
 		iSvr.EXPECT().GetImageAliases().Return(nil, nil),
-		iSvr.EXPECT().DeleteImageAlias("16.04/amd64").Return(nil),
+		iSvr.EXPECT().DeleteImageAlias("16.04/"+s.Arch()).Return(nil),
 	)
 
 	s.expectAlias(iSvr, "16.04/"+s.Arch(), "fingerprint")


### PR DESCRIPTION
This small patch fixes a lxd test (`TestFindImageRemoteServersCopyLocalNoCallback`) which failed because of a bad expect when removing the image alias (hard-coded architecture).


## QA steps

Run:
```
go test github.com/juju/juju/internal/container/lxd/... -gocheck.v -gocheck.f=TestFindImageRemoteServersCopyLocalNoCallback
```

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/

**Jira card:** JUJU-

