### PR TITLE
refactor: use Get/Set methods for application and unit relation settings

### DIFF
--- a/apiserver/facades/agent/uniter/service.go
+++ b/apiserver/facades/agent/uniter/service.go
@@ -311,18 +311,18 @@ type RelationService interface {
 	// LeaveScope updates the given relation to indicate it is not in scope.
 	LeaveScope(ctx context.Context, relationID corerelation.UnitUUID) error
 
-	// UpdateRelationApplicationSettings updates settings for a specific application
+	// SetRelationApplicationSettings updates settings for a specific application
 	// relation combination.
-	UpdateRelationApplicationSettings(
+	SetRelationApplicationSettings(
 		ctx context.Context,
 		relationUUID corerelation.UUID,
 		applicationID coreapplication.ID,
 		settings map[string]string,
 	) error
 
-	// UpdateRelationUnitSettings updates settings for a specific unit
+	// SetRelationUnitSettings updates settings for a specific unit
 	// relation combination.
-	UpdateRelationUnitSettings(
+	SetRelationUnitSettings(
 		ctx context.Context,
 		relationUnitUUID corerelation.UnitUUID,
 		settings map[string]string,

--- a/apiserver/facades/agent/uniter/service_mock_test.go
+++ b/apiserver/facades/agent/uniter/service_mock_test.go
@@ -1300,78 +1300,78 @@ func (c *MockRelationServiceLeaveScopeCall) DoAndReturn(f func(context.Context, 
 	return c
 }
 
-// UpdateRelationApplicationSettings mocks base method.
-func (m *MockRelationService) UpdateRelationApplicationSettings(arg0 context.Context, arg1 relation.UUID, arg2 application.ID, arg3 map[string]string) error {
+// SetRelationApplicationSettings mocks base method.
+func (m *MockRelationService) SetRelationApplicationSettings(arg0 context.Context, arg1 relation.UUID, arg2 application.ID, arg3 map[string]string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateRelationApplicationSettings", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "SetRelationApplicationSettings", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// UpdateRelationApplicationSettings indicates an expected call of UpdateRelationApplicationSettings.
-func (mr *MockRelationServiceMockRecorder) UpdateRelationApplicationSettings(arg0, arg1, arg2, arg3 any) *MockRelationServiceUpdateRelationApplicationSettingsCall {
+// SetRelationApplicationSettings indicates an expected call of SetRelationApplicationSettings.
+func (mr *MockRelationServiceMockRecorder) SetRelationApplicationSettings(arg0, arg1, arg2, arg3 any) *MockRelationServiceSetRelationApplicationSettingsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRelationApplicationSettings", reflect.TypeOf((*MockRelationService)(nil).UpdateRelationApplicationSettings), arg0, arg1, arg2, arg3)
-	return &MockRelationServiceUpdateRelationApplicationSettingsCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetRelationApplicationSettings", reflect.TypeOf((*MockRelationService)(nil).SetRelationApplicationSettings), arg0, arg1, arg2, arg3)
+	return &MockRelationServiceSetRelationApplicationSettingsCall{Call: call}
 }
 
-// MockRelationServiceUpdateRelationApplicationSettingsCall wrap *gomock.Call
-type MockRelationServiceUpdateRelationApplicationSettingsCall struct {
+// MockRelationServiceSetRelationApplicationSettingsCall wrap *gomock.Call
+type MockRelationServiceSetRelationApplicationSettingsCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockRelationServiceUpdateRelationApplicationSettingsCall) Return(arg0 error) *MockRelationServiceUpdateRelationApplicationSettingsCall {
+func (c *MockRelationServiceSetRelationApplicationSettingsCall) Return(arg0 error) *MockRelationServiceSetRelationApplicationSettingsCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockRelationServiceUpdateRelationApplicationSettingsCall) Do(f func(context.Context, relation.UUID, application.ID, map[string]string) error) *MockRelationServiceUpdateRelationApplicationSettingsCall {
+func (c *MockRelationServiceSetRelationApplicationSettingsCall) Do(f func(context.Context, relation.UUID, application.ID, map[string]string) error) *MockRelationServiceSetRelationApplicationSettingsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockRelationServiceUpdateRelationApplicationSettingsCall) DoAndReturn(f func(context.Context, relation.UUID, application.ID, map[string]string) error) *MockRelationServiceUpdateRelationApplicationSettingsCall {
+func (c *MockRelationServiceSetRelationApplicationSettingsCall) DoAndReturn(f func(context.Context, relation.UUID, application.ID, map[string]string) error) *MockRelationServiceSetRelationApplicationSettingsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
-// UpdateRelationUnitSettings mocks base method.
-func (m *MockRelationService) UpdateRelationUnitSettings(arg0 context.Context, arg1 relation.UnitUUID, arg2 map[string]string) error {
+// SetRelationUnitSettings mocks base method.
+func (m *MockRelationService) SetRelationUnitSettings(arg0 context.Context, arg1 relation.UnitUUID, arg2 map[string]string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateRelationUnitSettings", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "SetRelationUnitSettings", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// UpdateRelationUnitSettings indicates an expected call of UpdateRelationUnitSettings.
-func (mr *MockRelationServiceMockRecorder) UpdateRelationUnitSettings(arg0, arg1, arg2 any) *MockRelationServiceUpdateRelationUnitSettingsCall {
+// SetRelationUnitSettings indicates an expected call of SetRelationUnitSettings.
+func (mr *MockRelationServiceMockRecorder) SetRelationUnitSettings(arg0, arg1, arg2 any) *MockRelationServiceSetRelationUnitSettingsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRelationUnitSettings", reflect.TypeOf((*MockRelationService)(nil).UpdateRelationUnitSettings), arg0, arg1, arg2)
-	return &MockRelationServiceUpdateRelationUnitSettingsCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetRelationUnitSettings", reflect.TypeOf((*MockRelationService)(nil).SetRelationUnitSettings), arg0, arg1, arg2)
+	return &MockRelationServiceSetRelationUnitSettingsCall{Call: call}
 }
 
-// MockRelationServiceUpdateRelationUnitSettingsCall wrap *gomock.Call
-type MockRelationServiceUpdateRelationUnitSettingsCall struct {
+// MockRelationServiceSetRelationUnitSettingsCall wrap *gomock.Call
+type MockRelationServiceSetRelationUnitSettingsCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockRelationServiceUpdateRelationUnitSettingsCall) Return(arg0 error) *MockRelationServiceUpdateRelationUnitSettingsCall {
+func (c *MockRelationServiceSetRelationUnitSettingsCall) Return(arg0 error) *MockRelationServiceSetRelationUnitSettingsCall {
 	c.Call = c.Call.Return(arg0)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockRelationServiceUpdateRelationUnitSettingsCall) Do(f func(context.Context, relation.UnitUUID, map[string]string) error) *MockRelationServiceUpdateRelationUnitSettingsCall {
+func (c *MockRelationServiceSetRelationUnitSettingsCall) Do(f func(context.Context, relation.UnitUUID, map[string]string) error) *MockRelationServiceSetRelationUnitSettingsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockRelationServiceUpdateRelationUnitSettingsCall) DoAndReturn(f func(context.Context, relation.UnitUUID, map[string]string) error) *MockRelationServiceUpdateRelationUnitSettingsCall {
+func (c *MockRelationServiceSetRelationUnitSettingsCall) DoAndReturn(f func(context.Context, relation.UnitUUID, map[string]string) error) *MockRelationServiceSetRelationUnitSettingsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -1678,7 +1678,7 @@ func (u *UniterAPI) updateUnitAndApplicationSettings(ctx context.Context, arg pa
 	if err != nil {
 		return internalerrors.Capture(err)
 	}
-	err = u.relationService.UpdateRelationApplicationSettings(ctx, relUUID, appID, arg.ApplicationSettings)
+	err = u.relationService.SetRelationApplicationSettings(ctx, relUUID, appID, arg.ApplicationSettings)
 	if err != nil {
 		return internalerrors.Capture(err)
 	}
@@ -1688,7 +1688,7 @@ func (u *UniterAPI) updateUnitAndApplicationSettings(ctx context.Context, arg pa
 		return internalerrors.Capture(err)
 	}
 
-	err = u.relationService.UpdateRelationUnitSettings(ctx, relUnitUUID, arg.Settings)
+	err = u.relationService.SetRelationUnitSettings(ctx, relUnitUUID, arg.Settings)
 	if err != nil {
 		return internalerrors.Capture(err)
 	}

--- a/apiserver/facades/agent/uniter/uniter_test.go
+++ b/apiserver/facades/agent/uniter/uniter_test.go
@@ -1195,8 +1195,8 @@ func (s *commitHookChangesSuite) TestUpdateUnitAndApplicationSettings(c *gc.C) {
 	s.expectGetRelationUUIDByKey(relationtesting.GenNewKey(c, relTag.Id()), relUUID)
 	s.expectGetApplicationIDByName("wordpress", appID)
 	s.expectGetRelationUnit(relUUID, relUnitUUID, unitTag.Id())
-	s.expectedUpdateRelationApplicationSettings(relUUID, appID, appSettings)
-	s.expectedUpdateRelationUnitSettings(relUnitUUID, unitSettings)
+	s.expectedSetRelationApplicationSettings(relUUID, appID, appSettings)
+	s.expectedSetRelationUnitSettings(relUnitUUID, unitSettings)
 	canAccess := func(tag names.Tag) bool {
 		return true
 	}
@@ -1288,10 +1288,10 @@ func (s *commitHookChangesSuite) expectGetRelationUnit(relUUID corerelation.UUID
 	s.relationService.EXPECT().GetRelationUnit(gomock.Any(), relUUID, coreunit.Name(unitTagID)).Return(uuid, nil)
 }
 
-func (s *commitHookChangesSuite) expectedUpdateRelationApplicationSettings(uuid corerelation.UUID, id coreapplication.ID, settings map[string]string) {
-	s.relationService.EXPECT().UpdateRelationApplicationSettings(gomock.Any(), uuid, id, settings).Return(nil)
+func (s *commitHookChangesSuite) expectedSetRelationApplicationSettings(uuid corerelation.UUID, id coreapplication.ID, settings map[string]string) {
+	s.relationService.EXPECT().SetRelationApplicationSettings(gomock.Any(), uuid, id, settings).Return(nil)
 }
 
-func (s *commitHookChangesSuite) expectedUpdateRelationUnitSettings(uuid corerelation.UnitUUID, settings map[string]string) {
-	s.relationService.EXPECT().UpdateRelationUnitSettings(gomock.Any(), uuid, settings).Return(nil)
+func (s *commitHookChangesSuite) expectedSetRelationUnitSettings(uuid corerelation.UnitUUID, settings map[string]string) {
+	s.relationService.EXPECT().SetRelationUnitSettings(gomock.Any(), uuid, settings).Return(nil)
 }

--- a/domain/relation/service/relation.go
+++ b/domain/relation/service/relation.go
@@ -601,29 +601,3 @@ func (s *Service) SetRelationUnitSettings(
 ) error {
 	return coreerrors.NotImplemented
 }
-
-// UpdateRelationApplicationSettings updates settings for a specific application
-// relation combination.
-func (s *Service) UpdateRelationApplicationSettings(
-	ctx context.Context,
-	relationUUID corerelation.UUID,
-	applicationID application.ID,
-	settings map[string]string,
-) error {
-	// TODO: (hml) 24-Mar-2025
-	// Implement leadership checking here: e.g.
-	// return s.leaderEnsurer.WithLeader(ctx, appName, unitName.String(), func(ctx context.Context) error {
-	//		return s.st.SetRelationStatus(ctx, appID, encodedStatus)
-	//	})
-	return coreerrors.NotImplemented
-}
-
-// UpdateRelationUnitSettings updates settings for a specific unit
-// relation combination.
-func (s *Service) UpdateRelationUnitSettings(
-	ctx context.Context,
-	relationUnitUUID corerelation.UnitUUID,
-	settings map[string]string,
-) error {
-	return coreerrors.NotImplemented
-}


### PR DESCRIPTION
There were both Set... and Update... methods on the relation domain, the update methods appear to be the old name in state. This change moves to having the Get/Set nomenclature.

<!--
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://github.com/juju/juju/blob/main/docs/contributor/reference/conventional-commits.md
-->

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps
Unit tests.

## Links

<!-- Add a Jira card reference or link, otherwise remove this line. -->
**Jira card:** [JUJU-7444](https://warthogs.atlassian.net/browse/JUJU-7444)


[JUJU-7444]: https://warthogs.atlassian.net/browse/JUJU-7444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ