### PR TITLE
feat: add table for controller api addresses

### DIFF
--- a/domain/controllernode/state/state.go
+++ b/domain/controllernode/state/state.go
@@ -92,17 +92,17 @@ func (st *State) UpdateDqliteNode(ctx context.Context, controllerID string, node
 	// uint64 when querying the table.
 	nodeStr := strconv.FormatUint(nodeID, 10)
 	controllerNode := dbControllerNode{
-		ControllerID: controllerID,
-		DQLiteNodeID: nodeStr,
-		BindAddress:  addr,
+		ControllerID:      controllerID,
+		DqliteNodeID:      nodeStr,
+		DqliteBindAddress: addr,
 	}
 
 	q := `
 UPDATE controller_node 
 SET    dqlite_node_id = $dbControllerNode.dqlite_node_id,
-       bind_address = $dbControllerNode.bind_address 
+       dqlite_bind_address = $dbControllerNode.dqlite_bind_address 
 WHERE  controller_id = $dbControllerNode.controller_id
-AND    (dqlite_node_id != $dbControllerNode.dqlite_node_id OR bind_address != $dbControllerNode.bind_address)`
+AND    (dqlite_node_id != $dbControllerNode.dqlite_node_id OR dqlite_bind_address != $dbControllerNode.dqlite_bind_address)`
 	stmt, err := st.Prepare(q, controllerNode)
 	if err != nil {
 		return errors.Errorf("preparing update controller node statement: %w", err)

--- a/domain/controllernode/state/state_test.go
+++ b/domain/controllernode/state/state_test.go
@@ -70,7 +70,7 @@ func (s *stateSuite) TestUpdateDqliteNode(c *gc.C) {
 		context.Background(), "0", nodeID, "192.168.5.60")
 	c.Assert(err, jc.ErrorIsNil)
 
-	row := s.DB().QueryRowContext(context.Background(), "SELECT dqlite_node_id, bind_address FROM controller_node WHERE controller_id = '0'")
+	row := s.DB().QueryRowContext(context.Background(), "SELECT dqlite_node_id, dqlite_bind_address FROM controller_node WHERE controller_id = '0'")
 	c.Assert(row.Err(), jc.ErrorIsNil)
 
 	var (

--- a/domain/controllernode/state/types.go
+++ b/domain/controllernode/state/types.go
@@ -8,12 +8,12 @@ type dbControllerNode struct {
 	// ControllerID is the nodes controller ID.
 	ControllerID string `db:"controller_id"`
 
-	// DQLiteNodeID is the uint64 from Dqlite NodeInfo, stored as text (due to
+	// DqliteNodeID is the uint64 from Dqlite NodeInfo, stored as text (due to
 	// db issues when the high bit is set).
-	DQLiteNodeID string `db:"dqlite_node_id"`
+	DqliteNodeID string `db:"dqlite_node_id"`
 
-	// BindAddress is the IP address (no port) that Dqlite is bound to.
-	BindAddress string `db:"bind_address"`
+	// DqliteBindAddress is the IP address (no port) that Dqlite is bound to.
+	DqliteBindAddress string `db:"dqlite_bind_address"`
 }
 
 type dbNamespace struct {

--- a/domain/schema/controller/sql/0009-controller-node.sql
+++ b/domain/schema/controller/sql/0009-controller-node.sql
@@ -1,14 +1,14 @@
 CREATE TABLE controller_node (
     controller_id TEXT NOT NULL PRIMARY KEY,
     dqlite_node_id TEXT,              -- This is the uint64 from Dqlite NodeInfo, stored as text.
-    bind_address TEXT               -- IP address (no port) that Dqlite is bound to.
+    dqlite_bind_address TEXT          -- IP address (no port) that Dqlite is bound to.
 );
 
 CREATE UNIQUE INDEX idx_controller_node_dqlite_node
 ON controller_node (dqlite_node_id);
 
-CREATE UNIQUE INDEX idx_controller_node_bind_address
-ON controller_node (bind_address);
+CREATE UNIQUE INDEX idx_controller_node_dqlite_bind_address
+ON controller_node (dqlite_bind_address);
 
 -- controller_node_agent_version tracks the reported agent version running for
 -- each controller in the cluster.
@@ -22,4 +22,15 @@ CREATE TABLE controller_node_agent_version (
     CONSTRAINT fk_controller_node_agent_version_architecture
     FOREIGN KEY (architecture_id)
     REFERENCES architecture (id)
+);
+
+CREATE TABLE controller_api_address (
+    controller_id TEXT NOT NULL,
+    -- The value of the configured IP address with the port appended.
+    -- e.g. 192.168.1.2:17070 or [2001:db8:0000:0000:0000:0000:0000:00001]:17070.
+    address TEXT NOT NULL,
+    CONSTRAINT fk_controller_api_address_controller
+    FOREIGN KEY (controller_id)
+    REFERENCES controller_node (controller_id),
+    PRIMARY KEY (controller_id, address)
 );

--- a/domain/schema/controller/triggers/controller-triggers.gen.go
+++ b/domain/schema/controller/triggers/controller-triggers.gen.go
@@ -67,7 +67,7 @@ AFTER UPDATE ON controller_node FOR EACH ROW
 WHEN 
 	NEW.controller_id != OLD.controller_id OR
 	(NEW.dqlite_node_id != OLD.dqlite_node_id OR (NEW.dqlite_node_id IS NOT NULL AND OLD.dqlite_node_id IS NULL) OR (NEW.dqlite_node_id IS NULL AND OLD.dqlite_node_id IS NOT NULL)) OR
-	(NEW.bind_address != OLD.bind_address OR (NEW.bind_address IS NOT NULL AND OLD.bind_address IS NULL) OR (NEW.bind_address IS NULL AND OLD.bind_address IS NOT NULL)) 
+	(NEW.dqlite_bind_address != OLD.dqlite_bind_address OR (NEW.dqlite_bind_address IS NOT NULL AND OLD.dqlite_bind_address IS NULL) OR (NEW.dqlite_bind_address IS NULL AND OLD.dqlite_bind_address IS NOT NULL)) 
 BEGIN
     INSERT INTO change_log (edit_type_id, namespace_id, changed, created_at)
     VALUES (2, %[2]d, OLD.%[1]s, DATETIME('now'));

--- a/domain/schema/controller_schema_test.go
+++ b/domain/schema/controller_schema_test.go
@@ -75,6 +75,9 @@ func (s *controllerSchemaSuite) TestControllerTables(c *gc.C) {
 		"controller_node",
 		"controller_node_agent_version",
 
+		// Controller API addresses
+		"controller_api_address",
+
 		// Model migration
 		"model_migration",
 		"model_migration_status",

--- a/internal/database/bootstrap.go
+++ b/internal/database/bootstrap.go
@@ -160,7 +160,7 @@ func InsertControllerNodeID(ctx context.Context, runner coredatabase.TxnRunner, 
 -- Accordingly, the controller ID remains the ID of the machine, 
 -- but it should probably become a UUID once machines have one.
 -- While HA is not supported in K8s, this doesn't matter.
-INSERT INTO controller_node (controller_id, dqlite_node_id, bind_address)
+INSERT INTO controller_node (controller_id, dqlite_node_id, dqlite_bind_address)
 VALUES ('0', ?, '127.0.0.1');`
 	return runner.StdTxn(ctx, func(ctx context.Context, tx *sql.Tx) error {
 		result, err := tx.ExecContext(ctx, q, nodeID)

--- a/internal/database/bootstrap_test.go
+++ b/internal/database/bootstrap_test.go
@@ -56,7 +56,7 @@ func (s *bootstrapSuite) TestBootstrapSuccess(c *gc.C) {
 			}
 
 			// Ensure we have a nodeID in the controller node.
-			row := tx.QueryRowContext(ctx, "SELECT controller_id, dqlite_node_id, bind_address FROM controller_node")
+			row := tx.QueryRowContext(ctx, "SELECT controller_id, dqlite_node_id, dqlite_bind_address FROM controller_node")
 			var controllerID, nodeID uint64
 			var bindAddress string
 			err = row.Scan(&controllerID, &nodeID, &bindAddress)
@@ -71,7 +71,7 @@ func (s *bootstrapSuite) TestBootstrapSuccess(c *gc.C) {
 				return fmt.Errorf("expected dqlite_node_id to be non-zero")
 			}
 			if bindAddress != "127.0.0.1" {
-				return fmt.Errorf("expected bind_address to be 127.0.0.1")
+				return fmt.Errorf("expected dqlite_bind_address to be 127.0.0.1")
 			}
 
 			return nil

--- a/internal/worker/changestreampruner/worker_test.go
+++ b/internal/worker/changestreampruner/worker_test.go
@@ -520,7 +520,7 @@ func (s *workerSuite) newPrunerWithLogger(c *gc.C, logger logger.Logger) *Pruner
 
 func (s *workerSuite) insertControllerNodes(c *gc.C, amount int) {
 	query, err := sqlair.Prepare(`
-INSERT INTO controller_node (controller_id, dqlite_node_id, bind_address)
+INSERT INTO controller_node (controller_id, dqlite_node_id, dqlite_bind_address)
 VALUES ($M.ctrl_id, $M.node_id, $M.addr)
 			`, sqlair.M{})
 	c.Assert(err, jc.ErrorIsNil)

--- a/internal/worker/dbaccessor/worker_integration_test.go
+++ b/internal/worker/dbaccessor/worker_integration_test.go
@@ -152,7 +152,7 @@ func (s *integrationSuite) TestWorkerSetsNodeIDAndAddress(c *gc.C) {
 		addr   string
 	)
 	err = db.StdTxn(context.Background(), func(ctx context.Context, tx *sql.Tx) error {
-		row := tx.QueryRowContext(ctx, "SELECT dqlite_node_id, bind_address FROM controller_node WHERE controller_id = '0'")
+		row := tx.QueryRowContext(ctx, "SELECT dqlite_node_id, dqlite_bind_address FROM controller_node WHERE controller_id = '0'")
 		if err := row.Scan(&nodeID, &addr); err != nil {
 			return err
 		}


### PR DESCRIPTION
This patch adds a new table (`controller_api_address`) on the controller DDL to track the api addresses.
This new table is going to be used in the replacement of the peergrouper worker.

As a bonus, the `bind_address` column in the `controller_node` table was renamed to `dqlite_bind_address` to avoid any confusion with the api addresses.


## QA steps

N/A.

## Links

**Jira card:** JUJU-7896
