### PR TITLE
refactor: remove state model from charm, block, annotation facades

### DIFF
--- a/apiserver/facades/client/annotations/register.go
+++ b/apiserver/facades/client/annotations/register.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"reflect"
 
-	"github.com/juju/errors"
+	"github.com/juju/names/v6"
 
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facade"
@@ -26,14 +26,9 @@ func newAPI(ctx facade.ModelContext) (*API, error) {
 	if !authorizer.AuthClient() {
 		return nil, apiservererrors.ErrPerm
 	}
-	st := ctx.State()
-	m, err := st.Model()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
 
 	return &API{
-		modelTag:          m.ModelTag(),
+		modelTag:          names.NewModelTag(ctx.ModelUUID().String()),
 		annotationService: ctx.DomainServices().Annotation(),
 		authorizer:        authorizer,
 	}, nil

--- a/apiserver/facades/client/block/register.go
+++ b/apiserver/facades/client/block/register.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"reflect"
 
-	"github.com/juju/errors"
+	"github.com/juju/names/v6"
 
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facade"
@@ -27,14 +27,8 @@ func NewAPI(ctx facade.ModelContext) (*API, error) {
 		return nil, apiservererrors.ErrPerm
 	}
 
-	st := ctx.State()
-	m, err := st.Model()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
 	return &API{
-		modelTag:   m.ModelTag(),
+		modelTag:   names.NewModelTag(ctx.ModelUUID().String()),
 		service:    ctx.DomainServices().BlockCommand(),
 		authorizer: authorizer,
 	}, nil

--- a/apiserver/facades/client/charms/client.go
+++ b/apiserver/facades/client/charms/client.go
@@ -49,7 +49,8 @@ type API struct {
 	backendState       charmsinterfaces.BackendState
 	charmhubHTTPClient facade.HTTPClient
 
-	tag             names.ModelTag
+	modelTag        names.ModelTag
+	controllerTag   names.ControllerTag
 	requestRecorder facade.RequestRecorder
 
 	newCharmHubRepository func(repository.CharmHubRepositoryConfig) (corecharm.Repository, error)
@@ -67,12 +68,12 @@ func (a *API) CharmInfo(ctx context.Context, args params.CharmURL) (params.Charm
 }
 
 func (a *API) checkCanRead(ctx context.Context) error {
-	err := a.authorizer.HasPermission(ctx, permission.ReadAccess, a.tag)
+	err := a.authorizer.HasPermission(ctx, permission.ReadAccess, a.modelTag)
 	return err
 }
 
 func (a *API) checkCanWrite(ctx context.Context) error {
-	err := a.authorizer.HasPermission(ctx, permission.SuperuserAccess, a.backendState.ControllerTag())
+	err := a.authorizer.HasPermission(ctx, permission.SuperuserAccess, a.controllerTag)
 	if err != nil && !errors.Is(err, authentication.ErrorEntityMissingPermission) {
 		return errors.Trace(err)
 	}
@@ -81,7 +82,7 @@ func (a *API) checkCanWrite(ctx context.Context) error {
 		return nil
 	}
 
-	return a.authorizer.HasPermission(ctx, permission.WriteAccess, a.tag)
+	return a.authorizer.HasPermission(ctx, permission.WriteAccess, a.modelTag)
 }
 
 // List returns a list of charm URLs currently in the state. If supplied

--- a/apiserver/facades/client/charms/client_test.go
+++ b/apiserver/facades/client/charms/client_test.go
@@ -439,6 +439,7 @@ func NewCharmsAPI(
 	modelConfigService ModelConfigService,
 	applicationService ApplicationService,
 	machineService MachineService,
+	controllerTag names.ControllerTag,
 	modelTag names.ModelTag,
 	repo corecharm.Repository,
 	logger corelogger.Logger,
@@ -449,7 +450,8 @@ func NewCharmsAPI(
 		modelConfigService: modelConfigService,
 		applicationService: applicationService,
 		machineService:     machineService,
-		tag:                modelTag,
+		controllerTag:      controllerTag,
+		modelTag:           modelTag,
 		requestRecorder:    noopRequestRecorder{},
 		newCharmHubRepository: func(repository.CharmHubRepositoryConfig) (corecharm.Repository, error) {
 			return repo, nil
@@ -465,6 +467,7 @@ func (s *charmsMockSuite) api(c *gc.C) *API {
 		s.modelConfigService,
 		s.applicationService,
 		s.machineService,
+		names.NewControllerTag("deadbeef-abcd-4fd2-967d-db9663db7bef"),
 		names.NewModelTag("deadbeef-abcd-4fd2-967d-db9663db7bea"),
 		s.repository,
 		loggertesting.WrapCheckLog(c),
@@ -480,7 +483,6 @@ func (s *charmsMockSuite) setupMocks(c *gc.C) *gomock.Controller {
 	s.authorizer.EXPECT().HasPermission(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 	s.state = mocks.NewMockBackendState(ctrl)
-	s.state.EXPECT().ControllerTag().Return(names.NewControllerTag("deadbeef-abcd-dead-beef-db9663db7b42")).AnyTimes()
 
 	s.repository = mocks.NewMockRepository(ctrl)
 	s.charmArchive = mocks.NewMockCharmArchive(ctrl)

--- a/apiserver/facades/client/charms/interfaces/state.go
+++ b/apiserver/facades/client/charms/interfaces/state.go
@@ -4,8 +4,6 @@
 package interfaces
 
 import (
-	"github.com/juju/names/v6"
-
 	"github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/state"
 )
@@ -13,7 +11,6 @@ import (
 type BackendState interface {
 	Application(string) (Application, error)
 	Charm(curl string) (state.CharmRefFull, error)
-	ControllerTag() names.ControllerTag
 	Machine(string) (Machine, error)
 }
 

--- a/apiserver/facades/client/charms/mocks/state_mock.go
+++ b/apiserver/facades/client/charms/mocks/state_mock.go
@@ -18,7 +18,6 @@ import (
 	constraints "github.com/juju/juju/core/constraints"
 	charm0 "github.com/juju/juju/internal/charm"
 	state "github.com/juju/juju/state"
-	names "github.com/juju/names/v6"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -119,44 +118,6 @@ func (c *MockBackendStateCharmCall) Do(f func(string) (state.CharmRefFull, error
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockBackendStateCharmCall) DoAndReturn(f func(string) (state.CharmRefFull, error)) *MockBackendStateCharmCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
-// ControllerTag mocks base method.
-func (m *MockBackendState) ControllerTag() names.ControllerTag {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ControllerTag")
-	ret0, _ := ret[0].(names.ControllerTag)
-	return ret0
-}
-
-// ControllerTag indicates an expected call of ControllerTag.
-func (mr *MockBackendStateMockRecorder) ControllerTag() *MockBackendStateControllerTagCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ControllerTag", reflect.TypeOf((*MockBackendState)(nil).ControllerTag))
-	return &MockBackendStateControllerTagCall{Call: call}
-}
-
-// MockBackendStateControllerTagCall wrap *gomock.Call
-type MockBackendStateControllerTagCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockBackendStateControllerTagCall) Return(arg0 names.ControllerTag) *MockBackendStateControllerTagCall {
-	c.Call = c.Call.Return(arg0)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockBackendStateControllerTagCall) Do(f func() names.ControllerTag) *MockBackendStateControllerTagCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockBackendStateControllerTagCall) DoAndReturn(f func() names.ControllerTag) *MockBackendStateControllerTagCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/client/charms/register.go
+++ b/apiserver/facades/client/charms/register.go
@@ -35,7 +35,7 @@ func newFacadeV7(stdCtx context.Context, ctx facade.ModelContext) (*APIv7, error
 }
 
 // makeFacadeBase provides the signature required for facade registration.
-func makeFacadeBase(stdCtx context.Context, ctx facade.ModelContext) (*API, error) {
+func makeFacadeBase(_ context.Context, ctx facade.ModelContext) (*API, error) {
 	authorizer := ctx.Auth()
 	if !authorizer.AuthClient() {
 		return nil, apiservererrors.ErrPerm
@@ -51,10 +51,6 @@ func makeFacadeBase(stdCtx context.Context, ctx facade.ModelContext) (*API, erro
 		return nil, errors.Trace(err)
 	}
 
-	modelInfo, err := domainServices.ModelInfo().GetModelInfo(stdCtx)
-	if err != nil {
-		return nil, fmt.Errorf("getting model info: %w", err)
-	}
 	charmhubHTTPClient, err := ctx.HTTPClient(corehttp.CharmhubPurpose)
 	if err != nil {
 		return nil, fmt.Errorf(
@@ -73,7 +69,8 @@ func makeFacadeBase(stdCtx context.Context, ctx facade.ModelContext) (*API, erro
 		newCharmHubRepository: func(cfg repository.CharmHubRepositoryConfig) (corecharm.Repository, error) {
 			return repository.NewCharmHubRepository(cfg)
 		},
-		tag:             names.NewModelTag(modelInfo.UUID.String()),
+		modelTag:        names.NewModelTag(ctx.ModelUUID().String()),
+		controllerTag:   names.NewControllerTag(ctx.ControllerUUID()),
 		requestRecorder: ctx.RequestRecorder(),
 		logger:          ctx.Logger().Child("charms"),
 	}, nil


### PR DESCRIPTION
The client facades annotation, block, charm no longer use any calls to state model.
Model and controller tags are sourced from the facade context.

## QA steps

smoke tests

## Links

**Jira card:** [JUJU-7744](https://warthogs.atlassian.net/browse/JUJU-7744)
**Jira card:** [JUJU-7747](https://warthogs.atlassian.net/browse/JUJU-7747)
**Jira card:** [JUJU-7786](https://warthogs.atlassian.net/browse/JUJU-7786)
