### PR TITLE
refactor(charm): remove redundant `kind` from charm_relation

### DIFF
--- a/domain/application/service/application.go
+++ b/domain/application/service/application.go
@@ -651,7 +651,7 @@ func (s *Service) MarkApplicationDead(ctx context.Context, appName string) error
 // as storage are still viable with the new charm.
 func (s *Service) SetApplicationCharm(ctx context.Context, name string, params UpdateCharmParams) error {
 	//TODO(storage) - update charm and storage directive for app
-	return nil
+	return coreerrors.NotImplemented
 }
 
 // GetApplicationIDByName returns an application ID by application name. It

--- a/domain/application/state/application_endpoint_test.go
+++ b/domain/application/state/application_endpoint_test.go
@@ -646,8 +646,8 @@ func (s *applicationEndpointStateSuite) addRelation(c *gc.C, name string) string
 	relUUID := uuid.MustNewUUID().String()
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		_, err := tx.ExecContext(ctx, `
-INSERT INTO charm_relation (uuid, charm_uuid, kind_id, scope_id, role_id, name)
-VALUES (?,?,0,0,0,?)`, relUUID, s.charmUUID, name)
+INSERT INTO charm_relation (uuid, charm_uuid, scope_id, role_id, name)
+VALUES (?,?,0,0,?)`, relUUID, s.charmUUID, name)
 		return errors.Capture(err)
 	})
 	c.Assert(err, jc.ErrorIsNil, gc.Commentf("(Arrange) Failed to add charm relation: %v", err))

--- a/domain/application/state/application_test.go
+++ b/domain/application/state/application_test.go
@@ -3570,7 +3570,7 @@ JOIN relation r ON r.uuid = re.relation_uuid
 LEFT JOIN relation_status rs ON rs.relation_uuid = re.relation_uuid
 LEFT JOIN relation_status_type rst ON rs.relation_status_type_id = rst.id
 WHERE a.name = ?
-AND cr.kind_id = 2 -- peer relation
+AND cr.role_id = 2 -- peer relation
 ORDER BY r.relation_id
 `, appName)
 		if err != nil {

--- a/domain/application/state/charm_test.go
+++ b/domain/application/state/charm_test.go
@@ -737,12 +737,12 @@ func (s *charmStateSuite) TestGetCharmMetadataWithRelation(c *gc.C) {
 		}
 
 		_, err = tx.ExecContext(ctx, `
-INSERT INTO charm_relation (uuid, charm_uuid, kind_id, name, role_id, scope_id)
+INSERT INTO charm_relation (uuid, charm_uuid, name, role_id, scope_id)
 VALUES
-    (?, ?, 0, 'foo', 0, 0),
-    (?, ?, 0, 'fred', 0, 1),
-    (?, ?, 1, 'faa', 1, 1),
-    (?, ?, 2, 'fee', 2, 0);`,
+    (?, ?, 'foo', 0, 0),
+    (?, ?, 'fred', 0, 1),
+    (?, ?, 'faa', 1, 1),
+    (?, ?, 'fee', 2, 0);`,
 			uuid.MustNewUUID().String(), charmUUID,
 			uuid.MustNewUUID().String(), charmUUID,
 			uuid.MustNewUUID().String(), charmUUID,

--- a/domain/application/state/exposed_test.go
+++ b/domain/application/state/exposed_test.go
@@ -476,8 +476,8 @@ func (s *exposedStateSuite) TestMergeExposeSettingsDifferentEndpointsNotOverwrit
 	s.setUpEndpoint(c, appID)
 	// Create a new endpoint
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
-		insertCharmRelation := `INSERT INTO charm_relation (uuid, charm_uuid, kind_id, scope_id, role_id, name) VALUES (?, ?, ?, ?, ?, ?)`
-		_, err := tx.ExecContext(ctx, insertCharmRelation, "charm-relation1-uuid", "charm0-uuid", "0", "0", "0", "endpoint1")
+		insertCharmRelation := `INSERT INTO charm_relation (uuid, charm_uuid, scope_id, role_id, name) VALUES (?, ?, ?, ?, ?)`
+		_, err := tx.ExecContext(ctx, insertCharmRelation, "charm-relation1-uuid", "charm0-uuid", "0", "0", "endpoint1")
 		if err != nil {
 			return err
 		}
@@ -544,8 +544,8 @@ func (s *exposedStateSuite) setUpEndpoint(c *gc.C, appID coreapplication.ID) {
 		if err != nil {
 			return err
 		}
-		insertCharmRelation := `INSERT INTO charm_relation (uuid, charm_uuid, kind_id, scope_id, role_id, name) VALUES (?, ?, ?, ?, ?, ?)`
-		_, err = tx.ExecContext(ctx, insertCharmRelation, "charm-relation0-uuid", "charm0-uuid", "0", "0", "0", "endpoint0")
+		insertCharmRelation := `INSERT INTO charm_relation (uuid, charm_uuid, scope_id, role_id, name) VALUES (?, ?, ?, ?, ?)`
+		_, err = tx.ExecContext(ctx, insertCharmRelation, "charm-relation0-uuid", "charm0-uuid", "0", "0", "endpoint0")
 		if err != nil {
 			return err
 		}

--- a/domain/application/state/metadata_test.go
+++ b/domain/application/state/metadata_test.go
@@ -106,7 +106,6 @@ var metadataDecodeTestCases = [...]struct {
 		inputArgs: decodeMetadataArgs{
 			relations: []charmRelation{
 				{
-					Kind:      "provides",
 					Name:      "db1",
 					Role:      "provider",
 					Interface: "mysql",
@@ -115,7 +114,6 @@ var metadataDecodeTestCases = [...]struct {
 					Scope:     "global",
 				},
 				{
-					Kind:      "provides",
 					Name:      "db2",
 					Role:      "provider",
 					Interface: "postgres",
@@ -124,7 +122,6 @@ var metadataDecodeTestCases = [...]struct {
 					Scope:     "global",
 				},
 				{
-					Kind:      "requires",
 					Name:      "blog",
 					Role:      "requirer",
 					Interface: "wordpress",
@@ -133,7 +130,6 @@ var metadataDecodeTestCases = [...]struct {
 					Scope:     "container",
 				},
 				{
-					Kind:      "peers",
 					Name:      "enclave",
 					Role:      "peer",
 					Interface: "vault",
@@ -487,42 +483,6 @@ SELECT charm_run_as_kind.* AS &charmRunAs.* FROM charm_run_as_kind ORDER BY id;
 func (s *metadataStateSuite) TestMetadataRunAsWithError(c *gc.C) {
 	_, err := encodeRunAs(charm.RunAs("invalid"))
 	c.Assert(err, gc.ErrorMatches, `unknown run as value "invalid"`)
-}
-
-func (s *metadataStateSuite) TestMetadataRelationKind(c *gc.C) {
-	type charmRelationKind struct {
-		ID   int    `db:"id"`
-		Name string `db:"name"`
-	}
-
-	stmt := sqlair.MustPrepare(`
-SELECT charm_relation_kind.* AS &charmRelationKind.* FROM charm_relation_kind ORDER BY id;
-`, charmRelationKind{})
-
-	var results []charmRelationKind
-	err := s.TxnRunner().Txn(context.Background(), func(ctx context.Context, tx *sqlair.TX) error {
-		return tx.Query(ctx, stmt).GetAll(&results)
-	})
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(results, gc.HasLen, 3)
-
-	m := []string{
-		relationKindProvides,
-		relationKindRequires,
-		relationKindPeers,
-	}
-
-	for i, value := range m {
-		c.Logf("result %d: %#v", i, value)
-		result, err := encodeRelationKind(value)
-		c.Assert(err, jc.ErrorIsNil)
-		c.Check(result, gc.DeepEquals, results[i].ID)
-	}
-}
-
-func (s *metadataStateSuite) TestMetadataRelationKindWithError(c *gc.C) {
-	_, err := encodeRelationKind("invalid")
-	c.Assert(err, gc.ErrorMatches, `unknown relation kind "invalid"`)
 }
 
 func (s *metadataStateSuite) TestMetadataRelationRole(c *gc.C) {

--- a/domain/application/state/types.go
+++ b/domain/application/state/types.go
@@ -374,7 +374,6 @@ type setCharmTerm struct {
 // charmRelation is used to get the relations of a charm.
 type charmRelation struct {
 	CharmUUID string `db:"charm_uuid"`
-	Kind      string `db:"kind"`
 	Name      string `db:"name"`
 	Role      string `db:"role"`
 	Interface string `db:"interface"`
@@ -394,7 +393,6 @@ type charmRelationName struct {
 type setCharmRelation struct {
 	UUID      string `db:"uuid"`
 	CharmUUID string `db:"charm_uuid"`
-	KindID    int    `db:"kind_id"`
 	Name      string `db:"name"`
 	RoleID    int    `db:"role_id"`
 	Interface string `db:"interface"`

--- a/domain/application/watcher_test.go
+++ b/domain/application/watcher_test.go
@@ -737,8 +737,8 @@ func (s *watcherSuite) TestWatchApplicationExposed(c *gc.C) {
 		if err != nil {
 			return err
 		}
-		insertCharmRelation := `INSERT INTO charm_relation (uuid, charm_uuid, kind_id, scope_id, role_id, name) VALUES (?, ?, ?, ?, ?, ?)`
-		_, err = tx.ExecContext(ctx, insertCharmRelation, "charm-relation0-uuid", "charm0-uuid", "0", "0", "0", "endpoint0")
+		insertCharmRelation := `INSERT INTO charm_relation (uuid, charm_uuid, scope_id, role_id, name) VALUES (?, ?, ?, ?, ?)`
+		_, err = tx.ExecContext(ctx, insertCharmRelation, "charm-relation0-uuid", "charm0-uuid", "0", "0", "endpoint0")
 		if err != nil {
 			return err
 		}

--- a/domain/relation/state/package_test.go
+++ b/domain/relation/state/package_test.go
@@ -126,8 +126,8 @@ func (s *baseRelationSuite) addCharmRelation(c *gc.C, charmUUID corecharm.ID, r 
 	// TODO(gfouillet): introduce proper UUID for this one, from corecharm and corecharmtesting
 	charmRelationUUID := uuid.MustNewUUID().String()
 	s.query(c, `
-INSERT INTO charm_relation (uuid, charm_uuid, kind_id, name, role_id, interface, optional, capacity, scope_id) 
-VALUES (?, ?, 0, ?, ?, ?, ?, ?, ?)
+INSERT INTO charm_relation (uuid, charm_uuid, name, role_id, interface, optional, capacity, scope_id) 
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 `, charmRelationUUID, charmUUID, r.Name, s.encodeRoleID(r.Role), r.Interface, r.Optional, r.Limit, s.encodeScopeID(r.Scope))
 	return charmRelationUUID
 }
@@ -138,8 +138,8 @@ func (s *baseRelationSuite) addCharmRelationWithDefaults(c *gc.C, charmUUID core
 	// TODO(gfouillet): introduce proper UUID for this one, from corecharm and corecharmtesting
 	charmRelationUUID := uuid.MustNewUUID().String()
 	s.query(c, `
-INSERT INTO charm_relation (uuid, charm_uuid, kind_id, scope_id, role_id, name) 
-VALUES (?, ?, 0, 0, 0, 'fake-provides')
+INSERT INTO charm_relation (uuid, charm_uuid, scope_id, role_id, name) 
+VALUES (?, ?, 0, 0, 'fake-provides')
 `, charmRelationUUID, charmUUID)
 	return charmRelationUUID
 }

--- a/domain/relation/state/relation_test.go
+++ b/domain/relation/state/relation_test.go
@@ -727,8 +727,8 @@ func (s *addRelationSuite) addApplicationEndpointFromRelation(c *gc.C,
 
 	// Add relation to charm
 	s.query(c, `
-INSERT INTO charm_relation (uuid, charm_uuid, kind_id, name, interface, capacity, role_id,  scope_id)
-SELECT ?, ?, 0, ?, ?, ?, crr.id, crs.id
+INSERT INTO charm_relation (uuid, charm_uuid, name, interface, capacity, role_id,  scope_id)
+SELECT ?, ?, ?, ?, ?, crr.id, crs.id
 FROM charm_relation_scope crs
 JOIN charm_relation_role crr ON crr.name = ?
 WHERE crs.name = ?

--- a/domain/relation/watcher_test.go
+++ b/domain/relation/watcher_test.go
@@ -680,12 +680,12 @@ VALUES (?, ?, 0)
 }
 
 // addCharmRelation inserts a new charm relation into the database with the given UUID and predefined attributes.
-func (s *watcherSuite) addCharmRelation(c *gc.C, charmUUID corecharm.ID, charmRelationUUID uuid.UUID, kind int) {
-	name := fmt.Sprintf("fake-%d", kind)
+func (s *watcherSuite) addCharmRelation(c *gc.C, charmUUID corecharm.ID, charmRelationUUID uuid.UUID, roleID int) {
+	name := fmt.Sprintf("fake-%d", roleID)
 	s.arrange(c, `
-INSERT INTO charm_relation (uuid, charm_uuid, kind_id, scope_id, role_id, name)
-VALUES (?, ?, ?,0,?, ?)
-`, charmRelationUUID.String(), charmUUID, kind, kind, name)
+INSERT INTO charm_relation (uuid, charm_uuid, scope_id, role_id, name)
+VALUES (?, ?, 0,?, ?)
+`, charmRelationUUID.String(), charmUUID, roleID, name)
 }
 
 // addRelation inserts a new relation into the database with the given UUID and default relation and life IDs.

--- a/domain/removal/state/relation_test.go
+++ b/domain/removal/state/relation_test.go
@@ -242,9 +242,9 @@ func (s *relationSuite) addAppUnitRelationScope(c *gc.C) (string, string) {
 
 	cr := "some-charm-relation-uuid"
 	_, err = s.DB().Exec(`
-INSERT INTO charm_relation (uuid, charm_uuid, kind_id, name, interface, capacity, role_id,  scope_id)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-		cr, charm, 0, cr, "interface", 0, 0, 0,
+INSERT INTO charm_relation (uuid, charm_uuid, name, interface, capacity, role_id,  scope_id)
+VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		cr, charm, cr, "interface", 0, 0, 0,
 	)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/domain/schema/model/sql/0015-charm.sql
+++ b/domain/schema/model/sql/0015-charm.sql
@@ -225,19 +225,6 @@ CREATE TABLE charm_hash (
     REFERENCES hash_kind (id)
 );
 
-CREATE TABLE charm_relation_kind (
-    id INT PRIMARY KEY,
-    name TEXT NOT NULL
-);
-
-CREATE UNIQUE INDEX idx_charm_relation_kind_name
-ON charm_relation_kind (name);
-
-INSERT INTO charm_relation_kind VALUES
-(0, 'provides'),
-(1, 'requires'),
-(2, 'peers');
-
 CREATE TABLE charm_relation_role (
     id INT PRIMARY KEY,
     name TEXT NOT NULL
@@ -266,7 +253,6 @@ INSERT INTO charm_relation_scope VALUES
 CREATE TABLE charm_relation (
     uuid TEXT NOT NULL PRIMARY KEY,
     charm_uuid TEXT NOT NULL,
-    kind_id TEXT NOT NULL,
     name TEXT NOT NULL,
     role_id INT NOT NULL,
     scope_id INT NOT NULL,
@@ -276,9 +262,6 @@ CREATE TABLE charm_relation (
     CONSTRAINT fk_charm_relation_charm
     FOREIGN KEY (charm_uuid)
     REFERENCES charm (uuid),
-    CONSTRAINT fk_charm_relation_kind
-    FOREIGN KEY (kind_id)
-    REFERENCES charm_relation_kind (id),
     CONSTRAINT fk_charm_relation_role
     FOREIGN KEY (role_id)
     REFERENCES charm_relation_role (id),
@@ -293,7 +276,6 @@ ON charm_relation (charm_uuid, name);
 CREATE VIEW v_charm_relation AS
 SELECT
     cr.charm_uuid,
-    crk.name AS kind,
     cr.name,
     crr.name AS role,
     cr.interface,
@@ -301,7 +283,6 @@ SELECT
     cr.capacity,
     crs.name AS scope
 FROM charm_relation AS cr
-JOIN charm_relation_kind AS crk ON cr.kind_id = crk.id
 JOIN charm_relation_role AS crr ON cr.role_id = crr.id
 JOIN charm_relation_scope AS crs ON cr.scope_id = crs.id;
 

--- a/domain/schema/model_schema_test.go
+++ b/domain/schema/model_schema_test.go
@@ -166,7 +166,6 @@ func (s *modelSchemaSuite) TestModelTables(c *gc.C) {
 		"charm_manifest_base",
 		"charm_metadata",
 		"charm_provenance",
-		"charm_relation_kind",
 		"charm_relation_role",
 		"charm_relation_scope",
 		"charm_relation",


### PR DESCRIPTION
This patch remove kind from relation table, which has the exact same meaning than role. It updates all places of use, especially in test.

Outside the tests, there is only one place of use for kind, is while decoding charm metadata, the kind was used in order to sort relation by role. The use of kind has been replaced by the role in this logic.

- `domain/removal/state/relation_test.go`: Updated SQL insert statements to remove `kind_id` column.
- `domain/application/state/charm_test.go`: Adjusted test cases to match updated schema without `kind_id`.
- `domain/application/state/types.go`: Removed `Kind` field from `charmRelation` struct and associated usage.
- `domain/schema/model/sql/0015-charm.sql`: Removed `charm_relation_kind` table and references to `kind_id`.
- `domain/application/state/metadata.go`: Replaced `kind`-based logic with `role`-based logic; removed `relationKind` constants and functions.
- `domain/application/state/metadata_test.go`: Adjusted test cases for changes in `charmRelation` struct.
- `domain/application/state/application_test.go`: Updated test logic referencing `kind_id`.
- `domain/application/watcher_test.go`: Updated SQL statements to remove `kind_id`.
- `domain/relation/state/relation_test.go`: Removed references to `kind_id` in insert statements.
- `domain/relation/state/package_test.go`: Aligned helper functions to schema changes.
- `domain/schema/model_schema_test.go`: Removed `charm_relation_kind` table validation.
- `domain/relation/watcher_test.go`: Updated SQL insert statements to exclude `kind_id`.

## QA steps

Unit test shall pass. No change in any logic.