### PR TITLE
fix(schema): enforce NOT NULL for charm_relation fields

### DIFF
--- a/domain/application/state/application_endpoint_test.go
+++ b/domain/application/state/application_endpoint_test.go
@@ -464,8 +464,8 @@ func (s *applicationEndpointStateSuite) addRelation(c *gc.C, name string) string
 	relUUID := uuid.MustNewUUID().String()
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		_, err := tx.ExecContext(ctx, `
-INSERT INTO charm_relation (uuid, charm_uuid, kind_id, name)
-VALUES (?,?,0,?)`, relUUID, s.charmUUID, name)
+INSERT INTO charm_relation (uuid, charm_uuid, kind_id, scope_id, role_id, name)
+VALUES (?,?,0,0,0,?)`, relUUID, s.charmUUID, name)
 		return errors.Capture(err)
 	})
 	c.Assert(err, jc.ErrorIsNil, gc.Commentf("(Arrange) Failed to add charm relation: %v", err))

--- a/domain/relation/state/relation_test.go
+++ b/domain/relation/state/relation_test.go
@@ -950,8 +950,8 @@ VALUES (?, ?, 0)
 // addCharmRelationWithDefaults inserts a new charm relation into the database with the given UUID and predefined attributes.
 func (s *relationSuite) addCharmRelationWithDefaults(c *gc.C, charmUUID, charmRelationUUID string) {
 	s.query(c, `
-INSERT INTO charm_relation (uuid, charm_uuid, kind_id, name) 
-VALUES (?, ?, 0, 'fake-provides')
+INSERT INTO charm_relation (uuid, charm_uuid, kind_id, scope_id, role_id, name) 
+VALUES (?, ?, 0, 0, 0, 'fake-provides')
 `, charmRelationUUID, charmUUID)
 }
 

--- a/domain/relation/watcher_test.go
+++ b/domain/relation/watcher_test.go
@@ -146,8 +146,8 @@ VALUES (?, 'app', 0)
 // addCharmRelation inserts a new charm relation into the database with the given UUID and predefined attributes.
 func (s *watcherSuite) addCharmRelation(c *gc.C, charmUUID, charmRelationUUID string) {
 	s.arrange(c, `
-INSERT INTO charm_relation (uuid, charm_uuid, kind_id, name) 
-VALUES (?, ?, 0, 'fake-provides')
+INSERT INTO charm_relation (uuid, charm_uuid, kind_id, scope_id, role_id, name) 
+VALUES (?, ?, 0,0,0, 'fake-provides')
 `, charmRelationUUID, charmUUID)
 }
 

--- a/domain/schema/model/sql/0015-charm.sql
+++ b/domain/schema/model/sql/0015-charm.sql
@@ -264,11 +264,11 @@ CREATE TABLE charm_relation (
     charm_uuid TEXT NOT NULL,
     kind_id TEXT NOT NULL,
     name TEXT NOT NULL,
-    role_id INT,
+    role_id INT NOT NULL,
+    scope_id INT NOT NULL,
     interface TEXT,
     optional BOOLEAN,
     capacity INT,
-    scope_id INT,
     CONSTRAINT fk_charm_relation_charm
     FOREIGN KEY (charm_uuid)
     REFERENCES charm (uuid),
@@ -297,9 +297,9 @@ SELECT
     cr.capacity,
     crs.name AS scope
 FROM charm_relation AS cr
-LEFT JOIN charm_relation_kind AS crk ON cr.kind_id = crk.id
-LEFT JOIN charm_relation_role AS crr ON cr.role_id = crr.id
-LEFT JOIN charm_relation_scope AS crs ON cr.scope_id = crs.id;
+JOIN charm_relation_kind AS crk ON cr.kind_id = crk.id
+JOIN charm_relation_role AS crr ON cr.role_id = crr.id
+JOIN charm_relation_scope AS crs ON cr.scope_id = crs.id;
 
 CREATE INDEX idx_charm_relation_charm
 ON charm_relation (charm_uuid);


### PR DESCRIPTION
There is no reason to allows NULL fields for role_id and scope_id. A relation should always have a scope and a role to be able to relates to another. This commit set this constraint in database, replace LEFT JOIN by simple JOIN in related view and update unit test helpers to insert relation in state.

- `domain/relation/watcher_test.go`: Updated `addCharmRelation` to include `scope_id` and `role_id` in the SQL `INSERT`.
- `domain/relation/state/relation_test.go`: Updated `addCharmRelationWithDefaults` to include `scope_id` and `role_id` in the SQL `INSERT`.
- `domain/schema/model/sql/0015-charm.sql`: Modified `charm_relation` table to make `scope_id` and `role_id` fields mandatory (`NOT NULL`). Updated JOIN clauses to change `LEFT JOIN` to `JOIN` for related fields.
- `domain/application/state/application_endpoint_test.go`: Updated SQL `INSERT` in transactional test to include mandatory `scope_id` and `role_id` fields.

## QA steps

Unit test should pass

## Links

follow up PR:
* #19325 
* comment: https://github.com/juju/juju/pull/19345#discussion_r2021254897