### PR TITLE
fix: kill the lease manager after API server tests

### DIFF
--- a/juju/testing/apiserver.go
+++ b/juju/testing/apiserver.go
@@ -433,6 +433,10 @@ func (s *ApiServerSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *ApiServerSuite) TearDownTest(c *gc.C) {
+	if s.LeaseManager != nil {
+		s.LeaseManager.Kill()
+	}
+
 	s.WithLeaseManager = false
 	s.WithAuditLogConfig = nil
 	s.WithUpgrading = false


### PR DESCRIPTION
The `ApiServerSuite` starts up a lease manager worker during each test (if required), but never tears it down. This means Goroutine leaks for each such test.

The fix is simple - to kill the manager during each tear-down.

## QA steps

I applied this patch:
```diff
diff --git a/cmd/jujud/agent/package_test.go b/cmd/jujud/agent/package_test.go
index 880dc2cd38..32522e7c26 100644
--- a/cmd/jujud/agent/package_test.go
+++ b/cmd/jujud/agent/package_test.go
@@ -4,6 +4,7 @@
 package agent // not agent_test for no good reason

 import (
+       "go.uber.org/goleak"
        stdtesting "testing"

        coretesting "github.com/juju/juju/internal/testing"
@@ -12,6 +13,8 @@ import (
 //go:generate go run go.uber.org/mock/mockgen -typed -package mocks -destination mocks/machine_mock.go github.com/juju/juju/cmd/jujud/agent CommandRunner

 func TestPackage(t *stdtesting.T) {
+       goleak.VerifyNone(t)
+
        // TODO(waigani) 2014-03-19 bug 1294458
        // Refactor to use base suites
        coretesting.MgoSSLTestPackage(t)
```

Without the fix, this causes a massive spew of leaked Goroutines.

With the fix, we get a clean pass.