### PR TITLE
chore: minor removals of unused methods from state application

### DIFF
--- a/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/provisioner.go
@@ -54,7 +54,6 @@ import (
 	"github.com/juju/juju/internal/storage"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
-	stateerrors "github.com/juju/juju/state/errors"
 	"github.com/juju/juju/state/watcher"
 )
 
@@ -1208,15 +1207,6 @@ func (a *API) updateUnitsFromCloud(ctx context.Context, app Application, unitUpd
 		} else if err != nil {
 			return nil, errors.Annotatef(err, "updating unit %q", unitName)
 		}
-	}
-
-	// TODO(units) - remove dual write to state
-	err = app.UpdateUnits(&unitUpdate)
-	// We ignore any updates for dying applications.
-	if stateerrors.IsNotAlive(err) {
-		return nil, nil
-	} else if err != nil {
-		return nil, errors.Trace(err)
 	}
 
 	// If pods are recreated on the Kubernetes side, new units are created on the Juju

--- a/apiserver/facades/controller/caasapplicationprovisioner/provisioner_test.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/provisioner_test.go
@@ -496,7 +496,7 @@ func (s *CAASApplicationProvisionerSuite) TestUpdateApplicationsUnitsWithStorage
 			},
 		},
 	})
-	s.st.app.CheckCallNames(c, "Life", "AllUnits", "UpdateUnits", "Name")
+	s.st.app.CheckCallNames(c, "Life", "AllUnits", "Name")
 	s.st.app.units[0].CheckCallNames(c, "UpdateOperation")
 	s.st.app.units[0].CheckCall(c, 0, "UpdateOperation", state.UnitUpdateProperties{
 		ProviderId: strPtr("gitlab-0"),
@@ -652,7 +652,7 @@ func (s *CAASApplicationProvisionerSuite) TestUpdateApplicationsUnitsWithoutStor
 			},
 		},
 	})
-	s.st.app.CheckCallNames(c, "Life", "AllUnits", "UpdateUnits", "Name")
+	s.st.app.CheckCallNames(c, "Life", "AllUnits", "Name")
 	s.st.app.units[0].CheckCallNames(c, "UpdateOperation")
 	s.st.app.units[0].CheckCall(c, 0, "UpdateOperation", state.UnitUpdateProperties{
 		ProviderId: strPtr("gitlab-0"),

--- a/apiserver/facades/controller/caasapplicationprovisioner/state.go
+++ b/apiserver/facades/controller/caasapplicationprovisioner/state.go
@@ -45,7 +45,6 @@ type Model interface {
 
 type Application interface {
 	AllUnits() ([]Unit, error)
-	UpdateUnits(unitsOp *state.UpdateUnitsOperation) error
 	StorageConstraints() (map[string]state.StorageConstraints, error)
 	DeviceConstraints() (map[string]state.DeviceConstraints, error)
 	Name() string

--- a/state/migration_import.go
+++ b/state/migration_import.go
@@ -617,17 +617,6 @@ func (i *importer) application(a description.Application, ctrlCfg controller.Con
 		return errors.Trace(err)
 	}
 
-	if cs := a.CloudService(); cs != nil {
-		app, err := i.st.Application(a.Name())
-		if err != nil {
-			return errors.Trace(err)
-		}
-		addr := i.makeAddresses(cs.Addresses())
-		if err := app.UpdateCloudService(cs.ProviderId(), networkAddresses(addr)); err != nil {
-			return errors.Trace(err)
-		}
-	}
-
 	for _, unit := range a.Units() {
 		if err := i.unit(a, unit, ctrlCfg); err != nil {
 			return errors.Trace(err)

--- a/state/modelmigration.go
+++ b/state/modelmigration.go
@@ -510,25 +510,6 @@ func (mig *modelMigration) getAllAgents() (names.Set, error) {
 		return agentTags.Union(unitTags), nil
 	}
 
-	applicationTags, err := mig.loadAgentTags(applicationsC, "name",
-		func(name string) names.Tag { return names.NewApplicationTag(name) },
-	)
-	if err != nil {
-		return nil, errors.Annotate(err, "loading application names")
-	}
-	for _, applicationTag := range applicationTags.Values() {
-		app, err := mig.st.Application(applicationTag.Id())
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		unitNames, err := app.UnitNames()
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		for _, unitName := range unitNames {
-			agentTags.Add(names.NewUnitTag(unitName))
-		}
-	}
 	return agentTags, nil
 }
 

--- a/state/unit.go
+++ b/state/unit.go
@@ -276,15 +276,6 @@ func (u *Unit) SetAgentVersion(v semversion.Binary) (err error) {
 	return nil
 }
 
-func (u *Unit) setPasswordHashOps(passwordHash string) []txn.Op {
-	return []txn.Op{{
-		C:      unitsC,
-		Id:     u.doc.DocID,
-		Assert: notDeadDoc,
-		Update: bson.D{{"$set", bson.D{{"passwordhash", passwordHash}}}},
-	}}
-}
-
 // UpdateOperation returns a model operation that will update a unit.
 func (u *Unit) UpdateOperation(props UnitUpdateProperties) *UpdateUnitOperation {
 	return &UpdateUnitOperation{


### PR DESCRIPTION
This patch is just the beginning of the cleanup of state/application.go. 

This only includes removal of unused methods, as well as UpdateUnits() which was dual-writing and could be simply removed.


## QA steps

Nothing should break since these methods are unused, unit tests should pass.



