### PR TITLE
refactor: remove some unused networking members

### DIFF
--- a/apiserver/common/networkingcommon/types.go
+++ b/apiserver/common/networkingcommon/types.go
@@ -158,18 +158,17 @@ func networkAddressesToStateArgs(
 		}
 
 		res = append(res, state.LinkLayerDeviceAddress{
-			DeviceName:        dev.InterfaceName,
-			ProviderID:        dev.ProviderAddressId,
-			ProviderNetworkID: dev.ProviderNetworkId,
-			ProviderSubnetID:  dev.ProviderSubnetId,
-			ConfigMethod:      configType,
-			CIDRAddress:       cidrAddress,
-			DNSServers:        dev.DNSServers,
-			DNSSearchDomains:  dev.DNSSearchDomains,
-			GatewayAddress:    dev.GatewayAddress.Value,
-			IsDefaultGateway:  dev.IsDefaultGateway,
-			Origin:            dev.Origin,
-			IsSecondary:       addr.IsSecondary,
+			DeviceName:       dev.InterfaceName,
+			ProviderID:       dev.ProviderAddressId,
+			ProviderSubnetID: dev.ProviderSubnetId,
+			ConfigMethod:     configType,
+			CIDRAddress:      cidrAddress,
+			DNSServers:       dev.DNSServers,
+			DNSSearchDomains: dev.DNSSearchDomains,
+			GatewayAddress:   dev.GatewayAddress.Value,
+			IsDefaultGateway: dev.IsDefaultGateway,
+			Origin:           dev.Origin,
+			IsSecondary:      addr.IsSecondary,
 		})
 	}
 

--- a/apiserver/facades/schema.json
+++ b/apiserver/facades/schema.json
@@ -14096,9 +14096,6 @@
                         "space-tag": {
                             "type": "string"
                         },
-                        "status": {
-                            "type": "string"
-                        },
                         "vlan-tag": {
                             "type": "integer"
                         },
@@ -15351,9 +15348,6 @@
                         "space-tag": {
                             "type": "string"
                         },
-                        "status": {
-                            "type": "string"
-                        },
                         "vlan-tag": {
                             "type": "integer"
                         },
@@ -15398,9 +15392,6 @@
                             "type": "string"
                         },
                         "space-tag": {
-                            "type": "string"
-                        },
-                        "status": {
                             "type": "string"
                         },
                         "vlan-tag": {

--- a/core/network/nic.go
+++ b/core/network/nic.go
@@ -89,10 +89,6 @@ type InterfaceInfo struct {
 	// subnet.
 	ProviderSubnetId Id
 
-	// ProviderNetworkId is the provider-specific id for the
-	// associated network.
-	ProviderNetworkId Id
-
 	// ProviderSpaceId is the provider-specific id for the associated space,
 	// if known and supported.
 	ProviderSpaceId Id

--- a/internal/provider/gce/environ_network.go
+++ b/internal/provider/gce/environ_network.go
@@ -179,10 +179,9 @@ func (e *environ) NetworkInterfaces(ctx envcontext.ProviderCallContext, ids []in
 				DeviceIndex: i,
 				// The network interface has no id in GCE so it's
 				// identified by the machine's id + its name.
-				ProviderId:        corenetwork.Id(fmt.Sprintf("%s/%s", ids[idx], iface.Name)),
-				ProviderSubnetId:  details.subnet,
-				ProviderNetworkId: details.network,
-				InterfaceName:     iface.Name,
+				ProviderId:       corenetwork.Id(fmt.Sprintf("%s/%s", ids[idx], iface.Name)),
+				ProviderSubnetId: details.subnet,
+				InterfaceName:    iface.Name,
 				Addresses: corenetwork.ProviderAddresses{corenetwork.NewMachineAddress(
 					iface.NetworkIP,
 					corenetwork.WithScope(corenetwork.ScopeCloudLocal),

--- a/internal/provider/gce/environ_network_test.go
+++ b/internal/provider/gce/environ_network_test.go
@@ -146,14 +146,13 @@ func (s *environNetSuite) TestInterfaces(c *gc.C) {
 	infos := infoList[0]
 
 	c.Assert(infos, gc.DeepEquals, corenetwork.InterfaceInfos{{
-		DeviceIndex:       0,
-		ProviderId:        "moana/somenetif",
-		ProviderSubnetId:  "go-team",
-		ProviderNetworkId: "go-team1",
-		InterfaceName:     "somenetif",
-		InterfaceType:     corenetwork.EthernetDevice,
-		Disabled:          false,
-		NoAutoStart:       false,
+		DeviceIndex:      0,
+		ProviderId:       "moana/somenetif",
+		ProviderSubnetId: "go-team",
+		InterfaceName:    "somenetif",
+		InterfaceType:    corenetwork.EthernetDevice,
+		Disabled:         false,
+		NoAutoStart:      false,
 		Addresses: corenetwork.ProviderAddresses{corenetwork.NewMachineAddress(
 			"10.0.10.3",
 			corenetwork.WithScope(corenetwork.ScopeCloudLocal),
@@ -232,14 +231,13 @@ func (s *environNetSuite) TestInterfacesForMultipleInstances(c *gc.C) {
 	// Check interfaces for first instance
 	infos := infoLists[0]
 	c.Assert(infos, gc.DeepEquals, corenetwork.InterfaceInfos{{
-		DeviceIndex:       0,
-		ProviderId:        "i-1/somenetif",
-		ProviderSubnetId:  "go-team",
-		ProviderNetworkId: "go-team1",
-		InterfaceName:     "somenetif",
-		InterfaceType:     corenetwork.EthernetDevice,
-		Disabled:          false,
-		NoAutoStart:       false,
+		DeviceIndex:      0,
+		ProviderId:       "i-1/somenetif",
+		ProviderSubnetId: "go-team",
+		InterfaceName:    "somenetif",
+		InterfaceType:    corenetwork.EthernetDevice,
+		Disabled:         false,
+		NoAutoStart:      false,
 		Addresses: corenetwork.ProviderAddresses{corenetwork.NewMachineAddress(
 			"10.0.10.3",
 			corenetwork.WithScope(corenetwork.ScopeCloudLocal),
@@ -252,14 +250,13 @@ func (s *environNetSuite) TestInterfacesForMultipleInstances(c *gc.C) {
 	// Check interfaces for second instance
 	infos = infoLists[1]
 	c.Assert(infos, gc.DeepEquals, corenetwork.InterfaceInfos{{
-		DeviceIndex:       0,
-		ProviderId:        "i-2/netif-0",
-		ProviderSubnetId:  "go-team",
-		ProviderNetworkId: "go-team1",
-		InterfaceName:     "netif-0",
-		InterfaceType:     corenetwork.EthernetDevice,
-		Disabled:          false,
-		NoAutoStart:       false,
+		DeviceIndex:      0,
+		ProviderId:       "i-2/netif-0",
+		ProviderSubnetId: "go-team",
+		InterfaceName:    "netif-0",
+		InterfaceType:    corenetwork.EthernetDevice,
+		Disabled:         false,
+		NoAutoStart:      false,
 		Addresses: corenetwork.ProviderAddresses{corenetwork.NewMachineAddress(
 			"10.0.10.42",
 			corenetwork.WithScope(corenetwork.ScopeCloudLocal),
@@ -271,14 +268,13 @@ func (s *environNetSuite) TestInterfacesForMultipleInstances(c *gc.C) {
 		},
 		Origin: corenetwork.OriginProvider,
 	}, {
-		DeviceIndex:       1,
-		ProviderId:        "i-2/netif-1",
-		ProviderSubnetId:  "shellac",
-		ProviderNetworkId: "albini",
-		InterfaceName:     "netif-1",
-		InterfaceType:     corenetwork.EthernetDevice,
-		Disabled:          false,
-		NoAutoStart:       false,
+		DeviceIndex:      1,
+		ProviderId:       "i-2/netif-1",
+		ProviderSubnetId: "shellac",
+		InterfaceName:    "netif-1",
+		InterfaceType:    corenetwork.EthernetDevice,
+		Disabled:         false,
+		NoAutoStart:      false,
 		Addresses: corenetwork.ProviderAddresses{corenetwork.NewMachineAddress(
 			"10.0.20.42",
 			corenetwork.WithScope(corenetwork.ScopeCloudLocal),
@@ -301,14 +297,13 @@ func (s *environNetSuite) TestPartialInterfacesForMultipleInstances(c *gc.C) {
 	// Check interfaces for first instance
 	infos := infoLists[0]
 	c.Assert(infos, gc.DeepEquals, corenetwork.InterfaceInfos{{
-		DeviceIndex:       0,
-		ProviderId:        "i-1/somenetif",
-		ProviderSubnetId:  "go-team",
-		ProviderNetworkId: "go-team1",
-		InterfaceName:     "somenetif",
-		InterfaceType:     corenetwork.EthernetDevice,
-		Disabled:          false,
-		NoAutoStart:       false,
+		DeviceIndex:      0,
+		ProviderId:       "i-1/somenetif",
+		ProviderSubnetId: "go-team",
+		InterfaceName:    "somenetif",
+		InterfaceType:    corenetwork.EthernetDevice,
+		Disabled:         false,
+		NoAutoStart:      false,
 		Addresses: corenetwork.ProviderAddresses{corenetwork.NewMachineAddress(
 			"10.0.10.3",
 			corenetwork.WithScope(corenetwork.ScopeCloudLocal),
@@ -347,14 +342,13 @@ func (s *environNetSuite) TestInterfacesMulti(c *gc.C) {
 	infos := infoList[0]
 
 	c.Assert(infos, gc.DeepEquals, corenetwork.InterfaceInfos{{
-		DeviceIndex:       0,
-		ProviderId:        "moana/somenetif",
-		ProviderSubnetId:  "go-team",
-		ProviderNetworkId: "go-team1",
-		InterfaceName:     "somenetif",
-		InterfaceType:     corenetwork.EthernetDevice,
-		Disabled:          false,
-		NoAutoStart:       false,
+		DeviceIndex:      0,
+		ProviderId:       "moana/somenetif",
+		ProviderSubnetId: "go-team",
+		InterfaceName:    "somenetif",
+		InterfaceType:    corenetwork.EthernetDevice,
+		Disabled:         false,
+		NoAutoStart:      false,
 		Addresses: corenetwork.ProviderAddresses{corenetwork.NewMachineAddress(
 			"10.0.10.3",
 			corenetwork.WithScope(corenetwork.ScopeCloudLocal),
@@ -363,14 +357,13 @@ func (s *environNetSuite) TestInterfacesMulti(c *gc.C) {
 		).AsProviderAddress()},
 		Origin: corenetwork.OriginProvider,
 	}, {
-		DeviceIndex:       1,
-		ProviderId:        "moana/othernetif",
-		ProviderSubnetId:  "shellac",
-		ProviderNetworkId: "albini",
-		InterfaceName:     "othernetif",
-		InterfaceType:     corenetwork.EthernetDevice,
-		Disabled:          false,
-		NoAutoStart:       false,
+		DeviceIndex:      1,
+		ProviderId:       "moana/othernetif",
+		ProviderSubnetId: "shellac",
+		InterfaceName:    "othernetif",
+		InterfaceType:    corenetwork.EthernetDevice,
+		Disabled:         false,
+		NoAutoStart:      false,
 		Addresses: corenetwork.ProviderAddresses{corenetwork.NewMachineAddress(
 			"10.0.20.3",
 			corenetwork.WithScope(corenetwork.ScopeCloudLocal),
@@ -408,14 +401,13 @@ func (s *environNetSuite) TestInterfacesLegacy(c *gc.C) {
 	infos := infoList[0]
 
 	c.Assert(infos, gc.DeepEquals, corenetwork.InterfaceInfos{{
-		DeviceIndex:       0,
-		ProviderId:        "moana/somenetif",
-		ProviderSubnetId:  "",
-		ProviderNetworkId: "legacy",
-		InterfaceName:     "somenetif",
-		InterfaceType:     corenetwork.EthernetDevice,
-		Disabled:          false,
-		NoAutoStart:       false,
+		DeviceIndex:      0,
+		ProviderId:       "moana/somenetif",
+		ProviderSubnetId: "",
+		InterfaceName:    "somenetif",
+		InterfaceType:    corenetwork.EthernetDevice,
+		Disabled:         false,
+		NoAutoStart:      false,
 		Addresses: corenetwork.ProviderAddresses{corenetwork.NewMachineAddress(
 			"10.240.0.2",
 			corenetwork.WithScope(corenetwork.ScopeCloudLocal),
@@ -454,14 +446,13 @@ func (s *environNetSuite) TestInterfacesSameSubnetwork(c *gc.C) {
 	infos := infoList[0]
 
 	c.Assert(infos, gc.DeepEquals, corenetwork.InterfaceInfos{{
-		DeviceIndex:       0,
-		ProviderId:        "moana/somenetif",
-		ProviderSubnetId:  "go-team",
-		ProviderNetworkId: "go-team1",
-		InterfaceName:     "somenetif",
-		InterfaceType:     corenetwork.EthernetDevice,
-		Disabled:          false,
-		NoAutoStart:       false,
+		DeviceIndex:      0,
+		ProviderId:       "moana/somenetif",
+		ProviderSubnetId: "go-team",
+		InterfaceName:    "somenetif",
+		InterfaceType:    corenetwork.EthernetDevice,
+		Disabled:         false,
+		NoAutoStart:      false,
 		Addresses: corenetwork.ProviderAddresses{corenetwork.NewMachineAddress(
 			"10.0.10.3",
 			corenetwork.WithScope(corenetwork.ScopeCloudLocal),
@@ -470,14 +461,13 @@ func (s *environNetSuite) TestInterfacesSameSubnetwork(c *gc.C) {
 		).AsProviderAddress()},
 		Origin: corenetwork.OriginProvider,
 	}, {
-		DeviceIndex:       1,
-		ProviderId:        "moana/othernetif",
-		ProviderSubnetId:  "go-team",
-		ProviderNetworkId: "go-team1",
-		InterfaceName:     "othernetif",
-		InterfaceType:     corenetwork.EthernetDevice,
-		Disabled:          false,
-		NoAutoStart:       false,
+		DeviceIndex:      1,
+		ProviderId:       "moana/othernetif",
+		ProviderSubnetId: "go-team",
+		InterfaceName:    "othernetif",
+		InterfaceType:    corenetwork.EthernetDevice,
+		Disabled:         false,
+		NoAutoStart:      false,
 		Addresses: corenetwork.ProviderAddresses{corenetwork.NewMachineAddress(
 			"10.0.10.4",
 			corenetwork.WithScope(corenetwork.ScopeCloudLocal),

--- a/internal/provider/lxd/environ_network.go
+++ b/internal/provider/lxd/environ_network.go
@@ -205,10 +205,6 @@ func makeInterfaceInfo(container *lxdapi.Instance, guestNetworkName string, netI
 		configType = network.ConfigLoopback
 	}
 
-	if ni.ParentInterfaceName != "" {
-		ni.ProviderNetworkId = makeNetworkID(ni.ParentInterfaceName)
-	}
-
 	// Iterate the list of addresses assigned to this interface ignoring
 	// any link-local ones. The first non link-local address is treated as
 	// the primary address and is used to populate the interface CIDR and

--- a/internal/provider/lxd/environ_network_test.go
+++ b/internal/provider/lxd/environ_network_test.go
@@ -260,7 +260,6 @@ func (s *environNetSuite) TestNetworkInterfaces(c *gc.C) {
 				Origin:              network.OriginProvider,
 				ProviderId:          "nic-00:16:3e:19:29:cb",
 				ProviderSubnetId:    "subnet-lxdbr0-10.55.158.0/24",
-				ProviderNetworkId:   "net-lxdbr0",
 				Addresses: network.ProviderAddresses{network.NewMachineAddress(
 					"10.55.158.99", network.WithCIDR("10.55.158.0/24"), network.WithConfigType(network.ConfigStatic),
 				).AsProviderAddress()},
@@ -275,7 +274,6 @@ func (s *environNetSuite) TestNetworkInterfaces(c *gc.C) {
 				Origin:              network.OriginProvider,
 				ProviderId:          "nic-00:16:3e:fe:fe:fe",
 				ProviderSubnetId:    "subnet-ovsbr0-10.42.42.0/24",
-				ProviderNetworkId:   "net-ovsbr0",
 				Addresses: network.ProviderAddresses{network.NewMachineAddress(
 					"10.42.42.99", network.WithCIDR("10.42.42.0/24"), network.WithConfigType(network.ConfigStatic),
 				).AsProviderAddress()},
@@ -338,7 +336,6 @@ func (s *environNetSuite) TestNetworkInterfacesPartialResults(c *gc.C) {
 				Origin:              network.OriginProvider,
 				ProviderId:          "nic-00:16:3e:19:29:cb",
 				ProviderSubnetId:    "subnet-lxdbr0-10.55.158.0/24",
-				ProviderNetworkId:   "net-lxdbr0",
 				Addresses: network.ProviderAddresses{network.NewMachineAddress(
 					"10.55.158.99", network.WithCIDR("10.55.158.0/24"), network.WithConfigType(network.ConfigStatic),
 				).AsProviderAddress()},

--- a/internal/provider/openstack/networking.go
+++ b/internal/provider/openstack/networking.go
@@ -515,9 +515,8 @@ func mapInterfaceList(
 
 	for idx, port := range in {
 		ni := network.InterfaceInfo{
-			DeviceIndex:       idx,
-			ProviderId:        network.Id(port.Id),
-			ProviderNetworkId: network.Id(port.NetworkId),
+			DeviceIndex: idx,
+			ProviderId:  network.Id(port.Id),
 			// NOTE(achilleasa): on microstack port.Name is always empty.
 			InterfaceName: port.Name,
 			Disabled:      port.Status != "ACTIVE",

--- a/internal/provider/openstack/networking_test.go
+++ b/internal/provider/openstack/networking_test.go
@@ -253,7 +253,6 @@ func (s *networkingSuite) TestNetworkInterfaces(c *gc.C) {
 		).AsProviderAddress(),
 	})
 	c.Assert(nic0.ProviderId, gc.Equals, network.Id("nic-0"))
-	c.Assert(nic0.ProviderNetworkId, gc.Equals, network.Id("deadbeef-0bad-400d-8000-4b1ddbeefbeef"))
 	c.Assert(nic0.ProviderSubnetId, gc.Equals, network.Id("sub-42"), gc.Commentf("expected NIC to use the provider subnet ID for the primary NIC address"))
 
 	nic1 := res[0][1]
@@ -270,7 +269,6 @@ func (s *networkingSuite) TestNetworkInterfaces(c *gc.C) {
 		).AsProviderAddress(),
 	})
 	c.Assert(nic1.ProviderId, gc.Equals, network.Id("nic-1"))
-	c.Assert(nic1.ProviderNetworkId, gc.Equals, network.Id("deadbeef-0bad-400d-8000-4b1ddbeefbeef"))
 	c.Assert(nic1.ProviderSubnetId, gc.Equals, network.Id("sub-42"), gc.Commentf("expected NIC to use the provider subnet ID for the primary NIC address"))
 }
 

--- a/rpc/params/network.go
+++ b/rpc/params/network.go
@@ -102,6 +102,7 @@ type NetworkConfig struct {
 
 	// ProviderNetworkId is a provider-specific id for the network this
 	// interface is part of.
+	// Deprecated: no longer written or read.
 	ProviderNetworkId string `json:"provider-network-id"`
 
 	// ProviderSubnetId is a provider-specific subnet id, to which the
@@ -219,7 +220,6 @@ func NetworkConfigFromInterfaceInfo(interfaceInfos network.InterfaceInfos) []Net
 			ConfigType:          string(v.ConfigType),
 			MTU:                 v.MTU,
 			ProviderId:          string(v.ProviderId),
-			ProviderNetworkId:   string(v.ProviderNetworkId),
 			ProviderSubnetId:    string(v.ProviderSubnetId),
 			ProviderSpaceId:     string(v.ProviderSpaceId),
 			ProviderVLANId:      string(v.ProviderVLANId),
@@ -268,7 +268,6 @@ func InterfaceInfoFromNetworkConfig(configs []NetworkConfig) network.InterfaceIn
 			MACAddress:          network.NormalizeMACAddress(v.MACAddress),
 			MTU:                 v.MTU,
 			ProviderId:          network.Id(v.ProviderId),
-			ProviderNetworkId:   network.Id(v.ProviderNetworkId),
 			ProviderSubnetId:    network.Id(v.ProviderSubnetId),
 			ProviderSpaceId:     network.Id(v.ProviderSpaceId),
 			ProviderVLANId:      network.Id(v.ProviderVLANId),

--- a/rpc/params/network.go
+++ b/rpc/params/network.go
@@ -43,12 +43,6 @@ type Subnet struct {
 	// Zones contain one or more availability zones this subnet is
 	// associated with.
 	Zones []string `json:"zones"`
-
-	// TODO (jack-w-shaw 2022-02-22): Remove this. It is unused
-	//
-	// Status returns the status of the subnet, whether it is in use, not
-	// in use or terminating.
-	Status string `json:"status,omitempty"`
 }
 
 // SubnetV2 is used by versions of spaces/subnets APIs that must include


### PR DESCRIPTION
We have been capturing provider network IDs for some providers when polling instance network interfaces. Though these were transported over the wire and were and written to Mongo, they were never used.

This was a denormalisation in any case, because it is implied by provider network IDs recorded against any subnets that the interfaces are connected to.

Here we remove `ProviderNetworkID` from `InterfaceInfo`.

As a drive-by, `Status` is removed from the `Subnet` RPC params. It was long-since abandoned and has no usages in 3.6, so it is a compatibility-safe removal. The facade schema is regenerated accordingly.

## QA steps

Bootstrapping to LXD successfully proves we've not broken anything.