### PR TITLE
test: fix flaky relations endpoint test

### DIFF
--- a/domain/relation/state/relation_test.go
+++ b/domain/relation/state/relation_test.go
@@ -230,9 +230,7 @@ func (s *relationSuite) TestGetRelationEndpoints(c *gc.C) {
 
 	// Assert:
 	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(endpoints, gc.HasLen, 2)
-	c.Check(endpoints[0], gc.DeepEquals, endpoint1)
-	c.Check(endpoints[1], gc.DeepEquals, endpoint2)
+	c.Assert(endpoints, jc.SameContents, endpoints)
 }
 
 func (s *relationSuite) TestGetRelationEndpointsPeer(c *gc.C) {


### PR DESCRIPTION
The test was accidently checking the order of the elements in the slice when it should not care. Use `jc.SameContents` to avoid this.

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps
Run test 100 times.
