### PR TITLE
refactor: remove Local from GetLocalRelationApplicationSettings

### DIFF
--- a/apiserver/facades/agent/uniter/service.go
+++ b/apiserver/facades/agent/uniter/service.go
@@ -245,12 +245,12 @@ type RelationService interface {
 		unitName coreunit.Name,
 	) error
 
-	// GetLocalRelationApplicationSettings returns the application settings
+	// GetRelationApplicationSettings returns the application settings
 	// for the given application and relation identifier combination.
 	// ApplicationSettings may only be read by the application leader.
 	// Returns NotFound if this unit is not the leader, if the application or
 	// relation is not found.
-	GetLocalRelationApplicationSettings(
+	GetRelationApplicationSettings(
 		ctx context.Context,
 		unitName coreunit.Name,
 		relationUUID corerelation.UUID,

--- a/apiserver/facades/agent/uniter/service_mock_test.go
+++ b/apiserver/facades/agent/uniter/service_mock_test.go
@@ -912,41 +912,41 @@ func (c *MockRelationServiceEnterScopeCall) DoAndReturn(f func(context.Context, 
 	return c
 }
 
-// GetLocalRelationApplicationSettings mocks base method.
-func (m *MockRelationService) GetLocalRelationApplicationSettings(arg0 context.Context, arg1 unit.Name, arg2 relation.UUID, arg3 application.ID) (map[string]string, error) {
+// GetRelationApplicationSettings mocks base method.
+func (m *MockRelationService) GetRelationApplicationSettings(arg0 context.Context, arg1 unit.Name, arg2 relation.UUID, arg3 application.ID) (map[string]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetLocalRelationApplicationSettings", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "GetRelationApplicationSettings", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(map[string]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetLocalRelationApplicationSettings indicates an expected call of GetLocalRelationApplicationSettings.
-func (mr *MockRelationServiceMockRecorder) GetLocalRelationApplicationSettings(arg0, arg1, arg2, arg3 any) *MockRelationServiceGetLocalRelationApplicationSettingsCall {
+// GetRelationApplicationSettings indicates an expected call of GetRelationApplicationSettings.
+func (mr *MockRelationServiceMockRecorder) GetRelationApplicationSettings(arg0, arg1, arg2, arg3 any) *MockRelationServiceGetRelationApplicationSettingsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLocalRelationApplicationSettings", reflect.TypeOf((*MockRelationService)(nil).GetLocalRelationApplicationSettings), arg0, arg1, arg2, arg3)
-	return &MockRelationServiceGetLocalRelationApplicationSettingsCall{Call: call}
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRelationApplicationSettings", reflect.TypeOf((*MockRelationService)(nil).GetRelationApplicationSettings), arg0, arg1, arg2, arg3)
+	return &MockRelationServiceGetRelationApplicationSettingsCall{Call: call}
 }
 
-// MockRelationServiceGetLocalRelationApplicationSettingsCall wrap *gomock.Call
-type MockRelationServiceGetLocalRelationApplicationSettingsCall struct {
+// MockRelationServiceGetRelationApplicationSettingsCall wrap *gomock.Call
+type MockRelationServiceGetRelationApplicationSettingsCall struct {
 	*gomock.Call
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockRelationServiceGetLocalRelationApplicationSettingsCall) Return(arg0 map[string]string, arg1 error) *MockRelationServiceGetLocalRelationApplicationSettingsCall {
+func (c *MockRelationServiceGetRelationApplicationSettingsCall) Return(arg0 map[string]string, arg1 error) *MockRelationServiceGetRelationApplicationSettingsCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockRelationServiceGetLocalRelationApplicationSettingsCall) Do(f func(context.Context, unit.Name, relation.UUID, application.ID) (map[string]string, error)) *MockRelationServiceGetLocalRelationApplicationSettingsCall {
+func (c *MockRelationServiceGetRelationApplicationSettingsCall) Do(f func(context.Context, unit.Name, relation.UUID, application.ID) (map[string]string, error)) *MockRelationServiceGetRelationApplicationSettingsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockRelationServiceGetLocalRelationApplicationSettingsCall) DoAndReturn(f func(context.Context, unit.Name, relation.UUID, application.ID) (map[string]string, error)) *MockRelationServiceGetLocalRelationApplicationSettingsCall {
+func (c *MockRelationServiceGetRelationApplicationSettingsCall) DoAndReturn(f func(context.Context, unit.Name, relation.UUID, application.ID) (map[string]string, error)) *MockRelationServiceGetRelationApplicationSettingsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/apiserver/facades/agent/uniter/uniter.go
+++ b/apiserver/facades/agent/uniter/uniter.go
@@ -1573,7 +1573,7 @@ func (u *UniterAPI) readLocalApplicationSettings(
 		return nil, errors.Trace(err)
 	}
 
-	settings, err := u.relationService.GetLocalRelationApplicationSettings(ctx, unitName, relUUID, appID)
+	settings, err := u.relationService.GetRelationApplicationSettings(ctx, unitName, relUUID, appID)
 	if errors.Is(err, errors.NotFound) {
 		return nil, apiservererrors.ErrPerm
 	} else if err != nil {

--- a/domain/relation/service/relation.go
+++ b/domain/relation/service/relation.go
@@ -233,12 +233,12 @@ func (s *Service) GetApplicationEndpoints(ctx context.Context, applicationID app
 	return s.st.GetApplicationEndpoints(ctx, applicationID)
 }
 
-// GetLocalRelationApplicationSettings returns the application settings
+// GetRelationApplicationSettings returns the application settings
 // for the given application and relation identifier combination.
 // ApplicationSettings may only be read by the application leader.
 // Returns NotFound if this unit is not the leader, if the application or
 // relation is not found.
-func (s *Service) GetLocalRelationApplicationSettings(
+func (s *Service) GetRelationApplicationSettings(
 	ctx context.Context,
 	unitName unit.Name,
 	relationUUID corerelation.UUID,


### PR DESCRIPTION
Remove "Local" to fit the Get/Set Relation Application Settings pattern. The Local/Remote destinction is part of the CMR work that will be done at a later date.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps
Unit tests


## Links


<!-- Add a Jira card reference or link, otherwise remove this line. -->
**Jira card:** [JUJU-7444](https://warthogs.atlassian.net/browse/JUJU-7444)


[JUJU-7444]: https://warthogs.atlassian.net/browse/JUJU-7444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ