### PR TITLE
fix: Warn on dropped error

### DIFF
--- a/container/lxd/image.go
+++ b/container/lxd/image.go
@@ -65,6 +65,10 @@ func (s *Server) FindImage(
 		// We already have an image with the given alias, so just use that.
 		target = entry.Target
 		image, _, err := s.GetImage(target)
+		if err != nil {
+			logger.Warningf("failed to get local image %s: %s", target, err)
+		}
+
 		if err == nil && isCompatibleVirtType(virtType, image.Type) {
 			logger.Debugf("found image locally - %q %q", image.Filename, target)
 			return SourcedImage{


### PR DESCRIPTION
If the LXD server returns a valid entry for an image alias but then fails to get the image metadata, it would be worth knowing about.

It's unclear at this stage whether or not this will be helpful in my user's situation, but a failure in `GetImage` is possible given what I can see in the logs that I have.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] ~~Comments saying why design decisions were made~~
- [ ] ~~Go unit tests, with comments saying what you're testing~~
- [ ] ~~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~~
- [ ] ~~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~~

## QA steps

Trivial change and challenging to test.

## Links

No public resources available at this time.