### PR TITLE
refactor: remove basic model information from apiserver network common

### DIFF
--- a/apiserver/common/networkingcommon/networkconfigapi.go
+++ b/apiserver/common/networkingcommon/networkconfigapi.go
@@ -25,6 +25,13 @@ import (
 
 var logger = internallogger.GetLogger("juju.apiserver.common.networkingcommon")
 
+// ModelInfoService is the interface that is used to ask questions about the
+// current model.
+type ModelInfoService interface {
+	// GetCloudType returns the type of the cloud that is in use by this model.
+	GetModelCloudType(context.Context) (string, error)
+}
+
 // NetworkService is the interface that is used to interact with the
 // network spaces/subnets.
 type NetworkService interface {
@@ -43,17 +50,14 @@ type NetworkConfigAPI struct {
 
 // NewNetworkConfigAPI constructs a new common network configuration API
 // and returns its reference.
-func NewNetworkConfigAPI(ctx context.Context, st *state.State, cloudService common.CloudService, networkService NetworkService, getCanModify common.GetAuthFunc) (*NetworkConfigAPI, error) {
-	// TODO (manadart 2020-08-11): This is a second access of the model when
-	// being instantiated by the provisioner API.
-	// We should ameliorate repeat model access at some point,
-	// as it queries state each time.
-	mod, err := st.Model()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	cloud, err := cloudService.Cloud(ctx, mod.CloudName())
+func NewNetworkConfigAPI(
+	ctx context.Context,
+	st *state.State,
+	modelInfoService ModelInfoService,
+	networkService NetworkService,
+	getCanModify common.GetAuthFunc,
+) (*NetworkConfigAPI, error) {
+	cloudType, err := modelInfoService.GetModelCloudType(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -61,7 +65,7 @@ func NewNetworkConfigAPI(ctx context.Context, st *state.State, cloudService comm
 	getModelOp := func(machine LinkLayerMachine, incoming network.InterfaceInfos) state.ModelOperation {
 		// We discover subnets via reported link-layer devices for the
 		// manual provider, which allows us to use spaces there.
-		return newUpdateMachineLinkLayerOp(machine, networkService, incoming, strings.EqualFold(cloud.Type, "manual"))
+		return newUpdateMachineLinkLayerOp(machine, networkService, incoming, strings.EqualFold(cloudType, "manual"))
 	}
 
 	return &NetworkConfigAPI{

--- a/apiserver/common/networkingcommon/types.go
+++ b/apiserver/common/networkingcommon/types.go
@@ -28,9 +28,6 @@ type NetworkBacking interface {
 	// SetAvailabilityZones replaces the cached list of availability
 	// zones with the given zones.
 	SetAvailabilityZones(network.AvailabilityZones) error
-
-	// ModelTag returns the tag of the model this state is associated to.
-	ModelTag() names.ModelTag
 }
 
 // BackingSubnetToParamsSubnetV2 converts a network backing subnet to the new

--- a/apiserver/facades/agent/machine/machiner.go
+++ b/apiserver/facades/agent/machine/machiner.go
@@ -50,6 +50,13 @@ type MachineService interface {
 	IsMachineController(context.Context, machine.Name) (bool, error)
 }
 
+// ModelInfoService is the interface that is used to ask questions about the
+// current model.
+type ModelInfoService interface {
+	// GetCloudType returns the type of the cloud that is in use by this model.
+	GetModelCloudType(context.Context) (string, error)
+}
+
 // MachinerAPI implements the API used by the machiner worker.
 type MachinerAPI struct {
 	*common.LifeGetter
@@ -79,7 +86,7 @@ func NewMachinerAPIForState(
 	ctrlSt, st *state.State,
 	clock clock.Clock,
 	controllerConfigService ControllerConfigService,
-	cloudService common.CloudService,
+	modelInfoService ModelInfoService,
 	networkService NetworkService,
 	machineService MachineService,
 	watcherRegistry facade.WatcherRegistry,
@@ -94,7 +101,7 @@ func NewMachinerAPIForState(
 		return authorizer.AuthOwner, nil
 	}
 
-	netConfigAPI, err := networkingcommon.NewNetworkConfigAPI(ctx, st, cloudService, networkService, getCanAccess)
+	netConfigAPI, err := networkingcommon.NewNetworkConfigAPI(ctx, st, modelInfoService, networkService, getCanAccess)
 	if err != nil {
 		return nil, errors.Annotate(err, "instantiating network config API")
 	}

--- a/apiserver/facades/agent/machine/machiner_test.go
+++ b/apiserver/facades/agent/machine/machiner_test.go
@@ -20,7 +20,6 @@ import (
 	coremachine "github.com/juju/juju/core/machine"
 	"github.com/juju/juju/core/network"
 	"github.com/juju/juju/core/status"
-	"github.com/juju/juju/juju/testing"
 	"github.com/juju/juju/rpc/params"
 	"github.com/juju/juju/state"
 )
@@ -54,7 +53,7 @@ func (s *machinerSuite) makeAPI(c *gc.C) {
 		st,
 		clock.WallClock,
 		s.ControllerDomainServices(c).ControllerConfig(),
-		apiservertesting.ConstCloudGetter(&testing.DefaultCloud),
+		s.ControllerDomainServices(c).ModelInfo(),
 		s.networkService,
 		s.machineService,
 		s.watcherRegistry,

--- a/apiserver/facades/agent/machine/register.go
+++ b/apiserver/facades/agent/machine/register.go
@@ -40,7 +40,7 @@ func newMachinerAPI(stdCtx context.Context, ctx facade.ModelContext) (*MachinerA
 		ctx.State(),
 		ctx.Clock(),
 		domainServices.ControllerConfig(),
-		domainServices.Cloud(),
+		domainServices.ModelInfo(),
 		domainServices.Network(),
 		domainServices.Machine(),
 		ctx.WatcherRegistry(),

--- a/apiserver/facades/agent/provisioner/provisioner.go
+++ b/apiserver/facades/agent/provisioner/provisioner.go
@@ -159,7 +159,7 @@ func MakeProvisionerAPI(stdCtx context.Context, ctx facade.ModelContext) (*Provi
 	storageProviderRegistry := provider.NewStorageProviderRegistry(env)
 
 	netConfigAPI, err := networkingcommon.NewNetworkConfigAPI(
-		stdCtx, st, domainServices.Cloud(), domainServices.Network(), getCanModify)
+		stdCtx, st, domainServices.ModelInfo(), domainServices.Network(), getCanModify)
 	if err != nil {
 		return nil, errors.Annotate(err, "instantiating network config API")
 	}

--- a/domain/model/service/modelservice.go
+++ b/domain/model/service/modelservice.go
@@ -149,6 +149,11 @@ func (s *ModelService) GetModelConstraints(ctx context.Context) (coreconstraints
 	return constraints.EncodeConstraints(cons), nil
 }
 
+// GetCloudType returns the type of the cloud that is in use by this model.
+func (s *ModelService) GetModelCloudType(ctx context.Context) (string, error) {
+	return s.modelSt.GetModelCloudType(ctx)
+}
+
 // SetModelConstraints sets the model constraints to the new values removing
 // any previously set constraints.
 //


### PR DESCRIPTION
<!--
The PR title should match: <type>(optional <scope>): <description>.

Please also ensure all commits in this PR comply with our conventional commits specification:
https://github.com/juju/juju/blob/main/docs/contributor/reference/conventional-commits.md
-->

<!-- Why this change is needed and what it does. -->
This change removes the need for the common/networkingcommon facade to access mongo state to retrieve the model related information for the current context. Instead we now pull this information from the facade model context which in turn is backed by DQlite.

This facade does not rely on mongo anymore for accessing model information.
## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## QA steps

1. Bootstrap a 4.0 controller on lxd and add a test model
```sh
$ juju bootstrap lxd lxdtest
$ juju add-model test
```

2. Chech the status
```sh
$  juju status
$  juju show-model test
```

3. Remove the model
```sh
$ juju destroy-model --no-prompt test
```

4. Check the status without any issues
```sh
$ juju status
```


## Links

<!-- Link to all relevant specification, documentation, bug, issue or JIRA card. -->

<!-- Add a Jira card reference or link, otherwise remove this line. -->
**Jira card:** [JUJU-7902](https://warthogs.atlassian.net/browse/JUJU-7902)