### PR TITLE
chore: remove go mod replace for names/v6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -310,6 +310,3 @@ replace gopkg.in/yaml.v2 => github.com/juju/yaml/v2 v2.0.0
 // methods, which sometimes clash with package names. Fix the package to v0.4.0
 // until the issue is resolved.
 replace go.uber.org/mock => go.uber.org/mock v0.4.0
-
-// TODO - the tip of names v6 has a space ID parsing bug
-replace github.com/juju/names/v6 => github.com/juju/names/v6 v6.0.0-20250311151448-68186dd8ce9d

--- a/go.sum
+++ b/go.sum
@@ -422,8 +422,8 @@ github.com/juju/mutex/v2 v2.0.0-20220128011612-57176ebdcfa3/go.mod h1:TTCG9BJD9r
 github.com/juju/mutex/v2 v2.0.0-20220203023141-11eeddb42c6c/go.mod h1:jwCfBs/smYDaeZLqeaCi8CB8M+tOes4yf827HoOEoqk=
 github.com/juju/mutex/v2 v2.0.0 h1:rVmJdOaXGWF8rjcFHBNd4x57/1tks5CgXHx55O55SB0=
 github.com/juju/mutex/v2 v2.0.0/go.mod h1:jwCfBs/smYDaeZLqeaCi8CB8M+tOes4yf827HoOEoqk=
-github.com/juju/names/v6 v6.0.0-20250311151448-68186dd8ce9d h1:ibqSeSEwCdwazMdqIAzQRY/7Hcgo/ul8yGgX6MqYdbY=
-github.com/juju/names/v6 v6.0.0-20250311151448-68186dd8ce9d/go.mod h1:msqFCjHhF+wL7NR5aEDRlpxCybna0+5E9kbRSb2fiz4=
+github.com/juju/names/v6 v6.0.0-20250318090139-ec8d71d906f5 h1:1eVFjYvtBVLGdisz+jbjfks5AC1oeyM0Ef1Q1IrZBGE=
+github.com/juju/names/v6 v6.0.0-20250318090139-ec8d71d906f5/go.mod h1:msqFCjHhF+wL7NR5aEDRlpxCybna0+5E9kbRSb2fiz4=
 github.com/juju/naturalsort v1.0.0 h1:kGmUUy3h8mJ5/SJYaqKOBR3f3owEd5R52Lh+Tjg/dNM=
 github.com/juju/naturalsort v1.0.0/go.mod h1:Zqa/vGkXr78k47zM6tFmU9phhxKz/PIdqBzpLhJ86zc=
 github.com/juju/os/v2 v2.2.5 h1:Ayw9aC7axKtGgzy3dFRKx84FxasfISMege0iYDsH6io=


### PR DESCRIPTION
Quick fix - an issue with a failing test was fixed due to changes in `juju/names/v6` but we ended up leaving the go mod replace to pin to an older version. This PR removes that replace from go mod.