### PR TITLE
feat: implement ApplicationRelationsInfo

### DIFF
--- a/domain/relation/service/package_mock_test.go
+++ b/domain/relation/service/package_mock_test.go
@@ -86,6 +86,45 @@ func (c *MockStateAddRelationCall) DoAndReturn(f func(context.Context, relation0
 	return c
 }
 
+// ApplicationRelationsInfo mocks base method.
+func (m *MockState) ApplicationRelationsInfo(arg0 context.Context, arg1 application.ID) ([]relation0.EndpointRelationData, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApplicationRelationsInfo", arg0, arg1)
+	ret0, _ := ret[0].([]relation0.EndpointRelationData)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ApplicationRelationsInfo indicates an expected call of ApplicationRelationsInfo.
+func (mr *MockStateMockRecorder) ApplicationRelationsInfo(arg0, arg1 any) *MockStateApplicationRelationsInfoCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplicationRelationsInfo", reflect.TypeOf((*MockState)(nil).ApplicationRelationsInfo), arg0, arg1)
+	return &MockStateApplicationRelationsInfoCall{Call: call}
+}
+
+// MockStateApplicationRelationsInfoCall wrap *gomock.Call
+type MockStateApplicationRelationsInfoCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateApplicationRelationsInfoCall) Return(arg0 []relation0.EndpointRelationData, arg1 error) *MockStateApplicationRelationsInfoCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateApplicationRelationsInfoCall) Do(f func(context.Context, application.ID) ([]relation0.EndpointRelationData, error)) *MockStateApplicationRelationsInfoCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateApplicationRelationsInfoCall) DoAndReturn(f func(context.Context, application.ID) ([]relation0.EndpointRelationData, error)) *MockStateApplicationRelationsInfoCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // EnterScope mocks base method.
 func (m *MockState) EnterScope(arg0 context.Context, arg1 relation.UUID, arg2 unit.Name, arg3 map[string]string) error {
 	m.ctrl.T.Helper()

--- a/domain/relation/service/relation.go
+++ b/domain/relation/service/relation.go
@@ -21,6 +21,12 @@ import (
 
 // State describes retrieval and persistence methods for relations.
 type State interface {
+	// ApplicationRelationEndpointNames returns a slice of names of the given application's
+	// relation endpoints.
+	ApplicationRelationsInfo(
+		ctx context.Context,
+		applicationID application.ID,
+	) ([]relation.EndpointRelationData, error)
 
 	// AddRelation establishes a relation between two endpoints identified
 	// by ep1 and ep2 and returns the created endpoints.
@@ -445,13 +451,19 @@ func (s *Service) ApplicationRelations(ctx context.Context, id application.ID) (
 }
 
 // ApplicationRelationsInfo returns all EndpointRelationData for an application.
-// Note: Replaces the functionality of the relationData method in the application
-// facade. Used for UnitInfo call.
+//
+// The following error types can be expected to be returned:
+//   - [relationerrors.ApplicationIDNotValid] if the application id is not valid.
+//   - [relationerrors.ApplicationNotFound] is returned if the application is
+//     not found.
 func (s *Service) ApplicationRelationsInfo(
 	ctx context.Context,
 	applicationID application.ID,
 ) ([]relation.EndpointRelationData, error) {
-	return nil, coreerrors.NotImplemented
+	if err := applicationID.Validate(); err != nil {
+		return nil, relationerrors.ApplicationIDNotValid
+	}
+	return s.st.ApplicationRelationsInfo(ctx, applicationID)
 }
 
 // EnterScope indicates that the provided unit has joined the relation.

--- a/domain/relation/service/relation_test.go
+++ b/domain/relation/service/relation_test.go
@@ -941,6 +941,34 @@ func (s *relationServiceSuite) TestSetRelationUnitSettings(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 }
 
+func (s *relationServiceSuite) TestApplicationRelationsInfo(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Arrange:
+	applicationID := coreapplicationtesting.GenApplicationUUID(c)
+	s.state.EXPECT().GetApplicationEndpoints(gomock.Any(), applicationID).Return(nil, nil)
+
+	// Act:
+	_, err := s.service.GetApplicationEndpoints(context.Background(), applicationID)
+
+	// Assert:
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *relationServiceSuite) TestApplicationRelationsInfoError(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Arrange:
+	applicationID := coreapplicationtesting.GenApplicationUUID(c)
+	s.state.EXPECT().GetApplicationEndpoints(gomock.Any(), applicationID).Return(nil, relationerrors.UnitNotFound)
+
+	// Act:
+	_, err := s.service.GetApplicationEndpoints(context.Background(), applicationID)
+
+	// Assert: service returned the error from state without translation.
+	c.Assert(err, jc.ErrorIs, relationerrors.UnitNotFound)
+}
+
 func (s *relationServiceSuite) TestSetRelationUnitSettingsEmpty(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
@@ -980,6 +1008,16 @@ func (s *relationServiceSuite) TestSetRelationUnitSettingsRelationUUIDNotValid(c
 
 	// Assert:
 	c.Assert(err, jc.ErrorIs, relationerrors.RelationUUIDNotValid)
+}
+
+func (s *relationServiceSuite) TestApplicationRelationsInfoApplicationUUIDNotValid(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	// Act.
+	_, err := s.service.ApplicationRelationsInfo(context.Background(), "bad-uuid")
+
+	// Assert.
+	c.Assert(err, jc.ErrorIs, relationerrors.ApplicationIDNotValid)
 }
 
 func (s *relationServiceSuite) setupMocks(c *gc.C) *gomock.Controller {

--- a/domain/relation/state/types.go
+++ b/domain/relation/state/types.go
@@ -36,6 +36,15 @@ type relationIDAndUUID struct {
 	ID int `db:"relation_id"`
 }
 
+type relationIDUUIDAppName struct {
+	// UUID is the UUID of the relation.
+	UUID corerelation.UUID `db:"uuid"`
+	// ID is the numeric ID of the relation
+	ID int `db:"relation_id"`
+	// AppName is the name of the application
+	AppName string `db:"application_name"`
+}
+
 type relationUUIDAndRole struct {
 	// UUID is the unique identifier of the relation.
 	UUID string `db:"relation_uuid"`
@@ -60,7 +69,6 @@ type relationUnit struct {
 // getRelationUnitEndpointName allows to fetch a endpoint name from a relation
 // unit, through the view v_relation_unit_endpoint
 type getRelationUnitEndpointName struct {
-
 	// RelationUnitUUID represents the unique identifier for a relation unit.
 	RelationUnitUUID corerelation.UnitUUID `db:"relation_unit_uuid"`
 	// EndpointName represents the name of the endpoint associated
@@ -149,6 +157,7 @@ type unitSettingsHash struct {
 }
 
 type keys []string
+
 type relationUnitUUID struct {
 	RelationUnitUUID corerelation.UnitUUID `db:"uuid"`
 }
@@ -248,3 +257,5 @@ type watcherMapperData struct {
 	Life         string `db:"value"`
 	Suspended    string `db:"name"`
 }
+
+type uuids []string

--- a/domain/relation/types.go
+++ b/domain/relation/types.go
@@ -78,8 +78,8 @@ type EndpointRelationData struct {
 	// ApplicationData are the settings for the relation and current application,
 	// set by the leader unit.
 	ApplicationData map[string]interface{}
-	// UnitRelationData are the settings for the relation and current unit,
-	// set by an individual unit.
+	// UnitRelationData are the RelationData for the relation and current unit,
+	// set by an individual unit, keyed on the unit name.
 	UnitRelationData map[string]RelationData
 }
 


### PR DESCRIPTION
Implement the ApplicationRelationsInfo of the relation domain.

There is one change from 3.6: units out of scope for a relation will not display either relation data.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Deploy a unit and run `juju show-unit <unitname>`.  There should be no errors. When relations is fully backed by DQLite, `juju show-unit` on a unit in an integration will show data from this implementation.

## Links

JUJU-7446