### PR TITLE
refactor: remove more uses of mongo model state

### DIFF
--- a/apiserver/common/tools.go
+++ b/apiserver/common/tools.go
@@ -16,6 +16,7 @@ import (
 	coreagentbinary "github.com/juju/juju/core/agentbinary"
 	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/machine"
+	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/core/semversion"
@@ -28,7 +29,6 @@ import (
 	"github.com/juju/juju/internal/errors"
 	coretools "github.com/juju/juju/internal/tools"
 	"github.com/juju/juju/rpc/params"
-	"github.com/juju/juju/state"
 	"github.com/juju/juju/state/binarystorage"
 )
 
@@ -203,7 +203,7 @@ type FindAgentsParams struct {
 	ControllerCfg controller.Config
 
 	// ModelType is the type of the model.
-	ModelType state.ModelType
+	ModelType coremodel.ModelType
 
 	// Number will be used to match tools versions exactly if non-zero.
 	Number semversion.Number

--- a/apiserver/facades/client/modelupgrader/findagents.go
+++ b/apiserver/facades/client/modelupgrader/findagents.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/juju/apiserver/common"
 	"github.com/juju/juju/controller"
 	"github.com/juju/juju/core/arch"
+	coremodel "github.com/juju/juju/core/model"
 	coreos "github.com/juju/juju/core/os"
 	"github.com/juju/juju/core/semversion"
 	envtools "github.com/juju/juju/environs/tools"
@@ -19,7 +20,6 @@ import (
 	"github.com/juju/juju/internal/docker"
 	"github.com/juju/juju/internal/featureflag"
 	coretools "github.com/juju/juju/internal/tools"
-	"github.com/juju/juju/state"
 )
 
 var errUpToDate = errors.AlreadyExistsf("no upgrades available")
@@ -56,7 +56,7 @@ func (m *ModelUpgraderAPI) decideVersion(
 	// highest minor version with the same major version number.
 	// CAAS models exclude agents with dev builds unless the current version
 	// is also a dev build.
-	allowDevBuilds := args.ModelType == state.ModelTypeIAAS || currentVersion.Build > 0
+	allowDevBuilds := args.ModelType == coremodel.IAAS || currentVersion.Build > 0
 	newestCurrent, found := streamVersions.NewestCompatible(currentVersion, allowDevBuilds)
 	if found {
 		if newestCurrent.Compare(currentVersion) == 0 {
@@ -77,7 +77,7 @@ func (m *ModelUpgraderAPI) findAgents(
 	args common.FindAgentsParams,
 ) (coretools.Versions, error) {
 	list, err := m.toolsFinder.FindAgents(ctx, args)
-	if args.ModelType != state.ModelTypeCAAS {
+	if args.ModelType != coremodel.CAAS {
 		// We return now for non CAAS model.
 		return toolListToVersions(list), errors.Annotate(err, "cannot find agents from simple streams")
 	}


### PR DESCRIPTION
This commit attempts to remove more pieces from the model upgrader that are relying on mongo state for accessing model information.

In this commit we were able to move the model type parameters for finding a desired version over to using core types instead of state.

We are able to now use the model info service for information about the model being upgraded. As part of this we have also wired in the current model's agent binary service.

However this still leaves a big hole when it comes to upgrading controllers. To currently perform this task we still need state as this check requires looping through every model in the controller and running checks. To remove these last pieces we are going to have to develop new domains for upgrading the controller and model that this facade can use.

This will allow us to remove the last of the mongo calls from the model upgrader.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Model upgrading isn't currently working till we finish moving everything to Dqlite. A follow up PR will cover a full end to end tests with unit tests.

## Documentation changes

N/A

## Links

**Jira card:** JUJU-7789
