### PR TITLE
chore: remove GetRelationDetailsForUnit

### DIFF
--- a/apiserver/facades/agent/uniter/service.go
+++ b/apiserver/facades/agent/uniter/service.go
@@ -253,7 +253,7 @@ type RelationService interface {
 
 	// GetRelationDetails returns the relation details requested by the uniter
 	// for a relation.
-	GetRelationDetails(ctx context.Context, relationID int) (relation.RelationDetails, error)
+	GetRelationDetails(ctx context.Context, relationUUID corerelation.UUID) (relation.RelationDetails, error)
 
 	// GetRelationUnit returns the relation unit UUID for the given unit within
 	// the given relation.
@@ -283,12 +283,9 @@ type RelationService interface {
 	// GetRelationStatus returns the status of the given relation.
 	GetRelationStatus(ctx context.Context, relationUUID corerelation.UUID) (corestatus.StatusInfo, error)
 
-	// GetRelationID returns the relation ID for the given relation UUID.
-	//
-	// The following error types can be expected to be returned:
-	//   - [relationerrors.RelationNotFound] is returned if the relation UUID
-	//     is not found.
-	GetRelationID(ctx context.Context, relationUUID corerelation.UUID) (int, error)
+	// GetRelationsStatusesForUnit returns RelationUnitStatus for
+	// any relation the unit is part of.
+	GetRelationsStatusForUnit(ctx context.Context, unitUUID coreunit.UUID) ([]relation.RelationUnitStatus, error)
 
 	// GetRemoteRelationApplicationSettings returns the application settings
 	// for the given application and relation identifier combination.

--- a/apiserver/facades/agent/uniter/service.go
+++ b/apiserver/facades/agent/uniter/service.go
@@ -255,14 +255,6 @@ type RelationService interface {
 	// for a relation.
 	GetRelationDetails(ctx context.Context, relationID int) (relation.RelationDetails, error)
 
-	// GetRelationDetailsForUnit returns the relation details specific to a unit,
-	// as requested by the uniter for a relation.
-	GetRelationDetailsForUnit(
-		ctx context.Context,
-		relationUUID corerelation.UUID,
-		unitName coreunit.Name,
-	) (relation.RelationDetails, error)
-
 	// GetRelationUnit returns the relation unit UUID for the given unit within
 	// the given relation.
 	GetRelationUnit(
@@ -291,9 +283,12 @@ type RelationService interface {
 	// GetRelationStatus returns the status of the given relation.
 	GetRelationStatus(ctx context.Context, relationUUID corerelation.UUID) (corestatus.StatusInfo, error)
 
-	// GetRelationsStatusesForUnit returns RelationUnitStatus for
-	// any relation the unit is part of.
-	GetRelationsStatusForUnit(ctx context.Context, unitUUID coreunit.UUID) ([]relation.RelationUnitStatus, error)
+	// GetRelationID returns the relation ID for the given relation UUID.
+	//
+	// The following error types can be expected to be returned:
+	//   - [relationerrors.RelationNotFound] is returned if the relation UUID
+	//     is not found.
+	GetRelationID(ctx context.Context, relationUUID corerelation.UUID) (int, error)
 
 	// GetRemoteRelationApplicationSettings returns the application settings
 	// for the given application and relation identifier combination.

--- a/apiserver/facades/agent/uniter/service_mock_test.go
+++ b/apiserver/facades/agent/uniter/service_mock_test.go
@@ -872,7 +872,7 @@ func (c *MockRelationServiceGetLocalRelationApplicationSettingsCall) DoAndReturn
 }
 
 // GetRelationDetails mocks base method.
-func (m *MockRelationService) GetRelationDetails(arg0 context.Context, arg1 int) (relation0.RelationDetails, error) {
+func (m *MockRelationService) GetRelationDetails(arg0 context.Context, arg1 relation.UUID) (relation0.RelationDetails, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRelationDetails", arg0, arg1)
 	ret0, _ := ret[0].(relation0.RelationDetails)
@@ -899,52 +899,13 @@ func (c *MockRelationServiceGetRelationDetailsCall) Return(arg0 relation0.Relati
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockRelationServiceGetRelationDetailsCall) Do(f func(context.Context, int) (relation0.RelationDetails, error)) *MockRelationServiceGetRelationDetailsCall {
+func (c *MockRelationServiceGetRelationDetailsCall) Do(f func(context.Context, relation.UUID) (relation0.RelationDetails, error)) *MockRelationServiceGetRelationDetailsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockRelationServiceGetRelationDetailsCall) DoAndReturn(f func(context.Context, int) (relation0.RelationDetails, error)) *MockRelationServiceGetRelationDetailsCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// GetRelationDetailsForUnit mocks base method.
-func (m *MockRelationService) GetRelationDetailsForUnit(arg0 context.Context, arg1 relation.UUID, arg2 unit.Name) (relation0.RelationDetails, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRelationDetailsForUnit", arg0, arg1, arg2)
-	ret0, _ := ret[0].(relation0.RelationDetails)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetRelationDetailsForUnit indicates an expected call of GetRelationDetailsForUnit.
-func (mr *MockRelationServiceMockRecorder) GetRelationDetailsForUnit(arg0, arg1, arg2 any) *MockRelationServiceGetRelationDetailsForUnitCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRelationDetailsForUnit", reflect.TypeOf((*MockRelationService)(nil).GetRelationDetailsForUnit), arg0, arg1, arg2)
-	return &MockRelationServiceGetRelationDetailsForUnitCall{Call: call}
-}
-
-// MockRelationServiceGetRelationDetailsForUnitCall wrap *gomock.Call
-type MockRelationServiceGetRelationDetailsForUnitCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockRelationServiceGetRelationDetailsForUnitCall) Return(arg0 relation0.RelationDetails, arg1 error) *MockRelationServiceGetRelationDetailsForUnitCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockRelationServiceGetRelationDetailsForUnitCall) Do(f func(context.Context, relation.UUID, unit.Name) (relation0.RelationDetails, error)) *MockRelationServiceGetRelationDetailsForUnitCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockRelationServiceGetRelationDetailsForUnitCall) DoAndReturn(f func(context.Context, relation.UUID, unit.Name) (relation0.RelationDetails, error)) *MockRelationServiceGetRelationDetailsForUnitCall {
+func (c *MockRelationServiceGetRelationDetailsCall) DoAndReturn(f func(context.Context, relation.UUID) (relation0.RelationDetails, error)) *MockRelationServiceGetRelationDetailsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -1957,11 +1957,11 @@ func (u *UniterAPI) getOneRelation(
 	} else if err != nil {
 		return nothing, err
 	}
-	unitName, err := coreunit.NewName(unitTag.Id())
+	relID, err := u.relationService.GetRelationID(ctx, relUUID)
 	if err != nil {
 		return nothing, internalerrors.Capture(err)
 	}
-	rel, err := u.relationService.GetRelationDetailsForUnit(ctx, relUUID, unitName)
+	rel, err := u.relationService.GetRelationDetails(ctx, relID)
 	if errors.Is(err, errors.NotFound) {
 		return nothing, apiservererrors.ErrPerm
 	} else if err != nil {

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -41,6 +41,7 @@ import (
 	"github.com/juju/juju/domain/unitstate"
 	"github.com/juju/juju/internal/charm"
 	internalerrors "github.com/juju/juju/internal/errors"
+	internalrelation "github.com/juju/juju/internal/relation"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/stateenvirons"
@@ -1902,9 +1903,9 @@ func (u *UniterAPI) prepareRelationResult(
 ) (params.RelationResultV2, error) {
 	var (
 		otherAppName string
-		unitEp       relation.Endpoint
+		unitEp       internalrelation.Endpoint
 	)
-	for _, v := range rel.Endpoint {
+	for _, v := range rel.Endpoints {
 		if v.ApplicationName == applicationName {
 			unitEp = v
 		} else {
@@ -1922,7 +1923,7 @@ func (u *UniterAPI) prepareRelationResult(
 	}
 	return params.RelationResultV2{
 		Id:   rel.ID,
-		Key:  rel.Key,
+		Key:  rel.Key.String(),
 		Life: rel.Life,
 		Endpoint: params.Endpoint{
 			ApplicationName: unitEp.ApplicationName,

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -1839,8 +1839,14 @@ func (u *UniterAPI) getRelationUnit(canAccess common.AuthFunc, relTag string, un
 
 func (u *UniterAPI) getOneRelationById(ctx context.Context, relID int, modelUUID model.UUID) (params.RelationResultV2, error) {
 	nothing := params.RelationResultV2{}
-	rel, err := u.relationService.GetRelationDetails(ctx, relID)
-	if errors.Is(err, errors.NotFound) {
+	relUUID, err := u.relationService.GetRelationUUIDByID(ctx, relID)
+	if errors.Is(err, relationerrors.RelationNotFound) {
+		return nothing, apiservererrors.ErrPerm
+	} else if err != nil {
+		return nothing, err
+	}
+	rel, err := u.relationService.GetRelationDetails(ctx, relUUID)
+	if errors.Is(err, relationerrors.RelationNotFound) {
 		return nothing, apiservererrors.ErrPerm
 	} else if err != nil {
 		return nothing, err
@@ -1957,12 +1963,8 @@ func (u *UniterAPI) getOneRelation(
 	} else if err != nil {
 		return nothing, err
 	}
-	relID, err := u.relationService.GetRelationID(ctx, relUUID)
-	if err != nil {
-		return nothing, internalerrors.Capture(err)
-	}
-	rel, err := u.relationService.GetRelationDetails(ctx, relID)
-	if errors.Is(err, errors.NotFound) {
+	rel, err := u.relationService.GetRelationDetails(ctx, relUUID)
+	if errors.Is(err, relationerrors.RelationNotFound) {
 		return nothing, apiservererrors.ErrPerm
 	} else if err != nil {
 		return nothing, err

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -30,6 +30,7 @@ import (
 	relationerrors "github.com/juju/juju/domain/relation/errors"
 	"github.com/juju/juju/internal/charm"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
+	internalrelation "github.com/juju/juju/internal/relation"
 	coretesting "github.com/juju/juju/internal/testing"
 	"github.com/juju/juju/rpc/params"
 )
@@ -301,8 +302,8 @@ func (s *uniterRelationSuite) TestRelation(c *gc.C) {
 		Life: life.Alive,
 		UUID: relUUID,
 		ID:   relID,
-		Key:  relTag.Id(),
-		Endpoint: []relation.Endpoint{
+		Key:  corerelation.Key(relTag.Id()),
+		Endpoints: []internalrelation.Endpoint{
 			{
 				ApplicationName: "wordpress",
 				Relation: charm.Relation{
@@ -1067,8 +1068,8 @@ func (s *uniterRelationSuite) expectGetRelationDetails(relUUID corerelation.UUID
 		Life: life.Alive,
 		UUID: relUUID,
 		ID:   relID,
-		Key:  relTag.Id(),
-		Endpoint: []relation.Endpoint{
+		Key:  corerelation.Key(relTag.Id()),
+		Endpoints: []internalrelation.Endpoint{
 			{
 				ApplicationName: "wordpress",
 				Relation: charm.Relation{
@@ -1108,7 +1109,7 @@ func (s *uniterRelationSuite) expectGetRelationDetailsUnexpectedAppName(c *gc.C,
 		Life: life.Alive,
 		UUID: relationtesting.GenRelationUUID(c),
 		ID:   relID,
-		Endpoint: []relation.Endpoint{
+		Endpoints: []internalrelation.Endpoint{
 			{
 				ApplicationName: "failure-application",
 				Relation: charm.Relation{

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -298,36 +298,10 @@ func (s *uniterRelationSuite) TestRelation(c *gc.C) {
 
 	relUUID := relationtesting.GenRelationUUID(c)
 	relID := 42
-	details := relation.RelationDetails{
-		Life: life.Alive,
-		UUID: relUUID,
-		ID:   relID,
-		Key:  corerelation.Key(relTag.Id()),
-		Endpoints: []internalrelation.Endpoint{
-			{
-				ApplicationName: "wordpress",
-				Relation: charm.Relation{
-					Name:      "database",
-					Role:      charm.RoleRequirer,
-					Interface: "mysql",
-					Scope:     charm.ScopeGlobal,
-				},
-			},
-			{
-				ApplicationName: "mysql",
-				Relation: charm.Relation{
-					Name:      "mysql",
-					Role:      charm.RoleProvider,
-					Interface: "mysql",
-					Scope:     charm.ScopeGlobal,
-				},
-			},
-		},
-	}
 
 	s.expectModelUUID(c)
 	s.expectGetRelationUUIDFromKey(corerelation.Key(relTag.Id()), relUUID, nil)
-	s.expectGetRelationDetailsForUnit(relUUID, details)
+	s.expectGetRelationDetails(relUUID, relID, relTag)
 
 	args := params.RelationUnits{RelationUnits: []params.RelationUnit{
 		{Relation: relTag.String(), Unit: "unit-wordpress-0"},
@@ -401,14 +375,21 @@ func (s *uniterRelationSuite) TestRelationById(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	relTag := names.NewRelationTag("mysql:database wordpress:mysql")
 	relUUID := relationtesting.GenRelationUUID(c)
-	relID := 37
 	relIDNotFound := -1
+	relID := 31
 	relIDUnexpectedAppName := 42
 
 	s.expectModelUUID(c)
+
+	s.expectGetRelationUUIDByID(relIDNotFound, relUUID, nil)
+	s.expectGetRelationDetailsNotFound(relUUID)
+
+	s.expectGetRelationUUIDByID(relID, relUUID, nil)
 	s.expectGetRelationDetails(relUUID, relID, relTag)
-	s.expectGetRelationDetailsNotFound(relIDNotFound)
-	s.expectGetRelationDetailsUnexpectedAppName(c, relIDUnexpectedAppName)
+
+	s.expectGetRelationUUIDByID(relIDUnexpectedAppName, relUUID, nil)
+	s.expectGetRelationDetailsUnexpectedAppName(c, relUUID)
+
 	args := params.RelationIds{
 		RelationIds: []int{
 			// The relation ID does not exist: ErrUnauthorized.
@@ -423,7 +404,7 @@ func (s *uniterRelationSuite) TestRelationById(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(result, gc.DeepEquals, params.RelationResultsV2{
 		Results: []params.RelationResultV2{
-			{Error: apiservertesting.ErrUnauthorized},
+			{Error: &params.Error{Message: `not found`, Code: params.CodeNotFound}},
 			{
 				Id:   relID,
 				Key:  relTag.Id(),
@@ -1064,7 +1045,7 @@ func (s *uniterRelationSuite) expectGetRelationUUIDFromKey(key corerelation.Key,
 }
 
 func (s *uniterRelationSuite) expectGetRelationDetails(relUUID corerelation.UUID, relID int, relTag names.RelationTag) {
-	s.relationService.EXPECT().GetRelationDetails(gomock.Any(), relID).Return(relation.RelationDetails{
+	s.relationService.EXPECT().GetRelationDetails(gomock.Any(), relUUID).Return(relation.RelationDetails{
 		Life: life.Alive,
 		UUID: relUUID,
 		ID:   relID,
@@ -1092,23 +1073,15 @@ func (s *uniterRelationSuite) expectGetRelationDetails(relUUID corerelation.UUID
 	}, nil)
 }
 
-func (s *uniterRelationSuite) expectGetRelationDetailsForUnit(
-	relUUID corerelation.UUID,
-	details relation.RelationDetails,
-) {
-	unitName := coreunit.Name(s.wordpressUnitTag.Id())
-	s.relationService.EXPECT().GetRelationDetailsForUnit(gomock.Any(), relUUID, unitName).Return(details, nil)
+func (s *uniterRelationSuite) expectGetRelationDetailsNotFound(relUUID corerelation.UUID) {
+	s.relationService.EXPECT().GetRelationDetails(gomock.Any(), relUUID).Return(relation.RelationDetails{}, errors.NotFound)
 }
 
-func (s *uniterRelationSuite) expectGetRelationDetailsNotFound(relID int) {
-	s.relationService.EXPECT().GetRelationDetails(gomock.Any(), relID).Return(relation.RelationDetails{}, errors.NotFound)
-}
-
-func (s *uniterRelationSuite) expectGetRelationDetailsUnexpectedAppName(c *gc.C, relID int) {
-	s.relationService.EXPECT().GetRelationDetails(gomock.Any(), relID).Return(relation.RelationDetails{
+func (s *uniterRelationSuite) expectGetRelationDetailsUnexpectedAppName(c *gc.C, relUUID corerelation.UUID) {
+	s.relationService.EXPECT().GetRelationDetails(gomock.Any(), relUUID).Return(relation.RelationDetails{
 		Life: life.Alive,
-		UUID: relationtesting.GenRelationUUID(c),
-		ID:   relID,
+		UUID: relUUID,
+		ID:   101,
 		Endpoints: []internalrelation.Endpoint{
 			{
 				ApplicationName: "failure-application",

--- a/domain/relation/service/package_mock_test.go
+++ b/domain/relation/service/package_mock_test.go
@@ -120,6 +120,45 @@ func (c *MockStateGetRegularRelationUUIDByEndpointIdentifiersCall) DoAndReturn(f
 	return c
 }
 
+// GetRelationDetails mocks base method.
+func (m *MockState) GetRelationDetails(arg0 context.Context, arg1 int) (relation0.RelationDetailsResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRelationDetails", arg0, arg1)
+	ret0, _ := ret[0].(relation0.RelationDetailsResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRelationDetails indicates an expected call of GetRelationDetails.
+func (mr *MockStateMockRecorder) GetRelationDetails(arg0, arg1 any) *MockStateGetRelationDetailsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRelationDetails", reflect.TypeOf((*MockState)(nil).GetRelationDetails), arg0, arg1)
+	return &MockStateGetRelationDetailsCall{Call: call}
+}
+
+// MockStateGetRelationDetailsCall wrap *gomock.Call
+type MockStateGetRelationDetailsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateGetRelationDetailsCall) Return(arg0 relation0.RelationDetailsResult, arg1 error) *MockStateGetRelationDetailsCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateGetRelationDetailsCall) Do(f func(context.Context, int) (relation0.RelationDetailsResult, error)) *MockStateGetRelationDetailsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateGetRelationDetailsCall) DoAndReturn(f func(context.Context, int) (relation0.RelationDetailsResult, error)) *MockStateGetRelationDetailsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetRelationEndpointUUID mocks base method.
 func (m *MockState) GetRelationEndpointUUID(arg0 context.Context, arg1 relation0.GetRelationEndpointUUIDArgs) (relation.EndpointUUID, error) {
 	m.ctrl.T.Helper()

--- a/domain/relation/service/package_mock_test.go
+++ b/domain/relation/service/package_mock_test.go
@@ -121,7 +121,7 @@ func (c *MockStateGetRegularRelationUUIDByEndpointIdentifiersCall) DoAndReturn(f
 }
 
 // GetRelationDetails mocks base method.
-func (m *MockState) GetRelationDetails(arg0 context.Context, arg1 int) (relation0.RelationDetailsResult, error) {
+func (m *MockState) GetRelationDetails(arg0 context.Context, arg1 relation.UUID) (relation0.RelationDetailsResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRelationDetails", arg0, arg1)
 	ret0, _ := ret[0].(relation0.RelationDetailsResult)
@@ -148,13 +148,13 @@ func (c *MockStateGetRelationDetailsCall) Return(arg0 relation0.RelationDetailsR
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateGetRelationDetailsCall) Do(f func(context.Context, int) (relation0.RelationDetailsResult, error)) *MockStateGetRelationDetailsCall {
+func (c *MockStateGetRelationDetailsCall) Do(f func(context.Context, relation.UUID) (relation0.RelationDetailsResult, error)) *MockStateGetRelationDetailsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetRelationDetailsCall) DoAndReturn(f func(context.Context, int) (relation0.RelationDetailsResult, error)) *MockStateGetRelationDetailsCall {
+func (c *MockStateGetRelationDetailsCall) DoAndReturn(f func(context.Context, relation.UUID) (relation0.RelationDetailsResult, error)) *MockStateGetRelationDetailsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/relation/service/relation.go
+++ b/domain/relation/service/relation.go
@@ -72,6 +72,13 @@ type State interface {
 		endpoint relation.EndpointIdentifier,
 	) (corerelation.UUID, error)
 
+	// GetRelationDetails returns relation details for the given relationID.
+	//
+	// The following error types can be expected to be returned:
+	//   - [relationerrors.RelationNotFound] is returned if the relation UUID
+	//     is not found.
+	GetRelationDetails(ctx context.Context, relationID int) (relation.RelationDetailsResult, error)
+
 	// WatcherApplicationSettingsNamespace provides the table name to set up
 	// watchers for relation application settings.
 	WatcherApplicationSettingsNamespace() string
@@ -197,8 +204,23 @@ func (s *Service) GetRelatedEndpoints(
 }
 
 // GetRelationDetails returns RelationDetails for the given relationID.
+//
+// The following error types can be expected to be returned:
+//   - [relationerrors.RelationNotFound] is returned if the relation UUID
+//     is not found.
 func (s *Service) GetRelationDetails(ctx context.Context, relationID int) (relation.RelationDetails, error) {
-	return relation.RelationDetails{}, coreerrors.NotImplemented
+	relationDetails, err := s.st.GetRelationDetails(ctx, relationID)
+	if err != nil {
+		return relation.RelationDetails{}, errors.Capture(err)
+	}
+
+	return relation.RelationDetails{
+		Life:      relationDetails.Life,
+		UUID:      relationDetails.UUID,
+		ID:        relationDetails.ID,
+		Key:       internalrelation.NaturalKey(relationDetails.Endpoints),
+		Endpoints: relationDetails.Endpoints,
+	}, nil
 }
 
 // GetRelationDetailsForUnit RelationDetails for the given relationID

--- a/domain/relation/service/relation.go
+++ b/domain/relation/service/relation.go
@@ -72,12 +72,12 @@ type State interface {
 		endpoint relation.EndpointIdentifier,
 	) (corerelation.UUID, error)
 
-	// GetRelationDetails returns relation details for the given relationID.
+	// GetRelationDetails returns relation details for the given relationUUID.
 	//
 	// The following error types can be expected to be returned:
 	//   - [relationerrors.RelationNotFound] is returned if the relation UUID
 	//     is not found.
-	GetRelationDetails(ctx context.Context, relationID int) (relation.RelationDetailsResult, error)
+	GetRelationDetails(ctx context.Context, relationUUID corerelation.UUID) (relation.RelationDetailsResult, error)
 
 	// WatcherApplicationSettingsNamespace provides the table name to set up
 	// watchers for relation application settings.
@@ -208,8 +208,17 @@ func (s *Service) GetRelatedEndpoints(
 // The following error types can be expected to be returned:
 //   - [relationerrors.RelationNotFound] is returned if the relation UUID
 //     is not found.
-func (s *Service) GetRelationDetails(ctx context.Context, relationID int) (relation.RelationDetails, error) {
-	relationDetails, err := s.st.GetRelationDetails(ctx, relationID)
+//   - [relationerrors.RelationUUIDNotValid] is returned if the relation UUID
+//     is not valid.
+func (s *Service) GetRelationDetails(
+	ctx context.Context,
+	relationUUID corerelation.UUID,
+) (relation.RelationDetails, error) {
+	if err := relationUUID.Validate(); err != nil {
+		return relation.RelationDetails{}, errors.Errorf(
+			"%w: %w", relationerrors.RelationUUIDNotValid, err)
+	}
+	relationDetails, err := s.st.GetRelationDetails(ctx, relationUUID)
 	if err != nil {
 		return relation.RelationDetails{}, errors.Capture(err)
 	}

--- a/domain/relation/service/relation.go
+++ b/domain/relation/service/relation.go
@@ -223,20 +223,6 @@ func (s *Service) GetRelationDetails(ctx context.Context, relationID int) (relat
 	}, nil
 }
 
-// GetRelationDetailsForUnit RelationDetails for the given relationID
-// and unit combination
-func (s *Service) GetRelationDetailsForUnit(
-	ctx context.Context,
-	relationUUID corerelation.UUID,
-	unitName unit.Name,
-) (relation.RelationDetails, error) {
-	// TODO (hml) 2025-03-11
-	// During implementation investigate the difference between the
-	// service methods returning RelationDetails and how their use
-	// by the uniter facade truly differs. Are both needed?
-	return relation.RelationDetails{}, coreerrors.NotImplemented
-}
-
 // GetRelationEndpoint returns the endpoint for the given application and
 // relation identifier combination.
 func (s *Service) GetRelationEndpoint(

--- a/domain/relation/service/relation_test.go
+++ b/domain/relation/service/relation_test.go
@@ -13,6 +13,7 @@ import (
 
 	coreapplication "github.com/juju/juju/core/application"
 	coreapplicationtesting "github.com/juju/juju/core/application/testing"
+	corelife "github.com/juju/juju/core/life"
 	corerelation "github.com/juju/juju/core/relation"
 	corerelationtesting "github.com/juju/juju/core/relation/testing"
 	"github.com/juju/juju/domain/relation"
@@ -303,6 +304,45 @@ func (s *relationServiceSuite) TestGetRelationUUIDByKeyRelationKeyNotValid(c *gc
 
 	// Assert:
 	c.Assert(err, jc.ErrorIs, relationerrors.RelationKeyNotValid)
+}
+
+func (s *relationServiceSuite) TestGetRelationDetails(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Arrange:
+	relationUUID := corerelationtesting.GenRelationUUID(c)
+	relationID := 7
+
+	endpoint1 := internalrelation.Endpoint{
+		ApplicationName: "app-1",
+		Relation: internalcharm.Relation{
+			Name: "fake-endpoint-name-1",
+		},
+	}
+
+	relationDetailsResult := relation.RelationDetailsResult{
+		Life:      corelife.Alive,
+		UUID:      relationUUID,
+		ID:        relationID,
+		Endpoints: []internalrelation.Endpoint{endpoint1},
+	}
+
+	s.state.EXPECT().GetRelationDetails(gomock.Any(), relationID).Return(relationDetailsResult, nil)
+
+	expectedRelationDetails := relation.RelationDetails{
+		Life:      relationDetailsResult.Life,
+		UUID:      relationDetailsResult.UUID,
+		ID:        relationDetailsResult.ID,
+		Key:       corerelation.Key("app-1:fake-endpoint-name-1"),
+		Endpoints: relationDetailsResult.Endpoints,
+	}
+
+	// Act:
+	relationDetails, err := s.service.GetRelationDetails(context.Background(), relationID)
+
+	// Assert:
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(relationDetails, gc.DeepEquals, expectedRelationDetails)
 }
 
 func (s *relationServiceSuite) setupMocks(c *gc.C) *gomock.Controller {

--- a/domain/relation/service/relation_test.go
+++ b/domain/relation/service/relation_test.go
@@ -311,7 +311,6 @@ func (s *relationServiceSuite) TestGetRelationDetails(c *gc.C) {
 
 	// Arrange:
 	relationUUID := corerelationtesting.GenRelationUUID(c)
-	relationID := 7
 
 	endpoint1 := internalrelation.Endpoint{
 		ApplicationName: "app-1",
@@ -323,11 +322,11 @@ func (s *relationServiceSuite) TestGetRelationDetails(c *gc.C) {
 	relationDetailsResult := relation.RelationDetailsResult{
 		Life:      corelife.Alive,
 		UUID:      relationUUID,
-		ID:        relationID,
+		ID:        7,
 		Endpoints: []internalrelation.Endpoint{endpoint1},
 	}
 
-	s.state.EXPECT().GetRelationDetails(gomock.Any(), relationID).Return(relationDetailsResult, nil)
+	s.state.EXPECT().GetRelationDetails(gomock.Any(), relationUUID).Return(relationDetailsResult, nil)
 
 	expectedRelationDetails := relation.RelationDetails{
 		Life:      relationDetailsResult.Life,
@@ -338,11 +337,24 @@ func (s *relationServiceSuite) TestGetRelationDetails(c *gc.C) {
 	}
 
 	// Act:
-	relationDetails, err := s.service.GetRelationDetails(context.Background(), relationID)
+	relationDetails, err := s.service.GetRelationDetails(context.Background(), relationUUID)
 
 	// Assert:
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(relationDetails, gc.DeepEquals, expectedRelationDetails)
+}
+
+// TestGetRelationEndpointUUIDRelationUUIDNotValid tests the failure scenario
+// where the provided RelationUUID is not valid.
+func (s *relationServiceSuite) TestGetRelationDetailsRelationUUIDNotValid(c *gc.C) {
+	// Arrange
+	defer s.setupMocks(c).Finish()
+
+	// Act
+	_, err := s.service.GetRelationDetails(context.Background(), "bad-relation-uuid")
+
+	// Assert
+	c.Assert(err, jc.ErrorIs, relationerrors.RelationUUIDNotValid, gc.Commentf("(Assert) unexpected error: %v", err))
 }
 
 func (s *relationServiceSuite) setupMocks(c *gc.C) *gomock.Controller {

--- a/domain/relation/state/relation.go
+++ b/domain/relation/state/relation.go
@@ -365,7 +365,7 @@ AND    e.endpoint_name    = $endpointIdentifier.endpoint_name
 // The following error types can be expected to be returned:
 //   - [relationerrors.RelationNotFound] is returned if the relation UUID
 //     is not found.
-func (st *State) GetRelationDetails(ctx context.Context, relationID int) (relation.RelationDetailsResult, error) {
+func (st *State) GetRelationDetails(ctx context.Context, relationUUID corerelation.UUID) (relation.RelationDetailsResult, error) {
 	db, err := st.DB()
 	if err != nil {
 		return relation.RelationDetailsResult{}, errors.Capture(err)
@@ -377,13 +377,13 @@ func (st *State) GetRelationDetails(ctx context.Context, relationID int) (relati
 		Life string `db:"value"`
 	}
 	rel := getRelation{
-		ID: relationID,
+		UUID: relationUUID.String(),
 	}
 	stmt, err := st.Prepare(`
 SELECT (r.uuid, r.relation_id, l.value) AS (&getRelation.*)
 FROM   relation r
 JOIN   life l ON r.life_id = l.id
-WHERE  relation_id = $getRelation.relation_id
+WHERE  r.uuid = $getRelation.uuid
 `, rel)
 	if err != nil {
 		return relation.RelationDetailsResult{}, errors.Capture(err)

--- a/domain/relation/state/relation.go
+++ b/domain/relation/state/relation.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/clock"
 
 	"github.com/juju/juju/core/database"
+	"github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/logger"
 	corerelation "github.com/juju/juju/core/relation"
 	"github.com/juju/juju/domain"
@@ -195,6 +196,24 @@ func (st *State) GetRelationEndpoints(ctx context.Context, uuid corerelation.UUI
 		return nil, errors.Capture(err)
 	}
 
+	var endpoints []internalrelation.Endpoint
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		endpoints, err = st.getEndpoints(ctx, tx, uuid)
+		return err
+	})
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	return endpoints, nil
+}
+
+// getEndpoints retrieves the endpoints of a given relation specified via its UUID.
+func (st *State) getEndpoints(
+	ctx context.Context,
+	tx *sqlair.TX,
+	uuid corerelation.UUID,
+) ([]internalrelation.Endpoint, error) {
 	id := relationUUID{
 		UUID: uuid.String(),
 	}
@@ -208,15 +227,9 @@ WHERE  relation_uuid = $relationUUID.uuid
 	}
 
 	var endpoints []endpoint
-	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		err = tx.Query(ctx, stmt, id).GetAll(&endpoints)
-		if errors.Is(err, sqlair.ErrNoRows) {
-			return relationerrors.RelationNotFound
-		}
-		return errors.Capture(err)
-	})
-	if err != nil {
-		return nil, errors.Capture(err)
+	err = tx.Query(ctx, stmt, id).GetAll(&endpoints)
+	if errors.Is(err, sqlair.ErrNoRows) {
+		return nil, relationerrors.RelationNotFound
 	}
 
 	if l := len(endpoints); l > 2 {
@@ -345,6 +358,60 @@ AND    e.endpoint_name    = $endpointIdentifier.endpoint_name
 	}
 
 	return corerelation.UUID(uuidAndRole[0].UUID), nil
+}
+
+// GetRelationDetails returns relation details for the given relationID.
+//
+// The following error types can be expected to be returned:
+//   - [relationerrors.RelationNotFound] is returned if the relation UUID
+//     is not found.
+func (st *State) GetRelationDetails(ctx context.Context, relationID int) (relation.RelationDetailsResult, error) {
+	db, err := st.DB()
+	if err != nil {
+		return relation.RelationDetailsResult{}, errors.Capture(err)
+	}
+
+	type getRelation struct {
+		UUID string `db:"uuid"`
+		ID   int    `db:"relation_id"`
+		Life string `db:"value"`
+	}
+	rel := getRelation{
+		ID: relationID,
+	}
+	stmt, err := st.Prepare(`
+SELECT (r.uuid, r.relation_id, l.value) AS (&getRelation.*)
+FROM   relation r
+JOIN   life l ON r.life_id = l.id
+WHERE  relation_id = $getRelation.relation_id
+`, rel)
+	if err != nil {
+		return relation.RelationDetailsResult{}, errors.Capture(err)
+	}
+
+	var endpoints []internalrelation.Endpoint
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		err = tx.Query(ctx, stmt, rel).Get(&rel)
+		if errors.Is(err, sqlair.ErrNoRows) {
+			return relationerrors.RelationNotFound
+		}
+
+		endpoints, err = st.getEndpoints(ctx, tx, corerelation.UUID(rel.UUID))
+		if err != nil {
+			return errors.Errorf("getting relation endpoints: %w", err)
+		}
+		return errors.Capture(err)
+	})
+	if err != nil {
+		return relation.RelationDetailsResult{}, errors.Capture(err)
+	}
+
+	return relation.RelationDetailsResult{
+		Life:      life.Value(rel.Life),
+		UUID:      corerelation.UUID(rel.UUID),
+		ID:        rel.ID,
+		Endpoints: endpoints,
+	}, nil
 }
 
 // WatcherApplicationSettingsNamespace returns the namespace string used for

--- a/domain/relation/state/relation_test.go
+++ b/domain/relation/state/relation_test.go
@@ -627,7 +627,7 @@ func (s *relationSuite) TestGetRelationDetails(c *gc.C) {
 	}
 
 	// Act: Get relation details.
-	details, err := s.state.GetRelationDetails(context.Background(), relationID)
+	details, err := s.state.GetRelationDetails(context.Background(), corerelation.UUID(relationUUID))
 
 	// Assert:
 	c.Assert(err, jc.ErrorIsNil)
@@ -636,7 +636,7 @@ func (s *relationSuite) TestGetRelationDetails(c *gc.C) {
 
 func (s *relationSuite) TestGetRelationDetailsNotFound(c *gc.C) {
 	// Act: Get relation details.
-	_, err := s.state.GetRelationDetails(context.Background(), 7)
+	_, err := s.state.GetRelationDetails(context.Background(), "unknown-relation-uuid")
 
 	// Assert:
 	c.Assert(err, jc.ErrorIs, relationerrors.RelationNotFound)

--- a/domain/relation/state/relation_test.go
+++ b/domain/relation/state/relation_test.go
@@ -14,6 +14,7 @@ import (
 	coreapplication "github.com/juju/juju/core/application"
 	coreapplicationtesting "github.com/juju/juju/core/application/testing"
 	"github.com/juju/juju/core/charm/testing"
+	corelife "github.com/juju/juju/core/life"
 	"github.com/juju/juju/core/network"
 	corerelation "github.com/juju/juju/core/relation"
 	corerelationtesting "github.com/juju/juju/core/relation/testing"
@@ -576,6 +577,71 @@ func (s *relationSuite) TestGetPeerRelationUUIDByEndpointIdentifiersNotFound(c *
 	c.Assert(err, jc.ErrorIs, relationerrors.RelationNotFound)
 }
 
+func (s *relationSuite) TestGetRelationDetails(c *gc.C) {
+	// Arrange: Add two endpoints and a relation on them.
+	relationUUID := corerelationtesting.GenRelationUUID(c).String()
+	relationID := 7
+
+	charmRelationUUID1 := "fake-charm-relation-uuid-1"
+	applicationEndpointUUID1 := "fake-application-endpoint-uuid-1"
+	relationEndpointUUID1 := "fake-relation-endpoint-uuid-1"
+	endpoint1 := internalrelation.Endpoint{
+		ApplicationName: s.fakeApplicationName1,
+		Relation: internalcharm.Relation{
+			Name:      "fake-endpoint-name-1",
+			Role:      internalcharm.RoleProvider,
+			Interface: "database",
+			Optional:  true,
+			Limit:     20,
+			Scope:     internalcharm.ScopeGlobal,
+		},
+	}
+
+	charmRelationUUID2 := "fake-charm-relation-uuid-2"
+	applicationEndpointUUID2 := "fake-application-endpoint-uuid-2"
+	relationEndpointUUID2 := "fake-relation-endpoint-uuid-2"
+	endpoint2 := internalrelation.Endpoint{
+		ApplicationName: s.fakeApplicationName2,
+		Relation: internalcharm.Relation{
+			Name:      "fake-endpoint-name-2",
+			Role:      internalcharm.RoleRequirer,
+			Interface: "database",
+			Optional:  false,
+			Limit:     10,
+			Scope:     internalcharm.ScopeGlobal,
+		},
+	}
+	s.addCharmRelation(c, s.fakeCharmUUID1, charmRelationUUID1, endpoint1.Relation)
+	s.addCharmRelation(c, s.fakeCharmUUID2, charmRelationUUID2, endpoint2.Relation)
+	s.addApplicationEndpoint(c, applicationEndpointUUID1, s.fakeApplicationUUID1, charmRelationUUID1)
+	s.addApplicationEndpoint(c, applicationEndpointUUID2, s.fakeApplicationUUID2, charmRelationUUID2)
+	s.addRelationWithLifeAndID(c, relationUUID, corelife.Dying, relationID)
+	s.addRelationEndpoint(c, relationEndpointUUID1, relationUUID, applicationEndpointUUID1)
+	s.addRelationEndpoint(c, relationEndpointUUID2, relationUUID, applicationEndpointUUID2)
+
+	expectedDetails := relation.RelationDetailsResult{
+		Life:      corelife.Dying,
+		UUID:      corerelation.UUID(relationUUID),
+		ID:        relationID,
+		Endpoints: []internalrelation.Endpoint{endpoint1, endpoint2},
+	}
+
+	// Act: Get relation details.
+	details, err := s.state.GetRelationDetails(context.Background(), relationID)
+
+	// Assert:
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(details, gc.DeepEquals, expectedDetails)
+}
+
+func (s *relationSuite) TestGetRelationDetailsNotFound(c *gc.C) {
+	// Act: Get relation details.
+	_, err := s.state.GetRelationDetails(context.Background(), 7)
+
+	// Assert:
+	c.Assert(err, jc.ErrorIs, relationerrors.RelationNotFound)
+}
+
 // addApplication adds a new application to the database with the specified UUID and name.
 func (s *relationSuite) addApplication(c *gc.C, charmUUID, appUUID, appName string) {
 	s.query(c, `
@@ -637,6 +703,16 @@ func (s *relationSuite) encodeScopeID(role internalcharm.RelationScope) int {
 	}[role]
 }
 
+// encodeLifeID returns the ID used in the database for the given life. This
+// reflects the contents of the life table.
+func (s *relationSuite) encodeLifeID(life corelife.Value) int {
+	return map[corelife.Value]int{
+		corelife.Alive: 0,
+		corelife.Dying: 1,
+		corelife.Dead:  2,
+	}[life]
+}
+
 // addRelation inserts a new relation into the database with the given UUID and default relation and life IDs.
 func (s *relationSuite) addRelation(c *gc.C, relationUUID string) {
 	s.query(c, `
@@ -652,6 +728,15 @@ func (s *relationSuite) addRelationWithID(c *gc.C, relationUUID string, relation
 INSERT INTO relation (uuid, life_id, relation_id) 
 VALUES (?,0,?)
 `, relationUUID, relationID)
+}
+
+// addRelationWithLifeAndID inserts a new relation into the database with the
+// given details.
+func (s *relationSuite) addRelationWithLifeAndID(c *gc.C, relationUUID string, life corelife.Value, relationID int) {
+	s.query(c, `
+INSERT INTO relation (uuid, life_id, relation_id) 
+VALUES (?,?,?)
+`, relationUUID, s.encodeLifeID(life), relationID)
 }
 
 // addRelationEndpoint inserts a relation endpoint into the database using the provided UUIDs for relation and endpoint.

--- a/domain/relation/types.go
+++ b/domain/relation/types.go
@@ -9,6 +9,7 @@ import (
 	corerelation "github.com/juju/juju/core/relation"
 	corewatcher "github.com/juju/juju/core/watcher"
 	"github.com/juju/juju/internal/charm"
+	"github.com/juju/juju/internal/relation"
 )
 
 // GetRelationEndpointUUIDArgs represents the arguments required to retrieve
@@ -25,11 +26,29 @@ type GetRelationEndpointUUIDArgs struct {
 
 // RelationDetails represents the current application's view of a relation.
 type RelationDetails struct {
-	Life     life.Value
-	UUID     corerelation.UUID
-	ID       int
-	Key      string
-	Endpoint []Endpoint
+	// Life is the current life value of the relation.
+	Life life.Value
+	// UUID is the unique identifier of the relation.
+	UUID corerelation.UUID
+	// ID is the sequential ID of the relation.
+	ID int
+	// Key is the natural key of the relation.
+	Key corerelation.Key
+	// Endpoints are the endpoints of the relation.
+	Endpoints []relation.Endpoint
+}
+
+// RelationDetailsResult represents the current application's view of a
+// relation. This struct is used for passing results from state to the service.
+type RelationDetailsResult struct {
+	// Life is the current life value of the relation.
+	Life life.Value
+	// UUID is the unique identifier of the relation.
+	UUID corerelation.UUID
+	// ID is the sequential ID of the relation.
+	ID int
+	// Endpoints are the endpoints of the relation.
+	Endpoints []relation.Endpoint
 }
 
 // Endpoint represents one endpoint of a relation.


### PR DESCRIPTION
#
> [!WARNING]
> Waiting for #19308  

Remove the GetRelationDetailsForUnit method. This method is made redundant by `GetRelationDetails`. It appears this method was added to replace the 3.6 function `getRelationUnit`  in the uniter facade. This function in fact gets the unit and relation separately. Whats more, in some places it is called the unit information is not used. This behaviour can continue to stay separate in 4.0 and this function be removed.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps
Unit tests pass


## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Jira card:** [JUJU-7701](https://warthogs.atlassian.net/browse/JUJU-7701)

