### PR TITLE
docs: fix issue accessing built docs locally

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,6 +125,8 @@ discovered that way. To preview the docs as they will be rendered on RTD, in
 errors, try `make clean`, then `make run` again. For other checks, see `make
 [Tab]` and select the command for the desired check.
 
+> Note: If you are building locally on an Ubuntu Cloud VM or a container, you may experience issues accessing the page from a browser. To resolve this, add the export variable to your shell `export SPHINX_HOST=0.0.0.0`
+
 </details>
 
 ----------------

--- a/docs/Makefile.sp
+++ b/docs/Makefile.sp
@@ -19,6 +19,8 @@ ALLFILES        =  *.rst **/*.rst
 METRICSDIR      = $(SOURCEDIR)/.sphinx/metrics
 REQPDFPACKS     = latexmk fonts-freefont-otf texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended texlive-font-utils texlive-lang-cjk texlive-xetex plantuml xindy tex-gyre dvipng
 CONFIRM_SUDO    ?= N
+SPHINX_HOST     ?= 127.0.0.1
+SPHINX_PORT     ?= 8000
 
 .PHONY: sp-full-help sp-spellcheck-install sp-pa11y-install sp-install sp-run sp-html \
         sp-epub sp-serve sp-clean sp-clean-doc sp-spelling sp-spellcheck sp-linkcheck \
@@ -68,7 +70,7 @@ sp-pa11y-install:
 sp-install: $(VENVDIR)
 
 sp-run: sp-install
-	. $(VENV); $(VENVDIR)/bin/sphinx-autobuild -b dirhtml "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS)
+	. $(VENV); $(VENVDIR)/bin/sphinx-autobuild -b dirhtml "$(SOURCEDIR)" --host $(SPHINX_HOST) --port $(SPHINX_PORT) "$(BUILDDIR)" $(SPHINXOPTS)
 
 # Doesn't depend on $(BUILDDIR) to rebuild properly at every run.
 sp-html: sp-install


### PR DESCRIPTION
## Checklist

- [~] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [~] Go unit tests, with comments saying what you're testing
- [~] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- [~] [doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed packages

If you are building locally on an Ubuntu Cloud VM or a container, you may experience issues accessing the page from a browser after a successful build. This is because the page is being served to localhost only, `127.0.0.1`. The best fix is to give users the option to serve the page to the host. 

## QA steps

```bash
git clone https://github.com/juju/juju.git #this may also be your forked branch.
cd juju/docs/
git switch 3.6
make run
```
After a successful build, it should be serving the build on the host IP address rather than only localhost.
```bash
...
The HTML pages are in _build.
[sphinx-autobuild] Serving on http://0.0.0.0:8000
...
```

Now you can visit `http://<VM_IP>:8000` in your browser. 
If it's running in a container, ensure the port is exposed to the host correctly. For example, if you map container port `8000` to the host, you can access it via `127.0.0.1:8000` in your browser.

This PR was supposed to be addressed in PR #19143, but it was left along the way and never addressed.

I am still struggling with it as a contributor.