### PR TITLE
refactor: use sequence table for relations

### DIFF
--- a/domain/relation/state/doc.go
+++ b/domain/relation/state/doc.go
@@ -14,7 +14,7 @@
 // the units of a single application and not added by a user.
 //
 // With any new row in the `relation` table, a sequential ID is assigned using
-// the `relation_sequence` table. The sequence is unique to a model. No relation
+// the `sequence` table. The sequence is unique to a model. No relation
 // ID is reused in the lifetime of a model. This ID is used by the units to
 // identify the relation.
 //
@@ -52,6 +52,9 @@
 // <insert>. When set to dead <insert>. A relation cannot be dead until all
 // relation units have left scope.
 //
+// The relation sequence is migrated in the sequence domain.
+//
+// Relation statuses are migrated in the status domain.
 // TODO:
 // * leave scope details
 // * more on Life

--- a/domain/relation/state/types.go
+++ b/domain/relation/state/types.go
@@ -33,7 +33,7 @@ type relationIDAndUUID struct {
 	// UUID is the UUID of the relation.
 	UUID corerelation.UUID `db:"uuid"`
 	// ID is the numeric ID of the relation
-	ID int `db:"relation_id"`
+	ID uint64 `db:"relation_id"`
 }
 
 type relationIDUUIDAppName struct {

--- a/domain/relation/types.go
+++ b/domain/relation/types.go
@@ -15,9 +15,13 @@ import (
 	corerelation "github.com/juju/juju/core/relation"
 	"github.com/juju/juju/core/unit"
 	"github.com/juju/juju/core/watcher"
+	sequence "github.com/juju/juju/domain/sequence"
 	"github.com/juju/juju/internal/charm"
 	"github.com/juju/juju/internal/errors"
 )
+
+// SequenceNamespace for the sequence table.
+const SequenceNamespace = sequence.StaticNamespace("relation")
 
 // GetRelationEndpointUUIDArgs represents the arguments required to retrieve
 // the UUID of a relation endpoint.

--- a/domain/schema/model/sql/0024-relation.sql
+++ b/domain/schema/model/sql/0024-relation.sql
@@ -185,21 +185,6 @@ INSERT INTO relation_status_type VALUES
 (4, 'suspended'),
 (5, 'error');
 
--- The relation_sequence table is used to keep track of the
--- sequence number for relation IDs within a model. Each
--- relation must have an relation ID.
-CREATE TABLE relation_sequence (
-    -- The sequence number will start at 0 for each model and will be
-    -- incremented.
-    sequence INT NOT NULL DEFAULT 0
-);
-
-INSERT INTO relation_sequence (sequence) VALUES (0);
-
--- A unique constraint over a constant index ensures only 1 entry matching the
--- condition can exist.
-CREATE UNIQUE INDEX idx_singleton_relation_sequence ON relation_sequence ((1));
-
 CREATE VIEW v_application_endpoint AS
 SELECT
     ae.uuid AS endpoint_uuid,

--- a/domain/schema/model_schema_test.go
+++ b/domain/schema/model_schema_test.go
@@ -265,7 +265,6 @@ func (s *modelSchemaSuite) TestModelTables(c *gc.C) {
 		"relation_application_setting",
 		"relation_application_settings_hash",
 		"relation_endpoint",
-		"relation_sequence",
 		"relation_status_type",
 		"relation_status",
 		"relation_unit_setting",


### PR DESCRIPTION
Design has changed thus the relation_sequence table is no longer required. All sequences are kept in the sequence table now. Their migration is handled there as well.

Switch over all relation sequence code to use sequence state NextValue method.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [x] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

Deploy two applications and relate them.
