### PR TITLE
ci: silence GOCOVERDIR warning for cover builds

### DIFF
--- a/internal/debug/coveruploader/cover_cover.go
+++ b/internal/debug/coveruploader/cover_cover.go
@@ -15,10 +15,27 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"os"
 	"runtime/coverage"
 	"time"
 	_ "unsafe"
 )
+
+// init silences the GOCOVERDIR warning by setting the GOCOVERDIR env var
+// to a temporary directory.
+func init() {
+	if putURL == "" {
+		return
+	}
+	if os.Getenv("GOCOVERDIR") != "" {
+		return
+	}
+	tempDir, err := os.MkdirTemp("", "gocover")
+	if err != nil {
+		return
+	}
+	os.Setenv("GOCOVERDIR", tempDir)
+}
 
 // putURL is injected by build scripts as the target for the
 // uploaded coverage profile.


### PR DESCRIPTION
When Juju is built for coverage profiling (with `COVERAGE_COLLECT_URL=http://anything make ...`) the 
cover uploader (`internal/debug/coveruploader`) is responsible for uploading coverage profiles.

But when go binaries are built with the coverage profiler enabled and the `GOCOVERDIR` environment
variable is not set, the runtime will emit this warning to stderr:
`warning: GOCOVERDIR not set, no coverage data emitted`

Since the output of stderr is often used by integration tests, it is important that it is pristine.

This change simply instructs Go to collect coverage profiles to a temporary directory by
setting `GOCOVERDIR` during startup. The size of the profiles emitted are quite small.

## QA steps

1. `make install COVERAGE_COLLECT_URL=http://localhost:9999`
2. `juju version`
3. No `warning: GOCOVERDIR not set, no coverage data emitted` should be emitted.
4. As expected, there may be `cover: cannot upload cover profile to http://localhost:9999`.
5. The process exit code should be 0 for `juju version`.
