### PR TITLE
docs: new support date for 3.6

### DIFF
--- a/docs/reference/juju/juju-roadmap-and-releases.md
+++ b/docs/reference/juju/juju-roadmap-and-releases.md
@@ -43,7 +43,7 @@ See the full list in the [milestone page](https://launchpad.net/juju/+milestone/
 ## ⭐ **Juju 3.6**
 > 30 May 2030: expected end of security fix support
 >
-> 30 May 2025: expected end of bug fix support
+> 1 May 2026: expected end of bug fix support
 
 ```{note}
 Juju 3.6 series is LTS


### PR DESCRIPTION
Updated bug-fix support date for 3.6 LTS. Bug-fixing will be supported until the 1st of May 2026.
