### PR TITLE
feat: implement application's exposed endpoints migration

### DIFF
--- a/core/network/portrange.go
+++ b/core/network/portrange.go
@@ -96,7 +96,7 @@ func (grp GroupedPortRanges) UniquePortRanges() []PortRange {
 // Clone returns a copy of this port range grouping.
 func (grp GroupedPortRanges) Clone() GroupedPortRanges {
 	if grp == nil {
-		return nil
+		return make(GroupedPortRanges)
 	}
 
 	grpCopy := make(GroupedPortRanges, len(grp))

--- a/domain/application/modelmigration/export_charm_test.go
+++ b/domain/application/modelmigration/export_charm_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/description/v9"
 	jc "github.com/juju/testing/checkers"
+	gomock "go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/core/constraints"
@@ -31,6 +32,7 @@ func (s *exportCharmSuite) TestApplicationExportMinimalCharm(c *gc.C) {
 	s.expectApplicationConfig()
 	s.expectApplicationConstraints(constraints.Value{})
 	s.expectApplicationUnits()
+	s.exportService.EXPECT().IsApplicationExposed(gomock.Any(), "prometheus").Return(false, nil)
 
 	exportOp := s.newExportOperation()
 

--- a/domain/application/modelmigration/import_test.go
+++ b/domain/application/modelmigration/import_test.go
@@ -6,6 +6,7 @@ package modelmigration
 import (
 	"context"
 
+	"github.com/juju/collections/set"
 	"github.com/juju/description/v9"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
@@ -334,11 +335,7 @@ func (s *importSuite) TestApplicationImportWithConstraints(c *gc.C) {
 func (s *importSuite) TestImportCharmMetadataEmpty(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	importOp := importOperation{
-		service: s.importService,
-	}
-
-	_, err := importOp.importCharmMetadata(nil)
+	_, err := importCharmMetadata(nil)
 	c.Assert(err, jc.ErrorIs, coreerrors.NotValid)
 }
 
@@ -348,11 +345,7 @@ func (s *importSuite) TestImportCharmMetadataInvalidUser(c *gc.C) {
 	metaExp := s.charmMetadata.EXPECT()
 	metaExp.RunAs().Return("foo").Times(2)
 
-	importOp := importOperation{
-		service: s.importService,
-	}
-
-	_, err := importOp.importCharmMetadata(s.charmMetadata)
+	_, err := importCharmMetadata(s.charmMetadata)
 	c.Assert(err, jc.ErrorIs, coreerrors.NotValid)
 }
 
@@ -363,11 +356,7 @@ func (s *importSuite) TestImportCharmMetadataInvalidAssumes(c *gc.C) {
 	metaExp.RunAs().Return("root")
 	metaExp.Assumes().Return("!![]")
 
-	importOp := importOperation{
-		service: s.importService,
-	}
-
-	_, err := importOp.importCharmMetadata(s.charmMetadata)
+	_, err := importCharmMetadata(s.charmMetadata)
 	c.Assert(err, jc.ErrorIs, coreerrors.NotValid)
 }
 
@@ -379,11 +368,7 @@ func (s *importSuite) TestImportCharmMetadataInvalidMinJujuVersion(c *gc.C) {
 	metaExp.Assumes().Return("[]")
 	metaExp.MinJujuVersion().Return("foo")
 
-	importOp := importOperation{
-		service: s.importService,
-	}
-
-	_, err := importOp.importCharmMetadata(s.charmMetadata)
+	_, err := importCharmMetadata(s.charmMetadata)
 	c.Assert(err, jc.ErrorIs, coreerrors.NotValid)
 }
 
@@ -402,11 +387,7 @@ func (s *importSuite) TestImportCharmMetadataInvalidRelationRole(c *gc.C) {
 		"provides": s.charmProvides,
 	})
 
-	importOp := importOperation{
-		service: s.importService,
-	}
-
-	_, err := importOp.importCharmMetadata(s.charmMetadata)
+	_, err := importCharmMetadata(s.charmMetadata)
 	c.Assert(err, jc.ErrorIs, coreerrors.NotValid)
 }
 
@@ -426,11 +407,7 @@ func (s *importSuite) TestImportCharmMetadataInvalidRelationScope(c *gc.C) {
 		"provides": s.charmProvides,
 	})
 
-	importOp := importOperation{
-		service: s.importService,
-	}
-
-	_, err := importOp.importCharmMetadata(s.charmMetadata)
+	_, err := importCharmMetadata(s.charmMetadata)
 	c.Assert(err, jc.ErrorIs, coreerrors.NotValid)
 }
 
@@ -462,11 +439,7 @@ func (s *importSuite) TestImportCharmMetadataInvalidStorage(c *gc.C) {
 		"storage": s.storage,
 	})
 
-	importOp := importOperation{
-		service: s.importService,
-	}
-
-	_, err := importOp.importCharmMetadata(s.charmMetadata)
+	_, err := importCharmMetadata(s.charmMetadata)
 	c.Assert(err, jc.ErrorIs, coreerrors.NotValid)
 }
 
@@ -510,11 +483,7 @@ func (s *importSuite) TestImportCharmMetadataInvalidResource(c *gc.C) {
 		"resource": s.resources,
 	})
 
-	importOp := importOperation{
-		service: s.importService,
-	}
-
-	_, err := importOp.importCharmMetadata(s.charmMetadata)
+	_, err := importCharmMetadata(s.charmMetadata)
 	c.Assert(err, jc.ErrorIs, coreerrors.NotValid)
 }
 
@@ -565,11 +534,7 @@ func (s *importSuite) TestImportCharmMetadata(c *gc.C) {
 		"resource": s.resources,
 	})
 
-	importOp := importOperation{
-		service: s.importService,
-	}
-
-	meta, err := importOp.importCharmMetadata(s.charmMetadata)
+	meta, err := importCharmMetadata(s.charmMetadata)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(meta, gc.DeepEquals, &internalcharm.Meta{
 		Name:           "foo",
@@ -674,11 +639,7 @@ func (s *importSuite) TestImportEmptyCharmManifest(c *gc.C) {
 
 	s.expectEmptyManifestBases()
 
-	importOp := importOperation{
-		service: s.importService,
-	}
-
-	_, err := importOp.importCharmManifest(s.charmManifest)
+	_, err := importCharmManifest(s.charmManifest)
 	c.Assert(err, gc.NotNil)
 }
 
@@ -687,11 +648,7 @@ func (s *importSuite) TestImportCharmManifest(c *gc.C) {
 
 	s.expectManifestBases()
 
-	importOp := importOperation{
-		service: s.importService,
-	}
-
-	meta, err := importOp.importCharmManifest(s.charmManifest)
+	meta, err := importCharmManifest(s.charmManifest)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(meta, gc.DeepEquals, &internalcharm.Manifest{
 		Bases: []internalcharm.Base{
@@ -722,11 +679,7 @@ func (s *importSuite) TestImportCharmManifestWithInvalidBase(c *gc.C) {
 		s.charmBase,
 	})
 
-	importOp := importOperation{
-		service: s.importService,
-	}
-
-	_, err := importOp.importCharmManifest(s.charmManifest)
+	_, err := importCharmManifest(s.charmManifest)
 	c.Assert(err, jc.ErrorIs, coreerrors.NotValid)
 }
 
@@ -735,11 +688,7 @@ func (s *importSuite) TestImportEmptyCharmLXDProfile(c *gc.C) {
 
 	s.expectEmptyLXDProfile()
 
-	importOp := importOperation{
-		service: s.importService,
-	}
-
-	meta, err := importOp.importCharmLXDProfile(s.charmMetadata)
+	meta, err := importCharmLXDProfile(s.charmMetadata)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(meta, gc.IsNil)
 }
@@ -749,11 +698,7 @@ func (s *importSuite) TestImportCharmLXDProfile(c *gc.C) {
 
 	s.expectLXDProfile()
 
-	importOp := importOperation{
-		service: s.importService,
-	}
-
-	meta, err := importOp.importCharmLXDProfile(s.charmMetadata)
+	meta, err := importCharmLXDProfile(s.charmMetadata)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(meta, gc.DeepEquals, &internalcharm.LXDProfile{
 		Config: map[string]string{
@@ -767,11 +712,7 @@ func (s *importSuite) TestImportEmptyCharmConfig(c *gc.C) {
 
 	s.expectEmptyCharmConfigs()
 
-	importOp := importOperation{
-		service: s.importService,
-	}
-
-	meta, err := importOp.importCharmConfig(s.charmConfigs)
+	meta, err := importCharmConfig(s.charmConfigs)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(meta, gc.NotNil)
 	c.Check(meta.Options, gc.HasLen, 0)
@@ -782,11 +723,7 @@ func (s *importSuite) TestImportCharmConfig(c *gc.C) {
 
 	s.expectCharmConfigs()
 
-	importOp := importOperation{
-		service: s.importService,
-	}
-
-	meta, err := importOp.importCharmConfig(s.charmConfigs)
+	meta, err := importCharmConfig(s.charmConfigs)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(meta, gc.NotNil)
 	c.Check(meta.Options, gc.DeepEquals, map[string]internalcharm.Option{
@@ -803,11 +740,7 @@ func (s *importSuite) TestImportEmptyCharmActions(c *gc.C) {
 
 	s.expectEmptyCharmActions()
 
-	importOp := importOperation{
-		service: s.importService,
-	}
-
-	meta, err := importOp.importCharmActions(s.charmActions)
+	meta, err := importCharmActions(s.charmActions)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(meta, gc.NotNil)
 	c.Check(meta.ActionSpecs, gc.HasLen, 0)
@@ -818,11 +751,7 @@ func (s *importSuite) TestImportCharmActions(c *gc.C) {
 
 	s.expectCharmActions()
 
-	importOp := importOperation{
-		service: s.importService,
-	}
-
-	meta, err := importOp.importCharmActions(s.charmActions)
+	meta, err := importCharmActions(s.charmActions)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(meta, gc.NotNil)
 	c.Check(meta.ActionSpecs, gc.DeepEquals, map[string]internalcharm.ActionSpec{
@@ -842,11 +771,7 @@ func (s *importSuite) TestImportCharmActionsNestedMaps(c *gc.C) {
 
 	s.expectCharmActionsNested()
 
-	importOp := importOperation{
-		service: s.importService,
-	}
-
-	meta, err := importOp.importCharmActions(s.charmActions)
+	meta, err := importCharmActions(s.charmActions)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(meta, gc.NotNil)
 	c.Check(meta.ActionSpecs, gc.DeepEquals, map[string]internalcharm.ActionSpec{
@@ -867,6 +792,67 @@ func (s *importSuite) TestImportCharmActionsNestedMaps(c *gc.C) {
 			},
 		},
 	})
+}
+
+func (s *importSuite) TestImportExposedEndpoints(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	model := description.NewModel(description.ModelArgs{})
+
+	appArgs := description.ApplicationArgs{
+		Name:     "prometheus",
+		CharmURL: "ch:prometheus-1",
+		Exposed:  true,
+		ExposedEndpoints: map[string]description.ExposedEndpointArgs{
+			"": {
+				ExposeToSpaceIDs: []string{"alpha"},
+			},
+			"endpoint0": {
+				ExposeToCIDRs:    []string{"10.0.0.0/24", "10.0.1.0/24"},
+				ExposeToSpaceIDs: []string{"space0", "space1"},
+			},
+		},
+	}
+	app := model.AddApplication(appArgs)
+	app.SetCharmMetadata(description.CharmMetadataArgs{
+		Name: "prometheus",
+	})
+	app.SetCharmManifest(description.CharmManifestArgs{
+		Bases: []description.CharmManifestBase{baseType{
+			name:          "ubuntu",
+			channel:       "24.04",
+			architectures: []string{"amd64"},
+		}},
+	})
+	app.SetCharmOrigin(description.CharmOriginArgs{
+		Source:   "charm-hub",
+		ID:       "1234",
+		Hash:     "deadbeef",
+		Revision: 1,
+		Channel:  "666/stable",
+		Platform: "arm64/ubuntu/24.04",
+	})
+
+	s.importService.EXPECT().ImportApplication(
+		gomock.Any(),
+		"prometheus",
+		gomock.Any(),
+	).DoAndReturn(func(_ context.Context, _ string, args service.ImportApplicationArgs) error {
+		c.Assert(args.Charm.Meta().Name, gc.Equals, "prometheus")
+		c.Check(args.ExposedEndpoints, gc.HasLen, 2)
+		c.Check(args.ExposedEndpoints[""].ExposeToSpaceIDs, gc.DeepEquals, set.NewStrings("alpha"))
+		c.Check(args.ExposedEndpoints["endpoint0"].ExposeToCIDRs, gc.DeepEquals, set.NewStrings("10.0.0.0/24", "10.0.1.0/24"))
+		c.Check(args.ExposedEndpoints["endpoint0"].ExposeToSpaceIDs, gc.DeepEquals, set.NewStrings("space0", "space1"))
+		return nil
+	})
+
+	importOp := importOperation{
+		service: s.importService,
+		logger:  loggertesting.WrapCheckLog(c),
+	}
+
+	err := importOp.Execute(context.Background(), model)
+	c.Assert(err, jc.ErrorIsNil)
 }
 
 func (s *importSuite) setupMocks(c *gc.C) *gomock.Controller {

--- a/domain/application/modelmigration/import_unit.go
+++ b/domain/application/modelmigration/import_unit.go
@@ -26,7 +26,7 @@ func (i *importOperation) importUnit(ctx context.Context, unit description.Unit)
 
 	var cloudContainer *application.CloudContainerParams
 	if cc := unit.CloudContainer(); cc != nil {
-		address, origin := makeAddress(cc.Address())
+		address, origin := i.makeAddress(cc.Address())
 
 		cloudContainer = &application.CloudContainerParams{
 			Address:       address,

--- a/domain/application/modelmigration/import_unit.go
+++ b/domain/application/modelmigration/import_unit.go
@@ -26,7 +26,7 @@ func (i *importOperation) importUnit(ctx context.Context, unit description.Unit)
 
 	var cloudContainer *application.CloudContainerParams
 	if cc := unit.CloudContainer(); cc != nil {
-		address, origin := i.makeAddress(cc.Address())
+		address, origin := makeAddress(cc.Address())
 
 		cloudContainer = &application.CloudContainerParams{
 			Address:       address,

--- a/domain/application/modelmigration/migrations_mock_test.go
+++ b/domain/application/modelmigration/migrations_mock_test.go
@@ -460,6 +460,45 @@ func (c *MockExportServiceGetCharmIDCall) DoAndReturn(f func(context.Context, ch
 	return c
 }
 
+// GetExposedEndpoints mocks base method.
+func (m *MockExportService) GetExposedEndpoints(arg0 context.Context, arg1 string) (map[string]application.ExposedEndpoint, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetExposedEndpoints", arg0, arg1)
+	ret0, _ := ret[0].(map[string]application.ExposedEndpoint)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetExposedEndpoints indicates an expected call of GetExposedEndpoints.
+func (mr *MockExportServiceMockRecorder) GetExposedEndpoints(arg0, arg1 any) *MockExportServiceGetExposedEndpointsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetExposedEndpoints", reflect.TypeOf((*MockExportService)(nil).GetExposedEndpoints), arg0, arg1)
+	return &MockExportServiceGetExposedEndpointsCall{Call: call}
+}
+
+// MockExportServiceGetExposedEndpointsCall wrap *gomock.Call
+type MockExportServiceGetExposedEndpointsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockExportServiceGetExposedEndpointsCall) Return(arg0 map[string]application.ExposedEndpoint, arg1 error) *MockExportServiceGetExposedEndpointsCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockExportServiceGetExposedEndpointsCall) Do(f func(context.Context, string) (map[string]application.ExposedEndpoint, error)) *MockExportServiceGetExposedEndpointsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockExportServiceGetExposedEndpointsCall) DoAndReturn(f func(context.Context, string) (map[string]application.ExposedEndpoint, error)) *MockExportServiceGetExposedEndpointsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetUnitUUIDByName mocks base method.
 func (m *MockExportService) GetUnitUUIDByName(arg0 context.Context, arg1 unit.Name) (unit.UUID, error) {
 	m.ctrl.T.Helper()
@@ -495,6 +534,45 @@ func (c *MockExportServiceGetUnitUUIDByNameCall) Do(f func(context.Context, unit
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockExportServiceGetUnitUUIDByNameCall) DoAndReturn(f func(context.Context, unit.Name) (unit.UUID, error)) *MockExportServiceGetUnitUUIDByNameCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// IsApplicationExposed mocks base method.
+func (m *MockExportService) IsApplicationExposed(arg0 context.Context, arg1 string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsApplicationExposed", arg0, arg1)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IsApplicationExposed indicates an expected call of IsApplicationExposed.
+func (mr *MockExportServiceMockRecorder) IsApplicationExposed(arg0, arg1 any) *MockExportServiceIsApplicationExposedCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsApplicationExposed", reflect.TypeOf((*MockExportService)(nil).IsApplicationExposed), arg0, arg1)
+	return &MockExportServiceIsApplicationExposedCall{Call: call}
+}
+
+// MockExportServiceIsApplicationExposedCall wrap *gomock.Call
+type MockExportServiceIsApplicationExposedCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockExportServiceIsApplicationExposedCall) Return(arg0 bool, arg1 error) *MockExportServiceIsApplicationExposedCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockExportServiceIsApplicationExposedCall) Do(f func(context.Context, string) (bool, error)) *MockExportServiceIsApplicationExposedCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockExportServiceIsApplicationExposedCall) DoAndReturn(f func(context.Context, string) (bool, error)) *MockExportServiceIsApplicationExposedCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/application/modelmigration/migrations_mock_test.go
+++ b/domain/application/modelmigration/migrations_mock_test.go
@@ -16,6 +16,7 @@ import (
 	charm "github.com/juju/juju/core/charm"
 	config "github.com/juju/juju/core/config"
 	constraints "github.com/juju/juju/core/constraints"
+	network "github.com/juju/juju/core/network"
 	unit "github.com/juju/juju/core/unit"
 	application "github.com/juju/juju/domain/application"
 	charm0 "github.com/juju/juju/domain/application/charm"
@@ -45,6 +46,45 @@ func NewMockImportService(ctrl *gomock.Controller) *MockImportService {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockImportService) EXPECT() *MockImportServiceMockRecorder {
 	return m.recorder
+}
+
+// GetSpaceUUIDByName mocks base method.
+func (m *MockImportService) GetSpaceUUIDByName(arg0 context.Context, arg1 string) (network.Id, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSpaceUUIDByName", arg0, arg1)
+	ret0, _ := ret[0].(network.Id)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSpaceUUIDByName indicates an expected call of GetSpaceUUIDByName.
+func (mr *MockImportServiceMockRecorder) GetSpaceUUIDByName(arg0, arg1 any) *MockImportServiceGetSpaceUUIDByNameCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSpaceUUIDByName", reflect.TypeOf((*MockImportService)(nil).GetSpaceUUIDByName), arg0, arg1)
+	return &MockImportServiceGetSpaceUUIDByNameCall{Call: call}
+}
+
+// MockImportServiceGetSpaceUUIDByNameCall wrap *gomock.Call
+type MockImportServiceGetSpaceUUIDByNameCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockImportServiceGetSpaceUUIDByNameCall) Return(arg0 network.Id, arg1 error) *MockImportServiceGetSpaceUUIDByNameCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockImportServiceGetSpaceUUIDByNameCall) Do(f func(context.Context, string) (network.Id, error)) *MockImportServiceGetSpaceUUIDByNameCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockImportServiceGetSpaceUUIDByNameCall) DoAndReturn(f func(context.Context, string) (network.Id, error)) *MockImportServiceGetSpaceUUIDByNameCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
 }
 
 // ImportApplication mocks base method.

--- a/domain/application/service/migration.go
+++ b/domain/application/service/migration.go
@@ -38,6 +38,12 @@ type MigrationState interface {
 	// If the application does not exist, an error satisfying
 	// [applicationerrors.ApplicationNotFound] is returned.
 	GetApplicationUnitsForExport(ctx context.Context, appID coreapplication.ID) ([]application.ExportUnit, error)
+
+	// GetSpaceUUIDByName returns the UUID of the space with the given name.
+	// It returns an error satisfying [networkerrors.SpaceNotFound] if the provided
+	//
+	// space name doesn't exist.
+	GetSpaceUUIDByName(ctx context.Context, name string) (network.Id, error)
 }
 
 // MigrationService provides the API for migrating applications.
@@ -358,6 +364,14 @@ func (s *MigrationService) GetExposedEndpoints(ctx context.Context, appName stri
 	}
 
 	return s.st.GetExposedEndpoints(ctx, appID)
+}
+
+// GetSpaceUUIDByName returns the UUID of the space with the given name.
+//
+// It returns an error satisfying [networkerrors.SpaceNotFound] if the provided
+// space name doesn't exist.
+func (s *MigrationService) GetSpaceUUIDByName(ctx context.Context, name string) (network.Id, error) {
+	return s.st.GetSpaceUUIDByName(ctx, name)
 }
 
 func makeUnitArgs(units []ImportUnitArg, charmUUID corecharm.ID) ([]application.InsertUnitArg, error) {

--- a/domain/application/service/package_mock_test.go
+++ b/domain/application/service/package_mock_test.go
@@ -2064,6 +2064,45 @@ func (c *MockStateGetModelTypeCall) DoAndReturn(f func(context.Context) (model.M
 	return c
 }
 
+// GetSpaceUUIDByName mocks base method.
+func (m *MockState) GetSpaceUUIDByName(ctx context.Context, name string) (network.Id, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSpaceUUIDByName", ctx, name)
+	ret0, _ := ret[0].(network.Id)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSpaceUUIDByName indicates an expected call of GetSpaceUUIDByName.
+func (mr *MockStateMockRecorder) GetSpaceUUIDByName(ctx, name any) *MockStateGetSpaceUUIDByNameCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSpaceUUIDByName", reflect.TypeOf((*MockState)(nil).GetSpaceUUIDByName), ctx, name)
+	return &MockStateGetSpaceUUIDByNameCall{Call: call}
+}
+
+// MockStateGetSpaceUUIDByNameCall wrap *gomock.Call
+type MockStateGetSpaceUUIDByNameCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateGetSpaceUUIDByNameCall) Return(arg0 network.Id, arg1 error) *MockStateGetSpaceUUIDByNameCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateGetSpaceUUIDByNameCall) Do(f func(context.Context, string) (network.Id, error)) *MockStateGetSpaceUUIDByNameCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateGetSpaceUUIDByNameCall) DoAndReturn(f func(context.Context, string) (network.Id, error)) *MockStateGetSpaceUUIDByNameCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetStoragePoolByName mocks base method.
 func (m *MockState) GetStoragePoolByName(ctx context.Context, name string) (storage0.StoragePoolDetails, error) {
 	m.ctrl.T.Helper()

--- a/domain/application/service/params.go
+++ b/domain/application/service/params.go
@@ -228,6 +228,9 @@ type ImportApplicationArgs struct {
 	// ScaleState is the scale state (including scaling, scale and scale
 	// target) of the application.
 	ScaleState application.ScaleState
+
+	// ExposedEndpoints is the exposed endpoints for the application.
+	ExposedEndpoints map[string]application.ExposedEndpoint
 }
 
 // ApplicationConfig represents the application config for the specified

--- a/domain/application/state/exposed_test.go
+++ b/domain/application/state/exposed_test.go
@@ -13,6 +13,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	coreapplication "github.com/juju/juju/core/application"
+	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/domain/application"
 	"github.com/juju/juju/domain/life"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
@@ -221,6 +222,20 @@ func (s *exposedStateSuite) TestSpacesExist(c *gc.C) {
 
 	err := s.state.SpacesExist(context.Background(), set.NewStrings("space0-uuid"))
 	c.Assert(err, gc.IsNil)
+}
+
+func (s *exposedStateSuite) TestGetSpaceUUIDByNameNotFound(c *gc.C) {
+	_, err := s.state.GetSpaceUUIDByName(context.Background(), "missing-space")
+	c.Assert(err, gc.ErrorMatches, "space not found.*")
+}
+
+func (s *exposedStateSuite) TestGetSpaceUUIDByName(c *gc.C) {
+	appID := s.createApplication(c, "foo", life.Alive)
+	s.setUpEndpoint(c, appID)
+
+	uuid, err := s.state.GetSpaceUUIDByName(context.Background(), "space0")
+	c.Assert(err, gc.IsNil)
+	c.Check(uuid, gc.Equals, network.Id("space0-uuid"))
 }
 
 func (s *exposedStateSuite) TestUnsetExposeSettings(c *gc.C) {

--- a/domain/port/state/updateunitports.go
+++ b/domain/port/state/updateunitports.go
@@ -166,7 +166,6 @@ func (st *State) resolveWildcardEndpoints(
 
 		for _, endpoint := range endpoints {
 			closePorts[endpoint] = append(closePorts[endpoint], openPortRange)
-
 		}
 	}
 


### PR DESCRIPTION
This patch implements export and import migration for the application's exposed endpoints. Tests were updated.

__Bonus: some methods that weren't using the receiver in the import operation were transformed into functions.__


## QA steps


 1. Bootstrap a 3.6 controller and deploy a charm, then expose the app.

```sh
$ juju bootstrap lxd src36
$ juju add-model moveme1
$ juju deploy grafana
$ juju expose grafana
$ juju show-application grafana
grafana:
  charm: grafana
  base: ubuntu@20.04
  channel: latest/stable
  principal: true
  exposed: true
  exposed-endpoints:
    "":
      expose-to-cidrs:
      - 0.0.0.0/0
      - ::/0
  remote: false
  life: alive
  endpoint-bindings:
    "": alpha
    application-dashboard: alpha
    certificates: alpha
    dashboards: alpha
    grafana-source: alpha
    nrpe-external-master: alpha
    website: alpha

```

 2. Bootstrap a 4.0 controller with the changes and migrate the model.

```sh
$ juju bootstrap lxd dst40
$ juju migrate src36:moveme1 dst40
```

 3. Verify no errors exist in the model logs for the agents. Check the expose settings of the grafana app using the repl:
```sh
repl (model-m)> select * from application_exposed_endpoint_cidr;
application_uuid			application_endpoint_uuid	cidr		
1328955d-a472-4ab3-83a7-6be821f37413	<nil>				0.0.0.0/0	
1328955d-a472-4ab3-83a7-6be821f37413	<nil>				::/0		
``` 

The same steps as above must be performed for a 4.0 -> 4.0 migration.


## Links

<!-- Add a Jira card reference or link, otherwise remove this line. -->
**Jira card:** JUJU-7506
