### PR TITLE
feat: get agent binary by sha256

### DIFF
--- a/domain/agentbinary/errors/errors.go
+++ b/domain/agentbinary/errors/errors.go
@@ -18,6 +18,8 @@ const (
 	// This is used to prevent the agent binary from being modified after it has been created.
 	AgentBinaryImmutable = errors.ConstError("agent binary is immutable")
 
+	NotFound = errors.ConstError("agent binary not found")
+
 	// ObjectNotFound defines an error that indicates the binary object
 	// associated with the agent binary does not exist.
 	ObjectNotFound = errors.ConstError("agent binary object not found")

--- a/domain/agentbinary/service/store.go
+++ b/domain/agentbinary/service/store.go
@@ -20,10 +20,22 @@ import (
 	agentbinaryerrors "github.com/juju/juju/domain/agentbinary/errors"
 	objectstoreerrors "github.com/juju/juju/domain/objectstore/errors"
 	"github.com/juju/juju/internal/errors"
+	intobjectstoreerrors "github.com/juju/juju/internal/objectstore/errors"
 )
 
 // State describes the interface that the cache state must implement.
 type State interface {
+	// CheckSHA256Exists checks that the given sha256 sum exists as an agent
+	// binary in the object store. This sha256 sum could exist as an object in
+	// the object store but unless the association has been made this will
+	// always return false.
+	CheckSHA256Exists(context.Context, string) (bool, error)
+
+	// GetObjectUUID returns the object store UUID for the given file path.
+	// The following errors can be returned:
+	// - [agentbinaryerrors.ObjectNotFound] when no object exists that matches this path.
+	GetObjectUUID(ctx context.Context, path string) (objectstore.UUID, error)
+
 	// RegisterAgentBinary registers a new agent binary's metadata to the database.
 	// [agentbinaryerrors.AlreadyExists] when the provided agent binary already
 	// exists.
@@ -32,11 +44,6 @@ type State interface {
 	// [coreerrors.NotSupported] if the architecture is not supported by the
 	// state layer.
 	RegisterAgentBinary(ctx context.Context, arg agentbinary.RegisterAgentBinaryArg) error
-
-	// GetObjectUUID returns the object store UUID for the given file path.
-	// The following errors can be returned:
-	// - [agentbinaryerrors.ObjectNotFound] when no object exists that matches this path.
-	GetObjectUUID(ctx context.Context, path string) (objectstore.UUID, error)
 }
 
 // AgentBinaryStore provides the API for working with agent binaries.
@@ -159,9 +166,6 @@ func (s *AgentBinaryStore) add(
 }
 
 // AddAgentBinaryWithSHA256 adds a new agent binary to the object store and saves its metadata to the database.
-// It always overwrites the binary in the store and the metadata in the database for the
-// given version and arch if it already exists.
-// It accepts the SHA256 hash of the binary.
 // The following errors can be returned:
 // - [coreerrors.NotSupported] if the architecture is not supported.
 // - [agentbinaryerrors.AlreadyExists] if an agent binary already exists for
@@ -196,6 +200,51 @@ func (s *AgentBinaryStore) AddAgentBinaryWithSHA256(
 		).Add(coreerrors.NotValid)
 	}
 	return s.add(ctx, data, version, size, encoded384)
+}
+
+// GetAgentBinaryForSHA256 returns the agent binary associated with the given
+// SHA256 sum. The following errors can be expected:
+// - [agentbinaryerrors.NotFound] when no agent binaries exist for the provided
+// sha.
+func (s *AgentBinaryStore) GetAgentBinaryForSHA256(
+	ctx context.Context,
+	sha256Sum string,
+) (io.ReadCloser, int64, error) {
+	// We check that this sha256 exists in the database and is associated with
+	// agent binaries. If we don't do this the possability exists to leak other
+	// non related objects out of the store via this interface.
+	exists, err := s.st.CheckSHA256Exists(ctx, sha256Sum)
+	if err != nil {
+		return nil, 0, errors.Errorf(
+			"checking if agent binaries exist for sha256 %q: %w", sha256Sum, err,
+		)
+	}
+
+	if !exists {
+		return nil, 0, errors.Errorf(
+			"no agent binaries exist for sha256 %q", sha256Sum,
+		).Add(agentbinaryerrors.NotFound)
+	}
+
+	objectStore, err := s.objectStoreGetter.GetObjectStore(ctx)
+	if err != nil {
+		return nil, 0, errors.Errorf(
+			"getting object store to fetch agent binaries: %w", err,
+		)
+	}
+
+	reader, size, err := objectStore.GetBySHA256(ctx, sha256Sum)
+	if errors.Is(err, intobjectstoreerrors.ObjectNotFound) {
+		return nil, 0, errors.Errorf(
+			"no agent binaries exist for sha256 %q", sha256Sum,
+		).Add(agentbinaryerrors.NotFound)
+	} else if err != nil {
+		return nil, 0, errors.Errorf(
+			"getting object with sha256 sum %q: %w", sha256Sum, err,
+		)
+	}
+
+	return reader, size, nil
 }
 
 type cleanupCloser struct {

--- a/domain/agentbinary/service/store_mock_test.go
+++ b/domain/agentbinary/service/store_mock_test.go
@@ -41,6 +41,45 @@ func (m *MockState) EXPECT() *MockStateMockRecorder {
 	return m.recorder
 }
 
+// CheckSHA256Exists mocks base method.
+func (m *MockState) CheckSHA256Exists(arg0 context.Context, arg1 string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CheckSHA256Exists", arg0, arg1)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CheckSHA256Exists indicates an expected call of CheckSHA256Exists.
+func (mr *MockStateMockRecorder) CheckSHA256Exists(arg0, arg1 any) *MockStateCheckSHA256ExistsCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckSHA256Exists", reflect.TypeOf((*MockState)(nil).CheckSHA256Exists), arg0, arg1)
+	return &MockStateCheckSHA256ExistsCall{Call: call}
+}
+
+// MockStateCheckSHA256ExistsCall wrap *gomock.Call
+type MockStateCheckSHA256ExistsCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateCheckSHA256ExistsCall) Return(arg0 bool, arg1 error) *MockStateCheckSHA256ExistsCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateCheckSHA256ExistsCall) Do(f func(context.Context, string) (bool, error)) *MockStateCheckSHA256ExistsCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateCheckSHA256ExistsCall) DoAndReturn(f func(context.Context, string) (bool, error)) *MockStateCheckSHA256ExistsCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetObjectUUID mocks base method.
 func (m *MockState) GetObjectUUID(arg0 context.Context, arg1 string) (objectstore.UUID, error) {
 	m.ctrl.T.Helper()

--- a/domain/agentbinary/service/store_test.go
+++ b/domain/agentbinary/service/store_test.go
@@ -25,6 +25,7 @@ import (
 	agentbinaryerrors "github.com/juju/juju/domain/agentbinary/errors"
 	objectstoreerrors "github.com/juju/juju/domain/objectstore/errors"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
+	intobjectstoreerrors "github.com/juju/juju/internal/objectstore/errors"
 )
 
 type storeSuite struct {
@@ -352,4 +353,69 @@ func (s *storeSuite) TestAddAgentBinaryWithSHA256FailedInvalidAgentVersion(c *gc
 		sha256Hash,
 	)
 	c.Assert(err, jc.ErrorIs, coreerrors.NotValid)
+}
+
+// TestGetAgentBinaryForSHA256NoObjectStore is here as a protection mechanism.
+// Because we are allowing the fetching of agent binaries based on sha it is
+// possible that this interface could be used to fetch objects for a given sha
+// that isn't related to agent binaries. This could and will pose a security
+// risk.
+//
+// This test asserts that when the database says the sha doesn't exist the
+// objectstore is never called.
+func (s *storeSuite) TestGetAgentBinaryForSHA256NoObjectStore(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+	sum := "439c9ea02f8561c5a152d7cf4818d72cd5f2916b555d82c5eee599f5e8f3d09e"
+
+	s.mockState.EXPECT().CheckSHA256Exists(gomock.Any(), sum).Return(false, nil)
+	s.mockObjectStore.EXPECT().GetBySHA256(gomock.Any(), sum).DoAndReturn(
+		func(_ context.Context, _ string) (io.ReadCloser, int64, error) {
+			c.Fatal("should never have got this far")
+			return nil, 0, nil
+		},
+	).AnyTimes()
+
+	store := NewAgentBinaryStore(s.mockState, loggertesting.WrapCheckLog(c), s.mockObjectStoreGetter)
+	_, _, err := store.GetAgentBinaryForSHA256(context.Background(), sum)
+	c.Check(err, jc.ErrorIs, agentbinaryerrors.NotFound)
+}
+
+// TestGetAgentBinaryForSHA256NotFound asserts that if no agent binaries exist
+// for a given sha we get back an error that satisfies
+// [agentbinaryerrors.NotFound].
+func (s *storeSuite) TestGetAgentBinaryForSHA256NotFound(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+	sum := "439c9ea02f8561c5a152d7cf4818d72cd5f2916b555d82c5eee599f5e8f3d09e"
+
+	// This first step tests the not found error via the state reporting that
+	// it doesn't exist.
+	s.mockState.EXPECT().CheckSHA256Exists(gomock.Any(), sum).Return(false, nil)
+
+	store := NewAgentBinaryStore(s.mockState, loggertesting.WrapCheckLog(c), s.mockObjectStoreGetter)
+	_, _, err := store.GetAgentBinaryForSHA256(context.Background(), sum)
+	c.Check(err, jc.ErrorIs, agentbinaryerrors.NotFound)
+
+	// This second step tests the not found error via the object store reporting
+	// that the object doesn't exist.
+	s.mockState.EXPECT().CheckSHA256Exists(gomock.Any(), sum).Return(true, nil)
+	s.mockObjectStore.EXPECT().GetBySHA256(gomock.Any(), sum).Return(
+		nil, 0, intobjectstoreerrors.ObjectNotFound,
+	)
+
+	_, _, err = store.GetAgentBinaryForSHA256(context.Background(), sum)
+	c.Check(err, jc.ErrorIs, agentbinaryerrors.NotFound)
+}
+
+func (s *storeSuite) TestGetAgentBinaryForSHA256(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+	sum := "439c9ea02f8561c5a152d7cf4818d72cd5f2916b555d82c5eee599f5e8f3d09e"
+
+	s.mockState.EXPECT().CheckSHA256Exists(gomock.Any(), sum).Return(true, nil)
+	s.mockObjectStore.EXPECT().GetBySHA256(gomock.Any(), sum).Return(
+		nil, 0, nil,
+	)
+
+	store := NewAgentBinaryStore(s.mockState, loggertesting.WrapCheckLog(c), s.mockObjectStoreGetter)
+	_, _, err := store.GetAgentBinaryForSHA256(context.Background(), sum)
+	c.Check(err, jc.ErrorIsNil)
 }

--- a/domain/agentbinary/state/state.go
+++ b/domain/agentbinary/state/state.go
@@ -32,6 +32,46 @@ func NewState(factory database.TxnRunnerFactory) *State {
 	}
 }
 
+// CheckSHA256Exists checks that the given sha256 sum exists as an agent
+// binary in the object store. This sha256 sum could exist as an object in
+// the object store but unless the association has been made this will
+// always return false.
+func (s *State) CheckSHA256Exists(ctx context.Context, sha256Sum string) (bool, error) {
+	db, err := s.DB()
+	if err != nil {
+		return false, errors.Capture(err)
+	}
+
+	dbVal := objectStoreSHA256Sum{Sum: sha256Sum}
+
+	stmt, err := s.Prepare(`
+SELECT &objectStoreSHA256Sum.*
+FROM v_agent_binary_store
+WHERE sha_256 = $objectStoreSHA256Sum.sha_256
+`, dbVal)
+	if err != nil {
+		return false, errors.Capture(err)
+	}
+
+	exists := false
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		err := tx.Query(ctx, stmt, dbVal).Get(&dbVal)
+		if errors.Is(err, sqlair.ErrNoRows) {
+			return nil
+		} else if err != nil {
+			return err
+		}
+		exists = true
+		return nil
+	})
+
+	if err != nil {
+		return false, errors.Capture(err)
+	}
+
+	return exists, nil
+}
+
 // GetObjectUUID returns the object store UUID for the given file path.
 // The following errors can be returned:
 // - [agentbinaryerrors.ObjectNotFound] when no object exists that matches this path.
@@ -107,7 +147,7 @@ WHERE  name = $architectureRecord.name
 	}
 
 	insertStmt, err := s.Prepare(`
-INSERT INTO agent_binary_store (*) 
+INSERT INTO agent_binary_store (*)
 VALUES ($agentBinaryRecord.*)
 `, agentBinary)
 	if err != nil {

--- a/domain/agentbinary/state/state_test.go
+++ b/domain/agentbinary/state/state_test.go
@@ -271,8 +271,18 @@ func getMetadata(c *gc.C, db *sql.DB, objStoreUUID objectstore.UUID) agentbinary
 SELECT version, architecture_name, size, sha_256
 FROM   v_agent_binary_store
 WHERE  object_store_uuid = ?`, objStoreUUID).Scan(&data.Version, &data.Arch, &data.Size, &data.SHA256)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, jc.ErrorIsNil)
 	return data
+}
+
+func getObjectSHA256(c *gc.C, db *sql.DB, objStoreUUID objectstore.UUID) string {
+	var sha string
+	err := db.QueryRow(`
+SELECT sha_256
+FROM   object_store_metadata
+WHERE  uuid = ?`, objStoreUUID).Scan(&sha)
+	c.Assert(err, jc.ErrorIsNil)
+	return sha
 }
 
 func (s *stateSuite) TestListAgentBinaries(c *gc.C) {
@@ -308,4 +318,28 @@ func (s *stateSuite) TestListAgentBinariesEmpty(c *gc.C) {
 	binaries, err := s.state.ListAgentBinaries(context.Background())
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(binaries, gc.HasLen, 0)
+}
+
+func (s *stateSuite) TestCheckSHA256Exists(c *gc.C) {
+	objStoreUUID, _ := s.addObjectStore(c)
+
+	err := s.state.RegisterAgentBinary(context.Background(), agentbinary.RegisterAgentBinaryArg{
+		Version:         "4.0.0",
+		Arch:            "amd64",
+		ObjectStoreUUID: objStoreUUID,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	sha := getMetadata(c, s.DB(), objStoreUUID).SHA256
+	exists, err := s.state.CheckSHA256Exists(context.Background(), sha)
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(exists, gc.Equals, true)
+}
+
+func (s *stateSuite) TestCheckSHA256NoExists(c *gc.C) {
+	objStoreUUID, _ := s.addObjectStore(c)
+	sha := getObjectSHA256(c, s.DB(), objStoreUUID)
+	exists, err := s.state.CheckSHA256Exists(context.Background(), sha)
+	c.Check(err, jc.ErrorIsNil)
+	c.Check(exists, gc.Equals, false)
 }

--- a/domain/agentbinary/state/types.go
+++ b/domain/agentbinary/state/types.go
@@ -17,6 +17,12 @@ type objectStoreUUID struct {
 	UUID string `db:"uuid"`
 }
 
+// objectStoreSHA256Sum is a database type for representing the sha 256 sum
+// of an object store row.
+type objectStoreSHA256Sum struct {
+	Sum string `db:"sha_256"`
+}
+
 // agentBinaryRecord represents an agent binary entry in the database.
 type agentBinaryRecord struct {
 	Version         string `db:"version"`


### PR DESCRIPTION
This PR introduces a set of changes on to the agent binary domain for fetching an agent binary based on its sha256 sum. This might seem like an odd way to fetch agent binaries but this exact case is needed for migrating agent binaries between controllers.

What we want to do is look at the exported model description and for every agent binary SHA exported as part of the model transfer exactly that object. This allows us to not guess what version corresponds to what object and instead be very exact about what is needed.

At the moment this is just the domain layer for the change. Follow up PR will put this into action for migration.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Unit tests inside of the `agentbinary` domain.

## Documentation changes

N/A

## Links

**Jira card:** JUJU-7810
