### PR TITLE
refactor: remove grandchild loggers & use logger tags

### DIFF
--- a/core/logger/labels.go
+++ b/core/logger/labels.go
@@ -41,4 +41,7 @@ const (
 
 	// STATUS_HISTORY defines a common tag for dealing with status history.
 	STATUS_HISTORY Tag = "status-history"
+
+	// DATABASE defines a common tag for dealing with database operations.
+	DATABASE Tag = "database"
 )

--- a/domain/services/base.go
+++ b/domain/services/base.go
@@ -24,6 +24,12 @@ func (s *serviceFactoryBase) controllerWatcherFactory() *domain.WatcherFactory {
 	)
 }
 
+// loggerFor returns a logger with the given name as a child of the factory's
+// logger.
+func (s *serviceFactoryBase) loggerFor(name string) logger.Logger {
+	return s.logger.Child(name)
+}
+
 // modelServiceFactoryBase is the foundation for model-scoped service factories.
 // It includes the ability to supply runners and watchers backed by a model
 // database in addition to those backed by the controller database.

--- a/domain/services/base.go
+++ b/domain/services/base.go
@@ -17,10 +17,10 @@ type serviceFactoryBase struct {
 	logger       logger.Logger
 }
 
-func (s *serviceFactoryBase) controllerWatcherFactory() *domain.WatcherFactory {
+func (s *serviceFactoryBase) controllerWatcherFactory(logger logger.Logger) *domain.WatcherFactory {
 	return domain.NewWatcherFactory(
 		s.controllerDB,
-		s.logger,
+		logger,
 	)
 }
 
@@ -39,9 +39,9 @@ type modelServiceFactoryBase struct {
 	modelDB changestream.WatchableDBFactory
 }
 
-func (s *modelServiceFactoryBase) modelWatcherFactory() *domain.WatcherFactory {
+func (s *modelServiceFactoryBase) modelWatcherFactory(logger logger.Logger) *domain.WatcherFactory {
 	return domain.NewWatcherFactory(
 		s.modelDB,
-		s.logger,
+		logger,
 	)
 }

--- a/domain/services/base.go
+++ b/domain/services/base.go
@@ -17,10 +17,10 @@ type serviceFactoryBase struct {
 	logger       logger.Logger
 }
 
-func (s *serviceFactoryBase) controllerWatcherFactory(childLogName string) *domain.WatcherFactory {
+func (s *serviceFactoryBase) controllerWatcherFactory() *domain.WatcherFactory {
 	return domain.NewWatcherFactory(
 		s.controllerDB,
-		s.logger.Child(childLogName),
+		s.logger,
 	)
 }
 
@@ -33,9 +33,9 @@ type modelServiceFactoryBase struct {
 	modelDB changestream.WatchableDBFactory
 }
 
-func (s *modelServiceFactoryBase) modelWatcherFactory(childLogName string) *domain.WatcherFactory {
+func (s *modelServiceFactoryBase) modelWatcherFactory() *domain.WatcherFactory {
 	return domain.NewWatcherFactory(
 		s.modelDB,
-		s.logger.Child(childLogName),
+		s.logger,
 	)
 }

--- a/domain/services/controller.go
+++ b/domain/services/controller.go
@@ -76,9 +76,11 @@ func (s *ControllerServices) Controller() *controllerservice.Service {
 
 // ControllerConfig returns the controller configuration service.
 func (s *ControllerServices) ControllerConfig() *controllerconfigservice.WatchableService {
+	logger := s.loggerFor("controllerconfig")
+
 	return controllerconfigservice.NewWatchableService(
 		controllerconfigstate.NewState(changestream.NewTxnRunnerFactory(s.controllerDB)),
-		s.controllerWatcherFactory(),
+		s.controllerWatcherFactory(logger),
 	)
 }
 
@@ -91,11 +93,13 @@ func (s *ControllerServices) ControllerNode() *controllernodeservice.Service {
 
 // Model returns the model service.
 func (s *ControllerServices) Model() *modelservice.WatchableService {
+	logger := s.loggerFor("model")
+
 	return modelservice.NewWatchableService(
 		modelstate.NewState(changestream.NewTxnRunnerFactory(s.controllerDB)),
 		s.dbDeleter,
-		s.loggerFor("model"),
-		s.controllerWatcherFactory(),
+		logger,
+		s.controllerWatcherFactory(logger),
 	)
 }
 
@@ -109,26 +113,32 @@ func (s *ControllerServices) ModelDefaults() *modeldefaultsservice.Service {
 
 // ExternalController returns the external controller service.
 func (s *ControllerServices) ExternalController() *externalcontrollerservice.WatchableService {
+	logger := s.loggerFor("externalcontroller")
+
 	return externalcontrollerservice.NewWatchableService(
 		externalcontrollerstate.NewState(changestream.NewTxnRunnerFactory(s.controllerDB)),
-		s.controllerWatcherFactory(),
+		s.controllerWatcherFactory(logger),
 	)
 }
 
 // Credential returns the credential service.
 func (s *ControllerServices) Credential() *credentialservice.WatchableService {
+	logger := s.loggerFor("credential")
+
 	return credentialservice.NewWatchableService(
 		credentialstate.NewState(changestream.NewTxnRunnerFactory(s.controllerDB)),
-		s.controllerWatcherFactory(),
-		s.loggerFor("credential"),
+		s.controllerWatcherFactory(logger),
+		logger,
 	)
 }
 
 // Cloud returns the cloud service.
 func (s *ControllerServices) Cloud() *cloudservice.WatchableService {
+	logger := s.loggerFor("cloud")
+
 	return cloudservice.NewWatchableService(
 		cloudstate.NewState(changestream.NewTxnRunnerFactory(s.controllerDB)),
-		s.controllerWatcherFactory(),
+		s.controllerWatcherFactory(logger),
 	)
 }
 
@@ -142,9 +152,11 @@ func (s *ControllerServices) AutocertCache() *autocertcacheservice.Service {
 
 // Upgrade returns the upgrade service.
 func (s *ControllerServices) Upgrade() *upgradeservice.WatchableService {
+	logger := s.loggerFor("upgrade")
+
 	return upgradeservice.NewWatchableService(
 		upgradestate.NewState(changestream.NewTxnRunnerFactory(s.controllerDB)),
-		s.controllerWatcherFactory(),
+		s.controllerWatcherFactory(logger),
 	)
 }
 
@@ -168,7 +180,7 @@ func (s *ControllerServices) SecretBackend() *secretbackendservice.WatchableServ
 	return secretbackendservice.NewWatchableService(
 		secretbackendstate.NewState(changestream.NewTxnRunnerFactory(s.controllerDB), logger),
 		logger,
-		s.controllerWatcherFactory(),
+		s.controllerWatcherFactory(logger),
 	)
 }
 

--- a/domain/services/controller.go
+++ b/domain/services/controller.go
@@ -78,7 +78,7 @@ func (s *ControllerServices) Controller() *controllerservice.Service {
 func (s *ControllerServices) ControllerConfig() *controllerconfigservice.WatchableService {
 	return controllerconfigservice.NewWatchableService(
 		controllerconfigstate.NewState(changestream.NewTxnRunnerFactory(s.controllerDB)),
-		s.controllerWatcherFactory("controllerconfig"),
+		s.controllerWatcherFactory(),
 	)
 }
 
@@ -95,7 +95,7 @@ func (s *ControllerServices) Model() *modelservice.WatchableService {
 		modelstate.NewState(changestream.NewTxnRunnerFactory(s.controllerDB)),
 		s.dbDeleter,
 		s.logger,
-		s.controllerWatcherFactory("model"),
+		s.controllerWatcherFactory(),
 	)
 }
 
@@ -111,7 +111,7 @@ func (s *ControllerServices) ModelDefaults() *modeldefaultsservice.Service {
 func (s *ControllerServices) ExternalController() *externalcontrollerservice.WatchableService {
 	return externalcontrollerservice.NewWatchableService(
 		externalcontrollerstate.NewState(changestream.NewTxnRunnerFactory(s.controllerDB)),
-		s.controllerWatcherFactory("externalcontroller"),
+		s.controllerWatcherFactory(),
 	)
 }
 
@@ -119,8 +119,8 @@ func (s *ControllerServices) ExternalController() *externalcontrollerservice.Wat
 func (s *ControllerServices) Credential() *credentialservice.WatchableService {
 	return credentialservice.NewWatchableService(
 		credentialstate.NewState(changestream.NewTxnRunnerFactory(s.controllerDB)),
-		s.controllerWatcherFactory("credential"),
-		s.logger.Child("credential"),
+		s.controllerWatcherFactory(),
+		s.logger,
 	)
 }
 
@@ -128,7 +128,7 @@ func (s *ControllerServices) Credential() *credentialservice.WatchableService {
 func (s *ControllerServices) Cloud() *cloudservice.WatchableService {
 	return cloudservice.NewWatchableService(
 		cloudstate.NewState(changestream.NewTxnRunnerFactory(s.controllerDB)),
-		s.controllerWatcherFactory("cloud"),
+		s.controllerWatcherFactory(),
 	)
 }
 
@@ -136,7 +136,7 @@ func (s *ControllerServices) Cloud() *cloudservice.WatchableService {
 func (s *ControllerServices) AutocertCache() *autocertcacheservice.Service {
 	return autocertcacheservice.NewService(
 		autocertcachestate.NewState(changestream.NewTxnRunnerFactory(s.controllerDB)),
-		s.logger.Child("autocertcache"),
+		s.logger,
 	)
 }
 
@@ -144,31 +144,29 @@ func (s *ControllerServices) AutocertCache() *autocertcacheservice.Service {
 func (s *ControllerServices) Upgrade() *upgradeservice.WatchableService {
 	return upgradeservice.NewWatchableService(
 		upgradestate.NewState(changestream.NewTxnRunnerFactory(s.controllerDB)),
-		s.controllerWatcherFactory("upgrade"),
+		s.controllerWatcherFactory(),
 	)
 }
 
 // Flag returns the flag service.
 func (s *ControllerServices) Flag() *flagservice.Service {
 	return flagservice.NewService(
-		flagstate.NewState(changestream.NewTxnRunnerFactory(s.controllerDB), s.logger.Child("flag")),
+		flagstate.NewState(changestream.NewTxnRunnerFactory(s.controllerDB), s.logger),
 	)
 }
 
 // Access returns the access service, this includes users and permissions.
 func (s *ControllerServices) Access() *accessservice.Service {
 	return accessservice.NewService(
-		accessstate.NewState(changestream.NewTxnRunnerFactory(s.controllerDB), s.logger.Child("access")),
+		accessstate.NewState(changestream.NewTxnRunnerFactory(s.controllerDB), s.logger),
 	)
 }
 
 func (s *ControllerServices) SecretBackend() *secretbackendservice.WatchableService {
-	log := s.logger.Child("secretbackend")
-
 	return secretbackendservice.NewWatchableService(
-		secretbackendstate.NewState(changestream.NewTxnRunnerFactory(s.controllerDB), log),
-		log,
-		s.controllerWatcherFactory("secretbackend"),
+		secretbackendstate.NewState(changestream.NewTxnRunnerFactory(s.controllerDB), s.logger),
+		s.logger,
+		s.controllerWatcherFactory(),
 	)
 }
 

--- a/domain/services/controller.go
+++ b/domain/services/controller.go
@@ -94,7 +94,7 @@ func (s *ControllerServices) Model() *modelservice.WatchableService {
 	return modelservice.NewWatchableService(
 		modelstate.NewState(changestream.NewTxnRunnerFactory(s.controllerDB)),
 		s.dbDeleter,
-		s.logger,
+		s.loggerFor("model"),
 		s.controllerWatcherFactory(),
 	)
 }
@@ -120,7 +120,7 @@ func (s *ControllerServices) Credential() *credentialservice.WatchableService {
 	return credentialservice.NewWatchableService(
 		credentialstate.NewState(changestream.NewTxnRunnerFactory(s.controllerDB)),
 		s.controllerWatcherFactory(),
-		s.logger,
+		s.loggerFor("credential"),
 	)
 }
 
@@ -136,7 +136,7 @@ func (s *ControllerServices) Cloud() *cloudservice.WatchableService {
 func (s *ControllerServices) AutocertCache() *autocertcacheservice.Service {
 	return autocertcacheservice.NewService(
 		autocertcachestate.NewState(changestream.NewTxnRunnerFactory(s.controllerDB)),
-		s.logger,
+		s.loggerFor("autocert"),
 	)
 }
 
@@ -151,21 +151,23 @@ func (s *ControllerServices) Upgrade() *upgradeservice.WatchableService {
 // Flag returns the flag service.
 func (s *ControllerServices) Flag() *flagservice.Service {
 	return flagservice.NewService(
-		flagstate.NewState(changestream.NewTxnRunnerFactory(s.controllerDB), s.logger),
+		flagstate.NewState(changestream.NewTxnRunnerFactory(s.controllerDB), s.loggerFor("flag")),
 	)
 }
 
 // Access returns the access service, this includes users and permissions.
 func (s *ControllerServices) Access() *accessservice.Service {
 	return accessservice.NewService(
-		accessstate.NewState(changestream.NewTxnRunnerFactory(s.controllerDB), s.logger),
+		accessstate.NewState(changestream.NewTxnRunnerFactory(s.controllerDB), s.loggerFor("access")),
 	)
 }
 
 func (s *ControllerServices) SecretBackend() *secretbackendservice.WatchableService {
+	logger := s.loggerFor("secretbackend")
+
 	return secretbackendservice.NewWatchableService(
-		secretbackendstate.NewState(changestream.NewTxnRunnerFactory(s.controllerDB), s.logger),
-		s.logger,
+		secretbackendstate.NewState(changestream.NewTxnRunnerFactory(s.controllerDB), logger),
+		logger,
 		s.controllerWatcherFactory(),
 	)
 }

--- a/domain/services/logsink.go
+++ b/domain/services/logsink.go
@@ -38,7 +38,7 @@ func NewLogSinkServices(
 func (s *LogSinkServices) ControllerConfig() *controllerconfigservice.WatchableService {
 	return controllerconfigservice.NewWatchableService(
 		controllerconfigstate.NewState(changestream.NewTxnRunnerFactory(s.controllerDB)),
-		s.controllerWatcherFactory("controllerconfig"),
+		s.controllerWatcherFactory(),
 	)
 }
 

--- a/domain/services/logsink.go
+++ b/domain/services/logsink.go
@@ -36,9 +36,11 @@ func NewLogSinkServices(
 
 // ControllerConfig returns the controller configuration service.
 func (s *LogSinkServices) ControllerConfig() *controllerconfigservice.WatchableService {
+	logger := s.loggerFor("controllerconfig")
+
 	return controllerconfigservice.NewWatchableService(
 		controllerconfigstate.NewState(changestream.NewTxnRunnerFactory(s.controllerDB)),
-		s.controllerWatcherFactory(),
+		s.controllerWatcherFactory(logger),
 	)
 }
 

--- a/domain/services/objectstore.go
+++ b/domain/services/objectstore.go
@@ -40,7 +40,7 @@ func NewObjectStoreServices(
 func (s *ObjectStoreServices) ControllerConfig() *controllerconfigservice.WatchableService {
 	return controllerconfigservice.NewWatchableService(
 		controllerconfigstate.NewState(changestream.NewTxnRunnerFactory(s.controllerDB)),
-		s.controllerWatcherFactory("controllerconfig"),
+		s.controllerWatcherFactory(),
 	)
 }
 
@@ -48,7 +48,7 @@ func (s *ObjectStoreServices) ControllerConfig() *controllerconfigservice.Watcha
 func (s *ObjectStoreServices) AgentObjectStore() *objectstoreservice.WatchableService {
 	return objectstoreservice.NewWatchableService(
 		objectstorestate.NewState(changestream.NewTxnRunnerFactory(s.controllerDB)),
-		s.controllerWatcherFactory("objectstore"),
+		s.controllerWatcherFactory(),
 	)
 }
 
@@ -56,6 +56,6 @@ func (s *ObjectStoreServices) AgentObjectStore() *objectstoreservice.WatchableSe
 func (s *ObjectStoreServices) ObjectStore() *objectstoreservice.WatchableService {
 	return objectstoreservice.NewWatchableService(
 		objectstorestate.NewState(changestream.NewTxnRunnerFactory(s.modelDB)),
-		s.modelWatcherFactory("objectstore"),
+		s.modelWatcherFactory(),
 	)
 }

--- a/domain/services/objectstore.go
+++ b/domain/services/objectstore.go
@@ -40,7 +40,7 @@ func NewObjectStoreServices(
 func (s *ObjectStoreServices) ControllerConfig() *controllerconfigservice.WatchableService {
 	return controllerconfigservice.NewWatchableService(
 		controllerconfigstate.NewState(changestream.NewTxnRunnerFactory(s.controllerDB)),
-		s.controllerWatcherFactory(),
+		s.controllerWatcherFactory(s.loggerFor("controllerconfig")),
 	)
 }
 
@@ -48,7 +48,7 @@ func (s *ObjectStoreServices) ControllerConfig() *controllerconfigservice.Watcha
 func (s *ObjectStoreServices) AgentObjectStore() *objectstoreservice.WatchableService {
 	return objectstoreservice.NewWatchableService(
 		objectstorestate.NewState(changestream.NewTxnRunnerFactory(s.controllerDB)),
-		s.controllerWatcherFactory(),
+		s.controllerWatcherFactory(s.loggerFor("agentobjectstore")),
 	)
 }
 
@@ -56,6 +56,6 @@ func (s *ObjectStoreServices) AgentObjectStore() *objectstoreservice.WatchableSe
 func (s *ObjectStoreServices) ObjectStore() *objectstoreservice.WatchableService {
 	return objectstoreservice.NewWatchableService(
 		objectstorestate.NewState(changestream.NewTxnRunnerFactory(s.modelDB)),
-		s.modelWatcherFactory(),
+		s.modelWatcherFactory(s.loggerFor("objectstore")),
 	)
 }

--- a/domain/services/provider.go
+++ b/domain/services/provider.go
@@ -44,7 +44,7 @@ func (s *ProviderServices) Model() *modelservice.ProviderService {
 	return modelservice.NewProviderService(
 		modelstate.NewModelState(
 			changestream.NewTxnRunnerFactory(s.modelDB),
-			s.logger,
+			s.loggerFor("model"),
 		),
 	)
 }

--- a/domain/services/provider.go
+++ b/domain/services/provider.go
@@ -53,7 +53,7 @@ func (s *ProviderServices) Model() *modelservice.ProviderService {
 func (s *ProviderServices) Cloud() *cloudservice.WatchableProviderService {
 	return cloudservice.NewWatchableProviderService(
 		cloudstate.NewState(changestream.NewTxnRunnerFactory(s.controllerDB)),
-		s.controllerWatcherFactory(),
+		s.controllerWatcherFactory(s.loggerFor("cloud")),
 	)
 }
 
@@ -61,7 +61,7 @@ func (s *ProviderServices) Cloud() *cloudservice.WatchableProviderService {
 func (s *ProviderServices) Credential() *credentialservice.WatchableProviderService {
 	return credentialservice.NewWatchableProviderService(
 		credentialstate.NewState(changestream.NewTxnRunnerFactory(s.controllerDB)),
-		s.controllerWatcherFactory(),
+		s.controllerWatcherFactory(s.loggerFor("credential")),
 	)
 }
 
@@ -69,6 +69,6 @@ func (s *ProviderServices) Credential() *credentialservice.WatchableProviderServ
 func (s *ProviderServices) Config() *modelconfigservice.WatchableProviderService {
 	return modelconfigservice.NewWatchableProviderService(
 		modelconfigstate.NewState(changestream.NewTxnRunnerFactory(s.modelDB)),
-		s.modelWatcherFactory(),
+		s.modelWatcherFactory(s.loggerFor("config")),
 	)
 }

--- a/domain/services/provider.go
+++ b/domain/services/provider.go
@@ -44,7 +44,7 @@ func (s *ProviderServices) Model() *modelservice.ProviderService {
 	return modelservice.NewProviderService(
 		modelstate.NewModelState(
 			changestream.NewTxnRunnerFactory(s.modelDB),
-			s.logger.Child("modelinfo"),
+			s.logger,
 		),
 	)
 }
@@ -53,7 +53,7 @@ func (s *ProviderServices) Model() *modelservice.ProviderService {
 func (s *ProviderServices) Cloud() *cloudservice.WatchableProviderService {
 	return cloudservice.NewWatchableProviderService(
 		cloudstate.NewState(changestream.NewTxnRunnerFactory(s.controllerDB)),
-		s.controllerWatcherFactory("cloud"),
+		s.controllerWatcherFactory(),
 	)
 }
 
@@ -61,7 +61,7 @@ func (s *ProviderServices) Cloud() *cloudservice.WatchableProviderService {
 func (s *ProviderServices) Credential() *credentialservice.WatchableProviderService {
 	return credentialservice.NewWatchableProviderService(
 		credentialstate.NewState(changestream.NewTxnRunnerFactory(s.controllerDB)),
-		s.controllerWatcherFactory("credential"),
+		s.controllerWatcherFactory(),
 	)
 }
 
@@ -69,6 +69,6 @@ func (s *ProviderServices) Credential() *credentialservice.WatchableProviderServ
 func (s *ProviderServices) Config() *modelconfigservice.WatchableProviderService {
 	return modelconfigservice.NewWatchableProviderService(
 		modelconfigstate.NewState(changestream.NewTxnRunnerFactory(s.modelDB)),
-		s.modelWatcherFactory("modelconfig"),
+		s.modelWatcherFactory(),
 	)
 }

--- a/internal/worker/domainservices/manifold_test.go
+++ b/internal/worker/domainservices/manifold_test.go
@@ -243,7 +243,7 @@ func (s *manifoldSuite) TestNewDomainServicesGetter(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	s.loggerContextGetter.EXPECT().GetLoggerContext(gomock.Any(), coremodel.UUID("model")).Return(s.loggerContext, nil)
-	s.loggerContext.EXPECT().GetLogger("juju.services").Return(s.logger)
+	s.loggerContext.EXPECT().GetLogger("juju.services", logger.DATABASE).Return(s.logger)
 
 	ctrlFactory := NewControllerDomainServices(s.dbGetter, s.dbDeleter, s.modelObjectStoreGetter, s.clock, s.logger)
 	factory := NewDomainServicesGetter(

--- a/internal/worker/domainservices/worker.go
+++ b/internal/worker/domainservices/worker.go
@@ -232,7 +232,7 @@ func (s *domainServicesGetter) ServicesForModel(ctx context.Context, modelUUID c
 				manager:   s.leaseManager,
 			},
 			s.clock,
-			loggerContext.GetLogger("juju.services"),
+			loggerContext.GetLogger("juju.services", logger.DATABASE),
 		),
 	}, nil
 }


### PR DESCRIPTION
Removes all grandchildren loggers from in the services package. It was just creating a LOT of noise. The domains services and state aren't separated as clear boundaries of work, they all interplay together. Thus, to see how an application was deployed you would need to join a lot of namespaces together to understand the logging as a whole. The solution is what we already have to hand - logger tags.


## QA steps

```sh
$ juju bootstrap lxd test
$ juju add-model default
$ juju deploy ubuntu
$ juju debug-log --replay --include-labels="logger-tags=database"
```

You can also view the controller model logs as well:

```sh
$ juju debug-log -m controller --replay --include-labels="logger-tags=database"
```