### PR TITLE
docs: new support date for 3.6

### DIFF
--- a/docs/user/reference/juju/juju-roadmap-and-releases.md
+++ b/docs/user/reference/juju/juju-roadmap-and-releases.md
@@ -49,7 +49,7 @@ See the full list in the [milestone page](https://launchpad.net/juju/+milestone/
 ## :juju: **Juju 3.6**
 > 30 May 2030: expected end of security fix support
 >
-> 30 May 2025: expected end of bug fix support
+> 1 May 2026: expected end of bug fix support
 
 ```{note}
 Juju 3.6 series is LTS


### PR DESCRIPTION
Extended support for 3.6 by 1 year.:
Support of 3.6 LTS for bug fixing extended until 1st of May 2026
