### PR TITLE
feat: implement device constraint state and service layer

### DIFF
--- a/apiserver/facades/client/application/deploy.go
+++ b/apiserver/facades/client/application/deploy.go
@@ -337,7 +337,7 @@ func stateDeviceConstraints(cons map[string]devices.Constraints) map[string]stat
 	for name, cons := range cons {
 		result[name] = state.DeviceConstraints{
 			Type:       state.DeviceType(cons.Type),
-			Count:      cons.Count,
+			Count:      int64(cons.Count),
 			Attributes: cons.Attributes,
 		}
 	}

--- a/core/devices/constraints.go
+++ b/core/devices/constraints.go
@@ -23,14 +23,14 @@ type Constraints struct {
 	// - gpu
 	// - nvidia.com/gpu
 	// - amd.com/gpu
-	Type DeviceType `bson:"type"`
+	Type DeviceType
 
 	// Count is the number of devices that the user has asked for - count min and max are the
 	// number of devices the charm requires.
-	Count int64 `bson:"count"`
+	Count int
 
 	// Attributes is a collection of key value pairs device related (node affinity labels/tags etc.).
-	Attributes map[string]string `bson:"attributes"`
+	Attributes map[string]string
 }
 
 // ParseConstraints parses the specified string and creates a
@@ -94,14 +94,14 @@ func parseAttributes(s string) (map[string]string, error) {
 	return attr, nil
 }
 
-func parseCount(s string) (int64, error) {
+func parseCount(s string) (int, error) {
 	errMsg := errors.Errorf("count must be greater than zero, got %q", s)
 	i, err := strconv.ParseInt(s, 10, 64)
 	if err != nil {
 		return 0, errMsg
 	}
 	if i > 0 {
-		return i, nil
+		return int(i), nil
 	}
 	return 0, errMsg
 }

--- a/domain/application/service/package_mock_test.go
+++ b/domain/application/service/package_mock_test.go
@@ -20,6 +20,7 @@ import (
 	changestream "github.com/juju/juju/core/changestream"
 	charm "github.com/juju/juju/core/charm"
 	constraints "github.com/juju/juju/core/constraints"
+	devices "github.com/juju/juju/core/devices"
 	model "github.com/juju/juju/core/model"
 	network "github.com/juju/juju/core/network"
 	semversion "github.com/juju/juju/core/semversion"
@@ -1904,6 +1905,45 @@ func (c *MockStateGetCharmModifiedVersionCall) Do(f func(context.Context, applic
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockStateGetCharmModifiedVersionCall) DoAndReturn(f func(context.Context, application.ID) (int, error)) *MockStateGetCharmModifiedVersionCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetDeviceConstraints mocks base method.
+func (m *MockState) GetDeviceConstraints(ctx context.Context, appID application.ID) (map[string]devices.Constraints, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDeviceConstraints", ctx, appID)
+	ret0, _ := ret[0].(map[string]devices.Constraints)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDeviceConstraints indicates an expected call of GetDeviceConstraints.
+func (mr *MockStateMockRecorder) GetDeviceConstraints(ctx, appID any) *MockStateGetDeviceConstraintsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeviceConstraints", reflect.TypeOf((*MockState)(nil).GetDeviceConstraints), ctx, appID)
+	return &MockStateGetDeviceConstraintsCall{Call: call}
+}
+
+// MockStateGetDeviceConstraintsCall wrap *gomock.Call
+type MockStateGetDeviceConstraintsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateGetDeviceConstraintsCall) Return(arg0 map[string]devices.Constraints, arg1 error) *MockStateGetDeviceConstraintsCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateGetDeviceConstraintsCall) Do(f func(context.Context, application.ID) (map[string]devices.Constraints, error)) *MockStateGetDeviceConstraintsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateGetDeviceConstraintsCall) DoAndReturn(f func(context.Context, application.ID) (map[string]devices.Constraints, error)) *MockStateGetDeviceConstraintsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/application/service/params.go
+++ b/domain/application/service/params.go
@@ -7,6 +7,7 @@ import (
 	corecharm "github.com/juju/juju/core/charm"
 	"github.com/juju/juju/core/config"
 	"github.com/juju/juju/core/constraints"
+	"github.com/juju/juju/core/devices"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/objectstore"
 	"github.com/juju/juju/core/resource"
@@ -73,6 +74,9 @@ type AddApplicationArgs struct {
 	// EndpointBindings is a map to bind application endpoint by name to a
 	// specific space. The default space is referenced by an empty key, if any.
 	EndpointBindings map[string]network.SpaceName
+
+	// Devices contains the device constraints for the application.
+	Devices map[string]devices.Constraints
 }
 
 // AddressParams contains parameters for a unit/cloud container address.

--- a/domain/application/service/provider.go
+++ b/domain/application/service/provider.go
@@ -137,6 +137,10 @@ func (s *ProviderService) CreateApplication(
 		return "", errors.Errorf("create application: %w", err)
 	}
 
+	if err := validateDeviceConstraints(args.Devices, charm.Meta()); err != nil {
+		return "", errors.Errorf("validating device constraints: %w", err)
+	}
+
 	modelType, err := s.st.GetModelType(ctx)
 	if err != nil {
 		return "", errors.Errorf("getting model type: %w", err)

--- a/domain/application/state/application.go
+++ b/domain/application/state/application.go
@@ -365,6 +365,9 @@ WHERE application_uuid = $applicationDetails.uuid
 	}
 	app.UUID = appUUID
 
+	if err := st.deleteDeviceConstraintAttributes(ctx, tx, appUUID); err != nil {
+		return errors.Errorf("deleting device constraint attributes for application %q: %w", name, err)
+	}
 	// delete application endpoints
 	if err := st.deleteApplicationEndpoints(ctx, tx, appUUID); err != nil {
 		return errors.Errorf("deleting application endpoints for application %q: %w", name, err)
@@ -386,10 +389,6 @@ WHERE application_uuid = $applicationDetails.uuid
 
 	if err := st.deleteCloudServices(ctx, tx, appUUID); err != nil {
 		return errors.Errorf("deleting cloud service for application %q: %w", name, err)
-	}
-
-	if err := st.deleteDeviceConstraintAttributes(ctx, tx, appUUID); err != nil {
-		return errors.Errorf("deleting device constraint attributes for application %q: %w", name, err)
 	}
 
 	// TODO(units) - fix these tables to allow deletion of rows

--- a/domain/application/state/application_test.go
+++ b/domain/application/state/application_test.go
@@ -3239,29 +3239,13 @@ func (s *applicationStateSuite) TestGetDeviceConstraints(c *gc.C) {
 	id := s.createApplication(c, "foo", life.Alive)
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		insertDeviceConstraint0 := `INSERT INTO device_constraint (uuid, application_uuid, name, type, count) VALUES (?, ?, ?, ?, ?)`
-		_, err := tx.ExecContext(ctx, insertDeviceConstraint0, "dev0-uuid", id.String(), "dev0", "type0", 42)
-		if err != nil {
-			return err
-		}
-		_, err = tx.ExecContext(ctx, insertDeviceConstraint0, "dev1-uuid", id.String(), "dev1", "type1", 3)
-		if err != nil {
-			return err
-		}
-		_, err = tx.ExecContext(ctx, insertDeviceConstraint0, "dev2-uuid", id.String(), "dev2", "type2", 1974)
+		_, err := tx.ExecContext(ctx, insertDeviceConstraint0, "dev3-uuid", id.String(), "dev3", "type3", 666)
 		if err != nil {
 			return err
 		}
 
 		insertDeviceConstraintAttrs0 := `INSERT INTO device_constraint_attribute (device_constraint_uuid, "key", value) VALUES (?, ?, ?)`
-		_, err = tx.ExecContext(ctx, insertDeviceConstraintAttrs0, "dev0-uuid", "k0", "v0")
-		if err != nil {
-			return err
-		}
-		_, err = tx.ExecContext(ctx, insertDeviceConstraintAttrs0, "dev0-uuid", "k1", "v1")
-		if err != nil {
-			return err
-		}
-		_, err = tx.ExecContext(ctx, insertDeviceConstraintAttrs0, "dev1-uuid", "k2", "v2")
+		_, err = tx.ExecContext(ctx, insertDeviceConstraintAttrs0, "dev3-uuid", "k666", "v666")
 		if err != nil {
 			return err
 		}
@@ -3271,7 +3255,8 @@ func (s *applicationStateSuite) TestGetDeviceConstraints(c *gc.C) {
 
 	cons, err := s.state.GetDeviceConstraints(context.Background(), id)
 	c.Assert(err, jc.ErrorIsNil)
-	c.Check(cons, gc.HasLen, 3)
+	c.Check(cons, gc.HasLen, 4)
+	// Device constraint added by createApplication().
 	c.Check(cons["dev0"].Type, gc.Equals, devices.DeviceType("type0"))
 	c.Check(cons["dev0"].Count, gc.Equals, 42)
 	c.Check(cons["dev0"].Attributes, gc.DeepEquals, map[string]string{
@@ -3284,6 +3269,10 @@ func (s *applicationStateSuite) TestGetDeviceConstraints(c *gc.C) {
 	c.Check(cons["dev2"].Type, gc.Equals, devices.DeviceType("type2"))
 	c.Check(cons["dev2"].Count, gc.Equals, 1974)
 	c.Check(cons["dev2"].Attributes, gc.DeepEquals, map[string]string{})
+	// Device constraint added manually via inserts.
+	c.Check(cons["dev3"].Type, gc.Equals, devices.DeviceType("type3"))
+	c.Check(cons["dev3"].Count, gc.Equals, 666)
+	c.Check(cons["dev3"].Attributes, gc.DeepEquals, map[string]string{"k666": "v666"})
 }
 
 func (s *applicationStateSuite) TestGetDeviceConstraintsFromCreatedApp(c *gc.C) {

--- a/domain/application/state/package_test.go
+++ b/domain/application/state/package_test.go
@@ -14,6 +14,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	coreapplication "github.com/juju/juju/core/application"
+	"github.com/juju/juju/core/devices"
 	coremodel "github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/objectstore"
 	objectstoretesting "github.com/juju/juju/core/objectstore/testing"
@@ -260,6 +261,22 @@ func (s *baseSuite) createApplication(c *gc.C, name string, l life.Life, units .
 		},
 		Scale:     len(units),
 		Placement: "placement",
+		Devices: map[string]devices.Constraints{
+			"dev0": {
+				Type:       devices.DeviceType("type0"),
+				Count:      42,
+				Attributes: map[string]string{"k0": "v0", "k1": "v1"},
+			},
+			"dev1": {
+				Type:       devices.DeviceType("type1"),
+				Count:      3,
+				Attributes: map[string]string{"k2": "v2"},
+			},
+			"dev2": {
+				Type:  devices.DeviceType("type2"),
+				Count: 1974,
+			},
+		},
 	}, nil)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/domain/application/state/types.go
+++ b/domain/application/state/types.go
@@ -1133,3 +1133,26 @@ type spaces []string
 // endpointNames is a type used to pass a slice of endpoint names to a query
 // using `IN` and sqlair.
 type endpointNames []string
+
+type deviceConstraint struct {
+	Name           string         `db:"name"`
+	Type           string         `db:"type"`
+	Count          int            `db:"count"`
+	AttributeKey   sql.NullString `db:"key"`
+	AttributeValue sql.NullString `db:"value"`
+}
+
+type setDeviceConstraint struct {
+	UUID            string `db:"uuid"`
+	ApplicationUUID string `db:"application_uuid"`
+	Name            string `db:"name"`
+	Type            string `db:"type"`
+	Count           int    `db:"count"`
+}
+
+type setDeviceConstraintAttribute struct {
+	DeviceConstraintUUID string `db:"device_constraint_uuid"`
+	ApplicationUUID      string `db:"application_uuid"`
+	AttributeKey         string `db:"key"`
+	AttributeValue       string `db:"value"`
+}

--- a/domain/application/state/types.go
+++ b/domain/application/state/types.go
@@ -1152,7 +1152,6 @@ type setDeviceConstraint struct {
 
 type setDeviceConstraintAttribute struct {
 	DeviceConstraintUUID string `db:"device_constraint_uuid"`
-	ApplicationUUID      string `db:"application_uuid"`
 	AttributeKey         string `db:"key"`
 	AttributeValue       string `db:"value"`
 }

--- a/domain/application/types.go
+++ b/domain/application/types.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/juju/juju/core/application"
 	"github.com/juju/juju/core/charm"
+	"github.com/juju/juju/core/devices"
 	"github.com/juju/juju/core/machine"
 	"github.com/juju/juju/core/model"
 	"github.com/juju/juju/core/network"
@@ -72,6 +73,8 @@ type AddApplicationArg struct {
 	// EndpointBindings is a map to bind application endpoint by name to a
 	// specific space. The default space is referenced by an empty key, if any.
 	EndpointBindings map[string]network.SpaceName
+	// Devices contains the device constraints for the application.
+	Devices map[string]devices.Constraints
 }
 
 // AddApplicationResourceArg defines the arguments required to add a resource to an application.

--- a/domain/schema/model/sql/0019-application.sql
+++ b/domain/schema/model/sql/0019-application.sql
@@ -211,6 +211,9 @@ CREATE TABLE device_constraint (
     REFERENCES application (uuid)
 );
 
+CREATE UNIQUE INDEX idx_device_constraint_application_name
+ON device_constraint (application_uuid, name);
+
 CREATE TABLE device_constraint_attribute (
     device_constraint_uuid TEXT NOT NULL,
     "key" TEXT NOT NULL,


### PR DESCRIPTION
This patch adds two state layer methods to insert and retrieve device constraints for a given application
as well as one service method for device constraints.

Also, it wires internally in the state layer the insertion of device
constraints when creating an application.

Also, as a bonus, the bson tags in the core/devices Constraint{} struct
were removed since they shouldn't have been in a core struct in the
first place (and mongo is being removed anyways). Also, the int64 for
the count field was replaced by an int for convenience (since it's
mapped to sql types at the state layer anyways).


## QA steps

Nothing wired yet, unit tests should pass.

## Links


**Jira card:** JUJU-7832
