### PR TITLE
refactor: remove state model from client usermanager facade

### DIFF
--- a/apiserver/facades/client/usermanager/domain_mock_test.go
+++ b/apiserver/facades/client/usermanager/domain_mock_test.go
@@ -199,6 +199,45 @@ func (c *MockAccessServiceGetAllUsersCall) DoAndReturn(f func(context.Context, b
 	return c
 }
 
+// GetUser mocks base method.
+func (m *MockAccessService) GetUser(arg0 context.Context, arg1 user.UUID) (user.User, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUser", arg0, arg1)
+	ret0, _ := ret[0].(user.User)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUser indicates an expected call of GetUser.
+func (mr *MockAccessServiceMockRecorder) GetUser(arg0, arg1 any) *MockAccessServiceGetUserCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUser", reflect.TypeOf((*MockAccessService)(nil).GetUser), arg0, arg1)
+	return &MockAccessServiceGetUserCall{Call: call}
+}
+
+// MockAccessServiceGetUserCall wrap *gomock.Call
+type MockAccessServiceGetUserCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockAccessServiceGetUserCall) Return(arg0 user.User, arg1 error) *MockAccessServiceGetUserCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockAccessServiceGetUserCall) Do(f func(context.Context, user.UUID) (user.User, error)) *MockAccessServiceGetUserCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockAccessServiceGetUserCall) DoAndReturn(f func(context.Context, user.UUID) (user.User, error)) *MockAccessServiceGetUserCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetUserByName mocks base method.
 func (m *MockAccessService) GetUserByName(arg0 context.Context, arg1 user.Name) (user.User, error) {
 	m.ctrl.T.Helper()
@@ -413,6 +452,45 @@ func NewMockModelService(ctrl *gomock.Controller) *MockModelService {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockModelService) EXPECT() *MockModelServiceMockRecorder {
 	return m.recorder
+}
+
+// ControllerModel mocks base method.
+func (m *MockModelService) ControllerModel(arg0 context.Context) (model.Model, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ControllerModel", arg0)
+	ret0, _ := ret[0].(model.Model)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ControllerModel indicates an expected call of ControllerModel.
+func (mr *MockModelServiceMockRecorder) ControllerModel(arg0 any) *MockModelServiceControllerModelCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ControllerModel", reflect.TypeOf((*MockModelService)(nil).ControllerModel), arg0)
+	return &MockModelServiceControllerModelCall{Call: call}
+}
+
+// MockModelServiceControllerModelCall wrap *gomock.Call
+type MockModelServiceControllerModelCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockModelServiceControllerModelCall) Return(arg0 model.Model, arg1 error) *MockModelServiceControllerModelCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockModelServiceControllerModelCall) Do(f func(context.Context) (model.Model, error)) *MockModelServiceControllerModelCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockModelServiceControllerModelCall) DoAndReturn(f func(context.Context) (model.Model, error)) *MockModelServiceControllerModelCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
 }
 
 // GetModelUser mocks base method.

--- a/apiserver/facades/client/usermanager/register.go
+++ b/apiserver/facades/client/usermanager/register.go
@@ -37,8 +37,8 @@ func newUserManagerAPI(stdCtx context.Context, ctx facade.ModelContext) (*UserMa
 	apiUserTag, _ := authorizer.GetAuthTag().(names.UserTag)
 	// Pretty much all the user manager methods have special casing for admin
 	// users, so look once when we start and remember if the user is an admin.
-	st := ctx.State()
-	err := authorizer.HasPermission(stdCtx, permission.SuperuserAccess, st.ControllerTag())
+	controllerTag := names.NewControllerTag(ctx.ControllerUUID())
+	err := authorizer.HasPermission(stdCtx, permission.SuperuserAccess, controllerTag)
 	if err != nil && !errors.Is(err, authentication.ErrorEntityMissingPermission) {
 		return nil, errors.Trace(err)
 	}
@@ -53,7 +53,6 @@ func newUserManagerAPI(stdCtx context.Context, ctx facade.ModelContext) (*UserMa
 	}
 
 	return NewAPI(
-		st,
 		accessService,
 		domainServices.Model(),
 		authorizer,
@@ -62,6 +61,6 @@ func newUserManagerAPI(stdCtx context.Context, ctx facade.ModelContext) (*UserMa
 		apiUser,
 		isAdmin,
 		ctx.Logger().Child("usermanager"),
-		ctx.ControllerUUID(),
+		controllerTag,
 	)
 }

--- a/apiserver/facades/client/usermanager/usermanager_test.go
+++ b/apiserver/facades/client/usermanager/usermanager_test.go
@@ -73,11 +73,6 @@ func (s *userManagerSuite) TestAddUser(c *gc.C) {
 		},
 	}).Return(newUserUUID(c), nil, nil)
 
-	f, release := s.NewFactory(c, s.ControllerModelUUID())
-	defer release()
-	sharedModelState := f.MakeModel(c, nil)
-	defer func() { _ = sharedModelState.Close() }()
-
 	args := params.AddUsers{
 		Users: []params.AddUser{{
 			Username:    "foobar",
@@ -679,6 +674,7 @@ func (s *userManagerSuite) TestRemoveUserBadTag(c *gc.C) {
 	defer s.setUpAPI(c).Finish()
 
 	s.blockCommandService.EXPECT().GetBlockSwitchedOn(gomock.Any(), gomock.Any()).Return("", blockcommanderrors.NotFound)
+	s.expectControllerModelUser(c)
 
 	tag := "not-a-tag"
 	got, err := s.api.RemoveUser(context.Background(), params.Entities{
@@ -694,6 +690,7 @@ func (s *userManagerSuite) TestRemoveUserNonExistent(c *gc.C) {
 	defer s.setUpAPI(c).Finish()
 
 	s.blockCommandService.EXPECT().GetBlockSwitchedOn(gomock.Any(), gomock.Any()).Return("", blockcommanderrors.NotFound)
+	s.expectControllerModelUser(c)
 
 	tag := "user-harvey"
 	s.accessService.EXPECT().RemoveUser(gomock.Any(), coreusertesting.GenNewName(c, "harvey")).Return(errors.NotFound)
@@ -708,10 +705,19 @@ func (s *userManagerSuite) TestRemoveUserNonExistent(c *gc.C) {
 	})
 }
 
+func (s *userManagerSuite) expectControllerModelUser(c *gc.C) {
+	userUUID := coreusertesting.GenUserUUID(c)
+	name, err := coreuser.NewName("admin")
+	c.Assert(err, jc.ErrorIsNil)
+	s.modelService.EXPECT().ControllerModel(gomock.Any()).Return(coremodel.Model{Owner: userUUID}, nil)
+	s.accessService.EXPECT().GetUser(gomock.Any(), userUUID).Return(coreuser.User{Name: name}, nil)
+}
+
 func (s *userManagerSuite) TestRemoveUser(c *gc.C) {
 	defer s.setUpAPI(c).Finish()
 
 	s.blockCommandService.EXPECT().GetBlockSwitchedOn(gomock.Any(), gomock.Any()).Return("", blockcommanderrors.NotFound)
+	s.expectControllerModelUser(c)
 
 	s.accessService.EXPECT().RemoveUser(gomock.Any(), coreusertesting.GenNewName(c, "jimmyjam")).Return(nil)
 
@@ -728,6 +734,7 @@ func (s *userManagerSuite) TestRemoveUserAsNormalUser(c *gc.C) {
 	defer s.setUpAPI(c).Finish()
 
 	s.blockCommandService.EXPECT().GetBlockSwitchedOn(gomock.Any(), gomock.Any()).Return("", blockcommanderrors.NotFound)
+	s.expectControllerModelUser(c)
 
 	jjam := names.NewUserTag("jimmyjam")
 
@@ -742,6 +749,7 @@ func (s *userManagerSuite) TestRemoveUserSelfAsNormalUser(c *gc.C) {
 	defer s.setUpAPI(c).Finish()
 
 	s.blockCommandService.EXPECT().GetBlockSwitchedOn(gomock.Any(), gomock.Any()).Return("", blockcommanderrors.NotFound)
+	s.expectControllerModelUser(c)
 
 	// Do not expect any calls to the user service as this should fail.
 	_, err := s.api.RemoveUser(context.Background(), params.Entities{
@@ -753,6 +761,7 @@ func (s *userManagerSuite) TestRemoveUserAsSelfAdmin(c *gc.C) {
 	defer s.setUpAPI(c).Finish()
 
 	s.blockCommandService.EXPECT().GetBlockSwitchedOn(gomock.Any(), gomock.Any()).Return("", blockcommanderrors.NotFound)
+	s.expectControllerModelUser(c)
 
 	expectedError := "cannot delete controller owner \"admin\""
 
@@ -770,6 +779,7 @@ func (s *userManagerSuite) TestRemoveUserBulk(c *gc.C) {
 	defer s.setUpAPI(c).Finish()
 
 	s.blockCommandService.EXPECT().GetBlockSwitchedOn(gomock.Any(), gomock.Any()).Return("", blockcommanderrors.NotFound)
+	s.expectControllerModelUser(c)
 
 	s.accessService.EXPECT().RemoveUser(gomock.Any(), coreusertesting.GenNewName(c, "jimmyjam")).Return(nil)
 	s.accessService.EXPECT().RemoveUser(gomock.Any(), coreusertesting.GenNewName(c, "alice")).Return(nil)
@@ -962,15 +972,12 @@ func (s *userManagerSuite) setUpAPI(c *gc.C) *gomock.Controller {
 	s.blockCommandService = NewMockBlockCommandService(ctrl)
 
 	ctx := facadetest.ModelContext{
-		StatePool_: s.StatePool(),
-		State_:     s.ControllerModel(c).State(),
 		Resources_: s.resources,
 		Auth_:      s.authorizer,
 	}
 
 	var err error
 	s.api, err = usermanager.NewAPI(
-		ctx.State(),
 		s.accessService,
 		s.modelService,
 		ctx.Auth(),
@@ -979,7 +986,7 @@ func (s *userManagerSuite) setUpAPI(c *gc.C) *gomock.Controller {
 		s.apiUser,
 		s.apiUser.Name.Name() == "admin",
 		ctx.Logger(),
-		s.ControllerUUID,
+		names.NewControllerTag(s.ControllerUUID),
 	)
 	c.Assert(err, jc.ErrorIsNil)
 


### PR DESCRIPTION
Remove the use of state entirely from the client usermanager facade.
Existing domain service api calls are used in place of any remaining state ones.

## QA steps

smoke tests

## Links


**Jira card:** [JUJU-7794](https://warthogs.atlassian.net/browse/JUJU-7794)
