### PR TITLE
feat(domain/relation): implements GetAllRelations

### DIFF
--- a/apiserver/facades/client/client/status.go
+++ b/apiserver/facades/client/client/status.go
@@ -122,10 +122,7 @@ func (c *Client) FullStatus(ctx context.Context, args params.StatusParams) (para
 		fetchNetworkInterfaces(c.stateAccessor, subnetInfos, context.spaceInfos); err != nil {
 		return noStatus, internalerrors.Errorf("could not fetch IP addresses and link layer devices: %w", err)
 	}
-	if context.relations, context.relationsByID, err = fetchRelations(ctx, c.relationService); err != nil &&
-		// todo(gfouillet): remove this exception whenever
-		//   relation domain will be fully implemented
-		!internalerrors.Is(err, errors.NotImplemented) {
+	if context.relations, context.relationsByID, err = fetchRelations(ctx, c.relationService); err != nil {
 		return noStatus, internalerrors.Errorf("could not fetch relations: %w", err)
 	}
 	if len(context.allAppsUnitsCharmBindings.applications) > 0 {

--- a/domain/relation/service/package_mock_test.go
+++ b/domain/relation/service/package_mock_test.go
@@ -42,6 +42,45 @@ func (m *MockState) EXPECT() *MockStateMockRecorder {
 	return m.recorder
 }
 
+// AllRelations mocks base method.
+func (m *MockState) AllRelations(arg0 context.Context) ([]relation.UUID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AllRelations", arg0)
+	ret0, _ := ret[0].([]relation.UUID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AllRelations indicates an expected call of AllRelations.
+func (mr *MockStateMockRecorder) AllRelations(arg0 any) *MockStateAllRelationsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllRelations", reflect.TypeOf((*MockState)(nil).AllRelations), arg0)
+	return &MockStateAllRelationsCall{Call: call}
+}
+
+// MockStateAllRelationsCall wrap *gomock.Call
+type MockStateAllRelationsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateAllRelationsCall) Return(arg0 []relation.UUID, arg1 error) *MockStateAllRelationsCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateAllRelationsCall) Do(f func(context.Context) ([]relation.UUID, error)) *MockStateAllRelationsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateAllRelationsCall) DoAndReturn(f func(context.Context) ([]relation.UUID, error)) *MockStateAllRelationsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetRelationEndpointUUID mocks base method.
 func (m *MockState) GetRelationEndpointUUID(arg0 context.Context, arg1 relation0.GetRelationEndpointUUIDArgs) (relation.EndpointUUID, error) {
 	m.ctrl.T.Helper()

--- a/domain/relation/service/relation.go
+++ b/domain/relation/service/relation.go
@@ -23,6 +23,10 @@ import (
 
 // State describes retrieval and persistence methods for relations.
 type State interface {
+
+	// AllRelations retrieves all unique identifiers for relations within the current model.
+	AllRelations(ctx context.Context) ([]corerelation.UUID, error)
+
 	// GetRelationID returns the relation ID for the given relation UUID.
 	//
 	// The following error types can be expected to be returned:
@@ -95,7 +99,7 @@ func (s *Service) AddRelation(ctx context.Context, ep1, ep2 string) (relation.En
 
 // AllRelations return all uuid of all relation for the current model.
 func (s *Service) AllRelations(ctx context.Context) ([]corerelation.UUID, error) {
-	return nil, coreerrors.NotImplemented
+	return s.st.AllRelations(ctx)
 }
 
 // ApplicationRelationEndpointNames returns a slice of names of the given application's

--- a/domain/relation/state/relation.go
+++ b/domain/relation/state/relation.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/clock"
 
 	"github.com/juju/juju/core/database"
+	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/logger"
 	corerelation "github.com/juju/juju/core/relation"
 	"github.com/juju/juju/domain"
@@ -33,6 +34,11 @@ func NewState(factory database.TxnRunnerFactory, clock clock.Clock, logger logge
 		clock:     clock,
 		logger:    logger,
 	}
+}
+
+// AllRelations retrieves all unique identifiers for relations within the current model.
+func (st *State) AllRelations(ctx context.Context) ([]corerelation.UUID, error) {
+	return nil, coreerrors.NotImplemented
 }
 
 // GetRelationID returns the relation ID for the given relation UUID.

--- a/domain/services/model.go
+++ b/domain/services/model.go
@@ -400,7 +400,7 @@ func (s *ModelServices) Resource() *resourceservice.Service {
 func (s *ModelServices) Relation() *relationservice.WatchableService {
 	return relationservice.NewWatchableService(
 		relationstate.NewState(
-			changestream.NewTxnRunnerFactory(s.controllerDB),
+			changestream.NewTxnRunnerFactory(s.modelDB),
 			s.clock,
 			s.logger.Child("relation.state"),
 		),


### PR DESCRIPTION
This PR implements the domain method `AllRelations()` used in status method.

It also updates some related code:
- Remove the not implemented exception from FullStatus method
- Fix the db in for the RelationService registration (aims controllerDB instead of ModelDB)

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Bootstrap a controller, add a model, run `juju status`. Should works.

It is not possible to go further while relation are fully available in DQLITE.

## Links

**Jira card:** [JUJU\-7445](https://warthogs.atlassian.net/browse/JUJU-7445)

