### PR TITLE
fix(application): delete application endpoints the canonical way

### DIFF
--- a/domain/application/state/application.go
+++ b/domain/application/state/application.go
@@ -370,10 +370,6 @@ WHERE application_uuid = $applicationDetails.uuid
 	if err := st.deleteDeviceConstraintAttributes(ctx, tx, appUUID); err != nil {
 		return errors.Errorf("deleting device constraint attributes for application %q: %w", name, err)
 	}
-	// delete application endpoints
-	if err := st.deleteApplicationEndpoints(ctx, tx, appUUID); err != nil {
-		return errors.Errorf("deleting application endpoints for application %q: %w", name, err)
-	}
 
 	// Check that there are no units.
 	var result countResult
@@ -474,6 +470,8 @@ func (st *State) deleteSimpleApplicationReferences(ctx context.Context, tx *sqla
 		"application_setting",
 		"application_exposed_endpoint_space",
 		"application_exposed_endpoint_cidr",
+		"application_endpoint",
+		"application_extra_endpoint",
 		"application_storage_directive",
 		"device_constraint",
 	} {

--- a/domain/application/state/application_endpoint.go
+++ b/domain/application/state/application_endpoint.go
@@ -267,34 +267,6 @@ func (st *State) checkEndpointBindingName(
 	return nil
 }
 
-// deleteApplicationEndpoints deletes all endpoints and extra endpoints
-// associated with a specific application identified by appID.
-func (st *State) deleteApplicationEndpoints(ctx context.Context, tx *sqlair.TX, appID coreapplication.ID) error {
-	type application struct {
-		UUID coreapplication.ID `db:"uuid"`
-	}
-	app := application{UUID: appID}
-	deleteApplicationEndpointStmt, err := st.Prepare(`
-DELETE FROM application_endpoint
-WHERE application_uuid = $application.uuid`, app)
-	if err != nil {
-		return internalerrors.Errorf("preparing delete application endpoint: %w", err)
-	}
-	if err := tx.Query(ctx, deleteApplicationEndpointStmt, app).Run(); err != nil {
-		return internalerrors.Errorf("deleting application endpoint: %w", err)
-	}
-	deleteApplicationExtraEndpointStmt, err := st.Prepare(`
-DELETE FROM application_extra_endpoint
-WHERE application_uuid = $application.uuid`, app)
-	if err != nil {
-		return internalerrors.Errorf("preparing delete application extra endpoint: %w", err)
-	}
-	if err := tx.Query(ctx, deleteApplicationExtraEndpointStmt, app).Run(); err != nil {
-		return internalerrors.Errorf("deleting application extra endpoint: %w", err)
-	}
-	return nil
-}
-
 // updateDefaultSpace updates the default space binding for an application in the database.
 // It uses the provided transaction to set the default space based on the binding map.
 // If no default space is specified in the bindings map, the operation is a no-op.


### PR DESCRIPTION
This patch is from @nvinuesa, I am just bring it to save time.

There was a bug where sometimes not all application endpoints were deleted. Fix by deleting them along with other simple references to the applicaiton table rather than using a bespoke function.

## Checklist


- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps
Nico has QA'd this patch already + Unit tests
