### PR TITLE
feat: add cloud service addresses retrieve

### DIFF
--- a/domain/application/service/application.go
+++ b/domain/application/service/application.go
@@ -80,6 +80,12 @@ type ApplicationState interface {
 	// exist.
 	UpsertCloudService(ctx context.Context, appName, providerID string, sAddrs network.SpaceAddresses) error
 
+	// CloudServiceAddresses returns the addresses of the cloud service for the
+	// specified application, returning an error satisfying
+	// [applicationerrors.ApplicationNotFoundError] if the application doesn't
+	// exist.
+	CloudServiceAddresses(ctx context.Context, applicationName string) (network.SpaceAddresses, error)
+
 	// GetApplicationScaleState looks up the scale state of the specified
 	// application, returning an error satisfying
 	// [applicationerrors.ApplicationNotFound] if the application is not found.
@@ -763,6 +769,18 @@ func (s *Service) GetCharmByApplicationID(ctx context.Context, id coreapplicatio
 		&actions,
 		&lxdProfile,
 	), locator, nil
+}
+
+// CloudServiceAddresses returns the addresses of the cloud service for the
+// specified application, returning an error satisfying
+// [applicationerrors.ApplicationNotFoundError] if the application doesn't
+// exist.
+func (s *Service) CloudServiceAddresses(ctx context.Context, applicationName string) (network.SpaceAddresses, error) {
+	addrs, err := s.st.CloudServiceAddresses(ctx, applicationName)
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+	return addrs, nil
 }
 
 // UpdateCloudService updates the cloud service for the specified application, returning an error

--- a/domain/application/service/application_test.go
+++ b/domain/application/service/application_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/juju/juju/core/devices"
 	coreerrors "github.com/juju/juju/core/errors"
 	modeltesting "github.com/juju/juju/core/model/testing"
+	"github.com/juju/juju/core/network"
 	objectstoretesting "github.com/juju/juju/core/objectstore/testing"
 	corestorage "github.com/juju/juju/core/storage"
 	coreunit "github.com/juju/juju/core/unit"
@@ -983,6 +984,59 @@ func (s *applicationServiceSuite) TestGetDeviceConstraints(c *gc.C) {
 			Count: 42,
 		},
 	})
+}
+
+func (s *applicationServiceSuite) TestCloudServiceAddresses(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.state.EXPECT().CloudServiceAddresses(gomock.Any(), "foo").Return(network.SpaceAddresses{
+		network.SpaceAddress{
+			MachineAddress: network.MachineAddress{
+				Value:      "foo",
+				Type:       network.IPv4Address,
+				Scope:      network.ScopeLinkLocal,
+				ConfigType: network.ConfigDHCP,
+			},
+		},
+		network.SpaceAddress{
+			MachineAddress: network.MachineAddress{
+				Value:      "bar",
+				Type:       network.IPv6Address,
+				Scope:      network.ScopeCloudLocal,
+				ConfigType: network.ConfigManual,
+			},
+		},
+	}, nil)
+
+	addrs, err := s.service.CloudServiceAddresses(context.Background(), "foo")
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(addrs, gc.DeepEquals, network.SpaceAddresses{
+		network.SpaceAddress{
+			MachineAddress: network.MachineAddress{
+				Value:      "foo",
+				Type:       network.IPv4Address,
+				Scope:      network.ScopeLinkLocal,
+				ConfigType: network.ConfigDHCP,
+			},
+		},
+		network.SpaceAddress{
+			MachineAddress: network.MachineAddress{
+				Value:      "bar",
+				Type:       network.IPv6Address,
+				Scope:      network.ScopeCloudLocal,
+				ConfigType: network.ConfigManual,
+			},
+		},
+	})
+}
+
+func (s *applicationServiceSuite) TestCloudServiceAddressesNotFound(c *gc.C) {
+	defer s.setupMocks(c).Finish()
+
+	s.state.EXPECT().CloudServiceAddresses(gomock.Any(), "foo").Return(nil, errors.Errorf("%w", applicationerrors.ApplicationNotFound))
+
+	_, err := s.service.CloudServiceAddresses(context.Background(), "foo")
+	c.Assert(err, gc.ErrorMatches, applicationerrors.ApplicationNotFound.Error())
 }
 
 type applicationWatcherServiceSuite struct {

--- a/domain/application/service/package_mock_test.go
+++ b/domain/application/service/package_mock_test.go
@@ -225,6 +225,45 @@ func (c *MockStateAttachStorageCall) DoAndReturn(f func(context.Context, string,
 	return c
 }
 
+// CloudServiceAddresses mocks base method.
+func (m *MockState) CloudServiceAddresses(ctx context.Context, applicationName string) (network.SpaceAddresses, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CloudServiceAddresses", ctx, applicationName)
+	ret0, _ := ret[0].(network.SpaceAddresses)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CloudServiceAddresses indicates an expected call of CloudServiceAddresses.
+func (mr *MockStateMockRecorder) CloudServiceAddresses(ctx, applicationName any) *MockStateCloudServiceAddressesCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloudServiceAddresses", reflect.TypeOf((*MockState)(nil).CloudServiceAddresses), ctx, applicationName)
+	return &MockStateCloudServiceAddressesCall{Call: call}
+}
+
+// MockStateCloudServiceAddressesCall wrap *gomock.Call
+type MockStateCloudServiceAddressesCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateCloudServiceAddressesCall) Return(arg0 network.SpaceAddresses, arg1 error) *MockStateCloudServiceAddressesCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateCloudServiceAddressesCall) Do(f func(context.Context, string) (network.SpaceAddresses, error)) *MockStateCloudServiceAddressesCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateCloudServiceAddressesCall) DoAndReturn(f func(context.Context, string) (network.SpaceAddresses, error)) *MockStateCloudServiceAddressesCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // CreateApplication mocks base method.
 func (m *MockState) CreateApplication(arg0 context.Context, arg1 string, arg2 application0.AddApplicationArg, arg3 []application0.AddUnitArg) (application.ID, error) {
 	m.ctrl.T.Helper()

--- a/domain/application/state/application.go
+++ b/domain/application/state/application.go
@@ -828,6 +828,53 @@ WHERE application_uuid = $applicationScale.application_uuid
 	return errors.Capture(err)
 }
 
+// CloudServiceAddresses returns the addresses of the cloud service for the
+// specified application, returning an error satisfying
+// [applicationerrors.ApplicationNotFoundError] if the application doesn't
+// exist.
+func (st *State) CloudServiceAddresses(ctx context.Context, applicationName string) (network.SpaceAddresses, error) {
+	db, err := st.DB()
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+	var addresses []ipAddress
+	ident := dbUUID{}
+	queryCloudServiceAddressesStmt, err := st.Prepare(`
+SELECT    
+    ip.address_value AS &ipAddress.address_value,
+    ip.config_type_id AS &ipAddress.config_type_id,
+    ip.type_id AS &ipAddress.type_id,
+    ip.origin_id AS &ipAddress.origin_id,
+    ip.scope_id AS &ipAddress.scope_id,
+    ip.device_uuid AS &ipAddress.device_uuid
+FROM      ip_address AS ip
+JOIN      link_layer_device AS lld ON lld.uuid = ip.device_uuid
+JOIN      net_node AS nn ON nn.uuid = lld.net_node_uuid
+JOIN      k8s_service AS ks ON nn.uuid = ks.net_node_uuid
+WHERE     ks.application_uuid = $dbUUID.uuid;
+`, ipAddress{}, ident)
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+
+	err = db.Txn(ctx, func(ctx context.Context, tx *sqlair.TX) error {
+		appUUID, err := st.lookupApplication(ctx, tx, applicationName)
+		if err != nil {
+			return errors.Capture(err)
+		}
+
+		ident.UUID = appUUID.String()
+		if err = tx.Query(ctx, queryCloudServiceAddressesStmt, ident).GetAll(&addresses); err != nil && !errors.Is(err, sqlair.ErrNoRows) {
+			return errors.Errorf("querying cloud service addresses for application %q: %w", applicationName, err)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, errors.Capture(err)
+	}
+	return encodeIpAddresses(addresses), nil
+}
+
 // UpsertCloudService updates the cloud service for the specified application,
 // returning an error satisfying [applicationerrors.ApplicationNotFoundError] if
 // the application doesn't exist.
@@ -2655,6 +2702,25 @@ func encodeConstraints(constraintUUID string, cons constraints.Constraints, cont
 	}
 	if cons.Container != nil {
 		res.ContainerTypeID = &containerTypeID
+	}
+	return res
+}
+
+func encodeIpAddresses(addresses []ipAddress) network.SpaceAddresses {
+	res := make(network.SpaceAddresses, len(addresses))
+	for i, addr := range addresses {
+		res[i] = network.SpaceAddress{
+			// TODO(nvinuesa): The subnet CIDR and the space ID are not
+			// inserted. This should be done when migrating machines to dqlite
+			// and rework the MachineAddress modelling so it takes a subnet UUID
+			// instead of a CIDR.
+			MachineAddress: network.MachineAddress{
+				Value:      addr.Value,
+				Type:       ipaddress.UnMarshallAddressType(ipaddress.AddressType(addr.TypeID)),
+				Scope:      ipaddress.UnMarshallScope(ipaddress.Scope(addr.ScopeID)),
+				ConfigType: ipaddress.UnMarshallConfigType(ipaddress.ConfigType(addr.ConfigTypeID)),
+			},
+		}
 	}
 	return res
 }

--- a/domain/ipaddress/ipaddress.go
+++ b/domain/ipaddress/ipaddress.go
@@ -34,6 +34,21 @@ func MarshallConfigType(configType corenetwork.AddressConfigType) ConfigType {
 	return ConfigTypeUnknown
 }
 
+// UnMarshallConfigType converts db config type id to an IP address config type.
+func UnMarshallConfigType(configType ConfigType) corenetwork.AddressConfigType {
+	switch configType {
+	case ConfigTypeDHCP:
+		return corenetwork.ConfigDHCP
+	case ConfigTypeStatic:
+		return corenetwork.ConfigStatic
+	case ConfigTypeManual:
+		return corenetwork.ConfigManual
+	case ConfigTypeLoopback:
+		return corenetwork.ConfigLoopback
+	}
+	return corenetwork.ConfigUnknown
+}
+
 // Scope represents the scope of an IP address, as recorded in
 // the ip_address_scope lookup table.
 type Scope int
@@ -61,6 +76,21 @@ func MarshallScope(scope corenetwork.Scope) Scope {
 	return ScopeUnknown
 }
 
+// UnMarshallScope converts a db scope id to an IP address scope.
+func UnMarshallScope(scope Scope) corenetwork.Scope {
+	switch scope {
+	case ScopePublic:
+		return corenetwork.ScopePublic
+	case ScopeCloudLocal:
+		return corenetwork.ScopeCloudLocal
+	case ScopeMachineLocal:
+		return corenetwork.ScopeMachineLocal
+	case ScopeLinkLocal:
+		return corenetwork.ScopeLinkLocal
+	}
+	return corenetwork.ScopeUnknown
+}
+
 // AddressType represents the type of an IP address, as recorded in
 // the ip_address_type lookup table.
 type AddressType int
@@ -81,6 +111,17 @@ func MarshallAddressType(addressType corenetwork.AddressType) AddressType {
 	return AddressTypeIPv4
 }
 
+// UnMarshallAddressType converts a db address type id to an IP address type.
+func UnMarshallAddressType(addressType AddressType) corenetwork.AddressType {
+	switch addressType {
+	case AddressTypeIPv4:
+		return corenetwork.IPv4Address
+	case AddressTypeIPv6:
+		return corenetwork.IPv6Address
+	}
+	return corenetwork.IPv4Address
+}
+
 // Origin represents the origin of an IP address, as recorded in
 // the ip_address_origin lookup table.
 type Origin int
@@ -99,4 +140,15 @@ func MarshallOrigin(origin corenetwork.Origin) Origin {
 		return OriginProvider
 	}
 	return OriginHost
+}
+
+// UnMarshallOrigin converts a db origin id to an IP address origin.
+func UnMarshallOrigin(origin Origin) corenetwork.Origin {
+	switch origin {
+	case OriginHost:
+		return corenetwork.OriginMachine
+	case OriginProvider:
+		return corenetwork.OriginProvider
+	}
+	return corenetwork.OriginMachine
 }


### PR DESCRIPTION
This patch adds the CloudServiceAddresses method on the state layer of the application domain to retrieve the list of addresses of a given cloud service.
The service layer is also added (it's only a proxy service method).

## QA steps

Nothing wired yet, unit tests should pass.

## Links

**Jira card:** JUJU-7856
