### PR TITLE
fix: k8s cloud reuse across controllers

### DIFF
--- a/caas/kubernetes/metadata.go
+++ b/caas/kubernetes/metadata.go
@@ -60,7 +60,9 @@ type StorageProvisioner struct {
 	Provisioner       string
 	Parameters        map[string]string
 	Namespace         string
-	Model             string
+	ModelName         string
+	ModelUUID         string
+	ControllerUUID    string
 	ReclaimPolicy     string
 	VolumeBindingMode string
 	IsDefault         bool

--- a/caas/kubernetes/provider/admissionregistration.go
+++ b/caas/kubernetes/provider/admissionregistration.go
@@ -22,16 +22,16 @@ import (
 
 func (k *kubernetesClient) getAdmissionControllerLabels(appName string) map[string]string {
 	return utils.LabelsMerge(
-		utils.LabelsForApp(appName, k.IsLegacyLabels()),
-		utils.LabelsForModel(k.CurrentModel(), k.IsLegacyLabels()),
+		utils.LabelsForApp(appName, k.LabelVersion()),
+		utils.LabelsForModel(k.ModelName(), k.ModelUUID(), k.ControllerUUID(), k.LabelVersion()),
 	)
 }
 
 const annotationDisableNamePrefixValue = "true"
 
-func decideNameForGlobalResource(meta k8sspecs.Meta, namespace string, isLegacy bool) string {
+func decideNameForGlobalResource(meta k8sspecs.Meta, namespace string, labelVersion constants.LabelVersion) string {
 	name := meta.Name
-	key := utils.AnnotationDisableNameKey(isLegacy)
+	key := utils.AnnotationDisableNameKey(labelVersion)
 	if k8sannotations.New(meta.Annotations).Has(key, annotationDisableNamePrefixValue) {
 		return name
 	}
@@ -50,7 +50,7 @@ func (k *kubernetesClient) ensureMutatingWebhookConfigurations(
 	}
 	for _, v := range cfgs {
 		obj := metav1.ObjectMeta{
-			Name:        decideNameForGlobalResource(v.Meta, k.namespace, k.IsLegacyLabels()),
+			Name:        decideNameForGlobalResource(v.Meta, k.namespace, k.LabelVersion()),
 			Namespace:   k.namespace,
 			Labels:      utils.LabelsMerge(v.Labels, k.getAdmissionControllerLabels(appName)),
 			Annotations: k8sannotations.New(v.Annotations).Merge(annotations),
@@ -240,7 +240,7 @@ func (k *kubernetesClient) ensureValidatingWebhookConfigurations(
 	}
 	for _, v := range cfgs {
 		obj := metav1.ObjectMeta{
-			Name:        decideNameForGlobalResource(v.Meta, k.namespace, k.IsLegacyLabels()),
+			Name:        decideNameForGlobalResource(v.Meta, k.namespace, k.LabelVersion()),
 			Namespace:   k.namespace,
 			Labels:      utils.LabelsMerge(v.Labels, k.getAdmissionControllerLabels(appName)),
 			Annotations: k8sannotations.New(v.Annotations).Merge(annotations),

--- a/caas/kubernetes/provider/application.go
+++ b/caas/kubernetes/provider/application.go
@@ -11,10 +11,11 @@ import (
 // Application returns an Application interface.
 func (k *kubernetesClient) Application(name string, deploymentType caas.DeploymentType) caas.Application {
 	return application.NewApplication(name,
-		k.namespace,
-		k.modelUUID,
-		k.CurrentModel(),
-		k.IsLegacyLabels(),
+		k.Namespace(),
+		k.ModelUUID(),
+		k.ModelName(),
+		k.ControllerUUID(),
+		k.LabelVersion(),
 		deploymentType,
 		k.client(),
 		k.newWatcher,

--- a/caas/kubernetes/provider/application/application.go
+++ b/caas/kubernetes/provider/application/application.go
@@ -91,7 +91,8 @@ type app struct {
 	namespace      string
 	modelUUID      string
 	modelName      string
-	legacyLabels   bool
+	controllerUUID string
+	labelVersion   constants.LabelVersion
 	deploymentType caas.DeploymentType
 	client         kubernetes.Interface
 	newWatcher     k8swatcher.NewK8sWatcherFunc
@@ -109,7 +110,8 @@ func NewApplication(
 	namespace string,
 	modelUUID string,
 	modelName string,
-	legacyLabels bool,
+	controllerUUID string,
+	labelVersion constants.LabelVersion,
 	deploymentType caas.DeploymentType,
 	client kubernetes.Interface,
 	newWatcher k8swatcher.NewK8sWatcherFunc,
@@ -121,7 +123,8 @@ func NewApplication(
 		namespace,
 		modelUUID,
 		modelName,
-		legacyLabels,
+		controllerUUID,
+		labelVersion,
 		deploymentType,
 		client,
 		newWatcher,
@@ -136,7 +139,8 @@ func newApplication(
 	namespace string,
 	modelUUID string,
 	modelName string,
-	legacyLabels bool,
+	controllerUUID string,
+	labelVersion constants.LabelVersion,
 	deploymentType caas.DeploymentType,
 	client kubernetes.Interface,
 	newWatcher k8swatcher.NewK8sWatcherFunc,
@@ -149,7 +153,7 @@ func newApplication(
 		namespace:      namespace,
 		modelUUID:      modelUUID,
 		modelName:      modelName,
-		legacyLabels:   legacyLabels,
+		labelVersion:   labelVersion,
 		deploymentType: deploymentType,
 		client:         client,
 		newWatcher:     newWatcher,
@@ -281,7 +285,7 @@ func (a *app) Ensure(config caas.ApplicationConfig) (err error) {
 					Namespace: a.namespace,
 					Labels:    a.labels(),
 					Annotations: a.annotations(config).
-						Add(utils.AnnotationKeyApplicationUUID(false), storageUniqueID),
+						Add(utils.AnnotationKeyApplicationUUID(a.labelVersion), storageUniqueID),
 				},
 				Spec: appsv1.StatefulSetSpec{
 					Replicas: numPods,
@@ -347,7 +351,7 @@ func (a *app) Ensure(config caas.ApplicationConfig) (err error) {
 					Namespace: a.namespace,
 					Labels:    a.labels(),
 					Annotations: a.annotations(config).
-						Add(utils.AnnotationKeyApplicationUUID(false), storageUniqueID),
+						Add(utils.AnnotationKeyApplicationUUID(a.labelVersion), storageUniqueID),
 				},
 				Spec: appsv1.DeploymentSpec{
 					Replicas: numPods,
@@ -384,7 +388,7 @@ func (a *app) Ensure(config caas.ApplicationConfig) (err error) {
 					Namespace: a.namespace,
 					Labels:    a.labels(),
 					Annotations: a.annotations(config).
-						Add(utils.AnnotationKeyApplicationUUID(false), storageUniqueID),
+						Add(utils.AnnotationKeyApplicationUUID(a.labelVersion), storageUniqueID),
 				},
 				Spec: appsv1.DaemonSetSpec{
 					Selector: &metav1.LabelSelector{
@@ -1852,26 +1856,26 @@ func (a *app) applyImagePullSecrets(applier resources.Applier, config caas.Appli
 }
 
 func (a *app) annotations(config caas.ApplicationConfig) annotations.Annotation {
-	return utils.ResourceTagsToAnnotations(config.ResourceTags, a.legacyLabels).
-		Merge(utils.AnnotationsForVersion(config.AgentVersion.String(), a.legacyLabels))
+	return utils.ResourceTagsToAnnotations(config.ResourceTags, a.labelVersion).
+		Merge(utils.AnnotationsForVersion(config.AgentVersion.String(), a.labelVersion))
 }
 
 func (a *app) upgradeAnnotations(anns annotations.Annotation, ver version.Number) annotations.Annotation {
-	return anns.Merge(utils.AnnotationsForVersion(ver.String(), a.legacyLabels))
+	return anns.Merge(utils.AnnotationsForVersion(ver.String(), a.labelVersion))
 }
 
 func (a *app) labels() labels.Set {
 	// TODO: add modelUUID for global resources?
-	return utils.LabelsForApp(a.name, a.legacyLabels)
+	return utils.LabelsForApp(a.name, a.labelVersion)
 }
 
 func (a *app) selectorLabels() labels.Set {
-	return utils.SelectorLabelsForApp(a.name, a.legacyLabels)
+	return utils.SelectorLabelsForApp(a.name, a.labelVersion)
 }
 
 func (a *app) labelSelector() string {
 	return utils.LabelsToSelector(
-		utils.SelectorLabelsForApp(a.name, a.legacyLabels),
+		utils.SelectorLabelsForApp(a.name, a.labelVersion),
 	).String()
 }
 
@@ -1914,7 +1918,7 @@ type annotationGetter interface {
 func (a *app) getStorageUniqPrefix(getMeta func() (annotationGetter, error)) (string, error) {
 	if r, err := getMeta(); err == nil {
 		// TODO: remove this function with existing one once we consolidated the annotation keys.
-		if uniqID := r.GetAnnotations()[utils.AnnotationKeyApplicationUUID(false)]; len(uniqID) > 0 {
+		if uniqID := r.GetAnnotations()[utils.AnnotationKeyApplicationUUID(a.labelVersion)]; len(uniqID) > 0 {
 			return uniqID, nil
 		}
 	} else if !errors.IsNotFound(err) {
@@ -2096,13 +2100,13 @@ func (a *app) filesystemToVolumeInfo(
 	} else if _, ok := storageClasses[qualifiedStorageClassName]; ok {
 		params.StorageConfig.StorageClass = qualifiedStorageClassName
 	} else {
-		sp := storage.StorageProvisioner(a.namespace, a.modelName, *params)
-		newStorageClass = storage.StorageClassSpec(sp, a.legacyLabels)
+		sp := storage.StorageProvisioner(a.namespace, a.modelName, a.modelUUID, *params)
+		newStorageClass = storage.StorageClassSpec(sp, a.labelVersion)
 		params.StorageConfig.StorageClass = newStorageClass.Name
 	}
 
 	labels := utils.LabelsMerge(
-		utils.LabelsForStorage(fs.StorageName, a.legacyLabels),
+		utils.LabelsForStorage(fs.StorageName, a.labelVersion),
 		utils.LabelsJuju)
 
 	pvcSpec := storage.PersistentVolumeClaimSpec(*params)
@@ -2110,8 +2114,8 @@ func (a *app) filesystemToVolumeInfo(
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   params.Name,
 			Labels: labels,
-			Annotations: utils.ResourceTagsToAnnotations(fs.ResourceTags, a.legacyLabels).
-				Merge(utils.AnnotationsForStorage(fs.StorageName, a.legacyLabels)).
+			Annotations: utils.ResourceTagsToAnnotations(fs.ResourceTags, a.labelVersion).
+				Merge(utils.AnnotationsForStorage(fs.StorageName, a.labelVersion)).
 				ToMap(),
 		},
 		Spec: *pvcSpec,

--- a/caas/kubernetes/provider/application/application_test.go
+++ b/caas/kubernetes/provider/application/application_test.go
@@ -94,7 +94,7 @@ func (s *applicationSuite) getApp(c *gc.C, deploymentType caas.DeploymentType, m
 	s.applier = resourcesmocks.NewMockApplier(ctrl)
 
 	return application.NewApplicationForTest(
-		s.appName, s.namespace, "deadbeef", s.namespace, false,
+		s.appName, s.namespace, "deadbeef", s.namespace, "badf00d", 2,
 		deploymentType,
 		s.client,
 		watcherFn,

--- a/caas/kubernetes/provider/application/package_test.go
+++ b/caas/kubernetes/provider/application/package_test.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/juju/juju/caas"
+	"github.com/juju/juju/caas/kubernetes/provider/constants"
 	"github.com/juju/juju/caas/kubernetes/provider/resources"
 	k8sutils "github.com/juju/juju/caas/kubernetes/provider/utils"
 	k8swatcher "github.com/juju/juju/caas/kubernetes/provider/watcher"
@@ -24,13 +25,13 @@ type (
 	AnnotationUpdater = annotationUpdater
 )
 
-func (a *app) IsLegacyLabels() bool {
-	return a.legacyLabels
+func (a *app) LabelVersion() constants.LabelVersion {
+	return a.labelVersion
 }
 
 type ApplicationInterfaceForTest interface {
 	caas.Application
-	IsLegacyLabels() bool
+	LabelVersion() constants.LabelVersion
 }
 
 func NewApplicationForTest(
@@ -38,7 +39,8 @@ func NewApplicationForTest(
 	namespace string,
 	modelUUID string,
 	modelName string,
-	legacyLabels bool,
+	controllerUUID string,
+	labelVersion constants.LabelVersion,
 	deploymentType caas.DeploymentType,
 	client kubernetes.Interface,
 	newWatcher k8swatcher.NewK8sWatcherFunc,
@@ -47,7 +49,7 @@ func NewApplicationForTest(
 	newApplier func() resources.Applier,
 ) ApplicationInterfaceForTest {
 	return newApplication(
-		name, namespace, modelUUID, modelName, legacyLabels, deploymentType,
+		name, namespace, modelUUID, modelName, controllerUUID, labelVersion, deploymentType,
 		client, newWatcher, clock, randomPrefix, newApplier,
 	)
 }

--- a/caas/kubernetes/provider/base_test.go
+++ b/caas/kubernetes/provider/base_test.go
@@ -204,9 +204,23 @@ func (s *BaseSuite) TearDownTest(c *gc.C) {
 
 func (s *BaseSuite) getNamespace() string {
 	if s.broker != nil {
-		return s.broker.GetCurrentNamespace()
+		return s.broker.Namespace()
 	}
 	return s.namespace
+}
+
+func (s *BaseSuite) getModelUUID() string {
+	if s.broker != nil {
+		return s.broker.ModelUUID()
+	}
+	return "badf00d"
+}
+
+func (s *BaseSuite) getControllerUUID() string {
+	if s.broker != nil {
+		return s.broker.ControllerUUID()
+	}
+	return "d0gf00d"
 }
 
 func (s *BaseSuite) setupController(c *gc.C) *gomock.Controller {
@@ -528,7 +542,7 @@ func (s *fakeClientSuite) SetUpTest(c *gc.C) {
 
 func (s *fakeClientSuite) getNamespace() string {
 	if s.broker != nil {
-		return s.broker.GetCurrentNamespace()
+		return s.broker.Namespace()
 	}
 	return s.namespace
 }

--- a/caas/kubernetes/provider/bootstrap.go
+++ b/caas/kubernetes/provider/bootstrap.go
@@ -206,7 +206,7 @@ func findControllerNamespace(
 	}
 
 	for _, ns := range namespaces.Items {
-		if ns.Annotations[providerutils.AnnotationControllerUUIDKey(false)] == controllerUUID {
+		if ns.Annotations[providerutils.AnnotationControllerUUIDKey(1)] == controllerUUID {
 			return &ns, nil
 		}
 	}
@@ -226,7 +226,7 @@ func findControllerNamespace(
 	}
 
 	for _, ns := range namespaces.Items {
-		if ns.Annotations[providerutils.AnnotationControllerUUIDKey(true)] == controllerUUID {
+		if ns.Annotations[providerutils.AnnotationControllerUUIDKey(0)] == controllerUUID {
 			return &ns, nil
 		}
 	}
@@ -288,10 +288,10 @@ func newcontrollerStack(
 		return nil, errors.Trace(err)
 	}
 
-	selectorLabels := providerutils.SelectorLabelsForApp(stackName, false)
-	labels := providerutils.LabelsForApp(stackName, false)
+	selectorLabels := providerutils.SelectorLabelsForApp(stackName, constants.LastLabelVersion)
+	labels := providerutils.LabelsForApp(stackName, constants.LastLabelVersion)
 
-	controllerUUIDKey := providerutils.AnnotationControllerUUIDKey(false)
+	controllerUUIDKey := providerutils.AnnotationControllerUUIDKey(constants.LastLabelVersion)
 	cs := &controllerStack{
 		ctx:              ctx,
 		stackName:        stackName,
@@ -382,7 +382,7 @@ func (c *controllerStack) getControllerSecret() (secret *core.Secret, err error)
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        c.resourceNameSecret,
 				Labels:      c.stackLabels,
-				Namespace:   c.broker.GetCurrentNamespace(),
+				Namespace:   c.broker.Namespace(),
 				Annotations: c.stackAnnotations,
 			},
 			Type: core.SecretTypeOpaque,
@@ -410,7 +410,7 @@ func (c *controllerStack) getControllerConfigMap() (cm *core.ConfigMap, err erro
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        c.resourceNameConfigMap,
 				Labels:      c.stackLabels,
-				Namespace:   c.broker.GetCurrentNamespace(),
+				Namespace:   c.broker.Namespace(),
 				Annotations: c.stackAnnotations,
 			},
 		})
@@ -431,7 +431,7 @@ func (c *controllerStack) doCleanUp() {
 // Deploy creates all resources for the controller stack.
 func (c *controllerStack) Deploy() (err error) {
 	// creating namespace for controller stack, this namespace will be removed by broker.DestroyController if bootstrap failed.
-	nsName := c.broker.GetCurrentNamespace()
+	nsName := c.broker.Namespace()
 	c.ctx.Infof("Creating k8s resources for controller %q", nsName)
 	if err = c.broker.createNamespace(nsName); err != nil {
 		return errors.Annotate(err, "creating namespace for controller stack")
@@ -503,7 +503,8 @@ func (c *controllerStack) Deploy() (err error) {
 	saName, saCleanUps, err := ensureControllerServiceAccount(
 		c.ctx.Context(),
 		c.broker.client(),
-		c.broker.GetCurrentNamespace(),
+		c.broker.Namespace(),
+		c.broker.ControllerUUID(),
 		c.stackLabels,
 		c.stackAnnotations,
 	)
@@ -599,7 +600,7 @@ func (c *controllerStack) createControllerProxy(ctx context.Context) error {
 	remotePort := intstr.FromInt(c.portAPIServer)
 	config := k8sproxy.ControllerProxyConfig{
 		Name:          c.getResourceName(proxyResourceName),
-		Namespace:     c.broker.GetCurrentNamespace(),
+		Namespace:     c.broker.Namespace(),
 		RemotePort:    remotePort.String(),
 		TargetService: c.resourceNameService,
 	}
@@ -609,11 +610,11 @@ func (c *controllerStack) createControllerProxy(ctx context.Context) error {
 		config,
 		c.stackLabels,
 		c.broker.clock,
-		k8sClient.CoreV1().ConfigMaps(c.broker.GetCurrentNamespace()),
-		k8sClient.RbacV1().Roles(c.broker.GetCurrentNamespace()),
-		k8sClient.RbacV1().RoleBindings(c.broker.GetCurrentNamespace()),
-		k8sClient.CoreV1().ServiceAccounts(c.broker.GetCurrentNamespace()),
-		k8sClient.CoreV1().Secrets(c.broker.GetCurrentNamespace()),
+		k8sClient.CoreV1().ConfigMaps(c.broker.Namespace()),
+		k8sClient.RbacV1().Roles(c.broker.Namespace()),
+		k8sClient.RbacV1().RoleBindings(c.broker.Namespace()),
+		k8sClient.CoreV1().ServiceAccounts(c.broker.Namespace()),
+		k8sClient.CoreV1().Secrets(c.broker.Namespace()),
 	)
 
 	return errors.Trace(err)
@@ -632,7 +633,7 @@ func (c *controllerStack) createControllerService(ctx context.Context) error {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        svcName,
 			Labels:      c.stackLabels,
-			Namespace:   c.broker.GetCurrentNamespace(),
+			Namespace:   c.broker.Namespace(),
 			Annotations: c.stackAnnotations,
 		},
 		Spec: core.ServiceSpec{
@@ -867,6 +868,7 @@ func ensureControllerServiceAccount(
 	ctx context.Context,
 	client kubernetes.Interface,
 	namespace string,
+	controllerUUID string,
 	labels map[string]string,
 	annotations map[string]string,
 ) (string, []func(), error) {
@@ -890,8 +892,9 @@ func ensureControllerServiceAccount(
 	clusterRoleBindingName := namespace
 	crb := resources.NewClusterRoleBinding(clusterRoleBindingName, &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        clusterRoleBindingName,
-			Labels:      providerutils.LabelsForModel(environsbootstrap.ControllerModelName, false),
+			Name: clusterRoleBindingName,
+			Labels: providerutils.LabelsForModel(environsbootstrap.ControllerModelName, "",
+				controllerUUID, constants.LastLabelVersion),
 			Annotations: annotations,
 		},
 		RoleRef: rbacv1.RoleRef{
@@ -920,7 +923,7 @@ func (c *controllerStack) createControllerStatefulset() error {
 				c.stackLabels,
 				providerutils.LabelsJujuModelOperatorDisableWebhook,
 			),
-			Namespace:   c.broker.GetCurrentNamespace(),
+			Namespace:   c.broker.Namespace(),
 			Annotations: c.stackAnnotations,
 		},
 		Spec: apps.StatefulSetSpec{
@@ -936,7 +939,7 @@ func (c *controllerStack) createControllerStatefulset() error {
 						providerutils.LabelsJujuModelOperatorDisableWebhook,
 					),
 					Name:        c.pcfg.GetPodName(), // This really should not be set.
-					Namespace:   c.broker.GetCurrentNamespace(),
+					Namespace:   c.broker.Namespace(),
 					Annotations: c.stackAnnotations,
 				},
 			},
@@ -1621,9 +1624,10 @@ func (c *controllerStack) buildContainerSpecForCommands(setupCmd, machineCmd str
 	controllerApp := application.NewApplication(
 		environsbootstrap.ControllerApplicationName,
 		c.broker.namespace,
-		c.broker.modelUUID,
+		c.broker.ModelUUID(),
 		environsbootstrap.ControllerModelName,
-		false,
+		c.broker.ControllerUUID(),
+		constants.LastLabelVersion,
 		caas.DeploymentStateful,
 		c.broker.client(),
 		c.broker.newWatcher,

--- a/caas/kubernetes/provider/bootstrap_test.go
+++ b/caas/kubernetes/provider/bootstrap_test.go
@@ -341,7 +341,7 @@ func (s *bootstrapSuite) TestBootstrap(c *gc.C) {
 	s.setupBroker(c, newK8sClientFunc, newK8sRestClientFunc, randomPrefixFunc, &bootstrapWatchers)
 
 	// Broker's namespace is "controller" now - controllerModelConfig.Name()
-	c.Assert(s.broker.GetCurrentNamespace(), jc.DeepEquals, s.namespace)
+	c.Assert(s.broker.Namespace(), jc.DeepEquals, s.namespace)
 	c.Assert(
 		s.broker.GetAnnotations().ToMap(), jc.DeepEquals,
 		map[string]string{
@@ -1233,7 +1233,7 @@ func (s *bootstrapSuite) TestBootstrapFailedTimeout(c *gc.C) {
 	s.setupBroker(c, newK8sClientFunc, newK8sRestClientFunc, randomPrefixFunc, &watchers)
 
 	// Broker's namespace is "controller" now - controllerModelConfig.Name()
-	c.Assert(s.broker.GetCurrentNamespace(), jc.DeepEquals, s.namespace)
+	c.Assert(s.broker.Namespace(), jc.DeepEquals, s.namespace)
 	c.Assert(
 		s.broker.GetAnnotations().ToMap(), jc.DeepEquals,
 		map[string]string{

--- a/caas/kubernetes/provider/configmap.go
+++ b/caas/kubernetes/provider/configmap.go
@@ -18,7 +18,7 @@ import (
 )
 
 func (k *kubernetesClient) getConfigMapLabels(appName string) map[string]string {
-	return utils.LabelsForApp(appName, k.IsLegacyLabels())
+	return utils.LabelsForApp(appName, k.LabelVersion())
 }
 
 func (k *kubernetesClient) ensureConfigMaps(

--- a/caas/kubernetes/provider/constants/constants.go
+++ b/caas/kubernetes/provider/constants/constants.go
@@ -57,6 +57,8 @@ const (
 
 	// JujuControllerStackName is the juju CAAS controller stack name.
 	JujuControllerStackName = "controller"
+	// JujuControllerModelName is the name of the juju controller model.
+	JujuControllerModelName = "controller"
 
 	// ControllerServiceFQDNTemplate is the FQDN of the controller service using the cluster DNS.
 	ControllerServiceFQDNTemplate = "controller-service.controller-%s.svc.cluster.local"

--- a/caas/kubernetes/provider/constants/labels.go
+++ b/caas/kubernetes/provider/constants/labels.go
@@ -3,6 +3,28 @@
 
 package constants
 
+// LabelVersion represents which version of labelling a model
+// uses.
+type LabelVersion int
+
+const (
+	LegacyLabelVersion LabelVersion = iota
+	// LabelVersion1 introduces domain based labelling
+	// scheme for juju resources in kubernetes.
+	LabelVersion1
+	// LabelVersion2 introduces model and controller uuid
+	// labelling to disambiguate cluster scoped resources.
+	LabelVersion2
+
+	labelVersionMax
+)
+const (
+	// FirstLabelVersion is the first supported label version.
+	FirstLabelVersion LabelVersion = LegacyLabelVersion
+	// LastLabelVersion is the last supported label version.
+	LastLabelVersion = labelVersionMax - 1
+)
+
 const (
 	// LabelJujuAppCreatedBy is a Juju application label to apply to objects
 	// created by applications managed by Juju. Think istio, kubeflow etc
@@ -20,48 +42,66 @@ const (
 
 	// LabelJujuModelOperatorDisableWebhook is the label used for bypassing
 	// model admission validation and mutation on objects.
+	// Since LabelVersion1.
 	LabelJujuModelOperatorDisableWebhook = "model.juju.is/disable-webhook"
 
 	// LabelJujuModelName is the juju label applied for juju models.
+	// Since LabelVersion1.
 	LabelJujuModelName = "model.juju.is/name"
+
+	// LabelJujuModelUUID is the juju label applied for juju models.
+	// Since LabelVersion2.
+	LabelJujuModelUUID = "model.juju.is/id"
+
+	// LabelJujuControllerUUID is the juju label applied for juju controllers.
+	// Since LabelVersion2.
+	LabelJujuControllerUUID = "controller.juju.is/id"
 
 	// LabelJujuOperatorName is the juju label applied to Juju operators to
 	// identify their name. Operator names are generally named after the thing
 	// the operator is controlling. i.e an operator name for a model test would be
-	// "test"
+	// "test".
+	// Since LabelVersion1.
 	LabelJujuOperatorName = "operator.juju.is/name"
 
 	// LabelJujuOperatorTarget is the juju label applied to Juju operators to
 	// describe the modeling paradigm they target. For example model,
-	// application
+	// application.
+	// Since LabelVersion1.
 	LabelJujuOperatorTarget = "operator.juju.is/target"
 
 	// LabelJujuStorageName is the juju label applied to Juju storage objects to
 	// describe their name.
+	// Since LabelVersion1.
 	LabelJujuStorageName = "storage.juju.is/name"
 
 	// LegacyLabelKubernetesAppName is the legacy label key used for juju app
 	// identification. This purely exists to maintain backwards functionality.
 	// See https://bugs.launchpad.net/juju/+bug/1888513
+	// For LegacyLabelVersion.
 	LegacyLabelKubernetesAppName = "juju-app"
 
 	// LegacyLabelModelName is the legacy label key used for juju models. This
 	// purely exists to maintain backwards functionality.
 	// See https://bugs.launchpad.net/juju/+bug/1888513
+	// For LegacyLabelVersion.
 	LegacyLabelModelName = "juju-model"
 
 	// LegacyLabelModelOperator is the legacy label key used for juju model
 	// operators. This purely exists to maintain backwards functionality.
 	// See https://bugs.launchpad.net/juju/+bug/1888513
+	// For LegacyLabelVersion.
 	LegacyLabelModelOperator = "juju-modeloperator"
 
 	// LegacyLabelKubernetesOperatorName is the legacy label key used for juju
 	// operators. This purely exists to maintain backwards functionality.
 	// See https://bugs.launchpad.net/juju/+bug/1888513
+	// For LegacyLabelVersion.
 	LegacyLabelKubernetesOperatorName = "juju-operator"
 
 	// LegacyLabelJujuStorageName is the legacy label key used for juju storage
 	// pvc. This purely exists to maintain backwards functionality.
 	// See https://bugs.launchpad.net/juju/+bug/1888513
+	// For LegacyLabelVersion.
 	LegacyLabelStorageName = "juju-storage"
 )

--- a/caas/kubernetes/provider/controller_upgrade.go
+++ b/caas/kubernetes/provider/controller_upgrade.go
@@ -11,15 +11,16 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/client-go/kubernetes"
 
+	"github.com/juju/juju/caas/kubernetes/provider/constants"
 	"github.com/juju/juju/caas/kubernetes/provider/resources"
 	providerutils "github.com/juju/juju/caas/kubernetes/provider/utils"
 	"github.com/juju/juju/environs/bootstrap"
 )
 
 type upgradeCAASControllerBridge struct {
-	clientFn    func() kubernetes.Interface
-	isLegacyFn  func() bool
-	namespaceFn func() string
+	clientFn       func() kubernetes.Interface
+	labelVersionFn func() constants.LabelVersion
+	namespaceFn    func() string
 }
 
 // UpgradeCAASControllerBroker describes the interface needed for upgrading
@@ -29,8 +30,8 @@ type UpgradeCAASControllerBroker interface {
 	// cluster
 	Client() kubernetes.Interface
 
-	// IsLegacyLabels indicates if this provider is operating on a legacy label schema
-	IsLegacyLabels() bool
+	// LabelVersion indicates if this provider is operating on a legacy label schema
+	LabelVersion() constants.LabelVersion
 
 	// Namespace returns the targeted Kubernetes namespace for this broker
 	Namespace() string
@@ -40,8 +41,8 @@ func (u *upgradeCAASControllerBridge) Client() kubernetes.Interface {
 	return u.clientFn()
 }
 
-func (u *upgradeCAASControllerBridge) IsLegacyLabels() bool {
-	return u.isLegacyFn()
+func (u *upgradeCAASControllerBridge) LabelVersion() constants.LabelVersion {
+	return u.labelVersionFn()
 }
 
 func (u *upgradeCAASControllerBridge) Namespace() string {
@@ -56,15 +57,15 @@ func controllerUpgrade(appName string, vers version.Number, broker UpgradeCAASCo
 		"",
 		"",
 		vers,
-		broker.IsLegacyLabels(),
+		broker.LabelVersion(),
 		broker.Client().AppsV1().StatefulSets(broker.Namespace()))
 }
 
 func (k *kubernetesClient) upgradeController(vers version.Number) error {
 	broker := &upgradeCAASControllerBridge{
-		clientFn:    k.client,
-		namespaceFn: k.GetCurrentNamespace,
-		isLegacyFn:  k.IsLegacyLabels,
+		clientFn:       k.client,
+		namespaceFn:    k.Namespace,
+		labelVersionFn: k.LabelVersion,
 	}
 	return controllerUpgrade(bootstrap.ControllerModelName, vers, broker)
 }
@@ -74,23 +75,26 @@ func (k *kubernetesClient) upgradeController(vers version.Number) error {
 func (k *kubernetesClient) InClusterCredentialUpgrade() error {
 	return inClusterCredentialUpgrade(
 		k.client(),
-		k.IsLegacyLabels(),
-		k.GetCurrentNamespace(),
+		k.LabelVersion(),
+		k.Namespace(),
+		k.ControllerUUID(),
 	)
 }
 
 func inClusterCredentialUpgrade(
 	client kubernetes.Interface,
-	legacyLabels bool,
+	labelVersion constants.LabelVersion,
 	namespace string,
+	controllerUUID string,
 ) error {
 	ctx := context.TODO()
-	labels := providerutils.LabelsForApp("controller", legacyLabels)
+	labels := providerutils.LabelsForApp("controller", labelVersion)
 
 	saName, cleanUps, err := ensureControllerServiceAccount(
 		ctx,
 		client,
 		namespace,
+		controllerUUID,
 		labels,
 		map[string]string{},
 	)

--- a/caas/kubernetes/provider/controller_upgrade_test.go
+++ b/caas/kubernetes/provider/controller_upgrade_test.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 
+	"github.com/juju/juju/caas/kubernetes/provider/constants"
 	k8sconstants "github.com/juju/juju/caas/kubernetes/provider/constants"
 	"github.com/juju/juju/caas/kubernetes/provider/utils"
 	"github.com/juju/juju/cloudconfig/podcfg"
@@ -38,8 +39,8 @@ func (d *dummyUpgradeCAASController) Client() kubernetes.Interface {
 	return d.client
 }
 
-func (d *dummyUpgradeCAASController) IsLegacyLabels() bool {
-	return false
+func (d *dummyUpgradeCAASController) LabelVersion() constants.LabelVersion {
+	return constants.LabelVersion2
 }
 
 func (d *dummyUpgradeCAASController) Namespace() string {
@@ -90,8 +91,8 @@ func (s *ControllerUpgraderSuite) TestControllerUpgrade(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(ss.Spec.Template.Spec.Containers[0].Image, gc.Equals, newImagePath)
 
-	c.Assert(ss.Annotations[utils.AnnotationVersionKey(false)], gc.Equals, version.MustParse("9.9.9").String())
-	c.Assert(ss.Spec.Template.Annotations[utils.AnnotationVersionKey(false)], gc.Equals, version.MustParse("9.9.9").String())
+	c.Assert(ss.Annotations[utils.AnnotationVersionKey(constants.LabelVersion2)], gc.Equals, version.MustParse("9.9.9").String())
+	c.Assert(ss.Spec.Template.Annotations[utils.AnnotationVersionKey(constants.LabelVersion2)], gc.Equals, version.MustParse("9.9.9").String())
 }
 
 func (s *ControllerUpgraderSuite) TestControllerDoesNotExist(c *gc.C) {

--- a/caas/kubernetes/provider/customresourcedefinitions.go
+++ b/caas/kubernetes/provider/customresourcedefinitions.go
@@ -33,13 +33,13 @@ import (
 
 func (k *kubernetesClient) getAPIExtensionLabelsGlobal(appName string) map[string]string {
 	return utils.LabelsMerge(
-		utils.LabelsForApp(appName, k.IsLegacyLabels()),
-		utils.LabelsForModel(k.CurrentModel(), k.IsLegacyLabels()),
+		utils.LabelsForApp(appName, k.LabelVersion()),
+		utils.LabelsForModel(k.ModelName(), k.ModelUUID(), k.ControllerUUID(), k.LabelVersion()),
 	)
 }
 
 func (k *kubernetesClient) getAPIExtensionLabelsNamespaced(appName string) map[string]string {
-	return utils.LabelsForApp(appName, k.IsLegacyLabels())
+	return utils.LabelsForApp(appName, k.LabelVersion())
 }
 
 func (k *kubernetesClient) getCRLabels(appName string, scope apiextensionsv1.ResourceScope) map[string]string {

--- a/caas/kubernetes/provider/daemonset.go
+++ b/caas/kubernetes/provider/daemonset.go
@@ -106,7 +106,7 @@ func (k *kubernetesClient) deleteDaemonSets(appName string) error {
 	if k.namespace == "" {
 		return errNoNamespace
 	}
-	labels := utils.LabelsForApp(appName, k.IsLegacyLabels())
+	labels := utils.LabelsForApp(appName, k.LabelVersion())
 	err := k.client().AppsV1().DaemonSets(k.namespace).DeleteCollection(context.TODO(), v1.DeleteOptions{
 		PropagationPolicy: constants.DefaultPropagationPolicy(),
 	}, v1.ListOptions{

--- a/caas/kubernetes/provider/ingress.go
+++ b/caas/kubernetes/provider/ingress.go
@@ -25,7 +25,7 @@ import (
 )
 
 func (k *kubernetesClient) getIngressLabels(appName string) map[string]string {
-	return utils.LabelsForApp(appName, k.IsLegacyLabels())
+	return utils.LabelsForApp(appName, k.LabelVersion())
 }
 
 // TODO(caas): should we overwrite the existing `juju expose` created ingress if user runs upgrade-charm with new ingress podspec v2.

--- a/caas/kubernetes/provider/k8s.go
+++ b/caas/kubernetes/provider/k8s.go
@@ -123,6 +123,10 @@ type kubernetesClient struct {
 
 	// modelUUID is the UUID of the model this client acts on.
 	modelUUID string
+	// modelName is the name of the model.
+	modelName string
+	// controllerUUID is the UUID of the controller.
+	controllerUUID string
 
 	// newWatcher is the k8s watcher generator.
 	newWatcher        k8swatcher.NewK8sWatcherFunc
@@ -131,9 +135,9 @@ type kubernetesClient struct {
 	// informerFactoryUnlocked informer factory setup for tracking this model
 	informerFactoryUnlocked informers.SharedInformerFactory
 
-	// isLegacyLabels describes if this client should use and implement legacy
+	// labelVersion describes if this client should use and implement legacy
 	// labels or new ones
-	isLegacyLabels bool
+	labelVersion constants.LabelVersion
 
 	// randomPrefix generates an annotation for stateful sets.
 	randomPrefix utils.RandomPrefixFunc
@@ -191,11 +195,15 @@ func newK8sBroker(
 	if modelUUID == "" {
 		return nil, errors.NotValidf("modelUUID is required")
 	}
+	modelName := newCfg.Name()
+	if modelName == "" {
+		return nil, errors.NotValidf("modelName is required")
+	}
 
-	isLegacy := false
+	labelVersion := constants.LastLabelVersion
 	if namespace != "" {
-		isLegacy, err = utils.IsLegacyModelLabels(
-			namespace, newCfg.Config.Name(), k8sClient.CoreV1().Namespaces())
+		labelVersion, err = utils.DetectModelLabelVersion(
+			namespace, modelName, modelUUID, controllerUUID, k8sClient.CoreV1().Namespaces())
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -215,17 +223,19 @@ func newK8sBroker(
 		),
 		namespace:         namespace,
 		modelUUID:         modelUUID,
+		modelName:         modelName,
+		controllerUUID:    controllerUUID,
 		newWatcher:        newWatcher,
 		newStringsWatcher: newStringsWatcher,
 		newClient:         newClient,
 		newRestClient:     newRestClient,
 		randomPrefix:      randomPrefix,
 		annotations: k8sannotations.New(nil).
-			Add(utils.AnnotationModelUUIDKey(isLegacy), modelUUID),
-		isLegacyLabels: isLegacy,
+			Add(utils.AnnotationModelUUIDKey(labelVersion), modelUUID),
+		labelVersion: labelVersion,
 	}
 	if len(controllerUUID) > 0 {
-		client.annotations.Add(utils.AnnotationControllerUUIDKey(isLegacy), controllerUUID)
+		client.annotations.Add(utils.AnnotationControllerUUIDKey(labelVersion), controllerUUID)
 	}
 	if namespace == "" {
 		return client, nil
@@ -242,7 +252,7 @@ func newK8sBroker(
 		return client, nil
 	}
 
-	if err := client.ensureNamespaceAnnotationForControllerUUID(ns, controllerUUID, isLegacy); err != nil {
+	if err := client.ensureNamespaceAnnotationForControllerUUID(ns, controllerUUID, labelVersion); err != nil {
 		return nil, errors.Trace(err)
 	}
 	return client, nil
@@ -251,16 +261,14 @@ func newK8sBroker(
 func (k *kubernetesClient) ensureNamespaceAnnotationForControllerUUID(
 	ns *core.Namespace,
 	controllerUUID string,
-	isLegacy bool,
+	labelVersion constants.LabelVersion,
 ) error {
 	if len(controllerUUID) == 0 {
 		// controllerUUID could be empty in add-k8s without -c because there might be no controller yet.
 		return nil
 	}
-
-	annotationControllerUUIDKey := utils.AnnotationControllerUUIDKey(isLegacy)
-
-	if !isLegacy {
+	annotationControllerUUIDKey := utils.AnnotationControllerUUIDKey(labelVersion)
+	if labelVersion > 0 {
 		// Ignore the controller uuid since it is handled below for model migrations.
 		expected := k.annotations.Copy()
 		expected.Remove(annotationControllerUUIDKey)
@@ -502,7 +510,7 @@ please choose a different initial model name then try again.`, initialModelName)
 			if errors.IsNotFound(err) {
 				// all good.
 				// ensure controller specific annotations.
-				_ = broker.addAnnotations(utils.AnnotationControllerIsControllerKey(k.IsLegacyLabels()), "true")
+				_ = broker.addAnnotations(utils.AnnotationControllerIsControllerKey(k.LabelVersion()), "true")
 				return nil
 			}
 			if err == nil {
@@ -544,8 +552,8 @@ func (k *kubernetesClient) DestroyController(ctx envcontext.ProviderCallContext,
 	// ensures all annnotations are set correctly, then we will accurately find the controller namespace to destroy it.
 	k.annotations.Merge(
 		k8sannotations.New(nil).
-			Add(utils.AnnotationControllerUUIDKey(k.IsLegacyLabels()), controllerUUID).
-			Add(utils.AnnotationControllerIsControllerKey(k.IsLegacyLabels()), "true"),
+			Add(utils.AnnotationControllerUUIDKey(k.LabelVersion()), controllerUUID).
+			Add(utils.AnnotationControllerIsControllerKey(k.LabelVersion()), "true"),
 	)
 	return k.Destroy(ctx)
 }
@@ -558,10 +566,20 @@ func (k *kubernetesClient) SharedInformerFactory() informers.SharedInformerFacto
 	return k.informerFactoryUnlocked
 }
 
-func (k *kubernetesClient) CurrentModel() string {
-	k.lock.Lock()
-	defer k.lock.Unlock()
-	return k.envCfgUnlocked.Name()
+func (k *kubernetesClient) ModelUUID() string {
+	return k.modelUUID
+}
+
+func (k *kubernetesClient) ModelName() string {
+	return k.modelName
+}
+
+func (k *kubernetesClient) ControllerUUID() string {
+	return k.controllerUUID
+}
+
+func (k *kubernetesClient) Namespace() string {
+	return k.namespace
 }
 
 // Provider is part of the Broker interface.
@@ -646,11 +664,11 @@ func (k *kubernetesClient) GetService(appName string, mode caas.DeploymentMode, 
 		return nil, errNoNamespace
 	}
 	services := k.client().CoreV1().Services(k.namespace)
-	labels := utils.LabelsForApp(appName, k.IsLegacyLabels())
+	labels := utils.LabelsForApp(appName, k.LabelVersion())
 	if mode == caas.ModeOperator {
-		labels = utils.LabelsForOperator(appName, OperatorAppTarget, k.IsLegacyLabels())
+		labels = utils.LabelsForOperator(appName, OperatorAppTarget, k.LabelVersion())
 	}
-	if !k.IsLegacyLabels() {
+	if k.LabelVersion() > 0 {
 		labels = utils.LabelsMerge(labels, utils.LabelsJuju)
 	}
 
@@ -850,16 +868,16 @@ func (k *kubernetesClient) applyRawK8sSpec(
 	}
 
 	labelGetter := func(isNamespaced bool) map[string]string {
-		labels := utils.SelectorLabelsForApp(appName, k.IsLegacyLabels())
+		labels := utils.SelectorLabelsForApp(appName, k.LabelVersion())
 		if !isNamespaced {
 			labels = utils.LabelsMerge(
 				labels,
-				utils.LabelsForModel(k.CurrentModel(), k.IsLegacyLabels()),
+				utils.LabelsForModel(k.ModelName(), k.ModelUUID(), k.ControllerUUID(), k.LabelVersion()),
 			)
 		}
 		return labels
 	}
-	annotations := utils.ResourceTagsToAnnotations(params.ResourceTags, k.IsLegacyLabels())
+	annotations := utils.ResourceTagsToAnnotations(params.ResourceTags, k.LabelVersion())
 
 	builder := k8sspecs.New(
 		deploymentName, k.namespace, params.Deployment, k.k8sConfig(),
@@ -941,7 +959,7 @@ func (k *kubernetesClient) ensureService(
 		return errors.Annotatef(err, "parsing unit spec for %s", appName)
 	}
 
-	annotations := utils.ResourceTagsToAnnotations(params.ResourceTags, k.IsLegacyLabels())
+	annotations := utils.ResourceTagsToAnnotations(params.ResourceTags, k.LabelVersion())
 
 	// ensure services.
 	if len(workloadSpec.Services) > 0 {
@@ -1134,7 +1152,7 @@ func (k *kubernetesClient) ensureService(
 		// CharmModifiedVersion is added for triggering rolling upgrade on workload pods to synchronise
 		// charm files to workload pods via init container when charm was upgraded.
 		// This approach was inspired from `kubectl rollout restart`.
-		Add(utils.AnnotationCharmModifiedVersionKey(k.IsLegacyLabels()), strconv.Itoa(params.CharmModifiedVersion))
+		Add(utils.AnnotationCharmModifiedVersionKey(k.LabelVersion()), strconv.Itoa(params.CharmModifiedVersion))
 
 	switch params.Deployment.DeploymentType {
 	case caas.DeploymentStateful:
@@ -1216,7 +1234,7 @@ type annotationGetter interface {
 func (k *kubernetesClient) getStorageUniqPrefix(getMeta func() (annotationGetter, error)) (string, error) {
 	r, err := getMeta()
 	if err == nil {
-		if uniqID := r.GetAnnotations()[utils.AnnotationKeyApplicationUUID(k.IsLegacyLabels())]; uniqID != "" {
+		if uniqID := r.GetAnnotations()[utils.AnnotationKeyApplicationUUID(k.LabelVersion())]; uniqID != "" {
 			return uniqID, nil
 		}
 	} else if !errors.IsNotFound(err) {
@@ -1489,14 +1507,14 @@ func (k *kubernetesClient) configureDaemonSet(
 		return cleanUps, errors.Trace(err)
 	}
 
-	selectorLabels := utils.SelectorLabelsForApp(appName, k.IsLegacyLabels())
+	selectorLabels := utils.SelectorLabelsForApp(appName, k.LabelVersion())
 	daemonSet := &apps.DaemonSet{
 		ObjectMeta: v1.ObjectMeta{
 			Name:   deploymentName,
-			Labels: utils.LabelsForApp(appName, k.IsLegacyLabels()),
+			Labels: utils.LabelsForApp(appName, k.LabelVersion()),
 			Annotations: k8sannotations.New(nil).
 				Merge(annotations).
-				Add(utils.AnnotationKeyApplicationUUID(k.IsLegacyLabels()), storageUniqueID).ToMap(),
+				Add(utils.AnnotationKeyApplicationUUID(k.LabelVersion()), storageUniqueID).ToMap(),
 		},
 		Spec: apps.DaemonSetSpec{
 			// TODO(caas): MinReadySeconds support.
@@ -1593,14 +1611,14 @@ func (k *kubernetesClient) configureDeployment(
 		return cleanUps, errors.Trace(err)
 	}
 
-	selectorLabels := utils.SelectorLabelsForApp(appName, k.IsLegacyLabels())
+	selectorLabels := utils.SelectorLabelsForApp(appName, k.LabelVersion())
 	deployment := &apps.Deployment{
 		ObjectMeta: v1.ObjectMeta{
 			Name:   deploymentName,
-			Labels: utils.LabelsForApp(appName, k.IsLegacyLabels()),
+			Labels: utils.LabelsForApp(appName, k.LabelVersion()),
 			Annotations: k8sannotations.New(nil).
 				Merge(annotations).
-				Add(utils.AnnotationKeyApplicationUUID(k.IsLegacyLabels()), storageUniqueID).ToMap(),
+				Add(utils.AnnotationKeyApplicationUUID(k.LabelVersion()), storageUniqueID).ToMap(),
 		},
 		Spec: apps.DeploymentSpec{
 			// TODO(caas): MinReadySeconds, ProgressDeadlineSeconds support.
@@ -1730,7 +1748,7 @@ func (k *kubernetesClient) deleteDeployments(appName string) error {
 		PropagationPolicy: constants.DefaultPropagationPolicy(),
 	}, v1.ListOptions{
 		LabelSelector: utils.LabelsToSelector(
-			utils.LabelsForApp(appName, k.IsLegacyLabels())).String(),
+			utils.LabelsForApp(appName, k.LabelVersion())).String(),
 	})
 	if k8serrors.IsNotFound(err) {
 		return nil
@@ -1848,11 +1866,11 @@ func (k *kubernetesClient) configureService(
 	service := &core.Service{
 		ObjectMeta: v1.ObjectMeta{
 			Name:        deploymentName,
-			Labels:      utils.LabelsForApp(appName, k.IsLegacyLabels()),
+			Labels:      utils.LabelsForApp(appName, k.LabelVersion()),
 			Annotations: annotations,
 		},
 		Spec: core.ServiceSpec{
-			Selector:                 utils.SelectorLabelsForApp(appName, k.IsLegacyLabels()),
+			Selector:                 utils.SelectorLabelsForApp(appName, k.LabelVersion()),
 			Type:                     k8sServiceType,
 			Ports:                    ports,
 			ExternalIPs:              config.Get(serviceExternalIPsConfigKey, []string(nil)).([]string),
@@ -1872,13 +1890,13 @@ func (k *kubernetesClient) configureHeadlessService(
 	service := &core.Service{
 		ObjectMeta: v1.ObjectMeta{
 			Name:   headlessServiceName(deploymentName),
-			Labels: utils.LabelsForApp(appName, k.IsLegacyLabels()),
+			Labels: utils.LabelsForApp(appName, k.LabelVersion()),
 			Annotations: k8sannotations.New(nil).
 				Merge(annotations).
 				Add("service.alpha.kubernetes.io/tolerate-unready-endpoints", "true").ToMap(),
 		},
 		Spec: core.ServiceSpec{
-			Selector:                 utils.SelectorLabelsForApp(appName, k.IsLegacyLabels()),
+			Selector:                 utils.SelectorLabelsForApp(appName, k.LabelVersion()),
 			Type:                     core.ServiceTypeClusterIP,
 			ClusterIP:                "None",
 			PublishNotReadyAddresses: true,
@@ -1996,10 +2014,10 @@ func (k *kubernetesClient) UnexposeService(appName string) error {
 
 func (k *kubernetesClient) applicationSelector(appName string, mode caas.DeploymentMode) string {
 	if mode == caas.ModeOperator {
-		return operatorSelector(appName, k.IsLegacyLabels())
+		return operatorSelector(appName, k.LabelVersion())
 	}
 	return utils.LabelsToSelector(
-		utils.SelectorLabelsForApp(appName, k.IsLegacyLabels())).String()
+		utils.SelectorLabelsForApp(appName, k.LabelVersion())).String()
 }
 
 // AnnotateUnit annotates the specified pod (name or uid) with a unit tag.
@@ -2034,7 +2052,7 @@ func (k *kubernetesClient) AnnotateUnit(appName string, mode caas.DeploymentMode
 	}
 
 	unitID := unit.Id()
-	if pod.Annotations != nil && pod.Annotations[utils.AnnotationUnitKey(k.IsLegacyLabels())] == unitID {
+	if pod.Annotations != nil && pod.Annotations[utils.AnnotationUnitKey(k.LabelVersion())] == unitID {
 		return nil
 	}
 
@@ -2044,7 +2062,7 @@ func (k *kubernetesClient) AnnotateUnit(appName string, mode caas.DeploymentMode
 		} `json:"metadata"`
 	}{}
 	patch.ObjectMeta.Annotations = map[string]string{
-		utils.AnnotationUnitKey(k.IsLegacyLabels()): unitID,
+		utils.AnnotationUnitKey(k.LabelVersion()): unitID,
 	}
 	jsonPatch, err := json.Marshal(patch)
 	if err != nil {
@@ -2103,7 +2121,7 @@ func (k *kubernetesClient) WatchContainerStart(appName string, containerName str
 	}
 
 	running := func(pod *core.Pod) set.Strings {
-		if _, ok := pod.Annotations[utils.AnnotationUnitKey(k.IsLegacyLabels())]; !ok {
+		if _, ok := pod.Annotations[utils.AnnotationUnitKey(k.LabelVersion())]; !ok {
 			// Ignore pods that aren't annotated as a unit yet.
 			return set.Strings{}
 		}

--- a/caas/kubernetes/provider/k8s_test.go
+++ b/caas/kubernetes/provider/k8s_test.go
@@ -942,7 +942,7 @@ func (s *K8sBrokerSuite) TestEnsureNamespaceAnnotationForControllerUUIDMigrated(
 	})
 	nsAfter := *nsBefore
 	nsAfter.SetAnnotations(annotations.New(nsAfter.GetAnnotations()).Add(
-		k8sutils.AnnotationControllerUUIDKey(false), newControllerUUID,
+		k8sutils.AnnotationControllerUUIDKey(1), newControllerUUID,
 	))
 	gomock.InOrder(
 		s.mockNamespaces.EXPECT().Get(gomock.Any(), s.getNamespace(), v1.GetOptions{}).Times(2).
@@ -1562,7 +1562,7 @@ func (s *K8sBrokerSuite) TestPrepareForBootstrap(c *gc.C) {
 	c.Assert(
 		s.broker.PrepareForBootstrap(ctx, "ctrl-1"), jc.ErrorIsNil,
 	)
-	c.Assert(s.broker.GetCurrentNamespace(), jc.DeepEquals, "controller-ctrl-1")
+	c.Assert(s.broker.Namespace(), jc.DeepEquals, "controller-ctrl-1")
 }
 
 func (s *K8sBrokerSuite) TestPrepareForBootstrapAlreadyExistNamespaceError(c *gc.C) {
@@ -1982,7 +1982,7 @@ func (s *K8sBrokerSuite) TestDestroy(c *gc.C) {
 func (s *K8sBrokerSuite) TestGetCurrentNamespace(c *gc.C) {
 	ctrl := s.setupController(c)
 	defer ctrl.Finish()
-	c.Assert(s.broker.GetCurrentNamespace(), jc.DeepEquals, s.getNamespace())
+	c.Assert(s.broker.Namespace(), jc.DeepEquals, s.getNamespace())
 }
 
 func (s *K8sBrokerSuite) TestCreate(c *gc.C) {

--- a/caas/kubernetes/provider/labels.go
+++ b/caas/kubernetes/provider/labels.go
@@ -7,12 +7,13 @@ import (
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
+	"github.com/juju/juju/caas/kubernetes/provider/constants"
 	"github.com/juju/juju/caas/kubernetes/provider/utils"
 )
 
-// IsLegacyLabels indicates if this provider is operating on a legacy label schema
-func (k *kubernetesClient) IsLegacyLabels() bool {
-	return k.isLegacyLabels
+// LabelVersion indicates if this provider is operating on a legacy label schema
+func (k *kubernetesClient) LabelVersion() constants.LabelVersion {
+	return k.labelVersion
 }
 
 func isK8sObjectOwnedByJuju(objMeta meta.ObjectMeta) bool {

--- a/caas/kubernetes/provider/modeloperator.go
+++ b/caas/kubernetes/provider/modeloperator.go
@@ -66,30 +66,38 @@ type ModelOperatorBroker interface {
 	// exists in the targets cluster.
 	EnsureServiceAccount(*core.ServiceAccount) ([]func(), error)
 
-	// Model returns the name of the current model being deployed to for the
+	// ModelName returns the name of the current model being deployed to for the
 	// broker
-	Model() string
+	ModelName() string
+
+	// ModelUUID returns the uuid of the current model being deployed to for the
+	// broker
+	ModelUUID() string
 
 	// Namespace returns the current default namespace targeted by this broker.
 	Namespace() string
 
-	// IsLegacyLabels indicates if this provider is operating on a legacy label schema
-	IsLegacyLabels() bool
+	// LabelVersion indicates if this provider is operating on a legacy label schema
+	LabelVersion() constants.LabelVersion
 }
 
 // modelOperatorBrokerBridge provides a pluggable struct of funcs to implement
 // the ModelOperatorBroker interface
 type modelOperatorBrokerBridge struct {
-	client               kubernetes.Interface
+	client kubernetes.Interface
+
 	ensureConfigMap      func(*core.ConfigMap) ([]func(), error)
 	ensureDeployment     func(*apps.Deployment) ([]func(), error)
 	ensureRole           func(*rbac.Role) ([]func(), error)
 	ensureRoleBinding    func(*rbac.RoleBinding) ([]func(), error)
 	ensureService        func(*core.Service) ([]func(), error)
 	ensureServiceAccount func(*core.ServiceAccount) ([]func(), error)
-	model                func() string
-	namespace            func() string
-	isLegacyLabels       func() bool
+
+	modelName      string
+	modelUUID      string
+	controllerUUID string
+	namespace      string
+	labelVersion   constants.LabelVersion
 }
 
 const (
@@ -163,27 +171,24 @@ func (m *modelOperatorBrokerBridge) EnsureServiceAccount(s *core.ServiceAccount)
 	return m.ensureServiceAccount(s)
 }
 
-// Model implements ModelOperatorBroker
-func (m *modelOperatorBrokerBridge) Model() string {
-	if m.model == nil {
-		return ""
-	}
-	return m.model()
+func (m *modelOperatorBrokerBridge) ModelName() string {
+	return m.modelName
 }
 
-// Namespace implements ModelOperatorBroker
+func (m *modelOperatorBrokerBridge) ModelUUID() string {
+	return m.modelUUID
+}
+
+func (m *modelOperatorBrokerBridge) ControllerUUID() string {
+	return m.controllerUUID
+}
+
 func (m *modelOperatorBrokerBridge) Namespace() string {
-	if m.namespace == nil {
-		return ""
-	}
-	return m.namespace()
+	return m.namespace
 }
 
-func (m *modelOperatorBrokerBridge) IsLegacyLabels() bool {
-	if m.isLegacyLabels == nil {
-		return true
-	}
-	return m.isLegacyLabels()
+func (m *modelOperatorBrokerBridge) LabelVersion() constants.LabelVersion {
+	return m.labelVersion
 }
 
 func ensureModelOperator(
@@ -198,9 +203,9 @@ func ensureModelOperator(
 	operatorName := modelOperatorName
 	modelTag := names.NewModelTag(modelUUID)
 
-	selectorLabels := modelOperatorLabels(operatorName, broker.IsLegacyLabels())
+	selectorLabels := modelOperatorLabels(operatorName, broker.LabelVersion())
 	labels := selectorLabels
-	if !broker.IsLegacyLabels() {
+	if broker.LabelVersion() > 0 {
 		labels = utils.LabelsMerge(labels, utils.LabelsJuju)
 	}
 
@@ -329,9 +334,10 @@ func (k *kubernetesClient) EnsureModelOperator(
 			_, c, err := k.ensureServiceAccount(sa)
 			return c, err
 		},
-		namespace:      func() string { return k.namespace },
-		model:          func() string { return k.CurrentModel() },
-		isLegacyLabels: k.IsLegacyLabels,
+		modelUUID:      k.ModelUUID(),
+		modelName:      k.ModelName(),
+		controllerUUID: k.ControllerUUID(),
+		namespace:      k.Namespace(),
 	}
 
 	return ensureModelOperator(modelUUID, agentPath, k.clock, config, bridge)
@@ -506,11 +512,11 @@ func (k *kubernetesClient) modelOperatorDeploymentExists(operatorName string) (b
 	return true, nil
 }
 
-func modelOperatorLabels(operatorName string, legacy bool) labels.Set {
-	if legacy {
+func modelOperatorLabels(operatorName string, labelVersion constants.LabelVersion) labels.Set {
+	if labelVersion == 0 {
 		return utils.LabelForKeyValue(constants.LegacyLabelModelOperator, operatorName)
 	}
-	return utils.LabelsForOperator(operatorName, OperatorModelTarget, legacy)
+	return utils.LabelsForOperator(operatorName, OperatorModelTarget, labelVersion)
 }
 
 func modelOperatorService(
@@ -540,11 +546,11 @@ func modelOperatorService(
 	}
 }
 
-func modelOperatorGlobalScopedName(model, operatorName string) string {
-	if model == "" {
+func modelOperatorGlobalScopedName(modelName, operatorName string) string {
+	if modelName == "" {
 		return operatorName
 	}
-	return fmt.Sprintf("%s-%s", model, operatorName)
+	return fmt.Sprintf("%s-%s", modelName, operatorName)
 }
 
 func ensureModelOperatorRBAC(
@@ -557,7 +563,7 @@ func ensureModelOperatorRBAC(
 	cleanUpFuncs := []func(){}
 
 	objMetaGlobal := meta.ObjectMeta{
-		Name:   modelOperatorGlobalScopedName(broker.Model(), operatorName),
+		Name:   modelOperatorGlobalScopedName(broker.ModelName(), operatorName),
 		Labels: labels,
 	}
 	objMetaNamespaced := meta.ObjectMeta{

--- a/caas/kubernetes/provider/modeloperator_test.go
+++ b/caas/kubernetes/provider/modeloperator_test.go
@@ -43,7 +43,6 @@ func (m *ModelOperatorSuite) assertEnsure(c *gc.C, isPrivateImageRepo bool) {
 		ensureRoleBindingCalled    = false
 		ensureServiceCalled        = false
 		ensureServiceAccountCalled = false
-		namespaceCalled            = false
 		modelUUID                  = "abcd-efff-face"
 		agentPath                  = "/var/app/juju"
 		model                      = "test-model"
@@ -90,13 +89,8 @@ func (m *ModelOperatorSuite) assertEnsure(c *gc.C, isPrivateImageRepo bool) {
 			_, err := m.client.CoreV1().Services(namespace).Create(context.TODO(), s, meta.CreateOptions{})
 			return nil, err
 		},
-		model: func() string {
-			return model
-		},
-		namespace: func() string {
-			namespaceCalled = true
-			return namespace
-		},
+		modelName: model,
+		namespace: namespace,
 	}
 
 	// fake k8sclient does not populate the token for secret, so we have to do it manually.
@@ -277,7 +271,6 @@ func (m *ModelOperatorSuite) assertEnsure(c *gc.C, isPrivateImageRepo bool) {
 	c.Assert(ensureRoleBindingCalled, jc.IsTrue)
 	c.Assert(ensureServiceAccountCalled, jc.IsTrue)
 	c.Assert(ensureServiceCalled, jc.IsTrue)
-	c.Assert(namespaceCalled, jc.IsTrue)
 }
 
 func (m *ModelOperatorSuite) TestDefaultImageRepo(c *gc.C) {

--- a/caas/kubernetes/provider/modeloperator_upgrade.go
+++ b/caas/kubernetes/provider/modeloperator_upgrade.go
@@ -4,15 +4,16 @@
 package provider
 
 import (
+	"github.com/juju/juju/caas/kubernetes/provider/constants"
 	"github.com/juju/names/v5"
 	"github.com/juju/version/v2"
 	"k8s.io/client-go/kubernetes"
 )
 
 type upgradeCAASModelOperatorBridge struct {
-	clientFn    func() kubernetes.Interface
-	namespaceFn func() string
-	isLegacyFn  func() bool
+	clientFn       func() kubernetes.Interface
+	namespaceFn    func() string
+	labelVersionFn func() constants.LabelVersion
 }
 
 type UpgradeCAASModelOperatorBroker interface {
@@ -20,8 +21,8 @@ type UpgradeCAASModelOperatorBroker interface {
 	// cluster
 	Client() kubernetes.Interface
 
-	// IsLegacyLabels indicates if this provider is operating on a legacy label schema
-	IsLegacyLabels() bool
+	// LabelVersion indicates if this provider is operating on a legacy label schema
+	LabelVersion() constants.LabelVersion
 
 	// Namespace returns the targeted Kubernetes namespace for this broker
 	Namespace() string
@@ -31,8 +32,8 @@ func (u *upgradeCAASModelOperatorBridge) Client() kubernetes.Interface {
 	return u.clientFn()
 }
 
-func (u *upgradeCAASModelOperatorBridge) IsLegacyLabels() bool {
-	return u.isLegacyFn()
+func (u *upgradeCAASModelOperatorBridge) LabelVersion() constants.LabelVersion {
+	return u.labelVersionFn()
 }
 
 func modelOperatorUpgrade(
@@ -43,7 +44,7 @@ func modelOperatorUpgrade(
 		operatorName,
 		"",
 		vers,
-		broker.IsLegacyLabels(),
+		broker.LabelVersion(),
 		broker.Client().AppsV1().Deployments(broker.Namespace()))
 }
 
@@ -53,9 +54,9 @@ func (u *upgradeCAASModelOperatorBridge) Namespace() string {
 
 func (k *kubernetesClient) upgradeModelOperator(agentTag names.Tag, vers version.Number) error {
 	broker := &upgradeCAASModelOperatorBridge{
-		clientFn:    k.client,
-		namespaceFn: k.GetCurrentNamespace,
-		isLegacyFn:  k.IsLegacyLabels,
+		clientFn:       k.client,
+		namespaceFn:    k.Namespace,
+		labelVersionFn: k.LabelVersion,
 	}
 	return modelOperatorUpgrade(modelOperatorName, vers, broker)
 }

--- a/caas/kubernetes/provider/modeloperator_upgrade_test.go
+++ b/caas/kubernetes/provider/modeloperator_upgrade_test.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 
+	"github.com/juju/juju/caas/kubernetes/provider/constants"
 	"github.com/juju/juju/caas/kubernetes/provider/utils"
 	"github.com/juju/juju/cloudconfig/podcfg"
 )
@@ -35,8 +36,8 @@ func (d *dummyUpgradeCAASModel) Client() kubernetes.Interface {
 	return d.client
 }
 
-func (d *dummyUpgradeCAASModel) IsLegacyLabels() bool {
-	return false
+func (d *dummyUpgradeCAASModel) LabelVersion() constants.LabelVersion {
+	return constants.LabelVersion1
 }
 
 func (d *dummyUpgradeCAASModel) Namespace() string {
@@ -87,6 +88,6 @@ func (s *modelUpgraderSuite) TestModelOperatorUpgrade(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(de.Spec.Template.Spec.Containers[0].Image, gc.Equals, newImagePath)
 
-	c.Assert(de.Annotations[utils.AnnotationVersionKey(false)], gc.Equals, version.MustParse("9.9.9").String())
-	c.Assert(de.Spec.Template.Annotations[utils.AnnotationVersionKey(false)], gc.Equals, version.MustParse("9.9.9").String())
+	c.Assert(de.Annotations[utils.AnnotationVersionKey(1)], gc.Equals, version.MustParse("9.9.9").String())
+	c.Assert(de.Spec.Template.Annotations[utils.AnnotationVersionKey(1)], gc.Equals, version.MustParse("9.9.9").String())
 }

--- a/caas/kubernetes/provider/namespaces.go
+++ b/caas/kubernetes/provider/namespaces.go
@@ -99,14 +99,10 @@ func (k *kubernetesClient) listNamespacesByAnnotations(annotations k8sannotation
 	return nil, errors.NotFoundf("namespace for %v", k.annotations)
 }
 
-// GetCurrentNamespace returns current namespace name.
-func (k *kubernetesClient) GetCurrentNamespace() string {
-	return k.namespace
-}
-
 func (k *kubernetesClient) ensureNamespaceAnnotations(ns *core.Namespace) error {
 	annotations := k8sannotations.New(ns.GetAnnotations()).Merge(k.annotations)
-	err := annotations.CheckKeysNonEmpty(utils.AnnotationControllerUUIDKey(false), utils.AnnotationModelUUIDKey(false))
+	err := annotations.CheckKeysNonEmpty(utils.AnnotationControllerUUIDKey(k.LabelVersion()),
+		utils.AnnotationModelUUIDKey(k.LabelVersion()))
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -119,7 +115,7 @@ func (k *kubernetesClient) createNamespace(name string) error {
 	ns := &core.Namespace{ObjectMeta: v1.ObjectMeta{Name: name}}
 	ns.SetLabels(utils.LabelsMerge(
 		ns.GetLabels(),
-		utils.LabelsForModel(k.CurrentModel(), false),
+		utils.LabelsForModel(k.ModelName(), k.ModelUUID(), k.ControllerUUID(), k.LabelVersion()),
 		utils.LabelsJuju))
 
 	if err := k.ensureNamespaceAnnotations(ns); err != nil {

--- a/caas/kubernetes/provider/operator.go
+++ b/caas/kubernetes/provider/operator.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/caas"
+	"github.com/juju/juju/caas/kubernetes/provider/constants"
 	k8sconstants "github.com/juju/juju/caas/kubernetes/provider/constants"
 	"github.com/juju/juju/caas/kubernetes/provider/resources"
 	"github.com/juju/juju/caas/kubernetes/provider/storage"
@@ -52,15 +53,17 @@ func GetOperatorPodName(
 	nsAPI typedcorev1.NamespaceInterface,
 	appName,
 	namespace,
-	model string,
+	modelName,
+	modelUUID,
+	controllerUUID string,
 ) (string, error) {
-	legacyLabels, err := utils.IsLegacyModelLabels(namespace, model, nsAPI)
+	labelVersion, err := utils.DetectModelLabelVersion(namespace, modelName, modelUUID, controllerUUID, nsAPI)
 	if err != nil {
-		return "", errors.Annotatef(err, "determining legacy label status for model %s", model)
+		return "", errors.Annotatef(err, "determining legacy label status for model %s", modelName)
 	}
 
 	podsList, err := podAPI.List(context.TODO(), v1.ListOptions{
-		LabelSelector: operatorSelector(appName, legacyLabels),
+		LabelSelector: operatorSelector(appName, labelVersion),
 	})
 	if err != nil {
 		return "", errors.Trace(err)
@@ -73,7 +76,7 @@ func GetOperatorPodName(
 
 func (k *kubernetesClient) deleteOperatorRBACResources(operatorName string) error {
 	selector := utils.LabelsToSelector(
-		utils.LabelsForOperator(operatorName, OperatorAppTarget, k.IsLegacyLabels()),
+		utils.LabelsForOperator(operatorName, OperatorAppTarget, k.LabelVersion()),
 	)
 
 	if err := k.deleteRoleBindings(selector); err != nil {
@@ -188,15 +191,15 @@ func (k *kubernetesClient) EnsureOperator(appName, agentPath string, config *caa
 
 	operatorName := k.operatorName(appName)
 
-	selectorLabels := utils.LabelsForOperator(appName, OperatorAppTarget, k.IsLegacyLabels())
+	selectorLabels := utils.LabelsForOperator(appName, OperatorAppTarget, k.LabelVersion())
 	labels := selectorLabels
 
-	if !k.IsLegacyLabels() {
+	if k.LabelVersion() > 0 {
 		labels = utils.LabelsMerge(selectorLabels, utils.LabelsJuju)
 	}
 
-	annotations := utils.ResourceTagsToAnnotations(config.ResourceTags, k.IsLegacyLabels()).
-		Merge(utils.AnnotationsForVersion(config.Version.String(), k.IsLegacyLabels()))
+	annotations := utils.ResourceTagsToAnnotations(config.ResourceTags, k.LabelVersion()).
+		Merge(utils.AnnotationsForVersion(config.Version.String(), k.LabelVersion()))
 
 	var cleanups []func()
 	defer func() {
@@ -252,7 +255,7 @@ func (k *kubernetesClient) EnsureOperator(appName, agentPath string, config *caa
 		}
 	} else {
 		configMapLabels := labels
-		if k.IsLegacyLabels() {
+		if k.LabelVersion() == 0 {
 			configMapLabels = k.getConfigMapLabels(appName)
 		}
 		cmCleanUp, err := k.ensureConfigMapLegacy(
@@ -318,9 +321,9 @@ func (k *kubernetesClient) EnsureOperator(appName, agentPath string, config *caa
 	return errors.Annotatef(err, "creating or updating %v operator StatefulSet", appName)
 }
 
-func operatorSelector(appName string, legacyLabels bool) string {
+func operatorSelector(appName string, labelVersion constants.LabelVersion) string {
 	return utils.LabelsToSelector(
-		utils.LabelsForOperator(appName, OperatorAppTarget, legacyLabels)).
+		utils.LabelsForOperator(appName, OperatorAppTarget, labelVersion)).
 		String()
 }
 
@@ -372,7 +375,7 @@ func (k *kubernetesClient) operatorVolumeClaim(
 	return &core.PersistentVolumeClaim{
 		ObjectMeta: v1.ObjectMeta{
 			Name:        params.Name,
-			Annotations: utils.ResourceTagsToAnnotations(storageParams.ResourceTags, k.IsLegacyLabels()).ToMap()},
+			Annotations: utils.ResourceTagsToAnnotations(storageParams.ResourceTags, k.LabelVersion()).ToMap()},
 		Spec: *pvcSpec,
 	}, nil
 }
@@ -559,7 +562,7 @@ func (k *kubernetesClient) operatorPodExists(appName string) (exists bool, termi
 	}
 	pods := k.client().CoreV1().Pods(k.namespace)
 	podList, err := pods.List(context.TODO(), v1.ListOptions{
-		LabelSelector: operatorSelector(appName, k.IsLegacyLabels()),
+		LabelSelector: operatorSelector(appName, k.LabelVersion()),
 	})
 	if err != nil {
 		return false, false, errors.Trace(err)
@@ -613,7 +616,7 @@ func (k *kubernetesClient) DeleteOperator(appName string) (err error) {
 	}
 	pods := k.client().CoreV1().Pods(k.namespace)
 	podsList, err := pods.List(context.TODO(), v1.ListOptions{
-		LabelSelector: operatorSelector(appName, k.IsLegacyLabels()),
+		LabelSelector: operatorSelector(appName, k.LabelVersion()),
 	})
 	if err != nil {
 		return errors.Trace(err)
@@ -662,7 +665,7 @@ func (k *kubernetesClient) WatchOperator(appName string) (watcher.NotifyWatcher,
 	factory := informers.NewSharedInformerFactoryWithOptions(k.client(), 0,
 		informers.WithNamespace(k.namespace),
 		informers.WithTweakListOptions(func(o *v1.ListOptions) {
-			o.LabelSelector = operatorSelector(appName, k.IsLegacyLabels())
+			o.LabelSelector = operatorSelector(appName, k.LabelVersion())
 		}),
 	)
 	return k.newWatcher(factory.Core().V1().Pods().Informer(), appName, k.clock)
@@ -674,7 +677,7 @@ func (k *kubernetesClient) Operator(appName string) (*caas.Operator, error) {
 		k.namespace,
 		k.operatorName(appName),
 		appName,
-		k.IsLegacyLabels(),
+		k.LabelVersion(),
 		k.clock.Now())
 }
 
@@ -682,7 +685,7 @@ func operator(client kubernetes.Interface,
 	namespace string,
 	operatorName string,
 	appName string,
-	legacyLabels bool,
+	labelVersion constants.LabelVersion,
 	now time.Time) (*caas.Operator, error) {
 	if namespace == "" {
 		return nil, errNoNamespace
@@ -698,7 +701,7 @@ func operator(client kubernetes.Interface,
 
 	pods := client.CoreV1().Pods(namespace)
 	podsList, err := pods.List(context.TODO(), v1.ListOptions{
-		LabelSelector: operatorSelector(appName, legacyLabels),
+		LabelSelector: operatorSelector(appName, labelVersion),
 	})
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -721,7 +724,7 @@ func operator(client kubernetes.Interface,
 	}
 
 	cfg := caas.OperatorConfig{}
-	if ver, ok := opPod.Annotations[utils.AnnotationVersionKey(legacyLabels)]; ok {
+	if ver, ok := opPod.Annotations[utils.AnnotationVersionKey(labelVersion)]; ok {
 		cfg.Version, err = version.Parse(ver)
 		if err != nil {
 			return nil, errors.Trace(err)

--- a/caas/kubernetes/provider/operator_test.go
+++ b/caas/kubernetes/provider/operator_test.go
@@ -1295,7 +1295,7 @@ func (s *K8sBrokerSuite) TestGetOperatorPodName(c *gc.C) {
 			}}, nil),
 	)
 
-	name, err := provider.GetOperatorPodName(s.mockPods, s.mockNamespaces, "mariadb-k8s", s.getNamespace(), "test")
+	name, err := provider.GetOperatorPodName(s.mockPods, s.mockNamespaces, "mariadb-k8s", s.getNamespace(), "test", s.getModelUUID(), s.getControllerUUID())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(name, jc.DeepEquals, `mariadb-k8s-operator-0`)
 }
@@ -1311,6 +1311,6 @@ func (s *K8sBrokerSuite) TestGetOperatorPodNameNotFound(c *gc.C) {
 			Return(&core.PodList{Items: []core.Pod{}}, nil),
 	)
 
-	_, err := provider.GetOperatorPodName(s.mockPods, s.mockNamespaces, "mariadb-k8s", s.getNamespace(), "test")
+	_, err := provider.GetOperatorPodName(s.mockPods, s.mockNamespaces, "mariadb-k8s", s.getNamespace(), "test", s.getModelUUID(), s.getControllerUUID())
 	c.Assert(err, gc.ErrorMatches, `operator pod for application "mariadb-k8s" not found`)
 }

--- a/caas/kubernetes/provider/operator_upgrade.go
+++ b/caas/kubernetes/provider/operator_upgrade.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/juju/juju/caas"
+	"github.com/juju/juju/caas/kubernetes/provider/constants"
 	"github.com/juju/juju/caas/kubernetes/provider/utils"
 	"github.com/juju/juju/cloudconfig/podcfg"
 )
@@ -27,7 +28,7 @@ type upgradeCAASOperatorBridge struct {
 	clientFn         func() kubernetes.Interface
 	clockFn          func() clock.Clock
 	deploymentNameFn func(string, bool) string
-	isLegacyFn       func() bool
+	labelVersionFn   func() constants.LabelVersion
 	namespaceFn      func() string
 	operatorFn       func(string) (*caas.Operator, error)
 	operatorNameFn   func(string) string
@@ -45,8 +46,8 @@ type UpgradeCAASOperatorBroker interface {
 	// finding legacy deployment names if set to True.
 	DeploymentName(string, bool) string
 
-	// IsLegacyLabels indicates if this provider is operating on a legacy label schema
-	IsLegacyLabels() bool
+	// LabelVersion indicates if this provider is operating on a legacy label schema
+	LabelVersion() constants.LabelVersion
 
 	Namespace() string
 
@@ -72,8 +73,8 @@ func (u *upgradeCAASOperatorBridge) DeploymentName(n string, l bool) string {
 	return u.deploymentNameFn(n, l)
 }
 
-func (u *upgradeCAASOperatorBridge) IsLegacyLabels() bool {
-	return u.isLegacyFn()
+func (u *upgradeCAASOperatorBridge) LabelVersion() constants.LabelVersion {
+	return u.labelVersionFn()
 }
 
 func (u *upgradeCAASOperatorBridge) Operator(n string) (*caas.Operator, error) {
@@ -231,7 +232,7 @@ func operatorUpgrade(
 					operatorImagePath,
 					baseImagePath,
 					vers,
-					broker.IsLegacyLabels(),
+					broker.LabelVersion(),
 					broker.Client().AppsV1().StatefulSets(broker.Namespace())))
 			}
 		}
@@ -243,8 +244,8 @@ func (k *kubernetesClient) upgradeOperator(agentTag names.Tag, vers version.Numb
 		clientFn:         k.client,
 		clockFn:          func() clock.Clock { return k.clock },
 		deploymentNameFn: k.deploymentName,
-		isLegacyFn:       k.IsLegacyLabels,
-		namespaceFn:      k.GetCurrentNamespace,
+		labelVersionFn:   k.LabelVersion,
+		namespaceFn:      k.Namespace,
 		operatorFn:       k.Operator,
 		operatorNameFn:   k.operatorName,
 	}

--- a/caas/kubernetes/provider/operator_upgrade_test.go
+++ b/caas/kubernetes/provider/operator_upgrade_test.go
@@ -48,8 +48,8 @@ func (d *DummyUpgradeCAASOperator) DeploymentName(n string, _ bool) string {
 	return n
 }
 
-func (d *DummyUpgradeCAASOperator) IsLegacyLabels() bool {
-	return false
+func (d *DummyUpgradeCAASOperator) LabelVersion() constants.LabelVersion {
+	return constants.LabelVersion1
 }
 
 func (d *DummyUpgradeCAASOperator) Namespace() string {
@@ -57,7 +57,7 @@ func (d *DummyUpgradeCAASOperator) Namespace() string {
 }
 
 func (d *DummyUpgradeCAASOperator) Operator(appName string) (*caas.Operator, error) {
-	return operator(d.client, d.Namespace(), d.OperatorName(appName), appName, false, d.Clock().Now())
+	return operator(d.client, d.Namespace(), d.OperatorName(appName), appName, d.LabelVersion(), d.Clock().Now())
 }
 
 func (d *DummyUpgradeCAASOperator) OperatorName(n string) string {

--- a/caas/kubernetes/provider/secrets.go
+++ b/caas/kubernetes/provider/secrets.go
@@ -22,8 +22,8 @@ import (
 	k8sannotations "github.com/juju/juju/core/annotations"
 )
 
-func getSecretLabels(appName string, legacy bool) map[string]string {
-	return utils.LabelsForApp(appName, legacy)
+func getSecretLabels(appName string, labelVersion constants.LabelVersion) map[string]string {
+	return utils.LabelsForApp(appName, labelVersion)
 }
 
 func processSecretData(in map[string]string) (_ map[string][]byte, err error) {
@@ -42,7 +42,7 @@ func (k *kubernetesClient) ensureSecrets(appName string, annotations k8sannotati
 			ObjectMeta: v1.ObjectMeta{
 				Name:        v.Name,
 				Namespace:   k.namespace,
-				Labels:      getSecretLabels(appName, k.IsLegacyLabels()),
+				Labels:      getSecretLabels(appName, k.LabelVersion()),
 				Annotations: annotations.Merge(v.Annotations),
 			},
 			Type:       v.Type,
@@ -79,7 +79,7 @@ func (k *kubernetesClient) ensureOCIImageSecretForApp(
 	logger.Debugf("ensuring docker secret %q", imageSecretName)
 	_, err = k.ensureOCIImageSecret(
 		imageSecretName,
-		getSecretLabels(appName, k.IsLegacyLabels()),
+		getSecretLabels(appName, k.LabelVersion()),
 		secretData, annotations.ToMap(),
 	)
 	return errors.Trace(err)
@@ -208,7 +208,7 @@ func (k *kubernetesClient) deleteSecrets(appName string) error {
 		PropagationPolicy: constants.DefaultPropagationPolicy(),
 	}, v1.ListOptions{
 		LabelSelector: utils.LabelsToSelector(
-			getSecretLabels(appName, k.IsLegacyLabels())).String(),
+			getSecretLabels(appName, k.LabelVersion())).String(),
 	})
 	if k8serrors.IsNotFound(err) {
 		return nil

--- a/caas/kubernetes/provider/services_test.go
+++ b/caas/kubernetes/provider/services_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 
 	"github.com/juju/errors"
+	"github.com/juju/juju/caas/kubernetes/provider/constants"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 	core "k8s.io/api/core/v1"
@@ -45,7 +46,7 @@ func (s *servicesSuite) TestFindServiceForApplication(c *gc.C) {
 		context.TODO(),
 		s.client.CoreV1().Services("test"),
 		"wallyworld",
-		false,
+		constants.LabelVersion1,
 	)
 
 	c.Assert(err, jc.ErrorIsNil)
@@ -87,7 +88,7 @@ func (s *servicesSuite) TestFindServiceForApplicationWithEndpoints(c *gc.C) {
 		context.TODO(),
 		s.client.CoreV1().Services("test"),
 		"wallyworld",
-		false,
+		constants.LabelVersion1,
 	)
 
 	c.Assert(err, jc.ErrorIsNil)
@@ -129,7 +130,7 @@ func (s *servicesSuite) TestFindServiceForApplicationWithMultiple(c *gc.C) {
 		context.TODO(),
 		s.client.CoreV1().Services("test"),
 		"wallyworld",
-		false,
+		constants.LabelVersion1,
 	)
 
 	c.Assert(errors.Is(err, errors.NotValid), jc.IsTrue)
@@ -140,7 +141,7 @@ func (s *servicesSuite) TestFindServiceForApplicationMissing(c *gc.C) {
 		context.TODO(),
 		s.client.CoreV1().Services("test"),
 		"wallyworld",
-		false,
+		constants.LabelVersion1,
 	)
 
 	c.Assert(errors.Is(err, errors.NotFound), jc.IsTrue)

--- a/caas/kubernetes/provider/statefulsets.go
+++ b/caas/kubernetes/provider/statefulsets.go
@@ -68,14 +68,14 @@ func (k *kubernetesClient) configureStatefulSet(
 		return errors.Trace(err)
 	}
 
-	selectorLabels := utils.SelectorLabelsForApp(appName, k.IsLegacyLabels())
+	selectorLabels := utils.SelectorLabelsForApp(appName, k.LabelVersion())
 	statefulSet := &apps.StatefulSet{
 		ObjectMeta: v1.ObjectMeta{
 			Name:   deploymentName,
-			Labels: utils.LabelsForApp(appName, k.IsLegacyLabels()),
+			Labels: utils.LabelsForApp(appName, k.LabelVersion()),
 			Annotations: k8sannotations.New(nil).
 				Merge(annotations).
-				Add(utils.AnnotationKeyApplicationUUID(k.IsLegacyLabels()), storageUniqueID).ToMap(),
+				Add(utils.AnnotationKeyApplicationUUID(k.LabelVersion()), storageUniqueID).ToMap(),
 		},
 		Spec: apps.StatefulSetSpec{
 			Replicas: replicas,
@@ -216,7 +216,7 @@ func (k *kubernetesClient) deleteStatefulSets(appName string) error {
 	if k.namespace == "" {
 		return errNoNamespace
 	}
-	labels := utils.LabelsForApp(appName, k.IsLegacyLabels())
+	labels := utils.LabelsForApp(appName, k.LabelVersion())
 	err := k.client().AppsV1().StatefulSets(k.namespace).DeleteCollection(context.TODO(), v1.DeleteOptions{
 		PropagationPolicy: constants.DefaultPropagationPolicy(),
 	}, v1.ListOptions{

--- a/caas/kubernetes/provider/storage/storage.go
+++ b/caas/kubernetes/provider/storage/storage.go
@@ -94,7 +94,7 @@ func VolumeSourceForFilesystem(fs storage.KubernetesFilesystemParams) (*corev1.V
 }
 
 // StorageClassSpec converts storage provisioner config to k8s storage class.
-func StorageClassSpec(cfg k8s.StorageProvisioner, legacyLabels bool) *storagev1.StorageClass {
+func StorageClassSpec(cfg k8s.StorageProvisioner, labelVersion constants.LabelVersion) *storagev1.StorageClass {
 	sc := storagev1.StorageClass{}
 	sc.Name = constants.QualifiedStorageClassName(cfg.Namespace, cfg.Name)
 	sc.Provisioner = cfg.Provisioner
@@ -107,8 +107,8 @@ func StorageClassSpec(cfg k8s.StorageProvisioner, legacyLabels bool) *storagev1.
 		bindMode := storagev1.VolumeBindingMode(cfg.VolumeBindingMode)
 		sc.VolumeBindingMode = &bindMode
 	}
-	if cfg.Model != "" {
-		sc.Labels = utils.LabelsForModel(cfg.Model, legacyLabels)
+	if cfg.ModelName != "" {
+		sc.Labels = utils.LabelsForModel(cfg.ModelName, cfg.ModelUUID, cfg.ControllerUUID, labelVersion)
 	}
 	return &sc
 }
@@ -241,11 +241,12 @@ func PersistentVolumeClaimSpec(params VolumeParams) *corev1.PersistentVolumeClai
 }
 
 // StorageProvisioner returns storage provisioner.
-func StorageProvisioner(namespace, model string, params VolumeParams) k8s.StorageProvisioner {
+func StorageProvisioner(namespace, modelName, modelUUID string, params VolumeParams) k8s.StorageProvisioner {
 	return k8s.StorageProvisioner{
 		Name:          params.StorageConfig.StorageClass,
 		Namespace:     namespace,
-		Model:         model,
+		ModelName:     modelName,
+		ModelUUID:     modelUUID,
 		Provisioner:   params.StorageConfig.StorageProvisioner,
 		Parameters:    params.StorageConfig.Parameters,
 		ReclaimPolicy: string(params.StorageConfig.ReclaimPolicy),

--- a/caas/kubernetes/provider/teardown.go
+++ b/caas/kubernetes/provider/teardown.go
@@ -20,7 +20,7 @@ import (
 func (k *kubernetesClient) deleteClusterScopeResourcesModelTeardown(ctx context.Context, wg *sync.WaitGroup, errChan chan<- error) {
 	defer wg.Done()
 
-	labels := utils.LabelsForModel(k.CurrentModel(), k.IsLegacyLabels())
+	labels := utils.LabelsForModel(k.ModelName(), k.ModelUUID(), k.ControllerUUID(), k.LabelVersion())
 	selector := k8slabels.NewSelector().Add(
 		labelSetToRequirements(labels)...,
 	)

--- a/caas/kubernetes/provider/upgrade.go
+++ b/caas/kubernetes/provider/upgrade.go
@@ -17,6 +17,7 @@ import (
 	appstyped "k8s.io/client-go/kubernetes/typed/apps/v1"
 
 	"github.com/juju/juju/caas"
+	"github.com/juju/juju/caas/kubernetes/provider/constants"
 	"github.com/juju/juju/caas/kubernetes/provider/utils"
 	"github.com/juju/juju/cloudconfig/podcfg"
 	k8sannotations "github.com/juju/juju/core/annotations"
@@ -51,7 +52,7 @@ func upgradeDeployment(
 	name,
 	imagePath string,
 	vers version.Number,
-	legacyLabels bool,
+	labelVersion constants.LabelVersion,
 	broker appstyped.DeploymentInterface,
 ) error {
 	de, err := broker.Get(context.TODO(), name, meta.GetOptions{})
@@ -80,11 +81,11 @@ func upgradeDeployment(
 	// just ensure juju-version to current version for now.
 	de.SetAnnotations(
 		k8sannotations.New(de.GetAnnotations()).
-			Merge(utils.AnnotationsForVersion(vers.String(), legacyLabels)).ToMap(),
+			Merge(utils.AnnotationsForVersion(vers.String(), labelVersion)).ToMap(),
 	)
 	de.Spec.Template.SetAnnotations(
 		k8sannotations.New(de.Spec.Template.GetAnnotations()).
-			Merge(utils.AnnotationsForVersion(vers.String(), legacyLabels)).ToMap(),
+			Merge(utils.AnnotationsForVersion(vers.String(), labelVersion)).ToMap(),
 	)
 
 	if _, err := broker.Update(context.TODO(), de, meta.UpdateOptions{}); err != nil {
@@ -101,7 +102,7 @@ func upgradeOperatorOrControllerStatefulSet(
 	imagePath string,
 	baseImagePath string,
 	vers version.Number,
-	legacyLabels bool,
+	labelVersion constants.LabelVersion,
 	broker appstyped.StatefulSetInterface,
 ) error {
 	ss, err := broker.Get(context.TODO(), name, meta.GetOptions{})
@@ -137,11 +138,11 @@ func upgradeOperatorOrControllerStatefulSet(
 	// just ensure juju-version to current version for now.
 	ss.SetAnnotations(
 		k8sannotations.New(ss.GetAnnotations()).
-			Merge(utils.AnnotationsForVersion(vers.String(), legacyLabels)).ToMap(),
+			Merge(utils.AnnotationsForVersion(vers.String(), labelVersion)).ToMap(),
 	)
 	ss.Spec.Template.SetAnnotations(
 		k8sannotations.New(ss.Spec.Template.GetAnnotations()).
-			Merge(utils.AnnotationsForVersion(vers.String(), legacyLabels)).ToMap(),
+			Merge(utils.AnnotationsForVersion(vers.String(), labelVersion)).ToMap(),
 	)
 
 	if _, err := broker.Update(context.TODO(), ss, meta.UpdateOptions{}); err != nil {

--- a/caas/kubernetes/provider/utils/annotations.go
+++ b/caas/kubernetes/provider/utils/annotations.go
@@ -22,39 +22,39 @@ type AnnotationKeySupplier func() string
 // storage object. The annotations returned by this function are storage
 // specific only and should be combined with other annotations where
 // appropriate.
-func AnnotationsForStorage(name string, legacy bool) annotations.Annotation {
+func AnnotationsForStorage(name string, labelVersion constants.LabelVersion) annotations.Annotation {
 	return annotations.Annotation{
-		AnnotationJujuStorageKey(legacy): name,
+		AnnotationJujuStorageKey(labelVersion): name,
 	}
 }
 
 // AnnotationJujuStorageKey returns the key used in annotations
 // to describe the storage UUID.
-func AnnotationJujuStorageKey(legacy bool) string {
-	if legacy {
+func AnnotationJujuStorageKey(labelVersion constants.LabelVersion) string {
+	if labelVersion == 0 {
 		return "juju-storage"
 	}
-	return annotationKey("storage", "name", false)
+	return annotationKey("storage", "name", labelVersion)
 }
 
 // AnnotationsForVersion provides the annotations that should be placed on an
 // object that requires juju version information. The annotations returned by
 // this function are version specific and may need to be combined with other
 // annotations for a complete set.
-func AnnotationsForVersion(vers string, legacy bool) annotations.Annotation {
+func AnnotationsForVersion(vers string, labelVersion constants.LabelVersion) annotations.Annotation {
 	return annotations.Annotation{
-		AnnotationVersionKey(legacy): vers,
+		AnnotationVersionKey(labelVersion): vers,
 	}
 }
 
 // AnnotationVersionKey returns the key used in annotations to describe the
 // Juju version. Legacy controls if the key returns is a legacy annotation key
 // or newer style.
-func AnnotationVersionKey(legacy bool) string {
-	if legacy {
+func AnnotationVersionKey(labelVersion constants.LabelVersion) string {
+	if labelVersion == constants.LegacyLabelVersion {
 		return "juju-version"
 	}
-	return annotationKey("", "version", false)
+	return annotationKey("", "version", labelVersion)
 }
 
 // MakeK8sDomain builds and returns a Kubernetes resource domain for the
@@ -69,8 +69,8 @@ func MakeK8sDomain(components ...string) string {
 	return strings.Join(append(parts, constants.Domain), ".")
 }
 
-func annotationKey(name, suffix string, legacy bool) string {
-	if legacy {
+func annotationKey(name, suffix string, labelVersion constants.LabelVersion) string {
+	if labelVersion == constants.LegacyLabelVersion {
 		return constants.LegacyDomain + "/" + name
 	}
 	return MakeK8sDomain(name) + "/" + suffix
@@ -78,65 +78,65 @@ func annotationKey(name, suffix string, legacy bool) string {
 
 // AnnotationModelUUIDKey returns the key used in annotations
 // to describe the model UUID.
-func AnnotationModelUUIDKey(legacy bool) string {
-	if legacy {
+func AnnotationModelUUIDKey(labelVersion constants.LabelVersion) string {
+	if labelVersion == constants.LegacyLabelVersion {
 		return "juju-model"
 	}
-	return annotationKey("model", "id", legacy)
+	return annotationKey("model", "id", labelVersion)
 }
 
 // AnnotationControllerUUIDKey returns the key used in annotations
 // to describe the controller UUID.
-func AnnotationControllerUUIDKey(legacy bool) string {
-	return annotationKey("controller", "id", legacy)
+func AnnotationControllerUUIDKey(labelVersion constants.LabelVersion) string {
+	return annotationKey("controller", "id", labelVersion)
 }
 
 // AnnotationControllerIsControllerKey returns the key used in annotations
 // to describe if this pod is a controller pod.
-func AnnotationControllerIsControllerKey(legacy bool) string {
-	if legacy {
-		return annotationKey("is-controller", "", true)
+func AnnotationControllerIsControllerKey(labelVersion constants.LabelVersion) string {
+	if labelVersion == constants.LegacyLabelVersion {
+		return annotationKey("is-controller", "", labelVersion)
 	}
-	return annotationKey("controller", "is-controller", false)
+	return annotationKey("controller", "is-controller", labelVersion)
 }
 
 // AnnotationUnitKey returns the key used in annotations
 // to describe the Juju unit.
-func AnnotationUnitKey(legacy bool) string {
-	return annotationKey("unit", "id", legacy)
+func AnnotationUnitKey(labelVersion constants.LabelVersion) string {
+	return annotationKey("unit", "id", labelVersion)
 }
 
 // AnnotationCharmModifiedVersionKey returns the key used in annotations
 // to describe the charm modified version.
-func AnnotationCharmModifiedVersionKey(legacy bool) string {
-	if legacy {
-		return annotationKey("charm-modified-version", "", true)
+func AnnotationCharmModifiedVersionKey(labelVersion constants.LabelVersion) string {
+	if labelVersion == constants.LegacyLabelVersion {
+		return annotationKey("charm-modified-version", "", labelVersion)
 	}
-	return annotationKey("charm", "modified-version", false)
+	return annotationKey("charm", "modified-version", labelVersion)
 }
 
 // AnnotationDisableNameKey returns the key used in annotations
 // to describe the disabled name prefix.
-func AnnotationDisableNameKey(legacy bool) string {
-	if legacy {
-		return annotationKey("disable-name-prefix", "", true)
+func AnnotationDisableNameKey(labelVersion constants.LabelVersion) string {
+	if labelVersion == constants.LegacyLabelVersion {
+		return annotationKey("disable-name-prefix", "", labelVersion)
 	}
-	return annotationKey("model", "disable-prefix", false)
+	return annotationKey("model", "disable-prefix", labelVersion)
 }
 
 // AnnotationKeyApplicationUUID is the key of annotation for recording pvc unique ID.
-func AnnotationKeyApplicationUUID(legacy bool) string {
-	if legacy {
+func AnnotationKeyApplicationUUID(labelVersion constants.LabelVersion) string {
+	if labelVersion == constants.LegacyLabelVersion {
 		return "juju-app-uuid"
 	}
 	return MakeK8sDomain("app") + "/uuid"
 }
 
 // ResourceTagsToAnnotations creates annotations from the resource tags.
-func ResourceTagsToAnnotations(in map[string]string, legacy bool) annotations.Annotation {
+func ResourceTagsToAnnotations(in map[string]string, labelVersion constants.LabelVersion) annotations.Annotation {
 	tagsAnnotationsMap := map[string]string{
-		tags.JujuController: AnnotationControllerUUIDKey(legacy),
-		tags.JujuModel:      AnnotationModelUUIDKey(legacy),
+		tags.JujuController: AnnotationControllerUUIDKey(labelVersion),
+		tags.JujuModel:      AnnotationModelUUIDKey(labelVersion),
 	}
 
 	out := annotations.New(nil)

--- a/caas/kubernetes/provider/utils/annotations_test.go
+++ b/caas/kubernetes/provider/utils/annotations_test.go
@@ -6,6 +6,7 @@ package utils_test
 import (
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/caas/kubernetes/provider/constants"
 	"github.com/juju/juju/caas/kubernetes/provider/utils"
 	"github.com/juju/juju/testing"
 )
@@ -17,30 +18,30 @@ type annotationSuite struct {
 var _ = gc.Suite(&annotationSuite{})
 
 func (s *annotationSuite) TestAnnotations(c *gc.C) {
-	c.Assert(utils.AnnotationJujuStorageKey(true), gc.DeepEquals, "juju-storage")
-	c.Assert(utils.AnnotationJujuStorageKey(false), gc.DeepEquals, "storage.juju.is/name")
+	c.Assert(utils.AnnotationJujuStorageKey(constants.LegacyLabelVersion), gc.DeepEquals, "juju-storage")
+	c.Assert(utils.AnnotationJujuStorageKey(constants.LabelVersion1), gc.DeepEquals, "storage.juju.is/name")
 
-	c.Assert(utils.AnnotationVersionKey(true), gc.DeepEquals, "juju-version")
-	c.Assert(utils.AnnotationVersionKey(false), gc.DeepEquals, "juju.is/version")
+	c.Assert(utils.AnnotationVersionKey(constants.LegacyLabelVersion), gc.DeepEquals, "juju-version")
+	c.Assert(utils.AnnotationVersionKey(constants.LabelVersion1), gc.DeepEquals, "juju.is/version")
 
-	c.Assert(utils.AnnotationModelUUIDKey(true), gc.DeepEquals, "juju-model")
-	c.Assert(utils.AnnotationModelUUIDKey(false), gc.DeepEquals, "model.juju.is/id")
+	c.Assert(utils.AnnotationModelUUIDKey(constants.LegacyLabelVersion), gc.DeepEquals, "juju-model")
+	c.Assert(utils.AnnotationModelUUIDKey(constants.LabelVersion1), gc.DeepEquals, "model.juju.is/id")
 
-	c.Assert(utils.AnnotationControllerUUIDKey(true), gc.DeepEquals, "juju.io/controller")
-	c.Assert(utils.AnnotationControllerUUIDKey(false), gc.DeepEquals, "controller.juju.is/id")
+	c.Assert(utils.AnnotationControllerUUIDKey(constants.LegacyLabelVersion), gc.DeepEquals, "juju.io/controller")
+	c.Assert(utils.AnnotationControllerUUIDKey(constants.LabelVersion1), gc.DeepEquals, "controller.juju.is/id")
 
-	c.Assert(utils.AnnotationControllerIsControllerKey(true), gc.DeepEquals, "juju.io/is-controller")
-	c.Assert(utils.AnnotationControllerIsControllerKey(false), gc.DeepEquals, "controller.juju.is/is-controller")
+	c.Assert(utils.AnnotationControllerIsControllerKey(constants.LegacyLabelVersion), gc.DeepEquals, "juju.io/is-controller")
+	c.Assert(utils.AnnotationControllerIsControllerKey(constants.LabelVersion1), gc.DeepEquals, "controller.juju.is/is-controller")
 
-	c.Assert(utils.AnnotationUnitKey(true), gc.DeepEquals, "juju.io/unit")
-	c.Assert(utils.AnnotationUnitKey(false), gc.DeepEquals, "unit.juju.is/id")
+	c.Assert(utils.AnnotationUnitKey(constants.LegacyLabelVersion), gc.DeepEquals, "juju.io/unit")
+	c.Assert(utils.AnnotationUnitKey(constants.LabelVersion1), gc.DeepEquals, "unit.juju.is/id")
 
-	c.Assert(utils.AnnotationCharmModifiedVersionKey(true), gc.DeepEquals, "juju.io/charm-modified-version")
-	c.Assert(utils.AnnotationCharmModifiedVersionKey(false), gc.DeepEquals, "charm.juju.is/modified-version")
+	c.Assert(utils.AnnotationCharmModifiedVersionKey(constants.LegacyLabelVersion), gc.DeepEquals, "juju.io/charm-modified-version")
+	c.Assert(utils.AnnotationCharmModifiedVersionKey(constants.LabelVersion1), gc.DeepEquals, "charm.juju.is/modified-version")
 
-	c.Assert(utils.AnnotationDisableNameKey(true), gc.DeepEquals, "juju.io/disable-name-prefix")
-	c.Assert(utils.AnnotationDisableNameKey(false), gc.DeepEquals, "model.juju.is/disable-prefix")
+	c.Assert(utils.AnnotationDisableNameKey(constants.LegacyLabelVersion), gc.DeepEquals, "juju.io/disable-name-prefix")
+	c.Assert(utils.AnnotationDisableNameKey(constants.LabelVersion1), gc.DeepEquals, "model.juju.is/disable-prefix")
 
-	c.Assert(utils.AnnotationKeyApplicationUUID(true), gc.DeepEquals, "juju-app-uuid")
-	c.Assert(utils.AnnotationKeyApplicationUUID(false), gc.DeepEquals, "app.juju.is/uuid")
+	c.Assert(utils.AnnotationKeyApplicationUUID(constants.LegacyLabelVersion), gc.DeepEquals, "juju-app-uuid")
+	c.Assert(utils.AnnotationKeyApplicationUUID(constants.LabelVersion1), gc.DeepEquals, "app.juju.is/uuid")
 }

--- a/caas/kubernetes/provider/utils/labels.go
+++ b/caas/kubernetes/provider/utils/labels.go
@@ -38,29 +38,31 @@ func HasLabels(src, has labels.Set) bool {
 	return true
 }
 
-// IsLegacyModelLabels checks to see if the provided model is running on an older
+const ErrBadModelLabels errors.ConstError = "bad model labels"
+
+// DetectModelLabelVersion checks to see if the provided model is running on an older
 // labeling scheme or a newer one.
-func IsLegacyModelLabels(namespace, model string, namespaceI core.NamespaceInterface) (bool, error) {
+func DetectModelLabelVersion(namespace, modelName, modelUUID, controllerUUID string, namespaceI core.NamespaceInterface) (constants.LabelVersion, error) {
 	ns, err := namespaceI.Get(context.TODO(), namespace, meta.GetOptions{})
 	if k8serrors.IsNotFound(err) {
-		return false, nil
+		return constants.LabelVersion2, nil
 	}
 	if err != nil {
-		return true, errors.Annotatef(err, "unable to determine legacy status for namespace %q", namespace)
+		return 0, errors.Annotatef(err, "unable to determine model label version for namespace %q", namespace)
 	}
-
-	if !HasLabels(ns.Labels, LabelsForModel(model, false)) &&
-		HasLabels(ns.Labels, LabelsForModel(model, true)) {
-		return true, nil
+	for i := constants.LastLabelVersion; i >= constants.FirstLabelVersion; i-- {
+		if HasLabels(ns.Labels, LabelsForModel(modelName, modelUUID, controllerUUID, i)) {
+			return i, nil
+		}
 	}
-	return false, nil
+	return 0, ErrBadModelLabels
 }
 
 // LabelsForApp returns the labels that should be on a k8s object for a given
 // application name
-func LabelsForApp(name string, legacy bool) labels.Set {
-	result := SelectorLabelsForApp(name, legacy)
-	if legacy {
+func LabelsForApp(name string, labelVersion constants.LabelVersion) labels.Set {
+	result := SelectorLabelsForApp(name, labelVersion)
+	if labelVersion == constants.LegacyLabelVersion {
 		return result
 	}
 	return LabelsMerge(result, LabelsJuju)
@@ -68,8 +70,8 @@ func LabelsForApp(name string, legacy bool) labels.Set {
 
 // SelectorLabelsForApp returns the pod selector labels that should be on
 // a k8s object for a given application name
-func SelectorLabelsForApp(name string, legacy bool) labels.Set {
-	if legacy {
+func SelectorLabelsForApp(name string, labelVersion constants.LabelVersion) labels.Set {
+	if labelVersion == constants.LegacyLabelVersion {
 		return labels.Set{
 			constants.LegacyLabelKubernetesAppName: name,
 		}
@@ -97,22 +99,37 @@ func LabelsMerge(a labels.Set, merges ...labels.Set) labels.Set {
 
 // LabelsForModel returns the labels that should be on a k8s object for a given
 // model name
-func LabelsForModel(name string, legacy bool) labels.Set {
-	if legacy {
+func LabelsForModel(modelName string, modelUUID string, controllerUUID string, labelVersion constants.LabelVersion) labels.Set {
+	switch labelVersion {
+	case constants.LegacyLabelVersion:
 		return map[string]string{
-			constants.LegacyLabelModelName: name,
+			constants.LegacyLabelModelName: modelName,
 		}
-	}
-	return map[string]string{
-		constants.LabelJujuModelName: name,
+	case constants.LabelVersion1:
+		return map[string]string{
+			constants.LabelJujuModelName: modelName,
+		}
+	case constants.LabelVersion2:
+		fallthrough
+	default:
+		if modelName == constants.JujuControllerModelName {
+			return map[string]string{
+				constants.LabelJujuModelName:      modelName,
+				constants.LabelJujuControllerUUID: controllerUUID,
+			}
+		}
+		return map[string]string{
+			constants.LabelJujuModelName: modelName,
+			constants.LabelJujuModelUUID: modelUUID,
+		}
 	}
 }
 
 // LabelsForOperator returns the labels that should be placed on a juju operator
 // Takes the operator name, type and a legacy flag to indicate these labels are
 // being used on a model that is operating in "legacy" label mode
-func LabelsForOperator(name, target string, legacy bool) labels.Set {
-	if legacy {
+func LabelsForOperator(name, target string, labelVersion constants.LabelVersion) labels.Set {
+	if labelVersion == constants.LegacyLabelVersion {
 		return map[string]string{
 			constants.LegacyLabelKubernetesOperatorName: name,
 		}
@@ -125,8 +142,8 @@ func LabelsForOperator(name, target string, legacy bool) labels.Set {
 
 // LabelsForStorage return the labels that should be placed on a k8s storage
 // object. Takes the storage name and a legacy flat.
-func LabelsForStorage(name string, legacy bool) labels.Set {
-	if legacy {
+func LabelsForStorage(name string, labelVersion constants.LabelVersion) labels.Set {
+	if labelVersion == constants.LegacyLabelVersion {
 		return map[string]string{
 			constants.LegacyLabelStorageName: name,
 		}

--- a/caas/kubernetes/provider/utils/labels_test.go
+++ b/caas/kubernetes/provider/utils/labels_test.go
@@ -61,51 +61,71 @@ func (l *LabelSuite) TestHasLabels(c *gc.C) {
 	}
 }
 
-func (l *LabelSuite) TestIsLegacyModelLabels(c *gc.C) {
+func (l *LabelSuite) TestDectectModelLabelVersion(c *gc.C) {
 	tests := []struct {
-		IsLegacy  bool
-		Model     string
-		Namespace *core.Namespace
+		LabelVersion   constants.LabelVersion
+		ModelName      string
+		ModelUUID      string
+		ControllerUUID string
+		Namespace      *core.Namespace
 	}{
 		{
-			IsLegacy: false,
-			Model:    "legacy-model-label-test-1",
+			LabelVersion:   constants.LegacyLabelVersion,
+			ModelName:      "model-label-test-3",
+			ModelUUID:      "badf00d3",
+			ControllerUUID: "d0gf00d3",
 			Namespace: &core.Namespace{
 				ObjectMeta: meta.ObjectMeta{
-					Name:   "legacy-model-label-test-1",
-					Labels: map[string]string{"model.juju.is/name": "legacy-model-label-test-1"},
+					Name:   "model-label-test-3",
+					Labels: map[string]string{"juju-model": "model-label-test-3"},
 				},
 			},
 		},
 		{
-			IsLegacy: false,
-			Model:    "legacy-model-label-test-2",
+			LabelVersion:   constants.LabelVersion1,
+			ModelName:      "model-label-test-1",
+			ModelUUID:      "badf00d1",
+			ControllerUUID: "d0gf00d1",
 			Namespace: &core.Namespace{
 				ObjectMeta: meta.ObjectMeta{
-					Name:   "legacy-model-label-test-2",
-					Labels: map[string]string{},
+					Name:   "model-label-test-1",
+					Labels: map[string]string{"model.juju.is/name": "model-label-test-1"},
 				},
 			},
 		},
 		{
-			IsLegacy: true,
-			Model:    "legacy-model-label-test-3",
+			LabelVersion:   constants.LabelVersion2,
+			ModelName:      "model-label-test-2",
+			ModelUUID:      "badf00d2",
+			ControllerUUID: "d0gf00d2",
 			Namespace: &core.Namespace{
 				ObjectMeta: meta.ObjectMeta{
-					Name:   "legacy-model-label-test-3",
-					Labels: map[string]string{"juju-model": "legacy-model-label-test-3"},
+					Name:   "model-label-test-2",
+					Labels: map[string]string{"model.juju.is/name": "model-label-test-2", "model.juju.is/id": "badf00d2"},
+				},
+			},
+		},
+		{
+			LabelVersion:   constants.LabelVersion2,
+			ModelName:      "controller",
+			ModelUUID:      "badf00d4",
+			ControllerUUID: "d0gf00d4",
+			Namespace: &core.Namespace{
+				ObjectMeta: meta.ObjectMeta{
+					Name:   "controller-foo",
+					Labels: map[string]string{"model.juju.is/name": "controller", "controller.juju.is/id": "d0gf00d4"},
 				},
 			},
 		},
 	}
 
-	for _, test := range tests {
+	for t, test := range tests {
 		_, err := l.client.CoreV1().Namespaces().Create(context.TODO(), test.Namespace, meta.CreateOptions{})
 		c.Assert(err, jc.ErrorIsNil)
 
-		legacy, err := utils.IsLegacyModelLabels(test.Namespace.Name, test.Model, l.client.CoreV1().Namespaces())
-		c.Assert(err, jc.ErrorIsNil)
-		c.Assert(legacy, gc.Equals, test.IsLegacy)
+		labelVersion, err := utils.DetectModelLabelVersion(test.Namespace.Name, test.ModelName, test.ModelUUID, test.ControllerUUID, l.client.CoreV1().Namespaces())
+		c.Assert(err, jc.ErrorIsNil, gc.Commentf("test %d", t))
+		c.Check(labelVersion, gc.Equals, test.LabelVersion, gc.Commentf("test %d", t))
 	}
 }
 
@@ -139,26 +159,26 @@ func (l *LabelSuite) TestSelectorLabelsForApp(c *gc.C) {
 	tests := []struct {
 		AppName        string
 		ExpectedLabels labels.Set
-		Legacy         bool
+		LabelVersion   constants.LabelVersion
 	}{
 		{
 			AppName: "tlm-boom",
 			ExpectedLabels: labels.Set{
 				"app.kubernetes.io/name": "tlm-boom",
 			},
-			Legacy: false,
+			LabelVersion: constants.LabelVersion1,
 		},
 		{
 			AppName: "tlm-boom",
 			ExpectedLabels: labels.Set{
 				"juju-app": "tlm-boom",
 			},
-			Legacy: true,
+			LabelVersion: constants.LegacyLabelVersion,
 		},
 	}
 
 	for _, test := range tests {
-		rval := utils.SelectorLabelsForApp(test.AppName, test.Legacy)
+		rval := utils.SelectorLabelsForApp(test.AppName, test.LabelVersion)
 		c.Assert(rval, jc.DeepEquals, test.ExpectedLabels)
 	}
 }
@@ -167,7 +187,7 @@ func (l *LabelSuite) TestLabelsForApp(c *gc.C) {
 	tests := []struct {
 		AppName        string
 		ExpectedLabels labels.Set
-		Legacy         bool
+		LabelVersion   constants.LabelVersion
 	}{
 		{
 			AppName: "tlm-boom",
@@ -175,19 +195,19 @@ func (l *LabelSuite) TestLabelsForApp(c *gc.C) {
 				"app.kubernetes.io/name":       "tlm-boom",
 				"app.kubernetes.io/managed-by": "juju",
 			},
-			Legacy: false,
+			LabelVersion: constants.LabelVersion1,
 		},
 		{
 			AppName: "tlm-boom",
 			ExpectedLabels: labels.Set{
 				"juju-app": "tlm-boom",
 			},
-			Legacy: true,
+			LabelVersion: constants.LegacyLabelVersion,
 		},
 	}
 
 	for _, test := range tests {
-		rval := utils.LabelsForApp(test.AppName, test.Legacy)
+		rval := utils.LabelsForApp(test.AppName, test.LabelVersion)
 		c.Assert(rval, jc.DeepEquals, test.ExpectedLabels)
 	}
 }
@@ -196,54 +216,60 @@ func (l *LabelSuite) TestLabelsForStorage(c *gc.C) {
 	tests := []struct {
 		AppName        string
 		ExpectedLabels labels.Set
-		Legacy         bool
+		LabelVersion   constants.LabelVersion
 	}{
 		{
 			AppName: "tlm-boom",
 			ExpectedLabels: labels.Set{
 				"storage.juju.is/name": "tlm-boom",
 			},
-			Legacy: false,
+			LabelVersion: constants.LabelVersion1,
 		},
 		{
 			AppName: "tlm-boom",
 			ExpectedLabels: labels.Set{
 				"juju-storage": "tlm-boom",
 			},
-			Legacy: true,
+			LabelVersion: constants.LegacyLabelVersion,
 		},
 	}
 
 	for _, test := range tests {
-		rval := utils.LabelsForStorage(test.AppName, test.Legacy)
+		rval := utils.LabelsForStorage(test.AppName, test.LabelVersion)
 		c.Assert(rval, jc.DeepEquals, test.ExpectedLabels)
 	}
 }
 
 func (l *LabelSuite) TestLabelsForModel(c *gc.C) {
 	tests := []struct {
-		AppName        string
+		ModelName      string
+		ModelUUID      string
+		ControllerUUID string
 		ExpectedLabels labels.Set
-		Legacy         bool
+		LabelVersion   constants.LabelVersion
 	}{
 		{
-			AppName: "tlm-boom",
+			ModelName:      "tlm-boom",
+			ModelUUID:      "d0gf00d",
+			ControllerUUID: "badf00d",
 			ExpectedLabels: labels.Set{
 				"model.juju.is/name": "tlm-boom",
 			},
-			Legacy: false,
+			LabelVersion: constants.LabelVersion1,
 		},
 		{
-			AppName: "tlm-boom",
+			ModelName:      "tlm-boom",
+			ModelUUID:      "d0gf00d",
+			ControllerUUID: "badf00d",
 			ExpectedLabels: labels.Set{
 				"juju-model": "tlm-boom",
 			},
-			Legacy: true,
+			LabelVersion: constants.LegacyLabelVersion,
 		},
 	}
 
 	for _, test := range tests {
-		rval := utils.LabelsForModel(test.AppName, test.Legacy)
+		rval := utils.LabelsForModel(test.ModelName, test.ModelUUID, test.ControllerUUID, test.LabelVersion)
 		c.Assert(rval, jc.DeepEquals, test.ExpectedLabels)
 	}
 }
@@ -253,7 +279,7 @@ func (l *LabelSuite) TestLabelsForOperator(c *gc.C) {
 		AppName        string
 		Target         string
 		ExpectedLabels labels.Set
-		Legacy         bool
+		LabelVersion   constants.LabelVersion
 	}{
 		{
 			AppName: "tlm-boom",
@@ -262,19 +288,19 @@ func (l *LabelSuite) TestLabelsForOperator(c *gc.C) {
 				"operator.juju.is/name":   "tlm-boom",
 				"operator.juju.is/target": "harry",
 			},
-			Legacy: false,
+			LabelVersion: constants.LabelVersion1,
 		},
 		{
 			AppName: "tlm-boom",
 			ExpectedLabels: labels.Set{
 				"juju-operator": "tlm-boom",
 			},
-			Legacy: true,
+			LabelVersion: constants.LegacyLabelVersion,
 		},
 	}
 
 	for _, test := range tests {
-		rval := utils.LabelsForOperator(test.AppName, test.Target, test.Legacy)
+		rval := utils.LabelsForOperator(test.AppName, test.Target, test.LabelVersion)
 		c.Assert(rval, jc.DeepEquals, test.ExpectedLabels)
 	}
 }

--- a/caas/kubernetes/provider/volume.go
+++ b/caas/kubernetes/provider/volume.go
@@ -192,7 +192,7 @@ func (k *kubernetesClient) EnsureStorageProvisioner(cfg k8s.StorageProvisioner) 
 		sc.VolumeBindingMode = &bindMode
 	}
 	if cfg.Namespace != "" {
-		sc.Labels = utils.LabelsForModel(k.CurrentModel(), k.IsLegacyLabels())
+		sc.Labels = utils.LabelsForModel(k.ModelName(), k.ModelUUID(), k.ControllerUUID(), k.LabelVersion())
 	}
 	_, err = k.client().StorageV1().StorageClasses().Create(context.TODO(), sc, v1.CreateOptions{})
 	if err != nil {
@@ -281,14 +281,14 @@ func (k *kubernetesClient) filesystemToVolumeInfo(
 	}
 
 	labels := utils.LabelsMerge(
-		utils.LabelsForStorage(fs.StorageName, k.IsLegacyLabels()),
+		utils.LabelsForStorage(fs.StorageName, k.LabelVersion()),
 		utils.LabelsJuju)
 
 	pvc = &core.PersistentVolumeClaim{
 		ObjectMeta: v1.ObjectMeta{
 			Name: params.Name,
-			Annotations: utils.ResourceTagsToAnnotations(fs.ResourceTags, k.IsLegacyLabels()).
-				Merge(utils.AnnotationsForStorage(fs.StorageName, k.IsLegacyLabels())).
+			Annotations: utils.ResourceTagsToAnnotations(fs.ResourceTags, k.LabelVersion()).
+				Merge(utils.AnnotationsForStorage(fs.StorageName, k.LabelVersion())).
 				ToMap(),
 			Labels: labels,
 		},

--- a/cmd/juju/ssh/ssh_container.go
+++ b/cmd/juju/ssh/ssh_container.go
@@ -262,6 +262,8 @@ func (c *sshContainer) resolveTarget(target string) (*resolvedTarget, error) {
 			appName,
 			c.execClient.NameSpace(),
 			modelName,
+			c.modelUUID,
+			"", // TODO: wire up controller UUID
 		)
 
 		if err != nil {

--- a/internal/worker/caasadmission/admission.go
+++ b/internal/worker/caasadmission/admission.go
@@ -11,6 +11,7 @@ import (
 	admission "k8s.io/api/admissionregistration/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/juju/juju/caas/kubernetes/provider/constants"
 	k8sconstants "github.com/juju/juju/caas/kubernetes/provider/constants"
 	k8sutils "github.com/juju/juju/caas/kubernetes/provider/utils"
 	"github.com/juju/juju/pki"
@@ -49,8 +50,11 @@ func (a AdmissionCreatorFunc) EnsureMutatingWebhookConfiguration() (func(), erro
 // context arguments.
 func NewAdmissionCreator(
 	authority pki.Authority,
-	namespace, modelName string,
-	legacyLabels bool,
+	namespace string,
+	modelName string,
+	modelUUID string,
+	controllerUUID string,
+	labelVersion constants.LabelVersion,
 	ensureConfig func(*admission.MutatingWebhookConfiguration) (func(), error),
 	service *admission.ServiceReference) (AdmissionCreator, error) {
 
@@ -69,7 +73,7 @@ func NewAdmissionCreator(
 	// MutatingWebhook Obj
 	obj := admission.MutatingWebhookConfiguration{
 		ObjectMeta: meta.ObjectMeta{
-			Labels:    k8sutils.LabelsForModel(modelName, legacyLabels),
+			Labels:    k8sutils.LabelsForModel(modelName, modelUUID, controllerUUID, labelVersion),
 			Name:      fmt.Sprintf("juju-model-admission-%s", namespace),
 			Namespace: namespace,
 		},
@@ -85,7 +89,7 @@ func NewAdmissionCreator(
 				MatchPolicy:             &matchPolicy,
 				Name:                    k8sutils.MakeK8sDomain(Component),
 				NamespaceSelector: &meta.LabelSelector{
-					MatchLabels: k8sutils.LabelsForModel(modelName, legacyLabels),
+					MatchLabels: k8sutils.LabelsForModel(modelName, modelUUID, controllerUUID, labelVersion),
 				},
 				ObjectSelector: &meta.LabelSelector{
 					MatchExpressions: []meta.LabelSelectorRequirement{

--- a/internal/worker/caasadmission/admission_test.go
+++ b/internal/worker/caasadmission/admission_test.go
@@ -8,6 +8,7 @@ import (
 	gc "gopkg.in/check.v1"
 	admission "k8s.io/api/admissionregistration/v1"
 
+	"github.com/juju/juju/caas/kubernetes/provider/constants"
 	"github.com/juju/juju/internal/worker/caasadmission"
 	pkitest "github.com/juju/juju/pki/test"
 )
@@ -57,7 +58,7 @@ func (a *AdmissionSuite) TestAdmissionCreatorObject(c *gc.C) {
 	}
 
 	admissionCreator, err := caasadmission.NewAdmissionCreator(
-		authority, "testns", "testmodel", false,
+		authority, "testns", "testmodel", "deadbeef", "badf00d", constants.LabelVersion1,
 		func(obj *admission.MutatingWebhookConfiguration) (func(), error) {
 			ensureWebhookCalled = true
 

--- a/internal/worker/caasadmission/controller.go
+++ b/internal/worker/caasadmission/controller.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 
 	"github.com/juju/errors"
+	"github.com/juju/juju/caas/kubernetes/provider/constants"
 	"github.com/juju/worker/v3/catacomb"
 )
 
@@ -31,7 +32,7 @@ func NewController(
 	logger Logger,
 	mux Mux,
 	path string,
-	legacyLabels bool,
+	labelVersion constants.LabelVersion,
 	admissionCreator AdmissionCreator,
 	rbacMapper RBACMapper) (*Controller, error) {
 
@@ -42,7 +43,7 @@ func NewController(
 	if err := catacomb.Invoke(catacomb.Plan{
 		Site: &c.catacomb,
 		Work: c.makeLoop(admissionCreator,
-			admissionHandler(logger, rbacMapper, legacyLabels),
+			admissionHandler(logger, rbacMapper, labelVersion),
 			logger, mux, path),
 	}); err != nil {
 		return c, errors.Trace(err)

--- a/internal/worker/caasadmission/controller_test.go
+++ b/internal/worker/caasadmission/controller_test.go
@@ -12,6 +12,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/caas/kubernetes/provider/constants"
 	"github.com/juju/juju/internal/worker/caasadmission"
 	rbacmappertest "github.com/juju/juju/internal/worker/caasrbacmapper/test"
 )
@@ -66,7 +67,7 @@ func (s *ControllerSuite) TestControllerStartup(c *gc.C) {
 		},
 	}
 
-	ctrl, err := caasadmission.NewController(logger, mux, path, false, creator, rbacMapper)
+	ctrl, err := caasadmission.NewController(logger, mux, path, constants.LabelVersion1, creator, rbacMapper)
 	c.Assert(err, jc.ErrorIsNil)
 
 	waitGroup.Wait()
@@ -98,7 +99,7 @@ func (s *ControllerSuite) TestControllerStartupMuxError(c *gc.C) {
 	}
 	creator := &dummyAdmissionCreator{}
 
-	ctrl, err := caasadmission.NewController(logger, mux, path, false, creator, rbacMapper)
+	ctrl, err := caasadmission.NewController(logger, mux, path, constants.LabelVersion1, creator, rbacMapper)
 	c.Assert(err, jc.ErrorIsNil)
 
 	waitGroup.Wait()
@@ -124,7 +125,7 @@ func (s *ControllerSuite) TestControllerStartupAdmissionError(c *gc.C) {
 		},
 	}
 
-	ctrl, err := caasadmission.NewController(logger, mux, path, false, creator, rbacMapper)
+	ctrl, err := caasadmission.NewController(logger, mux, path, constants.LabelVersion1, creator, rbacMapper)
 	c.Assert(err, jc.ErrorIsNil)
 
 	waitGroup.Wait()

--- a/internal/worker/caasadmission/handler.go
+++ b/internal/worker/caasadmission/handler.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/juju/juju/caas/kubernetes/provider/constants"
 	providerconst "github.com/juju/juju/caas/kubernetes/provider/constants"
 	providerutils "github.com/juju/juju/caas/kubernetes/provider/utils"
 )
@@ -51,7 +52,7 @@ var (
 	}
 )
 
-func admissionHandler(logger Logger, rbacMapper RBACMapper, legacyLabels bool) http.Handler {
+func admissionHandler(logger Logger, rbacMapper RBACMapper, labelVersion constants.LabelVersion) http.Handler {
 	codecFactory := serializer.NewCodecFactory(runtime.NewScheme())
 
 	return http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -154,7 +155,7 @@ func admissionHandler(logger Logger, rbacMapper RBACMapper, legacyLabels bool) h
 		}
 
 		patchJSON, err := json.Marshal(
-			patchForLabels(metaObj.Labels, appName, legacyLabels))
+			patchForLabels(metaObj.Labels, appName, labelVersion))
 		if err != nil {
 			http.Error(res,
 				fmt.Sprintf("marshalling patch object to json: %v", err),
@@ -194,7 +195,7 @@ func patchEscape(s string) string {
 func patchForLabels(
 	labels map[string]string,
 	appName string,
-	legacyLabels bool) []patchOperation {
+	labelVersion constants.LabelVersion) []patchOperation {
 	patches := []patchOperation{}
 
 	neededLabels := providerutils.LabelForKeyValue(

--- a/internal/worker/caasadmission/handler_test.go
+++ b/internal/worker/caasadmission/handler_test.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/juju/juju/caas/kubernetes/provider/constants"
 	providerconst "github.com/juju/juju/caas/kubernetes/provider/constants"
 	providerutils "github.com/juju/juju/caas/kubernetes/provider/utils"
 	rbacmappertest "github.com/juju/juju/internal/worker/caasrbacmapper/test"
@@ -90,7 +91,7 @@ func (h *HandlerSuite) TestEmptyBodyFails(c *gc.C) {
 	req := httptest.NewRequest(http.MethodPost, "/", nil)
 	recorder := httptest.NewRecorder()
 
-	admissionHandler(h.logger, &rbacmappertest.Mapper{}, false).ServeHTTP(recorder, req)
+	admissionHandler(h.logger, &rbacmappertest.Mapper{}, constants.LabelVersion1).ServeHTTP(recorder, req)
 
 	c.Assert(recorder.Code, gc.Equals, http.StatusBadRequest)
 }
@@ -100,7 +101,7 @@ func (h *HandlerSuite) TestUnknownContentType(c *gc.C) {
 	req.Header.Set("junk", "junk")
 	recorder := httptest.NewRecorder()
 
-	admissionHandler(h.logger, &rbacmappertest.Mapper{}, false).ServeHTTP(recorder, req)
+	admissionHandler(h.logger, &rbacmappertest.Mapper{}, constants.LabelVersion1).ServeHTTP(recorder, req)
 
 	c.Assert(recorder.Code, gc.Equals, http.StatusUnsupportedMediaType)
 }
@@ -122,7 +123,7 @@ func (h *HandlerSuite) TestUnknownServiceAccount(c *gc.C) {
 	req.Header.Set(HeaderContentType, ExpectedContentType)
 	recorder := httptest.NewRecorder()
 
-	admissionHandler(h.logger, &rbacmappertest.Mapper{}, false).ServeHTTP(recorder, req)
+	admissionHandler(h.logger, &rbacmappertest.Mapper{}, constants.LabelVersion1).ServeHTTP(recorder, req)
 	c.Assert(recorder.Code, gc.Equals, http.StatusOK)
 	c.Assert(recorder.Body, gc.NotNil)
 
@@ -157,7 +158,7 @@ func (h *HandlerSuite) TestRBACMapperFailure(c *gc.C) {
 		},
 	}
 
-	admissionHandler(h.logger, &rbacMapper, false).ServeHTTP(recorder, req)
+	admissionHandler(h.logger, &rbacMapper, constants.LabelVersion1).ServeHTTP(recorder, req)
 	c.Assert(recorder.Code, gc.Equals, http.StatusInternalServerError)
 }
 
@@ -196,7 +197,7 @@ func (h *HandlerSuite) TestPatchLabelsAdd(c *gc.C) {
 		},
 	}
 
-	admissionHandler(h.logger, &rbacMapper, false).ServeHTTP(recorder, req)
+	admissionHandler(h.logger, &rbacMapper, constants.LabelVersion1).ServeHTTP(recorder, req)
 	c.Assert(recorder.Code, gc.Equals, http.StatusOK)
 	c.Assert(recorder.Body, gc.NotNil)
 
@@ -284,7 +285,7 @@ func (h *HandlerSuite) TestPatchLabelsReplace(c *gc.C) {
 		},
 	}
 
-	admissionHandler(h.logger, &rbacMapper, false).ServeHTTP(recorder, req)
+	admissionHandler(h.logger, &rbacMapper, constants.LabelVersion1).ServeHTTP(recorder, req)
 	c.Assert(recorder.Code, gc.Equals, http.StatusOK)
 	c.Assert(recorder.Body, gc.NotNil)
 
@@ -359,7 +360,7 @@ func (h *HandlerSuite) TestSelfSubjectAccessReviewIgnore(c *gc.C) {
 		},
 	}
 
-	admissionHandler(h.logger, &rbacMapper, false).ServeHTTP(recorder, req)
+	admissionHandler(h.logger, &rbacMapper, constants.LabelVersion1).ServeHTTP(recorder, req)
 	c.Assert(recorder.Code, gc.Equals, http.StatusOK)
 	c.Assert(recorder.Body, gc.NotNil)
 

--- a/internal/worker/caasadmission/manifold.go
+++ b/internal/worker/caasadmission/manifold.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/juju/juju/agent"
 	"github.com/juju/juju/apiserver/apiserverhttp"
+	"github.com/juju/juju/caas/kubernetes/provider/constants"
 	"github.com/juju/juju/internal/worker/caasrbacmapper"
 	"github.com/juju/juju/internal/worker/muxhttpserver"
 	"github.com/juju/juju/pki"
@@ -19,12 +20,18 @@ import (
 // K8sBroker describes a Kubernetes broker interface this worker needs to
 // function.
 type K8sBroker interface {
-	// CurrentModel returns the current model the broker is targeting
-	CurrentModel() string
+	// ModelName returns the model the broker is targeting
+	ModelName() string
 
-	// GetCurrentNamespace returns the current namespace being targeted on the
+	// ModelID returns the model the broker is targeting
+	ModelID() string
+
+	// ControllerID returns the controller the broker is on
+	ControllerID() string
+
+	// Namespace returns the current namespace being targeted on the
 	// broker
-	GetCurrentNamespace() string
+	Namespace() string
 
 	// EnsureMutatingWebhookConfiguration make the supplied webhook config exist
 	// inside the k8s cluster if it currently does not. Return values is a
@@ -33,9 +40,9 @@ type K8sBroker interface {
 	// not nil then no other return values should be considered valid.
 	EnsureMutatingWebhookConfiguration(*admission.MutatingWebhookConfiguration) (func(), error)
 
-	// IsLegacyLabels reports if the k8s broker requires legacy labels to be
+	// LabelVersion reports if the k8s broker requires legacy labels to be
 	// used for the broker model/namespace
-	IsLegacyLabels() bool
+	LabelVersion() constants.LabelVersion
 }
 
 // Logger represents the methods used by the worker to log details
@@ -127,8 +134,9 @@ func (c ManifoldConfig) Start(context dependency.Context) (worker.Worker, error)
 	currentConfig := agent.CurrentConfig()
 	admissionPath := AdmissionPathForModel(currentConfig.Model().Id())
 	admissionCreator, err := NewAdmissionCreator(authority,
-		broker.GetCurrentNamespace(), broker.CurrentModel(),
-		broker.IsLegacyLabels(),
+		broker.Namespace(), broker.ModelName(),
+		broker.ModelID(), broker.ControllerID(),
+		broker.LabelVersion(),
 		broker.EnsureMutatingWebhookConfiguration,
 		&admission.ServiceReference{
 			Name:      c.ServiceName,
@@ -145,7 +153,7 @@ func (c ManifoldConfig) Start(context dependency.Context) (worker.Worker, error)
 		c.Logger,
 		mux,
 		AdmissionPathForModel(currentConfig.Model().Id()),
-		broker.IsLegacyLabels(),
+		broker.LabelVersion(),
 		admissionCreator,
 		rbacMapper)
 }

--- a/internal/worker/caasrbacmapper/mapper_test.go
+++ b/internal/worker/caasrbacmapper/mapper_test.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/juju/juju/caas/kubernetes/provider"
+	"github.com/juju/juju/caas/kubernetes/provider/constants"
 	"github.com/juju/juju/caas/kubernetes/provider/mocks"
 	"github.com/juju/juju/internal/worker/caasrbacmapper"
 	coretesting "github.com/juju/juju/testing"
@@ -71,7 +72,7 @@ func (m *MapperSuite) TestMapperAdditionSync(c *gc.C) {
 		ObjectMeta: meta.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
-			Labels:    provider.RBACLabels(appName, "test-model", false, false),
+			Labels:    provider.RBACLabels(appName, "test-model", "badf00d", "d0gf00d", false, constants.LabelVersion1),
 			UID:       uid,
 		},
 	}
@@ -126,7 +127,7 @@ func (m *MapperSuite) TestRBACMapperUpdateSync(c *gc.C) {
 		ObjectMeta: meta.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
-			Labels:    provider.RBACLabels(appName, "test-model", false, false),
+			Labels:    provider.RBACLabels(appName, "test-model", "deadbeef", "badf00d", false, constants.LabelVersion1),
 			UID:       uid,
 		},
 	}
@@ -157,7 +158,7 @@ func (m *MapperSuite) TestRBACMapperUpdateSync(c *gc.C) {
 	// Update SA with a new app name to check propagation
 	appName = "test-2"
 	sa2 := sa.DeepCopy()
-	sa2.ObjectMeta.Labels = provider.RBACLabels(appName, "test-model", false, false)
+	sa2.ObjectMeta.Labels = provider.RBACLabels(appName, "test-model", "deadbeef", "badf00d", false, constants.LabelVersion1)
 	waitGroup.Add(1)
 	m.mockSANamespaceLister.EXPECT().Get(gomock.Eq(name)).
 		DoAndReturn(func(_ string) (*core.ServiceAccount, error) {
@@ -207,7 +208,7 @@ func (m *MapperSuite) TestRBACMapperDeleteSync(c *gc.C) {
 		ObjectMeta: meta.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
-			Labels:    provider.RBACLabels(appName, "test-model", false, false),
+			Labels:    provider.RBACLabels(appName, "test-model", "deadbeef", "badf00d", false, constants.LabelVersion1),
 			UID:       uid,
 		},
 	}

--- a/secrets/provider/kubernetes/backend.go
+++ b/secrets/provider/kubernetes/backend.go
@@ -13,6 +13,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
+	"github.com/juju/juju/caas/kubernetes/provider/constants"
 	"github.com/juju/juju/caas/kubernetes/provider/resources"
 	"github.com/juju/juju/caas/kubernetes/provider/utils"
 	coresecrets "github.com/juju/juju/core/secrets"
@@ -90,7 +91,7 @@ func (k *k8sBackend) SaveContent(ctx context.Context, uri *coresecrets.URI, revi
 
 	name := uri.Name(revision)
 	labels := utils.LabelsMerge(
-		utils.LabelsForModel(k.model, false),
+		utils.LabelsForModel(k.model, "", "", constants.LabelVersion1),
 		utils.LabelsJuju)
 	in := &core.Secret{
 		ObjectMeta: v1.ObjectMeta{

--- a/secrets/provider/kubernetes/provider.go
+++ b/secrets/provider/kubernetes/provider.go
@@ -47,8 +47,8 @@ const (
 )
 
 var (
-	controllerIdKey = utils.AnnotationControllerUUIDKey(false)
-	modelIdKey      = utils.AnnotationModelUUIDKey(false)
+	controllerIdKey = utils.AnnotationControllerUUIDKey(constants.LabelVersion1)
+	modelIdKey      = utils.AnnotationModelUUIDKey(constants.LabelVersion1)
 )
 
 // These are patched for testing.


### PR DESCRIPTION
WIP

<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://github.com/juju/juju/blob/main/doc/conventional-commits.md
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

<!-- 

Describe steps to verify that the change works. 

If you're changing any of the facades, you need to ensure that you've tested
a model migration from 3.6 to 4.0 and from 4.0 to 4.0.

The following steps are a good starting point:

 1. Bootstrap a 3.6 controller and deploy a charm.

```sh
$ juju bootstrap lxd src36
$ juju add-model moveme1
$ juju deploy juju-qa-test
```

 2. Bootstrap a 4.0 controller with the changes and migrate the model.

```sh
$ juju bootstrap lxd dst40
$ juju migrate src36:moveme1 dst40
$ juju add-unit juju-qa-test
```

 3. Verify no errors exist in the model logs for the agents. If there are
    errors, this is a bug and should be fixed before merging. The fix can
    either be applied to the 4.0 branch (preferable) or the 3.6 branch, though
    that needs to be discussed with the team.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme1
```

    4. We also need to test a model migration from 4.0 to 4.0.

```sh
$ juju bootstrap lxd src40
$ juju add-model moveme2
$ juju deploy juju-qa-test
```

```sh
$ juju migrate src40:moveme2 dst40
$ juju add-unit juju-qa-test
```

    5. Verify that there are no errors in the controller or model logs.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme2
```

-->

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/

**Jira card:** JUJU-

