### PR TITLE
refactor: remove all ReconfigureDelay usage from clients

### DIFF
--- a/api/agent/provisioner/provisioner.go
+++ b/api/agent/provisioner/provisioner.go
@@ -257,19 +257,19 @@ func (st *Client) SetHostMachineNetworkConfig(ctx context.Context, hostMachineTa
 	return nil
 }
 
-func (st *Client) HostChangesForContainer(ctx context.Context, containerTag names.MachineTag) ([]network.DeviceToBridge, int, error) {
+func (st *Client) HostChangesForContainer(ctx context.Context, containerTag names.MachineTag) ([]network.DeviceToBridge, error) {
 	var result params.HostNetworkChangeResults
 	args := params.Entities{
 		Entities: []params.Entity{{Tag: containerTag.String()}},
 	}
 	if err := st.facade.FacadeCall(ctx, "HostChangesForContainers", args, &result); err != nil {
-		return nil, 0, err
+		return nil, err
 	}
 	if len(result.Results) != 1 {
-		return nil, 0, errors.Errorf("expected 1 result, got %d", len(result.Results))
+		return nil, errors.Errorf("expected 1 result, got %d", len(result.Results))
 	}
 	if err := result.Results[0].Error; err != nil {
-		return nil, 0, err
+		return nil, err
 	}
 	newBridges := result.Results[0].NewBridges
 	res := make([]network.DeviceToBridge, len(newBridges))
@@ -278,7 +278,7 @@ func (st *Client) HostChangesForContainer(ctx context.Context, containerTag name
 		res[i].DeviceName = bridgeInfo.HostDeviceName
 		res[i].MACAddress = bridgeInfo.MACAddress
 	}
-	return res, result.Results[0].ReconfigureDelay, nil
+	return res, nil
 }
 
 // DistributionGroupByMachineId returns a slice of machine.Ids

--- a/internal/container/broker/broker.go
+++ b/internal/container/broker/broker.go
@@ -34,7 +34,7 @@ type APICalls interface {
 	GetContainerProfileInfo(context.Context, names.MachineTag) ([]*apiprovisioner.LXDProfileResult, error)
 	ReleaseContainerAddresses(context.Context, names.MachineTag) error
 	SetHostMachineNetworkConfig(context.Context, names.MachineTag, []params.NetworkConfig) error
-	HostChangesForContainer(context.Context, names.MachineTag) ([]network.DeviceToBridge, int, error)
+	HostChangesForContainer(context.Context, names.MachineTag) ([]network.DeviceToBridge, error)
 }
 
 // resolvConf contains the full path to common resolv.conf files on the local

--- a/internal/container/broker/broker_test.go
+++ b/internal/container/broker/broker_test.go
@@ -181,12 +181,12 @@ func (f *fakeAPI) SetHostMachineNetworkConfig(ctx context.Context, hostMachineTa
 	return nil
 }
 
-func (f *fakeAPI) HostChangesForContainer(ctx context.Context, machineTag names.MachineTag) ([]network.DeviceToBridge, int, error) {
+func (f *fakeAPI) HostChangesForContainer(ctx context.Context, machineTag names.MachineTag) ([]network.DeviceToBridge, error) {
 	f.MethodCall(f, "HostChangesForContainer", machineTag)
 	if err := f.NextErr(); err != nil {
-		return nil, 0, err
+		return nil, err
 	}
-	return []network.DeviceToBridge{f.fakeDeviceToBridge}, 0, nil
+	return []network.DeviceToBridge{f.fakeDeviceToBridge}, nil
 }
 
 func (f *fakeAPI) PrepareHost(ctx context.Context, containerTag names.MachineTag, log corelogger.Logger, abort <-chan struct{}) error {

--- a/internal/container/broker/host_preparer.go
+++ b/internal/container/broker/host_preparer.go
@@ -21,7 +21,7 @@ type PrepareAPI interface {
 	// HostChangesForContainer returns the list of bridges to be created on the
 	// host machine, and the time to sleep after creating the bridges before
 	// bringing them up.
-	HostChangesForContainer(context.Context, names.MachineTag) ([]network.DeviceToBridge, int, error)
+	HostChangesForContainer(context.Context, names.MachineTag) ([]network.DeviceToBridge, error)
 	// SetHostMachineNetworkConfig allows us to report back the host machine's
 	// current networking config. This is called after we've created new
 	// bridges to inform the Controller what the current networking interfaces
@@ -74,7 +74,7 @@ func (hp *HostPreparer) Prepare(ctx context.Context, containerTag names.MachineT
 	}
 	defer releaser()
 
-	devicesToBridge, _, err := hp.api.HostChangesForContainer(ctx, containerTag)
+	devicesToBridge, err := hp.api.HostChangesForContainer(ctx, containerTag)
 	if err != nil {
 		return errors.Annotate(err, "unable to setup network")
 	}

--- a/internal/container/broker/host_preparer_test.go
+++ b/internal/container/broker/host_preparer_test.go
@@ -25,17 +25,16 @@ import (
 type fakePrepareAPI struct {
 	*jujutesting.Stub
 	requestedBridges []network.DeviceToBridge
-	reconfigureDelay int
 }
 
 var _ broker.PrepareAPI = (*fakePrepareAPI)(nil)
 
-func (api *fakePrepareAPI) HostChangesForContainer(ctx context.Context, tag names.MachineTag) ([]network.DeviceToBridge, int, error) {
+func (api *fakePrepareAPI) HostChangesForContainer(ctx context.Context, tag names.MachineTag) ([]network.DeviceToBridge, error) {
 	api.Stub.MethodCall(api, "HostChangesForContainer", tag)
 	if err := api.Stub.NextErr(); err != nil {
-		return nil, 0, err
+		return nil, err
 	}
-	return api.requestedBridges, api.reconfigureDelay, nil
+	return api.requestedBridges, nil
 }
 
 func (api *fakePrepareAPI) SetHostMachineNetworkConfig(ctx context.Context, tag names.MachineTag, config []params.NetworkConfig) error {

--- a/internal/container/broker/mocks/apicalls_mock.go
+++ b/internal/container/broker/mocks/apicalls_mock.go
@@ -123,13 +123,12 @@ func (c *MockAPICallsGetContainerProfileInfoCall) DoAndReturn(f func(context.Con
 }
 
 // HostChangesForContainer mocks base method.
-func (m *MockAPICalls) HostChangesForContainer(arg0 context.Context, arg1 names.MachineTag) ([]network0.DeviceToBridge, int, error) {
+func (m *MockAPICalls) HostChangesForContainer(arg0 context.Context, arg1 names.MachineTag) ([]network0.DeviceToBridge, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HostChangesForContainer", arg0, arg1)
 	ret0, _ := ret[0].([]network0.DeviceToBridge)
-	ret1, _ := ret[1].(int)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // HostChangesForContainer indicates an expected call of HostChangesForContainer.
@@ -145,19 +144,19 @@ type MockAPICallsHostChangesForContainerCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockAPICallsHostChangesForContainerCall) Return(arg0 []network0.DeviceToBridge, arg1 int, arg2 error) *MockAPICallsHostChangesForContainerCall {
-	c.Call = c.Call.Return(arg0, arg1, arg2)
+func (c *MockAPICallsHostChangesForContainerCall) Return(arg0 []network0.DeviceToBridge, arg1 error) *MockAPICallsHostChangesForContainerCall {
+	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockAPICallsHostChangesForContainerCall) Do(f func(context.Context, names.MachineTag) ([]network0.DeviceToBridge, int, error)) *MockAPICallsHostChangesForContainerCall {
+func (c *MockAPICallsHostChangesForContainerCall) Do(f func(context.Context, names.MachineTag) ([]network0.DeviceToBridge, error)) *MockAPICallsHostChangesForContainerCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockAPICallsHostChangesForContainerCall) DoAndReturn(f func(context.Context, names.MachineTag) ([]network0.DeviceToBridge, int, error)) *MockAPICallsHostChangesForContainerCall {
+func (c *MockAPICallsHostChangesForContainerCall) DoAndReturn(f func(context.Context, names.MachineTag) ([]network0.DeviceToBridge, error)) *MockAPICallsHostChangesForContainerCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/worker/containerbroker/mocks/state_mock.go
+++ b/internal/worker/containerbroker/mocks/state_mock.go
@@ -162,13 +162,12 @@ func (c *MockStateGetContainerProfileInfoCall) DoAndReturn(f func(context.Contex
 }
 
 // HostChangesForContainer mocks base method.
-func (m *MockState) HostChangesForContainer(arg0 context.Context, arg1 names.MachineTag) ([]network0.DeviceToBridge, int, error) {
+func (m *MockState) HostChangesForContainer(arg0 context.Context, arg1 names.MachineTag) ([]network0.DeviceToBridge, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HostChangesForContainer", arg0, arg1)
 	ret0, _ := ret[0].([]network0.DeviceToBridge)
-	ret1, _ := ret[1].(int)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // HostChangesForContainer indicates an expected call of HostChangesForContainer.
@@ -184,19 +183,19 @@ type MockStateHostChangesForContainerCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockStateHostChangesForContainerCall) Return(arg0 []network0.DeviceToBridge, arg1 int, arg2 error) *MockStateHostChangesForContainerCall {
-	c.Call = c.Call.Return(arg0, arg1, arg2)
+func (c *MockStateHostChangesForContainerCall) Return(arg0 []network0.DeviceToBridge, arg1 error) *MockStateHostChangesForContainerCall {
+	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockStateHostChangesForContainerCall) Do(f func(context.Context, names.MachineTag) ([]network0.DeviceToBridge, int, error)) *MockStateHostChangesForContainerCall {
+func (c *MockStateHostChangesForContainerCall) Do(f func(context.Context, names.MachineTag) ([]network0.DeviceToBridge, error)) *MockStateHostChangesForContainerCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateHostChangesForContainerCall) DoAndReturn(f func(context.Context, names.MachineTag) ([]network0.DeviceToBridge, int, error)) *MockStateHostChangesForContainerCall {
+func (c *MockStateHostChangesForContainerCall) DoAndReturn(f func(context.Context, names.MachineTag) ([]network0.DeviceToBridge, error)) *MockStateHostChangesForContainerCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }


### PR DESCRIPTION
In https://github.com/juju/juju/pull/18862, we removed the legacy e/n/i bridger. With that we also removed usage of the `net-bond-reconfigure-delay` configuration setting.

Here we roll back usage of that setting further back through the client and server-side.

## QA steps

TBC