### PR TITLE
feat: add device_constraint related tables to application DDL

### DIFF
--- a/domain/application/state/application.go
+++ b/domain/application/state/application.go
@@ -446,6 +446,7 @@ func (st *State) deleteSimpleApplicationReferences(ctx context.Context, tx *sqla
 		"application_exposed_endpoint_space",
 		"application_exposed_endpoint_cidr",
 		"application_storage_directive",
+		"device_constraint",
 	} {
 		deleteApplicationReference := fmt.Sprintf(`DELETE FROM %s WHERE application_uuid = $applicationID.uuid`, table)
 		deleteApplicationReferenceStmt, err := st.Prepare(deleteApplicationReference, app)

--- a/domain/credential/state/state.go
+++ b/domain/credential/state/state.go
@@ -225,7 +225,7 @@ func updateCredentialAttributes(ctx context.Context, tx *sqlair.TX, credentialUU
 	// Delete any keys no longer in the attributes map.
 	// TODO(wallyworld) - sqlair does not support IN operations with a list of values
 	deleteQuery := `
-DELETE FROM  cloud_credential_attributes
+DELETE FROM  cloud_credential_attribute
 WHERE        cloud_credential_uuid = $M.uuid
 `
 
@@ -238,7 +238,7 @@ WHERE        cloud_credential_uuid = $M.uuid
 	}
 
 	insertQuery := `
-INSERT INTO cloud_credential_attributes
+INSERT INTO cloud_credential_attribute
 VALUES (
     $CredentialAttribute.cloud_credential_uuid,
     $CredentialAttribute.key,
@@ -413,7 +413,7 @@ FROM   cloud_credential cc
        JOIN auth_type ON cc.auth_type_id = auth_type.id
        JOIN cloud ON cc.cloud_uuid = cloud.uuid
 	   JOIN user on cc.owner_uuid = user.uuid
-       LEFT JOIN cloud_credential_attributes cc_attr ON cc_attr.cloud_credential_uuid = cc.uuid
+       LEFT JOIN cloud_credential_attribute cc_attr ON cc_attr.cloud_credential_uuid = cc.uuid
 WHERE  user.removed = false
 AND    user.name = $ownerAndCloudName.owner_name
 AND    cloud.name = $ownerAndCloudName.cloud_name
@@ -475,7 +475,7 @@ FROM   cloud_credential cc
        JOIN auth_type ON cc.auth_type_id = auth_type.id
        JOIN cloud ON cc.cloud_uuid = cloud.uuid
 	   JOIN user on cc.owner_uuid = user.uuid
-       LEFT JOIN cloud_credential_attributes cc_attr ON cc_attr.cloud_credential_uuid = cc.uuid
+       LEFT JOIN cloud_credential_attribute cc_attr ON cc_attr.cloud_credential_uuid = cc.uuid
 WHERE  user.removed = false
 AND    cloud.name = $credentialKey.cloud_name
 AND    user.name = $credentialKey.owner_name
@@ -553,7 +553,7 @@ func GetCloudCredential(
 ) (credential.CloudCredentialResult, error) {
 	q := `
 SELECT ca.* AS &credentialWithAttribute.*
-FROM   v_cloud_credential_attributes ca
+FROM   v_cloud_credential_attribute ca
 WHERE  uuid = $M.id
 `
 
@@ -615,7 +615,7 @@ FROM   cloud_credential cc
        JOIN auth_type ON cc.auth_type_id = auth_type.id
        JOIN cloud ON cc.cloud_uuid = cloud.uuid
 	   JOIN user on cc.owner_uuid = user.uuid
-       LEFT JOIN cloud_credential_attributes cc_attr ON cc_attr.cloud_credential_uuid = cc.uuid
+       LEFT JOIN cloud_credential_attribute cc_attr ON cc_attr.cloud_credential_uuid = cc.uuid
 WHERE  user.removed = false
 AND    user.name = $ownerName.name
 `
@@ -671,8 +671,8 @@ func (st *State) RemoveCloudCredential(ctx context.Context, key corecredential.K
 	}
 
 	credAttrDeleteQ := `
-DELETE FROM cloud_credential_attributes
-WHERE  cloud_credential_attributes.cloud_credential_uuid = $M.uuid
+DELETE FROM cloud_credential_attribute
+WHERE  cloud_credential_attribute.cloud_credential_uuid = $M.uuid
 `
 
 	credDeleteQ := `

--- a/domain/credential/state/types.go
+++ b/domain/credential/state/types.go
@@ -48,7 +48,7 @@ type Credential struct {
 }
 
 // credentialWithAttribute represents a single returned from the
-// v_cloud_credential_attributes table.
+// v_cloud_credential_attribute table.
 type credentialWithAttribute struct {
 	ID string `db:"uuid"`
 

--- a/domain/schema/controller/sql/0005-cloud.sql
+++ b/domain/schema/controller/sql/0005-cloud.sql
@@ -228,7 +228,7 @@ JOIN cloud AS c ON cc.cloud_uuid = c.uuid
 JOIN user AS u ON cc.owner_uuid = u.uuid
 JOIN auth_type AS at ON cc.auth_type_id = at.id;
 
-CREATE TABLE cloud_credential_attributes (
+CREATE TABLE cloud_credential_attribute (
     cloud_credential_uuid TEXT NOT NULL,
     "key" TEXT NOT NULL,
     value TEXT,
@@ -239,9 +239,9 @@ CREATE TABLE cloud_credential_attributes (
     REFERENCES cloud_credential (uuid)
 );
 
--- v_cloud_credential_attributes is responsible for return a view of all cloud
+-- v_cloud_credential_attribute is responsible for return a view of all cloud
 -- credentials and their attributes repeated for every attribute.
-CREATE VIEW v_cloud_credential_attributes
+CREATE VIEW v_cloud_credential_attribute
 AS
 SELECT
     cc.uuid,
@@ -259,5 +259,5 @@ SELECT
     cca.value AS attribute_value
 FROM v_cloud_credential AS cc
 JOIN
-    cloud_credential_attributes AS cca
+    cloud_credential_attribute AS cca
     ON cc.uuid = cca.cloud_credential_uuid;

--- a/domain/schema/controller_schema_test.go
+++ b/domain/schema/controller_schema_test.go
@@ -48,7 +48,7 @@ func (s *controllerSchemaSuite) TestControllerTables(c *gc.C) {
 		"cloud_auth_type",
 		"cloud_ca_cert",
 		"cloud_credential",
-		"cloud_credential_attributes",
+		"cloud_credential_attribute",
 		"cloud_defaults",
 		"cloud_region",
 		"cloud_region_defaults",
@@ -158,7 +158,7 @@ func (s *controllerSchemaSuite) TestControllerViews(c *gc.C) {
 
 		// v_cloud_credential
 		"v_cloud_credential",
-		"v_cloud_credential_attributes",
+		"v_cloud_credential_attribute",
 
 		// Models
 		"v_model",

--- a/domain/schema/model/sql/0019-application.sql
+++ b/domain/schema/model/sql/0019-application.sql
@@ -200,6 +200,27 @@ CREATE TABLE application_status (
     REFERENCES workload_status_value (id)
 );
 
+CREATE TABLE device_constraint (
+    uuid TEXT NOT NULL PRIMARY KEY,
+    application_uuid TEXT NOT NULL,
+    name TEXT NOT NULL,
+    type TEXT NOT NULL,
+    count INT,
+    CONSTRAINT fk_device_constraint_application
+    FOREIGN KEY (application_uuid)
+    REFERENCES application (uuid)
+);
+
+CREATE TABLE device_constraint_attribute (
+    device_constraint_uuid TEXT NOT NULL,
+    "key" TEXT NOT NULL,
+    value TEXT NOT NULL,
+    CONSTRAINT fk_device_constraint_attribute_device_constraint
+    FOREIGN KEY (device_constraint_uuid)
+    REFERENCES device_constraint (uuid),
+    PRIMARY KEY (device_constraint_uuid, "key")
+);
+
 CREATE VIEW v_application_constraint AS
 SELECT
     ac.application_uuid,

--- a/domain/schema/model_schema_test.go
+++ b/domain/schema/model_schema_test.go
@@ -38,6 +38,8 @@ func (s *modelSchemaSuite) TestModelTables(c *gc.C) {
 		"application_status",
 		"k8s_service",
 		"workload_status_value",
+		"device_constraint",
+		"device_constraint_attribute",
 
 		// Annotations
 		"annotation_application",

--- a/domain/secretbackend/state/state.go
+++ b/domain/secretbackend/state/state.go
@@ -483,7 +483,7 @@ FROM secret_backend_reference sbr
     JOIN v_model vm ON sbr.model_uuid = vm.uuid
     JOIN v_cloud_auth vc ON vm.cloud_uuid = vc.uuid
     JOIN cloud_ca_cert ccc ON vc.uuid = ccc.cloud_uuid
-    JOIN v_cloud_credential_attributes vcca ON vm.cloud_credential_uuid = vcca.uuid
+    JOIN v_cloud_credential_attribute vcca ON vm.cloud_credential_uuid = vcca.uuid
 WHERE b.name = '%s'
 GROUP BY vm.name, vcca.attribute_key`, kubernetes.BackendName)
 	backendStmt, err := s.Prepare(backendQuery, secretBackendForK8sModelRow{}, cloudRow{}, cloudCredentialRow{})
@@ -658,7 +658,7 @@ SELECT
 FROM v_model vm
     JOIN v_cloud_auth vc ON vm.cloud_uuid = vc.uuid
     JOIN cloud_ca_cert ccc ON vc.uuid = ccc.cloud_uuid
-    JOIN v_cloud_credential_attributes vcca ON vm.cloud_credential_uuid = vcca.uuid
+    JOIN v_cloud_credential_attribute vcca ON vm.cloud_credential_uuid = vcca.uuid
 WHERE vm.uuid = $modelIdentifier.uuid
 GROUP BY vm.name, vcca.attribute_key`, modelIdentifier{}, modelDetails{}, secretBackendForK8sModelRow{}, cloudRow{}, cloudCredentialRow{})
 	if err != nil {


### PR DESCRIPTION
This patch adds the needed tables to finish the device constraints feature in the application domain.

This table will be used only as an insert and retrieve as constraints. 

The `application_uuid` field both in `device_constraint` and `device_constraint_attribute` was added for easier delete by reference (like the rest of application tables).

__Bonus: the cloud_credential_attributes table (and associated view) was renamed to the singular for uniformity with the rest of the DDL.__


## Links

**Jira card:** JUJU-7829
