### PR TITLE
refactor: handle machine dead when reporting agent version

### DIFF
--- a/domain/machine/errors/errors.go
+++ b/domain/machine/errors/errors.go
@@ -6,6 +6,10 @@ package errors
 import "github.com/juju/juju/internal/errors"
 
 const (
+	// MachineDead describes an error that occurs when the machine being
+	// operated on is considered dead.
+	MachineDead = errors.ConstError("machine is dead")
+
 	// MachineNotFound describes an error that occurs when the machine being
 	// operated on does not exist.
 	MachineNotFound = errors.ConstError("machine not found")

--- a/domain/machine/service/service.go
+++ b/domain/machine/service/service.go
@@ -191,7 +191,8 @@ func NewService(st State) *Service {
 // The following errors are possible:
 // - [coreerrors.NotValid] if the reportedVersion is not valid.
 // - [coreerrors.NotSupported] if the architecture is not supported.
-// - [machineerrors.MachineNotFound] - when the machine does not exist.
+// - [machineerrors.MachineNotFound] when the machine does not exist.
+// - [machineerrors.MachineDead] when the machine is dead.
 func (s *Service) SetReportedMachineAgentVersion(
 	ctx context.Context,
 	machineName machine.Name,

--- a/domain/machine/state/state.go
+++ b/domain/machine/state/state.go
@@ -432,6 +432,7 @@ WHERE st.machine_uuid = $machineUUID.uuid;
 //
 // The following errors can be expected:
 // - [machineerrors.MachineNotFound] if the machine does not exist.
+// - [machineerrors.MachineDead] if the machine is dead.
 // - [coreerrors.NotSupported] if the architecture is not known to the database.
 func (st *State) SetRunningAgentBinaryVersion(
 	ctx context.Context,
@@ -476,14 +477,9 @@ UPDATE SET version = excluded.version, architecture_id = excluded.architecture_i
 	}
 
 	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		machineExists, err := st.checkMachineExists(ctx, tx, machineUUID)
+		err := st.checkMachineNotDead(ctx, tx, machineUUID)
 		if err != nil {
 			return errors.Capture(err)
-		}
-		if !machineExists {
-			return errors.Errorf(
-				"machine %q does not exist", machineUUID,
-			).Add(machineerrors.MachineNotFound)
 		}
 
 		err = tx.Query(ctx, archMapStmt, archMap).Get(&archMap)
@@ -511,33 +507,40 @@ UPDATE SET version = excluded.version, architecture_id = excluded.architecture_i
 	return nil
 }
 
-// checkMachineExists checks if the machine with the given uuid exists. This is
-// intended as a helper func for state methods to assert the uuid exists first.
-// This is easier and more reliable to use then checking for foreign key errors.
-func (st *State) checkMachineExists(
+// checkMachineNotDead checks if the machine with the given uuid exists and that
+// it's current life status is not one of dead. This is meant as a helper func
+// to assert that a machine can be operated on inside of a transaction.
+// The following errors can be expected:
+// - [machineerrors.MachineNotFound] if the machine does not exist.
+// - [machineerrors.MachineDead] if the machine is dead.
+func (st *State) checkMachineNotDead(
 	ctx context.Context,
 	tx *sqlair.TX,
 	uuid string,
-) (bool, error) {
-	machineUUIDVal := machineUUID{UUID: uuid}
+) error {
+	machineLife := machineLife{UUID: uuid}
 	stmt, err := st.Prepare(`
-SELECT uuid AS &machineUUID.uuid FROM machine WHERE uuid = $machineUUID.uuid
-`, machineUUIDVal)
+SELECT &machineLife.* FROM machine WHERE uuid = $machineLife.uuid
+`, machineLife)
 	if err != nil {
-		return false, errors.Capture(err)
+		return errors.Capture(err)
 	}
 
-	err = tx.Query(ctx, stmt, machineUUIDVal).Get(&machineUUIDVal)
+	err = tx.Query(ctx, stmt, machineLife).Get(&machineLife)
 	if errors.Is(err, sqlair.ErrNoRows) {
-		return false, nil
+		return errors.Errorf("machine %q does not exist", uuid).Add(machineerrors.MachineNotFound)
 	} else if err != nil {
-		return false, errors.Errorf(
+		return errors.Errorf(
 			"checking if machine %q exists: %w",
 			uuid, err,
 		)
 	}
 
-	return true, nil
+	if machineLife.LifeID == life.Dead {
+		return errors.Errorf("machine %q is dead", uuid).Add(machineerrors.MachineDead)
+	}
+
+	return nil
 }
 
 // SetMachineStatus sets the status of the specified machine.

--- a/domain/machine/state/state_test.go
+++ b/domain/machine/state/state_test.go
@@ -951,6 +951,26 @@ func (s *stateSuite) TestSetRunningAgentBinaryVersionMachineNotFound(c *gc.C) {
 	c.Check(err, jc.ErrorIs, machineerrors.MachineNotFound)
 }
 
+func (s *stateSuite) TestSetRunningAgentBinaryVersionMachineDead(c *gc.C) {
+	err := s.state.CreateMachine(context.Background(), "666", "", "deadbeef")
+	c.Assert(err, jc.ErrorIsNil)
+
+	machineUUID, err := s.state.GetMachineUUID(context.Background(), "666")
+	c.Assert(err, jc.ErrorIsNil)
+
+	s.state.SetMachineLife(context.Background(), "666", life.Dead)
+
+	err = s.state.SetRunningAgentBinaryVersion(
+		context.Background(),
+		machineUUID,
+		coreagentbinary.Version{
+			Number: jujuversion.Current,
+			Arch:   corearch.Arch("noexist"),
+		},
+	)
+	c.Check(err, jc.ErrorIs, machineerrors.MachineDead)
+}
+
 // TestSetRunningAgentBinaryVersionNotSupportedArch tests that if we provide an
 // architecture that isn't supported by the database we get back an error
 // that satisfies [coreerrors.NotValid].


### PR DESCRIPTION
This PR refactors the code we had in the machine domain for recording a machine's reported agent version. This change now takes into consideration the fact that a machine might exist but it is dead and so we shouldn't operate on it any further.

This resembles the code that we had in the machine state prior.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Unit Tests! We haven't wired this up to the facades yet as the common facade code needs to be broken and moved. This is being done in this pulse. For now the unit tests demonstrate the contracts on offer and they can be checked against (

[juju/apiserver/common/tools.go](https://github.com/juju/juju/blob/e91cb674ece19f784d44deea5482d90dfea0ce44/apiserver/common/tools.go#L242)
Line 242 in [e91cb67](https://github.com/juju/juju/commit/e91cb674ece19f784d44deea5482d90dfea0ce44)
 func (t *ToolsSetter) SetTools(ctx context.Context, args params.EntitiesVersion) (params.ErrorResults, error) { 
).
Specifically we want to verify that the checkValidity checks are still the same and we haven't lost any validation logic.

## Documentation changes

N/A

## Links

**Jira card:** JUJU-7627

