### PR TITLE
feat: update unit ddl to include base

### DIFF
--- a/domain/annotation/state/state_test.go
+++ b/domain/annotation/state/state_test.go
@@ -388,9 +388,9 @@ func (s *stateSuite) ensureUnit(c *gc.C, unitName, uuid string) {
 
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		_, err := tx.ExecContext(ctx, `
-INSERT INTO unit (uuid, name, application_uuid, net_node_uuid, life_id)
-VALUES (?, ?, ?, ?, ?)
-`, uuid, unitName, "123", "321", "0")
+INSERT INTO unit (uuid, name, application_uuid, net_node_uuid, life_id, risk, os_id, architecture_id)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+`, uuid, unitName, "123", "321", "0", "stable", "0", "0")
 		return err
 	})
 	c.Assert(err, jc.ErrorIsNil)

--- a/domain/application/state/types.go
+++ b/domain/application/state/types.go
@@ -118,6 +118,11 @@ type unitDetails struct {
 	LifeID                  life.Life          `db:"life_id"`
 	PasswordHash            string             `db:"password_hash"`
 	PasswordHashAlgorithmID int                `db:"password_hash_algorithm_id"`
+	Track                   string             `db:"track"`
+	Risk                    string             `db:"risk"`
+	Branch                  string             `db:"branch"`
+	OSID                    int                `db:"os_id"`
+	ArchitectureID          int                `db:"architecture_id"`
 }
 
 type unitPassword struct {

--- a/domain/application/state/unit.go
+++ b/domain/application/state/unit.go
@@ -916,15 +916,22 @@ func (st *State) insertUnit(
 		return "", "", errors.Capture(err)
 	}
 	createParams := unitDetails{
-		ApplicationID: appUUID,
-		UnitUUID:      unitUUID,
-		Name:          args.UnitName,
-		NetNodeID:     nodeUUID.String(),
-		LifeID:        life.Alive,
+		ApplicationID:  appUUID,
+		UnitUUID:       unitUUID,
+		Name:           args.UnitName,
+		NetNodeID:      nodeUUID.String(),
+		LifeID:         life.Alive,
+		OSID:           int(args.Platform.OSType),
+		ArchitectureID: int(args.Platform.Architecture),
 	}
 	if args.Password != nil {
 		createParams.PasswordHash = args.Password.PasswordHash
 		createParams.PasswordHashAlgorithmID = args.Password.HashAlgorithm
+	}
+	if args.Channel != nil {
+		createParams.Track = args.Channel.Track
+		createParams.Branch = args.Channel.Branch
+		createParams.Risk = string(args.Channel.Risk)
 	}
 
 	createUnit := `INSERT INTO unit (*) VALUES ($unitDetails.*)`

--- a/domain/application/types.go
+++ b/domain/application/types.go
@@ -220,6 +220,12 @@ type InsertUnitArg struct {
 	Storage          []ApplicationStorageArg
 	StoragePoolKind  map[string]storage.StorageKind
 	StorageParentDir string
+	// Platform contains the platform information for the unit. The
+	// operating system and architecture.
+	Platform Platform
+	// Channel contains the channel information for the unit. The track,
+	// risk and branch of the charm when it was downloaded from the charm store.
+	Channel *Channel
 	UnitStatusArg
 }
 

--- a/domain/relation/state/relation_test.go
+++ b/domain/relation/state/relation_test.go
@@ -809,9 +809,9 @@ VALUES (?)
 `, fakeNetNodeUUID)
 
 	s.query(c, `
-INSERT INTO unit (uuid, name, life_id, application_uuid, net_node_uuid)
-VALUES (?,?,?,?,?)
-`, unitUUID, unitName, 0 /* alive */, appUUID, fakeNetNodeUUID)
+INSERT INTO unit (uuid, name, life_id, application_uuid, net_node_uuid, risk, os_id, architecture_id)
+VALUES (?,?,?,?,?,?,?,?)
+`, unitUUID, unitName, 0 /* alive */, appUUID, fakeNetNodeUUID, "stable", "0", "0")
 }
 
 // addApplicationEndpoint inserts a new application endpoint into the database with the specified UUIDs and relation data.

--- a/domain/resource/state/resource_test.go
+++ b/domain/resource/state/resource_test.go
@@ -102,12 +102,12 @@ func (s *resourceSuite) SetUpTest(c *gc.C) {
 			return errors.Capture(err)
 		}
 
-		_, err = tx.ExecContext(ctx, `INSERT INTO unit (uuid, name, life_id, application_uuid, net_node_uuid) VALUES (?, ?, ?, ?, ?),(?, ?, ?, ?, ?),(?, ?, ?, ?, ?)`,
-			s.constants.fakeUnitUUID1, s.constants.fakeUnitName1, 0 /* alive */, s.constants.fakeApplicationUUID1, fakeNetNodeUUID,
+		_, err = tx.ExecContext(ctx, `INSERT INTO unit (uuid, name, life_id, application_uuid, net_node_uuid, risk, os_id, architecture_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?),(?, ?, ?, ?, ?, ?, ?, ?),(?, ?, ?, ?, ?, ?, ?, ?)`,
+			s.constants.fakeUnitUUID1, s.constants.fakeUnitName1, 0 /* alive */, s.constants.fakeApplicationUUID1, fakeNetNodeUUID, "stable", "0", "0",
 			s.constants.fakeUnitUUID2, s.constants.fakeUnitName2, 0 /* alive */, s.constants.fakeApplicationUUID1,
-			fakeNetNodeUUID,
+			fakeNetNodeUUID, "stable", "0", "0",
 			s.constants.fakeUnitUUID3, s.constants.fakeUnitName3, 0 /* alive */, s.constants.fakeApplicationUUID1,
-			fakeNetNodeUUID,
+			fakeNetNodeUUID, "stable", "0", "0",
 		)
 		if err != nil {
 			return errors.Capture(err)

--- a/domain/schema/model/sql/0020-unit.sql
+++ b/domain/schema/model/sql/0020-unit.sql
@@ -23,6 +23,11 @@ CREATE TABLE unit (
     resolve_kind_id INT NOT NULL DEFAULT 0,
     password_hash_algorithm_id TEXT,
     password_hash TEXT,
+    track TEXT,
+    risk TEXT NOT NULL,
+    branch TEXT,
+    os_id TEXT NOT NULL,
+    architecture_id INT NOT NULL,
     CONSTRAINT fk_unit_life
     FOREIGN KEY (life_id)
     REFERENCES life (id),
@@ -40,7 +45,13 @@ CREATE TABLE unit (
     REFERENCES charm (uuid),
     CONSTRAINT fk_unit_password_hash_algorithm
     FOREIGN KEY (password_hash_algorithm_id)
-    REFERENCES password_hash_algorithm (id)
+    REFERENCES password_hash_algorithm (id),
+    CONSTRAINT fk_unit_os
+    FOREIGN KEY (os_id)
+    REFERENCES os (id),
+    CONSTRAINT fk_unit_architecture
+    FOREIGN KEY (architecture_id)
+    REFERENCES architecture (id)
 );
 
 CREATE UNIQUE INDEX idx_unit_name

--- a/domain/schema/model/triggers/application-triggers.gen.go
+++ b/domain/schema/model/triggers/application-triggers.gen.go
@@ -241,7 +241,12 @@ WHEN
 	(NEW.charm_uuid != OLD.charm_uuid OR (NEW.charm_uuid IS NOT NULL AND OLD.charm_uuid IS NULL) OR (NEW.charm_uuid IS NULL AND OLD.charm_uuid IS NOT NULL)) OR
 	NEW.resolve_kind_id != OLD.resolve_kind_id OR
 	(NEW.password_hash_algorithm_id != OLD.password_hash_algorithm_id OR (NEW.password_hash_algorithm_id IS NOT NULL AND OLD.password_hash_algorithm_id IS NULL) OR (NEW.password_hash_algorithm_id IS NULL AND OLD.password_hash_algorithm_id IS NOT NULL)) OR
-	(NEW.password_hash != OLD.password_hash OR (NEW.password_hash IS NOT NULL AND OLD.password_hash IS NULL) OR (NEW.password_hash IS NULL AND OLD.password_hash IS NOT NULL)) 
+	(NEW.password_hash != OLD.password_hash OR (NEW.password_hash IS NOT NULL AND OLD.password_hash IS NULL) OR (NEW.password_hash IS NULL AND OLD.password_hash IS NOT NULL)) OR
+	(NEW.track != OLD.track OR (NEW.track IS NOT NULL AND OLD.track IS NULL) OR (NEW.track IS NULL AND OLD.track IS NOT NULL)) OR
+	NEW.risk != OLD.risk OR
+	(NEW.branch != OLD.branch OR (NEW.branch IS NOT NULL AND OLD.branch IS NULL) OR (NEW.branch IS NULL AND OLD.branch IS NOT NULL)) OR
+	NEW.os_id != OLD.os_id OR
+	NEW.architecture_id != OLD.architecture_id 
 BEGIN
     INSERT INTO change_log (edit_type_id, namespace_id, changed, created_at)
     VALUES (2, %[2]d, OLD.%[1]s, DATETIME('now'));

--- a/domain/schema/secret_schema_test.go
+++ b/domain/schema/secret_schema_test.go
@@ -152,8 +152,8 @@ VALUES (?, ?, 'mysql', 0, 0, 'K68fQBBdlQH+MZqOxGP99DJaKl30Ra3z9XL2JiU2eMk=', ?);
 	s.assertExecSQL(c, `INSERT INTO net_node (uuid) VALUES (?);`, unitNetNodeUUID)
 	unitUUID := utils.MustNewUUID().String()
 	s.assertExecSQL(c, `
-INSERT INTO unit (uuid, life_id, name, application_uuid, net_node_uuid, charm_uuid, resolve_kind_id)
-VALUES (?, 0, 0, ?, ?, ?, 0);`,
+INSERT INTO unit (uuid, life_id, name, application_uuid, net_node_uuid, charm_uuid, resolve_kind_id, risk, os_id, architecture_id)
+VALUES (?, 0, 0, ?, ?, ?, 0, 'stable', 0, 0);`,
 		unitUUID, appUUID, unitNetNodeUUID, charmUUID)
 }
 

--- a/domain/secret/state/state_test.go
+++ b/domain/secret/state/state_test.go
@@ -712,9 +712,9 @@ VALUES (?, ?, ?, ?, ?)
 			}
 			unitUUID := uuid.MustNewUUID().String()
 			_, err = tx.ExecContext(ctx, `
-INSERT INTO unit (uuid, life_id, name, net_node_uuid, application_uuid)
-VALUES (?, ?, ?, ?, (SELECT uuid from application WHERE name = ?))
-`, unitUUID, life.Alive, appName+fmt.Sprintf("/%d", i), netNodeUUID, appName)
+INSERT INTO unit (uuid, life_id, name, net_node_uuid, application_uuid, risk, os_id, architecture_id)
+VALUES (?, ?, ?, ?, (SELECT uuid from application WHERE name = ?), ?, ? ,?)
+`, unitUUID, life.Alive, appName+fmt.Sprintf("/%d", i), netNodeUUID, appName, "stable", "0", "0")
 			if err != nil {
 				return errors.Capture(err)
 			}


### PR DESCRIPTION
This small patch adds a base (track, risk, branch) as well as the OS
(id) and the architecture (id) to the unit table.

This is the same behavior that we had in the legacy state.


## QA steps

Nothing wired yet, only `domain/schema/*` unit tests must pass.

## Links

<!-- Add a Jira card reference or link, otherwise remove this line. -->
**Jira card:** JUJU-7602
