### PR TITLE
fix: discover MAAS availability zones with subnets

### DIFF
--- a/internal/provider/maas/environ.go
+++ b/internal/provider/maas/environ.go
@@ -1178,7 +1178,7 @@ func (env *maasEnviron) Subnets(
 		}
 	} else {
 		var err error
-		subnets, err = env.filteredSubnets2(ctx, instId)
+		subnets, err = env.filteredSubnets(ctx, instId)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -1205,7 +1205,7 @@ func (env *maasEnviron) Subnets(
 	return result, checkNotFound(subnetMap)
 }
 
-func (env *maasEnviron) filteredSubnets2(
+func (env *maasEnviron) filteredSubnets(
 	ctx envcontext.ProviderCallContext, instId instance.Id,
 ) ([]corenetwork.SubnetInfo, error) {
 	args := gomaasapi.MachinesArgs{


### PR DESCRIPTION
This fix is required due to the introduction of referential integrity constraints, which we did not previously have under MongoDB.

For most providers we record the availability zones that subnets are accessible from when we do space/subnet discovery. 

In MAAS, zones are just a logical grouping and do not limit subnet availability, so we didn't include AZ info with discovered subnets.

The issue stems from the fact that subnet discovery is where we record availability zones in state. Without these records in the DB, we can't record instance info for provisioned machines, because we can't find a matching zone record. This includes the controller machine, which means the bootstrap worker would never run successfully.

We now look up zones when do MAAS space discovery, and just write the list against every subnet. This effectively says all subnets are available in all zones and puts all the work of finding a suitable instance onto the provisioner.

## QA steps

Bootstrap to MAAS.