### PR TITLE
docs: disallow /latest slug in google search

### DIFF
--- a/docs/.sphinx/_extra/robots.txt
+++ b/docs/.sphinx/_extra/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /docs/latest/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -100,6 +100,10 @@ ogp_image = \
 
 # html_favicon = '.sphinx/_static/favicon.png'
 
+# Add any extra paths that contain custom files (such as robots.txt or
+# .htaccess) here, relative to this directory. These files are copied
+# directly to the root of the documentation.
+html_extra_path = ['.sphinx/_extra']
 
 # Dictionary of values to pass into the Sphinx context for all pages:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_context


### PR DESCRIPTION
Adds `robots.txt` file to disallow `/docs/latest` slug appearing in Google search. Followed [these instructions](https://docs.readthedocs.com/platform/stable/reference/robots.html).

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [ ] ~Comments saying why design decisions were made~
- [ ] ~Go unit tests, with comments saying what you're testing~
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps


## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Fixes #19267.

<!-- Add a Jira card reference or link, otherwise remove this line. -->
**Jira card:** JUJU-
