### PR TITLE
refactor: remove state model from client storage facade

### DIFF
--- a/apiserver/facades/client/storage/base_test.go
+++ b/apiserver/facades/client/storage/base_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/apiserver/facades/client/storage"
 	apiservertesting "github.com/juju/juju/apiserver/testing"
+	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/domain/blockcommand"
 	jujustorage "github.com/juju/juju/internal/storage"
 	coretesting "github.com/juju/juju/internal/testing"
@@ -71,10 +72,14 @@ func (s *baseStorageSuite) setupMocks(c *gc.C) *gomock.Controller {
 	s.registry = jujustorage.StaticProviderRegistry{Providers: map[jujustorage.ProviderType]jujustorage.Provider{}}
 	s.poolsInUse = []string{}
 
-	s.api = storage.NewStorageAPIForTest(s.state, state.ModelTypeIAAS, s.storageAccessor, s.blockDeviceGetter,
+	s.api = storage.NewStorageAPIForTest(
+		coretesting.ControllerTag, coretesting.ModelTag, coremodel.IAAS,
+		s.state, s.storageAccessor, s.blockDeviceGetter,
 		s.storageService, s.storageRegistryGetter, s.authorizer,
 		s.blockCommandService)
-	s.apiCaas = storage.NewStorageAPIForTest(s.state, state.ModelTypeCAAS, s.storageAccessor, s.blockDeviceGetter,
+	s.apiCaas = storage.NewStorageAPIForTest(
+		coretesting.ControllerTag, coretesting.ModelTag, coremodel.CAAS,
+		s.state, s.storageAccessor, s.blockDeviceGetter,
 		s.storageService, s.storageRegistryGetter, s.authorizer,
 		s.blockCommandService)
 

--- a/apiserver/facades/client/storage/mock_test.go
+++ b/apiserver/facades/client/storage/mock_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/juju/juju/core/blockdevice"
 	"github.com/juju/juju/core/status"
 	"github.com/juju/juju/internal/charm"
-	"github.com/juju/juju/internal/testing"
 	"github.com/juju/juju/state"
 )
 
@@ -393,18 +392,9 @@ func (u *mockUnit) AssignedMachineId() (string, error) {
 }
 
 type mockState struct {
-	modelTag        names.ModelTag
 	unitName        string
 	unitErr         string
 	assignedMachine string
-}
-
-func (st *mockState) ControllerTag() names.ControllerTag {
-	return testing.ControllerTag
-}
-
-func (st *mockState) ModelTag() names.ModelTag {
-	return st.modelTag
 }
 
 func (st *mockState) Unit(unitName string) (storage.Unit, error) {

--- a/apiserver/facades/client/storage/shim.go
+++ b/apiserver/facades/client/storage/shim.go
@@ -108,8 +108,6 @@ var getStorageAccessor = func(
 }
 
 type backend interface {
-	ControllerTag() names.ControllerTag
-	ModelTag() names.ModelTag
 	Unit(string) (Unit, error)
 }
 
@@ -123,10 +121,6 @@ type Unit interface {
 
 type stateShim struct {
 	*state.State
-}
-
-func (s stateShim) ModelTag() names.ModelTag {
-	return names.NewModelTag(s.ModelUUID())
 }
 
 func (s stateShim) Unit(name string) (Unit, error) {

--- a/apiserver/facades/client/storage/storage.go
+++ b/apiserver/facades/client/storage/storage.go
@@ -16,6 +16,7 @@ import (
 	apiservererrors "github.com/juju/juju/apiserver/errors"
 	"github.com/juju/juju/apiserver/facade"
 	k8sconstants "github.com/juju/juju/caas/kubernetes/provider/constants"
+	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/permission"
 	domainstorage "github.com/juju/juju/domain/storage"
 	storageerrors "github.com/juju/juju/domain/storage/errors"
@@ -45,13 +46,18 @@ type StorageAPI struct {
 	storageService        StorageService
 	storageRegistryGetter storageRegistryGetter
 	authorizer            facade.Authorizer
-	modelType             state.ModelType
 	blockCommandService   common.BlockCommandService
+
+	controllerTag names.ControllerTag
+	modelTag      names.ModelTag
+	modelType     coremodel.ModelType
 }
 
 func NewStorageAPI(
+	controllerTag names.ControllerTag,
+	modelTag names.ModelTag,
+	modelType coremodel.ModelType,
 	backend backend,
-	modelType state.ModelType,
 	storageAccess storageAccess,
 	blockDeviceGetter blockDeviceGetter,
 	storageService StorageService,
@@ -60,6 +66,8 @@ func NewStorageAPI(
 	blockCommandService common.BlockCommandService,
 ) *StorageAPI {
 	return &StorageAPI{
+		controllerTag:         controllerTag,
+		modelTag:              modelTag,
 		backend:               backend,
 		modelType:             modelType,
 		storageAccess:         storageAccess,
@@ -72,7 +80,7 @@ func NewStorageAPI(
 }
 
 func (a *StorageAPI) checkCanRead(ctx context.Context) error {
-	err := a.authorizer.HasPermission(ctx, permission.SuperuserAccess, a.backend.ControllerTag())
+	err := a.authorizer.HasPermission(ctx, permission.SuperuserAccess, a.controllerTag)
 	if err != nil && !errors.Is(err, authentication.ErrorEntityMissingPermission) {
 		return errors.Trace(err)
 	}
@@ -80,11 +88,11 @@ func (a *StorageAPI) checkCanRead(ctx context.Context) error {
 	if err == nil {
 		return nil
 	}
-	return a.authorizer.HasPermission(ctx, permission.ReadAccess, a.backend.ModelTag())
+	return a.authorizer.HasPermission(ctx, permission.ReadAccess, a.modelTag)
 }
 
 func (a *StorageAPI) checkCanWrite(ctx context.Context) error {
-	return a.authorizer.HasPermission(ctx, permission.WriteAccess, a.backend.ModelTag())
+	return a.authorizer.HasPermission(ctx, permission.WriteAccess, a.modelTag)
 }
 
 // StorageDetails retrieves and returns detailed information about desired
@@ -191,7 +199,7 @@ func (a *StorageAPI) ListPools(
 }
 
 func (a *StorageAPI) ensureStoragePoolFilter(filter params.StoragePoolFilter) params.StoragePoolFilter {
-	if a.modelType == state.ModelTypeCAAS {
+	if a.modelType == coremodel.CAAS {
 		filter.Providers = append(filter.Providers, k8sconstants.CAASProviderType)
 	}
 	return filter
@@ -687,8 +695,8 @@ func (a *StorageAPI) importFilesystem(
 	cfg *storage.Config,
 ) (*params.ImportStorageDetails, error) {
 	resourceTags := map[string]string{
-		tags.JujuModel:      a.backend.ModelTag().Id(),
-		tags.JujuController: a.backend.ControllerTag().Id(),
+		tags.JujuModel:      a.modelTag.Id(),
+		tags.JujuController: a.controllerTag.Id(),
 	}
 	var volumeInfo *state.VolumeInfo
 	filesystemInfo := state.FilesystemInfo{Pool: arg.Pool}


### PR DESCRIPTION
Remove state model from the client storage facade.

The tests need to be modernised but this will be done as part of the storage epic.

## QA steps

smoke tests

## Links

**Jira card:** [JUJU-7792](https://warthogs.atlassian.net/browse/JUJU-7792)
