### PR TITLE
chore: ssh server improvements

### DIFF
--- a/internal/worker/sshserver/facade_client_mock_test.go
+++ b/internal/worker/sshserver/facade_client_mock_test.go
@@ -7,7 +7,7 @@
 //
 
 // Package sshserver_test is a generated GoMock package.
-package sshserver_test
+package sshserver
 
 import (
 	reflect "reflect"

--- a/internal/worker/sshserver/listener_mock_test.go
+++ b/internal/worker/sshserver/listener_mock_test.go
@@ -7,7 +7,7 @@
 //
 
 // Package sshserver_test is a generated GoMock package.
-package sshserver_test
+package sshserver
 
 import (
 	net "net"

--- a/internal/worker/sshserver/listener_test.go
+++ b/internal/worker/sshserver/listener_test.go
@@ -1,7 +1,7 @@
 // Copyright 2025 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
-package sshserver_test
+package sshserver
 
 import (
 	"context"

--- a/internal/worker/sshserver/package_test.go
+++ b/internal/worker/sshserver/package_test.go
@@ -9,8 +9,8 @@ import (
 	gc "gopkg.in/check.v1"
 )
 
-//go:generate go run go.uber.org/mock/mockgen -package sshserver_test -destination facade_client_mock_test.go github.com/juju/juju/internal/worker/sshserver FacadeClient
-//go:generate go run go.uber.org/mock/mockgen -package sshserver_test -destination listener_mock_test.go net Listener
+//go:generate go run go.uber.org/mock/mockgen -package sshserver -destination facade_client_mock_test.go github.com/juju/juju/internal/worker/sshserver FacadeClient
+//go:generate go run go.uber.org/mock/mockgen -package sshserver -destination listener_mock_test.go net Listener
 
 func TestPackage(t *stdtesting.T) {
 	gc.TestingT(t)

--- a/internal/worker/sshserver/server_test.go
+++ b/internal/worker/sshserver/server_test.go
@@ -124,7 +124,7 @@ func (s *sshServerSuite) TestSSHServerNoAuth(c *gc.C) {
 	s.facadeClient.EXPECT().HostKeyForTarget(gomock.Any()).Return(s.hostKey, nil)
 
 	// Start the server on an in-memory listener
-	listener := bufconn.Listen(8 * 1024)
+	listener := bufconn.Listen(1024)
 
 	server, err := NewServerWorker(ServerWorkerConfig{
 		Logger:                   loggo.GetLogger("test"),
@@ -133,6 +133,7 @@ func (s *sshServerSuite) TestSSHServerNoAuth(c *gc.C) {
 		JumpHostKey:              jujutesting.SSHServerHostKey,
 		NewSSHServerListener:     newTestingSSHServerListener,
 		FacadeClient:             s.facadeClient,
+		disableAuth:              true,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	defer workertest.DirtyKill(c, server)
@@ -242,7 +243,7 @@ func (s *sshServerSuite) TestSSHServerMaxConnections(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	s.facadeClient.EXPECT().HostKeyForTarget(gomock.Any()).Return(s.hostKey, nil).AnyTimes()
 	// Firstly, start the server on an in-memory listener
-	listener := bufconn.Listen(8 * 1024)
+	listener := bufconn.Listen(1024)
 	_, err := NewServerWorker(ServerWorkerConfig{
 		Logger:                   loggo.GetLogger("test"),
 		Listener:                 listener,
@@ -250,6 +251,7 @@ func (s *sshServerSuite) TestSSHServerMaxConnections(c *gc.C) {
 		JumpHostKey:              jujutesting.SSHServerHostKey,
 		NewSSHServerListener:     newTestingSSHServerListener,
 		FacadeClient:             s.facadeClient,
+		disableAuth:              true,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	// the reason we repeat this test 2 times is to make sure that closing the connections on
@@ -289,7 +291,7 @@ func (s *sshServerSuite) TestSSHServerMaxConnections(c *gc.C) {
 func (s *sshServerSuite) TestSSHWorkerReport(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 	// Firstly, start the server on an in-memory listener
-	listener := bufconn.Listen(8 * 1024)
+	listener := bufconn.Listen(1024)
 	worker, err := NewServerWorker(ServerWorkerConfig{
 		Logger:                   loggo.GetLogger("test"),
 		Listener:                 listener,
@@ -297,6 +299,7 @@ func (s *sshServerSuite) TestSSHWorkerReport(c *gc.C) {
 		JumpHostKey:              jujutesting.SSHServerHostKey,
 		NewSSHServerListener:     newTestingSSHServerListener,
 		FacadeClient:             s.facadeClient,
+		disableAuth:              true,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -309,9 +312,6 @@ func (s *sshServerSuite) TestSSHWorkerReport(c *gc.C) {
 	inMemoryDial(c, listener, &ssh.ClientConfig{
 		User:            "",
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
-		Auth: []ssh.AuthMethod{
-			ssh.Password(""), // No password needed
-		},
 	})
 
 	report = worker.(*ServerWorker).Report()

--- a/internal/worker/sshserver/types.go
+++ b/internal/worker/sshserver/types.go
@@ -1,0 +1,70 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package sshserver
+
+import (
+	"net"
+	"time"
+
+	"github.com/juju/errors"
+	gossh "golang.org/x/crypto/ssh"
+)
+
+// chanConn fulfills the net.Conn interface without
+// the tcpChan having to hold laddr or raddr directly.
+type chanConn struct {
+	gossh.Channel
+	laddr, raddr net.Addr
+}
+
+// newChannelConn creates a struct that fulfills the net.Conn
+// interface using the provided SSH channel. The client side
+// of the connection should also be treated as a TCP pipe.
+func newChannelConn(ch gossh.Channel) *chanConn {
+	// Use a zero address for local and remote address.
+	zeroAddr := &net.TCPAddr{
+		IP:   net.IPv4zero,
+		Port: 0,
+	}
+	return &chanConn{
+		Channel: ch,
+		laddr:   zeroAddr,
+		raddr:   zeroAddr,
+	}
+}
+
+// LocalAddr returns the local network address.
+func (t *chanConn) LocalAddr() net.Addr {
+	return t.laddr
+}
+
+// RemoteAddr returns the remote network address.
+func (t *chanConn) RemoteAddr() net.Addr {
+	return t.raddr
+}
+
+// SetDeadline sets the read and write deadlines associated
+// with the connection.
+func (t *chanConn) SetDeadline(deadline time.Time) error {
+	if err := t.SetReadDeadline(deadline); err != nil {
+		return err
+	}
+	return t.SetWriteDeadline(deadline)
+}
+
+// SetReadDeadline sets the read deadline.
+// A zero value for t means Read will not time out.
+// After the deadline, the error from Read will implement net.Error
+// with Timeout() == true.
+func (t *chanConn) SetReadDeadline(deadline time.Time) error {
+	// for compatibility with previous version,
+	// the error message contains "tcpChan"
+	return errors.New("ssh: tcpChan: deadline not supported")
+}
+
+// SetWriteDeadline exists to satisfy the net.Conn interface
+// but is not implemented by this type.  It always returns an error.
+func (t *chanConn) SetWriteDeadline(deadline time.Time) error {
+	return errors.New("ssh: tcpChan: deadline not supported")
+}


### PR DESCRIPTION
This PR makes 3 improvements to the SSH server, split into 3 separate commits each. Reviewing each commit separately should help.

1. Removes the use of the `_test` package from sshserver tests.
2. Simplifies conversion of an SSH channel to a net.Conn (see below)
3. Allows tests to disable auth on the ssh server and defaults the server to deny access.

Regarding the conversion of an SSH channel to a net.Conn - we were previously using 2 Go routines and a `net.Pipe` to take the data out of the SSH channel and into one end of the pipe, giving us something that satisfies net.Conn. Instead, we can use the same approach from `x/crypto/ssh`, transforming an SSH channel that we know is treated as a TCP pipe on both ends into a net.Conn by means of a struct, saving us the 2 go routines.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages
