### PR TITLE
docs: enable give feedback button

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -119,6 +119,7 @@ html_context = {
     # Your documentation GitHub repository URL
     "github_url": "https://github.com/juju/juju",
     # Docs branch in the repo; used in links for viewing the source files
+    "github_issues": "https://github.com/juju/juju/issues",
     'github_version': 'main',
     # Docs location in the repo; used in links for viewing the source files
     "github_folder": "/docs/",


### PR DESCRIPTION
> This is a change for 3.6+.

Following a change in the Canonical starter pack, our RTD docs no longer had links to issues -- the intent was to replace those links with a global "Give feedback" button. This PR updates conf.py to add the link to our GitHub issues that will make that button show.

## QA steps

In `juju/docs`, run `make run`, then follow the browser link.

## Documentation changes

This is a documentation change.