### PR TITLE
refactor: makefile simple streams target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -365,7 +365,7 @@ ${BUILD_DIR}/%/bin/pebble: phony_explicit
 # build for pebble
 	$(run_go_build)
 
-${JUJU_METADATA_SOURCE}/tools/released/juju-${JUJU_VERSION}-%.tgz: phony_explicit juju $(BUILD_AGENT_TARGETS)
+${JUJU_METADATA_SOURCE}/tools/released/juju-${JUJU_VERSION}-%.tgz: phony_explicit juju go-agent-build
 	@echo "Packaging simplestream tools for juju ${JUJU_VERSION} on $*"
 	@mkdir -p ${JUJU_METADATA_SOURCE}/tools/released
 	@tar czf "$@" -C $(call bin_platform_paths,$(subst -,/,$*)) jujud jujuc


### PR DESCRIPTION
This commit refactors the Makefile simple streams target to consider the go agent binaries instead of build agent targets. We did this because jujud was not being built as part of the target because of the introduction of cgo to the Makefile.

## Checklist

- ~[x] Code style: imports ordered, good names, simple structure, etc~
- ~[x] Comments saying why design decisions were made~
- ~[] Go unit tests, with comments saying what you're testing~
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

From a clean repository (delete _build and _deps). Run `make simplestreams` and confirm `jujud` is being built.

## Documentation changes

N/A

## Links

