### PR TITLE
chore: remove exposed column from application table

### DIFF
--- a/domain/application/modelmigration/export.go
+++ b/domain/application/modelmigration/export.go
@@ -236,7 +236,6 @@ func (e *exportOperation) createApplicationArgs(ctx context.Context, app applica
 		CharmURL:             charmURL,
 		CharmModifiedVersion: app.CharmModifiedVersion,
 		ForceCharm:           app.CharmUpgradeOnError,
-		Exposed:              app.Exposed,
 		Placement:            app.Placement,
 		CloudService:         cloudService,
 

--- a/domain/application/state/migration.go
+++ b/domain/application/state/migration.go
@@ -78,7 +78,6 @@ func (st *State) GetApplicationsForExport(ctx context.Context) ([]application.Ex
 			CharmUUID:            app.CharmUUID,
 			Life:                 app.Life,
 			Placement:            app.Placement,
-			Exposed:              app.Exposed,
 			Subordinate:          app.Subordinate,
 			CharmModifiedVersion: app.CharmModifiedVersion,
 			CharmUpgradeOnError:  app.CharmUpgradeOnError,

--- a/domain/application/state/migration_test.go
+++ b/domain/application/state/migration_test.go
@@ -50,7 +50,6 @@ func (s *migrationStateSuite) TestGetApplicationsForExport(c *gc.C) {
 			},
 			Placement:   "placement",
 			Subordinate: false,
-			Exposed:     false,
 		},
 	})
 }
@@ -79,7 +78,6 @@ func (s *migrationStateSuite) TestGetApplicationsForExportMany(c *gc.C) {
 			},
 			Placement:   "placement",
 			Subordinate: false,
-			Exposed:     false,
 		})
 	}
 
@@ -118,7 +116,6 @@ func (s *migrationStateSuite) TestGetApplicationsForExportDeadOrDying(c *gc.C) {
 			},
 			Placement:   "placement",
 			Subordinate: false,
-			Exposed:     false,
 		},
 		{
 			UUID:      id1,
@@ -133,7 +130,6 @@ func (s *migrationStateSuite) TestGetApplicationsForExportDeadOrDying(c *gc.C) {
 			},
 			Placement:   "placement",
 			Subordinate: false,
-			Exposed:     false,
 		},
 	}
 

--- a/domain/application/state/types.go
+++ b/domain/application/state/types.go
@@ -1083,7 +1083,6 @@ type exportApplication struct {
 	CharmUUID            corecharm.ID       `db:"charm_uuid"`
 	Life                 life.Life          `db:"life_id"`
 	Placement            string             `db:"placement"`
-	Exposed              bool               `db:"exposed"`
 	Subordinate          bool               `db:"subordinate"`
 	CharmModifiedVersion int                `db:"charm_modified_version"`
 	CharmUpgradeOnError  bool               `db:"charm_upgrade_on_error"`

--- a/domain/application/types.go
+++ b/domain/application/types.go
@@ -375,7 +375,6 @@ type ExportApplication struct {
 	CharmUUID            charm.ID
 	Life                 life.Life
 	Placement            string
-	Exposed              bool
 	Subordinate          bool
 	CharmModifiedVersion int
 	CharmUpgradeOnError  bool

--- a/domain/schema/model/sql/0019-application.sql
+++ b/domain/schema/model/sql/0019-application.sql
@@ -5,7 +5,6 @@ CREATE TABLE application (
     charm_uuid TEXT NOT NULL,
     charm_modified_version INT,
     charm_upgrade_on_error BOOLEAN DEFAULT FALSE,
-    exposed BOOLEAN DEFAULT FALSE,
     placement TEXT,
     -- space_uuid is the default binding for this application.
     space_uuid TEXT NOT NULL,
@@ -264,7 +263,6 @@ SELECT
     a.charm_uuid,
     a.charm_modified_version,
     a.charm_upgrade_on_error,
-    a.exposed,
     a.placement,
     cm.subordinate,
     c.reference_name,

--- a/domain/schema/model/triggers/application-triggers.gen.go
+++ b/domain/schema/model/triggers/application-triggers.gen.go
@@ -35,7 +35,6 @@ WHEN
 	NEW.charm_uuid != OLD.charm_uuid OR
 	(NEW.charm_modified_version != OLD.charm_modified_version OR (NEW.charm_modified_version IS NOT NULL AND OLD.charm_modified_version IS NULL) OR (NEW.charm_modified_version IS NULL AND OLD.charm_modified_version IS NOT NULL)) OR
 	(NEW.charm_upgrade_on_error != OLD.charm_upgrade_on_error OR (NEW.charm_upgrade_on_error IS NOT NULL AND OLD.charm_upgrade_on_error IS NULL) OR (NEW.charm_upgrade_on_error IS NULL AND OLD.charm_upgrade_on_error IS NOT NULL)) OR
-	(NEW.exposed != OLD.exposed OR (NEW.exposed IS NOT NULL AND OLD.exposed IS NULL) OR (NEW.exposed IS NULL AND OLD.exposed IS NOT NULL)) OR
 	(NEW.placement != OLD.placement OR (NEW.placement IS NOT NULL AND OLD.placement IS NULL) OR (NEW.placement IS NULL AND OLD.placement IS NOT NULL)) OR
 	NEW.space_uuid != OLD.space_uuid 
 BEGIN


### PR DESCRIPTION
__Note: first step before implementing exposed endpoints migration.__

This patch removes the exposed column from the application table because it's not needed.
The method IsApplicationExposed() doesn't look at it (it checks if there are any rows in the application_exposed_endpoint_space and application_exposed_endpoint_cidr tables) and it is never set.

Temporarily, it was removed from the exported applications so it's not migrated. This will be correctly implemented in a follow-up patch.

## QA steps

Nothing wired up, migration of exposed endpoints will be re implemented shortly.

## Links

**Jira card:** JUJU-7506
