### PR TITLE
feat: add public and private address retrieval for units

### DIFF
--- a/core/network/address_test.go
+++ b/core/network/address_test.go
@@ -1185,6 +1185,144 @@ func (s *AddressSuite) TestConvertToSpaceAddresses(c *gc.C) {
 	})
 }
 
+func (s *AddressSuite) TestSortOrderScope(c *gc.C) {
+	sas := network.SpaceAddresses{
+		{
+			MachineAddress: network.MachineAddress{
+				Value: "10.0.0.0",
+				Type:  network.IPv4Address,
+				Scope: network.ScopeCloudLocal,
+			},
+			Origin:  network.OriginMachine,
+			SpaceID: "0",
+		},
+		{
+			MachineAddress: network.MachineAddress{
+				Value: "10.0.0.1",
+				Type:  network.IPv4Address,
+				Scope: network.ScopePublic,
+			},
+			Origin:  network.OriginProvider,
+			SpaceID: "0",
+		},
+	}
+
+	sort.Sort(sas)
+	// Public addresses first.
+	c.Check(sas, gc.DeepEquals, network.SpaceAddresses{
+		{
+			MachineAddress: network.MachineAddress{
+				Value: "10.0.0.1",
+				Type:  network.IPv4Address,
+				Scope: network.ScopePublic,
+			},
+			Origin:  network.OriginProvider,
+			SpaceID: "0",
+		},
+		{
+			MachineAddress: network.MachineAddress{
+				Value: "10.0.0.0",
+				Type:  network.IPv4Address,
+				Scope: network.ScopeCloudLocal,
+			},
+			Origin:  network.OriginMachine,
+			SpaceID: "0",
+		},
+	})
+}
+
+func (s *AddressSuite) TestSortOrderSameScopeDiffOrigin(c *gc.C) {
+	sas := network.SpaceAddresses{
+		{
+			MachineAddress: network.MachineAddress{
+				Value: "10.0.0.0",
+				Type:  network.IPv4Address,
+				Scope: network.ScopePublic,
+			},
+			Origin:  network.OriginMachine,
+			SpaceID: "0",
+		},
+		{
+			MachineAddress: network.MachineAddress{
+				Value: "10.0.0.1",
+				Type:  network.IPv4Address,
+				Scope: network.ScopePublic,
+			},
+			Origin:  network.OriginProvider,
+			SpaceID: "0",
+		},
+	}
+
+	sort.Sort(sas)
+	// Public addresses first.
+	c.Check(sas, gc.DeepEquals, network.SpaceAddresses{
+		{
+			MachineAddress: network.MachineAddress{
+				Value: "10.0.0.1",
+				Type:  network.IPv4Address,
+				Scope: network.ScopePublic,
+			},
+			Origin:  network.OriginProvider,
+			SpaceID: "0",
+		},
+		{
+			MachineAddress: network.MachineAddress{
+				Value: "10.0.0.0",
+				Type:  network.IPv4Address,
+				Scope: network.ScopePublic,
+			},
+			Origin:  network.OriginMachine,
+			SpaceID: "0",
+		},
+	})
+}
+
+func (s *AddressSuite) TestSortOrderSameScopeSameOriginDiffValue(c *gc.C) {
+	sas := network.SpaceAddresses{
+		{
+			MachineAddress: network.MachineAddress{
+				Value: "10.0.0.0",
+				Type:  network.IPv4Address,
+				Scope: network.ScopePublic,
+			},
+			Origin:  network.OriginProvider,
+			SpaceID: "0",
+		},
+		{
+			MachineAddress: network.MachineAddress{
+				Value: "10.0.0.1",
+				Type:  network.IPv4Address,
+				Scope: network.ScopePublic,
+			},
+			Origin:  network.OriginProvider,
+			SpaceID: "0",
+		},
+	}
+
+	sort.Sort(sas)
+	// Public addresses first.
+	c.Check(sas, gc.DeepEquals, network.SpaceAddresses{
+		{
+			MachineAddress: network.MachineAddress{
+				Value: "10.0.0.0",
+				Type:  network.IPv4Address,
+				Scope: network.ScopePublic,
+			},
+			Origin:  network.OriginProvider,
+			SpaceID: "0",
+		},
+		{
+			MachineAddress: network.MachineAddress{
+				Value: "10.0.0.1",
+				Type:  network.IPv4Address,
+				Scope: network.ScopePublic,
+			},
+			Origin:  network.OriginProvider,
+			SpaceID: "0",
+		},
+	})
+}
+
 type testFindSubnetAddr struct {
 	val string
 }

--- a/domain/application/service/application.go
+++ b/domain/application/service/application.go
@@ -74,10 +74,6 @@ type ApplicationState interface {
 	// exist.
 	UpsertCloudService(ctx context.Context, appName, providerID string, sAddrs network.SpaceAddresses) error
 
-	// GetCloudServiceAddresses returns the addresses of the cloud service for the
-	// specified application.
-	GetCloudServiceAddresses(ctx context.Context, appUUID coreapplication.ID) (network.SpaceAddresses, error)
-
 	// GetUnitAddresses returns the addresses of the specified unit.
 	// The addresses are taken by unioning the net node UUIDs of the cloud service
 	// (if any) and the net node UUIDs of the unit, where each net node has an
@@ -797,22 +793,6 @@ func (s *Service) GetCharmByApplicationID(ctx context.Context, id coreapplicatio
 		&actions,
 		&lxdProfile,
 	), locator, nil
-}
-
-// GetCloudServiceAddresses returns the addresses of the cloud service for the
-// specified application, returning an error satisfying
-// [applicationerrors.ApplicationNotFoundError] if the application doesn't
-// exist.
-func (s *Service) GetCloudServiceAddresses(ctx context.Context, applicationName string) (network.SpaceAddresses, error) {
-	appUUID, err := s.st.GetApplicationIDByName(ctx, applicationName)
-	if err != nil {
-		return nil, errors.Capture(err)
-	}
-	addrs, err := s.st.GetCloudServiceAddresses(ctx, appUUID)
-	if err != nil {
-		return nil, errors.Capture(err)
-	}
-	return addrs, nil
 }
 
 // UpdateCloudService updates the cloud service for the specified application, returning an error

--- a/domain/application/service/application.go
+++ b/domain/application/service/application.go
@@ -78,12 +78,16 @@ type ApplicationState interface {
 	// specified application.
 	GetCloudServiceAddresses(ctx context.Context, appUUID coreapplication.ID) (network.SpaceAddresses, error)
 
-	// GetCloudContainerAddresses returns the addresses of the cloud container for the
-	// specified unit.
+	// GetUnitAddresses returns the addresses of the specified unit.
+	// The addresses are taken by unioning the net node UUIDs of the cloud service
+	// (if any) and the net node UUIDs of the unit, where each net node has an
+	// associated address.
+	// This apprach allows us to get the addresses regardless of the substrate
+	// (k8s or machines).
 	//
 	// The following errors may be returned:
 	// - [uniterrors.UnitNotFound] if the unit does not exist
-	GetCloudContainerAddresses(ctx context.Context, uuid coreunit.UUID) (network.SpaceAddresses, error)
+	GetUnitAddresses(ctx context.Context, uuid coreunit.UUID) (network.SpaceAddresses, error)
 
 	// GetApplicationScaleState looks up the scale state of the specified
 	// application, returning an error satisfying

--- a/domain/application/service/application_test.go
+++ b/domain/application/service/application_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/juju/juju/core/devices"
 	coreerrors "github.com/juju/juju/core/errors"
 	modeltesting "github.com/juju/juju/core/model/testing"
-	"github.com/juju/juju/core/network"
 	objectstoretesting "github.com/juju/juju/core/objectstore/testing"
 	corestorage "github.com/juju/juju/core/storage"
 	coreunit "github.com/juju/juju/core/unit"
@@ -985,69 +984,6 @@ func (s *applicationServiceSuite) TestGetDeviceConstraints(c *gc.C) {
 			Count: 42,
 		},
 	})
-}
-
-func (s *applicationServiceSuite) TestCloudServiceAddresses(c *gc.C) {
-	defer s.setupMocks(c).Finish()
-
-	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(coreapplication.ID("foo-uuid"), nil)
-	s.state.EXPECT().GetCloudServiceAddresses(gomock.Any(), coreapplication.ID("foo-uuid")).Return(network.SpaceAddresses{
-		network.SpaceAddress{
-			SpaceID: network.AlphaSpaceId,
-			Origin:  network.OriginProvider,
-			MachineAddress: network.MachineAddress{
-				Value:      "foo",
-				Type:       network.IPv4Address,
-				Scope:      network.ScopeLinkLocal,
-				ConfigType: network.ConfigDHCP,
-			},
-		},
-		network.SpaceAddress{
-			SpaceID: network.AlphaSpaceId,
-			Origin:  network.OriginProvider,
-			MachineAddress: network.MachineAddress{
-				Value:      "bar",
-				Type:       network.IPv6Address,
-				Scope:      network.ScopeCloudLocal,
-				ConfigType: network.ConfigManual,
-			},
-		},
-	}, nil)
-
-	addrs, err := s.service.GetCloudServiceAddresses(context.Background(), "foo")
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(addrs, gc.DeepEquals, network.SpaceAddresses{
-		network.SpaceAddress{
-			SpaceID: network.AlphaSpaceId,
-			Origin:  network.OriginProvider,
-			MachineAddress: network.MachineAddress{
-				Value:      "foo",
-				Type:       network.IPv4Address,
-				Scope:      network.ScopeLinkLocal,
-				ConfigType: network.ConfigDHCP,
-			},
-		},
-		network.SpaceAddress{
-			SpaceID: network.AlphaSpaceId,
-			Origin:  network.OriginProvider,
-			MachineAddress: network.MachineAddress{
-				Value:      "bar",
-				Type:       network.IPv6Address,
-				Scope:      network.ScopeCloudLocal,
-				ConfigType: network.ConfigManual,
-			},
-		},
-	})
-}
-
-func (s *applicationServiceSuite) TestCloudServiceAddressesNotFound(c *gc.C) {
-	defer s.setupMocks(c).Finish()
-
-	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(coreapplication.ID("foo-uuid"), nil)
-	s.state.EXPECT().GetCloudServiceAddresses(gomock.Any(), coreapplication.ID("foo-uuid")).Return(nil, errors.Errorf("%w", applicationerrors.ApplicationNotFound))
-
-	_, err := s.service.GetCloudServiceAddresses(context.Background(), "foo")
-	c.Assert(err, gc.ErrorMatches, applicationerrors.ApplicationNotFound.Error())
 }
 
 type applicationWatcherServiceSuite struct {

--- a/domain/application/service/application_test.go
+++ b/domain/application/service/application_test.go
@@ -990,8 +990,10 @@ func (s *applicationServiceSuite) TestGetDeviceConstraints(c *gc.C) {
 func (s *applicationServiceSuite) TestCloudServiceAddresses(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().CloudServiceAddresses(gomock.Any(), "foo").Return(network.SpaceAddresses{
+	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(coreapplication.ID("foo-uuid"), nil)
+	s.state.EXPECT().GetCloudServiceAddresses(gomock.Any(), coreapplication.ID("foo-uuid")).Return(network.SpaceAddresses{
 		network.SpaceAddress{
+			SpaceID: network.AlphaSpaceId,
 			MachineAddress: network.MachineAddress{
 				Value:      "foo",
 				Type:       network.IPv4Address,
@@ -1000,6 +1002,7 @@ func (s *applicationServiceSuite) TestCloudServiceAddresses(c *gc.C) {
 			},
 		},
 		network.SpaceAddress{
+			SpaceID: network.AlphaSpaceId,
 			MachineAddress: network.MachineAddress{
 				Value:      "bar",
 				Type:       network.IPv6Address,
@@ -1009,10 +1012,11 @@ func (s *applicationServiceSuite) TestCloudServiceAddresses(c *gc.C) {
 		},
 	}, nil)
 
-	addrs, err := s.service.CloudServiceAddresses(context.Background(), "foo")
+	addrs, err := s.service.GetCloudServiceAddresses(context.Background(), "foo")
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(addrs, gc.DeepEquals, network.SpaceAddresses{
 		network.SpaceAddress{
+			SpaceID: network.AlphaSpaceId,
 			MachineAddress: network.MachineAddress{
 				Value:      "foo",
 				Type:       network.IPv4Address,
@@ -1021,6 +1025,7 @@ func (s *applicationServiceSuite) TestCloudServiceAddresses(c *gc.C) {
 			},
 		},
 		network.SpaceAddress{
+			SpaceID: network.AlphaSpaceId,
 			MachineAddress: network.MachineAddress{
 				Value:      "bar",
 				Type:       network.IPv6Address,
@@ -1034,9 +1039,10 @@ func (s *applicationServiceSuite) TestCloudServiceAddresses(c *gc.C) {
 func (s *applicationServiceSuite) TestCloudServiceAddressesNotFound(c *gc.C) {
 	defer s.setupMocks(c).Finish()
 
-	s.state.EXPECT().CloudServiceAddresses(gomock.Any(), "foo").Return(nil, errors.Errorf("%w", applicationerrors.ApplicationNotFound))
+	s.state.EXPECT().GetApplicationIDByName(gomock.Any(), "foo").Return(coreapplication.ID("foo-uuid"), nil)
+	s.state.EXPECT().GetCloudServiceAddresses(gomock.Any(), coreapplication.ID("foo-uuid")).Return(nil, errors.Errorf("%w", applicationerrors.ApplicationNotFound))
 
-	_, err := s.service.CloudServiceAddresses(context.Background(), "foo")
+	_, err := s.service.GetCloudServiceAddresses(context.Background(), "foo")
 	c.Assert(err, gc.ErrorMatches, applicationerrors.ApplicationNotFound.Error())
 }
 

--- a/domain/application/service/application_test.go
+++ b/domain/application/service/application_test.go
@@ -994,6 +994,7 @@ func (s *applicationServiceSuite) TestCloudServiceAddresses(c *gc.C) {
 	s.state.EXPECT().GetCloudServiceAddresses(gomock.Any(), coreapplication.ID("foo-uuid")).Return(network.SpaceAddresses{
 		network.SpaceAddress{
 			SpaceID: network.AlphaSpaceId,
+			Origin:  network.OriginProvider,
 			MachineAddress: network.MachineAddress{
 				Value:      "foo",
 				Type:       network.IPv4Address,
@@ -1003,6 +1004,7 @@ func (s *applicationServiceSuite) TestCloudServiceAddresses(c *gc.C) {
 		},
 		network.SpaceAddress{
 			SpaceID: network.AlphaSpaceId,
+			Origin:  network.OriginProvider,
 			MachineAddress: network.MachineAddress{
 				Value:      "bar",
 				Type:       network.IPv6Address,
@@ -1017,6 +1019,7 @@ func (s *applicationServiceSuite) TestCloudServiceAddresses(c *gc.C) {
 	c.Check(addrs, gc.DeepEquals, network.SpaceAddresses{
 		network.SpaceAddress{
 			SpaceID: network.AlphaSpaceId,
+			Origin:  network.OriginProvider,
 			MachineAddress: network.MachineAddress{
 				Value:      "foo",
 				Type:       network.IPv4Address,
@@ -1026,6 +1029,7 @@ func (s *applicationServiceSuite) TestCloudServiceAddresses(c *gc.C) {
 		},
 		network.SpaceAddress{
 			SpaceID: network.AlphaSpaceId,
+			Origin:  network.OriginProvider,
 			MachineAddress: network.MachineAddress{
 				Value:      "bar",
 				Type:       network.IPv6Address,

--- a/domain/application/service/package_mock_test.go
+++ b/domain/application/service/package_mock_test.go
@@ -2026,45 +2026,6 @@ func (c *MockStateGetCharmModifiedVersionCall) DoAndReturn(f func(context.Contex
 	return c
 }
 
-// GetCloudContainerAddresses mocks base method.
-func (m *MockState) GetCloudContainerAddresses(ctx context.Context, uuid unit.UUID) (network.SpaceAddresses, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCloudContainerAddresses", ctx, uuid)
-	ret0, _ := ret[0].(network.SpaceAddresses)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetCloudContainerAddresses indicates an expected call of GetCloudContainerAddresses.
-func (mr *MockStateMockRecorder) GetCloudContainerAddresses(ctx, uuid any) *MockStateGetCloudContainerAddressesCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCloudContainerAddresses", reflect.TypeOf((*MockState)(nil).GetCloudContainerAddresses), ctx, uuid)
-	return &MockStateGetCloudContainerAddressesCall{Call: call}
-}
-
-// MockStateGetCloudContainerAddressesCall wrap *gomock.Call
-type MockStateGetCloudContainerAddressesCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockStateGetCloudContainerAddressesCall) Return(arg0 network.SpaceAddresses, arg1 error) *MockStateGetCloudContainerAddressesCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockStateGetCloudContainerAddressesCall) Do(f func(context.Context, unit.UUID) (network.SpaceAddresses, error)) *MockStateGetCloudContainerAddressesCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetCloudContainerAddressesCall) DoAndReturn(f func(context.Context, unit.UUID) (network.SpaceAddresses, error)) *MockStateGetCloudContainerAddressesCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // GetCloudServiceAddresses mocks base method.
 func (m *MockState) GetCloudServiceAddresses(ctx context.Context, appUUID application.ID) (network.SpaceAddresses, error) {
 	m.ctrl.T.Helper()
@@ -2490,6 +2451,45 @@ func (c *MockStateGetStorageUUIDByIDCall) Do(f func(context.Context, storage.ID)
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockStateGetStorageUUIDByIDCall) DoAndReturn(f func(context.Context, storage.ID) (storage.UUID, error)) *MockStateGetStorageUUIDByIDCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetUnitAddresses mocks base method.
+func (m *MockState) GetUnitAddresses(ctx context.Context, uuid unit.UUID) (network.SpaceAddresses, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUnitAddresses", ctx, uuid)
+	ret0, _ := ret[0].(network.SpaceAddresses)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUnitAddresses indicates an expected call of GetUnitAddresses.
+func (mr *MockStateMockRecorder) GetUnitAddresses(ctx, uuid any) *MockStateGetUnitAddressesCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnitAddresses", reflect.TypeOf((*MockState)(nil).GetUnitAddresses), ctx, uuid)
+	return &MockStateGetUnitAddressesCall{Call: call}
+}
+
+// MockStateGetUnitAddressesCall wrap *gomock.Call
+type MockStateGetUnitAddressesCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateGetUnitAddressesCall) Return(arg0 network.SpaceAddresses, arg1 error) *MockStateGetUnitAddressesCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateGetUnitAddressesCall) Do(f func(context.Context, unit.UUID) (network.SpaceAddresses, error)) *MockStateGetUnitAddressesCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateGetUnitAddressesCall) DoAndReturn(f func(context.Context, unit.UUID) (network.SpaceAddresses, error)) *MockStateGetUnitAddressesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/application/service/package_mock_test.go
+++ b/domain/application/service/package_mock_test.go
@@ -264,45 +264,6 @@ func (c *MockStateAttachStorageCall) DoAndReturn(f func(context.Context, string,
 	return c
 }
 
-// CloudServiceAddresses mocks base method.
-func (m *MockState) CloudServiceAddresses(ctx context.Context, applicationName string) (network.SpaceAddresses, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CloudServiceAddresses", ctx, applicationName)
-	ret0, _ := ret[0].(network.SpaceAddresses)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CloudServiceAddresses indicates an expected call of CloudServiceAddresses.
-func (mr *MockStateMockRecorder) CloudServiceAddresses(ctx, applicationName any) *MockStateCloudServiceAddressesCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloudServiceAddresses", reflect.TypeOf((*MockState)(nil).CloudServiceAddresses), ctx, applicationName)
-	return &MockStateCloudServiceAddressesCall{Call: call}
-}
-
-// MockStateCloudServiceAddressesCall wrap *gomock.Call
-type MockStateCloudServiceAddressesCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockStateCloudServiceAddressesCall) Return(arg0 network.SpaceAddresses, arg1 error) *MockStateCloudServiceAddressesCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockStateCloudServiceAddressesCall) Do(f func(context.Context, string) (network.SpaceAddresses, error)) *MockStateCloudServiceAddressesCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateCloudServiceAddressesCall) DoAndReturn(f func(context.Context, string) (network.SpaceAddresses, error)) *MockStateCloudServiceAddressesCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // CreateApplication mocks base method.
 func (m *MockState) CreateApplication(arg0 context.Context, arg1 string, arg2 application0.AddApplicationArg, arg3 []application0.AddUnitArg) (application.ID, error) {
 	m.ctrl.T.Helper()
@@ -2061,6 +2022,84 @@ func (c *MockStateGetCharmModifiedVersionCall) Do(f func(context.Context, applic
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockStateGetCharmModifiedVersionCall) DoAndReturn(f func(context.Context, application.ID) (int, error)) *MockStateGetCharmModifiedVersionCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetCloudContainerAddresses mocks base method.
+func (m *MockState) GetCloudContainerAddresses(ctx context.Context, uuid unit.UUID) (network.SpaceAddresses, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCloudContainerAddresses", ctx, uuid)
+	ret0, _ := ret[0].(network.SpaceAddresses)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetCloudContainerAddresses indicates an expected call of GetCloudContainerAddresses.
+func (mr *MockStateMockRecorder) GetCloudContainerAddresses(ctx, uuid any) *MockStateGetCloudContainerAddressesCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCloudContainerAddresses", reflect.TypeOf((*MockState)(nil).GetCloudContainerAddresses), ctx, uuid)
+	return &MockStateGetCloudContainerAddressesCall{Call: call}
+}
+
+// MockStateGetCloudContainerAddressesCall wrap *gomock.Call
+type MockStateGetCloudContainerAddressesCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateGetCloudContainerAddressesCall) Return(arg0 network.SpaceAddresses, arg1 error) *MockStateGetCloudContainerAddressesCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateGetCloudContainerAddressesCall) Do(f func(context.Context, unit.UUID) (network.SpaceAddresses, error)) *MockStateGetCloudContainerAddressesCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateGetCloudContainerAddressesCall) DoAndReturn(f func(context.Context, unit.UUID) (network.SpaceAddresses, error)) *MockStateGetCloudContainerAddressesCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetCloudServiceAddresses mocks base method.
+func (m *MockState) GetCloudServiceAddresses(ctx context.Context, appUUID application.ID) (network.SpaceAddresses, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCloudServiceAddresses", ctx, appUUID)
+	ret0, _ := ret[0].(network.SpaceAddresses)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetCloudServiceAddresses indicates an expected call of GetCloudServiceAddresses.
+func (mr *MockStateMockRecorder) GetCloudServiceAddresses(ctx, appUUID any) *MockStateGetCloudServiceAddressesCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCloudServiceAddresses", reflect.TypeOf((*MockState)(nil).GetCloudServiceAddresses), ctx, appUUID)
+	return &MockStateGetCloudServiceAddressesCall{Call: call}
+}
+
+// MockStateGetCloudServiceAddressesCall wrap *gomock.Call
+type MockStateGetCloudServiceAddressesCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateGetCloudServiceAddressesCall) Return(arg0 network.SpaceAddresses, arg1 error) *MockStateGetCloudServiceAddressesCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateGetCloudServiceAddressesCall) Do(f func(context.Context, application.ID) (network.SpaceAddresses, error)) *MockStateGetCloudServiceAddressesCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateGetCloudServiceAddressesCall) DoAndReturn(f func(context.Context, application.ID) (network.SpaceAddresses, error)) *MockStateGetCloudServiceAddressesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/application/service/package_mock_test.go
+++ b/domain/application/service/package_mock_test.go
@@ -2026,45 +2026,6 @@ func (c *MockStateGetCharmModifiedVersionCall) DoAndReturn(f func(context.Contex
 	return c
 }
 
-// GetCloudServiceAddresses mocks base method.
-func (m *MockState) GetCloudServiceAddresses(ctx context.Context, appUUID application.ID) (network.SpaceAddresses, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCloudServiceAddresses", ctx, appUUID)
-	ret0, _ := ret[0].(network.SpaceAddresses)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetCloudServiceAddresses indicates an expected call of GetCloudServiceAddresses.
-func (mr *MockStateMockRecorder) GetCloudServiceAddresses(ctx, appUUID any) *MockStateGetCloudServiceAddressesCall {
-	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCloudServiceAddresses", reflect.TypeOf((*MockState)(nil).GetCloudServiceAddresses), ctx, appUUID)
-	return &MockStateGetCloudServiceAddressesCall{Call: call}
-}
-
-// MockStateGetCloudServiceAddressesCall wrap *gomock.Call
-type MockStateGetCloudServiceAddressesCall struct {
-	*gomock.Call
-}
-
-// Return rewrite *gomock.Call.Return
-func (c *MockStateGetCloudServiceAddressesCall) Return(arg0 network.SpaceAddresses, arg1 error) *MockStateGetCloudServiceAddressesCall {
-	c.Call = c.Call.Return(arg0, arg1)
-	return c
-}
-
-// Do rewrite *gomock.Call.Do
-func (c *MockStateGetCloudServiceAddressesCall) Do(f func(context.Context, application.ID) (network.SpaceAddresses, error)) *MockStateGetCloudServiceAddressesCall {
-	c.Call = c.Call.Do(f)
-	return c
-}
-
-// DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockStateGetCloudServiceAddressesCall) DoAndReturn(f func(context.Context, application.ID) (network.SpaceAddresses, error)) *MockStateGetCloudServiceAddressesCall {
-	c.Call = c.Call.DoAndReturn(f)
-	return c
-}
-
 // GetDeviceConstraints mocks base method.
 func (m *MockState) GetDeviceConstraints(ctx context.Context, appID application.ID) (map[string]devices.Constraints, error) {
 	m.ctrl.T.Helper()

--- a/domain/application/service/unit.go
+++ b/domain/application/service/unit.go
@@ -5,7 +5,6 @@ package service
 
 import (
 	"context"
-	"fmt"
 	"sort"
 
 	coreapplication "github.com/juju/juju/core/application"
@@ -564,7 +563,7 @@ func (s *Service) GetUnitWorkloadVersion(ctx context.Context, unitName coreunit.
 	return version, nil
 }
 
-// GetPublicAddress returns the public address for the specified unit.
+// GetUnitPublicAddress returns the public address for the specified unit.
 // For k8s provider, it will return the first public address of the cloud
 // service if any, the first public address of the cloud container otherwise.
 // For machines provider, it will return the first public address of the
@@ -584,14 +583,11 @@ func (s *Service) GetUnitPublicAddress(ctx context.Context, unitName coreunit.Na
 	}
 
 	// First match the scope, then sort by origin.
-	matchedAddrs := addrs.AllMatchingScope(network.ScopeMatchCloudLocal)
-	fmt.Printf("out addrs: %v\n", addrs)
-	fmt.Printf("matched addrs: %v\n", matchedAddrs)
+	matchedAddrs := addrs.AllMatchingScope(network.ScopeMatchPublic)
 	if len(matchedAddrs) == 0 {
 		return network.SpaceAddress{}, network.NoAddressError(string(network.ScopePublic))
 	}
 	sort.Slice(matchedAddrs, matchedAddrs.Less)
-	fmt.Printf("sorted addrs: %v\n", matchedAddrs)
 
 	return matchedAddrs[0], nil
 }

--- a/domain/application/service/unit_test.go
+++ b/domain/application/service/unit_test.go
@@ -628,7 +628,7 @@ func (s *unitServiceSuite) TestGetPublicAddressNonMatchingAddresses(c *gc.C) {
 			MachineAddress: network.MachineAddress{
 				Value:      "10.0.0.2",
 				ConfigType: network.ConfigDHCP,
-				Type:       network.IPv6Address,
+				Type:       network.IPv4Address,
 				Scope:      network.ScopeMachineLocal,
 			},
 		},
@@ -646,7 +646,7 @@ func (s *unitServiceSuite) TestGetPublicAddressNonMatchingAddresses(c *gc.C) {
 			MachineAddress: network.MachineAddress{
 				Value:      "10.0.1.2",
 				ConfigType: network.ConfigDHCP,
-				Type:       network.IPv6Address,
+				Type:       network.IPv4Address,
 				Scope:      network.ScopeMachineLocal,
 			},
 		},
@@ -679,8 +679,17 @@ func (s *unitServiceSuite) TestGetPublicAddressMatchingAddress(c *gc.C) {
 			MachineAddress: network.MachineAddress{
 				Value:      "54.32.1.2",
 				ConfigType: network.ConfigDHCP,
-				Type:       network.IPv6Address,
+				Type:       network.IPv4Address,
 				Scope:      network.ScopePublic,
+			},
+		},
+		{
+			SpaceID: network.AlphaSpaceId,
+			MachineAddress: network.MachineAddress{
+				Value:      "54.32.1.3",
+				ConfigType: network.ConfigDHCP,
+				Type:       network.IPv4Address,
+				Scope:      network.ScopeCloudLocal,
 			},
 		},
 	}
@@ -717,7 +726,7 @@ func (s *unitServiceSuite) TestGetPublicAddressMatchingAddressSameOrigin(c *gc.C
 			MachineAddress: network.MachineAddress{
 				Value:      "54.32.1.2",
 				ConfigType: network.ConfigDHCP,
-				Type:       network.IPv6Address,
+				Type:       network.IPv4Address,
 				Scope:      network.ScopePublic,
 			},
 		},
@@ -727,7 +736,7 @@ func (s *unitServiceSuite) TestGetPublicAddressMatchingAddressSameOrigin(c *gc.C
 			MachineAddress: network.MachineAddress{
 				Value:      "54.32.1.3",
 				ConfigType: network.ConfigDHCP,
-				Type:       network.IPv6Address,
+				Type:       network.IPv4Address,
 				Scope:      network.ScopePublic,
 			},
 		},
@@ -765,7 +774,7 @@ func (s *unitServiceSuite) TestGetPublicAddressMatchingAddressOneProviderOnly(c 
 			MachineAddress: network.MachineAddress{
 				Value:      "54.32.1.2",
 				ConfigType: network.ConfigDHCP,
-				Type:       network.IPv6Address,
+				Type:       network.IPv4Address,
 				Scope:      network.ScopePublic,
 			},
 		},
@@ -775,7 +784,7 @@ func (s *unitServiceSuite) TestGetPublicAddressMatchingAddressOneProviderOnly(c 
 			MachineAddress: network.MachineAddress{
 				Value:      "54.32.1.3",
 				ConfigType: network.ConfigDHCP,
-				Type:       network.IPv6Address,
+				Type:       network.IPv4Address,
 				Scope:      network.ScopePublic,
 			},
 		},
@@ -813,7 +822,7 @@ func (s *unitServiceSuite) TestGetPublicAddressMatchingAddressOneProviderOtherUn
 			MachineAddress: network.MachineAddress{
 				Value:      "54.32.1.2",
 				ConfigType: network.ConfigDHCP,
-				Type:       network.IPv6Address,
+				Type:       network.IPv4Address,
 				Scope:      network.ScopePublic,
 			},
 		},
@@ -823,7 +832,7 @@ func (s *unitServiceSuite) TestGetPublicAddressMatchingAddressOneProviderOtherUn
 			MachineAddress: network.MachineAddress{
 				Value:      "54.32.1.3",
 				ConfigType: network.ConfigDHCP,
-				Type:       network.IPv6Address,
+				Type:       network.IPv4Address,
 				Scope:      network.ScopePublic,
 			},
 		},
@@ -882,7 +891,7 @@ func (s *unitServiceSuite) TestGetPrivateAddressNonMatchingAddresses(c *gc.C) {
 			MachineAddress: network.MachineAddress{
 				Value:      "10.0.0.2",
 				ConfigType: network.ConfigDHCP,
-				Type:       network.IPv6Address,
+				Type:       network.IPv4Address,
 				Scope:      network.ScopeMachineLocal,
 			},
 		},
@@ -900,7 +909,7 @@ func (s *unitServiceSuite) TestGetPrivateAddressNonMatchingAddresses(c *gc.C) {
 			MachineAddress: network.MachineAddress{
 				Value:      "10.0.1.2",
 				ConfigType: network.ConfigDHCP,
-				Type:       network.IPv6Address,
+				Type:       network.IPv4Address,
 				Scope:      network.ScopeMachineLocal,
 			},
 		},
@@ -945,7 +954,7 @@ func (s *unitServiceSuite) TestGetPrivateAddressMatchingAddress(c *gc.C) {
 			MachineAddress: network.MachineAddress{
 				Value:      "10.0.0.2",
 				ConfigType: network.ConfigDHCP,
-				Type:       network.IPv6Address,
+				Type:       network.IPv4Address,
 				Scope:      network.ScopeMachineLocal,
 			},
 		},

--- a/domain/application/state/application.go
+++ b/domain/application/state/application.go
@@ -2968,6 +2968,7 @@ func encodeIpAddress(address spaceAddress) network.SpaceAddress {
 	}
 	return network.SpaceAddress{
 		SpaceID: spaceUUID,
+		Origin:  ipaddress.UnMarshallOrigin(ipaddress.Origin(address.OriginID)),
 		// TODO(nvinuesa): The subnet CIDR is not inserted. This should be
 		// done when migrating machines to dqlite and rework the
 		// MachineAddress modelling so it takes a subnet UUID instead of a

--- a/domain/application/state/application.go
+++ b/domain/application/state/application.go
@@ -2956,25 +2956,29 @@ func encodeConstraints(constraintUUID string, cons constraints.Constraints, cont
 func encodeIpAddresses(addresses []spaceAddress) network.SpaceAddresses {
 	res := make(network.SpaceAddresses, len(addresses))
 	for i, addr := range addresses {
-		spaceUUID := network.AlphaSpaceId
-		if addr.SpaceUUID.Valid {
-			spaceUUID = addr.SpaceUUID.String
-		}
-		res[i] = network.SpaceAddress{
-			SpaceID: spaceUUID,
-			// TODO(nvinuesa): The subnet CIDR is not inserted. This should be
-			// done when migrating machines to dqlite and rework the
-			// MachineAddress modelling so it takes a subnet UUID instead of a
-			// CIDR.
-			MachineAddress: network.MachineAddress{
-				Value:      addr.Value,
-				Type:       ipaddress.UnMarshallAddressType(ipaddress.AddressType(addr.TypeID)),
-				Scope:      ipaddress.UnMarshallScope(ipaddress.Scope(addr.ScopeID)),
-				ConfigType: ipaddress.UnMarshallConfigType(ipaddress.ConfigType(addr.ConfigTypeID)),
-			},
-		}
+		res[i] = encodeIpAddress(addr)
 	}
 	return res
+}
+
+func encodeIpAddress(address spaceAddress) network.SpaceAddress {
+	spaceUUID := network.AlphaSpaceId
+	if address.SpaceUUID.Valid {
+		spaceUUID = address.SpaceUUID.String
+	}
+	return network.SpaceAddress{
+		SpaceID: spaceUUID,
+		// TODO(nvinuesa): The subnet CIDR is not inserted. This should be
+		// done when migrating machines to dqlite and rework the
+		// MachineAddress modelling so it takes a subnet UUID instead of a
+		// CIDR.
+		MachineAddress: network.MachineAddress{
+			Value:      address.Value,
+			Type:       ipaddress.UnMarshallAddressType(ipaddress.AddressType(address.TypeID)),
+			Scope:      ipaddress.UnMarshallScope(ipaddress.Scope(address.ScopeID)),
+			ConfigType: ipaddress.UnMarshallConfigType(ipaddress.ConfigType(address.ConfigTypeID)),
+		},
+	}
 }
 
 // lookupApplication looks up the application by name and returns the

--- a/domain/application/state/application_test.go
+++ b/domain/application/state/application_test.go
@@ -1131,6 +1131,7 @@ func (s *applicationStateSuite) TestCloudServiceAddresses(c *gc.C) {
 	expectedAddresses := network.SpaceAddresses{
 		{
 			SpaceID: network.AlphaSpaceId,
+			Origin:  network.OriginProvider,
 			MachineAddress: network.MachineAddress{
 				Value:      "10.0.0.1",
 				ConfigType: network.ConfigStatic,
@@ -1140,6 +1141,7 @@ func (s *applicationStateSuite) TestCloudServiceAddresses(c *gc.C) {
 		},
 		{
 			SpaceID: network.AlphaSpaceId,
+			Origin:  network.OriginProvider,
 			MachineAddress: network.MachineAddress{
 				Value:      "10.0.0.2",
 				ConfigType: network.ConfigDHCP,

--- a/domain/application/state/application_test.go
+++ b/domain/application/state/application_test.go
@@ -1126,9 +1126,29 @@ func (s *applicationStateSuite) TestUpsertCloudServiceNotFound(c *gc.C) {
 }
 
 func (s *applicationStateSuite) TestCloudServiceAddresses(c *gc.C) {
-	s.createApplication(c, "foo", life.Alive)
+	appID := s.createApplication(c, "foo", life.Alive)
 
 	expectedAddresses := network.SpaceAddresses{
+		{
+			SpaceID: network.AlphaSpaceId,
+			MachineAddress: network.MachineAddress{
+				Value:      "10.0.0.1",
+				ConfigType: network.ConfigStatic,
+				Type:       network.IPv4Address,
+				Scope:      network.ScopeCloudLocal,
+			},
+		},
+		{
+			SpaceID: network.AlphaSpaceId,
+			MachineAddress: network.MachineAddress{
+				Value:      "10.0.0.2",
+				ConfigType: network.ConfigDHCP,
+				Type:       network.IPv6Address,
+				Scope:      network.ScopeLinkLocal,
+			},
+		},
+	}
+	err := s.state.UpsertCloudService(context.Background(), "foo", "provider-id", network.SpaceAddresses{
 		{
 			MachineAddress: network.MachineAddress{
 				Value:      "10.0.0.1",
@@ -1145,19 +1165,13 @@ func (s *applicationStateSuite) TestCloudServiceAddresses(c *gc.C) {
 				Scope:      network.ScopeLinkLocal,
 			},
 		},
-	}
-	err := s.state.UpsertCloudService(context.Background(), "foo", "provider-id", expectedAddresses)
+	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	addresses, err := s.state.CloudServiceAddresses(context.Background(), "foo")
+	addresses, err := s.state.GetCloudServiceAddresses(context.Background(), appID)
 	c.Assert(err, jc.ErrorIsNil)
 	c.Check(addresses, gc.HasLen, 2)
 	c.Check(addresses, gc.DeepEquals, expectedAddresses)
-}
-
-func (s *applicationStateSuite) TestCloudServiceAddressesNotFound(c *gc.C) {
-	_, err := s.state.CloudServiceAddresses(context.Background(), "unknown-app")
-	c.Assert(err, jc.ErrorIs, applicationerrors.ApplicationNotFound)
 }
 
 func (s *applicationStateSuite) TestGetApplicationIDByUnitName(c *gc.C) {

--- a/domain/application/state/types.go
+++ b/domain/application/state/types.go
@@ -197,10 +197,13 @@ type ipAddress struct {
 }
 
 type spaceAddress struct {
-	Value     string         `db:"address_value"`
-	TypeID    int            `db:"type_id"`
-	ScopeID   int            `db:"scope_id"`
-	SpaceUUID sql.NullString `db:"space_uuid"`
+	Value        string         `db:"address_value"`
+	ConfigTypeID int            `db:"config_type_id"`
+	TypeID       int            `db:"type_id"`
+	OriginID     int            `db:"origin_id"`
+	ScopeID      int            `db:"scope_id"`
+	DeviceID     string         `db:"device_uuid"`
+	SpaceUUID    sql.NullString `db:"space_uuid"`
 }
 
 // These structs represent the persistent charm schema in the database.

--- a/domain/application/state/unit_test.go
+++ b/domain/application/state/unit_test.go
@@ -1374,7 +1374,7 @@ func (s *unitStateSuite) TestGetUnitAddressesIncludingK8sService(c *gc.C) {
 			return err
 		}
 		insertIPAddress1 := `INSERT INTO ip_address (uuid, device_uuid, address_value, type_id, scope_id, origin_id, config_type_id, subnet_uuid) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
-		_, err = tx.ExecContext(ctx, insertIPAddress1, "ip-address1-uuid", "lld1-uuid", "10.0.0.2", 0, 1, 0, 1, "subnet-uuid")
+		_, err = tx.ExecContext(ctx, insertIPAddress1, "ip-address1-uuid", "lld1-uuid", "10.0.0.2", 0, 1, 1, 1, "subnet-uuid")
 		if err != nil {
 			return err
 		}
@@ -1387,6 +1387,7 @@ func (s *unitStateSuite) TestGetUnitAddressesIncludingK8sService(c *gc.C) {
 	c.Check(addr, gc.DeepEquals, network.SpaceAddresses{
 		{
 			SpaceID: "space0-uuid",
+			Origin:  network.OriginMachine,
 			MachineAddress: network.MachineAddress{
 				Value:      "10.0.0.1",
 				Type:       network.IPv4Address,
@@ -1396,6 +1397,7 @@ func (s *unitStateSuite) TestGetUnitAddressesIncludingK8sService(c *gc.C) {
 		},
 		{
 			SpaceID: "space0-uuid",
+			Origin:  network.OriginProvider,
 			MachineAddress: network.MachineAddress{
 				Value:      "10.0.0.2",
 				Type:       network.IPv4Address,
@@ -1440,7 +1442,7 @@ func (s *unitStateSuite) TestGetUnitAddressesWithoutK8sService(c *gc.C) {
 			return err
 		}
 		insertIPAddress0 := `INSERT INTO ip_address (uuid, device_uuid, address_value, type_id, scope_id, origin_id, config_type_id, subnet_uuid) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
-		_, err = tx.ExecContext(ctx, insertIPAddress0, "ip-address0-uuid", "lld0-uuid", "10.0.0.1", 0, 3, 0, 1, "subnet-uuid")
+		_, err = tx.ExecContext(ctx, insertIPAddress0, "ip-address0-uuid", "lld0-uuid", "10.0.0.1", 0, 3, 1, 1, "subnet-uuid")
 		if err != nil {
 			return err
 		}
@@ -1453,6 +1455,7 @@ func (s *unitStateSuite) TestGetUnitAddressesWithoutK8sService(c *gc.C) {
 	c.Check(addr, gc.DeepEquals, network.SpaceAddresses{
 		{
 			SpaceID: "space0-uuid",
+			Origin:  network.OriginProvider,
 			MachineAddress: network.MachineAddress{
 				Value:      "10.0.0.1",
 				Type:       network.IPv4Address,

--- a/domain/ipaddress/ipaddress_test.go
+++ b/domain/ipaddress/ipaddress_test.go
@@ -115,7 +115,7 @@ func (s *ipAddressSuite) TestOriginDBValues(c *gc.C) {
 		dbValues[Origin(id)] = name
 	}
 	c.Assert(dbValues, jc.DeepEquals, map[Origin]string{
-		OriginHost:     "host",
+		OriginHost:     "machine",
 		OriginProvider: "provider",
 	})
 }

--- a/domain/schema/model/sql/0021-network.sql
+++ b/domain/schema/model/sql/0021-network.sql
@@ -137,7 +137,7 @@ CREATE UNIQUE INDEX idx_ip_address_origin_name
 ON ip_address_origin (name);
 
 INSERT INTO ip_address_origin VALUES
-(0, 'host'),
+(0, 'machine'),
 (1, 'provider');
 
 -- ip_address_scope denotes the context an ip address may apply to.


### PR DESCRIPTION
This patch adds the GetPublicAddress and GetPrivateAddress service methods to the application domain, which retrieve the public and private addresses for a unit name.
This methods are only used for k8s provider for the moment, because in the future we'll also retrieve the machine addresses inside these methods. But we need to finish migrating machines to dqlite first.



## QA steps

Nothing wired yet, unit tests should pass.

## Links

**Jira card:** JUJU-7856
