### PR TITLE
WIP: import peer relations with provided relation id

### DIFF
--- a/domain/application/modelmigration/import.go
+++ b/domain/application/modelmigration/import.go
@@ -26,7 +26,6 @@ import (
 	"github.com/juju/juju/core/semversion"
 	corestorage "github.com/juju/juju/core/storage"
 	"github.com/juju/juju/domain/application"
-	applicationcharm "github.com/juju/juju/domain/application/charm"
 	"github.com/juju/juju/domain/application/service"
 	"github.com/juju/juju/domain/application/state"
 	internalcharm "github.com/juju/juju/internal/charm"
@@ -203,17 +202,6 @@ func (i *importOperation) Execute(ctx context.Context, model description.Model) 
 			// name and not the charm name in the metadata, but the name of
 			// the charm from the store if it's a charm from the store.
 			ReferenceName: chURL.Name,
-			// When importing a charm, we don't have all the information
-			// about the charm. We could call charmhub store directly, but
-			// that has the potential to block a migration if the charmhub
-			// store is down. If we require that information, then it's
-			// possible to fill this missing information in the charmhub
-			// store using the charmhub identifier.
-			// If the controllers do not have the same charmhub url, then
-			// all bets are off.
-			DownloadInfo: &applicationcharm.DownloadInfo{
-				Provenance: applicationcharm.ProvenanceMigration,
-			},
 		})
 		if err != nil {
 			return errors.Errorf(

--- a/domain/application/modelmigration/import_test.go
+++ b/domain/application/modelmigration/import_test.go
@@ -1544,6 +1544,40 @@ func (s *importSuite) TestApplicationImportSubordinate(c *gc.C) {
 	}})
 }
 
+func (s *importSuite) TestImportPeerRelations(c *gc.C) {
+	model := description.NewModel(description.ModelArgs{})
+
+	rel1 := model.AddRelation(description.RelationArgs{
+		Id: 1,
+	})
+	rel1.AddEndpoint(description.EndpointArgs{
+		ApplicationName: "prometheus",
+		Name:            "testtwo",
+		Role:            "peer",
+	})
+	rel2 := model.AddRelation(description.RelationArgs{
+		Id: 7,
+	})
+	rel2.AddEndpoint(description.EndpointArgs{
+		ApplicationName: "prometheus",
+		Name:            "testone",
+		Role:            "peer",
+	})
+	rel3 := model.AddRelation(description.RelationArgs{
+		Id: 27,
+	})
+	rel3.AddEndpoint(description.EndpointArgs{
+		ApplicationName: "failme",
+		Name:            "testone",
+		Role:            "peer",
+	})
+	expected := map[string]int{"testone": 7, "testtwo": 1}
+
+	op := &importOperation{}
+	obtained := op.importPeerRelations("prometheus", model.Relations())
+	c.Check(obtained, jc.DeepEquals, expected)
+}
+
 func (s *importSuite) setupMocks(c *gc.C) *gomock.Controller {
 	ctrl := gomock.NewController(c)
 

--- a/domain/application/service/application.go
+++ b/domain/application/service/application.go
@@ -55,11 +55,11 @@ type ApplicationState interface {
 	// if the charm for the application is not found.
 	CreateApplication(context.Context, string, application.AddApplicationArg, []application.AddUnitArg) (coreapplication.ID, error)
 
-    // InsertMigratingApplication inserts a migrating application. Returns as 
-    // error satisfying [applicationerrors.ApplicationAlreadyExists] if the
-    // application already exists. If returns as error satisfying
-    // [applicationerrors.CharmNotFound] if the charm for the application is
-    // not found.
+	// InsertMigratingApplication inserts a migrating application. Returns as
+	// error satisfying [applicationerrors.ApplicationAlreadyExists] if the
+	// application already exists. If returns as error satisfying
+	// [applicationerrors.CharmNotFound] if the charm for the application is
+	// not found.
 	InsertMigratingApplication(context.Context, string, application.InsertApplicationArgs) (coreapplication.ID, error)
 
 	// GetModelType returns the model type for the underlying model. If the

--- a/domain/application/service/migration.go
+++ b/domain/application/service/migration.go
@@ -397,6 +397,7 @@ func makeInsertApplicationArg(
 		StorageParentDir: application.StorageParentDir,
 		Config:           applicationConfig,
 		Settings:         args.ApplicationSettings,
+		PeerRelations:    args.PeerRelations,
 	}, nil
 }
 

--- a/domain/application/service/migration_test.go
+++ b/domain/application/service/migration_test.go
@@ -440,12 +440,6 @@ func (s *migrationServiceSuite) assertImportApplication(c *gc.C, modelType corem
 		OSType:       deployment.Ubuntu,
 		Architecture: architecture.ARM64,
 	}
-	downloadInfo := &domaincharm.DownloadInfo{
-		Provenance:         domaincharm.ProvenanceDownload,
-		DownloadURL:        "http://example.com",
-		DownloadSize:       24,
-		CharmhubIdentifier: "foobar",
-	}
 
 	s.state.EXPECT().GetModelType(gomock.Any()).Return(modelType, nil)
 	s.state.EXPECT().StorageDefaults(gomock.Any()).Return(domainstorage.StorageDefaults{}, nil)
@@ -486,11 +480,10 @@ func (s *migrationServiceSuite) assertImportApplication(c *gc.C, modelType corem
 		},
 	}).MinTimes(1)
 
-	args := application.AddApplicationArg{
-		Charm:             ch,
-		Platform:          platform,
-		Scale:             1,
-		CharmDownloadInfo: downloadInfo,
+	args := application.InsertApplicationArgs{
+		Charm:    ch,
+		Platform: platform,
+		Scale:    1,
 		Config: map[string]application.ApplicationConfig{
 			"foo": {
 				Type:  domaincharm.OptionString,
@@ -502,7 +495,7 @@ func (s *migrationServiceSuite) assertImportApplication(c *gc.C, modelType corem
 		},
 		StorageParentDir: application.StorageParentDir,
 	}
-	s.state.EXPECT().CreateApplication(gomock.Any(), "ubuntu", args, nil).Return(id, nil)
+	s.state.EXPECT().InsertMigratingApplication(gomock.Any(), "ubuntu", args).Return(id, nil)
 
 	unitArg := ImportUnitArg{
 		UnitName:       "ubuntu/666",
@@ -543,7 +536,6 @@ func (s *migrationServiceSuite) assertImportApplication(c *gc.C, modelType corem
 		},
 		ApplicationConstraints: cons,
 		ReferenceName:          "ubuntu",
-		DownloadInfo:           downloadInfo,
 		ApplicationConfig: map[string]any{
 			"foo": "bar",
 		},

--- a/domain/application/service/package_mock_test.go
+++ b/domain/application/service/package_mock_test.go
@@ -2729,6 +2729,45 @@ func (c *MockStateInitialWatchStatementUnitLifeCall) DoAndReturn(f func(string) 
 	return c
 }
 
+// InsertMigratingApplication mocks base method.
+func (m *MockState) InsertMigratingApplication(arg0 context.Context, arg1 string, arg2 application0.InsertApplicationArgs) (application.ID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InsertMigratingApplication", arg0, arg1, arg2)
+	ret0, _ := ret[0].(application.ID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// InsertMigratingApplication indicates an expected call of InsertMigratingApplication.
+func (mr *MockStateMockRecorder) InsertMigratingApplication(arg0, arg1, arg2 any) *MockStateInsertMigratingApplicationCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertMigratingApplication", reflect.TypeOf((*MockState)(nil).InsertMigratingApplication), arg0, arg1, arg2)
+	return &MockStateInsertMigratingApplicationCall{Call: call}
+}
+
+// MockStateInsertMigratingApplicationCall wrap *gomock.Call
+type MockStateInsertMigratingApplicationCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockStateInsertMigratingApplicationCall) Return(arg0 application.ID, arg1 error) *MockStateInsertMigratingApplicationCall {
+	c.Call = c.Call.Return(arg0, arg1)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockStateInsertMigratingApplicationCall) Do(f func(context.Context, string, application0.InsertApplicationArgs) (application.ID, error)) *MockStateInsertMigratingApplicationCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockStateInsertMigratingApplicationCall) DoAndReturn(f func(context.Context, string, application0.InsertApplicationArgs) (application.ID, error)) *MockStateInsertMigratingApplicationCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // InsertMigratingCAASUnits mocks base method.
 func (m *MockState) InsertMigratingCAASUnits(arg0 context.Context, arg1 application.ID, arg2 ...application0.ImportUnitArg) error {
 	m.ctrl.T.Helper()

--- a/domain/application/service/params.go
+++ b/domain/application/service/params.go
@@ -216,9 +216,6 @@ type ImportApplicationArgs struct {
 	// via the name is use the proxy name.
 	ReferenceName string
 
-	// DownloadInfo contains the download information for the charm.
-	DownloadInfo *domaincharm.DownloadInfo
-
 	// ApplicationConfig contains the application config.
 	ApplicationConfig config.ConfigAttributes
 
@@ -226,7 +223,6 @@ type ImportApplicationArgs struct {
 	ApplicationSettings application.ApplicationSettings
 
 	// ResolvedResources contains a list of ResolvedResource instances,
-	// TODO (stickupkid): This isn't currently wired up.
 	ResolvedResources ResolvedResources
 
 	// Units contains the units to import.

--- a/domain/application/service/params.go
+++ b/domain/application/service/params.go
@@ -223,6 +223,7 @@ type ImportApplicationArgs struct {
 	ApplicationSettings application.ApplicationSettings
 
 	// ResolvedResources contains a list of ResolvedResource instances,
+	// TODO (stickupkid): This isn't currently wired up.
 	ResolvedResources ResolvedResources
 
 	// Units contains the units to import.
@@ -244,6 +245,9 @@ type ImportApplicationArgs struct {
 
 	// ExposedEndpoints is the exposed endpoints for the application.
 	ExposedEndpoints map[string]application.ExposedEndpoint
+
+	// PeerRelations is a map of peer relation endpoint to relation id.
+	PeerRelations map[string]int
 }
 
 // ApplicationConfig represents the application config for the specified

--- a/domain/application/service/provider.go
+++ b/domain/application/service/provider.go
@@ -128,8 +128,11 @@ func (s *ProviderService) CreateApplication(
 		args.ReferenceName,
 		charm,
 		origin,
-		args.DownloadInfo,
 	); err != nil {
+		return "", errors.Errorf("invalid application args: %w", err)
+	}
+
+	if err := validateDownloadInfoParams(origin.Source, args.DownloadInfo); err != nil {
 		return "", errors.Errorf("invalid application args: %w", err)
 	}
 

--- a/domain/application/state/application_test.go
+++ b/domain/application/state/application_test.go
@@ -228,7 +228,7 @@ func (s *applicationStateSuite) TestCreateApplicationWithPeerRelation(c *gc.C) {
 	scale := application.ScaleState{Scale: 1}
 	s.assertApplication(c, "666", platform, channel, scale, false)
 
-	s.assertPeerRelation(c, "666", "pollux", "castor")
+	s.assertPeerRelation(c, "666", map[string]int{"pollux": 1, "castor": 0})
 }
 
 func (s *applicationStateSuite) TestCreateApplicationWithStatus(c *gc.C) {
@@ -3777,17 +3777,16 @@ func (s *applicationStateSuite) addCharmModifiedVersion(c *gc.C, appID coreappli
 	c.Assert(err, jc.ErrorIsNil)
 }
 
-func (s *applicationStateSuite) assertPeerRelation(c *gc.C, appName string, peerRelationNames ...string) {
+func (s *baseSuite) assertPeerRelation(c *gc.C, appName string, peerRelationInput map[string]int) {
 	type peerRelation struct {
 		id     int
 		name   string
 		status corestatus.Status
 	}
 	var expected []peerRelation
-	slices.Sort(peerRelationNames)
-	for i, name := range peerRelationNames {
+	for name, id := range peerRelationInput {
 		expected = append(expected, peerRelation{
-			id:     i,
+			id:     id,
 			name:   name,
 			status: corestatus.Joining,
 		})
@@ -3825,5 +3824,5 @@ ORDER BY r.relation_id
 	})
 	c.Assert(err, jc.ErrorIsNil)
 
-	c.Assert(peerRelations, gc.DeepEquals, expected)
+	c.Check(peerRelations, jc.SameContents, expected)
 }

--- a/domain/application/state/application_test.go
+++ b/domain/application/state/application_test.go
@@ -3769,65 +3769,6 @@ func (s *applicationStateSuite) TestGetNetNodeUnitNotFound(c *gc.C) {
 	c.Assert(err, jc.ErrorIs, applicationerrors.UnitNotFound)
 }
 
-func (s *applicationStateSuite) assertApplication(
-	c *gc.C,
-	name string,
-	platform deployment.Platform,
-	channel *deployment.Channel,
-	scale application.ScaleState,
-	available bool,
-) {
-	var (
-		gotName      string
-		gotUUID      string
-		gotCharmUUID string
-		gotPlatform  deployment.Platform
-		gotChannel   deployment.Channel
-		gotScale     application.ScaleState
-		gotAvailable bool
-	)
-	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
-		err := tx.QueryRowContext(ctx, "SELECT uuid, charm_uuid, name FROM application WHERE name=?", name).Scan(&gotUUID, &gotCharmUUID, &gotName)
-		if err != nil {
-			return err
-		}
-		err = tx.QueryRowContext(ctx, "SELECT scale, scaling, scale_target FROM application_scale WHERE application_uuid=?", gotUUID).
-			Scan(&gotScale.Scale, &gotScale.Scaling, &gotScale.ScaleTarget)
-		if err != nil {
-			return err
-		}
-		err = tx.QueryRowContext(ctx, "SELECT channel, os_id, architecture_id FROM application_platform WHERE application_uuid=?", gotUUID).
-			Scan(&gotPlatform.Channel, &gotPlatform.OSType, &gotPlatform.Architecture)
-		if err != nil {
-			return err
-		}
-		err = tx.QueryRowContext(ctx, "SELECT track, risk, branch FROM application_channel WHERE application_uuid=?", gotUUID).
-			Scan(&gotChannel.Track, &gotChannel.Risk, &gotChannel.Branch)
-		if err != nil && !errors.Is(err, sql.ErrNoRows) {
-			return err
-		}
-		err = tx.QueryRowContext(ctx, "SELECT available FROM charm WHERE uuid=?", gotCharmUUID).Scan(&gotAvailable)
-		if err != nil {
-			return err
-		}
-		return nil
-	})
-	c.Assert(err, jc.ErrorIsNil)
-	c.Check(gotName, gc.Equals, name)
-	c.Check(gotPlatform, jc.DeepEquals, platform)
-	c.Check(gotScale, jc.DeepEquals, scale)
-	c.Check(gotAvailable, gc.Equals, available)
-
-	// Channel is optional, so we need to check it separately.
-	if channel != nil {
-		c.Check(gotChannel, gc.DeepEquals, *channel)
-	} else {
-		// Ensure it's empty if the original origin channel isn't set.
-		// Prevent the db from sending back bogus values.
-		c.Check(gotChannel, gc.DeepEquals, deployment.Channel{})
-	}
-}
-
 func (s *applicationStateSuite) addCharmModifiedVersion(c *gc.C, appID coreapplication.ID, charmModifiedVersion int) {
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
 		_, err := tx.ExecContext(ctx, "UPDATE application SET charm_modified_version = ? WHERE uuid = ?", charmModifiedVersion, appID)

--- a/domain/application/state/migration.go
+++ b/domain/application/state/migration.go
@@ -155,14 +155,7 @@ WHERE application_uuid = $applicationID.uuid
 	return exportUnits, nil
 }
 
-// InsertMigratingApplication inserts a migrating application. Returns an
-// error satisfying [applicationerrors.ApplicationAlreadyExists]
-// if the application already exists.
-func (st *State) InsertMigratingApplication(
-	ctx context.Context,
-	name string,
-	args application.InsertApplicationArgs,
-) (coreapplication.ID, error) {
+func (st *State) InsertMigratingApplication(ctx context.Context, name string, args application.InsertApplicationArgs) (coreapplication.ID, error) {
 	db, err := st.DB()
 	if err != nil {
 		return "", errors.Capture(err)
@@ -302,7 +295,9 @@ func (st *State) InsertMigratingApplication(
 		); err != nil {
 			return errors.Errorf("inserting or resolving resources for application %q: %w", name, err)
 		}
-
+		//if err := st.insertApplicationStorage(ctx, tx, appDetails, args.Storage); err != nil {
+		//	return errors.Errorf("inserting storage for application %q: %w", name, err)
+		//}
 		if err := st.insertApplicationConfig(ctx, tx, appDetails.UUID, args.Config); err != nil {
 			return errors.Errorf("inserting config for application %q: %w", name, err)
 		}
@@ -312,6 +307,9 @@ func (st *State) InsertMigratingApplication(
 		if err := st.updateConfigHash(ctx, tx, applicationID{ID: appUUID}); err != nil {
 			return errors.Errorf("refreshing config hash for application %q: %w", name, err)
 		}
+		//if err := st.insertApplicationStatus(ctx, tx, appDetails.UUID, args.Status); err != nil {
+		//	return errors.Errorf("inserting status for application %q: %w", name, err)
+		//}
 		if err := st.insertApplicationEndpoints(ctx, tx, insertApplicationEndpointsParams{
 			appID:     appDetails.UUID,
 			charmUUID: appDetails.CharmUUID,
@@ -319,6 +317,10 @@ func (st *State) InsertMigratingApplication(
 		}); err != nil {
 			return errors.Errorf("inserting exposed endpoints for application %q: %w", name, err)
 		}
+		if err := st.insertMigratingPeerRelations(ctx, tx, appDetails.UUID, args.PeerRelations); err != nil {
+			return errors.Errorf("inserting peer relation for application %q: %w", name, err)
+		}
+
 		if err := st.insertDeviceConstraints(ctx, tx, appUUID, args.Devices); err != nil {
 			return errors.Errorf("inserting device constraints for application %q: %w", appUUID, err)
 		}

--- a/domain/application/state/package_test.go
+++ b/domain/application/state/package_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/juju/juju/domain/deployment"
 	"github.com/juju/juju/domain/life"
 	schematesting "github.com/juju/juju/domain/schema/testing"
+	"github.com/juju/juju/internal/errors"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 	"github.com/juju/juju/internal/storage"
 	"github.com/juju/juju/internal/storage/provider"
@@ -365,4 +366,63 @@ func (s *baseSuite) createScalingApplication(c *gc.C, name string, l life.Life, 
 	c.Assert(err, jc.ErrorIsNil)
 
 	return appID
+}
+
+func (s *baseSuite) assertApplication(
+	c *gc.C,
+	name string,
+	platform deployment.Platform,
+	channel *deployment.Channel,
+	scale application.ScaleState,
+	available bool,
+) {
+	var (
+		gotName      string
+		gotUUID      string
+		gotCharmUUID string
+		gotPlatform  deployment.Platform
+		gotChannel   deployment.Channel
+		gotScale     application.ScaleState
+		gotAvailable bool
+	)
+	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
+		err := tx.QueryRowContext(ctx, "SELECT uuid, charm_uuid, name FROM application WHERE name=?", name).Scan(&gotUUID, &gotCharmUUID, &gotName)
+		if err != nil {
+			return err
+		}
+		err = tx.QueryRowContext(ctx, "SELECT scale, scaling, scale_target FROM application_scale WHERE application_uuid=?", gotUUID).
+			Scan(&gotScale.Scale, &gotScale.Scaling, &gotScale.ScaleTarget)
+		if err != nil {
+			return err
+		}
+		err = tx.QueryRowContext(ctx, "SELECT channel, os_id, architecture_id FROM application_platform WHERE application_uuid=?", gotUUID).
+			Scan(&gotPlatform.Channel, &gotPlatform.OSType, &gotPlatform.Architecture)
+		if err != nil {
+			return err
+		}
+		err = tx.QueryRowContext(ctx, "SELECT track, risk, branch FROM application_channel WHERE application_uuid=?", gotUUID).
+			Scan(&gotChannel.Track, &gotChannel.Risk, &gotChannel.Branch)
+		if err != nil && !errors.Is(err, sql.ErrNoRows) {
+			return err
+		}
+		err = tx.QueryRowContext(ctx, "SELECT available FROM charm WHERE uuid=?", gotCharmUUID).Scan(&gotAvailable)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(gotName, gc.Equals, name)
+	c.Check(gotPlatform, jc.DeepEquals, platform)
+	c.Check(gotScale, jc.DeepEquals, scale)
+	c.Check(gotAvailable, gc.Equals, available)
+
+	// Channel is optional, so we need to check it separately.
+	if channel != nil {
+		c.Check(gotChannel, gc.DeepEquals, *channel)
+	} else {
+		// Ensure it's empty if the original origin channel isn't set.
+		// Prevent the db from sending back bogus values.
+		c.Check(gotChannel, gc.DeepEquals, deployment.Channel{})
+	}
 }

--- a/domain/application/types.go
+++ b/domain/application/types.go
@@ -431,4 +431,6 @@ type InsertApplicationArgs struct {
 	EndpointBindings map[string]network.SpaceName
 	// Devices contains the device constraints for the application.
 	Devices map[string]devices.Constraints
+	// PeerRelations is a map of peer relation endpoint to relation id.
+	PeerRelations map[string]int
 }

--- a/domain/application/types.go
+++ b/domain/application/types.go
@@ -392,3 +392,43 @@ type UnitAttributes struct {
 	ProviderID  string
 	ResolveMode string
 }
+
+// InsertApplicationArgs contains arguments for importing an application to the
+// model.
+type InsertApplicationArgs struct {
+	// Charm is the charm to add to the application. This is required to
+	// be able to add the application.
+	Charm domaincharm.Charm
+	// Platform contains the platform information for the application. The
+	// operating system and architecture.
+	Platform deployment.Platform
+	// Channel contains the channel information for the application. The track,
+	// risk and branch of the charm when it was downloaded from the charm store.
+	Channel *deployment.Channel
+	// Resources defines the list of resources to add to an application.
+	// They should match all the resources defined in the Charm.
+	Resources []AddApplicationResourceArg
+	// Storage defines the list of storage directives to add to an application.
+	// The Name values should match the storage defined in the Charm.
+	Storage []ApplicationStorageArg
+	// Config contains the configuration for the application, overlaid on top
+	// of the charm's default configuration.
+	Config map[string]ApplicationConfig
+	// Settings contains the settings for the application. This includes the
+	// trust setting.
+	Settings ApplicationSettings
+	// Scale contains the scale information for the application.
+	Scale int
+	// Status contains the status of the application.
+	Status *status.StatusInfo[status.WorkloadStatusType]
+	// StoragePoolKind holds a mapping of the kind of storage supported
+	// by the named storage pool / provider type.
+	StoragePoolKind map[string]storage.StorageKind
+	// StorageParentDir is the parent directory for mounting charm storage.
+	StorageParentDir string
+	// EndpointBindings is a map to bind application endpoint by name to a
+	// specific space. The default space is referenced by an empty key, if any.
+	EndpointBindings map[string]network.SpaceName
+	// Devices contains the device constraints for the application.
+	Devices map[string]devices.Constraints
+}


### PR DESCRIPTION
Migrate peer relations as part of the application domain as they are created in the same domain. 

Relations have an ID which must not change during migration, thus refactor application import to decouple it from CreateApplication. Rather it now uses the new InsertMigratingApplication method. The refactor will be helpful in the future when application, relation, resource and other UUIDs are also migrated. 

TODO: update the Rollback functionality of application migration to delete any peer relations.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [ ] ~[Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- [ ] ~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

Update the ubuntu charm to have a peer relation
```
$ mkdir ubuntu ; cd ubuntu
$ juju download ubuntu
$ unzip ubuntu_25.charm

# Edit the metadata.yaml file to add
peers:
  test:
    interface: test
# 

$ zip -f ubuntu_25
```

```
$ juju bootstrap localhost dst
$ juju bootstrap localhost src 
$ juju add-model moveme 
$ juju deploy ~/ubuntu_r25.charm -n 2

# once the model is active and idle

$ juju migrate moveme dst

# verify the move.
```

## Links

**Jira card:** JUJU-7354
