### PR TITLE
refactor: remove basic model information from client/modelconfig

### DIFF
--- a/apiserver/facades/client/modelconfig/backend.go
+++ b/apiserver/facades/client/modelconfig/backend.go
@@ -3,13 +3,8 @@
 
 package modelconfig
 
-import (
-	"github.com/juju/names/v6"
-)
-
 // Backend contains the state.State methods used in this package,
 // allowing stubs to be created for testing.
 type Backend interface {
-	ControllerTag() names.ControllerTag
 	Sequences() (map[string]int, error)
 }

--- a/apiserver/facades/client/modelconfig/modelconfig.go
+++ b/apiserver/facades/client/modelconfig/modelconfig.go
@@ -27,6 +27,7 @@ import (
 // ModelConfigAPI provides the base implementation of the methods.
 type ModelConfigAPI struct {
 	backend                   Backend
+	controllerTag             names.ControllerTag
 	modelSecretBackendService ModelSecretBackendService
 	configService             ModelConfigService
 	modelSericve              ModelService
@@ -45,6 +46,7 @@ type ModelConfigAPIV3 struct {
 func NewModelConfigAPI(
 	modelUUID coremodel.UUID,
 	backend Backend,
+	controllerTag names.ControllerTag,
 	modelSecretBackendService ModelSecretBackendService,
 	configService ModelConfigService,
 	modelSericve ModelService,
@@ -58,6 +60,7 @@ func NewModelConfigAPI(
 	return &ModelConfigAPI{
 		modelUUID:                 modelUUID,
 		backend:                   backend,
+		controllerTag:             controllerTag,
 		modelSecretBackendService: modelSecretBackendService,
 		configService:             configService,
 		modelSericve:              modelSericve,
@@ -71,11 +74,11 @@ func (c *ModelConfigAPI) checkCanWrite(ctx context.Context) error {
 }
 
 func (c *ModelConfigAPI) isControllerAdmin(ctx context.Context) error {
-	return c.auth.HasPermission(ctx, permission.SuperuserAccess, c.backend.ControllerTag())
+	return c.auth.HasPermission(ctx, permission.SuperuserAccess, c.controllerTag)
 }
 
 func (c *ModelConfigAPI) canReadModel(ctx context.Context) error {
-	err := c.auth.HasPermission(ctx, permission.SuperuserAccess, c.backend.ControllerTag())
+	err := c.auth.HasPermission(ctx, permission.SuperuserAccess, c.controllerTag)
 	if err != nil && !errors.Is(err, authentication.ErrorEntityMissingPermission) {
 		return errors.Trace(err)
 	} else if err == nil {
@@ -95,7 +98,7 @@ func (c *ModelConfigAPI) canReadModel(ctx context.Context) error {
 }
 
 func (c *ModelConfigAPI) isModelAdmin(ctx context.Context) (bool, error) {
-	err := c.auth.HasPermission(ctx, permission.SuperuserAccess, c.backend.ControllerTag())
+	err := c.auth.HasPermission(ctx, permission.SuperuserAccess, c.controllerTag)
 	if err != nil && !errors.Is(err, authentication.ErrorEntityMissingPermission) {
 		return false, errors.Trace(err)
 	} else if err == nil {

--- a/apiserver/facades/client/modelconfig/modelconfig_test.go
+++ b/apiserver/facades/client/modelconfig/modelconfig_test.go
@@ -39,6 +39,7 @@ type modelconfigSuite struct {
 	testing.IsolationSuite
 	coretesting.JujuOSEnvSuite
 	backend                       *mockBackend
+	controllerTag                 names.ControllerTag
 	authorizer                    apiservertesting.FakeAuthorizer
 	mockModelSecretBackendService *mocks.MockModelSecretBackendService
 	mockModelConfigService        *mocks.MockModelConfigService
@@ -85,9 +86,10 @@ func (s *modelconfigSuite) getAPI(c *gc.C) (*modelconfig.ModelConfigAPI, *gomock
 	).AnyTimes()
 
 	modelID := modeltesting.GenModelUUID(c)
+	s.controllerTag = names.NewControllerTag(coretesting.ControllerTag.Id())
 	api, err := modelconfig.NewModelConfigAPI(
 		modelID, s.backend,
-		s.mockModelSecretBackendService, s.mockModelConfigService, s.mockModelService,
+		s.controllerTag, s.mockModelSecretBackendService, s.mockModelConfigService, s.mockModelService,
 		&s.authorizer, s.mockBlockCommandService,
 	)
 	c.Assert(err, jc.ErrorIsNil)
@@ -432,6 +434,7 @@ type modelSecretBackendSuite struct {
 	mockModelSecretBackendService *mocks.MockModelSecretBackendService
 	mockBlockCommandService       *mocks.MockBlockCommandService
 	modelID                       coremodel.UUID
+	controllerTag                 names.ControllerTag
 }
 
 var _ = gc.Suite(&modelSecretBackendSuite{})
@@ -444,7 +447,9 @@ func (s *modelSecretBackendSuite) setup(c *gc.C) (*modelconfig.ModelConfigAPI, *
 	s.mockModelSecretBackendService = mocks.NewMockModelSecretBackendService(ctrl)
 	s.mockBlockCommandService = mocks.NewMockBlockCommandService(ctrl)
 	s.modelID = modeltesting.GenModelUUID(c)
-	api, err := modelconfig.NewModelConfigAPI(s.modelID, nil, s.mockModelSecretBackendService, nil, nil, s.authorizer, s.mockBlockCommandService)
+	s.controllerTag = names.NewControllerTag(coretesting.ControllerTag.Id())
+
+	api, err := modelconfig.NewModelConfigAPI(s.modelID, nil, s.controllerTag, s.mockModelSecretBackendService, nil, nil, s.authorizer, s.mockBlockCommandService)
 	c.Assert(err, jc.ErrorIsNil)
 	return api, ctrl
 }

--- a/apiserver/facades/client/modelconfig/register.go
+++ b/apiserver/facades/client/modelconfig/register.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 
 	"github.com/juju/errors"
+	"github.com/juju/names/v6"
 
 	"github.com/juju/juju/apiserver/facade"
 )
@@ -40,9 +41,12 @@ func makeFacade(ctx facade.ModelContext) (*ModelConfigAPI, error) {
 
 	configService := domainServices.Config()
 	modelSericve := domainServices.ModelInfo()
+	controllerTag := names.NewControllerTag(ctx.ControllerUUID())
+
 	return NewModelConfigAPI(
 		ctx.ModelUUID(),
 		ctx.State(),
+		controllerTag,
 		modelSecretBackend, configService, modelSericve, auth,
 		domainServices.BlockCommand(),
 	)


### PR DESCRIPTION
<!--
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://github.com/juju/juju/blob/main/docs/contributor/reference/conventional-commits.md
-->

<!-- Why this change is needed and what it does. -->
This change removes the need for the client/modelconfig facade to access mongo state to retrieve the model tag for the current context. Instead we now pull this information from the facade model context which in turn is backed by DQlite.

In doing this work we were also able to invert some of the dependencies into the facade constructor removing the need to have an error return from new*.

This facade does not rely on mongo anymore for accessing model information.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

 1. Bootstrap a 4.0 controller on lxd and add a test model
```sh
$ juju bootstrap lxd lxdtest
$ juju add-model test
```

2. Chech the status
```sh
$  juju status
$  juju show-model test
```

3. Remove the model
```sh
$ juju destroy-model --no-prompt test
```

4. Check the status
```sh
$ juju status
```


## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Add a Jira card reference or link, otherwise remove this line. -->
**Jira card:** JUJU-7861
