### PR TITLE
feat: support storage id in deploy cmd

### DIFF
--- a/api/client/application/client.go
+++ b/api/client/application/client.go
@@ -1101,6 +1101,8 @@ type DeployFromRepositoryArg struct {
 	Storage map[string]storage.Constraints
 	//  Trust allows charm to run hooks that require access credentials
 	Trust bool
+	// StorageID is used by CAAS application to specify the storage ID and re-use the existing PVC.
+	StorageID string
 }
 
 // DeployFromRepository deploys a charm from a repository based on the
@@ -1188,5 +1190,6 @@ func paramsFromDeployFromRepositoryArg(arg DeployFromRepositoryArg) params.Deplo
 		Resources:        arg.Resources,
 		Storage:          arg.Storage,
 		Trust:            arg.Trust,
+		StorageID:        arg.StorageID,
 	}
 }

--- a/api/controller/caasunitprovisioner/client.go
+++ b/api/controller/caasunitprovisioner/client.go
@@ -238,6 +238,7 @@ type ProvisioningInfo struct {
 	Tags                 map[string]string
 	ImageDetails         resources.DockerImageDetails
 	CharmModifiedVersion int
+	StorageID            string
 }
 
 // ProvisioningInfo returns the provisioning info for the specified CAAS
@@ -267,6 +268,7 @@ func (c *Client) ProvisioningInfo(appName string) (*ProvisioningInfo, error) {
 		Tags:                 result.Tags,
 		CharmModifiedVersion: result.CharmModifiedVersion,
 		ImageDetails:         params.ConvertDockerImageInfo(result.ImageRepo),
+		StorageID:            result.StorageID,
 	}
 	if result.DeploymentInfo != nil {
 		info.DeploymentInfo = DeploymentInfo{

--- a/apiserver/facades/client/application/deployrepository.go
+++ b/apiserver/facades/client/application/deployrepository.go
@@ -141,6 +141,7 @@ func (api *DeployFromRepositoryAPI) DeployFromRepository(arg params.DeployFromRe
 		Placement:         dt.placement,
 		Resources:         pendingIDs,
 		Storage:           stateStorageConstraints(dt.storage),
+		StorageID:         dt.storageID,
 	})
 
 	if addApplicationErr != nil {
@@ -247,6 +248,7 @@ type deployTemplate struct {
 	storage                map[string]storage.Constraints
 	pendingResourceUploads []*params.PendingResourceUpload
 	resolvedResources      []resource.Resource
+	storageID              string
 }
 
 type validatorConfig struct {
@@ -369,6 +371,7 @@ func (v *deployFromRepositoryValidator) validate(arg params.DeployFromRepository
 	dt.origin = resolvedOrigin
 	dt.placement = arg.Placement
 	dt.storage = arg.Storage
+	dt.storageID = arg.StorageID
 	if len(arg.EndpointBindings) > 0 {
 		bindings, err := v.newStateBindings(v.state, arg.EndpointBindings)
 		if err != nil {

--- a/apiserver/facades/controller/caasunitprovisioner/provisioner.go
+++ b/apiserver/facades/controller/caasunitprovisioner/provisioner.go
@@ -437,6 +437,7 @@ func (f *Facade) provisioningInfo(model Model, tagString string) (*params.Kubern
 		Tags:                 resourceTags,
 		CharmModifiedVersion: app.CharmModifiedVersion(),
 		ImageRepo:            imageRepo,
+		StorageID:            app.StorageID(),
 	}
 	deployInfo := ch.Meta().Deployment
 	if deployInfo != nil {

--- a/apiserver/facades/controller/caasunitprovisioner/state.go
+++ b/apiserver/facades/controller/caasunitprovisioner/state.go
@@ -93,6 +93,7 @@ type Application interface {
 	Charm() (charmscommon.Charm, bool, error)
 	ClearResources() error
 	CharmModifiedVersion() int
+	StorageID() string
 }
 
 type stateShim struct {

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -2461,6 +2461,9 @@
                                 }
                             }
                         },
+                        "StorageID": {
+                            "type": "string"
+                        },
                         "Trust": {
                             "type": "boolean"
                         },
@@ -2507,7 +2510,8 @@
                         "DryRun",
                         "Placement",
                         "Storage",
-                        "Trust"
+                        "Trust",
+                        "StorageID"
                     ]
                 },
                 "DeployFromRepositoryArgs": {

--- a/caas/broker.go
+++ b/caas/broker.go
@@ -157,6 +157,8 @@ type ServiceParams struct {
 
 	// ImageDetails is the docker registry URL and auth details for the juju init container image.
 	ImageDetails resources.DockerImageDetails
+
+	StorageID string
 }
 
 // DeploymentState is returned by the OperatorExists call.

--- a/caas/kubernetes/provider/statefulsets.go
+++ b/caas/kubernetes/provider/statefulsets.go
@@ -53,6 +53,7 @@ func updateStrategyForStatefulSet(strategy specs.UpdateStrategy) (o apps.Statefu
 func (k *kubernetesClient) configureStatefulSet(
 	appName, deploymentName string, annotations k8sannotations.Annotation, workloadSpec *workloadSpec,
 	containers []specs.ContainerSpec, replicas *int32, filesystems []storage.KubernetesFilesystemParams,
+	storageID string,
 ) error {
 	logger.Debugf("creating/updating stateful set for %s", appName)
 
@@ -61,7 +62,7 @@ func (k *kubernetesClient) configureStatefulSet(
 		return applicationConfigMapName(deploymentName, fileSetName)
 	}
 
-	storageUniqueID, err := k.getStorageUniqPrefix(func() (annotationGetter, error) {
+	storageUniqueID, err := k.getStorageUniqPrefix(storageID, func() (annotationGetter, error) {
 		return k.getStatefulSet(deploymentName)
 	})
 	if err != nil {

--- a/cmd/juju/application/deploy.go
+++ b/cmd/juju/application/deploy.go
@@ -348,6 +348,8 @@ type DeployCommand struct {
 
 	controllerAPIRoot api.Connection
 	apiRoot           api.Connection
+
+	StorageID string
 }
 
 const deployDoc = `
@@ -651,6 +653,7 @@ func (c *DeployCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.Var(stringMap{&c.Resources}, "resource", "Resource to be uploaded to the controller")
 	f.StringVar(&c.BindToSpaces, "bind", "", "Configure application endpoint bindings to spaces")
 	f.StringVar(&c.machineMap, "map-machines", "", "Specify the existing machines to use for bundle deployments")
+	f.StringVar(&c.StorageID, "storage-id", "", "Specify the storage id")
 
 	c.flagSet = f
 }
@@ -918,6 +921,7 @@ func (c *DeployCommand) getDeployerFactory(base corebase.Base, defaultCharmSchem
 		Storage:            c.Storage,
 		Trust:              c.Trust,
 		UseExisting:        c.UseExisting,
+		StorageID:          c.StorageID,
 	}
 	return c.NewDeployerFactory(dep), cfg
 }

--- a/cmd/juju/application/deployer/charm.go
+++ b/cmd/juju/application/deployer/charm.go
@@ -50,6 +50,7 @@ type deployCharm struct {
 	baseFlag         corebase.Base
 	storage          map[string]storage.Constraints
 	trust            bool
+	storageID        string
 
 	validateCharmBaseWithName func(base corebase.Base, name string, imageStream string) error
 }
@@ -369,6 +370,7 @@ func (c *repositoryCharm) PrepareAndDeploy(ctx *cmd.Context, deployAPI DeployerA
 		Resources:        c.resources,
 		Storage:          c.storage,
 		Trust:            c.trust,
+		StorageID:        c.storageID,
 	})
 
 	for _, err := range errs {

--- a/cmd/juju/application/deployer/deployer.go
+++ b/cmd/juju/application/deployer/deployer.go
@@ -168,7 +168,6 @@ func (d *factory) GetDeployer(cfg DeployerConfig, deployAPI CharmDeployAPI, reso
 			}
 		}
 	}
-
 	return dk.CreateDeployer(*d)
 }
 
@@ -389,6 +388,7 @@ func (d *factory) setConfig(cfg DeployerConfig) {
 	d.bundleMachines = cfg.BundleMachines
 	d.trust = cfg.Trust
 	d.flagSet = cfg.FlagSet
+	d.storageID = cfg.StorageID
 }
 
 // DeployerDependencies are required for any deployer to be run.
@@ -437,6 +437,7 @@ type DeployerConfig struct {
 	Storage              map[string]storage.Constraints
 	Trust                bool
 	UseExisting          bool
+	StorageID            string
 }
 
 type factory struct {
@@ -473,6 +474,7 @@ type factory struct {
 	useExisting        bool
 	bundleMachines     map[string]string
 	trust              bool
+	storageID          string
 	flagSet            *gnuflag.FlagSet
 
 	// Private
@@ -503,6 +505,7 @@ func (d *factory) newDeployCharm() deployCharm {
 		baseFlag:         d.base,
 		storage:          d.storage,
 		trust:            d.trust,
+		storageID:        d.storageID,
 
 		validateCharmBaseWithName: d.validateCharmBaseWithName,
 	}

--- a/internal/worker/caasunitprovisioner/deployment_worker.go
+++ b/internal/worker/caasunitprovisioner/deployment_worker.go
@@ -231,6 +231,7 @@ func provisionInfoToServiceParams(info *apicaasunitprovisioner.ProvisioningInfo)
 			DeploymentType: caas.DeploymentType(info.DeploymentInfo.DeploymentType),
 			ServiceType:    caas.ServiceType(info.DeploymentInfo.ServiceType),
 		},
+		StorageID: info.StorageID,
 	}
 	if len(info.PodSpec) > 0 {
 		if serviceParams.PodSpec, err = k8sspecs.ParsePodSpec(info.PodSpec); err != nil {

--- a/rpc/params/applications.go
+++ b/rpc/params/applications.go
@@ -623,6 +623,8 @@ type DeployFromRepositoryArg struct {
 
 	//  Trust allows charm to run hooks that require access credentials
 	Trust bool
+
+	StorageID string
 }
 
 type DeployFromRepositoryResults struct {

--- a/rpc/params/kubernetes.go
+++ b/rpc/params/kubernetes.go
@@ -27,6 +27,7 @@ type KubernetesProvisioningInfo struct {
 	Devices              []KubernetesDeviceParams     `json:"devices,omitempty"`
 	CharmModifiedVersion int                          `json:"charm-modified-version,omitempty"`
 	ImageRepo            DockerImageInfo              `json:"image-repo,omitempty"`
+	StorageID            string                       `json:"storage-id,omitempty"`
 }
 
 // KubernetesProvisioningInfoResult holds unit provisioning info or an error.
@@ -48,6 +49,7 @@ type KubernetesFilesystemParams struct {
 	Attributes  map[string]interface{}                `json:"attributes,omitempty"`
 	Tags        map[string]string                     `json:"tags,omitempty"`
 	Attachment  *KubernetesFilesystemAttachmentParams `json:"attachment,omitempty"`
+	StorageID   string                                `json:"id,omitempty"`
 }
 
 // KubernetesFilesystemAttachmentParams holds the parameters for

--- a/state/application.go
+++ b/state/application.go
@@ -109,6 +109,7 @@ type applicationDoc struct {
 	DesiredScale      int                           `bson:"scale"`
 	PasswordHash      string                        `bson:"passwordhash"`
 	ProvisioningState *ApplicationProvisioningState `bson:"provisioning-state"`
+	StorageID         string                        `bson:"storage-id"`
 
 	// Placement is the placement directive that should be used allocating units/pods.
 	Placement string `bson:"placement,omitempty"`
@@ -131,6 +132,10 @@ func newApplication(st *State, doc *applicationDoc) *Application {
 		doc: *doc,
 	}
 	return app
+}
+
+func (a *Application) StorageID() string {
+	return a.doc.StorageID
 }
 
 // IsRemote returns false for a local application.

--- a/state/state.go
+++ b/state/state.go
@@ -1140,6 +1140,7 @@ type AddApplicationArgs struct {
 	Placement         []*instance.Placement
 	Constraints       constraints.Value
 	Resources         map[string]string
+	StorageID         string
 }
 
 // AddApplication creates a new application, running the supplied charm, with the
@@ -1312,6 +1313,7 @@ func (st *State) AddApplication(args AddApplicationArgs) (_ *Application, err er
 		DesiredScale: scale,
 		Placement:    placement,
 		HasResources: hasResources,
+		StorageID:    args.StorageID,
 	}
 
 	app := newApplication(st, appDoc)


### PR DESCRIPTION
<!--
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://github.com/juju/juju/blob/main/docs/contributor/reference/conventional-commits.md
-->

<!-- Why this change is needed and what it does. -->
Currently, when a user runs `juju deploy {application}`, Juju creates a new PVC with a randomly generated storage ID, this storage ID will be used in the k8s statefulset voumeClaimTemplates as the pvc name. The naming rules follow below source code:

```go
// Sidecar "{appName}-{storageName}-{uniqueId}", e.g., "dex-auth-test-0837847d-dex-auth-0"
"^" + regexp.QuoteMeta(a.name+"-"+storagePart),
// Pod-spec "{storageName}-{uniqueId}", e.g., "test-0837847d-dex-auth-0"
"^" + regexp.QuoteMeta(storagePart),
// Legacy "juju-{storageName}-{n}", e.g., "juju-test-1-dex-auth-0"
"^juju-" + regexp.QuoteMeta(s) + `-[0-9]+`, 
```

This change allow user to specify the storage id in `juju deploy {application}` command, so Juju can reuse an existing PVC is the name matches, or create a new one if not.

## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [ ] Code style: imports ordered, good names, simple structure, etc
- [ ] Comments saying why design decisions were made
- [ ] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages
- [ ] Test facades 
- [ ] Handle Kubernetes resource metadata annotations.  
- [ ] Ensure the design supports various Kubernetes resource types, such as Deployments and DaemonSets.  
- [ ] Warn users when `--storage-id` is used on non-Kubernetes clouds.  
- [ ] Support multiple deployer types:  
  - [ ] Local bundle  
  - [ ] Local charm  
  - [ ] Pre-deployed local charm  
  - [ ] Bundle from repository  
  - [x] Charm from repository



## QA steps

<!--

Describe steps to verify that the change works.

If you're changing any of the facades, you need to ensure that you've tested
a model migration from 3.6 to 4.0 and from 4.0 to 4.0.

The following steps are a good starting point:

 1. Bootstrap a 3.6 controller and deploy a charm.

```sh
$ juju bootstrap lxd src36
$ juju add-model moveme1
$ juju deploy juju-qa-test
```

 2. Bootstrap a 4.0 controller with the changes and migrate the model.

```sh
$ juju bootstrap lxd dst40
$ juju migrate src36:moveme1 dst40
$ juju add-unit juju-qa-test
```

 3. Verify no errors exist in the model logs for the agents. If there are
    errors, this is a bug and should be fixed before merging. The fix can
    either be applied to the 4.0 branch (preferable) or the 3.6 branch, though
    that needs to be discussed with the team.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme1
```

    4. We also need to test a model migration from 4.0 to 4.0.

```sh
$ juju bootstrap lxd src40
$ juju add-model moveme2
$ juju deploy juju-qa-test
```

```sh
$ juju migrate src40:moveme2 dst40
$ juju add-unit juju-qa-test
```

    5. Verify that there are no errors in the controller or model logs.

```sh
$ juju debug-log -m dst40:controller
$ juju debug-log -m dst40:moveme2
```

-->

**On k8s cloud**

```sh
juju deploy minio
# This will remove application and detach the storage
juju remove-application minio
# Remove juju storage
juju remove-storage {storage-name} --no-destroy

# Find the storage id on the pvc name and pass by --storage-id 
juju deploy minio --storage-id {storage-id}

# Verify the statefulset re-use the existing pvc.
kubectl get pvc,pv,statefulset,pod -n {namespace}
kubectl get pvc {pvc-name} -n {namespace} -o yaml
kubectl get statefulset {statefulset-name} -n {namespace} -o yaml
```


## Documentation changes

<!-- How it affects user workflow (CLI or API). -->

## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Replace #19267 with an issue reference or link, otherwise remove this line. -->
**Issue:** Partially fixes #19521

