### PR TITLE
docs: 3.6+ fix slug

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -131,7 +131,7 @@ html_context = {
 # TODO: If your documentation is hosted on https://docs.ubuntu.com/,
 #       uncomment and update as needed.
 
-# slug = ''
+slug = 'juju'
 
 
 # Template and asset locations


### PR DESCRIPTION
> This PR should be forward-merged into Juju 4.

Following the move of Juju docs under documentation.ubuntu.com, some links (e.g., [this one](https://documentation.ubuntu.com/juju/latest/user/reference/configuration/list-of-controller-configuration-keys/)) fail. 

The problem seems to be that, when you open a link in the Juju subproject, static resources are fetched from the root instead of the subproject, with the result that CSS or PNG files end up missing.

The fix is to specify the subproject slug in `conf.py` > `slug`. This PR does that.