### PR TITLE
test: fix failing pki tests

### DIFF
--- a/internal/pki/pem_test.go
+++ b/internal/pki/pem_test.go
@@ -158,7 +158,7 @@ func (p *PEMSuite) TestSignerFromPKCS1Pem(c *gc.C) {
 
 		signerPem, err := pki.UnmarshalSignerFromPemBlock(block)
 		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(signerPem, jc.DeepEquals, signer)
+		c.Assert(signerPem.Public(), jc.DeepEquals, signer.Public())
 	}
 }
 


### PR DESCRIPTION
This PR attempts to fix failing unit tests that we see once in a while with the PKI suite. The output of the failure looks something similar to:
```
pem_test.go:161:
17:19:05     c.Assert(signerPem, jc.DeepEquals, signer)
17:19:05 ... obtained *rsa.PrivateKey = &rsa.PrivateKey{PublicKey:rsa.PublicKey{N:21750771464037914821892998359942692670600069607802270669006622085837874039203498701952570170373064530779308676157972326057773520782086204606971089374074770276881678280968008122145994755424612921798111816770802460725922499054052220342981287199247875594200212982342256738918082730865208384685840176285705198486627452718646105453491806593670285788886084417872861370222395664060392354170546943384492473633057881825551073302864820866296236132521927752405455507878020899786086895637621084508827051065550969220936073941006031975313848750701553020465597908060120205957311333304131916037087585538990766664574248486118947820629, E:65537}, D:4461037194773420084509128239851834895278557694634698280321841261681031843049786041507781435602324593595527374926795322042595217657085489406359795196936479006922884456316759710908729244625782910239243785725998157923729912431680469349225368446658991406372616427394501487040410898071695355337515002663294115163251748895966340177866394709248447188120717466567834021611394818514781589404093221528658230085847331621456006807334945392936056625524810266984593616996837077210594847160394960829530163668757868183990692690731038943946494323804073669678120868167480631507011556238994112176580897514868709700665998305202601517251, Primes:[]*big.Int{157335142308436196701588849954449535616649768616452862493686401865590641493930788540878621846615226828527539633271462233964846436189297095589537025100612620741587505165357847300962810665213214626278779221482546884131684340631171338396324207325341904902872071894259159378759440316573199919458513376217640712223, 138244839295967345781036472279204674363251514453288448632181179688887861932572896329037768377881365522235577107281837134221034225066812818972723015223808492625516799366300022694237164823996988521362050373844796011137422491449128392652541391313048721240057208719699998430706058369614633467390218543441991136523}, Precomputed:rsa.PrecomputedValues{Dp:151052491783981651532172214766223122526200519421810795552172794076368511875705711506356453401727727421928876721934791091460825758961053652966929667505844730412754410867209603005578223706535475598295020959392127347140784270145311817933331082059149986366307746213387648322497886456792128704889294011499060890993, Dq:459852830714266465969848344551423150452245756607975369666226668480057889456351242805289126850147820068775742090535735466380601203359403001908137652300078602810056338585126034871045393161593351811296320879780361176556114914260799084459984791892284072055975578694395527074689423143811741396326771784951310981, Qinv:152443589930583564870978712801856954834861785222949561233973118910351957182691291495388449646315772075618779680392737478738454831098144627047406481121408067228707550324190437760898402731935631405864242407415425002192258028904518151343008366493761505462633476191097341704559068493591109726782501641541899626442, CRTValues:[]rsa.CRTValue{}, fips:(*rsa.PrivateKey)(0xc000202150)}}
17:19:05 ... expected *rsa.PrivateKey = &rsa.PrivateKey{PublicKey:rsa.PublicKey{N:21750771464037914821892998359942692670600069607802270669006622085837874039203498701952570170373064530779308676157972326057773520782086204606971089374074770276881678280968008122145994755424612921798111816770802460725922499054052220342981287199247875594200212982342256738918082730865208384685840176285705198486627452718646105453491806593670285788886084417872861370222395664060392354170546943384492473633057881825551073302864820866296236132521927752405455507878020899786086895637621084508827051065550969220936073941006031975313848750701553020465597908060120205957311333304131916037087585538990766664574248486118947820629, E:65537}, D:4461037194773420084509128239851834895278557694634698280321841261681031843049786041507781435602324593595527374926795322042595217657085489406359795196936479006922884456316759710908729244625782910239243785725998157923729912431680469349225368446658991406372616427394501487040410898071695355337515002663294115163251748895966340177866394709248447188120717466567834021611394818514781589404093221528658230085847331621456006807334945392936056625524810266984593616996837077210594847160394960829530163668757868183990692690731038943946494323804073669678120868167480631507011556238994112176580897514868709700665998305202601517251, Primes:[]*big.Int{157335142308436196701588849954449535616649768616452862493686401865590641493930788540878621846615226828527539633271462233964846436189297095589537025100612620741587505165357847300962810665213214626278779221482546884131684340631171338396324207325341904902872071894259159378759440316573199919458513376217640712223, 138244839295967345781036472279204674363251514453288448632181179688887861932572896329037768377881365522235577107281837134221034225066812818972723015223808492625516799366300022694237164823996988521362050373844796011137422491449128392652541391313048721240057208719699998430706058369614633467390218543441991136523}, Precomputed:rsa.PrecomputedValues{Dp:151052491783981651532172214766223122526200519421810795552172794076368511875705711506356453401727727421928876721934791091460825758961053652966929667505844730412754410867209603005578223706535475598295020959392127347140784270145311817933331082059149986366307746213387648322497886456792128704889294011499060890993, Dq:459852830714266465969848344551423150452245756607975369666226668480057889456351242805289126850147820068775742090535735466380601203359403001908137652300078602810056338585126034871045393161593351811296320879780361176556114914260799084459984791892284072055975578694395527074689423143811741396326771784951310981, Qinv:152443589930583564870978712801856954834861785222949561233973118910351957182691291495388449646315772075618779680392737478738454831098144627047406481121408067228707550324190437760898402731935631405864242407415425002192258028904518151343008366493761505462633476191097341704559068493591109726782501641541899626442, CRTValues:[]rsa.CRTValue{}, fips:(*rsa.PrivateKey)(0xc000202000)}}
17:19:05 ... mismatch at (*(*).Precomputed.fips).dQ: length mismatch, 127 vs 128; obtained []byte{0xa7, 0xa4, 0x64, 0x44, 0xf3, 0xe3, 0xa, 0xb4, 0x47, 0x54, 0x1f, 0x6f, 0xfe, 0xc0, 0x7a, 0x35, 0xb7, 0x9c, 0x1d, 0x4a, 0xcd, 0xa, 0x9b, 0xcd, 0x14, 0x2c, 0x85, 0xd6, 0x86, 0x4d, 0xe8, 0x96, 0x28, 0x66, 0x94, 0x2c, 0x37, 0xaa, 0x1a, 0x93, 0xe3, 0x2c, 0x4a, 0xc7, 0xc3, 0x5c, 0x16, 0xca, 0x22, 0xbc, 0x97, 0x13, 0xc0, 0x9e, 0xfa, 0xfe, 0x95, 0x0, 0xb, 0x93, 0xf0, 0x33, 0xe, 0xda, 0x40, 0x40, 0x37, 0x47, 0x9c, 0x16, 0x2e, 0xb, 0xe7, 0x57, 0x49, 0xd8, 0x87, 0x7a, 0x74, 0xf3, 0xfd, 0xa4, 0x4a, 0x40, 0x80, 0x18, 0xaf, 0xae, 0x7c, 0x5e, 0xcc, 0x7c, 0xdb, 0x3, 0x58, 0xc3, 0x6b, 0x83, 0x56, 0x91, 0xc9, 0x4b, 0xfd, 0xeb, 0x97, 0x48, 0x66, 0xfd, 0xcb, 0x1, 0x88, 0x8a, 0x6f, 0xc8, 0x3d, 0x5c, 0xd5, 0x31, 0x2e, 0xa7, 0xc1, 0x1b, 0xc5, 0xbb, 0x74, 0xaa, 0x85}; expected []byte{0x0, 0xa7, 0xa4, 0x64, 0x44, 0xf3, 0xe3, 0xa, 0xb4, 0x47, 0x54, 0x1f, 0x6f, 0xfe, 0xc0, 0x7a, 0x35, 0xb7, 0x9c, 0x1d, 0x4a, 0xcd, 0xa, 0x9b, 0xcd, 0x14, 0x2c, 0x85, 0xd6, 0x86, 0x4d, 0xe8, 0x96, 0x28, 0x66, 0x94, 0x2c, 0x37, 0xaa, 0x1a, 0x93, 0xe3, 0x2c, 0x4a, 0xc7, 0xc3, 0x5c, 0x16, 0xca, 0x22, 0xbc, 0x97, 0x13, 0xc0, 0x9e, 0xfa, 0xfe, 0x95, 0x0, 0xb, 0x93, 0xf0, 0x33, 0xe, 0xda, 0x40, 0x40, 0x37, 0x47, 0x9c, 0x16, 0x2e, 0xb, 0xe7, 0x57, 0x49, 0xd8, 0x87, 0x7a, 0x74, 0xf3, 0xfd, 0xa4, 0x4a, 0x40, 0x80, 0x18, 0xaf, 0xae, 0x7c, 0x5e, 0xcc, 0x7c, 0xdb, 0x3, 0x58, 0xc3, 0x6b, 0x83, 0x56, 0x91, 0xc9, 0x4b, 0xfd, 0xeb, 0x97, 0x48, 0x66, 0xfd, 0xcb, 0x1, 0x88, 0x8a, 0x6f, 0xc8, 0x3d, 0x5c, 0xd5, 0x31, 0x2e, 0xa7, 0xc1, 0x1b, 0xc5, 0xbb, 0x74, 0xaa, 0x85}
```

The reason for the failure is that we are doing a `DeepEquals` check over the `RSA` signers and that is comparing the deprecated CRT values. These values are not being used or properly filled out by Go anymore which is why we get a mismatch sometimes.

The fix is to just compare the public keys and call it a day. This is the strongest guarantee that things have been loaded correctly as they are computed from the private key.

See https://pkg.go.dev/crypto/rsa#PrecomputedValues

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

We haven't been able to replicate this locally but it does happen on our CI machines from time to time because of the Go lang version update. We are going to have to watch Jenkins failures for a while and see if this failure continues to happen.

## Documentation changes

N/A

## Links

N/A

