### PR TITLE
feat: implement state layer for exposed endpoints

### DIFF
--- a/apiserver/facades/client/application/application.go
+++ b/apiserver/facades/client/application/application.go
@@ -30,7 +30,6 @@ import (
 	"github.com/juju/juju/core/leadership"
 	corelogger "github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/model"
-	"github.com/juju/juju/core/network/firewall"
 	"github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/core/permission"
 	coreresource "github.com/juju/juju/core/resource"
@@ -1204,16 +1203,6 @@ func (api *APIBase) Expose(ctx context.Context, args params.ApplicationExpose) e
 	mappedExposeParams, err := api.mapExposedEndpointParams(ctx, args.ExposedEndpoints)
 	if err != nil {
 		return apiservererrors.ServerError(err)
-	}
-
-	// If an empty exposedEndpoints list is provided, all endpoints should
-	// be exposed. This emulates the expose behavior of pre 2.9 controllers.
-	if len(mappedExposeParams) == 0 {
-		mappedExposeParams = map[string]state.ExposedEndpoint{
-			"": {
-				ExposeToCIDRs: []string{firewall.AllNetworksIPV4CIDR, firewall.AllNetworksIPV6CIDR},
-			},
-		}
 	}
 
 	if err = app.MergeExposeSettings(mappedExposeParams); err != nil {

--- a/core/network/endpoint.go
+++ b/core/network/endpoint.go
@@ -1,7 +1,7 @@
-// Copyright 2024 Canonical Ltd.
+// Copyright 2025 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package port
+package network
 
 // WildcardEndpoint is a special endpoint that represents all endpoints
 const WildcardEndpoint = ""

--- a/domain/application/errors/errors.go
+++ b/domain/application/errors/errors.go
@@ -236,6 +236,10 @@ const (
 
 	// SpaceNotFound is returned when the specified space cannot be found.
 	SpaceNotFound = errors.ConstError("space not found")
+
+	// EndpointNotFound descries an error that occurs when the endpoint being
+	// operated on does not exist.
+	EndpointNotFound = errors.ConstError("endpoint not found")
 )
 
 const (

--- a/domain/application/service/application.go
+++ b/domain/application/service/application.go
@@ -296,6 +296,15 @@ type ApplicationState interface {
 	// If no application is found, an error satisfying
 	// [applicationerrors.ApplicationNotFound] is returned.
 	MergeExposeSettings(ctx context.Context, appID coreapplication.ID, exposedEndpoints map[string]application.ExposedEndpoint) error
+
+	// EndpointsExist returns an error satisfying
+	// [applicationerrors.EndpointNotFound] if any of the provided endpoints do not
+	// exist.
+	EndpointsExist(ctx context.Context, appID coreapplication.ID, endpoints set.Strings) error
+
+	// SpacesExist returns an error satisfying [networkerrors.SpaceNotFound] if any
+	// of the provided spaces do not exist.
+	SpacesExist(ctx context.Context, spaceUUIDs set.Strings) error
 }
 
 func validateCharmAndApplicationParams(

--- a/domain/application/service/application.go
+++ b/domain/application/service/application.go
@@ -264,12 +264,12 @@ type ApplicationState interface {
 	// for application scale change watchers.
 	NamespaceForWatchApplicationScale() string
 
-	// ApplicationExposed returns whether the provided application is exposed or
+	// IsApplicationExposed returns whether the provided application is exposed or
 	// not.
 	//
 	// If no application is found, an error satisfying
 	// [applicationerrors.ApplicationNotFound] is returned.
-	ApplicationExposed(ctx context.Context, appID coreapplication.ID) (bool, error)
+	IsApplicationExposed(ctx context.Context, appID coreapplication.ID) (bool, error)
 
 	// GetExposedEndpoints returns map where keys are endpoint names (or the ""
 	// value which represents all endpoints) and values are ExposedEndpoint

--- a/domain/application/service/exposed.go
+++ b/domain/application/service/exposed.go
@@ -92,7 +92,7 @@ func (s *Service) MergeExposeSettings(ctx context.Context, appName string, expos
 	validatedExposedEndpoints := make(map[string]application.ExposedEndpoint)
 	if len(exposedEndpoints) == 0 {
 		// If an empty exposedEndpoints list is provided, all endpoints should
-		// be exposed. This emulates the expose behavior of pre 2.9 controllers.
+		// be exposed.
 		validatedExposedEndpoints[network.WildcardEndpoint] = application.ExposedEndpoint{
 			ExposeToCIDRs: set.NewStrings(firewall.AllNetworksIPV4CIDR, firewall.AllNetworksIPV6CIDR),
 		}

--- a/domain/application/service/exposed.go
+++ b/domain/application/service/exposed.go
@@ -14,17 +14,17 @@ import (
 	"github.com/juju/juju/internal/errors"
 )
 
-// ApplicationExposed returns whether the provided application is exposed or not.
+// IsApplicationExposed returns whether the provided application is exposed or not.
 //
 // If no application is found, an error satisfying
 // [applicationerrors.ApplicationNotFound] is returned.
-func (s *Service) ApplicationExposed(ctx context.Context, appName string) (bool, error) {
+func (s *Service) IsApplicationExposed(ctx context.Context, appName string) (bool, error) {
 	appID, err := s.st.GetApplicationIDByName(ctx, appName)
 	if err != nil {
 		return false, errors.Capture(err)
 	}
 
-	return s.st.ApplicationExposed(ctx, appID)
+	return s.st.IsApplicationExposed(ctx, appID)
 }
 
 // GetExposedEndpoints returns map where keys are endpoint names (or the ""

--- a/domain/application/service/exposed_test.go
+++ b/domain/application/service/exposed_test.go
@@ -5,6 +5,7 @@ package service
 
 import (
 	"context"
+	"errors"
 
 	"github.com/juju/collections/set"
 	jc "github.com/juju/testing/checkers"
@@ -13,6 +14,7 @@ import (
 
 	coreapplication "github.com/juju/juju/core/application"
 	applicationtesting "github.com/juju/juju/core/application/testing"
+	"github.com/juju/juju/core/network/firewall"
 	"github.com/juju/juju/domain/application"
 	applicationerrors "github.com/juju/juju/domain/application/errors"
 )
@@ -91,5 +93,102 @@ func (s *exposedServiceSuite) TestUnsetExposeSettings(c *gc.C) {
 	s.state.EXPECT().UnsetExposeSettings(gomock.Any(), applicationUUID, exposedEndpoints).Return(nil)
 
 	err := s.service.UnsetExposeSettings(context.Background(), "foo", exposedEndpoints)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *exposedServiceSuite) TestMergeExposeSettingsNotFound(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(coreapplication.ID(""), applicationerrors.ApplicationNotFound)
+
+	err := s.service.MergeExposeSettings(context.Background(), "foo", map[string]application.ExposedEndpoint{
+		"endpoint0": {
+			ExposeToSpaceIDs: set.NewStrings("space0", "space1"),
+		},
+		"endpoint1": {
+			ExposeToCIDRs: set.NewStrings("10.0.0.0/24", "10.0.1.0/24"),
+		},
+	})
+	c.Assert(err, gc.ErrorMatches, "application not found")
+}
+
+func (s *exposedServiceSuite) TestMergeExposeSettingsEndpointsExistError(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	applicationUUID := applicationtesting.GenApplicationUUID(c)
+	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(applicationUUID, nil)
+	s.state.EXPECT().EndpointsExist(gomock.Any(), applicationUUID, set.NewStrings("endpoint0", "endpoint1")).Return(errors.New("boom"))
+
+	err := s.service.MergeExposeSettings(context.Background(), "foo", map[string]application.ExposedEndpoint{
+		"endpoint0": {
+			ExposeToSpaceIDs: set.NewStrings("space0", "space1"),
+		},
+		"endpoint1": {
+			ExposeToCIDRs: set.NewStrings("10.0.0.0/24", "10.0.1.0/24"),
+		},
+	})
+	c.Assert(err, gc.ErrorMatches, "boom")
+}
+
+func (s *exposedServiceSuite) TestMergeExposeSettingsSpacesNotExist(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	applicationUUID := applicationtesting.GenApplicationUUID(c)
+	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(applicationUUID, nil)
+	s.state.EXPECT().EndpointsExist(gomock.Any(), applicationUUID, set.NewStrings("endpoint0", "endpoint1")).Return(nil)
+	s.state.EXPECT().SpacesExist(gomock.Any(), set.NewStrings("space0", "space1")).Return(errors.New("one or more of the provided spaces \\[space0 space1\\] do not exist"))
+
+	err := s.service.MergeExposeSettings(context.Background(), "foo", map[string]application.ExposedEndpoint{
+		"endpoint0": {
+			ExposeToSpaceIDs: set.NewStrings("space0", "space1"),
+		},
+		"endpoint1": {
+			ExposeToCIDRs: set.NewStrings("10.0.0.0/24", "10.0.1.0/24"),
+		},
+	})
+	c.Assert(err, gc.ErrorMatches, "validating exposed endpoints to spaces .*: one or more of the provided spaces .* do not exist")
+}
+
+func (s *exposedServiceSuite) TestMergeExposeSettingsEmptyEndpointsList(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	applicationUUID := applicationtesting.GenApplicationUUID(c)
+	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(applicationUUID, nil)
+	s.state.EXPECT().EndpointsExist(gomock.Any(), applicationUUID, set.NewStrings()).Return(nil)
+	s.state.EXPECT().SpacesExist(gomock.Any(), set.NewStrings()).Return(nil)
+	s.state.EXPECT().MergeExposeSettings(gomock.Any(), applicationUUID, map[string]application.ExposedEndpoint{
+		"": {
+			ExposeToCIDRs: set.NewStrings(firewall.AllNetworksIPV4CIDR, firewall.AllNetworksIPV6CIDR),
+		},
+	}).Return(nil)
+
+	err := s.service.MergeExposeSettings(context.Background(), "foo", map[string]application.ExposedEndpoint{})
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *exposedServiceSuite) TestMergeExposeSettings(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	applicationUUID := applicationtesting.GenApplicationUUID(c)
+	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(applicationUUID, nil)
+	s.state.EXPECT().EndpointsExist(gomock.Any(), applicationUUID, set.NewStrings("endpoint0", "endpoint1")).Return(nil)
+	s.state.EXPECT().SpacesExist(gomock.Any(), set.NewStrings("space0", "space1")).Return(nil)
+	s.state.EXPECT().MergeExposeSettings(gomock.Any(), applicationUUID, map[string]application.ExposedEndpoint{
+		"endpoint0": {
+			ExposeToSpaceIDs: set.NewStrings("space0", "space1"),
+		},
+		"endpoint1": {
+			ExposeToCIDRs: set.NewStrings("10.0.0.0/24", "10.0.1.0/24"),
+		},
+	}).Return(nil)
+
+	err := s.service.MergeExposeSettings(context.Background(), "foo", map[string]application.ExposedEndpoint{
+		"endpoint0": {
+			ExposeToSpaceIDs: set.NewStrings("space0", "space1"),
+		},
+		"endpoint1": {
+			ExposeToCIDRs: set.NewStrings("10.0.0.0/24", "10.0.1.0/24"),
+		},
+	})
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/domain/application/service/exposed_test.go
+++ b/domain/application/service/exposed_test.go
@@ -30,7 +30,7 @@ func (s *exposedServiceSuite) TestApplicationExposedNotFound(c *gc.C) {
 
 	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(coreapplication.ID(""), applicationerrors.ApplicationNotFound)
 
-	_, err := s.service.ApplicationExposed(context.Background(), "foo")
+	_, err := s.service.IsApplicationExposed(context.Background(), "foo")
 	c.Assert(err, gc.ErrorMatches, "application not found")
 }
 
@@ -39,9 +39,9 @@ func (s *exposedServiceSuite) TestApplicationExposed(c *gc.C) {
 
 	applicationUUID := applicationtesting.GenApplicationUUID(c)
 	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(applicationUUID, nil)
-	s.state.EXPECT().ApplicationExposed(gomock.Any(), applicationUUID).Return(true, nil)
+	s.state.EXPECT().IsApplicationExposed(gomock.Any(), applicationUUID).Return(true, nil)
 
-	exposed, err := s.service.ApplicationExposed(context.Background(), "foo")
+	exposed, err := s.service.IsApplicationExposed(context.Background(), "foo")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(exposed, jc.IsTrue)
 }

--- a/domain/application/service/package_mock_test.go
+++ b/domain/application/service/package_mock_test.go
@@ -186,45 +186,6 @@ func (c *MockStateAddStorageForUnitCall) DoAndReturn(f func(context.Context, sto
 	return c
 }
 
-// ApplicationExposed mocks base method.
-func (m *MockState) ApplicationExposed(ctx context.Context, appID application.ID) (bool, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ApplicationExposed", ctx, appID)
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ApplicationExposed indicates an expected call of ApplicationExposed.
-func (mr *MockStateMockRecorder) ApplicationExposed(ctx, appID any) *MockStateApplicationExposedCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplicationExposed", reflect.TypeOf((*MockState)(nil).ApplicationExposed), ctx, appID)
-	return &MockStateApplicationExposedCall{Call: call}
-}
-
-// MockStateApplicationExposedCall wrap *gomock.Call
-type MockStateApplicationExposedCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockStateApplicationExposedCall) Return(arg0 bool, arg1 error) *MockStateApplicationExposedCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockStateApplicationExposedCall) Do(f func(context.Context, application.ID) (bool, error)) *MockStateApplicationExposedCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateApplicationExposedCall) DoAndReturn(f func(context.Context, application.ID) (bool, error)) *MockStateApplicationExposedCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // AttachStorage mocks base method.
 func (m *MockState) AttachStorage(ctx context.Context, parentDir string, storageUUID storage.UUID, unitUUID unit.UUID) error {
 	m.ctrl.T.Helper()
@@ -2419,6 +2380,45 @@ func (c *MockStateInsertMigratingIAASUnitsCall) Do(f func(context.Context, appli
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockStateInsertMigratingIAASUnitsCall) DoAndReturn(f func(context.Context, application.ID, ...application0.InsertUnitArg) error) *MockStateInsertMigratingIAASUnitsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// IsApplicationExposed mocks base method.
+func (m *MockState) IsApplicationExposed(ctx context.Context, appID application.ID) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsApplicationExposed", ctx, appID)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IsApplicationExposed indicates an expected call of IsApplicationExposed.
+func (mr *MockStateMockRecorder) IsApplicationExposed(ctx, appID any) *MockStateIsApplicationExposedCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsApplicationExposed", reflect.TypeOf((*MockState)(nil).IsApplicationExposed), ctx, appID)
+	return &MockStateIsApplicationExposedCall{Call: call}
+}
+
+// MockStateIsApplicationExposedCall wrap *gomock.Call
+type MockStateIsApplicationExposedCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateIsApplicationExposedCall) Return(arg0 bool, arg1 error) *MockStateIsApplicationExposedCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateIsApplicationExposedCall) Do(f func(context.Context, application.ID) (bool, error)) *MockStateIsApplicationExposedCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateIsApplicationExposedCall) DoAndReturn(f func(context.Context, application.ID) (bool, error)) *MockStateIsApplicationExposedCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/application/service/package_mock_test.go
+++ b/domain/application/service/package_mock_test.go
@@ -493,6 +493,44 @@ func (c *MockStateDetachStorageForUnitCall) DoAndReturn(f func(context.Context, 
 	return c
 }
 
+// EndpointsExist mocks base method.
+func (m *MockState) EndpointsExist(ctx context.Context, appID application.ID, endpoints set.Strings) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EndpointsExist", ctx, appID, endpoints)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// EndpointsExist indicates an expected call of EndpointsExist.
+func (mr *MockStateMockRecorder) EndpointsExist(ctx, appID, endpoints any) *MockStateEndpointsExistCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EndpointsExist", reflect.TypeOf((*MockState)(nil).EndpointsExist), ctx, appID, endpoints)
+	return &MockStateEndpointsExistCall{Call: call}
+}
+
+// MockStateEndpointsExistCall wrap *gomock.Call
+type MockStateEndpointsExistCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateEndpointsExistCall) Return(arg0 error) *MockStateEndpointsExistCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateEndpointsExistCall) Do(f func(context.Context, application.ID, set.Strings) error) *MockStateEndpointsExistCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateEndpointsExistCall) DoAndReturn(f func(context.Context, application.ID, set.Strings) error) *MockStateEndpointsExistCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetApplicationCharmOrigin mocks base method.
 func (m *MockState) GetApplicationCharmOrigin(ctx context.Context, appID application.ID) (application0.CharmOrigin, error) {
 	m.ctrl.T.Helper()
@@ -3225,6 +3263,44 @@ func (c *MockStateSetUnitPasswordCall) Do(f func(context.Context, unit.UUID, app
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockStateSetUnitPasswordCall) DoAndReturn(f func(context.Context, unit.UUID, application0.PasswordInfo) error) *MockStateSetUnitPasswordCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// SpacesExist mocks base method.
+func (m *MockState) SpacesExist(ctx context.Context, spaceUUIDs set.Strings) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SpacesExist", ctx, spaceUUIDs)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SpacesExist indicates an expected call of SpacesExist.
+func (mr *MockStateMockRecorder) SpacesExist(ctx, spaceUUIDs any) *MockStateSpacesExistCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SpacesExist", reflect.TypeOf((*MockState)(nil).SpacesExist), ctx, spaceUUIDs)
+	return &MockStateSpacesExistCall{Call: call}
+}
+
+// MockStateSpacesExistCall wrap *gomock.Call
+type MockStateSpacesExistCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateSpacesExistCall) Return(arg0 error) *MockStateSpacesExistCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateSpacesExistCall) Do(f func(context.Context, set.Strings) error) *MockStateSpacesExistCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateSpacesExistCall) DoAndReturn(f func(context.Context, set.Strings) error) *MockStateSpacesExistCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/application/state/exposed.go
+++ b/domain/application/state/exposed.go
@@ -5,38 +5,492 @@ package state
 
 import (
 	"context"
+	"database/sql"
 
+	"github.com/canonical/sqlair"
 	"github.com/juju/collections/set"
 
 	coreapplication "github.com/juju/juju/core/application"
 	"github.com/juju/juju/domain/application"
+	applicationerrors "github.com/juju/juju/domain/application/errors"
+	networkerrors "github.com/juju/juju/domain/network/errors"
+	"github.com/juju/juju/internal/errors"
 )
+
+const wildcardEndpointName = ""
 
 // ApplicationExposed returns whether the provided application is exposed or
 // not.
-func (s *State) ApplicationExposed(ctx context.Context, appID coreapplication.ID) (bool, error) {
-	return false, nil
+func (st *State) ApplicationExposed(ctx context.Context, appID coreapplication.ID) (bool, error) {
+	db, err := st.DB()
+	if err != nil {
+		return false, errors.Capture(err)
+	}
+
+	ident := applicationID{ID: appID}
+	query := `
+SELECT COUNT(*) AS &countResult.count
+FROM v_application_exposed_endpoint
+WHERE application_uuid = $applicationID.uuid;
+	`
+	stmt, err := st.Prepare(query, countResult{}, ident)
+	if err != nil {
+		return false, errors.Errorf("preparing application exposed query: %w", err)
+	}
+
+	var count countResult
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		if err := tx.Query(ctx, stmt, ident).Get(&count); err != nil {
+			return errors.Errorf("checking if application %q is exposed: %w", appID, err)
+		}
+		return nil
+	})
+
+	if err != nil {
+		return false, errors.Capture(err)
+	}
+	return count.Count > 0, nil
 }
 
 // GetExposedEndpoints returns map where keys are endpoint names (or the ""
 // value which represents all endpoints) and values are ExposedEndpoint
 // instances that specify which sources (spaces or CIDRs) can access the
 // opened ports for each endpoint once the application is exposed.
-func (s *State) GetExposedEndpoints(ctx context.Context, appID coreapplication.ID) (map[string]application.ExposedEndpoint, error) {
-	return nil, nil
+func (st *State) GetExposedEndpoints(ctx context.Context, appID coreapplication.ID) (map[string]application.ExposedEndpoint, error) {
+	db, err := st.DB()
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	ident := applicationID{ID: appID}
+	queryUniqueEndpoints := `
+SELECT DISTINCT name AS &endpointName.*
+FROM v_application_exposed_endpoint AS ax
+LEFT JOIN application_endpoint AS ae ON ax.application_endpoint_uuid = ae.uuid
+LEFT JOIN charm_relation AS cr ON ae.charm_relation_uuid = cr.uuid
+WHERE ax.application_uuid = $applicationID.uuid;
+	`
+	queryUniqueEndpointsStmt, err := st.Prepare(queryUniqueEndpoints, endpointName{}, ident)
+	if err != nil {
+		return nil, errors.Errorf("preparing application unique endpoints query: %w", err)
+	}
+
+	queryExposedCIDRs := `
+SELECT &endpointCIDR.*
+FROM application_exposed_endpoint_cidr AS ax
+LEFT JOIN application_endpoint AS ae ON ax.application_endpoint_uuid = ae.uuid
+LEFT JOIN charm_relation AS cr ON ae.charm_relation_uuid = cr.uuid
+WHERE ax.application_uuid = $applicationID.uuid;
+		`
+	exposedCIDRsStmt, err := st.Prepare(queryExposedCIDRs, endpointCIDR{}, ident)
+	if err != nil {
+		return nil, errors.Errorf("preparing application exposed CIDRs query: %w", err)
+	}
+
+	queryExposedSpaces := `
+SELECT name AS &endpointSpace.name, ax.space_uuid AS &endpointSpace.space_uuid
+FROM application_exposed_endpoint_space AS ax
+LEFT JOIN application_endpoint AS ae ON ax.application_endpoint_uuid = ae.uuid
+LEFT JOIN charm_relation AS cr ON ae.charm_relation_uuid = cr.uuid
+WHERE ax.application_uuid = $applicationID.uuid;
+		`
+	exposedSpacesStmt, err := st.Prepare(queryExposedSpaces, endpointSpace{}, ident)
+	if err != nil {
+		return nil, errors.Errorf("preparing application exposed Spaces query: %w", err)
+	}
+
+	var (
+		endpoints []endpointName
+		cidrs     []endpointCIDR
+		spaces    []endpointSpace
+	)
+
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		if err := tx.Query(ctx, queryUniqueEndpointsStmt, ident).GetAll(&endpoints); err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return errors.Errorf("retrieving unique endpoints for application %q: %w", appID, err)
+		}
+		if err := tx.Query(ctx, exposedCIDRsStmt, ident).GetAll(&cidrs); err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return errors.Errorf("retrieving exposed CIDRs for application %q: %w", appID, err)
+		}
+		if err := tx.Query(ctx, exposedSpacesStmt, ident).GetAll(&spaces); err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return errors.Errorf("retrieving exposed Spaces for application %q: %w", appID, err)
+		}
+		return nil
+	})
+
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+	return encodeExposedEndopints(endpoints, cidrs, spaces), nil
+}
+
+func encodeExposedEndopints(endpoints []endpointName, cidrs []endpointCIDR, spaces []endpointSpace) map[string]application.ExposedEndpoint {
+	if len(endpoints) == 0 {
+		return nil
+	}
+	// We first need to init the map with a new empty set of strings for cidrs
+	// and spaces for each endpoint.
+	exposed := make(map[string]application.ExposedEndpoint, len(endpoints))
+	for _, endpoint := range endpoints {
+		endpointName := wildcardEndpointName
+		if endpoint.Name.Valid {
+			endpointName = endpoint.Name.String
+		}
+		exposed[endpointName] = application.ExposedEndpoint{
+			ExposeToCIDRs:    set.NewStrings(),
+			ExposeToSpaceIDs: set.NewStrings(),
+		}
+	}
+
+	for _, endpointCIDR := range cidrs {
+		endpointName := wildcardEndpointName
+		if endpointCIDR.EndpointName.Valid {
+			endpointName = endpointCIDR.EndpointName.String
+		}
+		exposed[endpointName].ExposeToCIDRs.Add(endpointCIDR.CIDR)
+	}
+	for _, endpointSpace := range spaces {
+		endpointName := wildcardEndpointName
+		if endpointSpace.EndpointName.Valid {
+			endpointName = endpointSpace.EndpointName.String
+		}
+		exposed[endpointName].ExposeToSpaceIDs.Add(endpointSpace.SpaceUUID)
+	}
+	return exposed
 }
 
 // UnsetExposeSettings removes the expose settings for the provided list of
 // endpoint names. If the resulting exposed endpoints map for the application
 // becomes empty after the settings are removed, the application will be
 // automatically unexposed.
-func (s *State) UnsetExposeSettings(ctx context.Context, appID coreapplication.ID, exposedEndpoints set.Strings) error {
-	return nil
+func (st *State) UnsetExposeSettings(ctx context.Context, appID coreapplication.ID, exposedEndpoints set.Strings) error {
+	db, err := st.DB()
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		for _, endpoint := range exposedEndpoints.Values() {
+			if err := st.unsetExposedEndpoint(ctx, tx, appID, endpoint); err != nil {
+				return errors.Capture(err)
+			}
+		}
+		return nil
+	})
+
+	return errors.Capture(err)
 }
 
 // MergeExposeSettings marks the application as exposed and merges the provided
 // ExposedEndpoint details into the current set of expose settings. The merge
 // operation will overwrite expose settings for each existing endpoint name.
-func (s *State) MergeExposeSettings(ctx context.Context, appID coreapplication.ID, exposedEndpoints map[string]application.ExposedEndpoint) error {
+func (st *State) MergeExposeSettings(ctx context.Context, appID coreapplication.ID, exposedEndpoints map[string]application.ExposedEndpoint) error {
+	db, err := st.DB()
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		for endpoint, exposedEndpoint := range exposedEndpoints {
+			if err := st.unsetExposedEndpoint(ctx, tx, appID, endpoint); err != nil {
+				return errors.Capture(err)
+			}
+			if err := st.upsertExposedCIDRs(ctx, tx, appID, endpoint, exposedEndpoint.ExposeToCIDRs); err != nil {
+				return errors.Capture(err)
+			}
+			if err := st.upsertExposedSpaces(ctx, tx, appID, endpoint, exposedEndpoint.ExposeToSpaceIDs); err != nil {
+				return errors.Capture(err)
+			}
+		}
+		return nil
+	})
+
+	return errors.Capture(err)
+}
+
+func (st *State) unsetExposedEndpoint(ctx context.Context, tx *sqlair.TX, appID coreapplication.ID, endpoint string) error {
+	if err := st.unsetExposedEndpointCIDRs(ctx, tx, appID, endpoint); err != nil {
+		return errors.Capture(err)
+	}
+	if err := st.unsetExposedEndpointSpaces(ctx, tx, appID, endpoint); err != nil {
+		return errors.Capture(err)
+	}
+	return nil
+}
+
+func (st *State) unsetExposedEndpointCIDRs(ctx context.Context, tx *sqlair.TX, appID coreapplication.ID, endpoint string) error {
+	applicationID := applicationID{ID: appID}
+	endpointName := setEndpointName{Name: endpoint}
+
+	// Since we need to keep referential integrity with respect to the endpoint
+	// as stored in charm_relation, we first check if the provided endpoint is
+	// the wildcard and in that case we simply remove the CIDRs where the
+	// application_endpoint_uuid is NULL.
+	var (
+		unsetExposedCIDRQuery string
+		unsetExposedCIDRStmt  *sqlair.Statement
+		err                   error
+	)
+	if endpoint == wildcardEndpointName {
+		unsetExposedCIDRQuery = `
+DELETE FROM application_exposed_endpoint_cidr
+WHERE application_uuid = $applicationID.uuid
+AND application_endpoint_uuid IS NULL;
+`
+		unsetExposedCIDRStmt, err = st.Prepare(unsetExposedCIDRQuery, applicationID)
+		if err != nil {
+			return errors.Errorf("preparing unset exposed cidr endpoint %q on application %q query: %w", endpoint, appID, err)
+		}
+		if err := tx.Query(ctx, unsetExposedCIDRStmt, applicationID).Run(); err != nil {
+			return errors.Errorf("unsetting exposed cidr endpoint %q on application %q: %w", endpoint, appID, err)
+		}
+	} else {
+		unsetExposedCIDRQuery = `
+DELETE FROM application_exposed_endpoint_cidr
+WHERE application_uuid = $applicationID.uuid 
+AND application_endpoint_uuid IN (
+    SELECT application_endpoint_uuid
+    FROM application_endpoint
+    JOIN charm_relation 
+        ON application_endpoint.charm_relation_uuid = charm_relation.uuid
+    WHERE charm_relation.name = $setEndpointName.name
+    AND application_endpoint.application_uuid = $applicationID.uuid
+);
+`
+		unsetExposedCIDRStmt, err = st.Prepare(unsetExposedCIDRQuery, applicationID, endpointName)
+		if err != nil {
+			return errors.Errorf("preparing unset exposed cidr endpoint %q on application %q query: %w", endpoint, appID, err)
+		}
+		if err := tx.Query(ctx, unsetExposedCIDRStmt, applicationID, endpointName).Run(); err != nil {
+			return errors.Errorf("unsetting exposed cidr endpoint %q on application %q: %w", endpoint, appID, err)
+		}
+	}
+	return nil
+}
+
+func (st *State) unsetExposedEndpointSpaces(ctx context.Context, tx *sqlair.TX, appID coreapplication.ID, endpoint string) error {
+	applicationID := applicationID{ID: appID}
+	endpointName := setEndpointName{Name: endpoint}
+
+	// Since we need to keep referential integrity with respect to the endpoint
+	// as stored in charm_relation, we first check if the provided endpoint is
+	// the wildcard and in that case we simply remove the spaces where the
+	// application_endpoint_uuid is NULL.
+	var (
+		unsetExposedSpaceQuery string
+		unsetExposedSpaceStmt  *sqlair.Statement
+		err                    error
+	)
+	if endpoint == wildcardEndpointName {
+		unsetExposedSpaceQuery = `
+DELETE FROM application_exposed_endpoint_space
+WHERE application_uuid = $applicationID.uuid
+AND application_endpoint_uuid IS NULL;
+`
+		unsetExposedSpaceStmt, err = st.Prepare(unsetExposedSpaceQuery, applicationID)
+		if err != nil {
+			return errors.Errorf("preparing unset exposed space endpoint %q on application %q query: %w", endpoint, appID, err)
+		}
+		if err := tx.Query(ctx, unsetExposedSpaceStmt, applicationID).Run(); err != nil {
+			return errors.Errorf("unsetting exposed space endpoint %q on application %q: %w", endpoint, appID, err)
+		}
+	} else {
+		unsetExposedSpaceQuery = `
+DELETE FROM application_exposed_endpoint_space
+WHERE application_uuid = $applicationID.uuid 
+AND application_endpoint_uuid IN (
+    SELECT application_endpoint_uuid
+    FROM application_endpoint
+    JOIN charm_relation 
+        ON application_endpoint.charm_relation_uuid = charm_relation.uuid
+    WHERE charm_relation.name = $setEndpointName.name
+    AND application_endpoint.application_uuid = $applicationID.uuid
+);
+`
+		unsetExposedSpaceStmt, err := st.Prepare(unsetExposedSpaceQuery, applicationID, endpointName)
+		if err != nil {
+			return errors.Errorf("preparing unset exposed space endpoint %q on application %q query: %w", endpoint, appID, err)
+		}
+		if err := tx.Query(ctx, unsetExposedSpaceStmt, applicationID, endpointName).Run(); err != nil {
+			return errors.Errorf("unsetting exposed space endpoint %q on application %q: %w", endpoint, appID, err)
+		}
+	}
+
+	return nil
+}
+
+func (st *State) upsertExposedSpaces(ctx context.Context, tx *sqlair.TX, appID coreapplication.ID, endpoint string, exposeToSpaceIDs set.Strings) error {
+	if exposeToSpaceIDs.Size() == 0 {
+		return nil
+	}
+
+	var upsertExposedSpaceQuery string
+
+	// Since we need to keep referential integrity with respect to the endpoint
+	// as stored in charm_relation, we first check if the provided endpoint is
+	// the wildcard and in that case we simply insert the spaces and let the
+	// endpoint NULL.
+	if endpoint == wildcardEndpointName {
+		upsertExposedSpaceQuery = `
+INSERT INTO application_exposed_endpoint_space(application_uuid, space_uuid)
+VALUES ($setExposedSpace.application_uuid, $setExposedSpace.space_uuid)
+`
+	} else {
+		upsertExposedSpaceQuery = `
+INSERT INTO application_exposed_endpoint_space(application_uuid, application_endpoint_uuid, space_uuid)
+    SELECT $setExposedSpace.application_uuid, application_endpoint.uuid, $setExposedSpace.space_uuid
+    FROM application_endpoint
+    JOIN charm_relation 
+        ON application_endpoint.charm_relation_uuid = charm_relation.uuid
+    WHERE charm_relation.name = $setExposedSpace.endpoint
+    AND application_endpoint.application_uuid = $setExposedSpace.application_uuid;
+`
+	}
+
+	upsertExposedSpaceStmt, err := st.Prepare(upsertExposedSpaceQuery, setExposedSpace{})
+	if err != nil {
+		return errors.Errorf("preparing insert exposed endpoints to spaces query: %w", err)
+	}
+
+	for _, exposeToSpaceID := range exposeToSpaceIDs.Values() {
+		setExposedSpace := setExposedSpace{
+			ApplicationUUID: appID.String(),
+			EndpointName:    endpoint,
+			SpaceUUID:       exposeToSpaceID,
+		}
+		if err := tx.Query(ctx, upsertExposedSpaceStmt, setExposedSpace).Run(); err != nil {
+			return errors.Errorf("inserting exposed endpoints to spaces: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (st *State) upsertExposedCIDRs(ctx context.Context, tx *sqlair.TX, appID coreapplication.ID, endpoint string, exposeToCIDRs set.Strings) error {
+	if exposeToCIDRs.Size() == 0 {
+		return nil
+	}
+
+	var upsertExposedCIDRQuery string
+
+	// Since we need to keep referential integrity with respect to the endpoint
+	// as stored in charm_relation, we first check if the provided endpoint is
+	// the wildcard and in that case we simply insert the CIDRs and let the
+	// endpoint NULL.
+	if endpoint == wildcardEndpointName {
+		upsertExposedCIDRQuery = `
+INSERT INTO application_exposed_endpoint_cidr(application_uuid, cidr)
+VALUES ($setExposedCIDR.application_uuid, $setExposedCIDR.cidr)
+`
+	} else {
+		upsertExposedCIDRQuery = `
+INSERT INTO application_exposed_endpoint_cidr(application_uuid, application_endpoint_uuid, cidr)
+    SELECT $setExposedCIDR.application_uuid, application_endpoint.uuid, $setExposedCIDR.cidr
+    FROM application_endpoint
+    JOIN charm_relation 
+        ON application_endpoint.charm_relation_uuid = charm_relation.uuid
+    WHERE charm_relation.name = $setExposedCIDR.endpoint
+    AND application_endpoint.application_uuid = $setExposedCIDR.application_uuid;
+`
+	}
+
+	setExposedCIDR := setExposedCIDR{
+		ApplicationUUID: appID.String(),
+		EndpointName:    endpoint,
+	}
+	upsertExposedCIDRStmt, err := st.Prepare(upsertExposedCIDRQuery, setExposedCIDR)
+	if err != nil {
+		return errors.Errorf("preparing insert exposed endpoints to CIDRs query: %w", err)
+	}
+
+	for _, exposeToCIDR := range exposeToCIDRs.Values() {
+		setExposedCIDR.CIDR = exposeToCIDR
+		if err := tx.Query(ctx, upsertExposedCIDRStmt, setExposedCIDR).Run(); err != nil {
+			return errors.Errorf("inserting exposed endpoints to CIDRs: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// EndpointsExist returns an error satisfying
+// [applicationerrors.EndpointNotFound] if any of the provided endpoints do not
+// exist.
+func (st *State) EndpointsExist(ctx context.Context, appID coreapplication.ID, endpoints set.Strings) error {
+	db, err := st.DB()
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	type charmRelationName []string
+	eps := charmRelationName(endpoints.Values())
+
+	query := `
+SELECT COUNT(*) AS &countResult.count
+FROM application_endpoint
+LEFT JOIN charm_relation ON application_endpoint.charm_relation_uuid = charm_relation.uuid
+WHERE application_endpoint.application_uuid = $applicationID.uuid AND
+charm_relation.name IN ($charmRelationName[:]);
+	`
+	applicationID := applicationID{ID: appID}
+	stmt, err := st.Prepare(query, countResult{}, applicationID, eps)
+	if err != nil {
+		return errors.Errorf("preparing endpoint exists query: %w", err)
+	}
+
+	var count countResult
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		if err := tx.Query(ctx, stmt, applicationID, eps).Get(&count); err != nil {
+			return errors.Errorf("checking if endpoints %+v exist: %w", endpoints.Values(), err)
+		}
+		return nil
+	})
+
+	if err != nil {
+		return errors.Capture(err)
+	}
+	if count.Count != endpoints.Size() {
+		return errors.Errorf("endpoints %+v do not exist", endpoints.Values()).
+			Add(applicationerrors.EndpointNotFound)
+	}
+	return nil
+}
+
+// SpacesExist returns an error satisfying [networkerrors.SpaceNotFound] if any
+// of the provided spaces do not exist.
+func (st *State) SpacesExist(ctx context.Context, spaceUUIDs set.Strings) error {
+	db, err := st.DB()
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	type spaces []string
+	sps := spaces(spaceUUIDs.Values())
+
+	query := `
+SELECT COUNT(*) AS &countResult.count
+FROM space
+WHERE uuid IN ($spaces[:]);
+	`
+	stmt, err := st.Prepare(query, countResult{}, sps)
+	if err != nil {
+		return errors.Errorf("preparing space exists query: %w", err)
+	}
+
+	var count countResult
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		if err := tx.Query(ctx, stmt, sps).Get(&count); err != nil {
+			return errors.Errorf("checking if spaces %+v exist: %w", spaceUUIDs.Values(), err)
+		}
+		return nil
+	})
+
+	if err != nil {
+		return errors.Capture(err)
+	}
+	if count.Count != spaceUUIDs.Size() {
+		return errors.Errorf("spaces %+v do not exist", spaceUUIDs.Values()).
+			Add(networkerrors.SpaceNotFound)
+	}
 	return nil
 }

--- a/domain/application/state/exposed.go
+++ b/domain/application/state/exposed.go
@@ -65,22 +65,12 @@ func (st *State) GetExposedEndpoints(ctx context.Context, appID coreapplication.
 	query := `
 SELECT 
     cr.name AS &endpointCIDRsSpaces.name,
-    ec.cidr AS &endpointCIDRsSpaces.cidr,
-    es.space_uuid AS &endpointCIDRsSpaces.space_uuid
-FROM v_application_exposed_endpoint ax
-LEFT JOIN application_endpoint ae ON ax.application_endpoint_uuid = ae.uuid
+    cidr AS &endpointCIDRsSpaces.cidr,
+    e.space_uuid AS &endpointCIDRsSpaces.space_uuid
+FROM v_application_exposed_endpoint e
+LEFT JOIN application_endpoint ae ON e.application_endpoint_uuid = ae.uuid
 LEFT JOIN charm_relation cr ON ae.charm_relation_uuid = cr.uuid
-LEFT JOIN application_exposed_endpoint_cidr ec ON 
-    (ax.application_endpoint_uuid = ec.application_endpoint_uuid OR
-    ax.application_endpoint_uuid IS NULL AND 
-    ec.application_endpoint_uuid IS NULL AND 
-    ec.application_uuid = $applicationID.uuid)
-LEFT JOIN application_exposed_endpoint_space es ON 
-    (ax.application_endpoint_uuid = es.application_endpoint_uuid OR
-    ax.application_endpoint_uuid IS NULL AND 
-    es.application_endpoint_uuid IS NULL AND 
-    es.application_uuid = $applicationID.uuid)
-WHERE ax.application_uuid = $applicationID.uuid;
+WHERE e.application_uuid = $applicationID.uuid;
 	`
 	stmt, err := st.Prepare(query, endpointCIDRsSpaces{}, ident)
 	if err != nil {

--- a/domain/application/state/exposed_test.go
+++ b/domain/application/state/exposed_test.go
@@ -36,7 +36,7 @@ func (s *exposedStateSuite) SetUpTest(c *gc.C) {
 func (s *exposedStateSuite) TestApplicationNotExposed(c *gc.C) {
 	appUUID := coreapplication.ID(uuid.MustNewUUID().String())
 
-	isExposed, err := s.state.ApplicationExposed(context.Background(), appUUID)
+	isExposed, err := s.state.IsApplicationExposed(context.Background(), appUUID)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(isExposed, jc.IsFalse)
 }
@@ -46,7 +46,7 @@ func (s *exposedStateSuite) TestApplicationExposedToSpace(c *gc.C) {
 	s.setUpEndpoint(c, appID)
 	s.createExposedEndpointSpace(c, appID)
 
-	isExposed, err := s.state.ApplicationExposed(context.Background(), appID)
+	isExposed, err := s.state.IsApplicationExposed(context.Background(), appID)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(isExposed, jc.IsTrue)
 }
@@ -56,7 +56,7 @@ func (s *exposedStateSuite) TestApplicationExposedCIDR(c *gc.C) {
 	s.setUpEndpoint(c, appID)
 	s.createExposedEndpointCIDR(c, appID, "10.0.0.0/24")
 
-	isExposed, err := s.state.ApplicationExposed(context.Background(), appID)
+	isExposed, err := s.state.IsApplicationExposed(context.Background(), appID)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(isExposed, jc.IsTrue)
 }
@@ -118,7 +118,7 @@ func (s *exposedStateSuite) TestExposedEndpointsWithWildcard(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	isExposed, err := s.state.ApplicationExposed(context.Background(), appID)
+	isExposed, err := s.state.IsApplicationExposed(context.Background(), appID)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(isExposed, jc.IsTrue)
 
@@ -141,7 +141,7 @@ func (s *exposedStateSuite) TestExposedEndpointsWithWildcardMultipleTimes(c *gc.
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	isExposed, err := s.state.ApplicationExposed(context.Background(), appID)
+	isExposed, err := s.state.IsApplicationExposed(context.Background(), appID)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(isExposed, jc.IsTrue)
 
@@ -158,7 +158,7 @@ func (s *exposedStateSuite) TestExposedEndpointsWithWildcardMultipleTimes(c *gc.
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	isExposed, err = s.state.ApplicationExposed(context.Background(), appID)
+	isExposed, err = s.state.IsApplicationExposed(context.Background(), appID)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(isExposed, jc.IsTrue)
 
@@ -229,14 +229,14 @@ func (s *exposedStateSuite) TestUnsetExposeSettings(c *gc.C) {
 	s.createExposedEndpointSpace(c, appID)
 	s.createExposedEndpointCIDR(c, appID, "10.0.0.0/24")
 
-	isExposed, err := s.state.ApplicationExposed(context.Background(), appID)
+	isExposed, err := s.state.IsApplicationExposed(context.Background(), appID)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(isExposed, jc.IsTrue)
 
 	err = s.state.UnsetExposeSettings(context.Background(), appID, set.NewStrings("endpoint0"))
 	c.Assert(err, jc.ErrorIsNil)
 
-	isExposed, err = s.state.ApplicationExposed(context.Background(), appID)
+	isExposed, err = s.state.IsApplicationExposed(context.Background(), appID)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(isExposed, jc.IsFalse)
 }
@@ -257,7 +257,7 @@ func (s *exposedStateSuite) TestUnsetExposeSettingsOnlyOneEndpoint(c *gc.C) {
 	err = s.state.UnsetExposeSettings(context.Background(), appID, set.NewStrings("endpoint0"))
 	c.Assert(err, jc.ErrorIsNil)
 
-	isExposed, err := s.state.ApplicationExposed(context.Background(), appID)
+	isExposed, err := s.state.IsApplicationExposed(context.Background(), appID)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(isExposed, jc.IsTrue)
 
@@ -272,7 +272,7 @@ func (s *exposedStateSuite) TestMergeExposeSettingsNewEntry(c *gc.C) {
 	appID := s.createApplication(c, "foo", life.Alive)
 	s.setUpEndpoint(c, appID)
 
-	isExposed, err := s.state.ApplicationExposed(context.Background(), appID)
+	isExposed, err := s.state.IsApplicationExposed(context.Background(), appID)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(isExposed, jc.IsFalse)
 
@@ -284,7 +284,7 @@ func (s *exposedStateSuite) TestMergeExposeSettingsNewEntry(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	isExposed, err = s.state.ApplicationExposed(context.Background(), appID)
+	isExposed, err = s.state.IsApplicationExposed(context.Background(), appID)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(isExposed, jc.IsTrue)
 
@@ -307,7 +307,7 @@ func (s *exposedStateSuite) TestMergeExposeSettingsExistingOverwriteCIDR(c *gc.C
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	isExposed, err := s.state.ApplicationExposed(context.Background(), appID)
+	isExposed, err := s.state.IsApplicationExposed(context.Background(), appID)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(isExposed, jc.IsTrue)
 
@@ -339,7 +339,7 @@ func (s *exposedStateSuite) TestMergeExposeSettingsExistingOverwriteSpace(c *gc.
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	isExposed, err := s.state.ApplicationExposed(context.Background(), appID)
+	isExposed, err := s.state.IsApplicationExposed(context.Background(), appID)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(isExposed, jc.IsTrue)
 
@@ -363,7 +363,7 @@ func (s *exposedStateSuite) TestMergeExposeSettingsWildcard(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	isExposed, err := s.state.ApplicationExposed(context.Background(), appID)
+	isExposed, err := s.state.IsApplicationExposed(context.Background(), appID)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(isExposed, jc.IsFalse)
 
@@ -375,7 +375,7 @@ func (s *exposedStateSuite) TestMergeExposeSettingsWildcard(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	isExposed, err = s.state.ApplicationExposed(context.Background(), appID)
+	isExposed, err = s.state.IsApplicationExposed(context.Background(), appID)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(isExposed, jc.IsTrue)
 
@@ -399,26 +399,26 @@ func (s *exposedStateSuite) TestMergeExposeSettingsWildcardOverwrite(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	isExposed, err := s.state.ApplicationExposed(context.Background(), appID)
+	isExposed, err := s.state.IsApplicationExposed(context.Background(), appID)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(isExposed, jc.IsFalse)
 
 	err = s.state.MergeExposeSettings(context.Background(), appID, map[string]application.ExposedEndpoint{
 		"": {
 			ExposeToCIDRs:    set.NewStrings("192.168.0.0/24", "192.168.1.0/24"),
-			ExposeToSpaceIDs: set.NewStrings("space1-uuid"),
+			ExposeToSpaceIDs: set.NewStrings("space0-uuid", "space1-uuid"),
 		},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	isExposed, err = s.state.ApplicationExposed(context.Background(), appID)
+	isExposed, err = s.state.IsApplicationExposed(context.Background(), appID)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(isExposed, jc.IsTrue)
 
 	exposedEndpoints, err := s.state.GetExposedEndpoints(context.Background(), appID)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(exposedEndpoints[""].ExposeToCIDRs.SortedValues(), gc.DeepEquals, []string{"192.168.0.0/24", "192.168.1.0/24"})
-	c.Check(exposedEndpoints[""].ExposeToSpaceIDs.SortedValues(), gc.DeepEquals, []string{"space1-uuid"})
+	c.Check(exposedEndpoints[""].ExposeToSpaceIDs.SortedValues(), gc.DeepEquals, []string{"space0-uuid", "space1-uuid"})
 
 	// Overwrite the wildcard endpoint.
 	err = s.state.MergeExposeSettings(context.Background(), appID, map[string]application.ExposedEndpoint{
@@ -428,7 +428,7 @@ func (s *exposedStateSuite) TestMergeExposeSettingsWildcardOverwrite(c *gc.C) {
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	isExposed, err = s.state.ApplicationExposed(context.Background(), appID)
+	isExposed, err = s.state.IsApplicationExposed(context.Background(), appID)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(isExposed, jc.IsTrue)
 
@@ -457,7 +457,7 @@ func (s *exposedStateSuite) TestMergeExposeSettingsDifferentEndpointsNotOverwrit
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	isExposed, err := s.state.ApplicationExposed(context.Background(), appID)
+	isExposed, err := s.state.IsApplicationExposed(context.Background(), appID)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(isExposed, jc.IsFalse)
 
@@ -469,7 +469,7 @@ func (s *exposedStateSuite) TestMergeExposeSettingsDifferentEndpointsNotOverwrit
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	isExposed, err = s.state.ApplicationExposed(context.Background(), appID)
+	isExposed, err = s.state.IsApplicationExposed(context.Background(), appID)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(isExposed, jc.IsTrue)
 
@@ -486,7 +486,7 @@ func (s *exposedStateSuite) TestMergeExposeSettingsDifferentEndpointsNotOverwrit
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	isExposed, err = s.state.ApplicationExposed(context.Background(), appID)
+	isExposed, err = s.state.IsApplicationExposed(context.Background(), appID)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(isExposed, jc.IsTrue)
 
@@ -501,7 +501,6 @@ func (s *exposedStateSuite) TestMergeExposeSettingsDifferentEndpointsNotOverwrit
 
 func (s *exposedStateSuite) setUpEndpoint(c *gc.C, appID coreapplication.ID) {
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
-
 		insertSpace := `INSERT INTO space (uuid, name) VALUES (?, ?)`
 		_, err := tx.ExecContext(ctx, insertSpace, "space0-uuid", "space0")
 		if err != nil {

--- a/domain/application/state/exposed_test.go
+++ b/domain/application/state/exposed_test.go
@@ -443,8 +443,8 @@ func (s *exposedStateSuite) TestMergeExposeSettingsDifferentEndpointsNotOverwrit
 	s.setUpEndpoint(c, appID)
 	// Create a new endpoint
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
-		insertCharmRelation := `INSERT INTO charm_relation (uuid, charm_uuid, kind_id, name) VALUES (?, ?, ?, ?)`
-		_, err := tx.ExecContext(ctx, insertCharmRelation, "charm-relation1-uuid", "charm0-uuid", "0", "endpoint1")
+		insertCharmRelation := `INSERT INTO charm_relation (uuid, charm_uuid, kind_id, scope_id, role_id, name) VALUES (?, ?, ?, ?, ?, ?)`
+		_, err := tx.ExecContext(ctx, insertCharmRelation, "charm-relation1-uuid", "charm0-uuid", "0", "0", "0", "endpoint1")
 		if err != nil {
 			return err
 		}
@@ -511,8 +511,8 @@ func (s *exposedStateSuite) setUpEndpoint(c *gc.C, appID coreapplication.ID) {
 		if err != nil {
 			return err
 		}
-		insertCharmRelation := `INSERT INTO charm_relation (uuid, charm_uuid, kind_id, name) VALUES (?, ?, ?, ?)`
-		_, err = tx.ExecContext(ctx, insertCharmRelation, "charm-relation0-uuid", "charm0-uuid", "0", "endpoint0")
+		insertCharmRelation := `INSERT INTO charm_relation (uuid, charm_uuid, kind_id, scope_id, role_id, name) VALUES (?, ?, ?, ?, ?, ?)`
+		_, err = tx.ExecContext(ctx, insertCharmRelation, "charm-relation0-uuid", "charm0-uuid", "0", "0", "0", "endpoint0")
 		if err != nil {
 			return err
 		}

--- a/domain/application/state/exposed_test.go
+++ b/domain/application/state/exposed_test.go
@@ -1,0 +1,498 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/juju/clock"
+	"github.com/juju/collections/set"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	coreapplication "github.com/juju/juju/core/application"
+	"github.com/juju/juju/domain/application"
+	"github.com/juju/juju/domain/life"
+	loggertesting "github.com/juju/juju/internal/logger/testing"
+	"github.com/juju/juju/internal/uuid"
+)
+
+type exposedStateSuite struct {
+	baseSuite
+
+	state *State
+}
+
+var _ = gc.Suite(&exposedStateSuite{})
+
+func (s *exposedStateSuite) SetUpTest(c *gc.C) {
+	s.baseSuite.SetUpTest(c)
+
+	s.state = NewState(s.TxnRunnerFactory(), clock.WallClock, loggertesting.WrapCheckLog(c))
+}
+
+func (s *exposedStateSuite) TestApplicationNotExposed(c *gc.C) {
+	appUUID := coreapplication.ID(uuid.MustNewUUID().String())
+
+	isExposed, err := s.state.ApplicationExposed(context.Background(), appUUID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(isExposed, jc.IsFalse)
+}
+
+func (s *exposedStateSuite) TestApplicationExposedToSpace(c *gc.C) {
+	appID := s.createApplication(c, "foo", life.Alive)
+	s.setUpEndpoint(c, appID)
+	s.createExposedEndpointSpace(c, appID)
+
+	isExposed, err := s.state.ApplicationExposed(context.Background(), appID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(isExposed, jc.IsTrue)
+}
+
+func (s *exposedStateSuite) TestApplicationExposedCIDR(c *gc.C) {
+	appID := s.createApplication(c, "foo", life.Alive)
+	s.setUpEndpoint(c, appID)
+	s.createExposedEndpointCIDR(c, appID, "10.0.0.0/24")
+
+	isExposed, err := s.state.ApplicationExposed(context.Background(), appID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(isExposed, jc.IsTrue)
+}
+
+func (s *exposedStateSuite) TestExposedEndpointsEmpty(c *gc.C) {
+	appID := s.createApplication(c, "foo", life.Alive)
+	s.setUpEndpoint(c, appID)
+
+	exposedEndpoints, err := s.state.GetExposedEndpoints(context.Background(), appID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(exposedEndpoints, gc.IsNil)
+}
+
+func (s *exposedStateSuite) TestExposedEndpointsOnlySpace(c *gc.C) {
+	appID := s.createApplication(c, "foo", life.Alive)
+	s.setUpEndpoint(c, appID)
+	s.createExposedEndpointSpace(c, appID)
+
+	exposedEndpoints, err := s.state.GetExposedEndpoints(context.Background(), appID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(len(exposedEndpoints), gc.Equals, 1)
+	c.Check(exposedEndpoints["endpoint0"].ExposeToSpaceIDs.SortedValues(), gc.DeepEquals, []string{"space0-uuid"})
+}
+
+func (s *exposedStateSuite) TestExposedEndpointsOnlyCIDR(c *gc.C) {
+	appID := s.createApplication(c, "foo", life.Alive)
+	s.setUpEndpoint(c, appID)
+	s.createExposedEndpointCIDR(c, appID, "10.0.0.0/24")
+
+	exposedEndpoints, err := s.state.GetExposedEndpoints(context.Background(), appID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(len(exposedEndpoints), gc.Equals, 1)
+	c.Check(exposedEndpoints["endpoint0"].ExposeToCIDRs.SortedValues(), gc.DeepEquals, []string{"10.0.0.0/24"})
+}
+
+func (s *exposedStateSuite) TestExposedEndpointsFull(c *gc.C) {
+	appID := s.createApplication(c, "foo", life.Alive)
+	s.setUpEndpoint(c, appID)
+	s.createExposedEndpointSpace(c, appID)
+	s.createExposedEndpointCIDR(c, appID, "10.0.0.0/24")
+	s.createExposedEndpointCIDR(c, appID, "10.0.1.0/24")
+
+	exposedEndpoints, err := s.state.GetExposedEndpoints(context.Background(), appID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(len(exposedEndpoints), gc.Equals, 1)
+	c.Check(exposedEndpoints["endpoint0"].ExposeToCIDRs.SortedValues(), gc.DeepEquals, []string{"10.0.0.0/24", "10.0.1.0/24"})
+	c.Check(exposedEndpoints["endpoint0"].ExposeToSpaceIDs.SortedValues(), gc.DeepEquals, []string{"space0-uuid"})
+}
+
+func (s *exposedStateSuite) TestExposedEndpointsWithWildcard(c *gc.C) {
+	appID := s.createApplication(c, "foo", life.Alive)
+	s.setUpEndpoint(c, appID)
+
+	err := s.state.MergeExposeSettings(context.Background(), appID, map[string]application.ExposedEndpoint{
+		"": {
+			ExposeToSpaceIDs: set.NewStrings("space0-uuid"),
+			ExposeToCIDRs:    set.NewStrings("192.168.0.0/24", "192.168.1.0/24"),
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	isExposed, err := s.state.ApplicationExposed(context.Background(), appID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(isExposed, jc.IsTrue)
+
+	exposedEndpoints, err := s.state.GetExposedEndpoints(context.Background(), appID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(len(exposedEndpoints), gc.Equals, 1)
+	c.Check(exposedEndpoints[""].ExposeToCIDRs.SortedValues(), gc.DeepEquals, []string{"192.168.0.0/24", "192.168.1.0/24"})
+	c.Check(exposedEndpoints[""].ExposeToSpaceIDs.SortedValues(), gc.DeepEquals, []string{"space0-uuid"})
+}
+
+func (s *exposedStateSuite) TestExposedEndpointsWithWildcardMultipleTimes(c *gc.C) {
+	appID := s.createApplication(c, "foo", life.Alive)
+	s.setUpEndpoint(c, appID)
+
+	err := s.state.MergeExposeSettings(context.Background(), appID, map[string]application.ExposedEndpoint{
+		"": {
+			ExposeToSpaceIDs: set.NewStrings("space0-uuid"),
+			ExposeToCIDRs:    set.NewStrings("192.168.0.0/24", "192.168.1.0/24"),
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	isExposed, err := s.state.ApplicationExposed(context.Background(), appID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(isExposed, jc.IsTrue)
+
+	exposedEndpoints, err := s.state.GetExposedEndpoints(context.Background(), appID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(len(exposedEndpoints), gc.Equals, 1)
+	c.Check(exposedEndpoints[""].ExposeToCIDRs.SortedValues(), gc.DeepEquals, []string{"192.168.0.0/24", "192.168.1.0/24"})
+	c.Check(exposedEndpoints[""].ExposeToSpaceIDs.SortedValues(), gc.DeepEquals, []string{"space0-uuid"})
+
+	err = s.state.MergeExposeSettings(context.Background(), appID, map[string]application.ExposedEndpoint{
+		"": {
+			ExposeToCIDRs: set.NewStrings("10.0.0.0/24", "10.0.1.0/24"),
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	isExposed, err = s.state.ApplicationExposed(context.Background(), appID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(isExposed, jc.IsTrue)
+
+	exposedEndpoints, err = s.state.GetExposedEndpoints(context.Background(), appID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(len(exposedEndpoints), gc.Equals, 1)
+	c.Check(exposedEndpoints[""].ExposeToCIDRs.SortedValues(), gc.DeepEquals, []string{"10.0.0.0/24", "10.0.1.0/24"})
+	c.Check(exposedEndpoints[""].ExposeToSpaceIDs.IsEmpty(), jc.IsTrue)
+}
+
+func (s *exposedStateSuite) TestEndpointsOneNotExists(c *gc.C) {
+	appID := s.createApplication(c, "foo", life.Alive)
+	s.setUpEndpoint(c, appID)
+	s.createExposedEndpointSpace(c, appID)
+
+	err := s.state.EndpointsExist(context.Background(), appID, set.NewStrings("endpoint0", "unknown-endpoint"))
+	c.Assert(err, gc.ErrorMatches, "endpoint not found")
+}
+
+func (s *exposedStateSuite) TestEndpointsAllNotExists(c *gc.C) {
+	appID := s.createApplication(c, "foo", life.Alive)
+	s.setUpEndpoint(c, appID)
+	s.createExposedEndpointCIDR(c, appID, "10.0.0.0/24")
+
+	err := s.state.EndpointsExist(context.Background(), appID, set.NewStrings("missing-endpoint", "unknown-endpoint"))
+	c.Assert(err, gc.ErrorMatches, "endpoint not found")
+}
+
+func (s *exposedStateSuite) TestEndpointsExist(c *gc.C) {
+	appID := s.createApplication(c, "foo", life.Alive)
+	s.setUpEndpoint(c, appID)
+	s.createExposedEndpointSpace(c, appID)
+
+	err := s.state.EndpointsExist(context.Background(), appID, set.NewStrings("endpoint0"))
+	c.Assert(err, gc.IsNil)
+}
+
+func (s *exposedStateSuite) TestSpacesOneNotExists(c *gc.C) {
+	appID := s.createApplication(c, "foo", life.Alive)
+	s.setUpEndpoint(c, appID)
+	s.createExposedEndpointSpace(c, appID)
+
+	err := s.state.SpacesExist(context.Background(), set.NewStrings("space0-uuid", "unknown-space"))
+	c.Assert(err, gc.ErrorMatches, "space not found")
+}
+
+func (s *exposedStateSuite) TestSpacesAllNotExists(c *gc.C) {
+	appID := s.createApplication(c, "foo", life.Alive)
+	s.setUpEndpoint(c, appID)
+	s.createExposedEndpointCIDR(c, appID, "10.0.0.0/24")
+
+	err := s.state.SpacesExist(context.Background(), set.NewStrings("missing-space", "unknown-space"))
+	c.Assert(err, gc.ErrorMatches, "space not found")
+}
+
+func (s *exposedStateSuite) TestSpacesExist(c *gc.C) {
+	appID := s.createApplication(c, "foo", life.Alive)
+	s.setUpEndpoint(c, appID)
+	s.createExposedEndpointSpace(c, appID)
+
+	err := s.state.SpacesExist(context.Background(), set.NewStrings("space0-uuid"))
+	c.Assert(err, gc.IsNil)
+}
+
+func (s *exposedStateSuite) TestUnsetExposeSettings(c *gc.C) {
+	appID := s.createApplication(c, "foo", life.Alive)
+	s.setUpEndpoint(c, appID)
+	s.createExposedEndpointSpace(c, appID)
+	s.createExposedEndpointCIDR(c, appID, "10.0.0.0/24")
+
+	isExposed, err := s.state.ApplicationExposed(context.Background(), appID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(isExposed, jc.IsTrue)
+
+	err = s.state.UnsetExposeSettings(context.Background(), appID, set.NewStrings("endpoint0"))
+	c.Assert(err, jc.ErrorIsNil)
+
+	isExposed, err = s.state.ApplicationExposed(context.Background(), appID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(isExposed, jc.IsFalse)
+}
+
+func (s *exposedStateSuite) TestUnsetExposeSettingsOnlyOneEndpoint(c *gc.C) {
+	appID := s.createApplication(c, "foo", life.Alive)
+	s.setUpEndpoint(c, appID)
+	s.createExposedEndpointSpace(c, appID)
+	s.createExposedEndpointCIDR(c, appID, "10.0.0.0/24")
+
+	err := s.state.MergeExposeSettings(context.Background(), appID, map[string]application.ExposedEndpoint{
+		"": {
+			ExposeToCIDRs: set.NewStrings("192.168.0.0/24", "192.168.1.0/24"),
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.state.UnsetExposeSettings(context.Background(), appID, set.NewStrings("endpoint0"))
+	c.Assert(err, jc.ErrorIsNil)
+
+	isExposed, err := s.state.ApplicationExposed(context.Background(), appID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(isExposed, jc.IsTrue)
+
+	exposedEndpoints, err := s.state.GetExposedEndpoints(context.Background(), appID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(len(exposedEndpoints), gc.Equals, 1)
+	c.Check(exposedEndpoints[""].ExposeToCIDRs.SortedValues(), gc.DeepEquals, []string{"192.168.0.0/24", "192.168.1.0/24"})
+	c.Check(exposedEndpoints[""].ExposeToSpaceIDs.IsEmpty(), jc.IsTrue)
+}
+
+func (s *exposedStateSuite) TestMergeExposeSettingsNewEntry(c *gc.C) {
+	appID := s.createApplication(c, "foo", life.Alive)
+	s.setUpEndpoint(c, appID)
+
+	isExposed, err := s.state.ApplicationExposed(context.Background(), appID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(isExposed, jc.IsFalse)
+
+	err = s.state.MergeExposeSettings(context.Background(), appID, map[string]application.ExposedEndpoint{
+		"endpoint0": {
+			ExposeToSpaceIDs: set.NewStrings("space0-uuid"),
+			ExposeToCIDRs:    set.NewStrings("10.0.0.0/24", "10.0.1.0/24"),
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	isExposed, err = s.state.ApplicationExposed(context.Background(), appID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(isExposed, jc.IsTrue)
+
+	exposedEndpoints, err := s.state.GetExposedEndpoints(context.Background(), appID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(exposedEndpoints["endpoint0"].ExposeToCIDRs.SortedValues(), gc.DeepEquals, []string{"10.0.0.0/24", "10.0.1.0/24"})
+	c.Check(exposedEndpoints["endpoint0"].ExposeToSpaceIDs.SortedValues(), gc.DeepEquals, []string{"space0-uuid"})
+}
+
+func (s *exposedStateSuite) TestMergeExposeSettingsExistingOverwriteCIDR(c *gc.C) {
+	appID := s.createApplication(c, "foo", life.Alive)
+	s.setUpEndpoint(c, appID)
+	s.createExposedEndpointSpace(c, appID)
+	s.createExposedEndpointCIDR(c, appID, "10.0.0.0/24")
+
+	err := s.state.MergeExposeSettings(context.Background(), appID, map[string]application.ExposedEndpoint{
+		"endpoint0": {
+			ExposeToCIDRs: set.NewStrings("192.168.0.0/24", "192.168.1.0/24"),
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	isExposed, err := s.state.ApplicationExposed(context.Background(), appID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(isExposed, jc.IsTrue)
+
+	exposedEndpoints, err := s.state.GetExposedEndpoints(context.Background(), appID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(exposedEndpoints["endpoint0"].ExposeToCIDRs.SortedValues(), gc.DeepEquals, []string{"192.168.0.0/24", "192.168.1.0/24"})
+	c.Check(exposedEndpoints["endpoint0"].ExposeToSpaceIDs.IsEmpty(), jc.IsTrue)
+}
+
+func (s *exposedStateSuite) TestMergeExposeSettingsExistingOverwriteSpace(c *gc.C) {
+	appID := s.createApplication(c, "foo", life.Alive)
+	s.setUpEndpoint(c, appID)
+	s.createExposedEndpointSpace(c, appID)
+	// Create a new space
+	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		insertSpace := `INSERT INTO space (uuid, name) VALUES (?, ?)`
+		_, err := tx.ExecContext(ctx, insertSpace, "space1-uuid", "space1")
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.state.MergeExposeSettings(context.Background(), appID, map[string]application.ExposedEndpoint{
+		"endpoint0": {
+			ExposeToSpaceIDs: set.NewStrings("space1-uuid"),
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	isExposed, err := s.state.ApplicationExposed(context.Background(), appID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(isExposed, jc.IsTrue)
+
+	exposedEndpoints, err := s.state.GetExposedEndpoints(context.Background(), appID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(exposedEndpoints["endpoint0"].ExposeToCIDRs.IsEmpty(), jc.IsTrue)
+	c.Check(exposedEndpoints["endpoint0"].ExposeToSpaceIDs.SortedValues(), gc.DeepEquals, []string{"space1-uuid"})
+}
+
+func (s *exposedStateSuite) TestMergeExposeSettingsWildcard(c *gc.C) {
+	appID := s.createApplication(c, "foo", life.Alive)
+	s.setUpEndpoint(c, appID)
+	// Create a new space
+	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		insertSpace := `INSERT INTO space (uuid, name) VALUES (?, ?)`
+		_, err := tx.ExecContext(ctx, insertSpace, "space1-uuid", "space1")
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	isExposed, err := s.state.ApplicationExposed(context.Background(), appID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(isExposed, jc.IsFalse)
+
+	err = s.state.MergeExposeSettings(context.Background(), appID, map[string]application.ExposedEndpoint{
+		"": {
+			ExposeToCIDRs:    set.NewStrings("192.168.0.0/24", "192.168.1.0/24"),
+			ExposeToSpaceIDs: set.NewStrings("space1-uuid"),
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	isExposed, err = s.state.ApplicationExposed(context.Background(), appID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(isExposed, jc.IsTrue)
+
+	exposedEndpoints, err := s.state.GetExposedEndpoints(context.Background(), appID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(exposedEndpoints[""].ExposeToCIDRs.SortedValues(), gc.DeepEquals, []string{"192.168.0.0/24", "192.168.1.0/24"})
+	c.Check(exposedEndpoints[""].ExposeToSpaceIDs.SortedValues(), gc.DeepEquals, []string{"space1-uuid"})
+}
+
+func (s *exposedStateSuite) TestMergeExposeSettingsWildcardOverwrite(c *gc.C) {
+	appID := s.createApplication(c, "foo", life.Alive)
+	s.setUpEndpoint(c, appID)
+	// Create a new space
+	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		insertSpace := `INSERT INTO space (uuid, name) VALUES (?, ?)`
+		_, err := tx.ExecContext(ctx, insertSpace, "space1-uuid", "space1")
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	isExposed, err := s.state.ApplicationExposed(context.Background(), appID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(isExposed, jc.IsFalse)
+
+	err = s.state.MergeExposeSettings(context.Background(), appID, map[string]application.ExposedEndpoint{
+		"": {
+			ExposeToCIDRs:    set.NewStrings("192.168.0.0/24", "192.168.1.0/24"),
+			ExposeToSpaceIDs: set.NewStrings("space1-uuid"),
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	isExposed, err = s.state.ApplicationExposed(context.Background(), appID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(isExposed, jc.IsTrue)
+
+	exposedEndpoints, err := s.state.GetExposedEndpoints(context.Background(), appID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(exposedEndpoints[""].ExposeToCIDRs.SortedValues(), gc.DeepEquals, []string{"192.168.0.0/24", "192.168.1.0/24"})
+	c.Check(exposedEndpoints[""].ExposeToSpaceIDs.SortedValues(), gc.DeepEquals, []string{"space1-uuid"})
+
+	// Overwrite the wildcard endpoint.
+	err = s.state.MergeExposeSettings(context.Background(), appID, map[string]application.ExposedEndpoint{
+		"": {
+			ExposeToCIDRs: set.NewStrings("10.0.0.0/24", "10.0.1.0/24"),
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	isExposed, err = s.state.ApplicationExposed(context.Background(), appID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(isExposed, jc.IsTrue)
+
+	exposedEndpoints, err = s.state.GetExposedEndpoints(context.Background(), appID)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(exposedEndpoints[""].ExposeToCIDRs.SortedValues(), gc.DeepEquals, []string{"10.0.0.0/24", "10.0.1.0/24"})
+	c.Check(exposedEndpoints[""].ExposeToSpaceIDs.IsEmpty(), jc.IsTrue)
+}
+
+func (s *exposedStateSuite) setUpEndpoint(c *gc.C, appID coreapplication.ID) {
+	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+
+		insertSpace := `INSERT INTO space (uuid, name) VALUES (?, ?)`
+		_, err := tx.ExecContext(ctx, insertSpace, "space0-uuid", "space0")
+		if err != nil {
+			return err
+		}
+		insertCharm := `INSERT INTO charm (uuid, reference_name) VALUES (?, ?)`
+		_, err = tx.ExecContext(ctx, insertCharm, "charm0-uuid", "foo")
+		if err != nil {
+			return err
+		}
+		insertCharmRelation := `INSERT INTO charm_relation (uuid, charm_uuid, kind_id, name) VALUES (?, ?, ?, ?)`
+		_, err = tx.ExecContext(ctx, insertCharmRelation, "charm-relation0-uuid", "charm0-uuid", "0", "endpoint0")
+		if err != nil {
+			return err
+		}
+		insertEndpoint := `INSERT INTO application_endpoint (uuid, application_uuid, space_uuid, charm_relation_uuid) VALUES (?, ?, ?, ?)`
+		_, err = tx.ExecContext(ctx, insertEndpoint, "app-endpoint0-uuid", appID, "space0-uuid", "charm-relation0-uuid")
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+}
+
+func (s *exposedStateSuite) createExposedEndpointSpace(c *gc.C, appID coreapplication.ID) {
+	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		insertExposedSpace := `
+INSERT INTO application_exposed_endpoint_space
+(application_uuid, application_endpoint_uuid, space_uuid)
+VALUES (?, ?, ?)`
+		_, err := tx.ExecContext(ctx, insertExposedSpace, appID, "app-endpoint0-uuid", "space0-uuid")
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *exposedStateSuite) createExposedEndpointCIDR(c *gc.C, appID coreapplication.ID, cidr string) {
+	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		insertExposedCIDR := `
+INSERT INTO application_exposed_endpoint_cidr
+(application_uuid, application_endpoint_uuid, cidr)
+VALUES (?, ?, ?)`
+		_, err := tx.ExecContext(ctx, insertExposedCIDR, appID, "app-endpoint0-uuid", cidr)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	c.Assert(err, jc.ErrorIsNil)
+}

--- a/domain/application/state/types.go
+++ b/domain/application/state/types.go
@@ -1140,3 +1140,39 @@ type exportApplication struct {
 	Exposed      bool               `db:"exposed"`
 	Subordinate  bool               `db:"subordinate"`
 }
+
+type setExposedSpace struct {
+	ApplicationUUID string `db:"application_uuid"`
+	EndpointName    string `db:"endpoint"`
+	SpaceUUID       string `db:"space_uuid"`
+}
+
+type setExposedCIDR struct {
+	ApplicationUUID string `db:"application_uuid"`
+	EndpointName    string `db:"endpoint"`
+	CIDR            string `db:"cidr"`
+}
+
+// endpointCIDR is a struct used to retrieve rows when joining
+// application_exposed_endpoint_cidr, application_endpoint and charm_relation
+// tables to retrieve all the CIDRs exposed for an endpoint.
+type endpointCIDR struct {
+	EndpointName sql.NullString `db:"name"`
+	CIDR         string         `db:"cidr"`
+}
+
+// endpointSpace is a struct used to retrieve rows when joining
+// application_exposed_endpoint_cidr, application_endpoint and charm_relation
+// tables to retrieve all the Spaces exposed for an endpoint.
+type endpointSpace struct {
+	EndpointName sql.NullString `db:"name"`
+	SpaceUUID    string         `db:"space_uuid"`
+}
+
+type endpointName struct {
+	Name sql.NullString `db:"name"`
+}
+
+type setEndpointName struct {
+	Name string `db:"name"`
+}

--- a/domain/application/state/types.go
+++ b/domain/application/state/types.go
@@ -1176,3 +1176,11 @@ type endpointName struct {
 type setEndpointName struct {
 	Name string `db:"name"`
 }
+
+// spaces is a type used to pass a slice of space UUIDs to a query using `IN`
+// and sqlair.
+type spaces []string
+
+// endpointNames is a type used to pass a slice of endpoint names to a query
+// using `IN` and sqlair.
+type endpointNames []string

--- a/domain/application/state/types.go
+++ b/domain/application/state/types.go
@@ -1153,24 +1153,10 @@ type setExposedCIDR struct {
 	CIDR            string `db:"cidr"`
 }
 
-// endpointCIDR is a struct used to retrieve rows when joining
-// application_exposed_endpoint_cidr, application_endpoint and charm_relation
-// tables to retrieve all the CIDRs exposed for an endpoint.
-type endpointCIDR struct {
-	EndpointName sql.NullString `db:"name"`
-	CIDR         string         `db:"cidr"`
-}
-
-// endpointSpace is a struct used to retrieve rows when joining
-// application_exposed_endpoint_cidr, application_endpoint and charm_relation
-// tables to retrieve all the Spaces exposed for an endpoint.
-type endpointSpace struct {
-	EndpointName sql.NullString `db:"name"`
-	SpaceUUID    string         `db:"space_uuid"`
-}
-
-type endpointName struct {
-	Name sql.NullString `db:"name"`
+type endpointCIDRsSpaces struct {
+	Name      sql.NullString `db:"name"`
+	CIDR      string         `db:"cidr"`
+	SpaceUUID string         `db:"space_uuid"`
 }
 
 type setEndpointName struct {

--- a/domain/port/state/updateunitports.go
+++ b/domain/port/state/updateunitports.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/juju/juju/core/network"
 	coreunit "github.com/juju/juju/core/unit"
-	"github.com/juju/juju/domain/port"
 	porterrors "github.com/juju/juju/domain/port/errors"
 	"github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/internal/uuid"
@@ -44,7 +43,7 @@ func (st *State) UpdateUnitPorts(
 		for endpoint := range closePorts {
 			endpointsUnderActionSet.Add(endpoint)
 		}
-		endpointsUnderActionSet.Remove(port.WildcardEndpoint)
+		endpointsUnderActionSet.Remove(network.WildcardEndpoint)
 		endpointsUnderAction := endpoints(endpointsUnderActionSet.Values())
 
 		endpoints, err := st.lookupRelationUUIDs(ctx, tx, unitUUID, endpointsUnderAction)
@@ -104,7 +103,7 @@ func (st *State) resolveWildcardEndpoints(
 		}
 	}
 	// Ensure endpoints closed on the wildcard endpoint are not in the map.
-	for _, wildcardClosePorts := range closePorts[port.WildcardEndpoint] {
+	for _, wildcardClosePorts := range closePorts[network.WildcardEndpoint] {
 		delete(closePortsToEndpointMap, wildcardClosePorts)
 	}
 
@@ -119,8 +118,8 @@ func (st *State) resolveWildcardEndpoints(
 		return nil, nil, errors.Errorf("cannot update unit ports with conflict(s) on co-located units: %w", err)
 	}
 
-	wildcardOpen, _ := openPorts[port.WildcardEndpoint]
-	wildcardClose, _ := closePorts[port.WildcardEndpoint]
+	wildcardOpen, _ := openPorts[network.WildcardEndpoint]
+	wildcardClose, _ := closePorts[network.WildcardEndpoint]
 
 	wildcardOpened, err := st.getWildcardEndpointOpenedPorts(ctx, tx, unitUUID)
 	if err != nil {
@@ -134,7 +133,7 @@ func (st *State) resolveWildcardEndpoints(
 		wildcardOpenedSet[portRange] = true
 	}
 	for endpoint, endpointOpenPorts := range openPorts {
-		if endpoint == port.WildcardEndpoint {
+		if endpoint == network.WildcardEndpoint {
 			continue
 		}
 		for i, portRange := range endpointOpenPorts {
@@ -200,7 +199,7 @@ func (st *State) resolveWildcardEndpoints(
 			// This port range, open on the wildcard endpoint, is being closed
 			// on some endpoint. We need to close it on the wildcard, and open
 			// it on all endpoints other than the wildcard & targeted endpoint.
-			closePorts[port.WildcardEndpoint] = append(closePorts[port.WildcardEndpoint], portRange)
+			closePorts[network.WildcardEndpoint] = append(closePorts[network.WildcardEndpoint], portRange)
 
 			for _, otherEndpoint := range endpoints {
 				if otherEndpoint == endpoint {
@@ -433,7 +432,7 @@ func (st *State) openPorts(
 				return errors.Errorf("generating UUID for port range: %w", err)
 			}
 			var relationUUID string
-			if ep != port.WildcardEndpoint {
+			if ep != network.WildcardEndpoint {
 				relationUUID = endpointUUIDMaps[ep]
 			}
 			unitPortRange := unitPortRange{

--- a/domain/port/state/updateunitports_test.go
+++ b/domain/port/state/updateunitports_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/juju/juju/core/network"
 	coreunit "github.com/juju/juju/core/unit"
 	machinestate "github.com/juju/juju/domain/machine/state"
-	"github.com/juju/juju/domain/port"
 	porterrors "github.com/juju/juju/domain/port/errors"
 	"github.com/juju/juju/internal/logger"
 	coretesting "github.com/juju/juju/internal/testing"
@@ -157,7 +156,7 @@ func (s *updateUnitPortsSuite) TestGetWildcardEndpointOpenedPorts(c *gc.C) {
 	ctx := context.Background()
 
 	err := st.UpdateUnitPorts(ctx, s.unitUUID, network.GroupedPortRanges{
-		port.WildcardEndpoint: {network.MustParsePortRange("100-200/tcp")},
+		network.WildcardEndpoint: {network.MustParsePortRange("100-200/tcp")},
 	}, network.GroupedPortRanges{})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -253,15 +252,15 @@ func (s *updateUnitPortsSuite) TestUpdateUnitPortsOpenPortWildcardEndpoint(c *gc
 	ctx := context.Background()
 
 	err := st.UpdateUnitPorts(ctx, s.unitUUID, network.GroupedPortRanges{
-		port.WildcardEndpoint: {{Protocol: "tcp", FromPort: 1000, ToPort: 1500}},
+		network.WildcardEndpoint: {{Protocol: "tcp", FromPort: 1000, ToPort: 1500}},
 	}, network.GroupedPortRanges{})
 	c.Assert(err, jc.ErrorIsNil)
 
 	groupedPortRanges, err := st.GetUnitOpenedPorts(ctx, s.unitUUID)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(groupedPortRanges, gc.HasLen, 1)
-	c.Check(groupedPortRanges[port.WildcardEndpoint], gc.HasLen, 1)
-	c.Check(groupedPortRanges[port.WildcardEndpoint][0], jc.DeepEquals, network.PortRange{Protocol: "tcp", FromPort: 1000, ToPort: 1500})
+	c.Check(groupedPortRanges[network.WildcardEndpoint], gc.HasLen, 1)
+	c.Check(groupedPortRanges[network.WildcardEndpoint][0], jc.DeepEquals, network.PortRange{Protocol: "tcp", FromPort: 1000, ToPort: 1500})
 }
 
 func (s *updateUnitPortsSuite) TestUpdateUnitPortsOpenOnInvalidEndpoint(c *gc.C) {
@@ -664,7 +663,7 @@ func (s *updateUnitPortsSuite) TestUpdateUnitPortsOpenWildcard(c *gc.C) {
 	// Open port ranges on the wildcard endpoint and check the specific endpoints
 	// are cleaned up
 	err = st.UpdateUnitPorts(ctx, s.unitUUID, network.GroupedPortRanges{
-		port.WildcardEndpoint: {network.MustParsePortRange("100-200/tcp")},
+		network.WildcardEndpoint: {network.MustParsePortRange("100-200/tcp")},
 	}, network.GroupedPortRanges{})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -672,8 +671,8 @@ func (s *updateUnitPortsSuite) TestUpdateUnitPortsOpenWildcard(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(groupedPortRanges, gc.HasLen, 1)
 
-	c.Check(groupedPortRanges[port.WildcardEndpoint], gc.HasLen, 1)
-	c.Check(groupedPortRanges[port.WildcardEndpoint][0], jc.DeepEquals, network.MustParsePortRange("100-200/tcp"))
+	c.Check(groupedPortRanges[network.WildcardEndpoint], gc.HasLen, 1)
+	c.Check(groupedPortRanges[network.WildcardEndpoint][0], jc.DeepEquals, network.MustParsePortRange("100-200/tcp"))
 }
 
 func (s *updateUnitPortsSuite) TestUpdateUnitPortsOpenPortRangeOpenOnWildcard(c *gc.C) {
@@ -682,7 +681,7 @@ func (s *updateUnitPortsSuite) TestUpdateUnitPortsOpenPortRangeOpenOnWildcard(c 
 
 	// Open port ranges on the wildcard endpoint.
 	err := st.UpdateUnitPorts(ctx, s.unitUUID, network.GroupedPortRanges{
-		port.WildcardEndpoint: {network.MustParsePortRange("100-200/tcp")},
+		network.WildcardEndpoint: {network.MustParsePortRange("100-200/tcp")},
 	}, network.GroupedPortRanges{})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -696,8 +695,8 @@ func (s *updateUnitPortsSuite) TestUpdateUnitPortsOpenPortRangeOpenOnWildcard(c 
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(groupedPortRanges, gc.HasLen, 1)
 
-	c.Check(groupedPortRanges[port.WildcardEndpoint], gc.HasLen, 1)
-	c.Check(groupedPortRanges[port.WildcardEndpoint][0], jc.DeepEquals, network.MustParsePortRange("100-200/tcp"))
+	c.Check(groupedPortRanges[network.WildcardEndpoint], gc.HasLen, 1)
+	c.Check(groupedPortRanges[network.WildcardEndpoint][0], jc.DeepEquals, network.MustParsePortRange("100-200/tcp"))
 }
 
 func (s *updateUnitPortsSuite) TestUpdateUnitPortsCloseWildcard(c *gc.C) {
@@ -714,7 +713,7 @@ func (s *updateUnitPortsSuite) TestUpdateUnitPortsCloseWildcard(c *gc.C) {
 
 	// Close the wildcard endpoint and check the specific endpoints are cleaned up.
 	err = st.UpdateUnitPorts(ctx, s.unitUUID, network.GroupedPortRanges{}, network.GroupedPortRanges{
-		port.WildcardEndpoint: {network.MustParsePortRange("100-200/tcp")},
+		network.WildcardEndpoint: {network.MustParsePortRange("100-200/tcp")},
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -729,7 +728,7 @@ func (s *updateUnitPortsSuite) TestUpdateUnitPortsClosePortRangeOpenOnWildcard(c
 
 	// Open port ranges on the wildcard endpoint.
 	err := st.UpdateUnitPorts(ctx, s.unitUUID, network.GroupedPortRanges{
-		port.WildcardEndpoint: {network.MustParsePortRange("100-200/tcp")},
+		network.WildcardEndpoint: {network.MustParsePortRange("100-200/tcp")},
 	}, network.GroupedPortRanges{})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -766,8 +765,8 @@ func (s *updateUnitPortsSuite) TestUpdateUnitPortsOpenWildcardAndOtherRangeOnEnd
 	// are cleaned up. Also, open another independent range on one of the specific
 	// endpoints, and check that it is not affected.
 	err = st.UpdateUnitPorts(ctx, s.unitUUID, network.GroupedPortRanges{
-		port.WildcardEndpoint: {network.MustParsePortRange("100-200/tcp")},
-		"ep0":                 {network.MustParsePortRange("10-20/tcp")},
+		network.WildcardEndpoint: {network.MustParsePortRange("100-200/tcp")},
+		"ep0":                    {network.MustParsePortRange("10-20/tcp")},
 	}, network.GroupedPortRanges{})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -775,8 +774,8 @@ func (s *updateUnitPortsSuite) TestUpdateUnitPortsOpenWildcardAndOtherRangeOnEnd
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(groupedPortRanges, gc.HasLen, 2)
 
-	c.Check(groupedPortRanges[port.WildcardEndpoint], gc.HasLen, 1)
-	c.Check(groupedPortRanges[port.WildcardEndpoint][0], jc.DeepEquals, network.MustParsePortRange("100-200/tcp"))
+	c.Check(groupedPortRanges[network.WildcardEndpoint], gc.HasLen, 1)
+	c.Check(groupedPortRanges[network.WildcardEndpoint][0], jc.DeepEquals, network.MustParsePortRange("100-200/tcp"))
 
 	c.Check(groupedPortRanges["ep0"], gc.HasLen, 1)
 	c.Check(groupedPortRanges["ep0"][0], jc.DeepEquals, network.MustParsePortRange("10-20/tcp"))
@@ -787,8 +786,8 @@ func (s *updateUnitPortsSuite) TestUpdateUnitPortsOpenPortRangeOnWildcardAndOthe
 	ctx := context.Background()
 
 	err := st.UpdateUnitPorts(ctx, s.unitUUID, network.GroupedPortRanges{
-		port.WildcardEndpoint: {network.MustParsePortRange("100-200/tcp")},
-		"ep1":                 {network.MustParsePortRange("100-200/tcp")},
+		network.WildcardEndpoint: {network.MustParsePortRange("100-200/tcp")},
+		"ep1":                    {network.MustParsePortRange("100-200/tcp")},
 	},
 		network.GroupedPortRanges{},
 	)
@@ -798,6 +797,6 @@ func (s *updateUnitPortsSuite) TestUpdateUnitPortsOpenPortRangeOnWildcardAndOthe
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(groupedPortRanges, gc.HasLen, 1)
 
-	c.Check(groupedPortRanges[port.WildcardEndpoint], gc.HasLen, 1)
-	c.Check(groupedPortRanges[port.WildcardEndpoint][0], jc.DeepEquals, network.MustParsePortRange("100-200/tcp"))
+	c.Check(groupedPortRanges[network.WildcardEndpoint], gc.HasLen, 1)
+	c.Check(groupedPortRanges[network.WildcardEndpoint][0], jc.DeepEquals, network.MustParsePortRange("100-200/tcp"))
 }

--- a/domain/schema/model/sql/0019-application.sql
+++ b/domain/schema/model/sql/0019-application.sql
@@ -93,15 +93,24 @@ CREATE TABLE application_exposed_endpoint_cidr (
     PRIMARY KEY (application_uuid, application_endpoint_uuid, cidr)
 );
 
-CREATE VIEW v_application_exposed_endpoint AS
+CREATE VIEW v_application_exposed_endpoint (
+    application_uuid,
+    application_endpoint_uuid,
+    space_uuid,
+    cidr
+) AS
 SELECT
     aes.application_uuid,
-    aes.application_endpoint_uuid
+    aes.application_endpoint_uuid,
+    aes.space_uuid,
+    NULL AS n
 FROM application_exposed_endpoint_space AS aes
 UNION
 SELECT
     aec.application_uuid,
-    aec.application_endpoint_uuid
+    aec.application_endpoint_uuid,
+    NULL AS n,
+    aec.cidr
 FROM application_exposed_endpoint_cidr AS aec;
 
 CREATE TABLE application_config_hash (

--- a/domain/schema/model/sql/0019-application.sql
+++ b/domain/schema/model/sql/0019-application.sql
@@ -262,3 +262,11 @@ SELECT
 FROM application AS a
 JOIN charm AS c ON a.charm_uuid = c.uuid
 JOIN charm_metadata AS cm ON c.uuid = cm.charm_uuid;
+
+CREATE VIEW v_application_endpoint_uuid AS
+SELECT
+    a.uuid,
+    c.name,
+    a.application_uuid
+FROM application_endpoint AS a
+JOIN charm_relation AS c ON a.charm_relation_uuid = c.uuid;

--- a/domain/schema/model_schema_test.go
+++ b/domain/schema/model_schema_test.go
@@ -294,6 +294,7 @@ func (s *modelSchemaSuite) TestModelViews(c *gc.C) {
 		"v_application_charm_download_info",
 		"v_application_config",
 		"v_application_constraint",
+		"v_application_endpoint_uuid",
 		"v_application_export",
 		"v_application_exposed_endpoint",
 		"v_application_origin",

--- a/state/application.go
+++ b/state/application.go
@@ -692,8 +692,6 @@ func (a *Application) MergeExposeSettings(exposedEndpoints map[string]ExposedEnd
 			return errors.NotFoundf("endpoint %q", endpoint)
 		}
 
-		// TODO(nvinuesa): When we move to dqlite we have to make sure
-		// that the exposed spaces really exist.
 		exposeParams.ExposeToCIDRs = uniqueSortedStrings(exposeParams.ExposeToCIDRs)
 		for _, cidr := range exposeParams.ExposeToCIDRs {
 			if _, _, err := net.ParseCIDR(cidr); err != nil {


### PR DESCRIPTION
This patch implements the methods of the state layer for exposed endpoints in the application domain.

Also, the `MergeExposeSettings()` method on the service layer was updated, adding relevant checks and default values when an empty space and CIDR slices are provided.

It must be noted that the wildcard endpoint required special cases in the state layer code, the reason for this is that we have referential integrity with respect to the endpoints defined in the charm_relation table, which doesn't contain the wildcard (empty string "") endpoint for obvious reasons.


## QA steps

Nothing is wired yet, so just QAing unit tests in the application domain must pass.

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

**Launchpad bug:** https://bugs.launchpad.net/juju/+bug/

**Jira card:** JUJU-7504

