### PR TITLE
fix: allow container placement

### DIFF
--- a/core/instance/placement_test.go
+++ b/core/instance/placement_test.go
@@ -30,6 +30,10 @@ func (s *PlacementSuite) TestParsePlacement(c *gc.C) {
 		expectScope:     instance.MachineScope,
 		expectDirective: "0/lxd/0",
 	}, {
+		arg:             "lxd:0",
+		expectScope:     string(instance.LXD),
+		expectDirective: "0",
+	}, {
 		arg: "#:x",
 		err: `invalid value "x" for "#" scope: expected machine-id`,
 	}, {

--- a/domain/application/state/types.go
+++ b/domain/application/state/types.go
@@ -1174,6 +1174,11 @@ type machineNameWithNetNode struct {
 	NetNodeUUID string       `db:"net_node_uuid"`
 }
 
+type machineNameWithMachineUUID struct {
+	Name machine.Name `db:"name"`
+	UUID machine.UUID `db:"uuid"`
+}
+
 type netNodeUUID struct {
 	NetNodeUUID string `db:"uuid"`
 }

--- a/domain/deployment/placement.go
+++ b/domain/deployment/placement.go
@@ -92,8 +92,6 @@ func ParsePlacement(placement *instance.Placement) (Placement, error) {
 		container, err := instance.ParseContainerType(placement.Scope)
 		if err != nil {
 			return Placement{}, errors.Capture(err)
-		} else if placement.Directive != "" {
-			return Placement{}, errors.Errorf("placement directive %q is not supported for container type %q", placement.Directive, placement.Scope)
 		}
 
 		containerType, err := parseContainerType(container)
@@ -104,6 +102,7 @@ func ParsePlacement(placement *instance.Placement) (Placement, error) {
 		return Placement{
 			Type:      PlacementTypeContainer,
 			Container: containerType,
+			Directive: placement.Directive,
 		}, nil
 	}
 }

--- a/domain/deployment/placement_test.go
+++ b/domain/deployment/placement_test.go
@@ -91,8 +91,11 @@ func (s *PlacementSuite) TestPlacement(c *gc.C) {
 				Scope:     "lxd",
 				Directive: "0",
 			},
-			output: Placement{},
-			err:    ptr(`placement directive "0" is not supported for container type "lxd"`),
+			output: Placement{
+				Type:      PlacementTypeContainer,
+				Container: ContainerTypeLXD,
+				Directive: "0",
+			},
 		},
 		{
 			input: &instance.Placement{


### PR DESCRIPTION
The placement of a scope container can use the colon separator to place a unit onto a machine whilst targetting a machine: lxd:0. Thus inserting a unit on to any lxd container on machine 0.

The code error'd out originally, preventing this, but there are no unit tests in both core or state that permitted this. It was just transient knowledge.


## QA steps

```sh
$ juju bootstrap lxd test
$ juju deploy ubuntu --to lxd:0
```

## Links

Fixes: https://github.com/juju/juju/issues/19538
