### PR TITLE
refactor: remove instance ID argument from environ Network.Subnets

### DIFF
--- a/apiserver/testing/stub_network.go
+++ b/apiserver/testing/stub_network.go
@@ -416,9 +416,9 @@ type StubNetworkingEnviron struct {
 var _ environs.NetworkingEnviron = (*StubNetworkingEnviron)(nil)
 
 func (se *StubNetworkingEnviron) Subnets(
-	ctx envcontext.ProviderCallContext, instId instance.Id, subIds []network.Id,
+	ctx envcontext.ProviderCallContext, subIds []network.Id,
 ) ([]network.SubnetInfo, error) {
-	se.MethodCall(se, "Subnets", ctx, instId, subIds)
+	se.MethodCall(se, "Subnets", ctx, subIds)
 	if err := se.NextErr(); err != nil {
 		return nil, err
 	}

--- a/domain/network/service/package_mock_test.go
+++ b/domain/network/service/package_mock_test.go
@@ -884,18 +884,18 @@ func (c *MockProviderWithNetworkingSpacesCall) DoAndReturn(f func(envcontext.Pro
 }
 
 // Subnets mocks base method.
-func (m *MockProviderWithNetworking) Subnets(arg0 envcontext.ProviderCallContext, arg1 instance.Id, arg2 []network.Id) ([]network.SubnetInfo, error) {
+func (m *MockProviderWithNetworking) Subnets(arg0 envcontext.ProviderCallContext, arg1 []network.Id) ([]network.SubnetInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Subnets", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "Subnets", arg0, arg1)
 	ret0, _ := ret[0].([]network.SubnetInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Subnets indicates an expected call of Subnets.
-func (mr *MockProviderWithNetworkingMockRecorder) Subnets(arg0, arg1, arg2 any) *MockProviderWithNetworkingSubnetsCall {
+func (mr *MockProviderWithNetworkingMockRecorder) Subnets(arg0, arg1 any) *MockProviderWithNetworkingSubnetsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Subnets", reflect.TypeOf((*MockProviderWithNetworking)(nil).Subnets), arg0, arg1, arg2)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Subnets", reflect.TypeOf((*MockProviderWithNetworking)(nil).Subnets), arg0, arg1)
 	return &MockProviderWithNetworkingSubnetsCall{Call: call}
 }
 
@@ -911,13 +911,13 @@ func (c *MockProviderWithNetworkingSubnetsCall) Return(arg0 []network.SubnetInfo
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockProviderWithNetworkingSubnetsCall) Do(f func(envcontext.ProviderCallContext, instance.Id, []network.Id) ([]network.SubnetInfo, error)) *MockProviderWithNetworkingSubnetsCall {
+func (c *MockProviderWithNetworkingSubnetsCall) Do(f func(envcontext.ProviderCallContext, []network.Id) ([]network.SubnetInfo, error)) *MockProviderWithNetworkingSubnetsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockProviderWithNetworkingSubnetsCall) DoAndReturn(f func(envcontext.ProviderCallContext, instance.Id, []network.Id) ([]network.SubnetInfo, error)) *MockProviderWithNetworkingSubnetsCall {
+func (c *MockProviderWithNetworkingSubnetsCall) DoAndReturn(f func(envcontext.ProviderCallContext, []network.Id) ([]network.SubnetInfo, error)) *MockProviderWithNetworkingSubnetsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/network/service/space.go
+++ b/domain/network/service/space.go
@@ -13,7 +13,6 @@ import (
 	"github.com/juju/names/v6"
 
 	coreerrors "github.com/juju/juju/core/errors"
-	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/logger"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/providertracker"
@@ -172,7 +171,7 @@ func (s *ProviderService) ReloadSpaces(ctx context.Context) error {
 	}
 
 	s.Service.logger.Debugf(ctx, "environ does not support space discovery, falling back to subnet discovery")
-	subnets, err := networkProvider.Subnets(callContext, instance.UnknownId, nil)
+	subnets, err := networkProvider.Subnets(callContext, nil)
 	if err != nil {
 		return errors.Capture(err)
 	}

--- a/domain/network/service/space_test.go
+++ b/domain/network/service/space_test.go
@@ -12,7 +12,6 @@ import (
 	gc "gopkg.in/check.v1"
 
 	coreerrors "github.com/juju/juju/core/errors"
-	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/network"
 	networkerrors "github.com/juju/juju/domain/network/errors"
 	"github.com/juju/juju/internal/errors"
@@ -512,7 +511,7 @@ func (s *spaceSuite) TestReloadSpacesUsingSubnets(c *gc.C) {
 	}
 
 	s.providerWithNetworking.EXPECT().SupportsSpaceDiscovery().Return(false, nil)
-	s.providerWithNetworking.EXPECT().Subnets(gomock.Any(), instance.UnknownId, nil).Return(twoSubnets, nil)
+	s.providerWithNetworking.EXPECT().Subnets(gomock.Any(), nil).Return(twoSubnets, nil)
 
 	s.st.EXPECT().UpsertSubnets(gomock.Any(), gomock.Any()).Do(
 		func(ctx context.Context, subnets []network.SubnetInfo) error {
@@ -537,7 +536,7 @@ func (s *spaceSuite) TestReloadSpacesUsingSubnetsFailsOnSave(c *gc.C) {
 	}
 
 	s.providerWithNetworking.EXPECT().SupportsSpaceDiscovery().Return(false, nil)
-	s.providerWithNetworking.EXPECT().Subnets(gomock.Any(), instance.UnknownId, nil).Return(twoSubnets, nil)
+	s.providerWithNetworking.EXPECT().Subnets(gomock.Any(), nil).Return(twoSubnets, nil)
 
 	s.st.EXPECT().UpsertSubnets(gomock.Any(), gomock.Any()).Do(
 		func(ctx context.Context, subnets []network.SubnetInfo) error {

--- a/environs/mocks/package_mock.go
+++ b/environs/mocks/package_mock.go
@@ -1744,18 +1744,18 @@ func (c *MockNetworkingEnvironStorageProviderTypesCall) DoAndReturn(f func() ([]
 }
 
 // Subnets mocks base method.
-func (m *MockNetworkingEnviron) Subnets(arg0 envcontext.ProviderCallContext, arg1 instance.Id, arg2 []network.Id) ([]network.SubnetInfo, error) {
+func (m *MockNetworkingEnviron) Subnets(arg0 envcontext.ProviderCallContext, arg1 []network.Id) ([]network.SubnetInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Subnets", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "Subnets", arg0, arg1)
 	ret0, _ := ret[0].([]network.SubnetInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Subnets indicates an expected call of Subnets.
-func (mr *MockNetworkingEnvironMockRecorder) Subnets(arg0, arg1, arg2 any) *MockNetworkingEnvironSubnetsCall {
+func (mr *MockNetworkingEnvironMockRecorder) Subnets(arg0, arg1 any) *MockNetworkingEnvironSubnetsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Subnets", reflect.TypeOf((*MockNetworkingEnviron)(nil).Subnets), arg0, arg1, arg2)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Subnets", reflect.TypeOf((*MockNetworkingEnviron)(nil).Subnets), arg0, arg1)
 	return &MockNetworkingEnvironSubnetsCall{Call: call}
 }
 
@@ -1771,13 +1771,13 @@ func (c *MockNetworkingEnvironSubnetsCall) Return(arg0 []network.SubnetInfo, arg
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockNetworkingEnvironSubnetsCall) Do(f func(envcontext.ProviderCallContext, instance.Id, []network.Id) ([]network.SubnetInfo, error)) *MockNetworkingEnvironSubnetsCall {
+func (c *MockNetworkingEnvironSubnetsCall) Do(f func(envcontext.ProviderCallContext, []network.Id) ([]network.SubnetInfo, error)) *MockNetworkingEnvironSubnetsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockNetworkingEnvironSubnetsCall) DoAndReturn(f func(envcontext.ProviderCallContext, instance.Id, []network.Id) ([]network.SubnetInfo, error)) *MockNetworkingEnvironSubnetsCall {
+func (c *MockNetworkingEnvironSubnetsCall) DoAndReturn(f func(envcontext.ProviderCallContext, []network.Id) ([]network.SubnetInfo, error)) *MockNetworkingEnvironSubnetsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/environs/networking.go
+++ b/environs/networking.go
@@ -24,9 +24,7 @@ var SupportsNetworking = supportsNetworking
 type Networking interface {
 	// Subnets returns basic information about subnets known
 	// by the provider for the environment.
-	Subnets(
-		ctx envcontext.ProviderCallContext, inst instance.Id, subnetIds []network.Id,
-	) ([]network.SubnetInfo, error)
+	Subnets(ctx envcontext.ProviderCallContext, subnetIds []network.Id) ([]network.SubnetInfo, error)
 
 	// NetworkInterfaces returns a slice with the network interfaces that
 	// correspond to the given instance IDs. If no instances where found,

--- a/environs/testing/package_mock.go
+++ b/environs/testing/package_mock.go
@@ -3976,18 +3976,18 @@ func (c *MockNetworkingEnvironStorageProviderTypesCall) DoAndReturn(f func() ([]
 }
 
 // Subnets mocks base method.
-func (m *MockNetworkingEnviron) Subnets(arg0 envcontext.ProviderCallContext, arg1 instance.Id, arg2 []network.Id) ([]network.SubnetInfo, error) {
+func (m *MockNetworkingEnviron) Subnets(arg0 envcontext.ProviderCallContext, arg1 []network.Id) ([]network.SubnetInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Subnets", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "Subnets", arg0, arg1)
 	ret0, _ := ret[0].([]network.SubnetInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Subnets indicates an expected call of Subnets.
-func (mr *MockNetworkingEnvironMockRecorder) Subnets(arg0, arg1, arg2 any) *MockNetworkingEnvironSubnetsCall {
+func (mr *MockNetworkingEnvironMockRecorder) Subnets(arg0, arg1 any) *MockNetworkingEnvironSubnetsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Subnets", reflect.TypeOf((*MockNetworkingEnviron)(nil).Subnets), arg0, arg1, arg2)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Subnets", reflect.TypeOf((*MockNetworkingEnviron)(nil).Subnets), arg0, arg1)
 	return &MockNetworkingEnvironSubnetsCall{Call: call}
 }
 
@@ -4003,13 +4003,13 @@ func (c *MockNetworkingEnvironSubnetsCall) Return(arg0 []network.SubnetInfo, arg
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockNetworkingEnvironSubnetsCall) Do(f func(envcontext.ProviderCallContext, instance.Id, []network.Id) ([]network.SubnetInfo, error)) *MockNetworkingEnvironSubnetsCall {
+func (c *MockNetworkingEnvironSubnetsCall) Do(f func(envcontext.ProviderCallContext, []network.Id) ([]network.SubnetInfo, error)) *MockNetworkingEnvironSubnetsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockNetworkingEnvironSubnetsCall) DoAndReturn(f func(envcontext.ProviderCallContext, instance.Id, []network.Id) ([]network.SubnetInfo, error)) *MockNetworkingEnvironSubnetsCall {
+func (c *MockNetworkingEnvironSubnetsCall) DoAndReturn(f func(envcontext.ProviderCallContext, []network.Id) ([]network.SubnetInfo, error)) *MockNetworkingEnvironSubnetsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/provider/azure/environ_network.go
+++ b/internal/provider/azure/environ_network.go
@@ -160,11 +160,6 @@ func (*azureEnviron) SuperSubnets(envcontext.ProviderCallContext) ([]string, err
 	return nil, errors.NotSupportedf("super subnets")
 }
 
-// AreSpacesRoutable implements environs.NetworkingEnviron.
-func (*azureEnviron) AreSpacesRoutable(_ envcontext.ProviderCallContext, _, _ *environs.ProviderSpaceInfo) (bool, error) {
-	return false, nil
-}
-
 // NetworkInterfaces implements environs.NetworkingEnviron. It returns back
 // a slice where the i_th element contains the list of network interfaces
 // for the i_th provided instance ID.

--- a/internal/provider/azure/environ_network.go
+++ b/internal/provider/azure/environ_network.go
@@ -155,11 +155,6 @@ func (env *azureEnviron) allPublicIPs(ctx envcontext.ProviderCallContext) (map[s
 	return idToIPMap, nil
 }
 
-// SuperSubnets implements environs.NetworkingEnviron.
-func (*azureEnviron) SuperSubnets(envcontext.ProviderCallContext) ([]string, error) {
-	return nil, errors.NotSupportedf("super subnets")
-}
-
 // NetworkInterfaces implements environs.NetworkingEnviron. It returns back
 // a slice where the i_th element contains the list of network interfaces
 // for the i_th provided instance ID.

--- a/internal/provider/azure/environ_network.go
+++ b/internal/provider/azure/environ_network.go
@@ -45,10 +45,7 @@ func (env *azureEnviron) networkInfo(ctx context.Context) (vnetRG string, vnetNa
 
 // Subnets implements environs.NetworkingEnviron.
 func (env *azureEnviron) Subnets(
-	ctx envcontext.ProviderCallContext, instanceID instance.Id, _ []network.Id) ([]network.SubnetInfo, error) {
-	if instanceID != instance.UnknownId {
-		return nil, errors.NotSupportedf("subnets for instance")
-	}
+	ctx envcontext.ProviderCallContext, _ []network.Id) ([]network.SubnetInfo, error) {
 	subnets, err := env.allSubnets(ctx)
 	if err != nil {
 		return nil, env.HandleCredentialError(ctx, err)

--- a/internal/provider/azure/environ_network_test.go
+++ b/internal/provider/azure/environ_network_test.go
@@ -6,7 +6,6 @@ package azure_test
 import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork"
-	"github.com/juju/errors"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
@@ -15,16 +14,6 @@ import (
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/internal/provider/azure/internal/azuretesting"
 )
-
-func (s *environSuite) TestSubnetsInstanceIDError(c *gc.C) {
-	env := s.openEnviron(c)
-
-	netEnv, ok := environs.SupportsNetworking(env)
-	c.Assert(ok, jc.IsTrue)
-
-	_, err := netEnv.Subnets(s.callCtx, "some-ID", nil)
-	c.Assert(err, jc.ErrorIs, errors.NotSupported)
-}
 
 func (s *environSuite) TestSubnetsSuccessOld(c *gc.C) {
 	env := s.openEnviron(c)
@@ -52,7 +41,7 @@ func (s *environSuite) TestSubnetsSuccessOld(c *gc.C) {
 	netEnv, ok := environs.SupportsNetworking(env)
 	c.Assert(ok, jc.IsTrue)
 
-	subs, err := netEnv.Subnets(s.callCtx, instance.UnknownId, nil)
+	subs, err := netEnv.Subnets(s.callCtx, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(subs, gc.HasLen, 1)
@@ -89,7 +78,7 @@ func (s *environSuite) TestSubnetsSuccessNew(c *gc.C) {
 	netEnv, ok := environs.SupportsNetworking(env)
 	c.Assert(ok, jc.IsTrue)
 
-	subs, err := netEnv.Subnets(s.callCtx, instance.UnknownId, nil)
+	subs, err := netEnv.Subnets(s.callCtx, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(subs, gc.HasLen, 1)

--- a/internal/provider/dummy/environs.go
+++ b/internal/provider/dummy/environs.go
@@ -919,9 +919,7 @@ func (env *environ) DeriveAvailabilityZones(envcontext.ProviderCallContext, envi
 }
 
 // Subnets implements environs.Environ.Subnets.
-func (env *environ) Subnets(
-	ctx envcontext.ProviderCallContext, instId instance.Id, subnetIds []network.Id,
-) ([]network.SubnetInfo, error) {
+func (env *environ) Subnets(ctx envcontext.ProviderCallContext, subnetIds []network.Id) ([]network.SubnetInfo, error) {
 	if err := env.checkBroken("Subnets"); err != nil {
 		return nil, err
 	}

--- a/internal/provider/ec2/local_test.go
+++ b/internal/provider/ec2/local_test.go
@@ -2100,22 +2100,7 @@ func (t *localServerSuite) assertInterfaceLooksValid(c *gc.C, expIfaceID, expDev
 	c.Assert(iface, gc.DeepEquals, expectedInterface)
 }
 
-func (t *localServerSuite) TestSubnetsWithInstanceId(c *gc.C) {
-	env, instId := t.setUpInstanceWithDefaultVpc(c)
-	subnets, err := env.Subnets(t.callCtx, instId, nil)
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(subnets, gc.HasLen, 1)
-	validateSubnets(c, subnets, "")
-
-	interfaceList, err := env.NetworkInterfaces(t.callCtx, []instance.Id{instId})
-	c.Assert(err, jc.ErrorIsNil)
-	c.Assert(interfaceList, gc.HasLen, 1)
-	interfaces := interfaceList[0]
-	c.Assert(interfaces, gc.HasLen, 1)
-	c.Assert(interfaces[0].ProviderSubnetId, gc.Equals, subnets[0].ProviderId)
-}
-
-func (t *localServerSuite) TestSubnetsWithInstanceIdAndSubnetId(c *gc.C) {
+func (t *localServerSuite) TestSubnetsWithSubnetId(c *gc.C) {
 	env, instId := t.setUpInstanceWithDefaultVpc(c)
 	interfaceList, err := env.NetworkInterfaces(t.callCtx, []instance.Id{instId})
 	c.Assert(err, jc.ErrorIsNil)
@@ -2123,18 +2108,11 @@ func (t *localServerSuite) TestSubnetsWithInstanceIdAndSubnetId(c *gc.C) {
 	interfaces := interfaceList[0]
 	c.Assert(interfaces, gc.HasLen, 1)
 
-	subnets, err := env.Subnets(t.callCtx, instId, []network.Id{interfaces[0].ProviderSubnetId})
+	subnets, err := env.Subnets(t.callCtx, []network.Id{interfaces[0].ProviderSubnetId})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(subnets, gc.HasLen, 1)
 	c.Assert(subnets[0].ProviderId, gc.Equals, interfaces[0].ProviderSubnetId)
-	validateSubnets(c, subnets, "")
-}
-
-func (t *localServerSuite) TestSubnetsWithInstanceIdMissingSubnet(c *gc.C) {
-	env, instId := t.setUpInstanceWithDefaultVpc(c)
-	subnets, err := env.Subnets(t.callCtx, instId, []network.Id{"missing"})
-	c.Assert(err, gc.ErrorMatches, `failed to find the following subnet ids: \[missing\]`)
-	c.Assert(subnets, gc.HasLen, 0)
+	validateSubnets(c, subnets, "vpc-0")
 }
 
 func (t *localServerSuite) TestInstanceInformation(c *gc.C) {
@@ -2196,12 +2174,12 @@ func validateSubnets(c *gc.C, subnets []network.SubnetInfo, vpcId network.Id) {
 func (t *localServerSuite) TestSubnets(c *gc.C) {
 	env, _ := t.setUpInstanceWithDefaultVpc(c)
 
-	subnets, err := env.Subnets(t.callCtx, instance.UnknownId, []network.Id{"subnet-0"})
+	subnets, err := env.Subnets(t.callCtx, []network.Id{"subnet-0"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(subnets, gc.HasLen, 1)
 	validateSubnets(c, subnets, "vpc-0")
 
-	subnets, err = env.Subnets(t.callCtx, instance.UnknownId, nil)
+	subnets, err = env.Subnets(t.callCtx, nil)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(subnets, gc.HasLen, 4)
 	validateSubnets(c, subnets, "vpc-0")
@@ -2210,7 +2188,7 @@ func (t *localServerSuite) TestSubnets(c *gc.C) {
 func (t *localServerSuite) TestSubnetsMissingSubnet(c *gc.C) {
 	env, _ := t.setUpInstanceWithDefaultVpc(c)
 
-	_, err := env.Subnets(t.callCtx, "", []network.Id{"subnet-0", "Missing"})
+	_, err := env.Subnets(t.callCtx, []network.Id{"subnet-0", "Missing"})
 	c.Assert(err, gc.ErrorMatches, `failed to find the following subnet ids: \[Missing\]`)
 }
 

--- a/internal/provider/gce/environ_network.go
+++ b/internal/provider/gce/environ_network.go
@@ -296,11 +296,6 @@ func (e *environ) SupportsSpaces() (bool, error) {
 	return false, nil
 }
 
-// AreSpacesRoutable implements environs.NetworkingEnviron.
-func (*environ) AreSpacesRoutable(ctx envcontext.ProviderCallContext, space1, space2 *environs.ProviderSpaceInfo) (bool, error) {
-	return false, nil
-}
-
 // SuperSubnets implements environs.SuperSubnets
 func (e *environ) SuperSubnets(ctx envcontext.ProviderCallContext) ([]string, error) {
 	subnets, err := e.Subnets(ctx, nil)

--- a/internal/provider/gce/environ_network.go
+++ b/internal/provider/gce/environ_network.go
@@ -296,19 +296,6 @@ func (e *environ) SupportsSpaces() (bool, error) {
 	return false, nil
 }
 
-// SuperSubnets implements environs.SuperSubnets
-func (e *environ) SuperSubnets(ctx envcontext.ProviderCallContext) ([]string, error) {
-	subnets, err := e.Subnets(ctx, nil)
-	if err != nil {
-		return nil, err
-	}
-	cidrs := make([]string, len(subnets))
-	for i, subnet := range subnets {
-		cidrs[i] = subnet.CIDR
-	}
-	return cidrs, nil
-}
-
 func copyStrings(items []string) []string {
 	if items == nil {
 		return nil

--- a/internal/provider/gce/environ_network_test.go
+++ b/internal/provider/gce/environ_network_test.go
@@ -81,7 +81,7 @@ func (s *environNetSuite) cannedData() {
 func (s *environNetSuite) TestSubnetsInvalidCredentialError(c *gc.C) {
 	s.FakeConn.Err = gce.InvalidCredentialError
 	c.Assert(s.InvalidatedCredentials, jc.IsFalse)
-	_, err := s.NetEnv.Subnets(s.CallCtx, instance.UnknownId, nil)
+	_, err := s.NetEnv.Subnets(s.CallCtx, nil)
 	c.Check(err, gc.NotNil)
 	c.Assert(s.InvalidatedCredentials, jc.IsTrue)
 }
@@ -89,7 +89,7 @@ func (s *environNetSuite) TestSubnetsInvalidCredentialError(c *gc.C) {
 func (s *environNetSuite) TestGettingAllSubnets(c *gc.C) {
 	s.cannedData()
 
-	subnets, err := s.NetEnv.Subnets(s.CallCtx, instance.UnknownId, nil)
+	subnets, err := s.NetEnv.Subnets(s.CallCtx, nil)
 	c.Assert(err, jc.ErrorIsNil)
 
 	c.Assert(subnets, gc.DeepEquals, []corenetwork.SubnetInfo{{
@@ -116,9 +116,7 @@ func (s *environNetSuite) TestGettingAllSubnets(c *gc.C) {
 func (s *environNetSuite) TestRestrictingToSubnets(c *gc.C) {
 	s.cannedData()
 
-	subnets, err := s.NetEnv.Subnets(s.CallCtx, instance.UnknownId, []corenetwork.Id{
-		"shellac",
-	})
+	subnets, err := s.NetEnv.Subnets(s.CallCtx, []corenetwork.Id{"shellac"})
 	c.Assert(err, jc.ErrorIsNil)
 	c.Assert(subnets, gc.DeepEquals, []corenetwork.SubnetInfo{{
 		ProviderId:        "shellac",
@@ -132,50 +130,8 @@ func (s *environNetSuite) TestRestrictingToSubnets(c *gc.C) {
 func (s *environNetSuite) TestRestrictingToSubnetsWithMissing(c *gc.C) {
 	s.cannedData()
 
-	subnets, err := s.NetEnv.Subnets(s.CallCtx, instance.UnknownId, []corenetwork.Id{"shellac", "brunettes"})
+	subnets, err := s.NetEnv.Subnets(s.CallCtx, []corenetwork.Id{"shellac", "brunettes"})
 	c.Assert(err, gc.ErrorMatches, `subnets \["brunettes"\] not found`)
-	c.Assert(err, jc.ErrorIs, errors.NotFound)
-	c.Assert(subnets, gc.IsNil)
-}
-
-func (s *environNetSuite) TestSpecificInstance(c *gc.C) {
-	s.cannedData()
-	s.FakeEnviron.Insts = []instances.Instance{s.NewInstance(c, "moana")}
-
-	subnets, err := s.NetEnv.Subnets(s.CallCtx, "moana", nil)
-	c.Assert(err, jc.ErrorIsNil)
-
-	c.Assert(subnets, gc.DeepEquals, []corenetwork.SubnetInfo{{
-		ProviderId:        "go-team",
-		ProviderNetworkId: "go-team1",
-		CIDR:              "10.0.10.0/24",
-		AvailabilityZones: []string{"a-zone", "b-zone"},
-		VLANTag:           0,
-	}})
-}
-
-func (s *environNetSuite) TestSpecificInstanceAndRestrictedSubnets(c *gc.C) {
-	s.cannedData()
-	s.FakeEnviron.Insts = []instances.Instance{s.NewInstance(c, "moana")}
-
-	subnets, err := s.NetEnv.Subnets(s.CallCtx, "moana", []corenetwork.Id{"go-team"})
-	c.Assert(err, jc.ErrorIsNil)
-
-	c.Assert(subnets, gc.DeepEquals, []corenetwork.SubnetInfo{{
-		ProviderId:        "go-team",
-		ProviderNetworkId: "go-team1",
-		CIDR:              "10.0.10.0/24",
-		AvailabilityZones: []string{"a-zone", "b-zone"},
-		VLANTag:           0,
-	}})
-}
-
-func (s *environNetSuite) TestSpecificInstanceAndRestrictedSubnetsWithMissing(c *gc.C) {
-	s.cannedData()
-	s.FakeEnviron.Insts = []instances.Instance{s.NewInstance(c, "moana")}
-
-	subnets, err := s.NetEnv.Subnets(s.CallCtx, "moana", []corenetwork.Id{"go-team", "shellac"})
-	c.Assert(err, gc.ErrorMatches, `subnets \["shellac"\] not found`)
 	c.Assert(err, jc.ErrorIs, errors.NotFound)
 	c.Assert(subnets, gc.IsNil)
 }

--- a/internal/provider/lxd/environ_network.go
+++ b/internal/provider/lxd/environ_network.go
@@ -318,9 +318,3 @@ func (e *environ) SupportsSpaces() (bool, error) {
 	// work there.
 	return e.server().HasExtension("network"), nil
 }
-
-// AreSpacesRoutable returns whether the communication between the
-// two spaces can use cloud-local addresses.
-func (*environ) AreSpacesRoutable(envcontext.ProviderCallContext, *environs.ProviderSpaceInfo, *environs.ProviderSpaceInfo) (bool, error) {
-	return false, errors.NotSupportedf("spaces")
-}

--- a/internal/provider/lxd/environ_network.go
+++ b/internal/provider/lxd/environ_network.go
@@ -60,10 +60,6 @@ func (e *environ) Subnets(ctx envcontext.ProviderCallContext, subnetIDs []networ
 		networkName := networkDetails.Name
 		state, err := srv.GetNetworkState(networkName)
 		if err != nil {
-			// Unfortunately, LXD on bionic and earlier does not
-			// support the network_state extension out of the box
-			// so this call will fail. If that's the case then
-			// use a fallback method for detecting subnets.
 			if isErrMissingAPIExtension(err, "network_state") {
 				return nil, errors.Errorf("network_state extension unsupported; upgrade to a newer version of LXD")
 			}

--- a/internal/provider/lxd/package_mock_test.go
+++ b/internal/provider/lxd/package_mock_test.go
@@ -581,50 +581,6 @@ func (c *MockServerEnsureDefaultStorageCall) DoAndReturn(f func(*api.Profile, st
 	return c
 }
 
-// FilterContainers mocks base method.
-func (m *MockServer) FilterContainers(arg0 string, arg1 ...string) ([]lxd0.Container, error) {
-	m.ctrl.T.Helper()
-	varargs := []any{arg0}
-	for _, a := range arg1 {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "FilterContainers", varargs...)
-	ret0, _ := ret[0].([]lxd0.Container)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// FilterContainers indicates an expected call of FilterContainers.
-func (mr *MockServerMockRecorder) FilterContainers(arg0 any, arg1 ...any) *MockServerFilterContainersCall {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0}, arg1...)
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FilterContainers", reflect.TypeOf((*MockServer)(nil).FilterContainers), varargs...)
-	return &MockServerFilterContainersCall{Call: call}
-}
-
-// MockServerFilterContainersCall wrap *gomock.Call
-type MockServerFilterContainersCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockServerFilterContainersCall) Return(arg0 []lxd0.Container, arg1 error) *MockServerFilterContainersCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockServerFilterContainersCall) Do(f func(string, ...string) ([]lxd0.Container, error)) *MockServerFilterContainersCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockServerFilterContainersCall) DoAndReturn(f func(string, ...string) ([]lxd0.Container, error)) *MockServerFilterContainersCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // FindImage mocks base method.
 func (m *MockServer) FindImage(arg0 context.Context, arg1 base.Base, arg2 string, arg3 instance.VirtType, arg4 []lxd0.ServerSpec, arg5 bool, arg6 environs.StatusCallbackFunc) (lxd0.SourcedImage, error) {
 	m.ctrl.T.Helper()

--- a/internal/provider/lxd/server.go
+++ b/internal/provider/lxd/server.go
@@ -51,7 +51,6 @@ type Server interface {
 	ContainerAddresses(name string) ([]network.ProviderAddress, error)
 	RemoveContainer(name string) error
 	RemoveContainers(names []string) error
-	FilterContainers(prefix string, statuses ...string) ([]lxd.Container, error)
 	CreateContainerFromSpec(spec lxd.ContainerSpec) (*lxd.Container, error)
 	WriteContainer(*lxd.Container) error
 	CreateProfileWithConfig(string, map[string]string) error

--- a/internal/provider/manual/environ_network.go
+++ b/internal/provider/manual/environ_network.go
@@ -24,11 +24,6 @@ func (e *manualEnviron) Subnets(envcontext.ProviderCallContext, []network.Id) ([
 	return nil, errors.NotSupportedf("subnets")
 }
 
-// SuperSubnets implements environs.NetworkingEnviron.
-func (e *manualEnviron) SuperSubnets(envcontext.ProviderCallContext) ([]string, error) {
-	return nil, errors.NotSupportedf("super subnets")
-}
-
 // NetworkInterfaces implements environs.NetworkingEnviron.
 func (e *manualEnviron) NetworkInterfaces(
 	envcontext.ProviderCallContext, []instance.Id,

--- a/internal/provider/manual/environ_network.go
+++ b/internal/provider/manual/environ_network.go
@@ -20,7 +20,7 @@ func (e *manualEnviron) SupportsSpaces() (bool, error) {
 }
 
 // Subnets implements environs.NetworkingEnviron.
-func (e *manualEnviron) Subnets(envcontext.ProviderCallContext, instance.Id, []network.Id) ([]network.SubnetInfo, error) {
+func (e *manualEnviron) Subnets(envcontext.ProviderCallContext, []network.Id) ([]network.SubnetInfo, error) {
 	return nil, errors.NotSupportedf("subnets")
 }
 

--- a/internal/provider/manual/environ_network.go
+++ b/internal/provider/manual/environ_network.go
@@ -29,11 +29,6 @@ func (e *manualEnviron) SuperSubnets(envcontext.ProviderCallContext) ([]string, 
 	return nil, errors.NotSupportedf("super subnets")
 }
 
-// AreSpacesRoutable implements environs.NetworkingEnviron.
-func (*manualEnviron) AreSpacesRoutable(_ envcontext.ProviderCallContext, _, _ *environs.ProviderSpaceInfo) (bool, error) {
-	return false, nil
-}
-
 // NetworkInterfaces implements environs.NetworkingEnviron.
 func (e *manualEnviron) NetworkInterfaces(
 	envcontext.ProviderCallContext, []instance.Id,

--- a/internal/provider/oci/networking.go
+++ b/internal/provider/oci/networking.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/juju/juju/core/instance"
 	"github.com/juju/juju/core/network"
-	"github.com/juju/juju/environs"
 	"github.com/juju/juju/environs/envcontext"
 	"github.com/juju/juju/environs/tags"
 )
@@ -1039,8 +1038,4 @@ func (e *Environ) networkInterfacesForInstance(ctx envcontext.ProviderCallContex
 
 func (e *Environ) SupportsSpaces() (bool, error) {
 	return false, nil
-}
-
-func (e *Environ) AreSpacesRoutable(ctx envcontext.ProviderCallContext, space1, space2 *environs.ProviderSpaceInfo) (bool, error) {
-	return false, errors.NotImplementedf("AreSpacesRoutable")
 }

--- a/internal/provider/openstack/local_test.go
+++ b/internal/provider/openstack/local_test.go
@@ -1428,7 +1428,7 @@ func (s *localServerSuite) prepareNetworkingEnviron(c *gc.C, cfg *config.Config)
 func (s *localServerSuite) TestSubnetsFindAll(c *gc.C) {
 	env := s.prepareNetworkingEnviron(c, s.env.Config())
 	// the environ is opened with network:"private_999" which maps to network id "999"
-	obtainedSubnets, err := env.Subnets(s.callCtx, "", []network.Id{})
+	obtainedSubnets, err := env.Subnets(s.callCtx, []network.Id{})
 	c.Assert(err, jc.ErrorIsNil)
 	neutronClient := openstack.GetNeutronClient(s.env)
 	openstackSubnets, err := neutronClient.ListSubnetsV2()
@@ -1466,7 +1466,7 @@ func (s *localServerSuite) TestSubnetsFindAllWithExternal(c *gc.C) {
 	env := s.prepareNetworkingEnviron(c, cfg)
 	// private_999 is the internal network, 998 is the external network
 	// the environ is opened with network:"private_999" which maps to network id "999"
-	obtainedSubnets, err := env.Subnets(s.callCtx, "", []network.Id{})
+	obtainedSubnets, err := env.Subnets(s.callCtx, []network.Id{})
 	c.Assert(err, jc.ErrorIsNil)
 	neutronClient := openstack.GetNeutronClient(s.env)
 	openstackSubnets, err := neutronClient.ListSubnetsV2()
@@ -1527,7 +1527,7 @@ func (s *localServerSuite) testFindNetworks(c *gc.C, internal bool) {
 
 func (s *localServerSuite) TestSubnetsWithMissingSubnet(c *gc.C) {
 	env := s.prepareNetworkingEnviron(c, s.env.Config())
-	subnets, err := env.Subnets(s.callCtx, "", []network.Id{"missing"})
+	subnets, err := env.Subnets(s.callCtx, []network.Id{"missing"})
 	c.Assert(err, gc.ErrorMatches, `failed to find the following subnet ids: \[missing\]`)
 	c.Assert(subnets, gc.HasLen, 0)
 }

--- a/internal/provider/openstack/network_mock_test.go
+++ b/internal/provider/openstack/network_mock_test.go
@@ -338,18 +338,18 @@ func (c *MockNetworkingResolveNetworksCall) DoAndReturn(f func(string, bool) ([]
 }
 
 // Subnets mocks base method.
-func (m *MockNetworking) Subnets(arg0 instance.Id, arg1 []network.Id) ([]network.SubnetInfo, error) {
+func (m *MockNetworking) Subnets(arg0 []network.Id) ([]network.SubnetInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Subnets", arg0, arg1)
+	ret := m.ctrl.Call(m, "Subnets", arg0)
 	ret0, _ := ret[0].([]network.SubnetInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Subnets indicates an expected call of Subnets.
-func (mr *MockNetworkingMockRecorder) Subnets(arg0, arg1 any) *MockNetworkingSubnetsCall {
+func (mr *MockNetworkingMockRecorder) Subnets(arg0 any) *MockNetworkingSubnetsCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Subnets", reflect.TypeOf((*MockNetworking)(nil).Subnets), arg0, arg1)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Subnets", reflect.TypeOf((*MockNetworking)(nil).Subnets), arg0)
 	return &MockNetworkingSubnetsCall{Call: call}
 }
 
@@ -365,13 +365,13 @@ func (c *MockNetworkingSubnetsCall) Return(arg0 []network.SubnetInfo, arg1 error
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockNetworkingSubnetsCall) Do(f func(instance.Id, []network.Id) ([]network.SubnetInfo, error)) *MockNetworkingSubnetsCall {
+func (c *MockNetworkingSubnetsCall) Do(f func([]network.Id) ([]network.SubnetInfo, error)) *MockNetworkingSubnetsCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockNetworkingSubnetsCall) DoAndReturn(f func(instance.Id, []network.Id) ([]network.SubnetInfo, error)) *MockNetworkingSubnetsCall {
+func (c *MockNetworkingSubnetsCall) DoAndReturn(f func([]network.Id) ([]network.SubnetInfo, error)) *MockNetworkingSubnetsCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/provider/openstack/networking_interfaces.go
+++ b/internal/provider/openstack/networking_interfaces.go
@@ -27,7 +27,7 @@ type Networking interface {
 	// Subnets returns basic information about subnets known
 	// by OpenStack for the environment.
 	// Needed for Environ.Networking
-	Subnets(instance.Id, []corenetwork.Id) ([]corenetwork.SubnetInfo, error)
+	Subnets([]corenetwork.Id) ([]corenetwork.SubnetInfo, error)
 
 	// CreatePort creates a port for a given network id with a subnet ID.
 	CreatePort(string, string, corenetwork.Id) (*neutron.PortV2, error)

--- a/internal/provider/openstack/provider.go
+++ b/internal/provider/openstack/provider.go
@@ -2291,7 +2291,7 @@ func validateAuthURL(authURL string) error {
 
 // Subnets is specified on environs.Networking.
 func (e *Environ) Subnets(ctx envcontext.ProviderCallContext, subnetIds []network.Id) ([]network.SubnetInfo, error) {
-	subnets, err := e.networking.Subnets(instance.UnknownId, subnetIds)
+	subnets, err := e.networking.Subnets(subnetIds)
 	if err != nil {
 		return subnets, e.HandleCredentialError(ctx, err)
 	}
@@ -2315,7 +2315,7 @@ func (e *Environ) SupportsSpaces() (bool, error) {
 
 // SuperSubnets is specified on environs.Networking
 func (e *Environ) SuperSubnets(ctx envcontext.ProviderCallContext) ([]string, error) {
-	subnets, err := e.networking.Subnets("", nil)
+	subnets, err := e.networking.Subnets(nil)
 	if err != nil {
 		return nil, e.HandleCredentialError(ctx, err)
 	}

--- a/internal/provider/openstack/provider.go
+++ b/internal/provider/openstack/provider.go
@@ -2313,19 +2313,6 @@ func (e *Environ) SupportsSpaces() (bool, error) {
 	return true, nil
 }
 
-// SuperSubnets is specified on environs.Networking
-func (e *Environ) SuperSubnets(ctx envcontext.ProviderCallContext) ([]string, error) {
-	subnets, err := e.networking.Subnets(nil)
-	if err != nil {
-		return nil, e.HandleCredentialError(ctx, err)
-	}
-	cidrs := make([]string, len(subnets))
-	for i, subnet := range subnets {
-		cidrs[i] = subnet.CIDR
-	}
-	return cidrs, nil
-}
-
 // SupportsRulesWithIPV6CIDRs returns true if the environment supports ingress
 // rules containing IPV6 CIDRs. It is part of the FirewallFeatureQuerier
 // interface.

--- a/internal/provider/openstack/provider.go
+++ b/internal/provider/openstack/provider.go
@@ -2326,11 +2326,6 @@ func (e *Environ) SuperSubnets(ctx envcontext.ProviderCallContext) ([]string, er
 	return cidrs, nil
 }
 
-// AreSpacesRoutable is specified on environs.NetworkingEnviron.
-func (*Environ) AreSpacesRoutable(ctx envcontext.ProviderCallContext, space1, space2 *environs.ProviderSpaceInfo) (bool, error) {
-	return false, nil
-}
-
 // SupportsRulesWithIPV6CIDRs returns true if the environment supports ingress
 // rules containing IPV6 CIDRs. It is part of the FirewallFeatureQuerier
 // interface.

--- a/internal/provider/openstack/provider.go
+++ b/internal/provider/openstack/provider.go
@@ -2290,10 +2290,8 @@ func validateAuthURL(authURL string) error {
 }
 
 // Subnets is specified on environs.Networking.
-func (e *Environ) Subnets(
-	ctx envcontext.ProviderCallContext, instId instance.Id, subnetIds []network.Id,
-) ([]network.SubnetInfo, error) {
-	subnets, err := e.networking.Subnets(instId, subnetIds)
+func (e *Environ) Subnets(ctx envcontext.ProviderCallContext, subnetIds []network.Id) ([]network.SubnetInfo, error) {
+	subnets, err := e.networking.Subnets(instance.UnknownId, subnetIds)
 	if err != nil {
 		return subnets, e.HandleCredentialError(ctx, err)
 	}

--- a/internal/upgrades/upgradevalidation/mocks/lxd_mock.go
+++ b/internal/upgrades/upgradevalidation/mocks/lxd_mock.go
@@ -761,50 +761,6 @@ func (c *MockServerEnsureDefaultStorageCall) DoAndReturn(f func(*api.Profile, st
 	return c
 }
 
-// FilterContainers mocks base method.
-func (m *MockServer) FilterContainers(arg0 string, arg1 ...string) ([]lxd0.Container, error) {
-	m.ctrl.T.Helper()
-	varargs := []any{arg0}
-	for _, a := range arg1 {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "FilterContainers", varargs...)
-	ret0, _ := ret[0].([]lxd0.Container)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// FilterContainers indicates an expected call of FilterContainers.
-func (mr *MockServerMockRecorder) FilterContainers(arg0 any, arg1 ...any) *MockServerFilterContainersCall {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0}, arg1...)
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FilterContainers", reflect.TypeOf((*MockServer)(nil).FilterContainers), varargs...)
-	return &MockServerFilterContainersCall{Call: call}
-}
-
-// MockServerFilterContainersCall wrap *gomock.Call
-type MockServerFilterContainersCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockServerFilterContainersCall) Return(arg0 []lxd0.Container, arg1 error) *MockServerFilterContainersCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockServerFilterContainersCall) Do(f func(string, ...string) ([]lxd0.Container, error)) *MockServerFilterContainersCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockServerFilterContainersCall) DoAndReturn(f func(string, ...string) ([]lxd0.Container, error)) *MockServerFilterContainersCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // FindImage mocks base method.
 func (m *MockServer) FindImage(arg0 context.Context, arg1 base.Base, arg2 string, arg3 instance.VirtType, arg4 []lxd0.ServerSpec, arg5 bool, arg6 environs.StatusCallbackFunc) (lxd0.SourcedImage, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
No one actually calls `Subnets` with an instance ID, yet we do dances inside providers to accommodate it.

Here we remove the argument and its provider handling.

Logic for network detection fall-backs for old and unsupported versions of LXD are removed.

As a drive-by we remove all definitions of `AreSpacesRoutable` and `SuperSubnets` from providers. These methods were removed from the environs `Network` interface long since.

## QA steps

Bootstrap on LXD successfully.