### PR TITLE
fix: correct agent tag handling for k8s vs machine controllers

### DIFF
--- a/api/controller/sshtunneler/client.go
+++ b/api/controller/sshtunneler/client.go
@@ -26,8 +26,8 @@ func NewClient(caller base.APICaller) *Client {
 }
 
 // ControllerAddresses returns a list of addresses for the specified controller machine.
-func (c *Client) ControllerAddresses(machineTag names.MachineTag) (network.SpaceAddresses, error) {
-	machine := params.Entity{Tag: machineTag.String()}
+func (c *Client) ControllerAddresses(tag names.Tag) (network.SpaceAddresses, error) {
+	machine := params.Entity{Tag: tag.String()}
 	var result params.StringsResult
 	if err := c.facade.FacadeCall("ControllerAddresses", machine, &result); err != nil {
 		return network.SpaceAddresses{}, err

--- a/apiserver/facades/controller/sshtunneler/facade_test.go
+++ b/apiserver/facades/controller/sshtunneler/facade_test.go
@@ -113,6 +113,16 @@ func (s *sshtunnelerSuite) TestControllerAddress(c *gc.C) {
 	c.Assert(addresses, gc.DeepEquals, params.StringsResult{})
 }
 
+func (s *sshtunnelerSuite) TestControllerAddressWithControllerTag(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	f := newFacade(s.ctx, s.backend)
+
+	entity := params.Entity{Tag: names.NewControllerTag("1").String()}
+	result := f.ControllerAddresses(entity)
+	c.Assert(result.Error.Message, gc.Equals, "SSH proxy from machine to k8s controller not supported")
+}
+
 func (s *sshtunnelerSuite) TestMachineHostKeys(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 


### PR DESCRIPTION
The `sshtunneler` worker was logging errors when the controller was bootstrapped on k8s:
```
2025-04-16T14:24:32.505Z [jujud] 2025-04-16 14:24:32 ERROR juju.worker.dependency engine.go:695 "ssh-tunneler" manifold worker returned unexpected error: machine tag controller-0 not valid
```

This happens because the agent tag in the agent.conf file is different for controllers on machines vs controllers on K8s.
Instead of assuming it is a machine tag in the `sshtunneler` worker, just send the plain tag to the facade and let it decide what to do. In this case, the facade can handle machine tags by fetching the addresses of the specified machine. For a controller tag, there is a todo to handle this in the future because a controller in k8s does not have the capability of retrieving its unit specific ingress address.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

1. `make microk8s-operator-update`
2. `make install`
3. `juju bootstrap microk8s agent-test`
4. `microk8s.kubectl logs -n controller-agent-test -c api-server controller-0`
5. Verify the above error is no longer present.

## Links

**Jira card:** [JUJU-7881](https://warthogs.atlassian.net/browse/JUJU-7881)
