### PR TITLE
feat: return ssh wire format public key

### DIFF
--- a/apiserver/facades/client/sshclient/facade.go
+++ b/apiserver/facades/client/sshclient/facade.go
@@ -362,14 +362,14 @@ func (facade *Facade) PublicHostKeyForTarget(arg params.SSHHostKeyRequestArg) pa
 	switch info.Target() {
 	case virtualhostname.MachineTarget:
 		machineId, _ := info.Machine()
-		hostkey, err = facade.backend.MachineVirtualPublicHostKeyPEM(strconv.Itoa(machineId))
+		hostkey, err = facade.backend.MachineVirtualHostKeySSHAuthKeyFormat(strconv.Itoa(machineId))
 		if err != nil {
 			res.Error = apiservererrors.ServerError(errors.Annotate(err, "failed to get machine host key"))
 			return res
 		}
 	case virtualhostname.ContainerTarget, virtualhostname.UnitTarget:
 		unitName, _ := info.Unit()
-		hostkey, err = facade.backend.UnitVirtualPublicHostKeyPEM(unitName)
+		hostkey, err = facade.backend.UnitVirtualHostKeySSHAuthKeyFormat(unitName)
 		if err != nil {
 			res.Error = apiservererrors.ServerError(errors.Annotate(err, "failed to get unit host key"))
 			return res

--- a/apiserver/facades/client/sshclient/facade_test.go
+++ b/apiserver/facades/client/sshclient/facade_test.go
@@ -452,12 +452,12 @@ func (backend *mockBackend) SSHServerHostKey() (string, error) {
 	return "", errors.NotImplementedf("SSHServerHostKey")
 }
 
-func (backend *mockBackend) UnitVirtualPublicHostKeyPEM(unitID string) (string, error) {
-	return "", errors.NotImplementedf("UnitVirtualHostKeyPEM")
+func (backend *mockBackend) UnitVirtualHostKeySSHAuthKeyFormat(unitID string) (string, error) {
+	return "", errors.NotImplementedf("UnitVirtualHostKeySSHAuthKeyFormat")
 }
 
-func (backend *mockBackend) MachineVirtualPublicHostKeyPEM(machineID string) (string, error) {
-	return "", errors.NotImplementedf("MachineVirtualHostKey")
+func (backend *mockBackend) MachineVirtualHostKeySSHAuthKeyFormat(machineID string) (string, error) {
+	return "", errors.NotImplementedf("MachineVirtualHostKeySSHAuthKeyFormat")
 }
 
 func (backend *mockBackend) ModelTag() names.ModelTag {
@@ -664,7 +664,7 @@ func (s *facadeSuiteNewMocks) TestPublicHostKeyForTarget(c *gc.C) {
 
 	// Test container target hits correct methods.
 	gomock.InOrder(
-		s.mockBackend.EXPECT().UnitVirtualPublicHostKeyPEM("postgresql/1").Return("postgres-container-host-key", nil).Times(1),
+		s.mockBackend.EXPECT().UnitVirtualHostKeySSHAuthKeyFormat("postgresql/1").Return("postgres-container-host-key", nil).Times(1),
 		s.mockBackend.EXPECT().SSHServerHostKey().Return("server-host-key", nil).Times(1),
 	)
 	res := facade.PublicHostKeyForTarget(params.SSHHostKeyRequestArg{
@@ -678,7 +678,7 @@ func (s *facadeSuiteNewMocks) TestPublicHostKeyForTarget(c *gc.C) {
 
 	// Test unit target hits correct methods.
 	gomock.InOrder(
-		s.mockBackend.EXPECT().UnitVirtualPublicHostKeyPEM("openfga/1").Return("openfga-container-host-key", nil).Times(1),
+		s.mockBackend.EXPECT().UnitVirtualHostKeySSHAuthKeyFormat("openfga/1").Return("openfga-container-host-key", nil).Times(1),
 		s.mockBackend.EXPECT().SSHServerHostKey().Return("server-host-key", nil).Times(1),
 	)
 	res = facade.PublicHostKeyForTarget(params.SSHHostKeyRequestArg{
@@ -692,7 +692,7 @@ func (s *facadeSuiteNewMocks) TestPublicHostKeyForTarget(c *gc.C) {
 
 	// Test machine target hits correct methods.
 	gomock.InOrder(
-		s.mockBackend.EXPECT().MachineVirtualPublicHostKeyPEM("1").Return("machine-host-key", nil).Times(1),
+		s.mockBackend.EXPECT().MachineVirtualHostKeySSHAuthKeyFormat("1").Return("machine-host-key", nil).Times(1),
 		s.mockBackend.EXPECT().SSHServerHostKey().Return("server-host-key", nil).Times(1),
 	)
 	res = facade.PublicHostKeyForTarget(params.SSHHostKeyRequestArg{
@@ -730,7 +730,7 @@ func (s *facadeSuiteNewMocks) TestPublicHostKeyForTargetErrors(c *gc.C) {
 
 	// Test MachineVirtualHostKey fail.
 	gomock.InOrder(
-		s.mockBackend.EXPECT().MachineVirtualPublicHostKeyPEM("1").Return("", errors.New("an-error")).Times(1),
+		s.mockBackend.EXPECT().MachineVirtualHostKeySSHAuthKeyFormat("1").Return("", errors.New("an-error")).Times(1),
 	)
 	res = facade.PublicHostKeyForTarget(params.SSHHostKeyRequestArg{
 		Hostname: "1.8419cd78-4993-4c3a-928e-c646226beeee.juju.local",
@@ -739,7 +739,7 @@ func (s *facadeSuiteNewMocks) TestPublicHostKeyForTargetErrors(c *gc.C) {
 
 	// Test UnitVirtualHostKey fail.
 	gomock.InOrder(
-		s.mockBackend.EXPECT().UnitVirtualPublicHostKeyPEM("openfga/1").Return("", errors.New("an-error")).Times(1),
+		s.mockBackend.EXPECT().UnitVirtualHostKeySSHAuthKeyFormat("openfga/1").Return("", errors.New("an-error")).Times(1),
 	)
 	res = facade.PublicHostKeyForTarget(params.SSHHostKeyRequestArg{
 		Hostname: "1.openfga.8419cd78-4993-4c3a-928e-c646226beeee.juju.local",
@@ -748,7 +748,7 @@ func (s *facadeSuiteNewMocks) TestPublicHostKeyForTargetErrors(c *gc.C) {
 
 	// Test SSHServerHostKey fail.
 	gomock.InOrder(
-		s.mockBackend.EXPECT().UnitVirtualPublicHostKeyPEM("postgresql/1").Return("postgres-container-host-key", nil).Times(1),
+		s.mockBackend.EXPECT().UnitVirtualHostKeySSHAuthKeyFormat("postgresql/1").Return("postgres-container-host-key", nil).Times(1),
 		s.mockBackend.EXPECT().SSHServerHostKey().Return("", errors.New("an-error")).Times(1),
 	)
 	res = facade.PublicHostKeyForTarget(params.SSHHostKeyRequestArg{

--- a/apiserver/facades/client/sshclient/mocks/state_mock.go
+++ b/apiserver/facades/client/sshclient/mocks/state_mock.go
@@ -102,19 +102,19 @@ func (mr *MockBackendMockRecorder) GetSSHHostKeys(arg0 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSSHHostKeys", reflect.TypeOf((*MockBackend)(nil).GetSSHHostKeys), arg0)
 }
 
-// MachineVirtualPublicHostKeyPEM mocks base method.
-func (m *MockBackend) MachineVirtualPublicHostKeyPEM(arg0 string) (string, error) {
+// MachineVirtualHostKeySSHAuthKeyFormat mocks base method.
+func (m *MockBackend) MachineVirtualHostKeySSHAuthKeyFormat(arg0 string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MachineVirtualPublicHostKeyPEM", arg0)
+	ret := m.ctrl.Call(m, "MachineVirtualHostKeySSHAuthKeyFormat", arg0)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// MachineVirtualPublicHostKeyPEM indicates an expected call of MachineVirtualPublicHostKeyPEM.
-func (mr *MockBackendMockRecorder) MachineVirtualPublicHostKeyPEM(arg0 any) *gomock.Call {
+// MachineVirtualHostKeySSHAuthKeyFormat indicates an expected call of MachineVirtualHostKeySSHAuthKeyFormat.
+func (mr *MockBackendMockRecorder) MachineVirtualHostKeySSHAuthKeyFormat(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MachineVirtualPublicHostKeyPEM", reflect.TypeOf((*MockBackend)(nil).MachineVirtualPublicHostKeyPEM), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MachineVirtualHostKeySSHAuthKeyFormat", reflect.TypeOf((*MockBackend)(nil).MachineVirtualHostKeySSHAuthKeyFormat), arg0)
 }
 
 // Model mocks base method.
@@ -176,19 +176,19 @@ func (mr *MockBackendMockRecorder) SSHServerHostKey() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SSHServerHostKey", reflect.TypeOf((*MockBackend)(nil).SSHServerHostKey))
 }
 
-// UnitVirtualPublicHostKeyPEM mocks base method.
-func (m *MockBackend) UnitVirtualPublicHostKeyPEM(arg0 string) (string, error) {
+// UnitVirtualHostKeySSHAuthKeyFormat mocks base method.
+func (m *MockBackend) UnitVirtualHostKeySSHAuthKeyFormat(arg0 string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UnitVirtualPublicHostKeyPEM", arg0)
+	ret := m.ctrl.Call(m, "UnitVirtualHostKeySSHAuthKeyFormat", arg0)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// UnitVirtualPublicHostKeyPEM indicates an expected call of UnitVirtualPublicHostKeyPEM.
-func (mr *MockBackendMockRecorder) UnitVirtualPublicHostKeyPEM(arg0 any) *gomock.Call {
+// UnitVirtualHostKeySSHAuthKeyFormat indicates an expected call of UnitVirtualHostKeySSHAuthKeyFormat.
+func (mr *MockBackendMockRecorder) UnitVirtualHostKeySSHAuthKeyFormat(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnitVirtualPublicHostKeyPEM", reflect.TypeOf((*MockBackend)(nil).UnitVirtualPublicHostKeyPEM), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnitVirtualHostKeySSHAuthKeyFormat", reflect.TypeOf((*MockBackend)(nil).UnitVirtualHostKeySSHAuthKeyFormat), arg0)
 }
 
 // MockModel is a mock of Model interface.


### PR DESCRIPTION
There was a misunderstanding about what state returned in the original PR in that it returned the public key pre-pem encoded. Instead it returns the private key. This PR parses the key and marshals the public key into SSH wire format. We've moved away from PEM encoded result to wire format for ease of use on the client side.

<!-- 
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://github.com/juju/juju/blob/main/doc/conventional-commits.md
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

<!-- 

Describe steps to verify that the change works. 

If you're changing any of the facades, you need to ensure that you've tested
a model migration from 3.6 to 4.0 and from 4.0 to 4.0.

The following steps are a good starting point:

 1. Bootstrap a 3.6 controller and deploy a charm.

```sh
$ juju bootstrap lxd src36
$ juju add-model moveme1
$ juju deploy juju-qa-test
```

 2. Bootstrap a 4.0 controller with the changes and migrate the model.

```sh
$ juju bootstrap lxd dst40
$ juju migrate src36:moveme1 dst40
$ juju add-unit juju-qa-test
```

 3. Verify no errors exist in the model logs for the agents. If there are
    errors, this is a bug and should be fixed before merging. The fix can
    either be applied to the 4.0 branch (preferable) or the 3.6 branch, though
    that needs to be discussed with the team.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme1
```

    4. We also need to test a model migration from 4.0 to 4.0.

```sh
$ juju bootstrap lxd src40
$ juju add-model moveme2
$ juju deploy juju-qa-test
```

```sh
$ juju migrate src40:moveme2 dst40
$ juju add-unit juju-qa-test
```

    5. Verify that there are no errors in the controller or model logs.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme2
```

-->

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/

**Jira card:** JUJU-

