### PR TITLE
feat: insert cloud service addresses

### DIFF
--- a/domain/application/state/application_test.go
+++ b/domain/application/state/application_test.go
@@ -980,6 +980,73 @@ func (s *applicationStateSuite) TestUpsertCloudServiceAnother(c *gc.C) {
 	c.Assert(providerIds, jc.SameContents, []string{"provider-id", "another-provider-id"})
 }
 
+func (s *applicationStateSuite) TestUpsertCloudServiceUpdateRemoveAddresses(c *gc.C) {
+	appID := s.createApplication(c, "foo", life.Alive)
+	s.createApplication(c, "bar", life.Alive)
+	err := s.state.UpsertCloudService(context.Background(), "foo", "provider-id", network.SpaceAddresses{
+		network.SpaceAddress{
+			MachineAddress: network.MachineAddress{
+				Value:      "10.0.0.1",
+				ConfigType: network.ConfigStatic,
+				Type:       network.IPv4Address,
+				Scope:      network.ScopeCloudLocal,
+			},
+		},
+		network.SpaceAddress{
+			MachineAddress: network.MachineAddress{
+				Value:      "10.0.0.2",
+				ConfigType: network.ConfigDHCP,
+				Type:       network.IPv6Address,
+				Scope:      network.ScopeLinkLocal,
+			},
+		},
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	var resultAddresses []string
+	err = s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		rows, err := tx.QueryContext(ctx, `
+SELECT address_value 
+FROM ip_address
+JOIN link_layer_device ON link_layer_device.uuid = ip_address.device_uuid
+JOIN net_node ON net_node.uuid = link_layer_device.net_node_uuid
+JOIN k8s_service ON k8s_service.net_node_uuid = net_node.uuid
+WHERE application_uuid = ?
+			`, appID)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = rows.Close() }()
+
+		for rows.Next() {
+			var addressVal string
+			if err := rows.Scan(&addressVal); err != nil {
+				return err
+			}
+			resultAddresses = append(resultAddresses, addressVal)
+		}
+		return rows.Err()
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(resultAddresses, jc.SameContents, []string{"10.0.0.1", "10.0.0.2"})
+
+	err = s.state.UpsertCloudService(context.Background(), "foo", "provider-id", network.SpaceAddresses{})
+	c.Assert(err, jc.ErrorIsNil)
+	var count int
+	err = s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		rows := tx.QueryRowContext(ctx, "SELECT count(*) FROM ip_address")
+		if err != nil {
+			return err
+		}
+
+		if err := rows.Scan(&count); err != nil {
+			return err
+		}
+		return rows.Err()
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(count, gc.Equals, 0)
+}
+
 func (s *applicationStateSuite) TestUpsertCloudServiceNotFound(c *gc.C) {
 	err := s.state.UpsertCloudService(context.Background(), "foo", "provider-id", network.SpaceAddresses{})
 	c.Assert(err, jc.ErrorIs, applicationerrors.ApplicationNotFound)

--- a/domain/application/state/types.go
+++ b/domain/application/state/types.go
@@ -161,6 +161,14 @@ type cloudService struct {
 	ProviderID      string             `db:"provider_id"`
 }
 
+type cloudServiceDevice struct {
+	UUID              string `db:"uuid"`
+	Name              string `db:"name"`
+	NetNodeID         string `db:"net_node_uuid"`
+	DeviceTypeID      int    `db:"device_type_id"`
+	VirtualPortTypeID int    `db:"virtual_port_type_id"`
+}
+
 type applicationCharmUUID struct {
 	CharmUUID corecharm.ID `db:"charm_uuid"`
 }

--- a/domain/application/types.go
+++ b/domain/application/types.go
@@ -155,11 +155,20 @@ type CloudService struct {
 // ServiceAddress contains parameters for a cloud service address.
 // This may be from a load balancer, or cluster service etc.
 type ServiceAddress struct {
+	Device      CloudServiceDevice
 	Value       string
 	AddressType ipaddress.AddressType
 	Scope       ipaddress.Scope
 	Origin      ipaddress.Origin
 	ConfigType  ipaddress.ConfigType
+}
+
+// CloudServiceDevice is the placeholder link layer device
+// used to tie the cloud service IP address to the application.
+type CloudServiceDevice struct {
+	Name              string
+	DeviceTypeID      linklayerdevice.DeviceType
+	VirtualPortTypeID linklayerdevice.VirtualPortType
 }
 
 // Origin contains parameters for an application's origin.


### PR DESCRIPTION
__This is the first patch of a series finishing the addresses for k8s units.__

This patch finishes the cloud service creation by taking care of the provided space addresses and inserting them. The net nodes and the link layer devices are previously created.

Bonus: the UpsertCloudService method was divided into smaller ones because it was starting to grow badly.


## QA steps

Nothing wired up yet.

## Links
**Jira card:** JUJU-7833
