### PR TITLE
chore: remove unused agent facade

### DIFF
--- a/apiserver/facades/agent-schema.json
+++ b/apiserver/facades/agent-schema.json
@@ -10990,17 +10990,6 @@
                         }
                     }
                 },
-                "Resolved": {
-                    "type": "object",
-                    "properties": {
-                        "Params": {
-                            "$ref": "#/definitions/Entities"
-                        },
-                        "Result": {
-                            "$ref": "#/definitions/ResolvedModeResults"
-                        }
-                    }
-                },
                 "SetAgentStatus": {
                     "type": "object",
                     "properties": {
@@ -12949,36 +12938,6 @@
                             "type": "array",
                             "items": {
                                 "$ref": "#/definitions/RelationUnitsWatchResult"
-                            }
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "results"
-                    ]
-                },
-                "ResolvedModeResult": {
-                    "type": "object",
-                    "properties": {
-                        "error": {
-                            "$ref": "#/definitions/Error"
-                        },
-                        "mode": {
-                            "type": "string"
-                        }
-                    },
-                    "additionalProperties": false,
-                    "required": [
-                        "mode"
-                    ]
-                },
-                "ResolvedModeResults": {
-                    "type": "object",
-                    "properties": {
-                        "results": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/ResolvedModeResult"
                             }
                         }
                     },

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -428,34 +428,6 @@ func (u *UniterAPI) AvailabilityZone(ctx context.Context, args params.Entities) 
 	return results, nil
 }
 
-// Resolved returns the current resolved setting for each given unit.
-func (u *UniterAPI) Resolved(ctx context.Context, args params.Entities) (params.ResolvedModeResults, error) {
-	result := params.ResolvedModeResults{
-		Results: make([]params.ResolvedModeResult, len(args.Entities)),
-	}
-	canAccess, err := u.accessUnit()
-	if err != nil {
-		return params.ResolvedModeResults{}, err
-	}
-	for i, entity := range args.Entities {
-		tag, err := names.ParseUnitTag(entity.Tag)
-		if err != nil {
-			result.Results[i].Error = apiservererrors.ServerError(apiservererrors.ErrPerm)
-			continue
-		}
-		err = apiservererrors.ErrPerm
-		if canAccess(tag) {
-			var unit *state.Unit
-			unit, err = u.getUnit(tag)
-			if err == nil {
-				result.Results[i].Mode = params.ResolvedMode(unit.Resolved())
-			}
-		}
-		result.Results[i].Error = apiservererrors.ServerError(err)
-	}
-	return result, nil
-}
-
 // ClearResolved removes any resolved setting from each given unit.
 func (u *UniterAPI) ClearResolved(ctx context.Context, args params.Entities) (params.ErrorResults, error) {
 	result := params.ErrorResults{


### PR DESCRIPTION
The agent facade "Resolved" in unused, and has been unused for a long time.

Now that we're developing a new major version, we can remove it.

## QA steps

> [!NOTE]  
> There is currently a bug on the main branch that means units in error status will not be shown as being in error status in juju status. These QA steps base themselves on `juju debug-log` instead.

Construct a charm that fails
e.g., build a charm with:
```py
    def __init__(self, *args):
        logger.debug('Initializing Charm')
        super().__init__(*args)
        self.framework.observe(self.on.install, self._on_install)

    def _on_install(self, _):
        logger.info("Installing the charm...")
        raise Exception("This charm is not meant to be installed.")
```
in it's `src/charm.py`

In my example, I have built then charm to `./error-charm.charm`

Then run:
```
$ juju bootstrap lxd lxd
$ juju add-model m
$ juju deploy ./error-charm.charm ch
```
And wait until the hook stops retrying.
Then run:
```
$ juju resolve ch/0
```
and observe that the hooks begin running again

Then run:
```
$ juju resolve ch/0 --no-retry
```
and observe the unit moves on to the next hook (i,.e. leader-elected). This will probably fail as well.

#### If you want to be really sure, cherry-pick this patch onto 3.6 and re-run the QA