### PR TITLE
chore: remove unused code

### DIFF
--- a/cmd/juju/common/authkeys_test.go
+++ b/cmd/juju/common/authkeys_test.go
@@ -95,32 +95,3 @@ func (s *AuthKeysSuite) TestReadAuthorizedKeysClientKeys(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(keys, gc.Equals, prefix)
 }
-
-func (s *AuthKeysSuite) TestFinalizeAuthorizedKeysNoop(c *gc.C) {
-	attrs := map[string]interface{}{"authorized-keys": "meep"}
-	err := common.FinalizeAuthorizedKeys(cmdtesting.Context(c), attrs)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(attrs, jc.DeepEquals, map[string]interface{}{"authorized-keys": "meep"})
-}
-
-func (s *AuthKeysSuite) TestFinalizeAuthorizedKeysPath(c *gc.C) {
-	writeFile(c, filepath.Join(s.dotssh, "whatever"), "meep")
-	attrs := map[string]interface{}{"authorized-keys-path": "whatever"}
-	err := common.FinalizeAuthorizedKeys(cmdtesting.Context(c), attrs)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(attrs, jc.DeepEquals, map[string]interface{}{"authorized-keys": "meep\n"})
-}
-
-func (s *AuthKeysSuite) TestFinalizeAuthorizedKeysDefault(c *gc.C) {
-	writeFile(c, filepath.Join(s.dotssh, "id_ed25519.pub"), "meep")
-	attrs := map[string]interface{}{}
-	err := common.FinalizeAuthorizedKeys(cmdtesting.Context(c), attrs)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(attrs, jc.DeepEquals, map[string]interface{}{"authorized-keys": "meep\n"})
-}
-
-func (s *AuthKeysSuite) TestFinalizeAuthorizedKeysConflict(c *gc.C) {
-	attrs := map[string]interface{}{"authorized-keys": "foo", "authorized-keys-path": "bar"}
-	err := common.FinalizeAuthorizedKeys(cmdtesting.Context(c), attrs)
-	c.Assert(err, gc.ErrorMatches, `"authorized-keys" and "authorized-keys-path" may not both be specified`)
-}

--- a/cmd/juju/machine/add.go
+++ b/cmd/juju/machine/add.go
@@ -400,7 +400,6 @@ var (
 )
 
 func (c *addCommand) tryManualProvision(ctx *cmd.Context, client manual.ProvisioningClientAPI, config *config.Config) error {
-
 	var provisionMachine manual.ProvisionMachineFunc
 	switch c.Placement.Scope {
 	case sshScope:


### PR DESCRIPTION
The FinalizeAuthorizedKeys isn't called anywhere in the code base. This is implemented differently in 4.0 and we can remove this.

> [!NOTE]
> I spotted this whilst investigating an issue someone was having.

## QA steps

```sh
$ juju bootstrap lxd test
$ juju add-model m1
$ juju add-machine
```