### PR TITLE
refactor: more granular removal state

### DIFF
--- a/domain/removal/service/package_mock_test.go
+++ b/domain/removal/service/package_mock_test.go
@@ -78,40 +78,40 @@ func (c *MockStateNamespaceForWatchRemovalsCall) DoAndReturn(f func() string) *M
 	return c
 }
 
-// RelationAdvanceLifeAndScheduleRemoval mocks base method.
-func (m *MockState) RelationAdvanceLifeAndScheduleRemoval(arg0 context.Context, arg1, arg2 string, arg3 bool, arg4 time.Time) error {
+// RelationAdvanceLife mocks base method.
+func (m *MockState) RelationAdvanceLife(arg0 context.Context, arg1 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RelationAdvanceLifeAndScheduleRemoval", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "RelationAdvanceLife", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// RelationAdvanceLifeAndScheduleRemoval indicates an expected call of RelationAdvanceLifeAndScheduleRemoval.
-func (mr *MockStateMockRecorder) RelationAdvanceLifeAndScheduleRemoval(arg0, arg1, arg2, arg3, arg4 any) *MockStateRelationAdvanceLifeAndScheduleRemovalCall {
+// RelationAdvanceLife indicates an expected call of RelationAdvanceLife.
+func (mr *MockStateMockRecorder) RelationAdvanceLife(arg0, arg1 any) *MockStateRelationAdvanceLifeCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RelationAdvanceLifeAndScheduleRemoval", reflect.TypeOf((*MockState)(nil).RelationAdvanceLifeAndScheduleRemoval), arg0, arg1, arg2, arg3, arg4)
-	return &MockStateRelationAdvanceLifeAndScheduleRemovalCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RelationAdvanceLife", reflect.TypeOf((*MockState)(nil).RelationAdvanceLife), arg0, arg1)
+	return &MockStateRelationAdvanceLifeCall{Call: call}
 }
 
-// MockStateRelationAdvanceLifeAndScheduleRemovalCall wrap *gomock.Call
-type MockStateRelationAdvanceLifeAndScheduleRemovalCall struct {
+// MockStateRelationAdvanceLifeCall wrap *gomock.Call
+type MockStateRelationAdvanceLifeCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockStateRelationAdvanceLifeAndScheduleRemovalCall) Return(arg0 error) *MockStateRelationAdvanceLifeAndScheduleRemovalCall {
+func (c *MockStateRelationAdvanceLifeCall) Return(arg0 error) *MockStateRelationAdvanceLifeCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateRelationAdvanceLifeAndScheduleRemovalCall) Do(f func(context.Context, string, string, bool, time.Time) error) *MockStateRelationAdvanceLifeAndScheduleRemovalCall {
+func (c *MockStateRelationAdvanceLifeCall) Do(f func(context.Context, string) error) *MockStateRelationAdvanceLifeCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateRelationAdvanceLifeAndScheduleRemovalCall) DoAndReturn(f func(context.Context, string, string, bool, time.Time) error) *MockStateRelationAdvanceLifeAndScheduleRemovalCall {
+func (c *MockStateRelationAdvanceLifeCall) DoAndReturn(f func(context.Context, string) error) *MockStateRelationAdvanceLifeCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -151,6 +151,44 @@ func (c *MockStateRelationExistsCall) Do(f func(context.Context, string) (bool, 
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockStateRelationExistsCall) DoAndReturn(f func(context.Context, string) (bool, error)) *MockStateRelationExistsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// RelationScheduleRemoval mocks base method.
+func (m *MockState) RelationScheduleRemoval(arg0 context.Context, arg1, arg2 string, arg3 bool, arg4 time.Time) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RelationScheduleRemoval", arg0, arg1, arg2, arg3, arg4)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RelationScheduleRemoval indicates an expected call of RelationScheduleRemoval.
+func (mr *MockStateMockRecorder) RelationScheduleRemoval(arg0, arg1, arg2, arg3, arg4 any) *MockStateRelationScheduleRemovalCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RelationScheduleRemoval", reflect.TypeOf((*MockState)(nil).RelationScheduleRemoval), arg0, arg1, arg2, arg3, arg4)
+	return &MockStateRelationScheduleRemovalCall{Call: call}
+}
+
+// MockStateRelationScheduleRemovalCall wrap *gomock.Call
+type MockStateRelationScheduleRemovalCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateRelationScheduleRemovalCall) Return(arg0 error) *MockStateRelationScheduleRemovalCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateRelationScheduleRemovalCall) Do(f func(context.Context, string, string, bool, time.Time) error) *MockStateRelationScheduleRemovalCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateRelationScheduleRemovalCall) DoAndReturn(f func(context.Context, string, string, bool, time.Time) error) *MockStateRelationScheduleRemovalCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/removal/service/service_test.go
+++ b/domain/removal/service/service_test.go
@@ -36,7 +36,8 @@ func (s *serviceSuite) TestRemoveRelationNoForceSuccess(c *gc.C) {
 
 	exp := s.state.EXPECT()
 	exp.RelationExists(gomock.Any(), rUUID.String()).Return(true, nil)
-	exp.RelationAdvanceLifeAndScheduleRemoval(gomock.Any(), gomock.Any(), rUUID.String(), false, when.UTC()).Return(nil)
+	exp.RelationAdvanceLife(gomock.Any(), rUUID.String()).Return(nil)
+	exp.RelationScheduleRemoval(gomock.Any(), gomock.Any(), rUUID.String(), false, when.UTC()).Return(nil)
 
 	jobUUID, err := s.newService(c).RemoveRelation(context.Background(), rUUID, false)
 	c.Assert(err, jc.ErrorIsNil)
@@ -53,7 +54,8 @@ func (s *serviceSuite) TestRemoveRelationForceSuccess(c *gc.C) {
 
 	exp := s.state.EXPECT()
 	exp.RelationExists(gomock.Any(), rUUID.String()).Return(true, nil)
-	exp.RelationAdvanceLifeAndScheduleRemoval(gomock.Any(), gomock.Any(), rUUID.String(), true, when.UTC()).Return(nil)
+	exp.RelationAdvanceLife(gomock.Any(), rUUID.String()).Return(nil)
+	exp.RelationScheduleRemoval(gomock.Any(), gomock.Any(), rUUID.String(), true, when.UTC()).Return(nil)
 
 	jobUUID, err := s.newService(c).RemoveRelation(context.Background(), rUUID, true)
 	c.Assert(err, jc.ErrorIsNil)

--- a/domain/removal/state/state.go
+++ b/domain/removal/state/state.go
@@ -82,34 +82,23 @@ AND    life_id = 0`, relationUUID)
 	return errors.Capture(db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
 		err = tx.Query(ctx, stmt, relationUUID).Run()
 		if err != nil {
-			return errors.Errorf("advancing relation %q life: %w", rUUID, err)
+			return errors.Errorf("advancing relation life: %w", err)
 		}
 		return nil
 	}))
 }
 
-// RelationAdvanceLifeAndScheduleRemoval advances the life cycle of the relation
-// with the input UUID to dying if it is alive, and schedules a removal job for
-// the relation, qualified with the input force boolean.
+// RelationScheduleRemoval schedules a removal job for the relation with the
+// input UUID, qualified with the input force boolean.
 // We don't care if the relation does not exist at this point because:
 // - it should have been validated prior to calling this method,
 // - the removal job executor will handle that fact.
-func (st *State) RelationAdvanceLifeAndScheduleRemoval(
+func (st *State) RelationScheduleRemoval(
 	ctx context.Context, removalUUID, relUUID string, force bool, when time.Time,
 ) error {
 	db, err := st.DB()
 	if err != nil {
 		return errors.Capture(err)
-	}
-
-	relationUUID := entityUUID{UUID: relUUID}
-	lifeStmt, err := st.Prepare(`
-UPDATE relation
-SET    life_id = 1
-WHERE  uuid = $entityUUID.uuid
-AND    life_id = 0`, relationUUID)
-	if err != nil {
-		return errors.Errorf("preparing relation life update: %w", err)
 	}
 
 	removalRec := removal{
@@ -122,18 +111,13 @@ AND    life_id = 0`, relationUUID)
 
 	removalStmt, err := st.Prepare("INSERT INTO removal (*) VALUES ($removal.*)", removalRec)
 	if err != nil {
-		return errors.Errorf("preparing relation life update: %w", err)
+		return errors.Errorf("preparing relation removal: %w", err)
 	}
 
 	return errors.Capture(db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
-		err = tx.Query(ctx, lifeStmt, relationUUID).Run()
-		if err != nil {
-			return errors.Errorf("advancing relation %q life: %w", relUUID, err)
-		}
-
 		err = tx.Query(ctx, removalStmt, removalRec).Run()
 		if err != nil {
-			return errors.Errorf("scheduling relation %q removal: %w", relUUID, err)
+			return errors.Errorf("scheduling relation removal: %w", err)
 		}
 
 		return nil


### PR DESCRIPTION
Instead of having a single transaction for `RelationAdvanceLifeAndScheduleRemoval`, we have:
- `RelationAdvanceLife`
- `RelationScheduleRemoval`

The reasons for this are:
- There is no requirement for a single transaction. These can happily be done separately.
- Separate methods make it easier to abstract them as different entity removals are added.
- The coordination is pushed up to the service layer as it should be.

We do not need to worry about scheduling a removal job for an entity that is removed, or is still alive; that will be handled in the removal worker. 

## QA steps

Logic not yet recruited. Unit tests pass.