### PR TITLE
refactor: remove state based model calls from agent/caasagent

### DIFF
--- a/apiserver/facades/agent/caasagent/caasagent_test.go
+++ b/apiserver/facades/agent/caasagent/caasagent_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/juju/juju/apiserver/facade/facadetest"
 	"github.com/juju/juju/apiserver/facades/agent/caasagent"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
+	modeltesting "github.com/juju/juju/core/model/testing"
 	coretesting "github.com/juju/juju/internal/testing"
 )
 
@@ -38,6 +39,11 @@ func (s *caasagentSuite) TestPermission(c *gc.C) {
 	s.authorizer = &apiservertesting.FakeAuthorizer{
 		Tag: names.NewApplicationTag("someapp"),
 	}
-	_, err := caasagent.NewStateFacadeV2(facadetest.ModelContext{Auth_: s.authorizer})
+	modelUUID := modeltesting.GenModelUUID(c)
+
+	_, err := caasagent.NewStateFacadeV2(facadetest.ModelContext{
+		Auth_:      s.authorizer,
+		ModelUUID_: modelUUID,
+	})
 	c.Assert(err, gc.ErrorMatches, "permission denied")
 }

--- a/apiserver/facades/agent/caasagent/register.go
+++ b/apiserver/facades/agent/caasagent/register.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"reflect"
 
-	"github.com/juju/errors"
+	"github.com/juju/names/v6"
 
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/common/cloudspec"
@@ -32,10 +32,8 @@ func newStateFacadeV2(ctx facade.ModelContext) (*FacadeV2, error) {
 	}
 
 	resources := ctx.Resources()
-	model, err := ctx.State().Model()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
+
+	authFunc := common.AuthFuncForTag(names.NewModelTag(ctx.ModelUUID().String()))
 
 	domainServices := ctx.DomainServices()
 
@@ -45,8 +43,9 @@ func newStateFacadeV2(ctx facade.ModelContext) (*FacadeV2, error) {
 		cloudspec.MakeCloudSpecWatcherForModel(ctx.State(), domainServices.Cloud()),
 		cloudspec.MakeCloudSpecCredentialWatcherForModel(ctx.State()),
 		cloudspec.MakeCloudSpecCredentialContentWatcherForModel(ctx.State(), domainServices.Credential()),
-		common.AuthFuncForTag(model.ModelTag()),
+		authFunc,
 	)
+
 	return &FacadeV2{
 		CloudSpecer:        cloudSpecAPI,
 		ModelConfigWatcher: commonmodel.NewModelConfigWatcher(domainServices.Config(), ctx.WatcherRegistry()),


### PR DESCRIPTION
<!--
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://github.com/juju/juju/blob/main/docs/contributor/reference/conventional-commits.md
-->

<!-- Why this change is needed and what it does. -->

This change removes the need for the agent/caasagent facade to access mongo state to retrieve the model tag for the current context. Instead we now pull this information from the facade model context which in turn is backed by DQlite.

In doing this work we were also able to invert some of the dependencies into the facade constructor removing the need to have an error return from new*.

This facade does not rely on mongo anymore for accessing model information.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

<!--

Describe steps to verify that the change works.

If you're changing any of the facades, you need to ensure that you've tested
a model migration from 3.6 to 4.0 and from 4.0 to 4.0.

The following steps are a good starting point:

 1. Bootstrap a 3.6 controller and deploy a charm.

```sh
$ juju bootstrap lxd src36
$ juju add-model moveme1
$ juju deploy juju-qa-test
```

 2. Bootstrap a 4.0 controller with the changes and migrate the model.

```sh
$ juju bootstrap lxd dst40
$ juju migrate src36:moveme1 dst40
$ juju add-unit juju-qa-test
```

 3. Verify no errors exist in the model logs for the agents. If there are
    errors, this is a bug and should be fixed before merging. The fix can
    either be applied to the 4.0 branch (preferable) or the 3.6 branch, though
    that needs to be discussed with the team.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme1
```

    4. We also need to test a model migration from 4.0 to 4.0.

```sh
$ juju bootstrap lxd src40
$ juju add-model moveme2
$ juju deploy juju-qa-test
```

```sh
$ juju migrate src40:moveme2 dst40
$ juju add-unit juju-qa-test
```

    5. Verify that there are no errors in the controller or model logs.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme2
```

-->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Add a Jira card reference or link, otherwise remove this line. -->
**Jira card:** JUJU-7740
