### PR TITLE
test: fix two machine watcher tests missing harness.Run()

### DIFF
--- a/domain/machine/watcher_test.go
+++ b/domain/machine/watcher_test.go
@@ -107,6 +107,8 @@ func (s *watcherSuite) TestMachineCloudInstanceWatchWithSet(c *gc.C) {
 	}, func(w watchertest.WatcherC[struct{}]) {
 		w.Check(watchertest.SliceAssert(struct{}{}))
 	})
+
+	harness.Run(c, struct{}{})
 }
 
 func (s *watcherSuite) TestMachineCloudInstanceWatchWithDelete(c *gc.C) {
@@ -133,6 +135,8 @@ func (s *watcherSuite) TestMachineCloudInstanceWatchWithDelete(c *gc.C) {
 	}, func(w watchertest.WatcherC[struct{}]) {
 		w.Check(watchertest.SliceAssert(struct{}{}))
 	})
+
+	harness.Run(c, struct{}{})
 }
 
 func (s *watcherSuite) TestWatchLXDProfiles(c *gc.C) {


### PR DESCRIPTION
This small patch fixes two tests that were missing the harness.Run() at the end of these watcher tests.


## QA steps

Simply two unit tests fix, nothing should break.

## Links

**Jira card:** JUJU-
