### PR TITLE
refactor: remove call to ModelExists in common controller config

### DIFF
--- a/apiserver/common/controllerconfig.go
+++ b/apiserver/common/controllerconfig.go
@@ -86,22 +86,8 @@ func (s *ControllerConfigAPI) getModelControllerInfo(ctx context.Context, model 
 	if err != nil {
 		return params.ControllerAPIInfoResult{}, errors.Trace(err)
 	}
-	// First see if the requested model UUID is hosted by this controller.
-	modelExists, err := s.st.ModelExists(modelTag.Id())
-	if err != nil {
-		return params.ControllerAPIInfoResult{}, errors.Trace(err)
-	}
-	if modelExists {
-		addrs, caCert, err := ControllerAPIInfo(ctx, s.st, s.controllerConfigService)
-		if err != nil {
-			return params.ControllerAPIInfoResult{}, errors.Trace(err)
-		}
-		return params.ControllerAPIInfoResult{
-			Addresses: addrs,
-			CACert:    caCert,
-		}, nil
-	}
 
+	// First try to get the controller info for this model
 	ctrl, err := s.externalControllerService.ControllerForModel(ctx, modelTag.Id())
 	if err == nil {
 		return params.ControllerAPIInfoResult{

--- a/apiserver/common/controllerconfig_test.go
+++ b/apiserver/common/controllerconfig_test.go
@@ -90,7 +90,7 @@ func (s *controllerConfigSuite) expectStateControllerInfo(c *gc.C) {
 func (s *controllerConfigSuite) TestControllerInfo(c *gc.C) {
 	defer s.setup(c).Finish()
 
-	s.st.EXPECT().ModelExists(testing.ModelTag.Id()).Return(true, nil)
+	s.externalControllerService.EXPECT().ControllerForModel(gomock.Any(), testing.ModelTag.Id()).Return(nil, fmt.Errorf("pow"))
 	s.expectStateControllerInfo(c)
 
 	results, err := s.ctrlConfigAPI.ControllerAPIInfoForModels(context.Background(), params.Entities{

--- a/apiserver/common/interfaces.go
+++ b/apiserver/common/interfaces.go
@@ -134,7 +134,6 @@ func AuthFuncForMachineAgent(authorizer Authorizer) GetAuthFunc {
 // ControllerConfigState defines the methods needed by
 // ControllerConfigAPI
 type ControllerConfigState interface {
-	ModelExists(string) (bool, error)
 	APIHostPortsForAgents(controller.Config) ([]network.SpaceHostPorts, error)
 	CompletedMigrationForModel(string) (state.ModelMigration, error)
 }

--- a/apiserver/common/mocks/common_mock.go
+++ b/apiserver/common/mocks/common_mock.go
@@ -298,45 +298,6 @@ func (c *MockControllerConfigStateCompletedMigrationForModelCall) DoAndReturn(f 
 	return c
 }
 
-// ModelExists mocks base method.
-func (m *MockControllerConfigState) ModelExists(arg0 string) (bool, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ModelExists", arg0)
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ModelExists indicates an expected call of ModelExists.
-func (mr *MockControllerConfigStateMockRecorder) ModelExists(arg0 any) *MockControllerConfigStateModelExistsCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModelExists", reflect.TypeOf((*MockControllerConfigState)(nil).ModelExists), arg0)
-	return &MockControllerConfigStateModelExistsCall{Call: call}
-}
-
-// MockControllerConfigStateModelExistsCall wrap *gomock.Call
-type MockControllerConfigStateModelExistsCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockControllerConfigStateModelExistsCall) Return(arg0 bool, arg1 error) *MockControllerConfigStateModelExistsCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockControllerConfigStateModelExistsCall) Do(f func(string) (bool, error)) *MockControllerConfigStateModelExistsCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockControllerConfigStateModelExistsCall) DoAndReturn(f func(string) (bool, error)) *MockControllerConfigStateModelExistsCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // MockControllerConfigService is a mock of ControllerConfigService interface.
 type MockControllerConfigService struct {
 	ctrl     *gomock.Controller


### PR DESCRIPTION
<!--
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://github.com/juju/juju/blob/main/docs/contributor/reference/conventional-commits.md
-->

<!-- Why this change is needed and what it does. -->

This PR is to remove the call to modelExists in common controller config off the mongo state.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

<!--

Describe steps to verify that the change works.

If you're changing any of the facades, you need to ensure that you've tested
a model migration from 3.6 to 4.0 and from 4.0 to 4.0.

The following steps are a good starting point:

 1. Bootstrap a 3.6 controller and deploy a charm.

```sh
$ juju bootstrap lxd src36
$ juju add-model moveme1
$ juju deploy juju-qa-test
```

 2. Bootstrap a 4.0 controller with the changes and migrate the model.

```sh
$ juju bootstrap lxd dst40
$ juju migrate src36:moveme1 dst40
$ juju add-unit juju-qa-test
```

 3. Verify no errors exist in the model logs for the agents. If there are
    errors, this is a bug and should be fixed before merging. The fix can
    either be applied to the 4.0 branch (preferable) or the 3.6 branch, though
    that needs to be discussed with the team.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme1
```

    4. We also need to test a model migration from 4.0 to 4.0.

```sh
$ juju bootstrap lxd src40
$ juju add-model moveme2
$ juju deploy juju-qa-test
```

```sh
$ juju migrate src40:moveme2 dst40
$ juju add-unit juju-qa-test
```

    5. Verify that there are no errors in the controller or model logs.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme2
```

-->

## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->



<!-- Add a Jira card reference or link, otherwise remove this line. -->
**Jira card:** JUJU-7839
