### PR TITLE
Fix disallow link to include correct pattern

### DIFF
--- a/docs/reference/juju-cli/list-of-juju-cli-commands/controller-config.md
+++ b/docs/reference/juju-cli/list-of-juju-cli-commands/controller-config.md
@@ -192,3 +192,6 @@ The following keys are available:
     ssh-max-concurrent-connections:
       type: int
       description: The maximum number of concurrent ssh connections to the controller
+    ssh-server-port:
+      type: int
+      description: The port used for ssh connections to the controller


### PR DESCRIPTION
Modifies `robots.txt` file to disallow `/latest` slug appearing in Google search.
## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [ ] ~Comments saying why design decisions were made~
- [ ] ~Go unit tests, with comments saying what you're testing~
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps
- Check out this branch
- In a terminal, go to the `docs` folder and run `make html`
  - This should create a `_build` directory
- `cd` into `_build` and run `python3 -m http.server`
- Go to http://0.0.0.0:8000/robots.txt and make sure the expected content is there
