### PR TITLE
fix: flaky tests in sshserver worker 

### DIFF
--- a/internal/worker/sshserver/server.go
+++ b/internal/worker/sshserver/server.go
@@ -126,10 +126,10 @@ func NewServerWorker(config ServerWorkerConfig) (worker.Worker, error) {
 	// Start server.
 	s.tomb.Go(func() error {
 		err := s.Server.Serve(listener)
-		if errors.Is(err, ssh.ErrServerClosed) {
-			return nil
+		if !errors.Is(err, ssh.ErrServerClosed) {
+			s.config.Logger.Errorf("serve returned an unexpected error: %v", err)
 		}
-		return errors.Trace(err)
+		return tomb.ErrDying
 	})
 
 	// Handle server cleanup.


### PR DESCRIPTION
This PR fixes flakiness in the sshserver worker tests that I was often observing locally. Below is a short explanation on the issue followed by a way to see the flakiness 100% of the time.

Closing the listener used in the SSH server outside of the server's `Close()` method doesn't allow the server to know it's in a "dying" state so the error returned by `Serve()` is sometimes an unexpected one, causing flaky tests.

This change isn't strictly the most correct fix but an ideal fix would be a change to the upstream Gliderlab's SSH library (which I intend to do). For now, since the error returned by Serve() is not useful to us anyway, we can just log it and always return the tomb's ErrDying error instead.

To manifest the flaky test
1. Don't include the changes from this PR.
2. Add a `time.Sleep(1*time.Second)` before `s.Server.Close()`.
3. Run a test like `TestSSHServerNoAuth` which fails.

Output:
```
server_test.go:202:
    // Server isn't gracefully closed, it's forcefully closed. All connections ended
    // from server side.
    workertest.CleanKill(c, server)
/home/kian/go/pkg/mod/github.com/juju/worker/v3@v3.5.0/workertest/check.go:83:
    c.Check(err, jc.ErrorIsNil)
... value *errors.Err = &errors.unformatter{message:"", cause:(*errors.errorString)(0xc0003f7390), previous:(*errors.errorString)(0xc0003f7390), function:"github.com/juju/juju/internal/worker/sshserver.NewServerWorker.func1", line:132} ("closed")
... error stack:
        closed
        github.com/juju/juju/internal/worker/sshserver.NewServerWorker.func1:132:
```

The `closed` error comes from the in-memory listener, `bufconn.Listener` and is surfaced from `server.Serve()` because the server wasn't "shutdown" when it returned from `listener.Accept()`.