### PR TITLE
fix(state): enforce deterministic peer relation ordering

### DIFF
--- a/domain/application/state/peer_relation.go
+++ b/domain/application/state/peer_relation.go
@@ -29,7 +29,9 @@ FROM   application_endpoint ae
 JOIN   charm_relation cr ON cr.uuid = ae.charm_relation_uuid
 JOIN   charm_relation_role crr ON crr.id = cr.role_id
 WHERE  ae.application_uuid = $application.uuid
-AND    crr.name = 'peer'`, app,
+AND    crr.name = 'peer'
+ORDER BY cr.name -- ensure that peer endpoints relation id are always generated in alphabetical order
+`, app,
 		peerEndpoint{})
 	if err != nil {
 		return nil, errors.Capture(err)


### PR DESCRIPTION
Before_ this commit, peer relation creation wasn't deterministic. Despite not a bug, it was not nice,
 and make the feature more complex to test.
After this change, peer relation will always been created in alphabetic order, their relation_id will be sequentially ordered corresponding to their names.

- `domain/application/state/peer_relation.go`: Added `ORDER BY cr.name` clause  while fetching peer charm relation to ensure peer relation IDs are always generated in alphabetical order.
- `domain/application/state/application_test.go`: Refactored peer relation testing logic for better determinism and robustness. Combined queries to include relation statuses in a single step, and ensured peer relations are sorted before assertions.

## Checklist


- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing

## QA steps

Run the unit test until it fails. It you reach your EOD or get bored, it is good, if you reach the End Of Universe, maybe you QAed too far.

## Links

Matrix: https://matrix.to/#/!wJiiHsLipVywuWOyNi:ubuntu.com/$5syeziZFSSb5Xzi0OwXCzKIU92IitpI7bm6R4Wq1JUA?via=ubuntu.com&via=matrix.org