### PR TITLE
fix: always create K8s unit virtual host key

### DIFF
--- a/testing/factory/factory.go
+++ b/testing/factory/factory.go
@@ -115,6 +115,7 @@ type ApplicationParams struct {
 	Password                string
 	Placement               []*instance.Placement
 	DesiredScale            int
+	NumUnits                int
 }
 
 // UnitParams are used to create units.
@@ -553,6 +554,7 @@ func (factory *Factory) MakeApplicationReturningPassword(c *gc.C, params *Applic
 		Resources:         resourceMap,
 		EndpointBindings:  params.EndpointBindings,
 		Placement:         params.Placement,
+		NumUnits:          params.NumUnits,
 	})
 	c.Assert(err, jc.ErrorIsNil)
 	err = application.SetPassword(params.Password)


### PR DESCRIPTION
Virtual host keys for k8s units are part of the SSH proxy feature. They are unique SSH host keys that should be created for each unit of a k8s application. Currently there is a bug where the initial k8s unit does not have a virtual host key. Only after scaling, is a virtual host key created for new units.

The reason for this issue is that the `newUnitVirtualHostKeysOps` method was added in the wrong place, within `AddUnitOps()`. `(application).AddUnitOps()` is only called when scaling a unit. On application creation, the more general `addUnitOpsWithCons` is called so we move the host key ops logic there. 

Note that we aim to create the host keys outside of the state layer, if you follow the scale logic you can see that the host keys are generated in the facade layer. During application creation, we don't have a clear way of passing in a host key so we opt to create it when we create the units. A similar approach was taken for machines and their virtual host keys. 

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

1. `make install`
2. `make microk8s-operator-update`
3. `juju bootstrap microk8s test-host-keys`
4. `juju add-model foo`
5. `juju deploy hello-kubecon`
6. Open a [Mongo session](https://discourse.charmhub.io/t/login-into-mongodb/309) (I was having troubles with the script and had to do it manually)
7. `db.virtualhostkeys.find().pretty()`, you should see 2 keys, one for the controller unit and one for hello-kubecon.

Output:
```
juju:PRIMARY> db.virtualhostkeys.find().pretty()
{
        "_id" : "b4bc9ab8-4377-4074-81a4-5f7d788f64fd:unit-controller/0-hostkey",
        "hostkey" : BinData(0,"<key>"),
        "model-uuid" : "b4bc9ab8-4377-4074-81a4-5f7d788f64fd",
        "txn-revno" : 2
}
{
        "_id" : "03be088a-b6b6-44af-808f-f503304028b1:unit-hello-kubecon/0-hostkey",
        "hostkey" : BinData(0,"<key>"),
        "model-uuid" : "03be088a-b6b6-44af-808f-f503304028b1",
        "txn-revno" : 2
}
```

## Links

**Jira Card:** [JUJU-7853](https://warthogs.atlassian.net/browse/JUJU-7853)


[JUJU-7853]: https://warthogs.atlassian.net/browse/JUJU-7853?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ