### PR TITLE
refactor(relation): remove ApplicationRelationEndpointNames

### DIFF
--- a/domain/relation/service/relation.go
+++ b/domain/relation/service/relation.go
@@ -169,13 +169,6 @@ func (s *Service) AddRelation(ctx context.Context, ep1, ep2 string) (relation.En
 	return s.st.AddRelation(ctx, idep1, idep2)
 }
 
-// ApplicationRelationEndpointNames returns a slice of names of the given application's
-// relation endpoints.
-// Note: Replaces the functionality in CharmRelations method of the application facade.
-func (s *Service) ApplicationRelationEndpointNames(ctx context.Context, id application.ID) ([]string, error) {
-	return nil, coreerrors.NotImplemented
-}
-
 // ApplicationRelations returns relation UUIDs for the given
 // application ID.
 func (s *Service) ApplicationRelations(ctx context.Context, id application.ID) (


### PR DESCRIPTION
This function is already covered by `GetApplicationEndpoints` and a loop. No needs to clutter the service layer with useless function.

So the use case will be covered whenever #19410 lands.

## Links

<!-- Add a Jira card reference or link, otherwise remove this line. -->
**Jira card:** JUJU-7440
