### PR TITLE
refactor: replace unitname with machine id

### DIFF
--- a/state/sshconnrequests_test.go
+++ b/state/sshconnrequests_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/juju/mgo/v3"
 	"github.com/juju/mgo/v3/bson"
 	jc "github.com/juju/testing/checkers"
-	"github.com/juju/utils/v3"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/state"
@@ -25,12 +24,13 @@ type SSHReqConnReqSuite struct {
 var _ = gc.Suite(&SSHReqConnReqSuite{})
 
 func (s *SSHReqConnReqSuite) TestInsertSSHConnReq(c *gc.C) {
-	unit := s.Factory.MakeUnit(c, nil)
+	machine := s.Factory.MakeMachine(c, &factory.MachineParams{InstanceId: "instance-id"})
+
 	err := s.State.InsertSSHConnRequest(
 		state.SSHConnRequestArg{
 			TunnelID:           "uuid",
 			ModelUUID:          s.Model.UUID(),
-			UnitName:           unit.Name(),
+			MachineId:          machine.Id(),
 			Expires:            time.Now(),
 			Username:           "test",
 			Password:           "test-password",
@@ -39,17 +39,18 @@ func (s *SSHReqConnReqSuite) TestInsertSSHConnReq(c *gc.C) {
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = s.State.GetSSHConnRequest(state.SSHReqConnKeyID(unit.Name(), "uuid"))
+	_, err = s.State.GetSSHConnRequest(state.SSHReqConnKeyID(machine.Id(), "uuid"))
 	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *SSHReqConnReqSuite) TestRemoveSSHConnReq(c *gc.C) {
-	unit := s.Factory.MakeUnit(c, nil)
+	machine := s.Factory.MakeMachine(c, &factory.MachineParams{InstanceId: "instance-id"})
+
 	err := s.State.InsertSSHConnRequest(
 		state.SSHConnRequestArg{
 			TunnelID:           "uuid",
 			ModelUUID:          s.Model.UUID(),
-			UnitName:           unit.Name(),
+			MachineId:          machine.Id(),
 			Expires:            time.Now(),
 			Username:           "test",
 			Password:           "test-password",
@@ -58,14 +59,14 @@ func (s *SSHReqConnReqSuite) TestRemoveSSHConnReq(c *gc.C) {
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	id := state.SSHReqConnKeyID(unit.Name(), "uuid")
+	id := state.SSHReqConnKeyID(machine.Id(), "uuid")
 	_, err = s.State.GetSSHConnRequest(id)
 	c.Assert(err, jc.ErrorIsNil)
 
 	err = s.State.RemoveSSHConnRequest(state.SSHConnRequestRemoveArg{
 		TunnelID:  "uuid",
 		ModelUUID: s.Model.UUID(),
-		UnitName:  unit.Name(),
+		MachineId: machine.Id(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	// assert it is actually deleted.
@@ -74,12 +75,13 @@ func (s *SSHReqConnReqSuite) TestRemoveSSHConnReq(c *gc.C) {
 }
 
 func (s *SSHReqConnReqSuite) TestGetSSHConnReq(c *gc.C) {
-	unit := s.Factory.MakeUnit(c, nil)
+	machine := s.Factory.MakeMachine(c, &factory.MachineParams{InstanceId: "instance-id"})
+
 	err := s.State.InsertSSHConnRequest(
 		state.SSHConnRequestArg{
 			TunnelID:           "uuid",
 			ModelUUID:          s.Model.UUID(),
-			UnitName:           unit.Name(),
+			MachineId:          machine.Id(),
 			Expires:            time.Now(),
 			Username:           "test",
 			Password:           "test-password",
@@ -88,10 +90,10 @@ func (s *SSHReqConnReqSuite) TestGetSSHConnReq(c *gc.C) {
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = s.State.GetSSHConnRequest(state.SSHReqConnKeyID(unit.Name(), "uuid"))
+	_, err = s.State.GetSSHConnRequest(state.SSHReqConnKeyID(machine.Id(), "uuid"))
 	c.Assert(err, jc.ErrorIsNil)
 
-	req, err := s.State.GetSSHConnRequest(state.SSHReqConnKeyID(unit.Name(), "uuid"))
+	req, err := s.State.GetSSHConnRequest(state.SSHReqConnKeyID(machine.Id(), "uuid"))
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(req.Username, gc.Equals, "test")
 	c.Assert(req.Password, gc.Equals, "test-password")
@@ -101,12 +103,9 @@ func (s *SSHReqConnReqSuite) TestGetSSHConnReq(c *gc.C) {
 }
 
 func (s *SSHReqConnReqSuite) TestSSHConnReqWatcher(c *gc.C) {
-	app := s.Factory.MakeApplication(c, &factory.ApplicationParams{
-		Name:  utils.RandomString(10, utils.LowerAlpha),
-		Charm: s.Factory.MakeCharm(c, &factory.CharmParams{Name: "wordpress"}),
-	})
-	unit := s.Factory.MakeUnit(c, &factory.UnitParams{Application: app})
-	w := s.State.WatchSSHConnRequest(unit.Name())
+	machine := s.Factory.MakeMachine(c, &factory.MachineParams{InstanceId: "instance-id"})
+
+	w := s.State.WatchSSHConnRequest(machine.Id())
 	defer testing.AssertStop(c, w)
 	wc := statetesting.NewStringsWatcherC(c, w)
 
@@ -118,7 +117,7 @@ func (s *SSHReqConnReqSuite) TestSSHConnReqWatcher(c *gc.C) {
 	err := s.State.InsertSSHConnRequest(
 		state.SSHConnRequestArg{
 			ModelUUID:          s.Model.UUID(),
-			UnitName:           "other-unit",
+			MachineId:          "other-unit",
 			Expires:            time.Now(),
 			Username:           "test",
 			Password:           "test-password",
@@ -134,7 +133,7 @@ func (s *SSHReqConnReqSuite) TestSSHConnReqWatcher(c *gc.C) {
 		state.SSHConnRequestArg{
 			TunnelID:           "uuid",
 			ModelUUID:          s.Model.UUID(),
-			UnitName:           unit.Name(),
+			MachineId:          machine.Id(),
 			Expires:            time.Now(),
 			Username:           "test",
 			Password:           "test-password",
@@ -143,25 +142,25 @@ func (s *SSHReqConnReqSuite) TestSSHConnReqWatcher(c *gc.C) {
 		},
 	)
 	c.Assert(err, jc.ErrorIsNil)
-	id := state.SSHReqConnKeyID(unit.Name(), "uuid")
+	id := state.SSHReqConnKeyID(machine.Id(), "uuid")
 	wc.AssertChange(id)
 
 	// assert deleting the document don't produce a notification.
 	err = s.State.RemoveSSHConnRequest(state.SSHConnRequestRemoveArg{
 		TunnelID:  "uuid",
 		ModelUUID: s.Model.UUID(),
-		UnitName:  unit.Name(),
+		MachineId: machine.Id(),
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	wc.AssertNoChange()
 }
 
 func (s *SSHReqConnReqSuite) TestCleanupExpiredSSHConnRequest(c *gc.C) {
-	unit := s.Factory.MakeUnit(c, nil)
+	machine := s.Factory.MakeMachine(c, &factory.MachineParams{InstanceId: "instance-id"})
 	req1 := state.SSHConnRequestArg{
 		TunnelID:           "tunnelid-1",
 		ModelUUID:          s.Model.UUID(),
-		UnitName:           unit.Name(),
+		MachineId:          machine.Id(),
 		Expires:            time.Now().Add(-time.Minute),
 		Username:           "test",
 		Password:           "test-password",
@@ -175,7 +174,7 @@ func (s *SSHReqConnReqSuite) TestCleanupExpiredSSHConnRequest(c *gc.C) {
 	req2 := state.SSHConnRequestArg{
 		TunnelID:           "tunnelid-2",
 		ModelUUID:          s.Model.UUID(),
-		UnitName:           unit.Name(),
+		MachineId:          machine.Id(),
 		Expires:            time.Now().Add(time.Minute),
 		Username:           "test",
 		Password:           "test-password",
@@ -189,8 +188,8 @@ func (s *SSHReqConnReqSuite) TestCleanupExpiredSSHConnRequest(c *gc.C) {
 
 	err = s.State.Cleanup(nil)
 	c.Assert(err, jc.ErrorIsNil)
-	_, err = s.State.GetSSHConnRequest(state.SSHReqConnKeyID(req1.UnitName, req1.TunnelID))
+	_, err = s.State.GetSSHConnRequest(state.SSHReqConnKeyID(req1.MachineId, req1.TunnelID))
 	c.Assert(err, gc.ErrorMatches, "sshreqconn key \".*\" not found")
-	_, err = s.State.GetSSHConnRequest(state.SSHReqConnKeyID(req2.UnitName, req2.TunnelID))
+	_, err = s.State.GetSSHConnRequest(state.SSHReqConnKeyID(req2.MachineId, req2.TunnelID))
 	c.Assert(err, jc.ErrorIsNil)
 }


### PR DESCRIPTION
We had a misunderstanding when implementing this feature in that it was believed you can SSH to a unit. 

This PR replaces unit name with machine id. Machine units cannot be SSH'd to and it does not make sense to have the machine agent watch for unit names because of this. 

Instead, it is better for a machine agent to watch its own machine id. 

If we do not do this, we may end up watching many incoming unit names, and update the single authorized_keys file concurrently, leading to potential locks etc.

As a side, I've godoc'd some params to be kind to us in the future.

<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://github.com/juju/juju/blob/main/doc/conventional-commits.md
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

<!-- 

Describe steps to verify that the change works. 

If you're changing any of the facades, you need to ensure that you've tested
a model migration from 3.6 to 4.0 and from 4.0 to 4.0.

The following steps are a good starting point:

 1. Bootstrap a 3.6 controller and deploy a charm.

```sh
$ juju bootstrap lxd src36
$ juju add-model moveme1
$ juju deploy juju-qa-test
```

 2. Bootstrap a 4.0 controller with the changes and migrate the model.

```sh
$ juju bootstrap lxd dst40
$ juju migrate src36:moveme1 dst40
$ juju add-unit juju-qa-test
```

 3. Verify no errors exist in the model logs for the agents. If there are
    errors, this is a bug and should be fixed before merging. The fix can
    either be applied to the 4.0 branch (preferable) or the 3.6 branch, though
    that needs to be discussed with the team.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme1
```

    4. We also need to test a model migration from 4.0 to 4.0.

```sh
$ juju bootstrap lxd src40
$ juju add-model moveme2
$ juju deploy juju-qa-test
```

```sh
$ juju migrate src40:moveme2 dst40
$ juju add-unit juju-qa-test
```

    5. Verify that there are no errors in the controller or model logs.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme2
```

-->

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/

**Jira card:** JUJU-

