### PR TITLE
feat: store agent stream as first class value in DDL

### DIFF
--- a/agent/agentbootstrap/bootstrap.go
+++ b/agent/agentbootstrap/bootstrap.go
@@ -17,6 +17,7 @@ import (
 	k8sconstants "github.com/juju/juju/caas/kubernetes/provider/constants"
 	"github.com/juju/juju/cloud"
 	coreagent "github.com/juju/juju/core/agent"
+	"github.com/juju/juju/core/agentbinary"
 	"github.com/juju/juju/core/credential"
 	coredatabase "github.com/juju/juju/core/database"
 	"github.com/juju/juju/core/instance"
@@ -268,7 +269,7 @@ func (b *AgentBootstrap) Initialize(ctx context.Context) (_ *state.Controller, r
 		modeldefaultsbootstrap.SetCloudDefaults(stateParams.ControllerCloud.Name, stateParams.ControllerInheritedConfig),
 		secretbackendbootstrap.CreateDefaultBackends(model.ModelType(modelType)),
 		controllerModelCreateFunc,
-		modelbootstrap.CreateLocalModelRecord(controllerModelUUID, controllerUUID, agentVersion),
+		modelbootstrap.CreateLocalModelRecord(controllerModelUUID, controllerUUID, agentVersion, agentbinary.AgentStreamReleased),
 		modelbootstrap.SetModelConstraints(stateParams.ModelConstraints),
 		modelconfigbootstrap.SetModelConfig(
 			controllerModelUUID, stateParams.ControllerModelConfig.AllAttrs(), controllerModelDefaults),

--- a/core/agentbinary/types.go
+++ b/core/agentbinary/types.go
@@ -12,6 +12,10 @@ import (
 	"github.com/juju/juju/internal/errors"
 )
 
+// AgentStream is an identifier representing the stream that should be used for
+// agent binaries.
+type AgentStream string
+
 // Metadata describes the data around an available agent binary within the
 // system.
 type Metadata struct {
@@ -38,6 +42,19 @@ type Version struct {
 	// Arch is the architecture of the agent binary.
 	Arch arch.Arch
 }
+
+const (
+	// AgentStreamZero represents the zero value AgentStream
+	AgentStreamZero = AgentStream("")
+	// AgentStreamReleased represents the released stream for agent binaries.
+	AgentStreamReleased = AgentStream("released")
+	// AgentStreamTesting represents the testing stream for agent binaries.
+	AgentStreamTesting = AgentStream("testing")
+	// AgentStreamProposed represents the proposed stream for agent binaries.
+	AgentStreamProposed = AgentStream("proposed")
+	// AgentStreamDevel represents the devel stream for agent binaries.
+	AgentStreamDevel = AgentStream("devel")
+)
 
 // Validate checks that the version is valid by checking that the version
 // number is a non zero value and the architecture is supported. If these checks

--- a/domain/agentprovisioner/state/state_test.go
+++ b/domain/agentprovisioner/state/state_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/juju/juju/core/semversion"
 	"github.com/juju/juju/domain/model"
 	modelstate "github.com/juju/juju/domain/model/state"
+	"github.com/juju/juju/domain/modelagent"
 	modelconfigstate "github.com/juju/juju/domain/modelconfig/state"
 	schematesting "github.com/juju/juju/domain/schema/testing"
 	"github.com/juju/juju/environs/config"
@@ -110,6 +111,7 @@ func (s *suite) TestModelID(c *gc.C) {
 	err := modelSt.Create(context.Background(), model.ModelDetailArgs{
 		UUID:           modelID,
 		AgentVersion:   semversion.Number{Major: 4, Minor: 21, Patch: 67},
+		AgentStream:    modelagent.AgentStreamReleased,
 		ControllerUUID: uuid.MustNewUUID(),
 		Name:           "test-model",
 		Type:           coremodel.IAAS,

--- a/domain/keyupdater/keyupdater_test.go
+++ b/domain/keyupdater/keyupdater_test.go
@@ -11,6 +11,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/core/agentbinary"
 	"github.com/juju/juju/core/changestream"
 	"github.com/juju/juju/core/credential"
 	"github.com/juju/juju/core/machine"
@@ -108,7 +109,7 @@ func (s *keyUpdaterSuite) SetUpTest(c *gc.C) {
 	err = modelFn(context.Background(), s.ControllerTxnRunner(), s.ControllerSuite.NoopTxnRunner())
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = modelbootstrap.CreateLocalModelRecord(modelUUID, uuid.MustNewUUID(), jujuversion.Current)(
+	err = modelbootstrap.CreateLocalModelRecord(modelUUID, uuid.MustNewUUID(), jujuversion.Current, agentbinary.AgentStreamReleased)(
 		context.Background(), s.ControllerTxnRunner(), s.ModelTxnRunner())
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/domain/keyupdater/state/state_test.go
+++ b/domain/keyupdater/state/state_test.go
@@ -18,6 +18,7 @@ import (
 	machineerrors "github.com/juju/juju/domain/machine/errors"
 	"github.com/juju/juju/domain/model"
 	modelstate "github.com/juju/juju/domain/model/state"
+	"github.com/juju/juju/domain/modelagent"
 	schematesting "github.com/juju/juju/domain/schema/testing"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 	"github.com/juju/juju/internal/uuid"
@@ -102,6 +103,7 @@ func (s *stateSuite) TestGetModelId(c *gc.C) {
 	args := model.ModelDetailArgs{
 		UUID:            modelUUID,
 		AgentVersion:    jujuversion.Current,
+		AgentStream:     modelagent.AgentStreamReleased,
 		ControllerUUID:  uuid.MustNewUUID(),
 		Name:            "my-awesome-model",
 		Type:            coremodel.IAAS,

--- a/domain/model/modelmigration/migrations_mock_test.go
+++ b/domain/model/modelmigration/migrations_mock_test.go
@@ -14,6 +14,7 @@ import (
 	reflect "reflect"
 
 	controller "github.com/juju/juju/controller"
+	agentbinary "github.com/juju/juju/core/agentbinary"
 	constraints "github.com/juju/juju/core/constraints"
 	model "github.com/juju/juju/core/model"
 	semversion "github.com/juju/juju/core/semversion"
@@ -315,17 +316,17 @@ func (m *MockModelDetailService) EXPECT() *MockModelDetailServiceMockRecorder {
 }
 
 // CreateModelForVersion mocks base method.
-func (m *MockModelDetailService) CreateModelForVersion(arg0 context.Context, arg1 uuid.UUID, arg2 semversion.Number) error {
+func (m *MockModelDetailService) CreateModelForVersion(arg0 context.Context, arg1 uuid.UUID, arg2 semversion.Number, arg3 agentbinary.AgentStream) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateModelForVersion", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "CreateModelForVersion", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CreateModelForVersion indicates an expected call of CreateModelForVersion.
-func (mr *MockModelDetailServiceMockRecorder) CreateModelForVersion(arg0, arg1, arg2 any) *MockModelDetailServiceCreateModelForVersionCall {
+func (mr *MockModelDetailServiceMockRecorder) CreateModelForVersion(arg0, arg1, arg2, arg3 any) *MockModelDetailServiceCreateModelForVersionCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateModelForVersion", reflect.TypeOf((*MockModelDetailService)(nil).CreateModelForVersion), arg0, arg1, arg2)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateModelForVersion", reflect.TypeOf((*MockModelDetailService)(nil).CreateModelForVersion), arg0, arg1, arg2, arg3)
 	return &MockModelDetailServiceCreateModelForVersionCall{Call: call}
 }
 
@@ -341,13 +342,13 @@ func (c *MockModelDetailServiceCreateModelForVersionCall) Return(arg0 error) *Mo
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockModelDetailServiceCreateModelForVersionCall) Do(f func(context.Context, uuid.UUID, semversion.Number) error) *MockModelDetailServiceCreateModelForVersionCall {
+func (c *MockModelDetailServiceCreateModelForVersionCall) Do(f func(context.Context, uuid.UUID, semversion.Number, agentbinary.AgentStream) error) *MockModelDetailServiceCreateModelForVersionCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockModelDetailServiceCreateModelForVersionCall) DoAndReturn(f func(context.Context, uuid.UUID, semversion.Number) error) *MockModelDetailServiceCreateModelForVersionCall {
+func (c *MockModelDetailServiceCreateModelForVersionCall) DoAndReturn(f func(context.Context, uuid.UUID, semversion.Number, agentbinary.AgentStream) error) *MockModelDetailServiceCreateModelForVersionCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/domain/model/service/modelservice_test.go
+++ b/domain/model/service/modelservice_test.go
@@ -13,6 +13,7 @@ import (
 	"go.uber.org/mock/gomock"
 	gc "gopkg.in/check.v1"
 
+	"github.com/juju/juju/core/agentbinary"
 	coreconstraints "github.com/juju/juju/core/constraints"
 	"github.com/juju/juju/core/instance"
 	coremodel "github.com/juju/juju/core/model"
@@ -24,6 +25,7 @@ import (
 	machineerrors "github.com/juju/juju/domain/machine/errors"
 	"github.com/juju/juju/domain/model"
 	modelerrors "github.com/juju/juju/domain/model/errors"
+	"github.com/juju/juju/domain/modelagent"
 	networkerrors "github.com/juju/juju/domain/network/errors"
 	"github.com/juju/juju/environs"
 	"github.com/juju/juju/internal/uuid"
@@ -340,7 +342,7 @@ func (s *modelServiceSuite) TestAgentVersionUnsupportedGreater(c *gc.C) {
 	)
 
 	err = svc.CreateModelForVersion(
-		context.Background(), uuid.MustNewUUID(), agentVersion,
+		context.Background(), uuid.MustNewUUID(), agentVersion, agentbinary.AgentStreamReleased,
 	)
 	c.Assert(err, jc.ErrorIs, modelerrors.AgentVersionNotSupported)
 }
@@ -368,7 +370,7 @@ func (s *modelServiceSuite) TestAgentVersionUnsupportedLess(c *gc.C) {
 		DefaultAgentBinaryFinder(),
 	)
 	err = svc.CreateModelForVersion(
-		context.Background(), uuid.MustNewUUID(), agentVersion,
+		context.Background(), uuid.MustNewUUID(), agentVersion, agentbinary.AgentStreamReleased,
 	)
 	// Add the correct error detail when restoring this test.
 	c.Assert(err, gc.NotNil)
@@ -612,6 +614,7 @@ func (s *providerModelServiceSuite) TestCreateModel(c *gc.C) {
 		Cloud:          "aws",
 		CloudType:      "ec2",
 		CloudRegion:    "myregion",
+		AgentStream:    modelagent.AgentStreamReleased,
 		AgentVersion:   jujuversion.Current,
 	}).Return(nil)
 
@@ -653,6 +656,7 @@ func (s *providerModelServiceSuite) TestCreateModelFailedErrorAlreadyExists(c *g
 		Cloud:          "aws",
 		CloudType:      "ec2",
 		CloudRegion:    "myregion",
+		AgentStream:    modelagent.AgentStreamReleased,
 		AgentVersion:   jujuversion.Current,
 	}).Return(modelerrors.AlreadyExists)
 

--- a/domain/model/state/modelstate.go
+++ b/domain/model/state/modelstate.go
@@ -875,7 +875,10 @@ func InsertModelInfo(
 		return errors.Capture(err)
 	}
 
-	v := dbModelAgent{TargetVersion: args.AgentVersion.String()}
+	v := dbModelAgent{
+		StreamID:      int(args.AgentStream),
+		TargetVersion: args.AgentVersion.String(),
+	}
 	vStmt, err := preparer.Prepare("INSERT INTO agent_version (*) VALUES ($dbModelAgent.*)", v)
 	if err != nil {
 		return errors.Capture(err)

--- a/domain/model/state/modelstate_test.go
+++ b/domain/model/state/modelstate_test.go
@@ -21,6 +21,7 @@ import (
 	machineerrors "github.com/juju/juju/domain/machine/errors"
 	"github.com/juju/juju/domain/model"
 	modelerrors "github.com/juju/juju/domain/model/errors"
+	"github.com/juju/juju/domain/modelagent"
 	networkerrors "github.com/juju/juju/domain/network/errors"
 	schematesting "github.com/juju/juju/domain/schema/testing"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
@@ -47,6 +48,7 @@ func (s *modelSuite) createTestModel(c *gc.C) coremodel.UUID {
 	id := modeltesting.GenModelUUID(c)
 	args := model.ModelDetailArgs{
 		UUID:            id,
+		AgentStream:     modelagent.AgentStreamReleased,
 		AgentVersion:    jujuversion.Current,
 		ControllerUUID:  s.controllerUUID,
 		Name:            "my-awesome-model",
@@ -69,6 +71,7 @@ func (s *modelSuite) TestCreateAndReadModel(c *gc.C) {
 	id := modeltesting.GenModelUUID(c)
 	args := model.ModelDetailArgs{
 		UUID:            id,
+		AgentStream:     modelagent.AgentStreamReleased,
 		AgentVersion:    jujuversion.Current,
 		ControllerUUID:  s.controllerUUID,
 		Name:            "my-awesome-model",
@@ -106,6 +109,7 @@ func (s *modelSuite) TestDeleteModel(c *gc.C) {
 	id := modeltesting.GenModelUUID(c)
 	args := model.ModelDetailArgs{
 		UUID:            id,
+		AgentStream:     modelagent.AgentStreamReleased,
 		AgentVersion:    jujuversion.Current,
 		ControllerUUID:  s.controllerUUID,
 		Name:            "my-awesome-model",
@@ -139,6 +143,7 @@ func (s *modelSuite) TestCreateModelMultipleTimesWithSameUUID(c *gc.C) {
 	id := modeltesting.GenModelUUID(c)
 	args := model.ModelDetailArgs{
 		UUID:           id,
+		AgentStream:    modelagent.AgentStreamReleased,
 		AgentVersion:   jujuversion.Current,
 		ControllerUUID: s.controllerUUID,
 		Name:           "my-awesome-model",
@@ -161,6 +166,7 @@ func (s *modelSuite) TestCreateModelMultipleTimesWithDifferentUUID(c *gc.C) {
 
 	err := state.Create(context.Background(), model.ModelDetailArgs{
 		UUID:         modeltesting.GenModelUUID(c),
+		AgentStream:  modelagent.AgentStreamReleased,
 		AgentVersion: jujuversion.Current,
 		Name:         "my-awesome-model",
 		Type:         coremodel.IAAS,
@@ -172,6 +178,7 @@ func (s *modelSuite) TestCreateModelMultipleTimesWithDifferentUUID(c *gc.C) {
 
 	err = state.Create(context.Background(), model.ModelDetailArgs{
 		UUID:         modeltesting.GenModelUUID(c),
+		AgentStream:  modelagent.AgentStreamReleased,
 		AgentVersion: jujuversion.Current,
 		Name:         "my-awesome-model",
 		Type:         coremodel.IAAS,
@@ -191,6 +198,7 @@ func (s *modelSuite) TestCreateModelAndUpdate(c *gc.C) {
 	id := modeltesting.GenModelUUID(c)
 	err := state.Create(context.Background(), model.ModelDetailArgs{
 		UUID:           id,
+		AgentStream:    modelagent.AgentStreamReleased,
 		AgentVersion:   jujuversion.Current,
 		ControllerUUID: s.controllerUUID,
 		Name:           "my-awesome-model",
@@ -215,6 +223,7 @@ func (s *modelSuite) TestCreateModelAndDelete(c *gc.C) {
 	id := modeltesting.GenModelUUID(c)
 	err := state.Create(context.Background(), model.ModelDetailArgs{
 		UUID:         id,
+		AgentStream:  modelagent.AgentStreamReleased,
 		AgentVersion: jujuversion.Current,
 		Name:         "my-awesome-model",
 		Type:         coremodel.IAAS,
@@ -293,7 +302,7 @@ func (s *modelSuite) TestSetModelConstraints(c *gc.C) {
 	state := NewModelState(runner, loggertesting.WrapCheckLog(c))
 
 	_, err := s.DB().ExecContext(context.Background(), `
-INSERT INTO space (uuid, name) VALUES 
+INSERT INTO space (uuid, name) VALUES
 	(?, ?),
 	(?, ?)`,
 		uuid.MustNewUUID().String(), "space1",
@@ -382,7 +391,7 @@ func (s *modelSuite) TestSetModelConstraintsOverwrites(c *gc.C) {
 	state := NewModelState(runner, loggertesting.WrapCheckLog(c))
 
 	_, err := s.DB().ExecContext(context.Background(), `
-INSERT INTO space (uuid, name) VALUES 
+INSERT INTO space (uuid, name) VALUES
 	(?, ?),
 	(?, ?)`,
 		uuid.MustNewUUID().String(), "space1",
@@ -526,6 +535,7 @@ func (s *modelSuite) TestGetModelCloudType(c *gc.C) {
 	cloudType := "ec2"
 	args := model.ModelDetailArgs{
 		UUID:            id,
+		AgentStream:     modelagent.AgentStreamReleased,
 		AgentVersion:    jujuversion.Current,
 		ControllerUUID:  s.controllerUUID,
 		Name:            "mymodel",
@@ -560,6 +570,7 @@ func (s *modelSuite) TestGetModelCloudRegionAndCredential(c *gc.C) {
 	cloudType := "ec2"
 	args := model.ModelDetailArgs{
 		UUID:            uuid,
+		AgentStream:     modelagent.AgentStreamReleased,
 		AgentVersion:    jujuversion.Current,
 		ControllerUUID:  s.controllerUUID,
 		Name:            "mymodel",
@@ -603,6 +614,7 @@ func (s *modelSuite) TestIsControllerModelTrue(c *gc.C) {
 	cloudType := "ec2"
 	args := model.ModelDetailArgs{
 		UUID:              uuid,
+		AgentStream:       modelagent.AgentStreamReleased,
 		AgentVersion:      jujuversion.Current,
 		ControllerUUID:    s.controllerUUID,
 		Name:              "mycontrollermodel",
@@ -630,6 +642,7 @@ func (s *modelSuite) TestIsControllerModelFalse(c *gc.C) {
 	cloudType := "ec2"
 	args := model.ModelDetailArgs{
 		UUID:              uuid,
+		AgentStream:       modelagent.AgentStreamReleased,
 		AgentVersion:      jujuversion.Current,
 		ControllerUUID:    s.controllerUUID,
 		Name:              "mycontrollermodel",

--- a/domain/model/state/types.go
+++ b/domain/model/state/types.go
@@ -390,6 +390,10 @@ type dbPermission struct {
 
 // dbModelAgent represents a row from the controller model_agent table.
 type dbModelAgent struct {
+	// StreamID is the unique identifier for the agent stream that is being used
+	// for model agents.
+	StreamID int `db:"stream_id"`
+
 	// TargetVersion describes the desired agent version that should be
 	// being run in this model. It should not be considered "the" version that
 	// is being run for every agent as each agent needs to upgrade to this

--- a/domain/model/types.go
+++ b/domain/model/types.go
@@ -12,6 +12,7 @@ import (
 	"github.com/juju/juju/core/semversion"
 	corestatus "github.com/juju/juju/core/status"
 	"github.com/juju/juju/core/user"
+	"github.com/juju/juju/domain/modelagent"
 	"github.com/juju/juju/internal/errors"
 	"github.com/juju/juju/internal/uuid"
 )
@@ -111,6 +112,10 @@ type ModelDetailArgs struct {
 	// IsControllerModel is a boolean value that indicates if the model is the
 	// controller model.
 	IsControllerModel bool
+
+	// AgentStream is the agent stream used when getting model agents for
+	// [ModelDetailArgs.AgentVersion].
+	AgentStream modelagent.AgentStream
 
 	// AgentVersion is the target version for agents running in this model.
 	AgentVersion semversion.Number

--- a/domain/modelagent/state/modelstate_test.go
+++ b/domain/modelagent/state/modelstate_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/juju/juju/domain/life"
 	machineerrors "github.com/juju/juju/domain/machine/errors"
 	machinestate "github.com/juju/juju/domain/machine/state"
+	"github.com/juju/juju/domain/modelagent"
 	modelagenterrors "github.com/juju/juju/domain/modelagent/errors"
 	schematesting "github.com/juju/juju/domain/schema/testing"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
@@ -159,9 +160,12 @@ func (s *modelStateSuite) setModelTargetAgentVersion(c *gc.C, vers string) {
 	db, err := domain.NewStateBase(s.TxnRunnerFactory()).DB()
 	c.Assert(err, jc.ErrorIsNil)
 
-	q := "INSERT INTO agent_version (target_version) values ($M.target_version)"
+	q := "INSERT INTO agent_version (*) VALUES ($M.stream_id, $M.target_version)"
 
-	args := sqlair.M{"target_version": vers}
+	args := sqlair.M{
+		"target_version": vers,
+		"stream_id":      modelagent.AgentStreamReleased,
+	}
 	stmt, err := sqlair.Prepare(q, args)
 	c.Assert(err, jc.ErrorIsNil)
 

--- a/domain/modelagent/types.go
+++ b/domain/modelagent/types.go
@@ -1,0 +1,57 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package modelagent
+
+import (
+	coreagentbinary "github.com/juju/juju/core/agentbinary"
+	coreerrors "github.com/juju/juju/core/errors"
+	"github.com/juju/juju/internal/errors"
+)
+
+// AgentStream represents the agent stream that is currently being used by a
+// model agent.
+type AgentStream int
+
+const (
+	// agentStreamZero represents the zero value for AgentStream. This is used
+	// to check if a value has been set/selected.
+	agentStreamZero AgentStream = 0
+
+	// AgentStreamReleased represents the released stream for agent binaries.
+	AgentStreamReleased AgentStream = iota
+	// AgentStreamTesting represents the testing stream for agent binaries.
+	AgentStreamTesting
+	// AgentStreamProposed represents the proposed stream for agent binaries.
+	AgentStreamProposed
+	// AgentStreamDevel represents the devel stream for agent binaries.
+	AgentStreamDevel
+)
+
+// AgentStreamFromCoreAgentStream converts a [coreagentbinary.AgentStream] to a
+// corresponding [AgentStream]. It returns an error if the value is not
+// recognised or supported satisfying [coreerrors.NotValid].
+func AgentStreamFromCoreAgentStream(
+	agentStream coreagentbinary.AgentStream,
+) (AgentStream, error) {
+	var rval AgentStream
+
+	switch agentStream {
+	case coreagentbinary.AgentStreamReleased:
+		rval = AgentStreamReleased
+	case coreagentbinary.AgentStreamTesting:
+		rval = AgentStreamTesting
+	case coreagentbinary.AgentStreamProposed:
+		rval = AgentStreamProposed
+	case coreagentbinary.AgentStreamDevel:
+		rval = AgentStreamDevel
+	}
+
+	if rval == agentStreamZero {
+		return rval, errors.Errorf(
+			"agent stream %q is not recognised as a valid value", agentStream,
+		).Add(coreerrors.NotValid)
+	}
+
+	return rval, nil
+}

--- a/domain/modelconfig/modelconfig_test.go
+++ b/domain/modelconfig/modelconfig_test.go
@@ -10,6 +10,7 @@ import (
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/juju/cloud"
+	"github.com/juju/juju/core/agentbinary"
 	"github.com/juju/juju/core/changestream"
 	"github.com/juju/juju/core/credential"
 	"github.com/juju/juju/core/model"
@@ -110,7 +111,7 @@ func (s *modelConfigSuite) SetUpTest(c *gc.C) {
 	err = modelFn(context.Background(), s.ControllerTxnRunner(), s.ControllerSuite.NoopTxnRunner())
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = modelbootstrap.CreateLocalModelRecord(modelUUID, uuid.MustNewUUID(), jujuversion.Current)(
+	err = modelbootstrap.CreateLocalModelRecord(modelUUID, uuid.MustNewUUID(), jujuversion.Current, agentbinary.AgentStreamReleased)(
 		context.Background(), s.ControllerTxnRunner(), s.ModelTxnRunner())
 	c.Assert(err, jc.ErrorIsNil)
 }

--- a/domain/modelconfig/state/state_test.go
+++ b/domain/modelconfig/state/state_test.go
@@ -155,7 +155,7 @@ func (s *stateSuite) TestAgentVersionNotFound(c *gc.C) {
 // is reported back correctly with no errors.
 func (s *stateSuite) TestAgentVersion(c *gc.C) {
 	err := s.TxnRunner().StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
-		_, err := tx.ExecContext(ctx, "INSERT INTO agent_version VALUES ('1.2.3')")
+		_, err := tx.ExecContext(ctx, "INSERT INTO agent_version VALUES (0, '1.2.3')")
 		return err
 	})
 	c.Assert(err, jc.ErrorIsNil)

--- a/domain/modelmigration/state/state_test.go
+++ b/domain/modelmigration/state/state_test.go
@@ -18,6 +18,7 @@ import (
 	machinestate "github.com/juju/juju/domain/machine/state"
 	"github.com/juju/juju/domain/model"
 	modelstate "github.com/juju/juju/domain/model/state"
+	"github.com/juju/juju/domain/modelagent"
 	schematesting "github.com/juju/juju/domain/schema/testing"
 	loggertesting "github.com/juju/juju/internal/logger/testing"
 	"github.com/juju/juju/internal/uuid"
@@ -41,6 +42,7 @@ func (s *migrationSuite) SetUpTest(c *gc.C) {
 	id := modeltesting.GenModelUUID(c)
 	args := model.ModelDetailArgs{
 		UUID:            id,
+		AgentStream:     modelagent.AgentStreamReleased,
 		AgentVersion:    jujuversion.Current,
 		ControllerUUID:  s.controllerUUID,
 		Name:            "my-awesome-model",

--- a/domain/schema/model/sql/0027-agent-version.sql
+++ b/domain/schema/model/sql/0027-agent-version.sql
@@ -1,7 +1,26 @@
-CREATE TABLE agent_version (
-    target_version TEXT NOT NULL
+-- agent_stream defines the recognised streams available in the model for
+-- fetching agent binaries.
+CREATE TABLE agent_stream (
+    id INT PRIMARY KEY,
+    name TEXT NOT NULL
 );
 
--- A unique constraint over a constant index 
+CREATE UNIQUE INDEX idx_agent_stream_name
+ON agent_stream (name);
+
+INSERT INTO agent_stream VALUES
+(0, 'released'),
+(1, 'testing'),
+(2, 'proposed'),
+(3, 'devel');
+
+CREATE TABLE agent_version (
+    stream_id INT NOT NULL,
+    target_version TEXT NOT NULL,
+    FOREIGN KEY (stream_id)
+    REFERENCES agent_stream(id)
+);
+
+-- A unique constraint over a constant index
 -- ensures only 1 row can exist.
 CREATE UNIQUE INDEX idx_singleton_agent_version ON agent_version ((1));

--- a/domain/schema/model_schema_test.go
+++ b/domain/schema/model_schema_test.go
@@ -69,6 +69,7 @@ func (s *modelSchemaSuite) TestModelTables(c *gc.C) {
 
 		// Model
 		"model",
+		"agent_stream",
 		"agent_version",
 
 		// Model config

--- a/domain/services/testing/suite.go
+++ b/domain/services/testing/suite.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/juju/juju/cloud"
 	"github.com/juju/juju/controller"
+	"github.com/juju/juju/core/agentbinary"
 	"github.com/juju/juju/core/credential"
 	coreerrors "github.com/juju/juju/core/errors"
 	"github.com/juju/juju/core/lease"
@@ -201,7 +202,7 @@ func (s *DomainServicesSuite) SeedModelDatabases(c *gc.C) {
 	err = fn(ctx, s.ControllerTxnRunner(), s.NoopTxnRunner())
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = modelbootstrap.CreateLocalModelRecord(s.ControllerModelUUID, controllerUUID, jujuversion.Current)(
+	err = modelbootstrap.CreateLocalModelRecord(s.ControllerModelUUID, controllerUUID, jujuversion.Current, agentbinary.AgentStreamReleased)(
 		ctx, s.ControllerTxnRunner(), s.ModelTxnRunner(c, s.ControllerModelUUID.String()))
 	c.Assert(err, jc.ErrorIsNil)
 
@@ -224,7 +225,7 @@ func (s *DomainServicesSuite) SeedModelDatabases(c *gc.C) {
 	err = fn(ctx, s.ControllerTxnRunner(), s.NoopTxnRunner())
 	c.Assert(err, jc.ErrorIsNil)
 
-	err = modelbootstrap.CreateLocalModelRecord(s.DefaultModelUUID, controllerUUID, jujuversion.Current)(
+	err = modelbootstrap.CreateLocalModelRecord(s.DefaultModelUUID, controllerUUID, jujuversion.Current, agentbinary.AgentStreamReleased)(
 		ctx, s.ControllerTxnRunner(), s.ModelTxnRunner(c, s.DefaultModelUUID.String()))
 	c.Assert(err, jc.ErrorIsNil)
 


### PR DESCRIPTION
This PR starts the work for storing the model's agent stream value as a first class value on the agent version table. To support upgrading a model we need this value to both be readable and reliable. The value also needs to be set as part of the upgrade process. Up until now this value was stored in ModelConfig but because we are now giving meaning to the value it should be stored and understood in the DDL.

This PR does the work to introduce the new DDL and fix up and broken domain functions or tests that will no longer work due to the change. No attempt is made to set the value correctly or extract it properly to be set. This is just about the DDL change and the bare minimum to support the DDL PR.

A follow up PR will be performed to have the value set correctly on model creation and also read as part of model config hydration. 

The valid values for what a stream can be were taken from `environ/tools/simplestreams.go`. The decision was made to be explicit about what value the stream can assume until a case is shown where a user defined value needs to be supported. This gives us a good constraints that can be relied upon in the database.

## Checklist

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- ~[ ] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing~
- ~[ ] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages~

## QA steps

If you can successfully bootstrap and interact with a controller and create a model that satisfies that this change has not broken anything.

## Documentation changes

N/A

## Links

**Jira card:** JUJU-7898
