### PR TITLE
feat: view and data type for machine interfaces

### DIFF
--- a/domain/network/state/linklayer_test.go
+++ b/domain/network/state/linklayer_test.go
@@ -1,0 +1,94 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package state
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/canonical/sqlair"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/juju/core/network"
+	schematesting "github.com/juju/juju/domain/schema/testing"
+)
+
+type linkLayerSuite struct {
+	schematesting.ModelSuite
+}
+
+var _ = gc.Suite(&linkLayerSuite{})
+
+func (s *linkLayerSuite) TestMachineInterfaceViewFitsType(c *gc.C) {
+	db, err := s.TxnRunnerFactory()()
+	c.Assert(err, jc.ErrorIsNil)
+
+	nodeUUID := "net-node-uuid"
+	machineUUID := "machine-uuid"
+	machineName := "0"
+	devUUID := "dev-uuid"
+	devName := "eth0"
+	subUUID := "sub-uuid"
+	addrUUID := "addr-uuid"
+
+	ctx := context.Background()
+
+	err = db.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		if _, err := tx.ExecContext(ctx, "INSERT INTO net_node (uuid) VALUES (?)", nodeUUID); err != nil {
+			return err
+		}
+
+		if _, err := tx.ExecContext(ctx, "INSERT INTO machine (uuid, net_node_uuid, name, life_id) VALUES (?, ?, ? ,?)",
+			machineUUID, nodeUUID, machineName, 0,
+		); err != nil {
+			return err
+		}
+
+		insertLLD := `
+INSERT INTO link_layer_device (uuid, net_node_uuid, name, mtu, mac_address, device_type_id, virtual_port_type_id) 
+VALUES (?, ?, ?, ?, ?, ?, ?)`
+
+		if _, err = tx.ExecContext(ctx, insertLLD, devUUID, nodeUUID, devName, 1500, "00:11:22:33:44:55", 0, 0); err != nil {
+			return err
+		}
+
+		if _, err = tx.ExecContext(ctx, "INSERT INTO subnet (uuid, cidr, space_uuid) VALUES (?, ?, ?)",
+			subUUID, "10.0.0.0/24", network.AlphaSpaceId,
+		); err != nil {
+			return err
+		}
+
+		insertIPAddress := `
+INSERT INTO ip_address (uuid, device_uuid, address_value, type_id, scope_id, origin_id, config_type_id, subnet_uuid) 
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+
+		_, err = tx.ExecContext(ctx, insertIPAddress, addrUUID, devUUID, "10.0.0.1", 0, 0, 0, 0, subUUID)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	stmt, err := sqlair.Prepare("SELECT &machineInterfaceRow.* FROM v_machine_interface", machineInterfaceRow{})
+	c.Assert(err, jc.ErrorIsNil)
+
+	var rows []machineInterfaceRow
+	err = db.Txn(ctx, func(ctx context.Context, txn *sqlair.TX) error {
+		return txn.Query(ctx, stmt).GetAll(&rows)
+	})
+	c.Assert(err, jc.ErrorIsNil)
+
+	c.Assert(rows, gc.HasLen, 1)
+
+	r := rows[0]
+	c.Check(r.MachineUUID, gc.Equals, machineUUID)
+	c.Check(r.MachineName, gc.Equals, machineName)
+	c.Check(r.DeviceUUID, gc.Equals, devUUID)
+	c.Check(r.DeviceName, gc.Equals, devName)
+	c.Check(r.AddressUUID.String, gc.Equals, addrUUID)
+	c.Check(r.SubnetUUID.String, gc.Equals, subUUID)
+}

--- a/domain/network/state/types.go
+++ b/domain/network/state/types.go
@@ -260,3 +260,38 @@ func flattenAZs(
 
 	return subnets
 }
+
+// machineInterfaceRow is the type for a row from the v_machine_interface view.
+type machineInterfaceRow struct {
+	// MachineUUID and associated machine fields.
+	MachineUUID string `db:"machine_uuid"`
+	MachineName string `db:"machine_name"`
+	NetNodeUUID string `db:"net_node_uuid"`
+
+	// DeviceUUID and associated link-layer device fields.
+	DeviceUUID        string         `db:"device_uuid"`
+	DeviceName        string         `db:"device_name"`
+	MTU               sql.NullInt64  `db:"mtu"`
+	MacAddress        sql.NullString `db:"mac_address"`
+	ProviderID        sql.NullString `db:"device_provider_id"`
+	DeviceTypeID      int            `db:"device_type_id"`
+	VirtualPortTypeID int            `db:"virtual_port_type_id"`
+	IsAutoStart       bool           `db:"is_auto_start"`
+	IsEnabled         bool           `db:"is_enabled"`
+	ParentDeviceUUID  sql.NullString `db:"parent_device_uuid"`
+	ParentDeviceName  sql.NullString `db:"parent_device_name"`
+	DefaultGateway    sql.NullString `db:"is_default_gateway"`
+
+	// AddressUUID and associated IP address fields.
+	AddressUUID      sql.NullString `db:"address_uuid"`
+	AddressValue     sql.NullString `db:"address_value"`
+	SubnetUUID       sql.NullString `db:"subnet_uuid"`
+	CIDR             sql.NullString `db:"cidr"`
+	ProviderSubnetID sql.NullString `db:"provider_subnet_id"`
+	AddressTypeID    sql.NullInt64  `db:"address_type_id"`
+	ConfigTypeID     sql.NullInt64  `db:"config_type_id"`
+	OriginID         sql.NullInt64  `db:"origin_id"`
+	ScopeID          sql.NullInt64  `db:"scope_id"`
+	IsSecondary      sql.NullBool   `db:"is_secondary"`
+	IsShadow         sql.NullBool   `db:"is_shadow"`
+}

--- a/domain/schema/model/sql/0021-network.sql
+++ b/domain/schema/model/sql/0021-network.sql
@@ -96,6 +96,21 @@ CREATE TABLE link_layer_device_dns_address (
     PRIMARY KEY (device_uuid, dns_address)
 );
 
+-- Note that this table is defined for completeness in
+-- reflecting what we capture as network configuration.
+-- At the time of writing, we do not store any routes,
+-- but this can be easily changed at a later date.
+CREATE TABLE link_layer_device_route (
+    device_uuid TEXT NOT NULL,
+    destination_cidr TEXT NOT NULL,
+    gateway_ip TEXT NOT NULL,
+    metric INT NOT NULL,
+    CONSTRAINT fk_dns_server_device
+    FOREIGN KEY (device_uuid)
+    REFERENCES link_layer_device (uuid),
+    PRIMARY KEY (device_uuid, destination_cidr)
+);
+
 -- ip_address_type represents the possible ways of specifying
 -- an address, either a hostname resolvable by dns lookup,
 -- or IPv4 or IPv6 address.
@@ -314,3 +329,5 @@ SELECT
     null AS origin_id,
     fa.scope_id
 FROM fqdn_address AS fa;
+
+

--- a/domain/schema/model/sql/0021-network.sql
+++ b/domain/schema/model/sql/0021-network.sql
@@ -330,4 +330,42 @@ SELECT
     fa.scope_id
 FROM fqdn_address AS fa;
 
-
+CREATE VIEW v_machine_interface AS
+SELECT
+    m.uuid AS machine_uuid,
+    m.name AS machine_name,
+    d.net_node_uuid,
+    d.uuid AS device_uuid,
+    d.name AS device_name,
+    d.mtu,
+    d.mac_address,
+    d.device_type_id,
+    d.virtual_port_type_id,
+    d.is_auto_start,
+    d.is_enabled,
+    d.is_default_gateway,
+    d.gateway_address,
+    pd.provider_id AS device_provider_id,
+    dp.parent_uuid AS parent_device_uuid,
+    dd.name AS parent_device_name,
+    dns.dns_address,
+    a.uuid AS address_uuid,
+    a.address_value,
+    a.subnet_uuid,
+    s.cidr,
+    ps.provider_id AS provider_subnet_id,
+    a.type_id AS address_type_id,
+    a.config_type_id,
+    a.origin_id,
+    a.scope_id,
+    a.is_secondary,
+    a.is_shadow
+FROM machine AS m
+JOIN link_layer_device AS d ON m.net_node_uuid = d.net_node_uuid
+LEFT JOIN provider_link_layer_device AS pd ON d.uuid = pd.device_uuid
+LEFT JOIN link_layer_device_parent AS dp ON d.uuid = dp.device_uuid
+LEFT JOIN link_layer_device AS dd ON dp.parent_uuid = dd.uuid
+LEFT JOIN link_layer_device_dns_address AS dns ON d.uuid = dns.device_uuid
+LEFT JOIN ip_address AS a ON d.uuid = a.device_uuid
+LEFT JOIN subnet AS s ON a.subnet_uuid = s.uuid
+LEFT JOIN provider_subnet AS ps ON a.subnet_uuid = ps.subnet_uuid

--- a/domain/schema/model_schema_test.go
+++ b/domain/schema/model_schema_test.go
@@ -93,6 +93,7 @@ func (s *modelSchemaSuite) TestModelTables(c *gc.C) {
 		"link_layer_device_dns_domain",
 		"link_layer_device_dns_address",
 		"link_layer_device_parent",
+		"link_layer_device_route",
 		"link_layer_device_type",
 		"provider_link_layer_device",
 		"virtual_port_type",

--- a/domain/schema/model_schema_test.go
+++ b/domain/schema/model_schema_test.go
@@ -326,6 +326,7 @@ func (s *modelSchemaSuite) TestModelViews(c *gc.C) {
 		"v_hardware_characteristics",
 		"v_machine_agent_version",
 		"v_machine_cloud_instance_status",
+		"v_machine_interface",
 		"v_machine_status",
 		"v_machine_target_agent_version",
 		"v_model_constraint_space",


### PR DESCRIPTION
This patch is some groundwork for capturing machine network configuration.

There is a new table `link_layer_device_route`. We do not store route information in Mongo, but we capture it a send it server-side with detected configuration. At this point it exists only for completeness and has a comment to indicate so. I expect will need to store this information when networking is revisited.

A new view, `v_machine_interface` and a type, `machineInterfaceRow` are added to conform with `InterfaceInfos` from the _core/network_ package, which is how detected network configuration is captured and sent to the service layer.

Usage of the new view and types will be in an imminent patch.

## QA steps

Not yet recruited in application logic, but unit test verifies correctness.

## Links
**Jira card:** [JUJU-5801](https://warthogs.atlassian.net/browse/JUJU-5801)


[JUJU-5801]: https://warthogs.atlassian.net/browse/JUJU-5801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ