### PR TITLE
fix: do not attempt to validate model defaults

### DIFF
--- a/state/modelconfig.go
+++ b/state/modelconfig.go
@@ -201,30 +201,6 @@ func (st *State) UpdateModelConfigDefaultValues(updateAttrs map[string]interface
 	// applied as a delta to what's on disk; if there has
 	// been a concurrent update, the change may not be what
 	// the user asked for.
-
-	// Attempt to validate against the current old model and the new model, that
-	// should be enough to verify the config against.
-	// If there are additional fields in the config, then this should be fine
-	// and should not throw a validation error.
-	model, err := st.Model()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	oldConfig, err := model.ModelConfig()
-	if err != nil {
-		return errors.Trace(err)
-	}
-	validCfg, err := st.buildAndValidateModelConfig(updateAttrs, removeAttrs, oldConfig)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	validAttrs := validCfg.AllAttrs()
-	for k := range updateAttrs {
-		if v, ok := validAttrs[k]; ok {
-			updateAttrs[k] = v
-		}
-	}
-
 	updateAttrs = config.CoerceForStorage(updateAttrs)
 	settings.Update(updateAttrs)
 	for _, r := range removeAttrs {

--- a/state/modelconfig_test.go
+++ b/state/modelconfig_test.go
@@ -533,22 +533,6 @@ func (s *ModelConfigSourceSuite) TestUpdateModelConfigDefaultsArbitraryConfig(c 
 	c.Assert(cfg, jc.DeepEquals, expectedValues)
 }
 
-func (s *ModelConfigSourceSuite) TestUpdateModelConfigDefaultsWithValidationError(c *gc.C) {
-	// Set up values that will be removed.
-	attrs := map[string]interface{}{
-		"http-proxy":  "http://http-proxy",
-		"https-proxy": "https://https-proxy",
-	}
-	err := s.State.UpdateModelConfigDefaultValues(attrs, nil, nil)
-	c.Assert(err, jc.ErrorIsNil)
-
-	attrs = map[string]interface{}{
-		"test-mode": "baz",
-	}
-	err = s.State.UpdateModelConfigDefaultValues(attrs, []string{"http-proxy", "https-proxy"}, nil)
-	c.Assert(err, gc.ErrorMatches, `test-mode: expected bool, got string\("baz"\)`)
-}
-
 func (s *ModelConfigSourceSuite) TestUpdateModelConfigRegionDefaults(c *gc.C) {
 	// The test env is setup with dummy/dummy-region having a no-proxy
 	// dummy-proxy value and nether-region with a nether-proxy value.


### PR DESCRIPTION
Model defaults, when set are checked for validity by applying them to the model configuration for the current state's model.

The behaviour was introduced with https://github.com/juju/juju/pull/11848.

This is not correct. We should not be using a configuration validator for a model's cloud/region that may be different to another model to which we want to apply the defaults.

Furthermore, it introduces a kind of deadlock whereby:
- Model default for legacy proxy settings are used at bootstrap.
- Every model created then has those settings.
- Setting the default for legacy proxy settings back to "" works.
- But now setting the new juju-* proxy values fails because we validate against the current model configuration.

Model defaults are used to snapshot new model configuration, not to fall back on, so we can rely on the model-level configuration validation, also applied at creation, to ensure we never have invalid settings.

## QA steps

TBC

## Links

**Issue:**

**Jira card:**
