### PR TITLE
chore: remove state from modelworkermanager

### DIFF
--- a/cmd/jujud-controller/agent/machine.go
+++ b/cmd/jujud-controller/agent/machine.go
@@ -990,7 +990,7 @@ func (a *MachineAgent) startModelWorkers(cfg modelworkermanager.NewModelConfig) 
 	applyTestingOverrides(currentConfig, &manifoldsCfg)
 
 	var manifolds dependency.Manifolds
-	if cfg.ModelType == state.ModelTypeIAAS {
+	if cfg.ModelType == coremodel.IAAS {
 		manifolds = iaasModelManifolds(manifoldsCfg)
 	} else {
 		manifolds = caasModelManifolds(manifoldsCfg)

--- a/internal/worker/modelworkermanager/manifold_test.go
+++ b/internal/worker/modelworkermanager/manifold_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/juju/juju/core/http"
 	"github.com/juju/juju/core/lease"
 	"github.com/juju/juju/core/logger"
+	coremodel "github.com/juju/juju/core/model"
 	modelservice "github.com/juju/juju/domain/model/service"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 	"github.com/juju/juju/internal/pki"
@@ -163,7 +164,7 @@ func (s *ManifoldSuite) TestStart(c *gc.C) {
 		ModelName:    "test",
 		ModelOwner:   "owner",
 		ModelUUID:    "foo",
-		ModelType:    state.ModelTypeIAAS,
+		ModelType:    coremodel.IAAS,
 		ModelMetrics: dummyMetricSink{},
 	}
 	mw, err := config.NewModelWorker(modelConfig)

--- a/internal/worker/modelworkermanager/modelworkermanager.go
+++ b/internal/worker/modelworkermanager/modelworkermanager.go
@@ -26,7 +26,6 @@ import (
 	"github.com/juju/juju/internal/pki"
 	"github.com/juju/juju/internal/services"
 	internalworker "github.com/juju/juju/internal/worker"
-	"github.com/juju/juju/state"
 )
 
 // MetricSink describes a way to unregister a model metrics collector. This
@@ -60,7 +59,7 @@ type NewModelConfig struct {
 	ModelName              string
 	ModelOwner             string
 	ModelUUID              string
-	ModelType              state.ModelType
+	ModelType              model.ModelType
 	ModelMetrics           MetricSink
 	LoggerContext          corelogger.LoggerContext
 	ControllerConfig       controller.Config
@@ -236,7 +235,7 @@ func (m *modelWorkerManager) modelChanged(ctx context.Context, modelUUID string)
 		ModelName:    model.Name,
 		ModelOwner:   model.OwnerName.Name(),
 		ModelUUID:    modelUUID,
-		ModelType:    state.ModelType(model.ModelType),
+		ModelType:    model.ModelType,
 		ModelMetrics: m.config.ModelMetrics.ForModel(names.NewModelTag(modelUUID)),
 	}
 

--- a/internal/worker/modelworkermanager/modelworkermanager_test.go
+++ b/internal/worker/modelworkermanager/modelworkermanager_test.go
@@ -494,7 +494,7 @@ func (s *suite) assertStarts(c *gc.C, expect ...string) {
 	workers := s.waitWorkers(c, count)
 	for i, worker := range workers {
 		actual[i] = worker.config.ModelUUID
-		c.Assert(worker.config.ModelType, gc.Equals, state.ModelTypeIAAS)
+		c.Assert(worker.config.ModelType, gc.Equals, coremodel.IAAS)
 	}
 	c.Assert(actual, jc.SameContents, expect)
 }


### PR DESCRIPTION
The model worker manager was just using the state package to check if the model type was `IAAS` or `CAAS`. The type passed was a `core/model` `ModelType` and we converted back to state to check the value. This is no longer required.

## QA steps

```sh
$ juju boostrap lxd test
$ juju add-model default
```