### PR TITLE
chore: merge 3.6

### DIFF
--- a/cmd/juju/commands/help_action_commands.go
+++ b/cmd/juju/commands/help_action_commands.go
@@ -45,7 +45,7 @@ func (c *helpActionCmdsCommand) Run(ctx *cmd.Context) error {
 	if c.actionCmd == "" {
 		fmt.Fprint(ctx.Stdout, listHelpActionCmds())
 	} else {
-		c, err := jujuc.NewActionCommand(dummyHookContext{}, c.actionCmd)
+		c, err := jujuc.NewActionCommandForHelp(dummyHookContext{}, c.actionCmd)
 		if err != nil {
 			return err
 		}
@@ -58,7 +58,7 @@ func (c *helpActionCmdsCommand) Run(ctx *cmd.Context) error {
 }
 
 var helpActionCmdsDoc = fmt.Sprintf(`
-In addition to hook commands, Juju charms also have access to a set of action-specific commands. 
+In addition to hook commands, Juju charms also have access to a set of action-specific commands.
 These action commands are available when an action is running, and are used to log progress
 and report the outcome of the action.
 The currently available charm action commands include:
@@ -80,7 +80,7 @@ func listHelpActionCmds() string {
 	cmds := []cmd.Command{}
 	longest := 0
 	for _, name := range names {
-		if c, err := jujuc.NewActionCommand(dummyHookContext{}, name); err == nil {
+		if c, err := jujuc.NewActionCommandForHelp(dummyHookContext{}, name); err == nil {
 			// On Windows name has a '.exe' suffix, while Info().Name does not
 			name := c.Info().Name
 			if len(name) > longest {

--- a/cmd/juju/commands/help_action_commands_test.go
+++ b/cmd/juju/commands/help_action_commands_test.go
@@ -44,7 +44,7 @@ Global Options:
     Show more verbose output
 
 Details:
-In addition to hook commands, Juju charms also have access to a set of action-specific commands. 
+In addition to hook commands, Juju charms also have access to a set of action-specific commands.
 These action commands are available when an action is running, and are used to log progress
 and report the outcome of the action.
 The currently available charm action commands include:

--- a/cmd/juju/commands/help_hook_commands.go
+++ b/cmd/juju/commands/help_hook_commands.go
@@ -122,7 +122,7 @@ func (c *helpHookCmdsCommand) Run(ctx *cmd.Context) error {
 	if c.hookCmd == "" {
 		fmt.Fprint(ctx.Stdout, listHelpHookCmds())
 	} else {
-		c, err := jujuc.NewHookCommand(dummyHookContext{}, c.hookCmd)
+		c, err := jujuc.NewHookCommandForHelp(dummyHookContext{}, c.hookCmd)
 		if err != nil {
 			return err
 		}
@@ -157,7 +157,7 @@ func listHelpHookCmds() string {
 	cmds := []cmd.Command{}
 	longest := 0
 	for _, name := range names {
-		if c, err := jujuc.NewHookCommand(dummyHookContext{}, name); err == nil {
+		if c, err := jujuc.NewHookCommandForHelp(dummyHookContext{}, name); err == nil {
 			// On Windows name has a '.exe' suffix, while Info().Name does not
 			name := c.Info().Name
 			if len(name) > longest {

--- a/docs/reference/juju-cli/list-of-juju-cli-commands/help-action-commands.md
+++ b/docs/reference/juju-cli/list-of-juju-cli-commands/help-action-commands.md
@@ -17,7 +17,7 @@ For help on a specific action command, supply the name of that action command, f
 
 ## Details
 
-In addition to hook commands, Juju charms also have access to a set of action-specific commands. 
+In addition to hook commands, Juju charms also have access to a set of action-specific commands.
 These action commands are available when an action is running, and are used to log progress
 and report the outcome of the action.
 The currently available charm action commands include:

--- a/internal/worker/uniter/runner/jujuc/action-fail_test.go
+++ b/internal/worker/uniter/runner/jujuc/action-fail_test.go
@@ -76,7 +76,7 @@ func (s *ActionFailSuite) TestActionFail(c *gc.C) {
 	for i, t := range actionFailTests {
 		c.Logf("test %d: %s", i, t.summary)
 		hctx := &actionFailContext{}
-		com, err := jujuc.NewActionCommand(hctx, "action-fail")
+		com, err := jujuc.NewCommand(hctx, "action-fail")
 		c.Assert(err, jc.ErrorIsNil)
 		ctx := cmdtesting.Context(c)
 		code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, t.command)
@@ -89,7 +89,7 @@ func (s *ActionFailSuite) TestActionFail(c *gc.C) {
 
 func (s *ActionFailSuite) TestNonActionSetActionFailedFails(c *gc.C) {
 	hctx := &nonActionFailContext{}
-	com, err := jujuc.NewActionCommand(hctx, "action-fail")
+	com, err := jujuc.NewCommand(hctx, "action-fail")
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
 	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"oops"})

--- a/internal/worker/uniter/runner/jujuc/action-get_test.go
+++ b/internal/worker/uniter/runner/jujuc/action-get_test.go
@@ -41,7 +41,7 @@ func (ctx *nonActionContext) ActionParams() (map[string]interface{}, error) {
 
 func (s *ActionGetSuite) TestNonActionRunFail(c *gc.C) {
 	hctx := &nonActionContext{}
-	com, err := jujuc.NewActionCommand(hctx, "action-get")
+	com, err := jujuc.NewCommand(hctx, "action-get")
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
 	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{})
@@ -253,7 +253,7 @@ func (s *ActionGetSuite) TestActionGet(c *gc.C) {
 		c.Logf("test %d: %s\n args: %#v", i, t.summary, t.args)
 		hctx := &actionGetContext{}
 		hctx.actionParams = t.actionParams
-		com, err := jujuc.NewActionCommand(hctx, "action-get")
+		com, err := jujuc.NewCommand(hctx, "action-get")
 		c.Assert(err, jc.ErrorIsNil)
 		ctx := cmdtesting.Context(c)
 		code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, t.args)

--- a/internal/worker/uniter/runner/jujuc/action-log_test.go
+++ b/internal/worker/uniter/runner/jujuc/action-log_test.go
@@ -64,7 +64,7 @@ func (s *ActionLogSuite) TestActionLog(c *gc.C) {
 	for i, t := range actionLogTests {
 		c.Logf("test %d: %s", i, t.summary)
 		hctx := &actionLogContext{}
-		com, err := jujuc.NewActionCommand(hctx, "action-log")
+		com, err := jujuc.NewCommand(hctx, "action-log")
 		c.Assert(err, jc.ErrorIsNil)
 		ctx := cmdtesting.Context(c)
 		code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, t.command)
@@ -76,7 +76,7 @@ func (s *ActionLogSuite) TestActionLog(c *gc.C) {
 
 func (s *ActionLogSuite) TestNonActionLogActionFails(c *gc.C) {
 	hctx := &nonActionLogContext{}
-	com, err := jujuc.NewActionCommand(hctx, "action-log")
+	com, err := jujuc.NewCommand(hctx, "action-log")
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
 	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"oops"})

--- a/internal/worker/uniter/runner/jujuc/action-set_test.go
+++ b/internal/worker/uniter/runner/jujuc/action-set_test.go
@@ -45,7 +45,7 @@ func (a *nonActionSettingContext) UpdateActionResults(keys []string, value inter
 
 func (s *ActionSetSuite) TestActionSetOnNonActionContextFails(c *gc.C) {
 	hctx := &nonActionSettingContext{}
-	com, err := jujuc.NewActionCommand(hctx, "action-set")
+	com, err := jujuc.NewCommand(hctx, "action-set")
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
 	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"oops=nope"})
@@ -131,7 +131,7 @@ func (s *ActionSetSuite) TestActionSet(c *gc.C) {
 	for i, t := range actionSetTests {
 		c.Logf("test %d: %s", i, t.summary)
 		hctx := &actionSettingContext{}
-		com, err := jujuc.NewActionCommand(hctx, "action-set")
+		com, err := jujuc.NewCommand(hctx, "action-set")
 		c.Assert(err, jc.ErrorIsNil)
 		ctx := cmdtesting.Context(c)
 		c.Logf("  command list: %#v", t.command)

--- a/internal/worker/uniter/runner/jujuc/application-version-set_test.go
+++ b/internal/worker/uniter/runner/jujuc/application-version-set_test.go
@@ -23,7 +23,7 @@ func (s *ApplicationVersionSetSuite) createCommand(c *gc.C, err error) (*Context
 	hctx := s.GetHookContext(c, -1, "")
 	s.Stub.SetErrors(err)
 
-	com, err := jujuc.NewHookCommand(hctx, "application-version-set")
+	com, err := jujuc.NewCommand(hctx, "application-version-set")
 	c.Assert(err, jc.ErrorIsNil)
 	return hctx, jujuc.NewJujucCommandWrappedForTest(com)
 }

--- a/internal/worker/uniter/runner/jujuc/config-get_test.go
+++ b/internal/worker/uniter/runner/jujuc/config-get_test.go
@@ -43,7 +43,7 @@ func (s *ConfigGetSuite) TestOutputFormatKey(c *gc.C) {
 	for i, t := range configGetKeyTests {
 		c.Logf("test %d: %#v", i, t.args)
 		hctx := s.GetHookContext(c, -1, "")
-		com, err := jujuc.NewHookCommand(hctx, "config-get")
+		com, err := jujuc.NewCommand(hctx, "config-get")
 		c.Assert(err, jc.ErrorIsNil)
 		ctx := cmdtesting.Context(c)
 		code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, t.args)
@@ -100,7 +100,7 @@ func (s *ConfigGetSuite) TestOutputFormatAll(c *gc.C) {
 	for i, t := range configGetAllTests {
 		c.Logf("test %d: %#v", i, t.args)
 		hctx := s.GetHookContext(c, -1, "")
-		com, err := jujuc.NewHookCommand(hctx, "config-get")
+		com, err := jujuc.NewCommand(hctx, "config-get")
 		c.Assert(err, jc.ErrorIsNil)
 		ctx := cmdtesting.Context(c)
 		code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, t.args)
@@ -120,7 +120,7 @@ func (s *ConfigGetSuite) TestOutputFormatAll(c *gc.C) {
 
 func (s *ConfigGetSuite) TestOutputPath(c *gc.C) {
 	hctx := s.GetHookContext(c, -1, "")
-	com, err := jujuc.NewHookCommand(hctx, "config-get")
+	com, err := jujuc.NewCommand(hctx, "config-get")
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
 	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"--output", "some-file", "monsters"})
@@ -134,14 +134,14 @@ func (s *ConfigGetSuite) TestOutputPath(c *gc.C) {
 
 func (s *ConfigGetSuite) TestUnknownArg(c *gc.C) {
 	hctx := s.GetHookContext(c, -1, "")
-	com, err := jujuc.NewHookCommand(hctx, "config-get")
+	com, err := jujuc.NewCommand(hctx, "config-get")
 	c.Assert(err, jc.ErrorIsNil)
 	cmdtesting.TestInit(c, jujuc.NewJujucCommandWrappedForTest(com), []string{"multiple", "keys"}, `unrecognized args: \["keys"\]`)
 }
 
 func (s *ConfigGetSuite) TestAllPlusKey(c *gc.C) {
 	hctx := s.GetHookContext(c, -1, "")
-	com, err := jujuc.NewHookCommand(hctx, "config-get")
+	com, err := jujuc.NewCommand(hctx, "config-get")
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
 	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"--all", "--format", "json", "monsters"})

--- a/internal/worker/uniter/runner/jujuc/credential-get_test.go
+++ b/internal/worker/uniter/runner/jujuc/credential-get_test.go
@@ -26,7 +26,7 @@ var _ = gc.Suite(&CredentialGetSuite{})
 // this might be done.
 func runCredentialGetCommand(s *CredentialGetSuite, c *gc.C, args []string) (*cmd.Context, int) {
 	hctx := s.GetHookContext(c, -1, "")
-	com, err := jujuc.NewHookCommand(hctx, "credential-get")
+	com, err := jujuc.NewCommand(hctx, "credential-get")
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
 	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, args)

--- a/internal/worker/uniter/runner/jujuc/goal-state_test.go
+++ b/internal/worker/uniter/runner/jujuc/goal-state_test.go
@@ -89,7 +89,7 @@ func (s *GoalStateSuite) TestOutputPath(c *gc.C) {
 
 func (s *GoalStateSuite) getGoalStateCommand(c *gc.C, args []string) (*cmd.Context, int) {
 	hctx := s.GetHookContext(c, -1, "")
-	com, err := jujuc.NewHookCommand(hctx, "goal-state")
+	com, err := jujuc.NewCommand(hctx, "goal-state")
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
 	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, args)
@@ -98,7 +98,7 @@ func (s *GoalStateSuite) getGoalStateCommand(c *gc.C, args []string) (*cmd.Conte
 
 func (s *GoalStateSuite) TestUnknownArg(c *gc.C) {
 	hctx := s.GetHookContext(c, -1, "")
-	com, err := jujuc.NewHookCommand(hctx, "goal-state")
+	com, err := jujuc.NewCommand(hctx, "goal-state")
 	c.Assert(err, jc.ErrorIsNil)
 	cmdtesting.TestInit(c, jujuc.NewJujucCommandWrappedForTest(com), []string{}, "")
 }

--- a/internal/worker/uniter/runner/jujuc/network-get_test.go
+++ b/internal/worker/uniter/runner/jujuc/network-get_test.go
@@ -115,7 +115,7 @@ func (s *NetworkGetSuite) createCommand(c *gc.C) cmd.Command {
 
 	hctx.info.NetworkInterface.NetworkInfoResults = presetBindings
 
-	com, err := jujuc.NewHookCommand(hctx, "network-get")
+	com, err := jujuc.NewCommand(hctx, "network-get")
 	c.Assert(err, jc.ErrorIsNil)
 	return jujuc.NewJujucCommandWrappedForTest(com)
 }

--- a/internal/worker/uniter/runner/jujuc/opened-ports_test.go
+++ b/internal/worker/uniter/runner/jujuc/opened-ports_test.go
@@ -92,7 +92,7 @@ func (s *OpenedPortsSuite) TestRunAllFormatsWithEndpointDetails(c *gc.C) {
 
 func (s *OpenedPortsSuite) TestBadArgs(c *gc.C) {
 	hctx := s.GetHookContext(c, -1, "")
-	com, err := jujuc.NewHookCommand(hctx, "opened-ports")
+	com, err := jujuc.NewCommand(hctx, "opened-ports")
 	c.Assert(err, jc.ErrorIsNil)
 	err = cmdtesting.InitCommand(jujuc.NewJujucCommandWrappedForTest(com), []string{"foo"})
 	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["foo"\]`)
@@ -108,7 +108,7 @@ func (s *OpenedPortsSuite) getContextAndOpenPorts(c *gc.C) *Context {
 }
 
 func (s *OpenedPortsSuite) runCommand(c *gc.C, hctx *Context, args ...string) (stdout, stderr string) {
-	com, err := jujuc.NewHookCommand(hctx, "opened-ports")
+	com, err := jujuc.NewCommand(hctx, "opened-ports")
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
 	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, args)

--- a/internal/worker/uniter/runner/jujuc/ports_test.go
+++ b/internal/worker/uniter/runner/jujuc/ports_test.go
@@ -74,7 +74,7 @@ func makeAllEndpointsRanges(stringRanges ...string) network.GroupedPortRanges {
 func (s *PortsSuite) TestOpenClose(c *gc.C) {
 	hctx := s.GetHookContext(c, -1, "")
 	for _, t := range portsTests {
-		com, err := jujuc.NewHookCommand(hctx, t.cmd[0])
+		com, err := jujuc.NewCommand(hctx, t.cmd[0])
 		c.Assert(err, jc.ErrorIsNil)
 		ctx := cmdtesting.Context(c)
 		code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, t.cmd[1:])
@@ -98,7 +98,7 @@ func (s *PortsSuite) TestOpenCloseDeprecation(c *gc.C) {
 	hctx := s.GetHookContext(c, -1, "")
 	for _, t := range portsFormatDeprecationTests {
 		name := t.cmd[0]
-		com, err := jujuc.NewHookCommand(hctx, name)
+		com, err := jujuc.NewCommand(hctx, name)
 		c.Assert(err, jc.ErrorIsNil)
 		ctx := cmdtesting.Context(c)
 		code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, t.cmd[1:])

--- a/internal/worker/uniter/runner/jujuc/reboot_test.go
+++ b/internal/worker/uniter/runner/jujuc/reboot_test.go
@@ -91,7 +91,7 @@ func (s *JujuRebootSuite) TestJujuRebootCommand(c *gc.C) {
 		hctx := s.newHookContext(c)
 		hctx.shouldError = t.hctx.shouldError
 		hctx.rebootPriority = t.hctx.rebootPriority
-		com, err := jujuc.NewHookCommand(hctx, "juju-reboot")
+		com, err := jujuc.NewCommand(hctx, "juju-reboot")
 		c.Assert(err, jc.ErrorIsNil)
 		ctx := cmdtesting.Context(c)
 		code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, t.args)
@@ -102,7 +102,7 @@ func (s *JujuRebootSuite) TestJujuRebootCommand(c *gc.C) {
 
 func (s *JujuRebootSuite) TestRebootInActions(c *gc.C) {
 	jujucCtx := &actionGetContext{}
-	com, err := jujuc.NewHookCommand(jujucCtx, "juju-reboot")
+	com, err := jujuc.NewCommand(jujucCtx, "juju-reboot")
 	c.Assert(err, jc.ErrorIsNil)
 	cmdCtx := cmdtesting.Context(c)
 	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), cmdCtx, nil)

--- a/internal/worker/uniter/runner/jujuc/relation-get_test.go
+++ b/internal/worker/uniter/runner/jujuc/relation-get_test.go
@@ -146,7 +146,7 @@ func (s *RelationGetSuite) TestRelationGet(c *gc.C) {
 	for i, t := range relationGetTests {
 		c.Logf("test %d: %s", i, t.summary)
 		hctx, _ := s.newHookContext(t.relid, t.unit, "")
-		com, err := jujuc.NewHookCommand(hctx, "relation-get")
+		com, err := jujuc.NewCommand(hctx, "relation-get")
 		c.Assert(err, jc.ErrorIsNil)
 		ctx := cmdtesting.Context(c)
 		code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, t.args)
@@ -202,7 +202,7 @@ func (s *RelationGetSuite) TestRelationGetFormat(c *gc.C) {
 		for i, t := range relationGetFormatTests {
 			c.Logf("test %d: %s %s", i, format, t.summary)
 			hctx, _ := s.newHookContext(t.relid, t.unit, "")
-			com, err := jujuc.NewHookCommand(hctx, "relation-get")
+			com, err := jujuc.NewCommand(hctx, "relation-get")
 			c.Assert(err, jc.ErrorIsNil)
 			ctx := cmdtesting.Context(c)
 			args := append(t.args, "--format", format)
@@ -246,7 +246,7 @@ func (s *RelationGetSuite) TestHelp(c *gc.C) {
 	for i, t := range relationGetHelpTests {
 		c.Logf("test %d", i)
 		hctx, _ := s.newHookContext(t.relid, t.unit, "")
-		com, err := jujuc.NewHookCommand(hctx, "relation-get")
+		com, err := jujuc.NewCommand(hctx, "relation-get")
 		c.Assert(err, jc.ErrorIsNil)
 		ctx := cmdtesting.Context(c)
 		code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"--help"})
@@ -262,7 +262,7 @@ func (s *RelationGetSuite) TestHelp(c *gc.C) {
 
 func (s *RelationGetSuite) TestOutputPath(c *gc.C) {
 	hctx, _ := s.newHookContext(1, "m/0", "")
-	com, err := jujuc.NewHookCommand(hctx, "relation-get")
+	com, err := jujuc.NewCommand(hctx, "relation-get")
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
 	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"--output", "some-file", "pew"})
@@ -300,7 +300,7 @@ func (t relationGetInitTest) init(c *gc.C, s *RelationGetSuite) (cmd.Command, []
 	copy(args, t.args)
 
 	hctx, _ := s.newHookContext(t.ctxrelid, t.ctxunit, t.ctxapp)
-	com, err := jujuc.NewHookCommand(hctx, "relation-get")
+	com, err := jujuc.NewCommand(hctx, "relation-get")
 	c.Assert(err, jc.ErrorIsNil)
 
 	return com, args

--- a/internal/worker/uniter/runner/jujuc/relation-ids_test.go
+++ b/internal/worker/uniter/runner/jujuc/relation-ids_test.go
@@ -105,7 +105,7 @@ func (s *RelationIdsSuite) TestRelationIds(c *gc.C) {
 	for i, t := range relationIdsTests {
 		c.Logf("test %d: %s", i, t.summary)
 		hctx, _ := s.newHookContext(t.relid, "")
-		com, err := jujuc.NewHookCommand(hctx, "relation-ids")
+		com, err := jujuc.NewCommand(hctx, "relation-ids")
 		c.Assert(err, jc.ErrorIsNil)
 		ctx := cmdtesting.Context(c)
 		code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, t.args)
@@ -134,7 +134,7 @@ func (s *RelationIdsSuite) TestHelp(c *gc.C) {
 	} {
 		c.Logf("relid %d", relid)
 		hctx, _ := s.newHookContext(relid, "")
-		com, err := jujuc.NewHookCommand(hctx, "relation-ids")
+		com, err := jujuc.NewCommand(hctx, "relation-ids")
 		c.Assert(err, jc.ErrorIsNil)
 		ctx := cmdtesting.Context(c)
 		code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"--help"})
@@ -162,7 +162,7 @@ func (s *RelationIdsSuite) TestFilterNonLiveRelations(c *gc.C) {
 }
 
 func (s *RelationIdsSuite) assertOutputMatches(c *gc.C, hctx jujuc.Context, expOutput string) {
-	com, err := jujuc.NewHookCommand(hctx, "relation-ids")
+	com, err := jujuc.NewCommand(hctx, "relation-ids")
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
 	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, nil)

--- a/internal/worker/uniter/runner/jujuc/relation-list_test.go
+++ b/internal/worker/uniter/runner/jujuc/relation-list_test.go
@@ -123,7 +123,7 @@ func (s *RelationListSuite) TestRelationList(c *gc.C) {
 		info.setRelations(0, t.members0)
 		info.setRelations(1, t.members1)
 		c.Logf("%#v %#v", info.rels[t.relid], t.members1)
-		com, err := jujuc.NewHookCommand(hctx, "relation-list")
+		com, err := jujuc.NewCommand(hctx, "relation-list")
 		c.Assert(err, jc.ErrorIsNil)
 		ctx := cmdtesting.Context(c)
 		code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, t.args)
@@ -153,7 +153,7 @@ func (s *RelationListSuite) TestRelationListHelp(c *gc.C) {
 	} {
 		c.Logf("test relid %d", relid)
 		hctx, _ := s.newHookContext(relid, "", "")
-		com, err := jujuc.NewHookCommand(hctx, "relation-list")
+		com, err := jujuc.NewCommand(hctx, "relation-list")
 		c.Assert(err, jc.ErrorIsNil)
 		ctx := cmdtesting.Context(c)
 		code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"--help"})

--- a/internal/worker/uniter/runner/jujuc/relation-model-get_test.go
+++ b/internal/worker/uniter/runner/jujuc/relation-model-get_test.go
@@ -81,7 +81,7 @@ func (s *RelationModelGetSuite) TestInit(c *gc.C) {
 	for i, t := range relationModelGetInitTests {
 		c.Logf("test %d", i)
 		hctx, _ := s.newHookContext(t.ctxrelid, "", "")
-		com, err := jujuc.NewHookCommand(hctx, "relation-model-get")
+		com, err := jujuc.NewCommand(hctx, "relation-model-get")
 		c.Assert(err, jc.ErrorIsNil)
 
 		err = cmdtesting.InitCommand(com, t.args)
@@ -99,7 +99,7 @@ func (s *RelationModelGetSuite) TestInit(c *gc.C) {
 
 func (s *RelationModelGetSuite) TestRun(c *gc.C) {
 	hctx, _ := s.newHookContext(0, "", "")
-	com, err := jujuc.NewHookCommand(hctx, "relation-model-get")
+	com, err := jujuc.NewCommand(hctx, "relation-model-get")
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
 	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, nil)
@@ -111,7 +111,7 @@ func (s *RelationModelGetSuite) TestRun(c *gc.C) {
 
 func (s *RelationModelGetSuite) TestRunFormatJSON(c *gc.C) {
 	hctx, _ := s.newHookContext(0, "", "")
-	com, err := jujuc.NewHookCommand(hctx, "relation-model-get")
+	com, err := jujuc.NewCommand(hctx, "relation-model-get")
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
 	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"--format", "json"})

--- a/internal/worker/uniter/runner/jujuc/relation-set_test.go
+++ b/internal/worker/uniter/runner/jujuc/relation-set_test.go
@@ -34,7 +34,7 @@ func (s *RelationSetSuite) TestHelp(c *gc.C) {
 	for i, t := range helpTests {
 		c.Logf("test %d", i)
 		hctx, _ := s.newHookContext(t.relid, "", "")
-		com, err := jujuc.NewHookCommand(hctx, "relation-set")
+		com, err := jujuc.NewCommand(hctx, "relation-set")
 		c.Assert(err, jc.ErrorIsNil)
 		ctx := cmdtesting.Context(c)
 		code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"--help"})
@@ -77,7 +77,7 @@ func (t relationSetInitTest) init(c *gc.C, s *RelationSetSuite) (cmd.Command, []
 	copy(args, t.args)
 
 	hctx, _ := s.newHookContext(t.ctxrelid, "", "")
-	com, err := jujuc.NewHookCommand(hctx, "relation-set")
+	com, err := jujuc.NewCommand(hctx, "relation-set")
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctx := cmdtesting.Context(c)
@@ -338,7 +338,7 @@ func (s *RelationSetSuite) TestRun(c *gc.C) {
 		info.rels[1].Units["u/0"] = basic
 
 		// Run the command.
-		com, err := jujuc.NewHookCommand(hctx, "relation-set")
+		com, err := jujuc.NewCommand(hctx, "relation-set")
 		c.Assert(err, jc.ErrorIsNil)
 		rset := com.(*jujuc.RelationSetCommand)
 		rset.RelationId = 1
@@ -355,7 +355,7 @@ func (s *RelationSetSuite) TestRun(c *gc.C) {
 
 func (s *RelationSetSuite) TestRunDeprecationWarning(c *gc.C) {
 	hctx, _ := s.newHookContext(0, "", "")
-	com, _ := jujuc.NewHookCommand(hctx, "relation-set")
+	com, _ := jujuc.NewCommand(hctx, "relation-set")
 	com = jujuc.NewJujucCommandWrappedForTest(com)
 	// The rel= is needed to make this a valid command.
 	ctx, err := cmdtesting.RunCommand(c, com, "--format", "foo", "rel=")

--- a/internal/worker/uniter/runner/jujuc/resource-get_test.go
+++ b/internal/worker/uniter/runner/jujuc/resource-get_test.go
@@ -48,7 +48,7 @@ func (s *ResourceGetCmdSuite) TestRun(c *gc.C) {
 	hctx := mocks.NewMockContext(ctrl)
 	hctx.EXPECT().DownloadResource(gomock.Any(), "spam").Return(expected, nil)
 
-	com, err := jujuc.NewHookCommand(hctx, "resource-get")
+	com, err := jujuc.NewCommand(hctx, "resource-get")
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
 	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"spam"})
@@ -64,7 +64,7 @@ func (s *ResourceGetCmdSuite) TestRunDownloadFailure(c *gc.C) {
 	hctx := mocks.NewMockContext(ctrl)
 	hctx.EXPECT().DownloadResource(gomock.Any(), "spam").Return("", errors.New("<failure>"))
 
-	com, err := jujuc.NewHookCommand(hctx, "resource-get")
+	com, err := jujuc.NewCommand(hctx, "resource-get")
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
 	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"spam"})

--- a/internal/worker/uniter/runner/jujuc/secret-add_test.go
+++ b/internal/worker/uniter/runner/jujuc/secret-add_test.go
@@ -51,7 +51,7 @@ func (s *SecretAddSuite) TestAddSecretInvalidArgs(c *gc.C) {
 			err:  `ERROR expire time or duration "2022-01-01" not valid`,
 		},
 	} {
-		com, err := jujuc.NewHookCommand(hctx, "secret-add")
+		com, err := jujuc.NewCommand(hctx, "secret-add")
 		c.Assert(err, jc.ErrorIsNil)
 		ctx := cmdtesting.Context(c)
 		code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, t.args)
@@ -68,7 +68,7 @@ func ptr[T any](v T) *T {
 func (s *SecretAddSuite) TestAddSecretExpireDuration(c *gc.C) {
 	hctx, _ := s.ContextSuite.NewHookContext()
 
-	com, err := jujuc.NewHookCommand(hctx, "secret-add")
+	com, err := jujuc.NewCommand(hctx, "secret-add")
 	c.Assert(err, jc.ErrorIsNil)
 
 	expectedExpiry := time.Now().Add(time.Hour)
@@ -106,7 +106,7 @@ func (s *SecretAddSuite) TestAddSecretExpireDuration(c *gc.C) {
 func (s *SecretAddSuite) TestAddSecretExpireTimestamp(c *gc.C) {
 	hctx, _ := s.ContextSuite.NewHookContext()
 
-	com, err := jujuc.NewHookCommand(hctx, "secret-add")
+	com, err := jujuc.NewCommand(hctx, "secret-add")
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctx := cmdtesting.Context(c)
@@ -138,7 +138,7 @@ func (s *SecretAddSuite) TestAddSecretExpireTimestamp(c *gc.C) {
 func (s *SecretAddSuite) TestAddSecretBase64(c *gc.C) {
 	hctx, _ := s.ContextSuite.NewHookContext()
 
-	com, err := jujuc.NewHookCommand(hctx, "secret-add")
+	com, err := jujuc.NewCommand(hctx, "secret-add")
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
 	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"token#base64=key=", "--owner", "unit"})
@@ -171,7 +171,7 @@ func (s *SecretAddSuite) TestAddSecretFromFile(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	hctx, _ := s.ContextSuite.NewHookContext()
-	com, err := jujuc.NewHookCommand(hctx, "secret-add")
+	com, err := jujuc.NewCommand(hctx, "secret-add")
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
 	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"token#base64=key=", "--file", fileName})

--- a/internal/worker/uniter/runner/jujuc/secret-get_test.go
+++ b/internal/worker/uniter/runner/jujuc/secret-get_test.go
@@ -35,7 +35,7 @@ func (s *SecretGetSuite) TestSecretGetInit(c *gc.C) {
 		err:  "ERROR require either a secret URI or label",
 	}} {
 		hctx, _ := s.ContextSuite.NewHookContext()
-		com, err := jujuc.NewHookCommand(hctx, "secret-get")
+		com, err := jujuc.NewCommand(hctx, "secret-get")
 		c.Assert(err, jc.ErrorIsNil)
 		ctx := cmdtesting.Context(c)
 		code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, t.args)
@@ -50,7 +50,7 @@ func (s *SecretGetSuite) TestSecretGetJson(c *gc.C) {
 		"key": base64.StdEncoding.EncodeToString([]byte("s3cret!")),
 	})
 
-	com, err := jujuc.NewHookCommand(hctx, "secret-get")
+	com, err := jujuc.NewCommand(hctx, "secret-get")
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
 	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret:9m4e2mr0ui3e8a215n4g", "--format", "json"})
@@ -138,7 +138,7 @@ func (s *SecretGetSuite) assertSecretGet(c *gc.C, f func() ([]string, testing.St
 		"key":  base64.StdEncoding.EncodeToString([]byte("key")),
 	})
 
-	com, err := jujuc.NewHookCommand(hctx, "secret-get")
+	com, err := jujuc.NewCommand(hctx, "secret-get")
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
 	args, checkCall := f()
@@ -160,7 +160,7 @@ func (s *SecretGetSuite) TestSecretGetBinary(c *gc.C) {
 		"key": encodedValue,
 	})
 
-	com, err := jujuc.NewHookCommand(hctx, "secret-get")
+	com, err := jujuc.NewCommand(hctx, "secret-get")
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
 	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret:9m4e2mr0ui3e8a215n4g"})
@@ -184,7 +184,7 @@ func (s *SecretGetSuite) TestSecretGetKey(c *gc.C) {
 		"key":  base64.StdEncoding.EncodeToString([]byte("key")),
 	})
 
-	com, err := jujuc.NewHookCommand(hctx, "secret-get")
+	com, err := jujuc.NewCommand(hctx, "secret-get")
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
 	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret:9m4e2mr0ui3e8a215n4g", "cert"})
@@ -204,7 +204,7 @@ func (s *SecretGetSuite) TestSecretGetKeyBase64(c *gc.C) {
 		"key":  base64.StdEncoding.EncodeToString([]byte("key")),
 	})
 
-	com, err := jujuc.NewHookCommand(hctx, "secret-get")
+	com, err := jujuc.NewCommand(hctx, "secret-get")
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
 	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret:9m4e2mr0ui3e8a215n4g", "cert#base64"})

--- a/internal/worker/uniter/runner/jujuc/secret-grant_test.go
+++ b/internal/worker/uniter/runner/jujuc/secret-grant_test.go
@@ -42,7 +42,7 @@ func (s *SecretGrantSuite) TestGrantSecretInvalidArgs(c *gc.C) {
 			err:  `ERROR invalid value "-666" for option --relation: relation not found`,
 		},
 	} {
-		com, err := jujuc.NewHookCommand(hctx, "secret-grant")
+		com, err := jujuc.NewCommand(hctx, "secret-grant")
 		c.Assert(err, jc.ErrorIsNil)
 		ctx := cmdtesting.Context(c)
 		code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, t.args)
@@ -55,7 +55,7 @@ func (s *SecretGrantSuite) TestGrantSecretInvalidArgs(c *gc.C) {
 func (s *SecretGrantSuite) TestGrantSecret(c *gc.C) {
 	hctx, _ := s.newHookContext(1, "mediawiki/0", "mediawiki")
 
-	com, err := jujuc.NewHookCommand(hctx, "secret-grant")
+	com, err := jujuc.NewCommand(hctx, "secret-grant")
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
 	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{
@@ -75,7 +75,7 @@ func (s *SecretGrantSuite) TestGrantSecret(c *gc.C) {
 func (s *SecretGrantSuite) TestGrantSecretUnit(c *gc.C) {
 	hctx, _ := s.newHookContext(1, "mediawiki/0", "mediawiki")
 
-	com, err := jujuc.NewHookCommand(hctx, "secret-grant")
+	com, err := jujuc.NewCommand(hctx, "secret-grant")
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
 	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{
@@ -97,7 +97,7 @@ func (s *SecretGrantSuite) TestGrantSecretUnit(c *gc.C) {
 func (s *SecretGrantSuite) TestGrantSecretWrongUnit(c *gc.C) {
 	hctx, _ := s.newHookContext(1, "mediawiki/0", "mediawiki")
 
-	com, err := jujuc.NewHookCommand(hctx, "secret-grant")
+	com, err := jujuc.NewCommand(hctx, "secret-grant")
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
 	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{

--- a/internal/worker/uniter/runner/jujuc/secret-ids_test.go
+++ b/internal/worker/uniter/runner/jujuc/secret-ids_test.go
@@ -21,7 +21,7 @@ var _ = gc.Suite(&SecretIdsSuite{})
 func (s *SecretIdsSuite) TestSecretIds(c *gc.C) {
 	hctx, _ := s.ContextSuite.NewHookContext()
 
-	com, err := jujuc.NewHookCommand(hctx, "secret-ids")
+	com, err := jujuc.NewCommand(hctx, "secret-ids")
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
 	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, nil)

--- a/internal/worker/uniter/runner/jujuc/secret-info-get_test.go
+++ b/internal/worker/uniter/runner/jujuc/secret-info-get_test.go
@@ -32,7 +32,7 @@ func (s *SecretInfoGetSuite) TestSecretGetInit(c *gc.C) {
 		err:  "ERROR specify either a secret URI or label but not both",
 	}} {
 		hctx, _ := s.ContextSuite.NewHookContext()
-		com, err := jujuc.NewHookCommand(hctx, "secret-info-get")
+		com, err := jujuc.NewCommand(hctx, "secret-info-get")
 		c.Assert(err, jc.ErrorIsNil)
 		ctx := cmdtesting.Context(c)
 		code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, t.args)
@@ -44,7 +44,7 @@ func (s *SecretInfoGetSuite) TestSecretGetInit(c *gc.C) {
 func (s *SecretInfoGetSuite) TestSecretInfoGetURI(c *gc.C) {
 	hctx, _ := s.ContextSuite.NewHookContext()
 
-	com, err := jujuc.NewHookCommand(hctx, "secret-info-get")
+	com, err := jujuc.NewCommand(hctx, "secret-info-get")
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
 	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret:9m4e2mr0ui3e8a215n4g"})
@@ -71,7 +71,7 @@ func (s *SecretInfoGetSuite) TestSecretInfoGetWithGrants(c *gc.C) {
 		},
 	}
 
-	com, err := jujuc.NewHookCommand(hctx, "secret-info-get")
+	com, err := jujuc.NewCommand(hctx, "secret-info-get")
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
 	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret:9m4e2mr0ui3e8a215n4g"})
@@ -95,7 +95,7 @@ func (s *SecretInfoGetSuite) TestSecretInfoGetWithGrants(c *gc.C) {
 func (s *SecretInfoGetSuite) TestSecretInfoGetFailedNotFound(c *gc.C) {
 	hctx, _ := s.ContextSuite.NewHookContext()
 
-	com, err := jujuc.NewHookCommand(hctx, "secret-info-get")
+	com, err := jujuc.NewCommand(hctx, "secret-info-get")
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
 	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret:cd88u16ffbaql5kgmlh0"})
@@ -108,7 +108,7 @@ func (s *SecretInfoGetSuite) TestSecretInfoGetFailedNotFound(c *gc.C) {
 func (s *SecretInfoGetSuite) TestSecretInfoGetByLabelFailedNotFound(c *gc.C) {
 	hctx, _ := s.ContextSuite.NewHookContext()
 
-	com, err := jujuc.NewHookCommand(hctx, "secret-info-get")
+	com, err := jujuc.NewCommand(hctx, "secret-info-get")
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
 	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"--label", "not-found-label"})
@@ -121,7 +121,7 @@ func (s *SecretInfoGetSuite) TestSecretInfoGetByLabelFailedNotFound(c *gc.C) {
 func (s *SecretInfoGetSuite) TestSecretInfoGetByLabel(c *gc.C) {
 	hctx, _ := s.ContextSuite.NewHookContext()
 
-	com, err := jujuc.NewHookCommand(hctx, "secret-info-get")
+	com, err := jujuc.NewCommand(hctx, "secret-info-get")
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
 	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"--label", "label"})

--- a/internal/worker/uniter/runner/jujuc/secret-remove_test.go
+++ b/internal/worker/uniter/runner/jujuc/secret-remove_test.go
@@ -33,7 +33,7 @@ func (s *SecretRemoveSuite) TestRemoveSecretInvalidArgs(c *gc.C) {
 			err:  `ERROR secret URI "foo" not valid`,
 		},
 	} {
-		com, err := jujuc.NewHookCommand(hctx, "secret-remove")
+		com, err := jujuc.NewCommand(hctx, "secret-remove")
 		c.Assert(err, jc.ErrorIsNil)
 		ctx := cmdtesting.Context(c)
 		code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, t.args)
@@ -46,7 +46,7 @@ func (s *SecretRemoveSuite) TestRemoveSecretInvalidArgs(c *gc.C) {
 func (s *SecretRemoveSuite) TestRemoveSecret(c *gc.C) {
 	hctx, _ := s.ContextSuite.NewHookContext()
 
-	com, err := jujuc.NewHookCommand(hctx, "secret-remove")
+	com, err := jujuc.NewCommand(hctx, "secret-remove")
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
 	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{
@@ -64,7 +64,7 @@ func (s *SecretRemoveSuite) TestRemoveSecret(c *gc.C) {
 func (s *SecretRemoveSuite) TestRemoveSecretRevision(c *gc.C) {
 	hctx, _ := s.ContextSuite.NewHookContext()
 
-	com, err := jujuc.NewHookCommand(hctx, "secret-remove")
+	com, err := jujuc.NewCommand(hctx, "secret-remove")
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
 	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{

--- a/internal/worker/uniter/runner/jujuc/secret-revoke_test.go
+++ b/internal/worker/uniter/runner/jujuc/secret-revoke_test.go
@@ -45,7 +45,7 @@ func (s *SecretRevokeSuite) TestRevokeSecretInvalidArgs(c *gc.C) {
 			err:  `ERROR invalid value "-666" for option --relation: relation not found`,
 		},
 	} {
-		com, err := jujuc.NewHookCommand(hctx, "secret-revoke")
+		com, err := jujuc.NewCommand(hctx, "secret-revoke")
 		c.Assert(err, jc.ErrorIsNil)
 		ctx := cmdtesting.Context(c)
 		code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, t.args)
@@ -58,7 +58,7 @@ func (s *SecretRevokeSuite) TestRevokeSecretInvalidArgs(c *gc.C) {
 func (s *SecretRevokeSuite) TestRevokeSecretForApp(c *gc.C) {
 	hctx, _ := s.ContextSuite.NewHookContext()
 
-	com, err := jujuc.NewHookCommand(hctx, "secret-revoke")
+	com, err := jujuc.NewCommand(hctx, "secret-revoke")
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
 	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{
@@ -76,7 +76,7 @@ func (s *SecretRevokeSuite) TestRevokeSecretForApp(c *gc.C) {
 func (s *SecretRevokeSuite) TestRevokeSecretForRelation(c *gc.C) {
 	hctx, _ := s.newHookContext(1, "mediawiki/0", "mediawiki")
 
-	com, err := jujuc.NewHookCommand(hctx, "secret-revoke")
+	com, err := jujuc.NewCommand(hctx, "secret-revoke")
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
 	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{
@@ -94,7 +94,7 @@ func (s *SecretRevokeSuite) TestRevokeSecretForRelation(c *gc.C) {
 func (s *SecretRevokeSuite) TestRevokeSecretForRelationUnit(c *gc.C) {
 	hctx, _ := s.newHookContext(1, "mediawiki/0", "mediawiki")
 
-	com, err := jujuc.NewHookCommand(hctx, "secret-revoke")
+	com, err := jujuc.NewCommand(hctx, "secret-revoke")
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
 	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{

--- a/internal/worker/uniter/runner/jujuc/secret-set_test.go
+++ b/internal/worker/uniter/runner/jujuc/secret-set_test.go
@@ -51,7 +51,7 @@ func (s *SecretUpdateSuite) TestUpdateSecretInvalidArgs(c *gc.C) {
 			err:  `ERROR expire time or duration "2022-01-01" not valid`,
 		},
 	} {
-		com, err := jujuc.NewHookCommand(hctx, "secret-set")
+		com, err := jujuc.NewCommand(hctx, "secret-set")
 		c.Assert(err, jc.ErrorIsNil)
 		ctx := cmdtesting.Context(c)
 		code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, t.args)
@@ -65,7 +65,7 @@ func (s *SecretUpdateSuite) TestUpdateSecret(c *gc.C) {
 	hctx, _ := s.ContextSuite.NewHookContext()
 
 	expectedExpiry := time.Now().Add(time.Hour)
-	com, err := jujuc.NewHookCommand(hctx, "secret-set")
+	com, err := jujuc.NewCommand(hctx, "secret-set")
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
 	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{
@@ -98,7 +98,7 @@ func (s *SecretUpdateSuite) TestUpdateSecret(c *gc.C) {
 func (s *SecretUpdateSuite) TestUpdateSecretBase64(c *gc.C) {
 	hctx, _ := s.ContextSuite.NewHookContext()
 
-	com, err := jujuc.NewHookCommand(hctx, "secret-set")
+	com, err := jujuc.NewCommand(hctx, "secret-set")
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
 	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret:9m4e2mr0ui3e8a215n4g", "token#base64=key="})
@@ -114,7 +114,7 @@ func (s *SecretUpdateSuite) TestUpdateSecretBase64(c *gc.C) {
 func (s *SecretUpdateSuite) TestUpdateSecretRotateInterval(c *gc.C) {
 	hctx, _ := s.ContextSuite.NewHookContext()
 
-	com, err := jujuc.NewHookCommand(hctx, "secret-set")
+	com, err := jujuc.NewCommand(hctx, "secret-set")
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
 	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"--rotate", "daily", "secret:9m4e2mr0ui3e8a215n4g"})
@@ -143,7 +143,7 @@ func (s *SecretUpdateSuite) TestUpdateSecretFromFile(c *gc.C) {
 	c.Assert(err, jc.ErrorIsNil)
 
 	hctx, _ := s.ContextSuite.NewHookContext()
-	com, err := jujuc.NewHookCommand(hctx, "secret-set")
+	com, err := jujuc.NewCommand(hctx, "secret-set")
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
 	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"secret:9m4e2mr0ui3e8a215n4g", "token#base64=key=", "--file", fileName})

--- a/internal/worker/uniter/runner/jujuc/server.go
+++ b/internal/worker/uniter/runner/jujuc/server.go
@@ -166,9 +166,9 @@ func HookCommandNames() (names []string) {
 	return
 }
 
-// NewHookCommand returns an instance of the named hook Command, initialized to execute
-// against the supplied Context.
-func NewHookCommand(ctx Context, name string) (cmd.Command, error) {
+// NewHookCommandForHelp returns an instance of the named hook Command, only
+// for generating help.
+func NewHookCommandForHelp(ctx Context, name string) (cmd.Command, error) {
 	f := allHookCommands()[name]
 	if f == nil {
 		return nil, errors.Errorf("unknown hook command: %s", name)
@@ -180,12 +180,26 @@ func NewHookCommand(ctx Context, name string) (cmd.Command, error) {
 	return command, nil
 }
 
-// NewActionCommand returns an instance of the named action Command, initialized to execute
-// against the supplied Context.
-func NewActionCommand(ctx Context, name string) (cmd.Command, error) {
+// NewActionCommandForHelp returns an instance of the named action Command, only
+// for generating help.
+func NewActionCommandForHelp(ctx Context, name string) (cmd.Command, error) {
 	f := allActionCommands()[name]
 	if f == nil {
 		return nil, errors.Errorf("unknown action command: %s", name)
+	}
+	command, err := f(ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return command, nil
+}
+
+// NewCommand returns an instance of the named action Command, initialized to execute
+// against the supplied Context.
+func NewCommand(ctx Context, name string) (cmd.Command, error) {
+	f := allEnabledCommands()[name]
+	if f == nil {
+		return nil, errors.Errorf("unknown command: %s", name)
 	}
 	command, err := f(ctx)
 	if err != nil {

--- a/internal/worker/uniter/runner/jujuc/server_test.go
+++ b/internal/worker/uniter/runner/jujuc/server_test.go
@@ -260,13 +260,13 @@ var newCommandTests = []struct {
 	{"storage-get", ""},
 	{"status-get", ""},
 	{"status-set", ""},
-	{"random", "unknown hook command: random"},
+	{"random", "unknown command: random"},
 }
 
 func (s *NewCommandSuite) TestNewCommand(c *gc.C) {
 	ctx, _ := s.newHookContext(0, "", "")
 	for _, t := range newCommandTests {
-		com, err := jujuc.NewHookCommand(ctx, t.name)
+		com, err := jujuc.NewCommand(ctx, t.name)
 		if t.err == "" {
 			// At this level, just check basic sanity; commands are tested in
 			// more detail elsewhere.

--- a/internal/worker/uniter/runner/jujuc/state-delete_test.go
+++ b/internal/worker/uniter/runner/jujuc/state-delete_test.go
@@ -46,7 +46,7 @@ func (s *stateDeleteSuite) TestStateDelete(c *gc.C) {
 			test.expect()
 		}
 
-		toolCmd, err := jujuc.NewHookCommand(s.mockContext, "state-delete")
+		toolCmd, err := jujuc.NewCommand(s.mockContext, "state-delete")
 		c.Assert(err, jc.ErrorIsNil)
 
 		ctx := cmdtesting.Context(c)

--- a/internal/worker/uniter/runner/jujuc/state-get_test.go
+++ b/internal/worker/uniter/runner/jujuc/state-get_test.go
@@ -76,7 +76,7 @@ func (s *stateGetSuite) TestStateGet(c *gc.C) {
 		defer s.setupMocks(c).Finish()
 		test.expect()
 
-		toolCmd, err := jujuc.NewHookCommand(s.mockContext, "state-get")
+		toolCmd, err := jujuc.NewCommand(s.mockContext, "state-get")
 		c.Assert(err, jc.ErrorIsNil)
 
 		ctx := cmdtesting.Context(c)

--- a/internal/worker/uniter/runner/jujuc/state-set_test.go
+++ b/internal/worker/uniter/runner/jujuc/state-set_test.go
@@ -77,7 +77,7 @@ func (s *stateSetSuite) TestStateSet(c *gc.C) {
 			test.expect()
 		}
 
-		toolCmd, err := jujuc.NewHookCommand(s.mockContext, "state-set")
+		toolCmd, err := jujuc.NewCommand(s.mockContext, "state-set")
 		c.Assert(err, jc.ErrorIsNil)
 
 		ctx := cmdtesting.Context(c)
@@ -96,7 +96,7 @@ func (s *stateSetSuite) TestStateSetExistingEmpty(c *gc.C) {
 	s.expectStateSetOne()
 	s.expectStateSetOneEmpty()
 
-	toolCmd, err := jujuc.NewHookCommand(s.mockContext, "state-set")
+	toolCmd, err := jujuc.NewCommand(s.mockContext, "state-set")
 	c.Assert(err, jc.ErrorIsNil)
 
 	ctx := cmdtesting.Context(c)

--- a/internal/worker/uniter/runner/jujuc/status-get_test.go
+++ b/internal/worker/uniter/runner/jujuc/status-get_test.go
@@ -73,7 +73,7 @@ func (s *statusGetSuite) TestOutputFormatJustStatus(c *gc.C) {
 		c.Logf("test %d: %#v", i, t.args)
 		hctx := s.GetStatusHookContext(c)
 		setFakeStatus(hctx)
-		com, err := jujuc.NewHookCommand(hctx, "status-get")
+		com, err := jujuc.NewCommand(hctx, "status-get")
 		c.Assert(err, jc.ErrorIsNil)
 		ctx := cmdtesting.Context(c)
 		code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, t.args)
@@ -99,7 +99,7 @@ func (s *statusGetSuite) TestOutputFormatJustStatus(c *gc.C) {
 func (s *statusGetSuite) TestOutputPath(c *gc.C) {
 	hctx := s.GetStatusHookContext(c)
 	setFakeStatus(hctx)
-	com, err := jujuc.NewHookCommand(hctx, "status-get")
+	com, err := jujuc.NewCommand(hctx, "status-get")
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
 	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"--format", "json", "--output", "some-file", "--include-data"})
@@ -130,7 +130,7 @@ func (s *statusGetSuite) TestApplicationStatus(c *gc.C) {
 	}
 	hctx := s.GetStatusHookContext(c)
 	setFakeApplicationStatus(hctx)
-	com, err := jujuc.NewHookCommand(hctx, "status-get")
+	com, err := jujuc.NewCommand(hctx, "status-get")
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
 	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"--format", "json", "--include-data", "--application"})

--- a/internal/worker/uniter/runner/jujuc/status-set_test.go
+++ b/internal/worker/uniter/runner/jujuc/status-set_test.go
@@ -40,7 +40,7 @@ func (s *statusSetSuite) TestStatusSetInit(c *gc.C) {
 	for i, t := range statusSetInitTests {
 		c.Logf("test %d: %#v", i, t.args)
 		hctx := s.GetStatusHookContext(c)
-		com, err := jujuc.NewHookCommand(hctx, "status-set")
+		com, err := jujuc.NewCommand(hctx, "status-set")
 		c.Assert(err, jc.ErrorIsNil)
 		cmdtesting.TestInit(c, com, t.args, t.err)
 	}
@@ -53,7 +53,7 @@ func (s *statusSetSuite) TestStatus(c *gc.C) {
 	} {
 		c.Logf("test %d: %#v", i, args)
 		hctx := s.GetStatusHookContext(c)
-		com, err := jujuc.NewHookCommand(hctx, "status-set")
+		com, err := jujuc.NewCommand(hctx, "status-set")
 		c.Assert(err, jc.ErrorIsNil)
 		ctx := cmdtesting.Context(c)
 		code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, args)
@@ -74,7 +74,7 @@ func (s *statusSetSuite) TestApplicationStatus(c *gc.C) {
 	} {
 		c.Logf("test %d: %#v", i, args)
 		hctx := s.GetStatusHookContext(c)
-		com, err := jujuc.NewHookCommand(hctx, "status-set")
+		com, err := jujuc.NewCommand(hctx, "status-set")
 		c.Assert(err, jc.ErrorIsNil)
 		ctx := cmdtesting.Context(c)
 		code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, args)

--- a/internal/worker/uniter/runner/jujuc/storage-add_test.go
+++ b/internal/worker/uniter/runner/jujuc/storage-add_test.go
@@ -20,7 +20,7 @@ var _ = gc.Suite(&storageAddSuite{})
 
 func (s *storageAddSuite) getStorageUnitAddCommand(c *gc.C) cmd.Command {
 	hctx, _ := s.ContextSuite.NewHookContext()
-	com, err := jujuc.NewHookCommand(hctx, "storage-add")
+	com, err := jujuc.NewCommand(hctx, "storage-add")
 	c.Assert(err, jc.ErrorIsNil)
 	return jujuc.NewJujucCommandWrappedForTest(com)
 }

--- a/internal/worker/uniter/runner/jujuc/storage-get_test.go
+++ b/internal/worker/uniter/runner/jujuc/storage-get_test.go
@@ -38,7 +38,7 @@ func (s *storageGetSuite) TestOutputFormatKey(c *gc.C) {
 	for i, t := range storageGetTests {
 		c.Logf("test %d: %#v", i, t.args)
 		hctx, _ := s.newHookContext()
-		com, err := jujuc.NewHookCommand(hctx, "storage-get")
+		com, err := jujuc.NewCommand(hctx, "storage-get")
 		c.Assert(err, jc.ErrorIsNil)
 		ctx := cmdtesting.Context(c)
 		code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, t.args)
@@ -63,7 +63,7 @@ func (s *storageGetSuite) TestOutputFormatKey(c *gc.C) {
 
 func (s *storageGetSuite) TestOutputPath(c *gc.C) {
 	hctx, _ := s.newHookContext()
-	com, err := jujuc.NewHookCommand(hctx, "storage-get")
+	com, err := jujuc.NewCommand(hctx, "storage-get")
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
 	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"--format", "yaml", "--output", "some-file", "-s", "data/0"})

--- a/internal/worker/uniter/runner/jujuc/storage-list_test.go
+++ b/internal/worker/uniter/runner/jujuc/storage-list_test.go
@@ -76,7 +76,7 @@ func (s *storageListSuite) TestOutputNoMatches(c *gc.C) {
 
 func (s *storageListSuite) testOutputFormat(c *gc.C, args []string, format int, expect interface{}) {
 	hctx := s.newHookContext()
-	com, err := jujuc.NewHookCommand(hctx, "storage-list")
+	com, err := jujuc.NewCommand(hctx, "storage-list")
 	c.Assert(err, jc.ErrorIsNil)
 	ctx := cmdtesting.Context(c)
 	code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, args)

--- a/internal/worker/uniter/runner/jujuc/unit-get_test.go
+++ b/internal/worker/uniter/runner/jujuc/unit-get_test.go
@@ -37,7 +37,7 @@ var unitGetTests = []struct {
 
 func (s *UnitGetSuite) createCommand(c *gc.C) cmd.Command {
 	hctx := s.GetHookContext(c, -1, "")
-	com, err := jujuc.NewHookCommand(hctx, "unit-get")
+	com, err := jujuc.NewCommand(hctx, "unit-get")
 	c.Assert(err, jc.ErrorIsNil)
 	return jujuc.NewJujucCommandWrappedForTest(com)
 }
@@ -160,7 +160,7 @@ func (s *UnitGetSuite) TestNetworkInfoPrivateAddress(c *gc.C) {
 	launchCommand := func(input map[string]params.NetworkInfoResult, expected string) {
 		hctx := s.GetHookContext(c, -1, "")
 		hctx.info.NetworkInterface.NetworkInfoResults = input
-		com, err := jujuc.NewHookCommand(hctx, "unit-get")
+		com, err := jujuc.NewCommand(hctx, "unit-get")
 		c.Assert(err, jc.ErrorIsNil)
 		ctx := cmdtesting.Context(c)
 		code := cmd.Main(jujuc.NewJujucCommandWrappedForTest(com), ctx, []string{"private-address"})

--- a/internal/worker/uniter/runner/runner.go
+++ b/internal/worker/uniter/runner/runner.go
@@ -540,7 +540,7 @@ func (runner *runner) startJujucServer(ctx stdcontext.Context) (*jujuc.Server, e
 		if ctxId != runner.context.Id() {
 			return nil, errors.Errorf("wrong context ID; got %q", ctxId)
 		}
-		return jujuc.NewHookCommand(runner.context, cmdName)
+		return jujuc.NewCommand(runner.context, cmdName)
 	}
 
 	socket := runner.paths.GetJujucServerSocket()

--- a/scripts/md-gen/hook-commands/main.go
+++ b/scripts/md-gen/hook-commands/main.go
@@ -35,7 +35,7 @@ func main() {
 		if slices.Contains(ignoreCommands, name) {
 			continue
 		}
-		hookTool, err := jujuc.NewHookCommand(dummyHookContext{}, name)
+		hookTool, err := jujuc.NewHookCommandForHelp(dummyHookContext{}, name)
 		check(err)
 		jujucSuperCmd.Register(hookTool)
 	}
@@ -43,7 +43,7 @@ func main() {
 		if slices.Contains(ignoreCommands, name) {
 			continue
 		}
-		actionTool, err := jujuc.NewActionCommand(dummyHookContext{}, name)
+		actionTool, err := jujuc.NewActionCommandForHelp(dummyHookContext{}, name)
 		check(err)
 		jujucSuperCmd.Register(actionTool)
 	}


### PR DESCRIPTION
Merge 3.6

```
# Conflicts:
#       apiserver/common/secrets/secrets.go
#       apiserver/common/secrets/secrets_test.go
#       core/version/version.go
#       internal/worker/uniter/runner/jujuc/add-metric_test.go
#       internal/worker/uniter/runner/jujuc/k8s-raw-get_test.go
#       internal/worker/uniter/runner/jujuc/k8s-raw-set_test.go
#       internal/worker/uniter/runner/jujuc/k8s-spec-get_test.go
#       internal/worker/uniter/runner/jujuc/k8s-spec-set_test.go
#       internal/worker/uniter/runner/jujuc/payload-register_test.go
#       internal/worker/uniter/runner/jujuc/payload-status-set_test.go
#       internal/worker/uniter/runner/jujuc/payload-unregister_test.go
#       scripts/win-installer/setup.iss
#       snap/snapcraft.yaml
```

https://github.com/juju/juju/pull/19169 [from ca-scribner/lp2093271-allow-notfound-i…](https://github.com/juju/juju/commit/fabc8c64592a5ce80265ab4b5bc7c21ec6dd168a)
https://github.com/juju/juju/pull/19416 [from hpidcock/partially-revert-19313](https://github.com/juju/juju/commit/33b026f4ab2a4fe371764b9c41993d3e1e90ddef)
https://github.com/juju/juju/pull/19427 [from juju/increment-to-3.6.6](https://github.com/juju/juju/pull/19629/commits/6d3760b5de0eba780c2ca05b8251c0462a1e1b5e)
