### PR TITLE
fix: Revert pull request #19287 

### DIFF
--- a/apiserver/facades/client/applicationoffers/base.go
+++ b/apiserver/facades/client/applicationoffers/base.go
@@ -147,7 +147,6 @@ func (api *BaseAPI) applicationOffersFromModel(
 		}}
 		offer := params.ApplicationOfferAdminDetailsV5{
 			ApplicationOfferDetailsV5: *offerParams,
-			ApplicationName:           appOffer.ApplicationName,
 		}
 		// Only admins can see some sensitive details of the offer.
 		if isAdmin {
@@ -228,34 +227,14 @@ func (api *BaseAPI) getOfferAdminDetails(user names.UserTag, backend Backend, ap
 // checkOfferAccess returns the level of access the authenticated user has to the offer,
 // so long as it is greater than the requested perm.
 func (api *BaseAPI) checkOfferAccess(user names.UserTag, backend Backend, offerUUID string) (permission.Access, error) {
-	// If the authenticated user is controller superuser we return `admin`.
-	err := api.Authorizer.EntityHasPermission(user, permission.SuperuserAccess, backend.ControllerTag())
-	if err != nil && !errors.Is(err, authentication.ErrorEntityMissingPermission) {
+	access, err := backend.GetOfferAccess(offerUUID, user)
+	if err != nil && !errors.IsNotFound(err) {
 		return permission.NoAccess, errors.Trace(err)
-	} else if err == nil {
-		return permission.AdminAccess, nil
 	}
-
-	// If the authenticated user is model administrator we return `admin`.
-	err = api.Authorizer.EntityHasPermission(user, permission.AdminAccess, backend.ModelTag())
-	if err != nil && !errors.Is(err, authentication.ErrorEntityMissingPermission) {
-		return permission.NoAccess, errors.Trace(err)
-	} else if err == nil {
-		return permission.AdminAccess, nil
+	if !access.EqualOrGreaterOfferAccessThan(permission.ReadAccess) {
+		return permission.NoAccess, nil
 	}
-
-	// We loop through access levels in decreasing order to return the highest access level the authenticated
-	// user has to the application offer.
-	for _, access := range []permission.Access{permission.AdminAccess, permission.ConsumeAccess, permission.ReadAccess} {
-		err := api.Authorizer.EntityHasPermission(user, access, names.NewApplicationOfferTag(offerUUID))
-		if err != nil && !errors.Is(err, authentication.ErrorEntityMissingPermission) {
-			return permission.NoAccess, errors.Trace(err)
-		} else if err == nil {
-			return access, nil
-		}
-	}
-
-	return permission.NoAccess, nil
+	return access, nil
 }
 
 type offerModel struct {

--- a/apiserver/testing/fakeauthorizer.go
+++ b/apiserver/testing/fakeauthorizer.go
@@ -198,8 +198,5 @@ func (fa FakeAuthorizer) EntityHasPermission(entity names.Tag, operation permiss
 	if operation == permission.ConsumeAccess && fa.HasConsumeTag != emptyTag && entity == fa.HasConsumeTag {
 		return nil
 	}
-	if operation == permission.ReadAccess && fa.HasReadTag != emptyTag && entity == fa.HasReadTag {
-		return nil
-	}
 	return errors.WithType(apiservererrors.ErrPerm, authentication.ErrorEntityMissingPermission)
 }


### PR DESCRIPTION
Revert pull request #19287 from alesstimec/fix-authorization-check-for-list-show-offers

This reverts commit 0cd4a7bd2d86f53b54987bb53feae47bab30626f, reversing changes made to 452e7664edc798a035ecaecfe588aa5fea8c9247.

The reason for this revert is that I've noticed that Terraform tests were failing just after we landed this PR, after testing it out locally I confirm this suspect.

Since the release is tomorrow, it is very difficult that we find the exact issue, so we're just gonna revert this commit and work out the solution later.