### PR TITLE
refactor: remove model metrics

### DIFF
--- a/state/model.go
+++ b/state/model.go
@@ -6,7 +6,6 @@ package state
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
@@ -662,66 +661,6 @@ func (st *State) AllUnits() ([]*Unit, error) {
 		units = append(units, newUnit(st, m.Type(), &docs[i]))
 	}
 	return units, nil
-}
-
-// ModelMetrics contains metrics to be collected and sent to
-// Charmhub via the charm revision updater for a model.
-type ModelMetrics struct {
-	ApplicationCount string
-	MachineCount     string
-	UnitCount        string
-	CloudName        string
-	CloudRegion      string
-	Provider         string
-	UUID             string
-	ControllerUUID   string
-}
-
-// Metrics returns model level metrics to be collected and sent to
-// Charmhub via the charm revision updater.
-func (m *Model) Metrics() (ModelMetrics, error) {
-	appCnt, err := m.applicationCount()
-	if err != nil {
-		return ModelMetrics{}, errors.Trace(err)
-	}
-	machCnt, err := m.machineCount()
-	if err != nil {
-		return ModelMetrics{}, errors.Trace(err)
-	}
-	unitCnt, err := m.unitCount()
-	if err != nil {
-		return ModelMetrics{}, errors.Trace(err)
-	}
-
-	return ModelMetrics{
-		ApplicationCount: strconv.Itoa(appCnt),
-		MachineCount:     strconv.Itoa(machCnt),
-		UnitCount:        strconv.Itoa(unitCnt),
-		CloudName:        m.CloudName(),
-		CloudRegion:      m.CloudRegion(),
-		// TODO(wallyworld) - we no longer have cloud in state to get cloud type
-		//Provider:         cloud.Type,
-		UUID:           m.UUID(),
-		ControllerUUID: m.doc.ControllerUUID,
-	}, nil
-}
-
-func (m *Model) applicationCount() (int, error) {
-	coll, closer := m.st.db().GetCollection(applicationsC)
-	defer closer()
-	return coll.Find(isAliveDoc).Count()
-}
-
-func (m *Model) machineCount() (int, error) {
-	coll, closer := m.st.db().GetCollection(machinesC)
-	defer closer()
-	return coll.Find(isAliveDoc).Count()
-}
-
-func (m *Model) unitCount() (int, error) {
-	coll, closer := m.st.db().GetCollection(unitsC)
-	defer closer()
-	return coll.Find(isAliveDoc).Count()
 }
 
 // AllEndpointBindings returns all endpoint->space bindings


### PR DESCRIPTION
While planning the end of the model core work I noticed that we were not calling model metrics in state any more. This is due to the ChamrRevisionUpdater facade having been deleted. This was the only call site we had in 3.6.

This code can safely be removed now and we can get on with more transition work.

## Checklist

- ~[] Code style: imports ordered, good names, simple structure, etc~
- ~[ ] Comments saying why design decisions were made~
- ~[ ] Go unit tests, with comments saying what you're testing~
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Deleting unused code. No tests to run.

## Documentation changes

N/A

## Links

**Jira card:** JUJU-6969
