### PR TITLE
refactor: remove dead code paths for model

### DIFF
--- a/apiserver/common/crossmodel/interface.go
+++ b/apiserver/common/crossmodel/interface.go
@@ -27,9 +27,6 @@ type BakeryConfigService interface {
 }
 
 type Backend interface {
-	// AllModelUUIDs returns the UUIDs of all models in the controller.
-	AllModelUUIDs() ([]string, error)
-
 	// ControllerTag the tag of the controller in which we are operating.
 	ControllerTag() names.ControllerTag
 

--- a/state/model.go
+++ b/state/model.go
@@ -385,11 +385,6 @@ func (m *Model) Tag() names.Tag {
 	return m.ModelTag()
 }
 
-// Kind returns a human readable name identifying the model kind.
-func (m *Model) Kind() string {
-	return m.Tag().Kind()
-}
-
 // ModelTag is the concrete model tag for this model.
 func (m *Model) ModelTag() names.ModelTag {
 	return names.NewModelTag(m.doc.UUID)


### PR DESCRIPTION
Removes model kind off of state as we have no calls to this anymore. Also remove's all model uuids func off of model manager as it isn't used.

## Checklist

- ~[ ] Code style: imports ordered, good names, simple structure, etc~
- ~[ ] Comments saying why design decisions were made~
- ~[ ] Go unit tests, with comments saying what you're testing~
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Just code removal that wasn't being called.

## Documentation changes

N/A

## Links

**Jira card:** JUJU-6969
