### PR TITLE
fix: populate removal worker clock

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/canonical/sqlair v0.0.0-20250120155751-a83645b9a121
 	github.com/chzyer/readline v1.5.1
 	github.com/coreos/go-systemd/v22 v22.5.0
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/docker/distribution v2.8.3+incompatible
 	github.com/dustin/go-humanize v1.0.1
 	github.com/fatih/color v1.16.0
@@ -167,7 +168,6 @@ require (
 	github.com/cilium/ebpf v0.11.0 // indirect
 	github.com/cjlapao/common-go v0.0.39 // indirect
 	github.com/cosiner/argv v0.1.0 // indirect
-	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 // indirect
 	github.com/derekparker/trie v0.0.0-20230829180723-39f4de51ef7d // indirect
 	github.com/distribution/reference v0.5.0 // indirect

--- a/internal/worker/removal/manifold.go
+++ b/internal/worker/removal/manifold.go
@@ -115,6 +115,7 @@ func (config ManifoldConfig) start(ctx context.Context, getter dependency.Getter
 
 	wCfg := Config{
 		RemovalService: removalService,
+		Clock:          config.Clock,
 		Logger:         config.Logger,
 	}
 

--- a/internal/worker/removal/manifold_test.go
+++ b/internal/worker/removal/manifold_test.go
@@ -82,9 +82,14 @@ func (s *manifoldSuite) TestStartSuccess(c *gc.C) {
 	cfg := ManifoldConfig{
 		DomainServicesName: "domain-services",
 		GetRemovalService:  func(dependency.Getter, string) (RemovalService, error) { return noService{}, nil },
-		NewWorker:          func(Config) (worker.Worker, error) { return noWorker{}, nil },
-		Clock:              clock.WallClock,
-		Logger:             loggertesting.WrapCheckLog(c),
+		NewWorker: func(cfg Config) (worker.Worker, error) {
+			if err := cfg.Validate(); err != nil {
+				return nil, err
+			}
+			return noWorker{}, nil
+		},
+		Clock:  clock.WallClock,
+		Logger: loggertesting.WrapCheckLog(c),
 	}
 
 	w, err := Manifold(cfg).Start(context.Background(), noGetter{})


### PR DESCRIPTION
Passes clock from manifold config to removal worker config and ensures test coverage.

The update to go.mod is a drive-by from a prior patch that makes go-spew an explicit dependency instead of an implicit one. The usage is in tests.

## QA steps

Bootstrap and add a model. Ensure that there are no errors starting the removal worker.
