### PR TITLE
docs: fix intersphinx mapping issue

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -301,7 +301,7 @@ intersphinx_mapping = {
     # 'juju': ('https://canonical-juju.readthedocs-hosted.com/en/latest/', None),
     'tfjuju': ('https://canonical-terraform-provider-juju.readthedocs-hosted.com/en/latest/', None),
     'pyjuju': ('https://pythonlibjuju.readthedocs.io/en/latest/', None),
-    'jaas': ('https://canonical-jaas-documentation.readthedocs-hosted.com/en/latest/', None),
+    'jaas': ('https://canonical-jaas-documentation.readthedocs-hosted.com/latest/', None),
     'charmcraft': ('https://canonical-charmcraft.readthedocs-hosted.com/en/latest/', None),
     'ops': ('https://ops.readthedocs.io/en/latest/', None),
 }


### PR DESCRIPTION
## Checklist

<!-- If an item is not applicable, use `~strikethrough~`. -->

- [~] Code style: imports ordered, good names, simple structure, etc
- [~] Comments saying why design decisions were made
- [~] Go unit tests, with comments saying what you're testing
- [~] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [~] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

## Documentation changes

The current intersphinx mapping URL points to a 404 error page.
When building the docs, this error pops up and keeps affecting the build by auto-refreshing consistently and making it difficult to view some pages while making changes:
```bash
WARNING: failed to reach any of the inventories with the following issues:
intersphinx inventory 'https://canonical-jaas-documentation.readthedocs-hosted.com/en/latest/objects.inv' not fetchable
due to <class 'requests.exceptions.HTTPError'>: 404 Client Error: Not Found for url: https://canonical-jaas-
documentation.readthedocs-hosted.com/en/latest/objects.inv
```

The previous URL was https://canonical-jaas-documentation.readthedocs-hosted.com/en/latest/, but the correct URL is https://canonical-jaas-documentation.readthedocs-hosted.com/latest/