### PR TITLE
feat(relation): implement Get/SetRelationUnitSettings

### DIFF
--- a/domain/relation/service/package_mock_test.go
+++ b/domain/relation/service/package_mock_test.go
@@ -628,6 +628,45 @@ func (c *MockStateGetRelationUnitEndpointNameCall) DoAndReturn(f func(context.Co
 	return c
 }
 
+// GetRelationUnitSettings mocks base method.
+func (m *MockState) GetRelationUnitSettings(arg0 context.Context, arg1 relation.UnitUUID) (map[string]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRelationUnitSettings", arg0, arg1)
+	ret0, _ := ret[0].(map[string]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRelationUnitSettings indicates an expected call of GetRelationUnitSettings.
+func (mr *MockStateMockRecorder) GetRelationUnitSettings(arg0, arg1 any) *MockStateGetRelationUnitSettingsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRelationUnitSettings", reflect.TypeOf((*MockState)(nil).GetRelationUnitSettings), arg0, arg1)
+	return &MockStateGetRelationUnitSettingsCall{Call: call}
+}
+
+// MockStateGetRelationUnitSettingsCall wrap *gomock.Call
+type MockStateGetRelationUnitSettingsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateGetRelationUnitSettingsCall) Return(arg0 map[string]string, arg1 error) *MockStateGetRelationUnitSettingsCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateGetRelationUnitSettingsCall) Do(f func(context.Context, relation.UnitUUID) (map[string]string, error)) *MockStateGetRelationUnitSettingsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateGetRelationUnitSettingsCall) DoAndReturn(f func(context.Context, relation.UnitUUID) (map[string]string, error)) *MockStateGetRelationUnitSettingsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetRelationsStatusForUnit mocks base method.
 func (m *MockState) GetRelationsStatusForUnit(arg0 context.Context, arg1 unit.UUID) ([]relation0.RelationUnitStatusResult, error) {
 	m.ctrl.T.Helper()

--- a/domain/relation/service/package_mock_test.go
+++ b/domain/relation/service/package_mock_test.go
@@ -782,6 +782,44 @@ func (c *MockStateSetRelationApplicationSettingsCall) DoAndReturn(f func(context
 	return c
 }
 
+// SetRelationUnitSettings mocks base method.
+func (m *MockState) SetRelationUnitSettings(arg0 context.Context, arg1 relation.UnitUUID, arg2 map[string]string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetRelationUnitSettings", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetRelationUnitSettings indicates an expected call of SetRelationUnitSettings.
+func (mr *MockStateMockRecorder) SetRelationUnitSettings(arg0, arg1, arg2 any) *MockStateSetRelationUnitSettingsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetRelationUnitSettings", reflect.TypeOf((*MockState)(nil).SetRelationUnitSettings), arg0, arg1, arg2)
+	return &MockStateSetRelationUnitSettingsCall{Call: call}
+}
+
+// MockStateSetRelationUnitSettingsCall wrap *gomock.Call
+type MockStateSetRelationUnitSettingsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateSetRelationUnitSettingsCall) Return(arg0 error) *MockStateSetRelationUnitSettingsCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateSetRelationUnitSettingsCall) Do(f func(context.Context, relation.UnitUUID, map[string]string) error) *MockStateSetRelationUnitSettingsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateSetRelationUnitSettingsCall) DoAndReturn(f func(context.Context, relation.UnitUUID, map[string]string) error) *MockStateSetRelationUnitSettingsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // WatcherApplicationSettingsNamespace mocks base method.
 func (m *MockState) WatcherApplicationSettingsNamespace() string {
 	m.ctrl.T.Helper()

--- a/domain/relation/service/relation.go
+++ b/domain/relation/service/relation.go
@@ -123,6 +123,14 @@ type State interface {
 		unitName unit.Name,
 	) (corerelation.UnitUUID, error)
 
+	// GetRelationUnitSettings returns the relation unit settings for the given
+	// relation unit.
+	//
+	// The following error types can be expected to be returned:
+	//   - [relationerrors.RelationUnitNotFound] is returned if the
+	//     unit is not part of the relation.
+	GetRelationUnitSettings(ctx context.Context, relationUnitUUID corerelation.UnitUUID) (map[string]string, error)
+
 	// EnterScope indicates that the provided unit has joined the relation.
 	//
 	// The following error types can be expected to be returned:
@@ -566,13 +574,22 @@ func (s *Service) GetRelationUnitEndpointName(
 	return s.st.GetRelationUnitEndpointName(ctx, relationUnitUUID)
 }
 
-// GetRelationUnitSettings returns the unit settings for the
-// given unit and relation identifier combination.
+// GetRelationUnitSettings returns the relation unit settings for the given
+// relation unit.
+//
+// The following error types can be expected to be returned:
+//   - [relationerrors.RelationUnitNotFound] is returned if the
+//     unit is not part of the relation.
 func (s *Service) GetRelationUnitSettings(
 	ctx context.Context,
 	relationUnitUUID corerelation.UnitUUID,
 ) (map[string]string, error) {
-	return nil, coreerrors.NotImplemented
+	if err := relationUnitUUID.Validate(); err != nil {
+		return nil, errors.Errorf(
+			"%w:%w", relationerrors.RelationUUIDNotValid, err)
+	}
+
+	return s.st.GetRelationUnitSettings(ctx, relationUnitUUID)
 }
 
 // GetRelationUUIDByID returns the relation UUID based on the relation ID.

--- a/domain/relation/service/relation.go
+++ b/domain/relation/service/relation.go
@@ -166,6 +166,17 @@ type State interface {
 		settings map[string]string,
 	) error
 
+	// SetRelationUnitSettings records settings for a specific relation unit.
+	//
+	// The following error types can be expected to be returned:
+	//   - [relationerrors.RelationUnitNotFound] is returned if relation unit does
+	//     not exist.
+	SetRelationUnitSettings(
+		ctx context.Context,
+		relationUnitUUID corerelation.UnitUUID,
+		settings map[string]string,
+	) error
+
 	// WatcherApplicationSettingsNamespace provides the table name to set up
 	// watchers for relation application settings.
 	WatcherApplicationSettingsNamespace() string
@@ -706,10 +717,23 @@ func (s *Service) SetRelationSuspended(
 
 // SetRelationUnitSettings records settings for a specific unit
 // relation combination.
+//
+// If settings is not empty, the following error types can be expected to be
+// returned:
+//   - [relationerrors.RelationUnitNotFound] is returned if relation unit does
+//     not exist.
 func (s *Service) SetRelationUnitSettings(
 	ctx context.Context,
 	relationUnitUUID corerelation.UnitUUID,
 	settings map[string]string,
 ) error {
-	return coreerrors.NotImplemented
+	if len(settings) == 0 {
+		return nil
+	}
+
+	if err := relationUnitUUID.Validate(); err != nil {
+		return errors.Errorf(
+			"%w:%w", relationerrors.RelationUUIDNotValid, err)
+	}
+	return s.st.SetRelationUnitSettings(ctx, relationUnitUUID, settings)
 }

--- a/domain/relation/service/relation_test.go
+++ b/domain/relation/service/relation_test.go
@@ -896,6 +896,34 @@ func (s *relationServiceSuite) TestGetApplicationEndpointsApplicationUUIDNotVali
 	c.Assert(err, jc.ErrorIs, relationerrors.ApplicationIDNotValid)
 }
 
+func (s *relationServiceSuite) TestGetRelationUnitSettings(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Arrange:
+	relationUnitUUID := corerelationtesting.GenRelationUnitUUID(c)
+	expectedSettings := map[string]string{
+		"key": "value",
+	}
+	s.state.EXPECT().GetRelationUnitSettings(gomock.Any(), relationUnitUUID).Return(expectedSettings, nil)
+
+	// Act:
+	settings, err := s.service.GetRelationUnitSettings(context.Background(), relationUnitUUID)
+
+	// Assert:
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(settings, gc.DeepEquals, expectedSettings)
+}
+
+func (s *relationServiceSuite) TestGetRelationUnitSettingsUnitIDNotValid(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Act:
+	_, err := s.service.GetRelationUnitSettings(context.Background(), "bad-uuid")
+
+	// Assert:
+	c.Assert(err, jc.ErrorIs, relationerrors.RelationUUIDNotValid)
+}
+
 func (s *relationServiceSuite) setupMocks(c *gc.C) *gomock.Controller {
 	ctrl := gomock.NewController(c)
 

--- a/domain/relation/service/relation_test.go
+++ b/domain/relation/service/relation_test.go
@@ -924,6 +924,64 @@ func (s *relationServiceSuite) TestGetRelationUnitSettingsUnitIDNotValid(c *gc.C
 	c.Assert(err, jc.ErrorIs, relationerrors.RelationUUIDNotValid)
 }
 
+func (s *relationServiceSuite) TestSetRelationUnitSettings(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Arrange:
+	relationUnitUUID := corerelationtesting.GenRelationUnitUUID(c)
+	settings := map[string]string{
+		"key": "value",
+	}
+	s.state.EXPECT().SetRelationUnitSettings(gomock.Any(), relationUnitUUID, settings).Return(nil)
+
+	// Act:
+	err := s.service.SetRelationUnitSettings(context.Background(), relationUnitUUID, settings)
+
+	// Assert:
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *relationServiceSuite) TestSetRelationUnitSettingsEmpty(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Arrange:
+	relationUnitUUID := corerelationtesting.GenRelationUnitUUID(c)
+
+	// Act:
+	err := s.service.SetRelationUnitSettings(context.Background(), relationUnitUUID, make(map[string]string))
+
+	// Assert:
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *relationServiceSuite) TestSetRelationUnitSettingsNil(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Arrange:
+	relationUnitUUID := corerelationtesting.GenRelationUnitUUID(c)
+
+	// Act:
+	err := s.service.SetRelationUnitSettings(context.Background(), relationUnitUUID, nil)
+
+	// Assert:
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *relationServiceSuite) TestSetRelationUnitSettingsRelationUUIDNotValid(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Arrange:
+	settings := map[string]string{
+		"key": "value",
+	}
+
+	// Act:
+	err := s.service.SetRelationUnitSettings(context.Background(), "bad-uuid", settings)
+
+	// Assert:
+	c.Assert(err, jc.ErrorIs, relationerrors.RelationUUIDNotValid)
+}
+
 func (s *relationServiceSuite) setupMocks(c *gc.C) *gomock.Controller {
 	ctrl := gomock.NewController(c)
 

--- a/domain/relation/state/relation.go
+++ b/domain/relation/state/relation.go
@@ -1611,28 +1611,61 @@ func (st *State) GetRelationUnitSettings(
 	return relationSettings, nil
 }
 
-func (st *State) getRelationUnitSettings(
+// SetRelationUnitSettings records settings for a specific relation unit.
+//
+// The following error types can be expected to be returned:
+//   - [relationerrors.RelationUnitNotFound] is returned if relation unit does
+//     not exist.
+func (st *State) SetRelationUnitSettings(
 	ctx context.Context,
-	tx *sqlair.TX,
-	relUnitUUID corerelation.UnitUUID,
-) ([]relationSetting, error) {
-	id := relationUnitUUID{RelationUnitUUID: relUnitUUID}
-	stmt, err := st.Prepare(`
-SELECT &relationSetting.*
-FROM   relation_unit_setting
-WHERE  relation_unit_uuid = $relationUnitUUID.uuid
-`, id, relationSetting{})
+	relationUnitUUID corerelation.UnitUUID,
+	settings map[string]string,
+) error {
+	db, err := st.DB()
 	if err != nil {
-		return nil, errors.Capture(err)
+		return errors.Capture(err)
 	}
 
-	var settings []relationSetting
-	err = tx.Query(ctx, stmt, id).GetAll(&settings)
-	if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
-		return nil, errors.Capture(err)
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		// Get the relation endpoint UUID.
+		exists, err := st.checkExistsByUUID(ctx, tx, "relation_unit", relationUnitUUID.String())
+		if err != nil {
+			return errors.Errorf("checking relation unit exists: %w", err)
+		} else if !exists {
+			return relationerrors.RelationUnitNotFound
+		}
+
+		// Update the application settings specified in the settings argument.
+		err = st.updateUnitSettings(ctx, tx, relationUnitUUID, settings)
+		if err != nil {
+			return errors.Errorf("updating relation application settings: %w", err)
+		}
+
+		// Fetch all the new settings in the relation for this application.
+		newSettings, err := st.getRelationUnitSettings(ctx, tx, relationUnitUUID)
+		if err != nil {
+			return errors.Errorf("getting new relation application settings: %w", err)
+		}
+
+		// Hash the new settings.
+		hash, err := hashSettings(newSettings)
+		if err != nil {
+			return errors.Errorf("generating hash of relation application settings: %w", err)
+		}
+
+		// Update the hash in the database.
+		err = st.updateUnitSettingsHash(ctx, tx, relationUnitUUID, hash)
+		if err != nil {
+			return errors.Errorf("updating relation application settings hash: %w", err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return errors.Capture(err)
 	}
 
-	return settings, nil
+	return nil
 }
 
 func (st *State) updateApplicationSettingsHash(
@@ -1754,6 +1787,116 @@ AND         key IN ($keys[:])
 		return errors.Capture(err)
 	}
 	err = tx.Query(ctx, deleteStmt, id, unset).Run()
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	return nil
+}
+
+func (st *State) getRelationUnitSettings(
+	ctx context.Context,
+	tx *sqlair.TX,
+	relUnitUUID corerelation.UnitUUID,
+) ([]relationSetting, error) {
+	id := relationUnitUUID{RelationUnitUUID: relUnitUUID}
+	stmt, err := st.Prepare(`
+SELECT &relationSetting.*
+FROM   relation_unit_setting
+WHERE  relation_unit_uuid = $relationUnitUUID.uuid
+`, id, relationSetting{})
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	var settings []relationSetting
+	err = tx.Query(ctx, stmt, id).GetAll(&settings)
+	if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+		return nil, errors.Capture(err)
+	}
+
+	return settings, nil
+}
+
+// updateUnitSettings updates the settings for a relation unit according to the
+// provided settings map. If the value of a setting is empty then the setting is
+// deleted, otherwise it is inserted/updated.
+func (st *State) updateUnitSettings(
+	ctx context.Context,
+	tx *sqlair.TX,
+	relUnitUUID corerelation.UnitUUID,
+	settings map[string]string,
+) error {
+	if len(settings) == 0 {
+		return nil
+	}
+
+	// Determine the keys to set and unset.
+	var set []relationUnitSetting
+	var unset keys
+	for k, v := range settings {
+		if v == "" {
+			unset = append(unset, k)
+		} else {
+			set = append(set, relationUnitSetting{
+				UUID:  relUnitUUID,
+				Key:   k,
+				Value: v,
+			})
+		}
+	}
+
+	// Update the keys to set.
+	updateStmt, err := st.Prepare(`
+INSERT INTO relation_unit_setting (*) 
+VALUES ($relationUnitSetting.*) 
+ON CONFLICT (relation_unit_uuid, key) DO UPDATE SET value = excluded.value
+`, relationUnitSetting{})
+	if err != nil {
+		return errors.Capture(err)
+	}
+	err = tx.Query(ctx, updateStmt, set).Run()
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	// Delete the keys to unset.
+	id := relationUnitUUID{RelationUnitUUID: relUnitUUID}
+	deleteStmt, err := st.Prepare(`
+DELETE FROM relation_unit_setting
+WHERE       relation_unit_uuid = $relationUnitUUID.uuid
+AND         key IN ($keys[:])
+`, id, unset)
+	if err != nil {
+		return errors.Capture(err)
+	}
+	err = tx.Query(ctx, deleteStmt, id, unset).Run()
+	if err != nil {
+		return errors.Capture(err)
+	}
+
+	return nil
+}
+
+func (st *State) updateUnitSettingsHash(
+	ctx context.Context,
+	tx *sqlair.TX,
+	unitUUID corerelation.UnitUUID,
+	hash string,
+) error {
+	arg := unitSettingsHash{
+		RelationUnitUUID: unitUUID,
+		Hash:             hash,
+	}
+	stmt, err := st.Prepare(`
+INSERT INTO relation_unit_settings_hash (*) 
+VALUES ($unitSettingsHash.*) 
+ON CONFLICT (relation_unit_uuid) DO UPDATE SET sha256 = excluded.sha256
+`, unitSettingsHash{})
+	if err != nil {
+		return errors.Capture(err)
+	}
+	err = tx.Query(ctx, stmt, arg).Run()
 	if err != nil {
 		return errors.Capture(err)
 	}

--- a/domain/relation/state/relation.go
+++ b/domain/relation/state/relation.go
@@ -1569,6 +1569,72 @@ func (st *State) SetRelationApplicationSettings(
 	return nil
 }
 
+// GetRelationUnitSettings returns the relation unit settings for the given
+// relation unit.
+//
+// The following error types can be expected to be returned:
+//   - [relationerrors.RelationUnitNotFound] is returned if the
+//     unit is not part of the relation.
+func (st *State) GetRelationUnitSettings(
+	ctx context.Context,
+	relationUnitUUID corerelation.UnitUUID,
+) (map[string]string, error) {
+	db, err := st.DB()
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	var settings []relationSetting
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		relUnitExists, err := st.checkExistsByUUID(ctx, tx, "relation_unit", relationUnitUUID.String())
+		if err != nil {
+			return errors.Capture(err)
+		} else if !relUnitExists {
+			return relationerrors.RelationUnitNotFound
+		}
+
+		settings, err = st.getRelationUnitSettings(ctx, tx, relationUnitUUID)
+		if err != nil {
+			return errors.Capture(err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	relationSettings := make(map[string]string, len(settings))
+	for _, setting := range settings {
+		relationSettings[setting.Key] = setting.Value
+	}
+	return relationSettings, nil
+}
+
+func (st *State) getRelationUnitSettings(
+	ctx context.Context,
+	tx *sqlair.TX,
+	relUnitUUID corerelation.UnitUUID,
+) ([]relationSetting, error) {
+	id := relationUnitUUID{RelationUnitUUID: relUnitUUID}
+	stmt, err := st.Prepare(`
+SELECT &relationSetting.*
+FROM   relation_unit_setting
+WHERE  relation_unit_uuid = $relationUnitUUID.uuid
+`, id, relationSetting{})
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	var settings []relationSetting
+	err = tx.Query(ctx, stmt, id).GetAll(&settings)
+	if err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+		return nil, errors.Capture(err)
+	}
+
+	return settings, nil
+}
+
 func (st *State) updateApplicationSettingsHash(
 	ctx context.Context,
 	tx *sqlair.TX,

--- a/domain/relation/state/relation_test.go
+++ b/domain/relation/state/relation_test.go
@@ -2550,6 +2550,98 @@ func (s *relationSuite) TestSetRelationApplicationSettingsRelationNotFound(c *gc
 	c.Assert(err, jc.ErrorIs, relationerrors.RelationNotFound)
 }
 
+func (s *relationSuite) TestGetRelationUnitSettings(c *gc.C) {
+	// Arrange: Add relation with one endpoint.
+	endpoint1 := relation.Endpoint{
+		ApplicationName: s.fakeApplicationName1,
+		Relation: charm.Relation{
+			Name:      "fake-endpoint-name-1",
+			Role:      charm.RoleProvider,
+			Interface: "database",
+			Optional:  true,
+			Limit:     20,
+			Scope:     charm.ScopeContainer,
+		},
+	}
+	charmRelationUUID1 := s.addCharmRelation(c, s.fakeCharmUUID1, endpoint1.Relation)
+	applicationEndpointUUID1 := s.addApplicationEndpoint(c, s.fakeApplicationUUID1, charmRelationUUID1)
+	relationUUID := s.addRelation(c)
+	relationEndpointUUID1 := s.addRelationEndpoint(c, relationUUID, applicationEndpointUUID1)
+
+	// Arrange: Add a unit to the relation.
+	unitName := coreunittesting.GenNewName(c, "app/0")
+	unitUUID := s.addUnit(c, unitName, s.fakeApplicationUUID1, s.fakeCharmUUID1)
+	relationUnitUUID := s.addRelationUnit(c, unitUUID, relationEndpointUUID1)
+
+	// Arrange: Add application settings.
+	expectedSettings := map[string]string{
+		"key1": "value1",
+		"key2": "value2",
+	}
+	for k, v := range expectedSettings {
+		s.addRelationUnitSetting(c, relationUnitUUID, k, v)
+	}
+
+	// Act:
+	settings, err := s.state.GetRelationUnitSettings(
+		context.Background(),
+		relationUnitUUID,
+	)
+
+	// Assert:
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(settings, gc.DeepEquals, expectedSettings)
+}
+
+func (s *relationSuite) TestGetRelationUnitSettingsEmptyList(c *gc.C) {
+	// Arrange: Add relation with one endpoint.
+	endpoint1 := relation.Endpoint{
+		ApplicationName: s.fakeApplicationName1,
+		Relation: charm.Relation{
+			Name:      "fake-endpoint-name-1",
+			Role:      charm.RoleProvider,
+			Interface: "database",
+			Optional:  true,
+			Limit:     20,
+			Scope:     charm.ScopeContainer,
+		},
+	}
+	charmRelationUUID1 := s.addCharmRelation(c, s.fakeCharmUUID1, endpoint1.Relation)
+	applicationEndpointUUID1 := s.addApplicationEndpoint(c, s.fakeApplicationUUID1, charmRelationUUID1)
+	relationUUID := s.addRelation(c)
+	relationEndpointUUID1 := s.addRelationEndpoint(c, relationUUID, applicationEndpointUUID1)
+
+	// Arrange: Add a unit to the relation.
+	unitName := coreunittesting.GenNewName(c, "app/0")
+	unitUUID := s.addUnit(c, unitName, s.fakeApplicationUUID1, s.fakeCharmUUID1)
+	relationUnitUUID := s.addRelationUnit(c, unitUUID, relationEndpointUUID1)
+
+	// Act:
+	settings, err := s.state.GetRelationUnitSettings(
+		context.Background(),
+		relationUnitUUID,
+	)
+
+	// Assert:
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(settings, gc.HasLen, 0)
+	c.Assert(settings, gc.NotNil)
+}
+
+func (s *relationSuite) TestGetRelationUnitSettingsRelationUnitNotFound(c *gc.C) {
+	// Arrange: Add relation with one endpoint.
+	relationUnitUUID := corerelationtesting.GenRelationUnitUUID(c)
+
+	// Act:
+	_, err := s.state.GetRelationUnitSettings(
+		context.Background(),
+		relationUnitUUID,
+	)
+
+	// Assert:
+	c.Assert(err, jc.ErrorIs, relationerrors.RelationUnitNotFound)
+}
+
 // addUnit adds a new unit to the specified application in the database with
 // the given UUID and name. Returns the unit uuid.
 func (s *relationSuite) addUnit(c *gc.C, unitName coreunit.Name, appUUID coreapplication.ID, charmUUID corecharm.ID) coreunit.UUID {

--- a/domain/relation/state/relation_test.go
+++ b/domain/relation/state/relation_test.go
@@ -2642,6 +2642,210 @@ func (s *relationSuite) TestGetRelationUnitSettingsRelationUnitNotFound(c *gc.C)
 	c.Assert(err, jc.ErrorIs, relationerrors.RelationUnitNotFound)
 }
 
+func (s *relationSuite) TestSetRelationUnitSettings(c *gc.C) {
+	// Arrange: Add relation with one endpoint.
+	endpoint1 := relation.Endpoint{
+		ApplicationName: s.fakeApplicationName1,
+		Relation: charm.Relation{
+			Name:      "fake-endpoint-name-1",
+			Role:      charm.RoleProvider,
+			Interface: "database",
+			Scope:     charm.ScopeContainer,
+		},
+	}
+	charmRelationUUID1 := s.addCharmRelation(c, s.fakeCharmUUID1, endpoint1.Relation)
+	applicationEndpointUUID1 := s.addApplicationEndpoint(c, s.fakeApplicationUUID1, charmRelationUUID1)
+	relationUUID := s.addRelation(c)
+	relationEndpointUUID1 := s.addRelationEndpoint(c, relationUUID, applicationEndpointUUID1)
+
+	// Arrange: Add a unit to the relation.
+	unitName := coreunittesting.GenNewName(c, "app/0")
+	unitUUID := s.addUnit(c, unitName, s.fakeApplicationUUID1, s.fakeCharmUUID1)
+	relationUnitUUID := s.addRelationUnit(c, unitUUID, relationEndpointUUID1)
+
+	// Arrange: Declare settings and add initial settings.
+	initialSettings := map[string]string{
+		"key1": "value1",
+		"key2": "value2",
+		"key3": "value3",
+	}
+	settingsUpdate := map[string]string{
+		"key2": "value22",
+		"key3": "",
+	}
+	expectedSettings := map[string]string{
+		"key1": "value1",
+		"key2": "value22",
+	}
+	for k, v := range initialSettings {
+		s.addRelationUnitSetting(c, relationUnitUUID, k, v)
+	}
+
+	// Act:
+	err := s.state.SetRelationUnitSettings(
+		context.Background(),
+		relationUnitUUID,
+		settingsUpdate,
+	)
+
+	// Assert:
+	c.Assert(err, jc.ErrorIsNil, gc.Commentf(errors.ErrorStack(err)))
+
+	foundSettings := s.getRelationUnitSettings(c, relationUnitUUID)
+	c.Assert(foundSettings, gc.DeepEquals, expectedSettings)
+}
+
+func (s *relationSuite) TestSetRelationUnitSettingsNilMap(c *gc.C) {
+	// Arrange: Add relation with one endpoint.
+	endpoint1 := relation.Endpoint{
+		ApplicationName: s.fakeApplicationName1,
+		Relation: charm.Relation{
+			Name:      "fake-endpoint-name-1",
+			Role:      charm.RoleProvider,
+			Interface: "database",
+			Scope:     charm.ScopeContainer,
+		},
+	}
+	charmRelationUUID1 := s.addCharmRelation(c, s.fakeCharmUUID1, endpoint1.Relation)
+	applicationEndpointUUID1 := s.addApplicationEndpoint(c, s.fakeApplicationUUID1, charmRelationUUID1)
+	relationUUID := s.addRelation(c)
+	relationEndpointUUID1 := s.addRelationEndpoint(c, relationUUID, applicationEndpointUUID1)
+
+	// Arrange: Add a unit to the relation.
+	unitName := coreunittesting.GenNewName(c, "app/0")
+	unitUUID := s.addUnit(c, unitName, s.fakeApplicationUUID1, s.fakeCharmUUID1)
+	relationUnitUUID := s.addRelationUnit(c, unitUUID, relationEndpointUUID1)
+
+	// Act:
+	err := s.state.SetRelationUnitSettings(
+		context.Background(),
+		relationUnitUUID,
+		nil,
+	)
+
+	// Assert:
+	c.Assert(err, jc.ErrorIsNil, gc.Commentf(errors.ErrorStack(err)))
+
+	foundSettings := s.getRelationUnitSettings(c, relationUnitUUID)
+	c.Assert(foundSettings, gc.HasLen, 0)
+}
+
+// TestSetRelationUnitSettingsCheckHash checks that the settings hash is
+// updated when the settings are updated.
+func (s *relationSuite) TestSetRelationUnitSettingsHashUpdated(c *gc.C) {
+	// Arrange: Add relation with one endpoint.
+	endpoint1 := relation.Endpoint{
+		ApplicationName: s.fakeApplicationName1,
+		Relation: charm.Relation{
+			Name:      "fake-endpoint-name-1",
+			Role:      charm.RoleProvider,
+			Interface: "database",
+			Scope:     charm.ScopeContainer,
+		},
+	}
+	charmRelationUUID1 := s.addCharmRelation(c, s.fakeCharmUUID1, endpoint1.Relation)
+	applicationEndpointUUID1 := s.addApplicationEndpoint(c, s.fakeApplicationUUID1, charmRelationUUID1)
+	relationUUID := s.addRelation(c)
+	relationEndpointUUID1 := s.addRelationEndpoint(c, relationUUID, applicationEndpointUUID1)
+
+	// Arrange: Add a unit to the relation.
+	unitName := coreunittesting.GenNewName(c, "app/0")
+	unitUUID := s.addUnit(c, unitName, s.fakeApplicationUUID1, s.fakeCharmUUID1)
+	relationUnitUUID := s.addRelationUnit(c, unitUUID, relationEndpointUUID1)
+
+	// Arrange: Add some initial settings, this will also set the hash.
+	initialSettings := map[string]string{
+		"key1": "value1",
+	}
+	err := s.state.SetRelationUnitSettings(
+		context.Background(),
+		relationUnitUUID,
+		initialSettings,
+	)
+	c.Assert(err, jc.ErrorIsNil)
+
+	initialHash := s.getRelationUnitSettingsHash(c, relationUnitUUID)
+
+	// Act:
+	err = s.state.SetRelationUnitSettings(
+		context.Background(),
+		relationUnitUUID,
+		map[string]string{
+			"key1": "value2",
+		},
+	)
+
+	// Assert:
+	c.Assert(err, jc.ErrorIsNil, gc.Commentf(errors.ErrorStack(err)))
+
+	// Assert: Check the hash has changed.
+	foundHash := s.getRelationUnitSettingsHash(c, relationUnitUUID)
+	c.Assert(initialHash, gc.Not(gc.Equals), foundHash)
+}
+
+// TestSetRelationUnitSettingsHashConstant checks that the settings hash
+// is stays the same if the update does not actually change the settings.
+func (s *relationSuite) TestSetRelationUnitSettingsHashConstant(c *gc.C) {
+	// Arrange: Add relation with one endpoint.
+	endpoint1 := relation.Endpoint{
+		ApplicationName: s.fakeApplicationName1,
+		Relation: charm.Relation{
+			Name:      "fake-endpoint-name-1",
+			Role:      charm.RoleProvider,
+			Interface: "database",
+			Scope:     charm.ScopeContainer,
+		},
+	}
+	charmRelationUUID1 := s.addCharmRelation(c, s.fakeCharmUUID1, endpoint1.Relation)
+	applicationEndpointUUID1 := s.addApplicationEndpoint(c, s.fakeApplicationUUID1, charmRelationUUID1)
+	relationUUID := s.addRelation(c)
+	relationEndpointUUID1 := s.addRelationEndpoint(c, relationUUID, applicationEndpointUUID1)
+
+	// Arrange: Add a unit to the relation.
+	unitName := coreunittesting.GenNewName(c, "app/0")
+	unitUUID := s.addUnit(c, unitName, s.fakeApplicationUUID1, s.fakeCharmUUID1)
+	relationUnitUUID := s.addRelationUnit(c, unitUUID, relationEndpointUUID1)
+
+	// Arrange: Add some initial settings, this will also set the hash.
+	settings := map[string]string{
+		"key1": "value1",
+	}
+	err := s.state.SetRelationUnitSettings(
+		context.Background(),
+		relationUnitUUID,
+		settings,
+	)
+	c.Assert(err, jc.ErrorIsNil)
+
+	initialHash := s.getRelationUnitSettingsHash(c, relationUnitUUID)
+
+	// Act:
+	err = s.state.SetRelationUnitSettings(
+		context.Background(),
+		relationUnitUUID,
+		settings,
+	)
+
+	// Assert:
+	c.Assert(err, jc.ErrorIsNil, gc.Commentf(errors.ErrorStack(err)))
+
+	// Assert: Check the hash has changed.
+	foundHash := s.getRelationUnitSettingsHash(c, relationUnitUUID)
+	c.Assert(initialHash, gc.Equals, foundHash)
+}
+
+func (s *relationSuite) TestSetRelationUnitSettingsRelationUnitNotFound(c *gc.C) {
+	// Act:
+	err := s.state.SetRelationUnitSettings(
+		context.Background(),
+		"bad-uuid",
+		nil,
+	)
+
+	// Assert:
+	c.Assert(err, jc.ErrorIs, relationerrors.RelationUnitNotFound)
+}
+
 // addUnit adds a new unit to the specified application in the database with
 // the given UUID and name. Returns the unit uuid.
 func (s *relationSuite) addUnit(c *gc.C, unitName coreunit.Name, appUUID coreapplication.ID, charmUUID corecharm.ID) coreunit.UUID {
@@ -2872,6 +3076,53 @@ SELECT sha256
 FROM   relation_application_settings_hash
 WHERE  relation_endpoint_uuid = ?
 `, relationEndpointUUID).Scan(&hash)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	return hash
+}
+
+// getRelationUnitSettings gets the relation application settings.
+func (s *relationSuite) getRelationUnitSettings(c *gc.C, relationUnitUUID corerelation.UnitUUID) map[string]string {
+	settings := map[string]string{}
+	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		rows, err := tx.QueryContext(ctx, `
+SELECT key, value
+FROM relation_unit_setting 
+WHERE relation_unit_uuid = ?
+`, relationUnitUUID)
+		if err != nil {
+			return errors.Capture(err)
+		}
+		defer rows.Close()
+		var (
+			key, value string
+		)
+		for rows.Next() {
+			if err := rows.Scan(&key, &value); err != nil {
+				return errors.Capture(err)
+			}
+			settings[key] = value
+		}
+		return nil
+	})
+	c.Assert(err, jc.ErrorIsNil, gc.Commentf("(Assert) getting relation settings: %s",
+		errors.ErrorStack(err)))
+	return settings
+}
+
+func (s *relationSuite) getRelationUnitSettingsHash(c *gc.C, relationUnitUUID corerelation.UnitUUID) string {
+	var hash string
+	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		err := tx.QueryRow(`
+SELECT sha256
+FROM   relation_unit_settings_hash
+WHERE  relation_unit_uuid = ?
+`, relationUnitUUID).Scan(&hash)
 		if err != nil {
 			return err
 		}

--- a/domain/relation/state/types.go
+++ b/domain/relation/state/types.go
@@ -120,9 +120,20 @@ type relationApplicationSetting struct {
 	Value string `db:"value"`
 }
 
+type relationUnitSetting struct {
+	UUID  corerelation.UnitUUID `db:"relation_unit_uuid"`
+	Key   string                `db:"key"`
+	Value string                `db:"value"`
+}
+
 type applicationSettingsHash struct {
 	RelationEndpointUUID string `db:"relation_endpoint_uuid"`
 	Hash                 string `db:"sha256"`
+}
+
+type unitSettingsHash struct {
+	RelationUnitUUID corerelation.UnitUUID `db:"relation_unit_uuid"`
+	Hash             string                `db:"sha256"`
 }
 
 type keys []string

--- a/domain/schema/model/sql/0024-relation.sql
+++ b/domain/schema/model/sql/0024-relation.sql
@@ -115,6 +115,17 @@ CREATE TABLE relation_unit_setting (
 CREATE INDEX idx_relation_unit_setting_unit
 ON relation_unit_setting (relation_unit_uuid);
 
+-- relation_unit_settings_hash holds a hash of all settings for a relation unit.
+-- It allows watchers to easily determine when the relation units settings have
+-- changed.
+CREATE TABLE relation_unit_settings_hash (
+    relation_unit_uuid TEXT NOT NULL PRIMARY KEY,
+    sha256 TEXT NOT NULL,
+    CONSTRAINT fk_relation_unit_setting_hash_relation_unit
+    FOREIGN KEY (relation_unit_uuid)
+    REFERENCES relation_unit (uuid)
+);
+
 -- The relation_application_setting holds key value pair settings
 -- for a relation at the application level. Keys must be unique
 -- per application.

--- a/domain/schema/model_schema_test.go
+++ b/domain/schema/model_schema_test.go
@@ -267,6 +267,7 @@ func (s *modelSchemaSuite) TestModelTables(c *gc.C) {
 		"relation_status_type",
 		"relation_status",
 		"relation_unit_setting",
+		"relation_unit_settings_hash",
 		"relation_unit",
 		"relation",
 


### PR DESCRIPTION
This PR includes the full implementation of `GetRelationUnitSettings` and `SetRelationUnitSettings`. These very closly mirror the implementations for the relation application settings so hopefully there is nothing controversial in here (this is also why I brought it as one big PR rather than separately).

<!-- Why this change is needed and what it does. -->

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps
Unit tests.

## Links

**Jira card:** [JUJU-7444](https://warthogs.atlassian.net/browse/JUJU-7444)
