### PR TITLE
refactor(relation): table relation_unit refers relation_endpoint instead of relation

### DIFF
--- a/domain/relation/state/relation.go
+++ b/domain/relation/state/relation.go
@@ -520,9 +520,10 @@ func (st *State) GetRelationsStatusForUnit(
 	}
 
 	stmt, err := st.Prepare(`
-SELECT (ru.relation_uuid, ru.in_scope, vrs.status) AS (&relationUnitStatus.*)
+SELECT (re.relation_uuid, ru.in_scope, vrs.status) AS (&relationUnitStatus.*)
 FROM   relation_unit ru
-JOIN   v_relation_status vrs ON ru.relation_uuid = vrs.relation_uuid
+JOIN   relation_endpoint AS re ON ru.relation_endpoint_uuid = re.uuid 
+JOIN   v_relation_status AS vrs ON re.relation_uuid = vrs.relation_uuid
 WHERE  ru.unit_uuid = $unitUUIDArg.unit_uuid
 `, uuid, relationUnitStatus{})
 	if err != nil {
@@ -816,9 +817,10 @@ func (st *State) GetRelationUnit(
 		stmt, err := st.Prepare(`
 SELECT ru.uuid AS &getRelationUnit.unit_uuid
 FROM   relation_unit ru
-JOIN   unit u ON u.uuid = ru.unit_uuid
+JOIN   unit AS u ON ru.unit_uuid = u.uuid 
+JOIN   relation_endpoint AS re ON ru.relation_endpoint_uuid = re.uuid
 WHERE  u.name = $getRelationUnit.name
-AND    ru.relation_uuid = $getRelationUnit.relation_uuid`, args)
+AND    re.relation_uuid = $getRelationUnit.relation_uuid`, args)
 		if err != nil {
 			return errors.Capture(err)
 		}
@@ -1236,10 +1238,15 @@ func (st *State) upsertRelationUnitAndEnterScope(
 		UnitUUID:     unitUUID,
 	}
 	getRelationUnitStmt, err := st.Prepare(`
-SELECT  &relationUnit.* 
-FROM    relation_unit 
-WHERE   relation_uuid = $relationUnit.relation_uuid
-AND     unit_uuid = $relationUnit.unit_uuid
+SELECT   
+	ru.uuid AS &relationUnit.uuid,
+	re.uuid AS &relationUnit.relation_endpoint_uuid,
+	ru.unit_uuid AS &relationUnit.unit_uuid,
+	ru.in_scope AS &relationUnit.in_scope
+FROM    relation_unit AS ru
+JOIN    relation_endpoint AS re ON ru.relation_endpoint_uuid = re.uuid
+WHERE   re.relation_uuid = $relationUnit.relation_uuid
+AND     ru.unit_uuid = $relationUnit.unit_uuid
 `, getRelationUnit)
 	if err != nil {
 		return errors.Capture(err)
@@ -1272,9 +1279,14 @@ AND     unit_uuid = $relationUnit.unit_uuid
 	}
 
 	insertStmt, err := st.Prepare(`
-INSERT INTO relation_unit (*) 
-VALUES ($relationUnit.*)
-ON CONFLICT (relation_uuid, unit_uuid) DO UPDATE SET
+INSERT INTO relation_unit (uuid, relation_endpoint_uuid, unit_uuid, in_scope) 
+SELECT $relationUnit.uuid, re.uuid, $relationUnit.unit_uuid, $relationUnit.in_scope
+FROM   relation_endpoint AS re
+JOIN   application_endpoint AS ae ON re.endpoint_uuid = ae.uuid
+JOIN   unit AS u ON ae.application_uuid = u.application_uuid
+WHERE  re.relation_uuid = $relationUnit.relation_uuid
+AND    u.uuid = $relationUnit.unit_uuid 
+ON CONFLICT (relation_endpoint_uuid, unit_uuid) DO UPDATE SET
             in_scope = excluded.in_scope
 `, insertRelationUnit)
 	if err != nil {

--- a/domain/relation/state/relation_test.go
+++ b/domain/relation/state/relation_test.go
@@ -1335,7 +1335,7 @@ func (s *relationSuite) TestGetRelationsStatusForUnit(c *gc.C) {
 
 	// Arrange: Add unit to relation and set relation status.
 	relUnitUUID := corerelationtesting.GenRelationUnitUUID(c)
-	s.addRelationUnit(c, unitUUID, relationUUID, relUnitUUID, true)
+	s.addRelationUnit(c, unitUUID, relationEndpointUUID1, relUnitUUID, true)
 	s.addRelationStatus(c, relationUUID, corestatus.Suspended)
 
 	expectedResults := []relation.RelationUnitStatusResult{{
@@ -1400,10 +1400,10 @@ func (s *relationSuite) TestGetRelationsStatusForUnitPeer(c *gc.C) {
 
 	// Arrange: Add unit to both the relation and set their status.
 	relUnitUUID1 := corerelationtesting.GenRelationUnitUUID(c)
-	s.addRelationUnit(c, unitUUID, relationUUID1, relUnitUUID1, true)
+	s.addRelationUnit(c, unitUUID, relationEndpointUUID1, relUnitUUID1, true)
 	s.addRelationStatus(c, relationUUID1, corestatus.Suspended)
 	relUnitUUID2 := corerelationtesting.GenRelationUnitUUID(c)
-	s.addRelationUnit(c, unitUUID, relationUUID2, relUnitUUID2, false)
+	s.addRelationUnit(c, unitUUID, relationEndpointUUID2, relUnitUUID2, false)
 	s.addRelationStatus(c, relationUUID2, corestatus.Joined)
 
 	expectedResults := []relation.RelationUnitStatusResult{{
@@ -1531,7 +1531,7 @@ func (s *relationSuite) TestGetRelationUnitEndpointName(c *gc.C) {
 	s.addRelation(c, relationUUID)
 	s.addRelationEndpoint(c, relationEndpointUUID, relationUUID, applicationEndpointUUID)
 	s.addUnit(c, coreunittesting.GenUnitUUID(c), "unit-name", appUUID)
-	s.addRelationUnit(c, unitUUID, relationUUID, relationUnitUUID, true)
+	s.addRelationUnit(c, unitUUID, relationEndpointUUID, relationUnitUUID, true)
 
 	// Act
 	name, err := s.state.GetRelationUnitEndpointName(context.Background(), relationUnitUUID)
@@ -1556,11 +1556,17 @@ func (s *relationSuite) TestGetRelationUnit(c *gc.C) {
 	unitUUID := coreunittesting.GenUnitUUID(c)
 	relUUID := corerelationtesting.GenRelationUUID(c)
 	relUnitUUID := corerelationtesting.GenRelationUnitUUID(c)
+	relEndpointUUID := uuid.MustNewUUID().String()
+	applicationEndpointUUID := uuid.MustNewUUID().String()
+	charmRelationUUID := uuid.MustNewUUID().String()
 	s.addCharm(c, charmUUID)
 	s.addApplication(c, charmUUID, appUUID, "my-app")
 	s.addUnit(c, unitUUID, "my-app/0", appUUID)
 	s.addRelation(c, relUUID)
-	s.addRelationUnit(c, unitUUID, relUUID, relUnitUUID, true)
+	s.addCharmRelation(c, charmUUID, charmRelationUUID, charm.Relation{})
+	s.addApplicationEndpoint(c, applicationEndpointUUID, appUUID, charmRelationUUID)
+	s.addRelationEndpoint(c, relEndpointUUID, relUUID, applicationEndpointUUID)
+	s.addRelationUnit(c, unitUUID, relEndpointUUID, relUnitUUID, true)
 
 	// Act
 	uuid, err := s.state.GetRelationUnit(context.Background(), relUUID, "my-app/0")
@@ -1796,7 +1802,7 @@ func (s *relationSuite) TestEnterScopeRowAlreadyExists(c *gc.C) {
 	// Arrange: Add relation unit for the unit and relation with in_scope set to
 	// false.
 	relationUnitUUID := corerelationtesting.GenRelationUnitUUID(c)
-	s.addRelationUnit(c, unitUUID, relationUUID, relationUnitUUID, false)
+	s.addRelationUnit(c, unitUUID, relationEndpointUUID1, relationUnitUUID, false)
 
 	// Act: Enter scope.
 	err := s.state.EnterScope(context.Background(), relationUUID, unitName)
@@ -1858,7 +1864,7 @@ func (s *relationSuite) TestEnterScopeIdempotent(c *gc.C) {
 	// Arrange: Add relation unit for the unit and relation with in_scope set to
 	// false.
 	relationUnitUUID := corerelationtesting.GenRelationUnitUUID(c)
-	s.addRelationUnit(c, unitUUID, relationUUID, relationUnitUUID, true)
+	s.addRelationUnit(c, unitUUID, relationEndpointUUID1, relationUnitUUID, true)
 
 	// Act: Enter scope.
 	err := s.state.EnterScope(context.Background(), relationUUID, unitName)
@@ -2483,11 +2489,11 @@ VALUES (?,?,?)
 }
 
 // addRelationUnit inserts a relation unit into the database using the provided UUIDs for relation and unit.
-func (s *relationSuite) addRelationUnit(c *gc.C, unitUUID coreunit.UUID, relationUUID corerelation.UUID, relationUnitUUID corerelation.UnitUUID, inScope bool) {
+func (s *relationSuite) addRelationUnit(c *gc.C, unitUUID coreunit.UUID, relationEndpointUUID string, relationUnitUUID corerelation.UnitUUID, inScope bool) {
 	s.query(c, `
-INSERT INTO relation_unit (uuid, relation_uuid, unit_uuid, in_scope)
+INSERT INTO relation_unit (uuid, relation_endpoint_uuid, unit_uuid, in_scope)
 VALUES (?,?,?,?)
-`, relationUnitUUID, relationUUID, unitUUID, inScope)
+`, relationUnitUUID, relationEndpointUUID, unitUUID, inScope)
 }
 
 // addRelationStatus inserts a relation status into the relation_status table.
@@ -2569,8 +2575,9 @@ func (s *relationSuite) getRelationUnitInScope(c *gc.C, relationUUID corerelatio
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		err := tx.QueryRow(`
 SELECT in_scope
-FROM   relation_unit
-WHERE  relation_uuid = ?
+FROM   relation_unit AS ru
+JOIN   relation_endpoint AS re ON ru.relation_endpoint_uuid = re.uuid
+WHERE  re.relation_uuid = ?
 AND    unit_uuid = ?
 `, relationUUID, unitUUID).Scan(&inScope)
 		if err != nil {

--- a/domain/relation/state/types.go
+++ b/domain/relation/state/types.go
@@ -51,10 +51,11 @@ type applicationPlatform struct {
 }
 
 type relationUnit struct {
-	RelationUnitUUID corerelation.UnitUUID `db:"uuid"`
-	RelationUUID     corerelation.UUID     `db:"relation_uuid"`
-	UnitUUID         unit.UUID             `db:"unit_uuid"`
-	InScope          bool                  `db:"in_scope"`
+	RelationUnitUUID     corerelation.UnitUUID     `db:"uuid"`
+	RelationEndpointUUID corerelation.EndpointUUID `db:"relation_endpoint_uuid"`
+	RelationUUID         corerelation.UUID         `db:"relation_uuid"`
+	UnitUUID             unit.UUID                 `db:"unit_uuid"`
+	InScope              bool                      `db:"in_scope"`
 }
 
 // getRelationUnitEndpointName allows to fetch a endpoint name from a relation

--- a/domain/schema/model/sql/0024-relation.sql
+++ b/domain/schema/model/sql/0024-relation.sql
@@ -84,7 +84,7 @@ ON relation (relation_id);
 -- The relation_unit table links a relation to a specific unit.
 CREATE TABLE relation_unit (
     uuid TEXT NOT NULL PRIMARY KEY,
-    relation_uuid TEXT NOT NULL,
+    relation_endpoint_uuid TEXT NOT NULL,
     unit_uuid TEXT NOT NULL,
     in_scope BOOLEAN DEFAULT FALSE,
     departing BOOLEAN DEFAULT FALSE,
@@ -92,12 +92,12 @@ CREATE TABLE relation_unit (
     FOREIGN KEY (unit_uuid)
     REFERENCES unit (uuid),
     CONSTRAINT fk_relation_uuid
-    FOREIGN KEY (relation_uuid)
-    REFERENCES relation (uuid)
+    FOREIGN KEY (relation_endpoint_uuid)
+    REFERENCES relation_endpoint (uuid)
 );
 
 CREATE UNIQUE INDEX idx_relation_unit
-ON relation_unit (relation_uuid, unit_uuid);
+ON relation_unit (relation_endpoint_uuid, unit_uuid);
 
 -- The relation_unit_setting holds key value pair settings
 -- for a relation at the unit level. Keys must be unique
@@ -194,11 +194,9 @@ SELECT
     ru.uuid AS relation_unit_uuid,
     cr.name AS endpoint_name
 FROM relation_unit AS ru
-JOIN unit AS u ON ru.unit_uuid = u.uuid
-JOIN relation_endpoint AS re ON ru.relation_uuid = re.relation_uuid
+JOIN relation_endpoint AS re ON ru.relation_endpoint_uuid = re.uuid
 JOIN application_endpoint AS ae ON re.endpoint_uuid = ae.uuid
-JOIN charm_relation AS cr ON ae.charm_relation_uuid = cr.uuid
-WHERE u.application_uuid = ae.application_uuid;
+JOIN charm_relation AS cr ON ae.charm_relation_uuid = cr.uuid;
 
 CREATE VIEW v_relation_endpoint AS
 SELECT


### PR DESCRIPTION
This change introduce a direct reference from a relation unit to the application it belongs, instead of requiring a JOIN through unit<application_uuid>application_endpoint.

This simplifies the request GetRelationApplicationEndpointName, but make the insert a bit more complicated (insertion is done through relationUnitUUID) as long as few other requests.

However, new JOIN are unidirectional, which make the overall reasoning about schema simpler.

- `domain/relation/state/relation.go`: Updated queries to use `relation_endpoint_uuid` instead of `relation_uuid`. Adjusted JOINs and conditions accordingly.
- `domain/relation/state/relation_test.go`: Updated test cases to align with the new data model, replacing `relation_uuid` with `relation_endpoint_uuid`.
- `domain/relation/state/types.go`: Added `RelationEndpointUUID` field in `relationUnit` and reflected changes in the data structure.
- `domain/schema/model/sql/0024-relation.sql`: Modified `relation_unit` table schema to replace `relation_uuid` with `relation_endpoint_uuid`. Adjusted constraints, indexes and views

## Checklist

- [X] Code style: imports ordered, good names, simple structure, etc
- [X] Comments saying why design decisions were made
- [X] Go unit tests, with comments saying what you're testing

## QA steps

* Unit test should passes
* Deploy vault and easyrsa, integrate them. Should do something.

## Documentation changes



## Links

Suggested here: https://github.com/juju/juju/pull/19413#discussion_r2028425864

