### PR TITLE
feat: add check when deleting space if used in constraints

### DIFF
--- a/domain/network/service/interface.go
+++ b/domain/network/service/interface.go
@@ -71,6 +71,11 @@ type SpaceState interface {
 	// space is not found, an error is returned matching
 	// [github.com/juju/juju/domain/network/errors.SpaceNotFound].
 	DeleteSpace(ctx context.Context, uuid string) error
+	// IsSpaceUsedInConstraints checks if the provided space name is used in any
+	// constraints.
+	// This method doesn't check if the provided space name exists, it returns
+	// false in that case.
+	IsSpaceUsedInConstraints(ctx context.Context, name network.SpaceName) (bool, error)
 }
 
 // SubnetState describes persistence layer methods for the subnet (sub-) domain.

--- a/domain/network/service/package_mock_test.go
+++ b/domain/network/service/package_mock_test.go
@@ -475,6 +475,45 @@ func (c *MockStateGetSubnetsByCIDRCall) DoAndReturn(f func(context.Context, ...s
 	return c
 }
 
+// IsSpaceUsedInConstraints mocks base method.
+func (m *MockState) IsSpaceUsedInConstraints(arg0 context.Context, arg1 network.SpaceName) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsSpaceUsedInConstraints", arg0, arg1)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IsSpaceUsedInConstraints indicates an expected call of IsSpaceUsedInConstraints.
+func (mr *MockStateMockRecorder) IsSpaceUsedInConstraints(arg0, arg1 any) *MockStateIsSpaceUsedInConstraintsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsSpaceUsedInConstraints", reflect.TypeOf((*MockState)(nil).IsSpaceUsedInConstraints), arg0, arg1)
+	return &MockStateIsSpaceUsedInConstraintsCall{Call: call}
+}
+
+// MockStateIsSpaceUsedInConstraintsCall wrap *gomock.Call
+type MockStateIsSpaceUsedInConstraintsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateIsSpaceUsedInConstraintsCall) Return(arg0 bool, arg1 error) *MockStateIsSpaceUsedInConstraintsCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateIsSpaceUsedInConstraintsCall) Do(f func(context.Context, network.SpaceName) (bool, error)) *MockStateIsSpaceUsedInConstraintsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateIsSpaceUsedInConstraintsCall) DoAndReturn(f func(context.Context, network.SpaceName) (bool, error)) *MockStateIsSpaceUsedInConstraintsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // NamespaceForWatchSubnet mocks base method.
 func (m *MockState) NamespaceForWatchSubnet() string {
 	m.ctrl.T.Helper()

--- a/domain/network/service/space_test.go
+++ b/domain/network/service/space_test.go
@@ -715,6 +715,7 @@ func (s *spaceSuite) TestDeleteProviderSpaces(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
 	s.st.EXPECT().DeleteSpace(gomock.Any(), "1")
+	s.st.EXPECT().IsSpaceUsedInConstraints(gomock.Any(), network.SpaceName("1")).Return(false, nil)
 
 	providerService := NewProviderService(s.st, s.networkProviderGetter, s.zoneProviderGetter, loggertesting.WrapCheckLog(c))
 	provider := NewProviderSpaces(providerService, loggertesting.WrapCheckLog(c))
@@ -772,8 +773,6 @@ func (s *spaceSuite) TestDeleteProviderSpacesMatchesDefaultBindingSpace(c *gc.C)
 }
 
 func (s *spaceSuite) TestDeleteProviderSpacesContainsConstraintsSpace(c *gc.C) {
-	c.Skip("The check on spaces used in constraints before deleting has been removed until constraints are moved to dqlite.")
-
 	defer s.setupMocks(c).Finish()
 
 	providerService := NewProviderService(s.st, s.networkProviderGetter, s.zoneProviderGetter, loggertesting.WrapCheckLog(c))
@@ -784,6 +783,7 @@ func (s *spaceSuite) TestDeleteProviderSpacesContainsConstraintsSpace(c *gc.C) {
 			Name: "1",
 		},
 	}
+	s.st.EXPECT().IsSpaceUsedInConstraints(gomock.Any(), network.SpaceName("1")).Return(true, nil)
 
 	warnings, err := provider.deleteSpaces(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
@@ -828,6 +828,7 @@ func (s *spaceSuite) TestProviderSpacesRun(c *gc.C) {
 		},
 	)
 	s.st.EXPECT().DeleteSpace(gomock.Any(), "1")
+	s.st.EXPECT().IsSpaceUsedInConstraints(gomock.Any(), network.SpaceName("space1")).Return(false, nil)
 
 	providerService := NewProviderService(s.st, s.networkProviderGetter, s.zoneProviderGetter, loggertesting.WrapCheckLog(c))
 	provider := NewProviderSpaces(providerService, loggertesting.WrapCheckLog(c))

--- a/domain/network/state/space_test.go
+++ b/domain/network/state/space_test.go
@@ -4,7 +4,8 @@
 package state
 
 import (
-	ctx "context"
+	"context"
+	"database/sql"
 
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -12,6 +13,7 @@ import (
 	"github.com/juju/juju/core/network"
 	networkerrors "github.com/juju/juju/domain/network/errors"
 	schematesting "github.com/juju/juju/domain/schema/testing"
+	"github.com/juju/juju/internal/errors"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 	"github.com/juju/juju/internal/uuid"
 )
@@ -33,7 +35,7 @@ func (s *stateSuite) TestAddSpace(c *gc.C) {
 	subnetUUID, err := uuid.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.AddSubnet(
-		ctx.Background(),
+		context.Background(),
 		network.SubnetInfo{
 			ID:                network.Id(subnetUUID.String()),
 			CIDR:              "192.168.0.0/12",
@@ -47,7 +49,7 @@ func (s *stateSuite) TestAddSpace(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	subnets := []string{subnetUUID.String()}
-	err = st.AddSpace(ctx.Background(), spaceUUID.String(), "space0", "foo", subnets)
+	err = st.AddSpace(context.Background(), spaceUUID.String(), "space0", "foo", subnets)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Check the space entity.
@@ -90,7 +92,7 @@ func (s *stateSuite) TestAddSpaceFailDuplicateName(c *gc.C) {
 	subnetUUID, err := uuid.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.AddSubnet(
-		ctx.Background(),
+		context.Background(),
 		network.SubnetInfo{
 			ID:                network.Id(subnetUUID.String()),
 			CIDR:              "192.168.0.0/12",
@@ -104,7 +106,7 @@ func (s *stateSuite) TestAddSpaceFailDuplicateName(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	subnets := []string{subnetUUID.String()}
-	err = st.AddSpace(ctx.Background(), spaceUUID.String(), "space0", "foo", subnets)
+	err = st.AddSpace(context.Background(), spaceUUID.String(), "space0", "foo", subnets)
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Check the space entity.
@@ -115,7 +117,7 @@ func (s *stateSuite) TestAddSpaceFailDuplicateName(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(name, gc.Equals, "space0")
 	// Fails when trying to add a new space with the same name.
-	err = st.AddSpace(ctx.Background(), spaceUUID.String(), "space0", "bar", subnets)
+	err = st.AddSpace(context.Background(), spaceUUID.String(), "space0", "bar", subnets)
 	c.Assert(err, jc.ErrorIs, networkerrors.SpaceAlreadyExists)
 }
 
@@ -130,7 +132,7 @@ func (s *stateSuite) TestAddSpaceEmptyProviderID(c *gc.C) {
 	subnetUUID, err := uuid.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.AddSubnet(
-		ctx.Background(),
+		context.Background(),
 		network.SubnetInfo{
 			ID:                network.Id(subnetUUID.String()),
 			CIDR:              "192.168.0.0/12",
@@ -144,10 +146,10 @@ func (s *stateSuite) TestAddSpaceEmptyProviderID(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	subnets := []string{subnetUUID.String()}
-	err = st.AddSpace(ctx.Background(), spaceUUID.String(), "space0", "", subnets)
+	err = st.AddSpace(context.Background(), spaceUUID.String(), "space0", "", subnets)
 	c.Assert(err, jc.ErrorIsNil)
 
-	sp, err := st.GetSpace(ctx.Background(), spaceUUID.String())
+	sp, err := st.GetSpace(context.Background(), spaceUUID.String())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(sp.ProviderId.String(), gc.Equals, "")
 
@@ -166,7 +168,7 @@ func (s *stateSuite) TestRetrieveSpaceByUUID(c *gc.C) {
 	subnetUUID0, err := uuid.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.AddSubnet(
-		ctx.Background(),
+		context.Background(),
 		network.SubnetInfo{
 			ID:                network.Id(subnetUUID0.String()),
 			CIDR:              "192.168.0.0/12",
@@ -182,7 +184,7 @@ func (s *stateSuite) TestRetrieveSpaceByUUID(c *gc.C) {
 	subnetUUID1, err := uuid.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.AddSubnet(
-		ctx.Background(),
+		context.Background(),
 		network.SubnetInfo{
 			ID:                network.Id(subnetUUID1.String()),
 			CIDR:              "192.176.0.0/12",
@@ -198,10 +200,10 @@ func (s *stateSuite) TestRetrieveSpaceByUUID(c *gc.C) {
 	subnets := []string{subnetUUID0.String(), subnetUUID1.String()}
 	spaceUUID, err := uuid.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
-	err = st.AddSpace(ctx.Background(), spaceUUID.String(), "space0", "foo", subnets)
+	err = st.AddSpace(context.Background(), spaceUUID.String(), "space0", "foo", subnets)
 	c.Assert(err, jc.ErrorIsNil)
 
-	sp, err := st.GetSpace(ctx.Background(), spaceUUID.String())
+	sp, err := st.GetSpace(context.Background(), spaceUUID.String())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(sp.ID, gc.Equals, spaceUUID.String())
 	c.Check(sp.Name, gc.Equals, network.SpaceName("space0"))
@@ -241,7 +243,7 @@ func (s *stateSuite) TestRetrieveSpaceByUUID(c *gc.C) {
 func (s *stateSuite) TestRetrieveSpaceByUUIDNotFound(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
-	_, err := st.GetSpace(ctx.Background(), "unknown0")
+	_, err := st.GetSpace(context.Background(), "unknown0")
 	c.Assert(err, jc.ErrorIs, networkerrors.SpaceNotFound)
 }
 
@@ -250,18 +252,18 @@ func (s *stateSuite) TestRetrieveSpaceByName(c *gc.C) {
 
 	spaceUUID0, err := uuid.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
-	err = st.AddSpace(ctx.Background(), spaceUUID0.String(), "space0", "provider0", []string{})
+	err = st.AddSpace(context.Background(), spaceUUID0.String(), "space0", "provider0", []string{})
 	c.Assert(err, jc.ErrorIsNil)
 	spaceUUID1, err := uuid.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
-	err = st.AddSpace(ctx.Background(), spaceUUID1.String(), "space1", "provider1", []string{})
+	err = st.AddSpace(context.Background(), spaceUUID1.String(), "space1", "provider1", []string{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	sp0, err := st.GetSpaceByName(ctx.Background(), "space0")
+	sp0, err := st.GetSpaceByName(context.Background(), "space0")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(sp0.ID, gc.Equals, spaceUUID0.String())
 	c.Check(sp0.Name, gc.Equals, network.SpaceName("space0"))
-	sp1, err := st.GetSpaceByName(ctx.Background(), "space1")
+	sp1, err := st.GetSpaceByName(context.Background(), "space1")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(sp1.ID, gc.Equals, spaceUUID1.String())
 	c.Check(sp1.Name, gc.Equals, network.SpaceName("space1"))
@@ -273,7 +275,7 @@ func (s *stateSuite) TestRetrieveSpaceByName(c *gc.C) {
 func (s *stateSuite) TestRetrieveSpaceByNameNotFound(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
-	_, err := st.GetSpaceByName(ctx.Background(), "unknown0")
+	_, err := st.GetSpaceByName(context.Background(), "unknown0")
 	c.Assert(err, jc.ErrorIs, networkerrors.SpaceNotFound)
 }
 
@@ -282,10 +284,10 @@ func (s *stateSuite) TestRetrieveSpaceByUUIDWithoutSubnet(c *gc.C) {
 
 	spaceUUID, err := uuid.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
-	err = st.AddSpace(ctx.Background(), spaceUUID.String(), "space0", "foo", []string{})
+	err = st.AddSpace(context.Background(), spaceUUID.String(), "space0", "foo", []string{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	sp, err := st.GetSpace(ctx.Background(), spaceUUID.String())
+	sp, err := st.GetSpace(context.Background(), spaceUUID.String())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(sp.ID, gc.Equals, spaceUUID.String())
 	c.Check(sp.Name, gc.Equals, network.SpaceName("space0"))
@@ -299,7 +301,7 @@ func (s *stateSuite) TestRetrieveAllSpaces(c *gc.C) {
 	subnetUUID0, err := uuid.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.AddSubnet(
-		ctx.Background(),
+		context.Background(),
 		network.SubnetInfo{
 			ID:                network.Id(subnetUUID0.String()),
 			CIDR:              "192.168.0.0/24",
@@ -314,7 +316,7 @@ func (s *stateSuite) TestRetrieveAllSpaces(c *gc.C) {
 	subnetUUID1, err := uuid.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.AddSubnet(
-		ctx.Background(),
+		context.Background(),
 		network.SubnetInfo{
 			ID:                network.Id(subnetUUID1.String()),
 			CIDR:              "192.168.1.0/24",
@@ -329,7 +331,7 @@ func (s *stateSuite) TestRetrieveAllSpaces(c *gc.C) {
 	subnetUUID2, err := uuid.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.AddSubnet(
-		ctx.Background(),
+		context.Background(),
 		network.SubnetInfo{
 			ID:                network.Id(subnetUUID2.String()),
 			CIDR:              "192.168.2.0/24",
@@ -346,20 +348,20 @@ func (s *stateSuite) TestRetrieveAllSpaces(c *gc.C) {
 	subnets := []string{subnetUUID0.String()}
 	spaceUUID0, err := uuid.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
-	err = st.AddSpace(ctx.Background(), spaceUUID0.String(), "space0", "foo0", subnets)
+	err = st.AddSpace(context.Background(), spaceUUID0.String(), "space0", "foo0", subnets)
 	c.Assert(err, jc.ErrorIsNil)
 	subnets = []string{subnetUUID1.String()}
 	spaceUUID1, err := uuid.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
-	err = st.AddSpace(ctx.Background(), spaceUUID1.String(), "space1", "foo1", subnets)
+	err = st.AddSpace(context.Background(), spaceUUID1.String(), "space1", "foo1", subnets)
 	c.Assert(err, jc.ErrorIsNil)
 	subnets = []string{subnetUUID2.String()}
 	spaceUUID2, err := uuid.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
-	err = st.AddSpace(ctx.Background(), spaceUUID2.String(), "space2", "foo2", subnets)
+	err = st.AddSpace(context.Background(), spaceUUID2.String(), "space2", "foo2", subnets)
 	c.Assert(err, jc.ErrorIsNil)
 
-	sp, err := st.GetAllSpaces(ctx.Background())
+	sp, err := st.GetAllSpaces(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(sp, gc.HasLen, 4)
 }
@@ -369,13 +371,13 @@ func (s *stateSuite) TestUpdateSpace(c *gc.C) {
 
 	uuid, err := uuid.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
-	err = st.AddSpace(ctx.Background(), uuid.String(), "space0", "foo", []string{})
+	err = st.AddSpace(context.Background(), uuid.String(), "space0", "foo", []string{})
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = st.UpdateSpace(ctx.Background(), uuid.String(), "newSpaceName0")
+	err = st.UpdateSpace(context.Background(), uuid.String(), "newSpaceName0")
 	c.Assert(err, jc.ErrorIsNil)
 
-	sp, err := st.GetSpace(ctx.Background(), uuid.String())
+	sp, err := st.GetSpace(context.Background(), uuid.String())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(sp.Name, gc.Equals, network.SpaceName("newSpaceName0"))
 }
@@ -386,7 +388,7 @@ func (s *stateSuite) TestUpdateSpace(c *gc.C) {
 func (s *stateSuite) TestUpdateSpaceFailNotFound(c *gc.C) {
 	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
 
-	err := st.UpdateSpace(ctx.Background(), "unknownSpace", "newSpaceName0")
+	err := st.UpdateSpace(context.Background(), "unknownSpace", "newSpaceName0")
 	c.Assert(err, jc.ErrorIs, networkerrors.SpaceNotFound)
 }
 
@@ -398,7 +400,7 @@ func (s *stateSuite) TestDeleteSpace(c *gc.C) {
 	subnetUUID0, err := uuid.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
 	err = st.AddSubnet(
-		ctx.Background(),
+		context.Background(),
 		network.SubnetInfo{
 			ID:                network.Id(subnetUUID0.String()),
 			CIDR:              "192.168.0.0/20",
@@ -414,7 +416,7 @@ func (s *stateSuite) TestDeleteSpace(c *gc.C) {
 	// Create a space containing the newly created subnet.
 	spUUID, err := uuid.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
-	err = st.AddSpace(ctx.Background(), spUUID.String(), "space0", "foo", []string{subnetUUID0.String()})
+	err = st.AddSpace(context.Background(), spUUID.String(), "space0", "foo", []string{subnetUUID0.String()})
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Check the subnet entity.
@@ -426,16 +428,16 @@ func (s *stateSuite) TestDeleteSpace(c *gc.C) {
 	c.Check(name, gc.Equals, spUUID.String())
 
 	// Check that the subnet is linked to the newly created space.
-	subnet, err := st.GetSubnet(ctx.Background(), subnetUUID0.String())
+	subnet, err := st.GetSubnet(context.Background(), subnetUUID0.String())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(subnet.SpaceID, gc.Equals, spUUID.String())
 
 	// Delete the space.
-	err = st.DeleteSpace(ctx.Background(), spUUID.String())
+	err = st.DeleteSpace(context.Background(), spUUID.String())
 	c.Assert(err, jc.ErrorIsNil)
 
 	// Check that the subnet is not linked to the deleted space.
-	subnet, err = st.GetSubnet(ctx.Background(), subnetUUID0.String())
+	subnet, err = st.GetSubnet(context.Background(), subnetUUID0.String())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(subnet.SpaceID, gc.Equals, network.AlphaSpaceId)
 }
@@ -448,6 +450,68 @@ func (s *stateSuite) TestDeleteSpaceNotFound(c *gc.C) {
 
 	spUUID, err := uuid.NewUUID()
 	c.Assert(err, jc.ErrorIsNil)
-	err = st.DeleteSpace(ctx.Background(), spUUID.String())
+	err = st.DeleteSpace(context.Background(), spUUID.String())
 	c.Assert(err, jc.ErrorIs, networkerrors.SpaceNotFound)
+}
+
+func (s *stateSuite) TestIsSpaceNotUsedInConstraints(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+
+	// Create a space.
+	spUUID, err := uuid.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.AddSpace(context.Background(), spUUID.String(), "space0", "foo", []string{})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Check that the space is used in constraints.
+	used, err := st.IsSpaceUsedInConstraints(context.Background(), "space0")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(used, jc.IsFalse)
+}
+
+func (s *stateSuite) TestIsSpaceUsedInApplicationConstraints(c *gc.C) {
+	st := NewState(s.TxnRunnerFactory(), loggertesting.WrapCheckLog(c))
+
+	// Create a space.
+	spUUID, err := uuid.NewUUID()
+	c.Assert(err, jc.ErrorIsNil)
+	err = st.AddSpace(context.Background(), spUUID.String(), "space0", "foo", []string{})
+	c.Assert(err, jc.ErrorIsNil)
+
+	err = s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		addConstraintStmt := `INSERT INTO "constraint" (uuid) VALUES (?)`
+		_, err := tx.ExecContext(ctx, addConstraintStmt, "constraint-uuid")
+		if err != nil {
+			return err
+		}
+		addSpaceConsStmt := `INSERT INTO constraint_space (constraint_uuid, space, exclude) VALUES (?, ?, ?)`
+		_, err = tx.ExecContext(ctx, addSpaceConsStmt, "constraint-uuid", "space0", false)
+		if err != nil {
+			return err
+		}
+		addCharmStmt := `INSERT INTO charm (uuid, reference_name, source_id) VALUES (?, 'foo', 0)`
+		_, err = tx.ExecContext(ctx, addCharmStmt, "charm0-uuid")
+		if err != nil {
+			return errors.Capture(err)
+		}
+		addApplicationStmt := `INSERT INTO application (uuid, name, life_id, charm_uuid, space_uuid) VALUES (?, ?, ?, ?, ?)`
+		_, err = tx.ExecContext(ctx, addApplicationStmt, "app0-uuid", "app0", "0", "charm0-uuid", network.AlphaSpaceId)
+		if err != nil {
+			return err
+		}
+		addAppConstraintStmt := `INSERT INTO application_constraint (application_uuid, constraint_uuid) VALUES (?, ?)`
+		_, err = tx.ExecContext(ctx, addAppConstraintStmt, "app0-uuid", "constraint-uuid")
+		return err
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Check that the space is used in constraints.
+	used, err := st.IsSpaceUsedInConstraints(context.Background(), "space0")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(used, jc.IsTrue)
+
+	// Check that the space is not used in constraints.
+	used, err = st.IsSpaceUsedInConstraints(context.Background(), "space1")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(used, jc.IsFalse)
 }

--- a/domain/network/state/types.go
+++ b/domain/network/state/types.go
@@ -54,6 +54,14 @@ type space struct {
 	UUID string `db:"uuid"`
 }
 
+type spaceName struct {
+	Name string `db:"name"`
+}
+
+type countResult struct {
+	Count int `db:"count"`
+}
+
 // providerSpace represents a single row from the provider_space table.
 type providerSpace struct {
 	// SpaceUUID is the unique ID of the space.


### PR DESCRIPTION
This patch adds back a small check that was done before migrating to dqlite. The check consists of making sure that a space is not used as a constraint before deleting, and if it's the case it's skipped and logged.

## QA steps

Bootstrap, add a space, move a subnet onto it, deploy with a space constraint and then try to delete that space:

```
$ juju add-model m
$ juju add-space beta
$ juju move-to-space beta 10.254.213.0/24 # replace by one of your actual subnets here
$ juju deploy ubuntu --constraints="spaces=beta"
$ juju remove-space beta
```
After the last command, you should see in the debug-logs a trace log with the text: 
```
Unable to delete space "beta". Space is used in a constraint.
```
